### PR TITLE
Addition of UCAS

### DIFF
--- a/sources/Exported instances UCAS SansCanadianAboriginal Resized/Sans Canadian Aboriginal-RC B Italic.glyphs
+++ b/sources/Exported instances UCAS SansCanadianAboriginal Resized/Sans Canadian Aboriginal-RC B Italic.glyphs
@@ -1,0 +1,37320 @@
+{
+.appVersion = "3151";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+},
+{
+name = Width;
+tag = wdth;
+},
+{
+name = Slant;
+tag = slnt;
+}
+);
+classes = (
+{
+code = "zero one two three four five six seven eight nine ";
+name = Num;
+},
+{
+code = "zero.canadian one.canadian two.canadian three.canadian four.canadian five.canadian six.canadian seven.canadian eight.canadian nine.canadian 
+";
+name = Num_can;
+},
+{
+code = "ke-canadian.square ki-canadian.square kii-canadian.square ko-canadian.square koo-canadian.square ka-canadian.square kaa-canadian.square kweWestCree-canadian.square kwiiWestCree-canadian.square kwoWestCree-canadian.square kwooWestCree-canadian.square kwaWestCree-canadian.square kwaaWestCree-canadian.square ce-canadian.square ci-canadian.square cii-canadian.square co-canadian.square coo-canadian.square ca-canadian.square caa-canadian.square me-canadian.square mi-canadian.square mii-canadian.square mo-canadian.square moo-canadian.square ma-canadian.square maa-canadian.square ne-canadian.square ni-canadian.square nii-canadian.square no-canadian.square noo-canadian.square na-canadian.square naa-canadian.square nweWestCree-canadian.square nwaWestCree-canadian.square nwaaWestCree-canadian.square se-canadian.square si-canadian.square sii-canadian.square so-canadian.square soo-canadian.square sa-canadian.square saa-canadian.square sho-canadian.square shoo-canadian.square sha-canadian.square shaa-canadian.square ye-canadian.square yi-canadian.square yii-canadian.square yo-canadian.square yoo-canadian.square ya-canadian.square yaa-canadian.square re-canadian.square reRCree-canadian.square leWestCree-canadian.square ri-canadian.square rii-canadian.square ro-canadian.square loWestCree-canadian.square ra-canadian.square raa-canadian.square laWestCree-canadian.square reWestCree-canadian.square riWestCree-canadian.square roWestCree-canadian.square raWestCree-canadian.square theThCree-canadian.square thiThCree-canadian.square thiiThCree-canadian.square thoThCree-canadian.square thooThCree-canadian.square thaThCree-canadian.square thaaThCree-canadian.square thweeWoodScree-canadian.square thwiWoodScree-canadian.square thwiiWoodScree-canadian.square thwoWoodScree-canadian.square thwooWoodScree-canadian.square thwaWoodScree-canadian.square thwaaWoodScree-canadian.square nwiOjibway-canadian.square nwiiOjibway-canadian.square nwoOjibway-canadian.square nwooOjibway-canadian.square looWestCree-canadian.square laaWestCree-canadian.square ";
+name = Dene_square;
+},
+{
+code = "ke-canadian ki-canadian kii-canadian ko-canadian koo-canadian ka-canadian kaa-canadian kweWestCree-canadian kwiiWestCree-canadian kwoWestCree-canadian kwooWestCree-canadian kwaWestCree-canadian kwaaWestCree-canadian ce-canadian ci-canadian cii-canadian co-canadian coo-canadian ca-canadian caa-canadian me-canadian mi-canadian mii-canadian mo-canadian moo-canadian ma-canadian maa-canadian ne-canadian ni-canadian nii-canadian no-canadian noo-canadian na-canadian naa-canadian nweWestCree-canadian nwaWestCree-canadian nwaaWestCree-canadian se-canadian si-canadian sii-canadian so-canadian soo-canadian sa-canadian saa-canadian sho-canadian shoo-canadian sha-canadian shaa-canadian ye-canadian yi-canadian yii-canadian yo-canadian yoo-canadian ya-canadian yaa-canadian re-canadian reRCree-canadian leWestCree-canadian ri-canadian rii-canadian ro-canadian loWestCree-canadian ra-canadian raa-canadian laWestCree-canadian reWestCree-canadian riWestCree-canadian roWestCree-canadian raWestCree-canadian theThCree-canadian thiThCree-canadian thiiThCree-canadian thoThCree-canadian thooThCree-canadian thaThCree-canadian thaaThCree-canadian thweeWoodScree-canadian thwiWoodScree-canadian thwiiWoodScree-canadian thwoWoodScree-canadian thwooWoodScree-canadian thwaWoodScree-canadian thwaaWoodScree-canadian nwiOjibway-canadian nwiiOjibway-canadian nwoOjibway-canadian nwooOjibway-canadian looWestCree-canadian laaWestCree-canadian 
+";
+name = Dene_round;
+},
+{
+code = "acuteFinal-canadian.mid graveFinal-canadian.mid ringTophalfFinal-canadian.mid ringRighthalfFinal-canadian.mid ringFinal-canadian.mid doubleacuteFinal-canadian.mid doubleshortverticalstrokesFinal-canadian.mid shorthorizontalstrokeFinal-canadian.mid downtackFinal-canadian.mid pWestCree-canadian.mid c-canadian.mid mWestCree-canadian.mid ";
+name = Final_mid;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian ringFinal-canadian doubleacuteFinal-canadian doubleshortverticalstrokesFinal-canadian shorthorizontalstrokeFinal-canadian downtackFinal-canadian pWestCree-canadian c-canadian mWestCree-canadian ";
+name = Final_mid_ori;
+},
+{
+code = "acuteFinal-canadian.base graveFinal-canadian.base ringBottomhalfFinal-canadian.base ringTophalfFinal-canadian.base ringRighthalfFinal-canadian.base plusFinal-canadian.base pWestCree-canadian.base c-canadian.base thSayisi-canadian.base mWestCree-canadian.base ";
+name = Final_base;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringBottomhalfFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian plusFinal-canadian pWestCree-canadian c-canadian thSayisi-canadian mWestCree-canadian ";
+name = Final_base_ori;
+},
+{
+code = "ng-canadian ngai-canadian ngaai-canadian ngi-canadian ngii-canadian ngo-canadian ngoo-canadian nga-canadian ngaa-canadian ";
+name = Nunavik;
+},
+{
+code = "ng-canadian.nunavik ngai-canadian.nunavik ngaai-canadian.nunavik ngi-canadian.nunavik ngii-canadian.nunavik ngo-canadian.nunavik ngoo-canadian.nunavik nga-canadian.nunavik ngaa-canadian.nunavik ";
+name = Nunavik_alt;
+}
+);
+customParameters = (
+{
+name = vendorID;
+value = GOOG;
+},
+{
+name = panose;
+value = (
+2,
+11,
+5,
+2,
+4,
+5,
+4,
+2,
+2,
+4
+);
+},
+{
+name = unicodeRanges;
+value = (
+0,
+1,
+2,
+5,
+6,
+45,
+77
+);
+},
+{
+name = codePageRanges;
+value = (
+"1252"
+);
+},
+{
+name = fsType;
+value = (
+);
+}
+);
+date = "2022-06-21 10:06:40 +0000";
+familyName = "Sans Canadian Aboriginal";
+featurePrefixes = (
+{
+automatic = 1;
+code = "languagesystem DFLT dflt;
+
+languagesystem cans dflt;
+";
+name = Languagesystems;
+}
+);
+features = (
+{
+automatic = 1;
+code = "feature ss01;
+feature ss02;
+feature ss03;
+feature ss04;
+";
+tag = aalt;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+tag = salt;
+},
+{
+code = "lookup space_can {
+sub space by space.canadian;
+} space_can;
+
+lookup num_can {
+sub @Num by @Num_can;
+} num_can;
+";
+labels = (
+{
+language = dflt;
+value = "CAN Space and numerals";
+}
+);
+tag = ss01;
+},
+{
+code = "lookup dene_square {
+sub @Dene_round by @Dene_square;
+} dene_square;
+
+";
+labels = (
+{
+language = dflt;
+value = "Dene Square";
+}
+);
+tag = ss02;
+},
+{
+code = "lookup nunavik_alt {
+sub @Nunavik by @Nunavik_alt;
+} nunavik_alt;
+
+";
+labels = (
+{
+language = dflt;
+value = "Nunanvik Alt";
+}
+);
+tag = ss03;
+},
+{
+code = "lookup final_mid {
+sub @Final_mid_ori by @Final_mid;
+} final_mid;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final mid";
+}
+);
+tag = ss04;
+},
+{
+code = "lookup final_base {
+sub @Final_base_ori by @Final_base;
+} final_base;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final base";
+}
+);
+tag = ss05;
+},
+{
+code = "lookup plaincree_first {
+sub wiWestCree-canadian' plusFinal-canadian by i-canadian;
+} plaincree_first;
+
+lookup plaincree_second {
+sub i-canadian plusFinal-canadian' by raiseddoubledotFinal-canadian.cree;
+} plaincree_second;
+
+lookup plaincree_third {
+sub middledotFinal-canadian plusFinal-canadian by raiseddoubledotFinal-canadian.cree;
+} plaincree_third;
+";
+labels = (
+{
+language = dflt;
+value = Plaincree;
+}
+);
+tag = ss06;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+labels = (
+{
+language = dflt;
+value = "";
+}
+);
+tag = ss07;
+}
+);
+fontMaster = (
+{
+axesValues = (
+0,
+0,
+0
+);
+customParameters = (
+{
+name = typoAscender;
+value = 1033;
+},
+{
+name = typoDescender;
+value = -283;
+},
+{
+name = typoLineGap;
+value = 0;
+},
+{
+name = winAscent;
+value = 1033;
+},
+{
+name = winDescent;
+value = 283;
+},
+{
+name = hheaAscender;
+value = 1033;
+},
+{
+name = hheaDescender;
+value = -283;
+},
+{
+name = strikeoutPosition;
+value = 295;
+},
+{
+name = strikeoutSize;
+value = 48;
+},
+{
+name = "Master Icon Glyph Name";
+value = s;
+}
+);
+guides = (
+{
+locked = 1;
+pos = (417,345);
+},
+{
+locked = 1;
+pos = (97,704);
+}
+);
+id = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+metricValues = (
+{
+over = 23;
+pos = 1033;
+},
+{
+over = 23;
+pos = 690;
+},
+{
+over = 23;
+pos = 492;
+},
+{
+over = -23;
+},
+{
+over = -23;
+pos = -283;
+},
+{
+pos = 12;
+}
+);
+name = "RC B Italic";
+stemValues = (
+160
+);
+}
+);
+glyphs = (
+{
+glyphname = idotless;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(166,0,l),
+(279,530,l),
+(121,530,l),
+(8,0,l)
+);
+}
+);
+width = 279;
+}
+);
+note = dotlessi;
+unicode = 305;
+},
+{
+glyphname = "acuteFinal-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(178,345,l),
+(412,690,l),
+(280,690,l),
+(46,345,l)
+);
+}
+);
+width = 343;
+}
+);
+metricRight = "=|";
+note = uni141F;
+unicode = 5151;
+},
+{
+glyphname = "graveFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(337,345,l),
+(237,690,l),
+(119,690,l),
+(219,345,l)
+);
+}
+);
+width = 341;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+unicode = 5152;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(351,339,o),
+(407,395,o),
+(426,487,cs),
+(469,690,l),
+(360,690,l),
+(320,500,ls),
+(311,461,o),
+(293,439,o),
+(258,439,cs),
+(222,439,o),
+(207,461,o),
+(216,502,cs),
+(256,690,l),
+(147,690,l),
+(109,511,ls),
+(87,407,o),
+(137,339,o),
+(247,339,cs)
+);
+}
+);
+width = 428;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1421;
+unicode = 5153;
+},
+{
+glyphname = "ringTophalfFinal-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(184,345,l),
+(224,534,ls),
+(233,574,o),
+(251,596,o),
+(286,596,cs),
+(322,596,o),
+(337,574,o),
+(327,532,cs),
+(288,345,l),
+(397,345,l),
+(435,524,ls),
+(457,628,o),
+(407,696,o),
+(297,696,cs),
+(193,696,o),
+(137,639,o),
+(118,548,cs),
+(74,345,l)
+);
+}
+);
+width = 429;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+unicode = 5154;
+},
+{
+glyphname = "ringRighthalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(158,345,ls),
+(298,345,o),
+(378,427,o),
+(378,548,cs),
+(378,635,o),
+(319,690,o),
+(221,690,cs),
+(147,690,l),
+(126,588,l),
+(204,588,ls),
+(246,588,o),
+(267,568,o),
+(267,535,cs),
+(267,484,o),
+(239,446,o),
+(174,446,cs),
+(96,446,l),
+(73,345,l)
+);
+}
+);
+width = 365;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+unicode = 5155;
+},
+{
+glyphname = "ringFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(383,356,o),
+(454,429,o),
+(454,526,cs),
+(454,623,o),
+(381,696,o),
+(281,696,cs),
+(181,696,o),
+(106,624,o),
+(106,526,cs),
+(106,429,o),
+(179,356,o),
+(281,356,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(236,449,o),
+(209,483,o),
+(209,526,cs),
+(209,569,o),
+(236,603,o),
+(281,603,cs),
+(324,603,o),
+(353,569,o),
+(353,526,cs),
+(353,483,o),
+(325,449,o),
+(281,449,cs)
+);
+}
+);
+width = 440;
+}
+);
+note = uni1424;
+unicode = 5156;
+},
+{
+glyphname = "doubleacuteFinal-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(175,345,l),
+(412,690,l),
+(283,690,l),
+(46,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(356,345,l),
+(593,690,l),
+(465,690,l),
+(228,345,l)
+);
+}
+);
+width = 524;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricRight = "=|";
+note = uni1425;
+unicode = 5157;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(184,345,l),
+(257,690,l),
+(148,690,l),
+(74,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(343,345,l),
+(416,690,l),
+(307,690,l),
+(234,345,l)
+);
+}
+);
+width = 375;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "pWestCree-canadian";
+note = uni1426;
+unicode = 5158;
+},
+{
+glyphname = "middledotFinal-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(184,278,o),
+(217,312,o),
+(217,355,cs),
+(217,397,o),
+(184,431,o),
+(141,431,cs),
+(99,431,o),
+(65,397,o),
+(65,355,cs),
+(65,312,o),
+(99,278,o),
+(141,278,cs)
+);
+}
+);
+width = 237;
+}
+);
+note = uni1427;
+unicode = 5159;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(425,471,l),
+(449,582,l),
+(125,582,l),
+(101,471,l)
+);
+}
+);
+width = 431;
+}
+);
+metricRight = "=|";
+note = uni1428;
+unicode = 5160;
+},
+{
+glyphname = "plusFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(295,364,l),
+(319,476,l),
+(427,476,l),
+(449,581,l),
+(340,581,l),
+(363,690,l),
+(257,690,l),
+(234,581,l),
+(124,581,l),
+(102,476,l),
+(212,476,l),
+(187,364,l)
+);
+}
+);
+width = 431;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+unicode = 5161;
+},
+{
+glyphname = "downtackFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(291,345,l),
+(342,586,l),
+(450,586,l),
+(472,690,l),
+(147,690,l),
+(125,586,l),
+(233,586,l),
+(182,345,l)
+);
+}
+);
+width = 431;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni142A;
+unicode = 5162;
+},
+{
+glyphname = "thFinalWoodScree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(293,345,l),
+(305,400,l),
+(411,400,l),
+(429,489,l),
+(324,489,l),
+(335,546,l),
+(441,546,l),
+(460,635,l),
+(355,635,l),
+(366,690,l),
+(257,690,l),
+(245,635,l),
+(136,635,l),
+(118,546,l),
+(226,546,l),
+(214,489,l),
+(105,489,l),
+(87,400,l),
+(196,400,l),
+(184,345,l)
+);
+}
+);
+width = 431;
+}
+);
+metricLeft = "hyphen-canadian";
+metricRight = "hyphen-canadian";
+note = uni167E;
+unicode = 5758;
+},
+{
+glyphname = "ringSmallFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(304,482,o),
+(359,527,o),
+(359,593,cs),
+(359,658,o),
+(304,704,o),
+(242,704,cs),
+(181,704,o),
+(128,658,o),
+(128,593,cs),
+(128,527,o),
+(180,482,o),
+(242,482,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(215,548,o),
+(200,568,o),
+(200,593,cs),
+(200,617,o),
+(218,638,o),
+(243,638,cs),
+(270,638,o),
+(288,617,o),
+(288,593,cs),
+(288,568,o),
+(270,548,o),
+(243,548,cs)
+);
+}
+);
+width = 339;
+}
+);
+note = g725;
+unicode = 6366;
+},
+{
+glyphname = "raiseddotFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(242,552,o),
+(276,585,o),
+(276,628,cs),
+(276,669,o),
+(242,704,o),
+(200,704,cs),
+(157,704,o),
+(124,669,o),
+(124,628,cs),
+(124,585,o),
+(157,552,o),
+(200,552,cs)
+);
+}
+);
+width = 237;
+}
+);
+note = g725;
+unicode = 6367;
+},
+{
+glyphname = "acuteFinal-canadian.base";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-73,-344);
+ref = "acuteFinal-canadian";
+}
+);
+width = 343;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.base";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-73,-345);
+ref = "graveFinal-canadian";
+}
+);
+width = 341;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian.base";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-73,-345);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 428;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1421;
+},
+{
+glyphname = "ringTophalfFinal-canadian.base";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-73,-345);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 429;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.base";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-73,-345);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 365;
+}
+);
+metricLeft = "==|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "plusFinal-canadian.base";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(218,0,l),
+(242,112,l),
+(351,112,l),
+(373,216,l),
+(264,216,l),
+(287,326,l),
+(181,326,l),
+(157,216,l),
+(47,216,l),
+(25,112,l),
+(135,112,l),
+(111,0,l)
+);
+}
+);
+width = 432;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+},
+{
+glyphname = "acuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-34,-161);
+ref = "acuteFinal-canadian";
+}
+);
+width = 343;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.mid";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-162);
+ref = "graveFinal-canadian";
+}
+);
+width = 343;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringTophalfFinal-canadian.mid";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-37,-172);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 428;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.mid";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-34,-162);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 365;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "ringFinal-canadian.mid";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-39,-182);
+ref = "ringFinal-canadian";
+}
+);
+width = 440;
+}
+);
+metricLeft = "ringFinal-canadian";
+metricWidth = "ringFinal-canadian";
+note = uni1424;
+},
+{
+glyphname = "doubleacuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-34,-162);
+ref = "doubleacuteFinal-canadian";
+}
+);
+width = 524;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "doubleacuteFinal-canadian";
+note = uni1425;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian.mid";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-34,-162);
+ref = "doubleshortverticalstrokesFinal-canadian";
+}
+);
+width = 375;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricWidth = "doubleshortverticalstrokesFinal-canadian";
+note = uni1426;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian.mid";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-37,-173);
+ref = "shorthorizontalstrokeFinal-canadian";
+}
+);
+width = 431;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "shorthorizontalstrokeFinal-canadian";
+note = uni1428;
+},
+{
+glyphname = "downtackFinal-canadian.mid";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-34,-162);
+ref = "downtackFinal-canadian";
+}
+);
+width = 431;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "downtackFinal-canadian";
+note = uni142A;
+},
+{
+glyphname = "e-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (407,454);
+},
+{
+name = top_center_can;
+pos = (460,690);
+},
+{
+name = top_left_can;
+pos = (235,690);
+},
+{
+name = top_right_can;
+pos = (685,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(336,0,l),
+(791,651,l),
+(800,690,l),
+(119,690,l),
+(111,651,l),
+(290,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(373,196,l),
+(274,593,l),
+(251,561,l),
+(611,561,l),
+(584,593,l),
+(318,196,l)
+);
+}
+);
+width = 731;
+}
+);
+metricRight = "=|";
+note = uni1401;
+unicode = 5121;
+},
+{
+glyphname = "aai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (233,0);
+ref = ring_top.canadian;
+}
+);
+width = 730;
+}
+);
+note = uni1402;
+unicode = 5122;
+},
+{
+glyphname = "i-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (380,266);
+},
+{
+name = top_center_can;
+pos = (460,690);
+},
+{
+name = top_left_can;
+pos = (236,690);
+},
+{
+name = top_right_can;
+pos = (686,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(437,690,l),
+(-18,39,l),
+(-27,0,l),
+(654,0,l),
+(663,39,l),
+(484,690,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(400,494,l),
+(498,97,l),
+(522,128,l),
+(162,128,l),
+(188,97,l),
+(455,494,l)
+);
+}
+);
+width = 731;
+}
+);
+metricLeft = "e-canadian";
+metricWidth = "e-canadian";
+note = uni1403;
+unicode = 5123;
+},
+{
+glyphname = "ii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (270,0);
+ref = dot_top;
+}
+);
+width = 730;
+}
+);
+note = uni1404;
+unicode = 5124;
+},
+{
+glyphname = "o-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (296,360);
+},
+{
+name = top_center_can;
+pos = (443,690);
+},
+{
+name = top_double;
+pos = (554,690);
+},
+{
+name = top_left_can;
+pos = (223,690);
+},
+{
+name = top_right_can;
+pos = (672,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(47,0,l),
+(655,321,l),
+(666,369,l),
+(194,690,l),
+(156,690,l),
+(10,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(255,516,l),
+(208,528,l),
+(480,342,l),
+(482,371,l),
+(138,188,l),
+(183,178,l)
+);
+}
+);
+width = 667;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1405;
+unicode = 5125;
+},
+{
+glyphname = "oo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (35,0);
+ref = dot_top;
+}
+);
+width = 667;
+}
+);
+note = uni1406;
+unicode = 5126;
+},
+{
+glyphname = "yCreeoo-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (181,0);
+ref = doubledot_top;
+}
+);
+width = 667;
+}
+);
+note = uni1407;
+unicode = 5127;
+},
+{
+glyphname = "eeCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(47,0,l),
+(655,321,l),
+(666,369,l),
+(194,690,l),
+(156,690,l),
+(10,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(250,516,l),
+(217,523,l),
+(483,342,l),
+(490,374,l),
+(147,192,l),
+(179,178,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(301,295,l),
+(327,417,l),
+(275,417,l),
+(249,295,l)
+);
+}
+);
+width = 667;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "o-canadian";
+note = uni1408;
+unicode = 5128;
+},
+{
+glyphname = "iCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (213,15);
+ref = dot_middle_optic_small;
+}
+);
+width = 667;
+}
+);
+note = uni1409;
+unicode = 5129;
+},
+{
+glyphname = "a-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (403,338);
+},
+{
+name = top_center_can;
+pos = (400,690);
+},
+{
+name = top_left_can;
+pos = (193,690);
+},
+{
+name = top_right_can;
+pos = (630,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(661,690,l),
+(54,369,l),
+(43,321,l),
+(514,0,l),
+(553,0,l),
+(699,690,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(454,174,l),
+(501,161,l),
+(229,348,l),
+(227,319,l),
+(571,501,l),
+(526,512,l)
+);
+}
+);
+width = 667;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni140A;
+unicode = 5130;
+},
+{
+glyphname = "aa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (441,0);
+ref = dot_top;
+}
+);
+width = 667;
+}
+);
+note = uni140B;
+unicode = 5131;
+},
+{
+glyphname = "we-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "e-canadian";
+}
+);
+width = 966;
+}
+);
+note = uni140C;
+unicode = 5132;
+},
+{
+glyphname = "weWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (730,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 966;
+}
+);
+note = uni140D;
+unicode = 5133;
+},
+{
+glyphname = "wi-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "i-canadian";
+}
+);
+width = 966;
+}
+);
+note = uni140E;
+unicode = 5134;
+},
+{
+glyphname = "wiWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (730,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 966;
+}
+);
+note = uni140F;
+unicode = 5135;
+},
+{
+glyphname = "wii-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (507,0);
+ref = dot_top;
+}
+);
+width = 966;
+}
+);
+note = uni1410;
+unicode = 5136;
+},
+{
+glyphname = "wiiWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (270,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (730,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 966;
+}
+);
+note = uni1411;
+unicode = 5137;
+},
+{
+glyphname = "wo-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "o-canadian";
+}
+);
+width = 903;
+}
+);
+note = uni1412;
+unicode = 5138;
+},
+{
+glyphname = "woWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (667,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 903;
+}
+);
+note = uni1413;
+unicode = 5139;
+},
+{
+glyphname = "woo-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (491,0);
+ref = dot_top;
+}
+);
+width = 903;
+}
+);
+note = uni1414;
+unicode = 5140;
+},
+{
+glyphname = "wooWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (35,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (667,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 903;
+}
+);
+note = uni1415;
+unicode = 5141;
+},
+{
+glyphname = "wooNaskapi-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (155,-95);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (319,-206);
+ref = dot_top;
+}
+);
+width = 667;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricWidth = "o-canadian";
+note = uni1416;
+unicode = 5142;
+},
+{
+glyphname = "wa-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "a-canadian";
+}
+);
+width = 903;
+}
+);
+note = uni1417;
+unicode = 5143;
+},
+{
+glyphname = "waWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (667,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 903;
+}
+);
+note = uni1418;
+unicode = 5144;
+},
+{
+glyphname = "waa-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (678,0);
+ref = dot_top;
+}
+);
+width = 903;
+}
+);
+note = uni1419;
+unicode = 5145;
+},
+{
+glyphname = "waaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (441,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (667,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 903;
+}
+);
+note = uni141A;
+unicode = 5146;
+},
+{
+glyphname = "waaNaskapi-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (88,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (287,-95);
+ref = dot_top;
+}
+);
+width = 667;
+}
+);
+metricWidth = "a-canadian";
+note = uni141B;
+unicode = 5147;
+},
+{
+glyphname = "ai-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(287,339,o),
+(326,360,o),
+(357,408,c),
+(329,409,l),
+(342,362,o),
+(381,339,o),
+(440,339,cs),
+(535,339,o),
+(586,386,o),
+(610,495,cs),
+(651,690,l),
+(549,690,l),
+(505,490,ls),
+(497,451,o),
+(478,433,o),
+(446,433,cs),
+(412,433,o),
+(400,452,o),
+(408,493,cs),
+(450,690,l),
+(349,690,l),
+(306,490,ls),
+(298,450,o),
+(279,433,o),
+(247,433,cs),
+(214,433,o),
+(200,453,o),
+(209,493,cs),
+(250,690,l),
+(148,690,l),
+(106,497,ls),
+(86,403,o),
+(139,339,o),
+(230,339,cs)
+);
+}
+);
+width = 610;
+}
+);
+metricRight = "=|";
+note = uni141C;
+unicode = 5148;
+},
+{
+glyphname = "ycreew-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(413,510,o),
+(449,548,o),
+(449,604,cs),
+(449,659,o),
+(412,696,o),
+(363,696,cs),
+(313,696,o),
+(276,659,o),
+(276,604,cs),
+(276,548,o),
+(312,510,o),
+(363,510,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(227,339,o),
+(263,377,o),
+(263,433,cs),
+(263,488,o),
+(226,525,o),
+(177,525,cs),
+(127,525,o),
+(90,488,o),
+(90,433,cs),
+(90,377,o),
+(126,339,o),
+(177,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(156,389,o),
+(144,406,o),
+(144,433,cs),
+(144,459,o),
+(156,474,o),
+(177,474,cs),
+(196,474,o),
+(209,459,o),
+(209,433,cs),
+(209,406,o),
+(196,389,o),
+(177,389,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(343,560,o),
+(330,577,o),
+(330,604,cs),
+(330,630,o),
+(343,645,o),
+(363,645,cs),
+(382,645,o),
+(395,630,o),
+(395,604,cs),
+(395,577,o),
+(382,560,o),
+(363,560,cs)
+);
+}
+);
+width = 424;
+}
+);
+metricRight = "=|";
+note = uni141D;
+unicode = 5149;
+},
+{
+glyphname = "glottalstop-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(402,345,l),
+(406,365,l),
+(317,690,l),
+(293,690,l),
+(65,365,l),
+(61,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(311,584,l),
+(264,585,l),
+(312,393,l),
+(334,424,l),
+(163,424,l),
+(181,393,l)
+);
+}
+);
+width = 421;
+}
+);
+metricRight = "=|";
+note = uni141E;
+unicode = 5150;
+},
+{
+glyphname = "en-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+pos = (730,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 1073;
+}
+);
+note = uni142B;
+unicode = 5163;
+},
+{
+glyphname = "in-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+pos = (482,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 823;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142C;
+unicode = 5164;
+},
+{
+glyphname = "on-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (518,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 860;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142D;
+unicode = 5165;
+},
+{
+glyphname = "an-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (628,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 970;
+}
+);
+metricRight = "graveFinal-canadian";
+note = uni142E;
+unicode = 5166;
+},
+{
+glyphname = "pe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (398,454);
+},
+{
+name = top_center_can;
+pos = (459,690);
+},
+{
+name = top_left_can;
+pos = (235,690);
+},
+{
+name = top_right_can;
+pos = (685,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(336,0,l),
+(791,651,l),
+(800,690,l),
+(635,690,l),
+(297,195,l),
+(389,195,l),
+(264,690,l),
+(119,690,l),
+(111,651,l),
+(289,0,l)
+);
+}
+);
+width = 731;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni142F;
+unicode = 5167;
+},
+{
+glyphname = "paai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (234,0);
+ref = ring_top.canadian;
+}
+);
+width = 730;
+}
+);
+note = uni1430;
+unicode = 5168;
+},
+{
+glyphname = "pi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (381,266);
+},
+{
+name = top_center_can;
+pos = (461,690);
+},
+{
+name = top_left_can;
+pos = (236,690);
+},
+{
+name = top_right_can;
+pos = (686,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(437,690,l),
+(-18,39,l),
+(-27,0,l),
+(138,0,l),
+(476,495,l),
+(384,495,l),
+(509,0,l),
+(654,0,l),
+(663,39,l),
+(484,690,l)
+);
+}
+);
+width = 732;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni1431;
+unicode = 5169;
+},
+{
+glyphname = "pii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (271,0);
+ref = dot_top;
+}
+);
+width = 730;
+}
+);
+note = uni1432;
+unicode = 5170;
+},
+{
+glyphname = "po-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (193,362);
+},
+{
+name = top_center_can;
+pos = (421,690);
+},
+{
+name = top_double;
+pos = (538,690);
+},
+{
+name = top_left_can;
+pos = (205,690);
+},
+{
+name = top_right_can;
+pos = (651,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+name = "Thin Slanted";
+shapes = (
+{
+closed = 1;
+nodes = (
+(28,0,l),
+(633,321,l),
+(643,369,l),
+(174,690,l),
+(136,690,l),
+(107,553,l),
+(445,325,l),
+(459,395,l),
+(25,168,l),
+(-11,0,l)
+);
+}
+);
+width = 644;
+}
+);
+metricRight = "o-canadian";
+note = uni1433;
+unicode = 5171;
+},
+{
+glyphname = "poo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (16,0);
+ref = dot_top;
+}
+);
+width = 645;
+}
+);
+note = uni1434;
+unicode = 5172;
+},
+{
+glyphname = "ycreepoo-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (165,0);
+ref = doubledot_top;
+}
+);
+width = 645;
+}
+);
+note = uni1435;
+unicode = 5173;
+},
+{
+glyphname = "heeCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (121,17);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 645;
+}
+);
+note = uni1436;
+unicode = 5174;
+},
+{
+glyphname = "hiCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (96,22);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 645;
+}
+);
+note = uni1437;
+unicode = 5175;
+},
+{
+glyphname = "pa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (420,345);
+},
+{
+name = top_center_can;
+pos = (413,690);
+},
+{
+name = top_left_can;
+pos = (194,690);
+},
+{
+name = top_right_can;
+pos = (629,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(659,690,l),
+(54,369,l),
+(43,321,l),
+(513,0,l),
+(551,0,l),
+(580,137,l),
+(242,365,l),
+(229,295,l),
+(661,522,l),
+(696,690,l)
+);
+}
+);
+width = 644;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1438;
+unicode = 5176;
+},
+{
+glyphname = "paa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (440,0);
+ref = dot_top;
+}
+);
+width = 645;
+}
+);
+note = uni1439;
+unicode = 5177;
+},
+{
+glyphname = "pwe-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "pe-canadian";
+}
+);
+width = 966;
+}
+);
+note = uni143A;
+unicode = 5178;
+},
+{
+glyphname = "pweWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "pe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (730,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 966;
+}
+);
+note = uni143B;
+unicode = 5179;
+},
+{
+glyphname = "pwi-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "pi-canadian";
+}
+);
+width = 966;
+}
+);
+note = uni143C;
+unicode = 5180;
+},
+{
+glyphname = "pwiWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (730,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 966;
+}
+);
+note = uni143D;
+unicode = 5181;
+},
+{
+glyphname = "pwii-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (508,0);
+ref = dot_top;
+}
+);
+width = 966;
+}
+);
+note = uni143E;
+unicode = 5182;
+},
+{
+glyphname = "pwiiWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (271,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (730,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 966;
+}
+);
+note = uni143F;
+unicode = 5183;
+},
+{
+glyphname = "pwo-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "po-canadian";
+}
+);
+width = 881;
+}
+);
+note = uni1440;
+unicode = 5184;
+},
+{
+glyphname = "pwoWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (645,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 881;
+}
+);
+note = uni1441;
+unicode = 5185;
+},
+{
+glyphname = "pwoo-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (469,0);
+ref = dot_top;
+}
+);
+width = 881;
+}
+);
+note = uni1442;
+unicode = 5186;
+},
+{
+glyphname = "pwooWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (16,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (645,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 881;
+}
+);
+note = uni1443;
+unicode = 5187;
+},
+{
+glyphname = "pwa-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "pa-canadian";
+}
+);
+width = 881;
+}
+);
+note = uni1444;
+unicode = 5188;
+},
+{
+glyphname = "pwaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (645,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 881;
+}
+);
+note = uni1445;
+unicode = 5189;
+},
+{
+glyphname = "pwaa-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (677,0);
+ref = dot_top;
+}
+);
+width = 881;
+}
+);
+note = uni1446;
+unicode = 5190;
+},
+{
+glyphname = "pwaaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (440,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (645,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 881;
+}
+);
+note = uni1447;
+unicode = 5191;
+},
+{
+glyphname = "ycreepwaa-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+pos = (84,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (283,-95);
+ref = dot_top;
+}
+);
+width = 644;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1448;
+unicode = 5192;
+},
+{
+glyphname = "p-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(360,345,l),
+(380,437,l),
+(213,550,l),
+(194,467,l),
+(410,580,l),
+(434,690,l),
+(414,690,l),
+(114,530,l),
+(108,505,l),
+(341,345,l)
+);
+}
+);
+width = 392;
+}
+);
+note = uni1449;
+unicode = 5193;
+},
+{
+glyphname = "pWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(184,345,l),
+(257,690,l),
+(148,690,l),
+(74,345,l)
+);
+}
+);
+width = 216;
+}
+);
+metricRight = "=|";
+note = uni144A;
+unicode = 5194;
+},
+{
+color = 6;
+glyphname = "hCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(149,183,l),
+(171,289,ls),
+(178,322,o),
+(194,338,o),
+(213,338,cs),
+(246,338,o),
+(257,320,o),
+(249,286,cs),
+(227,183,l),
+(336,183,l),
+(362,306,ls),
+(379,382,o),
+(337,437,o),
+(260,437,cs),
+(216,437,o),
+(175,415,o),
+(162,384,c),
+(187,365,l),
+(222,527,l),
+(113,527,l),
+(40,183,l)
+);
+}
+);
+width = 384;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144B;
+unicode = 5195;
+},
+{
+glyphname = "te-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (383,345);
+},
+{
+name = top_center_can;
+pos = (456,690);
+},
+{
+name = top_left_can;
+pos = (230,690);
+},
+{
+name = top_right_can;
+pos = (683,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(528,-14,o),
+(635,82,o),
+(678,285,cs),
+(764,690,l),
+(604,690,l),
+(518,289,ls),
+(495,180,o),
+(441,130,o),
+(353,130,cs),
+(245,130,o),
+(205,191,o),
+(229,307,cs),
+(310,690,l),
+(150,690,l),
+(71,319,ls),
+(27,111,o),
+(134,-14,o),
+(339,-14,cs)
+);
+}
+);
+width = 725;
+}
+);
+metricRight = "=|";
+note = uni144C;
+unicode = 5196;
+},
+{
+glyphname = "taai-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (231,0);
+ref = ring_top.canadian;
+}
+);
+width = 725;
+}
+);
+note = uni144D;
+unicode = 5197;
+},
+{
+glyphname = "ti-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (384,345);
+},
+{
+name = middle_right_can;
+pos = (837,345);
+},
+{
+name = top_center_can;
+pos = (457,690);
+},
+{
+name = top_left_can;
+pos = (231,690);
+},
+{
+name = top_right_can;
+pos = (684,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(163,0,l),
+(249,401,ls),
+(272,510,o),
+(326,559,o),
+(414,559,cs),
+(522,559,o),
+(562,498,o),
+(538,383,cs),
+(457,0,l),
+(617,0,l),
+(696,371,ls),
+(740,579,o),
+(633,704,o),
+(428,704,cs),
+(239,704,o),
+(132,608,o),
+(89,405,cs),
+(3,0,l)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni144E;
+unicode = 5198;
+},
+{
+glyphname = "tii-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (269,0);
+ref = dot_top;
+}
+);
+width = 725;
+}
+);
+note = uni144F;
+unicode = 5199;
+},
+{
+glyphname = "to-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (249,345);
+},
+{
+name = middle_right_can;
+pos = (735,345);
+},
+{
+name = top_center_can;
+pos = (377,690);
+},
+{
+name = top_double;
+pos = (469,690);
+},
+{
+name = top_left_can;
+pos = (212,690);
+},
+{
+name = top_right_can;
+pos = (593,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(175,0,ls),
+(506,0,o),
+(592,242,o),
+(592,412,cs),
+(592,584,o),
+(481,690,o),
+(288,690,cs),
+(142,690,l),
+(112,546,l),
+(264,546,ls),
+(375,546,o),
+(431,493,o),
+(431,396,cs),
+(431,283,o),
+(375,144,o),
+(189,144,cs),
+(26,144,l),
+(-4,0,l)
+);
+}
+);
+width = 617;
+}
+);
+note = uni1450;
+unicode = 5200;
+},
+{
+glyphname = "too-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (188,0);
+ref = dot_top;
+}
+);
+width = 617;
+}
+);
+note = uni1451;
+unicode = 5201;
+},
+{
+glyphname = "ycreetoo-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (96,0);
+ref = doubledot_top;
+}
+);
+width = 617;
+}
+);
+note = uni1452;
+unicode = 5202;
+},
+{
+glyphname = "deeCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (165,0);
+ref = stroke_middle;
+}
+);
+width = 617;
+}
+);
+note = uni1453;
+unicode = 5203;
+},
+{
+glyphname = "diCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (135,0);
+ref = dot_middle;
+}
+);
+width = 617;
+}
+);
+note = uni1454;
+unicode = 5204;
+},
+{
+glyphname = "ta-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (409,345);
+},
+{
+name = top_center_can;
+pos = (429,690);
+},
+{
+name = top_left_can;
+pos = (212,690);
+},
+{
+name = top_right_can;
+pos = (592,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(516,0,l),
+(546,144,l),
+(394,144,ls),
+(283,144,o),
+(227,197,o),
+(227,294,cs),
+(227,412,o),
+(289,546,o),
+(468,546,cs),
+(632,546,l),
+(662,690,l),
+(483,690,ls),
+(156,690,o),
+(67,452,o),
+(67,278,cs),
+(67,105,o),
+(177,0,o),
+(370,0,cs)
+);
+}
+);
+width = 616;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|to-canadian";
+note = uni1455;
+unicode = 5205;
+},
+{
+glyphname = "taa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (242,0);
+ref = dot_top;
+}
+);
+width = 617;
+}
+);
+note = uni1456;
+unicode = 5206;
+},
+{
+glyphname = "twe-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "te-canadian";
+}
+);
+width = 962;
+}
+);
+note = uni1457;
+unicode = 5207;
+},
+{
+glyphname = "tweWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (725,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 962;
+}
+);
+note = uni1458;
+unicode = 5208;
+},
+{
+glyphname = "twi-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ti-canadian";
+}
+);
+width = 962;
+}
+);
+note = uni1459;
+unicode = 5209;
+},
+{
+glyphname = "twiWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (725,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 962;
+}
+);
+note = uni145A;
+unicode = 5210;
+},
+{
+glyphname = "twii-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (505,0);
+ref = dot_top;
+}
+);
+width = 962;
+}
+);
+note = uni145B;
+unicode = 5211;
+},
+{
+glyphname = "twiiWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (269,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (725,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 962;
+}
+);
+note = uni145C;
+unicode = 5212;
+},
+{
+glyphname = "two-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "to-canadian";
+}
+);
+width = 854;
+}
+);
+note = uni145D;
+unicode = 5213;
+},
+{
+glyphname = "twoWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (617,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 854;
+}
+);
+note = uni145E;
+unicode = 5214;
+},
+{
+glyphname = "twoo-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (424,0);
+ref = dot_top;
+}
+);
+width = 854;
+}
+);
+note = uni145F;
+unicode = 5215;
+},
+{
+glyphname = "twooWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (188,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (617,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 854;
+}
+);
+note = uni1460;
+unicode = 5216;
+},
+{
+glyphname = "twa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ta-canadian";
+}
+);
+width = 854;
+}
+);
+note = uni1461;
+unicode = 5217;
+},
+{
+glyphname = "twaWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (617,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 854;
+}
+);
+note = uni1462;
+unicode = 5218;
+},
+{
+glyphname = "twaa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (479,0);
+ref = dot_top;
+}
+);
+width = 854;
+}
+);
+note = uni1463;
+unicode = 5219;
+},
+{
+glyphname = "twaaWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (242,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (617,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 854;
+}
+);
+note = uni1464;
+unicode = 5220;
+},
+{
+glyphname = "twaaNaskapi-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ta-canadian";
+}
+);
+width = 854;
+}
+);
+note = uni1465;
+unicode = 5221;
+},
+{
+glyphname = "t-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(333,345,l),
+(355,446,l),
+(276,446,ls),
+(233,446,o),
+(213,467,o),
+(213,499,cs),
+(213,549,o),
+(240,588,o),
+(307,588,cs),
+(384,588,l),
+(407,690,l),
+(322,690,ls),
+(182,690,o),
+(102,605,o),
+(102,487,cs),
+(102,400,o),
+(160,345,o),
+(258,345,cs)
+);
+}
+);
+width = 365;
+}
+);
+note = uni1466;
+unicode = 5222;
+},
+{
+glyphname = "tte-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+pos = (725,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 941;
+}
+);
+note = uni1467;
+unicode = 5223;
+},
+{
+glyphname = "tti-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+pos = (725,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 941;
+}
+);
+note = uni1468;
+unicode = 5224;
+},
+{
+glyphname = "tto-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+pos = (617,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 834;
+}
+);
+note = uni1469;
+unicode = 5225;
+},
+{
+glyphname = "tta-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+pos = (617,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 834;
+}
+);
+note = uni146A;
+unicode = 5226;
+},
+{
+glyphname = "ke-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (333,441);
+},
+{
+name = top_center_can;
+pos = (382,690);
+},
+{
+name = top_left_can;
+pos = (213,690);
+},
+{
+name = top_right_can;
+pos = (533,698);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(485,0,l),
+(570,400,ls),
+(602,552,o),
+(550,704,o),
+(361,704,cs),
+(180,704,o),
+(80,550,o),
+(80,392,cs),
+(80,268,o),
+(156,184,o),
+(273,184,cs),
+(328,184,o),
+(377,206,o),
+(398,243,c),
+(379,255,l),
+(325,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(266,319,o),
+(237,351,o),
+(237,405,cs),
+(237,457,o),
+(263,569,o),
+(346,569,cs),
+(395,569,o),
+(424,536,o),
+(424,482,cs),
+(424,430,o),
+(398,319,o),
+(314,319,cs)
+);
+}
+);
+width = 592;
+}
+);
+metricRight = "te-canadian";
+note = uni146B;
+unicode = 5227;
+},
+{
+glyphname = "kaai-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (171,0);
+ref = ring_top.canadian;
+}
+);
+width = 593;
+}
+);
+note = uni146C;
+unicode = 5228;
+},
+{
+glyphname = "ki-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (350,441);
+},
+{
+name = top_center_can;
+pos = (398,690);
+},
+{
+name = top_left_can;
+pos = (231,690);
+},
+{
+name = top_right_can;
+pos = (569,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(164,0,l),
+(222,271,l),
+(205,257,l),
+(208,217,o),
+(268,184,o),
+(339,184,cs),
+(514,184,o),
+(597,352,o),
+(597,486,cs),
+(597,620,o),
+(511,704,o),
+(376,704,cs),
+(234,704,o),
+(135,617,o),
+(102,465,cs),
+(4,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(283,319,o),
+(254,351,o),
+(254,405,cs),
+(254,457,o),
+(282,569,o),
+(364,569,cs),
+(413,569,o),
+(442,536,o),
+(442,482,cs),
+(442,431,o),
+(415,319,o),
+(331,319,cs)
+);
+}
+);
+width = 595;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni146D;
+unicode = 5229;
+},
+{
+glyphname = "kii-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (209,0);
+ref = dot_top;
+}
+);
+width = 593;
+}
+);
+note = uni146E;
+unicode = 5230;
+},
+{
+glyphname = "ko-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (299,277);
+},
+{
+name = top_center_can;
+pos = (384,690);
+},
+{
+name = top_double;
+pos = (552,690);
+},
+{
+name = top_left_can;
+pos = (213,690);
+},
+{
+name = top_right_can;
+pos = (552,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(402,-14,o),
+(500,72,o),
+(533,225,cs),
+(632,690,l),
+(471,690,l),
+(413,418,l),
+(431,433,l),
+(428,472,o),
+(369,506,o),
+(297,506,cs),
+(123,506,o),
+(40,337,o),
+(40,203,cs),
+(40,70,o),
+(125,-14,o),
+(266,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(223,121,o),
+(194,153,o),
+(194,207,cs),
+(194,259,o),
+(223,371,o),
+(304,371,cs),
+(353,371,o),
+(382,339,o),
+(382,285,cs),
+(382,233,o),
+(355,121,o),
+(272,121,cs)
+);
+}
+);
+width = 593;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni146F;
+unicode = 5231;
+},
+{
+glyphname = "koo-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (363,0);
+ref = dot_top;
+}
+);
+width = 593;
+}
+);
+note = uni1470;
+unicode = 5232;
+},
+{
+glyphname = "ycreekoo-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (179,0);
+ref = doubledot_top;
+}
+);
+width = 593;
+}
+);
+note = uni1471;
+unicode = 5233;
+},
+{
+glyphname = "ka-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (314,281);
+},
+{
+name = top_center_can;
+pos = (397,690);
+},
+{
+name = top_left_can;
+pos = (229,690);
+},
+{
+name = top_right_can;
+pos = (567,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(454,-14,o),
+(554,140,o),
+(554,297,cs),
+(554,422,o),
+(478,506,o),
+(360,506,cs),
+(305,506,o),
+(258,484,o),
+(236,446,c),
+(255,435,l),
+(309,690,l),
+(149,690,l),
+(65,292,ls),
+(25,106,o),
+(111,-14,o),
+(278,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(239,121,o),
+(211,154,o),
+(211,208,cs),
+(211,260,o),
+(237,371,o),
+(320,371,cs),
+(369,371,o),
+(398,339,o),
+(398,285,cs),
+(398,234,o),
+(372,121,o),
+(288,121,cs)
+);
+}
+);
+width = 592;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "==|ke-canadian";
+note = uni1472;
+unicode = 5234;
+},
+{
+glyphname = "kaa-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (42,0);
+ref = dot_top;
+}
+);
+width = 593;
+}
+);
+note = uni1473;
+unicode = 5235;
+},
+{
+glyphname = "kwe-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ke-canadian";
+}
+);
+width = 830;
+}
+);
+note = uni1474;
+unicode = 5236;
+},
+{
+glyphname = "kweWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (593,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 830;
+}
+);
+note = uni1475;
+unicode = 5237;
+},
+{
+glyphname = "kwi-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ki-canadian";
+}
+);
+width = 830;
+}
+);
+note = uni1476;
+unicode = 5238;
+},
+{
+glyphname = "kwiWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (593,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 830;
+}
+);
+note = uni1477;
+unicode = 5239;
+},
+{
+glyphname = "kwii-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (445,0);
+ref = dot_top;
+}
+);
+width = 830;
+}
+);
+note = uni1478;
+unicode = 5240;
+},
+{
+glyphname = "kwiiWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (209,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (593,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 830;
+}
+);
+note = uni1479;
+unicode = 5241;
+},
+{
+glyphname = "kwo-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ko-canadian";
+}
+);
+width = 830;
+}
+);
+note = uni147A;
+unicode = 5242;
+},
+{
+glyphname = "kwoWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (593,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 830;
+}
+);
+note = uni147B;
+unicode = 5243;
+},
+{
+glyphname = "kwoo-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (600,0);
+ref = dot_top;
+}
+);
+width = 830;
+}
+);
+note = uni147C;
+unicode = 5244;
+},
+{
+glyphname = "kwooWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (363,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (593,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 830;
+}
+);
+note = uni147D;
+unicode = 5245;
+},
+{
+glyphname = "kwa-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ka-canadian";
+}
+);
+width = 830;
+}
+);
+note = uni147E;
+unicode = 5246;
+},
+{
+glyphname = "kwaWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (593,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 830;
+}
+);
+note = uni147F;
+unicode = 5247;
+},
+{
+glyphname = "kwaa-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (278,0);
+ref = dot_top;
+}
+);
+width = 830;
+}
+);
+note = uni1480;
+unicode = 5248;
+},
+{
+glyphname = "kwaaWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (42,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (593,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 830;
+}
+);
+note = uni1481;
+unicode = 5249;
+},
+{
+glyphname = "kwaaNaskapi-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ka-canadian";
+}
+);
+width = 830;
+}
+);
+note = uni1482;
+unicode = 5250;
+},
+{
+glyphname = "k-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(327,339,o),
+(382,419,o),
+(382,497,cs),
+(382,558,o),
+(344,601,o),
+(280,601,cs),
+(245,601,o),
+(217,585,o),
+(203,560,c),
+(228,557,l),
+(257,690,l),
+(148,690,l),
+(106,495,ls),
+(89,412,o),
+(125,339,o),
+(228,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(214,418,o),
+(200,433,o),
+(200,456,cs),
+(200,485,o),
+(219,525,o),
+(249,525,cs),
+(270,525,o),
+(284,510,o),
+(284,486,cs),
+(284,457,o),
+(265,418,o),
+(235,418,cs)
+);
+}
+);
+width = 376;
+}
+);
+note = uni1483;
+unicode = 5251;
+},
+{
+glyphname = "kw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(297,339,o),
+(352,383,o),
+(370,469,cs),
+(416,690,l),
+(307,690,l),
+(278,554,l),
+(299,554,l),
+(297,580,o),
+(265,601,o),
+(226,601,cs),
+(142,601,o),
+(92,526,o),
+(92,454,cs),
+(92,385,o),
+(140,339,o),
+(218,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,416,o),
+(186,431,o),
+(186,455,cs),
+(186,484,o),
+(206,523,o),
+(236,523,cs),
+(257,523,o),
+(271,508,o),
+(271,485,cs),
+(271,456,o),
+(252,416,o),
+(222,416,cs)
+);
+}
+);
+width = 376;
+}
+);
+metricLeft = "=|k-canadian";
+metricRight = "=|k-canadian";
+note = uni1484;
+unicode = 5252;
+},
+{
+glyphname = "southslaveykeh-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+pos = (593,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni1485;
+unicode = 5253;
+},
+{
+glyphname = "southslaveykih-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+pos = (593,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni1486;
+unicode = 5254;
+},
+{
+glyphname = "southslaveykoh-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+pos = (593,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni1487;
+unicode = 5255;
+},
+{
+glyphname = "southslaveykah-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+pos = (593,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni1488;
+unicode = 5256;
+},
+{
+glyphname = "ce-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (313,360);
+},
+{
+name = top_center_can;
+pos = (383,690);
+},
+{
+name = top_left_can;
+pos = (214,690);
+},
+{
+name = top_right_can;
+pos = (545,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(477,0,l),
+(569,430,ls),
+(603,593,o),
+(517,704,o),
+(356,704,cs),
+(211,704,o),
+(121,620,o),
+(86,461,cs),
+(69,380,l),
+(227,380,l),
+(244,459,ls),
+(259,532,o),
+(291,565,o),
+(343,565,cs),
+(403,565,o),
+(428,523,o),
+(412,450,cs),
+(317,0,l)
+);
+}
+);
+width = 585;
+}
+);
+metricRight = "te-canadian";
+note = uni1489;
+unicode = 5257;
+},
+{
+glyphname = "caai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (173,0);
+ref = ring_top.canadian;
+}
+);
+width = 585;
+}
+);
+note = uni148A;
+unicode = 5258;
+},
+{
+glyphname = "ci-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (318,360);
+},
+{
+name = top_center_can;
+pos = (399,690);
+},
+{
+name = top_left_can;
+pos = (230,690);
+},
+{
+name = top_right_can;
+pos = (561,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(163,0,l),
+(261,459,ls),
+(276,532,o),
+(307,565,o),
+(359,565,cs),
+(419,565,o),
+(444,523,o),
+(430,450,cs),
+(414,380,l),
+(574,380,l),
+(584,430,ls),
+(619,593,o),
+(532,704,o),
+(372,704,cs),
+(226,704,o),
+(135,620,o),
+(101,461,cs),
+(3,0,l)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+unicode = 5259;
+},
+{
+glyphname = "cii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (211,0);
+ref = dot_top;
+}
+);
+width = 586;
+}
+);
+note = uni148C;
+unicode = 5260;
+},
+{
+glyphname = "co-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (313,360);
+},
+{
+name = top_center_can;
+pos = (383,690);
+},
+{
+name = top_double;
+pos = (545,690);
+},
+{
+name = top_left_can;
+pos = (214,690);
+},
+{
+name = top_right_can;
+pos = (545,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(401,-14,o),
+(492,70,o),
+(526,229,cs),
+(624,690,l),
+(464,690,l),
+(366,231,ls),
+(351,157,o),
+(320,125,o),
+(268,125,cs),
+(208,125,o),
+(184,167,o),
+(198,240,cs),
+(213,310,l),
+(54,310,l),
+(43,260,ls),
+(9,97,o),
+(96,-14,o),
+(255,-14,cs)
+);
+}
+);
+width = 585;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+unicode = 5261;
+},
+{
+glyphname = "coo-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (355,0);
+ref = dot_top;
+}
+);
+width = 585;
+}
+);
+note = uni148E;
+unicode = 5262;
+},
+{
+glyphname = "ycreecoo-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (172,0);
+ref = doubledot_top;
+}
+);
+width = 585;
+}
+);
+note = uni148F;
+unicode = 5263;
+},
+{
+glyphname = "ca-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (317,360);
+},
+{
+name = top_center_can;
+pos = (399,690);
+},
+{
+name = top_left_can;
+pos = (230,690);
+},
+{
+name = top_right_can;
+pos = (559,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(415,-14,o),
+(506,70,o),
+(540,229,cs),
+(557,310,l),
+(399,310,l),
+(383,231,ls),
+(367,157,o),
+(335,125,o),
+(284,125,cs),
+(224,125,o),
+(199,167,o),
+(214,240,cs),
+(309,690,l),
+(149,690,l),
+(58,260,ls),
+(23,97,o),
+(110,-14,o),
+(269,-14,cs)
+);
+}
+);
+width = 584;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+unicode = 5264;
+},
+{
+glyphname = "caa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (43,0);
+ref = dot_top;
+}
+);
+width = 585;
+}
+);
+note = uni1491;
+unicode = 5265;
+},
+{
+glyphname = "cwe-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ce-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni1492;
+unicode = 5266;
+},
+{
+glyphname = "cweWestCree-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (585,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni1493;
+unicode = 5267;
+},
+{
+glyphname = "cwi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+pos = (237,0);
+ref = "ci-canadian";
+}
+);
+width = 823;
+}
+);
+note = uni1494;
+unicode = 5268;
+},
+{
+glyphname = "cwiWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "ci-canadian";
+},
+{
+anchor = middle_right_can;
+pos = (586,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 823;
+}
+);
+note = uni1495;
+unicode = 5269;
+},
+{
+glyphname = "cwii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+pos = (237,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (448,0);
+ref = dot_top;
+}
+);
+width = 823;
+}
+);
+note = uni1496;
+unicode = 5270;
+},
+{
+glyphname = "cwiiWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (211,0);
+ref = dot_top;
+},
+{
+anchor = middle_right_can;
+pos = (586,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 823;
+}
+);
+note = uni1497;
+unicode = 5271;
+},
+{
+glyphname = "cwo-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "co-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni1498;
+unicode = 5272;
+},
+{
+glyphname = "cwoWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (585,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni1499;
+unicode = 5273;
+},
+{
+glyphname = "cwoo-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (592,0);
+ref = dot_top;
+}
+);
+width = 822;
+}
+);
+note = uni149A;
+unicode = 5274;
+},
+{
+glyphname = "cwooWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (355,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (585,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni149B;
+unicode = 5275;
+},
+{
+glyphname = "cwa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ca-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni149C;
+unicode = 5276;
+},
+{
+glyphname = "cwaWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (585,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni149D;
+unicode = 5277;
+},
+{
+glyphname = "cwaa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (278,0);
+ref = dot_top;
+}
+);
+width = 822;
+}
+);
+note = uni149E;
+unicode = 5278;
+},
+{
+glyphname = "cwaaWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (43,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (585,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni149F;
+unicode = 5279;
+},
+{
+glyphname = "cwaaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ca-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni14A0;
+unicode = 5280;
+},
+{
+glyphname = "c-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(309,339,o),
+(365,384,o),
+(382,464,cs),
+(387,491,l),
+(285,491,l),
+(278,461,ls),
+(273,436,o),
+(260,423,o),
+(239,423,cs),
+(214,423,o),
+(204,439,o),
+(210,467,cs),
+(257,690,l),
+(148,690,l),
+(105,489,ls),
+(86,398,o),
+(133,339,o),
+(232,339,cs)
+);
+}
+);
+width = 366;
+}
+);
+note = uni14A1;
+unicode = 5281;
+},
+{
+glyphname = "thSayisi-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(286,339,o),
+(341,384,o),
+(357,464,cs),
+(406,690,l),
+(297,690,l),
+(248,462,ls),
+(243,436,o),
+(227,423,o),
+(208,423,cs),
+(184,423,o),
+(173,439,o),
+(179,466,cs),
+(185,491,l),
+(83,491,l),
+(79,475,ls),
+(63,398,o),
+(109,339,o),
+(202,339,cs)
+);
+}
+);
+width = 365;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "=|c-canadian";
+note = uni14A2;
+unicode = 5282;
+},
+{
+glyphname = "me-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (204,345);
+},
+{
+name = top_center_can;
+pos = (360,690);
+},
+{
+name = top_left_can;
+pos = (209,690);
+},
+{
+name = top_right_can;
+pos = (503,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(437,0,l),
+(583,690,l),
+(129,690,l),
+(99,546,l),
+(392,546,l),
+(276,0,l)
+);
+}
+);
+width = 551;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+unicode = 5283;
+},
+{
+glyphname = "maai-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (157,0);
+ref = ring_top.canadian;
+}
+);
+width = 552;
+}
+);
+note = uni14A4;
+unicode = 5284;
+},
+{
+glyphname = "mi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (391,345);
+},
+{
+name = top_center_can;
+pos = (384,690);
+},
+{
+name = top_left_can;
+pos = (238,690);
+},
+{
+name = top_right_can;
+pos = (531,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(170,0,l),
+(287,546,l),
+(581,546,l),
+(611,690,l),
+(156,690,l),
+(10,0,l)
+);
+}
+);
+width = 552;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+unicode = 5285;
+},
+{
+glyphname = "mii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (195,0);
+ref = dot_top;
+}
+);
+width = 552;
+}
+);
+note = uni14A6;
+unicode = 5286;
+},
+{
+glyphname = "mo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (203,345);
+},
+{
+name = top_center_can;
+pos = (360,690);
+},
+{
+name = top_double;
+pos = (503,690);
+},
+{
+name = top_left_can;
+pos = (209,690);
+},
+{
+name = top_right_can;
+pos = (503,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(436,0,l),
+(582,690,l),
+(422,690,l),
+(306,144,l),
+(13,144,l),
+(-17,0,l)
+);
+}
+);
+width = 550;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+unicode = 5287;
+},
+{
+glyphname = "moo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (316,0);
+ref = dot_top;
+}
+);
+width = 552;
+}
+);
+note = uni14A8;
+unicode = 5288;
+},
+{
+glyphname = "ycreemoo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (131,0);
+ref = doubledot_top;
+}
+);
+width = 552;
+}
+);
+note = uni14A9;
+unicode = 5289;
+},
+{
+glyphname = "ma-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (391,345);
+},
+{
+name = top_center_can;
+pos = (384,690);
+},
+{
+name = top_left_can;
+pos = (238,690);
+},
+{
+name = top_right_can;
+pos = (530,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(464,0,l),
+(495,144,l),
+(201,144,l),
+(317,690,l),
+(156,690,l),
+(10,0,l)
+);
+}
+);
+width = 552;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+unicode = 5290;
+},
+{
+glyphname = "maa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (48,0);
+ref = dot_top;
+}
+);
+width = 552;
+}
+);
+note = uni14AB;
+unicode = 5291;
+},
+{
+glyphname = "mwe-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "me-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni14AC;
+unicode = 5292;
+},
+{
+glyphname = "mweWestCree-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "me-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (552,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni14AD;
+unicode = 5293;
+},
+{
+glyphname = "mwi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "mi-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni14AE;
+unicode = 5294;
+},
+{
+glyphname = "mwiWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (552,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni14AF;
+unicode = 5295;
+},
+{
+glyphname = "mwii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (432,0);
+ref = dot_top;
+}
+);
+width = 788;
+}
+);
+note = uni14B0;
+unicode = 5296;
+},
+{
+glyphname = "mwiiWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (195,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (552,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni14B1;
+unicode = 5297;
+},
+{
+glyphname = "mwo-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "mo-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni14B2;
+unicode = 5298;
+},
+{
+glyphname = "mwoWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (552,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni14B3;
+unicode = 5299;
+},
+{
+glyphname = "mwoo-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (552,0);
+ref = dot_top;
+}
+);
+width = 788;
+}
+);
+note = uni14B4;
+unicode = 5300;
+},
+{
+glyphname = "mwooWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (316,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (552,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni14B5;
+unicode = 5301;
+},
+{
+glyphname = "mwa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ma-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni14B6;
+unicode = 5302;
+},
+{
+glyphname = "mwaWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (552,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni14B7;
+unicode = 5303;
+},
+{
+glyphname = "mwaa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (285,0);
+ref = dot_top;
+}
+);
+width = 788;
+}
+);
+note = uni14B8;
+unicode = 5304;
+},
+{
+glyphname = "mwaaWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (48,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (552,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni14B9;
+unicode = 5305;
+},
+{
+glyphname = "mwaaNaskapi-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ma-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni14BA;
+unicode = 5306;
+},
+{
+glyphname = "m-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(321,345,l),
+(342,446,l),
+(205,446,l),
+(257,690,l),
+(148,690,l),
+(74,345,l)
+);
+}
+);
+width = 340;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni14BB;
+unicode = 5307;
+},
+{
+glyphname = "mWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "t-canadian";
+}
+);
+width = 365;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "t-canadian";
+note = uni14BC;
+unicode = 5308;
+},
+{
+glyphname = "mh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(308,345,l),
+(382,690,l),
+(272,690,l),
+(220,446,l),
+(83,446,l),
+(62,345,l)
+);
+}
+);
+width = 341;
+}
+);
+metricLeft = "=|m-canadian";
+metricRight = "=|m-canadian";
+note = uni14BD;
+unicode = 5309;
+},
+{
+glyphname = "mAthapascan-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(330,345,l),
+(348,431,l),
+(198,431,l),
+(195,388,l),
+(310,481,ls),
+(350,514,o),
+(373,552,o),
+(373,596,cs),
+(373,654,o),
+(327,696,o),
+(257,696,cs),
+(180,696,o),
+(128,657,o),
+(109,568,c),
+(206,568,l),
+(212,603,o),
+(228,618,o),
+(248,618,cs),
+(268,618,o),
+(278,607,o),
+(278,590,cs),
+(278,566,o),
+(258,542,o),
+(225,515,cs),
+(87,402,l),
+(74,345,l)
+);
+}
+);
+width = 351;
+}
+);
+note = uni14BE;
+unicode = 5310;
+},
+{
+glyphname = "mSayisi-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = two.canadian;
+}
+);
+width = 588;
+}
+);
+note = uni14BF;
+unicode = 5311;
+},
+{
+glyphname = "ne-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (504,245);
+},
+{
+name = top_center_can;
+pos = (544,511);
+},
+{
+name = top_left_can;
+pos = (177,511);
+},
+{
+name = top_right_can;
+pos = (735,511);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(656,-14,o),
+(757,130,o),
+(757,275,cs),
+(757,405,o),
+(667,492,o),
+(526,492,cs),
+(93,492,l),
+(63,350,l),
+(352,350,l),
+(346,409,l),
+(276,358,o),
+(250,271,o),
+(250,200,cs),
+(250,71,o),
+(343,-14,o),
+(484,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(439,121,o),
+(406,156,o),
+(406,210,cs),
+(406,270,o),
+(444,356,o),
+(516,356,cs),
+(568,356,o),
+(601,322,o),
+(601,269,cs),
+(601,207,o),
+(562,121,o),
+(491,121,cs)
+);
+}
+);
+width = 799;
+}
+);
+metricRight = "=|ke-canadian";
+note = uni14C0;
+unicode = 5312;
+},
+{
+glyphname = "naai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (145,-179);
+ref = ring_top.canadian;
+}
+);
+width = 798;
+}
+);
+note = uni14C1;
+unicode = 5313;
+},
+{
+glyphname = "ni-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (294,245);
+},
+{
+name = top_center_can;
+pos = (371,511);
+},
+{
+name = top_left_can;
+pos = (176,511);
+},
+{
+name = top_right_can;
+pos = (735,511);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(444,-14,o),
+(546,130,o),
+(546,276,cs),
+(546,312,o),
+(535,346,o),
+(519,369,c),
+(489,350,l),
+(781,350,l),
+(810,492,l),
+(319,492,ls),
+(140,492,o),
+(39,348,o),
+(39,203,cs),
+(39,71,o),
+(131,-14,o),
+(272,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(227,121,o),
+(194,156,o),
+(194,210,cs),
+(194,270,o),
+(233,356,o),
+(305,356,cs),
+(357,356,o),
+(389,322,o),
+(389,269,cs),
+(389,207,o),
+(351,121,o),
+(279,121,cs)
+);
+}
+);
+width = 800;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+unicode = 5314;
+},
+{
+glyphname = "nii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (183,-179);
+ref = dot_top;
+}
+);
+width = 798;
+}
+);
+note = uni14C3;
+unicode = 5315;
+},
+{
+glyphname = "no-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (505,245);
+},
+{
+name = top_center_can;
+pos = (562,511);
+},
+{
+name = top_double;
+pos = (563,511);
+},
+{
+name = top_left_can;
+pos = (179,511);
+},
+{
+name = top_right_can;
+pos = (738,511);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(481,0,ls),
+(661,0,o),
+(762,144,o),
+(762,289,cs),
+(762,421,o),
+(669,506,o),
+(528,506,cs),
+(356,506,o),
+(255,361,o),
+(255,216,cs),
+(255,180,o),
+(265,146,o),
+(281,123,c),
+(311,142,l),
+(19,142,l),
+(-11,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(443,135,o),
+(411,170,o),
+(411,224,cs),
+(411,285,o),
+(449,371,o),
+(521,371,cs),
+(573,371,o),
+(606,336,o),
+(606,282,cs),
+(606,221,o),
+(567,135,o),
+(496,135,cs)
+);
+}
+);
+width = 801;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14C4;
+unicode = 5316;
+},
+{
+glyphname = "noo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (372,-179);
+ref = dot_top;
+}
+);
+width = 798;
+}
+);
+note = uni14C5;
+unicode = 5317;
+},
+{
+glyphname = "ycreenoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (188,-179);
+ref = doubledot_top;
+}
+);
+width = 798;
+}
+);
+note = uni14C6;
+unicode = 5318;
+},
+{
+glyphname = "na-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (294,245);
+},
+{
+name = top_center_can;
+pos = (350,511);
+},
+{
+name = top_double;
+pos = (528,511);
+},
+{
+name = top_left_can;
+pos = (175,511);
+},
+{
+name = top_right_can;
+pos = (734,511);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(705,0,l),
+(736,142,l),
+(446,142,l),
+(452,83,l),
+(522,133,o),
+(548,221,o),
+(548,292,cs),
+(548,420,o),
+(455,506,o),
+(315,506,cs),
+(143,506,o),
+(42,361,o),
+(42,217,cs),
+(42,87,o),
+(132,0,o),
+(272,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(230,135,o),
+(197,170,o),
+(197,224,cs),
+(197,285,o),
+(236,371,o),
+(308,371,cs),
+(360,371,o),
+(392,336,o),
+(392,282,cs),
+(392,221,o),
+(354,135,o),
+(282,135,cs)
+);
+}
+);
+width = 799;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+unicode = 5319;
+},
+{
+glyphname = "naa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (161,-179);
+ref = dot_top;
+}
+);
+width = 798;
+}
+);
+note = uni14C8;
+unicode = 5320;
+},
+{
+glyphname = "nwe-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ne-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni14C9;
+unicode = 5321;
+},
+{
+glyphname = "nweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (798,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni14CA;
+unicode = 5322;
+},
+{
+glyphname = "nwa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "na-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni14CB;
+unicode = 5323;
+},
+{
+glyphname = "nwaWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (798,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni14CC;
+unicode = 5324;
+},
+{
+glyphname = "nwaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (398,-179);
+ref = dot_top;
+}
+);
+width = 1035;
+}
+);
+note = uni14CD;
+unicode = 5325;
+},
+{
+glyphname = "nwaaWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (161,-179);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (798,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni14CE;
+unicode = 5326;
+},
+{
+glyphname = "nwaaNaskapi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (156,-179);
+ref = doubledot_top;
+}
+);
+width = 798;
+}
+);
+note = uni14CF;
+unicode = 5327;
+},
+{
+glyphname = "n-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(472,435,l),
+(495,536,l),
+(337,536,l),
+(329,471,l),
+(369,493,o),
+(388,544,o),
+(388,583,cs),
+(388,651,o),
+(338,697,o),
+(261,697,cs),
+(173,697,o),
+(113,632,o),
+(113,552,cs),
+(113,483,o),
+(163,435,o),
+(239,435,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(222,513,o),
+(208,528,o),
+(208,552,cs),
+(208,581,o),
+(225,619,o),
+(258,619,cs),
+(280,619,o),
+(294,604,o),
+(294,581,cs),
+(294,552,o),
+(276,513,o),
+(244,513,cs)
+);
+}
+);
+width = 473;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni14D0;
+unicode = 5328;
+},
+{
+color = 6;
+glyphname = "ngCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-34,-161);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 428;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "=|";
+note = uni14D1;
+unicode = 5329;
+},
+{
+glyphname = "nh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(343,435,ls),
+(438,435,o),
+(496,498,o),
+(496,582,cs),
+(496,649,o),
+(446,697,o),
+(368,697,cs),
+(280,697,o),
+(221,632,o),
+(221,552,cs),
+(221,529,o),
+(229,507,o),
+(243,492,c),
+(260,536,l),
+(102,536,l),
+(81,435,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(329,513,o),
+(316,528,o),
+(316,552,cs),
+(316,581,o),
+(332,619,o),
+(365,619,cs),
+(387,619,o),
+(401,604,o),
+(401,581,cs),
+(401,552,o),
+(384,513,o),
+(352,513,cs)
+);
+}
+);
+width = 472;
+}
+);
+metricLeft = "=|n-canadian";
+metricRight = "=|n-canadian";
+note = uni14D2;
+unicode = 5330;
+},
+{
+glyphname = "le-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (504,245);
+},
+{
+name = top_center_can;
+pos = (545,511);
+},
+{
+name = top_left_can;
+pos = (177,511);
+},
+{
+name = top_right_can;
+pos = (735,511);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(435,0,ls),
+(641,0,o),
+(758,112,o),
+(758,282,cs),
+(758,410,o),
+(668,492,o),
+(526,492,cs),
+(93,492,l),
+(63,349,l),
+(498,349,ls),
+(562,349,o),
+(597,318,o),
+(597,266,cs),
+(597,192,o),
+(550,140,o),
+(454,140,cs),
+(405,140,l),
+(375,0,l)
+);
+}
+);
+width = 799;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D3;
+unicode = 5331;
+},
+{
+glyphname = "laai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (146,-179);
+ref = ring_top.canadian;
+}
+);
+width = 798;
+}
+);
+note = uni14D4;
+unicode = 5332;
+},
+{
+glyphname = "li-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (296,245);
+},
+{
+name = top_center_can;
+pos = (372,511);
+},
+{
+name = top_left_can;
+pos = (177,511);
+},
+{
+name = top_right_can;
+pos = (735,511);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(320,0,l),
+(350,140,l),
+(298,140,ls),
+(236,140,o),
+(200,172,o),
+(200,224,cs),
+(200,293,o),
+(245,349,o),
+(340,349,cs),
+(780,349,l),
+(810,492,l),
+(355,492,ls),
+(161,492,o),
+(42,385,o),
+(42,216,cs),
+(42,90,o),
+(131,0,o),
+(270,0,cs)
+);
+}
+);
+width = 799;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14D5;
+unicode = 5333;
+},
+{
+glyphname = "lii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (183,-179);
+ref = dot_top;
+}
+);
+width = 798;
+}
+);
+note = uni14D6;
+unicode = 5334;
+},
+{
+glyphname = "lo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (503,245);
+},
+{
+name = top_center_can;
+pos = (560,511);
+},
+{
+name = top_double;
+pos = (548,511);
+},
+{
+name = top_left_can;
+pos = (178,511);
+},
+{
+name = top_right_can;
+pos = (735,511);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(445,0,ls),
+(638,0,o),
+(757,106,o),
+(757,275,cs),
+(757,402,o),
+(669,492,o),
+(529,492,cs),
+(479,492,l),
+(450,353,l),
+(501,353,ls),
+(563,353,o),
+(600,321,o),
+(600,268,cs),
+(600,199,o),
+(554,143,o),
+(459,143,cs),
+(19,143,l),
+(-11,0,l)
+);
+}
+);
+width = 799;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D7;
+unicode = 5335;
+},
+{
+glyphname = "loo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (371,-179);
+ref = dot_top;
+}
+);
+width = 798;
+}
+);
+note = uni14D8;
+unicode = 5336;
+},
+{
+glyphname = "ycreeloo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (174,-179);
+ref = doubledot_top;
+}
+);
+width = 798;
+}
+);
+note = uni14D9;
+unicode = 5337;
+},
+{
+glyphname = "la-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (295,245);
+},
+{
+name = top_center_can;
+pos = (351,511);
+},
+{
+name = top_left_can;
+pos = (176,511);
+},
+{
+name = top_right_can;
+pos = (734,511);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(705,0,l),
+(736,143,l),
+(299,143,ls),
+(236,143,o),
+(201,174,o),
+(201,226,cs),
+(201,299,o),
+(248,353,o),
+(344,353,cs),
+(393,353,l),
+(423,492,l),
+(364,492,ls),
+(156,492,o),
+(41,380,o),
+(41,210,cs),
+(41,82,o),
+(129,0,o),
+(272,0,cs)
+);
+}
+);
+width = 799;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14DA;
+unicode = 5338;
+},
+{
+glyphname = "laa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (162,-179);
+ref = dot_top;
+}
+);
+width = 798;
+}
+);
+note = uni14DB;
+unicode = 5339;
+},
+{
+glyphname = "lwe-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "le-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni14DC;
+unicode = 5340;
+},
+{
+glyphname = "lweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "le-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (798,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni14DD;
+unicode = 5341;
+},
+{
+glyphname = "lwi-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "li-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni14DE;
+unicode = 5342;
+},
+{
+glyphname = "lwiWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (798,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni14DF;
+unicode = 5343;
+},
+{
+glyphname = "lwii-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (419,-179);
+ref = dot_top;
+}
+);
+width = 1035;
+}
+);
+note = uni14E0;
+unicode = 5344;
+},
+{
+glyphname = "lwiiWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (183,-179);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (798,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni14E1;
+unicode = 5345;
+},
+{
+glyphname = "lwo-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "lo-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni14E2;
+unicode = 5346;
+},
+{
+glyphname = "lwoWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (798,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni14E3;
+unicode = 5347;
+},
+{
+glyphname = "lwoo-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (608,-179);
+ref = dot_top;
+}
+);
+width = 1035;
+}
+);
+note = uni14E4;
+unicode = 5348;
+},
+{
+glyphname = "lwooWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (371,-179);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (798,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni14E5;
+unicode = 5349;
+},
+{
+glyphname = "lwa-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "la-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni14E6;
+unicode = 5350;
+},
+{
+glyphname = "lwaWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (798,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni14E7;
+unicode = 5351;
+},
+{
+glyphname = "lwaa-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (399,-179);
+ref = dot_top;
+}
+);
+width = 1035;
+}
+);
+note = uni14E8;
+unicode = 5352;
+},
+{
+glyphname = "lwaaWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (162,-179);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (798,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni14E9;
+unicode = 5353;
+},
+{
+glyphname = "l-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(437,345,l),
+(459,446,l),
+(276,446,ls),
+(235,446,o),
+(212,467,o),
+(212,501,cs),
+(212,545,o),
+(237,592,o),
+(301,592,cs),
+(323,592,l),
+(343,690,l),
+(313,690,ls),
+(177,690,o),
+(102,603,o),
+(102,489,cs),
+(102,400,o),
+(164,345,o),
+(267,345,cs)
+);
+}
+);
+width = 456;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "m-canadian";
+note = uni14EA;
+unicode = 5354;
+},
+{
+glyphname = "lWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(315,345,l),
+(328,410,l),
+(190,474,l),
+(180,422,l),
+(346,490,l),
+(355,533,l),
+(217,599,l),
+(205,546,l),
+(372,612,l),
+(388,690,l),
+(370,690,l),
+(128,597,l),
+(122,564,l),
+(267,497,l),
+(275,536,l),
+(101,470,l),
+(95,438,l),
+(297,345,l)
+);
+}
+);
+width = 347;
+}
+);
+metricRight = "=|";
+note = uni14EB;
+unicode = 5355;
+},
+{
+glyphname = "mediall-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(501,-14,l),
+(524,94,l),
+(219,234,l),
+(203,156,l),
+(569,304,l),
+(582,366,l),
+(276,504,l),
+(261,434,l),
+(626,574,l),
+(653,704,l),
+(615,704,l),
+(112,511,l),
+(100,456,l),
+(408,315,l),
+(419,373,l),
+(53,234,l),
+(42,179,l),
+(463,-14,l)
+);
+}
+);
+width = 612;
+}
+);
+metricRight = "=|";
+note = uni14EC;
+unicode = 5356;
+},
+{
+glyphname = "se-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (237,690);
+},
+{
+name = top_right_can;
+pos = (509,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(441,0,l),
+(520,366,l),
+(476,366,ls),
+(319,366,o),
+(260,429,o),
+(297,598,cs),
+(317,690,l),
+(156,690,l),
+(134,588,ls),
+(87,368,o),
+(199,224,o),
+(441,224,cs),
+(462,224,l),
+(340,273,l),
+(281,0,l)
+);
+}
+);
+width = 557;
+}
+);
+note = uni14ED;
+unicode = 5357;
+},
+{
+glyphname = "saai-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (284,0);
+ref = ring_top.canadian;
+}
+);
+width = 557;
+}
+);
+note = uni14EE;
+unicode = 5358;
+},
+{
+glyphname = "si-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (238,690);
+},
+{
+name = top_right_can;
+pos = (510,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(171,0,l),
+(230,277,l),
+(97,224,l),
+(136,224,ls),
+(370,224,o),
+(512,331,o),
+(566,582,cs),
+(589,690,l),
+(429,690,l),
+(409,597,ls),
+(376,446,o),
+(289,366,o),
+(141,366,cs),
+(89,366,l),
+(11,0,l)
+);
+}
+);
+width = 556;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+unicode = 5359;
+},
+{
+glyphname = "sii-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (322,0);
+ref = dot_top;
+}
+);
+width = 557;
+}
+);
+note = uni14F0;
+unicode = 5360;
+},
+{
+glyphname = "so-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (508,690);
+},
+{
+name = top_left_can;
+pos = (236,690);
+},
+{
+name = top_right_can;
+pos = (508,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(169,0,l),
+(189,93,ls),
+(222,243,o),
+(309,324,o),
+(458,324,cs),
+(510,324,l),
+(587,690,l),
+(427,690,l),
+(368,412,l),
+(502,466,l),
+(463,466,ls),
+(229,466,o),
+(86,358,o),
+(32,107,cs),
+(9,0,l)
+);
+}
+);
+width = 556;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+unicode = 5361;
+},
+{
+glyphname = "soo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (321,0);
+ref = dot_top;
+}
+);
+width = 557;
+}
+);
+note = uni14F2;
+unicode = 5362;
+},
+{
+glyphname = "ycreesoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (136,0);
+ref = doubledot_top;
+}
+);
+width = 557;
+}
+);
+note = uni14F3;
+unicode = 5363;
+},
+{
+glyphname = "sa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (239,690);
+},
+{
+name = top_right_can;
+pos = (510,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(443,0,l),
+(465,101,ls),
+(513,322,o),
+(401,466,o),
+(158,466,cs),
+(138,466,l),
+(260,416,l),
+(319,690,l),
+(157,690,l),
+(80,324,l),
+(124,324,ls),
+(280,324,o),
+(339,261,o),
+(302,92,cs),
+(283,0,l)
+);
+}
+);
+width = 557;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+unicode = 5364;
+},
+{
+glyphname = "saa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+}
+);
+width = 557;
+}
+);
+note = uni14F5;
+unicode = 5365;
+},
+{
+glyphname = "swe-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "se-canadian";
+}
+);
+width = 793;
+}
+);
+note = uni14F6;
+unicode = 5366;
+},
+{
+glyphname = "sweWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "se-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (557,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 793;
+}
+);
+note = uni14F7;
+unicode = 5367;
+},
+{
+glyphname = "swi-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "si-canadian";
+}
+);
+width = 793;
+}
+);
+note = uni14F8;
+unicode = 5368;
+},
+{
+glyphname = "swiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (557,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 793;
+}
+);
+note = uni14F9;
+unicode = 5369;
+},
+{
+glyphname = "swii-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (558,0);
+ref = dot_top;
+}
+);
+width = 793;
+}
+);
+note = uni14FA;
+unicode = 5370;
+},
+{
+glyphname = "swiiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (322,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (557,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 793;
+}
+);
+note = uni14FB;
+unicode = 5371;
+},
+{
+glyphname = "swo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "so-canadian";
+}
+);
+width = 793;
+}
+);
+note = uni14FC;
+unicode = 5372;
+},
+{
+glyphname = "swoWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (557,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 793;
+}
+);
+note = uni14FD;
+unicode = 5373;
+},
+{
+glyphname = "swoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (556,0);
+ref = dot_top;
+}
+);
+width = 793;
+}
+);
+note = uni14FE;
+unicode = 5374;
+},
+{
+glyphname = "swooWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (321,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (557,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 793;
+}
+);
+note = uni14FF;
+unicode = 5375;
+},
+{
+glyphname = "swa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "sa-canadian";
+}
+);
+width = 793;
+}
+);
+note = uni1500;
+unicode = 5376;
+},
+{
+glyphname = "swaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (557,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 793;
+}
+);
+note = uni1501;
+unicode = 5377;
+},
+{
+glyphname = "swaa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (285,0);
+ref = dot_top;
+}
+);
+width = 793;
+}
+);
+note = uni1502;
+unicode = 5378;
+},
+{
+glyphname = "swaaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (557,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 793;
+}
+);
+note = uni1503;
+unicode = 5379;
+},
+{
+glyphname = "swaaNaskapi-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "sa-canadian";
+}
+);
+width = 793;
+}
+);
+note = uni1504;
+unicode = 5380;
+},
+{
+glyphname = "s-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(329,345,l),
+(340,395,ls),
+(365,512,o),
+(308,593,o),
+(193,593,cs),
+(164,593,l),
+(227,551,l),
+(257,690,l),
+(148,690,l),
+(109,507,l),
+(150,507,ls),
+(221,507,o),
+(247,472,o),
+(232,398,cs),
+(220,345,l)
+);
+}
+);
+width = 362;
+}
+);
+metricRight = "=|";
+note = uni1505;
+unicode = 5381;
+},
+{
+color = 6;
+glyphname = "sAthapascan-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(289,177,o),
+(337,229,o),
+(337,293,cs),
+(337,336,o),
+(312,365,o),
+(270,380,cs),
+(212,399,ls),
+(195,404,o),
+(188,414,o),
+(188,424,cs),
+(188,444,o),
+(203,457,o),
+(232,457,cs),
+(260,457,o),
+(274,444,o),
+(269,415,c),
+(363,415,l),
+(377,494,o),
+(318,533,o),
+(239,533,cs),
+(143,533,o),
+(94,482,o),
+(94,414,cs),
+(94,373,o),
+(121,342,o),
+(159,329,cs),
+(218,310,ls),
+(236,303,o),
+(242,295,o),
+(242,283,cs),
+(242,265,o),
+(227,253,o),
+(199,253,cs),
+(166,253,o),
+(153,266,o),
+(157,295,c),
+(63,295,l),
+(50,219,o),
+(102,177,o),
+(195,177,cs)
+);
+}
+);
+width = 383;
+}
+);
+metricRight = "=|";
+note = uni1506;
+unicode = 5382;
+},
+{
+glyphname = "sw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(185,345,l),
+(195,396,ls),
+(212,474,o),
+(252,507,o),
+(331,507,cs),
+(365,507,l),
+(404,690,l),
+(295,690,l),
+(265,550,l),
+(347,593,l),
+(304,593,ls),
+(189,593,o),
+(114,526,o),
+(87,401,cs),
+(75,345,l)
+);
+}
+);
+width = 364;
+}
+);
+metricLeft = "=|s-canadian";
+metricRight = "=|s-canadian";
+note = uni1507;
+unicode = 5383;
+},
+{
+glyphname = "sBlackfoot-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(333,345,l),
+(354,446,l),
+(265,446,ls),
+(226,446,o),
+(208,467,o),
+(217,508,cs),
+(256,690,l),
+(147,690,l),
+(109,511,ls),
+(88,411,o),
+(139,345,o),
+(244,345,cs)
+);
+}
+);
+width = 352;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "m-canadian";
+note = uni1508;
+unicode = 5384;
+},
+{
+glyphname = "moosecreesk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(324,217,o),
+(363,332,o),
+(363,427,cs),
+(363,529,o),
+(308,592,o),
+(198,592,cs),
+(183,592,l),
+(229,551,l),
+(259,690,l),
+(150,690,l),
+(111,508,l),
+(158,508,ls),
+(229,508,o),
+(267,497,o),
+(263,429,c),
+(291,432,l),
+(281,457,o),
+(251,476,o),
+(209,476,cs),
+(117,476,o),
+(75,399,o),
+(75,334,cs),
+(75,265,o),
+(125,217,o),
+(203,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(184,295,o),
+(170,310,o),
+(170,333,cs),
+(170,362,o),
+(189,402,o),
+(219,402,cs),
+(242,402,o),
+(255,387,o),
+(255,363,cs),
+(255,333,o),
+(236,295,o),
+(206,295,cs)
+);
+}
+);
+width = 385;
+}
+);
+metricRight = "=|";
+note = uni1509;
+unicode = 5385;
+},
+{
+glyphname = "skwNaskapi-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(307,217,o),
+(355,295,o),
+(355,371,cs),
+(355,434,o),
+(317,476,o),
+(258,476,cs),
+(222,476,o),
+(196,461,o),
+(182,435,c),
+(199,437,l),
+(219,489,o),
+(257,508,o),
+(335,508,cs),
+(384,508,l),
+(422,690,l),
+(313,690,l),
+(283,548,l),
+(349,592,l),
+(322,592,ls),
+(152,592,o),
+(80,457,o),
+(80,346,cs),
+(80,270,o),
+(127,217,o),
+(210,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(188,295,o),
+(175,310,o),
+(175,333,cs),
+(175,362,o),
+(194,402,o),
+(224,402,cs),
+(246,402,o),
+(260,387,o),
+(260,363,cs),
+(260,333,o),
+(241,295,o),
+(211,295,cs)
+);
+}
+);
+width = 385;
+}
+);
+metricLeft = "=|moosecreesk-canadian";
+metricRight = "=|moosecreesk-canadian";
+note = uni150A;
+unicode = 5386;
+},
+{
+glyphname = "swNaskapi-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(316,191,l),
+(324,230,ls),
+(348,340,o),
+(290,416,o),
+(180,416,cs),
+(150,416,l),
+(199,376,l),
+(225,499,l),
+(116,499,l),
+(81,333,l),
+(132,333,ls),
+(198,333,o),
+(232,303,o),
+(215,233,cs),
+(207,191,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(277,2,o),
+(310,36,o),
+(310,76,cs),
+(310,118,o),
+(277,152,o),
+(236,152,cs),
+(195,152,o),
+(162,118,o),
+(162,76,cs),
+(162,36,o),
+(195,2,o),
+(236,2,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(238,538,o),
+(271,572,o),
+(271,613,cs),
+(271,655,o),
+(238,688,o),
+(197,688,cs),
+(156,688,o),
+(123,655,o),
+(123,613,cs),
+(123,572,o),
+(156,538,o),
+(197,538,cs)
+);
+}
+);
+width = 391;
+}
+);
+metricRight = "=|";
+note = uni150B;
+unicode = 5387;
+},
+{
+glyphname = "spwaNaskapi-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(551,0,l),
+(580,137,l),
+(242,365,l),
+(229,295,l),
+(661,522,l),
+(696,690,l),
+(659,690,l),
+(54,369,l),
+(43,321,l),
+(513,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(222,497,o),
+(256,531,o),
+(256,572,cs),
+(256,613,o),
+(222,647,o),
+(182,647,cs),
+(141,647,o),
+(107,613,o),
+(107,572,cs),
+(107,530,o),
+(141,497,o),
+(182,497,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(442,614,l),
+(452,661,ls),
+(470,745,o),
+(426,806,o),
+(345,806,cs),
+(317,806,l),
+(376,770,l),
+(399,875,l),
+(292,875,l),
+(261,727,l),
+(286,727,ls),
+(336,727,o),
+(355,700,o),
+(344,652,cs),
+(336,614,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(639,715,o),
+(672,749,o),
+(672,790,cs),
+(672,831,o),
+(639,865,o),
+(598,865,cs),
+(557,865,o),
+(524,831,o),
+(524,790,cs),
+(524,749,o),
+(557,715,o),
+(598,715,cs)
+);
+}
+);
+width = 644;
+}
+);
+metricRight = "pa-canadian";
+metricWidth = "pa-canadian";
+note = uni150C;
+unicode = 5388;
+},
+{
+glyphname = "stwaNaskapi-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (390,0);
+ref = "ta-canadian";
+}
+);
+width = 1009;
+}
+);
+note = uni150D;
+unicode = 5389;
+},
+{
+glyphname = "skwaNaskapi-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (390,0);
+ref = "ka-canadian";
+}
+);
+width = 984;
+}
+);
+note = uni150E;
+unicode = 5390;
+},
+{
+glyphname = "scwaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (390,0);
+ref = "ca-canadian";
+}
+);
+width = 977;
+}
+);
+note = uni150F;
+unicode = 5391;
+},
+{
+glyphname = "she-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (378,690);
+},
+{
+name = top_right_can;
+pos = (826,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(713,-14,o),
+(801,79,o),
+(833,231,cs),
+(849,310,l),
+(691,310,l),
+(673,232,ls),
+(658,156,o),
+(630,125,o),
+(582,125,cs),
+(527,125,o),
+(510,164,o),
+(522,242,cs),
+(552,428,ls),
+(578,605,o),
+(503,704,o),
+(349,704,cs),
+(206,704,o),
+(118,611,o),
+(86,459,cs),
+(70,380,l),
+(228,380,l),
+(244,458,ls),
+(261,533,o),
+(288,565,o),
+(336,565,cs),
+(390,565,o),
+(408,526,o),
+(397,448,cs),
+(367,262,ls),
+(341,85,o),
+(415,-14,o),
+(570,-14,cs)
+);
+}
+);
+width = 877;
+}
+);
+metricRight = "=|";
+note = uni1510;
+unicode = 5392;
+},
+{
+glyphname = "shi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (241,690);
+},
+{
+name = top_right_can;
+pos = (688,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(388,-14,o),
+(470,65,o),
+(514,242,cs),
+(565,451,ls),
+(585,531,o),
+(613,565,o),
+(661,565,cs),
+(714,565,o),
+(737,528,o),
+(720,448,cs),
+(705,380,l),
+(865,380,l),
+(874,423,ls),
+(909,591,o),
+(827,704,o),
+(668,704,cs),
+(531,704,o),
+(450,625,o),
+(407,449,cs),
+(354,239,ls),
+(334,158,o),
+(306,125,o),
+(259,125,cs),
+(206,125,o),
+(183,161,o),
+(200,242,cs),
+(214,310,l),
+(55,310,l),
+(45,267,ls),
+(12,98,o),
+(93,-14,o),
+(252,-14,cs)
+);
+}
+);
+width = 878;
+}
+);
+metricLeft = "she-canadian";
+metricRight = "she-canadian";
+note = uni1511;
+unicode = 5393;
+},
+{
+glyphname = "shii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (497,0);
+ref = dot_top;
+}
+);
+width = 876;
+}
+);
+note = uni1512;
+unicode = 5394;
+},
+{
+glyphname = "sho-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (505,511);
+},
+{
+name = top_left_can;
+pos = (334,511);
+},
+{
+name = top_right_can;
+pos = (674,511);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(327,120,l),
+(236,121,o),
+(187,146,o),
+(187,189,cs),
+(187,226,o),
+(213,250,o),
+(261,250,cs),
+(375,250,o),
+(471,102,o),
+(651,102,cs),
+(781,102,o),
+(866,186,o),
+(866,309,cs),
+(866,427,o),
+(765,504,o),
+(598,506,c),
+(571,372,l),
+(662,371,o),
+(710,346,o),
+(710,303,cs),
+(710,266,o),
+(684,242,o),
+(638,242,cs),
+(524,242,o),
+(426,389,o),
+(247,389,cs),
+(116,389,o),
+(33,304,o),
+(33,184,cs),
+(33,66,o),
+(132,-13,o),
+(299,-14,c)
+);
+}
+);
+width = 899;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1513;
+unicode = 5395;
+},
+{
+glyphname = "shoo-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (316,-179);
+ref = dot_top;
+}
+);
+width = 898;
+}
+);
+note = uni1514;
+unicode = 5396;
+},
+{
+glyphname = "sha-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (505,511);
+},
+{
+name = top_left_can;
+pos = (335,511);
+},
+{
+name = top_right_can;
+pos = (675,511);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(680,-22,o),
+(846,46,o),
+(846,218,cs),
+(846,319,o),
+(776,389,o),
+(655,389,cs),
+(495,389,o),
+(360,242,o),
+(267,242,cs),
+(231,242,o),
+(210,260,o),
+(210,289,cs),
+(210,350,o),
+(270,375,o),
+(368,372,c),
+(397,506,l),
+(218,514,o),
+(52,446,o),
+(52,273,cs),
+(52,173,o),
+(123,102,o),
+(243,102,cs),
+(403,102,o),
+(537,250,o),
+(631,250,cs),
+(668,250,o),
+(689,232,o),
+(689,204,cs),
+(689,142,o),
+(626,117,o),
+(529,120,c),
+(500,-14,l)
+);
+}
+);
+width = 898;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1515;
+unicode = 5397;
+},
+{
+glyphname = "shaa-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (317,-179);
+ref = dot_top;
+}
+);
+width = 898;
+}
+);
+note = uni1516;
+unicode = 5398;
+},
+{
+glyphname = "shwe-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "she-canadian";
+}
+);
+width = 1113;
+}
+);
+note = uni1517;
+unicode = 5399;
+},
+{
+glyphname = "shweWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "she-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (876,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1113;
+}
+);
+note = uni1518;
+unicode = 5400;
+},
+{
+glyphname = "shwi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "shi-canadian";
+}
+);
+width = 1113;
+}
+);
+note = uni1519;
+unicode = 5401;
+},
+{
+glyphname = "shwiWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (876,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1113;
+}
+);
+note = uni151A;
+unicode = 5402;
+},
+{
+glyphname = "shwii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (734,0);
+ref = dot_top;
+}
+);
+width = 1113;
+}
+);
+note = uni151B;
+unicode = 5403;
+},
+{
+glyphname = "shwiiWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (497,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (876,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1113;
+}
+);
+note = uni151C;
+unicode = 5404;
+},
+{
+glyphname = "shwo-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "sho-canadian";
+}
+);
+width = 1135;
+}
+);
+note = uni151D;
+unicode = 5405;
+},
+{
+glyphname = "shwoWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (898,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1135;
+}
+);
+note = uni151E;
+unicode = 5406;
+},
+{
+glyphname = "shwoo-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (553,-179);
+ref = dot_top;
+}
+);
+width = 1135;
+}
+);
+note = uni151F;
+unicode = 5407;
+},
+{
+glyphname = "shwooWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (316,-179);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (898,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1135;
+}
+);
+note = uni1520;
+unicode = 5408;
+},
+{
+glyphname = "shwa-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "sha-canadian";
+}
+);
+width = 1135;
+}
+);
+note = uni1521;
+unicode = 5409;
+},
+{
+glyphname = "shwaWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (898,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1135;
+}
+);
+note = uni1522;
+unicode = 5410;
+},
+{
+glyphname = "shwaa-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (553,-179);
+ref = dot_top;
+}
+);
+width = 1135;
+}
+);
+note = uni1523;
+unicode = 5411;
+},
+{
+glyphname = "shwaaWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (317,-179);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (898,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1135;
+}
+);
+note = uni1524;
+unicode = 5412;
+},
+{
+glyphname = "sh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(577,276,o),
+(700,333,o),
+(700,466,cs),
+(700,541,o),
+(645,596,o),
+(554,596,cs),
+(440,596,o),
+(335,492,o),
+(264,492,cs),
+(235,492,o),
+(218,506,o),
+(218,529,cs),
+(218,575,o),
+(268,606,o),
+(352,602,c),
+(372,699,l),
+(233,707,o),
+(107,651,o),
+(107,518,cs),
+(107,442,o),
+(161,387,o),
+(253,387,cs),
+(366,387,o),
+(472,492,o),
+(543,492,cs),
+(572,492,o),
+(589,477,o),
+(589,454,cs),
+(589,409,o),
+(541,378,o),
+(457,382,c),
+(437,284,l)
+);
+}
+);
+width = 703;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni1525;
+unicode = 5413;
+},
+{
+glyphname = "ye-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (681,345);
+},
+{
+name = top_left_can;
+pos = (203,690);
+},
+{
+name = top_right_can;
+pos = (533,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(466,0,l),
+(540,353,l),
+(257,353,l),
+(257,276,l),
+(609,600,l),
+(511,701,l),
+(31,253,l),
+(22,213,l),
+(351,213,l),
+(305,0,l)
+);
+}
+);
+width = 580;
+}
+);
+note = uni1526;
+unicode = 5414;
+},
+{
+glyphname = "yaai-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (13,0);
+ref = ring_top.canadian;
+}
+);
+width = 580;
+}
+);
+note = uni1527;
+unicode = 5415;
+},
+{
+glyphname = "yi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (238,690);
+},
+{
+name = top_right_can;
+pos = (567,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(170,0,l),
+(215,213,l),
+(543,213,l),
+(552,253,l),
+(238,701,l),
+(123,618,l),
+(362,279,l),
+(370,353,l),
+(84,353,l),
+(10,0,l)
+);
+}
+);
+width = 580;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni1528;
+unicode = 5416;
+},
+{
+glyphname = "yii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+}
+);
+width = 580;
+}
+);
+note = uni1529;
+unicode = 5417;
+},
+{
+glyphname = "yo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (681,345);
+},
+{
+name = top_double;
+pos = (532,690);
+},
+{
+name = top_left_can;
+pos = (203,690);
+},
+{
+name = top_right_can;
+pos = (532,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(498,71,l),
+(259,411,l),
+(251,337,l),
+(537,337,l),
+(611,690,l),
+(451,690,l),
+(406,476,l),
+(78,476,l),
+(70,437,l),
+(384,-12,l)
+);
+}
+);
+width = 580;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152A;
+unicode = 5418;
+},
+{
+glyphname = "yoo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (344,0);
+ref = dot_top;
+}
+);
+width = 580;
+}
+);
+note = uni152B;
+unicode = 5419;
+},
+{
+glyphname = "ycreeyoo-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (159,0);
+ref = doubledot_top;
+}
+);
+width = 580;
+}
+);
+note = uni152C;
+unicode = 5420;
+},
+{
+glyphname = "ya-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (239,690);
+},
+{
+name = top_right_can;
+pos = (566,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(591,437,l),
+(600,476,l),
+(271,476,l),
+(318,690,l),
+(156,690,l),
+(82,337,l),
+(365,337,l),
+(365,413,l),
+(14,90,l),
+(111,-12,l)
+);
+}
+);
+width = 580;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152D;
+unicode = 5421;
+},
+{
+glyphname = "yaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+}
+);
+width = 580;
+}
+);
+note = uni152E;
+unicode = 5422;
+},
+{
+glyphname = "ywe-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ye-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni152F;
+unicode = 5423;
+},
+{
+glyphname = "yweWestCree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ye-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (580,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni1530;
+unicode = 5424;
+},
+{
+glyphname = "ywi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "yi-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni1531;
+unicode = 5425;
+},
+{
+glyphname = "ywiWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (580,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni1532;
+unicode = 5426;
+},
+{
+glyphname = "ywii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (286,0);
+ref = dot_top;
+}
+);
+width = 816;
+}
+);
+note = uni1533;
+unicode = 5427;
+},
+{
+glyphname = "ywiiWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (580,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni1534;
+unicode = 5428;
+},
+{
+glyphname = "ywo-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "yo-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni1535;
+unicode = 5429;
+},
+{
+glyphname = "ywoWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (580,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni1536;
+unicode = 5430;
+},
+{
+glyphname = "ywoo-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (580,0);
+ref = dot_top;
+}
+);
+width = 816;
+}
+);
+note = uni1537;
+unicode = 5431;
+},
+{
+glyphname = "ywooWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (344,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (580,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni1538;
+unicode = 5432;
+},
+{
+glyphname = "ywa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ya-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni1539;
+unicode = 5433;
+},
+{
+glyphname = "ywaWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (580,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni153A;
+unicode = 5434;
+},
+{
+glyphname = "ywaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (286,0);
+ref = dot_top;
+}
+);
+width = 816;
+}
+);
+note = uni153B;
+unicode = 5435;
+},
+{
+glyphname = "ywaaWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (580,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni153C;
+unicode = 5436;
+},
+{
+glyphname = "ywaaNaskapi-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ya-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni153D;
+unicode = 5437;
+},
+{
+glyphname = "y-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(383,555,l),
+(388,582,l),
+(236,582,l),
+(259,690,l),
+(150,690,l),
+(108,497,l),
+(253,497,l),
+(254,560,l),
+(87,400,l),
+(155,334,l)
+);
+}
+);
+width = 339;
+}
+);
+note = uni153E;
+unicode = 5438;
+},
+{
+glyphname = "biblecreey-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(168,345,l),
+(272,582,l),
+(213,582,l),
+(253,345,l),
+(323,345,l),
+(467,582,l),
+(400,582,l),
+(409,345,l),
+(504,345,l),
+(510,370,l),
+(499,690,l),
+(426,690,l),
+(273,435,l),
+(332,435,l),
+(291,690,l),
+(217,690,l),
+(71,370,l),
+(65,345,l)
+);
+}
+);
+width = 528;
+}
+);
+metricRight = "=|";
+note = uni153F;
+unicode = 5439;
+},
+{
+glyphname = "yWestCree-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(257,192,l),
+(281,304,l),
+(390,304,l),
+(412,408,l),
+(303,408,l),
+(326,518,l),
+(220,518,l),
+(197,408,l),
+(87,408,l),
+(66,304,l),
+(175,304,l),
+(151,192,l)
+);
+}
+);
+width = 431;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1540;
+unicode = 5440;
+},
+{
+glyphname = "yiSayisi-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (39,183);
+ref = "fullstop-canadian";
+}
+);
+width = 378;
+}
+);
+metricLeft = "fullstop-canadian";
+metricWidth = "fullstop-canadian";
+note = uni1541;
+unicode = 5441;
+},
+{
+glyphname = "re-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (363,511);
+},
+{
+name = top_left_can;
+pos = (193,511);
+},
+{
+name = top_right_can;
+pos = (781,511);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(424,-14,o),
+(518,66,o),
+(551,219,cs),
+(579,350,l),
+(829,350,l),
+(859,492,l),
+(452,492,l),
+(395,224,ls),
+(381,156,o),
+(346,124,o),
+(294,124,cs),
+(229,124,o),
+(202,162,o),
+(217,236,cs),
+(271,492,l),
+(111,492,l),
+(60,250,ls),
+(26,94,o),
+(117,-14,o),
+(283,-14,cs)
+);
+}
+);
+width = 848;
+}
+);
+metricRight = "=|ne-canadian";
+note = uni1542;
+unicode = 5442;
+},
+{
+glyphname = "reRCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (593,511);
+},
+{
+name = top_left_can;
+pos = (176,511);
+},
+{
+name = top_right_can;
+pos = (764,511);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(656,-14,o),
+(750,66,o),
+(782,219,cs),
+(840,492,l),
+(680,492,l),
+(623,224,ls),
+(609,156,o),
+(574,124,o),
+(522,124,cs),
+(456,124,o),
+(429,163,o),
+(444,236,cs),
+(499,492,l),
+(93,492,l),
+(63,350,l),
+(313,350,l),
+(292,250,ls),
+(258,94,o),
+(349,-14,o),
+(515,-14,cs)
+);
+}
+);
+width = 847;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1543;
+unicode = 5443;
+},
+{
+glyphname = "leWestCree-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (596,511);
+},
+{
+name = top_left_can;
+pos = (178,511);
+},
+{
+name = top_right_can;
+pos = (766,511);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(396,0,l),
+(453,269,ls),
+(468,335,o),
+(502,368,o),
+(555,368,cs),
+(620,368,o),
+(647,329,o),
+(632,256,cs),
+(577,0,l),
+(737,0,l),
+(788,242,ls),
+(822,398,o),
+(731,506,o),
+(566,506,cs),
+(424,506,o),
+(330,426,o),
+(298,272,cs),
+(271,142,l),
+(19,142,l),
+(-11,0,l)
+);
+}
+);
+width = 848;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+unicode = 5444;
+},
+{
+glyphname = "raai-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (139,-179);
+ref = ring_top.canadian;
+}
+);
+width = 846;
+}
+);
+note = uni1545;
+unicode = 5445;
+},
+{
+glyphname = "ri-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (366,511);
+},
+{
+name = top_left_can;
+pos = (196,511);
+},
+{
+name = top_right_can;
+pos = (784,511);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(168,0,l),
+(225,269,ls),
+(239,335,o),
+(274,368,o),
+(327,368,cs),
+(391,368,o),
+(418,329,o),
+(403,256,cs),
+(348,0,l),
+(754,0,l),
+(784,142,l),
+(535,142,l),
+(556,242,ls),
+(589,398,o),
+(498,506,o),
+(337,506,cs),
+(191,506,o),
+(99,426,o),
+(66,272,cs),
+(7,0,l)
+);
+}
+);
+width = 847;
+}
+);
+metricLeft = "re-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+unicode = 5446;
+},
+{
+glyphname = "rii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (177,-179);
+ref = dot_top;
+}
+);
+width = 846;
+}
+);
+note = uni1547;
+unicode = 5447;
+},
+{
+glyphname = "ro-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (341,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(171,0,l),
+(231,284,l),
+(148,213,l),
+(261,213,ls),
+(458,213,o),
+(559,326,o),
+(559,483,cs),
+(559,608,o),
+(471,690,o),
+(329,690,cs),
+(156,690,l),
+(127,548,l),
+(306,548,ls),
+(368,548,o),
+(401,518,o),
+(401,469,cs),
+(401,395,o),
+(354,355,o),
+(270,355,cs),
+(86,355,l),
+(10,0,l)
+);
+}
+);
+width = 557;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1548;
+unicode = 5448;
+},
+{
+glyphname = "roo-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (153,0);
+ref = dot_top;
+}
+);
+width = 557;
+}
+);
+note = uni1549;
+unicode = 5449;
+},
+{
+glyphname = "loWestCree-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (344,690);
+},
+{
+name = top_left_can;
+pos = (238,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(215,0,ls),
+(412,0,o),
+(514,111,o),
+(514,270,cs),
+(514,393,o),
+(426,476,o),
+(285,476,cs),
+(201,476,l),
+(257,405,l),
+(317,690,l),
+(156,690,l),
+(82,336,l),
+(262,336,ls),
+(324,336,o),
+(356,306,o),
+(356,257,cs),
+(356,184,o),
+(308,142,o),
+(225,142,cs),
+(41,142,l),
+(11,0,l)
+);
+}
+);
+width = 558;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+unicode = 5450;
+},
+{
+glyphname = "ra-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (405,690);
+},
+{
+name = top_right_can;
+pos = (509,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(442,0,l),
+(517,354,l),
+(338,354,ls),
+(276,354,o),
+(243,384,o),
+(243,433,cs),
+(243,506,o),
+(291,548,o),
+(375,548,cs),
+(558,548,l),
+(588,690,l),
+(385,690,ls),
+(187,690,o),
+(86,579,o),
+(86,420,cs),
+(86,297,o),
+(173,213,o),
+(315,213,cs),
+(398,213,l),
+(342,285,l),
+(282,0,l)
+);
+}
+);
+width = 556;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+unicode = 5451;
+},
+{
+glyphname = "raa-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (216,0);
+ref = dot_top;
+}
+);
+width = 557;
+}
+);
+note = uni154C;
+unicode = 5452;
+},
+{
+glyphname = "laWestCree-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (509,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(442,0,l),
+(472,142,l),
+(293,142,ls),
+(231,142,o),
+(197,172,o),
+(197,220,cs),
+(197,295,o),
+(245,335,o),
+(328,335,cs),
+(513,335,l),
+(588,690,l),
+(428,690,l),
+(368,406,l),
+(451,476,l),
+(338,476,ls),
+(141,476,o),
+(40,364,o),
+(40,207,cs),
+(40,82,o),
+(128,0,o),
+(270,0,cs)
+);
+}
+);
+width = 556;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+unicode = 5453;
+},
+{
+glyphname = "rwaa-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (452,0);
+ref = dot_top;
+}
+);
+width = 794;
+}
+);
+note = uni154E;
+unicode = 5454;
+},
+{
+glyphname = "rwaaWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (216,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (557,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni154F;
+unicode = 5455;
+},
+{
+glyphname = "r-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(302,345,l),
+(342,531,l),
+(251,531,ls),
+(226,531,o),
+(214,544,o),
+(214,562,cs),
+(214,591,o),
+(234,605,o),
+(267,605,cs),
+(357,605,l),
+(375,690,l),
+(285,690,ls),
+(185,690,o),
+(113,648,o),
+(113,554,cs),
+(113,492,o),
+(157,448,o),
+(232,448,cs),
+(271,448,l),
+(222,482,l),
+(193,345,l)
+);
+}
+);
+width = 334;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni1550;
+unicode = 5456;
+},
+{
+glyphname = "rWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(148,690,l),
+(134,625,l),
+(272,560,l),
+(283,612,l),
+(117,545,l),
+(108,501,l),
+(245,436,l),
+(258,489,l),
+(91,422,l),
+(74,345,l),
+(93,345,l),
+(334,438,l),
+(341,470,l),
+(196,537,l),
+(187,498,l),
+(361,564,l),
+(368,597,l),
+(166,690,l)
+);
+}
+);
+width = 346;
+}
+);
+metricLeft = "=|lWestCree-canadian";
+metricRight = "=|lWestCree-canadian";
+note = uni1551;
+unicode = 5457;
+},
+{
+glyphname = "rMedial-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(39,-14,l),
+(542,179,l),
+(553,234,l),
+(246,375,l),
+(235,317,l),
+(601,456,l),
+(612,511,l),
+(191,704,l),
+(153,704,l),
+(130,596,l),
+(435,456,l),
+(451,533,l),
+(85,385,l),
+(72,324,l),
+(378,185,l),
+(393,256,l),
+(28,116,l),
+(1,-14,l)
+);
+}
+);
+width = 611;
+}
+);
+metricLeft = "mediall-canadian";
+metricRight = "mediall-canadian";
+note = uni1552;
+unicode = 5458;
+},
+{
+glyphname = "fe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(348,0,l),
+(843,651,l),
+(851,690,l),
+(706,690,l),
+(336,185,l),
+(361,185,l),
+(298,349,l),
+(192,357,l),
+(216,327,o),
+(246,312,o),
+(291,312,cs),
+(414,312,o),
+(495,432,o),
+(495,544,cs),
+(495,638,o),
+(436,704,o),
+(329,704,cs),
+(195,704,o),
+(122,582,o),
+(122,467,cs),
+(122,425,o),
+(131,386,o),
+(151,343,cs),
+(300,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(267,418,o),
+(249,440,o),
+(249,475,cs),
+(249,512,o),
+(270,588,o),
+(322,588,cs),
+(351,588,o),
+(368,568,o),
+(368,533,cs),
+(368,495,o),
+(349,418,o),
+(296,418,cs)
+);
+}
+);
+width = 782;
+}
+);
+metricRight = "e-canadian";
+note = uni1553;
+unicode = 5459;
+},
+{
+glyphname = "faai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (238,0);
+ref = ring_top.canadian;
+}
+);
+width = 781;
+}
+);
+note = uni1554;
+unicode = 5460;
+},
+{
+glyphname = "fi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (465,690);
+},
+{
+name = top_left_can;
+pos = (236,690);
+},
+{
+name = top_right_can;
+pos = (713,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(362,-14,o),
+(425,112,o),
+(425,214,cs),
+(425,311,o),
+(365,384,o),
+(282,384,cs),
+(248,384,o),
+(217,370,o),
+(188,344,c),
+(311,343,l),
+(447,505,l),
+(408,506,l),
+(582,0,l),
+(705,0,l),
+(713,39,l),
+(488,690,l),
+(441,690,l),
+(143,355,ls),
+(88,291,o),
+(54,223,o),
+(54,150,cs),
+(54,54,o),
+(119,-14,o),
+(219,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(198,101,o),
+(181,122,o),
+(181,157,cs),
+(181,195,o),
+(201,271,o),
+(253,271,cs),
+(282,271,o),
+(299,250,o),
+(299,215,cs),
+(299,177,o),
+(279,101,o),
+(227,101,cs)
+);
+}
+);
+width = 782;
+}
+);
+metricLeft = "fe-canadian";
+metricRight = "e-canadian";
+note = uni1555;
+unicode = 5461;
+},
+{
+glyphname = "fii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (274,0);
+ref = dot_top;
+}
+);
+width = 781;
+}
+);
+note = uni1556;
+unicode = 5462;
+},
+{
+glyphname = "fo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (322,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(63,0,l),
+(664,321,l),
+(673,368,l),
+(441,632,ls),
+(398,681,o),
+(357,704,o),
+(299,704,cs),
+(177,704,o),
+(102,595,o),
+(97,485,cs),
+(89,379,o),
+(151,305,o),
+(249,305,cs),
+(368,305,o),
+(444,399,o),
+(450,514,cs),
+(452,537,o),
+(451,560,o),
+(448,580,c),
+(384,505,l),
+(514,357,l),
+(524,386,l),
+(55,141,l),
+(25,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(237,418,o),
+(220,444,o),
+(224,490,cs),
+(227,533,o),
+(246,589,o),
+(294,589,cs),
+(326,589,o),
+(342,563,o),
+(338,518,cs),
+(335,474,o),
+(317,418,o),
+(269,418,cs)
+);
+}
+);
+width = 675;
+}
+);
+metricRight = "o-canadian";
+note = uni1557;
+unicode = 5463;
+},
+{
+glyphname = "foo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "fo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (133,0);
+ref = dot_top;
+}
+);
+width = 675;
+}
+);
+note = uni1558;
+unicode = 5464;
+},
+{
+glyphname = "fa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (540,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(544,0,l),
+(569,121,l),
+(213,365,l),
+(208,336,l),
+(396,489,l),
+(375,609,l),
+(349,570,o),
+(327,509,o),
+(327,462,cs),
+(327,370,o),
+(393,301,o),
+(496,301,cs),
+(616,301,o),
+(690,429,o),
+(690,535,cs),
+(690,635,o),
+(626,704,o),
+(526,704,cs),
+(476,704,o),
+(433,686,o),
+(387,647,cs),
+(54,368,l),
+(44,321,l),
+(505,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(463,417,o),
+(445,439,o),
+(445,473,cs),
+(445,511,o),
+(466,588,o),
+(518,588,cs),
+(547,588,o),
+(564,567,o),
+(564,532,cs),
+(564,494,o),
+(545,417,o),
+(493,417,cs)
+);
+}
+);
+width = 677;
+}
+);
+metricRight = "=|fo-canadian";
+note = uni1559;
+unicode = 5465;
+},
+{
+glyphname = "faa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (352,0);
+ref = dot_top;
+}
+);
+width = 675;
+}
+);
+note = uni155A;
+unicode = 5466;
+},
+{
+glyphname = "fwaa-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (588,0);
+ref = dot_top;
+}
+);
+width = 912;
+}
+);
+note = uni155B;
+unicode = 5467;
+},
+{
+glyphname = "fwaaWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (352,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (675,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 912;
+}
+);
+note = uni155C;
+unicode = 5468;
+},
+{
+glyphname = "f-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(352,345,l),
+(366,414,l),
+(187,534,l),
+(184,510,l),
+(277,592,l),
+(269,651,l),
+(256,635,o),
+(243,602,o),
+(243,576,cs),
+(243,530,o),
+(276,495,o),
+(323,495,cs),
+(384,495,o),
+(421,551,o),
+(421,612,cs),
+(421,665,o),
+(390,696,o),
+(344,696,cs),
+(318,696,o),
+(293,687,o),
+(267,665,cs),
+(104,527,l),
+(99,503,l),
+(332,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(311,553,o),
+(302,563,o),
+(302,580,cs),
+(302,606,o),
+(317,638,o),
+(338,638,cs),
+(352,638,o),
+(360,627,o),
+(360,609,cs),
+(360,587,o),
+(348,553,o),
+(325,553,cs)
+);
+}
+);
+width = 394;
+}
+);
+note = uni155D;
+unicode = 5469;
+},
+{
+glyphname = "the-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (846,345);
+},
+{
+name = top_center_can;
+pos = (463,690);
+},
+{
+name = top_left_can;
+pos = (229,690);
+},
+{
+name = top_right_can;
+pos = (694,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(537,-14,o),
+(643,80,o),
+(687,285,cs),
+(773,690,l),
+(612,690,l),
+(526,286,ls),
+(503,178,o),
+(450,128,o),
+(349,128,cs),
+(229,128,o),
+(204,198,o),
+(228,303,cs),
+(250,400,l),
+(178,354,l),
+(195,316,o),
+(230,292,o),
+(277,292,cs),
+(403,292,o),
+(472,404,o),
+(480,523,cs),
+(488,633,o),
+(428,704,o),
+(320,704,cs),
+(207,704,o),
+(137,629,o),
+(108,494,cs),
+(75,336,ls),
+(33,134,o),
+(113,-14,o),
+(345,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(252,408,o),
+(236,429,o),
+(236,466,cs),
+(236,504,o),
+(256,588,o),
+(309,588,cs),
+(337,588,o),
+(354,567,o),
+(354,531,cs),
+(354,492,o),
+(334,408,o),
+(281,408,cs)
+);
+}
+);
+width = 734;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155E;
+unicode = 5470;
+},
+{
+glyphname = "theNCree-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(538,-14,o),
+(644,85,o),
+(690,300,cs),
+(724,455,ls),
+(753,594,o),
+(703,704,o),
+(571,704,cs),
+(435,704,o),
+(362,578,o),
+(362,456,cs),
+(362,362,o),
+(413,292,o),
+(506,292,cs),
+(545,292,o),
+(579,306,o),
+(604,334,c),
+(551,391,l),
+(527,282,ls),
+(504,174,o),
+(451,127,o),
+(356,127,cs),
+(235,127,o),
+(207,202,o),
+(230,309,cs),
+(310,690,l),
+(150,690,l),
+(71,319,ls),
+(27,114,o),
+(132,-14,o),
+(344,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(506,408,o),
+(491,429,o),
+(491,466,cs),
+(491,504,o),
+(510,588,o),
+(563,588,cs),
+(592,588,o),
+(608,567,o),
+(608,531,cs),
+(608,492,o),
+(588,408,o),
+(535,408,cs)
+);
+}
+);
+width = 735;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155F;
+unicode = 5471;
+},
+{
+glyphname = "thi-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (458,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(341,-14,o),
+(414,112,o),
+(414,234,cs),
+(414,327,o),
+(362,398,o),
+(270,398,cs),
+(232,398,o),
+(198,384,o),
+(172,355,c),
+(225,298,l),
+(249,408,ls),
+(271,516,o),
+(326,563,o),
+(420,563,cs),
+(542,563,o),
+(569,488,o),
+(546,381,cs),
+(466,0,l),
+(626,0,l),
+(705,371,ls),
+(749,576,o),
+(644,704,o),
+(433,704,cs),
+(239,704,o),
+(132,605,o),
+(87,389,cs),
+(53,235,ls),
+(23,96,o),
+(73,-14,o),
+(206,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(185,101,o),
+(169,123,o),
+(169,158,cs),
+(169,198,o),
+(188,282,o),
+(242,282,cs),
+(270,282,o),
+(286,261,o),
+(286,224,cs),
+(286,185,o),
+(267,101,o),
+(213,101,cs)
+);
+}
+);
+width = 733;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1560;
+unicode = 5472;
+},
+{
+glyphname = "thiNCree-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (458,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(570,-14,o),
+(639,61,o),
+(668,196,cs),
+(701,354,ls),
+(745,555,o),
+(664,704,o),
+(432,704,cs),
+(240,704,o),
+(132,610,o),
+(89,405,cs),
+(3,0,l),
+(163,0,l),
+(249,404,ls),
+(273,512,o),
+(326,562,o),
+(427,562,cs),
+(548,562,o),
+(573,492,o),
+(549,386,cs),
+(526,290,l),
+(598,336,l),
+(581,374,o),
+(547,398,o),
+(499,398,cs),
+(374,398,o),
+(304,286,o),
+(297,167,cs),
+(289,57,o),
+(349,-14,o),
+(457,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(439,101,o),
+(423,123,o),
+(423,158,cs),
+(423,198,o),
+(442,282,o),
+(496,282,cs),
+(525,282,o),
+(541,261,o),
+(541,224,cs),
+(541,185,o),
+(521,101,o),
+(468,101,cs)
+);
+}
+);
+width = 734;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1561;
+unicode = 5473;
+},
+{
+glyphname = "thii-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "thi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (270,0);
+ref = dot_top;
+}
+);
+width = 734;
+}
+);
+note = uni1562;
+unicode = 5474;
+},
+{
+glyphname = "thiiNCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "thiNCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (270,0);
+ref = dot_top;
+}
+);
+width = 734;
+}
+);
+note = uni1563;
+unicode = 5475;
+},
+{
+glyphname = "tho-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (397,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(244,0,ls),
+(521,0,o),
+(652,196,o),
+(652,412,cs),
+(652,590,o),
+(535,704,o),
+(371,704,cs),
+(204,704,o),
+(96,587,o),
+(96,438,cs),
+(96,337,o),
+(159,270,o),
+(259,270,cs),
+(385,270,o),
+(455,386,o),
+(455,494,cs),
+(455,567,o),
+(416,622,o),
+(341,634,c),
+(315,588,l),
+(327,592,o),
+(343,596,o),
+(360,596,cs),
+(431,595,o),
+(497,531,o),
+(497,417,cs),
+(497,303,o),
+(451,144,o),
+(258,144,cs),
+(61,144,l),
+(31,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(239,384,o),
+(223,405,o),
+(223,440,cs),
+(223,479,o),
+(242,572,o),
+(299,572,cs),
+(328,572,o),
+(343,552,o),
+(343,517,cs),
+(343,480,o),
+(324,384,o),
+(267,384,cs)
+);
+}
+);
+width = 677;
+}
+);
+metricRight = "to-canadian";
+note = uni1564;
+unicode = 5476;
+},
+{
+glyphname = "thoo-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "tho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (209,0);
+ref = dot_top;
+}
+);
+width = 678;
+}
+);
+note = uni1565;
+unicode = 5477;
+},
+{
+glyphname = "tha-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (471,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(540,0,l),
+(570,144,l),
+(382,144,ls),
+(280,144,o),
+(224,199,o),
+(224,298,cs),
+(224,398,o),
+(285,589,o),
+(440,589,cs),
+(464,589,o),
+(488,584,o),
+(506,577,c),
+(487,630,l),
+(373,629,o),
+(311,521,o),
+(311,423,cs),
+(311,332,o),
+(370,270,o),
+(468,270,cs),
+(596,270,o),
+(676,378,o),
+(676,501,cs),
+(676,624,o),
+(584,704,o),
+(442,704,cs),
+(183,704,o),
+(65,459,o),
+(65,274,cs),
+(65,107,o),
+(170,0,o),
+(351,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(446,384,o),
+(431,405,o),
+(431,440,cs),
+(431,479,o),
+(450,572,o),
+(507,572,cs),
+(536,572,o),
+(551,552,o),
+(551,517,cs),
+(551,480,o),
+(531,384,o),
+(474,384,cs)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tho-canadian";
+note = uni1566;
+unicode = 5478;
+},
+{
+glyphname = "thaa-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (285,0);
+ref = dot_top;
+}
+);
+width = 678;
+}
+);
+note = uni1567;
+unicode = 5479;
+},
+{
+glyphname = "thwaa-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (521,0);
+ref = dot_top;
+}
+);
+width = 915;
+}
+);
+note = uni1568;
+unicode = 5480;
+},
+{
+glyphname = "thwaaWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (285,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (678,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 915;
+}
+);
+note = uni1569;
+unicode = 5481;
+},
+{
+glyphname = "th-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(338,345,l),
+(356,432,l),
+(272,432,ls),
+(222,432,o),
+(196,454,o),
+(196,497,cs),
+(196,552,o),
+(230,632,o),
+(305,632,cs),
+(313,632,o),
+(330,629,o),
+(335,628,c),
+(316,654,l),
+(251,654,o),
+(230,596,o),
+(230,560,cs),
+(230,510,o),
+(260,478,o),
+(307,478,cs),
+(375,478,o),
+(407,547,o),
+(407,599,cs),
+(407,657,o),
+(365,696,o),
+(295,696,cs),
+(167,696,o),
+(101,579,o),
+(101,485,cs),
+(101,400,o),
+(159,345,o),
+(253,345,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(295,535,o),
+(287,545,o),
+(287,562,cs),
+(287,586,o),
+(299,620,o),
+(322,620,cs),
+(336,620,o),
+(344,611,o),
+(344,593,cs),
+(344,569,o),
+(332,535,o),
+(309,535,cs)
+);
+}
+);
+width = 383;
+}
+);
+metricLeft = "t-canadian";
+note = uni156A;
+unicode = 5482;
+},
+{
+glyphname = "tthe-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (837,345);
+},
+{
+name = top_center_can;
+pos = (457,690);
+},
+{
+name = top_left_can;
+pos = (231,690);
+},
+{
+name = top_right_can;
+pos = (684,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(528,-14,o),
+(635,81,o),
+(678,286,cs),
+(764,690,l),
+(608,690,l),
+(522,289,ls),
+(498,180,o),
+(444,130,o),
+(353,130,cs),
+(242,130,o),
+(200,191,o),
+(225,307,cs),
+(306,690,l),
+(150,690,l),
+(71,319,ls),
+(27,111,o),
+(134,-14,o),
+(339,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(455,380,l),
+(522,690,l),
+(392,690,l),
+(327,380,l)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156B;
+unicode = 5483;
+},
+{
+glyphname = "tthi-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(159,0,l),
+(245,401,ls),
+(269,510,o),
+(323,559,o),
+(414,559,cs),
+(525,559,o),
+(567,498,o),
+(542,383,cs),
+(461,0,l),
+(617,0,l),
+(696,371,ls),
+(740,579,o),
+(633,704,o),
+(428,704,cs),
+(239,704,o),
+(132,609,o),
+(89,404,cs),
+(3,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(375,0,l),
+(440,310,l),
+(312,310,l),
+(245,0,l)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156C;
+unicode = 5484;
+},
+{
+glyphname = "ttho-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (384,690);
+},
+{
+name = top_left_can;
+pos = (217,690);
+},
+{
+name = top_right_can;
+pos = (598,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(184,0,ls),
+(515,0,o),
+(601,242,o),
+(601,412,cs),
+(601,584,o),
+(490,690,o),
+(297,690,cs),
+(151,690,l),
+(121,546,l),
+(272,546,ls),
+(384,546,o),
+(440,493,o),
+(440,396,cs),
+(440,283,o),
+(384,144,o),
+(198,144,cs),
+(35,144,l),
+(5,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(302,280,l),
+(330,412,l),
+(92,412,l),
+(64,280,l)
+);
+}
+);
+width = 626;
+}
+);
+metricRight = "to-canadian";
+note = uni156D;
+unicode = 5485;
+},
+{
+glyphname = "ttha-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (403,690);
+},
+{
+name = top_left_can;
+pos = (221,690);
+},
+{
+name = top_right_can;
+pos = (581,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(516,0,l),
+(546,144,l),
+(394,144,ls),
+(283,144,o),
+(227,197,o),
+(227,294,cs),
+(227,412,o),
+(289,546,o),
+(468,546,cs),
+(632,546,l),
+(663,690,l),
+(483,690,ls),
+(156,690,o),
+(67,452,o),
+(67,278,cs),
+(67,105,o),
+(177,0,o),
+(370,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(575,280,l),
+(602,412,l),
+(363,412,l),
+(335,280,l)
+);
+}
+);
+width = 626;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|ttho-canadian";
+note = uni156E;
+unicode = 5486;
+},
+{
+glyphname = "tth-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(281,459,l),
+(238,460,l),
+(301,332,l),
+(385,375,l),
+(318,509,l),
+(293,468,l),
+(452,522,l),
+(425,606,l),
+(281,556,l),
+(313,531,l),
+(347,690,l),
+(254,690,l),
+(220,531,l),
+(260,554,l),
+(123,606,l),
+(91,522,l),
+(216,474,l),
+(212,518,l),
+(97,394,l),
+(163,332,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(698,459,l),
+(654,460,l),
+(719,332,l),
+(803,375,l),
+(734,509,l),
+(710,468,l),
+(869,522,l),
+(841,606,l),
+(697,556,l),
+(729,531,l),
+(763,690,l),
+(670,690,l),
+(637,531,l),
+(676,554,l),
+(540,606,l),
+(507,522,l),
+(633,474,l),
+(628,518,l),
+(514,394,l),
+(580,332,l)
+);
+}
+);
+width = 842;
+}
+);
+metricRight = "=|";
+note = uni156F;
+unicode = 5487;
+},
+{
+glyphname = "tye-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(530,-14,o),
+(635,82,o),
+(679,290,cs),
+(764,690,l),
+(609,690,l),
+(527,305,ls),
+(501,185,o),
+(446,130,o),
+(349,130,cs),
+(242,130,o),
+(199,191,o),
+(224,307,cs),
+(305,690,l),
+(150,690,l),
+(71,319,ls),
+(27,113,o),
+(133,-14,o),
+(343,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(471,410,o),
+(511,445,o),
+(526,514,cs),
+(563,690,l),
+(490,690,l),
+(455,526,ls),
+(449,498,o),
+(437,486,o),
+(414,486,cs),
+(391,486,o),
+(384,499,o),
+(389,527,cs),
+(423,690,l),
+(350,690,l),
+(315,526,ls),
+(300,456,o),
+(338,410,o),
+(410,410,cs)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1570;
+unicode = 5488;
+},
+{
+glyphname = "tyi-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(158,0,l),
+(240,384,ls),
+(266,505,o),
+(321,559,o),
+(418,559,cs),
+(525,559,o),
+(568,498,o),
+(543,383,cs),
+(462,0,l),
+(617,0,l),
+(696,371,ls),
+(740,577,o),
+(634,704,o),
+(424,704,cs),
+(237,704,o),
+(132,608,o),
+(88,400,cs),
+(3,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(277,0,l),
+(312,164,ls),
+(318,191,o),
+(330,204,o),
+(353,204,cs),
+(376,204,o),
+(384,190,o),
+(378,162,cs),
+(344,0,l),
+(417,0,l),
+(452,163,ls),
+(467,234,o),
+(429,280,o),
+(357,280,cs),
+(296,280,o),
+(256,244,o),
+(242,176,cs),
+(204,0,l)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1571;
+unicode = 5489;
+},
+{
+glyphname = "tyo-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(189,0,ls),
+(520,0,o),
+(607,242,o),
+(607,412,cs),
+(607,584,o),
+(496,690,o),
+(301,690,cs),
+(156,690,l),
+(127,549,l),
+(279,549,ls),
+(388,549,o),
+(445,493,o),
+(445,396,cs),
+(445,261,o),
+(368,141,o),
+(203,141,cs),
+(41,141,l),
+(11,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(150,218,ls),
+(251,218,o),
+(307,272,o),
+(311,355,cs),
+(316,426,o),
+(272,471,o),
+(196,471,cs),
+(110,471,l),
+(94,393,l),
+(178,393,ls),
+(210,393,o),
+(226,379,o),
+(224,352,cs),
+(222,318,o),
+(201,297,o),
+(157,297,cs),
+(73,297,l),
+(57,218,l)
+);
+}
+);
+width = 632;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1572;
+unicode = 5490;
+},
+{
+glyphname = "tya-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(516,0,l),
+(546,141,l),
+(394,141,ls),
+(284,141,o),
+(227,197,o),
+(227,294,cs),
+(227,429,o),
+(304,549,o),
+(470,549,cs),
+(632,549,l),
+(662,690,l),
+(484,690,ls),
+(153,690,o),
+(67,447,o),
+(67,278,cs),
+(67,105,o),
+(178,0,o),
+(371,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(562,218,l),
+(579,297,l),
+(495,297,ls),
+(464,297,o),
+(447,311,o),
+(449,338,cs),
+(450,372,o),
+(472,393,o),
+(516,393,cs),
+(599,393,l),
+(615,471,l),
+(523,471,ls),
+(422,471,o),
+(366,417,o),
+(361,334,cs),
+(356,264,o),
+(400,218,o),
+(477,218,cs)
+);
+}
+);
+width = 630;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1573;
+unicode = 5491;
+},
+{
+glyphname = "heNunavik-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(468,0,l),
+(753,199,l),
+(671,316,l),
+(460,169,l),
+(511,128,l),
+(570,400,ls),
+(602,551,o),
+(550,704,o),
+(361,704,cs),
+(180,704,o),
+(80,550,o),
+(80,392,cs),
+(80,268,o),
+(156,184,o),
+(273,184,cs),
+(330,184,o),
+(379,206,o),
+(400,245,c),
+(378,249,l),
+(325,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(266,319,o),
+(237,351,o),
+(237,405,cs),
+(237,457,o),
+(263,569,o),
+(346,569,cs),
+(395,569,o),
+(424,536,o),
+(424,482,cs),
+(424,430,o),
+(398,319,o),
+(314,319,cs)
+);
+}
+);
+width = 781;
+}
+);
+metricLeft = "ke-canadian";
+note = uni1574;
+unicode = 5492;
+},
+{
+glyphname = "hiNunavik-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (586,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(351,0,l),
+(411,279,l),
+(391,257,l),
+(394,217,o),
+(454,184,o),
+(525,184,cs),
+(700,184,o),
+(782,353,o),
+(782,486,cs),
+(782,620,o),
+(697,704,o),
+(562,704,cs),
+(420,704,o),
+(322,617,o),
+(289,464,cs),
+(217,126,l),
+(275,140,l),
+(109,302,l),
+(8,199,l),
+(209,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(468,319,o),
+(440,351,o),
+(440,405,cs),
+(440,457,o),
+(468,569,o),
+(551,569,cs),
+(599,569,o),
+(628,536,o),
+(628,482,cs),
+(628,431,o),
+(602,319,o),
+(518,319,cs)
+);
+}
+);
+width = 780;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1575;
+unicode = 5493;
+},
+{
+glyphname = "hiiNunavik-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "hiNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (398,0);
+ref = dot_top;
+}
+);
+width = 781;
+}
+);
+note = uni1576;
+unicode = 5494;
+},
+{
+glyphname = "hoNunavik-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (383,690);
+},
+{
+name = top_right_can;
+pos = (553,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(402,-14,o),
+(501,72,o),
+(534,226,cs),
+(606,564,l),
+(547,550,l),
+(713,387,l),
+(815,491,l),
+(613,690,l),
+(471,690,l),
+(412,411,l),
+(432,433,l),
+(428,472,o),
+(369,506,o),
+(297,506,cs),
+(123,506,o),
+(40,337,o),
+(40,204,cs),
+(40,70,o),
+(125,-14,o),
+(261,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(224,121,o),
+(194,154,o),
+(194,208,cs),
+(194,259,o),
+(221,371,o),
+(304,371,cs),
+(354,371,o),
+(383,339,o),
+(383,285,cs),
+(383,233,o),
+(355,121,o),
+(272,121,cs)
+);
+}
+);
+width = 781;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "heNunavik-canadian";
+note = uni1577;
+unicode = 5495;
+},
+{
+glyphname = "hooNunavik-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "hoNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (364,0);
+ref = dot_top;
+}
+);
+width = 781;
+}
+);
+note = uni1578;
+unicode = 5496;
+},
+{
+glyphname = "haNunavik-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (586,690);
+},
+{
+name = top_left_can;
+pos = (417,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(642,-14,o),
+(742,140,o),
+(742,298,cs),
+(742,422,o),
+(667,506,o),
+(549,506,cs),
+(492,506,o),
+(443,484,o),
+(422,444,c),
+(444,440,l),
+(497,690,l),
+(354,690,l),
+(70,491,l),
+(151,374,l),
+(362,521,l),
+(311,562,l),
+(252,290,ls),
+(220,139,o),
+(272,-14,o),
+(461,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(427,121,o),
+(398,154,o),
+(398,208,cs),
+(398,260,o),
+(425,371,o),
+(508,371,cs),
+(557,371,o),
+(585,339,o),
+(585,285,cs),
+(585,233,o),
+(559,121,o),
+(476,121,cs)
+);
+}
+);
+width = 780;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1579;
+unicode = 5497;
+},
+{
+glyphname = "haaNunavik-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "haNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (230,0);
+ref = dot_top;
+}
+);
+width = 781;
+}
+);
+note = uni157A;
+unicode = 5498;
+},
+{
+glyphname = "hNunavik-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(415,339,o),
+(472,419,o),
+(472,497,cs),
+(472,557,o),
+(434,601,o),
+(375,601,cs),
+(340,601,o),
+(309,587,o),
+(297,555,c),
+(315,535,l),
+(348,690,l),
+(248,690,l),
+(103,589,l),
+(152,523,l),
+(281,615,l),
+(234,659,l),
+(198,492,ls),
+(179,402,o),
+(227,339,o),
+(318,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(304,417,o),
+(290,432,o),
+(290,456,cs),
+(290,492,o),
+(311,523,o),
+(340,523,cs),
+(362,523,o),
+(377,509,o),
+(377,485,cs),
+(377,450,o),
+(355,417,o),
+(326,417,cs)
+);
+}
+);
+width = 466;
+}
+);
+metricRight = "k-canadian";
+note = uni157B;
+unicode = 5499;
+},
+{
+color = 4;
+glyphname = "nunavuth-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(170,0,l),
+(231,285,l),
+(493,285,l),
+(433,0,l),
+(593,0,l),
+(740,690,l),
+(580,690,l),
+(524,426,l),
+(261,426,l),
+(317,690,l),
+(156,690,l),
+(10,0,l)
+);
+}
+);
+width = 708;
+}
+);
+metricRight = "=|";
+note = uni157C;
+unicode = 5500;
+},
+{
+glyphname = "hk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (73,345);
+ref = "fullstop-canadian";
+}
+);
+width = 378;
+}
+);
+metricLeft = "fullstop-canadian";
+note = uni157D;
+unicode = 5501;
+},
+{
+glyphname = "qaai-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (334,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (505,0);
+ref = ring_top.canadian;
+}
+);
+width = 927;
+}
+);
+note = uni157E;
+unicode = 5502;
+},
+{
+glyphname = "qi-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (334,0);
+ref = "ki-canadian";
+}
+);
+width = 927;
+}
+);
+note = uni157F;
+unicode = 5503;
+},
+{
+glyphname = "qii-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (334,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (543,0);
+ref = dot_top;
+}
+);
+width = 927;
+}
+);
+note = uni1580;
+unicode = 5504;
+},
+{
+glyphname = "qo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (334,0);
+ref = "ko-canadian";
+}
+);
+width = 927;
+}
+);
+note = uni1581;
+unicode = 5505;
+},
+{
+glyphname = "qoo-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (334,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (697,0);
+ref = dot_top;
+}
+);
+width = 927;
+}
+);
+note = uni1582;
+unicode = 5506;
+},
+{
+glyphname = "qa-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (334,0);
+ref = "ka-canadian";
+}
+);
+width = 927;
+}
+);
+note = uni1583;
+unicode = 5507;
+},
+{
+glyphname = "qaa-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (334,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (376,0);
+ref = dot_top;
+}
+);
+width = 927;
+}
+);
+note = uni1584;
+unicode = 5508;
+},
+{
+glyphname = "q-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (334,0);
+ref = "k-canadian";
+}
+);
+width = 710;
+}
+);
+note = uni1585;
+unicode = 5509;
+},
+{
+glyphname = "tlhe-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (402,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(176,0,l),
+(365,277,l),
+(254,215,l),
+(264,214,o),
+(275,213,o),
+(286,213,cs),
+(347,213,o),
+(398,234,o),
+(418,273,c),
+(412,318,l),
+(345,0,l),
+(503,0,l),
+(594,429,ls),
+(627,582,o),
+(550,704,o),
+(379,704,cs),
+(198,704,o),
+(98,568,o),
+(98,416,cs),
+(98,352,o),
+(125,289,o),
+(180,253,c),
+(7,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(282,350,o),
+(251,384,o),
+(251,433,cs),
+(251,489,o),
+(287,569,o),
+(361,569,cs),
+(414,569,o),
+(445,535,o),
+(445,486,cs),
+(445,430,o),
+(410,350,o),
+(334,350,cs)
+);
+}
+);
+width = 610;
+}
+);
+metricRight = "te-canadian";
+note = uni1586;
+unicode = 5510;
+},
+{
+glyphname = "tlhi-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(162,0,l),
+(233,332,l),
+(168,307,l),
+(200,253,o),
+(262,218,o),
+(337,217,c),
+(256,279,l),
+(330,0,l),
+(499,0,l),
+(439,234,l),
+(539,266,o),
+(606,383,o),
+(606,488,cs),
+(606,615,o),
+(514,704,o),
+(372,704,cs),
+(229,704,o),
+(135,619,o),
+(100,460,cs),
+(3,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(288,350,o),
+(257,381,o),
+(257,432,cs),
+(257,486,o),
+(291,569,o),
+(367,569,cs),
+(419,569,o),
+(450,537,o),
+(450,486,cs),
+(450,432,o),
+(416,350,o),
+(340,350,cs)
+);
+}
+);
+width = 614;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|tlhe-canadian";
+note = uni1587;
+unicode = 5511;
+},
+{
+glyphname = "tlho-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (412,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(427,-14,o),
+(521,71,o),
+(555,230,cs),
+(653,690,l),
+(494,690,l),
+(424,357,l),
+(488,383,l),
+(456,437,o),
+(394,471,o),
+(319,472,c),
+(400,411,l),
+(326,690,l),
+(156,690,l),
+(217,456,l),
+(117,424,o),
+(51,307,o),
+(51,202,cs),
+(51,74,o),
+(142,-14,o),
+(284,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(237,121,o),
+(206,153,o),
+(206,204,cs),
+(206,258,o),
+(240,340,o),
+(316,340,cs),
+(368,340,o),
+(399,309,o),
+(399,258,cs),
+(399,204,o),
+(365,121,o),
+(289,121,cs)
+);
+}
+);
+width = 614;
+}
+);
+metricLeft = "tlhe-canadian";
+metricRight = "te-canadian";
+note = uni1588;
+unicode = 5512;
+},
+{
+glyphname = "tlha-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(454,-14,o),
+(554,122,o),
+(554,273,cs),
+(554,338,o),
+(527,401,o),
+(472,437,c),
+(645,690,l),
+(476,690,l),
+(287,412,l),
+(399,474,l),
+(388,475,o),
+(377,476,o),
+(367,476,cs),
+(305,476,o),
+(255,456,o),
+(235,416,c),
+(241,372,l),
+(308,690,l),
+(149,690,l),
+(58,261,ls),
+(25,107,o),
+(103,-14,o),
+(273,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(238,121,o),
+(208,155,o),
+(208,204,cs),
+(208,260,o),
+(242,340,o),
+(318,340,cs),
+(370,340,o),
+(401,306,o),
+(401,257,cs),
+(401,201,o),
+(366,121,o),
+(291,121,cs)
+);
+}
+);
+width = 610;
+}
+);
+metricLeft = "te-canadian";
+note = uni1589;
+unicode = 5513;
+},
+{
+glyphname = "reWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(458,0,l),
+(744,201,l),
+(661,318,l),
+(451,172,l),
+(503,129,l),
+(567,430,ls),
+(602,593,o),
+(517,704,o),
+(356,704,cs),
+(211,704,o),
+(121,620,o),
+(86,461,cs),
+(69,380,l),
+(227,380,l),
+(244,459,ls),
+(259,532,o),
+(290,565,o),
+(343,565,cs),
+(403,565,o),
+(428,523,o),
+(412,450,cs),
+(317,0,l)
+);
+}
+);
+width = 772;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+unicode = 5514;
+},
+{
+glyphname = "riWestCree-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(349,0,l),
+(445,459,ls),
+(461,532,o),
+(493,565,o),
+(545,565,cs),
+(605,565,o),
+(630,523,o),
+(614,450,cs),
+(600,380,l),
+(758,380,l),
+(769,430,ls),
+(804,593,o),
+(717,704,o),
+(557,704,cs),
+(411,704,o),
+(322,620,o),
+(288,461,cs),
+(217,128,l),
+(280,148,l),
+(117,309,l),
+(8,201,l),
+(207,0,l)
+);
+}
+);
+width = 770;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+unicode = 5515;
+},
+{
+glyphname = "roWestCree-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(401,-14,o),
+(491,70,o),
+(525,229,cs),
+(595,561,l),
+(532,542,l),
+(696,381,l),
+(805,489,l),
+(605,690,l),
+(464,690,l),
+(366,231,ls),
+(351,157,o),
+(320,125,o),
+(268,125,cs),
+(208,125,o),
+(183,167,o),
+(198,240,cs),
+(213,310,l),
+(54,310,l),
+(43,260,ls),
+(9,97,o),
+(96,-14,o),
+(255,-14,cs)
+);
+}
+);
+width = 771;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+unicode = 5516;
+},
+{
+glyphname = "raWestCree-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(603,-14,o),
+(693,70,o),
+(727,229,cs),
+(745,310,l),
+(585,310,l),
+(569,231,ls),
+(554,157,o),
+(523,125,o),
+(470,125,cs),
+(411,125,o),
+(385,167,o),
+(401,240,cs),
+(496,690,l),
+(355,690,l),
+(70,489,l),
+(152,372,l),
+(361,518,l),
+(309,560,l),
+(246,260,ls),
+(212,97,o),
+(297,-14,o),
+(456,-14,cs)
+);
+}
+);
+width = 771;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+unicode = 5517;
+},
+{
+glyphname = "ngaai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:57:37 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (629,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (802,0);
+ref = ring_top.canadian;
+}
+);
+width = 1215;
+}
+);
+note = uni158E;
+unicode = 5518;
+},
+{
+glyphname = "ngi-canadian";
+kernLeft = mwestleft;
+kernRight = ciright;
+lastChange = "2023-01-13 15:57:37 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (629,0);
+ref = "ci-canadian";
+}
+);
+width = 1215;
+}
+);
+note = uni158F;
+unicode = 5519;
+},
+{
+glyphname = "ngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:57:37 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (629,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (840,0);
+ref = dot_top;
+}
+);
+width = 1215;
+}
+);
+note = uni1590;
+unicode = 5520;
+},
+{
+glyphname = "ngo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:57:37 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (602,0);
+ref = "co-canadian";
+}
+);
+width = 1187;
+}
+);
+note = uni1591;
+unicode = 5521;
+},
+{
+glyphname = "ngoo-canadian";
+lastChange = "2023-01-13 15:57:37 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "ngo-canadian";
+},
+{
+anchor = top_right_can;
+pos = (959,0);
+ref = dot_top;
+}
+);
+width = 1187;
+}
+);
+note = uni1592;
+unicode = 5522;
+},
+{
+glyphname = "nga-canadian";
+kernLeft = mwestleft;
+kernRight = caright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (631,0);
+ref = "ca-canadian";
+}
+);
+width = 1217;
+}
+);
+note = uni1593;
+unicode = 5523;
+},
+{
+glyphname = "ngaa-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (631,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (673,0);
+ref = dot_top;
+}
+);
+width = 1217;
+}
+);
+note = uni1594;
+unicode = 5524;
+},
+{
+glyphname = "ng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(547,217,o),
+(603,263,o),
+(620,344,cs),
+(625,369,l),
+(523,369,l),
+(517,340,ls),
+(511,314,o),
+(497,301,o),
+(475,301,cs),
+(451,301,o),
+(440,317,o),
+(447,345,cs),
+(488,536,l),
+(333,536,l),
+(331,473,l),
+(365,492,o),
+(384,536,o),
+(385,575,cs),
+(389,646,o),
+(340,697,o),
+(258,697,cs),
+(177,697,o),
+(117,641,o),
+(113,562,cs),
+(107,487,o),
+(157,435,o),
+(237,435,cs),
+(384,435,l),
+(364,470,l),
+(343,367,ls),
+(324,278,o),
+(372,217,o),
+(465,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(218,513,o),
+(205,530,o),
+(207,558,cs),
+(209,590,o),
+(226,619,o),
+(256,619,cs),
+(279,619,o),
+(293,602,o),
+(291,573,cs),
+(289,542,o),
+(271,513,o),
+(242,513,cs)
+);
+}
+);
+width = 629;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1595;
+unicode = 5525;
+},
+{
+glyphname = "nng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(848,217,o),
+(900,263,o),
+(918,344,cs),
+(924,369,l),
+(821,369,l),
+(814,340,ls),
+(809,314,o),
+(795,301,o),
+(774,301,cs),
+(749,301,o),
+(739,317,o),
+(745,345,cs),
+(786,536,l),
+(645,536,l),
+(637,473,l),
+(673,495,o),
+(692,545,o),
+(692,581,cs),
+(691,651,o),
+(642,697,o),
+(564,697,cs),
+(476,697,o),
+(417,632,o),
+(417,552,cs),
+(417,526,o),
+(424,505,o),
+(438,486,c),
+(454,536,l),
+(342,536,l),
+(332,473,l),
+(370,495,o),
+(388,545,o),
+(388,581,cs),
+(388,650,o),
+(338,697,o),
+(261,697,cs),
+(173,697,o),
+(113,632,o),
+(113,552,cs),
+(113,483,o),
+(163,435,o),
+(239,435,cs),
+(655,435,l),
+(640,367,ls),
+(620,277,o),
+(673,217,o),
+(766,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(222,513,o),
+(208,528,o),
+(208,552,cs),
+(208,581,o),
+(225,619,o),
+(258,619,cs),
+(280,619,o),
+(294,604,o),
+(294,581,cs),
+(294,552,o),
+(276,513,o),
+(244,513,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(526,513,o),
+(512,528,o),
+(512,552,cs),
+(512,581,o),
+(528,619,o),
+(561,619,cs),
+(583,619,o),
+(597,604,o),
+(597,581,cs),
+(597,552,o),
+(581,513,o),
+(548,513,cs)
+);
+}
+);
+width = 928;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1596;
+unicode = 5526;
+},
+{
+glyphname = "sheSayisi-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (710,345);
+},
+{
+name = top_center_can;
+pos = (394,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(493,0,l),
+(582,422,ls),
+(617,587,o),
+(539,704,o),
+(372,704,cs),
+(162,704,o),
+(75,517,o),
+(75,364,cs),
+(75,254,o),
+(130,184,o),
+(222,184,cs),
+(315,184,o),
+(366,256,o),
+(391,413,c),
+(308,413,l),
+(296,342,o),
+(281,315,o),
+(257,315,cs),
+(238,315,o),
+(227,330,o),
+(227,363,cs),
+(227,423,o),
+(256,569,o),
+(353,569,cs),
+(430,569,o),
+(438,497,o),
+(420,413,cs),
+(332,0,l)
+);
+}
+);
+width = 600;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1597;
+unicode = 5527;
+},
+{
+glyphname = "shiSayisi-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(163,0,l),
+(258,443,ls),
+(276,528,o),
+(312,569,o),
+(370,569,cs),
+(421,569,o),
+(449,537,o),
+(449,478,cs),
+(449,439,o),
+(427,315,o),
+(380,315,cs),
+(353,315,o),
+(346,343,o),
+(364,413,c),
+(281,413,l),
+(240,272,o),
+(285,184,o),
+(393,184,cs),
+(543,184,o),
+(602,371,o),
+(602,483,cs),
+(602,618,o),
+(517,704,o),
+(375,704,cs),
+(231,704,o),
+(135,620,o),
+(102,465,cs),
+(3,0,l)
+);
+}
+);
+width = 601;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni1598;
+unicode = 5528;
+},
+{
+glyphname = "shoSayisi-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (386,690);
+},
+{
+name = top_left_can;
+pos = (213,690);
+},
+{
+name = top_right_can;
+pos = (559,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(412,-14,o),
+(507,70,o),
+(540,225,cs),
+(639,690,l),
+(479,690,l),
+(384,246,ls),
+(366,161,o),
+(330,121,o),
+(273,121,cs),
+(221,121,o),
+(194,153,o),
+(194,212,cs),
+(194,251,o),
+(215,375,o),
+(263,375,cs),
+(290,375,o),
+(297,347,o),
+(278,276,c),
+(362,276,l),
+(403,417,o),
+(357,506,o),
+(249,506,cs),
+(100,506,o),
+(41,319,o),
+(41,207,cs),
+(41,71,o),
+(126,-14,o),
+(268,-14,cs)
+);
+}
+);
+width = 600;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1599;
+unicode = 5529;
+},
+{
+glyphname = "shaSayisi-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(481,-14,o),
+(568,173,o),
+(568,326,cs),
+(568,436,o),
+(512,506,o),
+(421,506,cs),
+(328,506,o),
+(277,434,o),
+(252,276,c),
+(335,276,l),
+(347,348,o),
+(361,375,o),
+(385,375,cs),
+(405,375,o),
+(416,359,o),
+(416,327,cs),
+(416,267,o),
+(387,121,o),
+(290,121,cs),
+(213,121,o),
+(206,193,o),
+(223,276,cs),
+(311,690,l),
+(151,690,l),
+(60,268,ls),
+(26,102,o),
+(104,-14,o),
+(271,-14,cs)
+);
+}
+);
+width = 601;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni159A;
+unicode = 5530;
+},
+{
+glyphname = "theWoodScree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(672,-14,o),
+(767,141,o),
+(767,276,cs),
+(767,405,o),
+(679,492,o),
+(535,492,cs),
+(102,492,l),
+(75,362,l),
+(364,362,l),
+(347,409,l),
+(285,358,o),
+(258,270,o),
+(258,201,cs),
+(258,74,o),
+(349,-14,o),
+(489,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(446,121,o),
+(413,156,o),
+(413,211,cs),
+(413,272,o),
+(455,357,o),
+(526,357,cs),
+(579,357,o),
+(611,323,o),
+(611,269,cs),
+(611,207,o),
+(570,121,o),
+(498,121,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(822,560,l),
+(849,690,l),
+(145,690,l),
+(118,560,l)
+);
+}
+);
+width = 817;
+}
+);
+note = uni159B;
+unicode = 5531;
+},
+{
+glyphname = "thiWoodScree-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(462,-14,o),
+(557,138,o),
+(557,277,cs),
+(557,315,o),
+(549,349,o),
+(530,376,c),
+(502,362,l),
+(792,362,l),
+(819,492,l),
+(333,492,ls),
+(140,492,o),
+(48,338,o),
+(48,202,cs),
+(48,74,o),
+(140,-14,o),
+(280,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(238,121,o),
+(205,156,o),
+(205,211,cs),
+(205,272,o),
+(246,357,o),
+(317,357,cs),
+(369,357,o),
+(402,323,o),
+(402,269,cs),
+(402,207,o),
+(360,121,o),
+(289,121,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(835,560,l),
+(862,690,l),
+(157,690,l),
+(130,560,l)
+);
+}
+);
+width = 818;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159C;
+unicode = 5532;
+},
+{
+glyphname = "thoWoodScree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(485,0,ls),
+(678,0,o),
+(770,155,o),
+(770,291,cs),
+(770,417,o),
+(678,506,o),
+(538,506,cs),
+(356,506,o),
+(260,354,o),
+(260,215,cs),
+(260,178,o),
+(270,143,o),
+(287,116,c),
+(315,129,l),
+(25,129,l),
+(-2,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(448,134,o),
+(416,169,o),
+(416,223,cs),
+(416,286,o),
+(457,371,o),
+(529,371,cs),
+(581,371,o),
+(613,335,o),
+(613,281,cs),
+(613,219,o),
+(572,134,o),
+(500,134,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(821,560,l),
+(848,690,l),
+(145,690,l),
+(117,560,l)
+);
+}
+);
+width = 817;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159D;
+unicode = 5533;
+},
+{
+glyphname = "thaWoodScree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(714,0,l),
+(742,129,l),
+(453,129,l),
+(469,83,l),
+(532,134,o),
+(559,222,o),
+(559,291,cs),
+(559,417,o),
+(469,506,o),
+(327,506,cs),
+(144,506,o),
+(50,351,o),
+(50,215,cs),
+(50,88,o),
+(138,0,o),
+(282,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(239,134,o),
+(206,169,o),
+(206,223,cs),
+(206,286,o),
+(247,371,o),
+(319,371,cs),
+(370,371,o),
+(403,335,o),
+(403,281,cs),
+(403,219,o),
+(361,134,o),
+(291,134,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(833,560,l),
+(860,690,l),
+(156,690,l),
+(128,560,l)
+);
+}
+);
+width = 817;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159E;
+unicode = 5534;
+},
+{
+glyphname = "thWoodScree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(463,344,l),
+(482,437,l),
+(325,437,l),
+(319,381,l),
+(358,402,o),
+(378,452,o),
+(378,492,cs),
+(378,559,o),
+(327,606,o),
+(249,606,cs),
+(161,606,o),
+(102,541,o),
+(102,461,cs),
+(102,391,o),
+(153,344,o),
+(227,344,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(211,421,o),
+(197,437,o),
+(197,460,cs),
+(197,489,o),
+(214,528,o),
+(246,528,cs),
+(269,528,o),
+(283,512,o),
+(283,489,cs),
+(283,460,o),
+(266,421,o),
+(233,421,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(520,639,l),
+(540,732,l),
+(160,732,l),
+(141,639,l)
+);
+}
+);
+width = 495;
+}
+);
+metricRight = "=|";
+note = uni159F;
+unicode = 5535;
+},
+{
+glyphname = "lhi-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (521,690);
+},
+{
+name = top_right_can;
+pos = (637,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(320,0,l),
+(350,140,l),
+(298,140,ls),
+(236,140,o),
+(200,172,o),
+(200,224,cs),
+(200,293,o),
+(244,349,o),
+(340,349,cs),
+(780,349,l),
+(807,475,l),
+(681,741,l),
+(541,674,l),
+(658,425,l),
+(703,492,l),
+(355,492,ls),
+(161,492,o),
+(42,385,o),
+(42,217,cs),
+(42,90,o),
+(131,0,o),
+(270,0,cs)
+);
+}
+);
+width = 799;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A0;
+unicode = 5536;
+},
+{
+glyphname = "lhii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "lhi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (332,0);
+ref = dot_top;
+}
+);
+width = 798;
+}
+);
+note = uni15A1;
+unicode = 5537;
+},
+{
+glyphname = "lho-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (455,510);
+},
+{
+name = top_right_can;
+pos = (559,510);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(259,-182,l),
+(142,67,l),
+(96,0,l),
+(445,0,ls),
+(638,0,o),
+(757,106,o),
+(757,274,cs),
+(757,402,o),
+(668,492,o),
+(529,492,cs),
+(479,492,l),
+(450,353,l),
+(501,353,ls),
+(563,353,o),
+(600,320,o),
+(600,268,cs),
+(600,199,o),
+(554,143,o),
+(459,143,cs),
+(19,143,l),
+(-8,16,l),
+(119,-248,l)
+);
+}
+);
+width = 799;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni15A2;
+unicode = 5538;
+},
+{
+glyphname = "lhoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "lho-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (370,-180);
+ref = dot_top;
+}
+);
+width = 798;
+}
+);
+note = uni15A3;
+unicode = 5539;
+},
+{
+glyphname = "lha-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (458,510);
+},
+{
+name = top_left_can;
+pos = (355,510);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(709,16,l),
+(736,143,l),
+(299,143,ls),
+(236,143,o),
+(201,174,o),
+(201,227,cs),
+(201,299,o),
+(248,353,o),
+(344,353,cs),
+(394,353,l),
+(424,492,l),
+(364,492,ls),
+(156,492,o),
+(41,380,o),
+(41,210,cs),
+(41,82,o),
+(129,0,o),
+(272,0,cs),
+(595,0,l),
+(559,63,l),
+(365,-155,l),
+(470,-249,l)
+);
+}
+);
+width = 799;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A4;
+unicode = 5540;
+},
+{
+glyphname = "lhaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "lha-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (165,-180);
+ref = dot_top;
+}
+);
+width = 798;
+}
+);
+note = uni15A5;
+unicode = 5541;
+},
+{
+glyphname = "lh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(452,356,l),
+(471,446,l),
+(276,446,ls),
+(235,446,o),
+(212,467,o),
+(212,501,cs),
+(212,545,o),
+(237,592,o),
+(301,592,cs),
+(323,592,l),
+(343,690,l),
+(313,690,ls),
+(177,690,o),
+(102,603,o),
+(102,489,cs),
+(102,400,o),
+(164,345,o),
+(267,345,cs),
+(394,345,l),
+(357,412,l),
+(238,280,l),
+(317,208,l)
+);
+}
+);
+width = 474;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni15A6;
+unicode = 5542;
+},
+{
+glyphname = "theThCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (203,690);
+},
+{
+name = top_right_can;
+pos = (532,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(321,74,l),
+(305,0,l),
+(466,0,l),
+(481,74,l),
+(552,74,l),
+(570,159,l),
+(499,159,l),
+(540,353,l),
+(270,353,l),
+(291,303,l),
+(609,600,l),
+(511,701,l),
+(31,253,l),
+(22,213,l),
+(351,213,l),
+(339,159,l),
+(128,159,l),
+(109,74,l)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "ye-canadian";
+note = uni15A7;
+unicode = 5543;
+},
+{
+glyphname = "thiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (271,690);
+},
+{
+name = top_right_can;
+pos = (601,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(206,0,l),
+(221,74,l),
+(433,74,l),
+(450,159,l),
+(240,159,l),
+(251,213,l),
+(579,213,l),
+(587,253,l),
+(273,701,l),
+(158,618,l),
+(383,294,l),
+(414,353,l),
+(120,353,l),
+(78,159,l),
+(8,159,l),
+(-11,74,l),
+(61,74,l),
+(44,0,l)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+unicode = 5544;
+},
+{
+glyphname = "thiiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (84,0);
+ref = dot_top;
+}
+);
+width = 615;
+}
+);
+note = uni15A9;
+unicode = 5545;
+},
+{
+glyphname = "thoThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (202,690);
+},
+{
+name = top_right_can;
+pos = (531,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(498,71,l),
+(273,396,l),
+(242,337,l),
+(536,337,l),
+(578,530,l),
+(649,530,l),
+(667,615,l),
+(595,615,l),
+(611,690,l),
+(451,690,l),
+(435,615,l),
+(223,615,l),
+(206,530,l),
+(417,530,l),
+(406,476,l),
+(78,476,l),
+(70,437,l),
+(383,-12,l)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+unicode = 5546;
+},
+{
+glyphname = "thooThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (343,0);
+ref = dot_top;
+}
+);
+width = 615;
+}
+);
+note = uni15AB;
+unicode = 5547;
+},
+{
+glyphname = "thaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (271,690);
+},
+{
+name = top_right_can;
+pos = (601,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(626,437,l),
+(635,476,l),
+(306,476,l),
+(318,530,l),
+(529,530,l),
+(547,615,l),
+(335,615,l),
+(352,690,l),
+(191,690,l),
+(175,615,l),
+(104,615,l),
+(87,530,l),
+(157,530,l),
+(116,337,l),
+(385,337,l),
+(366,386,l),
+(48,90,l),
+(145,-12,l)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+unicode = 5548;
+},
+{
+glyphname = "thaaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:57:37 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (83,0);
+ref = dot_top;
+}
+);
+width = 615;
+}
+);
+note = uni15AD;
+unicode = 5549;
+},
+{
+glyphname = "thThCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(156,614,l),
+(130,497,l),
+(281,497,l),
+(261,547,l),
+(109,400,l),
+(177,334,l),
+(404,555,l),
+(410,582,l),
+(258,582,l),
+(265,614,l),
+(357,614,l),
+(367,658,l),
+(273,658,l),
+(280,690,l),
+(171,690,l),
+(164,658,l),
+(128,658,l),
+(120,614,l)
+);
+}
+);
+width = 361;
+}
+);
+metricRight = "y-canadian";
+note = uni15AE;
+unicode = 5550;
+},
+{
+glyphname = "bAivilik-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(461,-14,o),
+(564,140,o),
+(564,297,cs),
+(564,419,o),
+(487,506,o),
+(370,506,cs),
+(315,506,o),
+(268,484,o),
+(246,448,c),
+(262,424,l),
+(317,690,l),
+(156,690,l),
+(11,0,l),
+(163,0,l),
+(180,76,l),
+(167,63,l),
+(183,15,o),
+(234,-14,o),
+(302,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(249,121,o),
+(220,154,o),
+(220,208,cs),
+(220,260,o),
+(246,371,o),
+(329,371,cs),
+(379,371,o),
+(408,339,o),
+(408,285,cs),
+(408,234,o),
+(382,121,o),
+(298,121,cs)
+);
+}
+);
+width = 602;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|ke-canadian";
+note = uni15AF;
+unicode = 5551;
+},
+{
+glyphname = "eBlackfoot-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(170,0,l),
+(258,411,l),
+(282,369,o),
+(328,342,o),
+(387,342,cs),
+(507,342,o),
+(579,451,o),
+(579,553,cs),
+(579,641,o),
+(520,704,o),
+(430,704,cs),
+(381,704,o),
+(334,685,o),
+(301,652,c),
+(310,690,l),
+(156,690,l),
+(10,0,l)
+);
+}
+);
+width = 555;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B0;
+unicode = 5552;
+},
+{
+glyphname = "iBlackfoot-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(216,-14,o),
+(263,5,o),
+(296,38,c),
+(287,0,l),
+(441,0,l),
+(587,690,l),
+(427,690,l),
+(339,279,l),
+(315,321,o),
+(269,348,o),
+(211,348,cs),
+(90,348,o),
+(18,239,o),
+(18,137,cs),
+(18,48,o),
+(77,-14,o),
+(167,-14,cs)
+);
+}
+);
+width = 555;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B1;
+unicode = 5553;
+},
+{
+glyphname = "oBlackfoot-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(432,-14,o),
+(503,94,o),
+(503,196,cs),
+(503,285,o),
+(445,348,o),
+(355,348,cs),
+(309,348,o),
+(267,331,o),
+(235,304,c),
+(317,690,l),
+(156,690,l),
+(10,0,l),
+(163,0,l),
+(178,68,l),
+(199,17,o),
+(249,-14,o),
+(312,-14,cs)
+);
+}
+);
+width = 555;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "eBlackfoot-canadian";
+note = uni15B2;
+unicode = 5554;
+},
+{
+glyphname = "aBlackfoot-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,0,l),
+(587,690,l),
+(434,690,l),
+(419,622,l),
+(398,672,o),
+(348,704,o),
+(285,704,cs),
+(165,704,o),
+(94,596,o),
+(94,494,cs),
+(94,405,o),
+(152,342,o),
+(241,342,cs),
+(288,342,o),
+(330,358,o),
+(362,385,c),
+(280,0,l)
+);
+}
+);
+width = 555;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B3;
+unicode = 5555;
+},
+{
+glyphname = "weBlackfoot-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(170,0,l),
+(229,276,l),
+(553,276,l),
+(580,409,l),
+(257,409,l),
+(289,556,l),
+(611,556,l),
+(639,690,l),
+(156,690,l),
+(10,0,l)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B4;
+unicode = 5556;
+},
+{
+glyphname = "wiBlackfoot-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(480,0,l),
+(627,690,l),
+(467,690,l),
+(408,413,l),
+(85,413,l),
+(57,281,l),
+(380,281,l),
+(348,133,l),
+(25,133,l),
+(-3,0,l)
+);
+}
+);
+width = 595;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B5;
+unicode = 5557;
+},
+{
+glyphname = "woBlackfoot-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(493,0,l),
+(521,133,l),
+(199,133,l),
+(230,281,l),
+(553,281,l),
+(581,413,l),
+(259,413,l),
+(317,690,l),
+(156,690,l),
+(10,0,l)
+);
+}
+);
+width = 595;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "weBlackfoot-canadian";
+note = uni15B6;
+unicode = 5558;
+},
+{
+glyphname = "waBlackfoot-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(480,0,l),
+(627,690,l),
+(143,690,l),
+(116,556,l),
+(438,556,l),
+(407,409,l),
+(84,409,l),
+(56,276,l),
+(378,276,l),
+(320,0,l)
+);
+}
+);
+width = 595;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B7;
+unicode = 5559;
+},
+{
+glyphname = "neBlackfoot-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(170,0,l),
+(292,574,l),
+(343,574,l),
+(326,672,l),
+(321,651,ls),
+(285,494,o),
+(374,384,o),
+(536,384,cs),
+(680,384,o),
+(778,467,o),
+(810,618,cs),
+(825,690,l),
+(668,690,l),
+(652,616,ls),
+(639,554,o),
+(603,521,o),
+(547,521,cs),
+(486,521,o),
+(458,560,o),
+(472,629,cs),
+(486,690,l),
+(156,690,l),
+(10,0,l)
+);
+}
+);
+width = 758;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B8;
+unicode = 5560;
+},
+{
+glyphname = "niBlackfoot-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(132,0,l),
+(148,73,ls),
+(160,136,o),
+(196,169,o),
+(252,169,cs),
+(314,169,o),
+(341,129,o),
+(326,61,cs),
+(314,0,l),
+(642,0,l),
+(789,690,l),
+(629,690,l),
+(507,116,l),
+(456,116,l),
+(474,17,l),
+(479,39,ls),
+(515,196,o),
+(426,306,o),
+(263,306,cs),
+(120,306,o),
+(22,223,o),
+(-10,71,cs),
+(-25,0,l)
+);
+}
+);
+width = 757;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B9;
+unicode = 5561;
+},
+{
+glyphname = "noBlackfoot-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(339,0,l),
+(355,72,ls),
+(369,137,o),
+(404,170,o),
+(459,170,cs),
+(521,170,o),
+(548,130,o),
+(533,62,cs),
+(521,0,l),
+(678,0,l),
+(687,43,ls),
+(719,199,o),
+(631,307,o),
+(469,307,cs),
+(327,307,o),
+(232,226,o),
+(194,55,cs),
+(185,18,l),
+(246,116,l),
+(195,116,l),
+(317,690,l),
+(156,690,l),
+(10,0,l)
+);
+}
+);
+width = 757;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "neBlackfoot-canadian";
+note = uni15BA;
+unicode = 5562;
+},
+{
+glyphname = "naBlackfoot-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(642,0,l),
+(789,690,l),
+(461,690,l),
+(444,617,ls),
+(431,553,o),
+(396,520,o),
+(340,520,cs),
+(279,520,o),
+(251,559,o),
+(266,628,cs),
+(278,690,l),
+(122,690,l),
+(112,646,ls),
+(81,491,o),
+(169,383,o),
+(329,383,cs),
+(471,383,o),
+(568,464,o),
+(606,635,cs),
+(613,671,l),
+(553,574,l),
+(604,574,l),
+(482,0,l)
+);
+}
+);
+width = 757;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BB;
+unicode = 5563;
+},
+{
+glyphname = "keBlackfoot-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(170,0,l),
+(278,504,l),
+(224,504,l),
+(310,249,l),
+(373,249,l),
+(709,690,l),
+(523,690,l),
+(337,443,l),
+(384,440,l),
+(304,690,l),
+(156,690,l),
+(10,0,l)
+);
+}
+);
+width = 623;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15BC;
+unicode = 5564;
+},
+{
+glyphname = "kiBlackfoot-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,0,l),
+(328,246,l),
+(282,250,l),
+(360,0,l),
+(508,0,l),
+(655,690,l),
+(495,690,l),
+(386,185,l),
+(440,185,l),
+(354,440,l),
+(292,440,l),
+(-44,0,l)
+);
+}
+);
+width = 623;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BD;
+unicode = 5565;
+},
+{
+glyphname = "koBlackfoot-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(157,0,l),
+(389,273,l),
+(299,285,l),
+(397,0,l),
+(562,0,l),
+(413,440,l),
+(351,440,l),
+(155,185,l),
+(210,185,l),
+(317,690,l),
+(156,690,l),
+(10,0,l)
+);
+}
+);
+width = 622;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "keBlackfoot-canadian";
+note = uni15BE;
+unicode = 5566;
+},
+{
+glyphname = "kaBlackfoot-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(508,0,l),
+(655,690,l),
+(507,690,l),
+(275,416,l),
+(365,405,l),
+(268,690,l),
+(102,690,l),
+(252,249,l),
+(315,249,l),
+(511,504,l),
+(455,504,l),
+(348,0,l)
+);
+}
+);
+width = 623;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BF;
+unicode = 5567;
+},
+{
+color = 9;
+glyphname = "heSayisi-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_right_can;
+pos = (653,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(585,0,l),
+(732,690,l),
+(575,690,l),
+(503,355,l),
+(528,355,l),
+(571,564,o),
+(491,704,o),
+(333,704,cs),
+(213,704,o),
+(127,620,o),
+(90,469,cs),
+(80,426,o),
+(73,381,o),
+(71,328,c),
+(225,328,l),
+(228,376,o),
+(232,409,o),
+(240,440,cs),
+(261,522,o),
+(300,564,o),
+(355,564,cs),
+(477,564,o),
+(504,372,o),
+(425,0,c)
+);
+}
+);
+width = 700;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni15C0;
+unicode = 5568;
+},
+{
+color = 9;
+glyphname = "hiSayisi-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(170,0,l),
+(249,361,o),
+(356,564,o),
+(471,564,cs),
+(535,564,o),
+(558,504,o),
+(536,400,cs),
+(529,373,o),
+(523,351,o),
+(516,328,c),
+(668,328,l),
+(679,355,o),
+(687,381,o),
+(693,406,cs),
+(729,582,o),
+(662,704,o),
+(527,704,cs),
+(388,704,o),
+(268,572,o),
+(223,369,c),
+(246,369,l),
+(315,690,l),
+(156,690,l),
+(10,0,l)
+);
+}
+);
+width = 701;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C1;
+unicode = 5569;
+},
+{
+color = 9;
+glyphname = "hoSayisi-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (440,690);
+},
+{
+name = top_left_can;
+pos = (224,690);
+},
+{
+name = top_right_can;
+pos = (654,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(355,-14,o),
+(476,118,o),
+(521,321,c),
+(497,321,l),
+(429,0,l),
+(586,0,l),
+(733,690,l),
+(573,690,l),
+(495,328,o),
+(386,126,o),
+(271,126,cs),
+(208,126,o),
+(185,185,o),
+(208,290,cs),
+(213,317,o),
+(220,339,o),
+(228,361,c),
+(74,361,l),
+(64,334,o),
+(56,309,o),
+(50,284,cs),
+(14,107,o),
+(81,-14,o),
+(216,-14,cs)
+);
+}
+);
+width = 701;
+}
+);
+metricLeft = "heSayisi-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15C2;
+unicode = 5570;
+},
+{
+color = 9;
+glyphname = "haSayisi-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(530,-14,o),
+(616,70,o),
+(653,220,cs),
+(663,264,o),
+(668,309,o),
+(670,361,c),
+(518,361,l),
+(515,314,o),
+(510,281,o),
+(502,250,cs),
+(482,168,o),
+(442,126,o),
+(386,126,cs),
+(265,126,o),
+(238,318,o),
+(317,690,c),
+(156,690,l),
+(10,0,l),
+(168,0,l),
+(239,335,l),
+(213,335,l),
+(172,126,o),
+(251,-14,o),
+(410,-14,cs)
+);
+}
+);
+width = 701;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C3;
+unicode = 5571;
+},
+{
+color = 9;
+glyphname = "ghuCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(336,0,l),
+(791,651,l),
+(800,690,l),
+(652,690,l),
+(525,503,l),
+(574,530,l),
+(251,530,l),
+(294,505,l),
+(249,690,l),
+(119,690,l),
+(111,651,l),
+(290,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(501,411,l),
+(483,432,l),
+(316,186,l),
+(377,177,l),
+(310,435,l),
+(281,411,l)
+);
+}
+);
+width = 731;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C4;
+unicode = 5572;
+},
+{
+color = 9;
+glyphname = "ghoCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,0,l),
+(249,186,l),
+(199,159,l),
+(522,159,l),
+(479,185,l),
+(525,0,l),
+(654,0,l),
+(663,39,l),
+(484,690,l),
+(437,690,l),
+(-18,39,l),
+(-27,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(484,330,l),
+(301,333,l),
+(319,260,l),
+(465,452,l),
+(366,459,l),
+(433,252,l)
+);
+}
+);
+width = 732;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C5;
+unicode = 5573;
+},
+{
+color = 9;
+glyphname = "gheCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (100,358);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(27,0,l),
+(633,321,l),
+(643,369,l),
+(174,690,l),
+(136,690,l),
+(111,572,l),
+(246,477,l),
+(241,566,l),
+(154,156,l),
+(192,239,l),
+(21,148,l),
+(-11,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(346,508,l),
+(308,453,l),
+(501,318,l),
+(507,392,l),
+(267,266,l),
+(283,213,l)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15C6;
+unicode = 5574;
+},
+{
+color = 9;
+glyphname = "gheeCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (28,14);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 645;
+}
+);
+note = uni15C7;
+unicode = 5575;
+},
+{
+color = 9;
+glyphname = "ghiCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (3,14);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 645;
+}
+);
+note = uni15C8;
+unicode = 5576;
+},
+{
+color = 9;
+glyphname = "ghaCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(550,0,l),
+(575,118,l),
+(440,213,l),
+(445,124,l),
+(532,534,l),
+(494,451,l),
+(665,542,l),
+(696,690,l),
+(659,690,l),
+(53,369,l),
+(43,321,l),
+(512,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(378,237,l),
+(194,363,l),
+(189,304,l),
+(419,424,l),
+(400,466,l),
+(344,199,l)
+);
+}
+);
+width = 643;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15C9;
+unicode = 5577;
+},
+{
+color = 9;
+glyphname = "ruCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(336,0,l),
+(791,651,l),
+(800,690,l),
+(651,690,l),
+(591,603,l),
+(648,627,l),
+(226,627,l),
+(270,603,l),
+(248,690,l),
+(119,690,l),
+(111,651,l),
+(290,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(573,504,l),
+(547,528,l),
+(318,191,l),
+(377,182,l),
+(286,529,l),
+(254,504,l)
+);
+}
+);
+width = 731;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CA;
+unicode = 5578;
+},
+{
+color = 9;
+glyphname = "roCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(437,690,l),
+(-18,39,l),
+(-27,0,l),
+(123,0,l),
+(183,87,l),
+(125,63,l),
+(547,63,l),
+(504,87,l),
+(525,0,l),
+(654,0,l),
+(663,39,l),
+(484,690,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(201,185,l),
+(227,161,l),
+(456,498,l),
+(397,508,l),
+(487,160,l),
+(519,185,l)
+);
+}
+);
+width = 732;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CB;
+unicode = 5579;
+},
+{
+color = 9;
+glyphname = "reCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(28,0,l),
+(633,321,l),
+(643,369,l),
+(174,690,l),
+(136,690,l),
+(111,573,l),
+(184,522,l),
+(175,611,l),
+(68,108,l),
+(110,191,l),
+(20,143,l),
+(-11,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(282,543,l),
+(244,486,l),
+(491,317,l),
+(495,390,l),
+(187,228,l),
+(204,176,l)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CC;
+unicode = 5580;
+},
+{
+color = 9;
+glyphname = "reeCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(28,0,l),
+(633,321,l),
+(643,369,l),
+(175,690,l),
+(136,690,l),
+(116,592,l),
+(180,545,l),
+(178,628,l),
+(64,91,l),
+(97,171,l),
+(16,128,l),
+(-11,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(272,575,l),
+(228,524,l),
+(531,319,l),
+(535,392,l),
+(165,197,l),
+(180,142,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(305,292,l),
+(333,424,l),
+(272,424,l),
+(244,292,l)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CD;
+unicode = 5581;
+},
+{
+color = 9;
+glyphname = "riCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(28,0,l),
+(633,321,l),
+(643,369,l),
+(175,690,l),
+(136,690,l),
+(116,592,l),
+(181,544,l),
+(178,628,l),
+(64,91,l),
+(105,176,l),
+(16,128,l),
+(-11,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(338,311,o),
+(363,332,o),
+(363,362,cs),
+(363,392,o),
+(338,413,o),
+(311,413,cs),
+(284,413,o),
+(259,392,o),
+(259,362,cs),
+(259,332,o),
+(284,311,o),
+(311,311,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(272,575,l),
+(228,524,l),
+(531,319,l),
+(535,392,l),
+(167,198,l),
+(180,142,l)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CE;
+unicode = 5582;
+},
+{
+color = 9;
+glyphname = "raCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(550,0,l),
+(575,117,l),
+(502,168,l),
+(511,78,l),
+(618,582,l),
+(576,498,l),
+(666,547,l),
+(696,690,l),
+(658,690,l),
+(53,369,l),
+(43,321,l),
+(512,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(441,204,l),
+(195,373,l),
+(191,299,l),
+(498,462,l),
+(482,514,l),
+(404,147,l)
+);
+}
+);
+width = 643;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15CF;
+unicode = 5583;
+},
+{
+color = 9;
+glyphname = "wuCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(345,0,l),
+(809,651,l),
+(816,690,l),
+(675,690,l),
+(399,279,l),
+(435,279,l),
+(522,690,l),
+(396,690,l),
+(308,279,l),
+(347,279,l),
+(240,690,l),
+(119,690,l),
+(111,651,l),
+(298,0,l)
+);
+}
+);
+width = 748;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D0;
+unicode = 5584;
+},
+{
+color = 9;
+glyphname = "woCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(115,0,l),
+(391,411,l),
+(356,411,l),
+(268,0,l),
+(394,0,l),
+(482,411,l),
+(442,411,l),
+(551,0,l),
+(670,0,l),
+(679,39,l),
+(493,690,l),
+(445,690,l),
+(-18,39,l),
+(-27,0,l)
+);
+}
+);
+width = 748;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D1;
+unicode = 5585;
+},
+{
+color = 9;
+glyphname = "weCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(47,0,l),
+(653,321,l),
+(664,369,l),
+(194,690,l),
+(156,690,l),
+(131,572,l),
+(408,390,l),
+(416,417,l),
+(99,417,l),
+(73,298,l),
+(390,298,l),
+(395,323,l),
+(41,143,l),
+(11,0,l)
+);
+}
+);
+width = 665;
+}
+);
+metricRight = "o-canadian";
+note = uni15D2;
+unicode = 5586;
+},
+{
+color = 9;
+glyphname = "weeCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(48,0,l),
+(653,321,l),
+(664,369,l),
+(195,690,l),
+(157,690,l),
+(135,587,l),
+(453,377,l),
+(464,405,l),
+(243,405,l),
+(258,471,l),
+(175,471,l),
+(160,405,l),
+(96,405,l),
+(76,311,l),
+(140,311,l),
+(127,244,l),
+(210,244,l),
+(223,311,l),
+(444,311,l),
+(440,335,l),
+(38,129,l),
+(11,0,l)
+);
+}
+);
+width = 665;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D3;
+unicode = 5587;
+},
+{
+color = 9;
+glyphname = "wiCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(49,0,l),
+(654,321,l),
+(665,369,l),
+(196,690,l),
+(158,690,l),
+(136,587,l),
+(441,386,l),
+(462,406,l),
+(309,406,l),
+(294,438,o),
+(263,460,o),
+(224,460,cs),
+(186,460,o),
+(155,438,o),
+(140,406,c),
+(98,406,l),
+(78,319,l),
+(143,319,l),
+(158,290,o),
+(189,270,o),
+(225,270,cs),
+(260,270,o),
+(290,291,o),
+(304,319,c),
+(441,319,l),
+(433,329,l),
+(39,129,l),
+(12,0,l)
+);
+}
+);
+width = 666;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D4;
+unicode = 5588;
+},
+{
+color = 9;
+glyphname = "waCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(550,0,l),
+(575,118,l),
+(298,299,l),
+(291,272,l),
+(607,272,l),
+(633,392,l),
+(316,392,l),
+(311,367,l),
+(666,547,l),
+(696,690,l),
+(659,690,l),
+(53,369,l),
+(43,321,l),
+(512,0,l)
+);
+}
+);
+width = 664;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15D5;
+unicode = 5589;
+},
+{
+color = 9;
+glyphname = "hwuCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(345,0,l),
+(809,651,l),
+(816,690,l),
+(685,690,l),
+(576,531,l),
+(609,552,l),
+(477,552,l),
+(507,690,l),
+(410,690,l),
+(380,552,l),
+(246,552,l),
+(270,539,l),
+(229,690,l),
+(119,690,l),
+(111,651,l),
+(298,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(350,209,l),
+(277,490,l),
+(264,468,l),
+(372,468,l),
+(317,208,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(450,468,l),
+(559,468,l),
+(555,490,l),
+(369,213,l),
+(395,203,l)
+);
+}
+);
+width = 748;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D6;
+unicode = 5590;
+},
+{
+color = 9;
+glyphname = "hwoCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(104,0,l),
+(214,158,l),
+(182,138,l),
+(312,138,l),
+(282,0,l),
+(381,0,l),
+(410,138,l),
+(543,138,l),
+(520,151,l),
+(560,0,l),
+(670,0,l),
+(679,39,l),
+(492,690,l),
+(444,690,l),
+(-18,39,l),
+(-27,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(420,476,l),
+(395,487,l),
+(340,222,l),
+(230,222,l),
+(234,200,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(527,222,l),
+(418,222,l),
+(472,482,l),
+(441,481,l),
+(512,200,l)
+);
+}
+);
+width = 748;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D7;
+unicode = 5591;
+},
+{
+color = 9;
+glyphname = "hweCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(47,0,l),
+(653,321,l),
+(664,369,l),
+(194,690,l),
+(156,690,l),
+(135,588,l),
+(245,516,l),
+(222,409,l),
+(98,409,l),
+(75,308,l),
+(201,308,l),
+(179,202,l),
+(37,129,l),
+(10,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(277,319,l),
+(435,319,l),
+(260,234,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(312,481,l),
+(443,399,l),
+(295,399,l)
+);
+}
+);
+width = 665;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D8;
+unicode = 5592;
+},
+{
+color = 9;
+glyphname = "hweeCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(47,0,l),
+(653,321,l),
+(664,369,l),
+(194,690,l),
+(156,690,l),
+(135,591,l),
+(283,497,l),
+(262,400,l),
+(214,400,l),
+(228,464,l),
+(161,464,l),
+(148,400,l),
+(95,400,l),
+(77,316,l),
+(129,316,l),
+(117,252,l),
+(184,252,l),
+(196,316,l),
+(244,316,l),
+(223,218,l),
+(37,128,l),
+(10,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(311,325,l),
+(446,325,l),
+(296,250,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(341,464,l),
+(455,392,l),
+(326,392,l)
+);
+}
+);
+width = 665;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D9;
+unicode = 5593;
+},
+{
+color = 9;
+glyphname = "hwiCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(47,0,l),
+(653,321,l),
+(664,369,l),
+(194,690,l),
+(156,690,l),
+(136,591,l),
+(283,497,l),
+(261,392,l),
+(237,392,l),
+(226,415,o),
+(202,432,o),
+(175,432,cs),
+(147,432,o),
+(125,415,o),
+(113,392,c),
+(94,392,l),
+(79,324,l),
+(112,324,l),
+(124,300,o),
+(147,284,o),
+(174,284,cs),
+(201,284,o),
+(224,300,o),
+(236,324,c),
+(246,324,l),
+(224,218,l),
+(37,128,l),
+(10,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(312,324,l),
+(445,324,l),
+(297,250,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(341,465,l),
+(455,392,l),
+(326,392,l)
+);
+}
+);
+width = 665;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15DA;
+unicode = 5594;
+},
+{
+color = 9;
+glyphname = "hwaCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(659,690,l),
+(53,369,l),
+(43,321,l),
+(512,0,l),
+(550,0,l),
+(571,101,l),
+(461,174,l),
+(484,281,l),
+(609,281,l),
+(630,382,l),
+(505,382,l),
+(527,488,l),
+(669,560,l),
+(696,690,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(429,371,l),
+(271,371,l),
+(446,456,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(394,209,l),
+(263,291,l),
+(412,291,l)
+);
+}
+);
+width = 664;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15DB;
+unicode = 5595;
+},
+{
+color = 9;
+glyphname = "thuCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(528,-14,o),
+(635,82,o),
+(678,285,cs),
+(764,690,l),
+(150,690,l),
+(71,319,ls),
+(27,111,o),
+(134,-14,o),
+(339,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(281,550,l),
+(573,550,l),
+(518,289,ls),
+(495,180,o),
+(441,130,o),
+(353,130,cs),
+(245,130,o),
+(205,191,o),
+(229,307,cs)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DC;
+unicode = 5596;
+},
+{
+color = 9;
+glyphname = "thoCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(617,0,l),
+(696,371,ls),
+(740,579,o),
+(633,704,o),
+(428,704,cs),
+(239,704,o),
+(132,608,o),
+(89,405,cs),
+(3,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(249,401,ls),
+(272,510,o),
+(326,559,o),
+(414,559,cs),
+(522,559,o),
+(562,498,o),
+(538,383,cs),
+(486,140,l),
+(194,140,l)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DD;
+unicode = 5597;
+},
+{
+color = 9;
+glyphname = "theCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (384,345);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(280,0,ls),
+(598,0,o),
+(700,224,o),
+(700,412,cs),
+(700,585,o),
+(591,690,o),
+(397,690,cs),
+(156,690,l),
+(10,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(298,599,l),
+(241,550,l),
+(363,550,ls),
+(479,550,o),
+(542,497,o),
+(542,397,cs),
+(542,264,o),
+(461,140,o),
+(286,140,cs),
+(160,140,l),
+(190,93,l)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "to-canadian";
+note = uni15DE;
+unicode = 5598;
+},
+{
+color = 9;
+glyphname = "theeCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (298,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 726;
+}
+);
+note = uni15DF;
+unicode = 5599;
+},
+{
+color = 9;
+glyphname = "thiCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (269,0);
+ref = dot_middle;
+}
+);
+width = 726;
+}
+);
+note = uni15E0;
+unicode = 5600;
+},
+{
+color = 9;
+glyphname = "thaCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(610,0,l),
+(757,690,l),
+(487,690,ls),
+(169,690,o),
+(67,466,o),
+(67,277,cs),
+(67,104,o),
+(176,0,o),
+(369,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(225,426,o),
+(306,550,o),
+(481,550,cs),
+(607,550,l),
+(577,597,l),
+(469,91,l),
+(525,140,l),
+(403,140,ls),
+(287,140,o),
+(225,193,o),
+(225,293,cs)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15E1;
+unicode = 5601;
+},
+{
+color = 9;
+glyphname = "ttuCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(529,-14,o),
+(634,80,o),
+(678,291,cs),
+(763,690,l),
+(717,690,l),
+(354,504,l),
+(483,480,l),
+(197,690,l),
+(149,690,l),
+(70,318,ls),
+(26,111,o),
+(131,-14,o),
+(342,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(246,130,o),
+(205,193,o),
+(228,306,cs),
+(277,541,l),
+(196,518,l),
+(379,386,l),
+(406,386,l),
+(623,497,l),
+(571,540,l),
+(521,304,ls),
+(496,183,o),
+(441,130,o),
+(348,130,cs)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E2;
+unicode = 5602;
+},
+{
+color = 9;
+glyphname = "ttoCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(49,0,l),
+(412,185,l),
+(283,210,l),
+(569,0,l),
+(617,0,l),
+(696,372,ls),
+(740,579,o),
+(635,704,o),
+(424,704,cs),
+(237,704,o),
+(132,610,o),
+(88,399,cs),
+(3,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(520,559,o),
+(561,497,o),
+(538,384,cs),
+(489,149,l),
+(570,172,l),
+(387,303,l),
+(360,303,l),
+(143,192,l),
+(195,150,l),
+(245,385,ls),
+(270,507,o),
+(325,559,o),
+(418,559,cs)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E3;
+unicode = 5603;
+},
+{
+color = 9;
+glyphname = "tteCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (433,345);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(290,0,ls),
+(567,0,o),
+(710,187,o),
+(710,412,cs),
+(710,585,o),
+(601,690,o),
+(410,690,cs),
+(150,690,l),
+(141,651,l),
+(206,282,l),
+(219,415,l),
+(12,39,l),
+(3,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(343,331,l),
+(348,355,l),
+(300,621,l),
+(245,550,l),
+(373,550,ls),
+(489,550,o),
+(552,496,o),
+(552,396,cs),
+(552,265,o),
+(470,140,o),
+(296,140,cs),
+(164,140,l),
+(205,77,l)
+);
+}
+);
+width = 735;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15E4;
+unicode = 5604;
+},
+{
+color = 9;
+glyphname = "tteeCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (360,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 736;
+}
+);
+note = uni15E5;
+unicode = 5605;
+},
+{
+color = 9;
+glyphname = "ttiCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (351,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 736;
+}
+);
+note = uni15E6;
+unicode = 5606;
+},
+{
+color = 9;
+glyphname = "ttaCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(628,0,l),
+(637,39,l),
+(571,408,l),
+(557,274,l),
+(766,651,l),
+(775,690,l),
+(488,690,ls),
+(210,690,o),
+(67,502,o),
+(67,277,cs),
+(67,104,o),
+(177,0,o),
+(367,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(532,140,l),
+(404,140,ls),
+(288,140,o),
+(225,194,o),
+(225,294,cs),
+(225,425,o),
+(307,550,o),
+(482,550,cs),
+(612,550,l),
+(572,612,l),
+(435,358,l),
+(430,334,l),
+(477,69,l)
+);
+}
+);
+width = 736;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tteCarrier-canadian";
+note = uni15E7;
+unicode = 5607;
+},
+{
+color = 9;
+glyphname = "puCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(528,-14,o),
+(635,82,o),
+(678,285,cs),
+(764,690,l),
+(604,690,l),
+(575,555,l),
+(282,555,l),
+(310,690,l),
+(150,690,l),
+(71,319,ls),
+(27,111,o),
+(134,-14,o),
+(339,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(245,130,o),
+(205,191,o),
+(229,307,cs),
+(252,414,l),
+(545,414,l),
+(518,289,ls),
+(495,180,o),
+(441,130,o),
+(353,130,cs)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E8;
+unicode = 5608;
+},
+{
+color = 9;
+glyphname = "poCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(163,0,l),
+(192,134,l),
+(485,134,l),
+(457,0,l),
+(617,0,l),
+(696,371,ls),
+(740,579,o),
+(633,704,o),
+(428,704,cs),
+(239,704,o),
+(132,608,o),
+(89,405,cs),
+(3,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(249,401,ls),
+(272,510,o),
+(326,559,o),
+(414,559,cs),
+(522,559,o),
+(562,498,o),
+(538,383,cs),
+(515,275,l),
+(222,275,l)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E9;
+unicode = 5609;
+},
+{
+color = 9;
+glyphname = "peCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (419,345);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(289,0,ls),
+(607,0,o),
+(709,224,o),
+(709,412,cs),
+(709,585,o),
+(600,690,o),
+(409,690,cs),
+(149,690,l),
+(119,550,l),
+(198,550,l),
+(111,140,l),
+(32,140,l),
+(2,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(372,620,l),
+(258,550,l),
+(372,550,ls),
+(488,550,o),
+(550,496,o),
+(550,397,cs),
+(550,265,o),
+(470,140,o),
+(295,140,cs),
+(171,140,l),
+(256,70,l)
+);
+}
+);
+width = 734;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15EA;
+unicode = 5610;
+},
+{
+color = 9;
+glyphname = "peeCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (347,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 735;
+}
+);
+note = uni15EB;
+unicode = 5611;
+},
+{
+color = 9;
+glyphname = "piCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (337,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 735;
+}
+);
+note = uni15EC;
+unicode = 5612;
+},
+{
+color = 9;
+glyphname = "paCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(627,0,l),
+(657,140,l),
+(579,140,l),
+(665,550,l),
+(745,550,l),
+(774,690,l),
+(487,690,ls),
+(170,690,o),
+(67,466,o),
+(67,277,cs),
+(67,104,o),
+(176,0,o),
+(367,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(519,140,l),
+(404,140,ls),
+(288,140,o),
+(226,194,o),
+(226,293,cs),
+(226,425,o),
+(306,550,o),
+(482,550,cs),
+(606,550,l),
+(521,620,l),
+(404,70,l)
+);
+}
+);
+width = 734;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|peCarrier-canadian";
+note = uni15ED;
+unicode = 5613;
+},
+{
+color = 6;
+glyphname = "pCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(364,183,l),
+(386,286,l),
+(279,286,l),
+(330,527,l),
+(221,527,l),
+(170,286,l),
+(62,286,l),
+(40,183,l)
+);
+}
+);
+width = 430;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni15EE;
+unicode = 5614;
+},
+{
+color = 9;
+glyphname = "guCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (522,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(324,-14,o),
+(392,33,o),
+(440,128,c),
+(370,128,l),
+(395,32,o),
+(453,-14,o),
+(552,-14,cs),
+(681,-14,o),
+(755,60,o),
+(786,210,cs),
+(889,690,l),
+(735,690,l),
+(634,211,ls),
+(622,154,o),
+(595,127,o),
+(550,127,cs),
+(503,127,o),
+(483,156,o),
+(495,212,cs),
+(596,690,l),
+(445,690,l),
+(344,212,ls),
+(332,156,o),
+(303,127,o),
+(258,127,cs),
+(212,127,o),
+(193,157,o),
+(205,214,cs),
+(306,690,l),
+(153,690,l),
+(54,224,ls),
+(23,77,o),
+(89,-14,o),
+(229,-14,cs)
+);
+}
+);
+width = 854;
+}
+);
+metricRight = "=|";
+note = uni15EF;
+unicode = 5615;
+},
+{
+color = 9;
+glyphname = "goCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(160,0,l),
+(262,479,ls),
+(274,536,o),
+(300,563,o),
+(346,563,cs),
+(392,563,o),
+(413,533,o),
+(401,478,cs),
+(299,0,l),
+(450,0,l),
+(552,478,ls),
+(563,534,o),
+(592,563,o),
+(638,563,cs),
+(684,563,o),
+(702,532,o),
+(691,475,cs),
+(589,0,l),
+(743,0,l),
+(841,466,ls),
+(872,612,o),
+(807,704,o),
+(667,704,cs),
+(572,704,o),
+(503,657,o),
+(456,562,c),
+(527,562,l),
+(500,658,o),
+(442,704,o),
+(345,704,cs),
+(215,704,o),
+(141,630,o),
+(109,480,cs),
+(7,0,l)
+);
+}
+);
+width = 854;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F0;
+unicode = 5616;
+},
+{
+color = 9;
+glyphname = "geCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (466,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(402,0,ls),
+(556,0,o),
+(663,73,o),
+(663,215,cs),
+(663,281,o),
+(631,333,o),
+(569,365,c),
+(557,309,l),
+(669,340,o),
+(728,418,o),
+(728,519,cs),
+(728,623,o),
+(648,690,o),
+(533,690,cs),
+(157,690,l),
+(129,560,l),
+(497,560,ls),
+(543,560,o),
+(568,537,o),
+(568,499,cs),
+(568,443,o),
+(531,409,o),
+(465,409,cs),
+(98,409,l),
+(71,281,l),
+(438,281,ls),
+(483,281,o),
+(508,259,o),
+(508,221,cs),
+(508,170,o),
+(478,129,o),
+(405,129,cs),
+(38,129,l),
+(11,0,l)
+);
+}
+);
+width = 734;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15F1;
+unicode = 5617;
+},
+{
+color = 9;
+glyphname = "geeCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(402,0,ls),
+(556,0,o),
+(663,73,o),
+(663,215,cs),
+(663,281,o),
+(631,333,o),
+(569,365,c),
+(557,309,l),
+(669,340,o),
+(728,418,o),
+(728,519,cs),
+(728,623,o),
+(648,690,o),
+(533,690,cs),
+(157,690,l),
+(129,560,l),
+(497,560,ls),
+(543,560,o),
+(568,537,o),
+(568,499,cs),
+(568,443,o),
+(531,409,o),
+(465,409,cs),
+(388,409,l),
+(405,484,l),
+(313,484,l),
+(297,409,l),
+(98,409,l),
+(71,281,l),
+(270,281,l),
+(254,207,l),
+(346,207,l),
+(361,281,l),
+(438,281,ls),
+(483,281,o),
+(508,259,o),
+(508,221,cs),
+(508,170,o),
+(478,129,o),
+(405,129,cs),
+(38,129,l),
+(11,0,l)
+);
+}
+);
+width = 734;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F2;
+unicode = 5618;
+},
+{
+color = 9;
+glyphname = "giCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(402,0,ls),
+(556,0,o),
+(663,73,o),
+(663,215,cs),
+(663,280,o),
+(632,332,o),
+(570,366,c),
+(560,311,l),
+(670,341,o),
+(728,420,o),
+(728,519,cs),
+(728,623,o),
+(648,690,o),
+(533,690,cs),
+(157,690,l),
+(129,560,l),
+(497,560,ls),
+(543,560,o),
+(568,537,o),
+(568,499,cs),
+(568,443,o),
+(531,409,o),
+(465,409,cs),
+(398,409,l),
+(449,365,l),
+(441,418,o),
+(396,459,o),
+(339,459,cs),
+(299,459,o),
+(266,439,o),
+(246,409,c),
+(98,409,l),
+(71,281,l),
+(246,281,l),
+(266,251,o),
+(299,232,o),
+(339,232,cs),
+(395,232,o),
+(438,273,o),
+(448,325,c),
+(388,281,l),
+(438,281,ls),
+(483,281,o),
+(508,259,o),
+(508,221,cs),
+(508,170,o),
+(478,129,o),
+(405,129,cs),
+(38,129,l),
+(11,0,l)
+);
+}
+);
+width = 734;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F3;
+unicode = 5619;
+},
+{
+color = 9;
+glyphname = "gaCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (477,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(619,0,l),
+(646,129,l),
+(280,129,ls),
+(234,129,o),
+(208,153,o),
+(208,190,cs),
+(208,246,o),
+(245,281,o),
+(312,281,cs),
+(679,281,l),
+(706,409,l),
+(339,409,ls),
+(294,409,o),
+(268,431,o),
+(268,469,cs),
+(268,520,o),
+(298,560,o),
+(372,560,cs),
+(739,560,l),
+(766,690,l),
+(375,690,ls),
+(220,690,o),
+(113,616,o),
+(113,474,cs),
+(113,409,o),
+(145,356,o),
+(208,325,c),
+(219,381,l),
+(107,350,o),
+(48,271,o),
+(48,171,cs),
+(48,67,o),
+(128,0,o),
+(243,0,cs)
+);
+}
+);
+width = 734;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|geCarrier-canadian";
+note = uni15F4;
+unicode = 5620;
+},
+{
+color = 9;
+glyphname = "khuCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(316,-14,o),
+(383,27,o),
+(429,108,c),
+(375,111,l),
+(403,27,o),
+(459,-14,o),
+(552,-14,cs),
+(681,-14,o),
+(755,60,o),
+(786,210,cs),
+(889,690,l),
+(153,690,l),
+(54,224,ls),
+(23,77,o),
+(89,-14,o),
+(229,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(212,127,o),
+(193,157,o),
+(205,214,cs),
+(276,554,l),
+(416,554,l),
+(344,212,ls),
+(332,156,o),
+(303,127,o),
+(258,127,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(503,127,o),
+(483,156,o),
+(495,212,cs),
+(568,554,l),
+(706,554,l),
+(634,211,ls),
+(622,154,o),
+(595,127,o),
+(550,127,cs)
+);
+}
+);
+width = 854;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F5;
+unicode = 5621;
+},
+{
+color = 9;
+glyphname = "khoCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(743,0,l),
+(841,466,ls),
+(872,612,o),
+(807,704,o),
+(667,704,cs),
+(580,704,o),
+(513,663,o),
+(467,582,c),
+(521,579,l),
+(493,663,o),
+(437,704,o),
+(345,704,cs),
+(214,704,o),
+(141,630,o),
+(109,480,cs),
+(7,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(262,479,ls),
+(273,536,o),
+(300,563,o),
+(346,563,cs),
+(392,563,o),
+(413,533,o),
+(401,478,cs),
+(328,136,l),
+(189,136,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(552,478,ls),
+(563,534,o),
+(592,563,o),
+(638,563,cs),
+(684,563,o),
+(702,532,o),
+(691,475,cs),
+(619,136,l),
+(479,136,l)
+);
+}
+);
+width = 854;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F6;
+unicode = 5622;
+},
+{
+color = 9;
+glyphname = "kheCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(410,0,ls),
+(564,0,o),
+(671,73,o),
+(671,215,cs),
+(671,280,o),
+(639,330,o),
+(579,363,c),
+(570,311,l),
+(684,343,o),
+(736,427,o),
+(736,519,cs),
+(736,623,o),
+(656,690,o),
+(540,690,cs),
+(156,690,l),
+(10,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(230,282,l),
+(444,282,ls),
+(490,282,o),
+(516,259,o),
+(516,221,cs),
+(516,168,o),
+(482,128,o),
+(412,128,cs),
+(196,128,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(290,562,l),
+(504,562,ls),
+(551,562,o),
+(576,538,o),
+(576,499,cs),
+(576,447,o),
+(542,408,o),
+(472,408,cs),
+(256,408,l)
+);
+}
+);
+width = 742;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F7;
+unicode = 5623;
+},
+{
+color = 9;
+glyphname = "kheeCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(410,0,ls),
+(564,0,o),
+(671,73,o),
+(671,215,cs),
+(671,280,o),
+(639,330,o),
+(579,363,c),
+(570,311,l),
+(684,343,o),
+(736,427,o),
+(736,519,cs),
+(736,623,o),
+(656,690,o),
+(540,690,cs),
+(156,690,l),
+(10,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(230,284,l),
+(323,284,l),
+(306,206,l),
+(406,206,l),
+(427,305,l),
+(389,284,l),
+(444,284,ls),
+(490,284,o),
+(516,260,o),
+(516,222,cs),
+(516,169,o),
+(482,128,o),
+(412,128,cs),
+(196,128,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(465,485,l),
+(365,485,l),
+(349,407,l),
+(256,407,l),
+(290,562,l),
+(504,562,ls),
+(551,562,o),
+(576,538,o),
+(576,499,cs),
+(576,447,o),
+(542,407,o),
+(472,407,cs),
+(415,407,l),
+(444,386,l)
+);
+}
+);
+width = 742;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F8;
+unicode = 5624;
+},
+{
+color = 9;
+glyphname = "khiCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(410,0,ls),
+(564,0,o),
+(671,73,o),
+(671,215,cs),
+(671,279,o),
+(639,331,o),
+(577,363,c),
+(566,309,l),
+(684,342,o),
+(736,427,o),
+(736,519,cs),
+(736,623,o),
+(656,690,o),
+(540,690,cs),
+(156,690,l),
+(10,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(231,287,l),
+(292,287,l),
+(311,254,o),
+(346,232,o),
+(387,232,cs),
+(445,232,o),
+(490,277,o),
+(496,332,c),
+(403,287,l),
+(448,287,ls),
+(494,287,o),
+(516,261,o),
+(516,222,cs),
+(516,169,o),
+(482,128,o),
+(412,128,cs),
+(196,128,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(504,562,ls),
+(551,562,o),
+(576,537,o),
+(576,498,cs),
+(576,445,o),
+(545,404,o),
+(475,404,cs),
+(408,404,l),
+(497,357,l),
+(491,415,o),
+(445,459,o),
+(387,459,cs),
+(328,459,o),
+(282,415,o),
+(277,357,c),
+(330,404,l),
+(256,404,l),
+(290,562,l)
+);
+}
+);
+width = 742;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F9;
+unicode = 5625;
+},
+{
+color = 9;
+glyphname = "khaCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(628,0,l),
+(775,690,l),
+(375,690,ls),
+(220,690,o),
+(113,616,o),
+(113,474,cs),
+(113,410,o),
+(144,359,o),
+(206,327,c),
+(214,379,l),
+(100,347,o),
+(48,263,o),
+(48,171,cs),
+(48,67,o),
+(128,0,o),
+(243,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(234,128,o),
+(208,152,o),
+(208,190,cs),
+(208,242,o),
+(242,282,o),
+(312,282,cs),
+(527,282,l),
+(495,128,l),
+(280,128,ls)
+);
+},
+{
+closed = 1;
+nodes = (
+(294,408,o),
+(269,431,o),
+(269,469,cs),
+(269,522,o),
+(302,562,o),
+(373,562,cs),
+(587,562,l),
+(554,408,l),
+(340,408,ls)
+);
+}
+);
+width = 743;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15FA;
+unicode = 5626;
+},
+{
+color = 9;
+glyphname = "kkuCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(316,-14,o),
+(382,25,o),
+(430,108,c),
+(375,110,l),
+(403,27,o),
+(459,-14,o),
+(552,-14,cs),
+(681,-14,o),
+(754,59,o),
+(786,210,cs),
+(889,690,l),
+(842,690,l),
+(543,562,l),
+(511,402,l),
+(758,501,l),
+(707,558,l),
+(634,211,ls),
+(622,154,o),
+(595,127,o),
+(550,127,cs),
+(503,127,o),
+(483,158,o),
+(494,212,cs),
+(596,690,l),
+(446,690,l),
+(345,212,ls),
+(332,156,o),
+(303,127,o),
+(258,127,cs),
+(212,127,o),
+(193,157,o),
+(205,214,cs),
+(278,559,l),
+(201,524,l),
+(411,413,l),
+(442,560,l),
+(200,690,l),
+(153,690,l),
+(54,224,ls),
+(22,76,o),
+(90,-14,o),
+(229,-14,cs)
+);
+}
+);
+width = 854;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FB;
+unicode = 5627;
+},
+{
+color = 9;
+glyphname = "kkoCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(53,0,l),
+(353,128,l),
+(385,288,l),
+(137,188,l),
+(188,131,l),
+(262,479,ls),
+(273,536,o),
+(300,563,o),
+(346,563,cs),
+(392,563,o),
+(413,531,o),
+(402,478,cs),
+(299,0,l),
+(449,0,l),
+(551,478,ls),
+(563,534,o),
+(592,563,o),
+(638,563,cs),
+(684,563,o),
+(702,532,o),
+(691,475,cs),
+(617,130,l),
+(695,166,l),
+(485,276,l),
+(453,129,l),
+(696,0,l),
+(743,0,l),
+(841,466,ls),
+(873,613,o),
+(806,704,o),
+(667,704,cs),
+(580,704,o),
+(514,665,o),
+(466,582,c),
+(521,580,l),
+(493,663,o),
+(437,704,o),
+(344,704,cs),
+(214,704,o),
+(141,631,o),
+(109,480,cs),
+(7,0,l)
+);
+}
+);
+width = 854;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FC;
+unicode = 5628;
+},
+{
+color = 9;
+glyphname = "kkeCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(423,0,ls),
+(578,0,o),
+(685,72,o),
+(685,215,cs),
+(685,280,o),
+(654,330,o),
+(592,363,c),
+(583,311,l),
+(697,343,o),
+(750,427,o),
+(750,519,cs),
+(750,623,o),
+(670,690,o),
+(554,690,cs),
+(154,690,l),
+(145,651,l),
+(187,409,l),
+(113,409,l),
+(86,281,l),
+(152,281,l),
+(15,39,l),
+(7,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(316,281,l),
+(459,281,ls),
+(504,281,o),
+(530,259,o),
+(530,221,cs),
+(530,171,o),
+(499,129,o),
+(426,129,cs),
+(158,129,l),
+(198,67,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(302,632,l),
+(244,560,l),
+(518,560,ls),
+(564,560,o),
+(590,538,o),
+(590,499,cs),
+(590,443,o),
+(553,409,o),
+(486,409,cs),
+(342,409,l)
+);
+}
+);
+width = 756;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni15FD;
+unicode = 5629;
+},
+{
+color = 9;
+glyphname = "kkeeCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(423,0,ls),
+(578,0,o),
+(685,72,o),
+(685,215,cs),
+(685,280,o),
+(654,330,o),
+(592,363,c),
+(583,311,l),
+(697,343,o),
+(750,427,o),
+(750,519,cs),
+(750,623,o),
+(670,690,o),
+(554,690,cs),
+(154,690,l),
+(145,651,l),
+(187,409,l),
+(113,409,l),
+(86,281,l),
+(152,281,l),
+(15,39,l),
+(7,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(318,285,l),
+(359,285,l),
+(343,206,l),
+(442,206,l),
+(466,315,l),
+(431,285,l),
+(465,285,ls),
+(507,285,o),
+(530,259,o),
+(530,221,cs),
+(530,171,o),
+(499,129,o),
+(426,129,cs),
+(158,129,l),
+(198,67,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(501,485,l),
+(402,485,l),
+(384,405,l),
+(343,405,l),
+(302,632,l),
+(244,560,l),
+(518,560,ls),
+(564,560,o),
+(590,538,o),
+(590,499,cs),
+(590,443,o),
+(553,405,o),
+(489,405,cs),
+(455,405,l),
+(480,384,l)
+);
+}
+);
+width = 756;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FE;
+unicode = 5630;
+},
+{
+color = 9;
+glyphname = "kkiCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(423,0,ls),
+(578,0,o),
+(685,72,o),
+(685,215,cs),
+(685,280,o),
+(654,330,o),
+(592,363,c),
+(583,311,l),
+(697,343,o),
+(750,427,o),
+(750,519,cs),
+(750,623,o),
+(670,690,o),
+(554,690,cs),
+(154,690,l),
+(145,651,l),
+(187,409,l),
+(113,409,l),
+(86,281,l),
+(152,281,l),
+(15,39,l),
+(7,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(319,288,l),
+(323,288,l),
+(341,254,o),
+(376,232,o),
+(417,232,cs),
+(470,232,o),
+(512,270,o),
+(521,319,c),
+(430,288,l),
+(465,288,ls),
+(510,288,o),
+(530,259,o),
+(530,221,cs),
+(530,171,o),
+(499,129,o),
+(426,129,cs),
+(158,129,l),
+(198,67,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(515,419,o),
+(472,459,o),
+(417,459,cs),
+(376,459,o),
+(340,436,o),
+(323,402,c),
+(344,402,l),
+(302,632,l),
+(244,560,l),
+(518,560,ls),
+(564,560,o),
+(590,538,o),
+(590,499,cs),
+(590,443,o),
+(555,402,o),
+(489,402,cs),
+(432,402,l),
+(524,367,l)
+);
+}
+);
+width = 756;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FF;
+unicode = 5631;
+},
+{
+color = 9;
+glyphname = "kkaCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(644,0,l),
+(653,39,l),
+(611,281,l),
+(686,281,l),
+(712,409,l),
+(646,409,l),
+(783,651,l),
+(791,690,l),
+(375,690,ls),
+(220,690,o),
+(113,617,o),
+(113,474,cs),
+(113,410,o),
+(144,359,o),
+(206,327,c),
+(214,379,l),
+(100,347,o),
+(48,263,o),
+(48,171,cs),
+(48,67,o),
+(128,0,o),
+(243,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(554,129,l),
+(280,129,ls),
+(234,129,o),
+(208,152,o),
+(208,190,cs),
+(208,246,o),
+(245,281,o),
+(312,281,cs),
+(456,281,l),
+(496,58,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(294,409,o),
+(268,431,o),
+(268,469,cs),
+(268,519,o),
+(298,560,o),
+(372,560,cs),
+(639,560,l),
+(600,623,l),
+(482,409,l),
+(339,409,ls)
+);
+}
+);
+width = 756;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|kkeCarrier-canadian";
+note = uni1600;
+unicode = 5632;
+},
+{
+color = 6;
+glyphname = "kkCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(326,527,l),
+(174,299,l),
+(251,299,l),
+(195,527,l),
+(95,527,l),
+(91,508,l),
+(180,183,l),
+(204,183,l),
+(432,508,l),
+(436,527,l)
+);
+}
+);
+width = 411;
+}
+);
+note = uni1601;
+unicode = 5633;
+},
+{
+color = 9;
+glyphname = "nuCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(519,-14,o),
+(633,84,o),
+(671,263,cs),
+(683,313,l),
+(524,313,l),
+(516,275,ls),
+(495,179,o),
+(441,130,o),
+(354,130,cs),
+(249,130,o),
+(205,197,o),
+(231,317,cs),
+(309,690,l),
+(149,690,l),
+(72,328,ls),
+(28,122,o),
+(134,-14,o),
+(343,-14,cs)
+);
+}
+);
+width = 715;
+}
+);
+metricLeft = "te-canadian";
+note = uni1602;
+unicode = 5634;
+},
+{
+color = 9;
+glyphname = "noCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(609,0,l),
+(685,361,ls),
+(729,568,o),
+(623,704,o),
+(414,704,cs),
+(239,704,o),
+(125,606,o),
+(86,427,cs),
+(74,377,l),
+(234,377,l),
+(242,414,ls),
+(263,511,o),
+(316,559,o),
+(403,559,cs),
+(508,559,o),
+(553,493,o),
+(526,373,cs),
+(448,0,l)
+);
+}
+);
+width = 716;
+}
+);
+metricLeft = "=|nuCarrier-canadian";
+metricRight = "te-canadian";
+note = uni1603;
+unicode = 5635;
+},
+{
+color = 9;
+glyphname = "neCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (371,344);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(286,0,ls),
+(598,0,o),
+(704,218,o),
+(704,411,cs),
+(704,584,o),
+(594,690,o),
+(402,690,cs),
+(135,690,l),
+(104,546,l),
+(379,546,ls),
+(486,546,o),
+(545,491,o),
+(545,395,cs),
+(545,284,o),
+(483,142,o),
+(302,142,cs),
+(283,142,l),
+(253,0,l)
+);
+}
+);
+width = 729;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1604;
+unicode = 5636;
+},
+{
+color = 9;
+glyphname = "neeCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "neCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (286,-1);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 729;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1605;
+unicode = 5637;
+},
+{
+color = 9;
+glyphname = "niCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "neCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (256,-1);
+ref = dot_middle;
+}
+);
+width = 730;
+}
+);
+note = uni1606;
+unicode = 5638;
+},
+{
+color = 9;
+glyphname = "naCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(637,0,l),
+(667,144,l),
+(392,144,ls),
+(285,144,o),
+(226,199,o),
+(226,295,cs),
+(226,406,o),
+(288,548,o),
+(469,548,cs),
+(488,548,l),
+(518,690,l),
+(485,690,ls),
+(173,690,o),
+(68,471,o),
+(68,279,cs),
+(68,105,o),
+(177,0,o),
+(370,0,cs)
+);
+}
+);
+width = 729;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni1607;
+unicode = 5639;
+},
+{
+color = 9;
+glyphname = "muCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(323,-14,o),
+(393,30,o),
+(440,128,c),
+(370,128,l),
+(395,35,o),
+(453,-14,o),
+(552,-14,cs),
+(681,-14,o),
+(754,60,o),
+(786,210,cs),
+(827,395,l),
+(668,395,l),
+(630,211,ls),
+(617,154,o),
+(591,127,o),
+(552,127,cs),
+(505,127,o),
+(486,159,o),
+(497,211,cs),
+(536,395,l),
+(381,395,l),
+(342,212,ls),
+(329,155,o),
+(300,127,o),
+(259,127,cs),
+(215,127,o),
+(198,157,o),
+(210,214,cs),
+(310,690,l),
+(153,690,l),
+(54,224,ls),
+(23,77,o),
+(89,-14,o),
+(229,-14,cs)
+);
+}
+);
+width = 854;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "=|";
+note = uni1608;
+unicode = 5640;
+},
+{
+color = 9;
+glyphname = "moCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(742,0,l),
+(840,466,ls),
+(871,612,o),
+(806,704,o),
+(666,704,cs),
+(572,704,o),
+(501,660,o),
+(455,562,c),
+(525,562,l),
+(500,655,o),
+(441,704,o),
+(344,704,cs),
+(213,704,o),
+(141,630,o),
+(109,480,cs),
+(69,295,l),
+(227,295,l),
+(266,479,ls),
+(278,536,o),
+(303,563,o),
+(344,563,cs),
+(389,563,o),
+(409,530,o),
+(397,479,cs),
+(358,295,l),
+(514,295,l),
+(553,478,ls),
+(565,535,o),
+(594,563,o),
+(636,563,cs),
+(679,563,o),
+(696,532,o),
+(685,475,cs),
+(584,0,l)
+);
+}
+);
+width = 853;
+}
+);
+metricLeft = "=|muCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni1609;
+unicode = 5641;
+},
+{
+color = 9;
+glyphname = "meCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(406,0,ls),
+(560,0,o),
+(668,73,o),
+(668,215,cs),
+(668,281,o),
+(636,333,o),
+(573,365,c),
+(562,309,l),
+(673,340,o),
+(732,418,o),
+(732,519,cs),
+(732,623,o),
+(653,690,o),
+(537,690,cs),
+(135,690,l),
+(107,560,l),
+(501,560,ls),
+(547,560,o),
+(573,537,o),
+(573,499,cs),
+(573,443,o),
+(535,409,o),
+(469,409,cs),
+(322,409,l),
+(295,281,l),
+(441,281,ls),
+(487,281,o),
+(513,259,o),
+(513,221,cs),
+(513,170,o),
+(482,129,o),
+(409,129,cs),
+(262,129,l),
+(235,0,l)
+);
+}
+);
+width = 739;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160A;
+unicode = 5642;
+},
+{
+color = 9;
+glyphname = "meeCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(406,0,ls),
+(560,0,o),
+(668,73,o),
+(668,215,cs),
+(668,281,o),
+(636,333,o),
+(573,365,c),
+(562,309,l),
+(673,340,o),
+(732,418,o),
+(732,519,cs),
+(732,623,o),
+(653,690,o),
+(537,690,cs),
+(135,690,l),
+(107,560,l),
+(501,560,ls),
+(547,560,o),
+(573,537,o),
+(573,499,cs),
+(573,443,o),
+(535,406,o),
+(469,406,cs),
+(423,406,l),
+(438,476,l),
+(335,476,l),
+(279,213,l),
+(383,213,l),
+(397,284,l),
+(443,284,ls),
+(488,284,o),
+(513,259,o),
+(513,221,cs),
+(513,170,o),
+(482,129,o),
+(409,129,cs),
+(262,129,l),
+(235,0,l)
+);
+}
+);
+width = 739;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160B;
+unicode = 5643;
+},
+{
+color = 9;
+glyphname = "miCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(405,0,ls),
+(555,0,o),
+(642,61,o),
+(663,175,cs),
+(678,260,o),
+(647,327,o),
+(573,365,c),
+(561,309,l),
+(659,335,o),
+(713,395,o),
+(727,479,cs),
+(752,604,o),
+(668,690,o),
+(536,690,cs),
+(135,690,l),
+(107,560,l),
+(500,560,ls),
+(552,560,o),
+(578,531,o),
+(570,485,cs),
+(563,432,o),
+(527,406,o),
+(469,406,cs),
+(383,406,l),
+(471,358,l),
+(463,417,o),
+(418,459,o),
+(359,459,cs),
+(296,459,o),
+(248,407,o),
+(248,345,cs),
+(248,281,o),
+(296,232,o),
+(359,232,cs),
+(417,232,o),
+(462,274,o),
+(470,329,c),
+(382,284,l),
+(441,284,ls),
+(493,284,o),
+(519,256,o),
+(511,206,cs),
+(503,156,o),
+(469,129,o),
+(408,129,cs),
+(261,129,l),
+(234,0,l)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160C;
+unicode = 5644;
+},
+{
+color = 9;
+glyphname = "maCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(646,0,l),
+(673,129,l),
+(280,129,ls),
+(234,129,o),
+(208,153,o),
+(208,190,cs),
+(208,246,o),
+(245,281,o),
+(312,281,cs),
+(459,281,l),
+(486,409,l),
+(339,409,ls),
+(294,409,o),
+(268,431,o),
+(268,469,cs),
+(268,520,o),
+(298,560,o),
+(372,560,cs),
+(519,560,l),
+(546,690,l),
+(375,690,ls),
+(220,690,o),
+(113,616,o),
+(113,474,cs),
+(113,409,o),
+(145,356,o),
+(208,325,c),
+(219,381,l),
+(107,350,o),
+(48,271,o),
+(48,171,cs),
+(48,67,o),
+(128,0,o),
+(243,0,cs)
+);
+}
+);
+width = 738;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni160D;
+unicode = 5645;
+},
+{
+color = 9;
+glyphname = "yuCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(554,-14,o),
+(688,114,o),
+(738,350,cs),
+(783,564,o),
+(723,704,o),
+(564,704,cs),
+(412,704,o),
+(344,572,o),
+(344,451,cs),
+(344,353,o),
+(399,286,o),
+(486,286,cs),
+(497,286,o),
+(507,288,o),
+(526,291,c),
+(553,416,l),
+(549,415,o),
+(544,415,o),
+(538,415,cs),
+(501,415,o),
+(484,433,o),
+(484,467,cs),
+(484,502,o),
+(500,575,o),
+(552,575,cs),
+(608,575,o),
+(616,503,o),
+(591,384,cs),
+(555,209,o),
+(491,130,o),
+(378,130,cs),
+(260,130,o),
+(209,215,o),
+(237,344,cs),
+(310,690,l),
+(150,690,l),
+(76,347,ls),
+(32,136,o),
+(144,-14,o),
+(360,-14,cs)
+);
+}
+);
+width = 771;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160E;
+unicode = 5646;
+},
+{
+color = 9;
+glyphname = "yoCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(401,-14,o),
+(469,118,o),
+(469,239,cs),
+(469,337,o),
+(415,404,o),
+(327,404,cs),
+(317,404,o),
+(306,402,o),
+(287,399,c),
+(261,273,l),
+(266,274,o),
+(270,274,o),
+(276,274,cs),
+(312,274,o),
+(330,257,o),
+(330,223,cs),
+(330,187,o),
+(314,115,o),
+(263,115,cs),
+(207,115,o),
+(197,186,o),
+(222,305,cs),
+(258,481,o),
+(324,559,o),
+(437,559,cs),
+(554,559,o),
+(605,474,o),
+(578,346,cs),
+(504,0,l),
+(665,0,l),
+(737,343,ls),
+(782,554,o),
+(670,704,o),
+(454,704,cs),
+(260,704,o),
+(126,576,o),
+(75,340,cs),
+(30,126,o),
+(91,-14,o),
+(250,-14,cs)
+);
+}
+);
+width = 772;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160F;
+unicode = 5647;
+},
+{
+color = 9;
+glyphname = "yeCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(574,-14,o),
+(698,207,o),
+(698,406,cs),
+(698,584,o),
+(587,690,o),
+(390,690,cs),
+(156,690,l),
+(127,546,l),
+(363,546,ls),
+(478,546,o),
+(538,492,o),
+(538,393,cs),
+(538,267,o),
+(487,121,o),
+(323,121,cs),
+(234,121,o),
+(184,154,o),
+(184,211,cs),
+(184,245,o),
+(201,296,o),
+(247,296,cs),
+(276,296,o),
+(293,277,o),
+(293,244,cs),
+(293,226,o),
+(288,202,o),
+(281,185,c),
+(408,185,l),
+(418,212,o),
+(426,243,o),
+(426,271,cs),
+(426,362,o),
+(360,422,o),
+(256,422,cs),
+(120,422,o),
+(43,306,o),
+(43,192,cs),
+(43,66,o),
+(147,-14,o),
+(317,-14,cs)
+);
+}
+);
+width = 724;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1610;
+unicode = 5648;
+},
+{
+color = 9;
+glyphname = "yeeCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(571,-14,o),
+(698,204,o),
+(698,406,cs),
+(698,584,o),
+(585,690,o),
+(390,690,cs),
+(156,690,l),
+(127,546,l),
+(363,546,ls),
+(478,546,o),
+(537,492,o),
+(537,388,cs),
+(537,303,o),
+(509,121,o),
+(323,121,cs),
+(234,121,o),
+(184,153,o),
+(184,209,cs),
+(184,243,o),
+(201,296,o),
+(248,296,cs),
+(285,296,o),
+(300,267,o),
+(291,226,cs),
+(283,189,l),
+(375,189,l),
+(438,483,l),
+(346,483,l),
+(311,324,l),
+(326,323,l),
+(335,383,o),
+(297,422,o),
+(228,422,cs),
+(109,422,o),
+(44,306,o),
+(44,198,cs),
+(44,69,o),
+(147,-14,o),
+(320,-14,cs)
+);
+}
+);
+width = 724;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1611;
+unicode = 5649;
+},
+{
+color = 9;
+glyphname = "yiCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(569,-14,o),
+(698,199,o),
+(698,406,cs),
+(698,584,o),
+(586,690,o),
+(390,690,cs),
+(156,690,l),
+(127,546,l),
+(363,546,ls),
+(478,546,o),
+(537,492,o),
+(537,388,cs),
+(537,296,o),
+(504,121,o),
+(323,121,cs),
+(233,121,o),
+(183,154,o),
+(183,211,cs),
+(183,262,o),
+(213,308,o),
+(289,297,c),
+(247,344,l),
+(247,293,o),
+(289,252,o),
+(342,252,cs),
+(396,252,o),
+(437,293,o),
+(437,346,cs),
+(437,398,o),
+(396,438,o),
+(342,438,cs),
+(311,438,o),
+(285,425,o),
+(269,404,c),
+(130,398,o),
+(42,319,o),
+(42,191,cs),
+(42,70,o),
+(147,-14,o),
+(317,-14,cs)
+);
+}
+);
+width = 724;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1612;
+unicode = 5650;
+},
+{
+color = 9;
+glyphname = "yaCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(610,0,l),
+(640,144,l),
+(404,144,ls),
+(288,144,o),
+(229,198,o),
+(229,297,cs),
+(229,423,o),
+(280,569,o),
+(443,569,cs),
+(532,569,o),
+(582,536,o),
+(582,479,cs),
+(582,444,o),
+(565,394,o),
+(520,394,cs),
+(490,394,o),
+(474,412,o),
+(474,445,cs),
+(474,465,o),
+(479,488,o),
+(485,505,c),
+(358,505,l),
+(348,478,o),
+(341,446,o),
+(341,418,cs),
+(341,327,o),
+(407,268,o),
+(510,268,cs),
+(647,268,o),
+(724,384,o),
+(724,497,cs),
+(724,624,o),
+(620,704,o),
+(449,704,cs),
+(192,704,o),
+(68,483,o),
+(68,284,cs),
+(68,105,o),
+(180,0,o),
+(376,0,cs)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|yeCarrier-canadian";
+note = uni1613;
+unicode = 5651;
+},
+{
+color = 9;
+glyphname = "juCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(553,-14,o),
+(684,93,o),
+(684,251,cs),
+(684,352,o),
+(619,422,o),
+(514,422,cs),
+(397,422,o),
+(326,336,o),
+(311,233,cs),
+(308,217,o),
+(307,201,o),
+(308,185,c),
+(435,185,l),
+(435,193,o),
+(437,207,o),
+(440,221,cs),
+(447,263,o),
+(469,296,o),
+(503,296,cs),
+(529,296,o),
+(545,277,o),
+(545,245,cs),
+(545,176,o),
+(493,121,o),
+(398,121,cs),
+(289,121,o),
+(229,172,o),
+(229,264,cs),
+(229,445,o),
+(380,546,o),
+(586,546,cs),
+(740,546,l),
+(771,690,l),
+(148,690,l),
+(118,553,l),
+(377,553,l),
+(498,608,l),
+(263,602,o),
+(71,476,o),
+(71,257,cs),
+(71,100,o),
+(194,-14,o),
+(378,-14,cs)
+);
+}
+);
+width = 738;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni1614;
+unicode = 5652;
+},
+{
+color = 9;
+glyphname = "juSayisi-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (468,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(546,-14,o),
+(680,145,o),
+(691,332,cs),
+(701,502,o),
+(592,604,o),
+(380,610,c),
+(492,553,l),
+(751,553,l),
+(780,690,l),
+(156,690,l),
+(125,546,l),
+(291,546,ls),
+(467,546,o),
+(545,478,o),
+(534,345,cs),
+(528,257,o),
+(498,121,o),
+(326,121,cs),
+(231,121,o),
+(182,156,o),
+(186,218,cs),
+(187,256,o),
+(207,296,o),
+(246,296,cs),
+(278,296,o),
+(292,275,o),
+(290,237,cs),
+(290,219,o),
+(286,201,o),
+(279,185,c),
+(406,185,l),
+(416,210,o),
+(422,236,o),
+(423,261,cs),
+(429,357,o),
+(364,422,o),
+(256,422,cs),
+(135,422,o),
+(52,331,o),
+(45,212,cs),
+(37,76,o),
+(142,-14,o),
+(321,-14,cs)
+);
+}
+);
+width = 739;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1615;
+unicode = 5653;
+},
+{
+color = 9;
+glyphname = "joCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(632,0,l),
+(661,137,l),
+(402,137,l),
+(281,82,l),
+(516,88,o),
+(709,213,o),
+(709,433,cs),
+(709,589,o),
+(584,704,o),
+(402,704,cs),
+(226,704,o),
+(96,597,o),
+(96,439,cs),
+(96,338,o),
+(160,268,o),
+(266,268,cs),
+(383,268,o),
+(453,354,o),
+(469,457,cs),
+(470,472,o),
+(471,489,o),
+(471,505,c),
+(344,505,l),
+(344,497,o),
+(343,483,o),
+(340,469,cs),
+(331,427,o),
+(310,394,o),
+(276,394,cs),
+(249,394,o),
+(235,412,o),
+(235,444,cs),
+(235,514,o),
+(287,569,o),
+(381,569,cs),
+(491,569,o),
+(550,518,o),
+(550,426,cs),
+(550,244,o),
+(400,144,o),
+(193,144,cs),
+(39,144,l),
+(9,0,l)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1616;
+unicode = 5654;
+},
+{
+color = 9;
+glyphname = "jeCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(675,-14,o),
+(744,254,o),
+(744,415,cs),
+(744,590,o),
+(657,704,o),
+(506,704,cs),
+(384,704,o),
+(293,628,o),
+(245,490,c),
+(271,486,l),
+(316,690,l),
+(156,690,l),
+(10,0,l),
+(170,0,l),
+(229,274,ls),
+(268,457,o),
+(353,559,o),
+(468,559,cs),
+(550,559,o),
+(591,506,o),
+(591,405,cs),
+(591,335,o),
+(562,115,o),
+(475,115,cs),
+(444,115,o),
+(427,135,o),
+(427,168,cs),
+(427,217,o),
+(454,274,o),
+(513,274,cs),
+(520,274,o),
+(526,274,o),
+(531,273,c),
+(556,399,l),
+(536,402,o),
+(521,404,o),
+(505,404,cs),
+(355,404,o),
+(289,271,o),
+(289,156,cs),
+(289,51,o),
+(354,-14,o),
+(462,-14,cs)
+);
+}
+);
+width = 778;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "te-canadian";
+note = uni1617;
+unicode = 5655;
+},
+{
+color = 9;
+glyphname = "jeeCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(674,-14,o),
+(744,254,o),
+(744,413,cs),
+(744,590,o),
+(657,704,o),
+(506,704,cs),
+(384,704,o),
+(293,628,o),
+(245,488,c),
+(271,486,l),
+(316,690,l),
+(156,690,l),
+(10,0,l),
+(170,0,l),
+(228,269,ls),
+(269,457,o),
+(352,559,o),
+(467,559,cs),
+(550,559,o),
+(592,506,o),
+(592,405,cs),
+(592,307,o),
+(555,115,o),
+(450,115,cs),
+(404,115,o),
+(378,142,o),
+(378,188,cs),
+(378,231,o),
+(393,278,o),
+(433,298,c),
+(417,224,l),
+(497,224,l),
+(548,462,l),
+(468,462,l),
+(451,384,l),
+(335,357,o),
+(289,249,o),
+(289,155,cs),
+(289,53,o),
+(355,-14,o),
+(463,-14,cs)
+);
+}
+);
+width = 778;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1618;
+unicode = 5656;
+},
+{
+color = 9;
+glyphname = "jiCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(674,-14,o),
+(744,254,o),
+(744,413,cs),
+(744,590,o),
+(657,704,o),
+(506,704,cs),
+(384,704,o),
+(293,628,o),
+(245,488,c),
+(271,486,l),
+(316,690,l),
+(156,690,l),
+(10,0,l),
+(170,0,l),
+(228,269,ls),
+(269,457,o),
+(352,559,o),
+(467,559,cs),
+(550,559,o),
+(592,506,o),
+(592,405,cs),
+(592,307,o),
+(555,115,o),
+(450,115,cs),
+(404,115,o),
+(378,142,o),
+(378,188,cs),
+(378,214,o),
+(384,246,o),
+(403,266,c),
+(416,257,o),
+(433,250,o),
+(452,250,cs),
+(504,250,o),
+(542,293,o),
+(542,344,cs),
+(542,397,o),
+(503,436,o),
+(451,436,cs),
+(397,436,o),
+(357,390,o),
+(361,333,c),
+(309,289,o),
+(289,218,o),
+(289,155,cs),
+(289,53,o),
+(355,-14,o),
+(463,-14,cs)
+);
+}
+);
+width = 778;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1619;
+unicode = 5657;
+},
+{
+color = 9;
+glyphname = "jiSayisi-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(650,-14,o),
+(760,291,o),
+(760,480,cs),
+(760,621,o),
+(695,704,o),
+(575,704,cs),
+(422,704,o),
+(352,564,o),
+(352,447,cs),
+(352,351,o),
+(407,286,o),
+(495,286,cs),
+(511,286,o),
+(525,288,o),
+(533,291,c),
+(560,416,l),
+(554,415,o),
+(549,415,o),
+(544,415,cs),
+(508,415,o),
+(490,432,o),
+(490,466,cs),
+(490,498,o),
+(508,575,o),
+(560,575,cs),
+(594,575,o),
+(611,546,o),
+(611,491,cs),
+(611,401,o),
+(566,130,o),
+(390,130,cs),
+(236,130,o),
+(233,292,o),
+(263,432,cs),
+(317,690,l),
+(156,690,l),
+(10,0,l),
+(169,0,l),
+(218,237,l),
+(194,239,l),
+(176,100,o),
+(248,-14,o),
+(398,-14,cs)
+);
+}
+);
+width = 778;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161A;
+unicode = 5658;
+},
+{
+color = 9;
+glyphname = "jaCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (476,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(436,-14,o),
+(527,62,o),
+(575,201,c),
+(548,205,l),
+(504,1,l),
+(664,1,l),
+(810,691,l),
+(650,691,l),
+(591,416,ls),
+(553,234,o),
+(468,131,o),
+(353,131,cs),
+(270,131,o),
+(229,184,o),
+(229,285,cs),
+(229,355,o),
+(258,576,o),
+(345,576,cs),
+(376,576,o),
+(393,555,o),
+(393,522,cs),
+(393,472,o),
+(366,416,o),
+(307,416,cs),
+(300,416,o),
+(294,416,o),
+(289,417,c),
+(264,292,l),
+(284,289,o),
+(299,287,o),
+(315,287,cs),
+(465,287,o),
+(531,419,o),
+(531,534,cs),
+(531,639,o),
+(467,704,o),
+(358,704,cs),
+(145,704,o),
+(76,437,o),
+(76,275,cs),
+(76,99,o),
+(163,-14,o),
+(314,-14,cs)
+);
+}
+);
+width = 778;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni161B;
+unicode = 5659;
+},
+{
+color = 9;
+glyphname = "jjuCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(553,-14,o),
+(676,95,o),
+(676,253,cs),
+(676,354,o),
+(611,422,o),
+(506,422,cs),
+(403,422,o),
+(327,355,o),
+(304,248,cs),
+(299,227,o),
+(297,206,o),
+(297,185,c),
+(424,185,l),
+(425,193,o),
+(427,211,o),
+(431,227,cs),
+(441,270,o),
+(463,296,o),
+(495,296,cs),
+(522,296,o),
+(536,277,o),
+(536,246,cs),
+(536,177,o),
+(486,120,o),
+(389,120,cs),
+(283,120,o),
+(226,176,o),
+(226,270,cs),
+(226,454,o),
+(354,546,o),
+(557,546,cs),
+(730,546,l),
+(760,690,l),
+(576,690,ls),
+(460,690,o),
+(356,666,o),
+(274,619,c),
+(209,704,l),
+(79,603,l),
+(148,514,l),
+(96,449,o),
+(70,364,o),
+(70,273,cs),
+(70,106,o),
+(188,-14,o),
+(376,-14,cs)
+);
+}
+);
+width = 730;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni161C;
+unicode = 5660;
+},
+{
+color = 9;
+glyphname = "jjoCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(694,87,l),
+(624,176,l),
+(676,241,o),
+(702,326,o),
+(702,416,cs),
+(702,583,o),
+(583,704,o),
+(397,704,cs),
+(220,704,o),
+(96,595,o),
+(96,437,cs),
+(96,336,o),
+(161,268,o),
+(266,268,cs),
+(370,268,o),
+(445,334,o),
+(469,441,cs),
+(473,463,o),
+(475,484,o),
+(476,505,c),
+(349,505,l),
+(348,497,o),
+(345,479,o),
+(341,463,cs),
+(331,420,o),
+(310,394,o),
+(278,394,cs),
+(251,394,o),
+(236,412,o),
+(236,443,cs),
+(236,513,o),
+(287,570,o),
+(384,570,cs),
+(490,570,o),
+(546,514,o),
+(546,419,cs),
+(546,236,o),
+(418,144,o),
+(214,144,cs),
+(43,144,l),
+(12,0,l),
+(197,0,ls),
+(312,0,o),
+(415,24,o),
+(498,71,c),
+(564,-14,l)
+);
+}
+);
+width = 731;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|jjuCarrier-canadian";
+note = uni161D;
+unicode = 5661;
+},
+{
+color = 9;
+glyphname = "jjeCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(689,-14,o),
+(757,257,o),
+(757,414,cs),
+(757,596,o),
+(662,704,o),
+(485,704,cs),
+(405,704,o),
+(332,679,o),
+(271,633,c),
+(212,704,l),
+(86,598,l),
+(161,507,l),
+(130,455,o),
+(106,393,o),
+(92,321,cs),
+(23,0,l),
+(184,0,l),
+(247,299,ls),
+(284,469,o),
+(363,559,o),
+(475,559,cs),
+(562,559,o),
+(605,507,o),
+(605,405,cs),
+(605,336,o),
+(576,115,o),
+(488,115,cs),
+(458,115,o),
+(440,135,o),
+(440,169,cs),
+(440,218,o),
+(468,274,o),
+(524,274,cs),
+(531,274,o),
+(538,274,o),
+(545,273,c),
+(570,399,l),
+(556,402,o),
+(535,404,o),
+(519,404,cs),
+(369,404,o),
+(302,271,o),
+(302,156,cs),
+(302,52,o),
+(366,-14,o),
+(475,-14,cs)
+);
+}
+);
+width = 791;
+}
+);
+metricRight = "jeCarrier-canadian";
+note = uni161E;
+unicode = 5662;
+},
+{
+color = 9;
+glyphname = "jjeeCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(689,-14,o),
+(757,257,o),
+(757,414,cs),
+(757,596,o),
+(662,704,o),
+(485,704,cs),
+(405,704,o),
+(332,679,o),
+(271,633,c),
+(212,704,l),
+(86,598,l),
+(161,507,l),
+(130,455,o),
+(106,393,o),
+(92,321,cs),
+(23,0,l),
+(184,0,l),
+(247,299,ls),
+(284,469,o),
+(363,559,o),
+(475,559,cs),
+(562,559,o),
+(605,507,o),
+(605,405,cs),
+(605,329,o),
+(578,115,o),
+(466,115,cs),
+(420,115,o),
+(390,141,o),
+(390,189,cs),
+(390,238,o),
+(408,281,o),
+(445,298,c),
+(430,224,l),
+(510,224,l),
+(560,460,l),
+(480,460,l),
+(464,384,l),
+(353,359,o),
+(302,256,o),
+(302,156,cs),
+(302,52,o),
+(366,-14,o),
+(475,-14,cs)
+);
+}
+);
+width = 791;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161F;
+unicode = 5663;
+},
+{
+color = 9;
+glyphname = "jjiCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(618,-14,o),
+(707,110,o),
+(744,289,cs),
+(793,541,o),
+(696,704,o),
+(482,704,cs),
+(401,704,o),
+(329,680,o),
+(270,635,c),
+(212,704,l),
+(86,598,l),
+(161,509,l),
+(129,456,o),
+(106,393,o),
+(91,321,cs),
+(22,0,l),
+(183,0,l),
+(247,299,ls),
+(283,469,o),
+(362,559,o),
+(475,559,cs),
+(585,559,o),
+(626,472,o),
+(593,302,cs),
+(570,190,o),
+(535,115,o),
+(463,115,cs),
+(408,115,o),
+(382,154,o),
+(394,218,cs),
+(397,240,o),
+(404,260,o),
+(419,270,c),
+(434,258,o),
+(453,250,o),
+(475,250,cs),
+(528,250,o),
+(565,294,o),
+(565,344,cs),
+(565,396,o),
+(526,436,o),
+(474,436,cs),
+(418,436,o),
+(384,388,o),
+(384,342,c),
+(343,312,o),
+(318,264,o),
+(307,207,cs),
+(281,75,o),
+(352,-14,o),
+(475,-14,cs)
+);
+}
+);
+width = 790;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1620;
+unicode = 5664;
+},
+{
+color = 9;
+glyphname = "jjaCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(428,-14,o),
+(501,11,o),
+(562,57,c),
+(621,-14,l),
+(747,92,l),
+(671,183,l),
+(702,235,o),
+(726,297,o),
+(742,369,cs),
+(811,690,l),
+(650,690,l),
+(585,390,ls),
+(550,221,o),
+(470,130,o),
+(357,130,cs),
+(271,130,o),
+(229,183,o),
+(229,285,cs),
+(229,354,o),
+(258,575,o),
+(345,575,cs),
+(376,575,o),
+(393,554,o),
+(393,521,cs),
+(393,471,o),
+(366,415,o),
+(310,415,cs),
+(301,415,o),
+(296,415,o),
+(289,416,c),
+(264,291,l),
+(277,288,o),
+(299,286,o),
+(314,286,cs),
+(465,286,o),
+(531,418,o),
+(531,533,cs),
+(531,638,o),
+(467,704,o),
+(357,704,cs),
+(145,704,o),
+(76,433,o),
+(76,275,cs),
+(76,94,o),
+(172,-14,o),
+(349,-14,cs)
+);
+}
+);
+width = 791;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "=|jjeCarrier-canadian";
+note = uni1621;
+unicode = 5665;
+},
+{
+color = 9;
+glyphname = "luCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(526,-14,o),
+(640,85,o),
+(680,270,cs),
+(769,690,l),
+(609,690,l),
+(524,291,ls),
+(501,185,o),
+(444,130,o),
+(358,130,cs),
+(276,130,o),
+(229,179,o),
+(229,264,cs),
+(229,389,o),
+(308,543,o),
+(456,561,c),
+(484,690,l),
+(147,690,l),
+(118,557,l),
+(299,557,l),
+(433,607,l),
+(210,600,o),
+(69,446,o),
+(69,248,cs),
+(69,92,o),
+(179,-14,o),
+(354,-14,cs)
+);
+}
+);
+width = 730;
+}
+);
+metricRight = "te-canadian";
+note = uni1622;
+unicode = 5666;
+},
+{
+color = 9;
+glyphname = "loCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(163,0,l),
+(247,399,ls),
+(270,504,o),
+(327,559,o),
+(413,559,cs),
+(496,559,o),
+(542,511,o),
+(542,426,cs),
+(542,300,o),
+(463,147,o),
+(315,128,c),
+(287,0,l),
+(625,0,l),
+(653,132,l),
+(471,132,l),
+(339,83,l),
+(561,90,o),
+(703,243,o),
+(703,441,cs),
+(703,598,o),
+(592,704,o),
+(418,704,cs),
+(246,704,o),
+(131,605,o),
+(92,420,cs),
+(3,0,l)
+);
+}
+);
+width = 729;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|luCarrier-canadian";
+note = uni1623;
+unicode = 5667;
+},
+{
+color = 9;
+glyphname = "leCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (375,351);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(279,0,ls),
+(616,0,o),
+(697,248,o),
+(697,424,cs),
+(697,588,o),
+(608,704,o),
+(467,704,cs),
+(373,704,o),
+(295,653,o),
+(258,568,c),
+(270,567,l),
+(297,690,l),
+(153,690,l),
+(86,374,l),
+(221,374,l),
+(255,494,o),
+(322,559,o),
+(410,559,cs),
+(491,559,o),
+(538,500,o),
+(538,408,cs),
+(538,277,o),
+(468,144,o),
+(290,144,cs),
+(37,144,l),
+(6,0,l)
+);
+}
+);
+width = 721;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1624;
+unicode = 5668;
+},
+{
+color = 9;
+glyphname = "leeCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "leCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (290,6);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 721;
+}
+);
+metricLeft = "leCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1625;
+unicode = 5669;
+},
+{
+color = 9;
+glyphname = "liCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "leCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (260,6);
+ref = dot_middle;
+}
+);
+width = 723;
+}
+);
+note = uni1626;
+unicode = 5670;
+},
+{
+color = 9;
+glyphname = "laCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(610,0,l),
+(641,144,l),
+(408,144,ls),
+(284,144,o),
+(228,197,o),
+(228,295,cs),
+(228,393,o),
+(277,559,o),
+(425,559,cs),
+(520,559,o),
+(569,489,o),
+(554,374,c),
+(691,374,l),
+(757,690,l),
+(613,690,l),
+(582,546,l),
+(594,543,l),
+(584,641,o),
+(514,704,o),
+(411,704,cs),
+(177,704,o),
+(67,460,o),
+(67,281,cs),
+(67,105,o),
+(178,0,o),
+(383,0,cs)
+);
+}
+);
+width = 722;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|leCarrier-canadian";
+note = uni1627;
+unicode = 5671;
+},
+{
+color = 1;
+glyphname = "dluCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(598,-14,o),
+(685,211,o),
+(685,367,cs),
+(685,503,o),
+(606,588,o),
+(460,616,c),
+(524,569,l),
+(722,569,l),
+(705,493,l),
+(821,493,l),
+(880,766,l),
+(763,766,l),
+(747,690,l),
+(434,690,l),
+(407,561,l),
+(488,547,o),
+(533,488,o),
+(533,395,cs),
+(533,301,o),
+(490,130,o),
+(345,130,cs),
+(248,130,o),
+(206,198,o),
+(230,313,cs),
+(309,690,l),
+(149,690,l),
+(70,317,ls),
+(27,115,o),
+(132,-14,o),
+(335,-14,cs)
+);
+}
+);
+width = 801;
+}
+);
+metricLeft = "te-canadian";
+note = uni1628;
+unicode = 5672;
+},
+{
+color = 9;
+glyphname = "dloCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(700,-76,l),
+(759,197,l),
+(642,197,l),
+(626,121,l),
+(466,121,l),
+(453,104,l),
+(597,138,o),
+(703,263,o),
+(703,441,cs),
+(703,598,o),
+(592,704,o),
+(418,704,cs),
+(246,704,o),
+(131,605,o),
+(92,420,cs),
+(3,0,l),
+(163,0,l),
+(247,399,ls),
+(270,504,o),
+(327,559,o),
+(413,559,cs),
+(496,559,o),
+(542,511,o),
+(542,426,cs),
+(542,300,o),
+(463,147,o),
+(315,128,c),
+(287,0,l),
+(601,0,l),
+(584,-76,l)
+);
+}
+);
+width = 801;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "dluCarrier-canadian";
+note = uni1629;
+unicode = 5673;
+},
+{
+color = 9;
+glyphname = "dleCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (390,351);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(294,0,ls),
+(631,0,o),
+(712,248,o),
+(712,424,cs),
+(712,588,o),
+(622,704,o),
+(481,704,cs),
+(381,704,o),
+(270,634,o),
+(226,520,c),
+(239,521,l),
+(275,694,l),
+(359,694,l),
+(383,806,l),
+(117,806,l),
+(94,694,l),
+(168,694,l),
+(100,374,l),
+(236,374,l),
+(270,494,o),
+(336,559,o),
+(424,559,cs),
+(505,559,o),
+(553,500,o),
+(553,408,cs),
+(553,277,o),
+(482,144,o),
+(304,144,cs),
+(51,144,l),
+(20,0,l)
+);
+}
+);
+width = 736;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni162A;
+unicode = 5674;
+},
+{
+color = 9;
+glyphname = "dleeCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (304,6);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 737;
+}
+);
+note = uni162B;
+unicode = 5675;
+},
+{
+color = 9;
+glyphname = "dliCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (275,6);
+ref = dot_middle;
+}
+);
+width = 737;
+}
+);
+note = uni162C;
+unicode = 5676;
+},
+{
+color = 9;
+glyphname = "dlaCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(610,0,l),
+(641,144,l),
+(408,144,ls),
+(284,144,o),
+(228,197,o),
+(228,295,cs),
+(228,393,o),
+(277,559,o),
+(425,559,cs),
+(520,559,o),
+(569,489,o),
+(554,374,c),
+(691,374,l),
+(758,694,l),
+(833,694,l),
+(857,806,l),
+(590,806,l),
+(567,694,l),
+(642,694,l),
+(610,541,l),
+(620,538,l),
+(610,641,o),
+(514,704,o),
+(411,704,cs),
+(177,704,o),
+(67,460,o),
+(67,281,cs),
+(67,105,o),
+(178,0,o),
+(383,0,cs)
+);
+}
+);
+width = 736;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni162D;
+unicode = 5677;
+},
+{
+color = 9;
+glyphname = "lhuCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(588,-14,o),
+(705,169,o),
+(705,358,cs),
+(705,490,o),
+(637,586,o),
+(522,608,c),
+(580,554,l),
+(761,554,l),
+(789,690,l),
+(522,690,l),
+(495,561,l),
+(532,532,o),
+(553,475,o),
+(553,408,cs),
+(553,302,o),
+(505,130,o),
+(369,130,cs),
+(284,130,o),
+(236,183,o),
+(236,273,cs),
+(236,362,o),
+(281,510,o),
+(385,561,c),
+(413,690,l),
+(146,690,l),
+(117,554,l),
+(299,554,l),
+(381,611,l),
+(186,585,o),
+(74,426,o),
+(74,253,cs),
+(74,93,o),
+(187,-14,o),
+(367,-14,cs)
+);
+}
+);
+width = 748;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162E;
+unicode = 5678;
+},
+{
+color = 9;
+glyphname = "lhoCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(268,0,l),
+(295,128,l),
+(257,157,o),
+(237,214,o),
+(237,282,cs),
+(237,387,o),
+(284,559,o),
+(420,559,cs),
+(505,559,o),
+(554,507,o),
+(554,416,cs),
+(554,327,o),
+(508,180,o),
+(404,128,c),
+(376,0,l),
+(643,0,l),
+(672,135,l),
+(490,135,l),
+(409,79,l),
+(603,104,o),
+(714,264,o),
+(714,437,cs),
+(714,597,o),
+(602,704,o),
+(422,704,cs),
+(201,704,o),
+(84,521,o),
+(84,331,cs),
+(84,200,o),
+(153,103,o),
+(268,82,c),
+(210,135,l),
+(28,135,l),
+(0,0,l)
+);
+}
+);
+width = 748;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162F;
+unicode = 5679;
+},
+{
+color = 9;
+glyphname = "lheCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (387,345);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(614,-14,o),
+(720,236,o),
+(720,420,cs),
+(720,590,o),
+(627,704,o),
+(479,704,cs),
+(386,704,o),
+(308,658,o),
+(270,579,c),
+(277,578,l),
+(300,690,l),
+(156,690,l),
+(97,408,l),
+(232,408,l),
+(273,509,o),
+(339,559,o),
+(421,559,cs),
+(510,559,o),
+(560,502,o),
+(560,405,cs),
+(560,295,o),
+(497,130,o),
+(359,130,cs),
+(269,130,o),
+(211,189,o),
+(206,282,c),
+(71,282,l),
+(11,0,l),
+(154,0,l),
+(185,144,l),
+(166,141,l),
+(184,47,o),
+(269,-14,o),
+(384,-14,cs)
+);
+}
+);
+width = 744;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1630;
+unicode = 5680;
+},
+{
+color = 9;
+glyphname = "lheeCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (302,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 745;
+}
+);
+note = uni1631;
+unicode = 5681;
+},
+{
+color = 9;
+glyphname = "lhiCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (273,0);
+ref = dot_middle;
+}
+);
+width = 745;
+}
+);
+note = uni1632;
+unicode = 5682;
+},
+{
+color = 9;
+glyphname = "lhaCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(399,-14,o),
+(477,32,o),
+(516,111,c),
+(508,112,l),
+(484,0,l),
+(628,0,l),
+(689,282,l),
+(553,282,l),
+(512,181,o),
+(445,130,o),
+(364,130,cs),
+(275,130,o),
+(225,187,o),
+(225,285,cs),
+(225,395,o),
+(288,559,o),
+(426,559,cs),
+(517,559,o),
+(575,500,o),
+(579,408,c),
+(715,408,l),
+(775,690,l),
+(631,690,l),
+(601,546,l),
+(619,549,l),
+(602,642,o),
+(517,704,o),
+(404,704,cs),
+(171,704,o),
+(66,454,o),
+(66,270,cs),
+(66,99,o),
+(158,-14,o),
+(306,-14,cs)
+);
+}
+);
+width = 743;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1633;
+unicode = 5683;
+},
+{
+color = 9;
+glyphname = "tlhuCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(588,-14,o),
+(705,169,o),
+(705,358,cs),
+(705,480,o),
+(661,581,o),
+(546,608,c),
+(548,569,l),
+(740,569,l),
+(723,493,l),
+(839,493,l),
+(897,766,l),
+(781,766,l),
+(764,690,l),
+(522,690,l),
+(495,561,l),
+(532,532,o),
+(553,475,o),
+(553,408,cs),
+(553,302,o),
+(505,130,o),
+(369,130,cs),
+(284,130,o),
+(236,183,o),
+(236,273,cs),
+(236,362,o),
+(281,510,o),
+(385,561,c),
+(413,690,l),
+(146,690,l),
+(117,554,l),
+(301,554,l),
+(355,602,l),
+(148,564,o),
+(74,389,o),
+(74,253,cs),
+(74,93,o),
+(187,-14,o),
+(367,-14,cs)
+);
+}
+);
+width = 814;
+}
+);
+metricLeft = "lhuCarrier-canadian";
+note = uni1634;
+unicode = 5684;
+},
+{
+color = 9;
+glyphname = "tlhoCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(77,-76,l),
+(94,0,l),
+(336,0,l),
+(363,128,l),
+(326,157,o),
+(305,214,o),
+(305,282,cs),
+(305,387,o),
+(353,559,o),
+(489,559,cs),
+(574,559,o),
+(622,507,o),
+(622,416,cs),
+(622,327,o),
+(577,180,o),
+(472,128,c),
+(444,0,l),
+(712,0,l),
+(741,135,l),
+(556,135,l),
+(501,88,l),
+(710,126,o),
+(783,300,o),
+(783,437,cs),
+(783,597,o),
+(670,704,o),
+(491,704,cs),
+(270,704,o),
+(153,521,o),
+(153,331,cs),
+(153,210,o),
+(197,109,o),
+(312,82,c),
+(310,121,l),
+(119,121,l),
+(135,197,l),
+(19,197,l),
+(-40,-76,l)
+);
+}
+);
+width = 817;
+}
+);
+metricLeft = "=|tlhuCarrier-canadian";
+metricRight = "lhuCarrier-canadian";
+note = uni1635;
+unicode = 5685;
+},
+{
+color = 9;
+glyphname = "tlheCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (398,345);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(624,-14,o),
+(730,236,o),
+(730,420,cs),
+(730,590,o),
+(637,704,o),
+(489,704,cs),
+(371,704,o),
+(275,631,o),
+(226,515,c),
+(255,545,l),
+(286,694,l),
+(360,694,l),
+(384,806,l),
+(117,806,l),
+(93,694,l),
+(168,694,l),
+(107,408,l),
+(242,408,l),
+(283,509,o),
+(350,559,o),
+(431,559,cs),
+(520,559,o),
+(571,502,o),
+(571,405,cs),
+(571,295,o),
+(508,130,o),
+(369,130,cs),
+(278,130,o),
+(220,189,o),
+(216,282,c),
+(80,282,l),
+(20,0,l),
+(164,0,l),
+(194,144,l),
+(176,141,l),
+(193,47,o),
+(279,-14,o),
+(394,-14,cs)
+);
+}
+);
+width = 754;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1636;
+unicode = 5686;
+},
+{
+color = 9;
+glyphname = "tlheeCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (312,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 755;
+}
+);
+note = uni1637;
+unicode = 5687;
+},
+{
+color = 9;
+glyphname = "tlhiCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (283,0);
+ref = dot_middle;
+}
+);
+width = 755;
+}
+);
+note = uni1638;
+unicode = 5688;
+},
+{
+color = 9;
+glyphname = "tlhaCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(399,-14,o),
+(478,32,o),
+(516,111,c),
+(508,112,l),
+(485,0,l),
+(629,0,l),
+(689,282,l),
+(554,282,l),
+(513,181,o),
+(446,130,o),
+(364,130,cs),
+(275,130,o),
+(225,187,o),
+(225,285,cs),
+(225,395,o),
+(288,559,o),
+(426,559,cs),
+(518,559,o),
+(575,500,o),
+(580,408,c),
+(716,408,l),
+(777,694,l),
+(851,694,l),
+(875,806,l),
+(608,806,l),
+(583,694,l),
+(658,694,l),
+(625,540,l),
+(633,539,l),
+(609,646,o),
+(520,704,o),
+(404,704,cs),
+(171,704,o),
+(66,454,o),
+(66,270,cs),
+(66,99,o),
+(158,-14,o),
+(306,-14,cs)
+);
+}
+);
+width = 754;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni1639;
+unicode = 5689;
+},
+{
+color = 9;
+glyphname = "tluCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(330,-14,o),
+(395,26,o),
+(439,103,c),
+(387,105,l),
+(410,27,o),
+(469,-14,o),
+(559,-14,cs),
+(767,-14,o),
+(825,224,o),
+(825,364,cs),
+(825,478,o),
+(780,556,o),
+(697,592,c),
+(664,569,l),
+(865,569,l),
+(848,493,l),
+(964,493,l),
+(1022,766,l),
+(906,766,l),
+(890,690,l),
+(585,690,l),
+(557,561,l),
+(636,549,o),
+(674,498,o),
+(674,404,cs),
+(674,329,o),
+(644,127,o),
+(555,127,cs),
+(513,127,o),
+(496,157,o),
+(507,213,cs),
+(527,310,l),
+(373,310,l),
+(353,213,ls),
+(341,155,o),
+(317,127,o),
+(277,127,cs),
+(240,127,o),
+(220,152,o),
+(220,204,cs),
+(220,308,o),
+(285,556,o),
+(448,561,c),
+(476,690,l),
+(147,690,l),
+(118,554,l),
+(309,554,l),
+(281,580,l),
+(128,512,o),
+(61,340,o),
+(61,194,cs),
+(61,65,o),
+(130,-14,o),
+(248,-14,cs)
+);
+}
+);
+width = 939;
+}
+);
+metricRight = "tlhuCarrier-canadian";
+note = uni163A;
+unicode = 5690;
+},
+{
+color = 1;
+glyphname = "tloCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(843,-76,l),
+(901,197,l),
+(785,197,l),
+(769,121,l),
+(586,121,l),
+(613,99,l),
+(777,160,o),
+(854,339,o),
+(854,496,cs),
+(854,625,o),
+(784,704,o),
+(668,704,cs),
+(584,704,o),
+(520,664,o),
+(477,586,c),
+(528,584,l),
+(505,663,o),
+(446,704,o),
+(355,704,cs),
+(148,704,o),
+(90,466,o),
+(90,326,cs),
+(90,222,o),
+(128,147,o),
+(196,108,c),
+(235,135,l),
+(29,135,l),
+(1,0,l),
+(330,0,l),
+(357,128,l),
+(279,141,o),
+(241,191,o),
+(241,286,cs),
+(241,360,o),
+(270,563,o),
+(359,563,cs),
+(402,563,o),
+(419,532,o),
+(408,477,cs),
+(387,380,l),
+(542,380,l),
+(562,476,ls),
+(574,535,o),
+(599,563,o),
+(638,563,cs),
+(675,563,o),
+(695,538,o),
+(695,486,cs),
+(695,382,o),
+(630,133,o),
+(467,128,c),
+(439,0,l),
+(744,0,l),
+(727,-76,l)
+);
+}
+);
+width = 939;
+}
+);
+metricLeft = "tluCarrier-canadian";
+metricRight = "tlhuCarrier-canadian";
+note = uni163B;
+unicode = 5691;
+},
+{
+color = 9;
+glyphname = "tleCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (333,345);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(554,-14,o),
+(676,75,o),
+(676,221,cs),
+(676,294,o),
+(639,351,o),
+(578,365,c),
+(569,327,l),
+(671,343,o),
+(742,428,o),
+(742,526,cs),
+(742,630,o),
+(655,704,o),
+(522,704,cs),
+(407,704,o),
+(307,651,o),
+(247,556,c),
+(254,554,l),
+(283,694,l),
+(359,694,l),
+(383,806,l),
+(117,806,l),
+(93,694,l),
+(167,694,l),
+(106,408,l),
+(241,408,l),
+(276,509,o),
+(352,561,o),
+(462,561,cs),
+(536,561,o),
+(578,535,o),
+(578,491,cs),
+(578,436,o),
+(533,411,o),
+(474,411,cs),
+(435,411,l),
+(407,280,l),
+(446,280,ls),
+(495,280,o),
+(522,262,o),
+(522,226,cs),
+(522,159,o),
+(462,128,o),
+(385,128,cs),
+(270,128,o),
+(209,183,o),
+(214,282,c),
+(80,282,l),
+(20,0,l),
+(164,0,l),
+(192,134,l),
+(174,132,l),
+(190,42,o),
+(279,-14,o),
+(402,-14,cs)
+);
+}
+);
+width = 746;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni163C;
+unicode = 5692;
+},
+{
+color = 9;
+glyphname = "tleeCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (248,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 746;
+}
+);
+note = uni163D;
+unicode = 5693;
+},
+{
+color = 9;
+glyphname = "tliCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (237,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 746;
+}
+);
+note = uni163E;
+unicode = 5694;
+},
+{
+color = 9;
+glyphname = "tlaCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(374,-14,o),
+(467,31,o),
+(527,111,c),
+(510,147,l),
+(478,0,l),
+(623,0,l),
+(683,282,l),
+(549,282,l),
+(513,181,o),
+(438,128,o),
+(327,128,cs),
+(252,128,o),
+(212,155,o),
+(212,199,cs),
+(212,254,o),
+(255,279,o),
+(314,279,cs),
+(355,279,l),
+(383,410,l),
+(343,410,ls),
+(295,410,o),
+(268,428,o),
+(268,464,cs),
+(268,530,o),
+(327,561,o),
+(404,561,cs),
+(519,561,o),
+(581,507,o),
+(576,408,c),
+(710,408,l),
+(770,694,l),
+(844,694,l),
+(868,806,l),
+(602,806,l),
+(578,694,l),
+(654,694,l),
+(611,488,l),
+(635,511,l),
+(625,631,o),
+(528,704,o),
+(386,704,cs),
+(234,704,o),
+(112,614,o),
+(112,469,cs),
+(112,398,o),
+(149,341,o),
+(208,326,c),
+(216,362,l),
+(116,344,o),
+(46,261,o),
+(46,163,cs),
+(46,60,o),
+(134,-14,o),
+(268,-14,cs)
+);
+}
+);
+width = 747;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni163F;
+unicode = 5695;
+},
+{
+color = 9;
+glyphname = "zuCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(554,-14,o),
+(690,96,o),
+(690,290,cs),
+(690,358,o),
+(671,425,o),
+(671,482,cs),
+(671,525,o),
+(689,553,o),
+(736,553,cs),
+(763,553,l),
+(792,690,l),
+(735,690,ls),
+(593,690,o),
+(520,624,o),
+(520,488,cs),
+(520,426,o),
+(536,365,o),
+(536,298,cs),
+(536,193,o),
+(473,130,o),
+(367,130,cs),
+(279,130,o),
+(227,172,o),
+(227,238,cs),
+(227,342,o),
+(348,436,o),
+(348,557,cs),
+(348,638,o),
+(291,690,o),
+(198,690,cs),
+(146,690,l),
+(117,553,l),
+(152,553,ls),
+(181,553,o),
+(191,542,o),
+(191,522,cs),
+(191,463,o),
+(68,364,o),
+(68,212,cs),
+(68,78,o),
+(180,-14,o),
+(355,-14,cs)
+);
+}
+);
+width = 750;
+}
+);
+metricRight = "=|";
+note = uni1640;
+unicode = 5696;
+},
+{
+color = 9;
+glyphname = "zoCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(57,0,ls),
+(199,0,o),
+(272,66,o),
+(272,202,cs),
+(272,264,o),
+(256,325,o),
+(256,392,cs),
+(256,497,o),
+(319,559,o),
+(425,559,cs),
+(513,559,o),
+(565,518,o),
+(565,452,cs),
+(565,348,o),
+(444,254,o),
+(444,132,cs),
+(444,52,o),
+(501,0,o),
+(594,0,cs),
+(646,0,l),
+(675,137,l),
+(640,137,ls),
+(612,137,o),
+(601,148,o),
+(602,168,cs),
+(601,227,o),
+(725,326,o),
+(725,478,cs),
+(725,611,o),
+(612,703,o),
+(438,703,cs),
+(238,703,o),
+(102,594,o),
+(102,400,cs),
+(102,331,o),
+(121,265,o),
+(121,208,cs),
+(121,165,o),
+(103,137,o),
+(56,137,cs),
+(29,137,l),
+(0,0,l)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1641;
+unicode = 5697;
+},
+{
+color = 9;
+glyphname = "zeCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (380,345);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(611,-14,o),
+(704,305,o),
+(704,482,cs),
+(704,623,o),
+(642,704,o),
+(529,704,cs),
+(413,704,o),
+(327,616,o),
+(287,616,cs),
+(269,616,o),
+(262,632,o),
+(270,667,cs),
+(275,690,l),
+(131,690,l),
+(119,631,ls),
+(98,533,o),
+(135,474,o),
+(221,474,cs),
+(327,474,o),
+(407,559,o),
+(474,559,cs),
+(519,559,o),
+(542,524,o),
+(542,455,cs),
+(542,359,o),
+(494,130,o),
+(375,130,cs),
+(301,130,o),
+(259,215,o),
+(161,215,cs),
+(79,215,o),
+(18,159,o),
+(-3,59,cs),
+(-15,0,l),
+(128,0,l),
+(133,23,ls),
+(141,58,o),
+(154,73,o),
+(174,73,cs),
+(218,73,o),
+(276,-14,o),
+(389,-14,cs)
+);
+}
+);
+width = 717;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1642;
+unicode = 5698;
+},
+{
+color = 9;
+glyphname = "zeeCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (295,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 719;
+}
+);
+note = uni1643;
+unicode = 5699;
+},
+{
+color = 9;
+glyphname = "ziCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (265,0);
+ref = dot_middle;
+}
+);
+width = 719;
+}
+);
+note = uni1644;
+unicode = 5700;
+},
+{
+color = 9;
+glyphname = "zaCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(346,-14,o),
+(432,73,o),
+(472,73,cs),
+(491,73,o),
+(497,58,o),
+(490,23,cs),
+(484,0,l),
+(628,0,l),
+(640,59,ls),
+(662,156,o),
+(624,215,o),
+(538,215,cs),
+(432,215,o),
+(353,130,o),
+(285,130,cs),
+(241,130,o),
+(218,166,o),
+(218,235,cs),
+(218,330,o),
+(266,559,o),
+(384,559,cs),
+(458,559,o),
+(500,474,o),
+(598,474,cs),
+(680,474,o),
+(741,530,o),
+(762,631,cs),
+(775,690,l),
+(631,690,l),
+(626,667,ls),
+(618,632,o),
+(606,616,o),
+(585,616,cs),
+(541,616,o),
+(483,704,o),
+(370,704,cs),
+(149,704,o),
+(55,384,o),
+(55,208,cs),
+(55,67,o),
+(117,-14,o),
+(230,-14,cs)
+);
+}
+);
+width = 718;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|zeCarrier-canadian";
+note = uni1645;
+unicode = 5701;
+},
+{
+color = 6;
+glyphname = "zCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(347,183,l),
+(367,278,l),
+(177,278,l),
+(172,223,l),
+(405,472,l),
+(417,527,l),
+(114,527,l),
+(93,432,l),
+(280,432,l),
+(285,487,l),
+(52,238,l),
+(41,183,l)
+);
+}
+);
+width = 413;
+}
+);
+metricRight = "=|";
+note = uni1646;
+unicode = 5702;
+},
+{
+color = 6;
+glyphname = "initialzCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(226,96,l),
+(244,183,l),
+(347,183,l),
+(367,278,l),
+(152,278,l),
+(175,225,l),
+(405,472,l),
+(417,527,l),
+(318,527,l),
+(336,614,l),
+(232,614,l),
+(213,527,l),
+(114,527,l),
+(93,432,l),
+(306,432,l),
+(282,485,l),
+(52,238,l),
+(41,183,l),
+(140,183,l),
+(122,96,l)
+);
+}
+);
+width = 413;
+}
+);
+metricLeft = "zCarrier-canadian";
+metricRight = "zCarrier-canadian";
+note = uni1647;
+unicode = 5703;
+},
+{
+color = 9;
+glyphname = "dzuCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(554,-14,o),
+(690,96,o),
+(690,290,cs),
+(690,358,o),
+(671,425,o),
+(671,482,cs),
+(671,525,o),
+(689,553,o),
+(736,553,cs),
+(763,553,l),
+(792,690,l),
+(735,690,ls),
+(601,690,o),
+(527,624,o),
+(523,488,cs),
+(522,426,o),
+(538,359,o),
+(537,298,cs),
+(536,193,o),
+(473,130,o),
+(367,130,cs),
+(279,130,o),
+(227,172,o),
+(227,238,cs),
+(227,342,o),
+(344,436,o),
+(344,557,cs),
+(344,638,o),
+(290,690,o),
+(198,690,cs),
+(146,690,l),
+(117,553,l),
+(152,553,ls),
+(181,553,o),
+(191,542,o),
+(191,522,cs),
+(191,463,o),
+(68,364,o),
+(68,212,cs),
+(68,78,o),
+(180,-14,o),
+(355,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(455,466,l),
+(487,620,l),
+(534,620,l),
+(550,690,l),
+(383,690,l),
+(368,620,l),
+(415,620,l),
+(383,466,l)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1648;
+unicode = 5704;
+},
+{
+color = 9;
+glyphname = "dzoCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(57,0,ls),
+(191,0,o),
+(265,66,o),
+(270,202,cs),
+(271,264,o),
+(254,330,o),
+(255,392,cs),
+(257,497,o),
+(319,559,o),
+(425,559,cs),
+(513,559,o),
+(565,518,o),
+(565,452,cs),
+(565,348,o),
+(448,254,o),
+(448,132,cs),
+(448,52,o),
+(502,0,o),
+(594,0,cs),
+(646,0,l),
+(675,137,l),
+(640,137,ls),
+(612,137,o),
+(601,148,o),
+(601,168,cs),
+(601,227,o),
+(725,326,o),
+(725,478,cs),
+(725,611,o),
+(612,703,o),
+(438,703,cs),
+(238,703,o),
+(102,594,o),
+(102,400,cs),
+(102,331,o),
+(121,265,o),
+(121,208,cs),
+(121,165,o),
+(103,137,o),
+(56,137,cs),
+(29,137,l),
+(0,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(410,0,l),
+(424,70,l),
+(377,70,l),
+(410,224,l),
+(337,224,l),
+(305,70,l),
+(258,70,l),
+(243,0,l)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1649;
+unicode = 5705;
+},
+{
+color = 9;
+glyphname = "dzeCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (402,345);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(636,-14,o),
+(730,305,o),
+(730,482,cs),
+(730,623,o),
+(668,704,o),
+(555,704,cs),
+(440,704,o),
+(354,616,o),
+(313,616,cs),
+(294,616,o),
+(288,632,o),
+(296,667,cs),
+(300,690,l),
+(156,690,l),
+(144,631,ls),
+(123,533,o),
+(161,474,o),
+(247,474,cs),
+(354,474,o),
+(433,559,o),
+(499,559,cs),
+(544,559,o),
+(568,524,o),
+(568,455,cs),
+(568,359,o),
+(520,130,o),
+(400,130,cs),
+(327,130,o),
+(284,215,o),
+(187,215,cs),
+(105,215,o),
+(44,159,o),
+(22,59,cs),
+(10,0,l),
+(154,0,l),
+(158,23,ls),
+(166,58,o),
+(180,73,o),
+(200,73,cs),
+(244,73,o),
+(302,-14,o),
+(415,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(144,242,l),
+(156,304,l),
+(272,304,l),
+(290,385,l),
+(175,385,l),
+(187,447,l),
+(105,447,l),
+(62,242,l)
+);
+}
+);
+width = 743;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164A;
+unicode = 5706;
+},
+{
+color = 9;
+glyphname = "dzeeCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "dzeCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (317,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 743;
+}
+);
+metricLeft = "dzeCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164B;
+unicode = 5707;
+},
+{
+color = 9;
+glyphname = "dziCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "dzeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (287,0);
+ref = dot_middle;
+}
+);
+width = 745;
+}
+);
+note = uni164C;
+unicode = 5708;
+},
+{
+color = 9;
+glyphname = "dzaCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(346,-14,o),
+(432,73,o),
+(472,73,cs),
+(492,73,o),
+(497,58,o),
+(490,23,cs),
+(485,0,l),
+(629,0,l),
+(641,59,ls),
+(662,156,o),
+(624,215,o),
+(538,215,cs),
+(432,215,o),
+(353,130,o),
+(285,130,cs),
+(241,130,o),
+(218,166,o),
+(218,235,cs),
+(218,330,o),
+(266,559,o),
+(385,559,cs),
+(458,559,o),
+(501,474,o),
+(598,474,cs),
+(680,474,o),
+(741,530,o),
+(763,631,cs),
+(776,690,l),
+(632,690,l),
+(627,667,ls),
+(619,632,o),
+(606,616,o),
+(585,616,cs),
+(541,616,o),
+(483,704,o),
+(370,704,cs),
+(150,704,o),
+(55,384,o),
+(55,208,cs),
+(55,67,o),
+(117,-14,o),
+(230,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(680,242,l),
+(724,447,l),
+(641,447,l),
+(628,385,l),
+(513,385,l),
+(496,304,l),
+(611,304,l),
+(598,242,l)
+);
+}
+);
+width = 744;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dzeCarrier-canadian";
+note = uni164D;
+unicode = 5709;
+},
+{
+color = 9;
+glyphname = "suCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(332,-14,o),
+(407,36,o),
+(449,135,c),
+(383,135,l),
+(404,35,o),
+(459,-14,o),
+(561,-14,cs),
+(729,-14,o),
+(797,107,o),
+(804,247,cs),
+(810,328,o),
+(793,429,o),
+(797,486,cs),
+(799,530,o),
+(821,553,o),
+(862,553,cs),
+(885,553,l),
+(914,690,l),
+(843,690,ls),
+(702,690,o),
+(652,602,o),
+(645,491,cs),
+(640,419,o),
+(653,311,o),
+(649,247,cs),
+(647,189,o),
+(626,127,o),
+(560,127,cs),
+(501,127,o),
+(497,177,o),
+(505,219,cs),
+(605,690,l),
+(455,690,l),
+(355,217,ls),
+(343,156,o),
+(314,127,o),
+(269,127,cs),
+(230,127,o),
+(208,150,o),
+(208,187,cs),
+(208,280,o),
+(346,449,o),
+(346,565,cs),
+(346,641,o),
+(296,690,o),
+(213,690,cs),
+(146,690,l),
+(117,553,l),
+(141,553,ls),
+(169,553,o),
+(184,541,o),
+(184,519,cs),
+(184,445,o),
+(47,305,o),
+(47,163,cs),
+(47,58,o),
+(119,-14,o),
+(234,-14,cs)
+);
+}
+);
+width = 872;
+}
+);
+metricRight = "=|";
+note = uni164E;
+unicode = 5710;
+},
+{
+color = 9;
+glyphname = "soCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(71,0,ls),
+(212,0,o),
+(262,88,o),
+(269,199,cs),
+(273,270,o),
+(261,379,o),
+(265,442,cs),
+(267,500,o),
+(288,563,o),
+(354,563,cs),
+(413,563,o),
+(417,513,o),
+(409,470,cs),
+(309,0,l),
+(459,0,l),
+(558,472,ls),
+(571,533,o),
+(600,563,o),
+(645,563,cs),
+(684,563,o),
+(706,540,o),
+(706,502,cs),
+(706,410,o),
+(568,241,o),
+(568,125,cs),
+(568,48,o),
+(618,0,o),
+(700,0,cs),
+(767,0,l),
+(796,137,l),
+(773,137,ls),
+(744,137,o),
+(730,149,o),
+(730,171,cs),
+(730,244,o),
+(867,384,o),
+(867,526,cs),
+(867,632,o),
+(795,704,o),
+(680,704,cs),
+(582,704,o),
+(507,654,o),
+(465,554,c),
+(531,554,l),
+(510,655,o),
+(455,704,o),
+(353,704,cs),
+(185,704,o),
+(117,582,o),
+(109,442,cs),
+(104,361,o),
+(121,261,o),
+(117,204,cs),
+(115,159,o),
+(93,137,o),
+(52,137,cs),
+(29,137,l),
+(0,0,l)
+);
+}
+);
+width = 871;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5711;
+},
+{
+color = 9;
+glyphname = "seCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(585,-14,o),
+(663,106,o),
+(663,212,cs),
+(663,283,o),
+(625,340,o),
+(556,368,c),
+(547,310,l),
+(662,341,o),
+(730,428,o),
+(730,532,cs),
+(730,631,o),
+(663,704,o),
+(564,704,cs),
+(456,704,o),
+(355,616,o),
+(315,616,cs),
+(293,616,o),
+(286,630,o),
+(293,662,cs),
+(298,690,l),
+(155,690,l),
+(144,635,ls),
+(124,542,o),
+(170,480,o),
+(257,480,cs),
+(357,480,o),
+(443,561,o),
+(511,561,cs),
+(548,561,o),
+(569,539,o),
+(569,504,cs),
+(569,450,o),
+(533,409,o),
+(467,409,cs),
+(96,409,l),
+(69,281,l),
+(440,281,ls),
+(484,281,o),
+(508,259,o),
+(508,221,cs),
+(508,181,o),
+(484,128,o),
+(427,128,cs),
+(357,128,o),
+(298,210,o),
+(186,210,cs),
+(97,210,o),
+(43,159,o),
+(20,55,cs),
+(10,0,l),
+(153,0,l),
+(158,23,ls),
+(166,59,o),
+(179,73,o),
+(202,73,cs),
+(260,73,o),
+(328,-14,o),
+(445,-14,cs)
+);
+}
+);
+width = 734;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni1650;
+unicode = 5712;
+},
+{
+color = 9;
+glyphname = "seeCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(585,-14,o),
+(663,106,o),
+(663,212,cs),
+(663,280,o),
+(628,335,o),
+(564,363,c),
+(556,316,l),
+(668,346,o),
+(730,431,o),
+(730,532,cs),
+(730,631,o),
+(663,704,o),
+(564,704,cs),
+(456,704,o),
+(355,616,o),
+(315,616,cs),
+(293,616,o),
+(286,630,o),
+(293,662,cs),
+(298,690,l),
+(155,690,l),
+(144,635,ls),
+(124,542,o),
+(170,480,o),
+(257,480,cs),
+(357,480,o),
+(443,561,o),
+(511,561,cs),
+(548,561,o),
+(569,539,o),
+(569,504,cs),
+(569,450,o),
+(532,408,o),
+(467,408,cs),
+(415,408,l),
+(434,337,l),
+(464,479,l),
+(375,479,l),
+(360,408,l),
+(95,408,l),
+(69,282,l),
+(333,282,l),
+(318,209,l),
+(407,209,l),
+(437,353,l),
+(388,282,l),
+(441,282,ls),
+(484,283,o),
+(508,259,o),
+(508,221,cs),
+(508,181,o),
+(484,128,o),
+(427,128,cs),
+(357,128,o),
+(298,210,o),
+(186,210,cs),
+(97,210,o),
+(43,159,o),
+(20,55,cs),
+(10,0,l),
+(153,0,l),
+(158,23,ls),
+(166,59,o),
+(179,73,o),
+(202,73,cs),
+(260,73,o),
+(328,-14,o),
+(445,-14,cs)
+);
+}
+);
+width = 734;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1651;
+unicode = 5713;
+},
+{
+color = 9;
+glyphname = "siCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(585,-14,o),
+(663,106,o),
+(663,212,cs),
+(663,280,o),
+(628,335,o),
+(564,363,c),
+(556,316,l),
+(668,346,o),
+(730,431,o),
+(730,532,cs),
+(730,631,o),
+(663,704,o),
+(564,704,cs),
+(456,704,o),
+(355,616,o),
+(315,616,cs),
+(293,616,o),
+(286,630,o),
+(293,662,cs),
+(298,690,l),
+(155,690,l),
+(144,635,ls),
+(124,542,o),
+(170,480,o),
+(257,480,cs),
+(357,480,o),
+(443,564,o),
+(511,564,cs),
+(548,564,o),
+(574,539,o),
+(574,504,cs),
+(574,450,o),
+(539,404,o),
+(472,404,cs),
+(394,404,l),
+(452,356,l),
+(449,413,o),
+(407,453,o),
+(351,453,cs),
+(314,453,o),
+(283,435,o),
+(265,408,c),
+(95,408,l),
+(69,282,l),
+(265,282,l),
+(284,255,o),
+(315,238,o),
+(351,238,cs),
+(404,238,o),
+(448,279,o),
+(452,332,c),
+(392,286,l),
+(449,286,ls),
+(494,286,o),
+(513,259,o),
+(513,221,cs),
+(513,181,o),
+(484,126,o),
+(427,126,cs),
+(357,126,o),
+(298,210,o),
+(186,210,cs),
+(97,210,o),
+(43,159,o),
+(20,55,cs),
+(10,0,l),
+(153,0,l),
+(158,23,ls),
+(166,59,o),
+(179,73,o),
+(202,73,cs),
+(260,73,o),
+(328,-14,o),
+(445,-14,cs)
+);
+}
+);
+width = 734;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1652;
+unicode = 5714;
+},
+{
+color = 9;
+glyphname = "saCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(320,-14,o),
+(421,73,o),
+(461,73,cs),
+(482,73,o),
+(490,60,o),
+(483,28,cs),
+(476,0,l),
+(620,0,l),
+(632,55,ls),
+(651,148,o),
+(606,210,o),
+(518,210,cs),
+(418,210,o),
+(332,128,o),
+(265,128,cs),
+(228,128,o),
+(207,151,o),
+(207,185,cs),
+(207,240,o),
+(242,281,o),
+(309,281,cs),
+(680,281,l),
+(707,409,l),
+(336,409,ls),
+(292,409,o),
+(267,431,o),
+(267,469,cs),
+(267,509,o),
+(292,561,o),
+(349,561,cs),
+(418,561,o),
+(478,480,o),
+(588,480,cs),
+(679,480,o),
+(733,530,o),
+(754,635,cs),
+(766,690,l),
+(622,690,l),
+(617,667,ls),
+(610,631,o),
+(597,616,o),
+(573,616,cs),
+(516,616,o),
+(447,704,o),
+(330,704,cs),
+(190,704,o),
+(113,583,o),
+(113,478,cs),
+(113,407,o),
+(151,350,o),
+(219,322,c),
+(229,380,l),
+(114,349,o),
+(45,262,o),
+(45,157,cs),
+(45,59,o),
+(113,-14,o),
+(211,-14,cs)
+);
+}
+);
+width = 734;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1653;
+unicode = 5715;
+},
+{
+color = 9;
+glyphname = "shuCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(324,-14,o),
+(393,27,o),
+(439,109,c),
+(388,114,l),
+(411,28,o),
+(467,-14,o),
+(561,-14,cs),
+(729,-14,o),
+(797,107,o),
+(804,247,cs),
+(810,328,o),
+(793,429,o),
+(797,486,cs),
+(799,530,o),
+(821,553,o),
+(862,553,cs),
+(885,553,l),
+(914,690,l),
+(843,690,ls),
+(703,690,o),
+(653,603,o),
+(645,494,cs),
+(644,486,o),
+(644,476,o),
+(644,467,c),
+(684,574,l),
+(582,574,l),
+(605,690,l),
+(455,690,l),
+(432,574,l),
+(318,574,l),
+(335,499,l),
+(342,524,o),
+(346,545,o),
+(346,565,cs),
+(346,641,o),
+(296,690,o),
+(213,690,cs),
+(146,690,l),
+(117,553,l),
+(141,553,ls),
+(169,553,o),
+(184,541,o),
+(184,519,cs),
+(184,445,o),
+(47,305,o),
+(47,163,cs),
+(47,58,o),
+(119,-14,o),
+(234,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(230,127,o),
+(208,150,o),
+(208,187,cs),
+(208,253,o),
+(274,351,o),
+(315,444,c),
+(404,444,l),
+(355,217,ls),
+(343,156,o),
+(314,127,o),
+(269,127,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(501,127,o),
+(497,177,o),
+(505,219,cs),
+(554,444,l),
+(642,444,l),
+(643,376,o),
+(652,300,o),
+(649,247,cs),
+(647,189,o),
+(626,127,o),
+(560,127,cs)
+);
+}
+);
+width = 872;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1654;
+unicode = 5716;
+},
+{
+color = 9;
+glyphname = "shoCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(71,0,ls),
+(210,0,o),
+(261,87,o),
+(269,196,cs),
+(270,204,o),
+(270,213,o),
+(270,223,c),
+(230,116,l),
+(332,116,l),
+(309,0,l),
+(459,0,l),
+(482,116,l),
+(596,116,l),
+(579,190,l),
+(572,166,o),
+(568,145,o),
+(568,125,cs),
+(568,48,o),
+(618,0,o),
+(700,0,cs),
+(767,0,l),
+(797,137,l),
+(773,137,ls),
+(745,137,o),
+(730,149,o),
+(730,171,cs),
+(730,244,o),
+(867,384,o),
+(867,526,cs),
+(867,632,o),
+(795,704,o),
+(680,704,cs),
+(590,704,o),
+(521,663,o),
+(475,581,c),
+(526,576,l),
+(503,662,o),
+(447,704,o),
+(353,704,cs),
+(185,704,o),
+(117,582,o),
+(109,442,cs),
+(104,361,o),
+(121,261,o),
+(117,204,cs),
+(115,159,o),
+(93,137,o),
+(52,137,cs),
+(29,137,l),
+(0,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(271,314,o),
+(262,389,o),
+(265,442,cs),
+(267,500,o),
+(288,563,o),
+(354,563,cs),
+(413,563,o),
+(417,513,o),
+(409,470,cs),
+(360,245,l),
+(271,245,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(558,472,ls),
+(571,533,o),
+(600,563,o),
+(645,563,cs),
+(684,563,o),
+(706,540,o),
+(706,502,cs),
+(706,437,o),
+(640,339,o),
+(599,245,c),
+(510,245,l)
+);
+}
+);
+width = 872;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1655;
+unicode = 5717;
+},
+{
+color = 9;
+glyphname = "sheCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(585,-14,o),
+(663,106,o),
+(663,212,cs),
+(663,280,o),
+(628,335,o),
+(564,363,c),
+(556,316,l),
+(668,346,o),
+(730,431,o),
+(730,532,cs),
+(730,631,o),
+(663,704,o),
+(564,704,cs),
+(456,704,o),
+(355,616,o),
+(315,616,cs),
+(293,616,o),
+(286,630,o),
+(293,662,cs),
+(298,690,l),
+(155,690,l),
+(144,635,ls),
+(124,542,o),
+(170,482,o),
+(257,482,cs),
+(281,482,o),
+(307,487,o),
+(319,491,c),
+(229,556,l),
+(198,409,l),
+(96,409,l),
+(69,281,l),
+(171,281,l),
+(139,131,l),
+(248,199,l),
+(228,205,o),
+(209,208,o),
+(186,208,cs),
+(97,208,o),
+(43,159,o),
+(20,55,cs),
+(10,0,l),
+(153,0,l),
+(158,23,ls),
+(166,59,o),
+(179,73,o),
+(202,73,cs),
+(260,73,o),
+(328,-14,o),
+(445,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(297,281,l),
+(440,281,ls),
+(484,281,o),
+(508,259,o),
+(508,221,cs),
+(508,181,o),
+(484,128,o),
+(427,128,cs),
+(379,128,o),
+(335,165,o),
+(276,188,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(342,500,l),
+(406,523,o),
+(463,561,o),
+(511,561,cs),
+(548,561,o),
+(569,539,o),
+(569,504,cs),
+(569,450,o),
+(533,409,o),
+(467,409,cs),
+(324,409,l)
+);
+}
+);
+width = 734;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1656;
+unicode = 5718;
+},
+{
+color = 9;
+glyphname = "sheeCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(585,-14,o),
+(663,106,o),
+(663,212,cs),
+(663,280,o),
+(628,335,o),
+(564,363,c),
+(556,316,l),
+(668,346,o),
+(730,431,o),
+(730,532,cs),
+(730,631,o),
+(663,704,o),
+(564,704,cs),
+(456,704,o),
+(355,616,o),
+(315,616,cs),
+(293,616,o),
+(286,630,o),
+(293,662,cs),
+(298,690,l),
+(155,690,l),
+(144,635,ls),
+(124,542,o),
+(170,483,o),
+(257,483,cs),
+(270,483,o),
+(284,485,o),
+(296,487,c),
+(230,556,l),
+(196,397,l),
+(93,397,l),
+(71,293,l),
+(174,293,l),
+(140,132,l),
+(234,201,l),
+(218,205,o),
+(204,207,o),
+(186,207,cs),
+(97,207,o),
+(43,159,o),
+(20,55,cs),
+(10,0,l),
+(153,0,l),
+(158,23,ls),
+(166,59,o),
+(179,73,o),
+(202,73,cs),
+(260,73,o),
+(328,-14,o),
+(445,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(376,125,o),
+(329,170,o),
+(263,193,c),
+(284,293,l),
+(363,293,l),
+(345,211,l),
+(417,211,l),
+(446,345,l),
+(424,293,l),
+(446,293,ls),
+(492,293,o),
+(513,259,o),
+(513,221,cs),
+(513,181,o),
+(484,125,o),
+(427,125,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(474,477,l),
+(402,477,l),
+(384,397,l),
+(306,397,l),
+(327,495,l),
+(398,518,o),
+(460,565,o),
+(511,565,cs),
+(548,565,o),
+(574,539,o),
+(574,504,cs),
+(574,450,o),
+(535,397,o),
+(469,397,cs),
+(445,397,l),
+(446,346,l)
+);
+}
+);
+width = 734;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1657;
+unicode = 5719;
+},
+{
+color = 9;
+glyphname = "shiCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(144,635,ls),
+(124,542,o),
+(170,483,o),
+(257,483,cs),
+(271,483,o),
+(285,485,o),
+(298,488,c),
+(230,556,l),
+(196,397,l),
+(94,397,l),
+(71,293,l),
+(173,293,l),
+(139,132,l),
+(232,202,l),
+(217,205,o),
+(203,207,o),
+(186,207,cs),
+(97,207,o),
+(43,159,o),
+(20,55,cs),
+(10,0,l),
+(153,0,l),
+(158,23,ls),
+(166,59,o),
+(179,73,o),
+(202,73,cs),
+(260,73,o),
+(328,-14,o),
+(445,-14,cs),
+(585,-14,o),
+(663,106,o),
+(663,212,cs),
+(663,280,o),
+(628,335,o),
+(564,363,c),
+(556,316,l),
+(668,346,o),
+(730,431,o),
+(730,532,cs),
+(730,631,o),
+(663,704,o),
+(564,704,cs),
+(456,704,o),
+(355,616,o),
+(315,616,cs),
+(293,616,o),
+(286,630,o),
+(293,662,cs),
+(298,690,l),
+(155,690,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(284,293,l),
+(322,293,l),
+(338,259,o),
+(371,238,o),
+(411,238,cs),
+(467,238,o),
+(502,283,o),
+(510,330,c),
+(422,293,l),
+(454,293,ls),
+(496,293,o),
+(514,258,o),
+(514,221,cs),
+(514,181,o),
+(484,125,o),
+(427,125,cs),
+(376,125,o),
+(329,170,o),
+(263,193,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(327,495,l),
+(398,518,o),
+(460,565,o),
+(511,565,cs),
+(548,565,o),
+(574,539,o),
+(574,504,cs),
+(574,450,o),
+(540,397,o),
+(476,397,cs),
+(422,397,l),
+(509,358,l),
+(505,407,o),
+(469,453,o),
+(411,453,cs),
+(371,453,o),
+(337,431,o),
+(321,397,c),
+(306,397,l)
+);
+}
+);
+width = 734;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1658;
+unicode = 5720;
+},
+{
+color = 9;
+glyphname = "shaCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(319,-14,o),
+(421,73,o),
+(461,73,cs),
+(482,73,o),
+(490,60,o),
+(483,28,cs),
+(476,0,l),
+(620,0,l),
+(632,55,ls),
+(651,148,o),
+(606,208,o),
+(518,208,cs),
+(495,208,o),
+(468,203,o),
+(457,199,c),
+(546,133,l),
+(578,281,l),
+(680,281,l),
+(707,409,l),
+(605,409,l),
+(637,558,l),
+(527,491,l),
+(547,485,o),
+(566,482,o),
+(588,482,cs),
+(679,482,o),
+(733,530,o),
+(754,635,cs),
+(766,690,l),
+(622,690,l),
+(617,667,ls),
+(610,631,o),
+(597,616,o),
+(573,616,cs),
+(516,616,o),
+(447,704,o),
+(330,704,cs),
+(189,704,o),
+(113,583,o),
+(113,478,cs),
+(113,410,o),
+(148,355,o),
+(211,327,c),
+(218,374,l),
+(108,344,o),
+(45,259,o),
+(45,157,cs),
+(45,59,o),
+(113,-14,o),
+(211,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(228,128,o),
+(207,151,o),
+(207,185,cs),
+(207,240,o),
+(242,281,o),
+(309,281,cs),
+(452,281,l),
+(433,189,l),
+(370,167,o),
+(312,128,o),
+(265,128,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(291,409,o),
+(267,431,o),
+(267,469,cs),
+(267,509,o),
+(292,561,o),
+(348,561,cs),
+(397,561,o),
+(440,525,o),
+(498,501,c),
+(479,409,l),
+(335,409,ls)
+);
+}
+);
+width = 734;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1659;
+unicode = 5721;
+},
+{
+color = 6;
+glyphname = "shCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(227,96,l),
+(250,204,l),
+(151,183,l),
+(224,183,ls),
+(313,183,o),
+(369,226,o),
+(369,304,cs),
+(369,359,o),
+(330,395,o),
+(266,395,cs),
+(216,395,ls),
+(197,395,o),
+(186,403,o),
+(186,417,cs),
+(186,438,o),
+(202,447,o),
+(225,447,cs),
+(396,447,l),
+(413,527,l),
+(319,527,l),
+(337,614,l),
+(235,614,l),
+(211,502,l),
+(304,527,l),
+(238,527,ls),
+(148,527,o),
+(91,485,o),
+(91,406,cs),
+(91,352,o),
+(129,316,o),
+(194,316,cs),
+(242,316,ls),
+(263,316,o),
+(273,308,o),
+(273,294,cs),
+(273,272,o),
+(260,263,o),
+(235,263,cs),
+(64,263,l),
+(46,183,l),
+(143,183,l),
+(125,96,l)
+);
+}
+);
+width = 414;
+}
+);
+metricRight = "=|";
+note = uni18F5;
+unicode = 5722;
+},
+{
+color = 9;
+glyphname = "tsuCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(324,-14,o),
+(393,27,o),
+(439,109,c),
+(388,114,l),
+(411,28,o),
+(467,-14,o),
+(561,-14,cs),
+(729,-14,o),
+(797,107,o),
+(804,247,cs),
+(810,328,o),
+(793,429,o),
+(797,486,cs),
+(799,530,o),
+(821,553,o),
+(862,553,cs),
+(885,553,l),
+(914,690,l),
+(843,690,ls),
+(702,690,o),
+(653,602,o),
+(646,491,cs),
+(644,469,o),
+(646,440,o),
+(646,410,c),
+(544,410,l),
+(580,579,l),
+(634,579,l),
+(658,690,l),
+(403,690,l),
+(380,579,l),
+(434,579,l),
+(398,410,l),
+(296,410,l),
+(322,467,o),
+(345,520,o),
+(345,565,cs),
+(345,641,o),
+(296,690,o),
+(213,690,cs),
+(146,690,l),
+(117,553,l),
+(141,553,ls),
+(169,553,o),
+(184,541,o),
+(184,519,cs),
+(184,445,o),
+(47,305,o),
+(47,163,cs),
+(47,58,o),
+(119,-14,o),
+(234,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(230,127,o),
+(208,150,o),
+(208,187,cs),
+(208,213,o),
+(218,244,o),
+(233,280,c),
+(370,280,l),
+(357,217,ls),
+(345,156,o),
+(314,127,o),
+(269,127,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(501,127,o),
+(495,177,o),
+(503,219,cs),
+(516,280,l),
+(652,280,l),
+(651,263,o),
+(650,246,o),
+(649,235,cs),
+(647,186,o),
+(626,127,o),
+(560,127,cs)
+);
+}
+);
+width = 872;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165B;
+unicode = 5723;
+},
+{
+color = 9;
+glyphname = "tsoCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(71,0,ls),
+(212,0,o),
+(261,88,o),
+(268,199,cs),
+(270,221,o),
+(268,249,o),
+(268,280,c),
+(370,280,l),
+(334,111,l),
+(280,111,l),
+(256,0,l),
+(511,0,l),
+(534,111,l),
+(480,111,l),
+(516,280,l),
+(618,280,l),
+(592,223,o),
+(569,170,o),
+(569,125,cs),
+(569,48,o),
+(618,0,o),
+(700,0,cs),
+(767,0,l),
+(797,137,l),
+(773,137,ls),
+(745,137,o),
+(730,149,o),
+(730,171,cs),
+(730,244,o),
+(867,384,o),
+(867,526,cs),
+(867,632,o),
+(795,704,o),
+(680,704,cs),
+(590,704,o),
+(521,663,o),
+(475,581,c),
+(526,576,l),
+(503,662,o),
+(447,704,o),
+(353,704,cs),
+(185,704,o),
+(117,582,o),
+(109,442,cs),
+(104,361,o),
+(121,261,o),
+(117,204,cs),
+(115,159,o),
+(93,137,o),
+(52,137,cs),
+(29,137,l),
+(0,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(263,427,o),
+(264,443,o),
+(265,455,cs),
+(267,503,o),
+(288,563,o),
+(354,563,cs),
+(413,563,o),
+(419,513,o),
+(411,470,cs),
+(398,410,l),
+(262,410,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(556,472,ls),
+(569,533,o),
+(600,563,o),
+(645,563,cs),
+(684,563,o),
+(706,540,o),
+(706,502,cs),
+(706,477,o),
+(696,445,o),
+(681,410,c),
+(543,410,l)
+);
+}
+);
+width = 872;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165C;
+unicode = 5724;
+},
+{
+color = 9;
+glyphname = "tseCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(588,-14,o),
+(666,106,o),
+(666,212,cs),
+(666,280,o),
+(631,335,o),
+(567,363,c),
+(559,316,l),
+(670,346,o),
+(733,431,o),
+(733,532,cs),
+(733,631,o),
+(666,704,o),
+(567,704,cs),
+(459,704,o),
+(357,616,o),
+(318,616,cs),
+(297,616,o),
+(289,630,o),
+(296,662,cs),
+(301,690,l),
+(157,690,l),
+(147,635,ls),
+(127,542,o),
+(173,487,o),
+(258,487,cs),
+(286,487,o),
+(314,492,o),
+(340,501,c),
+(295,559,l),
+(261,398,l),
+(185,398,l),
+(197,460,l),
+(108,460,l),
+(60,229,l),
+(149,229,l),
+(161,292,l),
+(238,292,l),
+(204,131,l),
+(270,188,l),
+(249,196,o),
+(214,203,o),
+(189,203,cs),
+(99,203,o),
+(45,159,o),
+(23,55,cs),
+(13,0,l),
+(156,0,l),
+(161,23,ls),
+(169,59,o),
+(182,73,o),
+(205,73,cs),
+(263,73,o),
+(331,-14,o),
+(448,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(394,128,o),
+(361,149,o),
+(322,167,c),
+(348,292,l),
+(443,292,ls),
+(488,292,o),
+(513,263,o),
+(513,221,cs),
+(513,181,o),
+(488,128,o),
+(431,128,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(397,524,l),
+(440,542,o),
+(480,561,o),
+(514,561,cs),
+(551,561,o),
+(573,539,o),
+(573,504,cs),
+(573,450,o),
+(536,398,o),
+(469,398,cs),
+(371,398,l)
+);
+}
+);
+width = 737;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni165D;
+unicode = 5725;
+},
+{
+color = 9;
+glyphname = "tseeCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(588,-14,o),
+(666,106,o),
+(666,212,cs),
+(666,280,o),
+(631,335,o),
+(567,363,c),
+(559,316,l),
+(670,346,o),
+(733,431,o),
+(733,532,cs),
+(733,631,o),
+(666,704,o),
+(567,704,cs),
+(459,704,o),
+(357,616,o),
+(318,616,cs),
+(297,616,o),
+(289,630,o),
+(296,662,cs),
+(301,690,l),
+(157,690,l),
+(147,635,ls),
+(127,542,o),
+(173,487,o),
+(258,487,cs),
+(286,487,o),
+(314,492,o),
+(340,501,c),
+(289,559,l),
+(255,398,l),
+(182,398,l),
+(194,460,l),
+(108,460,l),
+(60,229,l),
+(146,229,l),
+(158,292,l),
+(232,292,l),
+(198,131,l),
+(270,188,l),
+(249,196,o),
+(214,203,o),
+(189,203,cs),
+(99,203,o),
+(45,159,o),
+(23,55,cs),
+(13,0,l),
+(156,0,l),
+(161,23,ls),
+(169,59,o),
+(182,73,o),
+(205,73,cs),
+(263,73,o),
+(331,-14,o),
+(448,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(392,128,o),
+(353,155,o),
+(303,178,c),
+(328,292,l),
+(383,292,l),
+(365,206,l),
+(438,206,l),
+(459,310,l),
+(430,292,l),
+(444,292,ls),
+(488,292,o),
+(513,263,o),
+(513,221,cs),
+(513,177,o),
+(486,128,o),
+(431,128,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(496,482,l),
+(423,482,l),
+(406,398,l),
+(350,398,l),
+(375,514,l),
+(420,532,o),
+(476,561,o),
+(514,561,cs),
+(551,561,o),
+(574,539,o),
+(574,504,cs),
+(574,450,o),
+(537,398,o),
+(471,398,cs),
+(447,398,l),
+(475,384,l)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165E;
+unicode = 5726;
+},
+{
+color = 9;
+glyphname = "tsiCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(589,-14,o),
+(667,106,o),
+(667,213,cs),
+(667,280,o),
+(632,335,o),
+(568,363,c),
+(560,316,l),
+(671,346,o),
+(734,431,o),
+(734,533,cs),
+(734,631,o),
+(667,704,o),
+(568,704,cs),
+(460,704,o),
+(358,616,o),
+(319,616,cs),
+(298,616,o),
+(290,630,o),
+(297,662,cs),
+(302,690,l),
+(158,690,l),
+(148,635,ls),
+(128,542,o),
+(174,487,o),
+(259,487,cs),
+(279,487,o),
+(299,491,o),
+(316,497,c),
+(268,559,l),
+(234,398,l),
+(183,398,l),
+(195,461,l),
+(109,461,l),
+(61,229,l),
+(147,229,l),
+(159,293,l),
+(212,293,l),
+(177,131,l),
+(246,193,l),
+(228,199,o),
+(210,203,o),
+(190,203,cs),
+(100,203,o),
+(46,159,o),
+(24,55,cs),
+(14,0,l),
+(157,0,l),
+(162,23,ls),
+(170,59,o),
+(183,73,o),
+(206,73,cs),
+(264,73,o),
+(332,-14,o),
+(449,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(387,128,o),
+(334,165,o),
+(284,184,c),
+(306,293,l),
+(339,293,l),
+(354,259,o),
+(385,238,o),
+(424,238,cs),
+(471,238,o),
+(498,270,o),
+(513,303,c),
+(429,293,l),
+(445,293,ls),
+(489,293,o),
+(514,263,o),
+(514,221,cs),
+(514,177,o),
+(487,128,o),
+(432,128,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(503,428,o),
+(466,453,o),
+(427,453,cs),
+(390,453,o),
+(355,430,o),
+(342,398,c),
+(329,398,l),
+(353,506,l),
+(398,521,o),
+(470,562,o),
+(515,562,cs),
+(552,562,o),
+(575,539,o),
+(575,504,cs),
+(575,450,o),
+(538,398,o),
+(472,398,cs),
+(446,398,l),
+(518,385,l)
+);
+}
+);
+width = 738;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165F;
+unicode = 5727;
+},
+{
+color = 9;
+glyphname = "tsaCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(320,-14,o),
+(421,73,o),
+(461,73,cs),
+(482,73,o),
+(490,60,o),
+(483,28,cs),
+(477,0,l),
+(621,0,l),
+(632,55,ls),
+(652,148,o),
+(606,203,o),
+(521,203,cs),
+(493,203,o),
+(465,198,o),
+(439,188,c),
+(484,130,l),
+(518,292,l),
+(594,292,l),
+(582,230,l),
+(670,230,l),
+(719,461,l),
+(630,461,l),
+(617,398,l),
+(541,398,l),
+(575,558,l),
+(508,501,l),
+(529,494,o),
+(564,487,o),
+(589,487,cs),
+(679,487,o),
+(733,530,o),
+(755,635,cs),
+(766,690,l),
+(622,690,l),
+(617,667,ls),
+(610,631,o),
+(597,616,o),
+(574,616,cs),
+(516,616,o),
+(447,704,o),
+(330,704,cs),
+(190,704,o),
+(113,583,o),
+(113,478,cs),
+(113,410,o),
+(148,355,o),
+(212,327,c),
+(219,374,l),
+(108,344,o),
+(45,259,o),
+(45,157,cs),
+(45,59,o),
+(113,-14,o),
+(211,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(228,128,o),
+(206,151,o),
+(206,185,cs),
+(206,240,o),
+(242,292,o),
+(308,292,cs),
+(408,292,l),
+(382,166,l),
+(338,148,o),
+(298,128,o),
+(264,128,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(291,398,o),
+(266,427,o),
+(266,469,cs),
+(266,509,o),
+(291,562,o),
+(348,562,cs),
+(384,562,o),
+(417,541,o),
+(457,523,c),
+(431,398,l),
+(335,398,ls)
+);
+}
+);
+width = 736;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1660;
+unicode = 5728;
+},
+{
+color = 9;
+glyphname = "chuCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(324,-14,o),
+(393,27,o),
+(439,109,c),
+(388,114,l),
+(411,28,o),
+(467,-14,o),
+(561,-14,cs),
+(729,-14,o),
+(797,107,o),
+(804,247,cs),
+(810,328,o),
+(793,429,o),
+(797,486,cs),
+(799,530,o),
+(821,553,o),
+(862,553,cs),
+(885,553,l),
+(914,690,l),
+(843,690,ls),
+(702,690,o),
+(653,602,o),
+(646,491,cs),
+(641,419,o),
+(653,311,o),
+(649,247,cs),
+(647,189,o),
+(626,127,o),
+(560,127,cs),
+(501,127,o),
+(497,177,o),
+(505,219,cs),
+(582,579,l),
+(634,579,l),
+(658,690,l),
+(403,690,l),
+(380,579,l),
+(432,579,l),
+(355,217,ls),
+(343,156,o),
+(314,127,o),
+(269,127,cs),
+(230,127,o),
+(208,150,o),
+(208,187,cs),
+(208,280,o),
+(345,449,o),
+(345,565,cs),
+(345,641,o),
+(296,690,o),
+(213,690,cs),
+(146,690,l),
+(117,553,l),
+(141,553,ls),
+(169,553,o),
+(184,541,o),
+(184,519,cs),
+(184,445,o),
+(47,305,o),
+(47,163,cs),
+(47,58,o),
+(119,-14,o),
+(234,-14,cs)
+);
+}
+);
+width = 872;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164E;
+unicode = 5729;
+},
+{
+color = 9;
+glyphname = "choCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(71,0,ls),
+(212,0,o),
+(261,88,o),
+(268,199,cs),
+(272,270,o),
+(261,379,o),
+(265,442,cs),
+(267,500,o),
+(288,563,o),
+(354,563,cs),
+(413,563,o),
+(417,513,o),
+(409,470,cs),
+(332,111,l),
+(280,111,l),
+(256,0,l),
+(511,0,l),
+(534,111,l),
+(482,111,l),
+(558,472,ls),
+(571,533,o),
+(600,563,o),
+(645,563,cs),
+(684,563,o),
+(706,540,o),
+(706,502,cs),
+(706,410,o),
+(569,241,o),
+(569,125,cs),
+(569,48,o),
+(618,0,o),
+(700,0,cs),
+(767,0,l),
+(796,137,l),
+(773,137,ls),
+(745,137,o),
+(730,149,o),
+(730,171,cs),
+(730,244,o),
+(867,384,o),
+(867,526,cs),
+(867,632,o),
+(795,704,o),
+(680,704,cs),
+(590,704,o),
+(521,663,o),
+(475,581,c),
+(526,576,l),
+(503,662,o),
+(447,704,o),
+(353,704,cs),
+(185,704,o),
+(117,582,o),
+(109,442,cs),
+(104,361,o),
+(121,261,o),
+(117,204,cs),
+(115,159,o),
+(93,137,o),
+(52,137,cs),
+(29,137,l),
+(0,0,l)
+);
+}
+);
+width = 871;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5730;
+},
+{
+color = 9;
+glyphname = "cheCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(588,-14,o),
+(666,106,o),
+(666,212,cs),
+(666,280,o),
+(631,335,o),
+(567,363,c),
+(559,316,l),
+(670,346,o),
+(733,431,o),
+(733,532,cs),
+(733,631,o),
+(666,704,o),
+(567,704,cs),
+(459,704,o),
+(357,616,o),
+(318,616,cs),
+(297,616,o),
+(289,630,o),
+(296,662,cs),
+(301,690,l),
+(157,690,l),
+(147,635,ls),
+(127,542,o),
+(173,486,o),
+(261,486,cs),
+(360,486,o),
+(445,561,o),
+(514,561,cs),
+(550,561,o),
+(572,539,o),
+(572,504,cs),
+(572,450,o),
+(536,409,o),
+(469,409,cs),
+(186,409,l),
+(197,460,l),
+(108,460,l),
+(60,229,l),
+(149,229,l),
+(159,281,l),
+(442,281,ls),
+(487,281,o),
+(511,259,o),
+(511,221,cs),
+(511,181,o),
+(486,128,o),
+(430,128,cs),
+(360,128,o),
+(300,204,o),
+(189,204,cs),
+(99,204,o),
+(43,149,o),
+(23,55,cs),
+(13,0,l),
+(156,0,l),
+(161,23,ls),
+(169,59,o),
+(182,73,o),
+(205,73,cs),
+(263,73,o),
+(331,-14,o),
+(448,-14,cs)
+);
+}
+);
+width = 737;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni1663;
+unicode = 5731;
+},
+{
+color = 9;
+glyphname = "cheeCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(588,-14,o),
+(666,106,o),
+(666,212,cs),
+(666,280,o),
+(631,335,o),
+(567,363,c),
+(559,316,l),
+(670,346,o),
+(733,431,o),
+(733,532,cs),
+(733,631,o),
+(666,704,o),
+(567,704,cs),
+(459,704,o),
+(357,616,o),
+(318,616,cs),
+(297,616,o),
+(289,630,o),
+(296,662,cs),
+(301,690,l),
+(157,690,l),
+(147,635,ls),
+(127,542,o),
+(173,485,o),
+(260,485,cs),
+(359,485,o),
+(445,563,o),
+(514,563,cs),
+(550,563,o),
+(573,539,o),
+(573,504,cs),
+(573,450,o),
+(536,397,o),
+(469,397,cs),
+(415,397,l),
+(447,383,l),
+(468,478,l),
+(379,478,l),
+(361,397,l),
+(184,397,l),
+(197,460,l),
+(108,460,l),
+(60,229,l),
+(149,229,l),
+(162,293,l),
+(339,293,l),
+(322,209,l),
+(411,209,l),
+(433,317,l),
+(395,293,l),
+(448,293,ls),
+(493,293,o),
+(513,259,o),
+(513,221,cs),
+(513,181,o),
+(487,127,o),
+(430,127,cs),
+(360,127,o),
+(299,205,o),
+(189,205,cs),
+(99,205,o),
+(43,149,o),
+(23,55,cs),
+(13,0,l),
+(156,0,l),
+(161,23,ls),
+(169,59,o),
+(182,73,o),
+(205,73,cs),
+(263,73,o),
+(331,-14,o),
+(448,-14,cs)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1664;
+unicode = 5732;
+},
+{
+color = 9;
+glyphname = "chiCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(588,-14,o),
+(666,106,o),
+(666,212,cs),
+(666,280,o),
+(631,335,o),
+(567,363,c),
+(559,316,l),
+(670,346,o),
+(733,431,o),
+(733,532,cs),
+(733,631,o),
+(666,704,o),
+(567,704,cs),
+(459,704,o),
+(357,616,o),
+(318,616,cs),
+(297,616,o),
+(289,630,o),
+(296,662,cs),
+(301,690,l),
+(157,690,l),
+(147,635,ls),
+(127,542,o),
+(173,485,o),
+(260,485,cs),
+(359,485,o),
+(445,563,o),
+(514,563,cs),
+(550,563,o),
+(573,539,o),
+(573,504,cs),
+(573,450,o),
+(536,397,o),
+(472,397,cs),
+(418,397,l),
+(463,370,l),
+(455,417,o),
+(412,453,o),
+(361,453,cs),
+(318,453,o),
+(287,430,o),
+(270,397,c),
+(184,397,l),
+(197,461,l),
+(109,461,l),
+(60,229,l),
+(149,229,l),
+(162,293,l),
+(270,293,l),
+(289,258,o),
+(322,238,o),
+(361,238,cs),
+(414,238,o),
+(450,274,o),
+(463,320,c),
+(398,293,l),
+(451,293,ls),
+(492,293,o),
+(513,261,o),
+(513,221,cs),
+(513,181,o),
+(487,127,o),
+(430,127,cs),
+(360,127,o),
+(299,205,o),
+(189,205,cs),
+(99,205,o),
+(43,149,o),
+(23,55,cs),
+(13,0,l),
+(156,0,l),
+(161,23,ls),
+(169,59,o),
+(182,73,o),
+(205,73,cs),
+(263,73,o),
+(331,-14,o),
+(448,-14,cs)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1665;
+unicode = 5733;
+},
+{
+color = 9;
+glyphname = "chaCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(321,-13,o),
+(422,75,o),
+(462,75,cs),
+(484,75,o),
+(491,62,o),
+(484,30,cs),
+(478,2,l),
+(622,2,l),
+(634,56,ls),
+(653,150,o),
+(607,206,o),
+(520,206,cs),
+(419,206,o),
+(334,129,o),
+(266,129,cs),
+(230,129,o),
+(208,153,o),
+(208,187,cs),
+(208,242,o),
+(244,283,o),
+(310,283,cs),
+(593,283,l),
+(582,231,l),
+(671,231,l),
+(720,462,l),
+(632,462,l),
+(620,411,l),
+(337,411,ls),
+(293,411,o),
+(269,433,o),
+(269,470,cs),
+(269,511,o),
+(294,563,o),
+(350,563,cs),
+(419,563,o),
+(479,487,o),
+(590,487,cs),
+(680,487,o),
+(736,543,o),
+(756,637,cs),
+(768,692,l),
+(624,692,l),
+(618,668,ls),
+(611,633,o),
+(598,618,o),
+(575,618,cs),
+(517,618,o),
+(448,705,o),
+(331,705,cs),
+(191,705,o),
+(114,585,o),
+(114,479,cs),
+(114,412,o),
+(149,356,o),
+(213,328,c),
+(220,376,l),
+(109,346,o),
+(46,261,o),
+(46,158,cs),
+(46,61,o),
+(114,-13,o),
+(213,-13,cs)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1666;
+unicode = 5734;
+},
+{
+color = 9;
+glyphname = "ttsuCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(324,-14,o),
+(393,27,o),
+(439,109,c),
+(388,114,l),
+(411,28,o),
+(467,-14,o),
+(561,-14,cs),
+(729,-14,o),
+(797,107,o),
+(804,247,cs),
+(810,328,o),
+(793,429,o),
+(797,486,cs),
+(799,530,o),
+(821,553,o),
+(862,553,cs),
+(885,553,l),
+(914,690,l),
+(843,690,ls),
+(702,690,o),
+(653,602,o),
+(646,491,cs),
+(644,459,o),
+(646,428,o),
+(643,404,c),
+(707,546,l),
+(554,451,l),
+(582,579,l),
+(634,579,l),
+(658,690,l),
+(403,690,l),
+(380,579,l),
+(432,579,l),
+(406,453,l),
+(267,568,l),
+(301,414,l),
+(325,469,o),
+(345,520,o),
+(345,565,cs),
+(345,641,o),
+(296,690,o),
+(213,690,cs),
+(146,690,l),
+(117,553,l),
+(141,553,ls),
+(169,553,o),
+(184,541,o),
+(184,519,cs),
+(184,445,o),
+(47,305,o),
+(47,163,cs),
+(47,58,o),
+(119,-14,o),
+(234,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(230,127,o),
+(208,150,o),
+(208,187,cs),
+(208,239,o),
+(248,305,o),
+(283,376,c),
+(374,304,l),
+(355,217,ls),
+(343,156,o),
+(314,127,o),
+(269,127,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(501,127,o),
+(497,177,o),
+(505,219,cs),
+(520,289,l),
+(645,362,l),
+(648,321,o),
+(651,280,o),
+(649,247,cs),
+(647,189,o),
+(626,127,o),
+(560,127,cs)
+);
+}
+);
+width = 872;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1667;
+unicode = 5735;
+},
+{
+color = 9;
+glyphname = "ttsoCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(71,0,ls),
+(212,0,o),
+(261,88,o),
+(268,199,cs),
+(270,231,o),
+(268,262,o),
+(271,286,c),
+(207,144,l),
+(359,239,l),
+(332,111,l),
+(280,111,l),
+(256,0,l),
+(511,0,l),
+(534,111,l),
+(482,111,l),
+(508,237,l),
+(647,122,l),
+(612,275,l),
+(589,220,o),
+(569,170,o),
+(569,125,cs),
+(569,48,o),
+(618,0,o),
+(700,0,cs),
+(767,0,l),
+(797,137,l),
+(773,137,ls),
+(745,137,o),
+(730,149,o),
+(730,171,cs),
+(730,244,o),
+(867,384,o),
+(867,526,cs),
+(867,632,o),
+(795,704,o),
+(680,704,cs),
+(590,704,o),
+(521,663,o),
+(475,581,c),
+(526,576,l),
+(503,662,o),
+(447,704,o),
+(353,704,cs),
+(185,704,o),
+(117,582,o),
+(109,442,cs),
+(104,361,o),
+(121,261,o),
+(117,204,cs),
+(115,159,o),
+(93,137,o),
+(52,137,cs),
+(29,137,l),
+(0,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(266,369,o),
+(263,410,o),
+(265,442,cs),
+(267,500,o),
+(288,563,o),
+(354,563,cs),
+(413,563,o),
+(417,513,o),
+(409,470,cs),
+(394,401,l),
+(269,327,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(540,385,l),
+(558,472,ls),
+(571,533,o),
+(600,563,o),
+(645,563,cs),
+(684,563,o),
+(706,540,o),
+(706,502,cs),
+(706,451,o),
+(666,384,o),
+(631,314,c)
+);
+}
+);
+width = 872;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1668;
+unicode = 5736;
+},
+{
+color = 9;
+glyphname = "ttseCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(588,-14,o),
+(666,106,o),
+(666,212,cs),
+(666,280,o),
+(631,335,o),
+(567,363,c),
+(559,316,l),
+(670,346,o),
+(733,431,o),
+(733,532,cs),
+(733,630,o),
+(666,704,o),
+(567,704,cs),
+(459,704,o),
+(357,616,o),
+(318,616,cs),
+(296,616,o),
+(289,630,o),
+(296,662,cs),
+(301,690,l),
+(157,690,l),
+(146,635,ls),
+(128,543,o),
+(172,485,o),
+(260,485,cs),
+(275,485,o),
+(291,487,o),
+(305,491,c),
+(219,561,l),
+(257,397,l),
+(185,397,l),
+(198,460,l),
+(109,460,l),
+(60,229,l),
+(149,229,l),
+(162,293,l),
+(236,293,l),
+(134,137,l),
+(247,197,l),
+(229,202,o),
+(211,205,o),
+(189,205,cs),
+(98,205,o),
+(44,157,o),
+(23,55,cs),
+(12,0,l),
+(156,0,l),
+(161,23,ls),
+(168,59,o),
+(182,73,o),
+(205,73,cs),
+(263,73,o),
+(331,-14,o),
+(448,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(383,125,o),
+(340,160,o),
+(287,183,c),
+(356,293,l),
+(446,293,ls),
+(489,293,o),
+(515,264,o),
+(515,224,cs),
+(515,180,o),
+(485,125,o),
+(430,125,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(348,503,l),
+(408,525,o),
+(465,565,o),
+(513,565,cs),
+(551,565,o),
+(574,540,o),
+(574,502,cs),
+(574,450,o),
+(534,397,o),
+(469,397,cs),
+(370,397,l)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1669;
+unicode = 5737;
+},
+{
+color = 9;
+glyphname = "ttseeCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(588,-14,o),
+(666,106,o),
+(666,212,cs),
+(666,280,o),
+(631,335,o),
+(567,363,c),
+(559,316,l),
+(670,346,o),
+(733,431,o),
+(733,532,cs),
+(733,630,o),
+(666,704,o),
+(567,704,cs),
+(459,704,o),
+(357,616,o),
+(318,616,cs),
+(296,616,o),
+(289,630,o),
+(296,662,cs),
+(301,690,l),
+(157,690,l),
+(146,635,ls),
+(128,543,o),
+(172,485,o),
+(260,485,cs),
+(275,485,o),
+(291,487,o),
+(305,491,c),
+(217,561,l),
+(254,397,l),
+(185,397,l),
+(198,460,l),
+(109,460,l),
+(60,229,l),
+(149,229,l),
+(162,293,l),
+(234,293,l),
+(131,137,l),
+(247,197,l),
+(229,202,o),
+(211,205,o),
+(189,205,cs),
+(98,205,o),
+(44,157,o),
+(23,55,cs),
+(12,0,l),
+(156,0,l),
+(161,23,ls),
+(168,59,o),
+(182,73,o),
+(205,73,cs),
+(263,73,o),
+(331,-14,o),
+(448,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(383,125,o),
+(335,165,o),
+(282,186,c),
+(350,293,l),
+(384,293,l),
+(364,206,l),
+(440,206,l),
+(463,314,l),
+(431,293,l),
+(446,293,ls),
+(489,293,o),
+(515,264,o),
+(515,224,cs),
+(515,180,o),
+(485,125,o),
+(430,125,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(498,482,l),
+(423,482,l),
+(406,397,l),
+(363,397,l),
+(341,500,l),
+(401,520,o),
+(464,565,o),
+(513,565,cs),
+(551,565,o),
+(574,540,o),
+(574,502,cs),
+(574,450,o),
+(534,397,o),
+(469,397,cs),
+(451,397,l),
+(477,382,l)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166A;
+unicode = 5738;
+},
+{
+color = 9;
+glyphname = "ttsiCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(588,-14,o),
+(666,106,o),
+(666,212,cs),
+(666,280,o),
+(631,335,o),
+(567,363,c),
+(559,316,l),
+(670,346,o),
+(733,431,o),
+(733,532,cs),
+(733,630,o),
+(666,704,o),
+(567,704,cs),
+(459,704,o),
+(357,616,o),
+(318,616,cs),
+(296,616,o),
+(289,630,o),
+(296,662,cs),
+(301,690,l),
+(157,690,l),
+(146,635,ls),
+(128,543,o),
+(172,485,o),
+(260,485,cs),
+(275,485,o),
+(291,487,o),
+(305,491,c),
+(217,561,l),
+(254,397,l),
+(185,397,l),
+(198,460,l),
+(109,460,l),
+(60,229,l),
+(149,229,l),
+(162,293,l),
+(236,293,l),
+(134,137,l),
+(247,197,l),
+(229,202,o),
+(211,205,o),
+(189,205,cs),
+(98,205,o),
+(44,157,o),
+(23,55,cs),
+(12,0,l),
+(156,0,l),
+(161,23,ls),
+(168,59,o),
+(182,73,o),
+(205,73,cs),
+(263,73,o),
+(331,-14,o),
+(448,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(383,125,o),
+(326,170,o),
+(272,190,c),
+(338,293,l),
+(344,293,l),
+(359,257,o),
+(396,238,o),
+(429,238,cs),
+(478,238,o),
+(511,277,o),
+(520,314,c),
+(431,293,l),
+(469,293,ls),
+(499,293,o),
+(515,264,o),
+(515,224,cs),
+(515,180,o),
+(485,125,o),
+(430,125,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(505,424,o),
+(472,453,o),
+(429,453,cs),
+(396,453,o),
+(357,433,o),
+(344,397,c),
+(344,397,l),
+(324,495,l),
+(384,512,o),
+(464,565,o),
+(513,565,cs),
+(551,565,o),
+(574,540,o),
+(574,502,cs),
+(574,450,o),
+(545,397,o),
+(480,397,cs),
+(451,397,l),
+(520,382,l)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166B;
+unicode = 5739;
+},
+{
+color = 9;
+glyphname = "ttsaCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(320,-14,o),
+(421,73,o),
+(461,73,cs),
+(482,73,o),
+(490,60,o),
+(483,28,cs),
+(476,0,l),
+(620,0,l),
+(632,55,ls),
+(651,147,o),
+(607,205,o),
+(519,205,cs),
+(502,205,o),
+(488,203,o),
+(473,199,c),
+(559,128,l),
+(522,293,l),
+(594,293,l),
+(580,230,l),
+(668,230,l),
+(718,461,l),
+(629,461,l),
+(615,397,l),
+(543,397,l),
+(644,553,l),
+(531,493,l),
+(549,488,o),
+(568,485,o),
+(589,485,cs),
+(681,485,o),
+(733,532,o),
+(754,635,cs),
+(766,690,l),
+(622,690,l),
+(617,667,ls),
+(610,631,o),
+(596,616,o),
+(573,616,cs),
+(516,616,o),
+(447,704,o),
+(330,704,cs),
+(190,704,o),
+(113,583,o),
+(113,478,cs),
+(113,410,o),
+(148,355,o),
+(212,327,c),
+(219,374,l),
+(108,344,o),
+(45,259,o),
+(45,157,cs),
+(45,60,o),
+(113,-14,o),
+(212,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(228,125,o),
+(205,150,o),
+(205,187,cs),
+(205,240,o),
+(244,293,o),
+(309,293,cs),
+(409,293,l),
+(431,186,l),
+(370,165,o),
+(314,125,o),
+(266,125,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(290,397,o),
+(264,426,o),
+(264,466,cs),
+(264,510,o),
+(294,565,o),
+(349,565,cs),
+(395,565,o),
+(439,529,o),
+(492,507,c),
+(421,397,l),
+(332,397,ls)
+);
+}
+);
+width = 736;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni166C;
+unicode = 5740;
+},
+{
+glyphname = "qai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (334,0);
+ref = "ke-canadian";
+}
+);
+width = 927;
+}
+);
+note = uni166F;
+unicode = 5743;
+},
+{
+glyphname = "ngai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (624,0);
+ref = "ce-canadian";
+}
+);
+width = 1208;
+}
+);
+note = uni1670;
+unicode = 5744;
+},
+{
+glyphname = "nngi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (916,0);
+ref = "ci-canadian";
+}
+);
+width = 1499;
+}
+);
+note = uni1671;
+unicode = 5745;
+},
+{
+glyphname = "nngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (916,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (1125,0);
+ref = dot_top;
+}
+);
+width = 1499;
+}
+);
+note = uni1672;
+unicode = 5746;
+},
+{
+glyphname = "nngo-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (916,0);
+ref = "ce-canadian";
+}
+);
+width = 1499;
+}
+);
+note = uni1673;
+unicode = 5747;
+},
+{
+glyphname = "nngoo-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (916,0);
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (1109,0);
+ref = dot_top;
+}
+);
+width = 1499;
+}
+);
+note = uni1674;
+unicode = 5748;
+},
+{
+glyphname = "nnga-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (916,0);
+ref = "ca-canadian";
+}
+);
+width = 1499;
+}
+);
+note = uni1675;
+unicode = 5749;
+},
+{
+glyphname = "nngaa-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (916,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (957,0);
+ref = dot_top;
+}
+);
+width = 1499;
+}
+);
+note = uni1676;
+unicode = 5750;
+},
+{
+glyphname = "thweeWoodScree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 852;
+}
+);
+note = uni1677;
+unicode = 5751;
+},
+{
+glyphname = "thwiWoodScree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 852;
+}
+);
+note = uni1678;
+unicode = 5752;
+},
+{
+glyphname = "thwiiWoodScree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (84,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 852;
+}
+);
+note = uni1679;
+unicode = 5753;
+},
+{
+glyphname = "thwoWoodScree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 852;
+}
+);
+note = uni167A;
+unicode = 5754;
+},
+{
+glyphname = "thwooWoodScree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (343,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 852;
+}
+);
+note = uni167B;
+unicode = 5755;
+},
+{
+glyphname = "thwaWoodScree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 852;
+}
+);
+note = uni167C;
+unicode = 5756;
+},
+{
+glyphname = "thwaaWoodScree-canadian";
+lastChange = "2023-01-13 15:57:37 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (83,0);
+ref = dot_top;
+},
+{
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 852;
+}
+);
+note = uni167D;
+unicode = 5757;
+},
+{
+glyphname = "wBlackfoot-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(438,545,l),
+(457,634,l),
+(136,634,l),
+(118,545,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(408,401,l),
+(426,490,l),
+(105,490,l),
+(87,401,l)
+);
+}
+);
+width = 428;
+}
+);
+metricRight = "=|";
+note = uni167F;
+unicode = 5759;
+},
+{
+glyphname = "oy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-3,0);
+ref = ring_top.canadian;
+}
+);
+width = 667;
+}
+);
+note = uni18B0;
+unicode = 6320;
+},
+{
+glyphname = "ay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (404,0);
+ref = ring_top.canadian;
+}
+);
+width = 667;
+}
+);
+note = uni18B1;
+unicode = 6321;
+},
+{
+glyphname = "aay-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (174,0);
+ref = ring_top.canadian;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (441,0);
+ref = dot_top;
+}
+);
+width = 667;
+}
+);
+note = uni18B2;
+unicode = 6322;
+},
+{
+glyphname = "way-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (640,0);
+ref = ring_top.canadian;
+}
+);
+width = 903;
+}
+);
+note = uni18B3;
+unicode = 6323;
+},
+{
+glyphname = "poy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-21,0);
+ref = ring_top.canadian;
+}
+);
+width = 645;
+}
+);
+note = uni18B4;
+unicode = 6324;
+},
+{
+glyphname = "pay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (403,0);
+ref = ring_top.canadian;
+}
+);
+width = 645;
+}
+);
+note = uni18B5;
+unicode = 6325;
+},
+{
+glyphname = "pwoy-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (215,0);
+ref = ring_top.canadian;
+}
+);
+width = 881;
+}
+);
+note = uni18B6;
+unicode = 6326;
+},
+{
+glyphname = "tay-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (205,0);
+ref = ring_top.canadian;
+}
+);
+width = 617;
+}
+);
+note = uni18B7;
+unicode = 6327;
+},
+{
+glyphname = "kay-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (4,0);
+ref = ring_top.canadian;
+}
+);
+width = 593;
+}
+);
+note = uni18B8;
+unicode = 6328;
+},
+{
+glyphname = "kway-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (241,0);
+ref = ring_top.canadian;
+}
+);
+width = 830;
+}
+);
+note = uni18B9;
+unicode = 6329;
+},
+{
+glyphname = "may-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (12,0);
+ref = ring_top.canadian;
+}
+);
+width = 552;
+}
+);
+note = uni18BA;
+unicode = 6330;
+},
+{
+glyphname = "noy-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (334,-179);
+ref = ring_top.canadian;
+}
+);
+width = 798;
+}
+);
+note = uni18BB;
+unicode = 6331;
+},
+{
+glyphname = "nay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (124,-179);
+ref = ring_top.canadian;
+}
+);
+width = 798;
+}
+);
+note = uni18BC;
+unicode = 6332;
+},
+{
+glyphname = "lay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (125,-179);
+ref = ring_top.canadian;
+}
+);
+width = 798;
+}
+);
+note = uni18BD;
+unicode = 6333;
+},
+{
+glyphname = "soy-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (283,0);
+ref = ring_top.canadian;
+}
+);
+width = 557;
+}
+);
+note = uni18BE;
+unicode = 6334;
+},
+{
+glyphname = "say-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (12,0);
+ref = ring_top.canadian;
+}
+);
+width = 557;
+}
+);
+note = uni18BF;
+unicode = 6335;
+},
+{
+glyphname = "shoy-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (279,-179);
+ref = ring_top.canadian;
+}
+);
+width = 898;
+}
+);
+note = uni18C0;
+unicode = 6336;
+},
+{
+glyphname = "shay-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (279,-179);
+ref = ring_top.canadian;
+}
+);
+width = 898;
+}
+);
+note = uni18C1;
+unicode = 6337;
+},
+{
+glyphname = "shwoy-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (516,-179);
+ref = ring_top.canadian;
+}
+);
+width = 1135;
+}
+);
+note = uni18C2;
+unicode = 6338;
+},
+{
+glyphname = "yoy-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (306,0);
+ref = ring_top.canadian;
+}
+);
+width = 580;
+}
+);
+note = uni18C3;
+unicode = 6339;
+},
+{
+glyphname = "yay-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (13,0);
+ref = ring_top.canadian;
+}
+);
+width = 580;
+}
+);
+note = uni18C4;
+unicode = 6340;
+},
+{
+glyphname = "ray-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (179,0);
+ref = ring_top.canadian;
+}
+);
+width = 557;
+}
+);
+note = uni18C5;
+unicode = 6341;
+},
+{
+glyphname = "nwi-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ni-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni18C6;
+unicode = 6342;
+},
+{
+glyphname = "nwiOjibway-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (798,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni18C7;
+unicode = 6343;
+},
+{
+glyphname = "nwii-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (419,-179);
+ref = dot_top;
+}
+);
+width = 1035;
+}
+);
+note = uni18C8;
+unicode = 6344;
+},
+{
+glyphname = "nwiiOjibway-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (183,-179);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (798,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni18C9;
+unicode = 6345;
+},
+{
+glyphname = "nwo-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "no-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni18CA;
+unicode = 6346;
+},
+{
+glyphname = "nwoOjibway-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (798,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni18CB;
+unicode = 6347;
+},
+{
+glyphname = "nwoo-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (609,-179);
+ref = dot_top;
+}
+);
+width = 1035;
+}
+);
+note = uni18CC;
+unicode = 6348;
+},
+{
+glyphname = "nwooOjibway-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (372,-179);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (798,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni18CD;
+unicode = 6349;
+},
+{
+glyphname = "rwee-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "reRCree-canadian";
+}
+);
+width = 1083;
+}
+);
+note = uni18CE;
+unicode = 6350;
+},
+{
+glyphname = "rwi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ri-canadian";
+}
+);
+width = 1083;
+}
+);
+note = uni18CF;
+unicode = 6351;
+},
+{
+glyphname = "rwii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (413,-179);
+ref = dot_top;
+}
+);
+width = 1083;
+}
+);
+note = uni18D0;
+unicode = 6352;
+},
+{
+glyphname = "rwo-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ro-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni18D1;
+unicode = 6353;
+},
+{
+glyphname = "rwoo-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (389,0);
+ref = dot_top;
+}
+);
+width = 794;
+}
+);
+note = uni18D2;
+unicode = 6354;
+},
+{
+glyphname = "rwa-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ra-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni18D3;
+unicode = 6355;
+},
+{
+glyphname = "pOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(166,345,l),
+(318,573,l),
+(241,573,l),
+(297,345,l),
+(397,345,l),
+(401,364,l),
+(312,690,l),
+(288,690,l),
+(60,364,l),
+(56,345,l)
+);
+}
+);
+width = 411;
+}
+);
+metricLeft = "kkCarrier-canadian";
+note = uni18D4;
+unicode = 6356;
+},
+{
+glyphname = "tOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 429;
+}
+);
+metricRight = "=|";
+note = uni1422;
+unicode = 6357;
+},
+{
+glyphname = "kOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(184,345,l),
+(213,481,l),
+(192,480,l),
+(195,455,o),
+(226,434,o),
+(266,434,cs),
+(349,434,o),
+(400,508,o),
+(400,581,cs),
+(400,649,o),
+(351,696,o),
+(272,696,cs),
+(195,696,o),
+(140,652,o),
+(122,566,cs),
+(74,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(235,512,o),
+(220,526,o),
+(220,550,cs),
+(220,579,o),
+(240,618,o),
+(270,618,cs),
+(292,618,o),
+(305,604,o),
+(305,580,cs),
+(305,551,o),
+(285,512,o),
+(256,512,cs)
+);
+}
+);
+width = 376;
+}
+);
+metricLeft = "k-canadian";
+metricRight = "k-canadian";
+note = uni18D6;
+unicode = 6358;
+},
+{
+glyphname = "cOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(184,345,l),
+(232,573,ls),
+(238,599,o),
+(253,611,o),
+(272,611,cs),
+(298,611,o),
+(308,596,o),
+(302,569,cs),
+(297,544,l),
+(398,544,l),
+(402,559,ls),
+(418,637,o),
+(371,696,o),
+(278,696,cs),
+(194,696,o),
+(140,650,o),
+(123,571,cs),
+(74,345,l)
+);
+}
+);
+width = 365;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni18D7;
+unicode = 6359;
+},
+{
+glyphname = "mOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(184,345,l),
+(235,588,l),
+(372,588,l),
+(394,690,l),
+(148,690,l),
+(74,345,l)
+);
+}
+);
+width = 340;
+}
+);
+metricLeft = "m-canadian";
+metricRight = "m-canadian";
+note = uni18D8;
+unicode = 6360;
+},
+{
+glyphname = "nOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(327,427,o),
+(385,493,o),
+(385,573,cs),
+(385,595,o),
+(378,617,o),
+(363,633,c),
+(347,588,l),
+(504,588,l),
+(526,690,l),
+(264,690,ls),
+(169,690,o),
+(111,626,o),
+(111,543,cs),
+(111,475,o),
+(160,427,o),
+(239,427,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(219,505,o),
+(206,521,o),
+(206,544,cs),
+(206,573,o),
+(222,612,o),
+(255,612,cs),
+(277,612,o),
+(291,596,o),
+(291,573,cs),
+(291,544,o),
+(273,505,o),
+(242,505,cs)
+);
+}
+);
+width = 472;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "n-canadian";
+note = uni18D9;
+unicode = 6361;
+},
+{
+glyphname = "sOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(185,345,l),
+(214,485,l),
+(133,441,l),
+(176,441,ls),
+(290,441,o),
+(365,509,o),
+(392,634,cs),
+(404,690,l),
+(295,690,l),
+(284,639,ls),
+(268,560,o),
+(227,527,o),
+(148,527,cs),
+(114,527,l),
+(75,345,l)
+);
+}
+);
+width = 364;
+}
+);
+metricLeft = "s-canadian";
+metricRight = "s-canadian";
+note = uni18DA;
+unicode = 6362;
+},
+{
+color = 1;
+glyphname = "shOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(282,340,o),
+(333,383,o),
+(356,469,cs),
+(384,572,ls),
+(392,603,o),
+(405,616,o),
+(427,616,cs),
+(451,616,o),
+(462,599,o),
+(456,572,cs),
+(450,545,l),
+(550,545,l),
+(554,566,ls),
+(571,645,o),
+(520,696,o),
+(431,696,cs),
+(350,696,o),
+(298,655,o),
+(275,567,cs),
+(248,465,ls),
+(241,435,o),
+(227,421,o),
+(205,421,cs),
+(181,421,o),
+(171,438,o),
+(176,465,cs),
+(182,492,l),
+(83,492,l),
+(78,470,ls),
+(62,392,o),
+(113,340,o),
+(201,340,cs)
+);
+}
+);
+width = 516;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "c-canadian";
+note = uni18DB;
+unicode = 6363;
+},
+{
+color = 9;
+glyphname = "easternw-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (-44,-307);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (166,0);
+ref = "glottalstop-canadian";
+}
+);
+width = 583;
+}
+);
+note = uni18DC;
+unicode = 6364;
+},
+{
+color = 9;
+glyphname = "westernw-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (749,-307);
+ref = dot_top;
+scale = (-1,1);
+},
+{
+alignment = -1;
+ref = "glottalstop-canadian";
+}
+);
+width = 583;
+}
+);
+metricLeft = "glottalstop-canadian";
+note = uni18DD;
+unicode = 6365;
+},
+{
+glyphname = "rweRCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "reRCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (846,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1083;
+}
+);
+note = uni18E0;
+unicode = 6368;
+},
+{
+glyphname = "looWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+}
+);
+width = 557;
+}
+);
+note = uni18E1;
+unicode = 6369;
+},
+{
+glyphname = "laaWestCree-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (321,0);
+ref = dot_top;
+}
+);
+width = 557;
+}
+);
+note = uni18E2;
+unicode = 6370;
+},
+{
+glyphname = "thwe-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "the-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (734,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 971;
+}
+);
+note = uni18E3;
+unicode = 6371;
+},
+{
+glyphname = "thwa-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (678,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 915;
+}
+);
+note = uni18E4;
+unicode = 6372;
+},
+{
+glyphname = "tthwe-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "tthe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (725,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 962;
+}
+);
+note = uni18E5;
+unicode = 6373;
+},
+{
+glyphname = "tthoo-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ttho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (196,0);
+ref = dot_top;
+}
+);
+width = 627;
+}
+);
+note = uni18E6;
+unicode = 6374;
+},
+{
+glyphname = "tthaa-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ttha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (216,0);
+ref = dot_top;
+}
+);
+width = 627;
+}
+);
+note = uni18E7;
+unicode = 6375;
+},
+{
+glyphname = "tlhwe-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "tlhe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (611,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 848;
+}
+);
+note = uni18E8;
+unicode = 6376;
+},
+{
+glyphname = "tlhoo-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "tlho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (220,0);
+ref = dot_top;
+}
+);
+width = 611;
+}
+);
+note = uni18E9;
+unicode = 6377;
+},
+{
+glyphname = "shweSayisi-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "sheSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (601,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni18EA;
+unicode = 6378;
+},
+{
+glyphname = "shooSayisi-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "shoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (371,0);
+ref = dot_top;
+}
+);
+width = 601;
+}
+);
+note = uni18EB;
+unicode = 6379;
+},
+{
+color = 9;
+glyphname = "hooSayisi-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "hoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (465,0);
+ref = dot_top;
+}
+);
+width = 700;
+}
+);
+note = uni18EC;
+unicode = 6380;
+},
+{
+color = 9;
+glyphname = "gwuCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "guCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (853,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1090;
+}
+);
+note = uni18ED;
+unicode = 6381;
+},
+{
+color = 9;
+glyphname = "deneGeeCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "geCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (277,0);
+ref = dot_top;
+}
+);
+width = 734;
+}
+);
+note = uni18EE;
+unicode = 6382;
+},
+{
+color = 9;
+glyphname = "gaaCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (287,0);
+ref = dot_top;
+}
+);
+width = 734;
+}
+);
+note = uni18EF;
+unicode = 6383;
+},
+{
+color = 9;
+glyphname = "gwaCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (734,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 971;
+}
+);
+note = uni18F0;
+unicode = 6384;
+},
+{
+color = 9;
+glyphname = "juuSayisi-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "juSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (278,0);
+ref = dot_top;
+}
+);
+width = 737;
+}
+);
+note = uni18F1;
+unicode = 6385;
+},
+{
+color = 9;
+glyphname = "jwaCarrier-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "jaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (780,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1016;
+}
+);
+note = uni18F2;
+unicode = 6386;
+},
+{
+glyphname = "lBeaverDene-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "pWestCree-canadian";
+}
+);
+width = 216;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+unicode = 6387;
+},
+{
+glyphname = "rBeaverDene-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(184,345,l),
+(218,511,ls),
+(229,560,o),
+(255,583,o),
+(301,583,cs),
+(312,583,l),
+(336,696,l),
+(328,696,ls),
+(276,696,o),
+(239,663,o),
+(227,605,c),
+(230,605,l),
+(248,690,l),
+(148,690,l),
+(74,345,l)
+);
+}
+);
+width = 269;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni18F4;
+unicode = 6388;
+},
+{
+color = 6;
+glyphname = "sDentalCarrier-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(222,183,ls),
+(312,183,o),
+(369,225,o),
+(369,304,cs),
+(369,358,o),
+(330,395,o),
+(266,395,cs),
+(217,395,ls),
+(196,395,o),
+(185,403,o),
+(185,417,cs),
+(185,439,o),
+(202,447,o),
+(226,447,cs),
+(396,447,l),
+(413,527,l),
+(238,527,ls),
+(148,527,o),
+(91,485,o),
+(91,406,cs),
+(91,351,o),
+(129,315,o),
+(194,315,cs),
+(242,315,ls),
+(263,315,o),
+(273,307,o),
+(273,294,cs),
+(273,272,o),
+(257,263,o),
+(233,263,cs),
+(64,263,l),
+(46,183,l)
+);
+}
+);
+width = 414;
+}
+);
+metricLeft = "shCarrier-canadian";
+metricRight = "=|";
+note = uni18F5;
+unicode = 6389;
+},
+{
+glyphname = "pWestCree-canadian.base";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-73,-345);
+ref = "pWestCree-canadian";
+}
+);
+width = 216;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.base";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-74,-345);
+ref = "c-canadian";
+}
+);
+width = 365;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "thSayisi-canadian.base";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-74,-345);
+ref = "thSayisi-canadian";
+}
+);
+width = 365;
+}
+);
+metricLeft = "=|c-canadian";
+note = uni14A2;
+},
+{
+glyphname = "mWestCree-canadian.base";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-74,-345);
+ref = "mWestCree-canadian";
+}
+);
+width = 364;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+glyphname = "pWestCree-canadian.mid";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-34,-162);
+ref = "pWestCree-canadian";
+}
+);
+width = 215;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.mid";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-162);
+ref = "c-canadian";
+}
+);
+width = 366;
+}
+);
+metricLeft = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "mWestCree-canadian.mid";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-162);
+ref = "mWestCree-canadian";
+}
+);
+width = 364;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+color = 11;
+glyphname = "ngaai-canadian.nunavik";
+lastChange = "2023-01-13 15:57:37 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (652,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (825,0);
+ref = ring_top.canadian;
+}
+);
+width = 1238;
+}
+);
+note = uni158E;
+},
+{
+color = 11;
+glyphname = "ngi-canadian.nunavik";
+lastChange = "2023-01-13 15:57:37 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (652,0);
+ref = "ci-canadian";
+}
+);
+width = 1238;
+}
+);
+note = uni158F;
+},
+{
+color = 11;
+glyphname = "ngii-canadian.nunavik";
+lastChange = "2023-01-13 15:57:37 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (652,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (863,0);
+ref = dot_top;
+}
+);
+width = 1238;
+}
+);
+note = uni1590;
+},
+{
+color = 11;
+glyphname = "ngo-canadian.nunavik";
+lastChange = "2023-01-13 15:57:37 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (652,0);
+ref = "co-canadian";
+}
+);
+width = 1237;
+}
+);
+note = uni1591;
+},
+{
+color = 11;
+glyphname = "ngoo-canadian.nunavik";
+lastChange = "2023-01-13 15:57:37 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "ngo-canadian.nunavik";
+},
+{
+anchor = top_right_can;
+pos = (1009,0);
+ref = dot_top;
+}
+);
+width = 1237;
+}
+);
+note = uni1592;
+},
+{
+color = 11;
+glyphname = "nga-canadian.nunavik";
+lastChange = "2023-01-13 15:57:37 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (652,0);
+ref = "ca-canadian";
+}
+);
+width = 1236;
+}
+);
+note = uni1593;
+},
+{
+color = 11;
+glyphname = "ngaa-canadian.nunavik";
+lastChange = "2023-01-13 15:57:37 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (652,0);
+ref = "ca-canadian";
+},
+{
+anchor = top_left_can;
+pos = (694,0);
+ref = dot_top;
+}
+);
+width = 1236;
+}
+);
+note = uni1594;
+},
+{
+color = 11;
+glyphname = "ng-canadian.nunavik";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(565,170,o),
+(621,248,o),
+(621,327,cs),
+(621,388,o),
+(582,432,o),
+(523,432,cs),
+(487,432,o),
+(456,416,o),
+(445,387,c),
+(462,358,l),
+(499,536,l),
+(339,536,l),
+(334,476,l),
+(371,498,o),
+(388,546,o),
+(388,583,cs),
+(388,650,o),
+(338,697,o),
+(260,697,cs),
+(169,697,o),
+(113,632,o),
+(113,552,cs),
+(113,483,o),
+(163,435,o),
+(238,435,cs),
+(431,435,l),
+(382,497,l),
+(346,325,ls),
+(328,242,o),
+(370,170,o),
+(468,170,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(454,248,o),
+(440,264,o),
+(440,287,cs),
+(440,316,o),
+(459,355,o),
+(489,355,cs),
+(510,355,o),
+(524,340,o),
+(524,317,cs),
+(524,288,o),
+(504,248,o),
+(475,248,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(222,513,o),
+(208,528,o),
+(208,552,cs),
+(208,581,o),
+(226,619,o),
+(258,619,cs),
+(280,619,o),
+(295,603,o),
+(295,580,cs),
+(295,551,o),
+(275,513,o),
+(244,513,cs)
+);
+}
+);
+width = 652;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+color = 11;
+glyphname = "ngai-canadian.nunavik";
+lastChange = "2023-01-13 15:57:37 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (652,0);
+ref = "ce-canadian";
+}
+);
+width = 1237;
+}
+);
+note = uni1670;
+},
+{
+color = 11;
+glyphname = "ke-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (449,690);
+},
+{
+name = top_left_can;
+pos = (242,690);
+},
+{
+name = top_right_can;
+pos = (674,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(608,0,l),
+(754,690,l),
+(464,690,ls),
+(230,690,o),
+(84,577,o),
+(84,368,cs),
+(84,223,o),
+(184,129,o),
+(347,129,cs),
+(474,129,l),
+(447,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(288,270,o),
+(242,309,o),
+(242,379,cs),
+(242,479,o),
+(304,550,o),
+(425,550,cs),
+(564,550,l),
+(504,270,l),
+(375,270,ls)
+);
+}
+);
+width = 722;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146B;
+},
+{
+color = 11;
+glyphname = "ki-canadian.square";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (463,690);
+},
+{
+name = top_left_can;
+pos = (238,690);
+},
+{
+name = top_right_can;
+pos = (687,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(170,0,l),
+(198,129,l),
+(338,129,ls),
+(561,129,o),
+(708,243,o),
+(708,451,cs),
+(708,596,o),
+(608,690,o),
+(444,690,cs),
+(156,690,l),
+(10,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(287,550,l),
+(420,550,ls),
+(503,550,o),
+(550,511,o),
+(550,440,cs),
+(550,340,o),
+(487,270,o),
+(372,270,cs),
+(228,270,l)
+);
+}
+);
+width = 722;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni146D;
+},
+{
+color = 11;
+glyphname = "kii-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (273,0);
+ref = dot_top;
+}
+);
+width = 724;
+}
+);
+note = uni146E;
+},
+{
+color = 11;
+glyphname = "ko-canadian.square";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (449,690);
+},
+{
+name = top_left_can;
+pos = (242,690);
+},
+{
+name = top_right_can;
+pos = (674,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(608,0,l),
+(754,690,l),
+(594,690,l),
+(567,560,l),
+(426,560,ls),
+(203,560,o),
+(56,446,o),
+(56,239,cs),
+(56,94,o),
+(156,0,o),
+(320,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(261,140,o),
+(215,179,o),
+(215,249,cs),
+(215,350,o),
+(277,420,o),
+(392,420,cs),
+(537,420,l),
+(477,140,l),
+(345,140,ls)
+);
+}
+);
+width = 722;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146F;
+},
+{
+color = 11;
+glyphname = "koo-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (487,0);
+ref = dot_top;
+}
+);
+width = 724;
+}
+);
+note = uni1470;
+},
+{
+color = 11;
+glyphname = "ka-canadian.square";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (463,690);
+},
+{
+name = top_left_can;
+pos = (238,690);
+},
+{
+name = top_right_can;
+pos = (688,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(300,0,ls),
+(534,0,o),
+(681,113,o),
+(681,322,cs),
+(681,467,o),
+(581,560,o),
+(417,560,cs),
+(290,560,l),
+(317,690,l),
+(156,690,l),
+(10,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(260,420,l),
+(390,420,ls),
+(476,420,o),
+(522,381,o),
+(522,311,cs),
+(522,211,o),
+(460,140,o),
+(339,140,cs),
+(200,140,l)
+);
+}
+);
+width = 723;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1472;
+},
+{
+color = 11;
+glyphname = "kaa-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (48,0);
+ref = dot_top;
+}
+);
+width = 724;
+}
+);
+note = uni1473;
+},
+{
+color = 11;
+glyphname = "kweWestCree-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (724,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 960;
+}
+);
+note = uni1475;
+},
+{
+color = 11;
+glyphname = "kwiiWestCree-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (273,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (724,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 960;
+}
+);
+note = uni1479;
+},
+{
+color = 11;
+glyphname = "kwoWestCree-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (724,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 960;
+}
+);
+note = uni147B;
+},
+{
+color = 11;
+glyphname = "kwooWestCree-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (487,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (724,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 960;
+}
+);
+note = uni147D;
+},
+{
+color = 11;
+glyphname = "kwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (724,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 960;
+}
+);
+note = uni147F;
+},
+{
+color = 11;
+glyphname = "kwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (48,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (724,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 960;
+}
+);
+note = uni1481;
+},
+{
+color = 11;
+glyphname = "ce-canadian.square";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (441,690);
+},
+{
+name = top_left_can;
+pos = (214,690);
+},
+{
+name = top_right_can;
+pos = (668,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(602,0,l),
+(678,361,ls),
+(723,568,o),
+(616,704,o),
+(408,704,cs),
+(232,704,o),
+(118,606,o),
+(79,427,cs),
+(68,377,l),
+(227,377,l),
+(235,414,ls),
+(256,511,o),
+(309,559,o),
+(396,559,cs),
+(501,559,o),
+(546,493,o),
+(520,373,cs),
+(441,0,l)
+);
+}
+);
+width = 709;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni1489;
+},
+{
+color = 11;
+glyphname = "ci-canadian.square";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (457,690);
+},
+{
+name = top_left_can;
+pos = (230,690);
+},
+{
+name = top_right_can;
+pos = (685,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(163,0,l),
+(247,396,ls),
+(271,507,o),
+(328,559,o),
+(422,559,cs),
+(518,559,o),
+(563,502,o),
+(543,405,cs),
+(537,377,l),
+(696,377,l),
+(700,398,ls),
+(739,579,o),
+(627,704,o),
+(430,704,cs),
+(250,704,o),
+(132,608,o),
+(94,428,cs),
+(3,0,l)
+);
+}
+);
+width = 708;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+},
+{
+color = 11;
+glyphname = "cii-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (269,0);
+ref = dot_top;
+}
+);
+width = 710;
+}
+);
+note = uni148C;
+},
+{
+color = 11;
+glyphname = "co-canadian.square";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (441,690);
+},
+{
+name = top_left_can;
+pos = (214,690);
+},
+{
+name = top_right_can;
+pos = (668,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(500,-14,o),
+(619,82,o),
+(658,262,cs),
+(749,690,l),
+(588,690,l),
+(503,294,ls),
+(480,183,o),
+(422,130,o),
+(329,130,cs),
+(233,130,o),
+(186,187,o),
+(207,285,cs),
+(213,313,l),
+(54,313,l),
+(50,292,ls),
+(12,111,o),
+(125,-14,o),
+(322,-14,cs)
+);
+}
+);
+width = 710;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+},
+{
+color = 11;
+glyphname = "coo-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (480,0);
+ref = dot_top;
+}
+);
+width = 710;
+}
+);
+note = uni148E;
+},
+{
+color = 11;
+glyphname = "ca-canadian.square";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (456,690);
+},
+{
+name = top_left_can;
+pos = (230,690);
+},
+{
+name = top_right_can;
+pos = (684,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(519,-14,o),
+(633,84,o),
+(671,263,cs),
+(683,313,l),
+(524,313,l),
+(516,275,ls),
+(495,179,o),
+(441,130,o),
+(354,130,cs),
+(249,130,o),
+(205,197,o),
+(231,317,cs),
+(309,690,l),
+(149,690,l),
+(72,328,ls),
+(28,122,o),
+(134,-14,o),
+(343,-14,cs)
+);
+}
+);
+width = 709;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+},
+{
+color = 11;
+glyphname = "caa-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (42,0);
+ref = dot_top;
+}
+);
+width = 710;
+}
+);
+note = uni1491;
+},
+{
+color = 11;
+glyphname = "me-canadian.square";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (393,690);
+},
+{
+name = top_double;
+pos = (569,690);
+},
+{
+name = top_left_can;
+pos = (209,690);
+},
+{
+name = top_right_can;
+pos = (569,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(502,0,l),
+(649,690,l),
+(129,690,l),
+(99,546,l),
+(457,546,l),
+(342,0,l)
+);
+}
+);
+width = 617;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+},
+{
+color = 11;
+glyphname = "mi-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (416,690);
+},
+{
+name = top_left_can;
+pos = (238,690);
+},
+{
+name = top_right_can;
+pos = (595,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(170,0,l),
+(287,546,l),
+(645,546,l),
+(675,690,l),
+(156,690,l),
+(10,0,l)
+);
+}
+);
+width = 616;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+},
+{
+color = 11;
+glyphname = "mii-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (228,0);
+ref = dot_top;
+}
+);
+width = 617;
+}
+);
+note = uni14A6;
+},
+{
+color = 11;
+glyphname = "mo-canadian.square";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (392,690);
+},
+{
+name = top_double;
+pos = (568,690);
+},
+{
+name = top_left_can;
+pos = (209,690);
+},
+{
+name = top_right_can;
+pos = (568,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(501,0,l),
+(648,690,l),
+(488,690,l),
+(371,144,l),
+(13,144,l),
+(-17,0,l)
+);
+}
+);
+width = 616;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+},
+{
+color = 11;
+glyphname = "moo-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (381,0);
+ref = dot_top;
+}
+);
+width = 617;
+}
+);
+note = uni14A8;
+},
+{
+color = 11;
+glyphname = "ma-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (416,690);
+},
+{
+name = top_left_can;
+pos = (238,690);
+},
+{
+name = top_right_can;
+pos = (595,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(529,0,l),
+(559,144,l),
+(201,144,l),
+(317,690,l),
+(156,690,l),
+(10,0,l)
+);
+}
+);
+width = 616;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+},
+{
+color = 11;
+glyphname = "maa-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (48,0);
+ref = dot_top;
+}
+);
+width = 617;
+}
+);
+note = uni14AB;
+},
+{
+color = 11;
+glyphname = "ne-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (527,690);
+},
+{
+name = top_left_can;
+pos = (350,690);
+},
+{
+name = top_right_can;
+pos = (707,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(559,-14,o),
+(655,72,o),
+(692,242,cs),
+(786,690,l),
+(135,690,l),
+(105,549,l),
+(239,549,l),
+(182,282,ls),
+(143,101,o),
+(230,-14,o),
+(405,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(350,131,o),
+(320,177,o),
+(336,255,cs),
+(398,549,l),
+(597,549,l),
+(531,242,ls),
+(515,166,o),
+(480,131,o),
+(418,131,cs)
+);
+}
+);
+width = 748;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C0;
+},
+{
+color = 11;
+glyphname = "ni-canadian.square";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (408,690);
+},
+{
+name = top_left_can;
+pos = (229,690);
+},
+{
+name = top_right_can;
+pos = (587,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(439,-14,o),
+(536,72,o),
+(573,242,cs),
+(638,549,l),
+(772,549,l),
+(801,690,l),
+(149,690,l),
+(63,282,ls),
+(24,101,o),
+(111,-14,o),
+(286,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(231,131,o),
+(201,178,o),
+(217,255,cs),
+(279,549,l),
+(477,549,l),
+(412,242,ls),
+(396,167,o),
+(361,131,o),
+(299,131,cs)
+);
+}
+);
+width = 749;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+},
+{
+color = 11;
+glyphname = "nii-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (220,0);
+ref = dot_top;
+}
+);
+width = 748;
+}
+);
+note = uni14C3;
+},
+{
+color = 11;
+glyphname = "no-canadian.square";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (529,690);
+},
+{
+name = top_double;
+pos = (539,690);
+},
+{
+name = top_left_can;
+pos = (352,690);
+},
+{
+name = top_right_can;
+pos = (699,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(641,0,l),
+(728,408,ls),
+(766,588,o),
+(679,704,o),
+(505,704,cs),
+(351,704,o),
+(255,617,o),
+(218,447,cs),
+(153,141,l),
+(19,141,l),
+(-10,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(379,448,ls),
+(395,523,o),
+(430,558,o),
+(492,558,cs),
+(560,558,o),
+(590,512,o),
+(574,435,cs),
+(511,141,l),
+(313,141,l)
+);
+}
+);
+width = 749;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C4;
+},
+{
+color = 11;
+glyphname = "noo-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (339,0);
+ref = dot_top;
+}
+);
+width = 748;
+}
+);
+note = uni14C5;
+},
+{
+color = 11;
+glyphname = "na-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (409,690);
+},
+{
+name = top_double;
+pos = (418,690);
+},
+{
+name = top_left_can;
+pos = (230,690);
+},
+{
+name = top_right_can;
+pos = (588,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(654,0,l),
+(685,141,l),
+(551,141,l),
+(608,408,ls),
+(646,588,o),
+(559,704,o),
+(384,704,cs),
+(231,704,o),
+(134,617,o),
+(98,447,cs),
+(3,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(258,448,ls),
+(274,524,o),
+(310,558,o),
+(371,558,cs),
+(440,558,o),
+(469,513,o),
+(453,435,cs),
+(391,141,l),
+(193,141,l)
+);
+}
+);
+width = 748;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+},
+{
+color = 11;
+glyphname = "naa-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (221,0);
+ref = dot_top;
+}
+);
+width = 748;
+}
+);
+note = uni14C8;
+},
+{
+color = 11;
+glyphname = "nweWestCree-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (748,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 984;
+}
+);
+note = uni14CA;
+},
+{
+color = 11;
+glyphname = "nwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (748,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 984;
+}
+);
+note = uni14CC;
+},
+{
+color = 11;
+glyphname = "nwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (221,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (748,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 984;
+}
+);
+note = uni14CE;
+},
+{
+color = 11;
+glyphname = "se-canadian.square";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (236,690);
+},
+{
+name = top_right_can;
+pos = (676,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(605,0,l),
+(670,308,l),
+(407,308,ls),
+(287,308,o),
+(245,359,o),
+(273,490,cs),
+(316,690,l),
+(155,690,l),
+(113,490,ls),
+(72,298,o),
+(184,168,o),
+(379,168,cs),
+(520,168,l),
+(489,208,l),
+(444,0,l)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14ED;
+},
+{
+color = 11;
+glyphname = "si-canadian.square";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (238,690);
+},
+{
+name = top_right_can;
+pos = (677,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(171,0,l),
+(215,209,l),
+(168,169,l),
+(306,169,ls),
+(541,169,o),
+(662,263,o),
+(708,477,cs),
+(753,690,l),
+(593,690,l),
+(549,483,ls),
+(525,370,o),
+(447,308,o),
+(333,308,cs),
+(76,308,l),
+(11,0,l)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+},
+{
+color = 11;
+glyphname = "sii-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (489,0);
+ref = dot_top;
+}
+);
+width = 722;
+}
+);
+note = uni14F0;
+},
+{
+color = 11;
+glyphname = "so-canadian.square";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (671,690);
+},
+{
+name = top_left_can;
+pos = (236,690);
+},
+{
+name = top_right_can;
+pos = (671,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(169,0,l),
+(213,207,ls),
+(238,320,o),
+(314,382,o),
+(429,382,cs),
+(687,382,l),
+(752,690,l),
+(591,690,l),
+(547,481,l),
+(595,521,l),
+(456,521,ls),
+(221,521,o),
+(99,427,o),
+(54,213,cs),
+(9,0,l)
+);
+}
+);
+width = 721;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+},
+{
+color = 11;
+glyphname = "soo-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (484,0);
+ref = dot_top;
+}
+);
+width = 722;
+}
+);
+note = uni14F2;
+},
+{
+color = 11;
+glyphname = "sa-canadian.square";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (239,690);
+},
+{
+name = top_right_can;
+pos = (674,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(608,0,l),
+(650,200,ls),
+(691,391,o),
+(580,522,o),
+(384,522,cs),
+(243,522,l),
+(274,482,l),
+(319,690,l),
+(157,690,l),
+(93,382,l),
+(355,382,ls),
+(476,382,o),
+(518,330,o),
+(490,200,cs),
+(447,0,l)
+);
+}
+);
+width = 721;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+},
+{
+color = 11;
+glyphname = "saa-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+}
+);
+width = 722;
+}
+);
+note = uni14F5;
+},
+{
+color = 11;
+glyphname = "sho-canadian.square";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (451,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(598,0,l),
+(626,130,l),
+(280,130,ls),
+(229,130,o),
+(201,151,o),
+(201,189,cs),
+(201,246,o),
+(240,281,o),
+(312,281,cs),
+(445,281,ls),
+(613,281,o),
+(716,359,o),
+(716,515,cs),
+(716,622,o),
+(643,690,o),
+(525,690,cs),
+(157,690,l),
+(130,559,l),
+(477,559,ls),
+(529,559,o),
+(556,539,o),
+(556,501,cs),
+(556,442,o),
+(518,410,o),
+(446,410,cs),
+(313,410,ls),
+(144,410,o),
+(42,329,o),
+(42,175,cs),
+(42,69,o),
+(115,0,o),
+(234,0,cs)
+);
+}
+);
+width = 716;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+color = 11;
+glyphname = "shoo-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (265,0);
+ref = dot_top;
+}
+);
+width = 715;
+}
+);
+note = g728;
+},
+{
+color = 11;
+glyphname = "sha-canadian.square";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (495,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(386,0,ls),
+(557,0,o),
+(658,80,o),
+(658,237,cs),
+(658,343,o),
+(587,410,o),
+(470,410,cs),
+(340,410,ls),
+(288,410,o),
+(261,429,o),
+(261,469,cs),
+(261,527,o),
+(299,559,o),
+(370,559,cs),
+(719,559,l),
+(746,690,l),
+(372,690,ls),
+(204,690,o),
+(101,611,o),
+(101,454,cs),
+(101,348,o),
+(172,281,o),
+(291,281,cs),
+(419,281,ls),
+(471,281,o),
+(498,262,o),
+(498,223,cs),
+(498,164,o),
+(461,130,o),
+(388,130,cs),
+(39,130,l),
+(11,0,l)
+);
+}
+);
+width = 717;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+color = 11;
+glyphname = "shaa-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (305,0);
+ref = dot_top;
+}
+);
+width = 715;
+}
+);
+note = g730;
+},
+{
+color = 11;
+glyphname = "ye-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (205,690);
+},
+{
+name = top_right_can;
+pos = (693,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(625,0,l),
+(691,308,l),
+(284,308,l),
+(284,226,l),
+(756,584,l),
+(666,701,l),
+(21,209,l),
+(13,168,l),
+(501,168,l),
+(465,0,l)
+);
+}
+);
+width = 735;
+}
+);
+metricLeft = "ye-canadian";
+note = uni1526;
+},
+{
+color = 11;
+glyphname = "yi-canadian.square";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (231,690);
+},
+{
+name = top_right_can;
+pos = (719,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(165,0,l),
+(201,168,l),
+(689,168,l),
+(697,209,l),
+(234,701,l),
+(114,596,l),
+(460,226,l),
+(476,308,l),
+(70,308,l),
+(4,0,l)
+);
+}
+);
+width = 735;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni1528;
+},
+{
+color = 11;
+glyphname = "yii-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (43,0);
+ref = dot_top;
+}
+);
+width = 735;
+}
+);
+note = uni1529;
+},
+{
+color = 11;
+glyphname = "yo-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (694,690);
+},
+{
+name = top_left_can;
+pos = (206,690);
+},
+{
+name = top_right_can;
+pos = (694,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(664,94,l),
+(317,464,l),
+(300,382,l),
+(708,382,l),
+(773,690,l),
+(612,690,l),
+(577,522,l),
+(88,522,l),
+(79,481,l),
+(543,-12,l)
+);
+}
+);
+width = 735;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152A;
+},
+{
+color = 11;
+glyphname = "yoo-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (504,0);
+ref = dot_top;
+}
+);
+width = 735;
+}
+);
+note = uni152B;
+},
+{
+color = 11;
+glyphname = "ya-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (232,690);
+},
+{
+name = top_right_can;
+pos = (719,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(756,481,l),
+(765,522,l),
+(276,522,l),
+(313,690,l),
+(153,690,l),
+(87,382,l),
+(494,382,l),
+(494,464,l),
+(21,105,l),
+(112,-12,l)
+);
+}
+);
+width = 735;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152D;
+},
+{
+color = 11;
+glyphname = "yaa-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (43,0);
+ref = dot_top;
+}
+);
+width = 735;
+}
+);
+note = uni152E;
+},
+{
+color = 11;
+glyphname = "re-canadian.square";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (408,690);
+},
+{
+name = top_left_can;
+pos = (229,690);
+},
+{
+name = top_right_can;
+pos = (587,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(439,-14,o),
+(536,72,o),
+(573,242,cs),
+(638,549,l),
+(772,549,l),
+(801,690,l),
+(507,690,l),
+(412,242,ls),
+(396,167,o),
+(361,131,o),
+(299,131,cs),
+(231,131,o),
+(201,178,o),
+(217,255,cs),
+(309,690,l),
+(149,690,l),
+(63,282,ls),
+(24,101,o),
+(111,-14,o),
+(286,-14,cs)
+);
+}
+);
+width = 749;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1542;
+},
+{
+color = 11;
+glyphname = "reRCree-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (527,690);
+},
+{
+name = top_left_can;
+pos = (350,690);
+},
+{
+name = top_right_can;
+pos = (707,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(559,-14,o),
+(655,72,o),
+(692,242,cs),
+(786,690,l),
+(627,690,l),
+(531,242,ls),
+(515,166,o),
+(480,131,o),
+(418,131,cs),
+(350,131,o),
+(320,177,o),
+(336,255,cs),
+(428,690,l),
+(135,690,l),
+(105,549,l),
+(239,549,l),
+(182,282,ls),
+(143,101,o),
+(230,-14,o),
+(405,-14,cs)
+);
+}
+);
+width = 748;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni1543;
+},
+{
+color = 11;
+glyphname = "leWestCree-canadian.square";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (529,690);
+},
+{
+name = top_left_can;
+pos = (351,690);
+},
+{
+name = top_right_can;
+pos = (709,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(283,0,l),
+(379,448,ls),
+(395,523,o),
+(430,557,o),
+(492,557,cs),
+(560,557,o),
+(590,512,o),
+(574,434,cs),
+(482,0,l),
+(641,0,l),
+(728,407,ls),
+(766,588,o),
+(680,703,o),
+(505,703,cs),
+(351,703,o),
+(255,617,o),
+(218,447,cs),
+(153,141,l),
+(19,141,l),
+(-10,0,l)
+);
+}
+);
+width = 753;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+},
+{
+color = 11;
+glyphname = "ri-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (409,690);
+},
+{
+name = top_left_can;
+pos = (233,690);
+},
+{
+name = top_right_can;
+pos = (588,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(162,0,l),
+(258,448,ls),
+(274,524,o),
+(310,558,o),
+(371,558,cs),
+(440,558,o),
+(469,513,o),
+(453,435,cs),
+(361,0,l),
+(654,0,l),
+(685,141,l),
+(551,141,l),
+(608,408,ls),
+(646,588,o),
+(559,704,o),
+(384,704,cs),
+(231,704,o),
+(134,617,o),
+(98,447,cs),
+(3,0,l)
+);
+}
+);
+width = 748;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+},
+{
+color = 11;
+glyphname = "rii-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (221,0);
+ref = dot_top;
+}
+);
+width = 748;
+}
+);
+note = uni1547;
+},
+{
+color = 11;
+glyphname = "ro-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (454,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(170,0,l),
+(213,200,l),
+(125,129,l),
+(330,129,ls),
+(543,129,o),
+(690,243,o),
+(690,451,cs),
+(690,596,o),
+(589,690,o),
+(426,690,cs),
+(156,690,l),
+(127,550,l),
+(402,550,ls),
+(485,550,o),
+(530,510,o),
+(530,440,cs),
+(530,338,o),
+(468,270,o),
+(342,270,cs),
+(67,270,l),
+(10,0,l)
+);
+}
+);
+width = 704;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1548;
+},
+{
+color = 11;
+glyphname = "loWestCree-canadian.square";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (454,690);
+},
+{
+name = top_left_can;
+pos = (238,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(298,0,ls),
+(518,0,o),
+(664,113,o),
+(664,322,cs),
+(664,467,o),
+(564,560,o),
+(401,560,cs),
+(218,560,l),
+(274,490,l),
+(318,690,l),
+(157,690,l),
+(99,420,l),
+(376,420,ls),
+(460,420,o),
+(505,381,o),
+(505,311,cs),
+(505,211,o),
+(443,140,o),
+(317,140,cs),
+(40,140,l),
+(10,0,l)
+);
+}
+);
+width = 698;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+},
+{
+color = 11;
+glyphname = "ra-canadian.square";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (435,690);
+},
+{
+name = top_right_can;
+pos = (651,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(583,0,l),
+(641,270,l),
+(364,270,ls),
+(280,270,o),
+(235,309,o),
+(235,379,cs),
+(235,479,o),
+(298,550,o),
+(423,550,cs),
+(700,550,l),
+(730,690,l),
+(441,690,ls),
+(222,690,o),
+(76,577,o),
+(76,368,cs),
+(76,223,o),
+(177,129,o),
+(340,129,cs),
+(523,129,l),
+(466,200,l),
+(422,0,l)
+);
+}
+);
+width = 698;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+},
+{
+color = 11;
+glyphname = "raa-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (244,0);
+ref = dot_top;
+}
+);
+width = 697;
+}
+);
+note = uni154C;
+},
+{
+color = 11;
+glyphname = "laWestCree-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (650,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(582,0,l),
+(612,140,l),
+(336,140,ls),
+(252,140,o),
+(207,180,o),
+(207,249,cs),
+(207,352,o),
+(270,420,o),
+(395,420,cs),
+(672,420,l),
+(729,690,l),
+(569,690,l),
+(526,490,l),
+(614,560,l),
+(407,560,ls),
+(195,560,o),
+(48,446,o),
+(48,239,cs),
+(48,94,o),
+(148,0,o),
+(311,0,cs)
+);
+}
+);
+width = 697;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+},
+{
+color = 11;
+glyphname = "reWestCree-canadian.square";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(582,0,l),
+(867,201,l),
+(785,318,l),
+(576,173,l),
+(630,129,l),
+(678,361,ls),
+(723,569,o),
+(617,704,o),
+(409,704,cs),
+(243,704,o),
+(118,609,o),
+(79,427,cs),
+(68,377,l),
+(227,377,l),
+(235,414,ls),
+(256,511,o),
+(309,559,o),
+(396,559,cs),
+(501,559,o),
+(546,493,o),
+(520,373,cs),
+(441,0,l)
+);
+}
+);
+width = 895;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+},
+{
+color = 11;
+glyphname = "riWestCree-canadian.square";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(349,0,l),
+(433,396,ls),
+(457,507,o),
+(514,559,o),
+(607,559,cs),
+(703,559,o),
+(750,502,o),
+(729,405,cs),
+(724,377,l),
+(882,377,l),
+(887,398,ls),
+(924,579,o),
+(811,704,o),
+(615,704,cs),
+(441,704,o),
+(317,608,o),
+(279,428,cs),
+(215,128,l),
+(280,148,l),
+(117,309,l),
+(8,201,l),
+(208,0,l)
+);
+}
+);
+width = 895;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+},
+{
+color = 11;
+glyphname = "roWestCree-canadian.square";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(496,-14,o),
+(619,82,o),
+(658,262,cs),
+(722,561,l),
+(656,542,l),
+(820,381,l),
+(929,489,l),
+(729,690,l),
+(587,690,l),
+(503,294,ls),
+(479,183,o),
+(422,130,o),
+(329,130,cs),
+(233,130,o),
+(186,187,o),
+(207,285,cs),
+(213,313,l),
+(54,313,l),
+(50,292,ls),
+(12,111,o),
+(125,-14,o),
+(322,-14,cs)
+);
+}
+);
+width = 895;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+},
+{
+color = 11;
+glyphname = "raWestCree-canadian.square";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(693,-14,o),
+(818,81,o),
+(858,263,cs),
+(868,313,l),
+(710,313,l),
+(701,275,ls),
+(680,179,o),
+(627,130,o),
+(540,130,cs),
+(435,130,o),
+(391,197,o),
+(416,317,cs),
+(495,690,l),
+(354,690,l),
+(70,489,l),
+(152,372,l),
+(360,517,l),
+(307,560,l),
+(258,328,ls),
+(214,121,o),
+(319,-14,o),
+(528,-14,cs)
+);
+}
+);
+width = 894;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+},
+{
+color = 11;
+glyphname = "theThCree-canadian.square";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (205,690);
+},
+{
+name = top_right_can;
+pos = (693,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(625,0,l),
+(636,50,l),
+(715,50,l),
+(730,120,l),
+(651,120,l),
+(691,308,l),
+(324,308,l),
+(338,264,l),
+(756,584,l),
+(666,701,l),
+(21,209,l),
+(13,168,l),
+(501,168,l),
+(491,120,l),
+(278,120,l),
+(264,50,l),
+(475,50,l),
+(465,0,l)
+);
+}
+);
+width = 783;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15A7;
+},
+{
+color = 11;
+glyphname = "thiThCree-canadian.square";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (277,690);
+},
+{
+name = top_right_can;
+pos = (765,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(212,0,l),
+(223,50,l),
+(436,50,l),
+(450,120,l),
+(239,120,l),
+(249,168,l),
+(737,168,l),
+(746,209,l),
+(282,701,l),
+(162,596,l),
+(477,256,l),
+(500,308,l),
+(118,308,l),
+(78,120,l),
+(-1,120,l),
+(-15,50,l),
+(63,50,l),
+(52,0,l)
+);
+}
+);
+width = 783;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+},
+{
+color = 11;
+glyphname = "thiiThCree-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (90,0);
+ref = dot_top;
+}
+);
+width = 784;
+}
+);
+note = uni15A9;
+},
+{
+color = 11;
+glyphname = "thoThCree-canadian.square";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (205,690);
+},
+{
+name = top_right_can;
+pos = (693,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(663,94,l),
+(348,434,l),
+(325,382,l),
+(707,382,l),
+(747,570,l),
+(826,570,l),
+(840,639,l),
+(762,639,l),
+(773,690,l),
+(611,690,l),
+(601,639,l),
+(389,639,l),
+(375,570,l),
+(586,570,l),
+(576,522,l),
+(88,522,l),
+(79,481,l),
+(543,-12,l)
+);
+}
+);
+width = 783;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+},
+{
+color = 11;
+glyphname = "thooThCree-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (504,0);
+ref = dot_top;
+}
+);
+width = 784;
+}
+);
+note = uni15AB;
+},
+{
+color = 11;
+glyphname = "thaThCree-canadian.square";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (281,690);
+},
+{
+name = top_right_can;
+pos = (768,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(805,481,l),
+(813,522,l),
+(325,522,l),
+(335,570,l),
+(547,570,l),
+(562,639,l),
+(351,639,l),
+(361,690,l),
+(200,690,l),
+(189,639,l),
+(110,639,l),
+(96,570,l),
+(175,570,l),
+(135,382,l),
+(502,382,l),
+(488,426,l),
+(69,105,l),
+(160,-12,l)
+);
+}
+);
+width = 784;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+},
+{
+color = 11;
+glyphname = "thaaThCree-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (93,0);
+ref = dot_top;
+}
+);
+width = 784;
+}
+);
+note = uni15AD;
+},
+{
+color = 11;
+glyphname = "thweeWoodScree-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (784,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1021;
+}
+);
+note = uni1677;
+},
+{
+color = 11;
+glyphname = "thwiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (784,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1021;
+}
+);
+note = uni1678;
+},
+{
+color = 11;
+glyphname = "thwiiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (90,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (784,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1021;
+}
+);
+note = uni1679;
+},
+{
+color = 11;
+glyphname = "thwoWoodScree-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (784,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1021;
+}
+);
+note = uni167A;
+},
+{
+color = 11;
+glyphname = "thwooWoodScree-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (504,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (784,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1021;
+}
+);
+note = uni167B;
+},
+{
+color = 11;
+glyphname = "thwaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (784,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1021;
+}
+);
+note = uni167C;
+},
+{
+color = 11;
+glyphname = "thwaaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (93,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (784,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1021;
+}
+);
+note = uni167D;
+},
+{
+color = 11;
+glyphname = "nwiOjibway-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (748,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 984;
+}
+);
+note = uni18C7;
+},
+{
+color = 11;
+glyphname = "nwiiOjibway-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (220,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (748,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 984;
+}
+);
+note = uni18C9;
+},
+{
+color = 11;
+glyphname = "nwoOjibway-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (748,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 984;
+}
+);
+note = uni18CB;
+},
+{
+color = 11;
+glyphname = "nwooOjibway-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (339,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (748,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 984;
+}
+);
+note = uni18CD;
+},
+{
+color = 11;
+glyphname = "looWestCree-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+}
+);
+width = 697;
+}
+);
+note = uni18E1;
+},
+{
+color = 11;
+glyphname = "laaWestCree-canadian.square";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (461,0);
+ref = dot_top;
+}
+);
+width = 697;
+}
+);
+note = uni18E2;
+},
+{
+color = 0;
+glyphname = zero;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(579,573,o),
+(501,699,o),
+(334,699,cs),
+(165,699,o),
+(90,572,o),
+(90,345,cs),
+(90,110,o),
+(174,-10,o),
+(334,-10,cs),
+(500,-10,o),
+(579,104,o),
+(579,345,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(252,424,o),
+(254,569,o),
+(334,569,cs),
+(416,569,o),
+(416,423,o),
+(416,345,cs),
+(416,256,o),
+(412,121,o),
+(334,121,cs),
+(259,121,o),
+(252,256,o),
+(252,345,cs)
+);
+}
+);
+width = 629;
+}
+);
+unicode = 48;
+},
+{
+color = 0;
+glyphname = one;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(297,690,l),
+(67,504,l),
+(152,400,l),
+(236,468,ls),
+(251,480,o),
+(264,494,o),
+(280,512,c),
+(278,464,o),
+(278,423,o),
+(278,381,cs),
+(278,0,l),
+(443,0,l),
+(443,690,l)
+);
+}
+);
+width = 564;
+}
+);
+unicode = 49;
+},
+{
+color = 0;
+glyphname = two;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(599,0,l),
+(599,135,l),
+(321,135,l),
+(321,139,l),
+(392,209,ls),
+(476,287,o),
+(533,344,o),
+(561,407,cs),
+(576,438,o),
+(582,473,o),
+(582,512,cs),
+(582,621,o),
+(493,699,o),
+(359,699,cs),
+(241,699,o),
+(174,656,o),
+(106,595,c),
+(196,490,l),
+(252,538,o),
+(296,562,o),
+(341,562,cs),
+(385,562,o),
+(420,540,o),
+(420,490,cs),
+(420,451,o),
+(406,420,o),
+(367,375,cs),
+(347,352,o),
+(320,323,o),
+(285,287,cs),
+(110,108,l),
+(110,0,l)
+);
+}
+);
+width = 645;
+}
+);
+unicode = 50;
+},
+{
+color = 0;
+glyphname = three;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(575,639,o),
+(490,699,o),
+(352,699,cs),
+(237,699,o),
+(170,668,o),
+(113,630,c),
+(182,520,l),
+(212,541,o),
+(266,568,o),
+(327,568,cs),
+(381,568,o),
+(416,547,o),
+(416,500,cs),
+(416,433,o),
+(335,415,o),
+(267,415,cs),
+(218,415,l),
+(218,292,l),
+(266,292,ls),
+(377,292,o),
+(423,268,o),
+(423,206,cs),
+(423,154,o),
+(390,120,o),
+(292,120,cs),
+(238,120,o),
+(170,134,o),
+(111,164,c),
+(111,28,l),
+(169,5,o),
+(228,-10,o),
+(315,-10,cs),
+(473,-10,o),
+(596,58,o),
+(596,196,cs),
+(596,294,o),
+(534,348,o),
+(423,360,c),
+(423,363,l),
+(510,385,o),
+(575,444,o),
+(575,539,cs)
+);
+}
+);
+width = 638;
+}
+);
+unicode = 51;
+},
+{
+color = 0;
+glyphname = four;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(478,264,l),
+(478,691,l),
+(327,691,l),
+(29,261,l),
+(29,141,l),
+(317,141,l),
+(317,0,l),
+(478,0,l),
+(478,141,l),
+(562,141,l),
+(562,264,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(172,264,l),
+(276,413,ls),
+(295,441,o),
+(302,455,o),
+(316,484,c),
+(321,484,l),
+(321,478,o),
+(317,444,o),
+(317,384,cs),
+(317,264,l)
+);
+}
+);
+width = 592;
+}
+);
+unicode = 52;
+},
+{
+color = 0;
+glyphname = five;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(309,446,o),
+(289,440,o),
+(267,436,c),
+(278,554,l),
+(523,554,l),
+(523,690,l),
+(139,690,l),
+(113,333,l),
+(174,302,l),
+(203,311,o),
+(239,320,o),
+(277,320,cs),
+(361,320,o),
+(403,283,o),
+(403,222,cs),
+(403,156,o),
+(357,120,o),
+(280,120,cs),
+(221,120,o),
+(148,140,o),
+(99,163,c),
+(99,28,l),
+(149,4,o),
+(213,-10,o),
+(293,-10,cs),
+(476,-10,o),
+(568,75,o),
+(568,227,cs),
+(568,365,o),
+(479,446,o),
+(357,446,cs)
+);
+}
+);
+width = 617;
+}
+);
+unicode = 53;
+},
+{
+color = 0;
+glyphname = six;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(79,115,o),
+(167,-10,o),
+(334,-10,cs),
+(481,-10,o),
+(572,81,o),
+(572,233,cs),
+(572,374,o),
+(499,455,o),
+(378,455,cs),
+(300,455,o),
+(257,418,o),
+(232,370,c),
+(227,370,l),
+(233,497,o),
+(284,572,o),
+(427,572,cs),
+(472,572,o),
+(502,568,o),
+(528,562,c),
+(528,692,l),
+(502,696,o),
+(459,699,o),
+(430,699,cs),
+(174,699,o),
+(79,541,o),
+(79,292,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(270,121,o),
+(242,177,o),
+(242,242,cs),
+(242,287,o),
+(279,328,o),
+(333,328,cs),
+(389,328,o),
+(413,292,o),
+(413,230,cs),
+(413,156,o),
+(382,121,o),
+(330,121,cs)
+);
+}
+);
+width = 609;
+}
+);
+unicode = 54;
+},
+{
+color = 0;
+glyphname = seven;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(608,593,l),
+(608,690,l),
+(119,690,l),
+(119,554,l),
+(434,554,l),
+(189,0,l),
+(359,0,l)
+);
+}
+);
+width = 632;
+}
+);
+unicode = 55;
+},
+{
+color = 0;
+glyphname = eight;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(475,-10,o),
+(579,52,o),
+(579,183,cs),
+(579,274,o),
+(505,327,o),
+(434,364,c),
+(507,399,o),
+(558,450,o),
+(558,533,cs),
+(558,644,o),
+(468,699,o),
+(334,699,cs),
+(197,699,o),
+(107,639,o),
+(107,533,cs),
+(107,450,o),
+(160,399,o),
+(220,361,c),
+(143,326,o),
+(87,277,o),
+(87,180,cs),
+(87,68,o),
+(164,-10,o),
+(332,-10,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(272,109,o),
+(237,140,o),
+(237,186,cs),
+(237,238,o),
+(281,269,o),
+(330,292,c),
+(385,265,o),
+(429,232,o),
+(429,184,cs),
+(429,136,o),
+(395,109,o),
+(330,109,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(291,455,o),
+(261,481,o),
+(261,519,cs),
+(261,557,o),
+(294,581,o),
+(333,581,cs),
+(374,581,o),
+(405,558,o),
+(405,519,cs),
+(405,477,o),
+(371,454,o),
+(332,435,c)
+);
+}
+);
+width = 621;
+}
+);
+unicode = 56;
+},
+{
+color = 0;
+glyphname = nine;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(582,574,o),
+(496,699,o),
+(327,699,cs),
+(180,699,o),
+(89,610,o),
+(89,458,cs),
+(89,316,o),
+(163,235,o),
+(280,235,cs),
+(361,235,o),
+(404,270,o),
+(429,320,c),
+(434,320,l),
+(427,180,o),
+(361,118,o),
+(224,118,cs),
+(187,118,o),
+(160,121,o),
+(133,127,c),
+(133,-4,l),
+(159,-9,o),
+(202,-10,o),
+(232,-10,cs),
+(485,-10,o),
+(582,149,o),
+(582,389,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(393,569,o),
+(418,506,o),
+(418,447,cs),
+(418,405,o),
+(379,361,o),
+(329,361,cs),
+(275,361,o),
+(247,399,o),
+(247,460,cs),
+(247,533,o),
+(278,569,o),
+(332,569,cs)
+);
+}
+);
+width = 634;
+}
+);
+unicode = 57;
+},
+{
+glyphname = zero.canadian;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(514,-12,o),
+(599,281,o),
+(599,452,cs),
+(599,611,o),
+(520,704,o),
+(378,704,cs),
+(140,704,o),
+(56,411,o),
+(56,240,cs),
+(56,81,o),
+(135,-12,o),
+(278,-12,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(238,131,o),
+(212,169,o),
+(212,241,cs),
+(212,323,o),
+(252,560,o),
+(365,560,cs),
+(416,560,o),
+(443,523,o),
+(443,452,cs),
+(443,369,o),
+(403,131,o),
+(289,131,cs)
+);
+}
+);
+width = 612;
+}
+);
+metricRight = "=|";
+},
+{
+glyphname = one.canadian;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(312,0,l),
+(459,690,l),
+(316,690,l),
+(62,509,l),
+(144,393,l),
+(384,563,l),
+(276,584,l),
+(152,0,l)
+);
+}
+);
+width = 427;
+}
+);
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = two.canadian;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(526,144,l),
+(230,144,l),
+(222,81,l),
+(443,264,ls),
+(536,340,o),
+(588,413,o),
+(588,511,cs),
+(588,624,o),
+(505,704,o),
+(371,704,cs),
+(225,704,o),
+(120,615,o),
+(83,448,c),
+(242,448,l),
+(259,527,o),
+(297,565,o),
+(355,565,cs),
+(404,565,o),
+(429,538,o),
+(429,498,cs),
+(429,440,o),
+(389,396,o),
+(327,347,cs),
+(34,105,l),
+(12,0,l),
+(496,0,l)
+);
+}
+);
+width = 588;
+}
+);
+note = uni14BF;
+},
+{
+glyphname = three.canadian;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(449,-14,o),
+(538,84,o),
+(538,213,cs),
+(538,287,o),
+(498,341,o),
+(428,361,c),
+(414,309,l),
+(531,326,o),
+(595,421,o),
+(595,522,cs),
+(595,624,o),
+(514,704,o),
+(373,704,cs),
+(221,704,o),
+(114,615,o),
+(90,459,c),
+(248,459,l),
+(263,526,o),
+(298,565,o),
+(356,565,cs),
+(406,565,o),
+(434,538,o),
+(434,497,cs),
+(434,451,o),
+(409,412,o),
+(350,412,cs),
+(311,412,l),
+(282,279,l),
+(320,279,ls),
+(361,279,o),
+(382,259,o),
+(382,223,cs),
+(382,173,o),
+(347,125,o),
+(284,125,cs),
+(219,125,o),
+(189,172,o),
+(199,231,c),
+(40,231,l),
+(23,90,o),
+(111,-14,o),
+(281,-14,cs)
+);
+}
+);
+width = 610;
+}
+);
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = four.canadian;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(429,0,l),
+(459,142,l),
+(544,142,l),
+(571,271,l),
+(486,271,l),
+(576,691,l),
+(450,691,l),
+(33,244,l),
+(12,142,l),
+(301,142,l),
+(271,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(447,537,l),
+(388,537,l),
+(332,271,l),
+(163,271,l),
+(169,232,l)
+);
+}
+);
+width = 592;
+}
+);
+},
+{
+glyphname = five.canadian;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(469,-14,o),
+(554,120,o),
+(554,250,cs),
+(554,364,o),
+(476,436,o),
+(351,436,cs),
+(245,436,l),
+(282,399,l),
+(339,595,l),
+(280,551,l),
+(589,551,l),
+(619,690,l),
+(213,690,l),
+(110,334,l),
+(135,299,l),
+(302,299,ls),
+(362,299,o),
+(395,276,o),
+(395,231,cs),
+(395,178,o),
+(360,125,o),
+(293,125,cs),
+(232,125,o),
+(202,161,o),
+(208,211,c),
+(48,211,l),
+(34,78,o),
+(132,-14,o),
+(289,-14,cs)
+);
+}
+);
+width = 606;
+}
+);
+},
+{
+glyphname = six.canadian;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(465,-14,o),
+(569,93,o),
+(569,243,cs),
+(569,357,o),
+(491,436,o),
+(363,436,cs),
+(295,436,o),
+(240,411,o),
+(195,357,c),
+(225,302,l),
+(226,326,o),
+(228,340,o),
+(234,370,cs),
+(262,508,o),
+(309,566,o),
+(380,566,cs),
+(447,566,o),
+(467,526,o),
+(465,480,c),
+(623,480,l),
+(634,614,o),
+(536,704,o),
+(388,704,cs),
+(151,704,o),
+(57,445,o),
+(57,239,cs),
+(57,171,o),
+(71,120,o),
+(99,78,cs),
+(136,22,o),
+(208,-14,o),
+(301,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(248,119,o),
+(212,149,o),
+(212,197,cs),
+(212,253,o),
+(250,305,o),
+(321,305,cs),
+(379,305,o),
+(413,274,o),
+(413,225,cs),
+(413,171,o),
+(376,119,o),
+(306,119,cs)
+);
+}
+);
+width = 610;
+}
+);
+metricLeft = zero.canadian;
+},
+{
+glyphname = seven.canadian;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(206,0,l),
+(551,593,l),
+(572,690,l),
+(126,690,l),
+(96,546,l),
+(377,546,l),
+(384,590,l),
+(54,39,l),
+(46,0,l)
+);
+}
+);
+width = 506;
+}
+);
+},
+{
+glyphname = eight.canadian;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(444,-14,o),
+(556,64,o),
+(563,195,cs),
+(570,276,o),
+(526,338,o),
+(442,362,c),
+(421,310,l),
+(532,319,o),
+(608,396,o),
+(613,500,cs),
+(621,619,o),
+(530,704,o),
+(379,704,cs),
+(238,704,o),
+(135,622,o),
+(128,495,cs),
+(123,415,o),
+(164,351,o),
+(240,327,c),
+(244,380,l),
+(135,371,o),
+(56,295,o),
+(50,192,cs),
+(43,74,o),
+(144,-14,o),
+(299,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(240,117,o),
+(205,147,o),
+(208,195,cs),
+(210,251,o),
+(253,281,o),
+(311,281,cs),
+(375,281,o),
+(411,250,o),
+(408,203,cs),
+(405,147,o),
+(361,117,o),
+(303,117,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(312,409,o),
+(281,440,o),
+(283,488,cs),
+(285,538,o),
+(319,573,o),
+(374,573,cs),
+(426,573,o),
+(457,542,o),
+(455,495,cs),
+(453,444,o),
+(419,409,o),
+(365,409,cs)
+);
+}
+);
+width = 636;
+}
+);
+metricLeft = "=|";
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = nine.canadian;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(500,-14,o),
+(594,244,o),
+(594,451,cs),
+(594,519,o),
+(580,570,o),
+(552,611,cs),
+(515,668,o),
+(443,704,o),
+(350,704,cs),
+(187,704,o),
+(83,597,o),
+(83,446,cs),
+(83,332,o),
+(160,254,o),
+(288,254,cs),
+(356,254,o),
+(412,279,o),
+(456,332,c),
+(426,387,l),
+(425,364,o),
+(423,350,o),
+(417,320,cs),
+(389,182,o),
+(342,124,o),
+(271,124,cs),
+(204,124,o),
+(185,164,o),
+(186,210,c),
+(29,210,l),
+(17,75,o),
+(116,-14,o),
+(263,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(272,384,o),
+(238,415,o),
+(238,465,cs),
+(238,519,o),
+(275,571,o),
+(345,571,cs),
+(404,571,o),
+(440,541,o),
+(440,493,cs),
+(440,437,o),
+(401,384,o),
+(330,384,cs)
+);
+}
+);
+width = 609;
+}
+);
+metricLeft = "=|six.canadian";
+metricRight = "=|six.canadian";
+},
+{
+glyphname = CR;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+width = 256;
+}
+);
+note = CR;
+unicode = 13;
+},
+{
+color = 0;
+glyphname = .notdef;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(582,690,l),
+(185,690,l),
+(185,0,l),
+(582,0,l),
+(582,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(533,640,l),
+(533,49,l),
+(235,49,l),
+(235,640,l),
+(235,640,l)
+);
+}
+);
+width = 674;
+}
+);
+note = ".notdef";
+},
+{
+glyphname = .null;
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+width = 0;
+}
+);
+note = NULL;
+},
+{
+glyphname = space;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+width = 257;
+}
+);
+note = space;
+unicode = 32;
+},
+{
+glyphname = nbspace;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+width = 256;
+}
+);
+note = uni00A0;
+unicode = 160;
+},
+{
+glyphname = space.canadian;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+width = 516;
+}
+);
+note = space;
+},
+{
+glyphname = "hyphen-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(404,383,l),
+(422,471,l),
+(101,471,l),
+(83,383,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(373,239,l),
+(391,327,l),
+(71,327,l),
+(52,239,l)
+);
+}
+);
+width = 428;
+}
+);
+metricRight = "=|";
+note = uni1400;
+unicode = 5120;
+},
+{
+glyphname = "chi-canadian";
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(144,0,l),
+(338,259,l),
+(271,270,l),
+(364,0,l),
+(507,0,l),
+(515,39,l),
+(380,410,l),
+(361,286,l),
+(642,651,l),
+(651,690,l),
+(490,690,l),
+(300,435,l),
+(366,425,l),
+(275,690,l),
+(132,690,l),
+(125,651,l),
+(259,289,l),
+(277,412,l),
+(-10,39,l),
+(-17,0,l)
+);
+}
+);
+width = 593;
+}
+);
+metricRight = "=|";
+note = uni166D;
+unicode = 5741;
+},
+{
+glyphname = "fullstop-canadian";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,0,l),
+(172,103,l),
+(152,106,l),
+(187,0,l),
+(277,0,l),
+(282,18,l),
+(214,194,l),
+(210,147,l),
+(346,326,l),
+(350,345,l),
+(248,345,l),
+(171,236,l),
+(198,230,l),
+(159,345,l),
+(70,345,l),
+(65,326,l),
+(128,159,l),
+(136,198,l),
+(-1,18,l),
+(-5,0,l)
+);
+}
+);
+width = 378;
+}
+);
+note = uni1541;
+unicode = 5742;
+},
+{
+glyphname = period;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(-3,23,o),
+(29,-11,o),
+(93,-11,cs),
+(140,-11,o),
+(170,15,o),
+(181,63,cs),
+(192,119,o),
+(162,153,o),
+(99,153,cs),
+(49,153,o),
+(18,126,o),
+(9,78,cs)
+);
+}
+);
+width = 263;
+}
+);
+note = period;
+unicode = 46;
+},
+{
+glyphname = comma;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(58,-133,l),
+(108,-57,o),
+(157,50,o),
+(192,127,c),
+(188,137,l),
+(49,137,l),
+(25,61,o),
+(-14,-40,o),
+(-55,-133,c)
+);
+}
+);
+width = 271;
+}
+);
+note = comma;
+unicode = 44;
+},
+{
+glyphname = hyphen;
+kernLeft = hyphen;
+kernRight = hyphen;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(251,195,l),
+(278,324,l),
+(40,324,l),
+(13,195,l)
+);
+}
+);
+width = 286;
+}
+);
+unicode = 45;
+},
+{
+glyphname = quotesinglbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-27,-553);
+ref = quoteright;
+}
+);
+width = 273;
+}
+);
+unicode = 8218;
+},
+{
+glyphname = quotedblbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-88,-553);
+ref = quotedblright;
+}
+);
+width = 528;
+}
+);
+unicode = 8222;
+},
+{
+glyphname = quotedblleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(418,419,l),
+(442,497,o),
+(482,596,o),
+(524,689,c),
+(412,689,l),
+(361,614,o),
+(312,511,o),
+(275,430,c),
+(280,419,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(196,419,l),
+(220,497,o),
+(259,596,o),
+(301,689,c),
+(189,689,l),
+(139,614,o),
+(90,511,o),
+(53,430,c),
+(58,419,l)
+);
+}
+);
+width = 448;
+}
+);
+unicode = 8220;
+},
+{
+glyphname = quotedblright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(391,419,l),
+(442,495,o),
+(493,601,o),
+(527,678,c),
+(523,689,l),
+(384,689,l),
+(360,612,o),
+(321,510,o),
+(279,419,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(168,419,l),
+(219,495,o),
+(270,601,o),
+(304,678,c),
+(299,689,l),
+(161,689,l),
+(137,612,o),
+(97,510,o),
+(56,419,c)
+);
+}
+);
+width = 448;
+}
+);
+unicode = 8221;
+},
+{
+glyphname = quoteleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(198,419,l),
+(223,497,o),
+(263,596,o),
+(304,689,c),
+(189,689,l),
+(139,614,o),
+(90,511,o),
+(53,430,c),
+(58,419,l)
+);
+}
+);
+width = 229;
+}
+);
+unicode = 8216;
+},
+{
+glyphname = quoteright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(171,419,l),
+(222,495,o),
+(273,601,o),
+(308,678,c),
+(303,689,l),
+(162,689,l),
+(138,612,o),
+(98,510,o),
+(56,419,c)
+);
+}
+);
+width = 229;
+}
+);
+unicode = 8217;
+},
+{
+glyphname = dottedCircle;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(201,504,o),
+(188,494,o),
+(188,479,cs),
+(188,467,o),
+(201,454,o),
+(213,454,cs),
+(228,454,o),
+(239,467,o),
+(239,479,cs),
+(239,494,o),
+(228,504,o),
+(213,504,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(363,504,o),
+(351,494,o),
+(351,479,cs),
+(351,467,o),
+(363,454,o),
+(376,454,cs),
+(390,454,o),
+(401,467,o),
+(401,479,cs),
+(401,494,o),
+(390,504,o),
+(376,504,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(201,108,o),
+(188,98,o),
+(188,83,cs),
+(188,71,o),
+(201,58,o),
+(213,58,cs),
+(228,58,o),
+(239,71,o),
+(239,83,cs),
+(239,98,o),
+(228,108,o),
+(213,108,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(363,108,o),
+(351,98,o),
+(351,83,cs),
+(351,71,o),
+(363,58,o),
+(376,58,cs),
+(390,58,o),
+(401,71,o),
+(401,83,cs),
+(401,98,o),
+(390,108,o),
+(376,108,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(282,522,o),
+(270,511,o),
+(270,497,cs),
+(270,484,o),
+(282,471,o),
+(295,471,cs),
+(309,471,o),
+(320,484,o),
+(320,497,cs),
+(320,511,o),
+(309,522,o),
+(295,522,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(282,91,o),
+(270,80,o),
+(270,66,cs),
+(270,53,o),
+(282,41,o),
+(295,41,cs),
+(309,41,o),
+(320,53,o),
+(320,66,cs),
+(320,80,o),
+(309,91,o),
+(295,91,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(54,269,o),
+(67,256,o),
+(79,256,cs),
+(94,256,o),
+(104,269,o),
+(104,281,cs),
+(104,296,o),
+(94,306,o),
+(79,306,cs),
+(67,306,o),
+(54,296,o),
+(54,281,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(485,269,o),
+(497,256,o),
+(510,256,cs),
+(525,256,o),
+(535,269,o),
+(535,281,cs),
+(535,296,o),
+(525,306,o),
+(510,306,cs),
+(497,306,o),
+(485,296,o),
+(485,281,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(117,116,o),
+(129,103,o),
+(142,103,cs),
+(156,103,o),
+(167,116,o),
+(167,128,cs),
+(167,143,o),
+(156,154,o),
+(142,154,cs),
+(129,154,o),
+(117,143,o),
+(117,128,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(117,421,o),
+(129,409,o),
+(142,409,cs),
+(156,409,o),
+(167,421,o),
+(167,434,cs),
+(167,448,o),
+(156,459,o),
+(142,459,cs),
+(129,459,o),
+(117,448,o),
+(117,434,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(422,116,o),
+(435,103,o),
+(447,103,cs),
+(462,103,o),
+(472,116,o),
+(472,128,cs),
+(472,143,o),
+(462,154,o),
+(447,154,cs),
+(435,154,o),
+(422,143,o),
+(422,128,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(422,421,o),
+(435,409,o),
+(447,409,cs),
+(462,409,o),
+(472,421,o),
+(472,434,cs),
+(472,448,o),
+(462,459,o),
+(447,459,cs),
+(435,459,o),
+(422,448,o),
+(422,434,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(71,187,o),
+(84,175,o),
+(97,175,cs),
+(111,175,o),
+(122,187,o),
+(122,200,cs),
+(122,214,o),
+(111,225,o),
+(97,225,cs),
+(84,225,o),
+(71,214,o),
+(71,200,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(71,350,o),
+(84,337,o),
+(97,337,cs),
+(111,337,o),
+(122,350,o),
+(122,362,cs),
+(122,377,o),
+(111,387,o),
+(97,387,cs),
+(84,387,o),
+(71,377,o),
+(71,362,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(468,187,o),
+(480,175,o),
+(493,175,cs),
+(507,175,o),
+(518,187,o),
+(518,200,cs),
+(518,214,o),
+(507,225,o),
+(493,225,cs),
+(480,225,o),
+(468,214,o),
+(468,200,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(468,350,o),
+(480,337,o),
+(493,337,cs),
+(507,337,o),
+(518,350,o),
+(518,362,cs),
+(518,377,o),
+(507,387,o),
+(493,387,cs),
+(480,387,o),
+(468,377,o),
+(468,362,cs)
+);
+}
+);
+width = 582;
+}
+);
+note = uni25CC;
+unicode = 9676;
+},
+{
+glyphname = dotaccentcomb;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(162,741,o),
+(134,721,o),
+(126,676,cs),
+(115,623,o),
+(143,594,o),
+(204,594,cs),
+(256,594,o),
+(283,614,o),
+(292,659,cs),
+(303,712,o),
+(275,741,o),
+(213,741,cs)
+);
+}
+);
+width = 239;
+}
+);
+note = uni0307;
+unicode = 775;
+},
+{
+glyphname = dotaccent;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(258,594,o),
+(285,615,o),
+(293,660,cs),
+(303,712,o),
+(276,741,o),
+(214,741,cs),
+(162,741,o),
+(135,721,o),
+(127,675,cs),
+(116,623,o),
+(144,594,o),
+(206,594,cs)
+);
+}
+);
+width = 241;
+}
+);
+note = dotaccent;
+unicode = 729;
+},
+{
+glyphname = caron;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(410,625,o),
+(459,675,o),
+(515,727,c),
+(518,740,l),
+(405,740,l),
+(370,717,o),
+(339,693,o),
+(302,661,c),
+(278,693,o),
+(262,717,o),
+(236,740,c),
+(140,740,l),
+(137,727,l),
+(165,687,o),
+(199,633,o),
+(216,585,c),
+(376,585,l),
+(376,585,l)
+);
+}
+);
+width = 448;
+}
+);
+note = caron;
+unicode = 711;
+},
+{
+glyphname = breve;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(389,585,o),
+(456,642,o),
+(480,750,c),
+(389,750,l),
+(370,704,o),
+(343,684,o),
+(297,684,cs),
+(249,684,o),
+(228,703,o),
+(227,750,c),
+(142,750,l),
+(126,651,o),
+(185,585,o),
+(290,585,cs)
+);
+}
+);
+width = 409;
+}
+);
+note = breve;
+unicode = 728;
+},
+{
+glyphname = ring;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(308,584,o),
+(358,629,o),
+(358,700,cs),
+(358,771,o),
+(306,816,o),
+(243,816,cs),
+(177,816,o),
+(131,771,o),
+(131,699,cs),
+(131,629,o),
+(177,584,o),
+(243,584,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(219,655,o),
+(206,674,o),
+(206,699,cs),
+(206,727,o),
+(222,745,o),
+(243,745,cs),
+(265,745,o),
+(281,726,o),
+(281,699,cs),
+(281,674,o),
+(265,655,o),
+(243,655,cs)
+);
+}
+);
+width = 297;
+}
+);
+note = ring;
+unicode = 730;
+},
+{
+glyphname = ogonek;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(76,-228,o),
+(101,-225,o),
+(125,-216,c),
+(144,-126,l),
+(128,-130,o),
+(105,-135,o),
+(94,-135,cs),
+(71,-135,o),
+(60,-122,o),
+(65,-99,cs),
+(70,-69,o),
+(91,-42,o),
+(144,0,c),
+(86,22,l),
+(6,-29,o),
+(-34,-73,o),
+(-43,-124,cs),
+(-56,-185,o),
+(-16,-228,o),
+(51,-228,cs)
+);
+}
+);
+width = 258;
+}
+);
+note = ogonek;
+unicode = 731;
+},
+{
+glyphname = ring_top.canadian;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (226,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(325,757,o),
+(380,804,o),
+(380,868,cs),
+(380,933,o),
+(325,980,o),
+(263,980,cs),
+(201,980,o),
+(148,934,o),
+(148,868,cs),
+(148,804,o),
+(201,757,o),
+(263,757,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(236,824,o),
+(220,844,o),
+(220,868,cs),
+(220,893,o),
+(239,913,o),
+(264,913,cs),
+(290,913,o),
+(308,893,o),
+(308,868,cs),
+(308,844,o),
+(290,824,o),
+(264,824,cs)
+);
+}
+);
+width = 264;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (115,345);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(156,270,o),
+(190,303,o),
+(190,345,cs),
+(190,386,o),
+(156,420,o),
+(115,420,cs),
+(73,420,o),
+(40,386,o),
+(40,345,cs),
+(40,303,o),
+(73,270,o),
+(115,270,cs)
+);
+}
+);
+width = 188;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (98,345);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(131,285,o),
+(157,311,o),
+(157,345,cs),
+(157,379,o),
+(131,405,o),
+(99,405,cs),
+(65,405,o),
+(39,379,o),
+(39,345,cs),
+(39,311,o),
+(65,285,o),
+(99,285,cs)
+);
+}
+);
+width = 155;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_small;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (81,345);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(106,301,o),
+(125,321,o),
+(125,345,cs),
+(125,369,o),
+(106,388,o),
+(81,388,cs),
+(57,388,o),
+(39,369,o),
+(39,345,cs),
+(39,321,o),
+(57,301,o),
+(81,301,cs)
+);
+}
+);
+width = 122;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_top;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (188,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(263,763,o),
+(297,798,o),
+(297,839,cs),
+(297,882,o),
+(263,916,o),
+(220,916,cs),
+(178,916,o),
+(144,882,o),
+(144,839,cs),
+(144,798,o),
+(178,763,o),
+(220,763,cs)
+);
+}
+);
+width = 188;
+}
+);
+note = g725;
+},
+{
+glyphname = doubledot_middle;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(203,368,o),
+(237,402,o),
+(237,443,cs),
+(237,486,o),
+(203,520,o),
+(160,520,cs),
+(119,520,o),
+(84,486,o),
+(84,443,cs),
+(84,401,o),
+(119,368,o),
+(160,368,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(160,170,o),
+(194,204,o),
+(194,246,cs),
+(194,288,o),
+(160,322,o),
+(119,322,cs),
+(76,322,o),
+(43,289,o),
+(43,246,cs),
+(43,204,o),
+(76,170,o),
+(119,170,cs)
+);
+}
+);
+width = 237;
+}
+);
+metricRight = "=|";
+note = g725;
+},
+{
+glyphname = doubledot_top;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top_double;
+pos = (373,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(446,763,o),
+(481,798,o),
+(481,839,cs),
+(481,882,o),
+(446,916,o),
+(404,916,cs),
+(362,916,o),
+(328,882,o),
+(328,839,cs),
+(328,798,o),
+(362,763,o),
+(404,763,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(251,763,o),
+(285,798,o),
+(285,839,cs),
+(285,882,o),
+(251,916,o),
+(210,916,cs),
+(167,916,o),
+(133,882,o),
+(133,839,cs),
+(133,798,o),
+(167,763,o),
+(210,763,cs)
+);
+}
+);
+width = 361;
+}
+);
+note = g725;
+},
+{
+glyphname = g727;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (453,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(598,0,l),
+(626,130,l),
+(280,130,ls),
+(229,130,o),
+(201,151,o),
+(201,189,cs),
+(201,246,o),
+(240,281,o),
+(312,281,cs),
+(445,281,ls),
+(613,281,o),
+(716,359,o),
+(716,515,cs),
+(716,622,o),
+(643,690,o),
+(525,690,cs),
+(157,690,l),
+(130,559,l),
+(477,559,ls),
+(529,559,o),
+(556,539,o),
+(556,501,cs),
+(556,442,o),
+(518,410,o),
+(446,410,cs),
+(313,410,ls),
+(144,410,o),
+(42,329,o),
+(42,175,cs),
+(42,69,o),
+(115,0,o),
+(234,0,cs)
+);
+}
+);
+width = 716;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+glyphname = g728;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (265,0);
+ref = dot_top;
+}
+);
+width = 715;
+}
+);
+note = g728;
+},
+{
+glyphname = g729;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (495,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(386,0,ls),
+(557,0,o),
+(658,80,o),
+(658,237,cs),
+(658,343,o),
+(587,410,o),
+(470,410,cs),
+(340,410,ls),
+(288,410,o),
+(261,429,o),
+(261,469,cs),
+(261,527,o),
+(299,559,o),
+(370,559,cs),
+(719,559,l),
+(746,690,l),
+(372,690,ls),
+(204,690,o),
+(101,611,o),
+(101,454,cs),
+(101,348,o),
+(172,281,o),
+(291,281,cs),
+(419,281,ls),
+(471,281,o),
+(498,262,o),
+(498,223,cs),
+(498,164,o),
+(461,130,o),
+(388,130,cs),
+(39,130,l),
+(11,0,l)
+);
+}
+);
+width = 717;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+glyphname = g730;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (305,0);
+ref = dot_top;
+}
+);
+width = 715;
+}
+);
+note = g730;
+},
+{
+glyphname = g731;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = g727;
+}
+);
+width = 952;
+}
+);
+note = g731;
+},
+{
+glyphname = g732;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (715,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 952;
+}
+);
+note = g732;
+},
+{
+glyphname = g733;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (501,0);
+ref = dot_top;
+}
+);
+width = 952;
+}
+);
+note = g733;
+},
+{
+glyphname = g734;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (265,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (715,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 952;
+}
+);
+note = g734;
+},
+{
+glyphname = g735;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = g729;
+}
+);
+width = 952;
+}
+);
+note = g735;
+},
+{
+glyphname = g736;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (715,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 952;
+}
+);
+note = g736;
+},
+{
+glyphname = g737;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (542,0);
+ref = dot_top;
+}
+);
+width = 952;
+}
+);
+note = g737;
+},
+{
+glyphname = g738;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (305,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (715,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 952;
+}
+);
+note = g738;
+},
+{
+glyphname = g739;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(575,273,o),
+(634,339,o),
+(634,419,cs),
+(634,488,o),
+(583,536,o),
+(508,536,cs),
+(319,536,l),
+(355,486,l),
+(379,515,o),
+(388,554,o),
+(388,583,cs),
+(388,650,o),
+(338,697,o),
+(260,697,cs),
+(172,697,o),
+(113,632,o),
+(113,552,cs),
+(113,483,o),
+(163,435,o),
+(239,435,cs),
+(429,435,l),
+(392,485,l),
+(366,452,o),
+(357,415,o),
+(357,388,cs),
+(357,321,o),
+(408,273,o),
+(487,273,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(222,513,o),
+(208,528,o),
+(208,552,cs),
+(208,581,o),
+(227,619,o),
+(258,619,cs),
+(280,619,o),
+(295,603,o),
+(295,580,cs),
+(295,551,o),
+(275,513,o),
+(244,513,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(467,352,o),
+(452,368,o),
+(452,391,cs),
+(452,420,o),
+(471,458,o),
+(502,458,cs),
+(525,458,o),
+(539,442,o),
+(539,419,cs),
+(539,390,o),
+(520,352,o),
+(489,352,cs)
+);
+}
+);
+width = 645;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+glyphname = g740;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (227,0);
+ref = ring_top.canadian;
+}
+);
+width = 715;
+}
+);
+note = g740;
+},
+{
+glyphname = g741;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (268,0);
+ref = ring_top.canadian;
+}
+);
+width = 715;
+}
+);
+note = g741;
+},
+{
+glyphname = g742;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (464,0);
+ref = ring_top.canadian;
+}
+);
+width = 952;
+}
+);
+note = g742;
+},
+{
+glyphname = stroke_middle;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (85,345);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(105,226,l),
+(156,464,l),
+(64,464,l),
+(14,226,l)
+);
+}
+);
+width = 128;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (72,345);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(91,274,l),
+(121,415,l),
+(53,415,l),
+(24,274,l)
+);
+}
+);
+width = 102;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_small;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (64,345);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(76,284,l),
+(102,406,l),
+(51,406,l),
+(26,284,l)
+);
+}
+);
+width = 86;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_threequart;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (85,345);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(105,230,l),
+(154,460,l),
+(65,460,l),
+(16,230,l)
+);
+}
+);
+width = 128;
+}
+);
+note = g723;
+},
+{
+color = 8;
+glyphname = uni11AB0;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (271,690);
+},
+{
+name = top_right_can;
+pos = (544,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(206,0,l),
+(221,74,l),
+(433,74,l),
+(450,159,l),
+(240,159,l),
+(265,277,l),
+(131,224,l),
+(170,224,ls),
+(404,224,o),
+(547,331,o),
+(601,582,cs),
+(624,690,l),
+(464,690,l),
+(443,597,ls),
+(410,446,o),
+(324,366,o),
+(175,366,cs),
+(123,366,l),
+(79,159,l),
+(8,159,l),
+(-11,74,l),
+(61,74,l),
+(45,0,l)
+);
+}
+);
+width = 591;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB1;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB0;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (356,0);
+ref = dot_top;
+}
+);
+width = 592;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB2;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (235,690);
+},
+{
+name = top_right_can;
+pos = (507,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(169,0,l),
+(189,93,ls),
+(222,243,o),
+(309,324,o),
+(457,324,cs),
+(509,324,l),
+(553,530,l),
+(625,530,l),
+(642,615,l),
+(571,615,l),
+(587,690,l),
+(426,690,l),
+(411,615,l),
+(200,615,l),
+(183,530,l),
+(392,530,l),
+(368,412,l),
+(500,466,l),
+(462,466,ls),
+(228,466,o),
+(86,358,o),
+(32,107,cs),
+(9,0,l)
+);
+}
+);
+width = 591;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "theThCree-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB3;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB2;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (320,0);
+ref = dot_top;
+}
+);
+width = 592;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB4;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (272,690);
+},
+{
+name = top_right_can;
+pos = (545,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(477,0,l),
+(498,101,ls),
+(546,322,o),
+(435,466,o),
+(192,466,cs),
+(172,466,l),
+(294,416,l),
+(318,530,l),
+(529,530,l),
+(547,615,l),
+(336,615,l),
+(352,690,l),
+(191,690,l),
+(176,615,l),
+(104,615,l),
+(87,530,l),
+(157,530,l),
+(114,324,l),
+(156,324,ls),
+(314,324,o),
+(373,261,o),
+(336,92,cs),
+(317,0,l)
+);
+}
+);
+width = 590;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB5;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB4;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (84,0);
+ref = dot_top;
+}
+);
+width = 592;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB6;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (238,690);
+},
+{
+name = top_right_can;
+pos = (510,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(171,1,l),
+(231,278,l),
+(98,225,l),
+(133,225,ls),
+(384,225,o),
+(514,337,o),
+(569,592,cs),
+(580,640,l),
+(461,582,l),
+(661,380,l),
+(772,490,l),
+(573,691,l),
+(430,691,l),
+(411,604,ls),
+(377,449,o),
+(281,367,o),
+(130,367,cs),
+(89,367,l),
+(11,1,l)
+);
+}
+);
+width = 738;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB7;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB6;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (322,0);
+ref = dot_top;
+}
+);
+width = 738;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB8;
+kernRight = soright;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (416,690);
+},
+{
+name = top_right_can;
+pos = (689,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(351,0,l),
+(369,87,ls),
+(403,242,o),
+(499,324,o),
+(649,324,cs),
+(692,324,l),
+(769,690,l),
+(609,690,l),
+(550,412,l),
+(683,466,l),
+(646,466,ls),
+(396,466,o),
+(267,355,o),
+(211,99,cs),
+(201,50,l),
+(319,109,l),
+(119,311,l),
+(8,201,l),
+(207,0,l)
+);
+}
+);
+width = 738;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB9;
+kernRight = soright;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB8;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (501,0);
+ref = dot_top;
+}
+);
+width = 738;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABA;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (239,690);
+},
+{
+name = top_right_can;
+pos = (511,690);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(426,0,l),
+(711,201,l),
+(628,319,l),
+(374,142,l),
+(460,79,l),
+(466,111,ls),
+(507,312,o),
+(402,465,o),
+(191,465,cs),
+(153,465,l),
+(257,404,l),
+(319,690,l),
+(157,690,l),
+(80,324,l),
+(121,324,ls),
+(295,324,o),
+(340,265,o),
+(302,89,cs),
+(283,0,l)
+);
+}
+);
+width = 739;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABB;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = uni11ABA;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+}
+);
+width = 738;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABC;
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(492,0,l),
+(523,144,l),
+(185,144,l),
+(189,93,l),
+(624,580,l),
+(647,690,l),
+(133,690,l),
+(103,546,l),
+(440,546,l),
+(437,598,l),
+(2,110,l),
+(-22,0,l)
+);
+}
+);
+width = 583;
+}
+);
+metricRight = "=|";
+},
+{
+color = 8;
+glyphname = uni11ABD;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(500,0,l),
+(525,110,l),
+(272,597,l),
+(271,546,l),
+(609,546,l),
+(639,690,l),
+(126,690,l),
+(101,580,l),
+(354,93,l),
+(355,144,l),
+(17,144,l),
+(-13,0,l)
+);
+}
+);
+width = 584;
+}
+);
+metricLeft = "=|uni11ABC";
+metricRight = "=|uni11ABC";
+},
+{
+color = 8;
+glyphname = uni11ABE;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(168,0,l),
+(286,552,l),
+(191,552,l),
+(426,0,l),
+(568,0,l),
+(715,690,l),
+(556,690,l),
+(439,138,l),
+(533,138,l),
+(298,690,l),
+(156,690,l),
+(10,0,l)
+);
+}
+);
+width = 683;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABF;
+lastChange = "2023-01-13 15:57:34 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(152,0,l),
+(642,553,l),
+(526,553,l),
+(409,0,l),
+(568,0,l),
+(715,690,l),
+(573,690,l),
+(81,137,l),
+(198,137,l),
+(316,690,l),
+(156,690,l),
+(10,0,l)
+);
+}
+);
+width = 683;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = "raiseddoubledotFinal-canadian.cree";
+lastChange = "2023-01-13 15:57:31 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(242,552,o),
+(275,585,o),
+(275,628,cs),
+(275,669,o),
+(242,704,o),
+(199,704,cs),
+(157,704,o),
+(124,670,o),
+(124,628,cs),
+(124,585,o),
+(157,552,o),
+(199,552,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,354,o),
+(234,387,o),
+(234,430,cs),
+(234,472,o),
+(200,506,o),
+(157,506,cs),
+(116,506,o),
+(81,472,o),
+(81,430,cs),
+(81,387,o),
+(116,354,o),
+(157,354,cs)
+);
+}
+);
+width = 237;
+}
+);
+note = g725;
+}
+);
+instances = (
+{
+axesValues = (
+169,
+90,
+12
+);
+instanceInterpolations = {
+"D19189FD-F605-4705-8DF9-B27AB1AA0ED8" = 1;
+};
+name = "RC B Italic";
+}
+);
+kerningLTR = {
+"D19189FD-F605-4705-8DF9-B27AB1AA0ED8" = {
+"@MMK_L_caright" = {
+"@MMK_R_ecanleft" = -72.45;
+"@MMK_R_mwestleft" = -27.048;
+"@MMK_R_neleft" = -40.572;
+};
+"@MMK_L_ciright" = {
+"@MMK_R_icanleft" = -72.45;
+"@MMK_R_noleft" = -77.28;
+};
+"@MMK_L_ecanright" = {
+"@MMK_R_coleft" = -72.45;
+"@MMK_R_moleft" = -77.28;
+"@MMK_R_sileft" = -45.402;
+};
+"@MMK_L_icanright" = {
+"@MMK_R_celeft" = -72.45;
+"@MMK_R_meleft" = -77.28;
+"@MMK_R_mwestleft" = -81.144;
+"@MMK_R_saleft" = -37.674;
+"she-canadian" = -77.28;
+};
+"@MMK_L_maright" = {
+"@MMK_R_acanleft" = -64.722;
+"@MMK_R_ecanleft" = -77.28;
+"@MMK_R_mwestleft" = -46.368;
+"@MMK_R_neleft" = -40.572;
+};
+"@MMK_L_miright" = {
+"@MMK_R_acanleft" = -64.722;
+"@MMK_R_icanleft" = -77.28;
+"@MMK_R_moleft" = -95.634;
+"@MMK_R_noleft" = -77.28;
+"@MMK_R_yeleft" = -106.26;
+};
+"@MMK_L_mwestright" = {
+"@MMK_R_coleft" = -27.048;
+"@MMK_R_icanleft" = -81.144;
+"@MMK_R_moleft" = -46.368;
+"@MMK_R_noleft" = -68.586;
+"@MMK_R_sileft" = -19.32;
+"@MMK_R_yeleft" = -38.64;
+};
+"@MMK_L_naright" = {
+"@MMK_R_acanleft" = -69.552;
+"@MMK_R_celeft" = -77.28;
+"@MMK_R_meleft" = -77.28;
+"@MMK_R_mwestleft" = -68.586;
+"@MMK_R_neleft" = -81.144;
+"@MMK_R_saleft" = -43.47;
+};
+"@MMK_L_niright" = {
+"@MMK_R_coleft" = -40.572;
+"@MMK_R_moleft" = -40.572;
+"@MMK_R_noleft" = -81.144;
+"@MMK_R_sileft" = -0.966;
+};
+"@MMK_L_ocanright" = {
+"@MMK_R_meleft" = -64.722;
+"@MMK_R_moleft" = -64.722;
+"@MMK_R_noleft" = -69.552;
+};
+"@MMK_L_seright" = {
+"@MMK_R_ecanleft" = -45.402;
+"@MMK_R_mwestleft" = -19.32;
+"@MMK_R_neleft" = -0.966;
+};
+"@MMK_L_soright" = {
+"@MMK_R_icanleft" = -37.674;
+"@MMK_R_noleft" = -43.47;
+};
+"@MMK_L_yiright" = {
+"@MMK_R_meleft" = -106.26;
+"@MMK_R_mwestleft" = -38.64;
+};
+"shi-canadian" = {
+"@MMK_R_icanleft" = -77.28;
+};
+};
+};
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "italic angle";
+}
+);
+properties = (
+{
+key = copyrights;
+values = (
+{
+language = ENG;
+value = "Copyright 2018 Google Inc. All Rights Reserved.";
+}
+);
+},
+{
+key = manufacturers;
+values = (
+{
+language = ENG;
+value = "Monotype Imaging Inc.";
+}
+);
+},
+{
+key = designers;
+values = (
+{
+language = ENG;
+value = "Monotype Design Team";
+}
+);
+},
+{
+key = description;
+value = "Designed by Monotype design team.";
+},
+{
+key = trademarks;
+values = (
+{
+language = ENG;
+value = "Noto is a trademark of Google Inc.";
+}
+);
+},
+{
+key = licenseURL;
+value = "http://scripts.sil.org/OFL";
+},
+{
+key = licenses;
+values = (
+{
+language = ENG;
+value = "This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.";
+}
+);
+},
+{
+key = manufacturerURL;
+value = "http://www.google.com/get/noto/";
+},
+{
+key = designerURL;
+value = "http://www.monotype.com/studio";
+}
+);
+settings = {
+disablesNiceNames = 1;
+};
+stems = (
+{
+name = "New Stem";
+}
+);
+unitsPerEm = 966;
+userData = {
+GSDontShowVersionAlert = 1;
+};
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/sources/Exported instances UCAS SansCanadianAboriginal Resized/Sans Canadian Aboriginal-RC B roman.glyphs
+++ b/sources/Exported instances UCAS SansCanadianAboriginal Resized/Sans Canadian Aboriginal-RC B roman.glyphs
@@ -1,0 +1,37332 @@
+{
+.appVersion = "3151";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+},
+{
+name = Width;
+tag = wdth;
+},
+{
+name = Slant;
+tag = slnt;
+}
+);
+classes = (
+{
+code = "zero one two three four five six seven eight nine ";
+name = Num;
+},
+{
+code = "zero.canadian one.canadian two.canadian three.canadian four.canadian five.canadian six.canadian seven.canadian eight.canadian nine.canadian 
+";
+name = Num_can;
+},
+{
+code = "ke-canadian.square ki-canadian.square kii-canadian.square ko-canadian.square koo-canadian.square ka-canadian.square kaa-canadian.square kweWestCree-canadian.square kwiiWestCree-canadian.square kwoWestCree-canadian.square kwooWestCree-canadian.square kwaWestCree-canadian.square kwaaWestCree-canadian.square ce-canadian.square ci-canadian.square cii-canadian.square co-canadian.square coo-canadian.square ca-canadian.square caa-canadian.square me-canadian.square mi-canadian.square mii-canadian.square mo-canadian.square moo-canadian.square ma-canadian.square maa-canadian.square ne-canadian.square ni-canadian.square nii-canadian.square no-canadian.square noo-canadian.square na-canadian.square naa-canadian.square nweWestCree-canadian.square nwaWestCree-canadian.square nwaaWestCree-canadian.square se-canadian.square si-canadian.square sii-canadian.square so-canadian.square soo-canadian.square sa-canadian.square saa-canadian.square sho-canadian.square shoo-canadian.square sha-canadian.square shaa-canadian.square ye-canadian.square yi-canadian.square yii-canadian.square yo-canadian.square yoo-canadian.square ya-canadian.square yaa-canadian.square re-canadian.square reRCree-canadian.square leWestCree-canadian.square ri-canadian.square rii-canadian.square ro-canadian.square loWestCree-canadian.square ra-canadian.square raa-canadian.square laWestCree-canadian.square reWestCree-canadian.square riWestCree-canadian.square roWestCree-canadian.square raWestCree-canadian.square theThCree-canadian.square thiThCree-canadian.square thiiThCree-canadian.square thoThCree-canadian.square thooThCree-canadian.square thaThCree-canadian.square thaaThCree-canadian.square thweeWoodScree-canadian.square thwiWoodScree-canadian.square thwiiWoodScree-canadian.square thwoWoodScree-canadian.square thwooWoodScree-canadian.square thwaWoodScree-canadian.square thwaaWoodScree-canadian.square nwiOjibway-canadian.square nwiiOjibway-canadian.square nwoOjibway-canadian.square nwooOjibway-canadian.square looWestCree-canadian.square laaWestCree-canadian.square ";
+name = Dene_square;
+},
+{
+code = "ke-canadian ki-canadian kii-canadian ko-canadian koo-canadian ka-canadian kaa-canadian kweWestCree-canadian kwiiWestCree-canadian kwoWestCree-canadian kwooWestCree-canadian kwaWestCree-canadian kwaaWestCree-canadian ce-canadian ci-canadian cii-canadian co-canadian coo-canadian ca-canadian caa-canadian me-canadian mi-canadian mii-canadian mo-canadian moo-canadian ma-canadian maa-canadian ne-canadian ni-canadian nii-canadian no-canadian noo-canadian na-canadian naa-canadian nweWestCree-canadian nwaWestCree-canadian nwaaWestCree-canadian se-canadian si-canadian sii-canadian so-canadian soo-canadian sa-canadian saa-canadian sho-canadian shoo-canadian sha-canadian shaa-canadian ye-canadian yi-canadian yii-canadian yo-canadian yoo-canadian ya-canadian yaa-canadian re-canadian reRCree-canadian leWestCree-canadian ri-canadian rii-canadian ro-canadian loWestCree-canadian ra-canadian raa-canadian laWestCree-canadian reWestCree-canadian riWestCree-canadian roWestCree-canadian raWestCree-canadian theThCree-canadian thiThCree-canadian thiiThCree-canadian thoThCree-canadian thooThCree-canadian thaThCree-canadian thaaThCree-canadian thweeWoodScree-canadian thwiWoodScree-canadian thwiiWoodScree-canadian thwoWoodScree-canadian thwooWoodScree-canadian thwaWoodScree-canadian thwaaWoodScree-canadian nwiOjibway-canadian nwiiOjibway-canadian nwoOjibway-canadian nwooOjibway-canadian looWestCree-canadian laaWestCree-canadian 
+";
+name = Dene_round;
+},
+{
+code = "acuteFinal-canadian.mid graveFinal-canadian.mid ringTophalfFinal-canadian.mid ringRighthalfFinal-canadian.mid ringFinal-canadian.mid doubleacuteFinal-canadian.mid doubleshortverticalstrokesFinal-canadian.mid shorthorizontalstrokeFinal-canadian.mid downtackFinal-canadian.mid pWestCree-canadian.mid c-canadian.mid mWestCree-canadian.mid ";
+name = Final_mid;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian ringFinal-canadian doubleacuteFinal-canadian doubleshortverticalstrokesFinal-canadian shorthorizontalstrokeFinal-canadian downtackFinal-canadian pWestCree-canadian c-canadian mWestCree-canadian ";
+name = Final_mid_ori;
+},
+{
+code = "acuteFinal-canadian.base graveFinal-canadian.base ringBottomhalfFinal-canadian.base ringTophalfFinal-canadian.base ringRighthalfFinal-canadian.base plusFinal-canadian.base pWestCree-canadian.base c-canadian.base thSayisi-canadian.base mWestCree-canadian.base ";
+name = Final_base;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringBottomhalfFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian plusFinal-canadian pWestCree-canadian c-canadian thSayisi-canadian mWestCree-canadian ";
+name = Final_base_ori;
+},
+{
+code = "ng-canadian ngai-canadian ngaai-canadian ngi-canadian ngii-canadian ngo-canadian ngoo-canadian nga-canadian ngaa-canadian ";
+name = Nunavik;
+},
+{
+code = "ng-canadian.nunavik ngai-canadian.nunavik ngaai-canadian.nunavik ngi-canadian.nunavik ngii-canadian.nunavik ngo-canadian.nunavik ngoo-canadian.nunavik nga-canadian.nunavik ngaa-canadian.nunavik ";
+name = Nunavik_alt;
+}
+);
+customParameters = (
+{
+name = vendorID;
+value = GOOG;
+},
+{
+name = panose;
+value = (
+2,
+11,
+5,
+2,
+4,
+5,
+4,
+2,
+2,
+4
+);
+},
+{
+name = unicodeRanges;
+value = (
+0,
+1,
+2,
+5,
+6,
+45,
+77
+);
+},
+{
+name = codePageRanges;
+value = (
+"1252"
+);
+},
+{
+name = fsType;
+value = (
+);
+}
+);
+date = "2022-06-21 10:06:40 +0000";
+familyName = "Sans Canadian Aboriginal";
+featurePrefixes = (
+{
+automatic = 1;
+code = "languagesystem DFLT dflt;
+
+languagesystem cans dflt;
+";
+name = Languagesystems;
+}
+);
+features = (
+{
+automatic = 1;
+code = "feature ss01;
+feature ss02;
+feature ss03;
+feature ss04;
+";
+tag = aalt;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+tag = salt;
+},
+{
+code = "lookup space_can {
+sub space by space.canadian;
+} space_can;
+
+lookup num_can {
+sub @Num by @Num_can;
+} num_can;
+";
+labels = (
+{
+language = dflt;
+value = "CAN Space and numerals";
+}
+);
+tag = ss01;
+},
+{
+code = "lookup dene_square {
+sub @Dene_round by @Dene_square;
+} dene_square;
+
+";
+labels = (
+{
+language = dflt;
+value = "Dene Square";
+}
+);
+tag = ss02;
+},
+{
+code = "lookup nunavik_alt {
+sub @Nunavik by @Nunavik_alt;
+} nunavik_alt;
+
+";
+labels = (
+{
+language = dflt;
+value = "Nunanvik Alt";
+}
+);
+tag = ss03;
+},
+{
+code = "lookup final_mid {
+sub @Final_mid_ori by @Final_mid;
+} final_mid;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final mid";
+}
+);
+tag = ss04;
+},
+{
+code = "lookup final_base {
+sub @Final_base_ori by @Final_base;
+} final_base;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final base";
+}
+);
+tag = ss05;
+},
+{
+code = "lookup plaincree_first {
+sub wiWestCree-canadian' plusFinal-canadian by i-canadian;
+} plaincree_first;
+
+lookup plaincree_second {
+sub i-canadian plusFinal-canadian' by raiseddoubledotFinal-canadian.cree;
+} plaincree_second;
+
+lookup plaincree_third {
+sub middledotFinal-canadian plusFinal-canadian by raiseddoubledotFinal-canadian.cree;
+} plaincree_third;
+";
+labels = (
+{
+language = dflt;
+value = Plaincree;
+}
+);
+tag = ss06;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+labels = (
+{
+language = dflt;
+value = "";
+}
+);
+tag = ss07;
+}
+);
+fontMaster = (
+{
+axesValues = (
+0,
+0,
+0
+);
+customParameters = (
+{
+name = typoAscender;
+value = 1033;
+},
+{
+name = typoDescender;
+value = -283;
+},
+{
+name = typoLineGap;
+value = 0;
+},
+{
+name = winAscent;
+value = 1033;
+},
+{
+name = winDescent;
+value = 283;
+},
+{
+name = hheaAscender;
+value = 1033;
+},
+{
+name = hheaDescender;
+value = -283;
+},
+{
+name = strikeoutPosition;
+value = 295;
+},
+{
+name = strikeoutSize;
+value = 48;
+}
+);
+guides = (
+{
+locked = 1;
+pos = (417,345);
+}
+);
+id = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+metricValues = (
+{
+over = 23;
+pos = 1033;
+},
+{
+over = 23;
+pos = 690;
+},
+{
+over = 23;
+pos = 492;
+},
+{
+over = -23;
+},
+{
+over = -23;
+pos = -283;
+},
+{
+}
+);
+name = "RC B roman";
+stemValues = (
+160
+);
+}
+);
+glyphs = (
+{
+glyphname = idotless;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(219,530,l),
+(60,530,l),
+(60,0,l),
+(219,0,l)
+);
+}
+);
+width = 279;
+}
+);
+note = dotlessi;
+unicode = 305;
+},
+{
+glyphname = "acuteFinal-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(149,345,l),
+(317,690,l),
+(194,690,l),
+(26,345,l)
+);
+}
+);
+width = 343;
+}
+);
+metricRight = "=|";
+note = uni141F;
+unicode = 5151;
+},
+{
+glyphname = "graveFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(317,345,l),
+(149,690,l),
+(26,690,l),
+(194,345,l)
+);
+}
+);
+width = 343;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+unicode = 5152;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(314,339,o),
+(376,397,o),
+(376,507,cs),
+(376,690,l),
+(267,690,l),
+(267,507,ls),
+(267,461,o),
+(248,439,o),
+(215,439,cs),
+(181,439,o),
+(162,461,o),
+(162,507,cs),
+(162,690,l),
+(53,690,l),
+(53,506,ls),
+(53,399,o),
+(115,339,o),
+(214,339,cs)
+);
+}
+);
+width = 429;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1421;
+unicode = 5153;
+},
+{
+glyphname = "ringTophalfFinal-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(162,345,l),
+(162,527,ls),
+(162,574,o),
+(181,596,o),
+(215,596,cs),
+(248,596,o),
+(267,574,o),
+(267,527,cs),
+(267,345,l),
+(376,345,l),
+(376,527,ls),
+(376,638,o),
+(314,696,o),
+(214,696,cs),
+(115,696,o),
+(53,636,o),
+(53,528,cs),
+(53,345,l)
+);
+}
+);
+width = 429;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+unicode = 5154;
+},
+{
+glyphname = "ringRighthalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(138,345,ls),
+(254,345,o),
+(319,411,o),
+(319,517,cs),
+(319,623,o),
+(254,690,o),
+(138,690,cs),
+(53,690,l),
+(53,588,l),
+(130,588,ls),
+(182,588,o),
+(209,563,o),
+(209,517,cs),
+(209,470,o),
+(182,446,o),
+(130,446,cs),
+(53,446,l),
+(53,345,l)
+);
+}
+);
+width = 365;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+unicode = 5155;
+},
+{
+glyphname = "ringFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(322,356,o),
+(394,429,o),
+(394,526,cs),
+(394,623,o),
+(321,696,o),
+(220,696,cs),
+(121,696,o),
+(46,624,o),
+(46,526,cs),
+(46,429,o),
+(119,356,o),
+(220,356,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(176,449,o),
+(149,483,o),
+(149,526,cs),
+(149,569,o),
+(176,603,o),
+(220,603,cs),
+(264,603,o),
+(293,569,o),
+(293,526,cs),
+(293,483,o),
+(265,449,o),
+(220,449,cs)
+);
+}
+);
+width = 440;
+}
+);
+note = uni1424;
+unicode = 5156;
+},
+{
+glyphname = "doubleacuteFinal-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(317,690,l),
+(194,690,l),
+(26,345,l),
+(149,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(498,690,l),
+(376,690,l),
+(208,345,l),
+(330,345,l)
+);
+}
+);
+width = 524;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricRight = "=|";
+note = uni1425;
+unicode = 5157;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(162,690,l),
+(53,690,l),
+(53,345,l),
+(162,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(323,690,l),
+(213,690,l),
+(213,345,l),
+(323,345,l)
+);
+}
+);
+width = 376;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "pWestCree-canadian";
+note = uni1426;
+unicode = 5158;
+},
+{
+glyphname = "middledotFinal-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(160,278,o),
+(194,312,o),
+(194,355,cs),
+(194,397,o),
+(160,431,o),
+(118,431,cs),
+(76,431,o),
+(43,397,o),
+(43,355,cs),
+(43,312,o),
+(76,278,o),
+(118,278,cs)
+);
+}
+);
+width = 237;
+}
+);
+note = uni1427;
+unicode = 5159;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(378,471,l),
+(378,582,l),
+(53,582,l),
+(53,471,l)
+);
+}
+);
+width = 431;
+}
+);
+metricRight = "=|";
+note = uni1428;
+unicode = 5160;
+},
+{
+glyphname = "plusFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(270,364,l),
+(270,476,l),
+(378,476,l),
+(378,581,l),
+(270,581,l),
+(270,690,l),
+(162,690,l),
+(162,581,l),
+(53,581,l),
+(53,476,l),
+(162,476,l),
+(162,364,l)
+);
+}
+);
+width = 431;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+unicode = 5161;
+},
+{
+glyphname = "downtackFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(270,345,l),
+(270,586,l),
+(378,586,l),
+(378,690,l),
+(53,690,l),
+(53,586,l),
+(161,586,l),
+(161,345,l)
+);
+}
+);
+width = 431;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni142A;
+unicode = 5162;
+},
+{
+glyphname = "thFinalWoodScree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(271,345,l),
+(271,400,l),
+(378,400,l),
+(378,489,l),
+(271,489,l),
+(271,546,l),
+(378,546,l),
+(378,635,l),
+(271,635,l),
+(271,690,l),
+(162,690,l),
+(162,635,l),
+(53,635,l),
+(53,546,l),
+(162,546,l),
+(162,489,l),
+(53,489,l),
+(53,400,l),
+(162,400,l),
+(162,345,l)
+);
+}
+);
+width = 431;
+}
+);
+metricLeft = "hyphen-canadian";
+metricRight = "hyphen-canadian";
+note = uni167E;
+unicode = 5758;
+},
+{
+glyphname = "ringSmallFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(231,482,o),
+(286,527,o),
+(286,593,cs),
+(286,658,o),
+(231,704,o),
+(168,704,cs),
+(106,704,o),
+(53,658,o),
+(53,593,cs),
+(53,527,o),
+(106,482,o),
+(168,482,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(142,548,o),
+(126,568,o),
+(126,593,cs),
+(126,617,o),
+(144,638,o),
+(169,638,cs),
+(195,638,o),
+(213,617,o),
+(213,593,cs),
+(213,568,o),
+(195,548,o),
+(169,548,cs)
+);
+}
+);
+width = 339;
+}
+);
+note = g725;
+unicode = 6366;
+},
+{
+glyphname = "raiseddotFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(160,552,o),
+(194,585,o),
+(194,628,cs),
+(194,669,o),
+(160,704,o),
+(119,704,cs),
+(76,704,o),
+(43,669,o),
+(43,628,cs),
+(43,585,o),
+(76,552,o),
+(119,552,cs)
+);
+}
+);
+width = 237;
+}
+);
+note = g725;
+unicode = 6367;
+},
+{
+glyphname = "acuteFinal-canadian.base";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-344);
+ref = "acuteFinal-canadian";
+}
+);
+width = 343;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.base";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "graveFinal-canadian";
+}
+);
+width = 343;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian.base";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 429;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1421;
+},
+{
+glyphname = "ringTophalfFinal-canadian.base";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 429;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.base";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 365;
+}
+);
+metricLeft = "==|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "plusFinal-canadian.base";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(270,0,l),
+(270,112,l),
+(378,112,l),
+(378,216,l),
+(270,216,l),
+(270,326,l),
+(162,326,l),
+(162,216,l),
+(53,216,l),
+(53,112,l),
+(162,112,l),
+(162,0,l)
+);
+}
+);
+width = 431;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+},
+{
+glyphname = "acuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-161);
+ref = "acuteFinal-canadian";
+}
+);
+width = 343;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.mid";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "graveFinal-canadian";
+}
+);
+width = 343;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringTophalfFinal-canadian.mid";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-172);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 429;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.mid";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 365;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "ringFinal-canadian.mid";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-182);
+ref = "ringFinal-canadian";
+}
+);
+width = 440;
+}
+);
+metricLeft = "ringFinal-canadian";
+metricWidth = "ringFinal-canadian";
+note = uni1424;
+},
+{
+glyphname = "doubleacuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "doubleacuteFinal-canadian";
+}
+);
+width = 524;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "doubleacuteFinal-canadian";
+note = uni1425;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian.mid";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "doubleshortverticalstrokesFinal-canadian";
+}
+);
+width = 376;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricWidth = "doubleshortverticalstrokesFinal-canadian";
+note = uni1426;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian.mid";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-173);
+ref = "shorthorizontalstrokeFinal-canadian";
+}
+);
+width = 431;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "shorthorizontalstrokeFinal-canadian";
+note = uni1428;
+},
+{
+glyphname = "downtackFinal-canadian.mid";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "downtackFinal-canadian";
+}
+);
+width = 431;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "downtackFinal-canadian";
+note = uni142A;
+},
+{
+glyphname = "e-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (365,454);
+},
+{
+name = top_center_can;
+pos = (365,690);
+},
+{
+name = top_left_can;
+pos = (140,690);
+},
+{
+name = top_right_can;
+pos = (590,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(388,0,l),
+(706,651,l),
+(706,690,l),
+(24,690,l),
+(24,651,l),
+(341,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(393,202,l),
+(209,593,l),
+(185,561,l),
+(543,561,l),
+(526,593,l),
+(342,202,l)
+);
+}
+);
+width = 730;
+}
+);
+metricRight = "=|";
+note = uni1401;
+unicode = 5121;
+},
+{
+glyphname = "aai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (233,0);
+ref = ring_top.canadian;
+}
+);
+width = 730;
+}
+);
+note = uni1402;
+unicode = 5122;
+},
+{
+glyphname = "i-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (365,266);
+},
+{
+name = top_center_can;
+pos = (365,690);
+},
+{
+name = top_left_can;
+pos = (140,690);
+},
+{
+name = top_right_can;
+pos = (589,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(706,0,l),
+(706,39,l),
+(388,690,l),
+(341,690,l),
+(24,39,l),
+(24,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(388,488,l),
+(337,488,l),
+(522,97,l),
+(543,128,l),
+(185,128,l),
+(203,97,l)
+);
+}
+);
+width = 730;
+}
+);
+metricLeft = "e-canadian";
+metricWidth = "e-canadian";
+note = uni1403;
+unicode = 5123;
+},
+{
+glyphname = "ii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (270,0);
+ref = dot_top;
+}
+);
+width = 730;
+}
+);
+note = uni1404;
+unicode = 5124;
+},
+{
+glyphname = "o-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (268,345);
+},
+{
+name = top_center_can;
+pos = (349,690);
+},
+{
+name = top_double;
+pos = (459,690);
+},
+{
+name = top_left_can;
+pos = (128,690);
+},
+{
+name = top_right_can;
+pos = (579,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,0,l),
+(639,321,l),
+(639,369,l),
+(100,690,l),
+(63,690,l),
+(63,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(198,514,l),
+(159,506,l),
+(465,325,l),
+(465,368,l),
+(159,187,l),
+(198,178,l)
+);
+}
+);
+width = 667;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1405;
+unicode = 5125;
+},
+{
+glyphname = "oo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (35,0);
+ref = dot_top;
+}
+);
+width = 667;
+}
+);
+note = uni1406;
+unicode = 5126;
+},
+{
+glyphname = "yCreeoo-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (181,0);
+ref = doubledot_top;
+}
+);
+width = 667;
+}
+);
+note = uni1407;
+unicode = 5127;
+},
+{
+glyphname = "eeCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,0,l),
+(639,321,l),
+(639,369,l),
+(100,690,l),
+(63,690,l),
+(63,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(193,514,l),
+(159,510,l),
+(465,329,l),
+(465,364,l),
+(159,184,l),
+(193,178,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(291,406,l),
+(240,406,l),
+(240,284,l),
+(291,284,l)
+);
+}
+);
+width = 667;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "o-canadian";
+note = uni1408;
+unicode = 5128;
+},
+{
+glyphname = "iCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (207,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 667;
+}
+);
+note = uni1409;
+unicode = 5129;
+},
+{
+glyphname = "a-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (398,345);
+},
+{
+name = top_center_can;
+pos = (305,690);
+},
+{
+name = top_left_can;
+pos = (99,690);
+},
+{
+name = top_right_can;
+pos = (536,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(605,0,l),
+(605,690,l),
+(567,690,l),
+(28,369,l),
+(28,321,l),
+(567,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(507,186,l),
+(203,367,l),
+(203,324,l),
+(507,504,l),
+(469,514,l),
+(469,178,l)
+);
+}
+);
+width = 668;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni140A;
+unicode = 5130;
+},
+{
+glyphname = "aa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (441,0);
+ref = dot_top;
+}
+);
+width = 667;
+}
+);
+note = uni140B;
+unicode = 5131;
+},
+{
+glyphname = "we-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "e-canadian";
+}
+);
+width = 966;
+}
+);
+note = uni140C;
+unicode = 5132;
+},
+{
+glyphname = "weWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (730,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 966;
+}
+);
+note = uni140D;
+unicode = 5133;
+},
+{
+glyphname = "wi-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "i-canadian";
+}
+);
+width = 966;
+}
+);
+note = uni140E;
+unicode = 5134;
+},
+{
+glyphname = "wiWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (730,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 966;
+}
+);
+note = uni140F;
+unicode = 5135;
+},
+{
+glyphname = "wii-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (507,0);
+ref = dot_top;
+}
+);
+width = 966;
+}
+);
+note = uni1410;
+unicode = 5136;
+},
+{
+glyphname = "wiiWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (270,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (730,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 966;
+}
+);
+note = uni1411;
+unicode = 5137;
+},
+{
+glyphname = "wo-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "o-canadian";
+}
+);
+width = 903;
+}
+);
+note = uni1412;
+unicode = 5138;
+},
+{
+glyphname = "woWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (667,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 903;
+}
+);
+note = uni1413;
+unicode = 5139;
+},
+{
+glyphname = "woo-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (491,0);
+ref = dot_top;
+}
+);
+width = 903;
+}
+);
+note = uni1414;
+unicode = 5140;
+},
+{
+glyphname = "wooWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (35,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (667,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 903;
+}
+);
+note = uni1415;
+unicode = 5141;
+},
+{
+glyphname = "wooNaskapi-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (194,-95);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (370,-200);
+ref = dot_top;
+}
+);
+width = 667;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricWidth = "o-canadian";
+note = uni1416;
+unicode = 5142;
+},
+{
+glyphname = "wa-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "a-canadian";
+}
+);
+width = 903;
+}
+);
+note = uni1417;
+unicode = 5143;
+},
+{
+glyphname = "waWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (667,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 903;
+}
+);
+note = uni1418;
+unicode = 5144;
+},
+{
+glyphname = "waa-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (678,0);
+ref = dot_top;
+}
+);
+width = 903;
+}
+);
+note = uni1419;
+unicode = 5145;
+},
+{
+glyphname = "waaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (441,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (667,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 903;
+}
+);
+note = uni141A;
+unicode = 5146;
+},
+{
+glyphname = "waaNaskapi-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (107,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (284,-95);
+ref = dot_top;
+}
+);
+width = 668;
+}
+);
+metricWidth = "a-canadian";
+note = uni141B;
+unicode = 5147;
+},
+{
+glyphname = "ai-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(257,339,o),
+(295,360,o),
+(322,409,c),
+(289,409,l),
+(314,360,o),
+(355,339,o),
+(409,339,cs),
+(500,339,o),
+(556,397,o),
+(556,498,cs),
+(556,690,l),
+(454,690,l),
+(454,499,ls),
+(454,453,o),
+(438,433,o),
+(405,433,cs),
+(373,433,o),
+(355,454,o),
+(355,499,cs),
+(355,690,l),
+(254,690,l),
+(254,499,ls),
+(254,453,o),
+(237,433,o),
+(204,433,cs),
+(172,433,o),
+(156,455,o),
+(156,499,cs),
+(156,690,l),
+(53,690,l),
+(53,498,ls),
+(53,395,o),
+(111,339,o),
+(202,339,cs)
+);
+}
+);
+width = 609;
+}
+);
+metricRight = "=|";
+note = uni141C;
+unicode = 5148;
+},
+{
+glyphname = "ycreew-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(340,510,o),
+(376,548,o),
+(376,604,cs),
+(376,659,o),
+(339,696,o),
+(290,696,cs),
+(240,696,o),
+(203,659,o),
+(203,604,cs),
+(203,548,o),
+(239,510,o),
+(290,510,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(185,339,o),
+(221,377,o),
+(221,433,cs),
+(221,488,o),
+(185,525,o),
+(134,525,cs),
+(85,525,o),
+(48,488,o),
+(48,433,cs),
+(48,377,o),
+(84,339,o),
+(134,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(115,389,o),
+(101,406,o),
+(101,433,cs),
+(101,459,o),
+(115,474,o),
+(134,474,cs),
+(154,474,o),
+(167,459,o),
+(167,433,cs),
+(167,406,o),
+(154,389,o),
+(134,389,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(270,560,o),
+(257,577,o),
+(257,604,cs),
+(257,630,o),
+(270,645,o),
+(290,645,cs),
+(309,645,o),
+(322,630,o),
+(322,604,cs),
+(322,577,o),
+(309,560,o),
+(290,560,cs)
+);
+}
+);
+width = 424;
+}
+);
+metricRight = "=|";
+note = uni141D;
+unicode = 5149;
+},
+{
+glyphname = "glottalstop-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(381,345,l),
+(381,365,l),
+(222,690,l),
+(198,690,l),
+(40,365,l),
+(40,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(233,585,l),
+(186,585,l),
+(276,393,l),
+(297,424,l),
+(125,424,l),
+(142,393,l)
+);
+}
+);
+width = 421;
+}
+);
+metricRight = "=|";
+note = uni141E;
+unicode = 5150;
+},
+{
+glyphname = "en-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+pos = (730,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 1073;
+}
+);
+note = uni142B;
+unicode = 5163;
+},
+{
+glyphname = "in-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+pos = (482,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 825;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142C;
+unicode = 5164;
+},
+{
+glyphname = "on-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (518,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 861;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142D;
+unicode = 5165;
+},
+{
+glyphname = "an-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (628,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 971;
+}
+);
+metricRight = "graveFinal-canadian";
+note = uni142E;
+unicode = 5166;
+},
+{
+glyphname = "pe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (365,454);
+},
+{
+name = top_center_can;
+pos = (365,690);
+},
+{
+name = top_left_can;
+pos = (140,690);
+},
+{
+name = top_right_can;
+pos = (590,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(388,0,l),
+(706,651,l),
+(706,690,l),
+(557,690,l),
+(325,196,l),
+(412,196,l),
+(181,690,l),
+(24,690,l),
+(24,651,l),
+(341,0,l)
+);
+}
+);
+width = 730;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni142F;
+unicode = 5167;
+},
+{
+glyphname = "paai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (233,0);
+ref = ring_top.canadian;
+}
+);
+width = 730;
+}
+);
+note = uni1430;
+unicode = 5168;
+},
+{
+glyphname = "pi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (364,266);
+},
+{
+name = top_center_can;
+pos = (365,690);
+},
+{
+name = top_left_can;
+pos = (139,690);
+},
+{
+name = top_right_can;
+pos = (590,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(175,0,l),
+(410,494,l),
+(321,494,l),
+(552,0,l),
+(706,0,l),
+(706,39,l),
+(388,690,l),
+(341,690,l),
+(24,39,l),
+(24,0,l)
+);
+}
+);
+width = 730;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni1431;
+unicode = 5169;
+},
+{
+glyphname = "pii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (270,0);
+ref = dot_top;
+}
+);
+width = 730;
+}
+);
+note = uni1432;
+unicode = 5170;
+},
+{
+glyphname = "po-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (170,345);
+},
+{
+name = top_center_can;
+pos = (327,690);
+},
+{
+name = top_double;
+pos = (443,690);
+},
+{
+name = top_left_can;
+pos = (110,690);
+},
+{
+name = top_right_can;
+pos = (556,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(79,0,l),
+(617,321,l),
+(617,369,l),
+(79,690,l),
+(42,690,l),
+(42,539,l),
+(430,310,l),
+(430,382,l),
+(42,153,l),
+(42,0,l)
+);
+}
+);
+width = 645;
+}
+);
+metricRight = "o-canadian";
+note = uni1433;
+unicode = 5171;
+},
+{
+glyphname = "poo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (16,0);
+ref = dot_top;
+}
+);
+width = 645;
+}
+);
+note = uni1434;
+unicode = 5172;
+},
+{
+glyphname = "ycreepoo-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (165,0);
+ref = doubledot_top;
+}
+);
+width = 645;
+}
+);
+note = uni1435;
+unicode = 5173;
+},
+{
+glyphname = "heeCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (119,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 645;
+}
+);
+note = uni1436;
+unicode = 5174;
+},
+{
+glyphname = "hiCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (92,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 645;
+}
+);
+note = uni1437;
+unicode = 5175;
+},
+{
+glyphname = "pa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (399,345);
+},
+{
+name = top_center_can;
+pos = (319,690);
+},
+{
+name = top_left_can;
+pos = (99,690);
+},
+{
+name = top_right_can;
+pos = (534,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(604,0,l),
+(604,151,l),
+(215,380,l),
+(215,308,l),
+(604,537,l),
+(604,690,l),
+(565,690,l),
+(28,369,l),
+(28,321,l),
+(565,0,l)
+);
+}
+);
+width = 646;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1438;
+unicode = 5176;
+},
+{
+glyphname = "paa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (440,0);
+ref = dot_top;
+}
+);
+width = 645;
+}
+);
+note = uni1439;
+unicode = 5177;
+},
+{
+glyphname = "pwe-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "pe-canadian";
+}
+);
+width = 966;
+}
+);
+note = uni143A;
+unicode = 5178;
+},
+{
+glyphname = "pweWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "pe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (730,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 966;
+}
+);
+note = uni143B;
+unicode = 5179;
+},
+{
+glyphname = "pwi-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "pi-canadian";
+}
+);
+width = 966;
+}
+);
+note = uni143C;
+unicode = 5180;
+},
+{
+glyphname = "pwiWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (730,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 966;
+}
+);
+note = uni143D;
+unicode = 5181;
+},
+{
+glyphname = "pwii-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (507,0);
+ref = dot_top;
+}
+);
+width = 966;
+}
+);
+note = uni143E;
+unicode = 5182;
+},
+{
+glyphname = "pwiiWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (270,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (730,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 966;
+}
+);
+note = uni143F;
+unicode = 5183;
+},
+{
+glyphname = "pwo-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "po-canadian";
+}
+);
+width = 881;
+}
+);
+note = uni1440;
+unicode = 5184;
+},
+{
+glyphname = "pwoWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (645,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 881;
+}
+);
+note = uni1441;
+unicode = 5185;
+},
+{
+glyphname = "pwoo-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (469,0);
+ref = dot_top;
+}
+);
+width = 881;
+}
+);
+note = uni1442;
+unicode = 5186;
+},
+{
+glyphname = "pwooWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (16,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (645,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 881;
+}
+);
+note = uni1443;
+unicode = 5187;
+},
+{
+glyphname = "pwa-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "pa-canadian";
+}
+);
+width = 881;
+}
+);
+note = uni1444;
+unicode = 5188;
+},
+{
+glyphname = "pwaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (645,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 881;
+}
+);
+note = uni1445;
+unicode = 5189;
+},
+{
+glyphname = "pwaa-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (677,0);
+ref = dot_top;
+}
+);
+width = 881;
+}
+);
+note = uni1446;
+unicode = 5190;
+},
+{
+glyphname = "pwaaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (440,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (645,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 881;
+}
+);
+note = uni1447;
+unicode = 5191;
+},
+{
+glyphname = "ycreepwaa-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+pos = (107,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (283,-95);
+ref = dot_top;
+}
+);
+width = 646;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1448;
+unicode = 5192;
+},
+{
+glyphname = "p-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(339,345,l),
+(339,445,l),
+(148,559,l),
+(148,475,l),
+(339,588,l),
+(339,690,l),
+(320,690,l),
+(53,530,l),
+(53,505,l),
+(320,345,l)
+);
+}
+);
+width = 392;
+}
+);
+note = uni1449;
+unicode = 5193;
+},
+{
+glyphname = "pWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(162,345,l),
+(162,690,l),
+(53,690,l),
+(53,345,l)
+);
+}
+);
+width = 215;
+}
+);
+metricRight = "=|";
+note = uni144A;
+unicode = 5194;
+},
+{
+color = 6;
+glyphname = "hCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(162,183,l),
+(162,287,ls),
+(162,320,o),
+(178,338,o),
+(205,338,cs),
+(229,338,o),
+(242,321,o),
+(242,287,cs),
+(242,183,l),
+(351,183,l),
+(351,307,ls),
+(351,399,o),
+(290,437,o),
+(230,437,cs),
+(184,437,o),
+(147,412,o),
+(139,384,c),
+(162,363,l),
+(162,527,l),
+(53,527,l),
+(53,183,l)
+);
+}
+);
+width = 384;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144B;
+unicode = 5195;
+},
+{
+glyphname = "te-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (362,345);
+},
+{
+name = top_center_can;
+pos = (362,690);
+},
+{
+name = top_left_can;
+pos = (136,690);
+},
+{
+name = top_right_can;
+pos = (590,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(556,-14,o),
+(669,104,o),
+(669,309,cs),
+(669,690,l),
+(509,690,l),
+(509,309,ls),
+(509,188,o),
+(459,130,o),
+(362,130,cs),
+(269,130,o),
+(216,192,o),
+(216,309,cs),
+(216,690,l),
+(56,690,l),
+(56,308,ls),
+(56,102,o),
+(169,-14,o),
+(363,-14,cs)
+);
+}
+);
+width = 725;
+}
+);
+metricRight = "=|";
+note = uni144C;
+unicode = 5196;
+},
+{
+glyphname = "taai-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (231,0);
+ref = ring_top.canadian;
+}
+);
+width = 725;
+}
+);
+note = uni144D;
+unicode = 5197;
+},
+{
+glyphname = "ti-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (362,345);
+},
+{
+name = middle_right_can;
+pos = (815,345);
+},
+{
+name = top_center_can;
+pos = (362,690);
+},
+{
+name = top_left_can;
+pos = (136,690);
+},
+{
+name = top_right_can;
+pos = (590,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(216,0,l),
+(216,381,ls),
+(216,498,o),
+(271,559,o),
+(365,559,cs),
+(458,559,o),
+(509,497,o),
+(509,381,cs),
+(509,0,l),
+(669,0,l),
+(669,382,ls),
+(669,586,o),
+(557,704,o),
+(368,704,cs),
+(175,704,o),
+(56,586,o),
+(56,382,cs),
+(56,0,l)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni144E;
+unicode = 5198;
+},
+{
+glyphname = "tii-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (269,0);
+ref = dot_top;
+}
+);
+width = 725;
+}
+);
+note = uni144F;
+unicode = 5199;
+},
+{
+glyphname = "to-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (228,345);
+},
+{
+name = middle_right_can;
+pos = (713,345);
+},
+{
+name = top_center_can;
+pos = (281,690);
+},
+{
+name = top_double;
+pos = (374,690);
+},
+{
+name = top_left_can;
+pos = (117,690);
+},
+{
+name = top_right_can;
+pos = (498,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(217,0,ls),
+(439,0,o),
+(567,125,o),
+(567,346,cs),
+(567,567,o),
+(439,690,o),
+(217,690,cs),
+(47,690,l),
+(47,546,l),
+(210,546,ls),
+(333,546,o),
+(407,482,o),
+(407,346,cs),
+(407,210,o),
+(333,144,o),
+(211,144,cs),
+(47,144,l),
+(47,0,l)
+);
+}
+);
+width = 617;
+}
+);
+note = uni1450;
+unicode = 5200;
+},
+{
+glyphname = "too-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (187,0);
+ref = dot_top;
+}
+);
+width = 617;
+}
+);
+note = uni1451;
+unicode = 5201;
+},
+{
+glyphname = "ycreetoo-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (96,0);
+ref = doubledot_top;
+}
+);
+width = 617;
+}
+);
+note = uni1452;
+unicode = 5202;
+},
+{
+glyphname = "deeCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (164,0);
+ref = stroke_middle;
+}
+);
+width = 617;
+}
+);
+note = uni1453;
+unicode = 5203;
+},
+{
+glyphname = "diCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (134,0);
+ref = dot_middle;
+}
+);
+width = 617;
+}
+);
+note = uni1454;
+unicode = 5204;
+},
+{
+glyphname = "ta-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (390,345);
+},
+{
+name = top_center_can;
+pos = (337,690);
+},
+{
+name = top_left_can;
+pos = (120,690);
+},
+{
+name = top_right_can;
+pos = (501,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(570,0,l),
+(570,144,l),
+(408,144,ls),
+(284,144,o),
+(212,209,o),
+(212,345,cs),
+(212,481,o),
+(284,546,o),
+(408,546,cs),
+(570,546,l),
+(570,690,l),
+(401,690,ls),
+(180,690,o),
+(50,566,o),
+(50,345,cs),
+(50,124,o),
+(180,0,o),
+(400,0,cs)
+);
+}
+);
+width = 617;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|to-canadian";
+note = uni1455;
+unicode = 5205;
+},
+{
+glyphname = "taa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (243,0);
+ref = dot_top;
+}
+);
+width = 617;
+}
+);
+note = uni1456;
+unicode = 5206;
+},
+{
+glyphname = "twe-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "te-canadian";
+}
+);
+width = 962;
+}
+);
+note = uni1457;
+unicode = 5207;
+},
+{
+glyphname = "tweWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (725,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 962;
+}
+);
+note = uni1458;
+unicode = 5208;
+},
+{
+glyphname = "twi-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ti-canadian";
+}
+);
+width = 962;
+}
+);
+note = uni1459;
+unicode = 5209;
+},
+{
+glyphname = "twiWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (725,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 962;
+}
+);
+note = uni145A;
+unicode = 5210;
+},
+{
+glyphname = "twii-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (505,0);
+ref = dot_top;
+}
+);
+width = 962;
+}
+);
+note = uni145B;
+unicode = 5211;
+},
+{
+glyphname = "twiiWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (269,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (725,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 962;
+}
+);
+note = uni145C;
+unicode = 5212;
+},
+{
+glyphname = "two-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "to-canadian";
+}
+);
+width = 854;
+}
+);
+note = uni145D;
+unicode = 5213;
+},
+{
+glyphname = "twoWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (617,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 854;
+}
+);
+note = uni145E;
+unicode = 5214;
+},
+{
+glyphname = "twoo-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (424,0);
+ref = dot_top;
+}
+);
+width = 854;
+}
+);
+note = uni145F;
+unicode = 5215;
+},
+{
+glyphname = "twooWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (187,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (617,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 854;
+}
+);
+note = uni1460;
+unicode = 5216;
+},
+{
+glyphname = "twa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ta-canadian";
+}
+);
+width = 854;
+}
+);
+note = uni1461;
+unicode = 5217;
+},
+{
+glyphname = "twaWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (617,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 854;
+}
+);
+note = uni1462;
+unicode = 5218;
+},
+{
+glyphname = "twaa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (479,0);
+ref = dot_top;
+}
+);
+width = 854;
+}
+);
+note = uni1463;
+unicode = 5219;
+},
+{
+glyphname = "twaaWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (243,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (617,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 854;
+}
+);
+note = uni1464;
+unicode = 5220;
+},
+{
+glyphname = "twaaNaskapi-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ta-canadian";
+}
+);
+width = 854;
+}
+);
+note = uni1465;
+unicode = 5221;
+},
+{
+glyphname = "t-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(312,345,l),
+(312,446,l),
+(235,446,ls),
+(184,446,o),
+(156,470,o),
+(156,517,cs),
+(156,562,o),
+(184,588,o),
+(235,588,cs),
+(312,588,l),
+(312,690,l),
+(227,690,ls),
+(111,690,o),
+(46,623,o),
+(46,517,cs),
+(46,411,o),
+(111,345,o),
+(227,345,cs)
+);
+}
+);
+width = 365;
+}
+);
+note = uni1466;
+unicode = 5222;
+},
+{
+glyphname = "tte-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+pos = (725,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 941;
+}
+);
+note = uni1467;
+unicode = 5223;
+},
+{
+glyphname = "tti-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+pos = (725,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 941;
+}
+);
+note = uni1468;
+unicode = 5224;
+},
+{
+glyphname = "tto-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+pos = (617,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 834;
+}
+);
+note = uni1469;
+unicode = 5225;
+},
+{
+glyphname = "tta-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+pos = (617,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 834;
+}
+);
+note = uni146A;
+unicode = 5226;
+},
+{
+glyphname = "ke-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (294,441);
+},
+{
+name = top_center_can;
+pos = (290,690);
+},
+{
+name = top_left_can;
+pos = (121,690);
+},
+{
+name = top_right_can;
+pos = (458,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(538,0,l),
+(538,435,ls),
+(538,602,o),
+(446,704,o),
+(294,704,cs),
+(141,704,o),
+(42,601,o),
+(42,440,cs),
+(42,286,o),
+(134,184,o),
+(267,184,cs),
+(331,184,o),
+(380,214,o),
+(390,247,c),
+(378,260,l),
+(378,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(236,319,o),
+(199,360,o),
+(199,443,cs),
+(199,527,o),
+(233,569,o),
+(290,569,cs),
+(346,569,o),
+(381,527,o),
+(381,443,cs),
+(381,360,o),
+(343,319,o),
+(290,319,cs)
+);
+}
+);
+width = 594;
+}
+);
+metricRight = "te-canadian";
+note = uni146B;
+unicode = 5227;
+},
+{
+glyphname = "kaai-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (172,0);
+ref = ring_top.canadian;
+}
+);
+width = 593;
+}
+);
+note = uni146C;
+unicode = 5228;
+},
+{
+glyphname = "ki-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (308,441);
+},
+{
+name = top_center_can;
+pos = (304,690);
+},
+{
+name = top_left_can;
+pos = (135,690);
+},
+{
+name = top_right_can;
+pos = (473,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(216,0,l),
+(216,260,l),
+(203,247,l),
+(213,214,o),
+(262,184,o),
+(327,184,cs),
+(459,184,o),
+(552,287,o),
+(552,442,cs),
+(552,603,o),
+(453,704,o),
+(306,704,cs),
+(151,704,o),
+(56,599,o),
+(56,435,cs),
+(56,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(250,319,o),
+(213,360,o),
+(213,443,cs),
+(213,527,o),
+(247,569,o),
+(304,569,cs),
+(360,569,o),
+(395,527,o),
+(395,443,cs),
+(395,360,o),
+(357,319,o),
+(304,319,cs)
+);
+}
+);
+width = 594;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni146D;
+unicode = 5229;
+},
+{
+glyphname = "kii-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (210,0);
+ref = dot_top;
+}
+);
+width = 593;
+}
+);
+note = uni146E;
+unicode = 5230;
+},
+{
+glyphname = "ko-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (294,277);
+},
+{
+name = top_center_can;
+pos = (290,690);
+},
+{
+name = top_double;
+pos = (458,690);
+},
+{
+name = top_left_can;
+pos = (121,690);
+},
+{
+name = top_right_can;
+pos = (458,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(445,-14,o),
+(538,88,o),
+(538,255,cs),
+(538,690,l),
+(378,690,l),
+(378,430,l),
+(390,442,l),
+(380,475,o),
+(331,506,o),
+(269,506,cs),
+(134,506,o),
+(42,401,o),
+(42,243,cs),
+(42,86,o),
+(136,-14,o),
+(290,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(233,121,o),
+(199,162,o),
+(199,246,cs),
+(199,329,o),
+(236,371,o),
+(290,371,cs),
+(343,371,o),
+(381,329,o),
+(381,246,cs),
+(381,162,o),
+(346,121,o),
+(290,121,cs)
+);
+}
+);
+width = 594;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni146F;
+unicode = 5231;
+},
+{
+glyphname = "koo-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (364,0);
+ref = dot_top;
+}
+);
+width = 593;
+}
+);
+note = uni1470;
+unicode = 5232;
+},
+{
+glyphname = "ycreekoo-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (180,0);
+ref = doubledot_top;
+}
+);
+width = 593;
+}
+);
+note = uni1471;
+unicode = 5233;
+},
+{
+glyphname = "ka-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (308,281);
+},
+{
+name = top_center_can;
+pos = (304,690);
+},
+{
+name = top_left_can;
+pos = (136,690);
+},
+{
+name = top_right_can;
+pos = (473,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(451,-14,o),
+(552,87,o),
+(552,248,cs),
+(552,403,o),
+(459,506,o),
+(330,506,cs),
+(265,506,o),
+(216,475,o),
+(203,442,c),
+(216,430,l),
+(216,690,l),
+(56,690,l),
+(56,255,ls),
+(56,88,o),
+(147,-14,o),
+(302,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(247,121,o),
+(213,162,o),
+(213,246,cs),
+(213,329,o),
+(250,371,o),
+(304,371,cs),
+(357,371,o),
+(395,329,o),
+(395,246,cs),
+(395,162,o),
+(360,121,o),
+(304,121,cs)
+);
+}
+);
+width = 594;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "==|ke-canadian";
+note = uni1472;
+unicode = 5234;
+},
+{
+glyphname = "kaa-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (42,0);
+ref = dot_top;
+}
+);
+width = 593;
+}
+);
+note = uni1473;
+unicode = 5235;
+},
+{
+glyphname = "kwe-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ke-canadian";
+}
+);
+width = 830;
+}
+);
+note = uni1474;
+unicode = 5236;
+},
+{
+glyphname = "kweWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (593,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 830;
+}
+);
+note = uni1475;
+unicode = 5237;
+},
+{
+glyphname = "kwi-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ki-canadian";
+}
+);
+width = 830;
+}
+);
+note = uni1476;
+unicode = 5238;
+},
+{
+glyphname = "kwiWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (593,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 830;
+}
+);
+note = uni1477;
+unicode = 5239;
+},
+{
+glyphname = "kwii-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (446,0);
+ref = dot_top;
+}
+);
+width = 830;
+}
+);
+note = uni1478;
+unicode = 5240;
+},
+{
+glyphname = "kwiiWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (210,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (593,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 830;
+}
+);
+note = uni1479;
+unicode = 5241;
+},
+{
+glyphname = "kwo-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ko-canadian";
+}
+);
+width = 830;
+}
+);
+note = uni147A;
+unicode = 5242;
+},
+{
+glyphname = "kwoWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (593,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 830;
+}
+);
+note = uni147B;
+unicode = 5243;
+},
+{
+glyphname = "kwoo-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (601,0);
+ref = dot_top;
+}
+);
+width = 830;
+}
+);
+note = uni147C;
+unicode = 5244;
+},
+{
+glyphname = "kwooWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (364,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (593,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 830;
+}
+);
+note = uni147D;
+unicode = 5245;
+},
+{
+glyphname = "kwa-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ka-canadian";
+}
+);
+width = 830;
+}
+);
+note = uni147E;
+unicode = 5246;
+},
+{
+glyphname = "kwaWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (593,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 830;
+}
+);
+note = uni147F;
+unicode = 5247;
+},
+{
+glyphname = "kwaa-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (278,0);
+ref = dot_top;
+}
+);
+width = 830;
+}
+);
+note = uni1480;
+unicode = 5248;
+},
+{
+glyphname = "kwaaWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (42,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (593,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 830;
+}
+);
+note = uni1481;
+unicode = 5249;
+},
+{
+glyphname = "kwaaNaskapi-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ka-canadian";
+}
+);
+width = 830;
+}
+);
+note = uni1482;
+unicode = 5250;
+},
+{
+glyphname = "k-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(271,339,o),
+(332,386,o),
+(332,472,cs),
+(332,552,o),
+(281,601,o),
+(215,601,cs),
+(178,601,o),
+(149,581,o),
+(142,555,c),
+(162,554,l),
+(162,690,l),
+(53,690,l),
+(53,475,ls),
+(53,394,o),
+(106,339,o),
+(196,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(170,417,o),
+(153,434,o),
+(153,469,cs),
+(153,506,o),
+(171,523,o),
+(194,523,cs),
+(217,523,o),
+(236,506,o),
+(236,469,cs),
+(236,434,o),
+(217,417,o),
+(194,417,cs)
+);
+}
+);
+width = 376;
+}
+);
+note = uni1483;
+unicode = 5251;
+},
+{
+glyphname = "kw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(271,339,o),
+(324,394,o),
+(324,475,cs),
+(324,690,l),
+(214,690,l),
+(214,554,l),
+(236,555,l),
+(228,581,o),
+(199,601,o),
+(161,601,cs),
+(96,601,o),
+(44,552,o),
+(44,472,cs),
+(44,386,o),
+(105,339,o),
+(181,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(159,417,o),
+(141,434,o),
+(141,469,cs),
+(141,506,o),
+(159,523,o),
+(183,523,cs),
+(206,523,o),
+(224,506,o),
+(224,469,cs),
+(224,434,o),
+(207,417,o),
+(183,417,cs)
+);
+}
+);
+width = 377;
+}
+);
+metricLeft = "=|k-canadian";
+metricRight = "=|k-canadian";
+note = uni1484;
+unicode = 5252;
+},
+{
+glyphname = "southslaveykeh-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+pos = (593,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni1485;
+unicode = 5253;
+},
+{
+glyphname = "southslaveykih-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+pos = (593,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni1486;
+unicode = 5254;
+},
+{
+glyphname = "southslaveykoh-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+pos = (593,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni1487;
+unicode = 5255;
+},
+{
+glyphname = "southslaveykah-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+pos = (593,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni1488;
+unicode = 5256;
+},
+{
+glyphname = "ce-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (289,360);
+},
+{
+name = top_center_can;
+pos = (289,690);
+},
+{
+name = top_left_can;
+pos = (120,690);
+},
+{
+name = top_right_can;
+pos = (450,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(530,0,l),
+(530,439,ls),
+(530,608,o),
+(440,704,o),
+(289,704,cs),
+(134,704,o),
+(41,607,o),
+(41,438,cs),
+(41,380,l),
+(199,380,l),
+(199,454,ls),
+(199,526,o),
+(230,565,o),
+(285,565,cs),
+(339,565,o),
+(370,527,o),
+(370,453,cs),
+(370,0,l)
+);
+}
+);
+width = 586;
+}
+);
+metricRight = "te-canadian";
+note = uni1489;
+unicode = 5257;
+},
+{
+glyphname = "caai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (174,0);
+ref = ring_top.canadian;
+}
+);
+width = 585;
+}
+);
+note = uni148A;
+unicode = 5258;
+},
+{
+glyphname = "ci-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (294,360);
+},
+{
+name = top_center_can;
+pos = (305,690);
+},
+{
+name = top_left_can;
+pos = (136,690);
+},
+{
+name = top_right_can;
+pos = (467,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(216,0,l),
+(216,453,ls),
+(216,527,o),
+(248,565,o),
+(303,565,cs),
+(356,565,o),
+(386,527,o),
+(386,455,cs),
+(386,380,l),
+(546,380,l),
+(546,438,ls),
+(546,607,o),
+(456,704,o),
+(305,704,cs),
+(146,704,o),
+(56,604,o),
+(56,438,cs),
+(56,0,l)
+);
+}
+);
+width = 587;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+unicode = 5259;
+},
+{
+glyphname = "cii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (212,0);
+ref = dot_top;
+}
+);
+width = 585;
+}
+);
+note = uni148C;
+unicode = 5260;
+},
+{
+glyphname = "co-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (289,360);
+},
+{
+name = top_center_can;
+pos = (288,690);
+},
+{
+name = top_double;
+pos = (450,690);
+},
+{
+name = top_left_can;
+pos = (120,690);
+},
+{
+name = top_right_can;
+pos = (450,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,-14,o),
+(530,81,o),
+(530,251,cs),
+(530,690,l),
+(370,690,l),
+(370,235,ls),
+(370,160,o),
+(339,125,o),
+(285,125,cs),
+(228,125,o),
+(199,163,o),
+(199,242,cs),
+(199,310,l),
+(41,310,l),
+(41,252,ls),
+(41,83,o),
+(129,-14,o),
+(289,-14,cs)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+unicode = 5261;
+},
+{
+glyphname = "coo-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (356,0);
+ref = dot_top;
+}
+);
+width = 585;
+}
+);
+note = uni148E;
+unicode = 5262;
+},
+{
+glyphname = "ycreecoo-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (172,0);
+ref = doubledot_top;
+}
+);
+width = 585;
+}
+);
+note = uni148F;
+unicode = 5263;
+},
+{
+glyphname = "ca-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (294,360);
+},
+{
+name = top_center_can;
+pos = (305,690);
+},
+{
+name = top_left_can;
+pos = (136,690);
+},
+{
+name = top_right_can;
+pos = (467,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(454,-14,o),
+(546,83,o),
+(546,252,cs),
+(546,310,l),
+(386,310,l),
+(386,240,ls),
+(386,161,o),
+(357,125,o),
+(302,125,cs),
+(246,125,o),
+(216,162,o),
+(216,241,cs),
+(216,690,l),
+(56,690,l),
+(56,251,ls),
+(56,83,o),
+(142,-14,o),
+(301,-14,cs)
+);
+}
+);
+width = 587;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+unicode = 5264;
+},
+{
+glyphname = "caa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (43,0);
+ref = dot_top;
+}
+);
+width = 585;
+}
+);
+note = uni1491;
+unicode = 5265;
+},
+{
+glyphname = "cwe-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ce-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni1492;
+unicode = 5266;
+},
+{
+glyphname = "cweWestCree-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (585,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni1493;
+unicode = 5267;
+},
+{
+glyphname = "cwi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ci-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni1494;
+unicode = 5268;
+},
+{
+glyphname = "cwiWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (585,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni1495;
+unicode = 5269;
+},
+{
+glyphname = "cwii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (448,0);
+ref = dot_top;
+}
+);
+width = 822;
+}
+);
+note = uni1496;
+unicode = 5270;
+},
+{
+glyphname = "cwiiWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (212,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (585,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni1497;
+unicode = 5271;
+},
+{
+glyphname = "cwo-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "co-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni1498;
+unicode = 5272;
+},
+{
+glyphname = "cwoWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (585,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni1499;
+unicode = 5273;
+},
+{
+glyphname = "cwoo-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (592,0);
+ref = dot_top;
+}
+);
+width = 822;
+}
+);
+note = uni149A;
+unicode = 5274;
+},
+{
+glyphname = "cwooWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (356,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (585,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni149B;
+unicode = 5275;
+},
+{
+glyphname = "cwa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ca-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni149C;
+unicode = 5276;
+},
+{
+glyphname = "cwaWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (585,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni149D;
+unicode = 5277;
+},
+{
+glyphname = "cwaa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (279,0);
+ref = dot_top;
+}
+);
+width = 822;
+}
+);
+note = uni149E;
+unicode = 5278;
+},
+{
+glyphname = "cwaaWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (43,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (585,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni149F;
+unicode = 5279;
+},
+{
+glyphname = "cwaaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ca-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni14A0;
+unicode = 5280;
+},
+{
+glyphname = "c-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(281,339,o),
+(335,388,o),
+(335,471,cs),
+(335,491,l),
+(233,491,l),
+(233,464,ls),
+(233,439,o),
+(219,423,o),
+(196,423,cs),
+(174,423,o),
+(162,439,o),
+(162,466,cs),
+(162,690,l),
+(53,690,l),
+(53,480,ls),
+(53,388,o),
+(102,339,o),
+(196,339,cs)
+);
+}
+);
+width = 366;
+}
+);
+note = uni14A1;
+unicode = 5281;
+},
+{
+glyphname = "thSayisi-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(264,339,o),
+(313,388,o),
+(313,480,cs),
+(313,690,l),
+(204,690,l),
+(204,466,ls),
+(204,439,o),
+(192,423,o),
+(170,423,cs),
+(147,423,o),
+(133,439,o),
+(133,464,cs),
+(133,491,l),
+(31,491,l),
+(31,471,ls),
+(31,388,o),
+(85,339,o),
+(172,339,cs)
+);
+}
+);
+width = 366;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "=|c-canadian";
+note = uni14A2;
+unicode = 5282;
+},
+{
+glyphname = "me-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (183,345);
+},
+{
+name = top_center_can;
+pos = (267,690);
+},
+{
+name = top_left_can;
+pos = (115,690);
+},
+{
+name = top_right_can;
+pos = (410,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(490,0,l),
+(490,690,l),
+(36,690,l),
+(36,546,l),
+(329,546,l),
+(329,0,l)
+);
+}
+);
+width = 553;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+unicode = 5283;
+},
+{
+glyphname = "maai-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (157,0);
+ref = ring_top.canadian;
+}
+);
+width = 552;
+}
+);
+note = uni14A4;
+unicode = 5284;
+},
+{
+glyphname = "mi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (370,345);
+},
+{
+name = top_center_can;
+pos = (290,690);
+},
+{
+name = top_left_can;
+pos = (143,690);
+},
+{
+name = top_right_can;
+pos = (437,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(223,0,l),
+(223,546,l),
+(517,546,l),
+(517,690,l),
+(63,690,l),
+(63,0,l)
+);
+}
+);
+width = 553;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+unicode = 5285;
+},
+{
+glyphname = "mii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (195,0);
+ref = dot_top;
+}
+);
+width = 552;
+}
+);
+note = uni14A6;
+unicode = 5286;
+},
+{
+glyphname = "mo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (183,345);
+},
+{
+name = top_center_can;
+pos = (267,690);
+},
+{
+name = top_double;
+pos = (410,690);
+},
+{
+name = top_left_can;
+pos = (115,690);
+},
+{
+name = top_right_can;
+pos = (410,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(490,0,l),
+(490,690,l),
+(329,690,l),
+(329,144,l),
+(36,144,l),
+(36,0,l)
+);
+}
+);
+width = 553;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+unicode = 5287;
+},
+{
+glyphname = "moo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (316,0);
+ref = dot_top;
+}
+);
+width = 552;
+}
+);
+note = uni14A8;
+unicode = 5288;
+},
+{
+glyphname = "ycreemoo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (131,0);
+ref = doubledot_top;
+}
+);
+width = 552;
+}
+);
+note = uni14A9;
+unicode = 5289;
+},
+{
+glyphname = "ma-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (370,345);
+},
+{
+name = top_center_can;
+pos = (290,690);
+},
+{
+name = top_left_can;
+pos = (143,690);
+},
+{
+name = top_right_can;
+pos = (436,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(517,0,l),
+(517,144,l),
+(223,144,l),
+(223,690,l),
+(63,690,l),
+(63,0,l)
+);
+}
+);
+width = 553;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+unicode = 5290;
+},
+{
+glyphname = "maa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+}
+);
+width = 552;
+}
+);
+note = uni14AB;
+unicode = 5291;
+},
+{
+glyphname = "mwe-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "me-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni14AC;
+unicode = 5292;
+},
+{
+glyphname = "mweWestCree-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "me-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (552,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni14AD;
+unicode = 5293;
+},
+{
+glyphname = "mwi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "mi-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni14AE;
+unicode = 5294;
+},
+{
+glyphname = "mwiWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (552,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni14AF;
+unicode = 5295;
+},
+{
+glyphname = "mwii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (432,0);
+ref = dot_top;
+}
+);
+width = 788;
+}
+);
+note = uni14B0;
+unicode = 5296;
+},
+{
+glyphname = "mwiiWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (195,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (552,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni14B1;
+unicode = 5297;
+},
+{
+glyphname = "mwo-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "mo-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni14B2;
+unicode = 5298;
+},
+{
+glyphname = "mwoWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (552,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni14B3;
+unicode = 5299;
+},
+{
+glyphname = "mwoo-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (553,0);
+ref = dot_top;
+}
+);
+width = 788;
+}
+);
+note = uni14B4;
+unicode = 5300;
+},
+{
+glyphname = "mwooWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (316,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (552,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni14B5;
+unicode = 5301;
+},
+{
+glyphname = "mwa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ma-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni14B6;
+unicode = 5302;
+},
+{
+glyphname = "mwaWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (552,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni14B7;
+unicode = 5303;
+},
+{
+glyphname = "mwaa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (285,0);
+ref = dot_top;
+}
+);
+width = 788;
+}
+);
+note = uni14B8;
+unicode = 5304;
+},
+{
+glyphname = "mwaaWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (552,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni14B9;
+unicode = 5305;
+},
+{
+glyphname = "mwaaNaskapi-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ma-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni14BA;
+unicode = 5306;
+},
+{
+glyphname = "m-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(299,446,l),
+(162,446,l),
+(162,690,l),
+(53,690,l),
+(53,345,l),
+(299,345,l)
+);
+}
+);
+width = 340;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni14BB;
+unicode = 5307;
+},
+{
+glyphname = "mWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+ref = "t-canadian";
+}
+);
+width = 365;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "t-canadian";
+note = uni14BC;
+unicode = 5308;
+},
+{
+glyphname = "mh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(287,345,l),
+(287,690,l),
+(178,690,l),
+(178,446,l),
+(41,446,l),
+(41,345,l)
+);
+}
+);
+width = 340;
+}
+);
+metricLeft = "=|m-canadian";
+metricRight = "=|m-canadian";
+note = uni14BD;
+unicode = 5309;
+},
+{
+glyphname = "mAthapascan-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(309,345,l),
+(309,431,l),
+(161,431,l),
+(162,388,l),
+(251,477,ls),
+(288,513,o),
+(302,551,o),
+(302,586,cs),
+(302,651,o),
+(259,696,o),
+(178,696,cs),
+(91,696,o),
+(43,643,o),
+(42,568,c),
+(137,568,l),
+(137,602,o),
+(150,618,o),
+(175,618,cs),
+(196,618,o),
+(207,606,o),
+(207,583,cs),
+(207,560,o),
+(198,543,o),
+(170,513,cs),
+(54,401,l),
+(54,345,l)
+);
+}
+);
+width = 351;
+}
+);
+note = uni14BE;
+unicode = 5310;
+},
+{
+glyphname = "mSayisi-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = two.canadian;
+}
+);
+width = 588;
+}
+);
+note = uni14BF;
+unicode = 5311;
+},
+{
+glyphname = "ne-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (504,245);
+},
+{
+name = top_center_can;
+pos = (487,511);
+},
+{
+name = top_left_can;
+pos = (120,511);
+},
+{
+name = top_right_can;
+pos = (679,511);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(653,-14,o),
+(757,83,o),
+(757,240,cs),
+(757,402,o),
+(656,492,o),
+(485,492,cs),
+(41,492,l),
+(41,350,l),
+(326,350,l),
+(303,384,l),
+(270,348,o),
+(252,288,o),
+(252,231,cs),
+(252,79,o),
+(351,-14,o),
+(504,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(442,121,o),
+(410,168,o),
+(410,239,cs),
+(410,309,o),
+(442,356,o),
+(503,356,cs),
+(565,356,o),
+(600,310,o),
+(600,239,cs),
+(600,167,o),
+(565,121,o),
+(504,121,cs)
+);
+}
+);
+width = 799;
+}
+);
+metricRight = "=|ke-canadian";
+note = uni14C0;
+unicode = 5312;
+},
+{
+glyphname = "naai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (184,-179);
+ref = ring_top.canadian;
+}
+);
+width = 798;
+}
+);
+note = uni14C1;
+unicode = 5313;
+},
+{
+glyphname = "ni-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (296,245);
+},
+{
+name = top_center_can;
+pos = (315,511);
+},
+{
+name = top_left_can;
+pos = (121,511);
+},
+{
+name = top_right_can;
+pos = (678,511);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(448,-14,o),
+(546,79,o),
+(546,233,cs),
+(546,291,o),
+(528,350,o),
+(496,386,c),
+(472,350,l),
+(758,350,l),
+(758,492,l),
+(316,492,ls),
+(140,492,o),
+(42,390,o),
+(42,236,cs),
+(42,82,o),
+(144,-14,o),
+(295,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(233,121,o),
+(199,167,o),
+(199,240,cs),
+(199,311,o),
+(233,357,o),
+(295,357,cs),
+(355,357,o),
+(389,310,o),
+(389,240,cs),
+(389,168,o),
+(355,121,o),
+(295,121,cs)
+);
+}
+);
+width = 799;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+unicode = 5314;
+},
+{
+glyphname = "nii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (221,-179);
+ref = dot_top;
+}
+);
+width = 798;
+}
+);
+note = uni14C3;
+unicode = 5315;
+},
+{
+glyphname = "no-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (503,245);
+},
+{
+name = top_center_can;
+pos = (503,511);
+},
+{
+name = top_double;
+pos = (504,511);
+},
+{
+name = top_left_can;
+pos = (120,511);
+},
+{
+name = top_right_can;
+pos = (679,511);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(491,0,ls),
+(658,0,o),
+(757,94,o),
+(757,252,cs),
+(757,409,o),
+(656,506,o),
+(504,506,cs),
+(351,506,o),
+(252,411,o),
+(252,260,cs),
+(252,203,o),
+(270,144,o),
+(304,107,c),
+(326,142,l),
+(41,142,l),
+(41,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(442,134,o),
+(410,182,o),
+(410,253,cs),
+(410,325,o),
+(442,371,o),
+(504,371,cs),
+(565,371,o),
+(600,325,o),
+(600,253,cs),
+(600,181,o),
+(565,134,o),
+(503,134,cs)
+);
+}
+);
+width = 799;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14C4;
+unicode = 5316;
+},
+{
+glyphname = "noo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (409,-179);
+ref = dot_top;
+}
+);
+width = 798;
+}
+);
+note = uni14C5;
+unicode = 5317;
+},
+{
+glyphname = "ycreenoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (226,-179);
+ref = doubledot_top;
+}
+);
+width = 798;
+}
+);
+note = uni14C6;
+unicode = 5318;
+},
+{
+glyphname = "na-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (296,245);
+},
+{
+name = top_center_can;
+pos = (296,511);
+},
+{
+name = top_double;
+pos = (474,511);
+},
+{
+name = top_left_can;
+pos = (121,511);
+},
+{
+name = top_right_can;
+pos = (678,511);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(758,0,l),
+(758,143,l),
+(472,143,l),
+(495,105,l),
+(528,142,o),
+(546,202,o),
+(546,259,cs),
+(546,412,o),
+(448,506,o),
+(295,506,cs),
+(144,506,o),
+(42,409,o),
+(42,252,cs),
+(42,98,o),
+(139,0,o),
+(310,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(233,134,o),
+(199,181,o),
+(199,253,cs),
+(199,325,o),
+(233,371,o),
+(295,371,cs),
+(355,371,o),
+(389,325,o),
+(389,253,cs),
+(389,182,o),
+(355,134,o),
+(295,134,cs)
+);
+}
+);
+width = 799;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+unicode = 5319;
+},
+{
+glyphname = "naa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (201,-179);
+ref = dot_top;
+}
+);
+width = 798;
+}
+);
+note = uni14C8;
+unicode = 5320;
+},
+{
+glyphname = "nwe-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ne-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni14C9;
+unicode = 5321;
+},
+{
+glyphname = "nweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (798,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni14CA;
+unicode = 5322;
+},
+{
+glyphname = "nwa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "na-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni14CB;
+unicode = 5323;
+},
+{
+glyphname = "nwaWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (798,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni14CC;
+unicode = 5324;
+},
+{
+glyphname = "nwaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (438,-179);
+ref = dot_top;
+}
+);
+width = 1035;
+}
+);
+note = uni14CD;
+unicode = 5325;
+},
+{
+glyphname = "nwaaWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (201,-179);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (798,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni14CE;
+unicode = 5326;
+},
+{
+glyphname = "nwaaNaskapi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (196,-179);
+ref = doubledot_top;
+}
+);
+width = 798;
+}
+);
+note = uni14CF;
+unicode = 5327;
+},
+{
+glyphname = "n-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(433,435,l),
+(433,536,l),
+(276,536,l),
+(281,489,l),
+(301,499,o),
+(320,531,o),
+(320,571,cs),
+(320,647,o),
+(269,696,o),
+(183,696,cs),
+(99,696,o),
+(44,645,o),
+(44,565,cs),
+(44,488,o),
+(97,435,o),
+(187,435,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(158,513,o),
+(141,530,o),
+(141,565,cs),
+(141,601,o),
+(158,619,o),
+(183,619,cs),
+(207,619,o),
+(223,601,o),
+(223,565,cs),
+(223,531,o),
+(207,513,o),
+(183,513,cs)
+);
+}
+);
+width = 473;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni14D0;
+unicode = 5328;
+},
+{
+color = 6;
+glyphname = "ngCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-161);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 429;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "=|";
+note = uni14D1;
+unicode = 5329;
+},
+{
+glyphname = "nh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(285,435,ls),
+(376,435,o),
+(428,488,o),
+(428,565,cs),
+(428,645,o),
+(374,696,o),
+(290,696,cs),
+(204,696,o),
+(153,647,o),
+(153,571,cs),
+(153,531,o),
+(171,499,o),
+(191,489,c),
+(196,536,l),
+(40,536,l),
+(40,435,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(266,513,o),
+(249,531,o),
+(249,565,cs),
+(249,601,o),
+(266,619,o),
+(290,619,cs),
+(314,619,o),
+(331,601,o),
+(331,565,cs),
+(331,530,o),
+(314,513,o),
+(290,513,cs)
+);
+}
+);
+width = 472;
+}
+);
+metricLeft = "=|n-canadian";
+metricRight = "=|n-canadian";
+note = uni14D2;
+unicode = 5330;
+},
+{
+glyphname = "le-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (503,245);
+},
+{
+name = top_center_can;
+pos = (488,511);
+},
+{
+name = top_left_can;
+pos = (120,511);
+},
+{
+name = top_right_can;
+pos = (678,511);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(487,0,ls),
+(651,0,o),
+(757,90,o),
+(757,246,cs),
+(757,402,o),
+(660,492,o),
+(487,492,cs),
+(41,492,l),
+(41,349,l),
+(484,349,ls),
+(555,349,o),
+(598,313,o),
+(598,244,cs),
+(598,176,o),
+(554,140,o),
+(478,140,cs),
+(427,140,l),
+(427,0,l)
+);
+}
+);
+width = 799;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D3;
+unicode = 5331;
+},
+{
+glyphname = "laai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (184,-179);
+ref = ring_top.canadian;
+}
+);
+width = 798;
+}
+);
+note = uni14D4;
+unicode = 5332;
+},
+{
+glyphname = "li-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (296,245);
+},
+{
+name = top_center_can;
+pos = (315,511);
+},
+{
+name = top_left_can;
+pos = (121,511);
+},
+{
+name = top_right_can;
+pos = (678,511);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(372,0,l),
+(372,140,l),
+(319,140,ls),
+(242,140,o),
+(200,176,o),
+(200,243,cs),
+(200,310,o),
+(240,349,o),
+(316,349,cs),
+(758,349,l),
+(758,492,l),
+(311,492,ls),
+(146,492,o),
+(42,400,o),
+(42,244,cs),
+(42,90,o),
+(146,0,o),
+(312,0,cs)
+);
+}
+);
+width = 799;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14D5;
+unicode = 5333;
+},
+{
+glyphname = "lii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (221,-179);
+ref = dot_top;
+}
+);
+width = 798;
+}
+);
+note = uni14D6;
+unicode = 5334;
+},
+{
+glyphname = "lo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (503,245);
+},
+{
+name = top_center_can;
+pos = (503,511);
+},
+{
+name = top_double;
+pos = (491,511);
+},
+{
+name = top_left_can;
+pos = (120,511);
+},
+{
+name = top_right_can;
+pos = (678,511);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(485,0,ls),
+(654,0,o),
+(757,90,o),
+(757,246,cs),
+(757,404,o),
+(651,492,o),
+(491,492,cs),
+(427,492,l),
+(427,353,l),
+(480,353,ls),
+(558,353,o),
+(598,317,o),
+(598,248,cs),
+(598,180,o),
+(557,143,o),
+(484,143,cs),
+(41,143,l),
+(41,0,l)
+);
+}
+);
+width = 799;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D7;
+unicode = 5335;
+},
+{
+glyphname = "loo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (409,-179);
+ref = dot_top;
+}
+);
+width = 798;
+}
+);
+note = uni14D8;
+unicode = 5336;
+},
+{
+glyphname = "ycreeloo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (213,-179);
+ref = doubledot_top;
+}
+);
+width = 798;
+}
+);
+note = uni14D9;
+unicode = 5337;
+},
+{
+glyphname = "la-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (296,245);
+},
+{
+name = top_center_can;
+pos = (296,511);
+},
+{
+name = top_left_can;
+pos = (121,511);
+},
+{
+name = top_right_can;
+pos = (678,511);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(758,0,l),
+(758,143,l),
+(316,143,ls),
+(239,143,o),
+(200,180,o),
+(200,247,cs),
+(200,316,o),
+(242,353,o),
+(315,353,cs),
+(372,353,l),
+(372,492,l),
+(309,492,ls),
+(145,492,o),
+(42,399,o),
+(42,245,cs),
+(42,89,o),
+(145,0,o),
+(311,0,cs)
+);
+}
+);
+width = 799;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14DA;
+unicode = 5338;
+},
+{
+glyphname = "laa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (201,-179);
+ref = dot_top;
+}
+);
+width = 798;
+}
+);
+note = uni14DB;
+unicode = 5339;
+},
+{
+glyphname = "lwe-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "le-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni14DC;
+unicode = 5340;
+},
+{
+glyphname = "lweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "le-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (798,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni14DD;
+unicode = 5341;
+},
+{
+glyphname = "lwi-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "li-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni14DE;
+unicode = 5342;
+},
+{
+glyphname = "lwiWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (798,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni14DF;
+unicode = 5343;
+},
+{
+glyphname = "lwii-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (458,-179);
+ref = dot_top;
+}
+);
+width = 1035;
+}
+);
+note = uni14E0;
+unicode = 5344;
+},
+{
+glyphname = "lwiiWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (221,-179);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (798,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni14E1;
+unicode = 5345;
+},
+{
+glyphname = "lwo-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "lo-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni14E2;
+unicode = 5346;
+},
+{
+glyphname = "lwoWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (798,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni14E3;
+unicode = 5347;
+},
+{
+glyphname = "lwoo-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (645,-179);
+ref = dot_top;
+}
+);
+width = 1035;
+}
+);
+note = uni14E4;
+unicode = 5348;
+},
+{
+glyphname = "lwooWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (409,-179);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (798,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni14E5;
+unicode = 5349;
+},
+{
+glyphname = "lwa-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "la-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni14E6;
+unicode = 5350;
+},
+{
+glyphname = "lwaWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (798,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni14E7;
+unicode = 5351;
+},
+{
+glyphname = "lwaa-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (438,-179);
+ref = dot_top;
+}
+);
+width = 1035;
+}
+);
+note = uni14E8;
+unicode = 5352;
+},
+{
+glyphname = "lwaaWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (201,-179);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (798,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni14E9;
+unicode = 5353;
+},
+{
+glyphname = "l-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(417,345,l),
+(417,446,l),
+(236,446,ls),
+(184,446,o),
+(156,469,o),
+(156,518,cs),
+(156,565,o),
+(184,592,o),
+(235,592,cs),
+(249,592,l),
+(249,690,l),
+(226,690,ls),
+(114,690,o),
+(46,623,o),
+(46,517,cs),
+(46,411,o),
+(114,345,o),
+(226,345,cs)
+);
+}
+);
+width = 458;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "m-canadian";
+note = uni14EA;
+unicode = 5354;
+},
+{
+glyphname = "lWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(294,345,l),
+(294,415,l),
+(139,482,l),
+(139,430,l),
+(294,496,l),
+(294,539,l),
+(139,607,l),
+(139,552,l),
+(294,618,l),
+(294,690,l),
+(276,690,l),
+(53,597,l),
+(53,564,l),
+(213,497,l),
+(213,536,l),
+(53,470,l),
+(53,438,l),
+(276,345,l)
+);
+}
+);
+width = 347;
+}
+);
+metricRight = "=|";
+note = uni14EB;
+unicode = 5355;
+},
+{
+glyphname = "mediall-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(556,-14,l),
+(556,103,l),
+(219,244,l),
+(219,174,l),
+(556,314,l),
+(556,376,l),
+(219,516,l),
+(219,444,l),
+(556,586,l),
+(556,704,l),
+(519,704,l),
+(55,511,l),
+(55,456,l),
+(393,317,l),
+(393,373,l),
+(55,234,l),
+(55,179,l),
+(519,-14,l)
+);
+}
+);
+width = 611;
+}
+);
+metricRight = "=|";
+note = uni14EC;
+unicode = 5356;
+},
+{
+glyphname = "se-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (143,690);
+},
+{
+name = top_right_can;
+pos = (415,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(495,0,l),
+(495,366,l),
+(453,366,ls),
+(298,366,o),
+(222,428,o),
+(222,603,cs),
+(222,690,l),
+(62,690,l),
+(62,588,ls),
+(62,350,o),
+(194,224,o),
+(419,224,cs),
+(456,224,l),
+(334,277,l),
+(334,0,l)
+);
+}
+);
+width = 557;
+}
+);
+note = uni14ED;
+unicode = 5357;
+},
+{
+glyphname = "saai-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (283,0);
+ref = ring_top.canadian;
+}
+);
+width = 557;
+}
+);
+note = uni14EE;
+unicode = 5358;
+},
+{
+glyphname = "si-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (142,690);
+},
+{
+name = top_right_can;
+pos = (414,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(222,0,l),
+(222,277,l),
+(100,224,l),
+(137,224,ls),
+(362,224,o),
+(494,350,o),
+(494,588,cs),
+(494,690,l),
+(333,690,l),
+(333,603,ls),
+(333,428,o),
+(259,366,o),
+(103,366,cs),
+(62,366,l),
+(62,0,l)
+);
+}
+);
+width = 556;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+unicode = 5359;
+},
+{
+glyphname = "sii-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (321,0);
+ref = dot_top;
+}
+);
+width = 557;
+}
+);
+note = uni14F0;
+unicode = 5360;
+},
+{
+glyphname = "so-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (414,690);
+},
+{
+name = top_left_can;
+pos = (143,690);
+},
+{
+name = top_right_can;
+pos = (414,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(222,0,l),
+(222,87,ls),
+(222,262,o),
+(298,324,o),
+(453,324,cs),
+(495,324,l),
+(495,690,l),
+(334,690,l),
+(334,412,l),
+(456,466,l),
+(419,466,ls),
+(194,466,o),
+(62,340,o),
+(62,101,cs),
+(62,0,l)
+);
+}
+);
+width = 557;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+unicode = 5361;
+},
+{
+glyphname = "soo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (321,0);
+ref = dot_top;
+}
+);
+width = 557;
+}
+);
+note = uni14F2;
+unicode = 5362;
+},
+{
+glyphname = "ycreesoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (136,0);
+ref = doubledot_top;
+}
+);
+width = 557;
+}
+);
+note = uni14F3;
+unicode = 5363;
+},
+{
+glyphname = "sa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (142,690);
+},
+{
+name = top_right_can;
+pos = (414,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(494,0,l),
+(494,101,ls),
+(494,340,o),
+(362,466,o),
+(137,466,cs),
+(100,466,l),
+(222,412,l),
+(222,690,l),
+(62,690,l),
+(62,324,l),
+(103,324,ls),
+(259,324,o),
+(333,262,o),
+(333,87,cs),
+(333,0,l)
+);
+}
+);
+width = 556;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+unicode = 5364;
+},
+{
+glyphname = "saa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+}
+);
+width = 557;
+}
+);
+note = uni14F5;
+unicode = 5365;
+},
+{
+glyphname = "swe-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "se-canadian";
+}
+);
+width = 793;
+}
+);
+note = uni14F6;
+unicode = 5366;
+},
+{
+glyphname = "sweWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "se-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (557,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 793;
+}
+);
+note = uni14F7;
+unicode = 5367;
+},
+{
+glyphname = "swi-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "si-canadian";
+}
+);
+width = 793;
+}
+);
+note = uni14F8;
+unicode = 5368;
+},
+{
+glyphname = "swiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (557,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 793;
+}
+);
+note = uni14F9;
+unicode = 5369;
+},
+{
+glyphname = "swii-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (557,0);
+ref = dot_top;
+}
+);
+width = 793;
+}
+);
+note = uni14FA;
+unicode = 5370;
+},
+{
+glyphname = "swiiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (321,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (557,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 793;
+}
+);
+note = uni14FB;
+unicode = 5371;
+},
+{
+glyphname = "swo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "so-canadian";
+}
+);
+width = 793;
+}
+);
+note = uni14FC;
+unicode = 5372;
+},
+{
+glyphname = "swoWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (557,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 793;
+}
+);
+note = uni14FD;
+unicode = 5373;
+},
+{
+glyphname = "swoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (557,0);
+ref = dot_top;
+}
+);
+width = 793;
+}
+);
+note = uni14FE;
+unicode = 5374;
+},
+{
+glyphname = "swooWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (321,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (557,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 793;
+}
+);
+note = uni14FF;
+unicode = 5375;
+},
+{
+glyphname = "swa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "sa-canadian";
+}
+);
+width = 793;
+}
+);
+note = uni1500;
+unicode = 5376;
+},
+{
+glyphname = "swaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (557,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 793;
+}
+);
+note = uni1501;
+unicode = 5377;
+},
+{
+glyphname = "swaa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (286,0);
+ref = dot_top;
+}
+);
+width = 793;
+}
+);
+note = uni1502;
+unicode = 5378;
+},
+{
+glyphname = "swaaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (557,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 793;
+}
+);
+note = uni1503;
+unicode = 5379;
+},
+{
+glyphname = "swaaNaskapi-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "sa-canadian";
+}
+);
+width = 793;
+}
+);
+note = uni1504;
+unicode = 5380;
+},
+{
+glyphname = "s-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(309,345,l),
+(309,401,ls),
+(309,521,o),
+(241,593,o),
+(134,593,cs),
+(90,593,l),
+(162,551,l),
+(162,690,l),
+(53,690,l),
+(53,507,l),
+(90,507,ls),
+(164,507,o),
+(200,474,o),
+(200,397,cs),
+(200,345,l)
+);
+}
+);
+width = 362;
+}
+);
+metricRight = "=|";
+note = uni1505;
+unicode = 5381;
+},
+{
+color = 6;
+glyphname = "sAthapascan-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(277,177,o),
+(329,222,o),
+(329,282,cs),
+(329,326,o),
+(305,360,o),
+(251,378,cs),
+(179,401,ls),
+(159,409,o),
+(153,415,o),
+(153,429,cs),
+(153,445,o),
+(164,457,o),
+(190,457,cs),
+(217,457,o),
+(233,447,o),
+(234,415,c),
+(327,415,l),
+(327,492,o),
+(274,533,o),
+(192,533,cs),
+(112,533,o),
+(58,491,o),
+(58,428,cs),
+(58,384,o),
+(84,347,o),
+(134,330,cs),
+(207,307,ls),
+(227,300,o),
+(235,293,o),
+(235,279,cs),
+(235,262,o),
+(220,253,o),
+(196,253,cs),
+(165,253,o),
+(150,265,o),
+(148,295,c),
+(53,295,l),
+(55,218,o),
+(107,177,o),
+(194,177,cs)
+);
+}
+);
+width = 382;
+}
+);
+metricRight = "=|";
+note = uni1506;
+unicode = 5382;
+},
+{
+glyphname = "sw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(162,345,l),
+(162,397,ls),
+(162,474,o),
+(198,507,o),
+(272,507,cs),
+(309,507,l),
+(309,690,l),
+(200,690,l),
+(200,551,l),
+(272,593,l),
+(228,593,ls),
+(123,593,o),
+(53,521,o),
+(53,401,cs),
+(53,345,l)
+);
+}
+);
+width = 362;
+}
+);
+metricLeft = "=|s-canadian";
+metricRight = "=|s-canadian";
+note = uni1507;
+unicode = 5383;
+},
+{
+glyphname = "sBlackfoot-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(313,345,l),
+(313,446,l),
+(226,446,ls),
+(184,446,o),
+(162,467,o),
+(162,510,cs),
+(162,690,l),
+(53,690,l),
+(53,495,ls),
+(53,399,o),
+(108,345,o),
+(205,345,c)
+);
+}
+);
+width = 354;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "m-canadian";
+note = uni1508;
+unicode = 5384;
+},
+{
+glyphname = "moosecreesk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(271,217,o),
+(332,270,o),
+(332,379,cs),
+(332,513,o),
+(264,592,o),
+(140,592,cs),
+(110,592,l),
+(166,550,l),
+(166,690,l),
+(57,690,l),
+(57,508,l),
+(104,508,ls),
+(194,508,o),
+(219,482,o),
+(227,434,c),
+(254,432,l),
+(246,454,o),
+(220,476,o),
+(183,476,cs),
+(106,476,o),
+(54,424,o),
+(54,349,cs),
+(54,265,o),
+(115,217,o),
+(189,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(168,295,o),
+(150,312,o),
+(150,348,cs),
+(150,384,o),
+(168,402,o),
+(192,402,cs),
+(215,402,o),
+(233,384,o),
+(233,348,cs),
+(233,312,o),
+(216,295,o),
+(192,295,cs)
+);
+}
+);
+width = 386;
+}
+);
+metricRight = "=|";
+note = uni1509;
+unicode = 5385;
+},
+{
+glyphname = "skwNaskapi-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(271,217,o),
+(332,265,o),
+(332,349,cs),
+(332,424,o),
+(280,476,o),
+(204,476,cs),
+(166,476,o),
+(141,454,o),
+(132,432,c),
+(159,434,l),
+(167,482,o),
+(192,508,o),
+(282,508,cs),
+(329,508,l),
+(329,690,l),
+(220,690,l),
+(220,550,l),
+(276,592,l),
+(246,592,ls),
+(123,592,o),
+(54,513,o),
+(54,379,cs),
+(54,270,o),
+(115,217,o),
+(197,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(170,295,o),
+(154,312,o),
+(154,348,cs),
+(154,384,o),
+(171,402,o),
+(194,402,cs),
+(218,402,o),
+(237,384,o),
+(237,348,cs),
+(237,312,o),
+(218,295,o),
+(194,295,cs)
+);
+}
+);
+width = 386;
+}
+);
+metricLeft = "=|moosecreesk-canadian";
+metricRight = "=|moosecreesk-canadian";
+note = uni150A;
+unicode = 5386;
+},
+{
+glyphname = "swNaskapi-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(327,191,l),
+(327,238,ls),
+(327,346,o),
+(260,416,o),
+(154,416,cs),
+(120,416,l),
+(172,375,l),
+(172,499,l),
+(63,499,l),
+(63,333,l),
+(110,333,ls),
+(184,333,o),
+(218,305,o),
+(218,233,cs),
+(218,191,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(314,2,o),
+(348,36,o),
+(348,76,cs),
+(348,118,o),
+(314,152,o),
+(273,152,cs),
+(232,152,o),
+(199,118,o),
+(199,76,cs),
+(199,36,o),
+(232,2,o),
+(273,2,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(158,538,o),
+(192,572,o),
+(192,613,cs),
+(192,654,o),
+(158,688,o),
+(118,688,cs),
+(76,688,o),
+(43,654,o),
+(43,613,cs),
+(43,572,o),
+(76,538,o),
+(118,538,cs)
+);
+}
+);
+width = 391;
+}
+);
+metricRight = "=|";
+note = uni150B;
+unicode = 5387;
+},
+{
+glyphname = "spwaNaskapi-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(604,0,l),
+(604,152,l),
+(215,380,l),
+(215,308,l),
+(604,537,l),
+(604,690,l),
+(565,690,l),
+(28,369,l),
+(28,321,l),
+(565,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(154,497,o),
+(187,530,o),
+(187,572,cs),
+(187,613,o),
+(154,647,o),
+(113,647,cs),
+(72,647,o),
+(40,613,o),
+(40,572,cs),
+(40,530,o),
+(72,497,o),
+(113,497,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(365,614,l),
+(365,661,ls),
+(365,751,o),
+(314,806,o),
+(227,806,cs),
+(199,806,l),
+(266,770,l),
+(266,875,l),
+(159,875,l),
+(159,727,l),
+(185,727,ls),
+(231,727,o),
+(259,703,o),
+(259,652,cs),
+(259,614,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(525,715,o),
+(557,749,o),
+(557,790,cs),
+(557,831,o),
+(525,865,o),
+(483,865,cs),
+(442,865,o),
+(410,831,o),
+(410,790,cs),
+(410,749,o),
+(442,715,o),
+(483,715,cs)
+);
+}
+);
+width = 646;
+}
+);
+metricRight = "pa-canadian";
+metricWidth = "pa-canadian";
+note = uni150C;
+unicode = 5388;
+},
+{
+glyphname = "stwaNaskapi-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (390,0);
+ref = "ta-canadian";
+}
+);
+width = 1009;
+}
+);
+note = uni150D;
+unicode = 5389;
+},
+{
+glyphname = "skwaNaskapi-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (390,0);
+ref = "ka-canadian";
+}
+);
+width = 984;
+}
+);
+note = uni150E;
+unicode = 5390;
+},
+{
+glyphname = "scwaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (390,0);
+ref = "ca-canadian";
+}
+);
+width = 977;
+}
+);
+note = uni150F;
+unicode = 5391;
+},
+{
+glyphname = "she-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (284,690);
+},
+{
+name = top_right_can;
+pos = (732,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(748,-14,o),
+(837,82,o),
+(837,252,cs),
+(837,310,l),
+(677,310,l),
+(677,240,ls),
+(677,161,o),
+(650,125,o),
+(602,125,cs),
+(550,125,o),
+(526,162,o),
+(522,242,cs),
+(512,449,ls),
+(503,611,o),
+(431,704,o),
+(284,704,cs),
+(132,704,o),
+(40,608,o),
+(40,438,cs),
+(40,380,l),
+(199,380,l),
+(199,453,ls),
+(199,527,o),
+(227,565,o),
+(276,565,cs),
+(326,565,o),
+(351,528,o),
+(355,452,cs),
+(364,241,ls),
+(372,80,o),
+(442,-14,o),
+(597,-14,cs)
+);
+}
+);
+width = 877;
+}
+);
+metricRight = "=|";
+note = uni1510;
+unicode = 5392;
+},
+{
+glyphname = "shi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (146,690);
+},
+{
+name = top_right_can;
+pos = (592,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(434,-14,o),
+(504,80,o),
+(512,241,cs),
+(522,452,ls),
+(526,528,o),
+(551,565,o),
+(600,565,cs),
+(649,565,o),
+(677,527,o),
+(677,453,cs),
+(677,380,l),
+(837,380,l),
+(837,438,ls),
+(837,608,o),
+(744,704,o),
+(592,704,cs),
+(445,704,o),
+(373,611,o),
+(364,449,cs),
+(355,242,ls),
+(350,162,o),
+(327,125,o),
+(274,125,cs),
+(226,125,o),
+(199,161,o),
+(199,240,cs),
+(199,310,l),
+(40,310,l),
+(40,252,ls),
+(40,82,o),
+(129,-14,o),
+(279,-14,cs)
+);
+}
+);
+width = 877;
+}
+);
+metricLeft = "she-canadian";
+metricRight = "she-canadian";
+note = uni1511;
+unicode = 5393;
+},
+{
+glyphname = "shii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (498,0);
+ref = dot_top;
+}
+);
+width = 876;
+}
+);
+note = uni1512;
+unicode = 5394;
+},
+{
+glyphname = "sho-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (449,511);
+},
+{
+name = top_left_can;
+pos = (279,511);
+},
+{
+name = top_right_can;
+pos = (619,511);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(358,120,l),
+(254,119,o),
+(199,145,o),
+(199,197,cs),
+(199,231,o),
+(221,250,o),
+(263,250,cs),
+(369,250,o),
+(485,102,o),
+(652,102,cs),
+(775,102,o),
+(857,176,o),
+(857,288,cs),
+(857,425,o),
+(740,507,o),
+(545,506,c),
+(540,372,l),
+(644,373,o),
+(699,347,o),
+(699,296,cs),
+(699,262,o),
+(677,242,o),
+(636,242,cs),
+(529,242,o),
+(413,389,o),
+(245,389,cs),
+(124,389,o),
+(42,316,o),
+(42,204,cs),
+(42,67,o),
+(159,-15,o),
+(354,-14,c)
+);
+}
+);
+width = 899;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1513;
+unicode = 5395;
+},
+{
+glyphname = "shoo-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (355,-179);
+ref = dot_top;
+}
+);
+width = 898;
+}
+);
+note = uni1514;
+unicode = 5396;
+},
+{
+glyphname = "sha-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (449,511);
+},
+{
+name = top_left_can;
+pos = (279,511);
+},
+{
+name = top_right_can;
+pos = (619,511);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(740,-17,o),
+(857,67,o),
+(857,203,cs),
+(857,316,o),
+(779,389,o),
+(652,389,cs),
+(485,389,o),
+(369,242,o),
+(263,242,cs),
+(221,242,o),
+(199,262,o),
+(199,296,cs),
+(199,347,o),
+(254,375,o),
+(358,372,c),
+(354,506,l),
+(159,510,o),
+(42,425,o),
+(42,290,cs),
+(42,176,o),
+(120,102,o),
+(245,102,cs),
+(413,102,o),
+(529,250,o),
+(636,250,cs),
+(677,250,o),
+(699,231,o),
+(699,197,cs),
+(699,145,o),
+(644,117,o),
+(540,120,c),
+(545,-14,l)
+);
+}
+);
+width = 899;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1515;
+unicode = 5397;
+},
+{
+glyphname = "shaa-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (355,-179);
+ref = dot_top;
+}
+);
+width = 898;
+}
+);
+note = uni1516;
+unicode = 5398;
+},
+{
+glyphname = "shwe-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "she-canadian";
+}
+);
+width = 1113;
+}
+);
+note = uni1517;
+unicode = 5399;
+},
+{
+glyphname = "shweWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "she-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (876,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1113;
+}
+);
+note = uni1518;
+unicode = 5400;
+},
+{
+glyphname = "shwi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "shi-canadian";
+}
+);
+width = 1113;
+}
+);
+note = uni1519;
+unicode = 5401;
+},
+{
+glyphname = "shwiWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (876,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1113;
+}
+);
+note = uni151A;
+unicode = 5402;
+},
+{
+glyphname = "shwii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (735,0);
+ref = dot_top;
+}
+);
+width = 1113;
+}
+);
+note = uni151B;
+unicode = 5403;
+},
+{
+glyphname = "shwiiWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (498,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (876,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1113;
+}
+);
+note = uni151C;
+unicode = 5404;
+},
+{
+glyphname = "shwo-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "sho-canadian";
+}
+);
+width = 1135;
+}
+);
+note = uni151D;
+unicode = 5405;
+},
+{
+glyphname = "shwoWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (898,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1135;
+}
+);
+note = uni151E;
+unicode = 5406;
+},
+{
+glyphname = "shwoo-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (591,-179);
+ref = dot_top;
+}
+);
+width = 1135;
+}
+);
+note = uni151F;
+unicode = 5407;
+},
+{
+glyphname = "shwooWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (355,-179);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (898,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1135;
+}
+);
+note = uni1520;
+unicode = 5408;
+},
+{
+glyphname = "shwa-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "sha-canadian";
+}
+);
+width = 1135;
+}
+);
+note = uni1521;
+unicode = 5409;
+},
+{
+glyphname = "shwaWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (898,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1135;
+}
+);
+note = uni1522;
+unicode = 5410;
+},
+{
+glyphname = "shwaa-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (591,-179);
+ref = dot_top;
+}
+);
+width = 1135;
+}
+);
+note = uni1523;
+unicode = 5411;
+},
+{
+glyphname = "shwaaWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (355,-179);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (898,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1135;
+}
+);
+note = uni1524;
+unicode = 5412;
+},
+{
+glyphname = "sh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(563,284,o),
+(658,343,o),
+(658,449,cs),
+(658,534,o),
+(599,596,o),
+(501,596,cs),
+(378,596,o),
+(293,492,o),
+(213,492,cs),
+(177,492,o),
+(159,509,o),
+(159,537,cs),
+(159,579,o),
+(203,602,o),
+(285,602,c),
+(281,699,l),
+(142,699,o),
+(46,640,o),
+(46,534,cs),
+(46,449,o),
+(105,387,o),
+(203,387,cs),
+(327,387,o),
+(412,492,o),
+(492,492,cs),
+(527,492,o),
+(546,474,o),
+(546,446,cs),
+(546,405,o),
+(501,382,o),
+(419,382,c),
+(424,284,l)
+);
+}
+);
+width = 704;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni1525;
+unicode = 5413;
+},
+{
+glyphname = "ye-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (661,345);
+},
+{
+name = top_left_can;
+pos = (108,690);
+},
+{
+name = top_right_can;
+pos = (439,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(518,0,l),
+(518,353,l),
+(234,353,l),
+(238,276,l),
+(539,607,l),
+(431,701,l),
+(29,253,l),
+(29,213,l),
+(357,213,l),
+(357,0,l)
+);
+}
+);
+width = 580;
+}
+);
+note = uni1526;
+unicode = 5414;
+},
+{
+glyphname = "yaai-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (11,0);
+ref = ring_top.canadian;
+}
+);
+width = 580;
+}
+);
+note = uni1527;
+unicode = 5415;
+},
+{
+glyphname = "yi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (143,690);
+},
+{
+name = top_right_can;
+pos = (471,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(223,0,l),
+(223,213,l),
+(551,213,l),
+(551,253,l),
+(150,701,l),
+(43,608,l),
+(344,277,l),
+(348,353,l),
+(63,353,l),
+(63,0,l)
+);
+}
+);
+width = 580;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni1528;
+unicode = 5416;
+},
+{
+glyphname = "yii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (48,0);
+ref = dot_top;
+}
+);
+width = 580;
+}
+);
+note = uni1529;
+unicode = 5417;
+},
+{
+glyphname = "yo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (661,345);
+},
+{
+name = top_double;
+pos = (438,690);
+},
+{
+name = top_left_can;
+pos = (108,690);
+},
+{
+name = top_right_can;
+pos = (438,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(537,82,l),
+(237,412,l),
+(232,337,l),
+(518,337,l),
+(518,690,l),
+(357,690,l),
+(357,476,l),
+(29,476,l),
+(29,437,l),
+(431,-12,l)
+);
+}
+);
+width = 580;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152A;
+unicode = 5418;
+},
+{
+glyphname = "yoo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (344,0);
+ref = dot_top;
+}
+);
+width = 580;
+}
+);
+note = uni152B;
+unicode = 5419;
+},
+{
+glyphname = "ycreeyoo-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (159,0);
+ref = doubledot_top;
+}
+);
+width = 580;
+}
+);
+note = uni152C;
+unicode = 5420;
+},
+{
+glyphname = "ya-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (143,690);
+},
+{
+name = top_right_can;
+pos = (471,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(551,437,l),
+(551,476,l),
+(223,476,l),
+(223,690,l),
+(63,690,l),
+(63,337,l),
+(346,337,l),
+(342,413,l),
+(42,83,l),
+(150,-12,l)
+);
+}
+);
+width = 580;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152D;
+unicode = 5421;
+},
+{
+glyphname = "yaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+}
+);
+width = 580;
+}
+);
+note = uni152E;
+unicode = 5422;
+},
+{
+glyphname = "ywe-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ye-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni152F;
+unicode = 5423;
+},
+{
+glyphname = "yweWestCree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ye-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (580,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni1530;
+unicode = 5424;
+},
+{
+glyphname = "ywi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "yi-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni1531;
+unicode = 5425;
+},
+{
+glyphname = "ywiWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (580,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni1532;
+unicode = 5426;
+},
+{
+glyphname = "ywii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (285,0);
+ref = dot_top;
+}
+);
+width = 816;
+}
+);
+note = uni1533;
+unicode = 5427;
+},
+{
+glyphname = "ywiiWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (48,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (580,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni1534;
+unicode = 5428;
+},
+{
+glyphname = "ywo-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "yo-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni1535;
+unicode = 5429;
+},
+{
+glyphname = "ywoWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (580,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni1536;
+unicode = 5430;
+},
+{
+glyphname = "ywoo-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (581,0);
+ref = dot_top;
+}
+);
+width = 816;
+}
+);
+note = uni1537;
+unicode = 5431;
+},
+{
+glyphname = "ywooWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (344,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (580,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni1538;
+unicode = 5432;
+},
+{
+glyphname = "ywa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ya-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni1539;
+unicode = 5433;
+},
+{
+glyphname = "ywaWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (580,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni153A;
+unicode = 5434;
+},
+{
+glyphname = "ywaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (286,0);
+ref = dot_top;
+}
+);
+width = 816;
+}
+);
+note = uni153B;
+unicode = 5435;
+},
+{
+glyphname = "ywaaWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (580,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni153C;
+unicode = 5436;
+},
+{
+glyphname = "ywaaNaskapi-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ya-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni153D;
+unicode = 5437;
+},
+{
+glyphname = "y-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(317,555,l),
+(317,582,l),
+(164,582,l),
+(164,690,l),
+(55,690,l),
+(55,497,l),
+(201,497,l),
+(200,562,l),
+(53,393,l),
+(128,335,l)
+);
+}
+);
+width = 339;
+}
+);
+note = uni153E;
+unicode = 5438;
+},
+{
+glyphname = "biblecreey-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(201,582,l),
+(140,582,l),
+(230,345,l),
+(298,345,l),
+(388,582,l),
+(327,582,l),
+(387,345,l),
+(484,345,l),
+(484,370,l),
+(405,690,l),
+(331,690,l),
+(236,439,l),
+(292,439,l),
+(196,690,l),
+(123,690,l),
+(44,370,l),
+(44,345,l),
+(141,345,l)
+);
+}
+);
+width = 528;
+}
+);
+metricRight = "=|";
+note = uni153F;
+unicode = 5439;
+},
+{
+glyphname = "yWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(270,191,l),
+(270,304,l),
+(378,304,l),
+(378,408,l),
+(270,408,l),
+(270,517,l),
+(162,517,l),
+(162,408,l),
+(53,408,l),
+(53,304,l),
+(162,304,l),
+(162,191,l)
+);
+}
+);
+width = 431;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1540;
+unicode = 5440;
+},
+{
+glyphname = "yiSayisi-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,183);
+ref = "fullstop-canadian";
+}
+);
+width = 378;
+}
+);
+metricLeft = "fullstop-canadian";
+metricWidth = "fullstop-canadian";
+note = uni1541;
+unicode = 5441;
+},
+{
+glyphname = "re-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (309,511);
+},
+{
+name = top_left_can;
+pos = (139,511);
+},
+{
+name = top_right_can;
+pos = (727,511);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(465,-14,o),
+(556,86,o),
+(556,241,cs),
+(556,350,l),
+(807,350,l),
+(807,492,l),
+(400,492,l),
+(400,241,ls),
+(400,163,o),
+(367,124,o),
+(309,124,cs),
+(251,124,o),
+(219,164,o),
+(219,241,cs),
+(219,492,l),
+(59,492,l),
+(59,242,ls),
+(59,83,o),
+(154,-14,o),
+(309,-14,cs)
+);
+}
+);
+width = 848;
+}
+);
+metricRight = "=|ne-canadian";
+note = uni1542;
+unicode = 5442;
+},
+{
+glyphname = "reRCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (537,511);
+},
+{
+name = top_left_can;
+pos = (119,511);
+},
+{
+name = top_right_can;
+pos = (708,511);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(693,-14,o),
+(788,83,o),
+(788,242,cs),
+(788,492,l),
+(628,492,l),
+(628,241,ls),
+(628,164,o),
+(595,124,o),
+(537,124,cs),
+(479,124,o),
+(447,161,o),
+(447,239,cs),
+(447,492,l),
+(41,492,l),
+(41,350,l),
+(291,350,l),
+(291,240,ls),
+(291,85,o),
+(383,-14,o),
+(538,-14,cs)
+);
+}
+);
+width = 847;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1543;
+unicode = 5443;
+},
+{
+glyphname = "leWestCree-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (537,511);
+},
+{
+name = top_left_can;
+pos = (119,511);
+},
+{
+name = top_right_can;
+pos = (708,511);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(447,0,l),
+(447,245,ls),
+(447,328,o),
+(480,368,o),
+(539,368,cs),
+(596,368,o),
+(628,327,o),
+(628,251,cs),
+(628,0,l),
+(788,0,l),
+(788,251,ls),
+(788,410,o),
+(697,506,o),
+(540,506,cs),
+(386,506,o),
+(291,406,o),
+(291,245,cs),
+(291,142,l),
+(41,142,l),
+(41,0,l)
+);
+}
+);
+width = 847;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+unicode = 5444;
+},
+{
+glyphname = "raai-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (177,-179);
+ref = ring_top.canadian;
+}
+);
+width = 846;
+}
+);
+note = uni1545;
+unicode = 5445;
+},
+{
+glyphname = "ri-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (309,511);
+},
+{
+name = top_left_can;
+pos = (139,511);
+},
+{
+name = top_right_can;
+pos = (727,511);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(219,0,l),
+(219,251,ls),
+(219,327,o),
+(251,368,o),
+(309,368,cs),
+(367,368,o),
+(400,330,o),
+(400,253,cs),
+(400,0,l),
+(807,0,l),
+(807,142,l),
+(556,142,l),
+(556,253,ls),
+(556,408,o),
+(469,506,o),
+(310,506,cs),
+(156,506,o),
+(59,410,o),
+(59,248,cs),
+(59,0,l)
+);
+}
+);
+width = 848;
+}
+);
+metricLeft = "re-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+unicode = 5446;
+},
+{
+glyphname = "rii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (215,-179);
+ref = dot_top;
+}
+);
+width = 846;
+}
+);
+note = uni1547;
+unicode = 5447;
+},
+{
+glyphname = "ro-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (246,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(223,0,l),
+(223,253,l),
+(183,213,l),
+(264,213,ls),
+(416,213,o),
+(515,307,o),
+(515,449,cs),
+(515,602,o),
+(418,690,o),
+(240,690,cs),
+(63,690,l),
+(63,548,l),
+(242,548,ls),
+(315,548,o),
+(355,513,o),
+(355,451,cs),
+(355,389,o),
+(315,355,o),
+(242,355,cs),
+(63,355,l),
+(63,0,l)
+);
+}
+);
+width = 557;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1548;
+unicode = 5448;
+},
+{
+glyphname = "roo-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (153,0);
+ref = dot_top;
+}
+);
+width = 557;
+}
+);
+note = uni1549;
+unicode = 5449;
+},
+{
+glyphname = "loWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (248,690);
+},
+{
+name = top_left_can;
+pos = (143,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(240,0,ls),
+(418,0,o),
+(515,89,o),
+(515,241,cs),
+(515,384,o),
+(416,476,o),
+(264,476,cs),
+(183,476,l),
+(223,437,l),
+(223,690,l),
+(63,690,l),
+(63,336,l),
+(242,336,ls),
+(315,336,o),
+(355,300,o),
+(355,239,cs),
+(355,177,o),
+(315,142,o),
+(242,142,cs),
+(63,142,l),
+(63,0,l)
+);
+}
+);
+width = 557;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+unicode = 5450;
+},
+{
+glyphname = "ra-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (310,690);
+},
+{
+name = top_right_can;
+pos = (414,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(494,0,l),
+(494,355,l),
+(315,355,ls),
+(241,355,o),
+(201,389,o),
+(201,451,cs),
+(201,513,o),
+(241,548,o),
+(315,548,cs),
+(494,548,l),
+(494,690,l),
+(316,690,ls),
+(138,690,o),
+(42,602,o),
+(42,449,cs),
+(42,307,o),
+(140,213,o),
+(293,213,cs),
+(374,213,l),
+(333,253,l),
+(333,0,l)
+);
+}
+);
+width = 557;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+unicode = 5451;
+},
+{
+glyphname = "raa-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (216,0);
+ref = dot_top;
+}
+);
+width = 557;
+}
+);
+note = uni154C;
+unicode = 5452;
+},
+{
+glyphname = "laWestCree-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (414,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(494,0,l),
+(494,142,l),
+(315,142,ls),
+(241,142,o),
+(201,177,o),
+(201,239,cs),
+(201,300,o),
+(241,336,o),
+(315,336,cs),
+(494,336,l),
+(494,690,l),
+(333,690,l),
+(333,437,l),
+(374,476,l),
+(293,476,ls),
+(140,476,o),
+(42,384,o),
+(42,241,cs),
+(42,89,o),
+(138,0,o),
+(316,0,cs)
+);
+}
+);
+width = 557;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+unicode = 5453;
+},
+{
+glyphname = "rwaa-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (453,0);
+ref = dot_top;
+}
+);
+width = 794;
+}
+);
+note = uni154E;
+unicode = 5454;
+},
+{
+glyphname = "rwaaWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (216,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (557,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni154F;
+unicode = 5455;
+},
+{
+glyphname = "r-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(282,345,l),
+(282,531,l),
+(192,531,ls),
+(161,531,o),
+(146,544,o),
+(146,568,cs),
+(146,591,o),
+(162,605,o),
+(192,605,cs),
+(282,605,l),
+(282,690,l),
+(190,690,ls),
+(97,690,o),
+(44,645,o),
+(44,567,cs),
+(44,496,o),
+(97,448,o),
+(179,448,cs),
+(227,448,l),
+(173,481,l),
+(173,345,l)
+);
+}
+);
+width = 335;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni1550;
+unicode = 5456;
+},
+{
+glyphname = "rWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(71,345,l),
+(294,438,l),
+(294,470,l),
+(134,536,l),
+(134,497,l),
+(294,564,l),
+(294,597,l),
+(71,690,l),
+(53,690,l),
+(53,618,l),
+(208,552,l),
+(208,607,l),
+(53,539,l),
+(53,496,l),
+(208,430,l),
+(208,482,l),
+(53,415,l),
+(53,345,l)
+);
+}
+);
+width = 347;
+}
+);
+metricLeft = "=|lWestCree-canadian";
+metricRight = "=|lWestCree-canadian";
+note = uni1551;
+unicode = 5457;
+},
+{
+glyphname = "rMedial-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(93,-14,l),
+(563,179,l),
+(563,231,l),
+(225,370,l),
+(225,320,l),
+(563,459,l),
+(563,511,l),
+(93,704,l),
+(55,704,l),
+(55,587,l),
+(400,446,l),
+(400,518,l),
+(55,378,l),
+(55,312,l),
+(400,172,l),
+(400,244,l),
+(55,102,l),
+(55,-14,l)
+);
+}
+);
+width = 618;
+}
+);
+metricLeft = "mediall-canadian";
+metricRight = "mediall-canadian";
+note = uni1552;
+unicode = 5458;
+},
+{
+glyphname = "fe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(399,0,l),
+(757,651,l),
+(757,690,l),
+(620,690,l),
+(347,185,l),
+(386,185,l),
+(287,348,l),
+(174,347,l),
+(198,318,o),
+(226,304,o),
+(265,304,cs),
+(355,304,o),
+(437,386,o),
+(437,506,cs),
+(437,619,o),
+(367,704,o),
+(253,704,cs),
+(139,704,o),
+(69,619,o),
+(69,512,cs),
+(69,457,o),
+(85,406,o),
+(123,348,cs),
+(352,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(219,418,o),
+(197,448,o),
+(197,506,cs),
+(197,562,o),
+(220,589,o),
+(253,589,cs),
+(287,589,o),
+(308,564,o),
+(308,505,cs),
+(308,445,o),
+(286,418,o),
+(253,418,cs)
+);
+}
+);
+width = 781;
+}
+);
+metricRight = "e-canadian";
+note = uni1553;
+unicode = 5459;
+},
+{
+glyphname = "faai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (245,0);
+ref = ring_top.canadian;
+}
+);
+width = 781;
+}
+);
+note = uni1554;
+unicode = 5460;
+},
+{
+glyphname = "fi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (378,690);
+},
+{
+name = top_left_can;
+pos = (147,690);
+},
+{
+name = top_right_can;
+pos = (624,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(367,-14,o),
+(437,71,o),
+(437,184,cs),
+(437,303,o),
+(355,385,o),
+(265,385,cs),
+(226,385,o),
+(198,372,o),
+(174,343,c),
+(287,342,l),
+(386,505,l),
+(347,505,l),
+(620,0,l),
+(757,0,l),
+(757,39,l),
+(399,690,l),
+(352,690,l),
+(122,340,ls),
+(84,283,o),
+(69,233,o),
+(69,178,cs),
+(69,71,o),
+(139,-14,o),
+(253,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(220,100,o),
+(197,128,o),
+(197,184,cs),
+(197,242,o),
+(219,271,o),
+(253,271,cs),
+(286,271,o),
+(308,244,o),
+(308,185,cs),
+(308,126,o),
+(287,100,o),
+(253,100,cs)
+);
+}
+);
+width = 781;
+}
+);
+metricLeft = "fe-canadian";
+metricRight = "e-canadian";
+note = uni1555;
+unicode = 5461;
+},
+{
+glyphname = "fii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (283,0);
+ref = dot_top;
+}
+);
+width = 781;
+}
+);
+note = uni1556;
+unicode = 5462;
+},
+{
+glyphname = "fo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (228,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(115,0,l),
+(647,321,l),
+(647,368,l),
+(359,647,ls),
+(318,689,o),
+(271,704,o),
+(226,704,cs),
+(126,704,o),
+(43,630,o),
+(43,501,cs),
+(43,385,o),
+(114,302,o),
+(222,302,cs),
+(329,302,o),
+(398,386,o),
+(398,501,cs),
+(398,526,o),
+(388,570,o),
+(377,597,c),
+(329,497,l),
+(488,345,l),
+(488,379,l),
+(77,134,l),
+(77,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(193,418,o),
+(171,444,o),
+(171,503,cs),
+(171,562,o),
+(193,589,o),
+(227,589,cs),
+(261,589,o),
+(281,565,o),
+(281,505,cs),
+(281,445,o),
+(260,418,o),
+(226,418,cs)
+);
+}
+);
+width = 675;
+}
+);
+metricRight = "o-canadian";
+note = uni1557;
+unicode = 5463;
+},
+{
+glyphname = "foo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "fo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (133,0);
+ref = dot_top;
+}
+);
+width = 675;
+}
+);
+note = uni1558;
+unicode = 5464;
+},
+{
+glyphname = "fa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (448,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(598,0,l),
+(598,132,l),
+(187,377,l),
+(187,349,l),
+(346,500,l),
+(298,597,l),
+(287,570,o),
+(277,526,o),
+(277,501,cs),
+(277,386,o),
+(346,302,o),
+(453,302,cs),
+(561,302,o),
+(633,385,o),
+(633,501,cs),
+(633,630,o),
+(550,704,o),
+(449,704,cs),
+(404,704,o),
+(357,689,o),
+(316,647,cs),
+(28,368,l),
+(28,321,l),
+(560,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(415,417,o),
+(394,445,o),
+(394,504,cs),
+(394,564,o),
+(414,588,o),
+(448,588,cs),
+(482,588,o),
+(504,562,o),
+(504,503,cs),
+(504,443,o),
+(482,417,o),
+(449,417,cs)
+);
+}
+);
+width = 676;
+}
+);
+metricRight = "=|fo-canadian";
+note = uni1559;
+unicode = 5465;
+},
+{
+glyphname = "faa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (354,0);
+ref = dot_top;
+}
+);
+width = 675;
+}
+);
+note = uni155A;
+unicode = 5466;
+},
+{
+glyphname = "fwaa-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (590,0);
+ref = dot_top;
+}
+);
+width = 912;
+}
+);
+note = uni155B;
+unicode = 5467;
+},
+{
+glyphname = "fwaaWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (354,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (675,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 912;
+}
+);
+note = uni155C;
+unicode = 5468;
+},
+{
+glyphname = "f-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(330,345,l),
+(330,411,l),
+(127,530,l),
+(127,518,l),
+(202,593,l),
+(183,641,l),
+(176,629,o),
+(171,606,o),
+(171,591,cs),
+(171,533,o),
+(209,495,o),
+(259,495,cs),
+(311,495,o),
+(347,533,o),
+(347,594,cs),
+(347,665,o),
+(302,696,o),
+(256,696,cs),
+(235,696,o),
+(207,686,o),
+(185,665,cs),
+(44,527,l),
+(44,503,l),
+(311,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(241,553,o),
+(230,566,o),
+(230,594,cs),
+(230,625,o),
+(241,638,o),
+(257,638,cs),
+(273,638,o),
+(284,624,o),
+(284,594,cs),
+(284,566,o),
+(273,553,o),
+(258,553,cs)
+);
+}
+);
+width = 394;
+}
+);
+note = uni155D;
+unicode = 5469;
+},
+{
+glyphname = "the-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (825,345);
+},
+{
+name = top_center_can;
+pos = (367,690);
+},
+{
+name = top_left_can;
+pos = (133,690);
+},
+{
+name = top_right_can;
+pos = (599,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(563,-14,o),
+(679,104,o),
+(679,309,cs),
+(679,690,l),
+(518,690,l),
+(518,304,ls),
+(518,187,o),
+(466,128,o),
+(366,128,cs),
+(270,128,o),
+(214,179,o),
+(214,291,cs),
+(214,398,l),
+(155,346,l),
+(176,311,o),
+(212,292,o),
+(254,292,cs),
+(356,292,o),
+(424,374,o),
+(424,497,cs),
+(424,620,o),
+(358,704,o),
+(244,704,cs),
+(125,704,o),
+(56,617,o),
+(56,460,cs),
+(56,336,ls),
+(56,103,o),
+(170,-14,o),
+(367,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(205,407,o),
+(185,434,o),
+(185,497,cs),
+(185,561,o),
+(206,588,o),
+(240,588,cs),
+(273,588,o),
+(295,561,o),
+(295,499,cs),
+(295,437,o),
+(273,407,o),
+(239,407,cs)
+);
+}
+);
+width = 735;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155E;
+unicode = 5470;
+},
+{
+glyphname = "theNCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(567,-14,o),
+(679,104,o),
+(679,331,cs),
+(679,460,ls),
+(679,617,o),
+(610,704,o),
+(490,704,cs),
+(376,704,o),
+(310,620,o),
+(310,497,cs),
+(310,374,o),
+(379,292,o),
+(480,292,cs),
+(523,292,o),
+(558,311,o),
+(580,346,c),
+(520,398,l),
+(520,290,ls),
+(520,177,o),
+(465,127,o),
+(369,127,cs),
+(269,127,o),
+(216,188,o),
+(216,304,cs),
+(216,690,l),
+(56,690,l),
+(56,308,ls),
+(56,102,o),
+(169,-14,o),
+(367,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(461,407,o),
+(440,438,o),
+(440,499,cs),
+(440,561,o),
+(461,589,o),
+(495,589,cs),
+(528,589,o),
+(550,561,o),
+(550,497,cs),
+(550,435,o),
+(529,407,o),
+(496,407,cs)
+);
+}
+);
+width = 735;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155F;
+unicode = 5471;
+},
+{
+glyphname = "thi-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (363,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(358,-14,o),
+(424,70,o),
+(424,192,cs),
+(424,316,o),
+(356,398,o),
+(254,398,cs),
+(212,398,o),
+(176,379,o),
+(155,344,c),
+(214,292,l),
+(214,400,ls),
+(214,513,o),
+(270,563,o),
+(366,563,cs),
+(466,563,o),
+(518,501,o),
+(518,385,cs),
+(518,0,l),
+(679,0,l),
+(679,382,ls),
+(679,587,o),
+(565,704,o),
+(367,704,cs),
+(167,704,o),
+(56,585,o),
+(56,358,cs),
+(56,230,ls),
+(56,72,o),
+(125,-14,o),
+(244,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(206,100,o),
+(185,128,o),
+(185,192,cs),
+(185,255,o),
+(205,283,o),
+(239,283,cs),
+(273,283,o),
+(295,252,o),
+(295,190,cs),
+(295,128,o),
+(273,100,o),
+(240,100,cs)
+);
+}
+);
+width = 735;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1560;
+unicode = 5472;
+},
+{
+glyphname = "thiNCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (363,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(610,-14,o),
+(679,72,o),
+(679,230,cs),
+(679,358,ls),
+(679,585,o),
+(567,704,o),
+(367,704,cs),
+(169,704,o),
+(56,587,o),
+(56,382,cs),
+(56,0,l),
+(216,0,l),
+(216,385,ls),
+(216,501,o),
+(269,563,o),
+(369,563,cs),
+(465,563,o),
+(520,513,o),
+(520,400,cs),
+(520,292,l),
+(580,344,l),
+(558,379,o),
+(523,398,o),
+(480,398,cs),
+(379,398,o),
+(310,316,o),
+(310,192,cs),
+(310,70,o),
+(376,-14,o),
+(490,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(461,100,o),
+(440,128,o),
+(440,190,cs),
+(440,252,o),
+(461,283,o),
+(496,283,cs),
+(529,283,o),
+(550,255,o),
+(550,192,cs),
+(550,128,o),
+(528,100,o),
+(495,100,cs)
+);
+}
+);
+width = 735;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1561;
+unicode = 5473;
+},
+{
+glyphname = "thii-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "thi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (269,0);
+ref = dot_top;
+}
+);
+width = 734;
+}
+);
+note = uni1562;
+unicode = 5474;
+},
+{
+glyphname = "thiiNCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "thiNCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (269,0);
+ref = dot_top;
+}
+);
+width = 734;
+}
+);
+note = uni1563;
+unicode = 5475;
+},
+{
+glyphname = "tho-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (302,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(282,0,ls),
+(502,0,o),
+(628,124,o),
+(628,350,cs),
+(628,566,o),
+(496,704,o),
+(305,704,cs),
+(144,704,o),
+(49,608,o),
+(49,472,cs),
+(49,351,o),
+(123,270,o),
+(234,270,cs),
+(343,270,o),
+(408,344,o),
+(408,456,cs),
+(408,542,o),
+(364,624,o),
+(264,633,c),
+(241,584,l),
+(249,588,o),
+(270,591,o),
+(282,591,cs),
+(401,591,o),
+(470,500,o),
+(470,360,cs),
+(470,211,o),
+(401,144,o),
+(272,144,cs),
+(82,144,l),
+(82,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,384,o),
+(179,412,o),
+(179,478,cs),
+(179,544,o),
+(201,572,o),
+(233,572,cs),
+(266,572,o),
+(289,543,o),
+(289,477,cs),
+(289,412,o),
+(268,384,o),
+(234,384,cs)
+);
+}
+);
+width = 678;
+}
+);
+metricRight = "to-canadian";
+note = uni1564;
+unicode = 5476;
+},
+{
+glyphname = "thoo-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "tho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (209,0);
+ref = dot_top;
+}
+);
+width = 678;
+}
+);
+note = uni1565;
+unicode = 5477;
+},
+{
+glyphname = "tha-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (380,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(596,0,l),
+(596,144,l),
+(406,144,ls),
+(277,144,o),
+(209,210,o),
+(209,359,cs),
+(209,500,o),
+(277,591,o),
+(397,591,cs),
+(409,591,o),
+(429,588,o),
+(438,584,c),
+(414,633,l),
+(315,624,o),
+(270,542,o),
+(270,456,cs),
+(270,344,o),
+(337,270,o),
+(444,270,cs),
+(555,270,o),
+(629,352,o),
+(629,472,cs),
+(629,609,o),
+(533,704,o),
+(376,704,cs),
+(184,704,o),
+(50,566,o),
+(50,350,cs),
+(50,126,o),
+(174,0,o),
+(396,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(411,384,o),
+(389,412,o),
+(389,477,cs),
+(389,543,o),
+(412,572,o),
+(445,572,cs),
+(477,572,o),
+(500,544,o),
+(500,478,cs),
+(500,412,o),
+(478,384,o),
+(445,384,cs)
+);
+}
+);
+width = 678;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tho-canadian";
+note = uni1566;
+unicode = 5478;
+},
+{
+glyphname = "thaa-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (285,0);
+ref = dot_top;
+}
+);
+width = 678;
+}
+);
+note = uni1567;
+unicode = 5479;
+},
+{
+glyphname = "thwaa-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (522,0);
+ref = dot_top;
+}
+);
+width = 915;
+}
+);
+note = uni1568;
+unicode = 5480;
+},
+{
+glyphname = "thwaaWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (285,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (678,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 915;
+}
+);
+note = uni1569;
+unicode = 5481;
+},
+{
+glyphname = "th-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(318,345,l),
+(318,432,l),
+(235,432,ls),
+(170,432,o),
+(138,460,o),
+(138,525,cs),
+(138,590,o),
+(173,634,o),
+(234,634,cs),
+(240,634,o),
+(248,633,o),
+(252,632,c),
+(227,657,l),
+(183,653,o),
+(159,617,o),
+(159,578,cs),
+(159,517,o),
+(196,478,o),
+(247,478,cs),
+(298,478,o),
+(334,517,o),
+(334,579,cs),
+(334,652,o),
+(285,696,o),
+(211,696,cs),
+(115,696,o),
+(46,628,o),
+(46,517,cs),
+(46,410,o),
+(109,345,o),
+(228,345,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(229,535,o),
+(218,550,o),
+(218,578,cs),
+(218,608,o),
+(229,620,o),
+(245,620,cs),
+(261,620,o),
+(272,607,o),
+(272,577,cs),
+(272,549,o),
+(262,535,o),
+(245,535,cs)
+);
+}
+);
+width = 383;
+}
+);
+metricLeft = "t-canadian";
+note = uni156A;
+unicode = 5482;
+},
+{
+glyphname = "tthe-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (815,345);
+},
+{
+name = top_center_can;
+pos = (362,690);
+},
+{
+name = top_left_can;
+pos = (136,690);
+},
+{
+name = top_right_can;
+pos = (590,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(556,-14,o),
+(669,104,o),
+(669,309,cs),
+(669,690,l),
+(513,690,l),
+(513,308,ls),
+(513,188,o),
+(459,130,o),
+(362,130,cs),
+(269,130,o),
+(212,192,o),
+(212,308,cs),
+(212,690,l),
+(56,690,l),
+(56,308,ls),
+(56,102,o),
+(169,-14,o),
+(363,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(427,380,l),
+(427,690,l),
+(298,690,l),
+(298,380,l)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156B;
+unicode = 5483;
+},
+{
+glyphname = "tthi-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(212,0,l),
+(212,382,ls),
+(212,498,o),
+(271,559,o),
+(365,559,cs),
+(458,559,o),
+(513,497,o),
+(513,382,cs),
+(513,0,l),
+(669,0,l),
+(669,382,ls),
+(669,586,o),
+(556,704,o),
+(368,704,cs),
+(173,704,o),
+(56,586,o),
+(56,382,cs),
+(56,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(427,0,l),
+(427,310,l),
+(298,310,l),
+(298,0,l)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156C;
+unicode = 5484;
+},
+{
+glyphname = "ttho-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (317,690);
+},
+{
+name = top_left_can;
+pos = (136,690);
+},
+{
+name = top_right_can;
+pos = (497,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(226,0,ls),
+(447,0,o),
+(576,125,o),
+(576,346,cs),
+(576,567,o),
+(447,690,o),
+(226,690,cs),
+(56,690,l),
+(56,546,l),
+(218,546,ls),
+(342,546,o),
+(415,482,o),
+(415,346,cs),
+(415,210,o),
+(342,144,o),
+(219,144,cs),
+(56,144,l),
+(56,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(296,280,l),
+(296,412,l),
+(56,412,l),
+(56,280,l)
+);
+}
+);
+width = 626;
+}
+);
+metricRight = "to-canadian";
+note = uni156D;
+unicode = 5485;
+},
+{
+glyphname = "ttha-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (312,690);
+},
+{
+name = top_left_can;
+pos = (130,690);
+},
+{
+name = top_right_can;
+pos = (491,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(570,0,l),
+(570,144,l),
+(408,144,ls),
+(284,144,o),
+(212,209,o),
+(212,345,cs),
+(212,481,o),
+(284,546,o),
+(408,546,cs),
+(570,546,l),
+(570,690,l),
+(401,690,ls),
+(180,690,o),
+(50,566,o),
+(50,345,cs),
+(50,124,o),
+(180,0,o),
+(400,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(570,280,l),
+(570,412,l),
+(331,412,l),
+(331,280,l)
+);
+}
+);
+width = 626;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|ttho-canadian";
+note = uni156E;
+unicode = 5486;
+},
+{
+glyphname = "tth-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(649,460,l),
+(608,460,l),
+(697,332,l),
+(771,386,l),
+(680,512,l),
+(667,471,l),
+(810,521,l),
+(781,606,l),
+(639,555,l),
+(674,531,l),
+(674,690,l),
+(582,690,l),
+(582,531,l),
+(618,555,l),
+(475,606,l),
+(446,521,l),
+(590,471,l),
+(577,512,l),
+(486,386,l),
+(559,332,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(235,460,l),
+(193,460,l),
+(283,332,l),
+(357,386,l),
+(266,512,l),
+(253,471,l),
+(396,521,l),
+(367,606,l),
+(224,555,l),
+(260,531,l),
+(260,690,l),
+(168,690,l),
+(168,531,l),
+(204,555,l),
+(62,606,l),
+(32,521,l),
+(176,471,l),
+(162,512,l),
+(71,386,l),
+(145,332,l)
+);
+}
+);
+width = 842;
+}
+);
+metricRight = "=|";
+note = uni156F;
+unicode = 5487;
+},
+{
+glyphname = "tye-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(556,-14,o),
+(669,104,o),
+(669,309,cs),
+(669,690,l),
+(515,690,l),
+(515,312,ls),
+(515,188,o),
+(459,130,o),
+(362,130,cs),
+(269,130,o),
+(211,192,o),
+(211,312,cs),
+(211,690,l),
+(56,690,l),
+(56,308,ls),
+(56,102,o),
+(169,-14,o),
+(363,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(432,410,o),
+(469,454,o),
+(469,524,cs),
+(469,690,l),
+(395,690,l),
+(395,527,ls),
+(395,500,o),
+(385,486,o),
+(362,486,cs),
+(341,486,o),
+(329,500,o),
+(329,527,cs),
+(329,690,l),
+(256,690,l),
+(256,524,ls),
+(256,452,o),
+(296,410,o),
+(363,410,cs)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1570;
+unicode = 5488;
+},
+{
+glyphname = "tyi-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(212,0,l),
+(212,378,ls),
+(212,498,o),
+(271,559,o),
+(365,559,cs),
+(458,559,o),
+(514,497,o),
+(514,378,cs),
+(514,0,l),
+(669,0,l),
+(669,382,ls),
+(669,586,o),
+(556,704,o),
+(368,704,cs),
+(173,704,o),
+(56,586,o),
+(56,382,cs),
+(56,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(329,0,l),
+(329,161,ls),
+(329,189,o),
+(340,204,o),
+(362,204,cs),
+(384,204,o),
+(395,189,o),
+(395,161,cs),
+(395,0,l),
+(469,0,l),
+(469,166,ls),
+(469,238,o),
+(430,280,o),
+(362,280,cs),
+(294,280,o),
+(256,236,o),
+(256,166,cs),
+(256,0,l)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1571;
+unicode = 5489;
+},
+{
+glyphname = "tyo-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(233,0,ls),
+(450,0,o),
+(582,125,o),
+(582,346,cs),
+(582,567,o),
+(450,690,o),
+(232,690,cs),
+(63,690,l),
+(63,549,l),
+(219,549,ls),
+(348,549,o),
+(421,483,o),
+(421,346,cs),
+(421,209,o),
+(348,141,o),
+(219,141,cs),
+(63,141,l),
+(63,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(158,218,ls),
+(242,218,o),
+(290,265,o),
+(290,345,cs),
+(290,425,o),
+(242,471,o),
+(158,471,cs),
+(63,471,l),
+(63,393,l),
+(148,393,ls),
+(186,393,o),
+(204,377,o),
+(204,345,cs),
+(204,313,o),
+(186,297,o),
+(148,297,cs),
+(63,297,l),
+(63,218,l)
+);
+}
+);
+width = 632;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1572;
+unicode = 5490;
+},
+{
+glyphname = "tya-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(570,0,l),
+(570,141,l),
+(413,141,ls),
+(285,141,o),
+(212,208,o),
+(212,345,cs),
+(212,482,o),
+(285,549,o),
+(413,549,cs),
+(570,549,l),
+(570,690,l),
+(401,690,ls),
+(182,690,o),
+(50,566,o),
+(50,345,cs),
+(50,124,o),
+(182,0,o),
+(400,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(570,218,l),
+(570,297,l),
+(485,297,ls),
+(446,297,o),
+(429,313,o),
+(429,345,cs),
+(429,377,o),
+(446,393,o),
+(485,393,cs),
+(570,393,l),
+(570,471,l),
+(474,471,ls),
+(391,471,o),
+(342,425,o),
+(342,345,cs),
+(342,265,o),
+(391,218,o),
+(474,218,cs)
+);
+}
+);
+width = 633;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1573;
+unicode = 5491;
+},
+{
+glyphname = "heNunavik-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(521,0,l),
+(762,201,l),
+(675,309,l),
+(437,113,l),
+(538,105,l),
+(538,435,ls),
+(538,602,o),
+(446,704,o),
+(294,704,cs),
+(141,704,o),
+(42,601,o),
+(42,440,cs),
+(42,286,o),
+(134,184,o),
+(267,184,cs),
+(331,184,o),
+(380,214,o),
+(390,247,c),
+(379,260,l),
+(379,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(236,319,o),
+(199,360,o),
+(199,443,cs),
+(199,527,o),
+(233,569,o),
+(290,569,cs),
+(346,569,o),
+(381,527,o),
+(381,443,cs),
+(381,360,o),
+(343,319,o),
+(290,319,cs)
+);
+}
+);
+width = 781;
+}
+);
+metricLeft = "ke-canadian";
+note = uni1574;
+unicode = 5492;
+},
+{
+glyphname = "hiNunavik-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (493,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(403,0,l),
+(403,260,l),
+(392,247,l),
+(402,214,o),
+(450,184,o),
+(515,184,cs),
+(647,184,o),
+(741,287,o),
+(741,442,cs),
+(741,603,o),
+(641,704,o),
+(493,704,cs),
+(340,704,o),
+(244,602,o),
+(244,435,cs),
+(244,117,l),
+(345,113,l),
+(107,309,l),
+(19,201,l),
+(262,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(439,319,o),
+(401,360,o),
+(401,443,cs),
+(401,527,o),
+(437,569,o),
+(493,569,cs),
+(549,569,o),
+(583,527,o),
+(583,443,cs),
+(583,360,o),
+(546,319,o),
+(493,319,cs)
+);
+}
+);
+width = 783;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1575;
+unicode = 5493;
+},
+{
+glyphname = "hiiNunavik-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "hiNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (398,0);
+ref = dot_top;
+}
+);
+width = 781;
+}
+);
+note = uni1576;
+unicode = 5494;
+},
+{
+glyphname = "hoNunavik-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (289,690);
+},
+{
+name = top_right_can;
+pos = (459,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(446,-14,o),
+(538,88,o),
+(538,255,cs),
+(538,584,l),
+(437,577,l),
+(675,381,l),
+(762,489,l),
+(521,690,l),
+(379,690,l),
+(379,430,l),
+(390,442,l),
+(380,475,o),
+(331,506,o),
+(269,506,cs),
+(134,506,o),
+(42,401,o),
+(42,245,cs),
+(42,86,o),
+(137,-14,o),
+(290,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(233,121,o),
+(199,162,o),
+(199,246,cs),
+(199,329,o),
+(236,371,o),
+(290,371,cs),
+(343,371,o),
+(381,329,o),
+(381,246,cs),
+(381,162,o),
+(346,121,o),
+(290,121,cs)
+);
+}
+);
+width = 781;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "heNunavik-canadian";
+note = uni1577;
+unicode = 5495;
+},
+{
+glyphname = "hooNunavik-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "hoNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (364,0);
+ref = dot_top;
+}
+);
+width = 781;
+}
+);
+note = uni1578;
+unicode = 5496;
+},
+{
+glyphname = "haNunavik-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (493,690);
+},
+{
+name = top_left_can;
+pos = (324,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(640,-14,o),
+(741,87,o),
+(741,248,cs),
+(741,403,o),
+(647,506,o),
+(519,506,cs),
+(453,506,o),
+(405,475,o),
+(392,442,c),
+(403,430,l),
+(403,690,l),
+(262,690,l),
+(19,489,l),
+(107,381,l),
+(345,577,l),
+(244,573,l),
+(244,255,ls),
+(244,88,o),
+(335,-14,o),
+(491,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(437,121,o),
+(401,162,o),
+(401,246,cs),
+(401,329,o),
+(439,371,o),
+(493,371,cs),
+(546,371,o),
+(583,329,o),
+(583,246,cs),
+(583,162,o),
+(549,121,o),
+(493,121,cs)
+);
+}
+);
+width = 783;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1579;
+unicode = 5497;
+},
+{
+glyphname = "haaNunavik-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "haNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (229,0);
+ref = dot_top;
+}
+);
+width = 781;
+}
+);
+note = uni157A;
+unicode = 5498;
+},
+{
+glyphname = "hNunavik-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(364,339,o),
+(424,386,o),
+(424,472,cs),
+(424,552,o),
+(374,601,o),
+(308,601,cs),
+(270,601,o),
+(242,581,o),
+(234,555,c),
+(255,555,l),
+(255,690,l),
+(154,690,l),
+(34,589,l),
+(83,529,l),
+(203,630,l),
+(146,635,l),
+(146,475,ls),
+(146,394,o),
+(199,339,o),
+(289,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(262,416,o),
+(245,434,o),
+(245,469,cs),
+(245,506,o),
+(264,524,o),
+(286,524,cs),
+(310,524,o),
+(328,506,o),
+(328,469,cs),
+(328,434,o),
+(310,416,o),
+(286,416,cs)
+);
+}
+);
+width = 468;
+}
+);
+metricRight = "k-canadian";
+note = uni157B;
+unicode = 5499;
+},
+{
+color = 4;
+glyphname = "nunavuth-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(223,285,l),
+(485,285,l),
+(485,0,l),
+(645,0,l),
+(645,690,l),
+(485,690,l),
+(485,426,l),
+(223,426,l),
+(223,690,l),
+(63,690,l),
+(63,0,l),
+(223,0,l)
+);
+}
+);
+width = 708;
+}
+);
+metricRight = "=|";
+note = uni157C;
+unicode = 5500;
+},
+{
+glyphname = "hk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,345);
+ref = "fullstop-canadian";
+}
+);
+width = 378;
+}
+);
+metricLeft = "fullstop-canadian";
+note = uni157D;
+unicode = 5501;
+},
+{
+glyphname = "qaai-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (334,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (506,0);
+ref = ring_top.canadian;
+}
+);
+width = 927;
+}
+);
+note = uni157E;
+unicode = 5502;
+},
+{
+glyphname = "qi-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (334,0);
+ref = "ki-canadian";
+}
+);
+width = 927;
+}
+);
+note = uni157F;
+unicode = 5503;
+},
+{
+glyphname = "qii-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (334,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (544,0);
+ref = dot_top;
+}
+);
+width = 927;
+}
+);
+note = uni1580;
+unicode = 5504;
+},
+{
+glyphname = "qo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (334,0);
+ref = "ko-canadian";
+}
+);
+width = 927;
+}
+);
+note = uni1581;
+unicode = 5505;
+},
+{
+glyphname = "qoo-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (334,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (698,0);
+ref = dot_top;
+}
+);
+width = 927;
+}
+);
+note = uni1582;
+unicode = 5506;
+},
+{
+glyphname = "qa-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (334,0);
+ref = "ka-canadian";
+}
+);
+width = 927;
+}
+);
+note = uni1583;
+unicode = 5507;
+},
+{
+glyphname = "qaa-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (334,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (377,0);
+ref = dot_top;
+}
+);
+width = 927;
+}
+);
+note = uni1584;
+unicode = 5508;
+},
+{
+glyphname = "q-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (334,0);
+ref = "k-canadian";
+}
+);
+width = 710;
+}
+);
+note = uni1585;
+unicode = 5509;
+},
+{
+glyphname = "tlhe-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (307,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(229,0,l),
+(358,274,l),
+(238,219,l),
+(251,215,o),
+(266,214,o),
+(281,214,cs),
+(347,214,o),
+(396,243,o),
+(407,271,c),
+(397,328,l),
+(397,0,l),
+(555,0,l),
+(555,443,ls),
+(555,607,o),
+(465,704,o),
+(308,704,cs),
+(142,704,o),
+(52,595,o),
+(52,456,cs),
+(52,355,o),
+(99,278,o),
+(174,242,c),
+(59,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(245,350,o),
+(209,387,o),
+(209,458,cs),
+(209,530,o),
+(244,569,o),
+(304,569,cs),
+(363,569,o),
+(399,530,o),
+(399,459,cs),
+(399,387,o),
+(362,350,o),
+(304,350,cs)
+);
+}
+);
+width = 611;
+}
+);
+metricRight = "te-canadian";
+note = uni1586;
+unicode = 5510;
+},
+{
+glyphname = "tlhi-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(214,0,l),
+(214,328,l),
+(203,279,l),
+(204,249,o),
+(257,214,o),
+(330,214,c),
+(253,274,l),
+(384,0,l),
+(553,0,l),
+(438,242,l),
+(513,278,o),
+(559,355,o),
+(559,456,cs),
+(559,595,o),
+(470,704,o),
+(304,704,cs),
+(147,704,o),
+(56,607,o),
+(56,443,cs),
+(56,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(250,350,o),
+(213,387,o),
+(213,459,cs),
+(213,530,o),
+(249,569,o),
+(308,569,cs),
+(367,569,o),
+(403,530,o),
+(403,458,cs),
+(403,387,o),
+(366,350,o),
+(308,350,cs)
+);
+}
+);
+width = 611;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|tlhe-canadian";
+note = uni1587;
+unicode = 5511;
+},
+{
+glyphname = "tlho-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (315,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(465,-14,o),
+(555,83,o),
+(555,246,cs),
+(555,690,l),
+(397,690,l),
+(397,361,l),
+(409,411,l),
+(408,440,o),
+(355,475,o),
+(281,475,c),
+(358,415,l),
+(229,690,l),
+(59,690,l),
+(174,447,l),
+(99,412,o),
+(52,335,o),
+(52,234,cs),
+(52,95,o),
+(142,-14,o),
+(308,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(244,121,o),
+(209,159,o),
+(209,232,cs),
+(209,302,o),
+(245,340,o),
+(304,340,cs),
+(362,340,o),
+(399,302,o),
+(399,231,cs),
+(399,159,o),
+(363,121,o),
+(304,121,cs)
+);
+}
+);
+width = 611;
+}
+);
+metricLeft = "tlhe-canadian";
+metricRight = "te-canadian";
+note = uni1588;
+unicode = 5512;
+},
+{
+glyphname = "tlha-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(470,-14,o),
+(559,95,o),
+(559,234,cs),
+(559,335,o),
+(513,412,o),
+(438,447,c),
+(553,690,l),
+(384,690,l),
+(253,415,l),
+(374,470,l),
+(360,474,o),
+(346,475,o),
+(330,475,cs),
+(257,475,o),
+(204,440,o),
+(203,411,c),
+(214,361,l),
+(214,690,l),
+(56,690,l),
+(56,246,ls),
+(56,83,o),
+(147,-14,o),
+(304,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(249,121,o),
+(213,159,o),
+(213,231,cs),
+(213,302,o),
+(250,340,o),
+(308,340,cs),
+(366,340,o),
+(403,302,o),
+(403,232,cs),
+(403,159,o),
+(367,121,o),
+(308,121,cs)
+);
+}
+);
+width = 611;
+}
+);
+metricLeft = "te-canadian";
+note = uni1589;
+unicode = 5513;
+},
+{
+glyphname = "reWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(511,0,l),
+(753,201,l),
+(666,309,l),
+(428,113,l),
+(528,105,l),
+(528,439,ls),
+(528,608,o),
+(440,704,o),
+(289,704,cs),
+(134,704,o),
+(41,607,o),
+(41,438,cs),
+(41,380,l),
+(199,380,l),
+(199,454,ls),
+(199,526,o),
+(230,565,o),
+(285,565,cs),
+(339,565,o),
+(370,527,o),
+(370,453,cs),
+(370,0,l)
+);
+}
+);
+width = 772;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+unicode = 5514;
+},
+{
+glyphname = "riWestCree-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(403,0,l),
+(403,453,ls),
+(403,527,o),
+(436,565,o),
+(490,565,cs),
+(546,565,o),
+(574,527,o),
+(574,454,cs),
+(574,380,l),
+(732,380,l),
+(732,438,ls),
+(732,607,o),
+(643,704,o),
+(492,704,cs),
+(334,704,o),
+(244,604,o),
+(244,438,cs),
+(244,105,l),
+(345,113,l),
+(107,309,l),
+(19,201,l),
+(262,0,l)
+);
+}
+);
+width = 773;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+unicode = 5515;
+},
+{
+glyphname = "roWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,-14,o),
+(528,81,o),
+(528,251,cs),
+(528,584,l),
+(428,577,l),
+(666,381,l),
+(753,489,l),
+(511,690,l),
+(370,690,l),
+(370,235,ls),
+(370,160,o),
+(339,125,o),
+(285,125,cs),
+(228,125,o),
+(199,163,o),
+(199,242,cs),
+(199,310,l),
+(41,310,l),
+(41,252,ls),
+(41,83,o),
+(129,-14,o),
+(288,-14,cs)
+);
+}
+);
+width = 772;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+unicode = 5516;
+},
+{
+glyphname = "raWestCree-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(641,-14,o),
+(732,83,o),
+(732,252,cs),
+(732,310,l),
+(574,310,l),
+(574,240,ls),
+(574,161,o),
+(544,125,o),
+(490,125,cs),
+(433,125,o),
+(403,160,o),
+(403,235,cs),
+(403,690,l),
+(262,690,l),
+(19,489,l),
+(107,381,l),
+(345,577,l),
+(244,584,l),
+(244,251,ls),
+(244,83,o),
+(330,-14,o),
+(490,-14,cs)
+);
+}
+);
+width = 773;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+unicode = 5517;
+},
+{
+glyphname = "ngaai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (631,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (805,0);
+ref = ring_top.canadian;
+}
+);
+width = 1217;
+}
+);
+note = uni158E;
+unicode = 5518;
+},
+{
+glyphname = "ngi-canadian";
+kernLeft = mwestleft;
+kernRight = ciright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (631,0);
+ref = "ci-canadian";
+}
+);
+width = 1217;
+}
+);
+note = uni158F;
+unicode = 5519;
+},
+{
+glyphname = "ngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (631,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (842,0);
+ref = dot_top;
+}
+);
+width = 1217;
+}
+);
+note = uni1590;
+unicode = 5520;
+},
+{
+glyphname = "ngo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:57:17 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (605,0);
+ref = "co-canadian";
+}
+);
+width = 1191;
+}
+);
+note = uni1591;
+unicode = 5521;
+},
+{
+glyphname = "ngoo-canadian";
+lastChange = "2023-01-13 15:57:17 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+ref = "ngo-canadian";
+},
+{
+anchor = top_right_can;
+pos = (961,0);
+ref = dot_top;
+}
+);
+width = 1191;
+}
+);
+note = uni1592;
+unicode = 5522;
+},
+{
+glyphname = "nga-canadian";
+kernLeft = mwestleft;
+kernRight = caright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (631,0);
+ref = "ca-canadian";
+}
+);
+width = 1217;
+}
+);
+note = uni1593;
+unicode = 5523;
+},
+{
+glyphname = "ngaa-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (631,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (673,0);
+ref = dot_top;
+}
+);
+width = 1217;
+}
+);
+note = uni1594;
+unicode = 5524;
+},
+{
+glyphname = "ng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(547,217,o),
+(601,267,o),
+(601,349,cs),
+(601,369,l),
+(498,369,l),
+(498,344,ls),
+(498,317,o),
+(485,301,o),
+(463,301,cs),
+(440,301,o),
+(428,317,o),
+(428,345,cs),
+(428,536,l),
+(278,536,l),
+(285,491,l),
+(303,503,o),
+(320,533,o),
+(320,571,cs),
+(320,647,o),
+(269,696,o),
+(183,696,cs),
+(99,696,o),
+(44,645,o),
+(44,565,cs),
+(44,488,o),
+(97,435,o),
+(187,435,cs),
+(339,435,l),
+(319,461,l),
+(319,358,ls),
+(319,266,o),
+(369,217,o),
+(463,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(158,513,o),
+(141,530,o),
+(141,565,cs),
+(141,601,o),
+(158,619,o),
+(183,619,cs),
+(207,619,o),
+(223,601,o),
+(223,565,cs),
+(223,531,o),
+(207,513,o),
+(183,513,cs)
+);
+}
+);
+width = 632;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1595;
+unicode = 5525;
+},
+{
+glyphname = "nng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(843,217,o),
+(896,267,o),
+(896,349,cs),
+(896,369,l),
+(795,369,l),
+(795,344,ls),
+(795,317,o),
+(782,301,o),
+(758,301,cs),
+(736,301,o),
+(725,317,o),
+(725,345,cs),
+(725,536,l),
+(583,536,l),
+(590,491,l),
+(609,503,o),
+(624,533,o),
+(624,571,cs),
+(624,648,o),
+(573,696,o),
+(488,696,cs),
+(402,696,o),
+(350,646,o),
+(350,569,cs),
+(350,533,o),
+(366,502,o),
+(384,490,c),
+(391,536,l),
+(278,536,l),
+(285,491,l),
+(303,503,o),
+(320,533,o),
+(320,571,cs),
+(320,647,o),
+(269,696,o),
+(183,696,cs),
+(99,696,o),
+(44,645,o),
+(44,565,cs),
+(44,488,o),
+(97,435,o),
+(187,435,cs),
+(615,435,l),
+(615,358,ls),
+(615,266,o),
+(665,217,o),
+(758,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(158,513,o),
+(141,530,o),
+(141,565,cs),
+(141,601,o),
+(158,619,o),
+(183,619,cs),
+(207,619,o),
+(223,601,o),
+(223,565,cs),
+(223,531,o),
+(207,513,o),
+(183,513,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(463,513,o),
+(446,530,o),
+(446,565,cs),
+(446,601,o),
+(463,619,o),
+(488,619,cs),
+(511,619,o),
+(528,601,o),
+(528,565,cs),
+(528,531,o),
+(512,513,o),
+(488,513,cs)
+);
+}
+);
+width = 927;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1596;
+unicode = 5526;
+},
+{
+glyphname = "sheSayisi-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (690,345);
+},
+{
+name = top_center_can;
+pos = (300,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(545,0,l),
+(545,438,ls),
+(545,602,o),
+(456,704,o),
+(300,704,cs),
+(140,704,o),
+(42,597,o),
+(42,425,cs),
+(42,262,o),
+(118,184,o),
+(213,184,cs),
+(319,184,o),
+(364,269,o),
+(355,413,c),
+(272,413,l),
+(275,336,o),
+(262,315,o),
+(239,315,cs),
+(214,315,o),
+(195,339,o),
+(195,429,cs),
+(195,526,o),
+(234,569,o),
+(294,569,cs),
+(353,569,o),
+(384,528,o),
+(384,434,cs),
+(384,0,l)
+);
+}
+);
+width = 601;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1597;
+unicode = 5527;
+},
+{
+glyphname = "shiSayisi-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(216,0,l),
+(216,434,ls),
+(216,528,o),
+(251,569,o),
+(310,569,cs),
+(370,569,o),
+(406,527,o),
+(406,430,cs),
+(406,339,o),
+(386,315,o),
+(362,315,cs),
+(339,315,o),
+(326,336,o),
+(328,413,c),
+(245,413,l),
+(237,269,o),
+(282,184,o),
+(387,184,cs),
+(483,184,o),
+(559,262,o),
+(559,425,cs),
+(559,597,o),
+(468,704,o),
+(311,704,cs),
+(150,704,o),
+(56,602,o),
+(56,438,cs),
+(56,0,l)
+);
+}
+);
+width = 601;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni1598;
+unicode = 5528;
+},
+{
+glyphname = "shoSayisi-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (292,690);
+},
+{
+name = top_left_can;
+pos = (119,690);
+},
+{
+name = top_right_can;
+pos = (466,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(451,-14,o),
+(545,88,o),
+(545,252,cs),
+(545,690,l),
+(384,690,l),
+(384,256,ls),
+(384,161,o),
+(350,121,o),
+(291,121,cs),
+(231,121,o),
+(195,162,o),
+(195,260,cs),
+(195,351,o),
+(214,375,o),
+(239,375,cs),
+(262,375,o),
+(275,354,o),
+(272,276,c),
+(355,276,l),
+(364,421,o),
+(320,506,o),
+(213,506,cs),
+(118,506,o),
+(42,428,o),
+(42,259,cs),
+(42,91,o),
+(133,-14,o),
+(290,-14,cs)
+);
+}
+);
+width = 601;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1599;
+unicode = 5529;
+},
+{
+glyphname = "shaSayisi-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(461,-14,o),
+(559,93,o),
+(559,265,cs),
+(559,428,o),
+(487,506,o),
+(391,506,cs),
+(286,506,o),
+(237,421,o),
+(245,276,c),
+(328,276,l),
+(326,354,o),
+(339,375,o),
+(362,375,cs),
+(386,375,o),
+(406,351,o),
+(406,261,cs),
+(406,163,o),
+(367,121,o),
+(307,121,cs),
+(248,121,o),
+(216,161,o),
+(216,256,cs),
+(216,690,l),
+(56,690,l),
+(56,252,ls),
+(56,88,o),
+(145,-14,o),
+(301,-14,cs)
+);
+}
+);
+width = 601;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni159A;
+unicode = 5530;
+},
+{
+glyphname = "theWoodScree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(663,-14,o),
+(767,83,o),
+(767,240,cs),
+(767,402,o),
+(666,492,o),
+(495,492,cs),
+(50,492,l),
+(50,362,l),
+(336,362,l),
+(313,384,l),
+(279,348,o),
+(262,288,o),
+(262,231,cs),
+(262,79,o),
+(360,-14,o),
+(514,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(452,121,o),
+(419,168,o),
+(419,240,cs),
+(419,310,o),
+(452,357,o),
+(514,357,cs),
+(576,357,o),
+(610,311,o),
+(610,240,cs),
+(610,167,o),
+(576,121,o),
+(514,121,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(754,560,l),
+(754,690,l),
+(50,690,l),
+(50,560,l)
+);
+}
+);
+width = 817;
+}
+);
+note = uni159B;
+unicode = 5531;
+},
+{
+glyphname = "thiWoodScree-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(457,-14,o),
+(555,79,o),
+(555,233,cs),
+(555,291,o),
+(537,350,o),
+(504,386,c),
+(481,362,l),
+(767,362,l),
+(767,492,l),
+(325,492,ls),
+(150,492,o),
+(50,392,o),
+(50,237,cs),
+(50,83,o),
+(153,-14,o),
+(303,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(242,121,o),
+(208,167,o),
+(208,240,cs),
+(208,311,o),
+(242,357,o),
+(303,357,cs),
+(364,357,o),
+(398,310,o),
+(398,240,cs),
+(398,168,o),
+(364,121,o),
+(303,121,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(767,560,l),
+(767,690,l),
+(63,690,l),
+(63,560,l)
+);
+}
+);
+width = 817;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159C;
+unicode = 5532;
+},
+{
+glyphname = "thoWoodScree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(500,0,ls),
+(668,0,o),
+(767,94,o),
+(767,252,cs),
+(767,409,o),
+(666,506,o),
+(514,506,cs),
+(360,506,o),
+(262,411,o),
+(262,260,cs),
+(262,203,o),
+(279,144,o),
+(314,107,c),
+(336,129,l),
+(50,129,l),
+(50,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(452,134,o),
+(419,182,o),
+(419,253,cs),
+(419,325,o),
+(452,371,o),
+(514,371,cs),
+(576,371,o),
+(610,325,o),
+(610,253,cs),
+(610,181,o),
+(576,134,o),
+(514,134,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(754,560,l),
+(754,690,l),
+(50,690,l),
+(50,560,l)
+);
+}
+);
+width = 817;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159D;
+unicode = 5533;
+},
+{
+glyphname = "thaWoodScree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(767,0,l),
+(767,129,l),
+(481,129,l),
+(503,105,l),
+(537,142,o),
+(555,202,o),
+(555,259,cs),
+(555,412,o),
+(457,506,o),
+(303,506,cs),
+(153,506,o),
+(50,409,o),
+(50,252,cs),
+(50,98,o),
+(148,0,o),
+(319,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(242,134,o),
+(208,181,o),
+(208,253,cs),
+(208,325,o),
+(242,371,o),
+(303,371,cs),
+(364,371,o),
+(398,325,o),
+(398,253,cs),
+(398,182,o),
+(364,134,o),
+(303,134,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(767,560,l),
+(767,690,l),
+(63,690,l),
+(63,560,l)
+);
+}
+);
+width = 817;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159E;
+unicode = 5534;
+},
+{
+glyphname = "thWoodScree-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(441,344,l),
+(441,437,l),
+(285,437,l),
+(290,398,l),
+(310,409,o),
+(328,440,o),
+(328,480,cs),
+(328,556,o),
+(277,606,o),
+(191,606,cs),
+(107,606,o),
+(53,554,o),
+(53,474,cs),
+(53,397,o),
+(105,344,o),
+(196,344,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(167,422,o),
+(150,440,o),
+(150,474,cs),
+(150,510,o),
+(167,528,o),
+(191,528,cs),
+(215,528,o),
+(232,510,o),
+(232,474,cs),
+(232,440,o),
+(215,422,o),
+(191,422,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(437,639,l),
+(437,732,l),
+(58,732,l),
+(58,639,l)
+);
+}
+);
+width = 494;
+}
+);
+metricRight = "=|";
+note = uni159F;
+unicode = 5535;
+},
+{
+glyphname = "lhi-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (427,690);
+},
+{
+name = top_right_can;
+pos = (543,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(372,0,l),
+(372,140,l),
+(319,140,ls),
+(242,140,o),
+(200,176,o),
+(200,243,cs),
+(200,310,o),
+(240,349,o),
+(316,349,cs),
+(758,349,l),
+(758,475,l),
+(575,741,l),
+(459,662,l),
+(641,396,l),
+(634,492,l),
+(311,492,ls),
+(146,492,o),
+(42,400,o),
+(42,244,cs),
+(42,90,o),
+(146,0,o),
+(312,0,cs)
+);
+}
+);
+width = 799;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A0;
+unicode = 5536;
+},
+{
+glyphname = "lhii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "lhi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (333,0);
+ref = dot_top;
+}
+);
+width = 798;
+}
+);
+note = uni15A1;
+unicode = 5537;
+},
+{
+glyphname = "lho-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (397,510);
+},
+{
+name = top_right_can;
+pos = (502,510);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(340,-170,l),
+(156,96,l),
+(164,0,l),
+(485,0,ls),
+(654,0,o),
+(757,90,o),
+(757,246,cs),
+(757,404,o),
+(651,492,o),
+(491,492,cs),
+(427,492,l),
+(427,353,l),
+(480,353,ls),
+(558,353,o),
+(598,316,o),
+(598,248,cs),
+(598,182,o),
+(557,143,o),
+(483,143,cs),
+(41,143,l),
+(41,16,l),
+(223,-249,l)
+);
+}
+);
+width = 799;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni15A2;
+unicode = 5538;
+},
+{
+glyphname = "lhoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "lho-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (408,-180);
+ref = dot_top;
+}
+);
+width = 798;
+}
+);
+note = uni15A3;
+unicode = 5539;
+},
+{
+glyphname = "lha-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (402,510);
+},
+{
+name = top_left_can;
+pos = (298,510);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(758,16,l),
+(758,143,l),
+(316,143,ls),
+(239,143,o),
+(200,181,o),
+(200,247,cs),
+(200,316,o),
+(242,353,o),
+(315,353,cs),
+(372,353,l),
+(372,492,l),
+(309,492,ls),
+(145,492,o),
+(42,399,o),
+(42,245,cs),
+(42,89,o),
+(145,0,o),
+(311,0,cs),
+(634,0,l),
+(641,96,l),
+(459,-170,l),
+(575,-249,l)
+);
+}
+);
+width = 799;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A4;
+unicode = 5540;
+},
+{
+glyphname = "lhaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "lha-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (204,-180);
+ref = dot_top;
+}
+);
+width = 798;
+}
+);
+note = uni15A5;
+unicode = 5541;
+},
+{
+glyphname = "lh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(429,356,l),
+(429,446,l),
+(236,446,ls),
+(184,446,o),
+(156,470,o),
+(156,518,cs),
+(156,565,o),
+(184,592,o),
+(232,592,cs),
+(246,592,l),
+(246,690,l),
+(223,690,ls),
+(113,690,o),
+(46,621,o),
+(46,517,cs),
+(46,410,o),
+(113,345,o),
+(229,345,cs),
+(363,345,l),
+(355,408,l),
+(251,259,l),
+(326,208,l)
+);
+}
+);
+width = 475;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni15A6;
+unicode = 5542;
+},
+{
+glyphname = "theThCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (108,690);
+},
+{
+name = top_right_can;
+pos = (439,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(518,0,l),
+(518,74,l),
+(588,74,l),
+(588,159,l),
+(518,159,l),
+(518,353,l),
+(239,353,l),
+(238,276,l),
+(539,607,l),
+(431,701,l),
+(29,253,l),
+(29,213,l),
+(357,213,l),
+(357,159,l),
+(146,159,l),
+(146,74,l),
+(357,74,l),
+(357,0,l)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "ye-canadian";
+note = uni15A7;
+unicode = 5543;
+},
+{
+glyphname = "thiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (178,690);
+},
+{
+name = top_right_can;
+pos = (507,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(259,0,l),
+(259,74,l),
+(469,74,l),
+(469,159,l),
+(259,159,l),
+(259,213,l),
+(586,213,l),
+(586,253,l),
+(185,701,l),
+(79,608,l),
+(384,271,l),
+(381,353,l),
+(98,353,l),
+(98,159,l),
+(27,159,l),
+(27,74,l),
+(98,74,l),
+(98,0,l)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+unicode = 5544;
+},
+{
+glyphname = "thiiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (84,0);
+ref = dot_top;
+}
+);
+width = 615;
+}
+);
+note = uni15A9;
+unicode = 5545;
+},
+{
+glyphname = "thoThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (108,690);
+},
+{
+name = top_right_can;
+pos = (438,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(537,82,l),
+(237,412,l),
+(236,337,l),
+(518,337,l),
+(518,530,l),
+(588,530,l),
+(588,615,l),
+(518,615,l),
+(518,690,l),
+(357,690,l),
+(357,615,l),
+(146,615,l),
+(146,530,l),
+(357,530,l),
+(357,476,l),
+(29,476,l),
+(29,437,l),
+(431,-12,l)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+unicode = 5546;
+},
+{
+glyphname = "thooThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (344,0);
+ref = dot_top;
+}
+);
+width = 615;
+}
+);
+note = uni15AB;
+unicode = 5547;
+},
+{
+glyphname = "thaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (179,690);
+},
+{
+name = top_right_can;
+pos = (507,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(586,437,l),
+(586,476,l),
+(259,476,l),
+(259,530,l),
+(469,530,l),
+(469,615,l),
+(259,615,l),
+(259,690,l),
+(98,690,l),
+(98,615,l),
+(27,615,l),
+(27,530,l),
+(98,530,l),
+(98,337,l),
+(381,337,l),
+(380,412,l),
+(79,82,l),
+(185,-12,l)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+unicode = 5548;
+},
+{
+glyphname = "thaaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (85,0);
+ref = dot_top;
+}
+);
+width = 615;
+}
+);
+note = uni15AD;
+unicode = 5549;
+},
+{
+glyphname = "thThCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(338,555,l),
+(338,582,l),
+(186,582,l),
+(186,614,l),
+(279,614,l),
+(279,658,l),
+(186,658,l),
+(186,690,l),
+(77,690,l),
+(77,658,l),
+(41,658,l),
+(41,614,l),
+(77,614,l),
+(77,497,l),
+(237,497,l),
+(221,562,l),
+(75,393,l),
+(150,335,l)
+);
+}
+);
+width = 360;
+}
+);
+metricRight = "y-canadian";
+note = uni15AE;
+unicode = 5550;
+},
+{
+glyphname = "bAivilik-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(468,-14,o),
+(561,92,o),
+(561,248,cs),
+(561,397,o),
+(478,506,o),
+(342,506,cs),
+(273,506,o),
+(225,475,o),
+(213,442,c),
+(223,415,l),
+(223,690,l),
+(63,690,l),
+(63,0,l),
+(214,0,l),
+(214,74,l),
+(210,54,l),
+(225,19,o),
+(272,-14,o),
+(342,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(257,121,o),
+(222,162,o),
+(222,246,cs),
+(222,329,o),
+(259,371,o),
+(313,371,cs),
+(366,371,o),
+(404,329,o),
+(404,246,cs),
+(404,162,o),
+(369,121,o),
+(313,121,cs)
+);
+}
+);
+width = 603;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|ke-canadian";
+note = uni15AF;
+unicode = 5551;
+},
+{
+glyphname = "eBlackfoot-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(223,0,l),
+(223,399,l),
+(252,364,o),
+(297,342,o),
+(350,342,cs),
+(451,342,o),
+(519,419,o),
+(519,524,cs),
+(519,628,o),
+(451,704,o),
+(350,704,cs),
+(293,704,o),
+(244,679,o),
+(216,638,c),
+(216,690,l),
+(63,690,l),
+(63,0,l)
+);
+}
+);
+width = 555;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B0;
+unicode = 5552;
+},
+{
+glyphname = "iBlackfoot-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(263,-14,o),
+(311,11,o),
+(339,52,c),
+(339,0,l),
+(493,0,l),
+(493,690,l),
+(332,690,l),
+(332,291,l),
+(302,326,o),
+(258,348,o),
+(205,348,cs),
+(104,348,o),
+(36,270,o),
+(36,166,cs),
+(36,62,o),
+(104,-14,o),
+(205,-14,cs)
+);
+}
+);
+width = 556;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B1;
+unicode = 5553;
+},
+{
+glyphname = "oBlackfoot-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(451,-14,o),
+(519,62,o),
+(519,166,cs),
+(519,270,o),
+(451,348,o),
+(350,348,cs),
+(297,348,o),
+(252,326,o),
+(223,291,c),
+(223,690,l),
+(63,690,l),
+(63,0,l),
+(216,0,l),
+(216,52,l),
+(244,11,o),
+(293,-14,o),
+(350,-14,cs)
+);
+}
+);
+width = 555;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "eBlackfoot-canadian";
+note = uni15B2;
+unicode = 5554;
+},
+{
+glyphname = "aBlackfoot-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(493,0,l),
+(493,690,l),
+(339,690,l),
+(339,638,l),
+(311,679,o),
+(263,704,o),
+(205,704,cs),
+(104,704,o),
+(36,628,o),
+(36,524,cs),
+(36,419,o),
+(104,342,o),
+(205,342,cs),
+(258,342,o),
+(302,364,o),
+(332,399,c),
+(332,0,l)
+);
+}
+);
+width = 556;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B3;
+unicode = 5555;
+},
+{
+glyphname = "weBlackfoot-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(223,276,l),
+(546,276,l),
+(546,409,l),
+(223,409,l),
+(223,556,l),
+(546,556,l),
+(546,690,l),
+(63,690,l),
+(63,0,l),
+(223,0,l)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B4;
+unicode = 5556;
+},
+{
+glyphname = "wiBlackfoot-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(533,0,l),
+(533,690,l),
+(373,690,l),
+(373,413,l),
+(50,413,l),
+(50,281,l),
+(373,281,l),
+(373,133,l),
+(50,133,l),
+(50,0,l)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B5;
+unicode = 5557;
+},
+{
+glyphname = "woBlackfoot-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(546,0,l),
+(546,133,l),
+(223,133,l),
+(223,281,l),
+(546,281,l),
+(546,413,l),
+(223,413,l),
+(223,690,l),
+(63,690,l),
+(63,0,l)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "weBlackfoot-canadian";
+note = uni15B6;
+unicode = 5558;
+},
+{
+glyphname = "waBlackfoot-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(533,0,l),
+(533,690,l),
+(50,690,l),
+(50,556,l),
+(373,556,l),
+(373,409,l),
+(50,409,l),
+(50,276,l),
+(373,276,l),
+(373,0,l)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B7;
+unicode = 5559;
+},
+{
+glyphname = "neBlackfoot-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(223,0,l),
+(223,574,l),
+(274,574,l),
+(235,672,l),
+(235,651,ls),
+(235,485,o),
+(326,384,o),
+(481,384,cs),
+(630,384,o),
+(730,484,o),
+(730,645,cs),
+(730,690,l),
+(574,690,l),
+(574,637,ls),
+(574,562,o),
+(539,520,o),
+(482,520,cs),
+(425,520,o),
+(391,562,o),
+(391,637,cs),
+(391,690,l),
+(63,690,l),
+(63,0,l)
+);
+}
+);
+width = 758;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B8;
+unicode = 5560;
+},
+{
+glyphname = "niBlackfoot-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(185,0,l),
+(185,53,ls),
+(185,128,o),
+(219,170,o),
+(276,170,cs),
+(333,170,o),
+(367,128,o),
+(367,53,cs),
+(367,0,l),
+(696,0,l),
+(696,690,l),
+(536,690,l),
+(536,116,l),
+(485,116,l),
+(525,17,l),
+(525,39,ls),
+(525,205,o),
+(434,306,o),
+(278,306,cs),
+(128,306,o),
+(28,206,o),
+(28,44,cs),
+(28,0,l)
+);
+}
+);
+width = 759;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B9;
+unicode = 5561;
+},
+{
+glyphname = "noBlackfoot-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(391,0,l),
+(391,53,ls),
+(391,128,o),
+(425,170,o),
+(482,170,cs),
+(539,170,o),
+(574,128,o),
+(574,53,cs),
+(574,0,l),
+(730,0,l),
+(730,44,ls),
+(730,206,o),
+(630,306,o),
+(481,306,cs),
+(326,306,o),
+(235,205,o),
+(235,39,cs),
+(235,17,l),
+(274,116,l),
+(223,116,l),
+(223,690,l),
+(63,690,l),
+(63,0,l)
+);
+}
+);
+width = 758;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "neBlackfoot-canadian";
+note = uni15BA;
+unicode = 5562;
+},
+{
+glyphname = "naBlackfoot-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(696,0,l),
+(696,690,l),
+(367,690,l),
+(367,637,ls),
+(367,562,o),
+(333,520,o),
+(276,520,cs),
+(219,520,o),
+(185,562,o),
+(185,637,cs),
+(185,690,l),
+(28,690,l),
+(28,645,ls),
+(28,484,o),
+(128,384,o),
+(278,384,cs),
+(434,384,o),
+(525,485,o),
+(525,651,cs),
+(525,672,l),
+(485,574,l),
+(536,574,l),
+(536,0,l)
+);
+}
+);
+width = 759;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BB;
+unicode = 5563;
+},
+{
+glyphname = "keBlackfoot-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(223,0,l),
+(223,504,l),
+(167,504,l),
+(309,249,l),
+(372,249,l),
+(615,690,l),
+(449,690,l),
+(296,411,l),
+(365,411,l),
+(212,690,l),
+(63,690,l),
+(63,0,l)
+);
+}
+);
+width = 623;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15BC;
+unicode = 5564;
+},
+{
+glyphname = "kiBlackfoot-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(174,0,l),
+(328,279,l),
+(258,279,l),
+(412,0,l),
+(561,0,l),
+(561,690,l),
+(401,690,l),
+(401,185,l),
+(457,185,l),
+(314,440,l),
+(251,440,l),
+(8,0,l)
+);
+}
+);
+width = 624;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BD;
+unicode = 5565;
+},
+{
+glyphname = "koBlackfoot-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(212,0,l),
+(365,279,l),
+(296,279,l),
+(449,0,l),
+(615,0,l),
+(372,440,l),
+(309,440,l),
+(167,185,l),
+(223,185,l),
+(223,690,l),
+(63,690,l),
+(63,0,l)
+);
+}
+);
+width = 623;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "keBlackfoot-canadian";
+note = uni15BE;
+unicode = 5566;
+},
+{
+glyphname = "kaBlackfoot-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(561,0,l),
+(561,690,l),
+(412,690,l),
+(258,411,l),
+(328,411,l),
+(174,690,l),
+(8,690,l),
+(251,249,l),
+(314,249,l),
+(457,504,l),
+(401,504,l),
+(401,0,l)
+);
+}
+);
+width = 624;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BF;
+unicode = 5567;
+},
+{
+color = 9;
+glyphname = "heSayisi-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_right_can;
+pos = (559,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(639,0,l),
+(639,690,l),
+(479,690,l),
+(479,369,l),
+(504,369,l),
+(496,575,o),
+(393,704,o),
+(257,704,cs),
+(117,704,o),
+(42,599,o),
+(42,436,cs),
+(42,402,o),
+(44,365,o),
+(52,328,c),
+(206,328,l),
+(200,362,o),
+(197,394,o),
+(197,419,cs),
+(197,517,o),
+(233,564,o),
+(292,564,cs),
+(390,564,o),
+(474,439,o),
+(478,0,c)
+);
+}
+);
+width = 702;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni15C0;
+unicode = 5568;
+},
+{
+color = 9;
+glyphname = "hiSayisi-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(223,0,l),
+(227,439,o),
+(310,564,o),
+(409,564,cs),
+(468,564,o),
+(503,517,o),
+(503,419,cs),
+(503,394,o),
+(500,362,o),
+(496,328,c),
+(648,328,l),
+(656,365,o),
+(659,402,o),
+(659,436,cs),
+(659,599,o),
+(583,704,o),
+(443,704,cs),
+(307,704,o),
+(206,575,o),
+(196,369,c),
+(221,369,l),
+(221,690,l),
+(63,690,l),
+(63,0,l)
+);
+}
+);
+width = 701;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C1;
+unicode = 5569;
+},
+{
+color = 9;
+glyphname = "hoSayisi-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (344,690);
+},
+{
+name = top_left_can;
+pos = (129,690);
+},
+{
+name = top_right_can;
+pos = (558,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(393,-14,o),
+(496,115,o),
+(504,321,c),
+(479,321,l),
+(479,0,l),
+(639,0,l),
+(639,690,l),
+(478,690,l),
+(474,251,o),
+(390,126,o),
+(292,126,cs),
+(233,126,o),
+(197,173,o),
+(197,270,cs),
+(197,296,o),
+(200,327,o),
+(206,361,c),
+(52,361,l),
+(44,325,o),
+(42,288,o),
+(42,254,cs),
+(42,91,o),
+(117,-14,o),
+(257,-14,cs)
+);
+}
+);
+width = 702;
+}
+);
+metricLeft = "heSayisi-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15C2;
+unicode = 5570;
+},
+{
+color = 9;
+glyphname = "haSayisi-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(583,-14,o),
+(659,91,o),
+(659,254,cs),
+(659,288,o),
+(656,325,o),
+(648,361,c),
+(496,361,l),
+(500,327,o),
+(503,296,o),
+(503,270,cs),
+(503,173,o),
+(468,126,o),
+(409,126,cs),
+(310,126,o),
+(227,251,o),
+(223,690,c),
+(63,690,l),
+(63,0,l),
+(221,0,l),
+(221,321,l),
+(196,321,l),
+(206,115,o),
+(307,-14,o),
+(443,-14,cs)
+);
+}
+);
+width = 701;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C3;
+unicode = 5571;
+},
+{
+color = 9;
+glyphname = "ghuCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(388,0,l),
+(706,651,l),
+(706,690,l),
+(573,690,l),
+(486,510,l),
+(567,530,l),
+(168,530,l),
+(251,507,l),
+(164,690,l),
+(24,690,l),
+(24,651,l),
+(341,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(521,411,l),
+(457,428,l),
+(336,179,l),
+(400,179,l),
+(280,432,l),
+(218,411,l)
+);
+}
+);
+width = 730;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C4;
+unicode = 5572;
+},
+{
+color = 9;
+glyphname = "ghoCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(164,0,l),
+(251,183,l),
+(168,159,l),
+(567,159,l),
+(486,180,l),
+(573,0,l),
+(706,0,l),
+(706,39,l),
+(388,690,l),
+(341,690,l),
+(24,39,l),
+(24,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(400,511,l),
+(336,511,l),
+(457,262,l),
+(521,279,l),
+(218,279,l),
+(280,258,l)
+);
+}
+);
+width = 730;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C5;
+unicode = 5573;
+},
+{
+color = 9;
+glyphname = "gheCarrier-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (74,345);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(79,0,l),
+(617,321,l),
+(617,369,l),
+(79,690,l),
+(42,690,l),
+(42,559,l),
+(179,476,l),
+(173,524,l),
+(173,146,l),
+(179,215,l),
+(42,133,l),
+(42,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(291,496,l),
+(267,439,l),
+(480,309,l),
+(481,383,l),
+(267,254,l),
+(291,196,l)
+);
+}
+);
+width = 645;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15C6;
+unicode = 5574;
+},
+{
+color = 9;
+glyphname = "gheeCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (23,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 645;
+}
+);
+note = uni15C7;
+unicode = 5575;
+},
+{
+color = 9;
+glyphname = "ghiCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (-3,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 645;
+}
+);
+note = uni15C8;
+unicode = 5576;
+},
+{
+color = 9;
+glyphname = "ghaCarrier-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(604,0,l),
+(604,130,l),
+(477,209,l),
+(484,152,l),
+(484,538,l),
+(477,481,l),
+(604,557,l),
+(604,690,l),
+(565,690,l),
+(28,369,l),
+(28,321,l),
+(565,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(389,247,l),
+(166,382,l),
+(166,308,l),
+(389,442,l),
+(366,490,l),
+(366,205,l)
+);
+}
+);
+width = 646;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15C9;
+unicode = 5577;
+},
+{
+color = 9;
+glyphname = "ruCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(388,0,l),
+(706,651,l),
+(706,690,l),
+(573,690,l),
+(536,614,l),
+(561,627,l),
+(170,627,l),
+(202,612,l),
+(165,690,l),
+(24,690,l),
+(24,651,l),
+(341,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(527,504,l),
+(506,535,l),
+(337,183,l),
+(401,182,l),
+(235,531,l),
+(203,504,l)
+);
+}
+);
+width = 730;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CA;
+unicode = 5578;
+},
+{
+color = 9;
+glyphname = "roCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(164,0,l),
+(200,75,l),
+(171,63,l),
+(561,63,l),
+(534,77,l),
+(572,0,l),
+(706,0,l),
+(706,39,l),
+(388,690,l),
+(341,690,l),
+(24,39,l),
+(24,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(396,513,l),
+(333,513,l),
+(502,158,l),
+(528,185,l),
+(204,185,l),
+(228,155,l)
+);
+}
+);
+width = 730;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CB;
+unicode = 5579;
+},
+{
+color = 9;
+glyphname = "reCarrier-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(79,0,l),
+(617,321,l),
+(617,369,l),
+(79,690,l),
+(42,690,l),
+(42,558,l),
+(114,514,l),
+(97,547,l),
+(97,142,l),
+(114,178,l),
+(42,133,l),
+(42,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(218,521,l),
+(203,470,l),
+(473,308,l),
+(473,382,l),
+(203,221,l),
+(218,168,l)
+);
+}
+);
+width = 645;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CC;
+unicode = 5580;
+},
+{
+color = 9;
+glyphname = "reeCarrier-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(79,0,l),
+(617,321,l),
+(617,369,l),
+(79,690,l),
+(42,690,l),
+(42,577,l),
+(114,531,l),
+(97,558,l),
+(97,126,l),
+(114,156,l),
+(42,113,l),
+(42,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(202,531,l),
+(188,498,l),
+(511,309,l),
+(511,382,l),
+(187,190,l),
+(202,169,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(296,278,l),
+(296,412,l),
+(235,412,l),
+(235,278,l)
+);
+}
+);
+width = 645;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CD;
+unicode = 5581;
+},
+{
+color = 9;
+glyphname = "riCarrier-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(79,0,l),
+(617,321,l),
+(617,369,l),
+(79,690,l),
+(42,690,l),
+(42,577,l),
+(114,531,l),
+(97,558,l),
+(97,126,l),
+(114,156,l),
+(42,113,l),
+(42,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(307,294,o),
+(332,315,o),
+(332,345,cs),
+(332,375,o),
+(307,396,o),
+(280,396,cs),
+(253,396,o),
+(228,375,o),
+(228,345,cs),
+(228,315,o),
+(253,294,o),
+(280,294,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(202,531,l),
+(188,498,l),
+(511,309,l),
+(511,382,l),
+(187,190,l),
+(202,169,l)
+);
+}
+);
+width = 645;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CE;
+unicode = 5582;
+},
+{
+color = 9;
+glyphname = "raCarrier-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(604,0,l),
+(604,132,l),
+(539,173,l),
+(549,128,l),
+(549,561,l),
+(539,517,l),
+(604,557,l),
+(604,690,l),
+(565,690,l),
+(28,369,l),
+(28,321,l),
+(565,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(449,474,l),
+(426,522,l),
+(426,169,l),
+(449,217,l),
+(173,383,l),
+(173,309,l)
+);
+}
+);
+width = 646;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15CF;
+unicode = 5583;
+},
+{
+color = 9;
+glyphname = "wuCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(397,0,l),
+(723,651,l),
+(723,690,l),
+(598,690,l),
+(406,276,l),
+(440,276,l),
+(440,690,l),
+(317,690,l),
+(317,276,l),
+(353,276,l),
+(157,690,l),
+(24,690,l),
+(24,651,l),
+(350,0,l)
+);
+}
+);
+width = 747;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D0;
+unicode = 5584;
+},
+{
+color = 9;
+glyphname = "woCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(155,0,l),
+(348,413,l),
+(313,413,l),
+(313,0,l),
+(436,0,l),
+(436,413,l),
+(399,413,l),
+(595,0,l),
+(723,0,l),
+(723,39,l),
+(397,690,l),
+(350,690,l),
+(24,39,l),
+(24,0,l)
+);
+}
+);
+width = 747;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D1;
+unicode = 5585;
+},
+{
+color = 9;
+glyphname = "weCarrier-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,0,l),
+(638,321,l),
+(638,369,l),
+(99,690,l),
+(62,690,l),
+(62,560,l),
+(381,378,l),
+(381,405,l),
+(65,405,l),
+(65,285,l),
+(380,285,l),
+(380,312,l),
+(62,130,l),
+(62,0,l)
+);
+}
+);
+width = 666;
+}
+);
+metricRight = "o-canadian";
+note = uni15D2;
+unicode = 5586;
+},
+{
+color = 9;
+glyphname = "weeCarrier-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,0,l),
+(638,321,l),
+(638,369,l),
+(99,690,l),
+(62,690,l),
+(62,575,l),
+(442,356,l),
+(452,391,l),
+(210,391,l),
+(210,458,l),
+(127,458,l),
+(127,391,l),
+(62,391,l),
+(62,298,l),
+(127,298,l),
+(127,232,l),
+(210,232,l),
+(210,298,l),
+(452,298,l),
+(442,333,l),
+(62,115,l),
+(62,0,l)
+);
+}
+);
+width = 666;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D3;
+unicode = 5587;
+},
+{
+color = 9;
+glyphname = "wiCarrier-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,0,l),
+(638,321,l),
+(638,369,l),
+(99,690,l),
+(62,690,l),
+(62,575,l),
+(443,356,l),
+(453,391,l),
+(279,391,l),
+(265,420,o),
+(234,440,o),
+(198,440,cs),
+(162,440,o),
+(131,420,o),
+(116,391,c),
+(62,391,l),
+(62,298,l),
+(116,298,l),
+(132,270,o),
+(162,250,o),
+(198,250,cs),
+(233,250,o),
+(263,270,o),
+(278,298,c),
+(453,298,l),
+(443,333,l),
+(62,115,l),
+(62,0,l)
+);
+}
+);
+width = 666;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D4;
+unicode = 5588;
+},
+{
+color = 9;
+glyphname = "waCarrier-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(604,0,l),
+(604,129,l),
+(285,312,l),
+(285,285,l),
+(600,285,l),
+(600,405,l),
+(286,405,l),
+(286,378,l),
+(604,559,l),
+(604,690,l),
+(566,690,l),
+(28,369,l),
+(28,321,l),
+(565,0,l)
+);
+}
+);
+width = 666;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15D5;
+unicode = 5589;
+},
+{
+color = 9;
+glyphname = "hwuCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(397,0,l),
+(723,651,l),
+(723,690,l),
+(606,690,l),
+(529,532,l),
+(578,552,l),
+(424,552,l),
+(424,690,l),
+(327,690,l),
+(327,552,l),
+(171,552,l),
+(222,534,l),
+(146,690,l),
+(24,690,l),
+(24,651,l),
+(350,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(336,469,l),
+(336,201,l),
+(366,208,l),
+(238,487,l),
+(204,469,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(414,469,l),
+(547,469,l),
+(517,486,l),
+(384,205,l),
+(414,198,l)
+);
+}
+);
+width = 747;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D6;
+unicode = 5590;
+},
+{
+color = 9;
+glyphname = "hwoCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(145,0,l),
+(223,156,l),
+(175,135,l),
+(327,135,l),
+(327,0,l),
+(424,0,l),
+(424,135,l),
+(583,135,l),
+(529,156,l),
+(606,0,l),
+(723,0,l),
+(723,39,l),
+(397,690,l),
+(350,690,l),
+(24,39,l),
+(24,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(352,452,l),
+(336,457,l),
+(336,224,l),
+(216,224,l),
+(237,203,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(542,224,l),
+(414,224,l),
+(414,460,l),
+(399,455,l),
+(516,204,l)
+);
+}
+);
+width = 747;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D7;
+unicode = 5591;
+},
+{
+color = 9;
+glyphname = "hweCarrier-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,0,l),
+(638,321,l),
+(638,369,l),
+(99,690,l),
+(62,690,l),
+(62,574,l),
+(189,500,l),
+(189,395,l),
+(62,395,l),
+(62,295,l),
+(189,295,l),
+(189,188,l),
+(62,115,l),
+(62,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(263,305,l),
+(419,305,l),
+(263,220,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(263,469,l),
+(417,384,l),
+(263,384,l)
+);
+}
+);
+width = 666;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D8;
+unicode = 5592;
+},
+{
+color = 9;
+glyphname = "hweeCarrier-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,0,l),
+(638,321,l),
+(638,369,l),
+(99,690,l),
+(62,690,l),
+(62,578,l),
+(229,483,l),
+(229,386,l),
+(182,386,l),
+(182,451,l),
+(115,451,l),
+(115,386,l),
+(62,386,l),
+(62,303,l),
+(115,303,l),
+(115,239,l),
+(182,239,l),
+(182,303,l),
+(229,303,l),
+(229,207,l),
+(62,112,l),
+(62,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(295,311,l),
+(427,311,l),
+(295,237,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(295,453,l),
+(427,379,l),
+(295,379,l)
+);
+}
+);
+width = 666;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D9;
+unicode = 5593;
+},
+{
+color = 9;
+glyphname = "hwiCarrier-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,0,l),
+(638,321,l),
+(638,369,l),
+(99,690,l),
+(62,690,l),
+(62,578,l),
+(229,483,l),
+(229,379,l),
+(214,379,l),
+(203,403,o),
+(180,419,o),
+(152,419,cs),
+(125,419,o),
+(100,403,o),
+(89,379,c),
+(62,379,l),
+(62,311,l),
+(89,311,l),
+(100,287,o),
+(125,270,o),
+(152,270,cs),
+(178,270,o),
+(202,287,o),
+(213,311,c),
+(229,311,l),
+(229,207,l),
+(62,112,l),
+(62,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(295,311,l),
+(427,311,l),
+(295,237,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(295,453,l),
+(427,379,l),
+(295,379,l)
+);
+}
+);
+width = 666;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15DA;
+unicode = 5594;
+},
+{
+color = 9;
+glyphname = "hwaCarrier-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(604,0,l),
+(604,115,l),
+(476,188,l),
+(476,295,l),
+(604,295,l),
+(604,395,l),
+(476,395,l),
+(476,500,l),
+(604,574,l),
+(604,690,l),
+(566,690,l),
+(28,369,l),
+(28,321,l),
+(565,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(246,305,l),
+(403,305,l),
+(403,220,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(403,469,l),
+(403,384,l),
+(247,384,l)
+);
+}
+);
+width = 666;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15DB;
+unicode = 5595;
+},
+{
+color = 9;
+glyphname = "thuCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(556,-14,o),
+(669,104,o),
+(669,309,cs),
+(669,690,l),
+(56,690,l),
+(56,308,ls),
+(56,102,o),
+(169,-14,o),
+(363,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(215,550,l),
+(510,550,l),
+(510,309,ls),
+(510,188,o),
+(459,130,o),
+(362,130,cs),
+(269,130,o),
+(215,192,o),
+(215,309,cs)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DC;
+unicode = 5596;
+},
+{
+color = 9;
+glyphname = "thoCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(669,0,l),
+(669,382,ls),
+(669,586,o),
+(556,704,o),
+(368,704,cs),
+(173,704,o),
+(56,586,o),
+(56,382,cs),
+(56,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(215,381,ls),
+(215,498,o),
+(271,559,o),
+(365,559,cs),
+(458,559,o),
+(510,497,o),
+(510,381,cs),
+(510,140,l),
+(215,140,l)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DD;
+unicode = 5597;
+},
+{
+color = 9;
+glyphname = "theCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (361,345);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(327,0,ls),
+(547,0,o),
+(675,125,o),
+(675,346,cs),
+(675,567,o),
+(547,690,o),
+(326,690,cs),
+(63,690,l),
+(63,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(223,589,l),
+(184,550,l),
+(319,550,ls),
+(445,550,o),
+(515,484,o),
+(515,346,cs),
+(515,209,o),
+(445,140,o),
+(319,140,cs),
+(184,140,l),
+(223,100,l)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "to-canadian";
+note = uni15DE;
+unicode = 5598;
+},
+{
+color = 9;
+glyphname = "theeCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (298,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 726;
+}
+);
+note = uni15DF;
+unicode = 5599;
+},
+{
+color = 9;
+glyphname = "thiCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (268,0);
+ref = dot_middle;
+}
+);
+width = 726;
+}
+);
+note = uni15E0;
+unicode = 5600;
+},
+{
+color = 9;
+glyphname = "thaCarrier-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(664,0,l),
+(664,690,l),
+(401,690,ls),
+(180,690,o),
+(50,565,o),
+(50,344,cs),
+(50,123,o),
+(180,0,o),
+(400,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(212,482,o),
+(280,550,o),
+(407,550,cs),
+(543,550,l),
+(503,589,l),
+(503,100,l),
+(543,140,l),
+(407,140,ls),
+(280,140,o),
+(212,207,o),
+(212,344,cs)
+);
+}
+);
+width = 727;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15E1;
+unicode = 5601;
+},
+{
+color = 9;
+glyphname = "ttuCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(556,-14,o),
+(669,104,o),
+(669,309,cs),
+(669,690,l),
+(623,690,l),
+(342,518,l),
+(384,518,l),
+(103,690,l),
+(56,690,l),
+(56,308,ls),
+(56,102,o),
+(169,-14,o),
+(363,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(269,130,o),
+(215,192,o),
+(215,309,cs),
+(215,562,l),
+(71,558,l),
+(350,386,l),
+(377,386,l),
+(657,558,l),
+(510,562,l),
+(510,309,ls),
+(510,188,o),
+(459,130,o),
+(362,130,cs)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E2;
+unicode = 5602;
+},
+{
+color = 9;
+glyphname = "ttoCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(102,0,l),
+(384,172,l),
+(341,172,l),
+(621,0,l),
+(669,0,l),
+(669,382,ls),
+(669,587,o),
+(556,704,o),
+(362,704,cs),
+(169,704,o),
+(56,585,o),
+(56,381,cs),
+(56,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(456,559,o),
+(510,497,o),
+(510,381,cs),
+(510,128,l),
+(655,131,l),
+(376,303,l),
+(349,303,l),
+(69,131,l),
+(215,128,l),
+(215,381,ls),
+(215,501,o),
+(266,559,o),
+(362,559,cs)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E3;
+unicode = 5603;
+},
+{
+color = 9;
+glyphname = "tteCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (411,345);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(336,0,ls),
+(556,0,o),
+(685,125,o),
+(685,346,cs),
+(685,567,o),
+(556,690,o),
+(335,690,cs),
+(55,690,l),
+(55,651,l),
+(178,327,l),
+(178,362,l),
+(55,39,l),
+(55,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(325,331,l),
+(325,355,l),
+(202,679,l),
+(200,550,l),
+(329,550,ls),
+(456,550,o),
+(526,484,o),
+(526,346,cs),
+(526,209,o),
+(456,140,o),
+(329,140,cs),
+(200,140,l),
+(202,7,l)
+);
+}
+);
+width = 735;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15E4;
+unicode = 5604;
+},
+{
+color = 9;
+glyphname = "tteeCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (359,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 736;
+}
+);
+note = uni15E5;
+unicode = 5605;
+},
+{
+color = 9;
+glyphname = "ttiCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (350,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 736;
+}
+);
+note = uni15E6;
+unicode = 5606;
+},
+{
+color = 9;
+glyphname = "ttaCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(681,0,l),
+(681,39,l),
+(558,363,l),
+(558,327,l),
+(681,651,l),
+(681,690,l),
+(401,690,ls),
+(180,690,o),
+(50,565,o),
+(50,344,cs),
+(50,123,o),
+(180,0,o),
+(400,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(536,140,l),
+(407,140,ls),
+(280,140,o),
+(210,207,o),
+(210,344,cs),
+(210,482,o),
+(280,550,o),
+(407,550,cs),
+(536,550,l),
+(534,683,l),
+(412,358,l),
+(412,334,l),
+(534,11,l)
+);
+}
+);
+width = 736;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tteCarrier-canadian";
+note = uni15E7;
+unicode = 5607;
+},
+{
+color = 9;
+glyphname = "puCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(556,-14,o),
+(669,104,o),
+(669,309,cs),
+(669,690,l),
+(509,690,l),
+(509,555,l),
+(216,555,l),
+(216,690,l),
+(56,690,l),
+(56,308,ls),
+(56,102,o),
+(169,-14,o),
+(363,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(269,130,o),
+(216,192,o),
+(216,309,cs),
+(216,414,l),
+(509,414,l),
+(509,309,ls),
+(509,188,o),
+(459,130,o),
+(362,130,cs)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E8;
+unicode = 5608;
+},
+{
+color = 9;
+glyphname = "poCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(216,0,l),
+(216,134,l),
+(509,134,l),
+(509,0,l),
+(669,0,l),
+(669,382,ls),
+(669,586,o),
+(557,704,o),
+(368,704,cs),
+(175,704,o),
+(56,586,o),
+(56,382,cs),
+(56,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(216,381,ls),
+(216,498,o),
+(271,559,o),
+(365,559,cs),
+(458,559,o),
+(509,497,o),
+(509,381,cs),
+(509,275,l),
+(216,275,l)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E9;
+unicode = 5609;
+},
+{
+color = 9;
+glyphname = "peCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (399,345);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(335,0,ls),
+(555,0,o),
+(684,125,o),
+(684,346,cs),
+(684,567,o),
+(555,690,o),
+(334,690,cs),
+(54,690,l),
+(54,550,l),
+(133,550,l),
+(133,140,l),
+(54,140,l),
+(54,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(292,589,l),
+(244,550,l),
+(328,550,ls),
+(455,550,o),
+(524,484,o),
+(524,346,cs),
+(524,209,o),
+(455,140,o),
+(328,140,cs),
+(244,140,l),
+(292,100,l)
+);
+}
+);
+width = 734;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15EA;
+unicode = 5610;
+},
+{
+color = 9;
+glyphname = "peeCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (348,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 735;
+}
+);
+note = uni15EB;
+unicode = 5611;
+},
+{
+color = 9;
+glyphname = "piCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (338,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 735;
+}
+);
+note = uni15EC;
+unicode = 5612;
+},
+{
+color = 9;
+glyphname = "paCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(681,0,l),
+(681,140,l),
+(602,140,l),
+(602,550,l),
+(681,550,l),
+(681,690,l),
+(401,690,ls),
+(180,690,o),
+(50,567,o),
+(50,346,cs),
+(50,125,o),
+(180,0,o),
+(400,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(491,140,l),
+(407,140,ls),
+(280,140,o),
+(212,209,o),
+(212,346,cs),
+(212,484,o),
+(280,550,o),
+(407,550,cs),
+(491,550,l),
+(442,589,l),
+(442,100,l)
+);
+}
+);
+width = 735;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|peCarrier-canadian";
+note = uni15ED;
+unicode = 5613;
+},
+{
+color = 6;
+glyphname = "pCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(378,183,l),
+(378,286,l),
+(270,286,l),
+(270,527,l),
+(161,527,l),
+(161,286,l),
+(53,286,l),
+(53,183,l)
+);
+}
+);
+width = 431;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni15EE;
+unicode = 5614;
+},
+{
+color = 9;
+glyphname = "guCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (427,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(368,-14,o),
+(433,34,o),
+(464,128,c),
+(390,128,l),
+(428,30,o),
+(492,-14,o),
+(583,-14,cs),
+(717,-14,o),
+(794,74,o),
+(794,218,cs),
+(794,690,l),
+(641,690,l),
+(641,219,ls),
+(641,158,o),
+(618,127,o),
+(574,127,cs),
+(529,127,o),
+(503,159,o),
+(503,216,cs),
+(503,690,l),
+(353,690,l),
+(353,216,ls),
+(353,158,o),
+(327,127,o),
+(283,127,cs),
+(237,127,o),
+(212,158,o),
+(212,219,cs),
+(212,690,l),
+(59,690,l),
+(59,218,ls),
+(59,73,o),
+(142,-14,o),
+(271,-14,cs)
+);
+}
+);
+width = 853;
+}
+);
+metricRight = "=|";
+note = uni15EF;
+unicode = 5615;
+},
+{
+color = 9;
+glyphname = "goCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(212,0,l),
+(212,470,ls),
+(212,531,o),
+(235,563,o),
+(279,563,cs),
+(325,563,o),
+(350,531,o),
+(350,473,cs),
+(350,0,l),
+(501,0,l),
+(501,473,ls),
+(501,530,o),
+(526,563,o),
+(570,563,cs),
+(616,563,o),
+(641,531,o),
+(641,470,cs),
+(641,0,l),
+(794,0,l),
+(794,471,ls),
+(794,616,o),
+(711,704,o),
+(582,704,cs),
+(486,704,o),
+(421,656,o),
+(390,562,c),
+(463,562,l),
+(426,660,o),
+(362,704,o),
+(270,704,cs),
+(136,704,o),
+(59,615,o),
+(59,471,cs),
+(59,0,l)
+);
+}
+);
+width = 853;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F0;
+unicode = 5616;
+},
+{
+color = 9;
+glyphname = "geCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (369,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(450,0,ls),
+(599,0,o),
+(675,70,o),
+(675,195,cs),
+(675,275,o),
+(626,341,o),
+(549,372,c),
+(549,317,l),
+(629,344,o),
+(675,405,o),
+(675,493,cs),
+(675,616,o),
+(596,690,o),
+(450,690,cs),
+(63,690,l),
+(63,560,l),
+(421,560,ls),
+(484,560,o),
+(515,535,o),
+(515,486,cs),
+(515,435,o),
+(483,410,o),
+(422,410,cs),
+(63,410,l),
+(63,282,l),
+(422,282,ls),
+(482,282,o),
+(515,257,o),
+(515,204,cs),
+(515,155,o),
+(483,129,o),
+(421,129,cs),
+(63,129,l),
+(63,0,l)
+);
+}
+);
+width = 734;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15F1;
+unicode = 5617;
+},
+{
+color = 9;
+glyphname = "geeCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(450,0,ls),
+(599,0,o),
+(675,70,o),
+(675,195,cs),
+(675,275,o),
+(626,341,o),
+(549,372,c),
+(549,317,l),
+(629,344,o),
+(675,405,o),
+(675,493,cs),
+(675,616,o),
+(596,690,o),
+(450,690,cs),
+(63,690,l),
+(63,560,l),
+(421,560,ls),
+(484,560,o),
+(515,535,o),
+(515,486,cs),
+(515,435,o),
+(483,408,o),
+(422,408,cs),
+(350,408,l),
+(350,484,l),
+(261,484,l),
+(261,408,l),
+(63,408,l),
+(63,283,l),
+(261,283,l),
+(261,207,l),
+(350,207,l),
+(350,283,l),
+(422,283,ls),
+(482,283,o),
+(515,257,o),
+(515,204,cs),
+(515,155,o),
+(483,129,o),
+(421,129,cs),
+(63,129,l),
+(63,0,l)
+);
+}
+);
+width = 734;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F2;
+unicode = 5618;
+},
+{
+color = 9;
+glyphname = "giCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(450,0,ls),
+(599,0,o),
+(675,70,o),
+(675,195,cs),
+(675,270,o),
+(633,330,o),
+(567,362,c),
+(566,325,l),
+(636,354,o),
+(675,411,o),
+(675,493,cs),
+(675,616,o),
+(596,690,o),
+(450,690,cs),
+(63,690,l),
+(63,560,l),
+(421,560,ls),
+(484,560,o),
+(515,535,o),
+(515,486,cs),
+(515,435,o),
+(483,408,o),
+(428,408,cs),
+(369,408,l),
+(419,386,l),
+(405,429,o),
+(365,459,o),
+(316,459,cs),
+(276,459,o),
+(242,439,o),
+(222,408,c),
+(63,408,l),
+(63,283,l),
+(222,283,l),
+(242,252,o),
+(276,232,o),
+(316,232,cs),
+(365,232,o),
+(404,263,o),
+(420,305,c),
+(369,283,l),
+(428,283,ls),
+(482,283,o),
+(515,257,o),
+(515,204,cs),
+(515,155,o),
+(483,129,o),
+(421,129,cs),
+(63,129,l),
+(63,0,l)
+);
+}
+);
+width = 734;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F3;
+unicode = 5619;
+},
+{
+color = 9;
+glyphname = "gaCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (383,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(671,0,l),
+(671,129,l),
+(312,129,ls),
+(250,129,o),
+(219,155,o),
+(219,204,cs),
+(219,257,o),
+(252,282,o),
+(311,282,cs),
+(671,282,l),
+(671,410,l),
+(311,410,ls),
+(251,410,o),
+(219,435,o),
+(219,486,cs),
+(219,535,o),
+(250,560,o),
+(312,560,cs),
+(671,560,l),
+(671,690,l),
+(284,690,ls),
+(138,690,o),
+(59,616,o),
+(59,493,cs),
+(59,405,o),
+(105,345,o),
+(185,319,c),
+(185,373,l),
+(108,342,o),
+(59,275,o),
+(59,195,cs),
+(59,70,o),
+(134,0,o),
+(284,0,cs)
+);
+}
+);
+width = 734;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|geCarrier-canadian";
+note = uni15F4;
+unicode = 5620;
+},
+{
+color = 9;
+glyphname = "khuCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(368,-14,o),
+(433,34,o),
+(464,128,c),
+(390,128,l),
+(428,30,o),
+(492,-14,o),
+(583,-14,cs),
+(717,-14,o),
+(794,74,o),
+(794,218,cs),
+(794,690,l),
+(59,690,l),
+(59,218,ls),
+(59,73,o),
+(142,-14,o),
+(271,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(238,127,o),
+(213,158,o),
+(213,219,cs),
+(213,554,l),
+(353,554,l),
+(353,216,ls),
+(353,158,o),
+(328,127,o),
+(284,127,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(528,127,o),
+(503,159,o),
+(503,216,cs),
+(503,554,l),
+(640,554,l),
+(640,219,ls),
+(640,158,o),
+(618,127,o),
+(573,127,cs)
+);
+}
+);
+width = 853;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F5;
+unicode = 5621;
+},
+{
+color = 9;
+glyphname = "khoCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(794,0,l),
+(794,471,ls),
+(794,614,o),
+(716,704,o),
+(583,704,cs),
+(491,704,o),
+(426,659,o),
+(390,562,c),
+(464,562,l),
+(431,656,o),
+(366,704,o),
+(270,704,cs),
+(141,704,o),
+(59,617,o),
+(59,471,cs),
+(59,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(213,470,ls),
+(213,531,o),
+(238,563,o),
+(283,563,cs),
+(327,563,o),
+(353,531,o),
+(353,473,cs),
+(353,136,l),
+(213,136,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(502,473,ls),
+(502,530,o),
+(527,563,o),
+(573,563,cs),
+(618,563,o),
+(640,531,o),
+(640,470,cs),
+(640,136,l),
+(502,136,l)
+);
+}
+);
+width = 853;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F6;
+unicode = 5622;
+},
+{
+color = 9;
+glyphname = "kheCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(458,0,ls),
+(607,0,o),
+(683,70,o),
+(683,195,cs),
+(683,275,o),
+(634,341,o),
+(556,372,c),
+(556,317,l),
+(637,344,o),
+(683,405,o),
+(683,493,cs),
+(683,616,o),
+(604,690,o),
+(458,690,cs),
+(63,690,l),
+(63,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(222,283,l),
+(430,283,ls),
+(490,283,o),
+(523,257,o),
+(523,204,cs),
+(523,155,o),
+(491,128,o),
+(429,128,cs),
+(222,128,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(222,562,l),
+(429,562,ls),
+(492,562,o),
+(523,535,o),
+(523,486,cs),
+(523,435,o),
+(491,409,o),
+(430,409,cs),
+(222,409,l)
+);
+}
+);
+width = 742;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F7;
+unicode = 5623;
+},
+{
+color = 9;
+glyphname = "kheeCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(458,0,ls),
+(607,0,o),
+(683,70,o),
+(683,195,cs),
+(683,273,o),
+(637,336,o),
+(563,368,c),
+(563,321,l),
+(639,348,o),
+(683,408,o),
+(683,493,cs),
+(683,616,o),
+(604,690,o),
+(458,690,cs),
+(63,690,l),
+(63,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(222,284,l),
+(315,284,l),
+(315,206,l),
+(414,206,l),
+(414,323,l),
+(371,284,l),
+(436,284,ls),
+(493,284,o),
+(523,258,o),
+(523,205,cs),
+(523,155,o),
+(491,128,o),
+(429,128,cs),
+(222,128,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(414,485,l),
+(315,485,l),
+(315,407,l),
+(222,407,l),
+(222,562,l),
+(429,562,ls),
+(492,562,o),
+(523,535,o),
+(523,486,cs),
+(523,433,o),
+(494,407,o),
+(436,407,cs),
+(371,407,l),
+(414,369,l)
+);
+}
+);
+width = 742;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F8;
+unicode = 5624;
+},
+{
+color = 9;
+glyphname = "khiCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(458,0,ls),
+(607,0,o),
+(683,70,o),
+(683,195,cs),
+(683,273,o),
+(636,337,o),
+(564,369,c),
+(562,320,l),
+(639,347,o),
+(683,407,o),
+(683,493,cs),
+(683,616,o),
+(604,690,o),
+(458,690,cs),
+(63,690,l),
+(63,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(222,287,l),
+(268,287,l),
+(287,254,o),
+(322,232,o),
+(363,232,cs),
+(422,232,o),
+(466,277,o),
+(472,332,c),
+(384,287,l),
+(439,287,ls),
+(493,287,o),
+(523,260,o),
+(523,206,cs),
+(523,154,o),
+(491,128,o),
+(429,128,cs),
+(222,128,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(429,562,ls),
+(492,562,o),
+(523,536,o),
+(523,484,cs),
+(523,431,o),
+(494,404,o),
+(439,404,cs),
+(385,404,l),
+(473,358,l),
+(466,415,o),
+(422,459,o),
+(363,459,cs),
+(305,459,o),
+(259,415,o),
+(252,358,c),
+(303,404,l),
+(222,404,l),
+(222,562,l)
+);
+}
+);
+width = 742;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F9;
+unicode = 5625;
+},
+{
+color = 9;
+glyphname = "khaCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(679,0,l),
+(679,690,l),
+(284,690,ls),
+(138,690,o),
+(59,616,o),
+(59,493,cs),
+(59,407,o),
+(102,348,o),
+(180,322,c),
+(177,371,l),
+(105,338,o),
+(59,273,o),
+(59,195,cs),
+(59,70,o),
+(134,0,o),
+(284,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(250,128,o),
+(219,155,o),
+(219,204,cs),
+(219,257,o),
+(252,283,o),
+(311,283,cs),
+(520,283,l),
+(520,128,l),
+(312,128,ls)
+);
+},
+{
+closed = 1;
+nodes = (
+(251,409,o),
+(219,435,o),
+(219,486,cs),
+(219,535,o),
+(250,562,o),
+(312,562,cs),
+(520,562,l),
+(520,409,l),
+(311,409,ls)
+);
+}
+);
+width = 742;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15FA;
+unicode = 5626;
+},
+{
+color = 9;
+glyphname = "kkuCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(368,-14,o),
+(434,35,o),
+(464,130,c),
+(390,130,l),
+(427,31,o),
+(491,-14,o),
+(583,-14,cs),
+(717,-14,o),
+(794,74,o),
+(794,218,cs),
+(794,690,l),
+(749,690,l),
+(477,553,l),
+(477,405,l),
+(742,534,l),
+(641,544,l),
+(641,219,ls),
+(641,158,o),
+(618,127,o),
+(574,127,cs),
+(528,127,o),
+(502,159,o),
+(502,216,cs),
+(502,690,l),
+(353,690,l),
+(353,216,ls),
+(353,158,o),
+(328,127,o),
+(283,127,cs),
+(238,127,o),
+(212,158,o),
+(212,219,cs),
+(212,544,l),
+(113,533,l),
+(376,406,l),
+(376,554,l),
+(106,690,l),
+(59,690,l),
+(59,218,ls),
+(59,73,o),
+(142,-14,o),
+(271,-14,cs)
+);
+}
+);
+width = 853;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FB;
+unicode = 5627;
+},
+{
+color = 9;
+glyphname = "kkoCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(104,0,l),
+(376,137,l),
+(376,285,l),
+(111,156,l),
+(212,146,l),
+(212,470,ls),
+(212,531,o),
+(235,563,o),
+(279,563,cs),
+(325,563,o),
+(350,530,o),
+(350,473,cs),
+(350,0,l),
+(500,0,l),
+(500,473,ls),
+(500,531,o),
+(525,563,o),
+(569,563,cs),
+(615,563,o),
+(641,531,o),
+(641,470,cs),
+(641,146,l),
+(740,156,l),
+(476,284,l),
+(476,136,l),
+(747,0,l),
+(794,0,l),
+(794,471,ls),
+(794,616,o),
+(711,704,o),
+(582,704,cs),
+(485,704,o),
+(419,655,o),
+(389,559,c),
+(463,559,l),
+(426,659,o),
+(362,704,o),
+(270,704,cs),
+(136,704,o),
+(59,615,o),
+(59,471,cs),
+(59,0,l)
+);
+}
+);
+width = 853;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FC;
+unicode = 5628;
+},
+{
+color = 9;
+glyphname = "kkeCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(471,0,ls),
+(621,0,o),
+(697,70,o),
+(697,195,cs),
+(697,273,o),
+(650,337,o),
+(579,369,c),
+(577,320,l),
+(653,347,o),
+(697,407,o),
+(697,493,cs),
+(697,616,o),
+(617,690,o),
+(471,690,cs),
+(58,690,l),
+(58,651,l),
+(150,410,l),
+(77,410,l),
+(77,282,l),
+(150,282,l),
+(58,39,l),
+(58,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(311,282,l),
+(444,282,ls),
+(503,282,o),
+(537,257,o),
+(537,204,cs),
+(537,155,o),
+(505,129,o),
+(443,129,cs),
+(182,129,l),
+(227,62,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(226,628,l),
+(180,560,l),
+(443,560,ls),
+(505,560,o),
+(537,535,o),
+(537,486,cs),
+(537,435,o),
+(504,410,o),
+(444,410,cs),
+(309,410,l)
+);
+}
+);
+width = 756;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni15FD;
+unicode = 5629;
+},
+{
+color = 9;
+glyphname = "kkeeCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(471,0,ls),
+(621,0,o),
+(697,70,o),
+(697,195,cs),
+(697,273,o),
+(650,337,o),
+(579,369,c),
+(577,320,l),
+(653,347,o),
+(697,407,o),
+(697,493,cs),
+(697,616,o),
+(617,690,o),
+(471,690,cs),
+(58,690,l),
+(58,651,l),
+(150,410,l),
+(77,410,l),
+(77,282,l),
+(150,282,l),
+(58,39,l),
+(58,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(310,286,l),
+(351,286,l),
+(351,207,l),
+(450,207,l),
+(450,311,l),
+(414,286,l),
+(455,286,ls),
+(506,286,o),
+(537,260,o),
+(537,206,cs),
+(537,156,o),
+(505,129,o),
+(443,129,cs),
+(180,129,l),
+(227,62,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(450,484,l),
+(351,484,l),
+(351,406,l),
+(308,406,l),
+(225,628,l),
+(179,560,l),
+(443,560,ls),
+(505,560,o),
+(537,535,o),
+(537,484,cs),
+(537,431,o),
+(507,406,o),
+(455,406,cs),
+(414,406,l),
+(450,384,l)
+);
+}
+);
+width = 756;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FE;
+unicode = 5630;
+},
+{
+color = 9;
+glyphname = "kkiCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(471,0,ls),
+(621,0,o),
+(697,70,o),
+(697,195,cs),
+(697,273,o),
+(650,337,o),
+(579,369,c),
+(577,320,l),
+(653,347,o),
+(697,407,o),
+(697,493,cs),
+(697,616,o),
+(617,690,o),
+(471,690,cs),
+(58,690,l),
+(58,651,l),
+(150,410,l),
+(77,410,l),
+(77,282,l),
+(150,282,l),
+(58,39,l),
+(58,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(311,289,l),
+(303,289,l),
+(322,254,o),
+(356,232,o),
+(399,232,cs),
+(458,232,o),
+(500,278,o),
+(505,329,c),
+(430,289,l),
+(455,289,ls),
+(506,289,o),
+(537,260,o),
+(537,204,cs),
+(537,156,o),
+(505,129,o),
+(443,129,cs),
+(180,129,l),
+(227,62,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(500,414,o),
+(459,459,o),
+(399,459,cs),
+(357,459,o),
+(323,437,o),
+(304,403,c),
+(309,403,l),
+(225,628,l),
+(179,560,l),
+(443,560,ls),
+(505,560,o),
+(537,535,o),
+(537,482,cs),
+(537,431,o),
+(507,403,o),
+(455,403,cs),
+(431,403,l),
+(507,361,l)
+);
+}
+);
+width = 756;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FF;
+unicode = 5631;
+},
+{
+color = 9;
+glyphname = "kkaCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(697,0,l),
+(697,39,l),
+(606,282,l),
+(676,282,l),
+(676,410,l),
+(606,410,l),
+(697,651,l),
+(697,690,l),
+(284,690,ls),
+(138,690,o),
+(59,616,o),
+(59,493,cs),
+(59,407,o),
+(102,348,o),
+(180,322,c),
+(177,371,l),
+(105,338,o),
+(59,273,o),
+(59,195,cs),
+(59,70,o),
+(134,0,o),
+(284,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(576,129,l),
+(312,129,ls),
+(250,129,o),
+(219,155,o),
+(219,204,cs),
+(219,257,o),
+(252,282,o),
+(311,282,cs),
+(445,282,l),
+(529,62,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(251,410,o),
+(219,435,o),
+(219,486,cs),
+(219,535,o),
+(250,560,o),
+(312,560,cs),
+(575,560,l),
+(528,628,l),
+(445,410,l),
+(311,410,ls)
+);
+}
+);
+width = 755;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|kkeCarrier-canadian";
+note = uni1600;
+unicode = 5632;
+},
+{
+color = 6;
+glyphname = "kkCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(217,183,l),
+(376,508,l),
+(376,527,l),
+(270,527,l),
+(164,299,l),
+(247,299,l),
+(143,527,l),
+(35,527,l),
+(35,508,l),
+(193,183,l)
+);
+}
+);
+width = 411;
+}
+);
+note = uni1601;
+unicode = 5633;
+},
+{
+color = 9;
+glyphname = "nuCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(563,-14,o),
+(669,100,o),
+(669,286,cs),
+(669,313,l),
+(511,313,l),
+(511,281,ls),
+(511,182,o),
+(459,130,o),
+(369,130,cs),
+(265,130,o),
+(216,187,o),
+(216,311,cs),
+(216,690,l),
+(56,690,l),
+(56,307,ls),
+(56,97,o),
+(167,-14,o),
+(365,-14,cs)
+);
+}
+);
+width = 716;
+}
+);
+metricLeft = "te-canadian";
+note = uni1602;
+unicode = 5634;
+},
+{
+color = 9;
+glyphname = "noCarrier-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(661,0,l),
+(661,383,ls),
+(661,593,o),
+(549,704,o),
+(351,704,cs),
+(154,704,o),
+(47,589,o),
+(47,404,cs),
+(47,377,l),
+(206,377,l),
+(206,409,ls),
+(206,508,o),
+(258,559,o),
+(348,559,cs),
+(452,559,o),
+(500,502,o),
+(500,379,cs),
+(500,0,l)
+);
+}
+);
+width = 717;
+}
+);
+metricLeft = "=|nuCarrier-canadian";
+metricRight = "te-canadian";
+note = uni1603;
+unicode = 5635;
+},
+{
+color = 9;
+glyphname = "neCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (350,344);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(331,0,ls),
+(551,0,o),
+(680,125,o),
+(680,346,cs),
+(680,567,o),
+(551,690,o),
+(329,690,cs),
+(41,690,l),
+(41,546,l),
+(324,546,ls),
+(447,546,o),
+(521,480,o),
+(521,345,cs),
+(521,209,o),
+(447,142,o),
+(325,142,cs),
+(305,142,l),
+(305,0,l)
+);
+}
+);
+width = 730;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1604;
+unicode = 5636;
+},
+{
+color = 9;
+glyphname = "neeCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+ref = "neCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (286,-1);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 730;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1605;
+unicode = 5637;
+},
+{
+color = 9;
+glyphname = "niCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "neCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (256,-1);
+ref = dot_middle;
+}
+);
+width = 730;
+}
+);
+note = uni1606;
+unicode = 5638;
+},
+{
+color = 9;
+glyphname = "naCarrier-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(690,0,l),
+(690,144,l),
+(407,144,ls),
+(283,144,o),
+(210,210,o),
+(210,345,cs),
+(210,481,o),
+(283,548,o),
+(406,548,cs),
+(425,548,l),
+(425,690,l),
+(399,690,ls),
+(180,690,o),
+(50,565,o),
+(50,344,cs),
+(50,123,o),
+(180,0,o),
+(400,0,cs)
+);
+}
+);
+width = 731;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni1607;
+unicode = 5639;
+},
+{
+color = 9;
+glyphname = "muCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(368,-14,o),
+(433,34,o),
+(464,128,c),
+(390,128,l),
+(428,30,o),
+(492,-14,o),
+(583,-14,cs),
+(717,-14,o),
+(794,74,o),
+(794,218,cs),
+(794,395,l),
+(641,395,l),
+(641,219,ls),
+(641,158,o),
+(618,127,o),
+(574,127,cs),
+(529,127,o),
+(503,159,o),
+(503,216,cs),
+(503,395,l),
+(353,395,l),
+(353,216,ls),
+(353,158,o),
+(327,127,o),
+(283,127,cs),
+(237,127,o),
+(212,158,o),
+(212,219,cs),
+(212,690,l),
+(59,690,l),
+(59,218,ls),
+(59,73,o),
+(142,-14,o),
+(271,-14,cs)
+);
+}
+);
+width = 853;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "=|";
+note = uni1608;
+unicode = 5640;
+},
+{
+color = 9;
+glyphname = "moCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(794,0,l),
+(794,471,ls),
+(794,616,o),
+(711,704,o),
+(582,704,cs),
+(486,704,o),
+(421,656,o),
+(390,562,c),
+(463,562,l),
+(426,660,o),
+(362,704,o),
+(270,704,cs),
+(136,704,o),
+(59,615,o),
+(59,471,cs),
+(59,295,l),
+(212,295,l),
+(212,470,ls),
+(212,531,o),
+(235,563,o),
+(279,563,cs),
+(325,563,o),
+(350,530,o),
+(350,473,cs),
+(350,295,l),
+(501,295,l),
+(501,473,ls),
+(501,530,o),
+(526,563,o),
+(570,563,cs),
+(616,563,o),
+(641,531,o),
+(641,470,cs),
+(641,0,l)
+);
+}
+);
+width = 853;
+}
+);
+metricLeft = "=|muCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni1609;
+unicode = 5641;
+},
+{
+color = 9;
+glyphname = "meCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(454,0,ls),
+(604,0,o),
+(680,70,o),
+(680,195,cs),
+(680,275,o),
+(630,341,o),
+(553,372,c),
+(553,317,l),
+(633,344,o),
+(680,405,o),
+(680,493,cs),
+(680,616,o),
+(600,690,o),
+(454,690,cs),
+(41,690,l),
+(41,560,l),
+(426,560,ls),
+(488,560,o),
+(520,535,o),
+(520,486,cs),
+(520,435,o),
+(487,410,o),
+(427,410,cs),
+(287,410,l),
+(287,282,l),
+(427,282,ls),
+(486,282,o),
+(520,257,o),
+(520,204,cs),
+(520,155,o),
+(488,129,o),
+(426,129,cs),
+(287,129,l),
+(287,0,l)
+);
+}
+);
+width = 739;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160A;
+unicode = 5642;
+},
+{
+color = 9;
+glyphname = "meeCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(454,0,ls),
+(604,0,o),
+(680,70,o),
+(680,195,cs),
+(680,273,o),
+(633,337,o),
+(561,369,c),
+(559,320,l),
+(636,347,o),
+(680,407,o),
+(680,493,cs),
+(680,616,o),
+(600,690,o),
+(454,690,cs),
+(41,690,l),
+(41,560,l),
+(426,560,ls),
+(488,560,o),
+(520,535,o),
+(520,484,cs),
+(520,432,o),
+(489,406,o),
+(432,406,cs),
+(389,406,l),
+(389,476,l),
+(287,476,l),
+(287,213,l),
+(389,213,l),
+(389,285,l),
+(431,285,ls),
+(489,285,o),
+(520,259,o),
+(520,206,cs),
+(520,156,o),
+(488,129,o),
+(426,129,cs),
+(287,129,l),
+(287,0,l)
+);
+}
+);
+width = 739;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160B;
+unicode = 5643;
+},
+{
+color = 9;
+glyphname = "miCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(454,0,ls),
+(604,0,o),
+(680,70,o),
+(680,195,cs),
+(680,273,o),
+(633,337,o),
+(561,369,c),
+(559,320,l),
+(636,347,o),
+(680,407,o),
+(680,493,cs),
+(680,616,o),
+(600,690,o),
+(454,690,cs),
+(41,690,l),
+(41,560,l),
+(425,560,ls),
+(488,560,o),
+(520,535,o),
+(520,484,cs),
+(520,432,o),
+(489,406,o),
+(440,406,cs),
+(360,406,l),
+(449,361,l),
+(441,417,o),
+(397,459,o),
+(338,459,cs),
+(274,459,o),
+(226,409,o),
+(226,346,cs),
+(226,282,o),
+(274,232,o),
+(338,232,cs),
+(396,232,o),
+(440,276,o),
+(447,329,c),
+(359,285,l),
+(440,285,ls),
+(489,285,o),
+(520,259,o),
+(520,206,cs),
+(520,156,o),
+(488,129,o),
+(426,129,cs),
+(287,129,l),
+(287,0,l)
+);
+}
+);
+width = 739;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160C;
+unicode = 5644;
+},
+{
+color = 9;
+glyphname = "maCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(697,0,l),
+(697,129,l),
+(312,129,ls),
+(250,129,o),
+(219,154,o),
+(219,204,cs),
+(219,256,o),
+(251,281,o),
+(311,281,cs),
+(452,281,l),
+(452,409,l),
+(312,409,ls),
+(251,409,o),
+(219,435,o),
+(219,486,cs),
+(219,535,o),
+(250,560,o),
+(312,560,cs),
+(452,560,l),
+(452,690,l),
+(284,690,ls),
+(137,690,o),
+(59,617,o),
+(59,494,cs),
+(59,407,o),
+(106,347,o),
+(185,319,c),
+(185,373,l),
+(107,344,o),
+(59,278,o),
+(59,195,cs),
+(59,71,o),
+(136,0,o),
+(284,0,cs)
+);
+}
+);
+width = 738;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni160D;
+unicode = 5645;
+},
+{
+color = 9;
+glyphname = "yuCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(592,-14,o),
+(717,134,o),
+(717,383,cs),
+(717,601,o),
+(625,704,o),
+(496,704,cs),
+(381,704,o),
+(295,626,o),
+(295,490,cs),
+(295,362,o),
+(374,286,o),
+(480,286,cs),
+(492,286,o),
+(506,288,o),
+(518,291,c),
+(518,416,l),
+(512,415,o),
+(505,415,o),
+(497,415,cs),
+(457,415,o),
+(435,442,o),
+(435,497,cs),
+(435,548,o),
+(456,575,o),
+(490,575,cs),
+(532,575,o),
+(563,536,o),
+(563,386,cs),
+(563,201,o),
+(495,130,o),
+(384,130,cs),
+(277,130,o),
+(216,195,o),
+(216,333,cs),
+(216,690,l),
+(56,690,l),
+(56,323,ls),
+(56,107,o),
+(186,-14,o),
+(377,-14,cs)
+);
+}
+);
+width = 773;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160E;
+unicode = 5646;
+},
+{
+color = 9;
+glyphname = "yoCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(392,-14,o),
+(477,64,o),
+(477,200,cs),
+(477,327,o),
+(399,404,o),
+(293,404,cs),
+(281,404,o),
+(267,402,o),
+(255,399,c),
+(255,273,l),
+(261,274,o),
+(268,274,o),
+(276,274,cs),
+(316,274,o),
+(338,247,o),
+(338,193,cs),
+(338,142,o),
+(317,115,o),
+(282,115,cs),
+(240,115,o),
+(210,154,o),
+(210,303,cs),
+(210,489,o),
+(277,559,o),
+(388,559,cs),
+(496,559,o),
+(556,495,o),
+(556,356,cs),
+(556,0,l),
+(717,0,l),
+(717,367,ls),
+(717,582,o),
+(586,704,o),
+(395,704,cs),
+(181,704,o),
+(56,555,o),
+(56,307,cs),
+(56,89,o),
+(147,-14,o),
+(277,-14,cs)
+);
+}
+);
+width = 773;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160F;
+unicode = 5647;
+},
+{
+color = 9;
+glyphname = "yeCarrier-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(543,-14,o),
+(674,121,o),
+(674,338,cs),
+(674,571,o),
+(541,690,o),
+(298,690,cs),
+(62,690,l),
+(62,546,l),
+(303,546,ls),
+(445,546,o),
+(515,482,o),
+(515,332,cs),
+(515,191,o),
+(459,121,o),
+(327,121,cs),
+(227,121,o),
+(187,161,o),
+(187,223,cs),
+(187,271,o),
+(209,296,o),
+(241,296,cs),
+(274,296,o),
+(295,270,o),
+(295,221,cs),
+(295,205,o),
+(294,194,o),
+(294,185,c),
+(420,185,l),
+(424,201,o),
+(425,215,o),
+(425,234,cs),
+(425,341,o),
+(357,422,o),
+(242,422,cs),
+(123,422,o),
+(48,338,o),
+(48,221,cs),
+(48,84,o),
+(150,-14,o),
+(327,-14,cs)
+);
+}
+);
+width = 724;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1610;
+unicode = 5648;
+},
+{
+color = 9;
+glyphname = "yeeCarrier-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(543,-14,o),
+(674,121,o),
+(674,338,cs),
+(674,571,o),
+(541,690,o),
+(298,690,cs),
+(62,690,l),
+(62,546,l),
+(303,546,ls),
+(445,546,o),
+(515,482,o),
+(515,333,cs),
+(515,191,o),
+(461,121,o),
+(326,121,cs),
+(227,121,o),
+(187,160,o),
+(187,224,cs),
+(187,270,o),
+(209,296,o),
+(239,296,cs),
+(271,296,o),
+(292,270,o),
+(292,224,cs),
+(292,189,l),
+(378,189,l),
+(378,483,l),
+(292,483,l),
+(292,320,l),
+(305,320,l),
+(303,384,o),
+(266,422,o),
+(202,422,cs),
+(112,422,o),
+(48,341,o),
+(48,222,cs),
+(48,84,o),
+(148,-14,o),
+(327,-14,cs)
+);
+}
+);
+width = 724;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1611;
+unicode = 5649;
+},
+{
+color = 9;
+glyphname = "yiCarrier-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(543,-14,o),
+(674,121,o),
+(674,338,cs),
+(674,571,o),
+(541,690,o),
+(298,690,cs),
+(62,690,l),
+(62,546,l),
+(303,546,ls),
+(445,546,o),
+(515,482,o),
+(515,332,cs),
+(515,191,o),
+(459,121,o),
+(333,121,cs),
+(228,121,o),
+(187,161,o),
+(187,223,cs),
+(187,284,o),
+(218,304,o),
+(287,298,c),
+(214,336,l),
+(219,290,o),
+(258,252,o),
+(310,252,cs),
+(365,252,o),
+(404,296,o),
+(404,346,cs),
+(404,398,o),
+(363,438,o),
+(309,438,cs),
+(279,438,o),
+(252,425,o),
+(236,405,c),
+(114,398,o),
+(48,322,o),
+(48,213,cs),
+(48,83,o),
+(150,-14,o),
+(327,-14,cs)
+);
+}
+);
+width = 724;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1612;
+unicode = 5650;
+},
+{
+color = 9;
+glyphname = "yaCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(664,0,l),
+(664,144,l),
+(421,144,ls),
+(280,144,o),
+(210,208,o),
+(210,357,cs),
+(210,498,o),
+(266,569,o),
+(400,569,cs),
+(498,569,o),
+(538,528,o),
+(538,467,cs),
+(538,418,o),
+(517,394,o),
+(485,394,cs),
+(451,394,o),
+(430,420,o),
+(430,469,cs),
+(430,485,o),
+(431,496,o),
+(432,505,c),
+(305,505,l),
+(301,489,o),
+(300,474,o),
+(300,456,cs),
+(300,349,o),
+(368,268,o),
+(484,268,cs),
+(603,268,o),
+(677,352,o),
+(677,469,cs),
+(677,606,o),
+(576,704,o),
+(398,704,cs),
+(183,704,o),
+(50,569,o),
+(50,352,cs),
+(50,119,o),
+(185,0,o),
+(427,0,cs)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|yeCarrier-canadian";
+note = uni1613;
+unicode = 5651;
+},
+{
+color = 9;
+glyphname = "juCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(585,-14,o),
+(690,82,o),
+(690,223,cs),
+(690,338,o),
+(615,422,o),
+(497,422,cs),
+(381,422,o),
+(312,341,o),
+(312,234,cs),
+(312,215,o),
+(314,201,o),
+(318,185,c),
+(444,185,l),
+(443,194,o),
+(442,206,o),
+(442,221,cs),
+(442,269,o),
+(464,296,o),
+(497,296,cs),
+(529,296,o),
+(550,270,o),
+(550,225,cs),
+(550,159,o),
+(508,121,o),
+(410,121,cs),
+(277,121,o),
+(220,185,o),
+(220,306,cs),
+(220,481,o),
+(332,546,o),
+(520,546,cs),
+(676,546,l),
+(676,690,l),
+(52,690,l),
+(52,553,l),
+(311,553,l),
+(422,608,l),
+(182,608,o),
+(61,487,o),
+(61,298,cs),
+(61,114,o),
+(191,-14,o),
+(404,-14,cs)
+);
+}
+);
+width = 738;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni1614;
+unicode = 5652;
+},
+{
+color = 9;
+glyphname = "juSayisi-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (371,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(546,-14,o),
+(676,114,o),
+(676,298,cs),
+(676,487,o),
+(556,608,o),
+(315,608,c),
+(427,553,l),
+(685,553,l),
+(685,690,l),
+(62,690,l),
+(62,546,l),
+(217,546,ls),
+(406,546,o),
+(518,481,o),
+(518,306,cs),
+(518,185,o),
+(460,121,o),
+(327,121,cs),
+(229,121,o),
+(187,159,o),
+(187,225,cs),
+(187,270,o),
+(209,296,o),
+(241,296,cs),
+(273,296,o),
+(295,269,o),
+(295,221,cs),
+(295,206,o),
+(294,194,o),
+(294,185,c),
+(420,185,l),
+(424,201,o),
+(425,215,o),
+(425,234,cs),
+(425,341,o),
+(356,422,o),
+(241,422,cs),
+(123,422,o),
+(48,338,o),
+(48,223,cs),
+(48,82,o),
+(152,-14,o),
+(333,-14,cs)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1615;
+unicode = 5653;
+},
+{
+color = 9;
+glyphname = "joCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(685,0,l),
+(685,137,l),
+(427,137,l),
+(315,82,l),
+(556,82,o),
+(676,203,o),
+(676,391,cs),
+(676,576,o),
+(546,704,o),
+(333,704,cs),
+(152,704,o),
+(48,608,o),
+(48,467,cs),
+(48,352,o),
+(123,268,o),
+(241,268,cs),
+(356,268,o),
+(425,349,o),
+(425,456,cs),
+(425,474,o),
+(424,489,o),
+(420,505,c),
+(294,505,l),
+(294,496,o),
+(295,484,o),
+(295,469,cs),
+(295,421,o),
+(273,394,o),
+(241,394,cs),
+(209,394,o),
+(187,419,o),
+(187,465,cs),
+(187,530,o),
+(229,569,o),
+(327,569,cs),
+(460,569,o),
+(518,504,o),
+(518,384,cs),
+(518,209,o),
+(406,144,o),
+(217,144,cs),
+(62,144,l),
+(62,0,l)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1616;
+unicode = 5654;
+},
+{
+color = 9;
+glyphname = "jeCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(632,-14,o),
+(724,89,o),
+(724,307,cs),
+(724,565,o),
+(599,704,o),
+(430,704,cs),
+(300,704,o),
+(210,627,o),
+(195,468,c),
+(221,472,l),
+(221,690,l),
+(63,690,l),
+(63,0,l),
+(223,0,l),
+(223,260,ls),
+(223,475,o),
+(289,559,o),
+(404,559,cs),
+(504,559,o),
+(570,486,o),
+(570,304,cs),
+(570,154,o),
+(540,115,o),
+(498,115,cs),
+(464,115,o),
+(441,142,o),
+(441,193,cs),
+(441,247,o),
+(464,274,o),
+(503,274,cs),
+(511,274,o),
+(519,274,o),
+(525,273,c),
+(525,399,l),
+(513,402,o),
+(498,404,o),
+(487,404,cs),
+(380,404,o),
+(301,327,o),
+(301,200,cs),
+(301,64,o),
+(387,-14,o),
+(502,-14,cs)
+);
+}
+);
+width = 780;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "te-canadian";
+note = uni1617;
+unicode = 5655;
+},
+{
+color = 9;
+glyphname = "jeeCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(632,-14,o),
+(724,89,o),
+(724,307,cs),
+(724,565,o),
+(599,704,o),
+(430,704,cs),
+(316,704,o),
+(231,646,o),
+(203,526,c),
+(221,504,l),
+(221,690,l),
+(63,690,l),
+(63,0,l),
+(223,0,l),
+(223,260,ls),
+(223,475,o),
+(289,559,o),
+(404,559,cs),
+(504,559,o),
+(570,486,o),
+(570,304,cs),
+(570,171,o),
+(538,115,o),
+(470,115,cs),
+(415,115,o),
+(387,152,o),
+(387,211,cs),
+(387,251,o),
+(399,280,o),
+(422,298,c),
+(422,224,l),
+(503,224,l),
+(503,462,l),
+(422,462,l),
+(422,384,l),
+(352,361,o),
+(301,295,o),
+(301,193,cs),
+(301,63,o),
+(382,-14,o),
+(497,-14,cs)
+);
+}
+);
+width = 780;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1618;
+unicode = 5656;
+},
+{
+color = 9;
+glyphname = "jiCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(632,-14,o),
+(724,89,o),
+(724,307,cs),
+(724,565,o),
+(599,704,o),
+(430,704,cs),
+(316,704,o),
+(231,646,o),
+(203,526,c),
+(221,504,l),
+(221,690,l),
+(63,690,l),
+(63,0,l),
+(223,0,l),
+(223,260,ls),
+(223,475,o),
+(289,559,o),
+(404,559,cs),
+(504,559,o),
+(570,486,o),
+(570,304,cs),
+(570,171,o),
+(538,115,o),
+(470,115,cs),
+(415,115,o),
+(387,152,o),
+(387,211,cs),
+(387,232,o),
+(391,246,o),
+(399,258,c),
+(408,253,o),
+(418,250,o),
+(429,250,cs),
+(483,250,o),
+(520,294,o),
+(520,344,cs),
+(520,396,o),
+(481,436,o),
+(429,436,cs),
+(364,436,o),
+(327,376,o),
+(341,321,c),
+(317,290,o),
+(301,247,o),
+(301,193,cs),
+(301,63,o),
+(382,-14,o),
+(497,-14,cs)
+);
+}
+);
+width = 780;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1619;
+unicode = 5657;
+},
+{
+color = 9;
+glyphname = "jiSayisi-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(599,-14,o),
+(724,125,o),
+(724,383,cs),
+(724,601,o),
+(632,704,o),
+(502,704,cs),
+(387,704,o),
+(301,626,o),
+(301,490,cs),
+(301,362,o),
+(380,286,o),
+(487,286,cs),
+(498,286,o),
+(513,288,o),
+(525,291,c),
+(525,416,l),
+(519,415,o),
+(511,415,o),
+(503,415,cs),
+(464,415,o),
+(441,442,o),
+(441,497,cs),
+(441,548,o),
+(463,575,o),
+(496,575,cs),
+(539,575,o),
+(570,536,o),
+(570,385,cs),
+(570,204,o),
+(504,130,o),
+(404,130,cs),
+(289,130,o),
+(223,214,o),
+(223,430,cs),
+(223,690,l),
+(63,690,l),
+(63,0,l),
+(221,0,l),
+(221,217,l),
+(195,222,l),
+(210,63,o),
+(300,-14,o),
+(430,-14,cs)
+);
+}
+);
+width = 780;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161A;
+unicode = 5658;
+},
+{
+color = 9;
+glyphname = "jaCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (384,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(479,-14,o),
+(570,63,o),
+(584,222,c),
+(558,217,l),
+(558,0,l),
+(717,0,l),
+(717,690,l),
+(556,690,l),
+(556,430,ls),
+(556,214,o),
+(491,130,o),
+(376,130,cs),
+(274,130,o),
+(210,204,o),
+(210,385,cs),
+(210,536,o),
+(240,575,o),
+(283,575,cs),
+(317,575,o),
+(338,548,o),
+(338,497,cs),
+(338,442,o),
+(316,415,o),
+(275,415,cs),
+(268,415,o),
+(261,415,o),
+(255,416,c),
+(255,291,l),
+(267,288,o),
+(281,286,o),
+(293,286,cs),
+(399,286,o),
+(477,362,o),
+(477,490,cs),
+(477,626,o),
+(392,704,o),
+(277,704,cs),
+(147,704,o),
+(56,601,o),
+(56,383,cs),
+(56,125,o),
+(181,-14,o),
+(350,-14,cs)
+);
+}
+);
+width = 780;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni161B;
+unicode = 5659;
+},
+{
+color = 9;
+glyphname = "jjuCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(578,-14,o),
+(681,84,o),
+(681,221,cs),
+(681,338,o),
+(607,422,o),
+(489,422,cs),
+(370,422,o),
+(301,341,o),
+(301,234,cs),
+(301,216,o),
+(303,201,o),
+(307,185,c),
+(434,185,l),
+(433,195,o),
+(432,208,o),
+(432,221,cs),
+(432,269,o),
+(453,296,o),
+(486,296,cs),
+(518,296,o),
+(539,271,o),
+(539,224,cs),
+(539,160,o),
+(492,120,o),
+(400,120,cs),
+(266,120,o),
+(213,188,o),
+(213,309,cs),
+(213,460,o),
+(305,546,o),
+(505,546,cs),
+(668,546,l),
+(668,690,l),
+(490,690,ls),
+(370,690,o),
+(273,660,o),
+(204,609,c),
+(109,704,l),
+(4,600,l),
+(102,500,l),
+(71,446,o),
+(55,383,o),
+(55,314,cs),
+(55,119,o),
+(179,-14,o),
+(398,-14,cs)
+);
+}
+);
+width = 729;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni161C;
+unicode = 5660;
+},
+{
+color = 9;
+glyphname = "jjoCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(725,90,l),
+(627,189,l),
+(658,243,o),
+(674,307,o),
+(674,376,cs),
+(674,571,o),
+(551,704,o),
+(337,704,cs),
+(157,704,o),
+(48,606,o),
+(48,468,cs),
+(48,352,o),
+(122,268,o),
+(242,268,cs),
+(359,268,o),
+(428,349,o),
+(428,456,cs),
+(428,473,o),
+(426,489,o),
+(423,505,c),
+(296,505,l),
+(297,495,o),
+(298,482,o),
+(298,469,cs),
+(298,421,o),
+(277,394,o),
+(243,394,cs),
+(212,394,o),
+(190,418,o),
+(190,466,cs),
+(190,529,o),
+(233,570,o),
+(333,570,cs),
+(464,570,o),
+(516,501,o),
+(516,381,cs),
+(516,230,o),
+(424,144,o),
+(224,144,cs),
+(62,144,l),
+(62,0,l),
+(240,0,ls),
+(359,0,o),
+(456,30,o),
+(526,81,c),
+(620,-14,l)
+);
+}
+);
+width = 729;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|jjuCarrier-canadian";
+note = uni161D;
+unicode = 5661;
+},
+{
+color = 9;
+glyphname = "jjeCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(645,-14,o),
+(736,89,o),
+(736,307,cs),
+(736,555,o),
+(619,704,o),
+(413,704,cs),
+(329,704,o),
+(254,676,o),
+(196,624,c),
+(113,704,l),
+(12,597,l),
+(111,500,l),
+(88,446,o),
+(75,382,o),
+(75,306,cs),
+(75,0,l),
+(236,0,l),
+(236,300,ls),
+(236,476,o),
+(297,559,o),
+(412,559,cs),
+(515,559,o),
+(582,489,o),
+(582,303,cs),
+(582,154,o),
+(553,115,o),
+(510,115,cs),
+(475,115,o),
+(454,142,o),
+(454,193,cs),
+(454,247,o),
+(476,274,o),
+(516,274,cs),
+(525,274,o),
+(531,274,o),
+(537,273,c),
+(537,399,l),
+(526,402,o),
+(511,404,o),
+(499,404,cs),
+(393,404,o),
+(315,327,o),
+(315,200,cs),
+(315,64,o),
+(400,-14,o),
+(515,-14,cs)
+);
+}
+);
+width = 792;
+}
+);
+metricRight = "jeCarrier-canadian";
+note = uni161E;
+unicode = 5662;
+},
+{
+color = 9;
+glyphname = "jjeeCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(644,-14,o),
+(736,89,o),
+(736,307,cs),
+(736,555,o),
+(619,704,o),
+(413,704,cs),
+(329,704,o),
+(254,676,o),
+(196,624,c),
+(113,704,l),
+(12,597,l),
+(111,500,l),
+(88,446,o),
+(75,382,o),
+(75,306,cs),
+(75,0,l),
+(236,0,l),
+(236,300,ls),
+(236,476,o),
+(297,559,o),
+(412,559,cs),
+(515,559,o),
+(582,489,o),
+(582,303,cs),
+(582,172,o),
+(551,115,o),
+(482,115,cs),
+(428,115,o),
+(400,152,o),
+(400,211,cs),
+(400,250,o),
+(412,278,o),
+(435,296,c),
+(435,224,l),
+(515,224,l),
+(515,460,l),
+(435,460,l),
+(435,384,l),
+(364,361,o),
+(315,294,o),
+(315,193,cs),
+(315,63,o),
+(395,-14,o),
+(509,-14,cs)
+);
+}
+);
+width = 792;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161F;
+unicode = 5663;
+},
+{
+color = 9;
+glyphname = "jjiCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(644,-14,o),
+(736,89,o),
+(736,307,cs),
+(736,555,o),
+(619,704,o),
+(413,704,cs),
+(329,704,o),
+(254,676,o),
+(196,624,c),
+(113,704,l),
+(12,597,l),
+(111,500,l),
+(88,446,o),
+(75,382,o),
+(75,306,cs),
+(75,0,l),
+(236,0,l),
+(236,300,ls),
+(236,476,o),
+(297,559,o),
+(412,559,cs),
+(515,559,o),
+(582,489,o),
+(582,303,cs),
+(582,172,o),
+(551,115,o),
+(482,115,cs),
+(428,115,o),
+(400,152,o),
+(400,211,cs),
+(400,234,o),
+(405,250,o),
+(414,262,c),
+(425,255,o),
+(439,250,o),
+(454,250,cs),
+(507,250,o),
+(544,294,o),
+(544,344,cs),
+(544,396,o),
+(506,436,o),
+(454,436,cs),
+(396,436,o),
+(358,385,o),
+(364,333,c),
+(333,301,o),
+(315,254,o),
+(315,193,cs),
+(315,63,o),
+(395,-14,o),
+(509,-14,cs)
+);
+}
+);
+width = 792;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1620;
+unicode = 5664;
+},
+{
+color = 9;
+glyphname = "jjaCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(463,-14,o),
+(538,14,o),
+(596,66,c),
+(679,-14,l),
+(781,93,l),
+(681,189,l),
+(704,243,o),
+(717,308,o),
+(717,384,cs),
+(717,690,l),
+(556,690,l),
+(556,389,ls),
+(556,213,o),
+(496,130,o),
+(381,130,cs),
+(277,130,o),
+(210,201,o),
+(210,386,cs),
+(210,536,o),
+(240,575,o),
+(282,575,cs),
+(317,575,o),
+(338,548,o),
+(338,497,cs),
+(338,442,o),
+(316,415,o),
+(276,415,cs),
+(268,415,o),
+(261,415,o),
+(255,416,c),
+(255,291,l),
+(267,288,o),
+(281,286,o),
+(293,286,cs),
+(399,286,o),
+(477,362,o),
+(477,490,cs),
+(477,626,o),
+(392,704,o),
+(277,704,cs),
+(147,704,o),
+(56,601,o),
+(56,383,cs),
+(56,134,o),
+(173,-14,o),
+(379,-14,cs)
+);
+}
+);
+width = 793;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "=|jjeCarrier-canadian";
+note = uni1621;
+unicode = 5665;
+},
+{
+color = 9;
+glyphname = "luCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(564,-14,o),
+(674,102,o),
+(674,307,cs),
+(674,690,l),
+(514,690,l),
+(514,307,ls),
+(514,188,o),
+(464,130,o),
+(373,130,cs),
+(272,130,o),
+(220,198,o),
+(220,324,cs),
+(220,462,o),
+(273,551,o),
+(389,561,c),
+(389,690,l),
+(52,690,l),
+(52,557,l),
+(237,557,l),
+(358,613,l),
+(161,596,o),
+(61,497,o),
+(61,298,cs),
+(61,108,o),
+(173,-14,o),
+(366,-14,cs)
+);
+}
+);
+width = 730;
+}
+);
+metricRight = "te-canadian";
+note = uni1622;
+unicode = 5666;
+},
+{
+color = 9;
+glyphname = "loCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(216,0,l),
+(216,383,ls),
+(216,501,o),
+(268,559,o),
+(363,559,cs),
+(459,559,o),
+(510,492,o),
+(510,366,cs),
+(510,228,o),
+(457,139,o),
+(341,128,c),
+(341,0,l),
+(678,0,l),
+(678,132,l),
+(494,132,l),
+(372,76,l),
+(569,94,o),
+(669,193,o),
+(669,392,cs),
+(669,582,o),
+(557,704,o),
+(364,704,cs),
+(166,704,o),
+(56,587,o),
+(56,383,cs),
+(56,0,l)
+);
+}
+);
+width = 730;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|luCarrier-canadian";
+note = uni1623;
+unicode = 5667;
+},
+{
+color = 9;
+glyphname = "leCarrier-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (353,351);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(321,0,ls),
+(543,0,o),
+(671,125,o),
+(671,357,cs),
+(671,582,o),
+(548,704,o),
+(399,704,cs),
+(288,704,o),
+(213,642,o),
+(191,559,c),
+(202,562,l),
+(202,690,l),
+(59,690,l),
+(59,374,l),
+(194,374,l),
+(203,498,o),
+(268,559,o),
+(355,559,cs),
+(441,559,o),
+(512,497,o),
+(512,355,cs),
+(512,210,o),
+(442,144,o),
+(315,144,cs),
+(59,144,l),
+(59,0,l)
+);
+}
+);
+width = 721;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1624;
+unicode = 5668;
+},
+{
+color = 9;
+glyphname = "leeCarrier-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+ref = "leCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (289,6);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 721;
+}
+);
+metricLeft = "leCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1625;
+unicode = 5669;
+},
+{
+color = 9;
+glyphname = "liCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "leCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (259,6);
+ref = dot_middle;
+}
+);
+width = 723;
+}
+);
+note = uni1626;
+unicode = 5670;
+},
+{
+color = 9;
+glyphname = "laCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(664,0,l),
+(664,144,l),
+(408,144,ls),
+(280,144,o),
+(210,210,o),
+(210,355,cs),
+(210,497,o),
+(281,559,o),
+(368,559,cs),
+(455,559,o),
+(520,498,o),
+(528,374,c),
+(664,374,l),
+(664,690,l),
+(520,690,l),
+(520,562,l),
+(530,559,l),
+(509,642,o),
+(435,704,o),
+(324,704,cs),
+(175,704,o),
+(50,582,o),
+(50,357,cs),
+(50,125,o),
+(179,0,o),
+(402,0,cs)
+);
+}
+);
+width = 723;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|leCarrier-canadian";
+note = uni1627;
+unicode = 5671;
+},
+{
+color = 1;
+glyphname = "dluCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(557,-14,o),
+(669,108,o),
+(669,298,cs),
+(669,454,o),
+(608,549,o),
+(491,589,c),
+(462,569,l),
+(654,569,l),
+(654,493,l),
+(770,493,l),
+(770,766,l),
+(654,766,l),
+(654,690,l),
+(341,690,l),
+(341,561,l),
+(457,551,o),
+(510,462,o),
+(510,324,cs),
+(510,198,o),
+(459,130,o),
+(363,130,cs),
+(268,130,o),
+(216,188,o),
+(216,307,cs),
+(216,690,l),
+(56,690,l),
+(56,307,ls),
+(56,102,o),
+(166,-14,o),
+(361,-14,cs)
+);
+}
+);
+width = 802;
+}
+);
+metricLeft = "te-canadian";
+note = uni1628;
+unicode = 5672;
+},
+{
+color = 9;
+glyphname = "dloCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(770,-76,l),
+(770,197,l),
+(654,197,l),
+(654,121,l),
+(462,121,l),
+(491,100,l),
+(608,141,o),
+(669,236,o),
+(669,392,cs),
+(669,582,o),
+(557,704,o),
+(367,704,cs),
+(160,704,o),
+(56,587,o),
+(56,383,cs),
+(56,0,l),
+(216,0,l),
+(216,383,ls),
+(216,501,o),
+(267,559,o),
+(363,559,cs),
+(459,559,o),
+(510,492,o),
+(510,366,cs),
+(510,228,o),
+(457,139,o),
+(341,128,c),
+(341,0,l),
+(654,0,l),
+(654,-76,l)
+);
+}
+);
+width = 802;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "dluCarrier-canadian";
+note = uni1629;
+unicode = 5673;
+},
+{
+color = 9;
+glyphname = "dleCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (367,351);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(335,0,ls),
+(557,0,o),
+(686,125,o),
+(686,357,cs),
+(686,582,o),
+(562,704,o),
+(412,704,cs),
+(301,704,o),
+(206,647,o),
+(168,511,c),
+(189,495,l),
+(189,694,l),
+(264,694,l),
+(264,806,l),
+(-2,806,l),
+(-2,694,l),
+(73,694,l),
+(73,374,l),
+(209,374,l),
+(217,498,o),
+(282,559,o),
+(369,559,cs),
+(456,559,o),
+(526,497,o),
+(526,355,cs),
+(526,210,o),
+(457,144,o),
+(329,144,cs),
+(73,144,l),
+(73,0,l)
+);
+}
+);
+width = 736;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni162A;
+unicode = 5674;
+},
+{
+color = 9;
+glyphname = "dleeCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (303,6);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 737;
+}
+);
+note = uni162B;
+unicode = 5675;
+},
+{
+color = 9;
+glyphname = "dliCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (273,6);
+ref = dot_middle;
+}
+);
+width = 737;
+}
+);
+note = uni162C;
+unicode = 5676;
+},
+{
+color = 9;
+glyphname = "dlaCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(664,0,l),
+(664,144,l),
+(408,144,ls),
+(280,144,o),
+(210,210,o),
+(210,355,cs),
+(210,497,o),
+(281,559,o),
+(367,559,cs),
+(455,559,o),
+(520,498,o),
+(528,374,c),
+(664,374,l),
+(664,694,l),
+(739,694,l),
+(739,806,l),
+(472,806,l),
+(472,694,l),
+(548,694,l),
+(548,495,l),
+(569,511,l),
+(531,647,o),
+(436,704,o),
+(326,704,cs),
+(174,704,o),
+(50,582,o),
+(50,357,cs),
+(50,124,o),
+(180,0,o),
+(402,0,cs)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni162D;
+unicode = 5677;
+},
+{
+color = 9;
+glyphname = "lhuCarrier-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(576,-14,o),
+(688,112,o),
+(688,301,cs),
+(688,495,o),
+(587,589,o),
+(442,609,c),
+(514,554,l),
+(696,554,l),
+(696,690,l),
+(429,690,l),
+(429,561,l),
+(479,528,o),
+(527,456,o),
+(527,328,cs),
+(527,197,o),
+(476,130,o),
+(374,130,cs),
+(272,130,o),
+(221,197,o),
+(221,328,cs),
+(221,456,o),
+(270,528,o),
+(320,561,c),
+(320,690,l),
+(52,690,l),
+(52,554,l),
+(235,554,l),
+(306,609,l),
+(161,589,o),
+(61,495,o),
+(61,301,cs),
+(61,112,o),
+(173,-14,o),
+(374,-14,cs)
+);
+}
+);
+width = 748;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162E;
+unicode = 5678;
+},
+{
+color = 9;
+glyphname = "lhoCarrier-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(320,0,l),
+(320,128,l),
+(270,161,o),
+(221,234,o),
+(221,361,cs),
+(221,493,o),
+(272,559,o),
+(374,559,cs),
+(476,559,o),
+(526,493,o),
+(526,361,cs),
+(526,234,o),
+(479,161,o),
+(429,128,c),
+(429,0,l),
+(696,0,l),
+(696,135,l),
+(514,135,l),
+(442,81,l),
+(587,100,o),
+(688,195,o),
+(688,388,cs),
+(688,578,o),
+(576,704,o),
+(374,704,cs),
+(172,704,o),
+(61,578,o),
+(61,388,cs),
+(61,195,o),
+(161,100,o),
+(306,81,c),
+(235,135,l),
+(52,135,l),
+(52,0,l)
+);
+}
+);
+width = 748;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162F;
+unicode = 5679;
+},
+{
+color = 9;
+glyphname = "lheCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (367,345);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(566,-14,o),
+(694,107,o),
+(694,345,cs),
+(694,582,o),
+(566,704,o),
+(409,704,cs),
+(298,704,o),
+(220,642,o),
+(199,563,c),
+(206,562,l),
+(206,690,l),
+(63,690,l),
+(63,408,l),
+(198,408,l),
+(217,494,o),
+(274,559,o),
+(368,559,cs),
+(458,559,o),
+(533,498,o),
+(533,345,cs),
+(533,191,o),
+(459,130,o),
+(368,130,cs),
+(274,130,o),
+(217,196,o),
+(198,282,c),
+(63,282,l),
+(63,0,l),
+(206,0,l),
+(206,128,l),
+(199,127,l),
+(220,47,o),
+(298,-14,o),
+(409,-14,cs)
+);
+}
+);
+width = 744;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1630;
+unicode = 5680;
+},
+{
+color = 9;
+glyphname = "lheeCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (303,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 745;
+}
+);
+note = uni1631;
+unicode = 5681;
+},
+{
+color = 9;
+glyphname = "lhiCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (272,0);
+ref = dot_middle;
+}
+);
+width = 745;
+}
+);
+note = uni1632;
+unicode = 5682;
+},
+{
+color = 9;
+glyphname = "lhaCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(447,-14,o),
+(524,47,o),
+(546,127,c),
+(538,128,l),
+(538,0,l),
+(682,0,l),
+(682,282,l),
+(547,282,l),
+(526,196,o),
+(470,130,o),
+(376,130,cs),
+(286,130,o),
+(212,191,o),
+(212,345,cs),
+(212,498,o),
+(285,559,o),
+(376,559,cs),
+(470,559,o),
+(526,494,o),
+(547,408,c),
+(682,408,l),
+(682,690,l),
+(538,690,l),
+(538,562,l),
+(546,563,l),
+(524,642,o),
+(447,704,o),
+(335,704,cs),
+(178,704,o),
+(50,582,o),
+(50,345,cs),
+(50,107,o),
+(178,-14,o),
+(335,-14,cs)
+);
+}
+);
+width = 745;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1633;
+unicode = 5683;
+},
+{
+color = 9;
+glyphname = "tlhuCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(576,-14,o),
+(688,112,o),
+(688,301,cs),
+(688,457,o),
+(619,549,o),
+(523,588,c),
+(489,569,l),
+(671,569,l),
+(671,493,l),
+(788,493,l),
+(788,766,l),
+(671,766,l),
+(671,690,l),
+(429,690,l),
+(429,561,l),
+(480,528,o),
+(527,456,o),
+(527,328,cs),
+(527,197,o),
+(476,130,o),
+(374,130,cs),
+(272,130,o),
+(221,197,o),
+(221,328,cs),
+(221,456,o),
+(269,528,o),
+(320,561,c),
+(320,690,l),
+(52,690,l),
+(52,554,l),
+(238,554,l),
+(200,578,l),
+(116,533,o),
+(61,445,o),
+(61,301,cs),
+(61,112,o),
+(173,-14,o),
+(374,-14,cs)
+);
+}
+);
+width = 815;
+}
+);
+metricLeft = "lhuCarrier-canadian";
+note = uni1634;
+unicode = 5684;
+},
+{
+color = 9;
+glyphname = "tlhoCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(144,-76,l),
+(144,0,l),
+(386,0,l),
+(386,128,l),
+(335,161,o),
+(288,234,o),
+(288,361,cs),
+(288,493,o),
+(339,559,o),
+(440,559,cs),
+(543,559,o),
+(594,493,o),
+(594,361,cs),
+(594,234,o),
+(546,161,o),
+(496,128,c),
+(496,0,l),
+(763,0,l),
+(763,135,l),
+(578,135,l),
+(615,112,l),
+(699,156,o),
+(754,244,o),
+(754,388,cs),
+(754,578,o),
+(642,704,o),
+(440,704,cs),
+(239,704,o),
+(128,578,o),
+(128,388,cs),
+(128,233,o),
+(195,141,o),
+(293,101,c),
+(327,121,l),
+(144,121,l),
+(144,197,l),
+(27,197,l),
+(27,-76,l)
+);
+}
+);
+width = 815;
+}
+);
+metricLeft = "=|tlhuCarrier-canadian";
+metricRight = "lhuCarrier-canadian";
+note = uni1635;
+unicode = 5685;
+},
+{
+color = 9;
+glyphname = "tlheCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (377,345);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(578,-14,o),
+(704,107,o),
+(704,345,cs),
+(704,582,o),
+(578,704,o),
+(420,704,cs),
+(306,704,o),
+(210,647,o),
+(170,515,c),
+(191,497,l),
+(191,694,l),
+(267,694,l),
+(267,806,l),
+(-2,806,l),
+(-2,694,l),
+(73,694,l),
+(73,408,l),
+(209,408,l),
+(228,494,o),
+(285,559,o),
+(379,559,cs),
+(469,559,o),
+(544,501,o),
+(544,345,cs),
+(544,191,o),
+(469,130,o),
+(379,130,cs),
+(285,130,o),
+(228,196,o),
+(209,282,c),
+(73,282,l),
+(73,0,l),
+(216,0,l),
+(216,178,l),
+(205,146,l),
+(218,58,o),
+(300,-14,o),
+(420,-14,cs)
+);
+}
+);
+width = 754;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1636;
+unicode = 5686;
+},
+{
+color = 9;
+glyphname = "tlheeCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (314,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 755;
+}
+);
+note = uni1637;
+unicode = 5687;
+},
+{
+color = 9;
+glyphname = "tlhiCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (283,0);
+ref = dot_middle;
+}
+);
+width = 755;
+}
+);
+note = uni1638;
+unicode = 5688;
+},
+{
+color = 9;
+glyphname = "tlhaCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(454,-14,o),
+(537,57,o),
+(550,147,c),
+(538,178,l),
+(538,0,l),
+(682,0,l),
+(682,282,l),
+(547,282,l),
+(526,196,o),
+(470,130,o),
+(376,130,cs),
+(286,130,o),
+(212,191,o),
+(212,345,cs),
+(212,501,o),
+(285,559,o),
+(376,559,cs),
+(470,559,o),
+(526,494,o),
+(547,408,c),
+(682,408,l),
+(682,694,l),
+(756,694,l),
+(756,806,l),
+(489,806,l),
+(489,694,l),
+(563,694,l),
+(563,497,l),
+(585,515,l),
+(546,648,o),
+(449,704,o),
+(334,704,cs),
+(178,704,o),
+(50,582,o),
+(50,345,cs),
+(50,107,o),
+(178,-14,o),
+(334,-14,cs)
+);
+}
+);
+width = 754;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni1639;
+unicode = 5689;
+},
+{
+color = 9;
+glyphname = "tluCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(369,-14,o),
+(430,26,o),
+(462,108,c),
+(412,108,l),
+(442,26,o),
+(504,-14,o),
+(588,-14,cs),
+(733,-14,o),
+(811,85,o),
+(811,264,cs),
+(811,440,o),
+(753,545,o),
+(639,590,c),
+(607,569,l),
+(796,569,l),
+(796,493,l),
+(912,493,l),
+(912,766,l),
+(796,766,l),
+(796,690,l),
+(491,690,l),
+(491,561,l),
+(599,556,o),
+(651,462,o),
+(651,278,cs),
+(651,166,o),
+(627,127,o),
+(578,127,cs),
+(537,127,o),
+(514,161,o),
+(514,227,cs),
+(514,310,l),
+(359,310,l),
+(359,227,ls),
+(359,161,o),
+(335,127,o),
+(296,127,cs),
+(245,127,o),
+(222,166,o),
+(222,278,cs),
+(222,462,o),
+(273,556,o),
+(382,561,c),
+(382,690,l),
+(53,690,l),
+(53,554,l),
+(246,554,l),
+(210,578,l),
+(112,528,o),
+(62,428,o),
+(62,264,cs),
+(62,85,o),
+(139,-14,o),
+(284,-14,cs)
+);
+}
+);
+width = 939;
+}
+);
+metricRight = "tlhuCarrier-canadian";
+note = uni163A;
+unicode = 5690;
+},
+{
+color = 1;
+glyphname = "tloCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(912,-76,l),
+(912,197,l),
+(796,197,l),
+(796,121,l),
+(607,121,l),
+(639,99,l),
+(753,145,o),
+(811,249,o),
+(811,426,cs),
+(811,605,o),
+(733,704,o),
+(588,704,cs),
+(504,704,o),
+(442,664,o),
+(412,582,c),
+(462,582,l),
+(430,664,o),
+(369,704,o),
+(284,704,cs),
+(139,704,o),
+(62,605,o),
+(62,426,cs),
+(62,262,o),
+(112,161,o),
+(210,112,c),
+(246,135,l),
+(53,135,l),
+(53,0,l),
+(382,0,l),
+(382,128,l),
+(273,133,o),
+(222,228,o),
+(222,412,cs),
+(222,524,o),
+(245,563,o),
+(296,563,cs),
+(335,563,o),
+(359,528,o),
+(359,463,cs),
+(359,380,l),
+(514,380,l),
+(514,463,ls),
+(514,528,o),
+(537,563,o),
+(578,563,cs),
+(627,563,o),
+(651,524,o),
+(651,412,cs),
+(651,228,o),
+(599,133,o),
+(491,128,c),
+(491,0,l),
+(796,0,l),
+(796,-76,l)
+);
+}
+);
+width = 939;
+}
+);
+metricLeft = "tluCarrier-canadian";
+metricRight = "tlhuCarrier-canadian";
+note = uni163B;
+unicode = 5691;
+},
+{
+color = 9;
+glyphname = "tleCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (312,345);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(611,-14,o),
+(687,80,o),
+(687,191,cs),
+(687,273,o),
+(637,343,o),
+(560,365,c),
+(560,326,l),
+(639,343,o),
+(687,412,o),
+(687,498,cs),
+(687,610,o),
+(611,704,o),
+(442,704,cs),
+(311,704,o),
+(205,644,o),
+(171,522,c),
+(189,498,l),
+(189,694,l),
+(264,694,l),
+(264,806,l),
+(-2,806,l),
+(-2,694,l),
+(73,694,l),
+(73,408,l),
+(208,408,l),
+(219,501,o),
+(278,561,o),
+(403,561,cs),
+(488,561,o),
+(527,530,o),
+(527,479,cs),
+(527,434,o),
+(500,411,o),
+(440,411,cs),
+(400,411,l),
+(400,280,l),
+(440,280,ls),
+(501,280,o),
+(527,256,o),
+(527,211,cs),
+(527,159,o),
+(487,128,o),
+(403,128,cs),
+(278,128,o),
+(219,188,o),
+(208,282,c),
+(73,282,l),
+(73,0,l),
+(216,0,l),
+(216,161,l),
+(194,135,l),
+(233,29,o),
+(321,-14,o),
+(442,-14,cs)
+);
+}
+);
+width = 746;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni163C;
+unicode = 5692;
+},
+{
+color = 9;
+glyphname = "tleeCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (248,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 746;
+}
+);
+note = uni163D;
+unicode = 5693;
+},
+{
+color = 9;
+glyphname = "tliCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (235,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 746;
+}
+);
+note = uni163E;
+unicode = 5694;
+},
+{
+color = 9;
+glyphname = "tlaCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(425,-14,o),
+(513,29,o),
+(552,135,c),
+(528,161,l),
+(528,0,l),
+(672,0,l),
+(672,282,l),
+(538,282,l),
+(526,188,o),
+(468,128,o),
+(343,128,cs),
+(259,128,o),
+(218,159,o),
+(218,211,cs),
+(218,256,o),
+(244,280,o),
+(305,280,cs),
+(349,280,l),
+(349,411,l),
+(305,411,ls),
+(245,411,o),
+(218,434,o),
+(218,479,cs),
+(218,530,o),
+(258,561,o),
+(343,561,cs),
+(468,561,o),
+(526,501,o),
+(538,408,c),
+(672,408,l),
+(672,694,l),
+(748,694,l),
+(748,806,l),
+(481,806,l),
+(481,694,l),
+(556,694,l),
+(556,498,l),
+(575,522,l),
+(541,644,o),
+(435,704,o),
+(303,704,cs),
+(134,704,o),
+(59,610,o),
+(59,499,cs),
+(59,412,o),
+(107,344,o),
+(185,326,c),
+(185,365,l),
+(109,343,o),
+(59,273,o),
+(59,191,cs),
+(59,80,o),
+(134,-14,o),
+(303,-14,cs)
+);
+}
+);
+width = 746;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni163F;
+unicode = 5695;
+},
+{
+color = 9;
+glyphname = "zuCarrier-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(576,-14,o),
+(688,86,o),
+(688,238,cs),
+(688,344,o),
+(618,459,o),
+(618,508,cs),
+(618,536,o),
+(633,553,o),
+(668,553,cs),
+(697,553,l),
+(697,690,l),
+(634,690,ls),
+(513,690,o),
+(462,624,o),
+(462,533,cs),
+(462,447,o),
+(527,352,o),
+(527,264,cs),
+(527,180,o),
+(476,130,o),
+(375,130,cs),
+(272,130,o),
+(221,180,o),
+(221,264,cs),
+(221,352,o),
+(287,447,o),
+(287,533,cs),
+(287,624,o),
+(236,690,o),
+(115,690,cs),
+(51,690,l),
+(51,553,l),
+(80,553,ls),
+(116,553,o),
+(131,536,o),
+(131,508,cs),
+(131,459,o),
+(61,344,o),
+(61,238,cs),
+(61,86,o),
+(173,-14,o),
+(375,-14,cs)
+);
+}
+);
+width = 748;
+}
+);
+metricRight = "=|";
+note = uni1640;
+unicode = 5696;
+},
+{
+color = 9;
+glyphname = "zoCarrier-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(115,0,ls),
+(236,0,o),
+(288,66,o),
+(288,156,cs),
+(288,242,o),
+(222,338,o),
+(222,426,cs),
+(222,510,o),
+(272,559,o),
+(375,559,cs),
+(477,559,o),
+(527,510,o),
+(527,426,cs),
+(527,338,o),
+(462,242,o),
+(462,156,cs),
+(462,66,o),
+(514,0,o),
+(634,0,cs),
+(697,0,l),
+(697,137,l),
+(668,137,ls),
+(633,137,o),
+(618,154,o),
+(618,182,cs),
+(618,231,o),
+(688,346,o),
+(688,452,cs),
+(688,604,o),
+(577,704,o),
+(375,704,cs),
+(173,704,o),
+(62,604,o),
+(62,452,cs),
+(62,346,o),
+(131,231,o),
+(131,182,cs),
+(131,154,o),
+(116,137,o),
+(81,137,cs),
+(51,137,l),
+(51,0,l)
+);
+}
+);
+width = 748;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1641;
+unicode = 5697;
+},
+{
+color = 9;
+glyphname = "zeCarrier-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (357,345);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(574,-14,o),
+(668,111,o),
+(668,345,cs),
+(668,578,o),
+(575,704,o),
+(430,704,cs),
+(326,704,o),
+(254,616,o),
+(214,616,cs),
+(190,616,o),
+(181,631,o),
+(181,667,cs),
+(181,690,l),
+(37,690,l),
+(37,631,ls),
+(37,527,o),
+(92,474,o),
+(175,474,cs),
+(265,474,o),
+(327,559,o),
+(393,559,cs),
+(463,559,o),
+(507,501,o),
+(507,345,cs),
+(507,188,o),
+(463,130,o),
+(393,130,cs),
+(327,130,o),
+(265,215,o),
+(175,215,cs),
+(92,215,o),
+(37,162,o),
+(37,59,cs),
+(37,0,l),
+(181,0,l),
+(181,23,ls),
+(181,59,o),
+(190,73,o),
+(214,73,cs),
+(254,73,o),
+(326,-14,o),
+(430,-14,cs)
+);
+}
+);
+width = 718;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1642;
+unicode = 5698;
+},
+{
+color = 9;
+glyphname = "zeeCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (295,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 719;
+}
+);
+note = uni1643;
+unicode = 5699;
+},
+{
+color = 9;
+glyphname = "ziCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (264,0);
+ref = dot_middle;
+}
+);
+width = 719;
+}
+);
+note = uni1644;
+unicode = 5700;
+},
+{
+color = 9;
+glyphname = "zaCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(393,-14,o),
+(465,73,o),
+(504,73,cs),
+(528,73,o),
+(538,59,o),
+(538,23,cs),
+(538,0,l),
+(682,0,l),
+(682,59,ls),
+(682,162,o),
+(627,215,o),
+(544,215,cs),
+(454,215,o),
+(392,130,o),
+(326,130,cs),
+(256,130,o),
+(212,188,o),
+(212,345,cs),
+(212,501,o),
+(256,559,o),
+(326,559,cs),
+(392,559,o),
+(454,474,o),
+(544,474,cs),
+(627,474,o),
+(682,527,o),
+(682,631,cs),
+(682,690,l),
+(538,690,l),
+(538,667,ls),
+(538,631,o),
+(528,616,o),
+(504,616,cs),
+(465,616,o),
+(393,704,o),
+(289,704,cs),
+(145,704,o),
+(50,579,o),
+(50,345,cs),
+(50,112,o),
+(144,-14,o),
+(289,-14,cs)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|zeCarrier-canadian";
+note = uni1645;
+unicode = 5701;
+},
+{
+color = 6;
+glyphname = "zCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(360,183,l),
+(360,278,l),
+(170,278,l),
+(170,223,l),
+(356,472,l),
+(356,527,l),
+(53,527,l),
+(53,432,l),
+(241,432,l),
+(241,487,l),
+(53,238,l),
+(53,183,l)
+);
+}
+);
+width = 413;
+}
+);
+metricRight = "=|";
+note = uni1646;
+unicode = 5702;
+},
+{
+color = 6;
+glyphname = "initialzCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(153,183,l),
+(153,96,l),
+(258,96,l),
+(258,183,l),
+(360,183,l),
+(360,278,l),
+(138,278,l),
+(168,220,l),
+(356,472,l),
+(356,527,l),
+(258,527,l),
+(258,614,l),
+(153,614,l),
+(153,527,l),
+(53,527,l),
+(53,432,l),
+(271,432,l),
+(242,490,l),
+(53,238,l),
+(53,183,l)
+);
+}
+);
+width = 413;
+}
+);
+metricLeft = "zCarrier-canadian";
+metricRight = "zCarrier-canadian";
+note = uni1647;
+unicode = 5703;
+},
+{
+color = 9;
+glyphname = "dzuCarrier-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(576,-14,o),
+(688,86,o),
+(688,238,cs),
+(688,344,o),
+(618,459,o),
+(618,508,cs),
+(618,536,o),
+(633,553,o),
+(668,553,cs),
+(697,553,l),
+(697,690,l),
+(637,690,ls),
+(519,690,o),
+(465,624,o),
+(465,533,cs),
+(465,447,o),
+(527,355,o),
+(527,264,cs),
+(527,180,o),
+(477,130,o),
+(375,130,cs),
+(272,130,o),
+(221,180,o),
+(221,264,cs),
+(221,355,o),
+(284,447,o),
+(284,533,cs),
+(284,624,o),
+(230,690,o),
+(113,690,cs),
+(51,690,l),
+(51,553,l),
+(80,553,ls),
+(116,553,o),
+(131,536,o),
+(131,508,cs),
+(131,459,o),
+(61,344,o),
+(61,238,cs),
+(61,86,o),
+(173,-14,o),
+(375,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(411,466,l),
+(411,620,l),
+(458,620,l),
+(458,690,l),
+(292,690,l),
+(292,620,l),
+(339,620,l),
+(339,466,l)
+);
+}
+);
+width = 748;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1648;
+unicode = 5704;
+},
+{
+color = 9;
+glyphname = "dzoCarrier-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(113,0,ls),
+(231,0,o),
+(284,66,o),
+(284,156,cs),
+(284,242,o),
+(222,335,o),
+(222,426,cs),
+(222,510,o),
+(272,559,o),
+(375,559,cs),
+(477,559,o),
+(527,510,o),
+(527,426,cs),
+(527,335,o),
+(466,242,o),
+(466,156,cs),
+(466,66,o),
+(519,0,o),
+(637,0,cs),
+(697,0,l),
+(697,137,l),
+(668,137,ls),
+(633,137,o),
+(618,154,o),
+(618,182,cs),
+(618,231,o),
+(688,346,o),
+(688,452,cs),
+(688,604,o),
+(577,704,o),
+(375,704,cs),
+(173,704,o),
+(62,604,o),
+(62,452,cs),
+(62,346,o),
+(131,231,o),
+(131,182,cs),
+(131,154,o),
+(116,137,o),
+(81,137,cs),
+(51,137,l),
+(51,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(458,0,l),
+(458,70,l),
+(411,70,l),
+(411,224,l),
+(338,224,l),
+(338,70,l),
+(291,70,l),
+(291,0,l)
+);
+}
+);
+width = 748;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1649;
+unicode = 5705;
+},
+{
+color = 9;
+glyphname = "dzeCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (381,345);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(600,-14,o),
+(694,111,o),
+(694,345,cs),
+(694,578,o),
+(600,704,o),
+(455,704,cs),
+(351,704,o),
+(280,616,o),
+(240,616,cs),
+(216,616,o),
+(207,631,o),
+(207,667,cs),
+(207,690,l),
+(63,690,l),
+(63,631,ls),
+(63,527,o),
+(117,476,o),
+(201,476,cs),
+(291,476,o),
+(352,559,o),
+(418,559,cs),
+(489,559,o),
+(533,501,o),
+(533,345,cs),
+(533,188,o),
+(489,130,o),
+(418,130,cs),
+(352,130,o),
+(291,213,o),
+(201,213,cs),
+(117,213,o),
+(63,162,o),
+(63,59,cs),
+(63,0,l),
+(207,0,l),
+(207,23,ls),
+(207,57,o),
+(216,71,o),
+(240,71,cs),
+(280,71,o),
+(351,-14,o),
+(455,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(145,242,l),
+(145,304,l),
+(260,304,l),
+(260,385,l),
+(145,385,l),
+(145,447,l),
+(63,447,l),
+(63,242,l)
+);
+}
+);
+width = 744;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164A;
+unicode = 5706;
+},
+{
+color = 9;
+glyphname = "dzeeCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+ref = "dzeCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (317,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 744;
+}
+);
+metricLeft = "dzeCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164B;
+unicode = 5707;
+},
+{
+color = 9;
+glyphname = "dziCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "dzeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (287,0);
+ref = dot_middle;
+}
+);
+width = 745;
+}
+);
+note = uni164C;
+unicode = 5708;
+},
+{
+color = 9;
+glyphname = "dzaCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(393,-14,o),
+(465,71,o),
+(504,71,cs),
+(528,71,o),
+(538,57,o),
+(538,23,cs),
+(538,0,l),
+(682,0,l),
+(682,59,ls),
+(682,162,o),
+(627,213,o),
+(544,213,cs),
+(454,213,o),
+(392,130,o),
+(326,130,cs),
+(256,130,o),
+(212,188,o),
+(212,345,cs),
+(212,501,o),
+(256,559,o),
+(326,559,cs),
+(392,559,o),
+(454,476,o),
+(544,476,cs),
+(627,476,o),
+(682,527,o),
+(682,631,cs),
+(682,690,l),
+(538,690,l),
+(538,667,ls),
+(538,631,o),
+(528,616,o),
+(504,616,cs),
+(465,616,o),
+(393,704,o),
+(289,704,cs),
+(145,704,o),
+(50,579,o),
+(50,345,cs),
+(50,112,o),
+(144,-14,o),
+(289,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(682,242,l),
+(682,447,l),
+(600,447,l),
+(600,385,l),
+(485,385,l),
+(485,304,l),
+(600,304,l),
+(600,242,l)
+);
+}
+);
+width = 745;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dzeCarrier-canadian";
+note = uni164D;
+unicode = 5709;
+},
+{
+color = 9;
+glyphname = "suCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(368,-14,o),
+(439,37,o),
+(467,134,c),
+(405,134,l),
+(434,37,o),
+(504,-14,o),
+(597,-14,cs),
+(739,-14,o),
+(811,77,o),
+(811,192,cs),
+(811,312,o),
+(745,440,o),
+(745,508,cs),
+(745,536,o),
+(759,553,o),
+(794,553,cs),
+(820,553,l),
+(820,690,l),
+(760,690,ls),
+(639,690,o),
+(590,624,o),
+(590,533,cs),
+(590,429,o),
+(653,297,o),
+(653,213,cs),
+(653,159,o),
+(630,127,o),
+(583,127,cs),
+(537,127,o),
+(511,160,o),
+(511,227,cs),
+(511,690,l),
+(361,690,l),
+(361,227,ls),
+(361,160,o),
+(335,127,o),
+(288,127,cs),
+(242,127,o),
+(219,159,o),
+(219,213,cs),
+(219,297,o),
+(282,429,o),
+(282,533,cs),
+(282,624,o),
+(232,690,o),
+(112,690,cs),
+(52,690,l),
+(52,553,l),
+(77,553,ls),
+(112,553,o),
+(127,536,o),
+(127,508,cs),
+(127,440,o),
+(61,312,o),
+(61,192,cs),
+(61,77,o),
+(133,-14,o),
+(274,-14,cs)
+);
+}
+);
+width = 872;
+}
+);
+metricRight = "=|";
+note = uni164E;
+unicode = 5710;
+},
+{
+color = 9;
+glyphname = "soCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(112,0,ls),
+(232,0,o),
+(282,66,o),
+(282,156,cs),
+(282,261,o),
+(219,393,o),
+(219,477,cs),
+(219,530,o),
+(242,563,o),
+(288,563,cs),
+(335,563,o),
+(361,529,o),
+(361,463,cs),
+(361,0,l),
+(511,0,l),
+(511,463,ls),
+(511,529,o),
+(537,563,o),
+(583,563,cs),
+(630,563,o),
+(652,530,o),
+(652,477,cs),
+(652,393,o),
+(590,261,o),
+(590,156,cs),
+(590,66,o),
+(639,0,o),
+(760,0,cs),
+(820,0,l),
+(820,137,l),
+(794,137,ls),
+(759,137,o),
+(745,154,o),
+(745,182,cs),
+(745,250,o),
+(811,378,o),
+(811,497,cs),
+(811,612,o),
+(739,704,o),
+(597,704,cs),
+(504,704,o),
+(434,653,o),
+(406,555,c),
+(468,555,l),
+(438,653,o),
+(367,704,o),
+(274,704,cs),
+(133,704,o),
+(61,612,o),
+(61,497,cs),
+(61,378,o),
+(127,250,o),
+(127,182,cs),
+(127,154,o),
+(112,137,o),
+(77,137,cs),
+(52,137,l),
+(52,0,l)
+);
+}
+);
+width = 872;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5711;
+},
+{
+color = 9;
+glyphname = "seCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(604,-14,o),
+(675,73,o),
+(675,185,cs),
+(675,275,o),
+(621,348,o),
+(538,366,c),
+(538,324,l),
+(623,339,o),
+(675,410,o),
+(675,505,cs),
+(675,616,o),
+(604,704,o),
+(482,704,cs),
+(377,704,o),
+(278,616,o),
+(238,616,cs),
+(214,616,o),
+(204,631,o),
+(204,667,cs),
+(204,690,l),
+(61,690,l),
+(61,635,ls),
+(61,531,o),
+(115,480,o),
+(199,480,cs),
+(287,480,o),
+(371,561,o),
+(440,561,cs),
+(488,561,o),
+(515,533,o),
+(515,486,cs),
+(515,437,o),
+(484,409,o),
+(420,409,cs),
+(61,409,l),
+(61,281,l),
+(420,281,ls),
+(484,281,o),
+(515,253,o),
+(515,204,cs),
+(515,156,o),
+(488,128,o),
+(440,128,cs),
+(371,128,o),
+(287,210,o),
+(199,210,cs),
+(115,210,o),
+(61,158,o),
+(61,55,cs),
+(61,0,l),
+(204,0,l),
+(204,23,ls),
+(204,59,o),
+(214,73,o),
+(238,73,cs),
+(278,73,o),
+(377,-14,o),
+(482,-14,cs)
+);
+}
+);
+width = 734;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni1650;
+unicode = 5712;
+},
+{
+color = 9;
+glyphname = "seeCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(604,-14,o),
+(675,73,o),
+(675,185,cs),
+(675,272,o),
+(626,342,o),
+(548,364,c),
+(548,326,l),
+(627,344,o),
+(675,413,o),
+(675,505,cs),
+(675,616,o),
+(604,704,o),
+(482,704,cs),
+(377,704,o),
+(278,616,o),
+(238,616,cs),
+(214,616,o),
+(204,631,o),
+(204,667,cs),
+(204,690,l),
+(61,690,l),
+(61,635,ls),
+(61,531,o),
+(115,480,o),
+(199,480,cs),
+(287,480,o),
+(371,561,o),
+(440,561,cs),
+(488,561,o),
+(515,533,o),
+(515,486,cs),
+(515,437,o),
+(484,408,o),
+(432,408,cs),
+(386,408,l),
+(413,355,l),
+(413,479,l),
+(326,479,l),
+(326,408,l),
+(61,408,l),
+(61,282,l),
+(326,282,l),
+(326,209,l),
+(413,209,l),
+(413,332,l),
+(386,282,l),
+(432,282,ls),
+(484,282,o),
+(515,253,o),
+(515,204,cs),
+(515,156,o),
+(488,128,o),
+(440,128,cs),
+(371,128,o),
+(287,210,o),
+(199,210,cs),
+(115,210,o),
+(61,158,o),
+(61,55,cs),
+(61,0,l),
+(204,0,l),
+(204,23,ls),
+(204,59,o),
+(214,73,o),
+(238,73,cs),
+(278,73,o),
+(377,-14,o),
+(482,-14,cs)
+);
+}
+);
+width = 734;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1651;
+unicode = 5713;
+},
+{
+color = 9;
+glyphname = "siCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(604,-14,o),
+(675,73,o),
+(675,185,cs),
+(675,272,o),
+(626,342,o),
+(549,364,c),
+(548,326,l),
+(627,344,o),
+(675,413,o),
+(675,505,cs),
+(675,616,o),
+(604,704,o),
+(482,704,cs),
+(377,704,o),
+(278,616,o),
+(238,616,cs),
+(214,616,o),
+(204,631,o),
+(204,667,cs),
+(204,690,l),
+(61,690,l),
+(61,635,ls),
+(61,531,o),
+(115,480,o),
+(199,480,cs),
+(287,480,o),
+(371,564,o),
+(442,564,cs),
+(492,564,o),
+(518,534,o),
+(518,485,cs),
+(518,430,o),
+(491,404,o),
+(442,404,cs),
+(380,404,l),
+(431,358,l),
+(426,412,o),
+(384,453,o),
+(328,453,cs),
+(292,453,o),
+(261,435,o),
+(242,408,c),
+(61,408,l),
+(61,282,l),
+(242,282,l),
+(261,255,o),
+(292,238,o),
+(328,238,cs),
+(384,238,o),
+(424,279,o),
+(430,331,c),
+(378,286,l),
+(442,286,ls),
+(491,286,o),
+(518,260,o),
+(518,205,cs),
+(518,156,o),
+(492,126,o),
+(442,126,cs),
+(373,126,o),
+(287,210,o),
+(199,210,cs),
+(115,210,o),
+(61,158,o),
+(61,55,cs),
+(61,0,l),
+(204,0,l),
+(204,23,ls),
+(204,59,o),
+(214,73,o),
+(238,73,cs),
+(278,73,o),
+(377,-14,o),
+(482,-14,cs)
+);
+}
+);
+width = 734;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1652;
+unicode = 5714;
+},
+{
+color = 9;
+glyphname = "saCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(356,-14,o),
+(455,73,o),
+(496,73,cs),
+(520,73,o),
+(529,59,o),
+(529,23,cs),
+(529,0,l),
+(673,0,l),
+(673,55,ls),
+(673,158,o),
+(618,210,o),
+(535,210,cs),
+(446,210,o),
+(362,128,o),
+(295,128,cs),
+(246,128,o),
+(218,156,o),
+(218,204,cs),
+(218,253,o),
+(250,281,o),
+(313,281,cs),
+(673,281,l),
+(673,409,l),
+(313,409,ls),
+(250,409,o),
+(218,437,o),
+(218,486,cs),
+(218,533,o),
+(246,561,o),
+(295,561,cs),
+(362,561,o),
+(446,480,o),
+(535,480,cs),
+(618,480,o),
+(673,531,o),
+(673,635,cs),
+(673,690,l),
+(529,690,l),
+(529,667,ls),
+(529,631,o),
+(520,616,o),
+(496,616,cs),
+(455,616,o),
+(356,704,o),
+(251,704,cs),
+(130,704,o),
+(59,616,o),
+(59,505,cs),
+(59,410,o),
+(110,339,o),
+(195,324,c),
+(195,366,l),
+(112,348,o),
+(59,275,o),
+(59,185,cs),
+(59,73,o),
+(130,-14,o),
+(251,-14,cs)
+);
+}
+);
+width = 734;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1653;
+unicode = 5715;
+},
+{
+color = 9;
+glyphname = "shuCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(361,-14,o),
+(429,31,o),
+(461,117,c),
+(412,117,l),
+(443,31,o),
+(510,-14,o),
+(597,-14,cs),
+(739,-14,o),
+(811,77,o),
+(811,192,cs),
+(811,312,o),
+(745,440,o),
+(745,508,cs),
+(745,536,o),
+(759,553,o),
+(794,553,cs),
+(820,553,l),
+(820,690,l),
+(760,690,ls),
+(639,690,o),
+(592,624,o),
+(592,533,cs),
+(592,512,o),
+(596,486,o),
+(599,466,c),
+(621,574,l),
+(511,574,l),
+(511,690,l),
+(361,690,l),
+(361,574,l),
+(250,574,l),
+(273,466,l),
+(276,486,o),
+(280,512,o),
+(280,533,cs),
+(280,624,o),
+(232,690,o),
+(112,690,cs),
+(52,690,l),
+(52,553,l),
+(77,553,ls),
+(112,553,o),
+(127,536,o),
+(127,508,cs),
+(127,440,o),
+(61,312,o),
+(61,192,cs),
+(61,77,o),
+(133,-14,o),
+(274,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(242,127,o),
+(219,159,o),
+(219,213,cs),
+(219,274,o),
+(252,362,o),
+(270,444,c),
+(361,444,l),
+(361,227,ls),
+(361,160,o),
+(335,127,o),
+(288,127,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(537,127,o),
+(511,160,o),
+(511,227,cs),
+(511,444,l),
+(603,444,l),
+(619,362,o),
+(653,274,o),
+(653,213,cs),
+(653,159,o),
+(630,127,o),
+(583,127,cs)
+);
+}
+);
+width = 872;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1654;
+unicode = 5716;
+},
+{
+color = 9;
+glyphname = "shoCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(112,0,ls),
+(232,0,o),
+(280,66,o),
+(280,156,cs),
+(280,178,o),
+(276,204,o),
+(273,224,c),
+(250,116,l),
+(361,116,l),
+(361,0,l),
+(511,0,l),
+(511,116,l),
+(621,116,l),
+(599,224,l),
+(596,204,o),
+(592,178,o),
+(592,156,cs),
+(592,66,o),
+(639,0,o),
+(760,0,cs),
+(820,0,l),
+(820,137,l),
+(794,137,ls),
+(759,137,o),
+(745,154,o),
+(745,182,cs),
+(745,250,o),
+(811,378,o),
+(811,497,cs),
+(811,612,o),
+(739,704,o),
+(597,704,cs),
+(510,704,o),
+(443,659,o),
+(412,573,c),
+(460,573,l),
+(429,659,o),
+(361,704,o),
+(274,704,cs),
+(133,704,o),
+(61,612,o),
+(61,497,cs),
+(61,378,o),
+(127,250,o),
+(127,182,cs),
+(127,154,o),
+(112,137,o),
+(77,137,cs),
+(52,137,l),
+(52,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(252,327,o),
+(219,415,o),
+(219,477,cs),
+(219,530,o),
+(242,563,o),
+(288,563,cs),
+(335,563,o),
+(361,529,o),
+(361,463,cs),
+(361,245,l),
+(270,245,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(511,463,ls),
+(511,529,o),
+(537,563,o),
+(583,563,cs),
+(630,563,o),
+(652,530,o),
+(652,477,cs),
+(652,415,o),
+(619,327,o),
+(603,245,c),
+(511,245,l)
+);
+}
+);
+width = 872;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1655;
+unicode = 5717;
+},
+{
+color = 9;
+glyphname = "sheCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(604,-14,o),
+(675,73,o),
+(675,185,cs),
+(675,272,o),
+(626,342,o),
+(548,364,c),
+(548,326,l),
+(627,344,o),
+(675,413,o),
+(675,505,cs),
+(675,616,o),
+(604,704,o),
+(482,704,cs),
+(377,704,o),
+(278,616,o),
+(238,616,cs),
+(214,616,o),
+(204,631,o),
+(204,667,cs),
+(204,690,l),
+(61,690,l),
+(61,635,ls),
+(61,531,o),
+(115,482,o),
+(199,482,cs),
+(220,482,o),
+(242,487,o),
+(261,494,c),
+(163,515,l),
+(163,409,l),
+(61,409,l),
+(61,281,l),
+(163,281,l),
+(163,175,l),
+(260,196,l),
+(241,203,o),
+(220,208,o),
+(199,208,cs),
+(115,208,o),
+(61,158,o),
+(61,55,cs),
+(61,0,l),
+(204,0,l),
+(204,23,ls),
+(204,59,o),
+(214,73,o),
+(238,73,cs),
+(278,73,o),
+(377,-14,o),
+(482,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(289,281,l),
+(420,281,ls),
+(484,281,o),
+(515,253,o),
+(515,204,cs),
+(515,156,o),
+(488,128,o),
+(440,128,cs),
+(395,128,o),
+(343,162,o),
+(289,185,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(289,505,l),
+(343,527,o),
+(395,561,o),
+(440,561,cs),
+(488,561,o),
+(515,533,o),
+(515,486,cs),
+(515,437,o),
+(484,409,o),
+(420,409,cs),
+(289,409,l)
+);
+}
+);
+width = 734;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1656;
+unicode = 5718;
+},
+{
+color = 9;
+glyphname = "sheeCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(604,-14,o),
+(675,73,o),
+(675,185,cs),
+(675,272,o),
+(626,342,o),
+(548,364,c),
+(548,326,l),
+(627,344,o),
+(675,413,o),
+(675,505,cs),
+(675,616,o),
+(604,704,o),
+(482,704,cs),
+(377,704,o),
+(278,616,o),
+(238,616,cs),
+(214,616,o),
+(204,631,o),
+(204,667,cs),
+(204,690,l),
+(61,690,l),
+(61,635,ls),
+(61,531,o),
+(115,482,o),
+(199,482,cs),
+(218,482,o),
+(240,487,o),
+(258,493,c),
+(163,519,l),
+(163,397,l),
+(61,397,l),
+(61,293,l),
+(163,293,l),
+(163,171,l),
+(258,197,l),
+(240,203,o),
+(219,208,o),
+(199,208,cs),
+(115,208,o),
+(61,158,o),
+(61,55,cs),
+(61,0,l),
+(204,0,l),
+(204,23,ls),
+(204,59,o),
+(214,73,o),
+(238,73,cs),
+(278,73,o),
+(377,-14,o),
+(482,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(395,125,o),
+(333,168,o),
+(273,192,c),
+(273,293,l),
+(352,293,l),
+(352,211,l),
+(424,211,l),
+(424,315,l),
+(402,293,l),
+(440,293,ls),
+(491,293,o),
+(519,258,o),
+(519,210,cs),
+(519,155,o),
+(492,125,o),
+(442,125,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(424,477,l),
+(352,477,l),
+(352,397,l),
+(273,397,l),
+(273,497,l),
+(333,522,o),
+(395,565,o),
+(442,565,cs),
+(492,565,o),
+(519,535,o),
+(519,480,cs),
+(519,432,o),
+(490,397,o),
+(440,397,cs),
+(402,397,l),
+(424,375,l)
+);
+}
+);
+width = 734;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1657;
+unicode = 5719;
+},
+{
+color = 9;
+glyphname = "shiCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(61,635,ls),
+(61,531,o),
+(115,482,o),
+(199,482,cs),
+(216,482,o),
+(233,486,o),
+(251,490,c),
+(163,524,l),
+(163,397,l),
+(61,397,l),
+(61,293,l),
+(163,293,l),
+(163,166,l),
+(251,200,l),
+(233,204,o),
+(216,208,o),
+(199,208,cs),
+(115,208,o),
+(61,158,o),
+(61,55,cs),
+(61,0,l),
+(204,0,l),
+(204,23,ls),
+(204,59,o),
+(214,73,o),
+(238,73,cs),
+(278,73,o),
+(377,-14,o),
+(482,-14,cs),
+(604,-14,o),
+(675,73,o),
+(675,185,cs),
+(675,272,o),
+(626,342,o),
+(549,364,c),
+(548,326,l),
+(627,344,o),
+(675,413,o),
+(675,505,cs),
+(675,616,o),
+(604,704,o),
+(482,704,cs),
+(377,704,o),
+(278,616,o),
+(238,616,cs),
+(214,616,o),
+(204,631,o),
+(204,667,cs),
+(204,690,l),
+(61,690,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(273,293,l),
+(299,293,l),
+(318,256,o),
+(352,238,o),
+(387,238,cs),
+(444,238,o),
+(485,285,o),
+(487,337,c),
+(405,293,l),
+(448,293,ls),
+(494,293,o),
+(519,253,o),
+(519,210,cs),
+(519,155,o),
+(492,125,o),
+(442,125,cs),
+(395,125,o),
+(333,167,o),
+(273,191,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(273,498,l),
+(333,523,o),
+(395,565,o),
+(442,565,cs),
+(492,565,o),
+(519,535,o),
+(519,480,cs),
+(519,433,o),
+(494,397,o),
+(448,397,cs),
+(406,397,l),
+(488,352,l),
+(487,407,o),
+(444,453,o),
+(387,453,cs),
+(351,453,o),
+(317,434,o),
+(298,397,c),
+(273,397,l)
+);
+}
+);
+width = 734;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1658;
+unicode = 5720;
+},
+{
+color = 9;
+glyphname = "shaCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(356,-14,o),
+(455,73,o),
+(496,73,cs),
+(520,73,o),
+(529,59,o),
+(529,23,cs),
+(529,0,l),
+(673,0,l),
+(673,55,ls),
+(673,158,o),
+(618,208,o),
+(535,208,cs),
+(513,208,o),
+(493,203,o),
+(473,196,c),
+(571,175,l),
+(571,281,l),
+(673,281,l),
+(673,409,l),
+(571,409,l),
+(571,515,l),
+(473,494,l),
+(493,487,o),
+(513,482,o),
+(535,482,cs),
+(618,482,o),
+(673,531,o),
+(673,635,cs),
+(673,690,l),
+(529,690,l),
+(529,667,ls),
+(529,631,o),
+(520,616,o),
+(496,616,cs),
+(455,616,o),
+(356,704,o),
+(251,704,cs),
+(130,704,o),
+(59,616,o),
+(59,505,cs),
+(59,413,o),
+(107,344,o),
+(186,326,c),
+(185,364,l),
+(108,342,o),
+(59,272,o),
+(59,185,cs),
+(59,73,o),
+(130,-14,o),
+(251,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(246,128,o),
+(218,156,o),
+(218,204,cs),
+(218,253,o),
+(250,281,o),
+(313,281,cs),
+(445,281,l),
+(445,185,l),
+(391,162,o),
+(339,128,o),
+(295,128,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(250,409,o),
+(218,437,o),
+(218,486,cs),
+(218,533,o),
+(246,561,o),
+(295,561,cs),
+(339,561,o),
+(391,527,o),
+(445,505,c),
+(445,409,l),
+(313,409,ls)
+);
+}
+);
+width = 734;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1659;
+unicode = 5721;
+},
+{
+color = 6;
+glyphname = "shCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(259,96,l),
+(259,203,l),
+(202,183,l),
+(236,183,ls),
+(317,183,o),
+(360,218,o),
+(360,287,cs),
+(360,354,o),
+(318,395,o),
+(242,395,cs),
+(187,395,ls),
+(163,395,o),
+(149,402,o),
+(149,422,cs),
+(149,442,o),
+(163,447,o),
+(187,447,cs),
+(354,447,l),
+(354,527,l),
+(259,527,l),
+(259,614,l),
+(156,614,l),
+(156,500,l),
+(211,527,l),
+(178,527,ls),
+(97,527,o),
+(53,492,o),
+(53,423,cs),
+(53,356,o),
+(96,316,o),
+(172,316,cs),
+(226,316,ls),
+(250,316,o),
+(265,308,o),
+(265,288,cs),
+(265,268,o),
+(251,263,o),
+(226,263,cs),
+(60,263,l),
+(60,183,l),
+(156,183,l),
+(156,96,l)
+);
+}
+);
+width = 413;
+}
+);
+metricRight = "=|";
+note = uni18F5;
+unicode = 5722;
+},
+{
+color = 9;
+glyphname = "tsuCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(361,-14,o),
+(429,31,o),
+(461,117,c),
+(412,117,l),
+(443,31,o),
+(510,-14,o),
+(597,-14,cs),
+(739,-14,o),
+(811,77,o),
+(811,192,cs),
+(811,312,o),
+(745,440,o),
+(745,508,cs),
+(745,536,o),
+(759,553,o),
+(794,553,cs),
+(820,553,l),
+(820,690,l),
+(760,690,ls),
+(641,690,o),
+(594,627,o),
+(594,535,cs),
+(594,497,o),
+(604,453,o),
+(615,410,c),
+(508,410,l),
+(508,579,l),
+(563,579,l),
+(563,690,l),
+(308,690,l),
+(308,579,l),
+(364,579,l),
+(364,410,l),
+(257,410,l),
+(268,453,o),
+(278,497,o),
+(278,535,cs),
+(278,627,o),
+(231,690,o),
+(112,690,cs),
+(52,690,l),
+(52,553,l),
+(77,553,ls),
+(112,553,o),
+(127,536,o),
+(127,508,cs),
+(127,440,o),
+(61,312,o),
+(61,192,cs),
+(61,77,o),
+(133,-14,o),
+(274,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(242,127,o),
+(219,159,o),
+(219,213,cs),
+(219,232,o),
+(223,255,o),
+(227,280,c),
+(364,280,l),
+(364,227,ls),
+(364,160,o),
+(336,127,o),
+(289,127,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(536,127,o),
+(508,160,o),
+(508,227,cs),
+(508,280,l),
+(644,280,l),
+(649,255,o),
+(653,232,o),
+(653,213,cs),
+(653,159,o),
+(629,127,o),
+(583,127,cs)
+);
+}
+);
+width = 872;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165B;
+unicode = 5723;
+},
+{
+color = 9;
+glyphname = "tsoCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(112,0,ls),
+(231,0,o),
+(278,63,o),
+(278,155,cs),
+(278,193,o),
+(268,237,o),
+(257,280,c),
+(364,280,l),
+(364,111,l),
+(308,111,l),
+(308,0,l),
+(563,0,l),
+(563,111,l),
+(508,111,l),
+(508,280,l),
+(615,280,l),
+(604,237,o),
+(594,193,o),
+(594,155,cs),
+(594,63,o),
+(641,0,o),
+(760,0,cs),
+(820,0,l),
+(820,137,l),
+(794,137,ls),
+(759,137,o),
+(745,154,o),
+(745,182,cs),
+(745,250,o),
+(811,378,o),
+(811,497,cs),
+(811,612,o),
+(739,704,o),
+(597,704,cs),
+(510,704,o),
+(443,659,o),
+(412,573,c),
+(461,573,l),
+(428,659,o),
+(361,704,o),
+(274,704,cs),
+(133,704,o),
+(61,612,o),
+(61,497,cs),
+(61,378,o),
+(127,250,o),
+(127,182,cs),
+(127,154,o),
+(112,137,o),
+(77,137,cs),
+(52,137,l),
+(52,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(223,435,o),
+(219,458,o),
+(219,477,cs),
+(219,530,o),
+(242,563,o),
+(289,563,cs),
+(335,563,o),
+(364,529,o),
+(364,463,cs),
+(364,410,l),
+(227,410,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(508,463,ls),
+(508,529,o),
+(536,563,o),
+(583,563,cs),
+(629,563,o),
+(652,530,o),
+(652,477,cs),
+(652,458,o),
+(649,435,o),
+(644,410,c),
+(508,410,l)
+);
+}
+);
+width = 872;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165C;
+unicode = 5724;
+},
+{
+color = 9;
+glyphname = "tseCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(606,-14,o),
+(678,73,o),
+(678,185,cs),
+(678,272,o),
+(629,342,o),
+(551,364,c),
+(551,326,l),
+(630,344,o),
+(678,413,o),
+(678,505,cs),
+(678,616,o),
+(606,704,o),
+(485,704,cs),
+(380,704,o),
+(281,616,o),
+(241,616,cs),
+(217,616,o),
+(207,631,o),
+(207,667,cs),
+(207,690,l),
+(63,690,l),
+(63,640,ls),
+(63,537,o),
+(118,487,o),
+(201,487,cs),
+(234,487,o),
+(266,497,o),
+(297,509,c),
+(228,518,l),
+(228,398,l),
+(152,398,l),
+(152,461,l),
+(63,461,l),
+(63,229,l),
+(152,229,l),
+(152,292,l),
+(228,292,l),
+(228,172,l),
+(295,182,l),
+(265,194,o),
+(233,203,o),
+(201,203,cs),
+(118,203,o),
+(63,153,o),
+(63,49,cs),
+(63,0,l),
+(207,0,l),
+(207,23,ls),
+(207,59,o),
+(217,73,o),
+(241,73,cs),
+(281,73,o),
+(380,-14,o),
+(485,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(412,128,o),
+(376,145,o),
+(339,161,c),
+(339,292,l),
+(424,292,ls),
+(488,292,o),
+(519,254,o),
+(519,204,cs),
+(519,157,o),
+(492,128,o),
+(443,128,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(339,528,l),
+(376,545,o),
+(412,561,o),
+(443,561,cs),
+(492,561,o),
+(519,532,o),
+(519,486,cs),
+(519,436,o),
+(488,398,o),
+(424,398,cs),
+(339,398,l)
+);
+}
+);
+width = 737;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni165D;
+unicode = 5725;
+},
+{
+color = 9;
+glyphname = "tseeCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(606,-14,o),
+(678,73,o),
+(678,185,cs),
+(678,272,o),
+(629,342,o),
+(551,364,c),
+(551,326,l),
+(630,344,o),
+(678,413,o),
+(678,505,cs),
+(678,616,o),
+(606,704,o),
+(485,704,cs),
+(380,704,o),
+(281,616,o),
+(241,616,cs),
+(217,616,o),
+(207,631,o),
+(207,667,cs),
+(207,690,l),
+(63,690,l),
+(63,640,ls),
+(63,537,o),
+(118,487,o),
+(201,487,cs),
+(225,487,o),
+(248,493,o),
+(272,501,c),
+(223,518,l),
+(223,398,l),
+(149,398,l),
+(149,461,l),
+(63,461,l),
+(63,229,l),
+(149,229,l),
+(149,292,l),
+(223,292,l),
+(223,166,l),
+(270,189,l),
+(247,197,o),
+(224,203,o),
+(201,203,cs),
+(118,203,o),
+(63,153,o),
+(63,49,cs),
+(63,0,l),
+(207,0,l),
+(207,23,ls),
+(207,59,o),
+(217,73,o),
+(241,73,cs),
+(281,73,o),
+(380,-14,o),
+(485,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(406,128,o),
+(363,152,o),
+(318,172,c),
+(318,292,l),
+(373,292,l),
+(373,206,l),
+(445,206,l),
+(445,346,l),
+(387,292,l),
+(449,292,ls),
+(498,292,o),
+(521,254,o),
+(521,213,cs),
+(521,156,o),
+(493,128,o),
+(443,128,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(445,482,l),
+(373,482,l),
+(373,398,l),
+(318,398,l),
+(318,518,l),
+(363,538,o),
+(406,561,o),
+(443,561,cs),
+(493,561,o),
+(521,533,o),
+(521,477,cs),
+(521,436,o),
+(498,398,o),
+(449,398,cs),
+(388,398,l),
+(445,344,l)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165E;
+unicode = 5726;
+},
+{
+color = 9;
+glyphname = "tsiCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(606,-14,o),
+(678,73,o),
+(678,185,cs),
+(678,272,o),
+(628,342,o),
+(551,364,c),
+(551,326,l),
+(630,344,o),
+(678,413,o),
+(678,505,cs),
+(678,616,o),
+(606,704,o),
+(485,704,cs),
+(380,704,o),
+(281,616,o),
+(241,616,cs),
+(217,616,o),
+(207,631,o),
+(207,667,cs),
+(207,690,l),
+(63,690,l),
+(63,640,ls),
+(63,535,o),
+(118,487,o),
+(201,487,cs),
+(220,487,o),
+(240,492,o),
+(257,497,c),
+(201,547,l),
+(201,398,l),
+(149,398,l),
+(149,461,l),
+(63,461,l),
+(63,229,l),
+(149,229,l),
+(149,293,l),
+(201,293,l),
+(201,143,l),
+(254,193,l),
+(237,199,o),
+(219,203,o),
+(201,203,cs),
+(118,203,o),
+(63,155,o),
+(63,49,cs),
+(63,0,l),
+(207,0,l),
+(207,23,ls),
+(207,59,o),
+(217,73,o),
+(241,73,cs),
+(281,73,o),
+(380,-14,o),
+(485,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(400,128,o),
+(350,158,o),
+(297,180,c),
+(297,293,l),
+(320,293,l),
+(336,258,o),
+(368,238,o),
+(406,238,cs),
+(462,238,o),
+(498,286,o),
+(501,336,c),
+(436,294,l),
+(460,294,ls),
+(503,294,o),
+(521,258,o),
+(521,213,cs),
+(521,157,o),
+(493,128,o),
+(443,128,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(499,406,o),
+(463,453,o),
+(406,453,cs),
+(368,453,o),
+(336,432,o),
+(321,398,c),
+(297,398,l),
+(297,510,l),
+(350,531,o),
+(400,561,o),
+(443,561,cs),
+(493,561,o),
+(521,532,o),
+(521,477,cs),
+(521,432,o),
+(503,396,o),
+(460,396,cs),
+(437,396,l),
+(502,351,l)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165F;
+unicode = 5727;
+},
+{
+color = 9;
+glyphname = "tsaCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(356,-14,o),
+(455,73,o),
+(496,73,cs),
+(520,73,o),
+(529,59,o),
+(529,23,cs),
+(529,0,l),
+(673,0,l),
+(673,49,ls),
+(673,153,o),
+(618,203,o),
+(535,203,cs),
+(503,203,o),
+(471,194,o),
+(441,182,c),
+(508,172,l),
+(508,292,l),
+(584,292,l),
+(584,229,l),
+(673,229,l),
+(673,461,l),
+(584,461,l),
+(584,398,l),
+(508,398,l),
+(508,518,l),
+(440,509,l),
+(471,497,o),
+(502,487,o),
+(535,487,cs),
+(618,487,o),
+(673,537,o),
+(673,640,cs),
+(673,690,l),
+(529,690,l),
+(529,667,ls),
+(529,631,o),
+(520,616,o),
+(496,616,cs),
+(455,616,o),
+(356,704,o),
+(251,704,cs),
+(130,704,o),
+(59,616,o),
+(59,505,cs),
+(59,413,o),
+(107,344,o),
+(186,326,c),
+(185,364,l),
+(108,342,o),
+(59,272,o),
+(59,185,cs),
+(59,73,o),
+(130,-14,o),
+(251,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(245,128,o),
+(217,157,o),
+(217,204,cs),
+(217,254,o),
+(248,292,o),
+(312,292,cs),
+(398,292,l),
+(398,161,l),
+(360,145,o),
+(325,128,o),
+(294,128,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(249,398,o),
+(217,436,o),
+(217,486,cs),
+(217,532,o),
+(245,561,o),
+(294,561,cs),
+(325,561,o),
+(360,545,o),
+(398,528,c),
+(398,398,l),
+(312,398,ls)
+);
+}
+);
+width = 736;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1660;
+unicode = 5728;
+},
+{
+color = 9;
+glyphname = "chuCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(361,-14,o),
+(429,31,o),
+(461,117,c),
+(412,117,l),
+(443,31,o),
+(510,-14,o),
+(597,-14,cs),
+(739,-14,o),
+(811,77,o),
+(811,192,cs),
+(811,312,o),
+(745,440,o),
+(745,508,cs),
+(745,536,o),
+(759,553,o),
+(794,553,cs),
+(820,553,l),
+(820,690,l),
+(760,690,ls),
+(641,690,o),
+(594,627,o),
+(594,535,cs),
+(594,426,o),
+(653,297,o),
+(653,213,cs),
+(653,159,o),
+(629,127,o),
+(583,127,cs),
+(536,127,o),
+(509,160,o),
+(509,227,cs),
+(509,579,l),
+(563,579,l),
+(563,690,l),
+(308,690,l),
+(308,579,l),
+(362,579,l),
+(362,227,ls),
+(362,160,o),
+(336,127,o),
+(289,127,cs),
+(242,127,o),
+(219,159,o),
+(219,213,cs),
+(219,297,o),
+(278,426,o),
+(278,535,cs),
+(278,627,o),
+(231,690,o),
+(112,690,cs),
+(52,690,l),
+(52,553,l),
+(77,553,ls),
+(112,553,o),
+(127,536,o),
+(127,508,cs),
+(127,440,o),
+(61,312,o),
+(61,192,cs),
+(61,77,o),
+(133,-14,o),
+(274,-14,cs)
+);
+}
+);
+width = 872;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164E;
+unicode = 5729;
+},
+{
+color = 9;
+glyphname = "choCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(112,0,ls),
+(231,0,o),
+(278,63,o),
+(278,155,cs),
+(278,264,o),
+(219,393,o),
+(219,477,cs),
+(219,530,o),
+(242,563,o),
+(289,563,cs),
+(335,563,o),
+(362,529,o),
+(362,463,cs),
+(362,111,l),
+(308,111,l),
+(308,0,l),
+(563,0,l),
+(563,111,l),
+(509,111,l),
+(509,463,ls),
+(509,529,o),
+(536,563,o),
+(583,563,cs),
+(629,563,o),
+(652,530,o),
+(652,477,cs),
+(652,393,o),
+(594,264,o),
+(594,155,cs),
+(594,63,o),
+(641,0,o),
+(760,0,cs),
+(820,0,l),
+(820,137,l),
+(794,137,ls),
+(759,137,o),
+(745,154,o),
+(745,182,cs),
+(745,250,o),
+(811,378,o),
+(811,497,cs),
+(811,612,o),
+(739,704,o),
+(597,704,cs),
+(510,704,o),
+(443,659,o),
+(412,573,c),
+(461,573,l),
+(428,659,o),
+(361,704,o),
+(274,704,cs),
+(133,704,o),
+(61,612,o),
+(61,497,cs),
+(61,378,o),
+(127,250,o),
+(127,182,cs),
+(127,154,o),
+(112,137,o),
+(77,137,cs),
+(52,137,l),
+(52,0,l)
+);
+}
+);
+width = 872;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5730;
+},
+{
+color = 9;
+glyphname = "cheCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(606,-14,o),
+(678,73,o),
+(678,185,cs),
+(678,272,o),
+(629,342,o),
+(551,364,c),
+(551,326,l),
+(630,344,o),
+(678,413,o),
+(678,505,cs),
+(678,616,o),
+(606,704,o),
+(485,704,cs),
+(380,704,o),
+(281,616,o),
+(241,616,cs),
+(217,616,o),
+(207,631,o),
+(207,667,cs),
+(207,690,l),
+(63,690,l),
+(63,639,ls),
+(63,535,o),
+(118,485,o),
+(201,485,cs),
+(290,485,o),
+(374,561,o),
+(442,561,cs),
+(491,561,o),
+(518,533,o),
+(518,486,cs),
+(518,437,o),
+(487,409,o),
+(423,409,cs),
+(152,409,l),
+(152,461,l),
+(63,461,l),
+(63,229,l),
+(152,229,l),
+(152,281,l),
+(423,281,ls),
+(487,281,o),
+(518,253,o),
+(518,204,cs),
+(518,156,o),
+(491,128,o),
+(442,128,cs),
+(374,128,o),
+(290,205,o),
+(201,205,cs),
+(118,205,o),
+(63,155,o),
+(63,50,cs),
+(63,0,l),
+(207,0,l),
+(207,23,ls),
+(207,59,o),
+(217,73,o),
+(241,73,cs),
+(281,73,o),
+(380,-14,o),
+(485,-14,cs)
+);
+}
+);
+width = 737;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni1663;
+unicode = 5731;
+},
+{
+color = 9;
+glyphname = "cheeCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(606,-14,o),
+(678,73,o),
+(678,185,cs),
+(678,272,o),
+(629,342,o),
+(551,364,c),
+(551,326,l),
+(630,344,o),
+(678,413,o),
+(678,505,cs),
+(678,616,o),
+(606,704,o),
+(485,704,cs),
+(380,704,o),
+(281,616,o),
+(241,616,cs),
+(217,616,o),
+(207,631,o),
+(207,667,cs),
+(207,690,l),
+(63,690,l),
+(63,639,ls),
+(63,535,o),
+(118,485,o),
+(201,485,cs),
+(291,485,o),
+(377,565,o),
+(445,565,cs),
+(495,565,o),
+(522,535,o),
+(522,482,cs),
+(522,432,o),
+(493,397,o),
+(443,397,cs),
+(384,397,l),
+(418,381,l),
+(418,479,l),
+(329,479,l),
+(329,397,l),
+(152,397,l),
+(152,461,l),
+(63,461,l),
+(63,229,l),
+(152,229,l),
+(152,293,l),
+(329,293,l),
+(329,209,l),
+(418,209,l),
+(418,309,l),
+(384,293,l),
+(443,293,ls),
+(494,293,o),
+(522,258,o),
+(522,208,cs),
+(522,155,o),
+(495,125,o),
+(445,125,cs),
+(377,125,o),
+(291,205,o),
+(201,205,cs),
+(118,205,o),
+(63,155,o),
+(63,50,cs),
+(63,0,l),
+(207,0,l),
+(207,23,ls),
+(207,59,o),
+(217,73,o),
+(241,73,cs),
+(281,73,o),
+(380,-14,o),
+(485,-14,cs)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1664;
+unicode = 5732;
+},
+{
+color = 9;
+glyphname = "chiCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(606,-14,o),
+(678,73,o),
+(678,185,cs),
+(678,272,o),
+(628,342,o),
+(551,364,c),
+(551,326,l),
+(630,344,o),
+(678,413,o),
+(678,505,cs),
+(678,616,o),
+(606,704,o),
+(485,704,cs),
+(380,704,o),
+(281,616,o),
+(241,616,cs),
+(217,616,o),
+(207,631,o),
+(207,667,cs),
+(207,690,l),
+(63,690,l),
+(63,639,ls),
+(63,535,o),
+(118,485,o),
+(201,485,cs),
+(291,485,o),
+(377,565,o),
+(445,565,cs),
+(495,565,o),
+(522,535,o),
+(522,482,cs),
+(522,432,o),
+(493,397,o),
+(444,397,cs),
+(393,397,l),
+(444,349,l),
+(441,409,o),
+(399,453,o),
+(340,453,cs),
+(299,453,o),
+(266,430,o),
+(248,397,c),
+(152,397,l),
+(152,461,l),
+(63,461,l),
+(63,229,l),
+(152,229,l),
+(152,293,l),
+(248,293,l),
+(267,259,o),
+(299,238,o),
+(341,238,cs),
+(398,238,o),
+(440,283,o),
+(445,339,c),
+(392,293,l),
+(444,293,ls),
+(494,293,o),
+(522,258,o),
+(522,208,cs),
+(522,155,o),
+(495,125,o),
+(445,125,cs),
+(377,125,o),
+(291,205,o),
+(201,205,cs),
+(118,205,o),
+(63,155,o),
+(63,50,cs),
+(63,0,l),
+(207,0,l),
+(207,23,ls),
+(207,59,o),
+(217,73,o),
+(241,73,cs),
+(281,73,o),
+(380,-14,o),
+(485,-14,cs)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1665;
+unicode = 5733;
+},
+{
+color = 9;
+glyphname = "chaCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(356,-14,o),
+(455,73,o),
+(496,73,cs),
+(520,73,o),
+(529,59,o),
+(529,23,cs),
+(529,0,l),
+(673,0,l),
+(673,50,ls),
+(673,155,o),
+(618,205,o),
+(535,205,cs),
+(446,205,o),
+(362,128,o),
+(295,128,cs),
+(246,128,o),
+(218,156,o),
+(218,204,cs),
+(218,253,o),
+(250,281,o),
+(313,281,cs),
+(584,281,l),
+(584,229,l),
+(673,229,l),
+(673,461,l),
+(584,461,l),
+(584,409,l),
+(313,409,ls),
+(250,409,o),
+(218,437,o),
+(218,486,cs),
+(218,533,o),
+(246,561,o),
+(295,561,cs),
+(362,561,o),
+(446,485,o),
+(535,485,cs),
+(618,485,o),
+(673,535,o),
+(673,639,cs),
+(673,690,l),
+(529,690,l),
+(529,667,ls),
+(529,631,o),
+(520,616,o),
+(496,616,cs),
+(455,616,o),
+(356,704,o),
+(251,704,cs),
+(130,704,o),
+(59,616,o),
+(59,505,cs),
+(59,413,o),
+(107,344,o),
+(186,326,c),
+(185,364,l),
+(108,342,o),
+(59,272,o),
+(59,185,cs),
+(59,73,o),
+(130,-14,o),
+(251,-14,cs)
+);
+}
+);
+width = 736;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1666;
+unicode = 5734;
+},
+{
+color = 9;
+glyphname = "ttsuCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(361,-14,o),
+(429,31,o),
+(461,117,c),
+(412,117,l),
+(443,31,o),
+(510,-14,o),
+(597,-14,cs),
+(739,-14,o),
+(811,77,o),
+(811,192,cs),
+(811,312,o),
+(745,440,o),
+(745,508,cs),
+(745,536,o),
+(759,553,o),
+(794,553,cs),
+(820,553,l),
+(820,690,l),
+(760,690,ls),
+(641,690,o),
+(594,627,o),
+(594,535,cs),
+(594,502,o),
+(599,467,o),
+(605,433,c),
+(662,559,l),
+(508,451,l),
+(508,579,l),
+(563,579,l),
+(563,690,l),
+(308,690,l),
+(308,579,l),
+(364,579,l),
+(364,450,l),
+(211,559,l),
+(268,433,l),
+(272,469,o),
+(278,502,o),
+(278,535,cs),
+(278,627,o),
+(231,690,o),
+(112,690,cs),
+(52,690,l),
+(52,553,l),
+(77,553,ls),
+(112,553,o),
+(127,536,o),
+(127,508,cs),
+(127,440,o),
+(61,312,o),
+(61,192,cs),
+(61,77,o),
+(133,-14,o),
+(274,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(242,127,o),
+(219,159,o),
+(219,213,cs),
+(219,259,o),
+(238,318,o),
+(253,378,c),
+(364,303,l),
+(364,227,ls),
+(364,160,o),
+(336,127,o),
+(289,127,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(536,127,o),
+(508,160,o),
+(508,227,cs),
+(508,303,l),
+(618,378,l),
+(634,317,o),
+(653,259,o),
+(653,213,cs),
+(653,159,o),
+(629,127,o),
+(583,127,cs)
+);
+}
+);
+width = 872;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1667;
+unicode = 5735;
+},
+{
+color = 9;
+glyphname = "ttsoCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(112,0,ls),
+(231,0,o),
+(278,63,o),
+(278,155,cs),
+(278,187,o),
+(272,221,o),
+(268,257,c),
+(211,130,l),
+(364,240,l),
+(364,111,l),
+(308,111,l),
+(308,0,l),
+(563,0,l),
+(563,111,l),
+(508,111,l),
+(508,239,l),
+(662,130,l),
+(605,257,l),
+(599,223,o),
+(594,187,o),
+(594,155,cs),
+(594,63,o),
+(641,0,o),
+(760,0,cs),
+(820,0,l),
+(820,137,l),
+(794,137,ls),
+(759,137,o),
+(745,154,o),
+(745,182,cs),
+(745,250,o),
+(811,378,o),
+(811,497,cs),
+(811,612,o),
+(739,704,o),
+(597,704,cs),
+(510,704,o),
+(443,659,o),
+(412,573,c),
+(461,573,l),
+(429,659,o),
+(361,704,o),
+(274,704,cs),
+(133,704,o),
+(61,612,o),
+(61,497,cs),
+(61,378,o),
+(127,250,o),
+(127,182,cs),
+(127,154,o),
+(112,137,o),
+(77,137,cs),
+(52,137,l),
+(52,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(238,372,o),
+(219,431,o),
+(219,477,cs),
+(219,530,o),
+(242,563,o),
+(289,563,cs),
+(336,563,o),
+(364,529,o),
+(364,463,cs),
+(364,386,l),
+(253,312,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(508,386,l),
+(508,463,ls),
+(508,529,o),
+(536,563,o),
+(583,563,cs),
+(629,563,o),
+(653,530,o),
+(653,477,cs),
+(653,431,o),
+(634,373,o),
+(618,312,c)
+);
+}
+);
+width = 872;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1668;
+unicode = 5736;
+},
+{
+color = 9;
+glyphname = "ttseCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(606,-14,o),
+(678,73,o),
+(678,185,cs),
+(678,272,o),
+(628,342,o),
+(551,364,c),
+(551,326,l),
+(630,344,o),
+(678,413,o),
+(678,505,cs),
+(678,616,o),
+(606,704,o),
+(485,704,cs),
+(380,704,o),
+(281,616,o),
+(241,616,cs),
+(217,616,o),
+(207,631,o),
+(207,667,cs),
+(207,690,l),
+(63,690,l),
+(63,639,ls),
+(63,535,o),
+(118,485,o),
+(201,485,cs),
+(224,485,o),
+(244,490,o),
+(265,497,c),
+(154,555,l),
+(225,397,l),
+(152,397,l),
+(152,461,l),
+(63,461,l),
+(63,229,l),
+(152,229,l),
+(152,293,l),
+(225,293,l),
+(154,134,l),
+(266,192,l),
+(244,200,o),
+(224,205,o),
+(201,205,cs),
+(118,205,o),
+(63,155,o),
+(63,50,cs),
+(63,0,l),
+(207,0,l),
+(207,23,ls),
+(207,59,o),
+(217,73,o),
+(241,73,cs),
+(281,73,o),
+(380,-14,o),
+(485,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(399,125,o),
+(345,161,o),
+(291,184,c),
+(338,293,l),
+(444,293,ls),
+(494,293,o),
+(522,258,o),
+(522,208,cs),
+(522,155,o),
+(495,125,o),
+(445,125,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(291,506,l),
+(345,528,o),
+(399,565,o),
+(445,565,cs),
+(495,565,o),
+(522,535,o),
+(522,482,cs),
+(522,432,o),
+(493,397,o),
+(444,397,cs),
+(338,397,l)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1669;
+unicode = 5737;
+},
+{
+color = 9;
+glyphname = "ttseeCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(606,-14,o),
+(678,73,o),
+(678,185,cs),
+(678,272,o),
+(628,342,o),
+(551,364,c),
+(551,326,l),
+(630,344,o),
+(678,413,o),
+(678,505,cs),
+(678,616,o),
+(606,704,o),
+(485,704,cs),
+(380,704,o),
+(281,616,o),
+(241,616,cs),
+(217,616,o),
+(207,631,o),
+(207,667,cs),
+(207,690,l),
+(63,690,l),
+(63,639,ls),
+(63,535,o),
+(118,485,o),
+(201,485,cs),
+(224,485,o),
+(246,490,o),
+(258,499,c),
+(152,554,l),
+(222,397,l),
+(152,397,l),
+(152,461,l),
+(63,461,l),
+(63,229,l),
+(152,229,l),
+(152,293,l),
+(222,293,l),
+(152,136,l),
+(257,190,l),
+(246,200,o),
+(224,205,o),
+(201,205,cs),
+(118,205,o),
+(63,155,o),
+(63,50,cs),
+(63,0,l),
+(207,0,l),
+(207,23,ls),
+(207,59,o),
+(217,73,o),
+(241,73,cs),
+(281,73,o),
+(380,-14,o),
+(485,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(397,125,o),
+(342,164,o),
+(286,185,c),
+(332,293,l),
+(373,293,l),
+(373,206,l),
+(447,206,l),
+(447,315,l),
+(418,293,l),
+(444,293,ls),
+(494,293,o),
+(522,258,o),
+(522,208,cs),
+(522,155,o),
+(495,125,o),
+(445,125,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(447,482,l),
+(373,482,l),
+(373,397,l),
+(332,397,l),
+(286,504,l),
+(342,526,o),
+(397,565,o),
+(445,565,cs),
+(495,565,o),
+(522,535,o),
+(522,482,cs),
+(522,432,o),
+(493,397,o),
+(444,397,cs),
+(418,397,l),
+(447,375,l)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166A;
+unicode = 5738;
+},
+{
+color = 9;
+glyphname = "ttsiCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(606,-14,o),
+(678,73,o),
+(678,185,cs),
+(678,272,o),
+(628,342,o),
+(551,364,c),
+(551,326,l),
+(630,344,o),
+(678,413,o),
+(678,505,cs),
+(678,616,o),
+(606,704,o),
+(485,704,cs),
+(380,704,o),
+(281,616,o),
+(241,616,cs),
+(217,616,o),
+(207,631,o),
+(207,667,cs),
+(207,690,l),
+(63,690,l),
+(63,639,ls),
+(63,535,o),
+(118,485,o),
+(201,485,cs),
+(216,485,o),
+(230,487,o),
+(247,493,c),
+(168,519,l),
+(222,397,l),
+(152,397,l),
+(152,461,l),
+(63,461,l),
+(63,229,l),
+(152,229,l),
+(152,293,l),
+(222,293,l),
+(166,165,l),
+(247,198,l),
+(230,203,o),
+(216,205,o),
+(201,205,cs),
+(118,205,o),
+(63,155,o),
+(63,50,cs),
+(63,0,l),
+(207,0,l),
+(207,23,ls),
+(207,59,o),
+(217,73,o),
+(241,73,cs),
+(281,73,o),
+(380,-14,o),
+(485,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(394,125,o),
+(330,171,o),
+(270,191,c),
+(314,293,l),
+(322,293,l),
+(338,259,o),
+(369,238,o),
+(408,238,cs),
+(458,238,o),
+(496,278,o),
+(500,330,c),
+(431,293,l),
+(458,293,ls),
+(501,293,o),
+(522,258,o),
+(522,208,cs),
+(522,155,o),
+(495,125,o),
+(445,125,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(498,413,o),
+(459,453,o),
+(408,453,cs),
+(369,453,o),
+(338,430,o),
+(322,397,c),
+(314,397,l),
+(270,498,l),
+(330,519,o),
+(394,565,o),
+(445,565,cs),
+(495,565,o),
+(522,535,o),
+(522,482,cs),
+(522,432,o),
+(501,397,o),
+(458,397,cs),
+(432,397,l),
+(501,358,l)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166B;
+unicode = 5739;
+},
+{
+color = 9;
+glyphname = "ttsaCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(356,-14,o),
+(455,73,o),
+(496,73,cs),
+(520,73,o),
+(529,59,o),
+(529,23,cs),
+(529,0,l),
+(673,0,l),
+(673,50,ls),
+(673,155,o),
+(618,205,o),
+(535,205,cs),
+(512,205,o),
+(493,200,o),
+(471,192,c),
+(582,134,l),
+(511,293,l),
+(584,293,l),
+(584,229,l),
+(673,229,l),
+(673,461,l),
+(584,461,l),
+(584,397,l),
+(511,397,l),
+(582,555,l),
+(471,497,l),
+(493,490,o),
+(512,485,o),
+(535,485,cs),
+(618,485,o),
+(673,535,o),
+(673,639,cs),
+(673,690,l),
+(529,690,l),
+(529,667,ls),
+(529,631,o),
+(520,616,o),
+(496,616,cs),
+(455,616,o),
+(356,704,o),
+(251,704,cs),
+(130,704,o),
+(59,616,o),
+(59,505,cs),
+(59,413,o),
+(107,344,o),
+(185,326,c),
+(185,364,l),
+(108,342,o),
+(59,272,o),
+(59,185,cs),
+(59,73,o),
+(130,-14,o),
+(251,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(242,125,o),
+(214,155,o),
+(214,208,cs),
+(214,258,o),
+(243,293,o),
+(293,293,cs),
+(399,293,l),
+(445,184,l),
+(391,161,o),
+(337,125,o),
+(291,125,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(243,397,o),
+(214,432,o),
+(214,482,cs),
+(214,535,o),
+(242,565,o),
+(291,565,cs),
+(337,565,o),
+(391,528,o),
+(445,506,c),
+(399,397,l),
+(293,397,ls)
+);
+}
+);
+width = 736;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni166C;
+unicode = 5740;
+},
+{
+glyphname = "qai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (334,0);
+ref = "ke-canadian";
+}
+);
+width = 927;
+}
+);
+note = uni166F;
+unicode = 5743;
+},
+{
+glyphname = "ngai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (624,0);
+ref = "ce-canadian";
+}
+);
+width = 1208;
+}
+);
+note = uni1670;
+unicode = 5744;
+},
+{
+glyphname = "nngi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (904,0);
+ref = "ci-canadian";
+}
+);
+width = 1486;
+}
+);
+note = uni1671;
+unicode = 5745;
+},
+{
+glyphname = "nngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (904,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (1114,0);
+ref = dot_top;
+}
+);
+width = 1486;
+}
+);
+note = uni1672;
+unicode = 5746;
+},
+{
+glyphname = "nngo-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (904,0);
+ref = "ce-canadian";
+}
+);
+width = 1486;
+}
+);
+note = uni1673;
+unicode = 5747;
+},
+{
+glyphname = "nngoo-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (904,0);
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (1096,0);
+ref = dot_top;
+}
+);
+width = 1486;
+}
+);
+note = uni1674;
+unicode = 5748;
+},
+{
+glyphname = "nnga-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (904,0);
+ref = "ca-canadian";
+}
+);
+width = 1486;
+}
+);
+note = uni1675;
+unicode = 5749;
+},
+{
+glyphname = "nngaa-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (904,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (945,0);
+ref = dot_top;
+}
+);
+width = 1486;
+}
+);
+note = uni1676;
+unicode = 5750;
+},
+{
+glyphname = "thweeWoodScree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 852;
+}
+);
+note = uni1677;
+unicode = 5751;
+},
+{
+glyphname = "thwiWoodScree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 852;
+}
+);
+note = uni1678;
+unicode = 5752;
+},
+{
+glyphname = "thwiiWoodScree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (84,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 852;
+}
+);
+note = uni1679;
+unicode = 5753;
+},
+{
+glyphname = "thwoWoodScree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 852;
+}
+);
+note = uni167A;
+unicode = 5754;
+},
+{
+glyphname = "thwooWoodScree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (344,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 852;
+}
+);
+note = uni167B;
+unicode = 5755;
+},
+{
+glyphname = "thwaWoodScree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 852;
+}
+);
+note = uni167C;
+unicode = 5756;
+},
+{
+glyphname = "thwaaWoodScree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (85,0);
+ref = dot_top;
+},
+{
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 852;
+}
+);
+note = uni167D;
+unicode = 5757;
+},
+{
+glyphname = "wBlackfoot-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(375,545,l),
+(375,634,l),
+(53,634,l),
+(53,545,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(375,401,l),
+(375,490,l),
+(53,490,l),
+(53,401,l)
+);
+}
+);
+width = 428;
+}
+);
+metricRight = "=|";
+note = uni167F;
+unicode = 5759;
+},
+{
+glyphname = "oy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-3,0);
+ref = ring_top.canadian;
+}
+);
+width = 667;
+}
+);
+note = uni18B0;
+unicode = 6320;
+},
+{
+glyphname = "ay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (404,0);
+ref = ring_top.canadian;
+}
+);
+width = 667;
+}
+);
+note = uni18B1;
+unicode = 6321;
+},
+{
+glyphname = "aay-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (174,0);
+ref = ring_top.canadian;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (441,0);
+ref = dot_top;
+}
+);
+width = 667;
+}
+);
+note = uni18B2;
+unicode = 6322;
+},
+{
+glyphname = "way-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (640,0);
+ref = ring_top.canadian;
+}
+);
+width = 903;
+}
+);
+note = uni18B3;
+unicode = 6323;
+},
+{
+glyphname = "poy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-21,0);
+ref = ring_top.canadian;
+}
+);
+width = 645;
+}
+);
+note = uni18B4;
+unicode = 6324;
+},
+{
+glyphname = "pay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (403,0);
+ref = ring_top.canadian;
+}
+);
+width = 645;
+}
+);
+note = uni18B5;
+unicode = 6325;
+},
+{
+glyphname = "pwoy-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (215,0);
+ref = ring_top.canadian;
+}
+);
+width = 881;
+}
+);
+note = uni18B6;
+unicode = 6326;
+},
+{
+glyphname = "tay-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (205,0);
+ref = ring_top.canadian;
+}
+);
+width = 617;
+}
+);
+note = uni18B7;
+unicode = 6327;
+},
+{
+glyphname = "kay-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (4,0);
+ref = ring_top.canadian;
+}
+);
+width = 593;
+}
+);
+note = uni18B8;
+unicode = 6328;
+},
+{
+glyphname = "kway-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (241,0);
+ref = ring_top.canadian;
+}
+);
+width = 830;
+}
+);
+note = uni18B9;
+unicode = 6329;
+},
+{
+glyphname = "may-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (11,0);
+ref = ring_top.canadian;
+}
+);
+width = 552;
+}
+);
+note = uni18BA;
+unicode = 6330;
+},
+{
+glyphname = "noy-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (371,-179);
+ref = ring_top.canadian;
+}
+);
+width = 798;
+}
+);
+note = uni18BB;
+unicode = 6331;
+},
+{
+glyphname = "nay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (163,-179);
+ref = ring_top.canadian;
+}
+);
+width = 798;
+}
+);
+note = uni18BC;
+unicode = 6332;
+},
+{
+glyphname = "lay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (163,-179);
+ref = ring_top.canadian;
+}
+);
+width = 798;
+}
+);
+note = uni18BD;
+unicode = 6333;
+},
+{
+glyphname = "soy-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (283,0);
+ref = ring_top.canadian;
+}
+);
+width = 557;
+}
+);
+note = uni18BE;
+unicode = 6334;
+},
+{
+glyphname = "say-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (12,0);
+ref = ring_top.canadian;
+}
+);
+width = 557;
+}
+);
+note = uni18BF;
+unicode = 6335;
+},
+{
+glyphname = "shoy-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (317,-179);
+ref = ring_top.canadian;
+}
+);
+width = 898;
+}
+);
+note = uni18C0;
+unicode = 6336;
+},
+{
+glyphname = "shay-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (317,-179);
+ref = ring_top.canadian;
+}
+);
+width = 898;
+}
+);
+note = uni18C1;
+unicode = 6337;
+},
+{
+glyphname = "shwoy-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (554,-179);
+ref = ring_top.canadian;
+}
+);
+width = 1135;
+}
+);
+note = uni18C2;
+unicode = 6338;
+},
+{
+glyphname = "yoy-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (306,0);
+ref = ring_top.canadian;
+}
+);
+width = 580;
+}
+);
+note = uni18C3;
+unicode = 6339;
+},
+{
+glyphname = "yay-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (12,0);
+ref = ring_top.canadian;
+}
+);
+width = 580;
+}
+);
+note = uni18C4;
+unicode = 6340;
+},
+{
+glyphname = "ray-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (179,0);
+ref = ring_top.canadian;
+}
+);
+width = 557;
+}
+);
+note = uni18C5;
+unicode = 6341;
+},
+{
+glyphname = "nwi-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ni-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni18C6;
+unicode = 6342;
+},
+{
+glyphname = "nwiOjibway-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (798,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni18C7;
+unicode = 6343;
+},
+{
+glyphname = "nwii-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (458,-179);
+ref = dot_top;
+}
+);
+width = 1035;
+}
+);
+note = uni18C8;
+unicode = 6344;
+},
+{
+glyphname = "nwiiOjibway-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (221,-179);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (798,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni18C9;
+unicode = 6345;
+},
+{
+glyphname = "nwo-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "no-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni18CA;
+unicode = 6346;
+},
+{
+glyphname = "nwoOjibway-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (798,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni18CB;
+unicode = 6347;
+},
+{
+glyphname = "nwoo-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (645,-179);
+ref = dot_top;
+}
+);
+width = 1035;
+}
+);
+note = uni18CC;
+unicode = 6348;
+},
+{
+glyphname = "nwooOjibway-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (409,-179);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (798,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni18CD;
+unicode = 6349;
+},
+{
+glyphname = "rwee-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "reRCree-canadian";
+}
+);
+width = 1083;
+}
+);
+note = uni18CE;
+unicode = 6350;
+},
+{
+glyphname = "rwi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ri-canadian";
+}
+);
+width = 1083;
+}
+);
+note = uni18CF;
+unicode = 6351;
+},
+{
+glyphname = "rwii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (451,-179);
+ref = dot_top;
+}
+);
+width = 1083;
+}
+);
+note = uni18D0;
+unicode = 6352;
+},
+{
+glyphname = "rwo-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ro-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni18D1;
+unicode = 6353;
+},
+{
+glyphname = "rwoo-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (389,0);
+ref = dot_top;
+}
+);
+width = 794;
+}
+);
+note = uni18D2;
+unicode = 6354;
+},
+{
+glyphname = "rwa-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = "ra-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni18D3;
+unicode = 6355;
+},
+{
+glyphname = "pOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(139,345,l),
+(243,573,l),
+(168,573,l),
+(273,345,l),
+(376,345,l),
+(376,364,l),
+(217,690,l),
+(193,690,l),
+(35,364,l),
+(35,345,l)
+);
+}
+);
+width = 411;
+}
+);
+metricLeft = "kkCarrier-canadian";
+note = uni18D4;
+unicode = 6356;
+},
+{
+glyphname = "tOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 429;
+}
+);
+metricRight = "=|";
+note = uni1422;
+unicode = 6357;
+},
+{
+glyphname = "kOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(162,345,l),
+(162,480,l),
+(142,479,l),
+(149,454,o),
+(178,434,o),
+(215,434,cs),
+(281,434,o),
+(332,483,o),
+(332,562,cs),
+(332,648,o),
+(271,696,o),
+(196,696,cs),
+(106,696,o),
+(53,640,o),
+(53,559,cs),
+(53,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(171,511,o),
+(153,528,o),
+(153,565,cs),
+(153,601,o),
+(170,617,o),
+(194,617,cs),
+(217,617,o),
+(236,601,o),
+(236,565,cs),
+(236,528,o),
+(217,511,o),
+(194,511,cs)
+);
+}
+);
+width = 376;
+}
+);
+metricLeft = "k-canadian";
+metricRight = "k-canadian";
+note = uni18D6;
+unicode = 6358;
+},
+{
+glyphname = "cOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(162,345,l),
+(162,569,ls),
+(162,596,o),
+(174,611,o),
+(196,611,cs),
+(219,611,o),
+(233,596,o),
+(233,571,cs),
+(233,544,l),
+(335,544,l),
+(335,563,ls),
+(335,646,o),
+(281,696,o),
+(196,696,cs),
+(102,696,o),
+(53,646,o),
+(53,554,cs),
+(53,345,l)
+);
+}
+);
+width = 366;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni18D7;
+unicode = 6359;
+},
+{
+glyphname = "mOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(162,345,l),
+(162,588,l),
+(299,588,l),
+(299,690,l),
+(53,690,l),
+(53,345,l)
+);
+}
+);
+width = 340;
+}
+);
+metricLeft = "m-canadian";
+metricRight = "m-canadian";
+note = uni18D8;
+unicode = 6360;
+},
+{
+glyphname = "nOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(269,428,o),
+(320,477,o),
+(320,554,cs),
+(320,593,o),
+(301,625,o),
+(281,636,c),
+(276,588,l),
+(433,588,l),
+(433,690,l),
+(187,690,ls),
+(97,690,o),
+(44,637,o),
+(44,559,cs),
+(44,480,o),
+(99,428,o),
+(183,428,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(158,505,o),
+(141,524,o),
+(141,559,cs),
+(141,594,o),
+(158,612,o),
+(183,612,cs),
+(207,612,o),
+(223,594,o),
+(223,559,cs),
+(223,525,o),
+(207,505,o),
+(183,505,cs)
+);
+}
+);
+width = 473;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "n-canadian";
+note = uni18D9;
+unicode = 6361;
+},
+{
+glyphname = "sOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(162,345,l),
+(162,484,l),
+(90,441,l),
+(134,441,ls),
+(241,441,o),
+(309,514,o),
+(309,634,cs),
+(309,690,l),
+(200,690,l),
+(200,638,ls),
+(200,560,o),
+(164,527,o),
+(90,527,cs),
+(53,527,l),
+(53,345,l)
+);
+}
+);
+width = 362;
+}
+);
+metricLeft = "s-canadian";
+metricRight = "s-canadian";
+note = uni18DA;
+unicode = 6362;
+},
+{
+color = 1;
+glyphname = "shOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(255,339,o),
+(302,388,o),
+(309,474,cs),
+(316,568,ls),
+(319,597,o),
+(327,615,o),
+(353,615,cs),
+(377,615,o),
+(387,597,o),
+(387,567,cs),
+(387,544,l),
+(487,544,l),
+(487,565,ls),
+(487,648,o),
+(437,696,o),
+(353,696,cs),
+(263,696,o),
+(215,646,o),
+(209,560,cs),
+(202,467,ls),
+(199,438,o),
+(190,419,o),
+(166,419,cs),
+(141,419,o),
+(130,438,o),
+(130,468,cs),
+(130,491,l),
+(31,491,l),
+(31,469,ls),
+(31,386,o),
+(82,339,o),
+(165,339,cs)
+);
+}
+);
+width = 518;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "c-canadian";
+note = uni18DB;
+unicode = 6363;
+},
+{
+color = 9;
+glyphname = "easternw-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (19,-307);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (166,0);
+ref = "glottalstop-canadian";
+}
+);
+width = 583;
+}
+);
+note = uni18DC;
+unicode = 6364;
+},
+{
+color = 9;
+glyphname = "westernw-canadian";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (563,-307);
+ref = dot_top;
+scale = (-1,1);
+},
+{
+alignment = -1;
+pos = (421,0);
+ref = "glottalstop-canadian";
+scale = (-1,1);
+}
+);
+width = 584;
+}
+);
+metricLeft = "glottalstop-canadian";
+note = uni18DD;
+unicode = 6365;
+},
+{
+glyphname = "rweRCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "reRCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (846,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1083;
+}
+);
+note = uni18E0;
+unicode = 6368;
+},
+{
+glyphname = "looWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+}
+);
+width = 557;
+}
+);
+note = uni18E1;
+unicode = 6369;
+},
+{
+glyphname = "laaWestCree-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (321,0);
+ref = dot_top;
+}
+);
+width = 557;
+}
+);
+note = uni18E2;
+unicode = 6370;
+},
+{
+glyphname = "thwe-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "the-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (734,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 971;
+}
+);
+note = uni18E3;
+unicode = 6371;
+},
+{
+glyphname = "thwa-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (678,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 915;
+}
+);
+note = uni18E4;
+unicode = 6372;
+},
+{
+glyphname = "tthwe-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "tthe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (725,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 962;
+}
+);
+note = uni18E5;
+unicode = 6373;
+},
+{
+glyphname = "tthoo-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ttho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (222,0);
+ref = dot_top;
+}
+);
+width = 627;
+}
+);
+note = uni18E6;
+unicode = 6374;
+},
+{
+glyphname = "tthaa-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ttha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (218,0);
+ref = dot_top;
+}
+);
+width = 627;
+}
+);
+note = uni18E7;
+unicode = 6375;
+},
+{
+glyphname = "tlhwe-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "tlhe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (611,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 848;
+}
+);
+note = uni18E8;
+unicode = 6376;
+},
+{
+glyphname = "tlhoo-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "tlho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (220,0);
+ref = dot_top;
+}
+);
+width = 611;
+}
+);
+note = uni18E9;
+unicode = 6377;
+},
+{
+glyphname = "shweSayisi-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "sheSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (601,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni18EA;
+unicode = 6378;
+},
+{
+glyphname = "shooSayisi-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "shoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (371,0);
+ref = dot_top;
+}
+);
+width = 601;
+}
+);
+note = uni18EB;
+unicode = 6379;
+},
+{
+color = 9;
+glyphname = "hooSayisi-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "hoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (465,0);
+ref = dot_top;
+}
+);
+width = 700;
+}
+);
+note = uni18EC;
+unicode = 6380;
+},
+{
+color = 9;
+glyphname = "gwuCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "guCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (853,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1090;
+}
+);
+note = uni18ED;
+unicode = 6381;
+},
+{
+color = 9;
+glyphname = "deneGeeCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "geCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (275,0);
+ref = dot_top;
+}
+);
+width = 734;
+}
+);
+note = uni18EE;
+unicode = 6382;
+},
+{
+color = 9;
+glyphname = "gaaCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (289,0);
+ref = dot_top;
+}
+);
+width = 734;
+}
+);
+note = uni18EF;
+unicode = 6383;
+},
+{
+color = 9;
+glyphname = "gwaCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (734,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 971;
+}
+);
+note = uni18F0;
+unicode = 6384;
+},
+{
+color = 9;
+glyphname = "juuSayisi-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "juSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (276,0);
+ref = dot_top;
+}
+);
+width = 737;
+}
+);
+note = uni18F1;
+unicode = 6385;
+},
+{
+color = 9;
+glyphname = "jwaCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "jaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (780,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1016;
+}
+);
+note = uni18F2;
+unicode = 6386;
+},
+{
+glyphname = "lBeaverDene-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+ref = "pWestCree-canadian";
+}
+);
+width = 215;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+unicode = 6387;
+},
+{
+glyphname = "rBeaverDene-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(162,345,l),
+(162,507,ls),
+(162,557,o),
+(183,583,o),
+(229,583,cs),
+(241,583,l),
+(241,696,l),
+(231,696,ls),
+(182,696,o),
+(150,657,o),
+(147,606,c),
+(154,606,l),
+(154,690,l),
+(53,690,l),
+(53,345,l)
+);
+}
+);
+width = 269;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni18F4;
+unicode = 6388;
+},
+{
+color = 6;
+glyphname = "sDentalCarrier-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(231,183,ls),
+(318,183,o),
+(360,221,o),
+(360,287,cs),
+(360,351,o),
+(319,395,o),
+(237,395,cs),
+(187,395,ls),
+(163,395,o),
+(149,403,o),
+(149,421,cs),
+(149,440,o),
+(163,447,o),
+(187,447,cs),
+(354,447,l),
+(354,527,l),
+(184,527,ls),
+(96,527,o),
+(53,489,o),
+(53,423,cs),
+(53,359,o),
+(95,315,o),
+(178,315,cs),
+(226,315,ls),
+(250,315,o),
+(265,307,o),
+(265,289,cs),
+(265,270,o),
+(251,263,o),
+(226,263,cs),
+(60,263,l),
+(60,183,l)
+);
+}
+);
+width = 413;
+}
+);
+metricLeft = "shCarrier-canadian";
+metricRight = "=|";
+note = uni18F5;
+unicode = 6389;
+},
+{
+glyphname = "pWestCree-canadian.base";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "pWestCree-canadian";
+}
+);
+width = 215;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.base";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "c-canadian";
+}
+);
+width = 366;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "thSayisi-canadian.base";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "thSayisi-canadian";
+}
+);
+width = 366;
+}
+);
+metricLeft = "=|c-canadian";
+note = uni14A2;
+},
+{
+glyphname = "mWestCree-canadian.base";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "mWestCree-canadian";
+}
+);
+width = 365;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+glyphname = "pWestCree-canadian.mid";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "pWestCree-canadian";
+}
+);
+width = 215;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.mid";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "c-canadian";
+}
+);
+width = 366;
+}
+);
+metricLeft = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "mWestCree-canadian.mid";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "mWestCree-canadian";
+}
+);
+width = 365;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+color = 11;
+glyphname = "ngaai-canadian.nunavik";
+lastChange = "2023-01-13 15:57:17 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (652,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (825,0);
+ref = ring_top.canadian;
+}
+);
+width = 1239;
+}
+);
+note = uni158E;
+},
+{
+color = 11;
+glyphname = "ngi-canadian.nunavik";
+lastChange = "2023-01-13 15:57:17 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (652,0);
+ref = "ci-canadian";
+}
+);
+width = 1239;
+}
+);
+note = uni158F;
+},
+{
+color = 11;
+glyphname = "ngii-canadian.nunavik";
+lastChange = "2023-01-13 15:57:17 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (652,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (863,0);
+ref = dot_top;
+}
+);
+width = 1239;
+}
+);
+note = uni1590;
+},
+{
+color = 11;
+glyphname = "ngo-canadian.nunavik";
+lastChange = "2023-01-13 15:57:17 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (652,0);
+ref = "co-canadian";
+}
+);
+width = 1238;
+}
+);
+note = uni1591;
+},
+{
+color = 11;
+glyphname = "ngoo-canadian.nunavik";
+lastChange = "2023-01-13 15:57:17 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+ref = "ngo-canadian.nunavik";
+},
+{
+anchor = top_right_can;
+pos = (1008,0);
+ref = dot_top;
+}
+);
+width = 1238;
+}
+);
+note = uni1592;
+},
+{
+color = 11;
+glyphname = "nga-canadian.nunavik";
+lastChange = "2023-01-13 15:57:17 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (652,0);
+ref = "ca-canadian";
+}
+);
+width = 1239;
+}
+);
+note = uni1593;
+},
+{
+color = 11;
+glyphname = "ngaa-canadian.nunavik";
+lastChange = "2023-01-13 15:57:17 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (652,0);
+ref = "ca-canadian";
+},
+{
+anchor = top_left_can;
+pos = (694,0);
+ref = dot_top;
+}
+);
+width = 1239;
+}
+);
+note = uni1594;
+},
+{
+color = 11;
+glyphname = "ng-canadian.nunavik";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(548,170,o),
+(608,217,o),
+(608,303,cs),
+(608,383,o),
+(557,432,o),
+(492,432,cs),
+(461,432,o),
+(438,417,o),
+(427,396,c),
+(439,388,l),
+(439,536,l),
+(292,536,l),
+(299,509,l),
+(311,521,o),
+(320,545,o),
+(320,571,cs),
+(320,647,o),
+(269,696,o),
+(183,696,cs),
+(99,696,o),
+(44,645,o),
+(44,565,cs),
+(44,488,o),
+(97,435,o),
+(187,435,cs),
+(401,435,l),
+(329,507,l),
+(329,305,ls),
+(329,224,o),
+(383,170,o),
+(472,170,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(446,247,o),
+(429,265,o),
+(429,300,cs),
+(429,337,o),
+(447,354,o),
+(470,354,cs),
+(494,354,o),
+(512,337,o),
+(512,300,cs),
+(512,265,o),
+(494,247,o),
+(470,247,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(158,513,o),
+(141,530,o),
+(141,565,cs),
+(141,601,o),
+(158,619,o),
+(183,619,cs),
+(207,619,o),
+(223,601,o),
+(223,565,cs),
+(223,531,o),
+(207,513,o),
+(183,513,cs)
+);
+}
+);
+width = 652;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+color = 11;
+glyphname = "ngai-canadian.nunavik";
+lastChange = "2023-01-13 15:57:17 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (652,0);
+ref = "ce-canadian";
+}
+);
+width = 1238;
+}
+);
+note = uni1670;
+},
+{
+color = 11;
+glyphname = "ke-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (356,690);
+},
+{
+name = top_left_can;
+pos = (149,690);
+},
+{
+name = top_right_can;
+pos = (582,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(662,0,l),
+(662,690,l),
+(373,690,ls),
+(169,690,o),
+(50,585,o),
+(50,410,cs),
+(50,234,o),
+(169,129,o),
+(373,129,cs),
+(500,129,l),
+(500,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(265,270,o),
+(212,319,o),
+(212,410,cs),
+(212,500,o),
+(265,550,o),
+(367,550,cs),
+(500,550,l),
+(500,270,l),
+(367,270,ls)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146B;
+},
+{
+color = 11;
+glyphname = "ki-canadian.square";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (368,690);
+},
+{
+name = top_left_can;
+pos = (143,690);
+},
+{
+name = top_right_can;
+pos = (593,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(223,0,l),
+(223,129,l),
+(351,129,ls),
+(554,129,o),
+(673,234,o),
+(673,410,cs),
+(673,585,o),
+(554,690,o),
+(351,690,cs),
+(63,690,l),
+(63,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(223,550,l),
+(356,550,ls),
+(459,550,o),
+(513,500,o),
+(513,410,cs),
+(513,319,o),
+(459,270,o),
+(356,270,cs),
+(223,270,l)
+);
+}
+);
+width = 723;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni146D;
+},
+{
+color = 11;
+glyphname = "kii-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (274,0);
+ref = dot_top;
+}
+);
+width = 724;
+}
+);
+note = uni146E;
+},
+{
+color = 11;
+glyphname = "ko-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (356,690);
+},
+{
+name = top_left_can;
+pos = (149,690);
+},
+{
+name = top_right_can;
+pos = (582,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(662,0,l),
+(662,690,l),
+(500,690,l),
+(500,560,l),
+(373,560,ls),
+(169,560,o),
+(50,456,o),
+(50,280,cs),
+(50,104,o),
+(169,0,o),
+(373,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(265,140,o),
+(212,189,o),
+(212,280,cs),
+(212,371,o),
+(265,420,o),
+(367,420,cs),
+(500,420,l),
+(500,140,l),
+(367,140,ls)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146F;
+},
+{
+color = 11;
+glyphname = "koo-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (488,0);
+ref = dot_top;
+}
+);
+width = 724;
+}
+);
+note = uni1470;
+},
+{
+color = 11;
+glyphname = "ka-canadian.square";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (368,690);
+},
+{
+name = top_left_can;
+pos = (143,690);
+},
+{
+name = top_right_can;
+pos = (593,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(351,0,ls),
+(554,0,o),
+(673,104,o),
+(673,280,cs),
+(673,456,o),
+(554,560,o),
+(351,560,cs),
+(223,560,l),
+(223,690,l),
+(63,690,l),
+(63,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(223,420,l),
+(356,420,ls),
+(459,420,o),
+(513,371,o),
+(513,280,cs),
+(513,189,o),
+(459,140,o),
+(356,140,cs),
+(223,140,l)
+);
+}
+);
+width = 723;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1472;
+},
+{
+color = 11;
+glyphname = "kaa-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+}
+);
+width = 724;
+}
+);
+note = uni1473;
+},
+{
+color = 11;
+glyphname = "kweWestCree-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (724,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 960;
+}
+);
+note = uni1475;
+},
+{
+color = 11;
+glyphname = "kwiiWestCree-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (274,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (724,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 960;
+}
+);
+note = uni1479;
+},
+{
+color = 11;
+glyphname = "kwoWestCree-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (724,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 960;
+}
+);
+note = uni147B;
+},
+{
+color = 11;
+glyphname = "kwooWestCree-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (488,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (724,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 960;
+}
+);
+note = uni147D;
+},
+{
+color = 11;
+glyphname = "kwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (724,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 960;
+}
+);
+note = uni147F;
+},
+{
+color = 11;
+glyphname = "kwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (724,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 960;
+}
+);
+note = uni1481;
+},
+{
+color = 11;
+glyphname = "ce-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (347,690);
+},
+{
+name = top_left_can;
+pos = (120,690);
+},
+{
+name = top_right_can;
+pos = (575,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(654,0,l),
+(654,383,ls),
+(654,593,o),
+(543,704,o),
+(344,704,cs),
+(147,704,o),
+(41,589,o),
+(41,404,cs),
+(41,377,l),
+(199,377,l),
+(199,409,ls),
+(199,508,o),
+(251,559,o),
+(341,559,cs),
+(445,559,o),
+(494,502,o),
+(494,379,cs),
+(494,0,l)
+);
+}
+);
+width = 710;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni1489;
+},
+{
+color = 11;
+glyphname = "ci-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (362,690);
+},
+{
+name = top_left_can;
+pos = (136,690);
+},
+{
+name = top_right_can;
+pos = (590,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(216,0,l),
+(216,379,ls),
+(216,502,o),
+(265,559,o),
+(369,559,cs),
+(459,559,o),
+(511,508,o),
+(511,409,cs),
+(511,377,l),
+(669,377,l),
+(669,404,ls),
+(669,589,o),
+(563,704,o),
+(365,704,cs),
+(167,704,o),
+(56,593,o),
+(56,383,cs),
+(56,0,l)
+);
+}
+);
+width = 710;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+},
+{
+color = 11;
+glyphname = "cii-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (269,0);
+ref = dot_top;
+}
+);
+width = 710;
+}
+);
+note = uni148C;
+},
+{
+color = 11;
+glyphname = "co-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (347,690);
+},
+{
+name = top_left_can;
+pos = (120,690);
+},
+{
+name = top_right_can;
+pos = (575,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(543,-14,o),
+(654,97,o),
+(654,307,cs),
+(654,690,l),
+(494,690,l),
+(494,311,ls),
+(494,187,o),
+(445,130,o),
+(341,130,cs),
+(251,130,o),
+(199,182,o),
+(199,281,cs),
+(199,313,l),
+(41,313,l),
+(41,286,ls),
+(41,100,o),
+(147,-14,o),
+(344,-14,cs)
+);
+}
+);
+width = 710;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+},
+{
+color = 11;
+glyphname = "coo-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (480,0);
+ref = dot_top;
+}
+);
+width = 710;
+}
+);
+note = uni148E;
+},
+{
+color = 11;
+glyphname = "ca-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (362,690);
+},
+{
+name = top_left_can;
+pos = (136,690);
+},
+{
+name = top_right_can;
+pos = (590,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(563,-14,o),
+(669,100,o),
+(669,286,cs),
+(669,313,l),
+(511,313,l),
+(511,281,ls),
+(511,182,o),
+(459,130,o),
+(369,130,cs),
+(265,130,o),
+(216,187,o),
+(216,311,cs),
+(216,690,l),
+(56,690,l),
+(56,307,ls),
+(56,97,o),
+(167,-14,o),
+(365,-14,cs)
+);
+}
+);
+width = 710;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+},
+{
+color = 11;
+glyphname = "caa-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (43,0);
+ref = dot_top;
+}
+);
+width = 710;
+}
+);
+note = uni1491;
+},
+{
+color = 11;
+glyphname = "me-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (299,690);
+},
+{
+name = top_double;
+pos = (474,690);
+},
+{
+name = top_left_can;
+pos = (115,690);
+},
+{
+name = top_right_can;
+pos = (474,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(554,0,l),
+(554,690,l),
+(36,690,l),
+(36,546,l),
+(394,546,l),
+(394,0,l)
+);
+}
+);
+width = 617;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+},
+{
+color = 11;
+glyphname = "mi-canadian.square";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (322,690);
+},
+{
+name = top_left_can;
+pos = (143,690);
+},
+{
+name = top_right_can;
+pos = (500,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(223,0,l),
+(223,546,l),
+(582,546,l),
+(582,690,l),
+(63,690,l),
+(63,0,l)
+);
+}
+);
+width = 618;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+},
+{
+color = 11;
+glyphname = "mii-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (228,0);
+ref = dot_top;
+}
+);
+width = 617;
+}
+);
+note = uni14A6;
+},
+{
+color = 11;
+glyphname = "mo-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (299,690);
+},
+{
+name = top_double;
+pos = (474,690);
+},
+{
+name = top_left_can;
+pos = (115,690);
+},
+{
+name = top_right_can;
+pos = (474,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(554,0,l),
+(554,690,l),
+(394,690,l),
+(394,144,l),
+(36,144,l),
+(36,0,l)
+);
+}
+);
+width = 617;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+},
+{
+color = 11;
+glyphname = "moo-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (381,0);
+ref = dot_top;
+}
+);
+width = 617;
+}
+);
+note = uni14A8;
+},
+{
+color = 11;
+glyphname = "ma-canadian.square";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (322,690);
+},
+{
+name = top_left_can;
+pos = (143,690);
+},
+{
+name = top_right_can;
+pos = (500,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(582,0,l),
+(582,144,l),
+(223,144,l),
+(223,690,l),
+(63,690,l),
+(63,0,l)
+);
+}
+);
+width = 618;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+},
+{
+color = 11;
+glyphname = "maa-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+}
+);
+width = 617;
+}
+);
+note = uni14AB;
+},
+{
+color = 11;
+glyphname = "ne-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (433,690);
+},
+{
+name = top_left_can;
+pos = (255,690);
+},
+{
+name = top_right_can;
+pos = (613,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(597,-14,o),
+(693,89,o),
+(693,265,cs),
+(693,690,l),
+(41,690,l),
+(41,549,l),
+(175,549,l),
+(175,266,ls),
+(175,89,o),
+(270,-14,o),
+(434,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(368,130,o),
+(334,171,o),
+(334,249,cs),
+(334,549,l),
+(532,549,l),
+(532,249,ls),
+(532,172,o),
+(499,130,o),
+(434,130,cs)
+);
+}
+);
+width = 749;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C0;
+},
+{
+color = 11;
+glyphname = "ni-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (315,690);
+},
+{
+name = top_left_can;
+pos = (136,690);
+},
+{
+name = top_right_can;
+pos = (494,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(478,-14,o),
+(574,89,o),
+(574,266,cs),
+(574,549,l),
+(708,549,l),
+(708,690,l),
+(56,690,l),
+(56,265,ls),
+(56,89,o),
+(151,-14,o),
+(315,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(249,130,o),
+(215,172,o),
+(215,249,cs),
+(215,549,l),
+(413,549,l),
+(413,249,ls),
+(413,171,o),
+(381,130,o),
+(315,130,cs)
+);
+}
+);
+width = 749;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+},
+{
+color = 11;
+glyphname = "nii-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (220,0);
+ref = dot_top;
+}
+);
+width = 748;
+}
+);
+note = uni14C3;
+},
+{
+color = 11;
+glyphname = "no-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (434,690);
+},
+{
+name = top_double;
+pos = (443,690);
+},
+{
+name = top_left_can;
+pos = (255,690);
+},
+{
+name = top_right_can;
+pos = (603,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(693,0,l),
+(693,425,ls),
+(693,601,o),
+(597,704,o),
+(434,704,cs),
+(270,704,o),
+(175,601,o),
+(175,424,cs),
+(175,141,l),
+(41,141,l),
+(41,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(334,440,ls),
+(334,519,o),
+(368,559,o),
+(434,559,cs),
+(499,559,o),
+(532,518,o),
+(532,440,cs),
+(532,141,l),
+(334,141,l)
+);
+}
+);
+width = 749;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C4;
+},
+{
+color = 11;
+glyphname = "noo-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (339,0);
+ref = dot_top;
+}
+);
+width = 748;
+}
+);
+note = uni14C5;
+},
+{
+color = 11;
+glyphname = "na-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (315,690);
+},
+{
+name = top_double;
+pos = (325,690);
+},
+{
+name = top_left_can;
+pos = (136,690);
+},
+{
+name = top_right_can;
+pos = (494,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(708,0,l),
+(708,141,l),
+(574,141,l),
+(574,424,ls),
+(574,601,o),
+(478,704,o),
+(315,704,cs),
+(151,704,o),
+(56,601,o),
+(56,425,cs),
+(56,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(215,440,ls),
+(215,518,o),
+(249,559,o),
+(315,559,cs),
+(381,559,o),
+(413,519,o),
+(413,440,cs),
+(413,141,l),
+(215,141,l)
+);
+}
+);
+width = 749;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+},
+{
+color = 11;
+glyphname = "naa-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (220,0);
+ref = dot_top;
+}
+);
+width = 748;
+}
+);
+note = uni14C8;
+},
+{
+color = 11;
+glyphname = "nweWestCree-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (748,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 984;
+}
+);
+note = uni14CA;
+},
+{
+color = 11;
+glyphname = "nwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (748,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 984;
+}
+);
+note = uni14CC;
+},
+{
+color = 11;
+glyphname = "nwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (220,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (748,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 984;
+}
+);
+note = uni14CE;
+},
+{
+color = 11;
+glyphname = "se-canadian.square";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (143,690);
+},
+{
+name = top_right_can;
+pos = (582,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(659,0,l),
+(659,308,l),
+(401,308,ls),
+(282,308,o),
+(222,370,o),
+(222,490,cs),
+(222,690,l),
+(62,690,l),
+(62,484,ls),
+(62,285,o),
+(186,168,o),
+(404,168,cs),
+(537,168,l),
+(498,208,l),
+(498,0,l)
+);
+}
+);
+width = 721;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14ED;
+},
+{
+color = 11;
+glyphname = "si-canadian.square";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (142,690);
+},
+{
+name = top_right_can;
+pos = (582,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(222,0,l),
+(222,208,l),
+(183,168,l),
+(317,168,ls),
+(533,168,o),
+(658,285,o),
+(658,477,cs),
+(658,690,l),
+(497,690,l),
+(497,483,ls),
+(497,370,o),
+(439,308,o),
+(323,308,cs),
+(62,308,l),
+(62,0,l)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+},
+{
+color = 11;
+glyphname = "sii-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (489,0);
+ref = dot_top;
+}
+);
+width = 722;
+}
+);
+note = uni14F0;
+},
+{
+color = 11;
+glyphname = "so-canadian.square";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (579,690);
+},
+{
+name = top_left_can;
+pos = (143,690);
+},
+{
+name = top_right_can;
+pos = (579,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(222,0,l),
+(222,200,ls),
+(222,320,o),
+(282,382,o),
+(401,382,cs),
+(659,382,l),
+(659,690,l),
+(498,690,l),
+(498,482,l),
+(537,522,l),
+(404,522,ls),
+(186,522,o),
+(62,405,o),
+(62,206,cs),
+(62,0,l)
+);
+}
+);
+width = 721;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+},
+{
+color = 11;
+glyphname = "soo-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (485,0);
+ref = dot_top;
+}
+);
+width = 722;
+}
+);
+note = uni14F2;
+},
+{
+color = 11;
+glyphname = "sa-canadian.square";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (142,690);
+},
+{
+name = top_right_can;
+pos = (579,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(658,0,l),
+(658,206,ls),
+(658,405,o),
+(533,522,o),
+(317,522,cs),
+(183,522,l),
+(222,482,l),
+(222,690,l),
+(62,690,l),
+(62,382,l),
+(320,382,ls),
+(439,382,o),
+(497,320,o),
+(497,200,cs),
+(497,0,l)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+},
+{
+color = 11;
+glyphname = "saa-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+}
+);
+width = 722;
+}
+);
+note = uni14F5;
+},
+{
+color = 11;
+glyphname = "sho-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (357,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(651,0,l),
+(651,130,l),
+(308,130,ls),
+(242,130,o),
+(212,155,o),
+(212,205,cs),
+(212,257,o),
+(242,281,o),
+(307,281,cs),
+(433,281,ls),
+(589,281,o),
+(664,354,o),
+(664,486,cs),
+(664,618,o),
+(589,690,o),
+(433,690,cs),
+(64,690,l),
+(64,559,l),
+(407,559,ls),
+(473,559,o),
+(503,535,o),
+(503,486,cs),
+(503,440,o),
+(473,410,o),
+(408,410,cs),
+(282,410,ls),
+(126,410,o),
+(51,336,o),
+(51,204,cs),
+(51,71,o),
+(126,0,o),
+(282,0,cs)
+);
+}
+);
+width = 715;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+color = 11;
+glyphname = "shoo-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (264,0);
+ref = dot_top;
+}
+);
+width = 715;
+}
+);
+note = g728;
+},
+{
+color = 11;
+glyphname = "sha-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (357,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(433,0,ls),
+(588,0,o),
+(664,71,o),
+(664,204,cs),
+(664,336,o),
+(588,410,o),
+(433,410,cs),
+(307,410,ls),
+(242,410,o),
+(212,440,o),
+(212,485,cs),
+(212,535,o),
+(242,559,o),
+(308,559,cs),
+(651,559,l),
+(651,690,l),
+(282,690,ls),
+(127,690,o),
+(51,618,o),
+(51,486,cs),
+(51,354,o),
+(127,281,o),
+(282,281,cs),
+(408,281,ls),
+(473,281,o),
+(503,257,o),
+(503,204,cs),
+(503,155,o),
+(473,130,o),
+(407,130,cs),
+(64,130,l),
+(64,0,l)
+);
+}
+);
+width = 715;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+color = 11;
+glyphname = "shaa-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (264,0);
+ref = dot_top;
+}
+);
+width = 715;
+}
+);
+note = g730;
+},
+{
+color = 11;
+glyphname = "ye-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (110,690);
+},
+{
+name = top_right_can;
+pos = (599,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(678,0,l),
+(678,308,l),
+(271,308,l),
+(271,226,l),
+(694,596,l),
+(594,701,l),
+(29,209,l),
+(29,168,l),
+(518,168,l),
+(518,0,l)
+);
+}
+);
+width = 735;
+}
+);
+metricLeft = "ye-canadian";
+note = uni1526;
+},
+{
+color = 11;
+glyphname = "yi-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (137,690);
+},
+{
+name = top_right_can;
+pos = (625,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(217,0,l),
+(217,168,l),
+(706,168,l),
+(706,209,l),
+(141,701,l),
+(42,596,l),
+(464,226,l),
+(464,308,l),
+(57,308,l),
+(57,0,l)
+);
+}
+);
+width = 735;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni1528;
+},
+{
+color = 11;
+glyphname = "yii-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (43,0);
+ref = dot_top;
+}
+);
+width = 735;
+}
+);
+note = uni1529;
+},
+{
+color = 11;
+glyphname = "yo-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (599,690);
+},
+{
+name = top_left_can;
+pos = (110,690);
+},
+{
+name = top_right_can;
+pos = (599,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(694,94,l),
+(271,464,l),
+(271,382,l),
+(678,382,l),
+(678,690,l),
+(518,690,l),
+(518,522,l),
+(29,522,l),
+(29,481,l),
+(594,-12,l)
+);
+}
+);
+width = 735;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152A;
+},
+{
+color = 11;
+glyphname = "yoo-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (504,0);
+ref = dot_top;
+}
+);
+width = 735;
+}
+);
+note = uni152B;
+},
+{
+color = 11;
+glyphname = "ya-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (137,690);
+},
+{
+name = top_right_can;
+pos = (625,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(706,481,l),
+(706,522,l),
+(217,522,l),
+(217,690,l),
+(57,690,l),
+(57,382,l),
+(464,382,l),
+(464,464,l),
+(42,94,l),
+(141,-12,l)
+);
+}
+);
+width = 735;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152D;
+},
+{
+color = 11;
+glyphname = "yaa-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (43,0);
+ref = dot_top;
+}
+);
+width = 735;
+}
+);
+note = uni152E;
+},
+{
+color = 11;
+glyphname = "re-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (315,690);
+},
+{
+name = top_left_can;
+pos = (136,690);
+},
+{
+name = top_right_can;
+pos = (494,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(479,-14,o),
+(574,89,o),
+(574,266,cs),
+(574,549,l),
+(708,549,l),
+(708,690,l),
+(413,690,l),
+(413,249,ls),
+(413,171,o),
+(381,130,o),
+(315,130,cs),
+(249,130,o),
+(215,172,o),
+(215,249,cs),
+(215,690,l),
+(56,690,l),
+(56,265,ls),
+(56,89,o),
+(151,-14,o),
+(315,-14,cs)
+);
+}
+);
+width = 749;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1542;
+},
+{
+color = 11;
+glyphname = "reRCree-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (434,690);
+},
+{
+name = top_left_can;
+pos = (255,690);
+},
+{
+name = top_right_can;
+pos = (613,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(597,-14,o),
+(693,89,o),
+(693,265,cs),
+(693,690,l),
+(532,690,l),
+(532,249,ls),
+(532,172,o),
+(499,130,o),
+(434,130,cs),
+(368,130,o),
+(334,171,o),
+(334,249,cs),
+(334,690,l),
+(41,690,l),
+(41,549,l),
+(175,549,l),
+(175,266,ls),
+(175,89,o),
+(269,-14,o),
+(434,-14,cs)
+);
+}
+);
+width = 749;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni1543;
+},
+{
+color = 11;
+glyphname = "leWestCree-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (434,690);
+},
+{
+name = top_left_can;
+pos = (255,690);
+},
+{
+name = top_right_can;
+pos = (613,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(334,0,l),
+(334,440,ls),
+(334,519,o),
+(368,558,o),
+(434,558,cs),
+(499,558,o),
+(532,518,o),
+(532,440,cs),
+(532,0,l),
+(693,0,l),
+(693,424,ls),
+(693,601,o),
+(597,703,o),
+(434,703,cs),
+(269,703,o),
+(175,601,o),
+(175,424,cs),
+(175,141,l),
+(41,141,l),
+(41,0,l)
+);
+}
+);
+width = 752;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+},
+{
+color = 11;
+glyphname = "ri-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (315,690);
+},
+{
+name = top_left_can;
+pos = (139,690);
+},
+{
+name = top_right_can;
+pos = (494,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(215,0,l),
+(215,440,ls),
+(215,518,o),
+(249,559,o),
+(315,559,cs),
+(381,559,o),
+(413,519,o),
+(413,440,cs),
+(413,0,l),
+(708,0,l),
+(708,141,l),
+(574,141,l),
+(574,424,ls),
+(574,601,o),
+(479,704,o),
+(315,704,cs),
+(151,704,o),
+(56,601,o),
+(56,425,cs),
+(56,0,l)
+);
+}
+);
+width = 749;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+},
+{
+color = 11;
+glyphname = "rii-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (220,0);
+ref = dot_top;
+}
+);
+width = 748;
+}
+);
+note = uni1547;
+},
+{
+color = 11;
+glyphname = "ro-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (359,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(223,0,l),
+(223,169,l),
+(178,129,l),
+(333,129,ls),
+(537,129,o),
+(655,234,o),
+(655,410,cs),
+(655,585,o),
+(537,690,o),
+(333,690,cs),
+(63,690,l),
+(63,550,l),
+(339,550,ls),
+(441,550,o),
+(495,500,o),
+(495,410,cs),
+(495,319,o),
+(441,270,o),
+(339,270,cs),
+(63,270,l),
+(63,0,l)
+);
+}
+);
+width = 705;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1548;
+},
+{
+color = 11;
+glyphname = "loWestCree-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (359,690);
+},
+{
+name = top_left_can;
+pos = (143,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(333,0,ls),
+(537,0,o),
+(655,104,o),
+(655,280,cs),
+(655,456,o),
+(537,560,o),
+(333,560,cs),
+(178,560,l),
+(223,521,l),
+(223,690,l),
+(63,690,l),
+(63,420,l),
+(339,420,ls),
+(441,420,o),
+(495,371,o),
+(495,280,cs),
+(495,189,o),
+(441,140,o),
+(339,140,cs),
+(63,140,l),
+(63,0,l)
+);
+}
+);
+width = 697;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+},
+{
+color = 11;
+glyphname = "ra-canadian.square";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (338,690);
+},
+{
+name = top_right_can;
+pos = (554,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(635,0,l),
+(635,270,l),
+(358,270,ls),
+(255,270,o),
+(202,319,o),
+(202,410,cs),
+(202,500,o),
+(255,550,o),
+(358,550,cs),
+(635,550,l),
+(635,690,l),
+(364,690,ls),
+(160,690,o),
+(42,585,o),
+(42,410,cs),
+(42,234,o),
+(160,129,o),
+(364,129,cs),
+(519,129,l),
+(474,169,l),
+(474,0,l)
+);
+}
+);
+width = 698;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+},
+{
+color = 11;
+glyphname = "raa-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (245,0);
+ref = dot_top;
+}
+);
+width = 697;
+}
+);
+note = uni154C;
+},
+{
+color = 11;
+glyphname = "laWestCree-canadian.square";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (554,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(635,0,l),
+(635,140,l),
+(358,140,ls),
+(255,140,o),
+(202,189,o),
+(202,280,cs),
+(202,371,o),
+(255,420,o),
+(358,420,cs),
+(635,420,l),
+(635,690,l),
+(474,690,l),
+(474,521,l),
+(519,560,l),
+(364,560,ls),
+(160,560,o),
+(42,456,o),
+(42,280,cs),
+(42,104,o),
+(160,0,o),
+(364,0,cs)
+);
+}
+);
+width = 698;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+},
+{
+color = 11;
+glyphname = "reWestCree-canadian.square";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(636,0,l),
+(877,201,l),
+(789,309,l),
+(552,113,l),
+(654,111,l),
+(654,383,ls),
+(654,593,o),
+(543,704,o),
+(344,704,cs),
+(147,704,o),
+(41,589,o),
+(41,404,cs),
+(41,377,l),
+(199,377,l),
+(199,409,ls),
+(199,508,o),
+(251,559,o),
+(341,559,cs),
+(445,559,o),
+(494,502,o),
+(494,379,cs),
+(494,0,l)
+);
+}
+);
+width = 896;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+},
+{
+color = 11;
+glyphname = "riWestCree-canadian.square";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(403,0,l),
+(403,379,ls),
+(403,502,o),
+(451,559,o),
+(555,559,cs),
+(646,559,o),
+(697,508,o),
+(697,409,cs),
+(697,377,l),
+(857,377,l),
+(857,404,ls),
+(857,589,o),
+(750,704,o),
+(553,704,cs),
+(355,704,o),
+(243,593,o),
+(243,383,cs),
+(243,111,l),
+(345,113,l),
+(107,309,l),
+(19,201,l),
+(262,0,l)
+);
+}
+);
+width = 898;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+},
+{
+color = 11;
+glyphname = "roWestCree-canadian.square";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(543,-14,o),
+(654,97,o),
+(654,307,cs),
+(654,579,l),
+(552,577,l),
+(789,381,l),
+(877,489,l),
+(636,690,l),
+(494,690,l),
+(494,311,ls),
+(494,187,o),
+(445,130,o),
+(341,130,cs),
+(251,130,o),
+(199,182,o),
+(199,281,cs),
+(199,313,l),
+(41,313,l),
+(41,286,ls),
+(41,100,o),
+(147,-14,o),
+(344,-14,cs)
+);
+}
+);
+width = 896;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+},
+{
+color = 11;
+glyphname = "raWestCree-canadian.square";
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(750,-14,o),
+(857,100,o),
+(857,286,cs),
+(857,313,l),
+(697,313,l),
+(697,281,ls),
+(697,182,o),
+(646,130,o),
+(555,130,cs),
+(451,130,o),
+(403,187,o),
+(403,311,cs),
+(403,690,l),
+(262,690,l),
+(19,489,l),
+(107,381,l),
+(345,577,l),
+(243,579,l),
+(243,307,ls),
+(243,97,o),
+(355,-14,o),
+(553,-14,cs)
+);
+}
+);
+width = 898;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+},
+{
+color = 11;
+glyphname = "theThCree-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (110,690);
+},
+{
+name = top_right_can;
+pos = (599,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(518,50,l),
+(518,0,l),
+(678,0,l),
+(678,50,l),
+(757,50,l),
+(757,120,l),
+(678,120,l),
+(678,308,l),
+(271,308,l),
+(271,226,l),
+(694,596,l),
+(594,701,l),
+(29,209,l),
+(29,168,l),
+(518,168,l),
+(518,120,l),
+(306,120,l),
+(306,50,l)
+);
+}
+);
+width = 784;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15A7;
+},
+{
+color = 11;
+glyphname = "thiThCree-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (185,690);
+},
+{
+name = top_right_can;
+pos = (671,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(267,0,l),
+(267,50,l),
+(478,50,l),
+(478,120,l),
+(267,120,l),
+(267,168,l),
+(754,168,l),
+(754,209,l),
+(190,701,l),
+(91,596,l),
+(513,226,l),
+(513,308,l),
+(106,308,l),
+(106,120,l),
+(27,120,l),
+(27,50,l),
+(106,50,l),
+(106,0,l)
+);
+}
+);
+width = 783;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+},
+{
+color = 11;
+glyphname = "thiiThCree-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (91,0);
+ref = dot_top;
+}
+);
+width = 784;
+}
+);
+note = uni15A9;
+},
+{
+color = 11;
+glyphname = "thoThCree-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (110,690);
+},
+{
+name = top_right_can;
+pos = (599,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(694,94,l),
+(271,464,l),
+(271,382,l),
+(678,382,l),
+(678,570,l),
+(757,570,l),
+(757,639,l),
+(678,639,l),
+(678,690,l),
+(518,690,l),
+(518,639,l),
+(306,639,l),
+(306,570,l),
+(518,570,l),
+(518,522,l),
+(29,522,l),
+(29,481,l),
+(594,-12,l)
+);
+}
+);
+width = 784;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+},
+{
+color = 11;
+glyphname = "thooThCree-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (504,0);
+ref = dot_top;
+}
+);
+width = 784;
+}
+);
+note = uni15AB;
+},
+{
+color = 11;
+glyphname = "thaThCree-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (186,690);
+},
+{
+name = top_right_can;
+pos = (673,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(754,481,l),
+(754,522,l),
+(267,522,l),
+(267,570,l),
+(478,570,l),
+(478,639,l),
+(267,639,l),
+(267,690,l),
+(106,690,l),
+(106,639,l),
+(27,639,l),
+(27,570,l),
+(106,570,l),
+(106,382,l),
+(513,382,l),
+(513,464,l),
+(91,94,l),
+(190,-12,l)
+);
+}
+);
+width = 783;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+},
+{
+color = 11;
+glyphname = "thaaThCree-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (93,0);
+ref = dot_top;
+}
+);
+width = 784;
+}
+);
+note = uni15AD;
+},
+{
+color = 11;
+glyphname = "thweeWoodScree-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (784,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1021;
+}
+);
+note = uni1677;
+},
+{
+color = 11;
+glyphname = "thwiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (784,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1021;
+}
+);
+note = uni1678;
+},
+{
+color = 11;
+glyphname = "thwiiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (91,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (784,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1021;
+}
+);
+note = uni1679;
+},
+{
+color = 11;
+glyphname = "thwoWoodScree-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (784,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1021;
+}
+);
+note = uni167A;
+},
+{
+color = 11;
+glyphname = "thwooWoodScree-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (504,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (784,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1021;
+}
+);
+note = uni167B;
+},
+{
+color = 11;
+glyphname = "thwaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (784,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1021;
+}
+);
+note = uni167C;
+},
+{
+color = 11;
+glyphname = "thwaaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (93,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (784,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1021;
+}
+);
+note = uni167D;
+},
+{
+color = 11;
+glyphname = "nwiOjibway-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (748,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 984;
+}
+);
+note = uni18C7;
+},
+{
+color = 11;
+glyphname = "nwiiOjibway-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (220,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (748,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 984;
+}
+);
+note = uni18C9;
+},
+{
+color = 11;
+glyphname = "nwoOjibway-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (748,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 984;
+}
+);
+note = uni18CB;
+},
+{
+color = 11;
+glyphname = "nwooOjibway-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (339,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (748,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 984;
+}
+);
+note = uni18CD;
+},
+{
+color = 11;
+glyphname = "looWestCree-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+}
+);
+width = 697;
+}
+);
+note = uni18E1;
+},
+{
+color = 11;
+glyphname = "laaWestCree-canadian.square";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (462,0);
+ref = dot_top;
+}
+);
+width = 697;
+}
+);
+note = uni18E2;
+},
+{
+color = 0;
+glyphname = zero;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(539,573,o),
+(462,699,o),
+(295,699,cs),
+(127,699,o),
+(50,572,o),
+(50,345,cs),
+(50,110,o),
+(134,-10,o),
+(295,-10,cs),
+(461,-10,o),
+(539,104,o),
+(539,345,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(213,424,o),
+(214,569,o),
+(295,569,cs),
+(377,569,o),
+(377,423,o),
+(377,345,cs),
+(377,256,o),
+(372,121,o),
+(295,121,cs),
+(219,121,o),
+(213,256,o),
+(213,345,cs)
+);
+}
+);
+width = 589;
+}
+);
+unicode = 48;
+},
+{
+color = 0;
+glyphname = one;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(242,690,l),
+(12,504,l),
+(97,400,l),
+(181,468,ls),
+(196,480,o),
+(209,494,o),
+(225,512,c),
+(223,464,o),
+(222,423,o),
+(222,381,cs),
+(222,0,l),
+(388,0,l),
+(388,690,l)
+);
+}
+);
+width = 509;
+}
+);
+unicode = 49;
+},
+{
+color = 0;
+glyphname = two;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(527,0,l),
+(527,135,l),
+(249,135,l),
+(249,139,l),
+(321,209,ls),
+(405,287,o),
+(462,344,o),
+(491,407,cs),
+(504,438,o),
+(511,473,o),
+(511,512,cs),
+(511,621,o),
+(421,699,o),
+(288,699,cs),
+(169,699,o),
+(102,656,o),
+(35,595,c),
+(125,490,l),
+(181,538,o),
+(224,562,o),
+(270,562,cs),
+(315,562,o),
+(350,540,o),
+(350,490,cs),
+(350,451,o),
+(334,420,o),
+(296,375,cs),
+(275,352,o),
+(248,323,o),
+(213,287,cs),
+(39,108,l),
+(39,0,l)
+);
+}
+);
+width = 575;
+}
+);
+unicode = 50;
+},
+{
+color = 0;
+glyphname = three;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(496,639,o),
+(410,699,o),
+(272,699,cs),
+(157,699,o),
+(90,668,o),
+(34,630,c),
+(101,520,l),
+(132,540,o),
+(186,568,o),
+(247,568,cs),
+(301,568,o),
+(337,547,o),
+(337,500,cs),
+(337,433,o),
+(256,415,o),
+(187,415,cs),
+(138,415,l),
+(138,292,l),
+(186,292,ls),
+(298,292,o),
+(344,268,o),
+(344,206,cs),
+(344,153,o),
+(310,120,o),
+(213,120,cs),
+(158,120,o),
+(91,134,o),
+(32,164,c),
+(32,28,l),
+(89,5,o),
+(149,-10,o),
+(236,-10,cs),
+(393,-10,o),
+(516,58,o),
+(516,196,cs),
+(516,295,o),
+(454,347,o),
+(344,360,c),
+(344,363,l),
+(430,386,o),
+(496,444,o),
+(496,539,cs)
+);
+}
+);
+width = 558;
+}
+);
+unicode = 51;
+},
+{
+color = 0;
+glyphname = four;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(474,264,l),
+(474,691,l),
+(324,691,l),
+(26,261,l),
+(26,141,l),
+(314,141,l),
+(314,0,l),
+(474,0,l),
+(474,141,l),
+(558,141,l),
+(558,264,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(169,264,l),
+(272,413,ls),
+(291,441,o),
+(299,455,o),
+(313,484,c),
+(318,484,l),
+(318,478,o),
+(314,444,o),
+(314,384,cs),
+(314,264,l)
+);
+}
+);
+width = 588;
+}
+);
+unicode = 52;
+},
+{
+color = 0;
+glyphname = five;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(254,446,o),
+(235,440,o),
+(213,436,c),
+(223,554,l),
+(468,554,l),
+(468,690,l),
+(85,690,l),
+(58,333,l),
+(120,302,l),
+(149,311,o),
+(185,320,o),
+(222,320,cs),
+(306,320,o),
+(349,283,o),
+(349,222,cs),
+(349,156,o),
+(302,120,o),
+(225,120,cs),
+(166,120,o),
+(93,141,o),
+(44,163,c),
+(44,28,l),
+(95,4,o),
+(159,-10,o),
+(239,-10,cs),
+(421,-10,o),
+(513,75,o),
+(513,227,cs),
+(513,365,o),
+(425,446,o),
+(302,446,cs)
+);
+}
+);
+width = 562;
+}
+);
+unicode = 53;
+},
+{
+color = 0;
+glyphname = six;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(51,115,o),
+(139,-10,o),
+(306,-10,cs),
+(454,-10,o),
+(545,81,o),
+(545,233,cs),
+(545,374,o),
+(471,455,o),
+(350,455,cs),
+(272,455,o),
+(229,418,o),
+(204,370,c),
+(199,370,l),
+(205,497,o),
+(256,572,o),
+(399,572,cs),
+(444,572,o),
+(475,568,o),
+(500,562,c),
+(500,692,l),
+(474,696,o),
+(431,699,o),
+(403,699,cs),
+(147,699,o),
+(51,541,o),
+(51,292,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(242,121,o),
+(214,177,o),
+(214,242,cs),
+(214,287,o),
+(252,328,o),
+(305,328,cs),
+(361,328,o),
+(386,292,o),
+(386,230,cs),
+(386,156,o),
+(354,121,o),
+(303,121,cs)
+);
+}
+);
+width = 582;
+}
+);
+unicode = 54;
+},
+{
+color = 0;
+glyphname = seven;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(514,593,l),
+(514,690,l),
+(25,690,l),
+(25,554,l),
+(339,554,l),
+(96,0,l),
+(265,0,l)
+);
+}
+);
+width = 537;
+}
+);
+unicode = 55;
+},
+{
+color = 0;
+glyphname = eight;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(430,-10,o),
+(534,52,o),
+(534,183,cs),
+(534,274,o),
+(461,327,o),
+(388,364,c),
+(463,399,o),
+(513,450,o),
+(513,533,cs),
+(513,644,o),
+(422,699,o),
+(289,699,cs),
+(153,699,o),
+(63,639,o),
+(63,533,cs),
+(63,450,o),
+(115,399,o),
+(176,361,c),
+(98,326,o),
+(43,277,o),
+(43,180,cs),
+(43,68,o),
+(120,-10,o),
+(287,-10,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(228,109,o),
+(192,140,o),
+(192,186,cs),
+(192,238,o),
+(236,269,o),
+(286,292,c),
+(340,265,o),
+(384,232,o),
+(384,184,cs),
+(384,136,o),
+(350,109,o),
+(285,109,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(246,455,o),
+(216,481,o),
+(216,519,cs),
+(216,557,o),
+(248,581,o),
+(289,581,cs),
+(328,581,o),
+(360,558,o),
+(360,519,cs),
+(360,477,o),
+(326,454,o),
+(287,435,c)
+);
+}
+);
+width = 576;
+}
+);
+unicode = 56;
+},
+{
+color = 0;
+glyphname = nine;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(529,574,o),
+(443,699,o),
+(275,699,cs),
+(128,699,o),
+(37,610,o),
+(37,458,cs),
+(37,316,o),
+(110,235,o),
+(228,235,cs),
+(309,235,o),
+(352,270,o),
+(377,320,c),
+(382,320,l),
+(375,180,o),
+(309,118,o),
+(172,118,cs),
+(135,118,o),
+(108,121,o),
+(81,127,c),
+(81,-4,l),
+(107,-9,o),
+(150,-10,o),
+(179,-10,cs),
+(433,-10,o),
+(529,149,o),
+(529,389,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(340,569,o),
+(366,506,o),
+(366,447,cs),
+(366,405,o),
+(327,361,o),
+(277,361,cs),
+(223,361,o),
+(195,399,o),
+(195,460,cs),
+(195,533,o),
+(225,569,o),
+(279,569,cs)
+);
+}
+);
+width = 581;
+}
+);
+unicode = 57;
+},
+{
+glyphname = zero.canadian;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(568,583,o),
+(466,704,o),
+(306,704,cs),
+(147,704,o),
+(44,583,o),
+(44,345,cs),
+(44,106,o),
+(147,-12,o),
+(306,-12,cs),
+(466,-12,o),
+(568,106,o),
+(568,345,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(204,497,o),
+(240,560,o),
+(306,560,cs),
+(373,560,o),
+(409,497,o),
+(409,345,cs),
+(409,193,o),
+(374,131,o),
+(306,131,cs),
+(239,131,o),
+(204,193,o),
+(204,345,cs)
+);
+}
+);
+width = 612;
+}
+);
+metricRight = "=|";
+},
+{
+glyphname = one.canadian;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(365,0,l),
+(365,690,l),
+(221,690,l),
+(6,509,l),
+(93,401,l),
+(305,577,l),
+(204,584,l),
+(204,0,l)
+);
+}
+);
+width = 428;
+}
+);
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = two.canadian;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(548,144,l),
+(252,144,l),
+(253,94,l),
+(431,270,ls),
+(514,351,o),
+(536,418,o),
+(536,490,cs),
+(536,619,o),
+(442,704,o),
+(300,704,cs),
+(140,704,o),
+(43,602,o),
+(41,448,c),
+(199,448,l),
+(199,524,o),
+(234,565,o),
+(295,565,cs),
+(348,565,o),
+(376,533,o),
+(376,483,cs),
+(376,440,o),
+(361,397,o),
+(301,338,cs),
+(64,105,l),
+(64,0,l),
+(548,0,l)
+);
+}
+);
+width = 588;
+}
+);
+note = uni14BF;
+},
+{
+glyphname = three.canadian;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(452,-14,o),
+(551,69,o),
+(551,195,cs),
+(551,282,o),
+(501,354,o),
+(405,372,c),
+(402,319,l),
+(494,336,o),
+(542,410,o),
+(542,493,cs),
+(542,621,o),
+(449,704,o),
+(306,704,cs),
+(148,704,o),
+(57,602,o),
+(49,459,c),
+(208,459,l),
+(210,522,o),
+(239,565,o),
+(304,565,cs),
+(355,565,o),
+(382,536,o),
+(382,485,cs),
+(382,434,o),
+(357,412,o),
+(310,412,cs),
+(277,412,l),
+(277,279,l),
+(312,279,ls),
+(363,279,o),
+(389,254,o),
+(389,204,cs),
+(389,152,o),
+(359,125,o),
+(301,125,cs),
+(231,125,o),
+(203,168,o),
+(202,231,c),
+(43,231,l),
+(47,83,o),
+(137,-14,o),
+(303,-14,cs)
+);
+}
+);
+width = 610;
+}
+);
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = four.canadian;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(481,0,l),
+(481,142,l),
+(566,142,l),
+(566,271,l),
+(481,271,l),
+(481,691,l),
+(355,691,l),
+(33,244,l),
+(33,142,l),
+(324,142,l),
+(324,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(379,537,l),
+(327,537,l),
+(327,271,l),
+(158,271,l),
+(164,232,l)
+);
+}
+);
+width = 592;
+}
+);
+},
+{
+glyphname = five.canadian;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(466,-14,o),
+(558,81,o),
+(558,220,cs),
+(558,356,o),
+(469,436,o),
+(315,436,cs),
+(204,436,l),
+(249,396,l),
+(265,592,l),
+(215,551,l),
+(526,551,l),
+(526,690,l),
+(119,690,l),
+(91,334,l),
+(124,299,l),
+(291,299,ls),
+(365,299,o),
+(401,274,o),
+(401,215,cs),
+(401,158,o),
+(366,125,o),
+(309,125,cs),
+(248,125,o),
+(217,157,o),
+(214,211,c),
+(56,211,l),
+(63,70,o),
+(157,-14,o),
+(309,-14,cs)
+);
+}
+);
+width = 606;
+}
+);
+},
+{
+glyphname = six.canadian;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(475,-14,o),
+(572,77,o),
+(572,214,cs),
+(572,352,o),
+(478,436,o),
+(344,436,cs),
+(266,436,o),
+(208,407,o),
+(174,347,c),
+(208,298,l),
+(205,323,o),
+(204,341,o),
+(204,391,cs),
+(204,504,o),
+(239,566,o),
+(319,566,cs),
+(374,566,o),
+(409,530,o),
+(412,480,c),
+(572,480,l),
+(557,617,o),
+(469,704,o),
+(324,704,cs),
+(155,704,o),
+(44,585,o),
+(44,354,cs),
+(44,214,o),
+(68,124,o),
+(128,59,cs),
+(173,11,o),
+(239,-14,o),
+(320,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(255,119,o),
+(215,155,o),
+(215,215,cs),
+(215,270,o),
+(254,305,o),
+(318,305,cs),
+(382,305,o),
+(417,270,o),
+(417,212,cs),
+(417,154,o),
+(381,119,o),
+(317,119,cs)
+);
+}
+);
+width = 611;
+}
+);
+metricLeft = zero.canadian;
+},
+{
+glyphname = seven.canadian;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(477,593,l),
+(477,690,l),
+(31,690,l),
+(31,546,l),
+(317,546,l),
+(316,590,l),
+(99,39,l),
+(99,0,l),
+(258,0,l)
+);
+}
+);
+width = 506;
+}
+);
+},
+{
+glyphname = eight.canadian;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(473,-14,o),
+(578,70,o),
+(578,191,cs),
+(578,289,o),
+(517,355,o),
+(419,371,c),
+(413,319,l),
+(504,335,o),
+(562,401,o),
+(562,498,cs),
+(562,620,o),
+(465,704,o),
+(318,704,cs),
+(172,704,o),
+(73,620,o),
+(73,498,cs),
+(73,401,o),
+(131,335,o),
+(222,319,c),
+(216,371,l),
+(120,355,o),
+(59,289,o),
+(59,191,cs),
+(59,70,o),
+(162,-14,o),
+(318,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(253,117,o),
+(218,146,o),
+(218,199,cs),
+(218,252,o),
+(253,281,o),
+(318,281,cs),
+(383,281,o),
+(418,252,o),
+(418,199,cs),
+(418,146,o),
+(383,117,o),
+(318,117,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(262,410,o),
+(233,437,o),
+(233,491,cs),
+(233,544,o),
+(262,573,o),
+(318,573,cs),
+(375,573,o),
+(404,544,o),
+(404,491,cs),
+(404,437,o),
+(375,410,o),
+(318,410,cs)
+);
+}
+);
+width = 637;
+}
+);
+metricLeft = "=|";
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = nine.canadian;
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(456,-14,o),
+(566,104,o),
+(566,336,cs),
+(566,475,o),
+(543,566,o),
+(483,631,cs),
+(438,679,o),
+(372,704,o),
+(290,704,cs),
+(135,704,o),
+(39,612,o),
+(39,475,cs),
+(39,338,o),
+(132,254,o),
+(267,254,cs),
+(345,254,o),
+(403,283,o),
+(437,343,c),
+(403,391,l),
+(406,367,o),
+(407,349,o),
+(407,298,cs),
+(407,185,o),
+(372,127,o),
+(292,127,cs),
+(237,127,o),
+(202,159,o),
+(197,210,c),
+(39,210,l),
+(53,72,o),
+(142,-14,o),
+(286,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(229,384,o),
+(193,419,o),
+(193,478,cs),
+(193,536,o),
+(230,571,o),
+(293,571,cs),
+(355,571,o),
+(395,535,o),
+(395,474,cs),
+(395,419,o),
+(356,384,o),
+(293,384,cs)
+);
+}
+);
+width = 610;
+}
+);
+metricLeft = "=|six.canadian";
+metricRight = "=|six.canadian";
+},
+{
+glyphname = CR;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+width = 256;
+}
+);
+note = CR;
+unicode = 13;
+},
+{
+color = 0;
+glyphname = .notdef;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(488,690,l),
+(91,690,l),
+(91,0,l),
+(488,0,l),
+(488,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(439,640,l),
+(439,49,l),
+(140,49,l),
+(140,640,l),
+(140,640,l)
+);
+}
+);
+width = 580;
+}
+);
+note = ".notdef";
+},
+{
+glyphname = .null;
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+width = 0;
+}
+);
+note = NULL;
+},
+{
+glyphname = space;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+width = 257;
+}
+);
+note = space;
+unicode = 32;
+},
+{
+glyphname = nbspace;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+width = 256;
+}
+);
+note = uni00A0;
+unicode = 160;
+},
+{
+glyphname = space.canadian;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+width = 516;
+}
+);
+note = space;
+},
+{
+glyphname = "hyphen-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(375,383,l),
+(375,471,l),
+(53,471,l),
+(53,383,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(375,239,l),
+(375,327,l),
+(53,327,l),
+(53,239,l)
+);
+}
+);
+width = 428;
+}
+);
+metricRight = "=|";
+note = uni1400;
+unicode = 5120;
+},
+{
+glyphname = "chi-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(184,0,l),
+(332,270,l),
+(264,270,l),
+(411,0,l),
+(559,0,l),
+(559,39,l),
+(349,412,l),
+(348,288,l),
+(556,651,l),
+(556,690,l),
+(408,690,l),
+(263,425,l),
+(331,425,l),
+(186,690,l),
+(38,690,l),
+(38,651,l),
+(245,287,l),
+(245,412,l),
+(35,39,l),
+(35,0,l)
+);
+}
+);
+width = 594;
+}
+);
+metricRight = "=|";
+note = uni166D;
+unicode = 5741;
+},
+{
+glyphname = "fullstop-canadian";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(330,0,l),
+(330,18,l),
+(232,190,l),
+(234,153,l),
+(329,326,l),
+(329,345,l),
+(235,345,l),
+(169,213,l),
+(209,221,l),
+(142,345,l),
+(48,345,l),
+(48,326,l),
+(143,161,l),
+(144,198,l),
+(47,18,l),
+(47,0,l),
+(141,0,l),
+(213,143,l),
+(164,134,l),
+(236,0,l)
+);
+}
+);
+width = 378;
+}
+);
+note = uni1541;
+unicode = 5742;
+},
+{
+glyphname = period;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(43,14,o),
+(83,-11,o),
+(133,-11,cs),
+(182,-11,o),
+(219,14,o),
+(219,71,cs),
+(219,129,o),
+(182,153,o),
+(133,153,cs),
+(83,153,o),
+(43,129,o),
+(43,71,cs)
+);
+}
+);
+width = 263;
+}
+);
+note = period;
+unicode = 46;
+},
+{
+glyphname = comma;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(138,-133,l),
+(172,-57,o),
+(200,50,o),
+(218,127,c),
+(212,137,l),
+(72,137,l),
+(65,61,o),
+(46,-40,o),
+(25,-133,c)
+);
+}
+);
+width = 271;
+}
+);
+note = comma;
+unicode = 44;
+},
+{
+glyphname = hyphen;
+kernLeft = hyphen;
+kernRight = hyphen;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(263,324,l),
+(23,324,l),
+(23,195,l),
+(263,195,l)
+);
+}
+);
+width = 286;
+}
+);
+unicode = 45;
+},
+{
+glyphname = quotesinglbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (29,-553);
+ref = quoteright;
+}
+);
+width = 300;
+}
+);
+unicode = 8218;
+},
+{
+glyphname = quotedblbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (29,-553);
+ref = quotedblright;
+}
+);
+width = 527;
+}
+);
+unicode = 8222;
+},
+{
+glyphname = quotedblleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(381,419,l),
+(390,498,o),
+(408,592,o),
+(429,689,c),
+(317,689,l),
+(285,616,o),
+(257,520,o),
+(236,430,c),
+(242,419,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(158,419,l),
+(168,498,o),
+(185,592,o),
+(207,689,c),
+(95,689,l),
+(63,616,o),
+(35,520,o),
+(14,430,c),
+(20,419,l)
+);
+}
+);
+width = 448;
+}
+);
+unicode = 8220;
+},
+{
+glyphname = quotedblright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(354,419,l),
+(388,495,o),
+(417,601,o),
+(435,678,c),
+(428,689,l),
+(290,689,l),
+(283,613,o),
+(265,511,o),
+(242,419,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(131,419,l),
+(166,495,o),
+(194,601,o),
+(213,678,c),
+(206,689,l),
+(68,689,l),
+(61,614,o),
+(42,510,o),
+(19,419,c)
+);
+}
+);
+width = 448;
+}
+);
+unicode = 8221;
+},
+{
+glyphname = quoteleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(161,419,l),
+(171,497,o),
+(187,592,o),
+(210,689,c),
+(95,689,l),
+(63,616,o),
+(35,520,o),
+(14,430,c),
+(20,419,l)
+);
+}
+);
+width = 229;
+}
+);
+unicode = 8216;
+},
+{
+glyphname = quoteright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(134,419,l),
+(169,495,o),
+(197,601,o),
+(215,678,c),
+(209,689,l),
+(68,689,l),
+(61,614,o),
+(42,510,o),
+(19,419,c)
+);
+}
+);
+width = 229;
+}
+);
+unicode = 8217;
+},
+{
+glyphname = dottedCircle;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(193,504,o),
+(181,494,o),
+(181,479,cs),
+(181,467,o),
+(193,454,o),
+(206,454,cs),
+(220,454,o),
+(231,467,o),
+(231,479,cs),
+(231,494,o),
+(220,504,o),
+(206,504,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(355,504,o),
+(343,494,o),
+(343,479,cs),
+(343,467,o),
+(355,454,o),
+(368,454,cs),
+(383,454,o),
+(393,467,o),
+(393,479,cs),
+(393,494,o),
+(383,504,o),
+(368,504,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(193,108,o),
+(181,98,o),
+(181,83,cs),
+(181,71,o),
+(193,58,o),
+(206,58,cs),
+(220,58,o),
+(231,71,o),
+(231,83,cs),
+(231,98,o),
+(220,108,o),
+(206,108,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(355,108,o),
+(343,98,o),
+(343,83,cs),
+(343,71,o),
+(355,58,o),
+(368,58,cs),
+(383,58,o),
+(393,71,o),
+(393,83,cs),
+(393,98,o),
+(383,108,o),
+(368,108,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(274,522,o),
+(262,511,o),
+(262,497,cs),
+(262,484,o),
+(274,471,o),
+(287,471,cs),
+(301,471,o),
+(312,484,o),
+(312,497,cs),
+(312,511,o),
+(301,522,o),
+(287,522,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(274,91,o),
+(262,80,o),
+(262,66,cs),
+(262,53,o),
+(274,41,o),
+(287,41,cs),
+(301,41,o),
+(312,53,o),
+(312,66,cs),
+(312,80,o),
+(301,91,o),
+(287,91,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(46,269,o),
+(59,256,o),
+(71,256,cs),
+(86,256,o),
+(97,269,o),
+(97,281,cs),
+(97,296,o),
+(86,306,o),
+(71,306,cs),
+(59,306,o),
+(46,296,o),
+(46,281,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(477,269,o),
+(490,256,o),
+(502,256,cs),
+(517,256,o),
+(527,269,o),
+(527,281,cs),
+(527,296,o),
+(517,306,o),
+(502,306,cs),
+(490,306,o),
+(477,296,o),
+(477,281,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(109,116,o),
+(122,103,o),
+(134,103,cs),
+(149,103,o),
+(159,116,o),
+(159,128,cs),
+(159,143,o),
+(149,154,o),
+(134,154,cs),
+(122,154,o),
+(109,143,o),
+(109,128,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(109,421,o),
+(122,409,o),
+(134,409,cs),
+(149,409,o),
+(159,421,o),
+(159,434,cs),
+(159,448,o),
+(149,459,o),
+(134,459,cs),
+(122,459,o),
+(109,448,o),
+(109,434,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(414,116,o),
+(427,103,o),
+(440,103,cs),
+(454,103,o),
+(465,116,o),
+(465,128,cs),
+(465,143,o),
+(454,154,o),
+(440,154,cs),
+(427,154,o),
+(414,143,o),
+(414,128,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(414,421,o),
+(427,409,o),
+(440,409,cs),
+(454,409,o),
+(465,421,o),
+(465,434,cs),
+(465,448,o),
+(454,459,o),
+(440,459,cs),
+(427,459,o),
+(414,448,o),
+(414,434,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(64,187,o),
+(76,175,o),
+(89,175,cs),
+(103,175,o),
+(114,187,o),
+(114,200,cs),
+(114,214,o),
+(103,225,o),
+(89,225,cs),
+(76,225,o),
+(64,214,o),
+(64,200,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(64,350,o),
+(76,337,o),
+(89,337,cs),
+(103,337,o),
+(114,350,o),
+(114,362,cs),
+(114,377,o),
+(103,387,o),
+(89,387,cs),
+(76,387,o),
+(64,377,o),
+(64,362,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(460,187,o),
+(472,175,o),
+(485,175,cs),
+(499,175,o),
+(510,187,o),
+(510,200,cs),
+(510,214,o),
+(499,225,o),
+(485,225,cs),
+(472,225,o),
+(460,214,o),
+(460,200,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(460,350,o),
+(472,337,o),
+(485,337,cs),
+(499,337,o),
+(510,350,o),
+(510,362,cs),
+(510,377,o),
+(499,387,o),
+(485,387,cs),
+(472,387,o),
+(460,377,o),
+(460,362,cs)
+);
+}
+);
+width = 574;
+}
+);
+note = uni25CC;
+unicode = 9676;
+},
+{
+glyphname = dotaccentcomb;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(71,741,o),
+(34,725,o),
+(34,668,cs),
+(34,611,o),
+(71,594,o),
+(119,594,cs),
+(165,594,o),
+(204,611,o),
+(204,668,cs),
+(204,725,o),
+(165,741,o),
+(119,741,cs)
+);
+}
+);
+width = 239;
+}
+);
+note = uni0307;
+unicode = 775;
+},
+{
+glyphname = dotaccent;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(165,594,o),
+(205,611,o),
+(205,668,cs),
+(205,725,o),
+(166,741,o),
+(120,741,cs),
+(72,741,o),
+(35,725,o),
+(35,668,cs),
+(35,611,o),
+(72,594,o),
+(120,594,cs)
+);
+}
+);
+width = 241;
+}
+);
+note = dotaccent;
+unicode = 729;
+},
+{
+glyphname = caron;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(328,624,o),
+(368,675,o),
+(412,727,c),
+(412,740,l),
+(310,740,l),
+(279,717,o),
+(254,693,o),
+(223,661,c),
+(193,692,o),
+(170,717,o),
+(140,740,c),
+(35,740,l),
+(35,727,l),
+(72,687,o),
+(118,633,o),
+(145,585,c),
+(304,585,l),
+(304,585,l)
+);
+}
+);
+width = 448;
+}
+);
+note = caron;
+unicode = 711;
+},
+{
+glyphname = breve;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(306,585,o),
+(367,649,o),
+(373,750,c),
+(284,750,l),
+(272,698,o),
+(241,684,o),
+(203,684,cs),
+(155,684,o),
+(133,696,o),
+(122,750,c),
+(35,750,l),
+(40,645,o),
+(96,585,o),
+(203,585,cs)
+);
+}
+);
+width = 409;
+}
+);
+note = breve;
+unicode = 728;
+},
+{
+glyphname = ring;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(211,584,o),
+(261,629,o),
+(261,700,cs),
+(261,771,o),
+(210,816,o),
+(147,816,cs),
+(80,816,o),
+(35,771,o),
+(35,699,cs),
+(35,629,o),
+(80,584,o),
+(147,584,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(123,655,o),
+(109,674,o),
+(109,699,cs),
+(109,727,o),
+(126,745,o),
+(147,745,cs),
+(167,745,o),
+(185,726,o),
+(185,699,cs),
+(185,674,o),
+(168,655,o),
+(147,655,cs)
+);
+}
+);
+width = 297;
+}
+);
+note = ring;
+unicode = 730;
+},
+{
+glyphname = ogonek;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(180,-228,o),
+(203,-223,o),
+(223,-216,c),
+(223,-126,l),
+(212,-130,o),
+(188,-135,o),
+(173,-135,cs),
+(153,-135,o),
+(138,-125,o),
+(138,-99,cs),
+(138,-67,o),
+(157,-41,o),
+(197,0,c),
+(134,22,l),
+(62,-32,o),
+(35,-77,o),
+(35,-124,cs),
+(35,-188,o),
+(86,-228,o),
+(151,-228,cs)
+);
+}
+);
+width = 258;
+}
+);
+note = ogonek;
+unicode = 731;
+},
+{
+glyphname = ring_top.canadian;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (132,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(193,757,o),
+(248,804,o),
+(248,868,cs),
+(248,933,o),
+(193,980,o),
+(130,980,cs),
+(69,980,o),
+(15,934,o),
+(15,868,cs),
+(15,804,o),
+(69,757,o),
+(130,757,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(104,824,o),
+(88,844,o),
+(88,868,cs),
+(88,893,o),
+(106,913,o),
+(132,913,cs),
+(157,913,o),
+(176,893,o),
+(176,868,cs),
+(176,844,o),
+(157,824,o),
+(132,824,cs)
+);
+}
+);
+width = 264;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (94,345);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(136,270,o),
+(169,303,o),
+(169,345,cs),
+(169,386,o),
+(136,420,o),
+(94,420,cs),
+(52,420,o),
+(18,386,o),
+(18,345,cs),
+(18,303,o),
+(52,270,o),
+(94,270,cs)
+);
+}
+);
+width = 188;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (77,345);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(111,285,o),
+(137,311,o),
+(137,345,cs),
+(137,379,o),
+(111,405,o),
+(77,405,cs),
+(44,405,o),
+(18,379,o),
+(18,345,cs),
+(18,311,o),
+(44,285,o),
+(77,285,cs)
+);
+}
+);
+width = 156;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_small;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (61,345);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(85,301,o),
+(104,321,o),
+(104,345,cs),
+(104,369,o),
+(85,388,o),
+(61,388,cs),
+(37,388,o),
+(18,369,o),
+(18,345,cs),
+(18,321,o),
+(37,301,o),
+(61,301,cs)
+);
+}
+);
+width = 122;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_top;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (94,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(136,763,o),
+(170,798,o),
+(170,839,cs),
+(170,882,o),
+(136,916,o),
+(94,916,cs),
+(52,916,o),
+(18,882,o),
+(18,839,cs),
+(18,798,o),
+(52,763,o),
+(94,763,cs)
+);
+}
+);
+width = 188;
+}
+);
+note = g725;
+},
+{
+glyphname = doubledot_middle;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(160,368,o),
+(194,402,o),
+(194,443,cs),
+(194,486,o),
+(160,520,o),
+(118,520,cs),
+(76,520,o),
+(43,486,o),
+(43,443,cs),
+(43,401,o),
+(76,368,o),
+(118,368,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(160,170,o),
+(194,204,o),
+(194,246,cs),
+(194,288,o),
+(160,322,o),
+(118,322,cs),
+(76,322,o),
+(43,289,o),
+(43,246,cs),
+(43,204,o),
+(76,170,o),
+(118,170,cs)
+);
+}
+);
+width = 237;
+}
+);
+metricRight = "=|";
+note = g725;
+},
+{
+glyphname = doubledot_top;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top_double;
+pos = (278,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(321,763,o),
+(355,798,o),
+(355,839,cs),
+(355,882,o),
+(321,916,o),
+(278,916,cs),
+(236,916,o),
+(203,882,o),
+(203,839,cs),
+(203,798,o),
+(236,763,o),
+(278,763,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(126,763,o),
+(159,798,o),
+(159,839,cs),
+(159,882,o),
+(126,916,o),
+(83,916,cs),
+(41,916,o),
+(7,882,o),
+(7,839,cs),
+(7,798,o),
+(41,763,o),
+(83,763,cs)
+);
+}
+);
+width = 361;
+}
+);
+note = g725;
+},
+{
+glyphname = g727;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (357,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(651,0,l),
+(651,130,l),
+(308,130,ls),
+(242,130,o),
+(212,155,o),
+(212,205,cs),
+(212,257,o),
+(242,281,o),
+(307,281,cs),
+(433,281,ls),
+(588,281,o),
+(664,354,o),
+(664,486,cs),
+(664,618,o),
+(588,690,o),
+(433,690,cs),
+(64,690,l),
+(64,559,l),
+(407,559,ls),
+(473,559,o),
+(503,535,o),
+(503,486,cs),
+(503,440,o),
+(473,410,o),
+(408,410,cs),
+(282,410,ls),
+(127,410,o),
+(51,336,o),
+(51,204,cs),
+(51,71,o),
+(127,0,o),
+(282,0,cs)
+);
+}
+);
+width = 715;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+glyphname = g728;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (264,0);
+ref = dot_top;
+}
+);
+width = 715;
+}
+);
+note = g728;
+},
+{
+glyphname = g729;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (357,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(433,0,ls),
+(588,0,o),
+(664,71,o),
+(664,204,cs),
+(664,336,o),
+(588,410,o),
+(433,410,cs),
+(307,410,ls),
+(242,410,o),
+(212,440,o),
+(212,485,cs),
+(212,535,o),
+(242,559,o),
+(308,559,cs),
+(651,559,l),
+(651,690,l),
+(282,690,ls),
+(127,690,o),
+(51,618,o),
+(51,486,cs),
+(51,354,o),
+(127,281,o),
+(282,281,cs),
+(408,281,ls),
+(473,281,o),
+(503,257,o),
+(503,204,cs),
+(503,155,o),
+(473,130,o),
+(407,130,cs),
+(64,130,l),
+(64,0,l)
+);
+}
+);
+width = 715;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+glyphname = g730;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (264,0);
+ref = dot_top;
+}
+);
+width = 715;
+}
+);
+note = g730;
+},
+{
+glyphname = g731;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = g727;
+}
+);
+width = 952;
+}
+);
+note = g731;
+},
+{
+glyphname = g732;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (715,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 952;
+}
+);
+note = g732;
+},
+{
+glyphname = g733;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (500,0);
+ref = dot_top;
+}
+);
+width = 952;
+}
+);
+note = g733;
+},
+{
+glyphname = g734;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (264,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (715,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 952;
+}
+);
+note = g734;
+},
+{
+glyphname = g735;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = g729;
+}
+);
+width = 952;
+}
+);
+note = g735;
+},
+{
+glyphname = g736;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (715,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 952;
+}
+);
+note = g736;
+},
+{
+glyphname = g737;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (500,0);
+ref = dot_top;
+}
+);
+width = 952;
+}
+);
+note = g737;
+},
+{
+glyphname = g738;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (264,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (715,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 952;
+}
+);
+note = g738;
+},
+{
+glyphname = g739;
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(547,274,o),
+(601,327,o),
+(601,406,cs),
+(601,483,o),
+(549,536,o),
+(458,536,cs),
+(276,536,l),
+(281,489,l),
+(300,499,o),
+(320,531,o),
+(320,571,cs),
+(320,646,o),
+(269,696,o),
+(183,696,cs),
+(99,696,o),
+(44,644,o),
+(44,565,cs),
+(44,488,o),
+(97,435,o),
+(187,435,cs),
+(369,435,l),
+(364,482,l),
+(345,471,o),
+(326,440,o),
+(326,400,cs),
+(326,325,o),
+(377,274,o),
+(463,274,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(158,513,o),
+(141,531,o),
+(141,565,cs),
+(141,601,o),
+(158,619,o),
+(183,619,cs),
+(207,619,o),
+(223,600,o),
+(223,565,cs),
+(223,531,o),
+(207,513,o),
+(183,513,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(439,352,o),
+(422,371,o),
+(422,406,cs),
+(422,440,o),
+(439,458,o),
+(463,458,cs),
+(487,458,o),
+(504,440,o),
+(504,406,cs),
+(504,370,o),
+(487,352,o),
+(463,352,cs)
+);
+}
+);
+width = 645;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+glyphname = g740;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (226,0);
+ref = ring_top.canadian;
+}
+);
+width = 715;
+}
+);
+note = g740;
+},
+{
+glyphname = g741;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (226,0);
+ref = ring_top.canadian;
+}
+);
+width = 715;
+}
+);
+note = g741;
+},
+{
+glyphname = g742;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (463,0);
+ref = ring_top.canadian;
+}
+);
+width = 952;
+}
+);
+note = g742;
+},
+{
+glyphname = stroke_middle;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (64,345);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(110,464,l),
+(17,464,l),
+(17,226,l),
+(110,226,l)
+);
+}
+);
+width = 128;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (51,345);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(85,415,l),
+(17,415,l),
+(17,274,l),
+(85,274,l)
+);
+}
+);
+width = 102;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_small;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (43,345);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(69,406,l),
+(17,406,l),
+(17,284,l),
+(69,284,l)
+);
+}
+);
+width = 86;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_threequart;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (64,345);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(108,460,l),
+(19,460,l),
+(19,230,l),
+(108,230,l)
+);
+}
+);
+width = 128;
+}
+);
+note = g723;
+},
+{
+color = 8;
+glyphname = uni11AB0;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (178,690);
+},
+{
+name = top_right_can;
+pos = (450,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(259,0,l),
+(259,74,l),
+(469,74,l),
+(469,159,l),
+(259,159,l),
+(259,277,l),
+(136,224,l),
+(173,224,ls),
+(398,224,o),
+(530,352,o),
+(530,591,cs),
+(530,690,l),
+(370,690,l),
+(370,607,ls),
+(370,430,o),
+(295,366,o),
+(139,366,cs),
+(98,366,l),
+(98,159,l),
+(27,159,l),
+(27,74,l),
+(98,74,l),
+(98,0,l)
+);
+}
+);
+width = 592;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB1;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB0;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (356,0);
+ref = dot_top;
+}
+);
+width = 592;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB2;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (142,690);
+},
+{
+name = top_right_can;
+pos = (414,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(222,0,l),
+(222,83,ls),
+(222,260,o),
+(298,324,o),
+(453,324,cs),
+(495,324,l),
+(495,530,l),
+(565,530,l),
+(565,615,l),
+(495,615,l),
+(495,690,l),
+(334,690,l),
+(334,615,l),
+(123,615,l),
+(123,530,l),
+(334,530,l),
+(334,412,l),
+(456,466,l),
+(419,466,ls),
+(195,466,o),
+(62,338,o),
+(62,99,cs),
+(62,0,l)
+);
+}
+);
+width = 592;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "theThCree-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB3;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB2;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (321,0);
+ref = dot_top;
+}
+);
+width = 592;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB4;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (179,690);
+},
+{
+name = top_right_can;
+pos = (451,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(530,0,l),
+(530,99,ls),
+(530,338,o),
+(398,466,o),
+(173,466,cs),
+(136,466,l),
+(259,412,l),
+(259,530,l),
+(469,530,l),
+(469,615,l),
+(259,615,l),
+(259,690,l),
+(98,690,l),
+(98,615,l),
+(27,615,l),
+(27,530,l),
+(98,530,l),
+(98,324,l),
+(139,324,ls),
+(295,324,o),
+(370,260,o),
+(370,83,cs),
+(370,0,l)
+);
+}
+);
+width = 592;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB5;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB4;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (85,0);
+ref = dot_top;
+}
+);
+width = 592;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB6;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (142,690);
+},
+{
+name = top_right_can;
+pos = (414,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(222,0,l),
+(222,278,l),
+(100,224,l),
+(137,224,ls),
+(361,224,o),
+(494,352,o),
+(494,591,cs),
+(494,639,l),
+(391,583,l),
+(633,383,l),
+(719,489,l),
+(477,690,l),
+(333,690,l),
+(333,607,ls),
+(333,430,o),
+(258,366,o),
+(102,366,cs),
+(62,366,l),
+(62,0,l)
+);
+}
+);
+width = 738;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB7;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB6;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (321,0);
+ref = dot_top;
+}
+);
+width = 738;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB8;
+kernRight = soright;
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (325,690);
+},
+{
+name = top_right_can;
+pos = (597,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(405,0,l),
+(405,83,ls),
+(405,260,o),
+(480,324,o),
+(636,324,cs),
+(676,324,l),
+(676,690,l),
+(516,690,l),
+(516,412,l),
+(639,466,l),
+(602,466,ls),
+(377,466,o),
+(244,338,o),
+(244,99,cs),
+(244,51,l),
+(348,106,l),
+(105,307,l),
+(19,201,l),
+(262,0,l)
+);
+}
+);
+width = 738;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB9;
+kernRight = soright;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB8;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (501,0);
+ref = dot_top;
+}
+);
+width = 738;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABA;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (142,690);
+},
+{
+name = top_right_can;
+pos = (414,690);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(477,0,l),
+(719,201,l),
+(633,307,l),
+(391,106,l),
+(494,51,l),
+(494,99,ls),
+(494,338,o),
+(361,466,o),
+(137,466,cs),
+(100,466,l),
+(222,412,l),
+(222,690,l),
+(62,690,l),
+(62,324,l),
+(102,324,ls),
+(258,324,o),
+(333,260,o),
+(333,83,cs),
+(333,0,l)
+);
+}
+);
+width = 738;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABB;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = uni11ABA;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+}
+);
+width = 738;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABC;
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(544,0,l),
+(544,144,l),
+(207,144,l),
+(207,93,l),
+(554,580,l),
+(554,690,l),
+(40,690,l),
+(40,546,l),
+(377,546,l),
+(377,597,l),
+(31,110,l),
+(31,0,l)
+);
+}
+);
+width = 585;
+}
+);
+metricRight = "=|";
+},
+{
+color = 8;
+glyphname = uni11ABD;
+lastChange = "2023-01-13 15:57:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(554,0,l),
+(554,110,l),
+(207,597,l),
+(207,546,l),
+(545,546,l),
+(545,690,l),
+(31,690,l),
+(31,580,l),
+(377,93,l),
+(377,144,l),
+(40,144,l),
+(40,0,l)
+);
+}
+);
+width = 585;
+}
+);
+metricLeft = "=|uni11ABC";
+metricRight = "=|uni11ABC";
+},
+{
+color = 8;
+glyphname = uni11ABE;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(220,0,l),
+(220,552,l),
+(124,552,l),
+(479,0,l),
+(620,0,l),
+(620,690,l),
+(462,690,l),
+(462,138,l),
+(559,138,l),
+(204,690,l),
+(63,690,l),
+(63,0,l)
+);
+}
+);
+width = 683;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABF;
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(204,0,l),
+(558,553,l),
+(461,553,l),
+(461,0,l),
+(620,0,l),
+(620,690,l),
+(479,690,l),
+(124,137,l),
+(222,137,l),
+(222,690,l),
+(63,690,l),
+(63,0,l)
+);
+}
+);
+width = 683;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = "raiseddoubledotFinal-canadian.cree";
+lastChange = "2023-01-13 15:57:09 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(160,552,o),
+(194,585,o),
+(194,628,cs),
+(194,669,o),
+(160,704,o),
+(119,704,cs),
+(76,704,o),
+(43,670,o),
+(43,628,cs),
+(43,585,o),
+(76,552,o),
+(119,552,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(160,354,o),
+(194,387,o),
+(194,430,cs),
+(194,472,o),
+(160,506,o),
+(119,506,cs),
+(76,506,o),
+(43,472,o),
+(43,430,cs),
+(43,387,o),
+(76,354,o),
+(119,354,cs)
+);
+}
+);
+width = 237;
+}
+);
+note = g725;
+}
+);
+instances = (
+{
+axesValues = (
+169,
+90,
+0
+);
+instanceInterpolations = {
+"9763B71A-4976-465B-BEF0-2F1E1DB14637" = 1;
+};
+name = "RC B roman";
+}
+);
+kerningLTR = {
+"9763B71A-4976-465B-BEF0-2F1E1DB14637" = {
+"@MMK_L_caright" = {
+"@MMK_R_ecanleft" = -72.45;
+"@MMK_R_mwestleft" = -27.048;
+"@MMK_R_neleft" = -40.572;
+};
+"@MMK_L_ciright" = {
+"@MMK_R_icanleft" = -72.45;
+"@MMK_R_noleft" = -77.28;
+};
+"@MMK_L_ecanright" = {
+"@MMK_R_coleft" = -72.45;
+"@MMK_R_moleft" = -77.28;
+"@MMK_R_sileft" = -45.402;
+};
+"@MMK_L_icanright" = {
+"@MMK_R_celeft" = -72.45;
+"@MMK_R_meleft" = -77.28;
+"@MMK_R_mwestleft" = -81.144;
+"@MMK_R_saleft" = -37.674;
+"she-canadian" = -77.28;
+};
+"@MMK_L_maright" = {
+"@MMK_R_acanleft" = -64.722;
+"@MMK_R_ecanleft" = -77.28;
+"@MMK_R_mwestleft" = -46.368;
+"@MMK_R_neleft" = -40.572;
+};
+"@MMK_L_miright" = {
+"@MMK_R_acanleft" = -64.722;
+"@MMK_R_icanleft" = -77.28;
+"@MMK_R_moleft" = -95.634;
+"@MMK_R_noleft" = -77.28;
+"@MMK_R_yeleft" = -106.26;
+};
+"@MMK_L_mwestright" = {
+"@MMK_R_coleft" = -27.048;
+"@MMK_R_icanleft" = -81.144;
+"@MMK_R_moleft" = -46.368;
+"@MMK_R_noleft" = -68.586;
+"@MMK_R_sileft" = -19.32;
+"@MMK_R_yeleft" = -38.64;
+};
+"@MMK_L_naright" = {
+"@MMK_R_acanleft" = -69.552;
+"@MMK_R_celeft" = -77.28;
+"@MMK_R_meleft" = -77.28;
+"@MMK_R_mwestleft" = -68.586;
+"@MMK_R_neleft" = -81.144;
+"@MMK_R_saleft" = -43.47;
+};
+"@MMK_L_niright" = {
+"@MMK_R_coleft" = -40.572;
+"@MMK_R_moleft" = -40.572;
+"@MMK_R_noleft" = -81.144;
+"@MMK_R_sileft" = -0.966;
+};
+"@MMK_L_ocanright" = {
+"@MMK_R_meleft" = -64.722;
+"@MMK_R_moleft" = -64.722;
+"@MMK_R_noleft" = -69.552;
+};
+"@MMK_L_seright" = {
+"@MMK_R_ecanleft" = -45.402;
+"@MMK_R_mwestleft" = -19.32;
+"@MMK_R_neleft" = -0.966;
+};
+"@MMK_L_soright" = {
+"@MMK_R_icanleft" = -37.674;
+"@MMK_R_noleft" = -43.47;
+};
+"@MMK_L_yiright" = {
+"@MMK_R_meleft" = -106.26;
+"@MMK_R_mwestleft" = -38.64;
+};
+"shi-canadian" = {
+"@MMK_R_icanleft" = -77.28;
+};
+};
+};
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "italic angle";
+}
+);
+properties = (
+{
+key = copyrights;
+values = (
+{
+language = ENG;
+value = "Copyright 2018 Google Inc. All Rights Reserved.";
+}
+);
+},
+{
+key = manufacturers;
+values = (
+{
+language = ENG;
+value = "Monotype Imaging Inc.";
+}
+);
+},
+{
+key = designers;
+values = (
+{
+language = ENG;
+value = "Monotype Design Team";
+}
+);
+},
+{
+key = description;
+value = "Designed by Monotype design team.";
+},
+{
+key = trademarks;
+values = (
+{
+language = ENG;
+value = "Noto is a trademark of Google Inc.";
+}
+);
+},
+{
+key = licenseURL;
+value = "http://scripts.sil.org/OFL";
+},
+{
+key = licenses;
+values = (
+{
+language = ENG;
+value = "This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.";
+}
+);
+},
+{
+key = manufacturerURL;
+value = "http://www.google.com/get/noto/";
+},
+{
+key = designerURL;
+value = "http://www.monotype.com/studio";
+}
+);
+settings = {
+disablesNiceNames = 1;
+};
+stems = (
+{
+name = "New Stem";
+}
+);
+unitsPerEm = 966;
+userData = {
+GSDontShowVersionAlert = 1;
+};
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/sources/Exported instances UCAS SansCanadianAboriginal Resized/Sans Canadian Aboriginal-RC CB Italic.glyphs
+++ b/sources/Exported instances UCAS SansCanadianAboriginal Resized/Sans Canadian Aboriginal-RC CB Italic.glyphs
@@ -1,0 +1,37324 @@
+{
+.appVersion = "3151";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+},
+{
+name = Width;
+tag = wdth;
+},
+{
+name = Slant;
+tag = slnt;
+}
+);
+classes = (
+{
+code = "zero one two three four five six seven eight nine ";
+name = Num;
+},
+{
+code = "zero.canadian one.canadian two.canadian three.canadian four.canadian five.canadian six.canadian seven.canadian eight.canadian nine.canadian 
+";
+name = Num_can;
+},
+{
+code = "ke-canadian.square ki-canadian.square kii-canadian.square ko-canadian.square koo-canadian.square ka-canadian.square kaa-canadian.square kweWestCree-canadian.square kwiiWestCree-canadian.square kwoWestCree-canadian.square kwooWestCree-canadian.square kwaWestCree-canadian.square kwaaWestCree-canadian.square ce-canadian.square ci-canadian.square cii-canadian.square co-canadian.square coo-canadian.square ca-canadian.square caa-canadian.square me-canadian.square mi-canadian.square mii-canadian.square mo-canadian.square moo-canadian.square ma-canadian.square maa-canadian.square ne-canadian.square ni-canadian.square nii-canadian.square no-canadian.square noo-canadian.square na-canadian.square naa-canadian.square nweWestCree-canadian.square nwaWestCree-canadian.square nwaaWestCree-canadian.square se-canadian.square si-canadian.square sii-canadian.square so-canadian.square soo-canadian.square sa-canadian.square saa-canadian.square sho-canadian.square shoo-canadian.square sha-canadian.square shaa-canadian.square ye-canadian.square yi-canadian.square yii-canadian.square yo-canadian.square yoo-canadian.square ya-canadian.square yaa-canadian.square re-canadian.square reRCree-canadian.square leWestCree-canadian.square ri-canadian.square rii-canadian.square ro-canadian.square loWestCree-canadian.square ra-canadian.square raa-canadian.square laWestCree-canadian.square reWestCree-canadian.square riWestCree-canadian.square roWestCree-canadian.square raWestCree-canadian.square theThCree-canadian.square thiThCree-canadian.square thiiThCree-canadian.square thoThCree-canadian.square thooThCree-canadian.square thaThCree-canadian.square thaaThCree-canadian.square thweeWoodScree-canadian.square thwiWoodScree-canadian.square thwiiWoodScree-canadian.square thwoWoodScree-canadian.square thwooWoodScree-canadian.square thwaWoodScree-canadian.square thwaaWoodScree-canadian.square nwiOjibway-canadian.square nwiiOjibway-canadian.square nwoOjibway-canadian.square nwooOjibway-canadian.square looWestCree-canadian.square laaWestCree-canadian.square ";
+name = Dene_square;
+},
+{
+code = "ke-canadian ki-canadian kii-canadian ko-canadian koo-canadian ka-canadian kaa-canadian kweWestCree-canadian kwiiWestCree-canadian kwoWestCree-canadian kwooWestCree-canadian kwaWestCree-canadian kwaaWestCree-canadian ce-canadian ci-canadian cii-canadian co-canadian coo-canadian ca-canadian caa-canadian me-canadian mi-canadian mii-canadian mo-canadian moo-canadian ma-canadian maa-canadian ne-canadian ni-canadian nii-canadian no-canadian noo-canadian na-canadian naa-canadian nweWestCree-canadian nwaWestCree-canadian nwaaWestCree-canadian se-canadian si-canadian sii-canadian so-canadian soo-canadian sa-canadian saa-canadian sho-canadian shoo-canadian sha-canadian shaa-canadian ye-canadian yi-canadian yii-canadian yo-canadian yoo-canadian ya-canadian yaa-canadian re-canadian reRCree-canadian leWestCree-canadian ri-canadian rii-canadian ro-canadian loWestCree-canadian ra-canadian raa-canadian laWestCree-canadian reWestCree-canadian riWestCree-canadian roWestCree-canadian raWestCree-canadian theThCree-canadian thiThCree-canadian thiiThCree-canadian thoThCree-canadian thooThCree-canadian thaThCree-canadian thaaThCree-canadian thweeWoodScree-canadian thwiWoodScree-canadian thwiiWoodScree-canadian thwoWoodScree-canadian thwooWoodScree-canadian thwaWoodScree-canadian thwaaWoodScree-canadian nwiOjibway-canadian nwiiOjibway-canadian nwoOjibway-canadian nwooOjibway-canadian looWestCree-canadian laaWestCree-canadian 
+";
+name = Dene_round;
+},
+{
+code = "acuteFinal-canadian.mid graveFinal-canadian.mid ringTophalfFinal-canadian.mid ringRighthalfFinal-canadian.mid ringFinal-canadian.mid doubleacuteFinal-canadian.mid doubleshortverticalstrokesFinal-canadian.mid shorthorizontalstrokeFinal-canadian.mid downtackFinal-canadian.mid pWestCree-canadian.mid c-canadian.mid mWestCree-canadian.mid ";
+name = Final_mid;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian ringFinal-canadian doubleacuteFinal-canadian doubleshortverticalstrokesFinal-canadian shorthorizontalstrokeFinal-canadian downtackFinal-canadian pWestCree-canadian c-canadian mWestCree-canadian ";
+name = Final_mid_ori;
+},
+{
+code = "acuteFinal-canadian.base graveFinal-canadian.base ringBottomhalfFinal-canadian.base ringTophalfFinal-canadian.base ringRighthalfFinal-canadian.base plusFinal-canadian.base pWestCree-canadian.base c-canadian.base thSayisi-canadian.base mWestCree-canadian.base ";
+name = Final_base;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringBottomhalfFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian plusFinal-canadian pWestCree-canadian c-canadian thSayisi-canadian mWestCree-canadian ";
+name = Final_base_ori;
+},
+{
+code = "ng-canadian ngai-canadian ngaai-canadian ngi-canadian ngii-canadian ngo-canadian ngoo-canadian nga-canadian ngaa-canadian ";
+name = Nunavik;
+},
+{
+code = "ng-canadian.nunavik ngai-canadian.nunavik ngaai-canadian.nunavik ngi-canadian.nunavik ngii-canadian.nunavik ngo-canadian.nunavik ngoo-canadian.nunavik nga-canadian.nunavik ngaa-canadian.nunavik ";
+name = Nunavik_alt;
+}
+);
+customParameters = (
+{
+name = vendorID;
+value = GOOG;
+},
+{
+name = panose;
+value = (
+2,
+11,
+5,
+2,
+4,
+5,
+4,
+2,
+2,
+4
+);
+},
+{
+name = unicodeRanges;
+value = (
+0,
+1,
+2,
+5,
+6,
+45,
+77
+);
+},
+{
+name = codePageRanges;
+value = (
+"1252"
+);
+},
+{
+name = fsType;
+value = (
+);
+}
+);
+date = "2022-06-21 10:06:40 +0000";
+familyName = "Sans Canadian Aboriginal";
+featurePrefixes = (
+{
+automatic = 1;
+code = "languagesystem DFLT dflt;
+
+languagesystem cans dflt;
+";
+name = Languagesystems;
+}
+);
+features = (
+{
+automatic = 1;
+code = "feature ss01;
+feature ss02;
+feature ss03;
+feature ss04;
+";
+tag = aalt;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+tag = salt;
+},
+{
+code = "lookup space_can {
+sub space by space.canadian;
+} space_can;
+
+lookup num_can {
+sub @Num by @Num_can;
+} num_can;
+";
+labels = (
+{
+language = dflt;
+value = "CAN Space and numerals";
+}
+);
+tag = ss01;
+},
+{
+code = "lookup dene_square {
+sub @Dene_round by @Dene_square;
+} dene_square;
+
+";
+labels = (
+{
+language = dflt;
+value = "Dene Square";
+}
+);
+tag = ss02;
+},
+{
+code = "lookup nunavik_alt {
+sub @Nunavik by @Nunavik_alt;
+} nunavik_alt;
+
+";
+labels = (
+{
+language = dflt;
+value = "Nunanvik Alt";
+}
+);
+tag = ss03;
+},
+{
+code = "lookup final_mid {
+sub @Final_mid_ori by @Final_mid;
+} final_mid;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final mid";
+}
+);
+tag = ss04;
+},
+{
+code = "lookup final_base {
+sub @Final_base_ori by @Final_base;
+} final_base;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final base";
+}
+);
+tag = ss05;
+},
+{
+code = "lookup plaincree_first {
+sub wiWestCree-canadian' plusFinal-canadian by i-canadian;
+} plaincree_first;
+
+lookup plaincree_second {
+sub i-canadian plusFinal-canadian' by raiseddoubledotFinal-canadian.cree;
+} plaincree_second;
+
+lookup plaincree_third {
+sub middledotFinal-canadian plusFinal-canadian by raiseddoubledotFinal-canadian.cree;
+} plaincree_third;
+";
+labels = (
+{
+language = dflt;
+value = Plaincree;
+}
+);
+tag = ss06;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+labels = (
+{
+language = dflt;
+value = "";
+}
+);
+tag = ss07;
+}
+);
+fontMaster = (
+{
+axesValues = (
+0,
+0,
+0
+);
+customParameters = (
+{
+name = typoAscender;
+value = 1033;
+},
+{
+name = typoDescender;
+value = -283;
+},
+{
+name = typoLineGap;
+value = 0;
+},
+{
+name = winAscent;
+value = 1033;
+},
+{
+name = winDescent;
+value = 283;
+},
+{
+name = hheaAscender;
+value = 1033;
+},
+{
+name = hheaDescender;
+value = -283;
+},
+{
+name = strikeoutPosition;
+value = 293;
+},
+{
+name = strikeoutSize;
+value = 48;
+},
+{
+name = "Master Icon Glyph Name";
+value = s;
+}
+);
+guides = (
+{
+locked = 1;
+pos = (417,345);
+},
+{
+locked = 1;
+pos = (97,704);
+},
+{
+locked = 1;
+pos = (-55,-14);
+}
+);
+id = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+metricValues = (
+{
+over = 22;
+pos = 1033;
+},
+{
+over = 22;
+pos = 690;
+},
+{
+over = 22;
+pos = 489;
+},
+{
+over = -22;
+},
+{
+over = -22;
+pos = -283;
+},
+{
+pos = 12;
+}
+);
+name = "RC CB Italic";
+stemValues = (
+141
+);
+}
+);
+glyphs = (
+{
+glyphname = idotless;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(139,0,l),
+(251,528,l),
+(110,528,l),
+(-2,0,l)
+);
+}
+);
+width = 241;
+}
+);
+note = dotlessi;
+unicode = 305;
+},
+{
+glyphname = "acuteFinal-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(154,345,l),
+(361,690,l),
+(245,690,l),
+(38,345,l)
+);
+}
+);
+width = 283;
+}
+);
+metricRight = "=|";
+note = uni141F;
+unicode = 5151;
+},
+{
+glyphname = "graveFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(289,345,l),
+(216,690,l),
+(112,690,l),
+(185,345,l)
+);
+}
+);
+width = 285;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+unicode = 5152;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(301,339,o),
+(349,386,o),
+(366,469,cs),
+(412,690,l),
+(319,690,l),
+(272,472,ls),
+(266,439,o),
+(250,423,o),
+(222,423,cs),
+(191,423,o),
+(180,441,o),
+(187,474,cs),
+(233,690,l),
+(138,690,l),
+(95,487,ls),
+(76,397,o),
+(122,339,o),
+(213,339,cs)
+);
+}
+);
+width = 361;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1421;
+unicode = 5153;
+},
+{
+glyphname = "ringTophalfFinal-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(159,345,l),
+(205,562,ls),
+(212,596,o),
+(227,611,o),
+(256,611,cs),
+(286,611,o),
+(297,593,o),
+(291,560,cs),
+(245,345,l),
+(339,345,l),
+(383,548,ls),
+(402,638,o),
+(356,696,o),
+(264,696,cs),
+(176,696,o),
+(129,648,o),
+(111,565,cs),
+(65,345,l)
+);
+}
+);
+width = 361;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+unicode = 5154;
+},
+{
+glyphname = "ringRighthalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(119,345,ls),
+(263,345,o),
+(326,444,o),
+(326,554,cs),
+(326,640,o),
+(270,690,o),
+(181,690,cs),
+(138,690,l),
+(119,601,l),
+(166,601,ls),
+(207,601,o),
+(231,580,o),
+(231,540,cs),
+(231,488,o),
+(205,434,o),
+(132,434,cs),
+(84,434,l),
+(65,345,l)
+);
+}
+);
+width = 304;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+unicode = 5155;
+},
+{
+glyphname = "ringFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(355,383,o),
+(421,450,o),
+(421,540,cs),
+(421,629,o),
+(355,696,o),
+(263,696,cs),
+(169,696,o),
+(102,629,o),
+(102,540,cs),
+(102,450,o),
+(168,383,o),
+(263,383,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(216,463,o),
+(189,496,o),
+(189,540,cs),
+(189,583,o),
+(216,615,o),
+(263,615,cs),
+(306,615,o),
+(334,582,o),
+(334,540,cs),
+(334,496,o),
+(306,463,o),
+(263,463,cs)
+);
+}
+);
+width = 398;
+}
+);
+note = uni1424;
+unicode = 5156;
+},
+{
+glyphname = "doubleacuteFinal-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(150,345,l),
+(361,690,l),
+(249,690,l),
+(38,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(304,345,l),
+(516,690,l),
+(405,690,l),
+(193,345,l)
+);
+}
+);
+width = 438;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricRight = "=|";
+note = uni1425;
+unicode = 5157;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(159,345,l),
+(233,690,l),
+(138,690,l),
+(65,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(295,345,l),
+(368,690,l),
+(273,690,l),
+(200,345,l)
+);
+}
+);
+width = 317;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "pWestCree-canadian";
+note = uni1426;
+unicode = 5158;
+},
+{
+glyphname = "middledotFinal-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(163,287,o),
+(193,317,o),
+(193,355,cs),
+(193,392,o),
+(163,422,o),
+(126,422,cs),
+(88,422,o),
+(58,392,o),
+(58,355,cs),
+(58,317,o),
+(88,287,o),
+(126,287,cs)
+);
+}
+);
+width = 204;
+}
+);
+note = uni1427;
+unicode = 5159;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(374,490,l),
+(394,585,l),
+(116,585,l),
+(96,490,l)
+);
+}
+);
+width = 366;
+}
+);
+metricRight = "=|";
+note = uni1428;
+unicode = 5160;
+},
+{
+glyphname = "plusFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(260,393,l),
+(282,498,l),
+(376,498,l),
+(395,587,l),
+(300,587,l),
+(323,690,l),
+(233,690,l),
+(212,587,l),
+(117,587,l),
+(98,498,l),
+(192,498,l),
+(170,393,l)
+);
+}
+);
+width = 366;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+unicode = 5161;
+},
+{
+glyphname = "downtackFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(252,345,l),
+(306,600,l),
+(398,600,l),
+(417,690,l),
+(139,690,l),
+(120,600,l),
+(212,600,l),
+(157,345,l)
+);
+}
+);
+width = 366;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni142A;
+unicode = 5162;
+},
+{
+glyphname = "thFinalWoodScree-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(251,345,l),
+(264,405,l),
+(355,405,l),
+(372,484,l),
+(281,484,l),
+(295,551,l),
+(385,551,l),
+(403,630,l),
+(312,630,l),
+(325,690,l),
+(230,690,l),
+(217,630,l),
+(125,630,l),
+(108,551,l),
+(201,551,l),
+(186,484,l),
+(94,484,l),
+(77,405,l),
+(170,405,l),
+(156,345,l)
+);
+}
+);
+width = 364;
+}
+);
+metricLeft = "hyphen-canadian";
+metricRight = "hyphen-canadian";
+note = uni167E;
+unicode = 5758;
+},
+{
+glyphname = "ringSmallFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(279,499,o),
+(327,543,o),
+(327,602,cs),
+(327,661,o),
+(279,703,o),
+(223,703,cs),
+(167,703,o),
+(120,662,o),
+(120,602,cs),
+(120,543,o),
+(167,499,o),
+(223,499,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(197,557,o),
+(181,578,o),
+(181,602,cs),
+(181,626,o),
+(198,646,o),
+(223,646,cs),
+(249,646,o),
+(267,626,o),
+(267,602,cs),
+(267,578,o),
+(249,557,o),
+(223,557,cs)
+);
+}
+);
+width = 295;
+}
+);
+note = g725;
+unicode = 6366;
+},
+{
+glyphname = "raiseddotFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(224,569,o),
+(254,599,o),
+(254,637,cs),
+(254,673,o),
+(224,703,o),
+(186,703,cs),
+(149,703,o),
+(119,673,o),
+(119,637,cs),
+(119,599,o),
+(149,569,o),
+(186,569,cs)
+);
+}
+);
+width = 206;
+}
+);
+note = g725;
+unicode = 6367;
+},
+{
+glyphname = "acuteFinal-canadian.base";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-73,-345);
+ref = "acuteFinal-canadian";
+}
+);
+width = 283;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.base";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-74,-345);
+ref = "graveFinal-canadian";
+}
+);
+width = 284;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian.base";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-74,-345);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 361;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1421;
+},
+{
+glyphname = "ringTophalfFinal-canadian.base";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-73,-345);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 362;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.base";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-74,-345);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 304;
+}
+);
+metricLeft = "==|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "plusFinal-canadian.base";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(176,0,l),
+(198,105,l),
+(292,105,l),
+(311,194,l),
+(217,194,l),
+(240,297,l),
+(150,297,l),
+(128,194,l),
+(33,194,l),
+(14,105,l),
+(109,105,l),
+(87,0,l)
+);
+}
+);
+width = 366;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+},
+{
+glyphname = "acuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-34,-162);
+ref = "acuteFinal-canadian";
+}
+);
+width = 283;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.mid";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-162);
+ref = "graveFinal-canadian";
+}
+);
+width = 283;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringTophalfFinal-canadian.mid";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-37,-172);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 361;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.mid";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-34,-162);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 304;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "ringFinal-canadian.mid";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-42,-196);
+ref = "ringFinal-canadian";
+}
+);
+width = 398;
+}
+);
+metricLeft = "ringFinal-canadian";
+metricWidth = "ringFinal-canadian";
+note = uni1424;
+},
+{
+glyphname = "doubleacuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-34,-162);
+ref = "doubleacuteFinal-canadian";
+}
+);
+width = 438;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "doubleacuteFinal-canadian";
+note = uni1425;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian.mid";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-162);
+ref = "doubleshortverticalstrokesFinal-canadian";
+}
+);
+width = 317;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricWidth = "doubleshortverticalstrokesFinal-canadian";
+note = uni1426;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian.mid";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-39,-183);
+ref = "shorthorizontalstrokeFinal-canadian";
+}
+);
+width = 366;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "shorthorizontalstrokeFinal-canadian";
+note = uni1428;
+},
+{
+glyphname = "downtackFinal-canadian.mid";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-34,-162);
+ref = "downtackFinal-canadian";
+}
+);
+width = 366;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "downtackFinal-canadian";
+note = uni142A;
+},
+{
+glyphname = "e-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (347,454);
+},
+{
+name = top_center_can;
+pos = (403,690);
+},
+{
+name = top_left_can;
+pos = (213,690);
+},
+{
+name = top_right_can;
+pos = (592,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(275,0,l),
+(684,655,l),
+(691,690,l),
+(113,690,l),
+(106,655,l),
+(235,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(320,157,l),
+(243,605,l),
+(214,577,l),
+(537,577,l),
+(512,605,l),
+(249,157,l)
+);
+}
+);
+width = 615;
+}
+);
+metricRight = "=|";
+note = uni1401;
+unicode = 5121;
+},
+{
+glyphname = "aai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (191,0);
+ref = ring_top.canadian;
+}
+);
+width = 614;
+}
+);
+note = uni1402;
+unicode = 5122;
+},
+{
+glyphname = "i-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (323,291);
+},
+{
+name = top_center_can;
+pos = (402,690);
+},
+{
+name = top_left_can;
+pos = (212,690);
+},
+{
+name = top_right_can;
+pos = (592,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(382,690,l),
+(-27,35,l),
+(-34,0,l),
+(544,0,l),
+(551,35,l),
+(422,690,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(337,532,l),
+(413,85,l),
+(442,113,l),
+(120,113,l),
+(144,85,l),
+(408,532,l)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "e-canadian";
+metricWidth = "e-canadian";
+note = uni1403;
+unicode = 5123;
+},
+{
+glyphname = "ii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (224,0);
+ref = dot_top;
+}
+);
+width = 614;
+}
+);
+note = uni1404;
+unicode = 5124;
+},
+{
+glyphname = "o-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (264,359);
+},
+{
+name = top_center_can;
+pos = (387,690);
+},
+{
+name = top_double;
+pos = (485,690);
+},
+{
+name = top_left_can;
+pos = (202,690);
+},
+{
+name = top_right_can;
+pos = (583,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(32,0,l),
+(562,323,l),
+(572,367,l),
+(179,690,l),
+(146,690,l),
+(-1,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(229,532,l),
+(178,551,l),
+(432,340,l),
+(427,368,l),
+(103,167,l),
+(149,158,l)
+);
+}
+);
+width = 572;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1405;
+unicode = 5125;
+},
+{
+glyphname = "oo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (22,0);
+ref = dot_top;
+}
+);
+width = 572;
+}
+);
+note = uni1406;
+unicode = 5126;
+},
+{
+glyphname = "yCreeoo-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (134,0);
+ref = doubledot_top;
+}
+);
+width = 572;
+}
+);
+note = uni1407;
+unicode = 5127;
+},
+{
+glyphname = "eeCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(32,0,l),
+(562,323,l),
+(572,367,l),
+(179,690,l),
+(146,690,l),
+(-1,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(219,532,l),
+(200,537,l),
+(438,339,l),
+(445,375,l),
+(123,176,l),
+(139,158,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(263,291,l),
+(291,421,l),
+(245,421,l),
+(218,291,l)
+);
+}
+);
+width = 572;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "o-canadian";
+note = uni1408;
+unicode = 5128;
+},
+{
+glyphname = "iCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (189,14);
+ref = dot_middle_optic_small;
+}
+);
+width = 572;
+}
+);
+note = uni1409;
+unicode = 5129;
+},
+{
+glyphname = "a-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (352,343);
+},
+{
+name = top_center_can;
+pos = (344,690);
+},
+{
+name = top_left_can;
+pos = (187,690);
+},
+{
+name = top_right_can;
+pos = (554,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(582,690,l),
+(52,367,l),
+(43,323,l),
+(436,0,l),
+(469,0,l),
+(615,690,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(385,157,l),
+(437,139,l),
+(183,350,l),
+(187,322,l),
+(511,523,l),
+(466,531,l)
+);
+}
+);
+width = 572;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni140A;
+unicode = 5130;
+},
+{
+glyphname = "aa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (376,0);
+ref = dot_top;
+}
+);
+width = 572;
+}
+);
+note = uni140B;
+unicode = 5131;
+},
+{
+glyphname = "we-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "e-canadian";
+}
+);
+width = 818;
+}
+);
+note = uni140C;
+unicode = 5132;
+},
+{
+glyphname = "weWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (614,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 818;
+}
+);
+note = uni140D;
+unicode = 5133;
+},
+{
+glyphname = "wi-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "i-canadian";
+}
+);
+width = 818;
+}
+);
+note = uni140E;
+unicode = 5134;
+},
+{
+glyphname = "wiWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (614,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 818;
+}
+);
+note = uni140F;
+unicode = 5135;
+},
+{
+glyphname = "wii-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (428,0);
+ref = dot_top;
+}
+);
+width = 818;
+}
+);
+note = uni1410;
+unicode = 5136;
+},
+{
+glyphname = "wiiWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (224,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (614,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 818;
+}
+);
+note = uni1411;
+unicode = 5137;
+},
+{
+glyphname = "wo-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "o-canadian";
+}
+);
+width = 776;
+}
+);
+note = uni1412;
+unicode = 5138;
+},
+{
+glyphname = "woWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (572,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 776;
+}
+);
+note = uni1413;
+unicode = 5139;
+},
+{
+glyphname = "woo-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (412,0);
+ref = dot_top;
+}
+);
+width = 776;
+}
+);
+note = uni1414;
+unicode = 5140;
+},
+{
+glyphname = "wooWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (22,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (572,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 776;
+}
+);
+note = uni1415;
+unicode = 5141;
+},
+{
+glyphname = "wooNaskapi-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (133,-92);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (271,-205);
+ref = dot_top;
+}
+);
+width = 572;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricWidth = "o-canadian";
+note = uni1416;
+unicode = 5142;
+},
+{
+glyphname = "wa-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "a-canadian";
+}
+);
+width = 776;
+}
+);
+note = uni1417;
+unicode = 5143;
+},
+{
+glyphname = "waWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (572,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 776;
+}
+);
+note = uni1418;
+unicode = 5144;
+},
+{
+glyphname = "waa-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (580,0);
+ref = dot_top;
+}
+);
+width = 776;
+}
+);
+note = uni1419;
+unicode = 5145;
+},
+{
+glyphname = "waaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (376,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (572,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 776;
+}
+);
+note = uni141A;
+unicode = 5146;
+},
+{
+glyphname = "waaNaskapi-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (58,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (236,-92);
+ref = dot_top;
+}
+);
+width = 572;
+}
+);
+metricWidth = "a-canadian";
+note = uni141B;
+unicode = 5147;
+},
+{
+glyphname = "ai-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(245,339,o),
+(282,363,o),
+(308,410,c),
+(282,410,l),
+(292,363,o),
+(326,339,o),
+(379,339,cs),
+(457,339,o),
+(500,382,o),
+(519,470,cs),
+(565,690,l),
+(477,690,l),
+(431,471,ls),
+(423,438,o),
+(408,422,o),
+(382,422,cs),
+(354,422,o),
+(342,439,o),
+(350,472,cs),
+(395,690,l),
+(308,690,l),
+(262,472,ls),
+(255,438,o),
+(239,422,o),
+(213,422,cs),
+(186,422,o),
+(173,440,o),
+(180,471,cs),
+(226,690,l),
+(138,690,l),
+(91,468,ls),
+(75,394,o),
+(117,339,o),
+(194,339,cs)
+);
+}
+);
+width = 514;
+}
+);
+metricRight = "=|";
+note = uni141C;
+unicode = 5148;
+},
+{
+glyphname = "ycreew-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(362,510,o),
+(392,546,o),
+(392,604,cs),
+(392,662,o),
+(361,696,o),
+(319,696,cs),
+(276,696,o),
+(246,662,o),
+(246,604,cs),
+(246,546,o),
+(275,510,o),
+(319,510,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(202,339,o),
+(232,375,o),
+(232,433,cs),
+(232,491,o),
+(201,525,o),
+(158,525,cs),
+(116,525,o),
+(85,491,o),
+(85,433,cs),
+(85,375,o),
+(115,339,o),
+(158,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(142,384,o),
+(132,399,o),
+(132,433,cs),
+(132,466,o),
+(142,479,o),
+(158,479,cs),
+(175,479,o),
+(185,466,o),
+(185,433,cs),
+(185,399,o),
+(175,384,o),
+(158,384,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(303,555,o),
+(293,570,o),
+(293,604,cs),
+(293,637,o),
+(303,650,o),
+(319,650,cs),
+(335,650,o),
+(346,637,o),
+(346,604,cs),
+(346,570,o),
+(335,555,o),
+(319,555,cs)
+);
+}
+);
+width = 361;
+}
+);
+metricRight = "=|";
+note = uni141D;
+unicode = 5149;
+},
+{
+glyphname = "glottalstop-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(346,345,l),
+(351,363,l),
+(285,690,l),
+(265,690,l),
+(61,363,l),
+(57,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(279,595,l),
+(238,596,l),
+(273,387,l),
+(291,413,l),
+(147,413,l),
+(156,387,l)
+);
+}
+);
+width = 362;
+}
+);
+metricRight = "=|";
+note = uni141E;
+unicode = 5150;
+},
+{
+glyphname = "en-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+pos = (614,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 898;
+}
+);
+note = uni142B;
+unicode = 5163;
+},
+{
+glyphname = "in-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+pos = (415,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 700;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142C;
+unicode = 5164;
+},
+{
+glyphname = "on-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (439,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 724;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142D;
+unicode = 5165;
+},
+{
+glyphname = "an-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (544,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 829;
+}
+);
+metricRight = "graveFinal-canadian";
+note = uni142E;
+unicode = 5166;
+},
+{
+glyphname = "pe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (345,454);
+},
+{
+name = top_center_can;
+pos = (402,690);
+},
+{
+name = top_left_can;
+pos = (213,690);
+},
+{
+name = top_right_can;
+pos = (592,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(275,0,l),
+(684,655,l),
+(691,690,l),
+(553,690,l),
+(235,167,l),
+(331,167,l),
+(236,690,l),
+(113,690,l),
+(106,655,l),
+(235,0,l)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni142F;
+unicode = 5167;
+},
+{
+glyphname = "paai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (191,0);
+ref = ring_top.canadian;
+}
+);
+width = 614;
+}
+);
+note = uni1430;
+unicode = 5168;
+},
+{
+glyphname = "pi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (325,291);
+},
+{
+name = top_center_can;
+pos = (402,690);
+},
+{
+name = top_left_can;
+pos = (212,690);
+},
+{
+name = top_right_can;
+pos = (591,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(382,690,l),
+(-27,35,l),
+(-34,0,l),
+(104,0,l),
+(422,523,l),
+(326,523,l),
+(420,0,l),
+(543,0,l),
+(551,35,l),
+(422,690,l)
+);
+}
+);
+width = 614;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni1431;
+unicode = 5169;
+},
+{
+glyphname = "pii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (224,0);
+ref = dot_top;
+}
+);
+width = 614;
+}
+);
+note = uni1432;
+unicode = 5170;
+},
+{
+glyphname = "po-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (170,360);
+},
+{
+name = top_center_can;
+pos = (371,690);
+},
+{
+name = top_double;
+pos = (480,690);
+},
+{
+name = top_left_can;
+pos = (190,690);
+},
+{
+name = top_right_can;
+pos = (566,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+name = "Thin Slanted";
+shapes = (
+{
+closed = 1;
+nodes = (
+(16,0,l),
+(544,323,l),
+(554,367,l),
+(163,690,l),
+(129,690,l),
+(103,568,l),
+(396,327,l),
+(409,389,l),
+(14,149,l),
+(-17,0,l)
+);
+}
+);
+width = 554;
+}
+);
+metricRight = "o-canadian";
+note = uni1433;
+unicode = 5171;
+},
+{
+glyphname = "poo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (12,0);
+ref = dot_top;
+}
+);
+width = 554;
+}
+);
+note = uni1434;
+unicode = 5172;
+},
+{
+glyphname = "ycreepoo-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (129,0);
+ref = doubledot_top;
+}
+);
+width = 554;
+}
+);
+note = uni1435;
+unicode = 5173;
+},
+{
+glyphname = "heeCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (103,15);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 554;
+}
+);
+note = uni1436;
+unicode = 5174;
+},
+{
+glyphname = "hiCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (80,20);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 554;
+}
+);
+note = uni1437;
+unicode = 5175;
+},
+{
+glyphname = "pa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (378,345);
+},
+{
+name = top_center_can;
+pos = (376,690);
+},
+{
+name = top_left_can;
+pos = (189,690);
+},
+{
+name = top_right_can;
+pos = (554,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(580,690,l),
+(52,367,l),
+(43,323,l),
+(433,0,l),
+(467,0,l),
+(493,122,l),
+(200,363,l),
+(188,300,l),
+(582,541,l),
+(612,690,l)
+);
+}
+);
+width = 553;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1438;
+unicode = 5176;
+},
+{
+glyphname = "paa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (375,0);
+ref = dot_top;
+}
+);
+width = 554;
+}
+);
+note = uni1439;
+unicode = 5177;
+},
+{
+glyphname = "pwe-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "pe-canadian";
+}
+);
+width = 818;
+}
+);
+note = uni143A;
+unicode = 5178;
+},
+{
+glyphname = "pweWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "pe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (614,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 818;
+}
+);
+note = uni143B;
+unicode = 5179;
+},
+{
+glyphname = "pwi-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "pi-canadian";
+}
+);
+width = 818;
+}
+);
+note = uni143C;
+unicode = 5180;
+},
+{
+glyphname = "pwiWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (614,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 818;
+}
+);
+note = uni143D;
+unicode = 5181;
+},
+{
+glyphname = "pwii-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (428,0);
+ref = dot_top;
+}
+);
+width = 818;
+}
+);
+note = uni143E;
+unicode = 5182;
+},
+{
+glyphname = "pwiiWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (224,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (614,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 818;
+}
+);
+note = uni143F;
+unicode = 5183;
+},
+{
+glyphname = "pwo-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "po-canadian";
+}
+);
+width = 757;
+}
+);
+note = uni1440;
+unicode = 5184;
+},
+{
+glyphname = "pwoWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (554,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 757;
+}
+);
+note = uni1441;
+unicode = 5185;
+},
+{
+glyphname = "pwoo-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (395,0);
+ref = dot_top;
+}
+);
+width = 757;
+}
+);
+note = uni1442;
+unicode = 5186;
+},
+{
+glyphname = "pwooWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (12,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (554,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 757;
+}
+);
+note = uni1443;
+unicode = 5187;
+},
+{
+glyphname = "pwa-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "pa-canadian";
+}
+);
+width = 757;
+}
+);
+note = uni1444;
+unicode = 5188;
+},
+{
+glyphname = "pwaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (554,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 757;
+}
+);
+note = uni1445;
+unicode = 5189;
+},
+{
+glyphname = "pwaa-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (579,0);
+ref = dot_top;
+}
+);
+width = 757;
+}
+);
+note = uni1446;
+unicode = 5190;
+},
+{
+glyphname = "pwaaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (375,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (554,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 757;
+}
+);
+note = uni1447;
+unicode = 5191;
+},
+{
+glyphname = "ycreepwaa-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+pos = (50,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (228,-92);
+ref = dot_top;
+}
+);
+width = 553;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1448;
+unicode = 5192;
+},
+{
+glyphname = "p-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(306,345,l),
+(324,426,l),
+(182,545,l),
+(166,474,l),
+(358,592,l),
+(380,690,l),
+(363,690,l),
+(103,529,l),
+(99,506,l),
+(290,345,l)
+);
+}
+);
+width = 328;
+}
+);
+note = uni1449;
+unicode = 5193;
+},
+{
+glyphname = "pWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(159,345,l),
+(233,690,l),
+(138,690,l),
+(65,345,l)
+);
+}
+);
+width = 181;
+}
+);
+metricRight = "=|";
+note = uni144A;
+unicode = 5194;
+},
+{
+color = 6;
+glyphname = "hCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(124,183,l),
+(150,306,ls),
+(156,338,o),
+(171,353,o),
+(191,353,cs),
+(216,353,o),
+(226,335,o),
+(219,306,cs),
+(193,183,l),
+(287,183,l),
+(317,322,ls),
+(330,387,o),
+(296,437,o),
+(230,437,cs),
+(191,437,o),
+(156,414,o),
+(146,382,c),
+(163,366,l),
+(197,527,l),
+(103,527,l),
+(30,183,l)
+);
+}
+);
+width = 329;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144B;
+unicode = 5195;
+},
+{
+glyphname = "te-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (330,345);
+},
+{
+name = top_center_can;
+pos = (404,690);
+},
+{
+name = top_left_can;
+pos = (214,690);
+},
+{
+name = top_right_can;
+pos = (594,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(442,-14,o),
+(533,71,o),
+(570,242,cs),
+(665,690,l),
+(523,690,l),
+(430,253,ls),
+(410,157,o),
+(367,117,o),
+(296,117,cs),
+(209,117,o),
+(175,169,o),
+(196,269,cs),
+(286,690,l),
+(143,690,l),
+(57,282,ls),
+(17,98,o),
+(107,-14,o),
+(285,-14,cs)
+);
+}
+);
+width = 619;
+}
+);
+metricRight = "=|";
+note = uni144C;
+unicode = 5196;
+},
+{
+glyphname = "taai-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (192,0);
+ref = ring_top.canadian;
+}
+);
+width = 619;
+}
+);
+note = uni144D;
+unicode = 5197;
+},
+{
+glyphname = "ti-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (330,345);
+},
+{
+name = middle_right_can;
+pos = (713,345);
+},
+{
+name = top_center_can;
+pos = (404,690);
+},
+{
+name = top_left_can;
+pos = (214,690);
+},
+{
+name = top_right_can;
+pos = (594,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(139,0,l),
+(232,437,ls),
+(252,532,o),
+(295,573,o),
+(366,573,cs),
+(453,573,o),
+(486,521,o),
+(465,421,cs),
+(376,0,l),
+(518,0,l),
+(605,408,ls),
+(644,592,o),
+(554,703,o),
+(377,703,cs),
+(219,703,o),
+(128,619,o),
+(92,448,cs),
+(-4,0,l)
+);
+}
+);
+width = 618;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni144E;
+unicode = 5198;
+},
+{
+glyphname = "tii-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (225,0);
+ref = dot_top;
+}
+);
+width = 619;
+}
+);
+note = uni144F;
+unicode = 5199;
+},
+{
+glyphname = "to-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (210,345);
+},
+{
+name = middle_right_can;
+pos = (621,345);
+},
+{
+name = top_center_can;
+pos = (331,690);
+},
+{
+name = top_double;
+pos = (404,690);
+},
+{
+name = top_left_can;
+pos = (193,690);
+},
+{
+name = top_right_can;
+pos = (513,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(117,0,ls),
+(436,0,o),
+(505,265,o),
+(505,420,cs),
+(505,588,o),
+(404,690,o),
+(223,690,cs),
+(131,690,l),
+(104,560,l),
+(199,560,ls),
+(307,560,o),
+(362,508,o),
+(362,409,cs),
+(362,309,o),
+(321,129,o),
+(125,129,cs),
+(13,129,l),
+(-14,0,l)
+);
+}
+);
+width = 522;
+}
+);
+note = uni1450;
+unicode = 5200;
+},
+{
+glyphname = "too-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (153,0);
+ref = dot_top;
+}
+);
+width = 522;
+}
+);
+note = uni1451;
+unicode = 5201;
+},
+{
+glyphname = "ycreetoo-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (54,0);
+ref = doubledot_top;
+}
+);
+width = 522;
+}
+);
+note = uni1452;
+unicode = 5202;
+},
+{
+glyphname = "deeCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (131,0);
+ref = stroke_middle;
+}
+);
+width = 522;
+}
+);
+note = uni1453;
+unicode = 5203;
+},
+{
+glyphname = "diCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (104,0);
+ref = dot_middle;
+}
+);
+width = 522;
+}
+);
+note = uni1454;
+unicode = 5204;
+},
+{
+glyphname = "ta-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (356,345);
+},
+{
+name = top_center_can;
+pos = (382,690);
+},
+{
+name = top_left_can;
+pos = (199,690);
+},
+{
+name = top_right_can;
+pos = (519,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(433,0,l),
+(460,129,l),
+(365,129,ls),
+(257,129,o),
+(203,182,o),
+(203,281,cs),
+(203,393,o),
+(256,560,o),
+(440,560,cs),
+(553,560,l),
+(580,690,l),
+(446,690,ls),
+(139,690,o),
+(60,436,o),
+(60,270,cs),
+(60,101,o),
+(160,0,o),
+(340,0,cs)
+);
+}
+);
+width = 522;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|to-canadian";
+note = uni1455;
+unicode = 5205;
+},
+{
+glyphname = "taa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (202,0);
+ref = dot_top;
+}
+);
+width = 522;
+}
+);
+note = uni1456;
+unicode = 5206;
+},
+{
+glyphname = "twe-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "te-canadian";
+}
+);
+width = 823;
+}
+);
+note = uni1457;
+unicode = 5207;
+},
+{
+glyphname = "tweWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (619,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 823;
+}
+);
+note = uni1458;
+unicode = 5208;
+},
+{
+glyphname = "twi-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ti-canadian";
+}
+);
+width = 823;
+}
+);
+note = uni1459;
+unicode = 5209;
+},
+{
+glyphname = "twiWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (619,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 823;
+}
+);
+note = uni145A;
+unicode = 5210;
+},
+{
+glyphname = "twii-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (429,0);
+ref = dot_top;
+}
+);
+width = 823;
+}
+);
+note = uni145B;
+unicode = 5211;
+},
+{
+glyphname = "twiiWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (225,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (619,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 823;
+}
+);
+note = uni145C;
+unicode = 5212;
+},
+{
+glyphname = "two-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "to-canadian";
+}
+);
+width = 725;
+}
+);
+note = uni145D;
+unicode = 5213;
+},
+{
+glyphname = "twoWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (522,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 725;
+}
+);
+note = uni145E;
+unicode = 5214;
+},
+{
+glyphname = "twoo-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (356,0);
+ref = dot_top;
+}
+);
+width = 725;
+}
+);
+note = uni145F;
+unicode = 5215;
+},
+{
+glyphname = "twooWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (153,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (522,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 725;
+}
+);
+note = uni1460;
+unicode = 5216;
+},
+{
+glyphname = "twa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ta-canadian";
+}
+);
+width = 725;
+}
+);
+note = uni1461;
+unicode = 5217;
+},
+{
+glyphname = "twaWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (522,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 725;
+}
+);
+note = uni1462;
+unicode = 5218;
+},
+{
+glyphname = "twaa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (406,0);
+ref = dot_top;
+}
+);
+width = 725;
+}
+);
+note = uni1463;
+unicode = 5219;
+},
+{
+glyphname = "twaaWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (202,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (522,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 725;
+}
+);
+note = uni1464;
+unicode = 5220;
+},
+{
+glyphname = "twaaNaskapi-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (207,0);
+ref = "ta-canadian";
+}
+);
+width = 728;
+}
+);
+note = uni1465;
+unicode = 5221;
+},
+{
+glyphname = "t-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(282,345,l),
+(301,434,l),
+(254,434,ls),
+(213,434,o),
+(189,456,o),
+(189,494,cs),
+(189,542,o),
+(213,601,o),
+(291,601,cs),
+(337,601,l),
+(355,690,l),
+(302,690,ls),
+(159,690,o),
+(95,589,o),
+(95,481,cs),
+(95,394,o),
+(151,345,o),
+(240,345,cs)
+);
+}
+);
+width = 304;
+}
+);
+note = uni1466;
+unicode = 5222;
+},
+{
+glyphname = "tte-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+pos = (619,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 800;
+}
+);
+note = uni1467;
+unicode = 5223;
+},
+{
+glyphname = "tti-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+pos = (619,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 800;
+}
+);
+note = uni1468;
+unicode = 5224;
+},
+{
+glyphname = "tto-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+pos = (522,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 702;
+}
+);
+note = uni1469;
+unicode = 5225;
+},
+{
+glyphname = "tta-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+pos = (522,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 702;
+}
+);
+note = uni146A;
+unicode = 5226;
+},
+{
+glyphname = "ke-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (298,441);
+},
+{
+name = top_center_can;
+pos = (345,690);
+},
+{
+name = top_left_can;
+pos = (203,690);
+},
+{
+name = top_right_can;
+pos = (484,692);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(411,0,l),
+(499,421,ls),
+(529,559,o),
+(493,703,o),
+(328,703,cs),
+(145,703,o),
+(75,515,o),
+(75,375,cs),
+(75,258,o),
+(133,186,o),
+(230,186,cs),
+(277,186,o),
+(317,210,o),
+(343,258,c),
+(325,266,l),
+(269,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(234,307,o),
+(213,332,o),
+(213,382,cs),
+(213,434,o),
+(239,583,o),
+(315,583,cs),
+(353,583,o),
+(373,558,o),
+(373,508,cs),
+(373,457,o),
+(348,307,o),
+(271,307,cs)
+);
+}
+);
+width = 511;
+}
+);
+metricRight = "te-canadian";
+note = uni146B;
+unicode = 5227;
+},
+{
+glyphname = "kaai-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (143,0);
+ref = ring_top.canadian;
+}
+);
+width = 511;
+}
+);
+note = uni146C;
+unicode = 5228;
+},
+{
+glyphname = "ki-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (307,441);
+},
+{
+name = top_center_can;
+pos = (355,690);
+},
+{
+name = top_left_can;
+pos = (214,690);
+},
+{
+name = top_right_can;
+pos = (498,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(139,0,l),
+(199,284,l),
+(181,261,l),
+(181,219,o),
+(225,186,o),
+(287,186,cs),
+(452,186,o),
+(521,382,o),
+(521,507,cs),
+(521,631,o),
+(452,703,o),
+(337,703,cs),
+(213,703,o),
+(128,620,o),
+(96,466,cs),
+(-4,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(244,307,o),
+(224,332,o),
+(224,382,cs),
+(224,433,o),
+(253,583,o),
+(327,583,cs),
+(363,583,o),
+(384,558,o),
+(384,509,cs),
+(384,457,o),
+(358,307,o),
+(282,307,cs)
+);
+}
+);
+width = 511;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni146D;
+unicode = 5229;
+},
+{
+glyphname = "kii-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (176,0);
+ref = dot_top;
+}
+);
+width = 511;
+}
+);
+note = uni146E;
+unicode = 5230;
+},
+{
+glyphname = "ko-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (267,298);
+},
+{
+name = top_center_can;
+pos = (346,690);
+},
+{
+name = top_double;
+pos = (487,690);
+},
+{
+name = top_left_can;
+pos = (203,690);
+},
+{
+name = top_right_can;
+pos = (487,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(342,-14,o),
+(425,70,o),
+(458,224,cs),
+(557,690,l),
+(414,690,l),
+(354,406,l),
+(373,429,l),
+(373,470,o),
+(328,503,o),
+(267,503,cs),
+(101,503,o),
+(33,307,o),
+(33,183,cs),
+(33,59,o),
+(101,-14,o),
+(217,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(190,106,o),
+(170,130,o),
+(170,181,cs),
+(170,232,o),
+(199,382,o),
+(271,382,cs),
+(308,382,o),
+(329,357,o),
+(329,308,cs),
+(329,255,o),
+(304,106,o),
+(228,106,cs)
+);
+}
+);
+width = 510;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni146F;
+unicode = 5231;
+},
+{
+glyphname = "koo-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (308,0);
+ref = dot_top;
+}
+);
+width = 511;
+}
+);
+note = uni1470;
+unicode = 5232;
+},
+{
+glyphname = "ycreekoo-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (136,0);
+ref = doubledot_top;
+}
+);
+width = 511;
+}
+);
+note = uni1471;
+unicode = 5233;
+},
+{
+glyphname = "ka-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (277,302);
+},
+{
+name = top_center_can;
+pos = (355,690);
+},
+{
+name = top_left_can;
+pos = (214,690);
+},
+{
+name = top_right_can;
+pos = (497,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(409,-14,o),
+(478,175,o),
+(478,315,cs),
+(478,432,o),
+(420,503,o),
+(324,503,cs),
+(277,503,o),
+(238,480,o),
+(212,432,c),
+(229,424,l),
+(286,690,l),
+(143,690,l),
+(54,270,ls),
+(16,95,o),
+(87,-14,o),
+(227,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(202,106,o),
+(182,131,o),
+(182,182,cs),
+(182,233,o),
+(206,383,o),
+(283,383,cs),
+(320,383,o),
+(340,357,o),
+(340,308,cs),
+(340,257,o),
+(316,106,o),
+(239,106,cs)
+);
+}
+);
+width = 510;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "==|ke-canadian";
+note = uni1472;
+unicode = 5234;
+},
+{
+glyphname = "kaa-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+}
+);
+width = 511;
+}
+);
+note = uni1473;
+unicode = 5235;
+},
+{
+glyphname = "kwe-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ke-canadian";
+}
+);
+width = 715;
+}
+);
+note = uni1474;
+unicode = 5236;
+},
+{
+glyphname = "kweWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (511,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 715;
+}
+);
+note = uni1475;
+unicode = 5237;
+},
+{
+glyphname = "kwi-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ki-canadian";
+}
+);
+width = 715;
+}
+);
+note = uni1476;
+unicode = 5238;
+},
+{
+glyphname = "kwiWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (511,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 715;
+}
+);
+note = uni1477;
+unicode = 5239;
+},
+{
+glyphname = "kwii-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (380,0);
+ref = dot_top;
+}
+);
+width = 715;
+}
+);
+note = uni1478;
+unicode = 5240;
+},
+{
+glyphname = "kwiiWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (176,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (511,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 715;
+}
+);
+note = uni1479;
+unicode = 5241;
+},
+{
+glyphname = "kwo-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ko-canadian";
+}
+);
+width = 715;
+}
+);
+note = uni147A;
+unicode = 5242;
+},
+{
+glyphname = "kwoWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (511,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 715;
+}
+);
+note = uni147B;
+unicode = 5243;
+},
+{
+glyphname = "kwoo-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (512,0);
+ref = dot_top;
+}
+);
+width = 715;
+}
+);
+note = uni147C;
+unicode = 5244;
+},
+{
+glyphname = "kwooWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (308,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (511,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 715;
+}
+);
+note = uni147D;
+unicode = 5245;
+},
+{
+glyphname = "kwa-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ka-canadian";
+}
+);
+width = 715;
+}
+);
+note = uni147E;
+unicode = 5246;
+},
+{
+glyphname = "kwaWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (511,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 715;
+}
+);
+note = uni147F;
+unicode = 5247;
+},
+{
+glyphname = "kwaa-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (239,0);
+ref = dot_top;
+}
+);
+width = 715;
+}
+);
+note = uni1480;
+unicode = 5248;
+},
+{
+glyphname = "kwaaWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (511,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 715;
+}
+);
+note = uni1481;
+unicode = 5249;
+},
+{
+glyphname = "kwaaNaskapi-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (207,0);
+ref = "ka-canadian";
+}
+);
+width = 719;
+}
+);
+note = uni1482;
+unicode = 5250;
+},
+{
+glyphname = "k-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(297,339,o),
+(334,441,o),
+(334,506,cs),
+(334,564,o),
+(303,601,o),
+(253,601,cs),
+(217,601,o),
+(191,581,o),
+(178,549,c),
+(203,550,l),
+(233,690,l),
+(138,690,l),
+(94,484,ls),
+(79,415,o),
+(99,339,o),
+(195,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(185,409,o),
+(176,420,o),
+(176,442,cs),
+(176,469,o),
+(191,532,o),
+(223,532,cs),
+(240,532,o),
+(248,520,o),
+(248,498,cs),
+(248,470,o),
+(233,409,o),
+(201,409,cs)
+);
+}
+);
+width = 317;
+}
+);
+note = uni1483;
+unicode = 5251;
+},
+{
+glyphname = "kw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(255,338,o),
+(301,381,o),
+(321,470,cs),
+(366,690,l),
+(272,690,l),
+(241,543,l),
+(260,544,l),
+(263,576,o),
+(237,601,o),
+(199,601,cs),
+(117,601,o),
+(80,505,o),
+(80,444,cs),
+(80,380,o),
+(119,338,o),
+(185,338,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(172,408,o),
+(162,420,o),
+(162,441,cs),
+(162,469,o),
+(178,531,o),
+(210,531,cs),
+(226,531,o),
+(236,520,o),
+(236,497,cs),
+(236,471,o),
+(220,408,o),
+(188,408,cs)
+);
+}
+);
+width = 316;
+}
+);
+metricLeft = "=|k-canadian";
+metricRight = "=|k-canadian";
+note = uni1484;
+unicode = 5252;
+},
+{
+glyphname = "southslaveykeh-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+pos = (511,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 693;
+}
+);
+note = uni1485;
+unicode = 5253;
+},
+{
+glyphname = "southslaveykih-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+pos = (511,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 693;
+}
+);
+note = uni1486;
+unicode = 5254;
+},
+{
+glyphname = "southslaveykoh-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+pos = (511,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 693;
+}
+);
+note = uni1487;
+unicode = 5255;
+},
+{
+glyphname = "southslaveykah-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+pos = (511,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 693;
+}
+);
+note = uni1488;
+unicode = 5256;
+},
+{
+glyphname = "ce-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (276,371);
+},
+{
+name = top_center_can;
+pos = (342,690);
+},
+{
+name = top_left_can;
+pos = (202,690);
+},
+{
+name = top_right_can;
+pos = (478,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(402,0,l),
+(498,453,ls),
+(531,609,o),
+(461,703,o),
+(324,703,cs),
+(193,703,o),
+(118,629,o),
+(84,472,cs),
+(65,382,l),
+(206,382,l),
+(228,487,ls),
+(242,552,o),
+(268,580,o),
+(307,580,cs),
+(355,580,o),
+(376,546,o),
+(362,481,cs),
+(260,0,l)
+);
+}
+);
+width = 502;
+}
+);
+metricRight = "te-canadian";
+note = uni1489;
+unicode = 5257;
+},
+{
+glyphname = "caai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (143,0);
+ref = ring_top.canadian;
+}
+);
+width = 503;
+}
+);
+note = uni148A;
+unicode = 5258;
+},
+{
+glyphname = "ci-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (288,371);
+},
+{
+name = top_center_can;
+pos = (355,690);
+},
+{
+name = top_left_can;
+pos = (214,690);
+},
+{
+name = top_right_can;
+pos = (494,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(139,0,l),
+(242,487,ls),
+(256,552,o),
+(280,580,o),
+(322,580,cs),
+(370,580,o),
+(389,546,o),
+(376,481,cs),
+(355,382,l),
+(496,382,l),
+(511,453,ls),
+(544,609,o),
+(473,703,o),
+(336,703,cs),
+(206,703,o),
+(130,629,o),
+(97,472,cs),
+(-4,0,l)
+);
+}
+);
+width = 503;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+unicode = 5259;
+},
+{
+glyphname = "cii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:56:57 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (176,0);
+ref = dot_top;
+}
+);
+width = 503;
+}
+);
+note = uni148C;
+unicode = 5260;
+},
+{
+glyphname = "co-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (277,371);
+},
+{
+name = top_center_can;
+pos = (341,690);
+},
+{
+name = top_double;
+pos = (478,690);
+},
+{
+name = top_left_can;
+pos = (202,690);
+},
+{
+name = top_right_can;
+pos = (478,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(340,-14,o),
+(415,61,o),
+(448,217,cs),
+(549,690,l),
+(407,690,l),
+(303,203,ls),
+(290,138,o),
+(265,110,o),
+(224,110,cs),
+(176,110,o),
+(156,144,o),
+(169,209,cs),
+(190,308,l),
+(49,308,l),
+(35,237,ls),
+(1,81,o),
+(72,-14,o),
+(209,-14,cs)
+);
+}
+);
+width = 502;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+unicode = 5261;
+},
+{
+glyphname = "coo-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (299,0);
+ref = dot_top;
+}
+);
+width = 503;
+}
+);
+note = uni148E;
+unicode = 5262;
+},
+{
+glyphname = "ycreecoo-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (128,0);
+ref = doubledot_top;
+}
+);
+width = 503;
+}
+);
+note = uni148F;
+unicode = 5263;
+},
+{
+glyphname = "ca-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (289,371);
+},
+{
+name = top_center_can;
+pos = (355,690);
+},
+{
+name = top_left_can;
+pos = (215,690);
+},
+{
+name = top_right_can;
+pos = (492,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(353,-14,o),
+(427,61,o),
+(461,217,cs),
+(480,308,l),
+(339,308,l),
+(317,203,ls),
+(303,138,o),
+(278,110,o),
+(238,110,cs),
+(190,110,o),
+(170,144,o),
+(184,209,cs),
+(286,690,l),
+(143,690,l),
+(47,237,ls),
+(14,81,o),
+(85,-14,o),
+(221,-14,cs)
+);
+}
+);
+width = 503;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+unicode = 5264;
+},
+{
+glyphname = "caa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+}
+);
+width = 503;
+}
+);
+note = uni1491;
+unicode = 5265;
+},
+{
+glyphname = "cwe-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ce-canadian";
+}
+);
+width = 707;
+}
+);
+note = uni1492;
+unicode = 5266;
+},
+{
+glyphname = "cweWestCree-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (503,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 707;
+}
+);
+note = uni1493;
+unicode = 5267;
+},
+{
+glyphname = "cwi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:56:57 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+pos = (204,0);
+ref = "ci-canadian";
+}
+);
+width = 707;
+}
+);
+note = uni1494;
+unicode = 5268;
+},
+{
+glyphname = "cwiWestCree-canadian";
+lastChange = "2023-01-13 15:56:57 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "ci-canadian";
+},
+{
+anchor = middle_right_can;
+pos = (503,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 707;
+}
+);
+note = uni1495;
+unicode = 5269;
+},
+{
+glyphname = "cwii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:56:57 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+pos = (204,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (380,0);
+ref = dot_top;
+}
+);
+width = 707;
+}
+);
+note = uni1496;
+unicode = 5270;
+},
+{
+glyphname = "cwiiWestCree-canadian";
+lastChange = "2023-01-13 15:56:57 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (176,0);
+ref = dot_top;
+},
+{
+anchor = middle_right_can;
+pos = (503,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 707;
+}
+);
+note = uni1497;
+unicode = 5271;
+},
+{
+glyphname = "cwo-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "co-canadian";
+}
+);
+width = 707;
+}
+);
+note = uni1498;
+unicode = 5272;
+},
+{
+glyphname = "cwoWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (503,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 707;
+}
+);
+note = uni1499;
+unicode = 5273;
+},
+{
+glyphname = "cwoo-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (503,0);
+ref = dot_top;
+}
+);
+width = 707;
+}
+);
+note = uni149A;
+unicode = 5274;
+},
+{
+glyphname = "cwooWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (299,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (503,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 707;
+}
+);
+note = uni149B;
+unicode = 5275;
+},
+{
+glyphname = "cwa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ca-canadian";
+}
+);
+width = 707;
+}
+);
+note = uni149C;
+unicode = 5276;
+},
+{
+glyphname = "cwaWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (503,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 707;
+}
+);
+note = uni149D;
+unicode = 5277;
+},
+{
+glyphname = "cwaa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (240,0);
+ref = dot_top;
+}
+);
+width = 707;
+}
+);
+note = uni149E;
+unicode = 5278;
+},
+{
+glyphname = "cwaaWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (503,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 707;
+}
+);
+note = uni149F;
+unicode = 5279;
+},
+{
+glyphname = "cwaaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (207,0);
+ref = "ca-canadian";
+}
+);
+width = 710;
+}
+);
+note = uni14A0;
+unicode = 5280;
+},
+{
+glyphname = "c-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(268,339,o),
+(314,381,o),
+(329,458,cs),
+(336,490,l),
+(249,490,l),
+(241,449,ls),
+(236,426,o),
+(223,412,o),
+(205,412,cs),
+(185,412,o),
+(177,429,o),
+(182,453,cs),
+(233,690,l),
+(138,690,l),
+(94,479,ls),
+(75,394,o),
+(114,339,o),
+(199,339,cs)
+);
+}
+);
+width = 308;
+}
+);
+note = uni14A1;
+unicode = 5281;
+},
+{
+glyphname = "thSayisi-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(249,339,o),
+(294,381,o),
+(311,458,cs),
+(360,690,l),
+(266,690,l),
+(215,451,ls),
+(210,424,o),
+(196,412,o),
+(179,412,cs),
+(157,412,o),
+(151,429,o),
+(156,453,cs),
+(164,490,l),
+(77,490,l),
+(72,470,ls),
+(57,394,o),
+(95,339,o),
+(178,339,cs)
+);
+}
+);
+width = 309;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "=|c-canadian";
+note = uni14A2;
+unicode = 5282;
+},
+{
+glyphname = "me-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (176,345);
+},
+{
+name = top_center_can;
+pos = (323,690);
+},
+{
+name = top_left_can;
+pos = (196,690);
+},
+{
+name = top_right_can;
+pos = (441,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(366,0,l),
+(513,690,l),
+(126,690,l),
+(98,560,l),
+(342,560,l),
+(223,0,l)
+);
+}
+);
+width = 469;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+unicode = 5283;
+},
+{
+glyphname = "maai-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (128,0);
+ref = ring_top.canadian;
+}
+);
+width = 469;
+}
+);
+note = uni14A4;
+unicode = 5284;
+},
+{
+glyphname = "mi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (338,345);
+},
+{
+name = top_center_can;
+pos = (340,690);
+},
+{
+name = top_left_can;
+pos = (217,690);
+},
+{
+name = top_right_can;
+pos = (463,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(141,0,l),
+(261,560,l),
+(505,560,l),
+(533,690,l),
+(146,690,l),
+(-1,0,l)
+);
+}
+);
+width = 469;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+unicode = 5285;
+},
+{
+glyphname = "mii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (161,0);
+ref = dot_top;
+}
+);
+width = 469;
+}
+);
+note = uni14A6;
+unicode = 5286;
+},
+{
+glyphname = "mo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (175,345);
+},
+{
+name = top_center_can;
+pos = (323,690);
+},
+{
+name = top_double;
+pos = (441,690);
+},
+{
+name = top_left_can;
+pos = (196,690);
+},
+{
+name = top_right_can;
+pos = (441,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(366,0,l),
+(513,690,l),
+(370,690,l),
+(251,129,l),
+(6,129,l),
+(-21,0,l)
+);
+}
+);
+width = 469;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+unicode = 5287;
+},
+{
+glyphname = "moo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (263,0);
+ref = dot_top;
+}
+);
+width = 469;
+}
+);
+note = uni14A8;
+unicode = 5288;
+},
+{
+glyphname = "ycreemoo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (92,0);
+ref = doubledot_top;
+}
+);
+width = 469;
+}
+);
+note = uni14A9;
+unicode = 5289;
+},
+{
+glyphname = "ma-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (338,345);
+},
+{
+name = top_center_can;
+pos = (340,690);
+},
+{
+name = top_left_can;
+pos = (217,690);
+},
+{
+name = top_right_can;
+pos = (462,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(386,0,l),
+(413,129,l),
+(169,129,l),
+(288,690,l),
+(146,690,l),
+(-1,0,l)
+);
+}
+);
+width = 469;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+unicode = 5290;
+},
+{
+glyphname = "maa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (39,0);
+ref = dot_top;
+}
+);
+width = 469;
+}
+);
+note = uni14AB;
+unicode = 5291;
+},
+{
+glyphname = "mwe-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "me-canadian";
+}
+);
+width = 673;
+}
+);
+note = uni14AC;
+unicode = 5292;
+},
+{
+glyphname = "mweWestCree-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "me-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (469,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 673;
+}
+);
+note = uni14AD;
+unicode = 5293;
+},
+{
+glyphname = "mwi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "mi-canadian";
+}
+);
+width = 673;
+}
+);
+note = uni14AE;
+unicode = 5294;
+},
+{
+glyphname = "mwiWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (469,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 673;
+}
+);
+note = uni14AF;
+unicode = 5295;
+},
+{
+glyphname = "mwii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (365,0);
+ref = dot_top;
+}
+);
+width = 673;
+}
+);
+note = uni14B0;
+unicode = 5296;
+},
+{
+glyphname = "mwiiWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (161,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (469,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 673;
+}
+);
+note = uni14B1;
+unicode = 5297;
+},
+{
+glyphname = "mwo-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "mo-canadian";
+}
+);
+width = 673;
+}
+);
+note = uni14B2;
+unicode = 5298;
+},
+{
+glyphname = "mwoWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (469,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 673;
+}
+);
+note = uni14B3;
+unicode = 5299;
+},
+{
+glyphname = "mwoo-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (467,0);
+ref = dot_top;
+}
+);
+width = 673;
+}
+);
+note = uni14B4;
+unicode = 5300;
+},
+{
+glyphname = "mwooWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (263,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (469,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 673;
+}
+);
+note = uni14B5;
+unicode = 5301;
+},
+{
+glyphname = "mwa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ma-canadian";
+}
+);
+width = 673;
+}
+);
+note = uni14B6;
+unicode = 5302;
+},
+{
+glyphname = "mwaWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (469,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 673;
+}
+);
+note = uni14B7;
+unicode = 5303;
+},
+{
+glyphname = "mwaa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (242,0);
+ref = dot_top;
+}
+);
+width = 673;
+}
+);
+note = uni14B8;
+unicode = 5304;
+},
+{
+glyphname = "mwaaWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (39,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (469,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 673;
+}
+);
+note = uni14B9;
+unicode = 5305;
+},
+{
+glyphname = "mwaaNaskapi-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (207,0);
+ref = "ma-canadian";
+}
+);
+width = 676;
+}
+);
+note = uni14BA;
+unicode = 5306;
+},
+{
+glyphname = "m-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(277,345,l),
+(297,434,l),
+(178,434,l),
+(233,690,l),
+(138,690,l),
+(65,345,l)
+);
+}
+);
+width = 284;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni14BB;
+unicode = 5307;
+},
+{
+glyphname = "mWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "t-canadian";
+}
+);
+width = 304;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "t-canadian";
+note = uni14BC;
+unicode = 5308;
+},
+{
+glyphname = "mh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(262,345,l),
+(335,690,l),
+(241,690,l),
+(186,434,l),
+(68,434,l),
+(48,345,l)
+);
+}
+);
+width = 284;
+}
+);
+metricLeft = "=|m-canadian";
+metricRight = "=|m-canadian";
+note = uni14BD;
+unicode = 5309;
+},
+{
+glyphname = "mAthapascan-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(285,345,l),
+(301,424,l),
+(174,424,l),
+(170,384,l),
+(269,483,ls),
+(304,518,o),
+(332,558,o),
+(332,606,cs),
+(332,659,o),
+(296,696,o),
+(234,696,cs),
+(164,696,o),
+(120,656,o),
+(103,570,c),
+(186,570,l),
+(194,611,o),
+(208,629,o),
+(226,629,cs),
+(242,629,o),
+(250,619,o),
+(250,603,cs),
+(250,572,o),
+(223,538,o),
+(193,509,cs),
+(78,395,l),
+(68,345,l)
+);
+}
+);
+width = 298;
+}
+);
+note = uni14BE;
+unicode = 5310;
+},
+{
+glyphname = "mSayisi-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = two.canadian;
+}
+);
+width = 504;
+}
+);
+note = uni14BF;
+unicode = 5311;
+},
+{
+glyphname = "ne-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (430,245);
+},
+{
+name = top_center_can;
+pos = (470,508);
+},
+{
+name = top_left_can;
+pos = (164,508);
+},
+{
+name = top_right_can;
+pos = (632,508);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(576,-14,o),
+(648,169,o),
+(648,290,cs),
+(648,411,o),
+(575,489,o),
+(451,489,cs),
+(89,489,l),
+(62,361,l),
+(303,361,l),
+(302,410,l),
+(235,360,o),
+(211,254,o),
+(211,183,cs),
+(211,61,o),
+(284,-14,o),
+(402,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(369,106,o),
+(348,134,o),
+(348,185,cs),
+(348,237,o),
+(373,369,o),
+(449,369,cs),
+(489,369,o),
+(510,341,o),
+(510,291,cs),
+(510,239,o),
+(485,106,o),
+(409,106,cs)
+);
+}
+);
+width = 683;
+}
+);
+metricRight = "=|ke-canadian";
+note = uni14C0;
+unicode = 5312;
+},
+{
+glyphname = "naai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (116,-182);
+ref = ring_top.canadian;
+}
+);
+width = 684;
+}
+);
+note = uni14C1;
+unicode = 5313;
+},
+{
+glyphname = "ni-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (252,245);
+},
+{
+name = top_center_can;
+pos = (327,508);
+},
+{
+name = top_left_can;
+pos = (162,508);
+},
+{
+name = top_right_can;
+pos = (631,508);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(398,-14,o),
+(469,169,o),
+(469,292,cs),
+(469,330,o),
+(461,359,o),
+(443,382,c),
+(429,361,l),
+(670,361,l),
+(698,489,l),
+(288,489,ls),
+(103,489,o),
+(32,307,o),
+(32,185,cs),
+(32,61,o),
+(106,-14,o),
+(223,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(191,106,o),
+(169,134,o),
+(169,185,cs),
+(169,237,o),
+(195,369,o),
+(271,369,cs),
+(311,369,o),
+(332,341,o),
+(332,291,cs),
+(332,239,o),
+(307,106,o),
+(231,106,cs)
+);
+}
+);
+width = 683;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+unicode = 5314;
+},
+{
+glyphname = "nii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (149,-182);
+ref = dot_top;
+}
+);
+width = 684;
+}
+);
+note = uni14C3;
+unicode = 5315;
+},
+{
+glyphname = "no-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (429,245);
+},
+{
+name = top_center_can;
+pos = (485,508);
+},
+{
+name = top_double;
+pos = (487,508);
+},
+{
+name = top_left_can;
+pos = (164,508);
+},
+{
+name = top_right_can;
+pos = (633,508);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(395,0,ls),
+(580,0,o),
+(651,183,o),
+(651,303,cs),
+(651,429,o),
+(577,503,o),
+(459,503,cs),
+(285,503,o),
+(213,321,o),
+(213,197,cs),
+(213,159,o),
+(222,129,o),
+(240,107,c),
+(254,128,l),
+(12,128,l),
+(-15,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(372,121,o),
+(351,149,o),
+(351,198,cs),
+(351,250,o),
+(376,383,o),
+(452,383,cs),
+(492,383,o),
+(513,355,o),
+(513,305,cs),
+(513,253,o),
+(487,121,o),
+(412,121,cs)
+);
+}
+);
+width = 683;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14C4;
+unicode = 5316;
+},
+{
+glyphname = "noo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (306,-182);
+ref = dot_top;
+}
+);
+width = 684;
+}
+);
+note = uni14C5;
+unicode = 5317;
+},
+{
+glyphname = "ycreenoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (137,-182);
+ref = doubledot_top;
+}
+);
+width = 684;
+}
+);
+note = uni14C6;
+unicode = 5318;
+},
+{
+glyphname = "na-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (254,245);
+},
+{
+name = top_center_can;
+pos = (309,508);
+},
+{
+name = top_double;
+pos = (465,508);
+},
+{
+name = top_left_can;
+pos = (162,508);
+},
+{
+name = top_right_can;
+pos = (631,508);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(593,0,l),
+(620,128,l),
+(380,128,l),
+(381,79,l),
+(448,128,o),
+(472,235,o),
+(472,306,cs),
+(472,428,o),
+(399,503,o),
+(281,503,cs),
+(107,503,o),
+(35,321,o),
+(35,199,cs),
+(35,78,o),
+(108,0,o),
+(232,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(194,121,o),
+(172,149,o),
+(172,198,cs),
+(172,250,o),
+(198,383,o),
+(274,383,cs),
+(314,383,o),
+(335,355,o),
+(335,305,cs),
+(335,253,o),
+(310,121,o),
+(234,121,cs)
+);
+}
+);
+width = 682;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+unicode = 5319;
+},
+{
+glyphname = "naa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (130,-182);
+ref = dot_top;
+}
+);
+width = 684;
+}
+);
+note = uni14C8;
+unicode = 5320;
+},
+{
+glyphname = "nwe-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ne-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni14C9;
+unicode = 5321;
+},
+{
+glyphname = "nweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (684,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni14CA;
+unicode = 5322;
+},
+{
+glyphname = "nwa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "na-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni14CB;
+unicode = 5323;
+},
+{
+glyphname = "nwaWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (684,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni14CC;
+unicode = 5324;
+},
+{
+glyphname = "nwaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (334,-182);
+ref = dot_top;
+}
+);
+width = 888;
+}
+);
+note = uni14CD;
+unicode = 5325;
+},
+{
+glyphname = "nwaaWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (130,-182);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (684,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni14CE;
+unicode = 5326;
+},
+{
+glyphname = "nwaaNaskapi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (115,-182);
+ref = doubledot_top;
+}
+);
+width = 684;
+}
+);
+note = uni14CF;
+unicode = 5327;
+},
+{
+glyphname = "n-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(405,434,l),
+(424,524,l),
+(292,524,l),
+(288,472,l),
+(322,496,o),
+(340,552,o),
+(340,591,cs),
+(340,655,o),
+(300,696,o),
+(236,696,cs),
+(148,696,o),
+(101,614,o),
+(101,541,cs),
+(101,476,o),
+(142,434,o),
+(209,434,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(193,502,o),
+(184,516,o),
+(184,539,cs),
+(184,568,o),
+(197,627,o),
+(231,627,cs),
+(248,627,o),
+(258,614,o),
+(258,590,cs),
+(258,561,o),
+(244,502,o),
+(210,502,cs)
+);
+}
+);
+width = 392;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni14D0;
+unicode = 5328;
+},
+{
+color = 6;
+glyphname = "ngCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-161);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 361;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "=|";
+note = uni14D1;
+unicode = 5329;
+},
+{
+glyphname = "nh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(287,434,ls),
+(381,434,o),
+(427,513,o),
+(427,591,cs),
+(427,654,o),
+(385,696,o),
+(323,696,cs),
+(234,696,o),
+(187,614,o),
+(187,541,cs),
+(187,521,o),
+(192,501,o),
+(204,487,c),
+(217,524,l),
+(86,524,l),
+(67,434,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(279,502,o),
+(269,516,o),
+(269,539,cs),
+(269,568,o),
+(284,627,o),
+(317,627,cs),
+(335,627,o),
+(345,614,o),
+(345,590,cs),
+(345,561,o),
+(330,502,o),
+(297,502,cs)
+);
+}
+);
+width = 392;
+}
+);
+metricLeft = "=|n-canadian";
+metricRight = "=|n-canadian";
+note = uni14D2;
+unicode = 5330;
+},
+{
+glyphname = "le-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (429,245);
+},
+{
+name = top_center_can;
+pos = (472,508);
+},
+{
+name = top_left_can;
+pos = (164,508);
+},
+{
+name = top_right_can;
+pos = (632,508);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(341,0,ls),
+(536,0,o),
+(646,116,o),
+(646,283,cs),
+(646,409,o),
+(564,489,o),
+(429,489,cs),
+(89,489,l),
+(62,360,l),
+(402,360,ls),
+(469,360,o),
+(505,327,o),
+(505,270,cs),
+(505,202,o),
+(467,125,o),
+(361,125,cs),
+(339,125,l),
+(312,0,l)
+);
+}
+);
+width = 683;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D3;
+unicode = 5331;
+},
+{
+glyphname = "laai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (118,-182);
+ref = ring_top.canadian;
+}
+);
+width = 684;
+}
+);
+note = uni14D4;
+unicode = 5332;
+},
+{
+glyphname = "li-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (256,245);
+},
+{
+name = top_center_can;
+pos = (329,508);
+},
+{
+name = top_left_can;
+pos = (165,508);
+},
+{
+name = top_right_can;
+pos = (632,508);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(269,0,l),
+(295,125,l),
+(271,125,ls),
+(214,125,o),
+(180,159,o),
+(180,216,cs),
+(180,282,o),
+(217,360,o),
+(323,360,cs),
+(671,360,l),
+(698,489,l),
+(334,489,ls),
+(147,489,o),
+(38,374,o),
+(38,213,cs),
+(38,89,o),
+(119,0,o),
+(242,0,cs)
+);
+}
+);
+width = 683;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14D5;
+unicode = 5333;
+},
+{
+glyphname = "lii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (151,-182);
+ref = dot_top;
+}
+);
+width = 684;
+}
+);
+note = uni14D6;
+unicode = 5334;
+},
+{
+glyphname = "lo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (428,245);
+},
+{
+name = top_center_can;
+pos = (484,508);
+},
+{
+name = top_double;
+pos = (456,508);
+},
+{
+name = top_left_can;
+pos = (164,508);
+},
+{
+name = top_right_can;
+pos = (632,508);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(350,0,ls),
+(536,0,o),
+(645,115,o),
+(645,277,cs),
+(645,400,o),
+(565,489,o),
+(441,489,cs),
+(415,489,l),
+(389,364,l),
+(412,364,ls),
+(469,364,o),
+(504,329,o),
+(504,272,cs),
+(504,207,o),
+(467,128,o),
+(361,128,cs),
+(13,128,l),
+(-15,0,l)
+);
+}
+);
+width = 683;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D7;
+unicode = 5335;
+},
+{
+glyphname = "loo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (305,-182);
+ref = dot_top;
+}
+);
+width = 684;
+}
+);
+note = uni14D8;
+unicode = 5336;
+},
+{
+glyphname = "ycreeloo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (105,-182);
+ref = doubledot_top;
+}
+);
+width = 684;
+}
+);
+note = uni14D9;
+unicode = 5337;
+},
+{
+glyphname = "la-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (255,245);
+},
+{
+name = top_center_can;
+pos = (310,508);
+},
+{
+name = top_left_can;
+pos = (163,508);
+},
+{
+name = top_right_can;
+pos = (631,508);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(593,0,l),
+(620,128,l),
+(281,128,ls),
+(213,128,o),
+(178,161,o),
+(178,218,cs),
+(178,288,o),
+(216,364,o),
+(322,364,cs),
+(344,364,l),
+(370,489,l),
+(341,489,ls),
+(147,489,o),
+(37,374,o),
+(37,206,cs),
+(37,81,o),
+(118,0,o),
+(254,0,cs)
+);
+}
+);
+width = 682;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14DA;
+unicode = 5338;
+},
+{
+glyphname = "laa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (131,-182);
+ref = dot_top;
+}
+);
+width = 684;
+}
+);
+note = uni14DB;
+unicode = 5339;
+},
+{
+glyphname = "lwe-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "le-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni14DC;
+unicode = 5340;
+},
+{
+glyphname = "lweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "le-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (684,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni14DD;
+unicode = 5341;
+},
+{
+glyphname = "lwi-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "li-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni14DE;
+unicode = 5342;
+},
+{
+glyphname = "lwiWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (684,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni14DF;
+unicode = 5343;
+},
+{
+glyphname = "lwii-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (355,-182);
+ref = dot_top;
+}
+);
+width = 888;
+}
+);
+note = uni14E0;
+unicode = 5344;
+},
+{
+glyphname = "lwiiWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (151,-182);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (684,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni14E1;
+unicode = 5345;
+},
+{
+glyphname = "lwo-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "lo-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni14E2;
+unicode = 5346;
+},
+{
+glyphname = "lwoWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (684,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni14E3;
+unicode = 5347;
+},
+{
+glyphname = "lwoo-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (509,-182);
+ref = dot_top;
+}
+);
+width = 888;
+}
+);
+note = uni14E4;
+unicode = 5348;
+},
+{
+glyphname = "lwooWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (305,-182);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (684,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni14E5;
+unicode = 5349;
+},
+{
+glyphname = "lwa-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "la-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni14E6;
+unicode = 5350;
+},
+{
+glyphname = "lwaWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (684,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni14E7;
+unicode = 5351;
+},
+{
+glyphname = "lwaa-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (335,-182);
+ref = dot_top;
+}
+);
+width = 888;
+}
+);
+note = uni14E8;
+unicode = 5352;
+},
+{
+glyphname = "lwaaWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (131,-182);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (684,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni14E9;
+unicode = 5353;
+},
+{
+glyphname = "l-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(372,345,l),
+(391,434,l),
+(254,434,ls),
+(213,434,o),
+(189,456,o),
+(189,495,cs),
+(189,542,o),
+(213,602,o),
+(287,602,cs),
+(296,602,l),
+(315,690,l),
+(300,690,ls),
+(157,690,o),
+(95,588,o),
+(95,482,cs),
+(95,394,o),
+(152,345,o),
+(247,345,cs)
+);
+}
+);
+width = 378;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "m-canadian";
+note = uni14EA;
+unicode = 5354;
+},
+{
+glyphname = "lWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(267,345,l),
+(279,403,l),
+(160,469,l),
+(149,419,l),
+(298,491,l),
+(307,533,l),
+(186,597,l),
+(177,553,l),
+(326,619,l),
+(340,690,l),
+(326,690,l),
+(119,598,l),
+(112,567,l),
+(236,499,l),
+(243,534,l),
+(91,467,l),
+(84,436,l),
+(252,345,l)
+);
+}
+);
+width = 289;
+}
+);
+metricRight = "=|";
+note = uni14EB;
+unicode = 5355;
+},
+{
+glyphname = "mediall-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(414,-14,l),
+(435,83,l),
+(173,227,l),
+(157,156,l),
+(483,306,l),
+(495,364,l),
+(231,500,l),
+(216,441,l),
+(542,586,l),
+(566,703,l),
+(533,703,l),
+(104,513,l),
+(93,462,l),
+(357,318,l),
+(368,369,l),
+(44,228,l),
+(33,177,l),
+(381,-14,l)
+);
+}
+);
+width = 517;
+}
+);
+metricRight = "=|";
+note = uni14EC;
+unicode = 5356;
+},
+{
+glyphname = "se-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (217,690);
+},
+{
+name = top_right_can;
+pos = (443,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(368,0,l),
+(444,359,l),
+(414,359,ls),
+(284,359,o),
+(229,412,o),
+(261,560,cs),
+(288,690,l),
+(146,690,l),
+(119,563,ls),
+(73,354,o),
+(173,232,o),
+(380,232,cs),
+(395,232,l),
+(284,275,l),
+(225,0,l)
+);
+}
+);
+width = 472;
+}
+);
+note = uni14ED;
+unicode = 5357;
+},
+{
+glyphname = "saai-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (233,0);
+ref = ring_top.canadian;
+}
+);
+width = 472;
+}
+);
+note = uni14EE;
+unicode = 5358;
+},
+{
+glyphname = "si-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (218,690);
+},
+{
+name = top_right_can;
+pos = (445,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(143,0,l),
+(202,277,l),
+(83,232,l),
+(118,232,ls),
+(325,232,o),
+(438,324,o),
+(486,549,cs),
+(516,690,l),
+(373,690,l),
+(345,558,ls),
+(317,428,o),
+(247,359,o),
+(124,359,cs),
+(76,359,l),
+(0,0,l)
+);
+}
+);
+width = 472;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+unicode = 5359;
+},
+{
+glyphname = "sii-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (266,0);
+ref = dot_top;
+}
+);
+width = 472;
+}
+);
+note = uni14F0;
+unicode = 5360;
+},
+{
+glyphname = "so-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (444,690);
+},
+{
+name = top_left_can;
+pos = (217,690);
+},
+{
+name = top_right_can;
+pos = (443,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,0,l),
+(170,131,ls),
+(198,262,o),
+(269,330,o),
+(391,330,cs),
+(439,330,l),
+(515,690,l),
+(372,690,l),
+(314,412,l),
+(432,458,l),
+(397,458,ls),
+(190,458,o),
+(77,366,o),
+(29,141,cs),
+(-1,0,l)
+);
+}
+);
+width = 473;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+unicode = 5361;
+},
+{
+glyphname = "soo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (265,0);
+ref = dot_top;
+}
+);
+width = 472;
+}
+);
+note = uni14F2;
+unicode = 5362;
+},
+{
+glyphname = "ycreesoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (94,0);
+ref = doubledot_top;
+}
+);
+width = 472;
+}
+);
+note = uni14F3;
+unicode = 5363;
+},
+{
+glyphname = "sa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (218,690);
+},
+{
+name = top_right_can;
+pos = (444,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(369,0,l),
+(396,127,ls),
+(440,336,o),
+(342,458,o),
+(134,458,cs),
+(120,458,l),
+(230,414,l),
+(289,690,l),
+(147,690,l),
+(71,330,l),
+(99,330,ls),
+(230,330,o),
+(285,277,o),
+(253,129,cs),
+(226,0,l)
+);
+}
+);
+width = 472;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+unicode = 5364;
+},
+{
+glyphname = "saa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (40,0);
+ref = dot_top;
+}
+);
+width = 472;
+}
+);
+note = uni14F5;
+unicode = 5365;
+},
+{
+glyphname = "swe-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "se-canadian";
+}
+);
+width = 675;
+}
+);
+note = uni14F6;
+unicode = 5366;
+},
+{
+glyphname = "sweWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "se-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (472,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 675;
+}
+);
+note = uni14F7;
+unicode = 5367;
+},
+{
+glyphname = "swi-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "si-canadian";
+}
+);
+width = 675;
+}
+);
+note = uni14F8;
+unicode = 5368;
+},
+{
+glyphname = "swiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (472,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 675;
+}
+);
+note = uni14F9;
+unicode = 5369;
+},
+{
+glyphname = "swii-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (469,0);
+ref = dot_top;
+}
+);
+width = 675;
+}
+);
+note = uni14FA;
+unicode = 5370;
+},
+{
+glyphname = "swiiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (266,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (472,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 675;
+}
+);
+note = uni14FB;
+unicode = 5371;
+},
+{
+glyphname = "swo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "so-canadian";
+}
+);
+width = 675;
+}
+);
+note = uni14FC;
+unicode = 5372;
+},
+{
+glyphname = "swoWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (472,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 675;
+}
+);
+note = uni14FD;
+unicode = 5373;
+},
+{
+glyphname = "swoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (469,0);
+ref = dot_top;
+}
+);
+width = 675;
+}
+);
+note = uni14FE;
+unicode = 5374;
+},
+{
+glyphname = "swooWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (265,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (472,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 675;
+}
+);
+note = uni14FF;
+unicode = 5375;
+},
+{
+glyphname = "swa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "sa-canadian";
+}
+);
+width = 675;
+}
+);
+note = uni1500;
+unicode = 5376;
+},
+{
+glyphname = "swaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (472,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 675;
+}
+);
+note = uni1501;
+unicode = 5377;
+},
+{
+glyphname = "swaa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (243,0);
+ref = dot_top;
+}
+);
+width = 675;
+}
+);
+note = uni1502;
+unicode = 5378;
+},
+{
+glyphname = "swaaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (40,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (472,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 675;
+}
+);
+note = uni1503;
+unicode = 5379;
+},
+{
+glyphname = "swaaNaskapi-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (207,0);
+ref = "sa-canadian";
+}
+);
+width = 679;
+}
+);
+note = uni1504;
+unicode = 5380;
+},
+{
+glyphname = "s-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(280,345,l),
+(295,414,ls),
+(316,518,o),
+(270,584,o),
+(171,584,cs),
+(147,584,l),
+(202,549,l),
+(233,690,l),
+(138,690,l),
+(99,511,l),
+(135,511,ls),
+(195,511,o),
+(214,480,o),
+(200,413,cs),
+(185,345,l)
+);
+}
+);
+width = 301;
+}
+);
+metricRight = "=|";
+note = uni1505;
+unicode = 5381;
+},
+{
+color = 6;
+glyphname = "sAthapascan-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(248,177,o),
+(297,223,o),
+(297,288,cs),
+(297,332,o),
+(274,362,o),
+(235,378,cs),
+(197,392,ls),
+(180,399,o),
+(170,411,o),
+(170,426,cs),
+(170,450,o),
+(185,465,o),
+(210,465,cs),
+(234,465,o),
+(245,450,o),
+(240,418,c),
+(325,418,l),
+(337,494,o),
+(286,533,o),
+(215,533,cs),
+(131,533,o),
+(85,487,o),
+(85,417,cs),
+(85,379,o),
+(107,346,o),
+(145,331,cs),
+(183,317,ls),
+(202,309,o),
+(211,298,o),
+(211,282,cs),
+(211,260,o),
+(196,245,o),
+(172,245,cs),
+(145,245,o),
+(130,258,o),
+(138,293,c),
+(53,293,l),
+(41,218,o),
+(88,177,o),
+(168,177,cs)
+);
+}
+);
+width = 333;
+}
+);
+metricRight = "=|";
+note = uni1506;
+unicode = 5382;
+},
+{
+glyphname = "sw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(157,345,l),
+(172,412,ls),
+(186,482,o),
+(219,511,o),
+(285,511,cs),
+(313,511,l),
+(352,690,l),
+(257,690,l),
+(227,550,l),
+(298,584,l),
+(262,584,ls),
+(163,584,o),
+(101,528,o),
+(79,419,cs),
+(64,345,l)
+);
+}
+);
+width = 299;
+}
+);
+metricLeft = "=|s-canadian";
+metricRight = "=|s-canadian";
+note = uni1507;
+unicode = 5383;
+},
+{
+glyphname = "sBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(286,345,l),
+(305,434,l),
+(233,434,ls),
+(197,434,o),
+(182,453,o),
+(190,491,cs),
+(233,690,l),
+(138,690,l),
+(99,500,ls),
+(78,406,o),
+(125,345,o),
+(220,345,cs)
+);
+}
+);
+width = 292;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "m-canadian";
+note = uni1508;
+unicode = 5384;
+},
+{
+glyphname = "moosecreesk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(283,217,o),
+(315,348,o),
+(315,434,cs),
+(315,529,o),
+(267,585,o),
+(176,585,cs),
+(163,585,l),
+(203,551,l),
+(233,690,l),
+(138,690,l),
+(100,512,l),
+(138,512,ls),
+(212,512,o),
+(230,491,o),
+(229,429,c),
+(247,425,l),
+(243,448,o),
+(224,476,o),
+(183,476,cs),
+(97,476,o),
+(65,380,o),
+(65,325,cs),
+(65,260,o),
+(104,217,o),
+(171,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(156,285,o),
+(148,298,o),
+(148,320,cs),
+(148,348,o),
+(163,412,o),
+(196,412,cs),
+(213,412,o),
+(223,399,o),
+(223,377,cs),
+(223,350,o),
+(207,285,o),
+(175,285,cs)
+);
+}
+);
+width = 326;
+}
+);
+metricRight = "=|";
+note = uni1509;
+unicode = 5385;
+},
+{
+glyphname = "skwNaskapi-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(264,217,o),
+(307,306,o),
+(307,380,cs),
+(307,438,o),
+(276,476,o),
+(227,476,cs),
+(193,476,o),
+(166,458,o),
+(157,429,c),
+(177,431,l),
+(199,491,o),
+(228,512,o),
+(302,512,cs),
+(339,512,l),
+(376,690,l),
+(282,690,l),
+(252,549,l),
+(312,585,l),
+(294,585,ls),
+(123,585,o),
+(68,429,o),
+(68,329,cs),
+(68,263,o),
+(104,217,o),
+(173,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(157,285,o),
+(149,298,o),
+(149,320,cs),
+(149,348,o),
+(164,412,o),
+(197,412,cs),
+(214,412,o),
+(224,399,o),
+(224,377,cs),
+(224,350,o),
+(208,285,o),
+(176,285,cs)
+);
+}
+);
+width = 326;
+}
+);
+metricLeft = "=|moosecreesk-canadian";
+metricRight = "=|moosecreesk-canadian";
+note = uni150A;
+unicode = 5386;
+},
+{
+glyphname = "swNaskapi-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(264,188,l),
+(274,239,ls),
+(297,344,o),
+(244,411,o),
+(151,411,cs),
+(128,411,l),
+(174,376,l),
+(201,501,l),
+(106,501,l),
+(72,337,l),
+(109,337,ls),
+(167,337,o),
+(195,311,o),
+(181,242,cs),
+(169,188,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(231,14,o),
+(261,43,o),
+(261,82,cs),
+(261,120,o),
+(231,150,o),
+(193,150,cs),
+(157,150,o),
+(127,120,o),
+(127,82,cs),
+(127,43,o),
+(157,14,o),
+(193,14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(214,540,o),
+(244,571,o),
+(244,608,cs),
+(244,646,o),
+(214,676,o),
+(177,676,cs),
+(140,676,o),
+(110,646,o),
+(110,608,cs),
+(110,571,o),
+(140,540,o),
+(177,540,cs)
+);
+}
+);
+width = 328;
+}
+);
+metricRight = "=|";
+note = uni150B;
+unicode = 5387;
+},
+{
+glyphname = "spwaNaskapi-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(467,0,l),
+(493,122,l),
+(200,363,l),
+(188,300,l),
+(582,541,l),
+(612,690,l),
+(580,690,l),
+(52,367,l),
+(43,323,l),
+(433,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(214,505,o),
+(244,536,o),
+(244,573,cs),
+(244,611,o),
+(213,641,o),
+(177,641,cs),
+(141,641,o),
+(110,611,o),
+(110,573,cs),
+(110,535,o),
+(141,505,o),
+(177,505,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(394,614,l),
+(406,668,ls),
+(422,744,o),
+(387,793,o),
+(314,793,cs),
+(284,793,l),
+(346,763,l),
+(368,866,l),
+(277,866,l),
+(247,725,l),
+(268,725,ls),
+(308,725,o),
+(323,703,o),
+(313,658,cs),
+(303,614,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(561,713,o),
+(592,744,o),
+(592,781,cs),
+(592,818,o),
+(561,849,o),
+(525,849,cs),
+(488,849,o),
+(458,818,o),
+(458,781,cs),
+(458,744,o),
+(488,713,o),
+(525,713,cs)
+);
+}
+);
+width = 553;
+}
+);
+metricRight = "pa-canadian";
+metricWidth = "pa-canadian";
+note = uni150C;
+unicode = 5388;
+},
+{
+glyphname = "stwaNaskapi-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (328,0);
+ref = "ta-canadian";
+}
+);
+width = 850;
+}
+);
+note = uni150D;
+unicode = 5389;
+},
+{
+glyphname = "skwaNaskapi-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (328,0);
+ref = "ka-canadian";
+}
+);
+width = 839;
+}
+);
+note = uni150E;
+unicode = 5390;
+},
+{
+glyphname = "scwaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (328,0);
+ref = "ca-canadian";
+}
+);
+width = 832;
+}
+);
+note = uni150F;
+unicode = 5391;
+},
+{
+glyphname = "she-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (340,690);
+},
+{
+name = top_right_can;
+pos = (703,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(602,-14,o),
+(674,68,o),
+(706,218,cs),
+(725,308,l),
+(584,308,l),
+(562,203,ls),
+(549,137,o),
+(526,110,o),
+(489,110,cs),
+(445,110,o),
+(431,143,o),
+(441,208,cs),
+(485,452,ls),
+(513,616,o),
+(447,703,o),
+(316,703,cs),
+(190,703,o),
+(117,622,o),
+(85,471,cs),
+(66,382,l),
+(207,382,l),
+(229,487,ls),
+(243,553,o),
+(265,580,o),
+(303,580,cs),
+(346,580,o),
+(360,547,o),
+(350,482,cs),
+(306,238,ls),
+(278,73,o),
+(345,-14,o),
+(476,-14,cs)
+);
+}
+);
+width = 749;
+}
+);
+metricRight = "=|";
+note = uni1510;
+unicode = 5392;
+},
+{
+glyphname = "shi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (235,690);
+},
+{
+name = top_right_can;
+pos = (598,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(325,-14,o),
+(394,54,o),
+(436,223,cs),
+(499,482,ls),
+(517,554,o),
+(537,580,o),
+(576,580,cs),
+(618,580,o),
+(635,547,o),
+(620,480,cs),
+(600,382,l),
+(741,382,l),
+(754,444,ls),
+(787,598,o),
+(723,703,o),
+(584,703,cs),
+(466,703,o),
+(398,636,o),
+(356,467,cs),
+(292,207,ls),
+(273,135,o),
+(253,110,o),
+(214,110,cs),
+(173,110,o),
+(156,143,o),
+(171,210,cs),
+(191,308,l),
+(50,308,l),
+(37,245,ls),
+(4,91,o),
+(69,-14,o),
+(207,-14,cs)
+);
+}
+);
+width = 749;
+}
+);
+metricLeft = "she-canadian";
+metricRight = "she-canadian";
+note = uni1511;
+unicode = 5393;
+},
+{
+glyphname = "shii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (419,0);
+ref = dot_top;
+}
+);
+width = 749;
+}
+);
+note = uni1512;
+unicode = 5394;
+},
+{
+glyphname = "sho-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (440,508);
+},
+{
+name = top_left_can;
+pos = (302,508);
+},
+{
+name = top_right_can;
+pos = (578,508);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(285,108,l),
+(212,111,o),
+(166,140,o),
+(166,185,cs),
+(166,225,o),
+(191,255,o),
+(237,255,cs),
+(331,255,o),
+(386,107,o),
+(542,107,cs),
+(667,107,o),
+(740,197,o),
+(740,309,cs),
+(740,422,o),
+(648,499,o),
+(509,503,c),
+(484,381,l),
+(557,378,o),
+(604,349,o),
+(604,303,cs),
+(604,264,o),
+(578,234,o),
+(532,234,cs),
+(438,234,o),
+(383,383,o),
+(227,383,cs),
+(97,383,o),
+(29,287,o),
+(29,181,cs),
+(29,68,o),
+(122,-10,o),
+(259,-14,c)
+);
+}
+);
+width = 769;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1513;
+unicode = 5395;
+},
+{
+glyphname = "shoo-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (262,-182);
+ref = dot_top;
+}
+);
+width = 769;
+}
+);
+note = uni1514;
+unicode = 5396;
+},
+{
+glyphname = "sha-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (441,508);
+},
+{
+name = top_left_can;
+pos = (303,508);
+},
+{
+name = top_right_can;
+pos = (579,508);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(584,-18,o),
+(721,63,o),
+(721,220,cs),
+(721,315,o),
+(658,383,o),
+(555,383,cs),
+(414,383,o),
+(319,234,o),
+(241,234,cs),
+(209,234,o),
+(190,253,o),
+(190,283,cs),
+(190,352,o),
+(256,381,o),
+(333,381,c),
+(360,503,l),
+(185,507,o),
+(48,426,o),
+(48,269,cs),
+(48,174,o),
+(112,107,o),
+(214,107,cs),
+(355,107,o),
+(451,255,o),
+(528,255,cs),
+(560,255,o),
+(580,237,o),
+(580,207,cs),
+(580,138,o),
+(514,108,o),
+(436,108,c),
+(410,-14,l)
+);
+}
+);
+width = 769;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1515;
+unicode = 5397;
+},
+{
+glyphname = "shaa-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (263,-182);
+ref = dot_top;
+}
+);
+width = 769;
+}
+);
+note = uni1516;
+unicode = 5398;
+},
+{
+glyphname = "shwe-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "she-canadian";
+}
+);
+width = 952;
+}
+);
+note = uni1517;
+unicode = 5399;
+},
+{
+glyphname = "shweWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "she-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (749,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 952;
+}
+);
+note = uni1518;
+unicode = 5400;
+},
+{
+glyphname = "shwi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "shi-canadian";
+}
+);
+width = 952;
+}
+);
+note = uni1519;
+unicode = 5401;
+},
+{
+glyphname = "shwiWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (749,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 952;
+}
+);
+note = uni151A;
+unicode = 5402;
+},
+{
+glyphname = "shwii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (622,0);
+ref = dot_top;
+}
+);
+width = 952;
+}
+);
+note = uni151B;
+unicode = 5403;
+},
+{
+glyphname = "shwiiWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (419,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (749,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 952;
+}
+);
+note = uni151C;
+unicode = 5404;
+},
+{
+glyphname = "shwo-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "sho-canadian";
+}
+);
+width = 973;
+}
+);
+note = uni151D;
+unicode = 5405;
+},
+{
+glyphname = "shwoWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (769,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 973;
+}
+);
+note = uni151E;
+unicode = 5406;
+},
+{
+glyphname = "shwoo-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (466,-182);
+ref = dot_top;
+}
+);
+width = 973;
+}
+);
+note = uni151F;
+unicode = 5407;
+},
+{
+glyphname = "shwooWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (262,-182);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (769,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 973;
+}
+);
+note = uni1520;
+unicode = 5408;
+},
+{
+glyphname = "shwa-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "sha-canadian";
+}
+);
+width = 973;
+}
+);
+note = uni1521;
+unicode = 5409;
+},
+{
+glyphname = "shwaWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (769,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 973;
+}
+);
+note = uni1522;
+unicode = 5410;
+},
+{
+glyphname = "shwaa-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (466,-182);
+ref = dot_top;
+}
+);
+width = 973;
+}
+);
+note = uni1523;
+unicode = 5411;
+},
+{
+glyphname = "shwaaWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (263,-182);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (769,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 973;
+}
+);
+note = uni1524;
+unicode = 5412;
+},
+{
+glyphname = "sh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(492,280,o),
+(596,341,o),
+(596,464,cs),
+(596,535,o),
+(546,587,o),
+(466,587,cs),
+(372,587,o),
+(302,491,o),
+(242,491,cs),
+(215,491,o),
+(200,506,o),
+(200,530,cs),
+(200,581,o),
+(247,614,o),
+(325,611,c),
+(344,698,l),
+(208,704,o),
+(102,643,o),
+(102,522,cs),
+(102,449,o),
+(153,397,o),
+(233,397,cs),
+(327,397,o),
+(396,494,o),
+(456,494,cs),
+(483,494,o),
+(498,478,o),
+(498,454,cs),
+(498,405,o),
+(452,369,o),
+(375,373,c),
+(355,285,l)
+);
+}
+);
+width = 593;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni1525;
+unicode = 5413;
+},
+{
+glyphname = "ye-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (581,345);
+},
+{
+name = top_left_can;
+pos = (191,690);
+},
+{
+name = top_right_can;
+pos = (466,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(390,0,l),
+(464,345,l),
+(230,345,l),
+(238,300,l),
+(532,615,l),
+(436,701,l),
+(29,258,l),
+(21,221,l),
+(295,221,l),
+(248,0,l)
+);
+}
+);
+width = 493;
+}
+);
+note = uni1526;
+unicode = 5414;
+},
+{
+glyphname = "yaai-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (6,0);
+ref = ring_top.canadian;
+}
+);
+width = 493;
+}
+);
+note = uni1527;
+unicode = 5415;
+},
+{
+glyphname = "yi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (218,690);
+},
+{
+name = top_right_can;
+pos = (493,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,0,l),
+(188,221,l),
+(462,221,l),
+(470,258,l),
+(227,701,l),
+(114,638,l),
+(300,305,l),
+(307,345,l),
+(72,345,l),
+(-1,0,l)
+);
+}
+);
+width = 493;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni1528;
+unicode = 5416;
+},
+{
+glyphname = "yii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (39,0);
+ref = dot_top;
+}
+);
+width = 493;
+}
+);
+note = uni1529;
+unicode = 5417;
+},
+{
+glyphname = "yo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (581,345);
+},
+{
+name = top_double;
+pos = (466,690);
+},
+{
+name = top_left_can;
+pos = (191,690);
+},
+{
+name = top_right_can;
+pos = (466,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(422,52,l),
+(236,384,l),
+(229,345,l),
+(464,345,l),
+(536,690,l),
+(394,690,l),
+(347,469,l),
+(74,469,l),
+(66,432,l),
+(309,-12,l)
+);
+}
+);
+width = 493;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152A;
+unicode = 5418;
+},
+{
+glyphname = "yoo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (287,0);
+ref = dot_top;
+}
+);
+width = 493;
+}
+);
+note = uni152B;
+unicode = 5419;
+},
+{
+glyphname = "ycreeyoo-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (116,0);
+ref = doubledot_top;
+}
+);
+width = 493;
+}
+);
+note = uni152C;
+unicode = 5420;
+},
+{
+glyphname = "ya-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (217,690);
+},
+{
+name = top_right_can;
+pos = (491,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(507,432,l),
+(515,469,l),
+(242,469,l),
+(288,690,l),
+(146,690,l),
+(72,345,l),
+(306,345,l),
+(299,389,l),
+(5,74,l),
+(100,-12,l)
+);
+}
+);
+width = 493;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152D;
+unicode = 5421;
+},
+{
+glyphname = "yaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (38,0);
+ref = dot_top;
+}
+);
+width = 493;
+}
+);
+note = uni152E;
+unicode = 5422;
+},
+{
+glyphname = "ywe-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ye-canadian";
+}
+);
+width = 696;
+}
+);
+note = uni152F;
+unicode = 5423;
+},
+{
+glyphname = "yweWestCree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ye-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (493,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 696;
+}
+);
+note = uni1530;
+unicode = 5424;
+},
+{
+glyphname = "ywi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "yi-canadian";
+}
+);
+width = 696;
+}
+);
+note = uni1531;
+unicode = 5425;
+},
+{
+glyphname = "ywiWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (493,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 696;
+}
+);
+note = uni1532;
+unicode = 5426;
+},
+{
+glyphname = "ywii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (242,0);
+ref = dot_top;
+}
+);
+width = 696;
+}
+);
+note = uni1533;
+unicode = 5427;
+},
+{
+glyphname = "ywiiWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (39,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (493,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 696;
+}
+);
+note = uni1534;
+unicode = 5428;
+},
+{
+glyphname = "ywo-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "yo-canadian";
+}
+);
+width = 696;
+}
+);
+note = uni1535;
+unicode = 5429;
+},
+{
+glyphname = "ywoWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (493,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 696;
+}
+);
+note = uni1536;
+unicode = 5430;
+},
+{
+glyphname = "ywoo-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (491,0);
+ref = dot_top;
+}
+);
+width = 696;
+}
+);
+note = uni1537;
+unicode = 5431;
+},
+{
+glyphname = "ywooWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (287,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (493,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 696;
+}
+);
+note = uni1538;
+unicode = 5432;
+},
+{
+glyphname = "ywa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ya-canadian";
+}
+);
+width = 696;
+}
+);
+note = uni1539;
+unicode = 5433;
+},
+{
+glyphname = "ywaWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (493,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 696;
+}
+);
+note = uni153A;
+unicode = 5434;
+},
+{
+glyphname = "ywaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (242,0);
+ref = dot_top;
+}
+);
+width = 696;
+}
+);
+note = uni153B;
+unicode = 5435;
+},
+{
+glyphname = "ywaaWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (38,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (493,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 696;
+}
+);
+note = uni153C;
+unicode = 5436;
+},
+{
+glyphname = "ywaaNaskapi-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (207,0);
+ref = "ya-canadian";
+}
+);
+width = 699;
+}
+);
+note = uni153D;
+unicode = 5437;
+},
+{
+glyphname = "y-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(336,554,l),
+(342,580,l),
+(213,580,l),
+(237,690,l),
+(143,690,l),
+(102,501,l),
+(225,501,l),
+(226,557,l),
+(75,391,l),
+(139,336,l)
+);
+}
+);
+width = 292;
+}
+);
+note = uni153E;
+unicode = 5438;
+},
+{
+glyphname = "biblecreey-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(145,345,l),
+(244,592,l),
+(193,592,l),
+(220,345,l),
+(276,345,l),
+(410,592,l),
+(355,592,l),
+(352,345,l),
+(436,345,l),
+(440,367,l),
+(442,690,l),
+(374,690,l),
+(232,425,l),
+(290,425,l),
+(264,690,l),
+(195,690,l),
+(60,367,l),
+(55,345,l)
+);
+}
+);
+width = 449;
+}
+);
+metricRight = "=|";
+note = uni153F;
+unicode = 5439;
+},
+{
+glyphname = "yWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(219,207,l),
+(242,311,l),
+(336,311,l),
+(355,401,l),
+(261,401,l),
+(283,503,l),
+(193,503,l),
+(172,401,l),
+(77,401,l),
+(58,311,l),
+(153,311,l),
+(130,207,l)
+);
+}
+);
+width = 366;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1540;
+unicode = 5440;
+},
+{
+glyphname = "yiSayisi-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (39,183);
+ref = "fullstop-canadian";
+}
+);
+width = 326;
+}
+);
+metricLeft = "fullstop-canadian";
+metricWidth = "fullstop-canadian";
+note = uni1541;
+unicode = 5441;
+},
+{
+glyphname = "re-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (318,508);
+},
+{
+name = top_left_can;
+pos = (176,508);
+},
+{
+name = top_right_can;
+pos = (668,508);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(357,-14,o),
+(433,57,o),
+(466,209,cs),
+(497,361,l),
+(707,361,l),
+(734,489,l),
+(386,489,l),
+(326,202,ls),
+(312,137,o),
+(286,110,o),
+(242,110,cs),
+(191,110,o),
+(170,144,o),
+(185,212,cs),
+(243,489,l),
+(101,489,l),
+(47,234,ls),
+(14,84,o),
+(88,-14,o),
+(235,-14,cs)
+);
+}
+);
+width = 719;
+}
+);
+metricRight = "=|ne-canadian";
+note = uni1542;
+unicode = 5442;
+},
+{
+glyphname = "reRCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (512,508);
+},
+{
+name = top_left_can;
+pos = (163,508);
+},
+{
+name = top_right_can;
+pos = (655,508);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(554,-14,o),
+(630,57,o),
+(662,209,cs),
+(722,489,l),
+(580,489,l),
+(519,202,ls),
+(504,137,o),
+(478,110,o),
+(435,110,cs),
+(384,110,o),
+(363,144,o),
+(378,212,cs),
+(437,489,l),
+(89,489,l),
+(62,361,l),
+(270,361,l),
+(243,234,ls),
+(212,84,o),
+(285,-14,o),
+(431,-14,cs)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1543;
+unicode = 5443;
+},
+{
+glyphname = "leWestCree-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (513,508);
+},
+{
+name = top_left_can;
+pos = (163,508);
+},
+{
+name = top_right_can;
+pos = (655,508);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(332,0,l),
+(394,287,ls),
+(408,352,o),
+(434,379,o),
+(477,379,cs),
+(527,379,o),
+(549,346,o),
+(534,278,cs),
+(475,0,l),
+(618,0,l),
+(672,255,ls),
+(704,406,o),
+(631,503,o),
+(485,503,cs),
+(362,503,o),
+(286,432,o),
+(254,280,cs),
+(221,128,l),
+(12,128,l),
+(-15,0,l)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+unicode = 5444;
+},
+{
+glyphname = "raai-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (106,-182);
+ref = ring_top.canadian;
+}
+);
+width = 719;
+}
+);
+note = uni1545;
+unicode = 5445;
+},
+{
+glyphname = "ri-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (319,508);
+},
+{
+name = top_left_can;
+pos = (177,508);
+},
+{
+name = top_right_can;
+pos = (668,508);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(140,0,l),
+(201,287,ls),
+(214,352,o),
+(241,379,o),
+(285,379,cs),
+(334,379,o),
+(355,345,o),
+(342,278,cs),
+(282,0,l),
+(630,0,l),
+(657,128,l),
+(448,128,l),
+(475,255,ls),
+(508,405,o),
+(435,503,o),
+(295,503,cs),
+(165,503,o),
+(90,432,o),
+(57,280,cs),
+(-3,0,l)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "re-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+unicode = 5446;
+},
+{
+glyphname = "rii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (139,-182);
+ref = dot_top;
+}
+);
+width = 719;
+}
+);
+note = uni1547;
+unicode = 5447;
+},
+{
+glyphname = "ro-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (304,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,0,l),
+(202,284,l),
+(134,221,l),
+(210,221,ls),
+(416,221,o),
+(484,364,o),
+(484,494,cs),
+(484,613,o),
+(405,690,o),
+(274,690,cs),
+(146,690,l),
+(119,563,l),
+(248,563,ls),
+(310,563,o),
+(342,533,o),
+(342,479,cs),
+(342,403,o),
+(301,346,o),
+(204,346,cs),
+(73,346,l),
+(0,0,l)
+);
+}
+);
+width = 473;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1548;
+unicode = 5448;
+},
+{
+glyphname = "roo-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (126,0);
+ref = dot_top;
+}
+);
+width = 473;
+}
+);
+note = uni1549;
+unicode = 5449;
+},
+{
+glyphname = "loWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (304,690);
+},
+{
+name = top_left_can;
+pos = (217,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(163,0,ls),
+(369,0,o),
+(438,143,o),
+(438,272,cs),
+(438,392,o),
+(358,469,o),
+(227,469,cs),
+(179,469,l),
+(228,405,l),
+(288,690,l),
+(146,690,l),
+(72,345,l),
+(203,345,ls),
+(265,345,o),
+(297,315,o),
+(297,262,cs),
+(297,185,o),
+(255,128,o),
+(157,128,cs),
+(26,128,l),
+(-1,0,l)
+);
+}
+);
+width = 474;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+unicode = 5450;
+},
+{
+glyphname = "ra-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (357,690);
+},
+{
+name = top_right_can;
+pos = (444,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(370,0,l),
+(442,345,l),
+(314,345,ls),
+(252,345,o),
+(219,375,o),
+(219,428,cs),
+(219,505,o),
+(262,562,o),
+(358,562,cs),
+(489,562,l),
+(516,690,l),
+(353,690,ls),
+(147,690,o),
+(79,547,o),
+(79,417,cs),
+(79,298,o),
+(157,221,o),
+(289,221,cs),
+(337,221,l),
+(288,285,l),
+(227,0,l)
+);
+}
+);
+width = 473;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+unicode = 5451;
+},
+{
+glyphname = "raa-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (179,0);
+ref = dot_top;
+}
+);
+width = 473;
+}
+);
+note = uni154C;
+unicode = 5452;
+},
+{
+glyphname = "laWestCree-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (445,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(370,0,l),
+(397,127,l),
+(268,127,ls),
+(206,127,o),
+(174,156,o),
+(174,211,cs),
+(174,287,o),
+(214,344,o),
+(312,344,cs),
+(443,344,l),
+(517,690,l),
+(374,690,l),
+(314,406,l),
+(382,469,l),
+(306,469,ls),
+(100,469,o),
+(32,326,o),
+(32,196,cs),
+(32,76,o),
+(111,0,o),
+(242,0,cs)
+);
+}
+);
+width = 473;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+unicode = 5453;
+},
+{
+glyphname = "rwaa-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (383,0);
+ref = dot_top;
+}
+);
+width = 677;
+}
+);
+note = uni154E;
+unicode = 5454;
+},
+{
+glyphname = "rwaaWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (179,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (473,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 677;
+}
+);
+note = uni154F;
+unicode = 5455;
+},
+{
+glyphname = "r-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(256,345,l),
+(295,526,l),
+(236,526,ls),
+(208,526,o),
+(194,539,o),
+(194,560,cs),
+(194,592,o),
+(213,613,o),
+(253,613,cs),
+(313,613,l),
+(329,690,l),
+(268,690,ls),
+(170,690,o),
+(104,644,o),
+(104,555,cs),
+(104,496,o),
+(147,452,o),
+(216,452,cs),
+(239,452,l),
+(189,474,l),
+(161,345,l)
+);
+}
+);
+width = 278;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni1550;
+unicode = 5456;
+},
+{
+glyphname = "rWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(138,690,l),
+(127,632,l),
+(245,566,l),
+(256,615,l),
+(107,544,l),
+(99,501,l),
+(218,438,l),
+(228,482,l),
+(80,415,l),
+(65,345,l),
+(80,345,l),
+(286,437,l),
+(293,468,l),
+(169,535,l),
+(161,500,l),
+(314,568,l),
+(321,599,l),
+(154,690,l)
+);
+}
+);
+width = 289;
+}
+);
+metricLeft = "=|lWestCree-canadian";
+metricRight = "=|lWestCree-canadian";
+note = uni1551;
+unicode = 5457;
+},
+{
+glyphname = "rMedial-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(27,-14,l),
+(455,177,l),
+(467,228,l),
+(203,372,l),
+(192,321,l),
+(516,462,l),
+(527,513,l),
+(179,703,l),
+(146,703,l),
+(125,607,l),
+(387,463,l),
+(402,533,l),
+(77,384,l),
+(65,326,l),
+(328,189,l),
+(344,248,l),
+(18,103,l),
+(-7,-14,l)
+);
+}
+);
+width = 518;
+}
+);
+metricLeft = "mediall-canadian";
+metricRight = "mediall-canadian";
+note = uni1552;
+unicode = 5458;
+},
+{
+glyphname = "fe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(290,0,l),
+(737,655,l),
+(745,690,l),
+(626,690,l),
+(280,163,l),
+(306,163,l),
+(259,351,l),
+(179,352,l),
+(196,331,o),
+(222,320,o),
+(257,320,cs),
+(378,320,o),
+(440,461,o),
+(440,556,cs),
+(440,644,o),
+(391,703,o),
+(304,703,cs),
+(176,703,o),
+(120,567,o),
+(120,463,cs),
+(120,428,o),
+(126,394,o),
+(139,355,cs),
+(249,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(240,409,o),
+(227,428,o),
+(227,462,cs),
+(227,501,o),
+(247,604,o),
+(297,604,cs),
+(320,604,o),
+(332,584,o),
+(332,552,cs),
+(332,511,o),
+(313,409,o),
+(264,409,cs)
+);
+}
+);
+width = 668;
+}
+);
+metricRight = "e-canadian";
+note = uni1553;
+unicode = 5459;
+},
+{
+glyphname = "faai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (199,0);
+ref = ring_top.canadian;
+}
+);
+width = 668;
+}
+);
+note = uni1554;
+unicode = 5460;
+},
+{
+glyphname = "fi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (412,690);
+},
+{
+name = top_left_can;
+pos = (215,690);
+},
+{
+name = top_right_can;
+pos = (623,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(321,-14,o),
+(370,124,o),
+(370,217,cs),
+(370,311,o),
+(320,374,o),
+(250,374,cs),
+(226,374,o),
+(197,362,o),
+(172,342,c),
+(265,342,l),
+(398,526,l),
+(365,526,l),
+(499,0,l),
+(599,0,l),
+(606,35,l),
+(432,690,l),
+(390,690,l),
+(134,351,ls),
+(83,282,o),
+(50,213,o),
+(50,134,cs),
+(50,46,o),
+(100,-14,o),
+(186,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(170,86,o),
+(157,105,o),
+(157,139,cs),
+(157,179,o),
+(178,281,o),
+(227,281,cs),
+(250,281,o),
+(263,262,o),
+(263,228,cs),
+(263,186,o),
+(243,86,o),
+(194,86,cs)
+);
+}
+);
+width = 669;
+}
+);
+metricLeft = "fe-canadian";
+metricRight = "e-canadian";
+note = uni1555;
+unicode = 5461;
+},
+{
+glyphname = "fii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (232,0);
+ref = dot_top;
+}
+);
+width = 668;
+}
+);
+note = uni1556;
+unicode = 5462;
+},
+{
+glyphname = "fo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (289,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(46,0,l),
+(562,323,l),
+(572,367,l),
+(393,631,ls),
+(361,679,o),
+(327,703,o),
+(273,703,cs),
+(172,703,o),
+(107,607,o),
+(93,502,cs),
+(75,389,o),
+(128,311,o),
+(218,311,cs),
+(313,311,o),
+(380,405,o),
+(393,506,cs),
+(397,535,o),
+(399,565,o),
+(397,589,c),
+(339,514,l),
+(453,348,l),
+(465,391,l),
+(41,126,l),
+(13,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(205,410,o),
+(194,440,o),
+(202,497,cs),
+(209,550,o),
+(227,607,o),
+(267,607,cs),
+(295,607,o),
+(305,576,o),
+(298,520,cs),
+(291,467,o),
+(272,410,o),
+(233,410,cs)
+);
+}
+);
+width = 572;
+}
+);
+metricRight = "o-canadian";
+note = uni1557;
+unicode = 5463;
+},
+{
+glyphname = "foo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "fo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (109,0);
+ref = dot_top;
+}
+);
+width = 572;
+}
+);
+note = uni1558;
+unicode = 5464;
+},
+{
+glyphname = "fa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (474,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(455,0,l),
+(477,107,l),
+(178,362,l),
+(172,335,l),
+(351,504,l),
+(326,613,l),
+(299,567,o),
+(281,504,o),
+(281,456,cs),
+(281,368,o),
+(332,308,o),
+(418,308,cs),
+(537,308,o),
+(595,454,o),
+(595,551,cs),
+(595,643,o),
+(545,703,o),
+(463,703,cs),
+(416,703,o),
+(376,685,o),
+(335,643,cs),
+(52,367,l),
+(43,323,l),
+(421,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(396,408,o),
+(384,427,o),
+(384,460,cs),
+(384,500,o),
+(404,603,o),
+(453,603,cs),
+(476,603,o),
+(489,584,o),
+(489,552,cs),
+(489,511,o),
+(469,408,o),
+(419,408,cs)
+);
+}
+);
+width = 573;
+}
+);
+metricRight = "=|fo-canadian";
+note = uni1559;
+unicode = 5465;
+},
+{
+glyphname = "faa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (296,0);
+ref = dot_top;
+}
+);
+width = 572;
+}
+);
+note = uni155A;
+unicode = 5466;
+},
+{
+glyphname = "fwaa-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (499,0);
+ref = dot_top;
+}
+);
+width = 776;
+}
+);
+note = uni155B;
+unicode = 5467;
+},
+{
+glyphname = "fwaaWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (296,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (572,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 776;
+}
+);
+note = uni155C;
+unicode = 5468;
+},
+{
+glyphname = "f-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(297,345,l),
+(308,406,l),
+(160,531,l),
+(158,512,l),
+(245,599,l),
+(236,651,l),
+(223,630,o),
+(211,593,o),
+(211,568,cs),
+(211,526,o),
+(237,497,o),
+(276,497,cs),
+(332,497,o),
+(366,560,o),
+(366,623,cs),
+(366,668,o),
+(343,696,o),
+(303,696,cs),
+(279,696,o),
+(258,686,o),
+(235,664,cs),
+(94,526,l),
+(90,504,l),
+(280,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(267,547,o),
+(261,555,o),
+(261,571,cs),
+(261,592,o),
+(272,645,o),
+(296,645,cs),
+(307,645,o),
+(313,637,o),
+(313,620,cs),
+(313,600,o),
+(302,547,o),
+(278,547,cs)
+);
+}
+);
+width = 327;
+}
+);
+note = uni155D;
+unicode = 5469;
+},
+{
+glyphname = "the-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (721,345);
+},
+{
+name = top_center_can;
+pos = (409,690);
+},
+{
+name = top_left_can;
+pos = (213,690);
+},
+{
+name = top_right_can;
+pos = (603,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(449,-14,o),
+(540,67,o),
+(578,242,cs),
+(673,690,l),
+(530,690,l),
+(438,252,ls),
+(417,158,o),
+(375,116,o),
+(297,116,cs),
+(196,116,o),
+(174,181,o),
+(197,282,cs),
+(226,406,l),
+(155,366,l),
+(167,333,o),
+(196,305,o),
+(234,305,cs),
+(344,305,o),
+(404,400,o),
+(421,514,cs),
+(440,630,o),
+(389,703,o),
+(288,703,cs),
+(191,703,o),
+(131,635,o),
+(102,498,cs),
+(61,300,ls),
+(21,111,o),
+(96,-14,o),
+(290,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(223,407,o),
+(211,426,o),
+(211,460,cs),
+(211,499,o),
+(231,604,o),
+(280,604,cs),
+(303,604,o),
+(315,584,o),
+(315,551,cs),
+(315,510,o),
+(296,407,o),
+(246,407,cs)
+);
+}
+);
+width = 627;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155E;
+unicode = 5470;
+},
+{
+glyphname = "theNCree-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(452,-14,o),
+(540,71,o),
+(582,261,cs),
+(628,478,ls),
+(660,626,o),
+(599,703,o),
+(503,703,cs),
+(375,703,o),
+(319,566,o),
+(319,462,cs),
+(319,374,o),
+(362,305,o),
+(446,305,cs),
+(480,305,o),
+(514,322,o),
+(535,349,c),
+(470,400,l),
+(441,261,ls),
+(418,156,o),
+(377,113,o),
+(298,113,cs),
+(207,113,o),
+(176,171,o),
+(196,270,cs),
+(286,690,l),
+(143,690,l),
+(57,282,ls),
+(17,99,o),
+(107,-14,o),
+(288,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(439,407,o),
+(427,426,o),
+(427,460,cs),
+(427,499,o),
+(446,604,o),
+(496,604,cs),
+(518,604,o),
+(530,584,o),
+(530,551,cs),
+(530,510,o),
+(511,407,o),
+(462,407,cs)
+);
+}
+);
+width = 626;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155F;
+unicode = 5471;
+},
+{
+glyphname = "thi-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (404,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(294,-14,o),
+(350,124,o),
+(350,228,cs),
+(350,316,o),
+(306,384,o),
+(222,384,cs),
+(188,384,o),
+(155,368,o),
+(133,341,c),
+(198,290,l),
+(227,429,ls),
+(249,534,o),
+(292,577,o),
+(370,577,cs),
+(462,577,o),
+(493,519,o),
+(472,420,cs),
+(383,0,l),
+(525,0,l),
+(611,408,ls),
+(651,591,o),
+(561,703,o),
+(381,703,cs),
+(216,703,o),
+(127,618,o),
+(87,429,cs),
+(41,212,ls),
+(9,64,o),
+(70,-14,o),
+(165,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(150,86,o),
+(138,105,o),
+(138,139,cs),
+(138,180,o),
+(157,283,o),
+(207,283,cs),
+(230,283,o),
+(241,264,o),
+(241,230,cs),
+(241,190,o),
+(222,86,o),
+(173,86,cs)
+);
+}
+);
+width = 625;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1560;
+unicode = 5472;
+},
+{
+glyphname = "thiNCree-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (405,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(478,-14,o),
+(538,55,o),
+(567,191,cs),
+(609,389,ls),
+(648,579,o),
+(574,703,o),
+(380,703,cs),
+(220,703,o),
+(129,623,o),
+(92,448,cs),
+(-4,0,l),
+(139,0,l),
+(232,438,ls),
+(252,531,o),
+(295,574,o),
+(373,574,cs),
+(473,574,o),
+(496,509,o),
+(472,408,cs),
+(443,284,l),
+(515,324,l),
+(502,356,o),
+(473,384,o),
+(436,384,cs),
+(326,384,o),
+(266,290,o),
+(248,176,cs),
+(230,60,o),
+(280,-14,o),
+(382,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(366,86,o),
+(354,105,o),
+(354,139,cs),
+(354,180,o),
+(374,283,o),
+(423,283,cs),
+(446,283,o),
+(459,264,o),
+(459,230,cs),
+(459,190,o),
+(439,86,o),
+(389,86,cs)
+);
+}
+);
+width = 626;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1561;
+unicode = 5473;
+},
+{
+glyphname = "thii-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "thi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (225,0);
+ref = dot_top;
+}
+);
+width = 627;
+}
+);
+note = uni1562;
+unicode = 5474;
+},
+{
+glyphname = "thiiNCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "thiNCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (225,0);
+ref = dot_top;
+}
+);
+width = 627;
+}
+);
+note = uni1563;
+unicode = 5475;
+},
+{
+glyphname = "tho-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (353,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(190,0,ls),
+(472,0,o),
+(558,251,o),
+(558,429,cs),
+(558,595,o),
+(470,703,o),
+(329,703,cs),
+(172,703,o),
+(87,568,o),
+(87,431,cs),
+(87,339,o),
+(135,279,o),
+(217,279,cs),
+(342,279,o),
+(393,418,o),
+(393,513,cs),
+(393,584,o),
+(361,635,o),
+(305,644,c),
+(275,607,l),
+(284,611,o),
+(298,615,o),
+(313,615,cs),
+(380,614,o),
+(424,549,o),
+(424,443,cs),
+(424,333,o),
+(388,129,o),
+(197,129,cs),
+(45,129,l),
+(18,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(209,379,o),
+(197,396,o),
+(197,429,cs),
+(197,466,o),
+(219,590,o),
+(271,590,cs),
+(294,590,o),
+(305,573,o),
+(305,540,cs),
+(305,504,o),
+(283,379,o),
+(231,379,cs)
+);
+}
+);
+width = 574;
+}
+);
+metricRight = "to-canadian";
+note = uni1564;
+unicode = 5476;
+},
+{
+glyphname = "thoo-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "tho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (174,0);
+ref = dot_top;
+}
+);
+width = 574;
+}
+);
+note = uni1565;
+unicode = 5477;
+},
+{
+glyphname = "tha-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (418,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(451,0,l),
+(479,129,l),
+(344,129,ls),
+(246,129,o),
+(196,180,o),
+(196,278,cs),
+(196,381,o),
+(262,614,o),
+(399,614,cs),
+(419,614,o),
+(439,609,o),
+(454,597,c),
+(433,641,l),
+(321,644,o),
+(273,504,o),
+(273,418,cs),
+(273,332,o),
+(319,279,o),
+(399,279,cs),
+(512,279,o),
+(585,392,o),
+(585,516,cs),
+(585,632,o),
+(513,703,o),
+(396,703,cs),
+(165,703,o),
+(57,438,o),
+(57,265,cs),
+(57,103,o),
+(156,0,o),
+(317,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(381,379,o),
+(369,396,o),
+(369,429,cs),
+(369,466,o),
+(391,590,o),
+(444,590,cs),
+(467,590,o),
+(478,573,o),
+(478,540,cs),
+(478,504,o),
+(456,379,o),
+(404,379,cs)
+);
+}
+);
+width = 574;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tho-canadian";
+note = uni1566;
+unicode = 5478;
+},
+{
+glyphname = "thaa-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (239,0);
+ref = dot_top;
+}
+);
+width = 574;
+}
+);
+note = uni1567;
+unicode = 5479;
+},
+{
+glyphname = "thwaa-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (441,0);
+ref = dot_top;
+}
+);
+width = 777;
+}
+);
+note = uni1568;
+unicode = 5480;
+},
+{
+glyphname = "thwaaWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (239,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (574,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 777;
+}
+);
+note = uni1569;
+unicode = 5481;
+},
+{
+glyphname = "th-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(290,345,l),
+(306,423,l),
+(244,423,ls),
+(199,423,o),
+(176,446,o),
+(176,491,cs),
+(176,541,o),
+(207,639,o),
+(275,639,cs),
+(283,639,o),
+(291,638,o),
+(297,636,c),
+(279,658,l),
+(228,658,o),
+(204,586,o),
+(204,552,cs),
+(204,509,o),
+(228,480,o),
+(267,480,cs),
+(330,480,o),
+(357,557,o),
+(357,604,cs),
+(357,660,o),
+(323,696,o),
+(264,696,cs),
+(148,696,o),
+(95,566,o),
+(95,483,cs),
+(95,399,o),
+(146,345,o),
+(230,345,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(255,529,o),
+(249,537,o),
+(249,553,cs),
+(249,575,o),
+(260,628,o),
+(285,628,cs),
+(297,628,o),
+(302,620,o),
+(302,605,cs),
+(302,583,o),
+(292,529,o),
+(267,529,cs)
+);
+}
+);
+width = 323;
+}
+);
+metricLeft = "t-canadian";
+note = uni156A;
+unicode = 5482;
+},
+{
+glyphname = "tthe-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (713,345);
+},
+{
+name = top_center_can;
+pos = (404,690);
+},
+{
+name = top_left_can;
+pos = (214,690);
+},
+{
+name = top_right_can;
+pos = (594,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(442,-14,o),
+(533,71,o),
+(570,242,cs),
+(665,690,l),
+(532,690,l),
+(439,253,ls),
+(418,157,o),
+(375,117,o),
+(296,117,cs),
+(202,117,o),
+(165,168,o),
+(186,269,cs),
+(276,690,l),
+(143,690,l),
+(57,282,ls),
+(17,98,o),
+(107,-14,o),
+(285,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(391,382,l),
+(457,690,l),
+(351,690,l),
+(285,382,l)
+);
+}
+);
+width = 619;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156B;
+unicode = 5483;
+},
+{
+glyphname = "tthi-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(129,0,l),
+(222,437,ls),
+(242,532,o),
+(287,573,o),
+(365,573,cs),
+(459,573,o),
+(497,522,o),
+(475,421,cs),
+(385,0,l),
+(518,0,l),
+(605,408,ls),
+(644,592,o),
+(554,703,o),
+(377,703,cs),
+(219,703,o),
+(128,619,o),
+(92,448,cs),
+(-4,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(311,0,l),
+(377,308,l),
+(270,308,l),
+(204,0,l)
+);
+}
+);
+width = 618;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156C;
+unicode = 5484;
+},
+{
+glyphname = "ttho-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (342,690);
+},
+{
+name = top_left_can;
+pos = (203,690);
+},
+{
+name = top_right_can;
+pos = (522,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(129,0,ls),
+(448,0,o),
+(517,265,o),
+(517,420,cs),
+(517,588,o),
+(415,690,o),
+(236,690,cs),
+(143,690,l),
+(116,560,l),
+(211,560,ls),
+(319,560,o),
+(374,508,o),
+(374,409,cs),
+(374,309,o),
+(332,129,o),
+(136,129,cs),
+(24,129,l),
+(-3,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(248,287,l),
+(273,405,l),
+(82,405,l),
+(58,287,l)
+);
+}
+);
+width = 534;
+}
+);
+metricRight = "to-canadian";
+note = uni156D;
+unicode = 5485;
+},
+{
+glyphname = "ttha-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (357,690);
+},
+{
+name = top_left_can;
+pos = (207,690);
+},
+{
+name = top_right_can;
+pos = (508,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(434,0,l),
+(461,129,l),
+(365,129,ls),
+(257,129,o),
+(203,182,o),
+(203,281,cs),
+(203,393,o),
+(256,560,o),
+(440,560,cs),
+(553,560,l),
+(580,690,l),
+(446,690,ls),
+(139,690,o),
+(60,436,o),
+(60,270,cs),
+(60,101,o),
+(160,0,o),
+(340,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(493,287,l),
+(518,405,l),
+(327,405,l),
+(301,287,l)
+);
+}
+);
+width = 534;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|ttho-canadian";
+note = uni156E;
+unicode = 5486;
+},
+{
+glyphname = "tth-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(256,479,l),
+(219,479,l),
+(277,360,l),
+(350,396,l),
+(289,522,l),
+(270,486,l),
+(407,538,l),
+(382,609,l),
+(257,560,l),
+(286,541,l),
+(317,690,l),
+(237,690,l),
+(205,541,l),
+(240,560,l),
+(124,609,l),
+(93,537,l),
+(201,493,l),
+(197,527,l),
+(93,412,l),
+(150,360,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(611,479,l),
+(575,479,l),
+(633,360,l),
+(705,396,l),
+(644,522,l),
+(625,486,l),
+(762,538,l),
+(737,609,l),
+(612,560,l),
+(640,541,l),
+(672,690,l),
+(592,690,l),
+(560,541,l),
+(594,560,l),
+(479,609,l),
+(448,537,l),
+(555,493,l),
+(553,527,l),
+(448,412,l),
+(504,360,l)
+);
+}
+);
+width = 731;
+}
+);
+metricRight = "=|";
+note = uni156F;
+unicode = 5487;
+},
+{
+glyphname = "tye-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(442,-14,o),
+(533,71,o),
+(570,242,cs),
+(665,690,l),
+(532,690,l),
+(440,256,ls),
+(419,158,o),
+(375,117,o),
+(295,117,cs),
+(202,117,o),
+(165,168,o),
+(186,269,cs),
+(276,690,l),
+(143,690,l),
+(57,282,ls),
+(17,98,o),
+(107,-14,o),
+(285,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(408,411,o),
+(440,440,o),
+(453,501,cs),
+(494,690,l),
+(434,690,l),
+(396,512,ls),
+(390,485,o),
+(379,473,o),
+(359,473,cs),
+(338,473,o),
+(331,485,o),
+(337,512,cs),
+(375,690,l),
+(315,690,l),
+(276,509,ls),
+(264,449,o),
+(295,411,o),
+(355,411,cs)
+);
+}
+);
+width = 619;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1570;
+unicode = 5488;
+},
+{
+glyphname = "tyi-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(129,0,l),
+(221,434,ls),
+(242,531,o),
+(286,573,o),
+(366,573,cs),
+(459,573,o),
+(497,522,o),
+(475,421,cs),
+(385,0,l),
+(518,0,l),
+(605,408,ls),
+(644,592,o),
+(554,703,o),
+(376,703,cs),
+(219,703,o),
+(128,619,o),
+(92,447,cs),
+(-4,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(228,0,l),
+(266,178,ls),
+(270,205,o),
+(283,216,o),
+(302,216,cs),
+(323,216,o),
+(330,205,o),
+(325,178,cs),
+(287,0,l),
+(347,0,l),
+(385,181,ls),
+(398,241,o),
+(367,279,o),
+(307,279,cs),
+(254,279,o),
+(221,249,o),
+(209,188,cs),
+(168,0,l)
+);
+}
+);
+width = 618;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1571;
+unicode = 5489;
+},
+{
+glyphname = "tyo-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(129,0,ls),
+(448,0,o),
+(520,265,o),
+(520,420,cs),
+(520,588,o),
+(416,690,o),
+(236,690,cs),
+(146,690,l),
+(119,563,l),
+(213,563,ls),
+(320,563,o),
+(377,508,o),
+(377,409,cs),
+(377,259,o),
+(287,127,o),
+(136,127,cs),
+(27,127,l),
+(0,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(103,215,ls),
+(204,215,o),
+(251,268,o),
+(262,345,cs),
+(272,423,o),
+(230,474,o),
+(154,474,cs),
+(100,474,l),
+(85,403,l),
+(137,403,ls),
+(173,403,o),
+(190,384,o),
+(186,351,cs),
+(183,315,o),
+(163,287,o),
+(111,287,cs),
+(61,287,l),
+(45,215,l)
+);
+}
+);
+width = 537;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1572;
+unicode = 5490;
+},
+{
+glyphname = "tya-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(433,0,l),
+(460,127,l),
+(365,127,ls),
+(259,127,o),
+(203,182,o),
+(203,281,cs),
+(203,431,o),
+(292,563,o),
+(443,563,cs),
+(552,563,l),
+(579,690,l),
+(449,690,ls),
+(130,690,o),
+(60,425,o),
+(60,270,cs),
+(60,101,o),
+(162,0,o),
+(343,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(478,215,l),
+(494,287,l),
+(441,287,ls),
+(406,287,o),
+(389,305,o),
+(392,339,cs),
+(396,375,o),
+(415,403,o),
+(468,403,cs),
+(518,403,l),
+(533,474,l),
+(475,474,ls),
+(375,474,o),
+(328,422,o),
+(317,345,cs),
+(306,267,o),
+(349,215,o),
+(425,215,cs)
+);
+}
+);
+width = 536;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1573;
+unicode = 5491;
+},
+{
+glyphname = "heNunavik-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(395,0,l),
+(641,196,l),
+(566,294,l),
+(394,158,l),
+(437,126,l),
+(499,421,ls),
+(529,559,o),
+(493,703,o),
+(328,703,cs),
+(145,703,o),
+(75,515,o),
+(75,375,cs),
+(75,258,o),
+(133,186,o),
+(230,186,cs),
+(277,186,o),
+(317,210,o),
+(343,258,c),
+(325,264,l),
+(269,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(234,307,o),
+(213,332,o),
+(213,382,cs),
+(213,433,o),
+(239,583,o),
+(315,583,cs),
+(353,583,o),
+(373,558,o),
+(373,508,cs),
+(373,457,o),
+(348,307,o),
+(271,307,cs)
+);
+}
+);
+width = 668;
+}
+);
+metricLeft = "ke-canadian";
+note = uni1574;
+unicode = 5492;
+},
+{
+glyphname = "hiNunavik-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (510,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(296,0,l),
+(360,301,l),
+(338,261,l),
+(337,219,o),
+(383,186,o),
+(444,186,cs),
+(610,186,o),
+(677,383,o),
+(677,507,cs),
+(677,631,o),
+(609,703,o),
+(495,703,cs),
+(370,703,o),
+(285,620,o),
+(253,466,cs),
+(180,121,l),
+(226,134,l),
+(103,279,l),
+(6,195,l),
+(170,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(402,307,o),
+(382,332,o),
+(382,382,cs),
+(382,433,o),
+(411,583,o),
+(483,583,cs),
+(520,583,o),
+(541,558,o),
+(541,509,cs),
+(541,457,o),
+(515,307,o),
+(439,307,cs)
+);
+}
+);
+width = 667;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1575;
+unicode = 5493;
+},
+{
+glyphname = "hiiNunavik-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "hiNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (330,0);
+ref = dot_top;
+}
+);
+width = 668;
+}
+);
+note = uni1576;
+unicode = 5494;
+},
+{
+glyphname = "hoNunavik-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (342,690);
+},
+{
+name = top_right_can;
+pos = (485,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(341,-14,o),
+(425,70,o),
+(458,224,cs),
+(530,569,l),
+(484,555,l),
+(608,411,l),
+(704,495,l),
+(540,690,l),
+(414,690,l),
+(350,388,l),
+(372,429,l),
+(373,470,o),
+(328,503,o),
+(266,503,cs),
+(101,503,o),
+(33,307,o),
+(33,183,cs),
+(33,59,o),
+(101,-14,o),
+(215,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(190,106,o),
+(169,131,o),
+(169,181,cs),
+(169,233,o),
+(195,383,o),
+(271,383,cs),
+(309,383,o),
+(329,357,o),
+(329,308,cs),
+(329,257,o),
+(300,106,o),
+(227,106,cs)
+);
+}
+);
+width = 668;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "heNunavik-canadian";
+note = uni1577;
+unicode = 5495;
+},
+{
+glyphname = "hooNunavik-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "hoNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (307,0);
+ref = dot_top;
+}
+);
+width = 668;
+}
+);
+note = uni1578;
+unicode = 5496;
+},
+{
+glyphname = "haNunavik-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (514,690);
+},
+{
+name = top_left_can;
+pos = (372,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(566,-14,o),
+(636,175,o),
+(636,315,cs),
+(636,432,o),
+(578,503,o),
+(480,503,cs),
+(433,503,o),
+(394,480,o),
+(368,432,c),
+(386,426,l),
+(442,690,l),
+(316,690,l),
+(70,494,l),
+(145,396,l),
+(317,531,l),
+(273,564,l),
+(211,269,ls),
+(182,130,o),
+(218,-14,o),
+(383,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(358,106,o),
+(338,131,o),
+(338,182,cs),
+(338,233,o),
+(363,383,o),
+(440,383,cs),
+(477,383,o),
+(498,357,o),
+(498,308,cs),
+(498,257,o),
+(472,106,o),
+(396,106,cs)
+);
+}
+);
+width = 668;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1579;
+unicode = 5497;
+},
+{
+glyphname = "haaNunavik-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "haNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (192,0);
+ref = dot_top;
+}
+);
+width = 668;
+}
+);
+note = uni157A;
+unicode = 5498;
+},
+{
+glyphname = "hNunavik-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(366,339,o),
+(408,443,o),
+(408,509,cs),
+(408,565,o),
+(377,601,o),
+(327,601,cs),
+(296,601,o),
+(272,587,o),
+(254,552,c),
+(270,527,l),
+(304,690,l),
+(219,690,l),
+(97,593,l),
+(141,538,l),
+(245,622,l),
+(209,669,l),
+(168,479,ls),
+(152,400,o),
+(186,339,o),
+(265,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(256,408,o),
+(246,419,o),
+(246,443,cs),
+(246,487,o),
+(266,532,o),
+(297,532,cs),
+(314,532,o),
+(325,522,o),
+(325,497,cs),
+(325,456,o),
+(304,408,o),
+(273,408,cs)
+);
+}
+);
+width = 390;
+}
+);
+metricRight = "k-canadian";
+note = uni157B;
+unicode = 5499;
+},
+{
+color = 4;
+glyphname = "nunavuth-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(141,0,l),
+(204,293,l),
+(415,293,l),
+(354,0,l),
+(496,0,l),
+(642,690,l),
+(500,690,l),
+(442,419,l),
+(231,419,l),
+(288,690,l),
+(146,690,l),
+(-1,0,l)
+);
+}
+);
+width = 599;
+}
+);
+metricRight = "=|";
+note = uni157C;
+unicode = 5500;
+},
+{
+glyphname = "hk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (73,345);
+ref = "fullstop-canadian";
+}
+);
+width = 327;
+}
+);
+metricLeft = "fullstop-canadian";
+note = uni157D;
+unicode = 5501;
+},
+{
+glyphname = "qaai-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (277,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (420,0);
+ref = ring_top.canadian;
+}
+);
+width = 788;
+}
+);
+note = uni157E;
+unicode = 5502;
+},
+{
+glyphname = "qi-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (277,0);
+ref = "ki-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni157F;
+unicode = 5503;
+},
+{
+glyphname = "qii-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (277,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (453,0);
+ref = dot_top;
+}
+);
+width = 788;
+}
+);
+note = uni1580;
+unicode = 5504;
+},
+{
+glyphname = "qo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (277,0);
+ref = "ko-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni1581;
+unicode = 5505;
+},
+{
+glyphname = "qoo-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (277,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (585,0);
+ref = dot_top;
+}
+);
+width = 788;
+}
+);
+note = uni1582;
+unicode = 5506;
+},
+{
+glyphname = "qa-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (277,0);
+ref = "ka-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni1583;
+unicode = 5507;
+},
+{
+glyphname = "qaa-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (277,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (313,0);
+ref = dot_top;
+}
+);
+width = 788;
+}
+);
+note = uni1584;
+unicode = 5508;
+},
+{
+glyphname = "q-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (277,0);
+ref = "k-canadian";
+}
+);
+width = 594;
+}
+);
+note = uni1585;
+unicode = 5509;
+},
+{
+glyphname = "tlhe-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (358,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(144,0,l),
+(307,277,l),
+(203,219,l),
+(213,217,o),
+(223,216,o),
+(233,216,cs),
+(281,216,o),
+(325,234,o),
+(361,275,c),
+(350,317,l),
+(282,0,l),
+(423,0,l),
+(518,444,ls),
+(545,571,o),
+(505,703,o),
+(344,703,cs),
+(166,703,o),
+(92,539,o),
+(92,404,cs),
+(92,346,o),
+(111,294,o),
+(152,262,c),
+(-4,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(244,338,o),
+(226,368,o),
+(226,412,cs),
+(226,465,o),
+(253,583,o),
+(327,583,cs),
+(368,583,o),
+(386,554,o),
+(386,511,cs),
+(386,458,o),
+(358,338,o),
+(285,338,cs)
+);
+}
+);
+width = 524;
+}
+);
+metricRight = "te-canadian";
+note = uni1586;
+unicode = 5510;
+},
+{
+glyphname = "tlhi-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(137,0,l),
+(206,326,l),
+(151,302,l),
+(181,249,o),
+(221,222,o),
+(284,220,c),
+(233,251,l),
+(275,0,l),
+(424,0,l),
+(383,244,l),
+(484,286,o),
+(527,417,o),
+(527,508,cs),
+(527,626,o),
+(456,703,o),
+(335,703,cs),
+(213,703,o),
+(129,627,o),
+(96,469,cs),
+(-4,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(250,338,o),
+(229,364,o),
+(229,411,cs),
+(229,462,o),
+(256,583,o),
+(330,583,cs),
+(370,583,o),
+(390,557,o),
+(390,511,cs),
+(390,459,o),
+(364,338,o),
+(290,338,cs)
+);
+}
+);
+width = 526;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|tlhe-canadian";
+note = uni1587;
+unicode = 5511;
+},
+{
+glyphname = "tlho-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (366,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(355,-14,o),
+(439,63,o),
+(473,221,cs),
+(573,690,l),
+(432,690,l),
+(363,364,l),
+(418,387,l),
+(388,440,o),
+(349,468,o),
+(285,469,c),
+(336,439,l),
+(294,690,l),
+(146,690,l),
+(186,445,l),
+(85,404,o),
+(42,272,o),
+(42,182,cs),
+(42,64,o),
+(113,-14,o),
+(234,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,106,o),
+(180,132,o),
+(180,179,cs),
+(180,231,o),
+(205,352,o),
+(280,352,cs),
+(319,352,o),
+(340,326,o),
+(340,279,cs),
+(340,228,o),
+(314,106,o),
+(240,106,cs)
+);
+}
+);
+width = 526;
+}
+);
+metricLeft = "tlhe-canadian";
+metricRight = "te-canadian";
+note = uni1588;
+unicode = 5512;
+},
+{
+glyphname = "tlha-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(401,-14,o),
+(474,151,o),
+(474,286,cs),
+(474,344,o),
+(456,396,o),
+(415,428,c),
+(571,690,l),
+(422,690,l),
+(260,412,l),
+(364,470,l),
+(355,472,o),
+(344,473,o),
+(334,473,cs),
+(285,473,o),
+(242,456,o),
+(206,414,c),
+(217,373,l),
+(284,690,l),
+(143,690,l),
+(49,245,ls),
+(22,119,o),
+(61,-14,o),
+(222,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(198,106,o),
+(181,136,o),
+(181,179,cs),
+(181,232,o),
+(208,352,o),
+(281,352,cs),
+(322,352,o),
+(341,322,o),
+(341,278,cs),
+(341,225,o),
+(313,106,o),
+(240,106,cs)
+);
+}
+);
+width = 525;
+}
+);
+metricLeft = "te-canadian";
+note = uni1589;
+unicode = 5513;
+},
+{
+glyphname = "reWestCree-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(385,0,l),
+(633,199,l),
+(555,295,l),
+(386,159,l),
+(428,128,l),
+(497,453,ls),
+(529,609,o),
+(461,703,o),
+(324,703,cs),
+(193,703,o),
+(118,629,o),
+(84,472,cs),
+(65,382,l),
+(206,382,l),
+(228,487,ls),
+(242,553,o),
+(266,580,o),
+(307,580,cs),
+(356,580,o),
+(376,545,o),
+(362,481,cs),
+(260,0,l)
+);
+}
+);
+width = 660;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+unicode = 5514;
+},
+{
+glyphname = "riWestCree-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(295,0,l),
+(397,487,ls),
+(412,552,o),
+(436,580,o),
+(477,580,cs),
+(526,580,o),
+(546,546,o),
+(531,481,cs),
+(510,382,l),
+(651,382,l),
+(667,453,ls),
+(699,609,o),
+(629,703,o),
+(492,703,cs),
+(361,703,o),
+(287,629,o),
+(253,472,cs),
+(180,127,l),
+(229,139,l),
+(110,284,l),
+(7,199,l),
+(169,0,l)
+);
+}
+);
+width = 659;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+unicode = 5515;
+},
+{
+glyphname = "roWestCree-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(340,-14,o),
+(414,61,o),
+(447,217,cs),
+(521,563,l),
+(472,551,l),
+(592,406,l),
+(695,491,l),
+(532,690,l),
+(407,690,l),
+(303,203,ls),
+(290,138,o),
+(265,110,o),
+(224,110,cs),
+(176,110,o),
+(156,144,o),
+(169,209,cs),
+(190,308,l),
+(49,308,l),
+(35,237,ls),
+(1,81,o),
+(72,-14,o),
+(209,-14,cs)
+);
+}
+);
+width = 660;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+unicode = 5516;
+},
+{
+glyphname = "raWestCree-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(508,-14,o),
+(583,61,o),
+(617,217,cs),
+(637,308,l),
+(496,308,l),
+(473,203,ls),
+(459,137,o),
+(436,110,o),
+(394,110,cs),
+(345,110,o),
+(326,145,o),
+(339,209,cs),
+(441,690,l),
+(316,690,l),
+(69,491,l),
+(146,395,l),
+(316,530,l),
+(273,562,l),
+(205,237,ls),
+(172,81,o),
+(241,-14,o),
+(378,-14,cs)
+);
+}
+);
+width = 660;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+unicode = 5517;
+},
+{
+glyphname = "ngaai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:56:57 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (531,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (674,0);
+ref = ring_top.canadian;
+}
+);
+width = 1034;
+}
+);
+note = uni158E;
+unicode = 5518;
+},
+{
+glyphname = "ngi-canadian";
+kernLeft = mwestleft;
+kernRight = ciright;
+lastChange = "2023-01-13 15:56:57 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (531,0);
+ref = "ci-canadian";
+}
+);
+width = 1034;
+}
+);
+note = uni158F;
+unicode = 5519;
+},
+{
+glyphname = "ngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:56:57 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (531,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (707,0);
+ref = dot_top;
+}
+);
+width = 1034;
+}
+);
+note = uni1590;
+unicode = 5520;
+},
+{
+glyphname = "ngo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (505,0);
+ref = "co-canadian";
+}
+);
+width = 1007;
+}
+);
+note = uni1591;
+unicode = 5521;
+},
+{
+glyphname = "ngoo-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "ngo-canadian";
+},
+{
+anchor = top_right_can;
+pos = (804,0);
+ref = dot_top;
+}
+);
+width = 1007;
+}
+);
+note = uni1592;
+unicode = 5522;
+},
+{
+glyphname = "nga-canadian";
+kernLeft = mwestleft;
+kernRight = caright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (531,0);
+ref = "ca-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni1593;
+unicode = 5523;
+},
+{
+glyphname = "ngaa-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (531,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (568,0);
+ref = dot_top;
+}
+);
+width = 1035;
+}
+);
+note = uni1594;
+unicode = 5524;
+},
+{
+glyphname = "ng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(465,217,o),
+(511,259,o),
+(527,338,cs),
+(533,368,l),
+(446,368,l),
+(438,330,ls),
+(432,303,o),
+(420,291,o),
+(402,291,cs),
+(381,291,o),
+(373,305,o),
+(379,331,cs),
+(419,524,l),
+(286,524,l),
+(293,474,l),
+(316,493,o),
+(333,535,o),
+(337,573,cs),
+(347,643,o),
+(307,696,o),
+(235,696,cs),
+(160,696,o),
+(113,636,o),
+(102,565,cs),
+(91,486,o),
+(133,434,o),
+(208,434,cs),
+(343,434,l),
+(318,489,l),
+(290,357,ls),
+(271,271,o),
+(312,217,o),
+(393,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(189,502,o),
+(180,521,o),
+(184,555,cs),
+(188,590,o),
+(203,627,o),
+(230,627,cs),
+(250,627,o),
+(260,609,o),
+(255,575,cs),
+(251,540,o),
+(237,502,o),
+(209,502,cs)
+);
+}
+);
+width = 531;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1595;
+unicode = 5525;
+},
+{
+glyphname = "nng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(727,217,o),
+(773,259,o),
+(789,338,cs),
+(796,368,l),
+(709,368,l),
+(700,330,ls),
+(695,303,o),
+(683,291,o),
+(664,291,cs),
+(643,291,o),
+(635,305,o),
+(640,331,cs),
+(682,524,l),
+(562,524,l),
+(555,474,l),
+(585,499,o),
+(603,553,o),
+(603,590,cs),
+(603,655,o),
+(563,696,o),
+(498,696,cs),
+(411,696,o),
+(364,614,o),
+(364,541,cs),
+(364,519,o),
+(369,500,o),
+(381,483,c),
+(391,524,l),
+(301,524,l),
+(293,474,l),
+(323,499,o),
+(340,554,o),
+(340,590,cs),
+(340,652,o),
+(300,696,o),
+(236,696,cs),
+(148,696,o),
+(101,614,o),
+(101,541,cs),
+(101,476,o),
+(142,434,o),
+(209,434,cs),
+(568,434,l),
+(552,357,ls),
+(533,271,o),
+(575,217,o),
+(656,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(193,502,o),
+(184,516,o),
+(184,539,cs),
+(184,568,o),
+(197,627,o),
+(231,627,cs),
+(248,627,o),
+(258,614,o),
+(258,590,cs),
+(258,561,o),
+(244,502,o),
+(210,502,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(456,502,o),
+(446,516,o),
+(446,539,cs),
+(446,568,o),
+(460,627,o),
+(494,627,cs),
+(511,627,o),
+(521,614,o),
+(521,590,cs),
+(521,561,o),
+(507,502,o),
+(473,502,cs)
+);
+}
+);
+width = 794;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1596;
+unicode = 5526;
+},
+{
+glyphname = "sheSayisi-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (610,345);
+},
+{
+name = top_center_can;
+pos = (353,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(418,0,l),
+(510,429,ls),
+(545,597,o),
+(481,703,o),
+(338,703,cs),
+(140,703,o),
+(69,489,o),
+(69,347,cs),
+(69,246,o),
+(110,187,o),
+(187,187,cs),
+(267,187,o),
+(306,250,o),
+(334,413,c),
+(277,413,l),
+(264,331,o),
+(250,303,o),
+(227,303,cs),
+(210,303,o),
+(201,319,o),
+(201,349,cs),
+(201,399,o),
+(233,583,o),
+(319,583,cs),
+(376,583,o),
+(388,527,o),
+(367,428,cs),
+(275,0,l)
+);
+}
+);
+width = 519;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1597;
+unicode = 5527;
+},
+{
+glyphname = "shiSayisi-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(139,0,l),
+(234,444,ls),
+(254,542,o),
+(283,583,o),
+(331,583,cs),
+(373,583,o),
+(394,556,o),
+(394,502,cs),
+(394,460,o),
+(367,303,o),
+(324,303,cs),
+(298,303,o),
+(292,329,o),
+(312,413,c),
+(256,413,l),
+(217,263,o),
+(249,187,o),
+(344,187,cs),
+(476,187,o),
+(528,397,o),
+(528,499,cs),
+(528,627,o),
+(458,703,o),
+(335,703,cs),
+(212,703,o),
+(129,624,o),
+(97,471,cs),
+(-4,0,l)
+);
+}
+);
+width = 520;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni1598;
+unicode = 5528;
+},
+{
+glyphname = "shoSayisi-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (350,690);
+},
+{
+name = top_left_can;
+pos = (201,690);
+},
+{
+name = top_right_can;
+pos = (496,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(352,-14,o),
+(434,66,o),
+(467,218,cs),
+(567,690,l),
+(424,690,l),
+(329,245,ls),
+(309,148,o),
+(280,106,o),
+(232,106,cs),
+(190,106,o),
+(169,133,o),
+(169,187,cs),
+(169,230,o),
+(196,386,o),
+(240,386,cs),
+(266,386,o),
+(271,360,o),
+(251,276,c),
+(307,276,l),
+(346,427,o),
+(314,502,o),
+(219,502,cs),
+(87,502,o),
+(35,293,o),
+(35,190,cs),
+(35,63,o),
+(105,-14,o),
+(228,-14,cs)
+);
+}
+);
+width = 521;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1599;
+unicode = 5529;
+},
+{
+glyphname = "shaSayisi-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(422,-14,o),
+(494,201,o),
+(494,343,cs),
+(494,443,o),
+(452,502,o),
+(375,502,cs),
+(296,502,o),
+(255,440,o),
+(228,276,c),
+(284,276,l),
+(298,358,o),
+(312,386,o),
+(335,386,cs),
+(353,386,o),
+(361,371,o),
+(361,341,cs),
+(361,291,o),
+(329,106,o),
+(242,106,cs),
+(186,106,o),
+(174,162,o),
+(195,262,cs),
+(286,690,l),
+(144,690,l),
+(52,261,ls),
+(17,93,o),
+(80,-14,o),
+(224,-14,cs)
+);
+}
+);
+width = 521;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni159A;
+unicode = 5530;
+},
+{
+glyphname = "theWoodScree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(581,-14,o),
+(652,166,o),
+(652,290,cs),
+(652,412,o),
+(579,489,o),
+(455,489,cs),
+(94,489,l),
+(70,372,l),
+(310,372,l),
+(304,411,l),
+(240,361,o),
+(214,255,o),
+(214,185,cs),
+(214,66,o),
+(287,-14,o),
+(405,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(374,106,o),
+(352,135,o),
+(352,185,cs),
+(352,238,o),
+(379,371,o),
+(454,371,cs),
+(494,371,o),
+(515,343,o),
+(515,293,cs),
+(515,239,o),
+(488,106,o),
+(412,106,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(711,573,l),
+(735,690,l),
+(137,690,l),
+(112,573,l)
+);
+}
+);
+width = 692;
+}
+);
+note = uni159B;
+unicode = 5531;
+},
+{
+glyphname = "thiWoodScree-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(404,-14,o),
+(476,166,o),
+(476,290,cs),
+(476,328,o),
+(468,359,o),
+(451,383,c),
+(438,372,l),
+(678,372,l),
+(702,489,l),
+(302,489,ls),
+(101,489,o),
+(38,306,o),
+(38,185,cs),
+(38,66,o),
+(110,-14,o),
+(229,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(197,106,o),
+(176,135,o),
+(176,185,cs),
+(176,238,o),
+(202,371,o),
+(278,371,cs),
+(318,371,o),
+(339,343,o),
+(339,293,cs),
+(339,239,o),
+(312,106,o),
+(237,106,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(721,573,l),
+(746,690,l),
+(148,690,l),
+(123,573,l)
+);
+}
+);
+width = 693;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159C;
+unicode = 5532;
+},
+{
+glyphname = "thoWoodScree-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(391,0,ls),
+(592,0,o),
+(656,183,o),
+(656,304,cs),
+(656,423,o),
+(583,503,o),
+(466,503,cs),
+(290,503,o),
+(217,323,o),
+(217,199,cs),
+(217,161,o),
+(226,129,o),
+(243,106,c),
+(256,117,l),
+(16,117,l),
+(-9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(377,119,o),
+(356,146,o),
+(356,196,cs),
+(356,251,o),
+(383,383,o),
+(457,383,cs),
+(497,383,o),
+(519,355,o),
+(519,304,cs),
+(519,251,o),
+(492,119,o),
+(416,119,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(711,573,l),
+(736,690,l),
+(137,690,l),
+(112,573,l)
+);
+}
+);
+width = 694;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159D;
+unicode = 5533;
+},
+{
+glyphname = "thaWoodScree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(598,0,l),
+(623,117,l),
+(382,117,l),
+(387,78,l),
+(452,128,o),
+(478,234,o),
+(478,303,cs),
+(478,423,o),
+(405,503,o),
+(287,503,cs),
+(111,503,o),
+(40,323,o),
+(40,199,cs),
+(40,78,o),
+(113,0,o),
+(237,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(198,119,o),
+(177,146,o),
+(177,196,cs),
+(177,251,o),
+(204,383,o),
+(279,383,cs),
+(319,383,o),
+(340,355,o),
+(340,304,cs),
+(340,251,o),
+(314,119,o),
+(238,119,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(719,573,l),
+(744,690,l),
+(146,690,l),
+(121,573,l)
+);
+}
+);
+width = 692;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159E;
+unicode = 5534;
+},
+{
+glyphname = "thWoodScree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(395,344,l),
+(413,426,l),
+(282,426,l),
+(278,383,l),
+(312,406,o),
+(330,462,o),
+(330,501,cs),
+(330,565,o),
+(291,606,o),
+(226,606,cs),
+(138,606,o),
+(92,525,o),
+(92,451,cs),
+(92,385,o),
+(132,344,o),
+(199,344,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(184,412,o),
+(174,426,o),
+(174,449,cs),
+(174,478,o),
+(187,537,o),
+(221,537,cs),
+(239,537,o),
+(248,524,o),
+(248,500,cs),
+(248,471,o),
+(235,412,o),
+(201,412,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(449,647,l),
+(467,729,l),
+(150,729,l),
+(131,647,l)
+);
+}
+);
+width = 418;
+}
+);
+metricRight = "=|";
+note = uni159F;
+unicode = 5535;
+},
+{
+glyphname = "lhi-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (457,690);
+},
+{
+name = top_right_can;
+pos = (557,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(269,0,l),
+(295,125,l),
+(271,125,ls),
+(214,125,o),
+(180,160,o),
+(180,216,cs),
+(180,282,o),
+(217,360,o),
+(323,360,cs),
+(671,360,l),
+(695,474,l),
+(598,737,l),
+(468,688,l),
+(565,425,l),
+(616,489,l),
+(334,489,ls),
+(147,489,o),
+(38,374,o),
+(38,213,cs),
+(38,89,o),
+(119,0,o),
+(242,0,cs)
+);
+}
+);
+width = 683;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A0;
+unicode = 5536;
+},
+{
+glyphname = "lhii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "lhi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (278,0);
+ref = dot_top;
+}
+);
+width = 684;
+}
+);
+note = uni15A1;
+unicode = 5537;
+},
+{
+glyphname = "lho-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (395,506);
+},
+{
+name = top_right_can;
+pos = (483,506);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(216,-199,l),
+(119,64,l),
+(68,0,l),
+(350,0,ls),
+(536,0,o),
+(645,115,o),
+(645,276,cs),
+(645,400,o),
+(565,489,o),
+(441,489,cs),
+(415,489,l),
+(389,364,l),
+(412,364,ls),
+(470,364,o),
+(504,328,o),
+(504,272,cs),
+(504,207,o),
+(467,128,o),
+(361,128,cs),
+(13,128,l),
+(-12,14,l),
+(86,-248,l)
+);
+}
+);
+width = 683;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni15A2;
+unicode = 5538;
+},
+{
+glyphname = "lhoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "lho-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (304,-184);
+ref = dot_top;
+}
+);
+width = 684;
+}
+);
+note = uni15A3;
+unicode = 5539;
+},
+{
+glyphname = "lha-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (400,506);
+},
+{
+name = top_left_can;
+pos = (311,506);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(597,14,l),
+(621,128,l),
+(281,128,ls),
+(213,128,o),
+(178,161,o),
+(178,219,cs),
+(178,287,o),
+(215,364,o),
+(322,364,cs),
+(344,364,l),
+(371,489,l),
+(341,489,ls),
+(147,489,o),
+(37,374,o),
+(37,206,cs),
+(37,81,o),
+(118,0,o),
+(254,0,cs),
+(502,0,l),
+(466,59,l),
+(285,-169,l),
+(385,-249,l)
+);
+}
+);
+width = 683;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A4;
+unicode = 5540;
+},
+{
+glyphname = "lhaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "lha-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (132,-184);
+ref = dot_top;
+}
+);
+width = 684;
+}
+);
+note = uni15A5;
+unicode = 5541;
+},
+{
+glyphname = "lh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(385,355,l),
+(403,434,l),
+(254,434,ls),
+(213,434,o),
+(189,456,o),
+(189,495,cs),
+(189,542,o),
+(213,602,o),
+(287,602,cs),
+(296,602,l),
+(315,690,l),
+(300,690,ls),
+(157,690,o),
+(95,588,o),
+(95,482,cs),
+(95,394,o),
+(152,345,o),
+(247,345,cs),
+(342,345,l),
+(308,404,l),
+(197,265,l),
+(266,207,l)
+);
+}
+);
+width = 402;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni15A6;
+unicode = 5542;
+},
+{
+glyphname = "theThCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (191,690);
+},
+{
+name = top_right_can;
+pos = (466,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(266,82,l),
+(248,0,l),
+(390,0,l),
+(408,82,l),
+(466,82,l),
+(482,159,l),
+(424,159,l),
+(464,345,l),
+(217,345,l),
+(239,298,l),
+(532,615,l),
+(436,701,l),
+(29,258,l),
+(21,221,l),
+(295,221,l),
+(282,159,l),
+(106,159,l),
+(90,82,l)
+);
+}
+);
+width = 525;
+}
+);
+metricLeft = "ye-canadian";
+note = uni15A7;
+unicode = 5543;
+},
+{
+glyphname = "thiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (249,690);
+},
+{
+name = top_right_can;
+pos = (524,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(173,0,l),
+(190,82,l),
+(366,82,l),
+(382,159,l),
+(207,159,l),
+(219,221,l),
+(493,221,l),
+(500,258,l),
+(258,701,l),
+(145,638,l),
+(337,290,l),
+(370,345,l),
+(103,345,l),
+(64,159,l),
+(6,159,l),
+(-11,82,l),
+(48,82,l),
+(30,0,l)
+);
+}
+);
+width = 524;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+unicode = 5544;
+},
+{
+glyphname = "thiiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (70,0);
+ref = dot_top;
+}
+);
+width = 525;
+}
+);
+note = uni15A9;
+unicode = 5545;
+},
+{
+glyphname = "thoThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (191,690);
+},
+{
+name = top_right_can;
+pos = (466,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(422,52,l),
+(230,400,l),
+(197,345,l),
+(463,345,l),
+(502,530,l),
+(561,530,l),
+(578,608,l),
+(519,608,l),
+(536,690,l),
+(394,690,l),
+(376,608,l),
+(201,608,l),
+(185,530,l),
+(360,530,l),
+(347,469,l),
+(74,469,l),
+(66,432,l),
+(309,-12,l)
+);
+}
+);
+width = 525;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+unicode = 5546;
+},
+{
+glyphname = "thooThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (287,0);
+ref = dot_top;
+}
+);
+width = 525;
+}
+);
+note = uni15AB;
+unicode = 5547;
+},
+{
+glyphname = "thaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (249,690);
+},
+{
+name = top_right_can;
+pos = (524,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(539,432,l),
+(547,469,l),
+(273,469,l),
+(286,530,l),
+(462,530,l),
+(478,608,l),
+(302,608,l),
+(320,690,l),
+(178,690,l),
+(159,608,l),
+(101,608,l),
+(86,530,l),
+(144,530,l),
+(104,345,l),
+(351,345,l),
+(329,391,l),
+(36,74,l),
+(132,-12,l)
+);
+}
+);
+width = 525;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+unicode = 5548;
+},
+{
+glyphname = "thaaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:56:57 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (70,0);
+ref = dot_top;
+}
+);
+width = 525;
+}
+);
+note = uni15AD;
+unicode = 5549;
+},
+{
+glyphname = "thThCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(141,614,l),
+(117,501,l),
+(254,501,l),
+(233,549,l),
+(89,391,l),
+(154,336,l),
+(351,554,l),
+(356,580,l),
+(227,580,l),
+(235,614,l),
+(314,614,l),
+(323,654,l),
+(243,654,l),
+(251,690,l),
+(157,690,l),
+(150,654,l),
+(120,654,l),
+(111,614,l)
+);
+}
+);
+width = 306;
+}
+);
+metricRight = "y-canadian";
+note = uni15AE;
+unicode = 5550;
+},
+{
+glyphname = "bAivilik-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(410,-14,o),
+(483,175,o),
+(483,315,cs),
+(483,431,o),
+(424,503,o),
+(327,503,cs),
+(281,503,o),
+(242,480,o),
+(215,433,c),
+(231,422,l),
+(288,690,l),
+(146,690,l),
+(-1,0,l),
+(129,0,l),
+(147,81,l),
+(135,68,l),
+(145,15,o),
+(187,-14,o),
+(248,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(206,106,o),
+(185,131,o),
+(185,182,cs),
+(185,233,o),
+(211,383,o),
+(287,383,cs),
+(324,383,o),
+(345,357,o),
+(345,308,cs),
+(345,257,o),
+(320,106,o),
+(243,106,cs)
+);
+}
+);
+width = 515;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|ke-canadian";
+note = uni15AF;
+unicode = 5551;
+},
+{
+glyphname = "eBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(141,0,l),
+(229,410,l),
+(246,369,o),
+(288,344,o),
+(341,344,cs),
+(465,344,o),
+(520,470,o),
+(520,561,cs),
+(520,646,o),
+(470,703,o),
+(389,703,cs),
+(344,703,o),
+(300,684,o),
+(272,650,c),
+(280,690,l),
+(146,690,l),
+(-1,0,l)
+);
+}
+);
+width = 490;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B0;
+unicode = 5552;
+},
+{
+glyphname = "iBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(189,-14,o),
+(233,6,o),
+(261,40,c),
+(253,0,l),
+(387,0,l),
+(534,690,l),
+(392,690,l),
+(304,280,l),
+(287,321,o),
+(245,346,o),
+(192,346,cs),
+(69,346,o),
+(13,219,o),
+(13,128,cs),
+(13,43,o),
+(63,-14,o),
+(144,-14,cs)
+);
+}
+);
+width = 490;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B1;
+unicode = 5553;
+},
+{
+glyphname = "oBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(388,-14,o),
+(444,113,o),
+(444,204,cs),
+(444,289,o),
+(395,346,o),
+(315,346,cs),
+(273,346,o),
+(235,330,o),
+(206,303,c),
+(288,690,l),
+(146,690,l),
+(-1,0,l),
+(133,0,l),
+(148,66,l),
+(162,17,o),
+(207,-14,o),
+(266,-14,cs)
+);
+}
+);
+width = 490;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "eBlackfoot-canadian";
+note = uni15B2;
+unicode = 5554;
+},
+{
+glyphname = "aBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(386,0,l),
+(533,690,l),
+(399,690,l),
+(385,624,l),
+(371,672,o),
+(327,703,o),
+(268,703,cs),
+(144,703,o),
+(89,577,o),
+(89,486,cs),
+(89,401,o),
+(138,344,o),
+(217,344,cs),
+(260,344,o),
+(298,359,o),
+(327,386,c),
+(244,0,l)
+);
+}
+);
+width = 489;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B3;
+unicode = 5555;
+},
+{
+glyphname = "weBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(141,0,l),
+(202,282,l),
+(471,282,l),
+(497,404,l),
+(227,404,l),
+(263,569,l),
+(532,569,l),
+(557,690,l),
+(146,690,l),
+(-1,0,l)
+);
+}
+);
+width = 506;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B4;
+unicode = 5556;
+},
+{
+glyphname = "wiBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(404,0,l),
+(551,690,l),
+(408,690,l),
+(348,408,l),
+(79,408,l),
+(53,286,l),
+(322,286,l),
+(287,121,l),
+(17,121,l),
+(-8,0,l)
+);
+}
+);
+width = 507;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B5;
+unicode = 5557;
+},
+{
+glyphname = "woBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(411,0,l),
+(437,121,l),
+(167,121,l),
+(202,286,l),
+(471,286,l),
+(497,408,l),
+(228,408,l),
+(288,690,l),
+(146,690,l),
+(-1,0,l)
+);
+}
+);
+width = 506;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "weBlackfoot-canadian";
+note = uni15B6;
+unicode = 5558;
+},
+{
+glyphname = "waBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(404,0,l),
+(551,690,l),
+(138,690,l),
+(113,569,l),
+(383,569,l),
+(347,404,l),
+(77,404,l),
+(52,282,l),
+(322,282,l),
+(261,0,l)
+);
+}
+);
+width = 507;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B7;
+unicode = 5559;
+},
+{
+glyphname = "neBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(141,0,l),
+(266,586,l),
+(316,586,l),
+(296,667,l),
+(288,630,ls),
+(257,482,o),
+(327,386,o),
+(470,386,cs),
+(595,386,o),
+(675,461,o),
+(707,608,cs),
+(725,690,l),
+(585,690,l),
+(565,594,ls),
+(554,539,o),
+(526,512,o),
+(480,512,cs),
+(430,512,o),
+(409,546,o),
+(421,603,cs),
+(440,690,l),
+(146,690,l),
+(-1,0,l)
+);
+}
+);
+width = 654;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B8;
+unicode = 5560;
+},
+{
+glyphname = "niBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(111,0,l),
+(131,96,ls),
+(143,151,o),
+(171,178,o),
+(216,178,cs),
+(267,178,o),
+(288,144,o),
+(275,87,cs),
+(257,0,l),
+(551,0,l),
+(697,690,l),
+(555,690,l),
+(431,103,l),
+(381,103,l),
+(401,23,l),
+(409,60,ls),
+(440,208,o),
+(369,303,o),
+(226,303,cs),
+(101,303,o),
+(21,229,o),
+(-11,82,cs),
+(-28,0,l)
+);
+}
+);
+width = 654;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B9;
+unicode = 5561;
+},
+{
+glyphname = "noBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(293,0,l),
+(313,91,ls),
+(327,152,o),
+(352,180,o),
+(396,180,cs),
+(447,180,o),
+(468,144,o),
+(455,82,cs),
+(439,0,l),
+(578,0,l),
+(589,53,ls),
+(621,204,o),
+(548,303,o),
+(406,303,cs),
+(283,303,o),
+(205,229,o),
+(172,80,cs),
+(159,23,l),
+(213,103,l),
+(163,103,l),
+(288,690,l),
+(146,690,l),
+(-1,0,l)
+);
+}
+);
+width = 654;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "neBlackfoot-canadian";
+note = uni15BA;
+unicode = 5562;
+},
+{
+glyphname = "naBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(551,0,l),
+(697,690,l),
+(404,690,l),
+(384,599,ls),
+(370,538,o),
+(345,510,o),
+(300,510,cs),
+(249,510,o),
+(229,546,o),
+(242,608,cs),
+(258,690,l),
+(119,690,l),
+(107,637,ls),
+(75,486,o),
+(149,386,o),
+(291,386,cs),
+(413,386,o),
+(492,461,o),
+(525,610,cs),
+(537,667,l),
+(484,586,l),
+(533,586,l),
+(409,0,l)
+);
+}
+);
+width = 654;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BB;
+unicode = 5563;
+},
+{
+glyphname = "keBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(141,0,l),
+(253,526,l),
+(205,526,l),
+(274,251,l),
+(333,251,l),
+(629,690,l),
+(470,690,l),
+(288,415,l),
+(345,408,l),
+(276,690,l),
+(146,690,l),
+(-1,0,l)
+);
+}
+);
+width = 543;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15BC;
+unicode = 5564;
+},
+{
+glyphname = "kiBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(115,0,l),
+(298,275,l),
+(240,282,l),
+(308,0,l),
+(440,0,l),
+(586,690,l),
+(443,690,l),
+(332,165,l),
+(381,165,l),
+(311,440,l),
+(252,440,l),
+(-43,0,l)
+);
+}
+);
+width = 543;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BD;
+unicode = 5565;
+},
+{
+glyphname = "koBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(129,0,l),
+(338,281,l),
+(268,290,l),
+(337,0,l),
+(482,0,l),
+(373,439,l),
+(314,439,l),
+(128,164,l),
+(177,164,l),
+(288,690,l),
+(146,690,l),
+(-1,0,l)
+);
+}
+);
+width = 543;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "keBlackfoot-canadian";
+note = uni15BE;
+unicode = 5566;
+},
+{
+glyphname = "kaBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(441,0,l),
+(587,690,l),
+(456,690,l),
+(248,410,l),
+(319,400,l),
+(249,690,l),
+(104,690,l),
+(213,251,l),
+(272,251,l),
+(457,526,l),
+(410,526,l),
+(298,0,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BF;
+unicode = 5567;
+},
+{
+color = 9;
+glyphname = "heSayisi-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_right_can;
+pos = (568,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(492,0,l),
+(639,690,l),
+(497,690,l),
+(424,341,l),
+(446,341,l),
+(492,569,o),
+(437,703,o),
+(299,703,cs),
+(191,703,o),
+(116,620,o),
+(81,465,cs),
+(72,420,o),
+(67,380,o),
+(66,330,c),
+(201,330,l),
+(203,374,o),
+(207,410,o),
+(215,449,cs),
+(234,533,o),
+(270,580,o),
+(318,580,cs),
+(417,580,o),
+(433,397,o),
+(349,0,c)
+);
+}
+);
+width = 595;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni15C0;
+unicode = 5568;
+},
+{
+color = 9;
+glyphname = "hiSayisi-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(141,0,l),
+(222,372,o),
+(318,580,o),
+(411,580,cs),
+(463,580,o),
+(480,517,o),
+(458,407,cs),
+(450,374,o),
+(443,352,o),
+(435,330,c),
+(570,330,l),
+(582,359,o),
+(590,385,o),
+(597,414,cs),
+(633,590,o),
+(581,703,o),
+(465,703,cs),
+(344,703,o),
+(242,575,o),
+(194,359,c),
+(216,359,l),
+(287,690,l),
+(146,690,l),
+(-1,0,l)
+);
+}
+);
+width = 595;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C1;
+unicode = 5569;
+},
+{
+color = 9;
+glyphname = "hoSayisi-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (386,690);
+},
+{
+name = top_left_can;
+pos = (206,690);
+},
+{
+name = top_right_can;
+pos = (567,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(292,-14,o),
+(394,115,o),
+(441,330,c),
+(420,330,l),
+(350,0,l),
+(491,0,l),
+(637,690,l),
+(495,690,l),
+(414,318,o),
+(318,110,o),
+(226,110,cs),
+(173,110,o),
+(155,173,o),
+(179,283,cs),
+(186,316,o),
+(193,338,o),
+(202,359,c),
+(67,359,l),
+(55,330,o),
+(46,304,o),
+(40,275,cs),
+(3,99,o),
+(56,-14,o),
+(171,-14,cs)
+);
+}
+);
+width = 594;
+}
+);
+metricLeft = "heSayisi-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15C2;
+unicode = 5570;
+},
+{
+color = 9;
+glyphname = "haSayisi-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(445,-14,o),
+(521,70,o),
+(556,225,cs),
+(565,270,o),
+(570,310,o),
+(571,359,c),
+(437,359,l),
+(435,316,o),
+(431,280,o),
+(421,241,cs),
+(403,156,o),
+(368,110,o),
+(319,110,cs),
+(220,110,o),
+(205,293,o),
+(288,690,c),
+(146,690,l),
+(-1,0,l),
+(140,0,l),
+(213,349,l),
+(191,349,l),
+(146,121,o),
+(201,-14,o),
+(338,-14,cs)
+);
+}
+);
+width = 594;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C3;
+unicode = 5571;
+},
+{
+color = 9;
+glyphname = "ghuCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(275,0,l),
+(684,655,l),
+(691,690,l),
+(567,690,l),
+(452,497,l),
+(502,518,l),
+(216,518,l),
+(259,496,l),
+(226,690,l),
+(113,690,l),
+(106,655,l),
+(235,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(444,413,l),
+(420,436,l),
+(269,183,l),
+(314,175,l),
+(269,431,l),
+(234,413,l)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C4;
+unicode = 5572;
+},
+{
+color = 9;
+glyphname = "ghoCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(90,0,l),
+(207,193,l),
+(155,172,l),
+(440,172,l),
+(398,194,l),
+(431,0,l),
+(544,0,l),
+(551,35,l),
+(422,690,l),
+(382,690,l),
+(-27,35,l),
+(-34,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(406,391,l),
+(278,398,l),
+(303,260,l),
+(406,391,l),
+(277,393,l),
+(322,253,l)
+);
+}
+);
+width = 614;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C5;
+unicode = 5573;
+},
+{
+color = 9;
+glyphname = "gheCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (88,358);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(15,0,l),
+(544,323,l),
+(553,367,l),
+(162,690,l),
+(129,690,l),
+(107,587,l),
+(229,486,l),
+(220,572,l),
+(130,150,l),
+(169,227,l),
+(10,129,l),
+(-17,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(306,516,l),
+(269,470,l),
+(449,318,l),
+(455,391,l),
+(225,250,l),
+(241,207,l)
+);
+}
+);
+width = 553;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15C6;
+unicode = 5574;
+},
+{
+color = 9;
+glyphname = "gheeCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (21,14);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 554;
+}
+);
+note = uni15C7;
+unicode = 5575;
+},
+{
+color = 9;
+glyphname = "ghiCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (-2,14);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 554;
+}
+);
+note = uni15C8;
+unicode = 5576;
+},
+{
+color = 9;
+glyphname = "ghaCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(468,0,l),
+(490,102,l),
+(368,204,l),
+(377,118,l),
+(467,540,l),
+(427,463,l),
+(586,560,l),
+(614,690,l),
+(582,690,l),
+(52,367,l),
+(43,323,l),
+(434,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(327,219,l),
+(169,354,l),
+(166,314,l),
+(372,440,l),
+(350,455,l),
+(299,213,l)
+);
+}
+);
+width = 554;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15C9;
+unicode = 5577;
+},
+{
+color = 9;
+glyphname = "ruCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(275,0,l),
+(684,655,l),
+(691,690,l),
+(563,690,l),
+(509,599,l),
+(553,623,l),
+(204,623,l),
+(242,598,l),
+(226,690,l),
+(113,690,l),
+(106,655,l),
+(235,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(496,517,l),
+(482,542,l),
+(269,187,l),
+(314,180,l),
+(249,537,l),
+(219,517,l)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CA;
+unicode = 5578;
+},
+{
+color = 9;
+glyphname = "roCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(382,690,l),
+(-27,35,l),
+(-34,0,l),
+(94,0,l),
+(148,91,l),
+(104,67,l),
+(453,67,l),
+(415,92,l),
+(431,0,l),
+(543,0,l),
+(551,35,l),
+(422,690,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(161,173,l),
+(175,148,l),
+(388,502,l),
+(343,510,l),
+(408,153,l),
+(438,173,l)
+);
+}
+);
+width = 614;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CB;
+unicode = 5579;
+},
+{
+color = 9;
+glyphname = "reCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(17,0,l),
+(544,323,l),
+(554,367,l),
+(163,690,l),
+(129,690,l),
+(108,589,l),
+(176,531,l),
+(166,615,l),
+(56,101,l),
+(91,176,l),
+(10,125,l),
+(-17,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(252,544,l),
+(216,498,l),
+(433,317,l),
+(438,389,l),
+(160,215,l),
+(173,173,l)
+);
+}
+);
+width = 554;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CC;
+unicode = 5580;
+},
+{
+color = 9;
+glyphname = "reeCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(16,0,l),
+(544,323,l),
+(554,367,l),
+(163,690,l),
+(129,690,l),
+(111,604,l),
+(167,555,l),
+(168,628,l),
+(53,90,l),
+(83,162,l),
+(7,114,l),
+(-17,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(244,577,l),
+(211,531,l),
+(468,318,l),
+(472,390,l),
+(135,183,l),
+(151,138,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(262,288,l),
+(291,425,l),
+(245,425,l),
+(215,288,l)
+);
+}
+);
+width = 554;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CD;
+unicode = 5581;
+},
+{
+color = 9;
+glyphname = "riCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(16,0,l),
+(544,323,l),
+(554,367,l),
+(163,690,l),
+(129,690,l),
+(111,604,l),
+(170,553,l),
+(168,628,l),
+(53,90,l),
+(90,166,l),
+(7,114,l),
+(-17,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(301,317,o),
+(324,336,o),
+(324,361,cs),
+(324,387,o),
+(301,406,o),
+(277,406,cs),
+(254,406,o),
+(233,387,o),
+(233,361,cs),
+(233,336,o),
+(254,317,o),
+(277,317,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(244,577,l),
+(207,534,l),
+(468,318,l),
+(472,390,l),
+(138,185,l),
+(151,138,l)
+);
+}
+);
+width = 554;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CE;
+unicode = 5582;
+},
+{
+color = 9;
+glyphname = "raCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(467,0,l),
+(489,100,l),
+(421,158,l),
+(431,74,l),
+(540,588,l),
+(506,514,l),
+(587,565,l),
+(613,690,l),
+(580,690,l),
+(52,367,l),
+(43,323,l),
+(433,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(381,191,l),
+(164,373,l),
+(159,300,l),
+(437,474,l),
+(424,517,l),
+(345,146,l)
+);
+}
+);
+width = 554;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15CF;
+unicode = 5583;
+},
+{
+color = 9;
+glyphname = "wuCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(283,0,l),
+(698,655,l),
+(706,690,l),
+(585,690,l),
+(341,275,l),
+(370,275,l),
+(458,690,l),
+(351,690,l),
+(262,274,l),
+(292,274,l),
+(218,690,l),
+(113,690,l),
+(106,655,l),
+(242,0,l)
+);
+}
+);
+width = 629;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D0;
+unicode = 5584;
+},
+{
+color = 9;
+glyphname = "woCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(87,0,l),
+(330,414,l),
+(302,414,l),
+(213,0,l),
+(322,0,l),
+(410,415,l),
+(380,415,l),
+(454,0,l),
+(558,0,l),
+(565,35,l),
+(430,690,l),
+(388,690,l),
+(-27,35,l),
+(-34,0,l)
+);
+}
+);
+width = 628;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D1;
+unicode = 5585;
+},
+{
+color = 9;
+glyphname = "weCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(33,0,l),
+(560,323,l),
+(570,367,l),
+(180,690,l),
+(146,690,l),
+(125,587,l),
+(364,392,l),
+(371,412,l),
+(87,412,l),
+(64,305,l),
+(348,305,l),
+(355,324,l),
+(26,128,l),
+(0,0,l)
+);
+}
+);
+width = 570;
+}
+);
+metricRight = "o-canadian";
+note = uni15D2;
+unicode = 5586;
+},
+{
+color = 9;
+glyphname = "weeCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(33,0,l),
+(560,323,l),
+(570,367,l),
+(180,690,l),
+(147,690,l),
+(127,597,l),
+(415,363,l),
+(429,401,l),
+(218,401,l),
+(231,462,l),
+(158,462,l),
+(145,401,l),
+(85,401,l),
+(67,317,l),
+(128,317,l),
+(114,256,l),
+(187,256,l),
+(200,317,l),
+(412,317,l),
+(397,342,l),
+(24,118,l),
+(0,0,l)
+);
+}
+);
+width = 570;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D3;
+unicode = 5587;
+},
+{
+color = 9;
+glyphname = "wiCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(33,0,l),
+(560,323,l),
+(570,367,l),
+(180,690,l),
+(146,690,l),
+(127,597,l),
+(389,385,l),
+(403,405,l),
+(267,405,l),
+(254,430,o),
+(228,446,o),
+(197,446,cs),
+(166,446,o),
+(139,430,o),
+(127,405,c),
+(85,405,l),
+(68,322,l),
+(128,322,l),
+(141,298,o),
+(167,281,o),
+(197,281,cs),
+(226,281,o),
+(252,298,o),
+(266,322,c),
+(385,322,l),
+(378,330,l),
+(24,119,l),
+(0,0,l)
+);
+}
+);
+width = 570;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D4;
+unicode = 5588;
+},
+{
+color = 9;
+glyphname = "waCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(467,0,l),
+(488,102,l),
+(249,298,l),
+(242,277,l),
+(526,277,l),
+(549,384,l),
+(266,384,l),
+(258,366,l),
+(586,562,l),
+(612,690,l),
+(580,690,l),
+(52,367,l),
+(43,323,l),
+(433,0,l)
+);
+}
+);
+width = 570;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15D5;
+unicode = 5589;
+},
+{
+color = 9;
+glyphname = "hwuCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(283,0,l),
+(698,655,l),
+(706,690,l),
+(594,690,l),
+(491,520,l),
+(522,535,l),
+(412,535,l),
+(444,690,l),
+(361,690,l),
+(328,535,l),
+(214,535,l),
+(242,522,l),
+(210,690,l),
+(113,690,l),
+(106,655,l),
+(242,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(292,212,l),
+(243,483,l),
+(222,463,l),
+(320,463,l),
+(267,211,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(388,463,l),
+(483,463,l),
+(474,483,l),
+(315,216,l),
+(335,209,l)
+);
+}
+);
+width = 629;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D6;
+unicode = 5590;
+},
+{
+color = 9;
+glyphname = "hwoCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(77,0,l),
+(182,170,l),
+(150,155,l),
+(260,155,l),
+(227,0,l),
+(310,0,l),
+(343,155,l),
+(457,155,l),
+(430,168,l),
+(462,0,l),
+(558,0,l),
+(565,35,l),
+(429,690,l),
+(388,690,l),
+(-27,35,l),
+(-34,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(356,473,l),
+(337,481,l),
+(283,227,l),
+(188,227,l),
+(198,207,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(449,227,l),
+(352,227,l),
+(405,479,l),
+(380,478,l),
+(428,207,l)
+);
+}
+);
+width = 628;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D7;
+unicode = 5591;
+},
+{
+color = 9;
+glyphname = "hweCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(32,0,l),
+(560,323,l),
+(570,367,l),
+(179,690,l),
+(146,690,l),
+(127,597,l),
+(216,525,l),
+(190,401,l),
+(84,401,l),
+(66,312,l),
+(171,312,l),
+(146,191,l),
+(24,118,l),
+(-1,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(242,322,l),
+(389,322,l),
+(222,225,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(277,488,l),
+(399,391,l),
+(257,391,l)
+);
+}
+);
+width = 570;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D8;
+unicode = 5592;
+},
+{
+color = 9;
+glyphname = "hweeCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(33,0,l),
+(560,323,l),
+(570,367,l),
+(179,690,l),
+(146,690,l),
+(128,604,l),
+(252,503,l),
+(229,394,l),
+(188,394,l),
+(201,458,l),
+(143,458,l),
+(129,394,l),
+(83,394,l),
+(68,321,l),
+(114,321,l),
+(100,257,l),
+(158,257,l),
+(172,321,l),
+(213,321,l),
+(190,212,l),
+(23,112,l),
+(-1,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(275,327,l),
+(397,327,l),
+(258,243,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(305,469,l),
+(404,387,l),
+(289,387,l)
+);
+}
+);
+width = 570;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D9;
+unicode = 5593;
+},
+{
+color = 9;
+glyphname = "hwiCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(33,0,l),
+(560,323,l),
+(570,367,l),
+(180,690,l),
+(146,690,l),
+(128,604,l),
+(252,502,l),
+(228,387,l),
+(206,387,l),
+(196,408,o),
+(177,421,o),
+(154,421,cs),
+(130,421,o),
+(111,408,o),
+(100,387,c),
+(82,387,l),
+(69,327,l),
+(100,327,l),
+(110,306,o),
+(130,293,o),
+(153,293,cs),
+(175,293,o),
+(195,306,o),
+(206,327,c),
+(214,327,l),
+(190,212,l),
+(23,112,l),
+(-1,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(275,327,l),
+(395,327,l),
+(258,243,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(305,469,l),
+(405,387,l),
+(288,387,l)
+);
+}
+);
+width = 570;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15DA;
+unicode = 5594;
+},
+{
+color = 9;
+glyphname = "hwaCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(581,690,l),
+(52,367,l),
+(43,323,l),
+(434,0,l),
+(467,0,l),
+(486,93,l),
+(396,165,l),
+(422,289,l),
+(528,289,l),
+(547,378,l),
+(441,378,l),
+(467,498,l),
+(589,572,l),
+(613,690,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(370,368,l),
+(224,368,l),
+(391,465,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(335,202,l),
+(213,298,l),
+(355,298,l)
+);
+}
+);
+width = 570;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15DB;
+unicode = 5595;
+},
+{
+color = 9;
+glyphname = "thuCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(442,-14,o),
+(533,71,o),
+(570,242,cs),
+(665,690,l),
+(143,690,l),
+(57,282,ls),
+(17,98,o),
+(107,-14,o),
+(285,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(259,563,l),
+(496,563,l),
+(430,253,ls),
+(410,157,o),
+(367,117,o),
+(296,117,cs),
+(209,117,o),
+(175,169,o),
+(196,269,cs)
+);
+}
+);
+width = 619;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DC;
+unicode = 5596;
+},
+{
+color = 9;
+glyphname = "thoCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(518,0,l),
+(605,408,ls),
+(644,592,o),
+(554,703,o),
+(377,703,cs),
+(219,703,o),
+(128,619,o),
+(92,448,cs),
+(-4,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(232,437,ls),
+(252,532,o),
+(294,573,o),
+(366,573,cs),
+(453,573,o),
+(486,521,o),
+(465,421,cs),
+(403,127,l),
+(166,127,l)
+);
+}
+);
+width = 618;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DD;
+unicode = 5597;
+},
+{
+color = 9;
+glyphname = "theCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (331,345);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(204,0,ls),
+(501,0,o),
+(602,235,o),
+(602,423,cs),
+(602,591,o),
+(503,690,o),
+(323,690,cs),
+(146,690,l),
+(-1,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(273,623,l),
+(221,565,l),
+(298,565,ls),
+(404,565,o),
+(462,511,o),
+(462,411,cs),
+(462,293,o),
+(398,125,o),
+(213,125,cs),
+(138,125,l),
+(156,71,l)
+);
+}
+);
+width = 618;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "to-canadian";
+note = uni15DE;
+unicode = 5598;
+},
+{
+color = 9;
+glyphname = "theeCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (253,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 617;
+}
+);
+note = uni15DF;
+unicode = 5599;
+},
+{
+color = 9;
+glyphname = "thiCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (227,0);
+ref = dot_middle;
+}
+);
+width = 617;
+}
+);
+note = uni15E0;
+unicode = 5600;
+},
+{
+color = 9;
+glyphname = "thaCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(514,0,l),
+(661,690,l),
+(456,690,ls),
+(159,690,o),
+(59,455,o),
+(59,267,cs),
+(59,99,o),
+(157,0,o),
+(338,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,397,o),
+(262,565,o),
+(447,565,cs),
+(523,565,l),
+(504,618,l),
+(386,67,l),
+(439,125,l),
+(362,125,ls),
+(256,125,o),
+(199,179,o),
+(199,279,cs)
+);
+}
+);
+width = 617;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15E1;
+unicode = 5601;
+},
+{
+color = 9;
+glyphname = "ttuCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(442,-14,o),
+(532,68,o),
+(569,241,cs),
+(665,690,l),
+(625,690,l),
+(307,499,l),
+(410,488,l),
+(185,690,l),
+(143,690,l),
+(56,280,ls),
+(17,97,o),
+(104,-14,o),
+(284,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(209,117,o),
+(175,169,o),
+(196,267,cs),
+(255,544,l),
+(191,523,l),
+(330,398,l),
+(355,398,l),
+(541,511,l),
+(492,543,l),
+(430,255,ls),
+(410,158,o),
+(367,117,o),
+(293,117,cs)
+);
+}
+);
+width = 618;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E2;
+unicode = 5602;
+},
+{
+color = 9;
+glyphname = "ttoCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(37,0,l),
+(355,190,l),
+(252,202,l),
+(476,0,l),
+(518,0,l),
+(605,410,ls),
+(644,593,o),
+(556,703,o),
+(378,703,cs),
+(219,703,o),
+(129,622,o),
+(92,449,cs),
+(-4,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(452,573,o),
+(486,521,o),
+(466,423,cs),
+(407,146,l),
+(469,167,l),
+(331,292,l),
+(307,292,l),
+(121,179,l),
+(170,147,l),
+(231,435,ls),
+(252,531,o),
+(294,573,o),
+(368,573,cs)
+);
+}
+);
+width = 618;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E3;
+unicode = 5603;
+},
+{
+color = 9;
+glyphname = "tteCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (374,345);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(214,0,ls),
+(502,0,o),
+(612,226,o),
+(612,423,cs),
+(612,591,o),
+(514,690,o),
+(339,690,cs),
+(142,690,l),
+(134,655,l),
+(174,298,l),
+(193,418,l),
+(3,35,l),
+(-4,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(299,333,l),
+(303,353,l),
+(271,628,l),
+(222,565,l),
+(309,565,ls),
+(414,565,o),
+(472,510,o),
+(472,411,cs),
+(472,293,o),
+(409,125,o),
+(224,125,cs),
+(139,125,l),
+(168,68,l)
+);
+}
+);
+width = 628;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15E4;
+unicode = 5604;
+},
+{
+color = 9;
+glyphname = "tteeCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (308,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 628;
+}
+);
+note = uni15E5;
+unicode = 5605;
+},
+{
+color = 9;
+glyphname = "ttiCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (299,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 628;
+}
+);
+note = uni15E6;
+unicode = 5606;
+},
+{
+color = 9;
+glyphname = "ttaCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(528,0,l),
+(536,35,l),
+(497,391,l),
+(477,271,l),
+(668,655,l),
+(674,690,l),
+(456,690,ls),
+(168,690,o),
+(59,464,o),
+(59,267,cs),
+(59,99,o),
+(157,0,o),
+(331,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(448,125,l),
+(361,125,ls),
+(256,125,o),
+(199,180,o),
+(199,279,cs),
+(199,397,o),
+(262,565,o),
+(446,565,cs),
+(531,565,l),
+(502,622,l),
+(371,356,l),
+(367,337,l),
+(399,62,l)
+);
+}
+);
+width = 628;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tteCarrier-canadian";
+note = uni15E7;
+unicode = 5607;
+},
+{
+color = 9;
+glyphname = "puCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(442,-14,o),
+(533,71,o),
+(570,242,cs),
+(665,690,l),
+(523,690,l),
+(493,548,l),
+(256,548,l),
+(286,690,l),
+(143,690,l),
+(57,282,ls),
+(17,98,o),
+(107,-14,o),
+(285,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(209,117,o),
+(175,169,o),
+(196,269,cs),
+(229,422,l),
+(466,422,l),
+(430,253,ls),
+(410,157,o),
+(367,117,o),
+(296,117,cs)
+);
+}
+);
+width = 619;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E8;
+unicode = 5608;
+},
+{
+color = 9;
+glyphname = "poCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(139,0,l),
+(169,142,l),
+(406,142,l),
+(376,0,l),
+(518,0,l),
+(605,408,ls),
+(644,592,o),
+(554,703,o),
+(377,703,cs),
+(219,703,o),
+(128,619,o),
+(92,448,cs),
+(-4,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(232,437,ls),
+(252,532,o),
+(294,573,o),
+(366,573,cs),
+(453,573,o),
+(486,521,o),
+(465,421,cs),
+(433,268,l),
+(196,268,l)
+);
+}
+);
+width = 618;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E9;
+unicode = 5609;
+},
+{
+color = 9;
+glyphname = "peCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (360,345);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(213,0,ls),
+(510,0,o),
+(611,235,o),
+(611,423,cs),
+(611,591,o),
+(512,690,o),
+(337,690,cs),
+(141,690,l),
+(114,565,l),
+(180,565,l),
+(87,125,l),
+(20,125,l),
+(-6,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(334,627,l),
+(196,565,l),
+(307,565,ls),
+(412,565,o),
+(470,510,o),
+(470,411,cs),
+(470,295,o),
+(409,125,o),
+(222,125,cs),
+(102,125,l),
+(214,63,l)
+);
+}
+);
+width = 627;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15EA;
+unicode = 5610;
+},
+{
+color = 9;
+glyphname = "peeCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (294,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 626;
+}
+);
+note = uni15EB;
+unicode = 5611;
+},
+{
+color = 9;
+glyphname = "piCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (286,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 626;
+}
+);
+note = uni15EC;
+unicode = 5612;
+},
+{
+color = 9;
+glyphname = "paCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(528,0,l),
+(555,125,l),
+(490,125,l),
+(583,565,l),
+(648,565,l),
+(675,690,l),
+(456,690,ls),
+(159,690,o),
+(59,455,o),
+(59,267,cs),
+(59,99,o),
+(157,0,o),
+(332,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(473,125,l),
+(362,125,ls),
+(256,125,o),
+(199,180,o),
+(199,279,cs),
+(199,395,o),
+(261,565,o),
+(447,565,cs),
+(567,565,l),
+(455,627,l),
+(335,63,l)
+);
+}
+);
+width = 625;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|peCarrier-canadian";
+note = uni15ED;
+unicode = 5613;
+},
+{
+color = 6;
+glyphname = "pCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(309,183,l),
+(328,272,l),
+(237,272,l),
+(291,527,l),
+(196,527,l),
+(142,272,l),
+(50,272,l),
+(32,183,l)
+);
+}
+);
+width = 366;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni15EE;
+unicode = 5614;
+},
+{
+color = 9;
+glyphname = "guCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (454,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(262,-14,o),
+(323,29,o),
+(366,118,c),
+(309,118,l),
+(323,31,o),
+(373,-14,o),
+(457,-14,cs),
+(570,-14,o),
+(631,53,o),
+(658,182,cs),
+(766,690,l),
+(631,690,l),
+(524,185,ls),
+(514,137,o),
+(492,114,o),
+(457,114,cs),
+(421,114,o),
+(404,141,o),
+(413,187,cs),
+(521,690,l),
+(388,690,l),
+(281,185,ls),
+(271,138,o),
+(248,114,o),
+(213,114,cs),
+(177,114,o),
+(161,140,o),
+(171,187,cs),
+(278,690,l),
+(143,690,l),
+(38,192,ls),
+(11,66,o),
+(64,-14,o),
+(181,-14,cs)
+);
+}
+);
+width = 719;
+}
+);
+metricRight = "=|";
+note = uni15EF;
+unicode = 5615;
+},
+{
+color = 9;
+glyphname = "goCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(132,0,l),
+(239,505,ls),
+(249,553,o),
+(270,576,o),
+(305,576,cs),
+(342,576,o),
+(358,549,o),
+(349,502,cs),
+(242,0,l),
+(374,0,l),
+(480,504,ls),
+(491,552,o),
+(514,576,o),
+(549,576,cs),
+(585,576,o),
+(601,550,o),
+(590,502,cs),
+(484,0,l),
+(619,0,l),
+(725,497,ls),
+(752,624,o),
+(698,703,o),
+(582,703,cs),
+(499,703,o),
+(440,661,o),
+(395,572,c),
+(453,572,l),
+(440,659,o),
+(390,703,o),
+(305,703,cs),
+(192,703,o),
+(131,637,o),
+(104,508,cs),
+(-3,0,l)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F0;
+unicode = 5616;
+},
+{
+color = 9;
+glyphname = "geCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (409,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(307,0,ls),
+(469,0,o),
+(562,86,o),
+(562,216,cs),
+(562,282,o),
+(530,334,o),
+(469,363,c),
+(459,312,l),
+(572,342,o),
+(627,424,o),
+(627,522,cs),
+(627,624,o),
+(552,690,o),
+(440,690,cs),
+(147,690,l),
+(122,574,l),
+(411,574,ls),
+(459,574,o),
+(486,547,o),
+(486,504,cs),
+(486,445,o),
+(449,402,o),
+(375,402,cs),
+(85,402,l),
+(61,288,l),
+(350,288,ls),
+(398,288,o),
+(425,263,o),
+(425,221,cs),
+(425,179,o),
+(404,116,o),
+(314,116,cs),
+(24,116,l),
+(0,0,l)
+);
+}
+);
+width = 622;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15F1;
+unicode = 5617;
+},
+{
+color = 9;
+glyphname = "geeCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(307,0,ls),
+(469,0,o),
+(562,86,o),
+(562,216,cs),
+(562,282,o),
+(530,334,o),
+(469,363,c),
+(459,312,l),
+(572,342,o),
+(627,424,o),
+(627,522,cs),
+(627,624,o),
+(552,690,o),
+(440,690,cs),
+(147,690,l),
+(122,574,l),
+(411,574,ls),
+(459,574,o),
+(486,547,o),
+(486,504,cs),
+(486,445,o),
+(449,402,o),
+(375,402,cs),
+(336,402,l),
+(353,478,l),
+(272,478,l),
+(256,402,l),
+(85,402,l),
+(61,288,l),
+(232,288,l),
+(215,213,l),
+(297,213,l),
+(312,288,l),
+(350,288,ls),
+(398,288,o),
+(425,263,o),
+(425,221,cs),
+(425,179,o),
+(404,116,o),
+(314,116,cs),
+(24,116,l),
+(0,0,l)
+);
+}
+);
+width = 622;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F2;
+unicode = 5618;
+},
+{
+color = 9;
+glyphname = "giCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(307,0,ls),
+(469,0,o),
+(562,86,o),
+(562,216,cs),
+(562,281,o),
+(530,334,o),
+(469,363,c),
+(459,312,l),
+(572,342,o),
+(627,426,o),
+(627,522,cs),
+(627,624,o),
+(552,690,o),
+(440,690,cs),
+(147,690,l),
+(122,574,l),
+(411,574,ls),
+(459,574,o),
+(486,547,o),
+(486,504,cs),
+(486,445,o),
+(449,402,o),
+(375,402,cs),
+(347,402,l),
+(384,364,l),
+(378,408,o),
+(340,441,o),
+(293,441,cs),
+(260,441,o),
+(233,426,o),
+(217,402,c),
+(85,402,l),
+(61,288,l),
+(217,288,l),
+(233,264,o),
+(260,248,o),
+(293,248,cs),
+(340,248,o),
+(376,282,o),
+(384,327,c),
+(327,288,l),
+(350,288,ls),
+(398,288,o),
+(425,263,o),
+(425,221,cs),
+(425,179,o),
+(404,116,o),
+(314,116,cs),
+(24,116,l),
+(0,0,l)
+);
+}
+);
+width = 622;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F3;
+unicode = 5619;
+},
+{
+color = 9;
+glyphname = "gaCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (419,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(518,0,l),
+(543,116,l),
+(254,116,ls),
+(207,116,o),
+(179,143,o),
+(179,185,cs),
+(179,244,o),
+(215,288,o),
+(290,288,cs),
+(581,288,l),
+(605,402,l),
+(315,402,ls),
+(267,402,o),
+(240,427,o),
+(240,469,cs),
+(240,511,o),
+(261,574,o),
+(351,574,cs),
+(640,574,l),
+(665,690,l),
+(357,690,ls),
+(195,690,o),
+(102,604,o),
+(102,473,cs),
+(102,408,o),
+(134,355,o),
+(196,327,c),
+(207,378,l),
+(93,348,o),
+(38,266,o),
+(38,168,cs),
+(38,66,o),
+(113,0,o),
+(226,0,cs)
+);
+}
+);
+width = 623;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|geCarrier-canadian";
+note = uni15F4;
+unicode = 5620;
+},
+{
+color = 9;
+glyphname = "khuCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(257,-14,o),
+(315,24,o),
+(357,101,c),
+(311,104,l),
+(328,27,o),
+(377,-14,o),
+(457,-14,cs),
+(570,-14,o),
+(631,53,o),
+(658,182,cs),
+(766,690,l),
+(143,690,l),
+(38,192,ls),
+(11,66,o),
+(64,-14,o),
+(181,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(177,114,o),
+(161,140,o),
+(171,187,cs),
+(252,567,l),
+(362,567,l),
+(281,185,ls),
+(271,138,o),
+(248,114,o),
+(213,114,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(421,114,o),
+(404,141,o),
+(413,187,cs),
+(495,567,l),
+(605,567,l),
+(524,185,ls),
+(514,137,o),
+(492,114,o),
+(457,114,cs)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F5;
+unicode = 5621;
+},
+{
+color = 9;
+glyphname = "khoCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(619,0,l),
+(725,497,ls),
+(752,624,o),
+(698,703,o),
+(582,703,cs),
+(505,703,o),
+(447,666,o),
+(405,588,c),
+(451,585,l),
+(434,663,o),
+(384,703,o),
+(304,703,cs),
+(192,703,o),
+(131,637,o),
+(104,508,cs),
+(-3,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(239,505,ls),
+(248,553,o),
+(270,576,o),
+(304,576,cs),
+(341,576,o),
+(357,549,o),
+(348,502,cs),
+(268,123,l),
+(157,123,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(480,504,ls),
+(491,552,o),
+(514,576,o),
+(549,576,cs),
+(585,576,o),
+(601,550,o),
+(590,502,cs),
+(510,123,l),
+(400,123,l)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F6;
+unicode = 5622;
+},
+{
+color = 9;
+glyphname = "kheCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(314,0,ls),
+(476,0,o),
+(568,85,o),
+(568,216,cs),
+(568,280,o),
+(537,331,o),
+(477,360,c),
+(470,314,l),
+(594,349,o),
+(634,441,o),
+(634,522,cs),
+(634,624,o),
+(557,690,o),
+(444,690,cs),
+(146,690,l),
+(-1,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(202,289,l),
+(356,289,ls),
+(405,289,o),
+(431,264,o),
+(431,221,cs),
+(431,174,o),
+(405,114,o),
+(321,114,cs),
+(164,114,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(263,576,l),
+(416,576,ls),
+(465,576,o),
+(492,547,o),
+(492,504,cs),
+(492,453,o),
+(463,401,o),
+(381,401,cs),
+(225,401,l)
+);
+}
+);
+width = 628;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F7;
+unicode = 5623;
+},
+{
+color = 9;
+glyphname = "kheeCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(314,0,ls),
+(476,0,o),
+(568,85,o),
+(568,216,cs),
+(568,280,o),
+(537,331,o),
+(477,360,c),
+(470,314,l),
+(594,349,o),
+(634,441,o),
+(634,522,cs),
+(634,624,o),
+(557,690,o),
+(444,690,cs),
+(146,690,l),
+(-1,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(202,289,l),
+(279,289,l),
+(263,212,l),
+(339,212,l),
+(360,311,l),
+(324,289,l),
+(356,289,ls),
+(405,289,o),
+(431,264,o),
+(431,221,cs),
+(431,174,o),
+(405,114,o),
+(321,114,cs),
+(164,114,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(396,480,l),
+(320,480,l),
+(303,401,l),
+(225,401,l),
+(263,576,l),
+(416,576,ls),
+(465,576,o),
+(492,547,o),
+(492,504,cs),
+(492,453,o),
+(463,401,o),
+(381,401,cs),
+(347,401,l),
+(375,380,l)
+);
+}
+);
+width = 628;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F8;
+unicode = 5624;
+},
+{
+color = 9;
+glyphname = "khiCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(314,0,ls),
+(476,0,o),
+(568,85,o),
+(568,216,cs),
+(568,280,o),
+(538,331,o),
+(478,360,c),
+(463,312,l),
+(593,345,o),
+(634,440,o),
+(634,522,cs),
+(634,624,o),
+(557,690,o),
+(444,690,cs),
+(146,690,l),
+(-1,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(203,296,l),
+(256,296,l),
+(270,268,o),
+(300,248,o),
+(333,248,cs),
+(383,248,o),
+(419,288,o),
+(424,337,c),
+(334,296,l),
+(362,296,ls),
+(411,296,o),
+(431,269,o),
+(431,225,cs),
+(431,176,o),
+(405,114,o),
+(321,114,cs),
+(164,114,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(416,576,ls),
+(465,576,o),
+(492,546,o),
+(492,501,cs),
+(492,450,o),
+(469,395,o),
+(387,395,cs),
+(344,395,l),
+(425,353,l),
+(420,403,o),
+(384,441,o),
+(333,441,cs),
+(285,441,o),
+(245,403,o),
+(243,353,c),
+(279,395,l),
+(224,395,l),
+(263,576,l)
+);
+}
+);
+width = 628;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F9;
+unicode = 5625;
+},
+{
+color = 9;
+glyphname = "khaCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(525,0,l),
+(672,690,l),
+(357,690,ls),
+(195,690,o),
+(102,605,o),
+(102,473,cs),
+(102,410,o),
+(133,358,o),
+(193,329,c),
+(200,376,l),
+(76,341,o),
+(37,248,o),
+(37,168,cs),
+(37,66,o),
+(113,0,o),
+(226,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(206,114,o),
+(179,143,o),
+(179,185,cs),
+(179,237,o),
+(209,289,o),
+(290,289,cs),
+(445,289,l),
+(409,114,l),
+(254,114,ls)
+);
+},
+{
+closed = 1;
+nodes = (
+(267,401,o),
+(241,426,o),
+(241,469,cs),
+(241,516,o),
+(267,576,o),
+(351,576,cs),
+(507,576,l),
+(469,401,l),
+(315,401,ls)
+);
+}
+);
+width = 628;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15FA;
+unicode = 5626;
+},
+{
+color = 9;
+glyphname = "kkuCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(257,-14,o),
+(314,23,o),
+(357,101,c),
+(311,102,l),
+(328,27,o),
+(377,-14,o),
+(457,-14,cs),
+(570,-14,o),
+(631,52,o),
+(658,182,cs),
+(766,690,l),
+(725,690,l),
+(467,561,l),
+(439,417,l),
+(647,519,l),
+(604,564,l),
+(524,185,ls),
+(514,137,o),
+(492,114,o),
+(457,114,cs),
+(420,114,o),
+(403,142,o),
+(412,187,cs),
+(520,690,l),
+(389,690,l),
+(283,185,ls),
+(272,138,o),
+(248,114,o),
+(213,114,cs),
+(177,114,o),
+(161,140,o),
+(171,187,cs),
+(251,565,l),
+(186,540,l),
+(351,433,l),
+(379,563,l),
+(184,690,l),
+(143,690,l),
+(38,192,ls),
+(11,65,o),
+(64,-14,o),
+(181,-14,cs)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FB;
+unicode = 5627;
+},
+{
+color = 9;
+glyphname = "kkoCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(38,0,l),
+(296,128,l),
+(324,272,l),
+(115,171,l),
+(158,126,l),
+(239,505,ls),
+(249,553,o),
+(270,576,o),
+(304,576,cs),
+(341,576,o),
+(358,548,o),
+(350,502,cs),
+(242,0,l),
+(372,0,l),
+(479,504,ls),
+(489,552,o),
+(514,576,o),
+(549,576,cs),
+(585,576,o),
+(601,550,o),
+(590,502,cs),
+(510,125,l),
+(576,150,l),
+(411,257,l),
+(384,127,l),
+(578,0,l),
+(619,0,l),
+(725,497,ls),
+(752,625,o),
+(698,703,o),
+(582,703,cs),
+(505,703,o),
+(447,667,o),
+(405,588,c),
+(451,587,l),
+(434,663,o),
+(385,703,o),
+(304,703,cs),
+(192,703,o),
+(131,638,o),
+(104,508,cs),
+(-3,0,l)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FC;
+unicode = 5628;
+},
+{
+color = 9;
+glyphname = "kkeCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(327,0,ls),
+(489,0,o),
+(582,86,o),
+(582,216,cs),
+(582,282,o),
+(551,331,o),
+(491,360,c),
+(484,314,l),
+(608,349,o),
+(646,441,o),
+(646,522,cs),
+(646,624,o),
+(571,690,o),
+(458,690,cs),
+(144,690,l),
+(136,655,l),
+(164,402,l),
+(92,402,l),
+(68,288,l),
+(132,288,l),
+(5,35,l),
+(-3,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(274,288,l),
+(369,288,ls),
+(417,288,o),
+(444,263,o),
+(444,221,cs),
+(444,179,o),
+(423,116,o),
+(333,116,cs),
+(129,116,l),
+(160,59,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(270,639,l),
+(215,574,l),
+(430,574,ls),
+(478,574,o),
+(505,547,o),
+(505,504,cs),
+(505,445,o),
+(469,402,o),
+(394,402,cs),
+(298,402,l)
+);
+}
+);
+width = 642;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni15FD;
+unicode = 5629;
+},
+{
+color = 9;
+glyphname = "kkeeCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(327,0,ls),
+(489,0,o),
+(582,86,o),
+(582,216,cs),
+(582,282,o),
+(551,331,o),
+(491,360,c),
+(484,314,l),
+(608,349,o),
+(646,441,o),
+(646,522,cs),
+(646,624,o),
+(571,690,o),
+(458,690,cs),
+(144,690,l),
+(136,655,l),
+(164,402,l),
+(92,402,l),
+(68,288,l),
+(132,288,l),
+(5,35,l),
+(-3,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(276,293,l),
+(313,293,l),
+(296,211,l),
+(372,211,l),
+(395,319,l),
+(356,293,l),
+(382,293,ls),
+(424,293,o),
+(444,263,o),
+(444,221,cs),
+(444,179,o),
+(423,116,o),
+(333,116,cs),
+(129,116,l),
+(160,59,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(429,480,l),
+(353,480,l),
+(335,398,l),
+(298,398,l),
+(270,639,l),
+(215,574,l),
+(430,574,ls),
+(478,574,o),
+(505,547,o),
+(505,504,cs),
+(505,445,o),
+(469,398,o),
+(400,398,cs),
+(376,398,l),
+(409,381,l)
+);
+}
+);
+width = 642;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FE;
+unicode = 5630;
+},
+{
+color = 9;
+glyphname = "kkiCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(327,0,ls),
+(489,0,o),
+(582,86,o),
+(582,216,cs),
+(582,282,o),
+(551,331,o),
+(491,360,c),
+(484,314,l),
+(608,349,o),
+(646,441,o),
+(646,522,cs),
+(646,624,o),
+(571,690,o),
+(458,690,cs),
+(144,690,l),
+(136,655,l),
+(164,402,l),
+(92,402,l),
+(68,288,l),
+(132,288,l),
+(5,35,l),
+(-3,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(279,298,l),
+(281,298,l),
+(295,268,o),
+(324,248,o),
+(358,248,cs),
+(396,248,o),
+(427,273,o),
+(439,308,c),
+(352,298,l),
+(382,298,ls),
+(431,298,o),
+(444,263,o),
+(444,221,cs),
+(444,179,o),
+(423,116,o),
+(333,116,cs),
+(129,116,l),
+(160,59,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(433,414,o),
+(400,441,o),
+(358,441,cs),
+(324,441,o),
+(295,422,o),
+(281,391,c),
+(300,391,l),
+(270,639,l),
+(215,574,l),
+(430,574,ls),
+(478,574,o),
+(505,547,o),
+(505,504,cs),
+(505,445,o),
+(475,391,o),
+(400,391,cs),
+(353,391,l),
+(441,375,l)
+);
+}
+);
+width = 642;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FF;
+unicode = 5631;
+},
+{
+color = 9;
+glyphname = "kkaCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(540,0,l),
+(548,35,l),
+(520,288,l),
+(592,288,l),
+(616,402,l),
+(552,402,l),
+(679,655,l),
+(687,690,l),
+(357,690,ls),
+(195,690,o),
+(102,604,o),
+(102,473,cs),
+(102,408,o),
+(133,358,o),
+(193,329,c),
+(200,376,l),
+(76,341,o),
+(38,248,o),
+(38,168,cs),
+(38,66,o),
+(113,0,o),
+(226,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(469,116,l),
+(254,116,ls),
+(207,116,o),
+(179,143,o),
+(179,185,cs),
+(179,244,o),
+(215,288,o),
+(290,288,cs),
+(385,288,l),
+(413,51,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(267,402,o),
+(240,427,o),
+(240,469,cs),
+(240,511,o),
+(261,574,o),
+(351,574,cs),
+(554,574,l),
+(524,631,l),
+(410,402,l),
+(315,402,ls)
+);
+}
+);
+width = 642;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|kkeCarrier-canadian";
+note = uni1600;
+unicode = 5632;
+},
+{
+color = 6;
+glyphname = "kkCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(280,527,l),
+(145,289,l),
+(205,289,l),
+(171,527,l),
+(84,527,l),
+(81,510,l),
+(145,183,l),
+(166,183,l),
+(370,510,l),
+(374,527,l)
+);
+}
+);
+width = 338;
+}
+);
+note = uni1601;
+unicode = 5633;
+},
+{
+color = 9;
+glyphname = "nuCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(435,-14,o),
+(534,78,o),
+(570,242,cs),
+(583,308,l),
+(442,308,l),
+(430,250,ls),
+(412,161,o),
+(367,117,o),
+(294,117,cs),
+(211,116,o),
+(175,171,o),
+(196,268,cs),
+(286,690,l),
+(143,690,l),
+(55,276,ls),
+(18,102,o),
+(106,-14,o),
+(282,-14,cs)
+);
+}
+);
+width = 609;
+}
+);
+metricLeft = "te-canadian";
+note = uni1602;
+unicode = 5634;
+},
+{
+color = 9;
+glyphname = "noCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(507,0,l),
+(595,413,ls),
+(632,587,o),
+(544,703,o),
+(369,703,cs),
+(216,703,o),
+(117,611,o),
+(81,447,cs),
+(67,382,l),
+(208,382,l),
+(220,440,ls),
+(240,528,o),
+(284,573,o),
+(356,573,cs),
+(439,574,o),
+(475,519,o),
+(455,422,cs),
+(365,0,l)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "=|nuCarrier-canadian";
+metricRight = "te-canadian";
+note = uni1603;
+unicode = 5635;
+},
+{
+color = 9;
+glyphname = "neCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (298,345);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(212,0,ls),
+(489,0,o),
+(604,213,o),
+(604,419,cs),
+(604,589,o),
+(502,690,o),
+(324,690,cs),
+(128,690,l),
+(100,560,l),
+(300,560,ls),
+(407,560,o),
+(463,507,o),
+(463,409,cs),
+(463,298,o),
+(410,129,o),
+(225,129,cs),
+(214,129,l),
+(187,0,l)
+);
+}
+);
+width = 621;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1604;
+unicode = 5636;
+},
+{
+color = 9;
+glyphname = "neeCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "neCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (220,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 621;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1605;
+unicode = 5637;
+},
+{
+color = 9;
+glyphname = "niCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "neCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (193,0);
+ref = dot_middle;
+}
+);
+width = 620;
+}
+);
+note = uni1606;
+unicode = 5638;
+},
+{
+color = 9;
+glyphname = "naCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(536,0,l),
+(563,129,l),
+(363,129,ls),
+(257,129,o),
+(201,183,o),
+(201,281,cs),
+(201,391,o),
+(255,560,o),
+(439,560,cs),
+(450,560,l),
+(477,690,l),
+(452,690,ls),
+(176,690,o),
+(60,477,o),
+(60,270,cs),
+(60,100,o),
+(161,0,o),
+(340,0,cs)
+);
+}
+);
+width = 621;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni1607;
+unicode = 5639;
+},
+{
+color = 9;
+glyphname = "muCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(262,-14,o),
+(323,28,o),
+(366,118,c),
+(309,118,l),
+(323,32,o),
+(373,-14,o),
+(457,-14,cs),
+(570,-14,o),
+(631,53,o),
+(658,182,cs),
+(703,394,l),
+(567,394,l),
+(523,185,ls),
+(513,137,o),
+(491,114,o),
+(458,114,cs),
+(421,114,o),
+(405,141,o),
+(414,186,cs),
+(458,394,l),
+(326,394,l),
+(281,185,ls),
+(270,138,o),
+(247,114,o),
+(213,114,cs),
+(178,114,o),
+(162,140,o),
+(172,187,cs),
+(279,690,l),
+(143,690,l),
+(38,192,ls),
+(11,66,o),
+(64,-14,o),
+(181,-14,cs)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "=|";
+note = uni1608;
+unicode = 5640;
+},
+{
+color = 9;
+glyphname = "moCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(619,0,l),
+(725,497,ls),
+(752,624,o),
+(698,703,o),
+(582,703,cs),
+(499,703,o),
+(440,662,o),
+(395,572,c),
+(453,572,l),
+(440,658,o),
+(389,703,o),
+(304,703,cs),
+(192,703,o),
+(132,637,o),
+(104,508,cs),
+(59,296,l),
+(195,296,l),
+(240,505,ls),
+(250,553,o),
+(270,576,o),
+(304,576,cs),
+(341,576,o),
+(357,549,o),
+(348,503,cs),
+(303,296,l),
+(437,296,l),
+(481,504,ls),
+(491,552,o),
+(514,576,o),
+(549,576,cs),
+(584,576,o),
+(600,550,o),
+(589,502,cs),
+(483,0,l)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "=|muCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni1609;
+unicode = 5641;
+},
+{
+color = 9;
+glyphname = "meCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(311,0,ls),
+(473,0,o),
+(566,86,o),
+(566,216,cs),
+(566,282,o),
+(533,334,o),
+(471,363,c),
+(462,312,l),
+(576,342,o),
+(631,424,o),
+(631,522,cs),
+(631,624,o),
+(555,690,o),
+(442,690,cs),
+(129,690,l),
+(103,574,l),
+(414,574,ls),
+(462,574,o),
+(490,547,o),
+(490,504,cs),
+(490,445,o),
+(453,402,o),
+(379,402,cs),
+(275,402,l),
+(251,288,l),
+(354,288,ls),
+(402,288,o),
+(429,263,o),
+(429,221,cs),
+(429,179,o),
+(407,116,o),
+(318,116,cs),
+(214,116,l),
+(190,0,l)
+);
+}
+);
+width = 626;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160A;
+unicode = 5642;
+},
+{
+color = 9;
+glyphname = "meeCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(311,0,ls),
+(473,0,o),
+(566,86,o),
+(566,216,cs),
+(566,282,o),
+(533,334,o),
+(471,363,c),
+(462,312,l),
+(576,342,o),
+(631,424,o),
+(631,522,cs),
+(631,624,o),
+(555,690,o),
+(442,690,cs),
+(129,690,l),
+(103,574,l),
+(414,574,ls),
+(462,574,o),
+(490,547,o),
+(490,504,cs),
+(490,445,o),
+(453,399,o),
+(381,399,cs),
+(357,399,l),
+(374,472,l),
+(291,472,l),
+(237,217,l),
+(319,217,l),
+(335,291,l),
+(358,291,ls),
+(403,291,o),
+(429,263,o),
+(429,221,cs),
+(429,179,o),
+(407,116,o),
+(318,116,cs),
+(214,116,l),
+(190,0,l)
+);
+}
+);
+width = 626;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160B;
+unicode = 5643;
+},
+{
+color = 9;
+glyphname = "miCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(311,0,ls),
+(465,0,o),
+(544,71,o),
+(562,180,cs),
+(576,264,o),
+(545,327,o),
+(471,363,c),
+(462,312,l),
+(563,338,o),
+(613,403,o),
+(627,486,cs),
+(648,605,o),
+(571,690,o),
+(442,690,cs),
+(129,690,l),
+(103,574,l),
+(414,574,ls),
+(466,574,o),
+(495,541,o),
+(488,491,cs),
+(481,436,o),
+(445,399,o),
+(378,399,cs),
+(326,399,l),
+(403,358,l),
+(397,407,o),
+(360,442,o),
+(310,442,cs),
+(257,442,o),
+(216,397,o),
+(216,345,cs),
+(216,291,o),
+(257,248,o),
+(310,248,cs),
+(359,248,o),
+(396,284,o),
+(403,330,c),
+(324,291,l),
+(355,291,ls),
+(408,291,o),
+(435,261,o),
+(428,209,cs),
+(420,159,o),
+(391,116,o),
+(318,116,cs),
+(214,116,l),
+(190,0,l)
+);
+}
+);
+width = 624;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160C;
+unicode = 5644;
+},
+{
+color = 9;
+glyphname = "maCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(541,0,l),
+(566,116,l),
+(254,116,ls),
+(207,116,o),
+(179,143,o),
+(179,185,cs),
+(179,244,o),
+(215,288,o),
+(290,288,cs),
+(392,288,l),
+(416,402,l),
+(315,402,ls),
+(267,402,o),
+(240,427,o),
+(240,469,cs),
+(240,511,o),
+(261,574,o),
+(351,574,cs),
+(453,574,l),
+(478,690,l),
+(357,690,ls),
+(195,690,o),
+(102,604,o),
+(102,473,cs),
+(102,408,o),
+(134,355,o),
+(196,327,c),
+(207,378,l),
+(93,348,o),
+(38,266,o),
+(38,168,cs),
+(38,66,o),
+(113,0,o),
+(226,0,cs)
+);
+}
+);
+width = 626;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni160D;
+unicode = 5645;
+},
+{
+color = 9;
+glyphname = "yuCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(469,-14,o),
+(589,111,o),
+(642,357,cs),
+(689,580,o),
+(643,703,o),
+(508,703,cs),
+(359,703,o),
+(304,549,o),
+(304,443,cs),
+(304,353,o),
+(351,293,o),
+(425,293,cs),
+(438,293,o),
+(449,295,o),
+(459,298,c),
+(481,408,l),
+(476,407,o),
+(471,406,o),
+(466,406,cs),
+(440,406,o),
+(426,424,o),
+(426,458,cs),
+(426,496,o),
+(442,590,o),
+(492,590,cs),
+(538,590,o),
+(544,527,o),
+(517,400,cs),
+(475,201,o),
+(414,117,o),
+(303,117,cs),
+(213,117,o),
+(177,174,o),
+(198,275,cs),
+(286,690,l),
+(143,690,l),
+(58,286,ls),
+(20,107,o),
+(110,-14,o),
+(290,-14,cs)
+);
+}
+);
+width = 666;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160E;
+unicode = 5646;
+},
+{
+color = 9;
+glyphname = "yoCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(350,-14,o),
+(405,141,o),
+(405,246,cs),
+(405,337,o),
+(359,397,o),
+(285,397,cs),
+(272,397,o),
+(261,395,o),
+(251,391,c),
+(228,282,l),
+(233,283,o),
+(238,284,o),
+(243,284,cs),
+(270,284,o),
+(283,266,o),
+(283,232,cs),
+(283,194,o),
+(267,99,o),
+(217,99,cs),
+(172,99,o),
+(166,162,o),
+(192,290,cs),
+(234,489,o),
+(296,573,o),
+(406,573,cs),
+(497,573,o),
+(533,516,o),
+(512,414,cs),
+(424,0,l),
+(566,0,l),
+(652,404,ls),
+(690,582,o),
+(599,703,o),
+(420,703,cs),
+(241,703,o),
+(120,579,o),
+(67,332,cs),
+(20,110,o),
+(66,-14,o),
+(201,-14,cs)
+);
+}
+);
+width = 666;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160F;
+unicode = 5647;
+},
+{
+color = 9;
+glyphname = "yeCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(494,-14,o),
+(597,243,o),
+(597,417,cs),
+(597,594,o),
+(498,690,o),
+(319,690,cs),
+(144,690,l),
+(117,560,l),
+(295,560,ls),
+(400,560,o),
+(453,508,o),
+(453,404,cs),
+(453,298,o),
+(410,106,o),
+(259,106,cs),
+(190,106,o),
+(150,141,o),
+(150,202,cs),
+(150,237,o),
+(165,306,o),
+(214,306,cs),
+(239,306,o),
+(252,290,o),
+(252,257,cs),
+(252,233,o),
+(245,203,o),
+(237,179,c),
+(343,179,l),
+(355,210,o),
+(363,247,o),
+(363,280,cs),
+(363,365,o),
+(311,419,o),
+(222,419,cs),
+(86,419,o),
+(30,284,o),
+(30,183,cs),
+(30,64,o),
+(114,-14,o),
+(253,-14,cs)
+);
+}
+);
+width = 613;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1610;
+unicode = 5648;
+},
+{
+color = 9;
+glyphname = "yeeCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(494,-14,o),
+(597,244,o),
+(597,419,cs),
+(597,594,o),
+(497,690,o),
+(320,690,cs),
+(144,690,l),
+(117,560,l),
+(295,560,ls),
+(400,560,o),
+(453,508,o),
+(453,404,cs),
+(453,309,o),
+(413,106,o),
+(259,106,cs),
+(189,106,o),
+(150,139,o),
+(150,200,cs),
+(150,237,o),
+(166,306,o),
+(213,306,cs),
+(242,306,o),
+(254,278,o),
+(244,232,cs),
+(235,187,l),
+(316,187,l),
+(381,488,l),
+(298,488,l),
+(263,320,l),
+(277,319,l),
+(287,378,o),
+(252,419,o),
+(192,419,cs),
+(80,419,o),
+(32,284,o),
+(32,191,cs),
+(32,68,o),
+(114,-14,o),
+(258,-14,cs)
+);
+}
+);
+width = 613;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1611;
+unicode = 5649;
+},
+{
+color = 9;
+glyphname = "yiCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(496,-14,o),
+(597,242,o),
+(597,419,cs),
+(597,594,o),
+(498,690,o),
+(320,690,cs),
+(144,690,l),
+(117,560,l),
+(295,560,ls),
+(400,560,o),
+(453,508,o),
+(453,404,cs),
+(453,305,o),
+(412,106,o),
+(259,106,cs),
+(187,106,o),
+(148,142,o),
+(148,201,cs),
+(148,258,o),
+(175,308,o),
+(232,305,c),
+(201,344,l),
+(201,296,o),
+(242,260,o),
+(290,260,cs),
+(341,260,o),
+(379,298,o),
+(379,346,cs),
+(379,394,o),
+(341,431,o),
+(290,431,cs),
+(258,431,o),
+(231,416,o),
+(215,393,c),
+(95,383,o),
+(27,289,o),
+(27,181,cs),
+(27,66,o),
+(116,-14,o),
+(251,-14,cs)
+);
+}
+);
+width = 613;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1612;
+unicode = 5650;
+},
+{
+color = 9;
+glyphname = "yaCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(512,0,l),
+(540,129,l),
+(362,129,ls),
+(257,129,o),
+(203,182,o),
+(203,286,cs),
+(203,392,o),
+(246,583,o),
+(397,583,cs),
+(467,583,o),
+(506,549,o),
+(506,488,cs),
+(506,453,o),
+(492,384,o),
+(442,384,cs),
+(417,384,o),
+(405,400,o),
+(405,433,cs),
+(405,459,o),
+(412,487,o),
+(419,511,c),
+(314,511,l),
+(301,480,o),
+(293,442,o),
+(293,410,cs),
+(293,325,o),
+(346,270,o),
+(434,270,cs),
+(571,270,o),
+(627,406,o),
+(627,507,cs),
+(627,626,o),
+(542,703,o),
+(404,703,cs),
+(163,703,o),
+(59,446,o),
+(59,272,cs),
+(59,96,o),
+(158,0,o),
+(338,0,cs)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|yeCarrier-canadian";
+note = uni1613;
+unicode = 5651;
+},
+{
+color = 9;
+glyphname = "juCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(487,-14,o),
+(581,118,o),
+(581,257,cs),
+(581,354,o),
+(525,419,o),
+(433,419,cs),
+(321,419,o),
+(269,327,o),
+(261,231,cs),
+(259,211,o),
+(258,191,o),
+(260,179,c),
+(366,179,l),
+(366,193,o),
+(366,213,o),
+(371,238,cs),
+(379,277,o),
+(396,306,o),
+(424,306,cs),
+(449,306,o),
+(462,287,o),
+(462,253,cs),
+(462,188,o),
+(428,106,o),
+(327,106,cs),
+(241,106,o),
+(195,154,o),
+(195,240,cs),
+(195,407,o),
+(315,560,o),
+(543,560,cs),
+(640,560,l),
+(668,690,l),
+(136,690,l),
+(109,565,l),
+(334,565,l),
+(445,615,l),
+(208,603,o),
+(56,454,o),
+(56,238,cs),
+(56,86,o),
+(155,-14,o),
+(311,-14,cs)
+);
+}
+);
+width = 622;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni1614;
+unicode = 5652;
+},
+{
+color = 9;
+glyphname = "juSayisi-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (412,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(442,-14,o),
+(556,133,o),
+(580,308,cs),
+(605,490,o),
+(513,607,o),
+(322,620,c),
+(418,565,l),
+(646,565,l),
+(672,690,l),
+(140,690,l),
+(113,560,l),
+(213,560,ls),
+(395,560,o),
+(464,482,o),
+(441,324,cs),
+(428,217,o),
+(384,106,o),
+(263,106,cs),
+(183,106,o),
+(142,148,o),
+(151,221,cs),
+(155,260,o),
+(173,306,o),
+(209,306,cs),
+(238,306,o),
+(247,283,o),
+(243,240,cs),
+(242,219,o),
+(238,199,o),
+(230,179,c),
+(335,179,l),
+(346,204,o),
+(353,228,o),
+(355,256,cs),
+(367,355,o),
+(316,419,o),
+(218,419,cs),
+(113,419,o),
+(48,334,o),
+(34,228,cs),
+(13,87,o),
+(102,-14,o),
+(258,-14,cs)
+);
+}
+);
+width = 619;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1615;
+unicode = 5653;
+},
+{
+color = 9;
+glyphname = "joCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(527,0,l),
+(554,125,l),
+(329,125,l),
+(218,74,l),
+(456,87,o),
+(608,236,o),
+(608,452,cs),
+(608,604,o),
+(509,703,o),
+(353,703,cs),
+(177,703,o),
+(84,572,o),
+(84,433,cs),
+(84,336,o),
+(139,270,o),
+(231,270,cs),
+(343,270,o),
+(395,363,o),
+(403,459,cs),
+(405,479,o),
+(405,498,o),
+(404,511,c),
+(298,511,l),
+(298,497,o),
+(298,476,o),
+(293,452,cs),
+(285,412,o),
+(268,384,o),
+(240,384,cs),
+(214,384,o),
+(202,403,o),
+(202,437,cs),
+(202,501,o),
+(236,583,o),
+(337,583,cs),
+(423,583,o),
+(468,536,o),
+(468,450,cs),
+(468,283,o),
+(349,129,o),
+(121,129,cs),
+(23,129,l),
+(-5,0,l)
+);
+}
+);
+width = 620;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1616;
+unicode = 5654;
+},
+{
+color = 9;
+glyphname = "jeCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(586,-14,o),
+(643,282,o),
+(643,433,cs),
+(643,598,o),
+(574,703,o),
+(449,703,cs),
+(342,703,o),
+(260,625,o),
+(216,478,c),
+(242,476,l),
+(287,690,l),
+(146,690,l),
+(-1,0,l),
+(141,0,l),
+(208,312,ls),
+(242,479,o),
+(314,573,o),
+(408,573,cs),
+(476,573,o),
+(509,525,o),
+(509,428,cs),
+(509,354,o),
+(475,99,o),
+(401,99,cs),
+(377,99,o),
+(363,117,o),
+(363,150,cs),
+(363,192,o),
+(384,284,o),
+(441,284,cs),
+(447,284,o),
+(454,283,o),
+(458,282,c),
+(478,391,l),
+(466,395,o),
+(451,397,o),
+(435,397,cs),
+(298,397,o),
+(244,243,o),
+(244,143,cs),
+(244,46,o),
+(298,-14,o),
+(391,-14,cs)
+);
+}
+);
+width = 668;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "te-canadian";
+note = uni1617;
+unicode = 5655;
+},
+{
+color = 9;
+glyphname = "jeeCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(586,-14,o),
+(643,286,o),
+(643,431,cs),
+(643,598,o),
+(574,703,o),
+(449,703,cs),
+(341,703,o),
+(260,624,o),
+(216,477,c),
+(242,476,l),
+(287,690,l),
+(146,690,l),
+(-1,0,l),
+(141,0,l),
+(205,299,ls),
+(244,482,o),
+(311,573,o),
+(406,573,cs),
+(476,573,o),
+(509,525,o),
+(509,426,cs),
+(509,308,o),
+(471,99,o),
+(378,99,cs),
+(335,99,o),
+(313,127,o),
+(313,174,cs),
+(313,213,o),
+(328,279,o),
+(372,301,c),
+(356,230,l),
+(424,230,l),
+(469,449,l),
+(403,449,l),
+(387,375,l),
+(283,348,o),
+(243,221,o),
+(243,140,cs),
+(243,46,o),
+(298,-14,o),
+(391,-14,cs)
+);
+}
+);
+width = 668;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1618;
+unicode = 5656;
+},
+{
+color = 9;
+glyphname = "jiCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(586,-14,o),
+(643,286,o),
+(643,431,cs),
+(643,598,o),
+(574,703,o),
+(449,703,cs),
+(341,703,o),
+(260,624,o),
+(216,477,c),
+(242,476,l),
+(287,690,l),
+(146,690,l),
+(-1,0,l),
+(141,0,l),
+(205,299,ls),
+(244,482,o),
+(311,573,o),
+(406,573,cs),
+(476,573,o),
+(509,525,o),
+(509,426,cs),
+(509,308,o),
+(471,99,o),
+(378,99,cs),
+(335,99,o),
+(313,127,o),
+(313,174,cs),
+(313,203,o),
+(322,247,o),
+(347,271,c),
+(357,262,o),
+(373,255,o),
+(390,255,cs),
+(437,255,o),
+(469,293,o),
+(469,340,cs),
+(469,388,o),
+(436,424,o),
+(390,424,cs),
+(338,424,o),
+(303,376,o),
+(313,324,c),
+(263,277,o),
+(243,197,o),
+(243,140,cs),
+(243,46,o),
+(298,-14,o),
+(391,-14,cs)
+);
+}
+);
+width = 668;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1619;
+unicode = 5657;
+},
+{
+color = 9;
+glyphname = "jiSayisi-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(561,-14,o),
+(662,325,o),
+(662,503,cs),
+(662,634,o),
+(609,703,o),
+(507,703,cs),
+(359,703,o),
+(308,544,o),
+(308,442,cs),
+(308,350,o),
+(355,293,o),
+(425,293,cs),
+(441,293,o),
+(451,295,o),
+(459,298,c),
+(484,408,l),
+(479,407,o),
+(474,406,o),
+(468,406,cs),
+(442,407,o),
+(428,423,o),
+(428,459,cs),
+(428,492,o),
+(445,590,o),
+(496,590,cs),
+(522,590,o),
+(533,568,o),
+(533,520,cs),
+(533,439,o),
+(483,117,o),
+(323,117,cs),
+(195,117,o),
+(199,271,o),
+(224,388,cs),
+(288,690,l),
+(146,690,l),
+(-1,0,l),
+(140,0,l),
+(193,250,l),
+(165,253,l),
+(141,117,o),
+(191,-14,o),
+(333,-14,cs)
+);
+}
+);
+width = 669;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161A;
+unicode = 5658;
+},
+{
+color = 9;
+glyphname = "jaCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (421,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(369,-14,o),
+(451,66,o),
+(495,213,c),
+(469,214,l),
+(424,1,l),
+(565,1,l),
+(712,691,l),
+(570,691,l),
+(503,379,ls),
+(468,212,o),
+(397,117,o),
+(303,117,cs),
+(235,117,o),
+(202,166,o),
+(202,263,cs),
+(202,336,o),
+(236,591,o),
+(310,591,cs),
+(334,591,o),
+(348,573,o),
+(348,541,cs),
+(348,498,o),
+(326,407,o),
+(269,407,cs),
+(263,407,o),
+(257,408,o),
+(253,409,c),
+(233,299,l),
+(245,296,o),
+(260,294,o),
+(276,294,cs),
+(413,294,o),
+(467,446,o),
+(467,548,cs),
+(467,644,o),
+(412,704,o),
+(320,704,cs),
+(125,704,o),
+(68,409,o),
+(68,257,cs),
+(68,93,o),
+(137,-14,o),
+(262,-14,cs)
+);
+}
+);
+width = 668;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni161B;
+unicode = 5659;
+},
+{
+color = 9;
+glyphname = "jjuCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(474,-14,o),
+(578,116,o),
+(578,262,cs),
+(578,356,o),
+(522,419,o),
+(432,419,cs),
+(342,419,o),
+(283,357,o),
+(260,253,cs),
+(254,227,o),
+(251,199,o),
+(251,179,c),
+(357,179,l),
+(358,188,o),
+(361,212,o),
+(366,234,cs),
+(377,280,o),
+(395,306,o),
+(423,306,cs),
+(447,306,o),
+(459,287,o),
+(459,256,cs),
+(459,192,o),
+(423,103,o),
+(322,103,cs),
+(240,103,o),
+(196,153,o),
+(196,242,cs),
+(196,421,o),
+(303,560,o),
+(505,560,cs),
+(635,560,l),
+(663,690,l),
+(527,690,ls),
+(426,690,o),
+(335,665,o),
+(263,621,c),
+(200,703,l),
+(86,616,l),
+(154,529,l),
+(89,453,o),
+(58,350,o),
+(58,248,cs),
+(58,92,o),
+(154,-14,o),
+(307,-14,cs)
+);
+}
+);
+width = 618;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni161C;
+unicode = 5660;
+},
+{
+color = 9;
+glyphname = "jjoCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(575,73,l),
+(507,160,l),
+(572,237,o),
+(603,340,o),
+(603,441,cs),
+(603,598,o),
+(507,703,o),
+(353,703,cs),
+(186,703,o),
+(83,574,o),
+(83,428,cs),
+(83,333,o),
+(139,270,o),
+(228,270,cs),
+(318,270,o),
+(378,332,o),
+(401,437,cs),
+(407,463,o),
+(410,491,o),
+(410,511,c),
+(303,511,l),
+(302,501,o),
+(299,478,o),
+(295,456,cs),
+(284,410,o),
+(266,384,o),
+(238,384,cs),
+(214,384,o),
+(202,403,o),
+(202,434,cs),
+(202,497,o),
+(237,586,o),
+(339,586,cs),
+(421,586,o),
+(465,537,o),
+(465,447,cs),
+(465,269,o),
+(357,129,o),
+(155,129,cs),
+(25,129,l),
+(-2,0,l),
+(133,0,ls),
+(235,0,o),
+(325,25,o),
+(398,69,c),
+(461,-14,l)
+);
+}
+);
+width = 618;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|jjuCarrier-canadian";
+note = uni161D;
+unicode = 5661;
+},
+{
+color = 9;
+glyphname = "jjeCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(596,-14,o),
+(652,283,o),
+(652,431,cs),
+(652,607,o),
+(568,703,o),
+(416,703,cs),
+(351,703,o),
+(289,684,o),
+(237,642,c),
+(183,703,l),
+(77,606,l),
+(144,531,l),
+(120,489,o),
+(101,439,o),
+(88,379,cs),
+(8,0,l),
+(150,0,l),
+(230,376,ls),
+(258,506,o),
+(317,573,o),
+(407,573,cs),
+(482,573,o),
+(518,526,o),
+(518,428,cs),
+(518,356,o),
+(484,99,o),
+(410,99,cs),
+(384,99,o),
+(372,117,o),
+(372,151,cs),
+(372,192,o),
+(393,284,o),
+(448,284,cs),
+(456,284,o),
+(462,283,o),
+(467,282,c),
+(487,391,l),
+(476,395,o),
+(460,397,o),
+(444,397,cs),
+(306,397,o),
+(253,244,o),
+(253,144,cs),
+(253,46,o),
+(306,-14,o),
+(400,-14,cs)
+);
+}
+);
+width = 677;
+}
+);
+metricRight = "jeCarrier-canadian";
+note = uni161E;
+unicode = 5662;
+},
+{
+color = 9;
+glyphname = "jjeeCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(596,-14,o),
+(652,283,o),
+(652,431,cs),
+(652,607,o),
+(568,703,o),
+(416,703,cs),
+(351,703,o),
+(289,684,o),
+(237,642,c),
+(183,703,l),
+(77,606,l),
+(144,531,l),
+(120,489,o),
+(101,439,o),
+(88,379,cs),
+(8,0,l),
+(150,0,l),
+(230,376,ls),
+(258,506,o),
+(317,573,o),
+(407,573,cs),
+(482,573,o),
+(518,526,o),
+(518,428,cs),
+(518,340,o),
+(489,99,o),
+(390,99,cs),
+(350,99,o),
+(322,124,o),
+(322,175,cs),
+(322,228,o),
+(341,286,o),
+(381,303,c),
+(365,230,l),
+(432,230,l),
+(478,448,l),
+(412,448,l),
+(396,374,l),
+(295,348,o),
+(253,231,o),
+(253,144,cs),
+(253,46,o),
+(306,-14,o),
+(400,-14,cs)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161F;
+unicode = 5663;
+},
+{
+color = 9;
+glyphname = "jjiCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(520,-14,o),
+(596,91,o),
+(636,279,cs),
+(691,544,o),
+(608,703,o),
+(416,703,cs),
+(348,703,o),
+(287,683,o),
+(237,643,c),
+(183,703,l),
+(77,606,l),
+(144,532,l),
+(120,490,o),
+(100,438,o),
+(88,379,cs),
+(8,0,l),
+(150,0,l),
+(230,376,ls),
+(258,506,o),
+(317,573,o),
+(407,573,cs),
+(510,573,o),
+(543,481,o),
+(502,288,cs),
+(475,158,o),
+(445,99,o),
+(386,99,cs),
+(333,99,o),
+(312,144,o),
+(327,215,cs),
+(331,242,o),
+(340,262,o),
+(355,272,c),
+(366,262,o),
+(383,255,o),
+(401,255,cs),
+(447,255,o),
+(480,293,o),
+(480,340,cs),
+(480,387,o),
+(446,424,o),
+(401,424,cs),
+(341,424,o),
+(316,366,o),
+(324,324,c),
+(292,297,o),
+(270,253,o),
+(259,199,cs),
+(232,71,o),
+(290,-14,o),
+(399,-14,cs)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1620;
+unicode = 5664;
+},
+{
+color = 9;
+glyphname = "jjaCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(369,-14,o),
+(431,6,o),
+(483,47,c),
+(537,-14,l),
+(642,84,l),
+(576,158,l),
+(600,201,o),
+(618,251,o),
+(632,311,cs),
+(712,690,l),
+(570,690,l),
+(490,314,ls),
+(462,184,o),
+(403,117,o),
+(313,117,cs),
+(238,117,o),
+(202,163,o),
+(202,262,cs),
+(202,333,o),
+(236,590,o),
+(310,590,cs),
+(335,590,o),
+(348,573,o),
+(348,539,cs),
+(348,497,o),
+(326,406,o),
+(271,406,cs),
+(264,406,o),
+(258,407,o),
+(253,408,c),
+(233,298,l),
+(243,295,o),
+(260,293,o),
+(275,293,cs),
+(413,293,o),
+(467,445,o),
+(467,546,cs),
+(467,643,o),
+(412,703,o),
+(320,703,cs),
+(124,703,o),
+(68,407,o),
+(68,259,cs),
+(68,83,o),
+(152,-14,o),
+(303,-14,cs)
+);
+}
+);
+width = 676;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "=|jjeCarrier-canadian";
+note = uni1621;
+unicode = 5665;
+},
+{
+color = 9;
+glyphname = "luCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(442,-14,o),
+(534,69,o),
+(571,239,cs),
+(667,690,l),
+(525,690,l),
+(432,254,ls),
+(412,159,o),
+(370,117,o),
+(300,117,cs),
+(234,117,o),
+(199,158,o),
+(199,238,cs),
+(199,344,o),
+(254,549,o),
+(399,577,c),
+(424,690,l),
+(138,690,l),
+(113,573,l),
+(265,573,l),
+(373,616,l),
+(163,608,o),
+(55,404,o),
+(55,227,cs),
+(55,81,o),
+(142,-14,o),
+(297,-14,cs)
+);
+}
+);
+width = 620;
+}
+);
+metricRight = "te-canadian";
+note = uni1622;
+unicode = 5666;
+},
+{
+color = 9;
+glyphname = "loCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(139,0,l),
+(232,436,ls),
+(252,530,o),
+(294,573,o),
+(362,573,cs),
+(430,573,o),
+(464,531,o),
+(464,452,cs),
+(464,346,o),
+(409,141,o),
+(264,113,c),
+(240,0,l),
+(526,0,l),
+(551,117,l),
+(399,117,l),
+(291,73,l),
+(500,82,o),
+(609,286,o),
+(609,463,cs),
+(609,609,o),
+(521,703,o),
+(367,703,cs),
+(220,703,o),
+(128,621,o),
+(93,451,cs),
+(-4,0,l)
+);
+}
+);
+width = 621;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|luCarrier-canadian";
+note = uni1623;
+unicode = 5667;
+},
+{
+color = 9;
+glyphname = "leCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (319,346);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(212,0,ls),
+(531,0,o),
+(600,266,o),
+(600,440,cs),
+(600,597,o),
+(528,703,o),
+(414,703,cs),
+(334,703,o),
+(267,650,o),
+(227,555,c),
+(242,554,l),
+(270,690,l),
+(143,690,l),
+(76,376,l),
+(196,376,l),
+(225,498,o),
+(286,573,o),
+(359,573,cs),
+(422,573,o),
+(457,518,o),
+(457,425,cs),
+(457,307,o),
+(412,129,o),
+(214,129,cs),
+(23,129,l),
+(-4,0,l)
+);
+}
+);
+width = 615;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1624;
+unicode = 5668;
+},
+{
+color = 9;
+glyphname = "leeCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "leCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (241,1);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 615;
+}
+);
+metricLeft = "leCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1625;
+unicode = 5669;
+},
+{
+color = 9;
+glyphname = "liCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "leCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (213,1);
+ref = dot_middle;
+}
+);
+width = 614;
+}
+);
+note = uni1626;
+unicode = 5670;
+},
+{
+color = 9;
+glyphname = "laCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(516,0,l),
+(544,129,l),
+(368,129,ls),
+(257,129,o),
+(202,182,o),
+(202,281,cs),
+(202,374,o),
+(247,573,o),
+(377,573,cs),
+(457,573,o),
+(495,497,o),
+(475,376,c),
+(596,376,l),
+(663,690,l),
+(535,690,l),
+(502,540,l),
+(515,533,l),
+(514,639,o),
+(456,703,o),
+(367,703,cs),
+(155,703,o),
+(59,436,o),
+(59,270,cs),
+(59,101,o),
+(159,0,o),
+(344,0,cs)
+);
+}
+);
+width = 617;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|leCarrier-canadian";
+note = uni1627;
+unicode = 5671;
+},
+{
+color = 1;
+glyphname = "dluCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(519,-14,o),
+(588,245,o),
+(588,385,cs),
+(588,512,o),
+(526,589,o),
+(406,617,c),
+(439,582,l),
+(628,582,l),
+(611,504,l),
+(714,504,l),
+(769,767,l),
+(667,767,l),
+(650,690,l),
+(386,690,l),
+(361,576,l),
+(425,557,o),
+(455,506,o),
+(455,421,cs),
+(455,337,o),
+(419,117,o),
+(284,117,cs),
+(208,117,o),
+(177,176,o),
+(199,282,cs),
+(286,690,l),
+(143,690,l),
+(59,293,ls),
+(17,100,o),
+(100,-14,o),
+(272,-14,cs)
+);
+}
+);
+width = 684;
+}
+);
+metricLeft = "te-canadian";
+note = uni1628;
+unicode = 5672;
+},
+{
+color = 9;
+glyphname = "dloCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(590,-77,l),
+(646,185,l),
+(544,185,l),
+(526,107,l),
+(386,107,l),
+(316,84,l),
+(477,97,o),
+(609,250,o),
+(609,463,cs),
+(609,609,o),
+(521,703,o),
+(367,703,cs),
+(220,703,o),
+(128,621,o),
+(93,451,cs),
+(-4,0,l),
+(139,0,l),
+(232,436,ls),
+(252,530,o),
+(294,573,o),
+(362,573,cs),
+(430,573,o),
+(464,531,o),
+(464,452,cs),
+(464,346,o),
+(409,141,o),
+(264,113,c),
+(240,0,l),
+(504,0,l),
+(488,-77,l)
+);
+}
+);
+width = 684;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "dluCarrier-canadian";
+note = uni1629;
+unicode = 5673;
+},
+{
+color = 9;
+glyphname = "dleCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (335,346);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(227,0,ls),
+(547,0,o),
+(616,266,o),
+(616,440,cs),
+(616,597,o),
+(545,703,o),
+(431,703,cs),
+(346,703,o),
+(257,640,o),
+(215,528,c),
+(225,528,l),
+(260,696,l),
+(327,696,l),
+(349,796,l),
+(116,796,l),
+(95,696,l),
+(160,696,l),
+(92,376,l),
+(213,376,l),
+(241,498,o),
+(302,573,o),
+(375,573,cs),
+(439,573,o),
+(473,518,o),
+(473,425,cs),
+(473,307,o),
+(427,129,o),
+(230,129,cs),
+(39,129,l),
+(12,0,l)
+);
+}
+);
+width = 631;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni162A;
+unicode = 5674;
+},
+{
+color = 9;
+glyphname = "dleeCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (257,1);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 630;
+}
+);
+note = uni162B;
+unicode = 5675;
+},
+{
+color = 9;
+glyphname = "dliCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (231,1);
+ref = dot_middle;
+}
+);
+width = 630;
+}
+);
+note = uni162C;
+unicode = 5676;
+},
+{
+color = 9;
+glyphname = "dlaCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(516,0,l),
+(544,129,l),
+(368,129,ls),
+(257,129,o),
+(202,182,o),
+(202,281,cs),
+(202,374,o),
+(247,573,o),
+(377,573,cs),
+(457,573,o),
+(495,497,o),
+(475,376,c),
+(596,376,l),
+(664,696,l),
+(728,696,l),
+(750,796,l),
+(517,796,l),
+(497,696,l),
+(561,696,l),
+(526,527,l),
+(539,521,l),
+(539,639,o),
+(456,703,o),
+(367,703,cs),
+(155,703,o),
+(59,436,o),
+(59,270,cs),
+(59,101,o),
+(159,0,o),
+(344,0,cs)
+);
+}
+);
+width = 632;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni162D;
+unicode = 5677;
+},
+{
+color = 9;
+glyphname = "lhuCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(514,-14,o),
+(599,208,o),
+(599,375,cs),
+(599,497,o),
+(547,589,o),
+(458,617,c),
+(507,572,l),
+(658,572,l),
+(683,690,l),
+(456,690,l),
+(431,577,l),
+(457,554,o),
+(470,510,o),
+(470,455,cs),
+(470,354,o),
+(432,117,o),
+(300,117,cs),
+(237,117,o),
+(203,159,o),
+(203,241,cs),
+(203,327,o),
+(245,516,o),
+(341,577,c),
+(365,690,l),
+(138,690,l),
+(113,572,l),
+(266,572,l),
+(333,621,l),
+(153,586,o),
+(59,382,o),
+(59,225,cs),
+(59,80,o),
+(144,-14,o),
+(296,-14,cs)
+);
+}
+);
+width = 631;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162E;
+unicode = 5678;
+},
+{
+color = 9;
+glyphname = "lhoCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(218,0,l),
+(242,113,l),
+(217,136,o),
+(204,180,o),
+(204,235,cs),
+(204,336,o),
+(242,573,o),
+(373,573,cs),
+(437,573,o),
+(470,530,o),
+(470,449,cs),
+(470,363,o),
+(429,174,o),
+(333,113,c),
+(309,0,l),
+(536,0,l),
+(561,118,l),
+(409,118,l),
+(340,69,l),
+(522,103,o),
+(615,308,o),
+(615,465,cs),
+(615,610,o),
+(530,703,o),
+(379,703,cs),
+(159,703,o),
+(75,482,o),
+(75,315,cs),
+(75,192,o),
+(127,100,o),
+(216,72,c),
+(167,118,l),
+(16,118,l),
+(-9,0,l)
+);
+}
+);
+width = 631;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162F;
+unicode = 5679;
+},
+{
+color = 9;
+glyphname = "lheCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (331,345);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(524,-14,o),
+(619,263,o),
+(619,445,cs),
+(619,603,o),
+(548,703,o),
+(428,703,cs),
+(346,703,o),
+(280,656,o),
+(242,568,c),
+(248,566,l),
+(274,690,l),
+(147,690,l),
+(87,410,l),
+(207,410,l),
+(245,524,o),
+(302,573,o),
+(372,573,cs),
+(441,573,o),
+(479,524,o),
+(479,436,cs),
+(479,331,o),
+(425,117,o),
+(290,117,cs),
+(215,117,o),
+(176,177,o),
+(180,280,c),
+(59,280,l),
+(0,0,l),
+(128,0,l),
+(158,152,l),
+(148,152,l),
+(151,50,o),
+(214,-14,o),
+(319,-14,cs)
+);
+}
+);
+width = 632;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1630;
+unicode = 5680;
+},
+{
+color = 9;
+glyphname = "lheeCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (253,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 632;
+}
+);
+note = uni1631;
+unicode = 5681;
+},
+{
+color = 9;
+glyphname = "lhiCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (227,0);
+ref = dot_middle;
+}
+);
+width = 632;
+}
+);
+note = uni1632;
+unicode = 5682;
+},
+{
+color = 9;
+glyphname = "lhaCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(327,-14,o),
+(394,34,o),
+(432,122,c),
+(426,124,l),
+(400,0,l),
+(527,0,l),
+(587,280,l),
+(468,280,l),
+(429,166,o),
+(372,117,o),
+(302,117,cs),
+(233,117,o),
+(195,166,o),
+(195,254,cs),
+(195,358,o),
+(249,573,o),
+(384,573,cs),
+(458,573,o),
+(498,513,o),
+(495,410,c),
+(614,410,l),
+(674,690,l),
+(547,690,l),
+(515,538,l),
+(526,538,l),
+(524,639,o),
+(460,703,o),
+(362,703,cs),
+(151,703,o),
+(55,427,o),
+(55,244,cs),
+(55,87,o),
+(127,-14,o),
+(246,-14,cs)
+);
+}
+);
+width = 630;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1633;
+unicode = 5683;
+},
+{
+color = 9;
+glyphname = "tlhuCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(514,-14,o),
+(599,208,o),
+(599,375,cs),
+(599,486,o),
+(571,579,o),
+(480,617,c),
+(472,582,l),
+(639,582,l),
+(621,504,l),
+(724,504,l),
+(780,767,l),
+(677,767,l),
+(660,690,l),
+(456,690,l),
+(431,577,l),
+(457,554,o),
+(470,510,o),
+(470,455,cs),
+(470,354,o),
+(432,117,o),
+(300,117,cs),
+(237,117,o),
+(203,159,o),
+(203,241,cs),
+(203,327,o),
+(245,516,o),
+(341,577,c),
+(365,690,l),
+(138,690,l),
+(113,572,l),
+(287,572,l),
+(280,602,l),
+(128,543,o),
+(59,358,o),
+(59,225,cs),
+(59,80,o),
+(144,-14,o),
+(296,-14,cs)
+);
+}
+);
+width = 690;
+}
+);
+metricLeft = "lhuCarrier-canadian";
+note = uni1634;
+unicode = 5684;
+},
+{
+color = 9;
+glyphname = "tlhoCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(55,-77,l),
+(72,0,l),
+(277,0,l),
+(301,113,l),
+(275,136,o),
+(263,180,o),
+(263,235,cs),
+(263,336,o),
+(300,573,o),
+(432,573,cs),
+(496,573,o),
+(529,530,o),
+(529,449,cs),
+(529,363,o),
+(488,174,o),
+(392,113,c),
+(367,0,l),
+(595,0,l),
+(620,118,l),
+(445,118,l),
+(453,88,l),
+(606,147,o),
+(674,331,o),
+(674,465,cs),
+(674,610,o),
+(588,703,o),
+(437,703,cs),
+(218,703,o),
+(134,482,o),
+(134,315,cs),
+(134,204,o),
+(161,111,o),
+(252,72,c),
+(261,107,l),
+(95,107,l),
+(111,185,l),
+(9,185,l),
+(-47,-77,l)
+);
+}
+);
+width = 690;
+}
+);
+metricLeft = "=|tlhuCarrier-canadian";
+metricRight = "lhuCarrier-canadian";
+note = uni1635;
+unicode = 5685;
+},
+{
+color = 9;
+glyphname = "tlheCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (342,345);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(536,-14,o),
+(633,263,o),
+(633,445,cs),
+(633,603,o),
+(559,703,o),
+(440,703,cs),
+(327,703,o),
+(249,628,o),
+(207,507,c),
+(234,559,l),
+(263,696,l),
+(327,696,l),
+(348,796,l),
+(116,796,l),
+(95,696,l),
+(160,696,l),
+(99,410,l),
+(219,410,l),
+(257,524,o),
+(314,573,o),
+(384,573,cs),
+(453,573,o),
+(493,524,o),
+(493,436,cs),
+(493,331,o),
+(438,117,o),
+(302,117,cs),
+(228,117,o),
+(187,177,o),
+(191,280,c),
+(71,280,l),
+(12,0,l),
+(139,0,l),
+(171,152,l),
+(159,152,l),
+(162,50,o),
+(227,-14,o),
+(330,-14,cs)
+);
+}
+);
+width = 646;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1636;
+unicode = 5686;
+},
+{
+color = 9;
+glyphname = "tlheeCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (264,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 644;
+}
+);
+note = uni1637;
+unicode = 5687;
+},
+{
+color = 9;
+glyphname = "tlhiCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (238,0);
+ref = dot_middle;
+}
+);
+width = 644;
+}
+);
+note = uni1638;
+unicode = 5688;
+},
+{
+color = 9;
+glyphname = "tlhaCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(327,-14,o),
+(395,34,o),
+(434,122,c),
+(427,124,l),
+(402,0,l),
+(529,0,l),
+(589,280,l),
+(469,280,l),
+(430,166,o),
+(373,117,o),
+(302,117,cs),
+(233,117,o),
+(195,166,o),
+(195,254,cs),
+(195,358,o),
+(249,573,o),
+(384,573,cs),
+(460,573,o),
+(500,513,o),
+(496,410,c),
+(616,410,l),
+(677,696,l),
+(742,696,l),
+(764,796,l),
+(530,796,l),
+(509,696,l),
+(575,696,l),
+(538,526,l),
+(547,525,l),
+(541,645,o),
+(462,703,o),
+(362,703,cs),
+(151,703,o),
+(55,427,o),
+(55,244,cs),
+(55,87,o),
+(127,-14,o),
+(246,-14,cs)
+);
+}
+);
+width = 646;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni1639;
+unicode = 5689;
+},
+{
+color = 9;
+glyphname = "tluCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(272,-14,o),
+(326,23,o),
+(368,103,c),
+(323,104,l),
+(338,27,o),
+(386,-14,o),
+(464,-14,cs),
+(649,-14,o),
+(705,255,o),
+(705,393,cs),
+(705,500,o),
+(668,571,o),
+(601,603,c),
+(568,582,l),
+(745,582,l),
+(728,504,l),
+(831,504,l),
+(886,767,l),
+(783,767,l),
+(767,690,l),
+(509,690,l),
+(485,576,l),
+(544,568,o),
+(573,525,o),
+(573,439,cs),
+(573,367,o),
+(539,115,o),
+(461,115,cs),
+(428,115,o),
+(415,141,o),
+(426,191,cs),
+(450,308,l),
+(316,308,l),
+(292,191,ls),
+(280,140,o),
+(261,115,o),
+(231,115,cs),
+(202,115,o),
+(188,133,o),
+(188,179,cs),
+(188,252,o),
+(245,575,o),
+(394,576,c),
+(418,690,l),
+(139,690,l),
+(114,572,l),
+(290,572,l),
+(267,596,l),
+(100,524,o),
+(49,301,o),
+(49,171,cs),
+(49,51,o),
+(104,-14,o),
+(200,-14,cs)
+);
+}
+);
+width = 797;
+}
+);
+metricRight = "tlhuCarrier-canadian";
+note = uni163A;
+unicode = 5690;
+},
+{
+color = 1;
+glyphname = "tloCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(707,-77,l),
+(763,185,l),
+(661,185,l),
+(643,107,l),
+(477,107,l),
+(497,86,l),
+(677,154,o),
+(732,383,o),
+(732,519,cs),
+(732,639,o),
+(677,703,o),
+(582,703,cs),
+(509,703,o),
+(455,667,o),
+(413,586,c),
+(459,585,l),
+(443,663,o),
+(395,703,o),
+(318,703,cs),
+(132,703,o),
+(76,435,o),
+(76,297,cs),
+(76,197,o),
+(109,129,o),
+(167,95,c),
+(204,118,l),
+(17,118,l),
+(-8,0,l),
+(272,0,l),
+(297,114,l),
+(238,122,o),
+(209,165,o),
+(209,251,cs),
+(209,323,o),
+(242,575,o),
+(321,575,cs),
+(354,575,o),
+(366,549,o),
+(355,498,cs),
+(331,382,l),
+(466,382,l),
+(490,498,ls),
+(501,550,o),
+(521,575,o),
+(551,575,cs),
+(580,575,o),
+(593,556,o),
+(593,511,cs),
+(593,438,o),
+(537,115,o),
+(387,114,c),
+(363,0,l),
+(621,0,l),
+(605,-77,l)
+);
+}
+);
+width = 797;
+}
+);
+metricLeft = "tluCarrier-canadian";
+metricRight = "tlhuCarrier-canadian";
+note = uni163B;
+unicode = 5691;
+},
+{
+color = 9;
+glyphname = "tleCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (292,345);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(471,-14,o),
+(575,80,o),
+(575,218,cs),
+(575,293,o),
+(537,352,o),
+(476,359,c),
+(470,330,l),
+(573,341,o),
+(642,437,o),
+(642,535,cs),
+(642,633,o),
+(571,703,o),
+(458,703,cs),
+(358,703,o),
+(271,649,o),
+(223,551,c),
+(232,550,l),
+(263,696,l),
+(327,696,l),
+(349,796,l),
+(116,796,l),
+(95,696,l),
+(159,696,l),
+(99,410,l),
+(216,410,l),
+(244,519,o),
+(309,577,o),
+(399,577,cs),
+(461,577,o),
+(497,546,o),
+(497,498,cs),
+(497,446,o),
+(463,403,o),
+(403,403,cs),
+(380,403,l),
+(355,288,l),
+(378,288,ls),
+(413,288,o),
+(439,266,o),
+(439,226,cs),
+(439,161,o),
+(397,113,o),
+(319,113,cs),
+(221,113,o),
+(174,172,o),
+(188,280,c),
+(71,280,l),
+(13,0,l),
+(140,0,l),
+(171,146,l),
+(149,145,l),
+(151,47,o),
+(228,-14,o),
+(339,-14,cs)
+);
+}
+);
+width = 634;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni163C;
+unicode = 5692;
+},
+{
+color = 9;
+glyphname = "tleeCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (213,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 635;
+}
+);
+note = uni163D;
+unicode = 5693;
+},
+{
+color = 9;
+glyphname = "tliCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (202,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 635;
+}
+);
+note = uni163E;
+unicode = 5694;
+},
+{
+color = 9;
+glyphname = "tlaCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(307,-14,o),
+(386,29,o),
+(437,107,c),
+(420,135,l),
+(392,0,l),
+(519,0,l),
+(579,280,l),
+(462,280,l),
+(434,171,o),
+(369,113,o),
+(278,113,cs),
+(216,113,o),
+(181,144,o),
+(181,191,cs),
+(181,243,o),
+(214,287,o),
+(273,287,cs),
+(297,287,l),
+(322,402,l),
+(298,402,ls),
+(263,402,o),
+(238,424,o),
+(238,464,cs),
+(238,528,o),
+(280,577,o),
+(359,577,cs),
+(456,577,o),
+(503,518,o),
+(489,410,c),
+(607,410,l),
+(668,696,l),
+(732,696,l),
+(753,796,l),
+(521,796,l),
+(498,696,l),
+(564,696,l),
+(524,500,l),
+(537,519,l),
+(547,632,o),
+(467,703,o),
+(337,703,cs),
+(205,703,o),
+(102,610,o),
+(102,471,cs),
+(102,400,o),
+(137,344,o),
+(191,330,c),
+(200,358,l),
+(101,346,o),
+(34,251,o),
+(34,155,cs),
+(34,57,o),
+(106,-14,o),
+(219,-14,cs)
+);
+}
+);
+width = 635;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni163F;
+unicode = 5695;
+},
+{
+color = 9;
+glyphname = "zuCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(485,-14,o),
+(582,115,o),
+(582,302,cs),
+(582,357,o),
+(573,420,o),
+(573,489,cs),
+(573,539,o),
+(590,568,o),
+(639,568,cs),
+(659,568,l),
+(684,690,l),
+(626,690,ls),
+(497,690,o),
+(440,623,o),
+(440,483,cs),
+(440,426,o),
+(447,374,o),
+(447,298,cs),
+(447,193,o),
+(396,117,o),
+(298,117,cs),
+(230,117,o),
+(190,153,o),
+(190,211,cs),
+(190,308,o),
+(319,464,o),
+(319,575,cs),
+(319,646,o),
+(269,690,o),
+(185,690,cs),
+(137,690,l),
+(111,568,l),
+(140,568,ls),
+(168,568,o),
+(180,556,o),
+(180,535,cs),
+(180,474,o),
+(45,332,o),
+(45,185,cs),
+(45,67,o),
+(139,-14,o),
+(286,-14,cs)
+);
+}
+);
+width = 632;
+}
+);
+metricRight = "=|";
+note = uni1640;
+unicode = 5696;
+},
+{
+color = 9;
+glyphname = "zoCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(49,0,ls),
+(179,0,o),
+(236,67,o),
+(236,207,cs),
+(236,264,o),
+(228,316,o),
+(228,392,cs),
+(228,497,o),
+(279,573,o),
+(377,573,cs),
+(445,573,o),
+(485,537,o),
+(485,479,cs),
+(485,382,o),
+(356,226,o),
+(356,115,cs),
+(356,43,o),
+(407,0,o),
+(491,0,cs),
+(538,0,l),
+(564,122,l),
+(535,122,ls),
+(507,122,o),
+(496,133,o),
+(497,155,cs),
+(496,215,o),
+(631,357,o),
+(631,505,cs),
+(631,623,o),
+(536,703,o),
+(389,703,cs),
+(191,703,o),
+(95,575,o),
+(95,387,cs),
+(95,332,o),
+(102,270,o),
+(102,201,cs),
+(102,151,o),
+(85,122,o),
+(36,122,cs),
+(16,122,l),
+(-9,0,l)
+);
+}
+);
+width = 632;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1641;
+unicode = 5697;
+},
+{
+color = 9;
+glyphname = "zeCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (318,345);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(525,-14,o),
+(609,334,o),
+(609,501,cs),
+(609,630,o),
+(559,703,o),
+(469,703,cs),
+(372,703,o),
+(297,613,o),
+(262,613,cs),
+(244,613,o),
+(240,627,o),
+(248,665,cs),
+(254,690,l),
+(126,690,l),
+(111,622,ls),
+(94,538,o),
+(124,488,o),
+(193,488,cs),
+(284,488,o),
+(355,573,o),
+(412,573,cs),
+(447,573,o),
+(465,540,o),
+(465,476,cs),
+(465,384,o),
+(412,117,o),
+(307,117,cs),
+(248,117,o),
+(213,202,o),
+(127,202,cs),
+(59,202,o),
+(13,156,o),
+(-7,68,cs),
+(-21,0,l),
+(107,0,l),
+(112,25,ls),
+(121,63,o),
+(131,76,o),
+(150,76,cs),
+(186,76,o),
+(232,-14,o),
+(328,-14,cs)
+);
+}
+);
+width = 612;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1642;
+unicode = 5698;
+},
+{
+color = 9;
+glyphname = "zeeCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (240,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 611;
+}
+);
+note = uni1643;
+unicode = 5699;
+},
+{
+color = 9;
+glyphname = "ziCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (213,0);
+ref = dot_middle;
+}
+);
+width = 611;
+}
+);
+note = uni1644;
+unicode = 5700;
+},
+{
+color = 9;
+glyphname = "zaCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(284,-14,o),
+(358,76,o),
+(392,76,cs),
+(411,76,o),
+(415,63,o),
+(407,25,cs),
+(401,0,l),
+(528,0,l),
+(544,68,ls),
+(561,152,o),
+(531,202,o),
+(461,202,cs),
+(371,202,o),
+(299,117,o),
+(244,117,cs),
+(209,117,o),
+(190,150,o),
+(190,213,cs),
+(190,306,o),
+(243,573,o),
+(348,573,cs),
+(407,573,o),
+(441,488,o),
+(527,488,cs),
+(595,488,o),
+(642,534,o),
+(661,622,cs),
+(675,690,l),
+(548,690,l),
+(543,665,ls),
+(534,627,o),
+(524,613,o),
+(505,613,cs),
+(469,613,o),
+(423,703,o),
+(327,703,cs),
+(129,703,o),
+(46,355,o),
+(46,188,cs),
+(46,60,o),
+(96,-14,o),
+(186,-14,cs)
+);
+}
+);
+width = 613;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|zeCarrier-canadian";
+note = uni1645;
+unicode = 5701;
+},
+{
+color = 6;
+glyphname = "zCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(290,183,l),
+(309,270,l),
+(150,270,l),
+(141,218,l),
+(350,478,l),
+(360,527,l),
+(104,527,l),
+(85,440,l),
+(242,440,l),
+(250,492,l),
+(41,232,l),
+(31,183,l)
+);
+}
+);
+width = 347;
+}
+);
+metricRight = "=|";
+note = uni1646;
+unicode = 5702;
+},
+{
+color = 6;
+glyphname = "initialzCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(187,96,l),
+(206,183,l),
+(290,183,l),
+(309,270,l),
+(119,270,l),
+(143,220,l),
+(350,478,l),
+(360,527,l),
+(279,527,l),
+(298,614,l),
+(205,614,l),
+(186,527,l),
+(104,527,l),
+(85,440,l),
+(271,440,l),
+(247,490,l),
+(41,232,l),
+(31,183,l),
+(113,183,l),
+(95,96,l)
+);
+}
+);
+width = 347;
+}
+);
+metricLeft = "zCarrier-canadian";
+metricRight = "zCarrier-canadian";
+note = uni1647;
+unicode = 5703;
+},
+{
+color = 9;
+glyphname = "dzuCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(485,-14,o),
+(582,115,o),
+(582,302,cs),
+(582,357,o),
+(573,420,o),
+(573,489,cs),
+(573,539,o),
+(590,568,o),
+(639,568,cs),
+(659,568,l),
+(684,690,l),
+(626,690,ls),
+(516,690,o),
+(456,623,o),
+(446,483,cs),
+(443,426,o),
+(451,362,o),
+(449,298,cs),
+(445,193,o),
+(396,117,o),
+(298,117,cs),
+(230,117,o),
+(190,153,o),
+(190,211,cs),
+(190,308,o),
+(310,464,o),
+(310,575,cs),
+(310,646,o),
+(268,690,o),
+(185,690,cs),
+(137,690,l),
+(111,568,l),
+(140,568,ls),
+(168,568,o),
+(180,556,o),
+(180,535,cs),
+(180,474,o),
+(45,332,o),
+(45,185,cs),
+(45,67,o),
+(139,-14,o),
+(286,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(392,469,l),
+(428,637,l),
+(470,637,l),
+(482,690,l),
+(342,690,l),
+(330,637,l),
+(373,637,l),
+(337,469,l)
+);
+}
+);
+width = 632;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1648;
+unicode = 5704;
+},
+{
+color = 9;
+glyphname = "dzoCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(49,0,ls),
+(159,0,o),
+(219,67,o),
+(229,207,cs),
+(232,264,o),
+(224,327,o),
+(226,392,cs),
+(230,497,o),
+(279,573,o),
+(377,573,cs),
+(445,573,o),
+(485,537,o),
+(485,479,cs),
+(485,382,o),
+(365,226,o),
+(365,115,cs),
+(365,43,o),
+(408,0,o),
+(491,0,cs),
+(537,0,l),
+(563,122,l),
+(535,122,ls),
+(507,122,o),
+(496,133,o),
+(496,155,cs),
+(496,215,o),
+(631,357,o),
+(631,505,cs),
+(631,623,o),
+(536,703,o),
+(389,703,cs),
+(191,703,o),
+(95,575,o),
+(95,387,cs),
+(95,332,o),
+(102,270,o),
+(102,201,cs),
+(102,151,o),
+(85,122,o),
+(36,122,cs),
+(16,122,l),
+(-9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(333,0,l),
+(345,53,l),
+(302,53,l),
+(338,220,l),
+(283,220,l),
+(247,53,l),
+(205,53,l),
+(193,0,l)
+);
+}
+);
+width = 631;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1649;
+unicode = 5705;
+},
+{
+color = 9;
+glyphname = "dzeCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (344,345);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(545,-14,o),
+(629,334,o),
+(629,501,cs),
+(629,630,o),
+(580,703,o),
+(490,703,cs),
+(391,703,o),
+(316,613,o),
+(282,613,cs),
+(264,613,o),
+(260,627,o),
+(269,665,cs),
+(273,690,l),
+(146,690,l),
+(131,622,ls),
+(113,538,o),
+(144,488,o),
+(213,488,cs),
+(303,488,o),
+(376,573,o),
+(432,573,cs),
+(467,573,o),
+(485,540,o),
+(485,476,cs),
+(485,384,o),
+(432,117,o),
+(327,117,cs),
+(269,117,o),
+(233,202,o),
+(147,202,cs),
+(79,202,o),
+(32,156,o),
+(14,68,cs),
+(-1,0,l),
+(127,0,l),
+(132,25,ls),
+(140,63,o),
+(151,76,o),
+(169,76,cs),
+(206,76,o),
+(252,-14,o),
+(349,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(125,242,l),
+(138,308,l),
+(235,308,l),
+(251,382,l),
+(154,382,l),
+(167,447,l),
+(95,447,l),
+(51,242,l)
+);
+}
+);
+width = 633;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164A;
+unicode = 5706;
+},
+{
+color = 9;
+glyphname = "dzeeCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "dzeCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (266,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 633;
+}
+);
+metricLeft = "dzeCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164B;
+unicode = 5707;
+},
+{
+color = 9;
+glyphname = "dziCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "dzeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (239,0);
+ref = dot_middle;
+}
+);
+width = 632;
+}
+);
+note = uni164C;
+unicode = 5708;
+},
+{
+color = 9;
+glyphname = "dzaCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(284,-14,o),
+(359,76,o),
+(393,76,cs),
+(412,76,o),
+(415,63,o),
+(408,25,cs),
+(402,0,l),
+(529,0,l),
+(544,68,ls),
+(562,152,o),
+(532,202,o),
+(462,202,cs),
+(372,202,o),
+(299,117,o),
+(244,117,cs),
+(209,117,o),
+(190,150,o),
+(190,213,cs),
+(190,306,o),
+(243,573,o),
+(349,573,cs),
+(408,573,o),
+(442,488,o),
+(528,488,cs),
+(596,488,o),
+(643,534,o),
+(662,622,cs),
+(676,690,l),
+(549,690,l),
+(543,665,ls),
+(535,627,o),
+(525,613,o),
+(506,613,cs),
+(470,613,o),
+(423,703,o),
+(327,703,cs),
+(130,703,o),
+(46,355,o),
+(46,188,cs),
+(46,60,o),
+(96,-14,o),
+(186,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(581,242,l),
+(624,447,l),
+(552,447,l),
+(537,382,l),
+(441,382,l),
+(424,308,l),
+(522,308,l),
+(508,242,l)
+);
+}
+);
+width = 633;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dzeCarrier-canadian";
+note = uni164D;
+unicode = 5709;
+},
+{
+color = 9;
+glyphname = "suCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(271,-14,o),
+(340,40,o),
+(373,135,c),
+(324,135,l),
+(327,37,o),
+(378,-14,o),
+(474,-14,cs),
+(602,-14,o),
+(660,80,o),
+(676,207,cs),
+(688,287,o),
+(679,426,o),
+(689,495,cs),
+(694,539,o),
+(710,568,o),
+(747,568,cs),
+(763,568,l),
+(788,690,l),
+(735,690,ls),
+(626,690,o),
+(576,626,o),
+(560,520,cs),
+(549,445,o),
+(550,287,o),
+(542,223,cs),
+(538,169,o),
+(520,115,o),
+(467,115,cs),
+(416,115,o),
+(414,164,o),
+(423,204,cs),
+(526,690,l),
+(402,690,l),
+(298,200,ls),
+(286,142,o),
+(262,115,o),
+(223,115,cs),
+(192,115,o),
+(175,132,o),
+(175,166,cs),
+(175,242,o),
+(307,487,o),
+(307,586,cs),
+(307,654,o),
+(267,690,o),
+(191,690,cs),
+(138,690,l),
+(113,568,l),
+(128,568,ls),
+(153,568,o),
+(164,556,o),
+(164,532,cs),
+(164,454,o),
+(32,263,o),
+(32,139,cs),
+(32,47,o),
+(90,-14,o),
+(184,-14,cs)
+);
+}
+);
+width = 737;
+}
+);
+metricRight = "=|";
+note = uni164E;
+unicode = 5710;
+},
+{
+color = 9;
+glyphname = "soCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(44,0,ls),
+(155,0,o),
+(204,64,o),
+(219,170,cs),
+(231,244,o),
+(230,403,o),
+(238,467,cs),
+(242,521,o),
+(261,575,o),
+(313,575,cs),
+(364,575,o),
+(365,526,o),
+(357,486,cs),
+(254,0,l),
+(379,0,l),
+(482,490,ls),
+(495,548,o),
+(518,575,o),
+(556,575,cs),
+(588,575,o),
+(605,557,o),
+(605,524,cs),
+(605,447,o),
+(472,203,o),
+(472,103,cs),
+(472,36,o),
+(513,0,o),
+(589,0,cs),
+(640,0,l),
+(667,122,l),
+(650,122,ls),
+(626,122,o),
+(615,133,o),
+(615,157,cs),
+(615,236,o),
+(748,427,o),
+(748,551,cs),
+(748,642,o),
+(690,703,o),
+(596,703,cs),
+(508,703,o),
+(440,650,o),
+(407,554,c),
+(456,554,l),
+(452,653,o),
+(403,703,o),
+(305,703,cs),
+(178,703,o),
+(120,610,o),
+(103,483,cs),
+(92,403,o),
+(100,264,o),
+(91,195,cs),
+(86,151,o),
+(70,122,o),
+(33,122,cs),
+(17,122,l),
+(-9,0,l)
+);
+}
+);
+width = 736;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5711;
+},
+{
+color = 9;
+glyphname = "seCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(489,-14,o),
+(564,116,o),
+(564,223,cs),
+(564,297,o),
+(527,349,o),
+(464,360,c),
+(457,327,l),
+(582,344,o),
+(633,457,o),
+(633,547,cs),
+(633,639,o),
+(577,703,o),
+(491,703,cs),
+(390,703,o),
+(313,613,o),
+(279,613,cs),
+(265,613,o),
+(261,624,o),
+(267,653,cs),
+(274,690,l),
+(147,690,l),
+(132,623,ls),
+(115,539,o),
+(147,489,o),
+(217,489,cs),
+(311,489,o),
+(380,577,o),
+(440,577,cs),
+(471,577,o),
+(489,554,o),
+(489,518,cs),
+(489,460,o),
+(455,402,o),
+(383,402,cs),
+(85,402,l),
+(61,288,l),
+(357,288,ls),
+(403,288,o),
+(426,265,o),
+(426,224,cs),
+(426,184,o),
+(402,113,o),
+(346,113,cs),
+(287,113,o),
+(242,201,o),
+(149,201,cs),
+(79,201,o),
+(34,156,o),
+(14,67,cs),
+(0,0,l),
+(128,0,l),
+(133,25,ls),
+(141,62,o),
+(153,76,o),
+(171,76,cs),
+(217,76,o),
+(263,-14,o),
+(365,-14,cs)
+);
+}
+);
+width = 622;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni1650;
+unicode = 5712;
+},
+{
+color = 9;
+glyphname = "seeCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(489,-14,o),
+(564,116,o),
+(564,223,cs),
+(564,293,o),
+(529,345,o),
+(471,358,c),
+(460,328,l),
+(583,346,o),
+(633,458,o),
+(633,547,cs),
+(633,639,o),
+(577,703,o),
+(491,703,cs),
+(390,703,o),
+(313,613,o),
+(279,613,cs),
+(265,613,o),
+(261,624,o),
+(267,653,cs),
+(274,690,l),
+(147,690,l),
+(132,623,ls),
+(115,539,o),
+(147,489,o),
+(217,489,cs),
+(311,489,o),
+(380,577,o),
+(440,577,cs),
+(471,577,o),
+(489,554,o),
+(489,518,cs),
+(489,460,o),
+(455,399,o),
+(382,399,cs),
+(341,399,l),
+(360,336,l),
+(388,471,l),
+(314,471,l),
+(299,399,l),
+(85,399,l),
+(62,291,l),
+(276,291,l),
+(261,215,l),
+(334,215,l),
+(362,354,l),
+(318,291,l),
+(358,291,ls),
+(403,291,o),
+(426,265,o),
+(426,224,cs),
+(426,184,o),
+(402,113,o),
+(346,113,cs),
+(287,113,o),
+(243,201,o),
+(149,201,cs),
+(79,201,o),
+(34,156,o),
+(15,67,cs),
+(0,0,l),
+(129,0,l),
+(133,25,ls),
+(141,62,o),
+(153,76,o),
+(171,76,cs),
+(217,76,o),
+(263,-14,o),
+(365,-14,cs)
+);
+}
+);
+width = 622;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1651;
+unicode = 5713;
+},
+{
+color = 9;
+glyphname = "siCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(489,-14,o),
+(564,116,o),
+(564,223,cs),
+(564,293,o),
+(529,345,o),
+(471,358,c),
+(460,328,l),
+(583,346,o),
+(633,458,o),
+(633,547,cs),
+(633,639,o),
+(577,703,o),
+(491,703,cs),
+(390,703,o),
+(313,613,o),
+(279,613,cs),
+(265,613,o),
+(261,624,o),
+(267,653,cs),
+(274,690,l),
+(147,690,l),
+(132,623,ls),
+(115,539,o),
+(147,489,o),
+(217,489,cs),
+(311,489,o),
+(380,577,o),
+(440,577,cs),
+(471,577,o),
+(492,554,o),
+(492,518,cs),
+(492,460,o),
+(462,395,o),
+(388,395,cs),
+(321,395,l),
+(379,353,l),
+(378,405,o),
+(339,440,o),
+(289,440,cs),
+(257,440,o),
+(229,424,o),
+(213,399,c),
+(85,399,l),
+(62,291,l),
+(214,291,l),
+(229,266,o),
+(257,250,o),
+(289,250,cs),
+(336,250,o),
+(377,287,o),
+(380,336,c),
+(321,295,l),
+(371,295,ls),
+(416,295,o),
+(430,265,o),
+(430,224,cs),
+(430,184,o),
+(402,113,o),
+(346,113,cs),
+(287,113,o),
+(243,201,o),
+(149,201,cs),
+(79,201,o),
+(34,156,o),
+(15,67,cs),
+(0,0,l),
+(129,0,l),
+(133,25,ls),
+(141,62,o),
+(153,76,o),
+(171,76,cs),
+(217,76,o),
+(263,-14,o),
+(365,-14,cs)
+);
+}
+);
+width = 622;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1652;
+unicode = 5714;
+},
+{
+color = 9;
+glyphname = "saCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(275,-14,o),
+(353,76,o),
+(386,76,cs),
+(401,76,o),
+(405,66,o),
+(399,37,cs),
+(390,0,l),
+(519,0,l),
+(532,67,ls),
+(551,151,o),
+(519,201,o),
+(447,201,cs),
+(355,201,o),
+(285,113,o),
+(225,113,cs),
+(194,113,o),
+(176,136,o),
+(176,172,cs),
+(176,230,o),
+(210,288,o),
+(282,288,cs),
+(580,288,l),
+(604,402,l),
+(307,402,ls),
+(262,402,o),
+(239,425,o),
+(239,466,cs),
+(239,506,o),
+(263,577,o),
+(320,577,cs),
+(378,577,o),
+(423,489,o),
+(517,489,cs),
+(586,489,o),
+(632,534,o),
+(651,623,cs),
+(665,690,l),
+(537,690,l),
+(532,665,ls),
+(525,628,o),
+(513,613,o),
+(494,613,cs),
+(448,613,o),
+(402,703,o),
+(299,703,cs),
+(176,703,o),
+(101,574,o),
+(101,467,cs),
+(101,393,o),
+(138,341,o),
+(201,329,c),
+(208,363,l),
+(83,346,o),
+(32,233,o),
+(32,143,cs),
+(32,51,o),
+(88,-14,o),
+(174,-14,cs)
+);
+}
+);
+width = 623;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1653;
+unicode = 5715;
+},
+{
+color = 9;
+glyphname = "shuCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(263,-14,o),
+(326,29,o),
+(363,108,c),
+(327,112,l),
+(335,28,o),
+(385,-14,o),
+(474,-14,cs),
+(602,-14,o),
+(660,80,o),
+(676,207,cs),
+(688,287,o),
+(679,426,o),
+(689,495,cs),
+(694,539,o),
+(710,568,o),
+(747,568,cs),
+(763,568,l),
+(788,690,l),
+(735,690,ls),
+(631,690,o),
+(579,633,o),
+(561,532,cs),
+(558,521,o),
+(557,507,o),
+(556,493,c),
+(588,570,l),
+(500,570,l),
+(526,690,l),
+(402,690,l),
+(376,570,l),
+(284,570,l),
+(296,520,l),
+(303,546,o),
+(307,568,o),
+(307,586,cs),
+(307,654,o),
+(267,690,o),
+(191,690,cs),
+(138,690,l),
+(113,568,l),
+(128,568,ls),
+(153,568,o),
+(164,556,o),
+(164,532,cs),
+(164,454,o),
+(32,263,o),
+(32,139,cs),
+(32,47,o),
+(90,-14,o),
+(184,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(192,115,o),
+(175,132,o),
+(175,166,cs),
+(175,221,o),
+(240,351,o),
+(278,459,c),
+(353,459,l),
+(298,200,ls),
+(286,142,o),
+(262,115,o),
+(223,115,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(416,115,o),
+(414,164,o),
+(423,204,cs),
+(477,459,l),
+(553,459,l),
+(547,378,o),
+(548,275,o),
+(542,223,cs),
+(538,169,o),
+(520,115,o),
+(467,115,cs)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1654;
+unicode = 5716;
+},
+{
+color = 9;
+glyphname = "shoCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(44,0,ls),
+(149,0,o),
+(201,57,o),
+(218,157,cs),
+(221,169,o),
+(223,183,o),
+(224,197,c),
+(191,120,l),
+(279,120,l),
+(254,0,l),
+(379,0,l),
+(404,120,l),
+(496,120,l),
+(484,170,l),
+(477,144,o),
+(472,122,o),
+(472,103,cs),
+(472,36,o),
+(513,0,o),
+(589,0,cs),
+(641,0,l),
+(668,122,l),
+(651,122,ls),
+(627,122,o),
+(615,133,o),
+(615,157,cs),
+(615,236,o),
+(748,427,o),
+(748,551,cs),
+(748,642,o),
+(690,703,o),
+(596,703,cs),
+(517,703,o),
+(454,661,o),
+(417,582,c),
+(453,578,l),
+(444,662,o),
+(394,703,o),
+(305,703,cs),
+(178,703,o),
+(120,610,o),
+(103,483,cs),
+(92,403,o),
+(100,264,o),
+(91,195,cs),
+(86,151,o),
+(70,122,o),
+(33,122,cs),
+(17,122,l),
+(-9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(233,312,o),
+(232,414,o),
+(238,467,cs),
+(242,521,o),
+(261,575,o),
+(313,575,cs),
+(364,575,o),
+(365,526,o),
+(357,486,cs),
+(302,231,l),
+(227,231,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(482,490,ls),
+(495,548,o),
+(518,575,o),
+(556,575,cs),
+(588,575,o),
+(605,557,o),
+(605,524,cs),
+(605,469,o),
+(540,339,o),
+(502,231,c),
+(427,231,l)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1655;
+unicode = 5717;
+},
+{
+color = 9;
+glyphname = "sheCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(489,-14,o),
+(564,116,o),
+(564,223,cs),
+(564,293,o),
+(529,345,o),
+(471,358,c),
+(460,328,l),
+(582,346,o),
+(633,458,o),
+(633,547,cs),
+(633,639,o),
+(577,703,o),
+(491,703,cs),
+(390,703,o),
+(313,613,o),
+(279,613,cs),
+(265,613,o),
+(261,624,o),
+(267,653,cs),
+(274,690,l),
+(147,690,l),
+(132,623,ls),
+(115,539,o),
+(147,494,o),
+(217,494,cs),
+(236,494,o),
+(253,496,o),
+(267,500,c),
+(204,562,l),
+(170,402,l),
+(85,402,l),
+(61,288,l),
+(146,288,l),
+(112,126,l),
+(201,187,l),
+(185,193,o),
+(167,196,o),
+(149,196,cs),
+(79,196,o),
+(34,156,o),
+(14,67,cs),
+(0,0,l),
+(128,0,l),
+(133,25,ls),
+(141,62,o),
+(153,76,o),
+(171,76,cs),
+(217,76,o),
+(263,-14,o),
+(365,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(256,288,l),
+(357,288,ls),
+(403,288,o),
+(426,265,o),
+(426,224,cs),
+(426,184,o),
+(402,113,o),
+(346,113,cs),
+(306,113,o),
+(274,149,o),
+(232,173,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(304,515,l),
+(355,539,o),
+(399,577,o),
+(440,577,cs),
+(471,577,o),
+(489,554,o),
+(489,518,cs),
+(489,460,o),
+(455,402,o),
+(383,402,cs),
+(280,402,l)
+);
+}
+);
+width = 622;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1656;
+unicode = 5718;
+},
+{
+color = 9;
+glyphname = "sheeCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(489,-14,o),
+(564,116,o),
+(564,223,cs),
+(564,293,o),
+(529,345,o),
+(471,358,c),
+(460,328,l),
+(583,346,o),
+(633,458,o),
+(633,547,cs),
+(633,639,o),
+(577,703,o),
+(491,703,cs),
+(390,703,o),
+(313,613,o),
+(279,613,cs),
+(265,613,o),
+(261,624,o),
+(267,653,cs),
+(274,690,l),
+(147,690,l),
+(132,623,ls),
+(115,539,o),
+(147,494,o),
+(217,494,cs),
+(229,494,o),
+(241,495,o),
+(251,497,c),
+(205,559,l),
+(169,391,l),
+(83,391,l),
+(64,298,l),
+(149,298,l),
+(113,129,l),
+(185,191,l),
+(173,194,o),
+(161,196,o),
+(149,196,cs),
+(79,196,o),
+(34,156,o),
+(15,67,cs),
+(0,0,l),
+(129,0,l),
+(133,25,ls),
+(141,62,o),
+(153,76,o),
+(171,76,cs),
+(217,76,o),
+(263,-14,o),
+(365,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(302,110,o),
+(266,159,o),
+(212,183,c),
+(236,298,l),
+(305,298,l),
+(288,215,l),
+(347,215,l),
+(369,321,l),
+(348,298,l),
+(365,298,ls),
+(411,298,o),
+(432,265,o),
+(432,224,cs),
+(432,184,o),
+(402,110,o),
+(346,110,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(401,471,l),
+(342,471,l),
+(325,391,l),
+(256,391,l),
+(280,505,l),
+(344,528,o),
+(394,580,o),
+(440,580,cs),
+(471,580,o),
+(493,554,o),
+(493,518,cs),
+(493,460,o),
+(457,391,o),
+(385,391,cs),
+(368,391,l),
+(381,372,l)
+);
+}
+);
+width = 622;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1657;
+unicode = 5719;
+},
+{
+color = 9;
+glyphname = "shiCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(132,623,ls),
+(115,539,o),
+(147,494,o),
+(217,494,cs),
+(230,494,o),
+(241,496,o),
+(253,498,c),
+(204,559,l),
+(168,391,l),
+(83,391,l),
+(64,298,l),
+(148,298,l),
+(112,129,l),
+(182,191,l),
+(172,194,o),
+(160,196,o),
+(149,196,cs),
+(79,196,o),
+(34,156,o),
+(15,67,cs),
+(0,0,l),
+(129,0,l),
+(133,25,ls),
+(141,62,o),
+(153,76,o),
+(171,76,cs),
+(217,76,o),
+(263,-14,o),
+(365,-14,cs),
+(489,-14,o),
+(564,116,o),
+(564,223,cs),
+(564,293,o),
+(529,345,o),
+(471,358,c),
+(460,328,l),
+(583,346,o),
+(633,458,o),
+(633,547,cs),
+(633,639,o),
+(577,703,o),
+(491,703,cs),
+(390,703,o),
+(313,613,o),
+(279,613,cs),
+(265,613,o),
+(261,624,o),
+(267,653,cs),
+(274,690,l),
+(147,690,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(236,298,l),
+(270,298,l),
+(282,269,o),
+(310,250,o),
+(344,250,cs),
+(386,250,o),
+(416,282,o),
+(427,323,c),
+(357,298,l),
+(381,298,ls),
+(418,298,o),
+(432,262,o),
+(432,224,cs),
+(432,184,o),
+(402,110,o),
+(346,110,cs),
+(302,110,o),
+(266,158,o),
+(211,183,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(279,505,l),
+(343,529,o),
+(394,580,o),
+(440,580,cs),
+(471,580,o),
+(494,554,o),
+(494,518,cs),
+(494,460,o),
+(467,391,o),
+(400,391,cs),
+(356,391,l),
+(426,369,l),
+(417,411,o),
+(385,440,o),
+(344,440,cs),
+(313,440,o),
+(282,420,o),
+(270,391,c),
+(255,391,l)
+);
+}
+);
+width = 622;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1658;
+unicode = 5720;
+},
+{
+color = 9;
+glyphname = "shaCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(275,-14,o),
+(353,76,o),
+(386,76,cs),
+(401,76,o),
+(405,66,o),
+(399,37,cs),
+(390,0,l),
+(519,0,l),
+(532,67,ls),
+(551,151,o),
+(519,196,o),
+(447,196,cs),
+(430,196,o),
+(412,194,o),
+(399,189,c),
+(461,128,l),
+(496,288,l),
+(580,288,l),
+(604,402,l),
+(520,402,l),
+(554,564,l),
+(465,502,l),
+(480,497,o),
+(497,494,o),
+(517,494,cs),
+(586,494,o),
+(632,534,o),
+(651,623,cs),
+(665,690,l),
+(537,690,l),
+(532,665,ls),
+(525,628,o),
+(513,613,o),
+(494,613,cs),
+(448,613,o),
+(403,703,o),
+(299,703,cs),
+(176,703,o),
+(101,574,o),
+(101,467,cs),
+(101,397,o),
+(135,345,o),
+(194,331,c),
+(206,361,l),
+(82,344,o),
+(32,232,o),
+(32,143,cs),
+(32,51,o),
+(89,-14,o),
+(175,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(194,113,o),
+(176,136,o),
+(176,172,cs),
+(176,230,o),
+(211,288,o),
+(283,288,cs),
+(385,288,l),
+(361,175,l),
+(310,151,o),
+(267,113,o),
+(226,113,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(263,402,o),
+(239,425,o),
+(239,466,cs),
+(239,506,o),
+(264,577,o),
+(320,577,cs),
+(359,577,o),
+(391,541,o),
+(434,517,c),
+(410,402,l),
+(308,402,ls)
+);
+}
+);
+width = 623;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1659;
+unicode = 5721;
+},
+{
+color = 6;
+glyphname = "shCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(187,96,l),
+(211,201,l),
+(138,183,l),
+(175,183,ls),
+(264,183,o),
+(315,229,o),
+(315,306,cs),
+(315,358,o),
+(283,392,o),
+(227,392,cs),
+(201,392,ls),
+(179,392,o),
+(167,401,o),
+(167,417,cs),
+(167,439,o),
+(180,454,o),
+(208,454,cs),
+(344,454,l),
+(360,527,l),
+(279,527,l),
+(298,614,l),
+(210,614,l),
+(185,502,l),
+(258,527,l),
+(221,527,ls),
+(133,527,o),
+(81,482,o),
+(81,404,cs),
+(81,353,o),
+(113,319,o),
+(169,319,cs),
+(195,319,ls),
+(217,319,o),
+(229,310,o),
+(229,294,cs),
+(229,272,o),
+(216,257,o),
+(188,257,cs),
+(52,257,l),
+(36,183,l),
+(118,183,l),
+(99,96,l)
+);
+}
+);
+width = 349;
+}
+);
+metricRight = "=|";
+note = uni18F5;
+unicode = 5722;
+},
+{
+color = 9;
+glyphname = "tsuCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(263,-14,o),
+(326,29,o),
+(363,108,c),
+(327,112,l),
+(335,28,o),
+(385,-14,o),
+(474,-14,cs),
+(602,-14,o),
+(660,80,o),
+(676,207,cs),
+(688,287,o),
+(679,426,o),
+(689,495,cs),
+(694,539,o),
+(710,568,o),
+(747,568,cs),
+(763,568,l),
+(788,690,l),
+(735,690,ls),
+(626,690,o),
+(578,626,o),
+(562,520,cs),
+(558,489,o),
+(557,446,o),
+(555,401,c),
+(465,401,l),
+(505,594,l),
+(552,594,l),
+(572,690,l),
+(355,690,l),
+(335,594,l),
+(382,594,l),
+(341,401,l),
+(250,401,l),
+(278,473,o),
+(305,543,o),
+(305,586,cs),
+(305,654,o),
+(267,690,o),
+(191,690,cs),
+(138,690,l),
+(113,568,l),
+(128,568,ls),
+(153,568,o),
+(164,556,o),
+(164,532,cs),
+(164,454,o),
+(32,263,o),
+(32,139,cs),
+(32,47,o),
+(90,-14,o),
+(184,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(192,115,o),
+(175,132,o),
+(175,166,cs),
+(175,192,o),
+(189,238,o),
+(210,290,c),
+(317,290,l),
+(298,200,ls),
+(286,142,o),
+(262,115,o),
+(223,115,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(416,115,o),
+(413,164,o),
+(422,204,cs),
+(440,290,l),
+(549,290,l),
+(547,261,o),
+(545,236,o),
+(542,220,cs),
+(538,169,o),
+(520,115,o),
+(467,115,cs)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165B;
+unicode = 5723;
+},
+{
+color = 9;
+glyphname = "tsoCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(44,0,ls),
+(155,0,o),
+(203,64,o),
+(217,170,cs),
+(221,201,o),
+(222,243,o),
+(224,289,c),
+(316,289,l),
+(274,96,l),
+(228,96,l),
+(209,0,l),
+(425,0,l),
+(445,96,l),
+(398,96,l),
+(439,289,l),
+(530,289,l),
+(502,216,o),
+(474,147,o),
+(474,103,cs),
+(474,36,o),
+(513,0,o),
+(589,0,cs),
+(641,0,l),
+(668,122,l),
+(651,122,ls),
+(627,122,o),
+(615,133,o),
+(615,157,cs),
+(615,236,o),
+(748,427,o),
+(748,551,cs),
+(748,642,o),
+(690,703,o),
+(596,703,cs),
+(517,703,o),
+(454,661,o),
+(417,582,c),
+(453,578,l),
+(444,662,o),
+(394,703,o),
+(305,703,cs),
+(178,703,o),
+(120,610,o),
+(103,483,cs),
+(92,403,o),
+(100,264,o),
+(91,195,cs),
+(86,151,o),
+(70,122,o),
+(33,122,cs),
+(17,122,l),
+(-9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(233,429,o),
+(236,454,o),
+(238,469,cs),
+(242,521,o),
+(261,575,o),
+(313,575,cs),
+(364,575,o),
+(366,526,o),
+(357,486,cs),
+(339,400,l),
+(231,400,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(481,490,ls),
+(494,548,o),
+(518,575,o),
+(556,575,cs),
+(588,575,o),
+(605,557,o),
+(605,524,cs),
+(605,497,o),
+(590,452,o),
+(570,400,c),
+(463,400,l)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165C;
+unicode = 5724;
+},
+{
+color = 9;
+glyphname = "tseCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(491,-14,o),
+(565,116,o),
+(565,223,cs),
+(565,293,o),
+(531,345,o),
+(472,358,c),
+(461,328,l),
+(584,346,o),
+(634,458,o),
+(634,547,cs),
+(634,639,o),
+(578,703,o),
+(493,703,cs),
+(391,703,o),
+(315,613,o),
+(281,613,cs),
+(267,613,o),
+(263,624,o),
+(269,653,cs),
+(277,690,l),
+(149,690,l),
+(134,623,ls),
+(117,539,o),
+(149,497,o),
+(219,497,cs),
+(244,497,o),
+(268,502,o),
+(284,511,c),
+(261,559,l),
+(226,391,l),
+(158,391,l),
+(173,456,l),
+(99,456,l),
+(51,234,l),
+(126,234,l),
+(139,298,l),
+(206,298,l),
+(170,130,l),
+(213,179,l),
+(196,186,o),
+(176,193,o),
+(151,193,cs),
+(81,193,o),
+(36,156,o),
+(16,67,cs),
+(3,0,l),
+(130,0,l),
+(135,25,ls),
+(143,62,o),
+(155,76,o),
+(173,76,cs),
+(219,76,o),
+(265,-14,o),
+(367,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(319,113,o),
+(293,134,o),
+(262,154,c),
+(293,298,l),
+(360,298,ls),
+(406,298,o),
+(430,273,o),
+(430,224,cs),
+(430,184,o),
+(406,113,o),
+(350,113,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(344,536,l),
+(380,555,o),
+(412,577,o),
+(442,577,cs),
+(473,577,o),
+(491,554,o),
+(491,518,cs),
+(491,460,o),
+(458,391,o),
+(384,391,cs),
+(313,391,l)
+);
+}
+);
+width = 623;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni165D;
+unicode = 5725;
+},
+{
+color = 9;
+glyphname = "tseeCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(491,-14,o),
+(565,116,o),
+(565,223,cs),
+(565,293,o),
+(531,345,o),
+(472,358,c),
+(461,328,l),
+(584,346,o),
+(634,458,o),
+(634,547,cs),
+(634,639,o),
+(578,703,o),
+(493,703,cs),
+(391,703,o),
+(315,613,o),
+(281,613,cs),
+(267,613,o),
+(263,624,o),
+(269,653,cs),
+(277,690,l),
+(149,690,l),
+(134,623,ls),
+(117,539,o),
+(149,497,o),
+(219,497,cs),
+(244,497,o),
+(268,502,o),
+(284,511,c),
+(248,559,l),
+(213,389,l),
+(153,389,l),
+(166,456,l),
+(99,456,l),
+(51,234,l),
+(119,234,l),
+(133,300,l),
+(194,300,l),
+(157,130,l),
+(213,179,l),
+(196,186,o),
+(176,193,o),
+(151,193,cs),
+(81,193,o),
+(36,156,o),
+(16,67,cs),
+(3,0,l),
+(130,0,l),
+(135,25,ls),
+(143,62,o),
+(155,76,o),
+(173,76,cs),
+(219,76,o),
+(265,-14,o),
+(367,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(315,113,o),
+(273,148,o),
+(242,168,c),
+(270,300,l),
+(322,300,l),
+(302,208,l),
+(362,208,l),
+(386,320,l),
+(351,300,l),
+(362,300,ls),
+(406,300,o),
+(430,273,o),
+(430,224,cs),
+(430,175,o),
+(403,113,o),
+(350,113,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(419,479,l),
+(360,479,l),
+(342,389,l),
+(289,389,l),
+(317,524,l),
+(354,540,o),
+(403,577,o),
+(442,577,cs),
+(473,577,o),
+(494,554,o),
+(494,518,cs),
+(494,460,o),
+(460,389,o),
+(387,389,cs),
+(372,389,l),
+(398,378,l)
+);
+}
+);
+width = 623;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165E;
+unicode = 5726;
+},
+{
+color = 9;
+glyphname = "tsiCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(491,-14,o),
+(565,117,o),
+(565,223,cs),
+(565,293,o),
+(531,345,o),
+(472,358,c),
+(461,328,l),
+(584,346,o),
+(634,458,o),
+(634,547,cs),
+(634,639,o),
+(578,703,o),
+(493,703,cs),
+(391,703,o),
+(315,613,o),
+(281,613,cs),
+(267,613,o),
+(263,624,o),
+(269,654,cs),
+(277,690,l),
+(149,690,l),
+(134,623,ls),
+(117,539,o),
+(149,497,o),
+(219,497,cs),
+(242,497,o),
+(264,501,o),
+(279,510,c),
+(243,559,l),
+(208,389,l),
+(153,389,l),
+(166,456,l),
+(99,456,l),
+(51,234,l),
+(119,234,l),
+(133,300,l),
+(189,300,l),
+(153,130,l),
+(207,180,l),
+(191,187,o),
+(175,193,o),
+(151,193,cs),
+(81,193,o),
+(36,156,o),
+(16,67,cs),
+(3,0,l),
+(130,0,l),
+(135,25,ls),
+(143,62,o),
+(155,76,o),
+(173,76,cs),
+(219,76,o),
+(265,-14,o),
+(367,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(313,113,o),
+(270,150,o),
+(237,169,c),
+(265,300,l),
+(286,300,l),
+(296,271,o),
+(321,250,o),
+(354,250,cs),
+(385,250,o),
+(408,269,o),
+(422,304,c),
+(349,300,l),
+(362,300,ls),
+(406,300,o),
+(430,273,o),
+(430,224,cs),
+(430,175,o),
+(403,113,o),
+(350,113,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(424,414,o),
+(394,440,o),
+(360,440,cs),
+(330,440,o),
+(300,418,o),
+(293,389,c),
+(283,389,l),
+(312,522,l),
+(348,537,o),
+(402,577,o),
+(442,577,cs),
+(473,577,o),
+(494,554,o),
+(494,518,cs),
+(494,460,o),
+(460,389,o),
+(387,389,cs),
+(369,389,l),
+(432,378,l)
+);
+}
+);
+width = 623;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165F;
+unicode = 5727;
+},
+{
+color = 9;
+glyphname = "tsaCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(275,-14,o),
+(351,76,o),
+(385,76,cs),
+(399,76,o),
+(404,66,o),
+(397,37,cs),
+(389,0,l),
+(517,0,l),
+(531,67,ls),
+(550,151,o),
+(518,193,o),
+(447,193,cs),
+(421,193,o),
+(399,187,o),
+(382,179,c),
+(405,130,l),
+(440,298,l),
+(507,298,l),
+(494,234,l),
+(568,234,l),
+(615,456,l),
+(541,456,l),
+(526,391,l),
+(461,391,l),
+(497,559,l),
+(454,511,l),
+(470,503,o),
+(490,497,o),
+(515,497,cs),
+(585,497,o),
+(631,534,o),
+(649,623,cs),
+(664,690,l),
+(536,690,l),
+(530,665,ls),
+(523,628,o),
+(511,613,o),
+(493,613,cs),
+(447,613,o),
+(402,703,o),
+(299,703,cs),
+(176,703,o),
+(101,574,o),
+(101,467,cs),
+(101,397,o),
+(135,345,o),
+(194,331,c),
+(205,361,l),
+(82,344,o),
+(32,232,o),
+(32,143,cs),
+(32,51,o),
+(88,-14,o),
+(174,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(193,113,o),
+(175,136,o),
+(175,172,cs),
+(175,230,o),
+(209,298,o),
+(281,298,cs),
+(354,298,l),
+(323,154,l),
+(287,134,o),
+(254,113,o),
+(224,113,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(260,391,o),
+(236,416,o),
+(236,466,cs),
+(236,506,o),
+(261,577,o),
+(317,577,cs),
+(347,577,o),
+(373,555,o),
+(404,536,c),
+(373,391,l),
+(305,391,ls)
+);
+}
+);
+width = 623;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1660;
+unicode = 5728;
+},
+{
+color = 9;
+glyphname = "chuCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(263,-14,o),
+(326,29,o),
+(363,108,c),
+(327,112,l),
+(335,28,o),
+(385,-14,o),
+(474,-14,cs),
+(602,-14,o),
+(660,80,o),
+(676,207,cs),
+(688,287,o),
+(679,426,o),
+(689,495,cs),
+(694,539,o),
+(710,568,o),
+(747,568,cs),
+(763,568,l),
+(788,690,l),
+(735,690,ls),
+(626,690,o),
+(578,626,o),
+(562,520,cs),
+(551,445,o),
+(550,287,o),
+(542,223,cs),
+(538,169,o),
+(520,115,o),
+(467,115,cs),
+(416,115,o),
+(414,164,o),
+(423,204,cs),
+(505,594,l),
+(552,594,l),
+(572,690,l),
+(355,690,l),
+(335,594,l),
+(382,594,l),
+(298,200,ls),
+(286,142,o),
+(262,115,o),
+(223,115,cs),
+(192,115,o),
+(175,132,o),
+(175,166,cs),
+(175,242,o),
+(305,487,o),
+(305,586,cs),
+(305,654,o),
+(267,690,o),
+(191,690,cs),
+(138,690,l),
+(113,568,l),
+(128,568,ls),
+(153,568,o),
+(164,556,o),
+(164,532,cs),
+(164,454,o),
+(32,263,o),
+(32,139,cs),
+(32,47,o),
+(90,-14,o),
+(184,-14,cs)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164E;
+unicode = 5729;
+},
+{
+color = 9;
+glyphname = "choCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(44,0,ls),
+(155,0,o),
+(203,64,o),
+(217,170,cs),
+(229,244,o),
+(230,403,o),
+(238,467,cs),
+(242,521,o),
+(261,575,o),
+(313,575,cs),
+(364,575,o),
+(365,526,o),
+(357,486,cs),
+(274,96,l),
+(228,96,l),
+(209,0,l),
+(425,0,l),
+(445,96,l),
+(399,96,l),
+(482,490,ls),
+(495,548,o),
+(518,575,o),
+(556,575,cs),
+(588,575,o),
+(605,557,o),
+(605,524,cs),
+(605,447,o),
+(474,203,o),
+(474,103,cs),
+(474,36,o),
+(513,0,o),
+(589,0,cs),
+(640,0,l),
+(667,122,l),
+(651,122,ls),
+(627,122,o),
+(615,133,o),
+(615,157,cs),
+(615,236,o),
+(748,427,o),
+(748,551,cs),
+(748,642,o),
+(690,703,o),
+(596,703,cs),
+(517,703,o),
+(454,661,o),
+(417,582,c),
+(453,578,l),
+(444,662,o),
+(394,703,o),
+(305,703,cs),
+(178,703,o),
+(120,610,o),
+(103,483,cs),
+(92,403,o),
+(100,264,o),
+(91,195,cs),
+(86,151,o),
+(70,122,o),
+(33,122,cs),
+(17,122,l),
+(-9,0,l)
+);
+}
+);
+width = 736;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5730;
+},
+{
+color = 9;
+glyphname = "cheCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(491,-14,o),
+(565,116,o),
+(565,223,cs),
+(565,293,o),
+(531,345,o),
+(472,358,c),
+(461,328,l),
+(584,346,o),
+(634,458,o),
+(634,547,cs),
+(634,639,o),
+(578,703,o),
+(493,703,cs),
+(391,703,o),
+(315,613,o),
+(281,613,cs),
+(267,613,o),
+(263,624,o),
+(269,653,cs),
+(277,690,l),
+(149,690,l),
+(134,623,ls),
+(117,539,o),
+(149,495,o),
+(220,495,cs),
+(313,495,o),
+(382,577,o),
+(441,577,cs),
+(472,577,o),
+(490,554,o),
+(490,518,cs),
+(490,460,o),
+(457,402,o),
+(384,402,cs),
+(161,402,l),
+(173,456,l),
+(99,456,l),
+(51,234,l),
+(126,234,l),
+(136,288,l),
+(358,288,ls),
+(404,288,o),
+(428,265,o),
+(428,224,cs),
+(428,184,o),
+(403,113,o),
+(347,113,cs),
+(288,113,o),
+(244,195,o),
+(151,195,cs),
+(81,195,o),
+(35,153,o),
+(16,67,cs),
+(3,0,l),
+(130,0,l),
+(135,25,ls),
+(143,62,o),
+(155,76,o),
+(173,76,cs),
+(219,76,o),
+(265,-14,o),
+(367,-14,cs)
+);
+}
+);
+width = 623;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni1663;
+unicode = 5731;
+},
+{
+color = 9;
+glyphname = "cheeCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(491,-14,o),
+(565,116,o),
+(565,223,cs),
+(565,293,o),
+(531,345,o),
+(472,358,c),
+(461,328,l),
+(584,346,o),
+(634,458,o),
+(634,547,cs),
+(634,639,o),
+(578,703,o),
+(493,703,cs),
+(391,703,o),
+(315,613,o),
+(281,613,cs),
+(267,613,o),
+(263,624,o),
+(269,653,cs),
+(277,690,l),
+(149,690,l),
+(134,623,ls),
+(117,539,o),
+(148,494,o),
+(219,494,cs),
+(313,494,o),
+(381,579,o),
+(440,579,cs),
+(471,579,o),
+(493,554,o),
+(493,518,cs),
+(493,460,o),
+(460,391,o),
+(387,391,cs),
+(346,391,l),
+(371,372,l),
+(392,471,l),
+(318,471,l),
+(300,391,l),
+(158,391,l),
+(173,456,l),
+(99,456,l),
+(51,234,l),
+(126,234,l),
+(139,298,l),
+(282,298,l),
+(265,215,l),
+(338,215,l),
+(361,325,l),
+(330,298,l),
+(368,298,ls),
+(413,298,o),
+(430,265,o),
+(430,224,cs),
+(430,184,o),
+(404,111,o),
+(348,111,cs),
+(289,111,o),
+(243,196,o),
+(151,196,cs),
+(80,196,o),
+(35,153,o),
+(16,67,cs),
+(3,0,l),
+(130,0,l),
+(135,25,ls),
+(143,62,o),
+(155,76,o),
+(173,76,cs),
+(219,76,o),
+(265,-14,o),
+(367,-14,cs)
+);
+}
+);
+width = 623;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1664;
+unicode = 5732;
+},
+{
+color = 9;
+glyphname = "chiCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(491,-14,o),
+(565,116,o),
+(565,223,cs),
+(565,293,o),
+(531,345,o),
+(472,358,c),
+(461,328,l),
+(584,346,o),
+(634,458,o),
+(634,547,cs),
+(634,639,o),
+(578,703,o),
+(493,703,cs),
+(391,703,o),
+(315,613,o),
+(281,613,cs),
+(267,613,o),
+(263,624,o),
+(269,653,cs),
+(277,690,l),
+(149,690,l),
+(134,623,ls),
+(117,539,o),
+(148,494,o),
+(219,494,cs),
+(313,494,o),
+(381,579,o),
+(440,579,cs),
+(471,579,o),
+(493,554,o),
+(493,518,cs),
+(493,460,o),
+(460,391,o),
+(393,391,cs),
+(350,391,l),
+(391,370,l),
+(383,411,o),
+(347,440,o),
+(303,440,cs),
+(265,440,o),
+(238,420,o),
+(221,391,c),
+(158,391,l),
+(173,456,l),
+(99,456,l),
+(51,234,l),
+(126,234,l),
+(139,298,l),
+(222,298,l),
+(237,272,o),
+(263,250,o),
+(303,250,cs),
+(349,250,o),
+(382,280,o),
+(392,326,c),
+(335,298,l),
+(375,298,ls),
+(411,298,o),
+(430,270,o),
+(430,224,cs),
+(430,184,o),
+(404,111,o),
+(348,111,cs),
+(289,111,o),
+(243,196,o),
+(151,196,cs),
+(80,196,o),
+(35,153,o),
+(16,67,cs),
+(3,0,l),
+(130,0,l),
+(135,25,ls),
+(143,62,o),
+(155,76,o),
+(173,76,cs),
+(219,76,o),
+(265,-14,o),
+(367,-14,cs)
+);
+}
+);
+width = 623;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1665;
+unicode = 5733;
+},
+{
+color = 9;
+glyphname = "chaCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(275,-12,o),
+(352,78,o),
+(385,78,cs),
+(400,78,o),
+(404,68,o),
+(398,38,cs),
+(390,2,l),
+(518,2,l),
+(532,69,ls),
+(551,153,o),
+(519,197,o),
+(447,197,cs),
+(354,197,o),
+(286,115,o),
+(226,115,cs),
+(195,115,o),
+(177,138,o),
+(177,174,cs),
+(177,232,o),
+(211,290,o),
+(283,290,cs),
+(505,290,l),
+(495,236,l),
+(569,236,l),
+(615,458,l),
+(542,458,l),
+(530,404,l),
+(308,404,ls),
+(263,404,o),
+(240,427,o),
+(240,468,cs),
+(240,507,o),
+(264,579,o),
+(321,579,cs),
+(379,579,o),
+(423,497,o),
+(516,497,cs),
+(585,497,o),
+(632,539,o),
+(650,625,cs),
+(665,692,l),
+(537,692,l),
+(531,667,ls),
+(524,630,o),
+(512,615,o),
+(494,615,cs),
+(448,615,o),
+(403,705,o),
+(300,705,cs),
+(177,705,o),
+(101,575,o),
+(101,469,cs),
+(101,399,o),
+(136,347,o),
+(194,333,c),
+(206,363,l),
+(83,346,o),
+(33,234,o),
+(33,145,cs),
+(33,53,o),
+(89,-12,o),
+(175,-12,cs)
+);
+}
+);
+width = 624;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1666;
+unicode = 5734;
+},
+{
+color = 9;
+glyphname = "ttsuCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(263,-14,o),
+(326,29,o),
+(363,108,c),
+(327,112,l),
+(335,28,o),
+(385,-14,o),
+(474,-14,cs),
+(602,-14,o),
+(660,80,o),
+(676,207,cs),
+(688,287,o),
+(679,426,o),
+(689,495,cs),
+(694,539,o),
+(710,568,o),
+(747,568,cs),
+(763,568,l),
+(788,690,l),
+(735,690,ls),
+(626,690,o),
+(578,626,o),
+(562,520,cs),
+(557,489,o),
+(554,459,o),
+(551,429,c),
+(611,536,l),
+(472,438,l),
+(505,594,l),
+(552,594,l),
+(572,690,l),
+(355,690,l),
+(335,594,l),
+(382,594,l),
+(349,440,l),
+(239,547,l),
+(268,437,l),
+(289,497,o),
+(305,550,o),
+(305,586,cs),
+(305,654,o),
+(267,690,o),
+(191,690,cs),
+(138,690,l),
+(113,568,l),
+(128,568,ls),
+(153,568,o),
+(164,556,o),
+(164,532,cs),
+(164,454,o),
+(32,263,o),
+(32,139,cs),
+(32,47,o),
+(90,-14,o),
+(184,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(192,115,o),
+(175,132,o),
+(175,166,cs),
+(175,211,o),
+(214,294,o),
+(248,377,c),
+(321,308,l),
+(298,200,ls),
+(286,142,o),
+(262,115,o),
+(223,115,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(416,115,o),
+(414,164,o),
+(423,204,cs),
+(442,295,l),
+(548,366,l),
+(546,311,o),
+(545,258,o),
+(542,223,cs),
+(538,169,o),
+(520,115,o),
+(467,115,cs)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1667;
+unicode = 5735;
+},
+{
+color = 9;
+glyphname = "ttsoCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(44,0,ls),
+(155,0,o),
+(203,64,o),
+(217,170,cs),
+(222,201,o),
+(225,231,o),
+(229,261,c),
+(169,154,l),
+(307,252,l),
+(274,96,l),
+(228,96,l),
+(209,0,l),
+(425,0,l),
+(445,96,l),
+(399,96,l),
+(431,249,l),
+(541,143,l),
+(512,253,l),
+(491,193,o),
+(474,140,o),
+(474,103,cs),
+(474,36,o),
+(513,0,o),
+(589,0,cs),
+(641,0,l),
+(668,122,l),
+(651,122,ls),
+(627,122,o),
+(615,133,o),
+(615,157,cs),
+(615,236,o),
+(748,427,o),
+(748,551,cs),
+(748,642,o),
+(690,703,o),
+(596,703,cs),
+(517,703,o),
+(454,661,o),
+(417,582,c),
+(453,578,l),
+(444,662,o),
+(394,703,o),
+(305,703,cs),
+(178,703,o),
+(120,610,o),
+(103,483,cs),
+(92,403,o),
+(100,264,o),
+(91,195,cs),
+(86,151,o),
+(70,122,o),
+(33,122,cs),
+(17,122,l),
+(-9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(234,379,o),
+(235,432,o),
+(238,467,cs),
+(242,521,o),
+(261,575,o),
+(313,575,cs),
+(364,575,o),
+(365,526,o),
+(357,486,cs),
+(338,395,l),
+(232,324,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(459,382,l),
+(482,490,ls),
+(495,548,o),
+(518,575,o),
+(556,575,cs),
+(588,575,o),
+(605,557,o),
+(605,524,cs),
+(605,479,o),
+(565,396,o),
+(532,313,c)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1668;
+unicode = 5736;
+},
+{
+color = 9;
+glyphname = "ttseCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(489,-14,o),
+(565,116,o),
+(565,222,cs),
+(565,294,o),
+(531,344,o),
+(471,358,c),
+(460,328,l),
+(584,346,o),
+(634,456,o),
+(634,546,cs),
+(634,638,o),
+(578,703,o),
+(492,703,cs),
+(390,703,o),
+(315,613,o),
+(280,613,cs),
+(267,613,o),
+(262,624,o),
+(269,653,cs),
+(276,690,l),
+(149,690,l),
+(134,623,ls),
+(116,539,o),
+(147,494,o),
+(219,494,cs),
+(234,494,o),
+(246,496,o),
+(259,498,c),
+(198,562,l),
+(225,391,l),
+(158,391,l),
+(173,456,l),
+(99,456,l),
+(51,234,l),
+(126,234,l),
+(139,298,l),
+(206,298,l),
+(110,134,l),
+(200,188,l),
+(185,193,o),
+(169,196,o),
+(151,196,cs),
+(79,196,o),
+(35,154,o),
+(16,67,cs),
+(2,0,l),
+(129,0,l),
+(135,25,ls),
+(143,62,o),
+(155,76,o),
+(173,76,cs),
+(218,76,o),
+(264,-14,o),
+(366,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(307,110,o),
+(276,149,o),
+(236,170,c),
+(308,298,l),
+(373,298,ls),
+(412,298,o),
+(432,272,o),
+(432,233,cs),
+(432,189,o),
+(405,110,o),
+(347,110,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(302,516,l),
+(353,536,o),
+(398,580,o),
+(440,580,cs),
+(473,580,o),
+(493,554,o),
+(493,515,cs),
+(493,463,o),
+(460,391,o),
+(389,391,cs),
+(320,391,l)
+);
+}
+);
+width = 624;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1669;
+unicode = 5737;
+},
+{
+color = 9;
+glyphname = "ttseeCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(489,-14,o),
+(565,116,o),
+(565,222,cs),
+(565,294,o),
+(531,344,o),
+(471,358,c),
+(460,328,l),
+(584,346,o),
+(634,456,o),
+(634,546,cs),
+(634,638,o),
+(578,703,o),
+(492,703,cs),
+(390,703,o),
+(315,613,o),
+(280,613,cs),
+(267,613,o),
+(262,624,o),
+(269,653,cs),
+(276,690,l),
+(149,690,l),
+(134,623,ls),
+(116,539,o),
+(147,494,o),
+(219,494,cs),
+(234,494,o),
+(246,496,o),
+(259,498,c),
+(193,562,l),
+(219,391,l),
+(158,391,l),
+(173,456,l),
+(99,456,l),
+(51,234,l),
+(126,234,l),
+(139,298,l),
+(201,298,l),
+(105,134,l),
+(200,188,l),
+(185,193,o),
+(169,196,o),
+(151,196,cs),
+(79,196,o),
+(35,154,o),
+(16,67,cs),
+(2,0,l),
+(129,0,l),
+(135,25,ls),
+(143,62,o),
+(155,76,o),
+(173,76,cs),
+(218,76,o),
+(264,-14,o),
+(366,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(306,110,o),
+(265,159,o),
+(223,178,c),
+(293,298,l),
+(321,298,l),
+(301,208,l),
+(367,208,l),
+(389,315,l),
+(360,298,l),
+(373,298,ls),
+(412,298,o),
+(432,272,o),
+(432,233,cs),
+(432,189,o),
+(405,110,o),
+(347,110,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(424,479,l),
+(359,479,l),
+(340,391,l),
+(304,391,l),
+(287,507,l),
+(337,525,o),
+(395,580,o),
+(440,580,cs),
+(473,580,o),
+(493,554,o),
+(493,515,cs),
+(493,463,o),
+(460,391,o),
+(389,391,cs),
+(376,391,l),
+(402,374,l)
+);
+}
+);
+width = 624;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166A;
+unicode = 5738;
+},
+{
+color = 9;
+glyphname = "ttsiCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(489,-14,o),
+(565,116,o),
+(565,222,cs),
+(565,294,o),
+(531,344,o),
+(471,358,c),
+(460,328,l),
+(584,346,o),
+(634,456,o),
+(634,546,cs),
+(634,638,o),
+(578,703,o),
+(492,703,cs),
+(390,703,o),
+(315,613,o),
+(280,613,cs),
+(267,613,o),
+(262,624,o),
+(269,653,cs),
+(276,690,l),
+(149,690,l),
+(134,623,ls),
+(116,539,o),
+(147,494,o),
+(219,494,cs),
+(234,494,o),
+(246,496,o),
+(259,498,c),
+(193,562,l),
+(219,391,l),
+(158,391,l),
+(173,456,l),
+(99,456,l),
+(51,234,l),
+(126,234,l),
+(139,298,l),
+(201,298,l),
+(105,134,l),
+(200,188,l),
+(185,193,o),
+(169,196,o),
+(151,196,cs),
+(79,196,o),
+(35,154,o),
+(16,67,cs),
+(2,0,l),
+(129,0,l),
+(135,25,ls),
+(143,62,o),
+(155,76,o),
+(173,76,cs),
+(218,76,o),
+(264,-14,o),
+(366,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(306,110,o),
+(262,160,o),
+(221,179,c),
+(290,298,l),
+(287,298,l),
+(297,271,o),
+(327,250,o),
+(357,250,cs),
+(398,250,o),
+(423,282,o),
+(434,315,c),
+(360,298,l),
+(378,298,ls),
+(414,298,o),
+(432,272,o),
+(432,233,cs),
+(432,189,o),
+(405,110,o),
+(347,110,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(423,414,o),
+(395,440,o),
+(357,440,cs),
+(328,440,o),
+(297,420,o),
+(286,391,c),
+(299,391,l),
+(283,506,l),
+(333,523,o),
+(395,580,o),
+(440,580,cs),
+(473,580,o),
+(493,554,o),
+(493,515,cs),
+(493,463,o),
+(463,391,o),
+(391,391,cs),
+(376,391,l),
+(435,374,l)
+);
+}
+);
+width = 624;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166B;
+unicode = 5739;
+},
+{
+color = 9;
+glyphname = "ttsaCarrier-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(275,-14,o),
+(352,76,o),
+(385,76,cs),
+(400,76,o),
+(404,66,o),
+(398,37,cs),
+(390,0,l),
+(518,0,l),
+(532,67,ls),
+(550,151,o),
+(519,196,o),
+(447,196,cs),
+(433,196,o),
+(420,194,o),
+(408,191,c),
+(468,128,l),
+(441,298,l),
+(507,298,l),
+(494,234,l),
+(567,234,l),
+(614,456,l),
+(541,456,l),
+(526,391,l),
+(460,391,l),
+(555,555,l),
+(467,501,l),
+(481,497,o),
+(497,494,o),
+(516,494,cs),
+(587,494,o),
+(631,536,o),
+(650,623,cs),
+(665,690,l),
+(536,690,l),
+(531,665,ls),
+(524,628,o),
+(512,613,o),
+(494,613,cs),
+(447,613,o),
+(403,703,o),
+(300,703,cs),
+(177,703,o),
+(101,574,o),
+(101,468,cs),
+(101,396,o),
+(135,346,o),
+(195,331,c),
+(207,361,l),
+(82,344,o),
+(32,234,o),
+(32,144,cs),
+(32,52,o),
+(88,-14,o),
+(175,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(193,110,o),
+(174,136,o),
+(174,175,cs),
+(174,227,o),
+(206,298,o),
+(277,298,cs),
+(347,298,l),
+(364,174,l),
+(314,154,o),
+(269,110,o),
+(226,110,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(255,391,o),
+(234,417,o),
+(234,457,cs),
+(234,500,o),
+(261,580,o),
+(319,580,cs),
+(358,580,o),
+(390,541,o),
+(431,520,c),
+(358,391,l),
+(293,391,ls)
+);
+}
+);
+width = 623;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni166C;
+unicode = 5740;
+},
+{
+glyphname = "qai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (277,0);
+ref = "ke-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni166F;
+unicode = 5743;
+},
+{
+glyphname = "ngai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (517,0);
+ref = "ce-canadian";
+}
+);
+width = 1016;
+}
+);
+note = uni1670;
+unicode = 5744;
+},
+{
+glyphname = "nngi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (766,0);
+ref = "ci-canadian";
+}
+);
+width = 1265;
+}
+);
+note = uni1671;
+unicode = 5745;
+},
+{
+glyphname = "nngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (766,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (941,0);
+ref = dot_top;
+}
+);
+width = 1265;
+}
+);
+note = uni1672;
+unicode = 5746;
+},
+{
+glyphname = "nngo-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (766,0);
+ref = "ce-canadian";
+}
+);
+width = 1265;
+}
+);
+note = uni1673;
+unicode = 5747;
+},
+{
+glyphname = "nngoo-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (766,0);
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (927,0);
+ref = dot_top;
+}
+);
+width = 1265;
+}
+);
+note = uni1674;
+unicode = 5748;
+},
+{
+glyphname = "nnga-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (766,0);
+ref = "ca-canadian";
+}
+);
+width = 1265;
+}
+);
+note = uni1675;
+unicode = 5749;
+},
+{
+glyphname = "nngaa-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (766,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (802,0);
+ref = dot_top;
+}
+);
+width = 1265;
+}
+);
+note = uni1676;
+unicode = 5750;
+},
+{
+glyphname = "thweeWoodScree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (525,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 728;
+}
+);
+note = uni1677;
+unicode = 5751;
+},
+{
+glyphname = "thwiWoodScree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (525,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 728;
+}
+);
+note = uni1678;
+unicode = 5752;
+},
+{
+glyphname = "thwiiWoodScree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (70,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (525,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 728;
+}
+);
+note = uni1679;
+unicode = 5753;
+},
+{
+glyphname = "thwoWoodScree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (525,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 728;
+}
+);
+note = uni167A;
+unicode = 5754;
+},
+{
+glyphname = "thwooWoodScree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (287,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (525,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 728;
+}
+);
+note = uni167B;
+unicode = 5755;
+},
+{
+glyphname = "thwaWoodScree-canadian";
+lastChange = "2023-01-13 15:56:57 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = middle_right_can;
+pos = (525,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 729;
+}
+);
+note = uni167C;
+unicode = 5756;
+},
+{
+glyphname = "thwaaWoodScree-canadian";
+lastChange = "2023-01-13 15:56:57 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (70,0);
+ref = dot_top;
+},
+{
+anchor = middle_right_can;
+pos = (525,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 729;
+}
+);
+note = uni167D;
+unicode = 5757;
+},
+{
+glyphname = "wBlackfoot-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(379,548,l),
+(395,628,l),
+(126,628,l),
+(108,548,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(349,407,l),
+(365,487,l),
+(95,487,l),
+(78,407,l)
+);
+}
+);
+width = 357;
+}
+);
+metricRight = "=|";
+note = uni167F;
+unicode = 5759;
+},
+{
+glyphname = "oy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-11,0);
+ref = ring_top.canadian;
+}
+);
+width = 572;
+}
+);
+note = uni18B0;
+unicode = 6320;
+},
+{
+glyphname = "ay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (343,0);
+ref = ring_top.canadian;
+}
+);
+width = 572;
+}
+);
+note = uni18B1;
+unicode = 6321;
+},
+{
+glyphname = "aay-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (131,0);
+ref = ring_top.canadian;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (376,0);
+ref = dot_top;
+}
+);
+width = 572;
+}
+);
+note = uni18B2;
+unicode = 6322;
+},
+{
+glyphname = "way-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (547,0);
+ref = ring_top.canadian;
+}
+);
+width = 776;
+}
+);
+note = uni18B3;
+unicode = 6323;
+},
+{
+glyphname = "poy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-21,0);
+ref = ring_top.canadian;
+}
+);
+width = 554;
+}
+);
+note = uni18B4;
+unicode = 6324;
+},
+{
+glyphname = "pay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (342,0);
+ref = ring_top.canadian;
+}
+);
+width = 554;
+}
+);
+note = uni18B5;
+unicode = 6325;
+},
+{
+glyphname = "pwoy-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (183,0);
+ref = ring_top.canadian;
+}
+);
+width = 757;
+}
+);
+note = uni18B6;
+unicode = 6326;
+},
+{
+glyphname = "tay-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (169,0);
+ref = ring_top.canadian;
+}
+);
+width = 522;
+}
+);
+note = uni18B7;
+unicode = 6327;
+},
+{
+glyphname = "kay-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (2,0);
+ref = ring_top.canadian;
+}
+);
+width = 511;
+}
+);
+note = uni18B8;
+unicode = 6328;
+},
+{
+glyphname = "kway-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (206,0);
+ref = ring_top.canadian;
+}
+);
+width = 715;
+}
+);
+note = uni18B9;
+unicode = 6329;
+},
+{
+glyphname = "may-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (6,0);
+ref = ring_top.canadian;
+}
+);
+width = 469;
+}
+);
+note = uni18BA;
+unicode = 6330;
+},
+{
+glyphname = "noy-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (273,-182);
+ref = ring_top.canadian;
+}
+);
+width = 684;
+}
+);
+note = uni18BB;
+unicode = 6331;
+},
+{
+glyphname = "nay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (98,-182);
+ref = ring_top.canadian;
+}
+);
+width = 684;
+}
+);
+note = uni18BC;
+unicode = 6332;
+},
+{
+glyphname = "lay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (99,-182);
+ref = ring_top.canadian;
+}
+);
+width = 684;
+}
+);
+note = uni18BD;
+unicode = 6333;
+},
+{
+glyphname = "soy-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (232,0);
+ref = ring_top.canadian;
+}
+);
+width = 472;
+}
+);
+note = uni18BE;
+unicode = 6334;
+},
+{
+glyphname = "say-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (6,0);
+ref = ring_top.canadian;
+}
+);
+width = 472;
+}
+);
+note = uni18BF;
+unicode = 6335;
+},
+{
+glyphname = "shoy-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (229,-182);
+ref = ring_top.canadian;
+}
+);
+width = 769;
+}
+);
+note = uni18C0;
+unicode = 6336;
+},
+{
+glyphname = "shay-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (229,-182);
+ref = ring_top.canadian;
+}
+);
+width = 769;
+}
+);
+note = uni18C1;
+unicode = 6337;
+},
+{
+glyphname = "shwoy-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (433,-182);
+ref = ring_top.canadian;
+}
+);
+width = 973;
+}
+);
+note = uni18C2;
+unicode = 6338;
+},
+{
+glyphname = "yoy-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (254,0);
+ref = ring_top.canadian;
+}
+);
+width = 493;
+}
+);
+note = uni18C3;
+unicode = 6339;
+},
+{
+glyphname = "yay-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (5,0);
+ref = ring_top.canadian;
+}
+);
+width = 493;
+}
+);
+note = uni18C4;
+unicode = 6340;
+},
+{
+glyphname = "ray-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (146,0);
+ref = ring_top.canadian;
+}
+);
+width = 473;
+}
+);
+note = uni18C5;
+unicode = 6341;
+},
+{
+glyphname = "nwi-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ni-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni18C6;
+unicode = 6342;
+},
+{
+glyphname = "nwiOjibway-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (684,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni18C7;
+unicode = 6343;
+},
+{
+glyphname = "nwii-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (353,-182);
+ref = dot_top;
+}
+);
+width = 888;
+}
+);
+note = uni18C8;
+unicode = 6344;
+},
+{
+glyphname = "nwiiOjibway-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (149,-182);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (684,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni18C9;
+unicode = 6345;
+},
+{
+glyphname = "nwo-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "no-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni18CA;
+unicode = 6346;
+},
+{
+glyphname = "nwoOjibway-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (684,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni18CB;
+unicode = 6347;
+},
+{
+glyphname = "nwoo-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (510,-182);
+ref = dot_top;
+}
+);
+width = 888;
+}
+);
+note = uni18CC;
+unicode = 6348;
+},
+{
+glyphname = "nwooOjibway-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (306,-182);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (684,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni18CD;
+unicode = 6349;
+},
+{
+glyphname = "rwee-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "reRCree-canadian";
+}
+);
+width = 923;
+}
+);
+note = uni18CE;
+unicode = 6350;
+},
+{
+glyphname = "rwi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ri-canadian";
+}
+);
+width = 923;
+}
+);
+note = uni18CF;
+unicode = 6351;
+},
+{
+glyphname = "rwii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (343,-182);
+ref = dot_top;
+}
+);
+width = 923;
+}
+);
+note = uni18D0;
+unicode = 6352;
+},
+{
+glyphname = "rwo-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ro-canadian";
+}
+);
+width = 677;
+}
+);
+note = uni18D1;
+unicode = 6353;
+},
+{
+glyphname = "rwoo-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (329,0);
+ref = dot_top;
+}
+);
+width = 677;
+}
+);
+note = uni18D2;
+unicode = 6354;
+},
+{
+glyphname = "rwa-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ra-canadian";
+}
+);
+width = 677;
+}
+);
+note = uni18D3;
+unicode = 6355;
+},
+{
+glyphname = "pOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(139,345,l),
+(273,583,l),
+(214,583,l),
+(248,345,l),
+(334,345,l),
+(338,362,l),
+(273,690,l),
+(253,690,l),
+(49,362,l),
+(45,345,l)
+);
+}
+);
+width = 337;
+}
+);
+metricLeft = "kkCarrier-canadian";
+note = uni18D4;
+unicode = 6356;
+},
+{
+glyphname = "tOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 361;
+}
+);
+metricRight = "=|";
+note = uni1422;
+unicode = 6357;
+},
+{
+glyphname = "kOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(158,345,l),
+(190,492,l),
+(171,491,l),
+(168,459,o),
+(194,434,o),
+(232,434,cs),
+(314,434,o),
+(352,529,o),
+(352,590,cs),
+(352,655,o),
+(312,696,o),
+(245,696,cs),
+(177,696,o),
+(129,654,o),
+(111,564,cs),
+(65,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(205,503,o),
+(195,515,o),
+(195,537,cs),
+(195,563,o),
+(211,627,o),
+(243,627,cs),
+(260,627,o),
+(270,614,o),
+(270,593,cs),
+(270,565,o),
+(253,503,o),
+(221,503,cs)
+);
+}
+);
+width = 316;
+}
+);
+metricLeft = "k-canadian";
+metricRight = "k-canadian";
+note = uni18D6;
+unicode = 6358;
+},
+{
+glyphname = "cOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(159,345,l),
+(210,583,ls),
+(215,611,o),
+(228,622,o),
+(246,622,cs),
+(267,622,o),
+(275,606,o),
+(270,582,cs),
+(262,545,l),
+(349,545,l),
+(353,564,ls),
+(368,640,o),
+(330,696,o),
+(247,696,cs),
+(176,696,o),
+(130,654,o),
+(114,577,cs),
+(65,345,l)
+);
+}
+);
+width = 309;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni18D7;
+unicode = 6359;
+},
+{
+glyphname = "mOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(159,345,l),
+(213,601,l),
+(332,601,l),
+(351,690,l),
+(138,690,l),
+(65,345,l)
+);
+}
+);
+width = 283;
+}
+);
+metricLeft = "m-canadian";
+metricRight = "m-canadian";
+note = uni18D8;
+unicode = 6360;
+},
+{
+glyphname = "nOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(293,428,o),
+(339,510,o),
+(339,583,cs),
+(339,603,o),
+(334,622,o),
+(323,637,c),
+(310,601,l),
+(441,601,l),
+(460,690,l),
+(240,690,ls),
+(146,690,o),
+(100,611,o),
+(100,532,cs),
+(100,469,o),
+(141,428,o),
+(205,428,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(192,497,o),
+(183,510,o),
+(183,533,cs),
+(183,562,o),
+(196,621,o),
+(230,621,cs),
+(247,621,o),
+(257,608,o),
+(257,584,cs),
+(257,555,o),
+(243,497,o),
+(210,497,cs)
+);
+}
+);
+width = 392;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "n-canadian";
+note = uni18D9;
+unicode = 6361;
+},
+{
+glyphname = "sOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(158,345,l),
+(187,485,l),
+(118,450,l),
+(155,450,ls),
+(253,450,o),
+(314,506,o),
+(337,615,cs),
+(353,690,l),
+(258,690,l),
+(244,622,ls),
+(230,553,o),
+(196,524,o),
+(130,524,cs),
+(101,524,l),
+(64,345,l)
+);
+}
+);
+width = 300;
+}
+);
+metricLeft = "s-canadian";
+metricRight = "s-canadian";
+note = uni18DA;
+unicode = 6362;
+},
+{
+color = 1;
+glyphname = "shOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(243,342,o),
+(286,383,o),
+(310,467,cs),
+(342,580,ls),
+(351,612,o),
+(361,625,o),
+(381,625,cs),
+(399,625,o),
+(408,612,o),
+(403,586,cs),
+(394,548,l),
+(480,548,l),
+(486,574,ls),
+(502,648,o),
+(462,698,o),
+(384,698,cs),
+(315,698,o),
+(271,658,o),
+(247,573,cs),
+(216,461,ls),
+(207,428,o),
+(196,414,o),
+(177,414,cs),
+(158,414,o),
+(150,428,o),
+(155,454,cs),
+(163,493,l),
+(77,493,l),
+(71,466,ls),
+(55,391,o),
+(97,342,o),
+(174,342,cs)
+);
+}
+);
+width = 440;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "c-canadian";
+note = uni18DB;
+unicode = 6363;
+},
+{
+color = 9;
+glyphname = "easternw-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (-48,-307);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (151,0);
+ref = "glottalstop-canadian";
+}
+);
+width = 507;
+}
+);
+note = uni18DC;
+unicode = 6364;
+},
+{
+color = 9;
+glyphname = "westernw-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (673,-307);
+ref = dot_top;
+scale = (-1,1);
+},
+{
+alignment = -1;
+ref = "glottalstop-canadian";
+}
+);
+width = 507;
+}
+);
+metricLeft = "glottalstop-canadian";
+note = uni18DD;
+unicode = 6365;
+},
+{
+glyphname = "rweRCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "reRCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (719,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 923;
+}
+);
+note = uni18E0;
+unicode = 6368;
+},
+{
+glyphname = "looWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (39,0);
+ref = dot_top;
+}
+);
+width = 473;
+}
+);
+note = uni18E1;
+unicode = 6369;
+},
+{
+glyphname = "laaWestCree-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (266,0);
+ref = dot_top;
+}
+);
+width = 473;
+}
+);
+note = uni18E2;
+unicode = 6370;
+},
+{
+glyphname = "thwe-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "the-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (627,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 831;
+}
+);
+note = uni18E3;
+unicode = 6371;
+},
+{
+glyphname = "thwa-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (574,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 777;
+}
+);
+note = uni18E4;
+unicode = 6372;
+},
+{
+glyphname = "tthwe-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "tthe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (619,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 823;
+}
+);
+note = uni18E5;
+unicode = 6373;
+},
+{
+glyphname = "tthoo-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ttho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (163,0);
+ref = dot_top;
+}
+);
+width = 533;
+}
+);
+note = uni18E6;
+unicode = 6374;
+},
+{
+glyphname = "tthaa-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ttha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (178,0);
+ref = dot_top;
+}
+);
+width = 533;
+}
+);
+note = uni18E7;
+unicode = 6375;
+},
+{
+glyphname = "tlhwe-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "tlhe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (525,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 728;
+}
+);
+note = uni18E8;
+unicode = 6376;
+},
+{
+glyphname = "tlhoo-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "tlho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (185,0);
+ref = dot_top;
+}
+);
+width = 525;
+}
+);
+note = uni18E9;
+unicode = 6377;
+},
+{
+glyphname = "shweSayisi-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "sheSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (521,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 725;
+}
+);
+note = uni18EA;
+unicode = 6378;
+},
+{
+glyphname = "shooSayisi-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "shoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (317,0);
+ref = dot_top;
+}
+);
+width = 521;
+}
+);
+note = uni18EB;
+unicode = 6379;
+},
+{
+color = 9;
+glyphname = "hooSayisi-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "hoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (389,0);
+ref = dot_top;
+}
+);
+width = 595;
+}
+);
+note = uni18EC;
+unicode = 6380;
+},
+{
+color = 9;
+glyphname = "gwuCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "guCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (720,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 923;
+}
+);
+note = uni18ED;
+unicode = 6381;
+},
+{
+color = 9;
+glyphname = "deneGeeCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "geCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (230,0);
+ref = dot_top;
+}
+);
+width = 622;
+}
+);
+note = uni18EE;
+unicode = 6382;
+},
+{
+color = 9;
+glyphname = "gaaCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (241,0);
+ref = dot_top;
+}
+);
+width = 622;
+}
+);
+note = uni18EF;
+unicode = 6383;
+},
+{
+color = 9;
+glyphname = "gwaCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (622,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 826;
+}
+);
+note = uni18F0;
+unicode = 6384;
+},
+{
+color = 9;
+glyphname = "juuSayisi-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "juSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (234,0);
+ref = dot_top;
+}
+);
+width = 620;
+}
+);
+note = uni18F1;
+unicode = 6385;
+},
+{
+color = 9;
+glyphname = "jwaCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "jaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (669,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 873;
+}
+);
+note = uni18F2;
+unicode = 6386;
+},
+{
+glyphname = "lBeaverDene-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "pWestCree-canadian";
+}
+);
+width = 181;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+unicode = 6387;
+},
+{
+glyphname = "rBeaverDene-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(159,345,l),
+(198,527,ls),
+(208,575,o),
+(232,597,o),
+(271,597,cs),
+(280,597,l),
+(300,696,l),
+(296,696,ls),
+(248,696,o),
+(215,665,o),
+(202,607,c),
+(207,607,l),
+(224,690,l),
+(138,690,l),
+(65,345,l)
+);
+}
+);
+width = 231;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni18F4;
+unicode = 6388;
+},
+{
+color = 6;
+glyphname = "sDentalCarrier-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(174,183,ls),
+(263,183,o),
+(315,228,o),
+(315,306,cs),
+(315,357,o),
+(282,392,o),
+(227,392,cs),
+(201,392,ls),
+(178,392,o),
+(166,401,o),
+(166,417,cs),
+(166,439,o),
+(180,454,o),
+(208,454,cs),
+(343,454,l),
+(359,527,l),
+(221,527,ls),
+(132,527,o),
+(81,481,o),
+(81,404,cs),
+(81,353,o),
+(113,319,o),
+(168,319,cs),
+(194,319,ls),
+(217,319,o),
+(228,310,o),
+(228,294,cs),
+(228,272,o),
+(215,257,o),
+(187,257,cs),
+(51,257,l),
+(36,183,l)
+);
+}
+);
+width = 349;
+}
+);
+metricLeft = "shCarrier-canadian";
+metricRight = "=|";
+note = uni18F5;
+unicode = 6389;
+},
+{
+glyphname = "pWestCree-canadian.base";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-74,-345);
+ref = "pWestCree-canadian";
+}
+);
+width = 181;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.base";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-74,-345);
+ref = "c-canadian";
+}
+);
+width = 307;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "thSayisi-canadian.base";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-73,-345);
+ref = "thSayisi-canadian";
+}
+);
+width = 309;
+}
+);
+metricLeft = "=|c-canadian";
+note = uni14A2;
+},
+{
+glyphname = "mWestCree-canadian.base";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-73,-345);
+ref = "mWestCree-canadian";
+}
+);
+width = 303;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+glyphname = "pWestCree-canadian.mid";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-162);
+ref = "pWestCree-canadian";
+}
+);
+width = 181;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.mid";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-162);
+ref = "c-canadian";
+}
+);
+width = 308;
+}
+);
+metricLeft = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "mWestCree-canadian.mid";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-34,-162);
+ref = "mWestCree-canadian";
+}
+);
+width = 304;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+color = 11;
+glyphname = "ngaai-canadian.nunavik";
+lastChange = "2023-01-13 15:56:57 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (553,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (696,0);
+ref = ring_top.canadian;
+}
+);
+width = 1056;
+}
+);
+note = uni158E;
+},
+{
+color = 11;
+glyphname = "ngi-canadian.nunavik";
+lastChange = "2023-01-13 15:56:57 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (553,0);
+ref = "ci-canadian";
+}
+);
+width = 1056;
+}
+);
+note = uni158F;
+},
+{
+color = 11;
+glyphname = "ngii-canadian.nunavik";
+lastChange = "2023-01-13 15:56:57 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (553,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (729,0);
+ref = dot_top;
+}
+);
+width = 1056;
+}
+);
+note = uni1590;
+},
+{
+color = 11;
+glyphname = "ngo-canadian.nunavik";
+lastChange = "2023-01-13 15:56:57 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (553,0);
+ref = "co-canadian";
+}
+);
+width = 1055;
+}
+);
+note = uni1591;
+},
+{
+color = 11;
+glyphname = "ngoo-canadian.nunavik";
+lastChange = "2023-01-13 15:56:57 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "ngo-canadian.nunavik";
+},
+{
+anchor = top_right_can;
+pos = (852,0);
+ref = dot_top;
+}
+);
+width = 1055;
+}
+);
+note = uni1592;
+},
+{
+color = 11;
+glyphname = "nga-canadian.nunavik";
+lastChange = "2023-01-13 15:56:57 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (553,0);
+ref = "ca-canadian";
+}
+);
+width = 1056;
+}
+);
+note = uni1593;
+},
+{
+color = 11;
+glyphname = "ngaa-canadian.nunavik";
+lastChange = "2023-01-13 15:56:57 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (553,0);
+ref = "ca-canadian";
+},
+{
+anchor = top_left_can;
+pos = (589,0);
+ref = dot_top;
+}
+);
+width = 1056;
+}
+);
+note = uni1594;
+},
+{
+color = 11;
+glyphname = "ng-canadian.nunavik";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(496,167,o),
+(533,267,o),
+(533,333,cs),
+(533,391,o),
+(502,429,o),
+(451,429,cs),
+(418,429,o),
+(393,412,o),
+(380,384,c),
+(400,376,l),
+(433,524,l),
+(296,524,l),
+(297,481,l),
+(326,508,o),
+(340,555,o),
+(340,591,cs),
+(340,654,o),
+(301,696,o),
+(236,696,cs),
+(147,696,o),
+(101,614,o),
+(101,541,cs),
+(101,476,o),
+(142,434,o),
+(209,434,cs),
+(359,434,l),
+(328,478,l),
+(293,312,ls),
+(278,246,o),
+(299,167,o),
+(394,167,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(385,236,o),
+(374,249,o),
+(374,271,cs),
+(374,298,o),
+(389,360,o),
+(421,360,cs),
+(438,360,o),
+(447,348,o),
+(447,326,cs),
+(447,298,o),
+(432,236,o),
+(401,236,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(193,502,o),
+(183,516,o),
+(183,539,cs),
+(183,566,o),
+(197,627,o),
+(230,627,cs),
+(248,627,o),
+(258,613,o),
+(258,590,cs),
+(258,564,o),
+(243,502,o),
+(210,502,cs)
+);
+}
+);
+width = 553;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+color = 11;
+glyphname = "ngai-canadian.nunavik";
+lastChange = "2023-01-13 15:56:57 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (553,0);
+ref = "ce-canadian";
+}
+);
+width = 1055;
+}
+);
+note = uni1670;
+},
+{
+color = 11;
+glyphname = "ke-canadian.square";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (397,690);
+},
+{
+name = top_left_can;
+pos = (214,690);
+},
+{
+name = top_right_can;
+pos = (584,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(508,0,l),
+(655,690,l),
+(443,690,ls),
+(203,690,o),
+(76,552,o),
+(76,364,cs),
+(76,223,o),
+(173,130,o),
+(328,130,cs),
+(393,130,l),
+(366,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(263,256,o),
+(217,297,o),
+(217,371,cs),
+(217,465,o),
+(268,565,o),
+(411,565,cs),
+(486,565,l),
+(420,256,l),
+(354,256,ls)
+);
+}
+);
+width = 611;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146B;
+},
+{
+color = 11;
+glyphname = "ki-canadian.square";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (405,690);
+},
+{
+name = top_left_can;
+pos = (217,690);
+},
+{
+name = top_right_can;
+pos = (591,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(141,0,l),
+(169,130,l),
+(242,130,ls),
+(479,130,o),
+(606,270,o),
+(606,456,cs),
+(606,598,o),
+(509,690,o),
+(354,690,cs),
+(146,690,l),
+(-1,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(262,565,l),
+(334,565,ls),
+(419,565,o),
+(465,524,o),
+(465,449,cs),
+(465,356,o),
+(416,256,o),
+(273,256,cs),
+(196,256,l)
+);
+}
+);
+width = 612;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni146D;
+},
+{
+color = 11;
+glyphname = "kii-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (226,0);
+ref = dot_top;
+}
+);
+width = 611;
+}
+);
+note = uni146E;
+},
+{
+color = 11;
+glyphname = "ko-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (397,690);
+},
+{
+name = top_left_can;
+pos = (214,690);
+},
+{
+name = top_right_can;
+pos = (584,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(508,0,l),
+(655,690,l),
+(513,690,l),
+(485,559,l),
+(412,559,ls),
+(175,559,o),
+(48,420,o),
+(48,234,cs),
+(48,92,o),
+(145,0,o),
+(300,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(235,125,o),
+(189,166,o),
+(189,241,cs),
+(189,333,o),
+(238,434,o),
+(381,434,cs),
+(459,434,l),
+(392,125,l),
+(320,125,ls)
+);
+}
+);
+width = 611;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146F;
+},
+{
+color = 11;
+glyphname = "koo-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (405,0);
+ref = dot_top;
+}
+);
+width = 611;
+}
+);
+note = uni1470;
+},
+{
+color = 11;
+glyphname = "ka-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (405,690);
+},
+{
+name = top_left_can;
+pos = (217,690);
+},
+{
+name = top_right_can;
+pos = (592,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(211,0,ls),
+(451,0,o),
+(578,138,o),
+(578,326,cs),
+(578,467,o),
+(481,559,o),
+(326,559,cs),
+(261,559,l),
+(288,690,l),
+(146,690,l),
+(-1,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(234,434,l),
+(299,434,ls),
+(391,434,o),
+(438,393,o),
+(438,319,cs),
+(438,225,o),
+(386,125,o),
+(243,125,cs),
+(168,125,l)
+);
+}
+);
+width = 611;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1472;
+},
+{
+color = 11;
+glyphname = "kaa-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (39,0);
+ref = dot_top;
+}
+);
+width = 611;
+}
+);
+note = uni1473;
+},
+{
+color = 11;
+glyphname = "kweWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (611,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 814;
+}
+);
+note = uni1475;
+},
+{
+color = 11;
+glyphname = "kwiiWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (226,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (611,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 814;
+}
+);
+note = uni1479;
+},
+{
+color = 11;
+glyphname = "kwoWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (611,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 814;
+}
+);
+note = uni147B;
+},
+{
+color = 11;
+glyphname = "kwooWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (405,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (611,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 814;
+}
+);
+note = uni147D;
+},
+{
+color = 11;
+glyphname = "kwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (611,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 814;
+}
+);
+note = uni147F;
+},
+{
+color = 11;
+glyphname = "kwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (39,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (611,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 814;
+}
+);
+note = uni1481;
+},
+{
+color = 11;
+glyphname = "ce-canadian.square";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (391,690);
+},
+{
+name = top_left_can;
+pos = (202,690);
+},
+{
+name = top_right_can;
+pos = (582,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(505,0,l),
+(593,413,ls),
+(630,587,o),
+(542,703,o),
+(366,703,cs),
+(213,703,o),
+(115,611,o),
+(79,447,cs),
+(65,382,l),
+(206,382,l),
+(218,440,ls),
+(238,528,o),
+(282,573,o),
+(355,573,cs),
+(438,574,o),
+(473,519,o),
+(453,422,cs),
+(363,0,l)
+);
+}
+);
+width = 605;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni1489;
+},
+{
+color = 11;
+glyphname = "ci-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (404,690);
+},
+{
+name = top_left_can;
+pos = (215,690);
+},
+{
+name = top_right_can;
+pos = (595,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(139,0,l),
+(233,440,ls),
+(251,528,o),
+(298,573,o),
+(372,573,cs),
+(453,573,o),
+(488,521,o),
+(469,428,cs),
+(458,382,l),
+(599,382,l),
+(606,413,ls),
+(642,586,o),
+(551,704,o),
+(381,704,cs),
+(228,704,o),
+(128,614,o),
+(91,444,cs),
+(-4,0,l)
+);
+}
+);
+width = 606;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+},
+{
+color = 11;
+glyphname = "cii-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (225,0);
+ref = dot_top;
+}
+);
+width = 607;
+}
+);
+note = uni148C;
+},
+{
+color = 11;
+glyphname = "co-canadian.square";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (391,690);
+},
+{
+name = top_left_can;
+pos = (202,690);
+},
+{
+name = top_right_can;
+pos = (582,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(421,-14,o),
+(522,75,o),
+(557,245,cs),
+(652,690,l),
+(510,690,l),
+(416,250,ls),
+(397,161,o),
+(351,117,o),
+(276,117,cs),
+(196,117,o),
+(160,169,o),
+(181,262,cs),
+(190,308,l),
+(49,308,l),
+(43,276,ls),
+(7,103,o),
+(98,-14,o),
+(268,-14,cs)
+);
+}
+);
+width = 605;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+},
+{
+color = 11;
+glyphname = "coo-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (403,0);
+ref = dot_top;
+}
+);
+width = 607;
+}
+);
+note = uni148E;
+},
+{
+color = 11;
+glyphname = "ca-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (404,690);
+},
+{
+name = top_left_can;
+pos = (214,690);
+},
+{
+name = top_right_can;
+pos = (595,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(435,-14,o),
+(534,78,o),
+(569,242,cs),
+(583,308,l),
+(442,308,l),
+(430,250,ls),
+(411,161,o),
+(367,117,o),
+(294,117,cs),
+(211,116,o),
+(175,171,o),
+(196,268,cs),
+(286,690,l),
+(143,690,l),
+(55,276,ls),
+(18,102,o),
+(106,-14,o),
+(282,-14,cs)
+);
+}
+);
+width = 606;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+},
+{
+color = 11;
+glyphname = "caa-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+}
+);
+width = 607;
+}
+);
+note = uni1491;
+},
+{
+color = 11;
+glyphname = "me-canadian.square";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (351,690);
+},
+{
+name = top_double;
+pos = (497,690);
+},
+{
+name = top_left_can;
+pos = (195,690);
+},
+{
+name = top_right_can;
+pos = (497,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(422,0,l),
+(569,690,l),
+(126,690,l),
+(98,560,l),
+(399,560,l),
+(280,0,l)
+);
+}
+);
+width = 525;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+},
+{
+color = 11;
+glyphname = "mi-canadian.square";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (368,690);
+},
+{
+name = top_left_can;
+pos = (217,690);
+},
+{
+name = top_right_can;
+pos = (518,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(141,0,l),
+(261,560,l),
+(562,560,l),
+(589,690,l),
+(146,690,l),
+(-1,0,l)
+);
+}
+);
+width = 526;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+},
+{
+color = 11;
+glyphname = "mii-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (189,0);
+ref = dot_top;
+}
+);
+width = 526;
+}
+);
+note = uni14A6;
+},
+{
+color = 11;
+glyphname = "mo-canadian.square";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (351,690);
+},
+{
+name = top_double;
+pos = (498,690);
+},
+{
+name = top_left_can;
+pos = (196,690);
+},
+{
+name = top_right_can;
+pos = (498,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(422,0,l),
+(569,690,l),
+(427,690,l),
+(307,129,l),
+(6,129,l),
+(-21,0,l)
+);
+}
+);
+width = 525;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+},
+{
+color = 11;
+glyphname = "moo-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (320,0);
+ref = dot_top;
+}
+);
+width = 526;
+}
+);
+note = uni14A8;
+},
+{
+color = 11;
+glyphname = "ma-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (368,690);
+},
+{
+name = top_left_can;
+pos = (217,690);
+},
+{
+name = top_right_can;
+pos = (518,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(443,0,l),
+(470,129,l),
+(169,129,l),
+(288,690,l),
+(146,690,l),
+(-1,0,l)
+);
+}
+);
+width = 526;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+},
+{
+color = 11;
+glyphname = "maa-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (39,0);
+ref = dot_top;
+}
+);
+width = 526;
+}
+);
+note = uni14AB;
+},
+{
+color = 11;
+glyphname = "ne-canadian.square";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (474,690);
+},
+{
+name = top_left_can;
+pos = (319,690);
+},
+{
+name = top_right_can;
+pos = (632,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(485,-14,o),
+(568,62,o),
+(601,216,cs),
+(701,690,l),
+(132,690,l),
+(105,562,l),
+(221,562,l),
+(154,243,ls),
+(120,85,o),
+(195,-14,o),
+(350,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(301,117,o),
+(275,155,o),
+(290,221,cs),
+(362,562,l),
+(533,562,l),
+(460,215,ls),
+(445,148,o),
+(414,117,o),
+(361,117,cs)
+);
+}
+);
+width = 655;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C0;
+},
+{
+color = 11;
+glyphname = "ni-canadian.square";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (370,690);
+},
+{
+name = top_left_can;
+pos = (214,690);
+},
+{
+name = top_right_can;
+pos = (527,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(380,-14,o),
+(463,62,o),
+(497,216,cs),
+(570,562,l),
+(685,562,l),
+(712,690,l),
+(143,690,l),
+(48,243,ls),
+(15,85,o),
+(91,-14,o),
+(245,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(197,117,o),
+(171,156,o),
+(185,221,cs),
+(257,562,l),
+(429,562,l),
+(355,215,ls),
+(341,149,o),
+(310,117,o),
+(257,117,cs)
+);
+}
+);
+width = 655;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+},
+{
+color = 11;
+glyphname = "nii-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (191,0);
+ref = dot_top;
+}
+);
+width = 655;
+}
+);
+note = uni14C3;
+},
+{
+color = 11;
+glyphname = "no-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (474,690);
+},
+{
+name = top_double;
+pos = (484,690);
+},
+{
+name = top_left_can;
+pos = (318,690);
+},
+{
+name = top_right_can;
+pos = (609,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(554,0,l),
+(648,446,ls),
+(682,605,o),
+(607,704,o),
+(452,704,cs),
+(317,704,o),
+(234,628,o),
+(201,473,cs),
+(128,128,l),
+(12,128,l),
+(-15,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(342,474,ls),
+(356,541,o),
+(386,573,o),
+(440,573,cs),
+(500,573,o),
+(526,534,o),
+(512,469,cs),
+(440,128,l),
+(269,128,l)
+);
+}
+);
+width = 654;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C4;
+},
+{
+color = 11;
+glyphname = "noo-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (295,0);
+ref = dot_top;
+}
+);
+width = 655;
+}
+);
+note = uni14C5;
+},
+{
+color = 11;
+glyphname = "na-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (370,690);
+},
+{
+name = top_double;
+pos = (380,690);
+},
+{
+name = top_left_can;
+pos = (214,690);
+},
+{
+name = top_right_can;
+pos = (527,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(565,0,l),
+(592,128,l),
+(477,128,l),
+(545,446,ls),
+(579,605,o),
+(503,704,o),
+(349,704,cs),
+(213,704,o),
+(130,628,o),
+(98,473,cs),
+(-4,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(239,474,ls),
+(253,542,o),
+(284,573,o),
+(337,573,cs),
+(396,573,o),
+(423,535,o),
+(409,469,cs),
+(336,128,l),
+(165,128,l)
+);
+}
+);
+width = 654;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+},
+{
+color = 11;
+glyphname = "naa-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (191,0);
+ref = dot_top;
+}
+);
+width = 655;
+}
+);
+note = uni14C8;
+},
+{
+color = 11;
+glyphname = "nweWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (655,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 859;
+}
+);
+note = uni14CA;
+},
+{
+color = 11;
+glyphname = "nwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (655,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 859;
+}
+);
+note = uni14CC;
+},
+{
+color = 11;
+glyphname = "nwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (191,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (655,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 859;
+}
+);
+note = uni14CE;
+},
+{
+color = 11;
+glyphname = "se-canadian.square";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (218,690);
+},
+{
+name = top_right_can;
+pos = (595,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(511,0,l),
+(574,295,l),
+(387,295,ls),
+(258,295,o),
+(215,347,o),
+(244,478,cs),
+(289,690,l),
+(147,690,l),
+(101,478,ls),
+(62,292,o),
+(166,169,o),
+(362,169,cs),
+(442,169,l),
+(413,205,l),
+(369,0,l)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14ED;
+},
+{
+color = 11;
+glyphname = "si-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (218,690);
+},
+{
+name = top_right_can;
+pos = (595,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,0,l),
+(186,207,l),
+(142,170,l),
+(220,170,ls),
+(450,170,o),
+(565,257,o),
+(609,461,cs),
+(658,690,l),
+(516,690,l),
+(467,463,ls),
+(442,351,o),
+(369,295,o),
+(247,295,cs),
+(63,295,l),
+(0,0,l)
+);
+}
+);
+width = 614;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+},
+{
+color = 11;
+glyphname = "sii-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (416,0);
+ref = dot_top;
+}
+);
+width = 614;
+}
+);
+note = uni14F0;
+},
+{
+color = 11;
+glyphname = "so-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (587,690);
+},
+{
+name = top_left_can;
+pos = (218,690);
+},
+{
+name = top_right_can;
+pos = (587,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,0,l),
+(191,227,ls),
+(214,339,o),
+(289,395,o),
+(411,395,cs),
+(595,395,l),
+(658,690,l),
+(516,690,l),
+(471,483,l),
+(516,520,l),
+(438,520,ls),
+(208,520,o),
+(93,433,o),
+(48,229,cs),
+(0,0,l)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+},
+{
+color = 11;
+glyphname = "soo-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (408,0);
+ref = dot_top;
+}
+);
+width = 614;
+}
+);
+note = uni14F2;
+},
+{
+color = 11;
+glyphname = "sa-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (218,690);
+},
+{
+name = top_right_can;
+pos = (587,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(511,0,l),
+(556,212,ls),
+(596,398,o),
+(491,521,o),
+(296,521,cs),
+(215,521,l),
+(245,485,l),
+(289,690,l),
+(147,690,l),
+(84,395,l),
+(270,395,ls),
+(400,395,o),
+(441,343,o),
+(413,212,cs),
+(369,0,l)
+);
+}
+);
+width = 614;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+},
+{
+color = 11;
+glyphname = "saa-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (40,0);
+ref = dot_top;
+}
+);
+width = 614;
+}
+);
+note = uni14F5;
+},
+{
+color = 11;
+glyphname = "sho-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (399,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(502,0,l),
+(527,116,l),
+(254,116,ls),
+(204,116,o),
+(176,139,o),
+(176,184,cs),
+(176,239,o),
+(206,288,o),
+(289,288,cs),
+(368,288,ls),
+(534,288,o),
+(620,384,o),
+(620,521,cs),
+(620,623,o),
+(552,690,o),
+(445,690,cs),
+(149,690,l),
+(124,574,l),
+(399,574,ls),
+(450,574,o),
+(477,550,o),
+(477,506,cs),
+(477,450,o),
+(447,403,o),
+(364,403,cs),
+(286,403,ls),
+(118,403,o),
+(34,305,o),
+(34,169,cs),
+(34,67,o),
+(101,0,o),
+(209,0,cs)
+);
+}
+);
+width = 611;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+color = 11;
+glyphname = "shoo-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (221,0);
+ref = dot_top;
+}
+);
+width = 611;
+}
+);
+note = g728;
+},
+{
+color = 11;
+glyphname = "sha-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (410,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(304,0,ls),
+(475,0,o),
+(559,96,o),
+(559,237,cs),
+(559,337,o),
+(495,403,o),
+(389,403,cs),
+(315,403,ls),
+(265,403,o),
+(237,425,o),
+(237,469,cs),
+(237,527,o),
+(268,574,o),
+(350,574,cs),
+(625,574,l),
+(649,690,l),
+(349,690,ls),
+(179,690,o),
+(95,593,o),
+(95,454,cs),
+(95,353,o),
+(158,288,o),
+(264,288,cs),
+(338,288,ls),
+(388,288,o),
+(416,265,o),
+(416,221,cs),
+(416,162,o),
+(385,116,o),
+(302,116,cs),
+(27,116,l),
+(3,0,l)
+);
+}
+);
+width = 611;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+color = 11;
+glyphname = "shaa-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (231,0);
+ref = dot_top;
+}
+);
+width = 611;
+}
+);
+note = g730;
+},
+{
+color = 11;
+glyphname = "ye-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (194,690);
+},
+{
+name = top_right_can;
+pos = (602,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(526,0,l),
+(588,294,l),
+(248,294,l),
+(253,233,l),
+(668,598,l),
+(578,701,l),
+(18,207,l),
+(11,169,l),
+(419,169,l),
+(383,0,l)
+);
+}
+);
+width = 628;
+}
+);
+metricLeft = "ye-canadian";
+note = uni1526;
+},
+{
+color = 11;
+glyphname = "yi-canadian.square";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (216,690);
+},
+{
+name = top_right_can;
+pos = (622,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(141,0,l),
+(177,169,l),
+(586,169,l),
+(594,207,l),
+(217,701,l),
+(102,611,l),
+(389,233,l),
+(400,294,l),
+(61,294,l),
+(-2,0,l)
+);
+}
+);
+width = 628;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni1528;
+},
+{
+color = 11;
+glyphname = "yii-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (37,0);
+ref = dot_top;
+}
+);
+width = 628;
+}
+);
+note = uni1529;
+},
+{
+color = 11;
+glyphname = "yo-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (602,690);
+},
+{
+name = top_left_can;
+pos = (195,690);
+},
+{
+name = top_right_can;
+pos = (602,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(569,78,l),
+(282,457,l),
+(271,396,l),
+(611,396,l),
+(673,690,l),
+(530,690,l),
+(495,521,l),
+(85,521,l),
+(77,483,l),
+(454,-12,l)
+);
+}
+);
+width = 628;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152A;
+},
+{
+color = 11;
+glyphname = "yoo-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (423,0);
+ref = dot_top;
+}
+);
+width = 628;
+}
+);
+note = uni152B;
+},
+{
+color = 11;
+glyphname = "ya-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (215,690);
+},
+{
+name = top_right_can;
+pos = (622,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(653,483,l),
+(661,521,l),
+(252,521,l),
+(288,690,l),
+(146,690,l),
+(83,396,l),
+(422,396,l),
+(417,457,l),
+(3,92,l),
+(93,-12,l)
+);
+}
+);
+width = 628;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152D;
+},
+{
+color = 11;
+glyphname = "yaa-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+}
+);
+width = 628;
+}
+);
+note = uni152E;
+},
+{
+color = 11;
+glyphname = "re-canadian.square";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (370,690);
+},
+{
+name = top_left_can;
+pos = (214,690);
+},
+{
+name = top_right_can;
+pos = (527,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(380,-14,o),
+(463,62,o),
+(497,216,cs),
+(570,562,l),
+(685,562,l),
+(712,690,l),
+(456,690,l),
+(355,215,ls),
+(341,149,o),
+(310,117,o),
+(257,117,cs),
+(197,117,o),
+(171,156,o),
+(185,221,cs),
+(284,690,l),
+(143,690,l),
+(48,243,ls),
+(15,85,o),
+(91,-14,o),
+(245,-14,cs)
+);
+}
+);
+width = 655;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1542;
+},
+{
+color = 11;
+glyphname = "reRCree-canadian.square";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (475,690);
+},
+{
+name = top_left_can;
+pos = (319,690);
+},
+{
+name = top_right_can;
+pos = (632,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(485,-14,o),
+(568,62,o),
+(601,216,cs),
+(701,690,l),
+(560,690,l),
+(460,215,ls),
+(445,148,o),
+(414,117,o),
+(361,117,cs),
+(301,117,o),
+(275,155,o),
+(290,221,cs),
+(389,690,l),
+(132,690,l),
+(105,562,l),
+(221,562,l),
+(154,243,ls),
+(120,85,o),
+(195,-14,o),
+(350,-14,cs)
+);
+}
+);
+width = 655;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni1543;
+},
+{
+color = 11;
+glyphname = "leWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (473,690);
+},
+{
+name = top_left_can;
+pos = (318,690);
+},
+{
+name = top_right_can;
+pos = (631,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(242,-1,l),
+(342,473,ls),
+(356,540,o),
+(386,572,o),
+(440,572,cs),
+(500,572,o),
+(526,534,o),
+(512,468,cs),
+(412,-1,l),
+(554,-1,l),
+(648,446,ls),
+(682,605,o),
+(607,704,o),
+(452,704,cs),
+(317,704,o),
+(234,627,o),
+(201,472,cs),
+(127,128,l),
+(12,128,l),
+(-15,-1,l)
+);
+}
+);
+width = 655;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+},
+{
+color = 11;
+glyphname = "ri-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (370,690);
+},
+{
+name = top_left_can;
+pos = (215,690);
+},
+{
+name = top_right_can;
+pos = (527,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(138,0,l),
+(239,474,ls),
+(253,542,o),
+(284,573,o),
+(337,573,cs),
+(396,573,o),
+(423,535,o),
+(409,469,cs),
+(309,0,l),
+(565,0,l),
+(592,128,l),
+(477,128,l),
+(545,446,ls),
+(579,605,o),
+(503,704,o),
+(349,704,cs),
+(213,704,o),
+(130,628,o),
+(98,473,cs),
+(-4,0,l)
+);
+}
+);
+width = 654;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+},
+{
+color = 11;
+glyphname = "rii-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (191,0);
+ref = dot_top;
+}
+);
+width = 655;
+}
+);
+note = uni1547;
+},
+{
+color = 11;
+glyphname = "ro-canadian.square";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (398,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(141,0,l),
+(182,193,l),
+(105,130,l),
+(241,130,ls),
+(464,130,o),
+(589,270,o),
+(589,456,cs),
+(589,598,o),
+(494,690,o),
+(338,690,cs),
+(146,690,l),
+(119,565,l),
+(319,565,ls),
+(404,565,o),
+(448,524,o),
+(448,449,cs),
+(448,355,o),
+(401,256,o),
+(255,256,cs),
+(53,256,l),
+(-1,0,l)
+);
+}
+);
+width = 595;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1548;
+},
+{
+color = 11;
+glyphname = "loWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (397,690);
+},
+{
+name = top_left_can;
+pos = (218,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(209,0,ls),
+(438,0,o),
+(562,138,o),
+(562,326,cs),
+(562,467,o),
+(468,559,o),
+(311,559,cs),
+(198,559,l),
+(248,497,l),
+(289,690,l),
+(147,690,l),
+(92,434,l),
+(292,434,ls),
+(377,434,o),
+(421,393,o),
+(421,319,cs),
+(421,225,o),
+(374,125,o),
+(230,125,cs),
+(26,125,l),
+(0,0,l)
+);
+}
+);
+width = 588;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+},
+{
+color = 11;
+glyphname = "ra-canadian.square";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (380,690);
+},
+{
+name = top_right_can;
+pos = (559,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(483,0,l),
+(538,256,l),
+(338,256,ls),
+(253,256,o),
+(209,297,o),
+(209,371,cs),
+(209,465,o),
+(256,565,o),
+(401,565,cs),
+(604,565,l),
+(631,690,l),
+(421,690,ls),
+(192,690,o),
+(68,552,o),
+(68,364,cs),
+(68,223,o),
+(163,130,o),
+(319,130,cs),
+(432,130,l),
+(383,193,l),
+(341,0,l)
+);
+}
+);
+width = 587;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+},
+{
+color = 11;
+glyphname = "raa-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (202,0);
+ref = dot_top;
+}
+);
+width = 588;
+}
+);
+note = uni154C;
+},
+{
+color = 11;
+glyphname = "laWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (559,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(483,0,l),
+(509,125,l),
+(309,125,ls),
+(225,125,o),
+(180,166,o),
+(180,241,cs),
+(180,334,o),
+(228,434,o),
+(374,434,cs),
+(576,434,l),
+(630,690,l),
+(487,690,l),
+(446,497,l),
+(523,559,l),
+(388,559,ls),
+(165,559,o),
+(40,420,o),
+(40,234,cs),
+(40,92,o),
+(134,0,o),
+(290,0,cs)
+);
+}
+);
+width = 587;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+},
+{
+color = 11;
+glyphname = "reWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(489,0,l),
+(736,199,l),
+(659,295,l),
+(491,159,l),
+(533,128,l),
+(594,413,ls),
+(630,587,o),
+(545,703,o),
+(369,703,cs),
+(218,703,o),
+(116,617,o),
+(79,447,cs),
+(65,382,l),
+(206,382,l),
+(218,440,ls),
+(238,528,o),
+(282,573,o),
+(355,573,cs),
+(438,574,o),
+(473,519,o),
+(453,422,cs),
+(363,0,l)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+},
+{
+color = 11;
+glyphname = "riWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(295,0,l),
+(388,440,ls),
+(408,528,o),
+(453,573,o),
+(527,573,cs),
+(608,573,o),
+(643,521,o),
+(623,428,cs),
+(613,382,l),
+(754,382,l),
+(761,413,ls),
+(797,586,o),
+(706,704,o),
+(536,704,cs),
+(384,704,o),
+(282,614,o),
+(246,444,cs),
+(179,128,l),
+(230,138,l),
+(109,284,l),
+(7,199,l),
+(169,0,l)
+);
+}
+);
+width = 761;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+},
+{
+color = 11;
+glyphname = "roWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(420,-14,o),
+(522,75,o),
+(557,245,cs),
+(625,562,l),
+(574,552,l),
+(695,406,l),
+(798,491,l),
+(635,690,l),
+(509,690,l),
+(415,250,ls),
+(397,161,o),
+(351,117,o),
+(276,117,cs),
+(196,117,o),
+(160,169,o),
+(181,262,cs),
+(190,308,l),
+(49,308,l),
+(43,276,ls),
+(7,103,o),
+(98,-14,o),
+(268,-14,cs)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+},
+{
+color = 11;
+glyphname = "raWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(585,-14,o),
+(689,72,o),
+(725,242,cs),
+(739,308,l),
+(598,308,l),
+(585,250,ls),
+(566,161,o),
+(522,117,o),
+(449,117,cs),
+(366,116,o),
+(330,171,o),
+(351,268,cs),
+(441,690,l),
+(315,690,l),
+(69,491,l),
+(146,395,l),
+(314,530,l),
+(271,562,l),
+(211,276,ls),
+(174,102,o),
+(260,-14,o),
+(435,-14,cs)
+);
+}
+);
+width = 762;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+},
+{
+color = 11;
+glyphname = "theThCree-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (195,690);
+},
+{
+name = top_right_can;
+pos = (602,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(526,0,l),
+(536,53,l),
+(613,53,l),
+(628,118,l),
+(551,118,l),
+(588,294,l),
+(262,294,l),
+(277,252,l),
+(668,598,l),
+(578,701,l),
+(18,207,l),
+(11,169,l),
+(419,169,l),
+(408,118,l),
+(232,118,l),
+(218,53,l),
+(394,53,l),
+(383,0,l)
+);
+}
+);
+width = 679;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15A7;
+},
+{
+color = 11;
+glyphname = "thiThCree-canadian.square";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (265,690);
+},
+{
+name = top_right_can;
+pos = (670,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(190,0,l),
+(202,53,l),
+(379,53,l),
+(392,118,l),
+(216,118,l),
+(227,169,l),
+(637,169,l),
+(644,207,l),
+(268,701,l),
+(153,611,l),
+(429,243,l),
+(454,294,l),
+(111,294,l),
+(73,118,l),
+(-3,118,l),
+(-17,53,l),
+(60,53,l),
+(48,0,l)
+);
+}
+);
+width = 679;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+},
+{
+color = 11;
+glyphname = "thiiThCree-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (86,0);
+ref = dot_top;
+}
+);
+width = 679;
+}
+);
+note = uni15A9;
+},
+{
+color = 11;
+glyphname = "thoThCree-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (195,690);
+},
+{
+name = top_right_can;
+pos = (602,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(568,78,l),
+(292,446,l),
+(268,396,l),
+(610,396,l),
+(647,572,l),
+(725,572,l),
+(738,637,l),
+(662,637,l),
+(672,690,l),
+(530,690,l),
+(519,637,l),
+(343,637,l),
+(328,572,l),
+(505,572,l),
+(494,521,l),
+(85,521,l),
+(77,483,l),
+(454,-12,l)
+);
+}
+);
+width = 679;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+},
+{
+color = 11;
+glyphname = "thooThCree-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (423,0);
+ref = dot_top;
+}
+);
+width = 679;
+}
+);
+note = uni15AB;
+},
+{
+color = 11;
+glyphname = "thaThCree-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (268,690);
+},
+{
+name = top_right_can;
+pos = (673,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(703,483,l),
+(711,521,l),
+(301,521,l),
+(313,572,l),
+(489,572,l),
+(502,637,l),
+(327,637,l),
+(338,690,l),
+(195,690,l),
+(185,637,l),
+(107,637,l),
+(94,572,l),
+(170,572,l),
+(133,396,l),
+(460,396,l),
+(443,438,l),
+(53,92,l),
+(143,-12,l)
+);
+}
+);
+width = 678;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+},
+{
+color = 11;
+glyphname = "thaaThCree-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (89,0);
+ref = dot_top;
+}
+);
+width = 679;
+}
+);
+note = uni15AD;
+},
+{
+color = 11;
+glyphname = "thweeWoodScree-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (679,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 883;
+}
+);
+note = uni1677;
+},
+{
+color = 11;
+glyphname = "thwiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (679,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 883;
+}
+);
+note = uni1678;
+},
+{
+color = 11;
+glyphname = "thwiiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (86,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (679,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 883;
+}
+);
+note = uni1679;
+},
+{
+color = 11;
+glyphname = "thwoWoodScree-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (679,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 883;
+}
+);
+note = uni167A;
+},
+{
+color = 11;
+glyphname = "thwooWoodScree-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (423,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (679,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 883;
+}
+);
+note = uni167B;
+},
+{
+color = 11;
+glyphname = "thwaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (679,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 883;
+}
+);
+note = uni167C;
+},
+{
+color = 11;
+glyphname = "thwaaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (89,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (679,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 883;
+}
+);
+note = uni167D;
+},
+{
+color = 11;
+glyphname = "nwiOjibway-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (655,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 859;
+}
+);
+note = uni18C7;
+},
+{
+color = 11;
+glyphname = "nwiiOjibway-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (191,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (655,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 859;
+}
+);
+note = uni18C9;
+},
+{
+color = 11;
+glyphname = "nwoOjibway-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (655,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 859;
+}
+);
+note = uni18CB;
+},
+{
+color = 11;
+glyphname = "nwooOjibway-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (295,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (655,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 859;
+}
+);
+note = uni18CD;
+},
+{
+color = 11;
+glyphname = "looWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (40,0);
+ref = dot_top;
+}
+);
+width = 588;
+}
+);
+note = uni18E1;
+},
+{
+color = 11;
+glyphname = "laaWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (382,0);
+ref = dot_top;
+}
+);
+width = 588;
+}
+);
+note = uni18E2;
+},
+{
+color = 0;
+glyphname = zero;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(574,568,o),
+(501,699,o),
+(333,699,cs),
+(163,699,o),
+(92,565,o),
+(92,345,cs),
+(92,110,o),
+(176,-10,o),
+(333,-10,cs),
+(497,-10,o),
+(574,104,o),
+(574,345,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(240,434,o),
+(244,580,o),
+(333,580,cs),
+(424,580,o),
+(426,431,o),
+(426,345,cs),
+(426,242,o),
+(415,110,o),
+(333,110,cs),
+(252,110,o),
+(240,242,o),
+(240,345,cs)
+);
+}
+);
+width = 626;
+}
+);
+unicode = 48;
+},
+{
+color = 0;
+glyphname = one;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(295,690,l),
+(70,510,l),
+(147,413,l),
+(235,484,ls),
+(251,497,o),
+(264,510,o),
+(280,527,c),
+(278,483,o),
+(277,445,o),
+(277,405,cs),
+(277,0,l),
+(429,0,l),
+(429,690,l)
+);
+}
+);
+width = 549;
+}
+);
+unicode = 49;
+},
+{
+color = 0;
+glyphname = two;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(590,0,l),
+(590,124,l),
+(301,124,l),
+(301,128,l),
+(386,212,ls),
+(469,289,o),
+(525,346,o),
+(553,408,cs),
+(566,439,o),
+(573,474,o),
+(573,513,cs),
+(573,622,o),
+(485,699,o),
+(354,699,cs),
+(242,699,o),
+(175,659,o),
+(108,600,c),
+(190,503,l),
+(245,551,o),
+(291,574,o),
+(337,574,cs),
+(388,574,o),
+(425,548,o),
+(425,494,cs),
+(425,451,o),
+(410,417,o),
+(370,372,cs),
+(350,348,o),
+(323,319,o),
+(289,283,cs),
+(109,99,l),
+(109,0,l)
+);
+}
+);
+width = 638;
+}
+);
+unicode = 50;
+},
+{
+color = 0;
+glyphname = three;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(568,639,o),
+(483,699,o),
+(348,699,cs),
+(237,699,o),
+(169,669,o),
+(112,630,c),
+(175,529,l),
+(209,553,o),
+(264,579,o),
+(326,579,cs),
+(384,579,o),
+(423,555,o),
+(423,504,cs),
+(423,432,o),
+(342,411,o),
+(269,411,cs),
+(216,411,l),
+(216,298,l),
+(268,298,ls),
+(380,298,o),
+(432,272,o),
+(432,204,cs),
+(432,146,o),
+(395,108,o),
+(292,108,cs),
+(237,108,o),
+(168,125,o),
+(110,154,c),
+(110,29,l),
+(166,6,o),
+(227,-10,o),
+(313,-10,cs),
+(470,-10,o),
+(588,60,o),
+(588,195,cs),
+(588,294,o),
+(527,348,o),
+(416,360,c),
+(416,363,l),
+(503,384,o),
+(568,444,o),
+(568,538,cs)
+);
+}
+);
+width = 632;
+}
+);
+unicode = 51;
+},
+{
+color = 0;
+glyphname = four;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(472,258,l),
+(472,691,l),
+(334,691,l),
+(30,255,l),
+(30,146,l),
+(326,146,l),
+(326,0,l),
+(472,0,l),
+(472,146,l),
+(561,146,l),
+(561,258,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(162,258,l),
+(282,430,ls),
+(302,459,o),
+(310,473,o),
+(325,502,c),
+(329,502,l),
+(329,495,o),
+(326,461,o),
+(326,404,cs),
+(326,258,l)
+);
+}
+);
+width = 590;
+}
+);
+unicode = 52;
+},
+{
+color = 0;
+glyphname = five;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(299,442,o),
+(277,437,o),
+(254,432,c),
+(267,565,l),
+(517,565,l),
+(517,690,l),
+(140,690,l),
+(113,338,l),
+(170,309,l),
+(201,318,o),
+(238,327,o),
+(278,327,cs),
+(367,327,o),
+(412,288,o),
+(412,220,cs),
+(412,149,o),
+(361,108,o),
+(278,108,cs),
+(218,108,o),
+(147,129,o),
+(99,153,c),
+(99,29,l),
+(148,4,o),
+(212,-10,o),
+(290,-10,cs),
+(469,-10,o),
+(561,75,o),
+(561,225,cs),
+(561,362,o),
+(473,442,o),
+(350,442,cs)
+);
+}
+);
+width = 611;
+}
+);
+unicode = 53;
+},
+{
+color = 0;
+glyphname = six;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(81,118,o),
+(165,-10,o),
+(332,-10,cs),
+(477,-10,o),
+(567,81,o),
+(567,232,cs),
+(567,371,o),
+(494,451,o),
+(372,451,cs),
+(293,451,o),
+(245,413,o),
+(220,363,c),
+(215,363,l),
+(220,499,o),
+(274,583,o),
+(422,583,cs),
+(467,583,o),
+(497,579,o),
+(523,573,c),
+(523,691,l),
+(497,696,o),
+(455,699,o),
+(425,699,cs),
+(173,699,o),
+(81,538,o),
+(81,292,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(259,109,o),
+(230,176,o),
+(230,243,cs),
+(230,292,o),
+(273,335,o),
+(331,335,cs),
+(394,335,o),
+(422,296,o),
+(422,228,cs),
+(422,150,o),
+(386,109,o),
+(329,109,cs)
+);
+}
+);
+width = 605;
+}
+);
+unicode = 54;
+},
+{
+color = 0;
+glyphname = seven;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(602,602,l),
+(602,690,l),
+(118,690,l),
+(118,566,l),
+(442,566,l),
+(194,0,l),
+(349,0,l)
+);
+}
+);
+width = 625;
+}
+);
+unicode = 55;
+},
+{
+color = 0;
+glyphname = eight;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(472,-10,o),
+(575,53,o),
+(575,182,cs),
+(575,274,o),
+(502,328,o),
+(426,364,c),
+(501,400,o),
+(554,451,o),
+(554,534,cs),
+(554,643,o),
+(465,699,o),
+(333,699,cs),
+(199,699,o),
+(111,639,o),
+(111,534,cs),
+(111,449,o),
+(167,398,o),
+(228,362,c),
+(148,327,o),
+(90,276,o),
+(90,179,cs),
+(90,68,o),
+(169,-10,o),
+(331,-10,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(267,99,o),
+(227,132,o),
+(227,185,cs),
+(227,242,o),
+(276,274,o),
+(330,298,c),
+(393,270,o),
+(438,235,o),
+(438,183,cs),
+(438,129,o),
+(399,99,o),
+(329,99,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(285,451,o),
+(251,478,o),
+(251,521,cs),
+(251,565,o),
+(287,591,o),
+(332,591,cs),
+(380,591,o),
+(413,566,o),
+(413,522,cs),
+(413,476,o),
+(378,451,o),
+(332,429,c)
+);
+}
+);
+width = 619;
+}
+);
+unicode = 56;
+},
+{
+color = 0;
+glyphname = nine;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(577,573,o),
+(494,699,o),
+(327,699,cs),
+(180,699,o),
+(91,610,o),
+(91,460,cs),
+(91,320,o),
+(164,239,o),
+(283,239,cs),
+(365,239,o),
+(412,275,o),
+(438,327,c),
+(442,327,l),
+(435,179,o),
+(369,106,o),
+(226,106,cs),
+(189,106,o),
+(160,110,o),
+(134,116,c),
+(134,-4,l),
+(160,-9,o),
+(203,-10,o),
+(233,-10,cs),
+(483,-10,o),
+(577,153,o),
+(577,390,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(400,580,o),
+(427,508,o),
+(427,447,cs),
+(427,399,o),
+(382,354,o),
+(327,354,cs),
+(267,354,o),
+(235,395,o),
+(235,461,cs),
+(235,540,o),
+(270,580,o),
+(329,580,cs)
+);
+}
+);
+width = 629;
+}
+);
+unicode = 57;
+},
+{
+glyphname = zero.canadian;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(446,-12,o),
+(521,315,o),
+(521,476,cs),
+(521,623,o),
+(456,703,o),
+(336,703,cs),
+(117,703,o),
+(45,375,o),
+(45,214,cs),
+(45,70,o),
+(108,-12,o),
+(232,-12,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(201,116,o),
+(182,146,o),
+(182,207,cs),
+(182,285,o),
+(227,577,o),
+(327,577,cs),
+(364,577,o),
+(384,546,o),
+(384,484,cs),
+(384,406,o),
+(338,116,o),
+(239,116,cs)
+);
+}
+);
+width = 523;
+}
+);
+metricRight = "=|";
+},
+{
+glyphname = one.canadian;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(272,0,l),
+(419,690,l),
+(293,690,l),
+(64,504,l),
+(141,408,l),
+(354,579,l),
+(257,596,l),
+(130,0,l)
+);
+}
+);
+width = 375;
+}
+);
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = two.canadian;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(443,129,l),
+(193,129,l),
+(191,79,l),
+(389,281,ls),
+(468,360,o),
+(514,439,o),
+(514,528,cs),
+(514,633,o),
+(442,703,o),
+(330,703,cs),
+(202,703,o),
+(114,622,o),
+(79,449,c),
+(220,449,l),
+(238,543,o),
+(269,580,o),
+(317,580,cs),
+(355,580,o),
+(373,558,o),
+(373,522,cs),
+(373,463,o),
+(331,405,o),
+(281,355,cs),
+(23,92,l),
+(4,0,l),
+(416,0,l)
+);
+}
+);
+width = 504;
+}
+);
+note = uni14BF;
+},
+{
+glyphname = three.canadian;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(400,-14,o),
+(464,101,o),
+(464,215,cs),
+(464,293,o),
+(426,344,o),
+(358,363,c),
+(347,316,l),
+(477,327,o),
+(525,451,o),
+(525,537,cs),
+(525,638,o),
+(457,703,o),
+(341,703,cs),
+(208,703,o),
+(116,617,o),
+(89,461,c),
+(230,461,l),
+(247,541,o),
+(277,580,o),
+(324,580,cs),
+(360,580,o),
+(380,556,o),
+(380,517,cs),
+(380,471,o),
+(363,405,o),
+(295,405,cs),
+(264,405,l),
+(239,286,l),
+(270,286,ls),
+(304,286,o),
+(324,265,o),
+(324,225,cs),
+(324,183,o),
+(302,110,o),
+(239,110,cs),
+(174,110,o),
+(166,175,o),
+(177,229,c),
+(36,229,l),
+(12,100,o),
+(71,-14,o),
+(236,-14,cs)
+);
+}
+);
+width = 525;
+}
+);
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = four.canadian;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(355,0,l),
+(386,147,l),
+(459,147,l),
+(484,263,l),
+(411,263,l),
+(501,691,l),
+(388,691,l),
+(26,241,l),
+(6,147,l),
+(248,147,l),
+(217,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(383,550,l),
+(339,550,l),
+(278,263,l),
+(128,263,l),
+(134,229,l)
+);
+}
+);
+width = 497;
+}
+);
+},
+{
+glyphname = five.canadian;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(418,-14,o),
+(478,141,o),
+(478,255,cs),
+(478,363,o),
+(410,429,o),
+(289,429,cs),
+(210,429,l),
+(252,393,l),
+(311,601,l),
+(248,561,l),
+(521,561,l),
+(548,690,l),
+(198,690,l),
+(99,338,l),
+(119,307,l),
+(245,307,ls),
+(302,307,o),
+(334,284,o),
+(334,234,cs),
+(334,191,o),
+(314,110,o),
+(246,110,cs),
+(185,110,o),
+(173,161,o),
+(182,208,c),
+(41,208,l),
+(24,86,o),
+(94,-14,o),
+(240,-14,cs)
+);
+}
+);
+width = 521;
+}
+);
+},
+{
+glyphname = six.canadian;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(406,-14,o),
+(488,117,o),
+(488,252,cs),
+(488,359,o),
+(423,433,o),
+(320,433,cs),
+(257,433,o),
+(207,402,o),
+(169,344,c),
+(193,299,l),
+(196,324,o),
+(198,337,o),
+(208,381,cs),
+(238,523,o),
+(278,582,o),
+(337,582,cs),
+(399,582,o),
+(406,527,o),
+(401,483,c),
+(540,483,l),
+(550,609,o),
+(479,703,o),
+(347,703,cs),
+(112,703,o),
+(43,359,o),
+(43,213,cs),
+(43,158,o),
+(51,113,o),
+(72,77,cs),
+(104,20,o),
+(164,-14,o),
+(246,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(206,105,o),
+(180,134,o),
+(180,184,cs),
+(180,233,o),
+(207,315,o),
+(278,315,cs),
+(323,315,o),
+(348,286,o),
+(348,238,cs),
+(348,189,o),
+(323,105,o),
+(250,105,cs)
+);
+}
+);
+width = 525;
+}
+);
+metricLeft = zero.canadian;
+},
+{
+glyphname = seven.canadian;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(169,0,l),
+(476,602,l),
+(495,690,l),
+(119,690,l),
+(92,560,l),
+(324,560,l),
+(330,600,l),
+(37,35,l),
+(30,0,l)
+);
+}
+);
+width = 424;
+}
+);
+},
+{
+glyphname = eight.canadian;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(375,-14,o),
+(461,71,o),
+(476,184,cs),
+(490,272,o),
+(448,339,o),
+(370,364,c),
+(354,317,l),
+(453,326,o),
+(517,400,o),
+(530,494,cs),
+(548,616,o),
+(469,703,o),
+(337,703,cs),
+(214,703,o),
+(130,617,o),
+(115,507,cs),
+(102,420,o),
+(141,350,o),
+(215,326,c),
+(220,374,l),
+(117,364,o),
+(51,290,o),
+(39,200,cs),
+(21,79,o),
+(110,-14,o),
+(247,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(196,104,o),
+(170,138,o),
+(177,192,cs),
+(183,245,o),
+(212,287,o),
+(269,287,cs),
+(321,287,o),
+(347,254,o),
+(340,200,cs),
+(335,147,o),
+(304,104,o),
+(249,104,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(268,403,o),
+(245,437,o),
+(250,489,cs),
+(255,540,o),
+(280,585,o),
+(331,585,cs),
+(375,585,o),
+(397,553,o),
+(392,499,cs),
+(387,448,o),
+(361,403,o),
+(311,403,cs)
+);
+}
+);
+width = 538;
+}
+);
+metricLeft = "=|";
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = nine.canadian;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(455,-14,o),
+(524,330,o),
+(524,477,cs),
+(524,531,o),
+(515,577,o),
+(495,612,cs),
+(463,669,o),
+(403,703,o),
+(320,703,cs),
+(161,703,o),
+(79,573,o),
+(79,438,cs),
+(79,330,o),
+(143,257,o),
+(247,257,cs),
+(310,257,o),
+(360,288,o),
+(398,346,c),
+(374,390,l),
+(371,366,o),
+(369,353,o),
+(359,309,cs),
+(329,167,o),
+(289,108,o),
+(230,108,cs),
+(168,108,o),
+(161,162,o),
+(166,207,c),
+(27,207,l),
+(17,81,o),
+(88,-14,o),
+(219,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(244,375,o),
+(218,404,o),
+(218,452,cs),
+(218,500,o),
+(244,584,o),
+(317,584,cs),
+(361,584,o),
+(387,555,o),
+(387,506,cs),
+(387,457,o),
+(360,375,o),
+(288,375,cs)
+);
+}
+);
+width = 525;
+}
+);
+metricLeft = "=|six.canadian";
+metricRight = "=|six.canadian";
+},
+{
+glyphname = CR;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+width = 215;
+}
+);
+note = CR;
+unicode = 13;
+},
+{
+color = 0;
+glyphname = .notdef;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(582,690,l),
+(185,690,l),
+(185,0,l),
+(582,0,l),
+(582,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(533,640,l),
+(533,49,l),
+(235,49,l),
+(235,640,l),
+(235,640,l)
+);
+}
+);
+width = 674;
+}
+);
+note = ".notdef";
+},
+{
+glyphname = .null;
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+width = 0;
+}
+);
+note = NULL;
+},
+{
+glyphname = space;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+width = 217;
+}
+);
+note = space;
+unicode = 32;
+},
+{
+glyphname = nbspace;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+width = 215;
+}
+);
+note = uni00A0;
+unicode = 160;
+},
+{
+glyphname = space.canadian;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+width = 440;
+}
+);
+note = space;
+},
+{
+glyphname = "hyphen-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(345,385,l),
+(361,466,l),
+(91,466,l),
+(73,385,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(315,244,l),
+(331,325,l),
+(60,325,l),
+(43,244,l)
+);
+}
+);
+width = 358;
+}
+);
+metricRight = "=|";
+note = uni1400;
+unicode = 5120;
+},
+{
+glyphname = "chi-canadian";
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(118,0,l),
+(287,260,l),
+(238,269,l),
+(298,0,l),
+(428,0,l),
+(436,35,l),
+(337,409,l),
+(317,296,l),
+(565,655,l),
+(573,690,l),
+(433,690,l),
+(268,432,l),
+(315,424,l),
+(256,690,l),
+(128,690,l),
+(120,655,l),
+(219,290,l),
+(238,404,l),
+(-14,35,l),
+(-22,0,l)
+);
+}
+);
+width = 511;
+}
+);
+metricRight = "=|";
+note = uni166D;
+unicode = 5741;
+},
+{
+glyphname = "fullstop-canadian";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(78,0,l),
+(145,104,l),
+(126,112,l),
+(152,0,l),
+(234,0,l),
+(239,17,l),
+(187,190,l),
+(185,153,l),
+(303,327,l),
+(307,345,l),
+(216,345,l),
+(143,227,l),
+(173,217,l),
+(144,345,l),
+(62,345,l),
+(57,327,l),
+(105,161,l),
+(113,197,l),
+(-9,17,l),
+(-13,0,l)
+);
+}
+);
+width = 326;
+}
+);
+note = uni1541;
+unicode = 5742;
+},
+{
+glyphname = period;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(-2,21,o),
+(26,-11,o),
+(85,-11,cs),
+(129,-11,o),
+(158,14,o),
+(167,60,cs),
+(178,111,o),
+(151,142,o),
+(91,142,cs),
+(44,142,o),
+(16,116,o),
+(8,71,cs)
+);
+}
+);
+width = 247;
+}
+);
+note = period;
+unicode = 46;
+},
+{
+glyphname = comma;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(41,-132,l),
+(91,-57,o),
+(139,47,o),
+(173,124,c),
+(169,134,l),
+(45,134,l),
+(21,59,o),
+(-17,-39,o),
+(-59,-132,c)
+);
+}
+);
+width = 248;
+}
+);
+note = comma;
+unicode = 44;
+},
+{
+glyphname = hyphen;
+kernLeft = hyphen;
+kernRight = hyphen;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(218,201,l),
+(243,319,l),
+(42,319,l),
+(17,201,l)
+);
+}
+);
+width = 254;
+}
+);
+unicode = 45;
+},
+{
+glyphname = quotesinglbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-57,-555);
+ref = quoteright;
+}
+);
+width = 277;
+}
+);
+unicode = 8218;
+},
+{
+glyphname = quotedblbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-88,-555);
+ref = quotedblright;
+}
+);
+width = 509;
+}
+);
+unicode = 8222;
+},
+{
+glyphname = quotedblleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(398,423,l),
+(423,500,o),
+(461,595,o),
+(504,689,c),
+(406,689,l),
+(358,616,o),
+(310,520,o),
+(271,433,c),
+(276,423,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(188,423,l),
+(213,501,o),
+(251,595,o),
+(295,689,c),
+(196,689,l),
+(149,616,o),
+(100,520,o),
+(62,433,c),
+(67,423,l)
+);
+}
+);
+width = 436;
+}
+);
+unicode = 8220;
+},
+{
+glyphname = quotedblright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(373,423,l),
+(423,497,o),
+(472,601,o),
+(506,679,c),
+(502,689,l),
+(380,689,l),
+(356,613,o),
+(317,513,o),
+(274,423,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(162,423,l),
+(213,497,o),
+(263,601,o),
+(297,679,c),
+(292,689,l),
+(170,689,l),
+(147,614,o),
+(106,512,o),
+(64,423,c)
+);
+}
+);
+width = 436;
+}
+);
+unicode = 8221;
+},
+{
+glyphname = quoteleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(195,423,l),
+(220,500,o),
+(258,595,o),
+(300,689,c),
+(196,689,l),
+(149,616,o),
+(100,520,o),
+(62,433,c),
+(67,423,l)
+);
+}
+);
+width = 233;
+}
+);
+unicode = 8216;
+},
+{
+glyphname = quoteright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(169,423,l),
+(219,497,o),
+(270,601,o),
+(303,679,c),
+(299,689,l),
+(170,689,l),
+(147,614,o),
+(106,512,o),
+(64,423,c)
+);
+}
+);
+width = 233;
+}
+);
+unicode = 8217;
+},
+{
+glyphname = dottedCircle;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(202,504,o),
+(189,494,o),
+(189,479,cs),
+(189,467,o),
+(202,454,o),
+(214,454,cs),
+(229,454,o),
+(240,467,o),
+(240,479,cs),
+(240,494,o),
+(229,504,o),
+(214,504,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(364,504,o),
+(352,494,o),
+(352,479,cs),
+(352,467,o),
+(364,454,o),
+(377,454,cs),
+(391,454,o),
+(402,467,o),
+(402,479,cs),
+(402,494,o),
+(391,504,o),
+(377,504,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(202,108,o),
+(189,98,o),
+(189,83,cs),
+(189,71,o),
+(202,58,o),
+(214,58,cs),
+(229,58,o),
+(240,71,o),
+(240,83,cs),
+(240,98,o),
+(229,108,o),
+(214,108,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(364,108,o),
+(352,98,o),
+(352,83,cs),
+(352,71,o),
+(364,58,o),
+(377,58,cs),
+(391,58,o),
+(402,71,o),
+(402,83,cs),
+(402,98,o),
+(391,108,o),
+(377,108,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(283,522,o),
+(270,511,o),
+(270,497,cs),
+(270,484,o),
+(283,471,o),
+(296,471,cs),
+(310,471,o),
+(321,484,o),
+(321,497,cs),
+(321,511,o),
+(310,522,o),
+(296,522,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(283,91,o),
+(270,80,o),
+(270,66,cs),
+(270,53,o),
+(283,41,o),
+(296,41,cs),
+(310,41,o),
+(321,53,o),
+(321,66,cs),
+(321,80,o),
+(310,91,o),
+(296,91,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(55,269,o),
+(68,256,o),
+(80,256,cs),
+(95,256,o),
+(105,269,o),
+(105,281,cs),
+(105,296,o),
+(95,306,o),
+(80,306,cs),
+(68,306,o),
+(55,296,o),
+(55,281,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(486,269,o),
+(498,256,o),
+(511,256,cs),
+(526,256,o),
+(536,269,o),
+(536,281,cs),
+(536,296,o),
+(526,306,o),
+(511,306,cs),
+(498,306,o),
+(486,296,o),
+(486,281,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(118,116,o),
+(130,103,o),
+(143,103,cs),
+(157,103,o),
+(168,116,o),
+(168,128,cs),
+(168,143,o),
+(157,154,o),
+(143,154,cs),
+(130,154,o),
+(118,143,o),
+(118,128,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(118,421,o),
+(130,409,o),
+(143,409,cs),
+(157,409,o),
+(168,421,o),
+(168,434,cs),
+(168,448,o),
+(157,459,o),
+(143,459,cs),
+(130,459,o),
+(118,448,o),
+(118,434,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(423,116,o),
+(436,103,o),
+(448,103,cs),
+(463,103,o),
+(473,116,o),
+(473,128,cs),
+(473,143,o),
+(463,154,o),
+(448,154,cs),
+(436,154,o),
+(423,143,o),
+(423,128,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(423,421,o),
+(436,409,o),
+(448,409,cs),
+(463,409,o),
+(473,421,o),
+(473,434,cs),
+(473,448,o),
+(463,459,o),
+(448,459,cs),
+(436,459,o),
+(423,448,o),
+(423,434,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(72,187,o),
+(85,175,o),
+(98,175,cs),
+(112,175,o),
+(123,187,o),
+(123,200,cs),
+(123,214,o),
+(112,225,o),
+(98,225,cs),
+(85,225,o),
+(72,214,o),
+(72,200,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(72,350,o),
+(85,337,o),
+(98,337,cs),
+(112,337,o),
+(123,350,o),
+(123,362,cs),
+(123,377,o),
+(112,387,o),
+(98,387,cs),
+(85,387,o),
+(72,377,o),
+(72,362,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(469,187,o),
+(481,175,o),
+(494,175,cs),
+(508,175,o),
+(519,187,o),
+(519,200,cs),
+(519,214,o),
+(508,225,o),
+(494,225,cs),
+(481,225,o),
+(469,214,o),
+(469,200,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(469,350,o),
+(481,337,o),
+(494,337,cs),
+(508,337,o),
+(519,350,o),
+(519,362,cs),
+(519,377,o),
+(508,387,o),
+(494,387,cs),
+(481,387,o),
+(469,377,o),
+(469,362,cs)
+);
+}
+);
+width = 582;
+}
+);
+note = uni25CC;
+unicode = 9676;
+},
+{
+glyphname = dotaccentcomb;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(154,735,o),
+(128,715,o),
+(120,673,cs),
+(110,627,o),
+(135,600,o),
+(188,600,cs),
+(234,600,o),
+(260,620,o),
+(267,662,cs),
+(276,709,o),
+(252,735,o),
+(199,735,cs)
+);
+}
+);
+width = 207;
+}
+);
+note = uni0307;
+unicode = 775;
+},
+{
+glyphname = dotaccent;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(236,600,o),
+(260,619,o),
+(268,660,cs),
+(278,708,o),
+(253,735,o),
+(199,735,cs),
+(155,735,o),
+(129,716,o),
+(122,675,cs),
+(111,627,o),
+(136,600,o),
+(190,600,cs)
+);
+}
+);
+width = 209;
+}
+);
+note = dotaccent;
+unicode = 729;
+},
+{
+glyphname = caron;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(365,623,o),
+(406,671,o),
+(458,727,c),
+(461,739,l),
+(362,739,l),
+(331,715,o),
+(306,689,o),
+(272,655,c),
+(253,688,o),
+(241,716,o),
+(220,739,c),
+(135,739,l),
+(132,727,l),
+(156,683,o),
+(182,633,o),
+(195,585,c),
+(336,585,l),
+(336,585,l)
+);
+}
+);
+width = 385;
+}
+);
+note = caron;
+unicode = 711;
+},
+{
+glyphname = breve;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(342,585,o),
+(402,640,o),
+(427,742,c),
+(345,742,l),
+(327,696,o),
+(301,673,o),
+(264,673,cs),
+(225,673,o),
+(209,695,o),
+(210,742,c),
+(135,742,l),
+(118,646,o),
+(165,585,o),
+(257,585,cs)
+);
+}
+);
+width = 351;
+}
+);
+note = breve;
+unicode = 728;
+},
+{
+glyphname = ring;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(276,585,o),
+(320,629,o),
+(320,698,cs),
+(320,766,o),
+(275,811,o),
+(221,811,cs),
+(164,811,o),
+(127,767,o),
+(127,698,cs),
+(127,630,o),
+(164,585,o),
+(221,585,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(202,649,o),
+(191,670,o),
+(191,698,cs),
+(191,727,o),
+(205,747,o),
+(221,747,cs),
+(239,747,o),
+(252,726,o),
+(252,698,cs),
+(252,671,o),
+(239,649,o),
+(221,649,cs)
+);
+}
+);
+width = 252;
+}
+);
+note = ring;
+unicode = 730;
+},
+{
+glyphname = ogonek;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(53,-226,o),
+(74,-222,o),
+(94,-214,c),
+(112,-132,l),
+(99,-138,o),
+(80,-142,o),
+(71,-142,cs),
+(49,-142,o),
+(41,-126,o),
+(46,-99,cs),
+(52,-69,o),
+(76,-35,o),
+(117,0,c),
+(66,20,l),
+(-4,-30,o),
+(-39,-74,o),
+(-48,-124,cs),
+(-61,-185,o),
+(-29,-226,o),
+(33,-226,cs)
+);
+}
+);
+width = 222;
+}
+);
+note = ogonek;
+unicode = 731;
+},
+{
+glyphname = ring_top.canadian;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (212,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(303,757,o),
+(352,800,o),
+(352,859,cs),
+(352,919,o),
+(303,961,o),
+(247,961,cs),
+(191,961,o),
+(144,919,o),
+(144,859,cs),
+(144,800,o),
+(191,757,o),
+(247,757,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(221,815,o),
+(205,835,o),
+(205,859,cs),
+(205,883,o),
+(222,903,o),
+(247,903,cs),
+(273,903,o),
+(291,883,o),
+(291,859,cs),
+(291,835,o),
+(273,815,o),
+(247,815,cs)
+);
+}
+);
+width = 235;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (104,345);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(141,279,o),
+(170,309,o),
+(170,345,cs),
+(170,381,o),
+(141,411,o),
+(104,411,cs),
+(69,411,o),
+(39,381,o),
+(39,345,cs),
+(39,309,o),
+(69,279,o),
+(104,279,cs)
+);
+}
+);
+width = 167;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (90,345);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(119,293,o),
+(142,315,o),
+(142,345,cs),
+(142,375,o),
+(119,397,o),
+(90,397,cs),
+(61,397,o),
+(38,375,o),
+(38,345,cs),
+(38,315,o),
+(61,293,o),
+(90,293,cs)
+);
+}
+);
+width = 137;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_small;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (74,345);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(96,307,o),
+(113,324,o),
+(113,345,cs),
+(113,366,o),
+(96,383,o),
+(74,383,cs),
+(53,383,o),
+(38,366,o),
+(38,345,cs),
+(38,324,o),
+(53,307,o),
+(74,307,cs)
+);
+}
+);
+width = 108;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_top;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (179,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(246,768,o),
+(277,798,o),
+(277,836,cs),
+(277,872,o),
+(246,903,o),
+(210,903,cs),
+(172,903,o),
+(142,872,o),
+(142,836,cs),
+(142,798,o),
+(172,768,o),
+(210,768,cs)
+);
+}
+);
+width = 167;
+}
+);
+note = g725;
+},
+{
+glyphname = doubledot_middle;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(182,370,o),
+(213,400,o),
+(213,437,cs),
+(213,474,o),
+(182,504,o),
+(145,504,cs),
+(107,504,o),
+(77,474,o),
+(77,437,cs),
+(77,399,o),
+(107,370,o),
+(145,370,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(143,185,o),
+(173,215,o),
+(173,253,cs),
+(173,290,o),
+(143,320,o),
+(105,320,cs),
+(69,320,o),
+(38,291,o),
+(38,253,cs),
+(38,215,o),
+(69,185,o),
+(105,185,cs)
+);
+}
+);
+width = 209;
+}
+);
+metricRight = "=|";
+note = g725;
+},
+{
+glyphname = doubledot_top;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top_double;
+pos = (351,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(417,768,o),
+(448,798,o),
+(448,836,cs),
+(448,872,o),
+(417,903,o),
+(381,903,cs),
+(343,903,o),
+(313,872,o),
+(313,836,cs),
+(313,798,o),
+(343,768,o),
+(381,768,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(244,768,o),
+(274,798,o),
+(274,836,cs),
+(274,872,o),
+(244,903,o),
+(207,903,cs),
+(170,903,o),
+(140,872,o),
+(140,836,cs),
+(140,798,o),
+(170,768,o),
+(207,768,cs)
+);
+}
+);
+width = 336;
+}
+);
+note = g725;
+},
+{
+glyphname = g727;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (400,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(502,0,l),
+(527,116,l),
+(254,116,ls),
+(204,116,o),
+(176,139,o),
+(176,184,cs),
+(176,239,o),
+(206,288,o),
+(289,288,cs),
+(368,288,ls),
+(534,288,o),
+(620,384,o),
+(620,521,cs),
+(620,623,o),
+(552,690,o),
+(445,690,cs),
+(149,690,l),
+(124,574,l),
+(399,574,ls),
+(450,574,o),
+(477,550,o),
+(477,506,cs),
+(477,450,o),
+(447,403,o),
+(364,403,cs),
+(286,403,ls),
+(118,403,o),
+(34,305,o),
+(34,169,cs),
+(34,67,o),
+(101,0,o),
+(209,0,cs)
+);
+}
+);
+width = 611;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+glyphname = g728;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (221,0);
+ref = dot_top;
+}
+);
+width = 611;
+}
+);
+note = g728;
+},
+{
+glyphname = g729;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (410,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(304,0,ls),
+(475,0,o),
+(559,96,o),
+(559,237,cs),
+(559,337,o),
+(495,403,o),
+(389,403,cs),
+(315,403,ls),
+(265,403,o),
+(237,425,o),
+(237,469,cs),
+(237,527,o),
+(268,574,o),
+(350,574,cs),
+(625,574,l),
+(649,690,l),
+(349,690,ls),
+(179,690,o),
+(95,593,o),
+(95,454,cs),
+(95,353,o),
+(158,288,o),
+(264,288,cs),
+(338,288,ls),
+(388,288,o),
+(416,265,o),
+(416,221,cs),
+(416,162,o),
+(385,116,o),
+(302,116,cs),
+(27,116,l),
+(3,0,l)
+);
+}
+);
+width = 611;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+glyphname = g730;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (231,0);
+ref = dot_top;
+}
+);
+width = 611;
+}
+);
+note = g730;
+},
+{
+glyphname = g731;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = g727;
+}
+);
+width = 814;
+}
+);
+note = g731;
+},
+{
+glyphname = g732;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (611,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 814;
+}
+);
+note = g732;
+},
+{
+glyphname = g733;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (425,0);
+ref = dot_top;
+}
+);
+width = 814;
+}
+);
+note = g733;
+},
+{
+glyphname = g734;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (221,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (611,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 814;
+}
+);
+note = g734;
+},
+{
+glyphname = g735;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = g729;
+}
+);
+width = 814;
+}
+);
+note = g735;
+},
+{
+glyphname = g736;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (611,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 814;
+}
+);
+note = g736;
+},
+{
+glyphname = g737;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (435,0);
+ref = dot_top;
+}
+);
+width = 814;
+}
+);
+note = g737;
+},
+{
+glyphname = g738;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (231,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (611,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 814;
+}
+);
+note = g738;
+},
+{
+glyphname = g739;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(493,261,o),
+(539,343,o),
+(539,416,cs),
+(539,481,o),
+(498,524,o),
+(432,524,cs),
+(290,524,l),
+(299,483,l),
+(330,516,o),
+(340,563,o),
+(340,592,cs),
+(340,654,o),
+(299,696,o),
+(236,696,cs),
+(148,696,o),
+(101,614,o),
+(101,541,cs),
+(101,476,o),
+(142,434,o),
+(209,434,cs),
+(350,434,l),
+(340,474,l),
+(307,440,o),
+(299,393,o),
+(299,366,cs),
+(299,303,o),
+(340,261,o),
+(405,261,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(193,502,o),
+(183,516,o),
+(183,539,cs),
+(183,566,o),
+(198,627,o),
+(231,627,cs),
+(248,627,o),
+(258,613,o),
+(258,590,cs),
+(258,564,o),
+(243,502,o),
+(211,502,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(392,330,o),
+(382,344,o),
+(382,367,cs),
+(382,393,o),
+(396,454,o),
+(430,454,cs),
+(447,454,o),
+(457,441,o),
+(457,418,cs),
+(457,391,o),
+(442,330,o),
+(410,330,cs)
+);
+}
+);
+width = 541;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+glyphname = g740;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (188,0);
+ref = ring_top.canadian;
+}
+);
+width = 611;
+}
+);
+note = g740;
+},
+{
+glyphname = g741;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (197,0);
+ref = ring_top.canadian;
+}
+);
+width = 611;
+}
+);
+note = g741;
+},
+{
+glyphname = g742;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (392,0);
+ref = ring_top.canadian;
+}
+);
+width = 814;
+}
+);
+note = g742;
+},
+{
+glyphname = stroke_middle;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (78,345);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(94,228,l),
+(144,462,l),
+(62,462,l),
+(13,228,l)
+);
+}
+);
+width = 113;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (67,345);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(80,270,l),
+(112,420,l),
+(53,420,l),
+(21,270,l)
+);
+}
+);
+width = 91;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_small;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (60,345);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(69,279,l),
+(96,411,l),
+(51,411,l),
+(23,279,l)
+);
+}
+);
+width = 76;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_threequart;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (78,345);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(91,231,l),
+(139,459,l),
+(65,459,l),
+(16,231,l)
+);
+}
+);
+width = 113;
+}
+);
+note = g723;
+},
+{
+color = 8;
+glyphname = uni11AB0;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (249,690);
+},
+{
+name = top_right_can;
+pos = (475,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(174,0,l),
+(191,82,l),
+(366,82,l),
+(383,159,l),
+(208,159,l),
+(232,276,l),
+(115,232,l),
+(149,232,ls),
+(355,232,o),
+(469,324,o),
+(517,549,cs),
+(547,690,l),
+(404,690,l),
+(376,558,ls),
+(348,428,o),
+(278,359,o),
+(155,359,cs),
+(107,359,l),
+(65,159,l),
+(6,159,l),
+(-11,82,l),
+(48,82,l),
+(31,0,l)
+);
+}
+);
+width = 503;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB1;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB0;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (297,0);
+ref = dot_top;
+}
+);
+width = 503;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB2;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (215,690);
+},
+{
+name = top_right_can;
+pos = (443,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,0,l),
+(170,131,ls),
+(198,262,o),
+(268,330,o),
+(391,330,cs),
+(438,330,l),
+(480,530,l),
+(540,530,l),
+(555,608,l),
+(497,608,l),
+(514,690,l),
+(372,690,l),
+(355,608,l),
+(180,608,l),
+(163,530,l),
+(338,530,l),
+(313,413,l),
+(431,458,l),
+(396,458,ls),
+(189,458,o),
+(77,366,o),
+(29,141,cs),
+(-1,0,l)
+);
+}
+);
+width = 503;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "theThCree-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB3;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB2;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (265,0);
+ref = dot_top;
+}
+);
+width = 503;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB4;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (250,690);
+},
+{
+name = top_right_can;
+pos = (477,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(401,0,l),
+(428,127,ls),
+(472,336,o),
+(374,458,o),
+(166,458,cs),
+(152,458,l),
+(262,414,l),
+(287,530,l),
+(463,530,l),
+(478,608,l),
+(303,608,l),
+(321,690,l),
+(179,690,l),
+(160,608,l),
+(101,608,l),
+(86,530,l),
+(145,530,l),
+(102,330,l),
+(131,330,ls),
+(262,330,o),
+(317,277,o),
+(285,129,cs),
+(258,0,l)
+);
+}
+);
+width = 504;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB5;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB4;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (71,0);
+ref = dot_top;
+}
+);
+width = 503;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB6;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (219,690);
+},
+{
+name = top_right_can;
+pos = (446,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(144,1,l),
+(203,278,l),
+(85,233,l),
+(117,233,ls),
+(333,233,o),
+(440,331,o),
+(490,562,cs),
+(507,644,l),
+(398,601,l),
+(558,405,l),
+(664,492,l),
+(501,691,l),
+(375,691,l),
+(349,572,ls),
+(318,430,o),
+(241,360,o),
+(114,360,cs),
+(77,360,l),
+(1,1,l)
+);
+}
+);
+width = 628;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB7;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB6;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (267,0);
+ref = dot_top;
+}
+);
+width = 626;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB8;
+kernRight = soright;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (372,690);
+},
+{
+name = top_right_can;
+pos = (599,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(296,0,l),
+(322,119,ls),
+(353,261,o),
+(430,330,o),
+(556,330,cs),
+(593,330,l),
+(669,690,l),
+(527,690,l),
+(468,412,l),
+(586,458,l),
+(555,458,ls),
+(337,458,o),
+(231,359,o),
+(181,128,cs),
+(163,46,l),
+(272,90,l),
+(112,286,l),
+(7,199,l),
+(169,0,l)
+);
+}
+);
+width = 627;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB9;
+kernRight = soright;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB8;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (418,0);
+ref = dot_top;
+}
+);
+width = 626;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABA;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (218,690);
+},
+{
+name = top_right_can;
+pos = (445,690);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(354,0,l),
+(601,199,l),
+(522,297,l),
+(328,142,l),
+(389,108,l),
+(397,143,ls),
+(431,307,o),
+(354,455,o),
+(174,455,cs),
+(140,455,l),
+(224,385,l),
+(289,690,l),
+(147,690,l),
+(71,330,l),
+(104,330,ls),
+(243,330,o),
+(284,269,o),
+(251,116,cs),
+(227,0,l)
+);
+}
+);
+width = 628;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABB;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = uni11ABA;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (39,0);
+ref = dot_top;
+}
+);
+width = 626;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABC;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(412,0,l),
+(440,129,l),
+(153,129,l),
+(153,81,l),
+(546,592,l),
+(567,690,l),
+(129,690,l),
+(101,560,l),
+(389,560,l),
+(390,609,l),
+(-4,98,l),
+(-24,0,l)
+);
+}
+);
+width = 499;
+}
+);
+metricRight = "=|";
+},
+{
+color = 8;
+glyphname = uni11ABD;
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(419,0,l),
+(440,98,l),
+(243,609,l),
+(243,560,l),
+(531,560,l),
+(558,690,l),
+(122,690,l),
+(101,592,l),
+(298,81,l),
+(298,129,l),
+(11,129,l),
+(-17,0,l)
+);
+}
+);
+width = 498;
+}
+);
+metricLeft = "=|uni11ABC";
+metricRight = "=|uni11ABC";
+},
+{
+color = 8;
+glyphname = uni11ABE;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(139,0,l),
+(260,568,l),
+(172,568,l),
+(348,0,l),
+(473,0,l),
+(620,690,l),
+(481,690,l),
+(359,122,l),
+(447,122,l),
+(271,690,l),
+(146,690,l),
+(-1,0,l)
+);
+}
+);
+width = 576;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABF;
+lastChange = "2023-01-13 15:56:53 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(125,0,l),
+(557,569,l),
+(454,569,l),
+(333,0,l),
+(473,0,l),
+(620,690,l),
+(495,690,l),
+(61,121,l),
+(164,121,l),
+(286,690,l),
+(146,690,l),
+(-1,0,l)
+);
+}
+);
+width = 576;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = "raiseddoubledotFinal-canadian.cree";
+lastChange = "2023-01-13 15:56:50 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(223,569,o),
+(253,599,o),
+(253,637,cs),
+(253,673,o),
+(223,703,o),
+(185,703,cs),
+(149,703,o),
+(119,674,o),
+(119,637,cs),
+(119,598,o),
+(149,569,o),
+(185,569,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(185,384,o),
+(215,415,o),
+(215,452,cs),
+(215,490,o),
+(185,520,o),
+(148,520,cs),
+(111,520,o),
+(80,490,o),
+(80,452,cs),
+(80,414,o),
+(111,384,o),
+(148,384,cs)
+);
+}
+);
+width = 206;
+}
+);
+note = g725;
+}
+);
+instances = (
+{
+axesValues = (
+154,
+75,
+12
+);
+instanceInterpolations = {
+"ABE41ABD-D787-4F86-A3B4-502CADE9F2A5" = 1;
+};
+name = "RC CB Italic";
+}
+);
+kerningLTR = {
+"ABE41ABD-D787-4F86-A3B4-502CADE9F2A5" = {
+"@MMK_L_caright" = {
+"@MMK_R_ecanleft" = -63.756;
+"@MMK_R_mwestleft" = -25.116;
+"@MMK_R_neleft" = -37.674;
+};
+"@MMK_L_ciright" = {
+"@MMK_R_icanleft" = -63.756;
+"@MMK_R_noleft" = -70.518;
+};
+"@MMK_L_ecanright" = {
+"@MMK_R_coleft" = -63.756;
+"@MMK_R_moleft" = -64.722;
+"@MMK_R_sileft" = -34.776;
+};
+"@MMK_L_icanright" = {
+"@MMK_R_celeft" = -63.756;
+"@MMK_R_meleft" = -64.722;
+"@MMK_R_mwestleft" = -51.198;
+"@MMK_R_saleft" = -28.98;
+"she-canadian" = -64.722;
+};
+"@MMK_L_maright" = {
+"@MMK_R_acanleft" = -56.028;
+"@MMK_R_ecanleft" = -64.722;
+"@MMK_R_mwestleft" = -42.504;
+"@MMK_R_neleft" = -37.674;
+};
+"@MMK_L_miright" = {
+"@MMK_R_acanleft" = -56.028;
+"@MMK_R_icanleft" = -64.722;
+"@MMK_R_moleft" = -88.872;
+"@MMK_R_noleft" = -70.518;
+"@MMK_R_yeleft" = -91.77;
+};
+"@MMK_L_mwestright" = {
+"@MMK_R_coleft" = -25.116;
+"@MMK_R_icanleft" = -51.198;
+"@MMK_R_moleft" = -42.504;
+"@MMK_R_noleft" = -67.62;
+"@MMK_R_sileft" = -12.558;
+"@MMK_R_yeleft" = -26.082;
+};
+"@MMK_L_naright" = {
+"@MMK_R_acanleft" = -64.722;
+"@MMK_R_celeft" = -70.518;
+"@MMK_R_meleft" = -70.518;
+"@MMK_R_mwestleft" = -67.62;
+"@MMK_R_neleft" = -75.348;
+"@MMK_R_saleft" = -40.572;
+};
+"@MMK_L_niright" = {
+"@MMK_R_coleft" = -37.674;
+"@MMK_R_moleft" = -37.674;
+"@MMK_R_noleft" = -75.348;
+"@MMK_R_sileft" = -0.966;
+};
+"@MMK_L_ocanright" = {
+"@MMK_R_meleft" = -56.028;
+"@MMK_R_moleft" = -56.028;
+"@MMK_R_noleft" = -64.722;
+};
+"@MMK_L_seright" = {
+"@MMK_R_ecanleft" = -34.776;
+"@MMK_R_mwestleft" = -12.558;
+"@MMK_R_neleft" = -0.966;
+};
+"@MMK_L_soright" = {
+"@MMK_R_icanleft" = -28.98;
+"@MMK_R_noleft" = -40.572;
+};
+"@MMK_L_yiright" = {
+"@MMK_R_meleft" = -91.77;
+"@MMK_R_mwestleft" = -26.082;
+};
+"shi-canadian" = {
+"@MMK_R_icanleft" = -64.722;
+};
+};
+};
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "italic angle";
+}
+);
+properties = (
+{
+key = copyrights;
+values = (
+{
+language = ENG;
+value = "Copyright 2018 Google Inc. All Rights Reserved.";
+}
+);
+},
+{
+key = manufacturers;
+values = (
+{
+language = ENG;
+value = "Monotype Imaging Inc.";
+}
+);
+},
+{
+key = designers;
+values = (
+{
+language = ENG;
+value = "Monotype Design Team";
+}
+);
+},
+{
+key = description;
+value = "Designed by Monotype design team.";
+},
+{
+key = trademarks;
+values = (
+{
+language = ENG;
+value = "Noto is a trademark of Google Inc.";
+}
+);
+},
+{
+key = licenseURL;
+value = "http://scripts.sil.org/OFL";
+},
+{
+key = licenses;
+values = (
+{
+language = ENG;
+value = "This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.";
+}
+);
+},
+{
+key = manufacturerURL;
+value = "http://www.google.com/get/noto/";
+},
+{
+key = designerURL;
+value = "http://www.monotype.com/studio";
+}
+);
+settings = {
+disablesNiceNames = 1;
+};
+stems = (
+{
+name = "New Stem";
+}
+);
+unitsPerEm = 966;
+userData = {
+GSDontShowVersionAlert = 1;
+};
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/sources/Exported instances UCAS SansCanadianAboriginal Resized/Sans Canadian Aboriginal-RC CB roman.glyphs
+++ b/sources/Exported instances UCAS SansCanadianAboriginal Resized/Sans Canadian Aboriginal-RC CB roman.glyphs
@@ -1,0 +1,37332 @@
+{
+.appVersion = "3151";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+},
+{
+name = Width;
+tag = wdth;
+},
+{
+name = Slant;
+tag = slnt;
+}
+);
+classes = (
+{
+code = "zero one two three four five six seven eight nine ";
+name = Num;
+},
+{
+code = "zero.canadian one.canadian two.canadian three.canadian four.canadian five.canadian six.canadian seven.canadian eight.canadian nine.canadian 
+";
+name = Num_can;
+},
+{
+code = "ke-canadian.square ki-canadian.square kii-canadian.square ko-canadian.square koo-canadian.square ka-canadian.square kaa-canadian.square kweWestCree-canadian.square kwiiWestCree-canadian.square kwoWestCree-canadian.square kwooWestCree-canadian.square kwaWestCree-canadian.square kwaaWestCree-canadian.square ce-canadian.square ci-canadian.square cii-canadian.square co-canadian.square coo-canadian.square ca-canadian.square caa-canadian.square me-canadian.square mi-canadian.square mii-canadian.square mo-canadian.square moo-canadian.square ma-canadian.square maa-canadian.square ne-canadian.square ni-canadian.square nii-canadian.square no-canadian.square noo-canadian.square na-canadian.square naa-canadian.square nweWestCree-canadian.square nwaWestCree-canadian.square nwaaWestCree-canadian.square se-canadian.square si-canadian.square sii-canadian.square so-canadian.square soo-canadian.square sa-canadian.square saa-canadian.square sho-canadian.square shoo-canadian.square sha-canadian.square shaa-canadian.square ye-canadian.square yi-canadian.square yii-canadian.square yo-canadian.square yoo-canadian.square ya-canadian.square yaa-canadian.square re-canadian.square reRCree-canadian.square leWestCree-canadian.square ri-canadian.square rii-canadian.square ro-canadian.square loWestCree-canadian.square ra-canadian.square raa-canadian.square laWestCree-canadian.square reWestCree-canadian.square riWestCree-canadian.square roWestCree-canadian.square raWestCree-canadian.square theThCree-canadian.square thiThCree-canadian.square thiiThCree-canadian.square thoThCree-canadian.square thooThCree-canadian.square thaThCree-canadian.square thaaThCree-canadian.square thweeWoodScree-canadian.square thwiWoodScree-canadian.square thwiiWoodScree-canadian.square thwoWoodScree-canadian.square thwooWoodScree-canadian.square thwaWoodScree-canadian.square thwaaWoodScree-canadian.square nwiOjibway-canadian.square nwiiOjibway-canadian.square nwoOjibway-canadian.square nwooOjibway-canadian.square looWestCree-canadian.square laaWestCree-canadian.square ";
+name = Dene_square;
+},
+{
+code = "ke-canadian ki-canadian kii-canadian ko-canadian koo-canadian ka-canadian kaa-canadian kweWestCree-canadian kwiiWestCree-canadian kwoWestCree-canadian kwooWestCree-canadian kwaWestCree-canadian kwaaWestCree-canadian ce-canadian ci-canadian cii-canadian co-canadian coo-canadian ca-canadian caa-canadian me-canadian mi-canadian mii-canadian mo-canadian moo-canadian ma-canadian maa-canadian ne-canadian ni-canadian nii-canadian no-canadian noo-canadian na-canadian naa-canadian nweWestCree-canadian nwaWestCree-canadian nwaaWestCree-canadian se-canadian si-canadian sii-canadian so-canadian soo-canadian sa-canadian saa-canadian sho-canadian shoo-canadian sha-canadian shaa-canadian ye-canadian yi-canadian yii-canadian yo-canadian yoo-canadian ya-canadian yaa-canadian re-canadian reRCree-canadian leWestCree-canadian ri-canadian rii-canadian ro-canadian loWestCree-canadian ra-canadian raa-canadian laWestCree-canadian reWestCree-canadian riWestCree-canadian roWestCree-canadian raWestCree-canadian theThCree-canadian thiThCree-canadian thiiThCree-canadian thoThCree-canadian thooThCree-canadian thaThCree-canadian thaaThCree-canadian thweeWoodScree-canadian thwiWoodScree-canadian thwiiWoodScree-canadian thwoWoodScree-canadian thwooWoodScree-canadian thwaWoodScree-canadian thwaaWoodScree-canadian nwiOjibway-canadian nwiiOjibway-canadian nwoOjibway-canadian nwooOjibway-canadian looWestCree-canadian laaWestCree-canadian 
+";
+name = Dene_round;
+},
+{
+code = "acuteFinal-canadian.mid graveFinal-canadian.mid ringTophalfFinal-canadian.mid ringRighthalfFinal-canadian.mid ringFinal-canadian.mid doubleacuteFinal-canadian.mid doubleshortverticalstrokesFinal-canadian.mid shorthorizontalstrokeFinal-canadian.mid downtackFinal-canadian.mid pWestCree-canadian.mid c-canadian.mid mWestCree-canadian.mid ";
+name = Final_mid;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian ringFinal-canadian doubleacuteFinal-canadian doubleshortverticalstrokesFinal-canadian shorthorizontalstrokeFinal-canadian downtackFinal-canadian pWestCree-canadian c-canadian mWestCree-canadian ";
+name = Final_mid_ori;
+},
+{
+code = "acuteFinal-canadian.base graveFinal-canadian.base ringBottomhalfFinal-canadian.base ringTophalfFinal-canadian.base ringRighthalfFinal-canadian.base plusFinal-canadian.base pWestCree-canadian.base c-canadian.base thSayisi-canadian.base mWestCree-canadian.base ";
+name = Final_base;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringBottomhalfFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian plusFinal-canadian pWestCree-canadian c-canadian thSayisi-canadian mWestCree-canadian ";
+name = Final_base_ori;
+},
+{
+code = "ng-canadian ngai-canadian ngaai-canadian ngi-canadian ngii-canadian ngo-canadian ngoo-canadian nga-canadian ngaa-canadian ";
+name = Nunavik;
+},
+{
+code = "ng-canadian.nunavik ngai-canadian.nunavik ngaai-canadian.nunavik ngi-canadian.nunavik ngii-canadian.nunavik ngo-canadian.nunavik ngoo-canadian.nunavik nga-canadian.nunavik ngaa-canadian.nunavik ";
+name = Nunavik_alt;
+}
+);
+customParameters = (
+{
+name = vendorID;
+value = GOOG;
+},
+{
+name = panose;
+value = (
+2,
+11,
+5,
+2,
+4,
+5,
+4,
+2,
+2,
+4
+);
+},
+{
+name = unicodeRanges;
+value = (
+0,
+1,
+2,
+5,
+6,
+45,
+77
+);
+},
+{
+name = codePageRanges;
+value = (
+"1252"
+);
+},
+{
+name = fsType;
+value = (
+);
+}
+);
+date = "2022-06-21 10:06:40 +0000";
+familyName = "Sans Canadian Aboriginal";
+featurePrefixes = (
+{
+automatic = 1;
+code = "languagesystem DFLT dflt;
+
+languagesystem cans dflt;
+";
+name = Languagesystems;
+}
+);
+features = (
+{
+automatic = 1;
+code = "feature ss01;
+feature ss02;
+feature ss03;
+feature ss04;
+";
+tag = aalt;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+tag = salt;
+},
+{
+code = "lookup space_can {
+sub space by space.canadian;
+} space_can;
+
+lookup num_can {
+sub @Num by @Num_can;
+} num_can;
+";
+labels = (
+{
+language = dflt;
+value = "CAN Space and numerals";
+}
+);
+tag = ss01;
+},
+{
+code = "lookup dene_square {
+sub @Dene_round by @Dene_square;
+} dene_square;
+
+";
+labels = (
+{
+language = dflt;
+value = "Dene Square";
+}
+);
+tag = ss02;
+},
+{
+code = "lookup nunavik_alt {
+sub @Nunavik by @Nunavik_alt;
+} nunavik_alt;
+
+";
+labels = (
+{
+language = dflt;
+value = "Nunanvik Alt";
+}
+);
+tag = ss03;
+},
+{
+code = "lookup final_mid {
+sub @Final_mid_ori by @Final_mid;
+} final_mid;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final mid";
+}
+);
+tag = ss04;
+},
+{
+code = "lookup final_base {
+sub @Final_base_ori by @Final_base;
+} final_base;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final base";
+}
+);
+tag = ss05;
+},
+{
+code = "lookup plaincree_first {
+sub wiWestCree-canadian' plusFinal-canadian by i-canadian;
+} plaincree_first;
+
+lookup plaincree_second {
+sub i-canadian plusFinal-canadian' by raiseddoubledotFinal-canadian.cree;
+} plaincree_second;
+
+lookup plaincree_third {
+sub middledotFinal-canadian plusFinal-canadian by raiseddoubledotFinal-canadian.cree;
+} plaincree_third;
+";
+labels = (
+{
+language = dflt;
+value = Plaincree;
+}
+);
+tag = ss06;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+labels = (
+{
+language = dflt;
+value = "";
+}
+);
+tag = ss07;
+}
+);
+fontMaster = (
+{
+axesValues = (
+0,
+0,
+0
+);
+customParameters = (
+{
+name = typoAscender;
+value = 1033;
+},
+{
+name = typoDescender;
+value = -283;
+},
+{
+name = typoLineGap;
+value = 0;
+},
+{
+name = winAscent;
+value = 1033;
+},
+{
+name = winDescent;
+value = 283;
+},
+{
+name = hheaAscender;
+value = 1033;
+},
+{
+name = hheaDescender;
+value = -283;
+},
+{
+name = strikeoutPosition;
+value = 293;
+},
+{
+name = strikeoutSize;
+value = 48;
+}
+);
+guides = (
+{
+locked = 1;
+pos = (417,345);
+}
+);
+id = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+metricValues = (
+{
+over = 22;
+pos = 1033;
+},
+{
+over = 22;
+pos = 690;
+},
+{
+over = 22;
+pos = 489;
+},
+{
+over = -22;
+},
+{
+over = -22;
+pos = -283;
+},
+{
+}
+);
+name = "RC CB roman";
+stemValues = (
+141
+);
+}
+);
+glyphs = (
+{
+glyphname = idotless;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(190,528,l),
+(49,528,l),
+(49,0,l),
+(190,0,l)
+);
+}
+);
+width = 240;
+}
+);
+note = dotlessi;
+unicode = 305;
+},
+{
+glyphname = "acuteFinal-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(124,345,l),
+(267,690,l),
+(160,690,l),
+(16,345,l)
+);
+}
+);
+width = 283;
+}
+);
+metricRight = "=|";
+note = uni141F;
+unicode = 5151;
+},
+{
+glyphname = "graveFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(267,345,l),
+(124,690,l),
+(16,690,l),
+(160,345,l)
+);
+}
+);
+width = 283;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+unicode = 5152;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(266,339,o),
+(319,390,o),
+(319,487,cs),
+(319,690,l),
+(224,690,l),
+(224,482,ls),
+(224,443,o),
+(210,423,o),
+(181,423,cs),
+(152,423,o),
+(138,443,o),
+(138,482,cs),
+(138,690,l),
+(43,690,l),
+(43,486,ls),
+(43,390,o),
+(98,339,o),
+(181,339,cs)
+);
+}
+);
+width = 362;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1421;
+unicode = 5153;
+},
+{
+glyphname = "ringTophalfFinal-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(138,345,l),
+(138,554,ls),
+(138,591,o),
+(152,611,o),
+(181,611,cs),
+(210,611,o),
+(224,591,o),
+(224,554,cs),
+(224,345,l),
+(319,345,l),
+(319,548,ls),
+(319,644,o),
+(266,696,o),
+(181,696,cs),
+(98,696,o),
+(43,644,o),
+(43,549,cs),
+(43,345,l)
+);
+}
+);
+width = 362;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+unicode = 5154;
+},
+{
+glyphname = "ringRighthalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(96,345,ls),
+(203,345,o),
+(264,412,o),
+(264,517,cs),
+(264,622,o),
+(203,690,o),
+(96,690,cs),
+(42,690,l),
+(42,601,l),
+(87,601,ls),
+(141,601,o),
+(169,570,o),
+(169,517,cs),
+(169,463,o),
+(141,434,o),
+(87,434,cs),
+(42,434,l),
+(42,345,l)
+);
+}
+);
+width = 304;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+unicode = 5155;
+},
+{
+glyphname = "ringFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(293,383,o),
+(358,450,o),
+(358,540,cs),
+(358,629,o),
+(292,696,o),
+(200,696,cs),
+(106,696,o),
+(40,629,o),
+(40,540,cs),
+(40,450,o),
+(105,383,o),
+(200,383,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(154,463,o),
+(127,496,o),
+(127,540,cs),
+(127,583,o),
+(154,615,o),
+(200,615,cs),
+(243,615,o),
+(271,582,o),
+(271,540,cs),
+(271,496,o),
+(243,463,o),
+(200,463,cs)
+);
+}
+);
+width = 398;
+}
+);
+note = uni1424;
+unicode = 5156;
+},
+{
+glyphname = "doubleacuteFinal-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(267,690,l),
+(160,690,l),
+(16,345,l),
+(124,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(421,690,l),
+(314,690,l),
+(172,345,l),
+(279,345,l)
+);
+}
+);
+width = 437;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricRight = "=|";
+note = uni1425;
+unicode = 5157;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(138,690,l),
+(43,690,l),
+(43,345,l),
+(138,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(273,690,l),
+(179,690,l),
+(179,345,l),
+(273,345,l)
+);
+}
+);
+width = 316;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "pWestCree-canadian";
+note = uni1426;
+unicode = 5158;
+},
+{
+glyphname = "middledotFinal-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(139,287,o),
+(169,317,o),
+(169,355,cs),
+(169,392,o),
+(139,422,o),
+(101,422,cs),
+(65,422,o),
+(35,392,o),
+(35,355,cs),
+(35,317,o),
+(65,287,o),
+(101,287,cs)
+);
+}
+);
+width = 204;
+}
+);
+note = uni1427;
+unicode = 5159;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(322,490,l),
+(322,585,l),
+(43,585,l),
+(43,490,l)
+);
+}
+);
+width = 365;
+}
+);
+metricRight = "=|";
+note = uni1428;
+unicode = 5160;
+},
+{
+glyphname = "plusFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(228,393,l),
+(228,498,l),
+(322,498,l),
+(322,587,l),
+(228,587,l),
+(228,690,l),
+(139,690,l),
+(139,587,l),
+(43,587,l),
+(43,498,l),
+(139,498,l),
+(139,393,l)
+);
+}
+);
+width = 365;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+unicode = 5161;
+},
+{
+glyphname = "downtackFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(230,345,l),
+(230,600,l),
+(322,600,l),
+(322,690,l),
+(43,690,l),
+(43,600,l),
+(136,600,l),
+(136,345,l)
+);
+}
+);
+width = 365;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni142A;
+unicode = 5162;
+},
+{
+glyphname = "thFinalWoodScree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(230,345,l),
+(230,405,l),
+(322,405,l),
+(322,484,l),
+(230,484,l),
+(230,551,l),
+(322,551,l),
+(322,630,l),
+(230,630,l),
+(230,690,l),
+(136,690,l),
+(136,630,l),
+(43,630,l),
+(43,551,l),
+(136,551,l),
+(136,484,l),
+(43,484,l),
+(43,405,l),
+(136,405,l),
+(136,345,l)
+);
+}
+);
+width = 365;
+}
+);
+metricLeft = "hyphen-canadian";
+metricRight = "hyphen-canadian";
+note = uni167E;
+unicode = 5758;
+},
+{
+glyphname = "ringSmallFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(203,499,o),
+(251,543,o),
+(251,602,cs),
+(251,661,o),
+(203,703,o),
+(147,703,cs),
+(92,703,o),
+(43,662,o),
+(43,602,cs),
+(43,543,o),
+(91,499,o),
+(147,499,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(122,557,o),
+(104,578,o),
+(104,602,cs),
+(104,626,o),
+(122,646,o),
+(148,646,cs),
+(173,646,o),
+(190,626,o),
+(190,602,cs),
+(190,578,o),
+(173,557,o),
+(148,557,cs)
+);
+}
+);
+width = 295;
+}
+);
+note = g725;
+unicode = 6366;
+},
+{
+glyphname = "raiseddotFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(140,569,o),
+(170,599,o),
+(170,637,cs),
+(170,673,o),
+(140,703,o),
+(102,703,cs),
+(66,703,o),
+(36,673,o),
+(36,637,cs),
+(36,599,o),
+(66,569,o),
+(102,569,cs)
+);
+}
+);
+width = 206;
+}
+);
+note = g725;
+unicode = 6367;
+},
+{
+glyphname = "acuteFinal-canadian.base";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "acuteFinal-canadian";
+}
+);
+width = 283;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.base";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "graveFinal-canadian";
+}
+);
+width = 283;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian.base";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 362;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1421;
+},
+{
+glyphname = "ringTophalfFinal-canadian.base";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 362;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.base";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 304;
+}
+);
+metricLeft = "==|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "plusFinal-canadian.base";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(228,0,l),
+(228,105,l),
+(322,105,l),
+(322,194,l),
+(228,194,l),
+(228,297,l),
+(139,297,l),
+(139,194,l),
+(43,194,l),
+(43,105,l),
+(139,105,l),
+(139,0,l)
+);
+}
+);
+width = 365;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+},
+{
+glyphname = "acuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "acuteFinal-canadian";
+}
+);
+width = 283;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.mid";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "graveFinal-canadian";
+}
+);
+width = 283;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringTophalfFinal-canadian.mid";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-172);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 362;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.mid";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 304;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "ringFinal-canadian.mid";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-196);
+ref = "ringFinal-canadian";
+}
+);
+width = 398;
+}
+);
+metricLeft = "ringFinal-canadian";
+metricWidth = "ringFinal-canadian";
+note = uni1424;
+},
+{
+glyphname = "doubleacuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "doubleacuteFinal-canadian";
+}
+);
+width = 437;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "doubleacuteFinal-canadian";
+note = uni1425;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian.mid";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "doubleshortverticalstrokesFinal-canadian";
+}
+);
+width = 316;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricWidth = "doubleshortverticalstrokesFinal-canadian";
+note = uni1426;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian.mid";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-183);
+ref = "shorthorizontalstrokeFinal-canadian";
+}
+);
+width = 365;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "shorthorizontalstrokeFinal-canadian";
+note = uni1428;
+},
+{
+glyphname = "downtackFinal-canadian.mid";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "downtackFinal-canadian";
+}
+);
+width = 365;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "downtackFinal-canadian";
+note = uni142A;
+},
+{
+glyphname = "e-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (308,454);
+},
+{
+name = top_center_can;
+pos = (308,690);
+},
+{
+name = top_left_can;
+pos = (119,690);
+},
+{
+name = top_right_can;
+pos = (497,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(327,0,l),
+(596,655,l),
+(596,690,l),
+(18,690,l),
+(18,655,l),
+(287,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(340,171,l),
+(170,605,l),
+(145,577,l),
+(467,577,l),
+(447,605,l),
+(277,171,l)
+);
+}
+);
+width = 614;
+}
+);
+metricRight = "=|";
+note = uni1401;
+unicode = 5121;
+},
+{
+glyphname = "aai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (190,0);
+ref = ring_top.canadian;
+}
+);
+width = 614;
+}
+);
+note = uni1402;
+unicode = 5122;
+},
+{
+glyphname = "i-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (306,291);
+},
+{
+name = top_center_can;
+pos = (307,690);
+},
+{
+name = top_left_can;
+pos = (118,690);
+},
+{
+name = top_right_can;
+pos = (497,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(596,0,l),
+(596,35,l),
+(327,690,l),
+(287,690,l),
+(18,35,l),
+(18,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(338,519,l),
+(274,519,l),
+(445,85,l),
+(465,113,l),
+(144,113,l),
+(167,85,l)
+);
+}
+);
+width = 614;
+}
+);
+metricLeft = "e-canadian";
+metricWidth = "e-canadian";
+note = uni1403;
+unicode = 5123;
+},
+{
+glyphname = "ii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (224,0);
+ref = dot_top;
+}
+);
+width = 614;
+}
+);
+note = uni1404;
+unicode = 5124;
+},
+{
+glyphname = "o-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (237,345);
+},
+{
+name = top_center_can;
+pos = (293,690);
+},
+{
+name = top_double;
+pos = (390,690);
+},
+{
+name = top_left_can;
+pos = (106,690);
+},
+{
+name = top_right_can;
+pos = (489,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(85,0,l),
+(546,323,l),
+(546,367,l),
+(85,690,l),
+(51,690,l),
+(51,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(168,531,l),
+(138,517,l),
+(418,319,l),
+(418,374,l),
+(138,175,l),
+(168,158,l)
+);
+}
+);
+width = 572;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1405;
+unicode = 5125;
+},
+{
+glyphname = "oo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (23,0);
+ref = dot_top;
+}
+);
+width = 572;
+}
+);
+note = uni1406;
+unicode = 5126;
+},
+{
+glyphname = "yCreeoo-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (135,0);
+ref = doubledot_top;
+}
+);
+width = 572;
+}
+);
+note = uni1407;
+unicode = 5127;
+},
+{
+glyphname = "eeCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(85,0,l),
+(546,323,l),
+(546,367,l),
+(85,690,l),
+(51,690,l),
+(51,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(158,531,l),
+(138,526,l),
+(418,327,l),
+(418,364,l),
+(138,165,l),
+(158,158,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(253,411,l),
+(208,411,l),
+(208,279,l),
+(253,279,l)
+);
+}
+);
+width = 572;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "o-canadian";
+note = uni1408;
+unicode = 5128;
+},
+{
+glyphname = "iCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (184,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 572;
+}
+);
+note = uni1409;
+unicode = 5129;
+},
+{
+glyphname = "a-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (334,345);
+},
+{
+name = top_center_can;
+pos = (249,690);
+},
+{
+name = top_left_can;
+pos = (93,690);
+},
+{
+name = top_right_can;
+pos = (460,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(521,0,l),
+(521,690,l),
+(488,690,l),
+(26,367,l),
+(26,323,l),
+(488,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(434,174,l),
+(154,372,l),
+(154,317,l),
+(434,516,l),
+(405,531,l),
+(405,158,l)
+);
+}
+);
+width = 572;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni140A;
+unicode = 5130;
+},
+{
+glyphname = "aa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (376,0);
+ref = dot_top;
+}
+);
+width = 572;
+}
+);
+note = uni140B;
+unicode = 5131;
+},
+{
+glyphname = "we-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "e-canadian";
+}
+);
+width = 818;
+}
+);
+note = uni140C;
+unicode = 5132;
+},
+{
+glyphname = "weWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (614,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 818;
+}
+);
+note = uni140D;
+unicode = 5133;
+},
+{
+glyphname = "wi-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "i-canadian";
+}
+);
+width = 818;
+}
+);
+note = uni140E;
+unicode = 5134;
+},
+{
+glyphname = "wiWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (614,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 818;
+}
+);
+note = uni140F;
+unicode = 5135;
+},
+{
+glyphname = "wii-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (428,0);
+ref = dot_top;
+}
+);
+width = 818;
+}
+);
+note = uni1410;
+unicode = 5136;
+},
+{
+glyphname = "wiiWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (224,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (614,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 818;
+}
+);
+note = uni1411;
+unicode = 5137;
+},
+{
+glyphname = "wo-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "o-canadian";
+}
+);
+width = 776;
+}
+);
+note = uni1412;
+unicode = 5138;
+},
+{
+glyphname = "woWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (572,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 776;
+}
+);
+note = uni1413;
+unicode = 5139;
+},
+{
+glyphname = "woo-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (413,0);
+ref = dot_top;
+}
+);
+width = 776;
+}
+);
+note = uni1414;
+unicode = 5140;
+},
+{
+glyphname = "wooWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (23,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (572,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 776;
+}
+);
+note = uni1415;
+unicode = 5141;
+},
+{
+glyphname = "wooNaskapi-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (174,-92);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (324,-200);
+ref = dot_top;
+}
+);
+width = 572;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricWidth = "o-canadian";
+note = uni1416;
+unicode = 5142;
+},
+{
+glyphname = "wa-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "a-canadian";
+}
+);
+width = 776;
+}
+);
+note = uni1417;
+unicode = 5143;
+},
+{
+glyphname = "waWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (572,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 776;
+}
+);
+note = uni1418;
+unicode = 5144;
+},
+{
+glyphname = "waa-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (580,0);
+ref = dot_top;
+}
+);
+width = 776;
+}
+);
+note = uni1419;
+unicode = 5145;
+},
+{
+glyphname = "waaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (376,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (572,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 776;
+}
+);
+note = uni141A;
+unicode = 5146;
+},
+{
+glyphname = "waaNaskapi-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (78,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (229,-92);
+ref = dot_top;
+}
+);
+width = 572;
+}
+);
+metricWidth = "a-canadian";
+note = uni141B;
+unicode = 5147;
+},
+{
+glyphname = "ai-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(217,339,o),
+(246,360,o),
+(271,410,c),
+(243,410,l),
+(267,359,o),
+(298,339,o),
+(347,339,cs),
+(421,339,o),
+(470,385,o),
+(470,480,cs),
+(470,690,l),
+(383,690,l),
+(383,483,ls),
+(383,438,o),
+(367,422,o),
+(342,422,cs),
+(316,422,o),
+(300,440,o),
+(300,483,cs),
+(300,690,l),
+(213,690,l),
+(213,483,ls),
+(213,439,o),
+(197,422,o),
+(172,422,cs),
+(146,422,o),
+(131,440,o),
+(131,483,cs),
+(131,690,l),
+(43,690,l),
+(43,480,ls),
+(43,385,o),
+(94,339,o),
+(168,339,cs)
+);
+}
+);
+width = 513;
+}
+);
+metricRight = "=|";
+note = uni141C;
+unicode = 5148;
+},
+{
+glyphname = "ycreew-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(290,510,o),
+(320,546,o),
+(320,604,cs),
+(320,662,o),
+(289,696,o),
+(246,696,cs),
+(204,696,o),
+(173,662,o),
+(173,604,cs),
+(173,546,o),
+(203,510,o),
+(246,510,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(158,339,o),
+(188,375,o),
+(188,433,cs),
+(188,491,o),
+(157,525,o),
+(115,525,cs),
+(72,525,o),
+(43,491,o),
+(43,433,cs),
+(43,375,o),
+(71,339,o),
+(115,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(99,384,o),
+(89,399,o),
+(89,433,cs),
+(89,466,o),
+(99,479,o),
+(115,479,cs),
+(131,479,o),
+(142,466,o),
+(142,433,cs),
+(142,399,o),
+(131,384,o),
+(115,384,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(230,555,o),
+(220,570,o),
+(220,604,cs),
+(220,637,o),
+(230,650,o),
+(246,650,cs),
+(263,650,o),
+(272,637,o),
+(272,604,cs),
+(272,570,o),
+(263,555,o),
+(246,555,cs)
+);
+}
+);
+width = 363;
+}
+);
+metricRight = "=|";
+note = uni141D;
+unicode = 5149;
+},
+{
+glyphname = "glottalstop-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(325,345,l),
+(325,363,l),
+(191,690,l),
+(170,690,l),
+(36,363,l),
+(36,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(202,596,l),
+(159,596,l),
+(240,387,l),
+(253,414,l),
+(109,414,l),
+(121,387,l)
+);
+}
+);
+width = 361;
+}
+);
+metricRight = "=|";
+note = uni141E;
+unicode = 5150;
+},
+{
+glyphname = "en-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+pos = (614,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 898;
+}
+);
+note = uni142B;
+unicode = 5163;
+},
+{
+glyphname = "in-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+pos = (415,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 698;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142C;
+unicode = 5164;
+},
+{
+glyphname = "on-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (439,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 722;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142D;
+unicode = 5165;
+},
+{
+glyphname = "an-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (544,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 827;
+}
+);
+metricRight = "graveFinal-canadian";
+note = uni142E;
+unicode = 5166;
+},
+{
+glyphname = "pe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (308,454);
+},
+{
+name = top_center_can;
+pos = (308,690);
+},
+{
+name = top_left_can;
+pos = (119,690);
+},
+{
+name = top_right_can;
+pos = (497,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(327,0,l),
+(596,655,l),
+(596,690,l),
+(470,690,l),
+(264,168,l),
+(355,168,l),
+(149,690,l),
+(18,690,l),
+(18,655,l),
+(287,0,l)
+);
+}
+);
+width = 614;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni142F;
+unicode = 5167;
+},
+{
+glyphname = "paai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (190,0);
+ref = ring_top.canadian;
+}
+);
+width = 614;
+}
+);
+note = uni1430;
+unicode = 5168;
+},
+{
+glyphname = "pi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (307,291);
+},
+{
+name = top_center_can;
+pos = (307,690);
+},
+{
+name = top_left_can;
+pos = (118,690);
+},
+{
+name = top_right_can;
+pos = (497,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(147,0,l),
+(353,522,l),
+(261,522,l),
+(468,0,l),
+(596,0,l),
+(596,35,l),
+(327,690,l),
+(287,690,l),
+(18,35,l),
+(18,0,l)
+);
+}
+);
+width = 614;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni1431;
+unicode = 5169;
+},
+{
+glyphname = "pii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (224,0);
+ref = dot_top;
+}
+);
+width = 614;
+}
+);
+note = uni1432;
+unicode = 5170;
+},
+{
+glyphname = "po-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (148,345);
+},
+{
+name = top_center_can;
+pos = (275,690);
+},
+{
+name = top_double;
+pos = (384,690);
+},
+{
+name = top_left_can;
+pos = (96,690);
+},
+{
+name = top_right_can;
+pos = (470,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(68,0,l),
+(527,323,l),
+(527,367,l),
+(68,690,l),
+(35,690,l),
+(35,556,l),
+(381,314,l),
+(381,378,l),
+(35,135,l),
+(35,0,l)
+);
+}
+);
+width = 553;
+}
+);
+metricRight = "o-canadian";
+note = uni1433;
+unicode = 5171;
+},
+{
+glyphname = "poo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (12,0);
+ref = dot_top;
+}
+);
+width = 554;
+}
+);
+note = uni1434;
+unicode = 5172;
+},
+{
+glyphname = "ycreepoo-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (129,0);
+ref = doubledot_top;
+}
+);
+width = 554;
+}
+);
+note = uni1435;
+unicode = 5173;
+},
+{
+glyphname = "heeCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (102,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 554;
+}
+);
+note = uni1436;
+unicode = 5174;
+},
+{
+glyphname = "hiCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (78,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 554;
+}
+);
+note = uni1437;
+unicode = 5175;
+},
+{
+glyphname = "pa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (355,345);
+},
+{
+name = top_center_can;
+pos = (280,690);
+},
+{
+name = top_left_can;
+pos = (94,690);
+},
+{
+name = top_right_can;
+pos = (459,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(519,0,l),
+(519,133,l),
+(173,376,l),
+(173,312,l),
+(519,554,l),
+(519,690,l),
+(486,690,l),
+(26,367,l),
+(26,323,l),
+(486,0,l)
+);
+}
+);
+width = 554;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1438;
+unicode = 5176;
+},
+{
+glyphname = "paa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (375,0);
+ref = dot_top;
+}
+);
+width = 554;
+}
+);
+note = uni1439;
+unicode = 5177;
+},
+{
+glyphname = "pwe-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "pe-canadian";
+}
+);
+width = 818;
+}
+);
+note = uni143A;
+unicode = 5178;
+},
+{
+glyphname = "pweWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "pe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (614,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 818;
+}
+);
+note = uni143B;
+unicode = 5179;
+},
+{
+glyphname = "pwi-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "pi-canadian";
+}
+);
+width = 818;
+}
+);
+note = uni143C;
+unicode = 5180;
+},
+{
+glyphname = "pwiWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (614,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 818;
+}
+);
+note = uni143D;
+unicode = 5181;
+},
+{
+glyphname = "pwii-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (428,0);
+ref = dot_top;
+}
+);
+width = 818;
+}
+);
+note = uni143E;
+unicode = 5182;
+},
+{
+glyphname = "pwiiWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (224,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (614,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 818;
+}
+);
+note = uni143F;
+unicode = 5183;
+},
+{
+glyphname = "pwo-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "po-canadian";
+}
+);
+width = 757;
+}
+);
+note = uni1440;
+unicode = 5184;
+},
+{
+glyphname = "pwoWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (554,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 757;
+}
+);
+note = uni1441;
+unicode = 5185;
+},
+{
+glyphname = "pwoo-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (395,0);
+ref = dot_top;
+}
+);
+width = 757;
+}
+);
+note = uni1442;
+unicode = 5186;
+},
+{
+glyphname = "pwooWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (12,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (554,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 757;
+}
+);
+note = uni1443;
+unicode = 5187;
+},
+{
+glyphname = "pwa-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "pa-canadian";
+}
+);
+width = 757;
+}
+);
+note = uni1444;
+unicode = 5188;
+},
+{
+glyphname = "pwaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (554,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 757;
+}
+);
+note = uni1445;
+unicode = 5189;
+},
+{
+glyphname = "pwaa-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (579,0);
+ref = dot_top;
+}
+);
+width = 757;
+}
+);
+note = uni1446;
+unicode = 5190;
+},
+{
+glyphname = "pwaaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (375,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (554,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 757;
+}
+);
+note = uni1447;
+unicode = 5191;
+},
+{
+glyphname = "ycreepwaa-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+pos = (78,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (228,-92);
+ref = dot_top;
+}
+);
+width = 554;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1448;
+unicode = 5192;
+},
+{
+glyphname = "p-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(285,345,l),
+(285,433,l),
+(118,553,l),
+(118,481,l),
+(285,600,l),
+(285,690,l),
+(269,690,l),
+(43,529,l),
+(43,506,l),
+(269,345,l)
+);
+}
+);
+width = 328;
+}
+);
+note = uni1449;
+unicode = 5193;
+},
+{
+glyphname = "pWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(138,345,l),
+(138,690,l),
+(43,690,l),
+(43,345,l)
+);
+}
+);
+width = 181;
+}
+);
+metricRight = "=|";
+note = uni144A;
+unicode = 5194;
+},
+{
+color = 6;
+glyphname = "hCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(138,183,l),
+(138,304,ls),
+(138,334,o),
+(150,353,o),
+(174,353,cs),
+(196,353,o),
+(207,336,o),
+(207,308,cs),
+(207,183,l),
+(300,183,l),
+(300,324,ls),
+(300,407,o),
+(247,437,o),
+(201,437,cs),
+(157,437,o),
+(127,412,o),
+(119,381,c),
+(138,362,l),
+(138,527,l),
+(43,527,l),
+(43,183,l)
+);
+}
+);
+width = 330;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144B;
+unicode = 5195;
+},
+{
+glyphname = "te-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (309,345);
+},
+{
+name = top_center_can;
+pos = (309,690);
+},
+{
+name = top_left_can;
+pos = (121,690);
+},
+{
+name = top_right_can;
+pos = (499,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(477,-14,o),
+(570,85,o),
+(570,271,cs),
+(570,690,l),
+(428,690,l),
+(428,272,ls),
+(428,163,o),
+(387,117,o),
+(309,117,cs),
+(234,117,o),
+(191,166,o),
+(191,272,cs),
+(191,690,l),
+(48,690,l),
+(48,270,ls),
+(48,85,o),
+(145,-14,o),
+(310,-14,cs)
+);
+}
+);
+width = 618;
+}
+);
+metricRight = "=|";
+note = uni144C;
+unicode = 5196;
+},
+{
+glyphname = "taai-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (192,0);
+ref = ring_top.canadian;
+}
+);
+width = 619;
+}
+);
+note = uni144D;
+unicode = 5197;
+},
+{
+glyphname = "ti-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (309,345);
+},
+{
+name = middle_right_can;
+pos = (692,345);
+},
+{
+name = top_center_can;
+pos = (309,690);
+},
+{
+name = top_left_can;
+pos = (121,690);
+},
+{
+name = top_right_can;
+pos = (499,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(191,0,l),
+(191,417,ls),
+(191,526,o),
+(232,573,o),
+(310,573,cs),
+(385,573,o),
+(428,524,o),
+(428,417,cs),
+(428,0,l),
+(570,0,l),
+(570,419,ls),
+(570,605,o),
+(475,703,o),
+(310,703,cs),
+(149,703,o),
+(48,605,o),
+(48,419,cs),
+(48,0,l)
+);
+}
+);
+width = 618;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni144E;
+unicode = 5198;
+},
+{
+glyphname = "tii-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (226,0);
+ref = dot_top;
+}
+);
+width = 619;
+}
+);
+note = uni144F;
+unicode = 5199;
+},
+{
+glyphname = "to-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (187,345);
+},
+{
+name = middle_right_can;
+pos = (599,345);
+},
+{
+name = top_center_can;
+pos = (236,690);
+},
+{
+name = top_double;
+pos = (309,690);
+},
+{
+name = top_left_can;
+pos = (98,690);
+},
+{
+name = top_right_can;
+pos = (417,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(148,0,ls),
+(357,0,o),
+(478,116,o),
+(478,346,cs),
+(478,576,o),
+(357,690,o),
+(146,690,cs),
+(37,690,l),
+(37,560,l),
+(146,560,ls),
+(267,560,o),
+(336,497,o),
+(336,346,cs),
+(336,194,o),
+(267,129,o),
+(148,129,cs),
+(37,129,l),
+(37,0,l)
+);
+}
+);
+width = 522;
+}
+);
+note = uni1450;
+unicode = 5200;
+},
+{
+glyphname = "too-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (153,0);
+ref = dot_top;
+}
+);
+width = 522;
+}
+);
+note = uni1451;
+unicode = 5201;
+},
+{
+glyphname = "ycreetoo-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (54,0);
+ref = doubledot_top;
+}
+);
+width = 522;
+}
+);
+note = uni1452;
+unicode = 5202;
+},
+{
+glyphname = "deeCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (131,0);
+ref = stroke_middle;
+}
+);
+width = 522;
+}
+);
+note = uni1453;
+unicode = 5203;
+},
+{
+glyphname = "diCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (103,0);
+ref = dot_middle;
+}
+);
+width = 522;
+}
+);
+note = uni1454;
+unicode = 5204;
+},
+{
+glyphname = "ta-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (336,345);
+},
+{
+name = top_center_can;
+pos = (288,690);
+},
+{
+name = top_left_can;
+pos = (106,690);
+},
+{
+name = top_right_can;
+pos = (425,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(486,0,l),
+(486,129,l),
+(377,129,ls),
+(257,129,o),
+(187,192,o),
+(187,344,cs),
+(187,496,o),
+(257,560,o),
+(376,560,cs),
+(486,560,l),
+(486,690,l),
+(376,690,ls),
+(165,690,o),
+(44,574,o),
+(44,344,cs),
+(44,115,o),
+(165,0,o),
+(377,0,cs)
+);
+}
+);
+width = 523;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|to-canadian";
+note = uni1455;
+unicode = 5205;
+},
+{
+glyphname = "taa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (203,0);
+ref = dot_top;
+}
+);
+width = 522;
+}
+);
+note = uni1456;
+unicode = 5206;
+},
+{
+glyphname = "twe-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "te-canadian";
+}
+);
+width = 823;
+}
+);
+note = uni1457;
+unicode = 5207;
+},
+{
+glyphname = "tweWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (619,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 823;
+}
+);
+note = uni1458;
+unicode = 5208;
+},
+{
+glyphname = "twi-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ti-canadian";
+}
+);
+width = 823;
+}
+);
+note = uni1459;
+unicode = 5209;
+},
+{
+glyphname = "twiWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (619,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 823;
+}
+);
+note = uni145A;
+unicode = 5210;
+},
+{
+glyphname = "twii-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (430,0);
+ref = dot_top;
+}
+);
+width = 823;
+}
+);
+note = uni145B;
+unicode = 5211;
+},
+{
+glyphname = "twiiWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (226,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (619,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 823;
+}
+);
+note = uni145C;
+unicode = 5212;
+},
+{
+glyphname = "two-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "to-canadian";
+}
+);
+width = 725;
+}
+);
+note = uni145D;
+unicode = 5213;
+},
+{
+glyphname = "twoWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (522,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 725;
+}
+);
+note = uni145E;
+unicode = 5214;
+},
+{
+glyphname = "twoo-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (356,0);
+ref = dot_top;
+}
+);
+width = 725;
+}
+);
+note = uni145F;
+unicode = 5215;
+},
+{
+glyphname = "twooWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (153,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (522,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 725;
+}
+);
+note = uni1460;
+unicode = 5216;
+},
+{
+glyphname = "twa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ta-canadian";
+}
+);
+width = 725;
+}
+);
+note = uni1461;
+unicode = 5217;
+},
+{
+glyphname = "twaWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (522,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 725;
+}
+);
+note = uni1462;
+unicode = 5218;
+},
+{
+glyphname = "twaa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (407,0);
+ref = dot_top;
+}
+);
+width = 725;
+}
+);
+note = uni1463;
+unicode = 5219;
+},
+{
+glyphname = "twaaWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (203,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (522,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 725;
+}
+);
+note = uni1464;
+unicode = 5220;
+},
+{
+glyphname = "twaaNaskapi-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (207,0);
+ref = "ta-canadian";
+}
+);
+width = 728;
+}
+);
+note = uni1465;
+unicode = 5221;
+},
+{
+glyphname = "t-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(262,345,l),
+(262,434,l),
+(215,434,ls),
+(162,434,o),
+(134,463,o),
+(134,517,cs),
+(134,570,o),
+(162,601,o),
+(215,601,cs),
+(262,601,l),
+(262,690,l),
+(207,690,ls),
+(99,690,o),
+(40,622,o),
+(40,517,cs),
+(40,412,o),
+(99,345,o),
+(207,345,cs)
+);
+}
+);
+width = 304;
+}
+);
+note = uni1466;
+unicode = 5222;
+},
+{
+glyphname = "tte-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+pos = (619,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 800;
+}
+);
+note = uni1467;
+unicode = 5223;
+},
+{
+glyphname = "tti-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+pos = (619,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 800;
+}
+);
+note = uni1468;
+unicode = 5224;
+},
+{
+glyphname = "tto-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+pos = (522,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 702;
+}
+);
+note = uni1469;
+unicode = 5225;
+},
+{
+glyphname = "tta-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+pos = (522,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 702;
+}
+);
+note = uni146A;
+unicode = 5226;
+},
+{
+glyphname = "ke-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (256,441);
+},
+{
+name = top_center_can;
+pos = (251,690);
+},
+{
+name = top_left_can;
+pos = (108,690);
+},
+{
+name = top_right_can;
+pos = (392,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(463,0,l),
+(463,440,ls),
+(463,608,o),
+(389,703,o),
+(255,703,cs),
+(121,703,o),
+(39,605,o),
+(39,441,cs),
+(39,287,o),
+(116,186,o),
+(231,186,cs),
+(284,186,o),
+(324,218,o),
+(333,253,c),
+(321,274,l),
+(321,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(208,307,o),
+(178,348,o),
+(178,445,cs),
+(178,543,o),
+(205,583,o),
+(250,583,cs),
+(296,583,o),
+(324,544,o),
+(324,445,cs),
+(324,347,o),
+(294,307,o),
+(250,307,cs)
+);
+}
+);
+width = 511;
+}
+);
+metricRight = "te-canadian";
+note = uni146B;
+unicode = 5227;
+},
+{
+glyphname = "kaai-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (143,0);
+ref = ring_top.canadian;
+}
+);
+width = 511;
+}
+);
+note = uni146C;
+unicode = 5228;
+},
+{
+glyphname = "ki-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (266,441);
+},
+{
+name = top_center_can;
+pos = (261,690);
+},
+{
+name = top_left_can;
+pos = (120,690);
+},
+{
+name = top_right_can;
+pos = (404,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(191,0,l),
+(191,274,l),
+(179,253,l),
+(187,218,o),
+(227,186,o),
+(281,186,cs),
+(396,186,o),
+(473,288,o),
+(473,442,cs),
+(473,605,o),
+(391,703,o),
+(261,703,cs),
+(123,703,o),
+(48,602,o),
+(48,440,cs),
+(48,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(218,307,o),
+(188,347,o),
+(188,445,cs),
+(188,544,o),
+(215,583,o),
+(261,583,cs),
+(306,583,o),
+(333,543,o),
+(333,445,cs),
+(333,348,o),
+(304,307,o),
+(261,307,cs)
+);
+}
+);
+width = 512;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni146D;
+unicode = 5229;
+},
+{
+glyphname = "kii-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (177,0);
+ref = dot_top;
+}
+);
+width = 511;
+}
+);
+note = uni146E;
+unicode = 5230;
+},
+{
+glyphname = "ko-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (256,298);
+},
+{
+name = top_center_can;
+pos = (251,690);
+},
+{
+name = top_double;
+pos = (392,690);
+},
+{
+name = top_left_can;
+pos = (108,690);
+},
+{
+name = top_right_can;
+pos = (392,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(387,-14,o),
+(463,82,o),
+(463,249,cs),
+(463,690,l),
+(321,690,l),
+(321,415,l),
+(333,437,l),
+(324,471,o),
+(284,503,o),
+(231,503,cs),
+(116,503,o),
+(39,402,o),
+(39,242,cs),
+(39,85,o),
+(117,-14,o),
+(253,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(205,106,o),
+(178,147,o),
+(178,244,cs),
+(178,342,o),
+(208,383,o),
+(250,383,cs),
+(294,383,o),
+(324,343,o),
+(324,244,cs),
+(324,146,o),
+(296,106,o),
+(250,106,cs)
+);
+}
+);
+width = 511;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni146F;
+unicode = 5231;
+},
+{
+glyphname = "koo-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (309,0);
+ref = dot_top;
+}
+);
+width = 511;
+}
+);
+note = uni1470;
+unicode = 5232;
+},
+{
+glyphname = "ycreekoo-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (137,0);
+ref = doubledot_top;
+}
+);
+width = 511;
+}
+);
+note = uni1471;
+unicode = 5233;
+},
+{
+glyphname = "ka-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (266,302);
+},
+{
+name = top_center_can;
+pos = (261,690);
+},
+{
+name = top_left_can;
+pos = (120,690);
+},
+{
+name = top_right_can;
+pos = (404,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(390,-14,o),
+(473,85,o),
+(473,248,cs),
+(473,402,o),
+(396,503,o),
+(282,503,cs),
+(228,503,o),
+(188,471,o),
+(179,437,c),
+(191,415,l),
+(191,690,l),
+(48,690,l),
+(48,249,ls),
+(48,82,o),
+(122,-14,o),
+(257,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(215,106,o),
+(188,146,o),
+(188,244,cs),
+(188,343,o),
+(218,383,o),
+(261,383,cs),
+(304,383,o),
+(333,342,o),
+(333,244,cs),
+(333,147,o),
+(306,106,o),
+(261,106,cs)
+);
+}
+);
+width = 512;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "==|ke-canadian";
+note = uni1472;
+unicode = 5234;
+},
+{
+glyphname = "kaa-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+}
+);
+width = 511;
+}
+);
+note = uni1473;
+unicode = 5235;
+},
+{
+glyphname = "kwe-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ke-canadian";
+}
+);
+width = 715;
+}
+);
+note = uni1474;
+unicode = 5236;
+},
+{
+glyphname = "kweWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (511,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 715;
+}
+);
+note = uni1475;
+unicode = 5237;
+},
+{
+glyphname = "kwi-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ki-canadian";
+}
+);
+width = 715;
+}
+);
+note = uni1476;
+unicode = 5238;
+},
+{
+glyphname = "kwiWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (511,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 715;
+}
+);
+note = uni1477;
+unicode = 5239;
+},
+{
+glyphname = "kwii-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (381,0);
+ref = dot_top;
+}
+);
+width = 715;
+}
+);
+note = uni1478;
+unicode = 5240;
+},
+{
+glyphname = "kwiiWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (177,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (511,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 715;
+}
+);
+note = uni1479;
+unicode = 5241;
+},
+{
+glyphname = "kwo-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ko-canadian";
+}
+);
+width = 715;
+}
+);
+note = uni147A;
+unicode = 5242;
+},
+{
+glyphname = "kwoWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (511,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 715;
+}
+);
+note = uni147B;
+unicode = 5243;
+},
+{
+glyphname = "kwoo-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (513,0);
+ref = dot_top;
+}
+);
+width = 715;
+}
+);
+note = uni147C;
+unicode = 5244;
+},
+{
+glyphname = "kwooWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (309,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (511,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 715;
+}
+);
+note = uni147D;
+unicode = 5245;
+},
+{
+glyphname = "kwa-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ka-canadian";
+}
+);
+width = 715;
+}
+);
+note = uni147E;
+unicode = 5246;
+},
+{
+glyphname = "kwaWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (511,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 715;
+}
+);
+note = uni147F;
+unicode = 5247;
+},
+{
+glyphname = "kwaa-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (240,0);
+ref = dot_top;
+}
+);
+width = 715;
+}
+);
+note = uni1480;
+unicode = 5248;
+},
+{
+glyphname = "kwaaWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (511,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 715;
+}
+);
+note = uni1481;
+unicode = 5249;
+},
+{
+glyphname = "kwaaNaskapi-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (207,0);
+ref = "ka-canadian";
+}
+);
+width = 719;
+}
+);
+note = uni1482;
+unicode = 5250;
+},
+{
+glyphname = "k-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(230,339,o),
+(283,383,o),
+(283,475,cs),
+(283,555,o),
+(241,601,o),
+(185,601,cs),
+(150,601,o),
+(123,579,o),
+(118,546,c),
+(138,546,l),
+(138,690,l),
+(43,690,l),
+(43,470,ls),
+(43,390,o),
+(87,339,o),
+(165,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(144,408,o),
+(130,423,o),
+(130,469,cs),
+(130,516,o),
+(145,532,o),
+(164,532,cs),
+(184,532,o),
+(199,517,o),
+(199,469,cs),
+(199,423,o),
+(184,408,o),
+(164,408,cs)
+);
+}
+);
+width = 317;
+}
+);
+note = uni1483;
+unicode = 5251;
+},
+{
+glyphname = "kw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(229,339,o),
+(273,390,o),
+(273,470,cs),
+(273,690,l),
+(179,690,l),
+(179,546,l),
+(199,546,l),
+(193,579,o),
+(167,601,o),
+(131,601,cs),
+(76,601,o),
+(34,555,o),
+(34,475,cs),
+(34,383,o),
+(86,339,o),
+(152,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(133,408,o),
+(118,423,o),
+(118,469,cs),
+(118,517,o),
+(133,532,o),
+(153,532,cs),
+(171,532,o),
+(186,516,o),
+(186,469,cs),
+(186,423,o),
+(172,408,o),
+(153,408,cs)
+);
+}
+);
+width = 316;
+}
+);
+metricLeft = "=|k-canadian";
+metricRight = "=|k-canadian";
+note = uni1484;
+unicode = 5252;
+},
+{
+glyphname = "southslaveykeh-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+pos = (511,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 693;
+}
+);
+note = uni1485;
+unicode = 5253;
+},
+{
+glyphname = "southslaveykih-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+pos = (511,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 693;
+}
+);
+note = uni1486;
+unicode = 5254;
+},
+{
+glyphname = "southslaveykoh-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+pos = (511,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 693;
+}
+);
+note = uni1487;
+unicode = 5255;
+},
+{
+glyphname = "southslaveykah-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+pos = (511,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 693;
+}
+);
+note = uni1488;
+unicode = 5256;
+},
+{
+glyphname = "ce-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (250,371);
+},
+{
+name = top_center_can;
+pos = (247,690);
+},
+{
+name = top_left_can;
+pos = (107,690);
+},
+{
+name = top_right_can;
+pos = (384,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(454,0,l),
+(454,451,ls),
+(454,610,o),
+(382,703,o),
+(247,703,cs),
+(116,703,o),
+(36,615,o),
+(36,452,cs),
+(36,382,l),
+(177,382,l),
+(177,477,ls),
+(177,544,o),
+(200,580,o),
+(245,580,cs),
+(288,580,o),
+(312,546,o),
+(312,475,cs),
+(312,0,l)
+);
+}
+);
+width = 502;
+}
+);
+metricRight = "te-canadian";
+note = uni1489;
+unicode = 5257;
+},
+{
+glyphname = "caai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (143,0);
+ref = ring_top.canadian;
+}
+);
+width = 503;
+}
+);
+note = uni148A;
+unicode = 5258;
+},
+{
+glyphname = "ci-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (262,371);
+},
+{
+name = top_center_can;
+pos = (260,690);
+},
+{
+name = top_left_can;
+pos = (121,690);
+},
+{
+name = top_right_can;
+pos = (397,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(191,0,l),
+(191,475,ls),
+(191,546,o),
+(215,580,o),
+(259,580,cs),
+(303,580,o),
+(327,544,o),
+(327,477,cs),
+(327,382,l),
+(468,382,l),
+(468,452,ls),
+(468,615,o),
+(388,703,o),
+(260,703,cs),
+(121,703,o),
+(48,609,o),
+(48,451,cs),
+(48,0,l)
+);
+}
+);
+width = 504;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+unicode = 5259;
+},
+{
+glyphname = "cii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (177,0);
+ref = dot_top;
+}
+);
+width = 503;
+}
+);
+note = uni148C;
+unicode = 5260;
+},
+{
+glyphname = "co-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (250,371);
+},
+{
+name = top_center_can;
+pos = (246,690);
+},
+{
+name = top_double;
+pos = (384,690);
+},
+{
+name = top_left_can;
+pos = (107,690);
+},
+{
+name = top_right_can;
+pos = (384,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(382,-14,o),
+(454,80,o),
+(454,239,cs),
+(454,690,l),
+(312,690,l),
+(312,214,ls),
+(312,144,o),
+(288,110,o),
+(245,110,cs),
+(200,110,o),
+(177,146,o),
+(177,213,cs),
+(177,308,l),
+(36,308,l),
+(36,238,ls),
+(36,74,o),
+(114,-14,o),
+(249,-14,cs)
+);
+}
+);
+width = 502;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+unicode = 5261;
+},
+{
+glyphname = "coo-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (300,0);
+ref = dot_top;
+}
+);
+width = 503;
+}
+);
+note = uni148E;
+unicode = 5262;
+},
+{
+glyphname = "ycreecoo-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (128,0);
+ref = doubledot_top;
+}
+);
+width = 503;
+}
+);
+note = uni148F;
+unicode = 5263;
+},
+{
+glyphname = "ca-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (262,371);
+},
+{
+name = top_center_can;
+pos = (260,690);
+},
+{
+name = top_left_can;
+pos = (121,690);
+},
+{
+name = top_right_can;
+pos = (397,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(388,-14,o),
+(468,74,o),
+(468,238,cs),
+(468,308,l),
+(327,308,l),
+(327,213,ls),
+(327,146,o),
+(303,110,o),
+(258,110,cs),
+(215,110,o),
+(191,144,o),
+(191,215,cs),
+(191,690,l),
+(48,690,l),
+(48,239,ls),
+(48,80,o),
+(121,-14,o),
+(257,-14,cs)
+);
+}
+);
+width = 504;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+unicode = 5264;
+},
+{
+glyphname = "caa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (37,0);
+ref = dot_top;
+}
+);
+width = 503;
+}
+);
+note = uni1491;
+unicode = 5265;
+},
+{
+glyphname = "cwe-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ce-canadian";
+}
+);
+width = 707;
+}
+);
+note = uni1492;
+unicode = 5266;
+},
+{
+glyphname = "cweWestCree-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (503,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 707;
+}
+);
+note = uni1493;
+unicode = 5267;
+},
+{
+glyphname = "cwi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ci-canadian";
+}
+);
+width = 707;
+}
+);
+note = uni1494;
+unicode = 5268;
+},
+{
+glyphname = "cwiWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (503,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 707;
+}
+);
+note = uni1495;
+unicode = 5269;
+},
+{
+glyphname = "cwii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (381,0);
+ref = dot_top;
+}
+);
+width = 707;
+}
+);
+note = uni1496;
+unicode = 5270;
+},
+{
+glyphname = "cwiiWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (177,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (503,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 707;
+}
+);
+note = uni1497;
+unicode = 5271;
+},
+{
+glyphname = "cwo-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "co-canadian";
+}
+);
+width = 707;
+}
+);
+note = uni1498;
+unicode = 5272;
+},
+{
+glyphname = "cwoWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (503,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 707;
+}
+);
+note = uni1499;
+unicode = 5273;
+},
+{
+glyphname = "cwoo-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (504,0);
+ref = dot_top;
+}
+);
+width = 707;
+}
+);
+note = uni149A;
+unicode = 5274;
+},
+{
+glyphname = "cwooWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (300,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (503,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 707;
+}
+);
+note = uni149B;
+unicode = 5275;
+},
+{
+glyphname = "cwa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ca-canadian";
+}
+);
+width = 707;
+}
+);
+note = uni149C;
+unicode = 5276;
+},
+{
+glyphname = "cwaWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (503,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 707;
+}
+);
+note = uni149D;
+unicode = 5277;
+},
+{
+glyphname = "cwaa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (241,0);
+ref = dot_top;
+}
+);
+width = 707;
+}
+);
+note = uni149E;
+unicode = 5278;
+},
+{
+glyphname = "cwaaWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (37,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (503,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 707;
+}
+);
+note = uni149F;
+unicode = 5279;
+},
+{
+glyphname = "cwaaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (207,0);
+ref = "ca-canadian";
+}
+);
+width = 710;
+}
+);
+note = uni14A0;
+unicode = 5280;
+},
+{
+glyphname = "c-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(239,339,o),
+(285,385,o),
+(285,467,cs),
+(285,490,l),
+(198,490,l),
+(198,452,ls),
+(198,428,o),
+(185,412,o),
+(167,412,cs),
+(147,412,o),
+(138,427,o),
+(138,454,cs),
+(138,690,l),
+(43,690,l),
+(43,470,ls),
+(43,384,o),
+(86,339,o),
+(165,339,cs)
+);
+}
+);
+width = 308;
+}
+);
+note = uni14A1;
+unicode = 5281;
+},
+{
+glyphname = "thSayisi-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(222,339,o),
+(265,384,o),
+(265,470,cs),
+(265,690,l),
+(170,690,l),
+(170,454,ls),
+(170,427,o),
+(161,412,o),
+(141,412,cs),
+(122,412,o),
+(110,428,o),
+(110,452,cs),
+(110,490,l),
+(23,490,l),
+(23,467,ls),
+(23,385,o),
+(70,339,o),
+(147,339,cs)
+);
+}
+);
+width = 308;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "=|c-canadian";
+note = uni14A2;
+unicode = 5282;
+},
+{
+glyphname = "me-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (154,345);
+},
+{
+name = top_center_can;
+pos = (228,690);
+},
+{
+name = top_left_can;
+pos = (101,690);
+},
+{
+name = top_right_can;
+pos = (347,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(418,0,l),
+(418,690,l),
+(31,690,l),
+(31,560,l),
+(275,560,l),
+(275,0,l)
+);
+}
+);
+width = 469;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+unicode = 5283;
+},
+{
+glyphname = "maai-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (128,0);
+ref = ring_top.canadian;
+}
+);
+width = 469;
+}
+);
+note = uni14A4;
+unicode = 5284;
+},
+{
+glyphname = "mi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (317,345);
+},
+{
+name = top_center_can;
+pos = (245,690);
+},
+{
+name = top_left_can;
+pos = (123,690);
+},
+{
+name = top_right_can;
+pos = (368,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(193,0,l),
+(193,560,l),
+(439,560,l),
+(439,690,l),
+(51,690,l),
+(51,0,l)
+);
+}
+);
+width = 470;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+unicode = 5285;
+},
+{
+glyphname = "mii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (161,0);
+ref = dot_top;
+}
+);
+width = 469;
+}
+);
+note = uni14A6;
+unicode = 5286;
+},
+{
+glyphname = "mo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (154,345);
+},
+{
+name = top_center_can;
+pos = (228,690);
+},
+{
+name = top_double;
+pos = (348,690);
+},
+{
+name = top_left_can;
+pos = (101,690);
+},
+{
+name = top_right_can;
+pos = (347,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(418,0,l),
+(418,690,l),
+(275,690,l),
+(275,129,l),
+(31,129,l),
+(31,0,l)
+);
+}
+);
+width = 469;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+unicode = 5287;
+},
+{
+glyphname = "moo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (264,0);
+ref = dot_top;
+}
+);
+width = 469;
+}
+);
+note = uni14A8;
+unicode = 5288;
+},
+{
+glyphname = "ycreemoo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (93,0);
+ref = doubledot_top;
+}
+);
+width = 469;
+}
+);
+note = uni14A9;
+unicode = 5289;
+},
+{
+glyphname = "ma-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (317,345);
+},
+{
+name = top_center_can;
+pos = (245,690);
+},
+{
+name = top_left_can;
+pos = (123,690);
+},
+{
+name = top_right_can;
+pos = (367,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(439,0,l),
+(439,129,l),
+(193,129,l),
+(193,690,l),
+(51,690,l),
+(51,0,l)
+);
+}
+);
+width = 470;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+unicode = 5290;
+},
+{
+glyphname = "maa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (40,0);
+ref = dot_top;
+}
+);
+width = 469;
+}
+);
+note = uni14AB;
+unicode = 5291;
+},
+{
+glyphname = "mwe-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "me-canadian";
+}
+);
+width = 673;
+}
+);
+note = uni14AC;
+unicode = 5292;
+},
+{
+glyphname = "mweWestCree-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "me-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (469,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 673;
+}
+);
+note = uni14AD;
+unicode = 5293;
+},
+{
+glyphname = "mwi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "mi-canadian";
+}
+);
+width = 673;
+}
+);
+note = uni14AE;
+unicode = 5294;
+},
+{
+glyphname = "mwiWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (469,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 673;
+}
+);
+note = uni14AF;
+unicode = 5295;
+},
+{
+glyphname = "mwii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (365,0);
+ref = dot_top;
+}
+);
+width = 673;
+}
+);
+note = uni14B0;
+unicode = 5296;
+},
+{
+glyphname = "mwiiWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (161,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (469,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 673;
+}
+);
+note = uni14B1;
+unicode = 5297;
+},
+{
+glyphname = "mwo-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "mo-canadian";
+}
+);
+width = 673;
+}
+);
+note = uni14B2;
+unicode = 5298;
+},
+{
+glyphname = "mwoWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (469,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 673;
+}
+);
+note = uni14B3;
+unicode = 5299;
+},
+{
+glyphname = "mwoo-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (468,0);
+ref = dot_top;
+}
+);
+width = 673;
+}
+);
+note = uni14B4;
+unicode = 5300;
+},
+{
+glyphname = "mwooWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (264,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (469,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 673;
+}
+);
+note = uni14B5;
+unicode = 5301;
+},
+{
+glyphname = "mwa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ma-canadian";
+}
+);
+width = 673;
+}
+);
+note = uni14B6;
+unicode = 5302;
+},
+{
+glyphname = "mwaWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (469,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 673;
+}
+);
+note = uni14B7;
+unicode = 5303;
+},
+{
+glyphname = "mwaa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (243,0);
+ref = dot_top;
+}
+);
+width = 673;
+}
+);
+note = uni14B8;
+unicode = 5304;
+},
+{
+glyphname = "mwaaWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (40,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (469,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 673;
+}
+);
+note = uni14B9;
+unicode = 5305;
+},
+{
+glyphname = "mwaaNaskapi-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (207,0);
+ref = "ma-canadian";
+}
+);
+width = 676;
+}
+);
+note = uni14BA;
+unicode = 5306;
+},
+{
+glyphname = "m-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(257,434,l),
+(138,434,l),
+(138,690,l),
+(43,690,l),
+(43,345,l),
+(257,345,l)
+);
+}
+);
+width = 284;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni14BB;
+unicode = 5307;
+},
+{
+glyphname = "mWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+ref = "t-canadian";
+}
+);
+width = 304;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "t-canadian";
+note = uni14BC;
+unicode = 5308;
+},
+{
+glyphname = "mh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(240,345,l),
+(240,690,l),
+(146,690,l),
+(146,434,l),
+(27,434,l),
+(27,345,l)
+);
+}
+);
+width = 283;
+}
+);
+metricLeft = "=|m-canadian";
+metricRight = "=|m-canadian";
+note = uni14BD;
+unicode = 5309;
+},
+{
+glyphname = "mAthapascan-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(264,345,l),
+(264,424,l),
+(136,424,l),
+(139,385,l),
+(213,474,ls),
+(244,514,o),
+(259,554,o),
+(259,589,cs),
+(259,647,o),
+(227,696,o),
+(152,696,cs),
+(74,696,o),
+(35,644,o),
+(34,570,c),
+(118,570,l),
+(118,614,o),
+(128,629,o),
+(149,629,cs),
+(166,629,o),
+(175,615,o),
+(175,588,cs),
+(175,563,o),
+(170,542,o),
+(137,502,cs),
+(46,395,l),
+(46,345,l)
+);
+}
+);
+width = 298;
+}
+);
+note = uni14BE;
+unicode = 5310;
+},
+{
+glyphname = "mSayisi-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = two.canadian;
+}
+);
+width = 504;
+}
+);
+note = uni14BF;
+unicode = 5311;
+},
+{
+glyphname = "ne-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (430,245);
+},
+{
+name = top_center_can;
+pos = (414,508);
+},
+{
+name = top_left_can;
+pos = (108,508);
+},
+{
+name = top_right_can;
+pos = (576,508);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(557,-14,o),
+(645,72,o),
+(645,238,cs),
+(645,405,o),
+(560,489,o),
+(410,489,cs),
+(37,489,l),
+(37,361,l),
+(273,361,l),
+(263,394,l),
+(232,358,o),
+(215,295,o),
+(215,231,cs),
+(215,71,o),
+(298,-14,o),
+(430,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(383,106,o),
+(355,147,o),
+(355,238,cs),
+(355,327,o),
+(383,369,o),
+(430,369,cs),
+(477,369,o),
+(506,329,o),
+(506,238,cs),
+(506,147,o),
+(478,106,o),
+(430,106,cs)
+);
+}
+);
+width = 684;
+}
+);
+metricRight = "=|ke-canadian";
+note = uni14C0;
+unicode = 5312;
+},
+{
+glyphname = "naai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (156,-182);
+ref = ring_top.canadian;
+}
+);
+width = 684;
+}
+);
+note = uni14C1;
+unicode = 5313;
+},
+{
+glyphname = "ni-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (256,245);
+},
+{
+name = top_center_can;
+pos = (273,508);
+},
+{
+name = top_left_can;
+pos = (108,508);
+},
+{
+name = top_right_can;
+pos = (576,508);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(385,-14,o),
+(469,71,o),
+(469,231,cs),
+(469,295,o),
+(451,358,o),
+(420,394,c),
+(410,361,l),
+(646,361,l),
+(646,489,l),
+(274,489,ls),
+(124,489,o),
+(39,399,o),
+(39,235,cs),
+(39,71,o),
+(126,-14,o),
+(254,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(206,106,o),
+(178,147,o),
+(178,239,cs),
+(178,330,o),
+(207,371,o),
+(254,371,cs),
+(301,371,o),
+(329,328,o),
+(329,239,cs),
+(329,147,o),
+(301,106,o),
+(254,106,cs)
+);
+}
+);
+width = 683;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+unicode = 5314;
+},
+{
+glyphname = "nii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (189,-182);
+ref = dot_top;
+}
+);
+width = 684;
+}
+);
+note = uni14C3;
+unicode = 5315;
+},
+{
+glyphname = "no-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (428,245);
+},
+{
+name = top_center_can;
+pos = (428,508);
+},
+{
+name = top_double;
+pos = (430,508);
+},
+{
+name = top_left_can;
+pos = (108,508);
+},
+{
+name = top_right_can;
+pos = (576,508);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(412,0,ls),
+(560,0,o),
+(645,85,o),
+(645,251,cs),
+(645,416,o),
+(558,503,o),
+(430,503,cs),
+(298,503,o),
+(215,416,o),
+(215,258,cs),
+(215,195,o),
+(232,131,o),
+(264,96,c),
+(273,128,l),
+(37,128,l),
+(37,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(383,119,o),
+(355,161,o),
+(355,250,cs),
+(355,342,o),
+(383,383,o),
+(430,383,cs),
+(478,383,o),
+(506,343,o),
+(506,250,cs),
+(506,158,o),
+(477,119,o),
+(430,119,cs)
+);
+}
+);
+width = 684;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14C4;
+unicode = 5316;
+},
+{
+glyphname = "noo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (345,-182);
+ref = dot_top;
+}
+);
+width = 684;
+}
+);
+note = uni14C5;
+unicode = 5317;
+},
+{
+glyphname = "ycreenoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (175,-182);
+ref = doubledot_top;
+}
+);
+width = 684;
+}
+);
+note = uni14C6;
+unicode = 5318;
+},
+{
+glyphname = "na-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (256,245);
+},
+{
+name = top_center_can;
+pos = (255,508);
+},
+{
+name = top_double;
+pos = (412,508);
+},
+{
+name = top_left_can;
+pos = (108,508);
+},
+{
+name = top_right_can;
+pos = (576,508);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(646,0,l),
+(646,128,l),
+(410,128,l),
+(420,95,l),
+(451,130,o),
+(469,194,o),
+(469,258,cs),
+(469,417,o),
+(385,503,o),
+(254,503,cs),
+(126,503,o),
+(39,416,o),
+(39,251,cs),
+(39,86,o),
+(123,0,o),
+(273,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(207,119,o),
+(178,158,o),
+(178,250,cs),
+(178,343,o),
+(206,383,o),
+(254,383,cs),
+(301,383,o),
+(329,342,o),
+(329,250,cs),
+(329,161,o),
+(301,119,o),
+(254,119,cs)
+);
+}
+);
+width = 683;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+unicode = 5319;
+},
+{
+glyphname = "naa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (172,-182);
+ref = dot_top;
+}
+);
+width = 684;
+}
+);
+note = uni14C8;
+unicode = 5320;
+},
+{
+glyphname = "nwe-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ne-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni14C9;
+unicode = 5321;
+},
+{
+glyphname = "nweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (684,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni14CA;
+unicode = 5322;
+},
+{
+glyphname = "nwa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "na-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni14CB;
+unicode = 5323;
+},
+{
+glyphname = "nwaWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (684,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni14CC;
+unicode = 5324;
+},
+{
+glyphname = "nwaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (376,-182);
+ref = dot_top;
+}
+);
+width = 888;
+}
+);
+note = uni14CD;
+unicode = 5325;
+},
+{
+glyphname = "nwaaWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (172,-182);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (684,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni14CE;
+unicode = 5326;
+},
+{
+glyphname = "nwaaNaskapi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (156,-182);
+ref = doubledot_top;
+}
+);
+width = 684;
+}
+);
+note = uni14CF;
+unicode = 5327;
+},
+{
+glyphname = "n-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(364,434,l),
+(364,524,l),
+(234,524,l),
+(239,482,l),
+(255,494,o),
+(269,528,o),
+(269,570,cs),
+(269,647,o),
+(227,696,o),
+(152,696,cs),
+(77,696,o),
+(34,645,o),
+(34,565,cs),
+(34,486,o),
+(77,434,o),
+(156,434,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(130,502,o),
+(117,521,o),
+(117,565,cs),
+(117,610,o),
+(130,627,o),
+(152,627,cs),
+(173,627,o),
+(185,608,o),
+(185,564,cs),
+(185,522,o),
+(173,502,o),
+(152,502,cs)
+);
+}
+);
+width = 392;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni14D0;
+unicode = 5328;
+},
+{
+color = 6;
+glyphname = "ngCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-161);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 362;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "=|";
+note = uni14D1;
+unicode = 5329;
+},
+{
+glyphname = "nh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(236,434,ls),
+(314,434,o),
+(358,486,o),
+(358,565,cs),
+(358,645,o),
+(315,696,o),
+(241,696,cs),
+(164,696,o),
+(124,647,o),
+(124,570,cs),
+(124,528,o),
+(137,494,o),
+(154,482,c),
+(158,524,l),
+(28,524,l),
+(28,434,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(219,502,o),
+(207,522,o),
+(207,564,cs),
+(207,608,o),
+(219,627,o),
+(241,627,cs),
+(262,627,o),
+(274,610,o),
+(274,565,cs),
+(274,521,o),
+(262,502,o),
+(241,502,cs)
+);
+}
+);
+width = 392;
+}
+);
+metricLeft = "=|n-canadian";
+metricRight = "=|n-canadian";
+note = uni14D2;
+unicode = 5330;
+},
+{
+glyphname = "le-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (429,245);
+},
+{
+name = top_center_can;
+pos = (416,508);
+},
+{
+name = top_left_can;
+pos = (108,508);
+},
+{
+name = top_right_can;
+pos = (576,508);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(399,0,ls),
+(551,0,o),
+(645,85,o),
+(645,244,cs),
+(645,404,o),
+(555,489,o),
+(399,489,cs),
+(37,489,l),
+(37,360,l),
+(391,360,ls),
+(464,360,o),
+(504,322,o),
+(504,242,cs),
+(504,164,o),
+(464,125,o),
+(387,125,cs),
+(364,125,l),
+(364,0,l)
+);
+}
+);
+width = 684;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D3;
+unicode = 5331;
+},
+{
+glyphname = "laai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (156,-182);
+ref = ring_top.canadian;
+}
+);
+width = 684;
+}
+);
+note = uni14D4;
+unicode = 5332;
+},
+{
+glyphname = "li-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (256,245);
+},
+{
+name = top_center_can;
+pos = (273,508);
+},
+{
+name = top_left_can;
+pos = (109,508);
+},
+{
+name = top_right_can;
+pos = (576,508);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(320,0,l),
+(320,125,l),
+(297,125,ls),
+(219,125,o),
+(180,164,o),
+(180,242,cs),
+(180,321,o),
+(218,360,o),
+(293,360,cs),
+(646,360,l),
+(646,489,l),
+(285,489,ls),
+(135,489,o),
+(39,404,o),
+(39,244,cs),
+(39,85,o),
+(133,0,o),
+(285,0,cs)
+);
+}
+);
+width = 683;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14D5;
+unicode = 5333;
+},
+{
+glyphname = "lii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (189,-182);
+ref = dot_top;
+}
+);
+width = 684;
+}
+);
+note = uni14D6;
+unicode = 5334;
+},
+{
+glyphname = "lo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (428,245);
+},
+{
+name = top_center_can;
+pos = (428,508);
+},
+{
+name = top_double;
+pos = (400,508);
+},
+{
+name = top_left_can;
+pos = (108,508);
+},
+{
+name = top_right_can;
+pos = (576,508);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(399,0,ls),
+(549,0,o),
+(645,85,o),
+(645,244,cs),
+(645,405,o),
+(551,489,o),
+(400,489,cs),
+(364,489,l),
+(364,364,l),
+(387,364,ls),
+(465,364,o),
+(504,326,o),
+(504,247,cs),
+(504,168,o),
+(465,128,o),
+(391,128,cs),
+(37,128,l),
+(37,0,l)
+);
+}
+);
+width = 684;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D7;
+unicode = 5335;
+},
+{
+glyphname = "loo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (345,-182);
+ref = dot_top;
+}
+);
+width = 684;
+}
+);
+note = uni14D8;
+unicode = 5336;
+},
+{
+glyphname = "ycreeloo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (145,-182);
+ref = doubledot_top;
+}
+);
+width = 684;
+}
+);
+note = uni14D9;
+unicode = 5337;
+},
+{
+glyphname = "la-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (256,245);
+},
+{
+name = top_center_can;
+pos = (255,508);
+},
+{
+name = top_left_can;
+pos = (109,508);
+},
+{
+name = top_right_can;
+pos = (576,508);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(646,0,l),
+(646,128,l),
+(293,128,ls),
+(219,128,o),
+(180,168,o),
+(180,246,cs),
+(180,325,o),
+(219,364,o),
+(296,364,cs),
+(320,364,l),
+(320,489,l),
+(284,489,ls),
+(132,489,o),
+(39,403,o),
+(39,244,cs),
+(39,85,o),
+(135,0,o),
+(285,0,cs)
+);
+}
+);
+width = 683;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14DA;
+unicode = 5338;
+},
+{
+glyphname = "laa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (172,-182);
+ref = dot_top;
+}
+);
+width = 684;
+}
+);
+note = uni14DB;
+unicode = 5339;
+},
+{
+glyphname = "lwe-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "le-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni14DC;
+unicode = 5340;
+},
+{
+glyphname = "lweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "le-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (684,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni14DD;
+unicode = 5341;
+},
+{
+glyphname = "lwi-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "li-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni14DE;
+unicode = 5342;
+},
+{
+glyphname = "lwiWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (684,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni14DF;
+unicode = 5343;
+},
+{
+glyphname = "lwii-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (393,-182);
+ref = dot_top;
+}
+);
+width = 888;
+}
+);
+note = uni14E0;
+unicode = 5344;
+},
+{
+glyphname = "lwiiWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (189,-182);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (684,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni14E1;
+unicode = 5345;
+},
+{
+glyphname = "lwo-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "lo-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni14E2;
+unicode = 5346;
+},
+{
+glyphname = "lwoWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (684,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni14E3;
+unicode = 5347;
+},
+{
+glyphname = "lwoo-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (549,-182);
+ref = dot_top;
+}
+);
+width = 888;
+}
+);
+note = uni14E4;
+unicode = 5348;
+},
+{
+glyphname = "lwooWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (345,-182);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (684,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni14E5;
+unicode = 5349;
+},
+{
+glyphname = "lwa-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "la-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni14E6;
+unicode = 5350;
+},
+{
+glyphname = "lwaWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (684,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni14E7;
+unicode = 5351;
+},
+{
+glyphname = "lwaa-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (376,-182);
+ref = dot_top;
+}
+);
+width = 888;
+}
+);
+note = uni14E8;
+unicode = 5352;
+},
+{
+glyphname = "lwaaWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (172,-182);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (684,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni14E9;
+unicode = 5353;
+},
+{
+glyphname = "l-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(351,345,l),
+(351,434,l),
+(216,434,ls),
+(162,434,o),
+(133,463,o),
+(133,517,cs),
+(133,571,o),
+(162,602,o),
+(212,602,cs),
+(219,602,l),
+(219,690,l),
+(205,690,ls),
+(100,690,o),
+(40,622,o),
+(40,517,cs),
+(40,412,o),
+(100,345,o),
+(207,345,cs)
+);
+}
+);
+width = 378;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "m-canadian";
+note = uni14EA;
+unicode = 5354;
+},
+{
+glyphname = "lWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(246,345,l),
+(246,409,l),
+(109,476,l),
+(109,429,l),
+(246,497,l),
+(246,538,l),
+(109,608,l),
+(109,558,l),
+(246,625,l),
+(246,690,l),
+(231,690,l),
+(43,598,l),
+(43,567,l),
+(182,499,l),
+(182,534,l),
+(43,467,l),
+(43,436,l),
+(231,345,l)
+);
+}
+);
+width = 289;
+}
+);
+metricRight = "=|";
+note = uni14EB;
+unicode = 5355;
+},
+{
+glyphname = "mediall-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(469,-14,l),
+(469,93,l),
+(174,238,l),
+(174,174,l),
+(469,316,l),
+(469,374,l),
+(174,516,l),
+(174,452,l),
+(469,597,l),
+(469,703,l),
+(437,703,l),
+(47,513,l),
+(47,462,l),
+(343,319,l),
+(343,371,l),
+(47,228,l),
+(47,177,l),
+(437,-14,l)
+);
+}
+);
+width = 516;
+}
+);
+metricRight = "=|";
+note = uni14EC;
+unicode = 5356;
+},
+{
+glyphname = "se-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (123,690);
+},
+{
+name = top_right_can;
+pos = (350,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(420,0,l),
+(420,359,l),
+(384,359,ls),
+(257,359,o),
+(193,409,o),
+(193,571,cs),
+(193,690,l),
+(51,690,l),
+(51,561,ls),
+(51,340,o),
+(158,232,o),
+(354,232,cs),
+(386,232,l),
+(277,276,l),
+(277,0,l)
+);
+}
+);
+width = 472;
+}
+);
+note = uni14ED;
+unicode = 5357;
+},
+{
+glyphname = "saai-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (233,0);
+ref = ring_top.canadian;
+}
+);
+width = 472;
+}
+);
+note = uni14EE;
+unicode = 5358;
+},
+{
+glyphname = "si-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (124,690);
+},
+{
+name = top_right_can;
+pos = (350,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(194,0,l),
+(194,276,l),
+(86,232,l),
+(119,232,ls),
+(314,232,o),
+(421,340,o),
+(421,561,cs),
+(421,690,l),
+(278,690,l),
+(278,571,ls),
+(278,409,o),
+(215,359,o),
+(89,359,cs),
+(52,359,l),
+(52,0,l)
+);
+}
+);
+width = 472;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+unicode = 5359;
+},
+{
+glyphname = "sii-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (267,0);
+ref = dot_top;
+}
+);
+width = 472;
+}
+);
+note = uni14F0;
+unicode = 5360;
+},
+{
+glyphname = "so-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (350,690);
+},
+{
+name = top_left_can;
+pos = (123,690);
+},
+{
+name = top_right_can;
+pos = (349,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(193,0,l),
+(193,119,ls),
+(193,281,o),
+(257,330,o),
+(384,330,cs),
+(420,330,l),
+(420,690,l),
+(277,690,l),
+(277,413,l),
+(386,458,l),
+(354,458,ls),
+(158,458,o),
+(51,350,o),
+(51,128,cs),
+(51,0,l)
+);
+}
+);
+width = 472;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+unicode = 5361;
+},
+{
+glyphname = "soo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (266,0);
+ref = dot_top;
+}
+);
+width = 472;
+}
+);
+note = uni14F2;
+unicode = 5362;
+},
+{
+glyphname = "ycreesoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (95,0);
+ref = doubledot_top;
+}
+);
+width = 472;
+}
+);
+note = uni14F3;
+unicode = 5363;
+},
+{
+glyphname = "sa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (124,690);
+},
+{
+name = top_right_can;
+pos = (350,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(421,0,l),
+(421,128,ls),
+(421,350,o),
+(314,458,o),
+(119,458,cs),
+(86,458,l),
+(194,413,l),
+(194,690,l),
+(52,690,l),
+(52,330,l),
+(89,330,ls),
+(215,330,o),
+(278,281,o),
+(278,119,cs),
+(278,0,l)
+);
+}
+);
+width = 472;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+unicode = 5364;
+},
+{
+glyphname = "saa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (40,0);
+ref = dot_top;
+}
+);
+width = 472;
+}
+);
+note = uni14F5;
+unicode = 5365;
+},
+{
+glyphname = "swe-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "se-canadian";
+}
+);
+width = 675;
+}
+);
+note = uni14F6;
+unicode = 5366;
+},
+{
+glyphname = "sweWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "se-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (472,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 675;
+}
+);
+note = uni14F7;
+unicode = 5367;
+},
+{
+glyphname = "swi-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "si-canadian";
+}
+);
+width = 675;
+}
+);
+note = uni14F8;
+unicode = 5368;
+},
+{
+glyphname = "swiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (472,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 675;
+}
+);
+note = uni14F9;
+unicode = 5369;
+},
+{
+glyphname = "swii-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (470,0);
+ref = dot_top;
+}
+);
+width = 675;
+}
+);
+note = uni14FA;
+unicode = 5370;
+},
+{
+glyphname = "swiiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (267,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (472,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 675;
+}
+);
+note = uni14FB;
+unicode = 5371;
+},
+{
+glyphname = "swo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "so-canadian";
+}
+);
+width = 675;
+}
+);
+note = uni14FC;
+unicode = 5372;
+},
+{
+glyphname = "swoWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (472,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 675;
+}
+);
+note = uni14FD;
+unicode = 5373;
+},
+{
+glyphname = "swoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (469,0);
+ref = dot_top;
+}
+);
+width = 675;
+}
+);
+note = uni14FE;
+unicode = 5374;
+},
+{
+glyphname = "swooWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (266,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (472,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 675;
+}
+);
+note = uni14FF;
+unicode = 5375;
+},
+{
+glyphname = "swa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "sa-canadian";
+}
+);
+width = 675;
+}
+);
+note = uni1500;
+unicode = 5376;
+},
+{
+glyphname = "swaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (472,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 675;
+}
+);
+note = uni1501;
+unicode = 5377;
+},
+{
+glyphname = "swaa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (243,0);
+ref = dot_top;
+}
+);
+width = 675;
+}
+);
+note = uni1502;
+unicode = 5378;
+},
+{
+glyphname = "swaaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (40,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (472,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 675;
+}
+);
+note = uni1503;
+unicode = 5379;
+},
+{
+glyphname = "swaaNaskapi-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (207,0);
+ref = "sa-canadian";
+}
+);
+width = 679;
+}
+);
+note = uni1504;
+unicode = 5380;
+},
+{
+glyphname = "s-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(259,345,l),
+(259,416,ls),
+(259,526,o),
+(201,584,o),
+(112,584,cs),
+(75,584,l),
+(138,549,l),
+(138,690,l),
+(43,690,l),
+(43,511,l),
+(72,511,ls),
+(136,511,o),
+(164,482,o),
+(164,412,cs),
+(164,345,l)
+);
+}
+);
+width = 302;
+}
+);
+metricRight = "=|";
+note = uni1505;
+unicode = 5381;
+},
+{
+color = 6;
+glyphname = "sAthapascan-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(244,177,o),
+(289,221,o),
+(289,280,cs),
+(289,323,o),
+(267,355,o),
+(215,376,cs),
+(164,395,ls),
+(142,405,o),
+(133,414,o),
+(133,433,cs),
+(133,453,o),
+(145,465,o),
+(167,465,cs),
+(188,465,o),
+(203,456,o),
+(203,418,c),
+(288,418,l),
+(288,494,o),
+(242,533,o),
+(167,533,cs),
+(96,533,o),
+(47,491,o),
+(47,431,cs),
+(47,386,o),
+(70,352,o),
+(118,333,cs),
+(170,314,ls),
+(193,304,o),
+(204,294,o),
+(204,275,cs),
+(204,255,o),
+(189,245,o),
+(169,245,cs),
+(143,245,o),
+(128,257,o),
+(128,293,c),
+(43,293,l),
+(43,217,o),
+(90,177,o),
+(167,177,cs)
+);
+}
+);
+width = 332;
+}
+);
+metricRight = "=|";
+note = uni1506;
+unicode = 5382;
+},
+{
+glyphname = "sw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(138,345,l),
+(138,412,ls),
+(138,482,o),
+(166,511,o),
+(230,511,cs),
+(259,511,l),
+(259,690,l),
+(164,690,l),
+(164,549,l),
+(227,584,l),
+(190,584,ls),
+(101,584,o),
+(43,526,o),
+(43,416,cs),
+(43,345,l)
+);
+}
+);
+width = 302;
+}
+);
+metricLeft = "=|s-canadian";
+metricRight = "=|s-canadian";
+note = uni1507;
+unicode = 5383;
+},
+{
+glyphname = "sBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(266,345,l),
+(266,434,l),
+(195,434,ls),
+(153,434,o),
+(138,450,o),
+(138,497,cs),
+(138,690,l),
+(43,690,l),
+(43,481,ls),
+(43,392,o),
+(91,345,o),
+(179,345,c)
+);
+}
+);
+width = 293;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "m-canadian";
+note = uni1508;
+unicode = 5384;
+},
+{
+glyphname = "moosecreesk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(232,217,o),
+(283,265,o),
+(283,373,cs),
+(283,513,o),
+(223,585,o),
+(112,585,cs),
+(91,585,l),
+(138,550,l),
+(138,690,l),
+(44,690,l),
+(44,512,l),
+(80,512,ls),
+(161,512,o),
+(182,487,o),
+(188,429,c),
+(212,426,l),
+(204,452,o),
+(183,476,o),
+(151,476,cs),
+(86,476,o),
+(44,426,o),
+(44,349,cs),
+(44,261,o),
+(99,217,o),
+(162,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(143,285,o),
+(128,302,o),
+(128,348,cs),
+(128,394,o),
+(144,412,o),
+(163,412,cs),
+(183,412,o),
+(197,394,o),
+(197,348,cs),
+(197,301,o),
+(184,285,o),
+(163,285,cs)
+);
+}
+);
+width = 327;
+}
+);
+metricRight = "=|";
+note = uni1509;
+unicode = 5385;
+},
+{
+glyphname = "skwNaskapi-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(228,217,o),
+(282,261,o),
+(282,349,cs),
+(282,426,o),
+(241,476,o),
+(177,476,cs),
+(145,476,o),
+(123,452,o),
+(116,426,c),
+(139,429,l),
+(146,487,o),
+(166,512,o),
+(247,512,cs),
+(283,512,l),
+(283,690,l),
+(188,690,l),
+(188,550,l),
+(236,585,l),
+(215,585,ls),
+(104,585,o),
+(44,513,o),
+(44,373,cs),
+(44,265,o),
+(96,217,o),
+(165,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(144,285,o),
+(130,301,o),
+(130,348,cs),
+(130,394,o),
+(145,412,o),
+(164,412,cs),
+(184,412,o),
+(199,394,o),
+(199,348,cs),
+(199,302,o),
+(184,285,o),
+(164,285,cs)
+);
+}
+);
+width = 327;
+}
+);
+metricLeft = "=|moosecreesk-canadian";
+metricRight = "=|moosecreesk-canadian";
+note = uni150A;
+unicode = 5386;
+},
+{
+glyphname = "swNaskapi-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(276,188,l),
+(276,244,ls),
+(276,348,o),
+(218,411,o),
+(130,411,cs),
+(95,411,l),
+(147,376,l),
+(147,501,l),
+(53,501,l),
+(53,337,l),
+(96,337,ls),
+(154,337,o),
+(182,309,o),
+(182,241,cs),
+(182,188,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(267,14,o),
+(296,44,o),
+(296,82,cs),
+(296,120,o),
+(266,150,o),
+(229,150,cs),
+(192,150,o),
+(162,120,o),
+(162,82,cs),
+(162,44,o),
+(191,14,o),
+(229,14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(136,540,o),
+(167,570,o),
+(167,608,cs),
+(167,645,o),
+(137,677,o),
+(99,677,cs),
+(63,677,o),
+(33,645,o),
+(33,608,cs),
+(33,570,o),
+(63,540,o),
+(99,540,cs)
+);
+}
+);
+width = 329;
+}
+);
+metricRight = "=|";
+note = uni150B;
+unicode = 5387;
+},
+{
+glyphname = "spwaNaskapi-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(519,0,l),
+(519,133,l),
+(173,376,l),
+(173,312,l),
+(519,554,l),
+(519,690,l),
+(486,690,l),
+(26,367,l),
+(26,323,l),
+(486,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(145,505,o),
+(176,535,o),
+(176,573,cs),
+(176,611,o),
+(145,641,o),
+(108,641,cs),
+(71,641,o),
+(42,611,o),
+(42,573,cs),
+(42,535,o),
+(71,505,o),
+(108,505,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(316,614,l),
+(316,668,ls),
+(316,748,o),
+(276,793,o),
+(198,793,cs),
+(168,793,l),
+(236,763,l),
+(236,866,l),
+(146,866,l),
+(146,725,l),
+(166,725,ls),
+(201,725,o),
+(226,708,o),
+(226,658,cs),
+(226,614,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(447,713,o),
+(478,744,o),
+(478,781,cs),
+(478,818,o),
+(447,849,o),
+(412,849,cs),
+(375,849,o),
+(345,818,o),
+(345,781,cs),
+(345,744,o),
+(375,713,o),
+(412,713,cs)
+);
+}
+);
+width = 554;
+}
+);
+metricRight = "pa-canadian";
+metricWidth = "pa-canadian";
+note = uni150C;
+unicode = 5388;
+},
+{
+glyphname = "stwaNaskapi-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (328,0);
+ref = "ta-canadian";
+}
+);
+width = 850;
+}
+);
+note = uni150D;
+unicode = 5389;
+},
+{
+glyphname = "skwaNaskapi-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (328,0);
+ref = "ka-canadian";
+}
+);
+width = 839;
+}
+);
+note = uni150E;
+unicode = 5390;
+},
+{
+glyphname = "scwaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (328,0);
+ref = "ca-canadian";
+}
+);
+width = 832;
+}
+);
+note = uni150F;
+unicode = 5391;
+},
+{
+glyphname = "she-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (246,690);
+},
+{
+name = top_right_can;
+pos = (610,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(634,-14,o),
+(712,72,o),
+(712,240,cs),
+(712,308,l),
+(571,308,l),
+(571,215,ls),
+(571,144,o),
+(550,110,o),
+(512,110,cs),
+(472,110,o),
+(453,142,o),
+(449,218,cs),
+(440,474,ls),
+(434,617,o),
+(377,703,o),
+(245,703,cs),
+(116,703,o),
+(37,617,o),
+(37,450,cs),
+(37,382,l),
+(178,382,l),
+(178,475,ls),
+(178,546,o),
+(200,580,o),
+(238,580,cs),
+(277,580,o),
+(297,548,o),
+(299,472,cs),
+(310,215,ls),
+(316,72,o),
+(371,-14,o),
+(505,-14,cs)
+);
+}
+);
+width = 749;
+}
+);
+metricRight = "=|";
+note = uni1510;
+unicode = 5392;
+},
+{
+glyphname = "shi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (141,690);
+},
+{
+name = top_right_can;
+pos = (504,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(378,-14,o),
+(434,72,o),
+(440,215,cs),
+(449,472,ls),
+(453,548,o),
+(472,580,o),
+(512,580,cs),
+(549,580,o),
+(571,546,o),
+(571,475,cs),
+(571,382,l),
+(712,382,l),
+(712,450,ls),
+(712,617,o),
+(634,703,o),
+(504,703,cs),
+(372,703,o),
+(316,617,o),
+(310,474,cs),
+(299,218,ls),
+(297,142,o),
+(277,110,o),
+(237,110,cs),
+(200,110,o),
+(178,144,o),
+(178,215,cs),
+(178,308,l),
+(37,308,l),
+(37,240,ls),
+(37,72,o),
+(115,-14,o),
+(243,-14,cs)
+);
+}
+);
+width = 749;
+}
+);
+metricLeft = "she-canadian";
+metricRight = "she-canadian";
+note = uni1511;
+unicode = 5393;
+},
+{
+glyphname = "shii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (420,0);
+ref = dot_top;
+}
+);
+width = 749;
+}
+);
+note = uni1512;
+unicode = 5394;
+},
+{
+glyphname = "sho-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (384,508);
+},
+{
+name = top_left_can;
+pos = (247,508);
+},
+{
+name = top_right_can;
+pos = (523,508);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(319,108,l),
+(231,106,o),
+(179,137,o),
+(179,193,cs),
+(179,232,o),
+(201,255,o),
+(239,255,cs),
+(324,255,o),
+(407,107,o),
+(553,107,cs),
+(662,107,o),
+(730,183,o),
+(730,290,cs),
+(730,424,o),
+(625,506,o),
+(454,503,c),
+(450,381,l),
+(539,383,o),
+(591,353,o),
+(591,296,cs),
+(591,257,o),
+(568,234,o),
+(530,234,cs),
+(445,234,o),
+(362,383,o),
+(216,383,cs),
+(108,383,o),
+(39,306,o),
+(39,199,cs),
+(39,66,o),
+(144,-16,o),
+(315,-14,c)
+);
+}
+);
+width = 769;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1513;
+unicode = 5395;
+},
+{
+glyphname = "shoo-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (301,-182);
+ref = dot_top;
+}
+);
+width = 769;
+}
+);
+note = uni1514;
+unicode = 5396;
+},
+{
+glyphname = "sha-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (385,508);
+},
+{
+name = top_left_can;
+pos = (247,508);
+},
+{
+name = top_right_can;
+pos = (523,508);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(625,-17,o),
+(730,66,o),
+(730,198,cs),
+(730,306,o),
+(662,383,o),
+(553,383,cs),
+(407,383,o),
+(324,234,o),
+(239,234,cs),
+(201,234,o),
+(179,257,o),
+(179,296,cs),
+(179,353,o),
+(231,384,o),
+(319,381,c),
+(315,503,l),
+(144,506,o),
+(39,424,o),
+(39,291,cs),
+(39,183,o),
+(107,107,o),
+(216,107,cs),
+(362,107,o),
+(445,255,o),
+(530,255,cs),
+(568,255,o),
+(591,232,o),
+(591,193,cs),
+(591,137,o),
+(539,105,o),
+(450,108,c),
+(454,-14,l)
+);
+}
+);
+width = 769;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1515;
+unicode = 5397;
+},
+{
+glyphname = "shaa-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (301,-182);
+ref = dot_top;
+}
+);
+width = 769;
+}
+);
+note = uni1516;
+unicode = 5398;
+},
+{
+glyphname = "shwe-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "she-canadian";
+}
+);
+width = 952;
+}
+);
+note = uni1517;
+unicode = 5399;
+},
+{
+glyphname = "shweWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "she-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (749,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 952;
+}
+);
+note = uni1518;
+unicode = 5400;
+},
+{
+glyphname = "shwi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "shi-canadian";
+}
+);
+width = 952;
+}
+);
+note = uni1519;
+unicode = 5401;
+},
+{
+glyphname = "shwiWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (749,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 952;
+}
+);
+note = uni151A;
+unicode = 5402;
+},
+{
+glyphname = "shwii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (624,0);
+ref = dot_top;
+}
+);
+width = 952;
+}
+);
+note = uni151B;
+unicode = 5403;
+},
+{
+glyphname = "shwiiWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (420,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (749,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 952;
+}
+);
+note = uni151C;
+unicode = 5404;
+},
+{
+glyphname = "shwo-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "sho-canadian";
+}
+);
+width = 973;
+}
+);
+note = uni151D;
+unicode = 5405;
+},
+{
+glyphname = "shwoWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (769,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 973;
+}
+);
+note = uni151E;
+unicode = 5406;
+},
+{
+glyphname = "shwoo-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (505,-182);
+ref = dot_top;
+}
+);
+width = 973;
+}
+);
+note = uni151F;
+unicode = 5407;
+},
+{
+glyphname = "shwooWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (301,-182);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (769,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 973;
+}
+);
+note = uni1520;
+unicode = 5408;
+},
+{
+glyphname = "shwa-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "sha-canadian";
+}
+);
+width = 973;
+}
+);
+note = uni1521;
+unicode = 5409;
+},
+{
+glyphname = "shwaWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (769,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 973;
+}
+);
+note = uni1522;
+unicode = 5410;
+},
+{
+glyphname = "shwaa-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (505,-182);
+ref = dot_top;
+}
+);
+width = 973;
+}
+);
+note = uni1523;
+unicode = 5411;
+},
+{
+glyphname = "shwaaWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (301,-182);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (769,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 973;
+}
+);
+note = uni1524;
+unicode = 5412;
+},
+{
+glyphname = "sh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(469,285,o),
+(552,343,o),
+(552,443,cs),
+(552,529,o),
+(497,587,o),
+(413,587,cs),
+(312,587,o),
+(251,491,o),
+(187,491,cs),
+(154,491,o),
+(137,509,o),
+(137,541,cs),
+(137,584,o),
+(177,611,o),
+(249,611,c),
+(246,698,l),
+(123,698,o),
+(40,641,o),
+(40,540,cs),
+(40,455,o),
+(95,397,o),
+(178,397,cs),
+(279,397,o),
+(340,494,o),
+(404,494,cs),
+(438,494,o),
+(454,475,o),
+(454,442,cs),
+(454,399,o),
+(414,373,o),
+(342,373,c),
+(345,285,l)
+);
+}
+);
+width = 592;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni1525;
+unicode = 5413;
+},
+{
+glyphname = "ye-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (559,345);
+},
+{
+name = top_left_can;
+pos = (97,690);
+},
+{
+name = top_right_can;
+pos = (371,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(441,0,l),
+(441,345,l),
+(208,345,l),
+(216,300,l),
+(466,622,l),
+(364,701,l),
+(26,258,l),
+(26,221,l),
+(299,221,l),
+(299,0,l)
+);
+}
+);
+width = 493;
+}
+);
+note = uni1526;
+unicode = 5414;
+},
+{
+glyphname = "yaai-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (5,0);
+ref = ring_top.canadian;
+}
+);
+width = 493;
+}
+);
+note = uni1527;
+unicode = 5415;
+},
+{
+glyphname = "yi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (123,690);
+},
+{
+name = top_right_can;
+pos = (396,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(193,0,l),
+(193,221,l),
+(467,221,l),
+(467,258,l),
+(128,701,l),
+(27,622,l),
+(276,300,l),
+(285,345,l),
+(51,345,l),
+(51,0,l)
+);
+}
+);
+width = 493;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni1528;
+unicode = 5416;
+},
+{
+glyphname = "yii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (39,0);
+ref = dot_top;
+}
+);
+width = 493;
+}
+);
+note = uni1529;
+unicode = 5417;
+},
+{
+glyphname = "yo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (559,345);
+},
+{
+name = top_double;
+pos = (371,690);
+},
+{
+name = top_left_can;
+pos = (97,690);
+},
+{
+name = top_right_can;
+pos = (371,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(466,68,l),
+(216,389,l),
+(208,345,l),
+(441,345,l),
+(441,690,l),
+(299,690,l),
+(299,469,l),
+(26,469,l),
+(26,432,l),
+(364,-12,l)
+);
+}
+);
+width = 493;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152A;
+unicode = 5418;
+},
+{
+glyphname = "yoo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (288,0);
+ref = dot_top;
+}
+);
+width = 493;
+}
+);
+note = uni152B;
+unicode = 5419;
+},
+{
+glyphname = "ycreeyoo-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (116,0);
+ref = doubledot_top;
+}
+);
+width = 493;
+}
+);
+note = uni152C;
+unicode = 5420;
+},
+{
+glyphname = "ya-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (123,690);
+},
+{
+name = top_right_can;
+pos = (396,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(467,432,l),
+(467,469,l),
+(193,469,l),
+(193,690,l),
+(51,690,l),
+(51,345,l),
+(285,345,l),
+(276,389,l),
+(27,68,l),
+(128,-12,l)
+);
+}
+);
+width = 493;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152D;
+unicode = 5421;
+},
+{
+glyphname = "yaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (39,0);
+ref = dot_top;
+}
+);
+width = 493;
+}
+);
+note = uni152E;
+unicode = 5422;
+},
+{
+glyphname = "ywe-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ye-canadian";
+}
+);
+width = 696;
+}
+);
+note = uni152F;
+unicode = 5423;
+},
+{
+glyphname = "yweWestCree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ye-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (493,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 696;
+}
+);
+note = uni1530;
+unicode = 5424;
+},
+{
+glyphname = "ywi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "yi-canadian";
+}
+);
+width = 696;
+}
+);
+note = uni1531;
+unicode = 5425;
+},
+{
+glyphname = "ywiWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (493,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 696;
+}
+);
+note = uni1532;
+unicode = 5426;
+},
+{
+glyphname = "ywii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (242,0);
+ref = dot_top;
+}
+);
+width = 696;
+}
+);
+note = uni1533;
+unicode = 5427;
+},
+{
+glyphname = "ywiiWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (39,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (493,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 696;
+}
+);
+note = uni1534;
+unicode = 5428;
+},
+{
+glyphname = "ywo-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "yo-canadian";
+}
+);
+width = 696;
+}
+);
+note = uni1535;
+unicode = 5429;
+},
+{
+glyphname = "ywoWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (493,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 696;
+}
+);
+note = uni1536;
+unicode = 5430;
+},
+{
+glyphname = "ywoo-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (492,0);
+ref = dot_top;
+}
+);
+width = 696;
+}
+);
+note = uni1537;
+unicode = 5431;
+},
+{
+glyphname = "ywooWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (288,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (493,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 696;
+}
+);
+note = uni1538;
+unicode = 5432;
+},
+{
+glyphname = "ywa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ya-canadian";
+}
+);
+width = 696;
+}
+);
+note = uni1539;
+unicode = 5433;
+},
+{
+glyphname = "ywaWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (493,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 696;
+}
+);
+note = uni153A;
+unicode = 5434;
+},
+{
+glyphname = "ywaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (242,0);
+ref = dot_top;
+}
+);
+width = 696;
+}
+);
+note = uni153B;
+unicode = 5435;
+},
+{
+glyphname = "ywaaWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (39,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (493,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 696;
+}
+);
+note = uni153C;
+unicode = 5436;
+},
+{
+glyphname = "ywaaNaskapi-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (207,0);
+ref = "ya-canadian";
+}
+);
+width = 699;
+}
+);
+note = uni153D;
+unicode = 5437;
+},
+{
+glyphname = "y-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(271,554,l),
+(271,580,l),
+(142,580,l),
+(142,690,l),
+(48,690,l),
+(48,501,l),
+(172,501,l),
+(171,558,l),
+(43,384,l),
+(113,336,l)
+);
+}
+);
+width = 292;
+}
+);
+note = uni153E;
+unicode = 5438;
+},
+{
+glyphname = "biblecreey-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(168,592,l),
+(119,592,l),
+(196,345,l),
+(252,345,l),
+(330,592,l),
+(280,592,l),
+(330,345,l),
+(414,345,l),
+(414,367,l),
+(348,690,l),
+(279,690,l),
+(196,426,l),
+(252,426,l),
+(169,690,l),
+(100,690,l),
+(34,367,l),
+(34,345,l),
+(119,345,l)
+);
+}
+);
+width = 448;
+}
+);
+metricRight = "=|";
+note = uni153F;
+unicode = 5439;
+},
+{
+glyphname = "yWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(228,204,l),
+(228,309,l),
+(322,309,l),
+(322,398,l),
+(228,398,l),
+(228,500,l),
+(139,500,l),
+(139,398,l),
+(43,398,l),
+(43,309,l),
+(139,309,l),
+(139,204,l)
+);
+}
+);
+width = 365;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1540;
+unicode = 5440;
+},
+{
+glyphname = "yiSayisi-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,183);
+ref = "fullstop-canadian";
+}
+);
+width = 326;
+}
+);
+metricLeft = "fullstop-canadian";
+metricWidth = "fullstop-canadian";
+note = uni1541;
+unicode = 5441;
+},
+{
+glyphname = "re-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (263,508);
+},
+{
+name = top_left_can;
+pos = (121,508);
+},
+{
+name = top_right_can;
+pos = (611,508);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(399,-14,o),
+(472,80,o),
+(472,234,cs),
+(472,361,l),
+(682,361,l),
+(682,489,l),
+(334,489,l),
+(334,213,ls),
+(334,143,o),
+(308,110,o),
+(263,110,cs),
+(216,110,o),
+(191,145,o),
+(191,213,cs),
+(191,489,l),
+(48,489,l),
+(48,234,ls),
+(48,72,o),
+(129,-14,o),
+(263,-14,cs)
+);
+}
+);
+width = 719;
+}
+);
+metricRight = "=|ne-canadian";
+note = uni1542;
+unicode = 5442;
+},
+{
+glyphname = "reRCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (457,508);
+},
+{
+name = top_left_can;
+pos = (107,508);
+},
+{
+name = top_right_can;
+pos = (600,508);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(590,-14,o),
+(670,72,o),
+(670,234,cs),
+(670,489,l),
+(528,489,l),
+(528,213,ls),
+(528,145,o),
+(503,110,o),
+(456,110,cs),
+(411,110,o),
+(385,142,o),
+(385,213,cs),
+(385,489,l),
+(37,489,l),
+(37,361,l),
+(246,361,l),
+(246,233,ls),
+(246,80,o),
+(321,-14,o),
+(457,-14,cs)
+);
+}
+);
+width = 718;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1543;
+unicode = 5443;
+},
+{
+glyphname = "leWestCree-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (457,508);
+},
+{
+name = top_left_can;
+pos = (107,508);
+},
+{
+name = top_right_can;
+pos = (600,508);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(385,0,l),
+(385,274,ls),
+(385,346,o),
+(411,379,o),
+(457,379,cs),
+(503,379,o),
+(528,345,o),
+(528,276,cs),
+(528,0,l),
+(670,0,l),
+(670,255,ls),
+(670,416,o),
+(591,503,o),
+(457,503,cs),
+(322,503,o),
+(246,410,o),
+(246,254,cs),
+(246,128,l),
+(37,128,l),
+(37,0,l)
+);
+}
+);
+width = 718;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+unicode = 5444;
+},
+{
+glyphname = "raai-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (145,-182);
+ref = ring_top.canadian;
+}
+);
+width = 719;
+}
+);
+note = uni1545;
+unicode = 5445;
+},
+{
+glyphname = "ri-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (263,508);
+},
+{
+name = top_left_can;
+pos = (121,508);
+},
+{
+name = top_right_can;
+pos = (611,508);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(191,0,l),
+(191,276,ls),
+(191,345,o),
+(216,379,o),
+(263,379,cs),
+(308,379,o),
+(334,347,o),
+(334,276,cs),
+(334,0,l),
+(682,0,l),
+(682,128,l),
+(472,128,l),
+(472,256,ls),
+(472,410,o),
+(400,503,o),
+(263,503,cs),
+(129,503,o),
+(48,416,o),
+(48,254,cs),
+(48,0,l)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "re-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+unicode = 5446;
+},
+{
+glyphname = "rii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (179,-182);
+ref = dot_top;
+}
+);
+width = 719;
+}
+);
+note = uni1547;
+unicode = 5447;
+},
+{
+glyphname = "ro-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (209,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(193,1,l),
+(193,258,l),
+(157,221,l),
+(213,221,ls),
+(350,221,o),
+(438,314,o),
+(438,453,cs),
+(438,602,o),
+(355,690,o),
+(193,690,cs),
+(51,690,l),
+(51,563,l),
+(179,563,ls),
+(258,563,o),
+(296,523,o),
+(296,454,cs),
+(296,386,o),
+(258,346,o),
+(179,346,cs),
+(51,346,l),
+(51,1,l)
+);
+}
+);
+width = 473;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1548;
+unicode = 5448;
+},
+{
+glyphname = "roo-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (126,0);
+ref = dot_top;
+}
+);
+width = 473;
+}
+);
+note = uni1549;
+unicode = 5449;
+},
+{
+glyphname = "loWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (209,690);
+},
+{
+name = top_left_can;
+pos = (123,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(193,1,ls),
+(355,1,o),
+(438,89,o),
+(438,237,cs),
+(438,377,o),
+(350,469,o),
+(213,469,cs),
+(157,469,l),
+(193,433,l),
+(193,690,l),
+(51,690,l),
+(51,345,l),
+(179,345,ls),
+(258,345,o),
+(296,304,o),
+(296,236,cs),
+(296,168,o),
+(258,128,o),
+(179,128,cs),
+(51,128,l),
+(51,1,l)
+);
+}
+);
+width = 473;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+unicode = 5450;
+},
+{
+glyphname = "ra-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (263,690);
+},
+{
+name = top_right_can;
+pos = (350,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(421,1,l),
+(421,346,l),
+(293,346,ls),
+(214,346,o),
+(177,386,o),
+(177,454,cs),
+(177,523,o),
+(214,563,o),
+(293,563,cs),
+(421,563,l),
+(421,690,l),
+(279,690,ls),
+(118,690,o),
+(35,602,o),
+(35,453,cs),
+(35,314,o),
+(122,221,o),
+(259,221,cs),
+(315,221,l),
+(278,258,l),
+(278,1,l)
+);
+}
+);
+width = 472;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+unicode = 5451;
+},
+{
+glyphname = "raa-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (180,0);
+ref = dot_top;
+}
+);
+width = 473;
+}
+);
+note = uni154C;
+unicode = 5452;
+},
+{
+glyphname = "laWestCree-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (350,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(421,1,l),
+(421,128,l),
+(293,128,ls),
+(214,128,o),
+(177,168,o),
+(177,236,cs),
+(177,304,o),
+(214,345,o),
+(293,345,cs),
+(421,345,l),
+(421,690,l),
+(278,690,l),
+(278,433,l),
+(315,469,l),
+(259,469,ls),
+(122,469,o),
+(35,377,o),
+(35,237,cs),
+(35,89,o),
+(118,1,o),
+(279,1,cs)
+);
+}
+);
+width = 472;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+unicode = 5453;
+},
+{
+glyphname = "rwaa-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (384,0);
+ref = dot_top;
+}
+);
+width = 677;
+}
+);
+note = uni154E;
+unicode = 5454;
+},
+{
+glyphname = "rwaaWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (180,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (473,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 677;
+}
+);
+note = uni154F;
+unicode = 5455;
+},
+{
+glyphname = "r-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(234,345,l),
+(234,526,l),
+(174,526,ls),
+(141,526,o),
+(124,541,o),
+(124,570,cs),
+(124,598,o),
+(142,613,o),
+(175,613,cs),
+(234,613,l),
+(234,690,l),
+(169,690,ls),
+(82,690,o),
+(34,645,o),
+(34,570,cs),
+(34,499,o),
+(81,452,o),
+(159,452,cs),
+(187,452,l),
+(140,474,l),
+(140,345,l)
+);
+}
+);
+width = 277;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni1550;
+unicode = 5456;
+},
+{
+glyphname = "rWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(59,345,l),
+(246,436,l),
+(246,467,l),
+(108,534,l),
+(108,499,l),
+(246,567,l),
+(246,598,l),
+(59,690,l),
+(43,690,l),
+(43,625,l),
+(180,558,l),
+(180,608,l),
+(43,538,l),
+(43,497,l),
+(180,429,l),
+(180,476,l),
+(43,409,l),
+(43,345,l)
+);
+}
+);
+width = 289;
+}
+);
+metricLeft = "=|lWestCree-canadian";
+metricRight = "=|lWestCree-canadian";
+note = uni1551;
+unicode = 5457;
+},
+{
+glyphname = "rMedial-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(80,-14,l),
+(486,177,l),
+(486,222,l),
+(188,364,l),
+(188,325,l),
+(486,468,l),
+(486,513,l),
+(80,703,l),
+(47,703,l),
+(47,600,l),
+(358,454,l),
+(358,520,l),
+(47,378,l),
+(47,312,l),
+(358,170,l),
+(358,236,l),
+(47,91,l),
+(47,-14,l)
+);
+}
+);
+width = 533;
+}
+);
+metricLeft = "mediall-canadian";
+metricRight = "mediall-canadian";
+note = uni1552;
+unicode = 5458;
+},
+{
+glyphname = "fe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(342,0,l),
+(650,655,l),
+(650,690,l),
+(536,690,l),
+(298,163,l),
+(332,163,l),
+(242,350,l),
+(157,348,l),
+(178,324,o),
+(202,311,o),
+(235,311,cs),
+(311,311,o),
+(382,389,o),
+(382,509,cs),
+(382,621,o),
+(327,703,o),
+(224,703,cs),
+(123,703,o),
+(67,621,o),
+(67,518,cs),
+(67,459,o),
+(81,410,o),
+(114,349,cs),
+(300,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(195,408,o),
+(178,441,o),
+(178,514,cs),
+(178,580,o),
+(197,604,o),
+(225,604,cs),
+(253,604,o),
+(271,581,o),
+(271,507,cs),
+(271,435,o),
+(253,408,o),
+(225,408,cs)
+);
+}
+);
+width = 668;
+}
+);
+metricRight = "e-canadian";
+note = uni1553;
+unicode = 5459;
+},
+{
+glyphname = "faai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (206,0);
+ref = ring_top.canadian;
+}
+);
+width = 668;
+}
+);
+note = uni1554;
+unicode = 5460;
+},
+{
+glyphname = "fi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (323,690);
+},
+{
+name = top_left_can;
+pos = (126,690);
+},
+{
+name = top_right_can;
+pos = (533,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(327,-14,o),
+(382,69,o),
+(382,181,cs),
+(382,300,o),
+(311,379,o),
+(235,379,cs),
+(202,379,o),
+(178,366,o),
+(157,342,c),
+(242,340,l),
+(332,526,l),
+(298,526,l),
+(536,0,l),
+(650,0,l),
+(650,35,l),
+(342,690,l),
+(300,690,l),
+(114,340,ls),
+(81,280,o),
+(67,231,o),
+(67,172,cs),
+(67,69,o),
+(123,-14,o),
+(224,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(197,86,o),
+(178,110,o),
+(178,176,cs),
+(178,248,o),
+(195,282,o),
+(225,282,cs),
+(253,282,o),
+(271,255,o),
+(271,183,cs),
+(271,109,o),
+(253,86,o),
+(225,86,cs)
+);
+}
+);
+width = 668;
+}
+);
+metricLeft = "fe-canadian";
+metricRight = "e-canadian";
+note = uni1555;
+unicode = 5461;
+},
+{
+glyphname = "fii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (240,0);
+ref = dot_top;
+}
+);
+width = 668;
+}
+);
+note = uni1556;
+unicode = 5462;
+},
+{
+glyphname = "fo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (194,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,0,l),
+(546,323,l),
+(546,367,l),
+(311,644,ls),
+(273,690,o),
+(232,703,o),
+(189,703,cs),
+(93,703,o),
+(36,624,o),
+(36,503,cs),
+(36,388,o),
+(98,308,o),
+(191,308,cs),
+(282,308,o),
+(341,389,o),
+(341,503,cs),
+(341,535,o),
+(332,577,o),
+(323,603,c),
+(276,516,l),
+(419,348,l),
+(419,376,l),
+(65,120,l),
+(65,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(165,408,o),
+(147,432,o),
+(147,506,cs),
+(147,580,o),
+(165,604,o),
+(194,604,cs),
+(222,604,o),
+(241,581,o),
+(241,507,cs),
+(241,435,o),
+(222,408,o),
+(194,408,cs)
+);
+}
+);
+width = 572;
+}
+);
+metricRight = "o-canadian";
+note = uni1557;
+unicode = 5463;
+},
+{
+glyphname = "foo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "fo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (110,0);
+ref = dot_top;
+}
+);
+width = 572;
+}
+);
+note = uni1558;
+unicode = 5464;
+},
+{
+glyphname = "fa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (380,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(507,0,l),
+(507,120,l),
+(153,375,l),
+(153,349,l),
+(296,517,l),
+(249,603,l),
+(240,577,o),
+(231,535,o),
+(231,503,cs),
+(231,389,o),
+(290,308,o),
+(381,308,cs),
+(474,308,o),
+(536,388,o),
+(536,503,cs),
+(536,624,o),
+(479,703,o),
+(383,703,cs),
+(340,703,o),
+(298,690,o),
+(261,644,cs),
+(26,367,l),
+(26,323,l),
+(473,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(350,408,o),
+(331,434,o),
+(331,507,cs),
+(331,581,o),
+(350,604,o),
+(378,604,cs),
+(407,604,o),
+(425,580,o),
+(425,506,cs),
+(425,432,o),
+(407,408,o),
+(378,408,cs)
+);
+}
+);
+width = 572;
+}
+);
+metricRight = "=|fo-canadian";
+note = uni1559;
+unicode = 5465;
+},
+{
+glyphname = "faa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (296,0);
+ref = dot_top;
+}
+);
+width = 572;
+}
+);
+note = uni155A;
+unicode = 5466;
+},
+{
+glyphname = "fwaa-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (499,0);
+ref = dot_top;
+}
+);
+width = 776;
+}
+);
+note = uni155B;
+unicode = 5467;
+},
+{
+glyphname = "fwaaWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (296,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (572,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 776;
+}
+);
+note = uni155C;
+unicode = 5468;
+},
+{
+glyphname = "f-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(275,345,l),
+(275,404,l),
+(100,530,l),
+(100,520,l),
+(167,600,l),
+(149,645,l),
+(144,631,o),
+(140,610,o),
+(140,589,cs),
+(140,530,o),
+(173,497,o),
+(215,497,cs),
+(259,497,o),
+(289,530,o),
+(289,596,cs),
+(289,669,o),
+(251,696,o),
+(212,696,cs),
+(193,696,o),
+(170,686,o),
+(152,665,cs),
+(34,527,l),
+(34,504,l),
+(259,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(198,547,o),
+(189,560,o),
+(189,594,cs),
+(189,632,o),
+(198,645,o),
+(213,645,cs),
+(226,645,o),
+(235,633,o),
+(235,594,cs),
+(235,560,o),
+(228,547,o),
+(213,547,cs)
+);
+}
+);
+width = 327;
+}
+);
+note = uni155D;
+unicode = 5469;
+},
+{
+glyphname = "the-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (699,345);
+},
+{
+name = top_center_can;
+pos = (313,690);
+},
+{
+name = top_left_can;
+pos = (118,690);
+},
+{
+name = top_right_can;
+pos = (507,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(481,-14,o),
+(579,85,o),
+(579,271,cs),
+(579,690,l),
+(436,690,l),
+(436,269,ls),
+(436,164,o),
+(394,116,o),
+(313,116,cs),
+(235,116,o),
+(189,166,o),
+(189,271,cs),
+(189,404,l),
+(128,358,l),
+(144,327,o),
+(177,305,o),
+(212,305,cs),
+(303,305,o),
+(364,384,o),
+(364,504,cs),
+(364,622,o),
+(311,703,o),
+(210,703,cs),
+(103,703,o),
+(48,623,o),
+(48,461,cs),
+(48,309,ls),
+(48,91,o),
+(142,-14,o),
+(313,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(179,406,o),
+(159,430,o),
+(159,504,cs),
+(159,580,o),
+(179,604,o),
+(207,604,cs),
+(235,604,o),
+(253,580,o),
+(253,506,cs),
+(253,433,o),
+(236,406,o),
+(208,406,cs)
+);
+}
+);
+width = 627;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155E;
+unicode = 5470;
+},
+{
+glyphname = "theNCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(485,-14,o),
+(579,85,o),
+(579,298,cs),
+(579,461,ls),
+(579,623,o),
+(524,703,o),
+(417,703,cs),
+(316,703,o),
+(263,622,o),
+(263,504,cs),
+(263,384,o),
+(324,305,o),
+(415,305,cs),
+(450,305,o),
+(483,327,o),
+(499,358,c),
+(438,404,l),
+(438,269,ls),
+(438,162,o),
+(393,113,o),
+(314,113,cs),
+(233,113,o),
+(191,162,o),
+(191,266,cs),
+(191,690,l),
+(48,690,l),
+(48,270,ls),
+(48,85,o),
+(145,-14,o),
+(314,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(391,406,o),
+(374,433,o),
+(374,506,cs),
+(374,580,o),
+(391,604,o),
+(420,604,cs),
+(448,604,o),
+(468,580,o),
+(468,504,cs),
+(468,430,o),
+(448,406,o),
+(419,406,cs)
+);
+}
+);
+width = 627;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155F;
+unicode = 5471;
+},
+{
+glyphname = "thi-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (309,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(311,-14,o),
+(364,68,o),
+(364,185,cs),
+(364,305,o),
+(303,384,o),
+(212,384,cs),
+(177,384,o),
+(144,362,o),
+(128,331,c),
+(189,286,l),
+(189,421,ls),
+(189,527,o),
+(234,577,o),
+(313,577,cs),
+(394,577,o),
+(436,527,o),
+(436,424,cs),
+(436,0,l),
+(579,0,l),
+(579,419,ls),
+(579,605,o),
+(482,703,o),
+(313,703,cs),
+(142,703,o),
+(48,605,o),
+(48,391,cs),
+(48,229,ls),
+(48,67,o),
+(103,-14,o),
+(210,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(179,86,o),
+(159,110,o),
+(159,185,cs),
+(159,260,o),
+(179,284,o),
+(208,284,cs),
+(236,284,o),
+(253,257,o),
+(253,184,cs),
+(253,110,o),
+(235,86,o),
+(207,86,cs)
+);
+}
+);
+width = 627;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1560;
+unicode = 5472;
+},
+{
+glyphname = "thiNCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (309,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(524,-14,o),
+(579,67,o),
+(579,229,cs),
+(579,391,ls),
+(579,605,o),
+(485,703,o),
+(314,703,cs),
+(145,703,o),
+(48,605,o),
+(48,419,cs),
+(48,0,l),
+(191,0,l),
+(191,424,ls),
+(191,527,o),
+(233,577,o),
+(314,577,cs),
+(393,577,o),
+(438,527,o),
+(438,421,cs),
+(438,286,l),
+(499,331,l),
+(483,362,o),
+(450,384,o),
+(415,384,cs),
+(324,384,o),
+(263,305,o),
+(263,185,cs),
+(263,68,o),
+(316,-14,o),
+(417,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(391,86,o),
+(374,110,o),
+(374,184,cs),
+(374,257,o),
+(391,284,o),
+(419,284,cs),
+(448,284,o),
+(468,260,o),
+(468,185,cs),
+(468,110,o),
+(448,86,o),
+(420,86,cs)
+);
+}
+);
+width = 627;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1561;
+unicode = 5473;
+},
+{
+glyphname = "thii-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "thi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (226,0);
+ref = dot_top;
+}
+);
+width = 627;
+}
+);
+note = uni1562;
+unicode = 5474;
+},
+{
+glyphname = "thiiNCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "thiNCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (226,0);
+ref = dot_top;
+}
+);
+width = 627;
+}
+);
+note = uni1563;
+unicode = 5475;
+},
+{
+glyphname = "tho-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (254,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(212,0,ls),
+(416,0,o),
+(530,116,o),
+(530,354,cs),
+(530,570,o),
+(421,703,o),
+(260,703,cs),
+(122,703,o),
+(39,611,o),
+(39,480,cs),
+(39,355,o),
+(99,279,o),
+(193,279,cs),
+(290,279,o),
+(341,354,o),
+(341,459,cs),
+(341,560,o),
+(304,639,o),
+(222,646,c),
+(193,604,l),
+(204,611,o),
+(222,613,o),
+(237,613,cs),
+(334,613,o),
+(392,512,o),
+(392,363,cs),
+(392,195,o),
+(331,129,o),
+(205,129,cs),
+(68,129,l),
+(68,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(169,379,o),
+(150,404,o),
+(150,484,cs),
+(150,564,o),
+(171,590,o),
+(198,590,cs),
+(225,590,o),
+(243,565,o),
+(243,485,cs),
+(243,407,o),
+(226,379,o),
+(197,379,cs)
+);
+}
+);
+width = 574;
+}
+);
+metricRight = "to-canadian";
+note = uni1564;
+unicode = 5476;
+},
+{
+glyphname = "thoo-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "tho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (171,0);
+ref = dot_top;
+}
+);
+width = 574;
+}
+);
+note = uni1565;
+unicode = 5477;
+},
+{
+glyphname = "tha-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (325,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(508,0,l),
+(508,129,l),
+(370,129,ls),
+(244,129,o),
+(184,195,o),
+(184,363,cs),
+(184,512,o),
+(241,613,o),
+(339,613,cs),
+(353,613,o),
+(372,611,o),
+(382,604,c),
+(353,646,l),
+(271,639,o),
+(234,560,o),
+(234,459,cs),
+(234,354,o),
+(286,279,o),
+(383,279,cs),
+(476,279,o),
+(536,355,o),
+(536,480,cs),
+(536,611,o),
+(453,703,o),
+(316,703,cs),
+(155,703,o),
+(44,570,o),
+(44,354,cs),
+(44,122,o),
+(154,0,o),
+(364,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(350,379,o),
+(331,407,o),
+(331,485,cs),
+(331,565,o),
+(351,590,o),
+(378,590,cs),
+(405,590,o),
+(425,564,o),
+(425,484,cs),
+(425,404,o),
+(407,379,o),
+(378,379,cs)
+);
+}
+);
+width = 575;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tho-canadian";
+note = uni1566;
+unicode = 5478;
+},
+{
+glyphname = "thaa-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (239,0);
+ref = dot_top;
+}
+);
+width = 574;
+}
+);
+note = uni1567;
+unicode = 5479;
+},
+{
+glyphname = "thwaa-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (442,0);
+ref = dot_top;
+}
+);
+width = 777;
+}
+);
+note = uni1568;
+unicode = 5480;
+},
+{
+glyphname = "thwaaWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (239,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (574,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 777;
+}
+);
+note = uni1569;
+unicode = 5481;
+},
+{
+glyphname = "th-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(270,345,l),
+(270,423,l),
+(212,423,ls),
+(150,423,o),
+(118,455,o),
+(118,525,cs),
+(118,594,o),
+(148,639,o),
+(197,639,cs),
+(203,639,o),
+(210,639,o),
+(214,637,c),
+(191,661,l),
+(158,657,o),
+(135,621,o),
+(135,579,cs),
+(135,514,o),
+(166,480,o),
+(209,480,cs),
+(253,480,o),
+(284,515,o),
+(284,581,cs),
+(284,658,o),
+(240,696,o),
+(180,696,cs),
+(99,696,o),
+(40,633,o),
+(40,518,cs),
+(40,410,o),
+(96,345,o),
+(205,345,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(193,529,o),
+(185,543,o),
+(185,577,cs),
+(185,614,o),
+(193,628,o),
+(207,628,cs),
+(221,628,o),
+(230,615,o),
+(230,577,cs),
+(230,543,o),
+(222,529,o),
+(208,529,cs)
+);
+}
+);
+width = 323;
+}
+);
+metricLeft = "t-canadian";
+note = uni156A;
+unicode = 5482;
+},
+{
+glyphname = "tthe-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (692,345);
+},
+{
+name = top_center_can;
+pos = (309,690);
+},
+{
+name = top_left_can;
+pos = (121,690);
+},
+{
+name = top_right_can;
+pos = (499,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(477,-14,o),
+(570,85,o),
+(570,271,cs),
+(570,690,l),
+(438,690,l),
+(438,270,ls),
+(438,163,o),
+(387,117,o),
+(309,117,cs),
+(234,117,o),
+(182,166,o),
+(182,270,cs),
+(182,690,l),
+(48,690,l),
+(48,270,ls),
+(48,85,o),
+(145,-14,o),
+(310,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(362,382,l),
+(362,690,l),
+(256,690,l),
+(256,382,l)
+);
+}
+);
+width = 618;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156B;
+unicode = 5483;
+},
+{
+glyphname = "tthi-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(182,0,l),
+(182,420,ls),
+(182,526,o),
+(232,573,o),
+(310,573,cs),
+(385,573,o),
+(438,524,o),
+(438,420,cs),
+(438,0,l),
+(570,0,l),
+(570,419,ls),
+(570,605,o),
+(474,703,o),
+(310,703,cs),
+(143,703,o),
+(48,605,o),
+(48,419,cs),
+(48,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(362,0,l),
+(362,308,l),
+(256,308,l),
+(256,0,l)
+);
+}
+);
+width = 618;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156C;
+unicode = 5484;
+},
+{
+glyphname = "ttho-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (270,690);
+},
+{
+name = top_left_can;
+pos = (120,690);
+},
+{
+name = top_right_can;
+pos = (420,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(159,0,ls),
+(370,0,o),
+(490,116,o),
+(490,346,cs),
+(490,576,o),
+(370,690,o),
+(157,690,cs),
+(48,690,l),
+(48,560,l),
+(158,560,ls),
+(278,560,o),
+(347,497,o),
+(347,346,cs),
+(347,194,o),
+(278,129,o),
+(159,129,cs),
+(48,129,l),
+(48,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(240,287,l),
+(240,405,l),
+(48,405,l),
+(48,287,l)
+);
+}
+);
+width = 534;
+}
+);
+metricRight = "to-canadian";
+note = uni156D;
+unicode = 5485;
+},
+{
+glyphname = "ttha-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (266,690);
+},
+{
+name = top_left_can;
+pos = (116,690);
+},
+{
+name = top_right_can;
+pos = (416,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(486,0,l),
+(486,129,l),
+(377,129,ls),
+(257,129,o),
+(187,193,o),
+(187,345,cs),
+(187,497,o),
+(257,560,o),
+(376,560,cs),
+(486,560,l),
+(486,690,l),
+(376,690,ls),
+(165,690,o),
+(44,575,o),
+(44,345,cs),
+(44,116,o),
+(165,0,o),
+(377,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(486,287,l),
+(486,405,l),
+(296,405,l),
+(296,287,l)
+);
+}
+);
+width = 534;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|ttho-canadian";
+note = uni156E;
+unicode = 5486;
+},
+{
+glyphname = "tth-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(559,479,l),
+(525,479,l),
+(606,360,l),
+(669,408,l),
+(586,524,l),
+(576,491,l),
+(699,538,l),
+(672,609,l),
+(551,560,l),
+(582,541,l),
+(582,690,l),
+(502,690,l),
+(502,541,l),
+(533,560,l),
+(412,609,l),
+(384,538,l),
+(508,491,l),
+(497,524,l),
+(414,408,l),
+(479,360,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(206,479,l),
+(170,479,l),
+(252,360,l),
+(317,408,l),
+(232,524,l),
+(222,491,l),
+(346,538,l),
+(318,609,l),
+(197,560,l),
+(228,541,l),
+(228,690,l),
+(148,690,l),
+(148,541,l),
+(180,560,l),
+(58,609,l),
+(31,538,l),
+(155,491,l),
+(143,524,l),
+(60,408,l),
+(124,360,l)
+);
+}
+);
+width = 730;
+}
+);
+metricRight = "=|";
+note = uni156F;
+unicode = 5487;
+},
+{
+glyphname = "tye-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(477,-14,o),
+(570,85,o),
+(570,271,cs),
+(570,690,l),
+(438,690,l),
+(438,279,ls),
+(438,163,o),
+(387,117,o),
+(309,117,cs),
+(234,117,o),
+(182,166,o),
+(182,279,cs),
+(182,690,l),
+(48,690,l),
+(48,270,ls),
+(48,85,o),
+(145,-14,o),
+(310,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(368,411,o),
+(399,449,o),
+(399,509,cs),
+(399,690,l),
+(339,690,l),
+(339,512,ls),
+(339,486,o),
+(328,473,o),
+(309,473,cs),
+(291,473,o),
+(280,486,o),
+(280,512,cs),
+(280,690,l),
+(220,690,l),
+(220,509,ls),
+(220,448,o),
+(252,411,o),
+(310,411,cs)
+);
+}
+);
+width = 618;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1570;
+unicode = 5488;
+},
+{
+glyphname = "tyi-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(182,0,l),
+(182,411,ls),
+(182,526,o),
+(232,573,o),
+(310,573,cs),
+(385,573,o),
+(438,524,o),
+(438,411,cs),
+(438,0,l),
+(570,0,l),
+(570,419,ls),
+(570,605,o),
+(474,703,o),
+(310,703,cs),
+(143,703,o),
+(48,605,o),
+(48,419,cs),
+(48,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(280,0,l),
+(280,177,ls),
+(280,204,o),
+(291,216,o),
+(310,216,cs),
+(328,216,o),
+(339,204,o),
+(339,177,cs),
+(339,0,l),
+(399,0,l),
+(399,181,ls),
+(399,242,o),
+(367,279,o),
+(309,279,cs),
+(251,279,o),
+(220,241,o),
+(220,181,cs),
+(220,0,l)
+);
+}
+);
+width = 618;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1571;
+unicode = 5489;
+},
+{
+glyphname = "tyo-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(161,0,ls),
+(366,0,o),
+(493,116,o),
+(493,346,cs),
+(493,576,o),
+(366,690,o),
+(160,690,cs),
+(51,690,l),
+(51,563,l),
+(148,563,ls),
+(279,563,o),
+(351,499,o),
+(351,346,cs),
+(351,192,o),
+(279,127,o),
+(150,127,cs),
+(51,127,l),
+(51,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(114,215,ls),
+(193,215,o),
+(242,261,o),
+(242,345,cs),
+(242,430,o),
+(193,474,o),
+(114,474,cs),
+(51,474,l),
+(51,403,l),
+(103,403,ls),
+(147,403,o),
+(165,384,o),
+(165,345,cs),
+(165,306,o),
+(147,287,o),
+(103,287,cs),
+(51,287,l),
+(51,215,l)
+);
+}
+);
+width = 537;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1572;
+unicode = 5490;
+},
+{
+glyphname = "tya-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(486,0,l),
+(486,127,l),
+(389,127,ls),
+(258,127,o),
+(187,191,o),
+(187,345,cs),
+(187,498,o),
+(258,563,o),
+(388,563,cs),
+(486,563,l),
+(486,690,l),
+(376,690,ls),
+(172,690,o),
+(44,575,o),
+(44,345,cs),
+(44,116,o),
+(172,0,o),
+(377,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(486,215,l),
+(486,287,l),
+(435,287,ls),
+(390,287,o),
+(373,306,o),
+(373,345,cs),
+(373,384,o),
+(390,403,o),
+(434,403,cs),
+(486,403,l),
+(486,474,l),
+(423,474,ls),
+(344,474,o),
+(297,429,o),
+(297,345,cs),
+(297,260,o),
+(344,215,o),
+(423,215,cs)
+);
+}
+);
+width = 537;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1573;
+unicode = 5491;
+},
+{
+glyphname = "heNunavik-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(447,0,l),
+(652,199,l),
+(568,289,l),
+(373,100,l),
+(463,94,l),
+(463,440,ls),
+(463,608,o),
+(389,703,o),
+(255,703,cs),
+(121,703,o),
+(39,605,o),
+(39,441,cs),
+(39,287,o),
+(116,186,o),
+(231,186,cs),
+(284,186,o),
+(324,218,o),
+(333,253,c),
+(322,274,l),
+(322,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(208,307,o),
+(178,348,o),
+(178,445,cs),
+(178,543,o),
+(205,583,o),
+(250,583,cs),
+(296,583,o),
+(324,544,o),
+(324,445,cs),
+(324,347,o),
+(294,307,o),
+(250,307,cs)
+);
+}
+);
+width = 668;
+}
+);
+metricLeft = "ke-canadian";
+note = uni1574;
+unicode = 5492;
+},
+{
+glyphname = "hiNunavik-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (414,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(347,0,l),
+(347,274,l),
+(335,253,l),
+(345,218,o),
+(385,186,o),
+(438,186,cs),
+(553,186,o),
+(630,288,o),
+(630,441,cs),
+(630,605,o),
+(548,703,o),
+(414,703,cs),
+(280,703,o),
+(206,608,o),
+(206,440,cs),
+(206,97,l),
+(296,100,l),
+(100,289,l),
+(16,199,l),
+(221,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(375,307,o),
+(345,347,o),
+(345,445,cs),
+(345,544,o),
+(373,583,o),
+(417,583,cs),
+(464,583,o),
+(491,543,o),
+(491,445,cs),
+(491,348,o),
+(461,307,o),
+(417,307,cs)
+);
+}
+);
+width = 669;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1575;
+unicode = 5493;
+},
+{
+glyphname = "hiiNunavik-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "hiNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (330,0);
+ref = dot_top;
+}
+);
+width = 668;
+}
+);
+note = uni1576;
+unicode = 5494;
+},
+{
+glyphname = "hoNunavik-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (249,690);
+},
+{
+name = top_right_can;
+pos = (392,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(389,-14,o),
+(463,82,o),
+(463,249,cs),
+(463,596,l),
+(373,589,l),
+(568,401,l),
+(652,491,l),
+(447,690,l),
+(322,690,l),
+(322,415,l),
+(333,437,l),
+(324,471,o),
+(284,503,o),
+(231,503,cs),
+(116,503,o),
+(39,402,o),
+(39,247,cs),
+(39,85,o),
+(120,-14,o),
+(254,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(205,106,o),
+(178,147,o),
+(178,244,cs),
+(178,342,o),
+(208,383,o),
+(250,383,cs),
+(294,383,o),
+(324,343,o),
+(324,244,cs),
+(324,146,o),
+(296,106,o),
+(250,106,cs)
+);
+}
+);
+width = 668;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "heNunavik-canadian";
+note = uni1577;
+unicode = 5495;
+},
+{
+glyphname = "hooNunavik-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "hoNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (309,0);
+ref = dot_top;
+}
+);
+width = 668;
+}
+);
+note = uni1578;
+unicode = 5496;
+},
+{
+glyphname = "haNunavik-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (419,690);
+},
+{
+name = top_left_can;
+pos = (276,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(548,-14,o),
+(630,85,o),
+(630,248,cs),
+(630,402,o),
+(553,503,o),
+(439,503,cs),
+(385,503,o),
+(346,471,o),
+(335,437,c),
+(347,415,l),
+(347,690,l),
+(221,690,l),
+(16,491,l),
+(100,401,l),
+(296,589,l),
+(206,593,l),
+(206,249,ls),
+(206,82,o),
+(279,-14,o),
+(413,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(373,106,o),
+(345,146,o),
+(345,244,cs),
+(345,343,o),
+(375,383,o),
+(417,383,cs),
+(461,383,o),
+(491,342,o),
+(491,244,cs),
+(491,147,o),
+(464,106,o),
+(417,106,cs)
+);
+}
+);
+width = 669;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1579;
+unicode = 5497;
+},
+{
+glyphname = "haaNunavik-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "haNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (192,0);
+ref = dot_top;
+}
+);
+width = 668;
+}
+);
+note = uni157A;
+unicode = 5498;
+},
+{
+glyphname = "hNunavik-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(305,339,o),
+(357,383,o),
+(357,475,cs),
+(357,555,o),
+(315,601,o),
+(260,601,cs),
+(224,601,o),
+(198,579,o),
+(192,546,c),
+(213,546,l),
+(213,690,l),
+(126,690,l),
+(24,590,l),
+(71,543,l),
+(172,643,l),
+(118,643,l),
+(118,470,ls),
+(118,390,o),
+(162,339,o),
+(241,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(219,408,o),
+(205,423,o),
+(205,469,cs),
+(205,516,o),
+(220,532,o),
+(240,532,cs),
+(258,532,o),
+(274,517,o),
+(274,469,cs),
+(274,423,o),
+(259,408,o),
+(240,408,cs)
+);
+}
+);
+width = 391;
+}
+);
+metricRight = "k-canadian";
+note = uni157B;
+unicode = 5499;
+},
+{
+color = 4;
+glyphname = "nunavuth-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(193,293,l),
+(406,293,l),
+(406,0,l),
+(548,0,l),
+(548,690,l),
+(406,690,l),
+(406,419,l),
+(193,419,l),
+(193,690,l),
+(51,690,l),
+(51,0,l),
+(193,0,l)
+);
+}
+);
+width = 599;
+}
+);
+metricRight = "=|";
+note = uni157C;
+unicode = 5500;
+},
+{
+glyphname = "hk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,345);
+ref = "fullstop-canadian";
+}
+);
+width = 326;
+}
+);
+metricLeft = "fullstop-canadian";
+note = uni157D;
+unicode = 5501;
+},
+{
+glyphname = "qaai-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (277,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (421,0);
+ref = ring_top.canadian;
+}
+);
+width = 788;
+}
+);
+note = uni157E;
+unicode = 5502;
+},
+{
+glyphname = "qi-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (277,0);
+ref = "ki-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni157F;
+unicode = 5503;
+},
+{
+glyphname = "qii-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (277,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (454,0);
+ref = dot_top;
+}
+);
+width = 788;
+}
+);
+note = uni1580;
+unicode = 5504;
+},
+{
+glyphname = "qo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (277,0);
+ref = "ko-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni1581;
+unicode = 5505;
+},
+{
+glyphname = "qoo-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (277,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (586,0);
+ref = dot_top;
+}
+);
+width = 788;
+}
+);
+note = uni1582;
+unicode = 5506;
+},
+{
+glyphname = "qa-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (277,0);
+ref = "ka-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni1583;
+unicode = 5507;
+},
+{
+glyphname = "qaa-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (277,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (313,0);
+ref = dot_top;
+}
+);
+width = 788;
+}
+);
+note = uni1584;
+unicode = 5508;
+},
+{
+glyphname = "q-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (277,0);
+ref = "k-canadian";
+}
+);
+width = 594;
+}
+);
+note = uni1585;
+unicode = 5509;
+},
+{
+glyphname = "tlhe-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (264,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(196,0,l),
+(297,266,l),
+(192,225,l),
+(206,220,o),
+(223,218,o),
+(240,218,cs),
+(300,218,o),
+(340,254,o),
+(346,286,c),
+(335,327,l),
+(335,0,l),
+(475,0,l),
+(475,457,ls),
+(475,611,o),
+(401,703,o),
+(265,703,cs),
+(127,703,o),
+(45,607,o),
+(45,457,cs),
+(45,358,o),
+(83,285,o),
+(144,250,c),
+(48,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(215,338,o),
+(185,375,o),
+(185,461,cs),
+(185,547,o),
+(213,583,o),
+(261,583,cs),
+(307,583,o),
+(336,547,o),
+(336,461,cs),
+(336,375,o),
+(305,338,o),
+(261,338,cs)
+);
+}
+);
+width = 523;
+}
+);
+metricRight = "te-canadian";
+note = uni1586;
+unicode = 5510;
+},
+{
+glyphname = "tlhi-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(189,0,l),
+(189,327,l),
+(178,288,l),
+(182,256,o),
+(222,218,o),
+(284,218,c),
+(227,266,l),
+(327,0,l),
+(476,0,l),
+(381,250,l),
+(441,285,o),
+(479,358,o),
+(479,457,cs),
+(479,607,o),
+(398,703,o),
+(260,703,cs),
+(123,703,o),
+(48,611,o),
+(48,457,cs),
+(48,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(219,338,o),
+(188,375,o),
+(188,461,cs),
+(188,547,o),
+(217,583,o),
+(264,583,cs),
+(311,583,o),
+(340,547,o),
+(340,461,cs),
+(340,375,o),
+(309,338,o),
+(264,338,cs)
+);
+}
+);
+width = 524;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|tlhe-canadian";
+note = uni1587;
+unicode = 5511;
+},
+{
+glyphname = "tlho-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (269,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(401,-14,o),
+(475,78,o),
+(475,233,cs),
+(475,690,l),
+(335,690,l),
+(335,362,l),
+(347,402,l),
+(343,434,o),
+(302,471,o),
+(240,471,c),
+(297,424,l),
+(196,690,l),
+(48,690,l),
+(144,440,l),
+(83,405,o),
+(45,331,o),
+(45,233,cs),
+(45,83,o),
+(127,-14,o),
+(265,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(213,106,o),
+(185,143,o),
+(185,229,cs),
+(185,315,o),
+(215,352,o),
+(261,352,cs),
+(305,352,o),
+(336,315,o),
+(336,229,cs),
+(336,143,o),
+(307,106,o),
+(261,106,cs)
+);
+}
+);
+width = 523;
+}
+);
+metricLeft = "tlhe-canadian";
+metricRight = "te-canadian";
+note = uni1588;
+unicode = 5512;
+},
+{
+glyphname = "tlha-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(398,-14,o),
+(479,83,o),
+(479,233,cs),
+(479,331,o),
+(441,405,o),
+(381,440,c),
+(476,690,l),
+(327,690,l),
+(227,424,l),
+(332,465,l),
+(318,469,o),
+(301,471,o),
+(284,471,cs),
+(222,471,o),
+(182,434,o),
+(178,402,c),
+(189,362,l),
+(189,690,l),
+(48,690,l),
+(48,233,ls),
+(48,78,o),
+(123,-14,o),
+(260,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(217,106,o),
+(188,143,o),
+(188,229,cs),
+(188,315,o),
+(219,352,o),
+(264,352,cs),
+(309,352,o),
+(340,315,o),
+(340,229,cs),
+(340,143,o),
+(311,106,o),
+(264,106,cs)
+);
+}
+);
+width = 525;
+}
+);
+metricLeft = "te-canadian";
+note = uni1589;
+unicode = 5513;
+},
+{
+glyphname = "reWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(438,0,l),
+(642,199,l),
+(558,289,l),
+(363,100,l),
+(453,94,l),
+(453,451,ls),
+(453,610,o),
+(382,703,o),
+(247,703,cs),
+(116,703,o),
+(36,615,o),
+(36,452,cs),
+(36,382,l),
+(177,382,l),
+(177,477,ls),
+(177,544,o),
+(200,580,o),
+(245,580,cs),
+(288,580,o),
+(312,546,o),
+(312,475,cs),
+(312,0,l)
+);
+}
+);
+width = 658;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+unicode = 5514;
+},
+{
+glyphname = "riWestCree-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(347,0,l),
+(347,475,ls),
+(347,546,o),
+(371,580,o),
+(414,580,cs),
+(459,580,o),
+(482,544,o),
+(482,477,cs),
+(482,382,l),
+(623,382,l),
+(623,452,ls),
+(623,615,o),
+(544,703,o),
+(413,703,cs),
+(277,703,o),
+(206,609,o),
+(206,451,cs),
+(206,94,l),
+(296,100,l),
+(100,289,l),
+(16,199,l),
+(221,0,l)
+);
+}
+);
+width = 659;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+unicode = 5515;
+},
+{
+glyphname = "roWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(382,-14,o),
+(453,80,o),
+(453,239,cs),
+(453,596,l),
+(363,589,l),
+(558,401,l),
+(642,491,l),
+(438,690,l),
+(312,690,l),
+(312,214,ls),
+(312,144,o),
+(288,110,o),
+(245,110,cs),
+(200,110,o),
+(177,146,o),
+(177,213,cs),
+(177,308,l),
+(36,308,l),
+(36,238,ls),
+(36,74,o),
+(114,-14,o),
+(247,-14,cs)
+);
+}
+);
+width = 658;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+unicode = 5516;
+},
+{
+glyphname = "raWestCree-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(544,-14,o),
+(623,74,o),
+(623,238,cs),
+(623,308,l),
+(482,308,l),
+(482,213,ls),
+(482,146,o),
+(459,110,o),
+(413,110,cs),
+(371,110,o),
+(347,144,o),
+(347,214,cs),
+(347,690,l),
+(221,690,l),
+(16,491,l),
+(100,401,l),
+(296,589,l),
+(206,596,l),
+(206,239,ls),
+(206,80,o),
+(276,-14,o),
+(413,-14,cs)
+);
+}
+);
+width = 659;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+unicode = 5517;
+},
+{
+glyphname = "ngaai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (531,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (674,0);
+ref = ring_top.canadian;
+}
+);
+width = 1035;
+}
+);
+note = uni158E;
+unicode = 5518;
+},
+{
+glyphname = "ngi-canadian";
+kernLeft = mwestleft;
+kernRight = ciright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (531,0);
+ref = "ci-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni158F;
+unicode = 5519;
+},
+{
+glyphname = "ngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (531,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (708,0);
+ref = dot_top;
+}
+);
+width = 1035;
+}
+);
+note = uni1590;
+unicode = 5520;
+},
+{
+glyphname = "ngo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 16:35:41 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (506,0);
+ref = "co-canadian";
+}
+);
+width = 1008;
+}
+);
+note = uni1591;
+unicode = 5521;
+},
+{
+glyphname = "ngoo-canadian";
+lastChange = "2023-01-13 16:35:41 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+ref = "ngo-canadian";
+},
+{
+anchor = top_right_can;
+pos = (806,0);
+ref = dot_top;
+}
+);
+width = 1008;
+}
+);
+note = uni1592;
+unicode = 5522;
+},
+{
+glyphname = "nga-canadian";
+kernLeft = mwestleft;
+kernRight = caright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (531,0);
+ref = "ca-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni1593;
+unicode = 5523;
+},
+{
+glyphname = "ngaa-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (531,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (568,0);
+ref = dot_top;
+}
+);
+width = 1035;
+}
+);
+note = uni1594;
+unicode = 5524;
+},
+{
+glyphname = "ng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(463,217,o),
+(508,262,o),
+(508,343,cs),
+(508,368,l),
+(421,368,l),
+(421,334,ls),
+(421,304,o),
+(410,291,o),
+(389,291,cs),
+(370,291,o),
+(360,304,o),
+(360,335,cs),
+(360,524,l),
+(238,524,l),
+(240,483,l),
+(255,495,o),
+(269,529,o),
+(269,570,cs),
+(269,647,o),
+(227,696,o),
+(152,696,cs),
+(77,696,o),
+(34,645,o),
+(34,565,cs),
+(34,486,o),
+(77,434,o),
+(156,434,cs),
+(286,434,l),
+(267,457,l),
+(267,347,ls),
+(267,263,o),
+(309,217,o),
+(388,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(130,502,o),
+(117,521,o),
+(117,565,cs),
+(117,610,o),
+(130,627,o),
+(152,627,cs),
+(173,627,o),
+(185,608,o),
+(185,564,cs),
+(185,522,o),
+(173,502,o),
+(152,502,cs)
+);
+}
+);
+width = 531;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1595;
+unicode = 5525;
+},
+{
+glyphname = "nng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(724,217,o),
+(770,262,o),
+(770,343,cs),
+(770,368,l),
+(682,368,l),
+(682,334,ls),
+(682,304,o),
+(670,291,o),
+(651,291,cs),
+(632,291,o),
+(622,304,o),
+(622,335,cs),
+(622,524,l),
+(503,524,l),
+(503,483,l),
+(519,495,o),
+(532,529,o),
+(532,570,cs),
+(532,650,o),
+(491,696,o),
+(415,696,cs),
+(341,696,o),
+(298,645,o),
+(298,566,cs),
+(298,527,o),
+(311,492,o),
+(327,480,c),
+(327,524,l),
+(239,524,l),
+(240,483,l),
+(255,495,o),
+(269,529,o),
+(269,570,cs),
+(269,647,o),
+(227,696,o),
+(152,696,cs),
+(77,696,o),
+(34,645,o),
+(34,565,cs),
+(34,486,o),
+(77,434,o),
+(156,434,cs),
+(528,434,l),
+(528,347,ls),
+(528,263,o),
+(571,217,o),
+(650,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(130,502,o),
+(117,521,o),
+(117,565,cs),
+(117,610,o),
+(130,627,o),
+(152,627,cs),
+(173,627,o),
+(185,608,o),
+(185,564,cs),
+(185,522,o),
+(173,502,o),
+(152,502,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(394,502,o),
+(381,521,o),
+(381,565,cs),
+(381,610,o),
+(394,627,o),
+(415,627,cs),
+(437,627,o),
+(449,608,o),
+(449,564,cs),
+(449,522,o),
+(437,502,o),
+(415,502,cs)
+);
+}
+);
+width = 793;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1596;
+unicode = 5526;
+},
+{
+glyphname = "sheSayisi-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (592,345);
+},
+{
+name = top_center_can;
+pos = (260,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(472,0,l),
+(472,446,ls),
+(472,608,o),
+(400,703,o),
+(260,703,cs),
+(122,703,o),
+(39,604,o),
+(39,432,cs),
+(39,266,o),
+(102,187,o),
+(185,187,cs),
+(269,187,o),
+(308,250,o),
+(300,413,c),
+(244,413,l),
+(248,321,o),
+(234,303,o),
+(214,303,cs),
+(190,303,o),
+(175,328,o),
+(175,436,cs),
+(175,543,o),
+(204,583,o),
+(255,583,cs),
+(304,583,o),
+(329,544,o),
+(329,437,cs),
+(329,0,l)
+);
+}
+);
+width = 520;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1597;
+unicode = 5527;
+},
+{
+glyphname = "shiSayisi-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(191,0,l),
+(191,437,ls),
+(191,544,o),
+(217,583,o),
+(267,583,cs),
+(318,583,o),
+(347,543,o),
+(347,436,cs),
+(347,329,o),
+(330,303,o),
+(306,303,cs),
+(287,303,o),
+(273,321,o),
+(277,413,c),
+(220,413,l),
+(213,250,o),
+(252,187,o),
+(336,187,cs),
+(418,187,o),
+(482,266,o),
+(482,432,cs),
+(482,604,o),
+(400,703,o),
+(263,703,cs),
+(122,703,o),
+(48,608,o),
+(48,446,cs),
+(48,0,l)
+);
+}
+);
+width = 521;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni1598;
+unicode = 5528;
+},
+{
+glyphname = "shoSayisi-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (255,690);
+},
+{
+name = top_left_can;
+pos = (106,690);
+},
+{
+name = top_right_can;
+pos = (402,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(399,-14,o),
+(472,82,o),
+(472,243,cs),
+(472,690,l),
+(329,690,l),
+(329,253,ls),
+(329,146,o),
+(304,106,o),
+(255,106,cs),
+(204,106,o),
+(175,147,o),
+(175,254,cs),
+(175,360,o),
+(190,386,o),
+(214,386,cs),
+(234,386,o),
+(248,369,o),
+(244,276,c),
+(300,276,l),
+(308,440,o),
+(270,502,o),
+(185,502,cs),
+(102,502,o),
+(39,424,o),
+(39,257,cs),
+(39,86,o),
+(121,-14,o),
+(258,-14,cs)
+);
+}
+);
+width = 520;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1599;
+unicode = 5529;
+},
+{
+glyphname = "shaSayisi-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(399,-14,o),
+(482,86,o),
+(482,258,cs),
+(482,424,o),
+(419,502,o),
+(337,502,cs),
+(253,502,o),
+(213,440,o),
+(220,276,c),
+(277,276,l),
+(273,369,o),
+(287,386,o),
+(306,386,cs),
+(330,386,o),
+(347,361,o),
+(347,254,cs),
+(347,147,o),
+(317,106,o),
+(266,106,cs),
+(216,106,o),
+(191,146,o),
+(191,253,cs),
+(191,690,l),
+(48,690,l),
+(48,243,ls),
+(48,82,o),
+(121,-14,o),
+(261,-14,cs)
+);
+}
+);
+width = 521;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni159A;
+unicode = 5530;
+},
+{
+glyphname = "theWoodScree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(562,-14,o),
+(650,72,o),
+(650,238,cs),
+(650,405,o),
+(565,489,o),
+(414,489,cs),
+(42,489,l),
+(42,372,l),
+(278,372,l),
+(268,394,l),
+(237,358,o),
+(220,295,o),
+(220,231,cs),
+(220,71,o),
+(303,-14,o),
+(435,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(387,106,o),
+(359,147,o),
+(359,239,cs),
+(359,328,o),
+(387,371,o),
+(435,371,cs),
+(482,371,o),
+(511,330,o),
+(511,239,cs),
+(511,147,o),
+(482,106,o),
+(435,106,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(640,573,l),
+(640,690,l),
+(42,690,l),
+(42,573,l)
+);
+}
+);
+width = 692;
+}
+);
+note = uni159B;
+unicode = 5531;
+},
+{
+glyphname = "thiWoodScree-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(389,-14,o),
+(472,71,o),
+(472,231,cs),
+(472,295,o),
+(455,358,o),
+(424,394,c),
+(413,372,l),
+(650,372,l),
+(650,489,l),
+(278,489,ls),
+(127,489,o),
+(42,403,o),
+(42,238,cs),
+(42,72,o),
+(129,-14,o),
+(257,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(210,106,o),
+(182,147,o),
+(182,239,cs),
+(182,330,o),
+(210,371,o),
+(257,371,cs),
+(304,371,o),
+(332,328,o),
+(332,239,cs),
+(332,147,o),
+(305,106,o),
+(257,106,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(650,573,l),
+(650,690,l),
+(52,690,l),
+(52,573,l)
+);
+}
+);
+width = 692;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159C;
+unicode = 5532;
+},
+{
+glyphname = "thoWoodScree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(416,0,ls),
+(565,0,o),
+(650,85,o),
+(650,251,cs),
+(650,416,o),
+(563,503,o),
+(435,503,cs),
+(303,503,o),
+(220,416,o),
+(220,258,cs),
+(220,195,o),
+(237,131,o),
+(268,96,c),
+(278,117,l),
+(42,117,l),
+(42,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(387,119,o),
+(359,161,o),
+(359,250,cs),
+(359,342,o),
+(387,383,o),
+(435,383,cs),
+(482,383,o),
+(511,343,o),
+(511,250,cs),
+(511,158,o),
+(482,119,o),
+(435,119,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(640,573,l),
+(640,690,l),
+(42,690,l),
+(42,573,l)
+);
+}
+);
+width = 692;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159D;
+unicode = 5533;
+},
+{
+glyphname = "thaWoodScree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(650,0,l),
+(650,117,l),
+(413,117,l),
+(424,95,l),
+(455,130,o),
+(472,194,o),
+(472,258,cs),
+(472,417,o),
+(389,503,o),
+(257,503,cs),
+(129,503,o),
+(42,416,o),
+(42,251,cs),
+(42,86,o),
+(127,0,o),
+(276,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(210,119,o),
+(182,158,o),
+(182,250,cs),
+(182,343,o),
+(210,383,o),
+(257,383,cs),
+(305,383,o),
+(332,342,o),
+(332,250,cs),
+(332,161,o),
+(304,119,o),
+(257,119,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(650,573,l),
+(650,690,l),
+(52,690,l),
+(52,573,l)
+);
+}
+);
+width = 692;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159E;
+unicode = 5534;
+},
+{
+glyphname = "thWoodScree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(374,344,l),
+(374,426,l),
+(243,426,l),
+(248,392,l),
+(265,404,o),
+(278,439,o),
+(278,480,cs),
+(278,557,o),
+(237,606,o),
+(161,606,cs),
+(87,606,o),
+(43,555,o),
+(43,475,cs),
+(43,396,o),
+(87,344,o),
+(166,344,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(140,412,o),
+(127,431,o),
+(127,475,cs),
+(127,520,o),
+(140,537,o),
+(161,537,cs),
+(183,537,o),
+(195,518,o),
+(195,474,cs),
+(195,432,o),
+(183,412,o),
+(161,412,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(364,647,l),
+(364,729,l),
+(47,729,l),
+(47,647,l)
+);
+}
+);
+width = 417;
+}
+);
+metricRight = "=|";
+note = uni159F;
+unicode = 5535;
+},
+{
+glyphname = "lhi-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (361,690);
+},
+{
+name = top_right_can;
+pos = (462,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(320,0,l),
+(320,125,l),
+(297,125,ls),
+(219,125,o),
+(180,164,o),
+(180,242,cs),
+(180,321,o),
+(218,360,o),
+(293,360,cs),
+(646,360,l),
+(646,474,l),
+(492,737,l),
+(384,673,l),
+(539,411,l),
+(537,489,l),
+(285,489,ls),
+(135,489,o),
+(39,404,o),
+(39,243,cs),
+(39,85,o),
+(133,0,o),
+(285,0,cs)
+);
+}
+);
+width = 683;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A0;
+unicode = 5536;
+},
+{
+glyphname = "lhii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "lhi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (278,0);
+ref = dot_top;
+}
+);
+width = 684;
+}
+);
+note = uni15A1;
+unicode = 5537;
+},
+{
+glyphname = "lho-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (340,506);
+},
+{
+name = top_right_can;
+pos = (428,506);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(299,-185,l),
+(145,78,l),
+(146,0,l),
+(399,0,ls),
+(549,0,o),
+(645,85,o),
+(645,245,cs),
+(645,405,o),
+(551,489,o),
+(400,489,cs),
+(364,489,l),
+(364,364,l),
+(387,364,ls),
+(465,364,o),
+(504,325,o),
+(504,247,cs),
+(504,168,o),
+(465,128,o),
+(391,128,cs),
+(37,128,l),
+(37,14,l),
+(192,-249,l)
+);
+}
+);
+width = 684;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni15A2;
+unicode = 5538;
+},
+{
+glyphname = "lhoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "lho-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (344,-184);
+ref = dot_top;
+}
+);
+width = 684;
+}
+);
+note = uni15A3;
+unicode = 5539;
+},
+{
+glyphname = "lha-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (346,506);
+},
+{
+name = top_left_can;
+pos = (257,506);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(646,14,l),
+(646,128,l),
+(293,128,ls),
+(219,128,o),
+(180,168,o),
+(180,247,cs),
+(180,325,o),
+(219,364,o),
+(296,364,cs),
+(320,364,l),
+(320,489,l),
+(284,489,ls),
+(132,489,o),
+(39,404,o),
+(39,244,cs),
+(39,85,o),
+(135,0,o),
+(285,0,cs),
+(537,0,l),
+(539,79,l),
+(384,-185,l),
+(492,-249,l)
+);
+}
+);
+width = 683;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A4;
+unicode = 5540;
+},
+{
+glyphname = "lhaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "lha-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (173,-184);
+ref = dot_top;
+}
+);
+width = 684;
+}
+);
+note = uni15A5;
+unicode = 5541;
+},
+{
+glyphname = "lh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(362,355,l),
+(362,434,l),
+(214,434,ls),
+(160,434,o),
+(133,464,o),
+(133,517,cs),
+(133,571,o),
+(160,602,o),
+(206,602,cs),
+(214,602,l),
+(214,690,l),
+(199,690,ls),
+(97,690,o),
+(40,618,o),
+(40,518,cs),
+(40,412,o),
+(97,344,o),
+(213,344,cs),
+(300,344,l),
+(293,397,l),
+(203,250,l),
+(274,207,l)
+);
+}
+);
+width = 402;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni15A6;
+unicode = 5542;
+},
+{
+glyphname = "theThCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (97,690);
+},
+{
+name = top_right_can;
+pos = (371,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(441,0,l),
+(441,82,l),
+(500,82,l),
+(500,159,l),
+(441,159,l),
+(441,345,l),
+(189,345,l),
+(216,300,l),
+(466,622,l),
+(364,701,l),
+(26,258,l),
+(26,221,l),
+(299,221,l),
+(299,159,l),
+(125,159,l),
+(125,82,l),
+(299,82,l),
+(299,0,l)
+);
+}
+);
+width = 525;
+}
+);
+metricLeft = "ye-canadian";
+note = uni15A7;
+unicode = 5543;
+},
+{
+glyphname = "thiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (156,690);
+},
+{
+name = top_right_can;
+pos = (430,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(226,0,l),
+(226,82,l),
+(402,82,l),
+(402,159,l),
+(226,159,l),
+(226,221,l),
+(499,221,l),
+(499,258,l),
+(161,701,l),
+(60,622,l),
+(319,288,l),
+(336,345,l),
+(84,345,l),
+(84,159,l),
+(25,159,l),
+(25,82,l),
+(84,82,l),
+(84,0,l)
+);
+}
+);
+width = 525;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+unicode = 5544;
+},
+{
+glyphname = "thiiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (71,0);
+ref = dot_top;
+}
+);
+width = 525;
+}
+);
+note = uni15A9;
+unicode = 5545;
+},
+{
+glyphname = "thoThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (97,690);
+},
+{
+name = top_right_can;
+pos = (371,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(466,68,l),
+(216,389,l),
+(189,345,l),
+(441,345,l),
+(441,530,l),
+(500,530,l),
+(500,608,l),
+(441,608,l),
+(441,690,l),
+(299,690,l),
+(299,608,l),
+(125,608,l),
+(125,530,l),
+(299,530,l),
+(299,469,l),
+(26,469,l),
+(26,432,l),
+(364,-12,l)
+);
+}
+);
+width = 525;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+unicode = 5546;
+},
+{
+glyphname = "thooThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (288,0);
+ref = dot_top;
+}
+);
+width = 525;
+}
+);
+note = uni15AB;
+unicode = 5547;
+},
+{
+glyphname = "thaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (156,690);
+},
+{
+name = top_right_can;
+pos = (430,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(499,432,l),
+(499,469,l),
+(226,469,l),
+(226,530,l),
+(402,530,l),
+(402,608,l),
+(226,608,l),
+(226,690,l),
+(84,690,l),
+(84,608,l),
+(25,608,l),
+(25,530,l),
+(84,530,l),
+(84,345,l),
+(336,345,l),
+(309,389,l),
+(60,68,l),
+(161,-12,l)
+);
+}
+);
+width = 525;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+unicode = 5548;
+},
+{
+glyphname = "thaaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:56:39 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (72,0);
+ref = dot_top;
+}
+);
+width = 525;
+}
+);
+note = uni15AD;
+unicode = 5549;
+},
+{
+glyphname = "thThCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(285,554,l),
+(285,580,l),
+(156,580,l),
+(156,614,l),
+(235,614,l),
+(235,654,l),
+(156,654,l),
+(156,690,l),
+(63,690,l),
+(63,654,l),
+(32,654,l),
+(32,614,l),
+(63,614,l),
+(63,501,l),
+(208,501,l),
+(185,557,l),
+(57,384,l),
+(127,336,l)
+);
+}
+);
+width = 306;
+}
+);
+metricRight = "y-canadian";
+note = uni15AE;
+unicode = 5550;
+},
+{
+glyphname = "bAivilik-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(400,-14,o),
+(477,87,o),
+(477,248,cs),
+(477,401,o),
+(402,503,o),
+(292,503,cs),
+(232,503,o),
+(192,471,o),
+(183,437,c),
+(193,405,l),
+(193,690,l),
+(51,690,l),
+(51,0,l),
+(182,0,l),
+(182,74,l),
+(177,59,l),
+(192,18,o),
+(228,-14,o),
+(293,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(220,106,o),
+(192,146,o),
+(192,244,cs),
+(192,343,o),
+(222,383,o),
+(265,383,cs),
+(308,383,o),
+(338,342,o),
+(338,244,cs),
+(338,147,o),
+(310,106,o),
+(265,106,cs)
+);
+}
+);
+width = 516;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|ke-canadian";
+note = uni15AF;
+unicode = 5551;
+},
+{
+glyphname = "eBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(193,0,l),
+(193,400,l),
+(219,364,o),
+(259,344,o),
+(306,344,cs),
+(400,344,o),
+(458,420,o),
+(458,525,cs),
+(458,628,o),
+(400,703,o),
+(306,703,cs),
+(254,703,o),
+(210,678,o),
+(185,637,c),
+(185,690,l),
+(51,690,l),
+(51,0,l)
+);
+}
+);
+width = 490;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B0;
+unicode = 5552;
+},
+{
+glyphname = "iBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(236,-14,o),
+(280,12,o),
+(303,53,c),
+(303,0,l),
+(439,0,l),
+(439,690,l),
+(296,690,l),
+(296,290,l),
+(270,326,o),
+(231,346,o),
+(184,346,cs),
+(89,346,o),
+(32,270,o),
+(32,165,cs),
+(32,62,o),
+(89,-14,o),
+(184,-14,cs)
+);
+}
+);
+width = 490;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B1;
+unicode = 5553;
+},
+{
+glyphname = "oBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(400,-14,o),
+(458,62,o),
+(458,165,cs),
+(458,270,o),
+(400,346,o),
+(306,346,cs),
+(259,346,o),
+(219,326,o),
+(193,290,c),
+(193,690,l),
+(51,690,l),
+(51,0,l),
+(185,0,l),
+(185,53,l),
+(210,12,o),
+(254,-14,o),
+(306,-14,cs)
+);
+}
+);
+width = 490;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "eBlackfoot-canadian";
+note = uni15B2;
+unicode = 5554;
+},
+{
+glyphname = "aBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(439,0,l),
+(439,690,l),
+(303,690,l),
+(303,637,l),
+(280,678,o),
+(236,703,o),
+(184,703,cs),
+(89,703,o),
+(32,628,o),
+(32,525,cs),
+(32,420,o),
+(89,344,o),
+(184,344,cs),
+(231,344,o),
+(270,364,o),
+(296,400,c),
+(296,0,l)
+);
+}
+);
+width = 490;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B3;
+unicode = 5555;
+},
+{
+glyphname = "weBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(193,282,l),
+(463,282,l),
+(463,404,l),
+(193,404,l),
+(193,569,l),
+(463,569,l),
+(463,690,l),
+(51,690,l),
+(51,0,l),
+(193,0,l)
+);
+}
+);
+width = 506;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B4;
+unicode = 5556;
+},
+{
+glyphname = "wiBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(456,0,l),
+(456,690,l),
+(313,690,l),
+(313,408,l),
+(43,408,l),
+(43,286,l),
+(313,286,l),
+(313,121,l),
+(43,121,l),
+(43,0,l)
+);
+}
+);
+width = 507;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B5;
+unicode = 5557;
+},
+{
+glyphname = "woBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(463,0,l),
+(463,121,l),
+(193,121,l),
+(193,286,l),
+(463,286,l),
+(463,408,l),
+(193,408,l),
+(193,690,l),
+(51,690,l),
+(51,0,l)
+);
+}
+);
+width = 506;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "weBlackfoot-canadian";
+note = uni15B6;
+unicode = 5558;
+},
+{
+glyphname = "waBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(456,0,l),
+(456,690,l),
+(43,690,l),
+(43,569,l),
+(313,569,l),
+(313,404,l),
+(43,404,l),
+(43,282,l),
+(313,282,l),
+(313,0,l)
+);
+}
+);
+width = 507;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B7;
+unicode = 5559;
+},
+{
+glyphname = "neBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(193,0,l),
+(193,586,l),
+(243,586,l),
+(206,667,l),
+(206,646,ls),
+(206,481,o),
+(279,386,o),
+(414,386,cs),
+(548,386,o),
+(630,485,o),
+(630,644,cs),
+(630,690,l),
+(491,690,l),
+(491,629,ls),
+(491,553,o),
+(466,510,o),
+(418,510,cs),
+(370,510,o),
+(345,552,o),
+(345,628,cs),
+(345,690,l),
+(51,690,l),
+(51,0,l)
+);
+}
+);
+width = 654;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B8;
+unicode = 5560;
+},
+{
+glyphname = "niBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(163,0,l),
+(163,61,ls),
+(163,137,o),
+(188,180,o),
+(237,180,cs),
+(284,180,o),
+(309,138,o),
+(309,62,cs),
+(309,0,l),
+(603,0,l),
+(603,690,l),
+(461,690,l),
+(461,103,l),
+(411,103,l),
+(448,23,l),
+(448,43,ls),
+(448,209,o),
+(375,303,o),
+(241,303,cs),
+(106,303,o),
+(24,205,o),
+(24,45,cs),
+(24,0,l)
+);
+}
+);
+width = 654;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B9;
+unicode = 5561;
+},
+{
+glyphname = "noBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(345,0,l),
+(345,62,ls),
+(345,138,o),
+(370,180,o),
+(418,180,cs),
+(466,180,o),
+(491,137,o),
+(491,61,cs),
+(491,0,l),
+(630,0,l),
+(630,45,ls),
+(630,205,o),
+(548,303,o),
+(414,303,cs),
+(279,303,o),
+(206,209,o),
+(206,43,cs),
+(206,23,l),
+(243,103,l),
+(193,103,l),
+(193,690,l),
+(51,690,l),
+(51,0,l)
+);
+}
+);
+width = 654;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "neBlackfoot-canadian";
+note = uni15BA;
+unicode = 5562;
+},
+{
+glyphname = "naBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(603,0,l),
+(603,690,l),
+(309,690,l),
+(309,628,ls),
+(309,552,o),
+(284,510,o),
+(237,510,cs),
+(188,510,o),
+(163,553,o),
+(163,629,cs),
+(163,690,l),
+(24,690,l),
+(24,644,ls),
+(24,485,o),
+(106,386,o),
+(241,386,cs),
+(375,386,o),
+(448,481,o),
+(448,646,cs),
+(448,667,l),
+(411,586,l),
+(461,586,l),
+(461,0,l)
+);
+}
+);
+width = 654;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BB;
+unicode = 5563;
+},
+{
+glyphname = "keBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(193,0,l),
+(193,526,l),
+(148,526,l),
+(273,251,l),
+(332,251,l),
+(534,690,l),
+(392,690,l),
+(262,404,l),
+(315,404,l),
+(185,690,l),
+(51,690,l),
+(51,0,l)
+);
+}
+);
+width = 543;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15BC;
+unicode = 5564;
+},
+{
+glyphname = "kiBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(151,0,l),
+(281,286,l),
+(228,286,l),
+(358,0,l),
+(492,0,l),
+(492,690,l),
+(349,690,l),
+(349,164,l),
+(395,164,l),
+(270,439,l),
+(211,439,l),
+(9,0,l)
+);
+}
+);
+width = 543;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BD;
+unicode = 5565;
+},
+{
+glyphname = "koBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(185,0,l),
+(315,286,l),
+(262,286,l),
+(392,0,l),
+(534,0,l),
+(332,439,l),
+(273,439,l),
+(148,164,l),
+(193,164,l),
+(193,690,l),
+(51,690,l),
+(51,0,l)
+);
+}
+);
+width = 543;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "keBlackfoot-canadian";
+note = uni15BE;
+unicode = 5566;
+},
+{
+glyphname = "kaBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(492,0,l),
+(492,690,l),
+(358,690,l),
+(228,404,l),
+(281,404,l),
+(151,690,l),
+(9,690,l),
+(211,251,l),
+(270,251,l),
+(395,526,l),
+(349,526,l),
+(349,0,l)
+);
+}
+);
+width = 543;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BF;
+unicode = 5567;
+},
+{
+color = 9;
+glyphname = "heSayisi-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_right_can;
+pos = (473,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(544,0,l),
+(544,690,l),
+(403,690,l),
+(403,354,l),
+(425,354,l),
+(421,583,o),
+(331,703,o),
+(217,703,cs),
+(105,703,o),
+(35,613,o),
+(35,440,cs),
+(35,405,o),
+(38,367,o),
+(44,330,c),
+(180,330,l),
+(175,360,o),
+(172,397,o),
+(172,421,cs),
+(172,538,o),
+(205,580,o),
+(252,580,cs),
+(330,580,o),
+(398,452,o),
+(401,0,c)
+);
+}
+);
+width = 595;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni15C0;
+unicode = 5568;
+},
+{
+color = 9;
+glyphname = "hiSayisi-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(193,0,l),
+(197,452,o),
+(265,580,o),
+(343,580,cs),
+(390,580,o),
+(423,538,o),
+(423,421,cs),
+(423,397,o),
+(420,360,o),
+(415,330,c),
+(551,330,l),
+(557,367,o),
+(560,405,o),
+(560,440,cs),
+(560,613,o),
+(490,703,o),
+(378,703,cs),
+(264,703,o),
+(174,583,o),
+(170,354,c),
+(192,354,l),
+(192,690,l),
+(51,690,l),
+(51,0,l)
+);
+}
+);
+width = 595;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C1;
+unicode = 5569;
+},
+{
+color = 9;
+glyphname = "hoSayisi-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (293,690);
+},
+{
+name = top_left_can;
+pos = (112,690);
+},
+{
+name = top_right_can;
+pos = (473,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(331,-14,o),
+(421,106,o),
+(425,336,c),
+(403,336,l),
+(403,0,l),
+(544,0,l),
+(544,690,l),
+(401,690,l),
+(398,238,o),
+(330,110,o),
+(252,110,cs),
+(205,110,o),
+(172,152,o),
+(172,269,cs),
+(172,293,o),
+(175,329,o),
+(180,359,c),
+(44,359,l),
+(38,323,o),
+(35,285,o),
+(35,250,cs),
+(35,76,o),
+(105,-14,o),
+(217,-14,cs)
+);
+}
+);
+width = 595;
+}
+);
+metricLeft = "heSayisi-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15C2;
+unicode = 5570;
+},
+{
+color = 9;
+glyphname = "haSayisi-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(490,-14,o),
+(560,76,o),
+(560,250,cs),
+(560,285,o),
+(557,323,o),
+(551,359,c),
+(415,359,l),
+(420,329,o),
+(423,293,o),
+(423,269,cs),
+(423,152,o),
+(390,110,o),
+(343,110,cs),
+(265,110,o),
+(197,238,o),
+(193,690,c),
+(51,690,l),
+(51,0,l),
+(192,0,l),
+(192,336,l),
+(170,336,l),
+(174,106,o),
+(264,-14,o),
+(378,-14,cs)
+);
+}
+);
+width = 595;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C3;
+unicode = 5571;
+},
+{
+color = 9;
+glyphname = "ghuCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(327,0,l),
+(596,655,l),
+(596,690,l),
+(481,690,l),
+(406,498,l),
+(476,518,l),
+(142,518,l),
+(214,496,l),
+(137,690,l),
+(18,690,l),
+(18,655,l),
+(287,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(442,413,l),
+(384,427,l),
+(285,176,l),
+(333,176,l),
+(234,431,l),
+(177,413,l)
+);
+}
+);
+width = 614;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C4;
+unicode = 5572;
+},
+{
+color = 9;
+glyphname = "ghoCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(137,0,l),
+(214,194,l),
+(142,172,l),
+(476,172,l),
+(406,191,l),
+(481,0,l),
+(596,0,l),
+(596,35,l),
+(327,690,l),
+(287,690,l),
+(18,35,l),
+(18,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(333,514,l),
+(285,514,l),
+(384,263,l),
+(442,276,l),
+(177,276,l),
+(234,259,l)
+);
+}
+);
+width = 614;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C5;
+unicode = 5573;
+},
+{
+color = 9;
+glyphname = "gheCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (64,345);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(68,0,l),
+(527,323,l),
+(527,367,l),
+(68,690,l),
+(35,690,l),
+(35,574,l),
+(156,487,l),
+(151,549,l),
+(151,135,l),
+(156,201,l),
+(35,115,l),
+(35,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(248,501,l),
+(227,453,l),
+(429,309,l),
+(429,382,l),
+(227,239,l),
+(248,190,l)
+);
+}
+);
+width = 553;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15C6;
+unicode = 5574;
+},
+{
+color = 9;
+glyphname = "gheeCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (18,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 554;
+}
+);
+note = uni15C7;
+unicode = 5575;
+},
+{
+color = 9;
+glyphname = "ghiCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (-6,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 554;
+}
+);
+note = uni15C8;
+unicode = 5576;
+},
+{
+color = 9;
+glyphname = "ghaCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(519,0,l),
+(519,114,l),
+(399,200,l),
+(407,146,l),
+(407,544,l),
+(399,489,l),
+(519,574,l),
+(519,690,l),
+(486,690,l),
+(26,367,l),
+(26,323,l),
+(486,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(329,236,l),
+(126,381,l),
+(126,308,l),
+(329,453,l),
+(308,478,l),
+(308,220,l)
+);
+}
+);
+width = 554;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15C9;
+unicode = 5577;
+},
+{
+color = 9;
+glyphname = "ruCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(327,0,l),
+(596,655,l),
+(596,690,l),
+(482,690,l),
+(449,607,l),
+(478,623,l),
+(138,623,l),
+(172,606,l),
+(139,690,l),
+(18,690,l),
+(18,655,l),
+(287,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(448,517,l),
+(430,541,l),
+(288,177,l),
+(336,177,l),
+(193,540,l),
+(167,517,l)
+);
+}
+);
+width = 614;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CA;
+unicode = 5578;
+},
+{
+color = 9;
+glyphname = "roCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(138,0,l),
+(171,83,l),
+(140,67,l),
+(479,67,l),
+(447,84,l),
+(481,0,l),
+(596,0,l),
+(596,35,l),
+(327,690,l),
+(287,690,l),
+(18,35,l),
+(18,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(331,514,l),
+(283,514,l),
+(427,150,l),
+(451,173,l),
+(170,173,l),
+(189,149,l)
+);
+}
+);
+width = 614;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CB;
+unicode = 5579;
+},
+{
+color = 9;
+glyphname = "reCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(69,0,l),
+(527,323,l),
+(527,367,l),
+(69,690,l),
+(35,690,l),
+(35,571,l),
+(100,524,l),
+(86,557,l),
+(86,131,l),
+(100,166,l),
+(35,118,l),
+(35,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(188,531,l),
+(175,482,l),
+(418,308,l),
+(418,381,l),
+(175,207,l),
+(188,156,l)
+);
+}
+);
+width = 553;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CC;
+unicode = 5580;
+},
+{
+color = 9;
+glyphname = "reeCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(69,0,l),
+(527,323,l),
+(527,367,l),
+(69,690,l),
+(35,690,l),
+(35,589,l),
+(100,541,l),
+(86,559,l),
+(86,128,l),
+(100,147,l),
+(35,99,l),
+(35,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(173,534,l),
+(163,508,l),
+(446,308,l),
+(446,381,l),
+(161,179,l),
+(173,157,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(253,276,l),
+(253,413,l),
+(207,413,l),
+(207,276,l)
+);
+}
+);
+width = 553;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CD;
+unicode = 5581;
+},
+{
+color = 9;
+glyphname = "riCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(69,0,l),
+(527,323,l),
+(527,367,l),
+(69,690,l),
+(35,690,l),
+(35,589,l),
+(100,541,l),
+(86,559,l),
+(86,128,l),
+(100,147,l),
+(35,99,l),
+(35,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(269,300,o),
+(291,320,o),
+(291,345,cs),
+(291,370,o),
+(269,389,o),
+(245,389,cs),
+(222,389,o),
+(200,370,o),
+(200,345,cs),
+(200,320,o),
+(222,300,o),
+(245,300,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(173,534,l),
+(163,508,l),
+(446,308,l),
+(446,381,l),
+(161,179,l),
+(173,157,l)
+);
+}
+);
+width = 553;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CE;
+unicode = 5582;
+},
+{
+color = 9;
+glyphname = "raCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(519,0,l),
+(519,119,l),
+(455,166,l),
+(468,101,l),
+(468,589,l),
+(455,525,l),
+(519,572,l),
+(519,690,l),
+(485,690,l),
+(26,367,l),
+(26,323,l),
+(485,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(381,484,l),
+(366,534,l),
+(366,156,l),
+(381,207,l),
+(135,382,l),
+(135,309,l)
+);
+}
+);
+width = 554;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15CF;
+unicode = 5583;
+},
+{
+color = 9;
+glyphname = "wuCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(335,0,l),
+(611,655,l),
+(611,690,l),
+(504,690,l),
+(345,269,l),
+(373,269,l),
+(373,690,l),
+(268,690,l),
+(268,269,l),
+(297,269,l),
+(132,690,l),
+(18,690,l),
+(18,655,l),
+(295,0,l)
+);
+}
+);
+width = 629;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D0;
+unicode = 5584;
+},
+{
+color = 9;
+glyphname = "woCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(130,0,l),
+(293,421,l),
+(264,421,l),
+(264,0,l),
+(369,0,l),
+(369,421,l),
+(339,421,l),
+(503,0,l),
+(611,0,l),
+(611,35,l),
+(335,690,l),
+(295,690,l),
+(18,35,l),
+(18,0,l)
+);
+}
+);
+width = 629;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D1;
+unicode = 5585;
+},
+{
+color = 9;
+glyphname = "weCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(84,0,l),
+(544,323,l),
+(544,367,l),
+(84,690,l),
+(51,690,l),
+(51,575,l),
+(336,378,l),
+(336,398,l),
+(58,398,l),
+(58,292,l),
+(337,292,l),
+(337,311,l),
+(51,114,l),
+(51,0,l)
+);
+}
+);
+width = 570;
+}
+);
+metricRight = "o-canadian";
+note = uni15D2;
+unicode = 5586;
+},
+{
+color = 9;
+glyphname = "weeCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(84,0,l),
+(544,323,l),
+(544,367,l),
+(84,690,l),
+(51,690,l),
+(51,584,l),
+(391,353,l),
+(402,387,l),
+(185,387,l),
+(185,448,l),
+(112,448,l),
+(112,387,l),
+(51,387,l),
+(51,303,l),
+(112,303,l),
+(112,242,l),
+(185,242,l),
+(185,303,l),
+(402,303,l),
+(391,338,l),
+(51,104,l),
+(51,0,l)
+);
+}
+);
+width = 570;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D3;
+unicode = 5587;
+},
+{
+color = 9;
+glyphname = "wiCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(84,0,l),
+(544,323,l),
+(544,367,l),
+(84,690,l),
+(51,690,l),
+(51,584,l),
+(391,353,l),
+(402,387,l),
+(241,387,l),
+(227,412,o),
+(201,428,o),
+(171,428,cs),
+(140,428,o),
+(114,412,o),
+(100,387,c),
+(51,387,l),
+(51,303,l),
+(101,303,l),
+(115,279,o),
+(141,262,o),
+(171,262,cs),
+(200,262,o),
+(226,279,o),
+(240,303,c),
+(402,303,l),
+(391,338,l),
+(51,104,l),
+(51,0,l)
+);
+}
+);
+width = 570;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D4;
+unicode = 5588;
+},
+{
+color = 9;
+glyphname = "waCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(519,0,l),
+(519,115,l),
+(234,311,l),
+(234,292,l),
+(512,292,l),
+(512,398,l),
+(234,398,l),
+(234,378,l),
+(519,575,l),
+(519,690,l),
+(486,690,l),
+(26,367,l),
+(26,323,l),
+(486,0,l)
+);
+}
+);
+width = 570;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15D5;
+unicode = 5589;
+},
+{
+color = 9;
+glyphname = "hwuCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(335,0,l),
+(611,655,l),
+(611,690,l),
+(511,690,l),
+(444,527,l),
+(479,536,l),
+(357,536,l),
+(357,690,l),
+(275,690,l),
+(275,536,l),
+(148,536,l),
+(188,529,l),
+(123,690,l),
+(18,690,l),
+(18,655,l),
+(295,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(283,463,l),
+(283,203,l),
+(306,207,l),
+(205,470,l),
+(157,463,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(351,463,l),
+(470,463,l),
+(429,470,l),
+(327,207,l),
+(351,203,l)
+);
+}
+);
+width = 629;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D6;
+unicode = 5590;
+},
+{
+color = 9;
+glyphname = "hwoCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(122,0,l),
+(189,162,l),
+(157,148,l),
+(274,148,l),
+(274,0,l),
+(356,0,l),
+(356,148,l),
+(491,148,l),
+(445,160,l),
+(511,0,l),
+(611,0,l),
+(611,35,l),
+(335,690,l),
+(295,690,l),
+(18,35,l),
+(18,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(301,476,l),
+(282,480,l),
+(282,233,l),
+(186,233,l),
+(204,219,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(460,233,l),
+(350,233,l),
+(350,481,l),
+(329,477,l),
+(429,219,l)
+);
+}
+);
+width = 629;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D7;
+unicode = 5591;
+},
+{
+color = 9;
+glyphname = "hweCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(84,0,l),
+(544,323,l),
+(544,367,l),
+(84,690,l),
+(51,690,l),
+(51,584,l),
+(158,511,l),
+(158,389,l),
+(51,389,l),
+(51,300,l),
+(158,300,l),
+(158,178,l),
+(51,104,l),
+(51,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(226,310,l),
+(372,310,l),
+(226,213,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(226,476,l),
+(371,380,l),
+(226,380,l)
+);
+}
+);
+width = 570;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D8;
+unicode = 5592;
+},
+{
+color = 9;
+glyphname = "hweeCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(84,0,l),
+(544,323,l),
+(544,367,l),
+(84,690,l),
+(51,690,l),
+(51,590,l),
+(198,490,l),
+(198,383,l),
+(156,383,l),
+(156,445,l),
+(99,445,l),
+(99,383,l),
+(51,383,l),
+(51,308,l),
+(99,308,l),
+(99,244,l),
+(156,244,l),
+(156,308,l),
+(198,308,l),
+(198,198,l),
+(51,98,l),
+(51,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(258,315,l),
+(378,315,l),
+(258,231,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(258,458,l),
+(377,376,l),
+(258,376,l)
+);
+}
+);
+width = 570;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D9;
+unicode = 5593;
+},
+{
+color = 9;
+glyphname = "hwiCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(84,0,l),
+(544,323,l),
+(544,367,l),
+(84,690,l),
+(51,690,l),
+(51,590,l),
+(198,490,l),
+(198,376,l),
+(183,376,l),
+(173,396,o),
+(153,410,o),
+(129,410,cs),
+(106,410,o),
+(87,395,o),
+(76,376,c),
+(51,376,l),
+(51,315,l),
+(76,315,l),
+(87,295,o),
+(106,280,o),
+(129,280,cs),
+(151,280,o),
+(171,295,o),
+(182,315,c),
+(198,315,l),
+(198,198,l),
+(51,98,l),
+(51,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(258,315,l),
+(378,315,l),
+(258,231,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(258,458,l),
+(377,376,l),
+(258,376,l)
+);
+}
+);
+width = 570;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15DA;
+unicode = 5594;
+},
+{
+color = 9;
+glyphname = "hwaCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(519,0,l),
+(519,104,l),
+(412,178,l),
+(412,300,l),
+(519,300,l),
+(519,389,l),
+(412,389,l),
+(412,511,l),
+(519,584,l),
+(519,690,l),
+(486,690,l),
+(26,367,l),
+(26,323,l),
+(486,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(198,310,l),
+(344,310,l),
+(344,213,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(344,476,l),
+(344,380,l),
+(199,380,l)
+);
+}
+);
+width = 570;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15DB;
+unicode = 5595;
+},
+{
+color = 9;
+glyphname = "thuCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(477,-14,o),
+(570,85,o),
+(570,271,cs),
+(570,690,l),
+(48,690,l),
+(48,270,ls),
+(48,85,o),
+(145,-14,o),
+(310,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(189,563,l),
+(429,563,l),
+(429,272,ls),
+(429,163,o),
+(387,117,o),
+(309,117,cs),
+(234,117,o),
+(189,166,o),
+(189,272,cs)
+);
+}
+);
+width = 618;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DC;
+unicode = 5596;
+},
+{
+color = 9;
+glyphname = "thoCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(570,0,l),
+(570,419,ls),
+(570,605,o),
+(474,703,o),
+(310,703,cs),
+(143,703,o),
+(48,605,o),
+(48,419,cs),
+(48,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(189,417,ls),
+(189,526,o),
+(232,573,o),
+(310,573,cs),
+(385,573,o),
+(429,524,o),
+(429,417,cs),
+(429,127,l),
+(189,127,l)
+);
+}
+);
+width = 618;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DD;
+unicode = 5597;
+},
+{
+color = 9;
+glyphname = "theCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (307,345);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(243,0,ls),
+(453,0,o),
+(574,116,o),
+(574,346,cs),
+(574,576,o),
+(453,690,o),
+(242,690,cs),
+(51,690,l),
+(51,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(193,602,l),
+(156,565,l),
+(241,565,ls),
+(367,565,o),
+(432,500,o),
+(432,346,cs),
+(432,191,o),
+(367,125,o),
+(242,125,cs),
+(156,125,l),
+(193,88,l)
+);
+}
+);
+width = 618;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "to-canadian";
+note = uni15DE;
+unicode = 5598;
+},
+{
+color = 9;
+glyphname = "theeCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (251,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 617;
+}
+);
+note = uni15DF;
+unicode = 5599;
+},
+{
+color = 9;
+glyphname = "thiCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (224,0);
+ref = dot_middle;
+}
+);
+width = 617;
+}
+);
+note = uni15E0;
+unicode = 5600;
+},
+{
+color = 9;
+glyphname = "thaCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(568,0,l),
+(568,690,l),
+(376,690,ls),
+(165,690,o),
+(44,574,o),
+(44,344,cs),
+(44,114,o),
+(165,0,o),
+(377,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(187,498,o),
+(250,565,o),
+(376,565,cs),
+(462,565,l),
+(425,602,l),
+(425,88,l),
+(462,125,l),
+(377,125,ls),
+(250,125,o),
+(187,189,o),
+(187,344,cs)
+);
+}
+);
+width = 619;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15E1;
+unicode = 5601;
+},
+{
+color = 9;
+glyphname = "ttuCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(477,-14,o),
+(570,85,o),
+(570,271,cs),
+(570,690,l),
+(530,690,l),
+(292,515,l),
+(328,515,l),
+(90,690,l),
+(48,690,l),
+(48,270,ls),
+(48,85,o),
+(145,-14,o),
+(310,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(234,117,o),
+(189,166,o),
+(189,272,cs),
+(189,577,l),
+(61,573,l),
+(298,398,l),
+(322,398,l),
+(559,573,l),
+(429,577,l),
+(429,272,ls),
+(429,163,o),
+(387,117,o),
+(309,117,cs)
+);
+}
+);
+width = 618;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E2;
+unicode = 5602;
+},
+{
+color = 9;
+glyphname = "ttoCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(89,0,l),
+(327,175,l),
+(291,175,l),
+(528,0,l),
+(570,0,l),
+(570,419,ls),
+(570,605,o),
+(474,703,o),
+(309,703,cs),
+(142,703,o),
+(48,605,o),
+(48,418,cs),
+(48,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(385,573,o),
+(429,524,o),
+(429,417,cs),
+(429,113,l),
+(558,117,l),
+(321,292,l),
+(298,292,l),
+(60,117,l),
+(189,113,l),
+(189,417,ls),
+(189,526,o),
+(231,573,o),
+(310,573,cs)
+);
+}
+);
+width = 618;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E3;
+unicode = 5603;
+},
+{
+color = 9;
+glyphname = "tteCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (353,345);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(253,0,ls),
+(464,0,o),
+(584,116,o),
+(584,346,cs),
+(584,576,o),
+(464,690,o),
+(252,690,cs),
+(46,690,l),
+(46,655,l),
+(150,327,l),
+(150,361,l),
+(46,35,l),
+(46,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(280,333,l),
+(280,353,l),
+(176,680,l),
+(176,565,l),
+(252,565,ls),
+(379,565,o),
+(441,500,o),
+(441,346,cs),
+(441,191,o),
+(379,125,o),
+(253,125,cs),
+(176,125,l),
+(176,7,l)
+);
+}
+);
+width = 628;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15E4;
+unicode = 5604;
+},
+{
+color = 9;
+glyphname = "tteeCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (307,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 627;
+}
+);
+note = uni15E5;
+unicode = 5605;
+},
+{
+color = 9;
+glyphname = "ttiCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (299,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 627;
+}
+);
+note = uni15E6;
+unicode = 5606;
+},
+{
+color = 9;
+glyphname = "ttaCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(583,0,l),
+(583,35,l),
+(479,362,l),
+(479,328,l),
+(583,655,l),
+(583,690,l),
+(376,690,ls),
+(165,690,o),
+(44,574,o),
+(44,344,cs),
+(44,114,o),
+(165,0,o),
+(377,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(453,125,l),
+(377,125,ls),
+(250,125,o),
+(187,189,o),
+(187,344,cs),
+(187,498,o),
+(250,565,o),
+(376,565,cs),
+(453,565,l),
+(453,683,l),
+(349,356,l),
+(349,337,l),
+(453,10,l)
+);
+}
+);
+width = 629;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tteCarrier-canadian";
+note = uni15E7;
+unicode = 5607;
+},
+{
+color = 9;
+glyphname = "puCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(477,-14,o),
+(570,85,o),
+(570,271,cs),
+(570,690,l),
+(428,690,l),
+(428,548,l),
+(191,548,l),
+(191,690,l),
+(48,690,l),
+(48,270,ls),
+(48,85,o),
+(145,-14,o),
+(310,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(234,117,o),
+(191,166,o),
+(191,272,cs),
+(191,422,l),
+(428,422,l),
+(428,272,ls),
+(428,163,o),
+(387,117,o),
+(309,117,cs)
+);
+}
+);
+width = 618;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E8;
+unicode = 5608;
+},
+{
+color = 9;
+glyphname = "poCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(191,0,l),
+(191,142,l),
+(428,142,l),
+(428,0,l),
+(570,0,l),
+(570,419,ls),
+(570,605,o),
+(475,703,o),
+(310,703,cs),
+(149,703,o),
+(48,605,o),
+(48,419,cs),
+(48,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(191,417,ls),
+(191,526,o),
+(232,573,o),
+(310,573,cs),
+(385,573,o),
+(428,524,o),
+(428,417,cs),
+(428,268,l),
+(191,268,l)
+);
+}
+);
+width = 618;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E9;
+unicode = 5609;
+},
+{
+color = 9;
+glyphname = "peCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (339,345);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(252,0,ls),
+(463,0,o),
+(582,116,o),
+(582,346,cs),
+(582,576,o),
+(463,690,o),
+(250,690,cs),
+(45,690,l),
+(45,565,l),
+(112,565,l),
+(112,125,l),
+(45,125,l),
+(45,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(252,602,l),
+(197,565,l),
+(251,565,ls),
+(377,565,o),
+(440,500,o),
+(440,346,cs),
+(440,191,o),
+(377,125,o),
+(252,125,cs),
+(197,125,l),
+(252,88,l)
+);
+}
+);
+width = 626;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15EA;
+unicode = 5610;
+},
+{
+color = 9;
+glyphname = "peeCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (294,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 626;
+}
+);
+note = uni15EB;
+unicode = 5611;
+},
+{
+color = 9;
+glyphname = "piCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (286,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 626;
+}
+);
+note = uni15EC;
+unicode = 5612;
+},
+{
+color = 9;
+glyphname = "paCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(583,0,l),
+(583,125,l),
+(516,125,l),
+(516,565,l),
+(583,565,l),
+(583,690,l),
+(377,690,ls),
+(165,690,o),
+(44,576,o),
+(44,346,cs),
+(44,116,o),
+(165,0,o),
+(376,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(431,125,l),
+(376,125,ls),
+(250,125,o),
+(187,191,o),
+(187,346,cs),
+(187,500,o),
+(250,565,o),
+(377,565,cs),
+(431,565,l),
+(375,602,l),
+(375,88,l)
+);
+}
+);
+width = 628;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|peCarrier-canadian";
+note = uni15ED;
+unicode = 5613;
+},
+{
+color = 6;
+glyphname = "pCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(322,183,l),
+(322,272,l),
+(230,272,l),
+(230,527,l),
+(135,527,l),
+(135,272,l),
+(43,272,l),
+(43,183,l)
+);
+}
+);
+width = 365;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni15EE;
+unicode = 5614;
+},
+{
+color = 9;
+glyphname = "guCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (359,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(311,-14,o),
+(365,29,o),
+(392,118,c),
+(327,118,l),
+(359,27,o),
+(412,-14,o),
+(492,-14,cs),
+(600,-14,o),
+(671,59,o),
+(671,185,cs),
+(671,690,l),
+(536,690,l),
+(536,192,ls),
+(536,139,o),
+(517,114,o),
+(482,114,cs),
+(448,114,o),
+(426,140,o),
+(426,192,cs),
+(426,690,l),
+(294,690,l),
+(294,192,ls),
+(294,139,o),
+(273,114,o),
+(240,114,cs),
+(204,114,o),
+(184,139,o),
+(184,192,cs),
+(184,690,l),
+(48,690,l),
+(48,186,ls),
+(48,60,o),
+(122,-14,o),
+(230,-14,cs)
+);
+}
+);
+width = 719;
+}
+);
+metricRight = "=|";
+note = uni15EF;
+unicode = 5615;
+},
+{
+color = 9;
+glyphname = "goCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(184,0,l),
+(184,497,ls),
+(184,551,o),
+(203,576,o),
+(238,576,cs),
+(271,576,o),
+(294,551,o),
+(294,497,cs),
+(294,0,l),
+(426,0,l),
+(426,497,ls),
+(426,551,o),
+(446,576,o),
+(480,576,cs),
+(516,576,o),
+(536,551,o),
+(536,497,cs),
+(536,0,l),
+(671,0,l),
+(671,503,ls),
+(671,630,o),
+(598,703,o),
+(490,703,cs),
+(409,703,o),
+(355,661,o),
+(327,572,c),
+(392,572,l),
+(360,663,o),
+(307,703,o),
+(228,703,cs),
+(119,703,o),
+(48,631,o),
+(48,504,cs),
+(48,0,l)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F0;
+unicode = 5616;
+},
+{
+color = 9;
+glyphname = "geCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (313,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(363,0,ls),
+(498,0,o),
+(574,69,o),
+(574,192,cs),
+(574,273,o),
+(527,339,o),
+(457,368,c),
+(457,321,l),
+(530,347,o),
+(574,408,o),
+(574,496,cs),
+(574,618,o),
+(496,690,o),
+(363,690,cs),
+(51,690,l),
+(51,574,l),
+(334,574,ls),
+(396,574,o),
+(432,547,o),
+(432,490,cs),
+(432,431,o),
+(396,403,o),
+(335,403,cs),
+(51,403,l),
+(51,289,l),
+(335,289,ls),
+(395,289,o),
+(432,260,o),
+(432,201,cs),
+(432,143,o),
+(395,116,o),
+(334,116,cs),
+(51,116,l),
+(51,0,l)
+);
+}
+);
+width = 622;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15F1;
+unicode = 5617;
+},
+{
+color = 9;
+glyphname = "geeCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(363,0,ls),
+(498,0,o),
+(574,69,o),
+(574,192,cs),
+(574,273,o),
+(527,339,o),
+(457,368,c),
+(457,321,l),
+(530,347,o),
+(574,408,o),
+(574,496,cs),
+(574,618,o),
+(496,690,o),
+(363,690,cs),
+(51,690,l),
+(51,574,l),
+(334,574,ls),
+(396,574,o),
+(432,547,o),
+(432,490,cs),
+(432,431,o),
+(396,402,o),
+(335,402,cs),
+(296,402,l),
+(296,478,l),
+(221,478,l),
+(221,402,l),
+(51,402,l),
+(51,290,l),
+(221,290,l),
+(221,213,l),
+(296,213,l),
+(296,290,l),
+(335,290,ls),
+(395,290,o),
+(432,260,o),
+(432,201,cs),
+(432,143,o),
+(395,116,o),
+(334,116,cs),
+(51,116,l),
+(51,0,l)
+);
+}
+);
+width = 622;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F2;
+unicode = 5618;
+},
+{
+color = 9;
+glyphname = "giCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(363,0,ls),
+(498,0,o),
+(574,69,o),
+(574,192,cs),
+(574,272,o),
+(528,337,o),
+(460,366,c),
+(460,323,l),
+(531,349,o),
+(574,409,o),
+(574,496,cs),
+(574,618,o),
+(496,690,o),
+(363,690,cs),
+(51,690,l),
+(51,574,l),
+(334,574,ls),
+(396,574,o),
+(432,547,o),
+(432,490,cs),
+(432,431,o),
+(396,402,o),
+(348,402,cs),
+(309,402,l),
+(356,383,l),
+(343,417,o),
+(311,441,o),
+(270,441,cs),
+(239,441,o),
+(211,426,o),
+(194,402,c),
+(51,402,l),
+(51,290,l),
+(193,290,l),
+(210,265,o),
+(238,248,o),
+(270,248,cs),
+(311,248,o),
+(343,273,o),
+(356,309,c),
+(309,290,l),
+(347,290,ls),
+(395,290,o),
+(432,260,o),
+(432,201,cs),
+(432,143,o),
+(395,116,o),
+(334,116,cs),
+(51,116,l),
+(51,0,l)
+);
+}
+);
+width = 622;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F3;
+unicode = 5619;
+},
+{
+color = 9;
+glyphname = "gaCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (325,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(572,0,l),
+(572,116,l),
+(288,116,ls),
+(228,116,o),
+(191,143,o),
+(191,201,cs),
+(191,260,o),
+(228,289,o),
+(288,289,cs),
+(572,289,l),
+(572,403,l),
+(287,403,ls),
+(226,403,o),
+(191,431,o),
+(191,490,cs),
+(191,547,o),
+(227,574,o),
+(288,574,cs),
+(572,574,l),
+(572,690,l),
+(260,690,ls),
+(128,690,o),
+(48,618,o),
+(48,496,cs),
+(48,408,o),
+(93,347,o),
+(166,321,c),
+(166,369,l),
+(96,339,o),
+(48,273,o),
+(48,192,cs),
+(48,69,o),
+(125,0,o),
+(260,0,cs)
+);
+}
+);
+width = 623;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|geCarrier-canadian";
+note = uni15F4;
+unicode = 5620;
+},
+{
+color = 9;
+glyphname = "khuCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(311,-14,o),
+(366,29,o),
+(392,118,c),
+(327,118,l),
+(359,27,o),
+(412,-14,o),
+(492,-14,cs),
+(601,-14,o),
+(671,59,o),
+(671,185,cs),
+(671,690,l),
+(48,690,l),
+(48,186,ls),
+(48,60,o),
+(122,-14,o),
+(230,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(205,114,o),
+(185,139,o),
+(185,192,cs),
+(185,567,l),
+(296,567,l),
+(296,192,ls),
+(296,139,o),
+(275,114,o),
+(241,114,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(447,114,o),
+(425,140,o),
+(425,192,cs),
+(425,567,l),
+(535,567,l),
+(535,192,ls),
+(535,139,o),
+(516,114,o),
+(481,114,cs)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F5;
+unicode = 5621;
+},
+{
+color = 9;
+glyphname = "khoCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(671,0,l),
+(671,503,ls),
+(671,630,o),
+(599,703,o),
+(490,703,cs),
+(410,703,o),
+(355,662,o),
+(327,572,c),
+(392,572,l),
+(361,662,o),
+(308,703,o),
+(228,703,cs),
+(120,703,o),
+(48,632,o),
+(48,504,cs),
+(48,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(185,497,ls),
+(185,551,o),
+(205,576,o),
+(240,576,cs),
+(273,576,o),
+(295,551,o),
+(295,497,cs),
+(295,123,l),
+(185,123,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(425,497,ls),
+(425,551,o),
+(445,576,o),
+(480,576,cs),
+(515,576,o),
+(535,551,o),
+(535,497,cs),
+(535,123,l),
+(425,123,l)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F6;
+unicode = 5622;
+},
+{
+color = 9;
+glyphname = "kheCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(369,0,ls),
+(504,0,o),
+(581,69,o),
+(581,192,cs),
+(581,273,o),
+(533,339,o),
+(463,368,c),
+(463,321,l),
+(536,347,o),
+(581,408,o),
+(581,496,cs),
+(581,618,o),
+(501,690,o),
+(369,690,cs),
+(51,690,l),
+(51,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(192,289,l),
+(341,289,ls),
+(401,289,o),
+(438,260,o),
+(438,201,cs),
+(438,143,o),
+(401,114,o),
+(341,114,cs),
+(192,114,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(192,576,l),
+(341,576,ls),
+(402,576,o),
+(438,547,o),
+(438,490,cs),
+(438,431,o),
+(402,402,o),
+(341,402,cs),
+(192,402,l)
+);
+}
+);
+width = 629;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F7;
+unicode = 5623;
+},
+{
+color = 9;
+glyphname = "kheeCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(369,0,ls),
+(504,0,o),
+(581,69,o),
+(581,192,cs),
+(581,269,o),
+(539,329,o),
+(475,359,c),
+(475,327,l),
+(541,354,o),
+(581,413,o),
+(581,496,cs),
+(581,618,o),
+(501,690,o),
+(369,690,cs),
+(51,690,l),
+(51,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(192,290,l),
+(270,290,l),
+(270,211,l),
+(346,211,l),
+(346,324,l),
+(298,290,l),
+(354,290,ls),
+(407,290,o),
+(438,261,o),
+(438,201,cs),
+(438,143,o),
+(401,114,o),
+(341,114,cs),
+(192,114,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(346,480,l),
+(270,480,l),
+(270,402,l),
+(192,402,l),
+(192,576,l),
+(341,576,ls),
+(402,576,o),
+(438,547,o),
+(438,490,cs),
+(438,431,o),
+(409,402,o),
+(354,402,cs),
+(298,402,l),
+(346,367,l)
+);
+}
+);
+width = 629;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F8;
+unicode = 5624;
+},
+{
+color = 9;
+glyphname = "khiCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(369,0,ls),
+(504,0,o),
+(581,69,o),
+(581,192,cs),
+(581,272,o),
+(535,335,o),
+(469,366,c),
+(468,323,l),
+(538,348,o),
+(581,410,o),
+(581,496,cs),
+(581,618,o),
+(501,690,o),
+(369,690,cs),
+(51,690,l),
+(51,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(192,296,l),
+(228,296,l),
+(244,268,o),
+(273,248,o),
+(307,248,cs),
+(356,248,o),
+(392,289,o),
+(398,336,c),
+(321,296,l),
+(359,296,ls),
+(407,296,o),
+(438,266,o),
+(438,204,cs),
+(438,141,o),
+(401,114,o),
+(341,114,cs),
+(192,114,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(341,576,ls),
+(402,576,o),
+(438,549,o),
+(438,486,cs),
+(438,426,o),
+(409,395,o),
+(360,395,cs),
+(321,395,l),
+(398,354,l),
+(392,403,o),
+(356,441,o),
+(307,441,cs),
+(258,441,o),
+(220,403,o),
+(214,355,c),
+(250,395,l),
+(192,395,l),
+(192,576,l)
+);
+}
+);
+width = 629;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F9;
+unicode = 5625;
+},
+{
+color = 9;
+glyphname = "khaCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(578,0,l),
+(578,690,l),
+(260,690,ls),
+(128,690,o),
+(48,618,o),
+(48,496,cs),
+(48,410,o),
+(90,349,o),
+(161,323,c),
+(160,366,l),
+(94,336,o),
+(48,272,o),
+(48,192,cs),
+(48,69,o),
+(125,0,o),
+(260,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(228,114,o),
+(191,143,o),
+(191,201,cs),
+(191,260,o),
+(228,289,o),
+(288,289,cs),
+(437,289,l),
+(437,114,l),
+(288,114,ls)
+);
+},
+{
+closed = 1;
+nodes = (
+(226,402,o),
+(191,431,o),
+(191,490,cs),
+(191,547,o),
+(227,576,o),
+(288,576,cs),
+(437,576,l),
+(437,402,l),
+(287,402,ls)
+);
+}
+);
+width = 629;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15FA;
+unicode = 5626;
+},
+{
+color = 9;
+glyphname = "kkuCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(311,-14,o),
+(366,30,o),
+(392,119,c),
+(327,119,l),
+(358,28,o),
+(412,-14,o),
+(492,-14,cs),
+(600,-14,o),
+(671,59,o),
+(671,185,cs),
+(671,690,l),
+(631,690,l),
+(403,550,l),
+(403,418,l),
+(571,520,l),
+(536,539,l),
+(536,192,ls),
+(536,139,o),
+(516,114,o),
+(481,114,cs),
+(447,114,o),
+(425,140,o),
+(425,192,cs),
+(425,690,l),
+(296,690,l),
+(296,192,ls),
+(296,139,o),
+(274,114,o),
+(240,114,cs),
+(204,114,o),
+(184,139,o),
+(184,192,cs),
+(184,539,l),
+(150,520,l),
+(313,421,l),
+(313,554,l),
+(89,690,l),
+(48,690,l),
+(48,186,ls),
+(48,60,o),
+(122,-14,o),
+(230,-14,cs)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FB;
+unicode = 5627;
+},
+{
+color = 9;
+glyphname = "kkoCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(88,0,l),
+(317,140,l),
+(317,271,l),
+(149,170,l),
+(184,151,l),
+(184,497,ls),
+(184,551,o),
+(204,576,o),
+(238,576,cs),
+(271,576,o),
+(295,550,o),
+(295,497,cs),
+(295,0,l),
+(424,0,l),
+(424,497,ls),
+(424,551,o),
+(445,576,o),
+(480,576,cs),
+(515,576,o),
+(536,551,o),
+(536,497,cs),
+(536,151,l),
+(570,170,l),
+(407,269,l),
+(407,136,l),
+(630,0,l),
+(671,0,l),
+(671,503,ls),
+(671,630,o),
+(598,703,o),
+(490,703,cs),
+(409,703,o),
+(354,660,o),
+(327,571,c),
+(392,571,l),
+(360,662,o),
+(307,703,o),
+(228,703,cs),
+(119,703,o),
+(48,631,o),
+(48,504,cs),
+(48,0,l)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FC;
+unicode = 5628;
+},
+{
+color = 9;
+glyphname = "kkeCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(383,0,ls),
+(518,0,o),
+(593,69,o),
+(593,192,cs),
+(593,272,o),
+(549,335,o),
+(482,366,c),
+(480,323,l),
+(552,348,o),
+(593,410,o),
+(593,496,cs),
+(593,618,o),
+(515,690,o),
+(383,690,cs),
+(48,690,l),
+(48,655,l),
+(128,403,l),
+(59,403,l),
+(59,289,l),
+(128,289,l),
+(48,35,l),
+(48,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(270,289,l),
+(355,289,ls),
+(414,289,o),
+(451,260,o),
+(451,201,cs),
+(451,143,o),
+(414,116,o),
+(354,116,cs),
+(153,116,l),
+(196,55,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(194,635,l),
+(151,574,l),
+(354,574,ls),
+(414,574,o),
+(451,547,o),
+(451,490,cs),
+(451,431,o),
+(415,403,o),
+(355,403,cs),
+(269,403,l)
+);
+}
+);
+width = 641;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni15FD;
+unicode = 5629;
+},
+{
+color = 9;
+glyphname = "kkeeCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(383,0,ls),
+(518,0,o),
+(593,69,o),
+(593,192,cs),
+(593,272,o),
+(549,335,o),
+(482,366,c),
+(480,323,l),
+(552,348,o),
+(593,410,o),
+(593,496,cs),
+(593,618,o),
+(515,690,o),
+(383,690,cs),
+(48,690,l),
+(48,655,l),
+(128,403,l),
+(59,403,l),
+(59,289,l),
+(128,289,l),
+(48,35,l),
+(48,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(268,293,l),
+(302,293,l),
+(302,213,l),
+(379,213,l),
+(379,318,l),
+(329,293,l),
+(368,293,ls),
+(420,293,o),
+(451,264,o),
+(451,203,cs),
+(451,144,o),
+(414,116,o),
+(354,116,cs),
+(149,116,l),
+(193,55,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(379,478,l),
+(302,478,l),
+(302,399,l),
+(266,399,l),
+(191,635,l),
+(148,574,l),
+(354,574,ls),
+(414,574,o),
+(451,546,o),
+(451,488,cs),
+(451,427,o),
+(421,399,o),
+(368,399,cs),
+(329,399,l),
+(379,380,l)
+);
+}
+);
+width = 641;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FE;
+unicode = 5630;
+},
+{
+color = 9;
+glyphname = "kkiCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(383,0,ls),
+(518,0,o),
+(593,69,o),
+(593,192,cs),
+(593,272,o),
+(549,335,o),
+(482,366,c),
+(480,323,l),
+(552,348,o),
+(593,410,o),
+(593,496,cs),
+(593,618,o),
+(515,690,o),
+(383,690,cs),
+(48,690,l),
+(48,655,l),
+(128,403,l),
+(59,403,l),
+(59,289,l),
+(128,289,l),
+(48,35,l),
+(48,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(270,298,l),
+(260,298,l),
+(272,269,o),
+(301,248,o),
+(337,248,cs),
+(388,248,o),
+(420,292,o),
+(422,329,c),
+(349,298,l),
+(368,298,ls),
+(420,298,o),
+(451,264,o),
+(451,198,cs),
+(451,144,o),
+(414,116,o),
+(354,116,cs),
+(149,116,l),
+(193,55,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(420,401,o),
+(390,441,o),
+(337,441,cs),
+(301,441,o),
+(273,422,o),
+(260,392,c),
+(268,392,l),
+(191,635,l),
+(148,574,l),
+(354,574,ls),
+(414,574,o),
+(451,546,o),
+(451,483,cs),
+(451,427,o),
+(421,392,o),
+(368,392,cs),
+(350,392,l),
+(424,361,l)
+);
+}
+);
+width = 641;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FF;
+unicode = 5631;
+},
+{
+color = 9;
+glyphname = "kkaCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(593,0,l),
+(593,35,l),
+(514,289,l),
+(582,289,l),
+(582,403,l),
+(514,403,l),
+(593,655,l),
+(593,690,l),
+(260,690,ls),
+(128,690,o),
+(48,618,o),
+(48,496,cs),
+(48,410,o),
+(90,349,o),
+(161,323,c),
+(160,366,l),
+(94,336,o),
+(48,272,o),
+(48,192,cs),
+(48,69,o),
+(125,0,o),
+(260,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(490,116,l),
+(288,116,ls),
+(228,116,o),
+(191,143,o),
+(191,201,cs),
+(191,260,o),
+(228,289,o),
+(288,289,cs),
+(372,289,l),
+(446,55,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(226,403,o),
+(191,431,o),
+(191,490,cs),
+(191,547,o),
+(227,574,o),
+(288,574,cs),
+(491,574,l),
+(447,635,l),
+(373,403,l),
+(287,403,ls)
+);
+}
+);
+width = 641;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|kkeCarrier-canadian";
+note = uni1600;
+unicode = 5632;
+},
+{
+color = 6;
+glyphname = "kkCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(180,183,l),
+(314,510,l),
+(314,527,l),
+(221,527,l),
+(136,289,l),
+(203,289,l),
+(117,527,l),
+(24,527,l),
+(24,510,l),
+(158,183,l)
+);
+}
+);
+width = 338;
+}
+);
+note = uni1601;
+unicode = 5633;
+},
+{
+color = 9;
+glyphname = "nuCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(478,-14,o),
+(570,84,o),
+(570,265,cs),
+(570,308,l),
+(429,308,l),
+(429,256,ls),
+(429,161,o),
+(387,117,o),
+(311,117,cs),
+(233,117,o),
+(191,164,o),
+(191,264,cs),
+(191,690,l),
+(48,690,l),
+(48,270,ls),
+(48,84,o),
+(144,-14,o),
+(311,-14,cs)
+);
+}
+);
+width = 609;
+}
+);
+metricLeft = "te-canadian";
+note = uni1602;
+unicode = 5634;
+},
+{
+color = 9;
+glyphname = "noCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(560,0,l),
+(560,420,ls),
+(560,606,o),
+(465,703,o),
+(298,703,cs),
+(130,703,o),
+(39,606,o),
+(39,425,cs),
+(39,382,l),
+(180,382,l),
+(180,434,ls),
+(180,528,o),
+(221,573,o),
+(298,573,cs),
+(377,573,o),
+(418,526,o),
+(418,426,cs),
+(418,0,l)
+);
+}
+);
+width = 608;
+}
+);
+metricLeft = "=|nuCarrier-canadian";
+metricRight = "te-canadian";
+note = uni1603;
+unicode = 5635;
+},
+{
+color = 9;
+glyphname = "neCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (276,345);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(249,0,ls),
+(456,0,o),
+(578,116,o),
+(578,346,cs),
+(578,576,o),
+(457,690,o),
+(245,690,cs),
+(33,690,l),
+(33,560,l),
+(245,560,ls),
+(366,560,o),
+(436,497,o),
+(436,346,cs),
+(436,194,o),
+(364,129,o),
+(249,129,cs),
+(239,129,l),
+(239,0,l)
+);
+}
+);
+width = 622;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1604;
+unicode = 5636;
+},
+{
+color = 9;
+glyphname = "neeCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+ref = "neCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (220,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 622;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1605;
+unicode = 5637;
+},
+{
+color = 9;
+glyphname = "niCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "neCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (192,0);
+ref = dot_middle;
+}
+);
+width = 620;
+}
+);
+note = uni1606;
+unicode = 5638;
+},
+{
+color = 9;
+glyphname = "naCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(589,0,l),
+(589,129,l),
+(377,129,ls),
+(257,129,o),
+(187,192,o),
+(187,344,cs),
+(187,496,o),
+(258,560,o),
+(373,560,cs),
+(384,560,l),
+(384,690,l),
+(373,690,ls),
+(166,690,o),
+(44,574,o),
+(44,344,cs),
+(44,114,o),
+(165,0,o),
+(377,0,cs)
+);
+}
+);
+width = 622;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni1607;
+unicode = 5639;
+},
+{
+color = 9;
+glyphname = "muCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(311,-14,o),
+(365,29,o),
+(392,118,c),
+(327,118,l),
+(359,27,o),
+(412,-14,o),
+(492,-14,cs),
+(600,-14,o),
+(671,59,o),
+(671,185,cs),
+(671,394,l),
+(536,394,l),
+(536,192,ls),
+(536,139,o),
+(517,114,o),
+(482,114,cs),
+(448,114,o),
+(426,140,o),
+(426,192,cs),
+(426,394,l),
+(294,394,l),
+(294,192,ls),
+(294,139,o),
+(273,114,o),
+(240,114,cs),
+(204,114,o),
+(184,139,o),
+(184,192,cs),
+(184,690,l),
+(48,690,l),
+(48,186,ls),
+(48,60,o),
+(122,-14,o),
+(230,-14,cs)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "=|";
+note = uni1608;
+unicode = 5640;
+},
+{
+color = 9;
+glyphname = "moCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(671,0,l),
+(671,503,ls),
+(671,630,o),
+(598,703,o),
+(490,703,cs),
+(409,703,o),
+(355,661,o),
+(327,572,c),
+(392,572,l),
+(360,663,o),
+(307,703,o),
+(228,703,cs),
+(119,703,o),
+(48,631,o),
+(48,504,cs),
+(48,296,l),
+(184,296,l),
+(184,497,ls),
+(184,551,o),
+(203,576,o),
+(238,576,cs),
+(271,576,o),
+(294,550,o),
+(294,497,cs),
+(294,296,l),
+(426,296,l),
+(426,497,ls),
+(426,551,o),
+(446,576,o),
+(480,576,cs),
+(516,576,o),
+(536,551,o),
+(536,497,cs),
+(536,0,l)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "=|muCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni1609;
+unicode = 5641;
+},
+{
+color = 9;
+glyphname = "meCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(366,0,ls),
+(502,0,o),
+(578,69,o),
+(578,192,cs),
+(578,273,o),
+(531,339,o),
+(461,368,c),
+(461,321,l),
+(534,347,o),
+(578,408,o),
+(578,496,cs),
+(578,618,o),
+(499,690,o),
+(366,690,cs),
+(33,690,l),
+(33,574,l),
+(338,574,ls),
+(399,574,o),
+(435,547,o),
+(435,490,cs),
+(435,431,o),
+(400,403,o),
+(339,403,cs),
+(242,403,l),
+(242,289,l),
+(338,289,ls),
+(398,289,o),
+(435,260,o),
+(435,201,cs),
+(435,143,o),
+(399,116,o),
+(338,116,cs),
+(242,116,l),
+(242,0,l)
+);
+}
+);
+width = 626;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160A;
+unicode = 5642;
+},
+{
+color = 9;
+glyphname = "meeCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(366,0,ls),
+(502,0,o),
+(578,69,o),
+(578,192,cs),
+(578,272,o),
+(533,335,o),
+(467,366,c),
+(465,323,l),
+(536,348,o),
+(578,410,o),
+(578,496,cs),
+(578,618,o),
+(499,690,o),
+(366,690,cs),
+(33,690,l),
+(33,574,l),
+(338,574,ls),
+(399,574,o),
+(435,546,o),
+(435,488,cs),
+(435,429,o),
+(404,400,o),
+(350,400,cs),
+(325,400,l),
+(325,472,l),
+(242,472,l),
+(242,217,l),
+(325,217,l),
+(325,292,l),
+(348,292,ls),
+(404,292,o),
+(435,263,o),
+(435,202,cs),
+(435,144,o),
+(399,116,o),
+(338,116,cs),
+(242,116,l),
+(242,0,l)
+);
+}
+);
+width = 626;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160B;
+unicode = 5643;
+},
+{
+color = 9;
+glyphname = "miCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(366,0,ls),
+(502,0,o),
+(578,69,o),
+(578,192,cs),
+(578,272,o),
+(533,335,o),
+(467,366,c),
+(465,323,l),
+(536,348,o),
+(578,410,o),
+(578,496,cs),
+(578,618,o),
+(499,690,o),
+(366,690,cs),
+(33,690,l),
+(33,574,l),
+(338,574,ls),
+(399,574,o),
+(435,546,o),
+(435,488,cs),
+(435,429,o),
+(404,400,o),
+(356,400,cs),
+(302,400,l),
+(382,361,l),
+(375,407,o),
+(338,441,o),
+(289,441,cs),
+(235,441,o),
+(194,399,o),
+(194,346,cs),
+(194,291,o),
+(235,248,o),
+(289,248,cs),
+(337,248,o),
+(374,286,o),
+(380,329,c),
+(301,292,l),
+(355,292,ls),
+(404,292,o),
+(435,263,o),
+(435,202,cs),
+(435,144,o),
+(399,116,o),
+(338,116,cs),
+(242,116,l),
+(242,0,l)
+);
+}
+);
+width = 626;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160C;
+unicode = 5644;
+},
+{
+color = 9;
+glyphname = "maCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(593,0,l),
+(593,116,l),
+(288,116,ls),
+(227,116,o),
+(191,143,o),
+(191,200,cs),
+(191,259,o),
+(227,287,o),
+(287,287,cs),
+(384,287,l),
+(384,402,l),
+(288,402,ls),
+(228,402,o),
+(191,430,o),
+(191,489,cs),
+(191,546,o),
+(228,574,o),
+(288,574,cs),
+(384,574,l),
+(384,690,l),
+(260,690,ls),
+(125,690,o),
+(48,621,o),
+(48,497,cs),
+(48,414,o),
+(95,350,o),
+(166,322,c),
+(166,369,l),
+(93,342,o),
+(48,280,o),
+(48,193,cs),
+(48,71,o),
+(127,0,o),
+(260,0,cs)
+);
+}
+);
+width = 626;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni160D;
+unicode = 5645;
+},
+{
+color = 9;
+glyphname = "yuCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(511,-14,o),
+(618,126,o),
+(618,383,cs),
+(618,609,o),
+(542,703,o),
+(427,703,cs),
+(323,703,o),
+(257,623,o),
+(257,492,cs),
+(257,366,o),
+(323,293,o),
+(412,293,cs),
+(424,293,o),
+(437,295,o),
+(447,298,c),
+(447,408,l),
+(442,407,o),
+(438,406,o),
+(429,406,cs),
+(397,406,o),
+(377,433,o),
+(377,498,cs),
+(377,562,o),
+(393,590,o),
+(423,590,cs),
+(461,590,o),
+(483,551,o),
+(483,387,cs),
+(483,185,o),
+(424,117,o),
+(325,117,cs),
+(241,117,o),
+(191,168,o),
+(191,275,cs),
+(191,690,l),
+(48,690,l),
+(48,279,ls),
+(48,86,o),
+(156,-14,o),
+(320,-14,cs)
+);
+}
+);
+width = 666;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160E;
+unicode = 5646;
+},
+{
+color = 9;
+glyphname = "yoCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(344,-14,o),
+(410,67,o),
+(410,198,cs),
+(410,324,o),
+(345,397,o),
+(254,397,cs),
+(242,397,o),
+(230,395,o),
+(220,391,c),
+(220,282,l),
+(225,283,o),
+(230,284,o),
+(238,284,cs),
+(270,284,o),
+(291,257,o),
+(291,191,cs),
+(291,128,o),
+(273,99,o),
+(243,99,cs),
+(207,99,o),
+(184,139,o),
+(184,302,cs),
+(184,505,o),
+(242,573,o),
+(343,573,cs),
+(427,573,o),
+(476,522,o),
+(476,414,cs),
+(476,0,l),
+(618,0,l),
+(618,411,ls),
+(618,604,o),
+(512,703,o),
+(348,703,cs),
+(156,703,o),
+(48,564,o),
+(48,307,cs),
+(48,81,o),
+(125,-14,o),
+(241,-14,cs)
+);
+}
+);
+width = 666;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160F;
+unicode = 5647;
+},
+{
+color = 9;
+glyphname = "yeCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(458,-14,o),
+(570,122,o),
+(570,335,cs),
+(570,577,o),
+(448,690,o),
+(226,690,cs),
+(46,690,l),
+(46,560,l),
+(229,560,ls),
+(358,560,o),
+(427,497,o),
+(427,331,cs),
+(427,186,o),
+(384,106,o),
+(276,106,cs),
+(192,106,o),
+(156,152,o),
+(156,221,cs),
+(156,280,o),
+(174,306,o),
+(203,306,cs),
+(233,306,o),
+(250,279,o),
+(250,222,cs),
+(250,203,o),
+(249,190,o),
+(248,179,c),
+(354,179,l),
+(357,195,o),
+(359,212,o),
+(359,233,cs),
+(359,340,o),
+(306,419,o),
+(203,419,cs),
+(99,419,o),
+(36,337,o),
+(36,219,cs),
+(36,88,o),
+(120,-14,o),
+(276,-14,cs)
+);
+}
+);
+width = 614;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1610;
+unicode = 5648;
+},
+{
+color = 9;
+glyphname = "yeeCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(458,-14,o),
+(570,122,o),
+(570,335,cs),
+(570,577,o),
+(448,690,o),
+(226,690,cs),
+(46,690,l),
+(46,560,l),
+(229,560,ls),
+(358,560,o),
+(427,497,o),
+(427,331,cs),
+(427,186,o),
+(384,106,o),
+(276,106,cs),
+(192,106,o),
+(156,152,o),
+(156,222,cs),
+(156,278,o),
+(174,306,o),
+(201,306,cs),
+(229,306,o),
+(246,278,o),
+(246,227,cs),
+(246,187,l),
+(315,187,l),
+(315,488,l),
+(246,488,l),
+(246,315,l),
+(260,315,l),
+(258,380,o),
+(226,419,o),
+(169,419,cs),
+(94,419,o),
+(36,344,o),
+(36,220,cs),
+(36,88,o),
+(120,-14,o),
+(275,-14,cs)
+);
+}
+);
+width = 614;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1611;
+unicode = 5649;
+},
+{
+color = 9;
+glyphname = "yiCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(458,-14,o),
+(570,122,o),
+(570,335,cs),
+(570,577,o),
+(448,690,o),
+(226,690,cs),
+(46,690,l),
+(46,560,l),
+(229,560,ls),
+(358,560,o),
+(427,497,o),
+(427,331,cs),
+(427,186,o),
+(384,106,o),
+(282,106,cs),
+(195,106,o),
+(156,154,o),
+(156,221,cs),
+(156,280,o),
+(178,305,o),
+(213,306,c),
+(171,329,l),
+(178,292,o),
+(213,260,o),
+(259,260,cs),
+(310,260,o),
+(347,298,o),
+(347,346,cs),
+(347,394,o),
+(310,431,o),
+(259,431,cs),
+(227,431,o),
+(200,415,o),
+(185,393,c),
+(94,384,o),
+(36,315,o),
+(36,208,cs),
+(36,87,o),
+(120,-14,o),
+(276,-14,cs)
+);
+}
+);
+width = 614;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1612;
+unicode = 5650;
+},
+{
+color = 9;
+glyphname = "yaCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(568,0,l),
+(568,129,l),
+(385,129,ls),
+(256,129,o),
+(187,192,o),
+(187,358,cs),
+(187,503,o),
+(230,583,o),
+(340,583,cs),
+(422,583,o),
+(459,538,o),
+(459,469,cs),
+(459,410,o),
+(441,384,o),
+(412,384,cs),
+(382,384,o),
+(364,411,o),
+(364,468,cs),
+(364,487,o),
+(365,499,o),
+(366,511,c),
+(261,511,l),
+(257,495,o),
+(255,478,o),
+(255,457,cs),
+(255,350,o),
+(308,270,o),
+(412,270,cs),
+(516,270,o),
+(579,353,o),
+(579,470,cs),
+(579,602,o),
+(495,703,o),
+(340,703,cs),
+(157,703,o),
+(44,568,o),
+(44,355,cs),
+(44,113,o),
+(166,0,o),
+(388,0,cs)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|yeCarrier-canadian";
+note = uni1613;
+unicode = 5651;
+},
+{
+color = 9;
+glyphname = "juCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(499,-14,o),
+(584,87,o),
+(584,220,cs),
+(584,337,o),
+(522,419,o),
+(418,419,cs),
+(314,419,o),
+(261,340,o),
+(261,233,cs),
+(261,212,o),
+(263,195,o),
+(267,179,c),
+(373,179,l),
+(372,190,o),
+(370,205,o),
+(370,222,cs),
+(370,278,o),
+(387,306,o),
+(417,306,cs),
+(446,306,o),
+(465,278,o),
+(465,222,cs),
+(465,151,o),
+(428,106,o),
+(343,106,cs),
+(237,106,o),
+(189,175,o),
+(189,296,cs),
+(189,497,o),
+(301,560,o),
+(472,560,cs),
+(574,560,l),
+(574,690,l),
+(41,690,l),
+(41,565,l),
+(266,565,l),
+(373,617,l),
+(172,617,o),
+(48,501,o),
+(48,291,cs),
+(48,109,o),
+(156,-14,o),
+(335,-14,cs)
+);
+}
+);
+width = 620;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni1614;
+unicode = 5652;
+},
+{
+color = 9;
+glyphname = "juSayisi-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (312,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(464,-14,o),
+(572,109,o),
+(572,291,cs),
+(572,501,o),
+(448,617,o),
+(248,617,c),
+(355,565,l),
+(580,565,l),
+(580,690,l),
+(46,690,l),
+(46,560,l),
+(148,560,ls),
+(319,560,o),
+(431,497,o),
+(431,296,cs),
+(431,175,o),
+(384,106,o),
+(277,106,cs),
+(192,106,o),
+(156,151,o),
+(156,222,cs),
+(156,278,o),
+(174,306,o),
+(203,306,cs),
+(233,306,o),
+(250,278,o),
+(250,222,cs),
+(250,205,o),
+(249,190,o),
+(248,179,c),
+(354,179,l),
+(357,195,o),
+(359,212,o),
+(359,233,cs),
+(359,340,o),
+(306,419,o),
+(203,419,cs),
+(99,419,o),
+(36,337,o),
+(36,220,cs),
+(36,87,o),
+(121,-14,o),
+(285,-14,cs)
+);
+}
+);
+width = 621;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1615;
+unicode = 5653;
+},
+{
+color = 9;
+glyphname = "joCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(580,0,l),
+(580,125,l),
+(355,125,l),
+(248,72,l),
+(448,72,o),
+(572,188,o),
+(572,399,cs),
+(572,581,o),
+(464,703,o),
+(285,703,cs),
+(121,703,o),
+(36,603,o),
+(36,469,cs),
+(36,353,o),
+(99,270,o),
+(203,270,cs),
+(306,270,o),
+(359,350,o),
+(359,457,cs),
+(359,478,o),
+(357,495,o),
+(354,511,c),
+(248,511,l),
+(249,499,o),
+(250,485,o),
+(250,468,cs),
+(250,412,o),
+(233,384,o),
+(203,384,cs),
+(174,384,o),
+(156,412,o),
+(156,468,cs),
+(156,539,o),
+(192,583,o),
+(277,583,cs),
+(384,583,o),
+(431,515,o),
+(431,394,cs),
+(431,193,o),
+(319,129,o),
+(148,129,cs),
+(46,129,l),
+(46,0,l)
+);
+}
+);
+width = 621;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1616;
+unicode = 5654;
+},
+{
+color = 9;
+glyphname = "jeCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(545,-14,o),
+(621,81,o),
+(621,307,cs),
+(621,565,o),
+(514,703,o),
+(368,703,cs),
+(248,703,o),
+(175,618,o),
+(166,450,c),
+(192,454,l),
+(192,690,l),
+(51,690,l),
+(51,0,l),
+(193,0,l),
+(193,284,ls),
+(193,503,o),
+(254,573,o),
+(343,573,cs),
+(427,573,o),
+(486,496,o),
+(486,304,cs),
+(486,139,o),
+(463,99,o),
+(426,99,cs),
+(397,99,o),
+(379,128,o),
+(379,191,cs),
+(379,257,o),
+(400,284,o),
+(433,284,cs),
+(440,284,o),
+(444,283,o),
+(449,282,c),
+(449,391,l),
+(440,395,o),
+(427,397,o),
+(415,397,cs),
+(326,397,o),
+(260,324,o),
+(260,198,cs),
+(260,67,o),
+(326,-14,o),
+(429,-14,cs)
+);
+}
+);
+width = 669;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "te-canadian";
+note = uni1617;
+unicode = 5655;
+},
+{
+color = 9;
+glyphname = "jeeCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(544,-14,o),
+(621,82,o),
+(621,307,cs),
+(621,565,o),
+(514,703,o),
+(368,703,cs),
+(269,703,o),
+(201,646,o),
+(175,532,c),
+(192,516,l),
+(192,690,l),
+(51,690,l),
+(51,0,l),
+(193,0,l),
+(193,284,ls),
+(193,503,o),
+(254,573,o),
+(343,573,cs),
+(427,573,o),
+(486,496,o),
+(486,304,cs),
+(486,149,o),
+(457,99,o),
+(401,99,cs),
+(354,99,o),
+(325,138,o),
+(325,204,cs),
+(325,253,o),
+(337,287,o),
+(360,303,c),
+(360,230,l),
+(427,230,l),
+(427,449,l),
+(360,449,l),
+(360,375,l),
+(303,354,o),
+(260,291,o),
+(260,191,cs),
+(260,65,o),
+(324,-14,o),
+(428,-14,cs)
+);
+}
+);
+width = 669;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1618;
+unicode = 5656;
+},
+{
+color = 9;
+glyphname = "jiCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(544,-14,o),
+(621,82,o),
+(621,307,cs),
+(621,565,o),
+(514,703,o),
+(368,703,cs),
+(269,703,o),
+(201,646,o),
+(175,532,c),
+(192,516,l),
+(192,690,l),
+(51,690,l),
+(51,0,l),
+(193,0,l),
+(193,284,ls),
+(193,503,o),
+(254,573,o),
+(343,573,cs),
+(427,573,o),
+(486,496,o),
+(486,304,cs),
+(486,149,o),
+(457,99,o),
+(401,99,cs),
+(354,99,o),
+(325,138,o),
+(325,204,cs),
+(325,233,o),
+(330,252,o),
+(340,265,c),
+(348,259,o),
+(358,255,o),
+(370,255,cs),
+(415,255,o),
+(448,293,o),
+(448,340,cs),
+(448,387,o),
+(415,424,o),
+(370,424,cs),
+(307,424,o),
+(279,361,o),
+(295,314,c),
+(273,286,o),
+(260,245,o),
+(260,191,cs),
+(260,65,o),
+(324,-14,o),
+(428,-14,cs)
+);
+}
+);
+width = 669;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1619;
+unicode = 5657;
+},
+{
+color = 9;
+glyphname = "jiSayisi-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(514,-14,o),
+(621,125,o),
+(621,383,cs),
+(621,609,o),
+(545,703,o),
+(429,703,cs),
+(326,703,o),
+(260,623,o),
+(260,492,cs),
+(260,366,o),
+(326,293,o),
+(415,293,cs),
+(427,293,o),
+(440,295,o),
+(449,298,c),
+(449,408,l),
+(444,407,o),
+(440,406,o),
+(433,406,cs),
+(400,406,o),
+(379,433,o),
+(379,498,cs),
+(379,562,o),
+(396,590,o),
+(426,590,cs),
+(463,590,o),
+(486,551,o),
+(486,385,cs),
+(486,194,o),
+(427,117,o),
+(343,117,cs),
+(254,117,o),
+(193,186,o),
+(193,406,cs),
+(193,690,l),
+(51,690,l),
+(51,0,l),
+(192,0,l),
+(192,236,l),
+(166,240,l),
+(175,71,o),
+(248,-14,o),
+(368,-14,cs)
+);
+}
+);
+width = 669;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161A;
+unicode = 5658;
+},
+{
+color = 9;
+glyphname = "jaCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (327,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(421,-14,o),
+(495,71,o),
+(504,240,c),
+(477,236,l),
+(477,0,l),
+(618,0,l),
+(618,690,l),
+(476,690,l),
+(476,406,ls),
+(476,186,o),
+(415,117,o),
+(327,117,cs),
+(242,117,o),
+(184,194,o),
+(184,385,cs),
+(184,551,o),
+(207,590,o),
+(243,590,cs),
+(273,590,o),
+(291,562,o),
+(291,498,cs),
+(291,433,o),
+(270,406,o),
+(237,406,cs),
+(230,406,o),
+(225,407,o),
+(220,408,c),
+(220,298,l),
+(230,295,o),
+(242,293,o),
+(254,293,cs),
+(345,293,o),
+(410,366,o),
+(410,492,cs),
+(410,623,o),
+(344,703,o),
+(241,703,cs),
+(125,703,o),
+(48,609,o),
+(48,383,cs),
+(48,125,o),
+(156,-14,o),
+(301,-14,cs)
+);
+}
+);
+width = 669;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni161B;
+unicode = 5659;
+},
+{
+color = 9;
+glyphname = "jjuCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(497,-14,o),
+(581,88,o),
+(581,219,cs),
+(581,337,o),
+(518,419,o),
+(414,419,cs),
+(310,419,o),
+(256,340,o),
+(256,233,cs),
+(256,213,o),
+(258,195,o),
+(262,179,c),
+(368,179,l),
+(367,190,o),
+(366,206,o),
+(366,222,cs),
+(366,277,o),
+(384,306,o),
+(412,306,cs),
+(441,306,o),
+(460,277,o),
+(460,221,cs),
+(460,150,o),
+(422,103,o),
+(340,103,cs),
+(234,103,o),
+(188,173,o),
+(188,301,cs),
+(188,486,o),
+(291,560,o),
+(455,560,cs),
+(570,560,l),
+(570,690,l),
+(443,690,ls),
+(340,690,o),
+(253,663,o),
+(188,613,c),
+(100,703,l),
+(7,613,l),
+(101,519,l),
+(66,461,o),
+(47,389,o),
+(47,307,cs),
+(47,111,o),
+(158,-14,o),
+(334,-14,cs)
+);
+}
+);
+width = 617;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni161C;
+unicode = 5660;
+},
+{
+color = 9;
+glyphname = "jjoCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(610,76,l),
+(516,171,l),
+(551,229,o),
+(569,300,o),
+(569,383,cs),
+(569,579,o),
+(459,703,o),
+(283,703,cs),
+(122,703,o),
+(36,602,o),
+(36,470,cs),
+(36,353,o),
+(99,270,o),
+(203,270,cs),
+(307,270,o),
+(360,350,o),
+(360,457,cs),
+(360,477,o),
+(358,495,o),
+(355,511,c),
+(248,511,l),
+(249,499,o),
+(251,484,o),
+(251,468,cs),
+(251,412,o),
+(233,384,o),
+(204,384,cs),
+(175,384,o),
+(156,412,o),
+(156,469,cs),
+(156,540,o),
+(193,586,o),
+(277,586,cs),
+(383,586,o),
+(429,517,o),
+(429,388,cs),
+(429,204,o),
+(326,129,o),
+(161,129,cs),
+(46,129,l),
+(46,0,l),
+(173,0,ls),
+(277,0,o),
+(363,27,o),
+(428,76,c),
+(517,-14,l)
+);
+}
+);
+width = 617;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|jjuCarrier-canadian";
+note = uni161D;
+unicode = 5661;
+},
+{
+color = 9;
+glyphname = "jjeCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(554,-14,o),
+(629,81,o),
+(629,307,cs),
+(629,564,o),
+(529,703,o),
+(346,703,cs),
+(274,703,o),
+(211,680,o),
+(162,635,c),
+(87,703,l),
+(1,607,l),
+(90,526,l),
+(71,479,o),
+(60,422,o),
+(60,355,cs),
+(60,0,l),
+(202,0,l),
+(202,359,ls),
+(202,503,o),
+(251,573,o),
+(343,573,cs),
+(436,573,o),
+(495,505,o),
+(495,302,cs),
+(495,139,o),
+(471,99,o),
+(435,99,cs),
+(405,99,o),
+(387,128,o),
+(387,191,cs),
+(387,257,o),
+(409,284,o),
+(440,284,cs),
+(448,284,o),
+(453,283,o),
+(458,282,c),
+(458,391,l),
+(448,395,o),
+(436,397,o),
+(423,397,cs),
+(333,397,o),
+(268,324,o),
+(268,198,cs),
+(268,67,o),
+(333,-14,o),
+(438,-14,cs)
+);
+}
+);
+width = 677;
+}
+);
+metricRight = "jeCarrier-canadian";
+note = uni161E;
+unicode = 5662;
+},
+{
+color = 9;
+glyphname = "jjeeCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(552,-14,o),
+(629,82,o),
+(629,307,cs),
+(629,564,o),
+(529,703,o),
+(346,703,cs),
+(274,703,o),
+(211,680,o),
+(162,635,c),
+(87,703,l),
+(1,607,l),
+(90,526,l),
+(71,479,o),
+(60,422,o),
+(60,355,cs),
+(60,0,l),
+(202,0,l),
+(202,359,ls),
+(202,503,o),
+(251,573,o),
+(342,573,cs),
+(436,573,o),
+(495,505,o),
+(495,302,cs),
+(495,149,o),
+(466,99,o),
+(410,99,cs),
+(362,99,o),
+(333,138,o),
+(333,204,cs),
+(333,254,o),
+(346,286,o),
+(368,302,c),
+(368,230,l),
+(435,230,l),
+(435,448,l),
+(368,448,l),
+(368,375,l),
+(312,355,o),
+(268,290,o),
+(268,191,cs),
+(268,65,o),
+(332,-14,o),
+(437,-14,cs)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161F;
+unicode = 5663;
+},
+{
+color = 9;
+glyphname = "jjiCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(552,-14,o),
+(629,82,o),
+(629,307,cs),
+(629,564,o),
+(529,703,o),
+(346,703,cs),
+(274,703,o),
+(211,680,o),
+(162,635,c),
+(87,703,l),
+(1,607,l),
+(90,526,l),
+(71,479,o),
+(60,422,o),
+(60,355,cs),
+(60,0,l),
+(202,0,l),
+(202,359,ls),
+(202,503,o),
+(251,573,o),
+(342,573,cs),
+(436,573,o),
+(495,505,o),
+(495,302,cs),
+(495,149,o),
+(466,99,o),
+(410,99,cs),
+(362,99,o),
+(333,138,o),
+(333,204,cs),
+(333,234,o),
+(339,253,o),
+(349,266,c),
+(357,259,o),
+(369,255,o),
+(381,255,cs),
+(427,255,o),
+(460,293,o),
+(460,340,cs),
+(460,387,o),
+(427,424,o),
+(381,424,cs),
+(323,424,o),
+(292,365,o),
+(305,317,c),
+(283,289,o),
+(268,247,o),
+(268,191,cs),
+(268,65,o),
+(332,-14,o),
+(437,-14,cs)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1620;
+unicode = 5664;
+},
+{
+color = 9;
+glyphname = "jjaCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(404,-14,o),
+(467,10,o),
+(515,55,c),
+(591,-14,l),
+(677,83,l),
+(588,163,l),
+(608,211,o),
+(618,268,o),
+(618,335,cs),
+(618,690,l),
+(476,690,l),
+(476,330,ls),
+(476,186,o),
+(427,117,o),
+(335,117,cs),
+(242,117,o),
+(184,185,o),
+(184,387,cs),
+(184,551,o),
+(207,590,o),
+(243,590,cs),
+(273,590,o),
+(291,562,o),
+(291,498,cs),
+(291,433,o),
+(270,406,o),
+(238,406,cs),
+(230,406,o),
+(225,407,o),
+(220,408,c),
+(220,298,l),
+(230,295,o),
+(242,293,o),
+(254,293,cs),
+(345,293,o),
+(410,366,o),
+(410,492,cs),
+(410,623,o),
+(344,703,o),
+(241,703,cs),
+(125,703,o),
+(48,609,o),
+(48,383,cs),
+(48,126,o),
+(149,-14,o),
+(332,-14,cs)
+);
+}
+);
+width = 678;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "=|jjeCarrier-canadian";
+note = uni1621;
+unicode = 5665;
+},
+{
+color = 9;
+glyphname = "luCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(478,-14,o),
+(572,83,o),
+(572,271,cs),
+(572,690,l),
+(430,690,l),
+(430,273,ls),
+(430,164,o),
+(386,117,o),
+(319,117,cs),
+(233,117,o),
+(193,184,o),
+(193,319,cs),
+(193,464,o),
+(233,555,o),
+(329,577,c),
+(329,690,l),
+(43,690,l),
+(43,573,l),
+(196,573,l),
+(294,617,l),
+(135,597,o),
+(50,499,o),
+(50,298,cs),
+(50,103,o),
+(143,-14,o),
+(314,-14,cs)
+);
+}
+);
+width = 620;
+}
+);
+metricRight = "te-canadian";
+note = uni1622;
+unicode = 5666;
+},
+{
+color = 9;
+glyphname = "loCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(191,0,l),
+(191,416,ls),
+(191,526,o),
+(234,573,o),
+(303,573,cs),
+(388,573,o),
+(428,506,o),
+(428,371,cs),
+(428,226,o),
+(388,134,o),
+(292,113,c),
+(292,0,l),
+(578,0,l),
+(578,117,l),
+(425,117,l),
+(327,72,l),
+(485,93,o),
+(570,190,o),
+(570,392,cs),
+(570,586,o),
+(478,703,o),
+(307,703,cs),
+(142,703,o),
+(48,607,o),
+(48,418,cs),
+(48,0,l)
+);
+}
+);
+width = 621;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|luCarrier-canadian";
+note = uni1623;
+unicode = 5667;
+},
+{
+color = 9;
+glyphname = "leCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (298,346);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(240,0,ls),
+(451,0,o),
+(572,116,o),
+(572,356,cs),
+(572,598,o),
+(455,703,o),
+(340,703,cs),
+(241,703,o),
+(183,638,o),
+(163,548,c),
+(176,554,l),
+(176,690,l),
+(48,690,l),
+(48,376,l),
+(169,376,l),
+(172,511,o),
+(228,573,o),
+(299,573,cs),
+(369,573,o),
+(429,517,o),
+(429,355,cs),
+(429,194,o),
+(366,129,o),
+(241,129,cs),
+(48,129,l),
+(48,0,l)
+);
+}
+);
+width = 616;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1624;
+unicode = 5668;
+},
+{
+color = 9;
+glyphname = "leeCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+ref = "leCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (242,1);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 616;
+}
+);
+metricLeft = "leCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1625;
+unicode = 5669;
+},
+{
+color = 9;
+glyphname = "liCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "leCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (214,1);
+ref = dot_middle;
+}
+);
+width = 614;
+}
+);
+note = uni1626;
+unicode = 5670;
+},
+{
+color = 9;
+glyphname = "laCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(568,0,l),
+(568,129,l),
+(376,129,ls),
+(250,129,o),
+(187,194,o),
+(187,355,cs),
+(187,517,o),
+(247,573,o),
+(317,573,cs),
+(388,573,o),
+(444,511,o),
+(447,376,c),
+(568,376,l),
+(568,690,l),
+(441,690,l),
+(441,554,l),
+(453,548,l),
+(434,638,o),
+(376,703,o),
+(276,703,cs),
+(161,703,o),
+(44,598,o),
+(44,356,cs),
+(44,116,o),
+(165,0,o),
+(377,0,cs)
+);
+}
+);
+width = 616;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|leCarrier-canadian";
+note = uni1627;
+unicode = 5671;
+},
+{
+color = 1;
+glyphname = "dluCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(478,-14,o),
+(570,103,o),
+(570,298,cs),
+(570,467,o),
+(512,562,o),
+(404,599,c),
+(376,582,l),
+(556,582,l),
+(556,504,l),
+(659,504,l),
+(659,767,l),
+(556,767,l),
+(556,690,l),
+(292,690,l),
+(292,576,l),
+(388,555,o),
+(428,464,o),
+(428,319,cs),
+(428,184,o),
+(388,117,o),
+(305,117,cs),
+(234,117,o),
+(191,164,o),
+(191,273,cs),
+(191,690,l),
+(48,690,l),
+(48,271,ls),
+(48,83,o),
+(142,-14,o),
+(307,-14,cs)
+);
+}
+);
+width = 684;
+}
+);
+metricLeft = "te-canadian";
+note = uni1628;
+unicode = 5672;
+},
+{
+color = 9;
+glyphname = "dloCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(659,-77,l),
+(659,185,l),
+(556,185,l),
+(556,107,l),
+(376,107,l),
+(404,91,l),
+(512,128,o),
+(570,223,o),
+(570,392,cs),
+(570,586,o),
+(478,703,o),
+(308,703,cs),
+(141,703,o),
+(48,607,o),
+(48,418,cs),
+(48,0,l),
+(191,0,l),
+(191,416,ls),
+(191,526,o),
+(234,573,o),
+(305,573,cs),
+(388,573,o),
+(428,506,o),
+(428,371,cs),
+(428,226,o),
+(388,134,o),
+(292,114,c),
+(292,0,l),
+(556,0,l),
+(556,-77,l)
+);
+}
+);
+width = 684;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "dluCarrier-canadian";
+note = uni1629;
+unicode = 5673;
+},
+{
+color = 9;
+glyphname = "dleCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (314,346);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(256,0,ls),
+(467,0,o),
+(587,116,o),
+(587,356,cs),
+(587,598,o),
+(470,703,o),
+(355,703,cs),
+(260,703,o),
+(179,642,o),
+(151,503,c),
+(167,496,l),
+(167,696,l),
+(232,696,l),
+(232,796,l),
+(-1,796,l),
+(-1,696,l),
+(65,696,l),
+(65,376,l),
+(185,376,l),
+(188,511,o),
+(244,573,o),
+(315,573,cs),
+(384,573,o),
+(445,517,o),
+(445,355,cs),
+(445,194,o),
+(382,129,o),
+(256,129,cs),
+(65,129,l),
+(65,0,l)
+);
+}
+);
+width = 631;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni162A;
+unicode = 5674;
+},
+{
+color = 9;
+glyphname = "dleeCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (257,1);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 630;
+}
+);
+note = uni162B;
+unicode = 5675;
+},
+{
+color = 9;
+glyphname = "dliCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (230,1);
+ref = dot_middle;
+}
+);
+width = 630;
+}
+);
+note = uni162C;
+unicode = 5676;
+},
+{
+color = 9;
+glyphname = "dlaCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(568,0,l),
+(568,129,l),
+(376,129,ls),
+(250,129,o),
+(187,194,o),
+(187,355,cs),
+(187,517,o),
+(248,573,o),
+(317,573,cs),
+(387,573,o),
+(444,511,o),
+(447,376,c),
+(568,376,l),
+(568,696,l),
+(633,696,l),
+(633,796,l),
+(400,796,l),
+(400,696,l),
+(465,696,l),
+(465,496,l),
+(481,503,l),
+(454,642,o),
+(372,703,o),
+(276,703,cs),
+(161,703,o),
+(44,598,o),
+(44,356,cs),
+(44,116,o),
+(165,0,o),
+(377,0,cs)
+);
+}
+);
+width = 632;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni162D;
+unicode = 5677;
+},
+{
+color = 9;
+glyphname = "lhuCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(487,-14,o),
+(581,107,o),
+(581,295,cs),
+(581,493,o),
+(496,596,o),
+(372,617,c),
+(436,572,l),
+(588,572,l),
+(588,690,l),
+(361,690,l),
+(361,577,l),
+(410,532,o),
+(439,446,o),
+(439,325,cs),
+(439,179,o),
+(397,117,o),
+(316,117,cs),
+(235,117,o),
+(193,179,o),
+(193,325,cs),
+(193,446,o),
+(222,532,o),
+(270,577,c),
+(270,690,l),
+(43,690,l),
+(43,572,l),
+(195,572,l),
+(260,617,l),
+(136,596,o),
+(51,493,o),
+(51,295,cs),
+(51,107,o),
+(145,-14,o),
+(316,-14,cs)
+);
+}
+);
+width = 631;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162E;
+unicode = 5678;
+},
+{
+color = 9;
+glyphname = "lhoCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(270,0,l),
+(270,113,l),
+(222,157,o),
+(193,243,o),
+(193,365,cs),
+(193,511,o),
+(234,573,o),
+(316,573,cs),
+(397,573,o),
+(438,511,o),
+(438,365,cs),
+(438,243,o),
+(410,157,o),
+(361,113,c),
+(361,0,l),
+(588,0,l),
+(588,118,l),
+(436,118,l),
+(372,72,l),
+(496,94,o),
+(581,197,o),
+(581,395,cs),
+(581,582,o),
+(487,703,o),
+(316,703,cs),
+(144,703,o),
+(51,582,o),
+(51,395,cs),
+(51,197,o),
+(136,94,o),
+(260,72,c),
+(196,118,l),
+(43,118,l),
+(43,0,l)
+);
+}
+);
+width = 631;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162F;
+unicode = 5679;
+},
+{
+color = 9;
+glyphname = "lheCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (309,345);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(469,-14,o),
+(588,92,o),
+(588,345,cs),
+(588,598,o),
+(469,703,o),
+(352,703,cs),
+(251,703,o),
+(191,639,o),
+(172,553,c),
+(179,553,l),
+(179,690,l),
+(51,690,l),
+(51,410,l),
+(172,410,l),
+(187,501,o),
+(229,573,o),
+(312,573,cs),
+(383,573,o),
+(446,518,o),
+(446,345,cs),
+(446,172,o),
+(383,117,o),
+(312,117,cs),
+(229,117,o),
+(187,188,o),
+(172,280,c),
+(51,280,l),
+(51,0,l),
+(179,0,l),
+(179,137,l),
+(172,137,l),
+(191,50,o),
+(251,-14,o),
+(352,-14,cs)
+);
+}
+);
+width = 632;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1630;
+unicode = 5680;
+},
+{
+color = 9;
+glyphname = "lheeCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (253,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 632;
+}
+);
+note = uni1631;
+unicode = 5681;
+},
+{
+color = 9;
+glyphname = "lhiCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (226,0);
+ref = dot_middle;
+}
+);
+width = 632;
+}
+);
+note = uni1632;
+unicode = 5682;
+},
+{
+color = 9;
+glyphname = "lhaCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(383,-14,o),
+(441,50,o),
+(461,137,c),
+(455,137,l),
+(455,0,l),
+(583,0,l),
+(583,280,l),
+(462,280,l),
+(445,188,o),
+(405,117,o),
+(322,117,cs),
+(251,117,o),
+(187,172,o),
+(187,345,cs),
+(187,518,o),
+(250,573,o),
+(322,573,cs),
+(405,573,o),
+(445,501,o),
+(462,410,c),
+(583,410,l),
+(583,690,l),
+(455,690,l),
+(455,553,l),
+(461,553,l),
+(441,639,o),
+(383,703,o),
+(281,703,cs),
+(163,703,o),
+(44,598,o),
+(44,345,cs),
+(44,92,o),
+(163,-14,o),
+(281,-14,cs)
+);
+}
+);
+width = 634;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1633;
+unicode = 5683;
+},
+{
+color = 9;
+glyphname = "tlhuCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(487,-14,o),
+(581,107,o),
+(581,295,cs),
+(581,458,o),
+(523,557,o),
+(435,600,c),
+(401,582,l),
+(566,582,l),
+(566,504,l),
+(668,504,l),
+(668,767,l),
+(566,767,l),
+(566,690,l),
+(361,690,l),
+(361,577,l),
+(411,532,o),
+(440,446,o),
+(440,325,cs),
+(440,179,o),
+(398,117,o),
+(316,117,cs),
+(234,117,o),
+(192,179,o),
+(192,325,cs),
+(192,446,o),
+(221,532,o),
+(270,577,c),
+(270,690,l),
+(43,690,l),
+(43,572,l),
+(216,572,l),
+(181,591,l),
+(101,546,o),
+(51,449,o),
+(51,295,cs),
+(51,107,o),
+(145,-14,o),
+(316,-14,cs)
+);
+}
+);
+width = 690;
+}
+);
+metricLeft = "lhuCarrier-canadian";
+note = uni1634;
+unicode = 5684;
+},
+{
+color = 9;
+glyphname = "tlhoCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(125,-77,l),
+(125,0,l),
+(330,0,l),
+(330,113,l),
+(280,157,o),
+(252,243,o),
+(252,365,cs),
+(252,511,o),
+(293,573,o),
+(376,573,cs),
+(457,573,o),
+(498,511,o),
+(498,365,cs),
+(498,243,o),
+(470,157,o),
+(420,113,c),
+(420,0,l),
+(648,0,l),
+(648,118,l),
+(474,118,l),
+(510,99,l),
+(590,144,o),
+(640,241,o),
+(640,395,cs),
+(640,582,o),
+(546,703,o),
+(376,703,cs),
+(204,703,o),
+(111,582,o),
+(111,395,cs),
+(111,232,o),
+(168,132,o),
+(257,90,c),
+(290,107,l),
+(125,107,l),
+(125,185,l),
+(22,185,l),
+(22,-77,l)
+);
+}
+);
+width = 691;
+}
+);
+metricLeft = "=|tlhuCarrier-canadian";
+metricRight = "lhuCarrier-canadian";
+note = uni1635;
+unicode = 5685;
+},
+{
+color = 9;
+glyphname = "tlheCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (323,345);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(483,-14,o),
+(602,92,o),
+(602,345,cs),
+(602,598,o),
+(483,703,o),
+(365,703,cs),
+(262,703,o),
+(181,643,o),
+(151,506,c),
+(167,497,l),
+(167,696,l),
+(233,696,l),
+(233,796,l),
+(-1,796,l),
+(-1,696,l),
+(65,696,l),
+(65,410,l),
+(185,410,l),
+(201,501,o),
+(242,573,o),
+(325,573,cs),
+(396,573,o),
+(460,525,o),
+(460,345,cs),
+(460,172,o),
+(396,117,o),
+(325,117,cs),
+(242,117,o),
+(201,188,o),
+(185,280,c),
+(65,280,l),
+(65,0,l),
+(192,0,l),
+(192,176,l),
+(182,156,l),
+(196,60,o),
+(258,-14,o),
+(365,-14,cs)
+);
+}
+);
+width = 646;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1636;
+unicode = 5686;
+},
+{
+color = 9;
+glyphname = "tlheeCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (267,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 644;
+}
+);
+note = uni1637;
+unicode = 5687;
+},
+{
+color = 9;
+glyphname = "tlhiCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (240,0);
+ref = dot_middle;
+}
+);
+width = 644;
+}
+);
+note = uni1638;
+unicode = 5688;
+},
+{
+color = 9;
+glyphname = "tlhaCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(389,-14,o),
+(450,60,o),
+(465,156,c),
+(455,177,l),
+(455,0,l),
+(583,0,l),
+(583,280,l),
+(462,280,l),
+(445,188,o),
+(405,117,o),
+(322,117,cs),
+(251,117,o),
+(187,172,o),
+(187,345,cs),
+(187,525,o),
+(250,573,o),
+(322,573,cs),
+(405,573,o),
+(445,501,o),
+(462,410,c),
+(583,410,l),
+(583,696,l),
+(647,696,l),
+(647,796,l),
+(413,796,l),
+(413,696,l),
+(479,696,l),
+(479,497,l),
+(496,506,l),
+(467,643,o),
+(385,703,o),
+(281,703,cs),
+(163,703,o),
+(44,598,o),
+(44,345,cs),
+(44,92,o),
+(163,-14,o),
+(281,-14,cs)
+);
+}
+);
+width = 646;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni1639;
+unicode = 5689;
+},
+{
+color = 9;
+glyphname = "tluCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(315,-14,o),
+(367,21,o),
+(391,99,c),
+(348,99,l),
+(372,21,o),
+(424,-14,o),
+(493,-14,cs),
+(619,-14,o),
+(687,79,o),
+(687,260,cs),
+(687,451,o),
+(637,556,o),
+(535,600,c),
+(503,582,l),
+(673,582,l),
+(673,504,l),
+(776,504,l),
+(776,767,l),
+(673,767,l),
+(673,690,l),
+(414,690,l),
+(414,576,l),
+(504,571,o),
+(545,474,o),
+(545,270,cs),
+(545,145,o),
+(523,115,o),
+(487,115,cs),
+(454,115,o),
+(437,144,o),
+(437,204,cs),
+(437,308,l),
+(302,308,l),
+(302,204,ls),
+(302,144,o),
+(284,115,o),
+(252,115,cs),
+(215,115,o),
+(194,145,o),
+(194,270,cs),
+(194,474,o),
+(235,571,o),
+(324,576,c),
+(324,690,l),
+(44,690,l),
+(44,572,l),
+(223,572,l),
+(188,592,l),
+(98,544,o),
+(52,442,o),
+(52,260,cs),
+(52,79,o),
+(120,-14,o),
+(245,-14,cs)
+);
+}
+);
+width = 798;
+}
+);
+metricRight = "tlhuCarrier-canadian";
+note = uni163A;
+unicode = 5690;
+},
+{
+color = 1;
+glyphname = "tloCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(776,-77,l),
+(776,185,l),
+(673,185,l),
+(673,107,l),
+(503,107,l),
+(535,90,l),
+(637,133,o),
+(687,239,o),
+(687,430,cs),
+(687,611,o),
+(619,703,o),
+(493,703,cs),
+(424,703,o),
+(372,668,o),
+(348,590,c),
+(391,590,l),
+(367,668,o),
+(315,703,o),
+(245,703,cs),
+(120,703,o),
+(52,611,o),
+(52,430,cs),
+(52,247,o),
+(98,146,o),
+(188,98,c),
+(223,118,l),
+(44,118,l),
+(44,0,l),
+(324,0,l),
+(324,114,l),
+(235,119,o),
+(194,215,o),
+(194,420,cs),
+(194,545,o),
+(215,575,o),
+(252,575,cs),
+(284,575,o),
+(302,546,o),
+(302,486,cs),
+(302,382,l),
+(437,382,l),
+(437,486,ls),
+(437,546,o),
+(454,575,o),
+(487,575,cs),
+(523,575,o),
+(545,545,o),
+(545,420,cs),
+(545,215,o),
+(504,119,o),
+(414,114,c),
+(414,0,l),
+(673,0,l),
+(673,-77,l)
+);
+}
+);
+width = 798;
+}
+);
+metricLeft = "tluCarrier-canadian";
+metricRight = "tlhuCarrier-canadian";
+note = uni163B;
+unicode = 5691;
+},
+{
+color = 9;
+glyphname = "tleCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (270,345);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(508,-14,o),
+(585,68,o),
+(585,182,cs),
+(585,276,o),
+(537,343,o),
+(463,358,c),
+(463,331,l),
+(537,346,o),
+(585,412,o),
+(585,508,cs),
+(585,622,o),
+(508,703,o),
+(379,703,cs),
+(273,703,o),
+(175,645,o),
+(153,522,c),
+(167,507,l),
+(167,696,l),
+(232,696,l),
+(232,796,l),
+(-1,796,l),
+(-1,696,l),
+(65,696,l),
+(65,410,l),
+(182,410,l),
+(185,516,o),
+(235,577,o),
+(335,577,cs),
+(408,577,o),
+(444,543,o),
+(444,484,cs),
+(444,432,o),
+(419,403,o),
+(370,403,cs),
+(346,403,l),
+(346,288,l),
+(370,288,ls),
+(420,288,o),
+(444,258,o),
+(444,207,cs),
+(444,148,o),
+(408,113,o),
+(335,113,cs),
+(235,113,o),
+(185,174,o),
+(182,280,c),
+(65,280,l),
+(65,0,l),
+(192,0,l),
+(192,151,l),
+(171,132,l),
+(202,32,o),
+(283,-14,o),
+(379,-14,cs)
+);
+}
+);
+width = 633;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni163C;
+unicode = 5692;
+},
+{
+color = 9;
+glyphname = "tleeCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (213,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 635;
+}
+);
+note = uni163D;
+unicode = 5693;
+},
+{
+color = 9;
+glyphname = "tliCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (201,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 635;
+}
+);
+note = uni163E;
+unicode = 5694;
+},
+{
+color = 9;
+glyphname = "tlaCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(351,-14,o),
+(433,32,o),
+(463,132,c),
+(442,151,l),
+(442,0,l),
+(570,0,l),
+(570,280,l),
+(452,280,l),
+(449,174,o),
+(399,113,o),
+(299,113,cs),
+(227,113,o),
+(189,148,o),
+(189,207,cs),
+(189,258,o),
+(214,288,o),
+(265,288,cs),
+(290,288,l),
+(290,403,l),
+(265,403,ls),
+(214,403,o),
+(189,432,o),
+(189,484,cs),
+(189,543,o),
+(226,577,o),
+(298,577,cs),
+(399,577,o),
+(449,516,o),
+(452,410,c),
+(570,410,l),
+(570,696,l),
+(635,696,l),
+(635,796,l),
+(402,796,l),
+(402,696,l),
+(468,696,l),
+(468,507,l),
+(482,522,l),
+(460,645,o),
+(361,703,o),
+(255,703,cs),
+(127,703,o),
+(48,622,o),
+(48,508,cs),
+(48,412,o),
+(97,346,o),
+(171,331,c),
+(171,358,l),
+(98,343,o),
+(48,276,o),
+(48,182,cs),
+(48,68,o),
+(127,-14,o),
+(255,-14,cs)
+);
+}
+);
+width = 634;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni163F;
+unicode = 5695;
+},
+{
+color = 9;
+glyphname = "zuCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(482,-14,o),
+(581,77,o),
+(581,222,cs),
+(581,327,o),
+(519,459,o),
+(519,520,cs),
+(519,549,o),
+(532,568,o),
+(565,568,cs),
+(589,568,l),
+(589,690,l),
+(529,690,ls),
+(428,690,o),
+(381,635,o),
+(381,546,cs),
+(381,460,o),
+(439,335,o),
+(439,244,cs),
+(439,166,o),
+(396,117,o),
+(316,117,cs),
+(236,117,o),
+(193,165,o),
+(193,244,cs),
+(193,335,o),
+(251,460,o),
+(251,546,cs),
+(251,635,o),
+(204,690,o),
+(102,690,cs),
+(43,690,l),
+(43,568,l),
+(67,568,ls),
+(99,568,o),
+(114,549,o),
+(114,520,cs),
+(114,459,o),
+(50,327,o),
+(50,222,cs),
+(50,77,o),
+(150,-14,o),
+(316,-14,cs)
+);
+}
+);
+width = 632;
+}
+);
+metricRight = "=|";
+note = uni1640;
+unicode = 5696;
+},
+{
+color = 9;
+glyphname = "zoCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(102,0,ls),
+(205,0,o),
+(252,55,o),
+(252,144,cs),
+(252,230,o),
+(193,355,o),
+(193,445,cs),
+(193,524,o),
+(237,573,o),
+(317,573,cs),
+(397,573,o),
+(440,525,o),
+(440,445,cs),
+(440,355,o),
+(381,230,o),
+(381,144,cs),
+(381,55,o),
+(429,0,o),
+(529,0,cs),
+(589,0,l),
+(589,122,l),
+(565,122,ls),
+(532,122,o),
+(519,141,o),
+(519,170,cs),
+(519,231,o),
+(582,363,o),
+(582,468,cs),
+(582,612,o),
+(482,703,o),
+(317,703,cs),
+(151,703,o),
+(51,612,o),
+(51,468,cs),
+(51,363,o),
+(114,231,o),
+(114,170,cs),
+(114,141,o),
+(100,122,o),
+(68,122,cs),
+(43,122,l),
+(43,0,l)
+);
+}
+);
+width = 632;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1641;
+unicode = 5697;
+},
+{
+color = 9;
+glyphname = "zeCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (296,345);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(485,-14,o),
+(569,101,o),
+(569,345,cs),
+(569,588,o),
+(486,703,o),
+(368,703,cs),
+(283,703,o),
+(219,613,o),
+(186,613,cs),
+(168,613,o),
+(159,625,o),
+(159,665,cs),
+(159,690,l),
+(31,690,l),
+(31,622,ls),
+(31,529,o),
+(78,488,o),
+(144,488,cs),
+(222,488,o),
+(277,573,o),
+(331,573,cs),
+(384,573,o),
+(426,524,o),
+(426,345,cs),
+(426,166,o),
+(384,117,o),
+(331,117,cs),
+(277,117,o),
+(222,202,o),
+(144,202,cs),
+(78,202,o),
+(31,160,o),
+(31,68,cs),
+(31,0,l),
+(159,0,l),
+(159,25,ls),
+(159,66,o),
+(168,76,o),
+(186,76,cs),
+(219,76,o),
+(283,-14,o),
+(368,-14,cs)
+);
+}
+);
+width = 613;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1642;
+unicode = 5698;
+},
+{
+color = 9;
+glyphname = "zeeCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (240,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 611;
+}
+);
+note = uni1643;
+unicode = 5699;
+},
+{
+color = 9;
+glyphname = "ziCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (212,0);
+ref = dot_middle;
+}
+);
+width = 611;
+}
+);
+note = uni1644;
+unicode = 5700;
+},
+{
+color = 9;
+glyphname = "zaCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(330,-14,o),
+(394,76,o),
+(427,76,cs),
+(445,76,o),
+(454,65,o),
+(454,25,cs),
+(454,0,l),
+(583,0,l),
+(583,68,ls),
+(583,160,o),
+(535,202,o),
+(470,202,cs),
+(391,202,o),
+(336,117,o),
+(282,117,cs),
+(230,117,o),
+(187,166,o),
+(187,345,cs),
+(187,524,o),
+(230,573,o),
+(282,573,cs),
+(336,573,o),
+(391,488,o),
+(470,488,cs),
+(535,488,o),
+(583,529,o),
+(583,622,cs),
+(583,690,l),
+(454,690,l),
+(454,665,ls),
+(454,624,o),
+(445,613,o),
+(427,613,cs),
+(394,613,o),
+(330,703,o),
+(245,703,cs),
+(129,703,o),
+(44,588,o),
+(44,345,cs),
+(44,101,o),
+(128,-14,o),
+(245,-14,cs)
+);
+}
+);
+width = 614;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|zeCarrier-canadian";
+note = uni1645;
+unicode = 5701;
+},
+{
+color = 6;
+glyphname = "zCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(303,183,l),
+(303,270,l),
+(144,270,l),
+(144,218,l),
+(299,478,l),
+(299,527,l),
+(43,527,l),
+(43,440,l),
+(200,440,l),
+(200,492,l),
+(43,232,l),
+(43,183,l)
+);
+}
+);
+width = 346;
+}
+);
+metricRight = "=|";
+note = uni1646;
+unicode = 5702;
+},
+{
+color = 6;
+glyphname = "initialzCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(126,183,l),
+(126,96,l),
+(218,96,l),
+(218,183,l),
+(303,183,l),
+(303,270,l),
+(111,270,l),
+(142,215,l),
+(299,478,l),
+(299,527,l),
+(218,527,l),
+(218,614,l),
+(126,614,l),
+(126,527,l),
+(43,527,l),
+(43,440,l),
+(233,440,l),
+(201,495,l),
+(43,232,l),
+(43,183,l)
+);
+}
+);
+width = 346;
+}
+);
+metricLeft = "zCarrier-canadian";
+metricRight = "zCarrier-canadian";
+note = uni1647;
+unicode = 5703;
+},
+{
+color = 9;
+glyphname = "dzuCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(482,-14,o),
+(581,77,o),
+(581,222,cs),
+(581,327,o),
+(519,459,o),
+(519,520,cs),
+(519,549,o),
+(532,568,o),
+(565,568,cs),
+(589,568,l),
+(589,690,l),
+(536,690,ls),
+(440,690,o),
+(387,635,o),
+(387,546,cs),
+(387,460,o),
+(439,341,o),
+(439,244,cs),
+(439,166,o),
+(397,117,o),
+(316,117,cs),
+(235,117,o),
+(193,165,o),
+(193,244,cs),
+(193,341,o),
+(244,460,o),
+(244,546,cs),
+(244,635,o),
+(191,690,o),
+(97,690,cs),
+(43,690,l),
+(43,568,l),
+(67,568,ls),
+(99,568,o),
+(114,549,o),
+(114,520,cs),
+(114,459,o),
+(50,327,o),
+(50,222,cs),
+(50,77,o),
+(150,-14,o),
+(316,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(344,469,l),
+(344,637,l),
+(386,637,l),
+(386,690,l),
+(246,690,l),
+(246,637,l),
+(289,637,l),
+(289,469,l)
+);
+}
+);
+width = 632;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1648;
+unicode = 5704;
+},
+{
+color = 9;
+glyphname = "dzoCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,0,ls),
+(192,0,o),
+(244,55,o),
+(244,144,cs),
+(244,230,o),
+(193,349,o),
+(193,445,cs),
+(193,524,o),
+(236,573,o),
+(317,573,cs),
+(397,573,o),
+(440,525,o),
+(440,445,cs),
+(440,349,o),
+(388,230,o),
+(388,144,cs),
+(388,55,o),
+(440,0,o),
+(536,0,cs),
+(589,0,l),
+(589,122,l),
+(565,122,ls),
+(532,122,o),
+(519,141,o),
+(519,170,cs),
+(519,231,o),
+(582,363,o),
+(582,468,cs),
+(582,612,o),
+(482,703,o),
+(317,703,cs),
+(151,703,o),
+(51,612,o),
+(51,468,cs),
+(51,363,o),
+(114,231,o),
+(114,170,cs),
+(114,141,o),
+(100,122,o),
+(68,122,cs),
+(43,122,l),
+(43,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(385,0,l),
+(385,53,l),
+(343,53,l),
+(343,220,l),
+(289,220,l),
+(289,53,l),
+(246,53,l),
+(246,0,l)
+);
+}
+);
+width = 632;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1649;
+unicode = 5705;
+},
+{
+color = 9;
+glyphname = "dzeCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (323,345);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(505,-14,o),
+(588,101,o),
+(588,345,cs),
+(588,588,o),
+(506,703,o),
+(387,703,cs),
+(303,703,o),
+(240,613,o),
+(206,613,cs),
+(187,613,o),
+(179,625,o),
+(179,665,cs),
+(179,690,l),
+(51,690,l),
+(51,622,ls),
+(51,529,o),
+(99,489,o),
+(164,489,cs),
+(242,489,o),
+(298,573,o),
+(352,573,cs),
+(403,573,o),
+(446,524,o),
+(446,345,cs),
+(446,166,o),
+(403,117,o),
+(352,117,cs),
+(298,117,o),
+(242,201,o),
+(164,201,cs),
+(99,201,o),
+(51,160,o),
+(51,68,cs),
+(51,0,l),
+(179,0,l),
+(179,25,ls),
+(179,61,o),
+(187,71,o),
+(206,71,cs),
+(240,71,o),
+(303,-14,o),
+(387,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(124,242,l),
+(124,308,l),
+(221,308,l),
+(221,382,l),
+(124,382,l),
+(124,447,l),
+(51,447,l),
+(51,242,l)
+);
+}
+);
+width = 632;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164A;
+unicode = 5706;
+},
+{
+color = 9;
+glyphname = "dzeeCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+ref = "dzeCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (267,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 632;
+}
+);
+metricLeft = "dzeCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164B;
+unicode = 5707;
+},
+{
+color = 9;
+glyphname = "dziCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "dzeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (239,0);
+ref = dot_middle;
+}
+);
+width = 632;
+}
+);
+note = uni164C;
+unicode = 5708;
+},
+{
+color = 9;
+glyphname = "dzaCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(330,-14,o),
+(394,71,o),
+(427,71,cs),
+(445,71,o),
+(454,61,o),
+(454,25,cs),
+(454,0,l),
+(583,0,l),
+(583,68,ls),
+(583,160,o),
+(535,201,o),
+(470,201,cs),
+(391,201,o),
+(336,117,o),
+(282,117,cs),
+(230,117,o),
+(187,166,o),
+(187,345,cs),
+(187,524,o),
+(230,573,o),
+(282,573,cs),
+(336,573,o),
+(391,489,o),
+(470,489,cs),
+(535,489,o),
+(583,529,o),
+(583,622,cs),
+(583,690,l),
+(454,690,l),
+(454,665,ls),
+(454,625,o),
+(445,613,o),
+(427,613,cs),
+(394,613,o),
+(330,703,o),
+(245,703,cs),
+(128,703,o),
+(44,588,o),
+(44,345,cs),
+(44,101,o),
+(129,-14,o),
+(245,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(583,242,l),
+(583,447,l),
+(509,447,l),
+(509,382,l),
+(413,382,l),
+(413,308,l),
+(509,308,l),
+(509,242,l)
+);
+}
+);
+width = 634;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dzeCarrier-canadian";
+note = uni164D;
+unicode = 5709;
+},
+{
+color = 9;
+glyphname = "suCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(315,-14,o),
+(372,37,o),
+(392,135,c),
+(346,135,l),
+(366,37,o),
+(423,-14,o),
+(509,-14,cs),
+(620,-14,o),
+(689,65,o),
+(689,179,cs),
+(689,291,o),
+(634,435,o),
+(634,522,cs),
+(634,549,o),
+(646,568,o),
+(677,568,cs),
+(694,568,l),
+(694,690,l),
+(643,690,ls),
+(542,690,o),
+(498,636,o),
+(498,545,cs),
+(498,442,o),
+(550,272,o),
+(550,192,cs),
+(550,142,o),
+(531,115,o),
+(494,115,cs),
+(454,115,o),
+(431,144,o),
+(431,206,cs),
+(431,690,l),
+(307,690,l),
+(307,206,ls),
+(307,144,o),
+(284,115,o),
+(245,115,cs),
+(208,115,o),
+(188,142,o),
+(188,192,cs),
+(188,272,o),
+(239,442,o),
+(239,545,cs),
+(239,636,o),
+(196,690,o),
+(95,690,cs),
+(43,690,l),
+(43,568,l),
+(60,568,ls),
+(91,568,o),
+(104,548,o),
+(104,522,cs),
+(104,435,o),
+(49,291,o),
+(49,179,cs),
+(49,65,o),
+(118,-14,o),
+(229,-14,cs)
+);
+}
+);
+width = 737;
+}
+);
+metricRight = "=|";
+note = uni164E;
+unicode = 5710;
+},
+{
+color = 9;
+glyphname = "soCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(95,0,ls),
+(196,0,o),
+(239,54,o),
+(239,145,cs),
+(239,247,o),
+(187,417,o),
+(187,497,cs),
+(187,548,o),
+(207,575,o),
+(244,575,cs),
+(283,575,o),
+(306,546,o),
+(306,484,cs),
+(306,0,l),
+(431,0,l),
+(431,484,ls),
+(431,546,o),
+(454,575,o),
+(493,575,cs),
+(530,575,o),
+(550,548,o),
+(550,497,cs),
+(550,417,o),
+(498,247,o),
+(498,145,cs),
+(498,54,o),
+(542,0,o),
+(643,0,cs),
+(694,0,l),
+(694,122,l),
+(677,122,ls),
+(646,122,o),
+(634,142,o),
+(634,168,cs),
+(634,255,o),
+(689,399,o),
+(689,511,cs),
+(689,625,o),
+(620,703,o),
+(509,703,cs),
+(423,703,o),
+(366,653,o),
+(346,554,c),
+(392,554,l),
+(371,653,o),
+(315,703,o),
+(229,703,cs),
+(118,703,o),
+(49,625,o),
+(49,511,cs),
+(49,399,o),
+(104,255,o),
+(104,168,cs),
+(104,141,o),
+(91,122,o),
+(60,122,cs),
+(43,122,l),
+(43,0,l)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5711;
+},
+{
+color = 9;
+glyphname = "seCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(506,-14,o),
+(574,67,o),
+(574,179,cs),
+(574,281,o),
+(521,350,o),
+(440,360,c),
+(440,329,l),
+(521,340,o),
+(574,408,o),
+(574,511,cs),
+(574,623,o),
+(506,703,o),
+(411,703,cs),
+(319,703,o),
+(242,613,o),
+(207,613,cs),
+(188,613,o),
+(180,625,o),
+(180,665,cs),
+(180,690,l),
+(52,690,l),
+(52,623,ls),
+(52,530,o),
+(99,489,o),
+(164,489,cs),
+(243,489,o),
+(313,577,o),
+(366,577,cs),
+(409,577,o),
+(433,543,o),
+(433,491,cs),
+(433,433,o),
+(402,402,o),
+(346,402,cs),
+(52,402,l),
+(52,288,l),
+(346,288,ls),
+(402,288,o),
+(433,257,o),
+(433,199,cs),
+(433,147,o),
+(409,113,o),
+(366,113,cs),
+(313,113,o),
+(243,201,o),
+(164,201,cs),
+(99,201,o),
+(52,159,o),
+(52,67,cs),
+(52,0,l),
+(180,0,l),
+(180,25,ls),
+(180,65,o),
+(188,76,o),
+(207,76,cs),
+(242,76,o),
+(319,-14,o),
+(411,-14,cs)
+);
+}
+);
+width = 622;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni1650;
+unicode = 5712;
+},
+{
+color = 9;
+glyphname = "seeCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(506,-14,o),
+(574,67,o),
+(574,179,cs),
+(574,276,o),
+(526,343,o),
+(452,358,c),
+(452,331,l),
+(526,346,o),
+(574,412,o),
+(574,511,cs),
+(574,623,o),
+(506,703,o),
+(411,703,cs),
+(319,703,o),
+(242,613,o),
+(207,613,cs),
+(188,613,o),
+(180,625,o),
+(180,665,cs),
+(180,690,l),
+(52,690,l),
+(52,623,ls),
+(52,530,o),
+(99,489,o),
+(164,489,cs),
+(243,489,o),
+(313,577,o),
+(366,577,cs),
+(409,577,o),
+(433,543,o),
+(433,491,cs),
+(433,433,o),
+(402,399,o),
+(349,399,cs),
+(309,399,l),
+(340,356,l),
+(340,471,l),
+(266,471,l),
+(266,399,l),
+(52,399,l),
+(52,291,l),
+(266,291,l),
+(266,215,l),
+(340,215,l),
+(340,327,l),
+(309,291,l),
+(349,291,ls),
+(402,291,o),
+(433,257,o),
+(433,199,cs),
+(433,147,o),
+(409,113,o),
+(366,113,cs),
+(313,113,o),
+(243,201,o),
+(164,201,cs),
+(99,201,o),
+(52,159,o),
+(52,67,cs),
+(52,0,l),
+(180,0,l),
+(180,25,ls),
+(180,65,o),
+(188,76,o),
+(207,76,cs),
+(242,76,o),
+(319,-14,o),
+(411,-14,cs)
+);
+}
+);
+width = 622;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1651;
+unicode = 5713;
+},
+{
+color = 9;
+glyphname = "siCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(506,-14,o),
+(574,67,o),
+(574,179,cs),
+(574,276,o),
+(526,343,o),
+(452,358,c),
+(452,331,l),
+(526,346,o),
+(574,412,o),
+(574,511,cs),
+(574,623,o),
+(506,703,o),
+(411,703,cs),
+(319,703,o),
+(242,613,o),
+(207,613,cs),
+(188,613,o),
+(180,625,o),
+(180,665,cs),
+(180,690,l),
+(52,690,l),
+(52,623,ls),
+(52,530,o),
+(99,489,o),
+(164,489,cs),
+(243,489,o),
+(313,577,o),
+(367,577,cs),
+(410,577,o),
+(434,542,o),
+(434,487,cs),
+(434,425,o),
+(409,396,o),
+(362,396,cs),
+(306,396,l),
+(358,355,l),
+(354,404,o),
+(316,440,o),
+(267,440,cs),
+(234,440,o),
+(206,424,o),
+(190,399,c),
+(52,399,l),
+(52,291,l),
+(190,291,l),
+(207,266,o),
+(235,250,o),
+(267,250,cs),
+(316,250,o),
+(352,287,o),
+(357,334,c),
+(304,294,l),
+(362,294,ls),
+(409,294,o),
+(434,265,o),
+(434,203,cs),
+(434,148,o),
+(410,113,o),
+(367,113,cs),
+(313,113,o),
+(243,201,o),
+(164,201,cs),
+(99,201,o),
+(52,159,o),
+(52,67,cs),
+(52,0,l),
+(180,0,l),
+(180,25,ls),
+(180,65,o),
+(188,76,o),
+(207,76,cs),
+(242,76,o),
+(319,-14,o),
+(411,-14,cs)
+);
+}
+);
+width = 622;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1652;
+unicode = 5714;
+},
+{
+color = 9;
+glyphname = "saCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(304,-14,o),
+(382,76,o),
+(416,76,cs),
+(435,76,o),
+(443,65,o),
+(443,25,cs),
+(443,0,l),
+(571,0,l),
+(571,67,ls),
+(571,159,o),
+(524,201,o),
+(458,201,cs),
+(380,201,o),
+(310,113,o),
+(256,113,cs),
+(213,113,o),
+(189,147,o),
+(189,199,cs),
+(189,257,o),
+(221,288,o),
+(277,288,cs),
+(571,288,l),
+(571,402,l),
+(277,402,ls),
+(221,402,o),
+(189,433,o),
+(189,491,cs),
+(189,543,o),
+(213,577,o),
+(257,577,cs),
+(310,577,o),
+(380,489,o),
+(458,489,cs),
+(524,489,o),
+(571,530,o),
+(571,623,cs),
+(571,690,l),
+(443,690,l),
+(443,665,ls),
+(443,625,o),
+(435,613,o),
+(416,613,cs),
+(382,613,o),
+(304,703,o),
+(213,703,cs),
+(117,703,o),
+(48,623,o),
+(48,511,cs),
+(48,408,o),
+(101,340,o),
+(183,329,c),
+(183,360,l),
+(102,350,o),
+(48,281,o),
+(48,179,cs),
+(48,67,o),
+(117,-14,o),
+(213,-14,cs)
+);
+}
+);
+width = 623;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1653;
+unicode = 5715;
+},
+{
+color = 9;
+glyphname = "shuCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(309,-14,o),
+(363,31,o),
+(388,117,c),
+(351,117,l),
+(374,31,o),
+(429,-14,o),
+(509,-14,cs),
+(620,-14,o),
+(689,65,o),
+(689,179,cs),
+(689,291,o),
+(634,435,o),
+(634,522,cs),
+(634,549,o),
+(646,568,o),
+(677,568,cs),
+(694,568,l),
+(694,690,l),
+(643,690,ls),
+(542,690,o),
+(500,636,o),
+(500,545,cs),
+(500,527,o),
+(502,507,o),
+(504,489,c),
+(522,570,l),
+(431,570,l),
+(431,690,l),
+(307,690,l),
+(307,570,l),
+(216,570,l),
+(234,489,l),
+(236,507,o),
+(238,527,o),
+(238,545,cs),
+(238,636,o),
+(196,690,o),
+(95,690,cs),
+(43,690,l),
+(43,568,l),
+(60,568,ls),
+(91,568,o),
+(104,548,o),
+(104,522,cs),
+(104,435,o),
+(49,291,o),
+(49,179,cs),
+(49,65,o),
+(118,-14,o),
+(229,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(208,115,o),
+(188,142,o),
+(188,192,cs),
+(188,253,o),
+(216,364,o),
+(231,459,c),
+(307,459,l),
+(307,206,ls),
+(307,144,o),
+(284,115,o),
+(245,115,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(454,115,o),
+(431,144,o),
+(431,206,cs),
+(431,459,l),
+(507,459,l),
+(522,364,o),
+(550,253,o),
+(550,192,cs),
+(550,142,o),
+(531,115,o),
+(494,115,cs)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1654;
+unicode = 5716;
+},
+{
+color = 9;
+glyphname = "shoCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(95,0,ls),
+(196,0,o),
+(238,54,o),
+(238,145,cs),
+(238,162,o),
+(236,183,o),
+(234,201,c),
+(216,120,l),
+(306,120,l),
+(306,0,l),
+(431,0,l),
+(431,120,l),
+(522,120,l),
+(504,201,l),
+(502,183,o),
+(500,162,o),
+(500,145,cs),
+(500,54,o),
+(542,0,o),
+(643,0,cs),
+(694,0,l),
+(694,122,l),
+(677,122,ls),
+(646,122,o),
+(634,142,o),
+(634,168,cs),
+(634,255,o),
+(689,399,o),
+(689,511,cs),
+(689,625,o),
+(620,703,o),
+(509,703,cs),
+(428,703,o),
+(374,659,o),
+(350,573,c),
+(387,573,l),
+(364,659,o),
+(309,703,o),
+(229,703,cs),
+(118,703,o),
+(49,625,o),
+(49,511,cs),
+(49,399,o),
+(104,255,o),
+(104,168,cs),
+(104,141,o),
+(91,122,o),
+(60,122,cs),
+(43,122,l),
+(43,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(216,326,o),
+(187,437,o),
+(187,497,cs),
+(187,548,o),
+(207,575,o),
+(244,575,cs),
+(283,575,o),
+(306,546,o),
+(306,484,cs),
+(306,231,l),
+(231,231,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(431,484,ls),
+(431,546,o),
+(454,575,o),
+(493,575,cs),
+(530,575,o),
+(550,548,o),
+(550,497,cs),
+(550,437,o),
+(521,326,o),
+(507,231,c),
+(431,231,l)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1655;
+unicode = 5717;
+},
+{
+color = 9;
+glyphname = "sheCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(506,-14,o),
+(574,67,o),
+(574,179,cs),
+(574,276,o),
+(526,343,o),
+(452,358,c),
+(452,331,l),
+(526,346,o),
+(574,412,o),
+(574,511,cs),
+(574,623,o),
+(506,703,o),
+(411,703,cs),
+(319,703,o),
+(242,613,o),
+(207,613,cs),
+(188,613,o),
+(180,625,o),
+(180,665,cs),
+(180,690,l),
+(52,690,l),
+(52,623,ls),
+(52,530,o),
+(99,494,o),
+(164,494,cs),
+(185,494,o),
+(205,499,o),
+(225,507,c),
+(137,526,l),
+(137,402,l),
+(52,402,l),
+(52,289,l),
+(137,289,l),
+(137,163,l),
+(223,184,l),
+(204,191,o),
+(185,196,o),
+(164,196,cs),
+(99,196,o),
+(52,159,o),
+(52,67,cs),
+(52,0,l),
+(180,0,l),
+(180,25,ls),
+(180,65,o),
+(188,76,o),
+(207,76,cs),
+(242,76,o),
+(319,-14,o),
+(411,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(247,289,l),
+(346,289,ls),
+(402,289,o),
+(433,257,o),
+(433,199,cs),
+(433,147,o),
+(409,113,o),
+(366,113,cs),
+(331,113,o),
+(291,147,o),
+(247,171,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(247,519,l),
+(291,543,o),
+(331,577,o),
+(366,577,cs),
+(409,577,o),
+(433,543,o),
+(433,491,cs),
+(433,433,o),
+(402,402,o),
+(346,402,cs),
+(247,402,l)
+);
+}
+);
+width = 622;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1656;
+unicode = 5718;
+},
+{
+color = 9;
+glyphname = "sheeCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(506,-14,o),
+(574,67,o),
+(574,179,cs),
+(574,276,o),
+(526,343,o),
+(452,358,c),
+(452,331,l),
+(526,346,o),
+(574,412,o),
+(574,511,cs),
+(574,623,o),
+(506,703,o),
+(411,703,cs),
+(319,703,o),
+(242,613,o),
+(207,613,cs),
+(188,613,o),
+(180,625,o),
+(180,665,cs),
+(180,690,l),
+(52,690,l),
+(52,623,ls),
+(52,530,o),
+(99,494,o),
+(164,494,cs),
+(180,494,o),
+(196,497,o),
+(211,502,c),
+(137,525,l),
+(137,391,l),
+(52,391,l),
+(52,298,l),
+(137,298,l),
+(137,165,l),
+(212,186,l),
+(196,193,o),
+(181,196,o),
+(164,196,cs),
+(99,196,o),
+(52,159,o),
+(52,67,cs),
+(52,0,l),
+(180,0,l),
+(180,25,ls),
+(180,65,o),
+(188,76,o),
+(207,76,cs),
+(242,76,o),
+(319,-14,o),
+(411,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(330,110,o),
+(280,158,o),
+(224,183,c),
+(224,298,l),
+(294,298,l),
+(294,215,l),
+(353,215,l),
+(353,318,l),
+(328,298,l),
+(364,298,ls),
+(412,298,o),
+(438,258,o),
+(438,205,cs),
+(438,145,o),
+(413,110,o),
+(370,110,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(353,471,l),
+(294,471,l),
+(294,391,l),
+(224,391,l),
+(224,507,l),
+(280,531,o),
+(330,580,o),
+(370,580,cs),
+(413,580,o),
+(438,545,o),
+(438,485,cs),
+(438,432,o),
+(412,391,o),
+(364,391,cs),
+(328,391,l),
+(353,372,l)
+);
+}
+);
+width = 622;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1657;
+unicode = 5719;
+},
+{
+color = 9;
+glyphname = "shiCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(52,623,ls),
+(52,530,o),
+(99,494,o),
+(164,494,cs),
+(177,494,o),
+(189,496,o),
+(202,498,c),
+(137,525,l),
+(137,391,l),
+(52,391,l),
+(52,298,l),
+(137,298,l),
+(137,165,l),
+(202,191,l),
+(190,194,o),
+(178,196,o),
+(164,196,cs),
+(99,196,o),
+(52,159,o),
+(52,67,cs),
+(52,0,l),
+(180,0,l),
+(180,25,ls),
+(180,65,o),
+(188,76,o),
+(207,76,cs),
+(242,76,o),
+(319,-14,o),
+(411,-14,cs),
+(506,-14,o),
+(574,67,o),
+(574,179,cs),
+(574,276,o),
+(526,343,o),
+(452,358,c),
+(452,331,l),
+(526,346,o),
+(574,412,o),
+(574,511,cs),
+(574,623,o),
+(506,703,o),
+(411,703,cs),
+(319,703,o),
+(242,613,o),
+(207,613,cs),
+(188,613,o),
+(180,625,o),
+(180,665,cs),
+(180,690,l),
+(52,690,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(224,298,l),
+(248,298,l),
+(264,266,o),
+(292,250,o),
+(323,250,cs),
+(370,250,o),
+(405,292,o),
+(405,335,c),
+(333,298,l),
+(375,298,ls),
+(415,298,o),
+(438,258,o),
+(438,205,cs),
+(438,145,o),
+(413,110,o),
+(370,110,cs),
+(330,110,o),
+(279,157,o),
+(224,183,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(224,507,l),
+(279,532,o),
+(330,580,o),
+(370,580,cs),
+(413,580,o),
+(438,545,o),
+(438,485,cs),
+(438,431,o),
+(414,392,o),
+(375,392,cs),
+(335,392,l),
+(406,354,l),
+(407,400,o),
+(370,440,o),
+(323,440,cs),
+(292,440,o),
+(263,424,o),
+(248,391,c),
+(224,391,l)
+);
+}
+);
+width = 622;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1658;
+unicode = 5720;
+},
+{
+color = 9;
+glyphname = "shaCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(304,-14,o),
+(382,76,o),
+(416,76,cs),
+(435,76,o),
+(443,65,o),
+(443,25,cs),
+(443,0,l),
+(571,0,l),
+(571,67,ls),
+(571,159,o),
+(524,196,o),
+(458,196,cs),
+(437,196,o),
+(418,190,o),
+(398,183,c),
+(486,163,l),
+(486,289,l),
+(571,289,l),
+(571,402,l),
+(486,402,l),
+(486,526,l),
+(399,506,l),
+(418,498,o),
+(438,494,o),
+(458,494,cs),
+(524,494,o),
+(571,530,o),
+(571,623,cs),
+(571,690,l),
+(443,690,l),
+(443,665,ls),
+(443,625,o),
+(435,613,o),
+(416,613,cs),
+(382,613,o),
+(304,703,o),
+(213,703,cs),
+(117,703,o),
+(48,623,o),
+(48,511,cs),
+(48,412,o),
+(97,346,o),
+(171,331,c),
+(171,358,l),
+(97,343,o),
+(48,276,o),
+(48,179,cs),
+(48,67,o),
+(117,-14,o),
+(213,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(213,113,o),
+(189,147,o),
+(189,199,cs),
+(189,257,o),
+(221,289,o),
+(277,289,cs),
+(376,289,l),
+(376,171,l),
+(332,147,o),
+(291,113,o),
+(256,113,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(221,402,o),
+(189,433,o),
+(189,491,cs),
+(189,543,o),
+(213,577,o),
+(257,577,cs),
+(291,577,o),
+(332,543,o),
+(376,519,c),
+(376,402,l),
+(277,402,ls)
+);
+}
+);
+width = 623;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1659;
+unicode = 5721;
+},
+{
+color = 6;
+glyphname = "shCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(219,96,l),
+(219,197,l),
+(152,183,l),
+(186,183,ls),
+(265,183,o),
+(305,220,o),
+(305,287,cs),
+(305,353,o),
+(267,392,o),
+(200,392,cs),
+(170,392,ls),
+(144,392,o),
+(129,400,o),
+(129,422,cs),
+(129,446,o),
+(145,454,o),
+(170,454,cs),
+(299,454,l),
+(299,527,l),
+(219,527,l),
+(219,614,l),
+(130,614,l),
+(130,504,l),
+(194,527,l),
+(162,527,ls),
+(84,527,o),
+(43,490,o),
+(43,423,cs),
+(43,358,o),
+(81,319,o),
+(149,319,cs),
+(179,319,ls),
+(204,319,o),
+(219,310,o),
+(219,288,cs),
+(219,265,o),
+(205,257,o),
+(179,257,cs),
+(49,257,l),
+(49,183,l),
+(130,183,l),
+(130,96,l)
+);
+}
+);
+width = 348;
+}
+);
+metricRight = "=|";
+note = uni18F5;
+unicode = 5722;
+},
+{
+color = 9;
+glyphname = "tsuCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(309,-14,o),
+(363,31,o),
+(388,117,c),
+(351,117,l),
+(374,31,o),
+(429,-14,o),
+(509,-14,cs),
+(620,-14,o),
+(689,65,o),
+(689,179,cs),
+(689,291,o),
+(634,435,o),
+(634,522,cs),
+(634,549,o),
+(646,568,o),
+(677,568,cs),
+(694,568,l),
+(694,690,l),
+(643,690,ls),
+(545,690,o),
+(503,641,o),
+(503,550,cs),
+(503,506,o),
+(514,454,o),
+(524,401,c),
+(429,401,l),
+(429,594,l),
+(477,594,l),
+(477,690,l),
+(260,690,l),
+(260,594,l),
+(309,594,l),
+(309,401,l),
+(214,401,l),
+(224,454,o),
+(235,506,o),
+(235,550,cs),
+(235,641,o),
+(193,690,o),
+(95,690,cs),
+(43,690,l),
+(43,568,l),
+(60,568,ls),
+(91,568,o),
+(104,548,o),
+(104,522,cs),
+(104,435,o),
+(49,291,o),
+(49,179,cs),
+(49,65,o),
+(118,-14,o),
+(229,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(209,115,o),
+(188,142,o),
+(188,192,cs),
+(188,217,o),
+(192,251,o),
+(198,290,c),
+(309,290,l),
+(309,206,ls),
+(309,144,o),
+(285,115,o),
+(246,115,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(453,115,o),
+(429,144,o),
+(429,206,cs),
+(429,290,l),
+(540,290,l),
+(546,251,o),
+(550,217,o),
+(550,192,cs),
+(550,142,o),
+(529,115,o),
+(492,115,cs)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165B;
+unicode = 5723;
+},
+{
+color = 9;
+glyphname = "tsoCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(95,0,ls),
+(193,0,o),
+(234,48,o),
+(234,140,cs),
+(234,184,o),
+(223,236,o),
+(213,289,c),
+(309,289,l),
+(309,96,l),
+(261,96,l),
+(261,0,l),
+(477,0,l),
+(477,96,l),
+(429,96,l),
+(429,289,l),
+(524,289,l),
+(514,236,o),
+(503,184,o),
+(503,140,cs),
+(503,48,o),
+(545,0,o),
+(643,0,cs),
+(694,0,l),
+(694,122,l),
+(677,122,ls),
+(646,122,o),
+(634,142,o),
+(634,168,cs),
+(634,255,o),
+(689,399,o),
+(689,511,cs),
+(689,625,o),
+(620,703,o),
+(509,703,cs),
+(428,703,o),
+(374,659,o),
+(351,573,c),
+(388,573,l),
+(363,659,o),
+(309,703,o),
+(229,703,cs),
+(118,703,o),
+(49,625,o),
+(49,511,cs),
+(49,399,o),
+(104,255,o),
+(104,168,cs),
+(104,141,o),
+(91,122,o),
+(60,122,cs),
+(43,122,l),
+(43,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(192,439,o),
+(187,472,o),
+(187,497,cs),
+(187,548,o),
+(208,575,o),
+(245,575,cs),
+(285,575,o),
+(309,546,o),
+(309,484,cs),
+(309,400,l),
+(198,400,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(429,484,ls),
+(429,546,o),
+(453,575,o),
+(492,575,cs),
+(529,575,o),
+(550,548,o),
+(550,497,cs),
+(550,472,o),
+(545,439,o),
+(539,400,c),
+(429,400,l)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165C;
+unicode = 5724;
+},
+{
+color = 9;
+glyphname = "tseCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(507,-14,o),
+(576,67,o),
+(576,179,cs),
+(576,276,o),
+(526,343,o),
+(453,358,c),
+(453,331,l),
+(527,346,o),
+(576,412,o),
+(576,511,cs),
+(576,623,o),
+(507,703,o),
+(412,703,cs),
+(320,703,o),
+(242,613,o),
+(208,613,cs),
+(189,613,o),
+(181,625,o),
+(181,665,cs),
+(181,690,l),
+(53,690,l),
+(53,627,ls),
+(53,534,o),
+(100,497,o),
+(166,497,cs),
+(191,497,o),
+(216,505,o),
+(241,518,c),
+(195,529,l),
+(195,391,l),
+(128,391,l),
+(128,456,l),
+(53,456,l),
+(53,234,l),
+(128,234,l),
+(128,298,l),
+(195,298,l),
+(195,160,l),
+(242,172,l),
+(217,185,o),
+(191,193,o),
+(166,193,cs),
+(100,193,o),
+(53,156,o),
+(53,63,cs),
+(53,0,l),
+(181,0,l),
+(181,25,ls),
+(181,65,o),
+(189,76,o),
+(208,76,cs),
+(242,76,o),
+(320,-14,o),
+(412,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(344,113,o),
+(314,131,o),
+(282,151,c),
+(282,298,l),
+(349,298,ls),
+(406,298,o),
+(437,260,o),
+(437,201,cs),
+(437,148,o),
+(412,113,o),
+(369,113,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(282,539,l),
+(314,558,o),
+(344,577,o),
+(369,577,cs),
+(412,577,o),
+(437,542,o),
+(437,489,cs),
+(437,430,o),
+(405,391,o),
+(349,391,cs),
+(282,391,l)
+);
+}
+);
+width = 624;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni165D;
+unicode = 5725;
+},
+{
+color = 9;
+glyphname = "tseeCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(507,-14,o),
+(576,67,o),
+(576,179,cs),
+(576,276,o),
+(526,343,o),
+(453,358,c),
+(453,331,l),
+(527,346,o),
+(576,412,o),
+(576,511,cs),
+(576,623,o),
+(507,703,o),
+(412,703,cs),
+(320,703,o),
+(242,613,o),
+(208,613,cs),
+(189,613,o),
+(181,625,o),
+(181,665,cs),
+(181,690,l),
+(53,690,l),
+(53,627,ls),
+(53,534,o),
+(100,497,o),
+(166,497,cs),
+(184,497,o),
+(202,503,o),
+(220,511,c),
+(183,537,l),
+(183,389,l),
+(121,389,l),
+(121,456,l),
+(53,456,l),
+(53,234,l),
+(121,234,l),
+(121,300,l),
+(183,300,l),
+(183,151,l),
+(216,181,l),
+(200,187,o),
+(183,193,o),
+(166,193,cs),
+(100,193,o),
+(53,156,o),
+(53,63,cs),
+(53,0,l),
+(181,0,l),
+(181,25,ls),
+(181,65,o),
+(189,76,o),
+(208,76,cs),
+(242,76,o),
+(320,-14,o),
+(412,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(338,113,o),
+(300,141,o),
+(258,164,c),
+(258,300,l),
+(311,300,l),
+(311,208,l),
+(370,208,l),
+(370,324,l),
+(342,300,l),
+(371,300,ls),
+(419,300,o),
+(440,260,o),
+(440,208,cs),
+(440,148,o),
+(415,113,o),
+(369,113,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(370,479,l),
+(311,479,l),
+(311,389,l),
+(258,389,l),
+(258,526,l),
+(300,549,o),
+(338,577,o),
+(369,577,cs),
+(415,577,o),
+(440,542,o),
+(440,482,cs),
+(440,430,o),
+(418,389,o),
+(371,389,cs),
+(342,389,l),
+(370,366,l)
+);
+}
+);
+width = 624;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165E;
+unicode = 5726;
+},
+{
+color = 9;
+glyphname = "tsiCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(507,-14,o),
+(576,67,o),
+(576,179,cs),
+(576,276,o),
+(526,343,o),
+(453,358,c),
+(453,331,l),
+(527,346,o),
+(576,412,o),
+(576,511,cs),
+(576,623,o),
+(507,703,o),
+(412,703,cs),
+(320,703,o),
+(242,613,o),
+(208,613,cs),
+(189,613,o),
+(181,625,o),
+(181,665,cs),
+(181,690,l),
+(53,690,l),
+(53,627,ls),
+(53,533,o),
+(100,497,o),
+(166,497,cs),
+(187,497,o),
+(208,504,o),
+(229,513,c),
+(178,528,l),
+(178,389,l),
+(121,389,l),
+(121,456,l),
+(53,456,l),
+(53,234,l),
+(121,234,l),
+(121,300,l),
+(178,300,l),
+(178,161,l),
+(228,178,l),
+(207,185,o),
+(186,193,o),
+(166,193,cs),
+(100,193,o),
+(53,156,o),
+(53,63,cs),
+(53,0,l),
+(181,0,l),
+(181,25,ls),
+(181,65,o),
+(189,76,o),
+(208,76,cs),
+(242,76,o),
+(320,-14,o),
+(412,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(336,113,o),
+(298,143,o),
+(253,165,c),
+(253,300,l),
+(274,300,l),
+(286,268,o),
+(312,250,o),
+(342,250,cs),
+(389,250,o),
+(413,295,o),
+(416,333,c),
+(355,300,l),
+(374,300,ls),
+(420,300,o),
+(440,261,o),
+(440,208,cs),
+(440,148,o),
+(415,113,o),
+(369,113,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(414,397,o),
+(390,440,o),
+(342,440,cs),
+(312,440,o),
+(286,423,o),
+(274,389,c),
+(253,389,l),
+(253,525,l),
+(298,547,o),
+(336,577,o),
+(369,577,cs),
+(415,577,o),
+(440,542,o),
+(440,482,cs),
+(440,429,o),
+(419,389,o),
+(374,389,cs),
+(356,389,l),
+(416,351,l)
+);
+}
+);
+width = 624;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165F;
+unicode = 5727;
+},
+{
+color = 9;
+glyphname = "tsaCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(304,-14,o),
+(382,76,o),
+(416,76,cs),
+(435,76,o),
+(443,65,o),
+(443,25,cs),
+(443,0,l),
+(571,0,l),
+(571,63,ls),
+(571,156,o),
+(524,193,o),
+(458,193,cs),
+(433,193,o),
+(407,185,o),
+(383,172,c),
+(429,160,l),
+(429,298,l),
+(497,298,l),
+(497,234,l),
+(571,234,l),
+(571,456,l),
+(497,456,l),
+(497,391,l),
+(429,391,l),
+(429,529,l),
+(383,518,l),
+(408,505,o),
+(433,497,o),
+(458,497,cs),
+(524,497,o),
+(571,534,o),
+(571,627,cs),
+(571,690,l),
+(443,690,l),
+(443,665,ls),
+(443,625,o),
+(435,613,o),
+(416,613,cs),
+(382,613,o),
+(304,703,o),
+(213,703,cs),
+(117,703,o),
+(48,623,o),
+(48,511,cs),
+(48,412,o),
+(97,346,o),
+(171,331,c),
+(171,358,l),
+(97,343,o),
+(48,276,o),
+(48,179,cs),
+(48,67,o),
+(117,-14,o),
+(213,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(212,113,o),
+(187,148,o),
+(187,201,cs),
+(187,260,o),
+(218,298,o),
+(275,298,cs),
+(342,298,l),
+(342,151,l),
+(310,131,o),
+(280,113,o),
+(255,113,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(219,391,o),
+(187,430,o),
+(187,489,cs),
+(187,542,o),
+(212,577,o),
+(255,577,cs),
+(280,577,o),
+(310,558,o),
+(342,539,c),
+(342,391,l),
+(275,391,ls)
+);
+}
+);
+width = 624;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1660;
+unicode = 5728;
+},
+{
+color = 9;
+glyphname = "chuCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(309,-14,o),
+(363,31,o),
+(388,117,c),
+(351,117,l),
+(374,31,o),
+(429,-14,o),
+(509,-14,cs),
+(620,-14,o),
+(689,65,o),
+(689,179,cs),
+(689,291,o),
+(634,435,o),
+(634,522,cs),
+(634,549,o),
+(646,568,o),
+(677,568,cs),
+(694,568,l),
+(694,690,l),
+(643,690,ls),
+(545,690,o),
+(503,641,o),
+(503,550,cs),
+(503,435,o),
+(550,272,o),
+(550,192,cs),
+(550,142,o),
+(529,115,o),
+(492,115,cs),
+(453,115,o),
+(429,144,o),
+(429,206,cs),
+(429,594,l),
+(477,594,l),
+(477,690,l),
+(260,690,l),
+(260,594,l),
+(309,594,l),
+(309,206,ls),
+(309,144,o),
+(285,115,o),
+(246,115,cs),
+(209,115,o),
+(188,142,o),
+(188,192,cs),
+(188,272,o),
+(235,435,o),
+(235,550,cs),
+(235,641,o),
+(193,690,o),
+(95,690,cs),
+(43,690,l),
+(43,568,l),
+(60,568,ls),
+(91,568,o),
+(104,548,o),
+(104,522,cs),
+(104,435,o),
+(49,291,o),
+(49,179,cs),
+(49,65,o),
+(118,-14,o),
+(229,-14,cs)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164E;
+unicode = 5729;
+},
+{
+color = 9;
+glyphname = "choCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(95,0,ls),
+(193,0,o),
+(234,48,o),
+(234,140,cs),
+(234,255,o),
+(187,417,o),
+(187,497,cs),
+(187,548,o),
+(208,575,o),
+(245,575,cs),
+(285,575,o),
+(309,546,o),
+(309,484,cs),
+(309,96,l),
+(261,96,l),
+(261,0,l),
+(477,0,l),
+(477,96,l),
+(429,96,l),
+(429,484,ls),
+(429,546,o),
+(453,575,o),
+(492,575,cs),
+(529,575,o),
+(550,548,o),
+(550,497,cs),
+(550,417,o),
+(503,255,o),
+(503,140,cs),
+(503,48,o),
+(545,0,o),
+(643,0,cs),
+(694,0,l),
+(694,122,l),
+(677,122,ls),
+(646,122,o),
+(634,142,o),
+(634,168,cs),
+(634,255,o),
+(689,399,o),
+(689,511,cs),
+(689,625,o),
+(620,703,o),
+(509,703,cs),
+(428,703,o),
+(374,659,o),
+(351,573,c),
+(388,573,l),
+(363,659,o),
+(309,703,o),
+(229,703,cs),
+(118,703,o),
+(49,625,o),
+(49,511,cs),
+(49,399,o),
+(104,255,o),
+(104,168,cs),
+(104,141,o),
+(91,122,o),
+(60,122,cs),
+(43,122,l),
+(43,0,l)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5730;
+},
+{
+color = 9;
+glyphname = "cheCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(507,-14,o),
+(576,67,o),
+(576,179,cs),
+(576,276,o),
+(526,343,o),
+(453,358,c),
+(453,331,l),
+(527,346,o),
+(576,412,o),
+(576,511,cs),
+(576,623,o),
+(507,703,o),
+(412,703,cs),
+(320,703,o),
+(242,613,o),
+(208,613,cs),
+(189,613,o),
+(181,625,o),
+(181,665,cs),
+(181,690,l),
+(53,690,l),
+(53,624,ls),
+(53,531,o),
+(100,494,o),
+(166,494,cs),
+(244,494,o),
+(314,577,o),
+(367,577,cs),
+(411,577,o),
+(435,543,o),
+(435,491,cs),
+(435,433,o),
+(403,402,o),
+(347,402,cs),
+(128,402,l),
+(128,456,l),
+(53,456,l),
+(53,234,l),
+(128,234,l),
+(128,289,l),
+(347,289,ls),
+(403,289,o),
+(435,257,o),
+(435,199,cs),
+(435,147,o),
+(411,113,o),
+(367,113,cs),
+(314,113,o),
+(244,196,o),
+(166,196,cs),
+(100,196,o),
+(53,158,o),
+(53,66,cs),
+(53,0,l),
+(181,0,l),
+(181,25,ls),
+(181,65,o),
+(189,76,o),
+(208,76,cs),
+(242,76,o),
+(320,-14,o),
+(412,-14,cs)
+);
+}
+);
+width = 624;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni1663;
+unicode = 5731;
+},
+{
+color = 9;
+glyphname = "cheeCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(507,-14,o),
+(576,67,o),
+(576,179,cs),
+(576,276,o),
+(526,343,o),
+(453,358,c),
+(453,331,l),
+(527,346,o),
+(576,412,o),
+(576,511,cs),
+(576,623,o),
+(507,703,o),
+(412,703,cs),
+(320,703,o),
+(242,613,o),
+(208,613,cs),
+(189,613,o),
+(181,625,o),
+(181,665,cs),
+(181,690,l),
+(53,690,l),
+(53,624,ls),
+(53,531,o),
+(100,494,o),
+(166,494,cs),
+(245,494,o),
+(317,580,o),
+(371,580,cs),
+(414,580,o),
+(439,545,o),
+(439,491,cs),
+(439,432,o),
+(413,391,o),
+(365,391,cs),
+(312,391,l),
+(344,374,l),
+(344,471,l),
+(270,471,l),
+(270,391,l),
+(128,391,l),
+(128,456,l),
+(53,456,l),
+(53,234,l),
+(128,234,l),
+(128,298,l),
+(270,298,l),
+(270,215,l),
+(344,215,l),
+(344,316,l),
+(312,298,l),
+(365,298,ls),
+(413,298,o),
+(439,258,o),
+(439,199,cs),
+(439,145,o),
+(414,110,o),
+(371,110,cs),
+(317,110,o),
+(245,196,o),
+(166,196,cs),
+(100,196,o),
+(53,158,o),
+(53,66,cs),
+(53,0,l),
+(181,0,l),
+(181,25,ls),
+(181,65,o),
+(189,76,o),
+(208,76,cs),
+(242,76,o),
+(320,-14,o),
+(412,-14,cs)
+);
+}
+);
+width = 624;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1664;
+unicode = 5732;
+},
+{
+color = 9;
+glyphname = "chiCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(507,-14,o),
+(576,67,o),
+(576,179,cs),
+(576,276,o),
+(526,343,o),
+(453,358,c),
+(453,331,l),
+(527,346,o),
+(576,412,o),
+(576,511,cs),
+(576,623,o),
+(507,703,o),
+(412,703,cs),
+(320,703,o),
+(242,613,o),
+(208,613,cs),
+(189,613,o),
+(181,625,o),
+(181,665,cs),
+(181,690,l),
+(53,690,l),
+(53,624,ls),
+(53,531,o),
+(100,494,o),
+(166,494,cs),
+(245,494,o),
+(317,580,o),
+(371,580,cs),
+(414,580,o),
+(439,545,o),
+(439,491,cs),
+(439,432,o),
+(413,391,o),
+(366,391,cs),
+(306,391,l),
+(373,349,l),
+(370,401,o),
+(333,440,o),
+(281,440,cs),
+(245,440,o),
+(215,420,o),
+(200,391,c),
+(128,391,l),
+(128,456,l),
+(53,456,l),
+(53,234,l),
+(128,234,l),
+(128,298,l),
+(200,298,l),
+(215,270,o),
+(245,250,o),
+(281,250,cs),
+(333,250,o),
+(369,291,o),
+(375,339,c),
+(305,298,l),
+(366,298,ls),
+(413,298,o),
+(439,258,o),
+(439,199,cs),
+(439,145,o),
+(414,110,o),
+(371,110,cs),
+(317,110,o),
+(245,196,o),
+(166,196,cs),
+(100,196,o),
+(53,158,o),
+(53,66,cs),
+(53,0,l),
+(181,0,l),
+(181,25,ls),
+(181,65,o),
+(189,76,o),
+(208,76,cs),
+(242,76,o),
+(320,-14,o),
+(412,-14,cs)
+);
+}
+);
+width = 624;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1665;
+unicode = 5733;
+},
+{
+color = 9;
+glyphname = "chaCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(304,-14,o),
+(382,76,o),
+(416,76,cs),
+(435,76,o),
+(443,65,o),
+(443,25,cs),
+(443,0,l),
+(571,0,l),
+(571,66,ls),
+(571,158,o),
+(524,196,o),
+(458,196,cs),
+(380,196,o),
+(310,113,o),
+(257,113,cs),
+(213,113,o),
+(189,147,o),
+(189,199,cs),
+(189,257,o),
+(221,289,o),
+(277,289,cs),
+(497,289,l),
+(497,234,l),
+(571,234,l),
+(571,456,l),
+(497,456,l),
+(497,402,l),
+(277,402,ls),
+(221,402,o),
+(189,433,o),
+(189,491,cs),
+(189,543,o),
+(213,577,o),
+(256,577,cs),
+(310,577,o),
+(380,494,o),
+(458,494,cs),
+(524,494,o),
+(571,531,o),
+(571,624,cs),
+(571,690,l),
+(443,690,l),
+(443,665,ls),
+(443,625,o),
+(435,613,o),
+(416,613,cs),
+(382,613,o),
+(304,703,o),
+(213,703,cs),
+(117,703,o),
+(48,623,o),
+(48,511,cs),
+(48,412,o),
+(97,346,o),
+(171,331,c),
+(171,358,l),
+(97,343,o),
+(48,276,o),
+(48,179,cs),
+(48,67,o),
+(117,-14,o),
+(213,-14,cs)
+);
+}
+);
+width = 624;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1666;
+unicode = 5734;
+},
+{
+color = 9;
+glyphname = "ttsuCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(309,-14,o),
+(363,31,o),
+(388,117,c),
+(351,117,l),
+(374,31,o),
+(429,-14,o),
+(509,-14,cs),
+(620,-14,o),
+(689,65,o),
+(689,179,cs),
+(689,291,o),
+(634,435,o),
+(634,522,cs),
+(634,549,o),
+(646,568,o),
+(677,568,cs),
+(694,568,l),
+(694,690,l),
+(643,690,ls),
+(545,690,o),
+(503,641,o),
+(503,550,cs),
+(503,515,o),
+(508,475,o),
+(511,435,c),
+(559,545,l),
+(429,440,l),
+(429,594,l),
+(477,594,l),
+(477,690,l),
+(260,690,l),
+(260,594,l),
+(309,594,l),
+(309,439,l),
+(180,545,l),
+(226,435,l),
+(230,476,o),
+(235,515,o),
+(235,550,cs),
+(235,641,o),
+(193,690,o),
+(95,690,cs),
+(43,690,l),
+(43,568,l),
+(60,568,ls),
+(91,568,o),
+(104,548,o),
+(104,522,cs),
+(104,435,o),
+(49,291,o),
+(49,179,cs),
+(49,65,o),
+(118,-14,o),
+(229,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(209,115,o),
+(188,142,o),
+(188,192,cs),
+(188,240,o),
+(205,309,o),
+(217,382,c),
+(309,309,l),
+(309,206,ls),
+(309,144,o),
+(285,115,o),
+(246,115,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(453,115,o),
+(429,144,o),
+(429,206,cs),
+(429,309,l),
+(521,382,l),
+(533,309,o),
+(550,240,o),
+(550,192,cs),
+(550,142,o),
+(529,115,o),
+(492,115,cs)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1667;
+unicode = 5735;
+},
+{
+color = 9;
+glyphname = "ttsoCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(95,0,ls),
+(193,0,o),
+(235,48,o),
+(235,140,cs),
+(235,175,o),
+(230,213,o),
+(226,255,c),
+(180,145,l),
+(309,251,l),
+(309,96,l),
+(260,96,l),
+(260,0,l),
+(477,0,l),
+(477,96,l),
+(429,96,l),
+(429,250,l),
+(559,145,l),
+(511,255,l),
+(508,214,o),
+(503,175,o),
+(503,140,cs),
+(503,48,o),
+(545,0,o),
+(643,0,cs),
+(694,0,l),
+(694,122,l),
+(677,122,ls),
+(646,122,o),
+(634,141,o),
+(634,168,cs),
+(634,255,o),
+(689,399,o),
+(689,511,cs),
+(689,625,o),
+(620,703,o),
+(509,703,cs),
+(429,703,o),
+(374,659,o),
+(351,573,c),
+(388,573,l),
+(363,659,o),
+(309,703,o),
+(229,703,cs),
+(118,703,o),
+(49,625,o),
+(49,511,cs),
+(49,399,o),
+(104,255,o),
+(104,168,cs),
+(104,142,o),
+(91,122,o),
+(60,122,cs),
+(43,122,l),
+(43,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(205,381,o),
+(188,450,o),
+(188,497,cs),
+(188,548,o),
+(209,575,o),
+(246,575,cs),
+(285,575,o),
+(309,546,o),
+(309,484,cs),
+(309,381,l),
+(217,308,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(429,381,l),
+(429,484,ls),
+(429,546,o),
+(453,575,o),
+(492,575,cs),
+(529,575,o),
+(550,548,o),
+(550,497,cs),
+(550,450,o),
+(533,381,o),
+(521,308,c)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1668;
+unicode = 5736;
+},
+{
+color = 9;
+glyphname = "ttseCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(507,-14,o),
+(576,67,o),
+(576,179,cs),
+(576,276,o),
+(526,343,o),
+(453,358,c),
+(453,331,l),
+(527,346,o),
+(576,412,o),
+(576,511,cs),
+(576,623,o),
+(507,703,o),
+(412,703,cs),
+(320,703,o),
+(242,613,o),
+(208,613,cs),
+(189,613,o),
+(181,625,o),
+(181,665,cs),
+(181,690,l),
+(53,690,l),
+(53,624,ls),
+(53,531,o),
+(100,494,o),
+(166,494,cs),
+(185,494,o),
+(202,498,o),
+(216,506,c),
+(131,559,l),
+(194,391,l),
+(128,391,l),
+(128,456,l),
+(53,456,l),
+(53,234,l),
+(128,234,l),
+(128,298,l),
+(194,298,l),
+(131,130,l),
+(217,184,l),
+(201,191,o),
+(185,196,o),
+(166,196,cs),
+(100,196,o),
+(53,158,o),
+(53,66,cs),
+(53,0,l),
+(181,0,l),
+(181,25,ls),
+(181,65,o),
+(189,76,o),
+(208,76,cs),
+(242,76,o),
+(320,-14,o),
+(412,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(333,110,o),
+(289,152,o),
+(243,173,c),
+(288,298,l),
+(366,298,ls),
+(413,298,o),
+(439,258,o),
+(439,199,cs),
+(439,145,o),
+(414,110,o),
+(371,110,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(243,517,l),
+(289,538,o),
+(333,580,o),
+(371,580,cs),
+(414,580,o),
+(439,545,o),
+(439,491,cs),
+(439,432,o),
+(413,391,o),
+(366,391,cs),
+(288,391,l)
+);
+}
+);
+width = 624;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1669;
+unicode = 5737;
+},
+{
+color = 9;
+glyphname = "ttseeCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(507,-14,o),
+(576,67,o),
+(576,179,cs),
+(576,276,o),
+(526,343,o),
+(453,358,c),
+(453,331,l),
+(527,346,o),
+(576,412,o),
+(576,511,cs),
+(576,623,o),
+(507,703,o),
+(412,703,cs),
+(320,703,o),
+(242,613,o),
+(208,613,cs),
+(189,613,o),
+(181,625,o),
+(181,665,cs),
+(181,690,l),
+(53,690,l),
+(53,624,ls),
+(53,531,o),
+(100,494,o),
+(166,494,cs),
+(180,494,o),
+(195,496,o),
+(203,502,c),
+(127,555,l),
+(188,391,l),
+(128,391,l),
+(128,456,l),
+(53,456,l),
+(53,234,l),
+(128,234,l),
+(128,298,l),
+(188,298,l),
+(127,134,l),
+(202,187,l),
+(194,194,o),
+(180,196,o),
+(166,196,cs),
+(100,196,o),
+(53,158,o),
+(53,66,cs),
+(53,0,l),
+(181,0,l),
+(181,25,ls),
+(181,65,o),
+(189,76,o),
+(208,76,cs),
+(242,76,o),
+(320,-14,o),
+(412,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(330,110,o),
+(283,156,o),
+(233,179,c),
+(276,298,l),
+(309,298,l),
+(309,208,l),
+(375,208,l),
+(375,318,l),
+(349,298,l),
+(366,298,ls),
+(413,298,o),
+(439,258,o),
+(439,199,cs),
+(439,145,o),
+(414,110,o),
+(371,110,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(375,479,l),
+(309,479,l),
+(309,391,l),
+(276,391,l),
+(233,511,l),
+(283,533,o),
+(330,580,o),
+(371,580,cs),
+(414,580,o),
+(439,545,o),
+(439,491,cs),
+(439,432,o),
+(413,391,o),
+(366,391,cs),
+(349,391,l),
+(375,372,l)
+);
+}
+);
+width = 624;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166A;
+unicode = 5738;
+},
+{
+color = 9;
+glyphname = "ttsiCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(507,-14,o),
+(576,67,o),
+(576,179,cs),
+(576,276,o),
+(526,343,o),
+(453,358,c),
+(453,331,l),
+(527,346,o),
+(576,412,o),
+(576,511,cs),
+(576,623,o),
+(507,703,o),
+(412,703,cs),
+(320,703,o),
+(242,613,o),
+(208,613,cs),
+(189,613,o),
+(181,625,o),
+(181,665,cs),
+(181,690,l),
+(53,690,l),
+(53,624,ls),
+(53,531,o),
+(100,494,o),
+(166,494,cs),
+(179,494,o),
+(188,495,o),
+(206,502,c),
+(140,519,l),
+(188,391,l),
+(128,391,l),
+(128,456,l),
+(53,456,l),
+(53,234,l),
+(128,234,l),
+(128,298,l),
+(188,298,l),
+(135,157,l),
+(204,188,l),
+(187,195,o),
+(178,196,o),
+(166,196,cs),
+(100,196,o),
+(53,158,o),
+(53,66,cs),
+(53,0,l),
+(181,0,l),
+(181,25,ls),
+(181,65,o),
+(189,76,o),
+(208,76,cs),
+(242,76,o),
+(320,-14,o),
+(412,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(330,110,o),
+(271,164,o),
+(221,185,c),
+(263,298,l),
+(265,298,l),
+(278,270,o),
+(304,250,o),
+(336,250,cs),
+(373,250,o),
+(403,278,o),
+(412,316,c),
+(347,298,l),
+(375,298,ls),
+(421,298,o),
+(439,258,o),
+(439,199,cs),
+(439,145,o),
+(414,110,o),
+(371,110,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(405,412,o),
+(375,440,o),
+(335,440,cs),
+(303,440,o),
+(277,420,o),
+(265,391,c),
+(263,391,l),
+(221,505,l),
+(271,526,o),
+(330,580,o),
+(371,580,cs),
+(414,580,o),
+(439,545,o),
+(439,491,cs),
+(439,432,o),
+(420,391,o),
+(375,391,cs),
+(348,391,l),
+(412,372,l)
+);
+}
+);
+width = 624;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166B;
+unicode = 5739;
+},
+{
+color = 9;
+glyphname = "ttsaCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(304,-14,o),
+(382,76,o),
+(416,76,cs),
+(435,76,o),
+(443,65,o),
+(443,25,cs),
+(443,0,l),
+(571,0,l),
+(571,66,ls),
+(571,158,o),
+(524,196,o),
+(458,196,cs),
+(440,196,o),
+(423,191,o),
+(407,184,c),
+(493,130,l),
+(430,298,l),
+(497,298,l),
+(497,234,l),
+(571,234,l),
+(571,456,l),
+(497,456,l),
+(497,391,l),
+(430,391,l),
+(493,559,l),
+(407,506,l),
+(422,498,o),
+(440,494,o),
+(458,494,cs),
+(524,494,o),
+(571,531,o),
+(571,624,cs),
+(571,690,l),
+(443,690,l),
+(443,665,ls),
+(443,625,o),
+(435,613,o),
+(416,613,cs),
+(382,613,o),
+(304,703,o),
+(213,703,cs),
+(117,703,o),
+(48,623,o),
+(48,511,cs),
+(48,412,o),
+(97,346,o),
+(171,331,c),
+(171,358,l),
+(97,343,o),
+(48,276,o),
+(48,179,cs),
+(48,67,o),
+(117,-14,o),
+(213,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(210,110,o),
+(185,145,o),
+(185,199,cs),
+(185,258,o),
+(211,298,o),
+(258,298,cs),
+(335,298,l),
+(381,173,l),
+(335,152,o),
+(291,110,o),
+(253,110,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(211,391,o),
+(185,432,o),
+(185,491,cs),
+(185,545,o),
+(210,580,o),
+(253,580,cs),
+(291,580,o),
+(335,538,o),
+(381,517,c),
+(335,391,l),
+(258,391,ls)
+);
+}
+);
+width = 624;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni166C;
+unicode = 5740;
+},
+{
+glyphname = "qai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (277,0);
+ref = "ke-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni166F;
+unicode = 5743;
+},
+{
+glyphname = "ngai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (517,0);
+ref = "ce-canadian";
+}
+);
+width = 1016;
+}
+);
+note = uni1670;
+unicode = 5744;
+},
+{
+glyphname = "nngi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (769,0);
+ref = "ci-canadian";
+}
+);
+width = 1267;
+}
+);
+note = uni1671;
+unicode = 5745;
+},
+{
+glyphname = "nngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (769,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (944,0);
+ref = dot_top;
+}
+);
+width = 1267;
+}
+);
+note = uni1672;
+unicode = 5746;
+},
+{
+glyphname = "nngo-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (769,0);
+ref = "ce-canadian";
+}
+);
+width = 1267;
+}
+);
+note = uni1673;
+unicode = 5747;
+},
+{
+glyphname = "nngoo-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (769,0);
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (930,0);
+ref = dot_top;
+}
+);
+width = 1267;
+}
+);
+note = uni1674;
+unicode = 5748;
+},
+{
+glyphname = "nnga-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (769,0);
+ref = "ca-canadian";
+}
+);
+width = 1267;
+}
+);
+note = uni1675;
+unicode = 5749;
+},
+{
+glyphname = "nngaa-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (769,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (804,0);
+ref = dot_top;
+}
+);
+width = 1267;
+}
+);
+note = uni1676;
+unicode = 5750;
+},
+{
+glyphname = "thweeWoodScree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (525,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 728;
+}
+);
+note = uni1677;
+unicode = 5751;
+},
+{
+glyphname = "thwiWoodScree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (525,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 728;
+}
+);
+note = uni1678;
+unicode = 5752;
+},
+{
+glyphname = "thwiiWoodScree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (71,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (525,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 728;
+}
+);
+note = uni1679;
+unicode = 5753;
+},
+{
+glyphname = "thwoWoodScree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (525,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 728;
+}
+);
+note = uni167A;
+unicode = 5754;
+},
+{
+glyphname = "thwooWoodScree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (288,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (525,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 728;
+}
+);
+note = uni167B;
+unicode = 5755;
+},
+{
+glyphname = "thwaWoodScree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = middle_right_can;
+pos = (525,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 729;
+}
+);
+note = uni167C;
+unicode = 5756;
+},
+{
+glyphname = "thwaaWoodScree-canadian";
+lastChange = "2023-01-13 15:56:39 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (72,0);
+ref = dot_top;
+},
+{
+anchor = middle_right_can;
+pos = (525,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 729;
+}
+);
+note = uni167D;
+unicode = 5757;
+},
+{
+glyphname = "wBlackfoot-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(315,548,l),
+(315,628,l),
+(43,628,l),
+(43,548,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(315,407,l),
+(315,487,l),
+(43,487,l),
+(43,407,l)
+);
+}
+);
+width = 358;
+}
+);
+metricRight = "=|";
+note = uni167F;
+unicode = 5759;
+},
+{
+glyphname = "oy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-11,0);
+ref = ring_top.canadian;
+}
+);
+width = 572;
+}
+);
+note = uni18B0;
+unicode = 6320;
+},
+{
+glyphname = "ay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (343,0);
+ref = ring_top.canadian;
+}
+);
+width = 572;
+}
+);
+note = uni18B1;
+unicode = 6321;
+},
+{
+glyphname = "aay-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (131,0);
+ref = ring_top.canadian;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (376,0);
+ref = dot_top;
+}
+);
+width = 572;
+}
+);
+note = uni18B2;
+unicode = 6322;
+},
+{
+glyphname = "way-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (546,0);
+ref = ring_top.canadian;
+}
+);
+width = 776;
+}
+);
+note = uni18B3;
+unicode = 6323;
+},
+{
+glyphname = "poy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-21,0);
+ref = ring_top.canadian;
+}
+);
+width = 554;
+}
+);
+note = uni18B4;
+unicode = 6324;
+},
+{
+glyphname = "pay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (341,0);
+ref = ring_top.canadian;
+}
+);
+width = 554;
+}
+);
+note = uni18B5;
+unicode = 6325;
+},
+{
+glyphname = "pwoy-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (182,0);
+ref = ring_top.canadian;
+}
+);
+width = 757;
+}
+);
+note = uni18B6;
+unicode = 6326;
+},
+{
+glyphname = "tay-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (169,0);
+ref = ring_top.canadian;
+}
+);
+width = 522;
+}
+);
+note = uni18B7;
+unicode = 6327;
+},
+{
+glyphname = "kay-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (2,0);
+ref = ring_top.canadian;
+}
+);
+width = 511;
+}
+);
+note = uni18B8;
+unicode = 6328;
+},
+{
+glyphname = "kway-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (206,0);
+ref = ring_top.canadian;
+}
+);
+width = 715;
+}
+);
+note = uni18B9;
+unicode = 6329;
+},
+{
+glyphname = "may-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (6,0);
+ref = ring_top.canadian;
+}
+);
+width = 469;
+}
+);
+note = uni18BA;
+unicode = 6330;
+},
+{
+glyphname = "noy-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (311,-182);
+ref = ring_top.canadian;
+}
+);
+width = 684;
+}
+);
+note = uni18BB;
+unicode = 6331;
+},
+{
+glyphname = "nay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (138,-182);
+ref = ring_top.canadian;
+}
+);
+width = 684;
+}
+);
+note = uni18BC;
+unicode = 6332;
+},
+{
+glyphname = "lay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (138,-182);
+ref = ring_top.canadian;
+}
+);
+width = 684;
+}
+);
+note = uni18BD;
+unicode = 6333;
+},
+{
+glyphname = "soy-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (232,0);
+ref = ring_top.canadian;
+}
+);
+width = 472;
+}
+);
+note = uni18BE;
+unicode = 6334;
+},
+{
+glyphname = "say-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (6,0);
+ref = ring_top.canadian;
+}
+);
+width = 472;
+}
+);
+note = uni18BF;
+unicode = 6335;
+},
+{
+glyphname = "shoy-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (268,-182);
+ref = ring_top.canadian;
+}
+);
+width = 769;
+}
+);
+note = uni18C0;
+unicode = 6336;
+},
+{
+glyphname = "shay-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (268,-182);
+ref = ring_top.canadian;
+}
+);
+width = 769;
+}
+);
+note = uni18C1;
+unicode = 6337;
+},
+{
+glyphname = "shwoy-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (471,-182);
+ref = ring_top.canadian;
+}
+);
+width = 973;
+}
+);
+note = uni18C2;
+unicode = 6338;
+},
+{
+glyphname = "yoy-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (254,0);
+ref = ring_top.canadian;
+}
+);
+width = 493;
+}
+);
+note = uni18C3;
+unicode = 6339;
+},
+{
+glyphname = "yay-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (5,0);
+ref = ring_top.canadian;
+}
+);
+width = 493;
+}
+);
+note = uni18C4;
+unicode = 6340;
+},
+{
+glyphname = "ray-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (147,0);
+ref = ring_top.canadian;
+}
+);
+width = 473;
+}
+);
+note = uni18C5;
+unicode = 6341;
+},
+{
+glyphname = "nwi-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ni-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni18C6;
+unicode = 6342;
+},
+{
+glyphname = "nwiOjibway-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (684,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni18C7;
+unicode = 6343;
+},
+{
+glyphname = "nwii-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (393,-182);
+ref = dot_top;
+}
+);
+width = 888;
+}
+);
+note = uni18C8;
+unicode = 6344;
+},
+{
+glyphname = "nwiiOjibway-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (189,-182);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (684,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni18C9;
+unicode = 6345;
+},
+{
+glyphname = "nwo-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "no-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni18CA;
+unicode = 6346;
+},
+{
+glyphname = "nwoOjibway-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (684,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni18CB;
+unicode = 6347;
+},
+{
+glyphname = "nwoo-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (549,-182);
+ref = dot_top;
+}
+);
+width = 888;
+}
+);
+note = uni18CC;
+unicode = 6348;
+},
+{
+glyphname = "nwooOjibway-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (345,-182);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (684,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 888;
+}
+);
+note = uni18CD;
+unicode = 6349;
+},
+{
+glyphname = "rwee-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "reRCree-canadian";
+}
+);
+width = 923;
+}
+);
+note = uni18CE;
+unicode = 6350;
+},
+{
+glyphname = "rwi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ri-canadian";
+}
+);
+width = 923;
+}
+);
+note = uni18CF;
+unicode = 6351;
+},
+{
+glyphname = "rwii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (383,-182);
+ref = dot_top;
+}
+);
+width = 923;
+}
+);
+note = uni18D0;
+unicode = 6352;
+},
+{
+glyphname = "rwo-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ro-canadian";
+}
+);
+width = 677;
+}
+);
+note = uni18D1;
+unicode = 6353;
+},
+{
+glyphname = "rwoo-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (329,0);
+ref = dot_top;
+}
+);
+width = 677;
+}
+);
+note = uni18D2;
+unicode = 6354;
+},
+{
+glyphname = "rwa-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = "ra-canadian";
+}
+);
+width = 677;
+}
+);
+note = uni18D3;
+unicode = 6355;
+},
+{
+glyphname = "pOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(113,345,l),
+(200,583,l),
+(140,583,l),
+(225,345,l),
+(313,345,l),
+(313,362,l),
+(180,690,l),
+(158,690,l),
+(24,362,l),
+(24,345,l)
+);
+}
+);
+width = 338;
+}
+);
+metricLeft = "kkCarrier-canadian";
+note = uni18D4;
+unicode = 6356;
+},
+{
+glyphname = "tOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 362;
+}
+);
+metricRight = "=|";
+note = uni1422;
+unicode = 6357;
+},
+{
+glyphname = "kOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(138,345,l),
+(138,489,l),
+(118,489,l),
+(123,456,o),
+(150,434,o),
+(185,434,cs),
+(241,434,o),
+(283,479,o),
+(283,558,cs),
+(283,652,o),
+(230,696,o),
+(165,696,cs),
+(87,696,o),
+(43,643,o),
+(43,564,cs),
+(43,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(145,502,o),
+(129,519,o),
+(129,565,cs),
+(129,611,o),
+(144,627,o),
+(164,627,cs),
+(184,627,o),
+(199,611,o),
+(199,564,cs),
+(199,518,o),
+(184,502,o),
+(164,502,cs)
+);
+}
+);
+width = 317;
+}
+);
+metricLeft = "k-canadian";
+metricRight = "k-canadian";
+note = uni18D6;
+unicode = 6358;
+},
+{
+glyphname = "cOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(138,345,l),
+(138,581,ls),
+(138,608,o),
+(147,622,o),
+(167,622,cs),
+(185,622,o),
+(198,607,o),
+(198,582,cs),
+(198,545,l),
+(285,545,l),
+(285,568,ls),
+(285,649,o),
+(239,696,o),
+(165,696,cs),
+(86,696,o),
+(43,650,o),
+(43,564,cs),
+(43,345,l)
+);
+}
+);
+width = 308;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni18D7;
+unicode = 6359;
+},
+{
+glyphname = "mOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(138,345,l),
+(138,601,l),
+(257,601,l),
+(257,690,l),
+(43,690,l),
+(43,345,l)
+);
+}
+);
+width = 284;
+}
+);
+metricLeft = "m-canadian";
+metricRight = "m-canadian";
+note = uni18D8;
+unicode = 6360;
+},
+{
+glyphname = "nOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(227,428,o),
+(269,477,o),
+(269,554,cs),
+(269,595,o),
+(255,630,o),
+(239,641,c),
+(234,601,l),
+(364,601,l),
+(364,690,l),
+(156,690,ls),
+(77,690,o),
+(34,638,o),
+(34,559,cs),
+(34,478,o),
+(77,428,o),
+(152,428,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(130,497,o),
+(117,515,o),
+(117,559,cs),
+(117,603,o),
+(130,621,o),
+(152,621,cs),
+(173,621,o),
+(185,603,o),
+(185,559,cs),
+(185,516,o),
+(173,497,o),
+(152,497,cs)
+);
+}
+);
+width = 392;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "n-canadian";
+note = uni18D9;
+unicode = 6361;
+},
+{
+glyphname = "sOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(138,345,l),
+(138,486,l),
+(75,450,l),
+(112,450,ls),
+(201,450,o),
+(259,509,o),
+(259,618,cs),
+(259,690,l),
+(164,690,l),
+(164,622,ls),
+(164,553,o),
+(136,524,o),
+(72,524,cs),
+(43,524,l),
+(43,345,l)
+);
+}
+);
+width = 302;
+}
+);
+metricLeft = "s-canadian";
+metricRight = "s-canadian";
+note = uni18DA;
+unicode = 6362;
+},
+{
+color = 1;
+glyphname = "shOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(216,339,o),
+(257,384,o),
+(262,468,cs),
+(270,576,ls),
+(271,608,o),
+(279,623,o),
+(298,623,cs),
+(319,623,o),
+(328,608,o),
+(328,575,cs),
+(328,545,l),
+(415,545,l),
+(415,571,ls),
+(415,653,o),
+(374,696,o),
+(300,696,cs),
+(222,696,o),
+(182,650,o),
+(177,567,cs),
+(169,459,ls),
+(167,427,o),
+(159,412,o),
+(140,412,cs),
+(120,412,o),
+(110,427,o),
+(110,460,cs),
+(110,490,l),
+(23,490,l),
+(23,464,ls),
+(23,382,o),
+(65,339,o),
+(138,339,cs)
+);
+}
+);
+width = 438;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "c-canadian";
+note = uni18DB;
+unicode = 6363;
+},
+{
+color = 9;
+glyphname = "easternw-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (15,-307);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (151,0);
+ref = "glottalstop-canadian";
+}
+);
+width = 507;
+}
+);
+note = uni18DC;
+unicode = 6364;
+},
+{
+color = 9;
+glyphname = "westernw-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (488,-307);
+ref = dot_top;
+scale = (-1,1);
+},
+{
+alignment = -1;
+pos = (361,0);
+ref = "glottalstop-canadian";
+scale = (-1,1);
+}
+);
+width = 508;
+}
+);
+metricLeft = "glottalstop-canadian";
+note = uni18DD;
+unicode = 6365;
+},
+{
+glyphname = "rweRCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "reRCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (719,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 923;
+}
+);
+note = uni18E0;
+unicode = 6368;
+},
+{
+glyphname = "looWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (40,0);
+ref = dot_top;
+}
+);
+width = 473;
+}
+);
+note = uni18E1;
+unicode = 6369;
+},
+{
+glyphname = "laaWestCree-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (268,0);
+ref = dot_top;
+}
+);
+width = 473;
+}
+);
+note = uni18E2;
+unicode = 6370;
+},
+{
+glyphname = "thwe-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "the-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (627,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 831;
+}
+);
+note = uni18E3;
+unicode = 6371;
+},
+{
+glyphname = "thwa-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (574,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 777;
+}
+);
+note = uni18E4;
+unicode = 6372;
+},
+{
+glyphname = "tthwe-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "tthe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (619,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 823;
+}
+);
+note = uni18E5;
+unicode = 6373;
+},
+{
+glyphname = "tthoo-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ttho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (186,0);
+ref = dot_top;
+}
+);
+width = 533;
+}
+);
+note = uni18E6;
+unicode = 6374;
+},
+{
+glyphname = "tthaa-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ttha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (180,0);
+ref = dot_top;
+}
+);
+width = 533;
+}
+);
+note = uni18E7;
+unicode = 6375;
+},
+{
+glyphname = "tlhwe-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "tlhe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (525,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 728;
+}
+);
+note = uni18E8;
+unicode = 6376;
+},
+{
+glyphname = "tlhoo-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "tlho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (185,0);
+ref = dot_top;
+}
+);
+width = 525;
+}
+);
+note = uni18E9;
+unicode = 6377;
+},
+{
+glyphname = "shweSayisi-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "sheSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (521,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 725;
+}
+);
+note = uni18EA;
+unicode = 6378;
+},
+{
+glyphname = "shooSayisi-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "shoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (318,0);
+ref = dot_top;
+}
+);
+width = 521;
+}
+);
+note = uni18EB;
+unicode = 6379;
+},
+{
+color = 9;
+glyphname = "hooSayisi-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "hoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (390,0);
+ref = dot_top;
+}
+);
+width = 595;
+}
+);
+note = uni18EC;
+unicode = 6380;
+},
+{
+color = 9;
+glyphname = "gwuCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "guCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (720,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 923;
+}
+);
+note = uni18ED;
+unicode = 6381;
+},
+{
+color = 9;
+glyphname = "deneGeeCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "geCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (230,0);
+ref = dot_top;
+}
+);
+width = 622;
+}
+);
+note = uni18EE;
+unicode = 6382;
+},
+{
+color = 9;
+glyphname = "gaaCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (242,0);
+ref = dot_top;
+}
+);
+width = 622;
+}
+);
+note = uni18EF;
+unicode = 6383;
+},
+{
+color = 9;
+glyphname = "gwaCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (622,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 826;
+}
+);
+note = uni18F0;
+unicode = 6384;
+},
+{
+color = 9;
+glyphname = "juuSayisi-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "juSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (229,0);
+ref = dot_top;
+}
+);
+width = 620;
+}
+);
+note = uni18F1;
+unicode = 6385;
+},
+{
+color = 9;
+glyphname = "jwaCarrier-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "jaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (669,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 873;
+}
+);
+note = uni18F2;
+unicode = 6386;
+},
+{
+glyphname = "lBeaverDene-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+ref = "pWestCree-canadian";
+}
+);
+width = 181;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+unicode = 6387;
+},
+{
+glyphname = "rBeaverDene-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(138,345,l),
+(138,524,ls),
+(138,573,o),
+(157,597,o),
+(193,597,cs),
+(205,597,l),
+(205,696,l),
+(195,696,ls),
+(154,696,o),
+(127,657,o),
+(124,607,c),
+(129,607,l),
+(129,690,l),
+(43,690,l),
+(43,345,l)
+);
+}
+);
+width = 231;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni18F4;
+unicode = 6388;
+},
+{
+color = 6;
+glyphname = "sDentalCarrier-canadian";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(185,183,ls),
+(265,183,o),
+(305,221,o),
+(305,287,cs),
+(305,352,o),
+(268,392,o),
+(198,392,cs),
+(170,392,ls),
+(144,392,o),
+(129,400,o),
+(129,422,cs),
+(129,445,o),
+(145,454,o),
+(170,454,cs),
+(299,454,l),
+(299,527,l),
+(163,527,ls),
+(84,527,o),
+(43,489,o),
+(43,423,cs),
+(43,359,o),
+(81,319,o),
+(151,319,cs),
+(179,319,ls),
+(204,319,o),
+(219,310,o),
+(219,288,cs),
+(219,266,o),
+(205,257,o),
+(179,257,cs),
+(49,257,l),
+(49,183,l)
+);
+}
+);
+width = 348;
+}
+);
+metricLeft = "shCarrier-canadian";
+metricRight = "=|";
+note = uni18F5;
+unicode = 6389;
+},
+{
+glyphname = "pWestCree-canadian.base";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "pWestCree-canadian";
+}
+);
+width = 181;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.base";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "c-canadian";
+}
+);
+width = 308;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "thSayisi-canadian.base";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "thSayisi-canadian";
+}
+);
+width = 309;
+}
+);
+metricLeft = "=|c-canadian";
+note = uni14A2;
+},
+{
+glyphname = "mWestCree-canadian.base";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "mWestCree-canadian";
+}
+);
+width = 304;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+glyphname = "pWestCree-canadian.mid";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "pWestCree-canadian";
+}
+);
+width = 182;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.mid";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "c-canadian";
+}
+);
+width = 308;
+}
+);
+metricLeft = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "mWestCree-canadian.mid";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "mWestCree-canadian";
+}
+);
+width = 304;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+color = 11;
+glyphname = "ngaai-canadian.nunavik";
+lastChange = "2023-01-13 15:56:39 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (553,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (696,0);
+ref = ring_top.canadian;
+}
+);
+width = 1057;
+}
+);
+note = uni158E;
+},
+{
+color = 11;
+glyphname = "ngi-canadian.nunavik";
+lastChange = "2023-01-13 15:56:39 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (553,0);
+ref = "ci-canadian";
+}
+);
+width = 1057;
+}
+);
+note = uni158F;
+},
+{
+color = 11;
+glyphname = "ngii-canadian.nunavik";
+lastChange = "2023-01-13 15:56:39 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (553,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (729,0);
+ref = dot_top;
+}
+);
+width = 1057;
+}
+);
+note = uni1590;
+},
+{
+color = 11;
+glyphname = "ngo-canadian.nunavik";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (553,0);
+ref = "co-canadian";
+}
+);
+width = 1055;
+}
+);
+note = uni1591;
+},
+{
+color = 11;
+glyphname = "ngoo-canadian.nunavik";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+ref = "ngo-canadian.nunavik";
+},
+{
+anchor = top_right_can;
+pos = (853,0);
+ref = dot_top;
+}
+);
+width = 1055;
+}
+);
+note = uni1592;
+},
+{
+color = 11;
+glyphname = "nga-canadian.nunavik";
+lastChange = "2023-01-13 15:56:39 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (553,0);
+ref = "ca-canadian";
+}
+);
+width = 1057;
+}
+);
+note = uni1593;
+},
+{
+color = 11;
+glyphname = "ngaa-canadian.nunavik";
+lastChange = "2023-01-13 15:56:39 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (553,0);
+ref = "ca-canadian";
+},
+{
+anchor = top_left_can;
+pos = (590,0);
+ref = dot_top;
+}
+);
+width = 1057;
+}
+);
+note = uni1594;
+},
+{
+color = 11;
+glyphname = "ng-canadian.nunavik";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(467,167,o),
+(519,211,o),
+(519,303,cs),
+(519,384,o),
+(476,429,o),
+(421,429,cs),
+(387,429,o),
+(362,409,o),
+(355,376,c),
+(374,375,l),
+(374,524,l),
+(237,524,l),
+(242,487,l),
+(257,498,o),
+(269,531,o),
+(269,570,cs),
+(269,647,o),
+(227,696,o),
+(152,696,cs),
+(77,696,o),
+(34,645,o),
+(34,565,cs),
+(34,486,o),
+(77,434,o),
+(156,434,cs),
+(343,434,l),
+(280,497,l),
+(280,298,ls),
+(280,219,o),
+(324,167,o),
+(402,167,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(381,236,o),
+(366,251,o),
+(366,298,cs),
+(366,344,o),
+(382,360,o),
+(401,360,cs),
+(420,360,o),
+(436,345,o),
+(436,298,cs),
+(436,252,o),
+(420,236,o),
+(401,236,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(130,502,o),
+(117,521,o),
+(117,565,cs),
+(117,610,o),
+(130,627,o),
+(152,627,cs),
+(173,627,o),
+(185,608,o),
+(185,564,cs),
+(185,522,o),
+(173,502,o),
+(152,502,cs)
+);
+}
+);
+width = 553;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+color = 11;
+glyphname = "ngai-canadian.nunavik";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (553,0);
+ref = "ce-canadian";
+}
+);
+width = 1055;
+}
+);
+note = uni1670;
+},
+{
+color = 11;
+glyphname = "ke-canadian.square";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (303,690);
+},
+{
+name = top_left_can;
+pos = (121,690);
+},
+{
+name = top_right_can;
+pos = (491,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(561,0,l),
+(561,690,l),
+(354,690,ls),
+(157,690,o),
+(44,585,o),
+(44,410,cs),
+(44,235,o),
+(157,130,o),
+(354,130,cs),
+(419,130,l),
+(419,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(239,256,o),
+(187,310,o),
+(187,410,cs),
+(187,510,o),
+(239,565,o),
+(345,565,cs),
+(419,565,l),
+(419,256,l),
+(345,256,ls)
+);
+}
+);
+width = 612;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146B;
+},
+{
+color = 11;
+glyphname = "ki-canadian.square";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (310,690);
+},
+{
+name = top_left_can;
+pos = (123,690);
+},
+{
+name = top_right_can;
+pos = (497,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(193,0,l),
+(193,130,l),
+(260,130,ls),
+(457,130,o),
+(568,235,o),
+(568,410,cs),
+(568,585,o),
+(457,690,o),
+(260,690,cs),
+(51,690,l),
+(51,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(193,565,l),
+(268,565,ls),
+(374,565,o),
+(426,510,o),
+(426,410,cs),
+(426,310,o),
+(374,256,o),
+(268,256,cs),
+(193,256,l)
+);
+}
+);
+width = 612;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni146D;
+},
+{
+color = 11;
+glyphname = "kii-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (226,0);
+ref = dot_top;
+}
+);
+width = 611;
+}
+);
+note = uni146E;
+},
+{
+color = 11;
+glyphname = "ko-canadian.square";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (303,690);
+},
+{
+name = top_left_can;
+pos = (121,690);
+},
+{
+name = top_right_can;
+pos = (491,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(561,0,l),
+(561,690,l),
+(419,690,l),
+(419,559,l),
+(354,559,ls),
+(157,559,o),
+(44,455,o),
+(44,280,cs),
+(44,104,o),
+(157,0,o),
+(354,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(239,125,o),
+(187,180,o),
+(187,280,cs),
+(187,380,o),
+(239,434,o),
+(345,434,cs),
+(419,434,l),
+(419,125,l),
+(345,125,ls)
+);
+}
+);
+width = 612;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146F;
+},
+{
+color = 11;
+glyphname = "koo-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (406,0);
+ref = dot_top;
+}
+);
+width = 611;
+}
+);
+note = uni1470;
+},
+{
+color = 11;
+glyphname = "ka-canadian.square";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (310,690);
+},
+{
+name = top_left_can;
+pos = (123,690);
+},
+{
+name = top_right_can;
+pos = (497,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(260,0,ls),
+(457,0,o),
+(568,104,o),
+(568,280,cs),
+(568,455,o),
+(457,559,o),
+(260,559,cs),
+(193,559,l),
+(193,690,l),
+(51,690,l),
+(51,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(193,434,l),
+(268,434,ls),
+(374,434,o),
+(426,380,o),
+(426,280,cs),
+(426,180,o),
+(374,125,o),
+(268,125,cs),
+(193,125,l)
+);
+}
+);
+width = 612;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1472;
+},
+{
+color = 11;
+glyphname = "kaa-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (40,0);
+ref = dot_top;
+}
+);
+width = 611;
+}
+);
+note = uni1473;
+},
+{
+color = 11;
+glyphname = "kweWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (611,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 814;
+}
+);
+note = uni1475;
+},
+{
+color = 11;
+glyphname = "kwiiWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (226,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (611,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 814;
+}
+);
+note = uni1479;
+},
+{
+color = 11;
+glyphname = "kwoWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (611,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 814;
+}
+);
+note = uni147B;
+},
+{
+color = 11;
+glyphname = "kwooWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (406,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (611,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 814;
+}
+);
+note = uni147D;
+},
+{
+color = 11;
+glyphname = "kwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (611,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 814;
+}
+);
+note = uni147F;
+},
+{
+color = 11;
+glyphname = "kwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (40,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (611,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 814;
+}
+);
+note = uni1481;
+},
+{
+color = 11;
+glyphname = "ce-canadian.square";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (297,690);
+},
+{
+name = top_left_can;
+pos = (107,690);
+},
+{
+name = top_right_can;
+pos = (487,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(557,0,l),
+(557,420,ls),
+(557,606,o),
+(462,703,o),
+(296,703,cs),
+(128,703,o),
+(36,606,o),
+(36,425,cs),
+(36,382,l),
+(177,382,l),
+(177,434,ls),
+(177,528,o),
+(218,573,o),
+(296,573,cs),
+(374,573,o),
+(415,526,o),
+(415,426,cs),
+(415,0,l)
+);
+}
+);
+width = 605;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni1489;
+},
+{
+color = 11;
+glyphname = "ci-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (309,690);
+},
+{
+name = top_left_can;
+pos = (121,690);
+},
+{
+name = top_right_can;
+pos = (500,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(191,0,l),
+(191,426,ls),
+(191,526,o),
+(233,573,o),
+(311,573,cs),
+(387,573,o),
+(429,528,o),
+(429,434,cs),
+(429,382,l),
+(570,382,l),
+(570,425,ls),
+(570,606,o),
+(478,703,o),
+(311,703,cs),
+(144,703,o),
+(48,606,o),
+(48,420,cs),
+(48,0,l)
+);
+}
+);
+width = 606;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+},
+{
+color = 11;
+glyphname = "cii-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (226,0);
+ref = dot_top;
+}
+);
+width = 607;
+}
+);
+note = uni148C;
+},
+{
+color = 11;
+glyphname = "co-canadian.square";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (297,690);
+},
+{
+name = top_left_can;
+pos = (107,690);
+},
+{
+name = top_right_can;
+pos = (487,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(462,-14,o),
+(557,84,o),
+(557,270,cs),
+(557,690,l),
+(415,690,l),
+(415,264,ls),
+(415,164,o),
+(374,117,o),
+(296,117,cs),
+(218,117,o),
+(177,161,o),
+(177,256,cs),
+(177,308,l),
+(36,308,l),
+(36,265,ls),
+(36,84,o),
+(128,-14,o),
+(296,-14,cs)
+);
+}
+);
+width = 605;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+},
+{
+color = 11;
+glyphname = "coo-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (403,0);
+ref = dot_top;
+}
+);
+width = 607;
+}
+);
+note = uni148E;
+},
+{
+color = 11;
+glyphname = "ca-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (309,690);
+},
+{
+name = top_left_can;
+pos = (121,690);
+},
+{
+name = top_right_can;
+pos = (500,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(478,-14,o),
+(570,84,o),
+(570,265,cs),
+(570,308,l),
+(429,308,l),
+(429,256,ls),
+(429,161,o),
+(387,117,o),
+(311,117,cs),
+(233,117,o),
+(191,164,o),
+(191,264,cs),
+(191,690,l),
+(48,690,l),
+(48,270,ls),
+(48,84,o),
+(144,-14,o),
+(311,-14,cs)
+);
+}
+);
+width = 606;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+},
+{
+color = 11;
+glyphname = "caa-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (37,0);
+ref = dot_top;
+}
+);
+width = 607;
+}
+);
+note = uni1491;
+},
+{
+color = 11;
+glyphname = "me-canadian.square";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (257,690);
+},
+{
+name = top_double;
+pos = (404,690);
+},
+{
+name = top_left_can;
+pos = (101,690);
+},
+{
+name = top_right_can;
+pos = (404,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(474,0,l),
+(474,690,l),
+(31,690,l),
+(31,560,l),
+(332,560,l),
+(332,0,l)
+);
+}
+);
+width = 525;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+},
+{
+color = 11;
+glyphname = "mi-canadian.square";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (273,690);
+},
+{
+name = top_left_can;
+pos = (123,690);
+},
+{
+name = top_right_can;
+pos = (423,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(193,0,l),
+(193,560,l),
+(496,560,l),
+(496,690,l),
+(51,690,l),
+(51,0,l)
+);
+}
+);
+width = 527;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+},
+{
+color = 11;
+glyphname = "mii-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (190,0);
+ref = dot_top;
+}
+);
+width = 526;
+}
+);
+note = uni14A6;
+},
+{
+color = 11;
+glyphname = "mo-canadian.square";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (257,690);
+},
+{
+name = top_double;
+pos = (404,690);
+},
+{
+name = top_left_can;
+pos = (101,690);
+},
+{
+name = top_right_can;
+pos = (404,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(474,0,l),
+(474,690,l),
+(332,690,l),
+(332,129,l),
+(31,129,l),
+(31,0,l)
+);
+}
+);
+width = 525;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+},
+{
+color = 11;
+glyphname = "moo-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (320,0);
+ref = dot_top;
+}
+);
+width = 526;
+}
+);
+note = uni14A8;
+},
+{
+color = 11;
+glyphname = "ma-canadian.square";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (273,690);
+},
+{
+name = top_left_can;
+pos = (123,690);
+},
+{
+name = top_right_can;
+pos = (423,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(496,0,l),
+(496,129,l),
+(193,129,l),
+(193,690,l),
+(51,690,l),
+(51,0,l)
+);
+}
+);
+width = 527;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+},
+{
+color = 11;
+glyphname = "maa-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (40,0);
+ref = dot_top;
+}
+);
+width = 526;
+}
+);
+note = uni14AB;
+},
+{
+color = 11;
+glyphname = "ne-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (379,690);
+},
+{
+name = top_left_can;
+pos = (223,690);
+},
+{
+name = top_right_can;
+pos = (536,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(526,-14,o),
+(607,75,o),
+(607,232,cs),
+(607,690,l),
+(37,690,l),
+(37,562,l),
+(153,562,l),
+(153,233,ls),
+(153,75,o),
+(233,-14,o),
+(380,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(322,117,o),
+(294,153,o),
+(294,222,cs),
+(294,562,l),
+(465,562,l),
+(465,222,ls),
+(465,154,o),
+(437,117,o),
+(380,117,cs)
+);
+}
+);
+width = 655;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C0;
+},
+{
+color = 11;
+glyphname = "ni-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (275,690);
+},
+{
+name = top_left_can;
+pos = (120,690);
+},
+{
+name = top_right_can;
+pos = (432,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(422,-14,o),
+(502,75,o),
+(502,233,cs),
+(502,562,l),
+(617,562,l),
+(617,690,l),
+(48,690,l),
+(48,232,ls),
+(48,75,o),
+(129,-14,o),
+(275,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(217,117,o),
+(189,154,o),
+(189,222,cs),
+(189,562,l),
+(361,562,l),
+(361,222,ls),
+(361,153,o),
+(333,117,o),
+(275,117,cs)
+);
+}
+);
+width = 654;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+},
+{
+color = 11;
+glyphname = "nii-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (192,0);
+ref = dot_top;
+}
+);
+width = 655;
+}
+);
+note = uni14C3;
+},
+{
+color = 11;
+glyphname = "no-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (380,690);
+},
+{
+name = top_double;
+pos = (389,690);
+},
+{
+name = top_left_can;
+pos = (223,690);
+},
+{
+name = top_right_can;
+pos = (514,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(607,0,l),
+(607,458,ls),
+(607,614,o),
+(526,703,o),
+(380,703,cs),
+(233,703,o),
+(153,614,o),
+(153,457,cs),
+(153,128,l),
+(37,128,l),
+(37,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(294,468,ls),
+(294,537,o),
+(322,573,o),
+(380,573,cs),
+(437,573,o),
+(465,536,o),
+(465,468,cs),
+(465,128,l),
+(294,128,l)
+);
+}
+);
+width = 655;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C4;
+},
+{
+color = 11;
+glyphname = "noo-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (296,0);
+ref = dot_top;
+}
+);
+width = 655;
+}
+);
+note = uni14C5;
+},
+{
+color = 11;
+glyphname = "na-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (275,690);
+},
+{
+name = top_double;
+pos = (285,690);
+},
+{
+name = top_left_can;
+pos = (120,690);
+},
+{
+name = top_right_can;
+pos = (432,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(617,0,l),
+(617,128,l),
+(502,128,l),
+(502,457,ls),
+(502,614,o),
+(422,703,o),
+(275,703,cs),
+(129,703,o),
+(48,614,o),
+(48,458,cs),
+(48,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(189,468,ls),
+(189,536,o),
+(217,573,o),
+(275,573,cs),
+(333,573,o),
+(361,537,o),
+(361,468,cs),
+(361,128,l),
+(189,128,l)
+);
+}
+);
+width = 654;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+},
+{
+color = 11;
+glyphname = "naa-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (192,0);
+ref = dot_top;
+}
+);
+width = 655;
+}
+);
+note = uni14C8;
+},
+{
+color = 11;
+glyphname = "nweWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (655,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 859;
+}
+);
+note = uni14CA;
+},
+{
+color = 11;
+glyphname = "nwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (655,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 859;
+}
+);
+note = uni14CC;
+},
+{
+color = 11;
+glyphname = "nwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (192,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (655,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 859;
+}
+);
+note = uni14CE;
+},
+{
+color = 11;
+glyphname = "se-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (123,690);
+},
+{
+name = top_right_can;
+pos = (499,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(562,0,l),
+(562,295,l),
+(377,295,ls),
+(255,295,o),
+(193,354,o),
+(193,478,cs),
+(193,690,l),
+(51,690,l),
+(51,476,ls),
+(51,278,o),
+(172,169,o),
+(380,169,cs),
+(457,169,l),
+(420,205,l),
+(420,0,l)
+);
+}
+);
+width = 614;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14ED;
+},
+{
+color = 11;
+glyphname = "si-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (124,690);
+},
+{
+name = top_right_can;
+pos = (500,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(194,0,l),
+(194,205,l),
+(157,169,l),
+(236,169,ls),
+(442,169,o),
+(563,278,o),
+(563,461,cs),
+(563,690,l),
+(421,690,l),
+(421,463,ls),
+(421,354,o),
+(359,295,o),
+(243,295,cs),
+(52,295,l),
+(52,0,l)
+);
+}
+);
+width = 614;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+},
+{
+color = 11;
+glyphname = "sii-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (417,0);
+ref = dot_top;
+}
+);
+width = 614;
+}
+);
+note = uni14F0;
+},
+{
+color = 11;
+glyphname = "so-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (492,690);
+},
+{
+name = top_left_can;
+pos = (123,690);
+},
+{
+name = top_right_can;
+pos = (492,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(193,0,l),
+(193,212,ls),
+(193,336,o),
+(255,395,o),
+(377,395,cs),
+(562,395,l),
+(562,690,l),
+(420,690,l),
+(420,485,l),
+(457,521,l),
+(380,521,ls),
+(172,521,o),
+(51,412,o),
+(51,213,cs),
+(51,0,l)
+);
+}
+);
+width = 614;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+},
+{
+color = 11;
+glyphname = "soo-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (409,0);
+ref = dot_top;
+}
+);
+width = 614;
+}
+);
+note = uni14F2;
+},
+{
+color = 11;
+glyphname = "sa-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (124,690);
+},
+{
+name = top_right_can;
+pos = (493,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(563,0,l),
+(563,213,ls),
+(563,412,o),
+(442,521,o),
+(236,521,cs),
+(157,521,l),
+(194,485,l),
+(194,690,l),
+(52,690,l),
+(52,395,l),
+(238,395,ls),
+(359,395,o),
+(421,336,o),
+(421,212,cs),
+(421,0,l)
+);
+}
+);
+width = 614;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+},
+{
+color = 11;
+glyphname = "saa-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (41,0);
+ref = dot_top;
+}
+);
+width = 614;
+}
+);
+note = uni14F5;
+},
+{
+color = 11;
+glyphname = "sho-canadian.square";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (305,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(555,0,l),
+(555,116,l),
+(280,116,ls),
+(218,116,o),
+(186,144,o),
+(186,201,cs),
+(186,259,o),
+(216,288,o),
+(280,288,cs),
+(358,288,ls),
+(493,288,o),
+(567,361,o),
+(567,490,cs),
+(567,617,o),
+(493,690,o),
+(358,690,cs),
+(55,690,l),
+(55,574,l),
+(330,574,ls),
+(392,574,o),
+(424,546,o),
+(424,490,cs),
+(424,433,o),
+(394,403,o),
+(330,403,cs),
+(252,403,ls),
+(118,403,o),
+(43,328,o),
+(43,200,cs),
+(43,72,o),
+(118,0,o),
+(252,0,cs)
+);
+}
+);
+width = 610;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+color = 11;
+glyphname = "shoo-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (222,0);
+ref = dot_top;
+}
+);
+width = 611;
+}
+);
+note = g728;
+},
+{
+color = 11;
+glyphname = "sha-canadian.square";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (306,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(358,0,ls),
+(493,0,o),
+(566,72,o),
+(566,200,cs),
+(566,328,o),
+(493,403,o),
+(358,403,cs),
+(280,403,ls),
+(216,403,o),
+(186,433,o),
+(186,489,cs),
+(186,546,o),
+(217,574,o),
+(280,574,cs),
+(555,574,l),
+(555,690,l),
+(252,690,ls),
+(118,690,o),
+(43,617,o),
+(43,490,cs),
+(43,361,o),
+(118,288,o),
+(252,288,cs),
+(330,288,ls),
+(393,288,o),
+(424,259,o),
+(424,200,cs),
+(424,144,o),
+(392,116,o),
+(330,116,cs),
+(55,116,l),
+(55,0,l)
+);
+}
+);
+width = 609;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+color = 11;
+glyphname = "shaa-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (222,0);
+ref = dot_top;
+}
+);
+width = 611;
+}
+);
+note = g730;
+},
+{
+color = 11;
+glyphname = "ye-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (100,690);
+},
+{
+name = top_right_can;
+pos = (507,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(579,0,l),
+(579,294,l),
+(239,294,l),
+(239,233,l),
+(601,611,l),
+(501,701,l),
+(26,207,l),
+(26,169,l),
+(436,169,l),
+(436,0,l)
+);
+}
+);
+width = 628;
+}
+);
+metricLeft = "ye-canadian";
+note = uni1526;
+},
+{
+color = 11;
+glyphname = "yi-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (121,690);
+},
+{
+name = top_right_can;
+pos = (527,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(192,0,l),
+(192,169,l),
+(602,169,l),
+(602,207,l),
+(127,701,l),
+(27,611,l),
+(389,233,l),
+(389,294,l),
+(49,294,l),
+(49,0,l)
+);
+}
+);
+width = 628;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni1528;
+},
+{
+color = 11;
+glyphname = "yii-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (38,0);
+ref = dot_top;
+}
+);
+width = 628;
+}
+);
+note = uni1529;
+},
+{
+color = 11;
+glyphname = "yo-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (507,690);
+},
+{
+name = top_left_can;
+pos = (100,690);
+},
+{
+name = top_right_can;
+pos = (507,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(601,78,l),
+(239,457,l),
+(239,396,l),
+(579,396,l),
+(579,690,l),
+(436,690,l),
+(436,521,l),
+(26,521,l),
+(26,483,l),
+(501,-12,l)
+);
+}
+);
+width = 628;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152A;
+},
+{
+color = 11;
+glyphname = "yoo-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (424,0);
+ref = dot_top;
+}
+);
+width = 628;
+}
+);
+note = uni152B;
+},
+{
+color = 11;
+glyphname = "ya-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (122,690);
+},
+{
+name = top_right_can;
+pos = (527,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(602,483,l),
+(602,521,l),
+(192,521,l),
+(192,690,l),
+(49,690,l),
+(49,396,l),
+(389,396,l),
+(389,457,l),
+(27,78,l),
+(127,-12,l)
+);
+}
+);
+width = 628;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152D;
+},
+{
+color = 11;
+glyphname = "yaa-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (38,0);
+ref = dot_top;
+}
+);
+width = 628;
+}
+);
+note = uni152E;
+},
+{
+color = 11;
+glyphname = "re-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (275,690);
+},
+{
+name = top_left_can;
+pos = (120,690);
+},
+{
+name = top_right_can;
+pos = (432,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(424,-14,o),
+(502,75,o),
+(502,233,cs),
+(502,562,l),
+(617,562,l),
+(617,690,l),
+(361,690,l),
+(361,222,ls),
+(361,153,o),
+(333,117,o),
+(275,117,cs),
+(217,117,o),
+(189,154,o),
+(189,222,cs),
+(189,690,l),
+(48,690,l),
+(48,232,ls),
+(48,75,o),
+(129,-14,o),
+(275,-14,cs)
+);
+}
+);
+width = 654;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1542;
+},
+{
+color = 11;
+glyphname = "reRCree-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (380,690);
+},
+{
+name = top_left_can;
+pos = (223,690);
+},
+{
+name = top_right_can;
+pos = (536,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(526,-14,o),
+(607,75,o),
+(607,232,cs),
+(607,690,l),
+(465,690,l),
+(465,222,ls),
+(465,154,o),
+(437,117,o),
+(380,117,cs),
+(322,117,o),
+(294,153,o),
+(294,222,cs),
+(294,690,l),
+(37,690,l),
+(37,562,l),
+(153,562,l),
+(153,233,ls),
+(153,75,o),
+(231,-14,o),
+(380,-14,cs)
+);
+}
+);
+width = 655;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni1543;
+},
+{
+color = 11;
+glyphname = "leWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (380,690);
+},
+{
+name = top_left_can;
+pos = (223,690);
+},
+{
+name = top_right_can;
+pos = (536,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(294,-1,l),
+(294,467,ls),
+(294,537,o),
+(322,573,o),
+(380,573,cs),
+(437,573,o),
+(465,535,o),
+(465,467,cs),
+(465,-1,l),
+(607,-1,l),
+(607,457,ls),
+(607,613,o),
+(526,703,o),
+(380,703,cs),
+(231,703,o),
+(153,613,o),
+(153,456,cs),
+(153,128,l),
+(37,128,l),
+(37,-1,l)
+);
+}
+);
+width = 655;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+},
+{
+color = 11;
+glyphname = "ri-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (275,690);
+},
+{
+name = top_left_can;
+pos = (121,690);
+},
+{
+name = top_right_can;
+pos = (432,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(189,0,l),
+(189,468,ls),
+(189,536,o),
+(217,573,o),
+(275,573,cs),
+(333,573,o),
+(361,537,o),
+(361,468,cs),
+(361,0,l),
+(617,0,l),
+(617,128,l),
+(502,128,l),
+(502,457,ls),
+(502,614,o),
+(424,703,o),
+(275,703,cs),
+(129,703,o),
+(48,614,o),
+(48,458,cs),
+(48,0,l)
+);
+}
+);
+width = 654;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+},
+{
+color = 11;
+glyphname = "rii-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (192,0);
+ref = dot_top;
+}
+);
+width = 655;
+}
+);
+note = uni1547;
+},
+{
+color = 11;
+glyphname = "ro-canadian.square";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (303,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(193,0,l),
+(193,167,l),
+(144,130,l),
+(244,130,ls),
+(441,130,o),
+(553,235,o),
+(553,410,cs),
+(553,585,o),
+(441,690,o),
+(244,690,cs),
+(51,690,l),
+(51,565,l),
+(253,565,ls),
+(358,565,o),
+(411,510,o),
+(411,410,cs),
+(411,310,o),
+(358,256,o),
+(253,256,cs),
+(51,256,l),
+(51,0,l)
+);
+}
+);
+width = 597;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1548;
+},
+{
+color = 11;
+glyphname = "loWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (302,690);
+},
+{
+name = top_left_can;
+pos = (123,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(244,0,ls),
+(441,0,o),
+(553,104,o),
+(553,280,cs),
+(553,455,o),
+(441,559,o),
+(244,559,cs),
+(144,559,l),
+(193,523,l),
+(193,690,l),
+(51,690,l),
+(51,434,l),
+(253,434,ls),
+(358,434,o),
+(411,380,o),
+(411,280,cs),
+(411,180,o),
+(358,125,o),
+(253,125,cs),
+(51,125,l),
+(51,0,l)
+);
+}
+);
+width = 588;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+},
+{
+color = 11;
+glyphname = "ra-canadian.square";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (285,690);
+},
+{
+name = top_right_can;
+pos = (466,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(536,0,l),
+(536,256,l),
+(334,256,ls),
+(229,256,o),
+(177,310,o),
+(177,410,cs),
+(177,510,o),
+(229,565,o),
+(334,565,cs),
+(536,565,l),
+(536,690,l),
+(343,690,ls),
+(146,690,o),
+(35,585,o),
+(35,410,cs),
+(35,235,o),
+(146,130,o),
+(343,130,cs),
+(442,130,l),
+(393,167,l),
+(393,0,l)
+);
+}
+);
+width = 587;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+},
+{
+color = 11;
+glyphname = "raa-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (203,0);
+ref = dot_top;
+}
+);
+width = 588;
+}
+);
+note = uni154C;
+},
+{
+color = 11;
+glyphname = "laWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (466,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(536,0,l),
+(536,125,l),
+(334,125,ls),
+(229,125,o),
+(177,180,o),
+(177,280,cs),
+(177,380,o),
+(229,434,o),
+(334,434,cs),
+(536,434,l),
+(536,690,l),
+(393,690,l),
+(393,523,l),
+(442,559,l),
+(343,559,ls),
+(146,559,o),
+(35,455,o),
+(35,280,cs),
+(35,104,o),
+(146,0,o),
+(343,0,cs)
+);
+}
+);
+width = 587;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+},
+{
+color = 11;
+glyphname = "reWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(541,0,l),
+(746,199,l),
+(661,289,l),
+(466,100,l),
+(557,95,l),
+(557,420,ls),
+(557,606,o),
+(462,703,o),
+(296,703,cs),
+(128,703,o),
+(36,606,o),
+(36,425,cs),
+(36,382,l),
+(177,382,l),
+(177,434,ls),
+(177,528,o),
+(218,573,o),
+(296,573,cs),
+(374,573,o),
+(415,526,o),
+(415,426,cs),
+(415,0,l)
+);
+}
+);
+width = 762;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+},
+{
+color = 11;
+glyphname = "riWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(347,0,l),
+(347,426,ls),
+(347,526,o),
+(388,573,o),
+(467,573,cs),
+(543,573,o),
+(584,528,o),
+(584,434,cs),
+(584,382,l),
+(726,382,l),
+(726,425,ls),
+(726,606,o),
+(634,703,o),
+(467,703,cs),
+(299,703,o),
+(204,606,o),
+(204,420,cs),
+(204,95,l),
+(296,100,l),
+(100,289,l),
+(16,199,l),
+(221,0,l)
+);
+}
+);
+width = 762;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+},
+{
+color = 11;
+glyphname = "roWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(462,-14,o),
+(557,84,o),
+(557,270,cs),
+(557,595,l),
+(466,589,l),
+(661,401,l),
+(746,491,l),
+(541,690,l),
+(415,690,l),
+(415,264,ls),
+(415,164,o),
+(374,117,o),
+(296,117,cs),
+(218,117,o),
+(177,161,o),
+(177,256,cs),
+(177,308,l),
+(36,308,l),
+(36,265,ls),
+(36,84,o),
+(128,-14,o),
+(296,-14,cs)
+);
+}
+);
+width = 762;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+},
+{
+color = 11;
+glyphname = "raWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(634,-14,o),
+(726,84,o),
+(726,265,cs),
+(726,308,l),
+(584,308,l),
+(584,256,ls),
+(584,161,o),
+(543,117,o),
+(467,117,cs),
+(388,117,o),
+(347,164,o),
+(347,264,cs),
+(347,690,l),
+(221,690,l),
+(16,491,l),
+(100,401,l),
+(296,589,l),
+(204,595,l),
+(204,270,ls),
+(204,84,o),
+(299,-14,o),
+(467,-14,cs)
+);
+}
+);
+width = 762;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+},
+{
+color = 11;
+glyphname = "theThCree-canadian.square";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (100,690);
+},
+{
+name = top_right_can;
+pos = (507,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(436,53,l),
+(436,0,l),
+(579,0,l),
+(579,53,l),
+(655,53,l),
+(655,118,l),
+(579,118,l),
+(579,294,l),
+(239,294,l),
+(239,233,l),
+(601,611,l),
+(501,701,l),
+(26,207,l),
+(26,169,l),
+(436,169,l),
+(436,118,l),
+(259,118,l),
+(259,53,l)
+);
+}
+);
+width = 680;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15A7;
+},
+{
+color = 11;
+glyphname = "thiThCree-canadian.square";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (171,690);
+},
+{
+name = top_right_can;
+pos = (577,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(244,0,l),
+(244,53,l),
+(420,53,l),
+(420,118,l),
+(244,118,l),
+(244,169,l),
+(653,169,l),
+(653,207,l),
+(178,701,l),
+(79,611,l),
+(441,233,l),
+(441,294,l),
+(101,294,l),
+(101,118,l),
+(25,118,l),
+(25,53,l),
+(101,53,l),
+(101,0,l)
+);
+}
+);
+width = 679;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+},
+{
+color = 11;
+glyphname = "thiiThCree-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (86,0);
+ref = dot_top;
+}
+);
+width = 679;
+}
+);
+note = uni15A9;
+},
+{
+color = 11;
+glyphname = "thoThCree-canadian.square";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (100,690);
+},
+{
+name = top_right_can;
+pos = (507,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(601,78,l),
+(239,457,l),
+(239,396,l),
+(579,396,l),
+(579,572,l),
+(655,572,l),
+(655,637,l),
+(579,637,l),
+(579,690,l),
+(436,690,l),
+(436,637,l),
+(259,637,l),
+(259,572,l),
+(436,572,l),
+(436,521,l),
+(26,521,l),
+(26,483,l),
+(501,-12,l)
+);
+}
+);
+width = 680;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+},
+{
+color = 11;
+glyphname = "thooThCree-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (424,0);
+ref = dot_top;
+}
+);
+width = 679;
+}
+);
+note = uni15AB;
+},
+{
+color = 11;
+glyphname = "thaThCree-canadian.square";
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (173,690);
+},
+{
+name = top_right_can;
+pos = (580,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(653,483,l),
+(653,521,l),
+(244,521,l),
+(244,572,l),
+(420,572,l),
+(420,637,l),
+(244,637,l),
+(244,690,l),
+(101,690,l),
+(101,637,l),
+(25,637,l),
+(25,572,l),
+(101,572,l),
+(101,396,l),
+(441,396,l),
+(441,457,l),
+(79,78,l),
+(178,-12,l)
+);
+}
+);
+width = 679;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+},
+{
+color = 11;
+glyphname = "thaaThCree-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (89,0);
+ref = dot_top;
+}
+);
+width = 679;
+}
+);
+note = uni15AD;
+},
+{
+color = 11;
+glyphname = "thweeWoodScree-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (679,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 883;
+}
+);
+note = uni1677;
+},
+{
+color = 11;
+glyphname = "thwiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (679,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 883;
+}
+);
+note = uni1678;
+},
+{
+color = 11;
+glyphname = "thwiiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (86,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (679,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 883;
+}
+);
+note = uni1679;
+},
+{
+color = 11;
+glyphname = "thwoWoodScree-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (679,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 883;
+}
+);
+note = uni167A;
+},
+{
+color = 11;
+glyphname = "thwooWoodScree-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (424,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (679,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 883;
+}
+);
+note = uni167B;
+},
+{
+color = 11;
+glyphname = "thwaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (679,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 883;
+}
+);
+note = uni167C;
+},
+{
+color = 11;
+glyphname = "thwaaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (89,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (679,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 883;
+}
+);
+note = uni167D;
+},
+{
+color = 11;
+glyphname = "nwiOjibway-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (655,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 859;
+}
+);
+note = uni18C7;
+},
+{
+color = 11;
+glyphname = "nwiiOjibway-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (192,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (655,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 859;
+}
+);
+note = uni18C9;
+},
+{
+color = 11;
+glyphname = "nwoOjibway-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (655,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 859;
+}
+);
+note = uni18CB;
+},
+{
+color = 11;
+glyphname = "nwooOjibway-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (296,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (655,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 859;
+}
+);
+note = uni18CD;
+},
+{
+color = 11;
+glyphname = "looWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (40,0);
+ref = dot_top;
+}
+);
+width = 588;
+}
+);
+note = uni18E1;
+},
+{
+color = 11;
+glyphname = "laaWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (383,0);
+ref = dot_top;
+}
+);
+width = 588;
+}
+);
+note = uni18E2;
+},
+{
+color = 0;
+glyphname = zero;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(534,568,o),
+(462,699,o),
+(294,699,cs),
+(124,699,o),
+(52,565,o),
+(52,345,cs),
+(52,110,o),
+(135,-10,o),
+(294,-10,cs),
+(457,-10,o),
+(534,104,o),
+(534,345,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,434,o),
+(205,580,o),
+(294,580,cs),
+(384,580,o),
+(386,431,o),
+(386,345,cs),
+(386,242,o),
+(376,110,o),
+(294,110,cs),
+(213,110,o),
+(200,242,o),
+(200,345,cs)
+);
+}
+);
+width = 586;
+}
+);
+unicode = 48;
+},
+{
+color = 0;
+glyphname = one;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(238,690,l),
+(13,510,l),
+(90,413,l),
+(178,484,ls),
+(195,497,o),
+(208,510,o),
+(223,527,c),
+(222,483,o),
+(221,445,o),
+(221,405,cs),
+(221,0,l),
+(372,0,l),
+(372,690,l)
+);
+}
+);
+width = 492;
+}
+);
+unicode = 49;
+},
+{
+color = 0;
+glyphname = two;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(520,0,l),
+(520,124,l),
+(231,124,l),
+(231,128,l),
+(316,212,ls),
+(398,289,o),
+(454,346,o),
+(482,408,cs),
+(496,439,o),
+(502,474,o),
+(502,513,cs),
+(502,622,o),
+(414,699,o),
+(283,699,cs),
+(171,699,o),
+(104,659,o),
+(38,600,c),
+(120,503,l),
+(175,551,o),
+(220,574,o),
+(267,574,cs),
+(317,574,o),
+(355,548,o),
+(355,494,cs),
+(355,451,o),
+(339,417,o),
+(299,372,cs),
+(279,348,o),
+(252,319,o),
+(218,283,cs),
+(39,99,l),
+(39,0,l)
+);
+}
+);
+width = 567;
+}
+);
+unicode = 50;
+},
+{
+color = 0;
+glyphname = three;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(489,639,o),
+(404,699,o),
+(269,699,cs),
+(157,699,o),
+(90,669,o),
+(33,630,c),
+(96,529,l),
+(129,553,o),
+(185,579,o),
+(246,579,cs),
+(305,579,o),
+(344,555,o),
+(344,504,cs),
+(344,432,o),
+(263,411,o),
+(189,411,cs),
+(137,411,l),
+(137,298,l),
+(188,298,ls),
+(300,298,o),
+(353,271,o),
+(353,204,cs),
+(353,146,o),
+(315,108,o),
+(213,108,cs),
+(156,108,o),
+(89,125,o),
+(31,154,c),
+(31,29,l),
+(88,6,o),
+(148,-10,o),
+(234,-10,cs),
+(391,-10,o),
+(509,60,o),
+(509,195,cs),
+(509,294,o),
+(447,347,o),
+(337,360,c),
+(337,363,l),
+(424,385,o),
+(489,444,o),
+(489,538,cs)
+);
+}
+);
+width = 553;
+}
+);
+unicode = 51;
+},
+{
+color = 0;
+glyphname = four;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(470,258,l),
+(470,691,l),
+(332,691,l),
+(28,255,l),
+(28,146,l),
+(324,146,l),
+(324,0,l),
+(470,0,l),
+(470,146,l),
+(558,146,l),
+(558,258,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(159,258,l),
+(280,430,ls),
+(299,459,o),
+(308,473,o),
+(323,502,c),
+(327,502,l),
+(327,495,o),
+(324,461,o),
+(324,404,cs),
+(324,258,l)
+);
+}
+);
+width = 588;
+}
+);
+unicode = 52;
+},
+{
+color = 0;
+glyphname = five;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(246,442,o),
+(224,437,o),
+(201,432,c),
+(213,565,l),
+(463,565,l),
+(463,690,l),
+(86,690,l),
+(60,338,l),
+(116,309,l),
+(147,318,o),
+(184,327,o),
+(224,327,cs),
+(313,327,o),
+(357,287,o),
+(357,220,cs),
+(357,149,o),
+(308,108,o),
+(225,108,cs),
+(165,108,o),
+(93,129,o),
+(45,153,c),
+(45,29,l),
+(95,4,o),
+(158,-10,o),
+(237,-10,cs),
+(415,-10,o),
+(508,75,o),
+(508,225,cs),
+(508,362,o),
+(420,442,o),
+(296,442,cs)
+);
+}
+);
+width = 556;
+}
+);
+unicode = 53;
+},
+{
+color = 0;
+glyphname = six;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(52,118,o),
+(137,-10,o),
+(303,-10,cs),
+(449,-10,o),
+(539,81,o),
+(539,232,cs),
+(539,371,o),
+(466,451,o),
+(343,451,cs),
+(264,451,o),
+(217,413,o),
+(192,363,c),
+(187,363,l),
+(192,499,o),
+(246,583,o),
+(394,583,cs),
+(439,583,o),
+(469,579,o),
+(495,573,c),
+(495,691,l),
+(469,696,o),
+(427,699,o),
+(397,699,cs),
+(145,699,o),
+(52,538,o),
+(52,292,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(231,109,o),
+(202,176,o),
+(202,243,cs),
+(202,292,o),
+(245,335,o),
+(303,335,cs),
+(366,335,o),
+(394,296,o),
+(394,228,cs),
+(394,150,o),
+(358,109,o),
+(300,109,cs)
+);
+}
+);
+width = 577;
+}
+);
+unicode = 54;
+},
+{
+color = 0;
+glyphname = seven;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(507,602,l),
+(507,690,l),
+(23,690,l),
+(23,566,l),
+(348,566,l),
+(99,0,l),
+(254,0,l)
+);
+}
+);
+width = 530;
+}
+);
+unicode = 55;
+},
+{
+color = 0;
+glyphname = eight;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(428,-10,o),
+(529,53,o),
+(529,182,cs),
+(529,274,o),
+(457,328,o),
+(381,364,c),
+(457,400,o),
+(509,451,o),
+(509,534,cs),
+(509,643,o),
+(420,699,o),
+(288,699,cs),
+(155,699,o),
+(66,639,o),
+(66,534,cs),
+(66,449,o),
+(122,398,o),
+(184,362,c),
+(102,327,o),
+(44,276,o),
+(44,179,cs),
+(44,68,o),
+(124,-10,o),
+(286,-10,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(221,99,o),
+(182,132,o),
+(182,185,cs),
+(182,242,o),
+(231,274,o),
+(285,298,c),
+(348,270,o),
+(392,235,o),
+(392,183,cs),
+(392,129,o),
+(355,99,o),
+(284,99,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(240,451,o),
+(206,478,o),
+(206,521,cs),
+(206,565,o),
+(242,591,o),
+(288,591,cs),
+(334,591,o),
+(369,566,o),
+(369,522,cs),
+(369,476,o),
+(332,451,o),
+(287,429,c)
+);
+}
+);
+width = 574;
+}
+);
+unicode = 56;
+},
+{
+color = 0;
+glyphname = nine;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(524,573,o),
+(440,699,o),
+(273,699,cs),
+(127,699,o),
+(38,610,o),
+(38,460,cs),
+(38,320,o),
+(111,239,o),
+(230,239,cs),
+(312,239,o),
+(358,275,o),
+(384,327,c),
+(389,327,l),
+(383,179,o),
+(316,106,o),
+(173,106,cs),
+(137,106,o),
+(108,110,o),
+(81,116,c),
+(81,-4,l),
+(107,-9,o),
+(150,-10,o),
+(180,-10,cs),
+(430,-10,o),
+(524,153,o),
+(524,390,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(347,580,o),
+(374,508,o),
+(374,447,cs),
+(374,399,o),
+(328,354,o),
+(274,354,cs),
+(213,354,o),
+(182,395,o),
+(182,461,cs),
+(182,540,o),
+(216,580,o),
+(277,580,cs)
+);
+}
+);
+width = 577;
+}
+);
+unicode = 57;
+},
+{
+glyphname = zero.canadian;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(486,585,o),
+(405,703,o),
+(261,703,cs),
+(118,703,o),
+(37,585,o),
+(37,345,cs),
+(37,104,o),
+(118,-12,o),
+(261,-12,cs),
+(405,-12,o),
+(486,104,o),
+(486,345,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(179,512,o),
+(206,577,o),
+(262,577,cs),
+(317,577,o),
+(343,512,o),
+(343,345,cs),
+(343,178,o),
+(318,116,o),
+(262,116,cs),
+(205,116,o),
+(179,178,o),
+(179,345,cs)
+);
+}
+);
+width = 523;
+}
+);
+metricRight = "=|";
+},
+{
+glyphname = one.canadian;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(326,0,l),
+(326,690,l),
+(198,690,l),
+(8,504,l),
+(93,414,l),
+(272,589,l),
+(183,596,l),
+(183,0,l)
+);
+}
+);
+width = 377;
+}
+);
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = two.canadian;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(469,129,l),
+(218,129,l),
+(220,83,l),
+(374,277,ls),
+(440,361,o),
+(460,432,o),
+(460,497,cs),
+(460,626,o),
+(377,703,o),
+(256,703,cs),
+(116,703,o),
+(37,609,o),
+(36,449,c),
+(177,449,l),
+(177,540,o),
+(203,580,o),
+(252,580,cs),
+(295,580,o),
+(318,549,o),
+(318,497,cs),
+(318,450,o),
+(299,398,o),
+(250,336,cs),
+(56,92,l),
+(56,0,l),
+(469,0,l)
+);
+}
+);
+width = 504;
+}
+);
+note = uni14BF;
+},
+{
+glyphname = three.canadian;
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(392,-14,o),
+(476,64,o),
+(476,188,cs),
+(476,283,o),
+(430,353,o),
+(334,369,c),
+(333,322,l),
+(423,337,o),
+(469,412,o),
+(469,498,cs),
+(469,628,o),
+(389,703,o),
+(265,703,cs),
+(127,703,o),
+(47,606,o),
+(44,461,c),
+(185,461,l),
+(186,540,o),
+(212,580,o),
+(261,580,cs),
+(304,580,o),
+(326,551,o),
+(326,489,cs),
+(326,429,o),
+(303,405,o),
+(260,405,cs),
+(230,405,l),
+(230,286,l),
+(261,286,ls),
+(307,286,o),
+(331,260,o),
+(331,200,cs),
+(331,139,o),
+(307,110,o),
+(260,110,cs),
+(207,110,o),
+(182,150,o),
+(181,229,c),
+(40,229,l),
+(41,73,o),
+(118,-14,o),
+(264,-14,cs)
+);
+}
+);
+width = 524;
+}
+);
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = four.canadian;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(407,0,l),
+(407,147,l),
+(480,147,l),
+(480,263,l),
+(407,263,l),
+(407,691,l),
+(294,691,l),
+(26,241,l),
+(26,147,l),
+(270,147,l),
+(270,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(316,550,l),
+(274,550,l),
+(274,263,l),
+(123,263,l),
+(134,229,l)
+);
+}
+);
+width = 497;
+}
+);
+},
+{
+glyphname = five.canadian;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(394,-14,o),
+(482,70,o),
+(482,214,cs),
+(482,353,o),
+(404,429,o),
+(265,429,cs),
+(170,429,l),
+(220,393,l),
+(235,601,l),
+(181,561,l),
+(453,561,l),
+(453,690,l),
+(102,690,l),
+(78,338,l),
+(105,307,l),
+(233,307,ls),
+(309,307,o),
+(340,278,o),
+(340,209,cs),
+(340,141,o),
+(312,110,o),
+(267,110,cs),
+(217,110,o),
+(189,142,o),
+(189,208,c),
+(48,208,l),
+(51,63,o),
+(137,-14,o),
+(267,-14,cs)
+);
+}
+);
+width = 521;
+}
+);
+},
+{
+glyphname = six.canadian;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(408,-14,o),
+(494,78,o),
+(494,211,cs),
+(494,346,o),
+(413,433,o),
+(298,433,cs),
+(227,433,o),
+(177,400,o),
+(150,332,c),
+(183,292,l),
+(180,316,o),
+(180,330,o),
+(180,386,cs),
+(180,524,o),
+(209,582,o),
+(273,582,cs),
+(322,582,o),
+(348,545,o),
+(351,483,c),
+(492,483,l),
+(480,619,o),
+(405,703,o),
+(278,703,cs),
+(130,703,o),
+(37,586,o),
+(37,353,cs),
+(37,208,o),
+(59,120,o),
+(109,57,cs),
+(148,10,o),
+(206,-14,o),
+(279,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(220,105,o),
+(189,146,o),
+(189,214,cs),
+(189,276,o),
+(221,315,o),
+(273,315,cs),
+(326,315,o),
+(355,276,o),
+(355,211,cs),
+(355,145,o),
+(324,105,o),
+(273,105,cs)
+);
+}
+);
+width = 526;
+}
+);
+metricLeft = zero.canadian;
+},
+{
+glyphname = seven.canadian;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(400,602,l),
+(400,690,l),
+(24,690,l),
+(24,560,l),
+(260,560,l),
+(259,600,l),
+(82,35,l),
+(82,0,l),
+(221,0,l)
+);
+}
+);
+width = 424;
+}
+);
+},
+{
+glyphname = eight.canadian;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(405,-14,o),
+(493,67,o),
+(493,188,cs),
+(493,289,o),
+(438,353,o),
+(347,369,c),
+(342,322,l),
+(427,336,o),
+(480,402,o),
+(480,501,cs),
+(480,623,o),
+(396,703,o),
+(270,703,cs),
+(145,703,o),
+(61,623,o),
+(61,501,cs),
+(61,402,o),
+(115,336,o),
+(199,322,c),
+(194,369,l),
+(103,353,o),
+(48,289,o),
+(48,188,cs),
+(48,67,o),
+(136,-14,o),
+(270,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(219,104,o),
+(189,136,o),
+(189,196,cs),
+(189,256,o),
+(219,287,o),
+(270,287,cs),
+(322,287,o),
+(352,256,o),
+(352,196,cs),
+(352,136,o),
+(322,104,o),
+(270,104,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(225,403,o),
+(201,433,o),
+(201,494,cs),
+(201,554,o),
+(225,585,o),
+(270,585,cs),
+(316,585,o),
+(341,554,o),
+(341,494,cs),
+(341,433,o),
+(316,403,o),
+(270,403,cs)
+);
+}
+);
+width = 541;
+}
+);
+metricLeft = "=|";
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = nine.canadian;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(395,-14,o),
+(489,103,o),
+(489,337,cs),
+(489,482,o),
+(467,570,o),
+(415,633,cs),
+(377,680,o),
+(319,703,o),
+(245,703,cs),
+(118,703,o),
+(32,611,o),
+(32,479,cs),
+(32,344,o),
+(112,257,o),
+(227,257,cs),
+(298,257,o),
+(349,290,o),
+(376,357,c),
+(343,398,l),
+(346,374,o),
+(346,359,o),
+(346,303,cs),
+(346,166,o),
+(317,109,o),
+(251,109,cs),
+(204,109,o),
+(177,145,o),
+(174,207,c),
+(33,207,l),
+(45,71,o),
+(120,-14,o),
+(246,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,375,o),
+(171,413,o),
+(171,479,cs),
+(171,545,o),
+(201,584,o),
+(252,584,cs),
+(305,584,o),
+(335,544,o),
+(335,475,cs),
+(335,413,o),
+(303,375,o),
+(252,375,cs)
+);
+}
+);
+width = 526;
+}
+);
+metricLeft = "=|six.canadian";
+metricRight = "=|six.canadian";
+},
+{
+glyphname = CR;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+width = 215;
+}
+);
+note = CR;
+unicode = 13;
+},
+{
+color = 0;
+glyphname = .notdef;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(488,690,l),
+(91,690,l),
+(91,0,l),
+(488,0,l),
+(488,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(439,640,l),
+(439,49,l),
+(140,49,l),
+(140,640,l),
+(140,640,l)
+);
+}
+);
+width = 580;
+}
+);
+note = ".notdef";
+},
+{
+glyphname = .null;
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+width = 0;
+}
+);
+note = NULL;
+},
+{
+glyphname = space;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+width = 217;
+}
+);
+note = space;
+unicode = 32;
+},
+{
+glyphname = nbspace;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+width = 215;
+}
+);
+note = uni00A0;
+unicode = 160;
+},
+{
+glyphname = space.canadian;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+width = 440;
+}
+);
+note = space;
+},
+{
+glyphname = "hyphen-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(315,385,l),
+(315,466,l),
+(43,466,l),
+(43,385,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(315,244,l),
+(315,325,l),
+(43,325,l),
+(43,244,l)
+);
+}
+);
+width = 358;
+}
+);
+metricRight = "=|";
+note = uni1400;
+unicode = 5120;
+},
+{
+glyphname = "chi-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(163,0,l),
+(281,266,l),
+(230,266,l),
+(346,0,l),
+(480,0,l),
+(480,35,l),
+(303,407,l),
+(303,293,l),
+(478,655,l),
+(478,690,l),
+(344,690,l),
+(229,427,l),
+(279,427,l),
+(165,690,l),
+(32,690,l),
+(32,655,l),
+(206,293,l),
+(206,407,l),
+(29,35,l),
+(29,0,l)
+);
+}
+);
+width = 509;
+}
+);
+metricRight = "=|";
+note = uni166D;
+unicode = 5741;
+},
+{
+glyphname = "fullstop-canadian";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(287,0,l),
+(287,17,l),
+(201,189,l),
+(204,155,l),
+(286,327,l),
+(286,345,l),
+(199,345,l),
+(144,209,l),
+(182,215,l),
+(126,345,l),
+(40,345,l),
+(40,327,l),
+(121,161,l),
+(123,196,l),
+(39,17,l),
+(39,0,l),
+(126,0,l),
+(186,147,l),
+(140,139,l),
+(200,0,l)
+);
+}
+);
+width = 326;
+}
+);
+note = uni1541;
+unicode = 5742;
+},
+{
+glyphname = period;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(44,14,o),
+(80,-11,o),
+(127,-11,cs),
+(173,-11,o),
+(207,14,o),
+(207,65,cs),
+(207,120,o),
+(173,142,o),
+(127,142,cs),
+(80,142,o),
+(44,120,o),
+(44,65,cs)
+);
+}
+);
+width = 247;
+}
+);
+note = period;
+unicode = 46;
+},
+{
+glyphname = comma;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,-132,l),
+(155,-57,o),
+(181,47,o),
+(199,124,c),
+(193,134,l),
+(70,134,l),
+(61,59,o),
+(43,-39,o),
+(21,-132,c)
+);
+}
+);
+width = 248;
+}
+);
+note = comma;
+unicode = 44;
+},
+{
+glyphname = hyphen;
+kernLeft = hyphen;
+kernRight = hyphen;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(228,319,l),
+(26,319,l),
+(26,201,l),
+(228,201,l)
+);
+}
+);
+width = 254;
+}
+);
+unicode = 45;
+},
+{
+glyphname = quotesinglbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (29,-555);
+ref = quoteright;
+}
+);
+width = 292;
+}
+);
+unicode = 8218;
+},
+{
+glyphname = quotedblbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (29,-555);
+ref = quotedblright;
+}
+);
+width = 509;
+}
+);
+unicode = 8222;
+},
+{
+glyphname = quotedblleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(359,423,l),
+(369,500,o),
+(386,594,o),
+(410,689,c),
+(311,689,l),
+(279,617,o),
+(251,522,o),
+(231,433,c),
+(238,423,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(151,423,l),
+(159,500,o),
+(177,594,o),
+(200,689,c),
+(101,689,l),
+(71,617,o),
+(42,522,o),
+(22,433,c),
+(28,423,l)
+);
+}
+);
+width = 436;
+}
+);
+unicode = 8220;
+},
+{
+glyphname = quotedblright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(334,423,l),
+(369,497,o),
+(396,601,o),
+(414,679,c),
+(408,689,l),
+(285,689,l),
+(278,613,o),
+(260,513,o),
+(236,423,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(125,423,l),
+(159,497,o),
+(187,601,o),
+(205,679,c),
+(198,689,l),
+(76,689,l),
+(69,614,o),
+(50,512,o),
+(26,423,c)
+);
+}
+);
+width = 436;
+}
+);
+unicode = 8221;
+},
+{
+glyphname = quoteleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(156,423,l),
+(166,500,o),
+(184,595,o),
+(206,689,c),
+(101,689,l),
+(71,617,o),
+(42,522,o),
+(22,433,c),
+(28,423,l)
+);
+}
+);
+width = 233;
+}
+);
+unicode = 8216;
+},
+{
+glyphname = quoteright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(130,423,l),
+(165,497,o),
+(193,602,o),
+(211,679,c),
+(204,689,l),
+(76,689,l),
+(69,614,o),
+(50,512,o),
+(26,423,c)
+);
+}
+);
+width = 233;
+}
+);
+unicode = 8217;
+},
+{
+glyphname = dottedCircle;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(193,504,o),
+(181,494,o),
+(181,479,cs),
+(181,467,o),
+(193,454,o),
+(206,454,cs),
+(220,454,o),
+(231,467,o),
+(231,479,cs),
+(231,494,o),
+(220,504,o),
+(206,504,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(355,504,o),
+(343,494,o),
+(343,479,cs),
+(343,467,o),
+(355,454,o),
+(368,454,cs),
+(383,454,o),
+(393,467,o),
+(393,479,cs),
+(393,494,o),
+(383,504,o),
+(368,504,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(193,108,o),
+(181,98,o),
+(181,83,cs),
+(181,71,o),
+(193,58,o),
+(206,58,cs),
+(220,58,o),
+(231,71,o),
+(231,83,cs),
+(231,98,o),
+(220,108,o),
+(206,108,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(355,108,o),
+(343,98,o),
+(343,83,cs),
+(343,71,o),
+(355,58,o),
+(368,58,cs),
+(383,58,o),
+(393,71,o),
+(393,83,cs),
+(393,98,o),
+(383,108,o),
+(368,108,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(274,522,o),
+(262,511,o),
+(262,497,cs),
+(262,484,o),
+(274,471,o),
+(287,471,cs),
+(301,471,o),
+(312,484,o),
+(312,497,cs),
+(312,511,o),
+(301,522,o),
+(287,522,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(274,91,o),
+(262,80,o),
+(262,66,cs),
+(262,53,o),
+(274,41,o),
+(287,41,cs),
+(301,41,o),
+(312,53,o),
+(312,66,cs),
+(312,80,o),
+(301,91,o),
+(287,91,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(46,269,o),
+(59,256,o),
+(71,256,cs),
+(86,256,o),
+(97,269,o),
+(97,281,cs),
+(97,296,o),
+(86,306,o),
+(71,306,cs),
+(59,306,o),
+(46,296,o),
+(46,281,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(477,269,o),
+(490,256,o),
+(502,256,cs),
+(517,256,o),
+(527,269,o),
+(527,281,cs),
+(527,296,o),
+(517,306,o),
+(502,306,cs),
+(490,306,o),
+(477,296,o),
+(477,281,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(109,116,o),
+(122,103,o),
+(134,103,cs),
+(149,103,o),
+(159,116,o),
+(159,128,cs),
+(159,143,o),
+(149,154,o),
+(134,154,cs),
+(122,154,o),
+(109,143,o),
+(109,128,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(109,421,o),
+(122,409,o),
+(134,409,cs),
+(149,409,o),
+(159,421,o),
+(159,434,cs),
+(159,448,o),
+(149,459,o),
+(134,459,cs),
+(122,459,o),
+(109,448,o),
+(109,434,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(414,116,o),
+(427,103,o),
+(440,103,cs),
+(454,103,o),
+(465,116,o),
+(465,128,cs),
+(465,143,o),
+(454,154,o),
+(440,154,cs),
+(427,154,o),
+(414,143,o),
+(414,128,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(414,421,o),
+(427,409,o),
+(440,409,cs),
+(454,409,o),
+(465,421,o),
+(465,434,cs),
+(465,448,o),
+(454,459,o),
+(440,459,cs),
+(427,459,o),
+(414,448,o),
+(414,434,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(64,187,o),
+(76,175,o),
+(89,175,cs),
+(103,175,o),
+(114,187,o),
+(114,200,cs),
+(114,214,o),
+(103,225,o),
+(89,225,cs),
+(76,225,o),
+(64,214,o),
+(64,200,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(64,350,o),
+(76,337,o),
+(89,337,cs),
+(103,337,o),
+(114,350,o),
+(114,362,cs),
+(114,377,o),
+(103,387,o),
+(89,387,cs),
+(76,387,o),
+(64,377,o),
+(64,362,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(460,187,o),
+(472,175,o),
+(485,175,cs),
+(499,175,o),
+(510,187,o),
+(510,200,cs),
+(510,214,o),
+(499,225,o),
+(485,225,cs),
+(472,225,o),
+(460,214,o),
+(460,200,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(460,350,o),
+(472,337,o),
+(485,337,cs),
+(499,337,o),
+(510,350,o),
+(510,362,cs),
+(510,377,o),
+(499,387,o),
+(485,387,cs),
+(472,387,o),
+(460,377,o),
+(460,362,cs)
+);
+}
+);
+width = 574;
+}
+);
+note = uni25CC;
+unicode = 9676;
+},
+{
+glyphname = dotaccentcomb;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(63,735,o),
+(29,720,o),
+(29,668,cs),
+(29,617,o),
+(62,600,o),
+(103,600,cs),
+(144,600,o),
+(179,617,o),
+(179,668,cs),
+(179,720,o),
+(143,735,o),
+(103,735,cs)
+);
+}
+);
+width = 207;
+}
+);
+note = uni0307;
+unicode = 775;
+},
+{
+glyphname = dotaccent;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(144,600,o),
+(180,616,o),
+(180,668,cs),
+(180,720,o),
+(144,735,o),
+(104,735,cs),
+(64,735,o),
+(30,720,o),
+(30,668,cs),
+(30,617,o),
+(63,600,o),
+(104,600,cs)
+);
+}
+);
+width = 209;
+}
+);
+note = dotaccent;
+unicode = 729;
+},
+{
+glyphname = caron;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(285,623,o),
+(315,671,o),
+(356,727,c),
+(356,739,l),
+(265,739,l),
+(239,715,o),
+(219,689,o),
+(192,655,c),
+(166,688,o),
+(147,716,o),
+(123,739,c),
+(30,739,l),
+(30,727,l),
+(63,683,o),
+(99,633,o),
+(123,585,c),
+(265,585,l),
+(265,585,l)
+);
+}
+);
+width = 385;
+}
+);
+note = caron;
+unicode = 711;
+},
+{
+glyphname = breve;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(263,585,o),
+(316,645,o),
+(321,742,c),
+(242,742,l),
+(232,691,o),
+(205,673,o),
+(174,673,cs),
+(134,673,o),
+(117,689,o),
+(106,742,c),
+(30,742,l),
+(34,640,o),
+(84,585,o),
+(174,585,cs)
+);
+}
+);
+width = 351;
+}
+);
+note = breve;
+unicode = 728;
+},
+{
+glyphname = ring;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(180,585,o),
+(223,629,o),
+(223,698,cs),
+(223,766,o),
+(179,811,o),
+(125,811,cs),
+(68,811,o),
+(30,767,o),
+(30,698,cs),
+(30,630,o),
+(68,585,o),
+(125,585,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(105,649,o),
+(95,670,o),
+(95,698,cs),
+(95,727,o),
+(108,747,o),
+(125,747,cs),
+(142,747,o),
+(156,726,o),
+(156,698,cs),
+(156,671,o),
+(142,649,o),
+(125,649,cs)
+);
+}
+);
+width = 252;
+}
+);
+note = ring;
+unicode = 730;
+},
+{
+glyphname = ogonek;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(151,-226,o),
+(172,-222,o),
+(192,-214,c),
+(192,-132,l),
+(182,-137,o),
+(162,-142,o),
+(149,-142,cs),
+(132,-142,o),
+(121,-129,o),
+(121,-102,cs),
+(121,-69,o),
+(135,-40,o),
+(169,0,c),
+(114,20,l),
+(52,-33,o),
+(30,-77,o),
+(30,-125,cs),
+(30,-188,o),
+(73,-226,o),
+(129,-226,cs)
+);
+}
+);
+width = 221;
+}
+);
+note = ogonek;
+unicode = 731;
+},
+{
+glyphname = ring_top.canadian;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (117,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(173,757,o),
+(221,800,o),
+(221,859,cs),
+(221,919,o),
+(173,961,o),
+(117,961,cs),
+(61,961,o),
+(14,919,o),
+(14,859,cs),
+(14,800,o),
+(61,757,o),
+(117,757,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(91,815,o),
+(74,835,o),
+(74,859,cs),
+(74,883,o),
+(92,903,o),
+(117,903,cs),
+(143,903,o),
+(160,883,o),
+(160,859,cs),
+(160,835,o),
+(143,815,o),
+(117,815,cs)
+);
+}
+);
+width = 235;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (84,345);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(120,279,o),
+(149,309,o),
+(149,345,cs),
+(149,381,o),
+(120,411,o),
+(84,411,cs),
+(47,411,o),
+(18,381,o),
+(18,345,cs),
+(18,309,o),
+(47,279,o),
+(84,279,cs)
+);
+}
+);
+width = 167;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (69,345);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(98,293,o),
+(122,315,o),
+(122,345,cs),
+(122,375,o),
+(98,397,o),
+(69,397,cs),
+(40,397,o),
+(16,375,o),
+(16,345,cs),
+(16,315,o),
+(40,293,o),
+(69,293,cs)
+);
+}
+);
+width = 137;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_small;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (53,345);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(75,307,o),
+(92,324,o),
+(92,345,cs),
+(92,366,o),
+(75,383,o),
+(53,383,cs),
+(33,383,o),
+(16,366,o),
+(16,345,cs),
+(16,324,o),
+(33,307,o),
+(53,307,cs)
+);
+}
+);
+width = 108;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_top;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (84,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,768,o),
+(151,798,o),
+(151,836,cs),
+(151,872,o),
+(121,903,o),
+(84,903,cs),
+(46,903,o),
+(16,872,o),
+(16,836,cs),
+(16,798,o),
+(46,768,o),
+(84,768,cs)
+);
+}
+);
+width = 167;
+}
+);
+note = g725;
+},
+{
+glyphname = doubledot_middle;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(141,370,o),
+(171,400,o),
+(171,437,cs),
+(171,474,o),
+(141,504,o),
+(103,504,cs),
+(67,504,o),
+(36,474,o),
+(36,437,cs),
+(36,399,o),
+(67,370,o),
+(103,370,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(141,185,o),
+(171,215,o),
+(171,253,cs),
+(171,290,o),
+(141,320,o),
+(103,320,cs),
+(67,320,o),
+(36,291,o),
+(36,253,cs),
+(36,215,o),
+(67,185,o),
+(103,185,cs)
+);
+}
+);
+width = 207;
+}
+);
+metricRight = "=|";
+note = g725;
+},
+{
+glyphname = doubledot_top;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top_double;
+pos = (255,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(292,768,o),
+(323,798,o),
+(323,836,cs),
+(323,872,o),
+(292,903,o),
+(255,903,cs),
+(217,903,o),
+(188,872,o),
+(188,836,cs),
+(188,798,o),
+(217,768,o),
+(255,768,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(119,768,o),
+(149,798,o),
+(149,836,cs),
+(149,872,o),
+(119,903,o),
+(81,903,cs),
+(43,903,o),
+(14,872,o),
+(14,836,cs),
+(14,798,o),
+(43,768,o),
+(81,768,cs)
+);
+}
+);
+width = 336;
+}
+);
+note = g725;
+},
+{
+glyphname = g727;
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (305,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(555,0,l),
+(555,116,l),
+(280,116,ls),
+(218,116,o),
+(186,144,o),
+(186,201,cs),
+(186,259,o),
+(216,288,o),
+(280,288,cs),
+(358,288,ls),
+(493,288,o),
+(567,361,o),
+(567,490,cs),
+(567,617,o),
+(493,690,o),
+(358,690,cs),
+(55,690,l),
+(55,574,l),
+(330,574,ls),
+(392,574,o),
+(424,546,o),
+(424,490,cs),
+(424,433,o),
+(394,403,o),
+(330,403,cs),
+(252,403,ls),
+(118,403,o),
+(43,328,o),
+(43,200,cs),
+(43,72,o),
+(118,0,o),
+(252,0,cs)
+);
+}
+);
+width = 610;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+glyphname = g728;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (222,0);
+ref = dot_top;
+}
+);
+width = 611;
+}
+);
+note = g728;
+},
+{
+glyphname = g729;
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (306,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(358,0,ls),
+(493,0,o),
+(566,72,o),
+(566,200,cs),
+(566,328,o),
+(493,403,o),
+(358,403,cs),
+(280,403,ls),
+(216,403,o),
+(186,433,o),
+(186,489,cs),
+(186,546,o),
+(217,574,o),
+(280,574,cs),
+(555,574,l),
+(555,690,l),
+(252,690,ls),
+(118,690,o),
+(43,617,o),
+(43,490,cs),
+(43,361,o),
+(118,288,o),
+(252,288,cs),
+(330,288,ls),
+(393,288,o),
+(424,259,o),
+(424,200,cs),
+(424,144,o),
+(392,116,o),
+(330,116,cs),
+(55,116,l),
+(55,0,l)
+);
+}
+);
+width = 609;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+glyphname = g730;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (222,0);
+ref = dot_top;
+}
+);
+width = 611;
+}
+);
+note = g730;
+},
+{
+glyphname = g731;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = g727;
+}
+);
+width = 814;
+}
+);
+note = g731;
+},
+{
+glyphname = g732;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (611,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 814;
+}
+);
+note = g732;
+},
+{
+glyphname = g733;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (426,0);
+ref = dot_top;
+}
+);
+width = 814;
+}
+);
+note = g733;
+},
+{
+glyphname = g734;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (222,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (611,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 814;
+}
+);
+note = g734;
+},
+{
+glyphname = g735;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = g729;
+}
+);
+width = 814;
+}
+);
+note = g735;
+},
+{
+glyphname = g736;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (611,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 814;
+}
+);
+note = g736;
+},
+{
+glyphname = g737;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (426,0);
+ref = dot_top;
+}
+);
+width = 814;
+}
+);
+note = g737;
+},
+{
+glyphname = g738;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (222,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (611,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 814;
+}
+);
+note = g738;
+},
+{
+glyphname = g739;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(463,262,o),
+(506,314,o),
+(506,392,cs),
+(506,469,o),
+(462,524,o),
+(384,524,cs),
+(234,524,l),
+(239,482,l),
+(254,494,o),
+(269,528,o),
+(269,570,cs),
+(269,645,o),
+(227,696,o),
+(152,696,cs),
+(77,696,o),
+(34,643,o),
+(34,565,cs),
+(34,487,o),
+(78,434,o),
+(156,434,cs),
+(307,434,l),
+(301,475,l),
+(286,464,o),
+(271,428,o),
+(271,387,cs),
+(271,312,o),
+(313,262,o),
+(388,262,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(130,503,o),
+(117,522,o),
+(117,565,cs),
+(117,608,o),
+(130,627,o),
+(152,627,cs),
+(173,627,o),
+(185,606,o),
+(185,564,cs),
+(185,524,o),
+(173,503,o),
+(152,503,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(368,330,o),
+(355,351,o),
+(355,392,cs),
+(355,434,o),
+(367,454,o),
+(388,454,cs),
+(410,454,o),
+(423,435,o),
+(423,392,cs),
+(423,350,o),
+(410,330,o),
+(388,330,cs)
+);
+}
+);
+width = 540;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+glyphname = g740;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (188,0);
+ref = ring_top.canadian;
+}
+);
+width = 611;
+}
+);
+note = g740;
+},
+{
+glyphname = g741;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (188,0);
+ref = ring_top.canadian;
+}
+);
+width = 611;
+}
+);
+note = g741;
+},
+{
+glyphname = g742;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (392,0);
+ref = ring_top.canadian;
+}
+);
+width = 814;
+}
+);
+note = g742;
+},
+{
+glyphname = stroke_middle;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (56,345);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(98,462,l),
+(15,462,l),
+(15,228,l),
+(98,228,l)
+);
+}
+);
+width = 113;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (45,345);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(75,420,l),
+(15,420,l),
+(15,270,l),
+(75,270,l)
+);
+}
+);
+width = 91;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_small;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (38,345);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(61,411,l),
+(15,411,l),
+(15,279,l),
+(61,279,l)
+);
+}
+);
+width = 76;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_threequart;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (56,345);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(94,459,l),
+(19,459,l),
+(19,231,l),
+(94,231,l)
+);
+}
+);
+width = 113;
+}
+);
+note = g723;
+},
+{
+color = 8;
+glyphname = uni11AB0;
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (156,690);
+},
+{
+name = top_right_can;
+pos = (382,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(226,0,l),
+(226,82,l),
+(402,82,l),
+(402,159,l),
+(226,159,l),
+(226,276,l),
+(118,232,l),
+(150,232,ls),
+(344,232,o),
+(453,350,o),
+(453,576,cs),
+(453,690,l),
+(310,690,l),
+(310,586,ls),
+(310,418,o),
+(244,359,o),
+(119,359,cs),
+(84,359,l),
+(84,159,l),
+(25,159,l),
+(25,82,l),
+(84,82,l),
+(84,0,l)
+);
+}
+);
+width = 504;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB1;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB0;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (298,0);
+ref = dot_top;
+}
+);
+width = 503;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB2;
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (122,690);
+},
+{
+name = top_right_can;
+pos = (350,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(193,0,l),
+(193,103,ls),
+(193,271,o),
+(260,330,o),
+(385,330,cs),
+(420,330,l),
+(420,530,l),
+(479,530,l),
+(479,608,l),
+(420,608,l),
+(420,690,l),
+(278,690,l),
+(278,608,l),
+(102,608,l),
+(102,530,l),
+(278,530,l),
+(278,413,l),
+(386,458,l),
+(355,458,ls),
+(160,458,o),
+(51,340,o),
+(51,114,cs),
+(51,0,l)
+);
+}
+);
+width = 504;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "theThCree-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB3;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB2;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (266,0);
+ref = dot_top;
+}
+);
+width = 503;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB4;
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (156,690);
+},
+{
+name = top_right_can;
+pos = (383,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(453,0,l),
+(453,114,ls),
+(453,340,o),
+(344,458,o),
+(150,458,cs),
+(118,458,l),
+(226,413,l),
+(226,530,l),
+(402,530,l),
+(402,608,l),
+(226,608,l),
+(226,690,l),
+(84,690,l),
+(84,608,l),
+(25,608,l),
+(25,530,l),
+(84,530,l),
+(84,330,l),
+(119,330,ls),
+(244,330,o),
+(310,271,o),
+(310,103,cs),
+(310,0,l)
+);
+}
+);
+width = 504;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB5;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB4;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (71,0);
+ref = dot_top;
+}
+);
+width = 503;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB6;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (123,690);
+},
+{
+name = top_right_can;
+pos = (350,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(194,0,l),
+(194,279,l),
+(86,232,l),
+(118,232,ls),
+(312,232,o),
+(421,350,o),
+(421,576,cs),
+(421,643,l),
+(326,605,l),
+(530,406,l),
+(611,491,l),
+(406,690,l),
+(278,690,l),
+(278,586,ls),
+(278,418,o),
+(213,359,o),
+(87,359,cs),
+(52,359,l),
+(52,0,l)
+);
+}
+);
+width = 627;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB7;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB6;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (267,0);
+ref = dot_top;
+}
+);
+width = 626;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB8;
+kernRight = soright;
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (277,690);
+},
+{
+name = top_right_can;
+pos = (504,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(348,0,l),
+(348,103,ls),
+(348,271,o),
+(414,330,o),
+(540,330,cs),
+(575,330,l),
+(575,690,l),
+(433,690,l),
+(433,411,l),
+(541,458,l),
+(509,458,ls),
+(315,458,o),
+(206,340,o),
+(206,114,cs),
+(206,46,l),
+(301,85,l),
+(97,284,l),
+(16,199,l),
+(221,0,l)
+);
+}
+);
+width = 627;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB9;
+kernRight = soright;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB8;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (419,0);
+ref = dot_top;
+}
+);
+width = 626;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABA;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:56:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (124,690);
+},
+{
+name = top_right_can;
+pos = (351,690);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(406,0,l),
+(611,199,l),
+(530,284,l),
+(326,85,l),
+(421,46,l),
+(421,114,ls),
+(421,340,o),
+(312,458,o),
+(118,458,cs),
+(86,458,l),
+(194,411,l),
+(194,690,l),
+(52,690,l),
+(52,330,l),
+(87,330,ls),
+(213,330,o),
+(278,271,o),
+(278,103,cs),
+(278,0,l)
+);
+}
+);
+width = 627;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABB;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = uni11ABA;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (40,0);
+ref = dot_top;
+}
+);
+width = 626;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABC;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(465,0,l),
+(465,129,l),
+(177,129,l),
+(177,81,l),
+(472,592,l),
+(472,690,l),
+(35,690,l),
+(35,560,l),
+(323,560,l),
+(323,609,l),
+(28,98,l),
+(28,0,l)
+);
+}
+);
+width = 500;
+}
+);
+metricRight = "=|";
+},
+{
+color = 8;
+glyphname = uni11ABD;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(472,0,l),
+(472,98,l),
+(178,609,l),
+(178,560,l),
+(466,560,l),
+(466,690,l),
+(28,690,l),
+(28,592,l),
+(323,81,l),
+(323,129,l),
+(36,129,l),
+(36,0,l)
+);
+}
+);
+width = 500;
+}
+);
+metricLeft = "=|uni11ABC";
+metricRight = "=|uni11ABC";
+},
+{
+color = 8;
+glyphname = uni11ABE;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(191,0,l),
+(191,568,l),
+(109,568,l),
+(400,0,l),
+(526,0,l),
+(526,690,l),
+(386,690,l),
+(386,122,l),
+(469,122,l),
+(177,690,l),
+(51,690,l),
+(51,0,l)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABF;
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(177,0,l),
+(468,569,l),
+(385,569,l),
+(385,0,l),
+(526,0,l),
+(526,690,l),
+(400,690,l),
+(108,121,l),
+(191,121,l),
+(191,690,l),
+(51,690,l),
+(51,0,l)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = "raiseddoubledotFinal-canadian.cree";
+lastChange = "2023-01-13 15:56:33 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(140,569,o),
+(170,599,o),
+(170,637,cs),
+(170,673,o),
+(140,703,o),
+(102,703,cs),
+(66,703,o),
+(36,674,o),
+(36,637,cs),
+(36,598,o),
+(66,569,o),
+(102,569,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(140,384,o),
+(170,415,o),
+(170,452,cs),
+(170,490,o),
+(140,520,o),
+(102,520,cs),
+(66,520,o),
+(36,490,o),
+(36,452,cs),
+(36,414,o),
+(66,384,o),
+(102,384,cs)
+);
+}
+);
+width = 206;
+}
+);
+note = g725;
+}
+);
+instances = (
+{
+axesValues = (
+154,
+75,
+0
+);
+instanceInterpolations = {
+"86DE26EB-3058-4E6D-9480-BC9D8886A6AA" = 1;
+};
+name = "RC CB roman";
+}
+);
+kerningLTR = {
+"86DE26EB-3058-4E6D-9480-BC9D8886A6AA" = {
+"@MMK_L_caright" = {
+"@MMK_R_ecanleft" = -63.756;
+"@MMK_R_mwestleft" = -25.116;
+"@MMK_R_neleft" = -37.674;
+};
+"@MMK_L_ciright" = {
+"@MMK_R_icanleft" = -63.756;
+"@MMK_R_noleft" = -70.518;
+};
+"@MMK_L_ecanright" = {
+"@MMK_R_coleft" = -63.756;
+"@MMK_R_moleft" = -64.722;
+"@MMK_R_sileft" = -34.776;
+};
+"@MMK_L_icanright" = {
+"@MMK_R_celeft" = -63.756;
+"@MMK_R_meleft" = -64.722;
+"@MMK_R_mwestleft" = -51.198;
+"@MMK_R_saleft" = -28.98;
+"she-canadian" = -64.722;
+};
+"@MMK_L_maright" = {
+"@MMK_R_acanleft" = -56.028;
+"@MMK_R_ecanleft" = -64.722;
+"@MMK_R_mwestleft" = -42.504;
+"@MMK_R_neleft" = -37.674;
+};
+"@MMK_L_miright" = {
+"@MMK_R_acanleft" = -56.028;
+"@MMK_R_icanleft" = -64.722;
+"@MMK_R_moleft" = -88.872;
+"@MMK_R_noleft" = -70.518;
+"@MMK_R_yeleft" = -91.77;
+};
+"@MMK_L_mwestright" = {
+"@MMK_R_coleft" = -25.116;
+"@MMK_R_icanleft" = -51.198;
+"@MMK_R_moleft" = -42.504;
+"@MMK_R_noleft" = -67.62;
+"@MMK_R_sileft" = -12.558;
+"@MMK_R_yeleft" = -26.082;
+};
+"@MMK_L_naright" = {
+"@MMK_R_acanleft" = -64.722;
+"@MMK_R_celeft" = -70.518;
+"@MMK_R_meleft" = -70.518;
+"@MMK_R_mwestleft" = -67.62;
+"@MMK_R_neleft" = -75.348;
+"@MMK_R_saleft" = -40.572;
+};
+"@MMK_L_niright" = {
+"@MMK_R_coleft" = -37.674;
+"@MMK_R_moleft" = -37.674;
+"@MMK_R_noleft" = -75.348;
+"@MMK_R_sileft" = -0.966;
+};
+"@MMK_L_ocanright" = {
+"@MMK_R_meleft" = -56.028;
+"@MMK_R_moleft" = -56.028;
+"@MMK_R_noleft" = -64.722;
+};
+"@MMK_L_seright" = {
+"@MMK_R_ecanleft" = -34.776;
+"@MMK_R_mwestleft" = -12.558;
+"@MMK_R_neleft" = -0.966;
+};
+"@MMK_L_soright" = {
+"@MMK_R_icanleft" = -28.98;
+"@MMK_R_noleft" = -40.572;
+};
+"@MMK_L_yiright" = {
+"@MMK_R_meleft" = -91.77;
+"@MMK_R_mwestleft" = -26.082;
+};
+"shi-canadian" = {
+"@MMK_R_icanleft" = -64.722;
+};
+};
+};
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "italic angle";
+}
+);
+properties = (
+{
+key = copyrights;
+values = (
+{
+language = ENG;
+value = "Copyright 2018 Google Inc. All Rights Reserved.";
+}
+);
+},
+{
+key = manufacturers;
+values = (
+{
+language = ENG;
+value = "Monotype Imaging Inc.";
+}
+);
+},
+{
+key = designers;
+values = (
+{
+language = ENG;
+value = "Monotype Design Team";
+}
+);
+},
+{
+key = description;
+value = "Designed by Monotype design team.";
+},
+{
+key = trademarks;
+values = (
+{
+language = ENG;
+value = "Noto is a trademark of Google Inc.";
+}
+);
+},
+{
+key = licenseURL;
+value = "http://scripts.sil.org/OFL";
+},
+{
+key = licenses;
+values = (
+{
+language = ENG;
+value = "This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.";
+}
+);
+},
+{
+key = manufacturerURL;
+value = "http://www.google.com/get/noto/";
+},
+{
+key = designerURL;
+value = "http://www.monotype.com/studio";
+}
+);
+settings = {
+disablesNiceNames = 1;
+};
+stems = (
+{
+name = "New Stem";
+}
+);
+unitsPerEm = 966;
+userData = {
+GSDontShowVersionAlert = 1;
+};
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/sources/Exported instances UCAS SansCanadianAboriginal Resized/Sans Canadian Aboriginal-RC CL Italic.glyphs
+++ b/sources/Exported instances UCAS SansCanadianAboriginal Resized/Sans Canadian Aboriginal-RC CL Italic.glyphs
@@ -1,0 +1,37325 @@
+{
+.appVersion = "3151";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+},
+{
+name = Width;
+tag = wdth;
+},
+{
+name = Slant;
+tag = slnt;
+}
+);
+classes = (
+{
+code = "zero one two three four five six seven eight nine ";
+name = Num;
+},
+{
+code = "zero.canadian one.canadian two.canadian three.canadian four.canadian five.canadian six.canadian seven.canadian eight.canadian nine.canadian 
+";
+name = Num_can;
+},
+{
+code = "ke-canadian.square ki-canadian.square kii-canadian.square ko-canadian.square koo-canadian.square ka-canadian.square kaa-canadian.square kweWestCree-canadian.square kwiiWestCree-canadian.square kwoWestCree-canadian.square kwooWestCree-canadian.square kwaWestCree-canadian.square kwaaWestCree-canadian.square ce-canadian.square ci-canadian.square cii-canadian.square co-canadian.square coo-canadian.square ca-canadian.square caa-canadian.square me-canadian.square mi-canadian.square mii-canadian.square mo-canadian.square moo-canadian.square ma-canadian.square maa-canadian.square ne-canadian.square ni-canadian.square nii-canadian.square no-canadian.square noo-canadian.square na-canadian.square naa-canadian.square nweWestCree-canadian.square nwaWestCree-canadian.square nwaaWestCree-canadian.square se-canadian.square si-canadian.square sii-canadian.square so-canadian.square soo-canadian.square sa-canadian.square saa-canadian.square sho-canadian.square shoo-canadian.square sha-canadian.square shaa-canadian.square ye-canadian.square yi-canadian.square yii-canadian.square yo-canadian.square yoo-canadian.square ya-canadian.square yaa-canadian.square re-canadian.square reRCree-canadian.square leWestCree-canadian.square ri-canadian.square rii-canadian.square ro-canadian.square loWestCree-canadian.square ra-canadian.square raa-canadian.square laWestCree-canadian.square reWestCree-canadian.square riWestCree-canadian.square roWestCree-canadian.square raWestCree-canadian.square theThCree-canadian.square thiThCree-canadian.square thiiThCree-canadian.square thoThCree-canadian.square thooThCree-canadian.square thaThCree-canadian.square thaaThCree-canadian.square thweeWoodScree-canadian.square thwiWoodScree-canadian.square thwiiWoodScree-canadian.square thwoWoodScree-canadian.square thwooWoodScree-canadian.square thwaWoodScree-canadian.square thwaaWoodScree-canadian.square nwiOjibway-canadian.square nwiiOjibway-canadian.square nwoOjibway-canadian.square nwooOjibway-canadian.square looWestCree-canadian.square laaWestCree-canadian.square ";
+name = Dene_square;
+},
+{
+code = "ke-canadian ki-canadian kii-canadian ko-canadian koo-canadian ka-canadian kaa-canadian kweWestCree-canadian kwiiWestCree-canadian kwoWestCree-canadian kwooWestCree-canadian kwaWestCree-canadian kwaaWestCree-canadian ce-canadian ci-canadian cii-canadian co-canadian coo-canadian ca-canadian caa-canadian me-canadian mi-canadian mii-canadian mo-canadian moo-canadian ma-canadian maa-canadian ne-canadian ni-canadian nii-canadian no-canadian noo-canadian na-canadian naa-canadian nweWestCree-canadian nwaWestCree-canadian nwaaWestCree-canadian se-canadian si-canadian sii-canadian so-canadian soo-canadian sa-canadian saa-canadian sho-canadian shoo-canadian sha-canadian shaa-canadian ye-canadian yi-canadian yii-canadian yo-canadian yoo-canadian ya-canadian yaa-canadian re-canadian reRCree-canadian leWestCree-canadian ri-canadian rii-canadian ro-canadian loWestCree-canadian ra-canadian raa-canadian laWestCree-canadian reWestCree-canadian riWestCree-canadian roWestCree-canadian raWestCree-canadian theThCree-canadian thiThCree-canadian thiiThCree-canadian thoThCree-canadian thooThCree-canadian thaThCree-canadian thaaThCree-canadian thweeWoodScree-canadian thwiWoodScree-canadian thwiiWoodScree-canadian thwoWoodScree-canadian thwooWoodScree-canadian thwaWoodScree-canadian thwaaWoodScree-canadian nwiOjibway-canadian nwiiOjibway-canadian nwoOjibway-canadian nwooOjibway-canadian looWestCree-canadian laaWestCree-canadian 
+";
+name = Dene_round;
+},
+{
+code = "acuteFinal-canadian.mid graveFinal-canadian.mid ringTophalfFinal-canadian.mid ringRighthalfFinal-canadian.mid ringFinal-canadian.mid doubleacuteFinal-canadian.mid doubleshortverticalstrokesFinal-canadian.mid shorthorizontalstrokeFinal-canadian.mid downtackFinal-canadian.mid pWestCree-canadian.mid c-canadian.mid mWestCree-canadian.mid ";
+name = Final_mid;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian ringFinal-canadian doubleacuteFinal-canadian doubleshortverticalstrokesFinal-canadian shorthorizontalstrokeFinal-canadian downtackFinal-canadian pWestCree-canadian c-canadian mWestCree-canadian ";
+name = Final_mid_ori;
+},
+{
+code = "acuteFinal-canadian.base graveFinal-canadian.base ringBottomhalfFinal-canadian.base ringTophalfFinal-canadian.base ringRighthalfFinal-canadian.base plusFinal-canadian.base pWestCree-canadian.base c-canadian.base thSayisi-canadian.base mWestCree-canadian.base ";
+name = Final_base;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringBottomhalfFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian plusFinal-canadian pWestCree-canadian c-canadian thSayisi-canadian mWestCree-canadian ";
+name = Final_base_ori;
+},
+{
+code = "ng-canadian ngai-canadian ngaai-canadian ngi-canadian ngii-canadian ngo-canadian ngoo-canadian nga-canadian ngaa-canadian ";
+name = Nunavik;
+},
+{
+code = "ng-canadian.nunavik ngai-canadian.nunavik ngaai-canadian.nunavik ngi-canadian.nunavik ngii-canadian.nunavik ngo-canadian.nunavik ngoo-canadian.nunavik nga-canadian.nunavik ngaa-canadian.nunavik ";
+name = Nunavik_alt;
+}
+);
+customParameters = (
+{
+name = vendorID;
+value = GOOG;
+},
+{
+name = panose;
+value = (
+2,
+11,
+5,
+2,
+4,
+5,
+4,
+2,
+2,
+4
+);
+},
+{
+name = unicodeRanges;
+value = (
+0,
+1,
+2,
+5,
+6,
+45,
+77
+);
+},
+{
+name = codePageRanges;
+value = (
+"1252"
+);
+},
+{
+name = fsType;
+value = (
+);
+}
+);
+date = "2022-06-21 10:06:40 +0000";
+familyName = "Sans Canadian Aboriginal";
+featurePrefixes = (
+{
+automatic = 1;
+code = "languagesystem DFLT dflt;
+
+languagesystem cans dflt;
+";
+name = Languagesystems;
+}
+);
+features = (
+{
+automatic = 1;
+code = "feature ss01;
+feature ss02;
+feature ss03;
+feature ss04;
+";
+tag = aalt;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+tag = salt;
+},
+{
+code = "lookup space_can {
+sub space by space.canadian;
+} space_can;
+
+lookup num_can {
+sub @Num by @Num_can;
+} num_can;
+";
+labels = (
+{
+language = dflt;
+value = "CAN Space and numerals";
+}
+);
+tag = ss01;
+},
+{
+code = "lookup dene_square {
+sub @Dene_round by @Dene_square;
+} dene_square;
+
+";
+labels = (
+{
+language = dflt;
+value = "Dene Square";
+}
+);
+tag = ss02;
+},
+{
+code = "lookup nunavik_alt {
+sub @Nunavik by @Nunavik_alt;
+} nunavik_alt;
+
+";
+labels = (
+{
+language = dflt;
+value = "Nunanvik Alt";
+}
+);
+tag = ss03;
+},
+{
+code = "lookup final_mid {
+sub @Final_mid_ori by @Final_mid;
+} final_mid;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final mid";
+}
+);
+tag = ss04;
+},
+{
+code = "lookup final_base {
+sub @Final_base_ori by @Final_base;
+} final_base;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final base";
+}
+);
+tag = ss05;
+},
+{
+code = "lookup plaincree_first {
+sub wiWestCree-canadian' plusFinal-canadian by i-canadian;
+} plaincree_first;
+
+lookup plaincree_second {
+sub i-canadian plusFinal-canadian' by raiseddoubledotFinal-canadian.cree;
+} plaincree_second;
+
+lookup plaincree_third {
+sub middledotFinal-canadian plusFinal-canadian by raiseddoubledotFinal-canadian.cree;
+} plaincree_third;
+";
+labels = (
+{
+language = dflt;
+value = Plaincree;
+}
+);
+tag = ss06;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+labels = (
+{
+language = dflt;
+value = "";
+}
+);
+tag = ss07;
+}
+);
+fontMaster = (
+{
+axesValues = (
+0,
+0,
+0
+);
+customParameters = (
+{
+name = typoAscender;
+value = 1033;
+},
+{
+name = typoDescender;
+value = -283;
+},
+{
+name = typoLineGap;
+value = 0;
+},
+{
+name = winAscent;
+value = 1033;
+},
+{
+name = winDescent;
+value = 283;
+},
+{
+name = hheaAscender;
+value = 1033;
+},
+{
+name = hheaDescender;
+value = -283;
+},
+{
+name = strikeoutPosition;
+value = 284;
+},
+{
+name = strikeoutSize;
+value = 48;
+},
+{
+name = "Master Icon Glyph Name";
+value = s;
+}
+);
+guides = (
+{
+lockAngle = 1;
+locked = 1;
+pos = (222,345);
+},
+{
+locked = 1;
+pos = (-52,-12);
+},
+{
+locked = 1;
+pos = (99,701);
+}
+);
+id = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+metricValues = (
+{
+over = 16;
+pos = 1033;
+},
+{
+over = 16;
+pos = 690;
+},
+{
+over = 16;
+pos = 472;
+},
+{
+over = -16;
+},
+{
+over = -16;
+pos = -283;
+},
+{
+pos = 12;
+}
+);
+name = "RC CL Italic";
+stemValues = (
+61
+);
+}
+);
+glyphs = (
+{
+glyphname = idotless;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(67,0,l),
+(176,516,l),
+(115,516,l),
+(5,0,l)
+);
+}
+);
+width = 172;
+}
+);
+note = dotlessi;
+unicode = 305;
+},
+{
+glyphname = "acuteFinal-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(104,345,l),
+(294,690,l),
+(241,690,l),
+(52,345,l)
+);
+}
+);
+width = 226;
+}
+);
+metricRight = "=|";
+note = uni141F;
+unicode = 5151;
+},
+{
+glyphname = "graveFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(220,345,l),
+(173,690,l),
+(126,690,l),
+(172,345,l)
+);
+}
+);
+width = 226;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+unicode = 5152;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(262,339,o),
+(298,379,o),
+(313,449,cs),
+(364,690,l),
+(321,690,l),
+(270,454,ls),
+(259,399,o),
+(237,380,o),
+(195,380,cs),
+(146,380,o),
+(131,412,o),
+(142,458,cs),
+(190,690,l),
+(147,690,l),
+(99,461,ls),
+(83,386,o),
+(119,339,o),
+(192,339,cs)
+);
+}
+);
+width = 318;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1421;
+unicode = 5153;
+},
+{
+glyphname = "ringTophalfFinal-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(117,345,l),
+(167,581,ls),
+(179,636,o),
+(201,655,o),
+(243,655,cs),
+(292,655,o),
+(306,623,o),
+(297,577,cs),
+(247,345,l),
+(291,345,l),
+(339,574,ls),
+(355,648,o),
+(319,696,o),
+(245,696,cs),
+(176,696,o),
+(140,656,o),
+(125,585,cs),
+(73,345,l)
+);
+}
+);
+width = 318;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+unicode = 5154;
+},
+{
+glyphname = "ringRighthalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(105,345,ls),
+(250,345,o),
+(291,473,o),
+(291,562,cs),
+(291,645,o),
+(243,690,o),
+(165,690,cs),
+(143,690,l),
+(134,647,l),
+(162,647,ls),
+(216,647,o),
+(245,617,o),
+(245,559,cs),
+(245,500,o),
+(226,387,o),
+(110,387,cs),
+(79,387,l),
+(70,345,l)
+);
+}
+);
+width = 276;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+unicode = 5155;
+},
+{
+glyphname = "ringFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(355,397,o),
+(415,461,o),
+(415,547,cs),
+(415,631,o),
+(355,696,o),
+(266,696,cs),
+(177,696,o),
+(115,632,o),
+(115,547,cs),
+(115,461,o),
+(177,397,o),
+(266,397,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,436,o),
+(156,480,o),
+(156,547,cs),
+(156,612,o),
+(200,657,o),
+(266,657,cs),
+(330,657,o),
+(375,611,o),
+(375,547,cs),
+(375,480,o),
+(330,436,o),
+(266,436,cs)
+);
+}
+);
+width = 399;
+}
+);
+note = uni1424;
+unicode = 5156;
+},
+{
+glyphname = "doubleacuteFinal-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(103,345,l),
+(293,690,l),
+(242,690,l),
+(52,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(210,345,l),
+(400,690,l),
+(349,690,l),
+(158,345,l)
+);
+}
+);
+width = 332;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricRight = "=|";
+note = uni1425;
+unicode = 5157;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(117,345,l),
+(190,690,l),
+(147,690,l),
+(73,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(213,345,l),
+(286,690,l),
+(242,690,l),
+(169,345,l)
+);
+}
+);
+width = 240;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "pWestCree-canadian";
+note = uni1426;
+unicode = 5158;
+},
+{
+glyphname = "middledotFinal-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(132,314,o),
+(151,332,o),
+(151,355,cs),
+(151,377,o),
+(132,395,o),
+(110,395,cs),
+(88,395,o),
+(70,377,o),
+(70,355,cs),
+(70,332,o),
+(88,314,o),
+(110,314,cs)
+);
+}
+);
+width = 170;
+}
+);
+note = uni1427;
+unicode = 5159;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(349,504,l),
+(358,549,l),
+(118,549,l),
+(108,504,l)
+);
+}
+);
+width = 343;
+}
+);
+metricRight = "=|";
+note = uni1428;
+unicode = 5160;
+},
+{
+glyphname = "plusFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(229,407,l),
+(254,528,l),
+(354,528,l),
+(364,571,l),
+(264,571,l),
+(289,690,l),
+(247,690,l),
+(222,571,l),
+(122,571,l),
+(113,528,l),
+(213,528,l),
+(187,407,l)
+);
+}
+);
+width = 344;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+unicode = 5161;
+},
+{
+glyphname = "downtackFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(218,345,l),
+(283,647,l),
+(381,647,l),
+(390,690,l),
+(148,690,l),
+(139,647,l),
+(239,647,l),
+(175,345,l)
+);
+}
+);
+width = 345;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni142A;
+unicode = 5162;
+},
+{
+glyphname = "thFinalWoodScree-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(216,345,l),
+(235,430,l),
+(333,430,l),
+(342,469,l),
+(243,469,l),
+(264,565,l),
+(362,565,l),
+(371,605,l),
+(272,605,l),
+(290,690,l),
+(246,690,l),
+(229,605,l),
+(129,605,l),
+(121,565,l),
+(220,565,l),
+(200,469,l),
+(100,469,l),
+(92,430,l),
+(191,430,l),
+(173,345,l)
+);
+}
+);
+width = 343;
+}
+);
+metricLeft = "hyphen-canadian";
+metricRight = "hyphen-canadian";
+note = uni167E;
+unicode = 5758;
+},
+{
+glyphname = "ringSmallFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(262,535,o),
+(298,571,o),
+(298,619,cs),
+(298,667,o),
+(262,702,o),
+(215,702,cs),
+(168,702,o),
+(131,667,o),
+(131,619,cs),
+(131,571,o),
+(168,535,o),
+(215,535,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(185,566,o),
+(164,588,o),
+(164,619,cs),
+(164,649,o),
+(185,671,o),
+(215,671,cs),
+(245,671,o),
+(267,649,o),
+(267,619,cs),
+(267,588,o),
+(245,566,o),
+(215,566,cs)
+);
+}
+);
+width = 268;
+}
+);
+note = g725;
+unicode = 6366;
+},
+{
+glyphname = "raiseddotFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(202,621,o),
+(220,639,o),
+(220,662,cs),
+(220,684,o),
+(202,702,o),
+(180,702,cs),
+(156,702,o),
+(139,684,o),
+(139,662,cs),
+(139,639,o),
+(156,621,o),
+(180,621,cs)
+);
+}
+);
+width = 178;
+}
+);
+note = g725;
+unicode = 6367;
+},
+{
+glyphname = "acuteFinal-canadian.base";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-73,-345);
+ref = "acuteFinal-canadian";
+}
+);
+width = 226;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.base";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-74,-345);
+ref = "graveFinal-canadian";
+}
+);
+width = 225;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian.base";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-74,-345);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 318;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1421;
+},
+{
+glyphname = "ringTophalfFinal-canadian.base";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-73,-345);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 318;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.base";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-74,-345);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 276;
+}
+);
+metricLeft = "==|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "plusFinal-canadian.base";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(143,0,l),
+(168,122,l),
+(269,122,l),
+(278,164,l),
+(178,164,l),
+(203,283,l),
+(162,283,l),
+(137,164,l),
+(36,164,l),
+(27,122,l),
+(128,122,l),
+(102,0,l)
+);
+}
+);
+width = 344;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+},
+{
+glyphname = "acuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-34,-162);
+ref = "acuteFinal-canadian";
+}
+);
+width = 226;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.mid";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-162);
+ref = "graveFinal-canadian";
+}
+);
+width = 226;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringTophalfFinal-canadian.mid";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-172);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 318;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.mid";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-162);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 276;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "ringFinal-canadian.mid";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-43,-203);
+ref = "ringFinal-canadian";
+}
+);
+width = 399;
+}
+);
+metricLeft = "ringFinal-canadian";
+metricWidth = "ringFinal-canadian";
+note = uni1424;
+},
+{
+glyphname = "doubleacuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-34,-162);
+ref = "doubleacuteFinal-canadian";
+}
+);
+width = 332;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "doubleacuteFinal-canadian";
+note = uni1425;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian.mid";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-34,-162);
+ref = "doubleshortverticalstrokesFinal-canadian";
+}
+);
+width = 240;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricWidth = "doubleshortverticalstrokesFinal-canadian";
+note = uni1426;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian.mid";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-37,-172);
+ref = "shorthorizontalstrokeFinal-canadian";
+}
+);
+width = 343;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "shorthorizontalstrokeFinal-canadian";
+note = uni1428;
+},
+{
+glyphname = "downtackFinal-canadian.mid";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-162);
+ref = "downtackFinal-canadian";
+}
+);
+width = 345;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "downtackFinal-canadian";
+note = uni142A;
+},
+{
+glyphname = "e-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (311,454);
+},
+{
+name = top_center_can;
+pos = (363,690);
+},
+{
+name = top_left_can;
+pos = (194,690);
+},
+{
+name = top_right_can;
+pos = (534,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(231,0,l),
+(603,670,l),
+(608,690,l),
+(124,690,l),
+(120,670,l),
+(207,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(248,66,l),
+(179,654,l),
+(163,639,l),
+(542,639,l),
+(531,654,l),
+(213,66,l)
+);
+}
+);
+width = 538;
+}
+);
+metricRight = "=|";
+note = uni1401;
+unicode = 5121;
+},
+{
+glyphname = "aai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (156,0);
+ref = ring_top.canadian;
+}
+);
+width = 538;
+}
+);
+note = uni1402;
+unicode = 5122;
+},
+{
+glyphname = "i-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (305,403);
+},
+{
+name = top_center_can;
+pos = (365,690);
+},
+{
+name = top_left_can;
+pos = (193,690);
+},
+{
+name = top_right_can;
+pos = (533,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(353,690,l),
+(-19,19,l),
+(-23,0,l),
+(460,0,l),
+(465,19,l),
+(377,690,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(335,624,l),
+(406,36,l),
+(420,51,l),
+(43,51,l),
+(52,36,l),
+(370,624,l)
+);
+}
+);
+width = 538;
+}
+);
+metricLeft = "e-canadian";
+metricWidth = "e-canadian";
+note = uni1403;
+unicode = 5123;
+},
+{
+glyphname = "ii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (211,0);
+ref = dot_top;
+}
+);
+width = 538;
+}
+);
+note = uni1404;
+unicode = 5124;
+},
+{
+glyphname = "o-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (241,352);
+},
+{
+name = top_center_can;
+pos = (370,690);
+},
+{
+name = top_double;
+pos = (446,690);
+},
+{
+name = top_left_can;
+pos = (184,690);
+},
+{
+name = top_right_can;
+pos = (554,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(30,0,l),
+(510,332,l),
+(516,357,l),
+(177,690,l),
+(159,690,l),
+(13,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(195,618,l),
+(172,628,l),
+(464,340,l),
+(464,359,l),
+(58,76,l),
+(78,71,l)
+);
+}
+);
+width = 521;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1405;
+unicode = 5125;
+},
+{
+glyphname = "oo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (28,0);
+ref = dot_top;
+}
+);
+width = 521;
+}
+);
+note = uni1406;
+unicode = 5126;
+},
+{
+glyphname = "yCreeoo-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (160,0);
+ref = doubledot_top;
+}
+);
+width = 521;
+}
+);
+note = uni1407;
+unicode = 5127;
+},
+{
+glyphname = "eeCarrier-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(30,0,l),
+(510,332,l),
+(516,357,l),
+(177,690,l),
+(159,690,l),
+(13,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(191,618,l),
+(181,623,l),
+(467,340,l),
+(471,362,l),
+(67,79,l),
+(74,71,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(231,256,l),
+(270,440,l),
+(242,440,l),
+(202,256,l)
+);
+}
+);
+width = 521;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "o-canadian";
+note = uni1408;
+unicode = 5128;
+},
+{
+glyphname = "iCarrier-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (169,7);
+ref = dot_middle_optic_small;
+}
+);
+width = 521;
+}
+);
+note = uni1409;
+unicode = 5129;
+},
+{
+glyphname = "a-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (326,345);
+},
+{
+name = top_center_can;
+pos = (330,690);
+},
+{
+name = top_left_can;
+pos = (156,690);
+},
+{
+name = top_right_can;
+pos = (527,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(537,690,l),
+(56,357,l),
+(51,332,l),
+(390,0,l),
+(408,0,l),
+(554,690,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(372,71,l),
+(395,62,l),
+(103,350,l),
+(103,330,l),
+(509,613,l),
+(489,619,l)
+);
+}
+);
+width = 520;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni140A;
+unicode = 5130;
+},
+{
+glyphname = "aa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (372,0);
+ref = dot_top;
+}
+);
+width = 521;
+}
+);
+note = uni140B;
+unicode = 5131;
+},
+{
+glyphname = "we-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "e-canadian";
+}
+);
+width = 708;
+}
+);
+note = uni140C;
+unicode = 5132;
+},
+{
+glyphname = "weWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (538,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 708;
+}
+);
+note = uni140D;
+unicode = 5133;
+},
+{
+glyphname = "wi-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "i-canadian";
+}
+);
+width = 708;
+}
+);
+note = uni140E;
+unicode = 5134;
+},
+{
+glyphname = "wiWestCree-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (538,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 708;
+}
+);
+note = uni140F;
+unicode = 5135;
+},
+{
+glyphname = "wii-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (381,0);
+ref = dot_top;
+}
+);
+width = 708;
+}
+);
+note = uni1410;
+unicode = 5136;
+},
+{
+glyphname = "wiiWestCree-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (211,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (538,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 708;
+}
+);
+note = uni1411;
+unicode = 5137;
+},
+{
+glyphname = "wo-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "o-canadian";
+}
+);
+width = 690;
+}
+);
+note = uni1412;
+unicode = 5138;
+},
+{
+glyphname = "woWestCree-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (521,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 690;
+}
+);
+note = uni1413;
+unicode = 5139;
+},
+{
+glyphname = "woo-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (384,0);
+ref = dot_top;
+}
+);
+width = 690;
+}
+);
+note = uni1414;
+unicode = 5140;
+},
+{
+glyphname = "wooWestCree-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (28,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (521,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 690;
+}
+);
+note = uni1415;
+unicode = 5141;
+},
+{
+glyphname = "wooNaskapi-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (139,-95);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (250,-202);
+ref = dot_top;
+}
+);
+width = 521;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricWidth = "o-canadian";
+note = uni1416;
+unicode = 5142;
+},
+{
+glyphname = "wa-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "a-canadian";
+}
+);
+width = 690;
+}
+);
+note = uni1417;
+unicode = 5143;
+},
+{
+glyphname = "waWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (521,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 690;
+}
+);
+note = uni1418;
+unicode = 5144;
+},
+{
+glyphname = "waa-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (542,0);
+ref = dot_top;
+}
+);
+width = 690;
+}
+);
+note = uni1419;
+unicode = 5145;
+},
+{
+glyphname = "waaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (372,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (521,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 690;
+}
+);
+note = uni141A;
+unicode = 5146;
+},
+{
+glyphname = "waaNaskapi-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (85,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (240,-95);
+ref = dot_top;
+}
+);
+width = 520;
+}
+);
+metricWidth = "a-canadian";
+note = uni141B;
+unicode = 5147;
+},
+{
+glyphname = "ai-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(230,339,o),
+(270,371,o),
+(285,423,c),
+(271,423,l),
+(271,369,o),
+(301,339,o),
+(355,339,cs),
+(419,339,o),
+(457,378,o),
+(474,463,cs),
+(523,690,l),
+(481,690,l),
+(433,463,ls),
+(420,406,o),
+(398,380,o),
+(356,380,cs),
+(311,380,o),
+(295,407,o),
+(306,462,cs),
+(355,690,l),
+(314,690,l),
+(267,467,ls),
+(254,408,o),
+(228,380,o),
+(187,380,cs),
+(147,380,o),
+(128,409,o),
+(139,458,cs),
+(188,690,l),
+(147,690,l),
+(98,454,ls),
+(83,388,o),
+(115,339,o),
+(181,339,cs)
+);
+}
+);
+width = 476;
+}
+);
+metricRight = "=|";
+note = uni141C;
+unicode = 5148;
+},
+{
+glyphname = "ycreew-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(342,510,o),
+(368,545,o),
+(368,603,cs),
+(368,662,o),
+(342,696,o),
+(302,696,cs),
+(264,696,o),
+(238,662,o),
+(238,603,cs),
+(238,545,o),
+(264,510,o),
+(303,510,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,339,o),
+(226,374,o),
+(226,432,cs),
+(226,491,o),
+(200,525,o),
+(161,525,cs),
+(122,525,o),
+(96,491,o),
+(96,432,cs),
+(96,374,o),
+(122,339,o),
+(161,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(137,366,o),
+(125,387,o),
+(125,432,cs),
+(125,476,o),
+(137,497,o),
+(161,497,cs),
+(185,497,o),
+(198,476,o),
+(198,432,cs),
+(198,387,o),
+(185,366,o),
+(161,366,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(279,537,o),
+(267,558,o),
+(267,603,cs),
+(267,647,o),
+(279,668,o),
+(303,668,cs),
+(327,668,o),
+(340,647,o),
+(340,603,cs),
+(340,558,o),
+(327,537,o),
+(303,537,cs)
+);
+}
+);
+width = 344;
+}
+);
+metricRight = "=|";
+note = uni141D;
+unicode = 5149;
+},
+{
+glyphname = "glottalstop-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(312,345,l),
+(315,356,l),
+(271,690,l),
+(258,690,l),
+(72,356,l),
+(71,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(268,640,l),
+(244,644,l),
+(277,363,l),
+(289,381,l),
+(110,381,l),
+(117,363,l)
+);
+}
+);
+width = 335;
+}
+);
+metricRight = "=|";
+note = uni141E;
+unicode = 5150;
+},
+{
+glyphname = "en-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+pos = (538,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 764;
+}
+);
+note = uni142B;
+unicode = 5163;
+},
+{
+glyphname = "in-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+pos = (372,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 598;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142C;
+unicode = 5164;
+},
+{
+glyphname = "on-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (408,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 634;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142D;
+unicode = 5165;
+},
+{
+glyphname = "an-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (495,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 721;
+}
+);
+metricRight = "graveFinal-canadian";
+note = uni142E;
+unicode = 5166;
+},
+{
+glyphname = "pe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (312,454);
+},
+{
+name = top_center_can;
+pos = (366,690);
+},
+{
+name = top_left_can;
+pos = (194,690);
+},
+{
+name = top_right_can;
+pos = (534,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(231,0,l),
+(603,670,l),
+(608,690,l),
+(548,690,l),
+(211,72,l),
+(252,72,l),
+(176,690,l),
+(124,690,l),
+(120,670,l),
+(207,0,l)
+);
+}
+);
+width = 538;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni142F;
+unicode = 5167;
+},
+{
+glyphname = "paai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (156,0);
+ref = ring_top.canadian;
+}
+);
+width = 538;
+}
+);
+note = uni1430;
+unicode = 5168;
+},
+{
+glyphname = "pi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (307,403);
+},
+{
+name = top_center_can;
+pos = (365,690);
+},
+{
+name = top_left_can;
+pos = (193,690);
+},
+{
+name = top_right_can;
+pos = (533,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(353,690,l),
+(-19,19,l),
+(-23,0,l),
+(36,0,l),
+(374,617,l),
+(331,617,l),
+(408,0,l),
+(460,0,l),
+(464,19,l),
+(377,690,l)
+);
+}
+);
+width = 537;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni1431;
+unicode = 5169;
+},
+{
+glyphname = "pii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (211,0);
+ref = dot_top;
+}
+);
+width = 538;
+}
+);
+note = uni1432;
+unicode = 5170;
+},
+{
+glyphname = "po-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (189,353);
+},
+{
+name = top_center_can;
+pos = (348,690);
+},
+{
+name = top_double;
+pos = (431,690);
+},
+{
+name = top_left_can;
+pos = (165,690);
+},
+{
+name = top_right_can;
+pos = (527,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+name = "Thin Slanted";
+shapes = (
+{
+closed = 1;
+nodes = (
+(9,0,l),
+(484,332,l),
+(490,357,l),
+(156,690,l),
+(138,690,l),
+(128,639,l),
+(432,336,l),
+(438,367,l),
+(5,64,l),
+(-9,0,l)
+);
+}
+);
+width = 495;
+}
+);
+metricRight = "o-canadian";
+note = uni1433;
+unicode = 5171;
+},
+{
+glyphname = "poo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (10,0);
+ref = dot_top;
+}
+);
+width = 495;
+}
+);
+note = uni1434;
+unicode = 5172;
+},
+{
+glyphname = "ycreepoo-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (145,0);
+ref = doubledot_top;
+}
+);
+width = 495;
+}
+);
+note = uni1435;
+unicode = 5173;
+},
+{
+glyphname = "heeCarrier-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (131,8);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 495;
+}
+);
+note = uni1436;
+unicode = 5174;
+},
+{
+glyphname = "hiCarrier-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (113,9);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 495;
+}
+);
+note = uni1437;
+unicode = 5175;
+},
+{
+glyphname = "pa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (264,345);
+},
+{
+name = top_center_can;
+pos = (342,690);
+},
+{
+name = top_left_can;
+pos = (157,690);
+},
+{
+name = top_right_can;
+pos = (523,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(531,690,l),
+(57,357,l),
+(51,332,l),
+(384,0,l),
+(402,0,l),
+(412,50,l),
+(109,354,l),
+(103,323,l),
+(535,626,l),
+(549,690,l)
+);
+}
+);
+width = 493;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1438;
+unicode = 5176;
+},
+{
+glyphname = "paa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (367,0);
+ref = dot_top;
+}
+);
+width = 495;
+}
+);
+note = uni1439;
+unicode = 5177;
+},
+{
+glyphname = "pwe-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "pe-canadian";
+}
+);
+width = 708;
+}
+);
+note = uni143A;
+unicode = 5178;
+},
+{
+glyphname = "pweWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "pe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (538,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 708;
+}
+);
+note = uni143B;
+unicode = 5179;
+},
+{
+glyphname = "pwi-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "pi-canadian";
+}
+);
+width = 708;
+}
+);
+note = uni143C;
+unicode = 5180;
+},
+{
+glyphname = "pwiWestCree-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (538,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 708;
+}
+);
+note = uni143D;
+unicode = 5181;
+},
+{
+glyphname = "pwii-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (381,0);
+ref = dot_top;
+}
+);
+width = 708;
+}
+);
+note = uni143E;
+unicode = 5182;
+},
+{
+glyphname = "pwiiWestCree-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (211,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (538,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 708;
+}
+);
+note = uni143F;
+unicode = 5183;
+},
+{
+glyphname = "pwo-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "po-canadian";
+}
+);
+width = 664;
+}
+);
+note = uni1440;
+unicode = 5184;
+},
+{
+glyphname = "pwoWestCree-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (495,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 664;
+}
+);
+note = uni1441;
+unicode = 5185;
+},
+{
+glyphname = "pwoo-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (361,0);
+ref = dot_top;
+}
+);
+width = 664;
+}
+);
+note = uni1442;
+unicode = 5186;
+},
+{
+glyphname = "pwooWestCree-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (10,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (495,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 664;
+}
+);
+note = uni1443;
+unicode = 5187;
+},
+{
+glyphname = "pwa-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "pa-canadian";
+}
+);
+width = 664;
+}
+);
+note = uni1444;
+unicode = 5188;
+},
+{
+glyphname = "pwaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (495,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 664;
+}
+);
+note = uni1445;
+unicode = 5189;
+},
+{
+glyphname = "pwaa-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (536,0);
+ref = dot_top;
+}
+);
+width = 664;
+}
+);
+note = uni1446;
+unicode = 5190;
+},
+{
+glyphname = "pwaaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (367,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (495,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 664;
+}
+);
+note = uni1447;
+unicode = 5191;
+},
+{
+glyphname = "ycreepwaa-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+pos = (82,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (237,-95);
+ref = dot_top;
+}
+);
+width = 493;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1448;
+unicode = 5192;
+},
+{
+glyphname = "p-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(282,345,l),
+(291,383,l),
+(145,529,l),
+(139,498,l),
+(346,643,l),
+(355,690,l),
+(346,690,l),
+(112,526,l),
+(108,509,l),
+(272,345,l)
+);
+}
+);
+width = 309;
+}
+);
+note = uni1449;
+unicode = 5193;
+},
+{
+glyphname = "pWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(117,345,l),
+(190,690,l),
+(147,690,l),
+(73,345,l)
+);
+}
+);
+width = 144;
+}
+);
+metricRight = "=|";
+note = uni144A;
+unicode = 5194;
+},
+{
+color = 6;
+glyphname = "hCarrier-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(83,183,l),
+(115,334,ls),
+(123,375,o),
+(145,394,o),
+(173,394,cs),
+(207,394,o),
+(219,371,o),
+(211,331,cs),
+(179,183,l),
+(223,183,l),
+(255,334,ls),
+(268,393,o),
+(241,434,o),
+(187,434,cs),
+(151,434,o),
+(121,410,o),
+(112,372,c),
+(122,367,l),
+(156,527,l),
+(112,527,l),
+(39,183,l)
+);
+}
+);
+width = 269;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144B;
+unicode = 5195;
+},
+{
+glyphname = "te-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (296,345);
+},
+{
+name = top_center_can;
+pos = (369,690);
+},
+{
+name = top_left_can;
+pos = (187,690);
+},
+{
+name = top_right_can;
+pos = (551,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(372,-13,o),
+(448,60,o),
+(480,213,cs),
+(582,690,l),
+(521,690,l),
+(421,219,ls),
+(395,99,o),
+(342,45,o),
+(250,45,cs),
+(134,45,o),
+(94,110,o),
+(122,242,cs),
+(217,690,l),
+(156,690,l),
+(61,244,ls),
+(27,82,o),
+(96,-13,o),
+(247,-13,cs)
+);
+}
+);
+width = 544;
+}
+);
+metricRight = "=|";
+note = uni144C;
+unicode = 5196;
+},
+{
+glyphname = "taai-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (157,0);
+ref = ring_top.canadian;
+}
+);
+width = 545;
+}
+);
+note = uni144D;
+unicode = 5197;
+},
+{
+glyphname = "ti-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (295,345);
+},
+{
+name = middle_right_can;
+pos = (598,345);
+},
+{
+name = top_center_can;
+pos = (368,690);
+},
+{
+name = top_left_can;
+pos = (187,690);
+},
+{
+name = top_right_can;
+pos = (551,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(71,0,l),
+(170,470,ls),
+(196,591,o),
+(250,644,o),
+(341,644,cs),
+(457,644,o),
+(497,580,o),
+(469,448,cs),
+(374,0,l),
+(435,0,l),
+(529,445,ls),
+(564,608,o),
+(496,702,o),
+(344,702,cs),
+(219,702,o),
+(143,630,o),
+(110,477,cs),
+(9,0,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni144E;
+unicode = 5198;
+},
+{
+glyphname = "tii-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (213,0);
+ref = dot_top;
+}
+);
+width = 545;
+}
+);
+note = uni144F;
+unicode = 5199;
+},
+{
+glyphname = "to-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (215,345);
+},
+{
+name = middle_right_can;
+pos = (516,345);
+},
+{
+name = top_center_can;
+pos = (299,690);
+},
+{
+name = top_double;
+pos = (344,690);
+},
+{
+name = top_left_can;
+pos = (165,690);
+},
+{
+name = top_right_can;
+pos = (472,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(88,0,ls),
+(368,0,o),
+(439,295,o),
+(439,458,cs),
+(439,611,o),
+(358,690,o),
+(208,690,cs),
+(138,690,l),
+(127,633,l),
+(196,633,ls),
+(318,633,o),
+(377,577,o),
+(377,457,cs),
+(377,325,o),
+(321,57,o),
+(91,57,cs),
+(4,57,l),
+(-9,0,l)
+);
+}
+);
+width = 453;
+}
+);
+note = uni1450;
+unicode = 5200;
+},
+{
+glyphname = "too-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (144,0);
+ref = dot_top;
+}
+);
+width = 453;
+}
+);
+note = uni1451;
+unicode = 5201;
+},
+{
+glyphname = "ycreetoo-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (59,0);
+ref = doubledot_top;
+}
+);
+width = 453;
+}
+);
+note = uni1452;
+unicode = 5202;
+},
+{
+glyphname = "deeCarrier-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (155,0);
+ref = stroke_middle;
+}
+);
+width = 453;
+}
+);
+note = uni1453;
+unicode = 5203;
+},
+{
+glyphname = "diCarrier-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (134,0);
+ref = dot_middle;
+}
+);
+width = 453;
+}
+);
+note = uni1454;
+unicode = 5204;
+},
+{
+glyphname = "ta-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (282,345);
+},
+{
+name = top_center_can;
+pos = (346,690);
+},
+{
+name = top_left_can;
+pos = (171,690);
+},
+{
+name = top_right_can;
+pos = (481,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(361,0,l),
+(373,57,l),
+(300,57,ls),
+(179,57,o),
+(123,113,o),
+(123,233,cs),
+(123,369,o),
+(179,633,o),
+(406,633,cs),
+(496,633,l),
+(508,690,l),
+(409,690,ls),
+(132,690,o),
+(61,399,o),
+(61,231,cs),
+(61,78,o),
+(138,0,o),
+(289,0,cs)
+);
+}
+);
+width = 453;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|to-canadian";
+note = uni1455;
+unicode = 5205;
+},
+{
+glyphname = "taa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (190,0);
+ref = dot_top;
+}
+);
+width = 453;
+}
+);
+note = uni1456;
+unicode = 5206;
+},
+{
+glyphname = "twe-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "te-canadian";
+}
+);
+width = 714;
+}
+);
+note = uni1457;
+unicode = 5207;
+},
+{
+glyphname = "tweWestCree-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (545,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 714;
+}
+);
+note = uni1458;
+unicode = 5208;
+},
+{
+glyphname = "twi-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ti-canadian";
+}
+);
+width = 714;
+}
+);
+note = uni1459;
+unicode = 5209;
+},
+{
+glyphname = "twiWestCree-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (545,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 714;
+}
+);
+note = uni145A;
+unicode = 5210;
+},
+{
+glyphname = "twii-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (383,0);
+ref = dot_top;
+}
+);
+width = 714;
+}
+);
+note = uni145B;
+unicode = 5211;
+},
+{
+glyphname = "twiiWestCree-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (213,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (545,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 714;
+}
+);
+note = uni145C;
+unicode = 5212;
+},
+{
+glyphname = "two-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "to-canadian";
+}
+);
+width = 622;
+}
+);
+note = uni145D;
+unicode = 5213;
+},
+{
+glyphname = "twoWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (453,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 622;
+}
+);
+note = uni145E;
+unicode = 5214;
+},
+{
+glyphname = "twoo-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (314,0);
+ref = dot_top;
+}
+);
+width = 622;
+}
+);
+note = uni145F;
+unicode = 5215;
+},
+{
+glyphname = "twooWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (144,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (453,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 622;
+}
+);
+note = uni1460;
+unicode = 5216;
+},
+{
+glyphname = "twa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ta-canadian";
+}
+);
+width = 622;
+}
+);
+note = uni1461;
+unicode = 5217;
+},
+{
+glyphname = "twaWestCree-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (453,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 622;
+}
+);
+note = uni1462;
+unicode = 5218;
+},
+{
+glyphname = "twaa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (360,0);
+ref = dot_top;
+}
+);
+width = 622;
+}
+);
+note = uni1463;
+unicode = 5219;
+},
+{
+glyphname = "twaaWestCree-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (190,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (453,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 622;
+}
+);
+note = uni1464;
+unicode = 5220;
+},
+{
+glyphname = "twaaNaskapi-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ta-canadian";
+}
+);
+width = 639;
+}
+);
+note = uni1465;
+unicode = 5221;
+},
+{
+glyphname = "t-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(252,345,l),
+(262,387,l),
+(233,387,ls),
+(177,387,o),
+(149,417,o),
+(149,474,cs),
+(149,547,o),
+(178,647,o),
+(286,647,cs),
+(316,647,l),
+(326,690,l),
+(293,690,ls),
+(151,690,o),
+(105,570,o),
+(105,472,cs),
+(105,389,o),
+(150,345,o),
+(230,345,cs)
+);
+}
+);
+width = 276;
+}
+);
+note = uni1466;
+unicode = 5222;
+},
+{
+glyphname = "tte-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+pos = (545,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 689;
+}
+);
+note = uni1467;
+unicode = 5223;
+},
+{
+glyphname = "tti-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+pos = (545,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 689;
+}
+);
+note = uni1468;
+unicode = 5224;
+},
+{
+glyphname = "tto-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+pos = (453,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 598;
+}
+);
+note = uni1469;
+unicode = 5225;
+},
+{
+glyphname = "tta-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+pos = (453,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 598;
+}
+);
+note = uni146A;
+unicode = 5226;
+},
+{
+glyphname = "ke-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (281,441);
+},
+{
+name = top_center_can;
+pos = (318,690);
+},
+{
+name = top_left_can;
+pos = (180,690);
+},
+{
+name = top_right_can;
+pos = (458,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(341,0,l),
+(434,439,ls),
+(461,565,o),
+(445,702,o),
+(305,702,cs),
+(139,702,o),
+(92,484,o),
+(92,368,cs),
+(92,264,o),
+(136,205,o),
+(221,205,cs),
+(284,205,o),
+(329,241,o),
+(360,320,c),
+(348,320,l),
+(279,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(180,259,o),
+(151,297,o),
+(151,370,cs),
+(151,448,o),
+(185,648,o),
+(300,648,cs),
+(357,648,o),
+(386,611,o),
+(386,538,cs),
+(386,460,o),
+(353,259,o),
+(236,259,cs)
+);
+}
+);
+width = 450;
+}
+);
+metricRight = "te-canadian";
+note = uni146B;
+unicode = 5227;
+},
+{
+glyphname = "kaai-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (114,0);
+ref = ring_top.canadian;
+}
+);
+width = 450;
+}
+);
+note = uni146C;
+unicode = 5228;
+},
+{
+glyphname = "ki-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (287,441);
+},
+{
+name = top_center_can;
+pos = (325,690);
+},
+{
+name = top_left_can;
+pos = (186,690);
+},
+{
+name = top_right_can;
+pos = (464,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(71,0,l),
+(146,353,l),
+(131,323,l),
+(131,253,o),
+(173,205,o),
+(243,205,cs),
+(403,205,o),
+(450,426,o),
+(450,536,cs),
+(450,643,o),
+(403,702,o),
+(312,702,cs),
+(210,702,o),
+(142,625,o),
+(109,471,cs),
+(9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(185,259,o),
+(157,297,o),
+(157,369,cs),
+(157,448,o),
+(193,648,o),
+(307,648,cs),
+(364,648,o),
+(392,611,o),
+(392,538,cs),
+(392,456,o),
+(356,259,o),
+(242,259,cs)
+);
+}
+);
+width = 449;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni146D;
+unicode = 5229;
+},
+{
+glyphname = "kii-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (169,0);
+ref = dot_top;
+}
+);
+width = 450;
+}
+);
+note = uni146E;
+unicode = 5230;
+},
+{
+glyphname = "ko-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (270,397);
+},
+{
+name = top_center_can;
+pos = (319,690);
+},
+{
+name = top_double;
+pos = (457,690);
+},
+{
+name = top_left_can;
+pos = (181,690);
+},
+{
+name = top_right_can;
+pos = (457,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(288,-13,o),
+(355,65,o),
+(387,218,cs),
+(488,690,l),
+(426,690,l),
+(351,337,l),
+(365,367,l),
+(365,437,o),
+(324,485,o),
+(253,485,cs),
+(94,485,o),
+(45,265,o),
+(45,154,cs),
+(45,47,o),
+(94,-13,o),
+(185,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(132,42,o),
+(104,79,o),
+(104,152,cs),
+(104,231,o),
+(140,431,o),
+(254,431,cs),
+(311,431,o),
+(339,393,o),
+(339,321,cs),
+(339,236,o),
+(305,42,o),
+(189,42,cs)
+);
+}
+);
+width = 450;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni146F;
+unicode = 5231;
+},
+{
+glyphname = "koo-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (301,0);
+ref = dot_top;
+}
+);
+width = 450;
+}
+);
+note = uni1470;
+unicode = 5232;
+},
+{
+glyphname = "ycreekoo-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (172,0);
+ref = doubledot_top;
+}
+);
+width = 450;
+}
+);
+note = uni1471;
+unicode = 5233;
+},
+{
+glyphname = "ka-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (276,398);
+},
+{
+name = top_center_can;
+pos = (324,690);
+},
+{
+name = top_left_can;
+pos = (186,690);
+},
+{
+name = top_right_can;
+pos = (463,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(357,-13,o),
+(405,206,o),
+(405,322,cs),
+(405,426,o),
+(359,485,o),
+(274,485,cs),
+(216,485,o),
+(171,449,o),
+(136,370,c),
+(149,370,l),
+(217,690,l),
+(156,690,l),
+(63,251,ls),
+(27,82,o),
+(76,-13,o),
+(190,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(139,42,o),
+(111,79,o),
+(111,152,cs),
+(111,230,o),
+(144,431,o),
+(260,431,cs),
+(317,431,o),
+(345,393,o),
+(345,320,cs),
+(345,241,o),
+(312,42,o),
+(196,42,cs)
+);
+}
+);
+width = 450;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "==|ke-canadian";
+note = uni1472;
+unicode = 5234;
+},
+{
+glyphname = "kaa-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (31,0);
+ref = dot_top;
+}
+);
+width = 450;
+}
+);
+note = uni1473;
+unicode = 5235;
+},
+{
+glyphname = "kwe-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ke-canadian";
+}
+);
+width = 619;
+}
+);
+note = uni1474;
+unicode = 5236;
+},
+{
+glyphname = "kweWestCree-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (450,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 619;
+}
+);
+note = uni1475;
+unicode = 5237;
+},
+{
+glyphname = "kwi-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ki-canadian";
+}
+);
+width = 619;
+}
+);
+note = uni1476;
+unicode = 5238;
+},
+{
+glyphname = "kwiWestCree-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (450,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 619;
+}
+);
+note = uni1477;
+unicode = 5239;
+},
+{
+glyphname = "kwii-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (339,0);
+ref = dot_top;
+}
+);
+width = 619;
+}
+);
+note = uni1478;
+unicode = 5240;
+},
+{
+glyphname = "kwiiWestCree-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (169,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (450,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 619;
+}
+);
+note = uni1479;
+unicode = 5241;
+},
+{
+glyphname = "kwo-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ko-canadian";
+}
+);
+width = 619;
+}
+);
+note = uni147A;
+unicode = 5242;
+},
+{
+glyphname = "kwoWestCree-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (450,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 619;
+}
+);
+note = uni147B;
+unicode = 5243;
+},
+{
+glyphname = "kwoo-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (470,0);
+ref = dot_top;
+}
+);
+width = 619;
+}
+);
+note = uni147C;
+unicode = 5244;
+},
+{
+glyphname = "kwooWestCree-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (301,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (450,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 619;
+}
+);
+note = uni147D;
+unicode = 5245;
+},
+{
+glyphname = "kwa-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ka-canadian";
+}
+);
+width = 619;
+}
+);
+note = uni147E;
+unicode = 5246;
+},
+{
+glyphname = "kwaWestCree-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (450,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 619;
+}
+);
+note = uni147F;
+unicode = 5247;
+},
+{
+glyphname = "kwaa-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (200,0);
+ref = dot_top;
+}
+);
+width = 619;
+}
+);
+note = uni1480;
+unicode = 5248;
+},
+{
+glyphname = "kwaaWestCree-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (31,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (450,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 619;
+}
+);
+note = uni1481;
+unicode = 5249;
+},
+{
+glyphname = "kwaaNaskapi-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ka-canadian";
+}
+);
+width = 636;
+}
+);
+note = uni1482;
+unicode = 5250;
+},
+{
+glyphname = "k-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(264,339,o),
+(292,456,o),
+(292,513,cs),
+(292,567,o),
+(267,601,o),
+(223,601,cs),
+(185,601,o),
+(155,570,o),
+(143,527,c),
+(156,527,l),
+(190,690,l),
+(147,690,l),
+(101,477,ls),
+(89,419,o),
+(95,339,o),
+(174,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(151,375,o),
+(138,394,o),
+(138,429,cs),
+(138,468,o),
+(156,565,o),
+(213,565,cs),
+(238,565,o),
+(250,546,o),
+(250,512,cs),
+(250,471,o),
+(233,375,o),
+(176,375,cs)
+);
+}
+);
+width = 278;
+}
+);
+note = uni1483;
+unicode = 5251;
+},
+{
+glyphname = "kw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(220,338,o),
+(258,380,o),
+(275,465,cs),
+(323,690,l),
+(279,690,l),
+(243,520,l),
+(258,527,l),
+(259,572,o),
+(234,600,o),
+(195,600,cs),
+(114,600,o),
+(86,485,o),
+(86,431,cs),
+(86,373,o),
+(114,338,o),
+(164,338,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(139,375,o),
+(126,394,o),
+(126,428,cs),
+(126,467,o),
+(144,564,o),
+(200,564,cs),
+(225,564,o),
+(239,544,o),
+(239,510,cs),
+(239,476,o),
+(223,375,o),
+(164,375,cs)
+);
+}
+);
+width = 276;
+}
+);
+metricLeft = "=|k-canadian";
+metricRight = "=|k-canadian";
+note = uni1484;
+unicode = 5252;
+},
+{
+glyphname = "southslaveykeh-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+pos = (450,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 594;
+}
+);
+note = uni1485;
+unicode = 5253;
+},
+{
+glyphname = "southslaveykih-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+pos = (450,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 594;
+}
+);
+note = uni1486;
+unicode = 5254;
+},
+{
+glyphname = "southslaveykoh-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+pos = (450,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 594;
+}
+);
+note = uni1487;
+unicode = 5255;
+},
+{
+glyphname = "southslaveykah-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+pos = (450,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 594;
+}
+);
+note = uni1488;
+unicode = 5256;
+},
+{
+glyphname = "ce-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (273,420);
+},
+{
+name = top_center_can;
+pos = (317,690);
+},
+{
+name = top_left_can;
+pos = (180,690);
+},
+{
+name = top_right_can;
+pos = (453,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(336,0,l),
+(438,474,ls),
+(468,619,o),
+(411,702,o),
+(300,702,cs),
+(196,702,o),
+(137,636,o),
+(105,487,cs),
+(85,391,l),
+(146,391,l),
+(168,496,ls),
+(191,602,o),
+(230,647,o),
+(294,647,cs),
+(367,647,o),
+(402,594,o),
+(379,485,cs),
+(275,0,l)
+);
+}
+);
+width = 446;
+}
+);
+metricRight = "te-canadian";
+note = uni1489;
+unicode = 5257;
+},
+{
+glyphname = "caai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (114,0);
+ref = ring_top.canadian;
+}
+);
+width = 446;
+}
+);
+note = uni148A;
+unicode = 5258;
+},
+{
+glyphname = "ci-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (281,420);
+},
+{
+name = top_center_can;
+pos = (325,690);
+},
+{
+name = top_left_can;
+pos = (187,690);
+},
+{
+name = top_right_can;
+pos = (462,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(71,0,l),
+(176,496,ls),
+(198,602,o),
+(237,647,o),
+(301,647,cs),
+(375,647,o),
+(410,594,o),
+(386,485,cs),
+(366,391,l),
+(427,391,l),
+(444,474,ls),
+(476,619,o),
+(418,702,o),
+(308,702,cs),
+(203,702,o),
+(144,636,o),
+(113,487,cs),
+(9,0,l)
+);
+}
+);
+width = 446;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+unicode = 5259;
+},
+{
+glyphname = "cii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (169,0);
+ref = dot_top;
+}
+);
+width = 446;
+}
+);
+note = uni148C;
+unicode = 5260;
+},
+{
+glyphname = "co-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (275,420);
+},
+{
+name = top_center_can;
+pos = (317,690);
+},
+{
+name = top_double;
+pos = (454,690);
+},
+{
+name = top_left_can;
+pos = (181,690);
+},
+{
+name = top_right_can;
+pos = (454,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(290,-13,o),
+(349,54,o),
+(381,203,cs),
+(484,690,l),
+(423,690,l),
+(318,194,ls),
+(295,88,o),
+(257,43,o),
+(192,43,cs),
+(118,43,o),
+(84,96,o),
+(107,205,cs),
+(128,298,l),
+(67,298,l),
+(48,215,ls),
+(17,71,o),
+(75,-13,o),
+(186,-13,cs)
+);
+}
+);
+width = 447;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+unicode = 5261;
+},
+{
+glyphname = "coo-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (298,0);
+ref = dot_top;
+}
+);
+width = 446;
+}
+);
+note = uni148E;
+unicode = 5262;
+},
+{
+glyphname = "ycreecoo-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (167,0);
+ref = doubledot_top;
+}
+);
+width = 446;
+}
+);
+note = uni148F;
+unicode = 5263;
+},
+{
+glyphname = "ca-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (282,420);
+},
+{
+name = top_center_can;
+pos = (325,690);
+},
+{
+name = top_left_can;
+pos = (187,690);
+},
+{
+name = top_right_can;
+pos = (460,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(297,-13,o),
+(355,54,o),
+(386,203,cs),
+(407,298,l),
+(346,298,l),
+(324,194,ls),
+(300,88,o),
+(263,43,o),
+(199,43,cs),
+(125,43,o),
+(91,96,o),
+(114,205,cs),
+(217,690,l),
+(156,690,l),
+(55,215,ls),
+(24,71,o),
+(82,-13,o),
+(192,-13,cs)
+);
+}
+);
+width = 446;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+unicode = 5264;
+},
+{
+glyphname = "caa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (32,0);
+ref = dot_top;
+}
+);
+width = 446;
+}
+);
+note = uni1491;
+unicode = 5265;
+},
+{
+glyphname = "cwe-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ce-canadian";
+}
+);
+width = 615;
+}
+);
+note = uni1492;
+unicode = 5266;
+},
+{
+glyphname = "cweWestCree-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (446,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 615;
+}
+);
+note = uni1493;
+unicode = 5267;
+},
+{
+glyphname = "cwi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+pos = (170,0);
+ref = "ci-canadian";
+}
+);
+width = 616;
+}
+);
+note = uni1494;
+unicode = 5268;
+},
+{
+glyphname = "cwiWestCree-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "ci-canadian";
+},
+{
+anchor = middle_right_can;
+pos = (446,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 616;
+}
+);
+note = uni1495;
+unicode = 5269;
+},
+{
+glyphname = "cwii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+pos = (170,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (339,0);
+ref = dot_top;
+}
+);
+width = 616;
+}
+);
+note = uni1496;
+unicode = 5270;
+},
+{
+glyphname = "cwiiWestCree-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (169,0);
+ref = dot_top;
+},
+{
+anchor = middle_right_can;
+pos = (446,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 616;
+}
+);
+note = uni1497;
+unicode = 5271;
+},
+{
+glyphname = "cwo-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "co-canadian";
+}
+);
+width = 615;
+}
+);
+note = uni1498;
+unicode = 5272;
+},
+{
+glyphname = "cwoWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (446,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 615;
+}
+);
+note = uni1499;
+unicode = 5273;
+},
+{
+glyphname = "cwoo-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (468,0);
+ref = dot_top;
+}
+);
+width = 615;
+}
+);
+note = uni149A;
+unicode = 5274;
+},
+{
+glyphname = "cwooWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (298,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (446,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 615;
+}
+);
+note = uni149B;
+unicode = 5275;
+},
+{
+glyphname = "cwa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ca-canadian";
+}
+);
+width = 615;
+}
+);
+note = uni149C;
+unicode = 5276;
+},
+{
+glyphname = "cwaWestCree-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (446,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 615;
+}
+);
+note = uni149D;
+unicode = 5277;
+},
+{
+glyphname = "cwaa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (201,0);
+ref = dot_top;
+}
+);
+width = 615;
+}
+);
+note = uni149E;
+unicode = 5278;
+},
+{
+glyphname = "cwaaWestCree-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (32,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (446,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 615;
+}
+);
+note = uni149F;
+unicode = 5279;
+},
+{
+glyphname = "cwaaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ca-canadian";
+}
+);
+width = 632;
+}
+);
+note = uni14A0;
+unicode = 5280;
+},
+{
+glyphname = "c-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(233,339,o),
+(270,381,o),
+(283,449,cs),
+(291,485,l),
+(250,485,l),
+(242,443,ls),
+(232,402,o),
+(211,377,o),
+(179,377,cs),
+(142,377,o),
+(131,410,o),
+(140,452,cs),
+(190,690,l),
+(147,690,l),
+(99,460,ls),
+(84,394,o),
+(109,339,o),
+(177,339,cs)
+);
+}
+);
+width = 270;
+}
+);
+note = uni14A1;
+unicode = 5281;
+},
+{
+glyphname = "thSayisi-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(216,339,o),
+(250,381,o),
+(266,451,cs),
+(317,690,l),
+(272,690,l),
+(221,449,ls),
+(211,397,o),
+(189,377,o),
+(156,377,cs),
+(121,377,o),
+(109,410,o),
+(119,453,cs),
+(126,485,l),
+(85,485,l),
+(79,458,ls),
+(67,391,o),
+(92,339,o),
+(159,339,cs)
+);
+}
+);
+width = 270;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "=|c-canadian";
+note = uni14A2;
+unicode = 5282;
+},
+{
+glyphname = "me-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (177,345);
+},
+{
+name = top_center_can;
+pos = (282,690);
+},
+{
+name = top_left_can;
+pos = (160,690);
+},
+{
+name = top_right_can;
+pos = (401,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(285,0,l),
+(432,690,l),
+(130,690,l),
+(118,633,l),
+(358,633,l),
+(224,0,l)
+);
+}
+);
+width = 397;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+unicode = 5283;
+},
+{
+glyphname = "maai-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (99,0);
+ref = ring_top.canadian;
+}
+);
+width = 398;
+}
+);
+note = uni14A4;
+unicode = 5284;
+},
+{
+glyphname = "mi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (269,345);
+},
+{
+name = top_center_can;
+pos = (310,690);
+},
+{
+name = top_left_can;
+pos = (190,690);
+},
+{
+name = top_right_can;
+pos = (431,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(73,0,l),
+(209,633,l),
+(449,633,l),
+(462,690,l),
+(159,690,l),
+(13,0,l)
+);
+}
+);
+width = 398;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+unicode = 5285;
+},
+{
+glyphname = "mii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (155,0);
+ref = dot_top;
+}
+);
+width = 398;
+}
+);
+note = uni14A6;
+unicode = 5286;
+},
+{
+glyphname = "mo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (177,345);
+},
+{
+name = top_center_can;
+pos = (282,690);
+},
+{
+name = top_double;
+pos = (402,690);
+},
+{
+name = top_left_can;
+pos = (160,690);
+},
+{
+name = top_right_can;
+pos = (401,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(285,0,l),
+(432,690,l),
+(371,690,l),
+(236,57,l),
+(-5,57,l),
+(-16,0,l)
+);
+}
+);
+width = 397;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+unicode = 5287;
+},
+{
+glyphname = "moo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (245,0);
+ref = dot_top;
+}
+);
+width = 398;
+}
+);
+note = uni14A8;
+unicode = 5288;
+},
+{
+glyphname = "ycreemoo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (116,0);
+ref = doubledot_top;
+}
+);
+width = 398;
+}
+);
+note = uni14A9;
+unicode = 5289;
+},
+{
+glyphname = "ma-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (269,345);
+},
+{
+name = top_center_can;
+pos = (310,690);
+},
+{
+name = top_left_can;
+pos = (190,690);
+},
+{
+name = top_right_can;
+pos = (430,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(315,0,l),
+(327,57,l),
+(86,57,l),
+(220,690,l),
+(159,690,l),
+(13,0,l)
+);
+}
+);
+width = 398;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+unicode = 5290;
+},
+{
+glyphname = "maa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (35,0);
+ref = dot_top;
+}
+);
+width = 398;
+}
+);
+note = uni14AB;
+unicode = 5291;
+},
+{
+glyphname = "mwe-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "me-canadian";
+}
+);
+width = 568;
+}
+);
+note = uni14AC;
+unicode = 5292;
+},
+{
+glyphname = "mweWestCree-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "me-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (398,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 568;
+}
+);
+note = uni14AD;
+unicode = 5293;
+},
+{
+glyphname = "mwi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "mi-canadian";
+}
+);
+width = 568;
+}
+);
+note = uni14AE;
+unicode = 5294;
+},
+{
+glyphname = "mwiWestCree-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (398,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 568;
+}
+);
+note = uni14AF;
+unicode = 5295;
+},
+{
+glyphname = "mwii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (325,0);
+ref = dot_top;
+}
+);
+width = 568;
+}
+);
+note = uni14B0;
+unicode = 5296;
+},
+{
+glyphname = "mwiiWestCree-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (155,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (398,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 568;
+}
+);
+note = uni14B1;
+unicode = 5297;
+},
+{
+glyphname = "mwo-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "mo-canadian";
+}
+);
+width = 568;
+}
+);
+note = uni14B2;
+unicode = 5298;
+},
+{
+glyphname = "mwoWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (398,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 568;
+}
+);
+note = uni14B3;
+unicode = 5299;
+},
+{
+glyphname = "mwoo-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (415,0);
+ref = dot_top;
+}
+);
+width = 568;
+}
+);
+note = uni14B4;
+unicode = 5300;
+},
+{
+glyphname = "mwooWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (245,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (398,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 568;
+}
+);
+note = uni14B5;
+unicode = 5301;
+},
+{
+glyphname = "mwa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ma-canadian";
+}
+);
+width = 568;
+}
+);
+note = uni14B6;
+unicode = 5302;
+},
+{
+glyphname = "mwaWestCree-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (398,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 568;
+}
+);
+note = uni14B7;
+unicode = 5303;
+},
+{
+glyphname = "mwaa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (205,0);
+ref = dot_top;
+}
+);
+width = 568;
+}
+);
+note = uni14B8;
+unicode = 5304;
+},
+{
+glyphname = "mwaaWestCree-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (35,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (398,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 568;
+}
+);
+note = uni14B9;
+unicode = 5305;
+},
+{
+glyphname = "mwaaNaskapi-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ma-canadian";
+}
+);
+width = 583;
+}
+);
+note = uni14BA;
+unicode = 5306;
+},
+{
+glyphname = "m-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(240,345,l),
+(249,387,l),
+(127,387,l),
+(190,690,l),
+(147,690,l),
+(73,345,l)
+);
+}
+);
+width = 245;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni14BB;
+unicode = 5307;
+},
+{
+glyphname = "mWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "t-canadian";
+}
+);
+width = 276;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "t-canadian";
+note = uni14BC;
+unicode = 5308;
+},
+{
+glyphname = "mh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(218,345,l),
+(292,690,l),
+(249,690,l),
+(185,387,l),
+(61,387,l),
+(51,345,l)
+);
+}
+);
+width = 245;
+}
+);
+metricLeft = "=|m-canadian";
+metricRight = "=|m-canadian";
+note = uni14BD;
+unicode = 5309;
+},
+{
+glyphname = "mAthapascan-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(252,345,l),
+(261,384,l),
+(130,384,l),
+(128,361,l),
+(236,487,ls),
+(270,527,o),
+(296,567,o),
+(296,614,cs),
+(296,666,o),
+(268,696,o),
+(218,696,cs),
+(169,696,o),
+(131,663,o),
+(118,578,c),
+(158,578,l),
+(167,639,o),
+(189,661,o),
+(216,661,cs),
+(242,661,o),
+(255,646,o),
+(255,616,cs),
+(255,578,o),
+(237,545,o),
+(203,506,cs),
+(84,367,l),
+(79,345,l)
+);
+}
+);
+width = 269;
+}
+);
+note = uni14BE;
+unicode = 5310;
+},
+{
+glyphname = "mSayisi-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = two.canadian;
+}
+);
+width = 435;
+}
+);
+note = uni14BF;
+unicode = 5311;
+},
+{
+glyphname = "ne-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (391,245);
+},
+{
+name = top_center_can;
+pos = (436,491);
+},
+{
+name = top_left_can;
+pos = (134,491);
+},
+{
+name = top_right_can;
+pos = (586,491);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(520,-13,o),
+(567,197,o),
+(567,301,cs),
+(567,411,o),
+(513,472,o),
+(412,472,cs),
+(99,472,l),
+(88,416,l),
+(341,416,l),
+(340,439,l),
+(235,401,o),
+(207,243,o),
+(207,158,cs),
+(207,50,o),
+(261,-13,o),
+(356,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(298,42,o),
+(267,81,o),
+(267,157,cs),
+(267,233,o),
+(296,418,o),
+(416,418,cs),
+(476,418,o),
+(507,379,o),
+(507,303,cs),
+(507,228,o),
+(479,42,o),
+(357,42,cs)
+);
+}
+);
+width = 615;
+}
+);
+metricRight = "=|ke-canadian";
+note = uni14C0;
+unicode = 5312;
+},
+{
+glyphname = "naai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (75,-199);
+ref = ring_top.canadian;
+}
+);
+width = 615;
+}
+);
+note = uni14C1;
+unicode = 5313;
+},
+{
+glyphname = "ni-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (227,245);
+},
+{
+name = top_center_can;
+pos = (288,491);
+},
+{
+name = top_left_can;
+pos = (136,491);
+},
+{
+name = top_right_can;
+pos = (589,491);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(359,-13,o),
+(406,197,o),
+(406,301,cs),
+(406,360,o),
+(388,403,o),
+(355,425,c),
+(350,416,l),
+(605,416,l),
+(617,472,l),
+(263,472,ls),
+(91,472,o),
+(46,264,o),
+(46,158,cs),
+(46,50,o),
+(99,-13,o),
+(195,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(136,42,o),
+(106,81,o),
+(106,157,cs),
+(106,233,o),
+(134,418,o),
+(255,418,cs),
+(316,418,o),
+(346,379,o),
+(346,303,cs),
+(346,228,o),
+(318,42,o),
+(197,42,cs)
+);
+}
+);
+width = 616;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+unicode = 5314;
+},
+{
+glyphname = "nii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (131,-199);
+ref = dot_top;
+}
+);
+width = 615;
+}
+);
+note = uni14C3;
+unicode = 5315;
+},
+{
+glyphname = "no-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (391,245);
+},
+{
+name = top_center_can;
+pos = (441,491);
+},
+{
+name = top_double;
+pos = (444,491);
+},
+{
+name = top_left_can;
+pos = (133,491);
+},
+{
+name = top_right_can;
+pos = (587,491);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(353,0,ls),
+(526,0,o),
+(570,210,o),
+(570,314,cs),
+(570,422,o),
+(517,485,o),
+(421,485,cs),
+(257,485,o),
+(211,276,o),
+(211,171,cs),
+(211,112,o),
+(228,70,o),
+(262,47,c),
+(267,57,l),
+(12,57,l),
+(-1,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(300,54,o),
+(270,94,o),
+(270,169,cs),
+(270,245,o),
+(298,431,o),
+(419,431,cs),
+(479,431,o),
+(510,391,o),
+(510,315,cs),
+(510,240,o),
+(482,54,o),
+(360,54,cs)
+);
+}
+);
+width = 616;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14C4;
+unicode = 5316;
+},
+{
+glyphname = "noo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (286,-199);
+ref = dot_top;
+}
+);
+width = 615;
+}
+);
+note = uni14C5;
+unicode = 5317;
+},
+{
+glyphname = "ycreenoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (159,-199);
+ref = doubledot_top;
+}
+);
+width = 615;
+}
+);
+note = uni14C6;
+unicode = 5318;
+},
+{
+glyphname = "na-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (228,245);
+},
+{
+name = top_center_can;
+pos = (281,491);
+},
+{
+name = top_double;
+pos = (390,491);
+},
+{
+name = top_left_can;
+pos = (136,491);
+},
+{
+name = top_right_can;
+pos = (589,491);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(516,0,l),
+(527,57,l),
+(274,57,l),
+(274,34,l),
+(380,71,o),
+(408,229,o),
+(408,314,cs),
+(408,422,o),
+(355,485,o),
+(259,485,cs),
+(96,485,o),
+(48,276,o),
+(48,171,cs),
+(48,62,o),
+(102,0,o),
+(204,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(138,54,o),
+(108,94,o),
+(108,169,cs),
+(108,245,o),
+(136,431,o),
+(258,431,cs),
+(318,431,o),
+(349,391,o),
+(349,315,cs),
+(349,240,o),
+(320,54,o),
+(199,54,cs)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+unicode = 5319;
+},
+{
+glyphname = "naa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (126,-199);
+ref = dot_top;
+}
+);
+width = 615;
+}
+);
+note = uni14C8;
+unicode = 5320;
+},
+{
+glyphname = "nwe-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ne-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni14C9;
+unicode = 5321;
+},
+{
+glyphname = "nweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni14CA;
+unicode = 5322;
+},
+{
+glyphname = "nwa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "na-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni14CB;
+unicode = 5323;
+},
+{
+glyphname = "nwaWestCree-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni14CC;
+unicode = 5324;
+},
+{
+glyphname = "nwaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (296,-199);
+ref = dot_top;
+}
+);
+width = 784;
+}
+);
+note = uni14CD;
+unicode = 5325;
+},
+{
+glyphname = "nwaaWestCree-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (126,-199);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni14CE;
+unicode = 5326;
+},
+{
+glyphname = "nwaaNaskapi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (104,-199);
+ref = doubledot_top;
+}
+);
+width = 615;
+}
+);
+note = uni14CF;
+unicode = 5327;
+},
+{
+glyphname = "n-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(362,434,l),
+(372,476,l),
+(230,476,l),
+(227,452,l),
+(279,471,o),
+(300,554,o),
+(300,599,cs),
+(300,659,o),
+(271,696,o),
+(221,696,cs),
+(137,696,o),
+(107,590,o),
+(107,527,cs),
+(107,468,o),
+(137,434,o),
+(189,434,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(160,469,o),
+(146,489,o),
+(146,526,cs),
+(146,567,o),
+(163,660,o),
+(219,660,cs),
+(246,660,o),
+(261,640,o),
+(261,603,cs),
+(261,562,o),
+(244,469,o),
+(186,469,cs)
+);
+}
+);
+width = 349;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni14D0;
+unicode = 5328;
+},
+{
+color = 6;
+glyphname = "ngCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-161);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 317;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "=|";
+note = uni14D1;
+unicode = 5329;
+},
+{
+glyphname = "nh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(265,434,ls),
+(352,434,o),
+(382,538,o),
+(382,602,cs),
+(382,662,o),
+(352,696,o),
+(302,696,cs),
+(219,696,o),
+(188,590,o),
+(188,527,cs),
+(188,506,o),
+(193,477,o),
+(216,461,c),
+(220,476,l),
+(79,476,l),
+(71,434,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(242,469,o),
+(228,489,o),
+(228,526,cs),
+(228,567,o),
+(244,660,o),
+(300,660,cs),
+(328,660,o),
+(343,640,o),
+(343,603,cs),
+(343,562,o),
+(326,469,o),
+(270,469,cs)
+);
+}
+);
+width = 349;
+}
+);
+metricLeft = "=|n-canadian";
+metricRight = "=|n-canadian";
+note = uni14D2;
+unicode = 5330;
+},
+{
+glyphname = "le-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (391,245);
+},
+{
+name = top_center_can;
+pos = (437,491);
+},
+{
+name = top_left_can;
+pos = (134,491);
+},
+{
+name = top_right_can;
+pos = (586,491);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(304,0,ls),
+(495,0,o),
+(565,156,o),
+(565,287,cs),
+(565,402,o),
+(497,472,o),
+(380,472,cs),
+(99,472,l),
+(88,416,l),
+(368,416,ls),
+(457,416,o),
+(504,369,o),
+(504,284,cs),
+(504,194,o),
+(466,55,o),
+(309,55,cs),
+(301,55,l),
+(290,0,l)
+);
+}
+);
+width = 614;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D3;
+unicode = 5331;
+},
+{
+glyphname = "laai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (78,-199);
+ref = ring_top.canadian;
+}
+);
+width = 615;
+}
+);
+note = uni14D4;
+unicode = 5332;
+},
+{
+glyphname = "li-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (229,245);
+},
+{
+name = top_center_can;
+pos = (289,491);
+},
+{
+name = top_left_can;
+pos = (138,491);
+},
+{
+name = top_right_can;
+pos = (589,491);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(225,0,l),
+(237,55,l),
+(229,55,ls),
+(154,55,o),
+(110,106,o),
+(110,188,cs),
+(110,283,o),
+(161,416,o),
+(310,416,cs),
+(604,416,l),
+(616,472,l),
+(314,472,ls),
+(130,472,o),
+(49,326,o),
+(49,187,cs),
+(49,75,o),
+(114,0,o),
+(215,0,cs)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14D5;
+unicode = 5333;
+},
+{
+glyphname = "lii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (133,-199);
+ref = dot_top;
+}
+);
+width = 615;
+}
+);
+note = uni14D6;
+unicode = 5334;
+},
+{
+glyphname = "lo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (390,245);
+},
+{
+name = top_center_can;
+pos = (440,491);
+},
+{
+name = top_double;
+pos = (407,491);
+},
+{
+name = top_left_can;
+pos = (133,491);
+},
+{
+name = top_right_can;
+pos = (586,491);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(300,0,ls),
+(485,0,o),
+(566,147,o),
+(566,285,cs),
+(566,397,o),
+(501,472,o),
+(400,472,cs),
+(390,472,l),
+(379,417,l),
+(386,417,ls),
+(461,417,o),
+(505,367,o),
+(505,284,cs),
+(505,189,o),
+(454,56,o),
+(305,56,cs),
+(12,56,l),
+(-1,0,l)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D7;
+unicode = 5335;
+},
+{
+glyphname = "loo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (285,-199);
+ref = dot_top;
+}
+);
+width = 615;
+}
+);
+note = uni14D8;
+unicode = 5336;
+},
+{
+glyphname = "ycreeloo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (121,-199);
+ref = doubledot_top;
+}
+);
+width = 615;
+}
+);
+note = uni14D9;
+unicode = 5337;
+},
+{
+glyphname = "la-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (229,245);
+},
+{
+name = top_center_can;
+pos = (282,491);
+},
+{
+name = top_left_can;
+pos = (138,491);
+},
+{
+name = top_right_can;
+pos = (589,491);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(516,0,l),
+(527,56,l),
+(247,56,ls),
+(158,56,o),
+(110,103,o),
+(110,188,cs),
+(110,278,o),
+(150,417,o),
+(305,417,cs),
+(314,417,l),
+(326,472,l),
+(311,472,ls),
+(120,472,o),
+(50,317,o),
+(50,186,cs),
+(50,71,o),
+(118,0,o),
+(236,0,cs)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14DA;
+unicode = 5338;
+},
+{
+glyphname = "laa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (127,-199);
+ref = dot_top;
+}
+);
+width = 615;
+}
+);
+note = uni14DB;
+unicode = 5339;
+},
+{
+glyphname = "lwe-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "le-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni14DC;
+unicode = 5340;
+},
+{
+glyphname = "lweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "le-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni14DD;
+unicode = 5341;
+},
+{
+glyphname = "lwi-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "li-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni14DE;
+unicode = 5342;
+},
+{
+glyphname = "lwiWestCree-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni14DF;
+unicode = 5343;
+},
+{
+glyphname = "lwii-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (303,-199);
+ref = dot_top;
+}
+);
+width = 784;
+}
+);
+note = uni14E0;
+unicode = 5344;
+},
+{
+glyphname = "lwiiWestCree-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (133,-199);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni14E1;
+unicode = 5345;
+},
+{
+glyphname = "lwo-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "lo-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni14E2;
+unicode = 5346;
+},
+{
+glyphname = "lwoWestCree-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni14E3;
+unicode = 5347;
+},
+{
+glyphname = "lwoo-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (454,-199);
+ref = dot_top;
+}
+);
+width = 784;
+}
+);
+note = uni14E4;
+unicode = 5348;
+},
+{
+glyphname = "lwooWestCree-canadian";
+lastChange = "2023-01-13 15:56:14 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (285,-199);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni14E5;
+unicode = 5349;
+},
+{
+glyphname = "lwa-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "la-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni14E6;
+unicode = 5350;
+},
+{
+glyphname = "lwaWestCree-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni14E7;
+unicode = 5351;
+},
+{
+glyphname = "lwaa-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (297,-199);
+ref = dot_top;
+}
+);
+width = 784;
+}
+);
+note = uni14E8;
+unicode = 5352;
+},
+{
+glyphname = "lwaaWestCree-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (127,-199);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni14E9;
+unicode = 5353;
+},
+{
+glyphname = "l-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(344,345,l),
+(353,387,l),
+(232,387,ls),
+(177,387,o),
+(149,417,o),
+(149,474,cs),
+(149,547,o),
+(179,647,o),
+(285,647,cs),
+(288,647,l),
+(298,690,l),
+(293,690,ls),
+(151,690,o),
+(105,570,o),
+(105,472,cs),
+(105,390,o),
+(150,345,o),
+(232,345,cs)
+);
+}
+);
+width = 349;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "m-canadian";
+note = uni14EA;
+unicode = 5354;
+},
+{
+glyphname = "lWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(253,345,l),
+(259,373,l),
+(127,450,l),
+(122,427,l),
+(287,504,l),
+(292,526,l),
+(157,599,l),
+(154,578,l),
+(320,656,l),
+(327,690,l),
+(318,690,l),
+(128,602,l),
+(125,582,l),
+(259,509,l),
+(263,527,l),
+(97,452,l),
+(93,433,l),
+(244,345,l)
+);
+}
+);
+width = 281;
+}
+);
+metricRight = "=|";
+note = uni14EB;
+unicode = 5355;
+},
+{
+glyphname = "mediall-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(379,-13,l),
+(388,29,l),
+(102,192,l),
+(96,165,l),
+(451,326,l),
+(457,357,l),
+(169,510,l),
+(163,487,l),
+(520,651,l),
+(530,702,l),
+(513,702,l),
+(119,521,l),
+(112,491,l),
+(401,335,l),
+(406,356,l),
+(50,199,l),
+(44,169,l),
+(362,-13,l)
+);
+}
+);
+width = 490;
+}
+);
+metricRight = "=|";
+note = uni14EC;
+unicode = 5356;
+},
+{
+glyphname = "se-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (187,690);
+},
+{
+name = top_right_can;
+pos = (412,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(296,0,l),
+(363,315,l),
+(339,315,ls),
+(206,315,o),
+(151,375,o),
+(186,539,cs),
+(218,690,l),
+(157,690,l),
+(126,541,ls),
+(84,349,o),
+(163,259,o),
+(327,259,cs),
+(339,259,l),
+(295,282,l),
+(235,0,l)
+);
+}
+);
+width = 409;
+}
+);
+note = uni14ED;
+unicode = 5357;
+},
+{
+glyphname = "saai-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (203,0);
+ref = ring_top.canadian;
+}
+);
+width = 409;
+}
+);
+note = uni14EE;
+unicode = 5358;
+},
+{
+glyphname = "si-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (190,690);
+},
+{
+name = top_right_can;
+pos = (414,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(74,0,l),
+(134,282,l),
+(84,259,l),
+(119,259,ls),
+(276,259,o),
+(370,339,o),
+(411,528,cs),
+(444,690,l),
+(384,690,l),
+(350,531,ls),
+(317,383,o),
+(245,315,o),
+(124,315,cs),
+(80,315,l),
+(13,0,l)
+);
+}
+);
+width = 409;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+unicode = 5359;
+},
+{
+glyphname = "sii-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (259,0);
+ref = dot_top;
+}
+);
+width = 409;
+}
+);
+note = uni14F0;
+unicode = 5360;
+},
+{
+glyphname = "so-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (411,690);
+},
+{
+name = top_left_can;
+pos = (187,690);
+},
+{
+name = top_right_can;
+pos = (411,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(71,0,l),
+(105,158,ls),
+(137,307,o),
+(209,375,o),
+(330,375,cs),
+(375,375,l),
+(441,690,l),
+(381,690,l),
+(320,408,l),
+(370,431,l),
+(336,431,ls),
+(178,431,o),
+(84,351,o),
+(44,161,cs),
+(10,0,l)
+);
+}
+);
+width = 408;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+unicode = 5361;
+},
+{
+glyphname = "soo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (256,0);
+ref = dot_top;
+}
+);
+width = 409;
+}
+);
+note = uni14F2;
+unicode = 5362;
+},
+{
+glyphname = "ycreesoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (127,0);
+ref = doubledot_top;
+}
+);
+width = 409;
+}
+);
+note = uni14F3;
+unicode = 5363;
+},
+{
+glyphname = "sa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (191,690);
+},
+{
+name = top_right_can;
+pos = (415,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(299,0,l),
+(330,149,ls),
+(372,341,o),
+(293,431,o),
+(130,431,cs),
+(117,431,l),
+(161,408,l),
+(222,690,l),
+(160,690,l),
+(94,375,l),
+(117,375,ls),
+(250,375,o),
+(305,315,o),
+(270,151,cs),
+(238,0,l)
+);
+}
+);
+width = 409;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+unicode = 5364;
+},
+{
+glyphname = "saa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (35,0);
+ref = dot_top;
+}
+);
+width = 409;
+}
+);
+note = uni14F5;
+unicode = 5365;
+},
+{
+glyphname = "swe-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "se-canadian";
+}
+);
+width = 579;
+}
+);
+note = uni14F6;
+unicode = 5366;
+},
+{
+glyphname = "sweWestCree-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "se-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (409,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 579;
+}
+);
+note = uni14F7;
+unicode = 5367;
+},
+{
+glyphname = "swi-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "si-canadian";
+}
+);
+width = 579;
+}
+);
+note = uni14F8;
+unicode = 5368;
+},
+{
+glyphname = "swiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (409,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 579;
+}
+);
+note = uni14F9;
+unicode = 5369;
+},
+{
+glyphname = "swii-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (429,0);
+ref = dot_top;
+}
+);
+width = 579;
+}
+);
+note = uni14FA;
+unicode = 5370;
+},
+{
+glyphname = "swiiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (259,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (409,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 579;
+}
+);
+note = uni14FB;
+unicode = 5371;
+},
+{
+glyphname = "swo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "so-canadian";
+}
+);
+width = 579;
+}
+);
+note = uni14FC;
+unicode = 5372;
+},
+{
+glyphname = "swoWestCree-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (409,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 579;
+}
+);
+note = uni14FD;
+unicode = 5373;
+},
+{
+glyphname = "swoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (426,0);
+ref = dot_top;
+}
+);
+width = 579;
+}
+);
+note = uni14FE;
+unicode = 5374;
+},
+{
+glyphname = "swooWestCree-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (256,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (409,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 579;
+}
+);
+note = uni14FF;
+unicode = 5375;
+},
+{
+glyphname = "swa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "sa-canadian";
+}
+);
+width = 579;
+}
+);
+note = uni1500;
+unicode = 5376;
+},
+{
+glyphname = "swaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (409,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 579;
+}
+);
+note = uni1501;
+unicode = 5377;
+},
+{
+glyphname = "swaa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (205,0);
+ref = dot_top;
+}
+);
+width = 579;
+}
+);
+note = uni1502;
+unicode = 5378;
+},
+{
+glyphname = "swaaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (35,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (409,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 579;
+}
+);
+note = uni1503;
+unicode = 5379;
+},
+{
+glyphname = "swaaNaskapi-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "sa-canadian";
+}
+);
+width = 594;
+}
+);
+note = uni1504;
+unicode = 5380;
+},
+{
+glyphname = "s-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(240,345,l),
+(257,429,ls),
+(275,514,o),
+(241,569,o),
+(154,569,cs),
+(140,569,l),
+(160,547,l),
+(190,690,l),
+(147,690,l),
+(114,532,l),
+(142,532,ls),
+(209,532,o),
+(228,497,o),
+(213,427,cs),
+(196,345,l)
+);
+}
+);
+width = 267;
+}
+);
+metricRight = "=|";
+note = uni1505;
+unicode = 5381;
+},
+{
+color = 6;
+glyphname = "sAthapascan-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(212,177,o),
+(249,219,o),
+(249,280,cs),
+(249,320,o),
+(233,346,o),
+(193,365,cs),
+(174,376,ls),
+(149,387,o),
+(136,407,o),
+(136,430,cs),
+(136,469,o),
+(158,497,o),
+(200,497,cs),
+(235,497,o),
+(252,480,o),
+(242,429,c),
+(282,429,l),
+(295,490,o),
+(263,533,o),
+(202,533,cs),
+(132,533,o),
+(96,488,o),
+(96,427,cs),
+(96,392,o),
+(114,361,o),
+(150,344,cs),
+(169,334,ls),
+(199,319,o),
+(209,302,o),
+(209,277,cs),
+(209,237,o),
+(186,213,o),
+(148,213,cs),
+(110,213,o),
+(88,229,o),
+(100,284,c),
+(60,284,l),
+(45,215,o),
+(82,177,o),
+(147,177,cs)
+);
+}
+);
+width = 293;
+}
+);
+metricRight = "=|";
+note = uni1506;
+unicode = 5382;
+},
+{
+glyphname = "sw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(118,345,l),
+(135,427,ls),
+(151,500,o),
+(185,532,o),
+(247,532,cs),
+(279,532,l),
+(313,690,l),
+(269,690,l),
+(240,551,l),
+(270,569,l),
+(245,569,ls),
+(159,569,o),
+(112,526,o),
+(93,432,cs),
+(73,345,l)
+);
+}
+);
+width = 266;
+}
+);
+metricLeft = "=|s-canadian";
+metricRight = "=|s-canadian";
+note = uni1507;
+unicode = 5383;
+},
+{
+glyphname = "sBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(245,345,l),
+(255,387,l),
+(196,387,ls),
+(149,387,o),
+(130,412,o),
+(143,467,cs),
+(190,690,l),
+(147,690,l),
+(100,471,ls),
+(83,390,o),
+(117,345,o),
+(194,345,cs)
+);
+}
+);
+width = 251;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "m-canadian";
+note = uni1508;
+unicode = 5384;
+},
+{
+glyphname = "moosecreesk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(247,217,o),
+(271,358,o),
+(271,440,cs),
+(271,527,o),
+(233,570,o),
+(153,570,cs),
+(145,570,l),
+(160,549,l),
+(190,690,l),
+(147,690,l),
+(114,533,l),
+(140,533,ls),
+(227,533,o),
+(236,488,o),
+(231,413,c),
+(236,401,l),
+(241,433,o),
+(234,478,o),
+(180,478,cs),
+(98,478,o),
+(72,363,o),
+(72,311,cs),
+(72,254,o),
+(100,217,o),
+(151,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(126,252,o),
+(112,272,o),
+(112,308,cs),
+(112,348,o),
+(129,444,o),
+(185,444,cs),
+(213,444,o),
+(227,426,o),
+(227,390,cs),
+(227,351,o),
+(209,252,o),
+(153,252,cs)
+);
+}
+);
+width = 288;
+}
+);
+metricRight = "=|";
+note = uni1509;
+unicode = 5385;
+},
+{
+glyphname = "skwNaskapi-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(236,217,o),
+(266,330,o),
+(266,389,cs),
+(266,444,o),
+(241,478,o),
+(197,478,cs),
+(161,478,o),
+(130,451,o),
+(121,407,c),
+(131,409,l),
+(161,492,o),
+(198,533,o),
+(277,533,cs),
+(301,533,l),
+(334,690,l),
+(291,690,l),
+(261,548,l),
+(287,570,l),
+(272,570,ls),
+(126,570,o),
+(73,405,o),
+(73,313,cs),
+(73,256,o),
+(99,217,o),
+(150,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(126,252,o),
+(112,272,o),
+(112,308,cs),
+(112,348,o),
+(129,444,o),
+(185,444,cs),
+(213,444,o),
+(226,426,o),
+(226,390,cs),
+(226,351,o),
+(209,252,o),
+(153,252,cs)
+);
+}
+);
+width = 288;
+}
+);
+metricLeft = "=|moosecreesk-canadian";
+metricRight = "=|moosecreesk-canadian";
+note = uni150A;
+unicode = 5386;
+},
+{
+glyphname = "swNaskapi-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(222,178,l),
+(238,250,ls),
+(258,345,o),
+(218,397,o),
+(137,397,cs),
+(121,397,l),
+(138,374,l),
+(167,513,l),
+(125,513,l),
+(93,360,l),
+(124,360,ls),
+(185,360,o),
+(211,329,o),
+(194,251,cs),
+(179,178,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(208,63,o),
+(226,81,o),
+(226,103,cs),
+(226,127,o),
+(208,145,o),
+(185,145,cs),
+(163,145,o),
+(144,127,o),
+(144,103,cs),
+(144,81,o),
+(163,63,o),
+(185,63,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(185,545,o),
+(203,563,o),
+(203,586,cs),
+(203,610,o),
+(185,627,o),
+(162,627,cs),
+(140,627,o),
+(122,610,o),
+(122,586,cs),
+(122,563,o),
+(140,545,o),
+(162,545,cs)
+);
+}
+);
+width = 302;
+}
+);
+metricRight = "=|";
+note = uni150B;
+unicode = 5387;
+},
+{
+glyphname = "spwaNaskapi-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(402,0,l),
+(412,50,l),
+(109,354,l),
+(103,323,l),
+(535,626,l),
+(549,690,l),
+(531,690,l),
+(57,357,l),
+(51,332,l),
+(384,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(193,494,o),
+(211,512,o),
+(211,534,cs),
+(211,557,o),
+(193,576,o),
+(170,576,cs),
+(149,576,o),
+(129,557,o),
+(129,534,cs),
+(129,512,o),
+(149,494,o),
+(170,494,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(341,598,l),
+(354,658,ls),
+(367,720,o),
+(342,756,o),
+(284,756,cs),
+(263,756,l),
+(289,738,l),
+(310,836,l),
+(270,836,l),
+(245,722,l),
+(268,722,ls),
+(309,722,o),
+(321,703,o),
+(311,653,cs),
+(299,598,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(494,699,o),
+(511,719,o),
+(511,741,cs),
+(511,764,o),
+(494,782,o),
+(470,782,cs),
+(449,782,o),
+(430,764,o),
+(430,741,cs),
+(430,719,o),
+(449,699,o),
+(470,699,cs)
+);
+}
+);
+width = 493;
+}
+);
+metricRight = "pa-canadian";
+metricWidth = "pa-canadian";
+note = uni150C;
+unicode = 5388;
+},
+{
+glyphname = "stwaNaskapi-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (301,0);
+ref = "ta-canadian";
+}
+);
+width = 754;
+}
+);
+note = uni150D;
+unicode = 5389;
+},
+{
+glyphname = "skwaNaskapi-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (301,0);
+ref = "ka-canadian";
+}
+);
+width = 752;
+}
+);
+note = uni150E;
+unicode = 5390;
+},
+{
+glyphname = "scwaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (301,0);
+ref = "ca-canadian";
+}
+);
+width = 748;
+}
+);
+note = uni150F;
+unicode = 5391;
+},
+{
+glyphname = "she-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (316,690);
+},
+{
+name = top_right_can;
+pos = (615,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(549,-13,o),
+(606,56,o),
+(637,203,cs),
+(657,298,l),
+(596,298,l),
+(574,198,ls),
+(551,88,o),
+(516,43,o),
+(453,43,cs),
+(384,43,o),
+(360,100,o),
+(380,211,cs),
+(424,463,ls),
+(451,616,o),
+(403,702,o),
+(296,702,cs),
+(197,702,o),
+(140,634,o),
+(108,487,cs),
+(89,391,l),
+(150,391,l),
+(171,492,ls),
+(195,602,o),
+(230,647,o),
+(292,647,cs),
+(362,647,o),
+(385,589,o),
+(366,479,cs),
+(321,226,ls),
+(295,73,o),
+(342,-13,o),
+(450,-13,cs)
+);
+}
+);
+width = 699;
+}
+);
+metricRight = "=|";
+note = uni1510;
+unicode = 5392;
+},
+{
+glyphname = "shi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (277,690);
+},
+{
+name = top_right_can;
+pos = (577,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(272,-13,o),
+(326,43,o),
+(369,213,cs),
+(436,478,ls),
+(469,611,o),
+(501,647,o),
+(565,647,cs),
+(634,647,o),
+(657,588,o),
+(631,470,cs),
+(614,391,l),
+(675,391,l),
+(690,457,ls),
+(723,607,o),
+(677,702,o),
+(568,702,cs),
+(470,702,o),
+(419,646,o),
+(377,477,cs),
+(307,211,ls),
+(273,80,o),
+(242,43,o),
+(178,43,cs),
+(110,43,o),
+(87,100,o),
+(112,218,cs),
+(129,298,l),
+(69,298,l),
+(54,233,ls),
+(20,80,o),
+(66,-13,o),
+(175,-13,cs)
+);
+}
+);
+width = 698;
+}
+);
+metricLeft = "she-canadian";
+metricRight = "she-canadian";
+note = uni1511;
+unicode = 5393;
+},
+{
+glyphname = "shii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (423,0);
+ref = dot_top;
+}
+);
+width = 699;
+}
+);
+note = uni1512;
+unicode = 5394;
+},
+{
+glyphname = "sho-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (409,491);
+},
+{
+name = top_left_can;
+pos = (269,491);
+},
+{
+name = top_right_can;
+pos = (548,491);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(230,43,l),
+(150,43,o),
+(98,82,o),
+(98,149,cs),
+(98,218,o),
+(138,287,o),
+(216,287,cs),
+(325,287,o),
+(364,129,o),
+(499,129,cs),
+(611,129,o),
+(673,223,o),
+(673,324,cs),
+(673,422,o),
+(601,483,o),
+(493,485,c),
+(480,430,l),
+(562,429,o),
+(614,391,o),
+(614,324,cs),
+(614,254,o),
+(574,185,o),
+(497,185,cs),
+(387,185,o),
+(348,343,o),
+(213,343,cs),
+(99,343,o),
+(39,247,o),
+(39,149,cs),
+(39,50,o),
+(111,-11,o),
+(217,-13,c)
+);
+}
+);
+width = 712;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1513;
+unicode = 5395;
+},
+{
+glyphname = "shoo-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (253,-199);
+ref = dot_top;
+}
+);
+width = 712;
+}
+);
+note = uni1514;
+unicode = 5396;
+},
+{
+glyphname = "sha-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (412,491);
+},
+{
+name = top_left_can;
+pos = (270,491);
+},
+{
+name = top_right_can;
+pos = (552,491);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(550,-14,o),
+(648,68,o),
+(648,205,cs),
+(648,287,o),
+(597,343,o),
+(519,343,cs),
+(397,343,o),
+(298,185,o),
+(203,185,cs),
+(155,185,o),
+(126,219,o),
+(126,271,cs),
+(126,376,o),
+(201,430,o),
+(301,430,c),
+(314,485,l),
+(163,486,o),
+(65,405,o),
+(65,268,cs),
+(65,185,o),
+(115,129,o),
+(193,129,cs),
+(315,129,o),
+(413,287,o),
+(509,287,cs),
+(557,287,o),
+(587,253,o),
+(587,201,cs),
+(587,97,o),
+(514,43,o),
+(412,43,c),
+(400,-13,l)
+);
+}
+);
+width = 712;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1515;
+unicode = 5397;
+},
+{
+glyphname = "shaa-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (256,-199);
+ref = dot_top;
+}
+);
+width = 712;
+}
+);
+note = uni1516;
+unicode = 5398;
+},
+{
+glyphname = "shwe-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "she-canadian";
+}
+);
+width = 869;
+}
+);
+note = uni1517;
+unicode = 5399;
+},
+{
+glyphname = "shweWestCree-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "she-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (699,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 869;
+}
+);
+note = uni1518;
+unicode = 5400;
+},
+{
+glyphname = "shwi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "shi-canadian";
+}
+);
+width = 869;
+}
+);
+note = uni1519;
+unicode = 5401;
+},
+{
+glyphname = "shwiWestCree-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (699,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 869;
+}
+);
+note = uni151A;
+unicode = 5402;
+},
+{
+glyphname = "shwii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (592,0);
+ref = dot_top;
+}
+);
+width = 869;
+}
+);
+note = uni151B;
+unicode = 5403;
+},
+{
+glyphname = "shwiiWestCree-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (423,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (699,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 869;
+}
+);
+note = uni151C;
+unicode = 5404;
+},
+{
+glyphname = "shwo-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "sho-canadian";
+}
+);
+width = 882;
+}
+);
+note = uni151D;
+unicode = 5405;
+},
+{
+glyphname = "shwoWestCree-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (712,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 882;
+}
+);
+note = uni151E;
+unicode = 5406;
+},
+{
+glyphname = "shwoo-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (422,-199);
+ref = dot_top;
+}
+);
+width = 882;
+}
+);
+note = uni151F;
+unicode = 5407;
+},
+{
+glyphname = "shwooWestCree-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (253,-199);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (712,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 882;
+}
+);
+note = uni1520;
+unicode = 5408;
+},
+{
+glyphname = "shwa-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "sha-canadian";
+}
+);
+width = 882;
+}
+);
+note = uni1521;
+unicode = 5409;
+},
+{
+glyphname = "shwaWestCree-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (712,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 882;
+}
+);
+note = uni1522;
+unicode = 5410;
+},
+{
+glyphname = "shwaa-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (426,-199);
+ref = dot_top;
+}
+);
+width = 882;
+}
+);
+note = uni1523;
+unicode = 5411;
+},
+{
+glyphname = "shwaaWestCree-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (256,-199);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (712,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 882;
+}
+);
+note = uni1524;
+unicode = 5412;
+},
+{
+glyphname = "sh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(458,289,o),
+(537,353,o),
+(537,457,cs),
+(537,519,o),
+(497,562,o),
+(431,562,cs),
+(346,562,o),
+(293,469,o),
+(224,469,cs),
+(182,469,o),
+(158,494,o),
+(158,533,cs),
+(158,610,o),
+(219,657,o),
+(306,656,c),
+(315,697,l),
+(195,698,o),
+(115,636,o),
+(115,531,cs),
+(115,469,o),
+(155,425,o),
+(221,425,cs),
+(306,425,o),
+(360,519,o),
+(428,519,cs),
+(470,519,o),
+(494,494,o),
+(494,455,cs),
+(494,383,o),
+(437,330,o),
+(349,331,c),
+(340,291,l)
+);
+}
+);
+width = 542;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni1525;
+unicode = 5413;
+},
+{
+glyphname = "ye-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (476,345);
+},
+{
+name = top_left_can;
+pos = (169,690);
+},
+{
+name = top_right_can;
+pos = (440,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(324,0,l),
+(389,310,l),
+(128,310,l),
+(131,290,l),
+(474,665,l),
+(431,701,l),
+(49,280,l),
+(44,255,l),
+(317,255,l),
+(262,0,l)
+);
+}
+);
+width = 433;
+}
+);
+note = uni1526;
+unicode = 5414;
+},
+{
+glyphname = "yaai-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-24,0);
+ref = ring_top.canadian;
+}
+);
+width = 433;
+}
+);
+note = uni1527;
+unicode = 5415;
+},
+{
+glyphname = "yi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (187,690);
+},
+{
+name = top_right_can;
+pos = (460,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(71,0,l),
+(125,255,l),
+(397,255,l),
+(402,280,l),
+(188,701,l),
+(138,674,l),
+(333,292,l),
+(336,310,l),
+(75,310,l),
+(9,0,l)
+);
+}
+);
+width = 433;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni1528;
+unicode = 5416;
+},
+{
+glyphname = "yii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (32,0);
+ref = dot_top;
+}
+);
+width = 433;
+}
+);
+note = uni1529;
+unicode = 5417;
+},
+{
+glyphname = "yo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (476,345);
+},
+{
+name = top_double;
+pos = (440,690);
+},
+{
+name = top_left_can;
+pos = (167,690);
+},
+{
+name = top_right_can;
+pos = (440,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(341,15,l),
+(145,398,l),
+(143,380,l),
+(404,380,l),
+(470,690,l),
+(409,690,l),
+(355,435,l),
+(82,435,l),
+(77,410,l),
+(290,-12,l)
+);
+}
+);
+width = 433;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152A;
+unicode = 5418;
+},
+{
+glyphname = "yoo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (285,0);
+ref = dot_top;
+}
+);
+width = 433;
+}
+);
+note = uni152B;
+unicode = 5419;
+},
+{
+glyphname = "ycreeyoo-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (155,0);
+ref = doubledot_top;
+}
+);
+width = 433;
+}
+);
+note = uni152C;
+unicode = 5420;
+},
+{
+glyphname = "ya-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (186,690);
+},
+{
+name = top_right_can;
+pos = (459,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(429,410,l),
+(435,435,l),
+(162,435,l),
+(216,690,l),
+(155,690,l),
+(89,380,l),
+(351,380,l),
+(347,400,l),
+(5,25,l),
+(47,-12,l)
+);
+}
+);
+width = 433;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152D;
+unicode = 5421;
+},
+{
+glyphname = "yaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (31,0);
+ref = dot_top;
+}
+);
+width = 433;
+}
+);
+note = uni152E;
+unicode = 5422;
+},
+{
+glyphname = "ywe-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ye-canadian";
+}
+);
+width = 602;
+}
+);
+note = uni152F;
+unicode = 5423;
+},
+{
+glyphname = "yweWestCree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ye-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (433,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 602;
+}
+);
+note = uni1530;
+unicode = 5424;
+},
+{
+glyphname = "ywi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "yi-canadian";
+}
+);
+width = 602;
+}
+);
+note = uni1531;
+unicode = 5425;
+},
+{
+glyphname = "ywiWestCree-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (433,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 602;
+}
+);
+note = uni1532;
+unicode = 5426;
+},
+{
+glyphname = "ywii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (201,0);
+ref = dot_top;
+}
+);
+width = 602;
+}
+);
+note = uni1533;
+unicode = 5427;
+},
+{
+glyphname = "ywiiWestCree-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (32,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (433,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 602;
+}
+);
+note = uni1534;
+unicode = 5428;
+},
+{
+glyphname = "ywo-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "yo-canadian";
+}
+);
+width = 602;
+}
+);
+note = uni1535;
+unicode = 5429;
+},
+{
+glyphname = "ywoWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (433,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 602;
+}
+);
+note = uni1536;
+unicode = 5430;
+},
+{
+glyphname = "ywoo-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (454,0);
+ref = dot_top;
+}
+);
+width = 602;
+}
+);
+note = uni1537;
+unicode = 5431;
+},
+{
+glyphname = "ywooWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (285,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (433,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 602;
+}
+);
+note = uni1538;
+unicode = 5432;
+},
+{
+glyphname = "ywa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ya-canadian";
+}
+);
+width = 602;
+}
+);
+note = uni1539;
+unicode = 5433;
+},
+{
+glyphname = "ywaWestCree-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (433,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 602;
+}
+);
+note = uni153A;
+unicode = 5434;
+},
+{
+glyphname = "ywaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (200,0);
+ref = dot_top;
+}
+);
+width = 602;
+}
+);
+note = uni153B;
+unicode = 5435;
+},
+{
+glyphname = "ywaaWestCree-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (31,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (433,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 602;
+}
+);
+note = uni153C;
+unicode = 5436;
+},
+{
+glyphname = "ywaaNaskapi-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ya-canadian";
+}
+);
+width = 618;
+}
+);
+note = uni153D;
+unicode = 5437;
+},
+{
+glyphname = "y-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(297,546,l),
+(300,562,l),
+(167,562,l),
+(194,690,l),
+(151,690,l),
+(116,524,l),
+(248,524,l),
+(246,550,l),
+(77,362,l),
+(108,336,l)
+);
+}
+);
+width = 259;
+}
+);
+note = uni153E;
+unicode = 5438;
+},
+{
+glyphname = "biblecreey-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(105,345,l),
+(219,639,l),
+(194,639,l),
+(206,345,l),
+(231,345,l),
+(366,639,l),
+(342,639,l),
+(330,345,l),
+(369,345,l),
+(372,357,l),
+(384,690,l),
+(351,690,l),
+(213,392,l),
+(241,392,l),
+(229,690,l),
+(197,690,l),
+(67,357,l),
+(64,345,l)
+);
+}
+);
+width = 387;
+}
+);
+metricRight = "=|";
+note = uni153F;
+unicode = 5439;
+},
+{
+glyphname = "yWestCree-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(188,213,l),
+(213,334,l),
+(314,334,l),
+(324,377,l),
+(223,377,l),
+(248,496,l),
+(208,496,l),
+(183,377,l),
+(82,377,l),
+(72,334,l),
+(173,334,l),
+(148,213,l)
+);
+}
+);
+width = 345;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1540;
+unicode = 5440;
+},
+{
+glyphname = "yiSayisi-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (39,183);
+ref = "fullstop-canadian";
+}
+);
+width = 281;
+}
+);
+metricLeft = "fullstop-canadian";
+metricWidth = "fullstop-canadian";
+note = uni1541;
+unicode = 5441;
+},
+{
+glyphname = "re-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (283,491);
+},
+{
+name = top_left_can;
+pos = (146,491);
+},
+{
+name = top_right_can;
+pos = (623,491);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(296,-13,o),
+(357,49,o),
+(387,192,cs),
+(436,416,l),
+(638,416,l),
+(649,472,l),
+(387,472,l),
+(327,188,ls),
+(304,85,o),
+(265,43,o),
+(198,43,cs),
+(124,43,o),
+(94,98,o),
+(114,196,cs),
+(173,472,l),
+(112,472,l),
+(55,207,ls),
+(26,72,o),
+(79,-13,o),
+(195,-13,cs)
+);
+}
+);
+width = 649;
+}
+);
+metricRight = "=|ne-canadian";
+note = uni1542;
+unicode = 5442;
+},
+{
+glyphname = "reRCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (472,491);
+},
+{
+name = top_left_can;
+pos = (134,491);
+},
+{
+name = top_right_can;
+pos = (610,491);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(485,-13,o),
+(547,49,o),
+(577,192,cs),
+(638,472,l),
+(576,472,l),
+(515,188,ls),
+(493,85,o),
+(453,43,o),
+(386,43,cs),
+(312,43,o),
+(282,98,o),
+(302,196,cs),
+(361,472,l),
+(99,472,l),
+(88,416,l),
+(290,416,l),
+(244,207,ls),
+(216,73,o),
+(269,-13,o),
+(384,-13,cs)
+);
+}
+);
+width = 649;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1543;
+unicode = 5443;
+},
+{
+glyphname = "leWestCree-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (472,491);
+},
+{
+name = top_left_can;
+pos = (133,491);
+},
+{
+name = top_right_can;
+pos = (611,491);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(262,0,l),
+(322,284,ls),
+(344,387,o),
+(384,430,o),
+(451,430,cs),
+(526,430,o),
+(555,375,o),
+(534,276,cs),
+(475,0,l),
+(537,0,l),
+(593,266,ls),
+(622,400,o),
+(569,485,o),
+(453,485,cs),
+(354,485,o),
+(292,423,o),
+(261,280,cs),
+(213,57,l),
+(12,57,l),
+(-1,0,l)
+);
+}
+);
+width = 648;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+unicode = 5444;
+},
+{
+glyphname = "raai-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (72,-199);
+ref = ring_top.canadian;
+}
+);
+width = 648;
+}
+);
+note = uni1545;
+unicode = 5445;
+},
+{
+glyphname = "ri-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (282,491);
+},
+{
+name = top_left_can;
+pos = (145,491);
+},
+{
+name = top_right_can;
+pos = (621,491);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(72,0,l),
+(132,284,ls),
+(155,387,o),
+(195,430,o),
+(263,430,cs),
+(336,430,o),
+(366,375,o),
+(345,276,cs),
+(286,0,l),
+(548,0,l),
+(560,57,l),
+(358,57,l),
+(403,266,ls),
+(432,400,o),
+(379,485,o),
+(267,485,cs),
+(162,485,o),
+(100,423,o),
+(71,280,cs),
+(11,0,l)
+);
+}
+);
+width = 647;
+}
+);
+metricLeft = "re-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+unicode = 5446;
+},
+{
+glyphname = "rii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (128,-199);
+ref = dot_top;
+}
+);
+width = 648;
+}
+);
+note = uni1547;
+unicode = 5447;
+},
+{
+glyphname = "ro-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (276,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(74,0,l),
+(134,282,l),
+(105,256,l),
+(173,256,ls),
+(358,256,o),
+(415,408,o),
+(415,522,cs),
+(415,626,o),
+(355,690,o),
+(249,690,cs),
+(161,690,l),
+(150,634,l),
+(239,634,ls),
+(315,634,o),
+(355,594,o),
+(355,519,cs),
+(355,426,o),
+(310,311,o),
+(170,311,cs),
+(78,311,l),
+(13,0,l)
+);
+}
+);
+width = 410;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1548;
+unicode = 5448;
+},
+{
+glyphname = "roo-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (121,0);
+ref = dot_top;
+}
+);
+width = 410;
+}
+);
+note = uni1549;
+unicode = 5449;
+},
+{
+glyphname = "loWestCree-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (293,690);
+},
+{
+name = top_left_can;
+pos = (190,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(119,0,ls),
+(305,0,o),
+(362,152,o),
+(362,266,cs),
+(362,370,o),
+(301,434,o),
+(196,434,cs),
+(139,434,l),
+(160,407,l),
+(220,690,l),
+(159,690,l),
+(93,380,l),
+(184,380,ls),
+(261,380,o),
+(301,339,o),
+(301,265,cs),
+(301,172,o),
+(257,56,o),
+(116,56,cs),
+(24,56,l),
+(13,0,l)
+);
+}
+);
+width = 411;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+unicode = 5450;
+},
+{
+glyphname = "ra-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (328,690);
+},
+{
+name = top_right_can;
+pos = (414,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(299,0,l),
+(364,310,l),
+(272,310,ls),
+(196,310,o),
+(157,351,o),
+(157,425,cs),
+(157,518,o),
+(201,634,o),
+(342,634,cs),
+(434,634,l),
+(445,690,l),
+(339,690,ls),
+(153,690,o),
+(96,538,o),
+(96,424,cs),
+(96,320,o),
+(157,256,o),
+(262,256,cs),
+(319,256,l),
+(298,283,l),
+(237,0,l)
+);
+}
+);
+width = 411;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+unicode = 5451;
+},
+{
+glyphname = "raa-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (171,0);
+ref = dot_top;
+}
+);
+width = 410;
+}
+);
+note = uni154C;
+unicode = 5452;
+},
+{
+glyphname = "laWestCree-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (414,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(296,0,l),
+(308,56,l),
+(218,56,ls),
+(142,56,o),
+(101,96,o),
+(101,171,cs),
+(101,264,o),
+(146,379,o),
+(287,379,cs),
+(379,379,l),
+(445,690,l),
+(384,690,l),
+(324,408,l),
+(353,434,l),
+(284,434,ls),
+(98,434,o),
+(41,282,o),
+(41,168,cs),
+(41,64,o),
+(101,0,o),
+(207,0,cs)
+);
+}
+);
+width = 411;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+unicode = 5453;
+},
+{
+glyphname = "rwaa-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (341,0);
+ref = dot_top;
+}
+);
+width = 580;
+}
+);
+note = uni154E;
+unicode = 5454;
+},
+{
+glyphname = "rwaaWestCree-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (171,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (410,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 580;
+}
+);
+note = uni154F;
+unicode = 5455;
+},
+{
+glyphname = "r-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(215,345,l),
+(249,507,l),
+(213,507,ls),
+(174,507,o),
+(155,527,o),
+(155,562,cs),
+(155,601,o),
+(171,652,o),
+(243,652,cs),
+(280,652,l),
+(288,690,l),
+(251,690,ls),
+(156,690,o),
+(113,634,o),
+(113,561,cs),
+(113,507,o),
+(147,470,o),
+(206,470,cs),
+(226,470,l),
+(201,485,l),
+(171,345,l)
+);
+}
+);
+width = 242;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni1550;
+unicode = 5456;
+},
+{
+glyphname = "rWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(147,690,l),
+(141,662,l),
+(273,584,l),
+(278,608,l),
+(113,530,l),
+(108,508,l),
+(242,436,l),
+(247,457,l),
+(81,379,l),
+(73,345,l),
+(83,345,l),
+(272,433,l),
+(276,452,l),
+(141,526,l),
+(138,507,l),
+(304,582,l),
+(308,602,l),
+(156,690,l)
+);
+}
+);
+width = 280;
+}
+);
+metricLeft = "=|lWestCree-canadian";
+metricRight = "=|lWestCree-canadian";
+note = uni1551;
+unicode = 5457;
+},
+{
+glyphname = "rMedial-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(23,-13,l),
+(417,169,l),
+(424,199,l),
+(135,355,l),
+(130,333,l),
+(486,491,l),
+(492,521,l),
+(174,702,l),
+(157,702,l),
+(148,661,l),
+(434,497,l),
+(440,525,l),
+(85,364,l),
+(79,332,l),
+(367,180,l),
+(373,203,l),
+(16,39,l),
+(6,-13,l)
+);
+}
+);
+width = 490;
+}
+);
+metricLeft = "mediall-canadian";
+metricRight = "mediall-canadian";
+note = uni1552;
+unicode = 5458;
+},
+{
+glyphname = "fe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(244,0,l),
+(642,670,l),
+(646,690,l),
+(595,690,l),
+(236,70,l),
+(251,70,l),
+(200,364,l),
+(175,358,l),
+(188,336,o),
+(211,325,o),
+(243,325,cs),
+(357,325,o),
+(399,493,o),
+(399,571,cs),
+(399,650,o),
+(364,702,o),
+(298,702,cs),
+(184,702,o),
+(140,548,o),
+(140,445,cs),
+(140,417,o),
+(143,390,o),
+(149,361,cs),
+(220,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(207,366,o),
+(187,396,o),
+(187,449,cs),
+(187,513,o),
+(216,656,o),
+(295,656,cs),
+(332,656,o),
+(352,626,o),
+(352,572,cs),
+(352,508,o),
+(324,366,o),
+(244,366,cs)
+);
+}
+);
+width = 577;
+}
+);
+metricRight = "e-canadian";
+note = uni1553;
+unicode = 5459;
+},
+{
+glyphname = "faai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (166,0);
+ref = ring_top.canadian;
+}
+);
+width = 577;
+}
+);
+note = uni1554;
+unicode = 5460;
+},
+{
+glyphname = "fi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (377,690);
+},
+{
+name = top_left_can;
+pos = (205,690);
+},
+{
+name = top_right_can;
+pos = (573,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(288,-13,o),
+(326,147,o),
+(326,232,cs),
+(326,315,o),
+(291,366,o),
+(230,366,cs),
+(208,366,o),
+(182,355,o),
+(159,332,c),
+(192,334,l),
+(372,620,l),
+(356,620,l),
+(456,0,l),
+(498,0,l),
+(502,19,l),
+(388,690,l),
+(364,690,l),
+(136,335,ls),
+(96,272,o),
+(68,196,o),
+(68,116,cs),
+(68,37,o),
+(104,-13,o),
+(169,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(135,34,o),
+(116,64,o),
+(116,118,cs),
+(116,182,o),
+(145,324,o),
+(223,324,cs),
+(263,324,o),
+(278,292,o),
+(278,235,cs),
+(278,169,o),
+(249,34,o),
+(173,34,cs)
+);
+}
+);
+width = 575;
+}
+);
+metricLeft = "fe-canadian";
+metricRight = "e-canadian";
+note = uni1555;
+unicode = 5461;
+},
+{
+glyphname = "fii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (222,0);
+ref = dot_top;
+}
+);
+width = 577;
+}
+);
+note = uni1556;
+unicode = 5462;
+},
+{
+glyphname = "fo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (265,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(39,0,l),
+(509,332,l),
+(515,357,l),
+(346,647,ls),
+(327,678,o),
+(303,702,o),
+(258,702,cs),
+(153,702,o),
+(106,559,o),
+(100,469,cs),
+(94,379,o),
+(131,321,o),
+(198,321,cs),
+(298,321,o),
+(347,457,o),
+(353,546,cs),
+(355,578,o),
+(351,606,o),
+(347,625,c),
+(325,588,l),
+(470,340,l),
+(476,368,l),
+(34,56,l),
+(21,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(164,367,o),
+(146,401,o),
+(149,464,cs),
+(152,533,o),
+(180,657,o),
+(254,657,cs),
+(294,657,o),
+(312,623,o),
+(309,559,cs),
+(306,491,o),
+(279,367,o),
+(204,367,cs)
+);
+}
+);
+width = 520;
+}
+);
+metricRight = "o-canadian";
+note = uni1557;
+unicode = 5463;
+},
+{
+glyphname = "foo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "fo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (109,0);
+ref = dot_top;
+}
+);
+width = 520;
+}
+);
+note = uni1558;
+unicode = 5464;
+},
+{
+glyphname = "fa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (448,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(398,0,l),
+(408,46,l),
+(102,355,l),
+(99,334,l),
+(346,588,l),
+(331,632,l),
+(293,569,o),
+(279,498,o),
+(279,450,cs),
+(279,369,o),
+(317,320,o),
+(383,320,cs),
+(493,320,o),
+(538,482,o),
+(538,569,cs),
+(538,655,o),
+(498,702,o),
+(439,702,cs),
+(403,702,o),
+(372,687,o),
+(341,654,cs),
+(56,357,l),
+(51,332,l),
+(381,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(345,366,o),
+(326,395,o),
+(326,449,cs),
+(326,513,o),
+(354,656,o),
+(433,656,cs),
+(470,656,o),
+(490,626,o),
+(490,573,cs),
+(490,509,o),
+(462,366,o),
+(383,366,cs)
+);
+}
+);
+width = 522;
+}
+);
+metricRight = "=|fo-canadian";
+note = uni1559;
+unicode = 5465;
+},
+{
+glyphname = "faa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (293,0);
+ref = dot_top;
+}
+);
+width = 520;
+}
+);
+note = uni155A;
+unicode = 5466;
+},
+{
+glyphname = "fwaa-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (463,0);
+ref = dot_top;
+}
+);
+width = 689;
+}
+);
+note = uni155B;
+unicode = 5467;
+},
+{
+glyphname = "fwaaWestCree-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (293,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (520,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 689;
+}
+);
+note = uni155C;
+unicode = 5468;
+},
+{
+glyphname = "f-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(271,345,l),
+(277,376,l),
+(132,524,l),
+(132,515,l),
+(245,631,l),
+(243,663,l),
+(227,638,o),
+(214,596,o),
+(214,567,cs),
+(214,529,o),
+(234,504,o),
+(265,504,cs),
+(320,504,o),
+(341,584,o),
+(341,631,cs),
+(341,671,o),
+(325,696,o),
+(293,696,cs),
+(275,696,o),
+(261,689,o),
+(243,671,cs),
+(101,526,l),
+(98,509,l),
+(262,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(249,531,o),
+(242,545,o),
+(242,568,cs),
+(242,593,o),
+(252,668,o),
+(289,668,cs),
+(304,668,o),
+(313,656,o),
+(313,633,cs),
+(313,608,o),
+(301,531,o),
+(266,531,cs)
+);
+}
+);
+width = 308;
+}
+);
+note = uni155D;
+unicode = 5469;
+},
+{
+glyphname = "the-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (605,345);
+},
+{
+name = top_center_can;
+pos = (372,690);
+},
+{
+name = top_left_can;
+pos = (185,690);
+},
+{
+name = top_right_can;
+pos = (557,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(379,-13,o),
+(454,58,o),
+(487,213,cs),
+(589,690,l),
+(527,690,l),
+(428,219,ls),
+(402,99,o),
+(347,45,o),
+(253,45,cs),
+(114,45,o),
+(99,137,o),
+(122,248,cs),
+(163,439,l),
+(132,426,l),
+(130,374,o),
+(156,320,o),
+(214,320,cs),
+(324,320,o),
+(366,468,o),
+(374,554,cs),
+(381,644,o),
+(345,702,o),
+(272,702,cs),
+(196,702,o),
+(144,637,o),
+(119,518,cs),
+(63,250,ls),
+(32,102,o),
+(78,-13,o),
+(250,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(182,367,o),
+(162,396,o),
+(162,450,cs),
+(162,514,o),
+(190,656,o),
+(270,656,cs),
+(306,656,o),
+(326,626,o),
+(326,573,cs),
+(326,509,o),
+(298,367,o),
+(219,367,cs)
+);
+}
+);
+width = 551;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155E;
+unicode = 5470;
+},
+{
+glyphname = "theNCree-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(380,-13,o),
+(454,60,o),
+(489,219,cs),
+(548,497,ls),
+(577,631,o),
+(530,702,o),
+(457,702,cs),
+(343,702,o),
+(299,548,o),
+(299,450,cs),
+(299,373,o),
+(337,320,o),
+(400,320,cs),
+(443,320,o),
+(485,354,o),
+(505,407,c),
+(471,423,l),
+(430,226,ls),
+(403,99,o),
+(350,44,o),
+(252,44,cs),
+(135,44,o),
+(94,110,o),
+(122,242,cs),
+(217,690,l),
+(156,690,l),
+(61,244,ls),
+(27,82,o),
+(96,-13,o),
+(249,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(367,367,o),
+(348,396,o),
+(348,450,cs),
+(348,514,o),
+(376,656,o),
+(453,656,cs),
+(489,656,o),
+(508,626,o),
+(508,573,cs),
+(508,509,o),
+(480,367,o),
+(403,367,cs)
+);
+}
+);
+width = 552;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155F;
+unicode = 5471;
+},
+{
+glyphname = "thi-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (370,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(254,-13,o),
+(298,142,o),
+(298,240,cs),
+(298,317,o),
+(261,370,o),
+(198,370,cs),
+(155,370,o),
+(113,336,o),
+(93,283,c),
+(126,267,l),
+(168,464,ls),
+(195,591,o),
+(248,645,o),
+(346,645,cs),
+(463,645,o),
+(504,580,o),
+(476,448,cs),
+(381,0,l),
+(442,0,l),
+(536,445,ls),
+(571,608,o),
+(502,702,o),
+(349,702,cs),
+(218,702,o),
+(144,630,o),
+(109,470,cs),
+(50,193,ls),
+(21,59,o),
+(68,-13,o),
+(141,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(108,34,o),
+(90,64,o),
+(90,117,cs),
+(90,181,o),
+(117,323,o),
+(194,323,cs),
+(231,323,o),
+(250,294,o),
+(250,240,cs),
+(250,176,o),
+(222,34,o),
+(144,34,cs)
+);
+}
+);
+width = 551;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1560;
+unicode = 5472;
+},
+{
+glyphname = "thiNCree-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (370,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(401,-13,o),
+(454,53,o),
+(479,172,cs),
+(535,440,ls),
+(566,587,o),
+(520,702,o),
+(348,702,cs),
+(219,702,o),
+(143,632,o),
+(110,477,cs),
+(9,0,l),
+(71,0,l),
+(170,470,ls),
+(196,590,o),
+(251,644,o),
+(345,644,cs),
+(484,644,o),
+(499,553,o),
+(476,441,cs),
+(435,251,l),
+(465,264,l),
+(467,316,o),
+(441,370,o),
+(384,370,cs),
+(273,370,o),
+(232,222,o),
+(224,136,cs),
+(217,45,o),
+(253,-13,o),
+(326,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(291,34,o),
+(272,64,o),
+(272,117,cs),
+(272,181,o),
+(300,323,o),
+(379,323,cs),
+(416,323,o),
+(436,294,o),
+(436,240,cs),
+(436,176,o),
+(408,34,o),
+(328,34,cs)
+);
+}
+);
+width = 552;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1561;
+unicode = 5473;
+},
+{
+glyphname = "thii-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "thi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (214,0);
+ref = dot_top;
+}
+);
+width = 552;
+}
+);
+note = uni1562;
+unicode = 5474;
+},
+{
+glyphname = "thiiNCree-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "thiNCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (214,0);
+ref = dot_top;
+}
+);
+width = 552;
+}
+);
+note = uni1563;
+unicode = 5475;
+},
+{
+glyphname = "tho-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (331,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(153,0,ls),
+(423,0,o),
+(493,301,o),
+(493,461,cs),
+(493,610,o),
+(430,702,o),
+(316,702,cs),
+(162,702,o),
+(106,540,o),
+(106,429,cs),
+(106,347,o),
+(142,296,o),
+(205,296,cs),
+(318,296,o),
+(356,455,o),
+(356,541,cs),
+(356,612,o),
+(329,659,o),
+(277,666,c),
+(265,648,l),
+(267,655,o),
+(282,660,o),
+(306,660,cs),
+(391,660,o),
+(435,592,o),
+(435,473,cs),
+(435,349,o),
+(386,57,o),
+(156,57,cs),
+(46,57,l),
+(34,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(175,341,o),
+(156,371,o),
+(156,425,cs),
+(156,482,o),
+(183,637,o),
+(260,637,cs),
+(297,637,o),
+(316,606,o),
+(316,553,cs),
+(316,497,o),
+(290,341,o),
+(212,341,cs)
+);
+}
+);
+width = 507;
+}
+);
+metricRight = "to-canadian";
+note = uni1564;
+unicode = 5476;
+},
+{
+glyphname = "thoo-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "tho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (177,0);
+ref = dot_top;
+}
+);
+width = 507;
+}
+);
+note = uni1565;
+unicode = 5477;
+},
+{
+glyphname = "tha-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (372,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(374,0,l),
+(385,57,l),
+(286,57,ls),
+(178,57,o),
+(121,118,o),
+(121,238,cs),
+(121,370,o),
+(190,661,o),
+(358,661,cs),
+(385,661,o),
+(411,652,o),
+(427,636,c),
+(404,664,l),
+(294,673,o),
+(254,509,o),
+(254,426,cs),
+(254,346,o),
+(289,296,o),
+(351,296,cs),
+(456,296,o),
+(506,441,o),
+(506,538,cs),
+(506,641,o),
+(450,701,o),
+(356,701,cs),
+(147,701,o),
+(61,399,o),
+(61,238,cs),
+(61,87,o),
+(139,0,o),
+(274,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(317,341,o),
+(298,371,o),
+(298,425,cs),
+(298,482,o),
+(325,637,o),
+(403,637,cs),
+(439,637,o),
+(458,606,o),
+(458,553,cs),
+(458,497,o),
+(432,341,o),
+(354,341,cs)
+);
+}
+);
+width = 506;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tho-canadian";
+note = uni1566;
+unicode = 5478;
+},
+{
+glyphname = "thaa-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (217,0);
+ref = dot_top;
+}
+);
+width = 507;
+}
+);
+note = uni1567;
+unicode = 5479;
+},
+{
+glyphname = "thwaa-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (386,0);
+ref = dot_top;
+}
+);
+width = 676;
+}
+);
+note = uni1568;
+unicode = 5480;
+},
+{
+glyphname = "thwaaWestCree-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (217,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (507,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 676;
+}
+);
+note = uni1569;
+unicode = 5481;
+},
+{
+glyphname = "th-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(262,345,l),
+(270,384,l),
+(221,384,ls),
+(169,384,o),
+(142,412,o),
+(142,469,cs),
+(142,529,o),
+(176,666,o),
+(256,666,cs),
+(268,666,o),
+(278,663,o),
+(289,656,c),
+(273,672,l),
+(217,674,o),
+(199,590,o),
+(199,554,cs),
+(199,516,o),
+(217,492,o),
+(248,492,cs),
+(308,492,o),
+(327,579,o),
+(327,618,cs),
+(327,668,o),
+(302,696,o),
+(254,696,cs),
+(145,696,o),
+(103,543,o),
+(103,469,cs),
+(103,391,o),
+(144,345,o),
+(213,345,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(233,518,o),
+(224,529,o),
+(224,553,cs),
+(224,581,o),
+(236,655,o),
+(274,655,cs),
+(291,655,o),
+(299,643,o),
+(299,620,cs),
+(299,592,o),
+(287,518,o),
+(248,518,cs)
+);
+}
+);
+width = 296;
+}
+);
+metricLeft = "t-canadian";
+note = uni156A;
+unicode = 5482;
+},
+{
+glyphname = "tthe-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (598,345);
+},
+{
+name = top_center_can;
+pos = (368,690);
+},
+{
+name = top_left_can;
+pos = (187,690);
+},
+{
+name = top_right_can;
+pos = (551,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(372,-13,o),
+(448,60,o),
+(480,212,cs),
+(582,690,l),
+(525,690,l),
+(425,219,ls),
+(399,99,o),
+(345,45,o),
+(250,45,cs),
+(132,45,o),
+(90,110,o),
+(118,242,cs),
+(213,690,l),
+(156,690,l),
+(61,244,ls),
+(27,82,o),
+(96,-13,o),
+(247,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(328,391,l),
+(392,690,l),
+(345,690,l),
+(281,391,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156B;
+unicode = 5483;
+},
+{
+glyphname = "tthi-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(67,0,l),
+(166,470,ls),
+(192,591,o),
+(246,644,o),
+(340,644,cs),
+(459,644,o),
+(501,580,o),
+(473,448,cs),
+(378,0,l),
+(435,0,l),
+(529,445,ls),
+(564,608,o),
+(496,702,o),
+(344,702,cs),
+(219,702,o),
+(143,630,o),
+(111,478,cs),
+(9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(246,0,l),
+(309,298,l),
+(263,298,l),
+(199,0,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156C;
+unicode = 5484;
+},
+{
+glyphname = "ttho-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (318,690);
+},
+{
+name = top_left_can;
+pos = (185,690);
+},
+{
+name = top_right_can;
+pos = (492,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(108,0,ls),
+(388,0,o),
+(459,295,o),
+(459,458,cs),
+(459,611,o),
+(379,690,o),
+(228,690,cs),
+(158,690,l),
+(147,633,l),
+(216,633,ls),
+(338,633,o),
+(397,577,o),
+(397,457,cs),
+(397,325,o),
+(341,57,o),
+(111,57,cs),
+(24,57,l),
+(13,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(251,319,l),
+(262,371,l),
+(91,371,l),
+(80,319,l)
+);
+}
+);
+width = 473;
+}
+);
+metricRight = "to-canadian";
+note = uni156D;
+unicode = 5485;
+},
+{
+glyphname = "ttha-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (335,690);
+},
+{
+name = top_left_can;
+pos = (174,690);
+},
+{
+name = top_right_can;
+pos = (474,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(361,0,l),
+(373,57,l),
+(300,57,ls),
+(179,57,o),
+(123,113,o),
+(123,233,cs),
+(123,369,o),
+(179,633,o),
+(406,633,cs),
+(496,633,l),
+(508,690,l),
+(409,690,ls),
+(132,690,o),
+(61,399,o),
+(61,231,cs),
+(61,78,o),
+(138,0,o),
+(289,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(425,319,l),
+(437,371,l),
+(267,371,l),
+(255,319,l)
+);
+}
+);
+width = 473;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|ttho-canadian";
+note = uni156E;
+unicode = 5486;
+},
+{
+glyphname = "tth-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(234,505,l),
+(219,505,l),
+(276,388,l),
+(311,405,l),
+(251,526,l),
+(244,512,l),
+(368,564,l),
+(355,598,l),
+(238,548,l),
+(251,542,l),
+(283,690,l),
+(244,690,l),
+(212,541,l),
+(229,547,l),
+(127,598,l),
+(111,564,l),
+(210,515,l),
+(208,529,l),
+(101,412,l),
+(129,388,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(540,505,l),
+(526,505,l),
+(582,388,l),
+(616,405,l),
+(557,526,l),
+(551,512,l),
+(674,564,l),
+(661,597,l),
+(543,548,l),
+(557,542,l),
+(589,690,l),
+(551,690,l),
+(518,541,l),
+(535,547,l),
+(433,599,l),
+(416,565,l),
+(516,515,l),
+(513,529,l),
+(408,412,l),
+(435,388,l)
+);
+}
+);
+width = 645;
+}
+);
+metricRight = "=|";
+note = uni156F;
+unicode = 5487;
+},
+{
+glyphname = "tye-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(372,-13,o),
+(448,60,o),
+(480,212,cs),
+(582,690,l),
+(525,690,l),
+(424,219,ls),
+(399,99,o),
+(345,45,o),
+(250,45,cs),
+(132,45,o),
+(90,110,o),
+(118,242,cs),
+(213,690,l),
+(156,690,l),
+(61,244,ls),
+(27,82,o),
+(96,-13,o),
+(247,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(373,412,o),
+(403,443,o),
+(419,518,cs),
+(456,690,l),
+(423,690,l),
+(388,524,ls),
+(377,468,o),
+(356,445,o),
+(318,445,cs),
+(280,445,o),
+(268,467,o),
+(278,518,cs),
+(314,690,l),
+(282,690,l),
+(245,515,ls),
+(231,449,o),
+(258,412,o),
+(318,412,cs)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1570;
+unicode = 5488;
+},
+{
+glyphname = "tyi-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(67,0,l),
+(166,470,ls),
+(192,591,o),
+(246,644,o),
+(340,644,cs),
+(459,644,o),
+(501,580,o),
+(473,448,cs),
+(378,0,l),
+(435,0,l),
+(529,445,ls),
+(564,608,o),
+(496,702,o),
+(344,702,cs),
+(219,702,o),
+(143,630,o),
+(110,478,cs),
+(9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(167,0,l),
+(203,166,ls),
+(214,222,o),
+(235,244,o),
+(273,244,cs),
+(311,244,o),
+(324,223,o),
+(313,172,cs),
+(276,0,l),
+(309,0,l),
+(346,175,ls),
+(359,241,o),
+(333,278,o),
+(273,278,cs),
+(218,278,o),
+(188,246,o),
+(172,172,cs),
+(135,0,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1571;
+unicode = 5489;
+},
+{
+glyphname = "tyo-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(105,0,ls),
+(387,0,o),
+(459,295,o),
+(459,458,cs),
+(459,611,o),
+(377,690,o),
+(225,690,cs),
+(159,690,l),
+(148,634,l),
+(213,634,ls),
+(336,634,o),
+(398,577,o),
+(398,457,cs),
+(398,304,o),
+(321,56,o),
+(107,56,cs),
+(24,56,l),
+(13,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(100,210,ls),
+(219,210,o),
+(252,294,o),
+(256,366,cs),
+(261,440,o),
+(222,480,o),
+(155,480,cs),
+(114,480,l),
+(106,443,l),
+(148,443,ls),
+(196,443,o),
+(220,417,o),
+(219,369,cs),
+(217,317,o),
+(197,246,o),
+(105,246,cs),
+(65,246,l),
+(57,210,l)
+);
+}
+);
+width = 473;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1572;
+unicode = 5490;
+},
+{
+glyphname = "tya-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(360,0,l),
+(372,56,l),
+(305,56,ls),
+(183,56,o),
+(122,113,o),
+(122,233,cs),
+(122,385,o),
+(199,634,o),
+(411,634,cs),
+(495,634,l),
+(506,690,l),
+(414,690,ls),
+(132,690,o),
+(60,395,o),
+(60,232,cs),
+(60,78,o),
+(143,0,o),
+(295,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(405,210,l),
+(413,246,l),
+(372,246,ls),
+(324,246,o),
+(298,272,o),
+(300,321,cs),
+(301,373,o),
+(322,443,o),
+(413,443,cs),
+(455,443,l),
+(463,480,l),
+(419,480,ls),
+(299,480,o),
+(268,396,o),
+(264,324,cs),
+(259,250,o),
+(297,210,o),
+(364,210,cs)
+);
+}
+);
+width = 473;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1573;
+unicode = 5491;
+},
+{
+glyphname = "heNunavik-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(333,0,l),
+(551,190,l),
+(517,233,l),
+(335,73,l),
+(354,60,l),
+(434,439,ls),
+(461,565,o),
+(445,702,o),
+(305,702,cs),
+(139,702,o),
+(92,483,o),
+(92,368,cs),
+(92,264,o),
+(136,205,o),
+(221,205,cs),
+(284,205,o),
+(328,241,o),
+(359,319,c),
+(348,323,l),
+(279,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(180,259,o),
+(151,297,o),
+(151,370,cs),
+(151,449,o),
+(185,648,o),
+(300,648,cs),
+(357,648,o),
+(386,611,o),
+(386,538,cs),
+(386,460,o),
+(353,259,o),
+(236,259,cs)
+);
+}
+);
+width = 583;
+}
+);
+metricLeft = "ke-canadian";
+note = uni1574;
+unicode = 5492;
+},
+{
+glyphname = "hiNunavik-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (455,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(203,0,l),
+(279,360,l),
+(264,323,l),
+(264,253,o),
+(304,205,o),
+(376,205,cs),
+(535,205,o),
+(582,426,o),
+(582,536,cs),
+(582,643,o),
+(535,702,o),
+(443,702,cs),
+(342,702,o),
+(274,625,o),
+(241,471,cs),
+(154,57,l),
+(173,61,l),
+(56,225,l),
+(12,190,l),
+(149,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(318,259,o),
+(289,297,o),
+(289,369,cs),
+(289,448,o),
+(325,648,o),
+(439,648,cs),
+(496,648,o),
+(524,611,o),
+(524,538,cs),
+(524,456,o),
+(489,259,o),
+(375,259,cs)
+);
+}
+);
+width = 581;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1575;
+unicode = 5493;
+},
+{
+glyphname = "hiiNunavik-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "hiNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (300,0);
+ref = dot_top;
+}
+);
+width = 583;
+}
+);
+note = uni1576;
+unicode = 5494;
+},
+{
+glyphname = "hoNunavik-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (317,690);
+},
+{
+name = top_right_can;
+pos = (456,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(287,-13,o),
+(356,65,o),
+(387,218,cs),
+(475,633,l),
+(456,629,l),
+(573,465,l),
+(618,499,l),
+(480,690,l),
+(427,690,l),
+(350,329,l),
+(366,367,l),
+(366,437,o),
+(325,485,o),
+(254,485,cs),
+(94,485,o),
+(46,264,o),
+(46,154,cs),
+(46,46,o),
+(94,-13,o),
+(186,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(133,42,o),
+(105,78,o),
+(105,152,cs),
+(105,234,o),
+(140,431,o),
+(254,431,cs),
+(311,431,o),
+(340,393,o),
+(340,321,cs),
+(340,242,o),
+(304,42,o),
+(189,42,cs)
+);
+}
+);
+width = 584;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "heNunavik-canadian";
+note = uni1577;
+unicode = 5495;
+},
+{
+glyphname = "hooNunavik-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "hoNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (299,0);
+ref = dot_top;
+}
+);
+width = 583;
+}
+);
+note = uni1578;
+unicode = 5496;
+},
+{
+glyphname = "haNunavik-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (458,690);
+},
+{
+name = top_left_can;
+pos = (319,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(491,-13,o),
+(538,207,o),
+(538,322,cs),
+(538,426,o),
+(494,485,o),
+(408,485,cs),
+(346,485,o),
+(300,449,o),
+(269,371,c),
+(281,367,l),
+(351,690,l),
+(296,690,l),
+(78,499,l),
+(113,457,l),
+(295,616,l),
+(276,630,l),
+(196,251,ls),
+(169,125,o),
+(184,-13,o),
+(324,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(272,42,o),
+(243,79,o),
+(243,152,cs),
+(243,230,o),
+(277,431,o),
+(393,431,cs),
+(450,431,o),
+(479,393,o),
+(479,320,cs),
+(479,241,o),
+(444,42,o),
+(328,42,cs)
+);
+}
+);
+width = 583;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1579;
+unicode = 5497;
+},
+{
+glyphname = "haaNunavik-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "haNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (163,0);
+ref = dot_top;
+}
+);
+width = 583;
+}
+);
+note = uni157A;
+unicode = 5498;
+},
+{
+glyphname = "hNunavik-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(327,339,o),
+(357,459,o),
+(357,514,cs),
+(357,568,o),
+(333,601,o),
+(291,601,cs),
+(259,601,o),
+(236,584,o),
+(217,553,c),
+(224,541,l),
+(255,690,l),
+(216,690,l),
+(107,595,l),
+(130,569,l),
+(224,651,l),
+(210,673,l),
+(168,478,ls),
+(155,415,o),
+(166,339,o),
+(238,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(215,375,o),
+(202,393,o),
+(202,430,cs),
+(202,486,o),
+(226,565,o),
+(277,565,cs),
+(304,565,o),
+(318,547,o),
+(318,511,cs),
+(318,455,o),
+(294,375,o),
+(242,375,cs)
+);
+}
+);
+width = 343;
+}
+);
+metricRight = "k-canadian";
+note = uni157B;
+unicode = 5499;
+},
+{
+color = 4;
+glyphname = "nunavuth-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(73,0,l),
+(144,330,l),
+(415,330,l),
+(345,0,l),
+(406,0,l),
+(553,690,l),
+(492,690,l),
+(427,386,l),
+(156,386,l),
+(220,690,l),
+(159,690,l),
+(13,0,l)
+);
+}
+);
+width = 518;
+}
+);
+metricRight = "=|";
+note = uni157C;
+unicode = 5500;
+},
+{
+glyphname = "hk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (73,345);
+ref = "fullstop-canadian";
+}
+);
+width = 281;
+}
+);
+metricLeft = "fullstop-canadian";
+note = uni157D;
+unicode = 5501;
+},
+{
+glyphname = "qaai-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (243,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (357,0);
+ref = ring_top.canadian;
+}
+);
+width = 694;
+}
+);
+note = uni157E;
+unicode = 5502;
+},
+{
+glyphname = "qi-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (243,0);
+ref = "ki-canadian";
+}
+);
+width = 694;
+}
+);
+note = uni157F;
+unicode = 5503;
+},
+{
+glyphname = "qii-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (243,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (412,0);
+ref = dot_top;
+}
+);
+width = 694;
+}
+);
+note = uni1580;
+unicode = 5504;
+},
+{
+glyphname = "qo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (243,0);
+ref = "ko-canadian";
+}
+);
+width = 694;
+}
+);
+note = uni1581;
+unicode = 5505;
+},
+{
+glyphname = "qoo-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (243,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (545,0);
+ref = dot_top;
+}
+);
+width = 694;
+}
+);
+note = uni1582;
+unicode = 5506;
+},
+{
+glyphname = "qa-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (243,0);
+ref = "ka-canadian";
+}
+);
+width = 694;
+}
+);
+note = uni1583;
+unicode = 5507;
+},
+{
+glyphname = "qaa-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (243,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (273,0);
+ref = dot_top;
+}
+);
+width = 694;
+}
+);
+note = uni1584;
+unicode = 5508;
+},
+{
+glyphname = "q-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (243,0);
+ref = "k-canadian";
+}
+);
+width = 522;
+}
+);
+note = uni1585;
+unicode = 5509;
+},
+{
+glyphname = "tlhe-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (323,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(91,0,l),
+(247,267,l),
+(202,242,l),
+(210,241,o),
+(218,241,o),
+(226,241,cs),
+(283,241,o),
+(327,269,o),
+(362,329,c),
+(356,345,l),
+(283,0,l),
+(344,0,l),
+(441,458,ls),
+(466,571,o),
+(451,702,o),
+(312,702,cs),
+(155,702,o),
+(101,519,o),
+(101,403,cs),
+(101,328,o),
+(129,277,o),
+(181,259,c),
+(26,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(187,295,o),
+(159,331,o),
+(159,405,cs),
+(159,477,o),
+(191,648,o),
+(306,648,cs),
+(364,648,o),
+(390,610,o),
+(390,542,cs),
+(390,468,o),
+(358,295,o),
+(245,295,cs)
+);
+}
+);
+width = 453;
+}
+);
+metricRight = "te-canadian";
+note = uni1586;
+unicode = 5510;
+},
+{
+glyphname = "tlhi-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(70,0,l),
+(146,357,l),
+(127,349,l),
+(139,286,o),
+(179,246,o),
+(240,242,c),
+(220,256,l),
+(263,0,l),
+(327,0,l),
+(284,251,l),
+(411,269,o),
+(454,437,o),
+(454,534,cs),
+(454,639,o),
+(401,702,o),
+(309,702,cs),
+(218,702,o),
+(144,634,o),
+(112,485,cs),
+(9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(192,295,o),
+(163,334,o),
+(163,406,cs),
+(163,480,o),
+(198,648,o),
+(308,648,cs),
+(365,648,o),
+(394,609,o),
+(394,536,cs),
+(394,460,o),
+(362,295,o),
+(250,295,cs)
+);
+}
+);
+width = 456;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|tlhe-canadian";
+note = uni1587;
+unicode = 5511;
+},
+{
+glyphname = "tlho-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (336,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(283,-13,o),
+(357,56,o),
+(389,205,cs),
+(493,690,l),
+(432,690,l),
+(355,332,l),
+(375,341,l),
+(362,404,o),
+(323,443,o),
+(262,448,c),
+(281,434,l),
+(239,690,l),
+(175,690,l),
+(217,439,l),
+(91,421,o),
+(48,253,o),
+(48,156,cs),
+(48,51,o),
+(100,-13,o),
+(192,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(136,42,o),
+(108,81,o),
+(108,154,cs),
+(108,230,o),
+(139,395,o),
+(251,395,cs),
+(308,395,o),
+(338,355,o),
+(338,284,cs),
+(338,210,o),
+(303,42,o),
+(193,42,cs)
+);
+}
+);
+width = 455;
+}
+);
+metricLeft = "tlhe-canadian";
+metricRight = "te-canadian";
+note = uni1588;
+unicode = 5512;
+},
+{
+glyphname = "tlha-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(346,-13,o),
+(399,171,o),
+(399,287,cs),
+(399,361,o),
+(371,412,o),
+(320,431,c),
+(473,690,l),
+(410,690,l),
+(253,423,l),
+(298,447,l),
+(290,449,o),
+(282,449,o),
+(274,449,cs),
+(217,449,o),
+(173,421,o),
+(138,360,c),
+(144,345,l),
+(216,690,l),
+(156,690,l),
+(59,232,ls),
+(35,119,o),
+(49,-13,o),
+(188,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(136,42,o),
+(110,80,o),
+(110,148,cs),
+(110,222,o),
+(142,395,o),
+(255,395,cs),
+(313,395,o),
+(341,358,o),
+(341,285,cs),
+(341,213,o),
+(308,42,o),
+(194,42,cs)
+);
+}
+);
+width = 454;
+}
+);
+metricLeft = "te-canadian";
+note = uni1589;
+unicode = 5513;
+},
+{
+glyphname = "reWestCree-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(329,0,l),
+(547,191,l),
+(511,233,l),
+(331,71,l),
+(349,59,l),
+(437,474,ls),
+(468,619,o),
+(411,702,o),
+(300,702,cs),
+(196,702,o),
+(137,636,o),
+(105,487,cs),
+(85,391,l),
+(146,391,l),
+(168,496,ls),
+(191,602,o),
+(229,647,o),
+(294,647,cs),
+(368,647,o),
+(402,594,o),
+(379,485,cs),
+(275,0,l)
+);
+}
+);
+width = 579;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+unicode = 5514;
+},
+{
+glyphname = "riWestCree-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(202,0,l),
+(307,496,ls),
+(330,602,o),
+(368,647,o),
+(433,647,cs),
+(507,647,o),
+(541,594,o),
+(518,485,cs),
+(497,391,l),
+(558,391,l),
+(577,474,ls),
+(608,619,o),
+(550,702,o),
+(439,702,cs),
+(335,702,o),
+(276,636,o),
+(244,487,cs),
+(154,60,l),
+(173,63,l),
+(59,226,l),
+(12,191,l),
+(148,0,l)
+);
+}
+);
+width = 578;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+unicode = 5515;
+},
+{
+glyphname = "roWestCree-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(290,-13,o),
+(349,54,o),
+(381,203,cs),
+(471,630,l),
+(452,627,l),
+(567,464,l),
+(613,498,l),
+(477,690,l),
+(423,690,l),
+(318,194,ls),
+(295,88,o),
+(257,43,o),
+(192,43,cs),
+(118,43,o),
+(84,96,o),
+(107,205,cs),
+(128,298,l),
+(67,298,l),
+(48,215,ls),
+(17,71,o),
+(75,-13,o),
+(186,-13,cs)
+);
+}
+);
+width = 579;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+unicode = 5516;
+},
+{
+glyphname = "raWestCree-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(429,-13,o),
+(487,54,o),
+(519,203,cs),
+(540,298,l),
+(479,298,l),
+(457,194,ls),
+(434,88,o),
+(396,43,o),
+(331,43,cs),
+(257,43,o),
+(223,96,o),
+(246,205,cs),
+(350,690,l),
+(295,690,l),
+(78,498,l),
+(113,457,l),
+(294,618,l),
+(275,631,l),
+(187,215,ls),
+(157,71,o),
+(214,-13,o),
+(325,-13,cs)
+);
+}
+);
+width = 579;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+unicode = 5517;
+},
+{
+glyphname = "ngaai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (476,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (589,0);
+ref = ring_top.canadian;
+}
+);
+width = 922;
+}
+);
+note = uni158E;
+unicode = 5518;
+},
+{
+glyphname = "ngi-canadian";
+kernLeft = mwestleft;
+kernRight = ciright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (476,0);
+ref = "ci-canadian";
+}
+);
+width = 922;
+}
+);
+note = uni158F;
+unicode = 5519;
+},
+{
+glyphname = "ngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (476,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (645,0);
+ref = dot_top;
+}
+);
+width = 922;
+}
+);
+note = uni1590;
+unicode = 5520;
+},
+{
+glyphname = "ngo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:56:20 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (452,0);
+ref = "co-canadian";
+}
+);
+width = 899;
+}
+);
+note = uni1591;
+unicode = 5521;
+},
+{
+glyphname = "ngoo-canadian";
+lastChange = "2023-01-13 15:56:20 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "ngo-canadian";
+},
+{
+anchor = top_right_can;
+pos = (750,0);
+ref = dot_top;
+}
+);
+width = 899;
+}
+);
+note = uni1592;
+unicode = 5522;
+},
+{
+glyphname = "nga-canadian";
+kernLeft = mwestleft;
+kernRight = caright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (477,0);
+ref = "ca-canadian";
+}
+);
+width = 923;
+}
+);
+note = uni1593;
+unicode = 5523;
+},
+{
+glyphname = "ngaa-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (477,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (508,0);
+ref = dot_top;
+}
+);
+width = 923;
+}
+);
+note = uni1594;
+unicode = 5524;
+},
+{
+glyphname = "ng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(412,217,o),
+(449,257,o),
+(465,333,cs),
+(470,363,l),
+(430,363,l),
+(422,329,ls),
+(411,278,o),
+(391,255,o),
+(357,255,cs),
+(322,255,o),
+(308,280,o),
+(319,329,cs),
+(351,476,l),
+(237,476,l),
+(244,460,l),
+(279,484,o),
+(297,550,o),
+(298,591,cs),
+(302,655,o),
+(273,696,o),
+(220,696,cs),
+(143,696,o),
+(111,599,o),
+(107,538,cs),
+(102,471,o),
+(133,434,o),
+(188,434,cs),
+(318,434,l),
+(303,462,l),
+(277,338,ls),
+(262,265,o),
+(292,217,o),
+(354,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(158,469,o),
+(144,491,o),
+(146,533,cs),
+(148,576,o),
+(164,660,o),
+(218,660,cs),
+(246,660,o),
+(261,638,o),
+(259,596,cs),
+(257,554,o),
+(241,469,o),
+(185,469,cs)
+);
+}
+);
+width = 476;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1595;
+unicode = 5525;
+},
+{
+glyphname = "nng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(633,217,o),
+(670,257,o),
+(686,333,cs),
+(693,363,l),
+(652,363,l),
+(644,329,ls),
+(633,278,o),
+(612,255,o),
+(580,255,cs),
+(543,255,o),
+(529,280,o),
+(541,329,cs),
+(572,476,l),
+(463,476,l),
+(465,460,l),
+(501,487,o),
+(520,557,o),
+(520,600,cs),
+(520,659,o),
+(491,696,o),
+(440,696,cs),
+(357,696,o),
+(327,590,o),
+(327,527,cs),
+(327,499,o),
+(334,477,o),
+(348,462,c),
+(355,476,l),
+(243,476,l),
+(244,460,l),
+(283,487,o),
+(300,562,o),
+(300,599,cs),
+(300,658,o),
+(271,696,o),
+(221,696,cs),
+(137,696,o),
+(107,590,o),
+(107,527,cs),
+(107,468,o),
+(137,434,o),
+(189,434,cs),
+(519,434,l),
+(498,338,ls),
+(483,265,o),
+(513,217,o),
+(575,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(160,469,o),
+(146,489,o),
+(146,526,cs),
+(146,567,o),
+(163,660,o),
+(219,660,cs),
+(246,660,o),
+(261,640,o),
+(261,603,cs),
+(261,562,o),
+(244,469,o),
+(186,469,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(380,469,o),
+(366,489,o),
+(366,526,cs),
+(366,567,o),
+(383,660,o),
+(439,660,cs),
+(467,660,o),
+(480,640,o),
+(480,603,cs),
+(480,562,o),
+(464,469,o),
+(407,469,cs)
+);
+}
+);
+width = 698;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1596;
+unicode = 5526;
+},
+{
+glyphname = "sheSayisi-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (508,345);
+},
+{
+name = top_center_can;
+pos = (323,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(346,0,l),
+(440,446,ls),
+(474,609,o),
+(425,702,o),
+(313,702,cs),
+(140,702,o),
+(88,471,o),
+(88,350,cs),
+(88,259,o),
+(119,207,o),
+(185,207,cs),
+(254,207,o),
+(294,267,o),
+(320,411,c),
+(290,411,l),
+(270,303,o),
+(243,259,o),
+(200,259,cs),
+(163,259,o),
+(145,290,o),
+(145,348,cs),
+(145,435,o),
+(185,648,o),
+(307,648,cs),
+(381,648,o),
+(408,579,o),
+(380,445,cs),
+(284,0,l)
+);
+}
+);
+width = 455;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1597;
+unicode = 5527;
+},
+{
+glyphname = "shiSayisi-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(71,0,l),
+(169,463,ls),
+(196,588,o),
+(239,648,o),
+(306,648,cs),
+(367,648,o),
+(397,610,o),
+(397,532,cs),
+(397,463,o),
+(359,259,o),
+(279,259,cs),
+(230,259,o),
+(215,306,o),
+(240,411,c),
+(209,411,l),
+(179,276,o),
+(208,207,o),
+(286,207,cs),
+(407,207,o),
+(455,430,o),
+(455,529,cs),
+(455,639,o),
+(405,702,o),
+(310,702,cs),
+(209,702,o),
+(142,626,o),
+(110,475,cs),
+(9,0,l)
+);
+}
+);
+width = 455;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni1598;
+unicode = 5528;
+},
+{
+glyphname = "shoSayisi-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (321,690);
+},
+{
+name = top_left_can;
+pos = (179,690);
+},
+{
+name = top_right_can;
+pos = (463,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(294,-13,o),
+(359,64,o),
+(391,214,cs),
+(493,690,l),
+(432,690,l),
+(333,227,ls),
+(306,101,o),
+(263,42,o),
+(195,42,cs),
+(135,42,o),
+(104,80,o),
+(104,157,cs),
+(104,227,o),
+(143,431,o),
+(222,431,cs),
+(272,431,o),
+(287,384,o),
+(263,279,c),
+(293,279,l),
+(324,413,o),
+(295,483,o),
+(216,483,cs),
+(96,483,o),
+(46,260,o),
+(46,160,cs),
+(46,50,o),
+(98,-13,o),
+(192,-13,cs)
+);
+}
+);
+width = 455;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1599;
+unicode = 5529;
+},
+{
+glyphname = "shaSayisi-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(360,-13,o),
+(413,218,o),
+(413,340,cs),
+(413,431,o),
+(383,483,o),
+(316,483,cs),
+(247,483,o),
+(208,423,o),
+(181,279,c),
+(211,279,l),
+(231,386,o),
+(258,431,o),
+(301,431,cs),
+(338,431,o),
+(356,400,o),
+(356,342,cs),
+(356,255,o),
+(315,42,o),
+(194,42,cs),
+(121,42,o),
+(94,111,o),
+(122,244,cs),
+(216,690,l),
+(156,690,l),
+(61,243,ls),
+(26,81,o),
+(75,-13,o),
+(188,-13,cs)
+);
+}
+);
+width = 455;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni159A;
+unicode = 5530;
+},
+{
+glyphname = "theWoodScree-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(524,-13,o),
+(574,189,o),
+(574,300,cs),
+(574,411,o),
+(519,472,o),
+(418,472,cs),
+(107,472,l),
+(96,419,l),
+(349,419,l),
+(349,440,l),
+(246,403,o),
+(215,243,o),
+(215,160,cs),
+(215,52,o),
+(270,-13,o),
+(365,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(305,42,o),
+(274,81,o),
+(274,156,cs),
+(274,232,o),
+(303,419,o),
+(424,419,cs),
+(485,419,o),
+(515,380,o),
+(515,304,cs),
+(515,228,o),
+(487,42,o),
+(366,42,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(647,637,l),
+(659,690,l),
+(154,690,l),
+(142,637,l)
+);
+}
+);
+width = 626;
+}
+);
+note = uni159B;
+unicode = 5531;
+},
+{
+glyphname = "thiWoodScree-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(360,-13,o),
+(411,192,o),
+(411,300,cs),
+(411,358,o),
+(394,400,o),
+(361,425,c),
+(357,419,l),
+(611,419,l),
+(621,472,l),
+(279,472,ls),
+(94,472,o),
+(52,269,o),
+(52,160,cs),
+(52,52,o),
+(104,-13,o),
+(201,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(141,42,o),
+(111,81,o),
+(111,156,cs),
+(111,232,o),
+(139,419,o),
+(261,419,cs),
+(321,419,o),
+(352,380,o),
+(352,304,cs),
+(352,228,o),
+(323,42,o),
+(203,42,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(657,637,l),
+(669,690,l),
+(164,690,l),
+(153,637,l)
+);
+}
+);
+width = 628;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159C;
+unicode = 5532;
+},
+{
+glyphname = "thoWoodScree-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(349,0,ls),
+(535,0,o),
+(577,204,o),
+(577,312,cs),
+(577,420,o),
+(524,485,o),
+(427,485,cs),
+(268,485,o),
+(218,280,o),
+(218,172,cs),
+(218,114,o),
+(234,72,o),
+(268,47,c),
+(270,53,l),
+(18,53,l),
+(7,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(307,53,o),
+(277,93,o),
+(277,168,cs),
+(277,245,o),
+(305,431,o),
+(426,431,cs),
+(487,431,o),
+(518,391,o),
+(518,316,cs),
+(518,241,o),
+(490,53,o),
+(368,53,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(647,637,l),
+(659,690,l),
+(154,690,l),
+(142,637,l)
+);
+}
+);
+width = 627;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159D;
+unicode = 5533;
+},
+{
+glyphname = "thaWoodScree-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(521,0,l),
+(531,53,l),
+(279,53,l),
+(279,32,l),
+(381,71,o),
+(412,229,o),
+(412,312,cs),
+(412,420,o),
+(358,485,o),
+(263,485,cs),
+(104,485,o),
+(53,283,o),
+(53,172,cs),
+(53,62,o),
+(109,0,o),
+(209,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(142,53,o),
+(112,93,o),
+(112,168,cs),
+(112,245,o),
+(141,431,o),
+(261,431,cs),
+(323,431,o),
+(353,391,o),
+(353,316,cs),
+(353,241,o),
+(325,53,o),
+(203,53,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(655,637,l),
+(667,690,l),
+(161,690,l),
+(150,637,l)
+);
+}
+);
+width = 627;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159E;
+unicode = 5534;
+},
+{
+glyphname = "thWoodScree-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(355,345,l),
+(363,384,l),
+(222,384,l),
+(219,362,l),
+(271,383,o),
+(292,465,o),
+(292,510,cs),
+(292,570,o),
+(263,607,o),
+(213,607,cs),
+(129,607,o),
+(99,500,o),
+(99,439,cs),
+(99,379,o),
+(129,345,o),
+(182,345,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(153,380,o),
+(138,400,o),
+(138,438,cs),
+(138,478,o),
+(155,571,o),
+(211,571,cs),
+(239,571,o),
+(253,551,o),
+(253,513,cs),
+(253,473,o),
+(237,380,o),
+(179,380,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(421,676,l),
+(430,717,l),
+(156,717,l),
+(148,676,l)
+);
+}
+);
+width = 383;
+}
+);
+metricRight = "=|";
+note = uni159F;
+unicode = 5535;
+},
+{
+glyphname = "lhi-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (450,690);
+},
+{
+name = top_right_can;
+pos = (520,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(225,0,l),
+(237,55,l),
+(229,55,ls),
+(154,55,o),
+(110,106,o),
+(110,188,cs),
+(110,283,o),
+(161,416,o),
+(310,416,cs),
+(604,416,l),
+(615,467,l),
+(537,722,l),
+(480,703,l),
+(559,444,l),
+(581,472,l),
+(314,472,ls),
+(130,472,o),
+(49,326,o),
+(49,187,cs),
+(49,75,o),
+(114,0,o),
+(215,0,cs)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A0;
+unicode = 5536;
+},
+{
+glyphname = "lhii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "lhi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (295,0);
+ref = dot_top;
+}
+);
+width = 615;
+}
+);
+note = uni15A1;
+unicode = 5537;
+},
+{
+glyphname = "lho-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (355,490);
+},
+{
+name = top_right_can;
+pos = (439,490);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(135,-231,l),
+(56,27,l),
+(35,-1,l),
+(300,-1,ls),
+(485,-1,o),
+(566,147,o),
+(566,284,cs),
+(566,396,o),
+(501,471,o),
+(400,471,cs),
+(390,471,l),
+(379,416,l),
+(386,416,ls),
+(461,416,o),
+(505,366,o),
+(505,284,cs),
+(505,188,o),
+(454,56,o),
+(305,56,cs),
+(12,56,l),
+(0,5,l),
+(78,-249,l)
+);
+}
+);
+width = 616;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni15A2;
+unicode = 5538;
+},
+{
+glyphname = "lhoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "lho-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (283,-200);
+ref = dot_top;
+}
+);
+width = 615;
+}
+);
+note = uni15A3;
+unicode = 5539;
+},
+{
+glyphname = "lha-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (371,490);
+},
+{
+name = top_left_can;
+pos = (285,490);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(517,6,l),
+(527,56,l),
+(247,56,ls),
+(158,56,o),
+(110,103,o),
+(110,188,cs),
+(110,277,o),
+(150,417,o),
+(305,417,cs),
+(314,417,l),
+(326,472,l),
+(311,472,ls),
+(120,472,o),
+(50,317,o),
+(50,186,cs),
+(50,71,o),
+(118,0,o),
+(236,0,cs),
+(476,0,l),
+(461,25,l),
+(284,-215,l),
+(329,-249,l)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A4;
+unicode = 5540;
+},
+{
+glyphname = "lhaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "lha-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (129,-200);
+ref = dot_top;
+}
+);
+width = 615;
+}
+);
+note = uni15A5;
+unicode = 5541;
+},
+{
+glyphname = "lh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(358,349,l),
+(367,387,l),
+(232,387,ls),
+(177,387,o),
+(149,417,o),
+(149,474,cs),
+(149,547,o),
+(179,647,o),
+(285,647,cs),
+(288,647,l),
+(298,690,l),
+(293,690,ls),
+(151,690,o),
+(105,570,o),
+(105,472,cs),
+(105,390,o),
+(150,345,o),
+(232,345,cs),
+(335,345,l),
+(322,370,l),
+(222,233,l),
+(256,208,l)
+);
+}
+);
+width = 383;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni15A6;
+unicode = 5542;
+},
+{
+glyphname = "theThCree-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (167,690);
+},
+{
+name = top_right_can;
+pos = (440,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(288,117,l),
+(262,0,l),
+(324,0,l),
+(349,117,l),
+(409,117,l),
+(417,157,l),
+(357,157,l),
+(389,310,l),
+(122,310,l),
+(131,289,l),
+(474,665,l),
+(431,701,l),
+(49,280,l),
+(44,255,l),
+(317,255,l),
+(296,157,l),
+(114,157,l),
+(105,117,l)
+);
+}
+);
+width = 469;
+}
+);
+metricLeft = "ye-canadian";
+note = uni15A7;
+unicode = 5543;
+},
+{
+glyphname = "thiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (223,690);
+},
+{
+name = top_right_can;
+pos = (496,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(106,0,l),
+(131,117,l),
+(314,117,l),
+(323,157,l),
+(140,157,l),
+(160,255,l),
+(433,255,l),
+(438,280,l),
+(225,701,l),
+(175,674,l),
+(372,285,l),
+(387,310,l),
+(111,310,l),
+(78,157,l),
+(18,157,l),
+(11,117,l),
+(71,117,l),
+(44,0,l)
+);
+}
+);
+width = 469;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+unicode = 5544;
+},
+{
+glyphname = "thiiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (67,0);
+ref = dot_top;
+}
+);
+width = 469;
+}
+);
+note = uni15A9;
+unicode = 5545;
+},
+{
+glyphname = "thoThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (167,690);
+},
+{
+name = top_right_can;
+pos = (440,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(341,15,l),
+(143,405,l),
+(128,380,l),
+(404,380,l),
+(437,532,l),
+(497,532,l),
+(505,573,l),
+(444,573,l),
+(470,690,l),
+(409,690,l),
+(384,573,l),
+(201,573,l),
+(192,532,l),
+(375,532,l),
+(355,435,l),
+(82,435,l),
+(77,410,l),
+(290,-12,l)
+);
+}
+);
+width = 469;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+unicode = 5546;
+},
+{
+glyphname = "thooThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (285,0);
+ref = dot_top;
+}
+);
+width = 469;
+}
+);
+note = uni15AB;
+unicode = 5547;
+},
+{
+glyphname = "thaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (223,690);
+},
+{
+name = top_right_can;
+pos = (497,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(468,410,l),
+(472,435,l),
+(199,435,l),
+(220,532,l),
+(402,532,l),
+(411,573,l),
+(228,573,l),
+(254,690,l),
+(192,690,l),
+(167,573,l),
+(107,573,l),
+(99,532,l),
+(158,532,l),
+(127,380,l),
+(394,380,l),
+(385,401,l),
+(42,25,l),
+(85,-12,l)
+);
+}
+);
+width = 471;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+unicode = 5548;
+},
+{
+glyphname = "thaaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:56:20 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (67,0);
+ref = dot_top;
+}
+);
+width = 471;
+}
+);
+note = uni15AD;
+unicode = 5549;
+},
+{
+glyphname = "thThCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(148,612,l),
+(129,524,l),
+(265,524,l),
+(256,545,l),
+(91,362,l),
+(122,336,l),
+(310,546,l),
+(314,562,l),
+(180,562,l),
+(191,612,l),
+(280,612,l),
+(285,639,l),
+(196,639,l),
+(208,690,l),
+(164,690,l),
+(154,639,l),
+(123,639,l),
+(118,612,l)
+);
+}
+);
+width = 273;
+}
+);
+metricRight = "y-canadian";
+note = uni15AE;
+unicode = 5550;
+},
+{
+glyphname = "bAivilik-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(360,-13,o),
+(409,206,o),
+(409,322,cs),
+(409,426,o),
+(362,485,o),
+(278,485,cs),
+(219,485,o),
+(174,449,o),
+(140,369,c),
+(152,368,l),
+(220,690,l),
+(159,690,l),
+(13,0,l),
+(69,0,l),
+(96,127,l),
+(86,110,l),
+(89,27,o),
+(131,-13,o),
+(201,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(143,42,o),
+(115,79,o),
+(115,152,cs),
+(115,230,o),
+(148,431,o),
+(264,431,cs),
+(321,431,o),
+(349,393,o),
+(349,320,cs),
+(349,241,o),
+(315,42,o),
+(199,42,cs)
+);
+}
+);
+width = 454;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|ke-canadian";
+note = uni15AF;
+unicode = 5551;
+},
+{
+glyphname = "eBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(73,0,l),
+(163,420,l),
+(178,378,o),
+(216,353,o),
+(267,353,cs),
+(384,353,o),
+(436,483,o),
+(436,565,cs),
+(436,647,o),
+(389,702,o),
+(314,702,cs),
+(274,702,o),
+(238,686,o),
+(211,655,c),
+(217,690,l),
+(159,690,l),
+(13,0,l)
+);
+}
+);
+width = 411;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B0;
+unicode = 5552;
+},
+{
+glyphname = "iBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(184,-13,o),
+(219,4,o),
+(247,35,c),
+(240,0,l),
+(298,0,l),
+(445,690,l),
+(384,690,l),
+(294,270,l),
+(279,312,o),
+(241,337,o),
+(190,337,cs),
+(73,337,o),
+(21,207,o),
+(21,125,cs),
+(21,43,o),
+(69,-13,o),
+(144,-13,cs)
+);
+}
+);
+width = 410;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B1;
+unicode = 5553;
+},
+{
+glyphname = "oBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(308,-13,o),
+(357,118,o),
+(357,200,cs),
+(357,281,o),
+(312,337,o),
+(240,337,cs),
+(200,337,o),
+(165,322,o),
+(135,293,c),
+(220,690,l),
+(159,690,l),
+(13,0,l),
+(71,0,l),
+(84,60,l),
+(98,15,o),
+(136,-13,o),
+(188,-13,cs)
+);
+}
+);
+width = 410;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "eBlackfoot-canadian";
+note = uni15B2;
+unicode = 5554;
+},
+{
+glyphname = "aBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(298,0,l),
+(444,690,l),
+(385,690,l),
+(372,630,l),
+(358,674,o),
+(320,702,o),
+(268,702,cs),
+(148,702,o),
+(99,572,o),
+(99,490,cs),
+(99,409,o),
+(144,353,o),
+(217,353,cs),
+(256,353,o),
+(292,368,o),
+(321,397,c),
+(236,0,l)
+);
+}
+);
+width = 410;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B3;
+unicode = 5555;
+},
+{
+glyphname = "weBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(73,0,l),
+(141,319,l),
+(406,319,l),
+(417,373,l),
+(153,373,l),
+(209,636,l),
+(473,636,l),
+(484,690,l),
+(159,690,l),
+(13,0,l)
+);
+}
+);
+width = 433;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B4;
+unicode = 5556;
+},
+{
+glyphname = "wiBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(321,0,l),
+(468,690,l),
+(406,690,l),
+(339,371,l),
+(74,371,l),
+(63,317,l),
+(327,317,l),
+(271,54,l),
+(7,54,l),
+(-5,0,l)
+);
+}
+);
+width = 433;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B5;
+unicode = 5557;
+},
+{
+glyphname = "woBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(337,0,l),
+(349,54,l),
+(85,54,l),
+(141,317,l),
+(405,317,l),
+(416,371,l),
+(153,371,l),
+(220,690,l),
+(159,690,l),
+(13,0,l)
+);
+}
+);
+width = 433;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "weBlackfoot-canadian";
+note = uni15B6;
+unicode = 5558;
+},
+{
+glyphname = "waBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(321,0,l),
+(468,690,l),
+(142,690,l),
+(130,636,l),
+(394,636,l),
+(338,373,l),
+(74,373,l),
+(63,319,l),
+(328,319,l),
+(259,0,l)
+);
+}
+);
+width = 433;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B7;
+unicode = 5559;
+},
+{
+glyphname = "neBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(73,0,l),
+(211,641,l),
+(250,641,l),
+(234,673,l),
+(220,611,ls),
+(194,488,o),
+(244,407,o),
+(360,407,cs),
+(459,407,o),
+(527,469,o),
+(554,597,cs),
+(574,690,l),
+(514,690,l),
+(494,593,ls),
+(475,502,o),
+(430,463,o),
+(363,463,cs),
+(288,463,o),
+(261,516,o),
+(278,599,cs),
+(298,690,l),
+(159,690,l),
+(13,0,l)
+);
+}
+);
+width = 514;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B8;
+unicode = 5560;
+},
+{
+glyphname = "niBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(47,0,l),
+(67,97,ls),
+(86,187,o),
+(131,227,o),
+(198,227,cs),
+(274,227,o),
+(301,174,o),
+(284,91,cs),
+(264,0,l),
+(403,0,l),
+(550,690,l),
+(488,690,l),
+(352,48,l),
+(311,48,l),
+(328,16,l),
+(341,79,ls),
+(367,202,o),
+(317,283,o),
+(201,283,cs),
+(102,283,o),
+(34,221,o),
+(7,93,cs),
+(-13,0,l)
+);
+}
+);
+width = 515;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B9;
+unicode = 5561;
+},
+{
+glyphname = "noBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(151,0,l),
+(168,78,ls),
+(191,181,o),
+(227,228,o),
+(296,228,cs),
+(370,228,o),
+(403,171,o),
+(382,71,cs),
+(368,0,l),
+(428,0,l),
+(440,58,ls),
+(469,196,o),
+(415,283,o),
+(301,283,cs),
+(200,283,o),
+(135,211,o),
+(108,78,cs),
+(96,16,l),
+(125,48,l),
+(84,48,l),
+(220,690,l),
+(159,690,l),
+(13,0,l)
+);
+}
+);
+width = 515;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "neBlackfoot-canadian";
+note = uni15BA;
+unicode = 5562;
+},
+{
+glyphname = "naBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(404,0,l),
+(551,690,l),
+(412,690,l),
+(394,611,ls),
+(372,509,o),
+(335,462,o),
+(267,462,cs),
+(192,462,o),
+(160,519,o),
+(181,619,cs),
+(195,690,l),
+(134,690,l),
+(122,632,ls),
+(93,494,o),
+(147,407,o),
+(261,407,cs),
+(363,407,o),
+(427,479,o),
+(455,611,cs),
+(468,673,l),
+(439,641,l),
+(478,641,l),
+(342,0,l)
+);
+}
+);
+width = 516;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BB;
+unicode = 5563;
+},
+{
+glyphname = "keBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(73,0,l),
+(206,618,l),
+(181,618,l),
+(248,258,l),
+(279,258,l),
+(545,690,l),
+(478,690,l),
+(256,328,l),
+(284,326,l),
+(215,690,l),
+(159,690,l),
+(13,0,l)
+);
+}
+);
+width = 474;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15BC;
+unicode = 5564;
+},
+{
+glyphname = "kiBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(43,1,l),
+(265,362,l),
+(238,365,l),
+(306,1,l),
+(362,1,l),
+(509,691,l),
+(447,691,l),
+(316,72,l),
+(340,72,l),
+(272,432,l),
+(242,432,l),
+(-24,1,l)
+);
+}
+);
+width = 474;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BD;
+unicode = 5565;
+},
+{
+glyphname = "koBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(69,0,l),
+(297,360,l),
+(270,364,l),
+(337,0,l),
+(398,0,l),
+(315,432,l),
+(285,432,l),
+(63,71,l),
+(89,71,l),
+(220,690,l),
+(159,690,l),
+(13,0,l)
+);
+}
+);
+width = 474;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "keBlackfoot-canadian";
+note = uni15BE;
+unicode = 5566;
+},
+{
+glyphname = "kaBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(362,1,l),
+(509,691,l),
+(453,691,l),
+(224,330,l),
+(252,327,l),
+(185,691,l),
+(123,691,l),
+(206,259,l),
+(237,259,l),
+(458,619,l),
+(433,619,l),
+(300,1,l)
+);
+}
+);
+width = 474;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BF;
+unicode = 5567;
+},
+{
+color = 9;
+glyphname = "heSayisi-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_right_can;
+pos = (506,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(389,0,l),
+(536,690,l),
+(475,690,l),
+(385,267,l),
+(400,266,l),
+(452,546,o),
+(411,702,o),
+(281,702,cs),
+(191,702,o),
+(129,627,o),
+(97,482,cs),
+(85,426,o),
+(79,379,o),
+(78,340,c),
+(136,340,l),
+(137,377,o),
+(143,423,o),
+(155,473,cs),
+(178,584,o),
+(225,647,o),
+(288,647,cs),
+(409,647,o),
+(424,430,o),
+(327,0,c)
+);
+}
+);
+width = 501;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni15C0;
+unicode = 5568;
+},
+{
+color = 9;
+glyphname = "hiSayisi-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(73,0,l),
+(167,436,o),
+(265,647,o),
+(376,647,cs),
+(444,647,o),
+(469,568,o),
+(440,433,cs),
+(432,395,o),
+(422,367,o),
+(410,340,c),
+(469,340,l),
+(482,372,o),
+(493,406,o),
+(500,437,cs),
+(533,601,o),
+(494,702,o),
+(395,702,cs),
+(280,702,o),
+(187,560,o),
+(123,288,c),
+(134,287,l),
+(220,690,l),
+(159,690,l),
+(13,0,l)
+);
+}
+);
+width = 502;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C1;
+unicode = 5569;
+},
+{
+color = 9;
+glyphname = "hoSayisi-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (344,690);
+},
+{
+name = top_left_can;
+pos = (181,690);
+},
+{
+name = top_right_can;
+pos = (507,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(269,-13,o),
+(362,129,o),
+(426,402,c),
+(414,403,l),
+(329,0,l),
+(390,0,l),
+(537,690,l),
+(475,690,l),
+(383,254,o),
+(284,43,o),
+(174,43,cs),
+(105,43,o),
+(81,122,o),
+(109,257,cs),
+(118,295,o),
+(127,323,o),
+(139,350,c),
+(80,350,l),
+(67,318,o),
+(56,284,o),
+(49,253,cs),
+(16,89,o),
+(56,-13,o),
+(155,-13,cs)
+);
+}
+);
+width = 502;
+}
+);
+metricLeft = "heSayisi-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15C2;
+unicode = 5570;
+},
+{
+color = 9;
+glyphname = "haSayisi-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(356,-13,o),
+(419,63,o),
+(451,208,cs),
+(463,264,o),
+(469,311,o),
+(470,350,c),
+(412,350,l),
+(411,313,o),
+(406,267,o),
+(394,216,cs),
+(371,105,o),
+(324,43,o),
+(260,43,cs),
+(140,43,o),
+(125,260,o),
+(220,690,c),
+(159,690,l),
+(13,0,l),
+(73,0,l),
+(163,423,l),
+(149,424,l),
+(97,144,o),
+(137,-13,o),
+(267,-13,cs)
+);
+}
+);
+width = 502;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C3;
+unicode = 5571;
+},
+{
+color = 9;
+glyphname = "ghuCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(231,0,l),
+(603,670,l),
+(608,690,l),
+(554,690,l),
+(423,447,l),
+(450,461,l),
+(180,461,l),
+(201,446,l),
+(173,690,l),
+(124,690,l),
+(120,670,l),
+(207,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(425,413,l),
+(412,427,l),
+(227,84,l),
+(244,81,l),
+(204,425,l),
+(185,413,l)
+);
+}
+);
+width = 538;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C4;
+unicode = 5572;
+},
+{
+color = 9;
+glyphname = "ghoCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(30,0,l),
+(161,242,l),
+(133,229,l),
+(405,229,l),
+(383,243,l),
+(411,0,l),
+(460,0,l),
+(465,19,l),
+(377,690,l),
+(353,690,l),
+(-19,19,l),
+(-23,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(391,324,l),
+(185,327,l),
+(199,265,l),
+(364,558,l),
+(313,559,l),
+(353,262,l)
+);
+}
+);
+width = 538;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C5;
+unicode = 5573;
+},
+{
+color = 9;
+glyphname = "gheCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (81,351);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(9,0,l),
+(484,332,l),
+(490,357,l),
+(155,690,l),
+(138,690,l),
+(128,646,l),
+(239,537,l),
+(232,578,l),
+(135,128,l),
+(156,164,l),
+(3,57,l),
+(-9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(269,548,l),
+(250,531,l),
+(449,332,l),
+(451,366,l),
+(178,175,l),
+(186,158,l)
+);
+}
+);
+width = 495;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15C6;
+unicode = 5574;
+},
+{
+color = 9;
+glyphname = "gheeCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (24,6);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 495;
+}
+);
+note = uni15C7;
+unicode = 5575;
+},
+{
+color = 9;
+glyphname = "ghiCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (5,6);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 495;
+}
+);
+note = uni15C8;
+unicode = 5576;
+},
+{
+color = 9;
+glyphname = "ghaCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(403,0,l),
+(412,43,l),
+(302,153,l),
+(309,112,l),
+(406,561,l),
+(384,526,l),
+(538,633,l),
+(550,690,l),
+(532,690,l),
+(57,357,l),
+(51,332,l),
+(385,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(291,158,l),
+(100,350,l),
+(99,329,l),
+(363,515,l),
+(352,520,l),
+(275,158,l)
+);
+}
+);
+width = 495;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15C9;
+unicode = 5577;
+},
+{
+color = 9;
+glyphname = "ruCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(231,0,l),
+(603,670,l),
+(608,690,l),
+(552,690,l),
+(499,592,l),
+(523,608,l),
+(165,608,l),
+(185,592,l),
+(173,690,l),
+(124,690,l),
+(120,670,l),
+(207,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(499,559,l),
+(493,575,l),
+(227,85,l),
+(244,82,l),
+(185,573,l),
+(170,559,l)
+);
+}
+);
+width = 538;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CA;
+unicode = 5578;
+},
+{
+color = 9;
+glyphname = "roCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(353,690,l),
+(-19,19,l),
+(-23,0,l),
+(33,0,l),
+(84,98,l),
+(62,82,l),
+(419,82,l),
+(400,98,l),
+(411,0,l),
+(460,0,l),
+(464,19,l),
+(377,690,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(85,130,l),
+(92,115,l),
+(357,605,l),
+(339,608,l),
+(398,117,l),
+(414,130,l)
+);
+}
+);
+width = 537;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CB;
+unicode = 5579;
+},
+{
+color = 9;
+glyphname = "reCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(10,0,l),
+(484,332,l),
+(490,357,l),
+(156,690,l),
+(138,690,l),
+(128,647,l),
+(184,593,l),
+(178,633,l),
+(58,71,l),
+(75,105,l),
+(3,55,l),
+(-9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(215,596,l),
+(197,581,l),
+(442,333,l),
+(445,366,l),
+(103,124,l),
+(111,107,l)
+);
+}
+);
+width = 495;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CC;
+unicode = 5580;
+},
+{
+color = 9;
+glyphname = "reeCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(9,0,l),
+(484,332,l),
+(490,357,l),
+(155,690,l),
+(138,690,l),
+(129,652,l),
+(181,601,l),
+(179,637,l),
+(57,68,l),
+(74,102,l),
+(2,52,l),
+(-9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(212,608,l),
+(196,590,l),
+(453,333,l),
+(456,367,l),
+(95,112,l),
+(104,96,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(220,259,l),
+(259,440,l),
+(232,440,l),
+(193,259,l)
+);
+}
+);
+width = 495;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CD;
+unicode = 5581;
+},
+{
+color = 9;
+glyphname = "riCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(9,0,l),
+(484,332,l),
+(490,357,l),
+(155,690,l),
+(138,690,l),
+(129,652,l),
+(182,600,l),
+(179,637,l),
+(57,68,l),
+(76,103,l),
+(2,52,l),
+(-9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(282,317,o),
+(297,331,o),
+(297,351,cs),
+(297,369,o),
+(282,384,o),
+(264,384,cs),
+(245,384,o),
+(231,369,o),
+(231,351,cs),
+(231,331,o),
+(245,317,o),
+(264,317,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(212,608,l),
+(195,592,l),
+(453,333,l),
+(456,367,l),
+(96,113,l),
+(104,96,l)
+);
+}
+);
+width = 495;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CE;
+unicode = 5582;
+},
+{
+color = 9;
+glyphname = "raCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(403,0,l),
+(412,43,l),
+(357,97,l),
+(363,57,l),
+(483,619,l),
+(466,584,l),
+(538,635,l),
+(550,690,l),
+(531,690,l),
+(57,357,l),
+(51,332,l),
+(384,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(344,109,l),
+(99,356,l),
+(96,324,l),
+(438,566,l),
+(430,582,l),
+(326,94,l)
+);
+}
+);
+width = 494;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15CF;
+unicode = 5583;
+},
+{
+color = 9;
+glyphname = "wuCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(233,0,l),
+(608,670,l),
+(612,690,l),
+(558,690,l),
+(264,142,l),
+(274,141,l),
+(391,690,l),
+(342,690,l),
+(224,138,l),
+(235,138,l),
+(171,690,l),
+(124,690,l),
+(120,670,l),
+(210,0,l)
+);
+}
+);
+width = 543;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D0;
+unicode = 5584;
+},
+{
+color = 9;
+glyphname = "woCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(31,0,l),
+(325,548,l),
+(315,549,l),
+(198,0,l),
+(247,0,l),
+(364,552,l),
+(354,552,l),
+(418,0,l),
+(465,0,l),
+(469,19,l),
+(380,690,l),
+(355,690,l),
+(-19,19,l),
+(-23,0,l)
+);
+}
+);
+width = 542;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D1;
+unicode = 5585;
+},
+{
+color = 9;
+glyphname = "weCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(28,0,l),
+(503,332,l),
+(509,357,l),
+(175,690,l),
+(157,690,l),
+(148,646,l),
+(429,365,l),
+(433,377,l),
+(91,377,l),
+(80,327,l),
+(422,327,l),
+(424,337,l),
+(22,56,l),
+(11,0,l)
+);
+}
+);
+width = 514;
+}
+);
+metricRight = "o-canadian";
+note = uni15D2;
+unicode = 5586;
+},
+{
+color = 9;
+glyphname = "weeCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(28,0,l),
+(503,332,l),
+(509,357,l),
+(175,690,l),
+(157,690,l),
+(149,648,l),
+(447,354,l),
+(454,373,l),
+(195,373,l),
+(212,448,l),
+(176,448,l),
+(159,373,l),
+(90,373,l),
+(81,331,l),
+(150,331,l),
+(134,256,l),
+(171,256,l),
+(186,331,l),
+(445,331,l),
+(438,344,l),
+(22,53,l),
+(11,0,l)
+);
+}
+);
+width = 514;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D3;
+unicode = 5587;
+},
+{
+color = 9;
+glyphname = "wiCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(28,0,l),
+(503,332,l),
+(509,357,l),
+(175,690,l),
+(157,690,l),
+(149,648,l),
+(437,362,l),
+(441,375,l),
+(242,375,l),
+(236,394,o),
+(216,408,o),
+(194,408,cs),
+(172,408,o),
+(153,394,o),
+(145,375,c),
+(90,375,l),
+(81,332,l),
+(144,332,l),
+(153,313,o),
+(172,298,o),
+(194,298,cs),
+(215,298,o),
+(236,313,o),
+(243,332,c),
+(434,332,l),
+(430,339,l),
+(22,54,l),
+(11,0,l)
+);
+}
+);
+width = 514;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D4;
+unicode = 5588;
+},
+{
+color = 9;
+glyphname = "waCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(402,0,l),
+(412,43,l),
+(131,325,l),
+(128,313,l),
+(469,313,l),
+(479,362,l),
+(138,362,l),
+(136,353,l),
+(537,634,l),
+(549,690,l),
+(531,690,l),
+(57,357,l),
+(51,332,l),
+(384,0,l)
+);
+}
+);
+width = 513;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15D5;
+unicode = 5589;
+},
+{
+color = 9;
+glyphname = "hwuCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(233,0,l),
+(608,670,l),
+(612,690,l),
+(561,690,l),
+(434,455,l),
+(454,467,l),
+(337,467,l),
+(385,690,l),
+(345,690,l),
+(297,467,l),
+(180,467,l),
+(197,454,l),
+(168,690,l),
+(124,690,l),
+(120,670,l),
+(210,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(235,119,l),
+(197,443,l),
+(182,429,l),
+(291,429,l),
+(225,119,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(327,429,l),
+(435,429,l),
+(427,442,l),
+(253,120,l),
+(261,116,l)
+);
+}
+);
+width = 543;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D6;
+unicode = 5590;
+},
+{
+color = 9;
+glyphname = "hwoCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(28,0,l),
+(156,235,l),
+(135,223,l),
+(251,223,l),
+(204,0,l),
+(244,0,l),
+(292,223,l),
+(410,223,l),
+(392,236,l),
+(420,0,l),
+(465,0,l),
+(469,19,l),
+(380,690,l),
+(355,690,l),
+(-19,19,l),
+(-23,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(335,570,l),
+(327,574,l),
+(262,261,l),
+(154,261,l),
+(161,247,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(407,261,l),
+(298,261,l),
+(363,571,l),
+(355,571,l),
+(392,246,l)
+);
+}
+);
+width = 542;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D7;
+unicode = 5591;
+},
+{
+color = 9;
+glyphname = "hweCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(28,0,l),
+(503,332,l),
+(509,357,l),
+(175,690,l),
+(157,690,l),
+(149,648,l),
+(242,555,l),
+(204,372,l),
+(90,372,l),
+(80,329,l),
+(194,329,l),
+(155,147,l),
+(21,53,l),
+(11,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(231,332,l),
+(429,332,l),
+(197,171,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(273,531,l),
+(436,369,l),
+(239,369,l)
+);
+}
+);
+width = 514;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D8;
+unicode = 5592;
+},
+{
+color = 9;
+glyphname = "hweeCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(28,0,l),
+(503,332,l),
+(509,357,l),
+(175,690,l),
+(157,690,l),
+(149,651,l),
+(254,548,l),
+(216,370,l),
+(174,370,l),
+(190,447,l),
+(158,447,l),
+(142,370,l),
+(89,370,l),
+(81,332,l),
+(133,332,l),
+(118,256,l),
+(150,256,l),
+(165,332,l),
+(209,332,l),
+(170,155,l),
+(21,51,l),
+(11,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(242,334,l),
+(431,334,l),
+(210,177,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(283,525,l),
+(437,368,l),
+(249,368,l)
+);
+}
+);
+width = 514;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D9;
+unicode = 5593;
+},
+{
+color = 9;
+glyphname = "hwiCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(28,0,l),
+(503,332,l),
+(509,357,l),
+(175,690,l),
+(157,690,l),
+(149,651,l),
+(254,548,l),
+(216,368,l),
+(195,368,l),
+(189,386,o),
+(173,399,o),
+(154,399,cs),
+(133,399,o),
+(117,386,o),
+(111,368,c),
+(89,368,l),
+(81,334,l),
+(110,334,l),
+(116,316,o),
+(133,301,o),
+(153,301,cs),
+(172,301,o),
+(189,316,o),
+(196,334,c),
+(209,334,l),
+(170,155,l),
+(21,51,l),
+(11,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(242,334,l),
+(431,334,l),
+(209,177,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(283,525,l),
+(437,368,l),
+(249,368,l)
+);
+}
+);
+width = 514;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15DA;
+unicode = 5594;
+},
+{
+color = 9;
+glyphname = "hwaCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(532,690,l),
+(57,357,l),
+(51,332,l),
+(385,0,l),
+(403,0,l),
+(412,42,l),
+(318,134,l),
+(356,318,l),
+(469,318,l),
+(479,360,l),
+(366,360,l),
+(405,543,l),
+(538,637,l),
+(550,690,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(328,357,l),
+(131,357,l),
+(363,519,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(287,158,l),
+(125,321,l),
+(321,321,l)
+);
+}
+);
+width = 513;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15DB;
+unicode = 5595;
+},
+{
+color = 9;
+glyphname = "thuCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(372,-13,o),
+(448,60,o),
+(480,213,cs),
+(582,690,l),
+(156,690,l),
+(61,244,ls),
+(27,82,o),
+(96,-13,o),
+(247,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(206,634,l),
+(509,634,l),
+(421,219,ls),
+(395,99,o),
+(342,45,o),
+(250,45,cs),
+(134,45,o),
+(94,110,o),
+(122,242,cs)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DC;
+unicode = 5596;
+},
+{
+color = 9;
+glyphname = "thoCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(435,0,l),
+(529,445,ls),
+(564,608,o),
+(496,702,o),
+(344,702,cs),
+(219,702,o),
+(143,630,o),
+(110,477,cs),
+(9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(170,470,ls),
+(196,591,o),
+(249,644,o),
+(341,644,cs),
+(457,644,o),
+(497,580,o),
+(469,448,cs),
+(385,56,l),
+(82,56,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DD;
+unicode = 5597;
+},
+{
+color = 9;
+glyphname = "theCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (287,345);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(148,0,ls),
+(430,0,o),
+(512,291,o),
+(512,460,cs),
+(512,611,o),
+(433,690,o),
+(281,690,cs),
+(159,690,l),
+(13,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(214,663,l),
+(190,635,l),
+(270,635,ls),
+(391,635,o),
+(452,577,o),
+(452,459,cs),
+(452,327,o),
+(387,55,o),
+(154,55,cs),
+(71,55,l),
+(80,30,l)
+);
+}
+);
+width = 525;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "to-canadian";
+note = uni15DE;
+unicode = 5598;
+},
+{
+color = 9;
+glyphname = "theeCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (226,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 525;
+}
+);
+note = uni15DF;
+unicode = 5599;
+},
+{
+color = 9;
+glyphname = "thiCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (207,0);
+ref = dot_middle;
+}
+);
+width = 525;
+}
+);
+note = uni15E0;
+unicode = 5600;
+},
+{
+color = 9;
+glyphname = "thaCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(412,0,l),
+(559,690,l),
+(424,690,ls),
+(142,690,o),
+(59,399,o),
+(59,230,cs),
+(59,79,o),
+(139,0,o),
+(291,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(119,363,o),
+(184,635,o),
+(417,635,cs),
+(500,635,l),
+(492,660,l),
+(357,27,l),
+(382,55,l),
+(300,55,ls),
+(181,55,o),
+(119,113,o),
+(119,231,cs)
+);
+}
+);
+width = 524;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15E1;
+unicode = 5601;
+},
+{
+color = 9;
+glyphname = "ttuCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(370,-13,o),
+(447,60,o),
+(479,204,cs),
+(582,690,l),
+(559,690,l),
+(305,497,l),
+(344,492,l),
+(180,690,l),
+(156,690,l),
+(60,237,ls),
+(26,78,o),
+(93,-13,o),
+(242,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(135,45,o),
+(94,109,o),
+(120,234,cs),
+(203,623,l),
+(180,615,l),
+(311,452,l),
+(327,452,l),
+(526,610,l),
+(506,623,l),
+(419,212,ls),
+(395,98,o),
+(340,45,o),
+(244,45,cs)
+);
+}
+);
+width = 545;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E2;
+unicode = 5602;
+},
+{
+color = 9;
+glyphname = "ttoCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(32,0,l),
+(286,193,l),
+(247,198,l),
+(411,0,l),
+(435,0,l),
+(531,453,ls),
+(565,611,o),
+(497,702,o),
+(349,702,cs),
+(221,702,o),
+(143,630,o),
+(112,486,cs),
+(9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(456,644,o),
+(497,581,o),
+(470,456,cs),
+(388,67,l),
+(411,74,l),
+(280,238,l),
+(265,238,l),
+(65,80,l),
+(85,67,l),
+(172,478,ls),
+(196,592,o),
+(251,644,o),
+(347,644,cs)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E3;
+unicode = 5603;
+},
+{
+color = 9;
+glyphname = "tteCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (327,345);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(156,0,ls),
+(440,0,o),
+(522,293,o),
+(522,460,cs),
+(522,611,o),
+(441,690,o),
+(293,690,cs),
+(156,690,l),
+(151,670,l),
+(175,325,l),
+(184,377,l),
+(14,19,l),
+(9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(229,336,l),
+(232,351,l),
+(209,662,l),
+(187,635,l),
+(280,635,ls),
+(401,635,o),
+(463,577,o),
+(463,459,cs),
+(463,327,o),
+(397,55,o),
+(163,55,cs),
+(69,55,l),
+(82,30,l)
+);
+}
+);
+width = 535;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15E4;
+unicode = 5604;
+},
+{
+color = 9;
+glyphname = "tteeCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (270,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 534;
+}
+);
+note = uni15E5;
+unicode = 5605;
+},
+{
+color = 9;
+glyphname = "ttiCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (256,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 534;
+}
+);
+note = uni15E6;
+unicode = 5606;
+},
+{
+color = 9;
+glyphname = "ttaCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(425,0,l),
+(430,19,l),
+(406,365,l),
+(397,313,l),
+(567,670,l),
+(572,690,l),
+(424,690,ls),
+(140,690,o),
+(59,397,o),
+(59,230,cs),
+(59,79,o),
+(139,0,o),
+(288,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(393,55,l),
+(300,55,ls),
+(180,55,o),
+(119,113,o),
+(119,231,cs),
+(119,363,o),
+(184,635,o),
+(417,635,cs),
+(512,635,l),
+(498,660,l),
+(352,354,l),
+(349,339,l),
+(372,28,l)
+);
+}
+);
+width = 535;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tteCarrier-canadian";
+note = uni15E7;
+unicode = 5607;
+},
+{
+color = 9;
+glyphname = "puCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(372,-13,o),
+(448,60,o),
+(480,213,cs),
+(582,690,l),
+(521,690,l),
+(484,517,l),
+(181,517,l),
+(217,690,l),
+(156,690,l),
+(61,244,ls),
+(27,82,o),
+(96,-13,o),
+(247,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(134,45,o),
+(94,110,o),
+(122,242,cs),
+(169,462,l),
+(472,462,l),
+(421,219,ls),
+(395,99,o),
+(342,45,o),
+(250,45,cs)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E8;
+unicode = 5608;
+},
+{
+color = 9;
+glyphname = "poCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(71,0,l),
+(107,173,l),
+(411,173,l),
+(374,0,l),
+(435,0,l),
+(529,445,ls),
+(564,608,o),
+(496,702,o),
+(344,702,cs),
+(219,702,o),
+(143,630,o),
+(110,477,cs),
+(9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(170,470,ls),
+(196,591,o),
+(249,644,o),
+(341,644,cs),
+(457,644,o),
+(497,580,o),
+(469,448,cs),
+(422,228,l),
+(119,228,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E9;
+unicode = 5609;
+},
+{
+color = 9;
+glyphname = "peCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (318,345);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(154,0,ls),
+(436,0,o),
+(519,292,o),
+(519,460,cs),
+(519,611,o),
+(439,690,o),
+(290,690,cs),
+(153,690,l),
+(141,635,l),
+(208,635,l),
+(85,55,l),
+(17,55,l),
+(6,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(274,662,l),
+(216,635,l),
+(277,635,ls),
+(398,635,o),
+(459,577,o),
+(459,459,cs),
+(459,327,o),
+(395,55,o),
+(160,55,cs),
+(94,55,l),
+(140,28,l)
+);
+}
+);
+width = 532;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15EA;
+unicode = 5610;
+},
+{
+color = 9;
+glyphname = "peeCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (261,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 531;
+}
+);
+note = uni15EB;
+unicode = 5611;
+},
+{
+color = 9;
+glyphname = "piCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (247,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 531;
+}
+);
+note = uni15EC;
+unicode = 5612;
+},
+{
+color = 9;
+glyphname = "paCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(425,0,l),
+(437,55,l),
+(370,55,l),
+(493,635,l),
+(560,635,l),
+(572,690,l),
+(424,690,ls),
+(142,690,o),
+(59,398,o),
+(59,230,cs),
+(59,79,o),
+(139,0,o),
+(288,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(361,55,l),
+(300,55,ls),
+(180,55,o),
+(119,113,o),
+(119,231,cs),
+(119,362,o),
+(184,635,o),
+(417,635,cs),
+(485,635,l),
+(438,662,l),
+(303,28,l)
+);
+}
+);
+width = 530;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|peCarrier-canadian";
+note = uni15ED;
+unicode = 5613;
+},
+{
+color = 6;
+glyphname = "pCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(282,183,l),
+(292,225,l),
+(192,225,l),
+(256,527,l),
+(213,527,l),
+(149,225,l),
+(49,225,l),
+(41,183,l)
+);
+}
+);
+width = 345;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni15EE;
+unicode = 5614;
+},
+{
+color = 9;
+glyphname = "guCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (419,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(225,-13,o),
+(278,31,o),
+(310,113,c),
+(288,113,l),
+(290,33,o),
+(333,-13,o),
+(407,-13,cs),
+(495,-13,o),
+(549,48,o),
+(575,170,cs),
+(685,690,l),
+(626,690,l),
+(516,171,ls),
+(498,86,o),
+(463,44,o),
+(405,44,cs),
+(346,44,o),
+(321,89,o),
+(338,171,cs),
+(448,690,l),
+(391,690,l),
+(281,170,ls),
+(263,88,o),
+(225,44,o),
+(166,44,cs),
+(108,44,o),
+(84,87,o),
+(101,170,cs),
+(212,690,l),
+(153,690,l),
+(43,173,ls),
+(19,58,o),
+(61,-13,o),
+(154,-13,cs)
+);
+}
+);
+width = 645;
+}
+);
+metricRight = "=|";
+note = uni15EF;
+unicode = 5615;
+},
+{
+color = 9;
+glyphname = "goCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(65,0,l),
+(175,519,ls),
+(192,604,o),
+(228,645,o),
+(285,645,cs),
+(345,645,o),
+(370,601,o),
+(353,519,cs),
+(242,0,l),
+(299,0,l),
+(410,520,ls),
+(427,602,o),
+(465,645,o),
+(524,645,cs),
+(582,645,o),
+(606,603,o),
+(588,520,cs),
+(478,0,l),
+(537,0,l),
+(646,517,ls),
+(670,632,o),
+(629,702,o),
+(536,702,cs),
+(465,702,o),
+(412,659,o),
+(381,577,c),
+(402,577,l),
+(401,657,o),
+(357,702,o),
+(284,702,cs),
+(195,702,o),
+(141,641,o),
+(116,520,cs),
+(6,0,l)
+);
+}
+);
+width = 643;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F0;
+unicode = 5616;
+},
+{
+color = 9;
+glyphname = "geCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (366,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(242,0,ls),
+(417,0,o),
+(465,121,o),
+(465,217,cs),
+(465,289,o),
+(431,339,o),
+(370,353,c),
+(369,331,l),
+(493,355,o),
+(533,453,o),
+(533,536,cs),
+(533,627,o),
+(472,690,o),
+(376,690,cs),
+(159,690,l),
+(148,638,l),
+(367,638,ls),
+(433,638,o),
+(471,596,o),
+(471,531,cs),
+(471,449,o),
+(429,371,o),
+(311,371,cs),
+(92,371,l),
+(80,319,l),
+(300,319,ls),
+(369,319,o),
+(406,286,o),
+(406,222,cs),
+(406,172,o),
+(393,52,o),
+(246,52,cs),
+(24,52,l),
+(14,0,l)
+);
+}
+);
+width = 534;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15F1;
+unicode = 5617;
+},
+{
+color = 9;
+glyphname = "geeCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(242,0,ls),
+(417,0,o),
+(465,121,o),
+(465,217,cs),
+(465,289,o),
+(431,339,o),
+(370,353,c),
+(369,331,l),
+(493,355,o),
+(533,453,o),
+(533,536,cs),
+(533,627,o),
+(472,690,o),
+(376,690,cs),
+(159,690,l),
+(148,638,l),
+(367,638,ls),
+(433,638,o),
+(471,596,o),
+(471,531,cs),
+(471,449,o),
+(429,371,o),
+(311,371,cs),
+(289,371,l),
+(306,452,l),
+(267,452,l),
+(249,371,l),
+(92,371,l),
+(80,319,l),
+(239,319,l),
+(221,240,l),
+(261,240,l),
+(278,319,l),
+(300,319,ls),
+(369,319,o),
+(406,286,o),
+(406,222,cs),
+(406,172,o),
+(393,52,o),
+(246,52,cs),
+(24,52,l),
+(14,0,l)
+);
+}
+);
+width = 534;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F2;
+unicode = 5618;
+},
+{
+color = 9;
+glyphname = "giCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(242,0,ls),
+(417,0,o),
+(465,121,o),
+(465,217,cs),
+(465,288,o),
+(431,339,o),
+(370,353,c),
+(369,331,l),
+(493,355,o),
+(533,454,o),
+(533,536,cs),
+(533,627,o),
+(472,690,o),
+(376,690,cs),
+(159,690,l),
+(148,638,l),
+(367,638,ls),
+(433,638,o),
+(471,596,o),
+(471,531,cs),
+(471,449,o),
+(429,371,o),
+(311,371,cs),
+(302,371,l),
+(321,354,l),
+(318,382,o),
+(294,404,o),
+(264,404,cs),
+(242,404,o),
+(222,390,o),
+(213,371,c),
+(92,371,l),
+(80,319,l),
+(213,319,l),
+(222,299,o),
+(242,286,o),
+(264,286,cs),
+(294,286,o),
+(318,308,o),
+(320,336,c),
+(294,319,l),
+(300,319,ls),
+(369,319,o),
+(406,286,o),
+(406,222,cs),
+(406,172,o),
+(393,52,o),
+(246,52,cs),
+(24,52,l),
+(14,0,l)
+);
+}
+);
+width = 534;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F3;
+unicode = 5619;
+},
+{
+color = 9;
+glyphname = "gaCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (377,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(422,0,l),
+(433,52,l),
+(214,52,ls),
+(148,52,o),
+(109,94,o),
+(109,158,cs),
+(109,241,o),
+(152,319,o),
+(270,319,cs),
+(491,319,l),
+(501,371,l),
+(280,371,ls),
+(213,371,o),
+(176,404,o),
+(176,468,cs),
+(176,518,o),
+(187,638,o),
+(335,638,cs),
+(556,638,l),
+(568,690,l),
+(339,690,ls),
+(164,690,o),
+(116,569,o),
+(116,472,cs),
+(116,401,o),
+(151,351,o),
+(212,337,c),
+(213,358,l),
+(88,335,o),
+(48,237,o),
+(48,154,cs),
+(48,63,o),
+(108,0,o),
+(205,0,cs)
+);
+}
+);
+width = 535;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|geCarrier-canadian";
+note = uni15F4;
+unicode = 5620;
+},
+{
+color = 9;
+glyphname = "khuCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(222,-13,o),
+(273,27,o),
+(304,102,c),
+(289,103,l),
+(293,30,o),
+(335,-13,o),
+(407,-13,cs),
+(495,-13,o),
+(549,48,o),
+(575,170,cs),
+(685,690,l),
+(153,690,l),
+(43,173,ls),
+(19,58,o),
+(61,-13,o),
+(154,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(108,44,o),
+(84,87,o),
+(101,170,cs),
+(200,635,l),
+(380,635,l),
+(281,170,ls),
+(263,88,o),
+(225,44,o),
+(166,44,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(346,44,o),
+(321,89,o),
+(338,171,cs),
+(437,635,l),
+(614,635,l),
+(516,171,ls),
+(498,86,o),
+(463,44,o),
+(405,44,cs)
+);
+}
+);
+width = 645;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F5;
+unicode = 5621;
+},
+{
+color = 9;
+glyphname = "khoCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(537,0,l),
+(646,517,ls),
+(670,632,o),
+(629,702,o),
+(536,702,cs),
+(468,702,o),
+(416,663,o),
+(385,587,c),
+(402,586,l),
+(397,660,o),
+(355,702,o),
+(284,702,cs),
+(195,702,o),
+(141,641,o),
+(116,520,cs),
+(6,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(174,519,ls),
+(192,604,o),
+(227,645,o),
+(285,645,cs),
+(345,645,o),
+(370,601,o),
+(353,519,cs),
+(253,55,l),
+(76,55,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(410,520,ls),
+(427,602,o),
+(465,645,o),
+(524,645,cs),
+(582,645,o),
+(606,603,o),
+(588,520,cs),
+(490,55,l),
+(311,55,l)
+);
+}
+);
+width = 643;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F6;
+unicode = 5622;
+},
+{
+color = 9;
+glyphname = "kheCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(244,0,ls),
+(419,0,o),
+(467,120,o),
+(467,217,cs),
+(467,288,o),
+(433,338,o),
+(373,352,c),
+(373,331,l),
+(501,357,o),
+(535,460,o),
+(535,536,cs),
+(535,627,o),
+(474,690,o),
+(376,690,cs),
+(159,690,l),
+(13,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(141,319,l),
+(302,319,ls),
+(370,319,o),
+(407,286,o),
+(407,222,cs),
+(407,171,o),
+(395,52,o),
+(248,52,cs),
+(84,52,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(209,638,l),
+(369,638,ls),
+(435,638,o),
+(473,596,o),
+(473,531,cs),
+(473,453,o),
+(434,371,o),
+(313,371,cs),
+(153,371,l)
+);
+}
+);
+width = 536;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F7;
+unicode = 5623;
+},
+{
+color = 9;
+glyphname = "kheeCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(244,0,ls),
+(419,0,o),
+(467,120,o),
+(467,217,cs),
+(467,288,o),
+(433,338,o),
+(373,352,c),
+(373,331,l),
+(501,357,o),
+(535,460,o),
+(535,536,cs),
+(535,627,o),
+(474,690,o),
+(376,690,cs),
+(159,690,l),
+(13,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(141,319,l),
+(253,319,l),
+(235,231,l),
+(271,231,l),
+(293,334,l),
+(271,319,l),
+(302,319,ls),
+(370,319,o),
+(407,286,o),
+(407,222,cs),
+(407,171,o),
+(395,52,o),
+(248,52,cs),
+(84,52,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(320,461,l),
+(283,461,l),
+(264,371,l),
+(153,371,l),
+(209,638,l),
+(369,638,ls),
+(435,638,o),
+(473,596,o),
+(473,531,cs),
+(473,453,o),
+(434,371,o),
+(313,371,cs),
+(283,371,l),
+(298,356,l)
+);
+}
+);
+width = 536;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F8;
+unicode = 5624;
+},
+{
+color = 9;
+glyphname = "khiCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(244,0,ls),
+(419,0,o),
+(467,120,o),
+(467,217,cs),
+(467,284,o),
+(437,332,o),
+(383,350,c),
+(375,331,l),
+(501,358,o),
+(535,460,o),
+(535,536,cs),
+(535,627,o),
+(474,690,o),
+(376,690,cs),
+(159,690,l),
+(13,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(141,322,l),
+(225,322,l),
+(233,300,o),
+(253,286,o),
+(276,286,cs),
+(306,286,o),
+(330,310,o),
+(332,340,c),
+(288,322,l),
+(305,322,ls),
+(373,322,o),
+(407,288,o),
+(407,224,cs),
+(407,172,o),
+(395,52,o),
+(248,52,cs),
+(84,52,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(369,638,ls),
+(435,638,o),
+(473,595,o),
+(473,530,cs),
+(473,451,o),
+(437,368,o),
+(316,368,cs),
+(298,368,l),
+(332,350,l),
+(330,380,o),
+(306,404,o),
+(276,404,cs),
+(246,404,o),
+(221,380,o),
+(221,350,c),
+(238,368,l),
+(152,368,l),
+(209,638,l)
+);
+}
+);
+width = 536;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F9;
+unicode = 5625;
+},
+{
+color = 9;
+glyphname = "khaCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(425,0,l),
+(572,690,l),
+(340,690,ls),
+(164,690,o),
+(117,570,o),
+(117,472,cs),
+(117,402,o),
+(151,352,o),
+(211,338,c),
+(209,358,l),
+(81,332,o),
+(47,230,o),
+(47,154,cs),
+(47,63,o),
+(107,0,o),
+(207,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(148,52,o),
+(108,94,o),
+(108,158,cs),
+(108,237,o),
+(150,319,o),
+(270,319,cs),
+(432,319,l),
+(375,52,l),
+(213,52,ls)
+);
+},
+{
+closed = 1;
+nodes = (
+(213,371,o),
+(177,404,o),
+(177,468,cs),
+(177,519,o),
+(188,638,o),
+(335,638,cs),
+(499,638,l),
+(442,371,l),
+(281,371,ls)
+);
+}
+);
+width = 537;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15FA;
+unicode = 5626;
+},
+{
+color = 9;
+glyphname = "kkuCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(222,-13,o),
+(273,27,o),
+(304,102,c),
+(289,102,l),
+(293,30,o),
+(336,-13,o),
+(407,-13,cs),
+(495,-13,o),
+(549,48,o),
+(575,170,cs),
+(685,690,l),
+(661,690,l),
+(399,523,l),
+(387,458,l),
+(632,615,l),
+(614,635,l),
+(516,171,ls),
+(498,86,o),
+(463,44,o),
+(405,44,cs),
+(346,44,o),
+(320,89,o),
+(337,171,cs),
+(447,690,l),
+(391,690,l),
+(281,170,ls),
+(264,88,o),
+(225,44,o),
+(166,44,cs),
+(108,44,o),
+(84,88,o),
+(101,170,cs),
+(200,635,l),
+(173,628,l),
+(352,468,l),
+(363,525,l),
+(178,690,l),
+(153,690,l),
+(43,173,ls),
+(19,58,o),
+(61,-13,o),
+(154,-13,cs)
+);
+}
+);
+width = 645;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FB;
+unicode = 5627;
+},
+{
+color = 9;
+glyphname = "kkoCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(29,0,l),
+(291,167,l),
+(303,232,l),
+(58,74,l),
+(76,55,l),
+(175,519,ls),
+(192,604,o),
+(227,645,o),
+(285,645,cs),
+(344,645,o),
+(370,601,o),
+(353,519,cs),
+(242,0,l),
+(298,0,l),
+(409,520,ls),
+(426,602,o),
+(465,645,o),
+(524,645,cs),
+(582,645,o),
+(606,602,o),
+(588,520,cs),
+(491,55,l),
+(517,62,l),
+(338,222,l),
+(327,165,l),
+(512,0,l),
+(537,0,l),
+(646,517,ls),
+(670,632,o),
+(629,702,o),
+(536,702,cs),
+(468,702,o),
+(416,663,o),
+(385,587,c),
+(402,587,l),
+(397,660,o),
+(355,702,o),
+(284,702,cs),
+(195,702,o),
+(141,641,o),
+(116,520,cs),
+(6,0,l)
+);
+}
+);
+width = 643;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FC;
+unicode = 5628;
+},
+{
+color = 9;
+glyphname = "kkeCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(257,0,ls),
+(432,0,o),
+(480,121,o),
+(480,217,cs),
+(480,289,o),
+(446,338,o),
+(386,351,c),
+(386,331,l),
+(515,357,o),
+(548,460,o),
+(548,536,cs),
+(548,627,o),
+(488,690,o),
+(391,690,cs),
+(158,690,l),
+(155,670,l),
+(175,371,l),
+(94,371,l),
+(82,319,l),
+(161,319,l),
+(16,19,l),
+(12,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(223,319,l),
+(316,319,ls),
+(384,319,o),
+(420,286,o),
+(420,222,cs),
+(420,174,o),
+(409,52,o),
+(261,52,cs),
+(68,52,l),
+(81,28,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(212,665,l),
+(187,638,l),
+(383,638,ls),
+(448,638,o),
+(487,596,o),
+(487,531,cs),
+(487,449,o),
+(444,371,o),
+(327,371,cs),
+(232,371,l)
+);
+}
+);
+width = 549;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni15FD;
+unicode = 5629;
+},
+{
+color = 9;
+glyphname = "kkeeCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(257,0,ls),
+(432,0,o),
+(480,121,o),
+(480,217,cs),
+(480,289,o),
+(446,338,o),
+(386,351,c),
+(386,331,l),
+(515,357,o),
+(548,460,o),
+(548,536,cs),
+(548,627,o),
+(488,690,o),
+(391,690,cs),
+(158,690,l),
+(155,670,l),
+(175,371,l),
+(94,371,l),
+(82,319,l),
+(161,319,l),
+(16,19,l),
+(12,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(224,321,l),
+(285,321,l),
+(267,231,l),
+(303,231,l),
+(325,336,l),
+(302,321,l),
+(321,321,ls),
+(386,321,o),
+(420,286,o),
+(420,222,cs),
+(420,174,o),
+(409,52,o),
+(261,52,cs),
+(68,52,l),
+(81,28,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(352,461,l),
+(315,461,l),
+(296,370,l),
+(232,370,l),
+(212,665,l),
+(187,638,l),
+(383,638,ls),
+(448,638,o),
+(487,596,o),
+(487,531,cs),
+(487,449,o),
+(444,370,o),
+(328,370,cs),
+(312,370,l),
+(329,357,l)
+);
+}
+);
+width = 549;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FE;
+unicode = 5630;
+},
+{
+color = 9;
+glyphname = "kkiCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(257,0,ls),
+(432,0,o),
+(480,121,o),
+(480,217,cs),
+(480,289,o),
+(446,338,o),
+(386,351,c),
+(386,331,l),
+(515,357,o),
+(548,460,o),
+(548,536,cs),
+(548,627,o),
+(488,690,o),
+(391,690,cs),
+(158,690,l),
+(155,670,l),
+(175,371,l),
+(94,371,l),
+(82,319,l),
+(161,319,l),
+(16,19,l),
+(12,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(225,323,l),
+(247,323,l),
+(255,301,o),
+(275,286,o),
+(298,286,cs),
+(324,286,o),
+(346,304,o),
+(350,328,c),
+(300,323,l),
+(321,323,ls),
+(389,323,o),
+(420,286,o),
+(420,222,cs),
+(420,174,o),
+(409,52,o),
+(261,52,cs),
+(68,52,l),
+(81,28,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(348,384,o),
+(326,404,o),
+(298,404,cs),
+(275,404,o),
+(255,388,o),
+(247,367,c),
+(233,367,l),
+(212,665,l),
+(187,638,l),
+(383,638,ls),
+(448,638,o),
+(487,596,o),
+(487,531,cs),
+(487,449,o),
+(447,367,o),
+(328,367,cs),
+(300,367,l),
+(352,358,l)
+);
+}
+);
+width = 549;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FF;
+unicode = 5631;
+},
+{
+color = 9;
+glyphname = "kkaCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(438,0,l),
+(441,19,l),
+(421,319,l),
+(503,319,l),
+(515,371,l),
+(435,371,l),
+(580,670,l),
+(584,690,l),
+(339,690,ls),
+(164,690,o),
+(116,569,o),
+(116,472,cs),
+(116,401,o),
+(150,352,o),
+(210,339,c),
+(210,358,l),
+(82,332,o),
+(48,230,o),
+(48,154,cs),
+(48,63,o),
+(108,0,o),
+(205,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(409,52,l),
+(214,52,ls),
+(148,52,o),
+(109,94,o),
+(109,158,cs),
+(109,241,o),
+(152,319,o),
+(270,319,cs),
+(364,319,l),
+(385,25,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(213,371,o),
+(176,404,o),
+(176,468,cs),
+(176,516,o),
+(187,638,o),
+(335,638,cs),
+(528,638,l),
+(515,662,l),
+(373,371,l),
+(280,371,ls)
+);
+}
+);
+width = 549;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|kkeCarrier-canadian";
+note = uni1600;
+unicode = 5632;
+},
+{
+color = 6;
+glyphname = "kkCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(292,527,l),
+(134,232,l),
+(161,232,l),
+(131,527,l),
+(93,527,l),
+(90,516,l),
+(133,183,l),
+(146,183,l),
+(331,516,l),
+(334,527,l)
+);
+}
+);
+width = 303;
+}
+);
+note = uni1601;
+unicode = 5633;
+},
+{
+color = 9;
+glyphname = "nuCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(366,-13,o),
+(450,72,o),
+(484,232,cs),
+(498,298,l),
+(438,298,l),
+(424,234,ls),
+(398,109,o),
+(336,46,o),
+(241,45,cs),
+(138,45,o),
+(95,115,o),
+(121,239,cs),
+(217,690,l),
+(156,690,l),
+(61,242,ls),
+(28,87,o),
+(96,-13,o),
+(237,-13,cs)
+);
+}
+);
+width = 541;
+}
+);
+metricLeft = "te-canadian";
+note = uni1602;
+unicode = 5634;
+},
+{
+color = 9;
+glyphname = "noCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(432,0,l),
+(527,447,ls),
+(559,603,o),
+(493,702,o),
+(352,702,cs),
+(221,702,o),
+(137,617,o),
+(103,458,cs),
+(90,391,l),
+(151,391,l),
+(164,456,ls),
+(189,581,o),
+(251,643,o),
+(347,644,cs),
+(449,644,o),
+(493,575,o),
+(467,451,cs),
+(370,0,l)
+);
+}
+);
+width = 541;
+}
+);
+metricLeft = "=|nuCarrier-canadian";
+metricRight = "te-canadian";
+note = uni1603;
+unicode = 5635;
+},
+{
+color = 9;
+glyphname = "neCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (244,345);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(164,0,ls),
+(419,0,o),
+(509,273,o),
+(509,458,cs),
+(509,611,o),
+(429,690,o),
+(278,690,cs),
+(138,690,l),
+(126,633,l),
+(267,633,ls),
+(388,633,o),
+(448,577,o),
+(448,457,cs),
+(448,321,o),
+(387,57,o),
+(169,57,cs),
+(162,57,l),
+(150,0,l)
+);
+}
+);
+width = 523;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1604;
+unicode = 5636;
+},
+{
+color = 9;
+glyphname = "neeCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "neCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (183,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 523;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1605;
+unicode = 5637;
+},
+{
+color = 9;
+glyphname = "niCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "neCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (163,0);
+ref = dot_middle;
+}
+);
+width = 524;
+}
+);
+note = uni1606;
+unicode = 5638;
+},
+{
+color = 9;
+glyphname = "naCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(431,0,l),
+(443,57,l),
+(301,57,ls),
+(181,57,o),
+(121,113,o),
+(121,233,cs),
+(121,369,o),
+(182,633,o),
+(399,633,cs),
+(407,633,l),
+(418,690,l),
+(405,690,ls),
+(150,690,o),
+(60,416,o),
+(60,232,cs),
+(60,78,o),
+(140,0,o),
+(291,0,cs)
+);
+}
+);
+width = 522;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni1607;
+unicode = 5639;
+},
+{
+color = 9;
+glyphname = "muCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(226,-13,o),
+(278,31,o),
+(310,113,c),
+(288,113,l),
+(290,33,o),
+(333,-13,o),
+(407,-13,cs),
+(495,-13,o),
+(549,48,o),
+(575,170,cs),
+(621,388,l),
+(562,388,l),
+(516,171,ls),
+(498,86,o),
+(463,44,o),
+(405,44,cs),
+(346,44,o),
+(320,88,o),
+(338,171,cs),
+(384,388,l),
+(327,388,l),
+(281,170,ls),
+(264,88,o),
+(225,44,o),
+(166,44,cs),
+(108,44,o),
+(84,88,o),
+(101,170,cs),
+(212,690,l),
+(153,690,l),
+(43,173,ls),
+(19,58,o),
+(61,-13,o),
+(154,-13,cs)
+);
+}
+);
+width = 645;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "=|";
+note = uni1608;
+unicode = 5640;
+},
+{
+color = 9;
+glyphname = "moCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(537,0,l),
+(646,517,ls),
+(670,632,o),
+(629,702,o),
+(536,702,cs),
+(465,702,o),
+(412,659,o),
+(381,577,c),
+(402,577,l),
+(400,657,o),
+(356,702,o),
+(284,702,cs),
+(195,702,o),
+(141,641,o),
+(116,520,cs),
+(70,301,l),
+(128,301,l),
+(174,519,ls),
+(192,604,o),
+(227,645,o),
+(285,645,cs),
+(344,645,o),
+(370,602,o),
+(353,519,cs),
+(306,301,l),
+(363,301,l),
+(410,520,ls),
+(427,602,o),
+(465,645,o),
+(524,645,cs),
+(582,645,o),
+(606,602,o),
+(588,520,cs),
+(478,0,l)
+);
+}
+);
+width = 643;
+}
+);
+metricLeft = "=|muCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni1609;
+unicode = 5641;
+},
+{
+color = 9;
+glyphname = "meCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(241,0,ls),
+(415,0,o),
+(464,121,o),
+(464,217,cs),
+(464,289,o),
+(429,339,o),
+(368,353,c),
+(367,331,l),
+(491,355,o),
+(531,453,o),
+(531,536,cs),
+(531,627,o),
+(471,690,o),
+(375,690,cs),
+(138,690,l),
+(127,638,l),
+(366,638,ls),
+(431,638,o),
+(470,596,o),
+(470,531,cs),
+(470,449,o),
+(427,371,o),
+(309,371,cs),
+(244,371,l),
+(234,319,l),
+(298,319,ls),
+(367,319,o),
+(404,286,o),
+(404,222,cs),
+(404,172,o),
+(392,52,o),
+(244,52,cs),
+(177,52,l),
+(166,0,l)
+);
+}
+);
+width = 533;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160A;
+unicode = 5642;
+},
+{
+color = 9;
+glyphname = "meeCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(241,0,ls),
+(415,0,o),
+(464,121,o),
+(464,217,cs),
+(464,289,o),
+(429,339,o),
+(368,353,c),
+(367,331,l),
+(491,355,o),
+(531,453,o),
+(531,536,cs),
+(531,627,o),
+(471,690,o),
+(375,690,cs),
+(138,690,l),
+(127,638,l),
+(366,638,ls),
+(431,638,o),
+(470,596,o),
+(470,531,cs),
+(470,449,o),
+(427,370,o),
+(310,370,cs),
+(283,370,l),
+(302,458,l),
+(263,458,l),
+(215,233,l),
+(255,233,l),
+(272,320,l),
+(300,320,ls),
+(367,320,o),
+(404,286,o),
+(404,222,cs),
+(404,172,o),
+(392,52,o),
+(244,52,cs),
+(177,52,l),
+(166,0,l)
+);
+}
+);
+width = 533;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160B;
+unicode = 5643;
+},
+{
+color = 9;
+glyphname = "miCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(241,0,ls),
+(412,0,o),
+(456,116,o),
+(462,206,cs),
+(467,282,o),
+(433,337,o),
+(368,353,c),
+(367,331,l),
+(487,354,o),
+(526,446,o),
+(530,525,cs),
+(537,621,o),
+(476,690,o),
+(375,690,cs),
+(138,690,l),
+(127,638,l),
+(366,638,ls),
+(433,638,o),
+(471,594,o),
+(469,526,cs),
+(468,446,o),
+(425,370,o),
+(309,370,cs),
+(289,370,l),
+(321,352,l),
+(319,382,o),
+(294,404,o),
+(265,404,cs),
+(232,404,o),
+(207,376,o),
+(207,345,cs),
+(207,313,o),
+(232,286,o),
+(265,286,cs),
+(294,286,o),
+(318,308,o),
+(321,337,c),
+(288,320,l),
+(299,320,ls),
+(369,320,o),
+(406,285,o),
+(404,218,cs),
+(401,165,o),
+(386,52,o),
+(244,52,cs),
+(177,52,l),
+(166,0,l)
+);
+}
+);
+width = 531;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160C;
+unicode = 5644;
+},
+{
+color = 9;
+glyphname = "maCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(442,0,l),
+(454,52,l),
+(214,52,ls),
+(148,52,o),
+(109,94,o),
+(109,158,cs),
+(109,241,o),
+(152,319,o),
+(270,319,cs),
+(335,319,l),
+(346,371,l),
+(280,371,ls),
+(213,371,o),
+(176,404,o),
+(176,468,cs),
+(176,518,o),
+(187,638,o),
+(335,638,cs),
+(403,638,l),
+(413,690,l),
+(339,690,ls),
+(164,690,o),
+(116,569,o),
+(116,472,cs),
+(116,401,o),
+(151,351,o),
+(212,337,c),
+(213,358,l),
+(88,335,o),
+(48,237,o),
+(48,154,cs),
+(48,63,o),
+(108,0,o),
+(205,0,cs)
+);
+}
+);
+width = 534;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni160D;
+unicode = 5645;
+},
+{
+color = 9;
+glyphname = "yuCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(394,-13,o),
+(491,103,o),
+(546,363,cs),
+(594,591,o),
+(563,702,o),
+(461,702,cs),
+(337,702,o),
+(294,528,o),
+(294,442,cs),
+(294,365,o),
+(331,315,o),
+(392,315,cs),
+(407,315,o),
+(418,318,o),
+(426,323,c),
+(437,371,l),
+(426,367,o),
+(417,365,o),
+(408,365,cs),
+(368,365,o),
+(347,395,o),
+(347,447,cs),
+(347,500,o),
+(375,651,o),
+(453,651,cs),
+(517,651,o),
+(531,571,o),
+(491,378,cs),
+(441,143,o),
+(369,45,o),
+(239,45,cs),
+(135,45,o),
+(94,108,o),
+(120,233,cs),
+(217,690,l),
+(156,690,l),
+(60,236,ls),
+(27,80,o),
+(95,-13,o),
+(236,-13,cs)
+);
+}
+);
+width = 578;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160E;
+unicode = 5646;
+},
+{
+color = 9;
+glyphname = "yoCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(287,-13,o),
+(329,161,o),
+(329,247,cs),
+(329,325,o),
+(293,375,o),
+(231,375,cs),
+(217,375,o),
+(205,372,o),
+(198,367,c),
+(187,319,l),
+(197,323,o),
+(206,325,o),
+(215,325,cs),
+(255,325,o),
+(276,295,o),
+(276,242,cs),
+(276,189,o),
+(248,39,o),
+(170,39,cs),
+(106,39,o),
+(92,119,o),
+(132,312,cs),
+(183,547,o),
+(255,644,o),
+(384,644,cs),
+(489,644,o),
+(530,582,o),
+(503,457,cs),
+(407,0,l),
+(468,0,l),
+(564,454,ls),
+(596,610,o),
+(529,702,o),
+(387,702,cs),
+(229,702,o),
+(133,586,o),
+(78,327,cs),
+(30,99,o),
+(61,-13,o),
+(162,-13,cs)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160F;
+unicode = 5647;
+},
+{
+color = 9;
+glyphname = "yeCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(424,-13,o),
+(501,287,o),
+(501,441,cs),
+(501,607,o),
+(424,690,o),
+(277,690,cs),
+(154,690,l),
+(141,633,l),
+(270,633,ls),
+(383,633,o),
+(440,571,o),
+(440,437,cs),
+(440,315,o),
+(385,42,o),
+(206,42,cs),
+(129,42,o),
+(88,86,o),
+(88,166,cs),
+(88,223,o),
+(112,350,o),
+(193,350,cs),
+(230,350,o),
+(249,322,o),
+(249,270,cs),
+(249,228,o),
+(239,185,o),
+(224,145,c),
+(271,145,l),
+(286,188,o),
+(298,234,o),
+(298,277,cs),
+(298,355,o),
+(261,401,o),
+(195,401,cs),
+(78,401,o),
+(35,250,o),
+(35,162,cs),
+(35,55,o),
+(98,-13,o),
+(203,-13,cs)
+);
+}
+);
+width = 518;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1610;
+unicode = 5648;
+},
+{
+color = 9;
+glyphname = "yeeCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(426,-13,o),
+(502,294,o),
+(502,449,cs),
+(502,607,o),
+(423,690,o),
+(280,690,cs),
+(154,690,l),
+(141,633,l),
+(270,633,ls),
+(383,633,o),
+(440,571,o),
+(440,444,cs),
+(440,318,o),
+(384,42,o),
+(206,42,cs),
+(129,42,o),
+(88,85,o),
+(88,168,cs),
+(88,221,o),
+(112,350,o),
+(190,350,cs),
+(233,350,o),
+(251,308,o),
+(236,234,cs),
+(223,174,l),
+(263,174,l),
+(333,503,l),
+(293,503,l),
+(248,294,l),
+(259,294,l),
+(267,358,o),
+(237,401,o),
+(183,401,cs),
+(77,401,o),
+(36,251,o),
+(36,165,cs),
+(36,56,o),
+(97,-13,o),
+(206,-13,cs)
+);
+}
+);
+width = 518;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1611;
+unicode = 5649;
+},
+{
+color = 9;
+glyphname = "yiCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(429,-13,o),
+(502,297,o),
+(502,449,cs),
+(502,607,o),
+(424,690,o),
+(280,690,cs),
+(154,690,l),
+(141,633,l),
+(270,633,ls),
+(383,633,o),
+(440,571,o),
+(440,444,cs),
+(440,322,o),
+(388,42,o),
+(206,42,cs),
+(128,42,o),
+(87,87,o),
+(87,165,cs),
+(87,230,o),
+(108,330,o),
+(195,327,c),
+(180,344,l),
+(181,312,o),
+(208,289,o),
+(238,289,cs),
+(270,289,o),
+(296,314,o),
+(296,345,cs),
+(296,376,o),
+(270,401,o),
+(238,401,cs),
+(214,401,o),
+(194,387,o),
+(185,368,c),
+(78,366,o),
+(34,248,o),
+(34,159,cs),
+(34,54,o),
+(99,-13,o),
+(203,-13,cs)
+);
+}
+);
+width = 518;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1612;
+unicode = 5650;
+},
+{
+color = 9;
+glyphname = "yaCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(411,0,l),
+(424,57,l),
+(296,57,ls),
+(183,57,o),
+(126,119,o),
+(126,253,cs),
+(126,375,o),
+(180,648,o),
+(359,648,cs),
+(436,648,o),
+(477,604,o),
+(477,524,cs),
+(477,467,o),
+(453,340,o),
+(372,340,cs),
+(335,340,o),
+(316,368,o),
+(316,420,cs),
+(316,463,o),
+(326,504,o),
+(341,545,c),
+(294,545,l),
+(279,501,o),
+(268,456,o),
+(268,412,cs),
+(268,335,o),
+(304,289,o),
+(370,289,cs),
+(487,289,o),
+(530,440,o),
+(530,527,cs),
+(530,635,o),
+(468,702,o),
+(362,702,cs),
+(140,702,o),
+(63,403,o),
+(63,248,cs),
+(63,83,o),
+(141,0,o),
+(288,0,cs)
+);
+}
+);
+width = 518;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|yeCarrier-canadian";
+note = uni1613;
+unicode = 5651;
+},
+{
+color = 9;
+glyphname = "juCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(423,-13,o),
+(485,145,o),
+(485,259,cs),
+(485,345,o),
+(443,401,o),
+(375,401,cs),
+(298,401,o),
+(253,336,o),
+(235,232,cs),
+(228,199,o),
+(226,165,o),
+(227,145,c),
+(273,145,l),
+(274,163,o),
+(274,192,o),
+(282,232,cs),
+(300,311,o),
+(332,350,o),
+(373,350,cs),
+(411,350,o),
+(433,316,o),
+(433,258,cs),
+(433,171,o),
+(392,42,o),
+(261,42,cs),
+(169,42,o),
+(122,101,o),
+(122,210,cs),
+(122,325,o),
+(174,633,o),
+(487,633,cs),
+(559,633,l),
+(571,690,l),
+(146,690,l),
+(134,635,l),
+(384,635,l),
+(405,654,l),
+(165,648,o),
+(62,396,o),
+(62,213,cs),
+(62,71,o),
+(132,-13,o),
+(258,-13,cs)
+);
+}
+);
+width = 531;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni1614;
+unicode = 5652;
+},
+{
+color = 9;
+glyphname = "juSayisi-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (385,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(404,-13,o),
+(486,218,o),
+(496,378,cs),
+(505,546,o),
+(425,652,o),
+(273,660,c),
+(313,635,l),
+(565,635,l),
+(577,690,l),
+(151,690,l),
+(139,633,l),
+(200,633,ls),
+(367,633,o),
+(444,549,o),
+(436,386,cs),
+(430,263,o),
+(379,42,o),
+(213,42,cs),
+(129,42,o),
+(83,91,o),
+(87,178,cs),
+(89,234,o),
+(115,350,o),
+(188,350,cs),
+(227,350,o),
+(244,320,o),
+(242,264,cs),
+(242,231,o),
+(232,176,o),
+(219,145,c),
+(266,145,l),
+(280,185,o),
+(291,227,o),
+(292,269,cs),
+(297,351,o),
+(261,401,o),
+(191,401,cs),
+(84,401,o),
+(42,266,o),
+(35,183,cs),
+(26,66,o),
+(95,-13,o),
+(213,-13,cs)
+);
+}
+);
+width = 529;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1615;
+unicode = 5653;
+},
+{
+color = 9;
+glyphname = "joCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(431,0,l),
+(442,55,l),
+(192,55,l),
+(171,36,l),
+(411,42,o),
+(515,294,o),
+(515,477,cs),
+(515,618,o),
+(443,702,o),
+(319,702,cs),
+(154,702,o),
+(92,545,o),
+(92,431,cs),
+(92,345,o),
+(132,289,o),
+(201,289,cs),
+(277,289,o),
+(324,354,o),
+(342,458,cs),
+(348,491,o),
+(350,525,o),
+(350,545,c),
+(302,545,l),
+(302,526,o),
+(302,497,o),
+(294,458,cs),
+(275,379,o),
+(244,340,o),
+(204,340,cs),
+(165,340,o),
+(144,374,o),
+(144,432,cs),
+(144,519,o),
+(184,648,o),
+(316,648,cs),
+(407,648,o),
+(454,588,o),
+(454,480,cs),
+(454,365,o),
+(402,57,o),
+(90,57,cs),
+(17,57,l),
+(5,0,l)
+);
+}
+);
+width = 530;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1616;
+unicode = 5654;
+},
+{
+color = 9;
+glyphname = "jeCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(502,-13,o),
+(551,333,o),
+(551,470,cs),
+(551,618,o),
+(497,702,o),
+(387,702,cs),
+(280,702,o),
+(205,622,o),
+(156,453,c),
+(170,455,l),
+(220,690,l),
+(159,690,l),
+(13,0,l),
+(73,0,l),
+(136,294,ls),
+(186,535,o),
+(261,644,o),
+(374,644,cs),
+(456,644,o),
+(493,587,o),
+(493,469,cs),
+(493,375,o),
+(455,39,o),
+(337,39,cs),
+(298,39,o),
+(279,66,o),
+(279,119,cs),
+(279,186,o),
+(308,325,o),
+(399,325,cs),
+(412,325,o),
+(423,322,o),
+(429,319,c),
+(438,367,l),
+(426,372,o),
+(412,375,o),
+(396,375,cs),
+(271,375,o),
+(227,209,o),
+(227,118,cs),
+(227,36,o),
+(265,-13,o),
+(333,-13,cs)
+);
+}
+);
+width = 581;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "te-canadian";
+note = uni1617;
+unicode = 5655;
+},
+{
+color = 9;
+glyphname = "jeeCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(502,-13,o),
+(551,335,o),
+(551,469,cs),
+(551,618,o),
+(497,702,o),
+(387,702,cs),
+(279,702,o),
+(205,621,o),
+(156,453,c),
+(170,455,l),
+(220,690,l),
+(159,690,l),
+(13,0,l),
+(73,0,l),
+(135,289,ls),
+(187,536,o),
+(259,644,o),
+(373,644,cs),
+(456,644,o),
+(493,587,o),
+(493,469,cs),
+(493,356,o),
+(454,39,o),
+(329,39,cs),
+(285,39,o),
+(262,69,o),
+(262,128,cs),
+(262,189,o),
+(288,309,o),
+(362,328,c),
+(344,238,l),
+(378,238,l),
+(422,449,l),
+(388,449,l),
+(371,366,l),
+(264,347,o),
+(227,197,o),
+(227,117,cs),
+(227,36,o),
+(265,-13,o),
+(333,-13,cs)
+);
+}
+);
+width = 581;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1618;
+unicode = 5656;
+},
+{
+color = 9;
+glyphname = "jiCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(502,-13,o),
+(551,335,o),
+(551,469,cs),
+(551,618,o),
+(497,702,o),
+(387,702,cs),
+(279,702,o),
+(205,621,o),
+(156,453,c),
+(170,455,l),
+(220,690,l),
+(159,690,l),
+(13,0,l),
+(73,0,l),
+(135,289,ls),
+(187,536,o),
+(259,644,o),
+(373,644,cs),
+(456,644,o),
+(493,587,o),
+(493,469,cs),
+(493,356,o),
+(454,39,o),
+(329,39,cs),
+(285,39,o),
+(262,69,o),
+(262,128,cs),
+(262,182,o),
+(282,280,o),
+(339,313,c),
+(347,298,o),
+(362,287,o),
+(381,287,cs),
+(410,287,o),
+(435,312,o),
+(435,343,cs),
+(435,374,o),
+(411,398,o),
+(381,398,cs),
+(351,398,o),
+(328,372,o),
+(329,345,c),
+(254,303,o),
+(227,185,o),
+(227,117,cs),
+(227,36,o),
+(265,-13,o),
+(333,-13,cs)
+);
+}
+);
+width = 581;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1619;
+unicode = 5657;
+},
+{
+color = 9;
+glyphname = "jiSayisi-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(484,-13,o),
+(568,365,o),
+(568,530,cs),
+(568,648,o),
+(532,702,o),
+(460,702,cs),
+(333,702,o),
+(298,525,o),
+(298,443,cs),
+(298,355,o),
+(341,315,o),
+(393,315,cs),
+(409,315,o),
+(419,317,o),
+(428,323,c),
+(440,371,l),
+(432,367,o),
+(423,365,o),
+(410,365,cs),
+(375,365,o),
+(349,388,o),
+(349,449,cs),
+(349,491,o),
+(372,651,o),
+(456,651,cs),
+(496,651,o),
+(514,620,o),
+(514,540,cs),
+(514,410,o),
+(446,45,o),
+(260,45,cs),
+(106,45,o),
+(127,253,o),
+(156,391,cs),
+(220,690,l),
+(159,690,l),
+(13,0,l),
+(73,0,l),
+(138,308,l),
+(123,316,l),
+(90,163,o),
+(106,-13,o),
+(265,-13,cs)
+);
+}
+);
+width = 581;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161A;
+unicode = 5658;
+},
+{
+color = 9;
+glyphname = "jaCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (380,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(347,-12,o),
+(421,69,o),
+(471,237,c),
+(456,235,l),
+(407,0,l),
+(468,0,l),
+(614,690,l),
+(554,690,l),
+(491,396,ls),
+(440,156,o),
+(366,45,o),
+(253,45,cs),
+(171,45,o),
+(134,102,o),
+(134,221,cs),
+(134,315,o),
+(172,652,o),
+(290,652,cs),
+(327,652,o),
+(348,624,o),
+(348,572,cs),
+(348,503,o),
+(319,365,o),
+(228,365,cs),
+(215,365,o),
+(204,368,o),
+(198,371,c),
+(189,323,l),
+(201,318,o),
+(215,315,o),
+(231,315,cs),
+(355,315,o),
+(399,481,o),
+(399,572,cs),
+(399,654,o),
+(362,702,o),
+(294,702,cs),
+(125,702,o),
+(76,356,o),
+(76,219,cs),
+(76,72,o),
+(130,-12,o),
+(240,-12,cs)
+);
+}
+);
+width = 580;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni161B;
+unicode = 5659;
+},
+{
+color = 9;
+glyphname = "jjuCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(412,-13,o),
+(480,144,o),
+(480,262,cs),
+(480,347,o),
+(440,401,o),
+(372,401,cs),
+(301,401,o),
+(257,347,o),
+(231,237,cs),
+(223,207,o),
+(219,170,o),
+(219,145,c),
+(267,145,l),
+(268,159,o),
+(269,188,o),
+(276,225,cs),
+(295,307,o),
+(326,350,o),
+(368,350,cs),
+(406,350,o),
+(427,316,o),
+(427,260,cs),
+(427,174,o),
+(387,41,o),
+(255,41,cs),
+(170,41,o),
+(126,100,o),
+(126,212,cs),
+(126,378,o),
+(205,633,o),
+(461,633,cs),
+(554,633,l),
+(565,690,l),
+(471,690,ls),
+(377,690,o),
+(300,662,o),
+(241,616,c),
+(173,702,l),
+(124,664,l),
+(193,575,l),
+(98,476,o),
+(66,325,o),
+(66,215,cs),
+(66,75,o),
+(133,-13,o),
+(252,-13,cs)
+);
+}
+);
+width = 525;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni161C;
+unicode = 5660;
+},
+{
+color = 9;
+glyphname = "jjoCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(447,26,l),
+(378,115,l),
+(473,213,o),
+(505,365,o),
+(505,474,cs),
+(505,614,o),
+(438,702,o),
+(319,702,cs),
+(157,702,o),
+(91,546,o),
+(91,428,cs),
+(91,343,o),
+(131,289,o),
+(199,289,cs),
+(269,289,o),
+(314,343,o),
+(340,453,cs),
+(347,483,o),
+(352,520,o),
+(352,545,c),
+(304,545,l),
+(303,530,o),
+(301,501,o),
+(295,465,cs),
+(276,383,o),
+(245,340,o),
+(203,340,cs),
+(164,340,o),
+(143,374,o),
+(143,430,cs),
+(143,516,o),
+(184,649,o),
+(316,649,cs),
+(401,649,o),
+(445,589,o),
+(445,478,cs),
+(445,312,o),
+(366,57,o),
+(109,57,cs),
+(17,57,l),
+(5,0,l),
+(99,0,ls),
+(194,0,o),
+(270,28,o),
+(330,73,c),
+(397,-13,l)
+);
+}
+);
+width = 525;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|jjuCarrier-canadian";
+note = uni161D;
+unicode = 5661;
+},
+{
+color = 9;
+glyphname = "jjeCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(505,-13,o),
+(553,333,o),
+(553,469,cs),
+(553,627,o),
+(486,702,o),
+(366,702,cs),
+(314,702,o),
+(258,685,o),
+(211,639,c),
+(159,701,l),
+(114,659,l),
+(171,591,l),
+(144,553,o),
+(122,502,o),
+(107,436,cs),
+(14,0,l),
+(75,0,l),
+(167,434,ls),
+(197,573,o),
+(264,644,o),
+(363,644,cs),
+(453,644,o),
+(495,590,o),
+(495,469,cs),
+(495,376,o),
+(457,39,o),
+(339,39,cs),
+(300,39,o),
+(281,66,o),
+(281,119,cs),
+(281,186,o),
+(310,325,o),
+(401,325,cs),
+(413,325,o),
+(424,322,o),
+(431,319,c),
+(440,367,l),
+(428,372,o),
+(413,375,o),
+(397,375,cs),
+(274,375,o),
+(230,209,o),
+(230,118,cs),
+(230,36,o),
+(267,-13,o),
+(335,-13,cs)
+);
+}
+);
+width = 583;
+}
+);
+metricRight = "jeCarrier-canadian";
+note = uni161E;
+unicode = 5662;
+},
+{
+color = 9;
+glyphname = "jjeeCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(505,-13,o),
+(553,333,o),
+(553,469,cs),
+(553,627,o),
+(486,702,o),
+(366,702,cs),
+(314,702,o),
+(258,685,o),
+(211,639,c),
+(159,701,l),
+(114,659,l),
+(171,591,l),
+(144,553,o),
+(122,502,o),
+(107,436,cs),
+(14,0,l),
+(75,0,l),
+(167,434,ls),
+(197,573,o),
+(264,644,o),
+(363,644,cs),
+(453,644,o),
+(495,590,o),
+(495,469,cs),
+(495,369,o),
+(459,39,o),
+(333,39,cs),
+(289,39,o),
+(265,68,o),
+(265,128,cs),
+(265,198,o),
+(291,314,o),
+(366,329,c),
+(347,238,l),
+(381,238,l),
+(426,449,l),
+(391,449,l),
+(374,366,l),
+(269,349,o),
+(230,203,o),
+(230,118,cs),
+(230,36,o),
+(267,-13,o),
+(335,-13,cs)
+);
+}
+);
+width = 583;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161F;
+unicode = 5663;
+},
+{
+color = 9;
+glyphname = "jjiCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(425,-13,o),
+(488,67,o),
+(533,275,cs),
+(593,547,o),
+(531,702,o),
+(366,702,cs),
+(304,702,o),
+(252,681,o),
+(210,640,c),
+(159,701,l),
+(114,659,l),
+(170,593,l),
+(142,553,o),
+(121,499,o),
+(107,436,cs),
+(14,0,l),
+(75,0,l),
+(167,434,ls),
+(197,573,o),
+(264,644,o),
+(363,644,cs),
+(491,644,o),
+(529,521,o),
+(475,279,cs),
+(436,96,o),
+(393,39,o),
+(332,39,cs),
+(270,39,o),
+(251,97,o),
+(274,201,cs),
+(288,262,o),
+(310,298,o),
+(340,313,c),
+(347,298,o),
+(363,287,o),
+(382,287,cs),
+(411,287,o),
+(435,312,o),
+(435,343,cs),
+(435,373,o),
+(412,398,o),
+(382,398,cs),
+(349,398,o),
+(330,368,o),
+(330,343,c),
+(289,322,o),
+(257,272,o),
+(240,197,cs),
+(212,67,o),
+(248,-13,o),
+(335,-13,cs)
+);
+}
+);
+width = 584;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1620;
+unicode = 5664;
+},
+{
+color = 9;
+glyphname = "jjaCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(315,-13,o),
+(372,5,o),
+(419,50,c),
+(470,-12,l),
+(516,31,l),
+(459,99,l),
+(486,137,o),
+(507,187,o),
+(522,254,cs),
+(615,690,l),
+(554,690,l),
+(462,256,ls),
+(432,117,o),
+(365,45,o),
+(267,45,cs),
+(177,45,o),
+(134,99,o),
+(134,220,cs),
+(134,314,o),
+(172,651,o),
+(290,651,cs),
+(328,651,o),
+(348,624,o),
+(348,571,cs),
+(348,503,o),
+(319,365,o),
+(229,365,cs),
+(216,365,o),
+(205,368,o),
+(199,371,c),
+(190,323,l),
+(201,318,o),
+(216,315,o),
+(232,315,cs),
+(355,315,o),
+(400,481,o),
+(400,572,cs),
+(400,654,o),
+(363,702,o),
+(295,702,cs),
+(125,702,o),
+(76,356,o),
+(76,220,cs),
+(76,63,o),
+(143,-13,o),
+(264,-13,cs)
+);
+}
+);
+width = 584;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "=|jjeCarrier-canadian";
+note = uni1621;
+unicode = 5665;
+},
+{
+color = 9;
+glyphname = "luCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(370,-13,o),
+(442,60,o),
+(475,216,cs),
+(576,690,l),
+(515,690,l),
+(414,221,ls),
+(389,100,o),
+(337,44,o),
+(250,44,cs),
+(164,44,o),
+(122,101,o),
+(122,208,cs),
+(122,325,o),
+(174,620,o),
+(375,639,c),
+(386,690,l),
+(144,690,l),
+(132,639,l),
+(299,639,l),
+(342,655,l),
+(143,648,o),
+(60,365,o),
+(60,206,cs),
+(60,67,o),
+(125,-13,o),
+(248,-13,cs)
+);
+}
+);
+width = 538;
+}
+);
+metricRight = "te-canadian";
+note = uni1622;
+unicode = 5666;
+},
+{
+color = 9;
+glyphname = "loCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(71,0,l),
+(170,469,ls),
+(196,589,o),
+(248,645,o),
+(335,645,cs),
+(420,645,o),
+(463,588,o),
+(463,482,cs),
+(463,365,o),
+(412,70,o),
+(210,50,c),
+(199,0,l),
+(440,0,l),
+(452,51,l),
+(285,51,l),
+(242,35,l),
+(441,42,o),
+(526,325,o),
+(526,484,cs),
+(526,623,o),
+(460,702,o),
+(336,702,cs),
+(215,702,o),
+(143,630,o),
+(110,473,cs),
+(9,0,l)
+);
+}
+);
+width = 537;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|luCarrier-canadian";
+note = uni1623;
+unicode = 5667;
+},
+{
+color = 9;
+glyphname = "leCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (283,345);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(158,0,ls),
+(439,0,o),
+(509,296,o),
+(509,466,cs),
+(509,616,o),
+(455,702,o),
+(359,702,cs),
+(278,702,o),
+(209,636,o),
+(165,516,c),
+(175,516,l),
+(211,690,l),
+(156,690,l),
+(92,385,l),
+(144,385,l),
+(179,547,o),
+(254,644,o),
+(340,644,cs),
+(412,644,o),
+(447,582,o),
+(447,461,cs),
+(447,327,o),
+(392,57,o),
+(159,57,cs),
+(21,57,l),
+(10,0,l)
+);
+}
+);
+width = 523;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1624;
+unicode = 5668;
+},
+{
+color = 9;
+glyphname = "leeCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "leCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (222,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 523;
+}
+);
+metricLeft = "leCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1625;
+unicode = 5669;
+},
+{
+color = 9;
+glyphname = "liCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "leCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (202,0);
+ref = dot_middle;
+}
+);
+width = 523;
+}
+);
+note = uni1626;
+unicode = 5670;
+},
+{
+color = 9;
+glyphname = "laCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(412,0,l),
+(425,57,l),
+(302,57,ls),
+(181,57,o),
+(121,111,o),
+(121,232,cs),
+(121,357,o),
+(187,644,o),
+(342,644,cs),
+(432,644,o),
+(469,544,o),
+(443,385,c),
+(495,385,l),
+(559,690,l),
+(504,690,l),
+(463,496,l),
+(470,494,l),
+(479,625,o),
+(429,702,o),
+(339,702,cs),
+(144,702,o),
+(59,385,o),
+(59,231,cs),
+(59,78,o),
+(138,0,o),
+(291,0,cs)
+);
+}
+);
+width = 522;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|leCarrier-canadian";
+note = uni1627;
+unicode = 5671;
+},
+{
+color = 1;
+glyphname = "dluCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(466,-13,o),
+(513,338,o),
+(513,441,cs),
+(513,563,o),
+(466,635,o),
+(371,654,c),
+(379,641,l),
+(567,641,l),
+(550,558,l),
+(596,558,l),
+(642,773,l),
+(595,773,l),
+(578,690,l),
+(345,690,l),
+(334,639,l),
+(424,619,o),
+(457,561,o),
+(457,455,cs),
+(457,377,o),
+(419,44,o),
+(223,44,cs),
+(127,44,o),
+(95,113,o),
+(125,252,cs),
+(217,690,l),
+(156,690,l),
+(65,260,ls),
+(27,82,o),
+(81,-13,o),
+(217,-13,cs)
+);
+}
+);
+width = 561;
+}
+);
+metricLeft = "te-canadian";
+note = uni1628;
+unicode = 5672;
+},
+{
+color = 9;
+glyphname = "dloCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(461,-83,l),
+(506,131,l),
+(459,131,l),
+(441,48,l),
+(280,48,l),
+(240,37,l),
+(426,42,o),
+(526,305,o),
+(526,484,cs),
+(526,623,o),
+(460,702,o),
+(336,702,cs),
+(215,702,o),
+(143,630,o),
+(110,473,cs),
+(9,0,l),
+(71,0,l),
+(170,469,ls),
+(196,589,o),
+(248,645,o),
+(335,645,cs),
+(420,645,o),
+(463,588,o),
+(463,482,cs),
+(463,365,o),
+(412,70,o),
+(210,50,c),
+(199,0,l),
+(432,0,l),
+(414,-83,l)
+);
+}
+);
+width = 562;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "dluCarrier-canadian";
+note = uni1629;
+unicode = 5673;
+},
+{
+color = 9;
+glyphname = "dleCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (295,345);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(169,0,ls),
+(449,0,o),
+(520,296,o),
+(520,466,cs),
+(520,616,o),
+(465,702,o),
+(370,702,cs),
+(288,702,o),
+(213,634,o),
+(170,509,c),
+(176,509,l),
+(216,704,l),
+(277,704,l),
+(287,750,l),
+(120,750,l),
+(110,704,l),
+(170,704,l),
+(102,385,l),
+(154,385,l),
+(189,547,o),
+(264,644,o),
+(351,644,cs),
+(422,644,o),
+(458,582,o),
+(458,461,cs),
+(458,327,o),
+(403,57,o),
+(170,57,cs),
+(32,57,l),
+(20,0,l)
+);
+}
+);
+width = 533;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni162A;
+unicode = 5674;
+},
+{
+color = 9;
+glyphname = "dleeCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (233,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 533;
+}
+);
+note = uni162B;
+unicode = 5675;
+},
+{
+color = 9;
+glyphname = "dliCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (213,0);
+ref = dot_middle;
+}
+);
+width = 533;
+}
+);
+note = uni162C;
+unicode = 5676;
+},
+{
+color = 9;
+glyphname = "dlaCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(412,0,l),
+(425,57,l),
+(302,57,ls),
+(181,57,o),
+(121,111,o),
+(121,232,cs),
+(121,357,o),
+(187,644,o),
+(342,644,cs),
+(432,644,o),
+(469,544,o),
+(443,385,c),
+(495,385,l),
+(562,704,l),
+(621,704,l),
+(632,750,l),
+(466,750,l),
+(455,704,l),
+(516,704,l),
+(470,491,l),
+(478,489,l),
+(487,625,o),
+(429,702,o),
+(339,702,cs),
+(144,702,o),
+(59,385,o),
+(59,231,cs),
+(59,78,o),
+(138,0,o),
+(291,0,cs)
+);
+}
+);
+width = 534;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni162D;
+unicode = 5677;
+},
+{
+color = 9;
+glyphname = "lhuCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(470,-13,o),
+(534,280,o),
+(534,440,cs),
+(534,549,o),
+(500,628,o),
+(436,658,c),
+(451,639,l),
+(598,639,l),
+(610,690,l),
+(420,690,l),
+(410,639,l),
+(455,620,o),
+(478,559,o),
+(478,472,cs),
+(478,339,o),
+(431,44,o),
+(248,44,cs),
+(163,44,o),
+(123,99,o),
+(123,207,cs),
+(123,325,o),
+(176,592,o),
+(322,639,c),
+(333,690,l),
+(144,690,l),
+(132,639,l),
+(279,639,l),
+(302,663,l),
+(128,611,o),
+(60,348,o),
+(60,205,cs),
+(60,66,o),
+(123,-13,o),
+(245,-13,cs)
+);
+}
+);
+width = 559;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162E;
+unicode = 5678;
+},
+{
+color = 9;
+glyphname = "lhoCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(185,0,l),
+(196,50,l),
+(150,70,o),
+(127,130,o),
+(127,217,cs),
+(127,351,o),
+(175,645,o),
+(357,645,cs),
+(441,645,o),
+(483,590,o),
+(483,483,cs),
+(483,365,o),
+(430,98,o),
+(283,50,c),
+(272,0,l),
+(462,0,l),
+(472,51,l),
+(327,51,l),
+(303,27,l),
+(477,79,o),
+(546,342,o),
+(546,485,cs),
+(546,624,o),
+(482,702,o),
+(360,702,cs),
+(135,702,o),
+(71,410,o),
+(71,250,cs),
+(71,141,o),
+(105,62,o),
+(170,32,c),
+(155,51,l),
+(8,51,l),
+(-4,0,l)
+);
+}
+);
+width = 558;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162F;
+unicode = 5679;
+},
+{
+color = 9;
+glyphname = "lheCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (297,345);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(453,-13,o),
+(530,298,o),
+(530,469,cs),
+(530,615,o),
+(470,702,o),
+(363,702,cs),
+(280,702,o),
+(218,650,o),
+(180,549,c),
+(184,547,l),
+(214,690,l),
+(159,690,l),
+(101,419,l),
+(154,419,l),
+(191,573,o),
+(254,644,o),
+(343,644,cs),
+(426,644,o),
+(470,582,o),
+(470,470,cs),
+(470,339,o),
+(413,45,o),
+(237,45,cs),
+(140,45,o),
+(95,132,o),
+(122,270,c),
+(70,270,l),
+(13,0,l),
+(68,0,l),
+(104,179,l),
+(96,179,l),
+(88,62,o),
+(146,-13,o),
+(247,-13,cs)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1630;
+unicode = 5680;
+},
+{
+color = 9;
+glyphname = "lheeCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (236,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 544;
+}
+);
+note = uni1631;
+unicode = 5681;
+},
+{
+color = 9;
+glyphname = "lhiCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (216,0);
+ref = dot_middle;
+}
+);
+width = 544;
+}
+);
+note = uni1632;
+unicode = 5682;
+},
+{
+color = 9;
+glyphname = "lhaCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(310,-13,o),
+(372,40,o),
+(410,141,c),
+(407,143,l),
+(376,0,l),
+(431,0,l),
+(489,270,l),
+(437,270,l),
+(399,117,o),
+(336,45,o),
+(246,45,cs),
+(163,45,o),
+(121,107,o),
+(121,219,cs),
+(121,351,o),
+(177,644,o),
+(354,644,cs),
+(450,644,o),
+(496,557,o),
+(469,419,c),
+(521,419,l),
+(578,690,l),
+(523,690,l),
+(485,511,l),
+(494,511,l),
+(502,628,o),
+(444,702,o),
+(345,702,cs),
+(137,702,o),
+(60,391,o),
+(60,220,cs),
+(60,74,o),
+(120,-13,o),
+(227,-13,cs)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1633;
+unicode = 5683;
+},
+{
+color = 9;
+glyphname = "tlhuCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(470,-13,o),
+(534,280,o),
+(534,440,cs),
+(534,544,o),
+(508,624,o),
+(442,658,c),
+(439,641,l),
+(589,641,l),
+(572,558,l),
+(618,558,l),
+(664,773,l),
+(617,773,l),
+(599,690,l),
+(420,690,l),
+(410,639,l),
+(455,620,o),
+(478,559,o),
+(478,472,cs),
+(478,339,o),
+(431,44,o),
+(248,44,cs),
+(163,44,o),
+(123,99,o),
+(123,207,cs),
+(123,325,o),
+(176,592,o),
+(322,639,c),
+(333,690,l),
+(144,690,l),
+(132,639,l),
+(289,639,l),
+(281,655,l),
+(122,593,o),
+(60,342,o),
+(60,205,cs),
+(60,66,o),
+(123,-13,o),
+(245,-13,cs)
+);
+}
+);
+width = 582;
+}
+);
+metricLeft = "lhuCarrier-canadian";
+note = uni1634;
+unicode = 5684;
+},
+{
+color = 9;
+glyphname = "tlhoCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(11,-83,l),
+(29,0,l),
+(208,0,l),
+(219,50,l),
+(173,70,o),
+(150,130,o),
+(150,217,cs),
+(150,351,o),
+(197,645,o),
+(380,645,cs),
+(465,645,o),
+(506,590,o),
+(506,483,cs),
+(506,365,o),
+(452,98,o),
+(306,50,c),
+(296,0,l),
+(484,0,l),
+(496,51,l),
+(340,51,l),
+(348,35,l),
+(506,97,o),
+(568,348,o),
+(568,485,cs),
+(568,624,o),
+(505,702,o),
+(383,702,cs),
+(157,702,o),
+(94,410,o),
+(94,250,cs),
+(94,146,o),
+(120,66,o),
+(185,32,c),
+(189,48,l),
+(38,48,l),
+(56,131,l),
+(10,131,l),
+(-36,-83,l)
+);
+}
+);
+width = 581;
+}
+);
+metricLeft = "=|tlhuCarrier-canadian";
+metricRight = "lhuCarrier-canadian";
+note = uni1635;
+unicode = 5685;
+},
+{
+color = 9;
+glyphname = "tlheCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (303,345);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(460,-13,o),
+(539,298,o),
+(539,469,cs),
+(539,615,o),
+(478,702,o),
+(371,702,cs),
+(277,702,o),
+(212,640,o),
+(172,528,c),
+(184,548,l),
+(216,704,l),
+(276,704,l),
+(286,750,l),
+(120,750,l),
+(110,704,l),
+(170,704,l),
+(109,419,l),
+(160,419,l),
+(198,573,o),
+(262,644,o),
+(351,644,cs),
+(434,644,o),
+(478,582,o),
+(478,470,cs),
+(478,339,o),
+(421,45,o),
+(244,45,cs),
+(147,45,o),
+(102,132,o),
+(128,270,c),
+(77,270,l),
+(20,0,l),
+(74,0,l),
+(112,179,l),
+(103,179,l),
+(96,62,o),
+(153,-13,o),
+(255,-13,cs)
+);
+}
+);
+width = 552;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1636;
+unicode = 5686;
+},
+{
+color = 9;
+glyphname = "tlheeCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (242,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 553;
+}
+);
+note = uni1637;
+unicode = 5687;
+},
+{
+color = 9;
+glyphname = "tlhiCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (222,0);
+ref = dot_middle;
+}
+);
+width = 553;
+}
+);
+note = uni1638;
+unicode = 5688;
+},
+{
+color = 9;
+glyphname = "tlhaCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(310,-13,o),
+(372,40,o),
+(411,141,c),
+(407,143,l),
+(377,0,l),
+(431,0,l),
+(489,270,l),
+(438,270,l),
+(400,117,o),
+(336,45,o),
+(246,45,cs),
+(163,45,o),
+(121,107,o),
+(121,219,cs),
+(121,351,o),
+(177,644,o),
+(354,644,cs),
+(451,644,o),
+(496,557,o),
+(469,419,c),
+(521,419,l),
+(582,704,l),
+(640,704,l),
+(651,750,l),
+(485,750,l),
+(475,704,l),
+(535,704,l),
+(493,506,l),
+(501,505,l),
+(509,631,o),
+(445,702,o),
+(345,702,cs),
+(137,702,o),
+(60,391,o),
+(60,220,cs),
+(60,74,o),
+(120,-13,o),
+(227,-13,cs)
+);
+}
+);
+width = 553;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni1639;
+unicode = 5689;
+},
+{
+color = 9;
+glyphname = "tluCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(228,-13,o),
+(271,24,o),
+(307,108,c),
+(290,109,l),
+(294,31,o),
+(330,-13,o),
+(397,-13,cs),
+(569,-13,o),
+(625,329,o),
+(625,465,cs),
+(625,564,o),
+(595,623,o),
+(537,650,c),
+(523,641,l),
+(676,641,l),
+(659,558,l),
+(705,558,l),
+(751,773,l),
+(703,773,l),
+(686,690,l),
+(465,690,l),
+(454,639,l),
+(531,636,o),
+(568,589,o),
+(568,481,cs),
+(568,368,o),
+(517,44,o),
+(397,44,cs),
+(340,44,o),
+(322,93,o),
+(342,186,cs),
+(366,298,l),
+(308,298,l),
+(284,185,ls),
+(264,90,o),
+(229,44,o),
+(177,44,cs),
+(131,44,o),
+(111,73,o),
+(111,156,cs),
+(111,221,o),
+(155,644,o),
+(365,639,c),
+(376,690,l),
+(145,690,l),
+(133,639,l),
+(283,639,l),
+(272,647,l),
+(108,588,o),
+(50,286,o),
+(50,149,cs),
+(50,42,o),
+(90,-13,o),
+(166,-13,cs)
+);
+}
+);
+width = 669;
+}
+);
+metricRight = "tlhuCarrier-canadian";
+note = uni163A;
+unicode = 5690;
+},
+{
+color = 1;
+glyphname = "tloCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(568,-83,l),
+(613,131,l),
+(567,131,l),
+(549,48,l),
+(407,48,l),
+(415,40,l),
+(585,98,o),
+(642,403,o),
+(642,541,cs),
+(642,648,o),
+(604,702,o),
+(527,702,cs),
+(466,702,o),
+(422,666,o),
+(386,582,c),
+(404,582,l),
+(400,659,o),
+(363,702,o),
+(297,702,cs),
+(125,702,o),
+(69,360,o),
+(69,225,cs),
+(69,129,o),
+(98,71,o),
+(153,43,c),
+(167,51,l),
+(8,51,l),
+(-3,0,l),
+(229,0,l),
+(240,50,l),
+(162,54,o),
+(126,100,o),
+(126,209,cs),
+(126,322,o),
+(177,645,o),
+(296,645,cs),
+(354,645,o),
+(371,597,o),
+(352,503,cs),
+(327,391,l),
+(385,391,l),
+(410,504,ls),
+(430,600,o),
+(465,645,o),
+(517,645,cs),
+(562,645,o),
+(582,616,o),
+(582,534,cs),
+(582,469,o),
+(539,45,o),
+(328,50,c),
+(318,0,l),
+(539,0,l),
+(522,-83,l)
+);
+}
+);
+width = 668;
+}
+);
+metricLeft = "tluCarrier-canadian";
+metricRight = "tlhuCarrier-canadian";
+note = uni163B;
+unicode = 5691;
+},
+{
+color = 9;
+glyphname = "tleCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (244,345);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(404,-13,o),
+(487,89,o),
+(487,217,cs),
+(487,292,o),
+(448,345,o),
+(384,352,c),
+(382,336,l),
+(490,342,o),
+(557,444,o),
+(557,541,cs),
+(557,636,o),
+(493,702,o),
+(390,702,cs),
+(291,702,o),
+(210,639,o),
+(173,528,c),
+(180,528,l),
+(216,704,l),
+(277,704,l),
+(287,750,l),
+(120,750,l),
+(110,704,l),
+(170,704,l),
+(109,419,l),
+(159,419,l),
+(195,571,o),
+(266,646,o),
+(370,646,cs),
+(448,646,o),
+(495,600,o),
+(495,529,cs),
+(495,445,o),
+(442,371,o),
+(355,371,cs),
+(324,371,l),
+(312,319,l),
+(342,319,ls),
+(396,319,o),
+(429,283,o),
+(429,222,cs),
+(429,123,o),
+(372,43,o),
+(262,43,cs),
+(147,43,o),
+(99,125,o),
+(128,270,c),
+(77,270,l),
+(20,0,l),
+(75,0,l),
+(109,161,l),
+(99,162,l),
+(93,57,o),
+(162,-13,o),
+(271,-13,cs)
+);
+}
+);
+width = 556;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni163C;
+unicode = 5692;
+},
+{
+color = 9;
+glyphname = "tleeCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (183,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 555;
+}
+);
+note = uni163D;
+unicode = 5693;
+},
+{
+color = 9;
+glyphname = "tliCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (168,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 555;
+}
+);
+note = uni163E;
+unicode = 5694;
+},
+{
+color = 9;
+glyphname = "tlaCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(302,-13,o),
+(378,41,o),
+(417,131,c),
+(412,142,l),
+(382,0,l),
+(437,0,l),
+(495,270,l),
+(443,270,l),
+(409,119,o),
+(338,43,o),
+(233,43,cs),
+(155,43,o),
+(108,90,o),
+(108,160,cs),
+(108,244,o),
+(160,319,o),
+(248,319,cs),
+(280,319,l),
+(291,371,l),
+(261,371,ls),
+(207,371,o),
+(174,407,o),
+(174,468,cs),
+(174,567,o),
+(231,646,o),
+(342,646,cs),
+(455,646,o),
+(503,565,o),
+(474,419,c),
+(526,419,l),
+(585,704,l),
+(645,704,l),
+(655,750,l),
+(488,750,l),
+(478,704,l),
+(539,704,l),
+(500,525,l),
+(505,531,l),
+(512,635,o),
+(442,702,o),
+(332,702,cs),
+(199,702,o),
+(116,601,o),
+(116,472,cs),
+(116,405,o),
+(148,355,o),
+(200,341,c),
+(204,351,l),
+(106,336,o),
+(46,240,o),
+(46,149,cs),
+(46,54,o),
+(110,-13,o),
+(213,-13,cs)
+);
+}
+);
+width = 557;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni163F;
+unicode = 5695;
+},
+{
+color = 9;
+glyphname = "zuCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(439,-13,o),
+(509,142,o),
+(509,316,cs),
+(509,384,o),
+(498,468,o),
+(498,532,cs),
+(498,599,o),
+(521,637,o),
+(579,637,cs),
+(597,637,l),
+(609,690,l),
+(573,690,ls),
+(480,690,o),
+(440,636,o),
+(440,528,cs),
+(440,466,o),
+(450,389,o),
+(450,315,cs),
+(450,177,o),
+(402,45,o),
+(249,45,cs),
+(157,45,o),
+(106,95,o),
+(106,177,cs),
+(106,320,o),
+(263,506,o),
+(263,610,cs),
+(263,660,o),
+(231,690,o),
+(176,690,cs),
+(142,690,l),
+(130,637,l),
+(157,637,ls),
+(188,637,o),
+(203,623,o),
+(203,598,cs),
+(203,515,o),
+(43,330,o),
+(43,171,cs),
+(43,61,o),
+(119,-13,o),
+(242,-13,cs)
+);
+}
+);
+width = 557;
+}
+);
+metricRight = "=|";
+note = uni1640;
+unicode = 5696;
+},
+{
+color = 9;
+glyphname = "zoCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(31,0,ls),
+(124,0,o),
+(163,54,o),
+(163,161,cs),
+(163,224,o),
+(154,300,o),
+(154,375,cs),
+(154,513,o),
+(203,644,o),
+(355,644,cs),
+(446,644,o),
+(498,595,o),
+(498,513,cs),
+(498,370,o),
+(341,184,o),
+(341,80,cs),
+(341,30,o),
+(373,0,o),
+(429,0,cs),
+(463,0,l),
+(473,53,l),
+(446,53,ls),
+(415,53,o),
+(401,67,o),
+(401,92,cs),
+(401,175,o),
+(561,359,o),
+(561,519,cs),
+(561,629,o),
+(485,702,o),
+(362,702,cs),
+(166,702,o),
+(96,548,o),
+(96,374,cs),
+(96,306,o),
+(106,222,o),
+(106,157,cs),
+(106,91,o),
+(84,53,o),
+(25,53,cs),
+(7,53,l),
+(-5,0,l)
+);
+}
+);
+width = 558;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1641;
+unicode = 5697;
+},
+{
+color = 9;
+glyphname = "zeCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (299,345);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(449,-13,o),
+(526,378,o),
+(526,529,cs),
+(526,640,o),
+(489,702,o),
+(423,702,cs),
+(337,702,o),
+(250,599,o),
+(214,599,cs),
+(190,599,o),
+(184,615,o),
+(192,656,cs),
+(200,690,l),
+(144,690,l),
+(133,639,ls),
+(121,582,o),
+(142,544,o),
+(186,544,cs),
+(256,544,o),
+(336,644,o),
+(401,644,cs),
+(443,644,o),
+(465,602,o),
+(465,521,cs),
+(465,399,o),
+(396,45,o),
+(270,45,cs),
+(205,45,o),
+(164,146,o),
+(95,146,cs),
+(52,146,o),
+(21,111,o),
+(9,51,cs),
+(-3,0,l),
+(53,0,l),
+(60,34,ls),
+(68,70,o),
+(85,91,o),
+(104,91,cs),
+(146,91,o),
+(191,-13,o),
+(278,-13,cs)
+);
+}
+);
+width = 529;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1642;
+unicode = 5698;
+},
+{
+color = 9;
+glyphname = "zeeCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (239,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 529;
+}
+);
+note = uni1643;
+unicode = 5699;
+},
+{
+color = 9;
+glyphname = "ziCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (219,0);
+ref = dot_middle;
+}
+);
+width = 529;
+}
+);
+note = uni1644;
+unicode = 5700;
+},
+{
+color = 9;
+glyphname = "zaCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(239,-13,o),
+(326,91,o),
+(361,91,cs),
+(385,91,o),
+(392,74,o),
+(383,34,cs),
+(376,0,l),
+(432,0,l),
+(442,51,ls),
+(455,107,o),
+(434,146,o),
+(389,146,cs),
+(320,146,o),
+(240,45,o),
+(175,45,cs),
+(132,45,o),
+(110,88,o),
+(110,169,cs),
+(110,291,o),
+(180,644,o),
+(306,644,cs),
+(371,644,o),
+(411,544,o),
+(480,544,cs),
+(523,544,o),
+(554,579,o),
+(567,639,cs),
+(579,690,l),
+(523,690,l),
+(516,656,ls),
+(508,620,o),
+(491,599,o),
+(471,599,cs),
+(430,599,o),
+(384,702,o),
+(297,702,cs),
+(127,702,o),
+(48,312,o),
+(48,160,cs),
+(48,49,o),
+(87,-13,o),
+(153,-13,cs)
+);
+}
+);
+width = 529;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|zeCarrier-canadian";
+note = uni1645;
+unicode = 5701;
+},
+{
+color = 6;
+glyphname = "zCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(262,183,l),
+(270,225,l),
+(93,225,l),
+(89,198,l),
+(327,503,l),
+(333,527,l),
+(112,527,l),
+(103,485,l),
+(278,485,l),
+(283,512,l),
+(44,207,l),
+(39,183,l)
+);
+}
+);
+width = 323;
+}
+);
+metricRight = "=|";
+note = uni1646;
+unicode = 5702;
+},
+{
+color = 6;
+glyphname = "initialzCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(153,96,l),
+(171,183,l),
+(262,183,l),
+(270,225,l),
+(83,225,l),
+(94,203,l),
+(327,503,l),
+(333,527,l),
+(244,527,l),
+(263,614,l),
+(219,614,l),
+(201,527,l),
+(112,527,l),
+(103,485,l),
+(289,485,l),
+(278,507,l),
+(44,207,l),
+(39,183,l),
+(128,183,l),
+(109,96,l)
+);
+}
+);
+width = 323;
+}
+);
+metricLeft = "zCarrier-canadian";
+metricRight = "zCarrier-canadian";
+note = uni1647;
+unicode = 5703;
+},
+{
+color = 9;
+glyphname = "dzuCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(439,-13,o),
+(509,142,o),
+(509,316,cs),
+(509,384,o),
+(498,468,o),
+(498,532,cs),
+(498,599,o),
+(521,637,o),
+(579,637,cs),
+(597,637,l),
+(609,690,l),
+(573,690,ls),
+(488,690,o),
+(447,636,o),
+(443,528,cs),
+(442,466,o),
+(452,384,o),
+(451,315,cs),
+(449,177,o),
+(402,45,o),
+(249,45,cs),
+(157,45,o),
+(106,95,o),
+(106,177,cs),
+(106,320,o),
+(260,506,o),
+(260,610,cs),
+(260,660,o),
+(231,690,o),
+(176,690,cs),
+(142,690,l),
+(130,637,l),
+(157,637,ls),
+(188,637,o),
+(203,623,o),
+(203,598,cs),
+(203,515,o),
+(43,330,o),
+(43,171,cs),
+(43,61,o),
+(119,-13,o),
+(242,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(349,490,l),
+(384,660,l),
+(435,660,l),
+(441,690,l),
+(310,690,l),
+(304,660,l),
+(355,660,l),
+(318,490,l)
+);
+}
+);
+width = 557;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1648;
+unicode = 5704;
+},
+{
+color = 9;
+glyphname = "dzoCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(31,0,ls),
+(117,0,o),
+(157,54,o),
+(161,161,cs),
+(162,224,o),
+(153,305,o),
+(154,375,cs),
+(155,513,o),
+(203,644,o),
+(355,644,cs),
+(446,644,o),
+(498,595,o),
+(498,513,cs),
+(498,370,o),
+(345,184,o),
+(345,80,cs),
+(345,30,o),
+(373,0,o),
+(429,0,cs),
+(462,0,l),
+(473,53,l),
+(446,53,ls),
+(415,53,o),
+(401,67,o),
+(401,92,cs),
+(401,175,o),
+(561,359,o),
+(561,519,cs),
+(561,629,o),
+(485,702,o),
+(362,702,cs),
+(166,702,o),
+(96,548,o),
+(96,374,cs),
+(96,306,o),
+(106,222,o),
+(106,157,cs),
+(106,91,o),
+(84,53,o),
+(25,53,cs),
+(7,53,l),
+(-5,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(294,0,l),
+(300,30,l),
+(250,30,l),
+(286,200,l),
+(256,200,l),
+(219,30,l),
+(169,30,l),
+(162,0,l)
+);
+}
+);
+width = 557;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1649;
+unicode = 5705;
+},
+{
+color = 9;
+glyphname = "dzeCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (312,345);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(464,-13,o),
+(542,378,o),
+(542,529,cs),
+(542,640,o),
+(504,702,o),
+(438,702,cs),
+(352,702,o),
+(266,599,o),
+(229,599,cs),
+(206,599,o),
+(199,615,o),
+(208,656,cs),
+(214,690,l),
+(159,690,l),
+(148,639,ls),
+(135,582,o),
+(157,544,o),
+(202,544,cs),
+(271,544,o),
+(352,644,o),
+(416,644,cs),
+(458,644,o),
+(480,602,o),
+(480,521,cs),
+(480,399,o),
+(411,45,o),
+(285,45,cs),
+(219,45,o),
+(179,146,o),
+(110,146,cs),
+(68,146,o),
+(36,111,o),
+(23,51,cs),
+(13,0,l),
+(68,0,l),
+(74,34,ls),
+(83,70,o),
+(99,91,o),
+(120,91,cs),
+(160,91,o),
+(207,-13,o),
+(294,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(101,241,l),
+(119,326,l),
+(221,326,l),
+(230,364,l),
+(127,364,l),
+(145,449,l),
+(108,449,l),
+(64,241,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164A;
+unicode = 5706;
+},
+{
+color = 9;
+glyphname = "dzeeCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "dzeCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (251,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 544;
+}
+);
+metricLeft = "dzeCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164B;
+unicode = 5707;
+},
+{
+color = 9;
+glyphname = "dziCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "dzeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (231,0);
+ref = dot_middle;
+}
+);
+width = 544;
+}
+);
+note = uni164C;
+unicode = 5708;
+},
+{
+color = 9;
+glyphname = "dzaCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(239,-13,o),
+(326,91,o),
+(361,91,cs),
+(385,91,o),
+(392,74,o),
+(383,34,cs),
+(376,0,l),
+(432,0,l),
+(442,51,ls),
+(455,107,o),
+(434,146,o),
+(389,146,cs),
+(320,146,o),
+(240,45,o),
+(175,45,cs),
+(132,45,o),
+(110,88,o),
+(110,169,cs),
+(110,291,o),
+(180,644,o),
+(306,644,cs),
+(371,644,o),
+(411,544,o),
+(481,544,cs),
+(524,544,o),
+(554,579,o),
+(567,639,cs),
+(579,690,l),
+(523,690,l),
+(516,656,ls),
+(508,620,o),
+(491,599,o),
+(471,599,cs),
+(430,599,o),
+(384,702,o),
+(297,702,cs),
+(127,702,o),
+(48,312,o),
+(48,160,cs),
+(48,49,o),
+(87,-13,o),
+(153,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(483,241,l),
+(527,449,l),
+(490,449,l),
+(471,364,l),
+(370,364,l),
+(361,326,l),
+(464,326,l),
+(445,241,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dzeCarrier-canadian";
+note = uni164D;
+unicode = 5709;
+},
+{
+color = 9;
+glyphname = "suCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(221,-13,o),
+(277,38,o),
+(312,137,c),
+(294,137,l),
+(288,40,o),
+(327,-13,o),
+(408,-13,cs),
+(539,-13,o),
+(580,137,o),
+(587,262,cs),
+(591,336,o),
+(582,444,o),
+(586,518,cs),
+(589,577,o),
+(601,637,o),
+(665,637,cs),
+(682,637,l),
+(694,690,l),
+(663,690,ls),
+(567,690,o),
+(538,619,o),
+(531,528,cs),
+(526,459,o),
+(531,347,o),
+(528,271,cs),
+(526,175,o),
+(501,44,o),
+(403,44,cs),
+(323,44,o),
+(327,136,o),
+(342,205,cs),
+(445,690,l),
+(391,690,l),
+(288,203,ls),
+(266,97,o),
+(224,44,o),
+(163,44,cs),
+(117,44,o),
+(93,72,o),
+(93,126,cs),
+(93,261,o),
+(259,506,o),
+(259,613,cs),
+(259,664,o),
+(230,690,o),
+(174,690,cs),
+(142,690,l),
+(131,637,l),
+(149,637,ls),
+(183,637,o),
+(198,623,o),
+(198,592,cs),
+(198,493,o),
+(31,272,o),
+(31,116,cs),
+(31,37,o),
+(75,-13,o),
+(148,-13,cs)
+);
+}
+);
+width = 642;
+}
+);
+metricRight = "=|";
+note = uni164E;
+unicode = 5710;
+},
+{
+color = 9;
+glyphname = "soCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(26,0,ls),
+(122,0,o),
+(151,71,o),
+(156,161,cs),
+(161,231,o),
+(156,343,o),
+(159,418,cs),
+(161,515,o),
+(187,645,o),
+(285,645,cs),
+(365,645,o),
+(361,554,o),
+(346,485,cs),
+(243,0,l),
+(297,0,l),
+(400,487,ls),
+(423,593,o),
+(464,645,o),
+(525,645,cs),
+(571,645,o),
+(595,617,o),
+(595,564,cs),
+(595,429,o),
+(430,184,o),
+(430,76,cs),
+(430,26,o),
+(458,0,o),
+(514,0,cs),
+(546,0,l),
+(557,53,l),
+(540,53,ls),
+(506,53,o),
+(490,67,o),
+(490,98,cs),
+(490,197,o),
+(657,417,o),
+(657,574,cs),
+(657,653,o),
+(613,702,o),
+(541,702,cs),
+(468,702,o),
+(411,652,o),
+(376,553,c),
+(395,553,l),
+(400,650,o),
+(361,702,o),
+(281,702,cs),
+(150,702,o),
+(108,553,o),
+(101,428,cs),
+(97,354,o),
+(105,245,o),
+(101,172,cs),
+(99,113,o),
+(87,53,o),
+(23,53,cs),
+(6,53,l),
+(-5,0,l)
+);
+}
+);
+width = 641;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5711;
+},
+{
+color = 9;
+glyphname = "seCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(420,-13,o),
+(478,131,o),
+(478,221,cs),
+(478,298,o),
+(441,346,o),
+(378,353,c),
+(375,337,l),
+(510,349,o),
+(553,481,o),
+(553,567,cs),
+(553,648,o),
+(512,702,o),
+(442,702,cs),
+(350,702,o),
+(270,599,o),
+(223,599,cs),
+(204,599,o),
+(198,616,o),
+(206,651,cs),
+(213,690,l),
+(158,690,l),
+(147,639,ls),
+(134,581,o),
+(156,544,o),
+(202,544,cs),
+(276,544,o),
+(351,646,o),
+(424,646,cs),
+(469,646,o),
+(491,612,o),
+(491,558,cs),
+(491,484,o),
+(453,371,o),
+(341,371,cs),
+(90,371,l),
+(78,319,l),
+(329,319,ls),
+(387,319,o),
+(419,283,o),
+(419,224,cs),
+(419,164,o),
+(385,43,o),
+(296,43,cs),
+(219,43,o),
+(181,146,o),
+(110,146,cs),
+(69,146,o),
+(36,113,o),
+(22,51,cs),
+(12,0,l),
+(67,0,l),
+(73,34,ls),
+(81,71,o),
+(99,91,o),
+(119,91,cs),
+(163,91,o),
+(208,-13,o),
+(304,-13,cs)
+);
+}
+);
+width = 548;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni1650;
+unicode = 5712;
+},
+{
+color = 9;
+glyphname = "seeCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(419,-13,o),
+(477,131,o),
+(477,221,cs),
+(477,291,o),
+(446,337,o),
+(392,350,c),
+(386,339,l),
+(512,357,o),
+(552,484,o),
+(552,567,cs),
+(552,648,o),
+(511,702,o),
+(441,702,cs),
+(349,702,o),
+(269,599,o),
+(222,599,cs),
+(203,599,o),
+(197,616,o),
+(205,651,cs),
+(212,690,l),
+(157,690,l),
+(146,639,ls),
+(133,581,o),
+(155,544,o),
+(201,544,cs),
+(275,544,o),
+(350,646,o),
+(423,646,cs),
+(468,646,o),
+(490,612,o),
+(490,558,cs),
+(490,484,o),
+(452,370,o),
+(340,370,cs),
+(281,370,l),
+(294,343,l),
+(316,452,l),
+(279,452,l),
+(262,370,l),
+(88,370,l),
+(78,320,l),
+(251,320,l),
+(232,228,l),
+(269,228,l),
+(294,347,l),
+(270,320,l),
+(327,320,ls),
+(387,320,o),
+(418,283,o),
+(418,224,cs),
+(418,164,o),
+(384,43,o),
+(295,43,cs),
+(218,43,o),
+(180,146,o),
+(109,146,cs),
+(68,146,o),
+(35,113,o),
+(21,51,cs),
+(11,0,l),
+(66,0,l),
+(72,34,ls),
+(80,71,o),
+(98,91,o),
+(118,91,cs),
+(162,91,o),
+(207,-13,o),
+(303,-13,cs)
+);
+}
+);
+width = 547;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1651;
+unicode = 5713;
+},
+{
+color = 9;
+glyphname = "siCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(419,-13,o),
+(477,131,o),
+(477,221,cs),
+(477,291,o),
+(446,337,o),
+(392,350,c),
+(386,339,l),
+(512,357,o),
+(552,484,o),
+(552,567,cs),
+(552,648,o),
+(511,702,o),
+(441,702,cs),
+(349,702,o),
+(269,599,o),
+(222,599,cs),
+(203,599,o),
+(197,616,o),
+(205,651,cs),
+(212,690,l),
+(157,690,l),
+(146,639,ls),
+(133,581,o),
+(155,544,o),
+(201,544,cs),
+(275,544,o),
+(350,646,o),
+(423,646,cs),
+(468,646,o),
+(491,612,o),
+(491,558,cs),
+(491,484,o),
+(454,368,o),
+(343,368,cs),
+(293,368,l),
+(320,350,l),
+(319,381,o),
+(294,404,o),
+(264,404,cs),
+(241,404,o),
+(220,389,o),
+(212,370,c),
+(88,370,l),
+(78,320,l),
+(212,320,l),
+(220,300,o),
+(241,286,o),
+(264,286,cs),
+(294,286,o),
+(319,309,o),
+(320,340,c),
+(293,322,l),
+(333,322,ls),
+(392,322,o),
+(419,283,o),
+(419,224,cs),
+(419,164,o),
+(384,43,o),
+(295,43,cs),
+(218,43,o),
+(180,146,o),
+(109,146,cs),
+(68,146,o),
+(35,113,o),
+(21,51,cs),
+(11,0,l),
+(66,0,l),
+(72,34,ls),
+(80,71,o),
+(98,91,o),
+(118,91,cs),
+(162,91,o),
+(207,-13,o),
+(303,-13,cs)
+);
+}
+);
+width = 547;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1652;
+unicode = 5714;
+},
+{
+color = 9;
+glyphname = "saCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(243,-13,o),
+(324,91,o),
+(370,91,cs),
+(389,91,o),
+(396,73,o),
+(388,39,cs),
+(380,0,l),
+(436,0,l),
+(446,51,ls),
+(460,109,o),
+(439,146,o),
+(392,146,cs),
+(318,146,o),
+(242,43,o),
+(169,43,cs),
+(125,43,o),
+(102,77,o),
+(102,131,cs),
+(102,206,o),
+(140,319,o),
+(252,319,cs),
+(504,319,l),
+(515,371,l),
+(265,371,ls),
+(206,371,o),
+(175,407,o),
+(175,466,cs),
+(175,526,o),
+(208,646,o),
+(298,646,cs),
+(374,646,o),
+(413,544,o),
+(484,544,cs),
+(526,544,o),
+(557,577,o),
+(571,639,cs),
+(582,690,l),
+(527,690,l),
+(520,656,ls),
+(512,619,o),
+(496,599,o),
+(475,599,cs),
+(430,599,o),
+(386,702,o),
+(290,702,cs),
+(174,702,o),
+(115,558,o),
+(115,469,cs),
+(115,392,o),
+(153,344,o),
+(215,337,c),
+(219,353,l),
+(83,341,o),
+(42,209,o),
+(42,123,cs),
+(42,42,o),
+(82,-13,o),
+(151,-13,cs)
+);
+}
+);
+width = 546;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1653;
+unicode = 5715;
+},
+{
+color = 9;
+glyphname = "shuCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(215,-13,o),
+(270,32,o),
+(306,122,c),
+(293,123,l),
+(292,35,o),
+(331,-13,o),
+(408,-13,cs),
+(539,-13,o),
+(580,137,o),
+(587,262,cs),
+(591,336,o),
+(582,444,o),
+(586,518,cs),
+(589,577,o),
+(601,637,o),
+(665,637,cs),
+(682,637,l),
+(694,690,l),
+(663,690,ls),
+(587,690,o),
+(552,648,o),
+(536,582,cs),
+(532,565,o),
+(530,547,o),
+(529,527,c),
+(547,554,l),
+(416,554,l),
+(445,690,l),
+(391,690,l),
+(363,554,l),
+(234,554,l),
+(242,536,l),
+(252,566,o),
+(259,592,o),
+(259,613,cs),
+(259,664,o),
+(230,690,o),
+(174,690,cs),
+(142,690,l),
+(131,637,l),
+(149,637,ls),
+(183,637,o),
+(198,623,o),
+(198,592,cs),
+(198,493,o),
+(31,272,o),
+(31,116,cs),
+(31,37,o),
+(75,-13,o),
+(148,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(117,44,o),
+(93,72,o),
+(93,126,cs),
+(93,228,o),
+(186,386,o),
+(233,506,c),
+(353,506,l),
+(288,203,ls),
+(266,97,o),
+(224,44,o),
+(163,44,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(323,44,o),
+(327,136,o),
+(342,205,cs),
+(407,506,l),
+(527,506,l),
+(525,433,o),
+(530,343,o),
+(528,271,cs),
+(526,175,o),
+(501,44,o),
+(403,44,cs)
+);
+}
+);
+width = 642;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1654;
+unicode = 5716;
+},
+{
+color = 9;
+glyphname = "shoCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(26,0,ls),
+(100,0,o),
+(136,42,o),
+(153,108,cs),
+(156,125,o),
+(158,143,o),
+(158,162,c),
+(142,135,l),
+(271,135,l),
+(243,0,l),
+(297,0,l),
+(326,135,l),
+(455,135,l),
+(446,154,l),
+(436,124,o),
+(430,98,o),
+(430,76,cs),
+(430,26,o),
+(458,0,o),
+(514,0,cs),
+(546,0,l),
+(557,53,l),
+(540,53,ls),
+(506,53,o),
+(490,67,o),
+(490,98,cs),
+(490,197,o),
+(657,417,o),
+(657,574,cs),
+(657,653,o),
+(613,702,o),
+(541,702,cs),
+(472,702,o),
+(419,658,o),
+(383,568,c),
+(395,567,l),
+(396,655,o),
+(357,702,o),
+(281,702,cs),
+(150,702,o),
+(108,553,o),
+(101,428,cs),
+(97,354,o),
+(105,245,o),
+(101,172,cs),
+(99,113,o),
+(87,53,o),
+(23,53,cs),
+(6,53,l),
+(-5,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(164,257,o),
+(157,347,o),
+(159,418,cs),
+(161,515,o),
+(187,645,o),
+(285,645,cs),
+(365,645,o),
+(361,554,o),
+(346,485,cs),
+(282,184,l),
+(160,184,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(400,487,ls),
+(423,593,o),
+(464,645,o),
+(525,645,cs),
+(571,645,o),
+(595,617,o),
+(595,564,cs),
+(595,462,o),
+(502,303,o),
+(456,184,c),
+(336,184,l)
+);
+}
+);
+width = 641;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1655;
+unicode = 5717;
+},
+{
+color = 9;
+glyphname = "sheCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(420,-13,o),
+(478,131,o),
+(478,221,cs),
+(478,291,o),
+(447,337,o),
+(393,350,c),
+(387,339,l),
+(513,357,o),
+(553,484,o),
+(553,567,cs),
+(553,648,o),
+(512,702,o),
+(442,702,cs),
+(350,702,o),
+(270,599,o),
+(223,599,cs),
+(204,599,o),
+(198,616,o),
+(206,651,cs),
+(213,690,l),
+(158,690,l),
+(147,639,ls),
+(134,581,o),
+(156,546,o),
+(202,546,cs),
+(214,546,o),
+(227,548,o),
+(240,554,c),
+(219,580,l),
+(176,371,l),
+(90,371,l),
+(78,319,l),
+(164,319,l),
+(120,107,l),
+(153,131,l),
+(140,139,o),
+(125,144,o),
+(110,144,cs),
+(69,144,o),
+(36,113,o),
+(22,51,cs),
+(12,0,l),
+(67,0,l),
+(73,34,ls),
+(81,71,o),
+(99,91,o),
+(119,91,cs),
+(163,91,o),
+(208,-13,o),
+(304,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(213,319,l),
+(329,319,ls),
+(387,319,o),
+(419,283,o),
+(419,224,cs),
+(419,164,o),
+(385,43,o),
+(296,43,cs),
+(243,43,o),
+(210,90,o),
+(171,120,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(266,565,l),
+(317,593,o),
+(371,646,o),
+(424,646,cs),
+(469,646,o),
+(491,612,o),
+(491,558,cs),
+(491,484,o),
+(453,371,o),
+(341,371,cs),
+(224,371,l)
+);
+}
+);
+width = 548;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1656;
+unicode = 5718;
+},
+{
+color = 9;
+glyphname = "sheeCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(419,-13,o),
+(477,131,o),
+(477,221,cs),
+(477,291,o),
+(446,337,o),
+(392,350,c),
+(386,339,l),
+(512,357,o),
+(552,484,o),
+(552,567,cs),
+(552,648,o),
+(511,702,o),
+(441,702,cs),
+(349,702,o),
+(269,599,o),
+(222,599,cs),
+(203,599,o),
+(197,616,o),
+(205,651,cs),
+(212,690,l),
+(157,690,l),
+(146,639,ls),
+(133,581,o),
+(155,546,o),
+(201,546,cs),
+(212,546,o),
+(224,548,o),
+(235,554,c),
+(218,578,l),
+(174,367,l),
+(88,367,l),
+(78,323,l),
+(164,323,l),
+(120,109,l),
+(146,132,l),
+(134,139,o),
+(122,144,o),
+(109,144,cs),
+(68,144,o),
+(35,113,o),
+(21,51,cs),
+(11,0,l),
+(66,0,l),
+(72,34,ls),
+(80,71,o),
+(98,91,o),
+(118,91,cs),
+(162,91,o),
+(207,-13,o),
+(303,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(241,43,o),
+(206,95,o),
+(162,124,c),
+(205,323,l),
+(293,323,l),
+(273,228,l),
+(305,228,l),
+(327,333,l),
+(312,323,l),
+(330,323,ls),
+(389,323,o),
+(419,283,o),
+(419,224,cs),
+(419,164,o),
+(384,43,o),
+(295,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(353,452,l),
+(321,452,l),
+(302,367,l),
+(214,367,l),
+(256,560,l),
+(312,589,o),
+(368,647,o),
+(423,647,cs),
+(468,647,o),
+(492,612,o),
+(492,558,cs),
+(492,484,o),
+(453,367,o),
+(341,367,cs),
+(322,367,l),
+(333,358,l)
+);
+}
+);
+width = 547;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1657;
+unicode = 5719;
+},
+{
+color = 9;
+glyphname = "shiCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(146,639,ls),
+(133,581,o),
+(155,546,o),
+(201,546,cs),
+(212,546,o),
+(224,548,o),
+(235,554,c),
+(218,578,l),
+(174,367,l),
+(88,367,l),
+(78,323,l),
+(164,323,l),
+(120,109,l),
+(146,132,l),
+(134,139,o),
+(122,144,o),
+(109,144,cs),
+(68,144,o),
+(35,113,o),
+(21,51,cs),
+(11,0,l),
+(66,0,l),
+(72,34,ls),
+(80,71,o),
+(98,91,o),
+(118,91,cs),
+(162,91,o),
+(207,-13,o),
+(303,-13,cs),
+(419,-13,o),
+(477,131,o),
+(477,221,cs),
+(477,291,o),
+(446,337,o),
+(392,350,c),
+(386,339,l),
+(512,357,o),
+(552,484,o),
+(552,567,cs),
+(552,648,o),
+(511,702,o),
+(441,702,cs),
+(349,702,o),
+(269,599,o),
+(222,599,cs),
+(203,599,o),
+(197,616,o),
+(205,651,cs),
+(212,690,l),
+(157,690,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(205,323,l),
+(263,323,l),
+(269,300,o),
+(290,286,o),
+(313,286,cs),
+(340,286,o),
+(362,306,o),
+(367,334,c),
+(318,323,l),
+(337,323,ls),
+(392,323,o),
+(420,282,o),
+(420,224,cs),
+(420,164,o),
+(384,43,o),
+(295,43,cs),
+(241,43,o),
+(206,95,o),
+(162,124,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(255,560,l),
+(312,589,o),
+(368,647,o),
+(423,647,cs),
+(468,647,o),
+(492,612,o),
+(492,558,cs),
+(492,484,o),
+(457,367,o),
+(348,367,cs),
+(318,367,l),
+(366,356,l),
+(362,384,o),
+(340,404,o),
+(314,404,cs),
+(291,404,o),
+(269,388,o),
+(263,367,c),
+(214,367,l)
+);
+}
+);
+width = 547;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1658;
+unicode = 5720;
+},
+{
+color = 9;
+glyphname = "shaCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(244,-13,o),
+(324,91,o),
+(370,91,cs),
+(389,91,o),
+(396,73,o),
+(388,39,cs),
+(380,0,l),
+(436,0,l),
+(446,51,ls),
+(460,109,o),
+(439,144,o),
+(392,144,cs),
+(380,144,o),
+(366,142,o),
+(354,135,c),
+(375,110,l),
+(418,319,l),
+(504,319,l),
+(515,371,l),
+(429,371,l),
+(473,582,l),
+(440,558,l),
+(454,551,o),
+(469,546,o),
+(484,546,cs),
+(526,546,o),
+(557,577,o),
+(571,639,cs),
+(582,690,l),
+(527,690,l),
+(520,656,ls),
+(512,619,o),
+(496,599,o),
+(475,599,cs),
+(430,599,o),
+(386,702,o),
+(290,702,cs),
+(174,702,o),
+(115,558,o),
+(115,469,cs),
+(115,399,o),
+(147,353,o),
+(200,340,c),
+(206,351,l),
+(81,332,o),
+(42,206,o),
+(42,123,cs),
+(42,42,o),
+(82,-13,o),
+(151,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(126,43,o),
+(102,77,o),
+(102,131,cs),
+(102,206,o),
+(141,319,o),
+(252,319,cs),
+(369,319,l),
+(327,125,l),
+(276,97,o),
+(223,43,o),
+(169,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(206,371,o),
+(175,407,o),
+(175,466,cs),
+(175,526,o),
+(208,646,o),
+(298,646,cs),
+(351,646,o),
+(384,600,o),
+(422,570,c),
+(380,371,l),
+(265,371,ls)
+);
+}
+);
+width = 546;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1659;
+unicode = 5721;
+},
+{
+color = 6;
+glyphname = "shCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(145,96,l),
+(165,196,l),
+(136,184,l),
+(148,184,ls),
+(232,184,o),
+(266,234,o),
+(266,299,cs),
+(266,346,o),
+(241,375,o),
+(194,375,cs),
+(178,375,ls),
+(149,375,o),
+(133,389,o),
+(133,416,cs),
+(133,447,o),
+(145,490,o),
+(199,490,cs),
+(305,490,l),
+(314,527,l),
+(237,527,l),
+(255,614,l),
+(213,614,l),
+(191,512,l),
+(221,527,l),
+(210,527,ls),
+(126,527,o),
+(91,477,o),
+(91,412,cs),
+(91,365,o),
+(117,336,o),
+(163,336,cs),
+(180,336,ls),
+(209,336,o),
+(224,322,o),
+(224,295,cs),
+(224,264,o),
+(213,221,o),
+(158,221,cs),
+(52,221,l),
+(43,184,l),
+(122,184,l),
+(103,96,l)
+);
+}
+);
+width = 306;
+}
+);
+metricRight = "=|";
+note = uni18F5;
+unicode = 5722;
+},
+{
+color = 9;
+glyphname = "tsuCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(215,-13,o),
+(269,32,o),
+(306,122,c),
+(293,123,l),
+(292,35,o),
+(331,-13,o),
+(408,-13,cs),
+(539,-13,o),
+(580,137,o),
+(587,262,cs),
+(591,336,o),
+(582,444,o),
+(586,518,cs),
+(589,577,o),
+(601,637,o),
+(665,637,cs),
+(682,637,l),
+(694,690,l),
+(663,690,ls),
+(567,690,o),
+(538,619,o),
+(532,528,cs),
+(530,483,o),
+(534,428,o),
+(534,369,c),
+(377,369,l),
+(436,645,l),
+(497,645,l),
+(506,690,l),
+(329,690,l),
+(320,645,l),
+(382,645,l),
+(324,369,l),
+(168,369,l),
+(212,466,o),
+(258,556,o),
+(258,613,cs),
+(258,664,o),
+(230,690,o),
+(174,690,cs),
+(142,690,l),
+(131,637,l),
+(149,637,ls),
+(183,637,o),
+(198,623,o),
+(198,592,cs),
+(198,493,o),
+(31,272,o),
+(31,116,cs),
+(31,37,o),
+(75,-13,o),
+(148,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(117,44,o),
+(93,72,o),
+(93,126,cs),
+(93,181,o),
+(119,249,o),
+(151,321,c),
+(312,321,l),
+(288,203,ls),
+(266,97,o),
+(224,44,o),
+(163,44,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(323,44,o),
+(327,136,o),
+(342,205,cs),
+(366,321,l),
+(531,321,l),
+(530,301,o),
+(529,285,o),
+(528,271,cs),
+(526,175,o),
+(501,44,o),
+(403,44,cs)
+);
+}
+);
+width = 642;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165B;
+unicode = 5723;
+},
+{
+color = 9;
+glyphname = "tsoCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(26,0,ls),
+(122,0,o),
+(150,71,o),
+(156,161,cs),
+(157,207,o),
+(155,262,o),
+(154,321,c),
+(311,321,l),
+(252,44,l),
+(192,44,l),
+(183,0,l),
+(358,0,l),
+(368,44,l),
+(306,44,l),
+(365,321,l),
+(521,321,l),
+(477,224,o),
+(430,133,o),
+(430,76,cs),
+(430,26,o),
+(458,0,o),
+(514,0,cs),
+(546,0,l),
+(557,53,l),
+(540,53,ls),
+(506,53,o),
+(490,67,o),
+(490,98,cs),
+(490,197,o),
+(657,417,o),
+(657,574,cs),
+(657,653,o),
+(613,702,o),
+(541,702,cs),
+(472,702,o),
+(419,658,o),
+(383,568,c),
+(395,567,l),
+(396,655,o),
+(357,702,o),
+(281,702,cs),
+(150,702,o),
+(108,553,o),
+(101,428,cs),
+(97,354,o),
+(105,245,o),
+(101,172,cs),
+(99,113,o),
+(87,53,o),
+(23,53,cs),
+(6,53,l),
+(-5,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(157,388,o),
+(158,405,o),
+(159,418,cs),
+(161,515,o),
+(187,645,o),
+(285,645,cs),
+(365,645,o),
+(361,554,o),
+(346,485,cs),
+(322,369,l),
+(157,369,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(400,487,ls),
+(423,593,o),
+(464,645,o),
+(525,645,cs),
+(571,645,o),
+(595,617,o),
+(595,564,cs),
+(595,509,o),
+(570,440,o),
+(537,369,c),
+(376,369,l)
+);
+}
+);
+width = 641;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165C;
+unicode = 5724;
+},
+{
+color = 9;
+glyphname = "tseCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(422,-13,o),
+(480,131,o),
+(480,221,cs),
+(480,291,o),
+(449,337,o),
+(395,350,c),
+(390,339,l),
+(515,357,o),
+(554,484,o),
+(554,567,cs),
+(554,648,o),
+(514,702,o),
+(444,702,cs),
+(352,702,o),
+(275,599,o),
+(229,599,cs),
+(210,599,o),
+(203,616,o),
+(211,651,cs),
+(218,690,l),
+(163,690,l),
+(152,639,ls),
+(139,581,o),
+(160,547,o),
+(207,547,cs),
+(229,547,o),
+(252,555,o),
+(271,570,c),
+(264,589,l),
+(216,367,l),
+(130,367,l),
+(152,465,l),
+(115,465,l),
+(64,225,l),
+(100,225,l),
+(122,323,l),
+(207,323,l),
+(159,97,l),
+(175,116,l),
+(157,130,o),
+(139,143,o),
+(115,143,cs),
+(73,143,o),
+(41,113,o),
+(27,51,cs),
+(16,0,l),
+(71,0,l),
+(79,34,ls),
+(87,71,o),
+(103,91,o),
+(124,91,cs),
+(169,91,o),
+(210,-13,o),
+(306,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(258,43,o),
+(229,72,o),
+(200,99,c),
+(246,323,l),
+(332,323,ls),
+(390,323,o),
+(422,287,o),
+(422,224,cs),
+(422,164,o),
+(388,43,o),
+(298,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(303,586,l),
+(344,613,o),
+(384,646,o),
+(427,646,cs),
+(471,646,o),
+(494,612,o),
+(494,558,cs),
+(494,484,o),
+(456,367,o),
+(344,367,cs),
+(257,367,l)
+);
+}
+);
+width = 549;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni165D;
+unicode = 5725;
+},
+{
+color = 9;
+glyphname = "tseeCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(422,-13,o),
+(480,131,o),
+(480,221,cs),
+(480,291,o),
+(449,337,o),
+(395,350,c),
+(390,339,l),
+(515,357,o),
+(554,484,o),
+(554,567,cs),
+(554,648,o),
+(514,702,o),
+(444,702,cs),
+(352,702,o),
+(275,599,o),
+(229,599,cs),
+(210,599,o),
+(203,616,o),
+(211,651,cs),
+(218,690,l),
+(163,690,l),
+(152,639,ls),
+(139,581,o),
+(160,547,o),
+(207,547,cs),
+(229,547,o),
+(252,555,o),
+(271,570,c),
+(258,589,l),
+(212,366,l),
+(128,366,l),
+(149,465,l),
+(115,465,l),
+(64,225,l),
+(99,225,l),
+(119,324,l),
+(202,324,l),
+(154,97,l),
+(175,116,l),
+(157,130,o),
+(139,143,o),
+(115,143,cs),
+(73,143,o),
+(41,113,o),
+(27,51,cs),
+(16,0,l),
+(71,0,l),
+(79,34,ls),
+(87,71,o),
+(103,91,o),
+(124,91,cs),
+(169,91,o),
+(210,-13,o),
+(306,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(256,43,o),
+(221,78,o),
+(192,104,c),
+(239,324,l),
+(314,324,l),
+(293,224,l),
+(325,224,l),
+(349,336,l),
+(326,324,l),
+(332,324,ls),
+(390,324,o),
+(422,287,o),
+(422,224,cs),
+(422,160,o),
+(387,43,o),
+(298,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(375,455,l),
+(342,455,l),
+(324,366,l),
+(248,366,l),
+(294,582,l),
+(334,608,o),
+(382,646,o),
+(427,646,cs),
+(471,646,o),
+(495,612,o),
+(495,558,cs),
+(495,484,o),
+(457,366,o),
+(345,366,cs),
+(337,366,l),
+(354,358,l)
+);
+}
+);
+width = 549;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165E;
+unicode = 5726;
+},
+{
+color = 9;
+glyphname = "tsiCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(422,-13,o),
+(480,131,o),
+(480,221,cs),
+(480,291,o),
+(449,337,o),
+(395,350,c),
+(389,339,l),
+(515,357,o),
+(554,484,o),
+(554,567,cs),
+(554,648,o),
+(514,702,o),
+(444,702,cs),
+(352,702,o),
+(275,599,o),
+(229,599,cs),
+(210,599,o),
+(203,616,o),
+(211,651,cs),
+(218,690,l),
+(163,690,l),
+(152,639,ls),
+(139,581,o),
+(160,547,o),
+(207,547,cs),
+(229,547,o),
+(252,555,o),
+(272,570,c),
+(259,589,l),
+(212,366,l),
+(128,366,l),
+(149,465,l),
+(115,465,l),
+(64,225,l),
+(99,225,l),
+(119,324,l),
+(202,324,l),
+(155,97,l),
+(176,115,l),
+(157,130,o),
+(139,143,o),
+(115,143,cs),
+(73,143,o),
+(41,113,o),
+(27,51,cs),
+(16,0,l),
+(71,0,l),
+(79,34,ls),
+(87,71,o),
+(103,91,o),
+(124,91,cs),
+(169,91,o),
+(210,-13,o),
+(306,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(256,43,o),
+(221,77,o),
+(193,104,c),
+(239,324,l),
+(283,324,l),
+(289,302,o),
+(307,286,o),
+(330,286,cs),
+(354,286,o),
+(374,302,o),
+(379,328,c),
+(322,324,l),
+(332,324,ls),
+(390,324,o),
+(422,287,o),
+(422,224,cs),
+(422,160,o),
+(387,43,o),
+(298,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(381,384,o),
+(358,404,o),
+(333,404,cs),
+(311,404,o),
+(291,387,o),
+(286,366,c),
+(249,366,l),
+(294,582,l),
+(334,608,o),
+(382,646,o),
+(427,646,cs),
+(471,646,o),
+(495,611,o),
+(495,558,cs),
+(495,484,o),
+(457,366,o),
+(345,366,cs),
+(329,366,l),
+(383,357,l)
+);
+}
+);
+width = 549;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165F;
+unicode = 5727;
+},
+{
+color = 9;
+glyphname = "tsaCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(243,-13,o),
+(321,91,o),
+(367,91,cs),
+(386,91,o),
+(392,73,o),
+(384,39,cs),
+(377,0,l),
+(432,0,l),
+(443,51,ls),
+(456,109,o),
+(435,143,o),
+(388,143,cs),
+(366,143,o),
+(344,133,o),
+(324,120,c),
+(332,100,l),
+(379,323,l),
+(465,323,l),
+(443,225,l),
+(481,225,l),
+(531,464,l),
+(495,464,l),
+(474,367,l),
+(389,367,l),
+(437,593,l),
+(420,574,l),
+(439,559,o),
+(456,547,o),
+(480,547,cs),
+(522,547,o),
+(554,577,o),
+(568,639,cs),
+(579,690,l),
+(524,690,l),
+(517,656,ls),
+(509,619,o),
+(492,599,o),
+(471,599,cs),
+(427,599,o),
+(386,702,o),
+(290,702,cs),
+(174,702,o),
+(115,557,o),
+(115,468,cs),
+(115,399,o),
+(147,353,o),
+(200,340,c),
+(206,351,l),
+(80,332,o),
+(42,206,o),
+(42,123,cs),
+(42,42,o),
+(82,-13,o),
+(151,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(125,43,o),
+(102,77,o),
+(102,131,cs),
+(102,206,o),
+(140,323,o),
+(251,323,cs),
+(338,323,l),
+(293,103,l),
+(252,76,o),
+(211,43,o),
+(168,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(205,367,o),
+(174,403,o),
+(174,466,cs),
+(174,526,o),
+(207,646,o),
+(297,646,cs),
+(337,646,o),
+(367,617,o),
+(395,591,c),
+(349,367,l),
+(264,367,ls)
+);
+}
+);
+width = 549;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1660;
+unicode = 5728;
+},
+{
+color = 9;
+glyphname = "chuCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(215,-13,o),
+(270,32,o),
+(306,122,c),
+(293,123,l),
+(292,35,o),
+(331,-13,o),
+(408,-13,cs),
+(539,-13,o),
+(580,137,o),
+(587,262,cs),
+(591,336,o),
+(582,444,o),
+(586,518,cs),
+(589,577,o),
+(601,637,o),
+(665,637,cs),
+(682,637,l),
+(694,690,l),
+(663,690,ls),
+(567,690,o),
+(538,619,o),
+(532,528,cs),
+(527,459,o),
+(531,347,o),
+(528,271,cs),
+(526,175,o),
+(501,44,o),
+(403,44,cs),
+(323,44,o),
+(327,136,o),
+(342,205,cs),
+(436,645,l),
+(497,645,l),
+(506,690,l),
+(329,690,l),
+(320,645,l),
+(382,645,l),
+(288,203,ls),
+(266,97,o),
+(224,44,o),
+(163,44,cs),
+(117,44,o),
+(93,72,o),
+(93,126,cs),
+(93,261,o),
+(258,506,o),
+(258,613,cs),
+(258,664,o),
+(230,690,o),
+(174,690,cs),
+(142,690,l),
+(131,637,l),
+(149,637,ls),
+(183,637,o),
+(198,623,o),
+(198,592,cs),
+(198,493,o),
+(31,272,o),
+(31,116,cs),
+(31,37,o),
+(75,-13,o),
+(148,-13,cs)
+);
+}
+);
+width = 642;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164E;
+unicode = 5729;
+},
+{
+color = 9;
+glyphname = "choCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(26,0,ls),
+(122,0,o),
+(150,71,o),
+(156,161,cs),
+(160,231,o),
+(156,343,o),
+(159,418,cs),
+(161,515,o),
+(187,645,o),
+(285,645,cs),
+(365,645,o),
+(361,554,o),
+(346,485,cs),
+(252,44,l),
+(192,44,l),
+(183,0,l),
+(358,0,l),
+(368,44,l),
+(306,44,l),
+(400,487,ls),
+(423,593,o),
+(464,645,o),
+(525,645,cs),
+(571,645,o),
+(595,617,o),
+(595,564,cs),
+(595,429,o),
+(430,184,o),
+(430,76,cs),
+(430,26,o),
+(458,0,o),
+(514,0,cs),
+(546,0,l),
+(557,53,l),
+(540,53,ls),
+(506,53,o),
+(490,67,o),
+(490,98,cs),
+(490,197,o),
+(657,417,o),
+(657,574,cs),
+(657,653,o),
+(613,702,o),
+(541,702,cs),
+(472,702,o),
+(419,658,o),
+(383,568,c),
+(395,567,l),
+(396,655,o),
+(357,702,o),
+(281,702,cs),
+(150,702,o),
+(108,553,o),
+(101,428,cs),
+(97,354,o),
+(105,245,o),
+(101,172,cs),
+(99,113,o),
+(87,53,o),
+(23,53,cs),
+(6,53,l),
+(-5,0,l)
+);
+}
+);
+width = 641;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5730;
+},
+{
+color = 9;
+glyphname = "cheCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(422,-13,o),
+(480,131,o),
+(480,221,cs),
+(480,291,o),
+(449,337,o),
+(395,350,c),
+(390,339,l),
+(515,357,o),
+(554,484,o),
+(554,567,cs),
+(554,648,o),
+(514,702,o),
+(444,702,cs),
+(352,702,o),
+(275,599,o),
+(229,599,cs),
+(210,599,o),
+(203,616,o),
+(211,651,cs),
+(218,690,l),
+(163,690,l),
+(152,639,ls),
+(139,581,o),
+(160,546,o),
+(207,546,cs),
+(281,546,o),
+(353,646,o),
+(426,646,cs),
+(470,646,o),
+(493,612,o),
+(493,558,cs),
+(493,484,o),
+(455,371,o),
+(343,371,cs),
+(131,371,l),
+(152,465,l),
+(115,465,l),
+(64,225,l),
+(100,225,l),
+(121,319,l),
+(331,319,ls),
+(389,319,o),
+(421,283,o),
+(421,224,cs),
+(421,164,o),
+(387,43,o),
+(298,43,cs),
+(221,43,o),
+(185,144,o),
+(115,144,cs),
+(73,144,o),
+(42,114,o),
+(27,51,cs),
+(16,0,l),
+(71,0,l),
+(79,34,ls),
+(87,71,o),
+(103,91,o),
+(124,91,cs),
+(169,91,o),
+(210,-13,o),
+(306,-13,cs)
+);
+}
+);
+width = 549;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni1663;
+unicode = 5731;
+},
+{
+color = 9;
+glyphname = "cheeCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(422,-13,o),
+(480,131,o),
+(480,221,cs),
+(480,291,o),
+(449,337,o),
+(395,350,c),
+(390,339,l),
+(515,357,o),
+(554,484,o),
+(554,567,cs),
+(554,648,o),
+(514,702,o),
+(444,702,cs),
+(352,702,o),
+(275,599,o),
+(229,599,cs),
+(210,599,o),
+(203,616,o),
+(211,651,cs),
+(218,690,l),
+(163,690,l),
+(152,639,ls),
+(139,581,o),
+(160,546,o),
+(207,546,cs),
+(281,546,o),
+(353,647,o),
+(426,647,cs),
+(470,647,o),
+(494,612,o),
+(494,558,cs),
+(494,484,o),
+(457,367,o),
+(345,367,cs),
+(295,367,l),
+(308,353,l),
+(328,452,l),
+(292,452,l),
+(273,367,l),
+(130,367,l),
+(152,465,l),
+(115,465,l),
+(64,225,l),
+(100,225,l),
+(122,323,l),
+(265,323,l),
+(244,228,l),
+(282,228,l),
+(304,339,l),
+(287,323,l),
+(335,323,ls),
+(393,323,o),
+(422,283,o),
+(422,224,cs),
+(422,164,o),
+(388,43,o),
+(298,43,cs),
+(221,43,o),
+(185,144,o),
+(115,144,cs),
+(73,144,o),
+(42,114,o),
+(27,51,cs),
+(16,0,l),
+(71,0,l),
+(79,34,ls),
+(87,71,o),
+(103,91,o),
+(124,91,cs),
+(169,91,o),
+(210,-13,o),
+(306,-13,cs)
+);
+}
+);
+width = 549;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1664;
+unicode = 5732;
+},
+{
+color = 9;
+glyphname = "chiCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(422,-13,o),
+(480,131,o),
+(480,221,cs),
+(480,291,o),
+(449,337,o),
+(395,350,c),
+(390,339,l),
+(515,357,o),
+(554,484,o),
+(554,567,cs),
+(554,648,o),
+(514,702,o),
+(444,702,cs),
+(352,702,o),
+(275,599,o),
+(229,599,cs),
+(210,599,o),
+(203,616,o),
+(211,651,cs),
+(218,690,l),
+(163,690,l),
+(152,639,ls),
+(139,581,o),
+(160,546,o),
+(207,546,cs),
+(281,546,o),
+(353,647,o),
+(426,647,cs),
+(470,647,o),
+(494,612,o),
+(494,558,cs),
+(494,484,o),
+(457,367,o),
+(348,367,cs),
+(307,367,l),
+(328,355,l),
+(326,384,o),
+(301,404,o),
+(272,404,cs),
+(248,404,o),
+(228,388,o),
+(219,367,c),
+(130,367,l),
+(152,465,l),
+(115,465,l),
+(64,225,l),
+(100,225,l),
+(122,323,l),
+(219,323,l),
+(227,302,o),
+(246,286,o),
+(272,286,cs),
+(301,286,o),
+(326,307,o),
+(329,336,c),
+(303,323,l),
+(337,323,ls),
+(392,323,o),
+(422,286,o),
+(422,224,cs),
+(422,164,o),
+(388,43,o),
+(298,43,cs),
+(221,43,o),
+(185,144,o),
+(115,144,cs),
+(73,144,o),
+(42,114,o),
+(27,51,cs),
+(16,0,l),
+(71,0,l),
+(79,34,ls),
+(87,71,o),
+(103,91,o),
+(124,91,cs),
+(169,91,o),
+(210,-13,o),
+(306,-13,cs)
+);
+}
+);
+width = 549;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1665;
+unicode = 5733;
+},
+{
+color = 9;
+glyphname = "chaCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(243,-11,o),
+(321,93,o),
+(367,93,cs),
+(386,93,o),
+(392,75,o),
+(384,41,cs),
+(377,2,l),
+(432,2,l),
+(443,53,ls),
+(456,111,o),
+(435,146,o),
+(388,146,cs),
+(314,146,o),
+(242,45,o),
+(169,45,cs),
+(125,45,o),
+(102,80,o),
+(102,133,cs),
+(102,208,o),
+(140,321,o),
+(252,321,cs),
+(464,321,l),
+(444,227,l),
+(481,227,l),
+(531,467,l),
+(495,467,l),
+(475,373,l),
+(265,373,ls),
+(206,373,o),
+(175,409,o),
+(175,468,cs),
+(175,528,o),
+(208,648,o),
+(298,648,cs),
+(374,648,o),
+(410,548,o),
+(480,548,cs),
+(522,548,o),
+(554,578,o),
+(568,640,cs),
+(580,692,l),
+(524,692,l),
+(517,658,ls),
+(509,621,o),
+(492,601,o),
+(472,601,cs),
+(427,601,o),
+(386,704,o),
+(290,704,cs),
+(174,704,o),
+(115,560,o),
+(115,470,cs),
+(115,401,o),
+(147,355,o),
+(200,342,c),
+(206,353,l),
+(80,334,o),
+(42,208,o),
+(42,125,cs),
+(42,43,o),
+(82,-11,o),
+(151,-11,cs)
+);
+}
+);
+width = 549;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1666;
+unicode = 5734;
+},
+{
+color = 9;
+glyphname = "ttsuCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(215,-13,o),
+(269,32,o),
+(306,122,c),
+(293,123,l),
+(292,35,o),
+(331,-13,o),
+(408,-13,cs),
+(539,-13,o),
+(580,137,o),
+(587,262,cs),
+(591,336,o),
+(582,444,o),
+(586,518,cs),
+(589,577,o),
+(601,637,o),
+(665,637,cs),
+(682,637,l),
+(694,690,l),
+(663,690,ls),
+(567,690,o),
+(538,619,o),
+(532,528,cs),
+(530,511,o),
+(528,496,o),
+(528,478,c),
+(553,519,l),
+(381,388,l),
+(436,645,l),
+(497,645,l),
+(506,690,l),
+(329,690,l),
+(320,645,l),
+(382,645,l),
+(327,388,l),
+(207,516,l),
+(218,473,l),
+(242,529,o),
+(258,579,o),
+(258,613,cs),
+(258,664,o),
+(230,690,o),
+(174,690,cs),
+(142,690,l),
+(131,637,l),
+(149,637,ls),
+(183,637,o),
+(198,623,o),
+(198,592,cs),
+(198,493,o),
+(31,272,o),
+(31,116,cs),
+(31,37,o),
+(75,-13,o),
+(148,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(117,44,o),
+(93,72,o),
+(93,126,cs),
+(93,214,o),
+(160,337,o),
+(208,444,c),
+(315,331,l),
+(288,203,ls),
+(266,97,o),
+(224,44,o),
+(163,44,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(323,44,o),
+(327,136,o),
+(342,205,cs),
+(367,323,l),
+(526,442,l),
+(526,385,o),
+(529,326,o),
+(528,271,cs),
+(526,175,o),
+(501,44,o),
+(403,44,cs)
+);
+}
+);
+width = 642;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1667;
+unicode = 5735;
+},
+{
+color = 9;
+glyphname = "ttsoCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(26,0,ls),
+(122,0,o),
+(150,71,o),
+(156,161,cs),
+(157,179,o),
+(159,194,o),
+(160,212,c),
+(135,171,l),
+(307,301,l),
+(252,44,l),
+(192,44,l),
+(183,0,l),
+(358,0,l),
+(368,44,l),
+(306,44,l),
+(361,301,l),
+(482,174,l),
+(470,216,l),
+(447,160,o),
+(430,111,o),
+(430,76,cs),
+(430,26,o),
+(458,0,o),
+(514,0,cs),
+(546,0,l),
+(557,53,l),
+(540,53,ls),
+(506,53,o),
+(490,67,o),
+(490,98,cs),
+(490,197,o),
+(657,417,o),
+(657,574,cs),
+(657,653,o),
+(613,702,o),
+(541,702,cs),
+(472,702,o),
+(419,658,o),
+(383,568,c),
+(395,567,l),
+(396,655,o),
+(357,702,o),
+(281,702,cs),
+(150,702,o),
+(108,553,o),
+(101,428,cs),
+(97,354,o),
+(105,245,o),
+(101,172,cs),
+(99,113,o),
+(87,53,o),
+(23,53,cs),
+(6,53,l),
+(-5,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(162,304,o),
+(158,364,o),
+(159,418,cs),
+(161,515,o),
+(187,645,o),
+(285,645,cs),
+(365,645,o),
+(361,554,o),
+(346,485,cs),
+(321,367,l),
+(162,247,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(373,358,l),
+(400,487,ls),
+(423,593,o),
+(464,645,o),
+(525,645,cs),
+(571,645,o),
+(595,617,o),
+(595,564,cs),
+(595,475,o),
+(527,353,o),
+(480,245,c)
+);
+}
+);
+width = 641;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1668;
+unicode = 5736;
+},
+{
+color = 9;
+glyphname = "ttseCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(421,-13,o),
+(480,131,o),
+(480,221,cs),
+(480,291,o),
+(449,337,o),
+(395,350,c),
+(389,339,l),
+(515,357,o),
+(554,484,o),
+(554,567,cs),
+(554,647,o),
+(514,702,o),
+(444,702,cs),
+(352,702,o),
+(274,599,o),
+(228,599,cs),
+(209,599,o),
+(203,616,o),
+(211,651,cs),
+(218,690,l),
+(163,690,l),
+(152,639,ls),
+(139,581,o),
+(160,546,o),
+(207,546,cs),
+(213,546,o),
+(218,546,o),
+(225,548,c),
+(197,576,l),
+(220,367,l),
+(130,367,l),
+(152,465,l),
+(115,465,l),
+(64,225,l),
+(100,225,l),
+(122,323,l),
+(213,323,l),
+(99,116,l),
+(142,139,l),
+(134,142,o),
+(126,144,o),
+(115,144,cs),
+(72,144,o),
+(41,113,o),
+(27,51,cs),
+(16,0,l),
+(71,0,l),
+(78,34,ls),
+(86,71,o),
+(103,91,o),
+(124,91,cs),
+(168,91,o),
+(209,-13,o),
+(305,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(235,43,o),
+(201,111,o),
+(156,131,c),
+(259,323,l),
+(337,323,ls),
+(393,323,o),
+(423,286,o),
+(423,228,cs),
+(423,166,o),
+(388,43,o),
+(298,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(243,554,l),
+(301,570,o),
+(362,647,o),
+(426,647,cs),
+(471,647,o),
+(494,611,o),
+(494,557,cs),
+(494,485,o),
+(457,367,o),
+(346,367,cs),
+(264,367,l)
+);
+}
+);
+width = 549;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1669;
+unicode = 5737;
+},
+{
+color = 9;
+glyphname = "ttseeCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(421,-13,o),
+(480,131,o),
+(480,221,cs),
+(480,291,o),
+(449,337,o),
+(395,350,c),
+(389,339,l),
+(515,357,o),
+(554,484,o),
+(554,567,cs),
+(554,647,o),
+(514,702,o),
+(444,702,cs),
+(352,702,o),
+(274,599,o),
+(228,599,cs),
+(209,599,o),
+(203,616,o),
+(211,651,cs),
+(218,690,l),
+(163,690,l),
+(152,639,ls),
+(139,581,o),
+(160,546,o),
+(207,546,cs),
+(213,546,o),
+(218,546,o),
+(225,548,c),
+(195,576,l),
+(217,367,l),
+(130,367,l),
+(152,465,l),
+(115,465,l),
+(64,225,l),
+(100,225,l),
+(122,323,l),
+(210,323,l),
+(98,116,l),
+(142,139,l),
+(134,142,o),
+(126,144,o),
+(115,144,cs),
+(72,144,o),
+(41,113,o),
+(27,51,cs),
+(16,0,l),
+(71,0,l),
+(78,34,ls),
+(86,71,o),
+(103,91,o),
+(124,91,cs),
+(168,91,o),
+(209,-13,o),
+(305,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(234,43,o),
+(196,116,o),
+(152,135,c),
+(253,323,l),
+(307,323,l),
+(287,224,l),
+(322,224,l),
+(344,330,l),
+(329,323,l),
+(337,323,ls),
+(393,323,o),
+(423,286,o),
+(423,228,cs),
+(423,166,o),
+(388,43,o),
+(298,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(370,455,l),
+(335,455,l),
+(317,367,l),
+(257,367,l),
+(237,552,l),
+(295,565,o),
+(361,647,o),
+(426,647,cs),
+(471,647,o),
+(494,611,o),
+(494,557,cs),
+(494,485,o),
+(457,367,o),
+(346,367,cs),
+(339,367,l),
+(350,358,l)
+);
+}
+);
+width = 549;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166A;
+unicode = 5738;
+},
+{
+color = 9;
+glyphname = "ttsiCarrier-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(421,-13,o),
+(480,131,o),
+(480,221,cs),
+(480,291,o),
+(449,337,o),
+(395,350,c),
+(389,339,l),
+(515,357,o),
+(554,484,o),
+(554,567,cs),
+(554,647,o),
+(514,702,o),
+(444,702,cs),
+(352,702,o),
+(274,599,o),
+(228,599,cs),
+(209,599,o),
+(203,616,o),
+(211,651,cs),
+(218,690,l),
+(163,690,l),
+(152,639,ls),
+(139,581,o),
+(160,546,o),
+(207,546,cs),
+(213,546,o),
+(218,546,o),
+(225,548,c),
+(195,576,l),
+(217,367,l),
+(130,367,l),
+(152,465,l),
+(115,465,l),
+(64,225,l),
+(100,225,l),
+(122,323,l),
+(210,323,l),
+(98,116,l),
+(142,139,l),
+(134,142,o),
+(126,144,o),
+(115,144,cs),
+(72,144,o),
+(41,113,o),
+(27,51,cs),
+(16,0,l),
+(71,0,l),
+(78,34,ls),
+(86,71,o),
+(103,91,o),
+(124,91,cs),
+(168,91,o),
+(209,-13,o),
+(305,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(234,43,o),
+(197,115,o),
+(152,135,c),
+(253,323,l),
+(270,323,l),
+(273,308,o),
+(292,286,o),
+(319,286,cs),
+(346,286,o),
+(365,307,o),
+(371,330,c),
+(329,323,l),
+(336,323,ls),
+(392,323,o),
+(423,286,o),
+(423,228,cs),
+(423,166,o),
+(388,43,o),
+(298,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(364,389,o),
+(341,404,o),
+(319,404,cs),
+(296,404,o),
+(274,386,o),
+(270,367,c),
+(258,367,l),
+(238,552,l),
+(296,566,o),
+(361,647,o),
+(426,647,cs),
+(471,647,o),
+(494,611,o),
+(494,557,cs),
+(494,485,o),
+(457,367,o),
+(346,367,cs),
+(339,367,l),
+(371,358,l)
+);
+}
+);
+width = 549;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166B;
+unicode = 5739;
+},
+{
+color = 9;
+glyphname = "ttsaCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(244,-13,o),
+(321,91,o),
+(367,91,cs),
+(386,91,o),
+(393,73,o),
+(385,39,cs),
+(377,0,l),
+(433,0,l),
+(443,51,ls),
+(457,109,o),
+(436,144,o),
+(389,144,cs),
+(383,144,o),
+(377,144,o),
+(370,142,c),
+(398,114,l),
+(376,323,l),
+(465,323,l),
+(443,225,l),
+(481,225,l),
+(531,465,l),
+(495,465,l),
+(474,367,l),
+(384,367,l),
+(496,574,l),
+(453,551,l),
+(462,548,o),
+(470,546,o),
+(480,546,cs),
+(523,546,o),
+(554,577,o),
+(568,639,cs),
+(580,690,l),
+(524,690,l),
+(517,656,ls),
+(509,619,o),
+(493,599,o),
+(472,599,cs),
+(427,599,o),
+(386,702,o),
+(290,702,cs),
+(174,702,o),
+(115,558,o),
+(115,469,cs),
+(115,399,o),
+(147,353,o),
+(200,340,c),
+(206,351,l),
+(80,332,o),
+(42,206,o),
+(42,123,cs),
+(42,43,o),
+(82,-13,o),
+(151,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(125,43,o),
+(101,78,o),
+(101,132,cs),
+(101,205,o),
+(138,323,o),
+(249,323,cs),
+(332,323,l),
+(352,135,l),
+(295,120,o),
+(234,43,o),
+(169,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(203,367,o),
+(173,404,o),
+(173,462,cs),
+(173,524,o),
+(207,647,o),
+(298,647,cs),
+(361,647,o),
+(394,579,o),
+(439,558,c),
+(336,367,l),
+(258,367,ls)
+);
+}
+);
+width = 549;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni166C;
+unicode = 5740;
+},
+{
+glyphname = "qai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (243,0);
+ref = "ke-canadian";
+}
+);
+width = 694;
+}
+);
+note = uni166F;
+unicode = 5743;
+},
+{
+glyphname = "ngai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (471,0);
+ref = "ce-canadian";
+}
+);
+width = 916;
+}
+);
+note = uni1670;
+unicode = 5744;
+},
+{
+glyphname = "nngi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (687,0);
+ref = "ci-canadian";
+}
+);
+width = 1131;
+}
+);
+note = uni1671;
+unicode = 5745;
+},
+{
+glyphname = "nngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (687,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (856,0);
+ref = dot_top;
+}
+);
+width = 1131;
+}
+);
+note = uni1672;
+unicode = 5746;
+},
+{
+glyphname = "nngo-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (687,0);
+ref = "ce-canadian";
+}
+);
+width = 1131;
+}
+);
+note = uni1673;
+unicode = 5747;
+},
+{
+glyphname = "nngoo-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (687,0);
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (848,0);
+ref = dot_top;
+}
+);
+width = 1131;
+}
+);
+note = uni1674;
+unicode = 5748;
+},
+{
+glyphname = "nnga-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (687,0);
+ref = "ca-canadian";
+}
+);
+width = 1131;
+}
+);
+note = uni1675;
+unicode = 5749;
+},
+{
+glyphname = "nngaa-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (687,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (718,0);
+ref = dot_top;
+}
+);
+width = 1131;
+}
+);
+note = uni1676;
+unicode = 5750;
+},
+{
+glyphname = "thweeWoodScree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (469,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 638;
+}
+);
+note = uni1677;
+unicode = 5751;
+},
+{
+glyphname = "thwiWoodScree-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (469,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 638;
+}
+);
+note = uni1678;
+unicode = 5752;
+},
+{
+glyphname = "thwiiWoodScree-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (67,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (469,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 638;
+}
+);
+note = uni1679;
+unicode = 5753;
+},
+{
+glyphname = "thwoWoodScree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (469,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 638;
+}
+);
+note = uni167A;
+unicode = 5754;
+},
+{
+glyphname = "thwooWoodScree-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (285,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (469,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 638;
+}
+);
+note = uni167B;
+unicode = 5755;
+},
+{
+glyphname = "thwaWoodScree-canadian";
+lastChange = "2023-01-13 15:56:20 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = middle_right_can;
+pos = (471,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 641;
+}
+);
+note = uni167C;
+unicode = 5756;
+},
+{
+glyphname = "thwaaWoodScree-canadian";
+lastChange = "2023-01-13 15:56:20 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (67,0);
+ref = dot_top;
+},
+{
+anchor = middle_right_can;
+pos = (471,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 641;
+}
+);
+note = uni167D;
+unicode = 5757;
+},
+{
+glyphname = "wBlackfoot-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(358,564,l),
+(367,604,l),
+(129,604,l),
+(121,564,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(329,431,l),
+(338,470,l),
+(100,470,l),
+(92,431,l)
+);
+}
+);
+width = 339;
+}
+);
+metricRight = "=|";
+note = uni167F;
+unicode = 5759;
+},
+{
+glyphname = "oy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-27,0);
+ref = ring_top.canadian;
+}
+);
+width = 521;
+}
+);
+note = uni18B0;
+unicode = 6320;
+},
+{
+glyphname = "ay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (316,0);
+ref = ring_top.canadian;
+}
+);
+width = 521;
+}
+);
+note = uni18B1;
+unicode = 6321;
+},
+{
+glyphname = "aay-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (120,0);
+ref = ring_top.canadian;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (372,0);
+ref = dot_top;
+}
+);
+width = 521;
+}
+);
+note = uni18B2;
+unicode = 6322;
+},
+{
+glyphname = "way-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (486,0);
+ref = ring_top.canadian;
+}
+);
+width = 690;
+}
+);
+note = uni18B3;
+unicode = 6323;
+},
+{
+glyphname = "poy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-45,0);
+ref = ring_top.canadian;
+}
+);
+width = 495;
+}
+);
+note = uni18B4;
+unicode = 6324;
+},
+{
+glyphname = "pay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (311,0);
+ref = ring_top.canadian;
+}
+);
+width = 495;
+}
+);
+note = uni18B5;
+unicode = 6325;
+},
+{
+glyphname = "pwoy-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (124,0);
+ref = ring_top.canadian;
+}
+);
+width = 664;
+}
+);
+note = uni18B6;
+unicode = 6326;
+},
+{
+glyphname = "tay-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (135,0);
+ref = ring_top.canadian;
+}
+);
+width = 453;
+}
+);
+note = uni18B7;
+unicode = 6327;
+},
+{
+glyphname = "kay-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-25,0);
+ref = ring_top.canadian;
+}
+);
+width = 450;
+}
+);
+note = uni18B8;
+unicode = 6328;
+},
+{
+glyphname = "kway-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (145,0);
+ref = ring_top.canadian;
+}
+);
+width = 619;
+}
+);
+note = uni18B9;
+unicode = 6329;
+},
+{
+glyphname = "may-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-21,0);
+ref = ring_top.canadian;
+}
+);
+width = 398;
+}
+);
+note = uni18BA;
+unicode = 6330;
+},
+{
+glyphname = "noy-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (230,-199);
+ref = ring_top.canadian;
+}
+);
+width = 615;
+}
+);
+note = uni18BB;
+unicode = 6331;
+},
+{
+glyphname = "nay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (71,-199);
+ref = ring_top.canadian;
+}
+);
+width = 615;
+}
+);
+note = uni18BC;
+unicode = 6332;
+},
+{
+glyphname = "lay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (71,-199);
+ref = ring_top.canadian;
+}
+);
+width = 615;
+}
+);
+note = uni18BD;
+unicode = 6333;
+},
+{
+glyphname = "soy-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (201,0);
+ref = ring_top.canadian;
+}
+);
+width = 409;
+}
+);
+note = uni18BE;
+unicode = 6334;
+},
+{
+glyphname = "say-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-20,0);
+ref = ring_top.canadian;
+}
+);
+width = 409;
+}
+);
+note = uni18BF;
+unicode = 6335;
+},
+{
+glyphname = "shoy-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (197,-199);
+ref = ring_top.canadian;
+}
+);
+width = 712;
+}
+);
+note = uni18C0;
+unicode = 6336;
+},
+{
+glyphname = "shay-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (200,-199);
+ref = ring_top.canadian;
+}
+);
+width = 712;
+}
+);
+note = uni18C1;
+unicode = 6337;
+},
+{
+glyphname = "shwoy-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (367,-199);
+ref = ring_top.canadian;
+}
+);
+width = 882;
+}
+);
+note = uni18C2;
+unicode = 6338;
+},
+{
+glyphname = "yoy-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (229,0);
+ref = ring_top.canadian;
+}
+);
+width = 433;
+}
+);
+note = uni18C3;
+unicode = 6339;
+},
+{
+glyphname = "yay-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-25,0);
+ref = ring_top.canadian;
+}
+);
+width = 433;
+}
+);
+note = uni18C4;
+unicode = 6340;
+},
+{
+glyphname = "ray-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (116,0);
+ref = ring_top.canadian;
+}
+);
+width = 410;
+}
+);
+note = uni18C5;
+unicode = 6341;
+},
+{
+glyphname = "nwi-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ni-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni18C6;
+unicode = 6342;
+},
+{
+glyphname = "nwiOjibway-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni18C7;
+unicode = 6343;
+},
+{
+glyphname = "nwii-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (300,-199);
+ref = dot_top;
+}
+);
+width = 784;
+}
+);
+note = uni18C8;
+unicode = 6344;
+},
+{
+glyphname = "nwiiOjibway-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (131,-199);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni18C9;
+unicode = 6345;
+},
+{
+glyphname = "nwo-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "no-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni18CA;
+unicode = 6346;
+},
+{
+glyphname = "nwoOjibway-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni18CB;
+unicode = 6347;
+},
+{
+glyphname = "nwoo-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (455,-199);
+ref = dot_top;
+}
+);
+width = 784;
+}
+);
+note = uni18CC;
+unicode = 6348;
+},
+{
+glyphname = "nwooOjibway-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (286,-199);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni18CD;
+unicode = 6349;
+},
+{
+glyphname = "rwee-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "reRCree-canadian";
+}
+);
+width = 818;
+}
+);
+note = uni18CE;
+unicode = 6350;
+},
+{
+glyphname = "rwi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ri-canadian";
+}
+);
+width = 818;
+}
+);
+note = uni18CF;
+unicode = 6351;
+},
+{
+glyphname = "rwii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (298,-199);
+ref = dot_top;
+}
+);
+width = 818;
+}
+);
+note = uni18D0;
+unicode = 6352;
+},
+{
+glyphname = "rwo-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ro-canadian";
+}
+);
+width = 580;
+}
+);
+note = uni18D1;
+unicode = 6353;
+},
+{
+glyphname = "rwoo-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (290,0);
+ref = dot_top;
+}
+);
+width = 580;
+}
+);
+note = uni18D2;
+unicode = 6354;
+},
+{
+glyphname = "rwa-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ra-canadian";
+}
+);
+width = 580;
+}
+);
+note = uni18D3;
+unicode = 6355;
+},
+{
+glyphname = "pOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,345,l),
+(253,640,l),
+(226,640,l),
+(257,345,l),
+(296,345,l),
+(299,356,l),
+(255,690,l),
+(243,690,l),
+(56,356,l),
+(54,345,l)
+);
+}
+);
+width = 303;
+}
+);
+metricLeft = "kkCarrier-canadian";
+note = uni18D4;
+unicode = 6356;
+},
+{
+glyphname = "tOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 318;
+}
+);
+metricRight = "=|";
+note = uni1422;
+unicode = 6357;
+},
+{
+glyphname = "kOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(118,345,l),
+(154,515,l),
+(139,507,l),
+(138,463,o),
+(163,435,o),
+(202,435,cs),
+(283,435,o),
+(311,550,o),
+(311,604,cs),
+(311,662,o),
+(283,696,o),
+(233,696,cs),
+(177,696,o),
+(139,655,o),
+(122,570,cs),
+(73,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(171,470,o),
+(158,491,o),
+(158,525,cs),
+(158,558,o),
+(174,660,o),
+(233,660,cs),
+(258,660,o),
+(270,640,o),
+(270,607,cs),
+(270,568,o),
+(253,470,o),
+(197,470,cs)
+);
+}
+);
+width = 278;
+}
+);
+metricLeft = "k-canadian";
+metricRight = "k-canadian";
+note = uni18D6;
+unicode = 6358;
+},
+{
+glyphname = "cOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(117,345,l),
+(169,585,ls),
+(180,638,o),
+(201,658,o),
+(233,658,cs),
+(270,658,o),
+(280,625,o),
+(270,582,cs),
+(264,550,l),
+(304,550,l),
+(310,577,ls),
+(324,643,o),
+(298,696,o),
+(231,696,cs),
+(174,696,o),
+(139,654,o),
+(125,583,cs),
+(73,345,l)
+);
+}
+);
+width = 270;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni18D7;
+unicode = 6359;
+},
+{
+glyphname = "mOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(117,345,l),
+(182,647,l),
+(304,647,l),
+(314,690,l),
+(147,690,l),
+(73,345,l)
+);
+}
+);
+width = 245;
+}
+);
+metricLeft = "m-canadian";
+metricRight = "m-canadian";
+note = uni18D8;
+unicode = 6360;
+},
+{
+glyphname = "nOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(269,428,o),
+(298,533,o),
+(298,595,cs),
+(298,617,o),
+(295,646,o),
+(271,663,c),
+(268,647,l),
+(408,647,l),
+(417,690,l),
+(223,690,ls),
+(135,690,o),
+(106,585,o),
+(106,522,cs),
+(106,462,o),
+(136,428,o),
+(185,428,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(159,464,o),
+(145,483,o),
+(145,521,cs),
+(145,561,o),
+(161,654,o),
+(217,654,cs),
+(245,654,o),
+(260,635,o),
+(260,597,cs),
+(260,556,o),
+(242,464,o),
+(187,464,cs)
+);
+}
+);
+width = 349;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "n-canadian";
+note = uni18D9;
+unicode = 6361;
+},
+{
+glyphname = "sOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(117,345,l),
+(147,484,l),
+(117,466,l),
+(142,466,ls),
+(227,466,o),
+(275,509,o),
+(295,603,cs),
+(313,690,l),
+(270,690,l),
+(252,608,ls),
+(237,534,o),
+(203,502,o),
+(139,502,cs),
+(107,502,l),
+(73,345,l)
+);
+}
+);
+width = 267;
+}
+);
+metricLeft = "s-canadian";
+metricRight = "s-canadian";
+note = uni18DA;
+unicode = 6362;
+},
+{
+color = 1;
+glyphname = "shOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(210,340,o),
+(243,379,o),
+(265,452,cs),
+(303,586,ls),
+(317,633,o),
+(335,659,o),
+(369,659,cs),
+(403,659,o),
+(416,637,o),
+(405,589,cs),
+(397,551,l),
+(438,551,l),
+(444,582,ls),
+(461,652,o),
+(433,696,o),
+(371,696,cs),
+(315,696,o),
+(281,658,o),
+(260,585,cs),
+(220,450,ls),
+(208,404,o),
+(188,378,o),
+(156,378,cs),
+(121,378,o),
+(108,401,o),
+(119,448,cs),
+(128,486,l),
+(86,486,l),
+(79,455,ls),
+(64,384,o),
+(92,340,o),
+(153,340,cs)
+);
+}
+);
+width = 403;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "c-canadian";
+note = uni18DB;
+unicode = 6363;
+},
+{
+color = 9;
+glyphname = "easternw-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (-36,-307);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (99,0);
+ref = "glottalstop-canadian";
+}
+);
+width = 435;
+}
+);
+note = uni18DC;
+unicode = 6364;
+},
+{
+color = 9;
+glyphname = "westernw-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (603,-307);
+ref = dot_top;
+scale = (-1,1);
+},
+{
+alignment = -1;
+ref = "glottalstop-canadian";
+}
+);
+width = 444;
+}
+);
+metricLeft = "glottalstop-canadian";
+note = uni18DD;
+unicode = 6365;
+},
+{
+glyphname = "rweRCree-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "reRCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (648,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 818;
+}
+);
+note = uni18E0;
+unicode = 6368;
+},
+{
+glyphname = "looWestCree-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (35,0);
+ref = dot_top;
+}
+);
+width = 410;
+}
+);
+note = uni18E1;
+unicode = 6369;
+},
+{
+glyphname = "laaWestCree-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (258,0);
+ref = dot_top;
+}
+);
+width = 411;
+}
+);
+note = uni18E2;
+unicode = 6370;
+},
+{
+glyphname = "thwe-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "the-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (552,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 721;
+}
+);
+note = uni18E3;
+unicode = 6371;
+},
+{
+glyphname = "thwa-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (507,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 676;
+}
+);
+note = uni18E4;
+unicode = 6372;
+},
+{
+glyphname = "tthwe-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "tthe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (545,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 714;
+}
+);
+note = uni18E5;
+unicode = 6373;
+},
+{
+glyphname = "tthoo-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ttho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (162,0);
+ref = dot_top;
+}
+);
+width = 473;
+}
+);
+note = uni18E6;
+unicode = 6374;
+},
+{
+glyphname = "tthaa-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ttha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (180,0);
+ref = dot_top;
+}
+);
+width = 473;
+}
+);
+note = uni18E7;
+unicode = 6375;
+},
+{
+glyphname = "tlhwe-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "tlhe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (454,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 623;
+}
+);
+note = uni18E8;
+unicode = 6376;
+},
+{
+glyphname = "tlhoo-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "tlho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (179,0);
+ref = dot_top;
+}
+);
+width = 454;
+}
+);
+note = uni18E9;
+unicode = 6377;
+},
+{
+glyphname = "shweSayisi-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "sheSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (455,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 625;
+}
+);
+note = uni18EA;
+unicode = 6378;
+},
+{
+glyphname = "shooSayisi-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "shoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (307,0);
+ref = dot_top;
+}
+);
+width = 455;
+}
+);
+note = uni18EB;
+unicode = 6379;
+},
+{
+color = 9;
+glyphname = "hooSayisi-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "hoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (351,0);
+ref = dot_top;
+}
+);
+width = 502;
+}
+);
+note = uni18EC;
+unicode = 6380;
+},
+{
+color = 9;
+glyphname = "gwuCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "guCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (644,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 814;
+}
+);
+note = uni18ED;
+unicode = 6381;
+},
+{
+color = 9;
+glyphname = "deneGeeCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "geCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (212,0);
+ref = dot_top;
+}
+);
+width = 534;
+}
+);
+note = uni18EE;
+unicode = 6382;
+},
+{
+color = 9;
+glyphname = "gaaCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (220,0);
+ref = dot_top;
+}
+);
+width = 534;
+}
+);
+note = uni18EF;
+unicode = 6383;
+},
+{
+color = 9;
+glyphname = "gwaCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (534,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 704;
+}
+);
+note = uni18F0;
+unicode = 6384;
+},
+{
+color = 9;
+glyphname = "juuSayisi-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "juSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (232,0);
+ref = dot_top;
+}
+);
+width = 530;
+}
+);
+note = uni18F1;
+unicode = 6385;
+},
+{
+color = 9;
+glyphname = "jwaCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "jaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (582,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 751;
+}
+);
+note = uni18F2;
+unicode = 6386;
+},
+{
+glyphname = "lBeaverDene-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "pWestCree-canadian";
+}
+);
+width = 144;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+unicode = 6387;
+},
+{
+glyphname = "rBeaverDene-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(117,345,l),
+(163,561,ls),
+(176,619,o),
+(200,650,o),
+(238,650,cs),
+(243,650,l),
+(253,696,l),
+(250,696,ls),
+(208,696,o),
+(177,666,o),
+(166,615,c),
+(170,614,l),
+(186,690,l),
+(147,690,l),
+(73,345,l)
+);
+}
+);
+width = 183;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni18F4;
+unicode = 6388;
+},
+{
+color = 6;
+glyphname = "sDentalCarrier-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(148,184,ls),
+(232,184,o),
+(266,234,o),
+(266,299,cs),
+(266,346,o),
+(240,375,o),
+(194,375,cs),
+(177,375,ls),
+(148,375,o),
+(132,389,o),
+(132,416,cs),
+(132,447,o),
+(144,490,o),
+(198,490,cs),
+(305,490,l),
+(314,527,l),
+(210,527,ls),
+(126,527,o),
+(91,476,o),
+(91,412,cs),
+(91,365,o),
+(117,336,o),
+(162,336,cs),
+(180,336,ls),
+(209,336,o),
+(224,322,o),
+(224,295,cs),
+(224,264,o),
+(213,221,o),
+(158,221,cs),
+(51,221,l),
+(43,184,l)
+);
+}
+);
+width = 306;
+}
+);
+metricLeft = "shCarrier-canadian";
+metricRight = "=|";
+note = uni18F5;
+unicode = 6389;
+},
+{
+glyphname = "pWestCree-canadian.base";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-73,-345);
+ref = "pWestCree-canadian";
+}
+);
+width = 144;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.base";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-74,-345);
+ref = "c-canadian";
+}
+);
+width = 269;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "thSayisi-canadian.base";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-73,-345);
+ref = "thSayisi-canadian";
+}
+);
+width = 270;
+}
+);
+metricLeft = "=|c-canadian";
+note = uni14A2;
+},
+{
+glyphname = "mWestCree-canadian.base";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-73,-345);
+ref = "mWestCree-canadian";
+}
+);
+width = 276;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+glyphname = "pWestCree-canadian.mid";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-34,-162);
+ref = "pWestCree-canadian";
+}
+);
+width = 146;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.mid";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-162);
+ref = "c-canadian";
+}
+);
+width = 270;
+}
+);
+metricLeft = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "mWestCree-canadian.mid";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-34,-162);
+ref = "mWestCree-canadian";
+}
+);
+width = 277;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+color = 11;
+glyphname = "ngaai-canadian.nunavik";
+lastChange = "2023-01-13 15:56:21 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (480,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (593,0);
+ref = ring_top.canadian;
+}
+);
+width = 926;
+}
+);
+note = uni158E;
+},
+{
+color = 11;
+glyphname = "ngi-canadian.nunavik";
+lastChange = "2023-01-13 15:56:21 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (480,0);
+ref = "ci-canadian";
+}
+);
+width = 926;
+}
+);
+note = uni158F;
+},
+{
+color = 11;
+glyphname = "ngii-canadian.nunavik";
+lastChange = "2023-01-13 15:56:21 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (480,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (649,0);
+ref = dot_top;
+}
+);
+width = 926;
+}
+);
+note = uni1590;
+},
+{
+color = 11;
+glyphname = "ngo-canadian.nunavik";
+lastChange = "2023-01-13 15:56:21 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (480,0);
+ref = "co-canadian";
+}
+);
+width = 927;
+}
+);
+note = uni1591;
+},
+{
+color = 11;
+glyphname = "ngoo-canadian.nunavik";
+lastChange = "2023-01-13 15:56:21 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "ngo-canadian.nunavik";
+},
+{
+anchor = top_right_can;
+pos = (778,0);
+ref = dot_top;
+}
+);
+width = 927;
+}
+);
+note = uni1592;
+},
+{
+color = 11;
+glyphname = "nga-canadian.nunavik";
+lastChange = "2023-01-13 15:56:21 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (480,0);
+ref = "ca-canadian";
+}
+);
+width = 926;
+}
+);
+note = uni1593;
+},
+{
+color = 11;
+glyphname = "ngaa-canadian.nunavik";
+lastChange = "2023-01-13 15:56:21 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (480,0);
+ref = "ca-canadian";
+},
+{
+anchor = top_left_can;
+pos = (511,0);
+ref = dot_top;
+}
+);
+width = 926;
+}
+);
+note = uni1594;
+},
+{
+color = 11;
+glyphname = "ng-canadian.nunavik";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(426,152,o),
+(453,263,o),
+(453,323,cs),
+(453,378,o),
+(429,413,o),
+(382,413,cs),
+(354,413,o),
+(329,396,o),
+(314,366,c),
+(323,364,l),
+(347,476,l),
+(242,476,l),
+(246,463,l),
+(284,491,o),
+(299,559,o),
+(299,599,cs),
+(299,659,o),
+(270,696,o),
+(220,696,cs),
+(138,696,o),
+(107,591,o),
+(107,527,cs),
+(107,468,o),
+(137,434,o),
+(189,434,cs),
+(311,434,l),
+(298,453,l),
+(263,293,ls),
+(251,238,o),
+(258,152,o),
+(338,152,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(314,187,o),
+(298,208,o),
+(298,246,cs),
+(298,282,o),
+(314,379,o),
+(372,379,cs),
+(399,379,o),
+(412,358,o),
+(412,322,cs),
+(412,283,o),
+(397,187,o),
+(341,187,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(159,469,o),
+(146,489,o),
+(146,526,cs),
+(146,565,o),
+(161,660,o),
+(217,660,cs),
+(245,660,o),
+(260,639,o),
+(260,600,cs),
+(260,565,o),
+(243,469,o),
+(186,469,cs)
+);
+}
+);
+width = 480;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+color = 11;
+glyphname = "ngai-canadian.nunavik";
+lastChange = "2023-01-13 15:56:21 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (480,0);
+ref = "ce-canadian";
+}
+);
+width = 926;
+}
+);
+note = uni1670;
+},
+{
+color = 11;
+glyphname = "ke-canadian.square";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (350,690);
+},
+{
+name = top_left_can;
+pos = (177,690);
+},
+{
+name = top_right_can;
+pos = (522,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(405,0,l),
+(552,690,l),
+(422,690,ls),
+(134,690,o),
+(81,472,o),
+(81,350,cs),
+(81,215,o),
+(163,136,o),
+(305,136,cs),
+(372,136,l),
+(343,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,191,o),
+(141,246,o),
+(141,351,cs),
+(141,440,o),
+(170,635,o),
+(407,635,cs),
+(477,635,l),
+(384,191,l),
+(317,191,ls)
+);
+}
+);
+width = 517;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146B;
+},
+{
+color = 11;
+glyphname = "ki-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (362,690);
+},
+{
+name = top_left_can;
+pos = (190,690);
+},
+{
+name = top_right_can;
+pos = (534,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(73,0,l),
+(102,136,l),
+(177,136,ls),
+(459,136,o),
+(511,355,o),
+(511,476,cs),
+(511,610,o),
+(428,690,o),
+(288,690,cs),
+(159,690,l),
+(13,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(209,635,l),
+(279,635,ls),
+(391,635,o),
+(451,580,o),
+(451,476,cs),
+(451,386,o),
+(426,191,o),
+(188,191,cs),
+(115,191,l)
+);
+}
+);
+width = 517;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni146D;
+},
+{
+color = 11;
+glyphname = "kii-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (207,0);
+ref = dot_top;
+}
+);
+width = 519;
+}
+);
+note = uni146E;
+},
+{
+color = 11;
+glyphname = "ko-canadian.square";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (350,690);
+},
+{
+name = top_left_can;
+pos = (177,690);
+},
+{
+name = top_right_can;
+pos = (522,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(405,0,l),
+(552,690,l),
+(490,690,l),
+(462,554,l),
+(386,554,ls),
+(104,554,o),
+(52,335,o),
+(52,213,cs),
+(52,80,o),
+(135,0,o),
+(275,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(172,55,o),
+(112,110,o),
+(112,213,cs),
+(112,303,o),
+(137,498,o),
+(375,498,cs),
+(449,498,l),
+(355,55,l),
+(284,55,ls)
+);
+}
+);
+width = 517;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146F;
+},
+{
+color = 11;
+glyphname = "koo-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (367,0);
+ref = dot_top;
+}
+);
+width = 519;
+}
+);
+note = uni1470;
+},
+{
+color = 11;
+glyphname = "ka-canadian.square";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (362,690);
+},
+{
+name = top_left_can;
+pos = (190,690);
+},
+{
+name = top_right_can;
+pos = (534,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,0,ls),
+(428,0,o),
+(483,217,o),
+(483,340,cs),
+(483,474,o),
+(399,554,o),
+(258,554,cs),
+(192,554,l),
+(220,690,l),
+(159,690,l),
+(13,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(181,498,l),
+(246,498,ls),
+(363,498,o),
+(422,443,o),
+(422,339,cs),
+(422,250,o),
+(392,55,o),
+(156,55,cs),
+(86,55,l)
+);
+}
+);
+width = 517;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1472;
+},
+{
+color = 11;
+glyphname = "kaa-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (35,0);
+ref = dot_top;
+}
+);
+width = 519;
+}
+);
+note = uni1473;
+},
+{
+color = 11;
+glyphname = "kweWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (519,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 688;
+}
+);
+note = uni1475;
+},
+{
+color = 11;
+glyphname = "kwiiWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (207,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (519,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 688;
+}
+);
+note = uni1479;
+},
+{
+color = 11;
+glyphname = "kwoWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (519,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 688;
+}
+);
+note = uni147B;
+},
+{
+color = 11;
+glyphname = "kwooWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (367,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (519,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 688;
+}
+);
+note = uni147D;
+},
+{
+color = 11;
+glyphname = "kwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (519,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 688;
+}
+);
+note = uni147F;
+},
+{
+color = 11;
+glyphname = "kwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (35,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (519,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 688;
+}
+);
+note = uni1481;
+},
+{
+color = 11;
+glyphname = "ce-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (362,690);
+},
+{
+name = top_left_can;
+pos = (181,690);
+},
+{
+name = top_right_can;
+pos = (545,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(428,0,l),
+(524,447,ls),
+(555,603,o),
+(489,702,o),
+(348,702,cs),
+(217,702,o),
+(133,617,o),
+(99,458,cs),
+(86,391,l),
+(147,391,l),
+(160,456,ls),
+(185,581,o),
+(247,643,o),
+(344,644,cs),
+(446,644,o),
+(489,575,o),
+(463,451,cs),
+(366,0,l)
+);
+}
+);
+width = 538;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni1489;
+},
+{
+color = 11;
+glyphname = "ci-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (368,690);
+},
+{
+name = top_left_can;
+pos = (187,690);
+},
+{
+name = top_right_can;
+pos = (552,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(71,0,l),
+(171,474,ls),
+(195,587,o),
+(253,644,o),
+(345,644,cs),
+(450,644,o),
+(497,574,o),
+(469,453,cs),
+(457,391,l),
+(518,391,l),
+(528,444,ls),
+(562,601,o),
+(492,702,o),
+(351,702,cs),
+(224,702,o),
+(142,624,o),
+(110,474,cs),
+(9,0,l)
+);
+}
+);
+width = 537;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+},
+{
+color = 11;
+glyphname = "cii-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (213,0);
+ref = dot_top;
+}
+);
+width = 536;
+}
+);
+note = uni148C;
+},
+{
+color = 11;
+glyphname = "co-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (361,690);
+},
+{
+name = top_left_can;
+pos = (180,690);
+},
+{
+name = top_right_can;
+pos = (544,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(358,-13,o),
+(440,66,o),
+(472,215,cs),
+(574,690,l),
+(512,690,l),
+(412,215,ls),
+(388,102,o),
+(329,45,o),
+(238,45,cs),
+(132,45,o),
+(87,116,o),
+(113,237,cs),
+(127,298,l),
+(66,298,l),
+(54,245,ls),
+(20,89,o),
+(92,-13,o),
+(232,-13,cs)
+);
+}
+);
+width = 536;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+},
+{
+color = 11;
+glyphname = "coo-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (388,0);
+ref = dot_top;
+}
+);
+width = 536;
+}
+);
+note = uni148E;
+},
+{
+color = 11;
+glyphname = "ca-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (368,690);
+},
+{
+name = top_left_can;
+pos = (187,690);
+},
+{
+name = top_right_can;
+pos = (552,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(366,-13,o),
+(449,72,o),
+(483,232,cs),
+(497,298,l),
+(437,298,l),
+(423,234,ls),
+(397,109,o),
+(336,46,o),
+(241,45,cs),
+(138,45,o),
+(95,115,o),
+(121,239,cs),
+(217,690,l),
+(156,690,l),
+(61,242,ls),
+(28,87,o),
+(96,-13,o),
+(237,-13,cs)
+);
+}
+);
+width = 536;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+},
+{
+color = 11;
+glyphname = "caa-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (32,0);
+ref = dot_top;
+}
+);
+width = 536;
+}
+);
+note = uni1491;
+},
+{
+color = 11;
+glyphname = "me-canadian.square";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (313,690);
+},
+{
+name = top_double;
+pos = (463,690);
+},
+{
+name = top_left_can;
+pos = (160,690);
+},
+{
+name = top_right_can;
+pos = (462,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(347,0,l),
+(494,690,l),
+(130,690,l),
+(118,633,l),
+(419,633,l),
+(285,0,l)
+);
+}
+);
+width = 459;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+},
+{
+color = 11;
+glyphname = "mi-canadian.square";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (341,690);
+},
+{
+name = top_left_can;
+pos = (190,690);
+},
+{
+name = top_right_can;
+pos = (492,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(73,0,l),
+(209,633,l),
+(510,633,l),
+(523,690,l),
+(159,690,l),
+(13,0,l)
+);
+}
+);
+width = 459;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+},
+{
+color = 11;
+glyphname = "mii-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (185,0);
+ref = dot_top;
+}
+);
+width = 459;
+}
+);
+note = uni14A6;
+},
+{
+color = 11;
+glyphname = "mo-canadian.square";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (313,690);
+},
+{
+name = top_double;
+pos = (463,690);
+},
+{
+name = top_left_can;
+pos = (160,690);
+},
+{
+name = top_right_can;
+pos = (463,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(347,0,l),
+(494,690,l),
+(432,690,l),
+(297,57,l),
+(-5,57,l),
+(-16,0,l)
+);
+}
+);
+width = 459;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+},
+{
+color = 11;
+glyphname = "moo-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (307,0);
+ref = dot_top;
+}
+);
+width = 459;
+}
+);
+note = uni14A8;
+},
+{
+color = 11;
+glyphname = "ma-canadian.square";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (341,690);
+},
+{
+name = top_left_can;
+pos = (190,690);
+},
+{
+name = top_right_can;
+pos = (491,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(376,0,l),
+(387,57,l),
+(86,57,l),
+(220,690,l),
+(159,690,l),
+(13,0,l)
+);
+}
+);
+width = 459;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+},
+{
+color = 11;
+glyphname = "maa-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (35,0);
+ref = dot_top;
+}
+);
+width = 459;
+}
+);
+note = uni14AB;
+},
+{
+color = 11;
+glyphname = "ne-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (440,690);
+},
+{
+name = top_left_can;
+pos = (288,690);
+},
+{
+name = top_right_can;
+pos = (594,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(422,-13,o),
+(488,52,o),
+(518,193,cs),
+(624,690,l),
+(146,690,l),
+(134,633,l),
+(244,633,l),
+(154,202,ls),
+(126,68,o),
+(184,-13,o),
+(308,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(229,45,o),
+(191,98,o),
+(213,193,cs),
+(305,633,l),
+(551,633,l),
+(458,193,ls),
+(437,95,o),
+(390,45,o),
+(315,45,cs)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C0;
+},
+{
+color = 11;
+glyphname = "ni-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (340,690);
+},
+{
+name = top_left_can;
+pos = (187,690);
+},
+{
+name = top_right_can;
+pos = (494,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(322,-13,o),
+(387,52,o),
+(417,193,cs),
+(511,633,l),
+(622,633,l),
+(634,690,l),
+(156,690,l),
+(53,202,ls),
+(25,68,o),
+(83,-13,o),
+(208,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(128,45,o),
+(91,98,o),
+(112,193,cs),
+(205,633,l),
+(450,633,l),
+(356,193,ls),
+(335,95,o),
+(291,45,o),
+(214,45,cs)
+);
+}
+);
+width = 587;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+},
+{
+color = 11;
+glyphname = "nii-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (185,0);
+ref = dot_top;
+}
+);
+width = 586;
+}
+);
+note = uni14C3;
+},
+{
+color = 11;
+glyphname = "no-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (440,690);
+},
+{
+name = top_double;
+pos = (450,690);
+},
+{
+name = top_left_can;
+pos = (288,690);
+},
+{
+name = top_right_can;
+pos = (584,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(477,0,l),
+(580,488,ls),
+(608,622,o),
+(550,702,o),
+(425,702,cs),
+(311,702,o),
+(246,638,o),
+(215,497,cs),
+(122,57,l),
+(12,57,l),
+(-1,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(276,497,ls),
+(298,595,o),
+(342,644,o),
+(418,644,cs),
+(504,644,o),
+(542,592,o),
+(522,497,cs),
+(428,57,l),
+(183,57,l)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C4;
+},
+{
+color = 11;
+glyphname = "noo-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (285,0);
+ref = dot_top;
+}
+);
+width = 586;
+}
+);
+note = uni14C5;
+},
+{
+color = 11;
+glyphname = "na-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (339,690);
+},
+{
+name = top_double;
+pos = (349,690);
+},
+{
+name = top_left_can;
+pos = (186,690);
+},
+{
+name = top_right_can;
+pos = (493,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(487,0,l),
+(498,57,l),
+(388,57,l),
+(479,488,ls),
+(507,622,o),
+(449,702,o),
+(325,702,cs),
+(211,702,o),
+(145,638,o),
+(115,497,cs),
+(9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(175,497,ls),
+(196,595,o),
+(242,644,o),
+(318,644,cs),
+(404,644,o),
+(441,592,o),
+(420,497,cs),
+(327,57,l),
+(82,57,l)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+},
+{
+color = 11;
+glyphname = "naa-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (184,0);
+ref = dot_top;
+}
+);
+width = 586;
+}
+);
+note = uni14C8;
+},
+{
+color = 11;
+glyphname = "nweWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (586,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 756;
+}
+);
+note = uni14CA;
+},
+{
+color = 11;
+glyphname = "nwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (586,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 756;
+}
+);
+note = uni14CC;
+},
+{
+color = 11;
+glyphname = "nwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (184,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (586,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 756;
+}
+);
+note = uni14CE;
+},
+{
+color = 11;
+glyphname = "se-canadian.square";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (188,690);
+},
+{
+name = top_right_can;
+pos = (540,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(420,0,l),
+(469,230,l),
+(355,230,ls),
+(197,230,o),
+(138,310,o),
+(173,477,cs),
+(218,690,l),
+(157,690,l),
+(112,477,ls),
+(71,288,o),
+(159,175,o),
+(345,175,cs),
+(419,175,l),
+(400,191,l),
+(359,0,l)
+);
+}
+);
+width = 533;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14ED;
+},
+{
+color = 11;
+glyphname = "si-canadian.square";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (190,690);
+},
+{
+name = top_right_can;
+pos = (543,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(73,0,l),
+(115,192,l),
+(88,175,l),
+(162,175,ls),
+(363,175,o),
+(480,271,o),
+(523,470,cs),
+(569,690,l),
+(508,690,l),
+(461,470,ls),
+(427,312,o),
+(328,230,o),
+(175,230,cs),
+(62,230,l),
+(13,0,l)
+);
+}
+);
+width = 533;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+},
+{
+color = 11;
+glyphname = "sii-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (387,0);
+ref = dot_top;
+}
+);
+width = 533;
+}
+);
+note = uni14F0;
+},
+{
+color = 11;
+glyphname = "so-canadian.square";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (536,690);
+},
+{
+name = top_left_can;
+pos = (187,690);
+},
+{
+name = top_right_can;
+pos = (536,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(70,0,l),
+(118,219,ls),
+(152,378,o),
+(250,460,o),
+(404,460,cs),
+(518,460,l),
+(566,690,l),
+(505,690,l),
+(464,497,l),
+(491,515,l),
+(416,515,ls),
+(216,515,o),
+(98,418,o),
+(56,219,cs),
+(10,0,l)
+);
+}
+);
+width = 533;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+},
+{
+color = 11;
+glyphname = "soo-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (382,0);
+ref = dot_top;
+}
+);
+width = 533;
+}
+);
+note = uni14F2;
+},
+{
+color = 11;
+glyphname = "sa-canadian.square";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (194,690);
+},
+{
+name = top_right_can;
+pos = (540,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(423,0,l),
+(469,213,ls),
+(509,402,o),
+(422,515,o),
+(236,515,cs),
+(161,515,l),
+(181,498,l),
+(222,690,l),
+(160,690,l),
+(111,460,l),
+(225,460,ls),
+(384,460,o),
+(443,380,o),
+(408,213,cs),
+(362,0,l)
+);
+}
+);
+width = 534;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+},
+{
+color = 11;
+glyphname = "saa-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (38,0);
+ref = dot_top;
+}
+);
+width = 533;
+}
+);
+note = uni14F5;
+},
+{
+color = 11;
+glyphname = "sho-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (354,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(403,0,l),
+(414,52,l),
+(203,52,ls),
+(135,52,o),
+(101,84,o),
+(101,148,cs),
+(101,205,o),
+(116,319,o),
+(251,319,cs),
+(313,319,ls),
+(482,319,o),
+(526,450,o),
+(526,545,cs),
+(526,636,o),
+(472,690,o),
+(384,690,cs),
+(156,690,l),
+(145,638,l),
+(363,638,ls),
+(430,638,o),
+(465,605,o),
+(465,541,cs),
+(465,481,o),
+(447,372,o),
+(314,372,cs),
+(253,372,ls),
+(82,372,o),
+(41,238,o),
+(41,144,cs),
+(41,54,o),
+(93,0,o),
+(183,0,cs)
+);
+}
+);
+width = 520;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+color = 11;
+glyphname = "shoo-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (198,0);
+ref = dot_top;
+}
+);
+width = 521;
+}
+);
+note = g728;
+},
+{
+color = 11;
+glyphname = "sha-canadian.square";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (355,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(238,0,ls),
+(415,0,o),
+(459,130,o),
+(459,234,cs),
+(459,322,o),
+(406,372,o),
+(319,372,cs),
+(270,372,ls),
+(204,372,o),
+(169,399,o),
+(169,459,cs),
+(169,528,o),
+(187,638,o),
+(327,638,cs),
+(541,638,l),
+(553,690,l),
+(327,690,ls),
+(150,690,o),
+(107,558,o),
+(107,456,cs),
+(107,368,o),
+(159,319,o),
+(246,319,cs),
+(296,319,ls),
+(361,319,o),
+(397,291,o),
+(397,230,cs),
+(397,162,o),
+(374,52,o),
+(238,52,cs),
+(24,52,l),
+(13,0,l)
+);
+}
+);
+width = 520;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+color = 11;
+glyphname = "shaa-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (199,0);
+ref = dot_top;
+}
+);
+width = 520;
+}
+);
+note = g730;
+},
+{
+color = 11;
+glyphname = "ye-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (169,690);
+},
+{
+name = top_right_can;
+pos = (552,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(435,0,l),
+(484,230,l),
+(121,230,l),
+(124,203,l),
+(587,657,l),
+(546,701,l),
+(32,199,l),
+(27,175,l),
+(411,175,l),
+(374,0,l)
+);
+}
+);
+width = 545;
+}
+);
+metricLeft = "ye-canadian";
+note = uni1526;
+},
+{
+color = 11;
+glyphname = "yi-canadian.square";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (185,690);
+},
+{
+name = top_right_can;
+pos = (567,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(70,0,l),
+(107,175,l),
+(492,175,l),
+(496,199,l),
+(184,701,l),
+(133,664,l),
+(416,203,l),
+(420,230,l),
+(58,230,l),
+(9,0,l)
+);
+}
+);
+width = 545;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni1528;
+},
+{
+color = 11;
+glyphname = "yii-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (30,0);
+ref = dot_top;
+}
+);
+width = 545;
+}
+);
+note = uni1529;
+},
+{
+color = 11;
+glyphname = "yo-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (551,690);
+},
+{
+name = top_left_can;
+pos = (168,690);
+},
+{
+name = top_right_can;
+pos = (551,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(456,26,l),
+(173,487,l),
+(169,460,l),
+(532,460,l),
+(582,690,l),
+(520,690,l),
+(482,515,l),
+(99,515,l),
+(94,491,l),
+(405,-12,l)
+);
+}
+);
+width = 545;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152A;
+},
+{
+color = 11;
+glyphname = "yoo-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (396,0);
+ref = dot_top;
+}
+);
+width = 545;
+}
+);
+note = uni152B;
+},
+{
+color = 11;
+glyphname = "ya-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (187,690);
+},
+{
+name = top_right_can;
+pos = (569,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(559,491,l),
+(564,515,l),
+(181,515,l),
+(217,690,l),
+(156,690,l),
+(107,460,l),
+(470,460,l),
+(468,487,l),
+(4,33,l),
+(45,-12,l)
+);
+}
+);
+width = 545;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152D;
+},
+{
+color = 11;
+glyphname = "yaa-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (31,0);
+ref = dot_top;
+}
+);
+width = 545;
+}
+);
+note = uni152E;
+},
+{
+color = 11;
+glyphname = "re-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (340,690);
+},
+{
+name = top_left_can;
+pos = (187,690);
+},
+{
+name = top_right_can;
+pos = (494,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(322,-13,o),
+(387,52,o),
+(417,193,cs),
+(511,633,l),
+(622,633,l),
+(634,690,l),
+(462,690,l),
+(356,193,ls),
+(335,95,o),
+(291,45,o),
+(214,45,cs),
+(128,45,o),
+(91,98,o),
+(112,193,cs),
+(216,690,l),
+(156,690,l),
+(53,202,ls),
+(25,68,o),
+(83,-13,o),
+(208,-13,cs)
+);
+}
+);
+width = 587;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1542;
+},
+{
+color = 11;
+glyphname = "reRCree-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (440,690);
+},
+{
+name = top_left_can;
+pos = (288,690);
+},
+{
+name = top_right_can;
+pos = (594,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(422,-13,o),
+(488,52,o),
+(518,193,cs),
+(624,690,l),
+(563,690,l),
+(458,193,ls),
+(437,95,o),
+(390,45,o),
+(315,45,cs),
+(229,45,o),
+(191,98,o),
+(213,193,cs),
+(318,690,l),
+(146,690,l),
+(134,633,l),
+(244,633,l),
+(154,202,ls),
+(126,68,o),
+(184,-13,o),
+(308,-13,cs)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni1543;
+},
+{
+color = 11;
+glyphname = "leWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (440,690);
+},
+{
+name = top_left_can;
+pos = (287,690);
+},
+{
+name = top_right_can;
+pos = (593,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(170,0,l),
+(275,497,ls),
+(297,595,o),
+(341,644,o),
+(417,644,cs),
+(503,644,o),
+(541,592,o),
+(521,497,cs),
+(415,0,l),
+(476,0,l),
+(579,488,ls),
+(608,622,o),
+(549,702,o),
+(424,702,cs),
+(310,702,o),
+(245,638,o),
+(214,497,cs),
+(121,56,l),
+(12,56,l),
+(-1,0,l)
+);
+}
+);
+width = 587;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+},
+{
+color = 11;
+glyphname = "ri-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (339,690);
+},
+{
+name = top_left_can;
+pos = (188,690);
+},
+{
+name = top_right_can;
+pos = (493,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(70,0,l),
+(175,497,ls),
+(196,595,o),
+(242,644,o),
+(318,644,cs),
+(404,644,o),
+(441,592,o),
+(420,497,cs),
+(315,0,l),
+(487,0,l),
+(498,57,l),
+(388,57,l),
+(479,488,ls),
+(507,622,o),
+(449,702,o),
+(325,702,cs),
+(211,702,o),
+(145,638,o),
+(115,497,cs),
+(9,0,l)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+},
+{
+color = 11;
+glyphname = "rii-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (184,0);
+ref = dot_top;
+}
+);
+width = 586;
+}
+);
+note = uni1547;
+},
+{
+color = 11;
+glyphname = "ro-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (357,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(73,0,l),
+(108,162,l),
+(76,136,l),
+(166,136,ls),
+(445,136,o),
+(497,355,o),
+(497,476,cs),
+(497,610,o),
+(416,690,o),
+(275,690,cs),
+(159,690,l),
+(148,635,l),
+(266,635,ls),
+(379,635,o),
+(437,580,o),
+(437,476,cs),
+(437,386,o),
+(412,191,o),
+(173,191,cs),
+(53,191,l),
+(13,0,l)
+);
+}
+);
+width = 503;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1548;
+},
+{
+color = 11;
+glyphname = "loWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (354,690);
+},
+{
+name = top_left_can;
+pos = (190,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(137,0,ls),
+(414,0,o),
+(466,219,o),
+(466,340,cs),
+(466,474,o),
+(384,554,o),
+(243,554,cs),
+(164,554,l),
+(186,527,l),
+(220,690,l),
+(159,690,l),
+(118,498,l),
+(234,498,ls),
+(348,498,o),
+(405,443,o),
+(405,340,cs),
+(405,250,o),
+(379,55,o),
+(150,55,cs),
+(24,55,l),
+(13,0,l)
+);
+}
+);
+width = 502;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+},
+{
+color = 11;
+glyphname = "ra-canadian.square";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (339,690);
+},
+{
+name = top_right_can;
+pos = (505,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(388,0,l),
+(430,191,l),
+(313,191,ls),
+(200,191,o),
+(143,246,o),
+(143,350,cs),
+(143,440,o),
+(169,635,o),
+(398,635,cs),
+(524,635,l),
+(535,690,l),
+(411,690,ls),
+(133,690,o),
+(82,470,o),
+(82,350,cs),
+(82,215,o),
+(162,136,o),
+(304,136,cs),
+(384,136,l),
+(361,162,l),
+(327,0,l)
+);
+}
+);
+width = 502;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+},
+{
+color = 11;
+glyphname = "raa-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (185,0);
+ref = dot_top;
+}
+);
+width = 501;
+}
+);
+note = uni154C;
+},
+{
+color = 11;
+glyphname = "laWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (506,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(389,0,l),
+(401,55,l),
+(285,55,ls),
+(173,55,o),
+(114,110,o),
+(114,213,cs),
+(114,303,o),
+(139,498,o),
+(378,498,cs),
+(495,498,l),
+(536,690,l),
+(474,690,l),
+(440,527,l),
+(472,554,l),
+(385,554,ls),
+(105,554,o),
+(53,335,o),
+(53,213,cs),
+(53,80,o),
+(134,0,o),
+(276,0,cs)
+);
+}
+);
+width = 501;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+},
+{
+color = 11;
+glyphname = "reWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(421,0,l),
+(639,191,l),
+(603,233,l),
+(423,72,l),
+(441,61,l),
+(524,447,ls),
+(556,603,o),
+(490,702,o),
+(349,702,cs),
+(218,702,o),
+(133,620,o),
+(99,458,cs),
+(86,391,l),
+(147,391,l),
+(160,456,ls),
+(185,581,o),
+(247,643,o),
+(344,644,cs),
+(446,644,o),
+(489,575,o),
+(463,451,cs),
+(367,0,l)
+);
+}
+);
+width = 671;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+},
+{
+color = 11;
+glyphname = "riWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(203,0,l),
+(303,474,ls),
+(326,587,o),
+(384,644,o),
+(476,644,cs),
+(581,644,o),
+(626,575,o),
+(601,453,cs),
+(588,391,l),
+(649,391,l),
+(660,444,ls),
+(691,601,o),
+(622,702,o),
+(482,702,cs),
+(355,702,o),
+(273,627,o),
+(241,474,cs),
+(154,60,l),
+(173,62,l),
+(58,226,l),
+(12,191,l),
+(148,0,l)
+);
+}
+);
+width = 668;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+},
+{
+color = 11;
+glyphname = "roWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(358,-13,o),
+(440,63,o),
+(472,215,cs),
+(560,630,l),
+(541,628,l),
+(657,464,l),
+(702,498,l),
+(566,690,l),
+(511,690,l),
+(411,215,ls),
+(387,102,o),
+(329,45,o),
+(238,45,cs),
+(132,45,o),
+(88,115,o),
+(113,237,cs),
+(126,298,l),
+(65,298,l),
+(54,245,ls),
+(23,89,o),
+(92,-13,o),
+(232,-13,cs)
+);
+}
+);
+width = 668;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+},
+{
+color = 11;
+glyphname = "raWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(497,-13,o),
+(582,70,o),
+(616,232,cs),
+(630,298,l),
+(569,298,l),
+(555,234,ls),
+(530,109,o),
+(468,46,o),
+(372,45,cs),
+(269,45,o),
+(227,115,o),
+(253,239,cs),
+(349,690,l),
+(295,690,l),
+(78,498,l),
+(113,457,l),
+(293,617,l),
+(274,629,l),
+(192,242,ls),
+(159,87,o),
+(226,-13,o),
+(367,-13,cs)
+);
+}
+);
+width = 669;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+},
+{
+color = 11;
+glyphname = "theThCree-canadian.square";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (169,690);
+},
+{
+name = top_right_can;
+pos = (552,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(435,0,l),
+(450,71,l),
+(518,71,l),
+(526,107,l),
+(458,107,l),
+(484,230,l),
+(124,230,l),
+(131,211,l),
+(587,657,l),
+(546,701,l),
+(32,199,l),
+(27,175,l),
+(411,175,l),
+(397,107,l),
+(214,107,l),
+(207,71,l),
+(388,71,l),
+(374,0,l)
+);
+}
+);
+width = 588;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15A7;
+},
+{
+color = 11;
+glyphname = "thiThCree-canadian.square";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (226,690);
+},
+{
+name = top_right_can;
+pos = (608,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(115,0,l),
+(129,71,l),
+(312,71,l),
+(320,107,l),
+(138,107,l),
+(153,175,l),
+(536,175,l),
+(541,199,l),
+(230,701,l),
+(179,664,l),
+(460,207,l),
+(471,230,l),
+(102,230,l),
+(77,107,l),
+(8,107,l),
+(1,71,l),
+(69,71,l),
+(54,0,l)
+);
+}
+);
+width = 589;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+},
+{
+color = 11;
+glyphname = "thiiThCree-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (69,0);
+ref = dot_top;
+}
+);
+width = 587;
+}
+);
+note = uni15A9;
+},
+{
+color = 11;
+glyphname = "thoThCree-canadian.square";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (167,690);
+},
+{
+name = top_right_can;
+pos = (551,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(456,26,l),
+(176,483,l),
+(163,460,l),
+(531,460,l),
+(557,582,l),
+(626,582,l),
+(634,619,l),
+(565,619,l),
+(581,690,l),
+(519,690,l),
+(504,619,l),
+(322,619,l),
+(314,582,l),
+(496,582,l),
+(482,515,l),
+(99,515,l),
+(94,491,l),
+(404,-12,l)
+);
+}
+);
+width = 588;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+},
+{
+color = 11;
+glyphname = "thooThCree-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (396,0);
+ref = dot_top;
+}
+);
+width = 587;
+}
+);
+note = uni15AB;
+},
+{
+color = 11;
+glyphname = "thaThCree-canadian.square";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (231,690);
+},
+{
+name = top_right_can;
+pos = (613,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(603,491,l),
+(608,515,l),
+(224,515,l),
+(239,582,l),
+(421,582,l),
+(429,619,l),
+(246,619,l),
+(262,690,l),
+(200,690,l),
+(186,619,l),
+(117,619,l),
+(109,582,l),
+(177,582,l),
+(152,460,l),
+(511,460,l),
+(504,479,l),
+(48,33,l),
+(90,-12,l)
+);
+}
+);
+width = 589;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+},
+{
+color = 11;
+glyphname = "thaaThCree-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (74,0);
+ref = dot_top;
+}
+);
+width = 587;
+}
+);
+note = uni15AD;
+},
+{
+color = 11;
+glyphname = "thweeWoodScree-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (587,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 757;
+}
+);
+note = uni1677;
+},
+{
+color = 11;
+glyphname = "thwiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (587,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 757;
+}
+);
+note = uni1678;
+},
+{
+color = 11;
+glyphname = "thwiiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (69,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (587,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 757;
+}
+);
+note = uni1679;
+},
+{
+color = 11;
+glyphname = "thwoWoodScree-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (587,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 757;
+}
+);
+note = uni167A;
+},
+{
+color = 11;
+glyphname = "thwooWoodScree-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (396,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (587,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 757;
+}
+);
+note = uni167B;
+},
+{
+color = 11;
+glyphname = "thwaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (587,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 757;
+}
+);
+note = uni167C;
+},
+{
+color = 11;
+glyphname = "thwaaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (74,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (587,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 757;
+}
+);
+note = uni167D;
+},
+{
+color = 11;
+glyphname = "nwiOjibway-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (586,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 756;
+}
+);
+note = uni18C7;
+},
+{
+color = 11;
+glyphname = "nwiiOjibway-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (185,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (586,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 756;
+}
+);
+note = uni18C9;
+},
+{
+color = 11;
+glyphname = "nwoOjibway-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (586,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 756;
+}
+);
+note = uni18CB;
+},
+{
+color = 11;
+glyphname = "nwooOjibway-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (285,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (586,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 756;
+}
+);
+note = uni18CD;
+},
+{
+color = 11;
+glyphname = "looWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (35,0);
+ref = dot_top;
+}
+);
+width = 501;
+}
+);
+note = uni18E1;
+},
+{
+color = 11;
+glyphname = "laaWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (351,0);
+ref = dot_top;
+}
+);
+width = 501;
+}
+);
+note = uni18E2;
+},
+{
+color = 0;
+glyphname = zero;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(549,542,o),
+(501,700,o),
+(327,700,cs),
+(150,700,o),
+(102,526,o),
+(102,347,cs),
+(102,106,o),
+(183,-10,o),
+(326,-10,cs),
+(475,-10,o),
+(549,108,o),
+(549,347,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(167,488,o),
+(191,645,o),
+(327,645,cs),
+(470,645,o),
+(484,478,o),
+(484,347,cs),
+(484,161,o),
+(442,45,o),
+(326,45,cs),
+(215,45,o),
+(167,159,o),
+(167,347,cs)
+);
+}
+);
+width = 609;
+}
+);
+unicode = 48;
+},
+{
+color = 0;
+glyphname = one;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(283,690,l),
+(83,539,l),
+(119,495,l),
+(227,577,ls),
+(249,593,o),
+(262,605,o),
+(277,619,c),
+(276,596,o),
+(276,573,o),
+(276,548,cs),
+(276,0,l),
+(341,0,l),
+(341,690,l)
+);
+}
+);
+width = 460;
+}
+);
+unicode = 49;
+},
+{
+color = 0;
+glyphname = two;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(544,0,l),
+(544,56,l),
+(191,56,l),
+(191,58,l),
+(355,229,ls),
+(424,298,o),
+(472,353,o),
+(498,414,cs),
+(510,444,o),
+(516,479,o),
+(516,519,cs),
+(516,628,o),
+(437,699,o),
+(322,699,cs),
+(248,699,o),
+(181,674,o),
+(120,622,c),
+(156,578,l),
+(208,621,o),
+(264,642,o),
+(316,642,cs),
+(400,642,o),
+(451,595,o),
+(451,512,cs),
+(451,450,o),
+(431,403,o),
+(390,352,cs),
+(369,325,o),
+(343,296,o),
+(310,262,cs),
+(106,47,l),
+(106,0,l)
+);
+}
+);
+width = 594;
+}
+);
+unicode = 50;
+},
+{
+color = 0;
+glyphname = three;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(527,639,o),
+(447,699,o),
+(327,699,cs),
+(234,699,o),
+(166,670,o),
+(109,628,c),
+(138,582,l),
+(191,621,o),
+(251,644,o),
+(321,644,cs),
+(407,644,o),
+(464,606,o),
+(464,524,cs),
+(464,427,o),
+(379,384,o),
+(280,384,cs),
+(209,384,l),
+(209,331,l),
+(279,331,ls),
+(398,331,o),
+(480,298,o),
+(480,192,cs),
+(480,102,o),
+(420,44,o),
+(293,44,cs),
+(227,44,o),
+(155,63,o),
+(102,89,c),
+(102,30,l),
+(155,7,o),
+(219,-10,o),
+(299,-10,cs),
+(455,-10,o),
+(549,69,o),
+(549,189,cs),
+(549,292,o),
+(487,346,o),
+(379,360,c),
+(379,362,l),
+(464,380,o),
+(527,442,o),
+(527,534,cs)
+);
+}
+);
+width = 598;
+}
+);
+unicode = 51;
+},
+{
+color = 0;
+glyphname = four;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,226,l),
+(440,693,l),
+(378,693,l),
+(36,221,l),
+(36,174,l),
+(376,174,l),
+(376,0,l),
+(440,0,l),
+(440,174,l),
+(556,174,l),
+(556,226,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(100,226,l),
+(320,526,ls),
+(346,562,o),
+(355,579,o),
+(375,611,c),
+(378,611,l),
+(378,590,o),
+(376,556,o),
+(376,520,cs),
+(376,226,l)
+);
+}
+);
+width = 582;
+}
+);
+unicode = 52;
+},
+{
+color = 0;
+glyphname = five;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(245,421,o),
+(208,412,o),
+(179,405,c),
+(199,634,l),
+(483,634,l),
+(483,690,l),
+(143,690,l),
+(115,366,l),
+(146,347,l),
+(187,360,o),
+(230,368,o),
+(283,368,cs),
+(401,368,o),
+(460,310,o),
+(460,213,cs),
+(460,106,o),
+(385,44,o),
+(270,44,cs),
+(203,44,o),
+(139,65,o),
+(95,90,c),
+(95,30,l),
+(138,7,o),
+(198,-10,o),
+(273,-10,cs),
+(434,-10,o),
+(526,77,o),
+(526,214,cs),
+(526,347,o),
+(440,421,o),
+(306,421,cs)
+);
+}
+);
+width = 570;
+}
+);
+unicode = 53;
+},
+{
+color = 0;
+glyphname = six;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(88,134,o),
+(156,-10,o),
+(321,-10,cs),
+(454,-10,o),
+(536,79,o),
+(536,222,cs),
+(536,353,o),
+(462,433,o),
+(336,433,cs),
+(244,433,o),
+(179,388,o),
+(151,327,c),
+(148,327,l),
+(153,513,o),
+(219,647,o),
+(394,647,cs),
+(435,647,o),
+(467,641,o),
+(491,634,c),
+(491,690,l),
+(465,696,o),
+(431,701,o),
+(395,701,cs),
+(168,701,o),
+(88,523,o),
+(88,293,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(193,44,o),
+(157,166,o),
+(157,247,cs),
+(157,321,o),
+(240,380,o),
+(324,380,cs),
+(424,380,o),
+(472,319,o),
+(472,221,cs),
+(472,111,o),
+(417,44,o),
+(320,44,cs)
+);
+}
+);
+width = 582;
+}
+);
+unicode = 54;
+},
+{
+color = 0;
+glyphname = seven;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(564,650,l),
+(564,690,l),
+(113,690,l),
+(113,634,l),
+(494,634,l),
+(219,0,l),
+(288,0,l)
+);
+}
+);
+width = 588;
+}
+);
+unicode = 55;
+},
+{
+color = 0;
+glyphname = eight;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(458,-10,o),
+(552,59,o),
+(552,177,cs),
+(552,274,o),
+(482,329,o),
+(380,368,c),
+(469,405,o),
+(528,455,o),
+(528,539,cs),
+(528,642,o),
+(450,699,o),
+(329,699,cs),
+(211,699,o),
+(129,638,o),
+(129,538,cs),
+(129,441,o),
+(205,397,o),
+(274,366,c),
+(175,330,o),
+(107,275,o),
+(107,172,cs),
+(107,64,o),
+(191,-10,o),
+(326,-10,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(232,42,o),
+(169,93,o),
+(169,174,cs),
+(169,267,o),
+(247,310,o),
+(327,337,c),
+(437,296,o),
+(490,251,o),
+(490,178,cs),
+(490,89,o),
+(423,42,o),
+(326,42,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(247,427,o),
+(192,465,o),
+(192,534,cs),
+(192,608,o),
+(251,648,o),
+(329,648,cs),
+(414,648,o),
+(466,610,o),
+(466,535,cs),
+(466,469,o),
+(418,433,o),
+(330,396,c)
+);
+}
+);
+width = 611;
+}
+);
+unicode = 56;
+},
+{
+color = 0;
+glyphname = nine;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(549,563,o),
+(482,699,o),
+(317,699,cs),
+(183,699,o),
+(100,611,o),
+(100,469,cs),
+(100,339,o),
+(174,257,o),
+(298,257,cs),
+(389,257,o),
+(457,300,o),
+(486,363,c),
+(489,363,l),
+(483,173,o),
+(412,43,o),
+(240,43,cs),
+(201,43,o),
+(164,48,o),
+(140,56,c),
+(140,0,l),
+(166,-7,o),
+(207,-12,o),
+(242,-12,cs),
+(470,-12,o),
+(549,172,o),
+(549,396,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(444,644,o),
+(479,522,o),
+(479,443,cs),
+(479,370,o),
+(395,310,o),
+(314,310,cs),
+(214,310,o),
+(164,372,o),
+(164,470,cs),
+(164,581,o),
+(219,644,o),
+(318,644,cs)
+);
+}
+);
+width = 607;
+}
+);
+unicode = 57;
+},
+{
+glyphname = zero.canadian;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(372,-12,o),
+(439,369,o),
+(439,513,cs),
+(439,638,o),
+(393,702,o),
+(303,702,cs),
+(113,702,o),
+(49,321,o),
+(49,177,cs),
+(49,53,o),
+(95,-12,o),
+(185,-12,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(134,44,o),
+(108,85,o),
+(108,170,cs),
+(108,276,o),
+(162,646,o),
+(301,646,cs),
+(354,646,o),
+(380,606,o),
+(380,520,cs),
+(380,413,o),
+(325,44,o),
+(186,44,cs)
+);
+}
+);
+width = 441;
+}
+);
+metricRight = "=|";
+},
+{
+glyphname = one.canadian;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(176,0,l),
+(323,690,l),
+(268,690,l),
+(88,531,l),
+(123,491,l),
+(297,643,l),
+(252,648,l),
+(115,0,l)
+);
+}
+);
+width = 288;
+}
+);
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = two.canadian;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(351,57,l),
+(89,57,l),
+(88,33,l),
+(325,298,ls),
+(400,383,o),
+(442,470,o),
+(442,556,cs),
+(442,647,o),
+(389,702,o),
+(299,702,cs),
+(191,702,o),
+(120,624,o),
+(90,454,c),
+(151,454,l),
+(175,591,o),
+(221,647,o),
+(296,647,cs),
+(352,647,o),
+(383,614,o),
+(383,555,cs),
+(383,481,o),
+(341,403,o),
+(274,327,cs),
+(19,42,l),
+(10,0,l),
+(338,0,l)
+);
+}
+);
+width = 435;
+}
+);
+note = uni14BF;
+},
+{
+glyphname = three.canadian;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(356,-13,o),
+(398,125,o),
+(398,218,cs),
+(398,289,o),
+(368,335,o),
+(311,355,c),
+(306,332,l),
+(430,343,o),
+(464,480,o),
+(464,554,cs),
+(464,648,o),
+(411,702,o),
+(318,702,cs),
+(213,702,o),
+(144,625,o),
+(111,470,c),
+(172,470,l),
+(201,595,o),
+(244,647,o),
+(314,647,cs),
+(371,647,o),
+(401,613,o),
+(401,549,cs),
+(401,492,o),
+(386,372,o),
+(272,372,cs),
+(245,372,l),
+(234,319,l),
+(262,319,ls),
+(310,319,o),
+(337,282,o),
+(337,221,cs),
+(337,159,o),
+(316,43,o),
+(207,43,cs),
+(102,43,o),
+(95,132,o),
+(114,219,c),
+(53,219,l),
+(27,106,o),
+(55,-13,o),
+(207,-13,cs)
+);
+}
+);
+width = 468;
+}
+);
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = four.canadian;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(287,0,l),
+(324,174,l),
+(403,174,l),
+(413,227,l),
+(335,227,l),
+(434,693,l),
+(384,693,l),
+(29,216,l),
+(19,174,l),
+(265,174,l),
+(228,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(384,627,l),
+(363,627,l),
+(278,227,l),
+(75,227,l),
+(77,213,l)
+);
+}
+);
+width = 440;
+}
+);
+},
+{
+glyphname = five.canadian;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(371,-13,o),
+(406,156,o),
+(406,246,cs),
+(406,344,o),
+(353,397,o),
+(246,397,cs),
+(156,397,l),
+(178,375,l),
+(253,649,l),
+(222,633,l),
+(477,633,l),
+(489,690,l),
+(204,690,l),
+(114,356,l),
+(122,342,l),
+(229,342,ls),
+(307,342,o),
+(344,311,o),
+(344,241,cs),
+(344,184,o),
+(328,43,o),
+(210,43,cs),
+(110,43,o),
+(97,122,o),
+(112,192,c),
+(51,192,l),
+(31,91,o),
+(71,-13,o),
+(208,-13,cs)
+);
+}
+);
+width = 462;
+}
+);
+},
+{
+glyphname = six.canadian;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(336,-13,o),
+(393,147,o),
+(393,253,cs),
+(393,349,o),
+(344,412,o),
+(261,412,cs),
+(188,412,o),
+(129,358,o),
+(97,266,c),
+(113,261,l),
+(120,303,o),
+(124,325,o),
+(134,375,cs),
+(178,573,o),
+(238,647,o),
+(310,647,cs),
+(399,647,o),
+(397,560,o),
+(389,501,c),
+(449,501,l),
+(459,592,o),
+(435,702,o),
+(312,702,cs),
+(87,702,o),
+(45,222,o),
+(45,171,cs),
+(45,127,o),
+(52,91,o),
+(66,63,cs),
+(89,14,o),
+(134,-13,o),
+(193,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(136,42,o),
+(104,85,o),
+(104,155,cs),
+(104,226,o),
+(141,359,o),
+(247,359,cs),
+(303,359,o),
+(332,320,o),
+(332,251,cs),
+(332,183,o),
+(301,42,o),
+(195,42,cs)
+);
+}
+);
+width = 441;
+}
+);
+metricLeft = zero.canadian;
+},
+{
+glyphname = seven.canadian;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(102,0,l),
+(422,650,l),
+(431,690,l),
+(117,690,l),
+(104,633,l),
+(358,633,l),
+(361,653,l),
+(47,19,l),
+(44,0,l)
+);
+}
+);
+width = 365;
+}
+);
+},
+{
+glyphname = eight.canadian;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(346,-13,o),
+(397,110,o),
+(403,203,cs),
+(409,276,o),
+(371,330,o),
+(316,351,c),
+(308,333,l),
+(412,346,o),
+(459,457,o),
+(465,536,cs),
+(471,636,o),
+(412,702,o),
+(314,702,cs),
+(185,702,o),
+(132,580,o),
+(126,489,cs),
+(120,414,o),
+(152,359,o),
+(208,340,c),
+(208,360,l),
+(92,345,o),
+(50,236,o),
+(45,156,cs),
+(38,57,o),
+(103,-13,o),
+(208,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(139,42,o),
+(102,82,o),
+(105,154,cs),
+(107,223,o),
+(138,320,o),
+(241,320,cs),
+(310,320,o),
+(347,278,o),
+(344,208,cs),
+(342,141,o),
+(314,42,o),
+(209,42,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(214,371,o),
+(183,411,o),
+(185,479,cs),
+(186,545,o),
+(213,648,o),
+(312,648,cs),
+(374,648,o),
+(407,609,o),
+(405,541,cs),
+(403,475,o),
+(371,371,o),
+(275,371,cs)
+);
+}
+);
+width = 472;
+}
+);
+metricLeft = "=|";
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = nine.canadian;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(401,-13,o),
+(441,468,o),
+(441,519,cs),
+(441,563,o),
+(436,599,o),
+(422,627,cs),
+(399,675,o),
+(353,702,o),
+(294,702,cs),
+(151,702,o),
+(94,543,o),
+(94,437,cs),
+(94,341,o),
+(143,277,o),
+(226,277,cs),
+(298,277,o),
+(358,331,o),
+(390,424,c),
+(374,429,l),
+(367,386,o),
+(363,365,o),
+(353,315,cs),
+(310,117,o),
+(249,43,o),
+(177,43,cs),
+(88,43,o),
+(90,129,o),
+(98,188,c),
+(38,188,l),
+(28,98,o),
+(52,-13,o),
+(175,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(184,330,o),
+(155,370,o),
+(155,439,cs),
+(155,507,o),
+(185,648,o),
+(293,648,cs),
+(351,648,o),
+(383,605,o),
+(383,535,cs),
+(383,464,o),
+(346,330,o),
+(241,330,cs)
+);
+}
+);
+width = 440;
+}
+);
+metricLeft = "=|six.canadian";
+metricRight = "=|six.canadian";
+},
+{
+glyphname = CR;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+width = 194;
+}
+);
+note = CR;
+unicode = 13;
+},
+{
+color = 0;
+glyphname = .notdef;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(584,690,l),
+(187,690,l),
+(187,0,l),
+(584,0,l),
+(584,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(535,640,l),
+(535,49,l),
+(237,49,l),
+(237,640,l),
+(237,640,l)
+);
+}
+);
+width = 676;
+}
+);
+note = ".notdef";
+},
+{
+glyphname = .null;
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+width = 0;
+}
+);
+note = NULL;
+},
+{
+glyphname = space;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+width = 199;
+}
+);
+note = space;
+unicode = 32;
+},
+{
+glyphname = nbspace;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+width = 194;
+}
+);
+note = uni00A0;
+unicode = 160;
+},
+{
+glyphname = space.canadian;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+width = 386;
+}
+);
+note = space;
+},
+{
+glyphname = "hyphen-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(325,402,l),
+(333,441,l),
+(95,441,l),
+(86,402,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(296,269,l),
+(304,308,l),
+(66,308,l),
+(57,269,l)
+);
+}
+);
+width = 340;
+}
+);
+metricRight = "=|";
+note = uni1400;
+unicode = 5120;
+},
+{
+glyphname = "chi-canadian";
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(49,0,l),
+(235,308,l),
+(215,312,l),
+(271,0,l),
+(326,0,l),
+(330,19,l),
+(260,375,l),
+(250,325,l),
+(466,670,l),
+(470,690,l),
+(412,690,l),
+(230,386,l),
+(248,384,l),
+(195,690,l),
+(141,690,l),
+(136,670,l),
+(207,325,l),
+(215,375,l),
+(-5,19,l),
+(-10,0,l)
+);
+}
+);
+width = 416;
+}
+);
+metricRight = "=|";
+note = uni166D;
+unicode = 5741;
+},
+{
+glyphname = "fullstop-canadian";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(43,0,l),
+(128,142,l),
+(116,146,l),
+(143,0,l),
+(181,0,l),
+(183,10,l),
+(147,186,l),
+(143,161,l),
+(250,334,l),
+(253,345,l),
+(211,345,l),
+(125,201,l),
+(140,197,l),
+(113,345,l),
+(75,345,l),
+(72,334,l),
+(108,165,l),
+(113,189,l),
+(2,10,l),
+(0,0,l)
+);
+}
+);
+width = 281;
+}
+);
+note = uni1541;
+unicode = 5742;
+},
+{
+glyphname = period;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(24,8,o),
+(37,-9,o),
+(68,-9,cs),
+(94,-9,o),
+(110,11,o),
+(113,42,cs),
+(117,65,o),
+(104,81,o),
+(72,81,cs),
+(43,81,o),
+(30,59,o),
+(27,31,cs)
+);
+}
+);
+width = 208;
+}
+);
+note = period;
+unicode = 46;
+},
+{
+glyphname = comma;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(-8,-127,l),
+(37,-58,o),
+(79,36,o),
+(110,108,c),
+(108,119,l),
+(51,119,l),
+(25,45,o),
+(-8,-33,o),
+(-53,-127,c)
+);
+}
+);
+width = 184;
+}
+);
+note = comma;
+unicode = 44;
+},
+{
+glyphname = hyphen;
+kernLeft = hyphen;
+kernRight = hyphen;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(210,235,l),
+(220,289,l),
+(53,289,l),
+(42,235,l)
+);
+}
+);
+width = 252;
+}
+);
+unicode = 45;
+},
+{
+glyphname = quotesinglbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-14,-571);
+ref = quoteright;
+}
+);
+width = 199;
+}
+);
+unicode = 8218;
+},
+{
+glyphname = quotedblbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-90,-571);
+ref = quotedblright;
+}
+);
+width = 403;
+}
+);
+unicode = 8222;
+},
+{
+glyphname = quotedblleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(317,443,l),
+(338,514,o),
+(379,609,o),
+(426,690,c),
+(384,690,l),
+(338,621,o),
+(293,534,o),
+(261,452,c),
+(265,443,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(158,443,l),
+(182,517,o),
+(218,606,o),
+(269,690,c),
+(226,690,l),
+(181,621,o),
+(134,534,o),
+(103,452,c),
+(107,443,l)
+);
+}
+);
+width = 384;
+}
+);
+unicode = 8220;
+},
+{
+glyphname = quotedblright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(298,443,l),
+(346,513,o),
+(392,603,o),
+(421,680,c),
+(417,690,l),
+(366,690,l),
+(344,617,o),
+(305,526,o),
+(256,443,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(141,443,l),
+(188,513,o),
+(235,603,o),
+(265,680,c),
+(260,690,l),
+(209,690,l),
+(187,620,o),
+(146,523,o),
+(99,443,c)
+);
+}
+);
+width = 384;
+}
+);
+unicode = 8221;
+},
+{
+glyphname = quoteleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(161,443,l),
+(184,514,o),
+(224,609,o),
+(271,690,c),
+(227,690,l),
+(181,621,o),
+(134,534,o),
+(103,452,c),
+(107,443,l)
+);
+}
+);
+width = 230;
+}
+);
+unicode = 8216;
+},
+{
+glyphname = quoteright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(145,443,l),
+(191,513,o),
+(238,603,o),
+(268,680,c),
+(264,690,l),
+(210,690,l),
+(188,620,o),
+(147,523,o),
+(99,443,c)
+);
+}
+);
+width = 230;
+}
+);
+unicode = 8217;
+},
+{
+glyphname = dottedCircle;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(203,504,o),
+(190,494,o),
+(190,479,cs),
+(190,467,o),
+(203,454,o),
+(215,454,cs),
+(230,454,o),
+(241,467,o),
+(241,479,cs),
+(241,494,o),
+(230,504,o),
+(215,504,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(365,504,o),
+(353,494,o),
+(353,479,cs),
+(353,467,o),
+(365,454,o),
+(378,454,cs),
+(392,454,o),
+(403,467,o),
+(403,479,cs),
+(403,494,o),
+(392,504,o),
+(378,504,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(203,108,o),
+(190,98,o),
+(190,83,cs),
+(190,71,o),
+(203,58,o),
+(215,58,cs),
+(230,58,o),
+(241,71,o),
+(241,83,cs),
+(241,98,o),
+(230,108,o),
+(215,108,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(365,108,o),
+(353,98,o),
+(353,83,cs),
+(353,71,o),
+(365,58,o),
+(378,58,cs),
+(392,58,o),
+(403,71,o),
+(403,83,cs),
+(403,98,o),
+(392,108,o),
+(378,108,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(284,522,o),
+(271,511,o),
+(271,497,cs),
+(271,484,o),
+(284,471,o),
+(297,471,cs),
+(311,471,o),
+(322,484,o),
+(322,497,cs),
+(322,511,o),
+(311,522,o),
+(297,522,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(284,91,o),
+(271,80,o),
+(271,66,cs),
+(271,53,o),
+(284,41,o),
+(297,41,cs),
+(311,41,o),
+(322,53,o),
+(322,66,cs),
+(322,80,o),
+(311,91,o),
+(297,91,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(56,269,o),
+(69,256,o),
+(81,256,cs),
+(96,256,o),
+(106,269,o),
+(106,281,cs),
+(106,296,o),
+(96,306,o),
+(81,306,cs),
+(69,306,o),
+(56,296,o),
+(56,281,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(487,269,o),
+(499,256,o),
+(512,256,cs),
+(526,256,o),
+(537,269,o),
+(537,281,cs),
+(537,296,o),
+(526,306,o),
+(512,306,cs),
+(499,306,o),
+(487,296,o),
+(487,281,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(119,116,o),
+(131,103,o),
+(144,103,cs),
+(158,103,o),
+(169,116,o),
+(169,128,cs),
+(169,143,o),
+(158,154,o),
+(144,154,cs),
+(131,154,o),
+(119,143,o),
+(119,128,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(119,421,o),
+(131,409,o),
+(144,409,cs),
+(158,409,o),
+(169,421,o),
+(169,434,cs),
+(169,448,o),
+(158,459,o),
+(144,459,cs),
+(131,459,o),
+(119,448,o),
+(119,434,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(424,116,o),
+(437,103,o),
+(449,103,cs),
+(464,103,o),
+(474,116,o),
+(474,128,cs),
+(474,143,o),
+(464,154,o),
+(449,154,cs),
+(437,154,o),
+(424,143,o),
+(424,128,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(424,421,o),
+(437,409,o),
+(449,409,cs),
+(464,409,o),
+(474,421,o),
+(474,434,cs),
+(474,448,o),
+(464,459,o),
+(449,459,cs),
+(437,459,o),
+(424,448,o),
+(424,434,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(73,187,o),
+(86,175,o),
+(99,175,cs),
+(113,175,o),
+(124,187,o),
+(124,200,cs),
+(124,214,o),
+(113,225,o),
+(99,225,cs),
+(86,225,o),
+(73,214,o),
+(73,200,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(73,350,o),
+(86,337,o),
+(99,337,cs),
+(113,337,o),
+(124,350,o),
+(124,362,cs),
+(124,377,o),
+(113,387,o),
+(99,387,cs),
+(86,387,o),
+(73,377,o),
+(73,362,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(469,187,o),
+(482,175,o),
+(495,175,cs),
+(509,175,o),
+(520,187,o),
+(520,200,cs),
+(520,214,o),
+(509,225,o),
+(495,225,cs),
+(482,225,o),
+(469,214,o),
+(469,200,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(469,350,o),
+(482,337,o),
+(495,337,cs),
+(509,337,o),
+(520,350,o),
+(520,362,cs),
+(520,377,o),
+(509,387,o),
+(495,387,cs),
+(482,387,o),
+(469,377,o),
+(469,362,cs)
+);
+}
+);
+width = 583;
+}
+);
+note = uni25CC;
+unicode = 9676;
+},
+{
+glyphname = dotaccentcomb;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(135,709,o),
+(119,689,o),
+(117,659,cs),
+(114,639,o),
+(126,625,o),
+(148,625,cs),
+(174,625,o),
+(189,644,o),
+(191,671,cs),
+(194,696,o),
+(183,709,o),
+(160,709,cs)
+);
+}
+);
+width = 126;
+}
+);
+note = uni0307;
+unicode = 775;
+},
+{
+glyphname = dotaccent;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(173,625,o),
+(186,636,o),
+(192,661,cs),
+(199,692,o),
+(186,709,o),
+(159,709,cs),
+(138,709,o),
+(125,697,o),
+(119,672,cs),
+(112,641,o),
+(124,625,o),
+(151,625,cs)
+);
+}
+);
+width = 128;
+}
+);
+note = dotaccent;
+unicode = 729;
+},
+{
+glyphname = caron;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(263,622,o),
+(302,676,o),
+(348,730,c),
+(351,738,l),
+(306,738,l),
+(277,708,o),
+(251,673,o),
+(215,629,c),
+(202,669,o),
+(188,706,o),
+(173,738,c),
+(133,738,l),
+(131,730,l),
+(152,684,o),
+(170,636,o),
+(180,585,c),
+(240,585,l),
+(240,585,l)
+);
+}
+);
+width = 270;
+}
+);
+note = caron;
+unicode = 711;
+},
+{
+glyphname = breve;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(271,585,o),
+(311,626,o),
+(328,709,c),
+(290,709,l),
+(275,656,o),
+(250,628,o),
+(214,628,cs),
+(176,628,o),
+(156,659,o),
+(163,709,c),
+(127,709,l),
+(113,633,o),
+(147,585,o),
+(212,585,cs)
+);
+}
+);
+width = 255;
+}
+);
+note = breve;
+unicode = 728;
+},
+{
+glyphname = ring;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(239,588,o),
+(272,631,o),
+(272,691,cs),
+(272,748,o),
+(239,792,o),
+(197,792,cs),
+(156,792,o),
+(123,750,o),
+(123,691,cs),
+(123,629,o),
+(156,588,o),
+(197,588,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(172,625,o),
+(156,655,o),
+(156,691,cs),
+(156,727,o),
+(174,756,o),
+(197,756,cs),
+(220,756,o),
+(239,726,o),
+(239,691,cs),
+(239,655,o),
+(221,625,o),
+(197,625,cs)
+);
+}
+);
+width = 202;
+}
+);
+note = ring;
+unicode = 730;
+},
+{
+glyphname = ogonek;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(15,-214,o),
+(32,-212,o),
+(43,-206,c),
+(52,-164,l),
+(43,-168,o),
+(28,-172,o),
+(17,-172,cs),
+(-6,-172,o),
+(-14,-153,o),
+(-7,-117,cs),
+(2,-80,o),
+(30,-41,o),
+(72,0,c),
+(49,14,l),
+(-9,-36,o),
+(-41,-81,o),
+(-51,-128,cs),
+(-62,-181,o),
+(-42,-214,o),
+(1,-214,cs)
+);
+}
+);
+width = 164;
+}
+);
+note = ogonek;
+unicode = 731;
+},
+{
+glyphname = ring_top.canadian;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (212,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(290,757,o),
+(327,793,o),
+(327,840,cs),
+(327,889,o),
+(290,923,o),
+(243,923,cs),
+(196,923,o),
+(159,889,o),
+(159,840,cs),
+(159,793,o),
+(196,757,o),
+(243,757,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(213,788,o),
+(192,810,o),
+(192,840,cs),
+(192,870,o),
+(213,893,o),
+(243,893,cs),
+(273,893,o),
+(295,870,o),
+(295,840,cs),
+(295,810,o),
+(273,788,o),
+(243,788,cs)
+);
+}
+);
+width = 229;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (81,345);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(104,305,o),
+(122,323,o),
+(122,345,cs),
+(122,367,o),
+(104,384,o),
+(82,384,cs),
+(59,384,o),
+(42,367,o),
+(42,345,cs),
+(42,323,o),
+(59,305,o),
+(81,305,cs)
+);
+}
+);
+width = 117;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (76,345);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,309,o),
+(112,325,o),
+(112,345,cs),
+(112,365,o),
+(97,381,o),
+(76,381,cs),
+(56,381,o),
+(41,365,o),
+(41,345,cs),
+(41,325,o),
+(56,309,o),
+(76,309,cs)
+);
+}
+);
+width = 107;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_small;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (71,345);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(89,314,o),
+(102,327,o),
+(102,345,cs),
+(102,362,o),
+(89,376,o),
+(71,376,cs),
+(54,376,o),
+(41,362,o),
+(41,345,cs),
+(41,327,o),
+(54,314,o),
+(71,314,cs)
+);
+}
+);
+width = 99;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_top;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (156,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(208,789,o),
+(225,808,o),
+(225,830,cs),
+(225,853,o),
+(208,870,o),
+(185,870,cs),
+(162,870,o),
+(144,853,o),
+(144,830,cs),
+(144,808,o),
+(162,789,o),
+(185,789,cs)
+);
+}
+);
+width = 117;
+}
+);
+note = g725;
+},
+{
+glyphname = doubledot_middle;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(156,389,o),
+(175,407,o),
+(175,429,cs),
+(175,452,o),
+(156,469,o),
+(134,469,cs),
+(111,469,o),
+(94,452,o),
+(94,429,cs),
+(94,407,o),
+(111,389,o),
+(134,389,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(121,220,o),
+(139,238,o),
+(139,261,cs),
+(139,283,o),
+(121,300,o),
+(99,300,cs),
+(75,300,o),
+(58,283,o),
+(58,261,cs),
+(58,238,o),
+(75,220,o),
+(99,220,cs)
+);
+}
+);
+width = 187;
+}
+);
+metricRight = "=|";
+note = g725;
+},
+{
+glyphname = doubledot_top;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top_double;
+pos = (286,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(337,789,o),
+(355,808,o),
+(355,830,cs),
+(355,853,o),
+(337,870,o),
+(314,870,cs),
+(292,870,o),
+(273,852,o),
+(273,830,cs),
+(273,808,o),
+(292,789,o),
+(314,789,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(208,789,o),
+(226,808,o),
+(226,830,cs),
+(226,853,o),
+(208,870,o),
+(185,870,cs),
+(162,870,o),
+(145,853,o),
+(145,830,cs),
+(145,808,o),
+(162,789,o),
+(185,789,cs)
+);
+}
+);
+width = 247;
+}
+);
+note = g725;
+},
+{
+glyphname = g727;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (354,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(403,0,l),
+(414,52,l),
+(203,52,ls),
+(135,52,o),
+(101,84,o),
+(101,148,cs),
+(101,205,o),
+(116,319,o),
+(251,319,cs),
+(313,319,ls),
+(482,319,o),
+(526,450,o),
+(526,545,cs),
+(526,636,o),
+(472,690,o),
+(384,690,cs),
+(156,690,l),
+(145,638,l),
+(363,638,ls),
+(430,638,o),
+(465,605,o),
+(465,541,cs),
+(465,481,o),
+(447,372,o),
+(314,372,cs),
+(253,372,ls),
+(82,372,o),
+(41,238,o),
+(41,144,cs),
+(41,54,o),
+(93,0,o),
+(183,0,cs)
+);
+}
+);
+width = 520;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+glyphname = g728;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (198,0);
+ref = dot_top;
+}
+);
+width = 521;
+}
+);
+note = g728;
+},
+{
+glyphname = g729;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (355,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(238,0,ls),
+(415,0,o),
+(459,130,o),
+(459,234,cs),
+(459,322,o),
+(406,372,o),
+(319,372,cs),
+(270,372,ls),
+(204,372,o),
+(169,399,o),
+(169,459,cs),
+(169,528,o),
+(187,638,o),
+(327,638,cs),
+(541,638,l),
+(553,690,l),
+(327,690,ls),
+(150,690,o),
+(107,558,o),
+(107,456,cs),
+(107,368,o),
+(159,319,o),
+(246,319,cs),
+(296,319,ls),
+(361,319,o),
+(397,291,o),
+(397,230,cs),
+(397,162,o),
+(374,52,o),
+(238,52,cs),
+(24,52,l),
+(13,0,l)
+);
+}
+);
+width = 520;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+glyphname = g730;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (199,0);
+ref = dot_top;
+}
+);
+width = 520;
+}
+);
+note = g730;
+},
+{
+glyphname = g731;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = g727;
+}
+);
+width = 690;
+}
+);
+note = g731;
+},
+{
+glyphname = g732;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (521,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 690;
+}
+);
+note = g732;
+},
+{
+glyphname = g733;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (368,0);
+ref = dot_top;
+}
+);
+width = 690;
+}
+);
+note = g733;
+},
+{
+glyphname = g734;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (198,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (521,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 690;
+}
+);
+note = g734;
+},
+{
+glyphname = g735;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = g729;
+}
+);
+width = 689;
+}
+);
+note = g735;
+},
+{
+glyphname = g736;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (520,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 689;
+}
+);
+note = g736;
+},
+{
+glyphname = g737;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (369,0);
+ref = dot_top;
+}
+);
+width = 689;
+}
+);
+note = g737;
+},
+{
+glyphname = g738;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (199,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (520,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 689;
+}
+);
+note = g738;
+},
+{
+glyphname = g739;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(431,214,o),
+(462,318,o),
+(462,382,cs),
+(462,442,o),
+(432,476,o),
+(380,476,cs),
+(242,476,l),
+(245,462,l),
+(286,492,o),
+(299,562,o),
+(299,600,cs),
+(299,659,o),
+(270,696,o),
+(220,696,cs),
+(138,696,o),
+(107,591,o),
+(107,527,cs),
+(107,468,o),
+(137,434,o),
+(189,434,cs),
+(327,434,l),
+(324,448,l),
+(282,417,o),
+(270,348,o),
+(270,311,cs),
+(270,251,o),
+(299,214,o),
+(349,214,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(159,469,o),
+(146,489,o),
+(146,526,cs),
+(146,565,o),
+(161,660,o),
+(217,660,cs),
+(245,660,o),
+(260,639,o),
+(260,600,cs),
+(260,565,o),
+(243,469,o),
+(186,469,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(324,249,o),
+(309,270,o),
+(309,310,cs),
+(309,345,o),
+(324,440,o),
+(383,440,cs),
+(410,440,o),
+(423,421,o),
+(423,384,cs),
+(423,345,o),
+(408,249,o),
+(352,249,cs)
+);
+}
+);
+width = 476;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+glyphname = g740;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (143,0);
+ref = ring_top.canadian;
+}
+);
+width = 521;
+}
+);
+note = g740;
+},
+{
+glyphname = g741;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (144,0);
+ref = ring_top.canadian;
+}
+);
+width = 520;
+}
+);
+note = g741;
+},
+{
+glyphname = g742;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (312,0);
+ref = ring_top.canadian;
+}
+);
+width = 690;
+}
+);
+note = g742;
+},
+{
+glyphname = stroke_middle;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (61,345);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(58,236,l),
+(104,454,l),
+(64,454,l),
+(18,236,l)
+);
+}
+);
+width = 75;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (57,345);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(54,249,l),
+(95,440,l),
+(61,440,l),
+(21,249,l)
+);
+}
+);
+width = 69;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_small;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (55,345);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(50,252,l),
+(89,438,l),
+(61,438,l),
+(21,252,l)
+);
+}
+);
+width = 64;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_threequart;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (61,345);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(57,237,l),
+(102,453,l),
+(66,453,l),
+(20,237,l)
+);
+}
+);
+width = 75;
+}
+);
+note = g723;
+},
+{
+color = 8;
+glyphname = uni11AB0;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (223,690);
+},
+{
+name = top_right_can;
+pos = (447,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(107,0,l),
+(131,117,l),
+(315,117,l),
+(324,157,l),
+(141,157,l),
+(166,279,l),
+(121,259,l),
+(152,259,ls),
+(309,259,o),
+(403,339,o),
+(443,528,cs),
+(477,690,l),
+(416,690,l),
+(383,531,ls),
+(351,383,o),
+(279,315,o),
+(156,315,cs),
+(113,315,l),
+(79,157,l),
+(18,157,l),
+(11,117,l),
+(71,117,l),
+(45,0,l)
+);
+}
+);
+width = 441;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB1;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB0;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (291,0);
+ref = dot_top;
+}
+);
+width = 440;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB2;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (187,690);
+},
+{
+name = top_right_can;
+pos = (411,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(71,0,l),
+(105,158,ls),
+(137,307,o),
+(209,375,o),
+(331,375,cs),
+(375,375,l),
+(409,532,l),
+(469,532,l),
+(477,573,l),
+(417,573,l),
+(442,690,l),
+(381,690,l),
+(356,573,l),
+(173,573,l),
+(164,532,l),
+(347,532,l),
+(322,411,l),
+(367,431,l),
+(336,431,ls),
+(179,431,o),
+(84,351,o),
+(44,161,cs),
+(10,0,l)
+);
+}
+);
+width = 441;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "theThCree-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB3;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB2;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (257,0);
+ref = dot_top;
+}
+);
+width = 441;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB4;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (224,690);
+},
+{
+name = top_right_can;
+pos = (448,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(331,0,l),
+(363,149,ls),
+(405,341,o),
+(326,431,o),
+(162,431,cs),
+(150,431,l),
+(194,408,l),
+(221,532,l),
+(404,532,l),
+(412,573,l),
+(230,573,l),
+(255,690,l),
+(193,690,l),
+(168,573,l),
+(107,573,l),
+(99,532,l),
+(159,532,l),
+(127,375,l),
+(151,375,ls),
+(283,375,o),
+(338,315,o),
+(302,151,cs),
+(271,0,l)
+);
+}
+);
+width = 442;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB5;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB4;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (67,0);
+ref = dot_top;
+}
+);
+width = 440;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB6;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (191,690);
+},
+{
+name = top_right_can;
+pos = (415,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(74,1,l),
+(134,283,l),
+(84,260,l),
+(113,260,ls),
+(278,260,o),
+(370,342,o),
+(412,534,cs),
+(440,664,l),
+(393,654,l),
+(527,465,l),
+(575,499,l),
+(439,691,l),
+(384,691,l),
+(351,538,ls),
+(317,383,o),
+(243,316,o),
+(115,316,cs),
+(80,316,l),
+(13,1,l)
+);
+}
+);
+width = 541;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB7;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB6;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (260,0);
+ref = dot_top;
+}
+);
+width = 541;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB8;
+kernRight = soright;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (320,690);
+},
+{
+name = top_right_can;
+pos = (543,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(204,0,l),
+(237,153,ls),
+(269,308,o),
+(343,375,o),
+(471,375,cs),
+(507,375,l),
+(574,690,l),
+(513,690,l),
+(452,408,l),
+(502,431,l),
+(474,431,ls),
+(308,431,o),
+(216,349,o),
+(176,156,cs),
+(148,27,l),
+(193,37,l),
+(59,226,l),
+(12,191,l),
+(148,0,l)
+);
+}
+);
+width = 540;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB9;
+kernRight = soright;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB8;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (388,0);
+ref = dot_top;
+}
+);
+width = 541;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABA;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (190,690);
+},
+{
+name = top_right_can;
+pos = (415,690);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(294,0,l),
+(510,191,l),
+(474,233,l),
+(279,59,l),
+(309,52,l),
+(322,108,ls),
+(361,294,o),
+(296,430,o),
+(145,430,cs),
+(125,430,l),
+(159,396,l),
+(222,690,l),
+(160,690,l),
+(94,375,l),
+(120,375,ls),
+(250,375,o),
+(298,276,o),
+(259,96,cs),
+(239,0,l)
+);
+}
+);
+width = 542;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABB;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = uni11ABA;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (35,0);
+ref = dot_top;
+}
+);
+width = 541;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABC;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(343,0,l),
+(355,57,l),
+(64,57,l),
+(62,29,l),
+(487,645,l),
+(496,690,l),
+(144,690,l),
+(131,633,l),
+(423,633,l),
+(425,661,l),
+(0,44,l),
+(-10,0,l)
+);
+}
+);
+width = 440;
+}
+);
+metricRight = "=|";
+},
+{
+color = 8;
+glyphname = uni11ABD;
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(350,0,l),
+(359,44,l),
+(187,661,l),
+(186,633,l),
+(478,633,l),
+(491,690,l),
+(137,690,l),
+(128,645,l),
+(300,29,l),
+(300,57,l),
+(10,57,l),
+(-3,0,l)
+);
+}
+);
+width = 440;
+}
+);
+metricLeft = "=|uni11ABC";
+metricRight = "=|uni11ABC";
+},
+{
+color = 8;
+glyphname = uni11ABE;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(72,0,l),
+(207,629,l),
+(172,629,l),
+(339,0,l),
+(394,0,l),
+(541,690,l),
+(480,690,l),
+(346,61,l),
+(382,61,l),
+(213,690,l),
+(159,690,l),
+(13,0,l)
+);
+}
+);
+width = 506;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABF;
+lastChange = "2023-01-13 15:56:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(67,0,l),
+(511,633,l),
+(469,633,l),
+(333,0,l),
+(394,0,l),
+(541,690,l),
+(486,690,l),
+(42,57,l),
+(85,57,l),
+(219,690,l),
+(159,690,l),
+(13,0,l)
+);
+}
+);
+width = 506;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = "raiseddoubledotFinal-canadian.cree";
+lastChange = "2023-01-13 15:56:15 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(202,621,o),
+(219,639,o),
+(219,662,cs),
+(219,684,o),
+(202,702,o),
+(179,702,cs),
+(156,702,o),
+(138,684,o),
+(138,662,cs),
+(138,639,o),
+(156,621,o),
+(179,621,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(166,452,o),
+(185,469,o),
+(185,493,cs),
+(185,515,o),
+(166,533,o),
+(144,533,cs),
+(121,533,o),
+(103,516,o),
+(103,493,cs),
+(103,469,o),
+(121,452,o),
+(144,452,cs)
+);
+}
+);
+width = 178;
+}
+);
+note = g725;
+}
+);
+instances = (
+{
+axesValues = (
+67,
+68,
+12
+);
+instanceInterpolations = {
+"A0BEBE03-9AB7-4E04-894D-4F686A7231C4" = 1;
+};
+name = "RC CL Italic";
+}
+);
+kerningLTR = {
+"A0BEBE03-9AB7-4E04-894D-4F686A7231C4" = {
+"@MMK_L_caright" = {
+"@MMK_R_ecanleft" = -63.756;
+"@MMK_R_mwestleft" = -24.15;
+"@MMK_R_neleft" = -49.266;
+};
+"@MMK_L_ciright" = {
+"@MMK_R_icanleft" = -63.756;
+"@MMK_R_noleft" = -85.008;
+};
+"@MMK_L_ecanright" = {
+"@MMK_R_coleft" = -63.756;
+"@MMK_R_moleft" = -63.756;
+"@MMK_R_sileft" = -34.776;
+};
+"@MMK_L_icanright" = {
+"@MMK_R_celeft" = -63.756;
+"@MMK_R_meleft" = -63.756;
+"@MMK_R_mwestleft" = -37.674;
+"@MMK_R_saleft" = -29.946;
+"she-canadian" = -63.756;
+};
+"@MMK_L_maright" = {
+"@MMK_R_acanleft" = -60.858;
+"@MMK_R_ecanleft" = -63.756;
+"@MMK_R_mwestleft" = -45.402;
+"@MMK_R_neleft" = -49.266;
+};
+"@MMK_L_miright" = {
+"@MMK_R_acanleft" = -60.858;
+"@MMK_R_icanleft" = -63.756;
+"@MMK_R_moleft" = -85.008;
+"@MMK_R_noleft" = -85.008;
+"@MMK_R_yeleft" = -85.008;
+};
+"@MMK_L_mwestright" = {
+"@MMK_R_coleft" = -24.15;
+"@MMK_R_icanleft" = -37.674;
+"@MMK_R_moleft" = -45.402;
+"@MMK_R_noleft" = -72.45;
+"@MMK_R_sileft" = -12.558;
+"@MMK_R_yeleft" = -19.32;
+};
+"@MMK_L_naright" = {
+"@MMK_R_acanleft" = -80.178;
+"@MMK_R_celeft" = -85.008;
+"@MMK_R_meleft" = -85.008;
+"@MMK_R_mwestleft" = -72.45;
+"@MMK_R_neleft" = -99.498;
+"@MMK_R_saleft" = -56.028;
+};
+"@MMK_L_niright" = {
+"@MMK_R_coleft" = -49.266;
+"@MMK_R_moleft" = -49.266;
+"@MMK_R_noleft" = -99.498;
+"@MMK_R_sileft" = -3.864;
+};
+"@MMK_L_ocanright" = {
+"@MMK_R_meleft" = -60.858;
+"@MMK_R_moleft" = -60.858;
+"@MMK_R_noleft" = -80.178;
+};
+"@MMK_L_seright" = {
+"@MMK_R_ecanleft" = -34.776;
+"@MMK_R_mwestleft" = -12.558;
+"@MMK_R_neleft" = -3.864;
+};
+"@MMK_L_soright" = {
+"@MMK_R_icanleft" = -29.946;
+"@MMK_R_noleft" = -56.028;
+};
+"@MMK_L_yiright" = {
+"@MMK_R_meleft" = -85.008;
+"@MMK_R_mwestleft" = -19.32;
+};
+"shi-canadian" = {
+"@MMK_R_icanleft" = -63.756;
+};
+};
+};
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "italic angle";
+}
+);
+properties = (
+{
+key = copyrights;
+values = (
+{
+language = ENG;
+value = "Copyright 2018 Google Inc. All Rights Reserved.";
+}
+);
+},
+{
+key = manufacturers;
+values = (
+{
+language = ENG;
+value = "Monotype Imaging Inc.";
+}
+);
+},
+{
+key = designers;
+values = (
+{
+language = ENG;
+value = "Monotype Design Team";
+}
+);
+},
+{
+key = description;
+value = "Designed by Monotype design team.";
+},
+{
+key = trademarks;
+values = (
+{
+language = ENG;
+value = "Noto is a trademark of Google Inc.";
+}
+);
+},
+{
+key = licenseURL;
+value = "http://scripts.sil.org/OFL";
+},
+{
+key = licenses;
+values = (
+{
+language = ENG;
+value = "This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.";
+}
+);
+},
+{
+key = manufacturerURL;
+value = "http://www.google.com/get/noto/";
+},
+{
+key = designerURL;
+value = "http://www.monotype.com/studio";
+}
+);
+settings = {
+disablesNiceNames = 1;
+};
+stems = (
+{
+name = "New Stem";
+}
+);
+unitsPerEm = 966;
+userData = {
+GSDontShowVersionAlert = 1;
+};
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/sources/Exported instances UCAS SansCanadianAboriginal Resized/Sans Canadian Aboriginal-RC CL roman.glyphs
+++ b/sources/Exported instances UCAS SansCanadianAboriginal Resized/Sans Canadian Aboriginal-RC CL roman.glyphs
@@ -1,0 +1,37333 @@
+{
+.appVersion = "3151";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+},
+{
+name = Width;
+tag = wdth;
+},
+{
+name = Slant;
+tag = slnt;
+}
+);
+classes = (
+{
+code = "zero one two three four five six seven eight nine ";
+name = Num;
+},
+{
+code = "zero.canadian one.canadian two.canadian three.canadian four.canadian five.canadian six.canadian seven.canadian eight.canadian nine.canadian 
+";
+name = Num_can;
+},
+{
+code = "ke-canadian.square ki-canadian.square kii-canadian.square ko-canadian.square koo-canadian.square ka-canadian.square kaa-canadian.square kweWestCree-canadian.square kwiiWestCree-canadian.square kwoWestCree-canadian.square kwooWestCree-canadian.square kwaWestCree-canadian.square kwaaWestCree-canadian.square ce-canadian.square ci-canadian.square cii-canadian.square co-canadian.square coo-canadian.square ca-canadian.square caa-canadian.square me-canadian.square mi-canadian.square mii-canadian.square mo-canadian.square moo-canadian.square ma-canadian.square maa-canadian.square ne-canadian.square ni-canadian.square nii-canadian.square no-canadian.square noo-canadian.square na-canadian.square naa-canadian.square nweWestCree-canadian.square nwaWestCree-canadian.square nwaaWestCree-canadian.square se-canadian.square si-canadian.square sii-canadian.square so-canadian.square soo-canadian.square sa-canadian.square saa-canadian.square sho-canadian.square shoo-canadian.square sha-canadian.square shaa-canadian.square ye-canadian.square yi-canadian.square yii-canadian.square yo-canadian.square yoo-canadian.square ya-canadian.square yaa-canadian.square re-canadian.square reRCree-canadian.square leWestCree-canadian.square ri-canadian.square rii-canadian.square ro-canadian.square loWestCree-canadian.square ra-canadian.square raa-canadian.square laWestCree-canadian.square reWestCree-canadian.square riWestCree-canadian.square roWestCree-canadian.square raWestCree-canadian.square theThCree-canadian.square thiThCree-canadian.square thiiThCree-canadian.square thoThCree-canadian.square thooThCree-canadian.square thaThCree-canadian.square thaaThCree-canadian.square thweeWoodScree-canadian.square thwiWoodScree-canadian.square thwiiWoodScree-canadian.square thwoWoodScree-canadian.square thwooWoodScree-canadian.square thwaWoodScree-canadian.square thwaaWoodScree-canadian.square nwiOjibway-canadian.square nwiiOjibway-canadian.square nwoOjibway-canadian.square nwooOjibway-canadian.square looWestCree-canadian.square laaWestCree-canadian.square ";
+name = Dene_square;
+},
+{
+code = "ke-canadian ki-canadian kii-canadian ko-canadian koo-canadian ka-canadian kaa-canadian kweWestCree-canadian kwiiWestCree-canadian kwoWestCree-canadian kwooWestCree-canadian kwaWestCree-canadian kwaaWestCree-canadian ce-canadian ci-canadian cii-canadian co-canadian coo-canadian ca-canadian caa-canadian me-canadian mi-canadian mii-canadian mo-canadian moo-canadian ma-canadian maa-canadian ne-canadian ni-canadian nii-canadian no-canadian noo-canadian na-canadian naa-canadian nweWestCree-canadian nwaWestCree-canadian nwaaWestCree-canadian se-canadian si-canadian sii-canadian so-canadian soo-canadian sa-canadian saa-canadian sho-canadian shoo-canadian sha-canadian shaa-canadian ye-canadian yi-canadian yii-canadian yo-canadian yoo-canadian ya-canadian yaa-canadian re-canadian reRCree-canadian leWestCree-canadian ri-canadian rii-canadian ro-canadian loWestCree-canadian ra-canadian raa-canadian laWestCree-canadian reWestCree-canadian riWestCree-canadian roWestCree-canadian raWestCree-canadian theThCree-canadian thiThCree-canadian thiiThCree-canadian thoThCree-canadian thooThCree-canadian thaThCree-canadian thaaThCree-canadian thweeWoodScree-canadian thwiWoodScree-canadian thwiiWoodScree-canadian thwoWoodScree-canadian thwooWoodScree-canadian thwaWoodScree-canadian thwaaWoodScree-canadian nwiOjibway-canadian nwiiOjibway-canadian nwoOjibway-canadian nwooOjibway-canadian looWestCree-canadian laaWestCree-canadian 
+";
+name = Dene_round;
+},
+{
+code = "acuteFinal-canadian.mid graveFinal-canadian.mid ringTophalfFinal-canadian.mid ringRighthalfFinal-canadian.mid ringFinal-canadian.mid doubleacuteFinal-canadian.mid doubleshortverticalstrokesFinal-canadian.mid shorthorizontalstrokeFinal-canadian.mid downtackFinal-canadian.mid pWestCree-canadian.mid c-canadian.mid mWestCree-canadian.mid ";
+name = Final_mid;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian ringFinal-canadian doubleacuteFinal-canadian doubleshortverticalstrokesFinal-canadian shorthorizontalstrokeFinal-canadian downtackFinal-canadian pWestCree-canadian c-canadian mWestCree-canadian ";
+name = Final_mid_ori;
+},
+{
+code = "acuteFinal-canadian.base graveFinal-canadian.base ringBottomhalfFinal-canadian.base ringTophalfFinal-canadian.base ringRighthalfFinal-canadian.base plusFinal-canadian.base pWestCree-canadian.base c-canadian.base thSayisi-canadian.base mWestCree-canadian.base ";
+name = Final_base;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringBottomhalfFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian plusFinal-canadian pWestCree-canadian c-canadian thSayisi-canadian mWestCree-canadian ";
+name = Final_base_ori;
+},
+{
+code = "ng-canadian ngai-canadian ngaai-canadian ngi-canadian ngii-canadian ngo-canadian ngoo-canadian nga-canadian ngaa-canadian ";
+name = Nunavik;
+},
+{
+code = "ng-canadian.nunavik ngai-canadian.nunavik ngaai-canadian.nunavik ngi-canadian.nunavik ngii-canadian.nunavik ngo-canadian.nunavik ngoo-canadian.nunavik nga-canadian.nunavik ngaa-canadian.nunavik ";
+name = Nunavik_alt;
+}
+);
+customParameters = (
+{
+name = vendorID;
+value = GOOG;
+},
+{
+name = panose;
+value = (
+2,
+11,
+5,
+2,
+4,
+5,
+4,
+2,
+2,
+4
+);
+},
+{
+name = unicodeRanges;
+value = (
+0,
+1,
+2,
+5,
+6,
+45,
+77
+);
+},
+{
+name = codePageRanges;
+value = (
+"1252"
+);
+},
+{
+name = fsType;
+value = (
+);
+}
+);
+date = "2022-06-21 10:06:40 +0000";
+familyName = "Sans Canadian Aboriginal";
+featurePrefixes = (
+{
+automatic = 1;
+code = "languagesystem DFLT dflt;
+
+languagesystem cans dflt;
+";
+name = Languagesystems;
+}
+);
+features = (
+{
+automatic = 1;
+code = "feature ss01;
+feature ss02;
+feature ss03;
+feature ss04;
+";
+tag = aalt;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+tag = salt;
+},
+{
+code = "lookup space_can {
+sub space by space.canadian;
+} space_can;
+
+lookup num_can {
+sub @Num by @Num_can;
+} num_can;
+";
+labels = (
+{
+language = dflt;
+value = "CAN Space and numerals";
+}
+);
+tag = ss01;
+},
+{
+code = "lookup dene_square {
+sub @Dene_round by @Dene_square;
+} dene_square;
+
+";
+labels = (
+{
+language = dflt;
+value = "Dene Square";
+}
+);
+tag = ss02;
+},
+{
+code = "lookup nunavik_alt {
+sub @Nunavik by @Nunavik_alt;
+} nunavik_alt;
+
+";
+labels = (
+{
+language = dflt;
+value = "Nunanvik Alt";
+}
+);
+tag = ss03;
+},
+{
+code = "lookup final_mid {
+sub @Final_mid_ori by @Final_mid;
+} final_mid;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final mid";
+}
+);
+tag = ss04;
+},
+{
+code = "lookup final_base {
+sub @Final_base_ori by @Final_base;
+} final_base;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final base";
+}
+);
+tag = ss05;
+},
+{
+code = "lookup plaincree_first {
+sub wiWestCree-canadian' plusFinal-canadian by i-canadian;
+} plaincree_first;
+
+lookup plaincree_second {
+sub i-canadian plusFinal-canadian' by raiseddoubledotFinal-canadian.cree;
+} plaincree_second;
+
+lookup plaincree_third {
+sub middledotFinal-canadian plusFinal-canadian by raiseddoubledotFinal-canadian.cree;
+} plaincree_third;
+";
+labels = (
+{
+language = dflt;
+value = Plaincree;
+}
+);
+tag = ss06;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+labels = (
+{
+language = dflt;
+value = "";
+}
+);
+tag = ss07;
+}
+);
+fontMaster = (
+{
+axesValues = (
+0,
+0,
+0
+);
+customParameters = (
+{
+name = typoAscender;
+value = 1033;
+},
+{
+name = typoDescender;
+value = -283;
+},
+{
+name = typoLineGap;
+value = 0;
+},
+{
+name = winAscent;
+value = 1033;
+},
+{
+name = winDescent;
+value = 283;
+},
+{
+name = hheaAscender;
+value = 1033;
+},
+{
+name = hheaDescender;
+value = -283;
+},
+{
+name = strikeoutPosition;
+value = 284;
+},
+{
+name = strikeoutSize;
+value = 48;
+}
+);
+guides = (
+{
+lockAngle = 1;
+locked = 1;
+pos = (222,345);
+}
+);
+id = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+metricValues = (
+{
+over = 16;
+pos = 1033;
+},
+{
+over = 16;
+pos = 690;
+},
+{
+over = 16;
+pos = 472;
+},
+{
+over = -16;
+},
+{
+over = -16;
+pos = -283;
+},
+{
+}
+);
+name = "RC CL roman";
+stemValues = (
+61
+);
+}
+);
+glyphs = (
+{
+glyphname = idotless;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(116,516,l),
+(55,516,l),
+(55,0,l),
+(116,0,l)
+);
+}
+);
+width = 171;
+}
+);
+note = dotlessi;
+unicode = 305;
+},
+{
+glyphname = "acuteFinal-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(77,345,l),
+(197,690,l),
+(149,690,l),
+(29,345,l)
+);
+}
+);
+width = 226;
+}
+);
+metricRight = "=|";
+note = uni141F;
+unicode = 5151;
+},
+{
+glyphname = "graveFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(197,345,l),
+(77,690,l),
+(29,690,l),
+(149,345,l)
+);
+}
+);
+width = 226;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+unicode = 5152;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(228,339,o),
+(268,384,o),
+(268,473,cs),
+(268,690,l),
+(224,690,l),
+(224,470,ls),
+(224,407,o),
+(204,380,o),
+(159,380,cs),
+(115,380,o),
+(94,408,o),
+(94,469,cs),
+(94,690,l),
+(50,690,l),
+(50,470,ls),
+(50,385,o),
+(91,339,o),
+(159,339,cs)
+);
+}
+);
+width = 318;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1421;
+unicode = 5153;
+},
+{
+glyphname = "ringTophalfFinal-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(94,345,l),
+(94,565,ls),
+(94,627,o),
+(115,655,o),
+(159,655,cs),
+(204,655,o),
+(224,628,o),
+(224,565,cs),
+(224,345,l),
+(268,345,l),
+(268,561,ls),
+(268,650,o),
+(228,696,o),
+(159,696,cs),
+(91,696,o),
+(50,649,o),
+(50,564,cs),
+(50,345,l)
+);
+}
+);
+width = 318;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+unicode = 5154;
+},
+{
+glyphname = "ringRighthalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(71,345,ls),
+(175,345,o),
+(227,408,o),
+(227,517,cs),
+(227,625,o),
+(175,690,o),
+(73,690,cs),
+(46,690,l),
+(46,647,l),
+(69,647,ls),
+(147,647,o),
+(183,601,o),
+(183,517,cs),
+(183,431,o),
+(147,387,o),
+(69,387,cs),
+(46,387,l),
+(46,345,l)
+);
+}
+);
+width = 276;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+unicode = 5155;
+},
+{
+glyphname = "ringFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(289,397,o),
+(350,461,o),
+(350,547,cs),
+(350,631,o),
+(288,696,o),
+(200,696,cs),
+(111,696,o),
+(49,632,o),
+(49,547,cs),
+(49,461,o),
+(111,397,o),
+(200,397,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(134,436,o),
+(91,480,o),
+(91,547,cs),
+(91,612,o),
+(134,657,o),
+(200,657,cs),
+(265,657,o),
+(308,611,o),
+(308,547,cs),
+(308,480,o),
+(265,436,o),
+(200,436,cs)
+);
+}
+);
+width = 399;
+}
+);
+note = uni1424;
+unicode = 5156;
+},
+{
+glyphname = "doubleacuteFinal-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(197,690,l),
+(149,690,l),
+(29,345,l),
+(77,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(303,690,l),
+(255,690,l),
+(135,345,l),
+(185,345,l)
+);
+}
+);
+width = 332;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricRight = "=|";
+note = uni1425;
+unicode = 5157;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(94,690,l),
+(50,690,l),
+(50,345,l),
+(94,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(189,690,l),
+(146,690,l),
+(146,345,l),
+(189,345,l)
+);
+}
+);
+width = 239;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "pWestCree-canadian";
+note = uni1426;
+unicode = 5158;
+},
+{
+glyphname = "middledotFinal-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(107,314,o),
+(126,332,o),
+(126,355,cs),
+(126,377,o),
+(107,395,o),
+(85,395,cs),
+(62,395,o),
+(44,377,o),
+(44,355,cs),
+(44,332,o),
+(62,314,o),
+(85,314,cs)
+);
+}
+);
+width = 170;
+}
+);
+note = uni1427;
+unicode = 5159;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(293,504,l),
+(293,549,l),
+(50,549,l),
+(50,504,l)
+);
+}
+);
+width = 343;
+}
+);
+metricRight = "=|";
+note = uni1428;
+unicode = 5160;
+},
+{
+glyphname = "plusFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(193,407,l),
+(193,528,l),
+(293,528,l),
+(293,571,l),
+(193,571,l),
+(193,690,l),
+(152,690,l),
+(152,571,l),
+(50,571,l),
+(50,528,l),
+(152,528,l),
+(152,407,l)
+);
+}
+);
+width = 343;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+unicode = 5161;
+},
+{
+glyphname = "downtackFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(194,345,l),
+(194,647,l),
+(293,647,l),
+(293,690,l),
+(50,690,l),
+(50,647,l),
+(151,647,l),
+(151,345,l)
+);
+}
+);
+width = 343;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni142A;
+unicode = 5162;
+},
+{
+glyphname = "thFinalWoodScree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(193,345,l),
+(193,430,l),
+(293,430,l),
+(293,469,l),
+(193,469,l),
+(193,565,l),
+(293,565,l),
+(293,605,l),
+(193,605,l),
+(193,690,l),
+(150,690,l),
+(150,605,l),
+(50,605,l),
+(50,565,l),
+(150,565,l),
+(150,469,l),
+(50,469,l),
+(50,430,l),
+(150,430,l),
+(150,345,l)
+);
+}
+);
+width = 343;
+}
+);
+metricLeft = "hyphen-canadian";
+metricRight = "hyphen-canadian";
+note = uni167E;
+unicode = 5758;
+},
+{
+glyphname = "ringSmallFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(181,535,o),
+(217,571,o),
+(217,619,cs),
+(217,667,o),
+(181,702,o),
+(134,702,cs),
+(87,702,o),
+(50,667,o),
+(50,619,cs),
+(50,571,o),
+(87,535,o),
+(134,535,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(103,566,o),
+(83,588,o),
+(83,619,cs),
+(83,649,o),
+(103,671,o),
+(134,671,cs),
+(164,671,o),
+(185,649,o),
+(185,619,cs),
+(185,588,o),
+(164,566,o),
+(134,566,cs)
+);
+}
+);
+width = 268;
+}
+);
+note = g725;
+unicode = 6366;
+},
+{
+glyphname = "raiseddotFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(111,621,o),
+(129,639,o),
+(129,662,cs),
+(129,684,o),
+(111,702,o),
+(89,702,cs),
+(66,702,o),
+(48,684,o),
+(48,662,cs),
+(48,639,o),
+(66,621,o),
+(89,621,cs)
+);
+}
+);
+width = 178;
+}
+);
+note = g725;
+unicode = 6367;
+},
+{
+glyphname = "acuteFinal-canadian.base";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "acuteFinal-canadian";
+}
+);
+width = 226;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.base";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "graveFinal-canadian";
+}
+);
+width = 226;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian.base";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 318;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1421;
+},
+{
+glyphname = "ringTophalfFinal-canadian.base";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 318;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.base";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 276;
+}
+);
+metricLeft = "==|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "plusFinal-canadian.base";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(193,0,l),
+(193,122,l),
+(293,122,l),
+(293,164,l),
+(193,164,l),
+(193,283,l),
+(152,283,l),
+(152,164,l),
+(50,164,l),
+(50,122,l),
+(152,122,l),
+(152,0,l)
+);
+}
+);
+width = 343;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+},
+{
+glyphname = "acuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "acuteFinal-canadian";
+}
+);
+width = 226;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.mid";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "graveFinal-canadian";
+}
+);
+width = 226;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringTophalfFinal-canadian.mid";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-172);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 318;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.mid";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 276;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "ringFinal-canadian.mid";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-203);
+ref = "ringFinal-canadian";
+}
+);
+width = 399;
+}
+);
+metricLeft = "ringFinal-canadian";
+metricWidth = "ringFinal-canadian";
+note = uni1424;
+},
+{
+glyphname = "doubleacuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "doubleacuteFinal-canadian";
+}
+);
+width = 332;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "doubleacuteFinal-canadian";
+note = uni1425;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian.mid";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "doubleshortverticalstrokesFinal-canadian";
+}
+);
+width = 239;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricWidth = "doubleshortverticalstrokesFinal-canadian";
+note = uni1426;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian.mid";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-172);
+ref = "shorthorizontalstrokeFinal-canadian";
+}
+);
+width = 343;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "shorthorizontalstrokeFinal-canadian";
+note = uni1428;
+},
+{
+glyphname = "downtackFinal-canadian.mid";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "downtackFinal-canadian";
+}
+);
+width = 343;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "downtackFinal-canadian";
+note = uni142A;
+},
+{
+glyphname = "e-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (267,454);
+},
+{
+name = top_center_can;
+pos = (267,690);
+},
+{
+name = top_left_can;
+pos = (98,690);
+},
+{
+name = top_right_can;
+pos = (438,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(281,0,l),
+(511,670,l),
+(511,690,l),
+(27,690,l),
+(27,670,l),
+(257,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(284,71,l),
+(90,654,l),
+(80,639,l),
+(457,639,l),
+(449,654,l),
+(255,71,l)
+);
+}
+);
+width = 538;
+}
+);
+metricRight = "=|";
+note = uni1401;
+unicode = 5121;
+},
+{
+glyphname = "aai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (155,0);
+ref = ring_top.canadian;
+}
+);
+width = 538;
+}
+);
+note = uni1402;
+unicode = 5122;
+},
+{
+glyphname = "i-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (266,403);
+},
+{
+name = top_center_can;
+pos = (270,690);
+},
+{
+name = top_left_can;
+pos = (99,690);
+},
+{
+name = top_right_can;
+pos = (440,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(511,0,l),
+(511,19,l),
+(281,690,l),
+(257,690,l),
+(27,19,l),
+(27,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(284,618,l),
+(254,618,l),
+(449,36,l),
+(456,51,l),
+(80,51,l),
+(89,36,l)
+);
+}
+);
+width = 538;
+}
+);
+metricLeft = "e-canadian";
+metricWidth = "e-canadian";
+note = uni1403;
+unicode = 5123;
+},
+{
+glyphname = "ii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (211,0);
+ref = dot_top;
+}
+);
+width = 538;
+}
+);
+note = uni1404;
+unicode = 5124;
+},
+{
+glyphname = "o-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (214,345);
+},
+{
+name = top_center_can;
+pos = (273,690);
+},
+{
+name = top_double;
+pos = (350,690);
+},
+{
+name = top_left_can;
+pos = (87,690);
+},
+{
+name = top_right_can;
+pos = (457,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(80,0,l),
+(490,332,l),
+(490,357,l),
+(80,690,l),
+(63,690,l),
+(63,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(114,619,l),
+(99,612,l),
+(444,329,l),
+(444,360,l),
+(99,77,l),
+(114,71,l)
+);
+}
+);
+width = 521;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1405;
+unicode = 5125;
+},
+{
+glyphname = "oo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (29,0);
+ref = dot_top;
+}
+);
+width = 521;
+}
+);
+note = uni1406;
+unicode = 5126;
+},
+{
+glyphname = "yCreeoo-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (161,0);
+ref = doubledot_top;
+}
+);
+width = 521;
+}
+);
+note = uni1407;
+unicode = 5127;
+},
+{
+glyphname = "eeCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(80,0,l),
+(490,332,l),
+(490,357,l),
+(80,690,l),
+(63,690,l),
+(63,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(110,619,l),
+(99,616,l),
+(444,333,l),
+(444,356,l),
+(99,74,l),
+(110,71,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(226,438,l),
+(198,438,l),
+(198,252,l),
+(226,252,l)
+);
+}
+);
+width = 521;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "o-canadian";
+note = uni1408;
+unicode = 5128;
+},
+{
+glyphname = "iCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (165,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 521;
+}
+);
+note = uni1409;
+unicode = 5129;
+},
+{
+glyphname = "a-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (302,345);
+},
+{
+name = top_center_can;
+pos = (234,690);
+},
+{
+name = top_left_can;
+pos = (60,690);
+},
+{
+name = top_right_can;
+pos = (431,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(458,0,l),
+(458,690,l),
+(440,690,l),
+(30,357,l),
+(30,332,l),
+(440,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(421,77,l),
+(75,359,l),
+(75,329,l),
+(421,612,l),
+(407,619,l),
+(407,71,l)
+);
+}
+);
+width = 521;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni140A;
+unicode = 5130;
+},
+{
+glyphname = "aa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (372,0);
+ref = dot_top;
+}
+);
+width = 521;
+}
+);
+note = uni140B;
+unicode = 5131;
+},
+{
+glyphname = "we-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "e-canadian";
+}
+);
+width = 708;
+}
+);
+note = uni140C;
+unicode = 5132;
+},
+{
+glyphname = "weWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (538,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 708;
+}
+);
+note = uni140D;
+unicode = 5133;
+},
+{
+glyphname = "wi-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "i-canadian";
+}
+);
+width = 708;
+}
+);
+note = uni140E;
+unicode = 5134;
+},
+{
+glyphname = "wiWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (538,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 708;
+}
+);
+note = uni140F;
+unicode = 5135;
+},
+{
+glyphname = "wii-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (380,0);
+ref = dot_top;
+}
+);
+width = 708;
+}
+);
+note = uni1410;
+unicode = 5136;
+},
+{
+glyphname = "wiiWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (211,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (538,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 708;
+}
+);
+note = uni1411;
+unicode = 5137;
+},
+{
+glyphname = "wo-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "o-canadian";
+}
+);
+width = 690;
+}
+);
+note = uni1412;
+unicode = 5138;
+},
+{
+glyphname = "woWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (521,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 690;
+}
+);
+note = uni1413;
+unicode = 5139;
+},
+{
+glyphname = "woo-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (384,0);
+ref = dot_top;
+}
+);
+width = 690;
+}
+);
+note = uni1414;
+unicode = 5140;
+},
+{
+glyphname = "wooWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (29,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (521,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 690;
+}
+);
+note = uni1415;
+unicode = 5141;
+},
+{
+glyphname = "wooNaskapi-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (165,-95);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (295,-200);
+ref = dot_top;
+}
+);
+width = 521;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricWidth = "o-canadian";
+note = uni1416;
+unicode = 5142;
+},
+{
+glyphname = "wa-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "a-canadian";
+}
+);
+width = 690;
+}
+);
+note = uni1417;
+unicode = 5143;
+},
+{
+glyphname = "waWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (521,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 690;
+}
+);
+note = uni1418;
+unicode = 5144;
+},
+{
+glyphname = "waa-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (542,0);
+ref = dot_top;
+}
+);
+width = 690;
+}
+);
+note = uni1419;
+unicode = 5145;
+},
+{
+glyphname = "waaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (372,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (521,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 690;
+}
+);
+note = uni141A;
+unicode = 5146;
+},
+{
+glyphname = "waaNaskapi-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (107,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (237,-95);
+ref = dot_top;
+}
+);
+width = 521;
+}
+);
+metricWidth = "a-canadian";
+note = uni141B;
+unicode = 5147;
+},
+{
+glyphname = "ai-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(201,339,o),
+(231,370,o),
+(244,423,c),
+(231,423,l),
+(245,367,o),
+(278,339,o),
+(325,339,cs),
+(382,339,o),
+(426,377,o),
+(426,476,cs),
+(426,690,l),
+(384,690,l),
+(384,476,ls),
+(384,398,o),
+(355,380,o),
+(321,380,cs),
+(287,380,o),
+(258,400,o),
+(258,475,cs),
+(258,690,l),
+(217,690,l),
+(217,476,ls),
+(217,398,o),
+(188,380,o),
+(154,380,cs),
+(119,380,o),
+(92,400,o),
+(92,475,cs),
+(92,690,l),
+(50,690,l),
+(50,474,ls),
+(50,377,o),
+(95,339,o),
+(152,339,cs)
+);
+}
+);
+width = 476;
+}
+);
+metricRight = "=|";
+note = uni141C;
+unicode = 5148;
+},
+{
+glyphname = "ycreew-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(268,510,o),
+(294,545,o),
+(294,603,cs),
+(294,662,o),
+(268,696,o),
+(229,696,cs),
+(189,696,o),
+(163,662,o),
+(163,603,cs),
+(163,545,o),
+(189,510,o),
+(229,510,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(155,339,o),
+(181,374,o),
+(181,432,cs),
+(181,491,o),
+(155,525,o),
+(115,525,cs),
+(76,525,o),
+(50,491,o),
+(50,432,cs),
+(50,374,o),
+(76,339,o),
+(115,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(92,366,o),
+(78,387,o),
+(78,432,cs),
+(78,476,o),
+(92,497,o),
+(115,497,cs),
+(139,497,o),
+(152,476,o),
+(152,432,cs),
+(152,387,o),
+(139,366,o),
+(115,366,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(205,537,o),
+(192,558,o),
+(192,603,cs),
+(192,647,o),
+(205,668,o),
+(229,668,cs),
+(252,668,o),
+(266,647,o),
+(266,603,cs),
+(266,558,o),
+(252,537,o),
+(229,537,cs)
+);
+}
+);
+width = 344;
+}
+);
+metricRight = "=|";
+note = uni141D;
+unicode = 5149;
+},
+{
+glyphname = "glottalstop-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(289,345,l),
+(289,356,l),
+(175,690,l),
+(161,690,l),
+(47,356,l),
+(47,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(180,644,l),
+(157,644,l),
+(249,363,l),
+(257,381,l),
+(79,381,l),
+(86,363,l)
+);
+}
+);
+width = 336;
+}
+);
+metricRight = "=|";
+note = uni141E;
+unicode = 5150;
+},
+{
+glyphname = "en-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+pos = (538,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 764;
+}
+);
+note = uni142B;
+unicode = 5163;
+},
+{
+glyphname = "in-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+pos = (372,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 598;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142C;
+unicode = 5164;
+},
+{
+glyphname = "on-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (408,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 634;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142D;
+unicode = 5165;
+},
+{
+glyphname = "an-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (495,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 721;
+}
+);
+metricRight = "graveFinal-canadian";
+note = uni142E;
+unicode = 5166;
+},
+{
+glyphname = "pe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (267,454);
+},
+{
+name = top_center_can;
+pos = (267,690);
+},
+{
+name = top_left_can;
+pos = (98,690);
+},
+{
+name = top_right_can;
+pos = (438,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(281,0,l),
+(511,670,l),
+(511,690,l),
+(457,690,l),
+(251,74,l),
+(289,74,l),
+(82,690,l),
+(27,690,l),
+(27,670,l),
+(257,0,l)
+);
+}
+);
+width = 538;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni142F;
+unicode = 5167;
+},
+{
+glyphname = "paai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (155,0);
+ref = ring_top.canadian;
+}
+);
+width = 538;
+}
+);
+note = uni1430;
+unicode = 5168;
+},
+{
+glyphname = "pi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (270,403);
+},
+{
+name = top_center_can;
+pos = (270,690);
+},
+{
+name = top_left_can;
+pos = (99,690);
+},
+{
+name = top_right_can;
+pos = (440,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(81,0,l),
+(288,615,l),
+(250,615,l),
+(457,0,l),
+(511,0,l),
+(511,19,l),
+(281,690,l),
+(257,690,l),
+(27,19,l),
+(27,0,l)
+);
+}
+);
+width = 538;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni1431;
+unicode = 5169;
+},
+{
+glyphname = "pii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (211,0);
+ref = dot_top;
+}
+);
+width = 538;
+}
+);
+note = uni1432;
+unicode = 5170;
+},
+{
+glyphname = "po-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (165,345);
+},
+{
+name = top_center_can;
+pos = (250,690);
+},
+{
+name = top_double;
+pos = (333,690);
+},
+{
+name = top_left_can;
+pos = (69,690);
+},
+{
+name = top_right_can;
+pos = (431,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(59,0,l),
+(464,332,l),
+(464,357,l),
+(59,690,l),
+(42,690,l),
+(42,634,l),
+(412,329,l),
+(412,360,l),
+(42,56,l),
+(42,0,l)
+);
+}
+);
+width = 495;
+}
+);
+metricRight = "o-canadian";
+note = uni1433;
+unicode = 5171;
+},
+{
+glyphname = "poo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (10,0);
+ref = dot_top;
+}
+);
+width = 495;
+}
+);
+note = uni1434;
+unicode = 5172;
+},
+{
+glyphname = "ycreepoo-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (146,0);
+ref = doubledot_top;
+}
+);
+width = 495;
+}
+);
+note = uni1435;
+unicode = 5173;
+},
+{
+glyphname = "heeCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (130,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 495;
+}
+);
+note = uni1436;
+unicode = 5174;
+},
+{
+glyphname = "hiCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (111,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 495;
+}
+);
+note = uni1437;
+unicode = 5175;
+},
+{
+glyphname = "pa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (240,345);
+},
+{
+name = top_center_can;
+pos = (245,690);
+},
+{
+name = top_left_can;
+pos = (60,690);
+},
+{
+name = top_right_can;
+pos = (426,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(453,0,l),
+(453,56,l),
+(83,360,l),
+(83,329,l),
+(453,634,l),
+(453,690,l),
+(436,690,l),
+(30,357,l),
+(30,332,l),
+(436,0,l)
+);
+}
+);
+width = 495;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1438;
+unicode = 5176;
+},
+{
+glyphname = "paa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (367,0);
+ref = dot_top;
+}
+);
+width = 495;
+}
+);
+note = uni1439;
+unicode = 5177;
+},
+{
+glyphname = "pwe-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "pe-canadian";
+}
+);
+width = 708;
+}
+);
+note = uni143A;
+unicode = 5178;
+},
+{
+glyphname = "pweWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "pe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (538,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 708;
+}
+);
+note = uni143B;
+unicode = 5179;
+},
+{
+glyphname = "pwi-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "pi-canadian";
+}
+);
+width = 708;
+}
+);
+note = uni143C;
+unicode = 5180;
+},
+{
+glyphname = "pwiWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (538,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 708;
+}
+);
+note = uni143D;
+unicode = 5181;
+},
+{
+glyphname = "pwii-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (380,0);
+ref = dot_top;
+}
+);
+width = 708;
+}
+);
+note = uni143E;
+unicode = 5182;
+},
+{
+glyphname = "pwiiWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (211,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (538,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 708;
+}
+);
+note = uni143F;
+unicode = 5183;
+},
+{
+glyphname = "pwo-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "po-canadian";
+}
+);
+width = 664;
+}
+);
+note = uni1440;
+unicode = 5184;
+},
+{
+glyphname = "pwoWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (495,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 664;
+}
+);
+note = uni1441;
+unicode = 5185;
+},
+{
+glyphname = "pwoo-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (361,0);
+ref = dot_top;
+}
+);
+width = 664;
+}
+);
+note = uni1442;
+unicode = 5186;
+},
+{
+glyphname = "pwooWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (10,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (495,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 664;
+}
+);
+note = uni1443;
+unicode = 5187;
+},
+{
+glyphname = "pwa-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "pa-canadian";
+}
+);
+width = 664;
+}
+);
+note = uni1444;
+unicode = 5188;
+},
+{
+glyphname = "pwaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (495,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 664;
+}
+);
+note = uni1445;
+unicode = 5189;
+},
+{
+glyphname = "pwaa-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (537,0);
+ref = dot_top;
+}
+);
+width = 664;
+}
+);
+note = uni1446;
+unicode = 5190;
+},
+{
+glyphname = "pwaaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (367,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (495,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 664;
+}
+);
+note = uni1447;
+unicode = 5191;
+},
+{
+glyphname = "ycreepwaa-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+pos = (105,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (235,-95);
+ref = dot_top;
+}
+);
+width = 495;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1448;
+unicode = 5192;
+},
+{
+glyphname = "p-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(259,345,l),
+(259,385,l),
+(83,532,l),
+(83,502,l),
+(259,648,l),
+(259,690,l),
+(249,690,l),
+(50,526,l),
+(50,509,l),
+(249,345,l)
+);
+}
+);
+width = 309;
+}
+);
+note = uni1449;
+unicode = 5193;
+},
+{
+glyphname = "pWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(94,345,l),
+(94,690,l),
+(50,690,l),
+(50,345,l)
+);
+}
+);
+width = 144;
+}
+);
+metricRight = "=|";
+note = uni144A;
+unicode = 5194;
+},
+{
+color = 6;
+glyphname = "hCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(94,183,l),
+(94,333,ls),
+(94,372,o),
+(112,394,o),
+(146,394,cs),
+(176,394,o),
+(190,374,o),
+(190,332,cs),
+(190,183,l),
+(234,183,l),
+(234,340,ls),
+(234,404,o),
+(199,434,o),
+(155,434,cs),
+(114,434,o),
+(86,406,o),
+(83,367,c),
+(94,361,l),
+(94,527,l),
+(50,527,l),
+(50,183,l)
+);
+}
+);
+width = 269;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144B;
+unicode = 5195;
+},
+{
+glyphname = "te-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (271,345);
+},
+{
+name = top_center_can;
+pos = (271,690);
+},
+{
+name = top_left_can;
+pos = (91,690);
+},
+{
+name = top_right_can;
+pos = (454,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(407,-13,o),
+(485,71,o),
+(485,237,cs),
+(485,690,l),
+(424,690,l),
+(424,236,ls),
+(424,103,o),
+(369,45,o),
+(271,45,cs),
+(178,45,o),
+(121,105,o),
+(121,236,cs),
+(121,690,l),
+(59,690,l),
+(59,234,ls),
+(59,71,o),
+(141,-13,o),
+(272,-13,cs)
+);
+}
+);
+width = 544;
+}
+);
+metricRight = "=|";
+note = uni144C;
+unicode = 5196;
+},
+{
+glyphname = "taai-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (157,0);
+ref = ring_top.canadian;
+}
+);
+width = 545;
+}
+);
+note = uni144D;
+unicode = 5197;
+},
+{
+glyphname = "ti-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (271,345);
+},
+{
+name = middle_right_can;
+pos = (575,345);
+},
+{
+name = top_center_can;
+pos = (271,690);
+},
+{
+name = top_left_can;
+pos = (91,690);
+},
+{
+name = top_right_can;
+pos = (454,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,0,l),
+(121,454,ls),
+(121,586,o),
+(175,644,o),
+(272,644,cs),
+(367,644,o),
+(424,584,o),
+(424,454,cs),
+(424,0,l),
+(485,0,l),
+(485,456,ls),
+(485,618,o),
+(404,702,o),
+(272,702,cs),
+(140,702,o),
+(59,619,o),
+(59,453,cs),
+(59,0,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni144E;
+unicode = 5198;
+},
+{
+glyphname = "tii-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (213,0);
+ref = dot_top;
+}
+);
+width = 545;
+}
+);
+note = uni144F;
+unicode = 5199;
+},
+{
+glyphname = "to-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (192,345);
+},
+{
+name = middle_right_can;
+pos = (493,345);
+},
+{
+name = top_center_can;
+pos = (203,690);
+},
+{
+name = top_double;
+pos = (247,690);
+},
+{
+name = top_left_can;
+pos = (69,690);
+},
+{
+name = top_right_can;
+pos = (376,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(123,0,ls),
+(314,0,o),
+(403,121,o),
+(403,346,cs),
+(403,571,o),
+(314,690,o),
+(119,690,cs),
+(42,690,l),
+(42,633,l),
+(119,633,ls),
+(277,633,o),
+(341,538,o),
+(341,346,cs),
+(341,156,o),
+(277,57,o),
+(124,57,cs),
+(42,57,l),
+(42,0,l)
+);
+}
+);
+width = 453;
+}
+);
+note = uni1450;
+unicode = 5200;
+},
+{
+glyphname = "too-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (144,0);
+ref = dot_top;
+}
+);
+width = 453;
+}
+);
+note = uni1451;
+unicode = 5201;
+},
+{
+glyphname = "ycreetoo-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (59,0);
+ref = doubledot_top;
+}
+);
+width = 453;
+}
+);
+note = uni1452;
+unicode = 5202;
+},
+{
+glyphname = "deeCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (155,0);
+ref = stroke_middle;
+}
+);
+width = 453;
+}
+);
+note = uni1453;
+unicode = 5203;
+},
+{
+glyphname = "diCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (133,0);
+ref = dot_middle;
+}
+);
+width = 453;
+}
+);
+note = uni1454;
+unicode = 5204;
+},
+{
+glyphname = "ta-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (262,345);
+},
+{
+name = top_center_can;
+pos = (251,690);
+},
+{
+name = top_left_can;
+pos = (77,690);
+},
+{
+name = top_right_can;
+pos = (384,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(412,0,l),
+(412,57,l),
+(334,57,ls),
+(176,57,o),
+(112,152,o),
+(112,344,cs),
+(112,534,o),
+(176,633,o),
+(329,633,cs),
+(412,633,l),
+(412,690,l),
+(329,690,ls),
+(139,690,o),
+(50,569,o),
+(50,344,cs),
+(50,119,o),
+(139,0,o),
+(335,0,cs)
+);
+}
+);
+width = 454;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|to-canadian";
+note = uni1455;
+unicode = 5205;
+},
+{
+glyphname = "taa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (192,0);
+ref = dot_top;
+}
+);
+width = 453;
+}
+);
+note = uni1456;
+unicode = 5206;
+},
+{
+glyphname = "twe-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "te-canadian";
+}
+);
+width = 714;
+}
+);
+note = uni1457;
+unicode = 5207;
+},
+{
+glyphname = "tweWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (545,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 714;
+}
+);
+note = uni1458;
+unicode = 5208;
+},
+{
+glyphname = "twi-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ti-canadian";
+}
+);
+width = 714;
+}
+);
+note = uni1459;
+unicode = 5209;
+},
+{
+glyphname = "twiWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (545,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 714;
+}
+);
+note = uni145A;
+unicode = 5210;
+},
+{
+glyphname = "twii-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (383,0);
+ref = dot_top;
+}
+);
+width = 714;
+}
+);
+note = uni145B;
+unicode = 5211;
+},
+{
+glyphname = "twiiWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (213,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (545,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 714;
+}
+);
+note = uni145C;
+unicode = 5212;
+},
+{
+glyphname = "two-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "to-canadian";
+}
+);
+width = 622;
+}
+);
+note = uni145D;
+unicode = 5213;
+},
+{
+glyphname = "twoWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (453,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 622;
+}
+);
+note = uni145E;
+unicode = 5214;
+},
+{
+glyphname = "twoo-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (314,0);
+ref = dot_top;
+}
+);
+width = 622;
+}
+);
+note = uni145F;
+unicode = 5215;
+},
+{
+glyphname = "twooWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (144,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (453,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 622;
+}
+);
+note = uni1460;
+unicode = 5216;
+},
+{
+glyphname = "twa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ta-canadian";
+}
+);
+width = 622;
+}
+);
+note = uni1461;
+unicode = 5217;
+},
+{
+glyphname = "twaWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (453,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 622;
+}
+);
+note = uni1462;
+unicode = 5218;
+},
+{
+glyphname = "twaa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (362,0);
+ref = dot_top;
+}
+);
+width = 622;
+}
+);
+note = uni1463;
+unicode = 5219;
+},
+{
+glyphname = "twaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (192,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (453,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 622;
+}
+);
+note = uni1464;
+unicode = 5220;
+},
+{
+glyphname = "twaaNaskapi-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ta-canadian";
+}
+);
+width = 639;
+}
+);
+note = uni1465;
+unicode = 5221;
+},
+{
+glyphname = "t-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(230,345,l),
+(230,387,l),
+(209,387,ls),
+(129,387,o),
+(94,431,o),
+(94,517,cs),
+(94,602,o),
+(129,647,o),
+(209,647,cs),
+(230,647,l),
+(230,690,l),
+(203,690,ls),
+(102,690,o),
+(49,625,o),
+(49,517,cs),
+(49,409,o),
+(102,345,o),
+(205,345,cs)
+);
+}
+);
+width = 276;
+}
+);
+note = uni1466;
+unicode = 5222;
+},
+{
+glyphname = "tte-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+pos = (545,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 689;
+}
+);
+note = uni1467;
+unicode = 5223;
+},
+{
+glyphname = "tti-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+pos = (545,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 689;
+}
+);
+note = uni1468;
+unicode = 5224;
+},
+{
+glyphname = "tto-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+pos = (453,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 598;
+}
+);
+note = uni1469;
+unicode = 5225;
+},
+{
+glyphname = "tta-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+pos = (453,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 598;
+}
+);
+note = uni146A;
+unicode = 5226;
+},
+{
+glyphname = "ke-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (237,441);
+},
+{
+name = top_center_can;
+pos = (222,690);
+},
+{
+name = top_left_can;
+pos = (84,690);
+},
+{
+name = top_right_can;
+pos = (360,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(391,0,l),
+(391,449,ls),
+(391,615,o),
+(333,702,o),
+(224,702,cs),
+(115,702,o),
+(53,613,o),
+(53,451,cs),
+(53,295,o),
+(114,205,o),
+(215,205,cs),
+(279,205,o),
+(325,249,o),
+(336,313,c),
+(329,341,l),
+(329,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(151,259,o),
+(113,322,o),
+(113,454,cs),
+(113,586,o),
+(151,648,o),
+(222,648,cs),
+(294,648,o),
+(330,587,o),
+(330,454,cs),
+(330,322,o),
+(293,259,o),
+(222,259,cs)
+);
+}
+);
+width = 450;
+}
+);
+metricRight = "te-canadian";
+note = uni146B;
+unicode = 5227;
+},
+{
+glyphname = "kaai-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (113,0);
+ref = ring_top.canadian;
+}
+);
+width = 450;
+}
+);
+note = uni146C;
+unicode = 5228;
+},
+{
+glyphname = "ki-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (243,441);
+},
+{
+name = top_center_can;
+pos = (228,690);
+},
+{
+name = top_left_can;
+pos = (90,690);
+},
+{
+name = top_right_can;
+pos = (367,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,0,l),
+(121,341,l),
+(114,313,l),
+(125,249,o),
+(171,205,o),
+(234,205,cs),
+(336,205,o),
+(397,295,o),
+(397,451,cs),
+(397,613,o),
+(335,702,o),
+(228,702,cs),
+(117,702,o),
+(59,612,o),
+(59,449,cs),
+(59,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(157,259,o),
+(120,322,o),
+(120,454,cs),
+(120,587,o),
+(156,648,o),
+(228,648,cs),
+(299,648,o),
+(337,586,o),
+(337,454,cs),
+(337,322,o),
+(298,259,o),
+(228,259,cs)
+);
+}
+);
+width = 450;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni146D;
+unicode = 5229;
+},
+{
+glyphname = "kii-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (169,0);
+ref = dot_top;
+}
+);
+width = 450;
+}
+);
+note = uni146E;
+unicode = 5230;
+},
+{
+glyphname = "ko-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (237,397);
+},
+{
+name = top_center_can;
+pos = (222,690);
+},
+{
+name = top_double;
+pos = (360,690);
+},
+{
+name = top_left_can;
+pos = (84,690);
+},
+{
+name = top_right_can;
+pos = (360,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(332,-13,o),
+(391,74,o),
+(391,241,cs),
+(391,690,l),
+(329,690,l),
+(329,349,l),
+(336,377,l),
+(325,440,o),
+(279,485,o),
+(215,485,cs),
+(114,485,o),
+(53,395,o),
+(53,237,cs),
+(53,76,o),
+(114,-13,o),
+(223,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(151,42,o),
+(113,103,o),
+(113,236,cs),
+(113,368,o),
+(151,431,o),
+(222,431,cs),
+(293,431,o),
+(330,368,o),
+(330,236,cs),
+(330,102,o),
+(294,42,o),
+(222,42,cs)
+);
+}
+);
+width = 450;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni146F;
+unicode = 5231;
+},
+{
+glyphname = "koo-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (301,0);
+ref = dot_top;
+}
+);
+width = 450;
+}
+);
+note = uni1470;
+unicode = 5232;
+},
+{
+glyphname = "ycreekoo-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (173,0);
+ref = doubledot_top;
+}
+);
+width = 450;
+}
+);
+note = uni1471;
+unicode = 5233;
+},
+{
+glyphname = "ka-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (243,398);
+},
+{
+name = top_center_can;
+pos = (228,690);
+},
+{
+name = top_left_can;
+pos = (90,690);
+},
+{
+name = top_right_can;
+pos = (367,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(335,-13,o),
+(397,76,o),
+(397,239,cs),
+(397,395,o),
+(336,485,o),
+(234,485,cs),
+(171,485,o),
+(125,440,o),
+(114,377,c),
+(121,349,l),
+(121,690,l),
+(59,690,l),
+(59,241,ls),
+(59,74,o),
+(117,-13,o),
+(226,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(156,42,o),
+(120,102,o),
+(120,236,cs),
+(120,368,o),
+(157,431,o),
+(228,431,cs),
+(298,431,o),
+(337,368,o),
+(337,236,cs),
+(337,103,o),
+(299,42,o),
+(228,42,cs)
+);
+}
+);
+width = 450;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "==|ke-canadian";
+note = uni1472;
+unicode = 5234;
+},
+{
+glyphname = "kaa-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (32,0);
+ref = dot_top;
+}
+);
+width = 450;
+}
+);
+note = uni1473;
+unicode = 5235;
+},
+{
+glyphname = "kwe-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ke-canadian";
+}
+);
+width = 619;
+}
+);
+note = uni1474;
+unicode = 5236;
+},
+{
+glyphname = "kweWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (450,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 619;
+}
+);
+note = uni1475;
+unicode = 5237;
+},
+{
+glyphname = "kwi-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ki-canadian";
+}
+);
+width = 619;
+}
+);
+note = uni1476;
+unicode = 5238;
+},
+{
+glyphname = "kwiWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (450,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 619;
+}
+);
+note = uni1477;
+unicode = 5239;
+},
+{
+glyphname = "kwii-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (339,0);
+ref = dot_top;
+}
+);
+width = 619;
+}
+);
+note = uni1478;
+unicode = 5240;
+},
+{
+glyphname = "kwiiWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (169,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (450,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 619;
+}
+);
+note = uni1479;
+unicode = 5241;
+},
+{
+glyphname = "kwo-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ko-canadian";
+}
+);
+width = 619;
+}
+);
+note = uni147A;
+unicode = 5242;
+},
+{
+glyphname = "kwoWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (450,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 619;
+}
+);
+note = uni147B;
+unicode = 5243;
+},
+{
+glyphname = "kwoo-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (471,0);
+ref = dot_top;
+}
+);
+width = 619;
+}
+);
+note = uni147C;
+unicode = 5244;
+},
+{
+glyphname = "kwooWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (301,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (450,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 619;
+}
+);
+note = uni147D;
+unicode = 5245;
+},
+{
+glyphname = "kwa-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ka-canadian";
+}
+);
+width = 619;
+}
+);
+note = uni147E;
+unicode = 5246;
+},
+{
+glyphname = "kwaWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (450,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 619;
+}
+);
+note = uni147F;
+unicode = 5247;
+},
+{
+glyphname = "kwaa-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (201,0);
+ref = dot_top;
+}
+);
+width = 619;
+}
+);
+note = uni1480;
+unicode = 5248;
+},
+{
+glyphname = "kwaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (32,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (450,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 619;
+}
+);
+note = uni1481;
+unicode = 5249;
+},
+{
+glyphname = "kwaaNaskapi-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ka-canadian";
+}
+);
+width = 636;
+}
+);
+note = uni1482;
+unicode = 5250;
+},
+{
+glyphname = "k-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(196,339,o),
+(238,382,o),
+(238,473,cs),
+(238,557,o),
+(200,601,o),
+(153,601,cs),
+(114,601,o),
+(85,571,o),
+(82,521,c),
+(94,522,l),
+(94,690,l),
+(50,690,l),
+(50,469,ls),
+(50,384,o),
+(88,339,o),
+(144,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(111,375,o),
+(92,401,o),
+(92,470,cs),
+(92,537,o),
+(113,565,o),
+(145,565,cs),
+(176,565,o),
+(197,538,o),
+(197,471,cs),
+(197,404,o),
+(177,375,o),
+(145,375,cs)
+);
+}
+);
+width = 278;
+}
+);
+note = uni1483;
+unicode = 5251;
+},
+{
+glyphname = "kw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(190,339,o),
+(227,384,o),
+(227,469,cs),
+(227,690,l),
+(184,690,l),
+(184,522,l),
+(196,521,l),
+(192,571,o),
+(163,601,o),
+(126,601,cs),
+(77,601,o),
+(40,557,o),
+(40,473,cs),
+(40,382,o),
+(81,339,o),
+(133,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(100,375,o),
+(80,404,o),
+(80,471,cs),
+(80,538,o),
+(101,565,o),
+(132,565,cs),
+(164,565,o),
+(185,537,o),
+(185,470,cs),
+(185,401,o),
+(166,375,o),
+(132,375,cs)
+);
+}
+);
+width = 277;
+}
+);
+metricLeft = "=|k-canadian";
+metricRight = "=|k-canadian";
+note = uni1484;
+unicode = 5252;
+},
+{
+glyphname = "southslaveykeh-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+pos = (450,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 594;
+}
+);
+note = uni1485;
+unicode = 5253;
+},
+{
+glyphname = "southslaveykih-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+pos = (450,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 594;
+}
+);
+note = uni1486;
+unicode = 5254;
+},
+{
+glyphname = "southslaveykoh-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+pos = (450,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 594;
+}
+);
+note = uni1487;
+unicode = 5255;
+},
+{
+glyphname = "southslaveykah-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+pos = (450,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 594;
+}
+);
+note = uni1488;
+unicode = 5256;
+},
+{
+glyphname = "ce-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (235,420);
+},
+{
+name = top_center_can;
+pos = (220,690);
+},
+{
+name = top_left_can;
+pos = (83,690);
+},
+{
+name = top_right_can;
+pos = (356,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(386,0,l),
+(386,471,ls),
+(386,614,o),
+(328,702,o),
+(221,702,cs),
+(112,702,o),
+(52,618,o),
+(52,479,cs),
+(52,391,l),
+(113,391,l),
+(113,489,ls),
+(113,588,o),
+(148,647,o),
+(220,647,cs),
+(290,647,o),
+(326,588,o),
+(326,483,cs),
+(326,0,l)
+);
+}
+);
+width = 445;
+}
+);
+metricRight = "te-canadian";
+note = uni1489;
+unicode = 5257;
+},
+{
+glyphname = "caai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (114,0);
+ref = ring_top.canadian;
+}
+);
+width = 446;
+}
+);
+note = uni148A;
+unicode = 5258;
+},
+{
+glyphname = "ci-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (242,420);
+},
+{
+name = top_center_can;
+pos = (228,690);
+},
+{
+name = top_left_can;
+pos = (91,690);
+},
+{
+name = top_right_can;
+pos = (365,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,0,l),
+(121,483,ls),
+(121,588,o),
+(156,647,o),
+(225,647,cs),
+(298,647,o),
+(333,588,o),
+(333,489,cs),
+(333,391,l),
+(394,391,l),
+(394,479,ls),
+(394,618,o),
+(333,702,o),
+(226,702,cs),
+(117,702,o),
+(59,614,o),
+(59,471,cs),
+(59,0,l)
+);
+}
+);
+width = 446;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+unicode = 5259;
+},
+{
+glyphname = "cii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (169,0);
+ref = dot_top;
+}
+);
+width = 446;
+}
+);
+note = uni148C;
+unicode = 5260;
+},
+{
+glyphname = "co-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (235,420);
+},
+{
+name = top_center_can;
+pos = (219,690);
+},
+{
+name = top_double;
+pos = (356,690);
+},
+{
+name = top_left_can;
+pos = (83,690);
+},
+{
+name = top_right_can;
+pos = (356,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(328,-13,o),
+(386,75,o),
+(386,218,cs),
+(386,690,l),
+(326,690,l),
+(326,207,ls),
+(326,102,o),
+(290,43,o),
+(220,43,cs),
+(148,43,o),
+(113,102,o),
+(113,201,cs),
+(113,298,l),
+(52,298,l),
+(52,211,ls),
+(52,71,o),
+(112,-13,o),
+(221,-13,cs)
+);
+}
+);
+width = 445;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+unicode = 5261;
+},
+{
+glyphname = "coo-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (298,0);
+ref = dot_top;
+}
+);
+width = 446;
+}
+);
+note = uni148E;
+unicode = 5262;
+},
+{
+glyphname = "ycreecoo-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (168,0);
+ref = doubledot_top;
+}
+);
+width = 446;
+}
+);
+note = uni148F;
+unicode = 5263;
+},
+{
+glyphname = "ca-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (242,420);
+},
+{
+name = top_center_can;
+pos = (228,690);
+},
+{
+name = top_left_can;
+pos = (91,690);
+},
+{
+name = top_right_can;
+pos = (364,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(333,-13,o),
+(394,72,o),
+(394,211,cs),
+(394,298,l),
+(333,298,l),
+(333,201,ls),
+(333,102,o),
+(298,43,o),
+(225,43,cs),
+(156,43,o),
+(121,102,o),
+(121,207,cs),
+(121,690,l),
+(59,690,l),
+(59,218,ls),
+(59,75,o),
+(117,-13,o),
+(225,-13,cs)
+);
+}
+);
+width = 446;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+unicode = 5264;
+},
+{
+glyphname = "caa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (32,0);
+ref = dot_top;
+}
+);
+width = 446;
+}
+);
+note = uni1491;
+unicode = 5265;
+},
+{
+glyphname = "cwe-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ce-canadian";
+}
+);
+width = 615;
+}
+);
+note = uni1492;
+unicode = 5266;
+},
+{
+glyphname = "cweWestCree-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (446,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 615;
+}
+);
+note = uni1493;
+unicode = 5267;
+},
+{
+glyphname = "cwi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ci-canadian";
+}
+);
+width = 615;
+}
+);
+note = uni1494;
+unicode = 5268;
+},
+{
+glyphname = "cwiWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (446,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 615;
+}
+);
+note = uni1495;
+unicode = 5269;
+},
+{
+glyphname = "cwii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (339,0);
+ref = dot_top;
+}
+);
+width = 615;
+}
+);
+note = uni1496;
+unicode = 5270;
+},
+{
+glyphname = "cwiiWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (169,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (446,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 615;
+}
+);
+note = uni1497;
+unicode = 5271;
+},
+{
+glyphname = "cwo-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "co-canadian";
+}
+);
+width = 615;
+}
+);
+note = uni1498;
+unicode = 5272;
+},
+{
+glyphname = "cwoWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (446,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 615;
+}
+);
+note = uni1499;
+unicode = 5273;
+},
+{
+glyphname = "cwoo-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (468,0);
+ref = dot_top;
+}
+);
+width = 615;
+}
+);
+note = uni149A;
+unicode = 5274;
+},
+{
+glyphname = "cwooWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (298,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (446,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 615;
+}
+);
+note = uni149B;
+unicode = 5275;
+},
+{
+glyphname = "cwa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ca-canadian";
+}
+);
+width = 615;
+}
+);
+note = uni149C;
+unicode = 5276;
+},
+{
+glyphname = "cwaWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (446,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 615;
+}
+);
+note = uni149D;
+unicode = 5277;
+},
+{
+glyphname = "cwaa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (201,0);
+ref = dot_top;
+}
+);
+width = 615;
+}
+);
+note = uni149E;
+unicode = 5278;
+},
+{
+glyphname = "cwaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (32,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (446,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 615;
+}
+);
+note = uni149F;
+unicode = 5279;
+},
+{
+glyphname = "cwaaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ca-canadian";
+}
+);
+width = 632;
+}
+);
+note = uni14A0;
+unicode = 5280;
+},
+{
+glyphname = "c-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,339,o),
+(238,382,o),
+(238,458,cs),
+(238,485,l),
+(198,485,l),
+(198,451,ls),
+(198,403,o),
+(178,377,o),
+(146,377,cs),
+(111,377,o),
+(94,402,o),
+(94,457,cs),
+(94,690,l),
+(50,690,l),
+(50,463,ls),
+(50,381,o),
+(86,339,o),
+(145,339,cs)
+);
+}
+);
+width = 270;
+}
+);
+note = uni14A1;
+unicode = 5281;
+},
+{
+glyphname = "thSayisi-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(185,339,o),
+(220,381,o),
+(220,463,cs),
+(220,690,l),
+(176,690,l),
+(176,457,ls),
+(176,402,o),
+(159,377,o),
+(124,377,cs),
+(92,377,o),
+(72,403,o),
+(72,451,cs),
+(72,485,l),
+(32,485,l),
+(32,458,ls),
+(32,382,o),
+(70,339,o),
+(128,339,cs)
+);
+}
+);
+width = 270;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "=|c-canadian";
+note = uni14A2;
+unicode = 5282;
+},
+{
+glyphname = "me-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (154,345);
+},
+{
+name = top_center_can;
+pos = (185,690);
+},
+{
+name = top_left_can;
+pos = (64,690);
+},
+{
+name = top_right_can;
+pos = (304,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(335,0,l),
+(335,690,l),
+(33,690,l),
+(33,633,l),
+(274,633,l),
+(274,0,l)
+);
+}
+);
+width = 398;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+unicode = 5283;
+},
+{
+glyphname = "maai-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (99,0);
+ref = ring_top.canadian;
+}
+);
+width = 398;
+}
+);
+note = uni14A4;
+unicode = 5284;
+},
+{
+glyphname = "mi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (245,345);
+},
+{
+name = top_center_can;
+pos = (213,690);
+},
+{
+name = top_left_can;
+pos = (94,690);
+},
+{
+name = top_right_can;
+pos = (333,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(124,0,l),
+(124,633,l),
+(365,633,l),
+(365,690,l),
+(63,690,l),
+(63,0,l)
+);
+}
+);
+width = 398;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+unicode = 5285;
+},
+{
+glyphname = "mii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (156,0);
+ref = dot_top;
+}
+);
+width = 398;
+}
+);
+note = uni14A6;
+unicode = 5286;
+},
+{
+glyphname = "mo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (154,345);
+},
+{
+name = top_center_can;
+pos = (185,690);
+},
+{
+name = top_double;
+pos = (305,690);
+},
+{
+name = top_left_can;
+pos = (64,690);
+},
+{
+name = top_right_can;
+pos = (304,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(335,0,l),
+(335,690,l),
+(274,690,l),
+(274,57,l),
+(33,57,l),
+(33,0,l)
+);
+}
+);
+width = 398;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+unicode = 5287;
+},
+{
+glyphname = "moo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (246,0);
+ref = dot_top;
+}
+);
+width = 398;
+}
+);
+note = uni14A8;
+unicode = 5288;
+},
+{
+glyphname = "ycreemoo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (117,0);
+ref = doubledot_top;
+}
+);
+width = 398;
+}
+);
+note = uni14A9;
+unicode = 5289;
+},
+{
+glyphname = "ma-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (245,345);
+},
+{
+name = top_center_can;
+pos = (213,690);
+},
+{
+name = top_left_can;
+pos = (94,690);
+},
+{
+name = top_right_can;
+pos = (333,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(365,0,l),
+(365,57,l),
+(124,57,l),
+(124,690,l),
+(63,690,l),
+(63,0,l)
+);
+}
+);
+width = 398;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+unicode = 5290;
+},
+{
+glyphname = "maa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (35,0);
+ref = dot_top;
+}
+);
+width = 398;
+}
+);
+note = uni14AB;
+unicode = 5291;
+},
+{
+glyphname = "mwe-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "me-canadian";
+}
+);
+width = 568;
+}
+);
+note = uni14AC;
+unicode = 5292;
+},
+{
+glyphname = "mweWestCree-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "me-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (398,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 568;
+}
+);
+note = uni14AD;
+unicode = 5293;
+},
+{
+glyphname = "mwi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "mi-canadian";
+}
+);
+width = 568;
+}
+);
+note = uni14AE;
+unicode = 5294;
+},
+{
+glyphname = "mwiWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (398,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 568;
+}
+);
+note = uni14AF;
+unicode = 5295;
+},
+{
+glyphname = "mwii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (325,0);
+ref = dot_top;
+}
+);
+width = 568;
+}
+);
+note = uni14B0;
+unicode = 5296;
+},
+{
+glyphname = "mwiiWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (156,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (398,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 568;
+}
+);
+note = uni14B1;
+unicode = 5297;
+},
+{
+glyphname = "mwo-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "mo-canadian";
+}
+);
+width = 568;
+}
+);
+note = uni14B2;
+unicode = 5298;
+},
+{
+glyphname = "mwoWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (398,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 568;
+}
+);
+note = uni14B3;
+unicode = 5299;
+},
+{
+glyphname = "mwoo-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (415,0);
+ref = dot_top;
+}
+);
+width = 568;
+}
+);
+note = uni14B4;
+unicode = 5300;
+},
+{
+glyphname = "mwooWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (246,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (398,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 568;
+}
+);
+note = uni14B5;
+unicode = 5301;
+},
+{
+glyphname = "mwa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ma-canadian";
+}
+);
+width = 568;
+}
+);
+note = uni14B6;
+unicode = 5302;
+},
+{
+glyphname = "mwaWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (398,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 568;
+}
+);
+note = uni14B7;
+unicode = 5303;
+},
+{
+glyphname = "mwaa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (205,0);
+ref = dot_top;
+}
+);
+width = 568;
+}
+);
+note = uni14B8;
+unicode = 5304;
+},
+{
+glyphname = "mwaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (35,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (398,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 568;
+}
+);
+note = uni14B9;
+unicode = 5305;
+},
+{
+glyphname = "mwaaNaskapi-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ma-canadian";
+}
+);
+width = 583;
+}
+);
+note = uni14BA;
+unicode = 5306;
+},
+{
+glyphname = "m-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(217,387,l),
+(94,387,l),
+(94,690,l),
+(50,690,l),
+(50,345,l),
+(217,345,l)
+);
+}
+);
+width = 245;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni14BB;
+unicode = 5307;
+},
+{
+glyphname = "mWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+ref = "t-canadian";
+}
+);
+width = 276;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "t-canadian";
+note = uni14BC;
+unicode = 5308;
+},
+{
+glyphname = "mh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(195,345,l),
+(195,690,l),
+(153,690,l),
+(153,387,l),
+(28,387,l),
+(28,345,l)
+);
+}
+);
+width = 245;
+}
+);
+metricLeft = "=|m-canadian";
+metricRight = "=|m-canadian";
+note = uni14BD;
+unicode = 5309;
+},
+{
+glyphname = "mAthapascan-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(230,345,l),
+(230,384,l),
+(99,384,l),
+(100,362,l),
+(180,480,ls),
+(212,527,o),
+(218,562,o),
+(218,596,cs),
+(218,655,o),
+(188,696,o),
+(134,696,cs),
+(76,696,o),
+(44,653,o),
+(44,578,c),
+(85,578,l),
+(85,639,o),
+(100,661,o),
+(133,661,cs),
+(163,661,o),
+(178,638,o),
+(178,596,cs),
+(178,567,o),
+(176,544,o),
+(143,494,cs),
+(56,366,l),
+(56,345,l)
+);
+}
+);
+width = 269;
+}
+);
+note = uni14BE;
+unicode = 5310;
+},
+{
+glyphname = "mSayisi-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = two.canadian;
+}
+);
+width = 435;
+}
+);
+note = uni14BF;
+unicode = 5311;
+},
+{
+glyphname = "ne-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (389,245);
+},
+{
+name = top_center_can;
+pos = (382,491);
+},
+{
+name = top_left_can;
+pos = (80,491);
+},
+{
+name = top_right_can;
+pos = (532,491);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(497,-13,o),
+(562,71,o),
+(562,231,cs),
+(562,390,o),
+(497,472,o),
+(382,472,cs),
+(49,472,l),
+(49,416,l),
+(301,416,l),
+(298,433,l),
+(244,401,o),
+(217,319,o),
+(217,228,cs),
+(217,71,o),
+(282,-13,o),
+(390,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(315,42,o),
+(278,102,o),
+(278,231,cs),
+(278,350,o),
+(316,418,o),
+(390,418,cs),
+(463,418,o),
+(502,358,o),
+(502,231,cs),
+(502,102,o),
+(465,42,o),
+(390,42,cs)
+);
+}
+);
+width = 615;
+}
+);
+metricRight = "=|ke-canadian";
+note = uni14C0;
+unicode = 5312;
+},
+{
+glyphname = "naai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (121,-199);
+ref = ring_top.canadian;
+}
+);
+width = 615;
+}
+);
+note = uni14C1;
+unicode = 5313;
+},
+{
+glyphname = "ni-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (227,245);
+},
+{
+name = top_center_can;
+pos = (235,491);
+},
+{
+name = top_left_can;
+pos = (84,491);
+},
+{
+name = top_right_can;
+pos = (535,491);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(333,-13,o),
+(398,71,o),
+(398,228,cs),
+(398,319,o),
+(371,401,o),
+(317,433,c),
+(314,416,l),
+(566,416,l),
+(566,472,l),
+(234,472,ls),
+(119,472,o),
+(53,389,o),
+(53,230,cs),
+(53,71,o),
+(119,-13,o),
+(225,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(151,42,o),
+(113,102,o),
+(113,231,cs),
+(113,359,o),
+(153,419,o),
+(225,419,cs),
+(299,419,o),
+(337,351,o),
+(337,231,cs),
+(337,102,o),
+(299,42,o),
+(225,42,cs)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+unicode = 5314;
+},
+{
+glyphname = "nii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (177,-199);
+ref = dot_top;
+}
+);
+width = 615;
+}
+);
+note = uni14C3;
+unicode = 5315;
+},
+{
+glyphname = "no-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (388,245);
+},
+{
+name = top_center_can;
+pos = (386,491);
+},
+{
+name = top_double;
+pos = (390,491);
+},
+{
+name = top_left_can;
+pos = (79,491);
+},
+{
+name = top_right_can;
+pos = (532,491);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(382,0,ls),
+(497,0,o),
+(562,82,o),
+(562,242,cs),
+(562,402,o),
+(497,485,o),
+(390,485,cs),
+(282,485,o),
+(217,402,o),
+(217,244,cs),
+(217,154,o),
+(244,71,o),
+(299,40,c),
+(301,57,l),
+(49,57,l),
+(49,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(316,53,o),
+(278,122,o),
+(278,242,cs),
+(278,370,o),
+(315,431,o),
+(390,431,cs),
+(465,431,o),
+(502,370,o),
+(502,242,cs),
+(502,113,o),
+(463,53,o),
+(390,53,cs)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14C4;
+unicode = 5316;
+},
+{
+glyphname = "noo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (327,-199);
+ref = dot_top;
+}
+);
+width = 615;
+}
+);
+note = uni14C5;
+unicode = 5317;
+},
+{
+glyphname = "ycreenoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (202,-199);
+ref = doubledot_top;
+}
+);
+width = 615;
+}
+);
+note = uni14C6;
+unicode = 5318;
+},
+{
+glyphname = "na-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (227,245);
+},
+{
+name = top_center_can;
+pos = (229,491);
+},
+{
+name = top_double;
+pos = (337,491);
+},
+{
+name = top_left_can;
+pos = (84,491);
+},
+{
+name = top_right_can;
+pos = (535,491);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(566,0,l),
+(566,56,l),
+(314,56,l),
+(316,40,l),
+(371,71,o),
+(398,154,o),
+(398,244,cs),
+(398,402,o),
+(333,485,o),
+(225,485,cs),
+(119,485,o),
+(53,402,o),
+(53,242,cs),
+(53,82,o),
+(119,0,o),
+(234,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(153,53,o),
+(113,113,o),
+(113,242,cs),
+(113,370,o),
+(151,431,o),
+(225,431,cs),
+(299,431,o),
+(337,370,o),
+(337,242,cs),
+(337,122,o),
+(299,53,o),
+(225,53,cs)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+unicode = 5319;
+},
+{
+glyphname = "naa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (170,-199);
+ref = dot_top;
+}
+);
+width = 615;
+}
+);
+note = uni14C8;
+unicode = 5320;
+},
+{
+glyphname = "nwe-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ne-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni14C9;
+unicode = 5321;
+},
+{
+glyphname = "nweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni14CA;
+unicode = 5322;
+},
+{
+glyphname = "nwa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "na-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni14CB;
+unicode = 5323;
+},
+{
+glyphname = "nwaWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni14CC;
+unicode = 5324;
+},
+{
+glyphname = "nwaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (339,-199);
+ref = dot_top;
+}
+);
+width = 784;
+}
+);
+note = uni14CD;
+unicode = 5325;
+},
+{
+glyphname = "nwaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (170,-199);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni14CE;
+unicode = 5326;
+},
+{
+glyphname = "nwaaNaskapi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (149,-199);
+ref = doubledot_top;
+}
+);
+width = 615;
+}
+);
+note = uni14CF;
+unicode = 5327;
+},
+{
+glyphname = "n-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(321,434,l),
+(321,476,l),
+(181,476,l),
+(182,457,l),
+(212,471,o),
+(225,517,o),
+(225,567,cs),
+(225,651,o),
+(188,696,o),
+(132,696,cs),
+(76,696,o),
+(40,650,o),
+(40,565,cs),
+(40,481,o),
+(75,434,o),
+(138,434,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(99,469,o),
+(79,499,o),
+(79,565,cs),
+(79,632,o),
+(99,660,o),
+(133,660,cs),
+(166,660,o),
+(185,631,o),
+(185,565,cs),
+(185,498,o),
+(165,469,o),
+(132,469,cs)
+);
+}
+);
+width = 349;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni14D0;
+unicode = 5328;
+},
+{
+color = 6;
+glyphname = "ngCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-161);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 318;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "=|";
+note = uni14D1;
+unicode = 5329;
+},
+{
+glyphname = "nh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(212,434,ls),
+(273,434,o),
+(309,481,o),
+(309,565,cs),
+(309,650,o),
+(272,696,o),
+(216,696,cs),
+(160,696,o),
+(125,651,o),
+(125,567,cs),
+(125,517,o),
+(137,471,o),
+(167,457,c),
+(169,476,l),
+(28,476,l),
+(28,434,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(185,469,o),
+(164,498,o),
+(164,565,cs),
+(164,631,o),
+(183,660,o),
+(216,660,cs),
+(249,660,o),
+(270,632,o),
+(270,565,cs),
+(270,499,o),
+(249,469,o),
+(216,469,cs)
+);
+}
+);
+width = 349;
+}
+);
+metricLeft = "=|n-canadian";
+metricRight = "=|n-canadian";
+note = uni14D2;
+unicode = 5330;
+},
+{
+glyphname = "le-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (388,245);
+},
+{
+name = top_center_can;
+pos = (383,491);
+},
+{
+name = top_left_can;
+pos = (80,491);
+},
+{
+name = top_right_can;
+pos = (532,491);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(353,0,ls),
+(485,0,o),
+(562,81,o),
+(562,236,cs),
+(562,390,o),
+(486,472,o),
+(351,472,cs),
+(49,472,l),
+(49,416,l),
+(350,416,ls),
+(448,416,o),
+(501,355,o),
+(501,235,cs),
+(501,116,o),
+(449,55,o),
+(348,55,cs),
+(340,55,l),
+(340,0,l)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D3;
+unicode = 5331;
+},
+{
+glyphname = "laai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (121,-199);
+ref = ring_top.canadian;
+}
+);
+width = 615;
+}
+);
+note = uni14D4;
+unicode = 5332;
+},
+{
+glyphname = "li-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (227,245);
+},
+{
+name = top_center_can;
+pos = (235,491);
+},
+{
+name = top_left_can;
+pos = (84,491);
+},
+{
+name = top_right_can;
+pos = (535,491);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(275,0,l),
+(275,55,l),
+(268,55,ls),
+(166,55,o),
+(114,116,o),
+(114,236,cs),
+(114,356,o),
+(167,416,o),
+(266,416,cs),
+(566,416,l),
+(566,472,l),
+(264,472,ls),
+(132,472,o),
+(53,390,o),
+(53,236,cs),
+(53,81,o),
+(130,0,o),
+(263,0,cs)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14D5;
+unicode = 5333;
+},
+{
+glyphname = "lii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (177,-199);
+ref = dot_top;
+}
+);
+width = 615;
+}
+);
+note = uni14D6;
+unicode = 5334;
+},
+{
+glyphname = "lo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (388,245);
+},
+{
+name = top_center_can;
+pos = (386,491);
+},
+{
+name = top_double;
+pos = (353,491);
+},
+{
+name = top_left_can;
+pos = (79,491);
+},
+{
+name = top_right_can;
+pos = (532,491);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(352,0,ls),
+(483,0,o),
+(562,82,o),
+(562,237,cs),
+(562,391,o),
+(485,472,o),
+(353,472,cs),
+(340,472,l),
+(340,417,l),
+(348,417,ls),
+(449,417,o),
+(501,356,o),
+(501,238,cs),
+(501,117,o),
+(448,56,o),
+(350,56,cs),
+(49,56,l),
+(49,0,l)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D7;
+unicode = 5335;
+},
+{
+glyphname = "loo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (327,-199);
+ref = dot_top;
+}
+);
+width = 615;
+}
+);
+note = uni14D8;
+unicode = 5336;
+},
+{
+glyphname = "ycreeloo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (164,-199);
+ref = doubledot_top;
+}
+);
+width = 615;
+}
+);
+note = uni14D9;
+unicode = 5337;
+},
+{
+glyphname = "la-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (227,245);
+},
+{
+name = top_center_can;
+pos = (229,491);
+},
+{
+name = top_left_can;
+pos = (84,491);
+},
+{
+name = top_right_can;
+pos = (535,491);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(566,0,l),
+(566,56,l),
+(266,56,ls),
+(166,56,o),
+(114,117,o),
+(114,238,cs),
+(114,356,o),
+(166,417,o),
+(268,417,cs),
+(275,417,l),
+(275,472,l),
+(263,472,ls),
+(130,472,o),
+(53,390,o),
+(53,237,cs),
+(53,82,o),
+(131,0,o),
+(264,0,cs)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14DA;
+unicode = 5338;
+},
+{
+glyphname = "laa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (170,-199);
+ref = dot_top;
+}
+);
+width = 615;
+}
+);
+note = uni14DB;
+unicode = 5339;
+},
+{
+glyphname = "lwe-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "le-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni14DC;
+unicode = 5340;
+},
+{
+glyphname = "lweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "le-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni14DD;
+unicode = 5341;
+},
+{
+glyphname = "lwi-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "li-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni14DE;
+unicode = 5342;
+},
+{
+glyphname = "lwiWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni14DF;
+unicode = 5343;
+},
+{
+glyphname = "lwii-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (346,-199);
+ref = dot_top;
+}
+);
+width = 784;
+}
+);
+note = uni14E0;
+unicode = 5344;
+},
+{
+glyphname = "lwiiWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (177,-199);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni14E1;
+unicode = 5345;
+},
+{
+glyphname = "lwo-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "lo-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni14E2;
+unicode = 5346;
+},
+{
+glyphname = "lwoWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni14E3;
+unicode = 5347;
+},
+{
+glyphname = "lwoo-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (497,-199);
+ref = dot_top;
+}
+);
+width = 784;
+}
+);
+note = uni14E4;
+unicode = 5348;
+},
+{
+glyphname = "lwooWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (327,-199);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni14E5;
+unicode = 5349;
+},
+{
+glyphname = "lwa-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "la-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni14E6;
+unicode = 5350;
+},
+{
+glyphname = "lwaWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni14E7;
+unicode = 5351;
+},
+{
+glyphname = "lwaa-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (339,-199);
+ref = dot_top;
+}
+);
+width = 784;
+}
+);
+note = uni14E8;
+unicode = 5352;
+},
+{
+glyphname = "lwaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (170,-199);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni14E9;
+unicode = 5353;
+},
+{
+glyphname = "l-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(321,345,l),
+(321,387,l),
+(208,387,ls),
+(129,387,o),
+(94,430,o),
+(94,517,cs),
+(94,601,o),
+(129,647,o),
+(197,647,cs),
+(201,647,l),
+(201,690,l),
+(195,690,ls),
+(101,690,o),
+(49,625,o),
+(49,517,cs),
+(49,408,o),
+(101,345,o),
+(204,345,cs)
+);
+}
+);
+width = 349;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "m-canadian";
+note = uni14EA;
+unicode = 5354;
+},
+{
+glyphname = "lWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(230,345,l),
+(230,376,l),
+(80,453,l),
+(80,432,l),
+(230,505,l),
+(230,528,l),
+(80,603,l),
+(80,581,l),
+(230,658,l),
+(230,690,l),
+(221,690,l),
+(50,602,l),
+(50,582,l),
+(201,508,l),
+(201,526,l),
+(50,452,l),
+(50,433,l),
+(221,345,l)
+);
+}
+);
+width = 280;
+}
+);
+metricRight = "=|";
+note = uni14EB;
+unicode = 5355;
+},
+{
+glyphname = "mediall-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(432,-13,l),
+(432,34,l),
+(110,199,l),
+(110,173,l),
+(432,329,l),
+(432,360,l),
+(110,517,l),
+(110,491,l),
+(432,656,l),
+(432,702,l),
+(415,702,l),
+(58,521,l),
+(58,491,l),
+(382,334,l),
+(382,355,l),
+(58,199,l),
+(58,169,l),
+(415,-13,l)
+);
+}
+);
+width = 490;
+}
+);
+metricRight = "=|";
+note = uni14EC;
+unicode = 5356;
+},
+{
+glyphname = "se-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (91,690);
+},
+{
+name = top_right_can;
+pos = (315,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(346,0,l),
+(346,315,l),
+(311,315,ls),
+(182,315,o),
+(122,375,o),
+(122,537,cs),
+(122,690,l),
+(61,690,l),
+(61,533,ls),
+(61,345,o),
+(144,259,o),
+(301,259,cs),
+(329,259,l),
+(285,282,l),
+(285,0,l)
+);
+}
+);
+width = 409;
+}
+);
+note = uni14ED;
+unicode = 5357;
+},
+{
+glyphname = "saai-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (204,0);
+ref = ring_top.canadian;
+}
+);
+width = 409;
+}
+);
+note = uni14EE;
+unicode = 5358;
+},
+{
+glyphname = "si-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (94,690);
+},
+{
+name = top_right_can;
+pos = (318,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(124,0,l),
+(124,282,l),
+(79,259,l),
+(107,259,ls),
+(265,259,o),
+(348,345,o),
+(348,533,cs),
+(348,690,l),
+(287,690,l),
+(287,537,ls),
+(287,375,o),
+(227,315,o),
+(98,315,cs),
+(63,315,l),
+(63,0,l)
+);
+}
+);
+width = 409;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+unicode = 5359;
+},
+{
+glyphname = "sii-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (259,0);
+ref = dot_top;
+}
+);
+width = 409;
+}
+);
+note = uni14F0;
+unicode = 5360;
+},
+{
+glyphname = "so-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (316,690);
+},
+{
+name = top_left_can;
+pos = (92,690);
+},
+{
+name = top_right_can;
+pos = (315,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(122,0,l),
+(122,153,ls),
+(122,315,o),
+(182,375,o),
+(311,375,cs),
+(346,375,l),
+(346,690,l),
+(285,690,l),
+(285,408,l),
+(329,431,l),
+(301,431,ls),
+(144,431,o),
+(61,345,o),
+(61,156,cs),
+(61,0,l)
+);
+}
+);
+width = 409;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+unicode = 5361;
+},
+{
+glyphname = "soo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (256,0);
+ref = dot_top;
+}
+);
+width = 409;
+}
+);
+note = uni14F2;
+unicode = 5362;
+},
+{
+glyphname = "ycreesoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (128,0);
+ref = doubledot_top;
+}
+);
+width = 409;
+}
+);
+note = uni14F3;
+unicode = 5363;
+},
+{
+glyphname = "sa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (94,690);
+},
+{
+name = top_right_can;
+pos = (318,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(348,0,l),
+(348,156,ls),
+(348,345,o),
+(265,431,o),
+(107,431,cs),
+(79,431,l),
+(124,408,l),
+(124,690,l),
+(63,690,l),
+(63,375,l),
+(98,375,ls),
+(227,375,o),
+(287,315,o),
+(287,153,cs),
+(287,0,l)
+);
+}
+);
+width = 409;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+unicode = 5364;
+},
+{
+glyphname = "saa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+}
+);
+width = 409;
+}
+);
+note = uni14F5;
+unicode = 5365;
+},
+{
+glyphname = "swe-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "se-canadian";
+}
+);
+width = 579;
+}
+);
+note = uni14F6;
+unicode = 5366;
+},
+{
+glyphname = "sweWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "se-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (409,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 579;
+}
+);
+note = uni14F7;
+unicode = 5367;
+},
+{
+glyphname = "swi-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "si-canadian";
+}
+);
+width = 579;
+}
+);
+note = uni14F8;
+unicode = 5368;
+},
+{
+glyphname = "swiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (409,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 579;
+}
+);
+note = uni14F9;
+unicode = 5369;
+},
+{
+glyphname = "swii-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (429,0);
+ref = dot_top;
+}
+);
+width = 579;
+}
+);
+note = uni14FA;
+unicode = 5370;
+},
+{
+glyphname = "swiiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (259,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (409,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 579;
+}
+);
+note = uni14FB;
+unicode = 5371;
+},
+{
+glyphname = "swo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "so-canadian";
+}
+);
+width = 579;
+}
+);
+note = uni14FC;
+unicode = 5372;
+},
+{
+glyphname = "swoWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (409,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 579;
+}
+);
+note = uni14FD;
+unicode = 5373;
+},
+{
+glyphname = "swoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (426,0);
+ref = dot_top;
+}
+);
+width = 579;
+}
+);
+note = uni14FE;
+unicode = 5374;
+},
+{
+glyphname = "swooWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (256,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (409,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 579;
+}
+);
+note = uni14FF;
+unicode = 5375;
+},
+{
+glyphname = "swa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "sa-canadian";
+}
+);
+width = 579;
+}
+);
+note = uni1500;
+unicode = 5376;
+},
+{
+glyphname = "swaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (409,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 579;
+}
+);
+note = uni1501;
+unicode = 5377;
+},
+{
+glyphname = "swaa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (205,0);
+ref = dot_top;
+}
+);
+width = 579;
+}
+);
+note = uni1502;
+unicode = 5378;
+},
+{
+glyphname = "swaaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (409,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 579;
+}
+);
+note = uni1503;
+unicode = 5379;
+},
+{
+glyphname = "swaaNaskapi-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "sa-canadian";
+}
+);
+width = 594;
+}
+);
+note = uni1504;
+unicode = 5380;
+},
+{
+glyphname = "s-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(216,345,l),
+(216,427,ls),
+(216,522,o),
+(172,569,o),
+(93,569,cs),
+(69,569,l),
+(94,548,l),
+(94,690,l),
+(50,690,l),
+(50,532,l),
+(83,532,ls),
+(145,532,o),
+(173,499,o),
+(173,424,cs),
+(173,345,l)
+);
+}
+);
+width = 266;
+}
+);
+metricRight = "=|";
+note = uni1505;
+unicode = 5381;
+},
+{
+color = 6;
+glyphname = "sAthapascan-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(206,177,o),
+(241,216,o),
+(241,268,cs),
+(241,312,o),
+(222,340,o),
+(178,361,cs),
+(136,382,ls),
+(103,398,o),
+(96,415,o),
+(96,442,cs),
+(96,475,o),
+(113,497,o),
+(148,497,cs),
+(182,497,o),
+(203,480,o),
+(201,429,c),
+(242,429,l),
+(243,493,o),
+(211,533,o),
+(147,533,cs),
+(89,533,o),
+(55,495,o),
+(55,442,cs),
+(55,398,o),
+(74,368,o),
+(115,349,cs),
+(157,328,ls),
+(188,313,o),
+(200,298,o),
+(200,267,cs),
+(200,232,o),
+(181,213,o),
+(147,213,cs),
+(111,213,o),
+(90,230,o),
+(91,284,c),
+(50,284,l),
+(48,214,o),
+(83,177,o),
+(146,177,cs)
+);
+}
+);
+width = 292;
+}
+);
+metricRight = "=|";
+note = uni1506;
+unicode = 5382;
+},
+{
+glyphname = "sw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(94,345,l),
+(94,424,ls),
+(94,499,o),
+(123,532,o),
+(185,532,cs),
+(216,532,l),
+(216,690,l),
+(173,690,l),
+(173,548,l),
+(198,569,l),
+(174,569,ls),
+(96,569,o),
+(50,522,o),
+(50,427,cs),
+(50,345,l)
+);
+}
+);
+width = 266;
+}
+);
+metricLeft = "=|s-canadian";
+metricRight = "=|s-canadian";
+note = uni1507;
+unicode = 5383;
+},
+{
+glyphname = "sBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(223,345,l),
+(223,387,l),
+(166,387,ls),
+(112,387,o),
+(94,411,o),
+(94,469,cs),
+(94,690,l),
+(50,690,l),
+(50,464,ls),
+(50,385,o),
+(84,345,o),
+(162,345,c)
+);
+}
+);
+width = 251;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "m-canadian";
+note = uni1508;
+unicode = 5384;
+},
+{
+glyphname = "moosecreesk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(198,217,o),
+(238,259,o),
+(238,365,cs),
+(238,504,o),
+(190,570,o),
+(83,570,cs),
+(74,570,l),
+(94,548,l),
+(94,690,l),
+(50,690,l),
+(50,533,l),
+(75,533,ls),
+(161,533,o),
+(187,491,o),
+(193,410,c),
+(206,400,l),
+(200,444,o),
+(173,478,o),
+(138,478,cs),
+(88,478,o),
+(51,433,o),
+(51,350,cs),
+(51,260,o),
+(94,217,o),
+(144,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(113,252,o),
+(91,282,o),
+(91,350,cs),
+(91,415,o),
+(113,444,o),
+(144,444,cs),
+(175,444,o),
+(197,414,o),
+(197,349,cs),
+(197,279,o),
+(177,252,o),
+(144,252,cs)
+);
+}
+);
+width = 288;
+}
+);
+metricRight = "=|";
+note = uni1509;
+unicode = 5385;
+},
+{
+glyphname = "skwNaskapi-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(195,217,o),
+(238,260,o),
+(238,350,cs),
+(238,433,o),
+(200,478,o),
+(150,478,cs),
+(116,478,o),
+(88,444,o),
+(82,400,c),
+(95,410,l),
+(101,491,o),
+(127,533,o),
+(213,533,cs),
+(238,533,l),
+(238,690,l),
+(194,690,l),
+(194,548,l),
+(214,570,l),
+(205,570,ls),
+(99,570,o),
+(50,504,o),
+(50,365,cs),
+(50,259,o),
+(90,217,o),
+(144,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(111,252,o),
+(91,279,o),
+(91,349,cs),
+(91,414,o),
+(113,444,o),
+(144,444,cs),
+(175,444,o),
+(197,415,o),
+(197,350,cs),
+(197,282,o),
+(176,252,o),
+(144,252,cs)
+);
+}
+);
+width = 288;
+}
+);
+metricLeft = "=|moosecreesk-canadian";
+metricRight = "=|moosecreesk-canadian";
+note = uni150A;
+unicode = 5386;
+},
+{
+glyphname = "swNaskapi-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(235,178,l),
+(235,254,ls),
+(235,347,o),
+(190,397,o),
+(112,397,cs),
+(87,397,l),
+(109,376,l),
+(109,513,l),
+(67,513,l),
+(67,360,l),
+(104,360,ls),
+(163,360,o),
+(192,327,o),
+(192,251,cs),
+(192,178,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(237,63,o),
+(255,81,o),
+(255,103,cs),
+(255,127,o),
+(236,145,o),
+(214,145,cs),
+(192,145,o),
+(174,127,o),
+(174,103,cs),
+(174,81,o),
+(192,63,o),
+(214,63,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(110,545,o),
+(128,563,o),
+(128,585,cs),
+(128,609,o),
+(110,627,o),
+(88,627,cs),
+(66,627,o),
+(47,609,o),
+(47,585,cs),
+(47,563,o),
+(66,545,o),
+(88,545,cs)
+);
+}
+);
+width = 302;
+}
+);
+metricRight = "=|";
+note = uni150B;
+unicode = 5387;
+},
+{
+glyphname = "spwaNaskapi-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(453,0,l),
+(453,56,l),
+(83,360,l),
+(83,329,l),
+(453,634,l),
+(453,690,l),
+(436,690,l),
+(30,357,l),
+(30,332,l),
+(436,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(128,494,o),
+(147,511,o),
+(147,534,cs),
+(147,557,o),
+(128,576,o),
+(105,576,cs),
+(84,576,o),
+(65,557,o),
+(65,534,cs),
+(65,511,o),
+(84,494,o),
+(105,494,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(263,598,l),
+(263,658,ls),
+(263,722,o),
+(234,756,o),
+(172,756,cs),
+(152,756,l),
+(182,738,l),
+(182,836,l),
+(141,836,l),
+(141,722,l),
+(163,722,ls),
+(203,722,o),
+(222,702,o),
+(222,653,cs),
+(222,598,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(384,699,o),
+(404,718,o),
+(404,741,cs),
+(404,764,o),
+(384,782,o),
+(362,782,cs),
+(341,782,o),
+(322,764,o),
+(322,741,cs),
+(322,718,o),
+(341,699,o),
+(362,699,cs)
+);
+}
+);
+width = 495;
+}
+);
+metricRight = "pa-canadian";
+metricWidth = "pa-canadian";
+note = uni150C;
+unicode = 5388;
+},
+{
+glyphname = "stwaNaskapi-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (301,0);
+ref = "ta-canadian";
+}
+);
+width = 754;
+}
+);
+note = uni150D;
+unicode = 5389;
+},
+{
+glyphname = "skwaNaskapi-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (301,0);
+ref = "ka-canadian";
+}
+);
+width = 752;
+}
+);
+note = uni150E;
+unicode = 5390;
+},
+{
+glyphname = "scwaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (301,0);
+ref = "ca-canadian";
+}
+);
+width = 748;
+}
+);
+note = uni150F;
+unicode = 5391;
+},
+{
+glyphname = "she-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (219,690);
+},
+{
+name = top_right_can;
+pos = (519,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(583,-13,o),
+(644,65,o),
+(644,218,cs),
+(644,298,l),
+(582,298,l),
+(582,209,ls),
+(582,95,o),
+(548,43,o),
+(487,43,cs),
+(420,43,o),
+(392,94,o),
+(385,218,cs),
+(374,470,ls),
+(367,625,o),
+(322,702,o),
+(215,702,cs),
+(116,702,o),
+(56,626,o),
+(56,471,cs),
+(56,391,l),
+(117,391,l),
+(117,481,ls),
+(117,596,o),
+(152,647,o),
+(213,647,cs),
+(279,647,o),
+(307,596,o),
+(314,471,cs),
+(326,219,ls),
+(332,65,o),
+(379,-13,o),
+(484,-13,cs)
+);
+}
+);
+width = 700;
+}
+);
+metricRight = "=|";
+note = uni1510;
+unicode = 5392;
+},
+{
+glyphname = "shi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (184,690);
+},
+{
+name = top_right_can;
+pos = (483,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(322,-13,o),
+(367,65,o),
+(374,219,cs),
+(385,471,ls),
+(392,596,o),
+(420,647,o),
+(487,647,cs),
+(548,647,o),
+(582,596,o),
+(582,481,cs),
+(582,391,l),
+(644,391,l),
+(644,471,ls),
+(644,626,o),
+(583,702,o),
+(484,702,cs),
+(378,702,o),
+(332,625,o),
+(326,470,cs),
+(314,218,ls),
+(308,94,o),
+(279,43,o),
+(213,43,cs),
+(152,43,o),
+(117,95,o),
+(117,209,cs),
+(117,298,l),
+(56,298,l),
+(56,218,ls),
+(56,65,o),
+(117,-13,o),
+(215,-13,cs)
+);
+}
+);
+width = 700;
+}
+);
+metricLeft = "she-canadian";
+metricRight = "she-canadian";
+note = uni1511;
+unicode = 5393;
+},
+{
+glyphname = "shii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (424,0);
+ref = dot_top;
+}
+);
+width = 699;
+}
+);
+note = uni1512;
+unicode = 5394;
+},
+{
+glyphname = "sho-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (355,491);
+},
+{
+name = top_left_can;
+pos = (216,491);
+},
+{
+name = top_right_can;
+pos = (496,491);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(273,43,l),
+(165,42,o),
+(114,89,o),
+(114,174,cs),
+(114,242,o),
+(146,287,o),
+(208,287,cs),
+(304,287,o),
+(389,129,o),
+(513,129,cs),
+(605,129,o),
+(659,197,o),
+(659,297,cs),
+(659,416,o),
+(580,486,o),
+(440,485,c),
+(439,430,l),
+(548,431,o),
+(599,384,o),
+(599,298,cs),
+(599,231,o),
+(566,185,o),
+(504,185,cs),
+(408,185,o),
+(323,343,o),
+(200,343,cs),
+(108,343,o),
+(53,276,o),
+(53,176,cs),
+(53,57,o),
+(132,-14,o),
+(271,-13,c)
+);
+}
+);
+width = 712;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1513;
+unicode = 5395;
+},
+{
+glyphname = "shoo-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (298,-199);
+ref = dot_top;
+}
+);
+width = 712;
+}
+);
+note = uni1514;
+unicode = 5396;
+},
+{
+glyphname = "sha-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (356,491);
+},
+{
+name = top_left_can;
+pos = (215,491);
+},
+{
+name = top_right_can;
+pos = (497,491);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(580,-14,o),
+(659,57,o),
+(659,176,cs),
+(659,276,o),
+(605,343,o),
+(513,343,cs),
+(389,343,o),
+(304,185,o),
+(208,185,cs),
+(146,185,o),
+(114,231,o),
+(114,298,cs),
+(114,384,o),
+(165,431,o),
+(273,430,c),
+(271,485,l),
+(132,486,o),
+(53,416,o),
+(53,297,cs),
+(53,197,o),
+(108,129,o),
+(200,129,cs),
+(323,129,o),
+(408,287,o),
+(504,287,cs),
+(566,287,o),
+(599,242,o),
+(599,174,cs),
+(599,89,o),
+(548,42,o),
+(439,43,c),
+(440,-13,l)
+);
+}
+);
+width = 712;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1515;
+unicode = 5397;
+},
+{
+glyphname = "shaa-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (298,-199);
+ref = dot_top;
+}
+);
+width = 712;
+}
+);
+note = uni1516;
+unicode = 5398;
+},
+{
+glyphname = "shwe-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "she-canadian";
+}
+);
+width = 869;
+}
+);
+note = uni1517;
+unicode = 5399;
+},
+{
+glyphname = "shweWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "she-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (699,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 869;
+}
+);
+note = uni1518;
+unicode = 5400;
+},
+{
+glyphname = "shwi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "shi-canadian";
+}
+);
+width = 869;
+}
+);
+note = uni1519;
+unicode = 5401;
+},
+{
+glyphname = "shwiWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (699,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 869;
+}
+);
+note = uni151A;
+unicode = 5402;
+},
+{
+glyphname = "shwii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (593,0);
+ref = dot_top;
+}
+);
+width = 869;
+}
+);
+note = uni151B;
+unicode = 5403;
+},
+{
+glyphname = "shwiiWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (424,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (699,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 869;
+}
+);
+note = uni151C;
+unicode = 5404;
+},
+{
+glyphname = "shwo-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "sho-canadian";
+}
+);
+width = 882;
+}
+);
+note = uni151D;
+unicode = 5405;
+},
+{
+glyphname = "shwoWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (712,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 882;
+}
+);
+note = uni151E;
+unicode = 5406;
+},
+{
+glyphname = "shwoo-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (467,-199);
+ref = dot_top;
+}
+);
+width = 882;
+}
+);
+note = uni151F;
+unicode = 5407;
+},
+{
+glyphname = "shwooWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (298,-199);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (712,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 882;
+}
+);
+note = uni1520;
+unicode = 5408;
+},
+{
+glyphname = "shwa-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "sha-canadian";
+}
+);
+width = 882;
+}
+);
+note = uni1521;
+unicode = 5409;
+},
+{
+glyphname = "shwaWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (712,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 882;
+}
+);
+note = uni1522;
+unicode = 5410;
+},
+{
+glyphname = "shwaa-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (468,-199);
+ref = dot_top;
+}
+);
+width = 882;
+}
+);
+note = uni1523;
+unicode = 5411;
+},
+{
+glyphname = "shwaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (298,-199);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (712,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 882;
+}
+);
+note = uni1524;
+unicode = 5412;
+},
+{
+glyphname = "sh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(428,291,o),
+(493,344,o),
+(493,434,cs),
+(493,515,o),
+(446,562,o),
+(379,562,cs),
+(292,562,o),
+(237,469,o),
+(168,469,cs),
+(122,469,o),
+(94,497,o),
+(94,554,cs),
+(94,616,o),
+(138,656,o),
+(224,656,c),
+(223,697,l),
+(114,697,o),
+(49,643,o),
+(49,554,cs),
+(49,472,o),
+(97,425,o),
+(163,425,cs),
+(250,425,o),
+(305,519,o),
+(374,519,cs),
+(420,519,o),
+(449,491,o),
+(449,433,cs),
+(449,371,o),
+(404,331,o),
+(318,331,c),
+(320,291,l)
+);
+}
+);
+width = 542;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni1525;
+unicode = 5413;
+},
+{
+glyphname = "ye-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (453,345);
+},
+{
+name = top_left_can;
+pos = (71,690);
+},
+{
+name = top_right_can;
+pos = (344,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(374,0,l),
+(374,310,l),
+(112,310,l),
+(116,290,l),
+(388,668,l),
+(343,701,l),
+(40,280,l),
+(40,255,l),
+(312,255,l),
+(312,0,l)
+);
+}
+);
+width = 433;
+}
+);
+note = uni1526;
+unicode = 5414;
+},
+{
+glyphname = "yaai-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-24,0);
+ref = ring_top.canadian;
+}
+);
+width = 433;
+}
+);
+note = uni1527;
+unicode = 5415;
+},
+{
+glyphname = "yi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (91,690);
+},
+{
+name = top_right_can;
+pos = (363,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,0,l),
+(121,255,l),
+(393,255,l),
+(393,280,l),
+(90,701,l),
+(44,668,l),
+(318,290,l),
+(322,310,l),
+(60,310,l),
+(60,0,l)
+);
+}
+);
+width = 433;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni1528;
+unicode = 5416;
+},
+{
+glyphname = "yii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (32,0);
+ref = dot_top;
+}
+);
+width = 433;
+}
+);
+note = uni1529;
+unicode = 5417;
+},
+{
+glyphname = "yo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (453,345);
+},
+{
+name = top_double;
+pos = (344,690);
+},
+{
+name = top_left_can;
+pos = (71,690);
+},
+{
+name = top_right_can;
+pos = (344,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(388,22,l),
+(116,400,l),
+(112,380,l),
+(374,380,l),
+(374,690,l),
+(312,690,l),
+(312,435,l),
+(40,435,l),
+(40,410,l),
+(343,-12,l)
+);
+}
+);
+width = 433;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152A;
+unicode = 5418;
+},
+{
+glyphname = "yoo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (285,0);
+ref = dot_top;
+}
+);
+width = 433;
+}
+);
+note = uni152B;
+unicode = 5419;
+},
+{
+glyphname = "ycreeyoo-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (156,0);
+ref = doubledot_top;
+}
+);
+width = 433;
+}
+);
+note = uni152C;
+unicode = 5420;
+},
+{
+glyphname = "ya-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (91,690);
+},
+{
+name = top_right_can;
+pos = (363,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(393,410,l),
+(393,435,l),
+(121,435,l),
+(121,690,l),
+(60,690,l),
+(60,380,l),
+(322,380,l),
+(318,400,l),
+(45,22,l),
+(90,-12,l)
+);
+}
+);
+width = 433;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152D;
+unicode = 5421;
+},
+{
+glyphname = "yaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (32,0);
+ref = dot_top;
+}
+);
+width = 433;
+}
+);
+note = uni152E;
+unicode = 5422;
+},
+{
+glyphname = "ywe-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ye-canadian";
+}
+);
+width = 602;
+}
+);
+note = uni152F;
+unicode = 5423;
+},
+{
+glyphname = "yweWestCree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ye-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (433,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 602;
+}
+);
+note = uni1530;
+unicode = 5424;
+},
+{
+glyphname = "ywi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "yi-canadian";
+}
+);
+width = 602;
+}
+);
+note = uni1531;
+unicode = 5425;
+},
+{
+glyphname = "ywiWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (433,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 602;
+}
+);
+note = uni1532;
+unicode = 5426;
+},
+{
+glyphname = "ywii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (201,0);
+ref = dot_top;
+}
+);
+width = 602;
+}
+);
+note = uni1533;
+unicode = 5427;
+},
+{
+glyphname = "ywiiWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (32,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (433,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 602;
+}
+);
+note = uni1534;
+unicode = 5428;
+},
+{
+glyphname = "ywo-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "yo-canadian";
+}
+);
+width = 602;
+}
+);
+note = uni1535;
+unicode = 5429;
+},
+{
+glyphname = "ywoWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (433,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 602;
+}
+);
+note = uni1536;
+unicode = 5430;
+},
+{
+glyphname = "ywoo-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (454,0);
+ref = dot_top;
+}
+);
+width = 602;
+}
+);
+note = uni1537;
+unicode = 5431;
+},
+{
+glyphname = "ywooWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (285,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (433,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 602;
+}
+);
+note = uni1538;
+unicode = 5432;
+},
+{
+glyphname = "ywa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ya-canadian";
+}
+);
+width = 602;
+}
+);
+note = uni1539;
+unicode = 5433;
+},
+{
+glyphname = "ywaWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (433,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 602;
+}
+);
+note = uni153A;
+unicode = 5434;
+},
+{
+glyphname = "ywaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (201,0);
+ref = dot_top;
+}
+);
+width = 602;
+}
+);
+note = uni153B;
+unicode = 5435;
+},
+{
+glyphname = "ywaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (32,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (433,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 602;
+}
+);
+note = uni153C;
+unicode = 5436;
+},
+{
+glyphname = "ywaaNaskapi-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ya-canadian";
+}
+);
+width = 618;
+}
+);
+note = uni153D;
+unicode = 5437;
+},
+{
+glyphname = "y-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(232,546,l),
+(232,562,l),
+(98,562,l),
+(98,690,l),
+(54,690,l),
+(54,524,l),
+(187,524,l),
+(186,550,l),
+(50,359,l),
+(83,337,l)
+);
+}
+);
+width = 259;
+}
+);
+note = uni153E;
+unicode = 5438;
+},
+{
+glyphname = "biblecreey-canadian";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(131,639,l),
+(109,639,l),
+(182,345,l),
+(207,345,l),
+(279,639,l),
+(257,639,l),
+(309,345,l),
+(348,345,l),
+(348,357,l),
+(288,690,l),
+(255,690,l),
+(181,392,l),
+(208,392,l),
+(132,690,l),
+(100,690,l),
+(41,357,l),
+(41,345,l),
+(79,345,l)
+);
+}
+);
+width = 389;
+}
+);
+metricRight = "=|";
+note = uni153F;
+unicode = 5439;
+},
+{
+glyphname = "yWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(193,201,l),
+(193,323,l),
+(293,323,l),
+(293,365,l),
+(193,365,l),
+(193,484,l),
+(152,484,l),
+(152,365,l),
+(50,365,l),
+(50,323,l),
+(152,323,l),
+(152,201,l)
+);
+}
+);
+width = 343;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1540;
+unicode = 5440;
+},
+{
+glyphname = "yiSayisi-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,183);
+ref = "fullstop-canadian";
+}
+);
+width = 281;
+}
+);
+metricLeft = "fullstop-canadian";
+metricWidth = "fullstop-canadian";
+note = uni1541;
+unicode = 5441;
+},
+{
+glyphname = "re-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (229,491);
+},
+{
+name = top_left_can;
+pos = (92,491);
+},
+{
+name = top_right_can;
+pos = (568,491);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(338,-13,o),
+(396,69,o),
+(396,207,cs),
+(396,416,l),
+(599,416,l),
+(599,472,l),
+(336,472,l),
+(336,198,ls),
+(336,95,o),
+(300,43,o),
+(229,43,cs),
+(157,43,o),
+(122,96,o),
+(122,198,cs),
+(122,472,l),
+(61,472,l),
+(61,207,ls),
+(61,66,o),
+(122,-13,o),
+(229,-13,cs)
+);
+}
+);
+width = 648;
+}
+);
+metricRight = "=|ne-canadian";
+note = uni1542;
+unicode = 5442;
+},
+{
+glyphname = "reRCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (419,491);
+},
+{
+name = top_left_can;
+pos = (80,491);
+},
+{
+name = top_right_can;
+pos = (557,491);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(527,-13,o),
+(588,66,o),
+(588,207,cs),
+(588,472,l),
+(526,472,l),
+(526,198,ls),
+(526,96,o),
+(491,43,o),
+(419,43,cs),
+(348,43,o),
+(312,95,o),
+(312,198,cs),
+(312,472,l),
+(49,472,l),
+(49,416,l),
+(252,416,l),
+(252,207,ls),
+(252,69,o),
+(310,-13,o),
+(419,-13,cs)
+);
+}
+);
+width = 649;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1543;
+unicode = 5443;
+},
+{
+glyphname = "leWestCree-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (419,491);
+},
+{
+name = top_left_can;
+pos = (80,491);
+},
+{
+name = top_right_can;
+pos = (557,491);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(312,0,l),
+(312,274,ls),
+(312,378,o),
+(348,430,o),
+(419,430,cs),
+(491,430,o),
+(526,377,o),
+(526,274,cs),
+(526,0,l),
+(588,0,l),
+(588,266,ls),
+(588,407,o),
+(527,485,o),
+(419,485,cs),
+(310,485,o),
+(252,404,o),
+(252,266,cs),
+(252,57,l),
+(49,57,l),
+(49,0,l)
+);
+}
+);
+width = 649;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+unicode = 5444;
+},
+{
+glyphname = "raai-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (115,-199);
+ref = ring_top.canadian;
+}
+);
+width = 648;
+}
+);
+note = uni1545;
+unicode = 5445;
+},
+{
+glyphname = "ri-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (229,491);
+},
+{
+name = top_left_can;
+pos = (92,491);
+},
+{
+name = top_right_can;
+pos = (568,491);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(122,0,l),
+(122,274,ls),
+(122,377,o),
+(157,430,o),
+(230,430,cs),
+(300,430,o),
+(336,378,o),
+(336,274,cs),
+(336,0,l),
+(599,0,l),
+(599,57,l),
+(396,57,l),
+(396,266,ls),
+(396,404,o),
+(338,485,o),
+(229,485,cs),
+(122,485,o),
+(61,407,o),
+(61,266,cs),
+(61,0,l)
+);
+}
+);
+width = 648;
+}
+);
+metricLeft = "re-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+unicode = 5446;
+},
+{
+glyphname = "rii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (170,-199);
+ref = dot_top;
+}
+);
+width = 648;
+}
+);
+note = uni1547;
+unicode = 5447;
+},
+{
+glyphname = "ro-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (179,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(124,0,l),
+(124,276,l),
+(109,256,l),
+(167,256,ls),
+(287,256,o),
+(362,342,o),
+(362,471,cs),
+(362,604,o),
+(292,690,o),
+(158,690,cs),
+(63,690,l),
+(63,634,l),
+(152,634,ls),
+(251,634,o),
+(300,571,o),
+(300,471,cs),
+(300,374,o),
+(250,311,o),
+(152,311,cs),
+(63,311,l),
+(63,0,l)
+);
+}
+);
+width = 410;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1548;
+unicode = 5448;
+},
+{
+glyphname = "roo-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (121,0);
+ref = dot_top;
+}
+);
+width = 410;
+}
+);
+note = uni1549;
+unicode = 5449;
+},
+{
+glyphname = "loWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (196,690);
+},
+{
+name = top_left_can;
+pos = (94,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(158,0,ls),
+(292,0,o),
+(362,86,o),
+(362,218,cs),
+(362,348,o),
+(287,435,o),
+(167,435,cs),
+(109,435,l),
+(124,413,l),
+(124,690,l),
+(63,690,l),
+(63,380,l),
+(152,380,ls),
+(250,380,o),
+(300,316,o),
+(300,218,cs),
+(300,120,o),
+(251,56,o),
+(152,56,cs),
+(63,56,l),
+(63,0,l)
+);
+}
+);
+width = 410;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+unicode = 5450;
+},
+{
+glyphname = "ra-canadian";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (230,690);
+},
+{
+name = top_right_can;
+pos = (317,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(348,0,l),
+(348,311,l),
+(258,311,ls),
+(159,311,o),
+(109,374,o),
+(109,471,cs),
+(109,571,o),
+(158,634,o),
+(259,634,cs),
+(348,634,l),
+(348,690,l),
+(252,690,ls),
+(118,690,o),
+(48,604,o),
+(48,471,cs),
+(48,342,o),
+(123,256,o),
+(243,256,cs),
+(300,256,l),
+(286,276,l),
+(286,0,l)
+);
+}
+);
+width = 411;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+unicode = 5451;
+},
+{
+glyphname = "raa-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (172,0);
+ref = dot_top;
+}
+);
+width = 410;
+}
+);
+note = uni154C;
+unicode = 5452;
+},
+{
+glyphname = "laWestCree-canadian";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (317,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(348,0,l),
+(348,56,l),
+(259,56,ls),
+(158,56,o),
+(109,120,o),
+(109,218,cs),
+(109,316,o),
+(159,380,o),
+(258,380,cs),
+(348,380,l),
+(348,690,l),
+(286,690,l),
+(286,413,l),
+(300,435,l),
+(243,435,ls),
+(123,435,o),
+(48,348,o),
+(48,218,cs),
+(48,86,o),
+(118,0,o),
+(252,0,cs)
+);
+}
+);
+width = 411;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+unicode = 5453;
+},
+{
+glyphname = "rwaa-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (341,0);
+ref = dot_top;
+}
+);
+width = 580;
+}
+);
+note = uni154E;
+unicode = 5454;
+},
+{
+glyphname = "rwaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (172,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (410,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 580;
+}
+);
+note = uni154F;
+unicode = 5455;
+},
+{
+glyphname = "r-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(192,345,l),
+(192,507,l),
+(154,507,ls),
+(108,507,o),
+(82,530,o),
+(82,580,cs),
+(82,629,o),
+(110,652,o),
+(155,652,cs),
+(192,652,l),
+(192,690,l),
+(155,690,ls),
+(83,690,o),
+(40,651,o),
+(40,580,cs),
+(40,511,o),
+(81,470,o),
+(149,470,cs),
+(175,470,l),
+(148,486,l),
+(148,345,l)
+);
+}
+);
+width = 242;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni1550;
+unicode = 5456;
+},
+{
+glyphname = "rWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(60,345,l),
+(230,433,l),
+(230,452,l),
+(80,526,l),
+(80,508,l),
+(230,582,l),
+(230,602,l),
+(60,690,l),
+(50,690,l),
+(50,658,l),
+(201,581,l),
+(201,603,l),
+(50,528,l),
+(50,505,l),
+(201,432,l),
+(201,453,l),
+(50,376,l),
+(50,345,l)
+);
+}
+);
+width = 280;
+}
+);
+metricLeft = "=|lWestCree-canadian";
+metricRight = "=|lWestCree-canadian";
+note = uni1551;
+unicode = 5457;
+},
+{
+glyphname = "rMedial-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(75,-13,l),
+(446,169,l),
+(446,197,l),
+(115,354,l),
+(115,336,l),
+(446,493,l),
+(446,521,l),
+(75,702,l),
+(58,702,l),
+(58,657,l),
+(394,492,l),
+(394,519,l),
+(58,362,l),
+(58,327,l),
+(394,171,l),
+(394,198,l),
+(58,33,l),
+(58,-13,l)
+);
+}
+);
+width = 504;
+}
+);
+metricLeft = "mediall-canadian";
+metricRight = "mediall-canadian";
+note = uni1552;
+unicode = 5458;
+},
+{
+glyphname = "fe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(295,0,l),
+(550,670,l),
+(550,690,l),
+(501,690,l),
+(272,70,l),
+(289,70,l),
+(175,360,l),
+(150,353,l),
+(169,330,o),
+(190,322,o),
+(216,322,cs),
+(287,322,o),
+(336,394,o),
+(336,512,cs),
+(336,632,o),
+(292,702,o),
+(212,702,cs),
+(131,702,o),
+(87,632,o),
+(87,523,cs),
+(87,466,o),
+(99,412,o),
+(121,358,cs),
+(270,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(161,366,o),
+(136,425,o),
+(136,522,cs),
+(136,611,o),
+(163,656,o),
+(212,656,cs),
+(260,656,o),
+(287,611,o),
+(287,511,cs),
+(287,412,o),
+(260,366,o),
+(213,366,cs)
+);
+}
+);
+width = 577;
+}
+);
+metricRight = "e-canadian";
+note = uni1553;
+unicode = 5459;
+},
+{
+glyphname = "faai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (170,0);
+ref = ring_top.canadian;
+}
+);
+width = 577;
+}
+);
+note = uni1554;
+unicode = 5460;
+},
+{
+glyphname = "fi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (285,690);
+},
+{
+name = top_left_can;
+pos = (111,690);
+},
+{
+name = top_right_can;
+pos = (480,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(292,-13,o),
+(336,58,o),
+(336,178,cs),
+(336,296,o),
+(287,368,o),
+(216,368,cs),
+(190,368,o),
+(169,359,o),
+(150,337,c),
+(175,329,l),
+(289,620,l),
+(272,620,l),
+(501,0,l),
+(550,0,l),
+(550,19,l),
+(295,690,l),
+(270,690,l),
+(121,331,ls),
+(99,277,o),
+(87,224,o),
+(87,167,cs),
+(87,58,o),
+(131,-13,o),
+(212,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(163,34,o),
+(136,78,o),
+(136,168,cs),
+(136,265,o),
+(161,324,o),
+(213,324,cs),
+(260,324,o),
+(287,278,o),
+(287,179,cs),
+(287,78,o),
+(260,34,o),
+(212,34,cs)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "fe-canadian";
+metricRight = "e-canadian";
+note = uni1555;
+unicode = 5461;
+},
+{
+glyphname = "fii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (226,0);
+ref = dot_top;
+}
+);
+width = 577;
+}
+);
+note = uni1556;
+unicode = 5462;
+},
+{
+glyphname = "fo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (168,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(89,0,l),
+(489,332,l),
+(489,357,l),
+(258,655,ls),
+(233,688,o),
+(201,702,o),
+(166,702,cs),
+(88,702,o),
+(45,632,o),
+(45,510,cs),
+(45,394,o),
+(92,320,o),
+(168,320,cs),
+(242,320,o),
+(288,394,o),
+(288,510,cs),
+(288,561,o),
+(276,602,o),
+(265,628,c),
+(246,591,l),
+(442,340,l),
+(442,360,l),
+(71,52,l),
+(71,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(121,366,o),
+(95,411,o),
+(95,511,cs),
+(95,611,o),
+(121,656,o),
+(168,656,cs),
+(216,656,o),
+(242,611,o),
+(242,511,cs),
+(242,412,o),
+(216,366,o),
+(168,366,cs)
+);
+}
+);
+width = 520;
+}
+);
+metricRight = "o-canadian";
+note = uni1557;
+unicode = 5463;
+},
+{
+glyphname = "foo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "fo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (110,0);
+ref = dot_top;
+}
+);
+width = 520;
+}
+);
+note = uni1558;
+unicode = 5464;
+},
+{
+glyphname = "fa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (352,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(448,0,l),
+(448,52,l),
+(77,360,l),
+(77,340,l),
+(273,591,l),
+(254,628,l),
+(242,602,o),
+(231,561,o),
+(231,510,cs),
+(231,394,o),
+(276,320,o),
+(352,320,cs),
+(428,320,o),
+(474,394,o),
+(474,510,cs),
+(474,632,o),
+(432,702,o),
+(353,702,cs),
+(319,702,o),
+(287,688,o),
+(261,655,cs),
+(30,357,l),
+(30,332,l),
+(430,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(303,366,o),
+(277,412,o),
+(277,511,cs),
+(277,611,o),
+(303,656,o),
+(351,656,cs),
+(399,656,o),
+(425,611,o),
+(425,511,cs),
+(425,411,o),
+(399,366,o),
+(351,366,cs)
+);
+}
+);
+width = 519;
+}
+);
+metricRight = "=|fo-canadian";
+note = uni1559;
+unicode = 5465;
+},
+{
+glyphname = "faa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (293,0);
+ref = dot_top;
+}
+);
+width = 520;
+}
+);
+note = uni155A;
+unicode = 5466;
+},
+{
+glyphname = "fwaa-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (463,0);
+ref = dot_top;
+}
+);
+width = 689;
+}
+);
+note = uni155B;
+unicode = 5467;
+},
+{
+glyphname = "fwaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (293,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (520,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 689;
+}
+);
+note = uni155C;
+unicode = 5468;
+},
+{
+glyphname = "f-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(249,345,l),
+(249,376,l),
+(71,526,l),
+(71,518,l),
+(159,629,l),
+(153,658,l),
+(147,643,o),
+(142,624,o),
+(142,597,cs),
+(142,533,o),
+(167,504,o),
+(202,504,cs),
+(239,504,o),
+(262,535,o),
+(262,600,cs),
+(262,668,o),
+(237,696,o),
+(201,696,cs),
+(185,696,o),
+(169,688,o),
+(154,668,cs),
+(41,526,l),
+(41,509,l),
+(239,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(181,531,o),
+(169,552,o),
+(169,599,cs),
+(169,644,o),
+(181,668,o),
+(201,668,cs),
+(222,668,o),
+(234,649,o),
+(234,599,cs),
+(234,551,o),
+(223,531,o),
+(202,531,cs)
+);
+}
+);
+width = 308;
+}
+);
+note = uni155D;
+unicode = 5469;
+},
+{
+glyphname = "the-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (582,345);
+},
+{
+name = top_center_can;
+pos = (275,690);
+},
+{
+name = top_left_can;
+pos = (90,690);
+},
+{
+name = top_right_can;
+pos = (461,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(412,-13,o),
+(493,71,o),
+(493,237,cs),
+(493,690,l),
+(431,690,l),
+(431,235,ls),
+(431,103,o),
+(376,45,o),
+(275,45,cs),
+(178,45,o),
+(120,107,o),
+(120,238,cs),
+(120,430,l),
+(91,416,l),
+(100,359,o),
+(138,320,o),
+(185,320,cs),
+(259,320,o),
+(306,392,o),
+(306,511,cs),
+(306,630,o),
+(263,702,o),
+(184,702,cs),
+(102,702,o),
+(59,631,o),
+(59,497,cs),
+(59,248,ls),
+(59,74,o),
+(140,-13,o),
+(275,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(137,366,o),
+(109,412,o),
+(109,511,cs),
+(109,611,o),
+(135,656,o),
+(183,656,cs),
+(230,656,o),
+(256,611,o),
+(256,512,cs),
+(256,412,o),
+(231,366,o),
+(185,366,cs)
+);
+}
+);
+width = 552;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155E;
+unicode = 5470;
+},
+{
+glyphname = "theNCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(413,-13,o),
+(493,71,o),
+(493,246,cs),
+(493,497,ls),
+(493,631,o),
+(449,702,o),
+(368,702,cs),
+(288,702,o),
+(245,630,o),
+(245,511,cs),
+(245,392,o),
+(293,320,o),
+(366,320,cs),
+(413,320,o),
+(451,359,o),
+(461,416,c),
+(432,430,l),
+(432,237,ls),
+(432,104,o),
+(376,44,o),
+(276,44,cs),
+(177,44,o),
+(121,104,o),
+(121,233,cs),
+(121,690,l),
+(59,690,l),
+(59,234,ls),
+(59,71,o),
+(141,-13,o),
+(276,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(321,366,o),
+(296,412,o),
+(296,512,cs),
+(296,611,o),
+(321,656,o),
+(369,656,cs),
+(416,656,o),
+(442,611,o),
+(442,511,cs),
+(442,412,o),
+(414,366,o),
+(367,366,cs)
+);
+}
+);
+width = 552;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155F;
+unicode = 5471;
+},
+{
+glyphname = "thi-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (273,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(263,-13,o),
+(306,60,o),
+(306,179,cs),
+(306,298,o),
+(259,370,o),
+(185,370,cs),
+(138,370,o),
+(100,330,o),
+(91,273,c),
+(120,260,l),
+(120,453,ls),
+(120,585,o),
+(176,645,o),
+(275,645,cs),
+(375,645,o),
+(431,585,o),
+(431,457,cs),
+(431,0,l),
+(493,0,l),
+(493,456,ls),
+(493,618,o),
+(411,702,o),
+(275,702,cs),
+(138,702,o),
+(59,619,o),
+(59,443,cs),
+(59,193,ls),
+(59,59,o),
+(102,-13,o),
+(184,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(135,34,o),
+(109,79,o),
+(109,179,cs),
+(109,278,o),
+(137,324,o),
+(185,324,cs),
+(231,324,o),
+(256,277,o),
+(256,178,cs),
+(256,79,o),
+(230,34,o),
+(183,34,cs)
+);
+}
+);
+width = 552;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1560;
+unicode = 5472;
+},
+{
+glyphname = "thiNCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (273,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(449,-13,o),
+(493,59,o),
+(493,193,cs),
+(493,443,ls),
+(493,619,o),
+(413,702,o),
+(276,702,cs),
+(141,702,o),
+(59,618,o),
+(59,456,cs),
+(59,0,l),
+(121,0,l),
+(121,457,ls),
+(121,585,o),
+(177,645,o),
+(276,645,cs),
+(376,645,o),
+(432,585,o),
+(432,453,cs),
+(432,260,l),
+(461,273,l),
+(451,330,o),
+(413,370,o),
+(366,370,cs),
+(293,370,o),
+(245,298,o),
+(245,179,cs),
+(245,60,o),
+(288,-13,o),
+(368,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(321,34,o),
+(296,79,o),
+(296,178,cs),
+(296,277,o),
+(321,324,o),
+(367,324,cs),
+(414,324,o),
+(442,278,o),
+(442,179,cs),
+(442,79,o),
+(416,34,o),
+(369,34,cs)
+);
+}
+);
+width = 552;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1561;
+unicode = 5473;
+},
+{
+glyphname = "thii-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "thi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (215,0);
+ref = dot_top;
+}
+);
+width = 552;
+}
+);
+note = uni1562;
+unicode = 5474;
+},
+{
+glyphname = "thiiNCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "thiNCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (215,0);
+ref = dot_top;
+}
+);
+width = 552;
+}
+);
+note = uni1563;
+unicode = 5475;
+},
+{
+glyphname = "tho-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (231,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(183,0,ls),
+(371,0,o),
+(457,121,o),
+(457,353,cs),
+(457,569,o),
+(375,702,o),
+(235,702,cs),
+(135,702,o),
+(55,630,o),
+(55,488,cs),
+(55,363,o),
+(100,296,o),
+(177,296,cs),
+(254,296,o),
+(297,363,o),
+(297,480,cs),
+(297,595,o),
+(257,666,o),
+(186,668,c),
+(159,639,l),
+(178,652,o),
+(202,661,o),
+(226,661,cs),
+(341,661,o),
+(396,544,o),
+(396,356,cs),
+(396,156,o),
+(336,57,o),
+(182,57,cs),
+(80,57,l),
+(80,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(131,341,o),
+(105,386,o),
+(105,489,cs),
+(105,586,o),
+(136,637,o),
+(182,637,cs),
+(227,637,o),
+(252,591,o),
+(252,490,cs),
+(252,387,o),
+(226,341,o),
+(179,341,cs)
+);
+}
+);
+width = 507;
+}
+);
+metricRight = "to-canadian";
+note = uni1564;
+unicode = 5476;
+},
+{
+glyphname = "thoo-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "tho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (172,0);
+ref = dot_top;
+}
+);
+width = 507;
+}
+);
+note = uni1565;
+unicode = 5477;
+},
+{
+glyphname = "tha-canadian";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (278,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(427,0,l),
+(427,57,l),
+(326,57,ls),
+(171,57,o),
+(110,156,o),
+(110,356,cs),
+(110,544,o),
+(166,661,o),
+(281,661,cs),
+(305,661,o),
+(329,652,o),
+(347,639,c),
+(321,668,l),
+(250,666,o),
+(210,595,o),
+(210,480,cs),
+(210,363,o),
+(253,296,o),
+(330,296,cs),
+(406,296,o),
+(452,363,o),
+(452,488,cs),
+(452,630,o),
+(372,702,o),
+(271,702,cs),
+(132,702,o),
+(50,569,o),
+(50,353,cs),
+(50,124,o),
+(133,0,o),
+(325,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(280,341,o),
+(255,387,o),
+(255,490,cs),
+(255,591,o),
+(280,637,o),
+(326,637,cs),
+(370,637,o),
+(402,586,o),
+(402,489,cs),
+(402,386,o),
+(376,341,o),
+(328,341,cs)
+);
+}
+);
+width = 507;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tho-canadian";
+note = uni1566;
+unicode = 5478;
+},
+{
+glyphname = "thaa-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (219,0);
+ref = dot_top;
+}
+);
+width = 507;
+}
+);
+note = uni1567;
+unicode = 5479;
+},
+{
+glyphname = "thwaa-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (388,0);
+ref = dot_top;
+}
+);
+width = 676;
+}
+);
+note = uni1568;
+unicode = 5480;
+},
+{
+glyphname = "thwaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (219,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (507,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 676;
+}
+);
+note = uni1569;
+unicode = 5481;
+},
+{
+glyphname = "th-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(237,345,l),
+(237,384,l),
+(192,384,ls),
+(118,384,o),
+(88,432,o),
+(88,522,cs),
+(88,611,o),
+(118,666,o),
+(170,666,cs),
+(183,666,o),
+(193,662,o),
+(201,657,c),
+(184,676,l),
+(149,673,o),
+(129,640,o),
+(129,586,cs),
+(129,521,o),
+(154,492,o),
+(189,492,cs),
+(226,492,o),
+(249,523,o),
+(249,586,cs),
+(249,665,o),
+(214,696,o),
+(166,696,cs),
+(95,696,o),
+(49,632,o),
+(49,519,cs),
+(49,412,o),
+(93,345,o),
+(190,345,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(168,518,o),
+(156,538,o),
+(156,585,cs),
+(156,631,o),
+(168,655,o),
+(188,655,cs),
+(210,655,o),
+(221,636,o),
+(221,585,cs),
+(221,537,o),
+(211,518,o),
+(189,518,cs)
+);
+}
+);
+width = 296;
+}
+);
+metricLeft = "t-canadian";
+note = uni156A;
+unicode = 5482;
+},
+{
+glyphname = "tthe-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (575,345);
+},
+{
+name = top_center_can;
+pos = (271,690);
+},
+{
+name = top_left_can;
+pos = (91,690);
+},
+{
+name = top_right_can;
+pos = (454,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(407,-13,o),
+(485,71,o),
+(485,237,cs),
+(485,690,l),
+(428,690,l),
+(428,235,ls),
+(428,103,o),
+(369,45,o),
+(271,45,cs),
+(178,45,o),
+(117,105,o),
+(117,234,cs),
+(117,690,l),
+(59,690,l),
+(59,234,ls),
+(59,71,o),
+(141,-13,o),
+(272,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(296,391,l),
+(296,690,l),
+(248,690,l),
+(248,391,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156B;
+unicode = 5483;
+},
+{
+glyphname = "tthi-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(117,0,l),
+(117,455,ls),
+(117,586,o),
+(175,644,o),
+(272,644,cs),
+(367,644,o),
+(428,584,o),
+(428,456,cs),
+(428,0,l),
+(485,0,l),
+(485,456,ls),
+(485,618,o),
+(404,702,o),
+(272,702,cs),
+(138,702,o),
+(59,619,o),
+(59,453,cs),
+(59,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(296,0,l),
+(296,298,l),
+(248,298,l),
+(248,0,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156C;
+unicode = 5484;
+},
+{
+glyphname = "ttho-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (242,690);
+},
+{
+name = top_left_can;
+pos = (93,690);
+},
+{
+name = top_right_can;
+pos = (393,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(143,0,ls),
+(334,0,o),
+(423,121,o),
+(423,346,cs),
+(423,571,o),
+(334,690,o),
+(139,690,cs),
+(62,690,l),
+(62,633,l),
+(140,633,ls),
+(298,633,o),
+(361,538,o),
+(361,346,cs),
+(361,156,o),
+(298,57,o),
+(144,57,cs),
+(62,57,l),
+(62,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(233,319,l),
+(233,371,l),
+(62,371,l),
+(62,319,l)
+);
+}
+);
+width = 473;
+}
+);
+metricRight = "to-canadian";
+note = uni156D;
+unicode = 5485;
+},
+{
+glyphname = "ttha-canadian";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (242,690);
+},
+{
+name = top_left_can;
+pos = (81,690);
+},
+{
+name = top_right_can;
+pos = (382,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(412,0,l),
+(412,57,l),
+(334,57,ls),
+(176,57,o),
+(112,153,o),
+(112,344,cs),
+(112,535,o),
+(176,633,o),
+(329,633,cs),
+(412,633,l),
+(412,690,l),
+(329,690,ls),
+(139,690,o),
+(50,569,o),
+(50,344,cs),
+(50,119,o),
+(139,0,o),
+(335,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(412,319,l),
+(412,371,l),
+(241,371,l),
+(241,319,l)
+);
+}
+);
+width = 474;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|ttho-canadian";
+note = uni156E;
+unicode = 5486;
+},
+{
+glyphname = "tth-canadian";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(482,505,l),
+(467,505,l),
+(545,388,l),
+(576,411,l),
+(497,528,l),
+(492,514,l),
+(604,564,l),
+(589,599,l),
+(479,547,l),
+(494,541,l),
+(494,690,l),
+(456,690,l),
+(456,541,l),
+(470,547,l),
+(359,599,l),
+(345,564,l),
+(458,514,l),
+(453,528,l),
+(374,411,l),
+(405,388,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(178,505,l),
+(163,505,l),
+(245,388,l),
+(275,411,l),
+(192,528,l),
+(188,514,l),
+(300,564,l),
+(286,599,l),
+(175,547,l),
+(189,541,l),
+(189,690,l),
+(152,690,l),
+(152,541,l),
+(167,547,l),
+(55,599,l),
+(42,564,l),
+(154,514,l),
+(149,528,l),
+(66,411,l),
+(97,388,l)
+);
+}
+);
+width = 646;
+}
+);
+metricRight = "=|";
+note = uni156F;
+unicode = 5487;
+},
+{
+glyphname = "tye-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(407,-13,o),
+(485,71,o),
+(485,237,cs),
+(485,690,l),
+(428,690,l),
+(428,239,ls),
+(428,103,o),
+(369,45,o),
+(271,45,cs),
+(178,45,o),
+(117,105,o),
+(117,238,cs),
+(117,690,l),
+(59,690,l),
+(59,234,ls),
+(59,71,o),
+(141,-13,o),
+(272,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(327,412,o),
+(359,447,o),
+(359,520,cs),
+(359,690,l),
+(327,690,l),
+(327,522,ls),
+(327,467,o),
+(308,445,o),
+(271,445,cs),
+(237,445,o),
+(217,468,o),
+(217,522,cs),
+(217,690,l),
+(185,690,l),
+(185,520,ls),
+(185,446,o),
+(219,412,o),
+(272,412,cs)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1570;
+unicode = 5488;
+},
+{
+glyphname = "tyi-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(117,0,l),
+(117,451,ls),
+(117,586,o),
+(175,644,o),
+(272,644,cs),
+(367,644,o),
+(428,584,o),
+(428,452,cs),
+(428,0,l),
+(485,0,l),
+(485,456,ls),
+(485,618,o),
+(404,702,o),
+(272,702,cs),
+(138,702,o),
+(59,619,o),
+(59,453,cs),
+(59,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(217,0,l),
+(217,168,ls),
+(217,223,o),
+(238,244,o),
+(272,244,cs),
+(308,244,o),
+(327,222,o),
+(327,168,cs),
+(327,0,l),
+(359,0,l),
+(359,170,ls),
+(359,243,o),
+(326,278,o),
+(272,278,cs),
+(217,278,o),
+(185,242,o),
+(185,170,cs),
+(185,0,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1571;
+unicode = 5489;
+},
+{
+glyphname = "tyo-canadian";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(144,0,ls),
+(332,0,o),
+(423,121,o),
+(423,346,cs),
+(423,571,o),
+(332,690,o),
+(139,690,cs),
+(63,690,l),
+(63,634,l),
+(135,634,ls),
+(298,634,o),
+(362,539,o),
+(362,346,cs),
+(362,155,o),
+(298,56,o),
+(139,56,cs),
+(63,56,l),
+(63,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(109,210,ls),
+(188,210,o),
+(232,254,o),
+(232,345,cs),
+(232,436,o),
+(187,480,o),
+(109,480,cs),
+(63,480,l),
+(63,443,l),
+(104,443,ls),
+(165,443,o),
+(193,413,o),
+(193,345,cs),
+(193,276,o),
+(165,246,o),
+(105,246,cs),
+(63,246,l),
+(63,210,l)
+);
+}
+);
+width = 473;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1572;
+unicode = 5490;
+},
+{
+glyphname = "tya-canadian";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(412,0,l),
+(412,56,l),
+(339,56,ls),
+(177,56,o),
+(112,151,o),
+(112,344,cs),
+(112,536,o),
+(177,634,o),
+(334,634,cs),
+(412,634,l),
+(412,690,l),
+(329,690,ls),
+(141,690,o),
+(50,569,o),
+(50,344,cs),
+(50,119,o),
+(141,0,o),
+(335,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(412,210,l),
+(412,246,l),
+(370,246,ls),
+(309,246,o),
+(280,276,o),
+(280,345,cs),
+(280,413,o),
+(309,443,o),
+(369,443,cs),
+(412,443,l),
+(412,480,l),
+(364,480,ls),
+(285,480,o),
+(242,436,o),
+(242,345,cs),
+(242,254,o),
+(286,210,o),
+(364,210,cs)
+);
+}
+);
+width = 475;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1573;
+unicode = 5491;
+},
+{
+glyphname = "heNunavik-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(384,0,l),
+(561,191,l),
+(523,231,l),
+(350,43,l),
+(391,42,l),
+(391,449,ls),
+(391,615,o),
+(333,702,o),
+(224,702,cs),
+(115,702,o),
+(53,613,o),
+(53,451,cs),
+(53,295,o),
+(114,205,o),
+(215,205,cs),
+(279,205,o),
+(325,249,o),
+(336,313,c),
+(329,341,l),
+(329,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(151,259,o),
+(113,322,o),
+(113,454,cs),
+(113,586,o),
+(151,648,o),
+(222,648,cs),
+(294,648,o),
+(330,587,o),
+(330,454,cs),
+(330,322,o),
+(293,259,o),
+(222,259,cs)
+);
+}
+);
+width = 583;
+}
+);
+metricLeft = "ke-canadian";
+note = uni1574;
+unicode = 5492;
+},
+{
+glyphname = "hiNunavik-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (360,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(253,0,l),
+(253,341,l),
+(247,313,l),
+(258,249,o),
+(304,205,o),
+(367,205,cs),
+(469,205,o),
+(530,295,o),
+(530,451,cs),
+(530,613,o),
+(469,702,o),
+(359,702,cs),
+(250,702,o),
+(192,615,o),
+(192,449,cs),
+(192,42,l),
+(234,43,l),
+(61,231,l),
+(22,191,l),
+(199,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(291,259,o),
+(253,322,o),
+(253,454,cs),
+(253,587,o),
+(290,648,o),
+(361,648,cs),
+(433,648,o),
+(469,586,o),
+(469,454,cs),
+(469,322,o),
+(432,259,o),
+(361,259,cs)
+);
+}
+);
+width = 583;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1575;
+unicode = 5493;
+},
+{
+glyphname = "hiiNunavik-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "hiNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (301,0);
+ref = dot_top;
+}
+);
+width = 583;
+}
+);
+note = uni1576;
+unicode = 5494;
+},
+{
+glyphname = "hoNunavik-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (221,690);
+},
+{
+name = top_right_can;
+pos = (360,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(333,-13,o),
+(391,74,o),
+(391,241,cs),
+(391,648,l),
+(350,647,l),
+(523,459,l),
+(561,498,l),
+(384,690,l),
+(329,690,l),
+(329,349,l),
+(336,377,l),
+(325,440,o),
+(279,485,o),
+(215,485,cs),
+(114,485,o),
+(53,395,o),
+(53,239,cs),
+(53,76,o),
+(115,-13,o),
+(224,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(151,42,o),
+(113,103,o),
+(113,236,cs),
+(113,368,o),
+(151,431,o),
+(222,431,cs),
+(293,431,o),
+(330,368,o),
+(330,236,cs),
+(330,102,o),
+(294,42,o),
+(222,42,cs)
+);
+}
+);
+width = 583;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "heNunavik-canadian";
+note = uni1577;
+unicode = 5495;
+},
+{
+glyphname = "hooNunavik-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "hoNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (301,0);
+ref = dot_top;
+}
+);
+width = 583;
+}
+);
+note = uni1578;
+unicode = 5496;
+},
+{
+glyphname = "haNunavik-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (362,690);
+},
+{
+name = top_left_can;
+pos = (223,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(469,-13,o),
+(530,76,o),
+(530,239,cs),
+(530,395,o),
+(469,485,o),
+(367,485,cs),
+(304,485,o),
+(258,440,o),
+(247,377,c),
+(253,349,l),
+(253,690,l),
+(199,690,l),
+(22,498,l),
+(61,459,l),
+(234,647,l),
+(192,648,l),
+(192,241,ls),
+(192,74,o),
+(250,-13,o),
+(359,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(290,42,o),
+(253,102,o),
+(253,236,cs),
+(253,368,o),
+(291,431,o),
+(361,431,cs),
+(432,431,o),
+(469,368,o),
+(469,236,cs),
+(469,103,o),
+(433,42,o),
+(361,42,cs)
+);
+}
+);
+width = 583;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1579;
+unicode = 5497;
+},
+{
+glyphname = "haaNunavik-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "haNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (165,0);
+ref = dot_top;
+}
+);
+width = 583;
+}
+);
+note = uni157A;
+unicode = 5498;
+},
+{
+glyphname = "hNunavik-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(262,339,o),
+(303,382,o),
+(303,473,cs),
+(303,557,o),
+(267,601,o),
+(218,601,cs),
+(180,601,o),
+(151,571,o),
+(148,521,c),
+(159,521,l),
+(159,690,l),
+(119,690,l),
+(31,594,l),
+(56,571,l),
+(145,667,l),
+(116,665,l),
+(116,469,ls),
+(116,384,o),
+(154,339,o),
+(210,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(177,375,o),
+(156,401,o),
+(156,470,cs),
+(156,537,o),
+(179,565,o),
+(211,565,cs),
+(242,565,o),
+(264,538,o),
+(264,471,cs),
+(264,404,o),
+(242,375,o),
+(211,375,cs)
+);
+}
+);
+width = 343;
+}
+);
+metricRight = "k-canadian";
+note = uni157B;
+unicode = 5499;
+},
+{
+color = 4;
+glyphname = "nunavuth-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(124,330,l),
+(395,330,l),
+(395,0,l),
+(456,0,l),
+(456,690,l),
+(395,690,l),
+(395,386,l),
+(124,386,l),
+(124,690,l),
+(63,690,l),
+(63,0,l),
+(124,0,l)
+);
+}
+);
+width = 519;
+}
+);
+metricRight = "=|";
+note = uni157C;
+unicode = 5500;
+},
+{
+glyphname = "hk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,345);
+ref = "fullstop-canadian";
+}
+);
+width = 281;
+}
+);
+metricLeft = "fullstop-canadian";
+note = uni157D;
+unicode = 5501;
+},
+{
+glyphname = "qaai-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (243,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (356,0);
+ref = ring_top.canadian;
+}
+);
+width = 694;
+}
+);
+note = uni157E;
+unicode = 5502;
+},
+{
+glyphname = "qi-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (243,0);
+ref = "ki-canadian";
+}
+);
+width = 694;
+}
+);
+note = uni157F;
+unicode = 5503;
+},
+{
+glyphname = "qii-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (243,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (412,0);
+ref = dot_top;
+}
+);
+width = 694;
+}
+);
+note = uni1580;
+unicode = 5504;
+},
+{
+glyphname = "qo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (243,0);
+ref = "ko-canadian";
+}
+);
+width = 694;
+}
+);
+note = uni1581;
+unicode = 5505;
+},
+{
+glyphname = "qoo-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (243,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (545,0);
+ref = dot_top;
+}
+);
+width = 694;
+}
+);
+note = uni1582;
+unicode = 5506;
+},
+{
+glyphname = "qa-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (243,0);
+ref = "ka-canadian";
+}
+);
+width = 694;
+}
+);
+note = uni1583;
+unicode = 5507;
+},
+{
+glyphname = "qaa-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (243,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (274,0);
+ref = dot_top;
+}
+);
+width = 694;
+}
+);
+note = uni1584;
+unicode = 5508;
+},
+{
+glyphname = "q-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (243,0);
+ref = "k-canadian";
+}
+);
+width = 522;
+}
+);
+note = uni1585;
+unicode = 5509;
+},
+{
+glyphname = "tlhe-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (226,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(141,0,l),
+(242,265,l),
+(191,244,l),
+(199,242,o),
+(208,242,o),
+(217,242,cs),
+(284,242,o),
+(325,283,o),
+(339,339,c),
+(333,353,l),
+(333,0,l),
+(394,0,l),
+(394,476,ls),
+(394,615,o),
+(335,702,o),
+(226,702,cs),
+(118,702,o),
+(55,615,o),
+(55,470,cs),
+(55,350,o),
+(102,272,o),
+(174,253,c),
+(76,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(154,295,o),
+(115,355,o),
+(115,471,cs),
+(115,588,o),
+(153,648,o),
+(224,648,cs),
+(297,648,o),
+(334,589,o),
+(334,471,cs),
+(334,354,o),
+(295,295,o),
+(224,295,cs)
+);
+}
+);
+width = 453;
+}
+);
+metricRight = "te-canadian";
+note = uni1586;
+unicode = 5510;
+},
+{
+glyphname = "tlhi-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(120,0,l),
+(120,353,l),
+(115,339,l),
+(129,283,o),
+(169,242,o),
+(237,242,c),
+(213,265,l),
+(313,0,l),
+(377,0,l),
+(280,253,l),
+(352,272,o),
+(399,350,o),
+(399,470,cs),
+(399,615,o),
+(336,702,o),
+(227,702,cs),
+(119,702,o),
+(59,615,o),
+(59,476,cs),
+(59,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(159,295,o),
+(120,354,o),
+(120,471,cs),
+(120,589,o),
+(156,648,o),
+(230,648,cs),
+(301,648,o),
+(338,588,o),
+(338,471,cs),
+(338,355,o),
+(300,295,o),
+(230,295,cs)
+);
+}
+);
+width = 454;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|tlhe-canadian";
+note = uni1587;
+unicode = 5511;
+},
+{
+glyphname = "tlho-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (239,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(335,-13,o),
+(394,74,o),
+(394,213,cs),
+(394,690,l),
+(333,690,l),
+(333,337,l),
+(339,351,l),
+(325,407,o),
+(284,448,o),
+(217,448,c),
+(242,425,l),
+(141,690,l),
+(76,690,l),
+(174,437,l),
+(102,417,o),
+(55,340,o),
+(55,219,cs),
+(55,74,o),
+(118,-13,o),
+(226,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(153,42,o),
+(115,101,o),
+(115,218,cs),
+(115,335,o),
+(154,395,o),
+(224,395,cs),
+(295,395,o),
+(334,336,o),
+(334,218,cs),
+(334,100,o),
+(297,42,o),
+(224,42,cs)
+);
+}
+);
+width = 453;
+}
+);
+metricLeft = "tlhe-canadian";
+metricRight = "te-canadian";
+note = uni1588;
+unicode = 5512;
+},
+{
+glyphname = "tlha-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(336,-13,o),
+(399,74,o),
+(399,219,cs),
+(399,340,o),
+(352,417,o),
+(280,437,c),
+(377,690,l),
+(313,690,l),
+(213,425,l),
+(262,445,l),
+(254,447,o),
+(246,448,o),
+(237,448,cs),
+(169,448,o),
+(129,407,o),
+(115,351,c),
+(120,337,l),
+(120,690,l),
+(59,690,l),
+(59,213,ls),
+(59,74,o),
+(119,-13,o),
+(227,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(156,42,o),
+(120,100,o),
+(120,218,cs),
+(120,336,o),
+(159,395,o),
+(230,395,cs),
+(300,395,o),
+(338,335,o),
+(338,218,cs),
+(338,101,o),
+(301,42,o),
+(230,42,cs)
+);
+}
+);
+width = 454;
+}
+);
+metricLeft = "te-canadian";
+note = uni1589;
+unicode = 5513;
+},
+{
+glyphname = "reWestCree-canadian";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(380,0,l),
+(556,191,l),
+(518,231,l),
+(345,43,l),
+(386,42,l),
+(386,471,ls),
+(386,614,o),
+(328,702,o),
+(221,702,cs),
+(112,702,o),
+(52,618,o),
+(52,479,cs),
+(52,391,l),
+(113,391,l),
+(113,489,ls),
+(113,588,o),
+(148,647,o),
+(220,647,cs),
+(290,647,o),
+(326,588,o),
+(326,483,cs),
+(326,0,l)
+);
+}
+);
+width = 578;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+unicode = 5514;
+},
+{
+glyphname = "riWestCree-canadian";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(253,0,l),
+(253,483,ls),
+(253,588,o),
+(289,647,o),
+(358,647,cs),
+(431,647,o),
+(466,588,o),
+(466,489,cs),
+(466,391,l),
+(526,391,l),
+(526,479,ls),
+(526,618,o),
+(467,702,o),
+(357,702,cs),
+(249,702,o),
+(192,614,o),
+(192,471,cs),
+(192,42,l),
+(234,43,l),
+(61,231,l),
+(22,191,l),
+(199,0,l)
+);
+}
+);
+width = 578;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+unicode = 5515;
+},
+{
+glyphname = "roWestCree-canadian";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(328,-13,o),
+(386,75,o),
+(386,218,cs),
+(386,648,l),
+(345,647,l),
+(518,459,l),
+(556,498,l),
+(380,690,l),
+(326,690,l),
+(326,207,ls),
+(326,102,o),
+(290,43,o),
+(220,43,cs),
+(148,43,o),
+(113,102,o),
+(113,201,cs),
+(113,298,l),
+(52,298,l),
+(52,211,ls),
+(52,71,o),
+(112,-13,o),
+(221,-13,cs)
+);
+}
+);
+width = 578;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+unicode = 5516;
+},
+{
+glyphname = "raWestCree-canadian";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(467,-13,o),
+(526,72,o),
+(526,211,cs),
+(526,298,l),
+(466,298,l),
+(466,201,ls),
+(466,102,o),
+(431,43,o),
+(358,43,cs),
+(290,43,o),
+(253,102,o),
+(253,207,cs),
+(253,690,l),
+(199,690,l),
+(22,498,l),
+(61,459,l),
+(234,647,l),
+(192,648,l),
+(192,218,ls),
+(192,75,o),
+(250,-13,o),
+(357,-13,cs)
+);
+}
+);
+width = 578;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+unicode = 5517;
+},
+{
+glyphname = "ngaai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (477,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (590,0);
+ref = ring_top.canadian;
+}
+);
+width = 923;
+}
+);
+note = uni158E;
+unicode = 5518;
+},
+{
+glyphname = "ngi-canadian";
+kernLeft = mwestleft;
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (477,0);
+ref = "ci-canadian";
+}
+);
+width = 923;
+}
+);
+note = uni158F;
+unicode = 5519;
+},
+{
+glyphname = "ngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (477,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (646,0);
+ref = dot_top;
+}
+);
+width = 923;
+}
+);
+note = uni1590;
+unicode = 5520;
+},
+{
+glyphname = "ngo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (453,0);
+ref = "co-canadian";
+}
+);
+width = 898;
+}
+);
+note = uni1591;
+unicode = 5521;
+},
+{
+glyphname = "ngoo-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+ref = "ngo-canadian";
+},
+{
+anchor = top_right_can;
+pos = (750,0);
+ref = dot_top;
+}
+);
+width = 898;
+}
+);
+note = uni1592;
+unicode = 5522;
+},
+{
+glyphname = "nga-canadian";
+kernLeft = mwestleft;
+kernRight = caright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (477,0);
+ref = "ca-canadian";
+}
+);
+width = 923;
+}
+);
+note = uni1593;
+unicode = 5523;
+},
+{
+glyphname = "ngaa-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (477,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (509,0);
+ref = dot_top;
+}
+);
+width = 923;
+}
+);
+note = uni1594;
+unicode = 5524;
+},
+{
+glyphname = "ng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(409,217,o),
+(445,254,o),
+(445,329,cs),
+(445,363,l),
+(404,363,l),
+(404,324,ls),
+(404,275,o),
+(384,254,o),
+(352,254,cs),
+(318,254,o),
+(299,276,o),
+(299,330,cs),
+(299,476,l),
+(182,476,l),
+(182,457,l),
+(212,471,o),
+(225,517,o),
+(225,567,cs),
+(225,651,o),
+(188,696,o),
+(132,696,cs),
+(76,696,o),
+(40,650,o),
+(40,565,cs),
+(40,481,o),
+(75,434,o),
+(138,434,cs),
+(269,434,l),
+(256,448,l),
+(256,335,ls),
+(256,257,o),
+(292,217,o),
+(351,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(99,469,o),
+(79,499,o),
+(79,565,cs),
+(79,632,o),
+(99,660,o),
+(133,660,cs),
+(166,660,o),
+(185,631,o),
+(185,565,cs),
+(185,498,o),
+(165,469,o),
+(132,469,cs)
+);
+}
+);
+width = 477;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1595;
+unicode = 5525;
+},
+{
+glyphname = "nng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(629,217,o),
+(666,254,o),
+(666,329,cs),
+(666,363,l),
+(624,363,l),
+(624,324,ls),
+(624,275,o),
+(606,254,o),
+(572,254,cs),
+(538,254,o),
+(520,276,o),
+(520,330,cs),
+(520,476,l),
+(403,476,l),
+(402,457,l),
+(433,471,o),
+(445,517,o),
+(445,567,cs),
+(445,652,o),
+(410,696,o),
+(352,696,cs),
+(297,696,o),
+(260,650,o),
+(260,565,cs),
+(260,517,o),
+(273,470,o),
+(303,456,c),
+(302,476,l),
+(183,476,l),
+(182,457,l),
+(212,471,o),
+(225,517,o),
+(225,567,cs),
+(225,651,o),
+(188,696,o),
+(132,696,cs),
+(76,696,o),
+(40,650,o),
+(40,565,cs),
+(40,481,o),
+(75,434,o),
+(138,434,cs),
+(476,434,l),
+(476,335,ls),
+(476,257,o),
+(513,217,o),
+(572,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(99,469,o),
+(79,499,o),
+(79,565,cs),
+(79,632,o),
+(99,660,o),
+(133,660,cs),
+(166,660,o),
+(185,631,o),
+(185,565,cs),
+(185,498,o),
+(165,469,o),
+(132,469,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(321,469,o),
+(299,499,o),
+(299,565,cs),
+(299,632,o),
+(320,660,o),
+(354,660,cs),
+(387,660,o),
+(406,631,o),
+(406,565,cs),
+(406,498,o),
+(385,469,o),
+(353,469,cs)
+);
+}
+);
+width = 698;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1596;
+unicode = 5526;
+},
+{
+glyphname = "sheSayisi-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (485,345);
+},
+{
+name = top_center_can;
+pos = (226,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(396,0,l),
+(396,452,ls),
+(396,614,o),
+(338,702,o),
+(226,702,cs),
+(116,702,o),
+(53,613,o),
+(53,443,cs),
+(53,281,o),
+(103,207,o),
+(179,207,cs),
+(242,207,o),
+(287,252,o),
+(283,411,c),
+(253,411,l),
+(256,283,o),
+(225,259,o),
+(189,259,cs),
+(140,259,o),
+(112,311,o),
+(112,444,cs),
+(112,587,o),
+(151,648,o),
+(225,648,cs),
+(298,648,o),
+(334,587,o),
+(334,451,cs),
+(334,0,l)
+);
+}
+);
+width = 455;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1597;
+unicode = 5527;
+},
+{
+glyphname = "shiSayisi-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,0,l),
+(121,451,ls),
+(121,587,o),
+(156,648,o),
+(230,648,cs),
+(304,648,o),
+(343,586,o),
+(343,444,cs),
+(343,310,o),
+(315,259,o),
+(267,259,cs),
+(230,259,o),
+(199,283,o),
+(202,411,c),
+(172,411,l),
+(168,252,o),
+(213,207,o),
+(277,207,cs),
+(352,207,o),
+(403,281,o),
+(403,442,cs),
+(403,613,o),
+(339,702,o),
+(229,702,cs),
+(117,702,o),
+(59,614,o),
+(59,452,cs),
+(59,0,l)
+);
+}
+);
+width = 456;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni1598;
+unicode = 5528;
+},
+{
+glyphname = "shoSayisi-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (224,690);
+},
+{
+name = top_left_can;
+pos = (82,690);
+},
+{
+name = top_right_can;
+pos = (366,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(339,-13,o),
+(396,75,o),
+(396,238,cs),
+(396,690,l),
+(334,690,l),
+(334,239,ls),
+(334,102,o),
+(298,42,o),
+(225,42,cs),
+(151,42,o),
+(112,103,o),
+(112,245,cs),
+(112,380,o),
+(140,431,o),
+(189,431,cs),
+(225,431,o),
+(256,407,o),
+(253,279,c),
+(283,279,l),
+(287,438,o),
+(242,483,o),
+(179,483,cs),
+(103,483,o),
+(53,409,o),
+(53,247,cs),
+(53,76,o),
+(116,-13,o),
+(227,-13,cs)
+);
+}
+);
+width = 455;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1599;
+unicode = 5529;
+},
+{
+glyphname = "shaSayisi-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(340,-13,o),
+(403,76,o),
+(403,246,cs),
+(403,409,o),
+(352,483,o),
+(277,483,cs),
+(213,483,o),
+(168,438,o),
+(172,279,c),
+(202,279,l),
+(199,407,o),
+(230,431,o),
+(267,431,cs),
+(315,431,o),
+(343,379,o),
+(343,245,cs),
+(343,102,o),
+(304,42,o),
+(230,42,cs),
+(156,42,o),
+(121,102,o),
+(121,239,cs),
+(121,690,l),
+(59,690,l),
+(59,238,ls),
+(59,75,o),
+(117,-13,o),
+(229,-13,cs)
+);
+}
+);
+width = 456;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni159A;
+unicode = 5530;
+},
+{
+glyphname = "theWoodScree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(503,-13,o),
+(570,71,o),
+(570,231,cs),
+(570,390,o),
+(504,472,o),
+(389,472,cs),
+(57,472,l),
+(57,419,l),
+(308,419,l),
+(306,433,l),
+(252,401,o),
+(225,319,o),
+(225,228,cs),
+(225,71,o),
+(289,-13,o),
+(397,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(323,42,o),
+(285,102,o),
+(285,231,cs),
+(285,351,o),
+(324,419,o),
+(397,419,cs),
+(470,419,o),
+(509,359,o),
+(509,231,cs),
+(509,102,o),
+(471,42,o),
+(397,42,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(561,637,l),
+(561,690,l),
+(57,690,l),
+(57,637,l)
+);
+}
+);
+width = 626;
+}
+);
+note = uni159B;
+unicode = 5531;
+},
+{
+glyphname = "thiWoodScree-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(337,-13,o),
+(402,71,o),
+(402,228,cs),
+(402,319,o),
+(375,401,o),
+(321,433,c),
+(318,419,l),
+(570,419,l),
+(570,472,l),
+(238,472,ls),
+(123,472,o),
+(57,391,o),
+(57,231,cs),
+(57,71,o),
+(123,-13,o),
+(229,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(155,42,o),
+(117,102,o),
+(117,231,cs),
+(117,359,o),
+(156,419,o),
+(229,419,cs),
+(303,419,o),
+(341,351,o),
+(341,231,cs),
+(341,102,o),
+(303,42,o),
+(229,42,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(570,637,l),
+(570,690,l),
+(65,690,l),
+(65,637,l)
+);
+}
+);
+width = 626;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159C;
+unicode = 5532;
+},
+{
+glyphname = "thoWoodScree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(389,0,ls),
+(504,0,o),
+(570,82,o),
+(570,242,cs),
+(570,402,o),
+(503,485,o),
+(397,485,cs),
+(289,485,o),
+(225,402,o),
+(225,244,cs),
+(225,154,o),
+(252,71,o),
+(306,40,c),
+(308,53,l),
+(57,53,l),
+(57,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(324,53,o),
+(285,122,o),
+(285,242,cs),
+(285,370,o),
+(323,431,o),
+(397,431,cs),
+(471,431,o),
+(509,370,o),
+(509,242,cs),
+(509,113,o),
+(470,53,o),
+(397,53,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(561,637,l),
+(561,690,l),
+(57,690,l),
+(57,637,l)
+);
+}
+);
+width = 626;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159D;
+unicode = 5533;
+},
+{
+glyphname = "thaWoodScree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(570,0,l),
+(570,53,l),
+(318,53,l),
+(320,40,l),
+(375,71,o),
+(402,154,o),
+(402,244,cs),
+(402,402,o),
+(337,485,o),
+(229,485,cs),
+(123,485,o),
+(57,402,o),
+(57,242,cs),
+(57,82,o),
+(123,0,o),
+(238,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(156,53,o),
+(117,113,o),
+(117,242,cs),
+(117,370,o),
+(155,431,o),
+(229,431,cs),
+(303,431,o),
+(341,370,o),
+(341,242,cs),
+(341,122,o),
+(303,53,o),
+(229,53,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(570,637,l),
+(570,690,l),
+(65,690,l),
+(65,637,l)
+);
+}
+);
+width = 626;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159E;
+unicode = 5534;
+},
+{
+glyphname = "thWoodScree-canadian";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(331,345,l),
+(331,384,l),
+(191,384,l),
+(192,368,l),
+(222,383,o),
+(236,428,o),
+(236,478,cs),
+(236,561,o),
+(199,607,o),
+(143,607,cs),
+(87,607,o),
+(50,561,o),
+(50,476,cs),
+(50,392,o),
+(86,345,o),
+(149,345,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(110,380,o),
+(90,411,o),
+(90,476,cs),
+(90,543,o),
+(110,571,o),
+(144,571,cs),
+(177,571,o),
+(196,542,o),
+(196,476,cs),
+(196,410,o),
+(176,380,o),
+(143,380,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(327,676,l),
+(327,717,l),
+(54,717,l),
+(54,676,l)
+);
+}
+);
+width = 381;
+}
+);
+metricRight = "=|";
+note = uni159F;
+unicode = 5535;
+},
+{
+glyphname = "lhi-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (354,690);
+},
+{
+name = top_right_can;
+pos = (423,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(275,0,l),
+(275,55,l),
+(268,55,ls),
+(166,55,o),
+(114,116,o),
+(114,234,cs),
+(114,356,o),
+(167,416,o),
+(266,416,cs),
+(566,416,l),
+(566,467,l),
+(433,722,l),
+(384,694,l),
+(517,439,l),
+(519,472,l),
+(264,472,ls),
+(132,472,o),
+(53,390,o),
+(53,235,cs),
+(53,81,o),
+(130,0,o),
+(263,0,cs)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A0;
+unicode = 5536;
+},
+{
+glyphname = "lhii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "lhi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (295,0);
+ref = dot_top;
+}
+);
+width = 615;
+}
+);
+note = uni15A1;
+unicode = 5537;
+},
+{
+glyphname = "lho-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (300,490);
+},
+{
+name = top_right_can;
+pos = (384,490);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(231,-222,l),
+(99,33,l),
+(97,-1,l),
+(352,-1,ls),
+(483,-1,o),
+(562,81,o),
+(562,238,cs),
+(562,390,o),
+(485,471,o),
+(353,471,cs),
+(340,471,l),
+(340,416,l),
+(348,416,ls),
+(449,416,o),
+(501,355,o),
+(501,238,cs),
+(501,117,o),
+(448,56,o),
+(350,56,cs),
+(49,56,l),
+(49,5,l),
+(183,-250,l)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni15A2;
+unicode = 5538;
+},
+{
+glyphname = "lhoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "lho-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (326,-200);
+ref = dot_top;
+}
+);
+width = 615;
+}
+);
+note = uni15A3;
+unicode = 5539;
+},
+{
+glyphname = "lha-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (317,490);
+},
+{
+name = top_left_can;
+pos = (231,490);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(566,6,l),
+(566,56,l),
+(266,56,ls),
+(166,56,o),
+(114,117,o),
+(114,239,cs),
+(114,356,o),
+(166,417,o),
+(268,417,cs),
+(275,417,l),
+(275,472,l),
+(263,472,ls),
+(130,472,o),
+(53,391,o),
+(53,239,cs),
+(53,82,o),
+(131,0,o),
+(264,0,cs),
+(519,0,l),
+(517,34,l),
+(384,-221,l),
+(433,-249,l)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A4;
+unicode = 5540;
+},
+{
+glyphname = "lhaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "lha-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (173,-200);
+ref = dot_top;
+}
+);
+width = 615;
+}
+);
+note = uni15A5;
+unicode = 5541;
+},
+{
+glyphname = "lh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(333,349,l),
+(333,387,l),
+(202,387,ls),
+(124,387,o),
+(93,436,o),
+(93,518,cs),
+(93,600,o),
+(124,647,o),
+(191,647,cs),
+(196,647,l),
+(196,690,l),
+(190,690,ls),
+(94,690,o),
+(49,619,o),
+(49,518,cs),
+(49,413,o),
+(95,345,o),
+(202,345,cs),
+(303,345,l),
+(298,369,l),
+(225,228,l),
+(261,208,l)
+);
+}
+);
+width = 382;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni15A6;
+unicode = 5542;
+},
+{
+glyphname = "theThCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (71,690);
+},
+{
+name = top_right_can;
+pos = (344,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(374,0,l),
+(374,117,l),
+(435,117,l),
+(435,157,l),
+(374,157,l),
+(374,310,l),
+(102,310,l),
+(116,290,l),
+(388,668,l),
+(343,701,l),
+(40,280,l),
+(40,255,l),
+(312,255,l),
+(312,157,l),
+(130,157,l),
+(130,117,l),
+(312,117,l),
+(312,0,l)
+);
+}
+);
+width = 469;
+}
+);
+metricLeft = "ye-canadian";
+note = uni15A7;
+unicode = 5543;
+},
+{
+glyphname = "thiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (126,690);
+},
+{
+name = top_right_can;
+pos = (399,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(156,0,l),
+(156,117,l),
+(339,117,l),
+(339,157,l),
+(156,157,l),
+(156,255,l),
+(428,255,l),
+(428,280,l),
+(126,701,l),
+(80,668,l),
+(356,285,l),
+(366,310,l),
+(95,310,l),
+(95,157,l),
+(34,157,l),
+(34,117,l),
+(95,117,l),
+(95,0,l)
+);
+}
+);
+width = 468;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+unicode = 5544;
+},
+{
+glyphname = "thiiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (68,0);
+ref = dot_top;
+}
+);
+width = 469;
+}
+);
+note = uni15A9;
+unicode = 5545;
+},
+{
+glyphname = "thoThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (71,690);
+},
+{
+name = top_right_can;
+pos = (344,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(388,22,l),
+(116,400,l),
+(102,380,l),
+(374,380,l),
+(374,532,l),
+(435,532,l),
+(435,573,l),
+(374,573,l),
+(374,690,l),
+(312,690,l),
+(312,573,l),
+(130,573,l),
+(130,532,l),
+(312,532,l),
+(312,435,l),
+(40,435,l),
+(40,410,l),
+(343,-12,l)
+);
+}
+);
+width = 469;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+unicode = 5546;
+},
+{
+glyphname = "thooThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (285,0);
+ref = dot_top;
+}
+);
+width = 469;
+}
+);
+note = uni15AB;
+unicode = 5547;
+},
+{
+glyphname = "thaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (126,690);
+},
+{
+name = top_right_can;
+pos = (399,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(428,410,l),
+(428,435,l),
+(156,435,l),
+(156,532,l),
+(339,532,l),
+(339,573,l),
+(156,573,l),
+(156,690,l),
+(95,690,l),
+(95,573,l),
+(34,573,l),
+(34,532,l),
+(95,532,l),
+(95,380,l),
+(366,380,l),
+(353,400,l),
+(80,22,l),
+(126,-12,l)
+);
+}
+);
+width = 468;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+unicode = 5548;
+},
+{
+glyphname = "thaaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (67,0);
+ref = dot_top;
+}
+);
+width = 468;
+}
+);
+note = uni15AD;
+unicode = 5549;
+},
+{
+glyphname = "thThCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(244,546,l),
+(244,562,l),
+(112,562,l),
+(112,612,l),
+(199,612,l),
+(199,639,l),
+(112,639,l),
+(112,690,l),
+(68,690,l),
+(68,639,l),
+(37,639,l),
+(37,612,l),
+(68,612,l),
+(68,523,l),
+(208,523,l),
+(199,551,l),
+(63,359,l),
+(97,337,l)
+);
+}
+);
+width = 271;
+}
+);
+metricRight = "y-canadian";
+note = uni15AE;
+unicode = 5550;
+},
+{
+glyphname = "bAivilik-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(340,-13,o),
+(401,77,o),
+(401,238,cs),
+(401,395,o),
+(340,485,o),
+(241,485,cs),
+(174,485,o),
+(128,440,o),
+(118,377,c),
+(124,355,l),
+(124,690,l),
+(63,690,l),
+(63,0,l),
+(119,0,l),
+(119,114,l),
+(115,99,l),
+(128,32,o),
+(173,-13,o),
+(242,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(160,42,o),
+(124,104,o),
+(124,236,cs),
+(124,368,o),
+(161,431,o),
+(232,431,cs),
+(302,431,o),
+(340,368,o),
+(340,236,cs),
+(340,103,o),
+(303,42,o),
+(232,42,cs)
+);
+}
+);
+width = 454;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|ke-canadian";
+note = uni15AF;
+unicode = 5551;
+},
+{
+glyphname = "eBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(124,0,l),
+(124,411,l),
+(149,373,o),
+(185,353,o),
+(230,353,cs),
+(314,353,o),
+(370,428,o),
+(370,527,cs),
+(370,628,o),
+(314,702,o),
+(230,702,cs),
+(183,702,o),
+(145,680,o),
+(121,641,c),
+(121,690,l),
+(63,690,l),
+(63,0,l)
+);
+}
+);
+width = 411;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B0;
+unicode = 5552;
+},
+{
+glyphname = "iBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(228,-13,o),
+(266,10,o),
+(290,48,c),
+(290,0,l),
+(349,0,l),
+(349,690,l),
+(287,690,l),
+(287,279,l),
+(263,317,o),
+(225,337,o),
+(181,337,cs),
+(97,337,o),
+(41,262,o),
+(41,162,cs),
+(41,62,o),
+(97,-13,o),
+(181,-13,cs)
+);
+}
+);
+width = 412;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B1;
+unicode = 5553;
+},
+{
+glyphname = "oBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(314,-13,o),
+(370,62,o),
+(370,162,cs),
+(370,262,o),
+(314,337,o),
+(230,337,cs),
+(185,337,o),
+(149,317,o),
+(124,279,c),
+(124,690,l),
+(63,690,l),
+(63,0,l),
+(121,0,l),
+(121,48,l),
+(145,10,o),
+(183,-13,o),
+(230,-13,cs)
+);
+}
+);
+width = 411;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "eBlackfoot-canadian";
+note = uni15B2;
+unicode = 5554;
+},
+{
+glyphname = "aBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(349,0,l),
+(349,690,l),
+(290,690,l),
+(290,641,l),
+(266,680,o),
+(228,702,o),
+(181,702,cs),
+(97,702,o),
+(41,628,o),
+(41,527,cs),
+(41,428,o),
+(97,353,o),
+(181,353,cs),
+(225,353,o),
+(263,373,o),
+(287,411,c),
+(287,0,l)
+);
+}
+);
+width = 412;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B3;
+unicode = 5555;
+},
+{
+glyphname = "weBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(124,319,l),
+(387,319,l),
+(387,373,l),
+(124,373,l),
+(124,636,l),
+(387,636,l),
+(387,690,l),
+(63,690,l),
+(63,0,l),
+(124,0,l)
+);
+}
+);
+width = 433;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B4;
+unicode = 5556;
+},
+{
+glyphname = "wiBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(372,0,l),
+(372,690,l),
+(310,690,l),
+(310,371,l),
+(46,371,l),
+(46,317,l),
+(310,317,l),
+(310,54,l),
+(46,54,l),
+(46,0,l)
+);
+}
+);
+width = 435;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B5;
+unicode = 5557;
+},
+{
+glyphname = "woBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(387,0,l),
+(387,54,l),
+(124,54,l),
+(124,317,l),
+(387,317,l),
+(387,371,l),
+(124,371,l),
+(124,690,l),
+(63,690,l),
+(63,0,l)
+);
+}
+);
+width = 433;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "weBlackfoot-canadian";
+note = uni15B6;
+unicode = 5558;
+},
+{
+glyphname = "waBlackfoot-canadian";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(372,0,l),
+(372,690,l),
+(46,690,l),
+(46,636,l),
+(310,636,l),
+(310,373,l),
+(46,373,l),
+(46,319,l),
+(310,319,l),
+(310,0,l)
+);
+}
+);
+width = 435;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B7;
+unicode = 5559;
+},
+{
+glyphname = "neBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(124,0,l),
+(124,641,l),
+(164,641,l),
+(141,673,l),
+(141,643,ls),
+(141,490,o),
+(198,407,o),
+(307,407,cs),
+(416,407,o),
+(478,492,o),
+(478,641,cs),
+(478,690,l),
+(418,690,l),
+(418,635,ls),
+(418,522,o),
+(382,462,o),
+(309,462,cs),
+(237,462,o),
+(201,521,o),
+(201,634,cs),
+(201,690,l),
+(63,690,l),
+(63,0,l)
+);
+}
+);
+width = 514;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B8;
+unicode = 5560;
+},
+{
+glyphname = "niBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,0,l),
+(97,55,ls),
+(97,168,o),
+(132,228,o),
+(205,228,cs),
+(277,228,o),
+(313,169,o),
+(313,56,cs),
+(313,0,l),
+(452,0,l),
+(452,690,l),
+(390,690,l),
+(390,48,l),
+(350,48,l),
+(373,16,l),
+(373,46,ls),
+(373,200,o),
+(316,283,o),
+(207,283,cs),
+(98,283,o),
+(36,198,o),
+(36,48,cs),
+(36,0,l)
+);
+}
+);
+width = 515;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B9;
+unicode = 5561;
+},
+{
+glyphname = "noBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(201,0,l),
+(201,56,ls),
+(201,169,o),
+(237,228,o),
+(309,228,cs),
+(382,228,o),
+(418,168,o),
+(418,55,cs),
+(418,0,l),
+(478,0,l),
+(478,48,ls),
+(478,198,o),
+(416,283,o),
+(307,283,cs),
+(198,283,o),
+(141,200,o),
+(141,46,cs),
+(141,16,l),
+(164,48,l),
+(124,48,l),
+(124,690,l),
+(63,690,l),
+(63,0,l)
+);
+}
+);
+width = 514;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "neBlackfoot-canadian";
+note = uni15BA;
+unicode = 5562;
+},
+{
+glyphname = "naBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(452,0,l),
+(452,690,l),
+(313,690,l),
+(313,634,ls),
+(313,521,o),
+(277,462,o),
+(205,462,cs),
+(132,462,o),
+(97,522,o),
+(97,635,cs),
+(97,690,l),
+(36,690,l),
+(36,641,ls),
+(36,492,o),
+(98,407,o),
+(207,407,cs),
+(316,407,o),
+(373,490,o),
+(373,643,cs),
+(373,673,l),
+(350,641,l),
+(390,641,l),
+(390,0,l)
+);
+}
+);
+width = 515;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BB;
+unicode = 5563;
+},
+{
+glyphname = "keBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(124,0,l),
+(124,618,l),
+(100,618,l),
+(243,258,l),
+(274,258,l),
+(448,690,l),
+(387,690,l),
+(243,327,l),
+(264,327,l),
+(120,690,l),
+(63,690,l),
+(63,0,l)
+);
+}
+);
+width = 474;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15BC;
+unicode = 5564;
+},
+{
+glyphname = "kiBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(87,0,l),
+(231,362,l),
+(211,362,l),
+(355,0,l),
+(412,0,l),
+(412,690,l),
+(351,690,l),
+(351,71,l),
+(375,71,l),
+(231,432,l),
+(201,432,l),
+(26,0,l)
+);
+}
+);
+width = 475;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BD;
+unicode = 5565;
+},
+{
+glyphname = "koBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(120,0,l),
+(264,362,l),
+(243,362,l),
+(387,0,l),
+(448,0,l),
+(274,432,l),
+(243,432,l),
+(100,71,l),
+(124,71,l),
+(124,690,l),
+(63,690,l),
+(63,0,l)
+);
+}
+);
+width = 474;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "keBlackfoot-canadian";
+note = uni15BE;
+unicode = 5566;
+},
+{
+glyphname = "kaBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(412,0,l),
+(412,690,l),
+(355,690,l),
+(211,327,l),
+(231,327,l),
+(87,690,l),
+(26,690,l),
+(201,258,l),
+(231,258,l),
+(375,618,l),
+(351,618,l),
+(351,0,l)
+);
+}
+);
+width = 475;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BF;
+unicode = 5567;
+},
+{
+color = 9;
+glyphname = "heSayisi-canadian";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_right_can;
+pos = (410,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,0,l),
+(440,690,l),
+(379,690,l),
+(379,281,l),
+(389,281,l),
+(384,540,o),
+(321,702,o),
+(197,702,cs),
+(99,702,o),
+(44,620,o),
+(44,457,cs),
+(44,423,o),
+(47,375,o),
+(55,340,c),
+(114,340,l),
+(106,373,o),
+(103,423,o),
+(103,450,cs),
+(103,591,o),
+(142,647,o),
+(210,647,cs),
+(320,647,o),
+(377,454,o),
+(378,0,c)
+);
+}
+);
+width = 503;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni15C0;
+unicode = 5568;
+},
+{
+color = 9;
+glyphname = "hiSayisi-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(124,0,l),
+(125,454,o),
+(183,647,o),
+(293,647,cs),
+(360,647,o),
+(398,591,o),
+(398,450,cs),
+(398,423,o),
+(395,373,o),
+(388,340,c),
+(446,340,l),
+(455,375,o),
+(457,423,o),
+(457,457,cs),
+(457,620,o),
+(403,702,o),
+(305,702,cs),
+(181,702,o),
+(118,540,o),
+(113,281,c),
+(124,281,l),
+(124,690,l),
+(63,690,l),
+(63,0,l)
+);
+}
+);
+width = 501;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C1;
+unicode = 5569;
+},
+{
+color = 9;
+glyphname = "hoSayisi-canadian";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (246,690);
+},
+{
+name = top_left_can;
+pos = (83,690);
+},
+{
+name = top_right_can;
+pos = (410,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(321,-13,o),
+(384,150,o),
+(389,409,c),
+(379,409,l),
+(379,0,l),
+(440,0,l),
+(440,690,l),
+(378,690,l),
+(377,236,o),
+(320,43,o),
+(210,43,cs),
+(142,43,o),
+(103,99,o),
+(103,240,cs),
+(103,267,o),
+(106,317,o),
+(114,350,c),
+(55,350,l),
+(47,315,o),
+(44,267,o),
+(44,233,cs),
+(44,70,o),
+(99,-13,o),
+(197,-13,cs)
+);
+}
+);
+width = 503;
+}
+);
+metricLeft = "heSayisi-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15C2;
+unicode = 5570;
+},
+{
+color = 9;
+glyphname = "haSayisi-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(403,-13,o),
+(457,70,o),
+(457,233,cs),
+(457,267,o),
+(455,315,o),
+(446,350,c),
+(388,350,l),
+(395,317,o),
+(398,267,o),
+(398,240,cs),
+(398,99,o),
+(360,43,o),
+(293,43,cs),
+(183,43,o),
+(125,236,o),
+(124,690,c),
+(63,690,l),
+(63,0,l),
+(124,0,l),
+(124,409,l),
+(113,409,l),
+(118,150,o),
+(181,-13,o),
+(305,-13,cs)
+);
+}
+);
+width = 501;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C3;
+unicode = 5571;
+},
+{
+color = 9;
+glyphname = "ghuCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(281,0,l),
+(511,670,l),
+(511,690,l),
+(461,690,l),
+(380,447,l),
+(412,461,l),
+(128,461,l),
+(160,446,l),
+(78,690,l),
+(27,690,l),
+(27,670,l),
+(257,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(398,413,l),
+(375,424,l),
+(260,79,l),
+(279,79,l),
+(164,425,l),
+(142,413,l)
+);
+}
+);
+width = 538;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C4;
+unicode = 5572;
+},
+{
+color = 9;
+glyphname = "ghoCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(78,0,l),
+(160,243,l),
+(128,229,l),
+(412,229,l),
+(380,242,l),
+(461,0,l),
+(511,0,l),
+(511,19,l),
+(281,690,l),
+(257,690,l),
+(27,19,l),
+(27,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(279,611,l),
+(260,611,l),
+(375,266,l),
+(398,276,l),
+(142,276,l),
+(164,265,l)
+);
+}
+);
+width = 538;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C5;
+unicode = 5573;
+},
+{
+color = 9;
+glyphname = "gheCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (58,345);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(59,0,l),
+(464,332,l),
+(464,357,l),
+(59,690,l),
+(42,690,l),
+(42,639,l),
+(167,536,l),
+(159,570,l),
+(159,120,l),
+(167,153,l),
+(42,49,l),
+(42,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(204,540,l),
+(191,523,l),
+(426,328,l),
+(426,361,l),
+(191,168,l),
+(204,151,l)
+);
+}
+);
+width = 495;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15C6;
+unicode = 5574;
+},
+{
+color = 9;
+glyphname = "gheeCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (23,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 495;
+}
+);
+note = uni15C7;
+unicode = 5575;
+},
+{
+color = 9;
+glyphname = "ghiCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (4,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 495;
+}
+);
+note = uni15C8;
+unicode = 5576;
+},
+{
+color = 9;
+glyphname = "ghaCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(454,0,l),
+(454,49,l),
+(328,154,l),
+(336,125,l),
+(336,565,l),
+(328,536,l),
+(454,639,l),
+(454,690,l),
+(437,690,l),
+(31,357,l),
+(31,332,l),
+(437,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(304,167,l),
+(69,361,l),
+(69,327,l),
+(304,522,l),
+(292,529,l),
+(292,163,l)
+);
+}
+);
+width = 496;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15C9;
+unicode = 5577;
+},
+{
+color = 9;
+glyphname = "ruCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(281,0,l),
+(511,670,l),
+(511,690,l),
+(461,690,l),
+(429,594,l),
+(448,608,l),
+(91,608,l),
+(112,594,l),
+(79,690,l),
+(27,690,l),
+(27,670,l),
+(257,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(435,559,l),
+(424,574,l),
+(261,79,l),
+(280,79,l),
+(116,574,l),
+(103,559,l)
+);
+}
+);
+width = 538;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CA;
+unicode = 5578;
+},
+{
+color = 9;
+glyphname = "roCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(79,0,l),
+(111,96,l),
+(91,82,l),
+(449,82,l),
+(428,96,l),
+(461,0,l),
+(511,0,l),
+(511,19,l),
+(281,690,l),
+(257,690,l),
+(27,19,l),
+(27,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(278,611,l),
+(259,611,l),
+(423,116,l),
+(436,130,l),
+(105,130,l),
+(115,116,l)
+);
+}
+);
+width = 538;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CB;
+unicode = 5579;
+},
+{
+color = 9;
+glyphname = "reCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(59,0,l),
+(464,332,l),
+(464,357,l),
+(59,690,l),
+(42,690,l),
+(42,639,l),
+(103,587,l),
+(93,611,l),
+(93,79,l),
+(103,101,l),
+(42,51,l),
+(42,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(138,590,l),
+(128,572,l),
+(422,327,l),
+(422,361,l),
+(128,118,l),
+(138,99,l)
+);
+}
+);
+width = 495;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CC;
+unicode = 5580;
+},
+{
+color = 9;
+glyphname = "reeCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(59,0,l),
+(464,332,l),
+(464,357,l),
+(59,690,l),
+(42,690,l),
+(42,644,l),
+(103,593,l),
+(93,611,l),
+(93,79,l),
+(103,96,l),
+(42,45,l),
+(42,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(133,590,l),
+(125,580,l),
+(431,327,l),
+(431,361,l),
+(124,109,l),
+(133,99,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(215,255,l),
+(215,437,l),
+(188,437,l),
+(188,255,l)
+);
+}
+);
+width = 495;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CD;
+unicode = 5581;
+},
+{
+color = 9;
+glyphname = "riCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(59,0,l),
+(464,332,l),
+(464,357,l),
+(59,690,l),
+(42,690,l),
+(42,644,l),
+(103,593,l),
+(93,611,l),
+(93,79,l),
+(103,96,l),
+(42,45,l),
+(42,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(234,312,o),
+(249,327,o),
+(249,345,cs),
+(249,363,o),
+(234,378,o),
+(215,378,cs),
+(197,378,o),
+(183,363,o),
+(183,345,cs),
+(183,327,o),
+(197,312,o),
+(215,312,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(133,590,l),
+(125,580,l),
+(431,327,l),
+(431,361,l),
+(124,108,l),
+(133,99,l)
+);
+}
+);
+width = 495;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CE;
+unicode = 5582;
+},
+{
+color = 9;
+glyphname = "raCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(454,0,l),
+(454,51,l),
+(392,102,l),
+(403,67,l),
+(403,624,l),
+(392,588,l),
+(454,639,l),
+(454,690,l),
+(436,690,l),
+(31,357,l),
+(31,332,l),
+(436,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(367,572,l),
+(357,591,l),
+(357,99,l),
+(367,118,l),
+(72,361,l),
+(72,328,l)
+);
+}
+);
+width = 496;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15CF;
+unicode = 5583;
+},
+{
+color = 9;
+glyphname = "wuCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(283,0,l),
+(516,670,l),
+(516,690,l),
+(468,690,l),
+(282,120,l),
+(298,120,l),
+(298,690,l),
+(250,690,l),
+(250,120,l),
+(265,120,l),
+(77,690,l),
+(27,690,l),
+(27,670,l),
+(260,0,l)
+);
+}
+);
+width = 543;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D0;
+unicode = 5584;
+},
+{
+color = 9;
+glyphname = "woCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(76,0,l),
+(264,570,l),
+(247,570,l),
+(247,0,l),
+(296,0,l),
+(296,570,l),
+(281,570,l),
+(468,0,l),
+(516,0,l),
+(516,19,l),
+(283,690,l),
+(260,690,l),
+(27,19,l),
+(27,0,l)
+);
+}
+);
+width = 543;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D1;
+unicode = 5585;
+},
+{
+color = 9;
+glyphname = "weCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(77,0,l),
+(483,332,l),
+(483,357,l),
+(78,690,l),
+(61,690,l),
+(61,639,l),
+(405,356,l),
+(405,370,l),
+(64,370,l),
+(64,321,l),
+(405,321,l),
+(405,333,l),
+(61,49,l),
+(61,0,l)
+);
+}
+);
+width = 514;
+}
+);
+metricRight = "o-canadian";
+note = uni15D2;
+unicode = 5586;
+},
+{
+color = 9;
+glyphname = "weeCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(77,0,l),
+(483,332,l),
+(483,357,l),
+(78,690,l),
+(61,690,l),
+(61,642,l),
+(420,350,l),
+(425,366,l),
+(167,366,l),
+(167,441,l),
+(130,441,l),
+(130,366,l),
+(61,366,l),
+(61,325,l),
+(130,325,l),
+(130,249,l),
+(167,249,l),
+(167,325,l),
+(426,325,l),
+(421,340,l),
+(61,47,l),
+(61,0,l)
+);
+}
+);
+width = 514;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D3;
+unicode = 5587;
+},
+{
+color = 9;
+glyphname = "wiCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(77,0,l),
+(483,332,l),
+(483,357,l),
+(78,690,l),
+(61,690,l),
+(61,642,l),
+(420,350,l),
+(425,366,l),
+(218,366,l),
+(211,385,o),
+(191,400,o),
+(169,400,cs),
+(147,400,o),
+(128,385,o),
+(120,366,c),
+(61,366,l),
+(61,325,l),
+(119,325,l),
+(128,305,o),
+(147,290,o),
+(169,290,cs),
+(191,290,o),
+(211,305,o),
+(218,325,c),
+(426,325,l),
+(421,340,l),
+(61,47,l),
+(61,0,l)
+);
+}
+);
+width = 514;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D4;
+unicode = 5588;
+},
+{
+color = 9;
+glyphname = "waCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(454,0,l),
+(454,50,l),
+(109,333,l),
+(109,320,l),
+(451,320,l),
+(451,369,l),
+(109,369,l),
+(109,356,l),
+(454,639,l),
+(454,690,l),
+(438,690,l),
+(31,357,l),
+(31,332,l),
+(437,0,l)
+);
+}
+);
+width = 515;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15D5;
+unicode = 5589;
+},
+{
+color = 9;
+glyphname = "hwuCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(283,0,l),
+(516,670,l),
+(516,690,l),
+(470,690,l),
+(393,458,l),
+(412,467,l),
+(293,467,l),
+(293,690,l),
+(252,690,l),
+(252,467,l),
+(129,467,l),
+(151,459,l),
+(74,690,l),
+(27,690,l),
+(27,670,l),
+(260,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(254,430,l),
+(254,108,l),
+(264,109,l),
+(156,438,l),
+(134,430,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(291,430,l),
+(408,430,l),
+(388,438,l),
+(281,112,l),
+(291,111,l)
+);
+}
+);
+width = 543;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D6;
+unicode = 5590;
+},
+{
+color = 9;
+glyphname = "hwoCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(74,0,l),
+(152,232,l),
+(133,220,l),
+(251,220,l),
+(251,0,l),
+(292,0,l),
+(292,220,l),
+(416,220,l),
+(393,231,l),
+(470,0,l),
+(516,0,l),
+(516,19,l),
+(283,690,l),
+(260,690,l),
+(27,19,l),
+(27,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(263,578,l),
+(253,580,l),
+(253,263,l),
+(146,263,l),
+(156,252,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(403,263,l),
+(289,263,l),
+(289,582,l),
+(279,581,l),
+(387,252,l)
+);
+}
+);
+width = 543;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D7;
+unicode = 5591;
+},
+{
+color = 9;
+glyphname = "hweCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(77,0,l),
+(483,332,l),
+(483,357,l),
+(78,690,l),
+(61,690,l),
+(61,642,l),
+(175,549,l),
+(175,367,l),
+(61,367,l),
+(61,324,l),
+(175,324,l),
+(175,140,l),
+(61,46,l),
+(61,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(211,327,l),
+(410,327,l),
+(211,163,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(211,526,l),
+(409,363,l),
+(211,363,l)
+);
+}
+);
+width = 514;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D8;
+unicode = 5592;
+},
+{
+color = 9;
+glyphname = "hweeCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(77,0,l),
+(483,332,l),
+(483,357,l),
+(78,690,l),
+(61,690,l),
+(61,644,l),
+(188,542,l),
+(188,364,l),
+(146,364,l),
+(146,441,l),
+(114,441,l),
+(114,364,l),
+(61,364,l),
+(61,326,l),
+(114,326,l),
+(114,249,l),
+(146,249,l),
+(146,326,l),
+(188,326,l),
+(188,148,l),
+(61,43,l),
+(61,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(222,328,l),
+(411,328,l),
+(222,170,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(222,520,l),
+(410,362,l),
+(222,362,l)
+);
+}
+);
+width = 514;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D9;
+unicode = 5593;
+},
+{
+color = 9;
+glyphname = "hwiCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(77,0,l),
+(483,332,l),
+(483,357,l),
+(78,690,l),
+(61,690,l),
+(61,644,l),
+(188,542,l),
+(188,362,l),
+(171,362,l),
+(165,381,o),
+(149,394,o),
+(129,394,cs),
+(109,394,o),
+(93,381,o),
+(87,362,c),
+(61,362,l),
+(61,328,l),
+(86,328,l),
+(92,310,o),
+(109,296,o),
+(128,296,cs),
+(148,296,o),
+(165,310,o),
+(172,328,c),
+(188,328,l),
+(188,148,l),
+(61,43,l),
+(61,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(222,328,l),
+(411,328,l),
+(222,170,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(222,520,l),
+(410,362,l),
+(222,362,l)
+);
+}
+);
+width = 514;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15DA;
+unicode = 5594;
+},
+{
+color = 9;
+glyphname = "hwaCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(454,0,l),
+(454,47,l),
+(340,140,l),
+(340,323,l),
+(454,323,l),
+(454,366,l),
+(340,366,l),
+(340,549,l),
+(454,643,l),
+(454,690,l),
+(438,690,l),
+(31,357,l),
+(31,332,l),
+(437,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(106,327,l),
+(303,327,l),
+(303,163,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(303,526,l),
+(303,363,l),
+(105,363,l)
+);
+}
+);
+width = 515;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15DB;
+unicode = 5595;
+},
+{
+color = 9;
+glyphname = "thuCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(407,-13,o),
+(485,71,o),
+(485,237,cs),
+(485,690,l),
+(59,690,l),
+(59,234,ls),
+(59,71,o),
+(141,-13,o),
+(272,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(120,634,l),
+(424,634,l),
+(424,236,ls),
+(424,103,o),
+(369,45,o),
+(271,45,cs),
+(178,45,o),
+(120,105,o),
+(120,236,cs)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DC;
+unicode = 5596;
+},
+{
+color = 9;
+glyphname = "thoCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(485,0,l),
+(485,456,ls),
+(485,618,o),
+(404,702,o),
+(272,702,cs),
+(138,702,o),
+(59,619,o),
+(59,453,cs),
+(59,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(120,454,ls),
+(120,586,o),
+(175,644,o),
+(272,644,cs),
+(367,644,o),
+(424,584,o),
+(424,454,cs),
+(424,56,l),
+(120,56,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DD;
+unicode = 5597;
+},
+{
+color = 9;
+glyphname = "theCarrier-canadian";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (263,345);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(195,0,ls),
+(386,0,o),
+(474,121,o),
+(474,346,cs),
+(474,571,o),
+(386,690,o),
+(190,690,cs),
+(63,690,l),
+(63,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(124,656,l),
+(102,635,l),
+(190,635,ls),
+(351,635,o),
+(413,539,o),
+(413,346,cs),
+(413,154,o),
+(351,55,o),
+(195,55,cs),
+(102,55,l),
+(124,34,l)
+);
+}
+);
+width = 524;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "to-canadian";
+note = uni15DE;
+unicode = 5598;
+},
+{
+color = 9;
+glyphname = "theeCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (225,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 525;
+}
+);
+note = uni15DF;
+unicode = 5599;
+},
+{
+color = 9;
+glyphname = "thiCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (205,0);
+ref = dot_middle;
+}
+);
+width = 525;
+}
+);
+note = uni15E0;
+unicode = 5600;
+},
+{
+color = 9;
+glyphname = "thaCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(463,0,l),
+(463,690,l),
+(329,690,ls),
+(139,690,o),
+(50,569,o),
+(50,344,cs),
+(50,119,o),
+(139,0,o),
+(335,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(112,536,o),
+(174,635,o),
+(329,635,cs),
+(423,635,l),
+(401,656,l),
+(401,34,l),
+(423,55,l),
+(334,55,ls),
+(174,55,o),
+(112,151,o),
+(112,344,cs)
+);
+}
+);
+width = 526;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15E1;
+unicode = 5601;
+},
+{
+color = 9;
+glyphname = "ttuCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(407,-13,o),
+(485,71,o),
+(485,237,cs),
+(485,690,l),
+(463,690,l),
+(265,502,l),
+(281,502,l),
+(83,690,l),
+(59,690,l),
+(59,234,ls),
+(59,71,o),
+(141,-13,o),
+(272,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(178,45,o),
+(120,105,o),
+(120,236,cs),
+(120,642,l),
+(68,639,l),
+(265,452,l),
+(280,452,l),
+(477,639,l),
+(424,642,l),
+(424,236,ls),
+(424,103,o),
+(369,45,o),
+(271,45,cs)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E2;
+unicode = 5602;
+},
+{
+color = 9;
+glyphname = "ttoCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(82,0,l),
+(280,187,l),
+(264,187,l),
+(461,0,l),
+(485,0,l),
+(485,456,ls),
+(485,618,o),
+(404,702,o),
+(272,702,cs),
+(138,702,o),
+(59,619,o),
+(59,453,cs),
+(59,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(367,644,o),
+(424,584,o),
+(424,454,cs),
+(424,47,l),
+(477,50,l),
+(280,238,l),
+(265,238,l),
+(67,50,l),
+(120,47,l),
+(120,454,ls),
+(120,586,o),
+(175,644,o),
+(272,644,cs)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E3;
+unicode = 5603;
+},
+{
+color = 9;
+glyphname = "tteCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (304,345);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(204,0,ls),
+(395,0,o),
+(484,121,o),
+(484,346,cs),
+(484,571,o),
+(395,690,o),
+(200,690,cs),
+(59,690,l),
+(59,670,l),
+(153,333,l),
+(153,356,l),
+(59,19,l),
+(59,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(208,336,l),
+(208,351,l),
+(114,683,l),
+(114,635,l),
+(200,635,ls),
+(360,635,o),
+(422,539,o),
+(422,346,cs),
+(422,154,o),
+(360,55,o),
+(205,55,cs),
+(114,55,l),
+(114,4,l)
+);
+}
+);
+width = 534;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15E4;
+unicode = 5604;
+},
+{
+color = 9;
+glyphname = "tteeCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (270,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 534;
+}
+);
+note = uni15E5;
+unicode = 5605;
+},
+{
+color = 9;
+glyphname = "ttiCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (256,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 534;
+}
+);
+note = uni15E6;
+unicode = 5606;
+},
+{
+color = 9;
+glyphname = "ttaCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(475,0,l),
+(475,19,l),
+(382,356,l),
+(382,333,l),
+(475,670,l),
+(475,690,l),
+(329,690,ls),
+(139,690,o),
+(50,569,o),
+(50,344,cs),
+(50,119,o),
+(139,0,o),
+(335,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(420,55,l),
+(334,55,ls),
+(174,55,o),
+(112,151,o),
+(112,344,cs),
+(112,536,o),
+(174,635,o),
+(329,635,cs),
+(420,635,l),
+(420,686,l),
+(327,354,l),
+(327,339,l),
+(420,7,l)
+);
+}
+);
+width = 534;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tteCarrier-canadian";
+note = uni15E7;
+unicode = 5607;
+},
+{
+color = 9;
+glyphname = "puCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(407,-13,o),
+(485,71,o),
+(485,237,cs),
+(485,690,l),
+(424,690,l),
+(424,517,l),
+(121,517,l),
+(121,690,l),
+(59,690,l),
+(59,234,ls),
+(59,71,o),
+(141,-13,o),
+(272,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(178,45,o),
+(121,105,o),
+(121,236,cs),
+(121,462,l),
+(424,462,l),
+(424,236,ls),
+(424,103,o),
+(369,45,o),
+(271,45,cs)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E8;
+unicode = 5608;
+},
+{
+color = 9;
+glyphname = "poCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,0,l),
+(121,173,l),
+(424,173,l),
+(424,0,l),
+(485,0,l),
+(485,456,ls),
+(485,618,o),
+(404,702,o),
+(272,702,cs),
+(140,702,o),
+(59,619,o),
+(59,453,cs),
+(59,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(121,454,ls),
+(121,586,o),
+(175,644,o),
+(272,644,cs),
+(367,644,o),
+(424,584,o),
+(424,454,cs),
+(424,228,l),
+(121,228,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E9;
+unicode = 5609;
+},
+{
+color = 9;
+glyphname = "peCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (295,345);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(201,0,ls),
+(393,0,o),
+(481,121,o),
+(481,346,cs),
+(481,571,o),
+(393,690,o),
+(197,690,cs),
+(56,690,l),
+(56,635,l),
+(123,635,l),
+(123,55,l),
+(56,55,l),
+(56,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(184,656,l),
+(155,635,l),
+(198,635,ls),
+(358,635,o),
+(419,539,o),
+(419,346,cs),
+(419,154,o),
+(358,55,o),
+(202,55,cs),
+(155,55,l),
+(184,34,l)
+);
+}
+);
+width = 531;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15EA;
+unicode = 5610;
+},
+{
+color = 9;
+glyphname = "peeCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (261,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 531;
+}
+);
+note = uni15EB;
+unicode = 5611;
+},
+{
+color = 9;
+glyphname = "piCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (246,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 531;
+}
+);
+note = uni15EC;
+unicode = 5612;
+},
+{
+color = 9;
+glyphname = "paCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(475,0,l),
+(475,55,l),
+(409,55,l),
+(409,635,l),
+(475,635,l),
+(475,690,l),
+(334,690,ls),
+(139,690,o),
+(50,571,o),
+(50,346,cs),
+(50,121,o),
+(139,0,o),
+(330,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(377,55,l),
+(329,55,ls),
+(174,55,o),
+(112,154,o),
+(112,346,cs),
+(112,539,o),
+(174,635,o),
+(334,635,cs),
+(377,635,l),
+(348,656,l),
+(348,34,l)
+);
+}
+);
+width = 531;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|peCarrier-canadian";
+note = uni15ED;
+unicode = 5613;
+},
+{
+color = 6;
+glyphname = "pCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(293,183,l),
+(293,225,l),
+(193,225,l),
+(193,527,l),
+(150,527,l),
+(150,225,l),
+(50,225,l),
+(50,183,l)
+);
+}
+);
+width = 343;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni15EE;
+unicode = 5614;
+},
+{
+color = 9;
+glyphname = "guCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (323,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(270,-13,o),
+(317,29,o),
+(335,113,c),
+(310,113,l),
+(331,28,o),
+(379,-13,o),
+(444,-13,cs),
+(532,-13,o),
+(588,52,o),
+(588,176,cs),
+(588,690,l),
+(529,690,l),
+(529,179,ls),
+(529,86,o),
+(498,44,o),
+(441,44,cs),
+(384,44,o),
+(352,88,o),
+(352,179,cs),
+(352,690,l),
+(295,690,l),
+(295,179,ls),
+(295,86,o),
+(262,44,o),
+(205,44,cs),
+(147,44,o),
+(115,86,o),
+(115,179,cs),
+(115,690,l),
+(56,690,l),
+(56,178,ls),
+(56,51,o),
+(114,-13,o),
+(202,-13,cs)
+);
+}
+);
+width = 644;
+}
+);
+metricRight = "=|";
+note = uni15EF;
+unicode = 5615;
+},
+{
+color = 9;
+glyphname = "goCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(115,0,l),
+(115,511,ls),
+(115,603,o),
+(147,645,o),
+(204,645,cs),
+(260,645,o),
+(293,602,o),
+(293,511,cs),
+(293,0,l),
+(350,0,l),
+(350,511,ls),
+(350,604,o),
+(383,645,o),
+(440,645,cs),
+(498,645,o),
+(529,604,o),
+(529,511,cs),
+(529,0,l),
+(588,0,l),
+(588,512,ls),
+(588,639,o),
+(530,702,o),
+(442,702,cs),
+(375,702,o),
+(327,661,o),
+(309,577,c),
+(334,577,l),
+(313,662,o),
+(266,702,o),
+(200,702,cs),
+(113,702,o),
+(56,638,o),
+(56,514,cs),
+(56,0,l)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F0;
+unicode = 5616;
+},
+{
+color = 9;
+glyphname = "geCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (269,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(288,0,ls),
+(402,0,o),
+(474,63,o),
+(474,181,cs),
+(474,265,o),
+(431,329,o),
+(360,354,c),
+(360,336,l),
+(432,358,o),
+(474,420,o),
+(474,507,cs),
+(474,626,o),
+(401,690,o),
+(288,690,cs),
+(63,690,l),
+(63,638,l),
+(278,638,ls),
+(361,638,o),
+(413,596,o),
+(413,505,cs),
+(413,416,o),
+(361,371,o),
+(279,371,cs),
+(63,371,l),
+(63,319,l),
+(280,319,ls),
+(360,319,o),
+(413,273,o),
+(413,184,cs),
+(413,93,o),
+(360,52,o),
+(278,52,cs),
+(63,52,l),
+(63,0,l)
+);
+}
+);
+width = 534;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15F1;
+unicode = 5617;
+},
+{
+color = 9;
+glyphname = "geeCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(288,0,ls),
+(402,0,o),
+(474,63,o),
+(474,181,cs),
+(474,265,o),
+(431,329,o),
+(360,354,c),
+(360,336,l),
+(432,358,o),
+(474,420,o),
+(474,507,cs),
+(474,626,o),
+(401,690,o),
+(288,690,cs),
+(63,690,l),
+(63,638,l),
+(278,638,ls),
+(361,638,o),
+(413,596,o),
+(413,505,cs),
+(413,416,o),
+(361,371,o),
+(279,371,cs),
+(257,371,l),
+(257,452,l),
+(220,452,l),
+(220,371,l),
+(63,371,l),
+(63,320,l),
+(220,320,l),
+(220,240,l),
+(257,240,l),
+(257,320,l),
+(280,320,ls),
+(360,320,o),
+(413,273,o),
+(413,184,cs),
+(413,93,o),
+(360,52,o),
+(278,52,cs),
+(63,52,l),
+(63,0,l)
+);
+}
+);
+width = 534;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F2;
+unicode = 5618;
+},
+{
+color = 9;
+glyphname = "giCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(288,0,ls),
+(402,0,o),
+(474,63,o),
+(474,181,cs),
+(474,265,o),
+(431,329,o),
+(360,354,c),
+(360,336,l),
+(432,358,o),
+(474,420,o),
+(474,507,cs),
+(474,626,o),
+(401,690,o),
+(288,690,cs),
+(63,690,l),
+(63,638,l),
+(278,638,ls),
+(361,638,o),
+(413,596,o),
+(413,505,cs),
+(413,416,o),
+(361,371,o),
+(285,371,cs),
+(271,371,l),
+(295,363,l),
+(286,387,o),
+(265,404,o),
+(240,404,cs),
+(217,404,o),
+(198,390,o),
+(189,371,c),
+(63,371,l),
+(63,320,l),
+(189,320,l),
+(197,299,o),
+(217,286,o),
+(240,286,cs),
+(265,286,o),
+(286,302,o),
+(295,327,c),
+(271,320,l),
+(285,320,ls),
+(360,320,o),
+(413,273,o),
+(413,184,cs),
+(413,93,o),
+(360,52,o),
+(278,52,cs),
+(63,52,l),
+(63,0,l)
+);
+}
+);
+width = 534;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F3;
+unicode = 5619;
+},
+{
+color = 9;
+glyphname = "gaCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (279,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(472,0,l),
+(472,52,l),
+(256,52,ls),
+(174,52,o),
+(122,93,o),
+(122,184,cs),
+(122,273,o),
+(175,319,o),
+(254,319,cs),
+(472,319,l),
+(472,371,l),
+(255,371,ls),
+(173,371,o),
+(122,416,o),
+(122,505,cs),
+(122,596,o),
+(174,638,o),
+(256,638,cs),
+(472,638,l),
+(472,690,l),
+(246,690,ls),
+(133,690,o),
+(60,626,o),
+(60,507,cs),
+(60,420,o),
+(102,358,o),
+(175,336,c),
+(175,354,l),
+(103,329,o),
+(60,265,o),
+(60,181,cs),
+(60,63,o),
+(132,0,o),
+(246,0,cs)
+);
+}
+);
+width = 535;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|geCarrier-canadian";
+note = uni15F4;
+unicode = 5620;
+},
+{
+color = 9;
+glyphname = "khuCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(270,-13,o),
+(318,29,o),
+(336,113,c),
+(311,113,l),
+(332,28,o),
+(380,-13,o),
+(445,-13,cs),
+(532,-13,o),
+(588,52,o),
+(588,176,cs),
+(588,690,l),
+(56,690,l),
+(56,178,ls),
+(56,51,o),
+(114,-13,o),
+(202,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(147,44,o),
+(116,86,o),
+(116,179,cs),
+(116,635,l),
+(296,635,l),
+(296,179,ls),
+(296,86,o),
+(263,44,o),
+(206,44,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(384,44,o),
+(352,88,o),
+(352,179,cs),
+(352,635,l),
+(529,635,l),
+(529,179,ls),
+(529,86,o),
+(498,44,o),
+(441,44,cs)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F5;
+unicode = 5621;
+},
+{
+color = 9;
+glyphname = "khoCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(588,0,l),
+(588,512,ls),
+(588,639,o),
+(530,702,o),
+(442,702,cs),
+(374,702,o),
+(327,661,o),
+(308,577,c),
+(333,577,l),
+(312,662,o),
+(265,702,o),
+(200,702,cs),
+(112,702,o),
+(56,638,o),
+(56,514,cs),
+(56,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(115,511,ls),
+(115,603,o),
+(146,645,o),
+(203,645,cs),
+(260,645,o),
+(293,602,o),
+(293,511,cs),
+(293,55,l),
+(115,55,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(349,511,ls),
+(349,604,o),
+(382,645,o),
+(439,645,cs),
+(497,645,o),
+(528,604,o),
+(528,511,cs),
+(528,55,l),
+(349,55,l)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F6;
+unicode = 5622;
+},
+{
+color = 9;
+glyphname = "kheCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(290,0,ls),
+(404,0,o),
+(476,63,o),
+(476,181,cs),
+(476,265,o),
+(433,329,o),
+(362,354,c),
+(362,336,l),
+(434,358,o),
+(476,420,o),
+(476,507,cs),
+(476,626,o),
+(403,690,o),
+(290,690,cs),
+(63,690,l),
+(63,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(124,320,l),
+(282,320,ls),
+(361,320,o),
+(415,273,o),
+(415,184,cs),
+(415,93,o),
+(362,52,o),
+(280,52,cs),
+(124,52,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(124,638,l),
+(280,638,ls),
+(363,638,o),
+(415,596,o),
+(415,505,cs),
+(415,416,o),
+(363,371,o),
+(281,371,cs),
+(124,371,l)
+);
+}
+);
+width = 536;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F7;
+unicode = 5623;
+},
+{
+color = 9;
+glyphname = "kheeCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(290,0,ls),
+(404,0,o),
+(476,63,o),
+(476,181,cs),
+(476,269,o),
+(428,335,o),
+(349,354,c),
+(349,335,l),
+(429,352,o),
+(476,415,o),
+(476,507,cs),
+(476,626,o),
+(403,690,o),
+(290,690,cs),
+(63,690,l),
+(63,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(124,320,l),
+(236,320,l),
+(236,231,l),
+(272,231,l),
+(272,333,l),
+(250,320,l),
+(287,320,ls),
+(364,320,o),
+(415,273,o),
+(415,184,cs),
+(415,93,o),
+(362,52,o),
+(280,52,cs),
+(124,52,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(272,461,l),
+(236,461,l),
+(236,371,l),
+(124,371,l),
+(124,638,l),
+(280,638,ls),
+(363,638,o),
+(415,596,o),
+(415,505,cs),
+(415,416,o),
+(366,371,o),
+(287,371,cs),
+(250,371,l),
+(272,356,l)
+);
+}
+);
+width = 536;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F8;
+unicode = 5624;
+},
+{
+color = 9;
+glyphname = "khiCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(290,0,ls),
+(404,0,o),
+(476,63,o),
+(476,181,cs),
+(476,265,o),
+(433,329,o),
+(362,353,c),
+(362,336,l),
+(434,357,o),
+(476,420,o),
+(476,507,cs),
+(476,626,o),
+(403,690,o),
+(290,690,cs),
+(63,690,l),
+(63,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(124,322,l),
+(199,322,l),
+(208,300,o),
+(228,286,o),
+(251,286,cs),
+(281,286,o),
+(304,310,o),
+(307,340,c),
+(274,322,l),
+(290,322,ls),
+(364,322,o),
+(415,275,o),
+(415,185,cs),
+(415,92,o),
+(362,52,o),
+(280,52,cs),
+(124,52,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(280,638,ls),
+(363,638,o),
+(415,597,o),
+(415,503,cs),
+(415,414,o),
+(366,368,o),
+(289,368,cs),
+(274,368,l),
+(306,350,l),
+(304,380,o),
+(281,404,o),
+(251,404,cs),
+(221,404,o),
+(197,380,o),
+(194,350,c),
+(212,368,l),
+(124,368,l),
+(124,638,l)
+);
+}
+);
+width = 536;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F9;
+unicode = 5625;
+},
+{
+color = 9;
+glyphname = "khaCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(474,0,l),
+(474,690,l),
+(246,690,ls),
+(133,690,o),
+(60,626,o),
+(60,507,cs),
+(60,420,o),
+(102,357,o),
+(175,336,c),
+(174,353,l),
+(103,329,o),
+(60,265,o),
+(60,181,cs),
+(60,63,o),
+(132,0,o),
+(246,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(174,52,o),
+(122,93,o),
+(122,184,cs),
+(122,273,o),
+(175,320,o),
+(254,320,cs),
+(412,320,l),
+(412,52,l),
+(256,52,ls)
+);
+},
+{
+closed = 1;
+nodes = (
+(173,371,o),
+(122,416,o),
+(122,505,cs),
+(122,596,o),
+(174,638,o),
+(256,638,cs),
+(412,638,l),
+(412,371,l),
+(255,371,ls)
+);
+}
+);
+width = 537;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15FA;
+unicode = 5626;
+},
+{
+color = 9;
+glyphname = "kkuCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(270,-13,o),
+(316,28,o),
+(335,111,c),
+(311,111,l),
+(332,28,o),
+(379,-13,o),
+(444,-13,cs),
+(532,-13,o),
+(588,52,o),
+(588,176,cs),
+(588,690,l),
+(564,690,l),
+(339,519,l),
+(339,460,l),
+(544,618,l),
+(529,627,l),
+(529,179,ls),
+(529,86,o),
+(497,44,o),
+(440,44,cs),
+(384,44,o),
+(351,88,o),
+(351,179,cs),
+(351,690,l),
+(295,690,l),
+(295,179,ls),
+(295,86,o),
+(262,44,o),
+(206,44,cs),
+(147,44,o),
+(115,86,o),
+(115,179,cs),
+(115,627,l),
+(101,618,l),
+(303,461,l),
+(303,521,l),
+(81,690,l),
+(56,690,l),
+(56,178,ls),
+(56,51,o),
+(114,-13,o),
+(202,-13,cs)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FB;
+unicode = 5627;
+},
+{
+color = 9;
+glyphname = "kkoCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(80,0,l),
+(305,171,l),
+(305,230,l),
+(100,71,l),
+(115,63,l),
+(115,511,ls),
+(115,604,o),
+(147,645,o),
+(204,645,cs),
+(260,645,o),
+(294,602,o),
+(294,511,cs),
+(294,0,l),
+(350,0,l),
+(350,511,ls),
+(350,604,o),
+(383,645,o),
+(440,645,cs),
+(498,645,o),
+(529,604,o),
+(529,511,cs),
+(529,63,l),
+(544,71,l),
+(341,229,l),
+(341,169,l),
+(563,0,l),
+(588,0,l),
+(588,512,ls),
+(588,639,o),
+(531,702,o),
+(443,702,cs),
+(376,702,o),
+(328,662,o),
+(309,579,c),
+(334,579,l),
+(312,662,o),
+(266,702,o),
+(201,702,cs),
+(113,702,o),
+(56,638,o),
+(56,514,cs),
+(56,0,l)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FC;
+unicode = 5628;
+},
+{
+color = 9;
+glyphname = "kkeCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(303,0,ls),
+(417,0,o),
+(490,63,o),
+(490,181,cs),
+(490,265,o),
+(446,329,o),
+(376,353,c),
+(375,336,l),
+(447,357,o),
+(490,420,o),
+(490,507,cs),
+(490,626,o),
+(416,690,o),
+(303,690,cs),
+(62,690,l),
+(62,670,l),
+(146,371,l),
+(65,371,l),
+(65,319,l),
+(146,319,l),
+(62,19,l),
+(62,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(207,319,l),
+(295,319,ls),
+(375,319,o),
+(428,273,o),
+(428,184,cs),
+(428,93,o),
+(376,52,o),
+(294,52,cs),
+(105,52,l),
+(125,26,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(124,664,l),
+(104,638,l),
+(294,638,ls),
+(376,638,o),
+(428,596,o),
+(428,505,cs),
+(428,416,o),
+(377,371,o),
+(295,371,cs),
+(206,371,l)
+);
+}
+);
+width = 550;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni15FD;
+unicode = 5629;
+},
+{
+color = 9;
+glyphname = "kkeeCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(303,0,ls),
+(417,0,o),
+(490,63,o),
+(490,181,cs),
+(490,265,o),
+(446,329,o),
+(376,353,c),
+(375,336,l),
+(447,357,o),
+(490,420,o),
+(490,507,cs),
+(490,626,o),
+(416,690,o),
+(303,690,cs),
+(62,690,l),
+(62,670,l),
+(146,371,l),
+(65,371,l),
+(65,319,l),
+(146,319,l),
+(62,19,l),
+(62,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(206,321,l),
+(268,321,l),
+(268,239,l),
+(304,239,l),
+(304,336,l),
+(278,321,l),
+(299,321,ls),
+(378,321,o),
+(428,275,o),
+(428,185,cs),
+(428,94,o),
+(376,52,o),
+(294,52,cs),
+(103,52,l),
+(124,26,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(304,452,l),
+(268,452,l),
+(268,370,l),
+(205,370,l),
+(122,664,l),
+(102,638,l),
+(294,638,ls),
+(376,638,o),
+(428,596,o),
+(428,504,cs),
+(428,414,o),
+(379,370,o),
+(299,370,cs),
+(278,370,l),
+(304,356,l)
+);
+}
+);
+width = 550;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FE;
+unicode = 5630;
+},
+{
+color = 9;
+glyphname = "kkiCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(303,0,ls),
+(417,0,o),
+(490,63,o),
+(490,181,cs),
+(490,265,o),
+(446,329,o),
+(376,353,c),
+(375,336,l),
+(447,357,o),
+(490,420,o),
+(490,507,cs),
+(490,626,o),
+(416,690,o),
+(303,690,cs),
+(62,690,l),
+(62,670,l),
+(146,371,l),
+(65,371,l),
+(65,319,l),
+(146,319,l),
+(62,19,l),
+(62,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(207,323,l),
+(224,323,l),
+(231,301,o),
+(251,286,o),
+(275,286,cs),
+(305,286,o),
+(327,311,o),
+(328,337,c),
+(283,323,l),
+(299,323,ls),
+(378,323,o),
+(428,275,o),
+(428,183,cs),
+(428,94,o),
+(376,52,o),
+(294,52,cs),
+(103,52,l),
+(124,26,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(327,379,o),
+(306,404,o),
+(275,404,cs),
+(251,404,o),
+(231,388,o),
+(224,367,c),
+(206,367,l),
+(122,664,l),
+(102,638,l),
+(294,638,ls),
+(376,638,o),
+(428,596,o),
+(428,502,cs),
+(428,414,o),
+(379,367,o),
+(299,367,cs),
+(283,367,l),
+(329,353,l)
+);
+}
+);
+width = 550;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FF;
+unicode = 5631;
+},
+{
+color = 9;
+glyphname = "kkaCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(488,0,l),
+(488,19,l),
+(404,319,l),
+(486,319,l),
+(486,371,l),
+(404,371,l),
+(488,670,l),
+(488,690,l),
+(246,690,ls),
+(133,690,o),
+(60,626,o),
+(60,507,cs),
+(60,420,o),
+(102,357,o),
+(175,336,c),
+(174,353,l),
+(103,329,o),
+(60,265,o),
+(60,181,cs),
+(60,63,o),
+(132,0,o),
+(246,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(444,52,l),
+(256,52,ls),
+(174,52,o),
+(122,93,o),
+(122,184,cs),
+(122,273,o),
+(175,319,o),
+(254,319,cs),
+(342,319,l),
+(425,26,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(173,371,o),
+(122,416,o),
+(122,505,cs),
+(122,596,o),
+(174,638,o),
+(256,638,cs),
+(445,638,l),
+(426,664,l),
+(344,371,l),
+(255,371,ls)
+);
+}
+);
+width = 550;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|kkeCarrier-canadian";
+note = uni1600;
+unicode = 5632;
+},
+{
+color = 6;
+glyphname = "kkCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(158,183,l),
+(273,516,l),
+(273,527,l),
+(231,527,l),
+(137,234,l),
+(167,234,l),
+(72,527,l),
+(31,527,l),
+(31,516,l),
+(146,183,l)
+);
+}
+);
+width = 303;
+}
+);
+note = uni1601;
+unicode = 5633;
+},
+{
+color = 9;
+glyphname = "nuCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(406,-13,o),
+(485,71,o),
+(485,240,cs),
+(485,298,l),
+(424,298,l),
+(424,236,ls),
+(424,104,o),
+(369,45,o),
+(271,45,cs),
+(178,45,o),
+(121,106,o),
+(121,231,cs),
+(121,690,l),
+(59,690,l),
+(59,235,ls),
+(59,72,o),
+(142,-13,o),
+(271,-13,cs)
+);
+}
+);
+width = 540;
+}
+);
+metricLeft = "te-canadian";
+note = uni1602;
+unicode = 5634;
+},
+{
+color = 9;
+glyphname = "noCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(480,0,l),
+(480,455,ls),
+(480,617,o),
+(397,702,o),
+(268,702,cs),
+(133,702,o),
+(55,618,o),
+(55,450,cs),
+(55,391,l),
+(116,391,l),
+(116,454,ls),
+(116,585,o),
+(170,644,o),
+(268,644,cs),
+(361,644,o),
+(418,583,o),
+(418,459,cs),
+(418,0,l)
+);
+}
+);
+width = 539;
+}
+);
+metricLeft = "=|nuCarrier-canadian";
+metricRight = "te-canadian";
+note = uni1603;
+unicode = 5635;
+},
+{
+color = 9;
+glyphname = "neCarrier-canadian";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (220,345);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(203,0,ls),
+(382,0,o),
+(472,121,o),
+(472,346,cs),
+(472,571,o),
+(384,690,o),
+(188,690,cs),
+(42,690,l),
+(42,633,l),
+(189,633,ls),
+(347,633,o),
+(412,538,o),
+(412,346,cs),
+(412,156,o),
+(344,57,o),
+(204,57,cs),
+(200,57,l),
+(200,0,l)
+);
+}
+);
+width = 522;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1604;
+unicode = 5636;
+},
+{
+color = 9;
+glyphname = "neeCarrier-canadian";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+ref = "neCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (182,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 522;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1605;
+unicode = 5637;
+},
+{
+color = 9;
+glyphname = "niCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "neCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (162,0);
+ref = dot_middle;
+}
+);
+width = 524;
+}
+);
+note = uni1606;
+unicode = 5638;
+},
+{
+color = 9;
+glyphname = "naCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(482,0,l),
+(482,57,l),
+(334,57,ls),
+(176,57,o),
+(112,152,o),
+(112,344,cs),
+(112,534,o),
+(180,633,o),
+(320,633,cs),
+(324,633,l),
+(324,690,l),
+(320,690,ls),
+(142,690,o),
+(50,569,o),
+(50,344,cs),
+(50,119,o),
+(139,0,o),
+(335,0,cs)
+);
+}
+);
+width = 524;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni1607;
+unicode = 5639;
+},
+{
+color = 9;
+glyphname = "muCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(270,-13,o),
+(317,29,o),
+(335,113,c),
+(310,113,l),
+(331,28,o),
+(379,-13,o),
+(444,-13,cs),
+(532,-13,o),
+(588,52,o),
+(588,176,cs),
+(588,388,l),
+(529,388,l),
+(529,179,ls),
+(529,86,o),
+(498,44,o),
+(441,44,cs),
+(384,44,o),
+(352,88,o),
+(352,179,cs),
+(352,388,l),
+(295,388,l),
+(295,179,ls),
+(295,86,o),
+(262,44,o),
+(205,44,cs),
+(147,44,o),
+(115,86,o),
+(115,179,cs),
+(115,690,l),
+(56,690,l),
+(56,178,ls),
+(56,51,o),
+(114,-13,o),
+(202,-13,cs)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "=|";
+note = uni1608;
+unicode = 5640;
+},
+{
+color = 9;
+glyphname = "moCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(588,0,l),
+(588,512,ls),
+(588,639,o),
+(530,702,o),
+(442,702,cs),
+(375,702,o),
+(327,661,o),
+(309,577,c),
+(334,577,l),
+(313,662,o),
+(266,702,o),
+(200,702,cs),
+(113,702,o),
+(56,638,o),
+(56,514,cs),
+(56,301,l),
+(115,301,l),
+(115,511,ls),
+(115,603,o),
+(147,645,o),
+(204,645,cs),
+(260,645,o),
+(293,602,o),
+(293,511,cs),
+(293,301,l),
+(350,301,l),
+(350,511,ls),
+(350,604,o),
+(383,645,o),
+(440,645,cs),
+(498,645,o),
+(529,604,o),
+(529,511,cs),
+(529,0,l)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "=|muCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni1609;
+unicode = 5641;
+},
+{
+color = 9;
+glyphname = "meCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(286,0,ls),
+(401,0,o),
+(472,63,o),
+(472,181,cs),
+(472,265,o),
+(429,329,o),
+(358,354,c),
+(358,336,l),
+(430,358,o),
+(472,420,o),
+(472,507,cs),
+(472,626,o),
+(400,690,o),
+(286,690,cs),
+(42,690,l),
+(42,638,l),
+(276,638,ls),
+(359,638,o),
+(412,596,o),
+(412,505,cs),
+(412,416,o),
+(359,371,o),
+(278,371,cs),
+(215,371,l),
+(215,319,l),
+(278,319,ls),
+(358,319,o),
+(412,273,o),
+(412,184,cs),
+(412,93,o),
+(359,52,o),
+(276,52,cs),
+(215,52,l),
+(215,0,l)
+);
+}
+);
+width = 532;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160A;
+unicode = 5642;
+},
+{
+color = 9;
+glyphname = "meeCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(286,0,ls),
+(401,0,o),
+(472,63,o),
+(472,181,cs),
+(472,265,o),
+(429,329,o),
+(358,353,c),
+(358,336,l),
+(430,357,o),
+(472,420,o),
+(472,507,cs),
+(472,626,o),
+(400,690,o),
+(286,690,cs),
+(42,690,l),
+(42,638,l),
+(276,638,ls),
+(359,638,o),
+(412,596,o),
+(412,504,cs),
+(412,415,o),
+(361,370,o),
+(282,370,cs),
+(254,370,l),
+(254,458,l),
+(215,458,l),
+(215,233,l),
+(254,233,l),
+(254,320,l),
+(282,320,ls),
+(360,320,o),
+(412,274,o),
+(412,185,cs),
+(412,94,o),
+(359,52,o),
+(276,52,cs),
+(215,52,l),
+(215,0,l)
+);
+}
+);
+width = 532;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160B;
+unicode = 5643;
+},
+{
+color = 9;
+glyphname = "miCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(286,0,ls),
+(401,0,o),
+(472,63,o),
+(472,181,cs),
+(472,265,o),
+(429,329,o),
+(358,353,c),
+(358,336,l),
+(430,357,o),
+(472,420,o),
+(472,507,cs),
+(472,626,o),
+(400,690,o),
+(286,690,cs),
+(42,690,l),
+(42,638,l),
+(276,638,ls),
+(359,638,o),
+(412,596,o),
+(412,504,cs),
+(412,415,o),
+(361,370,o),
+(285,370,cs),
+(264,370,l),
+(297,353,l),
+(294,382,o),
+(270,404,o),
+(241,404,cs),
+(208,404,o),
+(183,377,o),
+(183,345,cs),
+(183,313,o),
+(208,286,o),
+(241,286,cs),
+(270,286,o),
+(294,309,o),
+(297,337,c),
+(264,320,l),
+(284,320,ls),
+(360,320,o),
+(412,274,o),
+(412,185,cs),
+(412,94,o),
+(359,52,o),
+(276,52,cs),
+(215,52,l),
+(215,0,l)
+);
+}
+);
+width = 532;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160C;
+unicode = 5644;
+},
+{
+color = 9;
+glyphname = "maCarrier-canadian";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(492,0,l),
+(492,52,l),
+(256,52,ls),
+(174,52,o),
+(122,93,o),
+(122,184,cs),
+(122,273,o),
+(174,319,o),
+(254,319,cs),
+(318,319,l),
+(318,371,l),
+(255,371,ls),
+(174,371,o),
+(122,415,o),
+(122,504,cs),
+(122,596,o),
+(174,638,o),
+(256,638,cs),
+(318,638,l),
+(318,690,l),
+(246,690,ls),
+(132,690,o),
+(60,627,o),
+(60,507,cs),
+(60,423,o),
+(103,359,o),
+(175,337,c),
+(175,354,l),
+(102,331,o),
+(60,268,o),
+(60,182,cs),
+(60,64,o),
+(133,0,o),
+(246,0,cs)
+);
+}
+);
+width = 534;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni160D;
+unicode = 5645;
+},
+{
+color = 9;
+glyphname = "yuCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(438,-13,o),
+(519,108,o),
+(519,388,cs),
+(519,606,o),
+(466,702,o),
+(371,702,cs),
+(291,702,o),
+(244,629,o),
+(244,506,cs),
+(244,385,o),
+(291,315,o),
+(369,315,cs),
+(384,315,o),
+(398,318,o),
+(408,323,c),
+(408,371,l),
+(401,368,o),
+(391,365,o),
+(375,365,cs),
+(322,365,o),
+(297,412,o),
+(297,508,cs),
+(297,605,o),
+(322,651,o),
+(371,651,cs),
+(430,651,o),
+(461,581,o),
+(461,389,cs),
+(461,132,o),
+(400,45,o),
+(278,45,cs),
+(179,45,o),
+(121,106,o),
+(121,234,cs),
+(121,690,l),
+(59,690,l),
+(59,236,ls),
+(59,71,o),
+(144,-13,o),
+(276,-13,cs)
+);
+}
+);
+width = 578;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160E;
+unicode = 5646;
+},
+{
+color = 9;
+glyphname = "yoCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(288,-13,o),
+(333,61,o),
+(333,184,cs),
+(333,304,o),
+(288,375,o),
+(209,375,cs),
+(195,375,o),
+(180,372,o),
+(170,367,c),
+(170,319,l),
+(178,322,o),
+(186,325,o),
+(203,325,cs),
+(256,325,o),
+(281,278,o),
+(281,182,cs),
+(281,85,o),
+(256,39,o),
+(208,39,cs),
+(148,39,o),
+(118,109,o),
+(118,300,cs),
+(118,557,o),
+(178,644,o),
+(300,644,cs),
+(399,644,o),
+(457,583,o),
+(457,456,cs),
+(457,0,l),
+(519,0,l),
+(519,454,ls),
+(519,618,o),
+(434,702,o),
+(302,702,cs),
+(140,702,o),
+(59,582,o),
+(59,301,cs),
+(59,84,o),
+(113,-13,o),
+(207,-13,cs)
+);
+}
+);
+width = 578;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160F;
+unicode = 5647;
+},
+{
+color = 9;
+glyphname = "yeCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(389,-13,o),
+(468,124,o),
+(468,342,cs),
+(468,571,o),
+(380,690,o),
+(183,690,cs),
+(56,690,l),
+(56,633,l),
+(183,633,ls),
+(342,633,o),
+(407,538,o),
+(407,341,cs),
+(407,151,o),
+(358,42,o),
+(242,42,cs),
+(137,42,o),
+(97,111,o),
+(97,208,cs),
+(97,302,o),
+(126,350,o),
+(173,350,cs),
+(220,350,o),
+(246,302,o),
+(246,215,cs),
+(246,184,o),
+(243,165,o),
+(241,145,c),
+(288,145,l),
+(293,171,o),
+(295,186,o),
+(295,220,cs),
+(295,331,o),
+(251,401,o),
+(172,401,cs),
+(93,401,o),
+(43,330,o),
+(43,208,cs),
+(43,86,o),
+(105,-13,o),
+(241,-13,cs)
+);
+}
+);
+width = 518;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1610;
+unicode = 5648;
+},
+{
+color = 9;
+glyphname = "yeeCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(389,-13,o),
+(468,124,o),
+(468,342,cs),
+(468,571,o),
+(380,690,o),
+(183,690,cs),
+(56,690,l),
+(56,633,l),
+(183,633,ls),
+(342,633,o),
+(407,538,o),
+(407,341,cs),
+(407,151,o),
+(358,42,o),
+(240,42,cs),
+(137,42,o),
+(97,112,o),
+(97,212,cs),
+(97,301,o),
+(124,350,o),
+(166,350,cs),
+(211,350,o),
+(237,303,o),
+(237,232,cs),
+(237,174,l),
+(270,174,l),
+(270,503,l),
+(237,503,l),
+(237,293,l),
+(246,293,l),
+(240,361,o),
+(206,401,o),
+(156,401,cs),
+(91,401,o),
+(43,333,o),
+(43,212,cs),
+(43,86,o),
+(105,-13,o),
+(239,-13,cs)
+);
+}
+);
+width = 518;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1611;
+unicode = 5649;
+},
+{
+color = 9;
+glyphname = "yiCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(389,-13,o),
+(468,124,o),
+(468,342,cs),
+(468,571,o),
+(380,690,o),
+(183,690,cs),
+(56,690,l),
+(56,633,l),
+(183,633,ls),
+(342,633,o),
+(407,538,o),
+(407,341,cs),
+(407,151,o),
+(358,42,o),
+(243,42,cs),
+(139,42,o),
+(97,113,o),
+(97,196,cs),
+(97,278,o),
+(127,324,o),
+(169,326,c),
+(155,336,l),
+(157,311,o),
+(183,289,o),
+(212,289,cs),
+(243,289,o),
+(269,315,o),
+(269,345,cs),
+(269,376,o),
+(243,401,o),
+(212,401,cs),
+(187,401,o),
+(168,387,o),
+(159,368,c),
+(90,360,o),
+(43,295,o),
+(43,191,cs),
+(43,86,o),
+(105,-13,o),
+(241,-13,cs)
+);
+}
+);
+width = 518;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1612;
+unicode = 5650;
+},
+{
+color = 9;
+glyphname = "yaCarrier-canadian";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(463,0,l),
+(463,57,l),
+(335,57,ls),
+(176,57,o),
+(112,152,o),
+(112,349,cs),
+(112,539,o),
+(160,648,o),
+(285,648,cs),
+(381,648,o),
+(421,579,o),
+(421,482,cs),
+(421,387,o),
+(393,340,o),
+(346,340,cs),
+(298,340,o),
+(272,387,o),
+(272,474,cs),
+(272,506,o),
+(274,525,o),
+(277,545,c),
+(231,545,l),
+(226,519,o),
+(224,503,o),
+(224,469,cs),
+(224,358,o),
+(268,289,o),
+(347,289,cs),
+(425,289,o),
+(474,359,o),
+(474,482,cs),
+(474,604,o),
+(412,702,o),
+(286,702,cs),
+(129,702,o),
+(50,566,o),
+(50,348,cs),
+(50,119,o),
+(138,0,o),
+(336,0,cs)
+);
+}
+);
+width = 517;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|yeCarrier-canadian";
+note = uni1613;
+unicode = 5651;
+},
+{
+color = 9;
+glyphname = "juCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(426,-13,o),
+(487,87,o),
+(487,206,cs),
+(487,330,o),
+(438,401,o),
+(358,401,cs),
+(279,401,o),
+(237,331,o),
+(237,220,cs),
+(237,186,o),
+(239,169,o),
+(243,145,c),
+(290,145,l),
+(287,164,o),
+(285,185,o),
+(285,215,cs),
+(285,301,o),
+(310,350,o),
+(357,350,cs),
+(406,350,o),
+(434,301,o),
+(434,206,cs),
+(434,112,o),
+(394,42,o),
+(290,42,cs),
+(178,42,o),
+(117,130,o),
+(117,301,cs),
+(117,539,o),
+(229,633,o),
+(412,633,cs),
+(475,633,l),
+(475,690,l),
+(49,690,l),
+(49,635,l),
+(299,635,l),
+(346,659,l),
+(176,659,o),
+(56,538,o),
+(56,299,cs),
+(56,104,o),
+(144,-13,o),
+(286,-13,cs)
+);
+}
+);
+width = 530;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni1614;
+unicode = 5652;
+},
+{
+color = 9;
+glyphname = "juSayisi-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (269,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(386,-13,o),
+(475,104,o),
+(475,299,cs),
+(475,538,o),
+(355,659,o),
+(185,659,c),
+(232,635,l),
+(481,635,l),
+(481,690,l),
+(56,690,l),
+(56,633,l),
+(119,633,ls),
+(301,633,o),
+(413,539,o),
+(413,301,cs),
+(413,130,o),
+(353,42,o),
+(242,42,cs),
+(136,42,o),
+(97,112,o),
+(97,206,cs),
+(97,301,o),
+(126,350,o),
+(173,350,cs),
+(220,350,o),
+(246,301,o),
+(246,215,cs),
+(246,185,o),
+(243,164,o),
+(241,145,c),
+(288,145,l),
+(293,169,o),
+(295,186,o),
+(295,220,cs),
+(295,331,o),
+(251,401,o),
+(172,401,cs),
+(93,401,o),
+(43,330,o),
+(43,206,cs),
+(43,87,o),
+(104,-13,o),
+(244,-13,cs)
+);
+}
+);
+width = 530;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1615;
+unicode = 5653;
+},
+{
+color = 9;
+glyphname = "joCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(481,0,l),
+(481,55,l),
+(232,55,l),
+(185,31,l),
+(355,31,o),
+(475,152,o),
+(475,390,cs),
+(475,585,o),
+(386,702,o),
+(244,702,cs),
+(104,702,o),
+(43,603,o),
+(43,484,cs),
+(43,359,o),
+(93,289,o),
+(172,289,cs),
+(251,289,o),
+(295,358,o),
+(295,469,cs),
+(295,503,o),
+(293,521,o),
+(288,545,c),
+(241,545,l),
+(243,526,o),
+(246,505,o),
+(246,474,cs),
+(246,388,o),
+(220,340,o),
+(173,340,cs),
+(126,340,o),
+(97,388,o),
+(97,484,cs),
+(97,578,o),
+(136,648,o),
+(242,648,cs),
+(353,648,o),
+(413,559,o),
+(413,388,cs),
+(413,151,o),
+(301,57,o),
+(119,57,cs),
+(56,57,l),
+(56,0,l)
+);
+}
+);
+width = 530;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1616;
+unicode = 5654;
+},
+{
+color = 9;
+glyphname = "jeCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(469,-13,o),
+(522,84,o),
+(522,301,cs),
+(522,567,o),
+(437,702,o),
+(306,702,cs),
+(175,702,o),
+(109,583,o),
+(105,373,c),
+(124,378,l),
+(124,690,l),
+(63,690,l),
+(63,0,l),
+(124,0,l),
+(124,284,ls),
+(124,539,o),
+(186,644,o),
+(297,644,cs),
+(398,644,o),
+(464,540,o),
+(464,301,cs),
+(464,109,o),
+(434,39,o),
+(374,39,cs),
+(327,39,o),
+(300,85,o),
+(300,182,cs),
+(300,278,o),
+(325,325,o),
+(382,325,cs),
+(395,325,o),
+(404,322,o),
+(411,319,c),
+(411,367,l),
+(402,372,o),
+(386,375,o),
+(375,375,cs),
+(294,375,o),
+(248,304,o),
+(248,184,cs),
+(248,61,o),
+(294,-13,o),
+(375,-13,cs)
+);
+}
+);
+width = 581;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "te-canadian";
+note = uni1617;
+unicode = 5655;
+},
+{
+color = 9;
+glyphname = "jeeCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(469,-13,o),
+(522,86,o),
+(522,301,cs),
+(522,567,o),
+(437,702,o),
+(306,702,cs),
+(203,702,o),
+(140,629,o),
+(116,496,c),
+(124,490,l),
+(124,690,l),
+(63,690,l),
+(63,0,l),
+(124,0,l),
+(124,284,ls),
+(124,539,o),
+(186,644,o),
+(297,644,cs),
+(398,644,o),
+(464,540,o),
+(464,301,cs),
+(464,113,o),
+(431,39,o),
+(365,39,cs),
+(313,39,o),
+(282,89,o),
+(282,185,cs),
+(282,270,o),
+(303,318,o),
+(343,329,c),
+(343,238,l),
+(378,238,l),
+(378,449,l),
+(343,449,l),
+(343,366,l),
+(287,353,o),
+(248,292,o),
+(248,182,cs),
+(248,60,o),
+(294,-13,o),
+(375,-13,cs)
+);
+}
+);
+width = 581;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1618;
+unicode = 5656;
+},
+{
+color = 9;
+glyphname = "jiCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(469,-13,o),
+(522,86,o),
+(522,301,cs),
+(522,567,o),
+(437,702,o),
+(306,702,cs),
+(203,702,o),
+(140,629,o),
+(116,497,c),
+(124,491,l),
+(124,690,l),
+(63,690,l),
+(63,0,l),
+(124,0,l),
+(124,284,ls),
+(124,539,o),
+(186,644,o),
+(297,644,cs),
+(398,644,o),
+(464,540,o),
+(464,301,cs),
+(464,113,o),
+(431,39,o),
+(365,39,cs),
+(313,39,o),
+(282,89,o),
+(282,185,cs),
+(282,251,o),
+(296,291,o),
+(321,310,c),
+(327,297,o),
+(341,287,o),
+(358,287,cs),
+(387,287,o),
+(412,312,o),
+(412,343,cs),
+(412,373,o),
+(387,398,o),
+(358,398,cs),
+(325,398,o),
+(304,367,o),
+(307,341,c),
+(270,318,o),
+(248,265,o),
+(248,182,cs),
+(248,60,o),
+(294,-13,o),
+(375,-13,cs)
+);
+}
+);
+width = 581;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1619;
+unicode = 5657;
+},
+{
+color = 9;
+glyphname = "jiSayisi-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(437,-13,o),
+(522,123,o),
+(522,388,cs),
+(522,606,o),
+(469,702,o),
+(375,702,cs),
+(294,702,o),
+(248,629,o),
+(248,506,cs),
+(248,385,o),
+(294,315,o),
+(375,315,cs),
+(386,315,o),
+(402,318,o),
+(411,323,c),
+(411,371,l),
+(404,368,o),
+(395,365,o),
+(382,365,cs),
+(325,365,o),
+(300,412,o),
+(300,508,cs),
+(300,605,o),
+(327,651,o),
+(374,651,cs),
+(434,651,o),
+(464,581,o),
+(464,388,cs),
+(464,150,o),
+(398,45,o),
+(297,45,cs),
+(186,45,o),
+(124,151,o),
+(124,406,cs),
+(124,690,l),
+(63,690,l),
+(63,0,l),
+(124,0,l),
+(124,312,l),
+(105,317,l),
+(109,106,o),
+(175,-13,o),
+(306,-13,cs)
+);
+}
+);
+width = 581;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161A;
+unicode = 5658;
+},
+{
+color = 9;
+glyphname = "jaCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (284,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(406,-13,o),
+(472,106,o),
+(475,317,c),
+(458,312,l),
+(458,0,l),
+(519,0,l),
+(519,690,l),
+(457,690,l),
+(457,406,ls),
+(457,151,o),
+(395,45,o),
+(284,45,cs),
+(183,45,o),
+(118,150,o),
+(118,388,cs),
+(118,581,o),
+(148,651,o),
+(208,651,cs),
+(254,651,o),
+(281,605,o),
+(281,508,cs),
+(281,412,o),
+(256,365,o),
+(200,365,cs),
+(186,365,o),
+(178,368,o),
+(170,371,c),
+(170,323,l),
+(180,318,o),
+(195,315,o),
+(207,315,cs),
+(288,315,o),
+(333,385,o),
+(333,506,cs),
+(333,629,o),
+(288,702,o),
+(207,702,cs),
+(113,702,o),
+(59,606,o),
+(59,388,cs),
+(59,123,o),
+(145,-13,o),
+(275,-13,cs)
+);
+}
+);
+width = 582;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni161B;
+unicode = 5659;
+},
+{
+color = 9;
+glyphname = "jjuCarrier-canadian";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(419,-13,o),
+(481,86,o),
+(481,208,cs),
+(481,330,o),
+(432,401,o),
+(354,401,cs),
+(274,401,o),
+(231,331,o),
+(231,220,cs),
+(231,189,o),
+(233,169,o),
+(238,145,c),
+(284,145,l),
+(281,164,o),
+(279,185,o),
+(279,215,cs),
+(279,301,o),
+(304,350,o),
+(353,350,cs),
+(398,350,o),
+(428,298,o),
+(428,208,cs),
+(428,110,o),
+(388,41,o),
+(287,41,cs),
+(181,41,o),
+(119,128,o),
+(119,311,cs),
+(119,529,o),
+(215,633,o),
+(384,633,cs),
+(469,633,l),
+(469,690,l),
+(383,690,ls),
+(290,690,o),
+(216,663,o),
+(163,611,c),
+(73,702,l),
+(33,663,l),
+(126,569,l),
+(80,508,o),
+(58,421,o),
+(58,313,cs),
+(58,102,o),
+(149,-13,o),
+(284,-13,cs)
+);
+}
+);
+width = 524;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni161C;
+unicode = 5660;
+},
+{
+color = 9;
+glyphname = "jjoCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(493,27,l),
+(399,121,l),
+(444,182,o),
+(467,269,o),
+(467,377,cs),
+(467,587,o),
+(377,702,o),
+(242,702,cs),
+(105,702,o),
+(43,604,o),
+(43,482,cs),
+(43,359,o),
+(93,289,o),
+(172,289,cs),
+(251,289,o),
+(294,358,o),
+(294,469,cs),
+(294,500,o),
+(292,521,o),
+(288,545,c),
+(241,545,l),
+(243,526,o),
+(246,504,o),
+(246,474,cs),
+(246,388,o),
+(220,340,o),
+(173,340,cs),
+(128,340,o),
+(97,391,o),
+(97,482,cs),
+(97,580,o),
+(137,649,o),
+(238,649,cs),
+(345,649,o),
+(406,562,o),
+(406,379,cs),
+(406,160,o),
+(309,57,o),
+(141,57,cs),
+(56,57,l),
+(56,0,l),
+(142,0,ls),
+(235,0,o),
+(308,27,o),
+(362,78,c),
+(452,-13,l)
+);
+}
+);
+width = 526;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|jjuCarrier-canadian";
+note = uni161D;
+unicode = 5661;
+},
+{
+color = 9;
+glyphname = "jjeCarrier-canadian";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(470,-13,o),
+(525,84,o),
+(525,301,cs),
+(525,582,o),
+(445,702,o),
+(286,702,cs),
+(224,702,o),
+(172,678,o),
+(133,633,c),
+(62,702,l),
+(24,660,l),
+(102,585,l),
+(78,539,o),
+(65,478,o),
+(65,403,cs),
+(65,0,l),
+(126,0,l),
+(126,406,ls),
+(126,564,o),
+(185,644,o),
+(286,644,cs),
+(406,644,o),
+(466,557,o),
+(466,300,cs),
+(466,109,o),
+(436,39,o),
+(376,39,cs),
+(327,39,o),
+(302,85,o),
+(302,182,cs),
+(302,278,o),
+(327,325,o),
+(381,325,cs),
+(397,325,o),
+(406,322,o),
+(413,319,c),
+(413,367,l),
+(404,372,o),
+(388,375,o),
+(374,375,cs),
+(296,375,o),
+(250,304,o),
+(250,184,cs),
+(250,61,o),
+(296,-13,o),
+(377,-13,cs)
+);
+}
+);
+width = 584;
+}
+);
+metricRight = "jeCarrier-canadian";
+note = uni161E;
+unicode = 5662;
+},
+{
+color = 9;
+glyphname = "jjeeCarrier-canadian";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(470,-13,o),
+(525,86,o),
+(525,301,cs),
+(525,582,o),
+(445,702,o),
+(286,702,cs),
+(224,702,o),
+(172,678,o),
+(133,633,c),
+(62,702,l),
+(24,660,l),
+(102,585,l),
+(78,539,o),
+(65,478,o),
+(65,403,cs),
+(65,0,l),
+(126,0,l),
+(126,406,ls),
+(126,564,o),
+(185,644,o),
+(285,644,cs),
+(406,644,o),
+(466,557,o),
+(466,300,cs),
+(466,112,o),
+(433,39,o),
+(368,39,cs),
+(314,39,o),
+(284,89,o),
+(284,185,cs),
+(284,275,o),
+(306,318,o),
+(346,329,c),
+(346,238,l),
+(381,238,l),
+(381,449,l),
+(346,449,l),
+(346,366,l),
+(291,355,o),
+(250,293,o),
+(250,182,cs),
+(250,60,o),
+(296,-13,o),
+(377,-13,cs)
+);
+}
+);
+width = 584;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161F;
+unicode = 5663;
+},
+{
+color = 9;
+glyphname = "jjiCarrier-canadian";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(470,-13,o),
+(525,86,o),
+(525,301,cs),
+(525,582,o),
+(445,702,o),
+(286,702,cs),
+(224,702,o),
+(172,678,o),
+(133,633,c),
+(62,702,l),
+(24,660,l),
+(102,585,l),
+(78,539,o),
+(65,478,o),
+(65,403,cs),
+(65,0,l),
+(126,0,l),
+(126,406,ls),
+(126,564,o),
+(185,644,o),
+(285,644,cs),
+(406,644,o),
+(466,557,o),
+(466,300,cs),
+(466,112,o),
+(433,39,o),
+(368,39,cs),
+(314,39,o),
+(284,89,o),
+(284,185,cs),
+(284,254,o),
+(298,292,o),
+(323,309,c),
+(328,297,o),
+(344,287,o),
+(359,287,cs),
+(389,287,o),
+(413,312,o),
+(413,343,cs),
+(413,373,o),
+(389,398,o),
+(359,398,cs),
+(327,398,o),
+(306,368,o),
+(309,341,c),
+(273,319,o),
+(250,266,o),
+(250,182,cs),
+(250,60,o),
+(296,-13,o),
+(377,-13,cs)
+);
+}
+);
+width = 584;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1620;
+unicode = 5664;
+},
+{
+color = 9;
+glyphname = "jjaCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(359,-13,o),
+(412,12,o),
+(450,57,c),
+(522,-13,l),
+(559,30,l),
+(481,104,l),
+(505,151,o),
+(519,212,o),
+(519,287,cs),
+(519,690,l),
+(457,690,l),
+(457,284,ls),
+(457,126,o),
+(399,45,o),
+(298,45,cs),
+(178,45,o),
+(118,132,o),
+(118,389,cs),
+(118,581,o),
+(148,651,o),
+(208,651,cs),
+(256,651,o),
+(281,605,o),
+(281,508,cs),
+(281,412,o),
+(256,365,o),
+(203,365,cs),
+(186,365,o),
+(178,368,o),
+(170,371,c),
+(170,323,l),
+(180,318,o),
+(195,315,o),
+(209,315,cs),
+(288,315,o),
+(333,385,o),
+(333,506,cs),
+(333,629,o),
+(288,702,o),
+(207,702,cs),
+(113,702,o),
+(59,606,o),
+(59,388,cs),
+(59,108,o),
+(138,-13,o),
+(298,-13,cs)
+);
+}
+);
+width = 583;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "=|jjeCarrier-canadian";
+note = uni1621;
+unicode = 5665;
+},
+{
+color = 9;
+glyphname = "luCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(396,-13,o),
+(479,62,o),
+(479,242,cs),
+(479,690,l),
+(418,690,l),
+(418,242,ls),
+(418,96,o),
+(357,44,o),
+(275,44,cs),
+(156,44,o),
+(115,151,o),
+(115,324,cs),
+(115,526,o),
+(165,622,o),
+(289,639,c),
+(289,690,l),
+(47,690,l),
+(47,639,l),
+(212,639,l),
+(247,655,l),
+(128,639,o),
+(54,541,o),
+(54,317,cs),
+(54,113,o),
+(120,-13,o),
+(274,-13,cs)
+);
+}
+);
+width = 538;
+}
+);
+metricRight = "te-canadian";
+note = uni1622;
+unicode = 5666;
+},
+{
+color = 9;
+glyphname = "loCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,0,l),
+(121,447,ls),
+(121,594,o),
+(181,645,o),
+(264,645,cs),
+(383,645,o),
+(423,539,o),
+(423,366,cs),
+(423,164,o),
+(373,68,o),
+(249,50,c),
+(249,0,l),
+(491,0,l),
+(491,51,l),
+(327,51,l),
+(292,35,l),
+(411,50,o),
+(485,149,o),
+(485,373,cs),
+(485,577,o),
+(419,702,o),
+(264,702,cs),
+(142,702,o),
+(59,628,o),
+(59,447,cs),
+(59,0,l)
+);
+}
+);
+width = 538;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|luCarrier-canadian";
+note = uni1623;
+unicode = 5667;
+},
+{
+color = 9;
+glyphname = "leCarrier-canadian";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (260,345);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(193,0,ls),
+(384,0,o),
+(472,121,o),
+(472,356,cs),
+(472,590,o),
+(384,702,o),
+(274,702,cs),
+(173,702,o),
+(123,618,o),
+(107,511,c),
+(115,513,l),
+(115,690,l),
+(60,690,l),
+(60,385,l),
+(112,385,l),
+(113,537,o),
+(162,644,o),
+(261,644,cs),
+(351,644,o),
+(411,556,o),
+(411,356,cs),
+(411,156,o),
+(349,57,o),
+(194,57,cs),
+(60,57,l),
+(60,0,l)
+);
+}
+);
+width = 522;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1624;
+unicode = 5668;
+},
+{
+color = 9;
+glyphname = "leeCarrier-canadian";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+ref = "leCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (222,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 522;
+}
+);
+metricLeft = "leCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1625;
+unicode = 5669;
+},
+{
+color = 9;
+glyphname = "liCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "leCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (202,0);
+ref = dot_middle;
+}
+);
+width = 523;
+}
+);
+note = uni1626;
+unicode = 5670;
+},
+{
+color = 9;
+glyphname = "laCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(463,0,l),
+(463,57,l),
+(328,57,ls),
+(174,57,o),
+(112,156,o),
+(112,356,cs),
+(112,556,o),
+(172,644,o),
+(262,644,cs),
+(360,644,o),
+(410,537,o),
+(411,385,c),
+(463,385,l),
+(463,690,l),
+(408,690,l),
+(408,513,l),
+(415,511,l),
+(399,618,o),
+(350,702,o),
+(248,702,cs),
+(138,702,o),
+(50,590,o),
+(50,356,cs),
+(50,121,o),
+(139,0,o),
+(329,0,cs)
+);
+}
+);
+width = 523;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|leCarrier-canadian";
+note = uni1627;
+unicode = 5671;
+},
+{
+color = 1;
+glyphname = "dluCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(419,-13,o),
+(485,113,o),
+(485,317,cs),
+(485,522,o),
+(423,621,o),
+(325,647,c),
+(312,641,l),
+(482,641,l),
+(482,558,l),
+(528,558,l),
+(528,773,l),
+(482,773,l),
+(482,690,l),
+(249,690,l),
+(249,639,l),
+(373,622,o),
+(423,526,o),
+(423,324,cs),
+(423,151,o),
+(383,44,o),
+(264,44,cs),
+(181,44,o),
+(121,96,o),
+(121,242,cs),
+(121,690,l),
+(59,690,l),
+(59,242,ls),
+(59,62,o),
+(142,-13,o),
+(264,-13,cs)
+);
+}
+);
+width = 561;
+}
+);
+metricLeft = "te-canadian";
+note = uni1628;
+unicode = 5672;
+},
+{
+color = 9;
+glyphname = "dloCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(528,-83,l),
+(528,131,l),
+(482,131,l),
+(482,48,l),
+(312,48,l),
+(325,43,l),
+(423,69,o),
+(485,168,o),
+(485,373,cs),
+(485,577,o),
+(419,702,o),
+(264,702,cs),
+(142,702,o),
+(59,628,o),
+(59,447,cs),
+(59,0,l),
+(121,0,l),
+(121,448,ls),
+(121,594,o),
+(181,645,o),
+(264,645,cs),
+(383,645,o),
+(423,539,o),
+(423,366,cs),
+(423,164,o),
+(373,68,o),
+(249,50,c),
+(249,0,l),
+(482,0,l),
+(482,-83,l)
+);
+}
+);
+width = 561;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "dluCarrier-canadian";
+note = uni1629;
+unicode = 5673;
+},
+{
+color = 9;
+glyphname = "dleCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (271,345);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(204,0,ls),
+(394,0,o),
+(483,121,o),
+(483,356,cs),
+(483,590,o),
+(395,702,o),
+(285,702,cs),
+(189,702,o),
+(131,627,o),
+(111,510,c),
+(117,507,l),
+(117,704,l),
+(178,704,l),
+(178,750,l),
+(11,750,l),
+(11,704,l),
+(71,704,l),
+(71,385,l),
+(123,385,l),
+(124,537,o),
+(173,644,o),
+(271,644,cs),
+(360,644,o),
+(421,556,o),
+(421,356,cs),
+(421,156,o),
+(359,57,o),
+(205,57,cs),
+(71,57,l),
+(71,0,l)
+);
+}
+);
+width = 533;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni162A;
+unicode = 5674;
+},
+{
+color = 9;
+glyphname = "dleeCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (234,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 533;
+}
+);
+note = uni162B;
+unicode = 5675;
+},
+{
+color = 9;
+glyphname = "dliCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (213,0);
+ref = dot_middle;
+}
+);
+width = 533;
+}
+);
+note = uni162C;
+unicode = 5676;
+},
+{
+color = 9;
+glyphname = "dlaCarrier-canadian";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(463,0,l),
+(463,57,l),
+(328,57,ls),
+(174,57,o),
+(112,156,o),
+(112,356,cs),
+(112,556,o),
+(173,644,o),
+(262,644,cs),
+(360,644,o),
+(410,537,o),
+(411,385,c),
+(463,385,l),
+(463,704,l),
+(523,704,l),
+(523,750,l),
+(355,750,l),
+(355,704,l),
+(416,704,l),
+(416,507,l),
+(422,510,l),
+(402,627,o),
+(344,702,o),
+(248,702,cs),
+(138,702,o),
+(50,590,o),
+(50,356,cs),
+(50,121,o),
+(139,0,o),
+(329,0,cs)
+);
+}
+);
+width = 534;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni162D;
+unicode = 5677;
+},
+{
+color = 9;
+glyphname = "lhuCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(433,-13,o),
+(506,104,o),
+(506,316,cs),
+(506,505,o),
+(449,621,o),
+(345,659,c),
+(366,639,l),
+(513,639,l),
+(513,690,l),
+(325,690,l),
+(325,639,l),
+(407,602,o),
+(445,493,o),
+(445,327,cs),
+(445,133,o),
+(396,44,o),
+(280,44,cs),
+(164,44,o),
+(116,133,o),
+(116,327,cs),
+(116,494,o),
+(155,603,o),
+(237,639,c),
+(237,690,l),
+(47,690,l),
+(47,639,l),
+(194,639,l),
+(215,659,l),
+(111,621,o),
+(54,507,o),
+(54,316,cs),
+(54,104,o),
+(128,-13,o),
+(280,-13,cs)
+);
+}
+);
+width = 560;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162E;
+unicode = 5678;
+},
+{
+color = 9;
+glyphname = "lhoCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(236,0,l),
+(236,50,l),
+(154,88,o),
+(115,197,o),
+(115,363,cs),
+(115,556,o),
+(164,645,o),
+(280,645,cs),
+(396,645,o),
+(444,556,o),
+(444,363,cs),
+(444,196,o),
+(406,87,o),
+(324,50,c),
+(324,0,l),
+(513,0,l),
+(513,51,l),
+(366,51,l),
+(344,31,l),
+(449,69,o),
+(506,183,o),
+(506,374,cs),
+(506,585,o),
+(433,702,o),
+(280,702,cs),
+(128,702,o),
+(54,585,o),
+(54,374,cs),
+(54,185,o),
+(111,69,o),
+(215,31,c),
+(194,51,l),
+(47,51,l),
+(47,0,l)
+);
+}
+);
+width = 560;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162F;
+unicode = 5679;
+},
+{
+color = 9;
+glyphname = "lheCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (273,345);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(403,-13,o),
+(494,99,o),
+(494,345,cs),
+(494,590,o),
+(403,702,o),
+(287,702,cs),
+(181,702,o),
+(127,623,o),
+(112,529,c),
+(117,528,l),
+(117,690,l),
+(63,690,l),
+(63,419,l),
+(114,419,l),
+(120,545,o),
+(163,644,o),
+(273,644,cs),
+(368,644,o),
+(432,556,o),
+(432,345,cs),
+(432,133,o),
+(368,45,o),
+(273,45,cs),
+(163,45,o),
+(120,145,o),
+(114,270,c),
+(63,270,l),
+(63,0,l),
+(117,0,l),
+(117,161,l),
+(112,160,l),
+(127,67,o),
+(181,-13,o),
+(287,-13,cs)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1630;
+unicode = 5680;
+},
+{
+color = 9;
+glyphname = "lheeCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (236,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 544;
+}
+);
+note = uni1631;
+unicode = 5681;
+},
+{
+color = 9;
+glyphname = "lhiCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (215,0);
+ref = dot_middle;
+}
+);
+width = 544;
+}
+);
+note = uni1632;
+unicode = 5682;
+},
+{
+color = 9;
+glyphname = "lhaCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(363,-13,o),
+(417,67,o),
+(432,160,c),
+(427,161,l),
+(427,0,l),
+(482,0,l),
+(482,270,l),
+(430,270,l),
+(424,145,o),
+(381,45,o),
+(270,45,cs),
+(176,45,o),
+(112,133,o),
+(112,345,cs),
+(112,556,o),
+(176,644,o),
+(270,644,cs),
+(381,644,o),
+(424,545,o),
+(430,419,c),
+(482,419,l),
+(482,690,l),
+(427,690,l),
+(427,528,l),
+(432,529,l),
+(417,623,o),
+(363,702,o),
+(257,702,cs),
+(141,702,o),
+(50,590,o),
+(50,345,cs),
+(50,99,o),
+(141,-13,o),
+(257,-13,cs)
+);
+}
+);
+width = 545;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1633;
+unicode = 5683;
+},
+{
+color = 9;
+glyphname = "tlhuCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(433,-13,o),
+(506,104,o),
+(506,316,cs),
+(506,488,o),
+(461,602,o),
+(373,649,c),
+(358,641,l),
+(503,641,l),
+(503,558,l),
+(550,558,l),
+(550,773,l),
+(503,773,l),
+(503,690,l),
+(325,690,l),
+(325,639,l),
+(407,602,o),
+(446,493,o),
+(446,327,cs),
+(446,133,o),
+(396,44,o),
+(280,44,cs),
+(164,44,o),
+(115,133,o),
+(115,327,cs),
+(115,494,o),
+(154,603,o),
+(237,639,c),
+(237,690,l),
+(47,690,l),
+(47,639,l),
+(200,639,l),
+(184,646,l),
+(98,598,o),
+(54,487,o),
+(54,316,cs),
+(54,104,o),
+(128,-13,o),
+(280,-13,cs)
+);
+}
+);
+width = 582;
+}
+);
+metricLeft = "lhuCarrier-canadian";
+note = uni1634;
+unicode = 5684;
+},
+{
+color = 9;
+glyphname = "tlhoCarrier-canadian";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(78,-83,l),
+(78,0,l),
+(258,0,l),
+(258,50,l),
+(175,88,o),
+(136,197,o),
+(136,363,cs),
+(136,556,o),
+(185,645,o),
+(302,645,cs),
+(418,645,o),
+(467,556,o),
+(467,363,cs),
+(467,196,o),
+(428,87,o),
+(346,50,c),
+(346,0,l),
+(534,0,l),
+(534,51,l),
+(383,51,l),
+(398,43,l),
+(484,92,o),
+(527,203,o),
+(527,374,cs),
+(527,585,o),
+(454,702,o),
+(302,702,cs),
+(150,702,o),
+(76,585,o),
+(76,374,cs),
+(76,202,o),
+(122,88,o),
+(209,41,c),
+(224,48,l),
+(78,48,l),
+(78,131,l),
+(32,131,l),
+(32,-83,l)
+);
+}
+);
+width = 581;
+}
+);
+metricLeft = "=|tlhuCarrier-canadian";
+metricRight = "lhuCarrier-canadian";
+note = uni1635;
+unicode = 5685;
+},
+{
+color = 9;
+glyphname = "tlheCarrier-canadian";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (282,345);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(411,-13,o),
+(501,99,o),
+(501,345,cs),
+(501,590,o),
+(411,702,o),
+(295,702,cs),
+(192,702,o),
+(131,632,o),
+(111,526,c),
+(117,522,l),
+(117,704,l),
+(177,704,l),
+(177,750,l),
+(11,750,l),
+(11,704,l),
+(71,704,l),
+(71,419,l),
+(123,419,l),
+(128,545,o),
+(172,644,o),
+(281,644,cs),
+(377,644,o),
+(440,559,o),
+(440,345,cs),
+(440,133,o),
+(377,45,o),
+(281,45,cs),
+(172,45,o),
+(128,145,o),
+(123,270,c),
+(71,270,l),
+(71,0,l),
+(126,0,l),
+(126,162,l),
+(121,155,l),
+(138,62,o),
+(191,-13,o),
+(295,-13,cs)
+);
+}
+);
+width = 551;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1636;
+unicode = 5686;
+},
+{
+color = 9;
+glyphname = "tlheeCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (244,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 553;
+}
+);
+note = uni1637;
+unicode = 5687;
+},
+{
+color = 9;
+glyphname = "tlhiCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (223,0);
+ref = dot_middle;
+}
+);
+width = 553;
+}
+);
+note = uni1638;
+unicode = 5688;
+},
+{
+color = 9;
+glyphname = "tlhaCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(361,-13,o),
+(414,62,o),
+(432,155,c),
+(427,162,l),
+(427,0,l),
+(482,0,l),
+(482,270,l),
+(430,270,l),
+(424,145,o),
+(381,45,o),
+(270,45,cs),
+(176,45,o),
+(112,133,o),
+(112,345,cs),
+(112,559,o),
+(176,644,o),
+(270,644,cs),
+(381,644,o),
+(424,545,o),
+(430,419,c),
+(482,419,l),
+(482,704,l),
+(542,704,l),
+(542,750,l),
+(375,750,l),
+(375,704,l),
+(435,704,l),
+(435,523,l),
+(441,526,l),
+(420,632,o),
+(359,702,o),
+(257,702,cs),
+(141,702,o),
+(50,590,o),
+(50,345,cs),
+(50,99,o),
+(141,-13,o),
+(257,-13,cs)
+);
+}
+);
+width = 553;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni1639;
+unicode = 5689;
+},
+{
+color = 9;
+glyphname = "tluCarrier-canadian";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(268,-13,o),
+(314,25,o),
+(331,109,c),
+(316,109,l),
+(332,25,o),
+(379,-13,o),
+(436,-13,cs),
+(530,-13,o),
+(593,59,o),
+(593,284,cs),
+(593,510,o),
+(544,611,o),
+(453,648,c),
+(439,641,l),
+(590,641,l),
+(590,558,l),
+(637,558,l),
+(637,773,l),
+(590,773,l),
+(590,690,l),
+(368,690,l),
+(368,639,l),
+(483,635,o),
+(531,529,o),
+(531,286,cs),
+(531,86,o),
+(490,44,o),
+(434,44,cs),
+(385,44,o),
+(353,88,o),
+(353,189,cs),
+(353,298,l),
+(295,298,l),
+(295,189,ls),
+(295,88,o),
+(261,44,o),
+(213,44,cs),
+(156,44,o),
+(116,86,o),
+(116,286,cs),
+(116,529,o),
+(164,635,o),
+(279,639,c),
+(279,690,l),
+(48,690,l),
+(48,639,l),
+(206,639,l),
+(190,646,l),
+(102,608,o),
+(54,508,o),
+(54,284,cs),
+(54,59,o),
+(116,-13,o),
+(211,-13,cs)
+);
+}
+);
+width = 669;
+}
+);
+metricRight = "tlhuCarrier-canadian";
+note = uni163A;
+unicode = 5690;
+},
+{
+color = 1;
+glyphname = "tloCarrier-canadian";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(637,-83,l),
+(637,131,l),
+(590,131,l),
+(590,48,l),
+(439,48,l),
+(453,42,l),
+(544,78,o),
+(593,180,o),
+(593,406,cs),
+(593,631,o),
+(530,702,o),
+(436,702,cs),
+(379,702,o),
+(332,665,o),
+(316,581,c),
+(331,581,l),
+(314,665,o),
+(268,702,o),
+(211,702,cs),
+(116,702,o),
+(54,631,o),
+(54,406,cs),
+(54,182,o),
+(102,82,o),
+(190,43,c),
+(206,51,l),
+(48,51,l),
+(48,0,l),
+(279,0,l),
+(279,50,l),
+(164,55,o),
+(116,160,o),
+(116,404,cs),
+(116,604,o),
+(156,645,o),
+(213,645,cs),
+(261,645,o),
+(295,602,o),
+(295,500,cs),
+(295,391,l),
+(353,391,l),
+(353,500,ls),
+(353,602,o),
+(385,645,o),
+(434,645,cs),
+(490,645,o),
+(531,604,o),
+(531,404,cs),
+(531,160,o),
+(483,55,o),
+(368,50,c),
+(368,0,l),
+(590,0,l),
+(590,-83,l)
+);
+}
+);
+width = 669;
+}
+);
+metricLeft = "tluCarrier-canadian";
+metricRight = "tlhuCarrier-canadian";
+note = uni163B;
+unicode = 5691;
+},
+{
+color = 9;
+glyphname = "tleCarrier-canadian";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (220,345);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(421,-13,o),
+(496,57,o),
+(496,179,cs),
+(496,270,o),
+(453,334,o),
+(378,350,c),
+(378,340,l),
+(453,355,o),
+(496,420,o),
+(496,511,cs),
+(496,633,o),
+(421,702,o),
+(310,702,cs),
+(198,702,o),
+(129,633,o),
+(111,531,c),
+(117,526,l),
+(117,704,l),
+(178,704,l),
+(178,750,l),
+(11,750,l),
+(11,704,l),
+(71,704,l),
+(71,419,l),
+(121,419,l),
+(123,550,o),
+(167,646,o),
+(296,646,cs),
+(384,646,o),
+(436,599,o),
+(436,503,cs),
+(436,419,o),
+(395,371,o),
+(327,371,cs),
+(295,371,l),
+(295,319,l),
+(327,319,ls),
+(394,319,o),
+(436,270,o),
+(436,187,cs),
+(436,92,o),
+(384,43,o),
+(295,43,cs),
+(167,43,o),
+(123,140,o),
+(121,270,c),
+(71,270,l),
+(71,0,l),
+(126,0,l),
+(126,154,l),
+(117,146,l),
+(138,53,o),
+(202,-13,o),
+(310,-13,cs)
+);
+}
+);
+width = 556;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni163C;
+unicode = 5692;
+},
+{
+color = 9;
+glyphname = "tleeCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (183,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 555;
+}
+);
+note = uni163D;
+unicode = 5693;
+},
+{
+color = 9;
+glyphname = "tliCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (166,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 555;
+}
+);
+note = uni163E;
+unicode = 5694;
+},
+{
+color = 9;
+glyphname = "tlaCarrier-canadian";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(354,-13,o),
+(417,53,o),
+(439,146,c),
+(431,154,l),
+(431,0,l),
+(485,0,l),
+(485,270,l),
+(435,270,l),
+(434,140,o),
+(388,43,o),
+(261,43,cs),
+(172,43,o),
+(120,92,o),
+(120,187,cs),
+(120,270,o),
+(161,319,o),
+(229,319,cs),
+(259,319,l),
+(259,371,l),
+(229,371,ls),
+(160,371,o),
+(120,419,o),
+(120,503,cs),
+(120,599,o),
+(173,646,o),
+(260,646,cs),
+(388,646,o),
+(434,550,o),
+(435,419,c),
+(485,419,l),
+(485,704,l),
+(545,704,l),
+(545,750,l),
+(379,750,l),
+(379,704,l),
+(439,704,l),
+(439,526,l),
+(444,531,l),
+(426,633,o),
+(357,702,o),
+(245,702,cs),
+(134,702,o),
+(60,633,o),
+(60,511,cs),
+(60,420,o),
+(102,355,o),
+(178,340,c),
+(178,350,l),
+(102,334,o),
+(60,270,o),
+(60,179,cs),
+(60,57,o),
+(134,-13,o),
+(245,-13,cs)
+);
+}
+);
+width = 556;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni163F;
+unicode = 5695;
+},
+{
+color = 9;
+glyphname = "zuCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(417,-13,o),
+(504,76,o),
+(504,228,cs),
+(504,345,o),
+(431,497,o),
+(431,576,cs),
+(431,605,o),
+(442,637,o),
+(491,637,cs),
+(512,637,l),
+(512,690,l),
+(476,690,ls),
+(402,690,o),
+(372,645,o),
+(372,582,cs),
+(372,495,o),
+(443,349,o),
+(443,237,cs),
+(443,113,o),
+(384,45,o),
+(278,45,cs),
+(172,45,o),
+(113,113,o),
+(113,237,cs),
+(113,349,o),
+(185,495,o),
+(185,582,cs),
+(185,645,o),
+(156,690,o),
+(81,690,cs),
+(45,690,l),
+(45,637,l),
+(66,637,ls),
+(115,637,o),
+(127,604,o),
+(127,576,cs),
+(127,497,o),
+(52,345,o),
+(52,228,cs),
+(52,76,o),
+(139,-13,o),
+(278,-13,cs)
+);
+}
+);
+width = 557;
+}
+);
+metricRight = "=|";
+note = uni1640;
+unicode = 5696;
+},
+{
+color = 9;
+glyphname = "zoCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(81,0,ls),
+(156,0,o),
+(185,44,o),
+(185,107,cs),
+(185,195,o),
+(114,341,o),
+(114,453,cs),
+(114,577,o),
+(173,644,o),
+(279,644,cs),
+(385,644,o),
+(444,577,o),
+(444,453,cs),
+(444,341,o),
+(372,195,o),
+(372,107,cs),
+(372,44,o),
+(402,0,o),
+(476,0,cs),
+(512,0,l),
+(512,53,l),
+(492,53,ls),
+(442,53,o),
+(431,86,o),
+(431,114,cs),
+(431,193,o),
+(505,345,o),
+(505,462,cs),
+(505,613,o),
+(418,702,o),
+(279,702,cs),
+(140,702,o),
+(53,613,o),
+(53,462,cs),
+(53,345,o),
+(127,193,o),
+(127,114,cs),
+(127,85,o),
+(115,53,o),
+(67,53,cs),
+(45,53,l),
+(45,0,l)
+);
+}
+);
+width = 557;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1641;
+unicode = 5697;
+},
+{
+color = 9;
+glyphname = "zeCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (274,345);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(410,-13,o),
+(478,91,o),
+(478,345,cs),
+(478,599,o),
+(410,702,o),
+(319,702,cs),
+(243,702,o),
+(173,599,o),
+(137,599,cs),
+(119,599,o),
+(103,611,o),
+(103,656,cs),
+(103,690,l),
+(47,690,l),
+(47,639,ls),
+(47,576,o),
+(78,544,o),
+(123,544,cs),
+(183,544,o),
+(245,644,o),
+(306,644,cs),
+(367,644,o),
+(417,569,o),
+(417,345,cs),
+(417,121,o),
+(367,45,o),
+(306,45,cs),
+(245,45,o),
+(183,146,o),
+(123,146,cs),
+(78,146,o),
+(47,114,o),
+(47,51,cs),
+(47,0,l),
+(103,0,l),
+(103,34,ls),
+(103,78,o),
+(119,91,o),
+(137,91,cs),
+(173,91,o),
+(243,-13,o),
+(319,-13,cs)
+);
+}
+);
+width = 528;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1642;
+unicode = 5698;
+},
+{
+color = 9;
+glyphname = "zeeCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (237,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 529;
+}
+);
+note = uni1643;
+unicode = 5699;
+},
+{
+color = 9;
+glyphname = "ziCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (216,0);
+ref = dot_middle;
+}
+);
+width = 529;
+}
+);
+note = uni1644;
+unicode = 5700;
+},
+{
+color = 9;
+glyphname = "zaCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(286,-13,o),
+(356,91,o),
+(392,91,cs),
+(411,91,o),
+(426,78,o),
+(426,34,cs),
+(426,0,l),
+(482,0,l),
+(482,51,ls),
+(482,114,o),
+(450,146,o),
+(407,146,cs),
+(346,146,o),
+(284,45,o),
+(223,45,cs),
+(162,45,o),
+(112,121,o),
+(112,345,cs),
+(112,569,o),
+(162,644,o),
+(223,644,cs),
+(284,644,o),
+(346,544,o),
+(407,544,cs),
+(450,544,o),
+(482,576,o),
+(482,639,cs),
+(482,690,l),
+(426,690,l),
+(426,656,ls),
+(426,611,o),
+(411,599,o),
+(392,599,cs),
+(356,599,o),
+(286,702,o),
+(210,702,cs),
+(120,702,o),
+(50,599,o),
+(50,345,cs),
+(50,91,o),
+(120,-13,o),
+(210,-13,cs)
+);
+}
+);
+width = 529;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|zeCarrier-canadian";
+note = uni1645;
+unicode = 5701;
+},
+{
+color = 6;
+glyphname = "zCarrier-canadian";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(273,183,l),
+(273,225,l),
+(96,225,l),
+(96,198,l),
+(270,503,l),
+(270,527,l),
+(50,527,l),
+(50,485,l),
+(226,485,l),
+(226,512,l),
+(50,207,l),
+(50,183,l)
+);
+}
+);
+width = 323;
+}
+);
+metricRight = "=|";
+note = uni1646;
+unicode = 5702;
+},
+{
+color = 6;
+glyphname = "initialzCarrier-canadian";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(139,183,l),
+(139,96,l),
+(183,96,l),
+(183,183,l),
+(273,183,l),
+(273,225,l),
+(83,225,l),
+(98,201,l),
+(270,503,l),
+(270,527,l),
+(183,527,l),
+(183,614,l),
+(139,614,l),
+(139,527,l),
+(50,527,l),
+(50,485,l),
+(238,485,l),
+(224,509,l),
+(50,207,l),
+(50,183,l)
+);
+}
+);
+width = 323;
+}
+);
+metricLeft = "zCarrier-canadian";
+metricRight = "zCarrier-canadian";
+note = uni1647;
+unicode = 5703;
+},
+{
+color = 9;
+glyphname = "dzuCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(417,-13,o),
+(504,76,o),
+(504,228,cs),
+(504,345,o),
+(431,497,o),
+(431,576,cs),
+(431,605,o),
+(442,637,o),
+(491,637,cs),
+(512,637,l),
+(512,690,l),
+(479,690,ls),
+(407,690,o),
+(375,645,o),
+(375,582,cs),
+(375,495,o),
+(443,352,o),
+(443,237,cs),
+(443,113,o),
+(384,45,o),
+(278,45,cs),
+(172,45,o),
+(113,113,o),
+(113,237,cs),
+(113,352,o),
+(183,495,o),
+(183,582,cs),
+(183,645,o),
+(151,690,o),
+(78,690,cs),
+(45,690,l),
+(45,637,l),
+(66,637,ls),
+(115,637,o),
+(127,604,o),
+(127,576,cs),
+(127,497,o),
+(52,345,o),
+(52,228,cs),
+(52,76,o),
+(139,-13,o),
+(278,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(294,490,l),
+(294,660,l),
+(344,660,l),
+(344,690,l),
+(213,690,l),
+(213,660,l),
+(264,660,l),
+(264,490,l)
+);
+}
+);
+width = 557;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1648;
+unicode = 5704;
+},
+{
+color = 9;
+glyphname = "dzoCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(78,0,ls),
+(151,0,o),
+(183,44,o),
+(183,107,cs),
+(183,195,o),
+(114,338,o),
+(114,453,cs),
+(114,577,o),
+(173,644,o),
+(279,644,cs),
+(385,644,o),
+(444,577,o),
+(444,453,cs),
+(444,338,o),
+(375,195,o),
+(375,107,cs),
+(375,44,o),
+(407,0,o),
+(479,0,cs),
+(512,0,l),
+(512,53,l),
+(492,53,ls),
+(442,53,o),
+(431,86,o),
+(431,114,cs),
+(431,193,o),
+(505,345,o),
+(505,462,cs),
+(505,613,o),
+(418,702,o),
+(279,702,cs),
+(140,702,o),
+(53,613,o),
+(53,462,cs),
+(53,345,o),
+(127,193,o),
+(127,114,cs),
+(127,85,o),
+(115,53,o),
+(67,53,cs),
+(45,53,l),
+(45,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(345,0,l),
+(345,30,l),
+(294,30,l),
+(294,200,l),
+(264,200,l),
+(264,30,l),
+(213,30,l),
+(213,0,l)
+);
+}
+);
+width = 557;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1649;
+unicode = 5705;
+},
+{
+color = 9;
+glyphname = "dzeCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (288,345);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(424,-13,o),
+(494,91,o),
+(494,345,cs),
+(494,599,o),
+(425,702,o),
+(334,702,cs),
+(258,702,o),
+(188,599,o),
+(152,599,cs),
+(133,599,o),
+(118,611,o),
+(118,656,cs),
+(118,690,l),
+(63,690,l),
+(63,639,ls),
+(63,576,o),
+(94,544,o),
+(137,544,cs),
+(198,544,o),
+(260,644,o),
+(322,644,cs),
+(382,644,o),
+(432,569,o),
+(432,345,cs),
+(432,121,o),
+(382,45,o),
+(322,45,cs),
+(260,45,o),
+(198,146,o),
+(137,146,cs),
+(94,146,o),
+(63,114,o),
+(63,51,cs),
+(63,0,l),
+(118,0,l),
+(118,34,ls),
+(118,76,o),
+(133,89,o),
+(152,89,cs),
+(188,89,o),
+(258,-13,o),
+(334,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(99,241,l),
+(99,326,l),
+(202,326,l),
+(202,364,l),
+(99,364,l),
+(99,449,l),
+(63,449,l),
+(63,241,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164A;
+unicode = 5706;
+},
+{
+color = 9;
+glyphname = "dzeeCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+ref = "dzeCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (250,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 544;
+}
+);
+metricLeft = "dzeCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164B;
+unicode = 5707;
+},
+{
+color = 9;
+glyphname = "dziCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "dzeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (230,0);
+ref = dot_middle;
+}
+);
+width = 544;
+}
+);
+note = uni164C;
+unicode = 5708;
+},
+{
+color = 9;
+glyphname = "dzaCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(286,-13,o),
+(356,89,o),
+(392,89,cs),
+(411,89,o),
+(426,76,o),
+(426,34,cs),
+(426,0,l),
+(482,0,l),
+(482,51,ls),
+(482,114,o),
+(450,146,o),
+(407,146,cs),
+(346,146,o),
+(284,45,o),
+(223,45,cs),
+(162,45,o),
+(112,121,o),
+(112,345,cs),
+(112,569,o),
+(162,644,o),
+(223,644,cs),
+(284,644,o),
+(346,544,o),
+(407,544,cs),
+(450,544,o),
+(482,576,o),
+(482,639,cs),
+(482,690,l),
+(426,690,l),
+(426,656,ls),
+(426,611,o),
+(411,599,o),
+(392,599,cs),
+(356,599,o),
+(286,702,o),
+(210,702,cs),
+(120,702,o),
+(50,599,o),
+(50,345,cs),
+(50,91,o),
+(120,-13,o),
+(210,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(482,241,l),
+(482,449,l),
+(444,449,l),
+(444,364,l),
+(343,364,l),
+(343,326,l),
+(444,326,l),
+(444,241,l)
+);
+}
+);
+width = 545;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dzeCarrier-canadian";
+note = uni164D;
+unicode = 5709;
+},
+{
+color = 9;
+glyphname = "suCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(269,-13,o),
+(315,39,o),
+(330,137,c),
+(313,137,l),
+(328,39,o),
+(375,-13,o),
+(448,-13,cs),
+(537,-13,o),
+(592,58,o),
+(592,175,cs),
+(592,308,o),
+(521,474,o),
+(521,575,cs),
+(521,604,o),
+(531,637,o),
+(580,637,cs),
+(597,637,l),
+(597,690,l),
+(565,690,ls),
+(490,690,o),
+(463,645,o),
+(463,582,cs),
+(463,477,o),
+(532,300,o),
+(532,179,cs),
+(532,90,o),
+(499,44,o),
+(443,44,cs),
+(382,44,o),
+(349,99,o),
+(349,204,cs),
+(349,690,l),
+(295,690,l),
+(295,204,ls),
+(295,99,o),
+(262,44,o),
+(201,44,cs),
+(144,44,o),
+(111,90,o),
+(111,179,cs),
+(111,300,o),
+(181,477,o),
+(181,582,cs),
+(181,645,o),
+(153,690,o),
+(77,690,cs),
+(45,690,l),
+(45,637,l),
+(63,637,ls),
+(111,637,o),
+(123,604,o),
+(123,575,cs),
+(123,474,o),
+(51,308,o),
+(51,175,cs),
+(51,58,o),
+(106,-13,o),
+(195,-13,cs)
+);
+}
+);
+width = 642;
+}
+);
+metricRight = "=|";
+note = uni164E;
+unicode = 5710;
+},
+{
+color = 9;
+glyphname = "soCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(77,0,ls),
+(153,0,o),
+(180,44,o),
+(180,108,cs),
+(180,213,o),
+(111,389,o),
+(111,511,cs),
+(111,600,o),
+(143,645,o),
+(199,645,cs),
+(261,645,o),
+(294,591,o),
+(294,486,cs),
+(294,0,l),
+(348,0,l),
+(348,486,ls),
+(348,590,o),
+(381,645,o),
+(441,645,cs),
+(498,645,o),
+(531,600,o),
+(531,511,cs),
+(531,389,o),
+(462,213,o),
+(462,108,cs),
+(462,44,o),
+(490,0,o),
+(565,0,cs),
+(597,0,l),
+(597,53,l),
+(580,53,ls),
+(531,53,o),
+(520,86,o),
+(520,115,cs),
+(520,215,o),
+(591,382,o),
+(591,515,cs),
+(591,632,o),
+(536,702,o),
+(447,702,cs),
+(374,702,o),
+(328,651,o),
+(312,553,c),
+(329,553,l),
+(314,651,o),
+(268,702,o),
+(194,702,cs),
+(105,702,o),
+(51,632,o),
+(51,515,cs),
+(51,382,o),
+(122,215,o),
+(122,115,cs),
+(122,86,o),
+(111,53,o),
+(63,53,cs),
+(45,53,l),
+(45,0,l)
+);
+}
+);
+width = 642;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5711;
+},
+{
+color = 9;
+glyphname = "seCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(429,-13,o),
+(487,59,o),
+(487,172,cs),
+(487,276,o),
+(439,344,o),
+(355,353,c),
+(355,337,l),
+(439,346,o),
+(487,413,o),
+(487,518,cs),
+(487,631,o),
+(429,702,o),
+(347,702,cs),
+(266,702,o),
+(192,599,o),
+(150,599,cs),
+(132,599,o),
+(117,611,o),
+(117,656,cs),
+(117,690,l),
+(61,690,l),
+(61,639,ls),
+(61,576,o),
+(93,544,o),
+(136,544,cs),
+(199,544,o),
+(270,646,o),
+(332,646,cs),
+(390,646,o),
+(427,595,o),
+(427,512,cs),
+(427,419,o),
+(382,371,o),
+(314,371,cs),
+(61,371,l),
+(61,319,l),
+(314,319,ls),
+(384,319,o),
+(427,270,o),
+(427,178,cs),
+(427,95,o),
+(390,43,o),
+(333,43,cs),
+(270,43,o),
+(199,146,o),
+(136,146,cs),
+(93,146,o),
+(61,114,o),
+(61,51,cs),
+(61,0,l),
+(117,0,l),
+(117,34,ls),
+(117,78,o),
+(132,91,o),
+(150,91,cs),
+(192,91,o),
+(266,-13,o),
+(348,-13,cs)
+);
+}
+);
+width = 547;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni1650;
+unicode = 5712;
+},
+{
+color = 9;
+glyphname = "seeCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(429,-13,o),
+(487,59,o),
+(487,172,cs),
+(487,270,o),
+(444,334,o),
+(371,350,c),
+(371,340,l),
+(444,355,o),
+(487,421,o),
+(487,518,cs),
+(487,631,o),
+(429,702,o),
+(347,702,cs),
+(266,702,o),
+(192,599,o),
+(150,599,cs),
+(132,599,o),
+(117,611,o),
+(117,656,cs),
+(117,690,l),
+(61,690,l),
+(61,639,ls),
+(61,576,o),
+(93,544,o),
+(136,544,cs),
+(199,544,o),
+(270,646,o),
+(332,646,cs),
+(390,646,o),
+(427,595,o),
+(427,512,cs),
+(427,419,o),
+(382,370,o),
+(313,370,cs),
+(254,370,l),
+(271,350,l),
+(271,452,l),
+(235,452,l),
+(235,370,l),
+(61,370,l),
+(61,320,l),
+(235,320,l),
+(235,228,l),
+(271,228,l),
+(271,337,l),
+(254,320,l),
+(313,320,ls),
+(384,320,o),
+(427,270,o),
+(427,178,cs),
+(427,95,o),
+(390,43,o),
+(333,43,cs),
+(270,43,o),
+(199,146,o),
+(136,146,cs),
+(93,146,o),
+(61,114,o),
+(61,51,cs),
+(61,0,l),
+(117,0,l),
+(117,34,ls),
+(117,78,o),
+(132,91,o),
+(150,91,cs),
+(192,91,o),
+(266,-13,o),
+(348,-13,cs)
+);
+}
+);
+width = 547;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1651;
+unicode = 5713;
+},
+{
+color = 9;
+glyphname = "siCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(429,-13,o),
+(487,59,o),
+(487,172,cs),
+(487,270,o),
+(444,334,o),
+(371,350,c),
+(371,340,l),
+(444,355,o),
+(487,421,o),
+(487,518,cs),
+(487,631,o),
+(429,702,o),
+(347,702,cs),
+(266,702,o),
+(192,599,o),
+(150,599,cs),
+(132,599,o),
+(117,611,o),
+(117,656,cs),
+(117,690,l),
+(61,690,l),
+(61,639,ls),
+(61,576,o),
+(93,544,o),
+(136,544,cs),
+(199,544,o),
+(270,646,o),
+(332,646,cs),
+(390,646,o),
+(427,594,o),
+(427,510,cs),
+(427,417,o),
+(384,369,o),
+(318,369,cs),
+(273,369,l),
+(298,351,l),
+(297,381,o),
+(272,404,o),
+(242,404,cs),
+(218,404,o),
+(198,389,o),
+(189,370,c),
+(61,370,l),
+(61,320,l),
+(190,320,l),
+(198,300,o),
+(218,286,o),
+(242,286,cs),
+(271,286,o),
+(296,309,o),
+(298,339,c),
+(273,321,l),
+(318,321,ls),
+(386,321,o),
+(427,272,o),
+(427,180,cs),
+(427,96,o),
+(390,43,o),
+(333,43,cs),
+(270,43,o),
+(199,146,o),
+(136,146,cs),
+(93,146,o),
+(61,114,o),
+(61,51,cs),
+(61,0,l),
+(117,0,l),
+(117,34,ls),
+(117,78,o),
+(132,91,o),
+(150,91,cs),
+(192,91,o),
+(266,-13,o),
+(348,-13,cs)
+);
+}
+);
+width = 547;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1652;
+unicode = 5714;
+},
+{
+color = 9;
+glyphname = "saCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(281,-13,o),
+(355,91,o),
+(397,91,cs),
+(414,91,o),
+(430,78,o),
+(430,34,cs),
+(430,0,l),
+(486,0,l),
+(486,51,ls),
+(486,114,o),
+(454,146,o),
+(411,146,cs),
+(348,146,o),
+(276,43,o),
+(213,43,cs),
+(156,43,o),
+(120,95,o),
+(120,178,cs),
+(120,270,o),
+(163,319,o),
+(233,319,cs),
+(486,319,l),
+(486,371,l),
+(233,371,ls),
+(165,371,o),
+(120,419,o),
+(120,512,cs),
+(120,595,o),
+(156,646,o),
+(214,646,cs),
+(276,646,o),
+(348,544,o),
+(411,544,cs),
+(454,544,o),
+(486,576,o),
+(486,639,cs),
+(486,690,l),
+(430,690,l),
+(430,656,ls),
+(430,611,o),
+(414,599,o),
+(397,599,cs),
+(355,599,o),
+(281,702,o),
+(200,702,cs),
+(118,702,o),
+(60,631,o),
+(60,518,cs),
+(60,413,o),
+(108,346,o),
+(192,337,c),
+(192,353,l),
+(108,344,o),
+(60,276,o),
+(60,172,cs),
+(60,59,o),
+(118,-13,o),
+(199,-13,cs)
+);
+}
+);
+width = 547;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1653;
+unicode = 5715;
+},
+{
+color = 9;
+glyphname = "shuCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(266,-13,o),
+(311,35,o),
+(328,127,c),
+(315,127,l),
+(332,35,o),
+(378,-13,o),
+(448,-13,cs),
+(537,-13,o),
+(592,58,o),
+(592,175,cs),
+(592,308,o),
+(521,474,o),
+(521,575,cs),
+(521,604,o),
+(531,637,o),
+(580,637,cs),
+(597,637,l),
+(597,690,l),
+(565,690,ls),
+(490,690,o),
+(463,645,o),
+(463,582,cs),
+(463,564,o),
+(466,546,o),
+(468,526,c),
+(479,554,l),
+(349,554,l),
+(349,690,l),
+(295,690,l),
+(295,554,l),
+(164,554,l),
+(176,526,l),
+(178,546,o),
+(181,564,o),
+(181,582,cs),
+(181,645,o),
+(153,690,o),
+(77,690,cs),
+(45,690,l),
+(45,637,l),
+(63,637,ls),
+(111,637,o),
+(123,604,o),
+(123,575,cs),
+(123,474,o),
+(51,308,o),
+(51,175,cs),
+(51,58,o),
+(106,-13,o),
+(195,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(144,44,o),
+(111,90,o),
+(111,179,cs),
+(111,275,o),
+(155,405,o),
+(173,506,c),
+(295,506,l),
+(295,204,ls),
+(295,99,o),
+(262,44,o),
+(201,44,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(382,44,o),
+(349,99,o),
+(349,204,cs),
+(349,506,l),
+(470,506,l),
+(489,405,o),
+(532,275,o),
+(532,179,cs),
+(532,90,o),
+(499,44,o),
+(443,44,cs)
+);
+}
+);
+width = 642;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1654;
+unicode = 5716;
+},
+{
+color = 9;
+glyphname = "shoCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(77,0,ls),
+(153,0,o),
+(180,44,o),
+(180,108,cs),
+(180,126,o),
+(177,144,o),
+(175,164,c),
+(163,135,l),
+(294,135,l),
+(294,0,l),
+(348,0,l),
+(348,135,l),
+(479,135,l),
+(467,164,l),
+(465,144,o),
+(463,126,o),
+(463,108,cs),
+(463,44,o),
+(490,0,o),
+(565,0,cs),
+(597,0,l),
+(597,53,l),
+(580,53,ls),
+(531,53,o),
+(520,86,o),
+(520,115,cs),
+(520,215,o),
+(591,382,o),
+(591,515,cs),
+(591,632,o),
+(536,702,o),
+(447,702,cs),
+(377,702,o),
+(331,655,o),
+(314,563,c),
+(327,563,l),
+(310,655,o),
+(265,702,o),
+(194,702,cs),
+(105,702,o),
+(51,632,o),
+(51,515,cs),
+(51,382,o),
+(122,215,o),
+(122,115,cs),
+(122,86,o),
+(111,53,o),
+(63,53,cs),
+(45,53,l),
+(45,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(155,285,o),
+(111,414,o),
+(111,511,cs),
+(111,600,o),
+(143,645,o),
+(199,645,cs),
+(261,645,o),
+(294,591,o),
+(294,486,cs),
+(294,184,l),
+(172,184,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(348,486,ls),
+(348,590,o),
+(381,645,o),
+(441,645,cs),
+(498,645,o),
+(531,600,o),
+(531,511,cs),
+(531,414,o),
+(488,285,o),
+(469,184,c),
+(348,184,l)
+);
+}
+);
+width = 642;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1655;
+unicode = 5717;
+},
+{
+color = 9;
+glyphname = "sheCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(429,-13,o),
+(487,59,o),
+(487,172,cs),
+(487,270,o),
+(444,334,o),
+(371,350,c),
+(371,340,l),
+(444,355,o),
+(487,421,o),
+(487,518,cs),
+(487,631,o),
+(429,702,o),
+(347,702,cs),
+(266,702,o),
+(192,599,o),
+(150,599,cs),
+(132,599,o),
+(117,611,o),
+(117,656,cs),
+(117,690,l),
+(61,690,l),
+(61,639,ls),
+(61,576,o),
+(93,546,o),
+(136,546,cs),
+(151,546,o),
+(165,551,o),
+(180,558,c),
+(148,569,l),
+(148,371,l),
+(61,371,l),
+(61,319,l),
+(148,319,l),
+(148,121,l),
+(180,131,l),
+(165,139,o),
+(151,144,o),
+(136,144,cs),
+(93,144,o),
+(61,114,o),
+(61,51,cs),
+(61,0,l),
+(117,0,l),
+(117,34,ls),
+(117,78,o),
+(132,91,o),
+(150,91,cs),
+(192,91,o),
+(266,-13,o),
+(348,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(196,319,l),
+(314,319,ls),
+(384,319,o),
+(427,270,o),
+(427,178,cs),
+(427,95,o),
+(390,43,o),
+(333,43,cs),
+(289,43,o),
+(241,93,o),
+(196,122,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(196,568,l),
+(241,597,o),
+(289,646,o),
+(332,646,cs),
+(390,646,o),
+(427,595,o),
+(427,512,cs),
+(427,419,o),
+(382,371,o),
+(314,371,cs),
+(196,371,l)
+);
+}
+);
+width = 547;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1656;
+unicode = 5718;
+},
+{
+color = 9;
+glyphname = "sheeCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(429,-13,o),
+(487,59,o),
+(487,172,cs),
+(487,270,o),
+(444,334,o),
+(371,350,c),
+(371,340,l),
+(444,355,o),
+(487,421,o),
+(487,518,cs),
+(487,631,o),
+(429,702,o),
+(347,702,cs),
+(266,702,o),
+(192,599,o),
+(150,599,cs),
+(132,599,o),
+(117,611,o),
+(117,656,cs),
+(117,690,l),
+(61,690,l),
+(61,639,ls),
+(61,576,o),
+(93,546,o),
+(136,546,cs),
+(148,546,o),
+(161,550,o),
+(174,556,c),
+(148,567,l),
+(148,367,l),
+(61,367,l),
+(61,323,l),
+(148,323,l),
+(148,123,l),
+(174,133,l),
+(161,140,o),
+(149,144,o),
+(136,144,cs),
+(93,144,o),
+(61,114,o),
+(61,51,cs),
+(61,0,l),
+(117,0,l),
+(117,34,ls),
+(117,78,o),
+(132,91,o),
+(150,91,cs),
+(192,91,o),
+(266,-13,o),
+(348,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(288,43,o),
+(237,98,o),
+(187,126,c),
+(187,323,l),
+(276,323,l),
+(276,228,l),
+(308,228,l),
+(308,335,l),
+(293,323,l),
+(320,323,ls),
+(387,323,o),
+(428,270,o),
+(428,180,cs),
+(428,95,o),
+(391,43,o),
+(334,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(308,452,l),
+(276,452,l),
+(276,367,l),
+(187,367,l),
+(187,564,l),
+(237,592,o),
+(288,647,o),
+(333,647,cs),
+(391,647,o),
+(428,595,o),
+(428,510,cs),
+(428,419,o),
+(385,367,o),
+(320,367,cs),
+(293,367,l),
+(308,355,l)
+);
+}
+);
+width = 547;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1657;
+unicode = 5719;
+},
+{
+color = 9;
+glyphname = "shiCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(61,639,ls),
+(61,576,o),
+(93,546,o),
+(136,546,cs),
+(147,546,o),
+(159,550,o),
+(170,554,c),
+(148,567,l),
+(148,367,l),
+(61,367,l),
+(61,323,l),
+(148,323,l),
+(148,123,l),
+(171,135,l),
+(159,140,o),
+(148,144,o),
+(136,144,cs),
+(93,144,o),
+(61,114,o),
+(61,51,cs),
+(61,0,l),
+(117,0,l),
+(117,34,ls),
+(117,78,o),
+(132,91,o),
+(150,91,cs),
+(192,91,o),
+(266,-13,o),
+(348,-13,cs),
+(429,-13,o),
+(487,59,o),
+(487,172,cs),
+(487,270,o),
+(444,334,o),
+(371,350,c),
+(371,340,l),
+(444,355,o),
+(487,421,o),
+(487,518,cs),
+(487,631,o),
+(429,702,o),
+(347,702,cs),
+(266,702,o),
+(192,599,o),
+(150,599,cs),
+(132,599,o),
+(117,611,o),
+(117,656,cs),
+(117,690,l),
+(61,690,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(187,323,l),
+(242,323,l),
+(249,300,o),
+(270,286,o),
+(292,286,cs),
+(321,286,o),
+(345,311,o),
+(345,339,c),
+(302,322,l),
+(323,322,ls),
+(388,322,o),
+(428,270,o),
+(428,180,cs),
+(428,95,o),
+(391,43,o),
+(334,43,cs),
+(288,43,o),
+(237,97,o),
+(187,126,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(187,564,l),
+(237,593,o),
+(288,647,o),
+(333,647,cs),
+(391,647,o),
+(428,595,o),
+(428,510,cs),
+(428,419,o),
+(386,368,o),
+(323,368,cs),
+(303,368,l),
+(346,351,l),
+(345,380,o),
+(321,404,o),
+(292,404,cs),
+(270,404,o),
+(249,389,o),
+(242,367,c),
+(187,367,l)
+);
+}
+);
+width = 547;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1658;
+unicode = 5720;
+},
+{
+color = 9;
+glyphname = "shaCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(281,-13,o),
+(355,91,o),
+(397,91,cs),
+(414,91,o),
+(430,78,o),
+(430,34,cs),
+(430,0,l),
+(486,0,l),
+(486,51,ls),
+(486,114,o),
+(454,144,o),
+(411,144,cs),
+(396,144,o),
+(382,139,o),
+(367,131,c),
+(399,121,l),
+(399,319,l),
+(486,319,l),
+(486,371,l),
+(399,371,l),
+(399,569,l),
+(367,558,l),
+(382,551,o),
+(396,546,o),
+(411,546,cs),
+(454,546,o),
+(486,576,o),
+(486,639,cs),
+(486,690,l),
+(430,690,l),
+(430,656,ls),
+(430,611,o),
+(414,599,o),
+(397,599,cs),
+(355,599,o),
+(281,702,o),
+(200,702,cs),
+(118,702,o),
+(60,631,o),
+(60,518,cs),
+(60,421,o),
+(102,355,o),
+(176,340,c),
+(176,350,l),
+(102,334,o),
+(60,270,o),
+(60,172,cs),
+(60,59,o),
+(118,-13,o),
+(199,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(156,43,o),
+(120,95,o),
+(120,178,cs),
+(120,270,o),
+(163,319,o),
+(233,319,cs),
+(351,319,l),
+(351,122,l),
+(306,93,o),
+(258,43,o),
+(213,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(165,371,o),
+(120,419,o),
+(120,512,cs),
+(120,595,o),
+(156,646,o),
+(214,646,cs),
+(258,646,o),
+(306,597,o),
+(351,568,c),
+(351,371,l),
+(233,371,ls)
+);
+}
+);
+width = 547;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1659;
+unicode = 5721;
+},
+{
+color = 6;
+glyphname = "shCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(174,96,l),
+(174,194,l),
+(143,184,l),
+(158,184,ls),
+(223,184,o),
+(256,218,o),
+(256,279,cs),
+(256,338,o),
+(226,375,o),
+(166,375,cs),
+(147,375,ls),
+(114,375,o),
+(92,388,o),
+(92,432,cs),
+(92,474,o),
+(115,490,o),
+(147,490,cs),
+(252,490,l),
+(252,527,l),
+(174,527,l),
+(174,614,l),
+(132,614,l),
+(132,513,l),
+(162,527,l),
+(148,527,ls),
+(84,527,o),
+(50,492,o),
+(50,431,cs),
+(50,373,o),
+(81,336,o),
+(140,336,cs),
+(160,336,ls),
+(192,336,o),
+(214,321,o),
+(214,278,cs),
+(214,237,o),
+(192,221,o),
+(160,221,cs),
+(55,221,l),
+(55,184,l),
+(132,184,l),
+(132,96,l)
+);
+}
+);
+width = 306;
+}
+);
+metricRight = "=|";
+note = uni18F5;
+unicode = 5722;
+},
+{
+color = 9;
+glyphname = "tsuCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(266,-13,o),
+(311,35,o),
+(328,127,c),
+(315,127,l),
+(332,35,o),
+(378,-13,o),
+(448,-13,cs),
+(537,-13,o),
+(592,58,o),
+(592,175,cs),
+(592,308,o),
+(521,474,o),
+(521,575,cs),
+(521,604,o),
+(531,637,o),
+(580,637,cs),
+(597,637,l),
+(597,690,l),
+(565,690,ls),
+(492,690,o),
+(465,648,o),
+(465,583,cs),
+(465,526,o),
+(488,449,o),
+(506,369,c),
+(348,369,l),
+(348,645,l),
+(410,645,l),
+(410,690,l),
+(233,690,l),
+(233,645,l),
+(296,645,l),
+(296,369,l),
+(137,369,l),
+(156,449,o),
+(179,526,o),
+(179,583,cs),
+(179,648,o),
+(151,690,o),
+(77,690,cs),
+(45,690,l),
+(45,637,l),
+(63,637,ls),
+(111,637,o),
+(123,604,o),
+(123,575,cs),
+(123,474,o),
+(51,308,o),
+(51,175,cs),
+(51,58,o),
+(106,-13,o),
+(195,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(145,44,o),
+(111,90,o),
+(111,179,cs),
+(111,222,o),
+(120,270,o),
+(130,321,c),
+(296,321,l),
+(296,204,ls),
+(296,99,o),
+(263,44,o),
+(202,44,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(381,44,o),
+(348,99,o),
+(348,204,cs),
+(348,321,l),
+(513,321,l),
+(524,270,o),
+(532,222,o),
+(532,179,cs),
+(532,90,o),
+(499,44,o),
+(442,44,cs)
+);
+}
+);
+width = 642;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165B;
+unicode = 5723;
+},
+{
+color = 9;
+glyphname = "tsoCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(77,0,ls),
+(151,0,o),
+(178,42,o),
+(178,106,cs),
+(178,163,o),
+(156,241,o),
+(137,321,c),
+(295,321,l),
+(295,44,l),
+(234,44,l),
+(234,0,l),
+(410,0,l),
+(410,44,l),
+(347,44,l),
+(347,321,l),
+(505,321,l),
+(487,241,o),
+(464,163,o),
+(464,106,cs),
+(464,42,o),
+(492,0,o),
+(565,0,cs),
+(597,0,l),
+(597,53,l),
+(580,53,ls),
+(531,53,o),
+(520,86,o),
+(520,115,cs),
+(520,215,o),
+(591,382,o),
+(591,515,cs),
+(591,632,o),
+(536,702,o),
+(447,702,cs),
+(377,702,o),
+(331,655,o),
+(314,563,c),
+(328,563,l),
+(310,655,o),
+(265,702,o),
+(194,702,cs),
+(105,702,o),
+(51,632,o),
+(51,515,cs),
+(51,382,o),
+(122,215,o),
+(122,115,cs),
+(122,86,o),
+(111,53,o),
+(63,53,cs),
+(45,53,l),
+(45,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(120,419,o),
+(111,468,o),
+(111,511,cs),
+(111,600,o),
+(143,645,o),
+(200,645,cs),
+(262,645,o),
+(295,591,o),
+(295,486,cs),
+(295,369,l),
+(129,369,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(347,486,ls),
+(347,590,o),
+(381,645,o),
+(441,645,cs),
+(497,645,o),
+(531,600,o),
+(531,511,cs),
+(531,468,o),
+(523,419,o),
+(512,369,c),
+(347,369,l)
+);
+}
+);
+width = 642;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165C;
+unicode = 5724;
+},
+{
+color = 9;
+glyphname = "tseCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(431,-13,o),
+(489,59,o),
+(489,172,cs),
+(489,270,o),
+(447,334,o),
+(373,350,c),
+(373,340,l),
+(446,355,o),
+(489,421,o),
+(489,518,cs),
+(489,631,o),
+(431,702,o),
+(350,702,cs),
+(268,702,o),
+(194,599,o),
+(152,599,cs),
+(134,599,o),
+(119,611,o),
+(119,656,cs),
+(119,690,l),
+(63,690,l),
+(63,639,ls),
+(63,577,o),
+(95,547,o),
+(138,547,cs),
+(159,547,o),
+(184,560,o),
+(207,576,c),
+(189,583,l),
+(189,367,l),
+(100,367,l),
+(100,465,l),
+(63,465,l),
+(63,225,l),
+(100,225,l),
+(100,323,l),
+(189,323,l),
+(189,106,l),
+(207,114,l),
+(184,129,o),
+(159,143,o),
+(138,143,cs),
+(95,143,o),
+(63,113,o),
+(63,50,cs),
+(63,0,l),
+(119,0,l),
+(119,34,ls),
+(119,78,o),
+(134,91,o),
+(152,91,cs),
+(194,91,o),
+(268,-13,o),
+(350,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(301,43,o),
+(265,73,o),
+(230,99,c),
+(230,323,l),
+(316,323,ls),
+(386,323,o),
+(430,271,o),
+(430,179,cs),
+(430,96,o),
+(393,43,o),
+(336,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(230,590,l),
+(265,616,o),
+(301,646,o),
+(335,646,cs),
+(393,646,o),
+(430,594,o),
+(430,511,cs),
+(430,418,o),
+(384,367,o),
+(316,367,cs),
+(230,367,l)
+);
+}
+);
+width = 549;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni165D;
+unicode = 5725;
+},
+{
+color = 9;
+glyphname = "tseeCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(431,-13,o),
+(489,59,o),
+(489,172,cs),
+(489,270,o),
+(447,334,o),
+(373,350,c),
+(373,340,l),
+(446,355,o),
+(489,421,o),
+(489,518,cs),
+(489,631,o),
+(431,702,o),
+(350,702,cs),
+(268,702,o),
+(194,599,o),
+(152,599,cs),
+(134,599,o),
+(119,611,o),
+(119,656,cs),
+(119,690,l),
+(63,690,l),
+(63,639,ls),
+(63,577,o),
+(95,547,o),
+(138,547,cs),
+(157,547,o),
+(179,559,o),
+(200,573,c),
+(185,587,l),
+(185,366,l),
+(98,366,l),
+(98,465,l),
+(63,465,l),
+(63,225,l),
+(98,225,l),
+(98,324,l),
+(185,324,l),
+(185,102,l),
+(198,117,l),
+(178,130,o),
+(156,143,o),
+(138,143,cs),
+(95,143,o),
+(63,113,o),
+(63,50,cs),
+(63,0,l),
+(119,0,l),
+(119,34,ls),
+(119,78,o),
+(134,91,o),
+(152,91,cs),
+(194,91,o),
+(268,-13,o),
+(350,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(299,43,o),
+(261,76,o),
+(221,104,c),
+(221,324,l),
+(297,324,l),
+(297,224,l),
+(328,224,l),
+(328,334,l),
+(314,324,l),
+(324,324,ls),
+(392,324,o),
+(431,271,o),
+(431,181,cs),
+(431,96,o),
+(394,43,o),
+(336,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(328,455,l),
+(297,455,l),
+(297,366,l),
+(221,366,l),
+(221,585,l),
+(261,613,o),
+(299,646,o),
+(335,646,cs),
+(394,646,o),
+(431,594,o),
+(431,509,cs),
+(431,418,o),
+(389,366,o),
+(324,366,cs),
+(314,366,l),
+(328,355,l)
+);
+}
+);
+width = 549;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165E;
+unicode = 5726;
+},
+{
+color = 9;
+glyphname = "tsiCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(431,-13,o),
+(489,59,o),
+(489,172,cs),
+(489,270,o),
+(447,334,o),
+(373,350,c),
+(373,340,l),
+(447,355,o),
+(489,421,o),
+(489,518,cs),
+(489,631,o),
+(431,702,o),
+(350,702,cs),
+(268,702,o),
+(194,599,o),
+(152,599,cs),
+(134,599,o),
+(119,611,o),
+(119,656,cs),
+(119,690,l),
+(63,690,l),
+(63,639,ls),
+(63,577,o),
+(95,547,o),
+(138,547,cs),
+(159,547,o),
+(183,560,o),
+(206,575,c),
+(185,579,l),
+(185,366,l),
+(98,366,l),
+(98,465,l),
+(63,465,l),
+(63,225,l),
+(98,225,l),
+(98,324,l),
+(185,324,l),
+(185,111,l),
+(206,115,l),
+(183,129,o),
+(159,143,o),
+(138,143,cs),
+(95,143,o),
+(63,113,o),
+(63,50,cs),
+(63,0,l),
+(119,0,l),
+(119,34,ls),
+(119,78,o),
+(134,91,o),
+(152,91,cs),
+(194,91,o),
+(268,-13,o),
+(350,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(299,43,o),
+(261,76,o),
+(221,104,c),
+(221,324,l),
+(266,324,l),
+(271,300,o),
+(291,286,o),
+(313,286,cs),
+(342,286,o),
+(361,312,o),
+(363,338,c),
+(304,324,l),
+(323,324,ls),
+(391,324,o),
+(431,271,o),
+(431,181,cs),
+(431,96,o),
+(394,43,o),
+(336,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(362,378,o),
+(342,404,o),
+(313,404,cs),
+(291,404,o),
+(272,389,o),
+(266,366,c),
+(221,366,l),
+(221,585,l),
+(261,613,o),
+(299,646,o),
+(335,646,cs),
+(394,646,o),
+(431,594,o),
+(431,509,cs),
+(431,418,o),
+(389,366,o),
+(323,366,cs),
+(304,366,l),
+(363,350,l)
+);
+}
+);
+width = 549;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165F;
+unicode = 5727;
+},
+{
+color = 9;
+glyphname = "tsaCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(281,-13,o),
+(355,91,o),
+(397,91,cs),
+(414,91,o),
+(430,78,o),
+(430,34,cs),
+(430,0,l),
+(486,0,l),
+(486,50,ls),
+(486,113,o),
+(454,143,o),
+(411,143,cs),
+(389,143,o),
+(365,129,o),
+(342,114,c),
+(359,106,l),
+(359,323,l),
+(448,323,l),
+(448,225,l),
+(486,225,l),
+(486,465,l),
+(448,465,l),
+(448,367,l),
+(359,367,l),
+(359,583,l),
+(343,576,l),
+(365,560,o),
+(389,547,o),
+(411,547,cs),
+(454,547,o),
+(486,577,o),
+(486,639,cs),
+(486,690,l),
+(430,690,l),
+(430,656,ls),
+(430,611,o),
+(414,599,o),
+(397,599,cs),
+(355,599,o),
+(281,702,o),
+(200,702,cs),
+(118,702,o),
+(60,631,o),
+(60,518,cs),
+(60,421,o),
+(102,355,o),
+(176,340,c),
+(176,350,l),
+(102,334,o),
+(60,270,o),
+(60,172,cs),
+(60,59,o),
+(118,-13,o),
+(199,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(156,43,o),
+(119,96,o),
+(119,179,cs),
+(119,271,o),
+(162,323,o),
+(233,323,cs),
+(319,323,l),
+(319,99,l),
+(284,73,o),
+(247,43,o),
+(213,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(164,367,o),
+(119,418,o),
+(119,511,cs),
+(119,594,o),
+(156,646,o),
+(213,646,cs),
+(247,646,o),
+(284,616,o),
+(319,590,c),
+(319,367,l),
+(233,367,ls)
+);
+}
+);
+width = 549;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1660;
+unicode = 5728;
+},
+{
+color = 9;
+glyphname = "chuCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(266,-13,o),
+(311,35,o),
+(328,127,c),
+(315,127,l),
+(332,35,o),
+(378,-13,o),
+(448,-13,cs),
+(537,-13,o),
+(592,58,o),
+(592,175,cs),
+(592,308,o),
+(521,474,o),
+(521,575,cs),
+(521,604,o),
+(531,637,o),
+(580,637,cs),
+(597,637,l),
+(597,690,l),
+(565,690,ls),
+(492,690,o),
+(465,648,o),
+(465,583,cs),
+(465,474,o),
+(532,300,o),
+(532,179,cs),
+(532,90,o),
+(499,44,o),
+(442,44,cs),
+(381,44,o),
+(348,99,o),
+(348,204,cs),
+(348,645,l),
+(410,645,l),
+(410,690,l),
+(233,690,l),
+(233,645,l),
+(296,645,l),
+(296,204,ls),
+(296,99,o),
+(263,44,o),
+(202,44,cs),
+(145,44,o),
+(111,90,o),
+(111,179,cs),
+(111,300,o),
+(179,474,o),
+(179,583,cs),
+(179,648,o),
+(151,690,o),
+(77,690,cs),
+(45,690,l),
+(45,637,l),
+(63,637,ls),
+(111,637,o),
+(123,604,o),
+(123,575,cs),
+(123,474,o),
+(51,308,o),
+(51,175,cs),
+(51,58,o),
+(106,-13,o),
+(195,-13,cs)
+);
+}
+);
+width = 642;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164E;
+unicode = 5729;
+},
+{
+color = 9;
+glyphname = "choCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(77,0,ls),
+(151,0,o),
+(178,42,o),
+(178,106,cs),
+(178,215,o),
+(111,389,o),
+(111,511,cs),
+(111,600,o),
+(143,645,o),
+(200,645,cs),
+(262,645,o),
+(295,591,o),
+(295,486,cs),
+(295,44,l),
+(234,44,l),
+(234,0,l),
+(410,0,l),
+(410,44,l),
+(347,44,l),
+(347,486,ls),
+(347,590,o),
+(381,645,o),
+(441,645,cs),
+(497,645,o),
+(531,600,o),
+(531,511,cs),
+(531,389,o),
+(464,215,o),
+(464,106,cs),
+(464,42,o),
+(492,0,o),
+(565,0,cs),
+(597,0,l),
+(597,53,l),
+(580,53,ls),
+(531,53,o),
+(520,86,o),
+(520,115,cs),
+(520,215,o),
+(591,382,o),
+(591,515,cs),
+(591,632,o),
+(536,702,o),
+(447,702,cs),
+(377,702,o),
+(331,655,o),
+(314,563,c),
+(328,563,l),
+(310,655,o),
+(265,702,o),
+(194,702,cs),
+(105,702,o),
+(51,632,o),
+(51,515,cs),
+(51,382,o),
+(122,215,o),
+(122,115,cs),
+(122,86,o),
+(111,53,o),
+(63,53,cs),
+(45,53,l),
+(45,0,l)
+);
+}
+);
+width = 642;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5730;
+},
+{
+color = 9;
+glyphname = "cheCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(431,-13,o),
+(489,59,o),
+(489,172,cs),
+(489,270,o),
+(447,334,o),
+(373,350,c),
+(373,340,l),
+(446,355,o),
+(489,421,o),
+(489,518,cs),
+(489,631,o),
+(431,702,o),
+(350,702,cs),
+(268,702,o),
+(194,599,o),
+(152,599,cs),
+(134,599,o),
+(119,611,o),
+(119,656,cs),
+(119,690,l),
+(63,690,l),
+(63,639,ls),
+(63,576,o),
+(95,546,o),
+(138,546,cs),
+(201,546,o),
+(272,646,o),
+(334,646,cs),
+(392,646,o),
+(429,595,o),
+(429,512,cs),
+(429,419,o),
+(384,371,o),
+(316,371,cs),
+(100,371,l),
+(100,465,l),
+(63,465,l),
+(63,225,l),
+(100,225,l),
+(100,319,l),
+(316,319,ls),
+(385,319,o),
+(429,270,o),
+(429,178,cs),
+(429,95,o),
+(392,43,o),
+(335,43,cs),
+(272,43,o),
+(201,144,o),
+(138,144,cs),
+(95,144,o),
+(63,114,o),
+(63,51,cs),
+(63,0,l),
+(119,0,l),
+(119,34,ls),
+(119,78,o),
+(134,91,o),
+(152,91,cs),
+(194,91,o),
+(268,-13,o),
+(350,-13,cs)
+);
+}
+);
+width = 549;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni1663;
+unicode = 5731;
+},
+{
+color = 9;
+glyphname = "cheeCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(431,-13,o),
+(489,59,o),
+(489,172,cs),
+(489,270,o),
+(447,334,o),
+(373,350,c),
+(373,340,l),
+(446,355,o),
+(489,421,o),
+(489,518,cs),
+(489,631,o),
+(431,702,o),
+(350,702,cs),
+(268,702,o),
+(194,599,o),
+(152,599,cs),
+(134,599,o),
+(119,611,o),
+(119,656,cs),
+(119,690,l),
+(63,690,l),
+(63,639,ls),
+(63,576,o),
+(95,546,o),
+(138,546,cs),
+(201,546,o),
+(273,647,o),
+(335,647,cs),
+(393,647,o),
+(430,595,o),
+(430,512,cs),
+(430,419,o),
+(387,367,o),
+(322,367,cs),
+(266,367,l),
+(283,355,l),
+(283,452,l),
+(246,452,l),
+(246,367,l),
+(100,367,l),
+(100,465,l),
+(63,465,l),
+(63,225,l),
+(100,225,l),
+(100,323,l),
+(246,323,l),
+(246,228,l),
+(283,228,l),
+(283,335,l),
+(266,323,l),
+(322,323,ls),
+(390,323,o),
+(430,270,o),
+(430,178,cs),
+(430,95,o),
+(393,43,o),
+(336,43,cs),
+(273,43,o),
+(201,144,o),
+(138,144,cs),
+(95,144,o),
+(63,114,o),
+(63,51,cs),
+(63,0,l),
+(119,0,l),
+(119,34,ls),
+(119,78,o),
+(134,91,o),
+(152,91,cs),
+(194,91,o),
+(268,-13,o),
+(350,-13,cs)
+);
+}
+);
+width = 549;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1664;
+unicode = 5732;
+},
+{
+color = 9;
+glyphname = "chiCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(431,-13,o),
+(489,59,o),
+(489,172,cs),
+(489,270,o),
+(447,334,o),
+(373,350,c),
+(373,340,l),
+(447,355,o),
+(489,421,o),
+(489,518,cs),
+(489,631,o),
+(431,702,o),
+(350,702,cs),
+(268,702,o),
+(194,599,o),
+(152,599,cs),
+(134,599,o),
+(119,611,o),
+(119,656,cs),
+(119,690,l),
+(63,690,l),
+(63,639,ls),
+(63,576,o),
+(95,546,o),
+(138,546,cs),
+(201,546,o),
+(273,647,o),
+(335,647,cs),
+(393,647,o),
+(430,595,o),
+(430,512,cs),
+(430,419,o),
+(387,367,o),
+(321,367,cs),
+(274,367,l),
+(307,349,l),
+(305,380,o),
+(281,404,o),
+(250,404,cs),
+(226,404,o),
+(205,388,o),
+(197,367,c),
+(100,367,l),
+(100,465,l),
+(63,465,l),
+(63,225,l),
+(100,225,l),
+(100,323,l),
+(197,323,l),
+(205,301,o),
+(226,286,o),
+(250,286,cs),
+(281,286,o),
+(305,310,o),
+(307,341,c),
+(274,323,l),
+(321,323,ls),
+(390,323,o),
+(430,270,o),
+(430,178,cs),
+(430,95,o),
+(393,43,o),
+(336,43,cs),
+(273,43,o),
+(201,144,o),
+(138,144,cs),
+(95,144,o),
+(63,114,o),
+(63,51,cs),
+(63,0,l),
+(119,0,l),
+(119,34,ls),
+(119,78,o),
+(134,91,o),
+(152,91,cs),
+(194,91,o),
+(268,-13,o),
+(350,-13,cs)
+);
+}
+);
+width = 549;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1665;
+unicode = 5733;
+},
+{
+color = 9;
+glyphname = "chaCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(281,-13,o),
+(355,91,o),
+(397,91,cs),
+(414,91,o),
+(430,78,o),
+(430,34,cs),
+(430,0,l),
+(486,0,l),
+(486,51,ls),
+(486,114,o),
+(454,144,o),
+(411,144,cs),
+(348,144,o),
+(276,43,o),
+(214,43,cs),
+(156,43,o),
+(120,95,o),
+(120,178,cs),
+(120,270,o),
+(165,319,o),
+(233,319,cs),
+(448,319,l),
+(448,225,l),
+(486,225,l),
+(486,465,l),
+(448,465,l),
+(448,371,l),
+(233,371,ls),
+(163,371,o),
+(120,419,o),
+(120,512,cs),
+(120,595,o),
+(156,646,o),
+(213,646,cs),
+(276,646,o),
+(348,546,o),
+(411,546,cs),
+(454,546,o),
+(486,576,o),
+(486,639,cs),
+(486,690,l),
+(430,690,l),
+(430,656,ls),
+(430,611,o),
+(414,599,o),
+(397,599,cs),
+(355,599,o),
+(281,702,o),
+(199,702,cs),
+(118,702,o),
+(60,631,o),
+(60,518,cs),
+(60,421,o),
+(102,355,o),
+(176,340,c),
+(176,350,l),
+(102,334,o),
+(60,270,o),
+(60,172,cs),
+(60,59,o),
+(118,-13,o),
+(200,-13,cs)
+);
+}
+);
+width = 549;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1666;
+unicode = 5734;
+},
+{
+color = 9;
+glyphname = "ttsuCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(266,-13,o),
+(311,35,o),
+(328,127,c),
+(315,127,l),
+(332,35,o),
+(378,-13,o),
+(448,-13,cs),
+(537,-13,o),
+(592,58,o),
+(592,175,cs),
+(592,308,o),
+(521,474,o),
+(521,575,cs),
+(521,604,o),
+(531,637,o),
+(580,637,cs),
+(597,637,l),
+(597,690,l),
+(565,690,ls),
+(492,690,o),
+(465,648,o),
+(465,583,cs),
+(465,552,o),
+(470,515,o),
+(476,476,c),
+(496,521,l),
+(348,389,l),
+(348,645,l),
+(410,645,l),
+(410,690,l),
+(233,690,l),
+(233,645,l),
+(296,645,l),
+(296,389,l),
+(148,520,l),
+(167,475,l),
+(173,515,o),
+(179,552,o),
+(179,583,cs),
+(179,648,o),
+(151,690,o),
+(77,690,cs),
+(45,690,l),
+(45,637,l),
+(63,637,ls),
+(111,637,o),
+(123,604,o),
+(123,575,cs),
+(123,474,o),
+(51,308,o),
+(51,175,cs),
+(51,58,o),
+(106,-13,o),
+(195,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(145,44,o),
+(111,90,o),
+(111,179,cs),
+(111,260,o),
+(142,359,o),
+(161,447,c),
+(296,329,l),
+(296,204,ls),
+(296,99,o),
+(263,44,o),
+(202,44,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(381,44,o),
+(348,99,o),
+(348,204,cs),
+(348,329,l),
+(481,447,l),
+(501,360,o),
+(532,260,o),
+(532,179,cs),
+(532,90,o),
+(499,44,o),
+(442,44,cs)
+);
+}
+);
+width = 642;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1667;
+unicode = 5735;
+},
+{
+color = 9;
+glyphname = "ttsoCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(77,0,ls),
+(151,0,o),
+(179,42,o),
+(179,106,cs),
+(179,138,o),
+(173,175,o),
+(167,214,c),
+(148,170,l),
+(296,300,l),
+(296,44,l),
+(233,44,l),
+(233,0,l),
+(410,0,l),
+(410,44,l),
+(348,44,l),
+(348,300,l),
+(496,169,l),
+(476,213,l),
+(470,175,o),
+(465,138,o),
+(465,106,cs),
+(465,42,o),
+(492,0,o),
+(565,0,cs),
+(597,0,l),
+(597,53,l),
+(580,53,ls),
+(531,53,o),
+(521,86,o),
+(521,115,cs),
+(521,215,o),
+(592,382,o),
+(592,515,cs),
+(592,632,o),
+(537,702,o),
+(448,702,cs),
+(378,702,o),
+(332,655,o),
+(315,563,c),
+(328,563,l),
+(311,655,o),
+(266,702,o),
+(195,702,cs),
+(106,702,o),
+(51,632,o),
+(51,515,cs),
+(51,382,o),
+(123,215,o),
+(123,115,cs),
+(123,86,o),
+(111,53,o),
+(63,53,cs),
+(45,53,l),
+(45,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(142,330,o),
+(111,430,o),
+(111,511,cs),
+(111,600,o),
+(145,645,o),
+(202,645,cs),
+(263,645,o),
+(296,590,o),
+(296,486,cs),
+(296,360,l),
+(161,242,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(348,360,l),
+(348,486,ls),
+(348,591,o),
+(381,645,o),
+(442,645,cs),
+(499,645,o),
+(532,600,o),
+(532,511,cs),
+(532,430,o),
+(501,329,o),
+(481,242,c)
+);
+}
+);
+width = 642;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1668;
+unicode = 5736;
+},
+{
+color = 9;
+glyphname = "ttseCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(431,-13,o),
+(489,59,o),
+(489,172,cs),
+(489,270,o),
+(447,334,o),
+(373,350,c),
+(373,340,l),
+(447,355,o),
+(489,421,o),
+(489,518,cs),
+(489,631,o),
+(431,702,o),
+(350,702,cs),
+(268,702,o),
+(194,599,o),
+(152,599,cs),
+(134,599,o),
+(119,611,o),
+(119,656,cs),
+(119,690,l),
+(63,690,l),
+(63,639,ls),
+(63,576,o),
+(95,546,o),
+(138,546,cs),
+(147,546,o),
+(157,547,o),
+(158,555,c),
+(124,575,l),
+(192,367,l),
+(100,367,l),
+(100,465,l),
+(63,465,l),
+(63,225,l),
+(100,225,l),
+(100,323,l),
+(192,323,l),
+(124,115,l),
+(158,134,l),
+(156,143,o),
+(147,144,o),
+(138,144,cs),
+(95,144,o),
+(63,114,o),
+(63,51,cs),
+(63,0,l),
+(119,0,l),
+(119,34,ls),
+(119,78,o),
+(134,91,o),
+(152,91,cs),
+(194,91,o),
+(268,-13,o),
+(350,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(282,43,o),
+(224,116,o),
+(174,134,c),
+(235,323,l),
+(321,323,ls),
+(390,323,o),
+(430,270,o),
+(430,178,cs),
+(430,95,o),
+(393,43,o),
+(336,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(174,555,l),
+(224,574,o),
+(282,647,o),
+(335,647,cs),
+(393,647,o),
+(430,595,o),
+(430,512,cs),
+(430,419,o),
+(387,367,o),
+(321,367,cs),
+(235,367,l)
+);
+}
+);
+width = 549;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1669;
+unicode = 5737;
+},
+{
+color = 9;
+glyphname = "ttseeCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(431,-13,o),
+(489,59,o),
+(489,172,cs),
+(489,270,o),
+(447,334,o),
+(373,350,c),
+(373,340,l),
+(447,355,o),
+(489,421,o),
+(489,518,cs),
+(489,631,o),
+(431,702,o),
+(350,702,cs),
+(268,702,o),
+(194,599,o),
+(152,599,cs),
+(134,599,o),
+(119,611,o),
+(119,656,cs),
+(119,690,l),
+(63,690,l),
+(63,639,ls),
+(63,576,o),
+(95,546,o),
+(138,546,cs),
+(144,546,o),
+(154,546,o),
+(153,554,c),
+(122,573,l),
+(189,367,l),
+(100,367,l),
+(100,465,l),
+(63,465,l),
+(63,225,l),
+(100,225,l),
+(100,323,l),
+(189,323,l),
+(122,117,l),
+(153,136,l),
+(154,144,o),
+(144,144,o),
+(138,144,cs),
+(95,144,o),
+(63,114,o),
+(63,51,cs),
+(63,0,l),
+(119,0,l),
+(119,34,ls),
+(119,78,o),
+(134,91,o),
+(152,91,cs),
+(194,91,o),
+(268,-13,o),
+(350,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(281,43,o),
+(221,118,o),
+(170,136,c),
+(230,323,l),
+(289,323,l),
+(289,224,l),
+(324,224,l),
+(324,335,l),
+(308,323,l),
+(321,323,ls),
+(390,323,o),
+(430,270,o),
+(430,178,cs),
+(430,95,o),
+(393,43,o),
+(336,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(324,455,l),
+(289,455,l),
+(289,367,l),
+(230,367,l),
+(170,554,l),
+(221,572,o),
+(281,647,o),
+(335,647,cs),
+(393,647,o),
+(430,595,o),
+(430,512,cs),
+(430,419,o),
+(387,367,o),
+(321,367,cs),
+(308,367,l),
+(324,355,l)
+);
+}
+);
+width = 549;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166A;
+unicode = 5738;
+},
+{
+color = 9;
+glyphname = "ttsiCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(431,-13,o),
+(489,59,o),
+(489,172,cs),
+(489,270,o),
+(447,334,o),
+(373,350,c),
+(373,340,l),
+(447,355,o),
+(489,421,o),
+(489,518,cs),
+(489,631,o),
+(431,702,o),
+(350,702,cs),
+(268,702,o),
+(194,599,o),
+(152,599,cs),
+(134,599,o),
+(119,611,o),
+(119,656,cs),
+(119,690,l),
+(63,690,l),
+(63,639,ls),
+(63,576,o),
+(95,546,o),
+(138,546,cs),
+(145,546,o),
+(153,546,o),
+(156,554,c),
+(127,560,l),
+(189,367,l),
+(100,367,l),
+(100,465,l),
+(63,465,l),
+(63,225,l),
+(100,225,l),
+(100,323,l),
+(189,323,l),
+(124,124,l),
+(155,135,l),
+(153,144,o),
+(144,144,o),
+(138,144,cs),
+(95,144,o),
+(63,114,o),
+(63,51,cs),
+(63,0,l),
+(119,0,l),
+(119,34,ls),
+(119,78,o),
+(134,91,o),
+(152,91,cs),
+(194,91,o),
+(268,-13,o),
+(350,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(281,43,o),
+(217,121,o),
+(166,138,c),
+(226,323,l),
+(246,323,l),
+(253,301,o),
+(272,286,o),
+(296,286,cs),
+(321,286,o),
+(343,305,o),
+(347,331,c),
+(304,323,l),
+(324,323,ls),
+(392,323,o),
+(430,270,o),
+(430,178,cs),
+(430,95,o),
+(393,43,o),
+(336,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(343,384,o),
+(322,404,o),
+(296,404,cs),
+(273,404,o),
+(253,388,o),
+(246,367,c),
+(226,367,l),
+(166,552,l),
+(217,569,o),
+(281,647,o),
+(335,647,cs),
+(393,647,o),
+(430,595,o),
+(430,512,cs),
+(430,419,o),
+(390,367,o),
+(324,367,cs),
+(304,367,l),
+(347,358,l)
+);
+}
+);
+width = 549;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166B;
+unicode = 5739;
+},
+{
+color = 9;
+glyphname = "ttsaCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(281,-13,o),
+(355,91,o),
+(397,91,cs),
+(414,91,o),
+(430,78,o),
+(430,34,cs),
+(430,0,l),
+(486,0,l),
+(486,51,ls),
+(486,114,o),
+(454,144,o),
+(411,144,cs),
+(402,144,o),
+(392,143,o),
+(390,134,c),
+(425,115,l),
+(356,323,l),
+(448,323,l),
+(448,225,l),
+(486,225,l),
+(486,465,l),
+(448,465,l),
+(448,367,l),
+(356,367,l),
+(425,575,l),
+(390,555,l),
+(391,547,o),
+(402,546,o),
+(411,546,cs),
+(454,546,o),
+(486,576,o),
+(486,639,cs),
+(486,690,l),
+(430,690,l),
+(430,656,ls),
+(430,611,o),
+(414,599,o),
+(397,599,cs),
+(355,599,o),
+(281,702,o),
+(200,702,cs),
+(118,702,o),
+(60,631,o),
+(60,518,cs),
+(60,421,o),
+(102,355,o),
+(176,340,c),
+(176,350,l),
+(102,334,o),
+(60,270,o),
+(60,172,cs),
+(60,59,o),
+(118,-13,o),
+(199,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(156,43,o),
+(119,95,o),
+(119,178,cs),
+(119,270,o),
+(159,323,o),
+(228,323,cs),
+(314,323,l),
+(375,134,l),
+(325,116,o),
+(267,43,o),
+(213,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(161,367,o),
+(119,419,o),
+(119,512,cs),
+(119,595,o),
+(156,647,o),
+(213,647,cs),
+(267,647,o),
+(325,574,o),
+(375,555,c),
+(314,367,l),
+(228,367,ls)
+);
+}
+);
+width = 549;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni166C;
+unicode = 5740;
+},
+{
+glyphname = "qai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (243,0);
+ref = "ke-canadian";
+}
+);
+width = 694;
+}
+);
+note = uni166F;
+unicode = 5743;
+},
+{
+glyphname = "ngai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (471,0);
+ref = "ce-canadian";
+}
+);
+width = 916;
+}
+);
+note = uni1670;
+unicode = 5744;
+},
+{
+glyphname = "nngi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (710,0);
+ref = "ci-canadian";
+}
+);
+width = 1154;
+}
+);
+note = uni1671;
+unicode = 5745;
+},
+{
+glyphname = "nngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (710,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (879,0);
+ref = dot_top;
+}
+);
+width = 1154;
+}
+);
+note = uni1672;
+unicode = 5746;
+},
+{
+glyphname = "nngo-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (710,0);
+ref = "ce-canadian";
+}
+);
+width = 1154;
+}
+);
+note = uni1673;
+unicode = 5747;
+},
+{
+glyphname = "nngoo-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (710,0);
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (871,0);
+ref = dot_top;
+}
+);
+width = 1154;
+}
+);
+note = uni1674;
+unicode = 5748;
+},
+{
+glyphname = "nnga-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (710,0);
+ref = "ca-canadian";
+}
+);
+width = 1154;
+}
+);
+note = uni1675;
+unicode = 5749;
+},
+{
+glyphname = "nngaa-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (710,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (742,0);
+ref = dot_top;
+}
+);
+width = 1154;
+}
+);
+note = uni1676;
+unicode = 5750;
+},
+{
+glyphname = "thweeWoodScree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (469,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 638;
+}
+);
+note = uni1677;
+unicode = 5751;
+},
+{
+glyphname = "thwiWoodScree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (469,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 638;
+}
+);
+note = uni1678;
+unicode = 5752;
+},
+{
+glyphname = "thwiiWoodScree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (68,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (469,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 638;
+}
+);
+note = uni1679;
+unicode = 5753;
+},
+{
+glyphname = "thwoWoodScree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (469,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 638;
+}
+);
+note = uni167A;
+unicode = 5754;
+},
+{
+glyphname = "thwooWoodScree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (285,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (469,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 638;
+}
+);
+note = uni167B;
+unicode = 5755;
+},
+{
+glyphname = "thwaWoodScree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = middle_right_can;
+pos = (468,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 638;
+}
+);
+note = uni167C;
+unicode = 5756;
+},
+{
+glyphname = "thwaaWoodScree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (67,0);
+ref = dot_top;
+},
+{
+anchor = middle_right_can;
+pos = (468,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 638;
+}
+);
+note = uni167D;
+unicode = 5757;
+},
+{
+glyphname = "wBlackfoot-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(290,564,l),
+(290,604,l),
+(50,604,l),
+(50,564,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(290,431,l),
+(290,470,l),
+(50,470,l),
+(50,431,l)
+);
+}
+);
+width = 340;
+}
+);
+metricRight = "=|";
+note = uni167F;
+unicode = 5759;
+},
+{
+glyphname = "oy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-27,0);
+ref = ring_top.canadian;
+}
+);
+width = 521;
+}
+);
+note = uni18B0;
+unicode = 6320;
+},
+{
+glyphname = "ay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (316,0);
+ref = ring_top.canadian;
+}
+);
+width = 521;
+}
+);
+note = uni18B1;
+unicode = 6321;
+},
+{
+glyphname = "aay-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (120,0);
+ref = ring_top.canadian;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (372,0);
+ref = dot_top;
+}
+);
+width = 521;
+}
+);
+note = uni18B2;
+unicode = 6322;
+},
+{
+glyphname = "way-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (486,0);
+ref = ring_top.canadian;
+}
+);
+width = 690;
+}
+);
+note = uni18B3;
+unicode = 6323;
+},
+{
+glyphname = "poy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-46,0);
+ref = ring_top.canadian;
+}
+);
+width = 495;
+}
+);
+note = uni18B4;
+unicode = 6324;
+},
+{
+glyphname = "pay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (312,0);
+ref = ring_top.canadian;
+}
+);
+width = 495;
+}
+);
+note = uni18B5;
+unicode = 6325;
+},
+{
+glyphname = "pwoy-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (124,0);
+ref = ring_top.canadian;
+}
+);
+width = 664;
+}
+);
+note = uni18B6;
+unicode = 6326;
+},
+{
+glyphname = "tay-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (136,0);
+ref = ring_top.canadian;
+}
+);
+width = 453;
+}
+);
+note = uni18B7;
+unicode = 6327;
+},
+{
+glyphname = "kay-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-24,0);
+ref = ring_top.canadian;
+}
+);
+width = 450;
+}
+);
+note = uni18B8;
+unicode = 6328;
+},
+{
+glyphname = "kway-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (145,0);
+ref = ring_top.canadian;
+}
+);
+width = 619;
+}
+);
+note = uni18B9;
+unicode = 6329;
+},
+{
+glyphname = "may-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-20,0);
+ref = ring_top.canadian;
+}
+);
+width = 398;
+}
+);
+note = uni18BA;
+unicode = 6330;
+},
+{
+glyphname = "noy-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (271,-199);
+ref = ring_top.canadian;
+}
+);
+width = 615;
+}
+);
+note = uni18BB;
+unicode = 6331;
+},
+{
+glyphname = "nay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (114,-199);
+ref = ring_top.canadian;
+}
+);
+width = 615;
+}
+);
+note = uni18BC;
+unicode = 6332;
+},
+{
+glyphname = "lay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (114,-199);
+ref = ring_top.canadian;
+}
+);
+width = 615;
+}
+);
+note = uni18BD;
+unicode = 6333;
+},
+{
+glyphname = "soy-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (201,0);
+ref = ring_top.canadian;
+}
+);
+width = 409;
+}
+);
+note = uni18BE;
+unicode = 6334;
+},
+{
+glyphname = "say-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-20,0);
+ref = ring_top.canadian;
+}
+);
+width = 409;
+}
+);
+note = uni18BF;
+unicode = 6335;
+},
+{
+glyphname = "shoy-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (242,-199);
+ref = ring_top.canadian;
+}
+);
+width = 712;
+}
+);
+note = uni18C0;
+unicode = 6336;
+},
+{
+glyphname = "shay-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (242,-199);
+ref = ring_top.canadian;
+}
+);
+width = 712;
+}
+);
+note = uni18C1;
+unicode = 6337;
+},
+{
+glyphname = "shwoy-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (411,-199);
+ref = ring_top.canadian;
+}
+);
+width = 882;
+}
+);
+note = uni18C2;
+unicode = 6338;
+},
+{
+glyphname = "yoy-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (229,0);
+ref = ring_top.canadian;
+}
+);
+width = 433;
+}
+);
+note = uni18C3;
+unicode = 6339;
+},
+{
+glyphname = "yay-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-24,0);
+ref = ring_top.canadian;
+}
+);
+width = 433;
+}
+);
+note = uni18C4;
+unicode = 6340;
+},
+{
+glyphname = "ray-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (116,0);
+ref = ring_top.canadian;
+}
+);
+width = 410;
+}
+);
+note = uni18C5;
+unicode = 6341;
+},
+{
+glyphname = "nwi-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ni-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni18C6;
+unicode = 6342;
+},
+{
+glyphname = "nwiOjibway-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni18C7;
+unicode = 6343;
+},
+{
+glyphname = "nwii-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (346,-199);
+ref = dot_top;
+}
+);
+width = 784;
+}
+);
+note = uni18C8;
+unicode = 6344;
+},
+{
+glyphname = "nwiiOjibway-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (177,-199);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni18C9;
+unicode = 6345;
+},
+{
+glyphname = "nwo-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "no-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni18CA;
+unicode = 6346;
+},
+{
+glyphname = "nwoOjibway-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni18CB;
+unicode = 6347;
+},
+{
+glyphname = "nwoo-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (497,-199);
+ref = dot_top;
+}
+);
+width = 784;
+}
+);
+note = uni18CC;
+unicode = 6348;
+},
+{
+glyphname = "nwooOjibway-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (327,-199);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (615,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni18CD;
+unicode = 6349;
+},
+{
+glyphname = "rwee-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "reRCree-canadian";
+}
+);
+width = 818;
+}
+);
+note = uni18CE;
+unicode = 6350;
+},
+{
+glyphname = "rwi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ri-canadian";
+}
+);
+width = 818;
+}
+);
+note = uni18CF;
+unicode = 6351;
+},
+{
+glyphname = "rwii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (340,-199);
+ref = dot_top;
+}
+);
+width = 818;
+}
+);
+note = uni18D0;
+unicode = 6352;
+},
+{
+glyphname = "rwo-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ro-canadian";
+}
+);
+width = 580;
+}
+);
+note = uni18D1;
+unicode = 6353;
+},
+{
+glyphname = "rwoo-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (290,0);
+ref = dot_top;
+}
+);
+width = 580;
+}
+);
+note = uni18D2;
+unicode = 6354;
+},
+{
+glyphname = "rwa-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = "ra-canadian";
+}
+);
+width = 580;
+}
+);
+note = uni18D3;
+unicode = 6355;
+},
+{
+glyphname = "pOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(71,345,l),
+(165,640,l),
+(139,640,l),
+(233,345,l),
+(272,345,l),
+(272,356,l),
+(158,690,l),
+(146,690,l),
+(31,356,l),
+(31,345,l)
+);
+}
+);
+width = 303;
+}
+);
+metricLeft = "kkCarrier-canadian";
+note = uni18D4;
+unicode = 6356;
+},
+{
+glyphname = "tOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 318;
+}
+);
+metricRight = "=|";
+note = uni1422;
+unicode = 6357;
+},
+{
+glyphname = "kOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(94,344,l),
+(94,513,l),
+(82,513,l),
+(85,463,o),
+(114,433,o),
+(153,433,cs),
+(200,433,o),
+(238,476,o),
+(238,560,cs),
+(238,652,o),
+(196,695,o),
+(144,695,cs),
+(88,695,o),
+(50,649,o),
+(50,564,cs),
+(50,344,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(113,469,o),
+(91,497,o),
+(91,563,cs),
+(91,634,o),
+(111,660,o),
+(145,660,cs),
+(177,660,o),
+(198,631,o),
+(198,563,cs),
+(198,496,o),
+(176,469,o),
+(145,469,cs)
+);
+}
+);
+width = 278;
+}
+);
+metricLeft = "k-canadian";
+metricRight = "k-canadian";
+note = uni18D6;
+unicode = 6358;
+},
+{
+glyphname = "cOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(94,345,l),
+(94,578,ls),
+(94,633,o),
+(111,658,o),
+(146,658,cs),
+(178,658,o),
+(198,632,o),
+(198,583,cs),
+(198,550,l),
+(238,550,l),
+(238,577,ls),
+(238,653,o),
+(200,696,o),
+(145,696,cs),
+(86,696,o),
+(50,654,o),
+(50,572,cs),
+(50,345,l)
+);
+}
+);
+width = 270;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni18D7;
+unicode = 6359;
+},
+{
+glyphname = "mOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(94,345,l),
+(94,647,l),
+(217,647,l),
+(217,690,l),
+(50,690,l),
+(50,345,l)
+);
+}
+);
+width = 245;
+}
+);
+metricLeft = "m-canadian";
+metricRight = "m-canadian";
+note = uni18D8;
+unicode = 6360;
+},
+{
+glyphname = "nOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(188,428,o),
+(225,472,o),
+(225,556,cs),
+(225,607,o),
+(212,652,o),
+(182,667,c),
+(181,647,l),
+(321,647,l),
+(321,690,l),
+(138,690,ls),
+(75,690,o),
+(40,642,o),
+(40,557,cs),
+(40,473,o),
+(76,428,o),
+(132,428,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(99,464,o),
+(79,492,o),
+(79,557,cs),
+(79,624,o),
+(99,654,o),
+(132,654,cs),
+(165,654,o),
+(185,625,o),
+(185,558,cs),
+(185,493,o),
+(166,464,o),
+(133,464,cs)
+);
+}
+);
+width = 349;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "n-canadian";
+note = uni18D9;
+unicode = 6361;
+},
+{
+glyphname = "sOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(94,345,l),
+(94,487,l),
+(69,466,l),
+(93,466,ls),
+(172,466,o),
+(216,513,o),
+(216,608,cs),
+(216,690,l),
+(173,690,l),
+(173,611,ls),
+(173,535,o),
+(145,502,o),
+(83,502,cs),
+(50,502,l),
+(50,345,l)
+);
+}
+);
+width = 266;
+}
+);
+metricLeft = "s-canadian";
+metricRight = "s-canadian";
+note = uni18DA;
+unicode = 6362;
+},
+{
+color = 1;
+glyphname = "shOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(184,339,o),
+(213,379,o),
+(218,457,cs),
+(227,582,ls),
+(231,633,o),
+(245,658,o),
+(277,658,cs),
+(310,658,o),
+(329,634,o),
+(329,584,cs),
+(329,550,l),
+(370,550,l),
+(370,581,ls),
+(370,656,o),
+(333,696,o),
+(279,696,cs),
+(219,696,o),
+(189,656,o),
+(185,578,cs),
+(175,453,ls),
+(172,402,o),
+(157,377,o),
+(126,377,cs),
+(93,377,o),
+(73,401,o),
+(73,450,cs),
+(73,485,l),
+(32,485,l),
+(32,454,ls),
+(32,379,o),
+(69,339,o),
+(124,339,cs)
+);
+}
+);
+width = 402;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "c-canadian";
+note = uni18DB;
+unicode = 6363;
+},
+{
+color = 9;
+glyphname = "easternw-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (29,-307);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (99,0);
+ref = "glottalstop-canadian";
+}
+);
+width = 435;
+}
+);
+note = uni18DC;
+unicode = 6364;
+},
+{
+color = 9;
+glyphname = "westernw-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (416,-307);
+ref = dot_top;
+scale = (-1,1);
+},
+{
+alignment = -1;
+pos = (336,0);
+ref = "glottalstop-canadian";
+scale = (-1,1);
+}
+);
+width = 445;
+}
+);
+metricLeft = "glottalstop-canadian";
+note = uni18DD;
+unicode = 6365;
+},
+{
+glyphname = "rweRCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "reRCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (648,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 818;
+}
+);
+note = uni18E0;
+unicode = 6368;
+},
+{
+glyphname = "looWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (35,0);
+ref = dot_top;
+}
+);
+width = 410;
+}
+);
+note = uni18E1;
+unicode = 6369;
+},
+{
+glyphname = "laaWestCree-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (258,0);
+ref = dot_top;
+}
+);
+width = 410;
+}
+);
+note = uni18E2;
+unicode = 6370;
+},
+{
+glyphname = "thwe-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "the-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (552,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 721;
+}
+);
+note = uni18E3;
+unicode = 6371;
+},
+{
+glyphname = "thwa-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (507,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 676;
+}
+);
+note = uni18E4;
+unicode = 6372;
+},
+{
+glyphname = "tthwe-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "tthe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (545,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 714;
+}
+);
+note = uni18E5;
+unicode = 6373;
+},
+{
+glyphname = "tthoo-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ttho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (184,0);
+ref = dot_top;
+}
+);
+width = 473;
+}
+);
+note = uni18E6;
+unicode = 6374;
+},
+{
+glyphname = "tthaa-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ttha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (184,0);
+ref = dot_top;
+}
+);
+width = 473;
+}
+);
+note = uni18E7;
+unicode = 6375;
+},
+{
+glyphname = "tlhwe-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "tlhe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (454,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 623;
+}
+);
+note = uni18E8;
+unicode = 6376;
+},
+{
+glyphname = "tlhoo-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "tlho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (180,0);
+ref = dot_top;
+}
+);
+width = 454;
+}
+);
+note = uni18E9;
+unicode = 6377;
+},
+{
+glyphname = "shweSayisi-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "sheSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (455,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 625;
+}
+);
+note = uni18EA;
+unicode = 6378;
+},
+{
+glyphname = "shooSayisi-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "shoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (307,0);
+ref = dot_top;
+}
+);
+width = 455;
+}
+);
+note = uni18EB;
+unicode = 6379;
+},
+{
+color = 9;
+glyphname = "hooSayisi-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "hoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (351,0);
+ref = dot_top;
+}
+);
+width = 502;
+}
+);
+note = uni18EC;
+unicode = 6380;
+},
+{
+color = 9;
+glyphname = "gwuCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "guCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (644,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 814;
+}
+);
+note = uni18ED;
+unicode = 6381;
+},
+{
+color = 9;
+glyphname = "deneGeeCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "geCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (211,0);
+ref = dot_top;
+}
+);
+width = 534;
+}
+);
+note = uni18EE;
+unicode = 6382;
+},
+{
+color = 9;
+glyphname = "gaaCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (221,0);
+ref = dot_top;
+}
+);
+width = 534;
+}
+);
+note = uni18EF;
+unicode = 6383;
+},
+{
+color = 9;
+glyphname = "gwaCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (534,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 704;
+}
+);
+note = uni18F0;
+unicode = 6384;
+},
+{
+color = 9;
+glyphname = "juuSayisi-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "juSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (210,0);
+ref = dot_top;
+}
+);
+width = 530;
+}
+);
+note = uni18F1;
+unicode = 6385;
+},
+{
+color = 9;
+glyphname = "jwaCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "jaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (582,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 751;
+}
+);
+note = uni18F2;
+unicode = 6386;
+},
+{
+glyphname = "lBeaverDene-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+ref = "pWestCree-canadian";
+}
+);
+width = 144;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+unicode = 6387;
+},
+{
+glyphname = "rBeaverDene-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(94,345,l),
+(94,560,ls),
+(94,618,o),
+(111,650,o),
+(148,650,cs),
+(156,650,l),
+(156,696,l),
+(148,696,ls),
+(111,696,o),
+(86,658,o),
+(85,614,c),
+(90,614,l),
+(90,690,l),
+(50,690,l),
+(50,345,l)
+);
+}
+);
+width = 183;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni18F4;
+unicode = 6388;
+},
+{
+color = 6;
+glyphname = "sDentalCarrier-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(158,184,ls),
+(223,184,o),
+(256,218,o),
+(256,279,cs),
+(256,338,o),
+(226,375,o),
+(166,375,cs),
+(147,375,ls),
+(114,375,o),
+(92,388,o),
+(92,432,cs),
+(92,474,o),
+(115,490,o),
+(147,490,cs),
+(252,490,l),
+(252,527,l),
+(148,527,ls),
+(84,527,o),
+(50,492,o),
+(50,431,cs),
+(50,373,o),
+(81,336,o),
+(140,336,cs),
+(160,336,ls),
+(192,336,o),
+(214,321,o),
+(214,278,cs),
+(214,237,o),
+(192,221,o),
+(160,221,cs),
+(55,221,l),
+(55,184,l)
+);
+}
+);
+width = 306;
+}
+);
+metricLeft = "shCarrier-canadian";
+metricRight = "=|";
+note = uni18F5;
+unicode = 6389;
+},
+{
+glyphname = "pWestCree-canadian.base";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "pWestCree-canadian";
+}
+);
+width = 144;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.base";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "c-canadian";
+}
+);
+width = 270;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "thSayisi-canadian.base";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "thSayisi-canadian";
+}
+);
+width = 270;
+}
+);
+metricLeft = "=|c-canadian";
+note = uni14A2;
+},
+{
+glyphname = "mWestCree-canadian.base";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "mWestCree-canadian";
+}
+);
+width = 276;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+glyphname = "pWestCree-canadian.mid";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "pWestCree-canadian";
+}
+);
+width = 145;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.mid";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "c-canadian";
+}
+);
+width = 270;
+}
+);
+metricLeft = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "mWestCree-canadian.mid";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "mWestCree-canadian";
+}
+);
+width = 276;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+color = 11;
+glyphname = "ngaai-canadian.nunavik";
+lastChange = "2023-01-13 15:56:02 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (480,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (594,0);
+ref = ring_top.canadian;
+}
+);
+width = 926;
+}
+);
+note = uni158E;
+},
+{
+color = 11;
+glyphname = "ngi-canadian.nunavik";
+lastChange = "2023-01-13 15:56:02 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (480,0);
+ref = "ci-canadian";
+}
+);
+width = 926;
+}
+);
+note = uni158F;
+},
+{
+color = 11;
+glyphname = "ngii-canadian.nunavik";
+lastChange = "2023-01-13 15:56:02 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (480,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (649,0);
+ref = dot_top;
+}
+);
+width = 926;
+}
+);
+note = uni1590;
+},
+{
+color = 11;
+glyphname = "ngo-canadian.nunavik";
+lastChange = "2023-01-13 15:56:02 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (480,0);
+ref = "co-canadian";
+}
+);
+width = 925;
+}
+);
+note = uni1591;
+},
+{
+color = 11;
+glyphname = "ngoo-canadian.nunavik";
+lastChange = "2023-01-13 15:56:02 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+ref = "ngo-canadian.nunavik";
+},
+{
+anchor = top_right_can;
+pos = (777,0);
+ref = dot_top;
+}
+);
+width = 925;
+}
+);
+note = uni1592;
+},
+{
+color = 11;
+glyphname = "nga-canadian.nunavik";
+lastChange = "2023-01-13 15:56:02 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (480,0);
+ref = "ca-canadian";
+}
+);
+width = 926;
+}
+);
+note = uni1593;
+},
+{
+color = 11;
+glyphname = "ngaa-canadian.nunavik";
+lastChange = "2023-01-13 15:56:02 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (480,0);
+ref = "ca-canadian";
+},
+{
+anchor = top_left_can;
+pos = (512,0);
+ref = dot_top;
+}
+);
+width = 926;
+}
+);
+note = uni1594;
+},
+{
+color = 11;
+glyphname = "ng-canadian.nunavik";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(399,152,o),
+(440,195,o),
+(440,286,cs),
+(440,371,o),
+(403,413,o),
+(354,413,cs),
+(316,413,o),
+(287,384,o),
+(284,333,c),
+(297,333,l),
+(297,476,l),
+(180,476,l),
+(182,456,l),
+(212,470,o),
+(225,517,o),
+(225,567,cs),
+(225,651,o),
+(188,696,o),
+(132,696,cs),
+(76,696,o),
+(40,650,o),
+(40,565,cs),
+(40,481,o),
+(75,434,o),
+(138,434,cs),
+(280,434,l),
+(253,461,l),
+(253,283,ls),
+(253,197,o),
+(290,152,o),
+(347,152,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(313,188,o),
+(295,213,o),
+(295,283,cs),
+(295,350,o),
+(316,378,o),
+(348,378,cs),
+(379,378,o),
+(400,351,o),
+(400,284,cs),
+(400,216,o),
+(379,188,o),
+(348,188,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(99,469,o),
+(79,499,o),
+(79,565,cs),
+(79,632,o),
+(99,660,o),
+(133,660,cs),
+(166,660,o),
+(185,631,o),
+(185,565,cs),
+(185,498,o),
+(165,469,o),
+(132,469,cs)
+);
+}
+);
+width = 480;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+color = 11;
+glyphname = "ngai-canadian.nunavik";
+lastChange = "2023-01-13 15:56:02 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (480,0);
+ref = "ce-canadian";
+}
+);
+width = 925;
+}
+);
+note = uni1670;
+},
+{
+color = 11;
+glyphname = "ke-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (254,690);
+},
+{
+name = top_left_can;
+pos = (81,690);
+},
+{
+name = top_right_can;
+pos = (426,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(456,0,l),
+(456,690,l),
+(327,690,ls),
+(142,690,o),
+(50,589,o),
+(50,412,cs),
+(50,235,o),
+(142,136,o),
+(327,136,cs),
+(394,136,l),
+(394,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(177,191,o),
+(112,268,o),
+(112,412,cs),
+(112,557,o),
+(177,635,o),
+(324,635,cs),
+(394,635,l),
+(394,191,l),
+(324,191,ls)
+);
+}
+);
+width = 519;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146B;
+},
+{
+color = 11;
+glyphname = "ki-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (266,690);
+},
+{
+name = top_left_can;
+pos = (94,690);
+},
+{
+name = top_right_can;
+pos = (438,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(124,0,l),
+(124,136,l),
+(191,136,ls),
+(377,136,o),
+(468,235,o),
+(468,412,cs),
+(468,589,o),
+(377,690,o),
+(191,690,cs),
+(63,690,l),
+(63,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(124,635,l),
+(195,635,ls),
+(341,635,o),
+(407,557,o),
+(407,412,cs),
+(407,268,o),
+(341,191,o),
+(195,191,cs),
+(124,191,l)
+);
+}
+);
+width = 518;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni146D;
+},
+{
+color = 11;
+glyphname = "kii-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (207,0);
+ref = dot_top;
+}
+);
+width = 519;
+}
+);
+note = uni146E;
+},
+{
+color = 11;
+glyphname = "ko-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (254,690);
+},
+{
+name = top_left_can;
+pos = (81,690);
+},
+{
+name = top_right_can;
+pos = (426,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(456,0,l),
+(456,690,l),
+(394,690,l),
+(394,554,l),
+(327,554,ls),
+(142,554,o),
+(50,455,o),
+(50,277,cs),
+(50,100,o),
+(142,0,o),
+(327,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(177,55,o),
+(112,132,o),
+(112,277,cs),
+(112,422,o),
+(177,498,o),
+(324,498,cs),
+(394,498,l),
+(394,55,l),
+(324,55,ls)
+);
+}
+);
+width = 519;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146F;
+},
+{
+color = 11;
+glyphname = "koo-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (367,0);
+ref = dot_top;
+}
+);
+width = 519;
+}
+);
+note = uni1470;
+},
+{
+color = 11;
+glyphname = "ka-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (266,690);
+},
+{
+name = top_left_can;
+pos = (94,690);
+},
+{
+name = top_right_can;
+pos = (438,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(191,0,ls),
+(377,0,o),
+(468,100,o),
+(468,277,cs),
+(468,455,o),
+(377,554,o),
+(191,554,cs),
+(124,554,l),
+(124,690,l),
+(63,690,l),
+(63,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(124,498,l),
+(195,498,ls),
+(341,498,o),
+(407,422,o),
+(407,277,cs),
+(407,132,o),
+(341,55,o),
+(195,55,cs),
+(124,55,l)
+);
+}
+);
+width = 518;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1472;
+},
+{
+color = 11;
+glyphname = "kaa-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (35,0);
+ref = dot_top;
+}
+);
+width = 519;
+}
+);
+note = uni1473;
+},
+{
+color = 11;
+glyphname = "kweWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (519,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 688;
+}
+);
+note = uni1475;
+},
+{
+color = 11;
+glyphname = "kwiiWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (207,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (519,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 688;
+}
+);
+note = uni1479;
+},
+{
+color = 11;
+glyphname = "kwoWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (519,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 688;
+}
+);
+note = uni147B;
+},
+{
+color = 11;
+glyphname = "kwooWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (367,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (519,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 688;
+}
+);
+note = uni147D;
+},
+{
+color = 11;
+glyphname = "kwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (519,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 688;
+}
+);
+note = uni147F;
+},
+{
+color = 11;
+glyphname = "kwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (35,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (519,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 688;
+}
+);
+note = uni1481;
+},
+{
+color = 11;
+glyphname = "ce-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (265,690);
+},
+{
+name = top_left_can;
+pos = (83,690);
+},
+{
+name = top_right_can;
+pos = (447,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(477,0,l),
+(477,455,ls),
+(477,617,o),
+(395,702,o),
+(265,702,cs),
+(130,702,o),
+(52,618,o),
+(52,450,cs),
+(52,391,l),
+(113,391,l),
+(113,454,ls),
+(113,585,o),
+(167,644,o),
+(266,644,cs),
+(358,644,o),
+(415,583,o),
+(415,459,cs),
+(415,0,l)
+);
+}
+);
+width = 536;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni1489;
+},
+{
+color = 11;
+glyphname = "ci-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (271,690);
+},
+{
+name = top_left_can;
+pos = (91,690);
+},
+{
+name = top_right_can;
+pos = (455,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,0,l),
+(121,459,ls),
+(121,583,o),
+(178,644,o),
+(271,644,cs),
+(369,644,o),
+(424,585,o),
+(424,454,cs),
+(424,391,l),
+(485,391,l),
+(485,450,ls),
+(485,618,o),
+(406,702,o),
+(271,702,cs),
+(142,702,o),
+(59,617,o),
+(59,455,cs),
+(59,0,l)
+);
+}
+);
+width = 537;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+},
+{
+color = 11;
+glyphname = "cii-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (213,0);
+ref = dot_top;
+}
+);
+width = 536;
+}
+);
+note = uni148C;
+},
+{
+color = 11;
+glyphname = "co-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (265,690);
+},
+{
+name = top_left_can;
+pos = (83,690);
+},
+{
+name = top_right_can;
+pos = (447,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(395,-13,o),
+(477,72,o),
+(477,235,cs),
+(477,690,l),
+(415,690,l),
+(415,231,ls),
+(415,106,o),
+(358,45,o),
+(266,45,cs),
+(167,45,o),
+(113,104,o),
+(113,236,cs),
+(113,298,l),
+(52,298,l),
+(52,240,ls),
+(52,71,o),
+(130,-13,o),
+(265,-13,cs)
+);
+}
+);
+width = 536;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+},
+{
+color = 11;
+glyphname = "coo-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (388,0);
+ref = dot_top;
+}
+);
+width = 536;
+}
+);
+note = uni148E;
+},
+{
+color = 11;
+glyphname = "ca-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (271,690);
+},
+{
+name = top_left_can;
+pos = (91,690);
+},
+{
+name = top_right_can;
+pos = (455,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(406,-13,o),
+(485,71,o),
+(485,240,cs),
+(485,298,l),
+(424,298,l),
+(424,236,ls),
+(424,104,o),
+(369,45,o),
+(271,45,cs),
+(178,45,o),
+(121,106,o),
+(121,231,cs),
+(121,690,l),
+(59,690,l),
+(59,235,ls),
+(59,72,o),
+(142,-13,o),
+(271,-13,cs)
+);
+}
+);
+width = 537;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+},
+{
+color = 11;
+glyphname = "caa-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (32,0);
+ref = dot_top;
+}
+);
+width = 536;
+}
+);
+note = uni1491;
+},
+{
+color = 11;
+glyphname = "me-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (216,690);
+},
+{
+name = top_double;
+pos = (366,690);
+},
+{
+name = top_left_can;
+pos = (64,690);
+},
+{
+name = top_right_can;
+pos = (366,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(397,0,l),
+(397,690,l),
+(33,690,l),
+(33,633,l),
+(335,633,l),
+(335,0,l)
+);
+}
+);
+width = 460;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+},
+{
+color = 11;
+glyphname = "mi-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (244,690);
+},
+{
+name = top_left_can;
+pos = (94,690);
+},
+{
+name = top_right_can;
+pos = (394,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(124,0,l),
+(124,633,l),
+(426,633,l),
+(426,690,l),
+(63,690,l),
+(63,0,l)
+);
+}
+);
+width = 459;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+},
+{
+color = 11;
+glyphname = "mii-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (185,0);
+ref = dot_top;
+}
+);
+width = 459;
+}
+);
+note = uni14A6;
+},
+{
+color = 11;
+glyphname = "mo-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (216,690);
+},
+{
+name = top_double;
+pos = (366,690);
+},
+{
+name = top_left_can;
+pos = (64,690);
+},
+{
+name = top_right_can;
+pos = (366,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(397,0,l),
+(397,690,l),
+(335,690,l),
+(335,57,l),
+(33,57,l),
+(33,0,l)
+);
+}
+);
+width = 460;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+},
+{
+color = 11;
+glyphname = "moo-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (307,0);
+ref = dot_top;
+}
+);
+width = 459;
+}
+);
+note = uni14A8;
+},
+{
+color = 11;
+glyphname = "ma-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (244,690);
+},
+{
+name = top_left_can;
+pos = (94,690);
+},
+{
+name = top_right_can;
+pos = (394,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(426,0,l),
+(426,57,l),
+(124,57,l),
+(124,690,l),
+(63,690,l),
+(63,0,l)
+);
+}
+);
+width = 459;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+},
+{
+color = 11;
+glyphname = "maa-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (35,0);
+ref = dot_top;
+}
+);
+width = 459;
+}
+);
+note = uni14AB;
+},
+{
+color = 11;
+glyphname = "ne-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (344,690);
+},
+{
+name = top_left_can;
+pos = (191,690);
+},
+{
+name = top_right_can;
+pos = (497,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(462,-13,o),
+(527,60,o),
+(527,203,cs),
+(527,690,l),
+(49,690,l),
+(49,633,l),
+(160,633,l),
+(160,207,ls),
+(160,60,o),
+(225,-13,o),
+(344,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(261,45,o),
+(221,95,o),
+(221,202,cs),
+(221,633,l),
+(467,633,l),
+(467,202,ls),
+(467,96,o),
+(427,45,o),
+(344,45,cs)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C0;
+},
+{
+color = 11;
+glyphname = "ni-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (242,690);
+},
+{
+name = top_left_can;
+pos = (90,690);
+},
+{
+name = top_right_can;
+pos = (396,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(361,-13,o),
+(426,60,o),
+(426,207,cs),
+(426,633,l),
+(537,633,l),
+(537,690,l),
+(59,690,l),
+(59,203,ls),
+(59,60,o),
+(125,-13,o),
+(242,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(160,45,o),
+(120,96,o),
+(120,202,cs),
+(120,633,l),
+(365,633,l),
+(365,202,ls),
+(365,95,o),
+(326,45,o),
+(242,45,cs)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+},
+{
+color = 11;
+glyphname = "nii-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (185,0);
+ref = dot_top;
+}
+);
+width = 586;
+}
+);
+note = uni14C3;
+},
+{
+color = 11;
+glyphname = "no-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (344,690);
+},
+{
+name = top_double;
+pos = (354,690);
+},
+{
+name = top_left_can;
+pos = (191,690);
+},
+{
+name = top_right_can;
+pos = (488,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(527,0,l),
+(527,487,ls),
+(527,630,o),
+(462,702,o),
+(344,702,cs),
+(225,702,o),
+(160,630,o),
+(160,483,cs),
+(160,57,l),
+(49,57,l),
+(49,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(221,488,ls),
+(221,595,o),
+(261,644,o),
+(344,644,cs),
+(427,644,o),
+(467,594,o),
+(467,488,cs),
+(467,57,l),
+(221,57,l)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C4;
+},
+{
+color = 11;
+glyphname = "noo-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (285,0);
+ref = dot_top;
+}
+);
+width = 586;
+}
+);
+note = uni14C5;
+},
+{
+color = 11;
+glyphname = "na-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (242,690);
+},
+{
+name = top_double;
+pos = (252,690);
+},
+{
+name = top_left_can;
+pos = (90,690);
+},
+{
+name = top_right_can;
+pos = (396,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(537,0,l),
+(537,57,l),
+(426,57,l),
+(426,483,ls),
+(426,630,o),
+(361,702,o),
+(242,702,cs),
+(125,702,o),
+(59,630,o),
+(59,487,cs),
+(59,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(120,488,ls),
+(120,594,o),
+(160,644,o),
+(242,644,cs),
+(326,644,o),
+(365,595,o),
+(365,488,cs),
+(365,57,l),
+(120,57,l)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+},
+{
+color = 11;
+glyphname = "naa-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (185,0);
+ref = dot_top;
+}
+);
+width = 586;
+}
+);
+note = uni14C8;
+},
+{
+color = 11;
+glyphname = "nweWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (586,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 756;
+}
+);
+note = uni14CA;
+},
+{
+color = 11;
+glyphname = "nwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (586,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 756;
+}
+);
+note = uni14CC;
+},
+{
+color = 11;
+glyphname = "nwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (185,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (586,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 756;
+}
+);
+note = uni14CE;
+},
+{
+color = 11;
+glyphname = "se-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (92,690);
+},
+{
+name = top_right_can;
+pos = (443,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(470,0,l),
+(470,230,l),
+(356,230,ls),
+(201,230,o),
+(122,317,o),
+(122,477,cs),
+(122,690,l),
+(61,690,l),
+(61,477,ls),
+(61,284,o),
+(166,175,o),
+(357,175,cs),
+(433,175,l),
+(410,191,l),
+(410,0,l)
+);
+}
+);
+width = 533;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14ED;
+},
+{
+color = 11;
+glyphname = "si-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (94,690);
+},
+{
+name = top_right_can;
+pos = (446,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(124,0,l),
+(124,191,l),
+(100,175,l),
+(176,175,ls),
+(367,175,o),
+(472,284,o),
+(472,470,cs),
+(472,690,l),
+(412,690,l),
+(412,470,ls),
+(412,317,o),
+(332,230,o),
+(179,230,cs),
+(63,230,l),
+(63,0,l)
+);
+}
+);
+width = 533;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+},
+{
+color = 11;
+glyphname = "sii-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (387,0);
+ref = dot_top;
+}
+);
+width = 533;
+}
+);
+note = uni14F0;
+},
+{
+color = 11;
+glyphname = "so-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (440,690);
+},
+{
+name = top_left_can;
+pos = (92,690);
+},
+{
+name = top_right_can;
+pos = (440,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(122,0,l),
+(122,213,ls),
+(122,373,o),
+(201,460,o),
+(356,460,cs),
+(470,460,l),
+(470,690,l),
+(410,690,l),
+(410,498,l),
+(433,515,l),
+(357,515,ls),
+(166,515,o),
+(61,406,o),
+(61,213,cs),
+(61,0,l)
+);
+}
+);
+width = 533;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+},
+{
+color = 11;
+glyphname = "soo-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (382,0);
+ref = dot_top;
+}
+);
+width = 533;
+}
+);
+note = uni14F2;
+},
+{
+color = 11;
+glyphname = "sa-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (97,690);
+},
+{
+name = top_right_can;
+pos = (442,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(472,0,l),
+(472,213,ls),
+(472,406,o),
+(367,515,o),
+(176,515,cs),
+(100,515,l),
+(124,498,l),
+(124,690,l),
+(63,690,l),
+(63,460,l),
+(177,460,ls),
+(332,460,o),
+(412,373,o),
+(412,213,cs),
+(412,0,l)
+);
+}
+);
+width = 533;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+},
+{
+color = 11;
+glyphname = "saa-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (38,0);
+ref = dot_top;
+}
+);
+width = 533;
+}
+);
+note = uni14F5;
+},
+{
+color = 11;
+glyphname = "sho-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (261,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(457,0,l),
+(457,52,l),
+(235,52,ls),
+(150,52,o),
+(116,99,o),
+(116,185,cs),
+(116,272,o),
+(150,319,o),
+(235,319,cs),
+(298,319,ls),
+(410,319,o),
+(467,388,o),
+(467,505,cs),
+(467,620,o),
+(410,690,o),
+(298,690,cs),
+(64,690,l),
+(64,638,l),
+(287,638,ls),
+(371,638,o),
+(405,590,o),
+(405,505,cs),
+(405,417,o),
+(371,372,o),
+(287,372,cs),
+(222,372,ls),
+(111,372,o),
+(54,301,o),
+(54,185,cs),
+(54,70,o),
+(111,0,o),
+(222,0,cs)
+);
+}
+);
+width = 521;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+color = 11;
+glyphname = "shoo-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (202,0);
+ref = dot_top;
+}
+);
+width = 521;
+}
+);
+note = g728;
+},
+{
+color = 11;
+glyphname = "sha-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (261,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(298,0,ls),
+(410,0,o),
+(466,70,o),
+(466,185,cs),
+(466,301,o),
+(410,371,o),
+(298,371,cs),
+(234,371,ls),
+(150,371,o),
+(115,417,o),
+(115,504,cs),
+(115,590,o),
+(149,638,o),
+(234,638,cs),
+(457,638,l),
+(457,690,l),
+(221,690,ls),
+(109,690,o),
+(54,619,o),
+(54,504,cs),
+(54,388,o),
+(109,319,o),
+(221,319,cs),
+(286,319,ls),
+(370,319,o),
+(404,272,o),
+(404,185,cs),
+(404,99,o),
+(370,52,o),
+(286,52,cs),
+(63,52,l),
+(63,0,l)
+);
+}
+);
+width = 520;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+color = 11;
+glyphname = "shaa-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (202,0);
+ref = dot_top;
+}
+);
+width = 520;
+}
+);
+note = g730;
+},
+{
+color = 11;
+glyphname = "ye-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (72,690);
+},
+{
+name = top_right_can;
+pos = (455,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(486,0,l),
+(486,230,l),
+(123,230,l),
+(122,203,l),
+(500,664,l),
+(455,701,l),
+(40,199,l),
+(40,175,l),
+(424,175,l),
+(424,0,l)
+);
+}
+);
+width = 545;
+}
+);
+metricLeft = "ye-canadian";
+note = uni1526;
+},
+{
+color = 11;
+glyphname = "yi-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (91,690);
+},
+{
+name = top_right_can;
+pos = (473,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(122,0,l),
+(122,175,l),
+(505,175,l),
+(505,199,l),
+(91,701,l),
+(45,664,l),
+(423,203,l),
+(423,230,l),
+(60,230,l),
+(60,0,l)
+);
+}
+);
+width = 545;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni1528;
+},
+{
+color = 11;
+glyphname = "yii-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (32,0);
+ref = dot_top;
+}
+);
+width = 545;
+}
+);
+note = uni1529;
+},
+{
+color = 11;
+glyphname = "yo-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (455,690);
+},
+{
+name = top_left_can;
+pos = (72,690);
+},
+{
+name = top_right_can;
+pos = (455,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(500,26,l),
+(122,487,l),
+(123,460,l),
+(486,460,l),
+(486,690,l),
+(424,690,l),
+(424,515,l),
+(40,515,l),
+(40,491,l),
+(455,-12,l)
+);
+}
+);
+width = 545;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152A;
+},
+{
+color = 11;
+glyphname = "yoo-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (397,0);
+ref = dot_top;
+}
+);
+width = 545;
+}
+);
+note = uni152B;
+},
+{
+color = 11;
+glyphname = "ya-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (91,690);
+},
+{
+name = top_right_can;
+pos = (473,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(505,491,l),
+(505,515,l),
+(122,515,l),
+(122,690,l),
+(60,690,l),
+(60,460,l),
+(423,460,l),
+(423,487,l),
+(45,26,l),
+(91,-12,l)
+);
+}
+);
+width = 545;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152D;
+},
+{
+color = 11;
+glyphname = "yaa-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (32,0);
+ref = dot_top;
+}
+);
+width = 545;
+}
+);
+note = uni152E;
+},
+{
+color = 11;
+glyphname = "re-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (242,690);
+},
+{
+name = top_left_can;
+pos = (90,690);
+},
+{
+name = top_right_can;
+pos = (396,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(362,-13,o),
+(426,60,o),
+(426,207,cs),
+(426,633,l),
+(537,633,l),
+(537,690,l),
+(365,690,l),
+(365,202,ls),
+(365,95,o),
+(326,45,o),
+(242,45,cs),
+(160,45,o),
+(120,96,o),
+(120,202,cs),
+(120,690,l),
+(59,690,l),
+(59,203,ls),
+(59,60,o),
+(125,-13,o),
+(242,-13,cs)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1542;
+},
+{
+color = 11;
+glyphname = "reRCree-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (344,690);
+},
+{
+name = top_left_can;
+pos = (191,690);
+},
+{
+name = top_right_can;
+pos = (497,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(462,-13,o),
+(527,60,o),
+(527,203,cs),
+(527,690,l),
+(467,690,l),
+(467,202,ls),
+(467,96,o),
+(427,45,o),
+(344,45,cs),
+(261,45,o),
+(221,95,o),
+(221,202,cs),
+(221,690,l),
+(49,690,l),
+(49,633,l),
+(160,633,l),
+(160,207,ls),
+(160,60,o),
+(224,-13,o),
+(344,-13,cs)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni1543;
+},
+{
+color = 11;
+glyphname = "leWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (344,690);
+},
+{
+name = top_left_can;
+pos = (191,690);
+},
+{
+name = top_right_can;
+pos = (497,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(221,0,l),
+(221,488,ls),
+(221,594,o),
+(261,643,o),
+(344,643,cs),
+(427,643,o),
+(467,594,o),
+(467,488,cs),
+(467,0,l),
+(527,0,l),
+(527,486,ls),
+(527,630,o),
+(462,701,o),
+(344,701,cs),
+(224,701,o),
+(160,630,o),
+(160,483,cs),
+(160,56,l),
+(49,56,l),
+(49,0,l)
+);
+}
+);
+width = 588;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+},
+{
+color = 11;
+glyphname = "ri-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (242,690);
+},
+{
+name = top_left_can;
+pos = (92,690);
+},
+{
+name = top_right_can;
+pos = (396,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(120,0,l),
+(120,488,ls),
+(120,594,o),
+(160,644,o),
+(242,644,cs),
+(326,644,o),
+(365,595,o),
+(365,488,cs),
+(365,0,l),
+(537,0,l),
+(537,57,l),
+(426,57,l),
+(426,483,ls),
+(426,630,o),
+(362,702,o),
+(242,702,cs),
+(125,702,o),
+(59,630,o),
+(59,487,cs),
+(59,0,l)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+},
+{
+color = 11;
+glyphname = "rii-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (185,0);
+ref = dot_top;
+}
+);
+width = 586;
+}
+);
+note = uni1547;
+},
+{
+color = 11;
+glyphname = "ro-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (261,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(124,0,l),
+(124,156,l),
+(97,136,l),
+(178,136,ls),
+(362,136,o),
+(454,235,o),
+(454,412,cs),
+(454,589,o),
+(362,690,o),
+(178,690,cs),
+(63,690,l),
+(63,635,l),
+(181,635,ls),
+(327,635,o),
+(392,557,o),
+(392,412,cs),
+(392,268,o),
+(327,191,o),
+(181,191,cs),
+(63,191,l),
+(63,0,l)
+);
+}
+);
+width = 504;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1548;
+},
+{
+color = 11;
+glyphname = "loWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (258,690);
+},
+{
+name = top_left_can;
+pos = (94,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(178,0,ls),
+(362,0,o),
+(454,100,o),
+(454,277,cs),
+(454,455,o),
+(362,554,o),
+(178,554,cs),
+(97,554,l),
+(124,533,l),
+(124,690,l),
+(63,690,l),
+(63,498,l),
+(181,498,ls),
+(327,498,o),
+(392,422,o),
+(392,277,cs),
+(392,132,o),
+(327,55,o),
+(181,55,cs),
+(63,55,l),
+(63,0,l)
+);
+}
+);
+width = 502;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+},
+{
+color = 11;
+glyphname = "ra-canadian.square";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (243,690);
+},
+{
+name = top_right_can;
+pos = (409,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,0,l),
+(440,191,l),
+(321,191,ls),
+(175,191,o),
+(109,268,o),
+(109,412,cs),
+(109,557,o),
+(175,635,o),
+(321,635,cs),
+(440,635,l),
+(440,690,l),
+(325,690,ls),
+(140,690,o),
+(48,589,o),
+(48,412,cs),
+(48,235,o),
+(140,136,o),
+(325,136,cs),
+(406,136,l),
+(378,156,l),
+(378,0,l)
+);
+}
+);
+width = 503;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+},
+{
+color = 11;
+glyphname = "raa-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (185,0);
+ref = dot_top;
+}
+);
+width = 501;
+}
+);
+note = uni154C;
+},
+{
+color = 11;
+glyphname = "laWestCree-canadian.square";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (409,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,0,l),
+(440,55,l),
+(321,55,ls),
+(175,55,o),
+(109,132,o),
+(109,277,cs),
+(109,422,o),
+(175,498,o),
+(321,498,cs),
+(440,498,l),
+(440,690,l),
+(378,690,l),
+(378,533,l),
+(406,554,l),
+(325,554,ls),
+(140,554,o),
+(48,455,o),
+(48,277,cs),
+(48,100,o),
+(140,0,o),
+(325,0,cs)
+);
+}
+);
+width = 503;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+},
+{
+color = 11;
+glyphname = "reWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(470,0,l),
+(647,191,l),
+(609,231,l),
+(436,43,l),
+(477,42,l),
+(477,455,ls),
+(477,617,o),
+(395,702,o),
+(265,702,cs),
+(130,702,o),
+(52,618,o),
+(52,450,cs),
+(52,391,l),
+(113,391,l),
+(113,454,ls),
+(113,585,o),
+(167,644,o),
+(266,644,cs),
+(358,644,o),
+(415,583,o),
+(415,459,cs),
+(415,0,l)
+);
+}
+);
+width = 669;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+},
+{
+color = 11;
+glyphname = "riWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(253,0,l),
+(253,459,ls),
+(253,583,o),
+(311,644,o),
+(404,644,cs),
+(502,644,o),
+(556,585,o),
+(556,454,cs),
+(556,391,l),
+(617,391,l),
+(617,450,ls),
+(617,618,o),
+(539,702,o),
+(405,702,cs),
+(274,702,o),
+(192,617,o),
+(192,455,cs),
+(192,42,l),
+(234,43,l),
+(61,231,l),
+(22,191,l),
+(199,0,l)
+);
+}
+);
+width = 669;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+},
+{
+color = 11;
+glyphname = "roWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(395,-13,o),
+(477,72,o),
+(477,235,cs),
+(477,648,l),
+(436,647,l),
+(609,459,l),
+(647,498,l),
+(470,690,l),
+(415,690,l),
+(415,231,ls),
+(415,106,o),
+(358,45,o),
+(266,45,cs),
+(167,45,o),
+(113,104,o),
+(113,236,cs),
+(113,298,l),
+(52,298,l),
+(52,240,ls),
+(52,71,o),
+(130,-13,o),
+(265,-13,cs)
+);
+}
+);
+width = 669;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+},
+{
+color = 11;
+glyphname = "raWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(539,-13,o),
+(617,71,o),
+(617,240,cs),
+(617,298,l),
+(556,298,l),
+(556,236,ls),
+(556,104,o),
+(502,45,o),
+(404,45,cs),
+(311,45,o),
+(253,106,o),
+(253,231,cs),
+(253,690,l),
+(199,690,l),
+(22,498,l),
+(61,459,l),
+(234,647,l),
+(192,648,l),
+(192,235,ls),
+(192,72,o),
+(274,-13,o),
+(405,-13,cs)
+);
+}
+);
+width = 669;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+},
+{
+color = 11;
+glyphname = "theThCree-canadian.square";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (72,690);
+},
+{
+name = top_right_can;
+pos = (455,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(424,71,l),
+(424,0,l),
+(486,0,l),
+(486,71,l),
+(554,71,l),
+(554,107,l),
+(486,107,l),
+(486,230,l),
+(123,230,l),
+(122,203,l),
+(500,664,l),
+(455,701,l),
+(40,199,l),
+(40,175,l),
+(424,175,l),
+(424,107,l),
+(242,107,l),
+(242,71,l)
+);
+}
+);
+width = 588;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15A7;
+},
+{
+color = 11;
+glyphname = "thiThCree-canadian.square";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (128,690);
+},
+{
+name = top_right_can;
+pos = (509,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(163,0,l),
+(163,71,l),
+(346,71,l),
+(346,107,l),
+(163,107,l),
+(163,175,l),
+(548,175,l),
+(548,199,l),
+(132,701,l),
+(87,664,l),
+(466,203,l),
+(466,230,l),
+(102,230,l),
+(102,107,l),
+(34,107,l),
+(34,71,l),
+(102,71,l),
+(102,0,l)
+);
+}
+);
+width = 588;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+},
+{
+color = 11;
+glyphname = "thiiThCree-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (69,0);
+ref = dot_top;
+}
+);
+width = 587;
+}
+);
+note = uni15A9;
+},
+{
+color = 11;
+glyphname = "thoThCree-canadian.square";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (72,690);
+},
+{
+name = top_right_can;
+pos = (455,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(500,26,l),
+(122,487,l),
+(123,460,l),
+(486,460,l),
+(486,582,l),
+(554,582,l),
+(554,619,l),
+(486,619,l),
+(486,690,l),
+(424,690,l),
+(424,619,l),
+(242,619,l),
+(242,582,l),
+(424,582,l),
+(424,515,l),
+(40,515,l),
+(40,491,l),
+(455,-12,l)
+);
+}
+);
+width = 588;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+},
+{
+color = 11;
+glyphname = "thooThCree-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (397,0);
+ref = dot_top;
+}
+);
+width = 587;
+}
+);
+note = uni15AB;
+},
+{
+color = 11;
+glyphname = "thaThCree-canadian.square";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (133,690);
+},
+{
+name = top_right_can;
+pos = (515,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(548,491,l),
+(548,515,l),
+(163,515,l),
+(163,582,l),
+(346,582,l),
+(346,619,l),
+(163,619,l),
+(163,690,l),
+(102,690,l),
+(102,619,l),
+(34,619,l),
+(34,582,l),
+(102,582,l),
+(102,460,l),
+(466,460,l),
+(466,487,l),
+(87,26,l),
+(132,-12,l)
+);
+}
+);
+width = 588;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+},
+{
+color = 11;
+glyphname = "thaaThCree-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (74,0);
+ref = dot_top;
+}
+);
+width = 587;
+}
+);
+note = uni15AD;
+},
+{
+color = 11;
+glyphname = "thweeWoodScree-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (587,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 757;
+}
+);
+note = uni1677;
+},
+{
+color = 11;
+glyphname = "thwiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (587,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 757;
+}
+);
+note = uni1678;
+},
+{
+color = 11;
+glyphname = "thwiiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (69,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (587,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 757;
+}
+);
+note = uni1679;
+},
+{
+color = 11;
+glyphname = "thwoWoodScree-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (587,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 757;
+}
+);
+note = uni167A;
+},
+{
+color = 11;
+glyphname = "thwooWoodScree-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (397,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (587,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 757;
+}
+);
+note = uni167B;
+},
+{
+color = 11;
+glyphname = "thwaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (587,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 757;
+}
+);
+note = uni167C;
+},
+{
+color = 11;
+glyphname = "thwaaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (74,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (587,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 757;
+}
+);
+note = uni167D;
+},
+{
+color = 11;
+glyphname = "nwiOjibway-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (586,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 756;
+}
+);
+note = uni18C7;
+},
+{
+color = 11;
+glyphname = "nwiiOjibway-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (185,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (586,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 756;
+}
+);
+note = uni18C9;
+},
+{
+color = 11;
+glyphname = "nwoOjibway-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (586,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 756;
+}
+);
+note = uni18CB;
+},
+{
+color = 11;
+glyphname = "nwooOjibway-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (285,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (586,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 756;
+}
+);
+note = uni18CD;
+},
+{
+color = 11;
+glyphname = "looWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (35,0);
+ref = dot_top;
+}
+);
+width = 501;
+}
+);
+note = uni18E1;
+},
+{
+color = 11;
+glyphname = "laaWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (351,0);
+ref = dot_top;
+}
+);
+width = 501;
+}
+);
+note = uni18E2;
+},
+{
+color = 0;
+glyphname = zero;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(507,542,o),
+(459,700,o),
+(284,700,cs),
+(108,700,o),
+(60,526,o),
+(60,347,cs),
+(60,106,o),
+(141,-10,o),
+(284,-10,cs),
+(434,-10,o),
+(507,108,o),
+(507,347,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(126,488,o),
+(149,645,o),
+(284,645,cs),
+(428,645,o),
+(441,478,o),
+(441,347,cs),
+(441,161,o),
+(400,45,o),
+(284,45,cs),
+(173,45,o),
+(126,159,o),
+(126,347,cs)
+);
+}
+);
+width = 566;
+}
+);
+unicode = 48;
+},
+{
+color = 0;
+glyphname = one;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(219,690,l),
+(19,539,l),
+(54,495,l),
+(163,577,ls),
+(185,593,o),
+(198,605,o),
+(213,619,c),
+(213,596,o),
+(212,573,o),
+(212,548,cs),
+(212,0,l),
+(277,0,l),
+(277,690,l)
+);
+}
+);
+width = 396;
+}
+);
+unicode = 49;
+},
+{
+color = 0;
+glyphname = two;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(477,0,l),
+(477,56,l),
+(125,56,l),
+(125,58,l),
+(289,229,ls),
+(357,298,o),
+(406,353,o),
+(432,414,cs),
+(443,444,o),
+(450,479,o),
+(450,519,cs),
+(450,628,o),
+(370,699,o),
+(255,699,cs),
+(182,699,o),
+(114,674,o),
+(53,622,c),
+(89,578,l),
+(141,621,o),
+(197,642,o),
+(249,642,cs),
+(333,642,o),
+(384,595,o),
+(384,512,cs),
+(384,450,o),
+(364,403,o),
+(324,352,cs),
+(302,325,o),
+(276,296,o),
+(243,262,cs),
+(40,47,l),
+(40,0,l)
+);
+}
+);
+width = 527;
+}
+);
+unicode = 50;
+},
+{
+color = 0;
+glyphname = three;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(450,639,o),
+(370,699,o),
+(250,699,cs),
+(156,699,o),
+(89,670,o),
+(32,628,c),
+(61,582,l),
+(114,621,o),
+(174,644,o),
+(243,644,cs),
+(329,644,o),
+(386,606,o),
+(386,524,cs),
+(386,427,o),
+(301,384,o),
+(203,384,cs),
+(131,384,l),
+(131,331,l),
+(202,331,ls),
+(321,331,o),
+(403,298,o),
+(403,192,cs),
+(403,102,o),
+(343,44,o),
+(215,44,cs),
+(150,44,o),
+(77,63,o),
+(25,89,c),
+(25,30,l),
+(77,7,o),
+(142,-10,o),
+(222,-10,cs),
+(378,-10,o),
+(471,69,o),
+(471,189,cs),
+(471,292,o),
+(410,346,o),
+(301,360,c),
+(301,362,l),
+(386,380,o),
+(450,443,o),
+(450,534,cs)
+);
+}
+);
+width = 521;
+}
+);
+unicode = 51;
+},
+{
+color = 0;
+glyphname = four;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(443,226,l),
+(443,693,l),
+(381,693,l),
+(39,221,l),
+(39,174,l),
+(380,174,l),
+(380,0,l),
+(443,0,l),
+(443,174,l),
+(560,174,l),
+(560,226,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(103,226,l),
+(323,526,ls),
+(350,562,o),
+(358,579,o),
+(379,611,c),
+(381,611,l),
+(381,590,o),
+(380,556,o),
+(380,520,cs),
+(380,226,l)
+);
+}
+);
+width = 584;
+}
+);
+unicode = 52;
+},
+{
+color = 0;
+glyphname = five;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(198,421,o),
+(159,412,o),
+(130,405,c),
+(151,634,l),
+(436,634,l),
+(436,690,l),
+(96,690,l),
+(67,366,l),
+(98,347,l),
+(140,360,o),
+(183,368,o),
+(236,368,cs),
+(353,368,o),
+(412,310,o),
+(412,213,cs),
+(412,106,o),
+(337,44,o),
+(221,44,cs),
+(155,44,o),
+(92,65,o),
+(46,90,c),
+(46,30,l),
+(91,7,o),
+(151,-10,o),
+(225,-10,cs),
+(385,-10,o),
+(478,77,o),
+(478,214,cs),
+(478,347,o),
+(392,421,o),
+(258,421,cs)
+);
+}
+);
+width = 523;
+}
+);
+unicode = 53;
+},
+{
+color = 0;
+glyphname = six;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(58,134,o),
+(126,-10,o),
+(290,-10,cs),
+(424,-10,o),
+(505,79,o),
+(505,222,cs),
+(505,353,o),
+(432,433,o),
+(305,433,cs),
+(213,433,o),
+(149,388,o),
+(120,327,c),
+(117,327,l),
+(122,513,o),
+(188,647,o),
+(363,647,cs),
+(404,647,o),
+(436,641,o),
+(460,634,c),
+(460,690,l),
+(434,696,o),
+(400,701,o),
+(364,701,cs),
+(137,701,o),
+(58,523,o),
+(58,293,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(162,44,o),
+(127,166,o),
+(127,247,cs),
+(127,321,o),
+(209,380,o),
+(293,380,cs),
+(393,380,o),
+(441,319,o),
+(441,221,cs),
+(441,111,o),
+(386,44,o),
+(289,44,cs)
+);
+}
+);
+width = 552;
+}
+);
+unicode = 54;
+},
+{
+color = 0;
+glyphname = seven;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(468,650,l),
+(468,690,l),
+(16,690,l),
+(16,634,l),
+(397,634,l),
+(123,0,l),
+(191,0,l)
+);
+}
+);
+width = 492;
+}
+);
+unicode = 55;
+},
+{
+color = 0;
+glyphname = eight;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(412,-10,o),
+(504,59,o),
+(504,177,cs),
+(504,274,o),
+(436,329,o),
+(332,368,c),
+(423,405,o),
+(482,455,o),
+(482,539,cs),
+(482,642,o),
+(404,699,o),
+(283,699,cs),
+(164,699,o),
+(83,638,o),
+(83,538,cs),
+(83,441,o),
+(157,397,o),
+(228,366,c),
+(128,330,o),
+(61,275,o),
+(61,172,cs),
+(61,64,o),
+(145,-10,o),
+(279,-10,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(185,42,o),
+(123,93,o),
+(123,174,cs),
+(123,267,o),
+(201,310,o),
+(280,337,c),
+(390,296,o),
+(442,251,o),
+(442,178,cs),
+(442,89,o),
+(377,42,o),
+(279,42,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(201,427,o),
+(145,465,o),
+(145,534,cs),
+(145,608,o),
+(204,648,o),
+(282,648,cs),
+(368,648,o),
+(419,610,o),
+(419,535,cs),
+(419,469,o),
+(372,433,o),
+(284,396,c)
+);
+}
+);
+width = 564;
+}
+);
+unicode = 56;
+},
+{
+color = 0;
+glyphname = nine;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(492,563,o),
+(425,699,o),
+(260,699,cs),
+(126,699,o),
+(43,611,o),
+(43,469,cs),
+(43,339,o),
+(117,257,o),
+(242,257,cs),
+(332,257,o),
+(400,300,o),
+(429,363,c),
+(432,363,l),
+(426,173,o),
+(355,43,o),
+(183,43,cs),
+(144,43,o),
+(106,48,o),
+(83,56,c),
+(83,0,l),
+(109,-7,o),
+(150,-12,o),
+(185,-12,cs),
+(413,-12,o),
+(492,172,o),
+(492,396,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(387,644,o),
+(422,522,o),
+(422,443,cs),
+(422,370,o),
+(338,310,o),
+(257,310,cs),
+(157,310,o),
+(107,372,o),
+(107,470,cs),
+(107,581,o),
+(162,644,o),
+(261,644,cs)
+);
+}
+);
+width = 550;
+}
+);
+unicode = 57;
+},
+{
+glyphname = zero.canadian;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(396,596,o),
+(334,702,o),
+(220,702,cs),
+(106,702,o),
+(45,596,o),
+(45,345,cs),
+(45,94,o),
+(106,-12,o),
+(220,-12,cs),
+(334,-12,o),
+(396,94,o),
+(396,345,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(107,563,o),
+(144,646,o),
+(221,646,cs),
+(299,646,o),
+(334,565,o),
+(334,345,cs),
+(334,125,o),
+(299,44,o),
+(221,44,cs),
+(143,44,o),
+(107,127,o),
+(107,345,cs)
+);
+}
+);
+width = 441;
+}
+);
+metricRight = "=|";
+},
+{
+glyphname = one.canadian;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(226,0,l),
+(226,690,l),
+(171,690,l),
+(25,531,l),
+(65,494,l),
+(206,647,l),
+(165,648,l),
+(165,0,l)
+);
+}
+);
+width = 289;
+}
+);
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = two.canadian;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(389,57,l),
+(128,57,l),
+(128,35,l),
+(311,297,ls),
+(366,376,o),
+(383,449,o),
+(383,516,cs),
+(383,637,o),
+(318,702,o),
+(219,702,cs),
+(104,702,o),
+(44,616,o),
+(44,454,c),
+(106,454,l),
+(106,587,o),
+(142,647,o),
+(217,647,cs),
+(283,647,o),
+(322,604,o),
+(322,517,cs),
+(322,457,o),
+(304,391,o),
+(255,320,cs),
+(61,42,l),
+(61,0,l),
+(389,0,l)
+);
+}
+);
+width = 435;
+}
+);
+note = uni14BF;
+},
+{
+glyphname = three.canadian;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(344,-13,o),
+(408,51,o),
+(408,181,cs),
+(408,275,o),
+(367,341,o),
+(286,357,c),
+(286,335,l),
+(361,349,o),
+(401,416,o),
+(401,507,cs),
+(401,639,o),
+(340,702,o),
+(238,702,cs),
+(126,702,o),
+(62,620,o),
+(61,470,c),
+(122,470,l),
+(123,592,o),
+(161,647,o),
+(236,647,cs),
+(304,647,o),
+(339,608,o),
+(339,505,cs),
+(339,414,o),
+(306,372,o),
+(244,372,cs),
+(215,372,l),
+(215,319,l),
+(245,319,ls),
+(311,319,o),
+(345,275,o),
+(345,185,cs),
+(345,83,o),
+(308,43,o),
+(237,43,cs),
+(158,43,o),
+(117,99,o),
+(117,219,c),
+(56,219,l),
+(56,66,o),
+(122,-13,o),
+(239,-13,cs)
+);
+}
+);
+width = 468;
+}
+);
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = four.canadian;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(337,0,l),
+(337,174,l),
+(415,174,l),
+(415,227,l),
+(337,227,l),
+(337,693,l),
+(288,693,l),
+(33,216,l),
+(33,174,l),
+(278,174,l),
+(278,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(300,627,l),
+(280,627,l),
+(280,227,l),
+(77,227,l),
+(82,213,l)
+);
+}
+);
+width = 440;
+}
+);
+},
+{
+glyphname = five.canadian;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(342,-13,o),
+(411,61,o),
+(411,195,cs),
+(411,329,o),
+(347,397,o),
+(226,397,cs),
+(122,397,l),
+(148,377,l),
+(164,650,l),
+(138,633,l),
+(391,633,l),
+(391,690,l),
+(107,690,l),
+(87,356,l),
+(99,342,l),
+(213,342,ls),
+(311,342,o),
+(349,296,o),
+(349,192,cs),
+(349,90,o),
+(308,43,o),
+(237,43,cs),
+(163,43,o),
+(121,89,o),
+(121,192,c),
+(60,192,l),
+(60,56,o),
+(130,-13,o),
+(237,-13,cs)
+);
+}
+);
+width = 462;
+}
+);
+},
+{
+glyphname = six.canadian;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(331,-13,o),
+(399,73,o),
+(399,201,cs),
+(399,329,o),
+(335,412,o),
+(241,412,cs),
+(162,412,o),
+(105,359,o),
+(93,252,c),
+(110,248,l),
+(107,285,o),
+(107,308,o),
+(107,358,cs),
+(107,569,o),
+(146,648,o),
+(231,648,cs),
+(299,648,o),
+(329,593,o),
+(333,501,c),
+(394,501,l),
+(387,623,o),
+(334,702,o),
+(233,702,cs),
+(112,702,o),
+(45,598,o),
+(45,347,cs),
+(45,192,o),
+(64,108,o),
+(101,53,cs),
+(135,6,o),
+(179,-13,o),
+(234,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(157,42,o),
+(118,105,o),
+(118,205,cs),
+(118,298,o),
+(161,359,o),
+(232,359,cs),
+(302,359,o),
+(338,298,o),
+(338,201,cs),
+(338,103,o),
+(298,42,o),
+(231,42,cs)
+);
+}
+);
+width = 441;
+}
+);
+metricLeft = zero.canadian;
+},
+{
+glyphname = seven.canadian;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(334,650,l),
+(334,690,l),
+(20,690,l),
+(20,633,l),
+(275,633,l),
+(274,653,l),
+(95,19,l),
+(95,0,l),
+(153,0,l)
+);
+}
+);
+width = 365;
+}
+);
+},
+{
+glyphname = eight.canadian;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(347,-13,o),
+(414,60,o),
+(414,179,cs),
+(414,280,o),
+(364,339,o),
+(293,355,c),
+(289,337,l),
+(352,348,o),
+(403,408,o),
+(403,511,cs),
+(403,630,o),
+(339,702,o),
+(238,702,cs),
+(135,702,o),
+(71,630,o),
+(71,511,cs),
+(71,408,o),
+(123,348,o),
+(186,337,c),
+(182,355,l),
+(111,339,o),
+(60,280,o),
+(60,179,cs),
+(60,60,o),
+(128,-13,o),
+(238,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(164,42,o),
+(121,86,o),
+(121,181,cs),
+(121,276,o),
+(166,319,o),
+(238,319,cs),
+(309,319,o),
+(354,276,o),
+(354,181,cs),
+(354,86,o),
+(310,42,o),
+(238,42,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(173,371,o),
+(132,414,o),
+(132,509,cs),
+(132,603,o),
+(170,648,o),
+(238,648,cs),
+(305,648,o),
+(343,603,o),
+(343,509,cs),
+(343,414,o),
+(302,371,o),
+(238,371,cs)
+);
+}
+);
+width = 474;
+}
+);
+metricLeft = "=|";
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = nine.canadian;
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(328,-13,o),
+(395,92,o),
+(395,343,cs),
+(395,497,o),
+(377,582,o),
+(339,637,cs),
+(305,684,o),
+(262,702,o),
+(207,702,cs),
+(109,702,o),
+(42,616,o),
+(42,489,cs),
+(42,360,o),
+(104,277,o),
+(200,277,cs),
+(277,277,o),
+(335,330,o),
+(348,438,c),
+(330,441,l),
+(332,405,o),
+(333,382,o),
+(333,331,cs),
+(333,121,o),
+(295,42,o),
+(210,42,cs),
+(141,42,o),
+(111,97,o),
+(106,188,c),
+(45,188,l),
+(53,67,o),
+(106,-13,o),
+(207,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(138,330,o),
+(101,391,o),
+(101,489,cs),
+(101,586,o),
+(142,648,o),
+(210,648,cs),
+(283,648,o),
+(323,584,o),
+(323,485,cs),
+(323,391,o),
+(279,330,o),
+(209,330,cs)
+);
+}
+);
+width = 440;
+}
+);
+metricLeft = "=|six.canadian";
+metricRight = "=|six.canadian";
+},
+{
+glyphname = CR;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+width = 194;
+}
+);
+note = CR;
+unicode = 13;
+},
+{
+color = 0;
+glyphname = .notdef;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(488,690,l),
+(91,690,l),
+(91,0,l),
+(488,0,l),
+(488,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(439,640,l),
+(439,49,l),
+(140,49,l),
+(140,640,l),
+(140,640,l)
+);
+}
+);
+width = 580;
+}
+);
+note = ".notdef";
+},
+{
+glyphname = .null;
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+width = 0;
+}
+);
+note = NULL;
+},
+{
+glyphname = space;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+width = 199;
+}
+);
+note = space;
+unicode = 32;
+},
+{
+glyphname = nbspace;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+width = 194;
+}
+);
+note = uni00A0;
+unicode = 160;
+},
+{
+glyphname = space.canadian;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+width = 386;
+}
+);
+note = space;
+},
+{
+glyphname = "hyphen-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(290,402,l),
+(290,441,l),
+(50,441,l),
+(50,402,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(290,269,l),
+(290,308,l),
+(50,308,l),
+(50,269,l)
+);
+}
+);
+width = 340;
+}
+);
+metricRight = "=|";
+note = uni1400;
+unicode = 5120;
+},
+{
+glyphname = "chi-canadian";
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,0,l),
+(218,308,l),
+(199,308,l),
+(320,0,l),
+(376,0,l),
+(376,19,l),
+(230,374,l),
+(230,325,l),
+(374,670,l),
+(374,690,l),
+(317,690,l),
+(199,386,l),
+(218,386,l),
+(100,690,l),
+(43,690,l),
+(43,670,l),
+(187,326,l),
+(187,375,l),
+(41,19,l),
+(41,0,l)
+);
+}
+);
+width = 417;
+}
+);
+metricRight = "=|";
+note = uni166D;
+unicode = 5741;
+},
+{
+glyphname = "fullstop-canadian";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(231,0,l),
+(231,10,l),
+(156,186,l),
+(158,161,l),
+(230,334,l),
+(230,345,l),
+(189,345,l),
+(132,193,l),
+(150,195,l),
+(92,345,l),
+(51,345,l),
+(51,334,l),
+(124,163,l),
+(124,188,l),
+(50,10,l),
+(50,0,l),
+(90,0,l),
+(152,157,l),
+(131,156,l),
+(191,0,l)
+);
+}
+);
+width = 281;
+}
+);
+note = uni1541;
+unicode = 5742;
+},
+{
+glyphname = period;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(70,8,o),
+(84,-9,o),
+(112,-9,cs),
+(143,-9,o),
+(156,8,o),
+(156,36,cs),
+(156,64,o),
+(143,81,o),
+(112,81,cs),
+(84,81,o),
+(70,64,o),
+(70,36,cs)
+);
+}
+);
+width = 208;
+}
+);
+note = period;
+unicode = 46;
+},
+{
+glyphname = comma;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(70,-127,l),
+(99,-58,o),
+(122,36,o),
+(137,108,c),
+(133,119,l),
+(76,119,l),
+(67,45,o),
+(50,-33,o),
+(24,-127,c)
+);
+}
+);
+width = 184;
+}
+);
+note = comma;
+unicode = 44;
+},
+{
+glyphname = hyphen;
+kernLeft = hyphen;
+kernRight = hyphen;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(210,289,l),
+(42,289,l),
+(42,235,l),
+(210,235,l)
+);
+}
+);
+width = 252;
+}
+);
+unicode = 45;
+},
+{
+glyphname = quotesinglbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (33,-571);
+ref = quoteright;
+}
+);
+width = 237;
+}
+);
+unicode = 8218;
+},
+{
+glyphname = quotedblbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (33,-571);
+ref = quotedblright;
+}
+);
+width = 404;
+}
+);
+unicode = 8222;
+},
+{
+glyphname = quotedblleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(272,443,l),
+(280,514,o),
+(300,608,o),
+(329,690,c),
+(287,690,l),
+(256,621,o),
+(229,535,o),
+(214,452,c),
+(220,443,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(115,443,l),
+(124,514,o),
+(143,608,o),
+(172,690,c),
+(130,690,l),
+(99,621,o),
+(71,535,o),
+(57,452,c),
+(64,443,l)
+);
+}
+);
+width = 384;
+}
+);
+unicode = 8220;
+},
+{
+glyphname = quotedblright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(254,443,l),
+(286,513,o),
+(313,603,o),
+(327,680,c),
+(321,690,l),
+(270,690,l),
+(263,617,o),
+(243,526,o),
+(212,443,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(97,443,l),
+(129,513,o),
+(156,603,o),
+(170,680,c),
+(164,690,l),
+(112,690,l),
+(106,620,o),
+(85,523,o),
+(55,443,c)
+);
+}
+);
+width = 384;
+}
+);
+unicode = 8221;
+},
+{
+glyphname = quoteleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(118,443,l),
+(126,514,o),
+(146,608,o),
+(175,690,c),
+(130,690,l),
+(99,621,o),
+(71,535,o),
+(57,452,c),
+(64,443,l)
+);
+}
+);
+width = 230;
+}
+);
+unicode = 8216;
+},
+{
+glyphname = quoteright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,443,l),
+(131,513,o),
+(158,603,o),
+(172,680,c),
+(166,690,l),
+(112,690,l),
+(106,620,o),
+(85,523,o),
+(55,443,c)
+);
+}
+);
+width = 230;
+}
+);
+unicode = 8217;
+},
+{
+glyphname = dottedCircle;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(193,504,o),
+(181,494,o),
+(181,479,cs),
+(181,467,o),
+(193,454,o),
+(206,454,cs),
+(220,454,o),
+(231,467,o),
+(231,479,cs),
+(231,494,o),
+(220,504,o),
+(206,504,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(355,504,o),
+(343,494,o),
+(343,479,cs),
+(343,467,o),
+(355,454,o),
+(368,454,cs),
+(383,454,o),
+(393,467,o),
+(393,479,cs),
+(393,494,o),
+(383,504,o),
+(368,504,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(193,108,o),
+(181,98,o),
+(181,83,cs),
+(181,71,o),
+(193,58,o),
+(206,58,cs),
+(220,58,o),
+(231,71,o),
+(231,83,cs),
+(231,98,o),
+(220,108,o),
+(206,108,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(355,108,o),
+(343,98,o),
+(343,83,cs),
+(343,71,o),
+(355,58,o),
+(368,58,cs),
+(383,58,o),
+(393,71,o),
+(393,83,cs),
+(393,98,o),
+(383,108,o),
+(368,108,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(274,522,o),
+(262,511,o),
+(262,497,cs),
+(262,484,o),
+(274,471,o),
+(287,471,cs),
+(301,471,o),
+(312,484,o),
+(312,497,cs),
+(312,511,o),
+(301,522,o),
+(287,522,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(274,91,o),
+(262,80,o),
+(262,66,cs),
+(262,53,o),
+(274,41,o),
+(287,41,cs),
+(301,41,o),
+(312,53,o),
+(312,66,cs),
+(312,80,o),
+(301,91,o),
+(287,91,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(46,269,o),
+(59,256,o),
+(71,256,cs),
+(86,256,o),
+(97,269,o),
+(97,281,cs),
+(97,296,o),
+(86,306,o),
+(71,306,cs),
+(59,306,o),
+(46,296,o),
+(46,281,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(477,269,o),
+(490,256,o),
+(502,256,cs),
+(517,256,o),
+(527,269,o),
+(527,281,cs),
+(527,296,o),
+(517,306,o),
+(502,306,cs),
+(490,306,o),
+(477,296,o),
+(477,281,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(109,116,o),
+(122,103,o),
+(134,103,cs),
+(149,103,o),
+(159,116,o),
+(159,128,cs),
+(159,143,o),
+(149,154,o),
+(134,154,cs),
+(122,154,o),
+(109,143,o),
+(109,128,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(109,421,o),
+(122,409,o),
+(134,409,cs),
+(149,409,o),
+(159,421,o),
+(159,434,cs),
+(159,448,o),
+(149,459,o),
+(134,459,cs),
+(122,459,o),
+(109,448,o),
+(109,434,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(414,116,o),
+(427,103,o),
+(440,103,cs),
+(454,103,o),
+(465,116,o),
+(465,128,cs),
+(465,143,o),
+(454,154,o),
+(440,154,cs),
+(427,154,o),
+(414,143,o),
+(414,128,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(414,421,o),
+(427,409,o),
+(440,409,cs),
+(454,409,o),
+(465,421,o),
+(465,434,cs),
+(465,448,o),
+(454,459,o),
+(440,459,cs),
+(427,459,o),
+(414,448,o),
+(414,434,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(64,187,o),
+(76,175,o),
+(89,175,cs),
+(103,175,o),
+(114,187,o),
+(114,200,cs),
+(114,214,o),
+(103,225,o),
+(89,225,cs),
+(76,225,o),
+(64,214,o),
+(64,200,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(64,350,o),
+(76,337,o),
+(89,337,cs),
+(103,337,o),
+(114,350,o),
+(114,362,cs),
+(114,377,o),
+(103,387,o),
+(89,387,cs),
+(76,387,o),
+(64,377,o),
+(64,362,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(460,187,o),
+(472,175,o),
+(485,175,cs),
+(499,175,o),
+(510,187,o),
+(510,200,cs),
+(510,214,o),
+(499,225,o),
+(485,225,cs),
+(472,225,o),
+(460,214,o),
+(460,200,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(460,350,o),
+(472,337,o),
+(485,337,cs),
+(499,337,o),
+(510,350,o),
+(510,362,cs),
+(510,377,o),
+(499,387,o),
+(485,387,cs),
+(472,387,o),
+(460,377,o),
+(460,362,cs)
+);
+}
+);
+width = 574;
+}
+);
+note = uni25CC;
+unicode = 9676;
+},
+{
+glyphname = dotaccentcomb;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(40,709,o),
+(25,693,o),
+(25,667,cs),
+(25,640,o),
+(40,625,o),
+(63,625,cs),
+(86,625,o),
+(100,639,o),
+(100,667,cs),
+(100,694,o),
+(86,709,o),
+(63,709,cs)
+);
+}
+);
+width = 126;
+}
+);
+note = uni0307;
+unicode = 775;
+},
+{
+glyphname = dotaccent;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(87,625,o),
+(101,640,o),
+(101,667,cs),
+(101,694,o),
+(87,709,o),
+(64,709,cs),
+(41,709,o),
+(26,693,o),
+(26,667,cs),
+(26,640,o),
+(41,625,o),
+(64,625,cs)
+);
+}
+);
+width = 128;
+}
+);
+note = dotaccent;
+unicode = 729;
+},
+{
+glyphname = caron;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(181,622,o),
+(210,676,o),
+(243,730,c),
+(243,738,l),
+(203,738,l),
+(181,708,o),
+(160,673,o),
+(134,629,c),
+(112,669,o),
+(91,706,o),
+(69,738,c),
+(26,738,l),
+(26,730,l),
+(56,684,o),
+(85,636,o),
+(105,585,c),
+(165,585,l),
+(165,585,l)
+);
+}
+);
+width = 270;
+}
+);
+note = caron;
+unicode = 711;
+},
+{
+glyphname = breve;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(186,585,o),
+(223,628,o),
+(229,709,c),
+(190,709,l),
+(185,657,o),
+(163,628,o),
+(127,628,cs),
+(88,628,o),
+(70,656,o),
+(64,709,c),
+(26,709,l),
+(31,625,o),
+(69,585,o),
+(127,585,cs)
+);
+}
+);
+width = 255;
+}
+);
+note = breve;
+unicode = 728;
+},
+{
+glyphname = ring;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,588,o),
+(176,631,o),
+(176,691,cs),
+(176,748,o),
+(142,792,o),
+(100,792,cs),
+(59,792,o),
+(26,750,o),
+(26,691,cs),
+(26,629,o),
+(60,588,o),
+(100,588,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(76,625,o),
+(59,655,o),
+(59,691,cs),
+(59,727,o),
+(77,756,o),
+(100,756,cs),
+(124,756,o),
+(142,726,o),
+(142,691,cs),
+(142,655,o),
+(126,625,o),
+(100,625,cs)
+);
+}
+);
+width = 202;
+}
+);
+note = ring;
+unicode = 730;
+},
+{
+glyphname = ogonek;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(110,-214,o),
+(126,-211,o),
+(137,-206,c),
+(137,-164,l),
+(129,-168,o),
+(116,-172,o),
+(102,-172,cs),
+(82,-172,o),
+(70,-154,o),
+(70,-119,cs),
+(70,-74,o),
+(94,-36,o),
+(123,0,c),
+(97,14,l),
+(47,-37,o),
+(26,-82,o),
+(26,-128,cs),
+(26,-185,o),
+(57,-214,o),
+(95,-214,cs)
+);
+}
+);
+width = 164;
+}
+);
+note = ogonek;
+unicode = 731;
+},
+{
+glyphname = ring_top.canadian;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (114,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(161,757,o),
+(198,793,o),
+(198,840,cs),
+(198,889,o),
+(161,923,o),
+(114,923,cs),
+(68,923,o),
+(31,889,o),
+(31,840,cs),
+(31,793,o),
+(68,757,o),
+(114,757,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(84,788,o),
+(63,810,o),
+(63,840,cs),
+(63,870,o),
+(84,893,o),
+(114,893,cs),
+(145,893,o),
+(166,870,o),
+(166,840,cs),
+(166,810,o),
+(145,788,o),
+(114,788,cs)
+);
+}
+);
+width = 229;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (59,345);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(81,305,o),
+(99,323,o),
+(99,345,cs),
+(99,367,o),
+(81,384,o),
+(59,384,cs),
+(37,384,o),
+(18,367,o),
+(18,345,cs),
+(18,323,o),
+(37,305,o),
+(59,305,cs)
+);
+}
+);
+width = 117;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (54,345);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(73,309,o),
+(90,325,o),
+(90,345,cs),
+(90,365,o),
+(73,381,o),
+(54,381,cs),
+(34,381,o),
+(18,365,o),
+(18,345,cs),
+(18,325,o),
+(34,309,o),
+(54,309,cs)
+);
+}
+);
+width = 107;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_small;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (49,345);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(67,314,o),
+(80,327,o),
+(80,345,cs),
+(80,362,o),
+(67,376,o),
+(49,376,cs),
+(32,376,o),
+(18,362,o),
+(18,345,cs),
+(18,327,o),
+(32,314,o),
+(49,314,cs)
+);
+}
+);
+width = 99;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_top;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (59,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(81,789,o),
+(99,808,o),
+(99,830,cs),
+(99,853,o),
+(81,870,o),
+(59,870,cs),
+(36,870,o),
+(18,853,o),
+(18,830,cs),
+(18,808,o),
+(36,789,o),
+(59,789,cs)
+);
+}
+);
+width = 117;
+}
+);
+note = g725;
+},
+{
+glyphname = doubledot_middle;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(115,389,o),
+(133,407,o),
+(133,429,cs),
+(133,452,o),
+(115,469,o),
+(93,469,cs),
+(71,469,o),
+(52,452,o),
+(52,429,cs),
+(52,407,o),
+(71,389,o),
+(93,389,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(115,220,o),
+(133,238,o),
+(133,261,cs),
+(133,283,o),
+(115,300,o),
+(93,300,cs),
+(71,300,o),
+(52,283,o),
+(52,261,cs),
+(52,238,o),
+(71,220,o),
+(93,220,cs)
+);
+}
+);
+width = 185;
+}
+);
+metricRight = "=|";
+note = g725;
+},
+{
+glyphname = doubledot_top;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top_double;
+pos = (188,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(211,789,o),
+(229,808,o),
+(229,830,cs),
+(229,853,o),
+(211,870,o),
+(188,870,cs),
+(165,870,o),
+(148,852,o),
+(148,830,cs),
+(148,808,o),
+(165,789,o),
+(188,789,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(81,789,o),
+(99,808,o),
+(99,830,cs),
+(99,853,o),
+(81,870,o),
+(59,870,cs),
+(37,870,o),
+(18,853,o),
+(18,830,cs),
+(18,808,o),
+(37,789,o),
+(59,789,cs)
+);
+}
+);
+width = 247;
+}
+);
+note = g725;
+},
+{
+glyphname = g727;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (261,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(457,0,l),
+(457,52,l),
+(235,52,ls),
+(150,52,o),
+(116,99,o),
+(116,185,cs),
+(116,272,o),
+(150,319,o),
+(235,319,cs),
+(298,319,ls),
+(410,319,o),
+(467,388,o),
+(467,505,cs),
+(467,620,o),
+(410,690,o),
+(298,690,cs),
+(64,690,l),
+(64,638,l),
+(287,638,ls),
+(371,638,o),
+(405,590,o),
+(405,505,cs),
+(405,417,o),
+(371,372,o),
+(287,372,cs),
+(222,372,ls),
+(110,372,o),
+(54,301,o),
+(54,185,cs),
+(54,70,o),
+(110,0,o),
+(222,0,cs)
+);
+}
+);
+width = 521;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+glyphname = g728;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (202,0);
+ref = dot_top;
+}
+);
+width = 521;
+}
+);
+note = g728;
+},
+{
+glyphname = g729;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (261,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(298,0,ls),
+(410,0,o),
+(466,70,o),
+(466,185,cs),
+(466,301,o),
+(410,371,o),
+(298,371,cs),
+(234,371,ls),
+(150,371,o),
+(115,417,o),
+(115,504,cs),
+(115,590,o),
+(149,638,o),
+(234,638,cs),
+(457,638,l),
+(457,690,l),
+(221,690,ls),
+(109,690,o),
+(54,619,o),
+(54,504,cs),
+(54,388,o),
+(109,319,o),
+(221,319,cs),
+(286,319,ls),
+(370,319,o),
+(404,272,o),
+(404,185,cs),
+(404,99,o),
+(370,52,o),
+(286,52,cs),
+(63,52,l),
+(63,0,l)
+);
+}
+);
+width = 520;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+glyphname = g730;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (202,0);
+ref = dot_top;
+}
+);
+width = 520;
+}
+);
+note = g730;
+},
+{
+glyphname = g731;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = g727;
+}
+);
+width = 690;
+}
+);
+note = g731;
+},
+{
+glyphname = g732;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (521,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 690;
+}
+);
+note = g732;
+},
+{
+glyphname = g733;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (372,0);
+ref = dot_top;
+}
+);
+width = 690;
+}
+);
+note = g733;
+},
+{
+glyphname = g734;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (202,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (521,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 690;
+}
+);
+note = g734;
+},
+{
+glyphname = g735;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = g729;
+}
+);
+width = 689;
+}
+);
+note = g735;
+},
+{
+glyphname = g736;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (520,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 689;
+}
+);
+note = g736;
+},
+{
+glyphname = g737;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (372,0);
+ref = dot_top;
+}
+);
+width = 689;
+}
+);
+note = g737;
+},
+{
+glyphname = g738;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (202,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (520,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 689;
+}
+);
+note = g738;
+},
+{
+glyphname = g739;
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(399,214,o),
+(437,267,o),
+(437,344,cs),
+(437,421,o),
+(399,476,o),
+(340,476,cs),
+(181,476,l),
+(182,457,l),
+(208,469,o),
+(225,517,o),
+(225,567,cs),
+(225,643,o),
+(188,696,o),
+(132,696,cs),
+(76,696,o),
+(40,643,o),
+(40,565,cs),
+(40,488,o),
+(77,434,o),
+(136,434,cs),
+(296,434,l),
+(295,453,l),
+(268,440,o),
+(251,391,o),
+(251,343,cs),
+(251,266,o),
+(287,214,o),
+(344,214,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(99,469,o),
+(78,506,o),
+(78,565,cs),
+(78,625,o),
+(100,660,o),
+(133,660,cs),
+(164,660,o),
+(186,623,o),
+(186,565,cs),
+(186,507,o),
+(166,469,o),
+(132,469,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(312,249,o),
+(289,286,o),
+(289,345,cs),
+(289,404,o),
+(311,440,o),
+(344,440,cs),
+(376,440,o),
+(398,403,o),
+(398,344,cs),
+(398,285,o),
+(376,249,o),
+(343,249,cs)
+);
+}
+);
+width = 477;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+glyphname = g740;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (146,0);
+ref = ring_top.canadian;
+}
+);
+width = 521;
+}
+);
+note = g740;
+},
+{
+glyphname = g741;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (146,0);
+ref = ring_top.canadian;
+}
+);
+width = 520;
+}
+);
+note = g741;
+},
+{
+glyphname = g742;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (316,0);
+ref = ring_top.canadian;
+}
+);
+width = 690;
+}
+);
+note = g742;
+},
+{
+glyphname = stroke_middle;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (38,345);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(58,454,l),
+(17,454,l),
+(17,236,l),
+(58,236,l)
+);
+}
+);
+width = 75;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (34,345);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(50,440,l),
+(17,440,l),
+(17,249,l),
+(50,249,l)
+);
+}
+);
+width = 69;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_small;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (32,345);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(46,438,l),
+(17,438,l),
+(17,252,l),
+(46,252,l)
+);
+}
+);
+width = 64;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_threequart;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (38,345);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(56,453,l),
+(19,453,l),
+(19,237,l),
+(56,237,l)
+);
+}
+);
+width = 75;
+}
+);
+note = g723;
+},
+{
+color = 8;
+glyphname = uni11AB0;
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (126,690);
+},
+{
+name = top_right_can;
+pos = (350,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(156,0,l),
+(156,117,l),
+(339,117,l),
+(339,157,l),
+(156,157,l),
+(156,282,l),
+(111,259,l),
+(134,259,ls),
+(289,259,o),
+(380,384,o),
+(380,593,cs),
+(380,690,l),
+(320,690,l),
+(320,599,ls),
+(320,412,o),
+(247,315,o),
+(122,315,cs),
+(95,315,l),
+(95,157,l),
+(34,157,l),
+(34,117,l),
+(95,117,l),
+(95,0,l)
+);
+}
+);
+width = 441;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB1;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB0;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (291,0);
+ref = dot_top;
+}
+);
+width = 440;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB2;
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (92,690);
+},
+{
+name = top_right_can;
+pos = (316,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(122,0,l),
+(122,91,ls),
+(122,277,o),
+(193,375,o),
+(320,375,cs),
+(347,375,l),
+(347,532,l),
+(408,532,l),
+(408,573,l),
+(347,573,l),
+(347,690,l),
+(285,690,l),
+(285,573,l),
+(102,573,l),
+(102,532,l),
+(285,532,l),
+(285,408,l),
+(329,431,l),
+(307,431,ls),
+(153,431,o),
+(61,306,o),
+(61,97,cs),
+(61,0,l)
+);
+}
+);
+width = 442;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "theThCree-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB3;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB2;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (257,0);
+ref = dot_top;
+}
+);
+width = 441;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB4;
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (126,690);
+},
+{
+name = top_right_can;
+pos = (350,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(380,0,l),
+(380,97,ls),
+(380,305,o),
+(289,431,o),
+(134,431,cs),
+(111,431,l),
+(156,408,l),
+(156,532,l),
+(339,532,l),
+(339,573,l),
+(156,573,l),
+(156,690,l),
+(95,690,l),
+(95,573,l),
+(34,573,l),
+(34,532,l),
+(95,532,l),
+(95,375,l),
+(122,375,ls),
+(247,375,o),
+(320,277,o),
+(320,91,cs),
+(320,0,l)
+);
+}
+);
+width = 441;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB5;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB4;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (68,0);
+ref = dot_top;
+}
+);
+width = 440;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB6;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (93,690);
+},
+{
+name = top_right_can;
+pos = (318,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(124,0,l),
+(124,283,l),
+(79,259,l),
+(102,259,ls),
+(257,259,o),
+(348,384,o),
+(348,593,cs),
+(348,663,l),
+(305,653,l),
+(482,462,l),
+(519,498,l),
+(343,690,l),
+(287,690,l),
+(287,599,ls),
+(287,412,o),
+(215,315,o),
+(90,315,cs),
+(63,315,l),
+(63,0,l)
+);
+}
+);
+width = 541;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB7;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB6;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (259,0);
+ref = dot_top;
+}
+);
+width = 541;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB8;
+kernRight = soright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (224,690);
+},
+{
+name = top_right_can;
+pos = (447,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(254,0,l),
+(254,91,ls),
+(254,277,o),
+(326,375,o),
+(451,375,cs),
+(478,375,l),
+(478,690,l),
+(417,690,l),
+(417,407,l),
+(462,431,l),
+(439,431,ls),
+(284,431,o),
+(193,305,o),
+(193,97,cs),
+(193,27,l),
+(236,37,l),
+(59,228,l),
+(22,191,l),
+(199,0,l)
+);
+}
+);
+width = 541;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB9;
+kernRight = soright;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB8;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (389,0);
+ref = dot_top;
+}
+);
+width = 541;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABA;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (93,690);
+},
+{
+name = top_right_can;
+pos = (318,690);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(343,0,l),
+(519,191,l),
+(482,228,l),
+(305,37,l),
+(348,27,l),
+(348,97,ls),
+(348,305,o),
+(257,431,o),
+(102,431,cs),
+(79,431,l),
+(124,407,l),
+(124,690,l),
+(63,690,l),
+(63,375,l),
+(90,375,ls),
+(215,375,o),
+(287,277,o),
+(287,91,cs),
+(287,0,l)
+);
+}
+);
+width = 541;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABB;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = uni11ABA;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (35,0);
+ref = dot_top;
+}
+);
+width = 541;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABC;
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(393,0,l),
+(393,57,l),
+(101,57,l),
+(101,29,l),
+(400,645,l),
+(400,690,l),
+(47,690,l),
+(47,633,l),
+(339,633,l),
+(339,661,l),
+(41,44,l),
+(41,0,l)
+);
+}
+);
+width = 441;
+}
+);
+metricRight = "=|";
+},
+{
+color = 8;
+glyphname = uni11ABD;
+lastChange = "2023-01-13 15:56:00 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(400,0,l),
+(400,44,l),
+(102,661,l),
+(102,633,l),
+(393,633,l),
+(393,690,l),
+(41,690,l),
+(41,645,l),
+(339,29,l),
+(339,57,l),
+(47,57,l),
+(47,0,l)
+);
+}
+);
+width = 441;
+}
+);
+metricLeft = "=|uni11ABC";
+metricRight = "=|uni11ABC";
+},
+{
+color = 8;
+glyphname = uni11ABE;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(123,0,l),
+(123,629,l),
+(90,629,l),
+(389,0,l),
+(444,0,l),
+(444,690,l),
+(384,690,l),
+(384,61,l),
+(417,61,l),
+(117,690,l),
+(63,690,l),
+(63,0,l)
+);
+}
+);
+width = 507;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABF;
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(117,0,l),
+(417,633,l),
+(384,633,l),
+(384,0,l),
+(444,0,l),
+(444,690,l),
+(389,690,l),
+(90,57,l),
+(123,57,l),
+(123,690,l),
+(63,690,l),
+(63,0,l)
+);
+}
+);
+width = 507;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = "raiseddoubledotFinal-canadian.cree";
+lastChange = "2023-01-13 15:55:56 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(111,621,o),
+(129,639,o),
+(129,662,cs),
+(129,684,o),
+(111,702,o),
+(89,702,cs),
+(66,702,o),
+(48,684,o),
+(48,662,cs),
+(48,639,o),
+(66,621,o),
+(89,621,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(111,452,o),
+(129,469,o),
+(129,493,cs),
+(129,515,o),
+(111,533,o),
+(89,533,cs),
+(66,533,o),
+(48,516,o),
+(48,493,cs),
+(48,469,o),
+(66,452,o),
+(89,452,cs)
+);
+}
+);
+width = 178;
+}
+);
+note = g725;
+}
+);
+instances = (
+{
+axesValues = (
+67,
+68,
+0
+);
+instanceInterpolations = {
+"2974A4AB-0281-4EAC-B7D6-9B88228DB59B" = 1;
+};
+name = "RC CL roman";
+}
+);
+kerningLTR = {
+"2974A4AB-0281-4EAC-B7D6-9B88228DB59B" = {
+"@MMK_L_caright" = {
+"@MMK_R_ecanleft" = -63.756;
+"@MMK_R_mwestleft" = -24.15;
+"@MMK_R_neleft" = -49.266;
+};
+"@MMK_L_ciright" = {
+"@MMK_R_icanleft" = -63.756;
+"@MMK_R_noleft" = -85.008;
+};
+"@MMK_L_ecanright" = {
+"@MMK_R_coleft" = -63.756;
+"@MMK_R_moleft" = -63.756;
+"@MMK_R_sileft" = -34.776;
+};
+"@MMK_L_icanright" = {
+"@MMK_R_celeft" = -63.756;
+"@MMK_R_meleft" = -63.756;
+"@MMK_R_mwestleft" = -37.674;
+"@MMK_R_saleft" = -29.946;
+"she-canadian" = -63.756;
+};
+"@MMK_L_maright" = {
+"@MMK_R_acanleft" = -60.858;
+"@MMK_R_ecanleft" = -63.756;
+"@MMK_R_mwestleft" = -45.402;
+"@MMK_R_neleft" = -49.266;
+};
+"@MMK_L_miright" = {
+"@MMK_R_acanleft" = -60.858;
+"@MMK_R_icanleft" = -63.756;
+"@MMK_R_moleft" = -85.008;
+"@MMK_R_noleft" = -85.008;
+"@MMK_R_yeleft" = -85.008;
+};
+"@MMK_L_mwestright" = {
+"@MMK_R_coleft" = -24.15;
+"@MMK_R_icanleft" = -37.674;
+"@MMK_R_moleft" = -45.402;
+"@MMK_R_noleft" = -72.45;
+"@MMK_R_sileft" = -12.558;
+"@MMK_R_yeleft" = -19.32;
+};
+"@MMK_L_naright" = {
+"@MMK_R_acanleft" = -80.178;
+"@MMK_R_celeft" = -85.008;
+"@MMK_R_meleft" = -85.008;
+"@MMK_R_mwestleft" = -72.45;
+"@MMK_R_neleft" = -99.498;
+"@MMK_R_saleft" = -56.028;
+};
+"@MMK_L_niright" = {
+"@MMK_R_coleft" = -49.266;
+"@MMK_R_moleft" = -49.266;
+"@MMK_R_noleft" = -99.498;
+"@MMK_R_sileft" = -3.864;
+};
+"@MMK_L_ocanright" = {
+"@MMK_R_meleft" = -60.858;
+"@MMK_R_moleft" = -60.858;
+"@MMK_R_noleft" = -80.178;
+};
+"@MMK_L_seright" = {
+"@MMK_R_ecanleft" = -34.776;
+"@MMK_R_mwestleft" = -12.558;
+"@MMK_R_neleft" = -3.864;
+};
+"@MMK_L_soright" = {
+"@MMK_R_icanleft" = -29.946;
+"@MMK_R_noleft" = -56.028;
+};
+"@MMK_L_yiright" = {
+"@MMK_R_meleft" = -85.008;
+"@MMK_R_mwestleft" = -19.32;
+};
+"shi-canadian" = {
+"@MMK_R_icanleft" = -63.756;
+};
+};
+};
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "italic angle";
+}
+);
+properties = (
+{
+key = copyrights;
+values = (
+{
+language = ENG;
+value = "Copyright 2018 Google Inc. All Rights Reserved.";
+}
+);
+},
+{
+key = manufacturers;
+values = (
+{
+language = ENG;
+value = "Monotype Imaging Inc.";
+}
+);
+},
+{
+key = designers;
+values = (
+{
+language = ENG;
+value = "Monotype Design Team";
+}
+);
+},
+{
+key = description;
+value = "Designed by Monotype design team.";
+},
+{
+key = trademarks;
+values = (
+{
+language = ENG;
+value = "Noto is a trademark of Google Inc.";
+}
+);
+},
+{
+key = licenseURL;
+value = "http://scripts.sil.org/OFL";
+},
+{
+key = licenses;
+values = (
+{
+language = ENG;
+value = "This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.";
+}
+);
+},
+{
+key = manufacturerURL;
+value = "http://www.google.com/get/noto/";
+},
+{
+key = designerURL;
+value = "http://www.monotype.com/studio";
+}
+);
+settings = {
+disablesNiceNames = 1;
+};
+stems = (
+{
+name = "New Stem";
+}
+);
+unitsPerEm = 966;
+userData = {
+GSDontShowVersionAlert = 1;
+};
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/sources/Exported instances UCAS SansCanadianAboriginal Resized/Sans Canadian Aboriginal-RC CR Italic.glyphs
+++ b/sources/Exported instances UCAS SansCanadianAboriginal Resized/Sans Canadian Aboriginal-RC CR Italic.glyphs
@@ -1,0 +1,37325 @@
+{
+.appVersion = "3151";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+},
+{
+name = Width;
+tag = wdth;
+},
+{
+name = Slant;
+tag = slnt;
+}
+);
+classes = (
+{
+code = "zero one two three four five six seven eight nine ";
+name = Num;
+},
+{
+code = "zero.canadian one.canadian two.canadian three.canadian four.canadian five.canadian six.canadian seven.canadian eight.canadian nine.canadian 
+";
+name = Num_can;
+},
+{
+code = "ke-canadian.square ki-canadian.square kii-canadian.square ko-canadian.square koo-canadian.square ka-canadian.square kaa-canadian.square kweWestCree-canadian.square kwiiWestCree-canadian.square kwoWestCree-canadian.square kwooWestCree-canadian.square kwaWestCree-canadian.square kwaaWestCree-canadian.square ce-canadian.square ci-canadian.square cii-canadian.square co-canadian.square coo-canadian.square ca-canadian.square caa-canadian.square me-canadian.square mi-canadian.square mii-canadian.square mo-canadian.square moo-canadian.square ma-canadian.square maa-canadian.square ne-canadian.square ni-canadian.square nii-canadian.square no-canadian.square noo-canadian.square na-canadian.square naa-canadian.square nweWestCree-canadian.square nwaWestCree-canadian.square nwaaWestCree-canadian.square se-canadian.square si-canadian.square sii-canadian.square so-canadian.square soo-canadian.square sa-canadian.square saa-canadian.square sho-canadian.square shoo-canadian.square sha-canadian.square shaa-canadian.square ye-canadian.square yi-canadian.square yii-canadian.square yo-canadian.square yoo-canadian.square ya-canadian.square yaa-canadian.square re-canadian.square reRCree-canadian.square leWestCree-canadian.square ri-canadian.square rii-canadian.square ro-canadian.square loWestCree-canadian.square ra-canadian.square raa-canadian.square laWestCree-canadian.square reWestCree-canadian.square riWestCree-canadian.square roWestCree-canadian.square raWestCree-canadian.square theThCree-canadian.square thiThCree-canadian.square thiiThCree-canadian.square thoThCree-canadian.square thooThCree-canadian.square thaThCree-canadian.square thaaThCree-canadian.square thweeWoodScree-canadian.square thwiWoodScree-canadian.square thwiiWoodScree-canadian.square thwoWoodScree-canadian.square thwooWoodScree-canadian.square thwaWoodScree-canadian.square thwaaWoodScree-canadian.square nwiOjibway-canadian.square nwiiOjibway-canadian.square nwoOjibway-canadian.square nwooOjibway-canadian.square looWestCree-canadian.square laaWestCree-canadian.square ";
+name = Dene_square;
+},
+{
+code = "ke-canadian ki-canadian kii-canadian ko-canadian koo-canadian ka-canadian kaa-canadian kweWestCree-canadian kwiiWestCree-canadian kwoWestCree-canadian kwooWestCree-canadian kwaWestCree-canadian kwaaWestCree-canadian ce-canadian ci-canadian cii-canadian co-canadian coo-canadian ca-canadian caa-canadian me-canadian mi-canadian mii-canadian mo-canadian moo-canadian ma-canadian maa-canadian ne-canadian ni-canadian nii-canadian no-canadian noo-canadian na-canadian naa-canadian nweWestCree-canadian nwaWestCree-canadian nwaaWestCree-canadian se-canadian si-canadian sii-canadian so-canadian soo-canadian sa-canadian saa-canadian sho-canadian shoo-canadian sha-canadian shaa-canadian ye-canadian yi-canadian yii-canadian yo-canadian yoo-canadian ya-canadian yaa-canadian re-canadian reRCree-canadian leWestCree-canadian ri-canadian rii-canadian ro-canadian loWestCree-canadian ra-canadian raa-canadian laWestCree-canadian reWestCree-canadian riWestCree-canadian roWestCree-canadian raWestCree-canadian theThCree-canadian thiThCree-canadian thiiThCree-canadian thoThCree-canadian thooThCree-canadian thaThCree-canadian thaaThCree-canadian thweeWoodScree-canadian thwiWoodScree-canadian thwiiWoodScree-canadian thwoWoodScree-canadian thwooWoodScree-canadian thwaWoodScree-canadian thwaaWoodScree-canadian nwiOjibway-canadian nwiiOjibway-canadian nwoOjibway-canadian nwooOjibway-canadian looWestCree-canadian laaWestCree-canadian 
+";
+name = Dene_round;
+},
+{
+code = "acuteFinal-canadian.mid graveFinal-canadian.mid ringTophalfFinal-canadian.mid ringRighthalfFinal-canadian.mid ringFinal-canadian.mid doubleacuteFinal-canadian.mid doubleshortverticalstrokesFinal-canadian.mid shorthorizontalstrokeFinal-canadian.mid downtackFinal-canadian.mid pWestCree-canadian.mid c-canadian.mid mWestCree-canadian.mid ";
+name = Final_mid;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian ringFinal-canadian doubleacuteFinal-canadian doubleshortverticalstrokesFinal-canadian shorthorizontalstrokeFinal-canadian downtackFinal-canadian pWestCree-canadian c-canadian mWestCree-canadian ";
+name = Final_mid_ori;
+},
+{
+code = "acuteFinal-canadian.base graveFinal-canadian.base ringBottomhalfFinal-canadian.base ringTophalfFinal-canadian.base ringRighthalfFinal-canadian.base plusFinal-canadian.base pWestCree-canadian.base c-canadian.base thSayisi-canadian.base mWestCree-canadian.base ";
+name = Final_base;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringBottomhalfFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian plusFinal-canadian pWestCree-canadian c-canadian thSayisi-canadian mWestCree-canadian ";
+name = Final_base_ori;
+},
+{
+code = "ng-canadian ngai-canadian ngaai-canadian ngi-canadian ngii-canadian ngo-canadian ngoo-canadian nga-canadian ngaa-canadian ";
+name = Nunavik;
+},
+{
+code = "ng-canadian.nunavik ngai-canadian.nunavik ngaai-canadian.nunavik ngi-canadian.nunavik ngii-canadian.nunavik ngo-canadian.nunavik ngoo-canadian.nunavik nga-canadian.nunavik ngaa-canadian.nunavik ";
+name = Nunavik_alt;
+}
+);
+customParameters = (
+{
+name = vendorID;
+value = GOOG;
+},
+{
+name = panose;
+value = (
+2,
+11,
+5,
+2,
+4,
+5,
+4,
+2,
+2,
+4
+);
+},
+{
+name = unicodeRanges;
+value = (
+0,
+1,
+2,
+5,
+6,
+45,
+77
+);
+},
+{
+name = codePageRanges;
+value = (
+"1252"
+);
+},
+{
+name = fsType;
+value = (
+);
+}
+);
+date = "2022-06-21 10:06:40 +0000";
+familyName = "Sans Canadian Aboriginal";
+featurePrefixes = (
+{
+automatic = 1;
+code = "languagesystem DFLT dflt;
+
+languagesystem cans dflt;
+";
+name = Languagesystems;
+}
+);
+features = (
+{
+automatic = 1;
+code = "feature ss01;
+feature ss02;
+feature ss03;
+feature ss04;
+";
+tag = aalt;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+tag = salt;
+},
+{
+code = "lookup space_can {
+sub space by space.canadian;
+} space_can;
+
+lookup num_can {
+sub @Num by @Num_can;
+} num_can;
+";
+labels = (
+{
+language = dflt;
+value = "CAN Space and numerals";
+}
+);
+tag = ss01;
+},
+{
+code = "lookup dene_square {
+sub @Dene_round by @Dene_square;
+} dene_square;
+
+";
+labels = (
+{
+language = dflt;
+value = "Dene Square";
+}
+);
+tag = ss02;
+},
+{
+code = "lookup nunavik_alt {
+sub @Nunavik by @Nunavik_alt;
+} nunavik_alt;
+
+";
+labels = (
+{
+language = dflt;
+value = "Nunanvik Alt";
+}
+);
+tag = ss03;
+},
+{
+code = "lookup final_mid {
+sub @Final_mid_ori by @Final_mid;
+} final_mid;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final mid";
+}
+);
+tag = ss04;
+},
+{
+code = "lookup final_base {
+sub @Final_base_ori by @Final_base;
+} final_base;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final base";
+}
+);
+tag = ss05;
+},
+{
+code = "lookup plaincree_first {
+sub wiWestCree-canadian' plusFinal-canadian by i-canadian;
+} plaincree_first;
+
+lookup plaincree_second {
+sub i-canadian plusFinal-canadian' by raiseddoubledotFinal-canadian.cree;
+} plaincree_second;
+
+lookup plaincree_third {
+sub middledotFinal-canadian plusFinal-canadian by raiseddoubledotFinal-canadian.cree;
+} plaincree_third;
+";
+labels = (
+{
+language = dflt;
+value = Plaincree;
+}
+);
+tag = ss06;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+labels = (
+{
+language = dflt;
+value = "";
+}
+);
+tag = ss07;
+}
+);
+fontMaster = (
+{
+axesValues = (
+0,
+0,
+0
+);
+customParameters = (
+{
+name = typoAscender;
+value = 1033;
+},
+{
+name = typoDescender;
+value = -283;
+},
+{
+name = typoLineGap;
+value = 0;
+},
+{
+name = winAscent;
+value = 1033;
+},
+{
+name = winDescent;
+value = 283;
+},
+{
+name = hheaAscender;
+value = 1033;
+},
+{
+name = hheaDescender;
+value = -283;
+},
+{
+name = strikeoutPosition;
+value = 287;
+},
+{
+name = strikeoutSize;
+value = 48;
+},
+{
+name = "Master Icon Glyph Name";
+value = s;
+}
+);
+guides = (
+{
+lockAngle = 1;
+locked = 1;
+pos = (222,345);
+},
+{
+locked = 1;
+pos = (-52,-12);
+},
+{
+locked = 1;
+pos = (99,701);
+}
+);
+id = "9563F490-07F6-43DA-A81C-32B2684714C2";
+metricValues = (
+{
+over = 18;
+pos = 1033;
+},
+{
+over = 18;
+pos = 690;
+},
+{
+over = 18;
+pos = 478;
+},
+{
+over = -18;
+},
+{
+over = -18;
+pos = -283;
+},
+{
+pos = 12;
+}
+);
+name = "RC CR Italic";
+stemValues = (
+90
+);
+}
+);
+glyphs = (
+{
+glyphname = idotless;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(94,0,l),
+(204,520,l),
+(114,520,l),
+(4,0,l)
+);
+}
+);
+width = 199;
+}
+);
+note = dotlessi;
+unicode = 305;
+},
+{
+glyphname = "acuteFinal-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(124,345,l),
+(322,690,l),
+(246,690,l),
+(48,345,l)
+);
+}
+);
+width = 251;
+}
+);
+metricRight = "=|";
+note = uni141F;
+unicode = 5151;
+},
+{
+glyphname = "graveFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(247,345,l),
+(188,690,l),
+(121,690,l),
+(179,345,l)
+);
+}
+);
+width = 249;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+unicode = 5152;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(281,339,o),
+(322,382,o),
+(338,458,cs),
+(387,690,l),
+(326,690,l),
+(277,462,ls),
+(267,413,o),
+(246,395,o),
+(208,395,cs),
+(164,395,o),
+(150,422,o),
+(159,466,cs),
+(207,690,l),
+(145,690,l),
+(99,472,ls),
+(82,390,o),
+(122,339,o),
+(203,339,cs)
+);
+}
+);
+width = 340;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1421;
+unicode = 5153;
+},
+{
+glyphname = "ringTophalfFinal-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(134,345,l),
+(183,573,ls),
+(193,621,o),
+(214,639,o),
+(252,639,cs),
+(296,639,o),
+(309,612,o),
+(300,569,cs),
+(253,345,l),
+(315,345,l),
+(360,562,ls),
+(378,644,o),
+(338,696,o),
+(256,696,cs),
+(179,696,o),
+(138,653,o),
+(122,577,cs),
+(72,345,l)
+);
+}
+);
+width = 341;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+unicode = 5154;
+},
+{
+glyphname = "ringRighthalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(115,345,ls),
+(259,345,o),
+(309,461,o),
+(309,558,cs),
+(309,643,o),
+(259,690,o),
+(176,690,cs),
+(144,690,l),
+(131,631,l),
+(169,631,ls),
+(219,631,o),
+(246,604,o),
+(246,553,cs),
+(246,495,o),
+(224,404,o),
+(123,404,cs),
+(84,404,l),
+(71,345,l)
+);
+}
+);
+width = 293;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+unicode = 5155;
+},
+{
+glyphname = "ringFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(358,389,o),
+(422,455,o),
+(422,543,cs),
+(422,630,o),
+(357,696,o),
+(267,696,cs),
+(176,696,o),
+(111,630,o),
+(111,543,cs),
+(111,455,o),
+(176,389,o),
+(267,389,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(208,442,o),
+(169,483,o),
+(169,543,cs),
+(169,601,o),
+(208,642,o),
+(267,642,cs),
+(325,642,o),
+(364,600,o),
+(364,543,cs),
+(364,483,o),
+(325,442,o),
+(267,442,cs)
+);
+}
+);
+width = 404;
+}
+);
+note = uni1424;
+unicode = 5156;
+},
+{
+glyphname = "doubleacuteFinal-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,345,l),
+(321,690,l),
+(248,690,l),
+(48,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(246,345,l),
+(447,690,l),
+(374,690,l),
+(174,345,l)
+);
+}
+);
+width = 376;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricRight = "=|";
+note = uni1425;
+unicode = 5157;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(133,345,l),
+(207,690,l),
+(145,690,l),
+(71,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(244,345,l),
+(318,690,l),
+(256,690,l),
+(183,345,l)
+);
+}
+);
+width = 270;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "pWestCree-canadian";
+note = uni1426;
+unicode = 5158;
+},
+{
+glyphname = "middledotFinal-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(145,304,o),
+(167,327,o),
+(167,355,cs),
+(167,383,o),
+(145,405,o),
+(117,405,cs),
+(90,405,o),
+(67,383,o),
+(67,355,cs),
+(67,327,o),
+(90,304,o),
+(117,304,cs)
+);
+}
+);
+width = 185;
+}
+);
+note = uni1427;
+unicode = 5159;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(364,499,l),
+(378,561,l),
+(118,561,l),
+(104,499,l)
+);
+}
+);
+width = 359;
+}
+);
+metricRight = "=|";
+note = uni1428;
+unicode = 5160;
+},
+{
+glyphname = "plusFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(242,399,l),
+(268,516,l),
+(368,516,l),
+(381,576,l),
+(280,576,l),
+(304,690,l),
+(246,690,l),
+(222,576,l),
+(121,576,l),
+(108,516,l),
+(209,516,l),
+(185,399,l)
+);
+}
+);
+width = 358;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+unicode = 5161;
+},
+{
+glyphname = "downtackFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(233,345,l),
+(294,631,l),
+(392,631,l),
+(405,690,l),
+(145,690,l),
+(132,631,l),
+(232,631,l),
+(171,345,l)
+);
+}
+);
+width = 358;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni142A;
+unicode = 5162;
+},
+{
+glyphname = "thFinalWoodScree-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(233,345,l),
+(249,420,l),
+(348,420,l),
+(359,474,l),
+(261,474,l),
+(279,560,l),
+(377,560,l),
+(388,614,l),
+(291,614,l),
+(306,690,l),
+(244,690,l),
+(229,614,l),
+(129,614,l),
+(118,560,l),
+(217,560,l),
+(199,474,l),
+(100,474,l),
+(88,420,l),
+(187,420,l),
+(171,345,l)
+);
+}
+);
+width = 359;
+}
+);
+metricLeft = "hyphen-canadian";
+metricRight = "hyphen-canadian";
+note = uni167E;
+unicode = 5758;
+},
+{
+glyphname = "ringSmallFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(270,521,o),
+(312,559,o),
+(312,611,cs),
+(312,665,o),
+(270,702,o),
+(220,702,cs),
+(170,702,o),
+(128,665,o),
+(128,611,cs),
+(128,559,o),
+(169,521,o),
+(220,521,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(190,561,o),
+(171,582,o),
+(171,611,cs),
+(171,640,o),
+(191,662,o),
+(220,662,cs),
+(249,662,o),
+(270,640,o),
+(270,611,cs),
+(270,582,o),
+(249,561,o),
+(220,561,cs)
+);
+}
+);
+width = 282;
+}
+);
+note = g725;
+unicode = 6366;
+},
+{
+glyphname = "raiseddotFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(212,602,o),
+(234,624,o),
+(234,652,cs),
+(234,680,o),
+(212,702,o),
+(184,702,cs),
+(156,702,o),
+(133,680,o),
+(133,652,cs),
+(133,624,o),
+(156,602,o),
+(184,602,cs)
+);
+}
+);
+width = 190;
+}
+);
+note = g725;
+unicode = 6367;
+},
+{
+glyphname = "acuteFinal-canadian.base";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-74,-345);
+ref = "acuteFinal-canadian";
+}
+);
+width = 251;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.base";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-73,-345);
+ref = "graveFinal-canadian";
+}
+);
+width = 250;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian.base";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-73,-345);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 340;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1421;
+},
+{
+glyphname = "ringTophalfFinal-canadian.base";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-73,-345);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 341;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.base";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-73,-345);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 293;
+}
+);
+metricLeft = "==|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "plusFinal-canadian.base";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(157,0,l),
+(183,117,l),
+(283,117,l),
+(296,177,l),
+(195,177,l),
+(219,291,l),
+(161,291,l),
+(137,177,l),
+(36,177,l),
+(23,117,l),
+(125,117,l),
+(99,0,l)
+);
+}
+);
+width = 358;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+},
+{
+glyphname = "acuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-162);
+ref = "acuteFinal-canadian";
+}
+);
+width = 251;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.mid";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-162);
+ref = "graveFinal-canadian";
+}
+);
+width = 251;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringTophalfFinal-canadian.mid";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-37,-172);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 340;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.mid";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-34,-162);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 293;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "ringFinal-canadian.mid";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-42,-199);
+ref = "ringFinal-canadian";
+}
+);
+width = 404;
+}
+);
+metricLeft = "ringFinal-canadian";
+metricWidth = "ringFinal-canadian";
+note = uni1424;
+},
+{
+glyphname = "doubleacuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-162);
+ref = "doubleacuteFinal-canadian";
+}
+);
+width = 376;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "doubleacuteFinal-canadian";
+note = uni1425;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian.mid";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-162);
+ref = "doubleshortverticalstrokesFinal-canadian";
+}
+);
+width = 270;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricWidth = "doubleshortverticalstrokesFinal-canadian";
+note = uni1426;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian.mid";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-37,-176);
+ref = "shorthorizontalstrokeFinal-canadian";
+}
+);
+width = 359;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "shorthorizontalstrokeFinal-canadian";
+note = uni1428;
+},
+{
+glyphname = "downtackFinal-canadian.mid";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-34,-162);
+ref = "downtackFinal-canadian";
+}
+);
+width = 358;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "downtackFinal-canadian";
+note = uni142A;
+},
+{
+glyphname = "e-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (329,454);
+},
+{
+name = top_center_can;
+pos = (383,690);
+},
+{
+name = top_left_can;
+pos = (203,690);
+},
+{
+name = top_right_can;
+pos = (564,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(252,0,l),
+(642,665,l),
+(647,690,l),
+(121,690,l),
+(115,665,l),
+(222,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(279,98,l),
+(202,637,l),
+(182,616,l),
+(551,616,l),
+(535,637,l),
+(232,98,l)
+);
+}
+);
+width = 575;
+}
+);
+metricRight = "=|";
+note = uni1401;
+unicode = 5121;
+},
+{
+glyphname = "aai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (174,0);
+ref = ring_top.canadian;
+}
+);
+width = 577;
+}
+);
+note = uni1402;
+unicode = 5122;
+},
+{
+glyphname = "i-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (317,363);
+},
+{
+name = top_center_can;
+pos = (384,690);
+},
+{
+name = top_left_can;
+pos = (202,690);
+},
+{
+name = top_right_can;
+pos = (563,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(368,690,l),
+(-21,25,l),
+(-27,0,l),
+(500,0,l),
+(505,25,l),
+(399,690,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(342,592,l),
+(419,53,l),
+(440,73,l),
+(70,73,l),
+(86,53,l),
+(389,592,l)
+);
+}
+);
+width = 575;
+}
+);
+metricLeft = "e-canadian";
+metricWidth = "e-canadian";
+note = uni1403;
+unicode = 5123;
+},
+{
+glyphname = "ii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (221,0);
+ref = dot_top;
+}
+);
+width = 577;
+}
+);
+note = uni1404;
+unicode = 5124;
+},
+{
+glyphname = "o-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (253,354);
+},
+{
+name = top_center_can;
+pos = (383,690);
+},
+{
+name = top_double;
+pos = (467,690);
+},
+{
+name = top_left_can;
+pos = (191,690);
+},
+{
+name = top_right_can;
+pos = (575,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(32,0,l),
+(539,328,l),
+(547,361,l),
+(179,690,l),
+(156,690,l),
+(9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(209,588,l),
+(175,601,l),
+(463,340,l),
+(461,362,l),
+(75,108,l),
+(104,101,l)
+);
+}
+);
+width = 550;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1405;
+unicode = 5125;
+},
+{
+glyphname = "oo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (27,0);
+ref = dot_top;
+}
+);
+width = 550;
+}
+);
+note = uni1406;
+unicode = 5126;
+},
+{
+glyphname = "yCreeoo-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (155,0);
+ref = doubledot_top;
+}
+);
+width = 550;
+}
+);
+note = uni1407;
+unicode = 5127;
+},
+{
+glyphname = "eeCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(32,0,l),
+(539,328,l),
+(547,361,l),
+(179,690,l),
+(156,690,l),
+(9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(203,588,l),
+(188,592,l),
+(467,340,l),
+(472,367,l),
+(88,114,l),
+(99,101,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(246,269,l),
+(281,434,l),
+(247,434,l),
+(213,269,l)
+);
+}
+);
+width = 550;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "o-canadian";
+note = uni1408;
+unicode = 5128;
+},
+{
+glyphname = "iCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (181,9);
+ref = dot_middle_optic_small;
+}
+);
+width = 550;
+}
+);
+note = uni1409;
+unicode = 5129;
+},
+{
+glyphname = "a-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (341,345);
+},
+{
+name = top_center_can;
+pos = (340,690);
+},
+{
+name = top_left_can;
+pos = (168,690);
+},
+{
+name = top_right_can;
+pos = (547,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(562,690,l),
+(55,361,l),
+(48,328,l),
+(415,0,l),
+(440,0,l),
+(586,690,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(386,101,l),
+(419,89,l),
+(131,350,l),
+(133,327,l),
+(520,582,l),
+(491,588,l)
+);
+}
+);
+width = 551;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni140A;
+unicode = 5130;
+},
+{
+glyphname = "aa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (383,0);
+ref = dot_top;
+}
+);
+width = 550;
+}
+);
+note = uni140B;
+unicode = 5131;
+},
+{
+glyphname = "we-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "e-canadian";
+}
+);
+width = 761;
+}
+);
+note = uni140C;
+unicode = 5132;
+},
+{
+glyphname = "weWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (577,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 761;
+}
+);
+note = uni140D;
+unicode = 5133;
+},
+{
+glyphname = "wi-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "i-canadian";
+}
+);
+width = 761;
+}
+);
+note = uni140E;
+unicode = 5134;
+},
+{
+glyphname = "wiWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (577,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 761;
+}
+);
+note = uni140F;
+unicode = 5135;
+},
+{
+glyphname = "wii-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (406,0);
+ref = dot_top;
+}
+);
+width = 761;
+}
+);
+note = uni1410;
+unicode = 5136;
+},
+{
+glyphname = "wiiWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (221,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (577,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 761;
+}
+);
+note = uni1411;
+unicode = 5137;
+},
+{
+glyphname = "wo-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "o-canadian";
+}
+);
+width = 735;
+}
+);
+note = uni1412;
+unicode = 5138;
+},
+{
+glyphname = "woWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (550,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 735;
+}
+);
+note = uni1413;
+unicode = 5139;
+},
+{
+glyphname = "woo-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (404,0);
+ref = dot_top;
+}
+);
+width = 735;
+}
+);
+note = uni1414;
+unicode = 5140;
+},
+{
+glyphname = "wooWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (27,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (550,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 735;
+}
+);
+note = uni1415;
+unicode = 5141;
+},
+{
+glyphname = "wooNaskapi-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (141,-94);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (265,-204);
+ref = dot_top;
+}
+);
+width = 550;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricWidth = "o-canadian";
+note = uni1416;
+unicode = 5142;
+},
+{
+glyphname = "wa-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "a-canadian";
+}
+);
+width = 735;
+}
+);
+note = uni1417;
+unicode = 5143;
+},
+{
+glyphname = "waWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (550,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 735;
+}
+);
+note = uni1418;
+unicode = 5144;
+},
+{
+glyphname = "waa-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (568,0);
+ref = dot_top;
+}
+);
+width = 735;
+}
+);
+note = uni1419;
+unicode = 5145;
+},
+{
+glyphname = "waaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (383,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (550,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 735;
+}
+);
+note = uni141A;
+unicode = 5146;
+},
+{
+glyphname = "waaNaskapi-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (79,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (245,-94);
+ref = dot_top;
+}
+);
+width = 551;
+}
+);
+metricWidth = "a-canadian";
+note = uni141B;
+unicode = 5147;
+},
+{
+glyphname = "ai-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(240,339,o),
+(279,368,o),
+(298,419,c),
+(281,419,l),
+(284,367,o),
+(316,339,o),
+(371,339,cs),
+(441,339,o),
+(481,380,o),
+(499,468,cs),
+(547,690,l),
+(489,690,l),
+(441,468,ls),
+(431,417,o),
+(410,395,o),
+(373,395,cs),
+(332,395,o),
+(317,418,o),
+(327,468,cs),
+(375,690,l),
+(317,690,l),
+(270,470,ls),
+(260,419,o),
+(237,395,o),
+(200,395,cs),
+(162,395,o),
+(146,420,o),
+(156,465,cs),
+(204,690,l),
+(145,690,l),
+(97,461,ls),
+(81,390,o),
+(118,339,o),
+(188,339,cs)
+);
+}
+);
+width = 500;
+}
+);
+metricRight = "=|";
+note = uni141C;
+unicode = 5148;
+},
+{
+glyphname = "ycreew-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(355,510,o),
+(383,545,o),
+(383,603,cs),
+(383,661,o),
+(355,696,o),
+(314,696,cs),
+(273,696,o),
+(244,661,o),
+(244,603,cs),
+(244,545,o),
+(272,510,o),
+(314,510,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(204,339,o),
+(232,374,o),
+(232,432,cs),
+(232,490,o),
+(203,525,o),
+(162,525,cs),
+(122,525,o),
+(94,490,o),
+(94,432,cs),
+(94,374,o),
+(122,339,o),
+(162,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(141,373,o),
+(128,392,o),
+(128,432,cs),
+(128,472,o),
+(141,491,o),
+(162,491,cs),
+(184,491,o),
+(197,472,o),
+(197,432,cs),
+(197,392,o),
+(184,373,o),
+(162,373,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(293,544,o),
+(279,563,o),
+(279,603,cs),
+(279,643,o),
+(293,662,o),
+(314,662,cs),
+(335,662,o),
+(348,643,o),
+(348,603,cs),
+(348,563,o),
+(335,544,o),
+(314,544,cs)
+);
+}
+);
+width = 358;
+}
+);
+metricRight = "=|";
+note = uni141D;
+unicode = 5149;
+},
+{
+glyphname = "glottalstop-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(330,345,l),
+(333,359,l),
+(280,690,l),
+(265,690,l),
+(70,359,l),
+(67,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(275,625,l),
+(246,628,l),
+(282,372,l),
+(296,392,l),
+(125,392,l),
+(131,372,l)
+);
+}
+);
+width = 351;
+}
+);
+metricRight = "=|";
+note = uni141E;
+unicode = 5150;
+},
+{
+glyphname = "en-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+pos = (577,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 828;
+}
+);
+note = uni142B;
+unicode = 5163;
+},
+{
+glyphname = "in-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+pos = (396,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 645;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142C;
+unicode = 5164;
+},
+{
+glyphname = "on-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (428,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 677;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142D;
+unicode = 5165;
+},
+{
+glyphname = "an-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (522,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 771;
+}
+);
+metricRight = "graveFinal-canadian";
+note = uni142E;
+unicode = 5166;
+},
+{
+glyphname = "pe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (329,454);
+},
+{
+name = top_center_can;
+pos = (384,690);
+},
+{
+name = top_left_can;
+pos = (202,690);
+},
+{
+name = top_right_can;
+pos = (564,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(252,0,l),
+(642,665,l),
+(647,690,l),
+(560,690,l),
+(224,105,l),
+(286,105,l),
+(197,690,l),
+(121,690,l),
+(115,665,l),
+(222,0,l)
+);
+}
+);
+width = 575;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni142F;
+unicode = 5167;
+},
+{
+glyphname = "paai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (174,0);
+ref = ring_top.canadian;
+}
+);
+width = 577;
+}
+);
+note = uni1430;
+unicode = 5168;
+},
+{
+glyphname = "pi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (319,363);
+},
+{
+name = top_center_can;
+pos = (384,690);
+},
+{
+name = top_left_can;
+pos = (202,690);
+},
+{
+name = top_right_can;
+pos = (563,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(368,690,l),
+(-21,25,l),
+(-27,0,l),
+(61,0,l),
+(396,584,l),
+(335,584,l),
+(423,0,l),
+(499,0,l),
+(505,25,l),
+(399,690,l)
+);
+}
+);
+width = 574;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni1431;
+unicode = 5169;
+},
+{
+glyphname = "pii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (221,0);
+ref = dot_top;
+}
+);
+width = 577;
+}
+);
+note = uni1432;
+unicode = 5170;
+},
+{
+glyphname = "po-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (186,355);
+},
+{
+name = top_center_can;
+pos = (361,690);
+},
+{
+name = top_double;
+pos = (455,690);
+},
+{
+name = top_left_can;
+pos = (176,690);
+},
+{
+name = top_right_can;
+pos = (552,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+name = "Thin Slanted";
+shapes = (
+{
+closed = 1;
+nodes = (
+(13,0,l),
+(516,328,l),
+(523,361,l),
+(159,690,l),
+(136,690,l),
+(120,614,l),
+(429,333,l),
+(438,375,l),
+(10,94,l),
+(-11,0,l)
+);
+}
+);
+width = 526;
+}
+);
+metricRight = "o-canadian";
+note = uni1433;
+unicode = 5171;
+},
+{
+glyphname = "poo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (12,0);
+ref = dot_top;
+}
+);
+width = 526;
+}
+);
+note = uni1434;
+unicode = 5172;
+},
+{
+glyphname = "ycreepoo-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (143,0);
+ref = doubledot_top;
+}
+);
+width = 526;
+}
+);
+note = uni1435;
+unicode = 5173;
+},
+{
+glyphname = "heeCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (126,11);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 526;
+}
+);
+note = uni1436;
+unicode = 5174;
+},
+{
+glyphname = "hiCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (105,13);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 526;
+}
+);
+note = uni1437;
+unicode = 5175;
+},
+{
+glyphname = "pa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (308,345);
+},
+{
+name = top_center_can;
+pos = (359,690);
+},
+{
+name = top_left_can;
+pos = (169,690);
+},
+{
+name = top_right_can;
+pos = (543,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(557,690,l),
+(56,361,l),
+(48,328,l),
+(411,0,l),
+(435,0,l),
+(451,75,l),
+(142,356,l),
+(134,315,l),
+(561,596,l),
+(582,690,l)
+);
+}
+);
+width = 526;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1438;
+unicode = 5176;
+},
+{
+glyphname = "paa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (380,0);
+ref = dot_top;
+}
+);
+width = 526;
+}
+);
+note = uni1439;
+unicode = 5177;
+},
+{
+glyphname = "pwe-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "pe-canadian";
+}
+);
+width = 761;
+}
+);
+note = uni143A;
+unicode = 5178;
+},
+{
+glyphname = "pweWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "pe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (577,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 761;
+}
+);
+note = uni143B;
+unicode = 5179;
+},
+{
+glyphname = "pwi-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "pi-canadian";
+}
+);
+width = 761;
+}
+);
+note = uni143C;
+unicode = 5180;
+},
+{
+glyphname = "pwiWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (577,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 761;
+}
+);
+note = uni143D;
+unicode = 5181;
+},
+{
+glyphname = "pwii-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (406,0);
+ref = dot_top;
+}
+);
+width = 761;
+}
+);
+note = uni143E;
+unicode = 5182;
+},
+{
+glyphname = "pwiiWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (221,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (577,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 761;
+}
+);
+note = uni143F;
+unicode = 5183;
+},
+{
+glyphname = "pwo-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "po-canadian";
+}
+);
+width = 711;
+}
+);
+note = uni1440;
+unicode = 5184;
+},
+{
+glyphname = "pwoWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (526,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 711;
+}
+);
+note = uni1441;
+unicode = 5185;
+},
+{
+glyphname = "pwoo-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (383,0);
+ref = dot_top;
+}
+);
+width = 711;
+}
+);
+note = uni1442;
+unicode = 5186;
+},
+{
+glyphname = "pwooWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (12,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (526,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 711;
+}
+);
+note = uni1443;
+unicode = 5187;
+},
+{
+glyphname = "pwa-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "pa-canadian";
+}
+);
+width = 711;
+}
+);
+note = uni1444;
+unicode = 5188;
+},
+{
+glyphname = "pwaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (526,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 711;
+}
+);
+note = uni1445;
+unicode = 5189;
+},
+{
+glyphname = "pwaa-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (564,0);
+ref = dot_top;
+}
+);
+width = 711;
+}
+);
+note = uni1446;
+unicode = 5190;
+},
+{
+glyphname = "pwaaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (380,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (526,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 711;
+}
+);
+note = uni1447;
+unicode = 5191;
+},
+{
+glyphname = "ycreepwaa-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+pos = (74,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (241,-94);
+ref = dot_top;
+}
+);
+width = 526;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1448;
+unicode = 5192;
+},
+{
+glyphname = "p-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(297,345,l),
+(308,398,l),
+(159,535,l),
+(150,490,l),
+(356,626,l),
+(370,690,l),
+(357,690,l),
+(110,527,l),
+(106,508,l),
+(284,345,l)
+);
+}
+);
+width = 324;
+}
+);
+note = uni1449;
+unicode = 5193;
+},
+{
+glyphname = "pWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(133,345,l),
+(207,690,l),
+(145,690,l),
+(71,345,l)
+);
+}
+);
+width = 159;
+}
+);
+metricRight = "=|";
+note = uni144A;
+unicode = 5194;
+},
+{
+color = 6;
+glyphname = "hCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,183,l),
+(126,324,ls),
+(134,361,o),
+(154,380,o),
+(181,380,cs),
+(212,380,o),
+(224,358,o),
+(216,322,cs),
+(186,183,l),
+(248,183,l),
+(279,329,ls),
+(293,391,o),
+(262,435,o),
+(204,435,cs),
+(166,435,o),
+(133,411,o),
+(124,375,c),
+(136,366,l),
+(170,527,l),
+(109,527,l),
+(36,183,l)
+);
+}
+);
+width = 294;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144B;
+unicode = 5195;
+},
+{
+glyphname = "te-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (313,345);
+},
+{
+name = top_center_can;
+pos = (386,690);
+},
+{
+name = top_left_can;
+pos = (198,690);
+},
+{
+name = top_right_can;
+pos = (576,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(405,-13,o),
+(488,66,o),
+(523,226,cs),
+(621,690,l),
+(530,690,l),
+(434,236,ls),
+(410,121,o),
+(359,71,o),
+(271,71,cs),
+(163,71,o),
+(124,132,o),
+(150,255,cs),
+(242,690,l),
+(153,690,l),
+(62,262,ls),
+(25,89,o),
+(102,-13,o),
+(266,-13,cs)
+);
+}
+);
+width = 583;
+}
+);
+metricRight = "=|";
+note = uni144C;
+unicode = 5196;
+},
+{
+glyphname = "taai-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (176,0);
+ref = ring_top.canadian;
+}
+);
+width = 582;
+}
+);
+note = uni144D;
+unicode = 5197;
+},
+{
+glyphname = "ti-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (314,345);
+},
+{
+name = middle_right_can;
+pos = (656,345);
+},
+{
+name = top_center_can;
+pos = (387,690);
+},
+{
+name = top_left_can;
+pos = (199,690);
+},
+{
+name = top_right_can;
+pos = (577,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,0,l),
+(193,454,ls),
+(217,569,o),
+(270,618,o),
+(356,618,cs),
+(464,618,o),
+(503,557,o),
+(477,435,cs),
+(385,0,l),
+(475,0,l),
+(566,428,ls),
+(603,601,o),
+(525,702,o),
+(362,702,cs),
+(222,702,o),
+(139,624,o),
+(105,464,cs),
+(7,0,l)
+);
+}
+);
+width = 583;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni144E;
+unicode = 5198;
+},
+{
+glyphname = "tii-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (222,0);
+ref = dot_top;
+}
+);
+width = 582;
+}
+);
+note = uni144F;
+unicode = 5199;
+},
+{
+glyphname = "to-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (218,345);
+},
+{
+name = middle_right_can;
+pos = (568,345);
+},
+{
+name = top_center_can;
+pos = (315,690);
+},
+{
+name = top_double;
+pos = (370,690);
+},
+{
+name = top_left_can;
+pos = (177,690);
+},
+{
+name = top_right_can;
+pos = (495,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(103,0,ls),
+(400,0,o),
+(470,281,o),
+(470,441,cs),
+(470,602,o),
+(381,690,o),
+(218,690,cs),
+(137,690,l),
+(120,607,l),
+(202,607,ls),
+(321,607,o),
+(380,551,o),
+(380,437,cs),
+(380,317,o),
+(328,83,o),
+(107,83,cs),
+(8,83,l),
+(-10,0,l)
+);
+}
+);
+width = 487;
+}
+);
+note = uni1450;
+unicode = 5200;
+},
+{
+glyphname = "too-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (152,0);
+ref = dot_top;
+}
+);
+width = 487;
+}
+);
+note = uni1451;
+unicode = 5201;
+},
+{
+glyphname = "ycreetoo-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (59,0);
+ref = doubledot_top;
+}
+);
+width = 487;
+}
+);
+note = uni1452;
+unicode = 5202;
+},
+{
+glyphname = "deeCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (151,0);
+ref = stroke_middle;
+}
+);
+width = 487;
+}
+);
+note = uni1453;
+unicode = 5203;
+},
+{
+glyphname = "diCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (128,0);
+ref = dot_middle;
+}
+);
+width = 487;
+}
+);
+note = uni1454;
+unicode = 5204;
+},
+{
+glyphname = "ta-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (312,345);
+},
+{
+name = top_center_can;
+pos = (362,690);
+},
+{
+name = top_left_can;
+pos = (181,690);
+},
+{
+name = top_right_can;
+pos = (501,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(394,0,l),
+(411,83,l),
+(326,83,ls),
+(209,83,o),
+(152,139,o),
+(152,252,cs),
+(152,381,o),
+(207,607,o),
+(422,607,cs),
+(523,607,l),
+(540,690,l),
+(426,690,ls),
+(135,690,o),
+(61,415,o),
+(61,247,cs),
+(61,88,o),
+(148,0,o),
+(310,0,cs)
+);
+}
+);
+width = 486;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|to-canadian";
+note = uni1455;
+unicode = 5205;
+},
+{
+glyphname = "taa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (200,0);
+ref = dot_top;
+}
+);
+width = 487;
+}
+);
+note = uni1456;
+unicode = 5206;
+},
+{
+glyphname = "twe-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "te-canadian";
+}
+);
+width = 767;
+}
+);
+note = uni1457;
+unicode = 5207;
+},
+{
+glyphname = "tweWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (582,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 767;
+}
+);
+note = uni1458;
+unicode = 5208;
+},
+{
+glyphname = "twi-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ti-canadian";
+}
+);
+width = 767;
+}
+);
+note = uni1459;
+unicode = 5209;
+},
+{
+glyphname = "twiWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (582,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 767;
+}
+);
+note = uni145A;
+unicode = 5210;
+},
+{
+glyphname = "twii-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (408,0);
+ref = dot_top;
+}
+);
+width = 767;
+}
+);
+note = uni145B;
+unicode = 5211;
+},
+{
+glyphname = "twiiWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (222,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (582,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 767;
+}
+);
+note = uni145C;
+unicode = 5212;
+},
+{
+glyphname = "two-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "to-canadian";
+}
+);
+width = 672;
+}
+);
+note = uni145D;
+unicode = 5213;
+},
+{
+glyphname = "twoWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (487,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 672;
+}
+);
+note = uni145E;
+unicode = 5214;
+},
+{
+glyphname = "twoo-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (336,0);
+ref = dot_top;
+}
+);
+width = 672;
+}
+);
+note = uni145F;
+unicode = 5215;
+},
+{
+glyphname = "twooWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (152,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (487,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 672;
+}
+);
+note = uni1460;
+unicode = 5216;
+},
+{
+glyphname = "twa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ta-canadian";
+}
+);
+width = 672;
+}
+);
+note = uni1461;
+unicode = 5217;
+},
+{
+glyphname = "twaWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (487,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 672;
+}
+);
+note = uni1462;
+unicode = 5218;
+},
+{
+glyphname = "twaa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (384,0);
+ref = dot_top;
+}
+);
+width = 672;
+}
+);
+note = uni1463;
+unicode = 5219;
+},
+{
+glyphname = "twaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (200,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (487,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 672;
+}
+);
+note = uni1464;
+unicode = 5220;
+},
+{
+glyphname = "twaaNaskapi-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (195,0);
+ref = "ta-canadian";
+}
+);
+width = 682;
+}
+);
+note = uni1465;
+unicode = 5221;
+},
+{
+glyphname = "t-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(268,345,l),
+(280,404,l),
+(242,404,ls),
+(191,404,o),
+(165,432,o),
+(165,482,cs),
+(165,546,o),
+(192,631,o),
+(291,631,cs),
+(328,631,l),
+(341,690,l),
+(298,690,ls),
+(156,690,o),
+(102,579,o),
+(102,476,cs),
+(102,391,o),
+(152,345,o),
+(236,345,cs)
+);
+}
+);
+width = 293;
+}
+);
+note = uni1466;
+unicode = 5222;
+},
+{
+glyphname = "tte-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+pos = (582,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 742;
+}
+);
+note = uni1467;
+unicode = 5223;
+},
+{
+glyphname = "tti-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+pos = (582,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 742;
+}
+);
+note = uni1468;
+unicode = 5224;
+},
+{
+glyphname = "tto-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+pos = (487,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 647;
+}
+);
+note = uni1469;
+unicode = 5225;
+},
+{
+glyphname = "tta-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+pos = (487,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 647;
+}
+);
+note = uni146A;
+unicode = 5226;
+},
+{
+glyphname = "ke-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (292,441);
+},
+{
+name = top_center_can;
+pos = (332,690);
+},
+{
+name = top_left_can;
+pos = (189,690);
+},
+{
+name = top_right_can;
+pos = (475,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(374,0,l),
+(465,431,ls),
+(493,563,o),
+(468,702,o),
+(318,702,cs),
+(144,702,o),
+(88,497,o),
+(88,373,cs),
+(88,263,o),
+(138,198,o),
+(230,198,cs),
+(288,198,o),
+(332,231,o),
+(362,298,c),
+(348,303,l),
+(283,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(202,276,o),
+(175,310,o),
+(175,377,cs),
+(175,446,o),
+(207,625,o),
+(310,625,cs),
+(361,625,o),
+(388,591,o),
+(388,525,cs),
+(388,455,o),
+(356,276,o),
+(254,276,cs)
+);
+}
+);
+width = 482;
+}
+);
+metricRight = "te-canadian";
+note = uni146B;
+unicode = 5227;
+},
+{
+glyphname = "kaai-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (128,0);
+ref = ring_top.canadian;
+}
+);
+width = 481;
+}
+);
+note = uni146C;
+unicode = 5228;
+},
+{
+glyphname = "ki-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (299,441);
+},
+{
+name = top_center_can;
+pos = (339,690);
+},
+{
+name = top_left_can;
+pos = (197,690);
+},
+{
+name = top_right_can;
+pos = (483,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(96,0,l),
+(166,329,l),
+(151,303,l),
+(150,243,o),
+(193,198,o),
+(264,198,cs),
+(426,198,o),
+(483,407,o),
+(483,524,cs),
+(483,638,o),
+(426,702,o),
+(325,702,cs),
+(213,702,o),
+(138,623,o),
+(106,470,cs),
+(6,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(210,276,o),
+(183,310,o),
+(183,377,cs),
+(183,446,o),
+(216,625,o),
+(318,625,cs),
+(369,625,o),
+(396,591,o),
+(396,526,cs),
+(396,453,o),
+(363,276,o),
+(262,276,cs)
+);
+}
+);
+width = 481;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni146D;
+unicode = 5229;
+},
+{
+glyphname = "kii-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (176,0);
+ref = dot_top;
+}
+);
+width = 481;
+}
+);
+note = uni146E;
+unicode = 5230;
+},
+{
+glyphname = "ko-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (275,362);
+},
+{
+name = top_center_can;
+pos = (333,690);
+},
+{
+name = top_double;
+pos = (476,690);
+},
+{
+name = top_left_can;
+pos = (190,690);
+},
+{
+name = top_right_can;
+pos = (476,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(315,-13,o),
+(388,67,o),
+(421,219,cs),
+(521,690,l),
+(431,690,l),
+(360,360,l),
+(376,386,l),
+(377,446,o),
+(333,492,o),
+(263,492,cs),
+(100,492,o),
+(43,283,o),
+(43,166,cs),
+(43,53,o),
+(100,-13,o),
+(203,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(157,65,o),
+(130,99,o),
+(130,164,cs),
+(130,235,o),
+(164,413,o),
+(266,413,cs),
+(317,413,o),
+(344,379,o),
+(344,313,cs),
+(344,240,o),
+(312,65,o),
+(210,65,cs)
+);
+}
+);
+width = 482;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni146F;
+unicode = 5231;
+},
+{
+glyphname = "koo-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (311,0);
+ref = dot_top;
+}
+);
+width = 481;
+}
+);
+note = uni1470;
+unicode = 5232;
+},
+{
+glyphname = "ycreekoo-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (164,0);
+ref = doubledot_top;
+}
+);
+width = 481;
+}
+);
+note = uni1471;
+unicode = 5233;
+},
+{
+glyphname = "ka-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (282,364);
+},
+{
+name = top_center_can;
+pos = (340,690);
+},
+{
+name = top_left_can;
+pos = (197,690);
+},
+{
+name = top_right_can;
+pos = (483,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(383,-13,o),
+(439,192,o),
+(439,317,cs),
+(439,427,o),
+(386,492,o),
+(296,492,cs),
+(240,492,o),
+(195,459,o),
+(164,391,c),
+(178,386,l),
+(242,690,l),
+(153,690,l),
+(61,259,ls),
+(24,88,o),
+(83,-13,o),
+(209,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(164,65,o),
+(137,99,o),
+(137,165,cs),
+(137,235,o),
+(169,413,o),
+(271,413,cs),
+(324,413,o),
+(351,380,o),
+(351,313,cs),
+(351,243,o),
+(319,65,o),
+(216,65,cs)
+);
+}
+);
+width = 482;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "==|ke-canadian";
+note = uni1472;
+unicode = 5234;
+},
+{
+glyphname = "kaa-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (33,0);
+ref = dot_top;
+}
+);
+width = 481;
+}
+);
+note = uni1473;
+unicode = 5235;
+},
+{
+glyphname = "kwe-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ke-canadian";
+}
+);
+width = 666;
+}
+);
+note = uni1474;
+unicode = 5236;
+},
+{
+glyphname = "kweWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (481,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 666;
+}
+);
+note = uni1475;
+unicode = 5237;
+},
+{
+glyphname = "kwi-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ki-canadian";
+}
+);
+width = 666;
+}
+);
+note = uni1476;
+unicode = 5238;
+},
+{
+glyphname = "kwiWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (481,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 666;
+}
+);
+note = uni1477;
+unicode = 5239;
+},
+{
+glyphname = "kwii-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (360,0);
+ref = dot_top;
+}
+);
+width = 666;
+}
+);
+note = uni1478;
+unicode = 5240;
+},
+{
+glyphname = "kwiiWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (176,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (481,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 666;
+}
+);
+note = uni1479;
+unicode = 5241;
+},
+{
+glyphname = "kwo-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ko-canadian";
+}
+);
+width = 666;
+}
+);
+note = uni147A;
+unicode = 5242;
+},
+{
+glyphname = "kwoWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (481,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 666;
+}
+);
+note = uni147B;
+unicode = 5243;
+},
+{
+glyphname = "kwoo-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (497,0);
+ref = dot_top;
+}
+);
+width = 666;
+}
+);
+note = uni147C;
+unicode = 5244;
+},
+{
+glyphname = "kwooWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (311,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (481,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 666;
+}
+);
+note = uni147D;
+unicode = 5245;
+},
+{
+glyphname = "kwa-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ka-canadian";
+}
+);
+width = 666;
+}
+);
+note = uni147E;
+unicode = 5246;
+},
+{
+glyphname = "kwaWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (481,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 666;
+}
+);
+note = uni147F;
+unicode = 5247;
+},
+{
+glyphname = "kwaa-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (218,0);
+ref = dot_top;
+}
+);
+width = 666;
+}
+);
+note = uni1480;
+unicode = 5248;
+},
+{
+glyphname = "kwaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (33,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (481,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 666;
+}
+);
+note = uni1481;
+unicode = 5249;
+},
+{
+glyphname = "kwaaNaskapi-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (195,0);
+ref = "ka-canadian";
+}
+);
+width = 675;
+}
+);
+note = uni1482;
+unicode = 5250;
+},
+{
+glyphname = "k-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(279,339,o),
+(311,449,o),
+(311,509,cs),
+(311,566,o),
+(283,601,o),
+(237,601,cs),
+(198,601,o),
+(169,574,o),
+(156,534,c),
+(174,534,l),
+(207,690,l),
+(145,690,l),
+(100,480,ls),
+(87,417,o),
+(99,339,o),
+(185,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(165,386,o),
+(153,404,o),
+(153,435,cs),
+(153,470,o),
+(171,554,o),
+(218,554,cs),
+(242,554,o),
+(254,536,o),
+(254,506,cs),
+(254,469,o),
+(236,386,o),
+(188,386,cs)
+);
+}
+);
+width = 298;
+}
+);
+note = uni1483;
+unicode = 5251;
+},
+{
+glyphname = "kw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(238,338,o),
+(279,381,o),
+(297,467,cs),
+(344,690,l),
+(283,690,l),
+(248,527,l),
+(264,532,l),
+(267,573,o),
+(240,600,o),
+(200,600,cs),
+(119,600,o),
+(86,495,o),
+(86,437,cs),
+(86,376,o),
+(119,338,o),
+(176,338,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(154,386,o),
+(141,404,o),
+(141,434,cs),
+(141,469,o),
+(159,553,o),
+(208,553,cs),
+(230,553,o),
+(243,535,o),
+(243,504,cs),
+(243,472,o),
+(227,386,o),
+(177,386,cs)
+);
+}
+);
+width = 298;
+}
+);
+metricLeft = "=|k-canadian";
+metricRight = "=|k-canadian";
+note = uni1484;
+unicode = 5252;
+},
+{
+glyphname = "southslaveykeh-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+pos = (481,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 640;
+}
+);
+note = uni1485;
+unicode = 5253;
+},
+{
+glyphname = "southslaveykih-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+pos = (481,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 640;
+}
+);
+note = uni1486;
+unicode = 5254;
+},
+{
+glyphname = "southslaveykoh-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+pos = (481,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 640;
+}
+);
+note = uni1487;
+unicode = 5255;
+},
+{
+glyphname = "southslaveykah-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+pos = (481,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 640;
+}
+);
+note = uni1488;
+unicode = 5256;
+},
+{
+glyphname = "ce-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (279,403);
+},
+{
+name = top_center_can;
+pos = (330,690);
+},
+{
+name = top_left_can;
+pos = (188,690);
+},
+{
+name = top_right_can;
+pos = (470,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(368,0,l),
+(467,464,ls),
+(497,613,o),
+(435,702,o),
+(313,702,cs),
+(197,702,o),
+(131,633,o),
+(99,480,cs),
+(79,387,l),
+(168,387,l),
+(190,491,ls),
+(211,583,o),
+(245,623,o),
+(302,623,cs),
+(370,623,o),
+(400,575,o),
+(380,481,cs),
+(277,0,l)
+);
+}
+);
+width = 476;
+}
+);
+metricRight = "te-canadian";
+note = uni1489;
+unicode = 5257;
+},
+{
+glyphname = "caai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (128,0);
+ref = ring_top.canadian;
+}
+);
+width = 475;
+}
+);
+note = uni148A;
+unicode = 5258;
+},
+{
+glyphname = "ci-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (289,403);
+},
+{
+name = top_center_can;
+pos = (339,690);
+},
+{
+name = top_left_can;
+pos = (198,690);
+},
+{
+name = top_right_can;
+pos = (481,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(96,0,l),
+(200,491,ls),
+(219,583,o),
+(254,623,o),
+(313,623,cs),
+(380,623,o),
+(410,575,o),
+(389,481,cs),
+(370,387,l),
+(459,387,l),
+(475,464,ls),
+(507,613,o),
+(444,702,o),
+(322,702,cs),
+(206,702,o),
+(140,633,o),
+(108,480,cs),
+(6,0,l)
+);
+}
+);
+width = 476;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+unicode = 5259;
+},
+{
+glyphname = "cii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:46 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (175,0);
+ref = dot_top;
+}
+);
+width = 476;
+}
+);
+note = uni148C;
+unicode = 5260;
+},
+{
+glyphname = "co-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (281,403);
+},
+{
+name = top_center_can;
+pos = (330,690);
+},
+{
+name = top_double;
+pos = (471,690);
+},
+{
+name = top_left_can;
+pos = (189,690);
+},
+{
+name = top_right_can;
+pos = (471,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(315,-13,o),
+(381,57,o),
+(413,210,cs),
+(516,690,l),
+(425,690,l),
+(322,199,ls),
+(301,106,o),
+(267,67,o),
+(209,67,cs),
+(141,67,o),
+(111,115,o),
+(131,209,cs),
+(152,302,l),
+(62,302,l),
+(45,226,ls),
+(14,76,o),
+(77,-13,o),
+(199,-13,cs)
+);
+}
+);
+width = 477;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+unicode = 5261;
+},
+{
+glyphname = "coo-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (306,0);
+ref = dot_top;
+}
+);
+width = 475;
+}
+);
+note = uni148E;
+unicode = 5262;
+},
+{
+glyphname = "ycreecoo-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (158,0);
+ref = doubledot_top;
+}
+);
+width = 475;
+}
+);
+note = uni148F;
+unicode = 5263;
+},
+{
+glyphname = "ca-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (289,403);
+},
+{
+name = top_center_can;
+pos = (340,690);
+},
+{
+name = top_left_can;
+pos = (198,690);
+},
+{
+name = top_right_can;
+pos = (479,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(323,-13,o),
+(388,57,o),
+(421,210,cs),
+(440,302,l),
+(352,302,l),
+(329,199,ls),
+(309,106,o),
+(274,67,o),
+(217,67,cs),
+(150,67,o),
+(120,115,o),
+(140,209,cs),
+(242,690,l),
+(153,690,l),
+(54,226,ls),
+(22,76,o),
+(85,-13,o),
+(207,-13,cs)
+);
+}
+);
+width = 475;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+unicode = 5264;
+},
+{
+glyphname = "caa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (34,0);
+ref = dot_top;
+}
+);
+width = 475;
+}
+);
+note = uni1491;
+unicode = 5265;
+},
+{
+glyphname = "cwe-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ce-canadian";
+}
+);
+width = 660;
+}
+);
+note = uni1492;
+unicode = 5266;
+},
+{
+glyphname = "cweWestCree-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (475,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 660;
+}
+);
+note = uni1493;
+unicode = 5267;
+},
+{
+glyphname = "cwi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:46 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+pos = (185,0);
+ref = "ci-canadian";
+}
+);
+width = 661;
+}
+);
+note = uni1494;
+unicode = 5268;
+},
+{
+glyphname = "cwiWestCree-canadian";
+lastChange = "2023-01-13 15:55:46 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "ci-canadian";
+},
+{
+anchor = middle_right_can;
+pos = (476,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 661;
+}
+);
+note = uni1495;
+unicode = 5269;
+},
+{
+glyphname = "cwii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:46 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+pos = (185,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (360,0);
+ref = dot_top;
+}
+);
+width = 661;
+}
+);
+note = uni1496;
+unicode = 5270;
+},
+{
+glyphname = "cwiiWestCree-canadian";
+lastChange = "2023-01-13 15:55:46 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (175,0);
+ref = dot_top;
+},
+{
+anchor = middle_right_can;
+pos = (476,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 661;
+}
+);
+note = uni1497;
+unicode = 5271;
+},
+{
+glyphname = "cwo-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "co-canadian";
+}
+);
+width = 660;
+}
+);
+note = uni1498;
+unicode = 5272;
+},
+{
+glyphname = "cwoWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (475,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 660;
+}
+);
+note = uni1499;
+unicode = 5273;
+},
+{
+glyphname = "cwoo-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (491,0);
+ref = dot_top;
+}
+);
+width = 660;
+}
+);
+note = uni149A;
+unicode = 5274;
+},
+{
+glyphname = "cwooWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (306,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (475,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 660;
+}
+);
+note = uni149B;
+unicode = 5275;
+},
+{
+glyphname = "cwa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ca-canadian";
+}
+);
+width = 660;
+}
+);
+note = uni149C;
+unicode = 5276;
+},
+{
+glyphname = "cwaWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (475,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 660;
+}
+);
+note = uni149D;
+unicode = 5277;
+},
+{
+glyphname = "cwaa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (219,0);
+ref = dot_top;
+}
+);
+width = 660;
+}
+);
+note = uni149E;
+unicode = 5278;
+},
+{
+glyphname = "cwaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (34,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (475,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 660;
+}
+);
+note = uni149F;
+unicode = 5279;
+},
+{
+glyphname = "cwaaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (195,0);
+ref = "ca-canadian";
+}
+);
+width = 670;
+}
+);
+note = uni14A0;
+unicode = 5280;
+},
+{
+glyphname = "c-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(249,339,o),
+(290,381,o),
+(304,452,cs),
+(312,487,l),
+(255,487,l),
+(245,446,ls),
+(238,410,o),
+(219,389,o),
+(191,389,cs),
+(159,389,o),
+(149,416,o),
+(156,453,cs),
+(207,690,l),
+(145,690,l),
+(98,468,ls),
+(82,394,o),
+(113,339,o),
+(187,339,cs)
+);
+}
+);
+width = 289;
+}
+);
+note = uni14A1;
+unicode = 5281;
+},
+{
+glyphname = "thSayisi-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(232,339,o),
+(270,381,o),
+(287,454,cs),
+(337,690,l),
+(275,690,l),
+(224,450,ls),
+(215,407,o),
+(196,389,o),
+(168,389,cs),
+(136,389,o),
+(126,416,o),
+(133,453,cs),
+(140,487,l),
+(83,487,l),
+(78,463,ls),
+(64,392,o),
+(95,339,o),
+(169,339,cs)
+);
+}
+);
+width = 290;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "=|c-canadian";
+note = uni14A2;
+unicode = 5282;
+},
+{
+glyphname = "me-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (180,345);
+},
+{
+name = top_center_can;
+pos = (300,690);
+},
+{
+name = top_left_can;
+pos = (174,690);
+},
+{
+name = top_right_can;
+pos = (421,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(321,0,l),
+(468,690,l),
+(128,690,l),
+(111,607,l),
+(359,607,l),
+(230,0,l)
+);
+}
+);
+width = 432;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+unicode = 5283;
+},
+{
+glyphname = "maai-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (114,0);
+ref = ring_top.canadian;
+}
+);
+width = 431;
+}
+);
+note = uni14A4;
+unicode = 5284;
+},
+{
+glyphname = "mi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (298,345);
+},
+{
+name = top_center_can;
+pos = (325,690);
+},
+{
+name = top_left_can;
+pos = (201,690);
+},
+{
+name = top_right_can;
+pos = (448,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,0,l),
+(228,607,l),
+(476,607,l),
+(494,690,l),
+(156,690,l),
+(9,0,l)
+);
+}
+);
+width = 430;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+unicode = 5285;
+},
+{
+glyphname = "mii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (161,0);
+ref = dot_top;
+}
+);
+width = 431;
+}
+);
+note = uni14A6;
+unicode = 5286;
+},
+{
+glyphname = "mo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (179,345);
+},
+{
+name = top_center_can;
+pos = (299,690);
+},
+{
+name = top_double;
+pos = (421,690);
+},
+{
+name = top_left_can;
+pos = (173,690);
+},
+{
+name = top_right_can;
+pos = (421,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(320,0,l),
+(467,690,l),
+(376,690,l),
+(247,83,l),
+(-1,83,l),
+(-18,0,l)
+);
+}
+);
+width = 431;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+unicode = 5287;
+},
+{
+glyphname = "moo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (258,0);
+ref = dot_top;
+}
+);
+width = 431;
+}
+);
+note = uni14A8;
+unicode = 5288;
+},
+{
+glyphname = "ycreemoo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (111,0);
+ref = doubledot_top;
+}
+);
+width = 431;
+}
+);
+note = uni14A9;
+unicode = 5289;
+},
+{
+glyphname = "ma-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (298,345);
+},
+{
+name = top_center_can;
+pos = (325,690);
+},
+{
+name = top_left_can;
+pos = (201,690);
+},
+{
+name = top_right_can;
+pos = (448,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(347,0,l),
+(364,83,l),
+(117,83,l),
+(245,690,l),
+(156,690,l),
+(9,0,l)
+);
+}
+);
+width = 430;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+unicode = 5290;
+},
+{
+glyphname = "maa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (38,0);
+ref = dot_top;
+}
+);
+width = 431;
+}
+);
+note = uni14AB;
+unicode = 5291;
+},
+{
+glyphname = "mwe-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "me-canadian";
+}
+);
+width = 616;
+}
+);
+note = uni14AC;
+unicode = 5292;
+},
+{
+glyphname = "mweWestCree-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "me-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (431,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 616;
+}
+);
+note = uni14AD;
+unicode = 5293;
+},
+{
+glyphname = "mwi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "mi-canadian";
+}
+);
+width = 616;
+}
+);
+note = uni14AE;
+unicode = 5294;
+},
+{
+glyphname = "mwiWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (431,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 616;
+}
+);
+note = uni14AF;
+unicode = 5295;
+},
+{
+glyphname = "mwii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (346,0);
+ref = dot_top;
+}
+);
+width = 616;
+}
+);
+note = uni14B0;
+unicode = 5296;
+},
+{
+glyphname = "mwiiWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (161,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (431,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 616;
+}
+);
+note = uni14B1;
+unicode = 5297;
+},
+{
+glyphname = "mwo-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "mo-canadian";
+}
+);
+width = 616;
+}
+);
+note = uni14B2;
+unicode = 5298;
+},
+{
+glyphname = "mwoWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (431,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 616;
+}
+);
+note = uni14B3;
+unicode = 5299;
+},
+{
+glyphname = "mwoo-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (443,0);
+ref = dot_top;
+}
+);
+width = 616;
+}
+);
+note = uni14B4;
+unicode = 5300;
+},
+{
+glyphname = "mwooWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (258,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (431,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 616;
+}
+);
+note = uni14B5;
+unicode = 5301;
+},
+{
+glyphname = "mwa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ma-canadian";
+}
+);
+width = 616;
+}
+);
+note = uni14B6;
+unicode = 5302;
+},
+{
+glyphname = "mwaWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (431,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 616;
+}
+);
+note = uni14B7;
+unicode = 5303;
+},
+{
+glyphname = "mwaa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (222,0);
+ref = dot_top;
+}
+);
+width = 616;
+}
+);
+note = uni14B8;
+unicode = 5304;
+},
+{
+glyphname = "mwaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (38,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (431,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 616;
+}
+);
+note = uni14B9;
+unicode = 5305;
+},
+{
+glyphname = "mwaaNaskapi-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (195,0);
+ref = "ma-canadian";
+}
+);
+width = 626;
+}
+);
+note = uni14BA;
+unicode = 5306;
+},
+{
+glyphname = "m-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(258,345,l),
+(270,404,l),
+(146,404,l),
+(207,690,l),
+(145,690,l),
+(71,345,l)
+);
+}
+);
+width = 266;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni14BB;
+unicode = 5307;
+},
+{
+glyphname = "mWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "t-canadian";
+}
+);
+width = 293;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "t-canadian";
+note = uni14BC;
+unicode = 5308;
+},
+{
+glyphname = "mh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(241,345,l),
+(314,690,l),
+(253,690,l),
+(192,404,l),
+(67,404,l),
+(54,345,l)
+);
+}
+);
+width = 266;
+}
+);
+metricLeft = "=|m-canadian";
+metricRight = "=|m-canadian";
+note = uni14BD;
+unicode = 5309;
+},
+{
+glyphname = "mAthapascan-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(269,345,l),
+(280,399,l),
+(147,399,l),
+(145,370,l),
+(251,485,ls),
+(287,524,o),
+(313,563,o),
+(313,611,cs),
+(313,663,o),
+(281,696,o),
+(227,696,cs),
+(169,696,o),
+(128,660,o),
+(113,575,c),
+(169,575,l),
+(178,629,o),
+(197,649,o),
+(223,649,cs),
+(245,649,o),
+(258,636,o),
+(258,611,cs),
+(258,575,o),
+(236,542,o),
+(203,506,cs),
+(83,377,l),
+(76,345,l)
+);
+}
+);
+width = 285;
+}
+);
+note = uni14BE;
+unicode = 5310;
+},
+{
+glyphname = "mSayisi-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = two.canadian;
+}
+);
+width = 469;
+}
+);
+note = uni14BF;
+unicode = 5311;
+},
+{
+glyphname = "ne-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (413,245);
+},
+{
+name = top_center_can;
+pos = (456,497);
+},
+{
+name = top_left_can;
+pos = (146,497);
+},
+{
+name = top_right_can;
+pos = (614,497);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(549,-13,o),
+(608,184,o),
+(608,296,cs),
+(608,410,o),
+(545,478,o),
+(433,478,cs),
+(97,478,l),
+(79,396,l),
+(334,396,l),
+(334,429,l),
+(242,386,o),
+(213,249,o),
+(213,169,cs),
+(213,55,o),
+(275,-13,o),
+(382,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(329,65,o),
+(300,101,o),
+(300,168,cs),
+(300,238,o),
+(330,401,o),
+(436,401,cs),
+(491,401,o),
+(520,364,o),
+(520,297,cs),
+(520,228,o),
+(491,65,o),
+(384,65,cs)
+);
+}
+);
+width = 653;
+}
+);
+metricRight = "=|ke-canadian";
+note = uni14C0;
+unicode = 5312;
+},
+{
+glyphname = "naai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (95,-193);
+ref = ring_top.canadian;
+}
+);
+width = 653;
+}
+);
+note = uni14C1;
+unicode = 5313;
+},
+{
+glyphname = "ni-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (242,245);
+},
+{
+name = top_center_can;
+pos = (307,497);
+},
+{
+name = top_left_can;
+pos = (148,497);
+},
+{
+name = top_right_can;
+pos = (616,497);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(379,-13,o),
+(438,184,o),
+(438,297,cs),
+(438,349,o),
+(421,387,o),
+(392,410,c),
+(384,396,l),
+(641,396,l),
+(659,478,l),
+(277,478,ls),
+(100,478,o),
+(43,283,o),
+(43,170,cs),
+(43,55,o),
+(105,-13,o),
+(212,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(159,65,o),
+(130,101,o),
+(130,168,cs),
+(130,238,o),
+(160,401,o),
+(266,401,cs),
+(322,401,o),
+(350,364,o),
+(350,297,cs),
+(350,228,o),
+(321,65,o),
+(215,65,cs)
+);
+}
+);
+width = 654;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+unicode = 5314;
+},
+{
+glyphname = "nii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (142,-193);
+ref = dot_top;
+}
+);
+width = 653;
+}
+);
+note = uni14C3;
+unicode = 5315;
+},
+{
+glyphname = "no-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (413,245);
+},
+{
+name = top_center_can;
+pos = (465,497);
+},
+{
+name = top_double;
+pos = (469,497);
+},
+{
+name = top_left_can;
+pos = (146,497);
+},
+{
+name = top_right_can;
+pos = (615,497);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(377,0,ls),
+(554,0,o),
+(611,196,o),
+(611,308,cs),
+(611,423,o),
+(548,492,o),
+(442,492,cs),
+(274,492,o),
+(216,296,o),
+(216,182,cs),
+(216,130,o),
+(232,91,o),
+(262,69,c),
+(270,82,l),
+(13,82,l),
+(-5,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(332,77,o),
+(303,115,o),
+(303,182,cs),
+(303,250,o),
+(333,413,o),
+(439,413,cs),
+(494,413,o),
+(523,377,o),
+(523,310,cs),
+(523,242,o),
+(493,77,o),
+(387,77,cs)
+);
+}
+);
+width = 654;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14C4;
+unicode = 5316;
+},
+{
+glyphname = "noo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (301,-193);
+ref = dot_top;
+}
+);
+width = 653;
+}
+);
+note = uni14C5;
+unicode = 5317;
+},
+{
+glyphname = "ycreenoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (156,-193);
+ref = doubledot_top;
+}
+);
+width = 653;
+}
+);
+note = uni14C6;
+unicode = 5318;
+},
+{
+glyphname = "na-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (243,245);
+},
+{
+name = top_center_can;
+pos = (298,497);
+},
+{
+name = top_double;
+pos = (425,497);
+},
+{
+name = top_left_can;
+pos = (148,497);
+},
+{
+name = top_right_can;
+pos = (617,497);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(556,0,l),
+(574,82,l),
+(319,82,l),
+(319,50,l),
+(412,92,o),
+(440,229,o),
+(440,309,cs),
+(440,423,o),
+(378,492,o),
+(272,492,cs),
+(104,492,o),
+(46,296,o),
+(46,183,cs),
+(46,70,o),
+(108,0,o),
+(220,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(162,77,o),
+(133,115,o),
+(133,182,cs),
+(133,250,o),
+(163,413,o),
+(269,413,cs),
+(325,413,o),
+(353,377,o),
+(353,310,cs),
+(353,242,o),
+(324,77,o),
+(218,77,cs)
+);
+}
+);
+width = 653;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+unicode = 5319;
+},
+{
+glyphname = "naa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (132,-193);
+ref = dot_top;
+}
+);
+width = 653;
+}
+);
+note = uni14C8;
+unicode = 5320;
+},
+{
+glyphname = "nwe-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ne-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni14C9;
+unicode = 5321;
+},
+{
+glyphname = "nweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni14CA;
+unicode = 5322;
+},
+{
+glyphname = "nwa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "na-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni14CB;
+unicode = 5323;
+},
+{
+glyphname = "nwaWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni14CC;
+unicode = 5324;
+},
+{
+glyphname = "nwaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (318,-193);
+ref = dot_top;
+}
+);
+width = 838;
+}
+);
+note = uni14CD;
+unicode = 5325;
+},
+{
+glyphname = "nwaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (132,-193);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni14CE;
+unicode = 5326;
+},
+{
+glyphname = "nwaaNaskapi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (113,-193);
+ref = doubledot_top;
+}
+);
+width = 653;
+}
+);
+note = uni14CF;
+unicode = 5327;
+},
+{
+glyphname = "n-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(385,434,l),
+(398,493,l),
+(257,493,l),
+(254,459,l),
+(299,480,o),
+(320,553,o),
+(320,595,cs),
+(320,657,o),
+(286,696,o),
+(230,696,cs),
+(144,696,o),
+(107,601,o),
+(107,533,cs),
+(107,471,o),
+(142,434,o),
+(200,434,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(175,481,o),
+(161,499,o),
+(161,532,cs),
+(161,569,o),
+(178,648,o),
+(226,648,cs),
+(252,648,o),
+(265,630,o),
+(265,597,cs),
+(265,560,o),
+(249,481,o),
+(199,481,cs)
+);
+}
+);
+width = 374;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni14D0;
+unicode = 5328;
+},
+{
+color = 6;
+glyphname = "ngCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-34,-161);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 341;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "=|";
+note = uni14D1;
+unicode = 5329;
+},
+{
+glyphname = "nh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(280,434,ls),
+(370,434,o),
+(407,527,o),
+(407,597,cs),
+(407,659,o),
+(371,696,o),
+(316,696,cs),
+(231,696,o),
+(193,601,o),
+(193,533,cs),
+(193,511,o),
+(200,485,o),
+(218,469,c),
+(225,493,l),
+(84,493,l),
+(71,434,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(262,481,o),
+(248,499,o),
+(248,532,cs),
+(248,569,o),
+(265,648,o),
+(313,648,cs),
+(338,648,o),
+(352,630,o),
+(352,597,cs),
+(352,560,o),
+(336,481,o),
+(287,481,cs)
+);
+}
+);
+width = 376;
+}
+);
+metricLeft = "=|n-canadian";
+metricRight = "=|n-canadian";
+note = uni14D2;
+unicode = 5330;
+},
+{
+glyphname = "le-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (412,245);
+},
+{
+name = top_center_can;
+pos = (457,497);
+},
+{
+name = top_left_can;
+pos = (146,497);
+},
+{
+name = top_right_can;
+pos = (614,497);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(327,0,ls),
+(521,0,o),
+(606,140,o),
+(606,285,cs),
+(606,404,o),
+(532,478,o),
+(408,478,cs),
+(97,478,l),
+(79,396,l),
+(390,396,ls),
+(472,396,o),
+(517,355,o),
+(517,279,cs),
+(517,196,o),
+(477,80,o),
+(338,80,cs),
+(323,80,l),
+(305,0,l)
+);
+}
+);
+width = 653;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D3;
+unicode = 5331;
+},
+{
+glyphname = "laai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (97,-193);
+ref = ring_top.canadian;
+}
+);
+width = 653;
+}
+);
+note = uni14D4;
+unicode = 5332;
+},
+{
+glyphname = "li-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (245,245);
+},
+{
+name = top_center_can;
+pos = (310,497);
+},
+{
+name = top_left_can;
+pos = (151,497);
+},
+{
+name = top_right_can;
+pos = (618,497);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(248,0,l),
+(265,80,l),
+(250,80,ls),
+(180,80,o),
+(138,126,o),
+(138,199,cs),
+(138,283,o),
+(184,396,o),
+(320,396,cs),
+(642,396,l),
+(660,478,l),
+(327,478,ls),
+(139,478,o),
+(48,343,o),
+(48,197,cs),
+(48,81,o),
+(120,0,o),
+(231,0,cs)
+);
+}
+);
+width = 655;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14D5;
+unicode = 5333;
+},
+{
+glyphname = "lii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (144,-193);
+ref = dot_top;
+}
+);
+width = 653;
+}
+);
+note = uni14D6;
+unicode = 5334;
+},
+{
+glyphname = "lo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (413,245);
+},
+{
+name = top_center_can;
+pos = (464,497);
+},
+{
+name = top_double;
+pos = (434,497);
+},
+{
+name = top_left_can;
+pos = (146,497);
+},
+{
+name = top_right_can;
+pos = (614,497);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(328,0,ls),
+(516,0,o),
+(606,135,o),
+(606,281,cs),
+(606,398,o),
+(535,478,o),
+(424,478,cs),
+(407,478,l),
+(389,398,l),
+(405,398,ls),
+(475,398,o),
+(517,354,o),
+(517,279,cs),
+(517,195,o),
+(470,82,o),
+(335,82,cs),
+(13,82,l),
+(-5,0,l)
+);
+}
+);
+width = 654;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D7;
+unicode = 5335;
+},
+{
+glyphname = "loo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (300,-193);
+ref = dot_top;
+}
+);
+width = 653;
+}
+);
+note = uni14D8;
+unicode = 5336;
+},
+{
+glyphname = "ycreeloo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (122,-193);
+ref = doubledot_top;
+}
+);
+width = 653;
+}
+);
+note = uni14D9;
+unicode = 5337;
+},
+{
+glyphname = "la-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (244,245);
+},
+{
+name = top_center_can;
+pos = (298,497);
+},
+{
+name = top_left_can;
+pos = (150,497);
+},
+{
+name = top_right_can;
+pos = (617,497);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(556,0,l),
+(574,82,l),
+(264,82,ls),
+(182,82,o),
+(137,125,o),
+(137,200,cs),
+(137,282,o),
+(177,398,o),
+(316,398,cs),
+(331,398,l),
+(349,478,l),
+(327,478,ls),
+(132,478,o),
+(47,338,o),
+(47,193,cs),
+(47,74,o),
+(122,0,o),
+(246,0,cs)
+);
+}
+);
+width = 653;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14DA;
+unicode = 5338;
+},
+{
+glyphname = "laa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (133,-193);
+ref = dot_top;
+}
+);
+width = 653;
+}
+);
+note = uni14DB;
+unicode = 5339;
+},
+{
+glyphname = "lwe-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "le-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni14DC;
+unicode = 5340;
+},
+{
+glyphname = "lweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "le-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni14DD;
+unicode = 5341;
+},
+{
+glyphname = "lwi-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "li-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni14DE;
+unicode = 5342;
+},
+{
+glyphname = "lwiWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni14DF;
+unicode = 5343;
+},
+{
+glyphname = "lwii-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (329,-193);
+ref = dot_top;
+}
+);
+width = 838;
+}
+);
+note = uni14E0;
+unicode = 5344;
+},
+{
+glyphname = "lwiiWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (144,-193);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni14E1;
+unicode = 5345;
+},
+{
+glyphname = "lwo-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "lo-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni14E2;
+unicode = 5346;
+},
+{
+glyphname = "lwoWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni14E3;
+unicode = 5347;
+},
+{
+glyphname = "lwoo-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (485,-193);
+ref = dot_top;
+}
+);
+width = 838;
+}
+);
+note = uni14E4;
+unicode = 5348;
+},
+{
+glyphname = "lwooWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (300,-193);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni14E5;
+unicode = 5349;
+},
+{
+glyphname = "lwa-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "la-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni14E6;
+unicode = 5350;
+},
+{
+glyphname = "lwaWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni14E7;
+unicode = 5351;
+},
+{
+glyphname = "lwaa-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (319,-193);
+ref = dot_top;
+}
+);
+width = 838;
+}
+);
+note = uni14E8;
+unicode = 5352;
+},
+{
+glyphname = "lwaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (133,-193);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni14E9;
+unicode = 5353;
+},
+{
+glyphname = "l-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(360,345,l),
+(374,404,l),
+(242,404,ls),
+(191,404,o),
+(165,431,o),
+(165,482,cs),
+(165,545,o),
+(192,631,o),
+(288,631,cs),
+(295,631,l),
+(307,690,l),
+(298,690,ls),
+(156,690,o),
+(102,578,o),
+(102,476,cs),
+(102,391,o),
+(152,345,o),
+(240,345,cs)
+);
+}
+);
+width = 370;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "m-canadian";
+note = uni14EA;
+unicode = 5354;
+},
+{
+glyphname = "lWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(264,345,l),
+(271,384,l),
+(140,457,l),
+(133,424,l),
+(297,499,l),
+(302,529,l),
+(169,598,l),
+(163,569,l),
+(327,642,l),
+(337,690,l),
+(326,690,l),
+(127,601,l),
+(122,577,l),
+(256,505,l),
+(261,529,l),
+(96,458,l),
+(91,434,l),
+(252,345,l)
+);
+}
+);
+width = 291;
+}
+);
+metricRight = "=|";
+note = uni14EB;
+unicode = 5355;
+},
+{
+glyphname = "mediall-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(401,-13,l),
+(414,48,l),
+(128,205,l),
+(119,162,l),
+(471,319,l),
+(480,360,l),
+(192,507,l),
+(183,470,l),
+(537,628,l),
+(553,702,l),
+(529,702,l),
+(115,518,l),
+(107,480,l),
+(395,328,l),
+(402,361,l),
+(49,210,l),
+(42,172,l),
+(378,-13,l)
+);
+}
+);
+width = 510;
+}
+);
+metricRight = "=|";
+note = uni14EC;
+unicode = 5356;
+},
+{
+glyphname = "se-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (199,690);
+},
+{
+name = top_right_can;
+pos = (430,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(327,0,l),
+(398,331,l),
+(372,331,ls),
+(238,331,o),
+(181,391,o),
+(214,551,cs),
+(244,690,l),
+(155,690,l),
+(125,553,ls),
+(82,353,o),
+(170,249,o),
+(352,249,cs),
+(365,249,l),
+(298,279,l),
+(238,0,l)
+);
+}
+);
+width = 439;
+}
+);
+note = uni14ED;
+unicode = 5357;
+},
+{
+glyphname = "saai-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (220,0);
+ref = ring_top.canadian;
+}
+);
+width = 439;
+}
+);
+note = uni14EE;
+unicode = 5358;
+},
+{
+glyphname = "si-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (203,690);
+},
+{
+name = top_right_can;
+pos = (433,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(101,0,l),
+(160,280,l),
+(86,249,l),
+(121,249,ls),
+(300,249,o),
+(402,335,o),
+(445,539,cs),
+(477,690,l),
+(387,690,l),
+(357,545,ls),
+(325,401,o),
+(251,331,o),
+(127,331,cs),
+(81,331,l),
+(11,0,l)
+);
+}
+);
+width = 439;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+unicode = 5359;
+},
+{
+glyphname = "sii-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (268,0);
+ref = dot_top;
+}
+);
+width = 439;
+}
+);
+note = uni14F0;
+unicode = 5360;
+},
+{
+glyphname = "so-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (429,690);
+},
+{
+name = top_left_can;
+pos = (199,690);
+},
+{
+name = top_right_can;
+pos = (429,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,0,l),
+(128,145,ls),
+(159,289,o),
+(233,358,o),
+(358,358,cs),
+(404,358,l),
+(473,690,l),
+(383,690,l),
+(324,410,l),
+(398,440,l),
+(363,440,ls),
+(184,440,o),
+(82,355,o),
+(39,151,cs),
+(7,0,l)
+);
+}
+);
+width = 440;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+unicode = 5361;
+},
+{
+glyphname = "soo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (266,0);
+ref = dot_top;
+}
+);
+width = 439;
+}
+);
+note = uni14F2;
+unicode = 5362;
+},
+{
+glyphname = "ycreesoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (119,0);
+ref = doubledot_top;
+}
+);
+width = 439;
+}
+);
+note = uni14F3;
+unicode = 5363;
+},
+{
+glyphname = "sa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (203,690);
+},
+{
+name = top_right_can;
+pos = (433,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(330,0,l),
+(360,137,ls),
+(403,337,o),
+(315,440,o),
+(133,440,cs),
+(120,440,l),
+(187,411,l),
+(247,690,l),
+(157,690,l),
+(87,358,l),
+(113,358,ls),
+(247,358,o),
+(304,298,o),
+(270,139,cs),
+(241,0,l)
+);
+}
+);
+width = 440;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+unicode = 5364;
+},
+{
+glyphname = "saa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (38,0);
+ref = dot_top;
+}
+);
+width = 439;
+}
+);
+note = uni14F5;
+unicode = 5365;
+},
+{
+glyphname = "swe-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "se-canadian";
+}
+);
+width = 624;
+}
+);
+note = uni14F6;
+unicode = 5366;
+},
+{
+glyphname = "sweWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "se-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (439,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 624;
+}
+);
+note = uni14F7;
+unicode = 5367;
+},
+{
+glyphname = "swi-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "si-canadian";
+}
+);
+width = 624;
+}
+);
+note = uni14F8;
+unicode = 5368;
+},
+{
+glyphname = "swiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (439,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 624;
+}
+);
+note = uni14F9;
+unicode = 5369;
+},
+{
+glyphname = "swii-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (453,0);
+ref = dot_top;
+}
+);
+width = 624;
+}
+);
+note = uni14FA;
+unicode = 5370;
+},
+{
+glyphname = "swiiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (268,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (439,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 624;
+}
+);
+note = uni14FB;
+unicode = 5371;
+},
+{
+glyphname = "swo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "so-canadian";
+}
+);
+width = 624;
+}
+);
+note = uni14FC;
+unicode = 5372;
+},
+{
+glyphname = "swoWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (439,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 624;
+}
+);
+note = uni14FD;
+unicode = 5373;
+},
+{
+glyphname = "swoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (451,0);
+ref = dot_top;
+}
+);
+width = 624;
+}
+);
+note = uni14FE;
+unicode = 5374;
+},
+{
+glyphname = "swooWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (266,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (439,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 624;
+}
+);
+note = uni14FF;
+unicode = 5375;
+},
+{
+glyphname = "swa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "sa-canadian";
+}
+);
+width = 624;
+}
+);
+note = uni1500;
+unicode = 5376;
+},
+{
+glyphname = "swaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (439,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 624;
+}
+);
+note = uni1501;
+unicode = 5377;
+},
+{
+glyphname = "swaa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (222,0);
+ref = dot_top;
+}
+);
+width = 624;
+}
+);
+note = uni1502;
+unicode = 5378;
+},
+{
+glyphname = "swaaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (38,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (439,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 624;
+}
+);
+note = uni1503;
+unicode = 5379;
+},
+{
+glyphname = "swaaNaskapi-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (195,0);
+ref = "sa-canadian";
+}
+);
+width = 634;
+}
+);
+note = uni1504;
+unicode = 5380;
+},
+{
+glyphname = "s-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(259,345,l),
+(274,421,ls),
+(294,515,o),
+(253,575,o),
+(161,575,cs),
+(144,575,l),
+(177,547,l),
+(207,690,l),
+(145,690,l),
+(110,525,l),
+(141,525,ls),
+(206,525,o),
+(227,490,o),
+(213,420,cs),
+(197,345,l)
+);
+}
+);
+width = 285;
+}
+);
+metricRight = "=|";
+note = uni1505;
+unicode = 5381;
+},
+{
+color = 6;
+glyphname = "sAthapascan-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(229,177,o),
+(271,221,o),
+(271,283,cs),
+(271,324,o),
+(252,352,o),
+(213,369,cs),
+(184,382,ls),
+(161,392,o),
+(150,409,o),
+(150,429,cs),
+(150,463,o),
+(170,486,o),
+(206,486,cs),
+(239,486,o),
+(254,469,o),
+(245,425,c),
+(302,425,l),
+(315,492,o),
+(275,533,o),
+(210,533,cs),
+(133,533,o),
+(93,488,o),
+(93,424,cs),
+(93,387,o),
+(113,356,o),
+(150,340,cs),
+(179,327,ls),
+(205,315,o),
+(214,300,o),
+(214,279,cs),
+(214,245,o),
+(194,224,o),
+(159,224,cs),
+(124,224,o),
+(105,241,o),
+(116,287,c),
+(59,287,l),
+(45,217,o),
+(86,177,o),
+(157,177,cs)
+);
+}
+);
+width = 314;
+}
+);
+metricRight = "=|";
+note = uni1506;
+unicode = 5382;
+},
+{
+glyphname = "sw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(133,345,l),
+(150,419,ls),
+(165,494,o),
+(200,525,o),
+(266,525,cs),
+(297,525,l),
+(331,690,l),
+(270,690,l),
+(241,551,l),
+(285,575,l),
+(255,575,ls),
+(163,575,o),
+(110,526,o),
+(89,425,cs),
+(72,345,l)
+);
+}
+);
+width = 285;
+}
+);
+metricLeft = "=|s-canadian";
+metricRight = "=|s-canadian";
+note = uni1507;
+unicode = 5383;
+},
+{
+glyphname = "sBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(265,345,l),
+(277,404,l),
+(213,404,ls),
+(168,404,o),
+(151,427,o),
+(161,476,cs),
+(207,690,l),
+(145,690,l),
+(101,482,ls),
+(82,396,o),
+(122,345,o),
+(206,345,cs)
+);
+}
+);
+width = 273;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "m-canadian";
+note = uni1508;
+unicode = 5384;
+},
+{
+glyphname = "moosecreesk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(263,217,o),
+(292,351,o),
+(292,437,cs),
+(292,527,o),
+(249,576,o),
+(164,576,cs),
+(153,576,l),
+(177,549,l),
+(207,690,l),
+(145,690,l),
+(110,526,l),
+(142,526,ls),
+(225,526,o),
+(238,490,o),
+(235,418,c),
+(244,411,l),
+(245,440,o),
+(233,477,o),
+(184,477,cs),
+(100,477,o),
+(71,372,o),
+(71,317,cs),
+(71,256,o),
+(103,217,o),
+(161,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(139,264,o),
+(126,282,o),
+(126,314,cs),
+(126,350,o),
+(144,433,o),
+(192,433,cs),
+(217,433,o),
+(230,415,o),
+(230,384,cs),
+(230,348,o),
+(212,264,o),
+(164,264,cs)
+);
+}
+);
+width = 308;
+}
+);
+metricRight = "=|";
+note = uni1509;
+unicode = 5385;
+},
+{
+glyphname = "skwNaskapi-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(249,217,o),
+(285,320,o),
+(285,384,cs),
+(285,441,o),
+(258,477,o),
+(212,477,cs),
+(175,477,o),
+(145,453,o),
+(134,414,c),
+(150,417,l),
+(177,492,o),
+(212,526,o),
+(289,526,cs),
+(320,526,l),
+(355,690,l),
+(293,690,l),
+(263,548,l),
+(301,576,l),
+(284,576,ls),
+(126,576,o),
+(73,413,o),
+(73,320,cs),
+(73,259,o),
+(103,217,o),
+(162,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(139,264,o),
+(128,282,o),
+(128,314,cs),
+(128,350,o),
+(145,433,o),
+(192,433,cs),
+(217,433,o),
+(230,415,o),
+(230,384,cs),
+(230,348,o),
+(212,264,o),
+(165,264,cs)
+);
+}
+);
+width = 308;
+}
+);
+metricLeft = "=|moosecreesk-canadian";
+metricRight = "=|moosecreesk-canadian";
+note = uni150A;
+unicode = 5386;
+},
+{
+glyphname = "swNaskapi-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(242,182,l),
+(254,244,ls),
+(275,344,o),
+(231,402,o),
+(143,402,cs),
+(125,402,l),
+(152,375,l),
+(181,509,l),
+(119,509,l),
+(86,353,l),
+(120,353,ls),
+(183,353,o),
+(209,322,o),
+(193,245,cs),
+(180,182,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(220,45,o),
+(242,68,o),
+(242,96,cs),
+(242,125,o),
+(220,147,o),
+(192,147,cs),
+(165,147,o),
+(142,125,o),
+(142,96,cs),
+(142,68,o),
+(165,45,o),
+(192,45,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(196,543,o),
+(218,566,o),
+(218,594,cs),
+(218,622,o),
+(196,645,o),
+(168,645,cs),
+(141,645,o),
+(119,622,o),
+(119,594,cs),
+(119,566,o),
+(141,543,o),
+(168,543,cs)
+);
+}
+);
+width = 316;
+}
+);
+metricRight = "=|";
+note = uni150B;
+unicode = 5387;
+},
+{
+glyphname = "spwaNaskapi-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(435,0,l),
+(451,75,l),
+(142,356,l),
+(134,315,l),
+(561,596,l),
+(582,690,l),
+(557,690,l),
+(56,361,l),
+(48,328,l),
+(411,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(203,497,o),
+(225,521,o),
+(225,548,cs),
+(225,577,o),
+(203,599,o),
+(175,599,cs),
+(148,599,o),
+(125,577,o),
+(125,548,cs),
+(125,521,o),
+(148,497,o),
+(175,497,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(364,604,l),
+(377,660,ls),
+(391,728,o),
+(362,770,o),
+(298,770,cs),
+(273,770,l),
+(312,747,l),
+(333,846,l),
+(274,846,l),
+(248,723,l),
+(270,723,ls),
+(313,723,o),
+(327,702,o),
+(316,654,cs),
+(306,604,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(525,704,o),
+(548,727,o),
+(548,755,cs),
+(548,783,o),
+(525,806,o),
+(497,806,cs),
+(470,806,o),
+(447,783,o),
+(447,755,cs),
+(447,727,o),
+(470,704,o),
+(497,704,cs)
+);
+}
+);
+width = 526;
+}
+);
+metricRight = "pa-canadian";
+metricWidth = "pa-canadian";
+note = uni150C;
+unicode = 5388;
+},
+{
+glyphname = "stwaNaskapi-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (316,0);
+ref = "ta-canadian";
+}
+);
+width = 803;
+}
+);
+note = uni150D;
+unicode = 5389;
+},
+{
+glyphname = "skwaNaskapi-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (316,0);
+ref = "ka-canadian";
+}
+);
+width = 797;
+}
+);
+note = uni150E;
+unicode = 5390;
+},
+{
+glyphname = "scwaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (316,0);
+ref = "ca-canadian";
+}
+);
+width = 791;
+}
+);
+note = uni150F;
+unicode = 5391;
+},
+{
+glyphname = "she-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (328,690);
+},
+{
+name = top_right_can;
+pos = (657,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(580,-13,o),
+(644,61,o),
+(675,211,cs),
+(695,302,l),
+(606,302,l),
+(583,201,ls),
+(564,106,o),
+(532,67,o),
+(476,67,cs),
+(414,67,o),
+(393,116,o),
+(410,211,cs),
+(453,458,ls),
+(480,616,o),
+(424,702,o),
+(306,702,cs),
+(196,702,o),
+(132,629,o),
+(100,479,cs),
+(81,387,l),
+(171,387,l),
+(192,489,ls),
+(213,583,o),
+(244,623,o),
+(299,623,cs),
+(362,623,o),
+(384,574,o),
+(367,479,cs),
+(324,232,ls),
+(297,73,o),
+(352,-13,o),
+(469,-13,cs)
+);
+}
+);
+width = 731;
+}
+);
+metricRight = "=|";
+note = uni1510;
+unicode = 5392;
+},
+{
+glyphname = "shi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (269,690);
+},
+{
+name = top_right_can;
+pos = (596,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(298,-13,o),
+(358,49,o),
+(401,217,cs),
+(466,478,ls),
+(495,588,o),
+(523,623,o),
+(580,623,cs),
+(640,623,o),
+(664,573,o),
+(641,473,cs),
+(623,387,l),
+(713,387,l),
+(726,451,ls),
+(760,604,o),
+(706,702,o),
+(584,702,cs),
+(478,702,o),
+(419,640,o),
+(377,472,cs),
+(310,211,ls),
+(282,101,o),
+(254,67,o),
+(196,67,cs),
+(136,67,o),
+(113,116,o),
+(134,215,cs),
+(153,302,l),
+(64,302,l),
+(49,239,ls),
+(16,85,o),
+(71,-13,o),
+(191,-13,cs)
+);
+}
+);
+width = 731;
+}
+);
+metricLeft = "she-canadian";
+metricRight = "she-canadian";
+note = uni1511;
+unicode = 5393;
+},
+{
+glyphname = "shii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (432,0);
+ref = dot_top;
+}
+);
+width = 732;
+}
+);
+note = uni1512;
+unicode = 5394;
+},
+{
+glyphname = "sho-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (429,497);
+},
+{
+name = top_left_can;
+pos = (286,497);
+},
+{
+name = top_right_can;
+pos = (571,497);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(255,67,l),
+(175,68,o),
+(125,103,o),
+(125,162,cs),
+(125,222,o),
+(159,275,o),
+(227,275,cs),
+(333,275,o),
+(384,122,o),
+(529,122,cs),
+(646,122,o),
+(713,213,o),
+(713,318,cs),
+(713,421,o),
+(633,489,o),
+(511,492,c),
+(494,412,l),
+(575,411,o),
+(626,375,o),
+(626,316,cs),
+(626,257,o),
+(590,203,o),
+(524,203,cs),
+(417,203,o),
+(366,357,o),
+(221,357,cs),
+(100,357,o),
+(38,262,o),
+(38,161,cs),
+(38,57,o),
+(118,-11,o),
+(238,-13,c)
+);
+}
+);
+width = 751;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1513;
+unicode = 5395;
+},
+{
+glyphname = "shoo-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (264,-193);
+ref = dot_top;
+}
+);
+width = 749;
+}
+);
+note = uni1514;
+unicode = 5396;
+},
+{
+glyphname = "sha-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (431,497);
+},
+{
+name = top_left_can;
+pos = (288,497);
+},
+{
+name = top_right_can;
+pos = (573,497);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(576,-15,o),
+(690,66,o),
+(690,210,cs),
+(690,297,o),
+(634,357,o),
+(545,357,cs),
+(413,357,o),
+(313,203,o),
+(221,203,cs),
+(178,203,o),
+(151,231,o),
+(151,276,cs),
+(151,368,o),
+(224,412,o),
+(318,412,c),
+(334,492,l),
+(175,494,o),
+(61,412,o),
+(61,269,cs),
+(61,182,o),
+(117,122,o),
+(206,122,cs),
+(336,122,o),
+(438,275,o),
+(528,275,cs),
+(573,275,o),
+(600,247,o),
+(600,202,cs),
+(600,110,o),
+(527,66,o),
+(433,67,c),
+(416,-13,l)
+);
+}
+);
+width = 751;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1515;
+unicode = 5397;
+},
+{
+glyphname = "shaa-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (266,-193);
+ref = dot_top;
+}
+);
+width = 749;
+}
+);
+note = uni1516;
+unicode = 5398;
+},
+{
+glyphname = "shwe-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "she-canadian";
+}
+);
+width = 917;
+}
+);
+note = uni1517;
+unicode = 5399;
+},
+{
+glyphname = "shweWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "she-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (732,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 917;
+}
+);
+note = uni1518;
+unicode = 5400;
+},
+{
+glyphname = "shwi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "shi-canadian";
+}
+);
+width = 917;
+}
+);
+note = uni1519;
+unicode = 5401;
+},
+{
+glyphname = "shwiWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (732,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 917;
+}
+);
+note = uni151A;
+unicode = 5402;
+},
+{
+glyphname = "shwii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (617,0);
+ref = dot_top;
+}
+);
+width = 917;
+}
+);
+note = uni151B;
+unicode = 5403;
+},
+{
+glyphname = "shwiiWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (432,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (732,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 917;
+}
+);
+note = uni151C;
+unicode = 5404;
+},
+{
+glyphname = "shwo-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "sho-canadian";
+}
+);
+width = 933;
+}
+);
+note = uni151D;
+unicode = 5405;
+},
+{
+glyphname = "shwoWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (749,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 933;
+}
+);
+note = uni151E;
+unicode = 5406;
+},
+{
+glyphname = "shwoo-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (449,-193);
+ref = dot_top;
+}
+);
+width = 933;
+}
+);
+note = uni151F;
+unicode = 5407;
+},
+{
+glyphname = "shwooWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (264,-193);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (749,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 933;
+}
+);
+note = uni1520;
+unicode = 5408;
+},
+{
+glyphname = "shwa-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "sha-canadian";
+}
+);
+width = 933;
+}
+);
+note = uni1521;
+unicode = 5409;
+},
+{
+glyphname = "shwaWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (749,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 933;
+}
+);
+note = uni1522;
+unicode = 5410;
+},
+{
+glyphname = "shwaa-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (451,-193);
+ref = dot_top;
+}
+);
+width = 933;
+}
+);
+note = uni1523;
+unicode = 5411;
+},
+{
+glyphname = "shwaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (266,-193);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (749,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 933;
+}
+);
+note = uni1524;
+unicode = 5412;
+},
+{
+glyphname = "sh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(478,286,o),
+(567,348,o),
+(567,459,cs),
+(567,525,o),
+(524,572,o),
+(451,572,cs),
+(361,572,o),
+(299,476,o),
+(232,476,cs),
+(194,476,o),
+(173,497,o),
+(173,532,cs),
+(173,600,o),
+(230,642,o),
+(315,639,c),
+(326,697,l),
+(201,700,o),
+(110,639,o),
+(110,527,cs),
+(110,461,o),
+(155,414,o),
+(227,414,cs),
+(317,414,o),
+(379,510,o),
+(446,510,cs),
+(484,510,o),
+(504,489,o),
+(504,454,cs),
+(504,389,o),
+(450,344,o),
+(365,347,c),
+(354,289,l)
+);
+}
+);
+width = 570;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni1525;
+unicode = 5413;
+},
+{
+glyphname = "ye-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (526,345);
+},
+{
+name = top_left_can;
+pos = (178,690);
+},
+{
+name = top_right_can;
+pos = (456,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(355,0,l),
+(423,323,l),
+(165,323,l),
+(170,294,l),
+(501,647,l),
+(440,701,l),
+(43,272,l),
+(37,242,l),
+(316,242,l),
+(264,0,l)
+);
+}
+);
+width = 463;
+}
+);
+note = uni1526;
+unicode = 5414;
+},
+{
+glyphname = "yaai-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-12,0);
+ref = ring_top.canadian;
+}
+);
+width = 463;
+}
+);
+note = uni1527;
+unicode = 5415;
+},
+{
+glyphname = "yi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (200,690);
+},
+{
+name = top_right_can;
+pos = (479,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,0,l),
+(148,242,l),
+(427,242,l),
+(434,272,l),
+(203,701,l),
+(130,661,l),
+(329,297,l),
+(333,323,l),
+(74,323,l),
+(6,0,l)
+);
+}
+);
+width = 463;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni1528;
+unicode = 5416;
+},
+{
+glyphname = "yii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+}
+);
+width = 463;
+}
+);
+note = uni1529;
+unicode = 5417;
+},
+{
+glyphname = "yo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (527,345);
+},
+{
+name = top_double;
+pos = (457,690);
+},
+{
+name = top_left_can;
+pos = (178,690);
+},
+{
+name = top_right_can;
+pos = (457,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(378,29,l),
+(179,393,l),
+(175,367,l),
+(433,367,l),
+(502,690,l),
+(412,690,l),
+(360,447,l),
+(81,447,l),
+(74,417,l),
+(305,-12,l)
+);
+}
+);
+width = 463;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152A;
+unicode = 5418;
+},
+{
+glyphname = "yoo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (293,0);
+ref = dot_top;
+}
+);
+width = 463;
+}
+);
+note = uni152B;
+unicode = 5419;
+},
+{
+glyphname = "ycreeyoo-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (145,0);
+ref = doubledot_top;
+}
+);
+width = 463;
+}
+);
+note = uni152C;
+unicode = 5420;
+},
+{
+glyphname = "ya-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (198,690);
+},
+{
+name = top_right_can;
+pos = (477,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(465,417,l),
+(470,447,l),
+(191,447,l),
+(243,690,l),
+(153,690,l),
+(84,367,l),
+(343,367,l),
+(337,396,l),
+(6,43,l),
+(68,-12,l)
+);
+}
+);
+width = 463;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152D;
+unicode = 5421;
+},
+{
+glyphname = "yaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (35,0);
+ref = dot_top;
+}
+);
+width = 463;
+}
+);
+note = uni152E;
+unicode = 5422;
+},
+{
+glyphname = "ywe-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ye-canadian";
+}
+);
+width = 647;
+}
+);
+note = uni152F;
+unicode = 5423;
+},
+{
+glyphname = "yweWestCree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ye-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (463,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 647;
+}
+);
+note = uni1530;
+unicode = 5424;
+},
+{
+glyphname = "ywi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "yi-canadian";
+}
+);
+width = 647;
+}
+);
+note = uni1531;
+unicode = 5425;
+},
+{
+glyphname = "ywiWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (463,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 647;
+}
+);
+note = uni1532;
+unicode = 5426;
+},
+{
+glyphname = "ywii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (221,0);
+ref = dot_top;
+}
+);
+width = 647;
+}
+);
+note = uni1533;
+unicode = 5427;
+},
+{
+glyphname = "ywiiWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (463,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 647;
+}
+);
+note = uni1534;
+unicode = 5428;
+},
+{
+glyphname = "ywo-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "yo-canadian";
+}
+);
+width = 647;
+}
+);
+note = uni1535;
+unicode = 5429;
+},
+{
+glyphname = "ywoWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (463,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 647;
+}
+);
+note = uni1536;
+unicode = 5430;
+},
+{
+glyphname = "ywoo-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (477,0);
+ref = dot_top;
+}
+);
+width = 647;
+}
+);
+note = uni1537;
+unicode = 5431;
+},
+{
+glyphname = "ywooWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (293,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (463,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 647;
+}
+);
+note = uni1538;
+unicode = 5432;
+},
+{
+glyphname = "ywa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ya-canadian";
+}
+);
+width = 647;
+}
+);
+note = uni1539;
+unicode = 5433;
+},
+{
+glyphname = "ywaWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (463,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 647;
+}
+);
+note = uni153A;
+unicode = 5434;
+},
+{
+glyphname = "ywaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (219,0);
+ref = dot_top;
+}
+);
+width = 647;
+}
+);
+note = uni153B;
+unicode = 5435;
+},
+{
+glyphname = "ywaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (35,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (463,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 647;
+}
+);
+note = uni153C;
+unicode = 5436;
+},
+{
+glyphname = "ywaaNaskapi-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (195,0);
+ref = "ya-canadian";
+}
+);
+width = 657;
+}
+);
+note = uni153D;
+unicode = 5437;
+},
+{
+glyphname = "y-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(315,549,l),
+(320,568,l),
+(185,568,l),
+(211,690,l),
+(150,690,l),
+(112,516,l),
+(245,516,l),
+(243,553,l),
+(77,373,l),
+(121,336,l)
+);
+}
+);
+width = 276;
+}
+);
+note = uni153E;
+unicode = 5438;
+},
+{
+glyphname = "biblecreey-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,345,l),
+(231,622,l),
+(197,623,l),
+(215,345,l),
+(251,345,l),
+(387,622,l),
+(353,622,l),
+(346,345,l),
+(401,345,l),
+(404,361,l),
+(411,690,l),
+(365,690,l),
+(223,404,l),
+(263,404,l),
+(244,690,l),
+(200,690,l),
+(66,361,l),
+(62,345,l)
+);
+}
+);
+width = 417;
+}
+);
+metricRight = "=|";
+note = uni153F;
+unicode = 5439;
+},
+{
+glyphname = "yWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(202,209,l),
+(227,327,l),
+(327,327,l),
+(340,385,l),
+(240,385,l),
+(264,499,l),
+(206,499,l),
+(182,385,l),
+(80,385,l),
+(68,327,l),
+(168,327,l),
+(144,209,l)
+);
+}
+);
+width = 358;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1540;
+unicode = 5440;
+},
+{
+glyphname = "yiSayisi-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (39,183);
+ref = "fullstop-canadian";
+}
+);
+width = 300;
+}
+);
+metricLeft = "fullstop-canadian";
+metricWidth = "fullstop-canadian";
+note = uni1541;
+unicode = 5441;
+},
+{
+glyphname = "re-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (299,497);
+},
+{
+name = top_left_can;
+pos = (157,497);
+},
+{
+name = top_right_can;
+pos = (651,497);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(324,-13,o),
+(392,53,o),
+(423,200,cs),
+(466,396,l),
+(674,396,l),
+(692,478,l),
+(394,478,l),
+(334,196,ls),
+(315,105,o),
+(279,67,o),
+(218,67,cs),
+(151,67,o),
+(122,115,o),
+(141,204,cs),
+(199,478,l),
+(109,478,l),
+(54,219,ls),
+(23,77,o),
+(85,-13,o),
+(214,-13,cs)
+);
+}
+);
+width = 687;
+}
+);
+metricRight = "=|ne-canadian";
+note = uni1542;
+unicode = 5442;
+},
+{
+glyphname = "reRCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (496,497);
+},
+{
+name = top_left_can;
+pos = (146,497);
+},
+{
+name = top_right_can;
+pos = (639,497);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(521,-13,o),
+(589,53,o),
+(620,200,cs),
+(680,478,l),
+(589,478,l),
+(529,196,ls),
+(509,105,o),
+(473,67,o),
+(413,67,cs),
+(345,67,o),
+(317,115,o),
+(336,204,cs),
+(394,478,l),
+(97,478,l),
+(79,396,l),
+(289,396,l),
+(251,219,ls),
+(220,78,o),
+(282,-13,o),
+(412,-13,cs)
+);
+}
+);
+width = 687;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1543;
+unicode = 5443;
+},
+{
+glyphname = "leWestCree-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (497,497);
+},
+{
+name = top_left_can;
+pos = (145,497);
+},
+{
+name = top_right_can;
+pos = (639,497);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(293,0,l),
+(353,283,ls),
+(373,374,o),
+(409,412,o),
+(469,412,cs),
+(537,412,o),
+(565,364,o),
+(546,274,cs),
+(488,0,l),
+(578,0,l),
+(633,259,ls),
+(664,401,o),
+(602,492,o),
+(473,492,cs),
+(363,492,o),
+(296,425,o),
+(264,278,cs),
+(222,82,l),
+(13,82,l),
+(-5,0,l)
+);
+}
+);
+width = 687;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+unicode = 5444;
+},
+{
+glyphname = "raai-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (89,-193);
+ref = ring_top.canadian;
+}
+);
+width = 687;
+}
+);
+note = uni1545;
+unicode = 5445;
+},
+{
+glyphname = "ri-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (299,497);
+},
+{
+name = top_left_can;
+pos = (156,497);
+},
+{
+name = top_right_can;
+pos = (650,497);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,0,l),
+(157,283,ls),
+(177,374,o),
+(212,412,o),
+(274,412,cs),
+(341,412,o),
+(369,363,o),
+(351,274,cs),
+(292,0,l),
+(589,0,l),
+(607,82,l),
+(398,82,l),
+(436,259,ls),
+(466,401,o),
+(404,492,o),
+(280,492,cs),
+(165,492,o),
+(98,425,o),
+(66,278,cs),
+(7,0,l)
+);
+}
+);
+width = 686;
+}
+);
+metricLeft = "re-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+unicode = 5446;
+},
+{
+glyphname = "rii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (136,-193);
+ref = dot_top;
+}
+);
+width = 687;
+}
+);
+note = uni1547;
+unicode = 5447;
+},
+{
+glyphname = "ro-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (290,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,0,l),
+(160,283,l),
+(118,243,l),
+(191,243,ls),
+(385,243,o),
+(447,389,o),
+(447,511,cs),
+(447,621,o),
+(380,690,o),
+(264,690,cs),
+(158,690,l),
+(141,609,l),
+(247,609,ls),
+(320,609,o),
+(358,572,o),
+(358,504,cs),
+(358,414,o),
+(312,323,o),
+(187,323,cs),
+(78,323,l),
+(10,0,l)
+);
+}
+);
+width = 441;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1548;
+unicode = 5448;
+},
+{
+glyphname = "roo-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (126,0);
+ref = dot_top;
+}
+);
+width = 440;
+}
+);
+note = uni1549;
+unicode = 5449;
+},
+{
+glyphname = "loWestCree-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (301,690);
+},
+{
+name = top_left_can;
+pos = (202,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(140,0,ls),
+(333,0,o),
+(396,146,o),
+(396,268,cs),
+(396,378,o),
+(328,446,o),
+(213,446,cs),
+(156,446,l),
+(186,406,l),
+(246,690,l),
+(157,690,l),
+(88,367,l),
+(196,367,ls),
+(269,367,o),
+(307,330,o),
+(307,263,cs),
+(307,173,o),
+(261,82,o),
+(136,82,cs),
+(27,82,l),
+(10,0,l)
+);
+}
+);
+width = 442;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+unicode = 5450;
+},
+{
+glyphname = "ra-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (343,690);
+},
+{
+name = top_right_can;
+pos = (431,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(330,0,l),
+(399,323,l),
+(291,323,ls),
+(218,323,o),
+(180,359,o),
+(180,427,cs),
+(180,517,o),
+(226,608,o),
+(351,608,cs),
+(460,608,l),
+(477,690,l),
+(347,690,ls),
+(154,690,o),
+(91,544,o),
+(91,422,cs),
+(91,312,o),
+(158,243,o),
+(274,243,cs),
+(331,243,l),
+(300,284,l),
+(240,0,l)
+);
+}
+);
+width = 442;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+unicode = 5451;
+},
+{
+glyphname = "raa-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (179,0);
+ref = dot_top;
+}
+);
+width = 440;
+}
+);
+note = uni154C;
+unicode = 5452;
+},
+{
+glyphname = "laWestCree-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (431,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(328,0,l),
+(346,81,l),
+(239,81,ls),
+(166,81,o),
+(127,118,o),
+(127,185,cs),
+(127,275,o),
+(174,367,o),
+(298,367,cs),
+(408,367,l),
+(476,690,l),
+(386,690,l),
+(326,407,l),
+(369,446,l),
+(295,446,ls),
+(101,446,o),
+(39,300,o),
+(39,179,cs),
+(39,69,o),
+(106,0,o),
+(222,0,cs)
+);
+}
+);
+width = 441;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+unicode = 5453;
+},
+{
+glyphname = "rwaa-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (363,0);
+ref = dot_top;
+}
+);
+width = 625;
+}
+);
+note = uni154E;
+unicode = 5454;
+},
+{
+glyphname = "rwaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (179,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (440,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 625;
+}
+);
+note = uni154F;
+unicode = 5455;
+},
+{
+glyphname = "r-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(235,345,l),
+(270,514,l),
+(224,514,ls),
+(189,514,o),
+(171,531,o),
+(171,561,cs),
+(171,600,o),
+(189,639,o),
+(250,639,cs),
+(297,639,l),
+(308,690,l),
+(260,690,ls),
+(164,690,o),
+(112,639,o),
+(112,559,cs),
+(112,503,o),
+(150,464,o),
+(213,464,cs),
+(236,464,l),
+(202,481,l),
+(173,345,l)
+);
+}
+);
+width = 262;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni1550;
+unicode = 5456;
+},
+{
+glyphname = "rWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(146,690,l),
+(138,651,l),
+(270,578,l),
+(276,611,l),
+(113,535,l),
+(107,505,l),
+(240,437,l),
+(246,466,l),
+(83,392,l),
+(72,345,l),
+(84,345,l),
+(283,434,l),
+(288,458,l),
+(154,529,l),
+(149,505,l),
+(314,577,l),
+(319,601,l),
+(157,690,l)
+);
+}
+);
+width = 291;
+}
+);
+metricLeft = "=|lWestCree-canadian";
+metricRight = "=|lWestCree-canadian";
+note = uni1551;
+unicode = 5457;
+},
+{
+glyphname = "rMedial-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(25,-13,l),
+(440,172,l),
+(448,210,l),
+(159,361,l),
+(153,328,l),
+(505,480,l),
+(513,518,l),
+(177,702,l),
+(154,702,l),
+(141,641,l),
+(427,485,l),
+(437,527,l),
+(83,371,l),
+(74,329,l),
+(363,183,l),
+(372,219,l),
+(18,62,l),
+(3,-13,l)
+);
+}
+);
+width = 509;
+}
+);
+metricLeft = "mediall-canadian";
+metricRight = "mediall-canadian";
+note = uni1552;
+unicode = 5458;
+},
+{
+glyphname = "fe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(267,0,l),
+(687,665,l),
+(693,690,l),
+(617,690,l),
+(257,102,l),
+(276,102,l),
+(222,360,l),
+(178,355,l),
+(193,335,o),
+(217,323,o),
+(251,323,cs),
+(369,323,o),
+(419,479,o),
+(419,565,cs),
+(419,648,o),
+(378,702,o),
+(302,702,cs),
+(182,702,o),
+(133,556,o),
+(133,454,cs),
+(133,423,o),
+(138,393,o),
+(148,358,cs),
+(236,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(220,382,o),
+(203,409,o),
+(203,456,cs),
+(203,511,o),
+(228,637,o),
+(298,637,cs),
+(331,637,o),
+(350,611,o),
+(350,563,cs),
+(350,508,o),
+(325,382,o),
+(255,382,cs)
+);
+}
+);
+width = 621;
+}
+);
+metricRight = "e-canadian";
+note = uni1553;
+unicode = 5459;
+},
+{
+glyphname = "faai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (184,0);
+ref = ring_top.canadian;
+}
+);
+width = 621;
+}
+);
+note = uni1554;
+unicode = 5460;
+},
+{
+glyphname = "fi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (393,690);
+},
+{
+name = top_left_can;
+pos = (209,690);
+},
+{
+name = top_right_can;
+pos = (600,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(303,-13,o),
+(346,137,o),
+(346,225,cs),
+(346,313,o),
+(304,368,o),
+(240,368,cs),
+(216,368,o),
+(189,357,o),
+(165,336,c),
+(219,337,l),
+(386,587,l),
+(364,587,l),
+(482,0,l),
+(545,0,l),
+(550,25,l),
+(409,690,l),
+(378,690,l),
+(136,341,ls),
+(91,275,o),
+(62,204,o),
+(62,124,cs),
+(62,41,o),
+(104,-13,o),
+(179,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(149,53,o),
+(131,79,o),
+(131,127,cs),
+(131,182,o),
+(156,308,o),
+(227,308,cs),
+(261,308,o),
+(277,280,o),
+(277,231,cs),
+(277,174,o),
+(251,53,o),
+(184,53,cs)
+);
+}
+);
+width = 620;
+}
+);
+metricLeft = "fe-canadian";
+metricRight = "e-canadian";
+note = uni1555;
+unicode = 5461;
+},
+{
+glyphname = "fii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (231,0);
+ref = dot_top;
+}
+);
+width = 621;
+}
+);
+note = uni1556;
+unicode = 5462;
+},
+{
+glyphname = "fo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (277,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(43,0,l),
+(539,328,l),
+(546,361,l),
+(368,641,ls),
+(344,679,o),
+(314,702,o),
+(267,702,cs),
+(161,702,o),
+(108,578,o),
+(99,484,cs),
+(89,384,o),
+(132,318,o),
+(210,318,cs),
+(307,318,o),
+(364,436,o),
+(373,529,cs),
+(375,561,o),
+(374,590,o),
+(370,611,c),
+(335,561,l),
+(475,343,l),
+(483,377,l),
+(38,81,l),
+(20,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(182,383,o),
+(164,416,o),
+(169,478,cs),
+(174,542,o),
+(198,639,o),
+(262,639,cs),
+(298,639,o),
+(315,606,o),
+(311,544,cs),
+(306,480,o),
+(282,383,o),
+(218,383,cs)
+);
+}
+);
+width = 549;
+}
+);
+metricRight = "o-canadian";
+note = uni1557;
+unicode = 5463;
+},
+{
+glyphname = "foo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "fo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (113,0);
+ref = dot_top;
+}
+);
+width = 550;
+}
+);
+note = uni1558;
+unicode = 5464;
+},
+{
+glyphname = "fa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (466,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(428,0,l),
+(442,68,l),
+(129,356,l),
+(125,334,l),
+(354,558,l),
+(334,625,l),
+(300,569,o),
+(285,502,o),
+(285,454,cs),
+(285,370,o),
+(329,316,o),
+(404,316,cs),
+(518,316,o),
+(568,470,o),
+(568,561,cs),
+(568,649,o),
+(524,702,o),
+(454,702,cs),
+(414,702,o),
+(380,686,o),
+(344,650,cs),
+(55,361,l),
+(48,328,l),
+(405,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(370,381,o),
+(353,408,o),
+(353,455,cs),
+(353,510,o),
+(378,637,o),
+(447,637,cs),
+(481,637,o),
+(499,611,o),
+(499,563,cs),
+(499,508,o),
+(474,381,o),
+(404,381,cs)
+);
+}
+);
+width = 551;
+}
+);
+metricRight = "=|fo-canadian";
+note = uni1559;
+unicode = 5465;
+},
+{
+glyphname = "faa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (301,0);
+ref = dot_top;
+}
+);
+width = 550;
+}
+);
+note = uni155A;
+unicode = 5466;
+},
+{
+glyphname = "fwaa-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (487,0);
+ref = dot_top;
+}
+);
+width = 734;
+}
+);
+note = uni155B;
+unicode = 5467;
+},
+{
+glyphname = "fwaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (301,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (550,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 734;
+}
+);
+note = uni155C;
+unicode = 5468;
+},
+{
+glyphname = "f-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(287,345,l),
+(295,386,l),
+(144,526,l),
+(143,513,l),
+(249,619,l),
+(245,659,l),
+(230,636,o),
+(217,595,o),
+(217,568,cs),
+(217,528,o),
+(240,501,o),
+(274,501,cs),
+(330,501,o),
+(356,575,o),
+(356,627,cs),
+(356,670,o),
+(337,696,o),
+(301,696,cs),
+(281,696,o),
+(264,687,o),
+(244,668,cs),
+(100,526,l),
+(97,507,l),
+(274,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(260,537,o),
+(252,549,o),
+(252,570,cs),
+(252,595,o),
+(265,660,o),
+(297,660,cs),
+(311,660,o),
+(320,649,o),
+(320,628,cs),
+(320,603,o),
+(307,537,o),
+(275,537,cs)
+);
+}
+);
+width = 323;
+}
+);
+note = uni155D;
+unicode = 5469;
+},
+{
+glyphname = "the-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (664,345);
+},
+{
+name = top_center_can;
+pos = (392,690);
+},
+{
+name = top_left_can;
+pos = (198,690);
+},
+{
+name = top_right_can;
+pos = (584,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(412,-13,o),
+(496,63,o),
+(530,226,cs),
+(630,690,l),
+(539,690,l),
+(442,235,ls),
+(418,122,o),
+(366,71,o),
+(274,71,cs),
+(147,71,o),
+(128,154,o),
+(152,264,cs),
+(187,426,l),
+(143,404,l),
+(147,358,o),
+(175,315,o),
+(225,315,cs),
+(337,315,o),
+(386,440,o),
+(397,538,cs),
+(409,639,o),
+(366,702,o),
+(281,702,cs),
+(197,702,o),
+(142,636,o),
+(115,511,cs),
+(65,272,ls),
+(30,106,o),
+(88,-13,o),
+(270,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,381,o),
+(182,408,o),
+(182,455,cs),
+(182,510,o),
+(208,637,o),
+(277,637,cs),
+(311,637,o),
+(328,611,o),
+(328,563,cs),
+(328,507,o),
+(303,381,o),
+(234,381,cs)
+);
+}
+);
+width = 591;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155E;
+unicode = 5470;
+},
+{
+glyphname = "theNCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(413,-13,o),
+(495,66,o),
+(532,239,cs),
+(585,490,ls),
+(615,629,o),
+(562,702,o),
+(480,702,cs),
+(360,702,o),
+(312,556,o),
+(312,456,cs),
+(312,376,o),
+(351,315,o),
+(424,315,cs),
+(465,315,o),
+(504,342,o),
+(525,384,c),
+(481,413,l),
+(444,242,ls),
+(418,120,o),
+(368,69,o),
+(273,69,cs),
+(163,69,o),
+(125,132,o),
+(150,255,cs),
+(242,690,l),
+(153,690,l),
+(62,262,ls),
+(25,89,o),
+(102,-13,o),
+(268,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(399,381,o),
+(381,408,o),
+(381,455,cs),
+(381,510,o),
+(407,637,o),
+(475,637,cs),
+(508,637,o),
+(526,611,o),
+(526,563,cs),
+(526,507,o),
+(500,381,o),
+(432,381,cs)
+);
+}
+);
+width = 589;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155F;
+unicode = 5471;
+},
+{
+glyphname = "thi-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (388,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(274,-13,o),
+(323,133,o),
+(323,234,cs),
+(323,314,o),
+(284,375,o),
+(211,375,cs),
+(170,375,o),
+(130,348,o),
+(110,305,c),
+(154,276,l),
+(190,447,ls),
+(216,570,o),
+(268,621,o),
+(361,621,cs),
+(471,621,o),
+(511,557,o),
+(485,435,cs),
+(392,0,l),
+(483,0,l),
+(574,428,ls),
+(610,601,o),
+(532,702,o),
+(367,702,cs),
+(221,702,o),
+(140,624,o),
+(102,451,cs),
+(49,200,ls),
+(19,61,o),
+(72,-13,o),
+(155,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(127,53,o),
+(109,79,o),
+(109,127,cs),
+(109,183,o),
+(134,309,o),
+(203,309,cs),
+(236,309,o),
+(254,282,o),
+(254,235,cs),
+(254,180,o),
+(228,53,o),
+(159,53,cs)
+);
+}
+);
+width = 591;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1560;
+unicode = 5472;
+},
+{
+glyphname = "thiNCree-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (388,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(439,-13,o),
+(495,54,o),
+(521,179,cs),
+(571,417,ls),
+(606,583,o),
+(548,702,o),
+(365,702,cs),
+(223,702,o),
+(140,627,o),
+(105,464,cs),
+(7,0,l),
+(97,0,l),
+(193,455,ls),
+(217,568,o),
+(270,619,o),
+(361,619,cs),
+(489,619,o),
+(509,536,o),
+(484,426,cs),
+(448,264,l),
+(494,286,l),
+(490,331,o),
+(461,375,o),
+(411,375,cs),
+(299,375,o),
+(250,249,o),
+(239,152,cs),
+(228,51,o),
+(271,-13,o),
+(355,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(326,53,o),
+(307,79,o),
+(307,127,cs),
+(307,183,o),
+(332,309,o),
+(403,309,cs),
+(437,309,o),
+(454,282,o),
+(454,235,cs),
+(454,180,o),
+(429,53,o),
+(358,53,cs)
+);
+}
+);
+width = 591;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1561;
+unicode = 5473;
+},
+{
+glyphname = "thii-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "thi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (224,0);
+ref = dot_top;
+}
+);
+width = 589;
+}
+);
+note = uni1562;
+unicode = 5474;
+},
+{
+glyphname = "thiiNCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "thiNCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (224,0);
+ref = dot_top;
+}
+);
+width = 589;
+}
+);
+note = uni1563;
+unicode = 5475;
+},
+{
+glyphname = "tho-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (344,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(171,0,ls),
+(448,0,o),
+(525,279,o),
+(525,447,cs),
+(525,603,o),
+(451,702,o),
+(326,702,cs),
+(169,702,o),
+(100,553,o),
+(100,431,cs),
+(100,345,o),
+(141,290,o),
+(213,290,cs),
+(330,290,o),
+(375,440,o),
+(375,529,cs),
+(375,603,o),
+(344,651,o),
+(288,658,c),
+(270,633,l),
+(276,639,o),
+(292,644,o),
+(313,644,cs),
+(394,644,o),
+(440,575,o),
+(440,460,cs),
+(440,339,o),
+(395,83,o),
+(175,83,cs),
+(47,83,l),
+(30,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(188,355,o),
+(171,381,o),
+(171,428,cs),
+(171,478,o),
+(197,620,o),
+(268,620,cs),
+(300,620,o),
+(318,593,o),
+(318,547,cs),
+(318,497,o),
+(293,355,o),
+(222,355,cs)
+);
+}
+);
+width = 540;
+}
+);
+metricRight = "to-canadian";
+note = uni1564;
+unicode = 5476;
+},
+{
+glyphname = "thoo-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "tho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (180,0);
+ref = dot_top;
+}
+);
+width = 541;
+}
+);
+note = uni1565;
+unicode = 5477;
+},
+{
+glyphname = "tha-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (393,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(410,0,l),
+(427,83,l),
+(312,83,ls),
+(205,83,o),
+(148,141,o),
+(148,255,cs),
+(148,377,o),
+(216,644,o),
+(377,644,cs),
+(403,644,o),
+(427,637,o),
+(444,622,c),
+(421,656,l),
+(309,664,o),
+(265,511,o),
+(265,424,cs),
+(265,341,o),
+(304,290,o),
+(374,290,cs),
+(483,290,o),
+(542,422,o),
+(542,529,cs),
+(542,638,o),
+(479,702,o),
+(375,702,cs),
+(155,702,o),
+(60,416,o),
+(60,249,cs),
+(60,94,o),
+(147,0,o),
+(295,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(344,355,o),
+(326,381,o),
+(326,428,cs),
+(326,478,o),
+(353,620,o),
+(423,620,cs),
+(456,620,o),
+(473,593,o),
+(473,547,cs),
+(473,497,o),
+(448,355,o),
+(377,355,cs)
+);
+}
+);
+width = 539;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tho-canadian";
+note = uni1566;
+unicode = 5478;
+},
+{
+glyphname = "thaa-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (230,0);
+ref = dot_top;
+}
+);
+width = 541;
+}
+);
+note = uni1567;
+unicode = 5479;
+},
+{
+glyphname = "thwaa-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (415,0);
+ref = dot_top;
+}
+);
+width = 726;
+}
+);
+note = uni1568;
+unicode = 5480;
+},
+{
+glyphname = "thwaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (230,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (541,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 726;
+}
+);
+note = uni1569;
+unicode = 5481;
+},
+{
+glyphname = "th-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(275,345,l),
+(287,397,l),
+(232,397,ls),
+(181,397,o),
+(155,425,o),
+(155,477,cs),
+(155,535,o),
+(187,656,o),
+(265,656,cs),
+(275,656,o),
+(286,654,o),
+(295,649,c),
+(278,668,l),
+(224,668,o),
+(203,591,o),
+(203,554,cs),
+(203,514,o),
+(223,487,o),
+(258,487,cs),
+(320,487,o),
+(342,570,o),
+(342,612,cs),
+(342,664,o),
+(313,696,o),
+(259,696,cs),
+(147,696,o),
+(101,554,o),
+(101,474,cs),
+(101,394,o),
+(146,345,o),
+(222,345,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(243,523,o),
+(235,533,o),
+(235,554,cs),
+(235,580,o),
+(246,645,o),
+(281,645,cs),
+(297,645,o),
+(304,635,o),
+(304,613,cs),
+(304,588,o),
+(293,523,o),
+(259,523,cs)
+);
+}
+);
+width = 310;
+}
+);
+metricLeft = "t-canadian";
+note = uni156A;
+unicode = 5482;
+},
+{
+glyphname = "tthe-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (655,345);
+},
+{
+name = top_center_can;
+pos = (386,690);
+},
+{
+name = top_left_can;
+pos = (198,690);
+},
+{
+name = top_right_can;
+pos = (576,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(405,-13,o),
+(488,65,o),
+(523,226,cs),
+(621,690,l),
+(537,690,l),
+(440,236,ls),
+(415,121,o),
+(364,71,o),
+(271,71,cs),
+(159,71,o),
+(118,131,o),
+(144,255,cs),
+(237,690,l),
+(153,690,l),
+(62,262,ls),
+(25,89,o),
+(102,-13,o),
+(266,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(355,387,l),
+(420,690,l),
+(353,690,l),
+(288,387,l)
+);
+}
+);
+width = 583;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156B;
+unicode = 5483;
+},
+{
+glyphname = "tthi-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(91,0,l),
+(187,454,ls),
+(212,569,o),
+(264,618,o),
+(356,618,cs),
+(468,618,o),
+(510,558,o),
+(484,435,cs),
+(391,0,l),
+(475,0,l),
+(566,428,ls),
+(603,601,o),
+(525,702,o),
+(362,702,cs),
+(222,702,o),
+(139,625,o),
+(105,464,cs),
+(7,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(275,0,l),
+(339,302,l),
+(271,302,l),
+(207,0,l)
+);
+}
+);
+width = 583;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156C;
+unicode = 5484;
+},
+{
+glyphname = "ttho-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (332,690);
+},
+{
+name = top_left_can;
+pos = (193,690);
+},
+{
+name = top_right_can;
+pos = (511,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,0,ls),
+(417,0,o),
+(488,281,o),
+(488,441,cs),
+(488,602,o),
+(398,690,o),
+(236,690,cs),
+(155,690,l),
+(137,607,l),
+(219,607,ls),
+(338,607,o),
+(397,551,o),
+(397,437,cs),
+(397,317,o),
+(346,83,o),
+(125,83,cs),
+(25,83,l),
+(8,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(255,307,l),
+(271,384,l),
+(90,384,l),
+(73,307,l)
+);
+}
+);
+width = 504;
+}
+);
+metricRight = "to-canadian";
+note = uni156D;
+unicode = 5485;
+},
+{
+glyphname = "ttha-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (348,690);
+},
+{
+name = top_left_can;
+pos = (185,690);
+},
+{
+name = top_right_can;
+pos = (494,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(394,0,l),
+(411,83,l),
+(326,83,ls),
+(209,83,o),
+(152,139,o),
+(152,252,cs),
+(152,381,o),
+(207,607,o),
+(422,607,cs),
+(524,607,l),
+(541,690,l),
+(426,690,ls),
+(135,690,o),
+(61,415,o),
+(61,247,cs),
+(61,88,o),
+(148,0,o),
+(311,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(457,307,l),
+(472,384,l),
+(292,384,l),
+(275,307,l)
+);
+}
+);
+width = 504;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|ttho-canadian";
+note = uni156E;
+unicode = 5486;
+},
+{
+glyphname = "tth-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(245,495,l),
+(223,495,l),
+(281,377,l),
+(329,400,l),
+(269,524,l),
+(257,501,l),
+(388,554,l),
+(371,601,l),
+(248,552,l),
+(268,540,l),
+(299,690,l),
+(245,690,l),
+(213,540,l),
+(236,551,l),
+(127,601,l),
+(105,554,l),
+(210,506,l),
+(207,527,l),
+(101,411,l),
+(139,377,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(575,495,l),
+(553,495,l),
+(611,377,l),
+(659,400,l),
+(598,524,l),
+(587,501,l),
+(718,554,l),
+(700,600,l),
+(578,552,l),
+(597,540,l),
+(629,690,l),
+(575,690,l),
+(543,540,l),
+(566,551,l),
+(456,601,l),
+(435,554,l),
+(540,506,l),
+(537,527,l),
+(431,411,l),
+(469,377,l)
+);
+}
+);
+width = 689;
+}
+);
+metricRight = "=|";
+note = uni156F;
+unicode = 5487;
+},
+{
+glyphname = "tye-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(405,-13,o),
+(488,66,o),
+(523,226,cs),
+(621,690,l),
+(537,690,l),
+(440,236,ls),
+(415,121,o),
+(364,71,o),
+(271,71,cs),
+(159,71,o),
+(118,131,o),
+(144,255,cs),
+(237,690,l),
+(153,690,l),
+(62,262,ls),
+(25,89,o),
+(102,-13,o),
+(266,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(391,412,o),
+(423,443,o),
+(439,514,cs),
+(476,690,l),
+(435,690,l),
+(399,521,ls),
+(388,474,o),
+(371,455,o),
+(338,455,cs),
+(304,455,o),
+(294,473,o),
+(303,518,cs),
+(339,690,l),
+(298,690,l),
+(260,515,ls),
+(246,450,o),
+(275,412,o),
+(336,412,cs)
+);
+}
+);
+width = 583;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1570;
+unicode = 5488;
+},
+{
+glyphname = "tyi-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(91,0,l),
+(187,454,ls),
+(212,569,o),
+(264,618,o),
+(356,618,cs),
+(468,618,o),
+(510,558,o),
+(484,435,cs),
+(391,0,l),
+(475,0,l),
+(566,428,ls),
+(603,601,o),
+(525,702,o),
+(362,702,cs),
+(222,702,o),
+(139,624,o),
+(105,464,cs),
+(7,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(193,0,l),
+(229,169,ls),
+(239,215,o),
+(257,235,o),
+(290,235,cs),
+(323,235,o),
+(334,216,o),
+(325,172,cs),
+(289,0,l),
+(330,0,l),
+(367,175,ls),
+(382,240,o),
+(353,278,o),
+(292,278,cs),
+(237,278,o),
+(204,246,o),
+(188,176,cs),
+(152,0,l)
+);
+}
+);
+width = 583;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1571;
+unicode = 5489;
+},
+{
+glyphname = "tyo-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(120,0,ls),
+(417,0,o),
+(490,281,o),
+(490,441,cs),
+(490,602,o),
+(399,690,o),
+(235,690,cs),
+(156,690,l),
+(139,609,l),
+(220,609,ls),
+(338,609,o),
+(399,551,o),
+(399,437,cs),
+(399,285,o),
+(317,81,o),
+(124,81,cs),
+(27,81,l),
+(11,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(106,212,ls),
+(218,212,o),
+(258,283,o),
+(264,357,cs),
+(270,433,o),
+(230,478,o),
+(159,478,cs),
+(112,478,l),
+(100,429,l),
+(149,429,ls),
+(193,429,o),
+(215,406,o),
+(213,362,cs),
+(211,315,o),
+(190,261,o),
+(112,261,cs),
+(66,261,l),
+(55,212,l)
+);
+}
+);
+width = 506;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1572;
+unicode = 5490;
+},
+{
+glyphname = "tya-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(393,0,l),
+(411,81,l),
+(329,81,ls),
+(212,81,o),
+(151,139,o),
+(151,253,cs),
+(151,405,o),
+(233,609,o),
+(427,609,cs),
+(523,609,l),
+(539,690,l),
+(431,690,ls),
+(132,690,o),
+(61,409,o),
+(61,248,cs),
+(61,88,o),
+(152,0,o),
+(315,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(439,212,l),
+(449,261,l),
+(402,261,ls),
+(356,261,o),
+(334,284,o),
+(337,327,cs),
+(339,375,o),
+(360,429,o),
+(438,429,cs),
+(484,429,l),
+(495,478,l),
+(443,478,ls),
+(332,478,o),
+(293,407,o),
+(286,332,cs),
+(279,257,o),
+(320,212,o),
+(391,212,cs)
+);
+}
+);
+width = 505;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1573;
+unicode = 5491;
+},
+{
+glyphname = "heNunavik-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(363,0,l),
+(595,192,l),
+(546,255,l),
+(364,103,l),
+(391,83,l),
+(465,431,ls),
+(493,562,o),
+(468,702,o),
+(318,702,cs),
+(144,702,o),
+(88,497,o),
+(88,373,cs),
+(88,263,o),
+(138,198,o),
+(230,198,cs),
+(288,198,o),
+(332,231,o),
+(362,298,c),
+(348,301,l),
+(283,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(202,276,o),
+(175,310,o),
+(175,377,cs),
+(175,446,o),
+(207,625,o),
+(310,625,cs),
+(361,625,o),
+(388,591,o),
+(388,525,cs),
+(388,455,o),
+(356,276,o),
+(254,276,cs)
+);
+}
+);
+width = 625;
+}
+);
+metricLeft = "ke-canadian";
+note = uni1574;
+unicode = 5492;
+},
+{
+glyphname = "hiNunavik-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (482,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(241,0,l),
+(313,340,l),
+(295,303,l),
+(294,243,o),
+(338,198,o),
+(409,198,cs),
+(571,198,o),
+(627,407,o),
+(627,524,cs),
+(627,638,o),
+(570,702,o),
+(468,702,cs),
+(357,702,o),
+(282,623,o),
+(250,470,cs),
+(167,79,l),
+(196,87,l),
+(73,244,l),
+(10,192,l),
+(160,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(354,276,o),
+(326,310,o),
+(326,377,cs),
+(326,446,o),
+(361,625,o),
+(462,625,cs),
+(514,625,o),
+(541,591,o),
+(541,526,cs),
+(541,453,o),
+(508,276,o),
+(406,276,cs)
+);
+}
+);
+width = 625;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1575;
+unicode = 5493;
+},
+{
+glyphname = "hiiNunavik-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "hiNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (319,0);
+ref = dot_top;
+}
+);
+width = 625;
+}
+);
+note = uni1576;
+unicode = 5494;
+},
+{
+glyphname = "hoNunavik-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (331,690);
+},
+{
+name = top_right_can;
+pos = (475,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(314,-13,o),
+(388,67,o),
+(421,219,cs),
+(503,611,l),
+(474,603,l),
+(598,445,l),
+(661,497,l),
+(510,690,l),
+(431,690,l),
+(358,350,l),
+(376,386,l),
+(377,446,o),
+(333,492,o),
+(263,492,cs),
+(100,492,o),
+(43,283,o),
+(43,166,cs),
+(43,52,o),
+(100,-13,o),
+(202,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(157,65,o),
+(130,99,o),
+(130,164,cs),
+(130,237,o),
+(163,413,o),
+(265,413,cs),
+(317,413,o),
+(344,380,o),
+(344,313,cs),
+(344,243,o),
+(310,65,o),
+(209,65,cs)
+);
+}
+);
+width = 626;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "heNunavik-canadian";
+note = uni1577;
+unicode = 5495;
+},
+{
+glyphname = "hooNunavik-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "hoNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (310,0);
+ref = dot_top;
+}
+);
+width = 625;
+}
+);
+note = uni1578;
+unicode = 5496;
+},
+{
+glyphname = "haNunavik-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (485,690);
+},
+{
+name = top_left_can;
+pos = (341,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(526,-13,o),
+(582,192,o),
+(582,317,cs),
+(582,427,o),
+(531,492,o),
+(440,492,cs),
+(383,492,o),
+(337,459,o),
+(308,391,c),
+(323,388,l),
+(387,690,l),
+(307,690,l),
+(75,497,l),
+(125,435,l),
+(306,586,l),
+(279,607,l),
+(205,259,ls),
+(177,128,o),
+(203,-13,o),
+(353,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(309,65,o),
+(281,99,o),
+(281,165,cs),
+(281,235,o),
+(313,413,o),
+(416,413,cs),
+(469,413,o),
+(496,380,o),
+(496,313,cs),
+(496,243,o),
+(464,65,o),
+(360,65,cs)
+);
+}
+);
+width = 625;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1579;
+unicode = 5497;
+},
+{
+glyphname = "haaNunavik-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "haNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (178,0);
+ref = dot_top;
+}
+);
+width = 625;
+}
+);
+note = uni157A;
+unicode = 5498;
+},
+{
+glyphname = "hNunavik-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(346,339,o),
+(382,451,o),
+(382,511,cs),
+(382,566,o),
+(354,601,o),
+(307,601,cs),
+(275,601,o),
+(252,585,o),
+(233,552,c),
+(242,535,l),
+(275,690,l),
+(220,690,l),
+(104,594,l),
+(135,558,l),
+(235,640,l),
+(213,672,l),
+(171,478,ls),
+(156,409,o),
+(178,339,o),
+(252,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(234,386,o),
+(220,403,o),
+(220,436,cs),
+(220,487,o),
+(243,554,o),
+(289,554,cs),
+(313,554,o),
+(327,537,o),
+(327,505,cs),
+(327,454,o),
+(302,386,o),
+(258,386,cs)
+);
+}
+);
+width = 368;
+}
+);
+metricRight = "k-canadian";
+note = uni157B;
+unicode = 5499;
+},
+{
+color = 4;
+glyphname = "nunavuth-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,0,l),
+(166,317,l),
+(424,317,l),
+(356,0,l),
+(447,0,l),
+(594,690,l),
+(503,690,l),
+(441,398,l),
+(184,398,l),
+(245,690,l),
+(156,690,l),
+(9,0,l)
+);
+}
+);
+width = 558;
+}
+);
+metricRight = "=|";
+note = uni157C;
+unicode = 5500;
+},
+{
+glyphname = "hk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (73,345);
+ref = "fullstop-canadian";
+}
+);
+width = 300;
+}
+);
+metricLeft = "fullstop-canadian";
+note = uni157D;
+unicode = 5501;
+},
+{
+glyphname = "qaai-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (261,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (389,0);
+ref = ring_top.canadian;
+}
+);
+width = 741;
+}
+);
+note = uni157E;
+unicode = 5502;
+},
+{
+glyphname = "qi-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (261,0);
+ref = "ki-canadian";
+}
+);
+width = 741;
+}
+);
+note = uni157F;
+unicode = 5503;
+},
+{
+glyphname = "qii-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (261,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (436,0);
+ref = dot_top;
+}
+);
+width = 741;
+}
+);
+note = uni1580;
+unicode = 5504;
+},
+{
+glyphname = "qo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (261,0);
+ref = "ko-canadian";
+}
+);
+width = 741;
+}
+);
+note = uni1581;
+unicode = 5505;
+},
+{
+glyphname = "qoo-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (261,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (572,0);
+ref = dot_top;
+}
+);
+width = 741;
+}
+);
+note = uni1582;
+unicode = 5506;
+},
+{
+glyphname = "qa-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (261,0);
+ref = "ka-canadian";
+}
+);
+width = 741;
+}
+);
+note = uni1583;
+unicode = 5507;
+},
+{
+glyphname = "qaa-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (261,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (294,0);
+ref = dot_top;
+}
+);
+width = 741;
+}
+);
+note = uni1584;
+unicode = 5508;
+},
+{
+glyphname = "q-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (261,0);
+ref = "k-canadian";
+}
+);
+width = 558;
+}
+);
+note = uni1585;
+unicode = 5509;
+},
+{
+glyphname = "tlhe-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (340,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(112,0,l),
+(273,270,l),
+(207,234,l),
+(215,233,o),
+(225,232,o),
+(233,232,cs),
+(289,232,o),
+(333,256,o),
+(370,310,c),
+(362,335,l),
+(291,0,l),
+(381,0,l),
+(476,453,ls),
+(501,572,o),
+(475,702,o),
+(327,702,cs),
+(162,702,o),
+(99,530,o),
+(99,406,cs),
+(99,336,o),
+(126,284,o),
+(175,260,c),
+(17,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(211,310,o),
+(185,346,o),
+(185,409,cs),
+(185,477,o),
+(217,625,o),
+(318,625,cs),
+(372,625,o),
+(396,588,o),
+(396,529,cs),
+(396,460,o),
+(363,310,o),
+(264,310,cs)
+);
+}
+);
+width = 489;
+}
+);
+metricRight = "te-canadian";
+note = uni1586;
+unicode = 5510;
+},
+{
+glyphname = "tlhi-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(96,0,l),
+(169,348,l),
+(137,333,l),
+(156,273,o),
+(197,238,o),
+(261,235,c),
+(230,254,l),
+(275,0,l),
+(369,0,l),
+(325,249,l),
+(442,275,o),
+(489,426,o),
+(489,524,cs),
+(489,633,o),
+(428,702,o),
+(324,702,cs),
+(219,702,o),
+(141,631,o),
+(108,479,cs),
+(7,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(216,310,o),
+(188,346,o),
+(188,410,cs),
+(188,477,o),
+(222,625,o),
+(321,625,cs),
+(374,625,o),
+(401,589,o),
+(401,526,cs),
+(401,457,o),
+(369,310,o),
+(270,310,cs)
+);
+}
+);
+width = 491;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|tlhe-canadian";
+note = uni1587;
+unicode = 5511;
+},
+{
+glyphname = "tlho-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (353,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(317,-13,o),
+(395,59,o),
+(428,211,cs),
+(529,690,l),
+(441,690,l),
+(366,342,l),
+(398,356,l),
+(380,416,o),
+(339,452,o),
+(275,455,c),
+(306,436,l),
+(261,690,l),
+(167,690,l),
+(212,440,l),
+(94,414,o),
+(48,264,o),
+(48,166,cs),
+(48,57,o),
+(108,-13,o),
+(213,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(162,65,o),
+(135,100,o),
+(135,164,cs),
+(135,233,o),
+(167,380,o),
+(267,380,cs),
+(319,380,o),
+(347,344,o),
+(347,280,cs),
+(347,213,o),
+(313,65,o),
+(215,65,cs)
+);
+}
+);
+width = 491;
+}
+);
+metricLeft = "tlhe-canadian";
+metricRight = "te-canadian";
+note = uni1588;
+unicode = 5512;
+},
+{
+glyphname = "tlha-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(371,-13,o),
+(434,159,o),
+(434,284,cs),
+(434,354,o),
+(408,406,o),
+(358,430,c),
+(516,690,l),
+(422,690,l),
+(261,419,l),
+(328,456,l),
+(318,457,o),
+(309,458,o),
+(300,458,cs),
+(245,458,o),
+(200,434,o),
+(164,380,c),
+(172,355,l),
+(243,690,l),
+(154,690,l),
+(57,237,ls),
+(32,118,o),
+(58,-13,o),
+(206,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(161,65,o),
+(137,101,o),
+(137,160,cs),
+(137,230,o),
+(170,380,o),
+(270,380,cs),
+(323,380,o),
+(349,344,o),
+(349,281,cs),
+(349,213,o),
+(316,65,o),
+(216,65,cs)
+);
+}
+);
+width = 489;
+}
+);
+metricLeft = "te-canadian";
+note = uni1589;
+unicode = 5513;
+},
+{
+glyphname = "reWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(357,0,l),
+(589,194,l),
+(539,255,l),
+(358,103,l),
+(385,83,l),
+(466,464,ls),
+(497,613,o),
+(435,702,o),
+(313,702,cs),
+(197,702,o),
+(131,633,o),
+(99,480,cs),
+(79,387,l),
+(168,387,l),
+(190,491,ls),
+(211,583,o),
+(244,623,o),
+(302,623,cs),
+(371,623,o),
+(400,575,o),
+(380,481,cs),
+(277,0,l)
+);
+}
+);
+width = 619;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+unicode = 5514;
+},
+{
+glyphname = "riWestCree-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(239,0,l),
+(343,491,ls),
+(362,583,o),
+(397,623,o),
+(455,623,cs),
+(523,623,o),
+(553,575,o),
+(532,481,cs),
+(512,387,l),
+(602,387,l),
+(618,464,ls),
+(650,613,o),
+(586,702,o),
+(465,702,cs),
+(349,702,o),
+(283,633,o),
+(251,480,cs),
+(167,83,l),
+(196,90,l),
+(76,246,l),
+(10,194,l),
+(158,0,l)
+);
+}
+);
+width = 619;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+unicode = 5515;
+},
+{
+glyphname = "roWestCree-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(315,-13,o),
+(381,57,o),
+(413,210,cs),
+(498,607,l),
+(468,600,l),
+(587,443,l),
+(655,496,l),
+(505,690,l),
+(425,690,l),
+(322,199,ls),
+(301,106,o),
+(267,67,o),
+(209,67,cs),
+(141,67,o),
+(111,115,o),
+(131,209,cs),
+(152,302,l),
+(62,302,l),
+(45,226,ls),
+(14,76,o),
+(77,-13,o),
+(199,-13,cs)
+);
+}
+);
+width = 620;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+unicode = 5516;
+},
+{
+glyphname = "raWestCree-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(468,-13,o),
+(533,57,o),
+(566,210,cs),
+(585,302,l),
+(497,302,l),
+(474,199,ls),
+(454,106,o),
+(420,67,o),
+(362,67,cs),
+(294,67,o),
+(265,115,o),
+(285,209,cs),
+(387,690,l),
+(307,690,l),
+(75,496,l),
+(126,435,l),
+(306,586,l),
+(279,607,l),
+(199,226,ls),
+(167,76,o),
+(230,-13,o),
+(352,-13,cs)
+);
+}
+);
+width = 620;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+unicode = 5517;
+},
+{
+glyphname = "ngaai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:46 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (507,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (634,0);
+ref = ring_top.canadian;
+}
+);
+width = 983;
+}
+);
+note = uni158E;
+unicode = 5518;
+},
+{
+glyphname = "ngi-canadian";
+kernLeft = mwestleft;
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:46 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (507,0);
+ref = "ci-canadian";
+}
+);
+width = 983;
+}
+);
+note = uni158F;
+unicode = 5519;
+},
+{
+glyphname = "ngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:46 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (507,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (682,0);
+ref = dot_top;
+}
+);
+width = 983;
+}
+);
+note = uni1590;
+unicode = 5520;
+},
+{
+glyphname = "ngo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:55:46 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (483,0);
+ref = "co-canadian";
+}
+);
+width = 960;
+}
+);
+note = uni1591;
+unicode = 5521;
+},
+{
+glyphname = "ngoo-canadian";
+lastChange = "2023-01-13 15:55:46 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "ngo-canadian";
+},
+{
+anchor = top_right_can;
+pos = (790,0);
+ref = dot_top;
+}
+);
+width = 960;
+}
+);
+note = uni1592;
+unicode = 5522;
+},
+{
+glyphname = "nga-canadian";
+kernLeft = mwestleft;
+kernRight = caright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (507,0);
+ref = "ca-canadian";
+}
+);
+width = 982;
+}
+);
+note = uni1593;
+unicode = 5523;
+},
+{
+glyphname = "ngaa-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (507,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (542,0);
+ref = dot_top;
+}
+);
+width = 982;
+}
+);
+note = uni1594;
+unicode = 5524;
+},
+{
+glyphname = "ng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(439,217,o),
+(481,258,o),
+(497,335,cs),
+(503,365,l),
+(446,365,l),
+(439,329,ls),
+(429,288,o),
+(411,268,o),
+(382,268,cs),
+(351,268,o),
+(338,290,o),
+(347,330,cs),
+(382,493,l),
+(259,493,l),
+(267,466,l),
+(297,487,o),
+(315,544,o),
+(318,583,cs),
+(324,650,o),
+(290,696,o),
+(229,696,cs),
+(152,696,o),
+(114,614,o),
+(107,549,cs),
+(100,477,o),
+(136,434,o),
+(199,434,cs),
+(333,434,l),
+(315,471,l),
+(289,346,ls),
+(272,268,o),
+(306,217,o),
+(376,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(172,481,o),
+(158,502,o),
+(161,542,cs),
+(164,582,o),
+(181,648,o),
+(225,648,cs),
+(252,648,o),
+(266,627,o),
+(263,587,cs),
+(260,547,o),
+(243,481,o),
+(198,481,cs)
+);
+}
+);
+width = 507;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1595;
+unicode = 5525;
+},
+{
+glyphname = "nng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(681,217,o),
+(723,258,o),
+(738,335,cs),
+(745,365,l),
+(687,365,l),
+(679,329,ls),
+(669,288,o),
+(652,268,o),
+(623,268,cs),
+(591,268,o),
+(579,290,o),
+(588,330,cs),
+(623,493,l),
+(508,493,l),
+(506,466,l),
+(541,492,o),
+(559,554,o),
+(559,595,cs),
+(559,657,o),
+(526,696,o),
+(469,696,cs),
+(384,696,o),
+(347,601,o),
+(347,533,cs),
+(347,507,o),
+(354,486,o),
+(367,469,c),
+(376,493,l),
+(270,493,l),
+(267,466,l),
+(302,492,o),
+(320,557,o),
+(320,595,cs),
+(320,656,o),
+(286,696,o),
+(230,696,cs),
+(144,696,o),
+(107,601,o),
+(107,533,cs),
+(107,471,o),
+(142,434,o),
+(200,434,cs),
+(548,434,l),
+(529,346,ls),
+(513,268,o),
+(548,217,o),
+(617,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(175,481,o),
+(161,499,o),
+(161,532,cs),
+(161,569,o),
+(178,648,o),
+(226,648,cs),
+(252,648,o),
+(265,630,o),
+(265,597,cs),
+(265,560,o),
+(249,481,o),
+(199,481,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(414,481,o),
+(401,499,o),
+(401,532,cs),
+(401,569,o),
+(417,648,o),
+(467,648,cs),
+(492,648,o),
+(505,630,o),
+(505,597,cs),
+(505,560,o),
+(489,481,o),
+(439,481,cs)
+);
+}
+);
+width = 748;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1596;
+unicode = 5526;
+},
+{
+glyphname = "sheSayisi-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (560,345);
+},
+{
+name = top_center_can;
+pos = (340,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(382,0,l),
+(474,439,ls),
+(509,602,o),
+(455,702,o),
+(327,702,cs),
+(145,702,o),
+(84,480,o),
+(84,350,cs),
+(84,255,o),
+(120,200,o),
+(191,200,cs),
+(265,200,o),
+(305,261,o),
+(333,412,c),
+(294,412,l),
+(275,313,o),
+(252,274,o),
+(215,274,cs),
+(184,274,o),
+(168,300,o),
+(168,350,cs),
+(168,424,o),
+(207,625,o),
+(317,625,cs),
+(387,625,o),
+(410,559,o),
+(384,439,cs),
+(291,0,l)
+);
+}
+);
+width = 490;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1597;
+unicode = 5527;
+},
+{
+glyphname = "shiSayisi-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,0,l),
+(194,457,ls),
+(218,572,o),
+(258,625,o),
+(321,625,cs),
+(376,625,o),
+(405,589,o),
+(405,520,cs),
+(405,459,o),
+(370,274,o),
+(301,274,cs),
+(259,274,o),
+(246,315,o),
+(269,412,c),
+(230,412,l),
+(196,272,o),
+(227,200,o),
+(313,200,cs),
+(440,200,o),
+(490,416,o),
+(490,517,cs),
+(490,634,o),
+(430,702,o),
+(324,702,cs),
+(213,702,o),
+(140,625,o),
+(107,474,cs),
+(7,0,l)
+);
+}
+);
+width = 490;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni1598;
+unicode = 5528;
+},
+{
+glyphname = "shoSayisi-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (337,690);
+},
+{
+name = top_left_can;
+pos = (189,690);
+},
+{
+name = top_right_can;
+pos = (483,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(322,-13,o),
+(395,65,o),
+(427,215,cs),
+(528,690,l),
+(438,690,l),
+(341,233,ls),
+(316,118,o),
+(276,65,o),
+(214,65,cs),
+(158,65,o),
+(130,100,o),
+(130,170,cs),
+(130,231,o),
+(164,415,o),
+(233,415,cs),
+(276,415,o),
+(289,375,o),
+(266,278,c),
+(305,278,l),
+(338,417,o),
+(307,490,o),
+(222,490,cs),
+(96,490,o),
+(44,273,o),
+(44,173,cs),
+(44,56,o),
+(104,-13,o),
+(211,-13,cs)
+);
+}
+);
+width = 489;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1599;
+unicode = 5529;
+},
+{
+glyphname = "shaSayisi-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(390,-13,o),
+(451,210,o),
+(451,340,cs),
+(451,435,o),
+(415,490,o),
+(344,490,cs),
+(270,490,o),
+(229,429,o),
+(202,278,c),
+(242,278,l),
+(260,377,o),
+(282,415,o),
+(320,415,cs),
+(352,415,o),
+(367,389,o),
+(367,340,cs),
+(367,266,o),
+(328,65,o),
+(217,65,cs),
+(147,65,o),
+(125,130,o),
+(151,251,cs),
+(244,690,l),
+(154,690,l),
+(60,251,ls),
+(26,88,o),
+(80,-13,o),
+(207,-13,cs)
+);
+}
+);
+width = 490;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni159A;
+unicode = 5530;
+},
+{
+glyphname = "theWoodScree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(553,-13,o),
+(613,178,o),
+(613,295,cs),
+(613,410,o),
+(550,478,o),
+(440,478,cs),
+(103,478,l),
+(87,403,l),
+(342,403,l),
+(341,430,l),
+(250,388,o),
+(220,250,o),
+(220,172,cs),
+(220,59,o),
+(282,-13,o),
+(387,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(336,65,o),
+(307,101,o),
+(307,169,cs),
+(307,239,o),
+(337,402,o),
+(442,402,cs),
+(497,402,o),
+(526,365,o),
+(526,298,cs),
+(526,228,o),
+(496,65,o),
+(391,65,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(681,614,l),
+(697,690,l),
+(149,690,l),
+(132,614,l)
+);
+}
+);
+width = 663;
+}
+);
+note = uni159B;
+unicode = 5531;
+},
+{
+glyphname = "thiWoodScree-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(381,-13,o),
+(440,179,o),
+(440,295,cs),
+(440,347,o),
+(426,385,o),
+(397,410,c),
+(390,403,l),
+(645,403,l),
+(662,478,l),
+(291,478,ls),
+(100,478,o),
+(47,287,o),
+(47,172,cs),
+(47,59,o),
+(109,-13,o),
+(214,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(164,65,o),
+(134,101,o),
+(134,169,cs),
+(134,239,o),
+(165,402,o),
+(270,402,cs),
+(326,402,o),
+(354,365,o),
+(354,298,cs),
+(354,228,o),
+(324,65,o),
+(218,65,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(691,614,l),
+(707,690,l),
+(158,690,l),
+(142,614,l)
+);
+}
+);
+width = 664;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159C;
+unicode = 5532;
+},
+{
+glyphname = "thoWoodScree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(373,0,ls),
+(563,0,o),
+(615,191,o),
+(615,307,cs),
+(615,420,o),
+(554,492,o),
+(448,492,cs),
+(282,492,o),
+(222,299,o),
+(222,185,cs),
+(222,132,o),
+(237,93,o),
+(266,69,c),
+(272,75,l),
+(18,75,l),
+(2,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(338,76,o),
+(309,113,o),
+(309,181,cs),
+(309,251,o),
+(340,413,o),
+(444,413,cs),
+(499,413,o),
+(528,377,o),
+(528,309,cs),
+(528,241,o),
+(498,76,o),
+(393,76,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(681,614,l),
+(697,690,l),
+(149,690,l),
+(132,614,l)
+);
+}
+);
+width = 663;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159D;
+unicode = 5533;
+},
+{
+glyphname = "thaWoodScree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(559,0,l),
+(575,75,l),
+(320,75,l),
+(322,48,l),
+(412,90,o),
+(442,228,o),
+(442,306,cs),
+(442,420,o),
+(380,492,o),
+(275,492,cs),
+(109,492,o),
+(49,300,o),
+(49,185,cs),
+(49,69,o),
+(113,0,o),
+(223,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(164,76,o),
+(136,113,o),
+(136,181,cs),
+(136,251,o),
+(166,413,o),
+(271,413,cs),
+(327,413,o),
+(355,377,o),
+(355,309,cs),
+(355,241,o),
+(325,76,o),
+(220,76,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(689,614,l),
+(705,690,l),
+(156,690,l),
+(140,614,l)
+);
+}
+);
+width = 663;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159E;
+unicode = 5534;
+},
+{
+glyphname = "thWoodScree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(377,345,l),
+(388,399,l),
+(248,399,l),
+(244,370,l),
+(291,391,o),
+(310,463,o),
+(310,506,cs),
+(310,568,o),
+(276,607,o),
+(220,607,cs),
+(135,607,o),
+(98,511,o),
+(98,444,cs),
+(98,382,o),
+(132,345,o),
+(191,345,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(165,391,o),
+(153,410,o),
+(153,442,cs),
+(153,479,o),
+(168,559,o),
+(217,559,cs),
+(242,559,o),
+(256,541,o),
+(256,508,cs),
+(256,471,o),
+(240,391,o),
+(189,391,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(438,667,l),
+(450,721,l),
+(156,721,l),
+(143,667,l)
+);
+}
+);
+width = 404;
+}
+);
+metricRight = "=|";
+note = uni159F;
+unicode = 5535;
+},
+{
+glyphname = "lhi-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (463,690);
+},
+{
+name = top_right_can;
+pos = (545,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(248,0,l),
+(265,80,l),
+(250,80,ls),
+(180,80,o),
+(138,126,o),
+(138,199,cs),
+(138,283,o),
+(184,396,o),
+(320,396,cs),
+(642,396,l),
+(658,469,l),
+(570,726,l),
+(487,697,l),
+(575,438,l),
+(608,478,l),
+(327,478,ls),
+(139,478,o),
+(48,343,o),
+(48,197,cs),
+(48,81,o),
+(120,0,o),
+(231,0,cs)
+);
+}
+);
+width = 655;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A0;
+unicode = 5536;
+},
+{
+glyphname = "lhii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "lhi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (298,0);
+ref = dot_top;
+}
+);
+width = 653;
+}
+);
+note = uni15A1;
+unicode = 5537;
+},
+{
+glyphname = "lho-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (375,496);
+},
+{
+name = top_right_can;
+pos = (463,496);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(168,-219,l),
+(79,41,l),
+(47,-1,l),
+(328,-1,ls),
+(516,-1,o),
+(606,135,o),
+(606,281,cs),
+(606,397,o),
+(535,478,o),
+(424,478,cs),
+(407,478,l),
+(389,398,l),
+(405,398,ls),
+(475,398,o),
+(517,353,o),
+(517,279,cs),
+(517,194,o),
+(470,81,o),
+(335,81,cs),
+(13,81,l),
+(-3,9,l),
+(85,-249,l)
+);
+}
+);
+width = 654;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni15A2;
+unicode = 5538;
+},
+{
+glyphname = "lhoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "lho-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (298,-194);
+ref = dot_top;
+}
+);
+width = 653;
+}
+);
+note = uni15A3;
+unicode = 5539;
+},
+{
+glyphname = "lha-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (389,496);
+},
+{
+name = top_left_can;
+pos = (300,496);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(558,9,l),
+(574,82,l),
+(264,82,ls),
+(182,82,o),
+(137,125,o),
+(137,200,cs),
+(137,282,o),
+(177,398,o),
+(316,398,cs),
+(331,398,l),
+(349,478,l),
+(327,478,ls),
+(132,478,o),
+(47,338,o),
+(47,193,cs),
+(47,74,o),
+(122,0,o),
+(246,0,cs),
+(498,0,l),
+(475,38,l),
+(295,-199,l),
+(360,-249,l)
+);
+}
+);
+width = 653;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A4;
+unicode = 5540;
+},
+{
+glyphname = "lhaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "lha-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (135,-194);
+ref = dot_top;
+}
+);
+width = 653;
+}
+);
+note = uni15A5;
+unicode = 5541;
+},
+{
+glyphname = "lh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(376,351,l),
+(386,404,l),
+(242,404,ls),
+(191,404,o),
+(165,431,o),
+(165,482,cs),
+(165,545,o),
+(192,631,o),
+(288,631,cs),
+(295,631,l),
+(307,690,l),
+(298,690,ls),
+(156,690,o),
+(102,578,o),
+(102,476,cs),
+(102,391,o),
+(152,345,o),
+(240,345,cs),
+(345,345,l),
+(325,382,l),
+(219,244,l),
+(266,208,l)
+);
+}
+);
+width = 397;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni15A6;
+unicode = 5542;
+},
+{
+glyphname = "theThCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (177,690);
+},
+{
+name = top_right_can;
+pos = (456,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(287,104,l),
+(264,0,l),
+(355,0,l),
+(377,104,l),
+(438,104,l),
+(449,158,l),
+(388,158,l),
+(423,323,l),
+(156,323,l),
+(170,293,l),
+(501,647,l),
+(440,701,l),
+(43,272,l),
+(37,242,l),
+(316,242,l),
+(298,158,l),
+(114,158,l),
+(102,104,l)
+);
+}
+);
+width = 497;
+}
+);
+metricLeft = "ye-canadian";
+note = uni15A7;
+unicode = 5543;
+},
+{
+glyphname = "thiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (232,690);
+},
+{
+name = top_right_can;
+pos = (512,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(129,0,l),
+(153,104,l),
+(337,104,l),
+(348,158,l),
+(163,158,l),
+(182,242,l),
+(461,242,l),
+(467,272,l),
+(237,701,l),
+(164,661,l),
+(366,287,l),
+(388,323,l),
+(108,323,l),
+(73,158,l),
+(13,158,l),
+(1,104,l),
+(62,104,l),
+(40,0,l)
+);
+}
+);
+width = 496;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+unicode = 5544;
+},
+{
+glyphname = "thiiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (69,0);
+ref = dot_top;
+}
+);
+width = 497;
+}
+);
+note = uni15A9;
+unicode = 5545;
+},
+{
+glyphname = "thoThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (178,690);
+},
+{
+name = top_right_can;
+pos = (457,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(378,29,l),
+(175,403,l),
+(154,367,l),
+(433,367,l),
+(468,531,l),
+(529,531,l),
+(541,585,l),
+(479,585,l),
+(501,690,l),
+(412,690,l),
+(389,585,l),
+(205,585,l),
+(193,531,l),
+(378,531,l),
+(360,447,l),
+(81,447,l),
+(74,417,l),
+(305,-12,l)
+);
+}
+);
+width = 497;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+unicode = 5546;
+},
+{
+glyphname = "thooThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (293,0);
+ref = dot_top;
+}
+);
+width = 497;
+}
+);
+note = uni15AB;
+unicode = 5547;
+},
+{
+glyphname = "thaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (234,690);
+},
+{
+name = top_right_can;
+pos = (513,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(500,417,l),
+(506,447,l),
+(226,447,l),
+(244,531,l),
+(429,531,l),
+(440,585,l),
+(255,585,l),
+(278,690,l),
+(187,690,l),
+(165,585,l),
+(104,585,l),
+(94,531,l),
+(154,531,l),
+(119,367,l),
+(386,367,l),
+(373,397,l),
+(41,43,l),
+(102,-12,l)
+);
+}
+);
+width = 498;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+unicode = 5548;
+},
+{
+glyphname = "thaaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:55:46 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (70,0);
+ref = dot_top;
+}
+);
+width = 498;
+}
+);
+note = uni15AD;
+unicode = 5549;
+},
+{
+glyphname = "thThCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(148,613,l),
+(128,516,l),
+(267,516,l),
+(253,546,l),
+(93,373,l),
+(135,336,l),
+(330,549,l),
+(334,568,l),
+(199,568,l),
+(209,613,l),
+(297,613,l),
+(303,644,l),
+(215,644,l),
+(225,690,l),
+(164,690,l),
+(155,644,l),
+(123,644,l),
+(117,613,l)
+);
+}
+);
+width = 290;
+}
+);
+metricRight = "y-canadian";
+note = uni15AE;
+unicode = 5550;
+},
+{
+glyphname = "bAivilik-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(384,-13,o),
+(442,192,o),
+(442,317,cs),
+(442,427,o),
+(390,492,o),
+(299,492,cs),
+(243,492,o),
+(200,459,o),
+(168,392,c),
+(182,387,l),
+(245,690,l),
+(156,690,l),
+(9,0,l),
+(92,0,l),
+(115,111,l),
+(105,97,l),
+(111,24,o),
+(155,-13,o),
+(223,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(168,65,o),
+(142,99,o),
+(142,165,cs),
+(142,235,o),
+(173,413,o),
+(276,413,cs),
+(327,413,o),
+(355,380,o),
+(355,313,cs),
+(355,243,o),
+(324,65,o),
+(220,65,cs)
+);
+}
+);
+width = 485;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|ke-canadian";
+note = uni15AF;
+unicode = 5551;
+},
+{
+glyphname = "eBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,0,l),
+(187,416,l),
+(205,375,o),
+(244,350,o),
+(296,350,cs),
+(415,350,o),
+(469,477,o),
+(469,563,cs),
+(469,646,o),
+(421,702,o),
+(343,702,cs),
+(300,702,o),
+(262,685,o),
+(234,654,c),
+(242,690,l),
+(156,690,l),
+(9,0,l)
+);
+}
+);
+width = 442;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B0;
+unicode = 5552;
+},
+{
+glyphname = "iBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(187,-13,o),
+(226,5,o),
+(254,36,c),
+(246,0,l),
+(332,0,l),
+(479,690,l),
+(389,690,l),
+(300,273,l),
+(284,315,o),
+(244,340,o),
+(192,340,cs),
+(72,340,o),
+(18,213,o),
+(18,127,cs),
+(18,43,o),
+(67,-13,o),
+(145,-13,cs)
+);
+}
+);
+width = 443;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B1;
+unicode = 5553;
+},
+{
+glyphname = "oBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(339,-13,o),
+(392,114,o),
+(392,200,cs),
+(392,284,o),
+(345,340,o),
+(269,340,cs),
+(228,340,o),
+(191,325,o),
+(162,297,c),
+(245,690,l),
+(156,690,l),
+(9,0,l),
+(95,0,l),
+(108,62,l),
+(122,16,o),
+(163,-13,o),
+(218,-13,cs)
+);
+}
+);
+width = 443;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "eBlackfoot-canadian";
+note = uni15B2;
+unicode = 5554;
+},
+{
+glyphname = "aBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(332,0,l),
+(479,690,l),
+(393,690,l),
+(380,628,l),
+(365,673,o),
+(325,702,o),
+(270,702,cs),
+(149,702,o),
+(96,576,o),
+(96,490,cs),
+(96,406,o),
+(143,350,o),
+(219,350,cs),
+(260,350,o),
+(297,365,o),
+(326,393,c),
+(242,0,l)
+);
+}
+);
+width = 443;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B3;
+unicode = 5555;
+},
+{
+glyphname = "weBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,0,l),
+(163,305,l),
+(437,305,l),
+(453,384,l),
+(181,384,l),
+(229,611,l),
+(501,611,l),
+(518,690,l),
+(156,690,l),
+(9,0,l)
+);
+}
+);
+width = 468;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B4;
+unicode = 5556;
+},
+{
+glyphname = "wiBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(357,0,l),
+(504,690,l),
+(413,690,l),
+(349,384,l),
+(76,384,l),
+(60,306,l),
+(332,306,l),
+(284,78,l),
+(12,78,l),
+(-5,0,l)
+);
+}
+);
+width = 468;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B5;
+unicode = 5557;
+},
+{
+glyphname = "woBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(371,0,l),
+(387,78,l),
+(116,78,l),
+(164,306,l),
+(437,306,l),
+(453,384,l),
+(181,384,l),
+(245,690,l),
+(156,690,l),
+(9,0,l)
+);
+}
+);
+width = 468;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "weBlackfoot-canadian";
+note = uni15B6;
+unicode = 5558;
+},
+{
+glyphname = "waBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(357,0,l),
+(504,690,l),
+(142,690,l),
+(126,611,l),
+(397,611,l),
+(349,384,l),
+(76,384,l),
+(60,305,l),
+(332,305,l),
+(267,0,l)
+);
+}
+);
+width = 468;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B7;
+unicode = 5559;
+},
+{
+glyphname = "neBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,0,l),
+(231,622,l),
+(275,622,l),
+(257,671,l),
+(247,621,ls),
+(218,487,o),
+(278,400,o),
+(405,400,cs),
+(515,400,o),
+(588,467,o),
+(617,604,cs),
+(636,690,l),
+(548,690,l),
+(528,596,ls),
+(512,517,o),
+(471,480,o),
+(411,480,cs),
+(342,480,o),
+(315,527,o),
+(331,604,cs),
+(350,690,l),
+(156,690,l),
+(9,0,l)
+);
+}
+);
+width = 573;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B8;
+unicode = 5560;
+},
+{
+glyphname = "niBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(70,0,l),
+(89,94,ls),
+(105,173,o),
+(146,210,o),
+(207,210,cs),
+(275,210,o),
+(302,162,o),
+(287,86,cs),
+(268,0,l),
+(463,0,l),
+(610,690,l),
+(519,690,l),
+(386,68,l),
+(342,68,l),
+(360,18,l),
+(371,69,ls),
+(399,203,o),
+(340,290,o),
+(213,290,cs),
+(102,290,o),
+(29,223,o),
+(0,86,cs),
+(-18,0,l)
+);
+}
+);
+width = 574;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B9;
+unicode = 5561;
+},
+{
+glyphname = "noBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(203,0,l),
+(221,81,ls),
+(241,170,o),
+(274,211,o),
+(336,211,cs),
+(404,211,o),
+(434,160,o),
+(416,73,cs),
+(401,0,l),
+(490,0,l),
+(501,54,ls),
+(531,198,o),
+(469,290,o),
+(343,290,cs),
+(232,290,o),
+(161,217,o),
+(132,77,cs),
+(120,18,l),
+(157,68,l),
+(113,68,l),
+(245,690,l),
+(156,690,l),
+(9,0,l)
+);
+}
+);
+width = 574;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "neBlackfoot-canadian";
+note = uni15BA;
+unicode = 5562;
+},
+{
+glyphname = "naBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(464,0,l),
+(611,690,l),
+(415,690,l),
+(398,609,ls),
+(379,520,o),
+(344,479,o),
+(283,479,cs),
+(214,479,o),
+(185,529,o),
+(203,616,cs),
+(217,690,l),
+(129,690,l),
+(118,636,ls),
+(87,492,o),
+(150,400,o),
+(275,400,cs),
+(386,400,o),
+(457,472,o),
+(487,612,cs),
+(499,671,l),
+(461,622,l),
+(505,622,l),
+(373,0,l)
+);
+}
+);
+width = 575;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BB;
+unicode = 5563;
+},
+{
+glyphname = "keBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,0,l),
+(224,585,l),
+(190,585,l),
+(263,256,l),
+(303,256,l),
+(584,690,l),
+(484,690,l),
+(272,358,l),
+(311,354,l),
+(239,690,l),
+(156,690,l),
+(9,0,l)
+);
+}
+);
+width = 508;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15BC;
+unicode = 5564;
+},
+{
+glyphname = "kiBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(69,1,l),
+(280,331,l),
+(242,336,l),
+(314,1,l),
+(397,1,l),
+(544,691,l),
+(454,691,l),
+(329,104,l),
+(362,104,l),
+(290,435,l),
+(249,435,l),
+(-31,1,l)
+);
+}
+);
+width = 508;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BD;
+unicode = 5565;
+},
+{
+glyphname = "koBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(92,0,l),
+(317,332,l),
+(273,338,l),
+(346,0,l),
+(438,0,l),
+(341,434,l),
+(300,434,l),
+(88,104,l),
+(121,104,l),
+(245,690,l),
+(156,690,l),
+(9,0,l)
+);
+}
+);
+width = 509;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "keBlackfoot-canadian";
+note = uni15BE;
+unicode = 5566;
+},
+{
+glyphname = "kaBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(397,1,l),
+(544,691,l),
+(461,691,l),
+(236,358,l),
+(279,353,l),
+(207,691,l),
+(116,691,l),
+(212,256,l),
+(252,256,l),
+(465,586,l),
+(432,586,l),
+(307,1,l)
+);
+}
+);
+width = 508;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BF;
+unicode = 5567;
+},
+{
+color = 9;
+glyphname = "heSayisi-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_right_can;
+pos = (536,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(435,0,l),
+(582,690,l),
+(492,690,l),
+(407,289,l),
+(424,288,l),
+(473,553,o),
+(426,702,o),
+(291,702,cs),
+(193,702,o),
+(126,624,o),
+(93,475,cs),
+(82,425,o),
+(76,381,o),
+(75,336,c),
+(161,336,l),
+(162,377,o),
+(167,418,o),
+(178,465,cs),
+(199,566,o),
+(242,623,o),
+(302,623,cs),
+(417,623,o),
+(435,418,o),
+(344,0,c)
+);
+}
+);
+width = 546;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni15C0;
+unicode = 5568;
+},
+{
+color = 9;
+glyphname = "hiSayisi-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,0,l),
+(187,412,o),
+(287,623,o),
+(394,623,cs),
+(459,623,o),
+(481,550,o),
+(455,423,cs),
+(447,387,o),
+(439,361,o),
+(427,336,c),
+(513,336,l),
+(526,368,o),
+(536,399,o),
+(543,429,cs),
+(578,597,o),
+(532,702,o),
+(426,702,cs),
+(306,702,o),
+(208,564,o),
+(149,311,c),
+(164,310,l),
+(245,690,l),
+(156,690,l),
+(9,0,l)
+);
+}
+);
+width = 546;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C1;
+unicode = 5569;
+},
+{
+color = 9;
+glyphname = "hoSayisi-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (365,690);
+},
+{
+name = top_left_can;
+pos = (193,690);
+},
+{
+name = top_right_can;
+pos = (539,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(285,-13,o),
+(384,126,o),
+(442,379,c),
+(428,380,l),
+(347,0,l),
+(437,0,l),
+(583,690,l),
+(493,690,l),
+(405,278,o),
+(305,67,o),
+(198,67,cs),
+(133,67,o),
+(110,140,o),
+(137,267,cs),
+(145,302,o),
+(154,328,o),
+(164,354,c),
+(78,354,l),
+(66,322,o),
+(55,291,o),
+(48,261,cs),
+(15,93,o),
+(60,-13,o),
+(166,-13,cs)
+);
+}
+);
+width = 548;
+}
+);
+metricLeft = "heSayisi-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15C2;
+unicode = 5570;
+},
+{
+color = 9;
+glyphname = "haSayisi-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(396,-13,o),
+(464,66,o),
+(497,214,cs),
+(508,265,o),
+(514,309,o),
+(515,354,c),
+(429,354,l),
+(428,313,o),
+(423,271,o),
+(412,225,cs),
+(391,124,o),
+(348,67,o),
+(288,67,cs),
+(172,67,o),
+(155,271,o),
+(245,690,c),
+(156,690,l),
+(9,0,l),
+(99,0,l),
+(183,401,l),
+(166,402,l),
+(116,137,o),
+(163,-13,o),
+(298,-13,cs)
+);
+}
+);
+width = 545;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C3;
+unicode = 5571;
+},
+{
+color = 9;
+glyphname = "ghuCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(252,0,l),
+(642,665,l),
+(647,690,l),
+(569,690,l),
+(442,465,l),
+(478,481,l),
+(195,481,l),
+(224,464,l),
+(192,690,l),
+(121,690,l),
+(115,665,l),
+(222,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(441,413,l),
+(424,430,l),
+(247,119,l),
+(274,114,l),
+(229,427,l),
+(205,413,l)
+);
+}
+);
+width = 575;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C4;
+unicode = 5572;
+},
+{
+color = 9;
+glyphname = "ghoCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(52,0,l),
+(180,225,l),
+(143,209,l),
+(426,209,l),
+(397,226,l),
+(428,0,l),
+(500,0,l),
+(505,25,l),
+(399,690,l),
+(368,690,l),
+(-21,25,l),
+(-27,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(405,349,l),
+(221,353,l),
+(239,263,l),
+(384,498,l),
+(305,499,l),
+(350,259,l)
+);
+}
+);
+width = 575;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C5;
+unicode = 5573;
+},
+{
+color = 9;
+glyphname = "gheCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (85,354);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(13,0,l),
+(516,328,l),
+(523,361,l),
+(159,690,l),
+(136,690,l),
+(122,625,l),
+(240,519,l),
+(232,576,l),
+(138,136,l),
+(165,186,l),
+(7,82,l),
+(-11,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(287,536,l),
+(261,510,l),
+(460,327,l),
+(463,375,l),
+(199,201,l),
+(210,176,l)
+);
+}
+);
+width = 526;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15C6;
+unicode = 5574;
+},
+{
+color = 9;
+glyphname = "gheeCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (24,9);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 526;
+}
+);
+note = uni15C7;
+unicode = 5575;
+},
+{
+color = 9;
+glyphname = "ghiCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (4,9);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 526;
+}
+);
+note = uni15C8;
+unicode = 5576;
+},
+{
+color = 9;
+glyphname = "ghaCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(436,0,l),
+(449,65,l),
+(332,171,l),
+(340,114,l),
+(434,554,l),
+(407,503,l),
+(565,608,l),
+(582,690,l),
+(559,690,l),
+(56,361,l),
+(48,328,l),
+(412,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(310,180,l),
+(126,351,l),
+(124,324,l),
+(373,489,l),
+(357,497,l),
+(291,179,l)
+);
+}
+);
+width = 527;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15C9;
+unicode = 5577;
+},
+{
+color = 9;
+glyphname = "ruCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(252,0,l),
+(642,665,l),
+(647,690,l),
+(566,690,l),
+(513,595,l),
+(543,612,l),
+(180,612,l),
+(206,594,l),
+(192,690,l),
+(121,690,l),
+(115,665,l),
+(222,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(507,545,l),
+(498,563,l),
+(247,121,l),
+(274,116,l),
+(210,560,l),
+(188,545,l)
+);
+}
+);
+width = 575;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CA;
+unicode = 5578;
+},
+{
+color = 9;
+glyphname = "roCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(368,690,l),
+(-21,25,l),
+(-27,0,l),
+(55,0,l),
+(108,95,l),
+(78,77,l),
+(441,77,l),
+(415,96,l),
+(429,0,l),
+(499,0,l),
+(505,25,l),
+(399,690,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(113,145,l),
+(123,127,l),
+(374,569,l),
+(346,574,l),
+(412,129,l),
+(433,145,l)
+);
+}
+);
+width = 574;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CB;
+unicode = 5579;
+},
+{
+color = 9;
+glyphname = "reCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(14,0,l),
+(516,328,l),
+(523,361,l),
+(160,690,l),
+(136,690,l),
+(123,627,l),
+(184,571,l),
+(176,627,l),
+(60,82,l),
+(83,130,l),
+(7,79,l),
+(-11,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(231,578,l),
+(207,551,l),
+(449,327,l),
+(453,374,l),
+(127,156,l),
+(136,130,l)
+);
+}
+);
+width = 526;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CC;
+unicode = 5580;
+},
+{
+color = 9;
+glyphname = "reeCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(13,0,l),
+(516,328,l),
+(523,361,l),
+(159,690,l),
+(136,690,l),
+(125,635,l),
+(179,584,l),
+(177,634,l),
+(59,75,l),
+(80,124,l),
+(5,74,l),
+(-11,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(226,597,l),
+(204,569,l),
+(469,327,l),
+(472,375,l),
+(111,137,l),
+(124,111,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(239,270,l),
+(274,435,l),
+(241,435,l),
+(205,270,l)
+);
+}
+);
+width = 526;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CD;
+unicode = 5581;
+},
+{
+color = 9;
+glyphname = "riCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(13,0,l),
+(516,328,l),
+(523,361,l),
+(159,690,l),
+(136,690,l),
+(125,635,l),
+(181,582,l),
+(177,634,l),
+(59,75,l),
+(84,126,l),
+(5,74,l),
+(-11,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(294,317,o),
+(312,333,o),
+(312,355,cs),
+(312,376,o),
+(294,391,o),
+(273,391,cs),
+(254,391,o),
+(237,376,o),
+(237,355,cs),
+(237,333,o),
+(254,317,o),
+(273,317,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(226,597,l),
+(202,571,l),
+(469,327,l),
+(472,375,l),
+(113,139,l),
+(124,111,l)
+);
+}
+);
+width = 526;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CE;
+unicode = 5582;
+},
+{
+color = 9;
+glyphname = "raCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(436,0,l),
+(449,63,l),
+(388,119,l),
+(396,63,l),
+(511,608,l),
+(488,559,l),
+(565,611,l),
+(582,690,l),
+(558,690,l),
+(56,361,l),
+(48,328,l),
+(412,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(365,139,l),
+(122,362,l),
+(119,316,l),
+(445,533,l),
+(436,559,l),
+(341,112,l)
+);
+}
+);
+width = 527;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15CF;
+unicode = 5583;
+},
+{
+color = 9;
+glyphname = "wuCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(257,0,l),
+(650,665,l),
+(656,690,l),
+(578,690,l),
+(297,188,l),
+(313,187,l),
+(420,690,l),
+(350,690,l),
+(242,185,l),
+(261,185,l),
+(187,690,l),
+(121,690,l),
+(115,665,l),
+(226,0,l)
+);
+}
+);
+width = 584;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D0;
+unicode = 5584;
+},
+{
+color = 9;
+glyphname = "woCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(51,0,l),
+(333,501,l),
+(316,502,l),
+(209,0,l),
+(279,0,l),
+(386,504,l),
+(368,504,l),
+(441,0,l),
+(508,0,l),
+(514,25,l),
+(403,690,l),
+(373,690,l),
+(-21,25,l),
+(-27,0,l)
+);
+}
+);
+width = 583;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D1;
+unicode = 5585;
+},
+{
+color = 9;
+glyphname = "weCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(31,0,l),
+(534,328,l),
+(541,361,l),
+(178,690,l),
+(155,690,l),
+(141,625,l),
+(415,375,l),
+(420,389,l),
+(91,389,l),
+(75,320,l),
+(406,320,l),
+(410,332,l),
+(25,81,l),
+(8,0,l)
+);
+}
+);
+width = 544;
+}
+);
+metricRight = "o-canadian";
+note = uni15D2;
+unicode = 5586;
+},
+{
+color = 9;
+glyphname = "weeCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(31,0,l),
+(534,328,l),
+(541,361,l),
+(178,690,l),
+(155,690,l),
+(142,630,l),
+(445,357,l),
+(455,384,l),
+(206,384,l),
+(221,454,l),
+(172,454,l),
+(156,384,l),
+(89,384,l),
+(77,327,l),
+(144,327,l),
+(129,256,l),
+(179,256,l),
+(193,327,l),
+(443,327,l),
+(434,343,l),
+(24,76,l),
+(8,0,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D3;
+unicode = 5587;
+},
+{
+color = 9;
+glyphname = "wiCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(31,0,l),
+(534,328,l),
+(541,361,l),
+(178,690,l),
+(155,690,l),
+(142,630,l),
+(429,371,l),
+(438,385,l),
+(255,385,l),
+(245,407,o),
+(223,422,o),
+(198,422,cs),
+(173,422,o),
+(151,407,o),
+(141,385,c),
+(90,385,l),
+(77,328,l),
+(141,328,l),
+(151,307,o),
+(173,292,o),
+(198,292,cs),
+(223,292,o),
+(244,307,o),
+(254,328,c),
+(426,328,l),
+(421,335,l),
+(24,77,l),
+(8,0,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D4;
+unicode = 5588;
+},
+{
+color = 9;
+glyphname = "waCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(435,0,l),
+(448,65,l),
+(174,315,l),
+(169,300,l),
+(498,300,l),
+(513,370,l),
+(184,370,l),
+(181,357,l),
+(564,609,l),
+(582,690,l),
+(557,690,l),
+(56,361,l),
+(48,328,l),
+(411,0,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15D5;
+unicode = 5589;
+},
+{
+color = 9;
+glyphname = "hwuCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(257,0,l),
+(650,665,l),
+(656,690,l),
+(583,690,l),
+(462,478,l),
+(487,491,l),
+(369,491,l),
+(412,690,l),
+(356,690,l),
+(314,491,l),
+(194,491,l),
+(215,478,l),
+(184,690,l),
+(121,690,l),
+(115,665,l),
+(226,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(260,151,l),
+(215,457,l),
+(199,440,l),
+(307,440,l),
+(245,151,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(355,440,l),
+(461,440,l),
+(452,457,l),
+(280,153,l),
+(293,148,l)
+);
+}
+);
+width = 584;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D6;
+unicode = 5590;
+},
+{
+color = 9;
+glyphname = "hwoCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(45,0,l),
+(167,212,l),
+(143,199,l),
+(260,199,l),
+(217,0,l),
+(273,0,l),
+(316,199,l),
+(435,199,l),
+(413,212,l),
+(446,0,l),
+(508,0,l),
+(514,25,l),
+(403,690,l),
+(373,690,l),
+(-21,25,l),
+(-27,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(349,537,l),
+(336,542,l),
+(274,249,l),
+(169,249,l),
+(177,233,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(431,249,l),
+(323,249,l),
+(384,539,l),
+(369,539,l),
+(413,233,l)
+);
+}
+);
+width = 583;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D7;
+unicode = 5591;
+},
+{
+color = 9;
+glyphname = "hweCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(31,0,l),
+(534,328,l),
+(541,361,l),
+(178,690,l),
+(155,690,l),
+(142,630,l),
+(238,544,l),
+(203,383,l),
+(89,383,l),
+(76,323,l),
+(190,323,l),
+(156,163,l),
+(23,76,l),
+(8,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(240,328,l),
+(425,328,l),
+(210,189,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(279,516,l),
+(432,377,l),
+(249,377,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D8;
+unicode = 5592;
+},
+{
+color = 9;
+glyphname = "hweeCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(31,0,l),
+(534,328,l),
+(541,361,l),
+(178,690,l),
+(155,690,l),
+(142,634,l),
+(258,531,l),
+(225,379,l),
+(182,379,l),
+(197,452,l),
+(156,452,l),
+(140,379,l),
+(88,379,l),
+(77,327,l),
+(128,327,l),
+(114,256,l),
+(156,256,l),
+(170,327,l),
+(214,327,l),
+(182,175,l),
+(23,72,l),
+(8,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(258,331,l),
+(429,331,l),
+(231,201,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(295,504,l),
+(435,376,l),
+(268,376,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D9;
+unicode = 5593;
+},
+{
+color = 9;
+glyphname = "hwiCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(31,0,l),
+(534,328,l),
+(541,361,l),
+(178,690,l),
+(155,690,l),
+(143,634,l),
+(258,531,l),
+(224,375,l),
+(202,375,l),
+(194,394,o),
+(177,408,o),
+(156,408,cs),
+(134,408,o),
+(117,394,o),
+(109,375,c),
+(88,375,l),
+(78,331,l),
+(108,331,l),
+(116,312,o),
+(134,298,o),
+(156,298,cs),
+(176,298,o),
+(194,312,o),
+(202,331,c),
+(214,331,l),
+(182,175,l),
+(23,72,l),
+(8,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(258,331,l),
+(428,331,l),
+(231,201,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(295,505,l),
+(435,375,l),
+(268,375,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15DA;
+unicode = 5594;
+},
+{
+color = 9;
+glyphname = "hwaCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(558,690,l),
+(56,361,l),
+(48,328,l),
+(412,0,l),
+(436,0,l),
+(448,60,l),
+(353,146,l),
+(386,307,l),
+(500,307,l),
+(513,367,l),
+(399,367,l),
+(433,526,l),
+(566,613,l),
+(582,690,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(350,361,l),
+(165,361,l),
+(380,500,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(310,174,l),
+(157,313,l),
+(340,313,l)
+);
+}
+);
+width = 545;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15DB;
+unicode = 5595;
+},
+{
+color = 9;
+glyphname = "thuCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(405,-13,o),
+(488,66,o),
+(523,226,cs),
+(621,690,l),
+(153,690,l),
+(62,262,ls),
+(25,89,o),
+(102,-13,o),
+(266,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(225,609,l),
+(514,609,l),
+(434,236,ls),
+(410,121,o),
+(359,71,o),
+(271,71,cs),
+(163,71,o),
+(124,132,o),
+(150,255,cs)
+);
+}
+);
+width = 583;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DC;
+unicode = 5596;
+},
+{
+color = 9;
+glyphname = "thoCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(475,0,l),
+(566,428,ls),
+(603,601,o),
+(525,702,o),
+(362,702,cs),
+(222,702,o),
+(139,624,o),
+(105,464,cs),
+(7,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(193,454,ls),
+(217,569,o),
+(269,618,o),
+(356,618,cs),
+(464,618,o),
+(503,557,o),
+(477,435,cs),
+(402,81,l),
+(114,81,l)
+);
+}
+);
+width = 583;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DD;
+unicode = 5597;
+},
+{
+color = 9;
+glyphname = "theCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (308,345);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(174,0,ls),
+(463,0,o),
+(553,268,o),
+(553,444,cs),
+(553,602,o),
+(465,690,o),
+(301,690,cs),
+(156,690,l),
+(9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(237,648,l),
+(203,610,l),
+(287,610,ls),
+(403,610,o),
+(464,552,o),
+(464,439,cs),
+(464,311,o),
+(400,80,o),
+(181,80,cs),
+(97,80,l),
+(108,44,l)
+);
+}
+);
+width = 568;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "to-canadian";
+note = uni15DE;
+unicode = 5598;
+},
+{
+color = 9;
+glyphname = "theeCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (241,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 568;
+}
+);
+note = uni15DF;
+unicode = 5599;
+},
+{
+color = 9;
+glyphname = "thiCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (218,0);
+ref = dot_middle;
+}
+);
+width = 568;
+}
+);
+note = uni15E0;
+unicode = 5600;
+},
+{
+color = 9;
+glyphname = "thaCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(457,0,l),
+(604,690,l),
+(439,690,ls),
+(149,690,o),
+(60,422,o),
+(60,245,cs),
+(60,88,o),
+(147,0,o),
+(311,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(148,379,o),
+(212,610,o),
+(431,610,cs),
+(516,610,l),
+(503,645,l),
+(375,42,l),
+(410,80,l),
+(326,80,ls),
+(209,80,o),
+(148,138,o),
+(148,251,cs)
+);
+}
+);
+width = 568;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15E1;
+unicode = 5601;
+},
+{
+color = 9;
+glyphname = "ttuCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(404,-13,o),
+(488,64,o),
+(522,221,cs),
+(621,690,l),
+(591,690,l),
+(311,497,l),
+(373,490,l),
+(184,690,l),
+(153,690,l),
+(61,256,ls),
+(24,86,o),
+(100,-13,o),
+(262,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(164,71,o),
+(124,131,o),
+(149,249,cs),
+(222,596,l),
+(185,582,l),
+(324,433,l),
+(342,433,l),
+(541,575,l),
+(511,594,l),
+(434,231,ls),
+(410,121,o),
+(358,71,o),
+(267,71,cs)
+);
+}
+);
+width = 583;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E2;
+unicode = 5602;
+},
+{
+color = 9;
+glyphname = "ttoCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(36,0,l),
+(317,192,l),
+(255,200,l),
+(444,0,l),
+(475,0,l),
+(567,434,ls),
+(603,604,o),
+(527,702,o),
+(365,702,cs),
+(223,702,o),
+(140,626,o),
+(106,469,cs),
+(7,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(464,618,o),
+(503,558,o),
+(478,440,cs),
+(405,94,l),
+(442,107,l),
+(304,257,l),
+(286,257,l),
+(86,115,l),
+(117,96,l),
+(194,459,ls),
+(217,569,o),
+(270,618,o),
+(360,618,cs)
+);
+}
+);
+width = 583;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E3;
+unicode = 5603;
+},
+{
+color = 9;
+glyphname = "tteCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (350,345);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(184,0,ls),
+(470,0,o),
+(563,266,o),
+(563,444,cs),
+(563,602,o),
+(474,690,o),
+(315,690,cs),
+(152,690,l),
+(146,665,l),
+(178,316,l),
+(190,392,l),
+(11,25,l),
+(5,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(257,335,l),
+(260,352,l),
+(232,649,l),
+(201,610,l),
+(297,610,ls),
+(413,610,o),
+(474,552,o),
+(474,439,cs),
+(474,311,o),
+(410,80,o),
+(191,80,cs),
+(95,80,l),
+(113,43,l)
+);
+}
+);
+width = 578;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15E4;
+unicode = 5604;
+},
+{
+color = 9;
+glyphname = "tteeCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (290,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 578;
+}
+);
+note = uni15E5;
+unicode = 5605;
+},
+{
+color = 9;
+glyphname = "ttiCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (277,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 578;
+}
+);
+note = uni15E6;
+unicode = 5606;
+},
+{
+color = 9;
+glyphname = "ttaCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(470,0,l),
+(475,25,l),
+(444,374,l),
+(432,298,l),
+(611,665,l),
+(616,690,l),
+(439,690,ls),
+(151,690,o),
+(60,424,o),
+(60,245,cs),
+(60,88,o),
+(147,0,o),
+(306,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(421,80,l),
+(326,80,ls),
+(209,80,o),
+(148,138,o),
+(148,251,cs),
+(148,379,o),
+(212,610,o),
+(431,610,cs),
+(527,610,l),
+(508,646,l),
+(365,355,l),
+(361,338,l),
+(389,41,l)
+);
+}
+);
+width = 576;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tteCarrier-canadian";
+note = uni15E7;
+unicode = 5607;
+},
+{
+color = 9;
+glyphname = "puCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(405,-13,o),
+(488,66,o),
+(523,226,cs),
+(621,690,l),
+(530,690,l),
+(497,527,l),
+(209,527,l),
+(242,690,l),
+(153,690,l),
+(62,262,ls),
+(25,89,o),
+(102,-13,o),
+(266,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(163,71,o),
+(124,132,o),
+(150,255,cs),
+(191,447,l),
+(479,447,l),
+(434,236,ls),
+(410,121,o),
+(359,71,o),
+(271,71,cs)
+);
+}
+);
+width = 583;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E8;
+unicode = 5608;
+},
+{
+color = 9;
+glyphname = "poCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,0,l),
+(131,162,l),
+(419,162,l),
+(385,0,l),
+(475,0,l),
+(566,428,ls),
+(603,601,o),
+(525,702,o),
+(362,702,cs),
+(222,702,o),
+(139,624,o),
+(105,464,cs),
+(7,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(193,454,ls),
+(217,569,o),
+(269,618,o),
+(356,618,cs),
+(464,618,o),
+(503,557,o),
+(477,435,cs),
+(437,242,l),
+(148,242,l)
+);
+}
+);
+width = 583;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E9;
+unicode = 5609;
+},
+{
+color = 9;
+glyphname = "peCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (338,345);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(181,0,ls),
+(469,0,o),
+(559,268,o),
+(559,444,cs),
+(559,602,o),
+(472,690,o),
+(312,690,cs),
+(149,690,l),
+(132,610,l),
+(200,610,l),
+(88,80,l),
+(19,80,l),
+(2,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(298,649,l),
+(211,610,l),
+(294,610,ls),
+(411,610,o),
+(471,552,o),
+(471,439,cs),
+(471,312,o),
+(408,80,o),
+(188,80,cs),
+(99,80,l),
+(169,41,l)
+);
+}
+);
+width = 574;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15EA;
+unicode = 5610;
+},
+{
+color = 9;
+glyphname = "peeCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (278,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 575;
+}
+);
+note = uni15EB;
+unicode = 5611;
+},
+{
+color = 9;
+glyphname = "piCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (266,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 575;
+}
+);
+note = uni15EC;
+unicode = 5612;
+},
+{
+color = 9;
+glyphname = "paCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(470,0,l),
+(487,80,l),
+(419,80,l),
+(531,610,l),
+(600,610,l),
+(617,690,l),
+(439,690,ls),
+(150,690,o),
+(60,422,o),
+(60,245,cs),
+(60,88,o),
+(147,0,o),
+(307,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(409,80,l),
+(326,80,ls),
+(209,80,o),
+(148,138,o),
+(148,251,cs),
+(148,378,o),
+(212,610,o),
+(431,610,cs),
+(521,610,l),
+(450,649,l),
+(322,41,l)
+);
+}
+);
+width = 574;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|peCarrier-canadian";
+note = uni15ED;
+unicode = 5613;
+},
+{
+color = 6;
+glyphname = "pCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(297,183,l),
+(310,242,l),
+(211,242,l),
+(271,527,l),
+(210,527,l),
+(149,242,l),
+(50,242,l),
+(37,183,l)
+);
+}
+);
+width = 358;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni15EE;
+unicode = 5614;
+},
+{
+color = 9;
+glyphname = "guCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (439,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(244,-13,o),
+(300,31,o),
+(337,116,c),
+(303,116,l),
+(309,34,o),
+(355,-13,o),
+(435,-13,cs),
+(533,-13,o),
+(591,50,o),
+(617,175,cs),
+(726,690,l),
+(640,690,l),
+(531,177,ls),
+(517,105,o),
+(485,70,o),
+(434,70,cs),
+(381,70,o),
+(357,108,o),
+(373,179,cs),
+(481,690,l),
+(397,690,l),
+(289,178,ls),
+(273,106,o),
+(240,70,o),
+(187,70,cs),
+(134,70,o),
+(113,107,o),
+(128,180,cs),
+(237,690,l),
+(151,690,l),
+(43,183,ls),
+(17,62,o),
+(64,-13,o),
+(168,-13,cs)
+);
+}
+);
+width = 686;
+}
+);
+metricRight = "=|";
+note = uni15EF;
+unicode = 5615;
+},
+{
+color = 9;
+glyphname = "goCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(91,0,l),
+(199,513,ls),
+(214,584,o),
+(246,620,o),
+(297,620,cs),
+(350,620,o),
+(373,582,o),
+(358,511,cs),
+(249,0,l),
+(333,0,l),
+(441,512,ls),
+(457,583,o),
+(491,620,o),
+(543,620,cs),
+(595,620,o),
+(617,582,o),
+(602,510,cs),
+(494,0,l),
+(580,0,l),
+(687,507,ls),
+(713,628,o),
+(667,702,o),
+(562,702,cs),
+(486,702,o),
+(430,659,o),
+(393,574,c),
+(427,574,l),
+(421,656,o),
+(375,702,o),
+(296,702,cs),
+(197,702,o),
+(140,639,o),
+(114,515,cs),
+(4,0,l)
+);
+}
+);
+width = 686;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F0;
+unicode = 5616;
+},
+{
+color = 9;
+glyphname = "geCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (387,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(273,0,ls),
+(442,0,o),
+(509,104,o),
+(509,216,cs),
+(509,285,o),
+(475,337,o),
+(414,355,c),
+(410,325,l),
+(530,350,o),
+(577,441,o),
+(577,530,cs),
+(577,626,o),
+(510,690,o),
+(407,690,cs),
+(157,690,l),
+(141,614,l),
+(390,614,ls),
+(451,614,o),
+(487,579,o),
+(487,522,cs),
+(487,446,o),
+(444,382,o),
+(342,382,cs),
+(92,382,l),
+(75,308,l),
+(327,308,ls),
+(388,308,o),
+(422,277,o),
+(422,221,cs),
+(422,169,o),
+(403,75,o),
+(278,75,cs),
+(26,75,l),
+(11,0,l)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15F1;
+unicode = 5617;
+},
+{
+color = 9;
+glyphname = "geeCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(273,0,ls),
+(442,0,o),
+(509,104,o),
+(509,216,cs),
+(509,285,o),
+(475,337,o),
+(414,355,c),
+(410,325,l),
+(530,350,o),
+(577,441,o),
+(577,530,cs),
+(577,626,o),
+(510,690,o),
+(407,690,cs),
+(157,690,l),
+(141,614,l),
+(390,614,ls),
+(451,614,o),
+(487,579,o),
+(487,522,cs),
+(487,446,o),
+(444,382,o),
+(342,382,cs),
+(312,382,l),
+(329,463,l),
+(275,463,l),
+(258,382,l),
+(92,382,l),
+(75,308,l),
+(243,308,l),
+(225,229,l),
+(279,229,l),
+(297,308,l),
+(327,308,ls),
+(388,308,o),
+(422,277,o),
+(422,221,cs),
+(422,169,o),
+(403,75,o),
+(278,75,cs),
+(26,75,l),
+(11,0,l)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F2;
+unicode = 5618;
+},
+{
+color = 9;
+glyphname = "giCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(273,0,ls),
+(442,0,o),
+(509,104,o),
+(509,216,cs),
+(509,285,o),
+(476,336,o),
+(414,355,c),
+(411,325,l),
+(530,350,o),
+(577,442,o),
+(577,530,cs),
+(577,626,o),
+(510,690,o),
+(407,690,cs),
+(157,690,l),
+(141,614,l),
+(390,614,ls),
+(451,614,o),
+(487,579,o),
+(487,522,cs),
+(487,446,o),
+(444,382,o),
+(342,382,cs),
+(325,382,l),
+(350,357,l),
+(346,391,o),
+(317,417,o),
+(280,417,cs),
+(254,417,o),
+(232,403,o),
+(221,382,c),
+(92,382,l),
+(75,308,l),
+(221,308,l),
+(232,287,o),
+(254,272,o),
+(280,272,cs),
+(316,272,o),
+(345,298,o),
+(349,332,c),
+(312,308,l),
+(327,308,ls),
+(388,308,o),
+(422,277,o),
+(422,221,cs),
+(422,169,o),
+(403,75,o),
+(278,75,cs),
+(26,75,l),
+(11,0,l)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F3;
+unicode = 5619;
+},
+{
+color = 9;
+glyphname = "gaCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (396,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(465,0,l),
+(481,75,l),
+(231,75,ls),
+(170,75,o),
+(134,111,o),
+(134,168,cs),
+(134,243,o),
+(178,308,o),
+(279,308,cs),
+(531,308,l),
+(547,382,l),
+(296,382,ls),
+(233,382,o),
+(199,412,o),
+(199,469,cs),
+(199,521,o),
+(218,614,o),
+(343,614,cs),
+(595,614,l),
+(611,690,l),
+(349,690,ls),
+(180,690,o),
+(112,585,o),
+(112,473,cs),
+(112,405,o),
+(146,353,o),
+(207,334,c),
+(212,365,l),
+(92,340,o),
+(44,248,o),
+(44,159,cs),
+(44,64,o),
+(111,0,o),
+(214,0,cs)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|geCarrier-canadian";
+note = uni15F4;
+unicode = 5620;
+},
+{
+color = 9;
+glyphname = "khuCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(241,-13,o),
+(296,26,o),
+(331,104,c),
+(304,106,l),
+(313,30,o),
+(359,-13,o),
+(435,-13,cs),
+(533,-13,o),
+(591,50,o),
+(617,175,cs),
+(726,690,l),
+(151,690,l),
+(43,183,ls),
+(17,62,o),
+(64,-13,o),
+(168,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(134,70,o),
+(113,107,o),
+(128,180,cs),
+(220,611,l),
+(381,611,l),
+(289,178,ls),
+(273,106,o),
+(240,70,o),
+(187,70,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(381,70,o),
+(357,108,o),
+(373,179,cs),
+(465,611,l),
+(623,611,l),
+(531,177,ls),
+(517,105,o),
+(485,70,o),
+(434,70,cs)
+);
+}
+);
+width = 686;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F5;
+unicode = 5621;
+},
+{
+color = 9;
+glyphname = "khoCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(580,0,l),
+(687,507,ls),
+(713,628,o),
+(667,702,o),
+(562,702,cs),
+(490,702,o),
+(435,664,o),
+(399,585,c),
+(426,583,l),
+(417,660,o),
+(371,702,o),
+(296,702,cs),
+(197,702,o),
+(140,639,o),
+(114,515,cs),
+(4,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,513,ls),
+(213,584,o),
+(245,620,o),
+(297,620,cs),
+(350,620,o),
+(373,582,o),
+(357,511,cs),
+(266,79,l),
+(107,79,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(441,512,ls),
+(457,583,o),
+(491,620,o),
+(543,620,cs),
+(595,620,o),
+(617,582,o),
+(602,510,cs),
+(510,79,l),
+(350,79,l)
+);
+}
+);
+width = 686;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F6;
+unicode = 5622;
+},
+{
+color = 9;
+glyphname = "kheCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(275,0,ls),
+(444,0,o),
+(512,103,o),
+(512,215,cs),
+(512,284,o),
+(479,334,o),
+(418,355,c),
+(416,326,l),
+(543,354,o),
+(579,452,o),
+(579,530,cs),
+(579,626,o),
+(512,690,o),
+(408,690,cs),
+(156,690,l),
+(9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(163,308,l),
+(328,308,ls),
+(391,308,o),
+(425,277,o),
+(425,221,cs),
+(425,167,o),
+(404,74,o),
+(280,74,cs),
+(114,74,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(229,615,l),
+(393,615,ls),
+(454,615,o),
+(489,579,o),
+(489,522,cs),
+(489,451,o),
+(451,382,o),
+(344,382,cs),
+(180,382,l)
+);
+}
+);
+width = 579;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F7;
+unicode = 5623;
+},
+{
+color = 9;
+glyphname = "kheeCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(275,0,ls),
+(444,0,o),
+(512,103,o),
+(512,215,cs),
+(512,284,o),
+(479,334,o),
+(418,355,c),
+(416,326,l),
+(543,354,o),
+(579,452,o),
+(579,530,cs),
+(579,626,o),
+(512,690,o),
+(408,690,cs),
+(156,690,l),
+(9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(163,308,l),
+(268,308,l),
+(249,224,l),
+(300,224,l),
+(322,326,l),
+(295,308,l),
+(328,308,ls),
+(391,308,o),
+(425,277,o),
+(425,221,cs),
+(425,167,o),
+(404,74,o),
+(280,74,cs),
+(114,74,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(352,468,l),
+(301,468,l),
+(283,382,l),
+(180,382,l),
+(229,615,l),
+(393,615,ls),
+(454,615,o),
+(489,579,o),
+(489,522,cs),
+(489,451,o),
+(451,382,o),
+(344,382,cs),
+(311,382,l),
+(330,364,l)
+);
+}
+);
+width = 579;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F8;
+unicode = 5624;
+},
+{
+color = 9;
+glyphname = "khiCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(275,0,ls),
+(444,0,o),
+(512,103,o),
+(512,215,cs),
+(512,282,o),
+(481,331,o),
+(424,354,c),
+(413,325,l),
+(542,353,o),
+(579,452,o),
+(579,530,cs),
+(579,626,o),
+(512,690,o),
+(408,690,cs),
+(156,690,l),
+(9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(164,312,l),
+(242,312,l),
+(251,289,o),
+(275,272,o),
+(302,272,cs),
+(338,272,o),
+(367,302,o),
+(370,339,c),
+(310,312,l),
+(332,312,ls),
+(395,312,o),
+(425,280,o),
+(425,223,cs),
+(425,168,o),
+(404,74,o),
+(280,74,cs),
+(114,74,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(393,615,ls),
+(454,615,o),
+(489,578,o),
+(489,520,cs),
+(489,449,o),
+(455,378,o),
+(348,378,cs),
+(320,378,l),
+(371,351,l),
+(368,388,o),
+(339,417,o),
+(302,417,cs),
+(266,417,o),
+(236,388,o),
+(234,351,c),
+(258,378,l),
+(179,378,l),
+(229,615,l)
+);
+}
+);
+width = 579;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F9;
+unicode = 5625;
+},
+{
+color = 9;
+glyphname = "khaCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(470,0,l),
+(616,690,l),
+(350,690,ls),
+(181,690,o),
+(113,586,o),
+(113,474,cs),
+(113,406,o),
+(147,355,o),
+(207,335,c),
+(209,364,l),
+(82,336,o),
+(45,238,o),
+(45,159,cs),
+(45,64,o),
+(112,0,o),
+(216,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(170,74,o),
+(135,111,o),
+(135,168,cs),
+(135,239,o),
+(174,308,o),
+(281,308,cs),
+(446,308,l),
+(396,74,l),
+(231,74,ls)
+);
+},
+{
+closed = 1;
+nodes = (
+(235,382,o),
+(201,412,o),
+(201,469,cs),
+(201,523,o),
+(222,615,o),
+(345,615,cs),
+(511,615,l),
+(462,382,l),
+(297,382,ls)
+);
+}
+);
+width = 581;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15FA;
+unicode = 5626;
+},
+{
+color = 9;
+glyphname = "kkuCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(241,-13,o),
+(295,26,o),
+(331,104,c),
+(304,104,l),
+(313,30,o),
+(359,-13,o),
+(435,-13,cs),
+(533,-13,o),
+(590,50,o),
+(617,175,cs),
+(726,690,l),
+(696,690,l),
+(430,536,l),
+(412,443,l),
+(650,582,l),
+(623,610,l),
+(531,177,ls),
+(517,105,o),
+(485,70,o),
+(434,70,cs),
+(381,70,o),
+(357,110,o),
+(372,179,cs),
+(480,690,l),
+(398,690,l),
+(289,178,ls),
+(274,106,o),
+(240,70,o),
+(187,70,cs),
+(134,70,o),
+(113,107,o),
+(128,180,cs),
+(219,610,l),
+(179,597,l),
+(358,456,l),
+(376,538,l),
+(182,690,l),
+(151,690,l),
+(43,183,ls),
+(17,61,o),
+(64,-13,o),
+(168,-13,cs)
+);
+}
+);
+width = 686;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FB;
+unicode = 5627;
+},
+{
+color = 9;
+glyphname = "kkoCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(35,0,l),
+(299,154,l),
+(318,246,l),
+(80,108,l),
+(107,80,l),
+(199,513,ls),
+(214,584,o),
+(245,620,o),
+(297,620,cs),
+(350,620,o),
+(373,580,o),
+(358,511,cs),
+(250,0,l),
+(332,0,l),
+(440,512,ls),
+(456,583,o),
+(491,620,o),
+(543,620,cs),
+(595,620,o),
+(617,582,o),
+(602,510,cs),
+(510,80,l),
+(551,93,l),
+(372,234,l),
+(355,152,l),
+(549,0,l),
+(580,0,l),
+(687,507,ls),
+(713,629,o),
+(667,702,o),
+(562,702,cs),
+(490,702,o),
+(435,664,o),
+(399,585,c),
+(426,585,l),
+(417,660,o),
+(371,702,o),
+(296,702,cs),
+(197,702,o),
+(140,639,o),
+(114,515,cs),
+(4,0,l)
+);
+}
+);
+width = 686;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FC;
+unicode = 5628;
+},
+{
+color = 9;
+glyphname = "kkeCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(289,0,ls),
+(458,0,o),
+(526,104,o),
+(526,216,cs),
+(526,285,o),
+(493,334,o),
+(432,355,c),
+(429,326,l),
+(555,354,o),
+(592,452,o),
+(592,530,cs),
+(592,626,o),
+(526,690,o),
+(422,690,cs),
+(155,690,l),
+(149,665,l),
+(174,382,l),
+(94,382,l),
+(78,308,l),
+(154,308,l),
+(14,25,l),
+(8,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(244,308,l),
+(342,308,ls),
+(404,308,o),
+(438,277,o),
+(438,221,cs),
+(438,170,o),
+(418,75,o),
+(294,75,cs),
+(91,75,l),
+(111,39,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(233,655,l),
+(199,614,l),
+(407,614,ls),
+(468,614,o),
+(502,579,o),
+(502,522,cs),
+(502,446,o),
+(460,382,o),
+(357,382,cs),
+(259,382,l)
+);
+}
+);
+width = 593;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni15FD;
+unicode = 5629;
+},
+{
+color = 9;
+glyphname = "kkeeCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(289,0,ls),
+(458,0,o),
+(526,104,o),
+(526,216,cs),
+(526,285,o),
+(493,334,o),
+(432,355,c),
+(429,326,l),
+(555,354,o),
+(592,452,o),
+(592,530,cs),
+(592,626,o),
+(526,690,o),
+(422,690,cs),
+(155,690,l),
+(149,665,l),
+(174,382,l),
+(94,382,l),
+(78,308,l),
+(154,308,l),
+(14,25,l),
+(8,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(245,311,l),
+(299,311,l),
+(282,224,l),
+(332,224,l),
+(355,329,l),
+(327,311,l),
+(350,311,ls),
+(408,311,o),
+(438,277,o),
+(438,221,cs),
+(438,170,o),
+(418,75,o),
+(294,75,cs),
+(91,75,l),
+(111,39,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(384,468,l),
+(333,468,l),
+(315,380,l),
+(259,380,l),
+(233,655,l),
+(199,614,l),
+(407,614,ls),
+(468,614,o),
+(502,579,o),
+(502,522,cs),
+(502,446,o),
+(460,380,o),
+(361,380,cs),
+(340,380,l),
+(363,365,l)
+);
+}
+);
+width = 593;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FE;
+unicode = 5630;
+},
+{
+color = 9;
+glyphname = "kkiCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(289,0,ls),
+(458,0,o),
+(526,104,o),
+(526,216,cs),
+(526,285,o),
+(493,334,o),
+(432,355,c),
+(429,326,l),
+(555,354,o),
+(592,452,o),
+(592,530,cs),
+(592,626,o),
+(526,690,o),
+(422,690,cs),
+(155,690,l),
+(149,665,l),
+(174,382,l),
+(94,382,l),
+(78,308,l),
+(154,308,l),
+(14,25,l),
+(8,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(247,314,l),
+(265,314,l),
+(274,289,o),
+(298,272,o),
+(326,272,cs),
+(355,272,o),
+(380,293,o),
+(387,321,c),
+(326,314,l),
+(350,314,ls),
+(412,314,o),
+(438,277,o),
+(438,221,cs),
+(438,170,o),
+(418,75,o),
+(294,75,cs),
+(91,75,l),
+(111,39,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(384,396,o),
+(357,417,o),
+(326,417,cs),
+(298,417,o),
+(274,401,o),
+(265,376,c),
+(260,376,l),
+(233,655,l),
+(199,614,l),
+(407,614,ls),
+(468,614,o),
+(502,579,o),
+(502,522,cs),
+(502,446,o),
+(464,376,o),
+(361,376,cs),
+(327,376,l),
+(389,364,l)
+);
+}
+);
+width = 593;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FF;
+unicode = 5631;
+},
+{
+color = 9;
+glyphname = "kkaCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(484,0,l),
+(489,25,l),
+(464,308,l),
+(545,308,l),
+(560,382,l),
+(484,382,l),
+(625,665,l),
+(631,690,l),
+(350,690,ls),
+(181,690,o),
+(113,585,o),
+(113,473,cs),
+(113,405,o),
+(146,355,o),
+(207,335,c),
+(209,364,l),
+(82,336,o),
+(45,238,o),
+(45,159,cs),
+(45,64,o),
+(112,0,o),
+(215,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(440,75,l),
+(232,75,ls),
+(171,75,o),
+(135,111,o),
+(135,168,cs),
+(135,243,o),
+(179,308,o),
+(281,308,cs),
+(379,308,l),
+(405,35,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(234,382,o),
+(200,412,o),
+(200,469,cs),
+(200,520,o),
+(219,614,o),
+(344,614,cs),
+(547,614,l),
+(527,651,l),
+(393,382,l),
+(297,382,ls)
+);
+}
+);
+width = 593;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|kkeCarrier-canadian";
+note = uni1600;
+unicode = 5632;
+},
+{
+color = 6;
+glyphname = "kkCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(294,527,l),
+(142,251,l),
+(182,251,l),
+(147,527,l),
+(92,527,l),
+(89,514,l),
+(142,183,l),
+(157,183,l),
+(353,514,l),
+(355,527,l)
+);
+}
+);
+width = 325;
+}
+);
+note = uni1601;
+unicode = 5633;
+},
+{
+color = 9;
+glyphname = "nuCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(400,-13,o),
+(491,75,o),
+(526,237,cs),
+(539,301,l),
+(450,301,l),
+(437,241,ls),
+(413,128,o),
+(356,71,o),
+(267,71,cs),
+(168,71,o),
+(126,136,o),
+(151,252,cs),
+(243,690,l),
+(154,690,l),
+(61,258,ls),
+(27,94,o),
+(103,-13,o),
+(260,-13,cs)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "te-canadian";
+note = uni1602;
+unicode = 5634;
+},
+{
+color = 9;
+glyphname = "noCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(469,0,l),
+(560,432,ls),
+(595,596,o),
+(519,702,o),
+(362,702,cs),
+(222,702,o),
+(131,614,o),
+(97,453,cs),
+(83,388,l),
+(172,388,l),
+(186,449,ls),
+(209,562,o),
+(266,618,o),
+(356,619,cs),
+(454,619,o),
+(497,554,o),
+(471,438,cs),
+(379,0,l)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "=|nuCarrier-canadian";
+metricRight = "te-canadian";
+note = uni1603;
+unicode = 5635;
+},
+{
+color = 9;
+glyphname = "neCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (267,345);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(185,0,ls),
+(452,0,o),
+(552,248,o),
+(552,441,cs),
+(552,602,o),
+(463,690,o),
+(300,690,cs),
+(135,690,l),
+(118,607,l),
+(285,607,ls),
+(403,607,o),
+(462,551,o),
+(462,437,cs),
+(462,310,o),
+(404,83,o),
+(194,83,cs),
+(185,83,l),
+(167,0,l)
+);
+}
+);
+width = 568;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1604;
+unicode = 5636;
+},
+{
+color = 9;
+glyphname = "neeCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "neCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (199,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 568;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1605;
+unicode = 5637;
+},
+{
+color = 9;
+glyphname = "niCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "neCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (178,0);
+ref = dot_middle;
+}
+);
+width = 568;
+}
+);
+note = uni1606;
+unicode = 5638;
+},
+{
+color = 9;
+glyphname = "naCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(477,0,l),
+(495,83,l),
+(327,83,ls),
+(210,83,o),
+(151,139,o),
+(151,253,cs),
+(151,380,o),
+(209,607,o),
+(418,607,cs),
+(428,607,l),
+(445,690,l),
+(427,690,ls),
+(160,690,o),
+(61,441,o),
+(61,248,cs),
+(61,88,o),
+(150,0,o),
+(312,0,cs)
+);
+}
+);
+width = 567;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni1607;
+unicode = 5639;
+},
+{
+color = 9;
+glyphname = "muCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(244,-13,o),
+(300,30,o),
+(337,116,c),
+(303,116,l),
+(309,34,o),
+(355,-13,o),
+(435,-13,cs),
+(533,-13,o),
+(590,50,o),
+(617,175,cs),
+(663,390,l),
+(577,390,l),
+(531,177,ls),
+(516,105,o),
+(484,70,o),
+(434,70,cs),
+(381,70,o),
+(357,109,o),
+(373,179,cs),
+(417,390,l),
+(333,390,l),
+(289,178,ls),
+(273,106,o),
+(240,70,o),
+(187,70,cs),
+(135,70,o),
+(113,107,o),
+(128,180,cs),
+(237,690,l),
+(151,690,l),
+(43,183,ls),
+(17,61,o),
+(64,-13,o),
+(168,-13,cs)
+);
+}
+);
+width = 686;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "=|";
+note = uni1608;
+unicode = 5640;
+},
+{
+color = 9;
+glyphname = "moCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(580,0,l),
+(687,507,ls),
+(713,629,o),
+(667,702,o),
+(562,702,cs),
+(486,702,o),
+(430,660,o),
+(393,574,c),
+(427,574,l),
+(421,656,o),
+(375,702,o),
+(296,702,cs),
+(197,702,o),
+(140,639,o),
+(114,515,cs),
+(68,299,l),
+(155,299,l),
+(200,513,ls),
+(214,584,o),
+(246,620,o),
+(297,620,cs),
+(350,620,o),
+(373,581,o),
+(357,511,cs),
+(313,299,l),
+(397,299,l),
+(441,512,ls),
+(457,583,o),
+(491,620,o),
+(543,620,cs),
+(595,620,o),
+(617,582,o),
+(602,510,cs),
+(494,0,l)
+);
+}
+);
+width = 686;
+}
+);
+metricLeft = "=|muCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni1609;
+unicode = 5641;
+},
+{
+color = 9;
+glyphname = "meCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(272,0,ls),
+(441,0,o),
+(509,104,o),
+(509,216,cs),
+(509,285,o),
+(475,337,o),
+(413,355,c),
+(410,325,l),
+(529,350,o),
+(576,441,o),
+(576,530,cs),
+(576,626,o),
+(509,690,o),
+(407,690,cs),
+(135,690,l),
+(120,614,l),
+(390,614,ls),
+(451,614,o),
+(486,579,o),
+(486,522,cs),
+(486,446,o),
+(443,382,o),
+(341,382,cs),
+(260,382,l),
+(244,308,l),
+(326,308,ls),
+(387,308,o),
+(421,277,o),
+(421,221,cs),
+(421,169,o),
+(403,75,o),
+(277,75,cs),
+(195,75,l),
+(180,0,l)
+);
+}
+);
+width = 576;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160A;
+unicode = 5642;
+},
+{
+color = 9;
+glyphname = "meeCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(272,0,ls),
+(441,0,o),
+(509,104,o),
+(509,216,cs),
+(509,285,o),
+(475,337,o),
+(413,355,c),
+(410,325,l),
+(529,350,o),
+(576,441,o),
+(576,530,cs),
+(576,626,o),
+(509,690,o),
+(407,690,cs),
+(135,690,l),
+(120,614,l),
+(390,614,ls),
+(451,614,o),
+(486,579,o),
+(486,522,cs),
+(486,446,o),
+(443,381,o),
+(343,381,cs),
+(314,381,l),
+(332,464,l),
+(277,464,l),
+(227,228,l),
+(282,228,l),
+(299,309,l),
+(328,309,ls),
+(388,309,o),
+(421,277,o),
+(421,221,cs),
+(421,169,o),
+(403,75,o),
+(277,75,cs),
+(195,75,l),
+(180,0,l)
+);
+}
+);
+width = 576;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160B;
+unicode = 5643;
+},
+{
+color = 9;
+glyphname = "miCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(272,0,ls),
+(437,0,o),
+(497,96,o),
+(507,196,cs),
+(515,274,o),
+(481,333,o),
+(413,355,c),
+(410,325,l),
+(523,348,o),
+(566,430,o),
+(574,510,cs),
+(585,615,o),
+(519,690,o),
+(407,690,cs),
+(135,690,l),
+(120,614,l),
+(390,614,ls),
+(453,614,o),
+(489,576,o),
+(485,514,cs),
+(482,440,o),
+(440,381,o),
+(341,381,cs),
+(306,381,l),
+(355,355,l),
+(351,390,o),
+(322,417,o),
+(285,417,cs),
+(245,417,o),
+(214,384,o),
+(214,345,cs),
+(214,305,o),
+(245,272,o),
+(285,272,cs),
+(322,272,o),
+(350,300,o),
+(355,335,c),
+(305,309,l),
+(327,309,ls),
+(391,309,o),
+(425,275,o),
+(421,213,cs),
+(417,157,o),
+(393,75,o),
+(277,75,cs),
+(195,75,l),
+(180,0,l)
+);
+}
+);
+width = 574;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160C;
+unicode = 5644;
+},
+{
+color = 9;
+glyphname = "maCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(486,0,l),
+(502,75,l),
+(231,75,ls),
+(170,75,o),
+(134,111,o),
+(134,168,cs),
+(134,243,o),
+(178,308,o),
+(279,308,cs),
+(360,308,l),
+(377,382,l),
+(296,382,ls),
+(233,382,o),
+(199,412,o),
+(199,469,cs),
+(199,521,o),
+(218,614,o),
+(343,614,cs),
+(426,614,l),
+(441,690,l),
+(349,690,ls),
+(180,690,o),
+(112,585,o),
+(112,473,cs),
+(112,405,o),
+(146,353,o),
+(207,334,c),
+(212,365,l),
+(92,340,o),
+(44,248,o),
+(44,159,cs),
+(44,64,o),
+(111,0,o),
+(214,0,cs)
+);
+}
+);
+width = 576;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni160D;
+unicode = 5645;
+},
+{
+color = 9;
+glyphname = "yuCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(430,-13,o),
+(536,106,o),
+(590,361,cs),
+(637,582,o),
+(603,702,o),
+(485,702,cs),
+(351,702,o),
+(303,537,o),
+(303,444,cs),
+(303,361,o),
+(345,307,o),
+(412,307,cs),
+(426,307,o),
+(438,309,o),
+(446,314,c),
+(461,384,l),
+(453,382,o),
+(445,380,o),
+(437,380,cs),
+(400,380,o),
+(381,406,o),
+(381,452,cs),
+(381,501,o),
+(405,630,o),
+(474,630,cs),
+(536,630,o),
+(545,552,o),
+(511,386,cs),
+(464,163,o),
+(394,71,o),
+(269,71,cs),
+(164,71,o),
+(125,133,o),
+(150,251,cs),
+(242,690,l),
+(153,690,l),
+(61,258,ls),
+(26,93,o),
+(101,-13,o),
+(261,-13,cs)
+);
+}
+);
+width = 621;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160E;
+unicode = 5646;
+},
+{
+color = 9;
+glyphname = "yoCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(316,-13,o),
+(363,153,o),
+(363,245,cs),
+(363,328,o),
+(323,383,o),
+(255,383,cs),
+(242,383,o),
+(229,381,o),
+(220,376,c),
+(206,305,l),
+(214,308,o),
+(222,310,o),
+(231,310,cs),
+(267,310,o),
+(286,284,o),
+(286,238,cs),
+(286,188,o),
+(262,60,o),
+(192,60,cs),
+(131,60,o),
+(122,138,o),
+(156,303,cs),
+(203,526,o),
+(272,618,o),
+(399,618,cs),
+(503,618,o),
+(543,556,o),
+(518,439,cs),
+(424,0,l),
+(515,0,l),
+(607,432,ls),
+(640,597,o),
+(565,702,o),
+(406,702,cs),
+(237,702,o),
+(130,583,o),
+(76,328,cs),
+(30,107,o),
+(64,-13,o),
+(182,-13,cs)
+);
+}
+);
+width = 623;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160F;
+unicode = 5647;
+},
+{
+color = 9;
+glyphname = "yeCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(456,-13,o),
+(545,267,o),
+(545,430,cs),
+(545,601,o),
+(458,690,o),
+(297,690,cs),
+(152,690,l),
+(134,607,l),
+(283,607,ls),
+(396,607,o),
+(454,547,o),
+(454,423,cs),
+(454,305,o),
+(402,65,o),
+(231,65,cs),
+(155,65,o),
+(112,106,o),
+(112,181,cs),
+(112,232,o),
+(134,334,o),
+(204,334,cs),
+(239,334,o),
+(256,310,o),
+(256,264,cs),
+(256,229,o),
+(246,191,o),
+(235,156,c),
+(302,156,l),
+(317,195,o),
+(327,239,o),
+(327,277,cs),
+(327,357,o),
+(283,408,o),
+(209,408,cs),
+(84,408,o),
+(35,266,o),
+(35,171,cs),
+(35,59,o),
+(107,-13,o),
+(227,-13,cs)
+);
+}
+);
+width = 563;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1610;
+unicode = 5648;
+},
+{
+color = 9;
+glyphname = "yeeCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(457,-13,o),
+(546,271,o),
+(546,436,cs),
+(546,601,o),
+(457,690,o),
+(298,690,cs),
+(152,690,l),
+(134,607,l),
+(283,607,ls),
+(396,607,o),
+(454,547,o),
+(454,428,cs),
+(454,310,o),
+(402,65,o),
+(231,65,cs),
+(155,65,o),
+(112,105,o),
+(112,181,cs),
+(112,230,o),
+(135,334,o),
+(202,334,cs),
+(242,334,o),
+(258,296,o),
+(244,232,cs),
+(233,179,l),
+(288,179,l),
+(355,497,l),
+(301,497,l),
+(260,303,l),
+(271,303,l),
+(279,366,o),
+(246,408,o),
+(190,408,cs),
+(81,408,o),
+(36,265,o),
+(36,176,cs),
+(36,61,o),
+(106,-13,o),
+(231,-13,cs)
+);
+}
+);
+width = 563;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1611;
+unicode = 5649;
+},
+{
+color = 9;
+glyphname = "yiCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(458,-13,o),
+(546,270,o),
+(546,436,cs),
+(546,601,o),
+(458,690,o),
+(298,690,cs),
+(152,690,l),
+(134,607,l),
+(283,607,ls),
+(396,607,o),
+(454,547,o),
+(454,428,cs),
+(454,307,o),
+(402,65,o),
+(231,65,cs),
+(153,65,o),
+(111,107,o),
+(111,179,cs),
+(111,242,o),
+(136,322,o),
+(213,319,c),
+(191,344,l),
+(192,306,o),
+(224,278,o),
+(261,278,cs),
+(299,278,o),
+(329,308,o),
+(329,346,cs),
+(329,383,o),
+(299,412,o),
+(261,412,cs),
+(234,412,o),
+(212,398,o),
+(200,377,c),
+(88,372,o),
+(34,265,o),
+(34,168,cs),
+(34,59,o),
+(108,-13,o),
+(226,-13,cs)
+);
+}
+);
+width = 563;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1612;
+unicode = 5650;
+},
+{
+color = 9;
+glyphname = "yaCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(456,0,l),
+(473,83,l),
+(325,83,ls),
+(212,83,o),
+(154,143,o),
+(154,267,cs),
+(154,384,o),
+(206,625,o),
+(377,625,cs),
+(453,625,o),
+(496,583,o),
+(496,509,cs),
+(496,458,o),
+(473,355,o),
+(403,355,cs),
+(369,355,o),
+(352,380,o),
+(352,426,cs),
+(352,463,o),
+(360,498,o),
+(373,533,c),
+(304,533,l),
+(291,495,o),
+(280,451,o),
+(280,412,cs),
+(280,332,o),
+(324,282,o),
+(399,282,cs),
+(523,282,o),
+(573,424,o),
+(573,519,cs),
+(573,631,o),
+(500,702,o),
+(381,702,cs),
+(152,702,o),
+(62,423,o),
+(62,260,cs),
+(62,89,o),
+(149,0,o),
+(311,0,cs)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|yeCarrier-canadian";
+note = uni1613;
+unicode = 5651;
+},
+{
+color = 9;
+glyphname = "juCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(453,-13,o),
+(528,132,o),
+(528,257,cs),
+(528,348,o),
+(481,408,o),
+(403,408,cs),
+(310,408,o),
+(262,328,o),
+(248,228,cs),
+(244,201,o),
+(243,174,o),
+(244,156,c),
+(312,156,l),
+(312,173,o),
+(312,198,o),
+(319,231,cs),
+(332,295,o),
+(358,334,o),
+(399,334,cs),
+(434,334,o),
+(453,305,o),
+(453,256,cs),
+(453,175,o),
+(412,65,o),
+(291,65,cs),
+(198,65,o),
+(150,121,o),
+(150,222,cs),
+(150,367,o),
+(238,607,o),
+(519,607,cs),
+(598,607,l),
+(616,690,l),
+(144,690,l),
+(127,610,l),
+(375,610,l),
+(434,640,l),
+(189,633,o),
+(61,426,o),
+(61,223,cs),
+(61,78,o),
+(144,-13,o),
+(283,-13,cs)
+);
+}
+);
+width = 574;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni1614;
+unicode = 5652;
+},
+{
+color = 9;
+glyphname = "juSayisi-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (401,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(426,-13,o),
+(521,183,o),
+(536,350,cs),
+(552,526,o),
+(464,637,o),
+(291,646,c),
+(355,610,l),
+(605,610,l),
+(621,690,l),
+(149,690,l),
+(131,607,l),
+(206,607,ls),
+(385,607,o),
+(463,524,o),
+(448,360,cs),
+(440,241,o),
+(389,65,o),
+(238,65,cs),
+(152,65,o),
+(106,112,o),
+(112,194,cs),
+(115,247,o),
+(140,334,o),
+(200,334,cs),
+(237,334,o),
+(252,306,o),
+(249,254,cs),
+(249,225,o),
+(241,185,o),
+(230,156,c),
+(298,156,l),
+(310,191,o),
+(319,227,o),
+(321,263,cs),
+(328,352,o),
+(286,408,o),
+(206,408,cs),
+(100,408,o),
+(46,294,o),
+(37,200,cs),
+(24,73,o),
+(101,-13,o),
+(236,-13,cs)
+);
+}
+);
+width = 574;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1615;
+unicode = 5653;
+},
+{
+color = 9;
+glyphname = "joCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(475,0,l),
+(493,80,l),
+(244,80,l),
+(185,49,l),
+(430,57,o),
+(558,264,o),
+(558,467,cs),
+(558,611,o),
+(475,702,o),
+(336,702,cs),
+(166,702,o),
+(91,557,o),
+(91,433,cs),
+(91,342,o),
+(138,282,o),
+(216,282,cs),
+(309,282,o),
+(357,361,o),
+(371,462,cs),
+(375,489,o),
+(376,516,o),
+(375,533,c),
+(307,533,l),
+(307,517,o),
+(307,492,o),
+(300,459,cs),
+(287,395,o),
+(261,355,o),
+(220,355,cs),
+(185,355,o),
+(166,384,o),
+(166,434,cs),
+(166,515,o),
+(207,625,o),
+(328,625,cs),
+(421,625,o),
+(469,569,o),
+(469,468,cs),
+(469,323,o),
+(382,83,o),
+(100,83,cs),
+(21,83,l),
+(3,0,l)
+);
+}
+);
+width = 575;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1616;
+unicode = 5654;
+},
+{
+color = 9;
+glyphname = "jeCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(543,-13,o),
+(593,314,o),
+(593,454,cs),
+(593,610,o),
+(532,702,o),
+(415,702,cs),
+(305,702,o),
+(226,622,o),
+(178,461,c),
+(196,460,l),
+(245,690,l),
+(156,690,l),
+(9,0,l),
+(99,0,l),
+(163,302,ls),
+(208,515,o),
+(283,619,o),
+(391,619,cs),
+(471,619,o),
+(508,564,o),
+(508,451,cs),
+(508,365,o),
+(473,60,o),
+(369,60,cs),
+(333,60,o),
+(315,85,o),
+(315,131,cs),
+(315,190,o),
+(342,310,o),
+(422,310,cs),
+(433,310,o),
+(442,308,o),
+(448,305,c),
+(461,376,l),
+(449,381,o),
+(434,383,o),
+(417,383,cs),
+(287,383,o),
+(240,223,o),
+(240,128,cs),
+(240,41,o),
+(284,-13,o),
+(362,-13,cs)
+);
+}
+);
+width = 624;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "te-canadian";
+note = uni1617;
+unicode = 5655;
+},
+{
+color = 9;
+glyphname = "jeeCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(543,-13,o),
+(593,316,o),
+(593,453,cs),
+(593,610,o),
+(532,702,o),
+(415,702,cs),
+(305,702,o),
+(226,622,o),
+(178,461,c),
+(196,460,l),
+(245,690,l),
+(156,690,l),
+(9,0,l),
+(99,0,l),
+(161,295,ls),
+(209,517,o),
+(281,619,o),
+(390,619,cs),
+(471,619,o),
+(508,563,o),
+(508,450,cs),
+(508,337,o),
+(471,60,o),
+(355,60,cs),
+(310,60,o),
+(286,91,o),
+(286,145,cs),
+(286,200,o),
+(309,298,o),
+(374,319,c),
+(356,236,l),
+(403,236,l),
+(447,448,l),
+(402,448,l),
+(384,369,l),
+(277,348,o),
+(239,208,o),
+(239,127,cs),
+(239,40,o),
+(284,-13,o),
+(362,-13,cs)
+);
+}
+);
+width = 623;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1618;
+unicode = 5656;
+},
+{
+color = 9;
+glyphname = "jiCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(543,-13,o),
+(593,316,o),
+(593,453,cs),
+(593,610,o),
+(532,702,o),
+(415,702,cs),
+(305,702,o),
+(226,622,o),
+(178,461,c),
+(196,460,l),
+(245,690,l),
+(156,690,l),
+(9,0,l),
+(99,0,l),
+(161,295,ls),
+(209,517,o),
+(281,619,o),
+(390,619,cs),
+(471,619,o),
+(508,563,o),
+(508,450,cs),
+(508,337,o),
+(471,60,o),
+(355,60,cs),
+(310,60,o),
+(286,91,o),
+(286,145,cs),
+(286,191,o),
+(302,269,o),
+(349,298,c),
+(357,285,o),
+(373,275,o),
+(391,275,cs),
+(427,275,o),
+(454,304,o),
+(454,342,cs),
+(454,379,o),
+(427,408,o),
+(391,408,cs),
+(354,408,o),
+(327,373,o),
+(330,337,c),
+(263,295,o),
+(239,191,o),
+(239,127,cs),
+(239,40,o),
+(284,-13,o),
+(362,-13,cs)
+);
+}
+);
+width = 623;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1619;
+unicode = 5657;
+},
+{
+color = 9;
+glyphname = "jiSayisi-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(522,-13,o),
+(612,350,o),
+(612,521,cs),
+(612,642,o),
+(569,702,o),
+(485,702,cs),
+(350,702,o),
+(307,533,o),
+(307,444,cs),
+(307,355,o),
+(353,307,o),
+(412,307,cs),
+(429,307,o),
+(440,309,o),
+(448,314,c),
+(465,384,l),
+(457,382,o),
+(449,380,o),
+(439,380,cs),
+(405,381,o),
+(383,402,o),
+(383,454,cs),
+(383,494,o),
+(405,630,o),
+(478,630,cs),
+(515,630,o),
+(531,601,o),
+(531,532,cs),
+(531,419,o),
+(469,71,o),
+(289,71,cs),
+(142,71,o),
+(154,257,o),
+(182,390,cs),
+(245,690,l),
+(156,690,l),
+(9,0,l),
+(99,0,l),
+(159,290,l),
+(139,296,l),
+(108,148,o),
+(140,-13,o),
+(296,-13,cs)
+);
+}
+);
+width = 625;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161A;
+unicode = 5658;
+},
+{
+color = 9;
+glyphname = "jaCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (401,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(364,-13,o),
+(443,68,o),
+(491,229,c),
+(472,230,l),
+(424,0,l),
+(514,0,l),
+(661,690,l),
+(570,690,l),
+(506,388,ls),
+(462,176,o),
+(386,71,o),
+(277,71,cs),
+(197,71,o),
+(160,127,o),
+(160,239,cs),
+(160,325,o),
+(196,630,o),
+(300,630,cs),
+(335,630,o),
+(354,606,o),
+(354,559,cs),
+(354,500,o),
+(327,381,o),
+(247,381,cs),
+(237,381,o),
+(227,382,o),
+(221,384,c),
+(209,314,l),
+(220,310,o),
+(235,307,o),
+(251,307,cs),
+(383,307,o),
+(430,467,o),
+(430,561,cs),
+(430,650,o),
+(385,703,o),
+(307,703,cs),
+(127,703,o),
+(75,377,o),
+(75,236,cs),
+(75,80,o),
+(137,-13,o),
+(254,-13,cs)
+);
+}
+);
+width = 625;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni161B;
+unicode = 5659;
+},
+{
+color = 9;
+glyphname = "jjuCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,-13,o),
+(524,130,o),
+(524,261,cs),
+(524,350,o),
+(477,408,o),
+(400,408,cs),
+(322,408,o),
+(270,350,o),
+(245,242,cs),
+(239,213,o),
+(236,180,o),
+(236,156,c),
+(303,156,l),
+(304,171,o),
+(306,197,o),
+(313,229,cs),
+(328,298,o),
+(355,334,o),
+(394,334,cs),
+(429,334,o),
+(448,305,o),
+(448,258,cs),
+(448,178,o),
+(407,63,o),
+(285,63,cs),
+(198,63,o),
+(152,120,o),
+(152,225,cs),
+(152,398,o),
+(242,607,o),
+(483,607,cs),
+(591,607,l),
+(609,690,l),
+(498,690,ls),
+(397,690,o),
+(314,662,o),
+(248,616,c),
+(182,702,l),
+(109,646,l),
+(179,557,l),
+(96,468,o),
+(64,336,o),
+(64,230,cs),
+(64,82,o),
+(143,-13,o),
+(277,-13,cs)
+);
+}
+);
+width = 569;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni161C;
+unicode = 5660;
+},
+{
+color = 9;
+glyphname = "jjoCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(504,43,l),
+(435,132,l),
+(519,222,o),
+(551,354,o),
+(551,460,cs),
+(551,608,o),
+(470,702,o),
+(336,702,cs),
+(173,702,o),
+(90,559,o),
+(90,429,cs),
+(90,340,o),
+(137,282,o),
+(214,282,cs),
+(293,282,o),
+(344,340,o),
+(368,447,cs),
+(375,476,o),
+(379,510,o),
+(379,533,c),
+(311,533,l),
+(310,519,o),
+(307,493,o),
+(301,461,cs),
+(286,392,o),
+(259,355,o),
+(220,355,cs),
+(185,355,o),
+(166,384,o),
+(166,432,cs),
+(166,512,o),
+(208,627,o),
+(329,627,cs),
+(416,627,o),
+(463,570,o),
+(463,465,cs),
+(463,292,o),
+(371,83,o),
+(130,83,cs),
+(22,83,l),
+(5,0,l),
+(116,0,ls),
+(216,0,o),
+(299,28,o),
+(365,73,c),
+(432,-13,l)
+);
+}
+);
+width = 568;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|jjuCarrier-canadian";
+note = uni161D;
+unicode = 5661;
+},
+{
+color = 9;
+glyphname = "jjeCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(549,-13,o),
+(598,314,o),
+(598,453,cs),
+(598,618,o),
+(525,702,o),
+(390,702,cs),
+(330,702,o),
+(270,683,o),
+(221,639,c),
+(167,702,l),
+(100,640,l),
+(162,568,l),
+(136,527,o),
+(115,475,o),
+(100,410,cs),
+(14,0,l),
+(103,0,l),
+(190,408,ls),
+(220,548,o),
+(286,619,o),
+(384,619,cs),
+(471,619,o),
+(513,567,o),
+(513,451,cs),
+(513,367,o),
+(478,60,o),
+(373,60,cs),
+(338,60,o),
+(320,85,o),
+(320,131,cs),
+(320,190,o),
+(346,310,o),
+(426,310,cs),
+(437,310,o),
+(446,308,o),
+(452,305,c),
+(466,376,l),
+(454,381,o),
+(439,383,o),
+(422,383,cs),
+(292,383,o),
+(244,223,o),
+(244,128,cs),
+(244,41,o),
+(288,-13,o),
+(367,-13,cs)
+);
+}
+);
+width = 629;
+}
+);
+metricRight = "jeCarrier-canadian";
+note = uni161E;
+unicode = 5662;
+},
+{
+color = 9;
+glyphname = "jjeeCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(549,-13,o),
+(598,314,o),
+(598,453,cs),
+(598,618,o),
+(525,702,o),
+(390,702,cs),
+(330,702,o),
+(270,683,o),
+(221,639,c),
+(167,702,l),
+(100,640,l),
+(162,568,l),
+(136,527,o),
+(115,475,o),
+(100,410,cs),
+(14,0,l),
+(103,0,l),
+(190,408,ls),
+(220,548,o),
+(286,619,o),
+(384,619,cs),
+(471,619,o),
+(513,567,o),
+(513,451,cs),
+(513,357,o),
+(480,60,o),
+(362,60,cs),
+(318,60,o),
+(291,89,o),
+(291,147,cs),
+(291,211,o),
+(315,303,o),
+(379,320,c),
+(361,236,l),
+(407,236,l),
+(452,448,l),
+(406,448,l),
+(389,369,l),
+(284,348,o),
+(244,214,o),
+(244,128,cs),
+(244,41,o),
+(288,-13,o),
+(367,-13,cs)
+);
+}
+);
+width = 629;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161F;
+unicode = 5663;
+},
+{
+color = 9;
+glyphname = "jjiCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(473,-13,o),
+(540,89,o),
+(581,284,cs),
+(636,549,o),
+(565,702,o),
+(390,702,cs),
+(324,702,o),
+(267,681,o),
+(221,639,c),
+(167,702,l),
+(100,640,l),
+(162,570,l),
+(135,527,o),
+(114,473,o),
+(100,410,cs),
+(14,0,l),
+(103,0,l),
+(190,408,ls),
+(220,548,o),
+(285,619,o),
+(384,619,cs),
+(504,619,o),
+(542,510,o),
+(497,290,cs),
+(463,132,o),
+(427,60,o),
+(359,60,cs),
+(301,60,o),
+(279,113,o),
+(298,204,cs),
+(308,252,o),
+(326,284,o),
+(353,298,c),
+(361,285,o),
+(378,275,o),
+(396,275,cs),
+(432,275,o),
+(459,305,o),
+(459,342,cs),
+(459,379,o),
+(432,408,o),
+(396,408,cs),
+(353,408,o),
+(332,367,o),
+(335,336,c),
+(294,311,o),
+(266,262,o),
+(252,195,cs),
+(225,67,o),
+(271,-13,o),
+(367,-13,cs)
+);
+}
+);
+width = 628;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1620;
+unicode = 5664;
+},
+{
+color = 9;
+glyphname = "jjaCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(344,-13,o),
+(404,7,o),
+(453,51,c),
+(507,-13,l),
+(574,49,l),
+(512,122,l),
+(538,162,o),
+(559,214,o),
+(574,280,cs),
+(661,690,l),
+(571,690,l),
+(484,282,ls),
+(454,142,o),
+(388,71,o),
+(290,71,cs),
+(203,71,o),
+(161,123,o),
+(161,239,cs),
+(161,323,o),
+(197,630,o),
+(301,630,cs),
+(336,630,o),
+(355,605,o),
+(355,558,cs),
+(355,499,o),
+(328,380,o),
+(248,380,cs),
+(238,380,o),
+(228,382,o),
+(222,384,c),
+(209,314,l),
+(220,309,o),
+(236,307,o),
+(252,307,cs),
+(383,307,o),
+(430,467,o),
+(430,561,cs),
+(430,649,o),
+(386,702,o),
+(307,702,cs),
+(126,702,o),
+(75,376,o),
+(75,237,cs),
+(75,71,o),
+(150,-13,o),
+(284,-13,cs)
+);
+}
+);
+width = 629;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "=|jjeCarrier-canadian";
+note = uni1621;
+unicode = 5665;
+},
+{
+color = 9;
+glyphname = "luCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(404,-13,o),
+(485,65,o),
+(520,228,cs),
+(618,690,l),
+(528,690,l),
+(432,237,ls),
+(407,123,o),
+(357,71,o),
+(274,71,cs),
+(192,71,o),
+(151,123,o),
+(151,220,cs),
+(151,338,o),
+(209,595,o),
+(390,617,c),
+(406,690,l),
+(143,690,l),
+(127,614,l),
+(290,614,l),
+(355,641,l),
+(154,632,o),
+(59,382,o),
+(59,215,cs),
+(59,73,o),
+(134,-13,o),
+(271,-13,cs)
+);
+}
+);
+width = 579;
+}
+);
+metricRight = "te-canadian";
+note = uni1622;
+unicode = 5666;
+},
+{
+color = 9;
+glyphname = "loCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,0,l),
+(193,453,ls),
+(217,567,o),
+(268,619,o),
+(351,619,cs),
+(433,619,o),
+(474,567,o),
+(474,469,cs),
+(474,352,o),
+(416,95,o),
+(235,72,c),
+(219,0,l),
+(482,0,l),
+(497,75,l),
+(334,75,l),
+(270,48,l),
+(471,58,o),
+(566,308,o),
+(566,474,cs),
+(566,616,o),
+(491,702,o),
+(354,702,cs),
+(220,702,o),
+(139,625,o),
+(104,462,cs),
+(7,0,l)
+);
+}
+);
+width = 580;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|luCarrier-canadian";
+note = uni1623;
+unicode = 5667;
+},
+{
+color = 9;
+glyphname = "leCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (300,345);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(182,0,ls),
+(479,0,o),
+(550,281,o),
+(550,455,cs),
+(550,608,o),
+(488,702,o),
+(384,702,cs),
+(300,702,o),
+(230,640,o),
+(188,528,c),
+(199,528,l),
+(233,690,l),
+(153,690,l),
+(87,383,l),
+(163,383,l),
+(197,530,o),
+(268,619,o),
+(352,619,cs),
+(422,619,o),
+(459,557,o),
+(459,446,cs),
+(459,316,o),
+(407,83,o),
+(184,83,cs),
+(23,83,l),
+(6,0,l)
+);
+}
+);
+width = 565;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1624;
+unicode = 5668;
+},
+{
+color = 9;
+glyphname = "leeCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "leCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (232,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 565;
+}
+);
+metricLeft = "leCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1625;
+unicode = 5669;
+},
+{
+color = 9;
+glyphname = "liCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "leCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (212,0);
+ref = dot_middle;
+}
+);
+width = 565;
+}
+);
+note = uni1626;
+unicode = 5670;
+},
+{
+color = 9;
+glyphname = "laCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(457,0,l),
+(475,83,l),
+(329,83,ls),
+(210,83,o),
+(150,138,o),
+(150,252,cs),
+(150,367,o),
+(210,619,o),
+(358,619,cs),
+(447,619,o),
+(487,526,o),
+(463,383,c),
+(539,383,l),
+(604,690,l),
+(523,690,l),
+(485,511,l),
+(494,507,l),
+(499,630,o),
+(445,702,o),
+(353,702,cs),
+(149,702,o),
+(60,408,o),
+(60,248,cs),
+(60,88,o),
+(148,0,o),
+(314,0,cs)
+);
+}
+);
+width = 564;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|leCarrier-canadian";
+note = uni1627;
+unicode = 5671;
+},
+{
+color = 1;
+glyphname = "dluCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(491,-13,o),
+(550,298,o),
+(550,418,cs),
+(550,543,o),
+(496,618,o),
+(390,641,c),
+(406,620,l),
+(599,620,l),
+(581,539,l),
+(647,539,l),
+(697,771,l),
+(631,771,l),
+(613,690,l),
+(364,690,l),
+(349,616,l),
+(431,598,o),
+(466,541,o),
+(466,440,cs),
+(466,355,o),
+(426,71,o),
+(251,71,cs),
+(159,71,o),
+(126,137,o),
+(153,266,cs),
+(242,690,l),
+(153,690,l),
+(64,274,ls),
+(25,90,o),
+(92,-13,o),
+(243,-13,cs)
+);
+}
+);
+width = 617;
+}
+);
+metricLeft = "te-canadian";
+note = uni1628;
+unicode = 5672;
+},
+{
+color = 9;
+glyphname = "dloCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(518,-81,l),
+(567,151,l),
+(500,151,l),
+(482,70,l),
+(327,70,l),
+(275,53,l),
+(452,63,o),
+(566,282,o),
+(566,474,cs),
+(566,616,o),
+(491,702,o),
+(354,702,cs),
+(220,702,o),
+(139,625,o),
+(104,462,cs),
+(7,0,l),
+(97,0,l),
+(193,453,ls),
+(217,567,o),
+(268,619,o),
+(351,619,cs),
+(433,619,o),
+(474,567,o),
+(474,469,cs),
+(474,352,o),
+(416,95,o),
+(235,72,c),
+(219,0,l),
+(469,0,l),
+(451,-81,l)
+);
+}
+);
+width = 619;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "dluCarrier-canadian";
+note = uni1629;
+unicode = 5673;
+},
+{
+color = 9;
+glyphname = "dleCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (314,345);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(194,0,ls),
+(492,0,o),
+(562,281,o),
+(562,455,cs),
+(562,608,o),
+(500,702,o),
+(396,702,cs),
+(311,702,o),
+(230,636,o),
+(187,515,c),
+(194,515,l),
+(233,701,l),
+(298,701,l),
+(311,766,l),
+(118,766,l),
+(104,701,l),
+(168,701,l),
+(99,383,l),
+(176,383,l),
+(210,530,o),
+(280,619,o),
+(364,619,cs),
+(435,619,o),
+(471,557,o),
+(471,446,cs),
+(471,316,o),
+(419,83,o),
+(196,83,cs),
+(36,83,l),
+(18,0,l)
+);
+}
+);
+width = 577;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni162A;
+unicode = 5674;
+},
+{
+color = 9;
+glyphname = "dleeCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (246,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 578;
+}
+);
+note = uni162B;
+unicode = 5675;
+},
+{
+color = 9;
+glyphname = "dliCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (224,0);
+ref = dot_middle;
+}
+);
+width = 578;
+}
+);
+note = uni162C;
+unicode = 5676;
+},
+{
+color = 9;
+glyphname = "dlaCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(457,0,l),
+(475,83,l),
+(329,83,ls),
+(210,83,o),
+(150,138,o),
+(150,252,cs),
+(150,367,o),
+(210,619,o),
+(358,619,cs),
+(447,619,o),
+(487,526,o),
+(463,383,c),
+(539,383,l),
+(607,701,l),
+(669,701,l),
+(683,766,l),
+(491,766,l),
+(476,701,l),
+(540,701,l),
+(497,503,l),
+(508,499,l),
+(514,630,o),
+(445,702,o),
+(353,702,cs),
+(149,702,o),
+(60,408,o),
+(60,248,cs),
+(60,88,o),
+(148,0,o),
+(314,0,cs)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni162D;
+unicode = 5677;
+},
+{
+color = 9;
+glyphname = "lhuCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(496,-13,o),
+(568,250,o),
+(568,413,cs),
+(568,528,o),
+(526,613,o),
+(451,643,c),
+(479,614,l),
+(631,614,l),
+(646,690,l),
+(440,690,l),
+(424,617,l),
+(466,596,o),
+(487,541,o),
+(487,464,cs),
+(487,341,o),
+(441,71,o),
+(275,71,cs),
+(194,71,o),
+(154,123,o),
+(154,222,cs),
+(154,330,o),
+(204,565,o),
+(334,617,c),
+(350,690,l),
+(143,690,l),
+(127,614,l),
+(279,614,l),
+(319,648,l),
+(140,603,o),
+(62,364,o),
+(62,215,cs),
+(62,73,o),
+(135,-13,o),
+(271,-13,cs)
+);
+}
+);
+width = 598;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162E;
+unicode = 5678;
+},
+{
+color = 9;
+glyphname = "lhoCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(203,0,l),
+(218,72,l),
+(177,94,o),
+(157,149,o),
+(157,226,cs),
+(157,349,o),
+(202,619,o),
+(368,619,cs),
+(448,619,o),
+(490,567,o),
+(490,468,cs),
+(490,359,o),
+(440,125,o),
+(309,72,c),
+(294,0,l),
+(499,0,l),
+(516,75,l),
+(363,75,l),
+(324,42,l),
+(503,87,o),
+(582,326,o),
+(582,474,cs),
+(582,616,o),
+(508,702,o),
+(371,702,cs),
+(147,702,o),
+(74,440,o),
+(74,276,cs),
+(74,161,o),
+(116,76,o),
+(191,46,c),
+(164,75,l),
+(13,75,l),
+(-4,0,l)
+);
+}
+);
+width = 598;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162F;
+unicode = 5679;
+},
+{
+color = 9;
+glyphname = "lheCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (315,345);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(486,-13,o),
+(572,282,o),
+(572,458,cs),
+(572,610,o),
+(505,702,o),
+(392,702,cs),
+(307,702,o),
+(242,651,o),
+(203,554,c),
+(208,552,l),
+(237,690,l),
+(156,690,l),
+(98,416,l),
+(174,416,l),
+(212,554,o),
+(275,619,o),
+(358,619,cs),
+(440,619,o),
+(482,560,o),
+(482,455,cs),
+(482,332,o),
+(426,71,o),
+(262,71,cs),
+(172,71,o),
+(126,149,o),
+(143,273,c),
+(68,273,l),
+(9,0,l),
+(90,0,l),
+(126,170,l),
+(116,170,l),
+(113,58,o),
+(175,-13,o),
+(279,-13,cs)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1630;
+unicode = 5680;
+},
+{
+color = 9;
+glyphname = "lheeCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (247,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 586;
+}
+);
+note = uni1631;
+unicode = 5681;
+},
+{
+color = 9;
+glyphname = "lhiCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (225,0);
+ref = dot_middle;
+}
+);
+width = 586;
+}
+);
+note = uni1632;
+unicode = 5682;
+},
+{
+color = 9;
+glyphname = "lhaCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(323,-13,o),
+(388,39,o),
+(427,136,c),
+(422,138,l),
+(393,0,l),
+(474,0,l),
+(532,273,l),
+(456,273,l),
+(418,135,o),
+(354,71,o),
+(271,71,cs),
+(190,71,o),
+(148,129,o),
+(148,235,cs),
+(148,357,o),
+(205,619,o),
+(368,619,cs),
+(458,619,o),
+(504,541,o),
+(487,416,c),
+(563,416,l),
+(621,690,l),
+(540,690,l),
+(504,520,l),
+(514,520,l),
+(517,632,o),
+(455,702,o),
+(354,702,cs),
+(144,702,o),
+(59,408,o),
+(59,232,cs),
+(59,80,o),
+(125,-13,o),
+(238,-13,cs)
+);
+}
+);
+width = 585;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1633;
+unicode = 5683;
+},
+{
+color = 9;
+glyphname = "tlhuCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(496,-13,o),
+(568,250,o),
+(568,413,cs),
+(568,522,o),
+(541,607,o),
+(464,643,c),
+(458,620,l),
+(618,620,l),
+(601,539,l),
+(667,539,l),
+(716,771,l),
+(649,771,l),
+(632,690,l),
+(440,690,l),
+(424,617,l),
+(466,596,o),
+(487,541,o),
+(487,464,cs),
+(487,341,o),
+(441,71,o),
+(275,71,cs),
+(194,71,o),
+(154,123,o),
+(154,222,cs),
+(154,330,o),
+(204,565,o),
+(334,617,c),
+(350,690,l),
+(143,690,l),
+(127,614,l),
+(294,614,l),
+(285,636,l),
+(127,576,o),
+(62,353,o),
+(62,215,cs),
+(62,73,o),
+(135,-13,o),
+(271,-13,cs)
+);
+}
+);
+width = 633;
+}
+);
+metricLeft = "lhuCarrier-canadian";
+note = uni1634;
+unicode = 5684;
+},
+{
+color = 9;
+glyphname = "tlhoCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(29,-81,l),
+(46,0,l),
+(239,0,l),
+(254,72,l),
+(213,94,o),
+(192,149,o),
+(192,226,cs),
+(192,349,o),
+(238,619,o),
+(404,619,cs),
+(484,619,o),
+(526,567,o),
+(526,468,cs),
+(526,359,o),
+(475,125,o),
+(345,72,c),
+(329,0,l),
+(536,0,l),
+(552,75,l),
+(385,75,l),
+(394,54,l),
+(552,114,o),
+(617,337,o),
+(617,474,cs),
+(617,616,o),
+(544,702,o),
+(408,702,cs),
+(183,702,o),
+(110,440,o),
+(110,276,cs),
+(110,168,o),
+(138,83,o),
+(214,46,c),
+(220,70,l),
+(61,70,l),
+(78,151,l),
+(12,151,l),
+(-38,-81,l)
+);
+}
+);
+width = 634;
+}
+);
+metricLeft = "=|tlhuCarrier-canadian";
+metricRight = "lhuCarrier-canadian";
+note = uni1635;
+unicode = 5685;
+},
+{
+color = 9;
+glyphname = "tlheCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (323,345);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(495,-13,o),
+(582,282,o),
+(582,458,cs),
+(582,610,o),
+(515,702,o),
+(401,702,cs),
+(298,702,o),
+(226,636,o),
+(185,519,c),
+(202,550,l),
+(235,701,l),
+(297,701,l),
+(311,766,l),
+(118,766,l),
+(104,701,l),
+(168,701,l),
+(106,416,l),
+(183,416,l),
+(221,554,o),
+(284,619,o),
+(368,619,cs),
+(448,619,o),
+(493,560,o),
+(493,455,cs),
+(493,332,o),
+(435,71,o),
+(271,71,cs),
+(181,71,o),
+(135,149,o),
+(153,273,c),
+(76,273,l),
+(18,0,l),
+(99,0,l),
+(134,170,l),
+(126,170,l),
+(123,58,o),
+(185,-13,o),
+(289,-13,cs)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1636;
+unicode = 5686;
+},
+{
+color = 9;
+glyphname = "tlheeCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (255,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 596;
+}
+);
+note = uni1637;
+unicode = 5687;
+},
+{
+color = 9;
+glyphname = "tlhiCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (233,0);
+ref = dot_middle;
+}
+);
+width = 596;
+}
+);
+note = uni1638;
+unicode = 5688;
+},
+{
+color = 9;
+glyphname = "tlhaCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(323,-13,o),
+(389,39,o),
+(428,136,c),
+(423,138,l),
+(394,0,l),
+(475,0,l),
+(533,273,l),
+(457,273,l),
+(419,135,o),
+(355,71,o),
+(271,71,cs),
+(190,71,o),
+(148,129,o),
+(148,235,cs),
+(148,357,o),
+(205,619,o),
+(368,619,cs),
+(459,619,o),
+(505,541,o),
+(488,416,c),
+(563,416,l),
+(624,701,l),
+(687,701,l),
+(701,766,l),
+(509,766,l),
+(495,701,l),
+(558,701,l),
+(518,512,l),
+(526,511,l),
+(527,636,o),
+(456,702,o),
+(354,702,cs),
+(144,702,o),
+(59,408,o),
+(59,232,cs),
+(59,80,o),
+(125,-13,o),
+(238,-13,cs)
+);
+}
+);
+width = 595;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni1639;
+unicode = 5689;
+},
+{
+color = 9;
+glyphname = "tluCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(250,-13,o),
+(298,24,o),
+(336,108,c),
+(309,108,l),
+(317,30,o),
+(360,-13,o),
+(432,-13,cs),
+(610,-13,o),
+(666,298,o),
+(666,435,cs),
+(666,539,o),
+(632,604,o),
+(568,634,c),
+(547,620,l),
+(714,620,l),
+(696,539,l),
+(762,539,l),
+(811,771,l),
+(745,771,l),
+(727,690,l),
+(489,690,l),
+(473,616,l),
+(547,611,o),
+(582,563,o),
+(582,461,cs),
+(582,363,o),
+(538,70,o),
+(431,70,cs),
+(380,70,o),
+(363,111,o),
+(380,189,cs),
+(403,302,l),
+(318,302,l),
+(295,189,ls),
+(277,108,o),
+(247,70,o),
+(201,70,cs),
+(159,70,o),
+(140,97,o),
+(140,166,cs),
+(140,238,o),
+(189,618,o),
+(382,616,c),
+(397,690,l),
+(144,690,l),
+(128,614,l),
+(290,614,l),
+(275,629,l),
+(107,565,o),
+(52,295,o),
+(52,159,cs),
+(52,46,o),
+(98,-13,o),
+(184,-13,cs)
+);
+}
+);
+width = 728;
+}
+);
+metricRight = "tlhuCarrier-canadian";
+note = uni163A;
+unicode = 5690;
+},
+{
+color = 1;
+glyphname = "tloCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(631,-81,l),
+(680,151,l),
+(613,151,l),
+(596,70,l),
+(441,70,l),
+(454,56,l),
+(631,118,o),
+(688,392,o),
+(688,530,cs),
+(688,643,o),
+(641,702,o),
+(555,702,cs),
+(489,702,o),
+(441,666,o),
+(403,582,c),
+(430,581,l),
+(422,660,o),
+(380,702,o),
+(308,702,cs),
+(129,702,o),
+(73,392,o),
+(73,255,cs),
+(73,156,o),
+(106,92,o),
+(164,61,c),
+(186,75,l),
+(14,75,l),
+(-3,0,l),
+(251,0,l),
+(267,73,l),
+(193,79,o),
+(157,127,o),
+(157,229,cs),
+(157,327,o),
+(202,620,o),
+(308,620,cs),
+(359,620,o),
+(377,579,o),
+(360,500,cs),
+(336,387,l),
+(421,387,l),
+(445,500,ls),
+(463,582,o),
+(493,620,o),
+(538,620,cs),
+(580,620,o),
+(599,593,o),
+(599,524,cs),
+(599,452,o),
+(550,71,o),
+(358,73,c),
+(342,0,l),
+(582,0,l),
+(564,-81,l)
+);
+}
+);
+width = 729;
+}
+);
+metricLeft = "tluCarrier-canadian";
+metricRight = "tlhuCarrier-canadian";
+note = uni163B;
+unicode = 5691;
+},
+{
+color = 9;
+glyphname = "tleCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (265,345);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(437,-13,o),
+(527,84,o),
+(527,216,cs),
+(527,292,o),
+(489,347,o),
+(426,355,c),
+(422,334,l),
+(527,342,o),
+(597,440,o),
+(597,538,cs),
+(597,634,o),
+(528,702,o),
+(419,702,cs),
+(318,702,o),
+(233,642,o),
+(192,536,c),
+(199,534,l),
+(234,701,l),
+(298,701,l),
+(311,766,l),
+(118,766,l),
+(104,701,l),
+(168,701,l),
+(107,416,l),
+(182,416,l),
+(213,553,o),
+(283,621,o),
+(385,621,cs),
+(461,621,o),
+(505,581,o),
+(505,518,cs),
+(505,444,o),
+(457,383,o),
+(378,383,cs),
+(349,383,l),
+(333,308,l),
+(360,308,ls),
+(411,308,o),
+(441,276,o),
+(441,222,cs),
+(441,135,o),
+(389,69,o),
+(290,69,cs),
+(179,69,o),
+(128,142,o),
+(151,273,c),
+(76,273,l),
+(18,0,l),
+(99,0,l),
+(133,159,l),
+(118,158,l),
+(115,54,o),
+(190,-13,o),
+(303,-13,cs)
+);
+}
+);
+width = 594;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni163C;
+unicode = 5692;
+},
+{
+color = 9;
+glyphname = "tleeCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (197,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 594;
+}
+);
+note = uni163D;
+unicode = 5693;
+},
+{
+color = 9;
+glyphname = "tliCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (184,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 594;
+}
+);
+note = uni163E;
+unicode = 5694;
+},
+{
+color = 9;
+glyphname = "tlaCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(311,-13,o),
+(388,36,o),
+(433,123,c),
+(424,139,l),
+(394,0,l),
+(474,0,l),
+(533,273,l),
+(459,273,l),
+(427,137,o),
+(357,69,o),
+(254,69,cs),
+(179,69,o),
+(134,109,o),
+(134,172,cs),
+(134,245,o),
+(183,307,o),
+(262,307,cs),
+(291,307,l),
+(306,382,l),
+(279,382,ls),
+(229,382,o),
+(198,413,o),
+(198,468,cs),
+(198,554,o),
+(250,621,o),
+(351,621,cs),
+(461,621,o),
+(512,548,o),
+(489,416,c),
+(563,416,l),
+(624,701,l),
+(687,701,l),
+(700,766,l),
+(507,766,l),
+(493,701,l),
+(557,701,l),
+(518,514,l),
+(526,526,l),
+(532,633,o),
+(457,702,o),
+(336,702,cs),
+(203,702,o),
+(112,606,o),
+(112,473,cs),
+(112,404,o),
+(146,351,o),
+(200,337,c),
+(206,354,l),
+(106,340,o),
+(43,245,o),
+(43,152,cs),
+(43,56,o),
+(111,-13,o),
+(220,-13,cs)
+);
+}
+);
+width = 595;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni163F;
+unicode = 5695;
+},
+{
+color = 9;
+glyphname = "zuCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(462,-13,o),
+(545,130,o),
+(545,310,cs),
+(545,375,o),
+(533,450,o),
+(533,518,cs),
+(533,578,o),
+(555,611,o),
+(611,611,cs),
+(630,611,l),
+(646,690,l),
+(602,690,ls),
+(496,690,o),
+(449,632,o),
+(449,513,cs),
+(449,451,o),
+(460,384,o),
+(460,307,cs),
+(460,180,o),
+(407,71,o),
+(273,71,cs),
+(186,71,o),
+(137,116,o),
+(137,190,cs),
+(137,317,o),
+(286,490,o),
+(286,597,cs),
+(286,655,o),
+(247,690,o),
+(181,690,cs),
+(141,690,l),
+(125,611,l),
+(153,611,ls),
+(185,611,o),
+(198,599,o),
+(198,575,cs),
+(198,498,o),
+(45,332,o),
+(45,177,cs),
+(45,64,o),
+(129,-13,o),
+(264,-13,cs)
+);
+}
+);
+width = 596;
+}
+);
+metricRight = "=|";
+note = uni1640;
+unicode = 5696;
+},
+{
+color = 9;
+glyphname = "zoCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(39,0,ls),
+(145,0,o),
+(192,58,o),
+(192,177,cs),
+(192,239,o),
+(181,305,o),
+(181,383,cs),
+(181,510,o),
+(235,619,o),
+(367,619,cs),
+(454,619,o),
+(503,574,o),
+(503,499,cs),
+(503,373,o),
+(354,200,o),
+(354,93,cs),
+(354,35,o),
+(393,0,o),
+(460,0,cs),
+(499,0,l),
+(516,78,l),
+(488,78,ls),
+(456,78,o),
+(442,91,o),
+(442,115,cs),
+(442,191,o),
+(595,357,o),
+(595,513,cs),
+(595,626,o),
+(511,702,o),
+(377,702,cs),
+(179,702,o),
+(96,559,o),
+(96,380,cs),
+(96,315,o),
+(107,240,o),
+(107,172,cs),
+(107,112,o),
+(86,78,o),
+(30,78,cs),
+(11,78,l),
+(-6,0,l)
+);
+}
+);
+width = 595;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1641;
+unicode = 5697;
+},
+{
+color = 9;
+glyphname = "zeCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (312,345);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(484,-13,o),
+(564,357,o),
+(564,517,cs),
+(564,636,o),
+(522,702,o),
+(445,702,cs),
+(354,702,o),
+(270,604,o),
+(233,604,cs),
+(211,604,o),
+(205,620,o),
+(213,660,cs),
+(219,690,l),
+(138,690,l),
+(127,634,ls),
+(111,566,o),
+(136,525,o),
+(190,525,cs),
+(268,525,o),
+(347,619,o),
+(410,619,cs),
+(452,619,o),
+(473,579,o),
+(473,502,cs),
+(473,389,o),
+(410,71,o),
+(288,71,cs),
+(223,71,o),
+(185,165,o),
+(108,165,cs),
+(56,165,o),
+(18,127,o),
+(4,56,cs),
+(-9,0,l),
+(72,0,l),
+(79,30,ls),
+(87,68,o),
+(102,86,o),
+(122,86,cs),
+(162,86,o),
+(210,-13,o),
+(301,-13,cs)
+);
+}
+);
+width = 568;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1642;
+unicode = 5698;
+},
+{
+color = 9;
+glyphname = "zeeCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (244,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 569;
+}
+);
+note = uni1643;
+unicode = 5699;
+},
+{
+color = 9;
+glyphname = "ziCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (222,0);
+ref = dot_middle;
+}
+);
+width = 569;
+}
+);
+note = uni1644;
+unicode = 5700;
+},
+{
+color = 9;
+glyphname = "zaCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(261,-13,o),
+(345,86,o),
+(382,86,cs),
+(404,86,o),
+(410,70,o),
+(401,30,cs),
+(394,0,l),
+(475,0,l),
+(488,56,ls),
+(502,124,o),
+(477,165,o),
+(423,165,cs),
+(346,165,o),
+(268,71,o),
+(205,71,cs),
+(162,71,o),
+(140,111,o),
+(140,187,cs),
+(140,300,o),
+(205,619,o),
+(326,619,cs),
+(390,619,o),
+(430,525,o),
+(506,525,cs),
+(558,525,o),
+(595,563,o),
+(611,634,cs),
+(622,690,l),
+(541,690,l),
+(535,660,ls),
+(526,622,o),
+(512,604,o),
+(492,604,cs),
+(451,604,o),
+(404,702,o),
+(312,702,cs),
+(130,702,o),
+(49,332,o),
+(49,173,cs),
+(49,54,o),
+(93,-13,o),
+(169,-13,cs)
+);
+}
+);
+width = 569;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|zeCarrier-canadian";
+note = uni1645;
+unicode = 5701;
+},
+{
+color = 6;
+glyphname = "zCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(277,183,l),
+(290,242,l),
+(115,242,l),
+(109,205,l),
+(341,495,l),
+(349,527,l),
+(111,527,l),
+(98,469,l),
+(271,469,l),
+(277,505,l),
+(44,215,l),
+(38,183,l)
+);
+}
+);
+width = 338;
+}
+);
+metricRight = "=|";
+note = uni1646;
+unicode = 5702;
+},
+{
+color = 6;
+glyphname = "initialzCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(168,96,l),
+(186,183,l),
+(277,183,l),
+(290,242,l),
+(97,242,l),
+(113,209,l),
+(341,495,l),
+(349,527,l),
+(260,527,l),
+(278,614,l),
+(217,614,l),
+(199,527,l),
+(111,527,l),
+(98,469,l),
+(289,469,l),
+(273,501,l),
+(44,215,l),
+(38,183,l),
+(126,183,l),
+(107,96,l)
+);
+}
+);
+width = 338;
+}
+);
+metricLeft = "zCarrier-canadian";
+metricRight = "zCarrier-canadian";
+note = uni1647;
+unicode = 5703;
+},
+{
+color = 9;
+glyphname = "dzuCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(462,-13,o),
+(545,130,o),
+(545,310,cs),
+(545,375,o),
+(533,450,o),
+(533,518,cs),
+(533,578,o),
+(555,611,o),
+(611,611,cs),
+(630,611,l),
+(646,690,l),
+(602,690,ls),
+(507,690,o),
+(459,631,o),
+(453,513,cs),
+(451,451,o),
+(463,377,o),
+(461,307,cs),
+(459,180,o),
+(407,71,o),
+(273,71,cs),
+(186,71,o),
+(137,116,o),
+(137,190,cs),
+(137,317,o),
+(281,490,o),
+(281,597,cs),
+(281,655,o),
+(246,690,o),
+(181,690,cs),
+(141,690,l),
+(125,611,l),
+(153,611,ls),
+(185,611,o),
+(198,599,o),
+(198,575,cs),
+(198,498,o),
+(45,332,o),
+(45,177,cs),
+(45,64,o),
+(129,-13,o),
+(264,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(370,482,l),
+(406,652,l),
+(455,652,l),
+(464,690,l),
+(327,690,l),
+(318,652,l),
+(367,652,l),
+(331,482,l)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1648;
+unicode = 5704;
+},
+{
+color = 9;
+glyphname = "dzoCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(39,0,ls),
+(133,0,o),
+(182,59,o),
+(187,177,cs),
+(189,239,o),
+(178,313,o),
+(180,383,cs),
+(182,510,o),
+(235,619,o),
+(367,619,cs),
+(454,619,o),
+(503,574,o),
+(503,499,cs),
+(503,373,o),
+(360,200,o),
+(360,93,cs),
+(360,35,o),
+(394,0,o),
+(460,0,cs),
+(498,0,l),
+(516,78,l),
+(488,78,ls),
+(456,78,o),
+(442,91,o),
+(442,115,cs),
+(442,191,o),
+(595,357,o),
+(595,513,cs),
+(595,626,o),
+(511,702,o),
+(377,702,cs),
+(179,702,o),
+(96,559,o),
+(96,380,cs),
+(96,315,o),
+(107,240,o),
+(107,172,cs),
+(107,112,o),
+(86,78,o),
+(30,78,cs),
+(11,78,l),
+(-6,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(315,0,l),
+(323,38,l),
+(273,38,l),
+(309,208,l),
+(270,208,l),
+(235,38,l),
+(185,38,l),
+(177,0,l)
+);
+}
+);
+width = 595;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1649;
+unicode = 5705;
+},
+{
+color = 9;
+glyphname = "dzeCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (330,345);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(502,-13,o),
+(582,357,o),
+(582,517,cs),
+(582,636,o),
+(540,702,o),
+(464,702,cs),
+(371,702,o),
+(288,604,o),
+(250,604,cs),
+(229,604,o),
+(222,620,o),
+(231,660,cs),
+(238,690,l),
+(156,690,l),
+(144,634,ls),
+(129,566,o),
+(155,525,o),
+(209,525,cs),
+(286,525,o),
+(365,619,o),
+(428,619,cs),
+(470,619,o),
+(492,579,o),
+(492,502,cs),
+(492,389,o),
+(427,71,o),
+(306,71,cs),
+(242,71,o),
+(202,165,o),
+(127,165,cs),
+(74,165,o),
+(37,127,o),
+(22,56,cs),
+(10,0,l),
+(91,0,l),
+(98,30,ls),
+(105,68,o),
+(121,86,o),
+(140,86,cs),
+(181,86,o),
+(228,-13,o),
+(320,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(111,242,l),
+(128,320,l),
+(230,320,l),
+(242,370,l),
+(138,370,l),
+(156,448,l),
+(105,448,l),
+(61,242,l)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164A;
+unicode = 5706;
+},
+{
+color = 9;
+glyphname = "dzeeCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "dzeCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (262,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 586;
+}
+);
+metricLeft = "dzeCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164B;
+unicode = 5707;
+},
+{
+color = 9;
+glyphname = "dziCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "dzeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (240,0);
+ref = dot_middle;
+}
+);
+width = 586;
+}
+);
+note = uni164C;
+unicode = 5708;
+},
+{
+color = 9;
+glyphname = "dzaCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(261,-13,o),
+(345,86,o),
+(382,86,cs),
+(404,86,o),
+(410,70,o),
+(401,30,cs),
+(395,0,l),
+(476,0,l),
+(488,56,ls),
+(502,124,o),
+(478,165,o),
+(424,165,cs),
+(346,165,o),
+(268,71,o),
+(205,71,cs),
+(162,71,o),
+(140,111,o),
+(140,187,cs),
+(140,300,o),
+(205,619,o),
+(327,619,cs),
+(391,619,o),
+(430,525,o),
+(506,525,cs),
+(558,525,o),
+(596,563,o),
+(611,634,cs),
+(623,690,l),
+(542,690,l),
+(535,660,ls),
+(527,622,o),
+(512,604,o),
+(492,604,cs),
+(451,604,o),
+(405,702,o),
+(313,702,cs),
+(130,702,o),
+(49,332,o),
+(49,173,cs),
+(49,54,o),
+(93,-13,o),
+(169,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(527,242,l),
+(571,448,l),
+(521,448,l),
+(504,370,l),
+(402,370,l),
+(391,320,l),
+(494,320,l),
+(477,242,l)
+);
+}
+);
+width = 587;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dzeCarrier-canadian";
+note = uni164D;
+unicode = 5709;
+},
+{
+color = 9;
+glyphname = "suCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(245,-13,o),
+(306,39,o),
+(341,137,c),
+(311,137,l),
+(309,39,o),
+(354,-13,o),
+(441,-13,cs),
+(572,-13,o),
+(621,114,o),
+(632,241,cs),
+(639,319,o),
+(628,440,o),
+(634,512,cs),
+(637,565,o),
+(652,611,o),
+(705,611,cs),
+(724,611,l),
+(740,690,l),
+(700,690,ls),
+(601,690,o),
+(562,624,o),
+(553,528,cs),
+(546,456,o),
+(551,325,o),
+(546,252,cs),
+(544,171,o),
+(519,70,o),
+(436,70,cs),
+(364,70,o),
+(365,147,o),
+(378,205,cs),
+(481,690,l),
+(402,690,l),
+(298,203,ls),
+(279,113,o),
+(243,70,o),
+(188,70,cs),
+(147,70,o),
+(124,95,o),
+(124,142,cs),
+(124,258,o),
+(279,498,o),
+(279,604,cs),
+(279,660,o),
+(245,690,o),
+(182,690,cs),
+(142,690,l),
+(126,611,l),
+(143,611,ls),
+(175,611,o),
+(189,599,o),
+(189,571,cs),
+(189,477,o),
+(33,272,o),
+(33,127,cs),
+(33,42,o),
+(83,-13,o),
+(165,-13,cs)
+);
+}
+);
+width = 691;
+}
+);
+metricRight = "=|";
+note = uni164E;
+unicode = 5710;
+},
+{
+color = 9;
+glyphname = "soCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(36,0,ls),
+(135,0,o),
+(174,66,o),
+(184,161,cs),
+(190,234,o),
+(185,365,o),
+(189,438,cs),
+(192,519,o),
+(216,620,o),
+(299,620,cs),
+(372,620,o),
+(371,543,o),
+(358,485,cs),
+(255,0,l),
+(333,0,l),
+(437,487,ls),
+(456,577,o),
+(492,620,o),
+(547,620,cs),
+(589,620,o),
+(612,595,o),
+(612,548,cs),
+(612,432,o),
+(457,191,o),
+(457,86,cs),
+(457,30,o),
+(490,0,o),
+(554,0,cs),
+(593,0,l),
+(610,78,l),
+(592,78,ls),
+(561,78,o),
+(547,91,o),
+(547,119,cs),
+(547,213,o),
+(702,417,o),
+(702,563,cs),
+(702,648,o),
+(653,702,o),
+(571,702,cs),
+(491,702,o),
+(429,651,o),
+(395,553,c),
+(424,553,l),
+(426,651,o),
+(382,702,o),
+(295,702,cs),
+(163,702,o),
+(115,576,o),
+(104,449,cs),
+(98,371,o),
+(108,250,o),
+(101,178,cs),
+(99,125,o),
+(84,78,o),
+(30,78,cs),
+(13,78,l),
+(-5,0,l)
+);
+}
+);
+width = 690;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5711;
+},
+{
+color = 9;
+glyphname = "seCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(453,-13,o),
+(518,124,o),
+(518,221,cs),
+(518,296,o),
+(481,346,o),
+(417,355,c),
+(413,334,l),
+(544,348,o),
+(590,470,o),
+(590,558,cs),
+(590,644,o),
+(543,702,o),
+(466,702,cs),
+(368,702,o),
+(288,604,o),
+(245,604,cs),
+(227,604,o),
+(221,619,o),
+(229,653,cs),
+(237,690,l),
+(156,690,l),
+(143,634,ls),
+(128,566,o),
+(154,525,o),
+(209,525,cs),
+(291,525,o),
+(365,621,o),
+(436,621,cs),
+(477,621,o),
+(499,590,o),
+(499,542,cs),
+(499,472,o),
+(461,382,o),
+(362,382,cs),
+(89,382,l),
+(73,308,l),
+(346,308,ls),
+(402,308,o),
+(431,276,o),
+(431,222,cs),
+(431,168,o),
+(400,69,o),
+(322,69,cs),
+(250,69,o),
+(206,165,o),
+(126,165,cs),
+(73,165,o),
+(36,128,o),
+(20,56,cs),
+(9,0,l),
+(90,0,l),
+(96,30,ls),
+(104,68,o),
+(119,86,o),
+(139,86,cs),
+(186,86,o),
+(234,-13,o),
+(334,-13,cs)
+);
+}
+);
+width = 584;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni1650;
+unicode = 5712;
+},
+{
+color = 9;
+glyphname = "seeCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(452,-13,o),
+(517,124,o),
+(517,221,cs),
+(517,291,o),
+(484,340,o),
+(428,353,c),
+(420,335,l),
+(545,354,o),
+(589,472,o),
+(589,558,cs),
+(589,644,o),
+(542,702,o),
+(465,702,cs),
+(367,702,o),
+(287,604,o),
+(244,604,cs),
+(226,604,o),
+(220,619,o),
+(228,653,cs),
+(236,690,l),
+(155,690,l),
+(142,634,ls),
+(127,566,o),
+(153,525,o),
+(208,525,cs),
+(290,525,o),
+(364,621,o),
+(435,621,cs),
+(476,621,o),
+(498,590,o),
+(498,542,cs),
+(498,472,o),
+(459,380,o),
+(361,380,cs),
+(308,380,l),
+(323,341,l),
+(347,459,l),
+(297,459,l),
+(281,380,l),
+(88,380,l),
+(73,310,l),
+(266,310,l),
+(247,223,l),
+(297,223,l),
+(324,350,l),
+(293,310,l),
+(346,310,ls),
+(401,310,o),
+(430,276,o),
+(430,222,cs),
+(430,168,o),
+(399,69,o),
+(321,69,cs),
+(249,69,o),
+(205,165,o),
+(125,165,cs),
+(72,165,o),
+(35,128,o),
+(19,56,cs),
+(8,0,l),
+(89,0,l),
+(95,30,ls),
+(103,68,o),
+(118,86,o),
+(138,86,cs),
+(185,86,o),
+(233,-13,o),
+(333,-13,cs)
+);
+}
+);
+width = 583;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1651;
+unicode = 5713;
+},
+{
+color = 9;
+glyphname = "siCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(452,-13,o),
+(517,124,o),
+(517,221,cs),
+(517,291,o),
+(484,340,o),
+(428,353,c),
+(420,335,l),
+(545,354,o),
+(589,472,o),
+(589,558,cs),
+(589,644,o),
+(542,702,o),
+(465,702,cs),
+(367,702,o),
+(287,604,o),
+(244,604,cs),
+(226,604,o),
+(220,619,o),
+(228,653,cs),
+(236,690,l),
+(155,690,l),
+(142,634,ls),
+(127,566,o),
+(153,525,o),
+(208,525,cs),
+(290,525,o),
+(364,621,o),
+(435,621,cs),
+(476,621,o),
+(500,590,o),
+(500,542,cs),
+(500,472,o),
+(464,378,o),
+(365,378,cs),
+(309,378,l),
+(347,351,l),
+(346,389,o),
+(316,417,o),
+(278,417,cs),
+(252,417,o),
+(228,402,o),
+(217,380,c),
+(88,380,l),
+(73,310,l),
+(217,310,l),
+(229,288,o),
+(252,272,o),
+(278,272,cs),
+(314,272,o),
+(345,301,o),
+(347,339,c),
+(308,312,l),
+(354,312,ls),
+(409,312,o),
+(432,276,o),
+(432,222,cs),
+(432,168,o),
+(399,69,o),
+(321,69,cs),
+(249,69,o),
+(205,165,o),
+(125,165,cs),
+(72,165,o),
+(35,128,o),
+(19,56,cs),
+(8,0,l),
+(89,0,l),
+(95,30,ls),
+(103,68,o),
+(118,86,o),
+(138,86,cs),
+(185,86,o),
+(233,-13,o),
+(333,-13,cs)
+);
+}
+);
+width = 583;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1652;
+unicode = 5714;
+},
+{
+color = 9;
+glyphname = "saCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(261,-13,o),
+(341,86,o),
+(384,86,cs),
+(402,86,o),
+(408,71,o),
+(401,37,cs),
+(393,0,l),
+(474,0,l),
+(486,56,ls),
+(501,124,o),
+(476,165,o),
+(420,165,cs),
+(338,165,o),
+(264,69,o),
+(193,69,cs),
+(152,69,o),
+(129,99,o),
+(129,148,cs),
+(129,217,o),
+(168,308,o),
+(267,308,cs),
+(540,308,l),
+(555,382,l),
+(283,382,ls),
+(228,382,o),
+(198,413,o),
+(198,468,cs),
+(198,522,o),
+(229,621,o),
+(307,621,cs),
+(379,621,o),
+(423,525,o),
+(503,525,cs),
+(555,525,o),
+(593,561,o),
+(609,634,cs),
+(621,690,l),
+(540,690,l),
+(533,660,ls),
+(526,622,o),
+(510,604,o),
+(490,604,cs),
+(442,604,o),
+(395,702,o),
+(295,702,cs),
+(176,702,o),
+(111,566,o),
+(111,469,cs),
+(111,394,o),
+(148,344,o),
+(212,335,c),
+(215,355,l),
+(85,342,o),
+(39,219,o),
+(39,131,cs),
+(39,45,o),
+(86,-13,o),
+(163,-13,cs)
+);
+}
+);
+width = 583;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1653;
+unicode = 5715;
+},
+{
+color = 9;
+glyphname = "shuCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(239,-13,o),
+(297,31,o),
+(333,118,c),
+(312,120,l),
+(315,33,o),
+(359,-13,o),
+(441,-13,cs),
+(572,-13,o),
+(621,114,o),
+(632,241,cs),
+(639,319,o),
+(628,440,o),
+(634,512,cs),
+(637,565,o),
+(652,611,o),
+(705,611,cs),
+(724,611,l),
+(740,690,l),
+(700,690,ls),
+(614,690,o),
+(571,643,o),
+(555,563,cs),
+(553,549,o),
+(551,532,o),
+(550,515,c),
+(572,560,l),
+(453,560,l),
+(481,690,l),
+(402,690,l),
+(375,560,l),
+(255,560,l),
+(265,530,l),
+(273,558,o),
+(279,583,o),
+(279,604,cs),
+(279,660,o),
+(245,690,o),
+(182,690,cs),
+(142,690,l),
+(126,611,l),
+(143,611,ls),
+(175,611,o),
+(189,599,o),
+(189,571,cs),
+(189,477,o),
+(33,272,o),
+(33,127,cs),
+(33,42,o),
+(83,-13,o),
+(165,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(147,70,o),
+(124,95,o),
+(124,142,cs),
+(124,229,o),
+(208,374,o),
+(252,489,c),
+(359,489,l),
+(298,203,ls),
+(279,113,o),
+(243,70,o),
+(188,70,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(364,70,o),
+(365,147,o),
+(378,205,cs),
+(439,489,l),
+(548,489,l),
+(544,412,o),
+(550,317,o),
+(546,252,cs),
+(544,171,o),
+(519,70,o),
+(436,70,cs)
+);
+}
+);
+width = 691;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1654;
+unicode = 5716;
+},
+{
+color = 9;
+glyphname = "shoCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(36,0,ls),
+(122,0,o),
+(164,46,o),
+(181,127,cs),
+(184,141,o),
+(185,157,o),
+(185,175,c),
+(163,129,l),
+(282,129,l),
+(255,0,l),
+(333,0,l),
+(361,129,l),
+(481,129,l),
+(471,159,l),
+(462,131,o),
+(457,106,o),
+(457,86,cs),
+(457,30,o),
+(490,0,o),
+(554,0,cs),
+(593,0,l),
+(611,78,l),
+(592,78,ls),
+(561,78,o),
+(547,91,o),
+(547,119,cs),
+(547,213,o),
+(702,417,o),
+(702,563,cs),
+(702,648,o),
+(653,702,o),
+(571,702,cs),
+(497,702,o),
+(440,659,o),
+(403,572,c),
+(423,570,l),
+(421,657,o),
+(377,702,o),
+(295,702,cs),
+(163,702,o),
+(115,576,o),
+(104,449,cs),
+(98,371,o),
+(108,250,o),
+(101,178,cs),
+(99,125,o),
+(84,78,o),
+(30,78,cs),
+(13,78,l),
+(-5,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(192,277,o),
+(186,373,o),
+(189,438,cs),
+(192,519,o),
+(216,620,o),
+(299,620,cs),
+(372,620,o),
+(371,543,o),
+(358,485,cs),
+(298,201,l),
+(188,201,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(437,487,ls),
+(456,577,o),
+(492,620,o),
+(547,620,cs),
+(589,620,o),
+(612,595,o),
+(612,548,cs),
+(612,461,o),
+(527,316,o),
+(484,201,c),
+(376,201,l)
+);
+}
+);
+width = 691;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1655;
+unicode = 5717;
+},
+{
+color = 9;
+glyphname = "sheCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(453,-13,o),
+(518,124,o),
+(518,221,cs),
+(518,291,o),
+(485,340,o),
+(429,353,c),
+(421,335,l),
+(546,354,o),
+(590,472,o),
+(590,558,cs),
+(590,644,o),
+(543,702,o),
+(466,702,cs),
+(368,702,o),
+(288,604,o),
+(245,604,cs),
+(227,604,o),
+(221,619,o),
+(229,653,cs),
+(237,690,l),
+(156,690,l),
+(143,634,ls),
+(128,566,o),
+(154,526,o),
+(209,526,cs),
+(224,526,o),
+(239,529,o),
+(253,536,c),
+(217,574,l),
+(177,382,l),
+(89,382,l),
+(73,308,l),
+(161,308,l),
+(121,114,l),
+(173,152,l),
+(158,158,o),
+(142,163,o),
+(126,163,cs),
+(73,163,o),
+(36,128,o),
+(20,56,cs),
+(9,0,l),
+(90,0,l),
+(96,30,ls),
+(104,68,o),
+(119,86,o),
+(139,86,cs),
+(186,86,o),
+(234,-13,o),
+(334,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(232,308,l),
+(346,308,ls),
+(402,308,o),
+(431,276,o),
+(431,222,cs),
+(431,168,o),
+(400,69,o),
+(322,69,cs),
+(273,69,o),
+(238,111,o),
+(196,139,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(283,548,l),
+(334,575,o),
+(385,621,o),
+(436,621,cs),
+(477,621,o),
+(499,590,o),
+(499,542,cs),
+(499,472,o),
+(461,382,o),
+(362,382,cs),
+(247,382,l)
+);
+}
+);
+width = 584;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1656;
+unicode = 5718;
+},
+{
+color = 9;
+glyphname = "sheeCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(453,-13,o),
+(518,124,o),
+(518,221,cs),
+(518,291,o),
+(485,340,o),
+(429,353,c),
+(421,335,l),
+(546,354,o),
+(590,472,o),
+(590,558,cs),
+(590,644,o),
+(543,702,o),
+(466,702,cs),
+(368,702,o),
+(288,604,o),
+(245,604,cs),
+(227,604,o),
+(221,619,o),
+(229,653,cs),
+(237,690,l),
+(156,690,l),
+(143,634,ls),
+(128,566,o),
+(154,526,o),
+(209,526,cs),
+(220,526,o),
+(233,529,o),
+(244,534,c),
+(217,571,l),
+(176,376,l),
+(88,376,l),
+(74,314,l),
+(163,314,l),
+(121,116,l),
+(163,154,l),
+(152,159,o),
+(139,163,o),
+(126,163,cs),
+(73,163,o),
+(36,128,o),
+(20,56,cs),
+(9,0,l),
+(90,0,l),
+(96,30,ls),
+(104,68,o),
+(119,86,o),
+(139,86,cs),
+(186,86,o),
+(234,-13,o),
+(334,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(270,67,o),
+(233,118,o),
+(184,145,c),
+(220,314,l),
+(304,314,l),
+(285,223,l),
+(327,223,l),
+(349,328,l),
+(331,314,l),
+(351,314,ls),
+(406,314,o),
+(434,276,o),
+(434,222,cs),
+(434,168,o),
+(400,67,o),
+(322,67,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(377,459,l),
+(334,459,l),
+(317,376,l),
+(233,376,l),
+(269,541,l),
+(327,568,o),
+(383,623,o),
+(436,623,cs),
+(477,623,o),
+(501,590,o),
+(501,542,cs),
+(501,472,o),
+(462,376,o),
+(363,376,cs),
+(345,376,l),
+(356,363,l)
+);
+}
+);
+width = 584;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1657;
+unicode = 5719;
+},
+{
+color = 9;
+glyphname = "shiCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(143,634,ls),
+(128,566,o),
+(154,526,o),
+(209,526,cs),
+(221,526,o),
+(233,529,o),
+(245,534,c),
+(217,571,l),
+(176,376,l),
+(88,376,l),
+(74,314,l),
+(162,314,l),
+(121,116,l),
+(162,154,l),
+(151,159,o),
+(138,163,o),
+(126,163,cs),
+(73,163,o),
+(36,128,o),
+(20,56,cs),
+(9,0,l),
+(90,0,l),
+(96,30,ls),
+(104,68,o),
+(119,86,o),
+(139,86,cs),
+(186,86,o),
+(234,-13,o),
+(334,-13,cs),
+(453,-13,o),
+(518,124,o),
+(518,221,cs),
+(518,291,o),
+(485,340,o),
+(429,353,c),
+(421,335,l),
+(546,354,o),
+(590,472,o),
+(590,558,cs),
+(590,644,o),
+(543,702,o),
+(466,702,cs),
+(368,702,o),
+(288,604,o),
+(245,604,cs),
+(227,604,o),
+(221,619,o),
+(229,653,cs),
+(237,690,l),
+(156,690,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(219,314,l),
+(272,314,l),
+(281,289,o),
+(303,272,o),
+(331,272,cs),
+(363,272,o),
+(388,298,o),
+(395,330,c),
+(340,314,l),
+(360,314,ls),
+(411,314,o),
+(435,274,o),
+(435,222,cs),
+(435,168,o),
+(400,67,o),
+(322,67,cs),
+(270,67,o),
+(233,118,o),
+(184,145,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(268,541,l),
+(327,568,o),
+(383,623,o),
+(436,623,cs),
+(477,623,o),
+(502,590,o),
+(502,542,cs),
+(502,472,o),
+(468,376,o),
+(374,376,cs),
+(339,376,l),
+(394,361,l),
+(388,394,o),
+(362,417,o),
+(331,417,cs),
+(305,417,o),
+(281,400,o),
+(271,376,c),
+(233,376,l)
+);
+}
+);
+width = 584;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1658;
+unicode = 5720;
+},
+{
+color = 9;
+glyphname = "shaCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(262,-13,o),
+(341,86,o),
+(384,86,cs),
+(402,86,o),
+(408,71,o),
+(401,37,cs),
+(393,0,l),
+(474,0,l),
+(486,56,ls),
+(501,124,o),
+(476,163,o),
+(420,163,cs),
+(406,163,o),
+(390,160,o),
+(377,154,c),
+(412,116,l),
+(452,308,l),
+(540,308,l),
+(555,382,l),
+(469,382,l),
+(509,576,l),
+(456,538,l),
+(470,531,o),
+(487,526,o),
+(503,526,cs),
+(555,526,o),
+(593,561,o),
+(609,634,cs),
+(621,690,l),
+(540,690,l),
+(533,660,ls),
+(526,622,o),
+(510,604,o),
+(490,604,cs),
+(442,604,o),
+(395,702,o),
+(296,702,cs),
+(177,702,o),
+(111,566,o),
+(111,469,cs),
+(111,399,o),
+(144,350,o),
+(200,337,c),
+(208,355,l),
+(84,336,o),
+(39,217,o),
+(39,131,cs),
+(39,45,o),
+(87,-13,o),
+(163,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(153,69,o),
+(129,99,o),
+(129,148,cs),
+(129,217,o),
+(169,308,o),
+(267,308,cs),
+(382,308,l),
+(347,142,l),
+(295,115,o),
+(243,69,o),
+(193,69,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(228,382,o),
+(198,413,o),
+(198,468,cs),
+(198,522,o),
+(230,621,o),
+(308,621,cs),
+(356,621,o),
+(392,579,o),
+(434,551,c),
+(397,382,l),
+(283,382,ls)
+);
+}
+);
+width = 583;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1659;
+unicode = 5721;
+},
+{
+color = 6;
+glyphname = "shCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(163,96,l),
+(185,198,l),
+(140,184,l),
+(161,184,ls),
+(247,184,o),
+(289,232,o),
+(289,301,cs),
+(289,350,o),
+(261,381,o),
+(211,381,cs),
+(188,381,ls),
+(160,381,o),
+(147,394,o),
+(147,417,cs),
+(147,446,o),
+(159,476,o),
+(205,476,cs),
+(325,476,l),
+(335,527,l),
+(255,527,l),
+(273,614,l),
+(214,614,l),
+(192,508,l),
+(238,527,l),
+(216,527,ls),
+(130,527,o),
+(89,479,o),
+(89,409,cs),
+(89,361,o),
+(117,330,o),
+(167,330,cs),
+(189,330,ls),
+(217,330,o),
+(231,317,o),
+(231,294,cs),
+(231,266,o),
+(218,234,o),
+(173,234,cs),
+(53,234,l),
+(43,184,l),
+(123,184,l),
+(104,96,l)
+);
+}
+);
+width = 328;
+}
+);
+metricRight = "=|";
+note = uni18F5;
+unicode = 5722;
+},
+{
+color = 9;
+glyphname = "tsuCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(239,-13,o),
+(296,31,o),
+(333,118,c),
+(312,120,l),
+(315,33,o),
+(359,-13,o),
+(441,-13,cs),
+(572,-13,o),
+(621,114,o),
+(632,241,cs),
+(639,319,o),
+(628,440,o),
+(634,512,cs),
+(637,565,o),
+(652,611,o),
+(705,611,cs),
+(724,611,l),
+(740,690,l),
+(700,690,ls),
+(601,690,o),
+(563,624,o),
+(554,528,cs),
+(552,487,o),
+(554,436,o),
+(554,381,c),
+(415,381,l),
+(468,627,l),
+(525,627,l),
+(538,690,l),
+(344,690,l),
+(330,627,l),
+(388,627,l),
+(336,381,l),
+(198,381,l),
+(237,468,o),
+(278,551,o),
+(278,604,cs),
+(278,660,o),
+(245,690,o),
+(182,690,cs),
+(142,690,l),
+(126,611,l),
+(143,611,ls),
+(175,611,o),
+(189,599,o),
+(189,571,cs),
+(189,477,o),
+(33,272,o),
+(33,127,cs),
+(33,42,o),
+(83,-13,o),
+(165,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(147,70,o),
+(124,95,o),
+(124,142,cs),
+(124,186,o),
+(145,246,o),
+(173,309,c),
+(321,309,l),
+(298,203,ls),
+(280,113,o),
+(243,70,o),
+(188,70,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(364,70,o),
+(365,147,o),
+(378,205,cs),
+(400,309,l),
+(550,309,l),
+(549,286,o),
+(548,266,o),
+(546,251,cs),
+(544,171,o),
+(519,70,o),
+(436,70,cs)
+);
+}
+);
+width = 691;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165B;
+unicode = 5723;
+},
+{
+color = 9;
+glyphname = "tsoCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(36,0,ls),
+(135,0,o),
+(172,66,o),
+(183,161,cs),
+(185,203,o),
+(182,254,o),
+(182,309,c),
+(321,309,l),
+(269,63,l),
+(211,63,l),
+(198,0,l),
+(392,0,l),
+(405,63,l),
+(347,63,l),
+(399,309,l),
+(537,309,l),
+(499,222,o),
+(458,139,o),
+(458,86,cs),
+(458,30,o),
+(490,0,o),
+(554,0,cs),
+(593,0,l),
+(611,78,l),
+(592,78,ls),
+(561,78,o),
+(547,91,o),
+(547,119,cs),
+(547,213,o),
+(702,417,o),
+(702,563,cs),
+(702,648,o),
+(653,702,o),
+(571,702,cs),
+(497,702,o),
+(440,659,o),
+(403,572,c),
+(423,570,l),
+(421,657,o),
+(377,702,o),
+(295,702,cs),
+(163,702,o),
+(115,576,o),
+(104,449,cs),
+(98,371,o),
+(108,250,o),
+(101,178,cs),
+(99,125,o),
+(84,78,o),
+(30,78,cs),
+(13,78,l),
+(-5,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(186,404,o),
+(188,424,o),
+(189,439,cs),
+(192,519,o),
+(216,620,o),
+(299,620,cs),
+(372,620,o),
+(371,543,o),
+(358,485,cs),
+(336,381,l),
+(185,381,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(437,487,ls),
+(456,577,o),
+(492,620,o),
+(547,620,cs),
+(589,620,o),
+(612,595,o),
+(612,548,cs),
+(612,503,o),
+(590,443,o),
+(563,381,c),
+(414,381,l)
+);
+}
+);
+width = 691;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165C;
+unicode = 5724;
+},
+{
+color = 9;
+glyphname = "tseCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(455,-13,o),
+(520,124,o),
+(520,221,cs),
+(520,291,o),
+(487,340,o),
+(431,353,c),
+(423,335,l),
+(547,354,o),
+(592,472,o),
+(592,558,cs),
+(592,644,o),
+(545,702,o),
+(468,702,cs),
+(370,702,o),
+(292,604,o),
+(249,604,cs),
+(231,604,o),
+(225,619,o),
+(233,653,cs),
+(241,690,l),
+(159,690,l),
+(147,634,ls),
+(132,566,o),
+(157,529,o),
+(213,529,cs),
+(237,529,o),
+(261,537,o),
+(280,550,c),
+(267,580,l),
+(224,376,l),
+(142,376,l),
+(160,461,l),
+(110,461,l),
+(60,229,l),
+(110,229,l),
+(128,314,l),
+(211,314,l),
+(167,109,l),
+(192,138,l),
+(174,151,o),
+(155,160,o),
+(129,160,cs),
+(77,160,o),
+(40,128,o),
+(24,56,cs),
+(13,0,l),
+(94,0,l),
+(100,30,ls),
+(108,68,o),
+(123,86,o),
+(143,86,cs),
+(190,86,o),
+(236,-13,o),
+(336,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(287,69,o),
+(257,95,o),
+(226,119,c),
+(268,314,l),
+(349,314,ls),
+(405,314,o),
+(435,282,o),
+(435,222,cs),
+(435,168,o),
+(403,69,o),
+(325,69,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(322,569,l),
+(361,593,o),
+(400,621,o),
+(439,621,cs),
+(480,621,o),
+(502,590,o),
+(502,542,cs),
+(502,472,o),
+(463,376,o),
+(365,376,cs),
+(281,376,l)
+);
+}
+);
+width = 586;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni165D;
+unicode = 5725;
+},
+{
+color = 9;
+glyphname = "tseeCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(455,-13,o),
+(520,124,o),
+(520,221,cs),
+(520,291,o),
+(487,340,o),
+(431,353,c),
+(423,335,l),
+(547,354,o),
+(592,472,o),
+(592,558,cs),
+(592,644,o),
+(545,702,o),
+(468,702,cs),
+(370,702,o),
+(292,604,o),
+(249,604,cs),
+(231,604,o),
+(225,619,o),
+(233,653,cs),
+(241,690,l),
+(159,690,l),
+(147,634,ls),
+(132,566,o),
+(157,529,o),
+(213,529,cs),
+(237,529,o),
+(261,537,o),
+(280,550,c),
+(259,580,l),
+(216,375,l),
+(138,375,l),
+(156,461,l),
+(110,461,l),
+(60,229,l),
+(106,229,l),
+(125,315,l),
+(203,315,l),
+(159,109,l),
+(192,138,l),
+(174,151,o),
+(155,160,o),
+(129,160,cs),
+(77,160,o),
+(40,128,o),
+(24,56,cs),
+(13,0,l),
+(94,0,l),
+(100,30,ls),
+(108,68,o),
+(123,86,o),
+(143,86,cs),
+(190,86,o),
+(236,-13,o),
+(336,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(284,69,o),
+(245,103,o),
+(214,128,c),
+(253,315,l),
+(323,315,l),
+(302,218,l),
+(345,218,l),
+(368,330,l),
+(341,315,l),
+(350,315,ls),
+(405,315,o),
+(435,282,o),
+(435,222,cs),
+(435,162,o),
+(401,69,o),
+(325,69,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(397,464,l),
+(355,464,l),
+(336,375,l),
+(267,375,l),
+(306,561,l),
+(345,583,o),
+(394,621,o),
+(439,621,cs),
+(480,621,o),
+(503,590,o),
+(503,542,cs),
+(503,472,o),
+(465,375,o),
+(367,375,cs),
+(355,375,l),
+(376,365,l)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165E;
+unicode = 5726;
+},
+{
+color = 9;
+glyphname = "tsiCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(455,-13,o),
+(520,124,o),
+(520,221,cs),
+(520,291,o),
+(487,340,o),
+(431,353,c),
+(423,335,l),
+(547,354,o),
+(592,472,o),
+(592,558,cs),
+(592,644,o),
+(545,702,o),
+(468,702,cs),
+(370,702,o),
+(292,604,o),
+(249,604,cs),
+(231,604,o),
+(225,619,o),
+(233,653,cs),
+(241,690,l),
+(159,690,l),
+(147,634,ls),
+(132,566,o),
+(157,529,o),
+(213,529,cs),
+(237,529,o),
+(260,537,o),
+(279,550,c),
+(258,580,l),
+(214,375,l),
+(138,375,l),
+(156,461,l),
+(110,461,l),
+(60,229,l),
+(106,229,l),
+(125,315,l),
+(202,315,l),
+(158,109,l),
+(191,138,l),
+(173,151,o),
+(155,160,o),
+(129,160,cs),
+(77,160,o),
+(40,128,o),
+(24,56,cs),
+(13,0,l),
+(94,0,l),
+(100,30,ls),
+(108,68,o),
+(123,86,o),
+(143,86,cs),
+(190,86,o),
+(236,-13,o),
+(336,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(284,69,o),
+(244,103,o),
+(213,128,c),
+(252,315,l),
+(291,315,l),
+(298,291,o),
+(320,272,o),
+(346,272,cs),
+(372,272,o),
+(393,290,o),
+(402,320,c),
+(338,315,l),
+(350,315,ls),
+(405,315,o),
+(435,282,o),
+(435,223,cs),
+(435,162,o),
+(401,69,o),
+(325,69,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(403,395,o),
+(379,417,o),
+(351,417,cs),
+(325,417,o),
+(301,399,o),
+(296,375,c),
+(266,375,l),
+(304,561,l),
+(344,582,o),
+(394,621,o),
+(439,621,cs),
+(480,621,o),
+(503,590,o),
+(503,543,cs),
+(503,472,o),
+(465,375,o),
+(367,375,cs),
+(350,375,l),
+(408,364,l)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165F;
+unicode = 5727;
+},
+{
+color = 9;
+glyphname = "tsaCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(261,-13,o),
+(339,86,o),
+(382,86,cs),
+(400,86,o),
+(406,71,o),
+(399,37,cs),
+(390,0,l),
+(471,0,l),
+(484,56,ls),
+(498,124,o),
+(473,160,o),
+(418,160,cs),
+(394,160,o),
+(370,153,o),
+(351,140,c),
+(364,110,l),
+(407,314,l),
+(489,314,l),
+(470,229,l),
+(521,229,l),
+(571,461,l),
+(521,461,l),
+(502,376,l),
+(420,376,l),
+(464,581,l),
+(439,552,l),
+(457,539,o),
+(476,529,o),
+(501,529,cs),
+(554,529,o),
+(591,561,o),
+(607,634,cs),
+(618,690,l),
+(537,690,l),
+(531,660,ls),
+(523,622,o),
+(508,604,o),
+(488,604,cs),
+(440,604,o),
+(395,702,o),
+(295,702,cs),
+(176,702,o),
+(111,566,o),
+(111,469,cs),
+(111,399,o),
+(144,350,o),
+(200,337,c),
+(208,355,l),
+(84,336,o),
+(39,217,o),
+(39,131,cs),
+(39,46,o),
+(86,-13,o),
+(163,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(152,69,o),
+(128,99,o),
+(128,148,cs),
+(128,217,o),
+(168,314,o),
+(266,314,cs),
+(350,314,l),
+(309,121,l),
+(270,97,o),
+(231,69,o),
+(192,69,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(226,376,o),
+(196,408,o),
+(196,468,cs),
+(196,522,o),
+(228,621,o),
+(306,621,cs),
+(344,621,o),
+(374,595,o),
+(405,571,c),
+(363,376,l),
+(282,376,ls)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1660;
+unicode = 5728;
+},
+{
+color = 9;
+glyphname = "chuCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(239,-13,o),
+(297,31,o),
+(333,118,c),
+(312,120,l),
+(315,33,o),
+(359,-13,o),
+(441,-13,cs),
+(572,-13,o),
+(621,114,o),
+(632,241,cs),
+(639,319,o),
+(628,440,o),
+(634,512,cs),
+(637,565,o),
+(652,611,o),
+(705,611,cs),
+(724,611,l),
+(740,690,l),
+(700,690,ls),
+(601,690,o),
+(563,624,o),
+(554,528,cs),
+(547,456,o),
+(551,325,o),
+(546,252,cs),
+(544,171,o),
+(519,70,o),
+(436,70,cs),
+(364,70,o),
+(365,147,o),
+(378,205,cs),
+(468,627,l),
+(525,627,l),
+(538,690,l),
+(344,690,l),
+(330,627,l),
+(388,627,l),
+(298,203,ls),
+(279,113,o),
+(243,70,o),
+(188,70,cs),
+(147,70,o),
+(124,95,o),
+(124,142,cs),
+(124,258,o),
+(278,498,o),
+(278,604,cs),
+(278,660,o),
+(245,690,o),
+(182,690,cs),
+(142,690,l),
+(126,611,l),
+(143,611,ls),
+(175,611,o),
+(189,599,o),
+(189,571,cs),
+(189,477,o),
+(33,272,o),
+(33,127,cs),
+(33,42,o),
+(83,-13,o),
+(165,-13,cs)
+);
+}
+);
+width = 691;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164E;
+unicode = 5729;
+},
+{
+color = 9;
+glyphname = "choCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(36,0,ls),
+(135,0,o),
+(172,66,o),
+(183,161,cs),
+(189,234,o),
+(185,365,o),
+(189,438,cs),
+(192,519,o),
+(216,620,o),
+(299,620,cs),
+(372,620,o),
+(371,543,o),
+(358,485,cs),
+(269,63,l),
+(211,63,l),
+(198,0,l),
+(392,0,l),
+(405,63,l),
+(347,63,l),
+(437,487,ls),
+(456,577,o),
+(492,620,o),
+(547,620,cs),
+(589,620,o),
+(612,595,o),
+(612,548,cs),
+(612,432,o),
+(458,191,o),
+(458,86,cs),
+(458,30,o),
+(490,0,o),
+(554,0,cs),
+(593,0,l),
+(610,78,l),
+(592,78,ls),
+(561,78,o),
+(547,91,o),
+(547,119,cs),
+(547,213,o),
+(702,417,o),
+(702,563,cs),
+(702,648,o),
+(653,702,o),
+(571,702,cs),
+(497,702,o),
+(440,659,o),
+(403,572,c),
+(423,570,l),
+(421,657,o),
+(377,702,o),
+(295,702,cs),
+(163,702,o),
+(115,576,o),
+(104,449,cs),
+(98,371,o),
+(108,250,o),
+(101,178,cs),
+(99,125,o),
+(84,78,o),
+(30,78,cs),
+(13,78,l),
+(-5,0,l)
+);
+}
+);
+width = 690;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5730;
+},
+{
+color = 9;
+glyphname = "cheCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(455,-13,o),
+(520,124,o),
+(520,221,cs),
+(520,291,o),
+(487,340,o),
+(431,353,c),
+(423,335,l),
+(547,354,o),
+(592,472,o),
+(592,558,cs),
+(592,644,o),
+(545,702,o),
+(468,702,cs),
+(370,702,o),
+(292,604,o),
+(249,604,cs),
+(231,604,o),
+(225,619,o),
+(233,653,cs),
+(241,690,l),
+(159,690,l),
+(147,634,ls),
+(132,566,o),
+(157,527,o),
+(213,527,cs),
+(296,527,o),
+(367,621,o),
+(438,621,cs),
+(479,621,o),
+(501,590,o),
+(501,542,cs),
+(501,472,o),
+(463,382,o),
+(364,382,cs),
+(143,382,l),
+(160,461,l),
+(110,461,l),
+(60,229,l),
+(110,229,l),
+(128,308,l),
+(348,308,ls),
+(404,308,o),
+(433,276,o),
+(433,222,cs),
+(433,168,o),
+(402,69,o),
+(324,69,cs),
+(252,69,o),
+(210,162,o),
+(129,162,cs),
+(77,162,o),
+(40,128,o),
+(24,56,cs),
+(13,0,l),
+(94,0,l),
+(100,30,ls),
+(108,68,o),
+(123,86,o),
+(143,86,cs),
+(190,86,o),
+(236,-13,o),
+(336,-13,cs)
+);
+}
+);
+width = 586;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni1663;
+unicode = 5731;
+},
+{
+color = 9;
+glyphname = "cheeCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(455,-13,o),
+(520,124,o),
+(520,221,cs),
+(520,291,o),
+(487,340,o),
+(431,353,c),
+(423,335,l),
+(547,354,o),
+(592,472,o),
+(592,558,cs),
+(592,644,o),
+(545,702,o),
+(468,702,cs),
+(370,702,o),
+(292,604,o),
+(249,604,cs),
+(231,604,o),
+(225,619,o),
+(233,653,cs),
+(241,690,l),
+(159,690,l),
+(147,634,ls),
+(132,566,o),
+(157,527,o),
+(213,527,cs),
+(295,527,o),
+(366,623,o),
+(438,623,cs),
+(478,623,o),
+(502,590,o),
+(502,542,cs),
+(502,472,o),
+(465,376,o),
+(366,376,cs),
+(319,376,l),
+(336,359,l),
+(356,459,l),
+(307,459,l),
+(289,376,l),
+(142,376,l),
+(160,461,l),
+(110,461,l),
+(60,229,l),
+(110,229,l),
+(128,314,l),
+(276,314,l),
+(258,223,l),
+(308,223,l),
+(331,334,l),
+(308,314,l),
+(354,314,ls),
+(410,314,o),
+(435,276,o),
+(435,222,cs),
+(435,168,o),
+(402,67,o),
+(324,67,cs),
+(252,67,o),
+(210,162,o),
+(129,162,cs),
+(77,162,o),
+(40,128,o),
+(24,56,cs),
+(13,0,l),
+(94,0,l),
+(100,30,ls),
+(108,68,o),
+(123,86,o),
+(143,86,cs),
+(190,86,o),
+(236,-13,o),
+(336,-13,cs)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1664;
+unicode = 5732;
+},
+{
+color = 9;
+glyphname = "chiCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(455,-13,o),
+(520,124,o),
+(520,221,cs),
+(520,291,o),
+(487,340,o),
+(431,353,c),
+(423,335,l),
+(547,354,o),
+(592,472,o),
+(592,558,cs),
+(592,644,o),
+(545,702,o),
+(468,702,cs),
+(370,702,o),
+(292,604,o),
+(249,604,cs),
+(231,604,o),
+(225,619,o),
+(233,653,cs),
+(241,690,l),
+(159,690,l),
+(147,634,ls),
+(132,566,o),
+(157,527,o),
+(213,527,cs),
+(295,527,o),
+(366,623,o),
+(438,623,cs),
+(478,623,o),
+(502,590,o),
+(502,542,cs),
+(502,472,o),
+(465,376,o),
+(370,376,cs),
+(328,376,l),
+(357,360,l),
+(352,393,o),
+(324,417,o),
+(290,417,cs),
+(260,417,o),
+(237,400,o),
+(226,376,c),
+(142,376,l),
+(160,461,l),
+(110,461,l),
+(60,229,l),
+(110,229,l),
+(128,314,l),
+(226,314,l),
+(237,292,o),
+(258,272,o),
+(290,272,cs),
+(325,272,o),
+(352,298,o),
+(358,332,c),
+(321,314,l),
+(357,314,ls),
+(408,314,o),
+(435,279,o),
+(435,222,cs),
+(435,168,o),
+(402,67,o),
+(324,67,cs),
+(252,67,o),
+(210,162,o),
+(129,162,cs),
+(77,162,o),
+(40,128,o),
+(24,56,cs),
+(13,0,l),
+(94,0,l),
+(100,30,ls),
+(108,68,o),
+(123,86,o),
+(143,86,cs),
+(190,86,o),
+(236,-13,o),
+(336,-13,cs)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1665;
+unicode = 5733;
+},
+{
+color = 9;
+glyphname = "chaCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(261,-11,o),
+(339,88,o),
+(382,88,cs),
+(400,88,o),
+(406,72,o),
+(398,39,cs),
+(390,2,l),
+(471,2,l),
+(484,58,ls),
+(498,126,o),
+(473,164,o),
+(417,164,cs),
+(335,164,o),
+(264,71,o),
+(193,71,cs),
+(152,71,o),
+(129,101,o),
+(129,149,cs),
+(129,219,o),
+(168,310,o),
+(267,310,cs),
+(488,310,l),
+(470,231,l),
+(521,231,l),
+(571,463,l),
+(521,463,l),
+(503,384,l),
+(283,384,ls),
+(227,384,o),
+(198,415,o),
+(198,469,cs),
+(198,524,o),
+(229,623,o),
+(307,623,cs),
+(379,623,o),
+(421,529,o),
+(501,529,cs),
+(553,529,o),
+(591,564,o),
+(607,636,cs),
+(618,692,l),
+(537,692,l),
+(530,662,ls),
+(523,624,o),
+(508,606,o),
+(488,606,cs),
+(440,606,o),
+(395,704,o),
+(295,704,cs),
+(176,704,o),
+(111,568,o),
+(111,470,cs),
+(111,401,o),
+(144,352,o),
+(200,339,c),
+(208,356,l),
+(84,338,o),
+(39,219,o),
+(39,133,cs),
+(39,47,o),
+(86,-11,o),
+(163,-11,cs)
+);
+}
+);
+width = 585;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1666;
+unicode = 5734;
+},
+{
+color = 9;
+glyphname = "ttsuCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(239,-13,o),
+(296,31,o),
+(333,118,c),
+(312,120,l),
+(315,33,o),
+(359,-13,o),
+(441,-13,cs),
+(572,-13,o),
+(621,114,o),
+(632,241,cs),
+(639,319,o),
+(628,440,o),
+(634,512,cs),
+(637,565,o),
+(652,611,o),
+(705,611,cs),
+(724,611,l),
+(740,690,l),
+(700,690,ls),
+(601,690,o),
+(563,624,o),
+(554,528,cs),
+(551,505,o),
+(549,483,o),
+(547,461,c),
+(584,526,l),
+(420,406,l),
+(468,627,l),
+(525,627,l),
+(538,690,l),
+(344,690,l),
+(330,627,l),
+(388,627,l),
+(342,407,l),
+(221,526,l),
+(240,462,l),
+(262,518,o),
+(278,568,o),
+(278,604,cs),
+(278,660,o),
+(245,690,o),
+(182,690,cs),
+(142,690,l),
+(126,611,l),
+(143,611,ls),
+(175,611,o),
+(189,599,o),
+(189,571,cs),
+(189,477,o),
+(33,272,o),
+(33,127,cs),
+(33,42,o),
+(83,-13,o),
+(165,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(147,70,o),
+(124,95,o),
+(124,142,cs),
+(124,216,o),
+(183,323,o),
+(225,420,c),
+(325,323,l),
+(298,203,ls),
+(279,113,o),
+(243,70,o),
+(188,70,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(364,70,o),
+(365,147,o),
+(378,205,cs),
+(401,313,l),
+(545,415,l),
+(545,358,o),
+(548,299,o),
+(546,252,cs),
+(544,171,o),
+(519,70,o),
+(436,70,cs)
+);
+}
+);
+width = 691;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1667;
+unicode = 5735;
+},
+{
+color = 9;
+glyphname = "ttsoCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(36,0,ls),
+(135,0,o),
+(172,66,o),
+(183,161,cs),
+(185,185,o),
+(186,207,o),
+(188,229,c),
+(152,164,l),
+(315,284,l),
+(269,63,l),
+(211,63,l),
+(198,0,l),
+(392,0,l),
+(405,63,l),
+(347,63,l),
+(394,283,l),
+(514,163,l),
+(497,228,l),
+(474,172,o),
+(458,122,o),
+(458,86,cs),
+(458,30,o),
+(490,0,o),
+(554,0,cs),
+(593,0,l),
+(611,78,l),
+(592,78,ls),
+(561,78,o),
+(547,91,o),
+(547,119,cs),
+(547,213,o),
+(702,417,o),
+(702,563,cs),
+(702,648,o),
+(653,702,o),
+(571,702,cs),
+(497,702,o),
+(440,659,o),
+(403,572,c),
+(423,570,l),
+(421,657,o),
+(377,702,o),
+(295,702,cs),
+(163,702,o),
+(115,576,o),
+(104,449,cs),
+(98,371,o),
+(108,250,o),
+(101,178,cs),
+(99,125,o),
+(84,78,o),
+(30,78,cs),
+(13,78,l),
+(-5,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(190,331,o),
+(187,390,o),
+(189,438,cs),
+(192,519,o),
+(216,620,o),
+(299,620,cs),
+(372,620,o),
+(371,543,o),
+(358,485,cs),
+(335,377,l),
+(190,274,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(412,367,l),
+(437,487,ls),
+(456,577,o),
+(492,620,o),
+(547,620,cs),
+(589,620,o),
+(612,595,o),
+(612,548,cs),
+(612,473,o),
+(554,367,o),
+(510,270,c)
+);
+}
+);
+width = 691;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1668;
+unicode = 5736;
+},
+{
+color = 9;
+glyphname = "ttseCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(454,-13,o),
+(520,123,o),
+(520,220,cs),
+(520,291,o),
+(487,340,o),
+(430,353,c),
+(422,335,l),
+(547,354,o),
+(592,471,o),
+(592,558,cs),
+(592,643,o),
+(545,702,o),
+(468,702,cs),
+(369,702,o),
+(292,604,o),
+(248,604,cs),
+(231,604,o),
+(225,619,o),
+(232,653,cs),
+(240,690,l),
+(158,690,l),
+(147,634,ls),
+(131,566,o),
+(156,527,o),
+(213,527,cs),
+(222,527,o),
+(230,528,o),
+(239,530,c),
+(200,571,l),
+(226,376,l),
+(142,376,l),
+(160,461,l),
+(110,461,l),
+(60,229,l),
+(110,229,l),
+(128,314,l),
+(214,314,l),
+(106,123,l),
+(165,157,l),
+(155,160,o),
+(143,162,o),
+(129,162,cs),
+(76,162,o),
+(40,128,o),
+(24,56,cs),
+(12,0,l),
+(93,0,l),
+(99,30,ls),
+(107,68,o),
+(123,86,o),
+(143,86,cs),
+(190,86,o),
+(236,-13,o),
+(335,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(268,67,o),
+(232,125,o),
+(187,146,c),
+(280,314,l),
+(357,314,ls),
+(409,314,o),
+(436,281,o),
+(436,228,cs),
+(436,172,o),
+(403,67,o),
+(324,67,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(267,541,l),
+(323,558,o),
+(380,623,o),
+(438,623,cs),
+(480,623,o),
+(503,590,o),
+(503,540,cs),
+(503,473,o),
+(465,376,o),
+(368,376,cs),
+(287,376,l)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1669;
+unicode = 5737;
+},
+{
+color = 9;
+glyphname = "ttseeCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(454,-13,o),
+(520,123,o),
+(520,220,cs),
+(520,291,o),
+(487,340,o),
+(430,353,c),
+(422,335,l),
+(547,354,o),
+(592,471,o),
+(592,558,cs),
+(592,643,o),
+(545,702,o),
+(468,702,cs),
+(369,702,o),
+(292,604,o),
+(248,604,cs),
+(231,604,o),
+(225,619,o),
+(232,653,cs),
+(240,690,l),
+(158,690,l),
+(147,634,ls),
+(131,566,o),
+(156,527,o),
+(213,527,cs),
+(222,527,o),
+(230,528,o),
+(239,530,c),
+(196,571,l),
+(222,376,l),
+(142,376,l),
+(160,461,l),
+(110,461,l),
+(60,229,l),
+(110,229,l),
+(128,314,l),
+(211,314,l),
+(102,123,l),
+(165,157,l),
+(155,160,o),
+(143,162,o),
+(129,162,cs),
+(76,162,o),
+(40,128,o),
+(24,56,cs),
+(12,0,l),
+(93,0,l),
+(99,30,ls),
+(107,68,o),
+(123,86,o),
+(143,86,cs),
+(190,86,o),
+(236,-13,o),
+(335,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(267,67,o),
+(225,131,o),
+(180,151,c),
+(270,314,l),
+(319,314,l),
+(298,218,l),
+(344,218,l),
+(366,326,l),
+(347,314,l),
+(357,314,ls),
+(409,314,o),
+(436,281,o),
+(436,228,cs),
+(436,172,o),
+(403,67,o),
+(324,67,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(396,464,l),
+(350,464,l),
+(331,376,l),
+(277,376,l),
+(257,535,l),
+(312,552,o),
+(378,623,o),
+(438,623,cs),
+(480,623,o),
+(503,590,o),
+(503,540,cs),
+(503,473,o),
+(465,376,o),
+(368,376,cs),
+(358,376,l),
+(374,363,l)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166A;
+unicode = 5738;
+},
+{
+color = 9;
+glyphname = "ttsiCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(454,-13,o),
+(520,123,o),
+(520,220,cs),
+(520,291,o),
+(487,340,o),
+(430,353,c),
+(422,335,l),
+(547,354,o),
+(592,471,o),
+(592,558,cs),
+(592,643,o),
+(545,702,o),
+(468,702,cs),
+(369,702,o),
+(292,604,o),
+(248,604,cs),
+(231,604,o),
+(225,619,o),
+(232,653,cs),
+(240,690,l),
+(158,690,l),
+(147,634,ls),
+(131,566,o),
+(156,527,o),
+(213,527,cs),
+(222,527,o),
+(230,528,o),
+(239,530,c),
+(196,571,l),
+(222,376,l),
+(142,376,l),
+(160,461,l),
+(110,461,l),
+(60,229,l),
+(110,229,l),
+(128,314,l),
+(211,314,l),
+(102,123,l),
+(165,157,l),
+(155,160,o),
+(143,162,o),
+(129,162,cs),
+(76,162,o),
+(40,128,o),
+(24,56,cs),
+(12,0,l),
+(93,0,l),
+(99,30,ls),
+(107,68,o),
+(123,86,o),
+(143,86,cs),
+(190,86,o),
+(236,-13,o),
+(335,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(267,67,o),
+(224,131,o),
+(179,151,c),
+(270,314,l),
+(281,314,l),
+(288,294,o),
+(311,272,o),
+(338,272,cs),
+(370,272,o),
+(391,298,o),
+(399,326,c),
+(347,314,l),
+(358,314,ls),
+(409,314,o),
+(436,281,o),
+(436,228,cs),
+(436,172,o),
+(403,67,o),
+(324,67,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(391,398,o),
+(366,417,o),
+(338,417,cs),
+(313,417,o),
+(288,399,o),
+(281,376,c),
+(276,376,l),
+(256,535,l),
+(312,551,o),
+(378,623,o),
+(438,623,cs),
+(480,623,o),
+(503,590,o),
+(503,540,cs),
+(503,473,o),
+(466,376,o),
+(369,376,cs),
+(358,376,l),
+(399,363,l)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166B;
+unicode = 5739;
+},
+{
+color = 9;
+glyphname = "ttsaCarrier-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(262,-13,o),
+(339,86,o),
+(383,86,cs),
+(400,86,o),
+(406,71,o),
+(399,37,cs),
+(391,0,l),
+(472,0,l),
+(484,56,ls),
+(499,124,o),
+(474,162,o),
+(418,162,cs),
+(409,162,o),
+(401,161,o),
+(392,159,c),
+(431,119,l),
+(405,314,l),
+(489,314,l),
+(470,229,l),
+(521,229,l),
+(571,461,l),
+(521,461,l),
+(502,376,l),
+(416,376,l),
+(525,567,l),
+(466,532,l),
+(476,529,o),
+(489,527,o),
+(501,527,cs),
+(554,527,o),
+(591,562,o),
+(607,634,cs),
+(619,690,l),
+(538,690,l),
+(531,660,ls),
+(524,622,o),
+(508,604,o),
+(488,604,cs),
+(440,604,o),
+(395,702,o),
+(296,702,cs),
+(177,702,o),
+(111,567,o),
+(111,469,cs),
+(111,399,o),
+(144,350,o),
+(201,337,c),
+(209,355,l),
+(84,336,o),
+(39,218,o),
+(39,131,cs),
+(39,46,o),
+(86,-13,o),
+(163,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(152,67,o),
+(128,99,o),
+(128,150,cs),
+(128,216,o),
+(166,314,o),
+(263,314,cs),
+(344,314,l),
+(364,149,l),
+(309,131,o),
+(252,67,o),
+(193,67,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(222,376,o),
+(195,409,o),
+(195,462,cs),
+(195,518,o),
+(228,623,o),
+(307,623,cs),
+(363,623,o),
+(399,565,o),
+(443,544,c),
+(351,376,l),
+(273,376,ls)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni166C;
+unicode = 5740;
+},
+{
+glyphname = "qai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (261,0);
+ref = "ke-canadian";
+}
+);
+width = 741;
+}
+);
+note = uni166F;
+unicode = 5743;
+},
+{
+glyphname = "ngai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (498,0);
+ref = "ce-canadian";
+}
+);
+width = 972;
+}
+);
+note = uni1670;
+unicode = 5744;
+},
+{
+glyphname = "nngi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (730,0);
+ref = "ci-canadian";
+}
+);
+width = 1203;
+}
+);
+note = uni1671;
+unicode = 5745;
+},
+{
+glyphname = "nngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (730,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (905,0);
+ref = dot_top;
+}
+);
+width = 1203;
+}
+);
+note = uni1672;
+unicode = 5746;
+},
+{
+glyphname = "nngo-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (730,0);
+ref = "ce-canadian";
+}
+);
+width = 1203;
+}
+);
+note = uni1673;
+unicode = 5747;
+},
+{
+glyphname = "nngoo-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (730,0);
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (896,0);
+ref = dot_top;
+}
+);
+width = 1203;
+}
+);
+note = uni1674;
+unicode = 5748;
+},
+{
+glyphname = "nnga-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (730,0);
+ref = "ca-canadian";
+}
+);
+width = 1203;
+}
+);
+note = uni1675;
+unicode = 5749;
+},
+{
+glyphname = "nngaa-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (730,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (764,0);
+ref = dot_top;
+}
+);
+width = 1203;
+}
+);
+note = uni1676;
+unicode = 5750;
+},
+{
+glyphname = "thweeWoodScree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (497,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 682;
+}
+);
+note = uni1677;
+unicode = 5751;
+},
+{
+glyphname = "thwiWoodScree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (497,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 682;
+}
+);
+note = uni1678;
+unicode = 5752;
+},
+{
+glyphname = "thwiiWoodScree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (69,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (497,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 682;
+}
+);
+note = uni1679;
+unicode = 5753;
+},
+{
+glyphname = "thwoWoodScree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (497,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 682;
+}
+);
+note = uni167A;
+unicode = 5754;
+},
+{
+glyphname = "thwooWoodScree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (293,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (497,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 682;
+}
+);
+note = uni167B;
+unicode = 5755;
+},
+{
+glyphname = "thwaWoodScree-canadian";
+lastChange = "2023-01-13 15:55:46 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = middle_right_can;
+pos = (498,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 683;
+}
+);
+note = uni167C;
+unicode = 5756;
+},
+{
+glyphname = "thwaaWoodScree-canadian";
+lastChange = "2023-01-13 15:55:46 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (70,0);
+ref = dot_top;
+},
+{
+anchor = middle_right_can;
+pos = (498,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 683;
+}
+);
+note = uni167D;
+unicode = 5757;
+},
+{
+glyphname = "wBlackfoot-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(372,558,l),
+(384,612,l),
+(129,612,l),
+(118,558,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(343,422,l),
+(355,476,l),
+(99,476,l),
+(88,422,l)
+);
+}
+);
+width = 354;
+}
+);
+metricRight = "=|";
+note = uni167F;
+unicode = 5759;
+},
+{
+glyphname = "oy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-19,0);
+ref = ring_top.canadian;
+}
+);
+width = 550;
+}
+);
+note = uni18B0;
+unicode = 6320;
+},
+{
+glyphname = "ay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (335,0);
+ref = ring_top.canadian;
+}
+);
+width = 550;
+}
+);
+note = uni18B1;
+unicode = 6321;
+},
+{
+glyphname = "aay-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (129,0);
+ref = ring_top.canadian;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (383,0);
+ref = dot_top;
+}
+);
+width = 550;
+}
+);
+note = uni18B2;
+unicode = 6322;
+},
+{
+glyphname = "way-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (521,0);
+ref = ring_top.canadian;
+}
+);
+width = 735;
+}
+);
+note = uni18B3;
+unicode = 6323;
+},
+{
+glyphname = "poy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-36,0);
+ref = ring_top.canadian;
+}
+);
+width = 526;
+}
+);
+note = uni18B4;
+unicode = 6324;
+},
+{
+glyphname = "pay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (332,0);
+ref = ring_top.canadian;
+}
+);
+width = 526;
+}
+);
+note = uni18B5;
+unicode = 6325;
+},
+{
+glyphname = "pwoy-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (150,0);
+ref = ring_top.canadian;
+}
+);
+width = 711;
+}
+);
+note = uni18B6;
+unicode = 6326;
+},
+{
+glyphname = "tay-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (153,0);
+ref = ring_top.canadian;
+}
+);
+width = 487;
+}
+);
+note = uni18B7;
+unicode = 6327;
+},
+{
+glyphname = "kay-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-14,0);
+ref = ring_top.canadian;
+}
+);
+width = 481;
+}
+);
+note = uni18B8;
+unicode = 6328;
+},
+{
+glyphname = "kway-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (171,0);
+ref = ring_top.canadian;
+}
+);
+width = 666;
+}
+);
+note = uni18B9;
+unicode = 6329;
+},
+{
+glyphname = "may-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-10,0);
+ref = ring_top.canadian;
+}
+);
+width = 431;
+}
+);
+note = uni18BA;
+unicode = 6330;
+},
+{
+glyphname = "noy-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (254,-193);
+ref = ring_top.canadian;
+}
+);
+width = 653;
+}
+);
+note = uni18BB;
+unicode = 6331;
+},
+{
+glyphname = "nay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (85,-193);
+ref = ring_top.canadian;
+}
+);
+width = 653;
+}
+);
+note = uni18BC;
+unicode = 6332;
+},
+{
+glyphname = "lay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (86,-193);
+ref = ring_top.canadian;
+}
+);
+width = 653;
+}
+);
+note = uni18BD;
+unicode = 6333;
+},
+{
+glyphname = "soy-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (218,0);
+ref = ring_top.canadian;
+}
+);
+width = 439;
+}
+);
+note = uni18BE;
+unicode = 6334;
+},
+{
+glyphname = "say-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-10,0);
+ref = ring_top.canadian;
+}
+);
+width = 439;
+}
+);
+note = uni18BF;
+unicode = 6335;
+},
+{
+glyphname = "shoy-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (216,-193);
+ref = ring_top.canadian;
+}
+);
+width = 749;
+}
+);
+note = uni18C0;
+unicode = 6336;
+},
+{
+glyphname = "shay-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (218,-193);
+ref = ring_top.canadian;
+}
+);
+width = 749;
+}
+);
+note = uni18C1;
+unicode = 6337;
+},
+{
+glyphname = "shwoy-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (402,-193);
+ref = ring_top.canadian;
+}
+);
+width = 933;
+}
+);
+note = uni18C2;
+unicode = 6338;
+},
+{
+glyphname = "yoy-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (245,0);
+ref = ring_top.canadian;
+}
+);
+width = 463;
+}
+);
+note = uni18C3;
+unicode = 6339;
+},
+{
+glyphname = "yay-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-13,0);
+ref = ring_top.canadian;
+}
+);
+width = 463;
+}
+);
+note = uni18C4;
+unicode = 6340;
+},
+{
+glyphname = "ray-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (131,0);
+ref = ring_top.canadian;
+}
+);
+width = 440;
+}
+);
+note = uni18C5;
+unicode = 6341;
+},
+{
+glyphname = "nwi-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ni-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni18C6;
+unicode = 6342;
+},
+{
+glyphname = "nwiOjibway-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni18C7;
+unicode = 6343;
+},
+{
+glyphname = "nwii-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (327,-193);
+ref = dot_top;
+}
+);
+width = 838;
+}
+);
+note = uni18C8;
+unicode = 6344;
+},
+{
+glyphname = "nwiiOjibway-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (142,-193);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni18C9;
+unicode = 6345;
+},
+{
+glyphname = "nwo-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "no-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni18CA;
+unicode = 6346;
+},
+{
+glyphname = "nwoOjibway-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni18CB;
+unicode = 6347;
+},
+{
+glyphname = "nwoo-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (486,-193);
+ref = dot_top;
+}
+);
+width = 838;
+}
+);
+note = uni18CC;
+unicode = 6348;
+},
+{
+glyphname = "nwooOjibway-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (301,-193);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni18CD;
+unicode = 6349;
+},
+{
+glyphname = "rwee-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "reRCree-canadian";
+}
+);
+width = 872;
+}
+);
+note = uni18CE;
+unicode = 6350;
+},
+{
+glyphname = "rwi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ri-canadian";
+}
+);
+width = 872;
+}
+);
+note = uni18CF;
+unicode = 6351;
+},
+{
+glyphname = "rwii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (321,-193);
+ref = dot_top;
+}
+);
+width = 872;
+}
+);
+note = uni18D0;
+unicode = 6352;
+},
+{
+glyphname = "rwo-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ro-canadian";
+}
+);
+width = 625;
+}
+);
+note = uni18D1;
+unicode = 6353;
+},
+{
+glyphname = "rwoo-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (310,0);
+ref = dot_top;
+}
+);
+width = 625;
+}
+);
+note = uni18D2;
+unicode = 6354;
+},
+{
+glyphname = "rwa-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ra-canadian";
+}
+);
+width = 625;
+}
+);
+note = uni18D3;
+unicode = 6355;
+},
+{
+glyphname = "pOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(115,345,l),
+(267,621,l),
+(228,621,l),
+(262,345,l),
+(318,345,l),
+(321,358,l),
+(268,690,l),
+(251,690,l),
+(57,358,l),
+(54,345,l)
+);
+}
+);
+width = 325;
+}
+);
+metricLeft = "kkCarrier-canadian";
+note = uni18D4;
+unicode = 6356;
+},
+{
+glyphname = "tOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 341;
+}
+);
+metricRight = "=|";
+note = uni1422;
+unicode = 6357;
+},
+{
+glyphname = "kOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(133,345,l),
+(168,507,l),
+(153,502,l),
+(150,462,o),
+(177,435,o),
+(216,435,cs),
+(298,435,o),
+(330,540,o),
+(330,598,cs),
+(330,659,o),
+(298,696,o),
+(241,696,cs),
+(179,696,o),
+(137,654,o),
+(119,568,cs),
+(72,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(186,482,o),
+(173,499,o),
+(173,530,cs),
+(173,562,o),
+(190,648,o),
+(240,648,cs),
+(263,648,o),
+(275,631,o),
+(275,601,cs),
+(275,565,o),
+(257,482,o),
+(210,482,cs)
+);
+}
+);
+width = 298;
+}
+);
+metricLeft = "k-canadian";
+metricRight = "k-canadian";
+note = uni18D6;
+unicode = 6358;
+},
+{
+glyphname = "cOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(134,345,l),
+(186,584,ls),
+(194,628,o),
+(214,645,o),
+(242,645,cs),
+(273,645,o),
+(284,618,o),
+(276,582,cs),
+(269,548,l),
+(326,548,l),
+(330,572,ls),
+(345,642,o),
+(315,696,o),
+(241,696,cs),
+(178,696,o),
+(139,654,o),
+(123,581,cs),
+(72,345,l)
+);
+}
+);
+width = 290;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni18D7;
+unicode = 6359;
+},
+{
+glyphname = "mOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(133,345,l),
+(194,631,l),
+(319,631,l),
+(331,690,l),
+(145,690,l),
+(71,345,l)
+);
+}
+);
+width = 267;
+}
+);
+metricLeft = "m-canadian";
+metricRight = "m-canadian";
+note = uni18D8;
+unicode = 6360;
+},
+{
+glyphname = "nOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(282,428,o),
+(319,523,o),
+(319,590,cs),
+(319,612,o),
+(313,639,o),
+(295,654,c),
+(288,631,l),
+(428,631,l),
+(441,690,l),
+(233,690,ls),
+(143,690,o),
+(106,596,o),
+(106,526,cs),
+(106,466,o),
+(141,428,o),
+(196,428,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(174,475,o),
+(161,494,o),
+(161,526,cs),
+(161,563,o),
+(177,642,o),
+(226,642,cs),
+(251,642,o),
+(265,624,o),
+(265,591,cs),
+(265,554,o),
+(248,475,o),
+(200,475,cs)
+);
+}
+);
+width = 375;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "n-canadian";
+note = uni18D9;
+unicode = 6361;
+},
+{
+glyphname = "sOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(134,345,l),
+(164,484,l),
+(120,460,l),
+(150,460,ls),
+(242,460,o),
+(295,508,o),
+(316,610,cs),
+(333,690,l),
+(271,690,l),
+(255,615,ls),
+(240,541,o),
+(205,510,o),
+(139,510,cs),
+(107,510,l),
+(72,345,l)
+);
+}
+);
+width = 286;
+}
+);
+metricLeft = "s-canadian";
+metricRight = "s-canadian";
+note = uni18DA;
+unicode = 6362;
+},
+{
+color = 1;
+glyphname = "shOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(225,341,o),
+(263,381,o),
+(285,458,cs),
+(322,583,ls),
+(333,626,o),
+(350,647,o),
+(379,647,cs),
+(409,647,o),
+(421,627,o),
+(412,587,cs),
+(404,550,l),
+(461,550,l),
+(468,578,ls),
+(483,650,o),
+(450,697,o),
+(382,697,cs),
+(320,697,o),
+(282,658,o),
+(260,580,cs),
+(223,455,ls),
+(212,412,o),
+(195,390,o),
+(165,390,cs),
+(135,390,o),
+(124,411,o),
+(132,451,cs),
+(141,489,l),
+(83,489,l),
+(77,460,ls),
+(62,388,o),
+(95,341,o),
+(163,341,cs)
+);
+}
+);
+width = 426;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "c-canadian";
+note = uni18DB;
+unicode = 6363;
+},
+{
+color = 9;
+glyphname = "easternw-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (-39,-307);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (119,0);
+ref = "glottalstop-canadian";
+}
+);
+width = 469;
+}
+);
+note = uni18DC;
+unicode = 6364;
+},
+{
+color = 9;
+glyphname = "westernw-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (634,-307);
+ref = dot_top;
+scale = (-1,1);
+},
+{
+alignment = -1;
+ref = "glottalstop-canadian";
+}
+);
+width = 474;
+}
+);
+metricLeft = "glottalstop-canadian";
+note = uni18DD;
+unicode = 6365;
+},
+{
+glyphname = "rweRCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "reRCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (687,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 872;
+}
+);
+note = uni18E0;
+unicode = 6368;
+},
+{
+glyphname = "looWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (38,0);
+ref = dot_top;
+}
+);
+width = 440;
+}
+);
+note = uni18E1;
+unicode = 6369;
+},
+{
+glyphname = "laaWestCree-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (268,0);
+ref = dot_top;
+}
+);
+width = 440;
+}
+);
+note = uni18E2;
+unicode = 6370;
+},
+{
+glyphname = "thwe-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "the-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (589,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 774;
+}
+);
+note = uni18E3;
+unicode = 6371;
+},
+{
+glyphname = "thwa-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (541,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 726;
+}
+);
+note = uni18E4;
+unicode = 6372;
+},
+{
+glyphname = "tthwe-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "tthe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (582,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 767;
+}
+);
+note = uni18E5;
+unicode = 6373;
+},
+{
+glyphname = "tthoo-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ttho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (169,0);
+ref = dot_top;
+}
+);
+width = 504;
+}
+);
+note = uni18E6;
+unicode = 6374;
+},
+{
+glyphname = "tthaa-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ttha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (185,0);
+ref = dot_top;
+}
+);
+width = 504;
+}
+);
+note = uni18E7;
+unicode = 6375;
+},
+{
+glyphname = "tlhwe-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "tlhe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (488,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 672;
+}
+);
+note = uni18E8;
+unicode = 6376;
+},
+{
+glyphname = "tlhoo-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "tlho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (185,0);
+ref = dot_top;
+}
+);
+width = 488;
+}
+);
+note = uni18E9;
+unicode = 6377;
+},
+{
+glyphname = "shweSayisi-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "sheSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (488,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 672;
+}
+);
+note = uni18EA;
+unicode = 6378;
+},
+{
+glyphname = "shooSayisi-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "shoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (319,0);
+ref = dot_top;
+}
+);
+width = 488;
+}
+);
+note = uni18EB;
+unicode = 6379;
+},
+{
+color = 9;
+glyphname = "hooSayisi-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "hoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (373,0);
+ref = dot_top;
+}
+);
+width = 545;
+}
+);
+note = uni18EC;
+unicode = 6380;
+},
+{
+color = 9;
+glyphname = "gwuCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "guCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (685,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 870;
+}
+);
+note = uni18ED;
+unicode = 6381;
+},
+{
+color = 9;
+glyphname = "deneGeeCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "geCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (223,0);
+ref = dot_top;
+}
+);
+width = 576;
+}
+);
+note = uni18EE;
+unicode = 6382;
+},
+{
+color = 9;
+glyphname = "gaaCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (233,0);
+ref = dot_top;
+}
+);
+width = 576;
+}
+);
+note = uni18EF;
+unicode = 6383;
+},
+{
+color = 9;
+glyphname = "gwaCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (576,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 761;
+}
+);
+note = uni18F0;
+unicode = 6384;
+},
+{
+color = 9;
+glyphname = "juuSayisi-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "juSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (238,0);
+ref = dot_top;
+}
+);
+width = 574;
+}
+);
+note = uni18F1;
+unicode = 6385;
+},
+{
+color = 9;
+glyphname = "jwaCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "jaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (624,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni18F2;
+unicode = 6386;
+},
+{
+glyphname = "lBeaverDene-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "pWestCree-canadian";
+}
+);
+width = 159;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+unicode = 6387;
+},
+{
+glyphname = "rBeaverDene-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(133,345,l),
+(177,550,ls),
+(188,604,o),
+(213,632,o),
+(252,632,cs),
+(259,632,l),
+(272,696,l),
+(269,696,ls),
+(224,696,o),
+(192,666,o),
+(180,611,c),
+(185,611,l),
+(201,690,l),
+(145,690,l),
+(71,345,l)
+);
+}
+);
+width = 203;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni18F4;
+unicode = 6388;
+},
+{
+color = 6;
+glyphname = "sDentalCarrier-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(161,184,ls),
+(246,184,o),
+(289,231,o),
+(289,301,cs),
+(289,350,o),
+(260,381,o),
+(210,381,cs),
+(188,381,ls),
+(160,381,o),
+(146,394,o),
+(146,417,cs),
+(146,445,o),
+(159,477,o),
+(205,477,cs),
+(324,477,l),
+(335,527,l),
+(215,527,ls),
+(130,527,o),
+(89,479,o),
+(89,409,cs),
+(89,360,o),
+(117,330,o),
+(167,330,cs),
+(188,330,ls),
+(216,330,o),
+(231,317,o),
+(231,294,cs),
+(231,266,o),
+(217,234,o),
+(172,234,cs),
+(53,234,l),
+(42,184,l)
+);
+}
+);
+width = 328;
+}
+);
+metricLeft = "shCarrier-canadian";
+metricRight = "=|";
+note = uni18F5;
+unicode = 6389;
+},
+{
+glyphname = "pWestCree-canadian.base";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-74,-345);
+ref = "pWestCree-canadian";
+}
+);
+width = 158;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.base";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-73,-345);
+ref = "c-canadian";
+}
+);
+width = 290;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "thSayisi-canadian.base";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-74,-345);
+ref = "thSayisi-canadian";
+}
+);
+width = 289;
+}
+);
+metricLeft = "=|c-canadian";
+note = uni14A2;
+},
+{
+glyphname = "mWestCree-canadian.base";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-74,-345);
+ref = "mWestCree-canadian";
+}
+);
+width = 292;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+glyphname = "pWestCree-canadian.mid";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-162);
+ref = "pWestCree-canadian";
+}
+);
+width = 160;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.mid";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-162);
+ref = "c-canadian";
+}
+);
+width = 289;
+}
+);
+metricLeft = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "mWestCree-canadian.mid";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-162);
+ref = "mWestCree-canadian";
+}
+);
+width = 293;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+color = 11;
+glyphname = "ngaai-canadian.nunavik";
+lastChange = "2023-01-13 15:55:46 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (518,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (645,0);
+ref = ring_top.canadian;
+}
+);
+width = 994;
+}
+);
+note = uni158E;
+},
+{
+color = 11;
+glyphname = "ngi-canadian.nunavik";
+lastChange = "2023-01-13 15:55:46 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (518,0);
+ref = "ci-canadian";
+}
+);
+width = 994;
+}
+);
+note = uni158F;
+},
+{
+color = 11;
+glyphname = "ngii-canadian.nunavik";
+lastChange = "2023-01-13 15:55:46 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (518,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (693,0);
+ref = dot_top;
+}
+);
+width = 994;
+}
+);
+note = uni1590;
+},
+{
+color = 11;
+glyphname = "ngo-canadian.nunavik";
+lastChange = "2023-01-13 15:55:46 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (518,0);
+ref = "co-canadian";
+}
+);
+width = 995;
+}
+);
+note = uni1591;
+},
+{
+color = 11;
+glyphname = "ngoo-canadian.nunavik";
+lastChange = "2023-01-13 15:55:46 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "ngo-canadian.nunavik";
+},
+{
+anchor = top_right_can;
+pos = (825,0);
+ref = dot_top;
+}
+);
+width = 995;
+}
+);
+note = uni1592;
+},
+{
+color = 11;
+glyphname = "nga-canadian.nunavik";
+lastChange = "2023-01-13 15:55:46 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (518,0);
+ref = "ca-canadian";
+}
+);
+width = 993;
+}
+);
+note = uni1593;
+},
+{
+color = 11;
+glyphname = "ngaa-canadian.nunavik";
+lastChange = "2023-01-13 15:55:46 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (518,0);
+ref = "ca-canadian";
+},
+{
+anchor = top_left_can;
+pos = (552,0);
+ref = dot_top;
+}
+);
+width = 993;
+}
+);
+note = uni1594;
+},
+{
+color = 11;
+glyphname = "ng-canadian.nunavik";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(460,157,o),
+(492,263,o),
+(492,326,cs),
+(492,383,o),
+(464,419,o),
+(415,419,cs),
+(384,419,o),
+(359,402,o),
+(344,372,c),
+(357,368,l),
+(384,493,l),
+(266,493,l),
+(269,469,l),
+(304,497,o),
+(319,557,o),
+(319,596,cs),
+(319,656,o),
+(286,696,o),
+(229,696,cs),
+(144,696,o),
+(107,602,o),
+(107,533,cs),
+(107,471,o),
+(142,434,o),
+(200,434,cs),
+(335,434,l),
+(315,462,l),
+(280,300,ls),
+(268,240,o),
+(282,157,o),
+(367,157,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(347,205,o),
+(332,223,o),
+(332,256,cs),
+(332,290,o),
+(349,372,o),
+(398,372,cs),
+(422,372,o),
+(436,355,o),
+(436,322,cs),
+(436,287,o),
+(418,205,o),
+(371,205,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(174,481,o),
+(160,499,o),
+(160,532,cs),
+(160,568,o),
+(178,648,o),
+(225,648,cs),
+(250,648,o),
+(265,630,o),
+(265,596,cs),
+(265,562,o),
+(247,481,o),
+(199,481,cs)
+);
+}
+);
+width = 518;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+color = 11;
+glyphname = "ngai-canadian.nunavik";
+lastChange = "2023-01-13 15:55:46 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (518,0);
+ref = "ce-canadian";
+}
+);
+width = 994;
+}
+);
+note = uni1670;
+},
+{
+color = 11;
+glyphname = "ke-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (371,690);
+},
+{
+name = top_left_can;
+pos = (190,690);
+},
+{
+name = top_right_can;
+pos = (553,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(450,0,l),
+(597,690,l),
+(432,690,ls),
+(166,690,o),
+(80,507,o),
+(80,355,cs),
+(80,218,o),
+(168,134,o),
+(317,134,cs),
+(388,134,l),
+(360,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(224,214,o),
+(169,265,o),
+(169,358,cs),
+(169,455,o),
+(212,610,o),
+(411,610,cs),
+(490,610,l),
+(405,214,l),
+(333,214,ls)
+);
+}
+);
+width = 561;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146B;
+},
+{
+color = 11;
+glyphname = "ki-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (383,690);
+},
+{
+name = top_left_can;
+pos = (201,690);
+},
+{
+name = top_right_can;
+pos = (564,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,0,l),
+(128,134,l),
+(208,134,ls),
+(469,134,o),
+(554,318,o),
+(554,468,cs),
+(554,605,o),
+(466,690,o),
+(319,690,cs),
+(156,690,l),
+(9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(229,610,l),
+(306,610,ls),
+(410,610,o),
+(465,559,o),
+(465,466,cs),
+(465,369,o),
+(426,214,o),
+(226,214,cs),
+(145,214,l)
+);
+}
+);
+width = 560;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni146D;
+},
+{
+color = 11;
+glyphname = "kii-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (218,0);
+ref = dot_top;
+}
+);
+width = 562;
+}
+);
+note = uni146E;
+},
+{
+color = 11;
+glyphname = "ko-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (371,690);
+},
+{
+name = top_left_can;
+pos = (190,690);
+},
+{
+name = top_right_can;
+pos = (553,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(450,0,l),
+(597,690,l),
+(507,690,l),
+(479,555,l),
+(398,555,ls),
+(136,555,o),
+(51,372,o),
+(51,222,cs),
+(51,85,o),
+(140,0,o),
+(287,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(196,80,o),
+(140,130,o),
+(140,224,cs),
+(140,321,o),
+(180,475,o),
+(380,475,cs),
+(461,475,l),
+(377,80,l),
+(299,80,ls)
+);
+}
+);
+width = 561;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146F;
+},
+{
+color = 11;
+glyphname = "koo-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (389,0);
+ref = dot_top;
+}
+);
+width = 562;
+}
+);
+note = uni1470;
+},
+{
+color = 11;
+glyphname = "ka-canadian.square";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (383,690);
+},
+{
+name = top_left_can;
+pos = (201,690);
+},
+{
+name = top_right_can;
+pos = (564,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(175,0,ls),
+(440,0,o),
+(526,183,o),
+(526,334,cs),
+(526,471,o),
+(437,555,o),
+(289,555,cs),
+(217,555,l),
+(245,690,l),
+(156,690,l),
+(9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(201,475,l),
+(272,475,ls),
+(382,475,o),
+(437,425,o),
+(437,331,cs),
+(437,235,o),
+(393,80,o),
+(195,80,cs),
+(117,80,l)
+);
+}
+);
+width = 561;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1472;
+},
+{
+color = 11;
+glyphname = "kaa-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (38,0);
+ref = dot_top;
+}
+);
+width = 562;
+}
+);
+note = uni1473;
+},
+{
+color = 11;
+glyphname = "kweWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (562,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 747;
+}
+);
+note = uni1475;
+},
+{
+color = 11;
+glyphname = "kwiiWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (218,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (562,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 747;
+}
+);
+note = uni1479;
+},
+{
+color = 11;
+glyphname = "kwoWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (562,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 747;
+}
+);
+note = uni147B;
+},
+{
+color = 11;
+glyphname = "kwooWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (389,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (562,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 747;
+}
+);
+note = uni147D;
+},
+{
+color = 11;
+glyphname = "kwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (562,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 747;
+}
+);
+note = uni147F;
+},
+{
+color = 11;
+glyphname = "kwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (38,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (562,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 747;
+}
+);
+note = uni1481;
+},
+{
+color = 11;
+glyphname = "ce-canadian.square";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (379,690);
+},
+{
+name = top_left_can;
+pos = (189,690);
+},
+{
+name = top_right_can;
+pos = (568,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(466,0,l),
+(557,432,ls),
+(592,596,o),
+(516,702,o),
+(359,702,cs),
+(219,702,o),
+(129,614,o),
+(94,453,cs),
+(80,388,l),
+(169,388,l),
+(183,449,ls),
+(206,562,o),
+(263,618,o),
+(353,619,cs),
+(451,619,o),
+(494,554,o),
+(469,438,cs),
+(376,0,l)
+);
+}
+);
+width = 574;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni1489;
+},
+{
+color = 11;
+glyphname = "ci-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (387,690);
+},
+{
+name = top_left_can;
+pos = (199,690);
+},
+{
+name = top_right_can;
+pos = (578,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,0,l),
+(194,459,ls),
+(216,565,o),
+(273,619,o),
+(360,619,cs),
+(460,619,o),
+(503,554,o),
+(479,442,cs),
+(468,388,l),
+(557,388,l),
+(566,431,ls),
+(601,594,o),
+(521,703,o),
+(367,703,cs),
+(229,703,o),
+(138,619,o),
+(104,460,cs),
+(7,0,l)
+);
+}
+);
+width = 573;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+},
+{
+color = 11;
+glyphname = "cii-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (222,0);
+ref = dot_top;
+}
+);
+width = 572;
+}
+);
+note = uni148C;
+},
+{
+color = 11;
+glyphname = "co-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (378,690);
+},
+{
+name = top_left_can;
+pos = (188,690);
+},
+{
+name = top_right_can;
+pos = (567,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(389,-14,o),
+(480,71,o),
+(514,230,cs),
+(611,690,l),
+(522,690,l),
+(424,231,ls),
+(401,125,o),
+(345,71,o),
+(258,71,cs),
+(158,71,o),
+(114,136,o),
+(139,247,cs),
+(151,301,l),
+(61,301,l),
+(52,259,ls),
+(17,96,o),
+(98,-14,o),
+(251,-14,cs)
+);
+}
+);
+width = 573;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+},
+{
+color = 11;
+glyphname = "coo-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (403,0);
+ref = dot_top;
+}
+);
+width = 572;
+}
+);
+note = uni148E;
+},
+{
+color = 11;
+glyphname = "ca-canadian.square";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (387,690);
+},
+{
+name = top_left_can;
+pos = (199,690);
+},
+{
+name = top_right_can;
+pos = (578,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(400,-13,o),
+(491,75,o),
+(525,237,cs),
+(539,301,l),
+(449,301,l),
+(437,241,ls),
+(412,128,o),
+(356,71,o),
+(267,71,cs),
+(168,71,o),
+(126,136,o),
+(151,252,cs),
+(243,690,l),
+(154,690,l),
+(61,258,ls),
+(27,94,o),
+(103,-13,o),
+(260,-13,cs)
+);
+}
+);
+width = 574;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+},
+{
+color = 11;
+glyphname = "caa-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (34,0);
+ref = dot_top;
+}
+);
+width = 572;
+}
+);
+note = uni1491;
+},
+{
+color = 11;
+glyphname = "me-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (330,690);
+},
+{
+name = top_double;
+pos = (483,690);
+},
+{
+name = top_left_can;
+pos = (173,690);
+},
+{
+name = top_right_can;
+pos = (483,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(382,0,l),
+(528,690,l),
+(128,690,l),
+(111,607,l),
+(420,607,l),
+(291,0,l)
+);
+}
+);
+width = 493;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+},
+{
+color = 11;
+glyphname = "mi-canadian.square";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (355,690);
+},
+{
+name = top_left_can;
+pos = (201,690);
+},
+{
+name = top_right_can;
+pos = (509,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,0,l),
+(228,607,l),
+(537,607,l),
+(554,690,l),
+(156,690,l),
+(9,0,l)
+);
+}
+);
+width = 491;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+},
+{
+color = 11;
+glyphname = "mii-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (191,0);
+ref = dot_top;
+}
+);
+width = 492;
+}
+);
+note = uni14A6;
+},
+{
+color = 11;
+glyphname = "mo-canadian.square";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (329,690);
+},
+{
+name = top_double;
+pos = (482,690);
+},
+{
+name = top_left_can;
+pos = (173,690);
+},
+{
+name = top_right_can;
+pos = (482,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(381,0,l),
+(527,690,l),
+(437,690,l),
+(308,83,l),
+(-1,83,l),
+(-19,0,l)
+);
+}
+);
+width = 492;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+},
+{
+color = 11;
+glyphname = "moo-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (319,0);
+ref = dot_top;
+}
+);
+width = 492;
+}
+);
+note = uni14A8;
+},
+{
+color = 11;
+glyphname = "ma-canadian.square";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (355,690);
+},
+{
+name = top_left_can;
+pos = (201,690);
+},
+{
+name = top_right_can;
+pos = (509,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(408,0,l),
+(426,83,l),
+(117,83,l),
+(245,690,l),
+(156,690,l),
+(9,0,l)
+);
+}
+);
+width = 491;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+},
+{
+color = 11;
+glyphname = "maa-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (38,0);
+ref = dot_top;
+}
+);
+width = 492;
+}
+);
+note = uni14AB;
+},
+{
+color = 11;
+glyphname = "ne-canadian.square";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (459,690);
+},
+{
+name = top_left_can;
+pos = (302,690);
+},
+{
+name = top_right_can;
+pos = (617,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(453,-14,o),
+(527,57,o),
+(558,204,cs),
+(662,690,l),
+(142,690,l),
+(125,608,l),
+(240,608,l),
+(157,220,ls),
+(127,75,o),
+(192,-14,o),
+(330,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(259,71,o),
+(225,119,o),
+(243,208,cs),
+(328,608,l),
+(555,608,l),
+(470,204,ls),
+(450,114,o),
+(409,71,o),
+(338,71,cs)
+);
+}
+);
+width = 623;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C0;
+},
+{
+color = 11;
+glyphname = "ni-canadian.square";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (355,690);
+},
+{
+name = top_left_can;
+pos = (198,690);
+},
+{
+name = top_right_can;
+pos = (514,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(350,-14,o),
+(422,57,o),
+(454,204,cs),
+(540,608,l),
+(655,608,l),
+(672,690,l),
+(153,690,l),
+(53,220,ls),
+(22,75,o),
+(88,-14,o),
+(226,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(155,71,o),
+(121,120,o),
+(139,208,cs),
+(224,608,l),
+(450,608,l),
+(364,204,ls),
+(346,115,o),
+(304,71,o),
+(235,71,cs)
+);
+}
+);
+width = 623;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+},
+{
+color = 11;
+glyphname = "nii-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (191,0);
+ref = dot_top;
+}
+);
+width = 622;
+}
+);
+note = uni14C3;
+},
+{
+color = 11;
+glyphname = "no-canadian.square";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (459,690);
+},
+{
+name = top_double;
+pos = (469,690);
+},
+{
+name = top_left_can;
+pos = (302,690);
+},
+{
+name = top_right_can;
+pos = (604,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(515,0,l),
+(614,469,ls),
+(644,614,o),
+(579,703,o),
+(441,703,cs),
+(318,703,o),
+(244,633,o),
+(214,486,cs),
+(128,82,l),
+(13,82,l),
+(-5,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(302,486,ls),
+(322,575,o),
+(362,618,o),
+(433,618,cs),
+(512,618,o),
+(546,570,o),
+(527,482,cs),
+(442,82,l),
+(216,82,l)
+);
+}
+);
+width = 623;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C4;
+},
+{
+color = 11;
+glyphname = "noo-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (296,0);
+ref = dot_top;
+}
+);
+width = 622;
+}
+);
+note = uni14C5;
+},
+{
+color = 11;
+glyphname = "na-canadian.square";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (356,690);
+},
+{
+name = top_double;
+pos = (365,690);
+},
+{
+name = top_left_can;
+pos = (199,690);
+},
+{
+name = top_right_can;
+pos = (514,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(527,0,l),
+(544,82,l),
+(429,82,l),
+(511,469,ls),
+(541,614,o),
+(476,703,o),
+(338,703,cs),
+(215,703,o),
+(142,633,o),
+(110,486,cs),
+(7,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,486,ls),
+(218,576,o),
+(260,618,o),
+(330,618,cs),
+(410,618,o),
+(443,571,o),
+(424,482,cs),
+(339,82,l),
+(113,82,l)
+);
+}
+);
+width = 624;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+},
+{
+color = 11;
+glyphname = "naa-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (191,0);
+ref = dot_top;
+}
+);
+width = 622;
+}
+);
+note = uni14C8;
+},
+{
+color = 11;
+glyphname = "nweWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (622,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 808;
+}
+);
+note = uni14CA;
+},
+{
+color = 11;
+glyphname = "nwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (622,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 808;
+}
+);
+note = uni14CC;
+},
+{
+color = 11;
+glyphname = "nwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (191,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (622,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 808;
+}
+);
+note = uni14CE;
+},
+{
+color = 11;
+glyphname = "se-canadian.square";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (200,690);
+},
+{
+name = top_right_can;
+pos = (568,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(461,0,l),
+(514,253,l),
+(370,253,ls),
+(220,253,o),
+(166,324,o),
+(200,479,cs),
+(244,690,l),
+(155,690,l),
+(109,479,ls),
+(69,290,o),
+(163,173,o),
+(354,173,cs),
+(435,173,l),
+(412,197,l),
+(370,0,l)
+);
+}
+);
+width = 573;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14ED;
+},
+{
+color = 11;
+glyphname = "si-canadian.square";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (203,690);
+},
+{
+name = top_right_can;
+pos = (570,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,0,l),
+(143,197,l),
+(110,173,l),
+(190,173,ls),
+(403,173,o),
+(520,267,o),
+(562,469,cs),
+(610,690,l),
+(520,690,l),
+(472,469,ls),
+(441,327,o),
+(352,253,o),
+(208,253,cs),
+(64,253,l),
+(10,0,l)
+);
+}
+);
+width = 572;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+},
+{
+color = 11;
+glyphname = "sii-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (406,0);
+ref = dot_top;
+}
+);
+width = 571;
+}
+);
+note = uni14F0;
+},
+{
+color = 11;
+glyphname = "so-canadian.square";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (561,690);
+},
+{
+name = top_left_can;
+pos = (199,690);
+},
+{
+name = top_right_can;
+pos = (561,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,0,l),
+(144,220,ls),
+(175,363,o),
+(265,437,o),
+(409,437,cs),
+(553,437,l),
+(607,690,l),
+(516,690,l),
+(474,493,l),
+(507,517,l),
+(426,517,ls),
+(213,517,o),
+(97,423,o),
+(54,221,cs),
+(7,0,l)
+);
+}
+);
+width = 572;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+},
+{
+color = 11;
+glyphname = "soo-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (399,0);
+ref = dot_top;
+}
+);
+width = 571;
+}
+);
+note = uni14F2;
+},
+{
+color = 11;
+glyphname = "sa-canadian.square";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (204,690);
+},
+{
+name = top_right_can;
+pos = (565,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(463,0,l),
+(508,211,ls),
+(549,400,o),
+(454,517,o),
+(264,517,cs),
+(183,517,l),
+(206,493,l),
+(247,690,l),
+(157,690,l),
+(103,437,l),
+(248,437,ls),
+(397,437,o),
+(451,366,o),
+(417,211,cs),
+(373,0,l)
+);
+}
+);
+width = 572;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+},
+{
+color = 11;
+glyphname = "saa-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (40,0);
+ref = dot_top;
+}
+);
+width = 571;
+}
+);
+note = uni14F5;
+},
+{
+color = 11;
+glyphname = "sho-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (375,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(447,0,l),
+(464,75,l),
+(225,75,ls),
+(162,75,o),
+(129,104,o),
+(129,161,cs),
+(129,222,o),
+(154,307,o),
+(270,307,cs),
+(338,307,ls),
+(506,307,o),
+(568,422,o),
+(568,535,cs),
+(568,631,o),
+(509,690,o),
+(412,690,cs),
+(156,690,l),
+(139,614,l),
+(382,614,ls),
+(445,614,o),
+(478,584,o),
+(478,528,cs),
+(478,466,o),
+(452,383,o),
+(338,383,cs),
+(270,383,ls),
+(100,383,o),
+(40,266,o),
+(40,155,cs),
+(40,59,o),
+(99,0,o),
+(196,0,cs)
+);
+}
+);
+width = 563;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+color = 11;
+glyphname = "shoo-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (212,0);
+ref = dot_top;
+}
+);
+width = 563;
+}
+);
+note = g728;
+},
+{
+color = 11;
+glyphname = "sha-canadian.square";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (380,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(269,0,ls),
+(443,0,o),
+(504,114,o),
+(504,234,cs),
+(504,327,o),
+(446,383,o),
+(351,383,cs),
+(291,383,ls),
+(229,383,o),
+(195,409,o),
+(195,464,cs),
+(195,532,o),
+(222,614,o),
+(341,614,cs),
+(582,614,l),
+(597,690,l),
+(340,690,ls),
+(166,690,o),
+(104,576,o),
+(104,456,cs),
+(104,363,o),
+(162,307,o),
+(258,307,cs),
+(318,307,ls),
+(380,307,o),
+(413,281,o),
+(413,226,cs),
+(413,158,o),
+(384,75,o),
+(268,75,cs),
+(27,75,l),
+(12,0,l)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+color = 11;
+glyphname = "shaa-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (215,0);
+ref = dot_top;
+}
+);
+width = 562;
+}
+);
+note = g730;
+},
+{
+color = 11;
+glyphname = "ye-canadian.square";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (180,690);
+},
+{
+name = top_right_can;
+pos = (580,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(477,0,l),
+(531,252,l),
+(167,252,l),
+(171,213,l),
+(626,636,l),
+(567,701,l),
+(29,202,l),
+(22,173,l),
+(424,173,l),
+(387,0,l)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "ye-canadian";
+note = uni1526;
+},
+{
+color = 11;
+glyphname = "yi-canadian.square";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (199,690);
+},
+{
+name = top_right_can;
+pos = (598,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(98,0,l),
+(134,173,l),
+(536,173,l),
+(542,202,l),
+(198,701,l),
+(125,645,l),
+(418,213,l),
+(424,252,l),
+(61,252,l),
+(7,0,l)
+);
+}
+);
+width = 586;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni1528;
+},
+{
+color = 11;
+glyphname = "yii-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (34,0);
+ref = dot_top;
+}
+);
+width = 585;
+}
+);
+note = uni1529;
+},
+{
+color = 11;
+glyphname = "yo-canadian.square";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (579,690);
+},
+{
+name = top_left_can;
+pos = (179,690);
+},
+{
+name = top_right_can;
+pos = (579,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(506,44,l),
+(213,476,l),
+(207,438,l),
+(570,438,l),
+(624,690,l),
+(533,690,l),
+(497,517,l),
+(95,517,l),
+(89,488,l),
+(433,-12,l)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152A;
+},
+{
+color = 11;
+glyphname = "yoo-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (415,0);
+ref = dot_top;
+}
+);
+width = 585;
+}
+);
+note = uni152B;
+},
+{
+color = 11;
+glyphname = "ya-canadian.square";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (199,690);
+},
+{
+name = top_right_can;
+pos = (598,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(603,488,l),
+(609,517,l),
+(208,517,l),
+(244,690,l),
+(154,690,l),
+(100,438,l),
+(464,438,l),
+(460,476,l),
+(5,54,l),
+(64,-12,l)
+);
+}
+);
+width = 586;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152D;
+},
+{
+color = 11;
+glyphname = "yaa-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (34,0);
+ref = dot_top;
+}
+);
+width = 585;
+}
+);
+note = uni152E;
+},
+{
+color = 11;
+glyphname = "re-canadian.square";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (355,690);
+},
+{
+name = top_left_can;
+pos = (198,690);
+},
+{
+name = top_right_can;
+pos = (514,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(350,-14,o),
+(422,57,o),
+(454,204,cs),
+(540,608,l),
+(655,608,l),
+(672,690,l),
+(468,690,l),
+(364,204,ls),
+(346,115,o),
+(304,71,o),
+(235,71,cs),
+(155,71,o),
+(121,120,o),
+(139,208,cs),
+(242,690,l),
+(153,690,l),
+(53,220,ls),
+(22,75,o),
+(88,-14,o),
+(226,-14,cs)
+);
+}
+);
+width = 623;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1542;
+},
+{
+color = 11;
+glyphname = "reRCree-canadian.square";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (459,690);
+},
+{
+name = top_left_can;
+pos = (302,690);
+},
+{
+name = top_right_can;
+pos = (617,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(453,-14,o),
+(527,57,o),
+(558,204,cs),
+(662,690,l),
+(572,690,l),
+(470,204,ls),
+(450,114,o),
+(409,71,o),
+(338,71,cs),
+(259,71,o),
+(225,119,o),
+(243,208,cs),
+(346,690,l),
+(142,690,l),
+(125,608,l),
+(240,608,l),
+(157,220,ls),
+(127,75,o),
+(192,-14,o),
+(330,-14,cs)
+);
+}
+);
+width = 623;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni1543;
+},
+{
+color = 11;
+glyphname = "leWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (459,690);
+},
+{
+name = top_left_can;
+pos = (301,690);
+},
+{
+name = top_right_can;
+pos = (617,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(199,0,l),
+(302,485,ls),
+(322,575,o),
+(362,618,o),
+(432,618,cs),
+(512,618,o),
+(546,570,o),
+(527,482,cs),
+(425,0,l),
+(514,0,l),
+(613,469,ls),
+(644,614,o),
+(579,703,o),
+(441,703,cs),
+(317,703,o),
+(244,633,o),
+(213,485,cs),
+(127,81,l),
+(13,81,l),
+(-5,0,l)
+);
+}
+);
+width = 623;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+},
+{
+color = 11;
+glyphname = "ri-canadian.square";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (356,690);
+},
+{
+name = top_left_can;
+pos = (200,690);
+},
+{
+name = top_right_can;
+pos = (514,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(96,0,l),
+(199,486,ls),
+(218,576,o),
+(260,618,o),
+(330,618,cs),
+(410,618,o),
+(443,571,o),
+(424,482,cs),
+(322,0,l),
+(527,0,l),
+(544,82,l),
+(429,82,l),
+(511,469,ls),
+(541,614,o),
+(476,703,o),
+(338,703,cs),
+(215,703,o),
+(142,633,o),
+(110,486,cs),
+(7,0,l)
+);
+}
+);
+width = 624;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+},
+{
+color = 11;
+glyphname = "rii-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (191,0);
+ref = dot_top;
+}
+);
+width = 622;
+}
+);
+note = uni1547;
+},
+{
+color = 11;
+glyphname = "ro-canadian.square";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (378,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,0,l),
+(136,174,l),
+(88,134,l),
+(200,134,ls),
+(455,134,o),
+(540,318,o),
+(540,468,cs),
+(540,605,o),
+(452,690,o),
+(304,690,cs),
+(156,690,l),
+(139,610,l),
+(292,610,ls),
+(396,610,o),
+(450,559,o),
+(450,466,cs),
+(450,369,o),
+(412,214,o),
+(210,214,cs),
+(55,214,l),
+(9,0,l)
+);
+}
+);
+width = 546;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1548;
+},
+{
+color = 11;
+glyphname = "loWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (375,690);
+},
+{
+name = top_left_can;
+pos = (202,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(170,0,ls),
+(425,0,o),
+(509,184,o),
+(509,334,cs),
+(509,471,o),
+(422,555,o),
+(274,555,cs),
+(178,555,l),
+(210,516,l),
+(246,690,l),
+(156,690,l),
+(110,475,l),
+(262,475,ls),
+(366,475,o),
+(420,425,o),
+(420,331,cs),
+(420,235,o),
+(381,80,o),
+(185,80,cs),
+(26,80,l),
+(9,0,l)
+);
+}
+);
+width = 542;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+},
+{
+color = 11;
+glyphname = "ra-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (359,690);
+},
+{
+name = top_right_can;
+pos = (534,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(432,0,l),
+(478,214,l),
+(326,214,ls),
+(221,214,o),
+(168,265,o),
+(168,358,cs),
+(168,455,o),
+(208,610,o),
+(403,610,cs),
+(561,610,l),
+(579,690,l),
+(418,690,ls),
+(162,690,o),
+(78,506,o),
+(78,355,cs),
+(78,218,o),
+(165,134,o),
+(314,134,cs),
+(411,134,l),
+(379,174,l),
+(342,0,l)
+);
+}
+);
+width = 543;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+},
+{
+color = 11;
+glyphname = "raa-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (195,0);
+ref = dot_top;
+}
+);
+width = 543;
+}
+);
+note = uni154C;
+},
+{
+color = 11;
+glyphname = "laWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (533,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(432,0,l),
+(448,80,l),
+(297,80,ls),
+(193,80,o),
+(138,130,o),
+(138,224,cs),
+(138,321,o),
+(178,475,o),
+(379,475,cs),
+(532,475,l),
+(579,690,l),
+(488,690,l),
+(451,516,l),
+(499,555,l),
+(388,555,ls),
+(134,555,o),
+(49,372,o),
+(49,222,cs),
+(49,85,o),
+(136,0,o),
+(284,0,cs)
+);
+}
+);
+width = 543;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+},
+{
+color = 11;
+glyphname = "reWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(456,0,l),
+(687,194,l),
+(637,255,l),
+(457,103,l),
+(484,84,l),
+(558,432,ls),
+(592,596,o),
+(517,702,o),
+(361,702,cs),
+(221,702,o),
+(129,618,o),
+(94,453,cs),
+(80,388,l),
+(169,388,l),
+(183,449,ls),
+(206,562,o),
+(263,618,o),
+(353,619,cs),
+(451,619,o),
+(494,554,o),
+(469,438,cs),
+(376,0,l)
+);
+}
+);
+width = 717;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+},
+{
+color = 11;
+glyphname = "riWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(239,0,l),
+(336,459,ls),
+(358,565,o),
+(414,619,o),
+(501,619,cs),
+(601,619,o),
+(644,554,o),
+(620,442,cs),
+(610,388,l),
+(698,388,l),
+(707,431,ls),
+(741,594,o),
+(662,703,o),
+(508,703,cs),
+(370,703,o),
+(280,621,o),
+(246,460,cs),
+(166,84,l),
+(197,89,l),
+(76,246,l),
+(10,194,l),
+(158,0,l)
+);
+}
+);
+width = 714;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+},
+{
+color = 11;
+glyphname = "roWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(389,-14,o),
+(479,69,o),
+(513,230,cs),
+(593,606,l),
+(562,601,l),
+(684,443,l),
+(751,496,l),
+(600,690,l),
+(521,690,l),
+(423,231,ls),
+(401,125,o),
+(345,71,o),
+(257,71,cs),
+(158,71,o),
+(115,135,o),
+(139,247,cs),
+(150,301,l),
+(61,301,l),
+(52,259,ls),
+(18,96,o),
+(98,-14,o),
+(251,-14,cs)
+);
+}
+);
+width = 716;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+},
+{
+color = 11;
+glyphname = "raWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(541,-13,o),
+(634,71,o),
+(669,237,cs),
+(682,301,l),
+(593,301,l),
+(580,241,ls),
+(556,128,o),
+(499,71,o),
+(410,71,cs),
+(311,71,o),
+(269,136,o),
+(294,252,cs),
+(386,690,l),
+(306,690,l),
+(75,496,l),
+(126,435,l),
+(305,586,l),
+(278,606,l),
+(204,258,ls),
+(170,94,o),
+(245,-13,o),
+(401,-13,cs)
+);
+}
+);
+width = 717;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+},
+{
+color = 11;
+glyphname = "theThCree-canadian.square";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (180,690);
+},
+{
+name = top_right_can;
+pos = (580,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(477,0,l),
+(491,64,l),
+(564,64,l),
+(574,111,l),
+(501,111,l),
+(531,252,l),
+(175,252,l),
+(185,225,l),
+(626,636,l),
+(567,701,l),
+(29,202,l),
+(22,173,l),
+(424,173,l),
+(412,111,l),
+(226,111,l),
+(216,64,l),
+(401,64,l),
+(387,0,l)
+);
+}
+);
+width = 631;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15A7;
+},
+{
+color = 11;
+glyphname = "thiThCree-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (240,690);
+},
+{
+name = top_right_can;
+pos = (639,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,0,l),
+(156,64,l),
+(341,64,l),
+(351,111,l),
+(166,111,l),
+(180,173,l),
+(582,173,l),
+(587,202,l),
+(243,701,l),
+(169,645,l),
+(458,220,l),
+(474,252,l),
+(106,252,l),
+(76,111,l),
+(3,111,l),
+(-7,64,l),
+(66,64,l),
+(52,0,l)
+);
+}
+);
+width = 632;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+},
+{
+color = 11;
+glyphname = "thiiThCree-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (75,0);
+ref = dot_top;
+}
+);
+width = 631;
+}
+);
+note = uni15A9;
+},
+{
+color = 11;
+glyphname = "thoThCree-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (178,690);
+},
+{
+name = top_right_can;
+pos = (579,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(506,44,l),
+(218,469,l),
+(202,438,l),
+(569,438,l),
+(599,579,l),
+(672,579,l),
+(682,626,l),
+(610,626,l),
+(623,690,l),
+(533,690,l),
+(520,626,l),
+(334,626,l),
+(325,579,l),
+(509,579,l),
+(497,517,l),
+(95,517,l),
+(89,488,l),
+(432,-12,l)
+);
+}
+);
+width = 630;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+},
+{
+color = 11;
+glyphname = "thooThCree-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (414,0);
+ref = dot_top;
+}
+);
+width = 631;
+}
+);
+note = uni15AB;
+},
+{
+color = 11;
+glyphname = "thaThCree-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (244,690);
+},
+{
+name = top_right_can;
+pos = (644,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(648,488,l),
+(654,517,l),
+(252,517,l),
+(266,579,l),
+(450,579,l),
+(460,626,l),
+(275,626,l),
+(289,690,l),
+(199,690,l),
+(185,626,l),
+(112,626,l),
+(102,579,l),
+(175,579,l),
+(145,438,l),
+(501,438,l),
+(492,465,l),
+(50,54,l),
+(109,-12,l)
+);
+}
+);
+width = 631;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+},
+{
+color = 11;
+glyphname = "thaaThCree-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (80,0);
+ref = dot_top;
+}
+);
+width = 631;
+}
+);
+note = uni15AD;
+},
+{
+color = 11;
+glyphname = "thweeWoodScree-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (631,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni1677;
+},
+{
+color = 11;
+glyphname = "thwiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (631,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni1678;
+},
+{
+color = 11;
+glyphname = "thwiiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (75,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (631,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni1679;
+},
+{
+color = 11;
+glyphname = "thwoWoodScree-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (631,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni167A;
+},
+{
+color = 11;
+glyphname = "thwooWoodScree-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (414,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (631,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni167B;
+},
+{
+color = 11;
+glyphname = "thwaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (631,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni167C;
+},
+{
+color = 11;
+glyphname = "thwaaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (80,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (631,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni167D;
+},
+{
+color = 11;
+glyphname = "nwiOjibway-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (622,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 808;
+}
+);
+note = uni18C7;
+},
+{
+color = 11;
+glyphname = "nwiiOjibway-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (191,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (622,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 808;
+}
+);
+note = uni18C9;
+},
+{
+color = 11;
+glyphname = "nwoOjibway-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (622,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 808;
+}
+);
+note = uni18CB;
+},
+{
+color = 11;
+glyphname = "nwooOjibway-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (296,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (622,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 808;
+}
+);
+note = uni18CD;
+},
+{
+color = 11;
+glyphname = "looWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (38,0);
+ref = dot_top;
+}
+);
+width = 543;
+}
+);
+note = uni18E1;
+},
+{
+color = 11;
+glyphname = "laaWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (371,0);
+ref = dot_top;
+}
+);
+width = 543;
+}
+);
+note = uni18E2;
+},
+{
+color = 0;
+glyphname = zero;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(558,551,o),
+(501,700,o),
+(329,700,cs),
+(155,700,o),
+(99,540,o),
+(99,346,cs),
+(99,108,o),
+(181,-10,o),
+(328,-10,cs),
+(483,-10,o),
+(558,106,o),
+(558,346,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(193,469,o),
+(211,622,o),
+(329,622,cs),
+(454,622,o),
+(463,461,o),
+(463,346,cs),
+(463,189,o),
+(433,69,o),
+(328,69,cs),
+(228,69,o),
+(193,188,o),
+(193,346,cs)
+);
+}
+);
+width = 614;
+}
+);
+unicode = 48;
+},
+{
+color = 0;
+glyphname = one;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(287,690,l),
+(78,528,l),
+(128,466,l),
+(230,544,ls),
+(250,559,o),
+(263,571,o),
+(278,586,c),
+(277,555,o),
+(276,527,o),
+(276,497,cs),
+(276,0,l),
+(373,0,l),
+(373,690,l)
+);
+}
+);
+width = 492;
+}
+);
+unicode = 49;
+},
+{
+color = 0;
+glyphname = two;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(560,0,l),
+(560,80,l),
+(230,80,l),
+(230,82,l),
+(366,223,ls),
+(440,295,o),
+(491,351,o),
+(518,412,cs),
+(530,442,o),
+(536,477,o),
+(536,517,cs),
+(536,626,o),
+(454,699,o),
+(333,699,cs),
+(245,699,o),
+(179,669,o),
+(116,614,c),
+(168,552,l),
+(221,596,o),
+(273,618,o),
+(324,618,cs),
+(396,618,o),
+(442,578,o),
+(442,505,cs),
+(442,450,o),
+(423,409,o),
+(384,358,cs),
+(362,333,o),
+(336,303,o),
+(302,270,cs),
+(107,66,l),
+(107,0,l)
+);
+}
+);
+width = 610;
+}
+);
+unicode = 50;
+},
+{
+color = 0;
+glyphname = three;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(542,639,o),
+(461,699,o),
+(335,699,cs),
+(235,699,o),
+(167,670,o),
+(110,629,c),
+(151,563,l),
+(198,596,o),
+(256,621,o),
+(323,621,cs),
+(399,621,o),
+(449,587,o),
+(449,517,cs),
+(449,429,o),
+(366,393,o),
+(276,393,cs),
+(212,393,l),
+(212,320,l),
+(275,320,ls),
+(391,320,o),
+(463,288,o),
+(463,196,cs),
+(463,118,o),
+(411,68,o),
+(293,68,cs),
+(230,68,o),
+(159,85,o),
+(105,112,c),
+(105,30,l),
+(158,7,o),
+(222,-10,o),
+(304,-10,cs),
+(460,-10,o),
+(562,66,o),
+(562,191,cs),
+(562,293,o),
+(501,347,o),
+(392,360,c),
+(392,362,l),
+(478,382,o),
+(542,443,o),
+(542,535,cs)
+);
+}
+);
+width = 611;
+}
+);
+unicode = 51;
+},
+{
+color = 0;
+glyphname = four;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(452,238,l),
+(452,692,l),
+(362,692,l),
+(34,233,l),
+(34,164,l),
+(358,164,l),
+(358,0,l),
+(452,0,l),
+(452,164,l),
+(558,164,l),
+(558,238,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(123,238,l),
+(306,492,ls),
+(330,526,o),
+(339,541,o),
+(357,573,c),
+(360,573,l),
+(360,556,o),
+(358,523,o),
+(358,478,cs),
+(358,238,l)
+);
+}
+);
+width = 584;
+}
+);
+unicode = 52;
+},
+{
+color = 0;
+glyphname = five;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(265,429,o),
+(232,420,o),
+(206,414,c),
+(223,609,l),
+(495,609,l),
+(495,690,l),
+(142,690,l),
+(114,356,l),
+(155,333,l),
+(192,345,o),
+(233,354,o),
+(281,354,cs),
+(388,354,o),
+(442,302,o),
+(442,215,cs),
+(442,122,o),
+(377,68,o),
+(272,68,cs),
+(208,68,o),
+(142,88,o),
+(96,112,c),
+(96,30,l),
+(142,6,o),
+(203,-10,o),
+(279,-10,cs),
+(446,-10,o),
+(539,76,o),
+(539,218,cs),
+(539,353,o),
+(452,429,o),
+(322,429,cs)
+);
+}
+);
+width = 584;
+}
+);
+unicode = 53;
+},
+{
+color = 0;
+glyphname = six;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(86,128,o),
+(159,-10,o),
+(325,-10,cs),
+(463,-10,o),
+(547,80,o),
+(547,225,cs),
+(547,359,o),
+(473,440,o),
+(349,440,cs),
+(261,440,o),
+(203,397,o),
+(175,341,c),
+(172,341,l),
+(177,508,o),
+(239,624,o),
+(404,624,cs),
+(446,624,o),
+(477,619,o),
+(502,612,c),
+(502,690,l),
+(476,696,o),
+(440,700,o),
+(406,700,cs),
+(170,700,o),
+(86,528,o),
+(86,293,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(216,68,o),
+(184,170,o),
+(184,246,cs),
+(184,310,o),
+(251,363,o),
+(327,363,cs),
+(413,363,o),
+(454,311,o),
+(454,223,cs),
+(454,125,o),
+(407,68,o),
+(323,68,cs)
+);
+}
+);
+width = 590;
+}
+);
+unicode = 54;
+},
+{
+color = 0;
+glyphname = seven;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(578,633,l),
+(578,690,l),
+(115,690,l),
+(115,610,l),
+(475,610,l),
+(210,0,l),
+(309,0,l)
+);
+}
+);
+width = 601;
+}
+);
+unicode = 55;
+},
+{
+color = 0;
+glyphname = eight;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(464,-10,o),
+(559,57,o),
+(559,179,cs),
+(559,274,o),
+(489,329,o),
+(396,366,c),
+(481,403,o),
+(538,454,o),
+(538,537,cs),
+(538,642,o),
+(456,699,o),
+(330,699,cs),
+(207,699,o),
+(123,639,o),
+(123,537,cs),
+(123,444,o),
+(191,397,o),
+(258,365,c),
+(165,329,o),
+(101,275,o),
+(101,175,cs),
+(101,66,o),
+(184,-10,o),
+(327,-10,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(244,62,o),
+(190,106,o),
+(190,178,cs),
+(190,258,o),
+(258,298,o),
+(328,324,c),
+(421,287,o),
+(471,245,o),
+(471,180,cs),
+(471,103,o),
+(414,62,o),
+(327,62,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(261,436,o),
+(213,469,o),
+(213,529,cs),
+(213,592,o),
+(264,628,o),
+(330,628,cs),
+(402,628,o),
+(447,594,o),
+(447,530,cs),
+(447,471,o),
+(404,440,o),
+(331,408,c)
+);
+}
+);
+width = 613;
+}
+);
+unicode = 56;
+},
+{
+color = 0;
+glyphname = nine;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(558,566,o),
+(486,699,o),
+(320,699,cs),
+(182,699,o),
+(97,611,o),
+(97,466,cs),
+(97,332,o),
+(170,250,o),
+(293,250,cs),
+(381,250,o),
+(440,292,o),
+(469,351,c),
+(472,351,l),
+(467,175,o),
+(397,66,o),
+(235,66,cs),
+(197,66,o),
+(162,71,o),
+(138,77,c),
+(138,-2,l),
+(164,-8,o),
+(206,-11,o),
+(239,-11,cs),
+(475,-11,o),
+(558,165,o),
+(558,394,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(428,621,o),
+(461,517,o),
+(461,445,cs),
+(461,381,o),
+(390,326,o),
+(319,326,cs),
+(233,326,o),
+(189,381,o),
+(189,467,cs),
+(189,566,o),
+(237,621,o),
+(322,621,cs)
+);
+}
+);
+width = 614;
+}
+);
+unicode = 57;
+},
+{
+glyphname = zero.canadian;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(407,-12,o),
+(475,346,o),
+(475,497,cs),
+(475,631,o),
+(422,702,o),
+(320,702,cs),
+(117,702,o),
+(50,345,o),
+(50,193,cs),
+(50,60,o),
+(102,-12,o),
+(207,-12,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(161,70,o),
+(136,107,o),
+(136,186,cs),
+(136,284,o),
+(187,621,o),
+(315,621,cs),
+(364,621,o),
+(389,582,o),
+(389,504,cs),
+(389,407,o),
+(337,70,o),
+(211,70,cs)
+);
+}
+);
+width = 480;
+}
+);
+metricRight = "=|";
+},
+{
+glyphname = one.canadian;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(213,0,l),
+(360,690,l),
+(279,690,l),
+(79,523,l),
+(129,462,l),
+(320,620,l),
+(257,630,l),
+(124,0,l)
+);
+}
+);
+width = 324;
+}
+);
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = two.canadian;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(392,83,l),
+(128,83,l),
+(127,49,l),
+(353,290,ls),
+(431,372,o),
+(476,455,o),
+(476,545,cs),
+(476,641,o),
+(415,702,o),
+(316,702,cs),
+(199,702,o),
+(120,623,o),
+(88,452,c),
+(178,452,l),
+(199,573,o),
+(242,623,o),
+(308,623,cs),
+(359,623,o),
+(387,593,o),
+(387,542,cs),
+(387,471,o),
+(344,401,o),
+(282,335,cs),
+(22,60,l),
+(10,0,l),
+(375,0,l)
+);
+}
+);
+width = 469;
+}
+);
+note = uni14BF;
+},
+{
+glyphname = three.canadian;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(377,-13,o),
+(429,113,o),
+(429,216,cs),
+(429,290,o),
+(395,339,o),
+(333,357,c),
+(327,327,l),
+(452,337,o),
+(493,467,o),
+(493,548,cs),
+(493,643,o),
+(433,702,o),
+(330,702,cs),
+(213,702,o),
+(134,622,o),
+(104,467,c),
+(194,467,l),
+(218,575,o),
+(258,623,o),
+(321,623,cs),
+(373,623,o),
+(401,592,o),
+(401,536,cs),
+(401,480,o),
+(383,384,o),
+(285,384,cs),
+(256,384,l),
+(240,307,l),
+(270,307,ls),
+(315,307,o),
+(340,276,o),
+(340,222,cs),
+(340,164,o),
+(316,67,o),
+(222,67,cs),
+(132,67,o),
+(122,146,o),
+(137,223,c),
+(48,223,l),
+(23,102,o),
+(65,-13,o),
+(222,-13,cs)
+);
+}
+);
+width = 497;
+}
+);
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = four.canadian;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(318,0,l),
+(353,164,l),
+(432,164,l),
+(447,240,l),
+(369,240,l),
+(465,692,l),
+(392,692,l),
+(29,225,l),
+(15,164,l),
+(266,164,l),
+(231,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(390,600,l),
+(361,600,l),
+(285,240,l),
+(95,240,l),
+(99,218,l)
+);
+}
+);
+width = 470;
+}
+);
+},
+{
+glyphname = five.canadian;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(392,-13,o),
+(440,147,o),
+(440,247,cs),
+(440,350,o),
+(380,409,o),
+(268,409,cs),
+(177,409,l),
+(207,382,l),
+(276,633,l),
+(234,607,l),
+(500,607,l),
+(518,690,l),
+(205,690,l),
+(110,350,l),
+(123,329,l),
+(241,329,ls),
+(313,329,o),
+(349,300,o),
+(349,236,cs),
+(349,182,o),
+(327,67,o),
+(228,67,cs),
+(142,67,o),
+(126,134,o),
+(138,198,c),
+(48,198,l),
+(31,88,o),
+(83,-13,o),
+(224,-13,cs)
+);
+}
+);
+width = 492;
+}
+);
+},
+{
+glyphname = six.canadian;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(367,-13,o),
+(435,132,o),
+(435,250,cs),
+(435,352,o),
+(379,419,o),
+(286,419,cs),
+(215,419,o),
+(157,375,o),
+(124,294,c),
+(143,273,l),
+(148,309,o),
+(151,329,o),
+(161,376,cs),
+(198,551,o),
+(252,624,o),
+(324,624,cs),
+(404,624,o),
+(408,551,o),
+(401,495,c),
+(490,495,l),
+(499,600,o),
+(455,702,o),
+(329,702,cs),
+(98,702,o),
+(46,282,o),
+(46,189,cs),
+(46,140,o),
+(53,100,o),
+(70,69,cs),
+(98,17,o),
+(150,-13,o),
+(218,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(164,64,o),
+(133,103,o),
+(133,167,cs),
+(133,233,o),
+(168,344,o),
+(263,344,cs),
+(317,344,o),
+(346,307,o),
+(346,244,cs),
+(346,181,o),
+(315,64,o),
+(220,64,cs)
+);
+}
+);
+width = 480;
+}
+);
+metricLeft = zero.canadian;
+},
+{
+glyphname = seven.canadian;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(128,0,l),
+(448,633,l),
+(461,690,l),
+(118,690,l),
+(100,607,l),
+(354,607,l),
+(357,635,l),
+(46,25,l),
+(42,0,l)
+);
+}
+);
+width = 393;
+}
+);
+},
+{
+glyphname = eight.canadian;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(361,-13,o),
+(428,93,o),
+(438,194,cs),
+(446,274,o),
+(407,333,o),
+(341,355,c),
+(330,327,l),
+(432,338,o),
+(487,433,o),
+(496,520,cs),
+(506,628,o),
+(439,702,o),
+(327,702,cs),
+(200,702,o),
+(133,597,o),
+(124,497,cs),
+(116,417,o),
+(151,355,o),
+(214,335,c),
+(216,365,l),
+(104,352,o),
+(52,258,o),
+(44,173,cs),
+(34,66,o),
+(109,-13,o),
+(227,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(162,64,o),
+(128,102,o),
+(132,168,cs),
+(135,234,o),
+(170,308,o),
+(255,308,cs),
+(321,308,o),
+(356,270,o),
+(351,204,cs),
+(348,140,o),
+(316,64,o),
+(228,64,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(237,383,o),
+(207,420,o),
+(210,484,cs),
+(213,547,o),
+(242,626,o),
+(324,626,cs),
+(380,626,o),
+(411,588,o),
+(408,525,cs),
+(405,462,o),
+(373,383,o),
+(294,383,cs)
+);
+}
+);
+width = 505;
+}
+);
+metricLeft = "=|";
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = nine.canadian;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(426,-13,o),
+(479,408,o),
+(479,500,cs),
+(479,550,o),
+(471,589,o),
+(455,621,cs),
+(428,672,o),
+(376,702,o),
+(307,702,cs),
+(157,702,o),
+(90,557,o),
+(90,440,cs),
+(90,338,o),
+(146,270,o),
+(239,270,cs),
+(310,270,o),
+(367,315,o),
+(401,396,c),
+(382,416,l),
+(378,381,o),
+(374,360,o),
+(364,314,cs),
+(326,139,o),
+(273,66,o),
+(201,66,cs),
+(121,66,o),
+(117,139,o),
+(124,195,c),
+(35,195,l),
+(26,90,o),
+(70,-13,o),
+(195,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(209,346,o),
+(179,383,o),
+(179,445,cs),
+(179,509,o),
+(211,626,o),
+(304,626,cs),
+(360,626,o),
+(392,586,o),
+(392,523,cs),
+(392,457,o),
+(356,346,o),
+(263,346,cs)
+);
+}
+);
+width = 480;
+}
+);
+metricLeft = "=|six.canadian";
+metricRight = "=|six.canadian";
+},
+{
+glyphname = CR;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+width = 206;
+}
+);
+note = CR;
+unicode = 13;
+},
+{
+color = 0;
+glyphname = .notdef;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(583,690,l),
+(186,690,l),
+(186,0,l),
+(583,0,l),
+(583,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(534,640,l),
+(534,49,l),
+(236,49,l),
+(236,640,l),
+(236,640,l)
+);
+}
+);
+width = 675;
+}
+);
+note = ".notdef";
+},
+{
+glyphname = .null;
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+width = 0;
+}
+);
+note = NULL;
+},
+{
+glyphname = space;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+width = 209;
+}
+);
+note = space;
+unicode = 32;
+},
+{
+glyphname = nbspace;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+width = 206;
+}
+);
+note = uni00A0;
+unicode = 160;
+},
+{
+glyphname = space.canadian;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+width = 412;
+}
+);
+note = space;
+},
+{
+glyphname = "hyphen-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(338,396,l),
+(350,450,l),
+(95,450,l),
+(83,396,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(309,260,l),
+(321,314,l),
+(65,314,l),
+(53,260,l)
+);
+}
+);
+width = 354;
+}
+);
+metricRight = "=|";
+note = uni1400;
+unicode = 5120;
+},
+{
+glyphname = "chi-canadian";
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(75,0,l),
+(258,291,l),
+(228,297,l),
+(289,0,l),
+(370,0,l),
+(375,25,l),
+(292,386,l),
+(278,315,l),
+(509,665,l),
+(514,690,l),
+(426,690,l),
+(247,403,l),
+(276,398,l),
+(217,690,l),
+(137,690,l),
+(131,665,l),
+(215,312,l),
+(228,384,l),
+(-8,25,l),
+(-13,0,l)
+);
+}
+);
+width = 458;
+}
+);
+metricRight = "=|";
+note = uni166D;
+unicode = 5741;
+},
+{
+glyphname = "fullstop-canadian";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(55,0,l),
+(135,128,l),
+(121,134,l),
+(149,0,l),
+(203,0,l),
+(206,12,l),
+(162,187,l),
+(159,158,l),
+(272,332,l),
+(275,345,l),
+(216,345,l),
+(132,211,l),
+(154,204,l),
+(125,345,l),
+(71,345,l),
+(68,332,l),
+(109,163,l),
+(115,192,l),
+(-2,12,l),
+(-4,0,l)
+);
+}
+);
+width = 300;
+}
+);
+note = uni1541;
+unicode = 5742;
+},
+{
+glyphname = period;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(14,13,o),
+(33,-10,o),
+(73,-10,cs),
+(106,-10,o),
+(128,12,o),
+(132,48,cs),
+(138,81,o),
+(121,102,o),
+(79,102,cs),
+(43,102,o),
+(25,79,o),
+(20,45,cs)
+);
+}
+);
+width = 223;
+}
+);
+note = period;
+unicode = 46;
+},
+{
+glyphname = comma;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(10,-128,l),
+(56,-58,o),
+(101,40,o),
+(133,113,c),
+(130,125,l),
+(49,125,l),
+(24,50,o),
+(-11,-35,o),
+(-55,-128,c)
+);
+}
+);
+width = 208;
+}
+);
+note = comma;
+unicode = 44;
+},
+{
+glyphname = hyphen;
+kernLeft = hyphen;
+kernRight = hyphen;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(215,222,l),
+(232,299,l),
+(48,299,l),
+(32,222,l)
+);
+}
+);
+width = 255;
+}
+);
+unicode = 45;
+},
+{
+glyphname = quotesinglbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-565);
+ref = quoteright;
+}
+);
+width = 230;
+}
+);
+unicode = 8218;
+},
+{
+glyphname = quotedblbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-89,-565);
+ref = quotedblright;
+}
+);
+width = 440;
+}
+);
+unicode = 8222;
+},
+{
+glyphname = quotedblleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(343,436,l),
+(366,510,o),
+(405,604,o),
+(451,690,c),
+(388,690,l),
+(342,619,o),
+(296,529,o),
+(262,445,c),
+(266,436,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(166,436,l),
+(190,512,o),
+(227,602,o),
+(274,690,c),
+(213,690,l),
+(166,619,o),
+(120,529,o),
+(86,445,c),
+(90,436,l)
+);
+}
+);
+width = 397;
+}
+);
+unicode = 8220;
+},
+{
+glyphname = quotedblright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(322,436,l),
+(370,507,o),
+(417,602,o),
+(449,680,c),
+(444,690,l),
+(368,690,l),
+(346,615,o),
+(306,521,o),
+(260,436,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(146,436,l),
+(194,507,o),
+(242,602,o),
+(273,680,c),
+(269,690,l),
+(192,690,l),
+(170,617,o),
+(128,519,o),
+(84,436,c)
+);
+}
+);
+width = 397;
+}
+);
+unicode = 8221;
+},
+{
+glyphname = quoteleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(170,436,l),
+(193,510,o),
+(233,604,o),
+(279,690,c),
+(213,690,l),
+(167,619,o),
+(120,529,o),
+(86,445,c),
+(90,436,l)
+);
+}
+);
+width = 225;
+}
+);
+unicode = 8216;
+},
+{
+glyphname = quoteright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(151,436,l),
+(199,507,o),
+(246,602,o),
+(278,680,c),
+(273,690,l),
+(192,690,l),
+(170,617,o),
+(129,519,o),
+(84,436,c)
+);
+}
+);
+width = 225;
+}
+);
+unicode = 8217;
+},
+{
+glyphname = dottedCircle;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(203,504,o),
+(190,494,o),
+(190,479,cs),
+(190,467,o),
+(203,454,o),
+(215,454,cs),
+(230,454,o),
+(241,467,o),
+(241,479,cs),
+(241,494,o),
+(230,504,o),
+(215,504,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(365,504,o),
+(353,494,o),
+(353,479,cs),
+(353,467,o),
+(365,454,o),
+(378,454,cs),
+(392,454,o),
+(403,467,o),
+(403,479,cs),
+(403,494,o),
+(392,504,o),
+(378,504,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(203,108,o),
+(190,98,o),
+(190,83,cs),
+(190,71,o),
+(203,58,o),
+(215,58,cs),
+(230,58,o),
+(241,71,o),
+(241,83,cs),
+(241,98,o),
+(230,108,o),
+(215,108,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(365,108,o),
+(353,98,o),
+(353,83,cs),
+(353,71,o),
+(365,58,o),
+(378,58,cs),
+(392,58,o),
+(403,71,o),
+(403,83,cs),
+(403,98,o),
+(392,108,o),
+(378,108,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(284,522,o),
+(271,511,o),
+(271,497,cs),
+(271,484,o),
+(284,471,o),
+(297,471,cs),
+(311,471,o),
+(322,484,o),
+(322,497,cs),
+(322,511,o),
+(311,522,o),
+(297,522,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(284,91,o),
+(271,80,o),
+(271,66,cs),
+(271,53,o),
+(284,41,o),
+(297,41,cs),
+(311,41,o),
+(322,53,o),
+(322,66,cs),
+(322,80,o),
+(311,91,o),
+(297,91,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(56,269,o),
+(69,256,o),
+(81,256,cs),
+(96,256,o),
+(106,269,o),
+(106,281,cs),
+(106,296,o),
+(96,306,o),
+(81,306,cs),
+(69,306,o),
+(56,296,o),
+(56,281,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(487,269,o),
+(499,256,o),
+(512,256,cs),
+(526,256,o),
+(537,269,o),
+(537,281,cs),
+(537,296,o),
+(526,306,o),
+(512,306,cs),
+(499,306,o),
+(487,296,o),
+(487,281,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(119,116,o),
+(131,103,o),
+(144,103,cs),
+(158,103,o),
+(169,116,o),
+(169,128,cs),
+(169,143,o),
+(158,154,o),
+(144,154,cs),
+(131,154,o),
+(119,143,o),
+(119,128,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(119,421,o),
+(131,409,o),
+(144,409,cs),
+(158,409,o),
+(169,421,o),
+(169,434,cs),
+(169,448,o),
+(158,459,o),
+(144,459,cs),
+(131,459,o),
+(119,448,o),
+(119,434,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(424,116,o),
+(437,103,o),
+(449,103,cs),
+(464,103,o),
+(474,116,o),
+(474,128,cs),
+(474,143,o),
+(464,154,o),
+(449,154,cs),
+(437,154,o),
+(424,143,o),
+(424,128,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(424,421,o),
+(437,409,o),
+(449,409,cs),
+(464,409,o),
+(474,421,o),
+(474,434,cs),
+(474,448,o),
+(464,459,o),
+(449,459,cs),
+(437,459,o),
+(424,448,o),
+(424,434,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(73,187,o),
+(86,175,o),
+(99,175,cs),
+(113,175,o),
+(124,187,o),
+(124,200,cs),
+(124,214,o),
+(113,225,o),
+(99,225,cs),
+(86,225,o),
+(73,214,o),
+(73,200,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(73,350,o),
+(86,337,o),
+(99,337,cs),
+(113,337,o),
+(124,350,o),
+(124,362,cs),
+(124,377,o),
+(113,387,o),
+(99,387,cs),
+(86,387,o),
+(73,377,o),
+(73,362,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(469,187,o),
+(482,175,o),
+(495,175,cs),
+(509,175,o),
+(520,187,o),
+(520,200,cs),
+(520,214,o),
+(509,225,o),
+(495,225,cs),
+(482,225,o),
+(469,214,o),
+(469,200,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(469,350,o),
+(482,337,o),
+(495,337,cs),
+(509,337,o),
+(520,350,o),
+(520,362,cs),
+(520,377,o),
+(509,387,o),
+(495,387,cs),
+(482,387,o),
+(469,377,o),
+(469,362,cs)
+);
+}
+);
+width = 583;
+}
+);
+note = uni25CC;
+unicode = 9676;
+},
+{
+glyphname = dotaccentcomb;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,719,o),
+(123,698,o),
+(119,665,cs),
+(113,634,o),
+(129,616,o),
+(163,616,cs),
+(196,616,o),
+(215,636,o),
+(219,668,cs),
+(225,700,o),
+(209,719,o),
+(175,719,cs)
+);
+}
+);
+width = 156;
+}
+);
+note = uni0307;
+unicode = 775;
+},
+{
+glyphname = dotaccent;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(197,616,o),
+(214,631,o),
+(220,661,cs),
+(228,697,o),
+(211,719,o),
+(175,719,cs),
+(144,719,o),
+(127,703,o),
+(121,672,cs),
+(112,637,o),
+(128,616,o),
+(165,616,cs)
+);
+}
+);
+width = 158;
+}
+);
+note = dotaccent;
+unicode = 729;
+},
+{
+glyphname = caron;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(301,623,o),
+(343,674,o),
+(391,729,c),
+(393,738,l),
+(330,738,l),
+(299,710,o),
+(272,678,o),
+(238,639,c),
+(222,675,o),
+(209,710,o),
+(190,738,c),
+(134,738,l),
+(132,729,l),
+(155,684,o),
+(176,635,o),
+(187,585,c),
+(276,585,l),
+(276,585,l)
+);
+}
+);
+width = 316;
+}
+);
+note = caron;
+unicode = 711;
+},
+{
+glyphname = breve;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(299,585,o),
+(347,631,o),
+(368,721,c),
+(313,721,l),
+(298,670,o),
+(271,644,o),
+(234,644,cs),
+(194,644,o),
+(176,671,o),
+(181,721,c),
+(130,721,l),
+(116,638,o),
+(155,585,o),
+(230,585,cs)
+);
+}
+);
+width = 294;
+}
+);
+note = breve;
+unicode = 728;
+},
+{
+glyphname = ring;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(255,587,o),
+(293,630,o),
+(293,694,cs),
+(293,754,o),
+(255,799,o),
+(208,799,cs),
+(160,799,o),
+(125,756,o),
+(125,693,cs),
+(125,629,o),
+(160,587,o),
+(208,587,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(185,634,o),
+(169,660,o),
+(169,693,cs),
+(169,727,o),
+(186,753,o),
+(208,753,cs),
+(229,753,o),
+(246,726,o),
+(246,693,cs),
+(246,661,o),
+(231,634,o),
+(208,634,cs)
+);
+}
+);
+width = 224;
+}
+);
+note = ring;
+unicode = 730;
+},
+{
+glyphname = ogonek;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(31,-219,o),
+(49,-215,o),
+(64,-209,c),
+(76,-153,l),
+(65,-157,o),
+(48,-161,o),
+(38,-161,cs),
+(15,-161,o),
+(7,-143,o),
+(14,-112,cs),
+(20,-76,o),
+(46,-39,o),
+(91,0,c),
+(57,16,l),
+(-7,-34,o),
+(-40,-78,o),
+(-49,-127,cs),
+(-61,-183,o),
+(-36,-219,o),
+(14,-219,cs)
+);
+}
+);
+width = 187;
+}
+);
+note = ogonek;
+unicode = 731;
+},
+{
+glyphname = ring_top.canadian;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (212,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(296,757,o),
+(336,796,o),
+(336,848,cs),
+(336,901,o),
+(296,939,o),
+(244,939,cs),
+(194,939,o),
+(153,901,o),
+(153,848,cs),
+(153,796,o),
+(194,757,o),
+(244,757,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(215,798,o),
+(195,819,o),
+(195,848,cs),
+(195,876,o),
+(215,898,o),
+(244,898,cs),
+(274,898,o),
+(294,876,o),
+(294,848,cs),
+(294,819,o),
+(274,798,o),
+(244,798,cs)
+);
+}
+);
+width = 231;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (90,345);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(117,296,o),
+(139,318,o),
+(139,345,cs),
+(139,372,o),
+(117,394,o),
+(90,394,cs),
+(63,394,o),
+(41,372,o),
+(41,345,cs),
+(41,318,o),
+(63,296,o),
+(90,296,cs)
+);
+}
+);
+width = 135;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (81,345);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(104,303,o),
+(123,321,o),
+(123,345,cs),
+(123,369,o),
+(104,386,o),
+(81,386,cs),
+(58,386,o),
+(40,369,o),
+(40,345,cs),
+(40,321,o),
+(58,303,o),
+(81,303,cs)
+);
+}
+);
+width = 118;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_small;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (72,345);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(92,311,o),
+(106,327,o),
+(106,345,cs),
+(106,363,o),
+(92,379,o),
+(72,379,cs),
+(54,379,o),
+(40,363,o),
+(40,345,cs),
+(40,327,o),
+(54,311,o),
+(72,311,cs)
+);
+}
+);
+width = 101;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_top;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (164,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(221,781,o),
+(244,804,o),
+(244,832,cs),
+(244,860,o),
+(221,882,o),
+(194,882,cs),
+(166,882,o),
+(144,860,o),
+(144,832,cs),
+(144,804,o),
+(166,781,o),
+(194,781,cs)
+);
+}
+);
+width = 135;
+}
+);
+note = g725;
+},
+{
+glyphname = doubledot_middle;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(166,382,o),
+(188,404,o),
+(188,432,cs),
+(188,460,o),
+(166,482,o),
+(139,482,cs),
+(111,482,o),
+(89,460,o),
+(89,432,cs),
+(89,404,o),
+(111,382,o),
+(139,382,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(129,208,o),
+(152,230,o),
+(152,258,cs),
+(152,286,o),
+(129,308,o),
+(101,308,cs),
+(73,308,o),
+(51,286,o),
+(51,258,cs),
+(51,230,o),
+(73,208,o),
+(101,208,cs)
+);
+}
+);
+width = 195;
+}
+);
+metricRight = "=|";
+note = g725;
+},
+{
+glyphname = doubledot_top;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top_double;
+pos = (311,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(368,781,o),
+(391,804,o),
+(391,832,cs),
+(391,860,o),
+(368,882,o),
+(340,882,cs),
+(312,882,o),
+(291,860,o),
+(291,832,cs),
+(291,804,o),
+(312,781,o),
+(340,781,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(221,781,o),
+(243,804,o),
+(243,832,cs),
+(243,860,o),
+(221,882,o),
+(193,882,cs),
+(165,882,o),
+(143,860,o),
+(143,832,cs),
+(143,804,o),
+(165,781,o),
+(193,781,cs)
+);
+}
+);
+width = 282;
+}
+);
+note = g725;
+},
+{
+glyphname = g727;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (376,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(447,0,l),
+(464,75,l),
+(225,75,ls),
+(162,75,o),
+(129,104,o),
+(129,161,cs),
+(129,222,o),
+(154,307,o),
+(270,307,cs),
+(338,307,ls),
+(506,307,o),
+(568,422,o),
+(568,535,cs),
+(568,631,o),
+(509,690,o),
+(412,690,cs),
+(156,690,l),
+(139,614,l),
+(382,614,ls),
+(445,614,o),
+(478,584,o),
+(478,528,cs),
+(478,466,o),
+(452,383,o),
+(338,383,cs),
+(270,383,ls),
+(100,383,o),
+(40,266,o),
+(40,155,cs),
+(40,59,o),
+(99,0,o),
+(196,0,cs)
+);
+}
+);
+width = 563;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+glyphname = g728;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (212,0);
+ref = dot_top;
+}
+);
+width = 563;
+}
+);
+note = g728;
+},
+{
+glyphname = g729;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (380,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(269,0,ls),
+(443,0,o),
+(504,114,o),
+(504,234,cs),
+(504,327,o),
+(446,383,o),
+(351,383,cs),
+(291,383,ls),
+(229,383,o),
+(195,409,o),
+(195,464,cs),
+(195,532,o),
+(222,614,o),
+(341,614,cs),
+(582,614,l),
+(597,690,l),
+(340,690,ls),
+(166,690,o),
+(104,576,o),
+(104,456,cs),
+(104,363,o),
+(162,307,o),
+(258,307,cs),
+(318,307,ls),
+(380,307,o),
+(413,281,o),
+(413,226,cs),
+(413,158,o),
+(384,75,o),
+(268,75,cs),
+(27,75,l),
+(12,0,l)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+glyphname = g730;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (215,0);
+ref = dot_top;
+}
+);
+width = 562;
+}
+);
+note = g730;
+},
+{
+glyphname = g731;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = g727;
+}
+);
+width = 748;
+}
+);
+note = g731;
+},
+{
+glyphname = g732;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (563,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 748;
+}
+);
+note = g732;
+},
+{
+glyphname = g733;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (397,0);
+ref = dot_top;
+}
+);
+width = 748;
+}
+);
+note = g733;
+},
+{
+glyphname = g734;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (212,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (563,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 748;
+}
+);
+note = g734;
+},
+{
+glyphname = g735;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = g729;
+}
+);
+width = 748;
+}
+);
+note = g735;
+},
+{
+glyphname = g736;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (562,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 748;
+}
+);
+note = g736;
+},
+{
+glyphname = g737;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (400,0);
+ref = dot_top;
+}
+);
+width = 748;
+}
+);
+note = g737;
+},
+{
+glyphname = g738;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (215,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (562,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 748;
+}
+);
+note = g738;
+},
+{
+glyphname = g739;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(462,231,o),
+(499,326,o),
+(499,393,cs),
+(499,456,o),
+(465,493,o),
+(406,493,cs),
+(264,493,l),
+(269,469,l),
+(306,500,o),
+(319,561,o),
+(319,596,cs),
+(319,657,o),
+(285,696,o),
+(229,696,cs),
+(144,696,o),
+(107,602,o),
+(107,533,cs),
+(107,471,o),
+(142,434,o),
+(200,434,cs),
+(342,434,l),
+(337,457,l),
+(297,425,o),
+(287,365,o),
+(287,331,cs),
+(287,270,o),
+(321,231,o),
+(377,231,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(174,481,o),
+(160,499,o),
+(160,532,cs),
+(160,568,o),
+(178,648,o),
+(225,648,cs),
+(250,648,o),
+(265,630,o),
+(265,596,cs),
+(265,562,o),
+(247,481,o),
+(199,481,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(355,278,o),
+(341,297,o),
+(341,331,cs),
+(341,364,o),
+(357,445,o),
+(407,445,cs),
+(432,445,o),
+(445,427,o),
+(445,394,cs),
+(445,359,o),
+(429,278,o),
+(381,278,cs)
+);
+}
+);
+width = 511;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+glyphname = g740;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (164,0);
+ref = ring_top.canadian;
+}
+);
+width = 563;
+}
+);
+note = g740;
+},
+{
+glyphname = g741;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (168,0);
+ref = ring_top.canadian;
+}
+);
+width = 562;
+}
+);
+note = g741;
+},
+{
+glyphname = g742;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (350,0);
+ref = ring_top.canadian;
+}
+);
+width = 748;
+}
+);
+note = g742;
+},
+{
+glyphname = stroke_middle;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (68,345);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(71,233,l),
+(118,457,l),
+(64,457,l),
+(16,233,l)
+);
+}
+);
+width = 89;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (61,345);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(64,256,l),
+(100,434,l),
+(58,434,l),
+(21,256,l)
+);
+}
+);
+width = 76;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_small;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (57,345);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(57,262,l),
+(92,428,l),
+(57,428,l),
+(22,262,l)
+);
+}
+);
+width = 69;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_threequart;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (68,345);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(69,235,l),
+(116,455,l),
+(66,455,l),
+(18,235,l)
+);
+}
+);
+width = 89;
+}
+);
+note = g723;
+},
+{
+color = 8;
+glyphname = uni11AB0;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (232,690);
+},
+{
+name = top_right_can;
+pos = (463,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(130,0,l),
+(153,104,l),
+(337,104,l),
+(349,158,l),
+(164,158,l),
+(189,278,l),
+(119,249,l),
+(151,249,ls),
+(329,249,o),
+(432,335,o),
+(475,539,cs),
+(507,690,l),
+(417,690,l),
+(386,545,ls),
+(355,401,o),
+(281,331,o),
+(156,331,cs),
+(111,331,l),
+(74,158,l),
+(13,158,l),
+(1,104,l),
+(63,104,l),
+(41,0,l)
+);
+}
+);
+width = 469;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB1;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB0;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (299,0);
+ref = dot_top;
+}
+);
+width = 470;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB2;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (198,690);
+},
+{
+name = top_right_can;
+pos = (429,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,0,l),
+(128,145,ls),
+(159,289,o),
+(233,358,o),
+(358,358,cs),
+(404,358,l),
+(440,531,l),
+(502,531,l),
+(513,585,l),
+(452,585,l),
+(474,690,l),
+(383,690,l),
+(361,585,l),
+(177,585,l),
+(165,531,l),
+(350,531,l),
+(325,412,l),
+(396,440,l),
+(363,440,ls),
+(185,440,o),
+(82,355,o),
+(39,151,cs),
+(7,0,l)
+);
+}
+);
+width = 470;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "theThCree-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB3;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB2;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (266,0);
+ref = dot_top;
+}
+);
+width = 471;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB4;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (235,690);
+},
+{
+name = top_right_can;
+pos = (465,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(362,0,l),
+(392,137,ls),
+(435,337,o),
+(346,440,o),
+(165,440,cs),
+(152,440,l),
+(219,411,l),
+(245,531,l),
+(430,531,l),
+(441,585,l),
+(257,585,l),
+(279,690,l),
+(188,690,l),
+(166,585,l),
+(104,585,l),
+(94,531,l),
+(155,531,l),
+(119,358,l),
+(145,358,ls),
+(279,358,o),
+(336,298,o),
+(301,139,cs),
+(272,0,l)
+);
+}
+);
+width = 472;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB5;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB4;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (70,0);
+ref = dot_top;
+}
+);
+width = 470;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB6;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (203,690);
+},
+{
+name = top_right_can;
+pos = (434,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,1,l),
+(160,281,l),
+(87,250,l),
+(116,250,ls),
+(303,250,o),
+(403,340,o),
+(447,549,cs),
+(470,657,l),
+(403,635,l),
+(550,443,l),
+(617,497,l),
+(469,691,l),
+(387,691,l),
+(358,554,ls),
+(326,402,o),
+(247,332,o),
+(117,332,cs),
+(81,332,l),
+(11,1,l)
+);
+}
+);
+width = 582;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB7;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB6;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (269,0);
+ref = dot_top;
+}
+);
+width = 582;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB8;
+kernRight = soright;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (341,690);
+},
+{
+name = top_right_can;
+pos = (572,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(240,0,l),
+(269,137,ls),
+(302,289,o),
+(381,358,o),
+(511,358,cs),
+(547,358,l),
+(617,690,l),
+(526,690,l),
+(467,410,l),
+(541,440,l),
+(512,440,ls),
+(325,440,o),
+(225,351,o),
+(180,142,cs),
+(156,34,l),
+(225,56,l),
+(77,247,l),
+(10,194,l),
+(159,0,l)
+);
+}
+);
+width = 583;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB9;
+kernRight = soright;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB8;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (409,0);
+ref = dot_top;
+}
+);
+width = 582;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABA;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:55:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (202,690);
+},
+{
+name = top_right_can;
+pos = (433,690);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(322,0,l),
+(554,194,l),
+(502,255,l),
+(304,89,l),
+(345,73,l),
+(356,121,ls),
+(392,298,o),
+(321,439,o),
+(157,439,cs),
+(132,439,l),
+(184,392,l),
+(247,690,l),
+(157,690,l),
+(87,358,l),
+(117,358,ls),
+(252,358,o),
+(299,273,o),
+(263,103,cs),
+(242,0,l)
+);
+}
+);
+width = 584;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABB;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = uni11ABA;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (37,0);
+ref = dot_top;
+}
+);
+width = 582;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABC;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(375,0,l),
+(393,83,l),
+(95,83,l),
+(94,47,l),
+(515,626,l),
+(528,690,l),
+(139,690,l),
+(122,607,l),
+(418,607,l),
+(420,642,l),
+(-1,64,l),
+(-14,0,l)
+);
+}
+);
+width = 469;
+}
+);
+metricRight = "=|";
+},
+{
+color = 8;
+glyphname = uni11ABD;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(383,0,l),
+(396,64,l),
+(208,642,l),
+(208,607,l),
+(504,607,l),
+(523,690,l),
+(132,690,l),
+(119,626,l),
+(307,47,l),
+(307,83,l),
+(11,83,l),
+(-8,0,l)
+);
+}
+);
+width = 470;
+}
+);
+metricLeft = "=|uni11ABC";
+metricRight = "=|uni11ABC";
+},
+{
+color = 8;
+glyphname = uni11ABE;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(98,0,l),
+(227,608,l),
+(173,608,l),
+(351,0,l),
+(431,0,l),
+(578,690,l),
+(489,690,l),
+(359,82,l),
+(413,82,l),
+(236,690,l),
+(156,690,l),
+(9,0,l)
+);
+}
+);
+width = 542;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABF;
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(89,0,l),
+(536,611,l),
+(472,611,l),
+(342,0,l),
+(431,0,l),
+(578,690,l),
+(497,690,l),
+(49,79,l),
+(114,79,l),
+(244,690,l),
+(156,690,l),
+(9,0,l)
+);
+}
+);
+width = 542;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = "raiseddoubledotFinal-canadian.cree";
+lastChange = "2023-01-13 15:55:37 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(211,602,o),
+(233,624,o),
+(233,652,cs),
+(233,680,o),
+(211,702,o),
+(183,702,cs),
+(155,702,o),
+(132,681,o),
+(132,652,cs),
+(132,624,o),
+(155,602,o),
+(183,602,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(175,428,o),
+(197,450,o),
+(197,478,cs),
+(197,506,o),
+(175,528,o),
+(147,528,cs),
+(119,528,o),
+(97,506,o),
+(97,478,cs),
+(97,450,o),
+(119,428,o),
+(147,428,cs)
+);
+}
+);
+width = 190;
+}
+);
+note = g725;
+}
+);
+instances = (
+{
+axesValues = (
+98,
+72,
+12
+);
+instanceInterpolations = {
+"9563F490-07F6-43DA-A81C-32B2684714C2" = 1;
+};
+name = "RC CR Italic";
+}
+);
+kerningLTR = {
+"9563F490-07F6-43DA-A81C-32B2684714C2" = {
+"@MMK_L_caright" = {
+"@MMK_R_ecanleft" = -64.722;
+"@MMK_R_mwestleft" = -24.15;
+"@MMK_R_neleft" = -46.368;
+};
+"@MMK_L_ciright" = {
+"@MMK_R_icanleft" = -64.722;
+"@MMK_R_noleft" = -81.144;
+};
+"@MMK_L_ecanright" = {
+"@MMK_R_coleft" = -64.722;
+"@MMK_R_moleft" = -64.722;
+"@MMK_R_sileft" = -35.742;
+};
+"@MMK_L_icanright" = {
+"@MMK_R_celeft" = -64.722;
+"@MMK_R_meleft" = -64.722;
+"@MMK_R_mwestleft" = -43.47;
+"@MMK_R_saleft" = -30.912;
+"she-canadian" = -64.722;
+};
+"@MMK_L_maright" = {
+"@MMK_R_acanleft" = -60.858;
+"@MMK_R_ecanleft" = -64.722;
+"@MMK_R_mwestleft" = -44.436;
+"@MMK_R_neleft" = -46.368;
+};
+"@MMK_L_miright" = {
+"@MMK_R_acanleft" = -60.858;
+"@MMK_R_icanleft" = -64.722;
+"@MMK_R_moleft" = -87.906;
+"@MMK_R_noleft" = -81.144;
+"@MMK_R_yeleft" = -88.872;
+};
+"@MMK_L_mwestright" = {
+"@MMK_R_coleft" = -24.15;
+"@MMK_R_icanleft" = -43.47;
+"@MMK_R_moleft" = -44.436;
+"@MMK_R_noleft" = -71.484;
+"@MMK_R_sileft" = -12.558;
+"@MMK_R_yeleft" = -22.218;
+};
+"@MMK_L_naright" = {
+"@MMK_R_acanleft" = -76.314;
+"@MMK_R_celeft" = -81.144;
+"@MMK_R_meleft" = -81.144;
+"@MMK_R_mwestleft" = -71.484;
+"@MMK_R_neleft" = -92.736;
+"@MMK_R_saleft" = -53.13;
+};
+"@MMK_L_niright" = {
+"@MMK_R_coleft" = -46.368;
+"@MMK_R_moleft" = -46.368;
+"@MMK_R_noleft" = -92.736;
+"@MMK_R_sileft" = -2.898;
+};
+"@MMK_L_ocanright" = {
+"@MMK_R_meleft" = -60.858;
+"@MMK_R_moleft" = -60.858;
+"@MMK_R_noleft" = -76.314;
+};
+"@MMK_L_seright" = {
+"@MMK_R_ecanleft" = -35.742;
+"@MMK_R_mwestleft" = -12.558;
+"@MMK_R_neleft" = -2.898;
+};
+"@MMK_L_soright" = {
+"@MMK_R_icanleft" = -30.912;
+"@MMK_R_noleft" = -53.13;
+};
+"@MMK_L_yiright" = {
+"@MMK_R_meleft" = -88.872;
+"@MMK_R_mwestleft" = -22.218;
+};
+"shi-canadian" = {
+"@MMK_R_icanleft" = -64.722;
+};
+};
+};
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "italic angle";
+}
+);
+properties = (
+{
+key = copyrights;
+values = (
+{
+language = ENG;
+value = "Copyright 2018 Google Inc. All Rights Reserved.";
+}
+);
+},
+{
+key = manufacturers;
+values = (
+{
+language = ENG;
+value = "Monotype Imaging Inc.";
+}
+);
+},
+{
+key = designers;
+values = (
+{
+language = ENG;
+value = "Monotype Design Team";
+}
+);
+},
+{
+key = description;
+value = "Designed by Monotype design team.";
+},
+{
+key = trademarks;
+values = (
+{
+language = ENG;
+value = "Noto is a trademark of Google Inc.";
+}
+);
+},
+{
+key = licenseURL;
+value = "http://scripts.sil.org/OFL";
+},
+{
+key = licenses;
+values = (
+{
+language = ENG;
+value = "This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.";
+}
+);
+},
+{
+key = manufacturerURL;
+value = "http://www.google.com/get/noto/";
+},
+{
+key = designerURL;
+value = "http://www.monotype.com/studio";
+}
+);
+settings = {
+disablesNiceNames = 1;
+};
+stems = (
+{
+name = "New Stem";
+}
+);
+unitsPerEm = 966;
+userData = {
+GSDontShowVersionAlert = 1;
+};
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/sources/Exported instances UCAS SansCanadianAboriginal Resized/Sans Canadian Aboriginal-RC CR roman.glyphs
+++ b/sources/Exported instances UCAS SansCanadianAboriginal Resized/Sans Canadian Aboriginal-RC CR roman.glyphs
@@ -1,0 +1,37333 @@
+{
+.appVersion = "3151";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+},
+{
+name = Width;
+tag = wdth;
+},
+{
+name = Slant;
+tag = slnt;
+}
+);
+classes = (
+{
+code = "zero one two three four five six seven eight nine ";
+name = Num;
+},
+{
+code = "zero.canadian one.canadian two.canadian three.canadian four.canadian five.canadian six.canadian seven.canadian eight.canadian nine.canadian 
+";
+name = Num_can;
+},
+{
+code = "ke-canadian.square ki-canadian.square kii-canadian.square ko-canadian.square koo-canadian.square ka-canadian.square kaa-canadian.square kweWestCree-canadian.square kwiiWestCree-canadian.square kwoWestCree-canadian.square kwooWestCree-canadian.square kwaWestCree-canadian.square kwaaWestCree-canadian.square ce-canadian.square ci-canadian.square cii-canadian.square co-canadian.square coo-canadian.square ca-canadian.square caa-canadian.square me-canadian.square mi-canadian.square mii-canadian.square mo-canadian.square moo-canadian.square ma-canadian.square maa-canadian.square ne-canadian.square ni-canadian.square nii-canadian.square no-canadian.square noo-canadian.square na-canadian.square naa-canadian.square nweWestCree-canadian.square nwaWestCree-canadian.square nwaaWestCree-canadian.square se-canadian.square si-canadian.square sii-canadian.square so-canadian.square soo-canadian.square sa-canadian.square saa-canadian.square sho-canadian.square shoo-canadian.square sha-canadian.square shaa-canadian.square ye-canadian.square yi-canadian.square yii-canadian.square yo-canadian.square yoo-canadian.square ya-canadian.square yaa-canadian.square re-canadian.square reRCree-canadian.square leWestCree-canadian.square ri-canadian.square rii-canadian.square ro-canadian.square loWestCree-canadian.square ra-canadian.square raa-canadian.square laWestCree-canadian.square reWestCree-canadian.square riWestCree-canadian.square roWestCree-canadian.square raWestCree-canadian.square theThCree-canadian.square thiThCree-canadian.square thiiThCree-canadian.square thoThCree-canadian.square thooThCree-canadian.square thaThCree-canadian.square thaaThCree-canadian.square thweeWoodScree-canadian.square thwiWoodScree-canadian.square thwiiWoodScree-canadian.square thwoWoodScree-canadian.square thwooWoodScree-canadian.square thwaWoodScree-canadian.square thwaaWoodScree-canadian.square nwiOjibway-canadian.square nwiiOjibway-canadian.square nwoOjibway-canadian.square nwooOjibway-canadian.square looWestCree-canadian.square laaWestCree-canadian.square ";
+name = Dene_square;
+},
+{
+code = "ke-canadian ki-canadian kii-canadian ko-canadian koo-canadian ka-canadian kaa-canadian kweWestCree-canadian kwiiWestCree-canadian kwoWestCree-canadian kwooWestCree-canadian kwaWestCree-canadian kwaaWestCree-canadian ce-canadian ci-canadian cii-canadian co-canadian coo-canadian ca-canadian caa-canadian me-canadian mi-canadian mii-canadian mo-canadian moo-canadian ma-canadian maa-canadian ne-canadian ni-canadian nii-canadian no-canadian noo-canadian na-canadian naa-canadian nweWestCree-canadian nwaWestCree-canadian nwaaWestCree-canadian se-canadian si-canadian sii-canadian so-canadian soo-canadian sa-canadian saa-canadian sho-canadian shoo-canadian sha-canadian shaa-canadian ye-canadian yi-canadian yii-canadian yo-canadian yoo-canadian ya-canadian yaa-canadian re-canadian reRCree-canadian leWestCree-canadian ri-canadian rii-canadian ro-canadian loWestCree-canadian ra-canadian raa-canadian laWestCree-canadian reWestCree-canadian riWestCree-canadian roWestCree-canadian raWestCree-canadian theThCree-canadian thiThCree-canadian thiiThCree-canadian thoThCree-canadian thooThCree-canadian thaThCree-canadian thaaThCree-canadian thweeWoodScree-canadian thwiWoodScree-canadian thwiiWoodScree-canadian thwoWoodScree-canadian thwooWoodScree-canadian thwaWoodScree-canadian thwaaWoodScree-canadian nwiOjibway-canadian nwiiOjibway-canadian nwoOjibway-canadian nwooOjibway-canadian looWestCree-canadian laaWestCree-canadian 
+";
+name = Dene_round;
+},
+{
+code = "acuteFinal-canadian.mid graveFinal-canadian.mid ringTophalfFinal-canadian.mid ringRighthalfFinal-canadian.mid ringFinal-canadian.mid doubleacuteFinal-canadian.mid doubleshortverticalstrokesFinal-canadian.mid shorthorizontalstrokeFinal-canadian.mid downtackFinal-canadian.mid pWestCree-canadian.mid c-canadian.mid mWestCree-canadian.mid ";
+name = Final_mid;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian ringFinal-canadian doubleacuteFinal-canadian doubleshortverticalstrokesFinal-canadian shorthorizontalstrokeFinal-canadian downtackFinal-canadian pWestCree-canadian c-canadian mWestCree-canadian ";
+name = Final_mid_ori;
+},
+{
+code = "acuteFinal-canadian.base graveFinal-canadian.base ringBottomhalfFinal-canadian.base ringTophalfFinal-canadian.base ringRighthalfFinal-canadian.base plusFinal-canadian.base pWestCree-canadian.base c-canadian.base thSayisi-canadian.base mWestCree-canadian.base ";
+name = Final_base;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringBottomhalfFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian plusFinal-canadian pWestCree-canadian c-canadian thSayisi-canadian mWestCree-canadian ";
+name = Final_base_ori;
+},
+{
+code = "ng-canadian ngai-canadian ngaai-canadian ngi-canadian ngii-canadian ngo-canadian ngoo-canadian nga-canadian ngaa-canadian ";
+name = Nunavik;
+},
+{
+code = "ng-canadian.nunavik ngai-canadian.nunavik ngaai-canadian.nunavik ngi-canadian.nunavik ngii-canadian.nunavik ngo-canadian.nunavik ngoo-canadian.nunavik nga-canadian.nunavik ngaa-canadian.nunavik ";
+name = Nunavik_alt;
+}
+);
+customParameters = (
+{
+name = vendorID;
+value = GOOG;
+},
+{
+name = panose;
+value = (
+2,
+11,
+5,
+2,
+4,
+5,
+4,
+2,
+2,
+4
+);
+},
+{
+name = unicodeRanges;
+value = (
+0,
+1,
+2,
+5,
+6,
+45,
+77
+);
+},
+{
+name = codePageRanges;
+value = (
+"1252"
+);
+},
+{
+name = fsType;
+value = (
+);
+}
+);
+date = "2022-06-21 10:06:40 +0000";
+familyName = "Sans Canadian Aboriginal";
+featurePrefixes = (
+{
+automatic = 1;
+code = "languagesystem DFLT dflt;
+
+languagesystem cans dflt;
+";
+name = Languagesystems;
+}
+);
+features = (
+{
+automatic = 1;
+code = "feature ss01;
+feature ss02;
+feature ss03;
+feature ss04;
+";
+tag = aalt;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+tag = salt;
+},
+{
+code = "lookup space_can {
+sub space by space.canadian;
+} space_can;
+
+lookup num_can {
+sub @Num by @Num_can;
+} num_can;
+";
+labels = (
+{
+language = dflt;
+value = "CAN Space and numerals";
+}
+);
+tag = ss01;
+},
+{
+code = "lookup dene_square {
+sub @Dene_round by @Dene_square;
+} dene_square;
+
+";
+labels = (
+{
+language = dflt;
+value = "Dene Square";
+}
+);
+tag = ss02;
+},
+{
+code = "lookup nunavik_alt {
+sub @Nunavik by @Nunavik_alt;
+} nunavik_alt;
+
+";
+labels = (
+{
+language = dflt;
+value = "Nunanvik Alt";
+}
+);
+tag = ss03;
+},
+{
+code = "lookup final_mid {
+sub @Final_mid_ori by @Final_mid;
+} final_mid;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final mid";
+}
+);
+tag = ss04;
+},
+{
+code = "lookup final_base {
+sub @Final_base_ori by @Final_base;
+} final_base;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final base";
+}
+);
+tag = ss05;
+},
+{
+code = "lookup plaincree_first {
+sub wiWestCree-canadian' plusFinal-canadian by i-canadian;
+} plaincree_first;
+
+lookup plaincree_second {
+sub i-canadian plusFinal-canadian' by raiseddoubledotFinal-canadian.cree;
+} plaincree_second;
+
+lookup plaincree_third {
+sub middledotFinal-canadian plusFinal-canadian by raiseddoubledotFinal-canadian.cree;
+} plaincree_third;
+";
+labels = (
+{
+language = dflt;
+value = Plaincree;
+}
+);
+tag = ss06;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+labels = (
+{
+language = dflt;
+value = "";
+}
+);
+tag = ss07;
+}
+);
+fontMaster = (
+{
+axesValues = (
+0,
+0,
+0
+);
+customParameters = (
+{
+name = typoAscender;
+value = 1033;
+},
+{
+name = typoDescender;
+value = -283;
+},
+{
+name = typoLineGap;
+value = 0;
+},
+{
+name = winAscent;
+value = 1033;
+},
+{
+name = winDescent;
+value = 283;
+},
+{
+name = hheaAscender;
+value = 1033;
+},
+{
+name = hheaDescender;
+value = -283;
+},
+{
+name = strikeoutPosition;
+value = 287;
+},
+{
+name = strikeoutSize;
+value = 48;
+}
+);
+guides = (
+{
+lockAngle = 1;
+locked = 1;
+pos = (222,345);
+}
+);
+id = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+metricValues = (
+{
+over = 18;
+pos = 1033;
+},
+{
+over = 18;
+pos = 690;
+},
+{
+over = 18;
+pos = 478;
+},
+{
+over = -18;
+},
+{
+over = -18;
+pos = -283;
+},
+{
+}
+);
+name = "RC CR roman";
+stemValues = (
+90
+);
+}
+);
+glyphs = (
+{
+glyphname = idotless;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(144,520,l),
+(55,520,l),
+(55,0,l),
+(144,0,l)
+);
+}
+);
+width = 199;
+}
+);
+note = dotlessi;
+unicode = 305;
+},
+{
+glyphname = "acuteFinal-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(95,345,l),
+(225,690,l),
+(156,690,l),
+(26,345,l)
+);
+}
+);
+width = 251;
+}
+);
+metricRight = "=|";
+note = uni141F;
+unicode = 5151;
+},
+{
+glyphname = "graveFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(225,345,l),
+(95,690,l),
+(26,690,l),
+(156,345,l)
+);
+}
+);
+width = 251;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+unicode = 5152;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(245,339,o),
+(291,387,o),
+(291,479,cs),
+(291,690,l),
+(230,690,l),
+(230,475,ls),
+(230,420,o),
+(211,395,o),
+(170,395,cs),
+(130,395,o),
+(111,421,o),
+(111,475,cs),
+(111,690,l),
+(49,690,l),
+(49,477,ls),
+(49,387,o),
+(96,339,o),
+(170,339,cs)
+);
+}
+);
+width = 340;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1421;
+unicode = 5153;
+},
+{
+glyphname = "ringTophalfFinal-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(111,345,l),
+(111,560,ls),
+(111,613,o),
+(130,639,o),
+(170,639,cs),
+(211,639,o),
+(230,614,o),
+(230,559,cs),
+(230,345,l),
+(291,345,l),
+(291,555,ls),
+(291,647,o),
+(245,696,o),
+(170,696,cs),
+(96,696,o),
+(49,647,o),
+(49,557,cs),
+(49,345,l)
+);
+}
+);
+width = 340;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+unicode = 5154;
+},
+{
+glyphname = "ringRighthalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(87,345,ls),
+(191,345,o),
+(247,410,o),
+(247,517,cs),
+(247,624,o),
+(191,690,o),
+(88,690,cs),
+(48,690,l),
+(48,631,l),
+(81,631,ls),
+(151,631,o),
+(185,590,o),
+(185,517,cs),
+(185,442,o),
+(151,404,o),
+(81,404,cs),
+(48,404,l),
+(48,345,l)
+);
+}
+);
+width = 293;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+unicode = 5155;
+},
+{
+glyphname = "ringFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(294,389,o),
+(357,455,o),
+(357,543,cs),
+(357,630,o),
+(293,696,o),
+(203,696,cs),
+(111,696,o),
+(47,630,o),
+(47,543,cs),
+(47,455,o),
+(111,389,o),
+(203,389,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(143,442,o),
+(104,483,o),
+(104,543,cs),
+(104,601,o),
+(143,642,o),
+(203,642,cs),
+(260,642,o),
+(299,600,o),
+(299,543,cs),
+(299,483,o),
+(260,442,o),
+(203,442,cs)
+);
+}
+);
+width = 404;
+}
+);
+note = uni1424;
+unicode = 5156;
+},
+{
+glyphname = "doubleacuteFinal-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(225,690,l),
+(156,690,l),
+(26,345,l),
+(95,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(351,690,l),
+(281,690,l),
+(152,345,l),
+(221,345,l)
+);
+}
+);
+width = 377;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricRight = "=|";
+note = uni1425;
+unicode = 5157;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(111,690,l),
+(49,690,l),
+(49,345,l),
+(111,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(222,690,l),
+(160,690,l),
+(160,345,l),
+(222,345,l)
+);
+}
+);
+width = 271;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "pWestCree-canadian";
+note = uni1426;
+unicode = 5158;
+},
+{
+glyphname = "middledotFinal-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,304,o),
+(143,327,o),
+(143,355,cs),
+(143,383,o),
+(121,405,o),
+(93,405,cs),
+(65,405,o),
+(43,383,o),
+(43,355,cs),
+(43,327,o),
+(65,304,o),
+(93,304,cs)
+);
+}
+);
+width = 185;
+}
+);
+note = uni1427;
+unicode = 5159;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(309,499,l),
+(309,561,l),
+(49,561,l),
+(49,499,l)
+);
+}
+);
+width = 358;
+}
+);
+metricRight = "=|";
+note = uni1428;
+unicode = 5160;
+},
+{
+glyphname = "plusFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(209,399,l),
+(209,516,l),
+(309,516,l),
+(309,576,l),
+(209,576,l),
+(209,690,l),
+(151,690,l),
+(151,576,l),
+(49,576,l),
+(49,516,l),
+(151,516,l),
+(151,399,l)
+);
+}
+);
+width = 358;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+unicode = 5161;
+},
+{
+glyphname = "downtackFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(211,345,l),
+(211,631,l),
+(309,631,l),
+(309,690,l),
+(49,690,l),
+(49,631,l),
+(149,631,l),
+(149,345,l)
+);
+}
+);
+width = 358;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni142A;
+unicode = 5162;
+},
+{
+glyphname = "thFinalWoodScree-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(211,345,l),
+(211,420,l),
+(309,420,l),
+(309,474,l),
+(211,474,l),
+(211,560,l),
+(309,560,l),
+(309,614,l),
+(211,614,l),
+(211,690,l),
+(149,690,l),
+(149,614,l),
+(49,614,l),
+(49,560,l),
+(149,560,l),
+(149,474,l),
+(49,474,l),
+(49,420,l),
+(149,420,l),
+(149,345,l)
+);
+}
+);
+width = 358;
+}
+);
+metricLeft = "hyphen-canadian";
+metricRight = "hyphen-canadian";
+note = uni167E;
+unicode = 5758;
+},
+{
+glyphname = "ringSmallFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(191,521,o),
+(233,559,o),
+(233,611,cs),
+(233,665,o),
+(191,702,o),
+(141,702,cs),
+(91,702,o),
+(49,665,o),
+(49,611,cs),
+(49,559,o),
+(90,521,o),
+(141,521,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(112,561,o),
+(92,582,o),
+(92,611,cs),
+(92,640,o),
+(112,662,o),
+(141,662,cs),
+(170,662,o),
+(190,640,o),
+(190,611,cs),
+(190,582,o),
+(170,561,o),
+(141,561,cs)
+);
+}
+);
+width = 282;
+}
+);
+note = g725;
+unicode = 6366;
+},
+{
+glyphname = "raiseddotFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(123,602,o),
+(145,624,o),
+(145,652,cs),
+(145,680,o),
+(123,702,o),
+(95,702,cs),
+(68,702,o),
+(44,680,o),
+(44,652,cs),
+(44,624,o),
+(68,602,o),
+(95,602,cs)
+);
+}
+);
+width = 190;
+}
+);
+note = g725;
+unicode = 6367;
+},
+{
+glyphname = "acuteFinal-canadian.base";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "acuteFinal-canadian";
+}
+);
+width = 251;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.base";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "graveFinal-canadian";
+}
+);
+width = 251;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian.base";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 340;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1421;
+},
+{
+glyphname = "ringTophalfFinal-canadian.base";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 340;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.base";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 293;
+}
+);
+metricLeft = "==|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "plusFinal-canadian.base";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(209,0,l),
+(209,117,l),
+(309,117,l),
+(309,177,l),
+(209,177,l),
+(209,291,l),
+(151,291,l),
+(151,177,l),
+(49,177,l),
+(49,117,l),
+(151,117,l),
+(151,0,l)
+);
+}
+);
+width = 358;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+},
+{
+glyphname = "acuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "acuteFinal-canadian";
+}
+);
+width = 251;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.mid";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "graveFinal-canadian";
+}
+);
+width = 251;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringTophalfFinal-canadian.mid";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-172);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 340;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.mid";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 293;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "ringFinal-canadian.mid";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-199);
+ref = "ringFinal-canadian";
+}
+);
+width = 404;
+}
+);
+metricLeft = "ringFinal-canadian";
+metricWidth = "ringFinal-canadian";
+note = uni1424;
+},
+{
+glyphname = "doubleacuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "doubleacuteFinal-canadian";
+}
+);
+width = 377;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "doubleacuteFinal-canadian";
+note = uni1425;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian.mid";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "doubleshortverticalstrokesFinal-canadian";
+}
+);
+width = 271;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricWidth = "doubleshortverticalstrokesFinal-canadian";
+note = uni1426;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian.mid";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-176);
+ref = "shorthorizontalstrokeFinal-canadian";
+}
+);
+width = 358;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "shorthorizontalstrokeFinal-canadian";
+note = uni1428;
+},
+{
+glyphname = "downtackFinal-canadian.mid";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "downtackFinal-canadian";
+}
+);
+width = 358;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "downtackFinal-canadian";
+note = uni142A;
+},
+{
+glyphname = "e-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (287,454);
+},
+{
+name = top_center_can;
+pos = (287,690);
+},
+{
+name = top_left_can;
+pos = (106,690);
+},
+{
+name = top_right_can;
+pos = (469,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(303,0,l),
+(552,665,l),
+(552,690,l),
+(25,690,l),
+(25,665,l),
+(273,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(309,106,l),
+(119,637,l),
+(103,616,l),
+(470,616,l),
+(459,637,l),
+(268,106,l)
+);
+}
+);
+width = 577;
+}
+);
+metricRight = "=|";
+note = uni1401;
+unicode = 5121;
+},
+{
+glyphname = "aai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (173,0);
+ref = ring_top.canadian;
+}
+);
+width = 577;
+}
+);
+note = uni1402;
+unicode = 5122;
+},
+{
+glyphname = "i-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (286,363);
+},
+{
+name = top_center_can;
+pos = (288,690);
+},
+{
+name = top_left_can;
+pos = (107,690);
+},
+{
+name = top_right_can;
+pos = (469,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(552,0,l),
+(552,25,l),
+(303,690,l),
+(273,690,l),
+(25,25,l),
+(25,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(308,583,l),
+(267,583,l),
+(458,53,l),
+(469,73,l),
+(103,73,l),
+(118,53,l)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "e-canadian";
+metricWidth = "e-canadian";
+note = uni1403;
+unicode = 5123;
+},
+{
+glyphname = "ii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (220,0);
+ref = dot_top;
+}
+);
+width = 577;
+}
+);
+note = uni1404;
+unicode = 5124;
+},
+{
+glyphname = "o-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (227,345);
+},
+{
+name = top_center_can;
+pos = (286,690);
+},
+{
+name = top_double;
+pos = (370,690);
+},
+{
+name = top_left_can;
+pos = (96,690);
+},
+{
+name = top_right_can;
+pos = (478,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(83,0,l),
+(521,328,l),
+(521,361,l),
+(83,690,l),
+(60,690,l),
+(60,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(134,588,l),
+(114,579,l),
+(446,326,l),
+(446,365,l),
+(114,112,l),
+(134,101,l)
+);
+}
+);
+width = 550;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1405;
+unicode = 5125;
+},
+{
+glyphname = "oo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (28,0);
+ref = dot_top;
+}
+);
+width = 550;
+}
+);
+note = uni1406;
+unicode = 5126;
+},
+{
+glyphname = "yCreeoo-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (156,0);
+ref = doubledot_top;
+}
+);
+width = 550;
+}
+);
+note = uni1407;
+unicode = 5127;
+},
+{
+glyphname = "eeCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(83,0,l),
+(521,328,l),
+(521,361,l),
+(83,690,l),
+(60,690,l),
+(60,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(128,588,l),
+(114,584,l),
+(446,331,l),
+(446,359,l),
+(114,106,l),
+(128,101,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(241,428,l),
+(206,428,l),
+(206,262,l),
+(241,262,l)
+);
+}
+);
+width = 550;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "o-canadian";
+note = uni1408;
+unicode = 5128;
+},
+{
+glyphname = "iCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (176,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 550;
+}
+);
+note = uni1409;
+unicode = 5129;
+},
+{
+glyphname = "a-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (320,345);
+},
+{
+name = top_center_can;
+pos = (244,690);
+},
+{
+name = top_left_can;
+pos = (72,690);
+},
+{
+name = top_right_can;
+pos = (451,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(490,0,l),
+(490,690,l),
+(467,690,l),
+(29,361,l),
+(29,328,l),
+(467,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(436,111,l),
+(103,364,l),
+(103,325,l),
+(436,578,l),
+(415,588,l),
+(415,101,l)
+);
+}
+);
+width = 550;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni140A;
+unicode = 5130;
+},
+{
+glyphname = "aa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (384,0);
+ref = dot_top;
+}
+);
+width = 550;
+}
+);
+note = uni140B;
+unicode = 5131;
+},
+{
+glyphname = "we-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "e-canadian";
+}
+);
+width = 761;
+}
+);
+note = uni140C;
+unicode = 5132;
+},
+{
+glyphname = "weWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (577,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 761;
+}
+);
+note = uni140D;
+unicode = 5133;
+},
+{
+glyphname = "wi-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "i-canadian";
+}
+);
+width = 761;
+}
+);
+note = uni140E;
+unicode = 5134;
+},
+{
+glyphname = "wiWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (577,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 761;
+}
+);
+note = uni140F;
+unicode = 5135;
+},
+{
+glyphname = "wii-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (406,0);
+ref = dot_top;
+}
+);
+width = 761;
+}
+);
+note = uni1410;
+unicode = 5136;
+},
+{
+glyphname = "wiiWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (220,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (577,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 761;
+}
+);
+note = uni1411;
+unicode = 5137;
+},
+{
+glyphname = "wo-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "o-canadian";
+}
+);
+width = 735;
+}
+);
+note = uni1412;
+unicode = 5138;
+},
+{
+glyphname = "woWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (550,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 735;
+}
+);
+note = uni1413;
+unicode = 5139;
+},
+{
+glyphname = "woo-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (404,0);
+ref = dot_top;
+}
+);
+width = 735;
+}
+);
+note = uni1414;
+unicode = 5140;
+},
+{
+glyphname = "wooWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (28,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (550,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 735;
+}
+);
+note = uni1415;
+unicode = 5141;
+},
+{
+glyphname = "wooNaskapi-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (173,-94);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (313,-200);
+ref = dot_top;
+}
+);
+width = 550;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricWidth = "o-canadian";
+note = uni1416;
+unicode = 5142;
+},
+{
+glyphname = "wa-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "a-canadian";
+}
+);
+width = 735;
+}
+);
+note = uni1417;
+unicode = 5143;
+},
+{
+glyphname = "waWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (550,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 735;
+}
+);
+note = uni1418;
+unicode = 5144;
+},
+{
+glyphname = "waa-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (568,0);
+ref = dot_top;
+}
+);
+width = 735;
+}
+);
+note = uni1419;
+unicode = 5145;
+},
+{
+glyphname = "waaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (384,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (550,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 735;
+}
+);
+note = uni141A;
+unicode = 5146;
+},
+{
+glyphname = "waaNaskapi-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (100,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (241,-94);
+ref = dot_top;
+}
+);
+width = 550;
+}
+);
+metricWidth = "a-canadian";
+note = uni141B;
+unicode = 5147;
+},
+{
+glyphname = "ai-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(211,339,o),
+(242,367,o),
+(259,420,c),
+(241,420,l),
+(258,365,o),
+(292,339,o),
+(339,339,cs),
+(405,339,o),
+(451,381,o),
+(451,478,cs),
+(451,690,l),
+(393,690,l),
+(393,479,ls),
+(393,413,o),
+(368,395,o),
+(335,395,cs),
+(302,395,o),
+(278,414,o),
+(278,479,cs),
+(278,690,l),
+(221,690,l),
+(221,479,ls),
+(221,413,o),
+(196,395,o),
+(163,395,cs),
+(130,395,o),
+(107,415,o),
+(107,479,cs),
+(107,690,l),
+(49,690,l),
+(49,477,ls),
+(49,381,o),
+(96,339,o),
+(160,339,cs)
+);
+}
+);
+width = 500;
+}
+);
+metricRight = "=|";
+note = uni141C;
+unicode = 5148;
+},
+{
+glyphname = "ycreew-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(281,510,o),
+(309,545,o),
+(309,603,cs),
+(309,661,o),
+(280,696,o),
+(241,696,cs),
+(199,696,o),
+(171,661,o),
+(171,603,cs),
+(171,545,o),
+(199,510,o),
+(240,510,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(159,339,o),
+(187,374,o),
+(187,432,cs),
+(187,490,o),
+(158,525,o),
+(118,525,cs),
+(77,525,o),
+(49,490,o),
+(49,432,cs),
+(49,374,o),
+(76,339,o),
+(118,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(97,373,o),
+(84,392,o),
+(84,432,cs),
+(84,472,o),
+(97,491,o),
+(118,491,cs),
+(139,491,o),
+(153,472,o),
+(153,432,cs),
+(153,392,o),
+(139,373,o),
+(118,373,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(218,544,o),
+(206,563,o),
+(206,603,cs),
+(206,643,o),
+(218,662,o),
+(240,662,cs),
+(262,662,o),
+(274,643,o),
+(274,603,cs),
+(274,563,o),
+(262,544,o),
+(240,544,cs)
+);
+}
+);
+width = 358;
+}
+);
+metricRight = "=|";
+note = uni141D;
+unicode = 5149;
+},
+{
+glyphname = "glottalstop-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(308,345,l),
+(308,359,l),
+(185,690,l),
+(168,690,l),
+(44,359,l),
+(44,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(191,628,l),
+(161,628,l),
+(252,372,l),
+(262,392,l),
+(91,392,l),
+(99,372,l)
+);
+}
+);
+width = 352;
+}
+);
+metricRight = "=|";
+note = uni141E;
+unicode = 5150;
+},
+{
+glyphname = "en-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+pos = (577,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 828;
+}
+);
+note = uni142B;
+unicode = 5163;
+},
+{
+glyphname = "in-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+pos = (396,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 647;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142C;
+unicode = 5164;
+},
+{
+glyphname = "on-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (428,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 679;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142D;
+unicode = 5165;
+},
+{
+glyphname = "an-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (522,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 773;
+}
+);
+metricRight = "graveFinal-canadian";
+note = uni142E;
+unicode = 5166;
+},
+{
+glyphname = "pe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (287,454);
+},
+{
+name = top_center_can;
+pos = (287,690);
+},
+{
+name = top_left_can;
+pos = (106,690);
+},
+{
+name = top_right_can;
+pos = (469,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(303,0,l),
+(552,665,l),
+(552,690,l),
+(472,690,l),
+(261,107,l),
+(318,107,l),
+(106,690,l),
+(25,690,l),
+(25,665,l),
+(273,0,l)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni142F;
+unicode = 5167;
+},
+{
+glyphname = "paai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (173,0);
+ref = ring_top.canadian;
+}
+);
+width = 577;
+}
+);
+note = uni1430;
+unicode = 5168;
+},
+{
+glyphname = "pi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (288,363);
+},
+{
+name = top_center_can;
+pos = (288,690);
+},
+{
+name = top_left_can;
+pos = (107,690);
+},
+{
+name = top_right_can;
+pos = (469,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(105,0,l),
+(316,582,l),
+(259,582,l),
+(471,0,l),
+(552,0,l),
+(552,25,l),
+(303,690,l),
+(273,690,l),
+(25,25,l),
+(25,0,l)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni1431;
+unicode = 5169;
+},
+{
+glyphname = "pii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (220,0);
+ref = dot_top;
+}
+);
+width = 577;
+}
+);
+note = uni1432;
+unicode = 5170;
+},
+{
+glyphname = "po-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (163,345);
+},
+{
+name = top_center_can;
+pos = (265,690);
+},
+{
+name = top_double;
+pos = (358,690);
+},
+{
+name = top_left_can;
+pos = (79,690);
+},
+{
+name = top_right_can;
+pos = (455,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(64,0,l),
+(497,328,l),
+(497,361,l),
+(64,690,l),
+(41,690,l),
+(41,607,l),
+(411,325,l),
+(411,366,l),
+(41,84,l),
+(41,0,l)
+);
+}
+);
+width = 526;
+}
+);
+metricRight = "o-canadian";
+note = uni1433;
+unicode = 5171;
+},
+{
+glyphname = "poo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (12,0);
+ref = dot_top;
+}
+);
+width = 526;
+}
+);
+note = uni1434;
+unicode = 5172;
+},
+{
+glyphname = "ycreepoo-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (144,0);
+ref = doubledot_top;
+}
+);
+width = 526;
+}
+);
+note = uni1435;
+unicode = 5173;
+},
+{
+glyphname = "heeCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (125,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 526;
+}
+);
+note = uni1436;
+unicode = 5174;
+},
+{
+glyphname = "hiCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (104,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 526;
+}
+);
+note = uni1437;
+unicode = 5175;
+},
+{
+glyphname = "pa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (284,345);
+},
+{
+name = top_center_can;
+pos = (263,690);
+},
+{
+name = top_left_can;
+pos = (72,690);
+},
+{
+name = top_right_can;
+pos = (447,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(486,0,l),
+(486,83,l),
+(116,365,l),
+(116,324,l),
+(486,606,l),
+(486,690,l),
+(463,690,l),
+(29,361,l),
+(29,328,l),
+(463,0,l)
+);
+}
+);
+width = 527;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1438;
+unicode = 5176;
+},
+{
+glyphname = "paa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (380,0);
+ref = dot_top;
+}
+);
+width = 526;
+}
+);
+note = uni1439;
+unicode = 5177;
+},
+{
+glyphname = "pwe-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "pe-canadian";
+}
+);
+width = 761;
+}
+);
+note = uni143A;
+unicode = 5178;
+},
+{
+glyphname = "pweWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "pe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (577,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 761;
+}
+);
+note = uni143B;
+unicode = 5179;
+},
+{
+glyphname = "pwi-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "pi-canadian";
+}
+);
+width = 761;
+}
+);
+note = uni143C;
+unicode = 5180;
+},
+{
+glyphname = "pwiWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (577,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 761;
+}
+);
+note = uni143D;
+unicode = 5181;
+},
+{
+glyphname = "pwii-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (406,0);
+ref = dot_top;
+}
+);
+width = 761;
+}
+);
+note = uni143E;
+unicode = 5182;
+},
+{
+glyphname = "pwiiWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (220,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (577,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 761;
+}
+);
+note = uni143F;
+unicode = 5183;
+},
+{
+glyphname = "pwo-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "po-canadian";
+}
+);
+width = 711;
+}
+);
+note = uni1440;
+unicode = 5184;
+},
+{
+glyphname = "pwoWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (526,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 711;
+}
+);
+note = uni1441;
+unicode = 5185;
+},
+{
+glyphname = "pwoo-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (383,0);
+ref = dot_top;
+}
+);
+width = 711;
+}
+);
+note = uni1442;
+unicode = 5186;
+},
+{
+glyphname = "pwooWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (12,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (526,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 711;
+}
+);
+note = uni1443;
+unicode = 5187;
+},
+{
+glyphname = "pwa-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "pa-canadian";
+}
+);
+width = 711;
+}
+);
+note = uni1444;
+unicode = 5188;
+},
+{
+glyphname = "pwaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (526,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 711;
+}
+);
+note = uni1445;
+unicode = 5189;
+},
+{
+glyphname = "pwaa-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (565,0);
+ref = dot_top;
+}
+);
+width = 711;
+}
+);
+note = uni1446;
+unicode = 5190;
+},
+{
+glyphname = "pwaaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (380,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (526,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 711;
+}
+);
+note = uni1447;
+unicode = 5191;
+},
+{
+glyphname = "ycreepwaa-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+pos = (99,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (239,-94);
+ref = dot_top;
+}
+);
+width = 527;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1448;
+unicode = 5192;
+},
+{
+glyphname = "p-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(274,345,l),
+(274,403,l),
+(97,540,l),
+(97,496,l),
+(274,632,l),
+(274,690,l),
+(262,690,l),
+(49,527,l),
+(49,508,l),
+(262,345,l)
+);
+}
+);
+width = 324;
+}
+);
+note = uni1449;
+unicode = 5193;
+},
+{
+glyphname = "pWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(111,345,l),
+(111,690,l),
+(49,690,l),
+(49,345,l)
+);
+}
+);
+width = 160;
+}
+);
+metricRight = "=|";
+note = uni144A;
+unicode = 5194;
+},
+{
+color = 6;
+glyphname = "hCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(111,183,l),
+(111,323,ls),
+(111,358,o),
+(128,380,o),
+(158,380,cs),
+(187,380,o),
+(200,360,o),
+(200,323,cs),
+(200,183,l),
+(262,183,l),
+(262,333,ls),
+(262,405,o),
+(219,435,o),
+(174,435,cs),
+(131,435,o),
+(101,408,o),
+(97,371,c),
+(111,361,l),
+(111,527,l),
+(49,527,l),
+(49,183,l)
+);
+}
+);
+width = 296;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144B;
+unicode = 5195;
+},
+{
+glyphname = "te-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (291,345);
+},
+{
+name = top_center_can;
+pos = (291,690);
+},
+{
+name = top_left_can;
+pos = (102,690);
+},
+{
+name = top_right_can;
+pos = (480,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,-13,o),
+(526,78,o),
+(526,253,cs),
+(526,690,l),
+(435,690,l),
+(435,253,ls),
+(435,127,o),
+(384,71,o),
+(291,71,cs),
+(200,71,o),
+(147,129,o),
+(147,253,cs),
+(147,690,l),
+(56,690,l),
+(56,251,ls),
+(56,78,o),
+(145,-13,o),
+(291,-13,cs)
+);
+}
+);
+width = 582;
+}
+);
+metricRight = "=|";
+note = uni144C;
+unicode = 5196;
+},
+{
+glyphname = "taai-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (175,0);
+ref = ring_top.canadian;
+}
+);
+width = 582;
+}
+);
+note = uni144D;
+unicode = 5197;
+},
+{
+glyphname = "ti-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (291,345);
+},
+{
+name = middle_right_can;
+pos = (633,345);
+},
+{
+name = top_center_can;
+pos = (291,690);
+},
+{
+name = top_left_can;
+pos = (102,690);
+},
+{
+name = top_right_can;
+pos = (480,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(147,0,l),
+(147,437,ls),
+(147,562,o),
+(198,618,o),
+(291,618,cs),
+(382,618,o),
+(435,560,o),
+(435,437,cs),
+(435,0,l),
+(526,0,l),
+(526,439,ls),
+(526,611,o),
+(438,702,o),
+(291,702,cs),
+(146,702,o),
+(56,611,o),
+(56,437,cs),
+(56,0,l)
+);
+}
+);
+width = 582;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni144E;
+unicode = 5198;
+},
+{
+glyphname = "tii-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (223,0);
+ref = dot_top;
+}
+);
+width = 582;
+}
+);
+note = uni144F;
+unicode = 5199;
+},
+{
+glyphname = "to-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (195,345);
+},
+{
+name = middle_right_can;
+pos = (545,345);
+},
+{
+name = top_center_can;
+pos = (219,690);
+},
+{
+name = top_double;
+pos = (274,690);
+},
+{
+name = top_left_can;
+pos = (80,690);
+},
+{
+name = top_right_can;
+pos = (399,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(136,0,ls),
+(335,0,o),
+(438,120,o),
+(438,346,cs),
+(438,572,o),
+(335,690,o),
+(133,690,cs),
+(42,690,l),
+(42,607,l),
+(134,607,ls),
+(279,607,o),
+(348,524,o),
+(348,346,cs),
+(348,169,o),
+(279,83,o),
+(137,83,cs),
+(42,83,l),
+(42,0,l)
+);
+}
+);
+width = 487;
+}
+);
+note = uni1450;
+unicode = 5200;
+},
+{
+glyphname = "too-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (152,0);
+ref = dot_top;
+}
+);
+width = 487;
+}
+);
+note = uni1451;
+unicode = 5201;
+},
+{
+glyphname = "ycreetoo-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (59,0);
+ref = doubledot_top;
+}
+);
+width = 487;
+}
+);
+note = uni1452;
+unicode = 5202;
+},
+{
+glyphname = "deeCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (151,0);
+ref = stroke_middle;
+}
+);
+width = 487;
+}
+);
+note = uni1453;
+unicode = 5203;
+},
+{
+glyphname = "diCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (128,0);
+ref = dot_middle;
+}
+);
+width = 487;
+}
+);
+note = uni1454;
+unicode = 5204;
+},
+{
+glyphname = "ta-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (293,345);
+},
+{
+name = top_center_can;
+pos = (269,690);
+},
+{
+name = top_left_can;
+pos = (88,690);
+},
+{
+name = top_right_can;
+pos = (407,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(445,0,l),
+(445,83,l),
+(353,83,ls),
+(208,83,o),
+(140,167,o),
+(140,344,cs),
+(140,521,o),
+(208,607,o),
+(350,607,cs),
+(445,607,l),
+(445,690,l),
+(351,690,ls),
+(152,690,o),
+(49,570,o),
+(49,344,cs),
+(49,118,o),
+(152,0,o),
+(354,0,cs)
+);
+}
+);
+width = 487;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|to-canadian";
+note = uni1455;
+unicode = 5205;
+},
+{
+glyphname = "taa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (201,0);
+ref = dot_top;
+}
+);
+width = 487;
+}
+);
+note = uni1456;
+unicode = 5206;
+},
+{
+glyphname = "twe-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "te-canadian";
+}
+);
+width = 767;
+}
+);
+note = uni1457;
+unicode = 5207;
+},
+{
+glyphname = "tweWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (582,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 767;
+}
+);
+note = uni1458;
+unicode = 5208;
+},
+{
+glyphname = "twi-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ti-canadian";
+}
+);
+width = 767;
+}
+);
+note = uni1459;
+unicode = 5209;
+},
+{
+glyphname = "twiWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (582,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 767;
+}
+);
+note = uni145A;
+unicode = 5210;
+},
+{
+glyphname = "twii-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (408,0);
+ref = dot_top;
+}
+);
+width = 767;
+}
+);
+note = uni145B;
+unicode = 5211;
+},
+{
+glyphname = "twiiWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (223,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (582,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 767;
+}
+);
+note = uni145C;
+unicode = 5212;
+},
+{
+glyphname = "two-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "to-canadian";
+}
+);
+width = 672;
+}
+);
+note = uni145D;
+unicode = 5213;
+},
+{
+glyphname = "twoWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (487,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 672;
+}
+);
+note = uni145E;
+unicode = 5214;
+},
+{
+glyphname = "twoo-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (336,0);
+ref = dot_top;
+}
+);
+width = 672;
+}
+);
+note = uni145F;
+unicode = 5215;
+},
+{
+glyphname = "twooWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (152,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (487,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 672;
+}
+);
+note = uni1460;
+unicode = 5216;
+},
+{
+glyphname = "twa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ta-canadian";
+}
+);
+width = 672;
+}
+);
+note = uni1461;
+unicode = 5217;
+},
+{
+glyphname = "twaWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (487,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 672;
+}
+);
+note = uni1462;
+unicode = 5218;
+},
+{
+glyphname = "twaa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (386,0);
+ref = dot_top;
+}
+);
+width = 672;
+}
+);
+note = uni1463;
+unicode = 5219;
+},
+{
+glyphname = "twaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (201,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (487,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 672;
+}
+);
+note = uni1464;
+unicode = 5220;
+},
+{
+glyphname = "twaaNaskapi-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (195,0);
+ref = "ta-canadian";
+}
+);
+width = 682;
+}
+);
+note = uni1465;
+unicode = 5221;
+},
+{
+glyphname = "t-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(245,345,l),
+(245,404,l),
+(213,404,ls),
+(143,404,o),
+(109,442,o),
+(109,517,cs),
+(109,590,o),
+(143,631,o),
+(213,631,cs),
+(245,631,l),
+(245,690,l),
+(207,690,ls),
+(103,690,o),
+(47,624,o),
+(47,517,cs),
+(47,410,o),
+(103,345,o),
+(208,345,cs)
+);
+}
+);
+width = 293;
+}
+);
+note = uni1466;
+unicode = 5222;
+},
+{
+glyphname = "tte-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+pos = (582,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 742;
+}
+);
+note = uni1467;
+unicode = 5223;
+},
+{
+glyphname = "tti-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+pos = (582,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 742;
+}
+);
+note = uni1468;
+unicode = 5224;
+},
+{
+glyphname = "tto-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+pos = (487,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 647;
+}
+);
+note = uni1469;
+unicode = 5225;
+},
+{
+glyphname = "tta-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+pos = (487,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 647;
+}
+);
+note = uni146A;
+unicode = 5226;
+},
+{
+glyphname = "ke-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (249,441);
+},
+{
+name = top_center_can;
+pos = (237,690);
+},
+{
+name = top_left_can;
+pos = (94,690);
+},
+{
+name = top_right_can;
+pos = (380,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(424,0,l),
+(424,446,ls),
+(424,611,o),
+(359,702,o),
+(240,702,cs),
+(120,702,o),
+(49,610,o),
+(49,447,cs),
+(49,293,o),
+(118,198,o),
+(226,198,cs),
+(287,198,o),
+(332,239,o),
+(343,293,c),
+(334,317,l),
+(334,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(174,276,o),
+(137,331,o),
+(137,451,cs),
+(137,570,o),
+(173,625,o),
+(237,625,cs),
+(300,625,o),
+(336,571,o),
+(336,451,cs),
+(336,331,o),
+(298,276,o),
+(237,276,cs)
+);
+}
+);
+width = 480;
+}
+);
+metricRight = "te-canadian";
+note = uni146B;
+unicode = 5227;
+},
+{
+glyphname = "kaai-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (128,0);
+ref = ring_top.canadian;
+}
+);
+width = 481;
+}
+);
+note = uni146C;
+unicode = 5228;
+},
+{
+glyphname = "ki-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (256,441);
+},
+{
+name = top_center_can;
+pos = (243,690);
+},
+{
+name = top_left_can;
+pos = (101,690);
+},
+{
+name = top_right_can;
+pos = (387,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(147,0,l),
+(147,317,l),
+(138,293,l),
+(149,239,o),
+(193,198,o),
+(255,198,cs),
+(363,198,o),
+(432,293,o),
+(432,448,cs),
+(432,610,o),
+(361,702,o),
+(243,702,cs),
+(122,702,o),
+(56,608,o),
+(56,446,cs),
+(56,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(182,276,o),
+(145,331,o),
+(145,451,cs),
+(145,571,o),
+(180,625,o),
+(243,625,cs),
+(308,625,o),
+(343,570,o),
+(343,451,cs),
+(343,331,o),
+(306,276,o),
+(243,276,cs)
+);
+}
+);
+width = 481;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni146D;
+unicode = 5229;
+},
+{
+glyphname = "kii-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (176,0);
+ref = dot_top;
+}
+);
+width = 481;
+}
+);
+note = uni146E;
+unicode = 5230;
+},
+{
+glyphname = "ko-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (249,362);
+},
+{
+name = top_center_can;
+pos = (237,690);
+},
+{
+name = top_double;
+pos = (380,690);
+},
+{
+name = top_left_can;
+pos = (94,690);
+},
+{
+name = top_right_can;
+pos = (380,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(358,-13,o),
+(424,78,o),
+(424,243,cs),
+(424,690,l),
+(334,690,l),
+(334,373,l),
+(343,397,l),
+(332,451,o),
+(287,492,o),
+(226,492,cs),
+(118,492,o),
+(49,397,o),
+(49,238,cs),
+(49,80,o),
+(118,-13,o),
+(239,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(173,65,o),
+(137,120,o),
+(137,239,cs),
+(137,358,o),
+(174,413,o),
+(237,413,cs),
+(298,413,o),
+(336,358,o),
+(336,239,cs),
+(336,119,o),
+(300,65,o),
+(237,65,cs)
+);
+}
+);
+width = 480;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni146F;
+unicode = 5231;
+},
+{
+glyphname = "koo-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (312,0);
+ref = dot_top;
+}
+);
+width = 481;
+}
+);
+note = uni1470;
+unicode = 5232;
+},
+{
+glyphname = "ycreekoo-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (165,0);
+ref = doubledot_top;
+}
+);
+width = 481;
+}
+);
+note = uni1471;
+unicode = 5233;
+},
+{
+glyphname = "ka-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (256,364);
+},
+{
+name = top_center_can;
+pos = (244,690);
+},
+{
+name = top_left_can;
+pos = (101,690);
+},
+{
+name = top_right_can;
+pos = (387,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(361,-13,o),
+(432,80,o),
+(432,242,cs),
+(432,397,o),
+(363,492,o),
+(255,492,cs),
+(193,492,o),
+(149,451,o),
+(138,397,c),
+(147,373,l),
+(147,690,l),
+(56,690,l),
+(56,243,ls),
+(56,78,o),
+(121,-13,o),
+(242,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(180,65,o),
+(145,119,o),
+(145,239,cs),
+(145,358,o),
+(182,413,o),
+(243,413,cs),
+(306,413,o),
+(343,358,o),
+(343,239,cs),
+(343,120,o),
+(308,65,o),
+(243,65,cs)
+);
+}
+);
+width = 481;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "==|ke-canadian";
+note = uni1472;
+unicode = 5234;
+},
+{
+glyphname = "kaa-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (34,0);
+ref = dot_top;
+}
+);
+width = 481;
+}
+);
+note = uni1473;
+unicode = 5235;
+},
+{
+glyphname = "kwe-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ke-canadian";
+}
+);
+width = 666;
+}
+);
+note = uni1474;
+unicode = 5236;
+},
+{
+glyphname = "kweWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (481,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 666;
+}
+);
+note = uni1475;
+unicode = 5237;
+},
+{
+glyphname = "kwi-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ki-canadian";
+}
+);
+width = 666;
+}
+);
+note = uni1476;
+unicode = 5238;
+},
+{
+glyphname = "kwiWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (481,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 666;
+}
+);
+note = uni1477;
+unicode = 5239;
+},
+{
+glyphname = "kwii-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (361,0);
+ref = dot_top;
+}
+);
+width = 666;
+}
+);
+note = uni1478;
+unicode = 5240;
+},
+{
+glyphname = "kwiiWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (176,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (481,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 666;
+}
+);
+note = uni1479;
+unicode = 5241;
+},
+{
+glyphname = "kwo-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ko-canadian";
+}
+);
+width = 666;
+}
+);
+note = uni147A;
+unicode = 5242;
+},
+{
+glyphname = "kwoWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (481,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 666;
+}
+);
+note = uni147B;
+unicode = 5243;
+},
+{
+glyphname = "kwoo-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (497,0);
+ref = dot_top;
+}
+);
+width = 666;
+}
+);
+note = uni147C;
+unicode = 5244;
+},
+{
+glyphname = "kwooWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (312,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (481,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 666;
+}
+);
+note = uni147D;
+unicode = 5245;
+},
+{
+glyphname = "kwa-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ka-canadian";
+}
+);
+width = 666;
+}
+);
+note = uni147E;
+unicode = 5246;
+},
+{
+glyphname = "kwaWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (481,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 666;
+}
+);
+note = uni147F;
+unicode = 5247;
+},
+{
+glyphname = "kwaa-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (219,0);
+ref = dot_top;
+}
+);
+width = 666;
+}
+);
+note = uni1480;
+unicode = 5248;
+},
+{
+glyphname = "kwaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (34,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (481,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 666;
+}
+);
+note = uni1481;
+unicode = 5249;
+},
+{
+glyphname = "kwaaNaskapi-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (195,0);
+ref = "ka-canadian";
+}
+);
+width = 675;
+}
+);
+note = uni1482;
+unicode = 5250;
+},
+{
+glyphname = "k-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(213,339,o),
+(259,383,o),
+(259,474,cs),
+(259,556,o),
+(218,601,o),
+(167,601,cs),
+(128,601,o),
+(100,574,o),
+(96,529,c),
+(111,529,l),
+(111,690,l),
+(49,690,l),
+(49,469,ls),
+(49,387,o),
+(90,339,o),
+(155,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(125,386,o),
+(106,409,o),
+(106,470,cs),
+(106,529,o),
+(127,554,o),
+(155,554,cs),
+(183,554,o),
+(203,530,o),
+(203,470,cs),
+(203,411,o),
+(184,386,o),
+(155,386,cs)
+);
+}
+);
+width = 298;
+}
+);
+note = uni1483;
+unicode = 5251;
+},
+{
+glyphname = "kw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(208,339,o),
+(248,387,o),
+(248,469,cs),
+(248,690,l),
+(186,690,l),
+(186,529,l),
+(202,529,l),
+(197,574,o),
+(168,601,o),
+(130,601,cs),
+(78,601,o),
+(39,556,o),
+(39,474,cs),
+(39,383,o),
+(85,339,o),
+(142,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(114,386,o),
+(95,411,o),
+(95,470,cs),
+(95,530,o),
+(115,554,o),
+(142,554,cs),
+(171,554,o),
+(190,529,o),
+(190,470,cs),
+(190,409,o),
+(172,386,o),
+(142,386,cs)
+);
+}
+);
+width = 297;
+}
+);
+metricLeft = "=|k-canadian";
+metricRight = "=|k-canadian";
+note = uni1484;
+unicode = 5252;
+},
+{
+glyphname = "southslaveykeh-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+pos = (481,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 640;
+}
+);
+note = uni1485;
+unicode = 5253;
+},
+{
+glyphname = "southslaveykih-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+pos = (481,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 640;
+}
+);
+note = uni1486;
+unicode = 5254;
+},
+{
+glyphname = "southslaveykoh-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+pos = (481,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 640;
+}
+);
+note = uni1487;
+unicode = 5255;
+},
+{
+glyphname = "southslaveykah-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+pos = (481,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 640;
+}
+);
+note = uni1488;
+unicode = 5256;
+},
+{
+glyphname = "ce-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (245,403);
+},
+{
+name = top_center_can;
+pos = (235,690);
+},
+{
+name = top_left_can;
+pos = (93,690);
+},
+{
+name = top_right_can;
+pos = (374,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(418,0,l),
+(418,464,ls),
+(418,612,o),
+(355,702,o),
+(235,702,cs),
+(116,702,o),
+(47,616,o),
+(47,468,cs),
+(47,387,l),
+(137,387,l),
+(137,483,ls),
+(137,572,o),
+(169,623,o),
+(234,623,cs),
+(296,623,o),
+(328,573,o),
+(328,479,cs),
+(328,0,l)
+);
+}
+);
+width = 474;
+}
+);
+metricRight = "te-canadian";
+note = uni1489;
+unicode = 5257;
+},
+{
+glyphname = "caai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (128,0);
+ref = ring_top.canadian;
+}
+);
+width = 475;
+}
+);
+note = uni148A;
+unicode = 5258;
+},
+{
+glyphname = "ci-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (254,403);
+},
+{
+name = top_center_can;
+pos = (243,690);
+},
+{
+name = top_left_can;
+pos = (102,690);
+},
+{
+name = top_right_can;
+pos = (384,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(147,0,l),
+(147,479,ls),
+(147,573,o),
+(180,623,o),
+(242,623,cs),
+(306,623,o),
+(338,572,o),
+(338,483,cs),
+(338,387,l),
+(428,387,l),
+(428,468,ls),
+(428,616,o),
+(359,702,o),
+(242,702,cs),
+(121,702,o),
+(56,612,o),
+(56,463,cs),
+(56,0,l)
+);
+}
+);
+width = 475;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+unicode = 5259;
+},
+{
+glyphname = "cii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (176,0);
+ref = dot_top;
+}
+);
+width = 475;
+}
+);
+note = uni148C;
+unicode = 5260;
+},
+{
+glyphname = "co-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (245,403);
+},
+{
+name = top_center_can;
+pos = (234,690);
+},
+{
+name = top_double;
+pos = (374,690);
+},
+{
+name = top_left_can;
+pos = (93,690);
+},
+{
+name = top_right_can;
+pos = (374,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(354,-13,o),
+(418,77,o),
+(418,227,cs),
+(418,690,l),
+(328,690,l),
+(328,211,ls),
+(328,117,o),
+(296,67,o),
+(234,67,cs),
+(169,67,o),
+(137,118,o),
+(137,207,cs),
+(137,302,l),
+(47,302,l),
+(47,222,ls),
+(47,73,o),
+(116,-13,o),
+(237,-13,cs)
+);
+}
+);
+width = 474;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+unicode = 5261;
+},
+{
+glyphname = "coo-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (306,0);
+ref = dot_top;
+}
+);
+width = 475;
+}
+);
+note = uni148E;
+unicode = 5262;
+},
+{
+glyphname = "ycreecoo-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (159,0);
+ref = doubledot_top;
+}
+);
+width = 475;
+}
+);
+note = uni148F;
+unicode = 5263;
+},
+{
+glyphname = "ca-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (254,403);
+},
+{
+name = top_center_can;
+pos = (243,690);
+},
+{
+name = top_left_can;
+pos = (102,690);
+},
+{
+name = top_right_can;
+pos = (384,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(359,-13,o),
+(428,73,o),
+(428,222,cs),
+(428,302,l),
+(338,302,l),
+(338,207,ls),
+(338,118,o),
+(306,67,o),
+(242,67,cs),
+(180,67,o),
+(147,117,o),
+(147,211,cs),
+(147,690,l),
+(56,690,l),
+(56,226,ls),
+(56,77,o),
+(121,-13,o),
+(241,-13,cs)
+);
+}
+);
+width = 475;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+unicode = 5264;
+},
+{
+glyphname = "caa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (35,0);
+ref = dot_top;
+}
+);
+width = 475;
+}
+);
+note = uni1491;
+unicode = 5265;
+},
+{
+glyphname = "cwe-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ce-canadian";
+}
+);
+width = 660;
+}
+);
+note = uni1492;
+unicode = 5266;
+},
+{
+glyphname = "cweWestCree-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (475,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 660;
+}
+);
+note = uni1493;
+unicode = 5267;
+},
+{
+glyphname = "cwi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ci-canadian";
+}
+);
+width = 660;
+}
+);
+note = uni1494;
+unicode = 5268;
+},
+{
+glyphname = "cwiWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (475,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 660;
+}
+);
+note = uni1495;
+unicode = 5269;
+},
+{
+glyphname = "cwii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (361,0);
+ref = dot_top;
+}
+);
+width = 660;
+}
+);
+note = uni1496;
+unicode = 5270;
+},
+{
+glyphname = "cwiiWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (176,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (475,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 660;
+}
+);
+note = uni1497;
+unicode = 5271;
+},
+{
+glyphname = "cwo-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "co-canadian";
+}
+);
+width = 660;
+}
+);
+note = uni1498;
+unicode = 5272;
+},
+{
+glyphname = "cwoWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (475,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 660;
+}
+);
+note = uni1499;
+unicode = 5273;
+},
+{
+glyphname = "cwoo-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (492,0);
+ref = dot_top;
+}
+);
+width = 660;
+}
+);
+note = uni149A;
+unicode = 5274;
+},
+{
+glyphname = "cwooWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (306,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (475,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 660;
+}
+);
+note = uni149B;
+unicode = 5275;
+},
+{
+glyphname = "cwa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ca-canadian";
+}
+);
+width = 660;
+}
+);
+note = uni149C;
+unicode = 5276;
+},
+{
+glyphname = "cwaWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (475,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 660;
+}
+);
+note = uni149D;
+unicode = 5277;
+},
+{
+glyphname = "cwaa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (219,0);
+ref = dot_top;
+}
+);
+width = 660;
+}
+);
+note = uni149E;
+unicode = 5278;
+},
+{
+glyphname = "cwaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (35,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (475,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 660;
+}
+);
+note = uni149F;
+unicode = 5279;
+},
+{
+glyphname = "cwaaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (195,0);
+ref = "ca-canadian";
+}
+);
+width = 670;
+}
+);
+note = uni14A0;
+unicode = 5280;
+},
+{
+glyphname = "c-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(218,339,o),
+(260,383,o),
+(260,462,cs),
+(260,487,l),
+(203,487,l),
+(203,452,ls),
+(203,412,o),
+(185,389,o),
+(156,389,cs),
+(126,389,o),
+(111,411,o),
+(111,457,cs),
+(111,690,l),
+(49,690,l),
+(49,466,ls),
+(49,383,o),
+(88,339,o),
+(156,339,cs)
+);
+}
+);
+width = 289;
+}
+);
+note = uni14A1;
+unicode = 5281;
+},
+{
+glyphname = "thSayisi-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,339,o),
+(239,383,o),
+(239,466,cs),
+(239,690,l),
+(178,690,l),
+(178,457,ls),
+(178,411,o),
+(162,389,o),
+(131,389,cs),
+(103,389,o),
+(86,412,o),
+(86,452,cs),
+(86,487,l),
+(29,487,l),
+(29,462,ls),
+(29,383,o),
+(71,339,o),
+(135,339,cs)
+);
+}
+);
+width = 288;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "=|c-canadian";
+note = uni14A2;
+unicode = 5282;
+},
+{
+glyphname = "me-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (157,345);
+},
+{
+name = top_center_can;
+pos = (205,690);
+},
+{
+name = top_left_can;
+pos = (77,690);
+},
+{
+name = top_right_can;
+pos = (327,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(371,0,l),
+(371,690,l),
+(33,690,l),
+(33,607,l),
+(281,607,l),
+(281,0,l)
+);
+}
+);
+width = 431;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+unicode = 5283;
+},
+{
+glyphname = "maai-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (114,0);
+ref = ring_top.canadian;
+}
+);
+width = 431;
+}
+);
+note = uni14A4;
+unicode = 5284;
+},
+{
+glyphname = "mi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (274,345);
+},
+{
+name = top_center_can;
+pos = (229,690);
+},
+{
+name = top_left_can;
+pos = (105,690);
+},
+{
+name = top_right_can;
+pos = (353,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(150,0,l),
+(150,607,l),
+(398,607,l),
+(398,690,l),
+(60,690,l),
+(60,0,l)
+);
+}
+);
+width = 431;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+unicode = 5285;
+},
+{
+glyphname = "mii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (161,0);
+ref = dot_top;
+}
+);
+width = 431;
+}
+);
+note = uni14A6;
+unicode = 5286;
+},
+{
+glyphname = "mo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (157,345);
+},
+{
+name = top_center_can;
+pos = (205,690);
+},
+{
+name = top_double;
+pos = (327,690);
+},
+{
+name = top_left_can;
+pos = (77,690);
+},
+{
+name = top_right_can;
+pos = (327,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(371,0,l),
+(371,690,l),
+(281,690,l),
+(281,83,l),
+(33,83,l),
+(33,0,l)
+);
+}
+);
+width = 431;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+unicode = 5287;
+},
+{
+glyphname = "moo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (259,0);
+ref = dot_top;
+}
+);
+width = 431;
+}
+);
+note = uni14A8;
+unicode = 5288;
+},
+{
+glyphname = "ycreemoo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (112,0);
+ref = doubledot_top;
+}
+);
+width = 431;
+}
+);
+note = uni14A9;
+unicode = 5289;
+},
+{
+glyphname = "ma-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (274,345);
+},
+{
+name = top_center_can;
+pos = (229,690);
+},
+{
+name = top_left_can;
+pos = (105,690);
+},
+{
+name = top_right_can;
+pos = (353,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(398,0,l),
+(398,83,l),
+(150,83,l),
+(150,690,l),
+(60,690,l),
+(60,0,l)
+);
+}
+);
+width = 431;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+unicode = 5290;
+},
+{
+glyphname = "maa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (38,0);
+ref = dot_top;
+}
+);
+width = 431;
+}
+);
+note = uni14AB;
+unicode = 5291;
+},
+{
+glyphname = "mwe-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "me-canadian";
+}
+);
+width = 616;
+}
+);
+note = uni14AC;
+unicode = 5292;
+},
+{
+glyphname = "mweWestCree-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "me-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (431,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 616;
+}
+);
+note = uni14AD;
+unicode = 5293;
+},
+{
+glyphname = "mwi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "mi-canadian";
+}
+);
+width = 616;
+}
+);
+note = uni14AE;
+unicode = 5294;
+},
+{
+glyphname = "mwiWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (431,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 616;
+}
+);
+note = uni14AF;
+unicode = 5295;
+},
+{
+glyphname = "mwii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (347,0);
+ref = dot_top;
+}
+);
+width = 616;
+}
+);
+note = uni14B0;
+unicode = 5296;
+},
+{
+glyphname = "mwiiWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (161,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (431,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 616;
+}
+);
+note = uni14B1;
+unicode = 5297;
+},
+{
+glyphname = "mwo-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "mo-canadian";
+}
+);
+width = 616;
+}
+);
+note = uni14B2;
+unicode = 5298;
+},
+{
+glyphname = "mwoWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (431,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 616;
+}
+);
+note = uni14B3;
+unicode = 5299;
+},
+{
+glyphname = "mwoo-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (443,0);
+ref = dot_top;
+}
+);
+width = 616;
+}
+);
+note = uni14B4;
+unicode = 5300;
+},
+{
+glyphname = "mwooWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (259,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (431,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 616;
+}
+);
+note = uni14B5;
+unicode = 5301;
+},
+{
+glyphname = "mwa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ma-canadian";
+}
+);
+width = 616;
+}
+);
+note = uni14B6;
+unicode = 5302;
+},
+{
+glyphname = "mwaWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (431,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 616;
+}
+);
+note = uni14B7;
+unicode = 5303;
+},
+{
+glyphname = "mwaa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (222,0);
+ref = dot_top;
+}
+);
+width = 616;
+}
+);
+note = uni14B8;
+unicode = 5304;
+},
+{
+glyphname = "mwaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (38,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (431,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 616;
+}
+);
+note = uni14B9;
+unicode = 5305;
+},
+{
+glyphname = "mwaaNaskapi-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (195,0);
+ref = "ma-canadian";
+}
+);
+width = 626;
+}
+);
+note = uni14BA;
+unicode = 5306;
+},
+{
+glyphname = "m-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(236,404,l),
+(111,404,l),
+(111,690,l),
+(49,690,l),
+(49,345,l),
+(236,345,l)
+);
+}
+);
+width = 266;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni14BB;
+unicode = 5307;
+},
+{
+glyphname = "mWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+ref = "t-canadian";
+}
+);
+width = 293;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "t-canadian";
+note = uni14BC;
+unicode = 5308;
+},
+{
+glyphname = "mh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(216,345,l),
+(216,690,l),
+(155,690,l),
+(155,404,l),
+(30,404,l),
+(30,345,l)
+);
+}
+);
+width = 265;
+}
+);
+metricLeft = "=|m-canadian";
+metricRight = "=|m-canadian";
+note = uni14BD;
+unicode = 5309;
+},
+{
+glyphname = "mAthapascan-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(246,345,l),
+(246,399,l),
+(114,399,l),
+(116,371,l),
+(195,478,ls),
+(227,522,o),
+(237,558,o),
+(237,594,cs),
+(237,652,o),
+(206,696,o),
+(143,696,cs),
+(77,696,o),
+(43,649,o),
+(42,575,c),
+(98,575,l),
+(98,629,o),
+(112,649,o),
+(141,649,cs),
+(168,649,o),
+(181,630,o),
+(181,593,cs),
+(181,565,o),
+(178,542,o),
+(144,497,cs),
+(54,377,l),
+(54,345,l)
+);
+}
+);
+width = 285;
+}
+);
+note = uni14BE;
+unicode = 5310;
+},
+{
+glyphname = "mSayisi-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = two.canadian;
+}
+);
+width = 469;
+}
+);
+note = uni14BF;
+unicode = 5311;
+},
+{
+glyphname = "ne-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (412,245);
+},
+{
+name = top_center_can;
+pos = (401,497);
+},
+{
+name = top_left_can;
+pos = (91,497);
+},
+{
+name = top_right_can;
+pos = (560,497);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(528,-13,o),
+(604,71,o),
+(604,233,cs),
+(604,395,o),
+(529,478,o),
+(400,478,cs),
+(46,478,l),
+(46,396,l),
+(298,396,l),
+(294,418,l),
+(246,385,o),
+(221,310,o),
+(221,229,cs),
+(221,71,o),
+(294,-13,o),
+(412,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(346,65,o),
+(310,119,o),
+(310,233,cs),
+(310,342,o),
+(347,401,o),
+(412,401,cs),
+(478,401,o),
+(515,348,o),
+(515,233,cs),
+(515,119,o),
+(479,65,o),
+(412,65,cs)
+);
+}
+);
+width = 653;
+}
+);
+metricRight = "=|ke-canadian";
+note = uni14C0;
+unicode = 5312;
+},
+{
+glyphname = "naai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (138,-193);
+ref = ring_top.canadian;
+}
+);
+width = 653;
+}
+);
+note = uni14C1;
+unicode = 5313;
+},
+{
+glyphname = "ni-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (242,245);
+},
+{
+name = top_center_can;
+pos = (253,497);
+},
+{
+name = top_left_can;
+pos = (94,497);
+},
+{
+name = top_right_can;
+pos = (562,497);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(358,-13,o),
+(432,71,o),
+(432,229,cs),
+(432,310,o),
+(407,385,o),
+(359,419,c),
+(355,396,l),
+(607,396,l),
+(607,478,l),
+(253,478,ls),
+(123,478,o),
+(49,392,o),
+(49,232,cs),
+(49,71,o),
+(125,-13,o),
+(241,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(174,65,o),
+(137,119,o),
+(137,234,cs),
+(137,349,o),
+(175,402,o),
+(241,402,cs),
+(306,402,o),
+(343,343,o),
+(343,234,cs),
+(343,119,o),
+(307,65,o),
+(241,65,cs)
+);
+}
+);
+width = 653;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+unicode = 5314;
+},
+{
+glyphname = "nii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (185,-193);
+ref = dot_top;
+}
+);
+width = 653;
+}
+);
+note = uni14C3;
+unicode = 5315;
+},
+{
+glyphname = "no-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (411,245);
+},
+{
+name = top_center_can;
+pos = (410,497);
+},
+{
+name = top_double;
+pos = (412,497);
+},
+{
+name = top_left_can;
+pos = (91,497);
+},
+{
+name = top_right_can;
+pos = (560,497);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(400,0,ls),
+(529,0,o),
+(604,84,o),
+(604,245,cs),
+(604,407,o),
+(528,492,o),
+(412,492,cs),
+(294,492,o),
+(221,407,o),
+(221,249,cs),
+(221,168,o),
+(246,93,o),
+(294,60,c),
+(298,82,l),
+(46,82,l),
+(46,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(347,76,o),
+(310,135,o),
+(310,244,cs),
+(310,359,o),
+(346,413,o),
+(412,413,cs),
+(479,413,o),
+(515,360,o),
+(515,244,cs),
+(515,129,o),
+(478,76,o),
+(412,76,cs)
+);
+}
+);
+width = 653;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14C4;
+unicode = 5316;
+},
+{
+glyphname = "noo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (342,-193);
+ref = dot_top;
+}
+);
+width = 653;
+}
+);
+note = uni14C5;
+unicode = 5317;
+},
+{
+glyphname = "ycreenoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (198,-193);
+ref = doubledot_top;
+}
+);
+width = 653;
+}
+);
+note = uni14C6;
+unicode = 5318;
+},
+{
+glyphname = "na-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (242,245);
+},
+{
+name = top_center_can;
+pos = (242,497);
+},
+{
+name = top_double;
+pos = (371,497);
+},
+{
+name = top_left_can;
+pos = (94,497);
+},
+{
+name = top_right_can;
+pos = (562,497);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(607,0,l),
+(607,82,l),
+(355,82,l),
+(359,60,l),
+(407,93,o),
+(432,168,o),
+(432,249,cs),
+(432,407,o),
+(358,492,o),
+(241,492,cs),
+(125,492,o),
+(49,407,o),
+(49,245,cs),
+(49,84,o),
+(123,0,o),
+(253,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(175,76,o),
+(137,129,o),
+(137,244,cs),
+(137,360,o),
+(174,413,o),
+(241,413,cs),
+(307,413,o),
+(343,359,o),
+(343,244,cs),
+(343,135,o),
+(306,76,o),
+(241,76,cs)
+);
+}
+);
+width = 653;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+unicode = 5319;
+},
+{
+glyphname = "naa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (175,-193);
+ref = dot_top;
+}
+);
+width = 653;
+}
+);
+note = uni14C8;
+unicode = 5320;
+},
+{
+glyphname = "nwe-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ne-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni14C9;
+unicode = 5321;
+},
+{
+glyphname = "nweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni14CA;
+unicode = 5322;
+},
+{
+glyphname = "nwa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "na-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni14CB;
+unicode = 5323;
+},
+{
+glyphname = "nwaWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni14CC;
+unicode = 5324;
+},
+{
+glyphname = "nwaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (360,-193);
+ref = dot_top;
+}
+);
+width = 838;
+}
+);
+note = uni14CD;
+unicode = 5325;
+},
+{
+glyphname = "nwaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (175,-193);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni14CE;
+unicode = 5326;
+},
+{
+glyphname = "nwaaNaskapi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (156,-193);
+ref = doubledot_top;
+}
+);
+width = 653;
+}
+);
+note = uni14CF;
+unicode = 5327;
+},
+{
+glyphname = "n-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(343,434,l),
+(343,493,l),
+(203,493,l),
+(206,466,l),
+(231,479,o),
+(245,522,o),
+(245,568,cs),
+(245,649,o),
+(207,696,o),
+(142,696,cs),
+(78,696,o),
+(39,648,o),
+(39,565,cs),
+(39,483,o),
+(78,434,o),
+(147,434,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(112,481,o),
+(94,507,o),
+(94,565,cs),
+(94,623,o),
+(112,648,o),
+(143,648,cs),
+(173,648,o),
+(189,622,o),
+(189,565,cs),
+(189,507,o),
+(172,481,o),
+(142,481,cs)
+);
+}
+);
+width = 373;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni14D0;
+unicode = 5328;
+},
+{
+color = 6;
+glyphname = "ngCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-161);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 340;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "=|";
+note = uni14D1;
+unicode = 5329;
+},
+{
+glyphname = "nh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(226,434,ls),
+(295,434,o),
+(334,483,o),
+(334,565,cs),
+(334,648,o),
+(295,696,o),
+(231,696,cs),
+(166,696,o),
+(128,649,o),
+(128,568,cs),
+(128,522,o),
+(142,479,o),
+(167,466,c),
+(170,493,l),
+(30,493,l),
+(30,434,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(201,481,o),
+(183,507,o),
+(183,565,cs),
+(183,622,o),
+(200,648,o),
+(230,648,cs),
+(260,648,o),
+(279,623,o),
+(279,565,cs),
+(279,507,o),
+(260,481,o),
+(231,481,cs)
+);
+}
+);
+width = 373;
+}
+);
+metricLeft = "=|n-canadian";
+metricRight = "=|n-canadian";
+note = uni14D2;
+unicode = 5330;
+},
+{
+glyphname = "le-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (412,245);
+},
+{
+name = top_center_can;
+pos = (403,497);
+},
+{
+name = top_left_can;
+pos = (91,497);
+},
+{
+name = top_right_can;
+pos = (559,497);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(379,0,ls),
+(519,0,o),
+(604,83,o),
+(604,239,cs),
+(604,394,o),
+(522,478,o),
+(378,478,cs),
+(46,478,l),
+(46,396,l),
+(374,396,ls),
+(465,396,o),
+(514,343,o),
+(514,238,cs),
+(514,133,o),
+(466,80,o),
+(371,80,cs),
+(355,80,l),
+(355,0,l)
+);
+}
+);
+width = 653;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D3;
+unicode = 5331;
+},
+{
+glyphname = "laai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (138,-193);
+ref = ring_top.canadian;
+}
+);
+width = 653;
+}
+);
+note = uni14D4;
+unicode = 5332;
+},
+{
+glyphname = "li-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (242,245);
+},
+{
+name = top_center_can;
+pos = (253,497);
+},
+{
+name = top_left_can;
+pos = (94,497);
+},
+{
+name = top_right_can;
+pos = (562,497);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(297,0,l),
+(297,80,l),
+(281,80,ls),
+(187,80,o),
+(138,133,o),
+(138,238,cs),
+(138,342,o),
+(187,396,o),
+(279,396,cs),
+(607,396,l),
+(607,478,l),
+(275,478,ls),
+(135,478,o),
+(49,394,o),
+(49,239,cs),
+(49,83,o),
+(133,0,o),
+(274,0,cs)
+);
+}
+);
+width = 653;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14D5;
+unicode = 5333;
+},
+{
+glyphname = "lii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (185,-193);
+ref = dot_top;
+}
+);
+width = 653;
+}
+);
+note = uni14D6;
+unicode = 5334;
+},
+{
+glyphname = "lo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (411,245);
+},
+{
+name = top_center_can;
+pos = (410,497);
+},
+{
+name = top_double;
+pos = (379,497);
+},
+{
+name = top_left_can;
+pos = (91,497);
+},
+{
+name = top_right_can;
+pos = (559,497);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(378,0,ls),
+(518,0,o),
+(604,84,o),
+(604,240,cs),
+(604,395,o),
+(519,478,o),
+(379,478,cs),
+(355,478,l),
+(355,398,l),
+(371,398,ls),
+(466,398,o),
+(514,345,o),
+(514,241,cs),
+(514,135,o),
+(465,82,o),
+(374,82,cs),
+(46,82,l),
+(46,0,l)
+);
+}
+);
+width = 653;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D7;
+unicode = 5335;
+},
+{
+glyphname = "loo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (342,-193);
+ref = dot_top;
+}
+);
+width = 653;
+}
+);
+note = uni14D8;
+unicode = 5336;
+},
+{
+glyphname = "ycreeloo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (164,-193);
+ref = doubledot_top;
+}
+);
+width = 653;
+}
+);
+note = uni14D9;
+unicode = 5337;
+},
+{
+glyphname = "la-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (242,245);
+},
+{
+name = top_center_can;
+pos = (242,497);
+},
+{
+name = top_left_can;
+pos = (94,497);
+},
+{
+name = top_right_can;
+pos = (562,497);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(607,0,l),
+(607,82,l),
+(279,82,ls),
+(187,82,o),
+(138,135,o),
+(138,241,cs),
+(138,345,o),
+(187,398,o),
+(281,398,cs),
+(297,398,l),
+(297,478,l),
+(274,478,ls),
+(133,478,o),
+(49,394,o),
+(49,240,cs),
+(49,84,o),
+(135,0,o),
+(275,0,cs)
+);
+}
+);
+width = 653;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14DA;
+unicode = 5338;
+},
+{
+glyphname = "laa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (175,-193);
+ref = dot_top;
+}
+);
+width = 653;
+}
+);
+note = uni14DB;
+unicode = 5339;
+},
+{
+glyphname = "lwe-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "le-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni14DC;
+unicode = 5340;
+},
+{
+glyphname = "lweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "le-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni14DD;
+unicode = 5341;
+},
+{
+glyphname = "lwi-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "li-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni14DE;
+unicode = 5342;
+},
+{
+glyphname = "lwiWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni14DF;
+unicode = 5343;
+},
+{
+glyphname = "lwii-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (371,-193);
+ref = dot_top;
+}
+);
+width = 838;
+}
+);
+note = uni14E0;
+unicode = 5344;
+},
+{
+glyphname = "lwiiWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (185,-193);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni14E1;
+unicode = 5345;
+},
+{
+glyphname = "lwo-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "lo-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni14E2;
+unicode = 5346;
+},
+{
+glyphname = "lwoWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni14E3;
+unicode = 5347;
+},
+{
+glyphname = "lwoo-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (526,-193);
+ref = dot_top;
+}
+);
+width = 838;
+}
+);
+note = uni14E4;
+unicode = 5348;
+},
+{
+glyphname = "lwooWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (342,-193);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni14E5;
+unicode = 5349;
+},
+{
+glyphname = "lwa-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "la-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni14E6;
+unicode = 5350;
+},
+{
+glyphname = "lwaWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni14E7;
+unicode = 5351;
+},
+{
+glyphname = "lwaa-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (360,-193);
+ref = dot_top;
+}
+);
+width = 838;
+}
+);
+note = uni14E8;
+unicode = 5352;
+},
+{
+glyphname = "lwaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (175,-193);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni14E9;
+unicode = 5353;
+},
+{
+glyphname = "l-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(339,345,l),
+(339,404,l),
+(213,404,ls),
+(143,404,o),
+(109,442,o),
+(109,517,cs),
+(109,590,o),
+(143,631,o),
+(206,631,cs),
+(212,631,l),
+(212,690,l),
+(202,690,ls),
+(103,690,o),
+(47,624,o),
+(47,517,cs),
+(47,410,o),
+(103,345,o),
+(208,345,cs)
+);
+}
+);
+width = 369;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "m-canadian";
+note = uni14EA;
+unicode = 5354;
+},
+{
+glyphname = "lWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(241,345,l),
+(241,387,l),
+(92,462,l),
+(92,431,l),
+(241,502,l),
+(241,532,l),
+(92,605,l),
+(92,573,l),
+(241,646,l),
+(241,690,l),
+(230,690,l),
+(49,601,l),
+(49,577,l),
+(199,505,l),
+(199,528,l),
+(49,458,l),
+(49,434,l),
+(230,345,l)
+);
+}
+);
+width = 290;
+}
+);
+metricRight = "=|";
+note = uni14EB;
+unicode = 5355;
+},
+{
+glyphname = "mediall-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(455,-13,l),
+(455,55,l),
+(133,213,l),
+(133,173,l),
+(455,325,l),
+(455,365,l),
+(133,517,l),
+(133,477,l),
+(455,635,l),
+(455,702,l),
+(432,702,l),
+(55,518,l),
+(55,480,l),
+(378,328,l),
+(378,361,l),
+(55,210,l),
+(55,172,l),
+(432,-13,l)
+);
+}
+);
+width = 510;
+}
+);
+metricRight = "=|";
+note = uni14EC;
+unicode = 5356;
+},
+{
+glyphname = "se-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (103,690);
+},
+{
+name = top_right_can;
+pos = (333,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(379,0,l),
+(379,331,l),
+(343,331,ls),
+(213,331,o),
+(149,389,o),
+(149,553,cs),
+(149,690,l),
+(58,690,l),
+(58,547,ls),
+(58,346,o),
+(153,249,o),
+(327,249,cs),
+(356,249,l),
+(289,280,l),
+(289,0,l)
+);
+}
+);
+width = 439;
+}
+);
+note = uni14ED;
+unicode = 5357;
+},
+{
+glyphname = "saai-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (220,0);
+ref = ring_top.canadian;
+}
+);
+width = 439;
+}
+);
+note = uni14EE;
+unicode = 5358;
+},
+{
+glyphname = "si-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (105,690);
+},
+{
+name = top_right_can;
+pos = (336,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(151,0,l),
+(151,280,l),
+(83,249,l),
+(112,249,ls),
+(287,249,o),
+(381,346,o),
+(381,547,cs),
+(381,690,l),
+(290,690,l),
+(290,553,ls),
+(290,389,o),
+(226,331,o),
+(96,331,cs),
+(60,331,l),
+(60,0,l)
+);
+}
+);
+width = 439;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+unicode = 5359;
+},
+{
+glyphname = "sii-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (269,0);
+ref = dot_top;
+}
+);
+width = 439;
+}
+);
+note = uni14F0;
+unicode = 5360;
+},
+{
+glyphname = "so-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (334,690);
+},
+{
+name = top_left_can;
+pos = (104,690);
+},
+{
+name = top_right_can;
+pos = (333,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(149,0,l),
+(149,137,ls),
+(149,300,o),
+(213,358,o),
+(343,358,cs),
+(379,358,l),
+(379,690,l),
+(289,690,l),
+(289,410,l),
+(356,440,l),
+(327,440,ls),
+(153,440,o),
+(58,344,o),
+(58,143,cs),
+(58,0,l)
+);
+}
+);
+width = 439;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+unicode = 5361;
+},
+{
+glyphname = "soo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (266,0);
+ref = dot_top;
+}
+);
+width = 439;
+}
+);
+note = uni14F2;
+unicode = 5362;
+},
+{
+glyphname = "ycreesoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (120,0);
+ref = doubledot_top;
+}
+);
+width = 439;
+}
+);
+note = uni14F3;
+unicode = 5363;
+},
+{
+glyphname = "sa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (105,690);
+},
+{
+name = top_right_can;
+pos = (336,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(381,0,l),
+(381,143,ls),
+(381,344,o),
+(287,440,o),
+(112,440,cs),
+(83,440,l),
+(151,410,l),
+(151,690,l),
+(60,690,l),
+(60,358,l),
+(96,358,ls),
+(226,358,o),
+(290,300,o),
+(290,137,cs),
+(290,0,l)
+);
+}
+);
+width = 439;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+unicode = 5364;
+},
+{
+glyphname = "saa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (38,0);
+ref = dot_top;
+}
+);
+width = 439;
+}
+);
+note = uni14F5;
+unicode = 5365;
+},
+{
+glyphname = "swe-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "se-canadian";
+}
+);
+width = 624;
+}
+);
+note = uni14F6;
+unicode = 5366;
+},
+{
+glyphname = "sweWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "se-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (439,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 624;
+}
+);
+note = uni14F7;
+unicode = 5367;
+},
+{
+glyphname = "swi-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "si-canadian";
+}
+);
+width = 624;
+}
+);
+note = uni14F8;
+unicode = 5368;
+},
+{
+glyphname = "swiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (439,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 624;
+}
+);
+note = uni14F9;
+unicode = 5369;
+},
+{
+glyphname = "swii-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (453,0);
+ref = dot_top;
+}
+);
+width = 624;
+}
+);
+note = uni14FA;
+unicode = 5370;
+},
+{
+glyphname = "swiiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (269,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (439,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 624;
+}
+);
+note = uni14FB;
+unicode = 5371;
+},
+{
+glyphname = "swo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "so-canadian";
+}
+);
+width = 624;
+}
+);
+note = uni14FC;
+unicode = 5372;
+},
+{
+glyphname = "swoWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (439,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 624;
+}
+);
+note = uni14FD;
+unicode = 5373;
+},
+{
+glyphname = "swoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (451,0);
+ref = dot_top;
+}
+);
+width = 624;
+}
+);
+note = uni14FE;
+unicode = 5374;
+},
+{
+glyphname = "swooWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (266,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (439,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 624;
+}
+);
+note = uni14FF;
+unicode = 5375;
+},
+{
+glyphname = "swa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "sa-canadian";
+}
+);
+width = 624;
+}
+);
+note = uni1500;
+unicode = 5376;
+},
+{
+glyphname = "swaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (439,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 624;
+}
+);
+note = uni1501;
+unicode = 5377;
+},
+{
+glyphname = "swaa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (223,0);
+ref = dot_top;
+}
+);
+width = 624;
+}
+);
+note = uni1502;
+unicode = 5378;
+},
+{
+glyphname = "swaaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (38,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (439,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 624;
+}
+);
+note = uni1503;
+unicode = 5379;
+},
+{
+glyphname = "swaaNaskapi-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (195,0);
+ref = "sa-canadian";
+}
+);
+width = 634;
+}
+);
+note = uni1504;
+unicode = 5380;
+},
+{
+glyphname = "s-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(236,345,l),
+(236,421,ls),
+(236,522,o),
+(185,575,o),
+(101,575,cs),
+(72,575,l),
+(111,549,l),
+(111,690,l),
+(49,690,l),
+(49,525,l),
+(80,525,ls),
+(145,525,o),
+(174,492,o),
+(174,418,cs),
+(174,345,l)
+);
+}
+);
+width = 285;
+}
+);
+metricRight = "=|";
+note = uni1505;
+unicode = 5381;
+},
+{
+color = 6;
+glyphname = "sAthapascan-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(224,177,o),
+(263,218,o),
+(263,272,cs),
+(263,316,o),
+(242,346,o),
+(196,366,cs),
+(148,386,ls),
+(119,400,o),
+(110,414,o),
+(110,439,cs),
+(110,468,o),
+(127,486,o),
+(157,486,cs),
+(188,486,o),
+(208,471,o),
+(207,425,c),
+(263,425,l),
+(264,493,o),
+(226,533,o),
+(157,533,cs),
+(94,533,o),
+(54,493,o),
+(54,438,cs),
+(54,393,o),
+(74,362,o),
+(118,344,cs),
+(166,323,ls),
+(194,310,o),
+(206,296,o),
+(206,270,cs),
+(206,240,o),
+(187,224,o),
+(157,224,cs),
+(125,224,o),
+(105,240,o),
+(106,287,c),
+(49,287,l),
+(48,215,o),
+(88,177,o),
+(156,177,cs)
+);
+}
+);
+width = 312;
+}
+);
+metricRight = "=|";
+note = uni1506;
+unicode = 5382;
+},
+{
+glyphname = "sw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(111,345,l),
+(111,418,ls),
+(111,492,o),
+(140,525,o),
+(205,525,cs),
+(236,525,l),
+(236,690,l),
+(174,690,l),
+(174,549,l),
+(213,575,l),
+(184,575,ls),
+(99,575,o),
+(49,522,o),
+(49,421,cs),
+(49,345,l)
+);
+}
+);
+width = 285;
+}
+);
+metricLeft = "=|s-canadian";
+metricRight = "=|s-canadian";
+note = uni1507;
+unicode = 5383;
+},
+{
+glyphname = "sBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(242,345,l),
+(242,404,l),
+(180,404,ls),
+(128,404,o),
+(111,425,o),
+(111,479,cs),
+(111,690,l),
+(49,690,l),
+(49,470,ls),
+(49,388,o),
+(89,345,o),
+(171,345,c)
+);
+}
+);
+width = 272;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "m-canadian";
+note = uni1508;
+unicode = 5384;
+},
+{
+glyphname = "moosecreesk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(214,217,o),
+(259,262,o),
+(259,367,cs),
+(259,507,o),
+(206,576,o),
+(97,576,cs),
+(81,576,l),
+(111,549,l),
+(111,690,l),
+(49,690,l),
+(49,526,l),
+(80,526,ls),
+(165,526,o),
+(189,489,o),
+(196,416,c),
+(213,410,l),
+(207,447,o),
+(181,477,o),
+(146,477,cs),
+(89,477,o),
+(50,430,o),
+(50,350,cs),
+(50,261,o),
+(98,217,o),
+(154,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(126,264,o),
+(105,290,o),
+(105,349,cs),
+(105,408,o),
+(126,433,o),
+(154,433,cs),
+(182,433,o),
+(202,407,o),
+(202,349,cs),
+(202,288,o),
+(184,264,o),
+(154,264,cs)
+);
+}
+);
+width = 308;
+}
+);
+metricRight = "=|";
+note = uni1509;
+unicode = 5385;
+},
+{
+glyphname = "skwNaskapi-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(211,217,o),
+(258,261,o),
+(258,350,cs),
+(258,430,o),
+(218,477,o),
+(162,477,cs),
+(128,477,o),
+(101,447,o),
+(95,410,c),
+(112,416,l),
+(118,489,o),
+(142,526,o),
+(228,526,cs),
+(259,526,l),
+(259,690,l),
+(197,690,l),
+(197,549,l),
+(226,576,l),
+(211,576,ls),
+(102,576,o),
+(49,507,o),
+(49,367,cs),
+(49,262,o),
+(93,217,o),
+(154,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(124,264,o),
+(105,288,o),
+(105,349,cs),
+(105,407,o),
+(126,433,o),
+(154,433,cs),
+(182,433,o),
+(203,408,o),
+(203,349,cs),
+(203,290,o),
+(183,264,o),
+(154,264,cs)
+);
+}
+);
+width = 308;
+}
+);
+metricLeft = "=|moosecreesk-canadian";
+metricRight = "=|moosecreesk-canadian";
+note = uni150A;
+unicode = 5386;
+},
+{
+glyphname = "swNaskapi-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(254,182,l),
+(254,248,ls),
+(254,346,o),
+(204,402,o),
+(120,402,cs),
+(91,402,l),
+(124,376,l),
+(124,509,l),
+(63,509,l),
+(63,353,l),
+(102,353,ls),
+(163,353,o),
+(192,319,o),
+(192,245,cs),
+(192,182,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(251,45,o),
+(273,68,o),
+(273,96,cs),
+(273,125,o),
+(250,147,o),
+(223,147,cs),
+(196,147,o),
+(173,125,o),
+(173,96,cs),
+(173,68,o),
+(195,45,o),
+(223,45,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(120,543,o),
+(143,565,o),
+(143,594,cs),
+(143,622,o),
+(121,645,o),
+(93,645,cs),
+(66,645,o),
+(43,622,o),
+(43,594,cs),
+(43,565,o),
+(66,543,o),
+(93,543,cs)
+);
+}
+);
+width = 316;
+}
+);
+metricRight = "=|";
+note = uni150B;
+unicode = 5387;
+},
+{
+glyphname = "spwaNaskapi-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(486,0,l),
+(486,83,l),
+(116,365,l),
+(116,324,l),
+(486,606,l),
+(486,690,l),
+(463,690,l),
+(29,361,l),
+(29,328,l),
+(463,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(136,497,o),
+(159,520,o),
+(159,548,cs),
+(159,577,o),
+(136,599,o),
+(109,599,cs),
+(82,599,o),
+(59,577,o),
+(59,548,cs),
+(59,520,o),
+(82,497,o),
+(109,497,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(287,604,l),
+(287,660,ls),
+(287,729,o),
+(253,770,o),
+(185,770,cs),
+(160,770,l),
+(204,747,l),
+(204,846,l),
+(145,846,l),
+(145,723,l),
+(168,723,ls),
+(207,723,o),
+(228,703,o),
+(228,654,cs),
+(228,604,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(414,704,o),
+(438,727,o),
+(438,755,cs),
+(438,783,o),
+(414,806,o),
+(387,806,cs),
+(360,806,o),
+(338,783,o),
+(338,755,cs),
+(338,727,o),
+(360,704,o),
+(387,704,cs)
+);
+}
+);
+width = 527;
+}
+);
+metricRight = "pa-canadian";
+metricWidth = "pa-canadian";
+note = uni150C;
+unicode = 5388;
+},
+{
+glyphname = "stwaNaskapi-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (316,0);
+ref = "ta-canadian";
+}
+);
+width = 803;
+}
+);
+note = uni150D;
+unicode = 5389;
+},
+{
+glyphname = "skwaNaskapi-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (316,0);
+ref = "ka-canadian";
+}
+);
+width = 797;
+}
+);
+note = uni150E;
+unicode = 5390;
+},
+{
+glyphname = "scwaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (316,0);
+ref = "ca-canadian";
+}
+);
+width = 791;
+}
+);
+note = uni150F;
+unicode = 5391;
+},
+{
+glyphname = "she-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (233,690);
+},
+{
+name = top_right_can;
+pos = (561,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(613,-13,o),
+(682,68,o),
+(682,227,cs),
+(682,302,l),
+(592,302,l),
+(592,213,ls),
+(592,113,o),
+(561,67,o),
+(506,67,cs),
+(447,67,o),
+(421,112,o),
+(415,218,cs),
+(405,471,ls),
+(398,621,o),
+(348,702,o),
+(230,702,cs),
+(119,702,o),
+(50,622,o),
+(50,463,cs),
+(50,387,l),
+(139,387,l),
+(139,478,ls),
+(139,577,o),
+(171,623,o),
+(226,623,cs),
+(285,623,o),
+(311,578,o),
+(316,471,cs),
+(327,218,ls),
+(334,69,o),
+(384,-13,o),
+(502,-13,cs)
+);
+}
+);
+width = 732;
+}
+);
+metricRight = "=|";
+note = uni1510;
+unicode = 5392;
+},
+{
+glyphname = "shi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (173,690);
+},
+{
+name = top_right_can;
+pos = (500,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(348,-13,o),
+(398,69,o),
+(405,218,cs),
+(415,471,ls),
+(421,578,o),
+(447,623,o),
+(506,623,cs),
+(561,623,o),
+(592,577,o),
+(592,478,cs),
+(592,387,l),
+(682,387,l),
+(682,463,ls),
+(682,622,o),
+(613,702,o),
+(501,702,cs),
+(384,702,o),
+(334,621,o),
+(327,471,cs),
+(316,218,ls),
+(311,112,o),
+(285,67,o),
+(226,67,cs),
+(171,67,o),
+(139,113,o),
+(139,213,cs),
+(139,302,l),
+(50,302,l),
+(50,227,ls),
+(50,68,o),
+(118,-13,o),
+(230,-13,cs)
+);
+}
+);
+width = 732;
+}
+);
+metricLeft = "she-canadian";
+metricRight = "she-canadian";
+note = uni1511;
+unicode = 5393;
+},
+{
+glyphname = "shii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (433,0);
+ref = dot_top;
+}
+);
+width = 732;
+}
+);
+note = uni1512;
+unicode = 5394;
+},
+{
+glyphname = "sho-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (374,497);
+},
+{
+name = top_left_can;
+pos = (232,497);
+},
+{
+name = top_right_can;
+pos = (517,497);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(295,67,l),
+(191,65,o),
+(138,105,o),
+(138,181,cs),
+(138,239,o),
+(167,275,o),
+(222,275,cs),
+(318,275,o),
+(406,122,o),
+(539,122,cs),
+(639,122,o),
+(699,192,o),
+(699,295,cs),
+(699,419,o),
+(609,494,o),
+(457,492,c),
+(454,412,l),
+(557,413,o),
+(611,373,o),
+(611,298,cs),
+(611,240,o),
+(581,203,o),
+(526,203,cs),
+(431,203,o),
+(343,357,o),
+(210,357,cs),
+(110,357,o),
+(49,287,o),
+(49,184,cs),
+(49,60,o),
+(139,-14,o),
+(292,-13,c)
+);
+}
+);
+width = 748;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1513;
+unicode = 5395;
+},
+{
+glyphname = "shoo-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (306,-193);
+ref = dot_top;
+}
+);
+width = 749;
+}
+);
+note = uni1514;
+unicode = 5396;
+},
+{
+glyphname = "sha-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (375,497);
+},
+{
+name = top_left_can;
+pos = (231,497);
+},
+{
+name = top_right_can;
+pos = (517,497);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(609,-14,o),
+(699,60,o),
+(699,184,cs),
+(699,287,o),
+(639,357,o),
+(539,357,cs),
+(406,357,o),
+(318,203,o),
+(222,203,cs),
+(167,203,o),
+(138,240,o),
+(138,298,cs),
+(138,373,o),
+(191,413,o),
+(295,412,c),
+(292,492,l),
+(139,494,o),
+(49,419,o),
+(49,295,cs),
+(49,192,o),
+(109,122,o),
+(210,122,cs),
+(343,122,o),
+(431,275,o),
+(526,275,cs),
+(581,275,o),
+(611,239,o),
+(611,181,cs),
+(611,105,o),
+(557,65,o),
+(454,67,c),
+(457,-13,l)
+);
+}
+);
+width = 748;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1515;
+unicode = 5397;
+},
+{
+glyphname = "shaa-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (307,-193);
+ref = dot_top;
+}
+);
+width = 749;
+}
+);
+note = uni1516;
+unicode = 5398;
+},
+{
+glyphname = "shwe-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "she-canadian";
+}
+);
+width = 917;
+}
+);
+note = uni1517;
+unicode = 5399;
+},
+{
+glyphname = "shweWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "she-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (732,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 917;
+}
+);
+note = uni1518;
+unicode = 5400;
+},
+{
+glyphname = "shwi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "shi-canadian";
+}
+);
+width = 917;
+}
+);
+note = uni1519;
+unicode = 5401;
+},
+{
+glyphname = "shwiWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (732,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 917;
+}
+);
+note = uni151A;
+unicode = 5402;
+},
+{
+glyphname = "shwii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (618,0);
+ref = dot_top;
+}
+);
+width = 917;
+}
+);
+note = uni151B;
+unicode = 5403;
+},
+{
+glyphname = "shwiiWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (433,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (732,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 917;
+}
+);
+note = uni151C;
+unicode = 5404;
+},
+{
+glyphname = "shwo-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "sho-canadian";
+}
+);
+width = 933;
+}
+);
+note = uni151D;
+unicode = 5405;
+},
+{
+glyphname = "shwoWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (749,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 933;
+}
+);
+note = uni151E;
+unicode = 5406;
+},
+{
+glyphname = "shwoo-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (492,-193);
+ref = dot_top;
+}
+);
+width = 933;
+}
+);
+note = uni151F;
+unicode = 5407;
+},
+{
+glyphname = "shwooWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (306,-193);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (749,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 933;
+}
+);
+note = uni1520;
+unicode = 5408;
+},
+{
+glyphname = "shwa-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "sha-canadian";
+}
+);
+width = 933;
+}
+);
+note = uni1521;
+unicode = 5409;
+},
+{
+glyphname = "shwaWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (749,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 933;
+}
+);
+note = uni1522;
+unicode = 5410;
+},
+{
+glyphname = "shwaa-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (492,-193);
+ref = dot_top;
+}
+);
+width = 933;
+}
+);
+note = uni1523;
+unicode = 5411;
+},
+{
+glyphname = "shwaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (307,-193);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (749,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 933;
+}
+);
+note = uni1524;
+unicode = 5412;
+},
+{
+glyphname = "sh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(453,289,o),
+(525,344,o),
+(525,438,cs),
+(525,520,o),
+(474,572,o),
+(400,572,cs),
+(306,572,o),
+(246,476,o),
+(178,476,cs),
+(134,476,o),
+(110,501,o),
+(110,550,cs),
+(110,605,o),
+(154,639,o),
+(236,639,c),
+(234,697,l),
+(119,697,o),
+(47,642,o),
+(47,549,cs),
+(47,467,o),
+(98,414,o),
+(172,414,cs),
+(266,414,o),
+(325,510,o),
+(394,510,cs),
+(437,510,o),
+(462,485,o),
+(462,437,cs),
+(462,382,o),
+(417,347,o),
+(336,347,c),
+(338,289,l)
+);
+}
+);
+width = 572;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni1525;
+unicode = 5413;
+},
+{
+glyphname = "ye-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (503,345);
+},
+{
+name = top_left_can;
+pos = (80,690);
+},
+{
+name = top_right_can;
+pos = (360,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(405,0,l),
+(405,323,l),
+(147,323,l),
+(153,294,l),
+(423,651,l),
+(358,701,l),
+(36,272,l),
+(36,242,l),
+(315,242,l),
+(315,0,l)
+);
+}
+);
+width = 463;
+}
+);
+note = uni1526;
+unicode = 5414;
+},
+{
+glyphname = "yaai-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-13,0);
+ref = ring_top.canadian;
+}
+);
+width = 463;
+}
+);
+note = uni1527;
+unicode = 5415;
+},
+{
+glyphname = "yi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (103,690);
+},
+{
+name = top_right_can;
+pos = (383,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(148,0,l),
+(148,242,l),
+(427,242,l),
+(427,272,l),
+(104,701,l),
+(40,651,l),
+(310,295,l),
+(316,323,l),
+(57,323,l),
+(57,0,l)
+);
+}
+);
+width = 463;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni1528;
+unicode = 5416;
+},
+{
+glyphname = "yii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+}
+);
+width = 463;
+}
+);
+note = uni1529;
+unicode = 5417;
+},
+{
+glyphname = "yo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (503,345);
+},
+{
+name = top_double;
+pos = (360,690);
+},
+{
+name = top_left_can;
+pos = (80,690);
+},
+{
+name = top_right_can;
+pos = (360,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(423,39,l),
+(152,395,l),
+(147,367,l),
+(405,367,l),
+(405,690,l),
+(315,690,l),
+(315,447,l),
+(36,447,l),
+(36,417,l),
+(358,-12,l)
+);
+}
+);
+width = 463;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152A;
+unicode = 5418;
+},
+{
+glyphname = "yoo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (293,0);
+ref = dot_top;
+}
+);
+width = 463;
+}
+);
+note = uni152B;
+unicode = 5419;
+},
+{
+glyphname = "ycreeyoo-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (146,0);
+ref = doubledot_top;
+}
+);
+width = 463;
+}
+);
+note = uni152C;
+unicode = 5420;
+},
+{
+glyphname = "ya-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (103,690);
+},
+{
+name = top_right_can;
+pos = (383,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(427,417,l),
+(427,447,l),
+(148,447,l),
+(148,690,l),
+(57,690,l),
+(57,367,l),
+(316,367,l),
+(310,396,l),
+(40,39,l),
+(104,-12,l)
+);
+}
+);
+width = 463;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152D;
+unicode = 5421;
+},
+{
+glyphname = "yaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+}
+);
+width = 463;
+}
+);
+note = uni152E;
+unicode = 5422;
+},
+{
+glyphname = "ywe-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ye-canadian";
+}
+);
+width = 647;
+}
+);
+note = uni152F;
+unicode = 5423;
+},
+{
+glyphname = "yweWestCree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ye-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (463,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 647;
+}
+);
+note = uni1530;
+unicode = 5424;
+},
+{
+glyphname = "ywi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "yi-canadian";
+}
+);
+width = 647;
+}
+);
+note = uni1531;
+unicode = 5425;
+},
+{
+glyphname = "ywiWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (463,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 647;
+}
+);
+note = uni1532;
+unicode = 5426;
+},
+{
+glyphname = "ywii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (220,0);
+ref = dot_top;
+}
+);
+width = 647;
+}
+);
+note = uni1533;
+unicode = 5427;
+},
+{
+glyphname = "ywiiWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (463,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 647;
+}
+);
+note = uni1534;
+unicode = 5428;
+},
+{
+glyphname = "ywo-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "yo-canadian";
+}
+);
+width = 647;
+}
+);
+note = uni1535;
+unicode = 5429;
+},
+{
+glyphname = "ywoWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (463,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 647;
+}
+);
+note = uni1536;
+unicode = 5430;
+},
+{
+glyphname = "ywoo-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (478,0);
+ref = dot_top;
+}
+);
+width = 647;
+}
+);
+note = uni1537;
+unicode = 5431;
+},
+{
+glyphname = "ywooWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (293,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (463,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 647;
+}
+);
+note = uni1538;
+unicode = 5432;
+},
+{
+glyphname = "ywa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ya-canadian";
+}
+);
+width = 647;
+}
+);
+note = uni1539;
+unicode = 5433;
+},
+{
+glyphname = "ywaWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (463,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 647;
+}
+);
+note = uni153A;
+unicode = 5434;
+},
+{
+glyphname = "ywaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (220,0);
+ref = dot_top;
+}
+);
+width = 647;
+}
+);
+note = uni153B;
+unicode = 5435;
+},
+{
+glyphname = "ywaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (463,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 647;
+}
+);
+note = uni153C;
+unicode = 5436;
+},
+{
+glyphname = "ywaaNaskapi-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (195,0);
+ref = "ya-canadian";
+}
+);
+width = 657;
+}
+);
+note = uni153D;
+unicode = 5437;
+},
+{
+glyphname = "y-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(250,549,l),
+(250,568,l),
+(115,568,l),
+(115,690,l),
+(53,690,l),
+(53,516,l),
+(186,516,l),
+(185,553,l),
+(49,368,l),
+(95,337,l)
+);
+}
+);
+width = 276;
+}
+);
+note = uni153E;
+unicode = 5438;
+},
+{
+glyphname = "biblecreey-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(148,622,l),
+(116,622,l),
+(191,345,l),
+(227,345,l),
+(303,622,l),
+(271,622,l),
+(324,345,l),
+(379,345,l),
+(379,361,l),
+(315,690,l),
+(270,690,l),
+(190,405,l),
+(228,405,l),
+(149,690,l),
+(103,690,l),
+(40,361,l),
+(40,345,l),
+(95,345,l)
+);
+}
+);
+width = 419;
+}
+);
+metricRight = "=|";
+note = uni153F;
+unicode = 5439;
+},
+{
+glyphname = "yWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(209,202,l),
+(209,319,l),
+(309,319,l),
+(309,378,l),
+(209,378,l),
+(209,493,l),
+(151,493,l),
+(151,378,l),
+(49,378,l),
+(49,319,l),
+(151,319,l),
+(151,202,l)
+);
+}
+);
+width = 358;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1540;
+unicode = 5440;
+},
+{
+glyphname = "yiSayisi-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,183);
+ref = "fullstop-canadian";
+}
+);
+width = 300;
+}
+);
+metricLeft = "fullstop-canadian";
+metricWidth = "fullstop-canadian";
+note = uni1541;
+unicode = 5441;
+},
+{
+glyphname = "re-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (245,497);
+},
+{
+name = top_left_can;
+pos = (103,497);
+},
+{
+name = top_right_can;
+pos = (596,497);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(366,-13,o),
+(431,73,o),
+(431,218,cs),
+(431,396,l),
+(641,396,l),
+(641,478,l),
+(343,478,l),
+(343,206,ls),
+(343,113,o),
+(309,67,o),
+(245,67,cs),
+(181,67,o),
+(148,114,o),
+(148,205,cs),
+(148,478,l),
+(58,478,l),
+(58,219,ls),
+(58,69,o),
+(127,-13,o),
+(245,-13,cs)
+);
+}
+);
+width = 687;
+}
+);
+metricRight = "=|ne-canadian";
+note = uni1542;
+unicode = 5442;
+},
+{
+glyphname = "reRCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (441,497);
+},
+{
+name = top_left_can;
+pos = (91,497);
+},
+{
+name = top_right_can;
+pos = (584,497);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(560,-13,o),
+(630,69,o),
+(630,219,cs),
+(630,478,l),
+(539,478,l),
+(539,205,ls),
+(539,114,o),
+(506,67,o),
+(441,67,cs),
+(378,67,o),
+(344,113,o),
+(344,205,cs),
+(344,478,l),
+(46,478,l),
+(46,396,l),
+(256,396,l),
+(256,218,ls),
+(256,73,o),
+(321,-13,o),
+(441,-13,cs)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1543;
+unicode = 5443;
+},
+{
+glyphname = "leWestCree-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (441,497);
+},
+{
+name = top_left_can;
+pos = (91,497);
+},
+{
+name = top_right_can;
+pos = (584,497);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(344,0,l),
+(344,272,ls),
+(344,365,o),
+(378,412,o),
+(441,412,cs),
+(506,412,o),
+(539,364,o),
+(539,273,cs),
+(539,0,l),
+(630,0,l),
+(630,260,ls),
+(630,410,o),
+(561,492,o),
+(441,492,cs),
+(321,492,o),
+(256,405,o),
+(256,260,cs),
+(256,82,l),
+(46,82,l),
+(46,0,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+unicode = 5444;
+},
+{
+glyphname = "raai-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (130,-193);
+ref = ring_top.canadian;
+}
+);
+width = 687;
+}
+);
+note = uni1545;
+unicode = 5445;
+},
+{
+glyphname = "ri-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (245,497);
+},
+{
+name = top_left_can;
+pos = (103,497);
+},
+{
+name = top_right_can;
+pos = (596,497);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(148,0,l),
+(148,273,ls),
+(148,364,o),
+(181,412,o),
+(245,412,cs),
+(309,412,o),
+(343,366,o),
+(343,273,cs),
+(343,0,l),
+(641,0,l),
+(641,82,l),
+(431,82,l),
+(431,260,ls),
+(431,405,o),
+(366,492,o),
+(245,492,cs),
+(127,492,o),
+(58,410,o),
+(58,260,cs),
+(58,0,l)
+);
+}
+);
+width = 687;
+}
+);
+metricLeft = "re-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+unicode = 5446;
+},
+{
+glyphname = "rii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (178,-193);
+ref = dot_top;
+}
+);
+width = 687;
+}
+);
+note = uni1547;
+unicode = 5447;
+},
+{
+glyphname = "ro-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (193,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(150,0,l),
+(150,270,l),
+(128,243,l),
+(187,243,ls),
+(315,243,o),
+(396,332,o),
+(396,465,cs),
+(396,603,o),
+(320,690,o),
+(175,690,cs),
+(60,690,l),
+(60,609,l),
+(165,609,ls),
+(260,609,o),
+(305,554,o),
+(305,466,cs),
+(305,378,o),
+(259,323,o),
+(166,323,cs),
+(60,323,l),
+(60,0,l)
+);
+}
+);
+width = 440;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1548;
+unicode = 5448;
+},
+{
+glyphname = "roo-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (126,0);
+ref = dot_top;
+}
+);
+width = 440;
+}
+);
+note = uni1549;
+unicode = 5449;
+},
+{
+glyphname = "loWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (205,690);
+},
+{
+name = top_left_can;
+pos = (105,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(175,0,ls),
+(320,0,o),
+(396,87,o),
+(396,225,cs),
+(396,358,o),
+(315,446,o),
+(187,446,cs),
+(128,446,l),
+(150,420,l),
+(150,690,l),
+(60,690,l),
+(60,367,l),
+(166,367,ls),
+(259,367,o),
+(305,312,o),
+(305,224,cs),
+(305,136,o),
+(260,82,o),
+(165,82,cs),
+(60,82,l),
+(60,0,l)
+);
+}
+);
+width = 440;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+unicode = 5450;
+},
+{
+glyphname = "ra-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (247,690);
+},
+{
+name = top_right_can;
+pos = (336,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(381,0,l),
+(381,323,l),
+(274,323,ls),
+(182,323,o),
+(135,378,o),
+(135,466,cs),
+(135,554,o),
+(181,609,o),
+(275,609,cs),
+(381,609,l),
+(381,690,l),
+(266,690,ls),
+(121,690,o),
+(44,603,o),
+(44,465,cs),
+(44,332,o),
+(126,243,o),
+(253,243,cs),
+(313,243,l),
+(291,270,l),
+(291,0,l)
+);
+}
+);
+width = 441;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+unicode = 5451;
+},
+{
+glyphname = "raa-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (180,0);
+ref = dot_top;
+}
+);
+width = 440;
+}
+);
+note = uni154C;
+unicode = 5452;
+},
+{
+glyphname = "laWestCree-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (336,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(381,0,l),
+(381,82,l),
+(275,82,ls),
+(181,82,o),
+(135,136,o),
+(135,224,cs),
+(135,312,o),
+(182,367,o),
+(274,367,cs),
+(381,367,l),
+(381,690,l),
+(291,690,l),
+(291,420,l),
+(313,446,l),
+(253,446,ls),
+(126,446,o),
+(44,358,o),
+(44,225,cs),
+(44,87,o),
+(121,0,o),
+(266,0,cs)
+);
+}
+);
+width = 441;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+unicode = 5453;
+},
+{
+glyphname = "rwaa-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (364,0);
+ref = dot_top;
+}
+);
+width = 625;
+}
+);
+note = uni154E;
+unicode = 5454;
+},
+{
+glyphname = "rwaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (180,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (440,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 625;
+}
+);
+note = uni154F;
+unicode = 5455;
+},
+{
+glyphname = "r-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(211,345,l),
+(211,514,l),
+(162,514,ls),
+(121,514,o),
+(98,534,o),
+(98,576,cs),
+(98,617,o),
+(122,639,o),
+(163,639,cs),
+(211,639,l),
+(211,690,l),
+(161,690,ls),
+(84,690,o),
+(39,648,o),
+(39,576,cs),
+(39,507,o),
+(82,464,o),
+(155,464,cs),
+(183,464,l),
+(149,482,l),
+(149,345,l)
+);
+}
+);
+width = 260;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni1550;
+unicode = 5456;
+},
+{
+glyphname = "rWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(61,345,l),
+(241,434,l),
+(241,458,l),
+(91,528,l),
+(91,505,l),
+(241,577,l),
+(241,601,l),
+(61,690,l),
+(49,690,l),
+(49,646,l),
+(199,573,l),
+(199,605,l),
+(49,532,l),
+(49,502,l),
+(199,431,l),
+(199,462,l),
+(49,387,l),
+(49,345,l)
+);
+}
+);
+width = 290;
+}
+);
+metricLeft = "=|lWestCree-canadian";
+metricRight = "=|lWestCree-canadian";
+note = uni1551;
+unicode = 5457;
+},
+{
+glyphname = "rMedial-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(78,-13,l),
+(469,172,l),
+(469,206,l),
+(142,357,l),
+(142,332,l),
+(469,484,l),
+(469,518,l),
+(78,702,l),
+(55,702,l),
+(55,637,l),
+(391,478,l),
+(391,520,l),
+(55,368,l),
+(55,322,l),
+(391,170,l),
+(391,212,l),
+(55,53,l),
+(55,-13,l)
+);
+}
+);
+width = 524;
+}
+);
+metricLeft = "mediall-canadian";
+metricRight = "mediall-canadian";
+note = uni1552;
+unicode = 5458;
+},
+{
+glyphname = "fe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(317,0,l),
+(597,665,l),
+(597,690,l),
+(526,690,l),
+(287,102,l),
+(309,102,l),
+(200,356,l),
+(155,351,l),
+(174,328,o),
+(197,318,o),
+(226,318,cs),
+(299,318,o),
+(357,393,o),
+(357,511,cs),
+(357,627,o),
+(308,702,o),
+(219,702,cs),
+(129,702,o),
+(80,627,o),
+(80,521,cs),
+(80,464,o),
+(93,412,o),
+(120,355,cs),
+(287,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(175,381,o),
+(152,431,o),
+(152,518,cs),
+(152,600,o),
+(177,638,o),
+(219,638,cs),
+(262,638,o),
+(286,600,o),
+(286,510,cs),
+(286,420,o),
+(262,381,o),
+(220,381,cs)
+);
+}
+);
+width = 622;
+}
+);
+metricRight = "e-canadian";
+note = uni1553;
+unicode = 5459;
+},
+{
+glyphname = "faai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (188,0);
+ref = ring_top.canadian;
+}
+);
+width = 621;
+}
+);
+note = uni1554;
+unicode = 5460;
+},
+{
+glyphname = "fi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (303,690);
+},
+{
+name = top_left_can;
+pos = (117,690);
+},
+{
+name = top_right_can;
+pos = (509,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(308,-13,o),
+(357,63,o),
+(357,179,cs),
+(357,297,o),
+(299,372,o),
+(226,372,cs),
+(197,372,o),
+(174,361,o),
+(155,339,c),
+(200,333,l),
+(309,587,l),
+(287,587,l),
+(526,0,l),
+(597,0,l),
+(597,25,l),
+(317,690,l),
+(287,690,l),
+(120,334,ls),
+(93,277,o),
+(80,226,o),
+(80,169,cs),
+(80,63,o),
+(129,-13,o),
+(219,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(177,52,o),
+(152,90,o),
+(152,172,cs),
+(152,259,o),
+(175,309,o),
+(220,309,cs),
+(262,309,o),
+(286,270,o),
+(286,180,cs),
+(286,90,o),
+(262,52,o),
+(219,52,cs)
+);
+}
+);
+width = 622;
+}
+);
+metricLeft = "fe-canadian";
+metricRight = "e-canadian";
+note = uni1555;
+unicode = 5461;
+},
+{
+glyphname = "fii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (236,0);
+ref = dot_top;
+}
+);
+width = 621;
+}
+);
+note = uni1556;
+unicode = 5462;
+},
+{
+glyphname = "fo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (181,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(95,0,l),
+(520,328,l),
+(520,361,l),
+(282,651,ls),
+(252,689,o),
+(216,702,o),
+(178,702,cs),
+(92,702,o),
+(43,628,o),
+(43,508,cs),
+(43,392,o),
+(96,316,o),
+(180,316,cs),
+(262,316,o),
+(312,393,o),
+(312,508,cs),
+(312,552,o),
+(302,592,o),
+(291,619,c),
+(263,565,l),
+(445,343,l),
+(445,365,l),
+(71,76,l),
+(71,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(139,381,o),
+(114,418,o),
+(114,509,cs),
+(114,600,o),
+(139,638,o),
+(182,638,cs),
+(223,638,o),
+(247,600,o),
+(247,510,cs),
+(247,420,o),
+(223,381,o),
+(182,381,cs)
+);
+}
+);
+width = 549;
+}
+);
+metricRight = "o-canadian";
+note = uni1557;
+unicode = 5463;
+},
+{
+glyphname = "foo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "fo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (113,0);
+ref = dot_top;
+}
+);
+width = 550;
+}
+);
+note = uni1558;
+unicode = 5464;
+},
+{
+glyphname = "fa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (369,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(478,0,l),
+(478,76,l),
+(104,365,l),
+(104,344,l),
+(287,565,l),
+(258,619,l),
+(246,592,o),
+(237,552,o),
+(237,508,cs),
+(237,393,o),
+(288,316,o),
+(370,316,cs),
+(454,316,o),
+(506,392,o),
+(506,508,cs),
+(506,628,o),
+(458,702,o),
+(371,702,cs),
+(333,702,o),
+(298,689,o),
+(267,651,cs),
+(29,361,l),
+(29,328,l),
+(455,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(327,381,o),
+(302,420,o),
+(302,510,cs),
+(302,600,o),
+(327,638,o),
+(368,638,cs),
+(411,638,o),
+(435,600,o),
+(435,509,cs),
+(435,418,o),
+(411,381,o),
+(368,381,cs)
+);
+}
+);
+width = 549;
+}
+);
+metricRight = "=|fo-canadian";
+note = uni1559;
+unicode = 5465;
+},
+{
+glyphname = "faa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (301,0);
+ref = dot_top;
+}
+);
+width = 550;
+}
+);
+note = uni155A;
+unicode = 5466;
+},
+{
+glyphname = "fwaa-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (487,0);
+ref = dot_top;
+}
+);
+width = 734;
+}
+);
+note = uni155B;
+unicode = 5467;
+},
+{
+glyphname = "fwaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (301,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (550,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 734;
+}
+);
+note = uni155C;
+unicode = 5468;
+},
+{
+glyphname = "f-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(265,345,l),
+(265,385,l),
+(83,527,l),
+(83,518,l),
+(166,618,l),
+(156,653,l),
+(150,639,o),
+(146,618,o),
+(146,594,cs),
+(146,532,o),
+(174,501,o),
+(213,501,cs),
+(251,501,o),
+(278,534,o),
+(278,599,cs),
+(278,668,o),
+(247,696,o),
+(211,696,cs),
+(193,696,o),
+(174,687,o),
+(157,667,cs),
+(40,526,l),
+(40,507,l),
+(252,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(191,537,o),
+(181,555,o),
+(181,597,cs),
+(181,639,o),
+(191,660,o),
+(211,660,cs),
+(230,660,o),
+(241,643,o),
+(241,597,cs),
+(241,554,o),
+(231,537,o),
+(211,537,cs)
+);
+}
+);
+width = 323;
+}
+);
+note = uni155D;
+unicode = 5469;
+},
+{
+glyphname = "the-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (639,345);
+},
+{
+name = top_center_can;
+pos = (295,690);
+},
+{
+name = top_left_can;
+pos = (100,690);
+},
+{
+name = top_right_can;
+pos = (487,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(444,-13,o),
+(532,78,o),
+(532,253,cs),
+(532,690,l),
+(442,690,l),
+(442,251,ls),
+(442,128,o),
+(390,71,o),
+(294,71,cs),
+(200,71,o),
+(145,130,o),
+(145,254,cs),
+(145,420,l),
+(105,395,l),
+(117,348,o),
+(155,315,o),
+(197,315,cs),
+(279,315,o),
+(332,390,o),
+(332,509,cs),
+(332,627,o),
+(285,702,o),
+(196,702,cs),
+(104,702,o),
+(56,628,o),
+(56,484,cs),
+(56,274,ls),
+(56,82,o),
+(143,-13,o),
+(294,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(154,381,o),
+(128,418,o),
+(128,509,cs),
+(128,599,o),
+(153,638,o),
+(195,638,cs),
+(237,638,o),
+(261,599,o),
+(261,510,cs),
+(261,420,o),
+(238,381,o),
+(196,381,cs)
+);
+}
+);
+width = 588;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155E;
+unicode = 5470;
+},
+{
+glyphname = "theNCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(447,-13,o),
+(532,78,o),
+(532,270,cs),
+(532,484,ls),
+(532,628,o),
+(484,702,o),
+(393,702,cs),
+(304,702,o),
+(257,627,o),
+(257,509,cs),
+(257,390,o),
+(310,315,o),
+(391,315,cs),
+(435,315,o),
+(471,348,o),
+(484,395,c),
+(443,420,l),
+(443,252,ls),
+(443,128,o),
+(389,69,o),
+(295,69,cs),
+(199,69,o),
+(147,127,o),
+(147,249,cs),
+(147,690,l),
+(56,690,l),
+(56,251,ls),
+(56,78,o),
+(145,-13,o),
+(295,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(352,381,o),
+(328,420,o),
+(328,510,cs),
+(328,599,o),
+(353,638,o),
+(394,638,cs),
+(437,638,o),
+(461,599,o),
+(461,509,cs),
+(461,418,o),
+(435,381,o),
+(393,381,cs)
+);
+}
+);
+width = 588;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155F;
+unicode = 5471;
+},
+{
+glyphname = "thi-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (292,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(285,-13,o),
+(332,63,o),
+(332,181,cs),
+(332,299,o),
+(279,375,o),
+(197,375,cs),
+(155,375,o),
+(117,342,o),
+(105,295,c),
+(145,270,l),
+(145,438,ls),
+(145,562,o),
+(199,621,o),
+(294,621,cs),
+(389,621,o),
+(442,563,o),
+(442,440,cs),
+(442,0,l),
+(532,0,l),
+(532,439,ls),
+(532,611,o),
+(443,702,o),
+(294,702,cs),
+(142,702,o),
+(56,611,o),
+(56,420,cs),
+(56,206,ls),
+(56,62,o),
+(104,-13,o),
+(196,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(153,52,o),
+(128,91,o),
+(128,181,cs),
+(128,271,o),
+(154,309,o),
+(196,309,cs),
+(238,309,o),
+(261,270,o),
+(261,180,cs),
+(261,91,o),
+(237,52,o),
+(195,52,cs)
+);
+}
+);
+width = 588;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1560;
+unicode = 5472;
+},
+{
+glyphname = "thiNCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (292,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(484,-13,o),
+(532,62,o),
+(532,206,cs),
+(532,420,ls),
+(532,611,o),
+(447,702,o),
+(295,702,cs),
+(145,702,o),
+(56,611,o),
+(56,439,cs),
+(56,0,l),
+(147,0,l),
+(147,440,ls),
+(147,563,o),
+(199,621,o),
+(295,621,cs),
+(389,621,o),
+(443,562,o),
+(443,438,cs),
+(443,270,l),
+(484,295,l),
+(471,342,o),
+(435,375,o),
+(391,375,cs),
+(310,375,o),
+(257,299,o),
+(257,181,cs),
+(257,63,o),
+(304,-13,o),
+(393,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(353,52,o),
+(328,91,o),
+(328,180,cs),
+(328,270,o),
+(352,309,o),
+(393,309,cs),
+(435,309,o),
+(461,271,o),
+(461,181,cs),
+(461,91,o),
+(437,52,o),
+(394,52,cs)
+);
+}
+);
+width = 588;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1561;
+unicode = 5473;
+},
+{
+glyphname = "thii-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "thi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (224,0);
+ref = dot_top;
+}
+);
+width = 589;
+}
+);
+note = uni1562;
+unicode = 5474;
+},
+{
+glyphname = "thiiNCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "thiNCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (224,0);
+ref = dot_top;
+}
+);
+width = 589;
+}
+);
+note = uni1563;
+unicode = 5475;
+},
+{
+glyphname = "tho-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (243,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(198,0,ls),
+(393,0,o),
+(492,119,o),
+(492,353,cs),
+(492,569,o),
+(399,702,o),
+(248,702,cs),
+(132,702,o),
+(50,622,o),
+(50,485,cs),
+(50,360,o),
+(102,290,o),
+(186,290,cs),
+(271,290,o),
+(319,360,o),
+(319,472,cs),
+(319,582,o),
+(279,656,o),
+(203,660,c),
+(174,627,l),
+(190,638,o),
+(213,644,o),
+(234,644,cs),
+(347,644,o),
+(404,532,o),
+(404,358,cs),
+(404,170,o),
+(341,83,o),
+(194,83,cs),
+(77,83,l),
+(77,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(147,355,o),
+(122,393,o),
+(122,487,cs),
+(122,579,o),
+(151,620,o),
+(190,620,cs),
+(231,620,o),
+(255,582,o),
+(255,488,cs),
+(255,395,o),
+(231,355,o),
+(189,355,cs)
+);
+}
+);
+width = 541;
+}
+);
+metricRight = "to-canadian";
+note = uni1564;
+unicode = 5476;
+},
+{
+glyphname = "thoo-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "tho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (176,0);
+ref = dot_top;
+}
+);
+width = 541;
+}
+);
+note = uni1565;
+unicode = 5477;
+},
+{
+glyphname = "tha-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (299,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(464,0,l),
+(464,83,l),
+(347,83,ls),
+(200,83,o),
+(137,170,o),
+(137,358,cs),
+(137,532,o),
+(195,644,o),
+(307,644,cs),
+(328,644,o),
+(352,638,o),
+(367,627,c),
+(338,660,l),
+(262,656,o),
+(222,582,o),
+(222,472,cs),
+(222,360,o),
+(270,290,o),
+(355,290,cs),
+(439,290,o),
+(491,360,o),
+(491,485,cs),
+(491,622,o),
+(409,702,o),
+(293,702,cs),
+(142,702,o),
+(49,569,o),
+(49,353,cs),
+(49,123,o),
+(144,0,o),
+(344,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(310,355,o),
+(286,395,o),
+(286,488,cs),
+(286,582,o),
+(311,620,o),
+(351,620,cs),
+(390,620,o),
+(419,579,o),
+(419,487,cs),
+(419,393,o),
+(394,355,o),
+(353,355,cs)
+);
+}
+);
+width = 541;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tho-canadian";
+note = uni1566;
+unicode = 5478;
+},
+{
+glyphname = "thaa-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (232,0);
+ref = dot_top;
+}
+);
+width = 541;
+}
+);
+note = uni1567;
+unicode = 5479;
+},
+{
+glyphname = "thwaa-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (417,0);
+ref = dot_top;
+}
+);
+width = 726;
+}
+);
+note = uni1568;
+unicode = 5480;
+},
+{
+glyphname = "thwaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (232,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (541,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 726;
+}
+);
+note = uni1569;
+unicode = 5481;
+},
+{
+glyphname = "th-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(254,345,l),
+(254,397,l),
+(203,397,ls),
+(131,397,o),
+(99,440,o),
+(99,523,cs),
+(99,605,o),
+(130,656,o),
+(184,656,cs),
+(194,656,o),
+(203,653,o),
+(211,649,c),
+(190,670,l),
+(156,668,o),
+(134,634,o),
+(134,584,cs),
+(134,519,o),
+(161,487,o),
+(201,487,cs),
+(241,487,o),
+(267,520,o),
+(267,584,cs),
+(267,662,o),
+(228,696,o),
+(174,696,cs),
+(98,696,o),
+(47,632,o),
+(47,519,cs),
+(47,411,o),
+(96,345,o),
+(199,345,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(180,523,o),
+(169,540,o),
+(169,582,cs),
+(169,625,o),
+(180,645,o),
+(199,645,cs),
+(218,645,o),
+(229,629,o),
+(229,582,cs),
+(229,540,o),
+(219,523,o),
+(200,523,cs)
+);
+}
+);
+width = 311;
+}
+);
+metricLeft = "t-canadian";
+note = uni156A;
+unicode = 5482;
+},
+{
+glyphname = "tthe-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (633,345);
+},
+{
+name = top_center_can;
+pos = (291,690);
+},
+{
+name = top_left_can;
+pos = (102,690);
+},
+{
+name = top_right_can;
+pos = (480,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,-13,o),
+(526,78,o),
+(526,253,cs),
+(526,690,l),
+(440,690,l),
+(440,251,ls),
+(440,127,o),
+(384,71,o),
+(291,71,cs),
+(200,71,o),
+(141,129,o),
+(141,251,cs),
+(141,690,l),
+(56,690,l),
+(56,251,ls),
+(56,78,o),
+(145,-13,o),
+(291,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(325,387,l),
+(325,690,l),
+(257,690,l),
+(257,387,l)
+);
+}
+);
+width = 582;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156B;
+unicode = 5483;
+},
+{
+glyphname = "tthi-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(141,0,l),
+(141,439,ls),
+(141,562,o),
+(198,618,o),
+(291,618,cs),
+(382,618,o),
+(440,560,o),
+(440,439,cs),
+(440,0,l),
+(526,0,l),
+(526,439,ls),
+(526,611,o),
+(437,702,o),
+(291,702,cs),
+(142,702,o),
+(56,611,o),
+(56,437,cs),
+(56,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(325,0,l),
+(325,302,l),
+(257,302,l),
+(257,0,l)
+);
+}
+);
+width = 582;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156C;
+unicode = 5484;
+},
+{
+glyphname = "ttho-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (257,690);
+},
+{
+name = top_left_can;
+pos = (103,690);
+},
+{
+name = top_right_can;
+pos = (412,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(154,0,ls),
+(353,0,o),
+(455,120,o),
+(455,346,cs),
+(455,572,o),
+(353,690,o),
+(151,690,cs),
+(59,690,l),
+(59,607,l),
+(152,607,ls),
+(297,607,o),
+(365,524,o),
+(365,346,cs),
+(365,169,o),
+(297,83,o),
+(155,83,cs),
+(59,83,l),
+(59,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(241,307,l),
+(241,384,l),
+(59,384,l),
+(59,307,l)
+);
+}
+);
+width = 504;
+}
+);
+metricRight = "to-canadian";
+note = uni156D;
+unicode = 5485;
+},
+{
+glyphname = "ttha-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (255,690);
+},
+{
+name = top_left_can;
+pos = (94,690);
+},
+{
+name = top_right_can;
+pos = (402,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(445,0,l),
+(445,83,l),
+(353,83,ls),
+(208,83,o),
+(140,167,o),
+(140,345,cs),
+(140,521,o),
+(208,607,o),
+(350,607,cs),
+(445,607,l),
+(445,690,l),
+(351,690,ls),
+(152,690,o),
+(49,571,o),
+(49,345,cs),
+(49,119,o),
+(152,0,o),
+(354,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(445,307,l),
+(445,384,l),
+(264,384,l),
+(264,307,l)
+);
+}
+);
+width = 504;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|ttho-canadian";
+note = uni156E;
+unicode = 5486;
+},
+{
+glyphname = "tth-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(520,495,l),
+(497,495,l),
+(578,377,l),
+(620,408,l),
+(539,526,l),
+(532,504,l),
+(651,554,l),
+(632,602,l),
+(515,551,l),
+(535,540,l),
+(535,690,l),
+(482,690,l),
+(482,540,l),
+(503,551,l),
+(385,602,l),
+(366,554,l),
+(486,504,l),
+(479,526,l),
+(397,408,l),
+(440,377,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(191,495,l),
+(169,495,l),
+(252,377,l),
+(295,408,l),
+(211,526,l),
+(204,504,l),
+(323,554,l),
+(303,602,l),
+(186,551,l),
+(207,540,l),
+(207,690,l),
+(154,690,l),
+(154,540,l),
+(175,551,l),
+(57,602,l),
+(39,554,l),
+(157,504,l),
+(151,526,l),
+(67,408,l),
+(109,377,l)
+);
+}
+);
+width = 690;
+}
+);
+metricRight = "=|";
+note = uni156F;
+unicode = 5487;
+},
+{
+glyphname = "tye-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,-13,o),
+(526,78,o),
+(526,253,cs),
+(526,690,l),
+(440,690,l),
+(440,257,ls),
+(440,127,o),
+(384,71,o),
+(291,71,cs),
+(200,71,o),
+(141,129,o),
+(141,257,cs),
+(141,690,l),
+(56,690,l),
+(56,251,ls),
+(56,78,o),
+(145,-13,o),
+(291,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(348,412,o),
+(381,448,o),
+(381,518,cs),
+(381,690,l),
+(338,690,l),
+(338,520,ls),
+(338,474,o),
+(322,455,o),
+(291,455,cs),
+(260,455,o),
+(243,475,o),
+(243,520,cs),
+(243,690,l),
+(201,690,l),
+(201,518,ls),
+(201,448,o),
+(235,412,o),
+(291,412,cs)
+);
+}
+);
+width = 582;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1570;
+unicode = 5488;
+},
+{
+glyphname = "tyi-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(141,0,l),
+(141,433,ls),
+(141,562,o),
+(198,618,o),
+(291,618,cs),
+(382,618,o),
+(440,560,o),
+(440,433,cs),
+(440,0,l),
+(526,0,l),
+(526,439,ls),
+(526,611,o),
+(437,702,o),
+(291,702,cs),
+(142,702,o),
+(56,611,o),
+(56,437,cs),
+(56,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(243,0,l),
+(243,170,ls),
+(243,215,o),
+(260,235,o),
+(291,235,cs),
+(322,235,o),
+(338,214,o),
+(338,170,cs),
+(338,0,l),
+(381,0,l),
+(381,172,ls),
+(381,242,o),
+(347,278,o),
+(291,278,cs),
+(234,278,o),
+(201,242,o),
+(201,172,cs),
+(201,0,l)
+);
+}
+);
+width = 582;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1571;
+unicode = 5489;
+},
+{
+glyphname = "tyo-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(155,0,ls),
+(350,0,o),
+(456,120,o),
+(456,346,cs),
+(456,572,o),
+(350,690,o),
+(152,690,cs),
+(60,690,l),
+(60,609,l),
+(145,609,ls),
+(297,609,o),
+(366,525,o),
+(366,346,cs),
+(366,168,o),
+(297,81,o),
+(148,81,cs),
+(60,81,l),
+(60,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(114,212,ls),
+(194,212,o),
+(240,257,o),
+(240,345,cs),
+(240,433,o),
+(194,478,o),
+(114,478,cs),
+(60,478,l),
+(60,429,l),
+(107,429,ls),
+(163,429,o),
+(187,402,o),
+(187,345,cs),
+(187,288,o),
+(163,261,o),
+(107,261,cs),
+(60,261,l),
+(60,212,l)
+);
+}
+);
+width = 505;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1572;
+unicode = 5490;
+},
+{
+glyphname = "tya-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(445,0,l),
+(445,81,l),
+(360,81,ls),
+(209,81,o),
+(139,166,o),
+(139,345,cs),
+(139,523,o),
+(209,609,o),
+(357,609,cs),
+(445,609,l),
+(445,690,l),
+(351,690,ls),
+(156,690,o),
+(49,571,o),
+(49,345,cs),
+(49,119,o),
+(156,0,o),
+(354,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(445,212,l),
+(445,261,l),
+(398,261,ls),
+(343,261,o),
+(318,288,o),
+(318,345,cs),
+(318,402,o),
+(343,429,o),
+(397,429,cs),
+(445,429,l),
+(445,478,l),
+(391,478,ls),
+(311,478,o),
+(266,433,o),
+(266,345,cs),
+(266,257,o),
+(311,212,o),
+(391,212,cs)
+);
+}
+);
+width = 505;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1573;
+unicode = 5491;
+},
+{
+glyphname = "heNunavik-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(414,0,l),
+(605,194,l),
+(551,251,l),
+(366,64,l),
+(424,60,l),
+(424,446,ls),
+(424,611,o),
+(359,702,o),
+(240,702,cs),
+(120,702,o),
+(49,610,o),
+(49,447,cs),
+(49,293,o),
+(118,198,o),
+(226,198,cs),
+(287,198,o),
+(332,239,o),
+(343,293,c),
+(335,317,l),
+(335,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(174,276,o),
+(137,331,o),
+(137,451,cs),
+(137,570,o),
+(173,625,o),
+(237,625,cs),
+(300,625,o),
+(336,571,o),
+(336,451,cs),
+(336,331,o),
+(298,276,o),
+(237,276,cs)
+);
+}
+);
+width = 625;
+}
+);
+metricLeft = "ke-canadian";
+note = uni1574;
+unicode = 5492;
+},
+{
+glyphname = "hiNunavik-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (386,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(291,0,l),
+(291,317,l),
+(282,293,l),
+(293,239,o),
+(338,198,o),
+(400,198,cs),
+(508,198,o),
+(576,293,o),
+(576,448,cs),
+(576,610,o),
+(505,702,o),
+(386,702,cs),
+(266,702,o),
+(201,611,o),
+(201,446,cs),
+(201,61,l),
+(259,64,l),
+(74,251,l),
+(20,194,l),
+(211,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(327,276,o),
+(290,331,o),
+(290,451,cs),
+(290,571,o),
+(325,625,o),
+(388,625,cs),
+(452,625,o),
+(488,570,o),
+(488,451,cs),
+(488,331,o),
+(451,276,o),
+(388,276,cs)
+);
+}
+);
+width = 625;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1575;
+unicode = 5493;
+},
+{
+glyphname = "hiiNunavik-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "hiNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (319,0);
+ref = dot_top;
+}
+);
+width = 625;
+}
+);
+note = uni1576;
+unicode = 5494;
+},
+{
+glyphname = "hoNunavik-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (236,690);
+},
+{
+name = top_right_can;
+pos = (380,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(359,-13,o),
+(424,78,o),
+(424,243,cs),
+(424,630,l),
+(366,626,l),
+(551,439,l),
+(605,496,l),
+(414,690,l),
+(335,690,l),
+(335,373,l),
+(343,397,l),
+(332,451,o),
+(287,492,o),
+(226,492,cs),
+(118,492,o),
+(49,397,o),
+(49,242,cs),
+(49,80,o),
+(120,-13,o),
+(240,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(173,65,o),
+(137,120,o),
+(137,239,cs),
+(137,358,o),
+(174,413,o),
+(237,413,cs),
+(298,413,o),
+(336,358,o),
+(336,239,cs),
+(336,119,o),
+(300,65,o),
+(237,65,cs)
+);
+}
+);
+width = 625;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "heNunavik-canadian";
+note = uni1577;
+unicode = 5495;
+},
+{
+glyphname = "hooNunavik-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "hoNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (312,0);
+ref = dot_top;
+}
+);
+width = 625;
+}
+);
+note = uni1578;
+unicode = 5496;
+},
+{
+glyphname = "haNunavik-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (389,690);
+},
+{
+name = top_left_can;
+pos = (246,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(505,-13,o),
+(576,80,o),
+(576,242,cs),
+(576,397,o),
+(508,492,o),
+(400,492,cs),
+(338,492,o),
+(294,451,o),
+(282,397,c),
+(291,373,l),
+(291,690,l),
+(211,690,l),
+(20,496,l),
+(74,439,l),
+(259,626,l),
+(201,629,l),
+(201,243,ls),
+(201,78,o),
+(266,-13,o),
+(386,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(325,65,o),
+(290,119,o),
+(290,239,cs),
+(290,358,o),
+(327,413,o),
+(388,413,cs),
+(451,413,o),
+(488,358,o),
+(488,239,cs),
+(488,120,o),
+(452,65,o),
+(388,65,cs)
+);
+}
+);
+width = 625;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1579;
+unicode = 5497;
+},
+{
+glyphname = "haaNunavik-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "haNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (179,0);
+ref = dot_top;
+}
+);
+width = 625;
+}
+);
+note = uni157A;
+unicode = 5498;
+},
+{
+glyphname = "hNunavik-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(283,339,o),
+(329,383,o),
+(329,474,cs),
+(329,556,o),
+(290,601,o),
+(238,601,cs),
+(199,601,o),
+(171,574,o),
+(166,529,c),
+(181,529,l),
+(181,690,l),
+(125,690,l),
+(30,593,l),
+(62,561,l),
+(156,659,l),
+(120,657,l),
+(120,469,ls),
+(120,387,o),
+(160,339,o),
+(225,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(195,386,o),
+(177,409,o),
+(177,470,cs),
+(177,529,o),
+(197,554,o),
+(225,554,cs),
+(253,554,o),
+(274,530,o),
+(274,470,cs),
+(274,411,o),
+(254,386,o),
+(225,386,cs)
+);
+}
+);
+width = 368;
+}
+);
+metricRight = "k-canadian";
+note = uni157B;
+unicode = 5499;
+},
+{
+color = 4;
+glyphname = "nunavuth-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(150,317,l),
+(408,317,l),
+(408,0,l),
+(497,0,l),
+(497,690,l),
+(408,690,l),
+(408,398,l),
+(150,398,l),
+(150,690,l),
+(60,690,l),
+(60,0,l),
+(150,0,l)
+);
+}
+);
+width = 557;
+}
+);
+metricRight = "=|";
+note = uni157C;
+unicode = 5500;
+},
+{
+glyphname = "hk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,345);
+ref = "fullstop-canadian";
+}
+);
+width = 300;
+}
+);
+metricLeft = "fullstop-canadian";
+note = uni157D;
+unicode = 5501;
+},
+{
+glyphname = "qaai-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (261,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (389,0);
+ref = ring_top.canadian;
+}
+);
+width = 741;
+}
+);
+note = uni157E;
+unicode = 5502;
+},
+{
+glyphname = "qi-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (261,0);
+ref = "ki-canadian";
+}
+);
+width = 741;
+}
+);
+note = uni157F;
+unicode = 5503;
+},
+{
+glyphname = "qii-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (261,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (437,0);
+ref = dot_top;
+}
+);
+width = 741;
+}
+);
+note = uni1580;
+unicode = 5504;
+},
+{
+glyphname = "qo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (261,0);
+ref = "ko-canadian";
+}
+);
+width = 741;
+}
+);
+note = uni1581;
+unicode = 5505;
+},
+{
+glyphname = "qoo-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (261,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (573,0);
+ref = dot_top;
+}
+);
+width = 741;
+}
+);
+note = uni1582;
+unicode = 5506;
+},
+{
+glyphname = "qa-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (261,0);
+ref = "ka-canadian";
+}
+);
+width = 741;
+}
+);
+note = uni1583;
+unicode = 5507;
+},
+{
+glyphname = "qaa-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (261,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (295,0);
+ref = dot_top;
+}
+);
+width = 741;
+}
+);
+note = uni1584;
+unicode = 5508;
+},
+{
+glyphname = "q-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (261,0);
+ref = "k-canadian";
+}
+);
+width = 558;
+}
+);
+note = uni1585;
+unicode = 5509;
+},
+{
+glyphname = "tlhe-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (244,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(163,0,l),
+(266,265,l),
+(196,238,l),
+(206,235,o),
+(217,233,o),
+(230,233,cs),
+(296,233,o),
+(338,273,o),
+(350,321,c),
+(342,345,l),
+(342,0,l),
+(431,0,l),
+(431,469,ls),
+(431,613,o),
+(365,702,o),
+(244,702,cs),
+(124,702,o),
+(52,612,o),
+(52,466,cs),
+(52,354,o),
+(98,277,o),
+(167,252,c),
+(69,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(179,310,o),
+(141,362,o),
+(141,468,cs),
+(141,573,o),
+(177,625,o),
+(242,625,cs),
+(307,625,o),
+(343,574,o),
+(343,468,cs),
+(343,361,o),
+(304,310,o),
+(242,310,cs)
+);
+}
+);
+width = 487;
+}
+);
+metricRight = "te-canadian";
+note = uni1586;
+unicode = 5510;
+},
+{
+glyphname = "tlhi-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(146,0,l),
+(146,345,l),
+(138,322,l),
+(149,273,o),
+(191,233,o),
+(258,233,c),
+(222,265,l),
+(325,0,l),
+(419,0,l),
+(321,252,l),
+(390,277,o),
+(435,354,o),
+(435,466,cs),
+(435,612,o),
+(364,702,o),
+(243,702,cs),
+(123,702,o),
+(56,613,o),
+(56,469,cs),
+(56,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(184,310,o),
+(145,361,o),
+(145,468,cs),
+(145,574,o),
+(181,625,o),
+(246,625,cs),
+(310,625,o),
+(347,573,o),
+(347,468,cs),
+(347,362,o),
+(309,310,o),
+(246,310,cs)
+);
+}
+);
+width = 487;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|tlhe-canadian";
+note = uni1587;
+unicode = 5511;
+},
+{
+glyphname = "tlho-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (254,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(365,-13,o),
+(431,76,o),
+(431,221,cs),
+(431,690,l),
+(342,690,l),
+(342,345,l),
+(350,368,l),
+(338,416,o),
+(297,457,o),
+(230,457,c),
+(266,425,l),
+(163,690,l),
+(69,690,l),
+(167,438,l),
+(98,412,o),
+(52,336,o),
+(52,224,cs),
+(52,77,o),
+(124,-13,o),
+(244,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(177,65,o),
+(141,117,o),
+(141,222,cs),
+(141,327,o),
+(179,380,o),
+(242,380,cs),
+(304,380,o),
+(343,328,o),
+(343,222,cs),
+(343,116,o),
+(307,65,o),
+(242,65,cs)
+);
+}
+);
+width = 487;
+}
+);
+metricLeft = "tlhe-canadian";
+metricRight = "te-canadian";
+note = uni1588;
+unicode = 5512;
+},
+{
+glyphname = "tlha-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(364,-13,o),
+(435,77,o),
+(435,224,cs),
+(435,336,o),
+(390,412,o),
+(321,438,c),
+(419,690,l),
+(325,690,l),
+(222,425,l),
+(292,452,l),
+(281,455,o),
+(270,457,o),
+(258,457,cs),
+(191,457,o),
+(149,416,o),
+(138,368,c),
+(146,345,l),
+(146,690,l),
+(56,690,l),
+(56,221,ls),
+(56,76,o),
+(123,-13,o),
+(243,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(181,65,o),
+(145,116,o),
+(145,222,cs),
+(145,328,o),
+(184,380,o),
+(246,380,cs),
+(309,380,o),
+(347,327,o),
+(347,222,cs),
+(347,117,o),
+(310,65,o),
+(246,65,cs)
+);
+}
+);
+width = 488;
+}
+);
+metricLeft = "te-canadian";
+note = uni1589;
+unicode = 5513;
+},
+{
+glyphname = "reWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(409,0,l),
+(599,194,l),
+(544,251,l),
+(359,64,l),
+(418,60,l),
+(418,464,ls),
+(418,612,o),
+(355,702,o),
+(235,702,cs),
+(116,702,o),
+(47,616,o),
+(47,468,cs),
+(47,387,l),
+(137,387,l),
+(137,483,ls),
+(137,572,o),
+(169,623,o),
+(234,623,cs),
+(296,623,o),
+(328,573,o),
+(328,479,cs),
+(328,0,l)
+);
+}
+);
+width = 619;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+unicode = 5514;
+},
+{
+glyphname = "riWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(291,0,l),
+(291,479,ls),
+(291,573,o),
+(324,623,o),
+(385,623,cs),
+(450,623,o),
+(482,572,o),
+(482,483,cs),
+(482,387,l),
+(571,387,l),
+(571,468,ls),
+(571,616,o),
+(503,702,o),
+(384,702,cs),
+(265,702,o),
+(201,612,o),
+(201,463,cs),
+(201,60,l),
+(259,64,l),
+(74,251,l),
+(20,194,l),
+(211,0,l)
+);
+}
+);
+width = 618;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+unicode = 5515;
+},
+{
+glyphname = "roWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(354,-13,o),
+(418,77,o),
+(418,227,cs),
+(418,630,l),
+(359,626,l),
+(544,439,l),
+(599,496,l),
+(409,690,l),
+(328,690,l),
+(328,211,ls),
+(328,117,o),
+(296,67,o),
+(234,67,cs),
+(169,67,o),
+(137,118,o),
+(137,207,cs),
+(137,302,l),
+(47,302,l),
+(47,222,ls),
+(47,73,o),
+(116,-13,o),
+(235,-13,cs)
+);
+}
+);
+width = 619;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+unicode = 5516;
+},
+{
+glyphname = "raWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(503,-13,o),
+(571,73,o),
+(571,222,cs),
+(571,302,l),
+(482,302,l),
+(482,207,ls),
+(482,118,o),
+(450,67,o),
+(385,67,cs),
+(324,67,o),
+(291,117,o),
+(291,211,cs),
+(291,690,l),
+(211,690,l),
+(20,496,l),
+(74,439,l),
+(259,626,l),
+(201,630,l),
+(201,226,ls),
+(201,77,o),
+(265,-13,o),
+(384,-13,cs)
+);
+}
+);
+width = 618;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+unicode = 5517;
+},
+{
+glyphname = "ngaai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (507,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (636,0);
+ref = ring_top.canadian;
+}
+);
+width = 982;
+}
+);
+note = uni158E;
+unicode = 5518;
+},
+{
+glyphname = "ngi-canadian";
+kernLeft = mwestleft;
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (507,0);
+ref = "ci-canadian";
+}
+);
+width = 982;
+}
+);
+note = uni158F;
+unicode = 5519;
+},
+{
+glyphname = "ngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (507,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (684,0);
+ref = dot_top;
+}
+);
+width = 982;
+}
+);
+note = uni1590;
+unicode = 5520;
+},
+{
+glyphname = "ngo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (482,0);
+ref = "co-canadian";
+}
+);
+width = 956;
+}
+);
+note = uni1591;
+unicode = 5521;
+},
+{
+glyphname = "ngoo-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+ref = "ngo-canadian";
+},
+{
+anchor = top_right_can;
+pos = (788,0);
+ref = dot_top;
+}
+);
+width = 956;
+}
+);
+note = uni1592;
+unicode = 5522;
+},
+{
+glyphname = "nga-canadian";
+kernLeft = mwestleft;
+kernRight = caright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (507,0);
+ref = "ca-canadian";
+}
+);
+width = 982;
+}
+);
+note = uni1593;
+unicode = 5523;
+},
+{
+glyphname = "ngaa-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (507,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (542,0);
+ref = dot_top;
+}
+);
+width = 982;
+}
+);
+note = uni1594;
+unicode = 5524;
+},
+{
+glyphname = "ng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(437,217,o),
+(477,258,o),
+(477,335,cs),
+(477,365,l),
+(419,365,l),
+(419,328,ls),
+(419,286,o),
+(402,268,o),
+(373,268,cs),
+(343,268,o),
+(327,287,o),
+(327,333,cs),
+(327,493,l),
+(205,493,l),
+(206,466,l),
+(231,479,o),
+(245,522,o),
+(245,568,cs),
+(245,649,o),
+(207,696,o),
+(142,696,cs),
+(78,696,o),
+(39,648,o),
+(39,565,cs),
+(39,483,o),
+(78,434,o),
+(147,434,cs),
+(281,434,l),
+(266,451,l),
+(266,340,ls),
+(266,259,o),
+(305,217,o),
+(372,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(112,481,o),
+(94,507,o),
+(94,565,cs),
+(94,623,o),
+(112,648,o),
+(143,648,cs),
+(173,648,o),
+(189,622,o),
+(189,565,cs),
+(189,507,o),
+(172,481,o),
+(142,481,cs)
+);
+}
+);
+width = 506;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1595;
+unicode = 5525;
+},
+{
+glyphname = "nng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(676,217,o),
+(717,258,o),
+(717,335,cs),
+(717,365,l),
+(659,365,l),
+(659,328,ls),
+(659,286,o),
+(642,268,o),
+(612,268,cs),
+(582,268,o),
+(567,287,o),
+(567,333,cs),
+(567,493,l),
+(446,493,l),
+(446,466,l),
+(471,479,o),
+(485,522,o),
+(485,568,cs),
+(485,651,o),
+(446,696,o),
+(382,696,cs),
+(319,696,o),
+(279,648,o),
+(279,565,cs),
+(279,521,o),
+(293,478,o),
+(318,465,c),
+(319,493,l),
+(206,493,l),
+(206,466,l),
+(231,479,o),
+(245,522,o),
+(245,568,cs),
+(245,649,o),
+(207,696,o),
+(142,696,cs),
+(78,696,o),
+(39,648,o),
+(39,565,cs),
+(39,483,o),
+(78,434,o),
+(147,434,cs),
+(505,434,l),
+(505,340,ls),
+(505,259,o),
+(545,217,o),
+(612,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(112,481,o),
+(94,507,o),
+(94,565,cs),
+(94,623,o),
+(112,648,o),
+(143,648,cs),
+(173,648,o),
+(189,622,o),
+(189,565,cs),
+(189,507,o),
+(172,481,o),
+(142,481,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(353,481,o),
+(334,507,o),
+(334,565,cs),
+(334,623,o),
+(353,648,o),
+(383,648,cs),
+(412,648,o),
+(430,622,o),
+(430,565,cs),
+(430,507,o),
+(411,481,o),
+(383,481,cs)
+);
+}
+);
+width = 746;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1596;
+unicode = 5526;
+},
+{
+glyphname = "sheSayisi-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (538,345);
+},
+{
+name = top_center_can;
+pos = (243,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(431,0,l),
+(431,450,ls),
+(431,611,o),
+(367,702,o),
+(243,702,cs),
+(121,702,o),
+(49,610,o),
+(49,439,cs),
+(49,276,o),
+(105,200,o),
+(185,200,cs),
+(257,200,o),
+(300,252,o),
+(296,412,c),
+(256,412,l),
+(259,298,o),
+(234,274,o),
+(202,274,cs),
+(160,274,o),
+(135,318,o),
+(135,441,cs),
+(135,571,o),
+(173,625,o),
+(241,625,cs),
+(307,625,o),
+(341,571,o),
+(341,446,cs),
+(341,0,l)
+);
+}
+);
+width = 487;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1597;
+unicode = 5527;
+},
+{
+glyphname = "shiSayisi-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(147,0,l),
+(147,446,ls),
+(147,571,o),
+(181,625,o),
+(247,625,cs),
+(315,625,o),
+(352,571,o),
+(352,441,cs),
+(352,318,o),
+(327,274,o),
+(285,274,cs),
+(254,274,o),
+(228,298,o),
+(232,412,c),
+(192,412,l),
+(187,252,o),
+(231,200,o),
+(303,200,cs),
+(383,200,o),
+(439,276,o),
+(439,440,cs),
+(439,610,o),
+(367,702,o),
+(245,702,cs),
+(121,702,o),
+(56,611,o),
+(56,450,cs),
+(56,0,l)
+);
+}
+);
+width = 488;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni1598;
+unicode = 5528;
+},
+{
+glyphname = "shoSayisi-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (240,690);
+},
+{
+name = top_left_can;
+pos = (92,690);
+},
+{
+name = top_right_can;
+pos = (386,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(367,-13,o),
+(431,78,o),
+(431,240,cs),
+(431,690,l),
+(341,690,l),
+(341,243,ls),
+(341,119,o),
+(307,65,o),
+(241,65,cs),
+(173,65,o),
+(135,119,o),
+(135,248,cs),
+(135,372,o),
+(160,415,o),
+(202,415,cs),
+(234,415,o),
+(259,392,o),
+(256,278,c),
+(296,278,l),
+(300,438,o),
+(257,490,o),
+(185,490,cs),
+(105,490,o),
+(49,413,o),
+(49,250,cs),
+(49,80,o),
+(121,-13,o),
+(242,-13,cs)
+);
+}
+);
+width = 487;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1599;
+unicode = 5529;
+},
+{
+glyphname = "shaSayisi-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(367,-13,o),
+(439,80,o),
+(439,251,cs),
+(439,413,o),
+(383,490,o),
+(303,490,cs),
+(231,490,o),
+(187,438,o),
+(192,278,c),
+(232,278,l),
+(228,392,o),
+(254,415,o),
+(285,415,cs),
+(327,415,o),
+(352,372,o),
+(352,248,cs),
+(352,119,o),
+(315,65,o),
+(247,65,cs),
+(181,65,o),
+(147,119,o),
+(147,243,cs),
+(147,690,l),
+(56,690,l),
+(56,240,ls),
+(56,78,o),
+(121,-13,o),
+(244,-13,cs)
+);
+}
+);
+width = 488;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni159A;
+unicode = 5530;
+},
+{
+glyphname = "theWoodScree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(534,-13,o),
+(610,71,o),
+(610,233,cs),
+(610,395,o),
+(536,478,o),
+(406,478,cs),
+(52,478,l),
+(52,403,l),
+(305,403,l),
+(300,418,l),
+(252,385,o),
+(228,310,o),
+(228,229,cs),
+(228,71,o),
+(300,-13,o),
+(418,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(353,65,o),
+(316,119,o),
+(316,234,cs),
+(316,343,o),
+(353,402,o),
+(418,402,cs),
+(484,402,o),
+(522,349,o),
+(522,234,cs),
+(522,119,o),
+(485,65,o),
+(418,65,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(601,614,l),
+(601,690,l),
+(52,690,l),
+(52,614,l)
+);
+}
+);
+width = 663;
+}
+);
+note = uni159B;
+unicode = 5531;
+},
+{
+glyphname = "thiWoodScree-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(362,-13,o),
+(435,71,o),
+(435,229,cs),
+(435,310,o),
+(411,385,o),
+(362,419,c),
+(357,403,l),
+(610,403,l),
+(610,478,l),
+(256,478,ls),
+(127,478,o),
+(52,394,o),
+(52,233,cs),
+(52,71,o),
+(128,-13,o),
+(243,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(177,65,o),
+(141,119,o),
+(141,234,cs),
+(141,349,o),
+(178,402,o),
+(243,402,cs),
+(310,402,o),
+(346,343,o),
+(346,234,cs),
+(346,119,o),
+(310,65,o),
+(243,65,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(610,614,l),
+(610,690,l),
+(61,690,l),
+(61,614,l)
+);
+}
+);
+width = 663;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159C;
+unicode = 5532;
+},
+{
+glyphname = "thoWoodScree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(407,0,ls),
+(536,0,o),
+(610,84,o),
+(610,245,cs),
+(610,407,o),
+(535,492,o),
+(418,492,cs),
+(300,492,o),
+(228,407,o),
+(228,249,cs),
+(228,168,o),
+(252,93,o),
+(300,60,c),
+(305,75,l),
+(52,75,l),
+(52,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(353,76,o),
+(316,135,o),
+(316,244,cs),
+(316,359,o),
+(353,413,o),
+(418,413,cs),
+(485,413,o),
+(522,360,o),
+(522,244,cs),
+(522,129,o),
+(484,76,o),
+(418,76,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(601,614,l),
+(601,690,l),
+(52,690,l),
+(52,614,l)
+);
+}
+);
+width = 663;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159D;
+unicode = 5533;
+},
+{
+glyphname = "thaWoodScree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(610,0,l),
+(610,75,l),
+(357,75,l),
+(362,60,l),
+(411,93,o),
+(435,168,o),
+(435,249,cs),
+(435,407,o),
+(362,492,o),
+(243,492,cs),
+(128,492,o),
+(52,407,o),
+(52,245,cs),
+(52,84,o),
+(127,0,o),
+(256,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(178,76,o),
+(141,129,o),
+(141,244,cs),
+(141,360,o),
+(177,413,o),
+(243,413,cs),
+(310,413,o),
+(346,359,o),
+(346,244,cs),
+(346,135,o),
+(310,76,o),
+(243,76,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(610,614,l),
+(610,690,l),
+(61,690,l),
+(61,614,l)
+);
+}
+);
+width = 663;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159E;
+unicode = 5534;
+},
+{
+glyphname = "thWoodScree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(354,345,l),
+(354,399,l),
+(213,399,l),
+(216,377,l),
+(242,390,o),
+(256,432,o),
+(256,479,cs),
+(256,559,o),
+(217,607,o),
+(153,607,cs),
+(89,607,o),
+(49,558,o),
+(49,476,cs),
+(49,394,o),
+(89,345,o),
+(157,345,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(123,391,o),
+(104,418,o),
+(104,476,cs),
+(104,534,o),
+(123,559,o),
+(154,559,cs),
+(184,559,o),
+(200,533,o),
+(200,475,cs),
+(200,418,o),
+(183,391,o),
+(153,391,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(348,667,l),
+(348,721,l),
+(53,721,l),
+(53,667,l)
+);
+}
+);
+width = 403;
+}
+);
+metricRight = "=|";
+note = uni159F;
+unicode = 5535;
+},
+{
+glyphname = "lhi-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (364,690);
+},
+{
+name = top_right_can;
+pos = (446,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(297,0,l),
+(297,80,l),
+(281,80,ls),
+(187,80,o),
+(138,133,o),
+(138,237,cs),
+(138,342,o),
+(187,396,o),
+(279,396,cs),
+(607,396,l),
+(607,469,l),
+(463,726,l),
+(393,686,l),
+(537,429,l),
+(537,478,l),
+(275,478,ls),
+(135,478,o),
+(49,394,o),
+(49,238,cs),
+(49,83,o),
+(133,0,o),
+(274,0,cs)
+);
+}
+);
+width = 653;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A0;
+unicode = 5536;
+},
+{
+glyphname = "lhii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "lhi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (297,0);
+ref = dot_top;
+}
+);
+width = 653;
+}
+);
+note = uni15A1;
+unicode = 5537;
+},
+{
+glyphname = "lho-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (321,496);
+},
+{
+name = top_right_can;
+pos = (408,496);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(259,-209,l),
+(116,49,l),
+(115,-1,l),
+(378,-1,ls),
+(518,-1,o),
+(604,83,o),
+(604,240,cs),
+(604,395,o),
+(519,478,o),
+(379,478,cs),
+(355,478,l),
+(355,398,l),
+(371,398,ls),
+(466,398,o),
+(514,344,o),
+(514,242,cs),
+(514,135,o),
+(465,81,o),
+(374,81,cs),
+(46,81,l),
+(46,9,l),
+(189,-250,l)
+);
+}
+);
+width = 653;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni15A2;
+unicode = 5538;
+},
+{
+glyphname = "lhoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "lho-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (341,-194);
+ref = dot_top;
+}
+);
+width = 653;
+}
+);
+note = uni15A3;
+unicode = 5539;
+},
+{
+glyphname = "lha-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (334,496);
+},
+{
+name = top_left_can;
+pos = (245,496);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(607,9,l),
+(607,82,l),
+(279,82,ls),
+(187,82,o),
+(138,135,o),
+(138,242,cs),
+(138,345,o),
+(187,398,o),
+(281,398,cs),
+(297,398,l),
+(297,478,l),
+(274,478,ls),
+(133,478,o),
+(49,395,o),
+(49,241,cs),
+(49,84,o),
+(135,0,o),
+(275,0,cs),
+(537,0,l),
+(537,49,l),
+(393,-209,l),
+(463,-249,l)
+);
+}
+);
+width = 653;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A4;
+unicode = 5540;
+},
+{
+glyphname = "lhaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "lha-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (178,-194);
+ref = dot_top;
+}
+);
+width = 653;
+}
+);
+note = uni15A5;
+unicode = 5541;
+},
+{
+glyphname = "lh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(351,351,l),
+(351,404,l),
+(210,404,ls),
+(139,404,o),
+(108,445,o),
+(108,518,cs),
+(108,589,o),
+(139,631,o),
+(200,631,cs),
+(207,631,l),
+(207,690,l),
+(197,690,ls),
+(98,690,o),
+(47,619,o),
+(47,518,cs),
+(47,412,o),
+(98,345,o),
+(209,345,cs),
+(310,345,l),
+(303,380,l),
+(223,236,l),
+(271,208,l)
+);
+}
+);
+width = 398;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni15A6;
+unicode = 5542;
+},
+{
+glyphname = "theThCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (80,690);
+},
+{
+name = top_right_can;
+pos = (360,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(405,0,l),
+(405,104,l),
+(467,104,l),
+(467,158,l),
+(405,158,l),
+(405,323,l),
+(134,323,l),
+(153,294,l),
+(423,651,l),
+(358,701,l),
+(36,272,l),
+(36,242,l),
+(315,242,l),
+(315,158,l),
+(130,158,l),
+(130,104,l),
+(315,104,l),
+(315,0,l)
+);
+}
+);
+width = 497;
+}
+);
+metricLeft = "ye-canadian";
+note = uni15A7;
+unicode = 5543;
+},
+{
+glyphname = "thiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (137,690);
+},
+{
+name = top_right_can;
+pos = (417,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(182,0,l),
+(182,104,l),
+(367,104,l),
+(367,158,l),
+(182,158,l),
+(182,242,l),
+(461,242,l),
+(461,272,l),
+(139,701,l),
+(73,651,l),
+(351,286,l),
+(363,323,l),
+(92,323,l),
+(92,158,l),
+(30,158,l),
+(30,104,l),
+(92,104,l),
+(92,0,l)
+);
+}
+);
+width = 497;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+unicode = 5544;
+},
+{
+glyphname = "thiiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (70,0);
+ref = dot_top;
+}
+);
+width = 497;
+}
+);
+note = uni15A9;
+unicode = 5545;
+},
+{
+glyphname = "thoThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (80,690);
+},
+{
+name = top_right_can;
+pos = (360,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(423,39,l),
+(152,395,l),
+(134,367,l),
+(405,367,l),
+(405,531,l),
+(467,531,l),
+(467,585,l),
+(405,585,l),
+(405,690,l),
+(315,690,l),
+(315,585,l),
+(130,585,l),
+(130,531,l),
+(315,531,l),
+(315,447,l),
+(36,447,l),
+(36,417,l),
+(358,-12,l)
+);
+}
+);
+width = 497;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+unicode = 5546;
+},
+{
+glyphname = "thooThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (293,0);
+ref = dot_top;
+}
+);
+width = 497;
+}
+);
+note = uni15AB;
+unicode = 5547;
+},
+{
+glyphname = "thaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (137,690);
+},
+{
+name = top_right_can;
+pos = (417,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(461,417,l),
+(461,447,l),
+(182,447,l),
+(182,531,l),
+(367,531,l),
+(367,585,l),
+(182,585,l),
+(182,690,l),
+(92,690,l),
+(92,585,l),
+(30,585,l),
+(30,531,l),
+(92,531,l),
+(92,367,l),
+(363,367,l),
+(345,395,l),
+(73,39,l),
+(139,-12,l)
+);
+}
+);
+width = 497;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+unicode = 5548;
+},
+{
+glyphname = "thaaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (69,0);
+ref = dot_top;
+}
+);
+width = 497;
+}
+);
+note = uni15AD;
+unicode = 5549;
+},
+{
+glyphname = "thThCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(265,549,l),
+(265,568,l),
+(130,568,l),
+(130,613,l),
+(216,613,l),
+(216,644,l),
+(130,644,l),
+(130,690,l),
+(69,690,l),
+(69,644,l),
+(37,644,l),
+(37,613,l),
+(69,613,l),
+(69,515,l),
+(213,515,l),
+(199,553,l),
+(64,368,l),
+(110,337,l)
+);
+}
+);
+width = 291;
+}
+);
+metricRight = "y-canadian";
+note = uni15AE;
+unicode = 5550;
+},
+{
+glyphname = "bAivilik-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(367,-13,o),
+(436,81,o),
+(436,242,cs),
+(436,397,o),
+(368,492,o),
+(263,492,cs),
+(198,492,o),
+(153,451,o),
+(142,397,c),
+(150,372,l),
+(150,690,l),
+(60,690,l),
+(60,0,l),
+(142,0,l),
+(142,100,l),
+(138,85,l),
+(153,28,o),
+(195,-13,o),
+(265,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(185,65,o),
+(149,120,o),
+(149,239,cs),
+(149,358,o),
+(185,413,o),
+(248,413,cs),
+(311,413,o),
+(347,358,o),
+(347,239,cs),
+(347,120,o),
+(312,65,o),
+(248,65,cs)
+);
+}
+);
+width = 485;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|ke-canadian";
+note = uni15AF;
+unicode = 5551;
+},
+{
+glyphname = "eBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(150,0,l),
+(150,406,l),
+(175,370,o),
+(213,350,o),
+(259,350,cs),
+(348,350,o),
+(406,425,o),
+(406,526,cs),
+(406,628,o),
+(348,702,o),
+(259,702,cs),
+(210,702,o),
+(169,679,o),
+(146,639,c),
+(146,690,l),
+(60,690,l),
+(60,0,l)
+);
+}
+);
+width = 442;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B0;
+unicode = 5552;
+},
+{
+glyphname = "iBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(231,-13,o),
+(271,11,o),
+(296,50,c),
+(296,0,l),
+(382,0,l),
+(382,690,l),
+(291,690,l),
+(291,284,l),
+(266,320,o),
+(227,340,o),
+(182,340,cs),
+(93,340,o),
+(36,265,o),
+(36,163,cs),
+(36,62,o),
+(93,-13,o),
+(182,-13,cs)
+);
+}
+);
+width = 442;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B1;
+unicode = 5553;
+},
+{
+glyphname = "oBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(348,-13,o),
+(406,62,o),
+(406,163,cs),
+(406,265,o),
+(348,340,o),
+(259,340,cs),
+(213,340,o),
+(175,320,o),
+(150,284,c),
+(150,690,l),
+(60,690,l),
+(60,0,l),
+(146,0,l),
+(146,50,l),
+(169,11,o),
+(210,-13,o),
+(259,-13,cs)
+);
+}
+);
+width = 442;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "eBlackfoot-canadian";
+note = uni15B2;
+unicode = 5554;
+},
+{
+glyphname = "aBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(382,0,l),
+(382,690,l),
+(296,690,l),
+(296,639,l),
+(271,679,o),
+(231,702,o),
+(182,702,cs),
+(93,702,o),
+(36,628,o),
+(36,526,cs),
+(36,425,o),
+(93,350,o),
+(182,350,cs),
+(227,350,o),
+(266,370,o),
+(291,406,c),
+(291,0,l)
+);
+}
+);
+width = 442;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B3;
+unicode = 5555;
+},
+{
+glyphname = "weBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(150,305,l),
+(422,305,l),
+(422,384,l),
+(150,384,l),
+(150,611,l),
+(422,611,l),
+(422,690,l),
+(60,690,l),
+(60,0,l),
+(150,0,l)
+);
+}
+);
+width = 468;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B4;
+unicode = 5556;
+},
+{
+glyphname = "wiBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(409,0,l),
+(409,690,l),
+(319,690,l),
+(319,384,l),
+(46,384,l),
+(46,306,l),
+(319,306,l),
+(319,78,l),
+(46,78,l),
+(46,0,l)
+);
+}
+);
+width = 469;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B5;
+unicode = 5557;
+},
+{
+glyphname = "woBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(422,0,l),
+(422,78,l),
+(150,78,l),
+(150,306,l),
+(422,306,l),
+(422,384,l),
+(150,384,l),
+(150,690,l),
+(60,690,l),
+(60,0,l)
+);
+}
+);
+width = 468;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "weBlackfoot-canadian";
+note = uni15B6;
+unicode = 5558;
+},
+{
+glyphname = "waBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(409,0,l),
+(409,690,l),
+(46,690,l),
+(46,611,l),
+(319,611,l),
+(319,384,l),
+(46,384,l),
+(46,305,l),
+(319,305,l),
+(319,0,l)
+);
+}
+);
+width = 469;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B7;
+unicode = 5559;
+},
+{
+glyphname = "neBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(150,0,l),
+(150,622,l),
+(194,622,l),
+(166,671,l),
+(166,645,ls),
+(166,488,o),
+(230,400,o),
+(351,400,cs),
+(469,400,o),
+(541,490,o),
+(541,643,cs),
+(541,690,l),
+(452,690,l),
+(452,634,ls),
+(452,533,o),
+(418,479,o),
+(353,479,cs),
+(288,479,o),
+(254,532,o),
+(254,633,cs),
+(254,690,l),
+(60,690,l),
+(60,0,l)
+);
+}
+);
+width = 573;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B8;
+unicode = 5560;
+},
+{
+glyphname = "niBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,0,l),
+(121,56,ls),
+(121,156,o),
+(155,211,o),
+(220,211,cs),
+(285,211,o),
+(319,157,o),
+(319,57,cs),
+(319,0,l),
+(513,0,l),
+(513,690,l),
+(423,690,l),
+(423,68,l),
+(379,68,l),
+(407,18,l),
+(407,44,ls),
+(407,202,o),
+(343,290,o),
+(222,290,cs),
+(103,290,o),
+(32,200,o),
+(32,46,cs),
+(32,0,l)
+);
+}
+);
+width = 573;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B9;
+unicode = 5561;
+},
+{
+glyphname = "noBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(254,0,l),
+(254,57,ls),
+(254,157,o),
+(288,211,o),
+(353,211,cs),
+(418,211,o),
+(452,156,o),
+(452,56,cs),
+(452,0,l),
+(541,0,l),
+(541,46,ls),
+(541,200,o),
+(469,290,o),
+(351,290,cs),
+(230,290,o),
+(166,202,o),
+(166,44,cs),
+(166,18,l),
+(194,68,l),
+(150,68,l),
+(150,690,l),
+(60,690,l),
+(60,0,l)
+);
+}
+);
+width = 573;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "neBlackfoot-canadian";
+note = uni15BA;
+unicode = 5562;
+},
+{
+glyphname = "naBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(513,0,l),
+(513,690,l),
+(319,690,l),
+(319,633,ls),
+(319,532,o),
+(285,479,o),
+(220,479,cs),
+(155,479,o),
+(121,533,o),
+(121,634,cs),
+(121,690,l),
+(32,690,l),
+(32,643,ls),
+(32,490,o),
+(103,400,o),
+(222,400,cs),
+(343,400,o),
+(407,488,o),
+(407,645,cs),
+(407,671,l),
+(379,622,l),
+(423,622,l),
+(423,0,l)
+);
+}
+);
+width = 573;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BB;
+unicode = 5563;
+},
+{
+glyphname = "keBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(150,0,l),
+(150,585,l),
+(118,585,l),
+(259,256,l),
+(300,256,l),
+(488,690,l),
+(398,690,l),
+(255,355,l),
+(287,355,l),
+(144,690,l),
+(60,690,l),
+(60,0,l)
+);
+}
+);
+width = 508;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15BC;
+unicode = 5564;
+},
+{
+glyphname = "kiBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(110,0,l),
+(254,335,l),
+(221,335,l),
+(364,0,l),
+(449,0,l),
+(449,690,l),
+(358,690,l),
+(358,104,l),
+(390,104,l),
+(249,434,l),
+(209,434,l),
+(20,0,l)
+);
+}
+);
+width = 509;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BD;
+unicode = 5565;
+},
+{
+glyphname = "koBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(144,0,l),
+(287,335,l),
+(255,335,l),
+(398,0,l),
+(488,0,l),
+(300,434,l),
+(259,434,l),
+(118,104,l),
+(150,104,l),
+(150,690,l),
+(60,690,l),
+(60,0,l)
+);
+}
+);
+width = 508;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "keBlackfoot-canadian";
+note = uni15BE;
+unicode = 5566;
+},
+{
+glyphname = "kaBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(449,0,l),
+(449,690,l),
+(364,690,l),
+(221,355,l),
+(254,355,l),
+(110,690,l),
+(20,690,l),
+(209,256,l),
+(249,256,l),
+(390,585,l),
+(358,585,l),
+(358,0,l)
+);
+}
+);
+width = 509;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BF;
+unicode = 5567;
+},
+{
+color = 9;
+glyphname = "heSayisi-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_right_can;
+pos = (440,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(485,0,l),
+(485,690,l),
+(396,690,l),
+(396,302,l),
+(411,302,l),
+(407,554,o),
+(331,702,o),
+(209,702,cs),
+(103,702,o),
+(43,618,o),
+(43,451,cs),
+(43,416,o),
+(45,373,o),
+(53,336,c),
+(138,336,l),
+(132,369,o),
+(129,413,o),
+(129,440,cs),
+(129,572,o),
+(167,623,o),
+(229,623,cs),
+(330,623,o),
+(393,453,o),
+(395,0,c)
+);
+}
+);
+width = 545;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni15C0;
+unicode = 5568;
+},
+{
+color = 9;
+glyphname = "hiSayisi-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(150,0,l),
+(152,453,o),
+(214,623,o),
+(316,623,cs),
+(378,623,o),
+(415,572,o),
+(415,440,cs),
+(415,413,o),
+(412,369,o),
+(407,336,c),
+(492,336,l),
+(499,373,o),
+(502,416,o),
+(502,451,cs),
+(502,618,o),
+(441,702,o),
+(336,702,cs),
+(213,702,o),
+(139,554,o),
+(134,302,c),
+(149,302,l),
+(149,690,l),
+(60,690,l),
+(60,0,l)
+);
+}
+);
+width = 545;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C1;
+unicode = 5569;
+},
+{
+color = 9;
+glyphname = "hoSayisi-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (268,690);
+},
+{
+name = top_left_can;
+pos = (95,690);
+},
+{
+name = top_right_can;
+pos = (441,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(331,-13,o),
+(407,136,o),
+(411,387,c),
+(396,387,l),
+(396,0,l),
+(485,0,l),
+(485,690,l),
+(395,690,l),
+(393,237,o),
+(330,67,o),
+(229,67,cs),
+(167,67,o),
+(129,118,o),
+(129,250,cs),
+(129,276,o),
+(132,321,o),
+(138,354,c),
+(53,354,l),
+(45,317,o),
+(43,273,o),
+(43,239,cs),
+(43,71,o),
+(103,-13,o),
+(209,-13,cs)
+);
+}
+);
+width = 545;
+}
+);
+metricLeft = "heSayisi-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15C2;
+unicode = 5570;
+},
+{
+color = 9;
+glyphname = "haSayisi-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(441,-13,o),
+(502,71,o),
+(502,239,cs),
+(502,273,o),
+(499,317,o),
+(492,354,c),
+(407,354,l),
+(412,321,o),
+(415,276,o),
+(415,250,cs),
+(415,118,o),
+(378,67,o),
+(316,67,cs),
+(214,67,o),
+(152,237,o),
+(150,690,c),
+(60,690,l),
+(60,0,l),
+(149,0,l),
+(149,387,l),
+(134,387,l),
+(139,136,o),
+(213,-13,o),
+(336,-13,cs)
+);
+}
+);
+width = 545;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C3;
+unicode = 5571;
+},
+{
+color = 9;
+glyphname = "ghuCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(303,0,l),
+(552,665,l),
+(552,690,l),
+(478,690,l),
+(397,466,l),
+(443,481,l),
+(134,481,l),
+(182,464,l),
+(99,690,l),
+(25,690,l),
+(25,665,l),
+(273,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(422,413,l),
+(386,425,l),
+(274,113,l),
+(303,113,l),
+(191,427,l),
+(156,413,l)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C4;
+unicode = 5572;
+},
+{
+color = 9;
+glyphname = "ghoCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,0,l),
+(182,226,l),
+(134,209,l),
+(443,209,l),
+(397,224,l),
+(478,0,l),
+(552,0,l),
+(552,25,l),
+(303,690,l),
+(273,690,l),
+(25,25,l),
+(25,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(303,577,l),
+(274,577,l),
+(386,265,l),
+(422,276,l),
+(156,276,l),
+(191,263,l)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C5;
+unicode = 5573;
+},
+{
+color = 9;
+glyphname = "gheCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (61,345);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(64,0,l),
+(497,328,l),
+(497,361,l),
+(64,690,l),
+(41,690,l),
+(41,616,l),
+(168,519,l),
+(160,562,l),
+(160,125,l),
+(168,170,l),
+(41,72,l),
+(41,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(224,526,l),
+(208,498,l),
+(438,322,l),
+(438,368,l),
+(208,193,l),
+(224,164,l)
+);
+}
+);
+width = 526;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15C6;
+unicode = 5574;
+},
+{
+color = 9;
+glyphname = "gheeCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (23,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 526;
+}
+);
+note = uni15C7;
+unicode = 5575;
+},
+{
+color = 9;
+glyphname = "ghiCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (2,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 526;
+}
+);
+note = uni15C8;
+unicode = 5576;
+},
+{
+color = 9;
+glyphname = "ghaCarrier-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(486,0,l),
+(486,72,l),
+(359,170,l),
+(367,132,l),
+(367,557,l),
+(359,519,l),
+(486,616,l),
+(486,690,l),
+(463,690,l),
+(29,361,l),
+(29,328,l),
+(463,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(319,191,l),
+(89,368,l),
+(89,321,l),
+(319,497,l),
+(303,511,l),
+(303,184,l)
+);
+}
+);
+width = 527;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15C9;
+unicode = 5577;
+},
+{
+color = 9;
+glyphname = "ruCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(303,0,l),
+(552,665,l),
+(552,690,l),
+(479,690,l),
+(445,598,l),
+(469,612,l),
+(108,612,l),
+(134,598,l),
+(100,690,l),
+(25,690,l),
+(25,665,l),
+(273,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(449,545,l),
+(437,562,l),
+(276,114,l),
+(305,114,l),
+(145,562,l),
+(128,545,l)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CA;
+unicode = 5578;
+},
+{
+color = 9;
+glyphname = "roCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,0,l),
+(133,92,l),
+(109,77,l),
+(469,77,l),
+(444,92,l),
+(478,0,l),
+(552,0,l),
+(552,25,l),
+(303,690,l),
+(273,690,l),
+(25,25,l),
+(25,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(303,577,l),
+(273,577,l),
+(435,128,l),
+(451,145,l),
+(129,145,l),
+(143,128,l)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CB;
+unicode = 5579;
+},
+{
+color = 9;
+glyphname = "reCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(64,0,l),
+(497,328,l),
+(497,361,l),
+(64,690,l),
+(41,690,l),
+(41,614,l),
+(104,565,l),
+(94,591,l),
+(94,98,l),
+(104,125,l),
+(41,74,l),
+(41,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(158,570,l),
+(147,540,l),
+(432,321,l),
+(432,368,l),
+(147,150,l),
+(158,118,l)
+);
+}
+);
+width = 526;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CC;
+unicode = 5580;
+},
+{
+color = 9;
+glyphname = "reeCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(64,0,l),
+(497,328,l),
+(497,361,l),
+(64,690,l),
+(41,690,l),
+(41,625,l),
+(104,575,l),
+(94,592,l),
+(94,97,l),
+(104,114,l),
+(41,65,l),
+(41,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(151,570,l),
+(141,554,l),
+(446,321,l),
+(446,368,l),
+(140,133,l),
+(151,120,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(233,263,l),
+(233,428,l),
+(199,428,l),
+(199,263,l)
+);
+}
+);
+width = 526;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CD;
+unicode = 5581;
+},
+{
+color = 9;
+glyphname = "riCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(64,0,l),
+(497,328,l),
+(497,361,l),
+(64,690,l),
+(41,690,l),
+(41,625,l),
+(104,575,l),
+(94,592,l),
+(94,97,l),
+(104,114,l),
+(41,65,l),
+(41,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(251,307,o),
+(269,324,o),
+(269,345,cs),
+(269,366,o),
+(251,383,o),
+(230,383,cs),
+(211,383,o),
+(193,366,o),
+(193,345,cs),
+(193,324,o),
+(211,307,o),
+(230,307,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(151,570,l),
+(141,554,l),
+(446,321,l),
+(446,368,l),
+(140,133,l),
+(151,120,l)
+);
+}
+);
+width = 526;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CE;
+unicode = 5582;
+},
+{
+color = 9;
+glyphname = "raCarrier-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(486,0,l),
+(486,75,l),
+(422,125,l),
+(433,78,l),
+(433,612,l),
+(422,565,l),
+(486,615,l),
+(486,690,l),
+(463,690,l),
+(29,361,l),
+(29,328,l),
+(463,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(380,541,l),
+(368,572,l),
+(368,119,l),
+(380,150,l),
+(95,369,l),
+(95,322,l)
+);
+}
+);
+width = 527;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15CF;
+unicode = 5583;
+},
+{
+color = 9;
+glyphname = "wuCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(307,0,l),
+(560,665,l),
+(560,690,l),
+(492,690,l),
+(310,172,l),
+(329,172,l),
+(329,690,l),
+(262,690,l),
+(262,172,l),
+(281,172,l),
+(98,690,l),
+(25,690,l),
+(25,665,l),
+(277,0,l)
+);
+}
+);
+width = 585;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D0;
+unicode = 5584;
+},
+{
+color = 9;
+glyphname = "woCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,0,l),
+(279,518,l),
+(259,518,l),
+(259,0,l),
+(327,0,l),
+(327,518,l),
+(307,518,l),
+(491,0,l),
+(560,0,l),
+(560,25,l),
+(307,690,l),
+(277,690,l),
+(25,25,l),
+(25,0,l)
+);
+}
+);
+width = 585;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D1;
+unicode = 5585;
+},
+{
+color = 9;
+glyphname = "weCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(81,0,l),
+(515,328,l),
+(515,361,l),
+(81,690,l),
+(58,690,l),
+(58,616,l),
+(390,364,l),
+(390,380,l),
+(63,380,l),
+(63,310,l),
+(391,310,l),
+(391,325,l),
+(58,72,l),
+(58,0,l)
+);
+}
+);
+width = 544;
+}
+);
+metricRight = "o-canadian";
+note = uni15D2;
+unicode = 5586;
+},
+{
+color = 9;
+glyphname = "weeCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(81,0,l),
+(515,328,l),
+(515,361,l),
+(81,690,l),
+(58,690,l),
+(58,621,l),
+(419,351,l),
+(426,374,l),
+(176,374,l),
+(176,444,l),
+(127,444,l),
+(127,374,l),
+(58,374,l),
+(58,317,l),
+(127,317,l),
+(127,246,l),
+(176,246,l),
+(176,317,l),
+(427,317,l),
+(420,339,l),
+(58,68,l),
+(58,0,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D3;
+unicode = 5587;
+},
+{
+color = 9;
+glyphname = "wiCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(81,0,l),
+(515,328,l),
+(515,361,l),
+(81,690,l),
+(58,690,l),
+(58,621,l),
+(419,351,l),
+(426,374,l),
+(229,374,l),
+(219,395,o),
+(198,410,o),
+(173,410,cs),
+(148,410,o),
+(126,395,o),
+(116,374,c),
+(58,374,l),
+(58,317,l),
+(116,317,l),
+(126,296,o),
+(148,280,o),
+(173,280,cs),
+(197,280,o),
+(219,296,o),
+(229,317,c),
+(427,317,l),
+(420,339,l),
+(58,68,l),
+(58,0,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D4;
+unicode = 5588;
+},
+{
+color = 9;
+glyphname = "waCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(486,0,l),
+(486,73,l),
+(154,325,l),
+(154,310,l),
+(482,310,l),
+(482,380,l),
+(154,380,l),
+(154,364,l),
+(486,616,l),
+(486,690,l),
+(464,690,l),
+(29,361,l),
+(29,328,l),
+(463,0,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15D5;
+unicode = 5589;
+},
+{
+color = 9;
+glyphname = "hwuCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(307,0,l),
+(560,665,l),
+(560,690,l),
+(496,690,l),
+(420,483,l),
+(444,492,l),
+(321,492,l),
+(321,690,l),
+(266,690,l),
+(266,492,l),
+(138,492,l),
+(166,484,l),
+(92,690,l),
+(25,690,l),
+(25,665,l),
+(277,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(270,441,l),
+(270,141,l),
+(284,143,l),
+(176,449,l),
+(145,441,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(317,441,l),
+(439,441,l),
+(412,449,l),
+(303,145,l),
+(317,142,l)
+);
+}
+);
+width = 585;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D6;
+unicode = 5590;
+},
+{
+color = 9;
+glyphname = "hwoCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(92,0,l),
+(167,207,l),
+(144,194,l),
+(265,194,l),
+(265,0,l),
+(320,0,l),
+(320,194,l),
+(451,194,l),
+(420,206,l),
+(495,0,l),
+(560,0,l),
+(560,25,l),
+(307,690,l),
+(277,690,l),
+(25,25,l),
+(25,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(282,543,l),
+(269,546,l),
+(269,252,l),
+(162,252,l),
+(175,241,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(432,252,l),
+(316,252,l),
+(316,547,l),
+(302,545,l),
+(411,241,l)
+);
+}
+);
+width = 585;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D7;
+unicode = 5591;
+},
+{
+color = 9;
+glyphname = "hweCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(81,0,l),
+(515,328,l),
+(515,361,l),
+(81,690,l),
+(58,690,l),
+(58,621,l),
+(173,535,l),
+(173,375,l),
+(58,375,l),
+(58,315,l),
+(173,315,l),
+(173,154,l),
+(58,67,l),
+(58,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(220,321,l),
+(406,321,l),
+(220,181,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(220,508,l),
+(405,370,l),
+(220,370,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D8;
+unicode = 5592;
+},
+{
+color = 9;
+glyphname = "hweeCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(81,0,l),
+(515,328,l),
+(515,361,l),
+(81,690,l),
+(58,690,l),
+(58,625,l),
+(195,524,l),
+(195,371,l),
+(153,371,l),
+(153,443,l),
+(111,443,l),
+(111,371,l),
+(58,371,l),
+(58,320,l),
+(111,320,l),
+(111,247,l),
+(153,247,l),
+(153,320,l),
+(195,320,l),
+(195,166,l),
+(58,63,l),
+(58,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(239,324,l),
+(409,324,l),
+(239,191,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(239,497,l),
+(408,367,l),
+(239,367,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D9;
+unicode = 5593;
+},
+{
+color = 9;
+glyphname = "hwiCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(81,0,l),
+(515,328,l),
+(515,361,l),
+(81,690,l),
+(58,690,l),
+(58,625,l),
+(195,524,l),
+(195,367,l),
+(178,367,l),
+(170,386,o),
+(153,400,o),
+(131,400,cs),
+(110,400,o),
+(93,386,o),
+(85,367,c),
+(58,367,l),
+(58,324,l),
+(84,324,l),
+(92,304,o),
+(110,291,o),
+(131,291,cs),
+(152,291,o),
+(170,304,o),
+(178,324,c),
+(195,324,l),
+(195,166,l),
+(58,63,l),
+(58,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(239,324,l),
+(409,324,l),
+(239,191,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(239,497,l),
+(408,367,l),
+(239,367,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15DA;
+unicode = 5594;
+},
+{
+color = 9;
+glyphname = "hwaCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(486,0,l),
+(486,68,l),
+(372,154,l),
+(372,315,l),
+(486,315,l),
+(486,375,l),
+(372,375,l),
+(372,535,l),
+(486,622,l),
+(486,690,l),
+(464,690,l),
+(29,361,l),
+(29,328,l),
+(463,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(139,320,l),
+(324,320,l),
+(324,181,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(324,508,l),
+(324,369,l),
+(139,369,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15DB;
+unicode = 5595;
+},
+{
+color = 9;
+glyphname = "thuCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,-13,o),
+(526,78,o),
+(526,253,cs),
+(526,690,l),
+(56,690,l),
+(56,251,ls),
+(56,78,o),
+(145,-13,o),
+(291,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(146,609,l),
+(436,609,l),
+(436,253,ls),
+(436,127,o),
+(384,71,o),
+(291,71,cs),
+(200,71,o),
+(146,129,o),
+(146,253,cs)
+);
+}
+);
+width = 582;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DC;
+unicode = 5596;
+},
+{
+color = 9;
+glyphname = "thoCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(526,0,l),
+(526,439,ls),
+(526,611,o),
+(437,702,o),
+(291,702,cs),
+(142,702,o),
+(56,611,o),
+(56,437,cs),
+(56,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(146,437,ls),
+(146,562,o),
+(198,618,o),
+(291,618,cs),
+(382,618,o),
+(436,560,o),
+(436,437,cs),
+(436,81,l),
+(146,81,l)
+);
+}
+);
+width = 582;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DD;
+unicode = 5597;
+},
+{
+color = 9;
+glyphname = "theCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (284,345);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(217,0,ls),
+(416,0,o),
+(519,120,o),
+(519,346,cs),
+(519,572,o),
+(416,690,o),
+(214,690,cs),
+(60,690,l),
+(60,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(150,637,l),
+(123,610,l),
+(214,610,ls),
+(363,610,o),
+(429,526,o),
+(429,346,cs),
+(429,167,o),
+(363,80,o),
+(217,80,cs),
+(123,80,l),
+(150,53,l)
+);
+}
+);
+width = 568;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "to-canadian";
+note = uni15DE;
+unicode = 5598;
+},
+{
+color = 9;
+glyphname = "theeCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (240,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 568;
+}
+);
+note = uni15DF;
+unicode = 5599;
+},
+{
+color = 9;
+glyphname = "thiCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (216,0);
+ref = dot_middle;
+}
+);
+width = 568;
+}
+);
+note = uni15E0;
+unicode = 5600;
+},
+{
+color = 9;
+glyphname = "thaCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(508,0,l),
+(508,690,l),
+(351,690,ls),
+(152,690,o),
+(49,570,o),
+(49,344,cs),
+(49,118,o),
+(152,0,o),
+(354,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(139,523,o),
+(204,610,o),
+(350,610,cs),
+(445,610,l),
+(418,637,l),
+(418,53,l),
+(445,80,l),
+(353,80,ls),
+(204,80,o),
+(139,164,o),
+(139,344,cs)
+);
+}
+);
+width = 568;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15E1;
+unicode = 5601;
+},
+{
+color = 9;
+glyphname = "ttuCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,-13,o),
+(526,78,o),
+(526,253,cs),
+(526,690,l),
+(496,690,l),
+(279,506,l),
+(303,506,l),
+(87,690,l),
+(56,690,l),
+(56,251,ls),
+(56,78,o),
+(145,-13,o),
+(291,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,71,o),
+(146,129,o),
+(146,253,cs),
+(146,619,l),
+(67,615,l),
+(282,433,l),
+(300,433,l),
+(516,615,l),
+(436,619,l),
+(436,253,ls),
+(436,127,o),
+(384,71,o),
+(291,71,cs)
+);
+}
+);
+width = 582;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E2;
+unicode = 5602;
+},
+{
+color = 9;
+glyphname = "ttoCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(86,0,l),
+(302,184,l),
+(278,184,l),
+(495,0,l),
+(526,0,l),
+(526,439,ls),
+(526,611,o),
+(437,702,o),
+(291,702,cs),
+(142,702,o),
+(56,611,o),
+(56,437,cs),
+(56,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(382,618,o),
+(436,560,o),
+(436,437,cs),
+(436,71,l),
+(515,74,l),
+(299,257,l),
+(281,257,l),
+(66,74,l),
+(146,71,l),
+(146,437,ls),
+(146,563,o),
+(198,618,o),
+(291,618,cs)
+);
+}
+);
+width = 582;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E3;
+unicode = 5603;
+},
+{
+color = 9;
+glyphname = "tteCarrier-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (327,345);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(227,0,ls),
+(426,0,o),
+(528,120,o),
+(528,346,cs),
+(528,572,o),
+(426,690,o),
+(224,690,cs),
+(55,690,l),
+(55,665,l),
+(155,331,l),
+(155,358,l),
+(55,25,l),
+(55,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(237,335,l),
+(237,352,l),
+(137,682,l),
+(137,610,l),
+(225,610,ls),
+(374,610,o),
+(439,526,o),
+(439,346,cs),
+(439,167,o),
+(374,80,o),
+(228,80,cs),
+(137,80,l),
+(137,5,l)
+);
+}
+);
+width = 577;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15E4;
+unicode = 5604;
+},
+{
+color = 9;
+glyphname = "tteeCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (290,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 578;
+}
+);
+note = uni15E5;
+unicode = 5605;
+},
+{
+color = 9;
+glyphname = "ttiCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (277,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 578;
+}
+);
+note = uni15E6;
+unicode = 5606;
+},
+{
+color = 9;
+glyphname = "ttaCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(523,0,l),
+(523,25,l),
+(423,358,l),
+(423,331,l),
+(523,665,l),
+(523,690,l),
+(351,690,ls),
+(152,690,o),
+(49,570,o),
+(49,344,cs),
+(49,118,o),
+(152,0,o),
+(354,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(440,80,l),
+(353,80,ls),
+(204,80,o),
+(139,164,o),
+(139,344,cs),
+(139,523,o),
+(204,610,o),
+(350,610,cs),
+(440,610,l),
+(440,685,l),
+(341,355,l),
+(341,338,l),
+(440,8,l)
+);
+}
+);
+width = 578;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tteCarrier-canadian";
+note = uni15E7;
+unicode = 5607;
+},
+{
+color = 9;
+glyphname = "puCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,-13,o),
+(526,78,o),
+(526,253,cs),
+(526,690,l),
+(435,690,l),
+(435,527,l),
+(147,527,l),
+(147,690,l),
+(56,690,l),
+(56,251,ls),
+(56,78,o),
+(145,-13,o),
+(291,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,71,o),
+(147,129,o),
+(147,253,cs),
+(147,447,l),
+(435,447,l),
+(435,253,ls),
+(435,127,o),
+(384,71,o),
+(291,71,cs)
+);
+}
+);
+width = 582;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E8;
+unicode = 5608;
+},
+{
+color = 9;
+glyphname = "poCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(147,0,l),
+(147,162,l),
+(435,162,l),
+(435,0,l),
+(526,0,l),
+(526,439,ls),
+(526,611,o),
+(438,702,o),
+(291,702,cs),
+(146,702,o),
+(56,611,o),
+(56,437,cs),
+(56,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(147,437,ls),
+(147,562,o),
+(198,618,o),
+(291,618,cs),
+(382,618,o),
+(435,560,o),
+(435,437,cs),
+(435,242,l),
+(147,242,l)
+);
+}
+);
+width = 582;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E9;
+unicode = 5609;
+},
+{
+color = 9;
+glyphname = "peCarrier-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (316,345);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(225,0,ls),
+(424,0,o),
+(526,120,o),
+(526,346,cs),
+(526,572,o),
+(424,690,o),
+(221,690,cs),
+(53,690,l),
+(53,610,l),
+(122,610,l),
+(122,80,l),
+(53,80,l),
+(53,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(211,637,l),
+(172,610,l),
+(222,610,ls),
+(371,610,o),
+(436,526,o),
+(436,346,cs),
+(436,167,o),
+(371,80,o),
+(225,80,cs),
+(172,80,l),
+(211,53,l)
+);
+}
+);
+width = 575;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15EA;
+unicode = 5610;
+},
+{
+color = 9;
+glyphname = "peeCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (278,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 575;
+}
+);
+note = uni15EB;
+unicode = 5611;
+},
+{
+color = 9;
+glyphname = "piCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (266,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 575;
+}
+);
+note = uni15EC;
+unicode = 5612;
+},
+{
+color = 9;
+glyphname = "paCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(523,0,l),
+(523,80,l),
+(454,80,l),
+(454,610,l),
+(523,610,l),
+(523,690,l),
+(354,690,ls),
+(152,690,o),
+(49,572,o),
+(49,346,cs),
+(49,120,o),
+(152,0,o),
+(351,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(403,80,l),
+(350,80,ls),
+(204,80,o),
+(139,167,o),
+(139,346,cs),
+(139,526,o),
+(204,610,o),
+(353,610,cs),
+(403,610,l),
+(364,637,l),
+(364,53,l)
+);
+}
+);
+width = 576;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|peCarrier-canadian";
+note = uni15ED;
+unicode = 5613;
+},
+{
+color = 6;
+glyphname = "pCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(309,183,l),
+(309,242,l),
+(210,242,l),
+(210,527,l),
+(149,527,l),
+(149,242,l),
+(49,242,l),
+(49,183,l)
+);
+}
+);
+width = 358;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni15EE;
+unicode = 5614;
+},
+{
+color = 9;
+glyphname = "guCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (343,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(290,-13,o),
+(341,30,o),
+(362,116,c),
+(324,116,l),
+(349,29,o),
+(399,-13,o),
+(470,-13,cs),
+(568,-13,o),
+(631,55,o),
+(631,181,cs),
+(631,690,l),
+(544,690,l),
+(544,185,ls),
+(544,106,o),
+(516,70,o),
+(466,70,cs),
+(415,70,o),
+(385,107,o),
+(385,185,cs),
+(385,690,l),
+(301,690,l),
+(301,185,ls),
+(301,106,o),
+(271,70,o),
+(221,70,cs),
+(169,70,o),
+(141,106,o),
+(141,185,cs),
+(141,690,l),
+(55,690,l),
+(55,183,ls),
+(55,55,o),
+(119,-13,o),
+(215,-13,cs)
+);
+}
+);
+width = 686;
+}
+);
+metricRight = "=|";
+note = uni15EF;
+unicode = 5615;
+},
+{
+color = 9;
+glyphname = "goCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(141,0,l),
+(141,504,ls),
+(141,583,o),
+(169,620,o),
+(220,620,cs),
+(270,620,o),
+(300,582,o),
+(300,504,cs),
+(300,0,l),
+(384,0,l),
+(384,504,ls),
+(384,583,o),
+(413,620,o),
+(464,620,cs),
+(516,620,o),
+(544,583,o),
+(544,504,cs),
+(544,0,l),
+(631,0,l),
+(631,507,ls),
+(631,635,o),
+(566,702,o),
+(469,702,cs),
+(396,702,o),
+(345,660,o),
+(323,574,c),
+(362,574,l),
+(337,661,o),
+(286,702,o),
+(214,702,cs),
+(118,702,o),
+(55,635,o),
+(55,508,cs),
+(55,0,l)
+);
+}
+);
+width = 686;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F0;
+unicode = 5616;
+},
+{
+color = 9;
+glyphname = "geCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (290,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(322,0,ls),
+(445,0,o),
+(519,66,o),
+(519,185,cs),
+(519,268,o),
+(473,333,o),
+(403,359,c),
+(403,331,l),
+(475,354,o),
+(519,416,o),
+(519,502,cs),
+(519,623,o),
+(444,690,o),
+(322,690,cs),
+(60,690,l),
+(60,614,l),
+(305,614,ls),
+(383,614,o),
+(429,579,o),
+(429,499,cs),
+(429,421,o),
+(383,383,o),
+(306,383,cs),
+(60,383,l),
+(60,308,l),
+(307,308,ls),
+(382,308,o),
+(429,269,o),
+(429,189,cs),
+(429,111,o),
+(383,75,o),
+(305,75,cs),
+(60,75,l),
+(60,0,l)
+);
+}
+);
+width = 576;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15F1;
+unicode = 5617;
+},
+{
+color = 9;
+glyphname = "geeCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(322,0,ls),
+(445,0,o),
+(519,66,o),
+(519,185,cs),
+(519,268,o),
+(473,333,o),
+(403,359,c),
+(403,331,l),
+(475,354,o),
+(519,416,o),
+(519,502,cs),
+(519,623,o),
+(444,690,o),
+(322,690,cs),
+(60,690,l),
+(60,614,l),
+(305,614,ls),
+(383,614,o),
+(429,579,o),
+(429,499,cs),
+(429,421,o),
+(383,382,o),
+(306,382,cs),
+(276,382,l),
+(276,463,l),
+(226,463,l),
+(226,382,l),
+(60,382,l),
+(60,309,l),
+(226,309,l),
+(226,229,l),
+(276,229,l),
+(276,309,l),
+(307,309,ls),
+(382,309,o),
+(429,269,o),
+(429,189,cs),
+(429,111,o),
+(383,75,o),
+(305,75,cs),
+(60,75,l),
+(60,0,l)
+);
+}
+);
+width = 576;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F2;
+unicode = 5618;
+},
+{
+color = 9;
+glyphname = "giCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(322,0,ls),
+(445,0,o),
+(519,66,o),
+(519,185,cs),
+(519,268,o),
+(473,333,o),
+(403,358,c),
+(403,331,l),
+(475,355,o),
+(519,416,o),
+(519,502,cs),
+(519,623,o),
+(444,690,o),
+(322,690,cs),
+(60,690,l),
+(60,614,l),
+(305,614,ls),
+(383,614,o),
+(429,579,o),
+(429,499,cs),
+(429,421,o),
+(383,382,o),
+(314,382,cs),
+(291,382,l),
+(322,370,l),
+(312,398,o),
+(287,417,o),
+(256,417,cs),
+(230,417,o),
+(208,403,o),
+(196,382,c),
+(60,382,l),
+(60,309,l),
+(196,309,l),
+(207,287,o),
+(230,272,o),
+(256,272,cs),
+(287,272,o),
+(312,293,o),
+(322,321,c),
+(291,309,l),
+(315,309,ls),
+(382,309,o),
+(429,269,o),
+(429,189,cs),
+(429,111,o),
+(383,75,o),
+(305,75,cs),
+(60,75,l),
+(60,0,l)
+);
+}
+);
+width = 576;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F3;
+unicode = 5619;
+},
+{
+color = 9;
+glyphname = "gaCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (301,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(517,0,l),
+(517,75,l),
+(270,75,ls),
+(194,75,o),
+(147,111,o),
+(147,189,cs),
+(147,269,o),
+(195,308,o),
+(270,308,cs),
+(517,308,l),
+(517,383,l),
+(270,383,ls),
+(193,383,o),
+(147,421,o),
+(147,499,cs),
+(147,579,o),
+(193,614,o),
+(270,614,cs),
+(517,614,l),
+(517,690,l),
+(254,690,ls),
+(132,690,o),
+(57,623,o),
+(57,502,cs),
+(57,416,o),
+(100,355,o),
+(174,331,c),
+(174,359,l),
+(102,333,o),
+(57,268,o),
+(57,185,cs),
+(57,66,o),
+(130,0,o),
+(254,0,cs)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|geCarrier-canadian";
+note = uni15F4;
+unicode = 5620;
+},
+{
+color = 9;
+glyphname = "khuCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(291,-13,o),
+(341,30,o),
+(363,116,c),
+(324,116,l),
+(350,29,o),
+(400,-13,o),
+(471,-13,cs),
+(568,-13,o),
+(631,55,o),
+(631,181,cs),
+(631,690,l),
+(55,690,l),
+(55,183,ls),
+(55,55,o),
+(119,-13,o),
+(215,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(170,70,o),
+(142,106,o),
+(142,185,cs),
+(142,611,l),
+(302,611,l),
+(302,185,ls),
+(302,106,o),
+(273,70,o),
+(222,70,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(415,70,o),
+(385,107,o),
+(385,185,cs),
+(385,611,l),
+(544,611,l),
+(544,185,ls),
+(544,106,o),
+(516,70,o),
+(466,70,cs)
+);
+}
+);
+width = 686;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F5;
+unicode = 5621;
+},
+{
+color = 9;
+glyphname = "khoCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(631,0,l),
+(631,507,ls),
+(631,635,o),
+(566,702,o),
+(469,702,cs),
+(395,702,o),
+(344,660,o),
+(323,574,c),
+(361,574,l),
+(336,661,o),
+(286,702,o),
+(214,702,cs),
+(117,702,o),
+(55,635,o),
+(55,508,cs),
+(55,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(141,504,ls),
+(141,583,o),
+(170,620,o),
+(220,620,cs),
+(270,620,o),
+(300,582,o),
+(300,504,cs),
+(300,79,l),
+(141,79,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(383,504,ls),
+(383,583,o),
+(412,620,o),
+(464,620,cs),
+(515,620,o),
+(544,583,o),
+(544,504,cs),
+(544,79,l),
+(383,79,l)
+);
+}
+);
+width = 686;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F6;
+unicode = 5622;
+},
+{
+color = 9;
+glyphname = "kheCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(326,0,ls),
+(449,0,o),
+(523,66,o),
+(523,185,cs),
+(523,268,o),
+(477,333,o),
+(406,359,c),
+(406,331,l),
+(479,354,o),
+(523,416,o),
+(523,502,cs),
+(523,623,o),
+(447,690,o),
+(326,690,cs),
+(60,690,l),
+(60,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(149,308,l),
+(310,308,ls),
+(384,308,o),
+(432,269,o),
+(432,189,cs),
+(432,111,o),
+(385,74,o),
+(309,74,cs),
+(149,74,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(149,615,l),
+(309,615,ls),
+(386,615,o),
+(432,579,o),
+(432,499,cs),
+(432,421,o),
+(385,382,o),
+(310,382,cs),
+(149,382,l)
+);
+}
+);
+width = 580;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F7;
+unicode = 5623;
+},
+{
+color = 9;
+glyphname = "kheeCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(326,0,ls),
+(449,0,o),
+(523,66,o),
+(523,185,cs),
+(523,269,o),
+(477,332,o),
+(404,355,c),
+(404,333,l),
+(478,353,o),
+(523,415,o),
+(523,502,cs),
+(523,623,o),
+(447,690,o),
+(326,690,cs),
+(60,690,l),
+(60,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(149,309,l),
+(253,309,l),
+(253,224,l),
+(303,224,l),
+(303,330,l),
+(272,309,l),
+(318,309,ls),
+(388,309,o),
+(432,269,o),
+(432,189,cs),
+(432,111,o),
+(385,74,o),
+(309,74,cs),
+(149,74,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(303,468,l),
+(253,468,l),
+(253,382,l),
+(149,382,l),
+(149,615,l),
+(309,615,ls),
+(386,615,o),
+(432,579,o),
+(432,499,cs),
+(432,421,o),
+(389,382,o),
+(318,382,cs),
+(272,382,l),
+(303,360,l)
+);
+}
+);
+width = 580;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F8;
+unicode = 5624;
+},
+{
+color = 9;
+glyphname = "khiCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(326,0,ls),
+(449,0,o),
+(523,66,o),
+(523,185,cs),
+(523,268,o),
+(478,331,o),
+(408,357,c),
+(408,331,l),
+(479,355,o),
+(523,416,o),
+(523,502,cs),
+(523,623,o),
+(447,690,o),
+(326,690,cs),
+(60,690,l),
+(60,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(149,313,l),
+(214,313,l),
+(225,289,o),
+(249,272,o),
+(276,272,cs),
+(313,272,o),
+(341,302,o),
+(345,339,c),
+(297,313,l),
+(322,313,ls),
+(388,313,o),
+(432,271,o),
+(432,191,cs),
+(432,110,o),
+(385,74,o),
+(309,74,cs),
+(149,74,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(309,615,ls),
+(386,615,o),
+(432,580,o),
+(432,497,cs),
+(432,418,o),
+(389,378,o),
+(322,378,cs),
+(297,378,l),
+(345,351,l),
+(341,388,o),
+(313,417,o),
+(276,417,cs),
+(240,417,o),
+(211,388,o),
+(207,352,c),
+(231,378,l),
+(149,378,l),
+(149,615,l)
+);
+}
+);
+width = 580;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F9;
+unicode = 5625;
+},
+{
+color = 9;
+glyphname = "khaCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(520,0,l),
+(520,690,l),
+(254,690,ls),
+(132,690,o),
+(57,623,o),
+(57,502,cs),
+(57,416,o),
+(99,355,o),
+(172,331,c),
+(171,357,l),
+(101,331,o),
+(57,268,o),
+(57,185,cs),
+(57,66,o),
+(130,0,o),
+(254,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(194,74,o),
+(147,111,o),
+(147,189,cs),
+(147,269,o),
+(195,308,o),
+(270,308,cs),
+(430,308,l),
+(430,74,l),
+(270,74,ls)
+);
+},
+{
+closed = 1;
+nodes = (
+(193,382,o),
+(147,421,o),
+(147,499,cs),
+(147,579,o),
+(193,615,o),
+(270,615,cs),
+(430,615,l),
+(430,382,l),
+(270,382,ls)
+);
+}
+);
+width = 580;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15FA;
+unicode = 5626;
+},
+{
+color = 9;
+glyphname = "kkuCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(290,-13,o),
+(341,30,o),
+(363,117,c),
+(324,117,l),
+(349,29,o),
+(399,-13,o),
+(470,-13,cs),
+(568,-13,o),
+(631,55,o),
+(631,181,cs),
+(631,690,l),
+(601,690,l),
+(369,529,l),
+(369,445,l),
+(565,583,l),
+(544,595,l),
+(544,185,ls),
+(544,106,o),
+(516,70,o),
+(465,70,cs),
+(415,70,o),
+(384,107,o),
+(384,185,cs),
+(384,690,l),
+(302,690,l),
+(302,185,ls),
+(302,106,o),
+(272,70,o),
+(222,70,cs),
+(170,70,o),
+(141,106,o),
+(141,185,cs),
+(141,595,l),
+(121,582,l),
+(314,446,l),
+(314,532,l),
+(86,690,l),
+(55,690,l),
+(55,183,ls),
+(55,55,o),
+(119,-13,o),
+(215,-13,cs)
+);
+}
+);
+width = 686;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FB;
+unicode = 5627;
+},
+{
+color = 9;
+glyphname = "kkoCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(85,0,l),
+(316,160,l),
+(316,244,l),
+(120,106,l),
+(141,95,l),
+(141,504,ls),
+(141,583,o),
+(170,620,o),
+(220,620,cs),
+(270,620,o),
+(300,582,o),
+(300,504,cs),
+(300,0,l),
+(384,0,l),
+(384,504,ls),
+(384,583,o),
+(413,620,o),
+(464,620,cs),
+(516,620,o),
+(544,583,o),
+(544,504,cs),
+(544,95,l),
+(564,107,l),
+(372,243,l),
+(372,157,l),
+(600,0,l),
+(631,0,l),
+(631,507,ls),
+(631,635,o),
+(566,702,o),
+(469,702,cs),
+(395,702,o),
+(344,660,o),
+(323,573,c),
+(362,573,l),
+(337,661,o),
+(286,702,o),
+(214,702,cs),
+(118,702,o),
+(55,635,o),
+(55,509,cs),
+(55,0,l)
+);
+}
+);
+width = 686;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FC;
+unicode = 5628;
+},
+{
+color = 9;
+glyphname = "kkeCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(339,0,ls),
+(463,0,o),
+(535,66,o),
+(535,185,cs),
+(535,268,o),
+(491,331,o),
+(421,357,c),
+(420,331,l),
+(493,355,o),
+(535,416,o),
+(535,502,cs),
+(535,623,o),
+(461,690,o),
+(339,690,cs),
+(58,690,l),
+(58,665,l),
+(142,383,l),
+(64,383,l),
+(64,308,l),
+(143,308,l),
+(58,25,l),
+(58,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(233,308,l),
+(324,308,ls),
+(398,308,o),
+(445,269,o),
+(445,189,cs),
+(445,111,o),
+(399,75,o),
+(322,75,cs),
+(123,75,l),
+(151,37,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(150,653,l),
+(122,614,l),
+(322,614,ls),
+(399,614,o),
+(445,579,o),
+(445,499,cs),
+(445,421,o),
+(399,383,o),
+(324,383,cs),
+(231,383,l)
+);
+}
+);
+width = 592;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni15FD;
+unicode = 5629;
+},
+{
+color = 9;
+glyphname = "kkeeCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(339,0,ls),
+(463,0,o),
+(535,66,o),
+(535,185,cs),
+(535,268,o),
+(491,331,o),
+(421,357,c),
+(420,331,l),
+(493,355,o),
+(535,416,o),
+(535,502,cs),
+(535,623,o),
+(461,690,o),
+(339,690,cs),
+(58,690,l),
+(58,665,l),
+(142,383,l),
+(64,383,l),
+(64,308,l),
+(143,308,l),
+(58,25,l),
+(58,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(231,311,l),
+(285,311,l),
+(285,229,l),
+(335,229,l),
+(335,329,l),
+(301,311,l),
+(331,311,ls),
+(402,311,o),
+(445,270,o),
+(445,191,cs),
+(445,112,o),
+(399,75,o),
+(322,75,cs),
+(121,75,l),
+(150,37,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(335,463,l),
+(285,463,l),
+(285,380,l),
+(229,380,l),
+(148,653,l),
+(120,614,l),
+(322,614,ls),
+(399,614,o),
+(445,578,o),
+(445,498,cs),
+(445,419,o),
+(403,380,o),
+(331,380,cs),
+(301,380,l),
+(335,365,l)
+);
+}
+);
+width = 592;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FE;
+unicode = 5630;
+},
+{
+color = 9;
+glyphname = "kkiCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(339,0,ls),
+(463,0,o),
+(535,66,o),
+(535,185,cs),
+(535,268,o),
+(491,331,o),
+(421,357,c),
+(420,331,l),
+(493,355,o),
+(535,416,o),
+(535,502,cs),
+(535,623,o),
+(461,690,o),
+(339,690,cs),
+(58,690,l),
+(58,665,l),
+(142,383,l),
+(64,383,l),
+(64,308,l),
+(143,308,l),
+(58,25,l),
+(58,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(232,315,l),
+(242,315,l),
+(251,290,o),
+(274,272,o),
+(303,272,cs),
+(341,272,o),
+(366,304,o),
+(368,334,c),
+(313,315,l),
+(331,315,ls),
+(402,315,o),
+(445,270,o),
+(445,188,cs),
+(445,112,o),
+(399,75,o),
+(322,75,cs),
+(121,75,l),
+(150,37,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(366,386,o),
+(342,417,o),
+(303,417,cs),
+(274,417,o),
+(252,401,o),
+(242,376,c),
+(230,376,l),
+(148,653,l),
+(120,614,l),
+(322,614,ls),
+(399,614,o),
+(445,578,o),
+(445,496,cs),
+(445,419,o),
+(403,376,o),
+(331,376,cs),
+(314,376,l),
+(369,355,l)
+);
+}
+);
+width = 592;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FF;
+unicode = 5631;
+},
+{
+color = 9;
+glyphname = "kkaCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(534,0,l),
+(534,25,l),
+(450,308,l),
+(528,308,l),
+(528,383,l),
+(450,383,l),
+(534,665,l),
+(534,690,l),
+(254,690,ls),
+(132,690,o),
+(57,623,o),
+(57,502,cs),
+(57,416,o),
+(99,355,o),
+(172,331,c),
+(171,357,l),
+(101,331,o),
+(57,268,o),
+(57,185,cs),
+(57,66,o),
+(130,0,o),
+(254,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(469,75,l),
+(270,75,ls),
+(194,75,o),
+(147,111,o),
+(147,189,cs),
+(147,269,o),
+(195,308,o),
+(270,308,cs),
+(360,308,l),
+(441,37,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(193,383,o),
+(147,421,o),
+(147,499,cs),
+(147,579,o),
+(193,614,o),
+(270,614,cs),
+(470,614,l),
+(442,653,l),
+(361,383,l),
+(270,383,ls)
+);
+}
+);
+width = 592;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|kkeCarrier-canadian";
+note = uni1600;
+unicode = 5632;
+},
+{
+color = 6;
+glyphname = "kkCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(170,183,l),
+(295,514,l),
+(295,527,l),
+(235,527,l),
+(141,253,l),
+(185,253,l),
+(90,527,l),
+(30,527,l),
+(30,514,l),
+(155,183,l)
+);
+}
+);
+width = 325;
+}
+);
+note = uni1601;
+unicode = 5633;
+},
+{
+color = 9;
+glyphname = "nuCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,-13,o),
+(525,77,o),
+(525,250,cs),
+(525,301,l),
+(436,301,l),
+(436,243,ls),
+(436,126,o),
+(384,71,o),
+(291,71,cs),
+(200,71,o),
+(147,128,o),
+(147,246,cs),
+(147,690,l),
+(56,690,l),
+(56,250,ls),
+(56,78,o),
+(145,-13,o),
+(292,-13,cs)
+);
+}
+);
+width = 575;
+}
+);
+metricLeft = "te-canadian";
+note = uni1602;
+unicode = 5634;
+},
+{
+color = 9;
+glyphname = "noCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(519,0,l),
+(519,440,ls),
+(519,611,o),
+(430,702,o),
+(284,702,cs),
+(135,702,o),
+(50,612,o),
+(50,440,cs),
+(50,388,l),
+(140,388,l),
+(140,446,ls),
+(140,564,o),
+(191,619,o),
+(284,619,cs),
+(376,619,o),
+(428,561,o),
+(428,443,cs),
+(428,0,l)
+);
+}
+);
+width = 575;
+}
+);
+metricLeft = "=|nuCarrier-canadian";
+metricRight = "te-canadian";
+note = uni1603;
+unicode = 5635;
+},
+{
+color = 9;
+glyphname = "neCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (244,345);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(225,0,ls),
+(415,0,o),
+(520,120,o),
+(520,346,cs),
+(520,572,o),
+(417,690,o),
+(214,690,cs),
+(40,690,l),
+(40,607,l),
+(215,607,ls),
+(360,607,o),
+(429,523,o),
+(429,346,cs),
+(429,169,o),
+(358,83,o),
+(225,83,cs),
+(217,83,l),
+(217,0,l)
+);
+}
+);
+width = 569;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1604;
+unicode = 5636;
+},
+{
+color = 9;
+glyphname = "neeCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+ref = "neCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (200,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 569;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1605;
+unicode = 5637;
+},
+{
+color = 9;
+glyphname = "niCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "neCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (177,0);
+ref = dot_middle;
+}
+);
+width = 568;
+}
+);
+note = uni1606;
+unicode = 5638;
+},
+{
+color = 9;
+glyphname = "naCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(529,0,l),
+(529,83,l),
+(353,83,ls),
+(208,83,o),
+(139,167,o),
+(139,344,cs),
+(139,521,o),
+(211,607,o),
+(344,607,cs),
+(351,607,l),
+(351,690,l),
+(344,690,ls),
+(154,690,o),
+(49,570,o),
+(49,344,cs),
+(49,118,o),
+(152,0,o),
+(354,0,cs)
+);
+}
+);
+width = 569;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni1607;
+unicode = 5639;
+},
+{
+color = 9;
+glyphname = "muCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(290,-13,o),
+(341,30,o),
+(362,116,c),
+(324,116,l),
+(349,29,o),
+(399,-13,o),
+(470,-13,cs),
+(568,-13,o),
+(631,55,o),
+(631,181,cs),
+(631,390,l),
+(544,390,l),
+(544,185,ls),
+(544,106,o),
+(516,70,o),
+(466,70,cs),
+(415,70,o),
+(385,107,o),
+(385,185,cs),
+(385,390,l),
+(301,390,l),
+(301,185,ls),
+(301,106,o),
+(271,70,o),
+(221,70,cs),
+(169,70,o),
+(141,106,o),
+(141,185,cs),
+(141,690,l),
+(55,690,l),
+(55,183,ls),
+(55,55,o),
+(119,-13,o),
+(215,-13,cs)
+);
+}
+);
+width = 686;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "=|";
+note = uni1608;
+unicode = 5640;
+},
+{
+color = 9;
+glyphname = "moCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(631,0,l),
+(631,507,ls),
+(631,635,o),
+(566,702,o),
+(469,702,cs),
+(396,702,o),
+(345,660,o),
+(323,574,c),
+(362,574,l),
+(337,661,o),
+(286,702,o),
+(214,702,cs),
+(118,702,o),
+(55,635,o),
+(55,509,cs),
+(55,299,l),
+(141,299,l),
+(141,504,ls),
+(141,583,o),
+(169,620,o),
+(220,620,cs),
+(270,620,o),
+(300,582,o),
+(300,504,cs),
+(300,299,l),
+(384,299,l),
+(384,504,ls),
+(384,583,o),
+(413,620,o),
+(464,620,cs),
+(516,620,o),
+(544,583,o),
+(544,504,cs),
+(544,0,l)
+);
+}
+);
+width = 686;
+}
+);
+metricLeft = "=|muCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni1609;
+unicode = 5641;
+},
+{
+color = 9;
+glyphname = "meCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(323,0,ls),
+(446,0,o),
+(520,66,o),
+(520,185,cs),
+(520,268,o),
+(474,333,o),
+(403,359,c),
+(403,331,l),
+(476,354,o),
+(520,416,o),
+(520,502,cs),
+(520,623,o),
+(444,690,o),
+(323,690,cs),
+(40,690,l),
+(40,614,l),
+(306,614,ls),
+(384,614,o),
+(429,579,o),
+(429,499,cs),
+(429,421,o),
+(383,383,o),
+(307,383,cs),
+(229,383,l),
+(229,308,l),
+(307,308,ls),
+(382,308,o),
+(429,269,o),
+(429,189,cs),
+(429,111,o),
+(383,75,o),
+(306,75,cs),
+(229,75,l),
+(229,0,l)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160A;
+unicode = 5642;
+},
+{
+color = 9;
+glyphname = "meeCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(323,0,ls),
+(446,0,o),
+(520,66,o),
+(520,185,cs),
+(520,268,o),
+(475,331,o),
+(405,357,c),
+(405,331,l),
+(476,355,o),
+(520,416,o),
+(520,502,cs),
+(520,623,o),
+(444,690,o),
+(323,690,cs),
+(40,690,l),
+(40,614,l),
+(306,614,ls),
+(384,614,o),
+(429,578,o),
+(429,498,cs),
+(429,420,o),
+(385,381,o),
+(314,381,cs),
+(284,381,l),
+(284,464,l),
+(229,464,l),
+(229,228,l),
+(284,228,l),
+(284,310,l),
+(313,310,ls),
+(385,310,o),
+(429,270,o),
+(429,190,cs),
+(429,112,o),
+(383,75,o),
+(306,75,cs),
+(229,75,l),
+(229,0,l)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160B;
+unicode = 5643;
+},
+{
+color = 9;
+glyphname = "miCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(323,0,ls),
+(446,0,o),
+(520,66,o),
+(520,185,cs),
+(520,268,o),
+(475,331,o),
+(405,357,c),
+(405,331,l),
+(476,355,o),
+(520,416,o),
+(520,502,cs),
+(520,623,o),
+(444,690,o),
+(323,690,cs),
+(40,690,l),
+(40,614,l),
+(306,614,ls),
+(384,614,o),
+(429,578,o),
+(429,498,cs),
+(429,420,o),
+(385,381,o),
+(318,381,cs),
+(282,381,l),
+(331,355,l),
+(327,390,o),
+(298,417,o),
+(262,417,cs),
+(221,417,o),
+(190,384,o),
+(190,346,cs),
+(190,305,o),
+(221,272,o),
+(262,272,cs),
+(298,272,o),
+(327,300,o),
+(330,334,c),
+(282,310,l),
+(317,310,ls),
+(385,310,o),
+(429,270,o),
+(429,190,cs),
+(429,112,o),
+(383,75,o),
+(306,75,cs),
+(229,75,l),
+(229,0,l)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160C;
+unicode = 5644;
+},
+{
+color = 9;
+glyphname = "maCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(537,0,l),
+(537,75,l),
+(270,75,ls),
+(193,75,o),
+(147,111,o),
+(147,189,cs),
+(147,268,o),
+(194,307,o),
+(269,307,cs),
+(347,307,l),
+(347,382,l),
+(270,382,ls),
+(194,382,o),
+(147,421,o),
+(147,499,cs),
+(147,578,o),
+(194,614,o),
+(270,614,cs),
+(347,614,l),
+(347,690,l),
+(254,690,ls),
+(130,690,o),
+(57,624,o),
+(57,503,cs),
+(57,420,o),
+(102,356,o),
+(174,331,c),
+(174,359,l),
+(100,335,o),
+(57,271,o),
+(57,185,cs),
+(57,67,o),
+(132,0,o),
+(254,0,cs)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni160D;
+unicode = 5645;
+},
+{
+color = 9;
+glyphname = "yuCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(472,-13,o),
+(564,116,o),
+(564,386,cs),
+(564,607,o),
+(502,702,o),
+(399,702,cs),
+(308,702,o),
+(255,627,o),
+(255,501,cs),
+(255,379,o),
+(309,307,o),
+(393,307,cs),
+(407,307,o),
+(420,309,o),
+(431,314,c),
+(431,384,l),
+(424,383,o),
+(416,380,o),
+(403,380,cs),
+(355,380,o),
+(330,419,o),
+(330,505,cs),
+(330,589,o),
+(355,630,o),
+(397,630,cs),
+(450,630,o),
+(479,570,o),
+(479,389,cs),
+(479,153,o),
+(416,71,o),
+(300,71,cs),
+(204,71,o),
+(147,129,o),
+(147,252,cs),
+(147,690,l),
+(56,690,l),
+(56,255,ls),
+(56,78,o),
+(151,-13,o),
+(298,-13,cs)
+);
+}
+);
+width = 620;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160E;
+unicode = 5646;
+},
+{
+color = 9;
+glyphname = "yoCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(312,-13,o),
+(366,63,o),
+(366,188,cs),
+(366,311,o),
+(312,383,o),
+(228,383,cs),
+(214,383,o),
+(200,381,o),
+(190,376,c),
+(190,305,l),
+(197,307,o),
+(205,310,o),
+(218,310,cs),
+(266,310,o),
+(290,270,o),
+(290,185,cs),
+(290,100,o),
+(267,60,o),
+(224,60,cs),
+(170,60,o),
+(142,120,o),
+(142,300,cs),
+(142,537,o),
+(204,619,o),
+(321,619,cs),
+(417,619,o),
+(474,560,o),
+(474,438,cs),
+(474,0,l),
+(564,0,l),
+(564,435,ls),
+(564,611,o),
+(470,702,o),
+(324,702,cs),
+(149,702,o),
+(56,574,o),
+(56,303,cs),
+(56,83,o),
+(119,-13,o),
+(222,-13,cs)
+);
+}
+);
+width = 620;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160F;
+unicode = 5647;
+},
+{
+color = 9;
+glyphname = "yeCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(421,-13,o),
+(514,124,o),
+(514,339,cs),
+(514,573,o),
+(412,690,o),
+(204,690,cs),
+(54,690,l),
+(54,607,l),
+(206,607,ls),
+(355,607,o),
+(424,524,o),
+(424,337,cs),
+(424,164,o),
+(375,65,o),
+(259,65,cs),
+(159,65,o),
+(120,127,o),
+(120,213,cs),
+(120,294,o),
+(145,334,o),
+(187,334,cs),
+(231,334,o),
+(254,294,o),
+(254,218,cs),
+(254,190,o),
+(252,175,o),
+(250,156,c),
+(318,156,l),
+(322,180,o),
+(324,196,o),
+(324,225,cs),
+(324,333,o),
+(276,408,o),
+(187,408,cs),
+(98,408,o),
+(43,332,o),
+(43,212,cs),
+(43,87,o),
+(113,-13,o),
+(258,-13,cs)
+);
+}
+);
+width = 563;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1610;
+unicode = 5648;
+},
+{
+color = 9;
+glyphname = "yeeCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(421,-13,o),
+(514,124,o),
+(514,339,cs),
+(514,573,o),
+(412,690,o),
+(204,690,cs),
+(54,690,l),
+(54,607,l),
+(206,607,ls),
+(355,607,o),
+(424,524,o),
+(424,337,cs),
+(424,164,o),
+(376,65,o),
+(258,65,cs),
+(159,65,o),
+(120,127,o),
+(120,215,cs),
+(120,293,o),
+(144,334,o),
+(183,334,cs),
+(222,334,o),
+(246,295,o),
+(246,229,cs),
+(246,179,l),
+(293,179,l),
+(293,497,l),
+(246,497,l),
+(246,300,l),
+(258,300,l),
+(252,368,o),
+(218,408,o),
+(164,408,cs),
+(95,408,o),
+(43,336,o),
+(43,214,cs),
+(43,87,o),
+(113,-13,o),
+(257,-13,cs)
+);
+}
+);
+width = 563;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1611;
+unicode = 5649;
+},
+{
+color = 9;
+glyphname = "yiCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(421,-13,o),
+(514,124,o),
+(514,339,cs),
+(514,573,o),
+(412,690,o),
+(204,690,cs),
+(54,690,l),
+(54,607,l),
+(206,607,ls),
+(355,607,o),
+(424,524,o),
+(424,337,cs),
+(424,164,o),
+(375,65,o),
+(262,65,cs),
+(161,65,o),
+(120,128,o),
+(120,205,cs),
+(120,278,o),
+(147,317,o),
+(188,319,c),
+(164,333,l),
+(169,303,o),
+(197,278,o),
+(233,278,cs),
+(271,278,o),
+(301,308,o),
+(301,346,cs),
+(301,383,o),
+(271,412,o),
+(233,412,cs),
+(206,412,o),
+(183,397,o),
+(172,377,c),
+(95,368,o),
+(43,302,o),
+(43,197,cs),
+(43,87,o),
+(113,-13,o),
+(258,-13,cs)
+);
+}
+);
+width = 563;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1612;
+unicode = 5650;
+},
+{
+color = 9;
+glyphname = "yaCarrier-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(508,0,l),
+(508,83,l),
+(357,83,ls),
+(208,83,o),
+(139,166,o),
+(139,353,cs),
+(139,526,o),
+(187,625,o),
+(309,625,cs),
+(404,625,o),
+(443,563,o),
+(443,477,cs),
+(443,396,o),
+(417,355,o),
+(375,355,cs),
+(332,355,o),
+(309,396,o),
+(309,471,cs),
+(309,499,o),
+(311,515,o),
+(313,533,c),
+(245,533,l),
+(241,510,o),
+(239,494,o),
+(239,465,cs),
+(239,356,o),
+(287,282,o),
+(376,282,cs),
+(466,282,o),
+(521,357,o),
+(521,478,cs),
+(521,603,o),
+(449,702,o),
+(310,702,cs),
+(141,702,o),
+(49,566,o),
+(49,351,cs),
+(49,117,o),
+(152,0,o),
+(359,0,cs)
+);
+}
+);
+width = 564;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|yeCarrier-canadian";
+note = uni1613;
+unicode = 5651;
+},
+{
+color = 9;
+glyphname = "juCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(460,-13,o),
+(531,86,o),
+(531,213,cs),
+(531,332,o),
+(477,408,o),
+(387,408,cs),
+(298,408,o),
+(250,333,o),
+(250,225,cs),
+(250,196,o),
+(252,179,o),
+(257,156,c),
+(325,156,l),
+(323,173,o),
+(320,191,o),
+(320,218,cs),
+(320,293,o),
+(344,334,o),
+(386,334,cs),
+(429,334,o),
+(455,293,o),
+(455,213,cs),
+(455,126,o),
+(413,65,o),
+(315,65,cs),
+(202,65,o),
+(144,147,o),
+(144,298,cs),
+(144,523,o),
+(260,607,o),
+(443,607,cs),
+(520,607,l),
+(520,690,l),
+(47,690,l),
+(47,610,l),
+(296,610,l),
+(366,644,l),
+(179,644,o),
+(54,525,o),
+(54,297,cs),
+(54,106,o),
+(152,-13,o),
+(309,-13,cs)
+);
+}
+);
+width = 574;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni1614;
+unicode = 5652;
+},
+{
+color = 9;
+glyphname = "juSayisi-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (291,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(422,-13,o),
+(520,106,o),
+(520,297,cs),
+(520,525,o),
+(395,644,o),
+(208,644,c),
+(279,610,l),
+(526,610,l),
+(526,690,l),
+(54,690,l),
+(54,607,l),
+(130,607,ls),
+(315,607,o),
+(430,523,o),
+(430,298,cs),
+(430,147,o),
+(373,65,o),
+(260,65,cs),
+(160,65,o),
+(120,126,o),
+(120,213,cs),
+(120,293,o),
+(145,334,o),
+(187,334,cs),
+(230,334,o),
+(254,293,o),
+(254,218,cs),
+(254,191,o),
+(252,173,o),
+(250,156,c),
+(318,156,l),
+(322,179,o),
+(324,196,o),
+(324,225,cs),
+(324,333,o),
+(276,408,o),
+(186,408,cs),
+(98,408,o),
+(43,332,o),
+(43,213,cs),
+(43,86,o),
+(114,-13,o),
+(265,-13,cs)
+);
+}
+);
+width = 573;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1615;
+unicode = 5653;
+},
+{
+color = 9;
+glyphname = "joCarrier-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(526,0,l),
+(526,80,l),
+(279,80,l),
+(208,45,l),
+(395,45,o),
+(520,165,o),
+(520,393,cs),
+(520,583,o),
+(422,702,o),
+(265,702,cs),
+(114,702,o),
+(43,604,o),
+(43,477,cs),
+(43,357,o),
+(98,282,o),
+(186,282,cs),
+(276,282,o),
+(324,356,o),
+(324,465,cs),
+(324,494,o),
+(322,511,o),
+(318,533,c),
+(250,533,l),
+(252,517,o),
+(254,498,o),
+(254,471,cs),
+(254,397,o),
+(230,355,o),
+(187,355,cs),
+(145,355,o),
+(120,397,o),
+(120,476,cs),
+(120,564,o),
+(160,625,o),
+(260,625,cs),
+(373,625,o),
+(430,543,o),
+(430,391,cs),
+(430,167,o),
+(315,83,o),
+(130,83,cs),
+(54,83,l),
+(54,0,l)
+);
+}
+);
+width = 573;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1616;
+unicode = 5654;
+},
+{
+color = 9;
+glyphname = "jeCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(505,-13,o),
+(568,83,o),
+(568,303,cs),
+(568,566,o),
+(473,702,o),
+(334,702,cs),
+(204,702,o),
+(133,595,o),
+(128,399,c),
+(149,405,l),
+(149,690,l),
+(60,690,l),
+(60,0,l),
+(150,0,l),
+(150,285,ls),
+(150,526,o),
+(213,619,o),
+(319,619,cs),
+(417,619,o),
+(482,525,o),
+(482,301,cs),
+(482,120,o),
+(454,60,o),
+(401,60,cs),
+(358,60,o),
+(334,100,o),
+(334,185,cs),
+(334,270,o),
+(358,310,o),
+(408,310,cs),
+(419,310,o),
+(427,307,o),
+(434,305,c),
+(434,376,l),
+(424,381,o),
+(410,383,o),
+(397,383,cs),
+(312,383,o),
+(258,311,o),
+(258,188,cs),
+(258,63,o),
+(312,-13,o),
+(402,-13,cs)
+);
+}
+);
+width = 624;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "te-canadian";
+note = uni1617;
+unicode = 5655;
+},
+{
+color = 9;
+glyphname = "jeeCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(504,-13,o),
+(568,84,o),
+(568,303,cs),
+(568,566,o),
+(473,702,o),
+(334,702,cs),
+(229,702,o),
+(163,635,o),
+(138,508,c),
+(149,498,l),
+(149,690,l),
+(60,690,l),
+(60,0,l),
+(150,0,l),
+(150,285,ls),
+(150,526,o),
+(213,619,o),
+(319,619,cs),
+(417,619,o),
+(482,525,o),
+(482,301,cs),
+(482,126,o),
+(450,60,o),
+(386,60,cs),
+(334,60,o),
+(302,107,o),
+(302,191,cs),
+(302,264,o),
+(322,306,o),
+(357,320,c),
+(357,236,l),
+(404,236,l),
+(404,448,l),
+(357,448,l),
+(357,369,l),
+(299,353,o),
+(258,291,o),
+(258,185,cs),
+(258,62,o),
+(311,-13,o),
+(402,-13,cs)
+);
+}
+);
+width = 624;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1618;
+unicode = 5656;
+},
+{
+color = 9;
+glyphname = "jiCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(504,-13,o),
+(568,84,o),
+(568,303,cs),
+(568,566,o),
+(473,702,o),
+(334,702,cs),
+(229,702,o),
+(163,635,o),
+(138,508,c),
+(149,498,l),
+(149,690,l),
+(60,690,l),
+(60,0,l),
+(150,0,l),
+(150,285,ls),
+(150,526,o),
+(213,619,o),
+(319,619,cs),
+(417,619,o),
+(482,525,o),
+(482,301,cs),
+(482,126,o),
+(450,60,o),
+(386,60,cs),
+(334,60,o),
+(302,107,o),
+(302,191,cs),
+(302,244,o),
+(314,276,o),
+(334,294,c),
+(342,283,o),
+(355,275,o),
+(369,275,cs),
+(405,275,o),
+(432,305,o),
+(432,342,cs),
+(432,379,o),
+(405,408,o),
+(369,408,cs),
+(325,408,o),
+(301,365,o),
+(309,330,c),
+(277,305,o),
+(258,257,o),
+(258,185,cs),
+(258,62,o),
+(311,-13,o),
+(402,-13,cs)
+);
+}
+);
+width = 624;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1619;
+unicode = 5657;
+},
+{
+color = 9;
+glyphname = "jiSayisi-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(473,-13,o),
+(568,124,o),
+(568,386,cs),
+(568,607,o),
+(505,702,o),
+(402,702,cs),
+(312,702,o),
+(258,627,o),
+(258,501,cs),
+(258,379,o),
+(312,307,o),
+(397,307,cs),
+(410,307,o),
+(424,309,o),
+(434,314,c),
+(434,384,l),
+(427,383,o),
+(419,380,o),
+(408,380,cs),
+(358,380,o),
+(334,419,o),
+(334,505,cs),
+(334,589,o),
+(358,630,o),
+(400,630,cs),
+(454,630,o),
+(482,570,o),
+(482,388,cs),
+(482,165,o),
+(417,71,o),
+(319,71,cs),
+(213,71,o),
+(150,163,o),
+(150,405,cs),
+(150,690,l),
+(60,690,l),
+(60,0,l),
+(149,0,l),
+(149,285,l),
+(128,291,l),
+(133,95,o),
+(204,-13,o),
+(334,-13,cs)
+);
+}
+);
+width = 624;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161A;
+unicode = 5658;
+},
+{
+color = 9;
+glyphname = "jaCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (305,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(420,-13,o),
+(491,95,o),
+(497,291,c),
+(475,285,l),
+(475,0,l),
+(564,0,l),
+(564,690,l),
+(474,690,l),
+(474,405,ls),
+(474,163,o),
+(411,71,o),
+(305,71,cs),
+(207,71,o),
+(142,165,o),
+(142,388,cs),
+(142,570,o),
+(170,630,o),
+(224,630,cs),
+(266,630,o),
+(290,589,o),
+(290,505,cs),
+(290,419,o),
+(266,380,o),
+(216,380,cs),
+(205,380,o),
+(197,383,o),
+(190,384,c),
+(190,314,l),
+(200,309,o),
+(214,307,o),
+(227,307,cs),
+(312,307,o),
+(366,379,o),
+(366,501,cs),
+(366,627,o),
+(312,702,o),
+(222,702,cs),
+(119,702,o),
+(56,607,o),
+(56,386,cs),
+(56,124,o),
+(151,-13,o),
+(290,-13,cs)
+);
+}
+);
+width = 624;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni161B;
+unicode = 5659;
+},
+{
+color = 9;
+glyphname = "jjuCarrier-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(455,-13,o),
+(526,87,o),
+(526,212,cs),
+(526,332,o),
+(471,408,o),
+(382,408,cs),
+(293,408,o),
+(244,333,o),
+(244,225,cs),
+(244,197,o),
+(246,179,o),
+(251,156,c),
+(319,156,l),
+(317,173,o),
+(314,193,o),
+(314,218,cs),
+(314,293,o),
+(338,334,o),
+(381,334,cs),
+(421,334,o),
+(449,291,o),
+(449,213,cs),
+(449,125,o),
+(409,63,o),
+(312,63,cs),
+(202,63,o),
+(145,146,o),
+(145,307,cs),
+(145,514,o),
+(246,607,o),
+(416,607,cs),
+(514,607,l),
+(514,690,l),
+(412,690,ls),
+(312,690,o),
+(232,662,o),
+(173,611,c),
+(82,702,l),
+(22,645,l),
+(118,550,l),
+(76,490,o),
+(55,409,o),
+(55,311,cs),
+(55,107,o),
+(155,-13,o),
+(308,-13,cs)
+);
+}
+);
+width = 569;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni161C;
+unicode = 5660;
+},
+{
+color = 9;
+glyphname = "jjoCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(546,44,l),
+(451,140,l),
+(493,200,o),
+(514,281,o),
+(514,379,cs),
+(514,582,o),
+(414,702,o),
+(261,702,cs),
+(114,702,o),
+(43,603,o),
+(43,478,cs),
+(43,357,o),
+(98,282,o),
+(187,282,cs),
+(276,282,o),
+(325,356,o),
+(325,465,cs),
+(325,493,o),
+(323,511,o),
+(318,533,c),
+(250,533,l),
+(252,517,o),
+(254,497,o),
+(254,471,cs),
+(254,397,o),
+(231,355,o),
+(188,355,cs),
+(147,355,o),
+(120,399,o),
+(120,477,cs),
+(120,565,o),
+(160,627,o),
+(257,627,cs),
+(367,627,o),
+(424,544,o),
+(424,383,cs),
+(424,176,o),
+(323,83,o),
+(153,83,cs),
+(54,83,l),
+(54,0,l),
+(156,0,ls),
+(257,0,o),
+(337,28,o),
+(395,79,c),
+(487,-13,l)
+);
+}
+);
+width = 568;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|jjuCarrier-canadian";
+note = uni161D;
+unicode = 5661;
+},
+{
+color = 9;
+glyphname = "jjeCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(510,-13,o),
+(572,83,o),
+(572,303,cs),
+(572,574,o),
+(484,702,o),
+(313,702,cs),
+(246,702,o),
+(188,678,o),
+(146,632,c),
+(71,702,l),
+(15,641,l),
+(99,562,l),
+(77,515,o),
+(64,455,o),
+(64,382,cs),
+(64,0,l),
+(155,0,l),
+(155,385,ls),
+(155,541,o),
+(212,619,o),
+(312,619,cs),
+(424,619,o),
+(487,537,o),
+(487,300,cs),
+(487,120,o),
+(458,60,o),
+(405,60,cs),
+(361,60,o),
+(338,100,o),
+(338,185,cs),
+(338,270,o),
+(363,310,o),
+(411,310,cs),
+(424,310,o),
+(432,307,o),
+(439,305,c),
+(439,376,l),
+(428,381,o),
+(413,383,o),
+(400,383,cs),
+(317,383,o),
+(262,311,o),
+(262,188,cs),
+(262,63,o),
+(316,-13,o),
+(407,-13,cs)
+);
+}
+);
+width = 628;
+}
+);
+metricRight = "jeCarrier-canadian";
+note = uni161E;
+unicode = 5662;
+},
+{
+color = 9;
+glyphname = "jjeeCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(509,-13,o),
+(572,84,o),
+(572,303,cs),
+(572,574,o),
+(484,702,o),
+(313,702,cs),
+(246,702,o),
+(188,678,o),
+(146,632,c),
+(71,702,l),
+(15,641,l),
+(99,562,l),
+(77,515,o),
+(64,455,o),
+(64,382,cs),
+(64,0,l),
+(155,0,l),
+(155,385,ls),
+(155,541,o),
+(212,619,o),
+(312,619,cs),
+(424,619,o),
+(487,537,o),
+(487,300,cs),
+(487,125,o),
+(454,60,o),
+(390,60,cs),
+(337,60,o),
+(307,107,o),
+(307,191,cs),
+(307,267,o),
+(327,306,o),
+(361,320,c),
+(361,236,l),
+(408,236,l),
+(408,448,l),
+(361,448,l),
+(361,369,l),
+(304,355,o),
+(262,291,o),
+(262,185,cs),
+(262,62,o),
+(316,-13,o),
+(407,-13,cs)
+);
+}
+);
+width = 628;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161F;
+unicode = 5663;
+},
+{
+color = 9;
+glyphname = "jjiCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(509,-13,o),
+(572,84,o),
+(572,303,cs),
+(572,574,o),
+(484,702,o),
+(313,702,cs),
+(246,702,o),
+(188,678,o),
+(146,632,c),
+(71,702,l),
+(15,641,l),
+(99,562,l),
+(77,515,o),
+(64,455,o),
+(64,382,cs),
+(64,0,l),
+(155,0,l),
+(155,385,ls),
+(155,541,o),
+(212,619,o),
+(312,619,cs),
+(424,619,o),
+(487,537,o),
+(487,300,cs),
+(487,125,o),
+(454,60,o),
+(390,60,cs),
+(337,60,o),
+(307,107,o),
+(307,191,cs),
+(307,246,o),
+(319,278,o),
+(339,294,c),
+(346,283,o),
+(360,275,o),
+(375,275,cs),
+(411,275,o),
+(438,305,o),
+(438,342,cs),
+(438,379,o),
+(411,408,o),
+(375,408,cs),
+(332,408,o),
+(308,367,o),
+(315,332,c),
+(283,307,o),
+(262,258,o),
+(262,185,cs),
+(262,62,o),
+(316,-13,o),
+(407,-13,cs)
+);
+}
+);
+width = 628;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1620;
+unicode = 5664;
+},
+{
+color = 9;
+glyphname = "jjaCarrier-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(383,-13,o),
+(440,12,o),
+(483,58,c),
+(558,-13,l),
+(612,48,l),
+(528,128,l),
+(552,175,o),
+(564,235,o),
+(564,308,cs),
+(564,690,l),
+(474,690,l),
+(474,304,ls),
+(474,149,o),
+(417,71,o),
+(317,71,cs),
+(204,71,o),
+(142,153,o),
+(142,389,cs),
+(142,570,o),
+(170,630,o),
+(224,630,cs),
+(267,630,o),
+(290,589,o),
+(290,505,cs),
+(290,419,o),
+(266,380,o),
+(218,380,cs),
+(205,380,o),
+(197,383,o),
+(190,384,c),
+(190,314,l),
+(200,309,o),
+(214,307,o),
+(228,307,cs),
+(312,307,o),
+(366,379,o),
+(366,501,cs),
+(366,627,o),
+(312,702,o),
+(222,702,cs),
+(119,702,o),
+(56,607,o),
+(56,386,cs),
+(56,116,o),
+(145,-13,o),
+(315,-13,cs)
+);
+}
+);
+width = 627;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "=|jjeCarrier-canadian";
+note = uni1621;
+unicode = 5665;
+},
+{
+color = 9;
+glyphname = "luCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(435,-13,o),
+(523,71,o),
+(523,255,cs),
+(523,690,l),
+(432,690,l),
+(432,256,ls),
+(432,122,o),
+(377,71,o),
+(297,71,cs),
+(187,71,o),
+(144,161,o),
+(144,322,cs),
+(144,502,o),
+(193,599,o),
+(310,617,c),
+(310,690,l),
+(47,690,l),
+(47,614,l),
+(212,614,l),
+(269,641,l),
+(134,625,o),
+(54,526,o),
+(54,310,cs),
+(54,109,o),
+(132,-13,o),
+(295,-13,cs)
+);
+}
+);
+width = 579;
+}
+);
+metricRight = "te-canadian";
+note = uni1622;
+unicode = 5666;
+},
+{
+color = 9;
+glyphname = "loCarrier-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(147,0,l),
+(147,434,ls),
+(147,568,o),
+(202,619,o),
+(283,619,cs),
+(391,619,o),
+(435,528,o),
+(435,368,cs),
+(435,187,o),
+(385,91,o),
+(269,72,c),
+(269,0,l),
+(531,0,l),
+(531,75,l),
+(367,75,l),
+(310,48,l),
+(444,65,o),
+(525,164,o),
+(525,380,cs),
+(525,581,o),
+(446,702,o),
+(284,702,cs),
+(145,702,o),
+(56,618,o),
+(56,435,cs),
+(56,0,l)
+);
+}
+);
+width = 578;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|luCarrier-canadian";
+note = uni1623;
+unicode = 5667;
+},
+{
+color = 9;
+glyphname = "leCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (278,345);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(214,0,ls),
+(414,0,o),
+(517,120,o),
+(517,356,cs),
+(517,593,o),
+(416,702,o),
+(302,702,cs),
+(200,702,o),
+(146,625,o),
+(128,523,c),
+(138,526,l),
+(138,690,l),
+(57,690,l),
+(57,383,l),
+(133,383,l),
+(135,528,o),
+(189,619,o),
+(279,619,cs),
+(364,619,o),
+(426,542,o),
+(426,355,cs),
+(426,169,o),
+(361,83,o),
+(215,83,cs),
+(57,83,l),
+(57,0,l)
+);
+}
+);
+width = 566;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1624;
+unicode = 5668;
+},
+{
+color = 9;
+glyphname = "leeCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+ref = "leCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (234,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 566;
+}
+);
+metricLeft = "leCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1625;
+unicode = 5669;
+},
+{
+color = 9;
+glyphname = "liCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "leCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (211,0);
+ref = dot_middle;
+}
+);
+width = 565;
+}
+);
+note = uni1626;
+unicode = 5670;
+},
+{
+color = 9;
+glyphname = "laCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(508,0,l),
+(508,83,l),
+(350,83,ls),
+(204,83,o),
+(139,169,o),
+(139,355,cs),
+(139,542,o),
+(201,619,o),
+(286,619,cs),
+(377,619,o),
+(430,528,o),
+(432,383,c),
+(508,383,l),
+(508,690,l),
+(428,690,l),
+(428,526,l),
+(438,523,l),
+(420,625,o),
+(365,702,o),
+(263,702,cs),
+(149,702,o),
+(49,593,o),
+(49,356,cs),
+(49,120,o),
+(152,0,o),
+(351,0,cs)
+);
+}
+);
+width = 565;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|leCarrier-canadian";
+note = uni1627;
+unicode = 5671;
+},
+{
+color = 1;
+glyphname = "dluCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(446,-13,o),
+(525,109,o),
+(525,310,cs),
+(525,501,o),
+(463,600,o),
+(359,630,c),
+(342,620,l),
+(518,620,l),
+(518,539,l),
+(584,539,l),
+(584,771,l),
+(518,771,l),
+(518,690,l),
+(269,690,l),
+(269,616,l),
+(385,599,o),
+(435,502,o),
+(435,322,cs),
+(435,161,o),
+(391,71,o),
+(284,71,cs),
+(202,71,o),
+(147,123,o),
+(147,256,cs),
+(147,690,l),
+(56,690,l),
+(56,255,ls),
+(56,71,o),
+(145,-13,o),
+(285,-13,cs)
+);
+}
+);
+width = 617;
+}
+);
+metricLeft = "te-canadian";
+note = uni1628;
+unicode = 5672;
+},
+{
+color = 9;
+glyphname = "dloCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(584,-81,l),
+(584,151,l),
+(518,151,l),
+(518,70,l),
+(342,70,l),
+(359,60,l),
+(463,90,o),
+(525,188,o),
+(525,380,cs),
+(525,581,o),
+(446,702,o),
+(285,702,cs),
+(144,702,o),
+(56,618,o),
+(56,435,cs),
+(56,0,l),
+(147,0,l),
+(147,434,ls),
+(147,567,o),
+(202,619,o),
+(284,619,cs),
+(391,619,o),
+(435,528,o),
+(435,368,cs),
+(435,187,o),
+(385,91,o),
+(269,73,c),
+(269,0,l),
+(518,0,l),
+(518,-81,l)
+);
+}
+);
+width = 617;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "dluCarrier-canadian";
+note = uni1629;
+unicode = 5673;
+},
+{
+color = 9;
+glyphname = "dleCarrier-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (292,345);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(227,0,ls),
+(427,0,o),
+(529,120,o),
+(529,356,cs),
+(529,593,o),
+(430,702,o),
+(315,702,cs),
+(218,702,o),
+(150,633,o),
+(127,507,c),
+(136,502,l),
+(136,701,l),
+(200,701,l),
+(200,766,l),
+(6,766,l),
+(6,701,l),
+(70,701,l),
+(70,383,l),
+(146,383,l),
+(148,528,o),
+(202,619,o),
+(292,619,cs),
+(377,619,o),
+(439,542,o),
+(439,355,cs),
+(439,169,o),
+(374,83,o),
+(228,83,cs),
+(70,83,l),
+(70,0,l)
+);
+}
+);
+width = 578;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni162A;
+unicode = 5674;
+},
+{
+color = 9;
+glyphname = "dleeCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (247,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 578;
+}
+);
+note = uni162B;
+unicode = 5675;
+},
+{
+color = 9;
+glyphname = "dliCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (224,0);
+ref = dot_middle;
+}
+);
+width = 578;
+}
+);
+note = uni162C;
+unicode = 5676;
+},
+{
+color = 9;
+glyphname = "dlaCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(508,0,l),
+(508,83,l),
+(350,83,ls),
+(204,83,o),
+(139,169,o),
+(139,355,cs),
+(139,542,o),
+(202,619,o),
+(286,619,cs),
+(377,619,o),
+(430,528,o),
+(432,383,c),
+(508,383,l),
+(508,701,l),
+(572,701,l),
+(572,766,l),
+(379,766,l),
+(379,701,l),
+(441,701,l),
+(441,502,l),
+(451,507,l),
+(428,633,o),
+(359,702,o),
+(263,702,cs),
+(149,702,o),
+(49,593,o),
+(49,356,cs),
+(49,119,o),
+(152,0,o),
+(351,0,cs)
+);
+}
+);
+width = 578;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni162D;
+unicode = 5677;
+},
+{
+color = 9;
+glyphname = "lhuCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(461,-13,o),
+(544,106,o),
+(544,308,cs),
+(544,502,o),
+(474,612,o),
+(362,644,c),
+(398,614,l),
+(551,614,l),
+(551,690,l),
+(345,690,l),
+(345,617,l),
+(415,577,o),
+(454,477,o),
+(454,326,cs),
+(454,150,o),
+(406,71,o),
+(298,71,cs),
+(193,71,o),
+(145,150,o),
+(145,326,cs),
+(145,477,o),
+(183,578,o),
+(254,617,c),
+(254,690,l),
+(47,690,l),
+(47,614,l),
+(199,614,l),
+(236,644,l),
+(124,612,o),
+(54,503,o),
+(54,308,cs),
+(54,106,o),
+(137,-13,o),
+(298,-13,cs)
+);
+}
+);
+width = 598;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162E;
+unicode = 5678;
+},
+{
+color = 9;
+glyphname = "lhoCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(253,0,l),
+(253,72,l),
+(183,113,o),
+(144,213,o),
+(144,364,cs),
+(144,540,o),
+(192,619,o),
+(298,619,cs),
+(406,619,o),
+(453,540,o),
+(453,364,cs),
+(453,213,o),
+(415,112,o),
+(344,72,c),
+(344,0,l),
+(551,0,l),
+(551,75,l),
+(399,75,l),
+(362,45,l),
+(474,77,o),
+(544,186,o),
+(544,382,cs),
+(544,583,o),
+(461,702,o),
+(298,702,cs),
+(137,702,o),
+(54,583,o),
+(54,382,cs),
+(54,187,o),
+(124,77,o),
+(236,45,c),
+(200,75,l),
+(47,75,l),
+(47,0,l)
+);
+}
+);
+width = 598;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162F;
+unicode = 5679;
+},
+{
+color = 9;
+glyphname = "lheCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (292,345);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(435,-13,o),
+(537,97,o),
+(537,345,cs),
+(537,593,o),
+(435,702,o),
+(315,702,cs),
+(210,702,o),
+(152,629,o),
+(134,536,c),
+(140,536,l),
+(140,690,l),
+(60,690,l),
+(60,416,l),
+(136,416,l),
+(146,529,o),
+(190,619,o),
+(293,619,cs),
+(381,619,o),
+(447,542,o),
+(447,345,cs),
+(447,148,o),
+(382,71,o),
+(293,71,cs),
+(190,71,o),
+(146,160,o),
+(136,273,c),
+(60,273,l),
+(60,0,l),
+(140,0,l),
+(140,154,l),
+(134,154,l),
+(152,61,o),
+(210,-13,o),
+(315,-13,cs)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1630;
+unicode = 5680;
+},
+{
+color = 9;
+glyphname = "lheeCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (247,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 586;
+}
+);
+note = uni1631;
+unicode = 5681;
+},
+{
+color = 9;
+glyphname = "lhiCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (224,0);
+ref = dot_middle;
+}
+);
+width = 586;
+}
+);
+note = uni1632;
+unicode = 5682;
+},
+{
+color = 9;
+glyphname = "lhaCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(377,-13,o),
+(435,61,o),
+(451,154,c),
+(445,154,l),
+(445,0,l),
+(526,0,l),
+(526,273,l),
+(450,273,l),
+(440,160,o),
+(396,71,o),
+(294,71,cs),
+(205,71,o),
+(139,148,o),
+(139,345,cs),
+(139,542,o),
+(205,619,o),
+(294,619,cs),
+(396,619,o),
+(440,529,o),
+(450,416,c),
+(526,416,l),
+(526,690,l),
+(445,690,l),
+(445,536,l),
+(451,536,l),
+(435,629,o),
+(377,702,o),
+(270,702,cs),
+(152,702,o),
+(49,593,o),
+(49,345,cs),
+(49,97,o),
+(152,-13,o),
+(270,-13,cs)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1633;
+unicode = 5683;
+},
+{
+color = 9;
+glyphname = "tlhuCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(461,-13,o),
+(544,106,o),
+(544,308,cs),
+(544,479,o),
+(492,586,o),
+(403,631,c),
+(381,620,l),
+(537,620,l),
+(537,539,l),
+(604,539,l),
+(604,771,l),
+(537,771,l),
+(537,690,l),
+(345,690,l),
+(345,617,l),
+(416,577,o),
+(454,477,o),
+(454,326,cs),
+(454,150,o),
+(406,71,o),
+(298,71,cs),
+(192,71,o),
+(144,150,o),
+(144,326,cs),
+(144,477,o),
+(182,578,o),
+(254,617,c),
+(254,690,l),
+(47,690,l),
+(47,614,l),
+(211,614,l),
+(187,627,l),
+(103,580,o),
+(54,475,o),
+(54,308,cs),
+(54,106,o),
+(137,-13,o),
+(298,-13,cs)
+);
+}
+);
+width = 633;
+}
+);
+metricLeft = "lhuCarrier-canadian";
+note = uni1634;
+unicode = 5684;
+},
+{
+color = 9;
+glyphname = "tlhoCarrier-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(96,-81,l),
+(96,0,l),
+(288,0,l),
+(288,72,l),
+(216,113,o),
+(179,213,o),
+(179,364,cs),
+(179,540,o),
+(227,619,o),
+(334,619,cs),
+(440,619,o),
+(489,540,o),
+(489,364,cs),
+(489,213,o),
+(451,112,o),
+(379,72,c),
+(379,0,l),
+(585,0,l),
+(585,75,l),
+(423,75,l),
+(445,63,l),
+(530,110,o),
+(579,214,o),
+(579,382,cs),
+(579,583,o),
+(496,702,o),
+(334,702,cs),
+(172,702,o),
+(90,583,o),
+(90,382,cs),
+(90,211,o),
+(142,103,o),
+(230,59,c),
+(252,70,l),
+(96,70,l),
+(96,151,l),
+(29,151,l),
+(29,-81,l)
+);
+}
+);
+width = 632;
+}
+);
+metricLeft = "=|tlhuCarrier-canadian";
+metricRight = "lhuCarrier-canadian";
+note = uni1635;
+unicode = 5685;
+},
+{
+color = 9;
+glyphname = "tlheCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (302,345);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(444,-13,o),
+(547,97,o),
+(547,345,cs),
+(547,593,o),
+(444,702,o),
+(326,702,cs),
+(221,702,o),
+(151,636,o),
+(127,517,c),
+(136,512,l),
+(136,701,l),
+(200,701,l),
+(200,766,l),
+(6,766,l),
+(6,701,l),
+(70,701,l),
+(70,416,l),
+(146,416,l),
+(156,529,o),
+(200,619,o),
+(302,619,cs),
+(391,619,o),
+(457,547,o),
+(457,345,cs),
+(457,148,o),
+(391,71,o),
+(302,71,cs),
+(200,71,o),
+(156,160,o),
+(146,273,c),
+(70,273,l),
+(70,0,l),
+(151,0,l),
+(151,169,l),
+(144,156,l),
+(160,62,o),
+(218,-13,o),
+(326,-13,cs)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1636;
+unicode = 5686;
+},
+{
+color = 9;
+glyphname = "tlheeCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (258,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 596;
+}
+);
+note = uni1637;
+unicode = 5687;
+},
+{
+color = 9;
+glyphname = "tlhiCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (235,0);
+ref = dot_middle;
+}
+);
+width = 596;
+}
+);
+note = uni1638;
+unicode = 5688;
+},
+{
+color = 9;
+glyphname = "tlhaCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(378,-13,o),
+(436,62,o),
+(452,156,c),
+(445,169,l),
+(445,0,l),
+(526,0,l),
+(526,273,l),
+(450,273,l),
+(440,160,o),
+(396,71,o),
+(294,71,cs),
+(205,71,o),
+(139,148,o),
+(139,345,cs),
+(139,547,o),
+(205,619,o),
+(294,619,cs),
+(396,619,o),
+(440,529,o),
+(450,416,c),
+(526,416,l),
+(526,701,l),
+(590,701,l),
+(590,766,l),
+(396,766,l),
+(396,701,l),
+(460,701,l),
+(460,512,l),
+(469,517,l),
+(445,636,o),
+(376,702,o),
+(270,702,cs),
+(152,702,o),
+(49,593,o),
+(49,345,cs),
+(49,97,o),
+(152,-13,o),
+(270,-13,cs)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni1639;
+unicode = 5689;
+},
+{
+color = 9;
+glyphname = "tluCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(291,-13,o),
+(339,24,o),
+(359,107,c),
+(334,107,l),
+(354,24,o),
+(403,-13,o),
+(466,-13,cs),
+(574,-13,o),
+(639,69,o),
+(639,275,cs),
+(639,489,o),
+(587,591,o),
+(492,631,c),
+(471,620,l),
+(633,620,l),
+(633,539,l),
+(699,539,l),
+(699,771,l),
+(633,771,l),
+(633,690,l),
+(393,690,l),
+(393,616,l),
+(500,612,o),
+(549,509,o),
+(549,280,cs),
+(549,109,o),
+(514,70,o),
+(463,70,cs),
+(418,70,o),
+(389,109,o),
+(389,196,cs),
+(389,302,l),
+(304,302,l),
+(304,196,ls),
+(304,109,o),
+(275,70,o),
+(231,70,cs),
+(180,70,o),
+(145,109,o),
+(145,280,cs),
+(145,509,o),
+(193,612,o),
+(301,616,c),
+(301,690,l),
+(48,690,l),
+(48,614,l),
+(216,614,l),
+(194,627,l),
+(103,585,o),
+(55,484,o),
+(55,275,cs),
+(55,69,o),
+(120,-13,o),
+(227,-13,cs)
+);
+}
+);
+width = 728;
+}
+);
+metricRight = "tlhuCarrier-canadian";
+note = uni163A;
+unicode = 5690;
+},
+{
+color = 1;
+glyphname = "tloCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(699,-81,l),
+(699,151,l),
+(633,151,l),
+(633,70,l),
+(471,70,l),
+(492,59,l),
+(587,99,o),
+(639,201,o),
+(639,414,cs),
+(639,621,o),
+(574,702,o),
+(466,702,cs),
+(403,702,o),
+(354,666,o),
+(334,582,c),
+(359,582,l),
+(339,666,o),
+(291,702,o),
+(227,702,cs),
+(120,702,o),
+(55,621,o),
+(55,414,cs),
+(55,206,o),
+(103,104,o),
+(194,63,c),
+(216,75,l),
+(48,75,l),
+(48,0,l),
+(301,0,l),
+(301,73,l),
+(193,77,o),
+(145,181,o),
+(145,410,cs),
+(145,581,o),
+(180,620,o),
+(231,620,cs),
+(275,620,o),
+(304,581,o),
+(304,494,cs),
+(304,387,l),
+(389,387,l),
+(389,494,ls),
+(389,581,o),
+(418,620,o),
+(463,620,cs),
+(514,620,o),
+(549,581,o),
+(549,410,cs),
+(549,181,o),
+(500,77,o),
+(393,73,c),
+(393,0,l),
+(633,0,l),
+(633,-81,l)
+);
+}
+);
+width = 728;
+}
+);
+metricLeft = "tluCarrier-canadian";
+metricRight = "tlhuCarrier-canadian";
+note = uni163B;
+unicode = 5691;
+},
+{
+color = 9;
+glyphname = "tleCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (242,345);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(462,-13,o),
+(537,61,o),
+(537,180,cs),
+(537,272,o),
+(493,337,o),
+(415,353,c),
+(415,337,l),
+(493,353,o),
+(537,417,o),
+(537,510,cs),
+(537,629,o),
+(462,702,o),
+(341,702,cs),
+(229,702,o),
+(148,638,o),
+(128,527,c),
+(136,519,l),
+(136,701,l),
+(200,701,l),
+(200,766,l),
+(6,766,l),
+(6,701,l),
+(70,701,l),
+(70,416,l),
+(144,416,l),
+(146,538,o),
+(195,621,o),
+(316,621,cs),
+(402,621,o),
+(448,578,o),
+(448,497,cs),
+(448,424,o),
+(412,383,o),
+(348,383,cs),
+(319,383,l),
+(319,308,l),
+(348,308,ls),
+(412,308,o),
+(448,267,o),
+(448,194,cs),
+(448,112,o),
+(402,69,o),
+(316,69,cs),
+(195,69,o),
+(146,152,o),
+(144,273,c),
+(70,273,l),
+(70,0,l),
+(151,0,l),
+(151,153,l),
+(137,141,l),
+(163,46,o),
+(235,-13,o),
+(341,-13,cs)
+);
+}
+);
+width = 594;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni163C;
+unicode = 5692;
+},
+{
+color = 9;
+glyphname = "tleeCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (197,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 594;
+}
+);
+note = uni163D;
+unicode = 5693;
+},
+{
+color = 9;
+glyphname = "tliCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (182,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 594;
+}
+);
+note = uni163E;
+unicode = 5694;
+},
+{
+color = 9;
+glyphname = "tlaCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(360,-13,o),
+(432,46,o),
+(457,141,c),
+(444,153,l),
+(444,0,l),
+(525,0,l),
+(525,273,l),
+(450,273,l),
+(449,152,o),
+(400,69,o),
+(279,69,cs),
+(193,69,o),
+(146,112,o),
+(146,194,cs),
+(146,267,o),
+(183,308,o),
+(246,308,cs),
+(277,308,l),
+(277,383,l),
+(246,383,ls),
+(183,383,o),
+(146,424,o),
+(146,497,cs),
+(146,578,o),
+(192,621,o),
+(278,621,cs),
+(400,621,o),
+(449,538,o),
+(450,416,c),
+(525,416,l),
+(525,701,l),
+(588,701,l),
+(588,766,l),
+(395,766,l),
+(395,701,l),
+(458,701,l),
+(458,519,l),
+(467,527,l),
+(447,638,o),
+(366,702,o),
+(253,702,cs),
+(132,702,o),
+(57,629,o),
+(57,510,cs),
+(57,417,o),
+(102,353,o),
+(179,337,c),
+(179,353,l),
+(102,337,o),
+(57,272,o),
+(57,180,cs),
+(57,61,o),
+(132,-13,o),
+(253,-13,cs)
+);
+}
+);
+width = 594;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni163F;
+unicode = 5695;
+},
+{
+color = 9;
+glyphname = "zuCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(449,-13,o),
+(543,77,o),
+(543,226,cs),
+(543,339,o),
+(470,482,o),
+(470,555,cs),
+(470,584,o),
+(483,611,o),
+(527,611,cs),
+(551,611,l),
+(551,690,l),
+(505,690,ls),
+(420,690,o),
+(384,641,o),
+(384,569,cs),
+(384,481,o),
+(453,345,o),
+(453,240,cs),
+(453,133,o),
+(397,71,o),
+(298,71,cs),
+(198,71,o),
+(143,132,o),
+(143,240,cs),
+(143,345,o),
+(213,481,o),
+(213,569,cs),
+(213,641,o),
+(176,690,o),
+(91,690,cs),
+(45,690,l),
+(45,611,l),
+(69,611,ls),
+(112,611,o),
+(126,584,o),
+(126,555,cs),
+(126,482,o),
+(53,339,o),
+(53,226,cs),
+(53,77,o),
+(146,-13,o),
+(298,-13,cs)
+);
+}
+);
+width = 596;
+}
+);
+metricRight = "=|";
+note = uni1640;
+unicode = 5696;
+},
+{
+color = 9;
+glyphname = "zoCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(91,0,ls),
+(176,0,o),
+(213,48,o),
+(213,121,cs),
+(213,209,o),
+(143,345,o),
+(143,450,cs),
+(143,556,o),
+(199,619,o),
+(298,619,cs),
+(398,619,o),
+(453,557,o),
+(453,450,cs),
+(453,345,o),
+(384,209,o),
+(384,121,cs),
+(384,48,o),
+(421,0,o),
+(505,0,cs),
+(551,0,l),
+(551,78,l),
+(527,78,ls),
+(484,78,o),
+(470,105,o),
+(470,134,cs),
+(470,208,o),
+(544,351,o),
+(544,464,cs),
+(544,612,o),
+(450,702,o),
+(298,702,cs),
+(147,702,o),
+(54,612,o),
+(54,464,cs),
+(54,351,o),
+(126,208,o),
+(126,134,cs),
+(126,105,o),
+(113,78,o),
+(69,78,cs),
+(45,78,l),
+(45,0,l)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1641;
+unicode = 5697;
+},
+{
+color = 9;
+glyphname = "zeCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (288,345);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(444,-13,o),
+(520,96,o),
+(520,345,cs),
+(520,594,o),
+(444,702,o),
+(342,702,cs),
+(261,702,o),
+(192,604,o),
+(156,604,cs),
+(137,604,o),
+(124,616,o),
+(124,660,cs),
+(124,690,l),
+(43,690,l),
+(43,634,ls),
+(43,559,o),
+(80,525,o),
+(131,525,cs),
+(199,525,o),
+(260,619,o),
+(321,619,cs),
+(381,619,o),
+(430,552,o),
+(430,345,cs),
+(430,138,o),
+(381,71,o),
+(321,71,cs),
+(260,71,o),
+(199,165,o),
+(131,165,cs),
+(80,165,o),
+(43,130,o),
+(43,56,cs),
+(43,0,l),
+(124,0,l),
+(124,30,ls),
+(124,73,o),
+(137,86,o),
+(156,86,cs),
+(192,86,o),
+(261,-13,o),
+(342,-13,cs)
+);
+}
+);
+width = 569;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1642;
+unicode = 5698;
+},
+{
+color = 9;
+glyphname = "zeeCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (243,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 569;
+}
+);
+note = uni1643;
+unicode = 5699;
+},
+{
+color = 9;
+glyphname = "ziCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (220,0);
+ref = dot_middle;
+}
+);
+width = 569;
+}
+);
+note = uni1644;
+unicode = 5700;
+},
+{
+color = 9;
+glyphname = "zaCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(308,-13,o),
+(377,86,o),
+(412,86,cs),
+(432,86,o),
+(445,73,o),
+(445,30,cs),
+(445,0,l),
+(526,0,l),
+(526,56,ls),
+(526,130,o),
+(489,165,o),
+(438,165,cs),
+(370,165,o),
+(309,71,o),
+(248,71,cs),
+(188,71,o),
+(139,138,o),
+(139,345,cs),
+(139,552,o),
+(188,619,o),
+(248,619,cs),
+(309,619,o),
+(370,525,o),
+(438,525,cs),
+(489,525,o),
+(526,559,o),
+(526,634,cs),
+(526,690,l),
+(445,690,l),
+(445,660,ls),
+(445,616,o),
+(432,604,o),
+(412,604,cs),
+(377,604,o),
+(308,702,o),
+(227,702,cs),
+(125,702,o),
+(49,594,o),
+(49,345,cs),
+(49,96,o),
+(125,-13,o),
+(227,-13,cs)
+);
+}
+);
+width = 569;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|zeCarrier-canadian";
+note = uni1645;
+unicode = 5701;
+},
+{
+color = 6;
+glyphname = "zCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(290,183,l),
+(290,242,l),
+(114,242,l),
+(114,205,l),
+(287,495,l),
+(287,527,l),
+(49,527,l),
+(49,469,l),
+(222,469,l),
+(222,505,l),
+(49,215,l),
+(49,183,l)
+);
+}
+);
+width = 339;
+}
+);
+metricRight = "=|";
+note = uni1646;
+unicode = 5702;
+},
+{
+color = 6;
+glyphname = "initialzCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(138,183,l),
+(138,96,l),
+(199,96,l),
+(199,183,l),
+(290,183,l),
+(290,242,l),
+(95,242,l),
+(115,206,l),
+(287,495,l),
+(287,527,l),
+(199,527,l),
+(199,614,l),
+(138,614,l),
+(138,527,l),
+(49,527,l),
+(49,469,l),
+(242,469,l),
+(221,504,l),
+(49,215,l),
+(49,183,l)
+);
+}
+);
+width = 339;
+}
+);
+metricLeft = "zCarrier-canadian";
+metricRight = "zCarrier-canadian";
+note = uni1647;
+unicode = 5703;
+},
+{
+color = 9;
+glyphname = "dzuCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(449,-13,o),
+(543,77,o),
+(543,226,cs),
+(543,339,o),
+(470,482,o),
+(470,555,cs),
+(470,584,o),
+(483,611,o),
+(527,611,cs),
+(551,611,l),
+(551,690,l),
+(509,690,ls),
+(428,690,o),
+(388,641,o),
+(388,569,cs),
+(388,481,o),
+(453,349,o),
+(453,240,cs),
+(453,133,o),
+(398,71,o),
+(298,71,cs),
+(197,71,o),
+(143,132,o),
+(143,240,cs),
+(143,349,o),
+(208,481,o),
+(208,569,cs),
+(208,641,o),
+(168,690,o),
+(87,690,cs),
+(45,690,l),
+(45,611,l),
+(69,611,ls),
+(112,611,o),
+(126,584,o),
+(126,555,cs),
+(126,482,o),
+(53,339,o),
+(53,226,cs),
+(53,77,o),
+(146,-13,o),
+(298,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(318,482,l),
+(318,652,l),
+(366,652,l),
+(366,690,l),
+(230,690,l),
+(230,652,l),
+(278,652,l),
+(278,482,l)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1648;
+unicode = 5704;
+},
+{
+color = 9;
+glyphname = "dzoCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(87,0,ls),
+(168,0,o),
+(209,48,o),
+(209,121,cs),
+(209,209,o),
+(143,341,o),
+(143,450,cs),
+(143,556,o),
+(198,619,o),
+(298,619,cs),
+(399,619,o),
+(453,557,o),
+(453,450,cs),
+(453,341,o),
+(388,209,o),
+(388,121,cs),
+(388,48,o),
+(429,0,o),
+(509,0,cs),
+(551,0,l),
+(551,78,l),
+(527,78,ls),
+(484,78,o),
+(470,105,o),
+(470,134,cs),
+(470,208,o),
+(544,351,o),
+(544,464,cs),
+(544,612,o),
+(450,702,o),
+(298,702,cs),
+(147,702,o),
+(54,612,o),
+(54,464,cs),
+(54,351,o),
+(126,208,o),
+(126,134,cs),
+(126,105,o),
+(113,78,o),
+(69,78,cs),
+(45,78,l),
+(45,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(367,0,l),
+(367,38,l),
+(318,38,l),
+(318,208,l),
+(279,208,l),
+(279,38,l),
+(230,38,l),
+(230,0,l)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1649;
+unicode = 5705;
+},
+{
+color = 9;
+glyphname = "dzeCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (306,345);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(462,-13,o),
+(537,96,o),
+(537,345,cs),
+(537,594,o),
+(462,702,o),
+(358,702,cs),
+(278,702,o),
+(210,604,o),
+(174,604,cs),
+(155,604,o),
+(141,616,o),
+(141,660,cs),
+(141,690,l),
+(60,690,l),
+(60,634,ls),
+(60,559,o),
+(97,525,o),
+(149,525,cs),
+(216,525,o),
+(277,619,o),
+(338,619,cs),
+(397,619,o),
+(447,552,o),
+(447,345,cs),
+(447,138,o),
+(397,71,o),
+(338,71,cs),
+(277,71,o),
+(216,165,o),
+(149,165,cs),
+(97,165,o),
+(60,130,o),
+(60,56,cs),
+(60,0,l),
+(141,0,l),
+(141,30,ls),
+(141,71,o),
+(155,83,o),
+(174,83,cs),
+(210,83,o),
+(278,-13,o),
+(358,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(109,242,l),
+(109,320,l),
+(212,320,l),
+(212,370,l),
+(109,370,l),
+(109,448,l),
+(60,448,l),
+(60,242,l)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164A;
+unicode = 5706;
+},
+{
+color = 9;
+glyphname = "dzeeCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+ref = "dzeCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (262,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 586;
+}
+);
+metricLeft = "dzeCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164B;
+unicode = 5707;
+},
+{
+color = 9;
+glyphname = "dziCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "dzeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (239,0);
+ref = dot_middle;
+}
+);
+width = 586;
+}
+);
+note = uni164C;
+unicode = 5708;
+},
+{
+color = 9;
+glyphname = "dzaCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(308,-13,o),
+(377,83,o),
+(412,83,cs),
+(432,83,o),
+(445,71,o),
+(445,30,cs),
+(445,0,l),
+(526,0,l),
+(526,56,ls),
+(526,130,o),
+(489,165,o),
+(438,165,cs),
+(370,165,o),
+(309,71,o),
+(248,71,cs),
+(188,71,o),
+(139,138,o),
+(139,345,cs),
+(139,552,o),
+(188,619,o),
+(248,619,cs),
+(309,619,o),
+(370,525,o),
+(438,525,cs),
+(489,525,o),
+(526,559,o),
+(526,634,cs),
+(526,690,l),
+(445,690,l),
+(445,660,ls),
+(445,616,o),
+(432,604,o),
+(412,604,cs),
+(377,604,o),
+(308,702,o),
+(227,702,cs),
+(125,702,o),
+(49,594,o),
+(49,345,cs),
+(49,96,o),
+(125,-13,o),
+(227,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(526,242,l),
+(526,448,l),
+(476,448,l),
+(476,370,l),
+(375,370,l),
+(375,320,l),
+(476,320,l),
+(476,242,l)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dzeCarrier-canadian";
+note = uni164D;
+unicode = 5709;
+},
+{
+color = 9;
+glyphname = "suCarrier-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(291,-13,o),
+(341,39,o),
+(359,137,c),
+(331,137,l),
+(350,39,o),
+(401,-13,o),
+(480,-13,cs),
+(579,-13,o),
+(639,62,o),
+(639,178,cs),
+(639,303,o),
+(572,460,o),
+(572,555,cs),
+(572,584,o),
+(583,611,o),
+(626,611,cs),
+(644,611,l),
+(644,690,l),
+(605,690,ls),
+(520,690,o),
+(486,642,o),
+(486,568,cs),
+(486,465,o),
+(551,292,o),
+(551,185,cs),
+(551,109,o),
+(523,70,o),
+(470,70,cs),
+(415,70,o),
+(384,115,o),
+(384,206,cs),
+(384,690,l),
+(306,690,l),
+(306,206,ls),
+(306,116,o),
+(275,70,o),
+(220,70,cs),
+(169,70,o),
+(140,109,o),
+(140,185,cs),
+(140,292,o),
+(205,465,o),
+(205,568,cs),
+(205,642,o),
+(170,690,o),
+(86,690,cs),
+(46,690,l),
+(46,611,l),
+(64,611,ls),
+(107,611,o),
+(120,583,o),
+(120,555,cs),
+(120,460,o),
+(52,303,o),
+(52,178,cs),
+(52,61,o),
+(112,-13,o),
+(212,-13,cs)
+);
+}
+);
+width = 690;
+}
+);
+metricRight = "=|";
+note = uni164E;
+unicode = 5710;
+},
+{
+color = 9;
+glyphname = "soCarrier-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(86,0,ls),
+(170,0,o),
+(204,47,o),
+(204,122,cs),
+(204,225,o),
+(139,398,o),
+(139,504,cs),
+(139,581,o),
+(167,620,o),
+(219,620,cs),
+(274,620,o),
+(305,575,o),
+(305,484,cs),
+(305,0,l),
+(384,0,l),
+(384,484,ls),
+(384,574,o),
+(415,620,o),
+(469,620,cs),
+(522,620,o),
+(551,581,o),
+(551,504,cs),
+(551,398,o),
+(486,225,o),
+(486,122,cs),
+(486,47,o),
+(520,0,o),
+(605,0,cs),
+(644,0,l),
+(644,78,l),
+(626,78,ls),
+(583,78,o),
+(571,106,o),
+(571,134,cs),
+(571,230,o),
+(639,386,o),
+(639,512,cs),
+(639,629,o),
+(578,702,o),
+(479,702,cs),
+(400,702,o),
+(349,651,o),
+(331,553,c),
+(358,553,l),
+(341,651,o),
+(290,702,o),
+(211,702,cs),
+(112,702,o),
+(51,628,o),
+(51,512,cs),
+(51,386,o),
+(119,230,o),
+(119,134,cs),
+(119,105,o),
+(107,78,o),
+(64,78,cs),
+(46,78,l),
+(46,0,l)
+);
+}
+);
+width = 690;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5711;
+},
+{
+color = 9;
+glyphname = "seCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(466,-13,o),
+(527,62,o),
+(527,174,cs),
+(527,278,o),
+(476,346,o),
+(392,355,c),
+(392,335,l),
+(476,344,o),
+(527,412,o),
+(527,516,cs),
+(527,628,o),
+(466,702,o),
+(378,702,cs),
+(292,702,o),
+(213,604,o),
+(172,604,cs),
+(154,604,o),
+(140,616,o),
+(140,660,cs),
+(140,690,l),
+(59,690,l),
+(59,634,ls),
+(59,559,o),
+(97,525,o),
+(148,525,cs),
+(217,525,o),
+(292,621,o),
+(353,621,cs),
+(406,621,o),
+(439,577,o),
+(439,504,cs),
+(439,424,o),
+(397,382,o),
+(330,382,cs),
+(59,382,l),
+(59,308,l),
+(330,308,ls),
+(398,308,o),
+(439,266,o),
+(439,185,cs),
+(439,113,o),
+(406,69,o),
+(353,69,cs),
+(292,69,o),
+(217,165,o),
+(148,165,cs),
+(97,165,o),
+(59,130,o),
+(59,56,cs),
+(59,0,l),
+(140,0,l),
+(140,30,ls),
+(140,73,o),
+(154,86,o),
+(172,86,cs),
+(213,86,o),
+(292,-13,o),
+(378,-13,cs)
+);
+}
+);
+width = 584;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni1650;
+unicode = 5712;
+},
+{
+color = 9;
+glyphname = "seeCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(466,-13,o),
+(527,62,o),
+(527,174,cs),
+(527,271,o),
+(482,337,o),
+(408,353,c),
+(408,337,l),
+(482,353,o),
+(527,417,o),
+(527,516,cs),
+(527,628,o),
+(466,702,o),
+(378,702,cs),
+(292,702,o),
+(213,604,o),
+(172,604,cs),
+(154,604,o),
+(140,616,o),
+(140,660,cs),
+(140,690,l),
+(59,690,l),
+(59,634,ls),
+(59,559,o),
+(97,525,o),
+(148,525,cs),
+(217,525,o),
+(292,621,o),
+(353,621,cs),
+(406,621,o),
+(439,577,o),
+(439,504,cs),
+(439,424,o),
+(397,380,o),
+(331,380,cs),
+(279,380,l),
+(301,353,l),
+(301,459,l),
+(252,459,l),
+(252,380,l),
+(59,380,l),
+(59,310,l),
+(252,310,l),
+(252,223,l),
+(301,223,l),
+(301,333,l),
+(279,310,l),
+(331,310,ls),
+(398,310,o),
+(439,266,o),
+(439,185,cs),
+(439,113,o),
+(406,69,o),
+(353,69,cs),
+(292,69,o),
+(217,165,o),
+(148,165,cs),
+(97,165,o),
+(59,130,o),
+(59,56,cs),
+(59,0,l),
+(140,0,l),
+(140,30,ls),
+(140,73,o),
+(154,86,o),
+(172,86,cs),
+(213,86,o),
+(292,-13,o),
+(378,-13,cs)
+);
+}
+);
+width = 584;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1651;
+unicode = 5713;
+},
+{
+color = 9;
+glyphname = "siCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(466,-13,o),
+(527,62,o),
+(527,174,cs),
+(527,271,o),
+(482,337,o),
+(408,353,c),
+(408,337,l),
+(482,353,o),
+(527,417,o),
+(527,516,cs),
+(527,628,o),
+(466,702,o),
+(378,702,cs),
+(292,702,o),
+(213,604,o),
+(172,604,cs),
+(154,604,o),
+(140,616,o),
+(140,660,cs),
+(140,690,l),
+(59,690,l),
+(59,634,ls),
+(59,559,o),
+(97,525,o),
+(148,525,cs),
+(217,525,o),
+(292,621,o),
+(353,621,cs),
+(406,621,o),
+(439,576,o),
+(439,501,cs),
+(439,420,o),
+(401,379,o),
+(339,379,cs),
+(291,379,l),
+(327,352,l),
+(323,389,o),
+(294,417,o),
+(256,417,cs),
+(230,417,o),
+(207,402,o),
+(195,380,c),
+(59,380,l),
+(59,310,l),
+(196,310,l),
+(207,288,o),
+(230,272,o),
+(256,272,cs),
+(294,272,o),
+(322,301,o),
+(326,337,c),
+(290,311,l),
+(339,311,ls),
+(403,311,o),
+(439,270,o),
+(439,188,cs),
+(439,114,o),
+(406,69,o),
+(353,69,cs),
+(292,69,o),
+(217,165,o),
+(148,165,cs),
+(97,165,o),
+(59,130,o),
+(59,56,cs),
+(59,0,l),
+(140,0,l),
+(140,30,ls),
+(140,73,o),
+(154,86,o),
+(172,86,cs),
+(213,86,o),
+(292,-13,o),
+(378,-13,cs)
+);
+}
+);
+width = 584;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1652;
+unicode = 5714;
+},
+{
+color = 9;
+glyphname = "saCarrier-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(294,-13,o),
+(372,86,o),
+(412,86,cs),
+(431,86,o),
+(444,73,o),
+(444,30,cs),
+(444,0,l),
+(526,0,l),
+(526,56,ls),
+(526,130,o),
+(488,165,o),
+(437,165,cs),
+(367,165,o),
+(293,69,o),
+(232,69,cs),
+(179,69,o),
+(146,113,o),
+(146,185,cs),
+(146,266,o),
+(186,308,o),
+(254,308,cs),
+(526,308,l),
+(526,382,l),
+(254,382,ls),
+(187,382,o),
+(146,424,o),
+(146,504,cs),
+(146,577,o),
+(179,621,o),
+(233,621,cs),
+(293,621,o),
+(367,525,o),
+(437,525,cs),
+(488,525,o),
+(526,559,o),
+(526,634,cs),
+(526,690,l),
+(444,690,l),
+(444,660,ls),
+(444,616,o),
+(431,604,o),
+(412,604,cs),
+(372,604,o),
+(294,702,o),
+(207,702,cs),
+(120,702,o),
+(57,628,o),
+(57,516,cs),
+(57,412,o),
+(108,344,o),
+(192,335,c),
+(192,355,l),
+(108,346,o),
+(57,278,o),
+(57,174,cs),
+(57,62,o),
+(120,-13,o),
+(207,-13,cs)
+);
+}
+);
+width = 585;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1653;
+unicode = 5715;
+},
+{
+color = 9;
+glyphname = "shuCarrier-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(287,-13,o),
+(336,34,o),
+(356,124,c),
+(334,124,l),
+(355,34,o),
+(404,-13,o),
+(480,-13,cs),
+(579,-13,o),
+(639,62,o),
+(639,178,cs),
+(639,303,o),
+(572,460,o),
+(572,555,cs),
+(572,584,o),
+(583,611,o),
+(626,611,cs),
+(644,611,l),
+(644,690,l),
+(605,690,ls),
+(520,690,o),
+(487,642,o),
+(487,568,cs),
+(487,551,o),
+(489,531,o),
+(492,513,c),
+(505,560,l),
+(384,560,l),
+(384,690,l),
+(306,690,l),
+(306,560,l),
+(185,560,l),
+(200,513,l),
+(202,531,o),
+(204,551,o),
+(204,568,cs),
+(204,642,o),
+(170,690,o),
+(86,690,cs),
+(46,690,l),
+(46,611,l),
+(64,611,ls),
+(107,611,o),
+(120,583,o),
+(120,555,cs),
+(120,460,o),
+(52,303,o),
+(52,178,cs),
+(52,61,o),
+(112,-13,o),
+(212,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(169,70,o),
+(140,109,o),
+(140,185,cs),
+(140,269,o),
+(180,390,o),
+(196,489,c),
+(306,489,l),
+(306,206,ls),
+(306,116,o),
+(275,70,o),
+(220,70,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(415,70,o),
+(384,115,o),
+(384,206,cs),
+(384,489,l),
+(495,489,l),
+(511,390,o),
+(551,269,o),
+(551,185,cs),
+(551,109,o),
+(523,70,o),
+(470,70,cs)
+);
+}
+);
+width = 690;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1654;
+unicode = 5716;
+},
+{
+color = 9;
+glyphname = "shoCarrier-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(86,0,ls),
+(170,0,o),
+(204,47,o),
+(204,122,cs),
+(204,139,o),
+(201,158,o),
+(199,177,c),
+(185,129,l),
+(305,129,l),
+(305,0,l),
+(384,0,l),
+(384,129,l),
+(504,129,l),
+(491,177,l),
+(489,158,o),
+(487,139,o),
+(487,122,cs),
+(487,47,o),
+(520,0,o),
+(605,0,cs),
+(644,0,l),
+(644,78,l),
+(626,78,ls),
+(583,78,o),
+(571,106,o),
+(571,134,cs),
+(571,230,o),
+(639,386,o),
+(639,512,cs),
+(639,629,o),
+(578,702,o),
+(479,702,cs),
+(404,702,o),
+(355,656,o),
+(333,566,c),
+(355,566,l),
+(336,656,o),
+(286,702,o),
+(211,702,cs),
+(112,702,o),
+(51,628,o),
+(51,512,cs),
+(51,386,o),
+(119,230,o),
+(119,134,cs),
+(119,105,o),
+(107,78,o),
+(64,78,cs),
+(46,78,l),
+(46,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(179,299,o),
+(139,421,o),
+(139,504,cs),
+(139,581,o),
+(167,620,o),
+(219,620,cs),
+(274,620,o),
+(305,575,o),
+(305,484,cs),
+(305,201,l),
+(196,201,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(384,484,ls),
+(384,574,o),
+(415,620,o),
+(469,620,cs),
+(522,620,o),
+(551,581,o),
+(551,504,cs),
+(551,421,o),
+(511,299,o),
+(494,201,c),
+(384,201,l)
+);
+}
+);
+width = 690;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1655;
+unicode = 5717;
+},
+{
+color = 9;
+glyphname = "sheCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(466,-13,o),
+(527,62,o),
+(527,174,cs),
+(527,271,o),
+(482,337,o),
+(408,353,c),
+(408,337,l),
+(482,353,o),
+(527,417,o),
+(527,516,cs),
+(527,628,o),
+(466,702,o),
+(378,702,cs),
+(292,702,o),
+(213,604,o),
+(172,604,cs),
+(154,604,o),
+(140,616,o),
+(140,660,cs),
+(140,690,l),
+(59,690,l),
+(59,634,ls),
+(59,559,o),
+(97,526,o),
+(148,526,cs),
+(165,526,o),
+(183,532,o),
+(199,540,c),
+(147,554,l),
+(147,382,l),
+(59,382,l),
+(59,308,l),
+(147,308,l),
+(147,135,l),
+(198,150,l),
+(182,157,o),
+(165,163,o),
+(148,163,cs),
+(97,163,o),
+(59,130,o),
+(59,56,cs),
+(59,0,l),
+(140,0,l),
+(140,30,ls),
+(140,73,o),
+(154,86,o),
+(172,86,cs),
+(213,86,o),
+(292,-13,o),
+(378,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(217,308,l),
+(330,308,ls),
+(398,308,o),
+(439,266,o),
+(439,185,cs),
+(439,113,o),
+(406,69,o),
+(353,69,cs),
+(311,69,o),
+(264,112,o),
+(217,139,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(217,551,l),
+(264,578,o),
+(311,621,o),
+(353,621,cs),
+(406,621,o),
+(439,577,o),
+(439,504,cs),
+(439,424,o),
+(397,382,o),
+(330,382,cs),
+(217,382,l)
+);
+}
+);
+width = 584;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1656;
+unicode = 5718;
+},
+{
+color = 9;
+glyphname = "sheeCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(466,-13,o),
+(527,62,o),
+(527,174,cs),
+(527,271,o),
+(482,337,o),
+(408,353,c),
+(408,337,l),
+(482,353,o),
+(527,417,o),
+(527,516,cs),
+(527,628,o),
+(466,702,o),
+(378,702,cs),
+(292,702,o),
+(213,604,o),
+(172,604,cs),
+(154,604,o),
+(140,616,o),
+(140,660,cs),
+(140,690,l),
+(59,690,l),
+(59,634,ls),
+(59,559,o),
+(97,526,o),
+(148,526,cs),
+(161,526,o),
+(176,530,o),
+(190,537,c),
+(147,553,l),
+(147,376,l),
+(59,376,l),
+(59,314,l),
+(147,314,l),
+(147,137,l),
+(191,153,l),
+(177,159,o),
+(162,163,o),
+(148,163,cs),
+(97,163,o),
+(59,130,o),
+(59,56,cs),
+(59,0,l),
+(140,0,l),
+(140,30,ls),
+(140,73,o),
+(154,86,o),
+(172,86,cs),
+(213,86,o),
+(292,-13,o),
+(378,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(310,67,o),
+(257,119,o),
+(204,146,c),
+(204,314,l),
+(288,314,l),
+(288,223,l),
+(330,223,l),
+(330,329,l),
+(311,314,l),
+(341,314,ls),
+(405,314,o),
+(441,266,o),
+(441,189,cs),
+(441,112,o),
+(409,67,o),
+(355,67,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(330,459,l),
+(288,459,l),
+(288,376,l),
+(204,376,l),
+(204,544,l),
+(257,571,o),
+(310,623,o),
+(355,623,cs),
+(409,623,o),
+(441,578,o),
+(441,500,cs),
+(441,424,o),
+(403,376,o),
+(341,376,cs),
+(311,376,l),
+(330,360,l)
+);
+}
+);
+width = 584;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1657;
+unicode = 5719;
+},
+{
+color = 9;
+glyphname = "shiCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(59,634,ls),
+(59,559,o),
+(97,526,o),
+(148,526,cs),
+(160,526,o),
+(173,530,o),
+(185,535,c),
+(147,552,l),
+(147,376,l),
+(59,376,l),
+(59,314,l),
+(147,314,l),
+(147,138,l),
+(185,155,l),
+(173,159,o),
+(160,163,o),
+(148,163,cs),
+(97,163,o),
+(59,130,o),
+(59,56,cs),
+(59,0,l),
+(140,0,l),
+(140,30,ls),
+(140,73,o),
+(154,86,o),
+(172,86,cs),
+(213,86,o),
+(292,-13,o),
+(378,-13,cs),
+(466,-13,o),
+(527,62,o),
+(527,174,cs),
+(527,271,o),
+(482,337,o),
+(408,353,c),
+(408,337,l),
+(482,353,o),
+(527,417,o),
+(527,516,cs),
+(527,628,o),
+(466,702,o),
+(378,702,cs),
+(292,702,o),
+(213,604,o),
+(172,604,cs),
+(154,604,o),
+(140,616,o),
+(140,660,cs),
+(140,690,l),
+(59,690,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(204,314,l),
+(249,314,l),
+(260,288,o),
+(283,272,o),
+(308,272,cs),
+(344,272,o),
+(372,304,o),
+(373,337,c),
+(319,313,l),
+(347,313,ls),
+(407,313,o),
+(441,267,o),
+(441,189,cs),
+(441,112,o),
+(409,67,o),
+(355,67,cs),
+(310,67,o),
+(256,119,o),
+(204,146,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(204,544,l),
+(256,571,o),
+(310,623,o),
+(355,623,cs),
+(409,623,o),
+(441,578,o),
+(441,500,cs),
+(441,423,o),
+(405,377,o),
+(347,377,cs),
+(320,377,l),
+(373,352,l),
+(373,386,o),
+(345,417,o),
+(308,417,cs),
+(283,417,o),
+(260,402,o),
+(249,376,c),
+(204,376,l)
+);
+}
+);
+width = 584;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1658;
+unicode = 5720;
+},
+{
+color = 9;
+glyphname = "shaCarrier-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(294,-13,o),
+(372,86,o),
+(412,86,cs),
+(431,86,o),
+(444,73,o),
+(444,30,cs),
+(444,0,l),
+(526,0,l),
+(526,56,ls),
+(526,130,o),
+(488,163,o),
+(437,163,cs),
+(419,163,o),
+(403,157,o),
+(385,150,c),
+(438,135,l),
+(438,308,l),
+(526,308,l),
+(526,382,l),
+(438,382,l),
+(438,554,l),
+(386,540,l),
+(403,532,o),
+(419,526,o),
+(437,526,cs),
+(488,526,o),
+(526,559,o),
+(526,634,cs),
+(526,690,l),
+(444,690,l),
+(444,660,ls),
+(444,616,o),
+(431,604,o),
+(412,604,cs),
+(372,604,o),
+(294,702,o),
+(207,702,cs),
+(120,702,o),
+(57,628,o),
+(57,516,cs),
+(57,417,o),
+(102,353,o),
+(178,337,c),
+(178,353,l),
+(102,337,o),
+(57,271,o),
+(57,174,cs),
+(57,62,o),
+(120,-13,o),
+(207,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(179,69,o),
+(146,113,o),
+(146,185,cs),
+(146,266,o),
+(186,308,o),
+(254,308,cs),
+(367,308,l),
+(367,139,l),
+(322,112,o),
+(273,69,o),
+(232,69,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(187,382,o),
+(146,424,o),
+(146,504,cs),
+(146,577,o),
+(179,621,o),
+(233,621,cs),
+(273,621,o),
+(322,578,o),
+(367,551,c),
+(367,382,l),
+(254,382,ls)
+);
+}
+);
+width = 585;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1659;
+unicode = 5721;
+},
+{
+color = 6;
+glyphname = "shCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(193,96,l),
+(193,195,l),
+(150,184,l),
+(173,184,ls),
+(242,184,o),
+(279,219,o),
+(279,282,cs),
+(279,343,o),
+(245,381,o),
+(182,381,cs),
+(158,381,ls),
+(127,381,o),
+(107,393,o),
+(107,428,cs),
+(107,464,o),
+(127,476,o),
+(158,476,cs),
+(274,476,l),
+(274,527,l),
+(193,527,l),
+(193,614,l),
+(135,614,l),
+(135,510,l),
+(177,527,l),
+(156,527,ls),
+(85,527,o),
+(49,491,o),
+(49,428,cs),
+(49,368,o),
+(83,330,o),
+(146,330,cs),
+(171,330,ls),
+(202,330,o),
+(221,317,o),
+(221,282,cs),
+(221,247,o),
+(202,234,o),
+(171,234,cs),
+(54,234,l),
+(54,184,l),
+(135,184,l),
+(135,96,l)
+);
+}
+);
+width = 328;
+}
+);
+metricRight = "=|";
+note = uni18F5;
+unicode = 5722;
+},
+{
+color = 9;
+glyphname = "tsuCarrier-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(287,-13,o),
+(336,34,o),
+(356,124,c),
+(334,124,l),
+(355,34,o),
+(404,-13,o),
+(480,-13,cs),
+(579,-13,o),
+(639,62,o),
+(639,178,cs),
+(639,303,o),
+(572,460,o),
+(572,555,cs),
+(572,584,o),
+(583,611,o),
+(626,611,cs),
+(644,611,l),
+(644,690,l),
+(605,690,ls),
+(522,690,o),
+(489,645,o),
+(489,571,cs),
+(489,519,o),
+(509,451,o),
+(525,381,c),
+(384,381,l),
+(384,627,l),
+(442,627,l),
+(442,690,l),
+(248,690,l),
+(248,627,l),
+(307,627,l),
+(307,381,l),
+(166,381,l),
+(183,451,o),
+(202,519,o),
+(202,571,cs),
+(202,645,o),
+(168,690,o),
+(86,690,cs),
+(46,690,l),
+(46,611,l),
+(64,611,ls),
+(107,611,o),
+(120,583,o),
+(120,555,cs),
+(120,460,o),
+(52,303,o),
+(52,178,cs),
+(52,61,o),
+(112,-13,o),
+(212,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(169,70,o),
+(140,109,o),
+(140,185,cs),
+(140,221,o),
+(147,265,o),
+(156,309,c),
+(307,309,l),
+(307,206,ls),
+(307,116,o),
+(276,70,o),
+(221,70,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(414,70,o),
+(384,115,o),
+(384,206,cs),
+(384,309,l),
+(535,309,l),
+(544,265,o),
+(551,221,o),
+(551,185,cs),
+(551,109,o),
+(522,70,o),
+(469,70,cs)
+);
+}
+);
+width = 690;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165B;
+unicode = 5723;
+},
+{
+color = 9;
+glyphname = "tsoCarrier-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(86,0,ls),
+(168,0,o),
+(201,44,o),
+(201,119,cs),
+(201,171,o),
+(182,239,o),
+(166,309,c),
+(307,309,l),
+(307,63,l),
+(248,63,l),
+(248,0,l),
+(442,0,l),
+(442,63,l),
+(383,63,l),
+(383,309,l),
+(525,309,l),
+(508,239,o),
+(489,171,o),
+(489,119,cs),
+(489,44,o),
+(522,0,o),
+(605,0,cs),
+(644,0,l),
+(644,78,l),
+(626,78,ls),
+(583,78,o),
+(571,106,o),
+(571,134,cs),
+(571,230,o),
+(639,386,o),
+(639,512,cs),
+(639,629,o),
+(578,702,o),
+(479,702,cs),
+(404,702,o),
+(354,656,o),
+(334,566,c),
+(356,566,l),
+(335,656,o),
+(286,702,o),
+(211,702,cs),
+(112,702,o),
+(51,628,o),
+(51,512,cs),
+(51,386,o),
+(119,230,o),
+(119,134,cs),
+(119,105,o),
+(107,78,o),
+(64,78,cs),
+(46,78,l),
+(46,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(147,425,o),
+(139,469,o),
+(139,504,cs),
+(139,581,o),
+(168,620,o),
+(220,620,cs),
+(275,620,o),
+(307,575,o),
+(307,484,cs),
+(307,381,l),
+(156,381,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(383,484,ls),
+(383,574,o),
+(414,620,o),
+(469,620,cs),
+(521,620,o),
+(551,581,o),
+(551,504,cs),
+(551,469,o),
+(543,425,o),
+(534,381,c),
+(383,381,l)
+);
+}
+);
+width = 690;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165C;
+unicode = 5724;
+},
+{
+color = 9;
+glyphname = "tseCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(468,-13,o),
+(529,62,o),
+(529,174,cs),
+(529,271,o),
+(484,337,o),
+(409,353,c),
+(409,337,l),
+(484,353,o),
+(529,417,o),
+(529,516,cs),
+(529,628,o),
+(468,702,o),
+(380,702,cs),
+(293,702,o),
+(214,604,o),
+(174,604,cs),
+(156,604,o),
+(142,616,o),
+(142,660,cs),
+(142,690,l),
+(61,690,l),
+(61,636,ls),
+(61,561,o),
+(99,529,o),
+(150,529,cs),
+(173,529,o),
+(198,540,o),
+(222,555,c),
+(195,564,l),
+(195,376,l),
+(111,376,l),
+(111,461,l),
+(61,461,l),
+(61,229,l),
+(111,229,l),
+(111,314,l),
+(195,314,l),
+(195,126,l),
+(223,135,l),
+(198,150,o),
+(173,160,o),
+(150,160,cs),
+(99,160,o),
+(61,128,o),
+(61,54,cs),
+(61,0,l),
+(142,0,l),
+(142,30,ls),
+(142,73,o),
+(156,86,o),
+(174,86,cs),
+(214,86,o),
+(293,-13,o),
+(380,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(324,69,o),
+(288,94,o),
+(252,118,c),
+(252,314,l),
+(333,314,ls),
+(402,314,o),
+(442,268,o),
+(442,186,cs),
+(442,114,o),
+(410,69,o),
+(355,69,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(252,572,l),
+(288,596,o),
+(324,621,o),
+(355,621,cs),
+(410,621,o),
+(442,576,o),
+(442,503,cs),
+(442,422,o),
+(400,376,o),
+(333,376,cs),
+(252,376,l)
+);
+}
+);
+width = 586;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni165D;
+unicode = 5725;
+},
+{
+color = 9;
+glyphname = "tseeCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(468,-13,o),
+(529,62,o),
+(529,174,cs),
+(529,271,o),
+(484,337,o),
+(409,353,c),
+(409,337,l),
+(484,353,o),
+(529,417,o),
+(529,516,cs),
+(529,628,o),
+(468,702,o),
+(380,702,cs),
+(293,702,o),
+(214,604,o),
+(174,604,cs),
+(156,604,o),
+(142,616,o),
+(142,660,cs),
+(142,690,l),
+(61,690,l),
+(61,636,ls),
+(61,561,o),
+(99,529,o),
+(150,529,cs),
+(169,529,o),
+(190,539,o),
+(212,551,c),
+(187,570,l),
+(187,375,l),
+(107,375,l),
+(107,461,l),
+(61,461,l),
+(61,229,l),
+(107,229,l),
+(107,315,l),
+(187,315,l),
+(187,120,l),
+(209,140,l),
+(188,151,o),
+(168,160,o),
+(150,160,cs),
+(99,160,o),
+(61,128,o),
+(61,54,cs),
+(61,0,l),
+(142,0,l),
+(142,30,ls),
+(142,73,o),
+(156,86,o),
+(174,86,cs),
+(214,86,o),
+(293,-13,o),
+(380,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(320,69,o),
+(280,99,o),
+(239,126,c),
+(239,315,l),
+(308,315,l),
+(308,218,l),
+(350,218,l),
+(350,330,l),
+(330,315,l),
+(346,315,ls),
+(410,315,o),
+(443,268,o),
+(443,190,cs),
+(443,114,o),
+(411,69,o),
+(355,69,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(350,464,l),
+(308,464,l),
+(308,375,l),
+(239,375,l),
+(239,564,l),
+(280,590,o),
+(320,621,o),
+(355,621,cs),
+(411,621,o),
+(443,576,o),
+(443,499,cs),
+(443,422,o),
+(409,375,o),
+(346,375,cs),
+(330,375,l),
+(350,360,l)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165E;
+unicode = 5726;
+},
+{
+color = 9;
+glyphname = "tsiCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(468,-13,o),
+(529,62,o),
+(529,174,cs),
+(529,271,o),
+(484,337,o),
+(410,353,c),
+(410,337,l),
+(484,353,o),
+(529,417,o),
+(529,516,cs),
+(529,628,o),
+(468,702,o),
+(380,702,cs),
+(293,702,o),
+(214,604,o),
+(174,604,cs),
+(156,604,o),
+(142,616,o),
+(142,660,cs),
+(142,690,l),
+(61,690,l),
+(61,636,ls),
+(61,561,o),
+(99,529,o),
+(150,529,cs),
+(172,529,o),
+(195,540,o),
+(218,553,c),
+(186,560,l),
+(186,375,l),
+(107,375,l),
+(107,461,l),
+(61,461,l),
+(61,229,l),
+(107,229,l),
+(107,315,l),
+(186,315,l),
+(186,129,l),
+(217,137,l),
+(195,150,o),
+(172,160,o),
+(150,160,cs),
+(99,160,o),
+(61,128,o),
+(61,54,cs),
+(61,0,l),
+(142,0,l),
+(142,30,ls),
+(142,73,o),
+(156,86,o),
+(174,86,cs),
+(214,86,o),
+(293,-13,o),
+(380,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(320,69,o),
+(279,100,o),
+(237,127,c),
+(237,315,l),
+(275,315,l),
+(284,289,o),
+(305,272,o),
+(330,272,cs),
+(366,272,o),
+(387,306,o),
+(389,336,c),
+(329,315,l),
+(347,315,ls),
+(410,315,o),
+(443,268,o),
+(443,190,cs),
+(443,114,o),
+(411,69,o),
+(355,69,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(387,384,o),
+(366,417,o),
+(330,417,cs),
+(305,417,o),
+(284,402,o),
+(275,375,c),
+(237,375,l),
+(237,563,l),
+(279,589,o),
+(320,621,o),
+(355,621,cs),
+(411,621,o),
+(443,576,o),
+(443,499,cs),
+(443,422,o),
+(409,375,o),
+(347,375,cs),
+(329,375,l),
+(389,350,l)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165F;
+unicode = 5727;
+},
+{
+color = 9;
+glyphname = "tsaCarrier-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(294,-13,o),
+(372,86,o),
+(412,86,cs),
+(431,86,o),
+(444,73,o),
+(444,30,cs),
+(444,0,l),
+(526,0,l),
+(526,54,ls),
+(526,128,o),
+(488,160,o),
+(437,160,cs),
+(413,160,o),
+(388,150,o),
+(363,135,c),
+(391,126,l),
+(391,314,l),
+(475,314,l),
+(475,229,l),
+(526,229,l),
+(526,461,l),
+(475,461,l),
+(475,376,l),
+(391,376,l),
+(391,564,l),
+(364,555,l),
+(388,540,o),
+(413,529,o),
+(437,529,cs),
+(488,529,o),
+(526,561,o),
+(526,636,cs),
+(526,690,l),
+(444,690,l),
+(444,660,ls),
+(444,616,o),
+(431,604,o),
+(412,604,cs),
+(372,604,o),
+(294,702,o),
+(207,702,cs),
+(120,702,o),
+(57,628,o),
+(57,516,cs),
+(57,417,o),
+(102,353,o),
+(178,337,c),
+(178,353,l),
+(102,337,o),
+(57,271,o),
+(57,174,cs),
+(57,62,o),
+(120,-13,o),
+(207,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(177,69,o),
+(144,114,o),
+(144,186,cs),
+(144,268,o),
+(185,314,o),
+(253,314,cs),
+(334,314,l),
+(334,118,l),
+(298,94,o),
+(263,69,o),
+(231,69,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(186,376,o),
+(144,422,o),
+(144,503,cs),
+(144,576,o),
+(177,621,o),
+(231,621,cs),
+(263,621,o),
+(298,596,o),
+(334,572,c),
+(334,376,l),
+(253,376,ls)
+);
+}
+);
+width = 587;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1660;
+unicode = 5728;
+},
+{
+color = 9;
+glyphname = "chuCarrier-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(287,-13,o),
+(336,34,o),
+(356,124,c),
+(334,124,l),
+(355,34,o),
+(404,-13,o),
+(480,-13,cs),
+(579,-13,o),
+(639,62,o),
+(639,178,cs),
+(639,303,o),
+(572,460,o),
+(572,555,cs),
+(572,584,o),
+(583,611,o),
+(626,611,cs),
+(644,611,l),
+(644,690,l),
+(605,690,ls),
+(522,690,o),
+(489,645,o),
+(489,571,cs),
+(489,460,o),
+(551,292,o),
+(551,185,cs),
+(551,109,o),
+(522,70,o),
+(469,70,cs),
+(414,70,o),
+(384,115,o),
+(384,206,cs),
+(384,627,l),
+(442,627,l),
+(442,690,l),
+(248,690,l),
+(248,627,l),
+(307,627,l),
+(307,206,ls),
+(307,116,o),
+(276,70,o),
+(221,70,cs),
+(169,70,o),
+(140,109,o),
+(140,185,cs),
+(140,292,o),
+(202,460,o),
+(202,571,cs),
+(202,645,o),
+(168,690,o),
+(86,690,cs),
+(46,690,l),
+(46,611,l),
+(64,611,ls),
+(107,611,o),
+(120,583,o),
+(120,555,cs),
+(120,460,o),
+(52,303,o),
+(52,178,cs),
+(52,61,o),
+(112,-13,o),
+(212,-13,cs)
+);
+}
+);
+width = 690;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164E;
+unicode = 5729;
+},
+{
+color = 9;
+glyphname = "choCarrier-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(86,0,ls),
+(168,0,o),
+(201,44,o),
+(201,119,cs),
+(201,230,o),
+(139,398,o),
+(139,504,cs),
+(139,581,o),
+(168,620,o),
+(220,620,cs),
+(275,620,o),
+(307,575,o),
+(307,484,cs),
+(307,63,l),
+(248,63,l),
+(248,0,l),
+(442,0,l),
+(442,63,l),
+(384,63,l),
+(384,484,ls),
+(384,574,o),
+(414,620,o),
+(469,620,cs),
+(521,620,o),
+(551,581,o),
+(551,504,cs),
+(551,398,o),
+(489,230,o),
+(489,119,cs),
+(489,44,o),
+(522,0,o),
+(605,0,cs),
+(644,0,l),
+(644,78,l),
+(626,78,ls),
+(583,78,o),
+(571,106,o),
+(571,134,cs),
+(571,230,o),
+(639,386,o),
+(639,512,cs),
+(639,629,o),
+(578,702,o),
+(479,702,cs),
+(404,702,o),
+(354,656,o),
+(334,566,c),
+(356,566,l),
+(335,656,o),
+(286,702,o),
+(211,702,cs),
+(112,702,o),
+(51,628,o),
+(51,512,cs),
+(51,386,o),
+(119,230,o),
+(119,134,cs),
+(119,105,o),
+(107,78,o),
+(64,78,cs),
+(46,78,l),
+(46,0,l)
+);
+}
+);
+width = 690;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5730;
+},
+{
+color = 9;
+glyphname = "cheCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(468,-13,o),
+(529,62,o),
+(529,174,cs),
+(529,271,o),
+(484,337,o),
+(409,353,c),
+(409,337,l),
+(484,353,o),
+(529,417,o),
+(529,516,cs),
+(529,628,o),
+(468,702,o),
+(380,702,cs),
+(293,702,o),
+(214,604,o),
+(174,604,cs),
+(156,604,o),
+(142,616,o),
+(142,660,cs),
+(142,690,l),
+(61,690,l),
+(61,634,ls),
+(61,559,o),
+(99,527,o),
+(150,527,cs),
+(219,527,o),
+(294,621,o),
+(354,621,cs),
+(408,621,o),
+(440,577,o),
+(440,504,cs),
+(440,424,o),
+(399,382,o),
+(332,382,cs),
+(111,382,l),
+(111,461,l),
+(61,461,l),
+(61,229,l),
+(111,229,l),
+(111,308,l),
+(332,308,ls),
+(400,308,o),
+(440,266,o),
+(440,185,cs),
+(440,113,o),
+(408,69,o),
+(355,69,cs),
+(294,69,o),
+(219,162,o),
+(150,162,cs),
+(99,162,o),
+(61,130,o),
+(61,56,cs),
+(61,0,l),
+(142,0,l),
+(142,30,ls),
+(142,73,o),
+(156,86,o),
+(174,86,cs),
+(214,86,o),
+(293,-13,o),
+(380,-13,cs)
+);
+}
+);
+width = 586;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni1663;
+unicode = 5731;
+},
+{
+color = 9;
+glyphname = "cheeCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(468,-13,o),
+(529,62,o),
+(529,174,cs),
+(529,271,o),
+(484,337,o),
+(409,353,c),
+(409,337,l),
+(484,353,o),
+(529,417,o),
+(529,516,cs),
+(529,628,o),
+(468,702,o),
+(380,702,cs),
+(293,702,o),
+(214,604,o),
+(174,604,cs),
+(156,604,o),
+(142,616,o),
+(142,660,cs),
+(142,690,l),
+(61,690,l),
+(61,634,ls),
+(61,559,o),
+(99,527,o),
+(150,527,cs),
+(220,527,o),
+(295,623,o),
+(356,623,cs),
+(411,623,o),
+(442,578,o),
+(442,504,cs),
+(442,424,o),
+(405,376,o),
+(343,376,cs),
+(288,376,l),
+(311,361,l),
+(311,459,l),
+(261,459,l),
+(261,376,l),
+(111,376,l),
+(111,461,l),
+(61,461,l),
+(61,229,l),
+(111,229,l),
+(111,314,l),
+(261,314,l),
+(261,223,l),
+(311,223,l),
+(311,328,l),
+(288,314,l),
+(343,314,ls),
+(407,314,o),
+(442,266,o),
+(442,185,cs),
+(442,112,o),
+(411,67,o),
+(356,67,cs),
+(295,67,o),
+(220,162,o),
+(150,162,cs),
+(99,162,o),
+(61,130,o),
+(61,56,cs),
+(61,0,l),
+(142,0,l),
+(142,30,ls),
+(142,73,o),
+(156,86,o),
+(174,86,cs),
+(214,86,o),
+(293,-13,o),
+(380,-13,cs)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1664;
+unicode = 5732;
+},
+{
+color = 9;
+glyphname = "chiCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(468,-13,o),
+(529,62,o),
+(529,174,cs),
+(529,271,o),
+(484,337,o),
+(410,353,c),
+(410,337,l),
+(484,353,o),
+(529,417,o),
+(529,516,cs),
+(529,628,o),
+(468,702,o),
+(380,702,cs),
+(293,702,o),
+(214,604,o),
+(174,604,cs),
+(156,604,o),
+(142,616,o),
+(142,660,cs),
+(142,690,l),
+(61,690,l),
+(61,634,ls),
+(61,559,o),
+(99,527,o),
+(150,527,cs),
+(220,527,o),
+(295,623,o),
+(356,623,cs),
+(411,623,o),
+(442,578,o),
+(442,504,cs),
+(442,424,o),
+(405,376,o),
+(343,376,cs),
+(292,376,l),
+(337,349,l),
+(335,387,o),
+(306,417,o),
+(268,417,cs),
+(239,417,o),
+(214,400,o),
+(204,376,c),
+(111,376,l),
+(111,461,l),
+(61,461,l),
+(61,229,l),
+(111,229,l),
+(111,314,l),
+(204,314,l),
+(214,290,o),
+(239,272,o),
+(268,272,cs),
+(305,272,o),
+(334,303,o),
+(338,340,c),
+(292,314,l),
+(343,314,ls),
+(407,314,o),
+(442,266,o),
+(442,185,cs),
+(442,112,o),
+(411,67,o),
+(356,67,cs),
+(295,67,o),
+(220,162,o),
+(150,162,cs),
+(99,162,o),
+(61,130,o),
+(61,56,cs),
+(61,0,l),
+(142,0,l),
+(142,30,ls),
+(142,73,o),
+(156,86,o),
+(174,86,cs),
+(214,86,o),
+(293,-13,o),
+(380,-13,cs)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1665;
+unicode = 5733;
+},
+{
+color = 9;
+glyphname = "chaCarrier-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(294,-13,o),
+(372,86,o),
+(412,86,cs),
+(431,86,o),
+(444,73,o),
+(444,30,cs),
+(444,0,l),
+(526,0,l),
+(526,56,ls),
+(526,130,o),
+(488,162,o),
+(437,162,cs),
+(367,162,o),
+(293,69,o),
+(233,69,cs),
+(179,69,o),
+(146,113,o),
+(146,185,cs),
+(146,266,o),
+(187,308,o),
+(254,308,cs),
+(475,308,l),
+(475,229,l),
+(526,229,l),
+(526,461,l),
+(475,461,l),
+(475,382,l),
+(254,382,ls),
+(186,382,o),
+(146,424,o),
+(146,504,cs),
+(146,577,o),
+(179,621,o),
+(232,621,cs),
+(293,621,o),
+(367,527,o),
+(437,527,cs),
+(488,527,o),
+(526,559,o),
+(526,634,cs),
+(526,690,l),
+(444,690,l),
+(444,660,ls),
+(444,616,o),
+(431,604,o),
+(412,604,cs),
+(372,604,o),
+(294,702,o),
+(207,702,cs),
+(120,702,o),
+(57,628,o),
+(57,516,cs),
+(57,417,o),
+(102,353,o),
+(178,337,c),
+(178,353,l),
+(102,337,o),
+(57,271,o),
+(57,174,cs),
+(57,62,o),
+(120,-13,o),
+(207,-13,cs)
+);
+}
+);
+width = 587;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1666;
+unicode = 5734;
+},
+{
+color = 9;
+glyphname = "ttsuCarrier-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(287,-13,o),
+(336,34,o),
+(356,124,c),
+(334,124,l),
+(355,34,o),
+(404,-13,o),
+(480,-13,cs),
+(579,-13,o),
+(639,62,o),
+(639,178,cs),
+(639,303,o),
+(572,460,o),
+(572,555,cs),
+(572,584,o),
+(583,611,o),
+(626,611,cs),
+(644,611,l),
+(644,690,l),
+(605,690,ls),
+(522,690,o),
+(489,645,o),
+(489,571,cs),
+(489,538,o),
+(495,501,o),
+(499,462,c),
+(529,528,l),
+(384,407,l),
+(384,627,l),
+(442,627,l),
+(442,690,l),
+(248,690,l),
+(248,627,l),
+(307,627,l),
+(307,407,l),
+(162,528,l),
+(191,461,l),
+(197,501,o),
+(202,538,o),
+(202,571,cs),
+(202,645,o),
+(168,690,o),
+(86,690,cs),
+(46,690,l),
+(46,611,l),
+(64,611,ls),
+(107,611,o),
+(120,583,o),
+(120,555,cs),
+(120,460,o),
+(52,303,o),
+(52,178,cs),
+(52,61,o),
+(112,-13,o),
+(212,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(169,70,o),
+(140,109,o),
+(140,185,cs),
+(140,254,o),
+(167,342,o),
+(185,424,c),
+(307,322,l),
+(307,206,ls),
+(307,116,o),
+(276,70,o),
+(221,70,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(414,70,o),
+(384,115,o),
+(384,206,cs),
+(384,322,l),
+(506,424,l),
+(524,343,o),
+(551,254,o),
+(551,185,cs),
+(551,109,o),
+(522,70,o),
+(469,70,cs)
+);
+}
+);
+width = 690;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1667;
+unicode = 5735;
+},
+{
+color = 9;
+glyphname = "ttsoCarrier-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(86,0,ls),
+(168,0,o),
+(202,44,o),
+(202,119,cs),
+(202,152,o),
+(197,188,o),
+(191,229,c),
+(162,161,l),
+(307,283,l),
+(307,63,l),
+(248,63,l),
+(248,0,l),
+(442,0,l),
+(442,63,l),
+(384,63,l),
+(384,283,l),
+(529,161,l),
+(499,228,l),
+(495,188,o),
+(489,152,o),
+(489,119,cs),
+(489,44,o),
+(522,0,o),
+(605,0,cs),
+(644,0,l),
+(644,78,l),
+(626,78,ls),
+(583,78,o),
+(572,105,o),
+(572,134,cs),
+(572,230,o),
+(639,386,o),
+(639,512,cs),
+(639,628,o),
+(579,702,o),
+(480,702,cs),
+(404,702,o),
+(355,656,o),
+(334,566,c),
+(356,566,l),
+(336,656,o),
+(287,702,o),
+(212,702,cs),
+(112,702,o),
+(52,629,o),
+(52,512,cs),
+(52,386,o),
+(120,230,o),
+(120,134,cs),
+(120,106,o),
+(107,78,o),
+(64,78,cs),
+(46,78,l),
+(46,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(167,348,o),
+(140,436,o),
+(140,504,cs),
+(140,581,o),
+(169,620,o),
+(221,620,cs),
+(276,620,o),
+(307,574,o),
+(307,484,cs),
+(307,368,l),
+(185,266,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(384,368,l),
+(384,484,ls),
+(384,575,o),
+(414,620,o),
+(469,620,cs),
+(522,620,o),
+(551,581,o),
+(551,504,cs),
+(551,436,o),
+(524,347,o),
+(506,266,c)
+);
+}
+);
+width = 690;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1668;
+unicode = 5736;
+},
+{
+color = 9;
+glyphname = "ttseCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(468,-13,o),
+(529,62,o),
+(529,174,cs),
+(529,271,o),
+(484,337,o),
+(410,353,c),
+(410,337,l),
+(484,353,o),
+(529,417,o),
+(529,516,cs),
+(529,628,o),
+(468,702,o),
+(380,702,cs),
+(293,702,o),
+(214,604,o),
+(174,604,cs),
+(156,604,o),
+(142,616,o),
+(142,660,cs),
+(142,690,l),
+(61,690,l),
+(61,634,ls),
+(61,559,o),
+(99,527,o),
+(150,527,cs),
+(162,527,o),
+(175,529,o),
+(182,538,c),
+(128,569,l),
+(197,376,l),
+(111,376,l),
+(111,461,l),
+(61,461,l),
+(61,229,l),
+(111,229,l),
+(111,314,l),
+(197,314,l),
+(128,121,l),
+(182,152,l),
+(175,160,o),
+(162,162,o),
+(150,162,cs),
+(99,162,o),
+(61,130,o),
+(61,56,cs),
+(61,0,l),
+(142,0,l),
+(142,30,ls),
+(142,73,o),
+(156,86,o),
+(174,86,cs),
+(214,86,o),
+(293,-13,o),
+(380,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(307,67,o),
+(251,128,o),
+(201,148,c),
+(258,314,l),
+(343,314,ls),
+(407,314,o),
+(442,266,o),
+(442,185,cs),
+(442,112,o),
+(411,67,o),
+(356,67,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(201,542,l),
+(251,561,o),
+(307,623,o),
+(356,623,cs),
+(411,623,o),
+(442,578,o),
+(442,504,cs),
+(442,424,o),
+(405,376,o),
+(343,376,cs),
+(258,376,l)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1669;
+unicode = 5737;
+},
+{
+color = 9;
+glyphname = "ttseeCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(468,-13,o),
+(529,62,o),
+(529,174,cs),
+(529,271,o),
+(484,337,o),
+(410,353,c),
+(410,337,l),
+(484,353,o),
+(529,417,o),
+(529,516,cs),
+(529,628,o),
+(468,702,o),
+(380,702,cs),
+(293,702,o),
+(214,604,o),
+(174,604,cs),
+(156,604,o),
+(142,616,o),
+(142,660,cs),
+(142,690,l),
+(61,690,l),
+(61,634,ls),
+(61,559,o),
+(99,527,o),
+(150,527,cs),
+(159,527,o),
+(170,528,o),
+(173,535,c),
+(126,567,l),
+(193,376,l),
+(111,376,l),
+(111,461,l),
+(61,461,l),
+(61,229,l),
+(111,229,l),
+(111,314,l),
+(193,314,l),
+(126,123,l),
+(173,155,l),
+(170,161,o),
+(159,162,o),
+(150,162,cs),
+(99,162,o),
+(61,130,o),
+(61,56,cs),
+(61,0,l),
+(142,0,l),
+(142,30,ls),
+(142,73,o),
+(156,86,o),
+(174,86,cs),
+(214,86,o),
+(293,-13,o),
+(380,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(305,67,o),
+(247,131,o),
+(194,152,c),
+(250,314,l),
+(302,314,l),
+(302,218,l),
+(348,218,l),
+(348,329,l),
+(328,314,l),
+(343,314,ls),
+(407,314,o),
+(442,266,o),
+(442,185,cs),
+(442,112,o),
+(411,67,o),
+(356,67,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(348,464,l),
+(302,464,l),
+(302,376,l),
+(250,376,l),
+(194,538,l),
+(247,558,o),
+(305,623,o),
+(356,623,cs),
+(411,623,o),
+(442,578,o),
+(442,504,cs),
+(442,424,o),
+(405,376,o),
+(343,376,cs),
+(328,376,l),
+(348,360,l)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166A;
+unicode = 5738;
+},
+{
+color = 9;
+glyphname = "ttsiCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(468,-13,o),
+(529,62,o),
+(529,174,cs),
+(529,271,o),
+(484,337,o),
+(410,353,c),
+(410,337,l),
+(484,353,o),
+(529,417,o),
+(529,516,cs),
+(529,628,o),
+(468,702,o),
+(380,702,cs),
+(293,702,o),
+(214,604,o),
+(174,604,cs),
+(156,604,o),
+(142,616,o),
+(142,660,cs),
+(142,690,l),
+(61,690,l),
+(61,634,ls),
+(61,559,o),
+(99,527,o),
+(150,527,cs),
+(158,527,o),
+(167,527,o),
+(176,536,c),
+(133,546,l),
+(193,376,l),
+(111,376,l),
+(111,461,l),
+(61,461,l),
+(61,229,l),
+(111,229,l),
+(111,314,l),
+(193,314,l),
+(130,135,l),
+(175,155,l),
+(167,162,o),
+(158,162,o),
+(150,162,cs),
+(99,162,o),
+(61,130,o),
+(61,56,cs),
+(61,0,l),
+(142,0,l),
+(142,30,ls),
+(142,73,o),
+(156,86,o),
+(174,86,cs),
+(214,86,o),
+(293,-13,o),
+(380,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(305,67,o),
+(241,136,o),
+(188,155,c),
+(243,314,l),
+(258,314,l),
+(269,290,o),
+(290,272,o),
+(316,272,cs),
+(346,272,o),
+(370,296,o),
+(376,326,c),
+(326,314,l),
+(348,314,ls),
+(411,314,o),
+(442,266,o),
+(442,185,cs),
+(442,112,o),
+(411,67,o),
+(356,67,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(371,394,o),
+(346,417,o),
+(316,417,cs),
+(290,417,o),
+(268,400,o),
+(258,376,c),
+(243,376,l),
+(188,535,l),
+(241,554,o),
+(305,623,o),
+(356,623,cs),
+(411,623,o),
+(442,578,o),
+(442,504,cs),
+(442,424,o),
+(410,376,o),
+(348,376,cs),
+(327,376,l),
+(377,363,l)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166B;
+unicode = 5739;
+},
+{
+color = 9;
+glyphname = "ttsaCarrier-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(294,-13,o),
+(372,86,o),
+(412,86,cs),
+(431,86,o),
+(444,73,o),
+(444,30,cs),
+(444,0,l),
+(526,0,l),
+(526,56,ls),
+(526,130,o),
+(488,162,o),
+(437,162,cs),
+(424,162,o),
+(412,160,o),
+(405,152,c),
+(458,121,l),
+(389,314,l),
+(475,314,l),
+(475,229,l),
+(526,229,l),
+(526,461,l),
+(475,461,l),
+(475,376,l),
+(389,376,l),
+(458,569,l),
+(405,538,l),
+(412,529,o),
+(424,527,o),
+(437,527,cs),
+(488,527,o),
+(526,559,o),
+(526,634,cs),
+(526,690,l),
+(444,690,l),
+(444,660,ls),
+(444,616,o),
+(431,604,o),
+(412,604,cs),
+(372,604,o),
+(294,702,o),
+(207,702,cs),
+(120,702,o),
+(57,628,o),
+(57,516,cs),
+(57,417,o),
+(102,353,o),
+(177,337,c),
+(177,353,l),
+(102,337,o),
+(57,271,o),
+(57,174,cs),
+(57,62,o),
+(120,-13,o),
+(207,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(176,67,o),
+(144,112,o),
+(144,185,cs),
+(144,266,o),
+(180,314,o),
+(243,314,cs),
+(328,314,l),
+(385,148,l),
+(336,128,o),
+(279,67,o),
+(230,67,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(182,376,o),
+(144,424,o),
+(144,504,cs),
+(144,578,o),
+(176,623,o),
+(231,623,cs),
+(279,623,o),
+(336,561,o),
+(385,542,c),
+(328,376,l),
+(243,376,ls)
+);
+}
+);
+width = 587;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni166C;
+unicode = 5740;
+},
+{
+glyphname = "qai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (261,0);
+ref = "ke-canadian";
+}
+);
+width = 741;
+}
+);
+note = uni166F;
+unicode = 5743;
+},
+{
+glyphname = "ngai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (498,0);
+ref = "ce-canadian";
+}
+);
+width = 972;
+}
+);
+note = uni1670;
+unicode = 5744;
+},
+{
+glyphname = "nngi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (746,0);
+ref = "ci-canadian";
+}
+);
+width = 1218;
+}
+);
+note = uni1671;
+unicode = 5745;
+},
+{
+glyphname = "nngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (746,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (921,0);
+ref = dot_top;
+}
+);
+width = 1218;
+}
+);
+note = uni1672;
+unicode = 5746;
+},
+{
+glyphname = "nngo-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (746,0);
+ref = "ce-canadian";
+}
+);
+width = 1218;
+}
+);
+note = uni1673;
+unicode = 5747;
+},
+{
+glyphname = "nngoo-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (746,0);
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (911,0);
+ref = dot_top;
+}
+);
+width = 1218;
+}
+);
+note = uni1674;
+unicode = 5748;
+},
+{
+glyphname = "nnga-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (746,0);
+ref = "ca-canadian";
+}
+);
+width = 1218;
+}
+);
+note = uni1675;
+unicode = 5749;
+},
+{
+glyphname = "nngaa-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (746,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (779,0);
+ref = dot_top;
+}
+);
+width = 1218;
+}
+);
+note = uni1676;
+unicode = 5750;
+},
+{
+glyphname = "thweeWoodScree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (497,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 682;
+}
+);
+note = uni1677;
+unicode = 5751;
+},
+{
+glyphname = "thwiWoodScree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (497,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 682;
+}
+);
+note = uni1678;
+unicode = 5752;
+},
+{
+glyphname = "thwiiWoodScree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (70,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (497,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 682;
+}
+);
+note = uni1679;
+unicode = 5753;
+},
+{
+glyphname = "thwoWoodScree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (497,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 682;
+}
+);
+note = uni167A;
+unicode = 5754;
+},
+{
+glyphname = "thwooWoodScree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (293,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (497,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 682;
+}
+);
+note = uni167B;
+unicode = 5755;
+},
+{
+glyphname = "thwaWoodScree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = middle_right_can;
+pos = (497,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 682;
+}
+);
+note = uni167C;
+unicode = 5756;
+},
+{
+glyphname = "thwaaWoodScree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (69,0);
+ref = dot_top;
+},
+{
+anchor = middle_right_can;
+pos = (497,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 682;
+}
+);
+note = uni167D;
+unicode = 5757;
+},
+{
+glyphname = "wBlackfoot-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(305,558,l),
+(305,612,l),
+(49,612,l),
+(49,558,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(305,422,l),
+(305,476,l),
+(49,476,l),
+(49,422,l)
+);
+}
+);
+width = 354;
+}
+);
+metricRight = "=|";
+note = uni167F;
+unicode = 5759;
+},
+{
+glyphname = "oy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-20,0);
+ref = ring_top.canadian;
+}
+);
+width = 550;
+}
+);
+note = uni18B0;
+unicode = 6320;
+},
+{
+glyphname = "ay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (335,0);
+ref = ring_top.canadian;
+}
+);
+width = 550;
+}
+);
+note = uni18B1;
+unicode = 6321;
+},
+{
+glyphname = "aay-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (129,0);
+ref = ring_top.canadian;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (384,0);
+ref = dot_top;
+}
+);
+width = 550;
+}
+);
+note = uni18B2;
+unicode = 6322;
+},
+{
+glyphname = "way-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (521,0);
+ref = ring_top.canadian;
+}
+);
+width = 735;
+}
+);
+note = uni18B3;
+unicode = 6323;
+},
+{
+glyphname = "poy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-36,0);
+ref = ring_top.canadian;
+}
+);
+width = 526;
+}
+);
+note = uni18B4;
+unicode = 6324;
+},
+{
+glyphname = "pay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (332,0);
+ref = ring_top.canadian;
+}
+);
+width = 526;
+}
+);
+note = uni18B5;
+unicode = 6325;
+},
+{
+glyphname = "pwoy-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (149,0);
+ref = ring_top.canadian;
+}
+);
+width = 711;
+}
+);
+note = uni18B6;
+unicode = 6326;
+},
+{
+glyphname = "tay-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (154,0);
+ref = ring_top.canadian;
+}
+);
+width = 487;
+}
+);
+note = uni18B7;
+unicode = 6327;
+},
+{
+glyphname = "kay-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-14,0);
+ref = ring_top.canadian;
+}
+);
+width = 481;
+}
+);
+note = uni18B8;
+unicode = 6328;
+},
+{
+glyphname = "kway-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (171,0);
+ref = ring_top.canadian;
+}
+);
+width = 666;
+}
+);
+note = uni18B9;
+unicode = 6329;
+},
+{
+glyphname = "may-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-10,0);
+ref = ring_top.canadian;
+}
+);
+width = 431;
+}
+);
+note = uni18BA;
+unicode = 6330;
+},
+{
+glyphname = "noy-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (294,-193);
+ref = ring_top.canadian;
+}
+);
+width = 653;
+}
+);
+note = uni18BB;
+unicode = 6331;
+},
+{
+glyphname = "nay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (128,-193);
+ref = ring_top.canadian;
+}
+);
+width = 653;
+}
+);
+note = uni18BC;
+unicode = 6332;
+},
+{
+glyphname = "lay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (128,-193);
+ref = ring_top.canadian;
+}
+);
+width = 653;
+}
+);
+note = uni18BD;
+unicode = 6333;
+},
+{
+glyphname = "soy-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (218,0);
+ref = ring_top.canadian;
+}
+);
+width = 439;
+}
+);
+note = uni18BE;
+unicode = 6334;
+},
+{
+glyphname = "say-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-10,0);
+ref = ring_top.canadian;
+}
+);
+width = 439;
+}
+);
+note = uni18BF;
+unicode = 6335;
+},
+{
+glyphname = "shoy-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (259,-193);
+ref = ring_top.canadian;
+}
+);
+width = 749;
+}
+);
+note = uni18C0;
+unicode = 6336;
+},
+{
+glyphname = "shay-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (259,-193);
+ref = ring_top.canadian;
+}
+);
+width = 749;
+}
+);
+note = uni18C1;
+unicode = 6337;
+},
+{
+glyphname = "shwoy-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (443,-193);
+ref = ring_top.canadian;
+}
+);
+width = 933;
+}
+);
+note = uni18C2;
+unicode = 6338;
+},
+{
+glyphname = "yoy-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (245,0);
+ref = ring_top.canadian;
+}
+);
+width = 463;
+}
+);
+note = uni18C3;
+unicode = 6339;
+},
+{
+glyphname = "yay-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-13,0);
+ref = ring_top.canadian;
+}
+);
+width = 463;
+}
+);
+note = uni18C4;
+unicode = 6340;
+},
+{
+glyphname = "ray-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (131,0);
+ref = ring_top.canadian;
+}
+);
+width = 440;
+}
+);
+note = uni18C5;
+unicode = 6341;
+},
+{
+glyphname = "nwi-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ni-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni18C6;
+unicode = 6342;
+},
+{
+glyphname = "nwiOjibway-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni18C7;
+unicode = 6343;
+},
+{
+glyphname = "nwii-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (371,-193);
+ref = dot_top;
+}
+);
+width = 838;
+}
+);
+note = uni18C8;
+unicode = 6344;
+},
+{
+glyphname = "nwiiOjibway-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (185,-193);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni18C9;
+unicode = 6345;
+},
+{
+glyphname = "nwo-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "no-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni18CA;
+unicode = 6346;
+},
+{
+glyphname = "nwoOjibway-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni18CB;
+unicode = 6347;
+},
+{
+glyphname = "nwoo-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (526,-193);
+ref = dot_top;
+}
+);
+width = 838;
+}
+);
+note = uni18CC;
+unicode = 6348;
+},
+{
+glyphname = "nwooOjibway-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (342,-193);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni18CD;
+unicode = 6349;
+},
+{
+glyphname = "rwee-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "reRCree-canadian";
+}
+);
+width = 872;
+}
+);
+note = uni18CE;
+unicode = 6350;
+},
+{
+glyphname = "rwi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ri-canadian";
+}
+);
+width = 872;
+}
+);
+note = uni18CF;
+unicode = 6351;
+},
+{
+glyphname = "rwii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (362,-193);
+ref = dot_top;
+}
+);
+width = 872;
+}
+);
+note = uni18D0;
+unicode = 6352;
+},
+{
+glyphname = "rwo-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ro-canadian";
+}
+);
+width = 625;
+}
+);
+note = uni18D1;
+unicode = 6353;
+},
+{
+glyphname = "rwoo-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (310,0);
+ref = dot_top;
+}
+);
+width = 625;
+}
+);
+note = uni18D2;
+unicode = 6354;
+},
+{
+glyphname = "rwa-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = "ra-canadian";
+}
+);
+width = 625;
+}
+);
+note = uni18D3;
+unicode = 6355;
+},
+{
+glyphname = "pOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(87,345,l),
+(182,621,l),
+(143,621,l),
+(237,345,l),
+(294,345,l),
+(294,358,l),
+(170,690,l),
+(155,690,l),
+(30,358,l),
+(30,345,l)
+);
+}
+);
+width = 324;
+}
+);
+metricLeft = "kkCarrier-canadian";
+note = uni18D4;
+unicode = 6356;
+},
+{
+glyphname = "tOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 340;
+}
+);
+metricRight = "=|";
+note = uni1422;
+unicode = 6357;
+},
+{
+glyphname = "kOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(111,344,l),
+(111,505,l),
+(96,504,l),
+(100,461,o),
+(128,433,o),
+(167,433,cs),
+(218,433,o),
+(259,477,o),
+(259,560,cs),
+(259,652,o),
+(213,695,o),
+(155,695,cs),
+(90,695,o),
+(49,647,o),
+(49,564,cs),
+(49,344,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(127,480,o),
+(106,505,o),
+(106,564,cs),
+(106,625,o),
+(125,648,o),
+(155,648,cs),
+(184,648,o),
+(203,623,o),
+(203,563,cs),
+(203,504,o),
+(183,480,o),
+(155,480,cs)
+);
+}
+);
+width = 298;
+}
+);
+metricLeft = "k-canadian";
+metricRight = "k-canadian";
+note = uni18D6;
+unicode = 6358;
+},
+{
+glyphname = "cOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(111,345,l),
+(111,578,ls),
+(111,624,o),
+(126,645,o),
+(156,645,cs),
+(185,645,o),
+(203,623,o),
+(203,582,cs),
+(203,548,l),
+(260,548,l),
+(260,573,ls),
+(260,652,o),
+(218,696,o),
+(156,696,cs),
+(88,696,o),
+(49,652,o),
+(49,569,cs),
+(49,345,l)
+);
+}
+);
+width = 289;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni18D7;
+unicode = 6359;
+},
+{
+glyphname = "mOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(111,345,l),
+(111,631,l),
+(236,631,l),
+(236,690,l),
+(49,690,l),
+(49,345,l)
+);
+}
+);
+width = 266;
+}
+);
+metricLeft = "m-canadian";
+metricRight = "m-canadian";
+note = uni18D8;
+unicode = 6360;
+},
+{
+glyphname = "nOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(207,428,o),
+(245,474,o),
+(245,555,cs),
+(245,603,o),
+(231,644,o),
+(206,658,c),
+(203,631,l),
+(343,631,l),
+(343,690,l),
+(147,690,ls),
+(78,690,o),
+(39,640,o),
+(39,558,cs),
+(39,475,o),
+(78,428,o),
+(142,428,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(112,475,o),
+(94,500,o),
+(94,558,cs),
+(94,616,o),
+(112,642,o),
+(142,642,cs),
+(172,642,o),
+(189,616,o),
+(189,558,cs),
+(189,501,o),
+(173,475,o),
+(143,475,cs)
+);
+}
+);
+width = 373;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "n-canadian";
+note = uni18D9;
+unicode = 6361;
+},
+{
+glyphname = "sOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(111,345,l),
+(111,486,l),
+(72,460,l),
+(101,460,ls),
+(185,460,o),
+(236,513,o),
+(236,613,cs),
+(236,690,l),
+(174,690,l),
+(174,616,ls),
+(174,543,o),
+(145,510,o),
+(80,510,cs),
+(49,510,l),
+(49,345,l)
+);
+}
+);
+width = 285;
+}
+);
+metricLeft = "s-canadian";
+metricRight = "s-canadian";
+note = uni18DA;
+unicode = 6362;
+},
+{
+color = 1;
+glyphname = "shOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(198,339,o),
+(232,381,o),
+(238,462,cs),
+(245,579,ls),
+(249,623,o),
+(261,645,o),
+(290,645,cs),
+(319,645,o),
+(336,624,o),
+(336,581,cs),
+(336,548,l),
+(393,548,l),
+(393,577,ls),
+(393,655,o),
+(355,696,o),
+(292,696,cs),
+(224,696,o),
+(190,654,o),
+(185,573,cs),
+(177,456,ls),
+(173,412,o),
+(160,389,o),
+(131,389,cs),
+(102,389,o),
+(86,411,o),
+(86,454,cs),
+(86,487,l),
+(29,487,l),
+(29,458,ls),
+(29,380,o),
+(68,339,o),
+(130,339,cs)
+);
+}
+);
+width = 422;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "c-canadian";
+note = uni18DB;
+unicode = 6363;
+},
+{
+color = 9;
+glyphname = "easternw-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (25,-307);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (119,0);
+ref = "glottalstop-canadian";
+}
+);
+width = 469;
+}
+);
+note = uni18DC;
+unicode = 6364;
+},
+{
+color = 9;
+glyphname = "westernw-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (447,-307);
+ref = dot_top;
+scale = (-1,1);
+},
+{
+alignment = -1;
+pos = (352,0);
+ref = "glottalstop-canadian";
+scale = (-1,1);
+}
+);
+width = 474;
+}
+);
+metricLeft = "glottalstop-canadian";
+note = uni18DD;
+unicode = 6365;
+},
+{
+glyphname = "rweRCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "reRCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (687,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 872;
+}
+);
+note = uni18E0;
+unicode = 6368;
+},
+{
+glyphname = "looWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (38,0);
+ref = dot_top;
+}
+);
+width = 440;
+}
+);
+note = uni18E1;
+unicode = 6369;
+},
+{
+glyphname = "laaWestCree-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (269,0);
+ref = dot_top;
+}
+);
+width = 440;
+}
+);
+note = uni18E2;
+unicode = 6370;
+},
+{
+glyphname = "thwe-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "the-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (589,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 774;
+}
+);
+note = uni18E3;
+unicode = 6371;
+},
+{
+glyphname = "thwa-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (541,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 726;
+}
+);
+note = uni18E4;
+unicode = 6372;
+},
+{
+glyphname = "tthwe-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "tthe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (582,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 767;
+}
+);
+note = uni18E5;
+unicode = 6373;
+},
+{
+glyphname = "tthoo-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ttho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (189,0);
+ref = dot_top;
+}
+);
+width = 504;
+}
+);
+note = uni18E6;
+unicode = 6374;
+},
+{
+glyphname = "tthaa-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ttha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (187,0);
+ref = dot_top;
+}
+);
+width = 504;
+}
+);
+note = uni18E7;
+unicode = 6375;
+},
+{
+glyphname = "tlhwe-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "tlhe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (488,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 672;
+}
+);
+note = uni18E8;
+unicode = 6376;
+},
+{
+glyphname = "tlhoo-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "tlho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (186,0);
+ref = dot_top;
+}
+);
+width = 488;
+}
+);
+note = uni18E9;
+unicode = 6377;
+},
+{
+glyphname = "shweSayisi-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "sheSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (488,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 672;
+}
+);
+note = uni18EA;
+unicode = 6378;
+},
+{
+glyphname = "shooSayisi-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "shoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (319,0);
+ref = dot_top;
+}
+);
+width = 488;
+}
+);
+note = uni18EB;
+unicode = 6379;
+},
+{
+color = 9;
+glyphname = "hooSayisi-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "hoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (374,0);
+ref = dot_top;
+}
+);
+width = 545;
+}
+);
+note = uni18EC;
+unicode = 6380;
+},
+{
+color = 9;
+glyphname = "gwuCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "guCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (685,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 870;
+}
+);
+note = uni18ED;
+unicode = 6381;
+},
+{
+color = 9;
+glyphname = "deneGeeCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "geCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (222,0);
+ref = dot_top;
+}
+);
+width = 576;
+}
+);
+note = uni18EE;
+unicode = 6382;
+},
+{
+color = 9;
+glyphname = "gaaCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (234,0);
+ref = dot_top;
+}
+);
+width = 576;
+}
+);
+note = uni18EF;
+unicode = 6383;
+},
+{
+color = 9;
+glyphname = "gwaCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (576,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 761;
+}
+);
+note = uni18F0;
+unicode = 6384;
+},
+{
+color = 9;
+glyphname = "juuSayisi-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "juSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (223,0);
+ref = dot_top;
+}
+);
+width = 574;
+}
+);
+note = uni18F1;
+unicode = 6385;
+},
+{
+color = 9;
+glyphname = "jwaCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "jaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (624,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni18F2;
+unicode = 6386;
+},
+{
+glyphname = "lBeaverDene-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+ref = "pWestCree-canadian";
+}
+);
+width = 160;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+unicode = 6387;
+},
+{
+glyphname = "rBeaverDene-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(111,345,l),
+(111,548,ls),
+(111,602,o),
+(129,632,o),
+(166,632,cs),
+(176,632,l),
+(176,696,l),
+(167,696,ls),
+(128,696,o),
+(101,658,o),
+(100,612,c),
+(105,612,l),
+(105,690,l),
+(49,690,l),
+(49,345,l)
+);
+}
+);
+width = 203;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni18F4;
+unicode = 6388;
+},
+{
+color = 6;
+glyphname = "sDentalCarrier-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(172,184,ls),
+(242,184,o),
+(279,219,o),
+(279,282,cs),
+(279,343,o),
+(245,381,o),
+(182,381,cs),
+(158,381,ls),
+(127,381,o),
+(107,393,o),
+(107,428,cs),
+(107,464,o),
+(127,476,o),
+(158,476,cs),
+(274,476,l),
+(274,527,l),
+(156,527,ls),
+(85,527,o),
+(49,491,o),
+(49,428,cs),
+(49,368,o),
+(83,330,o),
+(146,330,cs),
+(171,330,ls),
+(202,330,o),
+(221,317,o),
+(221,282,cs),
+(221,247,o),
+(202,234,o),
+(171,234,cs),
+(54,234,l),
+(54,184,l)
+);
+}
+);
+width = 328;
+}
+);
+metricLeft = "shCarrier-canadian";
+metricRight = "=|";
+note = uni18F5;
+unicode = 6389;
+},
+{
+glyphname = "pWestCree-canadian.base";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "pWestCree-canadian";
+}
+);
+width = 160;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.base";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "c-canadian";
+}
+);
+width = 289;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "thSayisi-canadian.base";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "thSayisi-canadian";
+}
+);
+width = 290;
+}
+);
+metricLeft = "=|c-canadian";
+note = uni14A2;
+},
+{
+glyphname = "mWestCree-canadian.base";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "mWestCree-canadian";
+}
+);
+width = 293;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+glyphname = "pWestCree-canadian.mid";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "pWestCree-canadian";
+}
+);
+width = 160;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.mid";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "c-canadian";
+}
+);
+width = 289;
+}
+);
+metricLeft = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "mWestCree-canadian.mid";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "mWestCree-canadian";
+}
+);
+width = 293;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+color = 11;
+glyphname = "ngaai-canadian.nunavik";
+lastChange = "2023-01-13 15:55:27 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (517,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (645,0);
+ref = ring_top.canadian;
+}
+);
+width = 992;
+}
+);
+note = uni158E;
+},
+{
+color = 11;
+glyphname = "ngi-canadian.nunavik";
+lastChange = "2023-01-13 15:55:27 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (517,0);
+ref = "ci-canadian";
+}
+);
+width = 992;
+}
+);
+note = uni158F;
+},
+{
+color = 11;
+glyphname = "ngii-canadian.nunavik";
+lastChange = "2023-01-13 15:55:27 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (517,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (692,0);
+ref = dot_top;
+}
+);
+width = 992;
+}
+);
+note = uni1590;
+},
+{
+color = 11;
+glyphname = "ngo-canadian.nunavik";
+lastChange = "2023-01-13 15:55:27 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (517,0);
+ref = "co-canadian";
+}
+);
+width = 991;
+}
+);
+note = uni1591;
+},
+{
+color = 11;
+glyphname = "ngoo-canadian.nunavik";
+lastChange = "2023-01-13 15:55:27 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+ref = "ngo-canadian.nunavik";
+},
+{
+anchor = top_right_can;
+pos = (823,0);
+ref = dot_top;
+}
+);
+width = 991;
+}
+);
+note = uni1592;
+},
+{
+color = 11;
+glyphname = "nga-canadian.nunavik";
+lastChange = "2023-01-13 15:55:27 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (517,0);
+ref = "ca-canadian";
+}
+);
+width = 992;
+}
+);
+note = uni1593;
+},
+{
+color = 11;
+glyphname = "ngaa-canadian.nunavik";
+lastChange = "2023-01-13 15:55:27 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (517,0);
+ref = "ca-canadian";
+},
+{
+anchor = top_left_can;
+pos = (551,0);
+ref = dot_top;
+}
+);
+width = 992;
+}
+);
+note = uni1594;
+},
+{
+color = 11;
+glyphname = "ng-canadian.nunavik";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(432,157,o),
+(478,201,o),
+(478,293,cs),
+(478,375,o),
+(438,419,o),
+(386,419,cs),
+(349,419,o),
+(320,392,o),
+(315,349,c),
+(330,349,l),
+(330,493,l),
+(203,493,l),
+(206,467,l),
+(232,480,o),
+(245,522,o),
+(245,568,cs),
+(245,649,o),
+(207,696,o),
+(142,696,cs),
+(78,696,o),
+(39,648,o),
+(39,565,cs),
+(39,483,o),
+(78,434,o),
+(147,434,cs),
+(308,434,l),
+(269,473,l),
+(269,288,ls),
+(269,206,o),
+(308,157,o),
+(374,157,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(344,205,o),
+(326,227,o),
+(326,289,cs),
+(326,348,o),
+(346,372,o),
+(374,372,cs),
+(402,372,o),
+(422,349,o),
+(422,289,cs),
+(422,229,o),
+(403,205,o),
+(374,205,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(112,481,o),
+(94,507,o),
+(94,565,cs),
+(94,623,o),
+(112,648,o),
+(143,648,cs),
+(173,648,o),
+(189,622,o),
+(189,565,cs),
+(189,507,o),
+(172,481,o),
+(142,481,cs)
+);
+}
+);
+width = 517;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+color = 11;
+glyphname = "ngai-canadian.nunavik";
+lastChange = "2023-01-13 15:55:27 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (517,0);
+ref = "ce-canadian";
+}
+);
+width = 991;
+}
+);
+note = uni1670;
+},
+{
+color = 11;
+glyphname = "ke-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (276,690);
+},
+{
+name = top_left_can;
+pos = (96,690);
+},
+{
+name = top_right_can;
+pos = (458,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(502,0,l),
+(502,690,l),
+(339,690,ls),
+(149,690,o),
+(49,587,o),
+(49,412,cs),
+(49,235,o),
+(149,134,o),
+(339,134,cs),
+(412,134,l),
+(412,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(201,214,o),
+(139,283,o),
+(139,412,cs),
+(139,540,o),
+(201,610,o),
+(333,610,cs),
+(412,610,l),
+(412,214,l),
+(333,214,ls)
+);
+}
+);
+width = 562;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146B;
+},
+{
+color = 11;
+glyphname = "ki-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (287,690);
+},
+{
+name = top_left_can;
+pos = (105,690);
+},
+{
+name = top_right_can;
+pos = (469,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(150,0,l),
+(150,134,l),
+(223,134,ls),
+(412,134,o),
+(513,235,o),
+(513,412,cs),
+(513,587,o),
+(412,690,o),
+(223,690,cs),
+(60,690,l),
+(60,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(150,610,l),
+(228,610,ls),
+(360,610,o),
+(422,540,o),
+(422,412,cs),
+(422,283,o),
+(360,214,o),
+(228,214,cs),
+(150,214,l)
+);
+}
+);
+width = 562;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni146D;
+},
+{
+color = 11;
+glyphname = "kii-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (219,0);
+ref = dot_top;
+}
+);
+width = 562;
+}
+);
+note = uni146E;
+},
+{
+color = 11;
+glyphname = "ko-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (276,690);
+},
+{
+name = top_left_can;
+pos = (96,690);
+},
+{
+name = top_right_can;
+pos = (458,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(502,0,l),
+(502,690,l),
+(412,690,l),
+(412,555,l),
+(339,555,ls),
+(149,555,o),
+(49,455,o),
+(49,278,cs),
+(49,102,o),
+(149,0,o),
+(339,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(201,80,o),
+(139,150,o),
+(139,278,cs),
+(139,407,o),
+(201,475,o),
+(333,475,cs),
+(412,475,l),
+(412,80,l),
+(333,80,ls)
+);
+}
+);
+width = 562;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146F;
+},
+{
+color = 11;
+glyphname = "koo-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (390,0);
+ref = dot_top;
+}
+);
+width = 562;
+}
+);
+note = uni1470;
+},
+{
+color = 11;
+glyphname = "ka-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (287,690);
+},
+{
+name = top_left_can;
+pos = (105,690);
+},
+{
+name = top_right_can;
+pos = (469,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(223,0,ls),
+(412,0,o),
+(513,102,o),
+(513,278,cs),
+(513,455,o),
+(412,555,o),
+(223,555,cs),
+(150,555,l),
+(150,690,l),
+(60,690,l),
+(60,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(150,475,l),
+(228,475,ls),
+(360,475,o),
+(422,407,o),
+(422,278,cs),
+(422,150,o),
+(360,80,o),
+(228,80,cs),
+(150,80,l)
+);
+}
+);
+width = 562;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1472;
+},
+{
+color = 11;
+glyphname = "kaa-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (38,0);
+ref = dot_top;
+}
+);
+width = 562;
+}
+);
+note = uni1473;
+},
+{
+color = 11;
+glyphname = "kweWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (562,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 747;
+}
+);
+note = uni1475;
+},
+{
+color = 11;
+glyphname = "kwiiWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (219,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (562,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 747;
+}
+);
+note = uni1479;
+},
+{
+color = 11;
+glyphname = "kwoWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (562,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 747;
+}
+);
+note = uni147B;
+},
+{
+color = 11;
+glyphname = "kwooWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (390,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (562,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 747;
+}
+);
+note = uni147D;
+},
+{
+color = 11;
+glyphname = "kwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (562,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 747;
+}
+);
+note = uni147F;
+},
+{
+color = 11;
+glyphname = "kwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (38,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (562,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 747;
+}
+);
+note = uni1481;
+},
+{
+color = 11;
+glyphname = "ce-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (281,690);
+},
+{
+name = top_left_can;
+pos = (93,690);
+},
+{
+name = top_right_can;
+pos = (471,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(516,0,l),
+(516,440,ls),
+(516,611,o),
+(427,702,o),
+(281,702,cs),
+(132,702,o),
+(47,612,o),
+(47,440,cs),
+(47,388,l),
+(137,388,l),
+(137,446,ls),
+(137,564,o),
+(188,619,o),
+(281,619,cs),
+(373,619,o),
+(425,561,o),
+(425,443,cs),
+(425,0,l)
+);
+}
+);
+width = 572;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni1489;
+},
+{
+color = 11;
+glyphname = "ci-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (291,690);
+},
+{
+name = top_left_can;
+pos = (102,690);
+},
+{
+name = top_right_can;
+pos = (480,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(147,0,l),
+(147,443,ls),
+(147,561,o),
+(200,619,o),
+(291,619,cs),
+(384,619,o),
+(436,564,o),
+(436,446,cs),
+(436,388,l),
+(525,388,l),
+(525,440,ls),
+(525,612,o),
+(440,702,o),
+(292,702,cs),
+(145,702,o),
+(56,611,o),
+(56,440,cs),
+(56,0,l)
+);
+}
+);
+width = 572;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+},
+{
+color = 11;
+glyphname = "cii-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (223,0);
+ref = dot_top;
+}
+);
+width = 572;
+}
+);
+note = uni148C;
+},
+{
+color = 11;
+glyphname = "co-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (281,690);
+},
+{
+name = top_left_can;
+pos = (93,690);
+},
+{
+name = top_right_can;
+pos = (471,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(427,-13,o),
+(516,78,o),
+(516,250,cs),
+(516,690,l),
+(425,690,l),
+(425,246,ls),
+(425,128,o),
+(373,71,o),
+(281,71,cs),
+(188,71,o),
+(137,126,o),
+(137,243,cs),
+(137,301,l),
+(47,301,l),
+(47,250,ls),
+(47,77,o),
+(132,-13,o),
+(281,-13,cs)
+);
+}
+);
+width = 572;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+},
+{
+color = 11;
+glyphname = "coo-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (404,0);
+ref = dot_top;
+}
+);
+width = 572;
+}
+);
+note = uni148E;
+},
+{
+color = 11;
+glyphname = "ca-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (291,690);
+},
+{
+name = top_left_can;
+pos = (102,690);
+},
+{
+name = top_right_can;
+pos = (480,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,-13,o),
+(525,77,o),
+(525,250,cs),
+(525,301,l),
+(436,301,l),
+(436,243,ls),
+(436,126,o),
+(384,71,o),
+(291,71,cs),
+(200,71,o),
+(147,128,o),
+(147,246,cs),
+(147,690,l),
+(56,690,l),
+(56,250,ls),
+(56,78,o),
+(145,-13,o),
+(292,-13,cs)
+);
+}
+);
+width = 572;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+},
+{
+color = 11;
+glyphname = "caa-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (35,0);
+ref = dot_top;
+}
+);
+width = 572;
+}
+);
+note = uni1491;
+},
+{
+color = 11;
+glyphname = "me-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (235,690);
+},
+{
+name = top_double;
+pos = (387,690);
+},
+{
+name = top_left_can;
+pos = (77,690);
+},
+{
+name = top_right_can;
+pos = (387,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(432,0,l),
+(432,690,l),
+(33,690,l),
+(33,607,l),
+(342,607,l),
+(342,0,l)
+);
+}
+);
+width = 492;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+},
+{
+color = 11;
+glyphname = "mi-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (260,690);
+},
+{
+name = top_left_can;
+pos = (105,690);
+},
+{
+name = top_right_can;
+pos = (413,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(150,0,l),
+(150,607,l),
+(459,607,l),
+(459,690,l),
+(60,690,l),
+(60,0,l)
+);
+}
+);
+width = 492;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+},
+{
+color = 11;
+glyphname = "mii-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (192,0);
+ref = dot_top;
+}
+);
+width = 492;
+}
+);
+note = uni14A6;
+},
+{
+color = 11;
+glyphname = "mo-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (235,690);
+},
+{
+name = top_double;
+pos = (387,690);
+},
+{
+name = top_left_can;
+pos = (77,690);
+},
+{
+name = top_right_can;
+pos = (387,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(432,0,l),
+(432,690,l),
+(342,690,l),
+(342,83,l),
+(33,83,l),
+(33,0,l)
+);
+}
+);
+width = 492;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+},
+{
+color = 11;
+glyphname = "moo-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (320,0);
+ref = dot_top;
+}
+);
+width = 492;
+}
+);
+note = uni14A8;
+},
+{
+color = 11;
+glyphname = "ma-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (260,690);
+},
+{
+name = top_left_can;
+pos = (105,690);
+},
+{
+name = top_right_can;
+pos = (413,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(459,0,l),
+(459,83,l),
+(150,83,l),
+(150,690,l),
+(60,690,l),
+(60,0,l)
+);
+}
+);
+width = 492;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+},
+{
+color = 11;
+glyphname = "maa-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (38,0);
+ref = dot_top;
+}
+);
+width = 492;
+}
+);
+note = uni14AB;
+},
+{
+color = 11;
+glyphname = "ne-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (363,690);
+},
+{
+name = top_left_can;
+pos = (206,690);
+},
+{
+name = top_right_can;
+pos = (522,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(494,-13,o),
+(566,67,o),
+(566,216,cs),
+(566,690,l),
+(46,690,l),
+(46,608,l),
+(160,608,l),
+(160,219,ls),
+(160,67,o),
+(233,-13,o),
+(363,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(287,71,o),
+(250,117,o),
+(250,213,cs),
+(250,608,l),
+(476,608,l),
+(476,213,ls),
+(476,118,o),
+(440,71,o),
+(363,71,cs)
+);
+}
+);
+width = 622;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C0;
+},
+{
+color = 11;
+glyphname = "ni-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (259,690);
+},
+{
+name = top_left_can;
+pos = (101,690);
+},
+{
+name = top_right_can;
+pos = (417,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(389,-13,o),
+(462,67,o),
+(462,219,cs),
+(462,608,l),
+(576,608,l),
+(576,690,l),
+(56,690,l),
+(56,216,ls),
+(56,67,o),
+(128,-13,o),
+(259,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(183,71,o),
+(146,118,o),
+(146,213,cs),
+(146,608,l),
+(372,608,l),
+(372,213,ls),
+(372,117,o),
+(335,71,o),
+(259,71,cs)
+);
+}
+);
+width = 622;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+},
+{
+color = 11;
+glyphname = "nii-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (191,0);
+ref = dot_top;
+}
+);
+width = 622;
+}
+);
+note = uni14C3;
+},
+{
+color = 11;
+glyphname = "no-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (363,690);
+},
+{
+name = top_double;
+pos = (373,690);
+},
+{
+name = top_left_can;
+pos = (206,690);
+},
+{
+name = top_right_can;
+pos = (507,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(566,0,l),
+(566,473,ls),
+(566,623,o),
+(494,702,o),
+(363,702,cs),
+(233,702,o),
+(160,623,o),
+(160,470,cs),
+(160,82,l),
+(46,82,l),
+(46,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(250,477,ls),
+(250,573,o),
+(287,618,o),
+(363,618,cs),
+(440,618,o),
+(476,572,o),
+(476,477,cs),
+(476,82,l),
+(250,82,l)
+);
+}
+);
+width = 622;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C4;
+},
+{
+color = 11;
+glyphname = "noo-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (296,0);
+ref = dot_top;
+}
+);
+width = 622;
+}
+);
+note = uni14C5;
+},
+{
+color = 11;
+glyphname = "na-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (259,690);
+},
+{
+name = top_double;
+pos = (269,690);
+},
+{
+name = top_left_can;
+pos = (101,690);
+},
+{
+name = top_right_can;
+pos = (417,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(576,0,l),
+(576,82,l),
+(462,82,l),
+(462,470,ls),
+(462,623,o),
+(389,702,o),
+(259,702,cs),
+(128,702,o),
+(56,623,o),
+(56,473,cs),
+(56,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(146,477,ls),
+(146,572,o),
+(183,618,o),
+(259,618,cs),
+(335,618,o),
+(372,573,o),
+(372,477,cs),
+(372,82,l),
+(146,82,l)
+);
+}
+);
+width = 622;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+},
+{
+color = 11;
+glyphname = "naa-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (191,0);
+ref = dot_top;
+}
+);
+width = 622;
+}
+);
+note = uni14C8;
+},
+{
+color = 11;
+glyphname = "nweWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (622,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 808;
+}
+);
+note = uni14CA;
+},
+{
+color = 11;
+glyphname = "nwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (622,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 808;
+}
+);
+note = uni14CC;
+},
+{
+color = 11;
+glyphname = "nwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (191,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (622,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 808;
+}
+);
+note = uni14CE;
+},
+{
+color = 11;
+glyphname = "se-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (104,690);
+},
+{
+name = top_right_can;
+pos = (471,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(511,0,l),
+(511,253,l),
+(367,253,ls),
+(222,253,o),
+(149,330,o),
+(149,479,cs),
+(149,690,l),
+(58,690,l),
+(58,478,ls),
+(58,282,o),
+(170,173,o),
+(368,173,cs),
+(449,173,l),
+(421,197,l),
+(421,0,l)
+);
+}
+);
+width = 571;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14ED;
+},
+{
+color = 11;
+glyphname = "si-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (105,690);
+},
+{
+name = top_right_can;
+pos = (473,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(151,0,l),
+(151,197,l),
+(123,173,l),
+(203,173,ls),
+(402,173,o),
+(513,282,o),
+(513,469,cs),
+(513,690,l),
+(423,690,l),
+(423,469,ls),
+(423,330,o),
+(350,253,o),
+(209,253,cs),
+(60,253,l),
+(60,0,l)
+);
+}
+);
+width = 571;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+},
+{
+color = 11;
+glyphname = "sii-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (406,0);
+ref = dot_top;
+}
+);
+width = 571;
+}
+);
+note = uni14F0;
+},
+{
+color = 11;
+glyphname = "so-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (467,690);
+},
+{
+name = top_left_can;
+pos = (104,690);
+},
+{
+name = top_right_can;
+pos = (467,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(149,0,l),
+(149,211,ls),
+(149,359,o),
+(222,437,o),
+(367,437,cs),
+(511,437,l),
+(511,690,l),
+(421,690,l),
+(421,493,l),
+(449,517,l),
+(368,517,ls),
+(170,517,o),
+(58,408,o),
+(58,212,cs),
+(58,0,l)
+);
+}
+);
+width = 571;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+},
+{
+color = 11;
+glyphname = "soo-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (399,0);
+ref = dot_top;
+}
+);
+width = 571;
+}
+);
+note = uni14F2;
+},
+{
+color = 11;
+glyphname = "sa-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (107,690);
+},
+{
+name = top_right_can;
+pos = (469,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(513,0,l),
+(513,212,ls),
+(513,408,o),
+(402,517,o),
+(203,517,cs),
+(123,517,l),
+(151,493,l),
+(151,690,l),
+(60,690,l),
+(60,437,l),
+(205,437,ls),
+(350,437,o),
+(423,359,o),
+(423,211,cs),
+(423,0,l)
+);
+}
+);
+width = 571;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+},
+{
+color = 11;
+glyphname = "saa-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (40,0);
+ref = dot_top;
+}
+);
+width = 571;
+}
+);
+note = uni14F5;
+},
+{
+color = 11;
+glyphname = "sho-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (282,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(501,0,l),
+(501,75,l),
+(256,75,ls),
+(177,75,o),
+(142,116,o),
+(142,191,cs),
+(142,268,o),
+(176,308,o),
+(256,308,cs),
+(326,308,ls),
+(448,308,o),
+(511,379,o),
+(511,499,cs),
+(511,619,o),
+(448,690,o),
+(326,690,cs),
+(62,690,l),
+(62,614,l),
+(308,614,ls),
+(386,614,o),
+(421,574,o),
+(421,499,cs),
+(421,423,o),
+(387,383,o),
+(308,383,cs),
+(238,383,ls),
+(115,383,o),
+(52,311,o),
+(52,191,cs),
+(52,71,o),
+(115,0,o),
+(238,0,cs)
+);
+}
+);
+width = 563;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+color = 11;
+glyphname = "shoo-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (214,0);
+ref = dot_top;
+}
+);
+width = 563;
+}
+);
+note = g728;
+},
+{
+color = 11;
+glyphname = "sha-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (282,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(326,0,ls),
+(447,0,o),
+(511,71,o),
+(511,190,cs),
+(511,311,o),
+(447,383,o),
+(326,383,cs),
+(255,383,ls),
+(176,383,o),
+(141,423,o),
+(141,498,cs),
+(141,574,o),
+(176,614,o),
+(255,614,cs),
+(501,614,l),
+(501,690,l),
+(237,690,ls),
+(115,690,o),
+(52,619,o),
+(52,498,cs),
+(52,379,o),
+(115,307,o),
+(237,307,cs),
+(307,307,ls),
+(386,307,o),
+(420,268,o),
+(420,190,cs),
+(420,115,o),
+(386,75,o),
+(307,75,cs),
+(62,75,l),
+(62,0,l)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+color = 11;
+glyphname = "shaa-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (214,0);
+ref = dot_top;
+}
+);
+width = 562;
+}
+);
+note = g730;
+},
+{
+color = 11;
+glyphname = "ye-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (83,690);
+},
+{
+name = top_right_can;
+pos = (483,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(527,0,l),
+(527,252,l),
+(164,252,l),
+(164,213,l),
+(546,645,l),
+(481,701,l),
+(36,202,l),
+(36,173,l),
+(438,173,l),
+(438,0,l)
+);
+}
+);
+width = 585;
+}
+);
+metricLeft = "ye-canadian";
+note = uni1526;
+},
+{
+color = 11;
+glyphname = "yi-canadian.square";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (101,690);
+},
+{
+name = top_right_can;
+pos = (501,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(147,0,l),
+(147,173,l),
+(549,173,l),
+(549,202,l),
+(103,701,l),
+(39,645,l),
+(420,213,l),
+(420,252,l),
+(56,252,l),
+(56,0,l)
+);
+}
+);
+width = 585;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni1528;
+},
+{
+color = 11;
+glyphname = "yii-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (35,0);
+ref = dot_top;
+}
+);
+width = 585;
+}
+);
+note = uni1529;
+},
+{
+color = 11;
+glyphname = "yo-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (483,690);
+},
+{
+name = top_left_can;
+pos = (83,690);
+},
+{
+name = top_right_can;
+pos = (483,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(546,44,l),
+(164,476,l),
+(164,438,l),
+(527,438,l),
+(527,690,l),
+(438,690,l),
+(438,517,l),
+(36,517,l),
+(36,488,l),
+(481,-12,l)
+);
+}
+);
+width = 585;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152A;
+},
+{
+color = 11;
+glyphname = "yoo-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (415,0);
+ref = dot_top;
+}
+);
+width = 585;
+}
+);
+note = uni152B;
+},
+{
+color = 11;
+glyphname = "ya-canadian.square";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (101,690);
+},
+{
+name = top_right_can;
+pos = (501,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(549,488,l),
+(549,517,l),
+(147,517,l),
+(147,690,l),
+(56,690,l),
+(56,438,l),
+(420,438,l),
+(420,476,l),
+(39,44,l),
+(103,-12,l)
+);
+}
+);
+width = 585;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152D;
+},
+{
+color = 11;
+glyphname = "yaa-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (35,0);
+ref = dot_top;
+}
+);
+width = 585;
+}
+);
+note = uni152E;
+},
+{
+color = 11;
+glyphname = "re-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (259,690);
+},
+{
+name = top_left_can;
+pos = (101,690);
+},
+{
+name = top_right_can;
+pos = (417,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(390,-13,o),
+(462,67,o),
+(462,219,cs),
+(462,608,l),
+(576,608,l),
+(576,690,l),
+(372,690,l),
+(372,213,ls),
+(372,117,o),
+(335,71,o),
+(259,71,cs),
+(183,71,o),
+(146,118,o),
+(146,213,cs),
+(146,690,l),
+(56,690,l),
+(56,216,ls),
+(56,67,o),
+(128,-13,o),
+(259,-13,cs)
+);
+}
+);
+width = 622;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1542;
+},
+{
+color = 11;
+glyphname = "reRCree-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (363,690);
+},
+{
+name = top_left_can;
+pos = (206,690);
+},
+{
+name = top_right_can;
+pos = (522,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(494,-13,o),
+(566,67,o),
+(566,216,cs),
+(566,690,l),
+(476,690,l),
+(476,213,ls),
+(476,118,o),
+(440,71,o),
+(363,71,cs),
+(287,71,o),
+(250,117,o),
+(250,213,cs),
+(250,690,l),
+(46,690,l),
+(46,608,l),
+(160,608,l),
+(160,219,ls),
+(160,67,o),
+(232,-13,o),
+(363,-13,cs)
+);
+}
+);
+width = 622;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni1543;
+},
+{
+color = 11;
+glyphname = "leWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (363,690);
+},
+{
+name = top_left_can;
+pos = (206,690);
+},
+{
+name = top_right_can;
+pos = (522,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(250,0,l),
+(250,477,ls),
+(250,572,o),
+(287,618,o),
+(363,618,cs),
+(440,618,o),
+(476,572,o),
+(476,477,cs),
+(476,0,l),
+(566,0,l),
+(566,472,ls),
+(566,623,o),
+(494,702,o),
+(363,702,cs),
+(232,702,o),
+(160,623,o),
+(160,470,cs),
+(160,81,l),
+(46,81,l),
+(46,0,l)
+);
+}
+);
+width = 624;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+},
+{
+color = 11;
+glyphname = "ri-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (259,690);
+},
+{
+name = top_left_can;
+pos = (103,690);
+},
+{
+name = top_right_can;
+pos = (417,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(146,0,l),
+(146,477,ls),
+(146,572,o),
+(183,618,o),
+(259,618,cs),
+(335,618,o),
+(372,573,o),
+(372,477,cs),
+(372,0,l),
+(576,0,l),
+(576,82,l),
+(462,82,l),
+(462,470,ls),
+(462,623,o),
+(390,702,o),
+(259,702,cs),
+(128,702,o),
+(56,623,o),
+(56,473,cs),
+(56,0,l)
+);
+}
+);
+width = 622;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+},
+{
+color = 11;
+glyphname = "rii-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (191,0);
+ref = dot_top;
+}
+);
+width = 622;
+}
+);
+note = uni1547;
+},
+{
+color = 11;
+glyphname = "ro-canadian.square";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (281,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(150,0,l),
+(150,160,l),
+(115,134,l),
+(209,134,ls),
+(398,134,o),
+(498,235,o),
+(498,412,cs),
+(498,587,o),
+(398,690,o),
+(209,690,cs),
+(60,690,l),
+(60,610,l),
+(213,610,ls),
+(346,610,o),
+(408,540,o),
+(408,412,cs),
+(408,283,o),
+(346,214,o),
+(213,214,cs),
+(60,214,l),
+(60,0,l)
+);
+}
+);
+width = 547;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1548;
+},
+{
+color = 11;
+glyphname = "loWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (279,690);
+},
+{
+name = top_left_can;
+pos = (105,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(209,0,ls),
+(398,0,o),
+(498,102,o),
+(498,278,cs),
+(498,455,o),
+(398,555,o),
+(209,555,cs),
+(115,555,l),
+(150,529,l),
+(150,690,l),
+(60,690,l),
+(60,475,l),
+(213,475,ls),
+(346,475,o),
+(408,407,o),
+(408,278,cs),
+(408,150,o),
+(346,80,o),
+(213,80,cs),
+(60,80,l),
+(60,0,l)
+);
+}
+);
+width = 542;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+},
+{
+color = 11;
+glyphname = "ra-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (264,690);
+},
+{
+name = top_right_can;
+pos = (439,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(483,0,l),
+(483,214,l),
+(329,214,ls),
+(197,214,o),
+(135,283,o),
+(135,412,cs),
+(135,540,o),
+(197,610,o),
+(329,610,cs),
+(483,610,l),
+(483,690,l),
+(334,690,ls),
+(145,690,o),
+(44,587,o),
+(44,412,cs),
+(44,235,o),
+(145,134,o),
+(334,134,cs),
+(428,134,l),
+(393,160,l),
+(393,0,l)
+);
+}
+);
+width = 543;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+},
+{
+color = 11;
+glyphname = "raa-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (196,0);
+ref = dot_top;
+}
+);
+width = 543;
+}
+);
+note = uni154C;
+},
+{
+color = 11;
+glyphname = "laWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (439,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(483,0,l),
+(483,80,l),
+(329,80,ls),
+(197,80,o),
+(135,150,o),
+(135,278,cs),
+(135,407,o),
+(197,475,o),
+(329,475,cs),
+(483,475,l),
+(483,690,l),
+(393,690,l),
+(393,529,l),
+(428,555,l),
+(334,555,ls),
+(145,555,o),
+(44,455,o),
+(44,278,cs),
+(44,102,o),
+(145,0,o),
+(334,0,cs)
+);
+}
+);
+width = 543;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+},
+{
+color = 11;
+glyphname = "reWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(505,0,l),
+(696,194,l),
+(641,251,l),
+(457,64,l),
+(516,60,l),
+(516,440,ls),
+(516,611,o),
+(427,702,o),
+(281,702,cs),
+(132,702,o),
+(47,612,o),
+(47,440,cs),
+(47,388,l),
+(137,388,l),
+(137,446,ls),
+(137,564,o),
+(188,619,o),
+(281,619,cs),
+(373,619,o),
+(425,561,o),
+(425,443,cs),
+(425,0,l)
+);
+}
+);
+width = 716;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+},
+{
+color = 11;
+glyphname = "riWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(291,0,l),
+(291,443,ls),
+(291,561,o),
+(343,619,o),
+(435,619,cs),
+(527,619,o),
+(579,564,o),
+(579,446,cs),
+(579,388,l),
+(668,388,l),
+(668,440,ls),
+(668,612,o),
+(583,702,o),
+(435,702,cs),
+(289,702,o),
+(200,611,o),
+(200,440,cs),
+(200,60,l),
+(259,64,l),
+(74,251,l),
+(20,194,l),
+(211,0,l)
+);
+}
+);
+width = 715;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+},
+{
+color = 11;
+glyphname = "roWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(427,-13,o),
+(516,78,o),
+(516,250,cs),
+(516,630,l),
+(457,626,l),
+(641,439,l),
+(696,496,l),
+(505,690,l),
+(425,690,l),
+(425,246,ls),
+(425,128,o),
+(373,71,o),
+(281,71,cs),
+(188,71,o),
+(137,126,o),
+(137,243,cs),
+(137,301,l),
+(47,301,l),
+(47,250,ls),
+(47,77,o),
+(132,-13,o),
+(281,-13,cs)
+);
+}
+);
+width = 716;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+},
+{
+color = 11;
+glyphname = "raWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(583,-13,o),
+(668,77,o),
+(668,250,cs),
+(668,301,l),
+(579,301,l),
+(579,243,ls),
+(579,126,o),
+(527,71,o),
+(435,71,cs),
+(343,71,o),
+(291,128,o),
+(291,246,cs),
+(291,690,l),
+(211,690,l),
+(20,496,l),
+(74,439,l),
+(259,626,l),
+(200,630,l),
+(200,250,ls),
+(200,78,o),
+(289,-13,o),
+(435,-13,cs)
+);
+}
+);
+width = 715;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+},
+{
+color = 11;
+glyphname = "theThCree-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (83,690);
+},
+{
+name = top_right_can;
+pos = (483,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(438,64,l),
+(438,0,l),
+(527,0,l),
+(527,64,l),
+(601,64,l),
+(601,111,l),
+(527,111,l),
+(527,252,l),
+(164,252,l),
+(164,213,l),
+(546,645,l),
+(481,701,l),
+(36,202,l),
+(36,173,l),
+(438,173,l),
+(438,111,l),
+(253,111,l),
+(253,64,l)
+);
+}
+);
+width = 631;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15A7;
+},
+{
+color = 11;
+glyphname = "thiThCree-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (143,690);
+},
+{
+name = top_right_can;
+pos = (543,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(193,0,l),
+(193,64,l),
+(378,64,l),
+(378,111,l),
+(193,111,l),
+(193,173,l),
+(595,173,l),
+(595,202,l),
+(150,701,l),
+(85,645,l),
+(467,213,l),
+(467,252,l),
+(103,252,l),
+(103,111,l),
+(30,111,l),
+(30,64,l),
+(103,64,l),
+(103,0,l)
+);
+}
+);
+width = 631;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+},
+{
+color = 11;
+glyphname = "thiiThCree-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (75,0);
+ref = dot_top;
+}
+);
+width = 631;
+}
+);
+note = uni15A9;
+},
+{
+color = 11;
+glyphname = "thoThCree-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (83,690);
+},
+{
+name = top_right_can;
+pos = (483,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(546,44,l),
+(164,476,l),
+(164,438,l),
+(527,438,l),
+(527,579,l),
+(601,579,l),
+(601,626,l),
+(527,626,l),
+(527,690,l),
+(438,690,l),
+(438,626,l),
+(253,626,l),
+(253,579,l),
+(438,579,l),
+(438,517,l),
+(36,517,l),
+(36,488,l),
+(481,-12,l)
+);
+}
+);
+width = 631;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+},
+{
+color = 11;
+glyphname = "thooThCree-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (415,0);
+ref = dot_top;
+}
+);
+width = 631;
+}
+);
+note = uni15AB;
+},
+{
+color = 11;
+glyphname = "thaThCree-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (149,690);
+},
+{
+name = top_right_can;
+pos = (548,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(595,488,l),
+(595,517,l),
+(193,517,l),
+(193,579,l),
+(378,579,l),
+(378,626,l),
+(193,626,l),
+(193,690,l),
+(103,690,l),
+(103,626,l),
+(30,626,l),
+(30,579,l),
+(103,579,l),
+(103,438,l),
+(467,438,l),
+(467,476,l),
+(85,44,l),
+(150,-12,l)
+);
+}
+);
+width = 631;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+},
+{
+color = 11;
+glyphname = "thaaThCree-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (81,0);
+ref = dot_top;
+}
+);
+width = 631;
+}
+);
+note = uni15AD;
+},
+{
+color = 11;
+glyphname = "thweeWoodScree-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (631,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni1677;
+},
+{
+color = 11;
+glyphname = "thwiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (631,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni1678;
+},
+{
+color = 11;
+glyphname = "thwiiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (75,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (631,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni1679;
+},
+{
+color = 11;
+glyphname = "thwoWoodScree-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (631,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni167A;
+},
+{
+color = 11;
+glyphname = "thwooWoodScree-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (415,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (631,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni167B;
+},
+{
+color = 11;
+glyphname = "thwaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (631,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni167C;
+},
+{
+color = 11;
+glyphname = "thwaaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (81,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (631,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni167D;
+},
+{
+color = 11;
+glyphname = "nwiOjibway-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (622,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 808;
+}
+);
+note = uni18C7;
+},
+{
+color = 11;
+glyphname = "nwiiOjibway-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (191,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (622,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 808;
+}
+);
+note = uni18C9;
+},
+{
+color = 11;
+glyphname = "nwoOjibway-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (622,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 808;
+}
+);
+note = uni18CB;
+},
+{
+color = 11;
+glyphname = "nwooOjibway-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (296,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (622,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 808;
+}
+);
+note = uni18CD;
+},
+{
+color = 11;
+glyphname = "looWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (38,0);
+ref = dot_top;
+}
+);
+width = 543;
+}
+);
+note = uni18E1;
+},
+{
+color = 11;
+glyphname = "laaWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (371,0);
+ref = dot_top;
+}
+);
+width = 543;
+}
+);
+note = uni18E2;
+},
+{
+color = 0;
+glyphname = zero;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(517,551,o),
+(460,700,o),
+(288,700,cs),
+(113,700,o),
+(57,540,o),
+(57,346,cs),
+(57,108,o),
+(139,-10,o),
+(287,-10,cs),
+(441,-10,o),
+(517,106,o),
+(517,346,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(152,469,o),
+(169,622,o),
+(288,622,cs),
+(412,622,o),
+(422,461,o),
+(422,346,cs),
+(422,189,o),
+(391,69,o),
+(287,69,cs),
+(187,69,o),
+(152,188,o),
+(152,346,cs)
+);
+}
+);
+width = 573;
+}
+);
+unicode = 48;
+},
+{
+color = 0;
+glyphname = one;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(226,690,l),
+(16,528,l),
+(68,466,l),
+(169,544,ls),
+(188,559,o),
+(201,571,o),
+(217,586,c),
+(215,555,o),
+(215,527,o),
+(215,497,cs),
+(215,0,l),
+(311,0,l),
+(311,690,l)
+);
+}
+);
+width = 430;
+}
+);
+unicode = 49;
+},
+{
+color = 0;
+glyphname = two;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(493,0,l),
+(493,80,l),
+(162,80,l),
+(162,82,l),
+(298,223,ls),
+(372,295,o),
+(423,351,o),
+(449,412,cs),
+(462,442,o),
+(469,477,o),
+(469,517,cs),
+(469,626,o),
+(386,699,o),
+(265,699,cs),
+(178,699,o),
+(110,669,o),
+(47,614,c),
+(99,552,l),
+(154,596,o),
+(206,618,o),
+(256,618,cs),
+(327,618,o),
+(374,578,o),
+(374,505,cs),
+(374,450,o),
+(355,409,o),
+(315,358,cs),
+(295,333,o),
+(268,303,o),
+(235,270,cs),
+(40,66,l),
+(40,0,l)
+);
+}
+);
+width = 541;
+}
+);
+unicode = 50;
+},
+{
+color = 0;
+glyphname = three;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(464,639,o),
+(383,699,o),
+(257,699,cs),
+(156,699,o),
+(89,670,o),
+(32,629,c),
+(73,563,l),
+(120,596,o),
+(178,621,o),
+(244,621,cs),
+(321,621,o),
+(371,587,o),
+(371,517,cs),
+(371,429,o),
+(288,393,o),
+(198,393,cs),
+(133,393,l),
+(133,320,l),
+(197,320,ls),
+(314,320,o),
+(384,288,o),
+(384,196,cs),
+(384,118,o),
+(333,68,o),
+(214,68,cs),
+(152,68,o),
+(81,85,o),
+(27,112,c),
+(27,30,l),
+(81,7,o),
+(144,-10,o),
+(226,-10,cs),
+(383,-10,o),
+(485,66,o),
+(485,191,cs),
+(485,293,o),
+(423,347,o),
+(315,360,c),
+(315,362,l),
+(400,382,o),
+(464,443,o),
+(464,535,cs)
+);
+}
+);
+width = 532;
+}
+);
+unicode = 51;
+},
+{
+color = 0;
+glyphname = four;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(453,238,l),
+(453,692,l),
+(363,692,l),
+(35,233,l),
+(35,164,l),
+(359,164,l),
+(359,0,l),
+(453,0,l),
+(453,164,l),
+(559,164,l),
+(559,238,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(124,238,l),
+(307,492,ls),
+(331,526,o),
+(340,541,o),
+(358,573,c),
+(361,573,l),
+(361,556,o),
+(359,523,o),
+(359,478,cs),
+(359,238,l)
+);
+}
+);
+width = 586;
+}
+);
+unicode = 52;
+},
+{
+color = 0;
+glyphname = five;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(215,429,o),
+(183,420,o),
+(156,414,c),
+(173,609,l),
+(445,609,l),
+(445,690,l),
+(92,690,l),
+(65,356,l),
+(104,333,l),
+(142,345,o),
+(183,354,o),
+(232,354,cs),
+(338,354,o),
+(392,301,o),
+(392,215,cs),
+(392,122,o),
+(327,68,o),
+(223,68,cs),
+(158,68,o),
+(92,88,o),
+(46,112,c),
+(46,30,l),
+(92,6,o),
+(154,-10,o),
+(229,-10,cs),
+(396,-10,o),
+(489,76,o),
+(489,218,cs),
+(489,353,o),
+(402,429,o),
+(271,429,cs)
+);
+}
+);
+width = 534;
+}
+);
+unicode = 53;
+},
+{
+color = 0;
+glyphname = six;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(56,128,o),
+(129,-10,o),
+(295,-10,cs),
+(433,-10,o),
+(517,80,o),
+(517,225,cs),
+(517,359,o),
+(443,440,o),
+(319,440,cs),
+(232,440,o),
+(173,397,o),
+(146,341,c),
+(142,341,l),
+(147,508,o),
+(210,624,o),
+(374,624,cs),
+(416,624,o),
+(447,619,o),
+(472,612,c),
+(472,690,l),
+(446,696,o),
+(410,700,o),
+(376,700,cs),
+(140,700,o),
+(56,528,o),
+(56,293,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(187,68,o),
+(154,170,o),
+(154,246,cs),
+(154,310,o),
+(221,363,o),
+(297,363,cs),
+(384,363,o),
+(424,311,o),
+(424,223,cs),
+(424,125,o),
+(377,68,o),
+(293,68,cs)
+);
+}
+);
+width = 560;
+}
+);
+unicode = 54;
+},
+{
+color = 0;
+glyphname = seven;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(482,633,l),
+(482,690,l),
+(18,690,l),
+(18,610,l),
+(380,610,l),
+(114,0,l),
+(213,0,l)
+);
+}
+);
+width = 505;
+}
+);
+unicode = 55;
+},
+{
+color = 0;
+glyphname = eight;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(417,-10,o),
+(514,57,o),
+(514,179,cs),
+(514,274,o),
+(443,329,o),
+(350,366,c),
+(435,403,o),
+(492,454,o),
+(492,537,cs),
+(492,642,o),
+(410,699,o),
+(285,699,cs),
+(160,699,o),
+(76,639,o),
+(76,537,cs),
+(76,444,o),
+(145,397,o),
+(213,365,c),
+(119,329,o),
+(55,275,o),
+(55,175,cs),
+(55,66,o),
+(137,-10,o),
+(282,-10,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(198,62,o),
+(144,106,o),
+(144,178,cs),
+(144,258,o),
+(212,298,o),
+(282,324,c),
+(375,287,o),
+(425,245,o),
+(425,180,cs),
+(425,103,o),
+(369,62,o),
+(281,62,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(214,436,o),
+(167,469,o),
+(167,529,cs),
+(167,592,o),
+(217,628,o),
+(284,628,cs),
+(356,628,o),
+(401,594,o),
+(401,530,cs),
+(401,471,o),
+(357,440,o),
+(285,408,c)
+);
+}
+);
+width = 568;
+}
+);
+unicode = 56;
+},
+{
+color = 0;
+glyphname = nine;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(503,566,o),
+(430,699,o),
+(265,699,cs),
+(126,699,o),
+(42,611,o),
+(42,466,cs),
+(42,332,o),
+(115,250,o),
+(238,250,cs),
+(326,250,o),
+(385,292,o),
+(413,351,c),
+(416,351,l),
+(411,175,o),
+(341,66,o),
+(180,66,cs),
+(142,66,o),
+(107,71,o),
+(82,77,c),
+(82,-2,l),
+(108,-8,o),
+(150,-11,o),
+(184,-11,cs),
+(419,-11,o),
+(503,165,o),
+(503,394,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(373,621,o),
+(406,517,o),
+(406,445,cs),
+(406,381,o),
+(334,326,o),
+(263,326,cs),
+(178,326,o),
+(134,381,o),
+(134,467,cs),
+(134,566,o),
+(182,621,o),
+(267,621,cs)
+);
+}
+);
+width = 559;
+}
+);
+unicode = 57;
+},
+{
+glyphname = zero.canadian;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(437,591,o),
+(367,702,o),
+(240,702,cs),
+(113,702,o),
+(43,591,o),
+(43,345,cs),
+(43,99,o),
+(113,-12,o),
+(240,-12,cs),
+(367,-12,o),
+(437,99,o),
+(437,345,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(134,544,o),
+(168,621,o),
+(241,621,cs),
+(313,621,o),
+(346,545,o),
+(346,345,cs),
+(346,145,o),
+(313,70,o),
+(241,70,cs),
+(168,70,o),
+(134,146,o),
+(134,345,cs)
+);
+}
+);
+width = 480;
+}
+);
+metricRight = "=|";
+},
+{
+glyphname = one.canadian;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(265,0,l),
+(265,690,l),
+(184,690,l),
+(19,523,l),
+(74,466,l),
+(233,626,l),
+(174,630,l),
+(174,0,l)
+);
+}
+);
+width = 325;
+}
+);
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = two.canadian;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(426,83,l),
+(162,83,l),
+(163,52,l),
+(339,288,ls),
+(401,371,o),
+(419,442,o),
+(419,509,cs),
+(419,631,o),
+(347,702,o),
+(238,702,cs),
+(112,702,o),
+(43,612,o),
+(43,452,c),
+(133,452,l),
+(133,569,o),
+(167,623,o),
+(236,623,cs),
+(296,623,o),
+(328,582,o),
+(328,509,cs),
+(328,454,o),
+(311,394,o),
+(259,324,cs),
+(62,60,l),
+(62,0,l),
+(426,0,l)
+);
+}
+);
+width = 469;
+}
+);
+note = uni14BF;
+},
+{
+glyphname = three.canadian;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(368,-13,o),
+(440,56,o),
+(440,184,cs),
+(440,278,o),
+(396,346,o),
+(309,361,c),
+(309,330,l),
+(390,345,o),
+(433,414,o),
+(433,504,cs),
+(433,635,o),
+(364,702,o),
+(252,702,cs),
+(128,702,o),
+(58,614,o),
+(56,467,c),
+(146,467,l),
+(146,573,o),
+(182,623,o),
+(250,623,cs),
+(311,623,o),
+(342,586,o),
+(342,499,cs),
+(342,419,o),
+(312,384,o),
+(255,384,cs),
+(225,384,l),
+(225,307,l),
+(256,307,ls),
+(317,307,o),
+(349,270,o),
+(349,190,cs),
+(349,103,o),
+(315,67,o),
+(249,67,cs),
+(178,67,o),
+(141,117,o),
+(141,223,c),
+(51,223,l),
+(51,69,o),
+(123,-13,o),
+(252,-13,cs)
+);
+}
+);
+width = 497;
+}
+);
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = four.canadian;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(368,0,l),
+(368,164,l),
+(447,164,l),
+(447,240,l),
+(368,240,l),
+(368,692,l),
+(297,692,l),
+(32,225,l),
+(32,164,l),
+(281,164,l),
+(281,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(312,600,l),
+(285,600,l),
+(285,240,l),
+(95,240,l),
+(101,218,l)
+);
+}
+);
+width = 470;
+}
+);
+},
+{
+glyphname = five.canadian;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(367,-13,o),
+(444,64,o),
+(444,202,cs),
+(444,338,o),
+(374,409,o),
+(244,409,cs),
+(141,409,l),
+(176,383,l),
+(192,633,l),
+(156,607,l),
+(421,607,l),
+(421,690,l),
+(108,690,l),
+(86,350,l),
+(103,329,l),
+(225,329,ls),
+(317,329,o),
+(355,290,o),
+(355,198,cs),
+(355,108,o),
+(317,67,o),
+(252,67,cs),
+(185,67,o),
+(147,108,o),
+(147,198,c),
+(57,198,l),
+(58,59,o),
+(134,-13,o),
+(253,-13,cs)
+);
+}
+);
+width = 492;
+}
+);
+},
+{
+glyphname = six.canadian;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(366,-13,o),
+(441,75,o),
+(441,204,cs),
+(441,335,o),
+(371,419,o),
+(267,419,cs),
+(189,419,o),
+(132,374,o),
+(114,281,c),
+(137,263,l),
+(134,296,o),
+(134,316,o),
+(134,368,cs),
+(134,552,o),
+(171,624,o),
+(251,624,cs),
+(315,624,o),
+(345,575,o),
+(349,495,c),
+(439,495,l),
+(429,621,o),
+(367,702,o),
+(255,702,cs),
+(121,702,o),
+(43,593,o),
+(43,349,cs),
+(43,198,o),
+(64,113,o),
+(107,55,cs),
+(143,7,o),
+(192,-13,o),
+(256,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(183,64,o),
+(145,120,o),
+(145,208,cs),
+(145,291,o),
+(186,344,o),
+(252,344,cs),
+(318,344,o),
+(354,291,o),
+(354,204,cs),
+(354,118,o),
+(315,64,o),
+(251,64,cs)
+);
+}
+);
+width = 481;
+}
+);
+metricLeft = zero.canadian;
+},
+{
+glyphname = seven.canadian;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(365,633,l),
+(365,690,l),
+(22,690,l),
+(22,607,l),
+(277,607,l),
+(276,635,l),
+(93,25,l),
+(93,0,l),
+(180,0,l)
+);
+}
+);
+width = 393;
+}
+);
+},
+{
+glyphname = eight.canadian;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(374,-13,o),
+(450,63,o),
+(450,182,cs),
+(450,283,o),
+(396,344,o),
+(318,360,c),
+(313,332,l),
+(385,344,o),
+(438,406,o),
+(438,508,cs),
+(438,627,o),
+(366,702,o),
+(254,702,cs),
+(141,702,o),
+(70,627,o),
+(70,508,cs),
+(70,406,o),
+(123,344,o),
+(194,332,c),
+(190,360,l),
+(111,344,o),
+(57,283,o),
+(57,182,cs),
+(57,63,o),
+(133,-13,o),
+(254,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(186,64,o),
+(146,104,o),
+(146,186,cs),
+(146,269,o),
+(187,307,o),
+(254,307,cs),
+(320,307,o),
+(361,269,o),
+(361,186,cs),
+(361,104,o),
+(321,64,o),
+(254,64,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(194,383,o),
+(157,421,o),
+(157,503,cs),
+(157,585,o),
+(192,626,o),
+(254,626,cs),
+(316,626,o),
+(350,585,o),
+(350,503,cs),
+(350,421,o),
+(313,383,o),
+(254,383,cs)
+);
+}
+);
+width = 507;
+}
+);
+metricLeft = "=|";
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = nine.canadian;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(359,-13,o),
+(438,97,o),
+(438,341,cs),
+(438,492,o),
+(417,577,o),
+(374,635,cs),
+(337,683,o),
+(288,702,o),
+(225,702,cs),
+(115,702,o),
+(40,614,o),
+(40,486,cs),
+(40,355,o),
+(110,270,o),
+(214,270,cs),
+(292,270,o),
+(349,316,o),
+(367,409,c),
+(344,427,l),
+(346,394,o),
+(347,374,o),
+(347,322,cs),
+(347,138,o),
+(310,66,o),
+(229,66,cs),
+(166,66,o),
+(136,115,o),
+(132,195,c),
+(43,195,l),
+(52,69,o),
+(114,-13,o),
+(226,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(162,346,o),
+(128,399,o),
+(128,486,cs),
+(128,572,o),
+(166,626,o),
+(230,626,cs),
+(298,626,o),
+(336,570,o),
+(336,482,cs),
+(336,399,o),
+(295,346,o),
+(229,346,cs)
+);
+}
+);
+width = 481;
+}
+);
+metricLeft = "=|six.canadian";
+metricRight = "=|six.canadian";
+},
+{
+glyphname = CR;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+width = 206;
+}
+);
+note = CR;
+unicode = 13;
+},
+{
+color = 0;
+glyphname = .notdef;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(488,690,l),
+(91,690,l),
+(91,0,l),
+(488,0,l),
+(488,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(439,640,l),
+(439,49,l),
+(140,49,l),
+(140,640,l),
+(140,640,l)
+);
+}
+);
+width = 580;
+}
+);
+note = ".notdef";
+},
+{
+glyphname = .null;
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+width = 0;
+}
+);
+note = NULL;
+},
+{
+glyphname = space;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+width = 209;
+}
+);
+note = space;
+unicode = 32;
+},
+{
+glyphname = nbspace;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+width = 206;
+}
+);
+note = uni00A0;
+unicode = 160;
+},
+{
+glyphname = space.canadian;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+width = 412;
+}
+);
+note = space;
+},
+{
+glyphname = "hyphen-canadian";
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(305,396,l),
+(305,450,l),
+(49,450,l),
+(49,396,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(305,260,l),
+(305,314,l),
+(49,314,l),
+(49,260,l)
+);
+}
+);
+width = 354;
+}
+);
+metricRight = "=|";
+note = uni1400;
+unicode = 5120;
+},
+{
+glyphname = "chi-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(122,0,l),
+(245,293,l),
+(214,293,l),
+(336,0,l),
+(420,0,l),
+(420,25,l),
+(260,385,l),
+(260,313,l),
+(418,665,l),
+(418,690,l),
+(333,690,l),
+(213,401,l),
+(244,401,l),
+(125,690,l),
+(41,690,l),
+(41,665,l),
+(198,314,l),
+(198,386,l),
+(38,25,l),
+(38,0,l)
+);
+}
+);
+width = 458;
+}
+);
+metricRight = "=|";
+note = uni166D;
+unicode = 5741;
+},
+{
+glyphname = "fullstop-canadian";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(254,0,l),
+(254,12,l),
+(175,187,l),
+(177,159,l),
+(253,332,l),
+(253,345,l),
+(196,345,l),
+(138,199,l),
+(163,203,l),
+(104,345,l),
+(47,345,l),
+(47,332,l),
+(124,163,l),
+(125,191,l),
+(46,12,l),
+(46,0,l),
+(103,0,l),
+(165,154,l),
+(136,150,l),
+(198,0,l)
+);
+}
+);
+width = 300;
+}
+);
+note = uni1541;
+unicode = 5742;
+},
+{
+glyphname = period;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(60,10,o),
+(83,-10,o),
+(117,-10,cs),
+(154,-10,o),
+(174,10,o),
+(174,46,cs),
+(174,84,o),
+(154,102,o),
+(117,102,cs),
+(83,102,o),
+(60,84,o),
+(60,46,cs)
+);
+}
+);
+width = 223;
+}
+);
+note = period;
+unicode = 46;
+},
+{
+glyphname = comma;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(88,-128,l),
+(119,-58,o),
+(143,40,o),
+(160,113,c),
+(156,125,l),
+(74,125,l),
+(65,50,o),
+(48,-35,o),
+(23,-128,c)
+);
+}
+);
+width = 208;
+}
+);
+note = comma;
+unicode = 44;
+},
+{
+glyphname = hyphen;
+kernLeft = hyphen;
+kernRight = hyphen;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(219,299,l),
+(36,299,l),
+(36,222,l),
+(219,222,l)
+);
+}
+);
+width = 255;
+}
+);
+unicode = 45;
+},
+{
+glyphname = quotesinglbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (31,-565);
+ref = quoteright;
+}
+);
+width = 256;
+}
+);
+unicode = 8218;
+},
+{
+glyphname = quotedblbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (31,-565);
+ref = quotedblright;
+}
+);
+width = 441;
+}
+);
+unicode = 8222;
+},
+{
+glyphname = quotedblleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(300,436,l),
+(309,509,o),
+(328,603,o),
+(355,690,c),
+(293,690,l),
+(262,620,o),
+(234,530,o),
+(217,445,c),
+(224,436,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(125,436,l),
+(133,509,o),
+(153,603,o),
+(180,690,c),
+(117,690,l),
+(86,619,o),
+(58,530,o),
+(42,445,c),
+(48,436,l)
+);
+}
+);
+width = 397;
+}
+);
+unicode = 8220;
+},
+{
+glyphname = quotedblright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(280,436,l),
+(313,507,o),
+(340,602,o),
+(355,680,c),
+(349,690,l),
+(272,690,l),
+(266,615,o),
+(246,521,o),
+(217,436,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(104,436,l),
+(137,507,o),
+(164,602,o),
+(180,680,c),
+(173,690,l),
+(97,690,l),
+(90,618,o),
+(70,519,o),
+(42,436,c)
+);
+}
+);
+width = 397;
+}
+);
+unicode = 8221;
+},
+{
+glyphname = quoteleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(128,436,l),
+(137,509,o),
+(156,604,o),
+(184,690,c),
+(117,690,l),
+(86,619,o),
+(58,530,o),
+(42,445,c),
+(48,436,l)
+);
+}
+);
+width = 225;
+}
+);
+unicode = 8216;
+},
+{
+glyphname = quoteright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(108,436,l),
+(141,507,o),
+(168,602,o),
+(184,680,c),
+(177,690,l),
+(97,690,l),
+(90,618,o),
+(70,519,o),
+(42,436,c)
+);
+}
+);
+width = 225;
+}
+);
+unicode = 8217;
+},
+{
+glyphname = dottedCircle;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(193,504,o),
+(181,494,o),
+(181,479,cs),
+(181,467,o),
+(193,454,o),
+(206,454,cs),
+(220,454,o),
+(231,467,o),
+(231,479,cs),
+(231,494,o),
+(220,504,o),
+(206,504,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(355,504,o),
+(343,494,o),
+(343,479,cs),
+(343,467,o),
+(355,454,o),
+(368,454,cs),
+(383,454,o),
+(393,467,o),
+(393,479,cs),
+(393,494,o),
+(383,504,o),
+(368,504,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(193,108,o),
+(181,98,o),
+(181,83,cs),
+(181,71,o),
+(193,58,o),
+(206,58,cs),
+(220,58,o),
+(231,71,o),
+(231,83,cs),
+(231,98,o),
+(220,108,o),
+(206,108,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(355,108,o),
+(343,98,o),
+(343,83,cs),
+(343,71,o),
+(355,58,o),
+(368,58,cs),
+(383,58,o),
+(393,71,o),
+(393,83,cs),
+(393,98,o),
+(383,108,o),
+(368,108,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(274,522,o),
+(262,511,o),
+(262,497,cs),
+(262,484,o),
+(274,471,o),
+(287,471,cs),
+(301,471,o),
+(312,484,o),
+(312,497,cs),
+(312,511,o),
+(301,522,o),
+(287,522,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(274,91,o),
+(262,80,o),
+(262,66,cs),
+(262,53,o),
+(274,41,o),
+(287,41,cs),
+(301,41,o),
+(312,53,o),
+(312,66,cs),
+(312,80,o),
+(301,91,o),
+(287,91,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(46,269,o),
+(59,256,o),
+(71,256,cs),
+(86,256,o),
+(97,269,o),
+(97,281,cs),
+(97,296,o),
+(86,306,o),
+(71,306,cs),
+(59,306,o),
+(46,296,o),
+(46,281,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(477,269,o),
+(490,256,o),
+(502,256,cs),
+(517,256,o),
+(527,269,o),
+(527,281,cs),
+(527,296,o),
+(517,306,o),
+(502,306,cs),
+(490,306,o),
+(477,296,o),
+(477,281,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(109,116,o),
+(122,103,o),
+(134,103,cs),
+(149,103,o),
+(159,116,o),
+(159,128,cs),
+(159,143,o),
+(149,154,o),
+(134,154,cs),
+(122,154,o),
+(109,143,o),
+(109,128,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(109,421,o),
+(122,409,o),
+(134,409,cs),
+(149,409,o),
+(159,421,o),
+(159,434,cs),
+(159,448,o),
+(149,459,o),
+(134,459,cs),
+(122,459,o),
+(109,448,o),
+(109,434,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(414,116,o),
+(427,103,o),
+(440,103,cs),
+(454,103,o),
+(465,116,o),
+(465,128,cs),
+(465,143,o),
+(454,154,o),
+(440,154,cs),
+(427,154,o),
+(414,143,o),
+(414,128,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(414,421,o),
+(427,409,o),
+(440,409,cs),
+(454,409,o),
+(465,421,o),
+(465,434,cs),
+(465,448,o),
+(454,459,o),
+(440,459,cs),
+(427,459,o),
+(414,448,o),
+(414,434,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(64,187,o),
+(76,175,o),
+(89,175,cs),
+(103,175,o),
+(114,187,o),
+(114,200,cs),
+(114,214,o),
+(103,225,o),
+(89,225,cs),
+(76,225,o),
+(64,214,o),
+(64,200,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(64,350,o),
+(76,337,o),
+(89,337,cs),
+(103,337,o),
+(114,350,o),
+(114,362,cs),
+(114,377,o),
+(103,387,o),
+(89,387,cs),
+(76,387,o),
+(64,377,o),
+(64,362,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(460,187,o),
+(472,175,o),
+(485,175,cs),
+(499,175,o),
+(510,187,o),
+(510,200,cs),
+(510,214,o),
+(499,225,o),
+(485,225,cs),
+(472,225,o),
+(460,214,o),
+(460,200,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(460,350,o),
+(472,337,o),
+(485,337,cs),
+(499,337,o),
+(510,350,o),
+(510,362,cs),
+(510,377,o),
+(499,387,o),
+(485,387,cs),
+(472,387,o),
+(460,377,o),
+(460,362,cs)
+);
+}
+);
+width = 574;
+}
+);
+note = uni25CC;
+unicode = 9676;
+},
+{
+glyphname = dotaccentcomb;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(48,719,o),
+(27,702,o),
+(27,667,cs),
+(27,632,o),
+(48,616,o),
+(78,616,cs),
+(107,616,o),
+(129,632,o),
+(129,667,cs),
+(129,703,o),
+(107,719,o),
+(78,719,cs)
+);
+}
+);
+width = 156;
+}
+);
+note = uni0307;
+unicode = 775;
+},
+{
+glyphname = dotaccent;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(108,616,o),
+(130,632,o),
+(130,667,cs),
+(130,703,o),
+(108,719,o),
+(79,719,cs),
+(49,719,o),
+(28,702,o),
+(28,667,cs),
+(28,632,o),
+(49,616,o),
+(79,616,cs)
+);
+}
+);
+width = 158;
+}
+);
+note = dotaccent;
+unicode = 729;
+},
+{
+glyphname = caron;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(220,623,o),
+(250,674,o),
+(288,729,c),
+(288,738,l),
+(229,738,l),
+(204,710,o),
+(184,678,o),
+(157,639,c),
+(133,675,o),
+(112,710,o),
+(88,738,c),
+(28,738,l),
+(28,729,l),
+(60,684,o),
+(92,635,o),
+(113,585,c),
+(203,585,l),
+(203,585,l)
+);
+}
+);
+width = 316;
+}
+);
+note = caron;
+unicode = 711;
+},
+{
+glyphname = breve;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(217,585,o),
+(260,635,o),
+(266,721,c),
+(213,721,l),
+(205,668,o),
+(181,644,o),
+(146,644,cs),
+(105,644,o),
+(87,668,o),
+(79,721,c),
+(28,721,l),
+(33,630,o),
+(75,585,o),
+(146,585,cs)
+);
+}
+);
+width = 294;
+}
+);
+note = breve;
+unicode = 728;
+},
+{
+glyphname = ring;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(158,587,o),
+(196,630,o),
+(196,694,cs),
+(196,754,o),
+(157,799,o),
+(111,799,cs),
+(64,799,o),
+(28,756,o),
+(28,693,cs),
+(28,629,o),
+(64,587,o),
+(111,587,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(88,634,o),
+(72,660,o),
+(72,693,cs),
+(72,727,o),
+(90,753,o),
+(111,753,cs),
+(132,753,o),
+(150,726,o),
+(150,693,cs),
+(150,661,o),
+(133,634,o),
+(111,634,cs)
+);
+}
+);
+width = 224;
+}
+);
+note = ring;
+unicode = 730;
+},
+{
+glyphname = ogonek;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(127,-219,o),
+(144,-214,o),
+(159,-209,c),
+(159,-153,l),
+(151,-157,o),
+(134,-161,o),
+(121,-161,cs),
+(100,-161,o),
+(89,-145,o),
+(89,-113,cs),
+(89,-72,o),
+(110,-38,o),
+(142,0,c),
+(105,16,l),
+(50,-35,o),
+(28,-80,o),
+(28,-128,cs),
+(28,-186,o),
+(64,-219,o),
+(109,-219,cs)
+);
+}
+);
+width = 187;
+}
+);
+note = ogonek;
+unicode = 731;
+},
+{
+glyphname = ring_top.canadian;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (115,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(165,757,o),
+(207,796,o),
+(207,848,cs),
+(207,901,o),
+(165,939,o),
+(115,939,cs),
+(65,939,o),
+(23,901,o),
+(23,848,cs),
+(23,796,o),
+(65,757,o),
+(115,757,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(86,798,o),
+(66,819,o),
+(66,848,cs),
+(66,876,o),
+(86,898,o),
+(115,898,cs),
+(145,898,o),
+(164,876,o),
+(164,848,cs),
+(164,819,o),
+(145,798,o),
+(115,798,cs)
+);
+}
+);
+width = 231;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (68,345);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(95,296,o),
+(117,318,o),
+(117,345,cs),
+(117,372,o),
+(95,394,o),
+(68,394,cs),
+(41,394,o),
+(18,372,o),
+(18,345,cs),
+(18,318,o),
+(41,296,o),
+(68,296,cs)
+);
+}
+);
+width = 135;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (59,345);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(82,303,o),
+(101,321,o),
+(101,345,cs),
+(101,369,o),
+(82,386,o),
+(59,386,cs),
+(36,386,o),
+(17,369,o),
+(17,345,cs),
+(17,321,o),
+(36,303,o),
+(59,303,cs)
+);
+}
+);
+width = 119;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_small;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (50,345);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(70,311,o),
+(84,327,o),
+(84,345,cs),
+(84,363,o),
+(70,379,o),
+(50,379,cs),
+(32,379,o),
+(17,363,o),
+(17,345,cs),
+(17,327,o),
+(32,311,o),
+(50,311,cs)
+);
+}
+);
+width = 101;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_top;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (68,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(96,781,o),
+(118,804,o),
+(118,832,cs),
+(118,860,o),
+(96,882,o),
+(68,882,cs),
+(40,882,o),
+(17,860,o),
+(17,832,cs),
+(17,804,o),
+(40,781,o),
+(68,781,cs)
+);
+}
+);
+width = 135;
+}
+);
+note = g725;
+},
+{
+glyphname = doubledot_middle;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(126,382,o),
+(148,404,o),
+(148,432,cs),
+(148,460,o),
+(126,482,o),
+(98,482,cs),
+(70,482,o),
+(47,460,o),
+(47,432,cs),
+(47,404,o),
+(70,382,o),
+(98,382,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(126,208,o),
+(148,230,o),
+(148,258,cs),
+(148,286,o),
+(126,308,o),
+(98,308,cs),
+(70,308,o),
+(47,286,o),
+(47,258,cs),
+(47,230,o),
+(70,208,o),
+(98,208,cs)
+);
+}
+);
+width = 195;
+}
+);
+metricRight = "=|";
+note = g725;
+},
+{
+glyphname = doubledot_top;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top_double;
+pos = (214,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(242,781,o),
+(266,804,o),
+(266,832,cs),
+(266,860,o),
+(242,882,o),
+(214,882,cs),
+(186,882,o),
+(165,860,o),
+(165,832,cs),
+(165,804,o),
+(186,781,o),
+(214,781,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(95,781,o),
+(117,804,o),
+(117,832,cs),
+(117,860,o),
+(95,882,o),
+(67,882,cs),
+(39,882,o),
+(16,860,o),
+(16,832,cs),
+(16,804,o),
+(39,781,o),
+(67,781,cs)
+);
+}
+);
+width = 282;
+}
+);
+note = g725;
+},
+{
+glyphname = g727;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (282,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(501,0,l),
+(501,75,l),
+(256,75,ls),
+(177,75,o),
+(142,116,o),
+(142,191,cs),
+(142,268,o),
+(176,308,o),
+(256,308,cs),
+(326,308,ls),
+(447,308,o),
+(511,379,o),
+(511,499,cs),
+(511,619,o),
+(447,690,o),
+(326,690,cs),
+(62,690,l),
+(62,614,l),
+(308,614,ls),
+(386,614,o),
+(421,574,o),
+(421,499,cs),
+(421,423,o),
+(387,383,o),
+(308,383,cs),
+(238,383,ls),
+(115,383,o),
+(52,311,o),
+(52,191,cs),
+(52,71,o),
+(115,0,o),
+(238,0,cs)
+);
+}
+);
+width = 563;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+glyphname = g728;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (214,0);
+ref = dot_top;
+}
+);
+width = 563;
+}
+);
+note = g728;
+},
+{
+glyphname = g729;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (282,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(326,0,ls),
+(447,0,o),
+(511,71,o),
+(511,190,cs),
+(511,311,o),
+(447,383,o),
+(326,383,cs),
+(255,383,ls),
+(176,383,o),
+(141,423,o),
+(141,498,cs),
+(141,574,o),
+(176,614,o),
+(255,614,cs),
+(501,614,l),
+(501,690,l),
+(237,690,ls),
+(115,690,o),
+(52,619,o),
+(52,498,cs),
+(52,379,o),
+(115,307,o),
+(237,307,cs),
+(307,307,ls),
+(386,307,o),
+(420,268,o),
+(420,190,cs),
+(420,115,o),
+(386,75,o),
+(307,75,cs),
+(62,75,l),
+(62,0,l)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+glyphname = g730;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (214,0);
+ref = dot_top;
+}
+);
+width = 562;
+}
+);
+note = g730;
+},
+{
+glyphname = g731;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = g727;
+}
+);
+width = 748;
+}
+);
+note = g731;
+},
+{
+glyphname = g732;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (563,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 748;
+}
+);
+note = g732;
+},
+{
+glyphname = g733;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (399,0);
+ref = dot_top;
+}
+);
+width = 748;
+}
+);
+note = g733;
+},
+{
+glyphname = g734;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (214,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (563,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 748;
+}
+);
+note = g734;
+},
+{
+glyphname = g735;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = g729;
+}
+);
+width = 748;
+}
+);
+note = g735;
+},
+{
+glyphname = g736;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (562,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 748;
+}
+);
+note = g736;
+},
+{
+glyphname = g737;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (399,0);
+ref = dot_top;
+}
+);
+width = 748;
+}
+);
+note = g737;
+},
+{
+glyphname = g738;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (214,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (562,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 748;
+}
+);
+note = g738;
+},
+{
+glyphname = g739;
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(430,231,o),
+(470,283,o),
+(470,361,cs),
+(470,439,o),
+(430,493,o),
+(363,493,cs),
+(203,493,l),
+(206,466,l),
+(228,478,o),
+(245,522,o),
+(245,568,cs),
+(245,644,o),
+(207,696,o),
+(142,696,cs),
+(78,696,o),
+(39,643,o),
+(39,565,cs),
+(39,488,o),
+(79,434,o),
+(146,434,cs),
+(306,434,l),
+(303,461,l),
+(280,448,o),
+(264,405,o),
+(264,358,cs),
+(264,282,o),
+(302,231,o),
+(367,231,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(112,481,o),
+(93,512,o),
+(93,565,cs),
+(93,618,o),
+(113,648,o),
+(143,648,cs),
+(171,648,o),
+(190,617,o),
+(190,565,cs),
+(190,513,o),
+(172,481,o),
+(142,481,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(338,278,o),
+(318,309,o),
+(318,362,cs),
+(318,414,o),
+(337,445,o),
+(367,445,cs),
+(396,445,o),
+(416,414,o),
+(416,361,cs),
+(416,308,o),
+(396,278,o),
+(366,278,cs)
+);
+}
+);
+width = 509;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+glyphname = g740;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (167,0);
+ref = ring_top.canadian;
+}
+);
+width = 563;
+}
+);
+note = g740;
+},
+{
+glyphname = g741;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (167,0);
+ref = ring_top.canadian;
+}
+);
+width = 562;
+}
+);
+note = g741;
+},
+{
+glyphname = g742;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (185,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (352,0);
+ref = ring_top.canadian;
+}
+);
+width = 748;
+}
+);
+note = g742;
+},
+{
+glyphname = stroke_middle;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (44,345);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(71,457,l),
+(17,457,l),
+(17,233,l),
+(71,233,l)
+);
+}
+);
+width = 89;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (39,345);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(59,434,l),
+(17,434,l),
+(17,256,l),
+(59,256,l)
+);
+}
+);
+width = 76;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_small;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (34,345);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(51,428,l),
+(17,428,l),
+(17,262,l),
+(51,262,l)
+);
+}
+);
+width = 69;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_threequart;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (44,345);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(70,455,l),
+(19,455,l),
+(19,235,l),
+(70,235,l)
+);
+}
+);
+width = 89;
+}
+);
+note = g723;
+},
+{
+color = 8;
+glyphname = uni11AB0;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (137,690);
+},
+{
+name = top_right_can;
+pos = (368,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(182,0,l),
+(182,104,l),
+(367,104,l),
+(367,158,l),
+(182,158,l),
+(182,280,l),
+(114,249,l),
+(141,249,ls),
+(313,249,o),
+(412,372,o),
+(412,586,cs),
+(412,690,l),
+(323,690,l),
+(323,594,ls),
+(323,414,o),
+(251,331,o),
+(122,331,cs),
+(92,331,l),
+(92,158,l),
+(30,158,l),
+(30,104,l),
+(92,104,l),
+(92,0,l)
+);
+}
+);
+width = 470;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB1;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB0;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (300,0);
+ref = dot_top;
+}
+);
+width = 470;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB2;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (103,690);
+},
+{
+name = top_right_can;
+pos = (334,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(149,0,l),
+(149,96,ls),
+(149,275,o),
+(219,358,o),
+(349,358,cs),
+(380,358,l),
+(380,531,l),
+(440,531,l),
+(440,585,l),
+(380,585,l),
+(380,690,l),
+(289,690,l),
+(289,585,l),
+(104,585,l),
+(104,531,l),
+(289,531,l),
+(289,410,l),
+(356,440,l),
+(330,440,ls),
+(158,440,o),
+(58,319,o),
+(58,103,cs),
+(58,0,l)
+);
+}
+);
+width = 470;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "theThCree-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB3;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB2;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (267,0);
+ref = dot_top;
+}
+);
+width = 471;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB4;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (137,690);
+},
+{
+name = top_right_can;
+pos = (368,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(412,0,l),
+(412,103,ls),
+(412,318,o),
+(313,440,o),
+(141,440,cs),
+(114,440,l),
+(182,410,l),
+(182,531,l),
+(367,531,l),
+(367,585,l),
+(182,585,l),
+(182,690,l),
+(92,690,l),
+(92,585,l),
+(30,585,l),
+(30,531,l),
+(92,531,l),
+(92,358,l),
+(122,358,ls),
+(251,358,o),
+(323,275,o),
+(323,96,cs),
+(323,0,l)
+);
+}
+);
+width = 470;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB5;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB4;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (70,0);
+ref = dot_top;
+}
+);
+width = 470;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB6;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (105,690);
+},
+{
+name = top_right_can;
+pos = (336,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(151,0,l),
+(151,282,l),
+(83,249,l),
+(109,249,ls),
+(281,249,o),
+(381,372,o),
+(381,586,cs),
+(381,656,l),
+(319,636,l),
+(510,441,l),
+(562,496,l),
+(372,690,l),
+(291,690,l),
+(291,594,ls),
+(291,414,o),
+(219,331,o),
+(91,331,cs),
+(60,331,l),
+(60,0,l)
+);
+}
+);
+width = 582;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB7;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB6;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (269,0);
+ref = dot_top;
+}
+);
+width = 582;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB8;
+kernRight = soright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (246,690);
+},
+{
+name = top_right_can;
+pos = (477,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(291,0,l),
+(291,96,ls),
+(291,275,o),
+(363,358,o),
+(492,358,cs),
+(522,358,l),
+(522,690,l),
+(432,690,l),
+(432,408,l),
+(499,440,l),
+(472,440,ls),
+(300,440,o),
+(202,318,o),
+(202,103,cs),
+(202,34,l),
+(263,54,l),
+(72,248,l),
+(20,194,l),
+(211,0,l)
+);
+}
+);
+width = 582;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB9;
+kernRight = soright;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB8;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (410,0);
+ref = dot_top;
+}
+);
+width = 582;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABA;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (105,690);
+},
+{
+name = top_right_can;
+pos = (336,690);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(372,0,l),
+(562,194,l),
+(510,248,l),
+(319,54,l),
+(381,34,l),
+(381,103,ls),
+(381,318,o),
+(281,440,o),
+(109,440,cs),
+(83,440,l),
+(151,408,l),
+(151,690,l),
+(60,690,l),
+(60,358,l),
+(91,358,ls),
+(219,358,o),
+(291,275,o),
+(291,96,cs),
+(291,0,l)
+);
+}
+);
+width = 582;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABB;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = uni11ABA;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (38,0);
+ref = dot_top;
+}
+);
+width = 582;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABC;
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(426,0,l),
+(426,83,l),
+(128,83,l),
+(128,47,l),
+(434,626,l),
+(434,690,l),
+(43,690,l),
+(43,607,l),
+(341,607,l),
+(341,642,l),
+(37,64,l),
+(37,0,l)
+);
+}
+);
+width = 471;
+}
+);
+metricRight = "=|";
+},
+{
+color = 8;
+glyphname = uni11ABD;
+lastChange = "2023-01-13 15:55:24 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(434,0,l),
+(434,64,l),
+(129,642,l),
+(129,607,l),
+(426,607,l),
+(426,690,l),
+(37,690,l),
+(37,626,l),
+(341,47,l),
+(341,83,l),
+(43,83,l),
+(43,0,l)
+);
+}
+);
+width = 471;
+}
+);
+metricLeft = "=|uni11ABC";
+metricRight = "=|uni11ABC";
+},
+{
+color = 8;
+glyphname = uni11ABE;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(148,0,l),
+(148,608,l),
+(98,608,l),
+(402,0,l),
+(482,0,l),
+(482,690,l),
+(393,690,l),
+(393,82,l),
+(444,82,l),
+(140,690,l),
+(60,690,l),
+(60,0,l)
+);
+}
+);
+width = 542;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABF;
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(140,0,l),
+(443,611,l),
+(393,611,l),
+(393,0,l),
+(482,0,l),
+(482,690,l),
+(402,690,l),
+(98,79,l),
+(149,79,l),
+(149,690,l),
+(60,690,l),
+(60,0,l)
+);
+}
+);
+width = 542;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = "raiseddoubledotFinal-canadian.cree";
+lastChange = "2023-01-13 15:55:21 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(123,602,o),
+(145,624,o),
+(145,652,cs),
+(145,680,o),
+(123,702,o),
+(95,702,cs),
+(68,702,o),
+(44,681,o),
+(44,652,cs),
+(44,624,o),
+(68,602,o),
+(95,602,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(123,428,o),
+(145,450,o),
+(145,478,cs),
+(145,506,o),
+(123,528,o),
+(95,528,cs),
+(68,528,o),
+(44,506,o),
+(44,478,cs),
+(44,450,o),
+(68,428,o),
+(95,428,cs)
+);
+}
+);
+width = 190;
+}
+);
+note = g725;
+}
+);
+instances = (
+{
+axesValues = (
+98,
+72,
+0
+);
+instanceInterpolations = {
+"7D3FB2DB-72C7-4646-AA25-FB3BBECA0225" = 1;
+};
+name = "RC CR roman";
+}
+);
+kerningLTR = {
+"7D3FB2DB-72C7-4646-AA25-FB3BBECA0225" = {
+"@MMK_L_caright" = {
+"@MMK_R_ecanleft" = -64.722;
+"@MMK_R_mwestleft" = -24.15;
+"@MMK_R_neleft" = -46.368;
+};
+"@MMK_L_ciright" = {
+"@MMK_R_icanleft" = -64.722;
+"@MMK_R_noleft" = -81.144;
+};
+"@MMK_L_ecanright" = {
+"@MMK_R_coleft" = -64.722;
+"@MMK_R_moleft" = -64.722;
+"@MMK_R_sileft" = -35.742;
+};
+"@MMK_L_icanright" = {
+"@MMK_R_celeft" = -64.722;
+"@MMK_R_meleft" = -64.722;
+"@MMK_R_mwestleft" = -43.47;
+"@MMK_R_saleft" = -30.912;
+"she-canadian" = -64.722;
+};
+"@MMK_L_maright" = {
+"@MMK_R_acanleft" = -60.858;
+"@MMK_R_ecanleft" = -64.722;
+"@MMK_R_mwestleft" = -44.436;
+"@MMK_R_neleft" = -46.368;
+};
+"@MMK_L_miright" = {
+"@MMK_R_acanleft" = -60.858;
+"@MMK_R_icanleft" = -64.722;
+"@MMK_R_moleft" = -87.906;
+"@MMK_R_noleft" = -81.144;
+"@MMK_R_yeleft" = -88.872;
+};
+"@MMK_L_mwestright" = {
+"@MMK_R_coleft" = -24.15;
+"@MMK_R_icanleft" = -43.47;
+"@MMK_R_moleft" = -44.436;
+"@MMK_R_noleft" = -71.484;
+"@MMK_R_sileft" = -12.558;
+"@MMK_R_yeleft" = -22.218;
+};
+"@MMK_L_naright" = {
+"@MMK_R_acanleft" = -76.314;
+"@MMK_R_celeft" = -81.144;
+"@MMK_R_meleft" = -81.144;
+"@MMK_R_mwestleft" = -71.484;
+"@MMK_R_neleft" = -92.736;
+"@MMK_R_saleft" = -53.13;
+};
+"@MMK_L_niright" = {
+"@MMK_R_coleft" = -46.368;
+"@MMK_R_moleft" = -46.368;
+"@MMK_R_noleft" = -92.736;
+"@MMK_R_sileft" = -2.898;
+};
+"@MMK_L_ocanright" = {
+"@MMK_R_meleft" = -60.858;
+"@MMK_R_moleft" = -60.858;
+"@MMK_R_noleft" = -76.314;
+};
+"@MMK_L_seright" = {
+"@MMK_R_ecanleft" = -35.742;
+"@MMK_R_mwestleft" = -12.558;
+"@MMK_R_neleft" = -2.898;
+};
+"@MMK_L_soright" = {
+"@MMK_R_icanleft" = -30.912;
+"@MMK_R_noleft" = -53.13;
+};
+"@MMK_L_yiright" = {
+"@MMK_R_meleft" = -88.872;
+"@MMK_R_mwestleft" = -22.218;
+};
+"shi-canadian" = {
+"@MMK_R_icanleft" = -64.722;
+};
+};
+};
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "italic angle";
+}
+);
+properties = (
+{
+key = copyrights;
+values = (
+{
+language = ENG;
+value = "Copyright 2018 Google Inc. All Rights Reserved.";
+}
+);
+},
+{
+key = manufacturers;
+values = (
+{
+language = ENG;
+value = "Monotype Imaging Inc.";
+}
+);
+},
+{
+key = designers;
+values = (
+{
+language = ENG;
+value = "Monotype Design Team";
+}
+);
+},
+{
+key = description;
+value = "Designed by Monotype design team.";
+},
+{
+key = trademarks;
+values = (
+{
+language = ENG;
+value = "Noto is a trademark of Google Inc.";
+}
+);
+},
+{
+key = licenseURL;
+value = "http://scripts.sil.org/OFL";
+},
+{
+key = licenses;
+values = (
+{
+language = ENG;
+value = "This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.";
+}
+);
+},
+{
+key = manufacturerURL;
+value = "http://www.google.com/get/noto/";
+},
+{
+key = designerURL;
+value = "http://www.monotype.com/studio";
+}
+);
+settings = {
+disablesNiceNames = 1;
+};
+stems = (
+{
+name = "New Stem";
+}
+);
+unitsPerEm = 966;
+userData = {
+GSDontShowVersionAlert = 1;
+};
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/sources/Exported instances UCAS SansCanadianAboriginal Resized/Sans Canadian Aboriginal-RC L Italic.glyphs
+++ b/sources/Exported instances UCAS SansCanadianAboriginal Resized/Sans Canadian Aboriginal-RC L Italic.glyphs
@@ -1,0 +1,37333 @@
+{
+.appVersion = "3151";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+},
+{
+name = Width;
+tag = wdth;
+},
+{
+name = Slant;
+tag = slnt;
+}
+);
+classes = (
+{
+code = "zero one two three four five six seven eight nine ";
+name = Num;
+},
+{
+code = "zero.canadian one.canadian two.canadian three.canadian four.canadian five.canadian six.canadian seven.canadian eight.canadian nine.canadian 
+";
+name = Num_can;
+},
+{
+code = "ke-canadian.square ki-canadian.square kii-canadian.square ko-canadian.square koo-canadian.square ka-canadian.square kaa-canadian.square kweWestCree-canadian.square kwiiWestCree-canadian.square kwoWestCree-canadian.square kwooWestCree-canadian.square kwaWestCree-canadian.square kwaaWestCree-canadian.square ce-canadian.square ci-canadian.square cii-canadian.square co-canadian.square coo-canadian.square ca-canadian.square caa-canadian.square me-canadian.square mi-canadian.square mii-canadian.square mo-canadian.square moo-canadian.square ma-canadian.square maa-canadian.square ne-canadian.square ni-canadian.square nii-canadian.square no-canadian.square noo-canadian.square na-canadian.square naa-canadian.square nweWestCree-canadian.square nwaWestCree-canadian.square nwaaWestCree-canadian.square se-canadian.square si-canadian.square sii-canadian.square so-canadian.square soo-canadian.square sa-canadian.square saa-canadian.square sho-canadian.square shoo-canadian.square sha-canadian.square shaa-canadian.square ye-canadian.square yi-canadian.square yii-canadian.square yo-canadian.square yoo-canadian.square ya-canadian.square yaa-canadian.square re-canadian.square reRCree-canadian.square leWestCree-canadian.square ri-canadian.square rii-canadian.square ro-canadian.square loWestCree-canadian.square ra-canadian.square raa-canadian.square laWestCree-canadian.square reWestCree-canadian.square riWestCree-canadian.square roWestCree-canadian.square raWestCree-canadian.square theThCree-canadian.square thiThCree-canadian.square thiiThCree-canadian.square thoThCree-canadian.square thooThCree-canadian.square thaThCree-canadian.square thaaThCree-canadian.square thweeWoodScree-canadian.square thwiWoodScree-canadian.square thwiiWoodScree-canadian.square thwoWoodScree-canadian.square thwooWoodScree-canadian.square thwaWoodScree-canadian.square thwaaWoodScree-canadian.square nwiOjibway-canadian.square nwiiOjibway-canadian.square nwoOjibway-canadian.square nwooOjibway-canadian.square looWestCree-canadian.square laaWestCree-canadian.square ";
+name = Dene_square;
+},
+{
+code = "ke-canadian ki-canadian kii-canadian ko-canadian koo-canadian ka-canadian kaa-canadian kweWestCree-canadian kwiiWestCree-canadian kwoWestCree-canadian kwooWestCree-canadian kwaWestCree-canadian kwaaWestCree-canadian ce-canadian ci-canadian cii-canadian co-canadian coo-canadian ca-canadian caa-canadian me-canadian mi-canadian mii-canadian mo-canadian moo-canadian ma-canadian maa-canadian ne-canadian ni-canadian nii-canadian no-canadian noo-canadian na-canadian naa-canadian nweWestCree-canadian nwaWestCree-canadian nwaaWestCree-canadian se-canadian si-canadian sii-canadian so-canadian soo-canadian sa-canadian saa-canadian sho-canadian shoo-canadian sha-canadian shaa-canadian ye-canadian yi-canadian yii-canadian yo-canadian yoo-canadian ya-canadian yaa-canadian re-canadian reRCree-canadian leWestCree-canadian ri-canadian rii-canadian ro-canadian loWestCree-canadian ra-canadian raa-canadian laWestCree-canadian reWestCree-canadian riWestCree-canadian roWestCree-canadian raWestCree-canadian theThCree-canadian thiThCree-canadian thiiThCree-canadian thoThCree-canadian thooThCree-canadian thaThCree-canadian thaaThCree-canadian thweeWoodScree-canadian thwiWoodScree-canadian thwiiWoodScree-canadian thwoWoodScree-canadian thwooWoodScree-canadian thwaWoodScree-canadian thwaaWoodScree-canadian nwiOjibway-canadian nwiiOjibway-canadian nwoOjibway-canadian nwooOjibway-canadian looWestCree-canadian laaWestCree-canadian 
+";
+name = Dene_round;
+},
+{
+code = "acuteFinal-canadian.mid graveFinal-canadian.mid ringTophalfFinal-canadian.mid ringRighthalfFinal-canadian.mid ringFinal-canadian.mid doubleacuteFinal-canadian.mid doubleshortverticalstrokesFinal-canadian.mid shorthorizontalstrokeFinal-canadian.mid downtackFinal-canadian.mid pWestCree-canadian.mid c-canadian.mid mWestCree-canadian.mid ";
+name = Final_mid;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian ringFinal-canadian doubleacuteFinal-canadian doubleshortverticalstrokesFinal-canadian shorthorizontalstrokeFinal-canadian downtackFinal-canadian pWestCree-canadian c-canadian mWestCree-canadian ";
+name = Final_mid_ori;
+},
+{
+code = "acuteFinal-canadian.base graveFinal-canadian.base ringBottomhalfFinal-canadian.base ringTophalfFinal-canadian.base ringRighthalfFinal-canadian.base plusFinal-canadian.base pWestCree-canadian.base c-canadian.base thSayisi-canadian.base mWestCree-canadian.base ";
+name = Final_base;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringBottomhalfFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian plusFinal-canadian pWestCree-canadian c-canadian thSayisi-canadian mWestCree-canadian ";
+name = Final_base_ori;
+},
+{
+code = "ng-canadian ngai-canadian ngaai-canadian ngi-canadian ngii-canadian ngo-canadian ngoo-canadian nga-canadian ngaa-canadian ";
+name = Nunavik;
+},
+{
+code = "ng-canadian.nunavik ngai-canadian.nunavik ngaai-canadian.nunavik ngi-canadian.nunavik ngii-canadian.nunavik ngo-canadian.nunavik ngoo-canadian.nunavik nga-canadian.nunavik ngaa-canadian.nunavik ";
+name = Nunavik_alt;
+}
+);
+customParameters = (
+{
+name = vendorID;
+value = GOOG;
+},
+{
+name = panose;
+value = (
+2,
+11,
+5,
+2,
+4,
+5,
+4,
+2,
+2,
+4
+);
+},
+{
+name = unicodeRanges;
+value = (
+0,
+1,
+2,
+5,
+6,
+45,
+77
+);
+},
+{
+name = codePageRanges;
+value = (
+"1252"
+);
+},
+{
+name = fsType;
+value = (
+);
+}
+);
+date = "2022-06-21 10:06:40 +0000";
+familyName = "Sans Canadian Aboriginal";
+featurePrefixes = (
+{
+automatic = 1;
+code = "languagesystem DFLT dflt;
+
+languagesystem cans dflt;
+";
+name = Languagesystems;
+}
+);
+features = (
+{
+automatic = 1;
+code = "feature ss01;
+feature ss02;
+feature ss03;
+feature ss04;
+";
+tag = aalt;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+tag = salt;
+},
+{
+code = "lookup space_can {
+sub space by space.canadian;
+} space_can;
+
+lookup num_can {
+sub @Num by @Num_can;
+} num_can;
+";
+labels = (
+{
+language = dflt;
+value = "CAN Space and numerals";
+}
+);
+tag = ss01;
+},
+{
+code = "lookup dene_square {
+sub @Dene_round by @Dene_square;
+} dene_square;
+
+";
+labels = (
+{
+language = dflt;
+value = "Dene Square";
+}
+);
+tag = ss02;
+},
+{
+code = "lookup nunavik_alt {
+sub @Nunavik by @Nunavik_alt;
+} nunavik_alt;
+
+";
+labels = (
+{
+language = dflt;
+value = "Nunanvik Alt";
+}
+);
+tag = ss03;
+},
+{
+code = "lookup final_mid {
+sub @Final_mid_ori by @Final_mid;
+} final_mid;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final mid";
+}
+);
+tag = ss04;
+},
+{
+code = "lookup final_base {
+sub @Final_base_ori by @Final_base;
+} final_base;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final base";
+}
+);
+tag = ss05;
+},
+{
+code = "lookup plaincree_first {
+sub wiWestCree-canadian' plusFinal-canadian by i-canadian;
+} plaincree_first;
+
+lookup plaincree_second {
+sub i-canadian plusFinal-canadian' by raiseddoubledotFinal-canadian.cree;
+} plaincree_second;
+
+lookup plaincree_third {
+sub middledotFinal-canadian plusFinal-canadian by raiseddoubledotFinal-canadian.cree;
+} plaincree_third;
+";
+labels = (
+{
+language = dflt;
+value = Plaincree;
+}
+);
+tag = ss06;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+labels = (
+{
+language = dflt;
+value = "";
+}
+);
+tag = ss07;
+}
+);
+fontMaster = (
+{
+axesValues = (
+0,
+0,
+0
+);
+customParameters = (
+{
+name = typoAscender;
+value = 1033;
+},
+{
+name = typoDescender;
+value = -283;
+},
+{
+name = typoLineGap;
+value = 0;
+},
+{
+name = winAscent;
+value = 1033;
+},
+{
+name = winDescent;
+value = 283;
+},
+{
+name = hheaAscender;
+value = 1033;
+},
+{
+name = hheaDescender;
+value = -283;
+},
+{
+name = strikeoutPosition;
+value = 283;
+},
+{
+name = strikeoutSize;
+value = 48;
+},
+{
+name = "Master Icon Glyph Name";
+value = s;
+}
+);
+guides = (
+{
+lockAngle = 1;
+locked = 1;
+pos = (747,345);
+},
+{
+locked = 1;
+pos = (-52,-12);
+},
+{
+locked = 1;
+pos = (109,701);
+},
+{
+locked = 1;
+pos = (750,357);
+},
+{
+locked = 1;
+pos = (746,332);
+}
+);
+id = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+metricValues = (
+{
+over = 16;
+pos = 1033;
+},
+{
+over = 16;
+pos = 690;
+},
+{
+over = 16;
+pos = 472;
+},
+{
+over = -16;
+},
+{
+over = -16;
+pos = -283;
+},
+{
+pos = 12;
+}
+);
+name = "RC L Italic";
+stemValues = (
+62
+);
+}
+);
+glyphs = (
+{
+glyphname = idotless;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(86,0,l),
+(196,516,l),
+(134,516,l),
+(25,0,l)
+);
+}
+);
+width = 212;
+}
+);
+note = dotlessi;
+unicode = 305;
+},
+{
+glyphname = "acuteFinal-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(124,345,l),
+(347,690,l),
+(293,690,l),
+(70,345,l)
+);
+}
+);
+width = 297;
+}
+);
+metricRight = "=|";
+note = uni141F;
+unicode = 5151;
+},
+{
+glyphname = "graveFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(274,345,l),
+(192,690,l),
+(144,690,l),
+(225,345,l)
+);
+}
+);
+width = 298;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+unicode = 5152;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(327,339,o),
+(375,387,o),
+(393,470,cs),
+(440,690,l),
+(393,690,l),
+(350,481,ls),
+(334,411,o),
+(302,382,o),
+(242,382,cs),
+(176,382,o),
+(153,419,o),
+(167,488,cs),
+(211,690,l),
+(164,690,l),
+(122,490,ls),
+(102,395,o),
+(146,339,o),
+(240,339,cs)
+);
+}
+);
+width = 410;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1421;
+unicode = 5153;
+},
+{
+glyphname = "ringTophalfFinal-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(137,345,l),
+(181,554,ls),
+(196,624,o),
+(228,653,o),
+(289,653,cs),
+(355,653,o),
+(378,615,o),
+(363,547,cs),
+(320,345,l),
+(366,345,l),
+(409,545,ls),
+(428,639,o),
+(384,696,o),
+(291,696,cs),
+(204,696,o),
+(156,647,o),
+(137,564,cs),
+(91,345,l)
+);
+}
+);
+width = 410;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+unicode = 5154;
+},
+{
+glyphname = "ringRighthalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(157,345,ls),
+(297,345,o),
+(359,449,o),
+(359,557,cs),
+(359,639,o),
+(309,690,o),
+(222,690,cs),
+(161,690,l),
+(152,647,l),
+(217,647,ls),
+(281,647,o),
+(313,613,o),
+(313,555,cs),
+(313,488,o),
+(282,387,o),
+(162,387,cs),
+(98,387,l),
+(88,345,l)
+);
+}
+);
+width = 361;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+unicode = 5155;
+},
+{
+glyphname = "ringFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(397,359,o),
+(469,431,o),
+(469,527,cs),
+(469,624,o),
+(395,696,o),
+(298,696,cs),
+(201,696,o),
+(128,624,o),
+(128,527,cs),
+(128,431,o),
+(200,359,o),
+(298,359,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(223,399,o),
+(172,453,o),
+(172,527,cs),
+(172,602,o),
+(224,655,o),
+(298,655,cs),
+(372,655,o),
+(426,602,o),
+(426,527,cs),
+(426,453,o),
+(373,399,o),
+(298,399,cs)
+);
+}
+);
+width = 472;
+}
+);
+note = uni1424;
+unicode = 5156;
+},
+{
+glyphname = "doubleacuteFinal-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(123,345,l),
+(347,690,l),
+(293,690,l),
+(70,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(254,345,l),
+(477,690,l),
+(424,690,l),
+(201,345,l)
+);
+}
+);
+width = 427;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricRight = "=|";
+note = uni1425;
+unicode = 5157;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:07 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(137,345,l),
+(211,690,l),
+(164,690,l),
+(91,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(255,345,l),
+(328,690,l),
+(282,690,l),
+(209,345,l)
+);
+}
+);
+width = 299;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "pWestCree-canadian";
+note = uni1426;
+unicode = 5158;
+},
+{
+glyphname = "middledotFinal-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(156,311,o),
+(175,330,o),
+(175,355,cs),
+(175,379,o),
+(156,398,o),
+(131,398,cs),
+(107,398,o),
+(89,379,o),
+(89,355,cs),
+(89,330,o),
+(107,311,o),
+(131,311,cs)
+);
+}
+);
+width = 213;
+}
+);
+note = uni1427;
+unicode = 5159;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(431,498,l),
+(440,544,l),
+(131,544,l),
+(122,498,l)
+);
+}
+);
+width = 441;
+}
+);
+metricRight = "=|";
+note = uni1428;
+unicode = 5160;
+},
+{
+glyphname = "plusFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(272,366,l),
+(302,507,l),
+(435,507,l),
+(443,552,l),
+(312,552,l),
+(341,690,l),
+(297,690,l),
+(267,552,l),
+(133,552,l),
+(124,507,l),
+(257,507,l),
+(227,366,l)
+);
+}
+);
+width = 443;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+unicode = 5161;
+},
+{
+glyphname = "downtackFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(269,345,l),
+(332,646,l),
+(464,646,l),
+(473,690,l),
+(163,690,l),
+(154,646,l),
+(287,646,l),
+(222,345,l)
+);
+}
+);
+width = 443;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni142A;
+unicode = 5162;
+},
+{
+glyphname = "thFinalWoodScree-canadian";
+lastChange = "2023-01-13 15:55:07 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(269,345,l),
+(287,430,l),
+(417,430,l),
+(426,469,l),
+(296,469,l),
+(316,565,l),
+(446,565,l),
+(455,605,l),
+(325,605,l),
+(343,690,l),
+(297,690,l),
+(278,605,l),
+(146,605,l),
+(137,565,l),
+(269,565,l),
+(249,469,l),
+(117,469,l),
+(108,430,l),
+(241,430,l),
+(223,345,l)
+);
+}
+);
+width = 444;
+}
+);
+metricLeft = "hyphen-canadian";
+metricRight = "hyphen-canadian";
+note = uni167E;
+unicode = 5758;
+},
+{
+glyphname = "ringSmallFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(296,511,o),
+(340,551,o),
+(340,607,cs),
+(340,663,o),
+(296,702,o),
+(242,702,cs),
+(189,702,o),
+(147,663,o),
+(147,607,cs),
+(147,551,o),
+(189,511,o),
+(242,511,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(205,545,o),
+(182,571,o),
+(182,607,cs),
+(182,642,o),
+(206,669,o),
+(243,669,cs),
+(280,669,o),
+(304,642,o),
+(304,607,cs),
+(304,571,o),
+(280,545,o),
+(243,545,cs)
+);
+}
+);
+width = 328;
+}
+);
+note = g725;
+unicode = 6366;
+},
+{
+glyphname = "raiseddotFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(222,615,o),
+(241,635,o),
+(241,659,cs),
+(241,683,o),
+(222,702,o),
+(198,702,cs),
+(173,702,o),
+(155,683,o),
+(155,659,cs),
+(155,635,o),
+(173,615,o),
+(198,615,cs)
+);
+}
+);
+width = 215;
+}
+);
+note = g725;
+unicode = 6367;
+},
+{
+glyphname = "acuteFinal-canadian.base";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-73,-345);
+ref = "acuteFinal-canadian";
+}
+);
+width = 297;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.base";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-73,-345);
+ref = "graveFinal-canadian";
+}
+);
+width = 297;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian.base";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-74,-345);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 410;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1421;
+},
+{
+glyphname = "ringTophalfFinal-canadian.base";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-74,-345);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 410;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.base";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-74,-345);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 361;
+}
+);
+metricLeft = "==|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "plusFinal-canadian.base";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(194,0,l),
+(224,141,l),
+(356,141,l),
+(366,185,l),
+(234,185,l),
+(264,324,l),
+(218,324,l),
+(189,185,l),
+(56,185,l),
+(46,141,l),
+(180,141,l),
+(150,0,l)
+);
+}
+);
+width = 443;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+},
+{
+glyphname = "acuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-34,-162);
+ref = "acuteFinal-canadian";
+}
+);
+width = 297;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.mid";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-162);
+ref = "graveFinal-canadian";
+}
+);
+width = 297;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringTophalfFinal-canadian.mid";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-37,-172);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 410;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.mid";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-34,-162);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 361;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "ringFinal-canadian.mid";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-39,-183);
+ref = "ringFinal-canadian";
+}
+);
+width = 472;
+}
+);
+metricLeft = "ringFinal-canadian";
+metricWidth = "ringFinal-canadian";
+note = uni1424;
+},
+{
+glyphname = "doubleacuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-34,-162);
+ref = "doubleacuteFinal-canadian";
+}
+);
+width = 427;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "doubleacuteFinal-canadian";
+note = uni1425;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian.mid";
+lastChange = "2023-01-13 15:55:07 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-162);
+ref = "doubleshortverticalstrokesFinal-canadian";
+}
+);
+width = 299;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricWidth = "doubleshortverticalstrokesFinal-canadian";
+note = uni1426;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian.mid";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-167);
+ref = "shorthorizontalstrokeFinal-canadian";
+}
+);
+width = 441;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "shorthorizontalstrokeFinal-canadian";
+note = uni1428;
+},
+{
+glyphname = "downtackFinal-canadian.mid";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-34,-162);
+ref = "downtackFinal-canadian";
+}
+);
+width = 443;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "downtackFinal-canadian";
+note = uni142A;
+},
+{
+glyphname = "e-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (387,454);
+},
+{
+name = top_center_can;
+pos = (439,690);
+},
+{
+name = top_left_can;
+pos = (217,690);
+},
+{
+name = top_right_can;
+pos = (661,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(309,0,l),
+(748,670,l),
+(752,690,l),
+(132,690,l),
+(128,670,l),
+(281,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(318,69,l),
+(191,654,l),
+(179,638,l),
+(682,638,l),
+(668,654,l),
+(295,69,l)
+);
+}
+);
+width = 691;
+}
+);
+metricRight = "=|";
+note = uni1401;
+unicode = 5121;
+},
+{
+glyphname = "aai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (226,0);
+ref = ring_top.canadian;
+}
+);
+width = 691;
+}
+);
+note = uni1402;
+unicode = 5122;
+},
+{
+glyphname = "i-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (385,403);
+},
+{
+name = top_center_can;
+pos = (442,690);
+},
+{
+name = top_left_can;
+pos = (219,690);
+},
+{
+name = top_right_can;
+pos = (663,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(428,690,l),
+(-11,19,l),
+(-14,0,l),
+(605,0,l),
+(610,19,l),
+(456,690,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(419,621,l),
+(546,36,l),
+(558,52,l),
+(55,52,l),
+(69,36,l),
+(442,621,l)
+);
+}
+);
+width = 691;
+}
+);
+metricLeft = "e-canadian";
+metricWidth = "e-canadian";
+note = uni1403;
+unicode = 5123;
+},
+{
+glyphname = "ii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (283,0);
+ref = dot_top;
+}
+);
+width = 691;
+}
+);
+note = uni1404;
+unicode = 5124;
+},
+{
+glyphname = "o-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (294,350);
+},
+{
+name = top_center_can;
+pos = (451,690);
+},
+{
+name = top_double;
+pos = (536,690);
+},
+{
+name = top_left_can;
+pos = (205,690);
+},
+{
+name = top_right_can;
+pos = (690,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(49,0,l),
+(649,331,l),
+(655,358,l),
+(196,690,l),
+(177,690,l),
+(30,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(217,626,l),
+(197,626,l),
+(589,342,l),
+(592,358,l),
+(80,74,l),
+(99,68,l)
+);
+}
+);
+width = 665;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1405;
+unicode = 5125;
+},
+{
+glyphname = "oo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (46,0);
+ref = dot_top;
+}
+);
+width = 665;
+}
+);
+note = uni1406;
+unicode = 5126;
+},
+{
+glyphname = "yCreeoo-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (221,0);
+ref = doubledot_top;
+}
+);
+width = 665;
+}
+);
+note = uni1407;
+unicode = 5127;
+},
+{
+glyphname = "eeCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(49,0,l),
+(648,330,l),
+(655,358,l),
+(196,690,l),
+(177,690,l),
+(30,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(216,626,l),
+(200,624,l),
+(590,342,l),
+(594,359,l),
+(83,76,l),
+(97,68,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(287,255,l),
+(327,441,l),
+(297,441,l),
+(257,255,l)
+);
+}
+);
+width = 665;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "o-canadian";
+note = uni1408;
+unicode = 5128;
+},
+{
+glyphname = "iCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (217,5);
+ref = dot_middle_optic_small;
+}
+);
+width = 665;
+}
+);
+note = uni1409;
+unicode = 5129;
+},
+{
+glyphname = "a-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:07 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (409,343);
+},
+{
+name = top_center_can;
+pos = (404,690);
+},
+{
+name = top_left_can;
+pos = (161,690);
+},
+{
+name = top_right_can;
+pos = (654,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(662,690,l),
+(63,358,l),
+(57,331,l),
+(515,0,l),
+(534,0,l),
+(681,690,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(495,64,l),
+(515,64,l),
+(123,348,l),
+(119,331,l),
+(632,615,l),
+(612,622,l)
+);
+}
+);
+width = 664;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni140A;
+unicode = 5130;
+},
+{
+glyphname = "aa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (496,0);
+ref = dot_top;
+}
+);
+width = 665;
+}
+);
+note = uni140B;
+unicode = 5131;
+},
+{
+glyphname = "we-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "e-canadian";
+}
+);
+width = 903;
+}
+);
+note = uni140C;
+unicode = 5132;
+},
+{
+glyphname = "weWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (691,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 903;
+}
+);
+note = uni140D;
+unicode = 5133;
+},
+{
+glyphname = "wi-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "i-canadian";
+}
+);
+width = 903;
+}
+);
+note = uni140E;
+unicode = 5134;
+},
+{
+glyphname = "wiWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (691,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 903;
+}
+);
+note = uni140F;
+unicode = 5135;
+},
+{
+glyphname = "wii-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (497,0);
+ref = dot_top;
+}
+);
+width = 903;
+}
+);
+note = uni1410;
+unicode = 5136;
+},
+{
+glyphname = "wiiWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (283,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (691,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 903;
+}
+);
+note = uni1411;
+unicode = 5137;
+},
+{
+glyphname = "wo-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "o-canadian";
+}
+);
+width = 878;
+}
+);
+note = uni1412;
+unicode = 5138;
+},
+{
+glyphname = "woWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (665,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 878;
+}
+);
+note = uni1413;
+unicode = 5139;
+},
+{
+glyphname = "woo-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (505,0);
+ref = dot_top;
+}
+);
+width = 878;
+}
+);
+note = uni1414;
+unicode = 5140;
+},
+{
+glyphname = "wooWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (46,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (665,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 878;
+}
+);
+note = uni1415;
+unicode = 5141;
+},
+{
+glyphname = "wooNaskapi-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (189,-96);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (338,-202);
+ref = dot_top;
+}
+);
+width = 665;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricWidth = "o-canadian";
+note = uni1416;
+unicode = 5142;
+},
+{
+glyphname = "wa-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "a-canadian";
+}
+);
+width = 878;
+}
+);
+note = uni1417;
+unicode = 5143;
+},
+{
+glyphname = "waWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (665,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 878;
+}
+);
+note = uni1418;
+unicode = 5144;
+},
+{
+glyphname = "waa-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (708,0);
+ref = dot_top;
+}
+);
+width = 878;
+}
+);
+note = uni1419;
+unicode = 5145;
+},
+{
+glyphname = "waaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (496,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (665,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 878;
+}
+);
+note = uni141A;
+unicode = 5146;
+},
+{
+glyphname = "waaNaskapi-canadian";
+lastChange = "2023-01-13 15:55:07 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (139,-201);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (327,-96);
+ref = dot_top;
+}
+);
+width = 664;
+}
+);
+metricWidth = "a-canadian";
+note = uni141B;
+unicode = 5147;
+},
+{
+glyphname = "ai-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(293,339,o),
+(335,371,o),
+(360,436,c),
+(346,439,l),
+(347,374,o),
+(383,339,o),
+(452,339,cs),
+(536,339,o),
+(582,385,o),
+(604,487,cs),
+(647,690,l),
+(603,690,l),
+(560,487,ls),
+(545,412,o),
+(513,380,o),
+(453,380,cs),
+(391,380,o),
+(369,414,o),
+(384,486,cs),
+(428,690,l),
+(384,690,l),
+(341,489,ls),
+(326,413,o),
+(292,380,o),
+(234,380,cs),
+(175,380,o),
+(150,416,o),
+(164,484,cs),
+(209,690,l),
+(164,690,l),
+(121,486,ls),
+(102,396,o),
+(144,339,o),
+(230,339,cs)
+);
+}
+);
+width = 618;
+}
+);
+metricRight = "=|";
+note = uni141C;
+unicode = 5148;
+},
+{
+glyphname = "ycreew-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(419,510,o),
+(455,549,o),
+(455,603,cs),
+(455,658,o),
+(420,696,o),
+(372,696,cs),
+(325,696,o),
+(288,658,o),
+(288,603,cs),
+(288,549,o),
+(324,510,o),
+(372,510,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(242,339,o),
+(278,378,o),
+(278,432,cs),
+(278,487,o),
+(242,525,o),
+(194,525,cs),
+(147,525,o),
+(110,487,o),
+(110,432,cs),
+(110,378,o),
+(146,339,o),
+(194,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(162,367,o),
+(140,393,o),
+(140,432,cs),
+(140,470,o),
+(162,497,o),
+(194,497,cs),
+(226,497,o),
+(248,470,o),
+(248,432,cs),
+(248,393,o),
+(226,367,o),
+(194,367,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(339,538,o),
+(318,564,o),
+(318,603,cs),
+(318,641,o),
+(340,668,o),
+(372,668,cs),
+(404,668,o),
+(425,641,o),
+(425,603,cs),
+(425,564,o),
+(404,538,o),
+(372,538,cs)
+);
+}
+);
+width = 446;
+}
+);
+metricRight = "=|";
+note = uni141D;
+unicode = 5149;
+},
+{
+glyphname = "glottalstop-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(394,345,l),
+(397,356,l),
+(321,690,l),
+(305,690,l),
+(87,356,l),
+(84,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(320,648,l),
+(294,649,l),
+(356,363,l),
+(369,381,l),
+(126,381,l),
+(135,363,l)
+);
+}
+);
+width = 432;
+}
+);
+metricRight = "=|";
+note = uni141E;
+unicode = 5150;
+},
+{
+glyphname = "en-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+pos = (691,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 986;
+}
+);
+note = uni142B;
+unicode = 5163;
+},
+{
+glyphname = "in-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+pos = (481,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 779;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142C;
+unicode = 5164;
+},
+{
+glyphname = "on-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (528,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 825;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142D;
+unicode = 5165;
+},
+{
+glyphname = "an-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (619,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 916;
+}
+);
+metricRight = "graveFinal-canadian";
+note = uni142E;
+unicode = 5166;
+},
+{
+glyphname = "pe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (387,454);
+},
+{
+name = top_center_can;
+pos = (441,690);
+},
+{
+name = top_left_can;
+pos = (217,690);
+},
+{
+name = top_right_can;
+pos = (661,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(309,0,l),
+(748,670,l),
+(752,690,l),
+(688,690,l),
+(289,71,l),
+(323,71,l),
+(186,690,l),
+(132,690,l),
+(128,670,l),
+(281,0,l)
+);
+}
+);
+width = 691;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni142F;
+unicode = 5167;
+},
+{
+glyphname = "paai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (226,0);
+ref = ring_top.canadian;
+}
+);
+width = 691;
+}
+);
+note = uni1430;
+unicode = 5168;
+},
+{
+glyphname = "pi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (385,403);
+},
+{
+name = top_center_can;
+pos = (442,690);
+},
+{
+name = top_left_can;
+pos = (217,690);
+},
+{
+name = top_right_can;
+pos = (661,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(428,690,l),
+(-11,19,l),
+(-14,0,l),
+(49,0,l),
+(448,619,l),
+(414,619,l),
+(551,0,l),
+(605,0,l),
+(610,19,l),
+(456,690,l)
+);
+}
+);
+width = 691;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni1431;
+unicode = 5169;
+},
+{
+glyphname = "pii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (284,0);
+ref = dot_top;
+}
+);
+width = 691;
+}
+);
+note = uni1432;
+unicode = 5170;
+},
+{
+glyphname = "po-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (245,352);
+},
+{
+name = top_center_can;
+pos = (424,690);
+},
+{
+name = top_double;
+pos = (515,690);
+},
+{
+name = top_left_can;
+pos = (182,690);
+},
+{
+name = top_right_can;
+pos = (660,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+name = "Thin Slanted";
+shapes = (
+{
+closed = 1;
+nodes = (
+(26,0,l),
+(619,331,l),
+(625,358,l),
+(173,690,l),
+(154,690,l),
+(143,639,l),
+(555,337,l),
+(562,365,l),
+(20,63,l),
+(8,0,l)
+);
+}
+);
+width = 635;
+}
+);
+metricRight = "o-canadian";
+note = uni1433;
+unicode = 5171;
+},
+{
+glyphname = "poo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (23,0);
+ref = dot_top;
+}
+);
+width = 636;
+}
+);
+note = uni1434;
+unicode = 5172;
+},
+{
+glyphname = "ycreepoo-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (200,0);
+ref = doubledot_top;
+}
+);
+width = 636;
+}
+);
+note = uni1435;
+unicode = 5173;
+},
+{
+glyphname = "heeCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (185,7);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 636;
+}
+);
+note = uni1436;
+unicode = 5174;
+},
+{
+glyphname = "hiCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (165,9);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 636;
+}
+);
+note = uni1437;
+unicode = 5175;
+},
+{
+glyphname = "pa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (304,345);
+},
+{
+name = top_center_can;
+pos = (405,690);
+},
+{
+name = top_left_can;
+pos = (162,690);
+},
+{
+name = top_right_can;
+pos = (646,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(655,690,l),
+(63,358,l),
+(57,331,l),
+(508,0,l),
+(527,0,l),
+(538,50,l),
+(126,353,l),
+(120,325,l),
+(661,627,l),
+(674,690,l)
+);
+}
+);
+width = 635;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1438;
+unicode = 5176;
+},
+{
+glyphname = "paa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (488,0);
+ref = dot_top;
+}
+);
+width = 636;
+}
+);
+note = uni1439;
+unicode = 5177;
+},
+{
+glyphname = "pwe-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "pe-canadian";
+}
+);
+width = 903;
+}
+);
+note = uni143A;
+unicode = 5178;
+},
+{
+glyphname = "pweWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "pe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (691,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 903;
+}
+);
+note = uni143B;
+unicode = 5179;
+},
+{
+glyphname = "pwi-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "pi-canadian";
+}
+);
+width = 903;
+}
+);
+note = uni143C;
+unicode = 5180;
+},
+{
+glyphname = "pwiWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (691,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 903;
+}
+);
+note = uni143D;
+unicode = 5181;
+},
+{
+glyphname = "pwii-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (497,0);
+ref = dot_top;
+}
+);
+width = 903;
+}
+);
+note = uni143E;
+unicode = 5182;
+},
+{
+glyphname = "pwiiWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (284,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (691,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 903;
+}
+);
+note = uni143F;
+unicode = 5183;
+},
+{
+glyphname = "pwo-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "po-canadian";
+}
+);
+width = 848;
+}
+);
+note = uni1440;
+unicode = 5184;
+},
+{
+glyphname = "pwoWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (636,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 848;
+}
+);
+note = uni1441;
+unicode = 5185;
+},
+{
+glyphname = "pwoo-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (478,0);
+ref = dot_top;
+}
+);
+width = 848;
+}
+);
+note = uni1442;
+unicode = 5186;
+},
+{
+glyphname = "pwooWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (23,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (636,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 848;
+}
+);
+note = uni1443;
+unicode = 5187;
+},
+{
+glyphname = "pwa-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "pa-canadian";
+}
+);
+width = 848;
+}
+);
+note = uni1444;
+unicode = 5188;
+},
+{
+glyphname = "pwaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (636,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 848;
+}
+);
+note = uni1445;
+unicode = 5189;
+},
+{
+glyphname = "pwaa-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (700,0);
+ref = dot_top;
+}
+);
+width = 848;
+}
+);
+note = uni1446;
+unicode = 5190;
+},
+{
+glyphname = "pwaaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (488,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (636,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 848;
+}
+);
+note = uni1447;
+unicode = 5191;
+},
+{
+glyphname = "ycreepwaa-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+pos = (136,-201);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (325,-96);
+ref = dot_top;
+}
+);
+width = 635;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1448;
+unicode = 5192;
+},
+{
+glyphname = "p-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(360,345,l),
+(368,382,l),
+(169,529,l),
+(162,497,l),
+(424,644,l),
+(434,690,l),
+(421,690,l),
+(129,526,l),
+(126,509,l),
+(348,345,l)
+);
+}
+);
+width = 405;
+}
+);
+note = uni1449;
+unicode = 5193;
+},
+{
+glyphname = "pWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(137,345,l),
+(211,690,l),
+(164,690,l),
+(91,345,l)
+);
+}
+);
+width = 181;
+}
+);
+metricRight = "=|";
+note = uni144A;
+unicode = 5194;
+},
+{
+color = 6;
+glyphname = "hCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(102,183,l),
+(131,320,ls),
+(141,366,o),
+(171,392,o),
+(211,392,cs),
+(255,392,o),
+(273,364,o),
+(263,315,cs),
+(235,183,l),
+(280,183,l),
+(310,321,ls),
+(325,390,o),
+(289,434,o),
+(225,434,cs),
+(179,434,o),
+(138,406,o),
+(127,366,c),
+(140,361,l),
+(176,527,l),
+(129,527,l),
+(56,183,l)
+);
+}
+);
+width = 338;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144B;
+unicode = 5195;
+},
+{
+glyphname = "te-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (367,345);
+},
+{
+name = top_center_can;
+pos = (440,690);
+},
+{
+name = top_left_can;
+pos = (201,690);
+},
+{
+name = top_right_can;
+pos = (681,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(485,-13,o),
+(582,79,o),
+(622,266,cs),
+(712,690,l),
+(650,690,l),
+(561,270,ls),
+(528,115,o),
+(453,45,o),
+(322,45,cs),
+(171,45,o),
+(111,126,o),
+(147,291,cs),
+(232,690,l),
+(170,690,l),
+(86,294,ls),
+(43,97,o),
+(132,-13,o),
+(318,-13,cs)
+);
+}
+);
+width = 689;
+}
+);
+metricRight = "=|";
+note = uni144C;
+unicode = 5196;
+},
+{
+glyphname = "taai-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (225,0);
+ref = ring_top.canadian;
+}
+);
+width = 689;
+}
+);
+note = uni144D;
+unicode = 5197;
+},
+{
+glyphname = "ti-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (367,345);
+},
+{
+name = middle_right_can;
+pos = (797,345);
+},
+{
+name = top_center_can;
+pos = (440,690);
+},
+{
+name = top_left_can;
+pos = (201,690);
+},
+{
+name = top_right_can;
+pos = (681,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(85,0,l),
+(174,420,ls),
+(207,575,o),
+(283,644,o),
+(413,644,cs),
+(564,644,o),
+(624,564,o),
+(588,399,cs),
+(503,0,l),
+(565,0,l),
+(649,396,ls),
+(692,593,o),
+(603,702,o),
+(417,702,cs),
+(250,702,o),
+(154,611,o),
+(113,424,cs),
+(23,0,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni144E;
+unicode = 5198;
+},
+{
+glyphname = "tii-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (282,0);
+ref = dot_top;
+}
+);
+width = 689;
+}
+);
+note = uni144F;
+unicode = 5199;
+},
+{
+glyphname = "to-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (282,345);
+},
+{
+name = middle_right_can;
+pos = (700,345);
+},
+{
+name = top_center_can;
+pos = (360,690);
+},
+{
+name = top_double;
+pos = (415,690);
+},
+{
+name = top_left_can;
+pos = (184,690);
+},
+{
+name = top_right_can;
+pos = (588,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(157,0,ls),
+(467,0,o),
+(550,263,o),
+(550,434,cs),
+(550,596,o),
+(456,690,o),
+(288,690,cs),
+(156,690,l),
+(144,634,l),
+(279,634,ls),
+(416,634,o),
+(488,563,o),
+(488,432,cs),
+(488,289,o),
+(422,56,o),
+(164,56,cs),
+(21,56,l),
+(9,0,l)
+);
+}
+);
+width = 585;
+}
+);
+note = uni1450;
+unicode = 5200;
+},
+{
+glyphname = "too-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (202,0);
+ref = dot_top;
+}
+);
+width = 585;
+}
+);
+note = uni1451;
+unicode = 5201;
+},
+{
+glyphname = "ycreetoo-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (99,0);
+ref = doubledot_top;
+}
+);
+width = 585;
+}
+);
+note = uni1452;
+unicode = 5202;
+},
+{
+glyphname = "deeCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (219,0);
+ref = stroke_middle;
+}
+);
+width = 585;
+}
+);
+note = uni1453;
+unicode = 5203;
+},
+{
+glyphname = "diCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (197,0);
+ref = dot_middle;
+}
+);
+width = 585;
+}
+);
+note = uni1454;
+unicode = 5204;
+},
+{
+glyphname = "ta-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (350,345);
+},
+{
+name = top_center_can;
+pos = (418,690);
+},
+{
+name = top_left_can;
+pos = (189,690);
+},
+{
+name = top_right_can;
+pos = (594,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(476,0,l),
+(488,56,l),
+(352,56,ls),
+(214,56,o),
+(144,127,o),
+(144,258,cs),
+(144,403,o),
+(210,634,o),
+(467,634,cs),
+(611,634,l),
+(623,690,l),
+(472,690,ls),
+(165,690,o),
+(82,428,o),
+(82,256,cs),
+(82,94,o),
+(175,0,o),
+(343,0,cs)
+);
+}
+);
+width = 585;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|to-canadian";
+note = uni1455;
+unicode = 5205;
+},
+{
+glyphname = "taa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (260,0);
+ref = dot_top;
+}
+);
+width = 585;
+}
+);
+note = uni1456;
+unicode = 5206;
+},
+{
+glyphname = "twe-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "te-canadian";
+}
+);
+width = 901;
+}
+);
+note = uni1457;
+unicode = 5207;
+},
+{
+glyphname = "tweWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (689,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 901;
+}
+);
+note = uni1458;
+unicode = 5208;
+},
+{
+glyphname = "twi-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ti-canadian";
+}
+);
+width = 901;
+}
+);
+note = uni1459;
+unicode = 5209;
+},
+{
+glyphname = "twiWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (689,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 901;
+}
+);
+note = uni145A;
+unicode = 5210;
+},
+{
+glyphname = "twii-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (495,0);
+ref = dot_top;
+}
+);
+width = 901;
+}
+);
+note = uni145B;
+unicode = 5211;
+},
+{
+glyphname = "twiiWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (282,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (689,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 901;
+}
+);
+note = uni145C;
+unicode = 5212;
+},
+{
+glyphname = "two-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "to-canadian";
+}
+);
+width = 798;
+}
+);
+note = uni145D;
+unicode = 5213;
+},
+{
+glyphname = "twoWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (585,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 798;
+}
+);
+note = uni145E;
+unicode = 5214;
+},
+{
+glyphname = "twoo-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (414,0);
+ref = dot_top;
+}
+);
+width = 798;
+}
+);
+note = uni145F;
+unicode = 5215;
+},
+{
+glyphname = "twooWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (202,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (585,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 798;
+}
+);
+note = uni1460;
+unicode = 5216;
+},
+{
+glyphname = "twa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ta-canadian";
+}
+);
+width = 798;
+}
+);
+note = uni1461;
+unicode = 5217;
+},
+{
+glyphname = "twaWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (585,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 798;
+}
+);
+note = uni1462;
+unicode = 5218;
+},
+{
+glyphname = "twaa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (472,0);
+ref = dot_top;
+}
+);
+width = 798;
+}
+);
+note = uni1463;
+unicode = 5219;
+},
+{
+glyphname = "twaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (260,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (585,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 798;
+}
+);
+note = uni1464;
+unicode = 5220;
+},
+{
+glyphname = "twaaNaskapi-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ta-canadian";
+}
+);
+width = 799;
+}
+);
+note = uni1465;
+unicode = 5221;
+},
+{
+glyphname = "t-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(320,345,l),
+(329,387,l),
+(264,387,ls),
+(200,387,o),
+(168,421,o),
+(168,479,cs),
+(168,552,o),
+(201,647,o),
+(319,647,cs),
+(384,647,l),
+(393,690,l),
+(325,690,ls),
+(186,690,o),
+(122,588,o),
+(122,477,cs),
+(122,395,o),
+(172,345,o),
+(259,345,cs)
+);
+}
+);
+width = 361;
+}
+);
+note = uni1466;
+unicode = 5222;
+},
+{
+glyphname = "tte-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+pos = (689,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 869;
+}
+);
+note = uni1467;
+unicode = 5223;
+},
+{
+glyphname = "tti-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+pos = (689,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 869;
+}
+);
+note = uni1468;
+unicode = 5224;
+},
+{
+glyphname = "tto-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+pos = (585,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 767;
+}
+);
+note = uni1469;
+unicode = 5225;
+},
+{
+glyphname = "tta-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+pos = (585,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 767;
+}
+);
+note = uni146A;
+unicode = 5226;
+},
+{
+glyphname = "ke-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (344,441);
+},
+{
+name = top_center_can;
+pos = (376,690);
+},
+{
+name = top_left_can;
+pos = (192,690);
+},
+{
+name = top_right_can;
+pos = (554,692);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(444,0,l),
+(534,421,ls),
+(563,559,o),
+(520,702,o),
+(356,702,cs),
+(180,702,o),
+(111,527,o),
+(111,401,cs),
+(111,281,o),
+(182,206,o),
+(292,206,cs),
+(373,206,o),
+(435,249,o),
+(467,327,c),
+(455,341,l),
+(383,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(220,259,o),
+(171,313,o),
+(171,402,cs),
+(171,493,o),
+(217,648,o),
+(352,648,cs),
+(435,648,o),
+(483,594,o),
+(483,504,cs),
+(483,412,o),
+(437,259,o),
+(303,259,cs)
+);
+}
+);
+width = 568;
+}
+);
+metricRight = "te-canadian";
+note = uni146B;
+unicode = 5227;
+},
+{
+glyphname = "kaai-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (162,0);
+ref = ring_top.canadian;
+}
+);
+width = 568;
+}
+);
+note = uni146C;
+unicode = 5228;
+},
+{
+glyphname = "ki-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (351,441);
+},
+{
+name = top_center_can;
+pos = (379,690);
+},
+{
+name = top_left_can;
+pos = (201,690);
+},
+{
+name = top_right_can;
+pos = (566,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(85,0,l),
+(161,361,l),
+(151,356,l),
+(146,277,o),
+(210,206,o),
+(310,206,cs),
+(483,206,o),
+(549,383,o),
+(549,504,cs),
+(549,627,o),
+(477,702,o),
+(360,702,cs),
+(241,702,o),
+(156,623,o),
+(126,482,cs),
+(23,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(225,259,o),
+(177,313,o),
+(177,403,cs),
+(177,492,o),
+(222,648,o),
+(356,648,cs),
+(440,648,o),
+(489,595,o),
+(489,505,cs),
+(489,415,o),
+(442,259,o),
+(309,259,cs)
+);
+}
+);
+width = 568;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni146D;
+unicode = 5229;
+},
+{
+glyphname = "kii-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (219,0);
+ref = dot_top;
+}
+);
+width = 568;
+}
+);
+note = uni146E;
+unicode = 5230;
+},
+{
+glyphname = "ko-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (337,397);
+},
+{
+name = top_center_can;
+pos = (378,690);
+},
+{
+name = top_double;
+pos = (560,690);
+},
+{
+name = top_left_can;
+pos = (195,690);
+},
+{
+name = top_right_can;
+pos = (560,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(376,-13,o),
+(460,67,o),
+(490,208,cs),
+(592,690,l),
+(530,690,l),
+(453,328,l),
+(464,333,l),
+(469,412,o),
+(406,484,o),
+(304,484,cs),
+(130,484,o),
+(66,305,o),
+(66,185,cs),
+(66,63,o),
+(137,-13,o),
+(256,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(175,42,o),
+(126,95,o),
+(126,185,cs),
+(126,274,o),
+(173,430,o),
+(306,430,cs),
+(389,430,o),
+(438,377,o),
+(438,287,cs),
+(438,196,o),
+(393,42,o),
+(258,42,cs)
+);
+}
+);
+width = 569;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni146F;
+unicode = 5231;
+},
+{
+glyphname = "koo-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (401,0);
+ref = dot_top;
+}
+);
+width = 568;
+}
+);
+note = uni1470;
+unicode = 5232;
+},
+{
+glyphname = "ycreekoo-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (244,0);
+ref = doubledot_top;
+}
+);
+width = 568;
+}
+);
+note = uni1471;
+unicode = 5233;
+},
+{
+glyphname = "ka-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (341,398);
+},
+{
+name = top_center_can;
+pos = (383,690);
+},
+{
+name = top_left_can;
+pos = (201,690);
+},
+{
+name = top_right_can;
+pos = (566,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(434,-13,o),
+(503,162,o),
+(503,289,cs),
+(503,409,o),
+(433,484,o),
+(323,484,cs),
+(242,484,o),
+(181,440,o),
+(148,363,c),
+(159,349,l),
+(232,690,l),
+(170,690,l),
+(80,269,ls),
+(44,98,o),
+(119,-13,o),
+(260,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(180,42,o),
+(131,96,o),
+(131,185,cs),
+(131,278,o),
+(178,431,o),
+(311,431,cs),
+(394,431,o),
+(442,377,o),
+(442,288,cs),
+(442,197,o),
+(397,42,o),
+(263,42,cs)
+);
+}
+);
+width = 568;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "==|ke-canadian";
+note = uni1472;
+unicode = 5234;
+},
+{
+glyphname = "kaa-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (42,0);
+ref = dot_top;
+}
+);
+width = 568;
+}
+);
+note = uni1473;
+unicode = 5235;
+},
+{
+glyphname = "kwe-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ke-canadian";
+}
+);
+width = 781;
+}
+);
+note = uni1474;
+unicode = 5236;
+},
+{
+glyphname = "kweWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (568,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 781;
+}
+);
+note = uni1475;
+unicode = 5237;
+},
+{
+glyphname = "kwi-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ki-canadian";
+}
+);
+width = 781;
+}
+);
+note = uni1476;
+unicode = 5238;
+},
+{
+glyphname = "kwiWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (568,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 781;
+}
+);
+note = uni1477;
+unicode = 5239;
+},
+{
+glyphname = "kwii-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (433,0);
+ref = dot_top;
+}
+);
+width = 781;
+}
+);
+note = uni1478;
+unicode = 5240;
+},
+{
+glyphname = "kwiiWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (219,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (568,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 781;
+}
+);
+note = uni1479;
+unicode = 5241;
+},
+{
+glyphname = "kwo-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ko-canadian";
+}
+);
+width = 781;
+}
+);
+note = uni147A;
+unicode = 5242;
+},
+{
+glyphname = "kwoWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (568,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 781;
+}
+);
+note = uni147B;
+unicode = 5243;
+},
+{
+glyphname = "kwoo-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (613,0);
+ref = dot_top;
+}
+);
+width = 781;
+}
+);
+note = uni147C;
+unicode = 5244;
+},
+{
+glyphname = "kwooWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (401,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (568,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 781;
+}
+);
+note = uni147D;
+unicode = 5245;
+},
+{
+glyphname = "kwa-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ka-canadian";
+}
+);
+width = 781;
+}
+);
+note = uni147E;
+unicode = 5246;
+},
+{
+glyphname = "kwaWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (568,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 781;
+}
+);
+note = uni147F;
+unicode = 5247;
+},
+{
+glyphname = "kwaa-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (254,0);
+ref = dot_top;
+}
+);
+width = 781;
+}
+);
+note = uni1480;
+unicode = 5248;
+},
+{
+glyphname = "kwaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (42,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (568,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 781;
+}
+);
+note = uni1481;
+unicode = 5249;
+},
+{
+glyphname = "kwaaNaskapi-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ka-canadian";
+}
+);
+width = 781;
+}
+);
+note = uni1482;
+unicode = 5250;
+},
+{
+glyphname = "k-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(308,339,o),
+(355,427,o),
+(355,499,cs),
+(355,560,o),
+(318,601,o),
+(261,601,cs),
+(213,601,o),
+(177,571,o),
+(159,526,c),
+(175,524,l),
+(211,690,l),
+(164,690,l),
+(121,486,ls),
+(105,415,o),
+(128,339,o),
+(219,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(183,376,o),
+(158,402,o),
+(158,444,cs),
+(158,495,o),
+(189,564,o),
+(249,564,cs),
+(289,564,o),
+(313,539,o),
+(313,497,cs),
+(313,445,o),
+(282,376,o),
+(221,376,cs)
+);
+}
+);
+width = 361;
+}
+);
+note = uni1483;
+unicode = 5251;
+},
+{
+glyphname = "kw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(277,339,o),
+(325,382,o),
+(341,463,cs),
+(390,690,l),
+(344,690,l),
+(307,520,l),
+(321,520,l),
+(321,566,o),
+(286,601,o),
+(235,601,cs),
+(151,601,o),
+(106,513,o),
+(106,443,cs),
+(106,381,o),
+(146,339,o),
+(211,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(172,376,o),
+(148,401,o),
+(148,443,cs),
+(148,494,o),
+(178,564,o),
+(239,564,cs),
+(277,564,o),
+(302,538,o),
+(302,496,cs),
+(302,447,o),
+(273,376,o),
+(211,376,cs)
+);
+}
+);
+width = 360;
+}
+);
+metricLeft = "=|k-canadian";
+metricRight = "=|k-canadian";
+note = uni1484;
+unicode = 5252;
+},
+{
+glyphname = "southslaveykeh-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+pos = (568,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 749;
+}
+);
+note = uni1485;
+unicode = 5253;
+},
+{
+glyphname = "southslaveykih-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+pos = (568,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 749;
+}
+);
+note = uni1486;
+unicode = 5254;
+},
+{
+glyphname = "southslaveykoh-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+pos = (568,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 749;
+}
+);
+note = uni1487;
+unicode = 5255;
+},
+{
+glyphname = "southslaveykah-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+pos = (568,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 749;
+}
+);
+note = uni1488;
+unicode = 5256;
+},
+{
+glyphname = "ce-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (339,419);
+},
+{
+name = top_center_can;
+pos = (378,690);
+},
+{
+name = top_left_can;
+pos = (195,690);
+},
+{
+name = top_right_can;
+pos = (557,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(441,0,l),
+(535,440,ls),
+(568,596,o),
+(497,702,o),
+(355,702,cs),
+(227,702,o),
+(152,626,o),
+(118,469,cs),
+(100,391,l),
+(162,391,l),
+(178,467,ls),
+(204,591,o),
+(260,647,o),
+(351,647,cs),
+(458,647,o),
+(500,571,o),
+(474,448,cs),
+(380,0,l)
+);
+}
+);
+width = 565;
+}
+);
+metricRight = "te-canadian";
+note = uni1489;
+unicode = 5257;
+},
+{
+glyphname = "caai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (167,0);
+ref = ring_top.canadian;
+}
+);
+width = 564;
+}
+);
+note = uni148A;
+unicode = 5258;
+},
+{
+glyphname = "ci-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (342,419);
+},
+{
+name = top_center_can;
+pos = (384,690);
+},
+{
+name = top_left_can;
+pos = (201,690);
+},
+{
+name = top_right_can;
+pos = (564,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(85,0,l),
+(184,467,ls),
+(210,591,o),
+(265,647,o),
+(356,647,cs),
+(465,647,o),
+(506,571,o),
+(480,448,cs),
+(469,391,l),
+(529,391,l),
+(540,440,ls),
+(575,596,o),
+(503,702,o),
+(361,702,cs),
+(233,702,o),
+(156,626,o),
+(123,469,cs),
+(23,0,l)
+);
+}
+);
+width = 564;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+unicode = 5259;
+},
+{
+glyphname = "cii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (226,0);
+ref = dot_top;
+}
+);
+width = 564;
+}
+);
+note = uni148C;
+unicode = 5260;
+},
+{
+glyphname = "co-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (339,419);
+},
+{
+name = top_center_can;
+pos = (376,690);
+},
+{
+name = top_double;
+pos = (556,690);
+},
+{
+name = top_left_can;
+pos = (194,690);
+},
+{
+name = top_right_can;
+pos = (556,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(377,-13,o),
+(453,64,o),
+(487,220,cs),
+(587,690,l),
+(525,690,l),
+(426,223,ls),
+(400,99,o),
+(345,43,o),
+(253,43,cs),
+(145,43,o),
+(104,119,o),
+(129,242,cs),
+(141,298,l),
+(80,298,l),
+(70,249,ls),
+(36,94,o),
+(106,-13,o),
+(248,-13,cs)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+unicode = 5261;
+},
+{
+glyphname = "coo-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (399,0);
+ref = dot_top;
+}
+);
+width = 564;
+}
+);
+note = uni148E;
+unicode = 5262;
+},
+{
+glyphname = "ycreecoo-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (242,0);
+ref = doubledot_top;
+}
+);
+width = 564;
+}
+);
+note = uni148F;
+unicode = 5263;
+},
+{
+glyphname = "ca-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (343,419);
+},
+{
+name = top_center_can;
+pos = (384,690);
+},
+{
+name = top_left_can;
+pos = (201,690);
+},
+{
+name = top_right_can;
+pos = (562,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(384,-13,o),
+(459,64,o),
+(493,220,cs),
+(509,298,l),
+(448,298,l),
+(433,223,ls),
+(406,99,o),
+(352,43,o),
+(260,43,cs),
+(153,43,o),
+(110,119,o),
+(136,242,cs),
+(232,690,l),
+(170,690,l),
+(76,249,ls),
+(43,94,o),
+(113,-13,o),
+(255,-13,cs)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+unicode = 5264;
+},
+{
+glyphname = "caa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (43,0);
+ref = dot_top;
+}
+);
+width = 564;
+}
+);
+note = uni1491;
+unicode = 5265;
+},
+{
+glyphname = "cwe-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ce-canadian";
+}
+);
+width = 777;
+}
+);
+note = uni1492;
+unicode = 5266;
+},
+{
+glyphname = "cweWestCree-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (564,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 777;
+}
+);
+note = uni1493;
+unicode = 5267;
+},
+{
+glyphname = "cwi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+pos = (213,0);
+ref = "ci-canadian";
+}
+);
+width = 777;
+}
+);
+note = uni1494;
+unicode = 5268;
+},
+{
+glyphname = "cwiWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "ci-canadian";
+},
+{
+anchor = middle_right_can;
+pos = (564,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 777;
+}
+);
+note = uni1495;
+unicode = 5269;
+},
+{
+glyphname = "cwii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+pos = (213,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (439,0);
+ref = dot_top;
+}
+);
+width = 777;
+}
+);
+note = uni1496;
+unicode = 5270;
+},
+{
+glyphname = "cwiiWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (226,0);
+ref = dot_top;
+},
+{
+anchor = middle_right_can;
+pos = (564,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 777;
+}
+);
+note = uni1497;
+unicode = 5271;
+},
+{
+glyphname = "cwo-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "co-canadian";
+}
+);
+width = 777;
+}
+);
+note = uni1498;
+unicode = 5272;
+},
+{
+glyphname = "cwoWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (564,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 777;
+}
+);
+note = uni1499;
+unicode = 5273;
+},
+{
+glyphname = "cwoo-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (611,0);
+ref = dot_top;
+}
+);
+width = 777;
+}
+);
+note = uni149A;
+unicode = 5274;
+},
+{
+glyphname = "cwooWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (399,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (564,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 777;
+}
+);
+note = uni149B;
+unicode = 5275;
+},
+{
+glyphname = "cwa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ca-canadian";
+}
+);
+width = 777;
+}
+);
+note = uni149C;
+unicode = 5276;
+},
+{
+glyphname = "cwaWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (564,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 777;
+}
+);
+note = uni149D;
+unicode = 5277;
+},
+{
+glyphname = "cwaa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (255,0);
+ref = dot_top;
+}
+);
+width = 777;
+}
+);
+note = uni149E;
+unicode = 5278;
+},
+{
+glyphname = "cwaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (43,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (564,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 777;
+}
+);
+note = uni149F;
+unicode = 5279;
+},
+{
+glyphname = "cwaaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ca-canadian";
+}
+);
+width = 778;
+}
+);
+note = uni14A0;
+unicode = 5280;
+},
+{
+glyphname = "c-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(287,339,o),
+(334,380,o),
+(350,454,cs),
+(356,485,l),
+(313,485,l),
+(306,452,ls),
+(295,403,o),
+(266,378,o),
+(221,378,cs),
+(171,378,o),
+(151,409,o),
+(163,468,cs),
+(211,690,l),
+(164,690,l),
+(119,472,ls),
+(101,391,o),
+(139,339,o),
+(219,339,cs)
+);
+}
+);
+width = 352;
+}
+);
+note = uni14A1;
+unicode = 5281;
+},
+{
+glyphname = "thSayisi-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(270,339,o),
+(315,380,o),
+(331,455,cs),
+(382,690,l),
+(335,690,l),
+(285,454,ls),
+(274,401,o),
+(243,378,o),
+(201,378,cs),
+(149,378,o),
+(129,412,o),
+(140,462,cs),
+(145,485,l),
+(101,485,l),
+(98,468,ls),
+(81,393,o),
+(121,339,o),
+(199,339,cs)
+);
+}
+);
+width = 352;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "=|c-canadian";
+note = uni14A2;
+unicode = 5282;
+},
+{
+glyphname = "me-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:55:07 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (224,345);
+},
+{
+name = top_center_can;
+pos = (329,690);
+},
+{
+name = top_left_can;
+pos = (169,690);
+},
+{
+name = top_right_can;
+pos = (488,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(372,0,l),
+(519,690,l),
+(138,690,l),
+(127,634,l),
+(445,634,l),
+(310,0,l)
+);
+}
+);
+width = 502;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+unicode = 5283;
+},
+{
+glyphname = "maai-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (152,0);
+ref = ring_top.canadian;
+}
+);
+width = 502;
+}
+);
+note = uni14A4;
+unicode = 5284;
+},
+{
+glyphname = "mi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (326,345);
+},
+{
+name = top_center_can;
+pos = (367,690);
+},
+{
+name = top_left_can;
+pos = (209,690);
+},
+{
+name = top_right_can;
+pos = (526,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(92,0,l),
+(227,634,l),
+(546,634,l),
+(557,690,l),
+(177,690,l),
+(30,0,l)
+);
+}
+);
+width = 502;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+unicode = 5285;
+},
+{
+glyphname = "mii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (209,0);
+ref = dot_top;
+}
+);
+width = 502;
+}
+);
+note = uni14A6;
+unicode = 5286;
+},
+{
+glyphname = "mo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:55:07 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (224,345);
+},
+{
+name = top_center_can;
+pos = (329,690);
+},
+{
+name = top_double;
+pos = (488,690);
+},
+{
+name = top_left_can;
+pos = (169,690);
+},
+{
+name = top_right_can;
+pos = (488,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(372,0,l),
+(519,690,l),
+(457,690,l),
+(323,56,l),
+(3,56,l),
+(-9,0,l)
+);
+}
+);
+width = 502;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+unicode = 5287;
+},
+{
+glyphname = "moo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (329,0);
+ref = dot_top;
+}
+);
+width = 502;
+}
+);
+note = uni14A8;
+unicode = 5288;
+},
+{
+glyphname = "ycreemoo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (173,0);
+ref = doubledot_top;
+}
+);
+width = 502;
+}
+);
+note = uni14A9;
+unicode = 5289;
+},
+{
+glyphname = "ma-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (326,345);
+},
+{
+name = top_center_can;
+pos = (367,690);
+},
+{
+name = top_left_can;
+pos = (209,690);
+},
+{
+name = top_right_can;
+pos = (526,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(411,0,l),
+(423,56,l),
+(104,56,l),
+(239,690,l),
+(177,690,l),
+(30,0,l)
+);
+}
+);
+width = 502;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+unicode = 5290;
+},
+{
+glyphname = "maa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+}
+);
+width = 502;
+}
+);
+note = uni14AB;
+unicode = 5291;
+},
+{
+glyphname = "mwe-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "me-canadian";
+}
+);
+width = 716;
+}
+);
+note = uni14AC;
+unicode = 5292;
+},
+{
+glyphname = "mweWestCree-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "me-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (502,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 716;
+}
+);
+note = uni14AD;
+unicode = 5293;
+},
+{
+glyphname = "mwi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "mi-canadian";
+}
+);
+width = 716;
+}
+);
+note = uni14AE;
+unicode = 5294;
+},
+{
+glyphname = "mwiWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (502,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 716;
+}
+);
+note = uni14AF;
+unicode = 5295;
+},
+{
+glyphname = "mwii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (421,0);
+ref = dot_top;
+}
+);
+width = 716;
+}
+);
+note = uni14B0;
+unicode = 5296;
+},
+{
+glyphname = "mwiiWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (209,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (502,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 716;
+}
+);
+note = uni14B1;
+unicode = 5297;
+},
+{
+glyphname = "mwo-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "mo-canadian";
+}
+);
+width = 716;
+}
+);
+note = uni14B2;
+unicode = 5298;
+},
+{
+glyphname = "mwoWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (502,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 716;
+}
+);
+note = uni14B3;
+unicode = 5299;
+},
+{
+glyphname = "mwoo-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (542,0);
+ref = dot_top;
+}
+);
+width = 716;
+}
+);
+note = uni14B4;
+unicode = 5300;
+},
+{
+glyphname = "mwooWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (329,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (502,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 716;
+}
+);
+note = uni14B5;
+unicode = 5301;
+},
+{
+glyphname = "mwa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ma-canadian";
+}
+);
+width = 716;
+}
+);
+note = uni14B6;
+unicode = 5302;
+},
+{
+glyphname = "mwaWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (502,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 716;
+}
+);
+note = uni14B7;
+unicode = 5303;
+},
+{
+glyphname = "mwaa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (263,0);
+ref = dot_top;
+}
+);
+width = 716;
+}
+);
+note = uni14B8;
+unicode = 5304;
+},
+{
+glyphname = "mwaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (502,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 716;
+}
+);
+note = uni14B9;
+unicode = 5305;
+},
+{
+glyphname = "mwaaNaskapi-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ma-canadian";
+}
+);
+width = 716;
+}
+);
+note = uni14BA;
+unicode = 5306;
+},
+{
+glyphname = "m-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(299,345,l),
+(309,387,l),
+(146,387,l),
+(211,690,l),
+(164,690,l),
+(91,345,l)
+);
+}
+);
+width = 326;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni14BB;
+unicode = 5307;
+},
+{
+glyphname = "mWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "t-canadian";
+}
+);
+width = 361;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "t-canadian";
+note = uni14BC;
+unicode = 5308;
+},
+{
+glyphname = "mh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(281,345,l),
+(355,690,l),
+(309,690,l),
+(244,387,l),
+(81,387,l),
+(72,345,l)
+);
+}
+);
+width = 325;
+}
+);
+metricLeft = "=|m-canadian";
+metricRight = "=|m-canadian";
+note = uni14BD;
+unicode = 5309;
+},
+{
+glyphname = "mAthapascan-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(316,345,l),
+(325,384,l),
+(152,384,l),
+(150,360,l),
+(288,483,ls),
+(329,521,o),
+(353,556,o),
+(353,605,cs),
+(353,659,o),
+(315,696,o),
+(256,696,cs),
+(191,696,o),
+(145,659,o),
+(130,574,c),
+(173,574,l),
+(184,634,o),
+(212,659,o),
+(253,659,cs),
+(289,659,o),
+(311,639,o),
+(311,604,cs),
+(311,564,o),
+(293,537,o),
+(249,498,cs),
+(100,367,l),
+(96,345,l)
+);
+}
+);
+width = 345;
+}
+);
+note = uni14BE;
+unicode = 5310;
+},
+{
+glyphname = "mSayisi-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = two.canadian;
+}
+);
+width = 561;
+}
+);
+note = uni14BF;
+unicode = 5311;
+},
+{
+glyphname = "ne-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (502,245);
+},
+{
+name = top_center_can;
+pos = (546,490);
+},
+{
+name = top_left_can;
+pos = (147,490);
+},
+{
+name = top_right_can;
+pos = (744,490);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(640,-13,o),
+(722,146,o),
+(722,277,cs),
+(722,395,o),
+(647,472,o),
+(517,472,cs),
+(112,472,l),
+(100,416,l),
+(440,416,l),
+(440,442,l),
+(315,409,o),
+(275,272,o),
+(275,183,cs),
+(275,66,o),
+(351,-13,o),
+(476,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(386,42,o),
+(335,98,o),
+(335,184,cs),
+(335,282,o),
+(389,418,o),
+(519,418,cs),
+(611,418,o),
+(661,362,o),
+(661,276,cs),
+(661,178,o),
+(607,42,o),
+(477,42,cs)
+);
+}
+);
+width = 789;
+}
+);
+metricRight = "=|ke-canadian";
+note = uni14C0;
+unicode = 5312;
+},
+{
+glyphname = "naai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (132,-200);
+ref = ring_top.canadian;
+}
+);
+width = 787;
+}
+);
+note = uni14C1;
+unicode = 5313;
+},
+{
+glyphname = "ni-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (289,245);
+},
+{
+name = top_center_can;
+pos = (350,490);
+},
+{
+name = top_left_can;
+pos = (152,490);
+},
+{
+name = top_right_can;
+pos = (750,490);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(430,-13,o),
+(511,146,o),
+(511,277,cs),
+(511,345,o),
+(480,398,o),
+(433,423,c),
+(424,416,l),
+(765,416,l),
+(777,472,l),
+(316,472,ls),
+(144,472,o),
+(65,316,o),
+(65,184,cs),
+(65,66,o),
+(140,-13,o),
+(266,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(176,42,o),
+(126,98,o),
+(126,184,cs),
+(126,282,o),
+(180,418,o),
+(309,418,cs),
+(400,418,o),
+(450,362,o),
+(450,276,cs),
+(450,178,o),
+(396,42,o),
+(267,42,cs)
+);
+}
+);
+width = 789;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+unicode = 5314;
+},
+{
+glyphname = "nii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (190,-200);
+ref = dot_top;
+}
+);
+width = 787;
+}
+);
+note = uni14C3;
+unicode = 5315;
+},
+{
+glyphname = "no-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (504,245);
+},
+{
+name = top_center_can;
+pos = (553,490);
+},
+{
+name = top_double;
+pos = (556,490);
+},
+{
+name = top_left_can;
+pos = (148,490);
+},
+{
+name = top_right_can;
+pos = (746,490);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(473,0,ls),
+(645,0,o),
+(725,156,o),
+(725,289,cs),
+(725,407,o),
+(649,484,o),
+(524,484,cs),
+(359,484,o),
+(278,326,o),
+(278,195,cs),
+(278,127,o),
+(310,74,o),
+(357,49,c),
+(365,56,l),
+(24,56,l),
+(13,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(389,54,o),
+(339,109,o),
+(339,196,cs),
+(339,294,o),
+(393,430,o),
+(523,430,cs),
+(614,430,o),
+(665,375,o),
+(665,289,cs),
+(665,190,o),
+(611,54,o),
+(481,54,cs)
+);
+}
+);
+width = 789;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14C4;
+unicode = 5316;
+},
+{
+glyphname = "noo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (393,-200);
+ref = dot_top;
+}
+);
+width = 787;
+}
+);
+note = uni14C5;
+unicode = 5317;
+},
+{
+glyphname = "ycreenoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (241,-200);
+ref = doubledot_top;
+}
+);
+width = 787;
+}
+);
+note = uni14C6;
+unicode = 5318;
+},
+{
+glyphname = "na-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (289,245);
+},
+{
+name = top_center_can;
+pos = (344,490);
+},
+{
+name = top_double;
+pos = (484,490);
+},
+{
+name = top_left_can;
+pos = (152,490);
+},
+{
+name = top_right_can;
+pos = (749,490);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(675,0,l),
+(688,56,l),
+(349,56,l),
+(348,30,l),
+(472,64,o),
+(512,200,o),
+(512,290,cs),
+(512,407,o),
+(437,484,o),
+(311,484,cs),
+(147,484,o),
+(67,326,o),
+(67,195,cs),
+(67,77,o),
+(141,0,o),
+(270,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(177,54,o),
+(127,109,o),
+(127,196,cs),
+(127,294,o),
+(181,430,o),
+(310,430,cs),
+(402,430,o),
+(452,375,o),
+(452,289,cs),
+(452,190,o),
+(398,54,o),
+(269,54,cs)
+);
+}
+);
+width = 788;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+unicode = 5319;
+},
+{
+glyphname = "naa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (185,-200);
+ref = dot_top;
+}
+);
+width = 787;
+}
+);
+note = uni14C8;
+unicode = 5320;
+},
+{
+glyphname = "nwe-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ne-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni14C9;
+unicode = 5321;
+},
+{
+glyphname = "nweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (787,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni14CA;
+unicode = 5322;
+},
+{
+glyphname = "nwa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "na-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni14CB;
+unicode = 5323;
+},
+{
+glyphname = "nwaWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (787,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni14CC;
+unicode = 5324;
+},
+{
+glyphname = "nwaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (398,-200);
+ref = dot_top;
+}
+);
+width = 1001;
+}
+);
+note = uni14CD;
+unicode = 5325;
+},
+{
+glyphname = "nwaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (185,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (787,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni14CE;
+unicode = 5326;
+},
+{
+glyphname = "nwaaNaskapi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (169,-200);
+ref = doubledot_top;
+}
+);
+width = 787;
+}
+);
+note = uni14CF;
+unicode = 5327;
+},
+{
+glyphname = "n-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(460,434,l),
+(468,477,l),
+(287,477,l),
+(284,452,l),
+(341,470,o),
+(363,543,o),
+(363,588,cs),
+(363,653,o),
+(323,696,o),
+(258,696,cs),
+(172,696,o),
+(127,615,o),
+(127,542,cs),
+(127,476,o),
+(167,434,o),
+(233,434,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(191,470,o),
+(167,498,o),
+(167,541,cs),
+(167,584,o),
+(190,660,o),
+(257,660,cs),
+(298,660,o),
+(323,632,o),
+(323,589,cs),
+(323,546,o),
+(299,470,o),
+(233,470,cs)
+);
+}
+);
+width = 467;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni14D0;
+unicode = 5328;
+},
+{
+color = 6;
+glyphname = "ngCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-161);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 410;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "=|";
+note = uni14D1;
+unicode = 5329;
+},
+{
+glyphname = "nh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(345,434,ls),
+(435,434,o),
+(480,515,o),
+(480,589,cs),
+(480,654,o),
+(439,696,o),
+(374,696,cs),
+(288,696,o),
+(243,615,o),
+(243,542,cs),
+(243,501,o),
+(264,472,o),
+(283,461,c),
+(289,477,l),
+(100,477,l),
+(91,434,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(308,470,o),
+(284,498,o),
+(284,541,cs),
+(284,584,o),
+(306,660,o),
+(373,660,cs),
+(414,660,o),
+(439,632,o),
+(439,589,cs),
+(439,546,o),
+(416,470,o),
+(350,470,cs)
+);
+}
+);
+width = 467;
+}
+);
+metricLeft = "=|n-canadian";
+metricRight = "=|n-canadian";
+note = uni14D2;
+unicode = 5330;
+},
+{
+glyphname = "le-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (502,245);
+},
+{
+name = top_center_can;
+pos = (546,490);
+},
+{
+name = top_left_can;
+pos = (147,490);
+},
+{
+name = top_right_can;
+pos = (744,490);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(435,0,ls),
+(649,0,o),
+(723,151,o),
+(723,281,cs),
+(723,398,o),
+(647,472,o),
+(521,472,cs),
+(112,472,l),
+(100,415,l),
+(508,415,ls),
+(608,415,o),
+(661,366,o),
+(661,278,cs),
+(661,180,o),
+(611,55,o),
+(440,55,cs),
+(400,55,l),
+(388,0,l)
+);
+}
+);
+width = 789;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D3;
+unicode = 5331;
+},
+{
+glyphname = "laai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (134,-200);
+ref = ring_top.canadian;
+}
+);
+width = 787;
+}
+);
+note = uni14D4;
+unicode = 5332;
+},
+{
+glyphname = "li-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (290,245);
+},
+{
+name = top_center_can;
+pos = (351,490);
+},
+{
+name = top_left_can;
+pos = (153,490);
+},
+{
+name = top_right_can;
+pos = (750,490);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(299,0,l),
+(311,55,l),
+(275,55,ls),
+(180,55,o),
+(127,107,o),
+(127,194,cs),
+(127,293,o),
+(178,415,o),
+(350,415,cs),
+(764,415,l),
+(776,472,l),
+(355,472,ls),
+(144,472,o),
+(66,327,o),
+(66,193,cs),
+(66,77,o),
+(140,0,o),
+(262,0,cs)
+);
+}
+);
+width = 788;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14D5;
+unicode = 5333;
+},
+{
+glyphname = "lii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (192,-200);
+ref = dot_top;
+}
+);
+width = 787;
+}
+);
+note = uni14D6;
+unicode = 5334;
+},
+{
+glyphname = "lo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (502,245);
+},
+{
+name = top_center_can;
+pos = (551,490);
+},
+{
+name = top_double;
+pos = (538,490);
+},
+{
+name = top_left_can;
+pos = (148,490);
+},
+{
+name = top_right_can;
+pos = (745,490);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(434,0,ls),
+(645,0,o),
+(724,145,o),
+(724,278,cs),
+(724,395,o),
+(648,472,o),
+(527,472,cs),
+(489,472,l),
+(478,416,l),
+(513,416,ls),
+(609,416,o),
+(663,365,o),
+(663,278,cs),
+(663,180,o),
+(611,56,o),
+(440,56,cs),
+(24,56,l),
+(13,0,l)
+);
+}
+);
+width = 790;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D7;
+unicode = 5335;
+},
+{
+glyphname = "loo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (391,-200);
+ref = dot_top;
+}
+);
+width = 787;
+}
+);
+note = uni14D8;
+unicode = 5336;
+},
+{
+glyphname = "ycreeloo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (221,-200);
+ref = doubledot_top;
+}
+);
+width = 787;
+}
+);
+note = uni14D9;
+unicode = 5337;
+},
+{
+glyphname = "la-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (290,245);
+},
+{
+name = top_center_can;
+pos = (345,490);
+},
+{
+name = top_left_can;
+pos = (153,490);
+},
+{
+name = top_right_can;
+pos = (749,490);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(675,0,l),
+(688,56,l),
+(279,56,ls),
+(181,56,o),
+(128,106,o),
+(128,194,cs),
+(128,293,o),
+(176,416,o),
+(347,416,cs),
+(387,416,l),
+(399,472,l),
+(353,472,ls),
+(138,472,o),
+(66,322,o),
+(66,191,cs),
+(66,74,o),
+(141,0,o),
+(267,0,cs)
+);
+}
+);
+width = 788;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14DA;
+unicode = 5338;
+},
+{
+glyphname = "laa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (185,-200);
+ref = dot_top;
+}
+);
+width = 787;
+}
+);
+note = uni14DB;
+unicode = 5339;
+},
+{
+glyphname = "lwe-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "le-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni14DC;
+unicode = 5340;
+},
+{
+glyphname = "lweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "le-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (787,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni14DD;
+unicode = 5341;
+},
+{
+glyphname = "lwi-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "li-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni14DE;
+unicode = 5342;
+},
+{
+glyphname = "lwiWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (787,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni14DF;
+unicode = 5343;
+},
+{
+glyphname = "lwii-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (405,-200);
+ref = dot_top;
+}
+);
+width = 1001;
+}
+);
+note = uni14E0;
+unicode = 5344;
+},
+{
+glyphname = "lwiiWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (192,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (787,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni14E1;
+unicode = 5345;
+},
+{
+glyphname = "lwo-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "lo-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni14E2;
+unicode = 5346;
+},
+{
+glyphname = "lwoWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (787,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni14E3;
+unicode = 5347;
+},
+{
+glyphname = "lwoo-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (604,-200);
+ref = dot_top;
+}
+);
+width = 1001;
+}
+);
+note = uni14E4;
+unicode = 5348;
+},
+{
+glyphname = "lwooWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (391,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (787,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni14E5;
+unicode = 5349;
+},
+{
+glyphname = "lwa-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "la-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni14E6;
+unicode = 5350;
+},
+{
+glyphname = "lwaWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (787,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni14E7;
+unicode = 5351;
+},
+{
+glyphname = "lwaa-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (399,-200);
+ref = dot_top;
+}
+);
+width = 1001;
+}
+);
+note = uni14E8;
+unicode = 5352;
+},
+{
+glyphname = "lwaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (185,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (787,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni14E9;
+unicode = 5353;
+},
+{
+glyphname = "l-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(441,345,l),
+(450,387,l),
+(265,387,ls),
+(201,387,o),
+(168,420,o),
+(168,479,cs),
+(168,550,o),
+(199,647,o),
+(317,647,cs),
+(337,647,l),
+(346,690,l),
+(322,690,ls),
+(184,690,o),
+(123,587,o),
+(123,477,cs),
+(123,393,o),
+(173,345,o),
+(263,345,cs)
+);
+}
+);
+width = 467;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "m-canadian";
+note = uni14EA;
+unicode = 5354;
+},
+{
+glyphname = "lWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(325,345,l),
+(330,374,l),
+(153,450,l),
+(147,429,l),
+(358,503,l),
+(363,526,l),
+(184,600,l),
+(179,578,l),
+(390,656,l),
+(398,690,l),
+(387,690,l),
+(146,602,l),
+(142,582,l),
+(325,508,l),
+(328,526,l),
+(114,452,l),
+(110,433,l),
+(314,345,l)
+);
+}
+);
+width = 370;
+}
+);
+metricRight = "=|";
+note = uni14EB;
+unicode = 5355;
+},
+{
+glyphname = "mediall-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(507,-13,l),
+(516,29,l),
+(125,195,l),
+(119,165,l),
+(579,326,l),
+(585,357,l),
+(193,514,l),
+(187,487,l),
+(648,652,l),
+(659,702,l),
+(639,702,l),
+(135,521,l),
+(129,491,l),
+(523,333,l),
+(527,357,l),
+(68,198,l),
+(62,169,l),
+(489,-13,l)
+);
+}
+);
+width = 634;
+}
+);
+metricRight = "=|";
+note = uni14EC;
+unicode = 5356;
+},
+{
+glyphname = "se-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (205,690);
+},
+{
+name = top_right_can;
+pos = (501,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(386,0,l),
+(453,314,l),
+(418,314,ls),
+(249,314,o),
+(174,405,o),
+(213,587,cs),
+(236,690,l),
+(174,690,l),
+(152,583,ls),
+(109,382,o),
+(208,258,o),
+(405,258,cs),
+(426,258,l),
+(384,282,l),
+(325,0,l)
+);
+}
+);
+width = 517;
+}
+);
+note = uni14ED;
+unicode = 5357;
+},
+{
+glyphname = "saai-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (290,0);
+ref = ring_top.canadian;
+}
+);
+width = 517;
+}
+);
+note = uni14EE;
+unicode = 5358;
+},
+{
+glyphname = "si-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (209,690);
+},
+{
+name = top_right_can;
+pos = (506,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(93,0,l),
+(153,283,l),
+(103,258,l),
+(145,258,ls),
+(336,258,o),
+(466,360,o),
+(512,579,cs),
+(536,690,l),
+(474,690,l),
+(452,585,ls),
+(413,404,o),
+(306,314,o),
+(149,314,cs),
+(98,314,l),
+(31,0,l)
+);
+}
+);
+width = 516;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+unicode = 5359;
+},
+{
+glyphname = "sii-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (347,0);
+ref = dot_top;
+}
+);
+width = 517;
+}
+);
+note = uni14F0;
+unicode = 5360;
+},
+{
+glyphname = "so-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (502,690);
+},
+{
+name = top_left_can;
+pos = (205,690);
+},
+{
+name = top_right_can;
+pos = (502,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(89,0,l),
+(112,104,ls),
+(151,286,o),
+(257,376,o),
+(415,376,cs),
+(467,376,l),
+(533,690,l),
+(471,690,l),
+(411,407,l),
+(460,432,l),
+(418,432,ls),
+(228,432,o),
+(99,329,o),
+(51,111,cs),
+(27,0,l)
+);
+}
+);
+width = 518;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+unicode = 5361;
+},
+{
+glyphname = "soo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (343,0);
+ref = dot_top;
+}
+);
+width = 517;
+}
+);
+note = uni14F2;
+unicode = 5362;
+},
+{
+glyphname = "ycreesoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (187,0);
+ref = doubledot_top;
+}
+);
+width = 517;
+}
+);
+note = uni14F3;
+unicode = 5363;
+},
+{
+glyphname = "sa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (210,690);
+},
+{
+name = top_right_can;
+pos = (506,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(390,0,l),
+(413,106,ls),
+(456,308,o),
+(356,432,o),
+(159,432,cs),
+(138,432,l),
+(180,408,l),
+(240,690,l),
+(179,690,l),
+(111,376,l),
+(147,376,ls),
+(315,376,o),
+(390,285,o),
+(351,102,cs),
+(328,0,l)
+);
+}
+);
+width = 518;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+unicode = 5364;
+},
+{
+glyphname = "saa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+}
+);
+width = 517;
+}
+);
+note = uni14F5;
+unicode = 5365;
+},
+{
+glyphname = "swe-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "se-canadian";
+}
+);
+width = 729;
+}
+);
+note = uni14F6;
+unicode = 5366;
+},
+{
+glyphname = "sweWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "se-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (517,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 729;
+}
+);
+note = uni14F7;
+unicode = 5367;
+},
+{
+glyphname = "swi-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "si-canadian";
+}
+);
+width = 729;
+}
+);
+note = uni14F8;
+unicode = 5368;
+},
+{
+glyphname = "swiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (517,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 729;
+}
+);
+note = uni14F9;
+unicode = 5369;
+},
+{
+glyphname = "swii-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (559,0);
+ref = dot_top;
+}
+);
+width = 729;
+}
+);
+note = uni14FA;
+unicode = 5370;
+},
+{
+glyphname = "swiiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (347,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (517,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 729;
+}
+);
+note = uni14FB;
+unicode = 5371;
+},
+{
+glyphname = "swo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "so-canadian";
+}
+);
+width = 729;
+}
+);
+note = uni14FC;
+unicode = 5372;
+},
+{
+glyphname = "swoWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (517,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 729;
+}
+);
+note = uni14FD;
+unicode = 5373;
+},
+{
+glyphname = "swoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (556,0);
+ref = dot_top;
+}
+);
+width = 729;
+}
+);
+note = uni14FE;
+unicode = 5374;
+},
+{
+glyphname = "swooWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (343,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (517,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 729;
+}
+);
+note = uni14FF;
+unicode = 5375;
+},
+{
+glyphname = "swa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "sa-canadian";
+}
+);
+width = 729;
+}
+);
+note = uni1500;
+unicode = 5376;
+},
+{
+glyphname = "swaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (517,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 729;
+}
+);
+note = uni1501;
+unicode = 5377;
+},
+{
+glyphname = "swaa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (263,0);
+ref = dot_top;
+}
+);
+width = 729;
+}
+);
+note = uni1502;
+unicode = 5378;
+},
+{
+glyphname = "swaaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (517,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 729;
+}
+);
+note = uni1503;
+unicode = 5379;
+},
+{
+glyphname = "swaaNaskapi-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "sa-canadian";
+}
+);
+width = 730;
+}
+);
+note = uni1504;
+unicode = 5380;
+},
+{
+glyphname = "s-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(300,345,l),
+(312,399,ls),
+(335,506,o),
+(281,573,o),
+(175,573,cs),
+(160,573,l),
+(180,547,l),
+(211,690,l),
+(164,690,l),
+(131,533,l),
+(161,533,ls),
+(247,533,o),
+(285,489,o),
+(267,401,cs),
+(254,345,l)
+);
+}
+);
+width = 344;
+}
+);
+metricRight = "=|";
+note = uni1505;
+unicode = 5381;
+},
+{
+color = 6;
+glyphname = "sAthapascan-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(270,177,o),
+(310,222,o),
+(310,280,cs),
+(310,318,o),
+(291,344,o),
+(252,359,cs),
+(193,381,ls),
+(165,391,o),
+(155,409,o),
+(155,432,cs),
+(155,470,o),
+(182,497,o),
+(236,497,cs),
+(285,497,o),
+(309,474,o),
+(300,429,c),
+(342,429,l),
+(353,490,o),
+(312,533,o),
+(238,533,cs),
+(154,533,o),
+(113,486,o),
+(113,429,cs),
+(113,389,o),
+(138,361,o),
+(170,349,cs),
+(229,327,ls),
+(259,316,o),
+(269,300,o),
+(269,277,cs),
+(269,239,o),
+(242,213,o),
+(187,213,cs),
+(131,213,o),
+(110,237,o),
+(119,284,c),
+(77,284,l),
+(66,221,o),
+(102,177,o),
+(186,177,cs)
+);
+}
+);
+width = 370;
+}
+);
+metricRight = "=|";
+note = uni1506;
+unicode = 5382;
+},
+{
+glyphname = "sw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(136,345,l),
+(147,398,ls),
+(167,493,o),
+(214,533,o),
+(304,533,cs),
+(339,533,l),
+(373,690,l),
+(326,690,l),
+(297,550,l),
+(327,573,l),
+(297,573,ls),
+(189,573,o),
+(126,517,o),
+(102,403,cs),
+(90,345,l)
+);
+}
+);
+width = 343;
+}
+);
+metricLeft = "=|s-canadian";
+metricRight = "=|s-canadian";
+note = uni1507;
+unicode = 5383;
+},
+{
+glyphname = "sBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(307,345,l),
+(317,387,l),
+(235,387,ls),
+(176,387,o),
+(153,417,o),
+(166,482,cs),
+(211,690,l),
+(164,690,l),
+(121,482,ls),
+(101,395,o),
+(141,345,o),
+(229,345,cs)
+);
+}
+);
+width = 334;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "m-canadian";
+note = uni1508;
+unicode = 5384;
+},
+{
+glyphname = "moosecreesk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(292,217,o),
+(334,320,o),
+(334,420,cs),
+(334,520,o),
+(290,572,o),
+(185,572,cs),
+(166,572,l),
+(181,550,l),
+(211,690,l),
+(165,690,l),
+(131,533,l),
+(177,533,ls),
+(270,533,o),
+(296,495,o),
+(292,405,c),
+(301,410,l),
+(297,447,o),
+(270,478,o),
+(219,478,cs),
+(132,478,o),
+(91,392,o),
+(91,324,cs),
+(91,260,o),
+(130,217,o),
+(197,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(156,253,o),
+(132,281,o),
+(132,324,cs),
+(132,374,o),
+(162,443,o),
+(223,443,cs),
+(264,443,o),
+(287,417,o),
+(287,375,cs),
+(287,321,o),
+(254,253,o),
+(198,253,cs)
+);
+}
+);
+width = 371;
+}
+);
+metricRight = "=|";
+note = uni1509;
+unicode = 5385;
+},
+{
+glyphname = "skwNaskapi-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(284,217,o),
+(328,303,o),
+(328,376,cs),
+(328,438,o),
+(293,478,o),
+(236,478,cs),
+(191,478,o),
+(153,450,o),
+(136,403,c),
+(152,414,l),
+(181,494,o),
+(230,533,o),
+(313,533,cs),
+(365,533,l),
+(398,690,l),
+(352,690,l),
+(322,549,l),
+(348,572,l),
+(315,572,ls),
+(150,572,o),
+(93,422,o),
+(93,328,cs),
+(93,261,o),
+(130,217,o),
+(196,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(156,253,o),
+(134,281,o),
+(134,324,cs),
+(134,374,o),
+(163,443,o),
+(223,443,cs),
+(264,443,o),
+(287,417,o),
+(287,375,cs),
+(287,321,o),
+(255,253,o),
+(199,253,cs)
+);
+}
+);
+width = 370;
+}
+);
+metricLeft = "=|moosecreesk-canadian";
+metricRight = "=|moosecreesk-canadian";
+note = uni150A;
+unicode = 5386;
+},
+{
+glyphname = "swNaskapi-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(282,178,l),
+(293,228,ls),
+(316,335,o),
+(268,399,o),
+(161,399,cs),
+(141,399,l),
+(156,375,l),
+(186,513,l),
+(141,513,l),
+(108,360,l),
+(147,360,ls),
+(233,360,o),
+(266,321,o),
+(247,229,cs),
+(236,178,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(267,63,o),
+(284,81,o),
+(284,104,cs),
+(284,127,o),
+(267,145,o),
+(243,145,cs),
+(221,145,o),
+(202,127,o),
+(202,104,cs),
+(202,81,o),
+(221,63,o),
+(243,63,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(203,545,o),
+(220,563,o),
+(220,585,cs),
+(220,610,o),
+(203,627,o),
+(180,627,cs),
+(156,627,o),
+(138,610,o),
+(138,585,cs),
+(138,563,o),
+(156,545,o),
+(180,545,cs)
+);
+}
+);
+width = 376;
+}
+);
+metricRight = "=|";
+note = uni150B;
+unicode = 5387;
+},
+{
+glyphname = "spwaNaskapi-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(527,0,l),
+(538,50,l),
+(126,353,l),
+(120,325,l),
+(661,627,l),
+(674,690,l),
+(655,690,l),
+(63,358,l),
+(57,331,l),
+(508,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(216,489,o),
+(234,508,o),
+(234,530,cs),
+(234,554,o),
+(216,573,o),
+(192,573,cs),
+(170,573,o),
+(151,554,o),
+(151,530,cs),
+(151,508,o),
+(170,489,o),
+(192,489,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(405,597,l),
+(413,639,ls),
+(429,713,o),
+(396,759,o),
+(325,759,cs),
+(303,759,l),
+(326,740,l),
+(346,837,l),
+(301,837,l),
+(277,723,l),
+(306,723,ls),
+(362,723,o),
+(382,696,o),
+(369,637,cs),
+(360,597,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(595,699,o),
+(613,718,o),
+(613,741,cs),
+(613,764,o),
+(595,782,o),
+(572,782,cs),
+(549,782,o),
+(530,764,o),
+(530,741,cs),
+(530,718,o),
+(549,699,o),
+(572,699,cs)
+);
+}
+);
+width = 635;
+}
+);
+metricRight = "pa-canadian";
+metricWidth = "pa-canadian";
+note = uni150C;
+unicode = 5388;
+},
+{
+glyphname = "stwaNaskapi-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (377,0);
+ref = "ta-canadian";
+}
+);
+width = 962;
+}
+);
+note = uni150D;
+unicode = 5389;
+},
+{
+glyphname = "skwaNaskapi-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (377,0);
+ref = "ka-canadian";
+}
+);
+width = 945;
+}
+);
+note = uni150E;
+unicode = 5390;
+},
+{
+glyphname = "scwaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (377,0);
+ref = "ca-canadian";
+}
+);
+width = 941;
+}
+);
+note = uni150F;
+unicode = 5391;
+},
+{
+glyphname = "she-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (371,690);
+},
+{
+name = top_right_can;
+pos = (761,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(718,-13,o),
+(794,71,o),
+(825,225,cs),
+(840,298,l),
+(780,298,l),
+(764,226,ls),
+(738,103,o),
+(687,43,o),
+(598,43,cs),
+(503,43,o),
+(465,107,o),
+(485,241,cs),
+(517,441,ls),
+(543,611,o),
+(480,702,o),
+(348,702,cs),
+(225,702,o),
+(149,618,o),
+(118,465,cs),
+(102,391,l),
+(164,391,l),
+(179,464,ls),
+(205,586,o),
+(256,647,o),
+(345,647,cs),
+(440,647,o),
+(478,582,o),
+(458,449,cs),
+(426,249,ls),
+(399,79,o),
+(463,-13,o),
+(596,-13,cs)
+);
+}
+);
+width = 896;
+}
+);
+metricRight = "=|";
+note = uni1510;
+unicode = 5392;
+},
+{
+glyphname = "shi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (331,690);
+},
+{
+name = top_right_can;
+pos = (722,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(361,-13,o),
+(427,65,o),
+(472,231,cs),
+(530,450,ls),
+(567,588,o),
+(612,647,o),
+(702,647,cs),
+(796,647,o),
+(839,582,o),
+(810,446,cs),
+(799,391,l),
+(861,391,l),
+(870,439,ls),
+(905,602,o),
+(837,702,o),
+(703,702,cs),
+(581,702,o),
+(516,625,o),
+(471,459,cs),
+(412,239,ls),
+(376,101,o),
+(330,43,o),
+(241,43,cs),
+(147,43,o),
+(103,107,o),
+(132,243,cs),
+(144,298,l),
+(82,298,l),
+(72,251,ls),
+(37,87,o),
+(105,-13,o),
+(240,-13,cs)
+);
+}
+);
+width = 897;
+}
+);
+metricLeft = "she-canadian";
+metricRight = "she-canadian";
+note = uni1511;
+unicode = 5393;
+},
+{
+glyphname = "shii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (562,0);
+ref = dot_top;
+}
+);
+width = 896;
+}
+);
+note = uni1512;
+unicode = 5394;
+},
+{
+glyphname = "sho-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (514,490);
+},
+{
+name = top_left_can;
+pos = (326,490);
+},
+{
+name = top_right_can;
+pos = (701,490);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(289,42,l),
+(178,42,o),
+(116,84,o),
+(116,156,cs),
+(116,226,o),
+(159,287,o),
+(251,287,cs),
+(395,287,o),
+(506,129,o),
+(673,129,cs),
+(795,129,o),
+(866,213,o),
+(866,318,cs),
+(866,419,o),
+(782,484,o),
+(643,484,c),
+(633,431,l),
+(744,430,o),
+(806,387,o),
+(806,317,cs),
+(806,246,o),
+(762,185,o),
+(669,185,cs),
+(526,185,o),
+(415,342,o),
+(247,342,cs),
+(126,342,o),
+(56,259,o),
+(56,155,cs),
+(56,53,o),
+(140,-12,o),
+(277,-13,c)
+);
+}
+);
+width = 922;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1513;
+unicode = 5395;
+},
+{
+glyphname = "shoo-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (355,-200);
+ref = dot_top;
+}
+);
+width = 919;
+}
+);
+note = uni1514;
+unicode = 5396;
+},
+{
+glyphname = "sha-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (515,490);
+},
+{
+name = top_left_can;
+pos = (326,490);
+},
+{
+name = top_right_can;
+pos = (702,490);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(713,-14,o),
+(839,53,o),
+(839,196,cs),
+(839,283,o),
+(779,342,o),
+(676,342,cs),
+(526,342,o),
+(379,185,o),
+(251,185,cs),
+(182,185,o),
+(141,221,o),
+(141,279,cs),
+(141,384,o),
+(233,431,o),
+(351,431,c),
+(361,484,l),
+(209,487,o),
+(81,419,o),
+(81,276,cs),
+(81,189,o),
+(143,129,o),
+(244,129,cs),
+(395,129,o),
+(542,287,o),
+(669,287,cs),
+(740,287,o),
+(780,251,o),
+(780,193,cs),
+(780,88,o),
+(689,41,o),
+(570,42,c),
+(558,-13,l)
+);
+}
+);
+width = 921;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1515;
+unicode = 5397;
+},
+{
+glyphname = "shaa-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (355,-200);
+ref = dot_top;
+}
+);
+width = 919;
+}
+);
+note = uni1516;
+unicode = 5398;
+},
+{
+glyphname = "shwe-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "she-canadian";
+}
+);
+width = 1109;
+}
+);
+note = uni1517;
+unicode = 5399;
+},
+{
+glyphname = "shweWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "she-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (896,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1109;
+}
+);
+note = uni1518;
+unicode = 5400;
+},
+{
+glyphname = "shwi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "shi-canadian";
+}
+);
+width = 1109;
+}
+);
+note = uni1519;
+unicode = 5401;
+},
+{
+glyphname = "shwiWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (896,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1109;
+}
+);
+note = uni151A;
+unicode = 5402;
+},
+{
+glyphname = "shwii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (775,0);
+ref = dot_top;
+}
+);
+width = 1109;
+}
+);
+note = uni151B;
+unicode = 5403;
+},
+{
+glyphname = "shwiiWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (562,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (896,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1109;
+}
+);
+note = uni151C;
+unicode = 5404;
+},
+{
+glyphname = "shwo-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "sho-canadian";
+}
+);
+width = 1132;
+}
+);
+note = uni151D;
+unicode = 5405;
+},
+{
+glyphname = "shwoWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (919,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1132;
+}
+);
+note = uni151E;
+unicode = 5406;
+},
+{
+glyphname = "shwoo-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (567,-200);
+ref = dot_top;
+}
+);
+width = 1132;
+}
+);
+note = uni151F;
+unicode = 5407;
+},
+{
+glyphname = "shwooWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (355,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (919,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1132;
+}
+);
+note = uni1520;
+unicode = 5408;
+},
+{
+glyphname = "shwa-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "sha-canadian";
+}
+);
+width = 1132;
+}
+);
+note = uni1521;
+unicode = 5409;
+},
+{
+glyphname = "shwaWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (919,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1132;
+}
+);
+note = uni1522;
+unicode = 5410;
+},
+{
+glyphname = "shwaa-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (567,-200);
+ref = dot_top;
+}
+);
+width = 1132;
+}
+);
+note = uni1523;
+unicode = 5411;
+},
+{
+glyphname = "shwaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (355,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (919,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1132;
+}
+);
+note = uni1524;
+unicode = 5412;
+},
+{
+glyphname = "sh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(590,286,o),
+(687,344,o),
+(687,456,cs),
+(687,523,o),
+(640,569,o),
+(561,569,cs),
+(451,569,o),
+(356,463,o),
+(260,463,cs),
+(209,463,o),
+(179,490,o),
+(179,534,cs),
+(179,615,o),
+(248,658,o),
+(345,655,c),
+(354,697,l),
+(230,702,o),
+(132,644,o),
+(132,531,cs),
+(132,465,o),
+(180,418,o),
+(258,418,cs),
+(369,418,o),
+(465,526,o),
+(559,526,cs),
+(611,526,o),
+(640,497,o),
+(640,454,cs),
+(640,374,o),
+(573,329,o),
+(475,332,c),
+(468,291,l)
+);
+}
+);
+width = 709;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni1525;
+unicode = 5413;
+},
+{
+glyphname = "ye-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (634,345);
+},
+{
+name = top_left_can;
+pos = (176,690);
+},
+{
+name = top_right_can;
+pos = (537,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(420,0,l),
+(487,310,l),
+(134,310,l),
+(136,279,l),
+(572,661,l),
+(534,701,l),
+(57,280,l),
+(52,255,l),
+(413,255,l),
+(359,0,l)
+);
+}
+);
+width = 550;
+}
+);
+note = uni1526;
+unicode = 5414;
+},
+{
+glyphname = "yaai-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-4,0);
+ref = ring_top.canadian;
+}
+);
+width = 550;
+}
+);
+note = uni1527;
+unicode = 5415;
+},
+{
+glyphname = "yi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (213,690);
+},
+{
+name = top_right_can;
+pos = (575,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(90,0,l),
+(145,255,l),
+(506,255,l),
+(511,280,l),
+(205,701,l),
+(159,668,l),
+(445,280,l),
+(447,310,l),
+(95,310,l),
+(29,0,l)
+);
+}
+);
+width = 550;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni1528;
+unicode = 5416;
+},
+{
+glyphname = "yii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (54,0);
+ref = dot_top;
+}
+);
+width = 550;
+}
+);
+note = uni1529;
+unicode = 5417;
+},
+{
+glyphname = "yo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (635,345);
+},
+{
+name = top_double;
+pos = (538,690);
+},
+{
+name = top_left_can;
+pos = (176,690);
+},
+{
+name = top_right_can;
+pos = (538,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(438,21,l),
+(152,410,l),
+(150,380,l),
+(502,380,l),
+(568,690,l),
+(506,690,l),
+(452,435,l),
+(91,435,l),
+(85,410,l),
+(392,-12,l)
+);
+}
+);
+width = 550;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152A;
+unicode = 5418;
+},
+{
+glyphname = "yoo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (378,0);
+ref = dot_top;
+}
+);
+width = 550;
+}
+);
+note = uni152B;
+unicode = 5419;
+},
+{
+glyphname = "ycreeyoo-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (221,0);
+ref = doubledot_top;
+}
+);
+width = 550;
+}
+);
+note = uni152C;
+unicode = 5420;
+},
+{
+glyphname = "ya-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (206,690);
+},
+{
+name = top_right_can;
+pos = (567,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(539,410,l),
+(544,435,l),
+(183,435,l),
+(237,690,l),
+(175,690,l),
+(109,380,l),
+(462,380,l),
+(459,411,l),
+(23,29,l),
+(62,-12,l)
+);
+}
+);
+width = 550;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152D;
+unicode = 5421;
+},
+{
+glyphname = "yaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (48,0);
+ref = dot_top;
+}
+);
+width = 550;
+}
+);
+note = uni152E;
+unicode = 5422;
+},
+{
+glyphname = "ywe-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ye-canadian";
+}
+);
+width = 763;
+}
+);
+note = uni152F;
+unicode = 5423;
+},
+{
+glyphname = "yweWestCree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ye-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (550,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 763;
+}
+);
+note = uni1530;
+unicode = 5424;
+},
+{
+glyphname = "ywi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "yi-canadian";
+}
+);
+width = 763;
+}
+);
+note = uni1531;
+unicode = 5425;
+},
+{
+glyphname = "ywiWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (550,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 763;
+}
+);
+note = uni1532;
+unicode = 5426;
+},
+{
+glyphname = "ywii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (267,0);
+ref = dot_top;
+}
+);
+width = 763;
+}
+);
+note = uni1533;
+unicode = 5427;
+},
+{
+glyphname = "ywiiWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (54,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (550,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 763;
+}
+);
+note = uni1534;
+unicode = 5428;
+},
+{
+glyphname = "ywo-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "yo-canadian";
+}
+);
+width = 763;
+}
+);
+note = uni1535;
+unicode = 5429;
+},
+{
+glyphname = "ywoWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (550,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 763;
+}
+);
+note = uni1536;
+unicode = 5430;
+},
+{
+glyphname = "ywoo-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (591,0);
+ref = dot_top;
+}
+);
+width = 763;
+}
+);
+note = uni1537;
+unicode = 5431;
+},
+{
+glyphname = "ywooWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (378,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (550,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 763;
+}
+);
+note = uni1538;
+unicode = 5432;
+},
+{
+glyphname = "ywa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ya-canadian";
+}
+);
+width = 763;
+}
+);
+note = uni1539;
+unicode = 5433;
+},
+{
+glyphname = "ywaWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (550,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 763;
+}
+);
+note = uni153A;
+unicode = 5434;
+},
+{
+glyphname = "ywaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (261,0);
+ref = dot_top;
+}
+);
+width = 763;
+}
+);
+note = uni153B;
+unicode = 5435;
+},
+{
+glyphname = "ywaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (48,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (550,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 763;
+}
+);
+note = uni153C;
+unicode = 5436;
+},
+{
+glyphname = "ywaaNaskapi-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ya-canadian";
+}
+);
+width = 763;
+}
+);
+note = uni153D;
+unicode = 5437;
+},
+{
+glyphname = "y-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(358,546,l),
+(361,562,l),
+(185,562,l),
+(212,690,l),
+(166,690,l),
+(130,524,l),
+(308,524,l),
+(302,550,l),
+(96,366,l),
+(124,336,l)
+);
+}
+);
+width = 334;
+}
+);
+note = uni153E;
+unicode = 5438;
+},
+{
+glyphname = "biblecreey-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(127,345,l),
+(257,639,l),
+(231,639,l),
+(264,345,l),
+(290,345,l),
+(448,639,l),
+(420,639,l),
+(428,345,l),
+(468,345,l),
+(470,357,l),
+(463,690,l),
+(433,690,l),
+(272,393,l),
+(298,393,l),
+(266,690,l),
+(236,690,l),
+(86,357,l),
+(83,345,l)
+);
+}
+);
+width = 505;
+}
+);
+metricRight = "=|";
+note = uni153F;
+unicode = 5439;
+},
+{
+glyphname = "yWestCree-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(236,193,l),
+(266,334,l),
+(398,334,l),
+(407,378,l),
+(275,378,l),
+(304,517,l),
+(259,517,l),
+(230,378,l),
+(97,378,l),
+(87,334,l),
+(220,334,l),
+(190,193,l)
+);
+}
+);
+width = 443;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1540;
+unicode = 5440;
+},
+{
+glyphname = "yiSayisi-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (39,183);
+ref = "fullstop-canadian";
+}
+);
+width = 335;
+}
+);
+metricLeft = "fullstop-canadian";
+metricWidth = "fullstop-canadian";
+note = uni1541;
+unicode = 5441;
+},
+{
+glyphname = "re-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (343,490);
+},
+{
+name = top_left_can;
+pos = (161,490);
+},
+{
+name = top_right_can;
+pos = (791,490);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(385,-13,o),
+(464,63,o),
+(497,217,cs),
+(540,416,l),
+(808,416,l),
+(819,472,l),
+(491,472,l),
+(438,220,ls),
+(411,99,o),
+(355,43,o),
+(266,43,cs),
+(158,43,o),
+(111,109,o),
+(137,231,cs),
+(189,472,l),
+(128,472,l),
+(77,238,ls),
+(44,84,o),
+(117,-13,o),
+(262,-13,cs)
+);
+}
+);
+width = 832;
+}
+);
+metricRight = "=|ne-canadian";
+note = uni1542;
+unicode = 5442;
+},
+{
+glyphname = "reRCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (595,490);
+},
+{
+name = top_left_can;
+pos = (147,490);
+},
+{
+name = top_right_can;
+pos = (777,490);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(638,-13,o),
+(717,63,o),
+(750,217,cs),
+(804,472,l),
+(742,472,l),
+(689,220,ls),
+(662,99,o),
+(607,43,o),
+(517,43,cs),
+(410,43,o),
+(362,109,o),
+(388,231,cs),
+(440,472,l),
+(112,472,l),
+(100,416,l),
+(368,416,l),
+(329,238,ls),
+(297,84,o),
+(370,-13,o),
+(514,-13,cs)
+);
+}
+);
+width = 831;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1543;
+unicode = 5443;
+},
+{
+glyphname = "leWestCree-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (596,490);
+},
+{
+name = top_left_can;
+pos = (147,490);
+},
+{
+name = top_right_can;
+pos = (778,490);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(341,0,l),
+(394,251,ls),
+(420,373,o),
+(476,430,o),
+(566,430,cs),
+(673,430,o),
+(720,363,o),
+(695,242,cs),
+(642,0,l),
+(704,0,l),
+(754,235,ls),
+(787,388,o),
+(714,484,o),
+(570,484,cs),
+(446,484,o),
+(367,410,o),
+(334,255,cs),
+(292,56,l),
+(24,56,l),
+(13,0,l)
+);
+}
+);
+width = 831;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+unicode = 5444;
+},
+{
+glyphname = "raai-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (128,-200);
+ref = ring_top.canadian;
+}
+);
+width = 831;
+}
+);
+note = uni1545;
+unicode = 5445;
+},
+{
+glyphname = "ri-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (344,490);
+},
+{
+name = top_left_can;
+pos = (162,490);
+},
+{
+name = top_right_can;
+pos = (792,490);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(89,0,l),
+(142,251,ls),
+(168,373,o),
+(224,430,o),
+(320,430,cs),
+(421,430,o),
+(468,362,o),
+(442,242,cs),
+(390,0,l),
+(719,0,l),
+(730,56,l),
+(463,56,l),
+(501,235,ls),
+(534,388,o),
+(461,484,o),
+(323,484,cs),
+(193,484,o),
+(114,410,o),
+(81,255,cs),
+(27,0,l)
+);
+}
+);
+width = 831;
+}
+);
+metricLeft = "re-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+unicode = 5446;
+},
+{
+glyphname = "rii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (185,-200);
+ref = dot_top;
+}
+);
+width = 831;
+}
+);
+note = uni1547;
+unicode = 5447;
+},
+{
+glyphname = "ro-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (321,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(91,0,l),
+(151,283,l),
+(118,255,l),
+(233,255,ls),
+(412,255,o),
+(508,366,o),
+(508,510,cs),
+(508,619,o),
+(435,690,o),
+(315,690,cs),
+(177,690,l),
+(165,634,l),
+(305,634,ls),
+(396,634,o),
+(448,586,o),
+(448,508,cs),
+(448,396,o),
+(373,311,o),
+(240,311,cs),
+(96,311,l),
+(30,0,l)
+);
+}
+);
+width = 521;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1548;
+unicode = 5448;
+},
+{
+glyphname = "roo-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (163,0);
+ref = dot_top;
+}
+);
+width = 522;
+}
+);
+note = uni1549;
+unicode = 5449;
+},
+{
+glyphname = "loWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (349,690);
+},
+{
+name = top_left_can;
+pos = (209,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(180,0,ls),
+(358,0,o),
+(455,111,o),
+(455,255,cs),
+(455,363,o),
+(382,435,o),
+(262,435,cs),
+(156,435,l),
+(179,405,l),
+(239,690,l),
+(177,690,l),
+(111,379,l),
+(252,379,ls),
+(343,379,o),
+(395,331,o),
+(395,253,cs),
+(395,141,o),
+(320,56,o),
+(186,56,cs),
+(43,56,l),
+(31,0,l)
+);
+}
+);
+width = 522;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+unicode = 5450;
+},
+{
+glyphname = "ra-canadian";
+lastChange = "2023-01-13 15:55:07 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (392,690);
+},
+{
+name = top_right_can;
+pos = (506,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(390,0,l),
+(456,311,l),
+(316,311,ls),
+(225,311,o),
+(173,358,o),
+(173,437,cs),
+(173,549,o),
+(248,634,o),
+(382,634,cs),
+(526,634,l),
+(537,690,l),
+(388,690,ls),
+(210,690,o),
+(113,579,o),
+(113,435,cs),
+(113,327,o),
+(186,255,o),
+(306,255,cs),
+(412,255,l),
+(389,285,l),
+(328,0,l)
+);
+}
+);
+width = 521;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+unicode = 5451;
+},
+{
+glyphname = "raa-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (233,0);
+ref = dot_top;
+}
+);
+width = 522;
+}
+);
+note = uni154C;
+unicode = 5452;
+},
+{
+glyphname = "laWestCree-canadian";
+lastChange = "2023-01-13 15:55:07 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (507,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(390,0,l),
+(402,56,l),
+(263,56,ls),
+(172,56,o),
+(120,103,o),
+(120,182,cs),
+(120,294,o),
+(195,379,o),
+(327,379,cs),
+(471,379,l),
+(538,690,l),
+(476,690,l),
+(416,407,l),
+(450,435,l),
+(335,435,ls),
+(156,435,o),
+(59,324,o),
+(59,180,cs),
+(59,71,o),
+(133,0,o),
+(253,0,cs)
+);
+}
+);
+width = 521;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+unicode = 5453;
+},
+{
+glyphname = "rwaa-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (446,0);
+ref = dot_top;
+}
+);
+width = 734;
+}
+);
+note = uni154E;
+unicode = 5454;
+},
+{
+glyphname = "rwaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (233,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (522,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 734;
+}
+);
+note = uni154F;
+unicode = 5455;
+},
+{
+glyphname = "r-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(273,345,l),
+(308,509,l),
+(241,509,ls),
+(195,509,o),
+(174,527,o),
+(174,563,cs),
+(174,615,o),
+(202,651,o),
+(270,651,cs),
+(338,651,l),
+(347,690,l),
+(278,690,ls),
+(185,690,o),
+(131,644,o),
+(131,562,cs),
+(131,507,o),
+(168,470,o),
+(234,470,cs),
+(280,470,l),
+(258,490,l),
+(228,345,l)
+);
+}
+);
+width = 318;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni1550;
+unicode = 5456;
+},
+{
+glyphname = "rWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(165,690,l),
+(159,661,l),
+(338,584,l),
+(343,606,l),
+(131,531,l),
+(128,508,l),
+(306,435,l),
+(311,457,l),
+(100,379,l),
+(92,345,l),
+(102,345,l),
+(344,433,l),
+(349,452,l),
+(166,526,l),
+(162,508,l),
+(376,582,l),
+(381,602,l),
+(176,690,l)
+);
+}
+);
+width = 371;
+}
+);
+metricLeft = "=|lWestCree-canadian";
+metricRight = "=|lWestCree-canadian";
+note = uni1551;
+unicode = 5457;
+},
+{
+glyphname = "rMedial-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(41,-13,l),
+(545,169,l),
+(551,199,l),
+(157,356,l),
+(153,332,l),
+(612,492,l),
+(618,521,l),
+(191,702,l),
+(173,702,l),
+(164,661,l),
+(555,495,l),
+(561,525,l),
+(101,364,l),
+(95,332,l),
+(487,176,l),
+(493,203,l),
+(32,38,l),
+(21,-13,l)
+);
+}
+);
+width = 633;
+}
+);
+metricLeft = "mediall-canadian";
+metricRight = "mediall-canadian";
+note = uni1552;
+unicode = 5458;
+},
+{
+glyphname = "fe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(320,0,l),
+(789,670,l),
+(793,690,l),
+(738,690,l),
+(308,66,l),
+(321,66,l),
+(228,367,l),
+(197,363,l),
+(219,336,o),
+(250,322,o),
+(290,322,cs),
+(416,322,o),
+(471,461,o),
+(471,554,cs),
+(471,641,o),
+(421,702,o),
+(334,702,cs),
+(207,702,o),
+(152,569,o),
+(152,468,cs),
+(152,432,o),
+(158,397,o),
+(172,358,cs),
+(292,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(236,367,o),
+(204,406,o),
+(204,472,cs),
+(204,536,o),
+(236,654,o),
+(331,654,cs),
+(387,654,o),
+(420,614,o),
+(420,552,cs),
+(420,485,o),
+(388,367,o),
+(291,367,cs)
+);
+}
+);
+width = 732;
+}
+);
+metricRight = "e-canadian";
+note = uni1553;
+unicode = 5459;
+},
+{
+glyphname = "faai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (234,0);
+ref = ring_top.canadian;
+}
+);
+width = 733;
+}
+);
+note = uni1554;
+unicode = 5460;
+},
+{
+glyphname = "fi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (449,690);
+},
+{
+name = top_left_can;
+pos = (220,690);
+},
+{
+name = top_right_can;
+pos = (708,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(350,-13,o),
+(400,127,o),
+(400,217,cs),
+(400,307,o),
+(350,369,o),
+(270,369,cs),
+(242,369,o),
+(214,359,o),
+(189,339,c),
+(223,335,l),
+(446,624,l),
+(429,625,l),
+(600,0,l),
+(647,0,l),
+(651,19,l),
+(464,690,l),
+(436,690,l),
+(155,335,ls),
+(109,277,o),
+(81,211,o),
+(81,137,cs),
+(81,47,o),
+(133,-13,o),
+(218,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(164,36,o),
+(133,74,o),
+(133,140,cs),
+(133,205,o),
+(165,323,o),
+(261,323,cs),
+(318,323,o),
+(349,282,o),
+(349,217,cs),
+(349,151,o),
+(317,36,o),
+(220,36,cs)
+);
+}
+);
+width = 732;
+}
+);
+metricLeft = "fe-canadian";
+metricRight = "e-canadian";
+note = uni1555;
+unicode = 5461;
+},
+{
+glyphname = "fii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (291,0);
+ref = dot_top;
+}
+);
+width = 733;
+}
+);
+note = uni1556;
+unicode = 5462;
+},
+{
+glyphname = "fo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (313,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(65,0,l),
+(656,331,l),
+(662,358,l),
+(414,644,ls),
+(383,681,o),
+(345,702,o),
+(297,702,cs),
+(170,702,o),
+(118,565,o),
+(116,474,cs),
+(114,382,o),
+(166,320,o),
+(249,320,cs),
+(365,320,o),
+(428,436,o),
+(429,538,cs),
+(430,568,o),
+(425,594,o),
+(416,615,c),
+(396,587,l),
+(602,348,l),
+(606,361,l),
+(57,55,l),
+(45,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(198,367,o),
+(167,408,o),
+(168,476,cs),
+(169,543,o),
+(201,654,o),
+(296,654,cs),
+(352,654,o),
+(384,613,o),
+(383,547,cs),
+(382,478,o),
+(351,367,o),
+(255,367,cs)
+);
+}
+);
+width = 672;
+}
+);
+metricRight = "o-canadian";
+note = uni1557;
+unicode = 5463;
+},
+{
+glyphname = "foo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "fo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (155,0);
+ref = dot_top;
+}
+);
+width = 671;
+}
+);
+note = uni1558;
+unicode = 5464;
+},
+{
+glyphname = "fa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (552,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(526,0,l),
+(535,46,l),
+(117,354,l),
+(115,337,l),
+(423,590,l),
+(408,623,l),
+(373,578,o),
+(356,515,o),
+(356,468,cs),
+(356,380,o),
+(410,319,o),
+(496,319,cs),
+(618,319,o),
+(672,457,o),
+(672,550,cs),
+(672,642,o),
+(620,702,o),
+(537,702,cs),
+(497,702,o),
+(459,687,o),
+(421,655,cs),
+(63,358,l),
+(57,331,l),
+(506,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(438,367,o),
+(406,406,o),
+(406,471,cs),
+(406,536,o),
+(439,654,o),
+(534,654,cs),
+(590,654,o),
+(622,614,o),
+(622,551,cs),
+(622,485,o),
+(590,367,o),
+(494,367,cs)
+);
+}
+);
+width = 671;
+}
+);
+metricRight = "=|fo-canadian";
+note = uni1559;
+unicode = 5465;
+},
+{
+glyphname = "faa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (393,0);
+ref = dot_top;
+}
+);
+width = 671;
+}
+);
+note = uni155A;
+unicode = 5466;
+},
+{
+glyphname = "fwaa-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (606,0);
+ref = dot_top;
+}
+);
+width = 885;
+}
+);
+note = uni155B;
+unicode = 5467;
+},
+{
+glyphname = "fwaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (393,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (671,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 885;
+}
+);
+note = uni155C;
+unicode = 5468;
+},
+{
+glyphname = "f-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(355,345,l),
+(362,377,l),
+(159,526,l),
+(157,511,l),
+(302,633,l),
+(302,664,l),
+(284,644,o),
+(271,606,o),
+(271,578,cs),
+(271,534,o),
+(298,504,o),
+(339,504,cs),
+(400,504,o),
+(428,571,o),
+(428,621,cs),
+(428,668,o),
+(403,696,o),
+(362,696,cs),
+(340,696,o),
+(319,688,o),
+(296,668,cs),
+(124,526,l),
+(121,509,l),
+(343,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(316,533,o),
+(301,551,o),
+(301,580,cs),
+(301,619,o),
+(323,667,o),
+(360,667,cs),
+(384,667,o),
+(397,650,o),
+(397,621,cs),
+(397,582,o),
+(377,533,o),
+(340,533,cs)
+);
+}
+);
+width = 410;
+}
+);
+note = uni155D;
+unicode = 5469;
+},
+{
+glyphname = "the-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (810,345);
+},
+{
+name = top_center_can;
+pos = (450,690);
+},
+{
+name = top_left_can;
+pos = (205,690);
+},
+{
+name = top_right_can;
+pos = (696,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(494,-13,o),
+(590,79,o),
+(631,266,cs),
+(721,690,l),
+(659,690,l),
+(570,269,ls),
+(536,115,o),
+(461,44,o),
+(326,44,cs),
+(148,44,o),
+(115,149,o),
+(146,291,cs),
+(176,433,l),
+(153,420,l),
+(159,366,o),
+(199,316,o),
+(268,316,cs),
+(394,316,o),
+(446,453,o),
+(449,547,cs),
+(451,639,o),
+(401,702,o),
+(314,702,cs),
+(218,702,o),
+(158,634,o),
+(133,519,cs),
+(87,298,ls),
+(49,122,o),
+(109,-13,o),
+(325,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(213,364,o),
+(182,404,o),
+(182,469,cs),
+(182,534,o),
+(213,654,o),
+(310,654,cs),
+(365,654,o),
+(397,614,o),
+(397,551,cs),
+(397,484,o),
+(366,364,o),
+(269,364,cs)
+);
+}
+);
+width = 698;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155E;
+unicode = 5470;
+},
+{
+glyphname = "theNCree-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(494,-13,o),
+(591,80,o),
+(632,270,cs),
+(676,483,ls),
+(704,614,o),
+(652,702,o),
+(550,702,cs),
+(422,702,o),
+(367,567,o),
+(367,467,cs),
+(367,385,o),
+(410,316,o),
+(498,316,cs),
+(551,316,o),
+(596,345,o),
+(620,393,c),
+(601,412,l),
+(571,269,ls),
+(538,114,o),
+(462,44,o),
+(324,44,cs),
+(168,44,o),
+(112,128,o),
+(147,292,cs),
+(232,690,l),
+(170,690,l),
+(86,294,ls),
+(43,98,o),
+(132,-13,o),
+(322,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(450,364,o),
+(419,404,o),
+(419,469,cs),
+(419,534,o),
+(451,654,o),
+(547,654,cs),
+(602,654,o),
+(634,614,o),
+(634,551,cs),
+(634,484,o),
+(602,364,o),
+(505,364,cs)
+);
+}
+);
+width = 698;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155F;
+unicode = 5471;
+},
+{
+glyphname = "thi-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (444,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(322,-13,o),
+(377,123,o),
+(377,223,cs),
+(377,304,o),
+(334,374,o),
+(245,374,cs),
+(193,374,o),
+(148,345,o),
+(124,297,c),
+(143,278,l),
+(173,421,ls),
+(206,576,o),
+(282,645,o),
+(420,645,cs),
+(576,645,o),
+(632,561,o),
+(597,398,cs),
+(512,0,l),
+(574,0,l),
+(658,396,ls),
+(699,592,o),
+(611,702,o),
+(422,702,cs),
+(250,702,o),
+(153,610,o),
+(112,419,cs),
+(68,207,ls),
+(40,75,o),
+(92,-13,o),
+(194,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(142,36,o),
+(110,75,o),
+(110,139,cs),
+(110,206,o),
+(142,326,o),
+(239,326,cs),
+(294,326,o),
+(325,286,o),
+(325,220,cs),
+(325,156,o),
+(293,36,o),
+(197,36,cs)
+);
+}
+);
+width = 697;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1560;
+unicode = 5472;
+},
+{
+glyphname = "thiNCree-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (444,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(526,-13,o),
+(585,56,o),
+(611,171,cs),
+(657,391,ls),
+(695,568,o),
+(635,702,o),
+(419,702,cs),
+(250,702,o),
+(154,611,o),
+(113,424,cs),
+(23,0,l),
+(85,0,l),
+(174,421,ls),
+(207,575,o),
+(283,645,o),
+(418,645,cs),
+(596,645,o),
+(629,541,o),
+(598,399,cs),
+(568,257,l),
+(591,270,l),
+(584,324,o),
+(545,374,o),
+(476,374,cs),
+(350,374,o),
+(298,237,o),
+(295,143,cs),
+(293,50,o),
+(343,-13,o),
+(430,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(379,36,o),
+(347,75,o),
+(347,139,cs),
+(347,206,o),
+(379,326,o),
+(475,326,cs),
+(531,326,o),
+(562,286,o),
+(562,220,cs),
+(562,156,o),
+(530,36,o),
+(434,36,cs)
+);
+}
+);
+width = 698;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1561;
+unicode = 5473;
+},
+{
+glyphname = "thii-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "thi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (285,0);
+ref = dot_top;
+}
+);
+width = 697;
+}
+);
+note = uni1562;
+unicode = 5474;
+},
+{
+glyphname = "thiiNCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "thiNCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (285,0);
+ref = dot_top;
+}
+);
+width = 697;
+}
+);
+note = uni1563;
+unicode = 5475;
+},
+{
+glyphname = "tho-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (396,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(223,0,ls),
+(515,0,o),
+(614,242,o),
+(614,430,cs),
+(614,596,o),
+(521,702,o),
+(374,702,cs),
+(207,702,o),
+(125,573,o),
+(125,442,cs),
+(125,354,o),
+(175,294,o),
+(258,294,cs),
+(377,294,o),
+(436,423,o),
+(436,524,cs),
+(436,611,o),
+(384,667,o),
+(302,663,c),
+(299,641,l),
+(315,651,o),
+(340,656,o),
+(370,656,cs),
+(483,656,o),
+(554,574,o),
+(554,436,cs),
+(554,296,o),
+(496,56,o),
+(228,56,cs),
+(70,56,l),
+(58,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(207,341,o),
+(176,380,o),
+(176,443,cs),
+(176,507,o),
+(209,633,o),
+(304,633,cs),
+(358,633,o),
+(388,594,o),
+(388,531,cs),
+(388,467,o),
+(356,341,o),
+(261,341,cs)
+);
+}
+);
+width = 650;
+}
+);
+metricRight = "to-canadian";
+note = uni1564;
+unicode = 5476;
+},
+{
+glyphname = "thoo-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "tho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (237,0);
+ref = dot_top;
+}
+);
+width = 652;
+}
+);
+note = uni1565;
+unicode = 5477;
+},
+{
+glyphname = "tha-canadian";
+lastChange = "2023-01-13 15:55:07 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (451,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(496,0,l),
+(507,56,l),
+(360,56,ls),
+(219,56,o),
+(143,130,o),
+(143,267,cs),
+(143,408,o),
+(218,655,o),
+(426,655,cs),
+(465,655,o),
+(503,646,o),
+(531,630,c),
+(511,660,l),
+(387,677,o),
+(319,550,o),
+(319,440,cs),
+(319,352,o),
+(368,294,o),
+(451,294,cs),
+(569,294,o),
+(633,419,o),
+(633,526,cs),
+(633,636,o),
+(556,701,o),
+(429,701,cs),
+(181,701,o),
+(82,439,o),
+(82,262,cs),
+(82,99,o),
+(179,0,o),
+(347,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(400,341,o),
+(368,380,o),
+(368,443,cs),
+(368,507,o),
+(401,633,o),
+(496,633,cs),
+(551,633,o),
+(581,594,o),
+(581,531,cs),
+(581,467,o),
+(549,341,o),
+(453,341,cs)
+);
+}
+);
+width = 652;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tho-canadian";
+note = uni1566;
+unicode = 5478;
+},
+{
+glyphname = "thaa-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (293,0);
+ref = dot_top;
+}
+);
+width = 652;
+}
+);
+note = uni1567;
+unicode = 5479;
+},
+{
+glyphname = "thwaa-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (506,0);
+ref = dot_top;
+}
+);
+width = 865;
+}
+);
+note = uni1568;
+unicode = 5480;
+},
+{
+glyphname = "thwaaWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (293,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (652,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 865;
+}
+);
+note = uni1569;
+unicode = 5481;
+},
+{
+glyphname = "th-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(329,345,l),
+(338,384,l),
+(265,384,ls),
+(197,384,o),
+(163,418,o),
+(163,480,cs),
+(163,547,o),
+(200,665,o),
+(298,665,cs),
+(315,665,o),
+(334,660,o),
+(349,652,c),
+(331,672,l),
+(267,677,o),
+(241,611,o),
+(241,565,cs),
+(241,521,o),
+(267,492,o),
+(307,492,cs),
+(371,492,o),
+(397,564,o),
+(397,608,cs),
+(397,662,o),
+(360,696,o),
+(296,696,cs),
+(172,696,o),
+(122,565,o),
+(122,477,cs),
+(122,394,o),
+(172,345,o),
+(256,345,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(283,521,o),
+(270,537,o),
+(270,565,cs),
+(270,596,o),
+(284,653,o),
+(327,653,cs),
+(353,653,o),
+(367,637,o),
+(367,609,cs),
+(367,579,o),
+(353,521,o),
+(308,521,cs)
+);
+}
+);
+width = 382;
+}
+);
+metricLeft = "t-canadian";
+note = uni156A;
+unicode = 5482;
+},
+{
+glyphname = "tthe-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (797,345);
+},
+{
+name = top_center_can;
+pos = (440,690);
+},
+{
+name = top_left_can;
+pos = (201,690);
+},
+{
+name = top_right_can;
+pos = (681,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(484,-13,o),
+(582,76,o),
+(622,269,cs),
+(712,690,l),
+(652,690,l),
+(562,270,ls),
+(529,115,o),
+(454,45,o),
+(321,45,cs),
+(170,45,o),
+(110,126,o),
+(146,291,cs),
+(230,690,l),
+(170,690,l),
+(86,294,ls),
+(43,97,o),
+(132,-13,o),
+(318,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(403,391,l),
+(467,690,l),
+(415,690,l),
+(352,391,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156B;
+unicode = 5483;
+},
+{
+glyphname = "tthi-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(83,0,l),
+(173,420,ls),
+(206,575,o),
+(281,644,o),
+(414,644,cs),
+(564,644,o),
+(625,564,o),
+(589,399,cs),
+(505,0,l),
+(565,0,l),
+(649,396,ls),
+(692,593,o),
+(603,702,o),
+(417,702,cs),
+(251,702,o),
+(154,613,o),
+(113,421,cs),
+(23,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(320,0,l),
+(384,298,l),
+(332,298,l),
+(269,0,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156C;
+unicode = 5484;
+},
+{
+glyphname = "ttho-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (394,690);
+},
+{
+name = top_left_can;
+pos = (203,690);
+},
+{
+name = top_right_can;
+pos = (608,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(178,0,ls),
+(487,0,o),
+(570,263,o),
+(570,434,cs),
+(570,596,o),
+(476,690,o),
+(307,690,cs),
+(176,690,l),
+(164,634,l),
+(299,634,ls),
+(437,634,o),
+(508,563,o),
+(508,432,cs),
+(508,289,o),
+(442,56,o),
+(185,56,cs),
+(41,56,l),
+(29,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(325,320,l),
+(335,371,l),
+(108,371,l),
+(98,320,l)
+);
+}
+);
+width = 605;
+}
+);
+metricRight = "to-canadian";
+note = uni156D;
+unicode = 5485;
+},
+{
+glyphname = "ttha-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (410,690);
+},
+{
+name = top_left_can;
+pos = (192,690);
+},
+{
+name = top_right_can;
+pos = (590,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(476,0,l),
+(488,56,l),
+(352,56,ls),
+(214,56,o),
+(144,127,o),
+(144,258,cs),
+(144,403,o),
+(210,634,o),
+(467,634,cs),
+(611,634,l),
+(623,690,l),
+(473,690,ls),
+(165,690,o),
+(82,428,o),
+(82,256,cs),
+(82,94,o),
+(175,0,o),
+(344,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(542,320,l),
+(554,371,l),
+(327,371,l),
+(315,320,l)
+);
+}
+);
+width = 605;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|ttho-canadian";
+note = uni156E;
+unicode = 5486;
+},
+{
+glyphname = "tth-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(278,489,l),
+(262,489,l),
+(327,358,l),
+(365,378,l),
+(296,512,l),
+(288,496,l),
+(446,550,l),
+(434,586,l),
+(283,535,l),
+(296,527,l),
+(330,690,l),
+(289,690,l),
+(254,526,l),
+(270,534,l),
+(134,586,l),
+(120,550,l),
+(250,499,l),
+(248,516,l),
+(128,386,l),
+(157,358,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(668,489,l),
+(652,489,l),
+(718,358,l),
+(755,378,l),
+(686,512,l),
+(678,496,l),
+(837,549,l),
+(824,586,l),
+(673,535,l),
+(686,527,l),
+(721,690,l),
+(678,690,l),
+(644,526,l),
+(660,534,l),
+(524,586,l),
+(510,550,l),
+(640,499,l),
+(639,516,l),
+(518,386,l),
+(548,358,l)
+);
+}
+);
+width = 823;
+}
+);
+metricRight = "=|";
+note = uni156F;
+unicode = 5487;
+},
+{
+glyphname = "tye-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(485,-13,o),
+(582,79,o),
+(622,268,cs),
+(712,690,l),
+(652,690,l),
+(563,274,ls),
+(530,116,o),
+(454,45,o),
+(321,45,cs),
+(170,45,o),
+(110,126,o),
+(145,291,cs),
+(230,690,l),
+(170,690,l),
+(86,294,ls),
+(43,98,o),
+(132,-13,o),
+(319,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(461,412,o),
+(504,453,o),
+(523,539,cs),
+(554,690,l),
+(519,690,l),
+(488,545,ls),
+(473,478,o),
+(443,448,o),
+(391,448,cs),
+(337,448,o),
+(319,478,o),
+(333,547,cs),
+(363,690,l),
+(327,690,l),
+(297,546,ls),
+(279,461,o),
+(314,412,o),
+(390,412,cs)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1570;
+unicode = 5488;
+},
+{
+glyphname = "tyi-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(83,0,l),
+(172,415,ls),
+(205,574,o),
+(281,644,o),
+(414,644,cs),
+(565,644,o),
+(625,564,o),
+(590,399,cs),
+(505,0,l),
+(565,0,l),
+(649,396,ls),
+(692,592,o),
+(603,702,o),
+(416,702,cs),
+(250,702,o),
+(154,611,o),
+(113,422,cs),
+(23,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(216,0,l),
+(247,145,ls),
+(262,212,o),
+(292,242,o),
+(344,242,cs),
+(398,242,o),
+(416,212,o),
+(402,143,cs),
+(372,0,l),
+(408,0,l),
+(439,144,ls),
+(456,229,o),
+(421,278,o),
+(344,278,cs),
+(273,278,o),
+(231,237,o),
+(213,151,cs),
+(181,0,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1571;
+unicode = 5489;
+},
+{
+glyphname = "tyo-canadian";
+lastChange = "2023-01-13 15:55:07 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(178,0,ls),
+(488,0,o),
+(571,263,o),
+(571,434,cs),
+(571,596,o),
+(476,690,o),
+(307,690,cs),
+(177,690,l),
+(165,634,l),
+(299,634,ls),
+(437,634,o),
+(509,563,o),
+(509,432,cs),
+(509,282,o),
+(437,56,o),
+(184,56,cs),
+(43,56,l),
+(31,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(160,210,ls),
+(274,210,o),
+(324,286,o),
+(326,368,cs),
+(327,438,o),
+(284,480,o),
+(210,480,cs),
+(132,480,l),
+(125,442,l),
+(201,442,ls),
+(257,442,o),
+(287,415,o),
+(286,367,cs),
+(286,309,o),
+(253,247,o),
+(165,247,cs),
+(83,247,l),
+(74,210,l)
+);
+}
+);
+width = 606;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1572;
+unicode = 5490;
+},
+{
+glyphname = "tya-canadian";
+lastChange = "2023-01-13 15:55:07 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(475,0,l),
+(487,56,l),
+(354,56,ls),
+(216,56,o),
+(144,127,o),
+(144,258,cs),
+(144,408,o),
+(217,634,o),
+(469,634,cs),
+(611,634,l),
+(622,690,l),
+(476,690,ls),
+(166,690,o),
+(82,427,o),
+(82,256,cs),
+(82,94,o),
+(177,0,o),
+(346,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(521,210,l),
+(528,247,l),
+(453,247,ls),
+(397,247,o),
+(367,274,o),
+(367,323,cs),
+(368,381,o),
+(401,442,o),
+(489,442,cs),
+(570,442,l),
+(578,480,l),
+(493,480,ls),
+(379,480,o),
+(329,404,o),
+(328,322,cs),
+(327,252,o),
+(370,210,o),
+(444,210,cs)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1573;
+unicode = 5491;
+},
+{
+glyphname = "heNunavik-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(438,0,l),
+(706,191,l),
+(674,238,l),
+(436,68,l),
+(456,52,l),
+(534,421,ls),
+(563,556,o),
+(520,702,o),
+(356,702,cs),
+(180,702,o),
+(111,526,o),
+(111,401,cs),
+(111,281,o),
+(182,206,o),
+(292,206,cs),
+(373,206,o),
+(436,250,o),
+(468,327,c),
+(450,316,l),
+(383,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(220,259,o),
+(171,313,o),
+(171,402,cs),
+(171,492,o),
+(217,648,o),
+(352,648,cs),
+(435,648,o),
+(483,594,o),
+(483,504,cs),
+(483,412,o),
+(437,259,o),
+(303,259,cs)
+);
+}
+);
+width = 745;
+}
+);
+metricLeft = "ke-canadian";
+note = uni1574;
+unicode = 5492;
+},
+{
+glyphname = "hiNunavik-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (561,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(263,0,l),
+(340,363,l),
+(328,356,l),
+(325,277,o),
+(388,206,o),
+(488,206,cs),
+(661,206,o),
+(726,384,o),
+(726,504,cs),
+(726,627,o),
+(655,702,o),
+(538,702,cs),
+(418,702,o),
+(333,623,o),
+(303,482,cs),
+(212,49,l),
+(235,55,l),
+(60,231,l),
+(19,191,l),
+(208,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(403,259,o),
+(355,313,o),
+(355,403,cs),
+(355,492,o),
+(400,648,o),
+(534,648,cs),
+(618,648,o),
+(667,595,o),
+(667,505,cs),
+(667,415,o),
+(621,259,o),
+(487,259,cs)
+);
+}
+);
+width = 745;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1575;
+unicode = 5493;
+},
+{
+glyphname = "hiiNunavik-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "hiNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (401,0);
+ref = dot_top;
+}
+);
+width = 745;
+}
+);
+note = uni1576;
+unicode = 5494;
+},
+{
+glyphname = "hoNunavik-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (378,690);
+},
+{
+name = top_right_can;
+pos = (560,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(374,-13,o),
+(459,67,o),
+(489,208,cs),
+(581,640,l),
+(557,635,l),
+(731,459,l),
+(772,498,l),
+(584,690,l),
+(529,690,l),
+(452,327,l),
+(463,333,l),
+(468,412,o),
+(404,484,o),
+(303,484,cs),
+(130,484,o),
+(65,305,o),
+(65,185,cs),
+(65,63,o),
+(136,-13,o),
+(254,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(174,42,o),
+(125,95,o),
+(125,185,cs),
+(125,274,o),
+(171,431,o),
+(305,431,cs),
+(388,431,o),
+(437,377,o),
+(437,287,cs),
+(437,198,o),
+(391,42,o),
+(257,42,cs)
+);
+}
+);
+width = 745;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "heNunavik-canadian";
+note = uni1577;
+unicode = 5495;
+},
+{
+glyphname = "hooNunavik-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "hoNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (402,0);
+ref = dot_top;
+}
+);
+width = 745;
+}
+);
+note = uni1578;
+unicode = 5496;
+},
+{
+glyphname = "haNunavik-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (560,690);
+},
+{
+name = top_left_can;
+pos = (378,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(611,-13,o),
+(681,163,o),
+(681,289,cs),
+(681,409,o),
+(611,484,o),
+(499,484,cs),
+(418,484,o),
+(356,440,o),
+(325,363,c),
+(342,374,l),
+(409,690,l),
+(355,690,l),
+(85,498,l),
+(117,452,l),
+(356,622,l),
+(336,638,l),
+(258,269,ls),
+(229,133,o),
+(272,-13,o),
+(436,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(357,42,o),
+(308,96,o),
+(308,185,cs),
+(308,278,o),
+(355,431,o),
+(489,431,cs),
+(572,431,o),
+(620,377,o),
+(620,288,cs),
+(620,198,o),
+(575,42,o),
+(440,42,cs)
+);
+}
+);
+width = 746;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1579;
+unicode = 5497;
+},
+{
+glyphname = "haaNunavik-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "haNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (218,0);
+ref = dot_top;
+}
+);
+width = 745;
+}
+);
+note = uni157A;
+unicode = 5498;
+},
+{
+glyphname = "hNunavik-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(396,339,o),
+(443,428,o),
+(443,499,cs),
+(443,560,o),
+(407,601,o),
+(351,601,cs),
+(312,601,o),
+(280,582,o),
+(261,550,c),
+(268,541,l),
+(299,690,l),
+(257,690,l),
+(122,594,l),
+(144,563,l),
+(268,651,l),
+(249,669,l),
+(210,484,ls),
+(192,406,o),
+(227,339,o),
+(307,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(271,376,o),
+(246,400,o),
+(246,444,cs),
+(246,500,o),
+(278,564,o),
+(338,564,cs),
+(378,564,o),
+(403,539,o),
+(403,497,cs),
+(403,440,o),
+(370,376,o),
+(310,376,cs)
+);
+}
+);
+width = 449;
+}
+);
+metricRight = "k-canadian";
+note = uni157B;
+unicode = 5499;
+},
+{
+color = 4;
+glyphname = "nunavuth-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(92,0,l),
+(162,330,l),
+(537,330,l),
+(467,0,l),
+(528,0,l),
+(675,690,l),
+(613,690,l),
+(549,385,l),
+(175,385,l),
+(239,690,l),
+(177,690,l),
+(30,0,l)
+);
+}
+);
+width = 658;
+}
+);
+metricRight = "=|";
+note = uni157C;
+unicode = 5500;
+},
+{
+glyphname = "hk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (73,345);
+ref = "fullstop-canadian";
+}
+);
+width = 335;
+}
+);
+metricLeft = "fullstop-canadian";
+note = uni157D;
+unicode = 5501;
+},
+{
+glyphname = "qaai-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (318,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (480,0);
+ref = ring_top.canadian;
+}
+);
+width = 886;
+}
+);
+note = uni157E;
+unicode = 5502;
+},
+{
+glyphname = "qi-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (318,0);
+ref = "ki-canadian";
+}
+);
+width = 886;
+}
+);
+note = uni157F;
+unicode = 5503;
+},
+{
+glyphname = "qii-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (318,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (537,0);
+ref = dot_top;
+}
+);
+width = 886;
+}
+);
+note = uni1580;
+unicode = 5504;
+},
+{
+glyphname = "qo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (318,0);
+ref = "ko-canadian";
+}
+);
+width = 886;
+}
+);
+note = uni1581;
+unicode = 5505;
+},
+{
+glyphname = "qoo-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (318,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (719,0);
+ref = dot_top;
+}
+);
+width = 886;
+}
+);
+note = uni1582;
+unicode = 5506;
+},
+{
+glyphname = "qa-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (318,0);
+ref = "ka-canadian";
+}
+);
+width = 886;
+}
+);
+note = uni1583;
+unicode = 5507;
+},
+{
+glyphname = "qaa-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (318,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (359,0);
+ref = dot_top;
+}
+);
+width = 886;
+}
+);
+note = uni1584;
+unicode = 5508;
+},
+{
+glyphname = "q-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (318,0);
+ref = "k-canadian";
+}
+);
+width = 679;
+}
+);
+note = uni1585;
+unicode = 5509;
+},
+{
+glyphname = "tlhe-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (383,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,0,l),
+(313,266,l),
+(270,242,l),
+(279,242,o),
+(290,242,o),
+(299,242,cs),
+(371,242,o),
+(431,274,o),
+(467,335,c),
+(463,350,l),
+(388,0,l),
+(449,0,l),
+(545,449,ls),
+(574,586,o),
+(513,702,o),
+(362,702,cs),
+(206,702,o),
+(120,566,o),
+(120,429,cs),
+(120,342,o),
+(166,276,o),
+(241,255,c),
+(55,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(229,296,o),
+(180,350,o),
+(180,435,cs),
+(180,529,o),
+(238,648,o),
+(358,648,cs),
+(445,648,o),
+(492,597,o),
+(492,515,cs),
+(492,416,o),
+(432,296,o),
+(309,296,cs)
+);
+}
+);
+width = 573;
+}
+);
+metricRight = "te-canadian";
+note = uni1586;
+unicode = 5510;
+},
+{
+glyphname = "tlhi-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(84,0,l),
+(164,377,l),
+(144,368,l),
+(160,298,o),
+(220,248,o),
+(301,243,c),
+(271,268,l),
+(352,0,l),
+(417,0,l),
+(343,247,l),
+(476,257,o),
+(554,391,o),
+(554,512,cs),
+(554,626,o),
+(480,702,o),
+(360,702,cs),
+(241,702,o),
+(156,627,o),
+(126,485,cs),
+(23,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(231,296,o),
+(181,347,o),
+(181,431,cs),
+(181,527,o),
+(239,648,o),
+(360,648,cs),
+(445,648,o),
+(494,596,o),
+(494,514,cs),
+(494,417,o),
+(436,296,o),
+(315,296,cs)
+);
+}
+);
+width = 574;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|tlhe-canadian";
+note = uni1587;
+unicode = 5511;
+},
+{
+glyphname = "tlho-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (402,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(379,-13,o),
+(463,63,o),
+(494,205,cs),
+(597,690,l),
+(535,690,l),
+(456,313,l),
+(475,322,l),
+(459,392,o),
+(399,441,o),
+(318,446,c),
+(348,422,l),
+(268,690,l),
+(202,690,l),
+(276,442,l),
+(144,433,o),
+(66,298,o),
+(66,178,cs),
+(66,64,o),
+(139,-13,o),
+(259,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(175,42,o),
+(126,94,o),
+(126,176,cs),
+(126,272,o),
+(184,394,o),
+(304,394,cs),
+(388,394,o),
+(439,343,o),
+(439,259,cs),
+(439,162,o),
+(381,42,o),
+(260,42,cs)
+);
+}
+);
+width = 574;
+}
+);
+metricLeft = "tlhe-canadian";
+metricRight = "te-canadian";
+note = uni1588;
+unicode = 5512;
+},
+{
+glyphname = "tlha-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(413,-13,o),
+(499,124,o),
+(499,261,cs),
+(499,348,o),
+(453,413,o),
+(379,435,c),
+(564,690,l),
+(498,690,l),
+(306,424,l),
+(350,447,l),
+(340,448,o),
+(329,448,o),
+(320,448,cs),
+(248,448,o),
+(188,415,o),
+(153,355,c),
+(156,340,l),
+(231,690,l),
+(170,690,l),
+(74,241,ls),
+(45,103,o),
+(106,-13,o),
+(257,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(175,42,o),
+(128,93,o),
+(128,175,cs),
+(128,273,o),
+(188,394,o),
+(310,394,cs),
+(390,394,o),
+(440,340,o),
+(440,255,cs),
+(440,160,o),
+(382,42,o),
+(262,42,cs)
+);
+}
+);
+width = 573;
+}
+);
+metricLeft = "te-canadian";
+note = uni1589;
+unicode = 5513;
+},
+{
+glyphname = "reWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(435,0,l),
+(702,191,l),
+(670,237,l),
+(432,67,l),
+(452,53,l),
+(534,440,ls),
+(567,596,o),
+(497,702,o),
+(355,702,cs),
+(227,702,o),
+(152,626,o),
+(118,469,cs),
+(100,391,l),
+(162,391,l),
+(178,467,ls),
+(204,591,o),
+(259,647,o),
+(351,647,cs),
+(458,647,o),
+(500,571,o),
+(474,448,cs),
+(380,0,l)
+);
+}
+);
+width = 741;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+unicode = 5514;
+},
+{
+glyphname = "riWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(262,0,l),
+(360,467,ls),
+(386,591,o),
+(441,647,o),
+(534,647,cs),
+(641,647,o),
+(685,570,o),
+(657,448,cs),
+(645,391,l),
+(707,391,l),
+(718,440,ls),
+(752,596,o),
+(680,702,o),
+(538,702,cs),
+(410,702,o),
+(334,626,o),
+(300,469,cs),
+(212,50,l),
+(235,57,l),
+(62,233,l),
+(19,191,l),
+(207,0,l)
+);
+}
+);
+width = 742;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+unicode = 5515;
+},
+{
+glyphname = "roWestCree-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(377,-13,o),
+(453,64,o),
+(487,220,cs),
+(576,639,l),
+(553,633,l),
+(724,457,l),
+(767,498,l),
+(581,690,l),
+(525,690,l),
+(426,223,ls),
+(400,99,o),
+(345,43,o),
+(253,43,cs),
+(145,43,o),
+(102,120,o),
+(129,242,cs),
+(142,298,l),
+(80,298,l),
+(70,249,ls),
+(36,94,o),
+(106,-13,o),
+(248,-13,cs)
+);
+}
+);
+width = 740;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+unicode = 5516;
+},
+{
+glyphname = "raWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(560,-13,o),
+(636,64,o),
+(669,220,cs),
+(687,298,l),
+(625,298,l),
+(610,223,ls),
+(583,99,o),
+(528,43,o),
+(437,43,cs),
+(329,43,o),
+(287,119,o),
+(313,242,cs),
+(408,690,l),
+(353,690,l),
+(85,498,l),
+(117,453,l),
+(355,623,l),
+(335,637,l),
+(253,249,ls),
+(220,94,o),
+(290,-13,o),
+(432,-13,cs)
+);
+}
+);
+width = 741;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+unicode = 5517;
+},
+{
+glyphname = "ngaai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:09 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (626,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (794,0);
+ref = ring_top.canadian;
+}
+);
+width = 1190;
+}
+);
+note = uni158E;
+unicode = 5518;
+},
+{
+glyphname = "ngi-canadian";
+kernLeft = mwestleft;
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:09 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (626,0);
+ref = "ci-canadian";
+}
+);
+width = 1190;
+}
+);
+note = uni158F;
+unicode = 5519;
+},
+{
+glyphname = "ngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:09 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (626,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (852,0);
+ref = dot_top;
+}
+);
+width = 1190;
+}
+);
+note = uni1590;
+unicode = 5520;
+},
+{
+glyphname = "ngo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:55:09 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (599,0);
+ref = "co-canadian";
+}
+);
+width = 1162;
+}
+);
+note = uni1591;
+unicode = 5521;
+},
+{
+glyphname = "ngoo-canadian";
+lastChange = "2023-01-13 15:55:09 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "ngo-canadian";
+},
+{
+anchor = top_right_can;
+pos = (997,0);
+ref = dot_top;
+}
+);
+width = 1162;
+}
+);
+note = uni1592;
+unicode = 5522;
+},
+{
+glyphname = "nga-canadian";
+kernLeft = mwestleft;
+kernRight = caright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (625,0);
+ref = "ca-canadian";
+}
+);
+width = 1189;
+}
+);
+note = uni1593;
+unicode = 5523;
+},
+{
+glyphname = "ngaa-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (625,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (668,0);
+ref = dot_top;
+}
+);
+width = 1189;
+}
+);
+note = uni1594;
+unicode = 5524;
+},
+{
+glyphname = "ng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(533,217,o),
+(581,261,o),
+(600,341,cs),
+(605,363,l),
+(561,363,l),
+(555,338,ls),
+(543,283,o),
+(513,256,o),
+(467,256,cs),
+(417,256,o),
+(397,287,o),
+(410,344,cs),
+(438,477,l),
+(297,477,l),
+(300,458,l),
+(344,481,o),
+(364,543,o),
+(364,585,cs),
+(365,651,o),
+(325,696,o),
+(258,696,cs),
+(173,696,o),
+(128,616,o),
+(127,546,cs),
+(126,478,o),
+(167,434,o),
+(235,434,cs),
+(399,434,l),
+(386,452,l),
+(365,351,ls),
+(348,270,o),
+(387,217,o),
+(464,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(192,470,o),
+(168,498,o),
+(169,543,cs),
+(169,587,o),
+(192,660,o),
+(258,660,cs),
+(299,660,o),
+(324,631,o),
+(323,586,cs),
+(323,543,o),
+(299,470,o),
+(234,470,cs)
+);
+}
+);
+width = 626;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1595;
+unicode = 5525;
+},
+{
+glyphname = "nng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(811,217,o),
+(859,261,o),
+(876,341,cs),
+(881,363,l),
+(837,363,l),
+(832,338,ls),
+(819,283,o),
+(789,256,o),
+(744,256,cs),
+(694,256,o),
+(673,287,o),
+(686,344,cs),
+(715,477,l),
+(576,477,l),
+(578,458,l),
+(622,481,o),
+(642,546,o),
+(642,588,cs),
+(642,653,o),
+(602,696,o),
+(536,696,cs),
+(450,696,o),
+(405,615,o),
+(405,542,cs),
+(405,507,o),
+(417,479,o),
+(440,461,c),
+(449,477,l),
+(297,477,l),
+(298,458,l),
+(344,482,o),
+(363,547,o),
+(363,587,cs),
+(363,653,o),
+(323,696,o),
+(258,696,cs),
+(172,696,o),
+(127,615,o),
+(127,542,cs),
+(127,476,o),
+(167,434,o),
+(233,434,cs),
+(660,434,l),
+(641,351,ls),
+(624,270,o),
+(665,217,o),
+(741,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(191,470,o),
+(167,498,o),
+(167,541,cs),
+(167,584,o),
+(190,660,o),
+(257,660,cs),
+(298,660,o),
+(323,632,o),
+(323,589,cs),
+(323,546,o),
+(299,470,o),
+(233,470,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(470,470,o),
+(446,498,o),
+(446,541,cs),
+(446,584,o),
+(469,660,o),
+(536,660,cs),
+(577,660,o),
+(601,632,o),
+(601,589,cs),
+(601,546,o),
+(579,470,o),
+(511,470,cs)
+);
+}
+);
+width = 902;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1596;
+unicode = 5526;
+},
+{
+glyphname = "sheSayisi-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (681,345);
+},
+{
+name = top_center_can;
+pos = (385,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(451,0,l),
+(543,432,ls),
+(574,580,o),
+(525,702,o),
+(368,702,cs),
+(179,702,o),
+(106,505,o),
+(106,371,cs),
+(106,270,o),
+(154,207,o),
+(239,207,cs),
+(325,207,o),
+(379,273,o),
+(404,411,c),
+(365,411,l),
+(345,307,o),
+(308,260,o),
+(248,260,cs),
+(194,260,o),
+(165,299,o),
+(165,370,cs),
+(165,469,o),
+(215,648,o),
+(363,648,cs),
+(477,648,o),
+(507,555,o),
+(481,434,cs),
+(389,0,l)
+);
+}
+);
+width = 574;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1597;
+unicode = 5527;
+},
+{
+glyphname = "shiSayisi-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(85,0,l),
+(184,467,ls),
+(209,586,o),
+(270,648,o),
+(360,648,cs),
+(447,648,o),
+(496,596,o),
+(496,505,cs),
+(496,428,o),
+(454,260,o),
+(354,260,cs),
+(288,260,o),
+(260,315,o),
+(283,411,c),
+(244,411,l),
+(213,290,o),
+(260,207,o),
+(356,207,cs),
+(498,207,o),
+(554,399,o),
+(554,505,cs),
+(554,627,o),
+(483,702,o),
+(362,702,cs),
+(239,702,o),
+(155,622,o),
+(125,476,cs),
+(23,0,l)
+);
+}
+);
+width = 573;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni1598;
+unicode = 5528;
+},
+{
+glyphname = "shoSayisi-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (382,690);
+},
+{
+name = top_left_can;
+pos = (195,690);
+},
+{
+name = top_right_can;
+pos = (567,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(383,-13,o),
+(465,68,o),
+(496,213,cs),
+(597,690,l),
+(535,690,l),
+(436,223,ls),
+(411,103,o),
+(351,42,o),
+(260,42,cs),
+(173,42,o),
+(126,94,o),
+(126,185,cs),
+(126,262,o),
+(166,430,o),
+(267,430,cs),
+(332,430,o),
+(360,375,o),
+(337,279,c),
+(377,279,l),
+(408,400,o),
+(360,483,o),
+(264,483,cs),
+(122,483,o),
+(66,291,o),
+(66,185,cs),
+(66,63,o),
+(137,-13,o),
+(258,-13,cs)
+);
+}
+);
+width = 574;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1599;
+unicode = 5529;
+},
+{
+glyphname = "shaSayisi-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(441,-13,o),
+(514,185,o),
+(514,319,cs),
+(514,420,o),
+(467,483,o),
+(383,483,cs),
+(297,483,o),
+(242,416,o),
+(216,279,c),
+(255,279,l),
+(276,383,o),
+(313,430,o),
+(372,430,cs),
+(426,430,o),
+(455,390,o),
+(455,320,cs),
+(455,220,o),
+(405,42,o),
+(258,42,cs),
+(143,42,o),
+(113,134,o),
+(139,256,cs),
+(232,690,l),
+(170,690,l),
+(78,258,ls),
+(46,110,o),
+(96,-13,o),
+(253,-13,cs)
+);
+}
+);
+width = 574;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni159A;
+unicode = 5530;
+},
+{
+glyphname = "theWoodScree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(649,-13,o),
+(730,146,o),
+(730,274,cs),
+(730,393,o),
+(653,472,o),
+(529,472,cs),
+(122,472,l),
+(111,419,l),
+(449,419,l),
+(450,443,l),
+(326,410,o),
+(285,275,o),
+(285,187,cs),
+(285,69,o),
+(361,-13,o),
+(482,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(398,42,o),
+(345,100,o),
+(345,189,cs),
+(345,289,o),
+(404,418,o),
+(529,418,cs),
+(617,418,o),
+(670,361,o),
+(670,273,cs),
+(670,176,o),
+(613,42,o),
+(484,42,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(805,637,l),
+(815,690,l),
+(168,690,l),
+(157,637,l)
+);
+}
+);
+width = 801;
+}
+);
+note = uni159B;
+unicode = 5531;
+},
+{
+glyphname = "thiWoodScree-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(432,-13,o),
+(513,146,o),
+(513,274,cs),
+(513,343,o),
+(483,397,o),
+(436,424,c),
+(426,419,l),
+(767,419,l),
+(778,472,l),
+(322,472,ls),
+(151,472,o),
+(68,323,o),
+(68,187,cs),
+(68,69,o),
+(144,-13,o),
+(265,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(181,42,o),
+(127,100,o),
+(127,189,cs),
+(127,289,o),
+(186,418,o),
+(312,418,cs),
+(400,418,o),
+(453,361,o),
+(453,273,cs),
+(453,176,o),
+(396,42,o),
+(267,42,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(813,637,l),
+(824,690,l),
+(178,690,l),
+(166,637,l)
+);
+}
+);
+width = 800;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159C;
+unicode = 5532;
+},
+{
+glyphname = "thoWoodScree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(478,0,ls),
+(649,0,o),
+(732,150,o),
+(732,285,cs),
+(732,404,o),
+(656,484,o),
+(534,484,cs),
+(368,484,o),
+(287,327,o),
+(287,198,cs),
+(287,129,o),
+(316,75,o),
+(364,47,c),
+(374,53,l),
+(33,53,l),
+(21,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(399,54,o),
+(347,111,o),
+(347,199,cs),
+(347,297,o),
+(403,430,o),
+(533,430,cs),
+(619,430,o),
+(671,372,o),
+(671,283,cs),
+(671,184,o),
+(612,54,o),
+(488,54,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(804,637,l),
+(815,690,l),
+(168,690,l),
+(157,637,l)
+);
+}
+);
+width = 801;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159D;
+unicode = 5533;
+},
+{
+glyphname = "thaWoodScree-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(678,0,l),
+(689,53,l),
+(351,53,l),
+(349,29,l),
+(474,63,o),
+(515,196,o),
+(515,285,cs),
+(515,404,o),
+(438,484,o),
+(318,484,cs),
+(150,484,o),
+(70,327,o),
+(70,198,cs),
+(70,79,o),
+(146,0,o),
+(270,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(182,54,o),
+(129,111,o),
+(129,199,cs),
+(129,297,o),
+(185,430,o),
+(316,430,cs),
+(402,430,o),
+(454,372,o),
+(454,283,cs),
+(454,184,o),
+(396,54,o),
+(270,54,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(812,637,l),
+(824,690,l),
+(177,690,l),
+(165,637,l)
+);
+}
+);
+width = 800;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159E;
+unicode = 5534;
+},
+{
+glyphname = "thWoodScree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(451,345,l),
+(460,385,l),
+(278,385,l),
+(275,362,l),
+(333,381,o),
+(355,454,o),
+(355,498,cs),
+(355,563,o),
+(314,607,o),
+(249,607,cs),
+(163,607,o),
+(118,526,o),
+(118,453,cs),
+(118,386,o),
+(159,345,o),
+(225,345,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(184,381,o),
+(159,409,o),
+(159,451,cs),
+(159,495,o),
+(183,570,o),
+(249,570,cs),
+(290,570,o),
+(314,542,o),
+(314,499,cs),
+(314,457,o),
+(292,381,o),
+(224,381,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(520,676,l),
+(528,717,l),
+(175,717,l),
+(165,676,l)
+);
+}
+);
+width = 496;
+}
+);
+metricRight = "=|";
+note = uni159F;
+unicode = 5535;
+},
+{
+glyphname = "lhi-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (558,690);
+},
+{
+name = top_right_can;
+pos = (643,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(299,0,l),
+(311,55,l),
+(275,55,ls),
+(180,55,o),
+(127,107,o),
+(127,194,cs),
+(127,293,o),
+(178,415,o),
+(350,415,cs),
+(764,415,l),
+(775,467,l),
+(658,722,l),
+(604,696,l),
+(718,447,l),
+(733,472,l),
+(355,472,ls),
+(144,472,o),
+(66,327,o),
+(66,193,cs),
+(66,77,o),
+(140,0,o),
+(262,0,cs)
+);
+}
+);
+width = 788;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A0;
+unicode = 5536;
+},
+{
+glyphname = "lhii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "lhi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (400,0);
+ref = dot_top;
+}
+);
+width = 787;
+}
+);
+note = uni15A1;
+unicode = 5537;
+},
+{
+glyphname = "lho-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (438,490);
+},
+{
+name = top_right_can;
+pos = (549,490);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(186,-224,l),
+(72,24,l),
+(55,0,l),
+(434,0,ls),
+(645,0,o),
+(724,144,o),
+(724,278,cs),
+(724,394,o),
+(648,471,o),
+(527,471,cs),
+(489,471,l),
+(478,416,l),
+(513,416,ls),
+(609,416,o),
+(663,364,o),
+(663,278,cs),
+(663,180,o),
+(612,56,o),
+(440,56,cs),
+(24,56,l),
+(14,6,l),
+(130,-249,l)
+);
+}
+);
+width = 791;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni15A2;
+unicode = 5538;
+},
+{
+glyphname = "lhoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "lho-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (389,-200);
+ref = dot_top;
+}
+);
+width = 787;
+}
+);
+note = uni15A3;
+unicode = 5539;
+},
+{
+glyphname = "lha-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (462,490);
+},
+{
+name = top_left_can;
+pos = (350,490);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(676,6,l),
+(688,56,l),
+(279,56,ls),
+(181,56,o),
+(128,106,o),
+(128,194,cs),
+(128,293,o),
+(176,416,o),
+(347,416,cs),
+(387,416,l),
+(399,472,l),
+(353,472,ls),
+(138,472,o),
+(66,322,o),
+(66,191,cs),
+(66,74,o),
+(141,0,o),
+(267,0,cs),
+(632,0,l),
+(618,24,l),
+(409,-213,l),
+(451,-249,l)
+);
+}
+);
+width = 788;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A4;
+unicode = 5540;
+},
+{
+glyphname = "lhaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "lha-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (190,-200);
+ref = dot_top;
+}
+);
+width = 787;
+}
+);
+note = uni15A5;
+unicode = 5541;
+},
+{
+glyphname = "lh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(459,350,l),
+(468,387,l),
+(265,387,ls),
+(201,387,o),
+(168,420,o),
+(168,479,cs),
+(168,550,o),
+(199,647,o),
+(317,647,cs),
+(337,647,l),
+(346,690,l),
+(322,690,ls),
+(184,690,o),
+(123,587,o),
+(123,477,cs),
+(123,393,o),
+(173,345,o),
+(263,345,cs),
+(431,345,l),
+(417,371,l),
+(302,238,l),
+(336,208,l)
+);
+}
+);
+width = 501;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni15A6;
+unicode = 5542;
+},
+{
+glyphname = "theThCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (175,690);
+},
+{
+name = top_right_can;
+pos = (537,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(384,117,l),
+(359,0,l),
+(420,0,l),
+(445,117,l),
+(526,117,l),
+(535,157,l),
+(454,157,l),
+(487,310,l),
+(144,310,l),
+(152,292,l),
+(572,661,l),
+(534,701,l),
+(57,280,l),
+(52,255,l),
+(413,255,l),
+(393,157,l),
+(149,157,l),
+(141,117,l)
+);
+}
+);
+width = 587;
+}
+);
+metricLeft = "ye-canadian";
+note = uni15A7;
+unicode = 5543;
+},
+{
+glyphname = "thiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (243,690);
+},
+{
+name = top_right_can;
+pos = (605,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(127,0,l),
+(153,117,l),
+(396,117,l),
+(405,157,l),
+(160,157,l),
+(182,255,l),
+(543,255,l),
+(548,280,l),
+(241,701,l),
+(196,668,l),
+(474,288,l),
+(487,310,l),
+(131,310,l),
+(99,157,l),
+(18,157,l),
+(10,117,l),
+(90,117,l),
+(66,0,l)
+);
+}
+);
+width = 587;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+unicode = 5544;
+},
+{
+glyphname = "thiiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (85,0);
+ref = dot_top;
+}
+);
+width = 587;
+}
+);
+note = uni15A9;
+unicode = 5545;
+},
+{
+glyphname = "thoThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (176,690);
+},
+{
+name = top_right_can;
+pos = (538,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(437,21,l),
+(159,402,l),
+(147,380,l),
+(502,380,l),
+(534,532,l),
+(616,532,l),
+(624,573,l),
+(543,573,l),
+(568,690,l),
+(506,690,l),
+(481,573,l),
+(237,573,l),
+(229,532,l),
+(472,532,l),
+(452,435,l),
+(91,435,l),
+(85,410,l),
+(392,-12,l)
+);
+}
+);
+width = 588;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+unicode = 5546;
+},
+{
+glyphname = "thooThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (378,0);
+ref = dot_top;
+}
+);
+width = 587;
+}
+);
+note = uni15AB;
+unicode = 5547;
+},
+{
+glyphname = "thaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (244,690);
+},
+{
+name = top_right_can;
+pos = (606,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(578,410,l),
+(582,435,l),
+(220,435,l),
+(241,532,l),
+(485,532,l),
+(493,573,l),
+(249,573,l),
+(274,690,l),
+(213,690,l),
+(187,573,l),
+(107,573,l),
+(99,532,l),
+(179,532,l),
+(147,380,l),
+(491,380,l),
+(483,398,l),
+(61,29,l),
+(99,-12,l)
+);
+}
+);
+width = 589;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+unicode = 5548;
+},
+{
+glyphname = "thaaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:55:09 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (86,0);
+ref = dot_top;
+}
+);
+width = 589;
+}
+);
+note = uni15AD;
+unicode = 5549;
+},
+{
+glyphname = "thThCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(178,612,l),
+(158,524,l),
+(329,524,l),
+(322,542,l),
+(124,366,l),
+(152,336,l),
+(385,546,l),
+(389,562,l),
+(213,562,l),
+(223,612,l),
+(342,612,l),
+(348,639,l),
+(228,639,l),
+(240,690,l),
+(193,690,l),
+(183,639,l),
+(142,639,l),
+(136,612,l)
+);
+}
+);
+width = 362;
+}
+);
+metricRight = "y-canadian";
+note = uni15AE;
+unicode = 5550;
+},
+{
+glyphname = "bAivilik-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,-13,o),
+(511,162,o),
+(511,289,cs),
+(511,409,o),
+(440,484,o),
+(330,484,cs),
+(250,484,o),
+(191,440,o),
+(160,373,c),
+(169,363,l),
+(239,690,l),
+(177,690,l),
+(31,0,l),
+(90,0,l),
+(119,138,l),
+(111,127,l),
+(121,41,o),
+(180,-13,o),
+(271,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(187,42,o),
+(139,96,o),
+(139,185,cs),
+(139,278,o),
+(185,431,o),
+(319,431,cs),
+(403,431,o),
+(451,377,o),
+(451,288,cs),
+(451,197,o),
+(406,42,o),
+(271,42,cs)
+);
+}
+);
+width = 576;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|ke-canadian";
+note = uni15AF;
+unicode = 5551;
+},
+{
+glyphname = "eBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(92,0,l),
+(181,418,l),
+(205,377,o),
+(249,353,o),
+(305,353,cs),
+(423,353,o),
+(490,460,o),
+(490,554,cs),
+(490,640,o),
+(434,702,o),
+(346,702,cs),
+(302,702,o),
+(261,686,o),
+(230,658,c),
+(237,690,l),
+(177,690,l),
+(30,0,l)
+);
+}
+);
+width = 472;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B0;
+unicode = 5552;
+},
+{
+glyphname = "iBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(216,-13,o),
+(258,4,o),
+(288,32,c),
+(281,0,l),
+(341,0,l),
+(488,690,l),
+(426,690,l),
+(337,271,l),
+(314,313,o),
+(269,337,o),
+(213,337,cs),
+(96,337,o),
+(28,230,o),
+(28,135,cs),
+(28,49,o),
+(85,-13,o),
+(172,-13,cs)
+);
+}
+);
+width = 471;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B1;
+unicode = 5553;
+},
+{
+glyphname = "oBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(344,-13,o),
+(412,92,o),
+(412,189,cs),
+(412,275,o),
+(356,337,o),
+(270,337,cs),
+(227,337,o),
+(185,321,o),
+(155,292,c),
+(239,690,l),
+(177,690,l),
+(30,0,l),
+(90,0,l),
+(102,60,l),
+(125,14,o),
+(170,-13,o),
+(228,-13,cs)
+);
+}
+);
+width = 472;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "eBlackfoot-canadian";
+note = uni15B2;
+unicode = 5554;
+},
+{
+glyphname = "aBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(341,0,l),
+(488,690,l),
+(428,690,l),
+(415,630,l),
+(393,675,o),
+(349,702,o),
+(290,702,cs),
+(174,702,o),
+(106,598,o),
+(106,500,cs),
+(106,414,o),
+(162,353,o),
+(247,353,cs),
+(292,353,o),
+(333,369,o),
+(364,398,c),
+(279,0,l)
+);
+}
+);
+width = 471;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B3;
+unicode = 5555;
+},
+{
+glyphname = "weBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(92,0,l),
+(159,319,l),
+(509,319,l),
+(520,372,l),
+(171,372,l),
+(227,637,l),
+(577,637,l),
+(587,690,l),
+(177,690,l),
+(30,0,l)
+);
+}
+);
+width = 552;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B4;
+unicode = 5556;
+},
+{
+glyphname = "wiBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(421,0,l),
+(568,690,l),
+(506,690,l),
+(439,371,l),
+(89,371,l),
+(78,318,l),
+(427,318,l),
+(371,53,l),
+(21,53,l),
+(11,0,l)
+);
+}
+);
+width = 551;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B5;
+unicode = 5557;
+},
+{
+glyphname = "woBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(441,0,l),
+(452,53,l),
+(103,53,l),
+(159,318,l),
+(509,318,l),
+(520,371,l),
+(171,371,l),
+(239,690,l),
+(177,690,l),
+(30,0,l)
+);
+}
+);
+width = 552;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "weBlackfoot-canadian";
+note = uni15B6;
+unicode = 5558;
+},
+{
+glyphname = "waBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(422,0,l),
+(569,690,l),
+(157,690,l),
+(147,637,l),
+(496,637,l),
+(440,372,l),
+(91,372,l),
+(79,319,l),
+(428,319,l),
+(360,0,l)
+);
+}
+);
+width = 552;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B7;
+unicode = 5559;
+},
+{
+glyphname = "neBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(92,0,l),
+(229,641,l),
+(273,641,l),
+(258,678,l),
+(252,650,ls),
+(221,506,o),
+(294,408,o),
+(435,408,cs),
+(559,408,o),
+(644,483,o),
+(673,628,cs),
+(687,690,l),
+(626,690,l),
+(613,631,ls),
+(591,518,o),
+(531,462,o),
+(438,462,cs),
+(335,462,o),
+(288,531,o),
+(311,639,cs),
+(322,690,l),
+(177,690,l),
+(30,0,l)
+);
+}
+);
+width = 635;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B8;
+unicode = 5560;
+},
+{
+glyphname = "niBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(56,0,l),
+(69,59,ls),
+(91,172,o),
+(152,228,o),
+(244,228,cs),
+(348,228,o),
+(395,158,o),
+(372,50,cs),
+(361,0,l),
+(505,0,l),
+(652,690,l),
+(590,690,l),
+(454,48,l),
+(409,48,l),
+(425,12,l),
+(431,40,ls),
+(462,184,o),
+(389,282,o),
+(247,282,cs),
+(123,282,o),
+(39,207,o),
+(9,62,cs),
+(-5,0,l)
+);
+}
+);
+width = 635;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B9;
+unicode = 5561;
+},
+{
+glyphname = "noBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(175,0,l),
+(185,53,ls),
+(211,171,o),
+(266,228,o),
+(359,228,cs),
+(463,228,o),
+(513,157,o),
+(489,43,cs),
+(480,0,l),
+(541,0,l),
+(548,36,ls),
+(578,185,o),
+(504,283,o),
+(364,283,cs),
+(239,283,o),
+(157,205,o),
+(125,52,cs),
+(116,13,l),
+(148,48,l),
+(102,48,l),
+(239,690,l),
+(177,690,l),
+(30,0,l)
+);
+}
+);
+width = 636;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "neBlackfoot-canadian";
+note = uni15BA;
+unicode = 5562;
+},
+{
+glyphname = "naBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(505,0,l),
+(652,690,l),
+(508,690,l),
+(497,637,ls),
+(472,519,o),
+(417,462,o),
+(324,462,cs),
+(219,462,o),
+(170,532,o),
+(194,646,cs),
+(203,690,l),
+(142,690,l),
+(135,654,ls),
+(105,505,o),
+(179,407,o),
+(319,407,cs),
+(443,407,o),
+(526,485,o),
+(558,638,cs),
+(566,677,l),
+(535,641,l),
+(581,641,l),
+(443,0,l)
+);
+}
+);
+width = 635;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BB;
+unicode = 5563;
+},
+{
+glyphname = "keBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(92,0,l),
+(225,623,l),
+(200,623,l),
+(312,258,l),
+(342,258,l),
+(662,690,l),
+(590,690,l),
+(325,327,l),
+(345,326,l),
+(234,690,l),
+(177,690,l),
+(30,0,l)
+);
+}
+);
+width = 594;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15BC;
+unicode = 5564;
+},
+{
+glyphname = "kiBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(51,0,l),
+(317,362,l),
+(297,364,l),
+(407,0,l),
+(464,0,l),
+(611,690,l),
+(549,690,l),
+(416,67,l),
+(440,67,l),
+(328,432,l),
+(298,432,l),
+(-21,0,l)
+);
+}
+);
+width = 594;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BD;
+unicode = 5565;
+},
+{
+glyphname = "koBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(89,0,l),
+(367,369,l),
+(335,374,l),
+(452,0,l),
+(515,0,l),
+(379,432,l),
+(348,432,l),
+(79,67,l),
+(106,67,l),
+(239,690,l),
+(177,690,l),
+(30,0,l)
+);
+}
+);
+width = 594;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "keBlackfoot-canadian";
+note = uni15BE;
+unicode = 5566;
+},
+{
+glyphname = "kaBlackfoot-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(464,1,l),
+(611,691,l),
+(553,691,l),
+(274,321,l),
+(306,317,l),
+(189,691,l),
+(126,691,l),
+(262,259,l),
+(293,259,l),
+(561,624,l),
+(535,624,l),
+(402,1,l)
+);
+}
+);
+width = 594;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BF;
+unicode = 5567;
+},
+{
+color = 9;
+glyphname = "heSayisi-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_right_can;
+pos = (624,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(508,0,l),
+(655,690,l),
+(593,690,l),
+(495,226,l),
+(508,225,l),
+(561,524,o),
+(496,702,o),
+(328,702,cs),
+(219,702,o),
+(147,627,o),
+(114,482,cs),
+(103,436,o),
+(98,392,o),
+(97,340,c),
+(156,340,l),
+(157,386,o),
+(162,428,o),
+(171,467,cs),
+(197,585,o),
+(252,647,o),
+(334,647,cs),
+(496,647,o),
+(535,420,o),
+(446,0,c)
+);
+}
+);
+width = 638;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni15C0;
+unicode = 5568;
+},
+{
+color = 9;
+glyphname = "hiSayisi-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(92,0,l),
+(183,426,o),
+(308,647,o),
+(458,647,cs),
+(550,647,o),
+(588,567,o),
+(559,434,cs),
+(553,398,o),
+(542,370,o),
+(529,340,c),
+(588,340,l),
+(603,375,o),
+(613,406,o),
+(620,435,cs),
+(653,598,o),
+(595,702,o),
+(472,702,cs),
+(327,702,o),
+(204,543,o),
+(135,263,c),
+(147,262,l),
+(239,690,l),
+(177,690,l),
+(30,0,l)
+);
+}
+);
+width = 640;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C1;
+unicode = 5569;
+},
+{
+color = 9;
+glyphname = "hoSayisi-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (412,690);
+},
+{
+name = top_left_can;
+pos = (200,690);
+},
+{
+name = top_right_can;
+pos = (625,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(358,-13,o),
+(482,147,o),
+(551,427,c),
+(539,428,l),
+(447,0,l),
+(509,0,l),
+(656,690,l),
+(594,690,l),
+(503,264,o),
+(378,43,o),
+(228,43,cs),
+(136,43,o),
+(98,123,o),
+(127,256,cs),
+(133,292,o),
+(144,320,o),
+(156,350,c),
+(98,350,l),
+(83,315,o),
+(72,284,o),
+(66,255,cs),
+(33,92,o),
+(91,-13,o),
+(213,-13,cs)
+);
+}
+);
+width = 639;
+}
+);
+metricLeft = "heSayisi-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15C2;
+unicode = 5570;
+},
+{
+color = 9;
+glyphname = "haSayisi-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(466,-13,o),
+(538,63,o),
+(571,208,cs),
+(582,254,o),
+(587,298,o),
+(588,350,c),
+(529,350,l),
+(527,303,o),
+(523,262,o),
+(514,223,cs),
+(488,104,o),
+(433,43,o),
+(351,43,cs),
+(189,43,o),
+(150,270,o),
+(239,690,c),
+(177,690,l),
+(30,0,l),
+(92,0,l),
+(190,464,l),
+(177,465,l),
+(124,166,o),
+(189,-13,o),
+(356,-13,cs)
+);
+}
+);
+width = 639;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C3;
+unicode = 5571;
+},
+{
+color = 9;
+glyphname = "ghuCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(309,0,l),
+(748,670,l),
+(752,690,l),
+(694,690,l),
+(537,446,l),
+(564,461,l),
+(213,461,l),
+(235,446,l),
+(183,690,l),
+(132,690,l),
+(128,670,l),
+(281,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(534,412,l),
+(525,425,l),
+(296,68,l),
+(319,64,l),
+(240,426,l),
+(224,412,l)
+);
+}
+);
+width = 691;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C4;
+unicode = 5572;
+},
+{
+color = 9;
+glyphname = "ghoCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(44,0,l),
+(200,243,l),
+(173,229,l),
+(524,229,l),
+(502,243,l),
+(555,0,l),
+(605,0,l),
+(610,19,l),
+(456,690,l),
+(428,690,l),
+(-11,19,l),
+(-14,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(510,293,l),
+(212,294,l),
+(221,266,l),
+(444,607,l),
+(410,610,l),
+(489,263,l)
+);
+}
+);
+width = 691;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C5;
+unicode = 5573;
+},
+{
+color = 9;
+glyphname = "gheCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (100,351);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(26,0,l),
+(618,330,l),
+(625,358,l),
+(173,690,l),
+(155,690,l),
+(145,644,l),
+(289,539,l),
+(283,576,l),
+(187,128,l),
+(207,162,l),
+(19,58,l),
+(8,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(326,549,l),
+(307,531,l),
+(574,334,l),
+(576,364,l),
+(232,173,l),
+(242,154,l)
+);
+}
+);
+width = 635;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15C6;
+unicode = 5574;
+},
+{
+color = 9;
+glyphname = "gheeCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (42,6);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 636;
+}
+);
+note = uni15C7;
+unicode = 5575;
+},
+{
+color = 9;
+glyphname = "ghiCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (20,6);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 636;
+}
+);
+note = uni15C8;
+unicode = 5576;
+},
+{
+color = 9;
+glyphname = "ghaCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(526,0,l),
+(536,45,l),
+(391,151,l),
+(397,114,l),
+(493,562,l),
+(473,527,l),
+(661,632,l),
+(673,690,l),
+(654,690,l),
+(62,359,l),
+(56,331,l),
+(507,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(374,158,l),
+(109,354,l),
+(108,327,l),
+(448,517,l),
+(438,532,l),
+(355,146,l)
+);
+}
+);
+width = 634;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15C9;
+unicode = 5577;
+},
+{
+color = 9;
+glyphname = "ruCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(309,0,l),
+(748,670,l),
+(752,690,l),
+(694,690,l),
+(631,594,l),
+(660,608,l),
+(182,608,l),
+(203,593,l),
+(182,690,l),
+(132,690,l),
+(128,670,l),
+(281,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(629,557,l),
+(617,571,l),
+(296,69,l),
+(319,66,l),
+(208,572,l),
+(192,557,l)
+);
+}
+);
+width = 691;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CA;
+unicode = 5578;
+},
+{
+color = 9;
+glyphname = "roCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(428,690,l),
+(-11,19,l),
+(-14,0,l),
+(44,0,l),
+(106,96,l),
+(78,82,l),
+(555,82,l),
+(534,97,l),
+(555,0,l),
+(605,0,l),
+(610,19,l),
+(456,690,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(109,132,l),
+(120,119,l),
+(441,621,l),
+(418,624,l),
+(530,118,l),
+(545,132,l)
+);
+}
+);
+width = 691;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CB;
+unicode = 5579;
+},
+{
+color = 9;
+glyphname = "reCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(26,0,l),
+(619,331,l),
+(625,358,l),
+(173,690,l),
+(155,690,l),
+(145,645,l),
+(215,594,l),
+(208,632,l),
+(89,71,l),
+(109,105,l),
+(19,55,l),
+(8,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(251,601,l),
+(233,582,l),
+(571,334,l),
+(572,363,l),
+(135,119,l),
+(144,100,l)
+);
+}
+);
+width = 635;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CC;
+unicode = 5580;
+},
+{
+color = 9;
+glyphname = "reeCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(26,0,l),
+(619,331,l),
+(625,358,l),
+(173,690,l),
+(155,690,l),
+(146,651,l),
+(214,601,l),
+(208,636,l),
+(88,67,l),
+(105,100,l),
+(18,51,l),
+(8,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(248,611,l),
+(228,593,l),
+(582,335,l),
+(583,363,l),
+(129,110,l),
+(138,91,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(272,257,l),
+(312,440,l),
+(279,440,l),
+(240,257,l)
+);
+}
+);
+width = 635;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CD;
+unicode = 5581;
+},
+{
+color = 9;
+glyphname = "riCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(26,0,l),
+(619,331,l),
+(625,358,l),
+(173,690,l),
+(155,690,l),
+(146,651,l),
+(214,601,l),
+(208,636,l),
+(88,67,l),
+(107,101,l),
+(18,51,l),
+(8,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(346,313,o),
+(362,328,o),
+(362,350,cs),
+(362,371,o),
+(346,385,o),
+(326,385,cs),
+(305,385,o),
+(289,371,o),
+(289,350,cs),
+(289,328,o),
+(305,313,o),
+(326,313,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(248,611,l),
+(228,593,l),
+(582,335,l),
+(583,363,l),
+(129,110,l),
+(138,91,l)
+);
+}
+);
+width = 635;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CE;
+unicode = 5582;
+},
+{
+color = 9;
+glyphname = "raCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(526,0,l),
+(536,44,l),
+(466,96,l),
+(473,58,l),
+(592,618,l),
+(572,584,l),
+(662,635,l),
+(673,690,l),
+(654,690,l),
+(62,358,l),
+(56,331,l),
+(508,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(448,107,l),
+(110,355,l),
+(109,327,l),
+(546,571,l),
+(536,589,l),
+(430,89,l)
+);
+}
+);
+width = 634;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15CF;
+unicode = 5583;
+},
+{
+color = 9;
+glyphname = "wuCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(312,0,l),
+(752,670,l),
+(756,690,l),
+(699,690,l),
+(332,117,l),
+(345,116,l),
+(467,690,l),
+(414,690,l),
+(293,115,l),
+(306,115,l),
+(180,690,l),
+(132,690,l),
+(128,670,l),
+(283,0,l)
+);
+}
+);
+width = 695;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D0;
+unicode = 5584;
+},
+{
+color = 9;
+glyphname = "woCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(43,0,l),
+(410,573,l),
+(397,574,l),
+(275,0,l),
+(328,0,l),
+(449,575,l),
+(436,575,l),
+(562,0,l),
+(610,0,l),
+(613,19,l),
+(459,690,l),
+(430,690,l),
+(-11,19,l),
+(-14,0,l)
+);
+}
+);
+width = 695;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D1;
+unicode = 5585;
+},
+{
+color = 9;
+glyphname = "weCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(46,0,l),
+(639,331,l),
+(645,358,l),
+(193,690,l),
+(174,690,l),
+(164,644,l),
+(548,364,l),
+(552,376,l),
+(108,376,l),
+(98,327,l),
+(546,327,l),
+(546,337,l),
+(40,56,l),
+(28,0,l)
+);
+}
+);
+width = 655;
+}
+);
+metricRight = "o-canadian";
+note = uni15D2;
+unicode = 5586;
+},
+{
+color = 9;
+glyphname = "weeCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(46,0,l),
+(639,331,l),
+(645,358,l),
+(193,690,l),
+(175,690,l),
+(165,648,l),
+(560,360,l),
+(565,373,l),
+(228,373,l),
+(245,456,l),
+(207,456,l),
+(189,373,l),
+(107,373,l),
+(99,330,l),
+(180,330,l),
+(162,247,l),
+(201,247,l),
+(218,330,l),
+(560,330,l),
+(558,341,l),
+(39,52,l),
+(28,0,l)
+);
+}
+);
+width = 655;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D3;
+unicode = 5587;
+},
+{
+color = 9;
+glyphname = "wiCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(46,0,l),
+(639,331,l),
+(645,358,l),
+(193,690,l),
+(175,690,l),
+(165,648,l),
+(556,363,l),
+(564,373,l),
+(291,373,l),
+(283,396,o),
+(261,412,o),
+(235,412,cs),
+(209,412,o),
+(187,396,o),
+(180,373,c),
+(107,373,l),
+(99,332,l),
+(180,332,l),
+(188,310,o),
+(210,293,o),
+(235,293,cs),
+(261,293,o),
+(282,310,o),
+(290,332,c),
+(559,332,l),
+(555,339,l),
+(39,52,l),
+(28,0,l)
+);
+}
+);
+width = 655;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D4;
+unicode = 5588;
+},
+{
+color = 9;
+glyphname = "waCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(526,0,l),
+(536,45,l),
+(153,326,l),
+(149,314,l),
+(593,314,l),
+(604,363,l),
+(156,363,l),
+(156,353,l),
+(661,634,l),
+(673,690,l),
+(654,690,l),
+(62,358,l),
+(56,331,l),
+(507,0,l)
+);
+}
+);
+width = 654;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15D5;
+unicode = 5589;
+},
+{
+color = 9;
+glyphname = "hwuCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(312,0,l),
+(752,670,l),
+(756,690,l),
+(702,690,l),
+(551,455,l),
+(572,467,l),
+(414,467,l),
+(462,690,l),
+(418,690,l),
+(371,467,l),
+(213,467,l),
+(229,456,l),
+(177,690,l),
+(132,690,l),
+(128,670,l),
+(283,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(307,97,l),
+(231,441,l),
+(220,428,l),
+(365,428,l),
+(295,96,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(403,428,l),
+(549,428,l),
+(544,440,l),
+(323,98,l),
+(332,94,l)
+);
+}
+);
+width = 695;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D6;
+unicode = 5590;
+},
+{
+color = 9;
+glyphname = "hwoCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(40,0,l),
+(191,235,l),
+(170,223,l),
+(328,223,l),
+(280,0,l),
+(324,0,l),
+(371,223,l),
+(529,223,l),
+(513,234,l),
+(565,0,l),
+(610,0,l),
+(613,19,l),
+(459,690,l),
+(430,690,l),
+(-11,19,l),
+(-14,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(419,592,l),
+(410,596,l),
+(339,262,l),
+(193,262,l),
+(198,249,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(522,262,l),
+(377,262,l),
+(446,594,l),
+(435,593,l),
+(511,248,l)
+);
+}
+);
+width = 695;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D7;
+unicode = 5591;
+},
+{
+color = 9;
+glyphname = "hweCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(46,0,l),
+(639,331,l),
+(645,358,l),
+(193,690,l),
+(174,690,l),
+(165,649,l),
+(298,554,l),
+(259,374,l),
+(107,374,l),
+(98,329,l),
+(250,329,l),
+(212,149,l),
+(39,52,l),
+(27,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(287,332,l),
+(550,332,l),
+(252,168,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(329,533,l),
+(552,371,l),
+(296,371,l)
+);
+}
+);
+width = 655;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D8;
+unicode = 5592;
+},
+{
+color = 9;
+glyphname = "hweeCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(46,0,l),
+(639,331,l),
+(645,358,l),
+(193,690,l),
+(174,690,l),
+(166,650,l),
+(307,548,l),
+(270,371,l),
+(212,371,l),
+(229,455,l),
+(194,455,l),
+(177,371,l),
+(106,371,l),
+(99,332,l),
+(168,332,l),
+(151,249,l),
+(185,249,l),
+(203,332,l),
+(262,332,l),
+(224,154,l),
+(39,51,l),
+(27,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(297,334,l),
+(553,334,l),
+(262,172,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(337,528,l),
+(554,369,l),
+(303,369,l)
+);
+}
+);
+width = 655;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D9;
+unicode = 5593;
+},
+{
+color = 9;
+glyphname = "hwiCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(46,0,l),
+(639,331,l),
+(645,358,l),
+(193,690,l),
+(174,690,l),
+(166,650,l),
+(308,548,l),
+(270,369,l),
+(236,369,l),
+(230,390,o),
+(210,406,o),
+(186,406,cs),
+(163,406,o),
+(144,390,o),
+(138,369,c),
+(106,369,l),
+(99,334,l),
+(137,334,l),
+(144,313,o),
+(164,298,o),
+(186,298,cs),
+(210,298,o),
+(229,313,o),
+(236,334,c),
+(263,334,l),
+(224,154,l),
+(39,51,l),
+(27,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(297,334,l),
+(553,334,l),
+(262,172,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(337,528,l),
+(554,369,l),
+(304,369,l)
+);
+}
+);
+width = 655;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15DA;
+unicode = 5594;
+},
+{
+color = 9;
+glyphname = "hwaCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(655,690,l),
+(62,358,l),
+(56,331,l),
+(508,0,l),
+(526,0,l),
+(535,41,l),
+(404,136,l),
+(441,316,l),
+(593,316,l),
+(603,360,l),
+(451,360,l),
+(490,541,l),
+(663,638,l),
+(673,690,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(413,357,l),
+(151,357,l),
+(448,522,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(371,156,l),
+(149,319,l),
+(406,319,l)
+);
+}
+);
+width = 655;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15DB;
+unicode = 5595;
+},
+{
+color = 9;
+glyphname = "thuCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(485,-13,o),
+(582,79,o),
+(622,266,cs),
+(712,690,l),
+(170,690,l),
+(86,294,ls),
+(43,97,o),
+(132,-13,o),
+(318,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(220,634,l),
+(639,634,l),
+(561,270,ls),
+(528,115,o),
+(453,45,o),
+(322,45,cs),
+(171,45,o),
+(111,126,o),
+(147,291,cs)
+);
+}
+);
+width = 689;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DC;
+unicode = 5596;
+},
+{
+color = 9;
+glyphname = "thoCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(565,0,l),
+(649,396,ls),
+(692,593,o),
+(603,702,o),
+(417,702,cs),
+(250,702,o),
+(154,611,o),
+(113,424,cs),
+(23,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(174,420,ls),
+(207,575,o),
+(282,644,o),
+(413,644,cs),
+(564,644,o),
+(624,564,o),
+(588,399,cs),
+(515,56,l),
+(97,56,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DD;
+unicode = 5597;
+},
+{
+color = 9;
+glyphname = "theCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (356,345);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(236,0,ls),
+(545,0,o),
+(632,262,o),
+(632,434,cs),
+(632,596,o),
+(538,690,o),
+(370,690,cs),
+(177,690,l),
+(30,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(232,656,l),
+(209,635,l),
+(359,635,ls),
+(497,635,o),
+(573,563,o),
+(573,432,cs),
+(573,282,o),
+(496,55,o),
+(241,55,cs),
+(89,55,l),
+(99,36,l)
+);
+}
+);
+width = 667;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "to-canadian";
+note = uni15DE;
+unicode = 5598;
+},
+{
+color = 9;
+glyphname = "theeCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (293,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 668;
+}
+);
+note = uni15DF;
+unicode = 5599;
+},
+{
+color = 9;
+glyphname = "thiCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (271,0);
+ref = dot_middle;
+}
+);
+width = 668;
+}
+);
+note = uni15E0;
+unicode = 5600;
+},
+{
+color = 9;
+glyphname = "thaCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(535,0,l),
+(682,690,l),
+(477,690,ls),
+(168,690,o),
+(81,428,o),
+(81,256,cs),
+(81,94,o),
+(174,0,o),
+(343,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(140,408,o),
+(217,635,o),
+(472,635,cs),
+(623,635,l),
+(613,654,l),
+(481,34,l),
+(504,55,l),
+(354,55,ls),
+(214,55,o),
+(140,127,o),
+(140,258,cs)
+);
+}
+);
+width = 665;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15E1;
+unicode = 5601;
+},
+{
+color = 9;
+glyphname = "ttuCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(484,-13,o),
+(582,76,o),
+(622,268,cs),
+(712,690,l),
+(685,690,l),
+(379,497,l),
+(425,489,l),
+(199,690,l),
+(170,690,l),
+(85,291,ls),
+(43,96,o),
+(131,-13,o),
+(318,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(172,45,o),
+(112,126,o),
+(146,289,cs),
+(219,635,l),
+(191,627,l),
+(384,453,l),
+(402,453,l),
+(657,616,l),
+(638,632,l),
+(561,271,ls),
+(528,115,o),
+(452,45,o),
+(318,45,cs)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E2;
+unicode = 5602;
+},
+{
+color = 9;
+glyphname = "ttoCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(50,0,l),
+(356,193,l),
+(310,201,l),
+(536,0,l),
+(565,0,l),
+(650,399,ls),
+(692,594,o),
+(604,702,o),
+(417,702,cs),
+(251,702,o),
+(154,613,o),
+(113,422,cs),
+(23,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(563,644,o),
+(623,564,o),
+(589,401,cs),
+(516,55,l),
+(544,63,l),
+(352,237,l),
+(333,237,l),
+(78,73,l),
+(98,58,l),
+(174,418,ls),
+(207,575,o),
+(283,644,o),
+(417,644,cs)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E3;
+unicode = 5603;
+},
+{
+color = 9;
+glyphname = "tteCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (407,345);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(244,0,ls),
+(542,0,o),
+(641,248,o),
+(641,434,cs),
+(641,595,o),
+(548,690,o),
+(381,690,cs),
+(170,690,l),
+(165,670,l),
+(220,322,l),
+(226,373,l),
+(27,19,l),
+(23,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(270,335,l),
+(274,352,l),
+(225,662,l),
+(204,635,l),
+(368,635,ls),
+(508,635,o),
+(582,563,o),
+(582,432,cs),
+(582,283,o),
+(506,55,o),
+(250,55,cs),
+(84,55,l),
+(99,31,l)
+);
+}
+);
+width = 676;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15E4;
+unicode = 5604;
+},
+{
+color = 9;
+glyphname = "tteeCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (348,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 677;
+}
+);
+note = uni15E5;
+unicode = 5605;
+},
+{
+color = 9;
+glyphname = "ttiCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (331,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 677;
+}
+);
+note = uni15E6;
+unicode = 5606;
+},
+{
+color = 9;
+glyphname = "ttaCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(553,0,l),
+(557,19,l),
+(503,368,l),
+(496,317,l),
+(695,670,l),
+(699,690,l),
+(478,690,ls),
+(181,690,o),
+(81,441,o),
+(81,256,cs),
+(81,95,o),
+(175,0,o),
+(343,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(519,55,l),
+(354,55,ls),
+(215,55,o),
+(141,127,o),
+(141,258,cs),
+(141,407,o),
+(216,635,o),
+(472,635,cs),
+(638,635,l),
+(623,659,l),
+(452,355,l),
+(448,338,l),
+(497,28,l)
+);
+}
+);
+width = 676;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tteCarrier-canadian";
+note = uni15E7;
+unicode = 5607;
+},
+{
+color = 9;
+glyphname = "puCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(485,-13,o),
+(582,79,o),
+(622,266,cs),
+(712,690,l),
+(650,690,l),
+(613,517,l),
+(195,517,l),
+(232,690,l),
+(170,690,l),
+(86,294,ls),
+(43,97,o),
+(132,-13,o),
+(318,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(171,45,o),
+(111,126,o),
+(147,291,cs),
+(184,463,l),
+(602,463,l),
+(561,270,ls),
+(528,115,o),
+(453,45,o),
+(322,45,cs)
+);
+}
+);
+width = 689;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E8;
+unicode = 5608;
+},
+{
+color = 9;
+glyphname = "poCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(85,0,l),
+(122,173,l),
+(540,173,l),
+(503,0,l),
+(565,0,l),
+(649,396,ls),
+(692,593,o),
+(603,702,o),
+(417,702,cs),
+(250,702,o),
+(154,611,o),
+(113,424,cs),
+(23,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(174,420,ls),
+(207,575,o),
+(282,644,o),
+(413,644,cs),
+(564,644,o),
+(624,564,o),
+(588,399,cs),
+(552,227,l),
+(133,227,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E9;
+unicode = 5609;
+},
+{
+color = 9;
+glyphname = "peCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (393,345);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(240,0,ls),
+(548,0,o),
+(636,261,o),
+(636,434,cs),
+(636,596,o),
+(542,690,o),
+(375,690,cs),
+(164,690,l),
+(153,635,l),
+(242,635,l),
+(119,55,l),
+(29,55,l),
+(17,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(309,662,l),
+(268,635,l),
+(363,635,ls),
+(501,635,o),
+(576,563,o),
+(576,432,cs),
+(576,282,o),
+(499,55,o),
+(244,55,cs),
+(145,55,l),
+(175,28,l)
+);
+}
+);
+width = 671;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15EA;
+unicode = 5610;
+},
+{
+color = 9;
+glyphname = "peeCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (334,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 671;
+}
+);
+note = uni15EB;
+unicode = 5611;
+},
+{
+color = 9;
+glyphname = "piCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (318,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 671;
+}
+);
+note = uni15EC;
+unicode = 5612;
+},
+{
+color = 9;
+glyphname = "paCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(553,0,l),
+(564,55,l),
+(474,55,l),
+(598,635,l),
+(688,635,l),
+(699,690,l),
+(478,690,ls),
+(170,690,o),
+(81,429,o),
+(81,256,cs),
+(81,94,o),
+(175,0,o),
+(342,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(449,55,l),
+(354,55,ls),
+(215,55,o),
+(141,127,o),
+(141,258,cs),
+(141,408,o),
+(217,635,o),
+(472,635,cs),
+(573,635,l),
+(542,662,l),
+(408,28,l)
+);
+}
+);
+width = 670;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|peCarrier-canadian";
+note = uni15ED;
+unicode = 5613;
+},
+{
+color = 6;
+glyphname = "pCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(365,183,l),
+(375,226,l),
+(243,226,l),
+(307,527,l),
+(261,527,l),
+(197,226,l),
+(65,226,l),
+(55,183,l)
+);
+}
+);
+width = 443;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni15EE;
+unicode = 5614;
+},
+{
+color = 9;
+glyphname = "guCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (516,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(307,-13,o),
+(373,38,o),
+(411,134,c),
+(388,134,l),
+(395,43,o),
+(453,-13,o),
+(544,-13,cs),
+(651,-13,o),
+(722,57,o),
+(750,185,cs),
+(857,690,l),
+(797,690,l),
+(691,188,ls),
+(670,94,o),
+(619,43,o),
+(542,43,cs),
+(459,43,o),
+(420,103,o),
+(441,203,cs),
+(545,690,l),
+(487,690,l),
+(384,204,ls),
+(360,99,o),
+(307,43,o),
+(227,43,cs),
+(140,43,o),
+(106,100,o),
+(129,210,cs),
+(232,690,l),
+(172,690,l),
+(71,214,ls),
+(41,71,o),
+(95,-13,o),
+(218,-13,cs)
+);
+}
+);
+width = 836;
+}
+);
+metricRight = "=|";
+note = uni15EF;
+unicode = 5615;
+},
+{
+color = 9;
+glyphname = "goCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(85,0,l),
+(191,501,ls),
+(212,596,o),
+(263,646,o),
+(339,646,cs),
+(423,646,o),
+(462,586,o),
+(440,487,cs),
+(337,0,l),
+(395,0,l),
+(498,486,ls),
+(521,591,o),
+(574,646,o),
+(655,646,cs),
+(742,646,o),
+(775,589,o),
+(752,480,cs),
+(649,0,l),
+(709,0,l),
+(810,475,ls),
+(840,618,o),
+(787,702,o),
+(664,702,cs),
+(574,702,o),
+(509,652,o),
+(471,555,c),
+(494,555,l),
+(487,647,o),
+(429,702,o),
+(338,702,cs),
+(231,702,o),
+(159,633,o),
+(132,504,cs),
+(25,0,l)
+);
+}
+);
+width = 834;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F0;
+unicode = 5616;
+},
+{
+color = 9;
+glyphname = "geCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (438,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(345,0,ls),
+(504,0,o),
+(588,81,o),
+(588,208,cs),
+(588,278,o),
+(553,332,o),
+(489,350,c),
+(486,332,l),
+(608,353,o),
+(658,443,o),
+(658,534,cs),
+(658,628,o),
+(591,690,o),
+(485,690,cs),
+(177,690,l),
+(165,638,l),
+(470,638,ls),
+(552,638,o),
+(596,598,o),
+(596,530,cs),
+(596,431,o),
+(533,371,o),
+(415,371,cs),
+(109,371,l),
+(98,319,l),
+(406,319,ls),
+(485,319,o),
+(528,280,o),
+(528,213,cs),
+(528,122,o),
+(478,52,o),
+(347,52,cs),
+(42,52,l),
+(30,0,l)
+);
+}
+);
+width = 676;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15F1;
+unicode = 5617;
+},
+{
+color = 9;
+glyphname = "geeCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(345,0,ls),
+(504,0,o),
+(588,81,o),
+(588,208,cs),
+(588,278,o),
+(553,332,o),
+(489,350,c),
+(486,332,l),
+(608,353,o),
+(658,443,o),
+(658,534,cs),
+(658,628,o),
+(591,690,o),
+(485,690,cs),
+(177,690,l),
+(165,638,l),
+(470,638,ls),
+(552,638,o),
+(596,598,o),
+(596,530,cs),
+(596,431,o),
+(533,371,o),
+(415,371,cs),
+(357,371,l),
+(376,458,l),
+(335,458,l),
+(317,371,l),
+(109,371,l),
+(98,319,l),
+(305,319,l),
+(288,234,l),
+(328,234,l),
+(347,319,l),
+(406,319,ls),
+(485,319,o),
+(528,280,o),
+(528,213,cs),
+(528,122,o),
+(478,52,o),
+(347,52,cs),
+(42,52,l),
+(30,0,l)
+);
+}
+);
+width = 676;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F2;
+unicode = 5618;
+},
+{
+color = 9;
+glyphname = "giCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(345,0,ls),
+(504,0,o),
+(588,81,o),
+(588,208,cs),
+(588,278,o),
+(553,332,o),
+(489,351,c),
+(487,332,l),
+(609,353,o),
+(658,443,o),
+(658,534,cs),
+(658,628,o),
+(591,690,o),
+(485,690,cs),
+(177,690,l),
+(165,638,l),
+(470,638,ls),
+(552,638,o),
+(596,598,o),
+(596,530,cs),
+(596,431,o),
+(533,371,o),
+(415,371,cs),
+(373,371,l),
+(396,354,l),
+(393,385,o),
+(365,411,o),
+(332,411,cs),
+(305,411,o),
+(283,394,o),
+(274,371,c),
+(109,371,l),
+(98,319,l),
+(275,319,l),
+(284,297,o),
+(306,280,o),
+(332,280,cs),
+(365,280,o),
+(391,305,o),
+(395,336,c),
+(370,319,l),
+(406,319,ls),
+(485,319,o),
+(528,280,o),
+(528,213,cs),
+(528,122,o),
+(478,52,o),
+(347,52,cs),
+(42,52,l),
+(30,0,l)
+);
+}
+);
+width = 676;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F3;
+unicode = 5619;
+},
+{
+color = 9;
+glyphname = "gaCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (450,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(547,0,l),
+(557,52,l),
+(252,52,ls),
+(171,52,o),
+(127,92,o),
+(127,159,cs),
+(127,259,o),
+(190,319,o),
+(307,319,cs),
+(615,319,l),
+(626,371,l),
+(318,371,ls),
+(238,371,o),
+(195,410,o),
+(195,477,cs),
+(195,568,o),
+(244,638,o),
+(376,638,cs),
+(682,638,l),
+(693,690,l),
+(378,690,ls),
+(219,690,o),
+(134,609,o),
+(134,482,cs),
+(134,412,o),
+(171,357,o),
+(234,340,c),
+(237,357,l),
+(115,337,o),
+(65,246,o),
+(65,156,cs),
+(65,62,o),
+(131,0,o),
+(239,0,cs)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|geCarrier-canadian";
+note = uni15F4;
+unicode = 5620;
+},
+{
+color = 9;
+glyphname = "khuCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(305,-13,o),
+(370,35,o),
+(407,127,c),
+(390,128,l),
+(397,42,o),
+(455,-13,o),
+(544,-13,cs),
+(651,-13,o),
+(722,57,o),
+(750,185,cs),
+(857,690,l),
+(172,690,l),
+(71,214,ls),
+(41,71,o),
+(95,-13,o),
+(218,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(140,43,o),
+(106,100,o),
+(129,210,cs),
+(220,636,l),
+(475,636,l),
+(384,204,ls),
+(360,99,o),
+(307,43,o),
+(227,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(459,43,o),
+(420,103,o),
+(441,203,cs),
+(533,636,l),
+(785,636,l),
+(691,188,ls),
+(670,94,o),
+(619,43,o),
+(542,43,cs)
+);
+}
+);
+width = 836;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F5;
+unicode = 5621;
+},
+{
+color = 9;
+glyphname = "khoCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(709,0,l),
+(810,475,ls),
+(840,618,o),
+(787,702,o),
+(664,702,cs),
+(577,702,o),
+(512,655,o),
+(475,563,c),
+(492,562,l),
+(484,648,o),
+(427,702,o),
+(338,702,cs),
+(231,702,o),
+(159,633,o),
+(132,504,cs),
+(25,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(191,501,ls),
+(212,596,o),
+(263,646,o),
+(339,646,cs),
+(423,646,o),
+(461,586,o),
+(440,487,cs),
+(348,54,l),
+(97,54,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(498,486,ls),
+(521,591,o),
+(574,646,o),
+(655,646,cs),
+(742,646,o),
+(775,589,o),
+(752,480,cs),
+(661,54,l),
+(407,54,l)
+);
+}
+);
+width = 834;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F6;
+unicode = 5622;
+},
+{
+color = 9;
+glyphname = "kheCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(348,0,ls),
+(507,0,o),
+(592,81,o),
+(592,209,cs),
+(592,279,o),
+(555,332,o),
+(491,350,c),
+(489,332,l),
+(613,353,o),
+(661,446,o),
+(661,534,cs),
+(661,628,o),
+(594,690,o),
+(487,690,cs),
+(177,690,l),
+(30,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(159,320,l),
+(409,320,ls),
+(488,320,o),
+(531,281,o),
+(531,213,cs),
+(531,122,o),
+(481,52,o),
+(350,52,cs),
+(102,52,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(228,638,l),
+(473,638,ls),
+(554,638,o),
+(599,598,o),
+(599,530,cs),
+(599,432,o),
+(537,371,o),
+(418,371,cs),
+(171,371,l)
+);
+}
+);
+width = 680;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F7;
+unicode = 5623;
+},
+{
+color = 9;
+glyphname = "kheeCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(348,0,ls),
+(507,0,o),
+(592,81,o),
+(592,209,cs),
+(592,279,o),
+(555,332,o),
+(491,350,c),
+(489,332,l),
+(613,353,o),
+(661,446,o),
+(661,534,cs),
+(661,628,o),
+(594,690,o),
+(487,690,cs),
+(177,690,l),
+(30,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(159,320,l),
+(320,320,l),
+(301,231,l),
+(345,231,l),
+(366,333,l),
+(346,320,l),
+(409,320,ls),
+(488,320,o),
+(531,281,o),
+(531,213,cs),
+(531,122,o),
+(481,52,o),
+(350,52,cs),
+(102,52,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(393,460,l),
+(350,460,l),
+(331,371,l),
+(171,371,l),
+(228,638,l),
+(473,638,ls),
+(554,638,o),
+(599,598,o),
+(599,530,cs),
+(599,432,o),
+(537,371,o),
+(418,371,cs),
+(356,371,l),
+(372,357,l)
+);
+}
+);
+width = 680;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F8;
+unicode = 5624;
+},
+{
+color = 9;
+glyphname = "khiCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(348,0,ls),
+(507,0,o),
+(592,81,o),
+(592,209,cs),
+(592,277,o),
+(556,330,o),
+(494,350,c),
+(489,332,l),
+(613,353,o),
+(661,446,o),
+(661,534,cs),
+(661,628,o),
+(594,690,o),
+(487,690,cs),
+(177,690,l),
+(30,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(160,321,l),
+(288,321,l),
+(298,298,o),
+(320,280,o),
+(346,280,cs),
+(380,280,o),
+(406,306,o),
+(410,339,c),
+(372,321,l),
+(410,321,ls),
+(489,321,o),
+(531,281,o),
+(531,213,cs),
+(531,122,o),
+(481,52,o),
+(350,52,cs),
+(102,52,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(473,638,ls),
+(554,638,o),
+(599,598,o),
+(599,530,cs),
+(599,431,o),
+(538,370,o),
+(419,370,cs),
+(376,370,l),
+(410,352,l),
+(407,385,o),
+(380,411,o),
+(346,411,cs),
+(312,411,o),
+(285,384,o),
+(283,352,c),
+(306,370,l),
+(171,370,l),
+(228,638,l)
+);
+}
+);
+width = 680;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F9;
+unicode = 5625;
+},
+{
+color = 9;
+glyphname = "khaCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(549,0,l),
+(696,690,l),
+(378,690,ls),
+(218,690,o),
+(134,609,o),
+(134,481,cs),
+(134,411,o),
+(171,357,o),
+(235,340,c),
+(236,357,l),
+(112,337,o),
+(65,243,o),
+(65,156,cs),
+(65,62,o),
+(131,0,o),
+(239,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(170,52,o),
+(126,92,o),
+(126,159,cs),
+(126,258,o),
+(188,319,o),
+(307,319,cs),
+(554,319,l),
+(497,52,l),
+(251,52,ls)
+);
+},
+{
+closed = 1;
+nodes = (
+(238,370,o),
+(194,409,o),
+(194,477,cs),
+(194,568,o),
+(245,638,o),
+(376,638,cs),
+(623,638,l),
+(566,370,l),
+(317,370,ls)
+);
+}
+);
+width = 679;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15FA;
+unicode = 5626;
+},
+{
+color = 9;
+glyphname = "kkuCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(303,-13,o),
+(369,34,o),
+(407,127,c),
+(390,128,l),
+(397,43,o),
+(453,-13,o),
+(544,-13,cs),
+(651,-13,o),
+(722,56,o),
+(750,185,cs),
+(857,690,l),
+(828,690,l),
+(497,519,l),
+(484,455,l),
+(806,619,l),
+(785,639,l),
+(691,188,ls),
+(670,94,o),
+(619,43,o),
+(542,43,cs),
+(454,43,o),
+(421,109,o),
+(441,203,cs),
+(545,690,l),
+(487,690,l),
+(384,204,ls),
+(360,97,o),
+(305,43,o),
+(227,43,cs),
+(140,43,o),
+(106,99,o),
+(129,210,cs),
+(221,642,l),
+(192,631,l),
+(448,462,l),
+(460,519,l),
+(201,690,l),
+(172,690,l),
+(71,214,ls),
+(41,71,o),
+(96,-13,o),
+(218,-13,cs)
+);
+}
+);
+width = 836;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FB;
+unicode = 5627;
+},
+{
+color = 9;
+glyphname = "kkoCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(53,0,l),
+(384,171,l),
+(397,235,l),
+(76,71,l),
+(96,50,l),
+(191,501,ls),
+(212,596,o),
+(262,646,o),
+(339,646,cs),
+(427,646,o),
+(460,581,o),
+(440,487,cs),
+(336,0,l),
+(394,0,l),
+(497,486,ls),
+(521,593,o),
+(576,646,o),
+(655,646,cs),
+(741,646,o),
+(775,590,o),
+(752,480,cs),
+(660,47,l),
+(689,59,l),
+(433,228,l),
+(421,171,l),
+(680,0,l),
+(709,0,l),
+(810,475,ls),
+(841,619,o),
+(785,702,o),
+(664,702,cs),
+(578,702,o),
+(512,656,o),
+(474,563,c),
+(492,562,l),
+(484,647,o),
+(428,702,o),
+(337,702,cs),
+(231,702,o),
+(160,634,o),
+(132,504,cs),
+(25,0,l)
+);
+}
+);
+width = 834;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FC;
+unicode = 5628;
+},
+{
+color = 9;
+glyphname = "kkeCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(362,0,ls),
+(521,0,o),
+(606,81,o),
+(606,208,cs),
+(606,278,o),
+(570,332,o),
+(503,351,c),
+(502,332,l),
+(627,353,o),
+(675,445,o),
+(675,534,cs),
+(675,629,o),
+(609,690,o),
+(500,690,cs),
+(175,690,l),
+(170,670,l),
+(216,371,l),
+(112,371,l),
+(100,319,l),
+(203,319,l),
+(32,19,l),
+(28,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(267,319,l),
+(423,319,ls),
+(502,319,o),
+(545,280,o),
+(545,213,cs),
+(545,123,o),
+(496,52,o),
+(364,52,cs),
+(86,52,l),
+(102,29,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(231,665,l),
+(209,638,l),
+(487,638,ls),
+(569,638,o),
+(613,598,o),
+(613,530,cs),
+(613,430,o),
+(550,371,o),
+(432,371,cs),
+(276,371,l)
+);
+}
+);
+width = 694;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni15FD;
+unicode = 5629;
+},
+{
+color = 9;
+glyphname = "kkeeCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(362,0,ls),
+(521,0,o),
+(606,81,o),
+(606,208,cs),
+(606,278,o),
+(570,332,o),
+(503,351,c),
+(502,332,l),
+(627,353,o),
+(675,445,o),
+(675,534,cs),
+(675,629,o),
+(609,690,o),
+(500,690,cs),
+(175,690,l),
+(170,670,l),
+(216,371,l),
+(112,371,l),
+(100,319,l),
+(203,319,l),
+(32,19,l),
+(28,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(268,321,l),
+(354,321,l),
+(335,231,l),
+(379,231,l),
+(401,336,l),
+(382,321,l),
+(424,321,ls),
+(503,321,o),
+(545,280,o),
+(545,213,cs),
+(545,123,o),
+(496,52,o),
+(364,52,cs),
+(86,52,l),
+(102,29,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(428,460,l),
+(384,460,l),
+(365,370,l),
+(276,370,l),
+(231,665,l),
+(209,638,l),
+(487,638,ls),
+(569,638,o),
+(613,598,o),
+(613,530,cs),
+(613,430,o),
+(550,370,o),
+(433,370,cs),
+(392,370,l),
+(406,356,l)
+);
+}
+);
+width = 694;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FE;
+unicode = 5630;
+},
+{
+color = 9;
+glyphname = "kkiCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(362,0,ls),
+(521,0,o),
+(606,81,o),
+(606,208,cs),
+(606,278,o),
+(570,332,o),
+(503,351,c),
+(502,332,l),
+(627,353,o),
+(675,445,o),
+(675,534,cs),
+(675,629,o),
+(609,690,o),
+(500,690,cs),
+(175,690,l),
+(170,670,l),
+(216,371,l),
+(112,371,l),
+(100,319,l),
+(203,319,l),
+(32,19,l),
+(28,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(268,321,l),
+(319,321,l),
+(327,298,o),
+(350,280,o),
+(377,280,cs),
+(409,280,o),
+(434,304,o),
+(438,335,c),
+(399,321,l),
+(424,321,ls),
+(503,321,o),
+(545,280,o),
+(545,213,cs),
+(545,123,o),
+(496,52,o),
+(364,52,cs),
+(86,52,l),
+(102,29,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(436,386,o),
+(409,411,o),
+(376,411,cs),
+(349,411,o),
+(327,393,o),
+(318,369,c),
+(276,369,l),
+(231,665,l),
+(209,638,l),
+(487,638,ls),
+(569,638,o),
+(613,598,o),
+(613,530,cs),
+(613,430,o),
+(550,369,o),
+(433,369,cs),
+(400,369,l),
+(439,355,l)
+);
+}
+);
+width = 694;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FF;
+unicode = 5631;
+},
+{
+color = 9;
+glyphname = "kkaCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(565,0,l),
+(570,19,l),
+(524,319,l),
+(629,319,l),
+(639,371,l),
+(537,371,l),
+(708,670,l),
+(712,690,l),
+(378,690,ls),
+(219,690,o),
+(134,609,o),
+(134,482,cs),
+(134,412,o),
+(170,357,o),
+(237,339,c),
+(238,357,l),
+(113,337,o),
+(65,244,o),
+(65,156,cs),
+(65,61,o),
+(131,0,o),
+(240,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(531,52,l),
+(253,52,ls),
+(171,52,o),
+(127,92,o),
+(127,159,cs),
+(127,260,o),
+(190,319,o),
+(308,319,cs),
+(464,319,l),
+(510,25,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(238,371,o),
+(195,410,o),
+(195,477,cs),
+(195,567,o),
+(244,638,o),
+(376,638,cs),
+(654,638,l),
+(638,661,l),
+(473,371,l),
+(318,371,ls)
+);
+}
+);
+width = 694;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|kkeCarrier-canadian";
+note = uni1600;
+unicode = 5632;
+},
+{
+color = 6;
+glyphname = "kkCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(379,527,l),
+(186,226,l),
+(220,226,l),
+(156,527,l),
+(115,527,l),
+(112,516,l),
+(188,183,l),
+(204,183,l),
+(422,516,l),
+(425,527,l)
+);
+}
+);
+width = 416;
+}
+);
+note = uni1601;
+unicode = 5633;
+},
+{
+color = 9;
+glyphname = "nuCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(478,-13,o),
+(583,81,o),
+(619,253,cs),
+(629,298,l),
+(567,298,l),
+(558,257,ls),
+(529,117,o),
+(448,44,o),
+(324,44,cs),
+(179,44,o),
+(114,136,o),
+(147,295,cs),
+(232,690,l),
+(170,690,l),
+(86,295,ls),
+(46,108,o),
+(138,-13,o),
+(320,-13,cs)
+);
+}
+);
+width = 686;
+}
+);
+metricLeft = "te-canadian";
+note = uni1602;
+unicode = 5634;
+},
+{
+color = 9;
+glyphname = "noCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(562,0,l),
+(646,395,ls),
+(686,582,o),
+(594,702,o),
+(412,702,cs),
+(254,702,o),
+(149,609,o),
+(113,437,cs),
+(103,391,l),
+(165,391,l),
+(174,433,ls),
+(203,573,o),
+(284,645,o),
+(409,645,cs),
+(554,645,o),
+(618,554,o),
+(584,395,cs),
+(500,0,l)
+);
+}
+);
+width = 685;
+}
+);
+metricLeft = "=|nuCarrier-canadian";
+metricRight = "te-canadian";
+note = uni1603;
+unicode = 5635;
+},
+{
+color = 9;
+glyphname = "neCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (311,345);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(242,0,ls),
+(541,0,o),
+(632,254,o),
+(632,433,cs),
+(632,596,o),
+(537,690,o),
+(369,690,cs),
+(152,690,l),
+(140,634,l),
+(361,634,ls),
+(497,634,o),
+(571,562,o),
+(571,431,cs),
+(571,287,o),
+(502,56,o),
+(248,56,cs),
+(228,56,l),
+(216,0,l)
+);
+}
+);
+width = 667;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1604;
+unicode = 5636;
+},
+{
+color = 9;
+glyphname = "neeCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "neCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (248,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 667;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1605;
+unicode = 5637;
+},
+{
+color = 9;
+glyphname = "niCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "neCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (226,0);
+ref = dot_middle;
+}
+);
+width = 668;
+}
+);
+note = uni1606;
+unicode = 5638;
+},
+{
+color = 9;
+glyphname = "naCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(562,0,l),
+(575,56,l),
+(354,56,ls),
+(216,56,o),
+(143,128,o),
+(143,259,cs),
+(143,403,o),
+(212,634,o),
+(466,634,cs),
+(486,634,l),
+(497,690,l),
+(472,690,ls),
+(174,690,o),
+(82,436,o),
+(82,257,cs),
+(82,94,o),
+(177,0,o),
+(345,0,cs)
+);
+}
+);
+width = 668;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni1607;
+unicode = 5639;
+},
+{
+color = 9;
+glyphname = "muCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(305,-13,o),
+(373,36,o),
+(411,134,c),
+(388,134,l),
+(395,44,o),
+(451,-13,o),
+(544,-13,cs),
+(651,-13,o),
+(722,57,o),
+(750,185,cs),
+(792,388,l),
+(731,388,l),
+(689,188,ls),
+(669,94,o),
+(618,43,o),
+(543,43,cs),
+(455,43,o),
+(422,109,o),
+(442,202,cs),
+(481,388,l),
+(422,388,l),
+(383,204,ls),
+(359,97,o),
+(305,43,o),
+(227,43,cs),
+(141,43,o),
+(107,99,o),
+(131,210,cs),
+(233,690,l),
+(172,690,l),
+(71,214,ls),
+(41,71,o),
+(96,-13,o),
+(218,-13,cs)
+);
+}
+);
+width = 836;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "=|";
+note = uni1608;
+unicode = 5640;
+},
+{
+color = 9;
+glyphname = "moCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(710,0,l),
+(810,475,ls),
+(841,619,o),
+(786,702,o),
+(664,702,cs),
+(576,702,o),
+(509,654,o),
+(471,555,c),
+(494,555,l),
+(487,645,o),
+(431,702,o),
+(338,702,cs),
+(231,702,o),
+(160,633,o),
+(132,504,cs),
+(89,301,l),
+(151,301,l),
+(193,501,ls),
+(213,596,o),
+(264,646,o),
+(339,646,cs),
+(427,646,o),
+(460,581,o),
+(440,488,cs),
+(400,301,l),
+(460,301,l),
+(499,486,ls),
+(523,593,o),
+(577,646,o),
+(655,646,cs),
+(741,646,o),
+(775,591,o),
+(751,480,cs),
+(649,0,l)
+);
+}
+);
+width = 835;
+}
+);
+metricLeft = "=|muCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni1609;
+unicode = 5641;
+},
+{
+color = 9;
+glyphname = "meCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(346,0,ls),
+(505,0,o),
+(589,81,o),
+(589,208,cs),
+(589,278,o),
+(554,332,o),
+(490,350,c),
+(487,332,l),
+(610,353,o),
+(659,443,o),
+(659,534,cs),
+(659,628,o),
+(592,690,o),
+(486,690,cs),
+(152,690,l),
+(141,638,l),
+(471,638,ls),
+(553,638,o),
+(597,598,o),
+(597,530,cs),
+(597,431,o),
+(534,371,o),
+(416,371,cs),
+(307,371,l),
+(297,319,l),
+(407,319,ls),
+(486,319,o),
+(529,280,o),
+(529,213,cs),
+(529,122,o),
+(479,52,o),
+(348,52,cs),
+(240,52,l),
+(229,0,l)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160A;
+unicode = 5642;
+},
+{
+color = 9;
+glyphname = "meeCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(346,0,ls),
+(505,0,o),
+(589,81,o),
+(589,208,cs),
+(589,278,o),
+(554,332,o),
+(490,350,c),
+(487,332,l),
+(610,353,o),
+(659,443,o),
+(659,534,cs),
+(659,628,o),
+(592,690,o),
+(486,690,cs),
+(152,690,l),
+(141,638,l),
+(471,638,ls),
+(553,638,o),
+(597,598,o),
+(597,530,cs),
+(597,431,o),
+(534,370,o),
+(416,370,cs),
+(351,370,l),
+(369,458,l),
+(325,458,l),
+(277,233,l),
+(322,233,l),
+(340,320,l),
+(408,320,ls),
+(486,320,o),
+(529,280,o),
+(529,213,cs),
+(529,122,o),
+(479,52,o),
+(348,52,cs),
+(240,52,l),
+(229,0,l)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160B;
+unicode = 5643;
+},
+{
+color = 9;
+glyphname = "miCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(346,0,ls),
+(503,0,o),
+(582,77,o),
+(588,197,cs),
+(592,272,o),
+(556,330,o),
+(490,350,c),
+(487,332,l),
+(605,352,o),
+(654,437,o),
+(658,523,cs),
+(664,622,o),
+(596,690,o),
+(486,690,cs),
+(152,690,l),
+(141,638,l),
+(471,638,ls),
+(554,638,o),
+(599,596,o),
+(597,526,cs),
+(595,427,o),
+(532,370,o),
+(416,370,cs),
+(355,370,l),
+(387,352,l),
+(385,386,o),
+(357,412,o),
+(324,412,cs),
+(288,412,o),
+(260,383,o),
+(260,347,cs),
+(260,312,o),
+(288,282,o),
+(324,282,cs),
+(356,282,o),
+(383,306,o),
+(387,338,c),
+(354,320,l),
+(407,320,ls),
+(488,320,o),
+(531,280,o),
+(528,209,cs),
+(526,118,o),
+(476,52,o),
+(348,52,cs),
+(240,52,l),
+(229,0,l)
+);
+}
+);
+width = 676;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160C;
+unicode = 5644;
+},
+{
+color = 9;
+glyphname = "maCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(573,0,l),
+(584,52,l),
+(252,52,ls),
+(171,52,o),
+(127,92,o),
+(127,159,cs),
+(127,259,o),
+(190,319,o),
+(307,319,cs),
+(416,319,l),
+(428,371,l),
+(318,371,ls),
+(238,371,o),
+(195,410,o),
+(195,477,cs),
+(195,568,o),
+(244,638,o),
+(376,638,cs),
+(484,638,l),
+(496,690,l),
+(378,690,ls),
+(219,690,o),
+(134,609,o),
+(134,482,cs),
+(134,412,o),
+(171,357,o),
+(234,340,c),
+(237,357,l),
+(115,337,o),
+(65,246,o),
+(65,156,cs),
+(65,62,o),
+(131,0,o),
+(239,0,cs)
+);
+}
+);
+width = 678;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni160D;
+unicode = 5645;
+},
+{
+color = 9;
+glyphname = "yuCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(515,-13,o),
+(626,103,o),
+(681,363,cs),
+(719,545,o),
+(699,702,o),
+(554,702,cs),
+(417,702,o),
+(368,554,o),
+(368,458,cs),
+(368,369,o),
+(415,315,o),
+(497,315,cs),
+(511,315,o),
+(524,317,o),
+(541,323,c),
+(552,372,l),
+(539,368,o),
+(525,366,o),
+(511,366,cs),
+(453,366,o),
+(423,400,o),
+(423,462,cs),
+(423,526,o),
+(452,650,o),
+(550,650,cs),
+(655,650,o),
+(654,526,o),
+(624,374,cs),
+(578,142,o),
+(492,45,o),
+(327,45,cs),
+(165,45,o),
+(115,144,o),
+(149,298,cs),
+(232,690,l),
+(170,690,l),
+(87,298,ls),
+(49,118,o),
+(123,-13,o),
+(325,-13,cs)
+);
+}
+);
+width = 727;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160E;
+unicode = 5646;
+},
+{
+color = 9;
+glyphname = "yoCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(354,-13,o),
+(405,135,o),
+(405,232,cs),
+(405,321,o),
+(357,375,o),
+(275,375,cs),
+(262,375,o),
+(249,373,o),
+(232,367,c),
+(221,318,l),
+(233,322,o),
+(247,324,o),
+(262,324,cs),
+(320,324,o),
+(350,290,o),
+(350,228,cs),
+(350,164,o),
+(321,40,o),
+(223,40,cs),
+(118,40,o),
+(118,164,o),
+(149,316,cs),
+(194,548,o),
+(281,644,o),
+(444,644,cs),
+(608,644,o),
+(657,546,o),
+(624,391,cs),
+(541,0,l),
+(603,0,l),
+(686,391,ls),
+(724,572,o),
+(650,702,o),
+(448,702,cs),
+(258,702,o),
+(146,586,o),
+(92,327,cs),
+(53,145,o),
+(73,-13,o),
+(218,-13,cs)
+);
+}
+);
+width = 726;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160F;
+unicode = 5647;
+},
+{
+color = 9;
+glyphname = "yeCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(523,-13,o),
+(632,231,o),
+(632,417,cs),
+(632,589,o),
+(532,690,o),
+(355,690,cs),
+(178,690,l),
+(166,634,l),
+(345,634,ls),
+(492,634,o),
+(570,555,o),
+(570,415,cs),
+(570,269,o),
+(497,42,o),
+(289,42,cs),
+(179,42,o),
+(116,95,o),
+(116,182,cs),
+(116,255,o),
+(156,350,o),
+(240,350,cs),
+(295,350,o),
+(326,314,o),
+(326,254,cs),
+(326,216,o),
+(316,179,o),
+(301,144,c),
+(352,144,l),
+(368,184,o),
+(379,222,o),
+(379,262,cs),
+(379,347,o),
+(327,400,o),
+(242,400,cs),
+(126,400,o),
+(60,288,o),
+(60,178,cs),
+(60,63,o),
+(146,-13,o),
+(286,-13,cs)
+);
+}
+);
+width = 670;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1610;
+unicode = 5648;
+},
+{
+color = 9;
+glyphname = "yeeCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(523,-13,o),
+(633,233,o),
+(633,420,cs),
+(633,589,o),
+(532,690,o),
+(356,690,cs),
+(179,690,l),
+(167,634,l),
+(346,634,ls),
+(493,634,o),
+(571,555,o),
+(571,416,cs),
+(571,279,o),
+(502,42,o),
+(290,42,cs),
+(180,42,o),
+(117,93,o),
+(117,181,cs),
+(117,250,o),
+(156,350,o),
+(243,350,cs),
+(314,350,o),
+(327,289,o),
+(313,221,cs),
+(302,174,l),
+(345,174,l),
+(414,502,l),
+(373,502,l),
+(329,300,l),
+(337,299,l),
+(338,363,o),
+(301,400,o),
+(238,400,cs),
+(121,400,o),
+(61,279,o),
+(61,178,cs),
+(61,63,o),
+(146,-13,o),
+(288,-13,cs)
+);
+}
+);
+width = 670;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1611;
+unicode = 5649;
+},
+{
+color = 9;
+glyphname = "yiCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(508,-13,o),
+(632,205,o),
+(632,420,cs),
+(632,589,o),
+(531,690,o),
+(356,690,cs),
+(179,690,l),
+(167,634,l),
+(346,634,ls),
+(493,634,o),
+(570,555,o),
+(570,416,cs),
+(570,241,o),
+(480,42,o),
+(290,42,cs),
+(179,42,o),
+(116,94,o),
+(116,178,cs),
+(116,257,o),
+(159,327,o),
+(257,325,c),
+(239,343,l),
+(240,310,o),
+(267,285,o),
+(299,285,cs),
+(333,285,o),
+(359,312,o),
+(359,346,cs),
+(359,380,o),
+(333,405,o),
+(299,405,cs),
+(274,405,o),
+(253,390,o),
+(245,370,c),
+(126,366,o),
+(60,281,o),
+(60,173,cs),
+(60,62,o),
+(146,-13,o),
+(287,-13,cs)
+);
+}
+);
+width = 670;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1612;
+unicode = 5650;
+},
+{
+color = 9;
+glyphname = "yaCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(538,0,l),
+(550,56,l),
+(370,56,ls),
+(224,56,o),
+(146,134,o),
+(146,274,cs),
+(146,421,o),
+(219,648,o),
+(427,648,cs),
+(536,648,o),
+(600,595,o),
+(600,508,cs),
+(600,435,o),
+(560,340,o),
+(475,340,cs),
+(421,340,o),
+(389,376,o),
+(389,436,cs),
+(389,473,o),
+(400,511,o),
+(413,546,c),
+(363,546,l),
+(347,506,o),
+(337,468,o),
+(337,428,cs),
+(337,343,o),
+(388,290,o),
+(474,290,cs),
+(589,290,o),
+(656,402,o),
+(656,512,cs),
+(656,627,o),
+(570,702,o),
+(430,702,cs),
+(193,702,o),
+(84,459,o),
+(84,272,cs),
+(84,100,o),
+(184,0,o),
+(360,0,cs)
+);
+}
+);
+width = 669;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|yeCarrier-canadian";
+note = uni1613;
+unicode = 5651;
+},
+{
+color = 9;
+glyphname = "juCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(517,-13,o),
+(620,108,o),
+(620,248,cs),
+(620,339,o),
+(567,400,o),
+(481,400,cs),
+(368,400,o),
+(314,300,o),
+(304,196,cs),
+(301,178,o),
+(300,159,o),
+(300,144,c),
+(352,144,l),
+(351,156,o),
+(352,171,o),
+(355,190,cs),
+(362,271,o),
+(398,350,o),
+(478,350,cs),
+(533,350,o),
+(565,310,o),
+(565,247,cs),
+(565,137,o),
+(491,42,o),
+(355,42,cs),
+(220,42,o),
+(143,114,o),
+(143,239,cs),
+(143,452,o),
+(315,634,o),
+(610,634,cs),
+(696,634,l),
+(708,690,l),
+(169,690,l),
+(157,635,l),
+(491,635,l),
+(554,659,l),
+(274,657,o),
+(81,479,o),
+(81,241,cs),
+(81,88,o),
+(185,-13,o),
+(349,-13,cs)
+);
+}
+);
+width = 690;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni1614;
+unicode = 5652;
+},
+{
+color = 9;
+glyphname = "juSayisi-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (459,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(528,-13,o),
+(633,188,o),
+(636,364,cs),
+(640,549,o),
+(521,658,o),
+(300,662,c),
+(376,635,l),
+(702,635,l),
+(714,690,l),
+(174,690,l),
+(162,634,l),
+(249,634,ls),
+(470,634,o),
+(579,542,o),
+(576,370,cs),
+(574,233,o),
+(508,42,o),
+(296,42,cs),
+(177,42,o),
+(114,96,o),
+(115,185,cs),
+(115,265,o),
+(162,350,o),
+(241,350,cs),
+(295,350,o),
+(325,314,o),
+(324,252,cs),
+(324,217,o),
+(313,175,o),
+(299,144,c),
+(350,144,l),
+(369,185,o),
+(375,228,o),
+(376,259,cs),
+(378,346,o),
+(328,400,o),
+(243,400,cs),
+(132,400,o),
+(62,294,o),
+(60,183,cs),
+(57,65,o),
+(142,-13,o),
+(294,-13,cs)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1615;
+unicode = 5653;
+},
+{
+color = 9;
+glyphname = "joCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(567,0,l),
+(579,55,l),
+(244,55,l),
+(183,31,l),
+(462,33,o),
+(654,211,o),
+(654,449,cs),
+(654,602,o),
+(551,702,o),
+(387,702,cs),
+(219,702,o),
+(116,582,o),
+(116,441,cs),
+(116,351,o),
+(169,290,o),
+(255,290,cs),
+(367,290,o),
+(422,389,o),
+(432,494,cs),
+(435,512,o),
+(436,530,o),
+(435,546,c),
+(384,546,l),
+(384,534,o),
+(384,519,o),
+(382,499,cs),
+(374,418,o),
+(337,340,o),
+(258,340,cs),
+(202,340,o),
+(171,380,o),
+(171,442,cs),
+(171,553,o),
+(245,648,o),
+(382,648,cs),
+(515,648,o),
+(592,576,o),
+(592,451,cs),
+(592,238,o),
+(421,56,o),
+(127,56,cs),
+(40,56,l),
+(28,0,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1616;
+unicode = 5654;
+},
+{
+color = 9;
+glyphname = "jeCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(639,-13,o),
+(685,308,o),
+(685,438,cs),
+(685,608,o),
+(609,702,o),
+(462,702,cs),
+(327,702,o),
+(229,617,o),
+(172,449,c),
+(184,433,l),
+(239,690,l),
+(177,690,l),
+(30,0,l),
+(92,0,l),
+(153,287,ls),
+(203,526,o),
+(302,645,o),
+(451,645,cs),
+(570,645,o),
+(626,575,o),
+(626,436,cs),
+(626,351,o),
+(598,40,o),
+(448,40,cs),
+(392,40,o),
+(360,76,o),
+(360,140,cs),
+(360,215,o),
+(394,324,o),
+(504,324,cs),
+(521,324,o),
+(534,322,o),
+(547,318,c),
+(557,367,l),
+(541,373,o),
+(523,375,o),
+(501,375,cs),
+(356,375,o),
+(305,238,o),
+(305,137,cs),
+(305,45,o),
+(357,-13,o),
+(443,-13,cs)
+);
+}
+);
+width = 733;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "te-canadian";
+note = uni1617;
+unicode = 5655;
+},
+{
+color = 9;
+glyphname = "jeeCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(639,-13,o),
+(685,308,o),
+(685,437,cs),
+(685,608,o),
+(609,702,o),
+(462,702,cs),
+(326,702,o),
+(229,617,o),
+(172,448,c),
+(184,433,l),
+(239,690,l),
+(177,690,l),
+(30,0,l),
+(92,0,l),
+(153,285,ls),
+(203,526,o),
+(302,645,o),
+(451,645,cs),
+(570,645,o),
+(626,574,o),
+(626,436,cs),
+(626,343,o),
+(596,40,o),
+(441,40,cs),
+(381,40,o),
+(347,78,o),
+(347,145,cs),
+(347,213,o),
+(375,315,o),
+(469,328,c),
+(449,237,l),
+(488,237,l),
+(533,454,l),
+(495,454,l),
+(477,370,l),
+(348,354,o),
+(305,227,o),
+(305,136,cs),
+(305,45,o),
+(357,-13,o),
+(444,-13,cs)
+);
+}
+);
+width = 733;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1618;
+unicode = 5656;
+},
+{
+color = 9;
+glyphname = "jiCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(639,-13,o),
+(685,308,o),
+(685,437,cs),
+(685,608,o),
+(609,702,o),
+(462,702,cs),
+(326,702,o),
+(229,617,o),
+(172,448,c),
+(184,433,l),
+(239,690,l),
+(177,690,l),
+(30,0,l),
+(92,0,l),
+(153,285,ls),
+(203,526,o),
+(302,645,o),
+(451,645,cs),
+(570,645,o),
+(626,574,o),
+(626,436,cs),
+(626,343,o),
+(596,40,o),
+(441,40,cs),
+(381,40,o),
+(347,78,o),
+(347,145,cs),
+(347,203,o),
+(367,285,o),
+(433,314,c),
+(440,298,o),
+(458,285,o),
+(479,285,cs),
+(513,285,o),
+(537,312,o),
+(537,346,cs),
+(537,380,o),
+(512,405,o),
+(478,405,cs),
+(446,405,o),
+(422,381,o),
+(420,349,c),
+(333,313,o),
+(305,212,o),
+(305,136,cs),
+(305,45,o),
+(357,-13,o),
+(444,-13,cs)
+);
+}
+);
+width = 733;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1619;
+unicode = 5657;
+},
+{
+color = 9;
+glyphname = "jiSayisi-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(612,-13,o),
+(706,337,o),
+(706,514,cs),
+(706,637,o),
+(658,702,o),
+(564,702,cs),
+(425,702,o),
+(374,550,o),
+(374,455,cs),
+(374,366,o),
+(423,315,o),
+(497,315,cs),
+(517,315,o),
+(536,318,o),
+(547,323,c),
+(558,373,l),
+(547,368,o),
+(532,366,o),
+(517,366,cs),
+(460,366,o),
+(428,396,o),
+(428,460,cs),
+(428,515,o),
+(457,650,o),
+(560,650,cs),
+(620,650,o),
+(648,608,o),
+(648,519,cs),
+(648,377,o),
+(577,44,o),
+(347,44,cs),
+(154,44,o),
+(143,242,o),
+(180,413,cs),
+(239,690,l),
+(177,690,l),
+(30,0,l),
+(92,0,l),
+(160,328,l),
+(147,340,l),
+(109,164,o),
+(154,-13,o),
+(349,-13,cs)
+);
+}
+);
+width = 735;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161A;
+unicode = 5658;
+},
+{
+color = 9;
+glyphname = "jaCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (455,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(454,-12,o),
+(551,72,o),
+(608,242,c),
+(596,258,l),
+(542,0,l),
+(603,0,l),
+(750,690,l),
+(688,690,l),
+(627,403,ls),
+(577,165,o),
+(477,44,o),
+(328,44,cs),
+(211,44,o),
+(154,115,o),
+(154,255,cs),
+(154,339,o),
+(183,650,o),
+(331,650,cs),
+(388,650,o),
+(420,613,o),
+(420,551,cs),
+(420,474,o),
+(385,366,o),
+(275,366,cs),
+(260,366,o),
+(246,368,o),
+(233,373,c),
+(223,323,l),
+(240,317,o),
+(257,315,o),
+(278,315,cs),
+(424,315,o),
+(474,453,o),
+(474,554,cs),
+(474,645,o),
+(423,702,o),
+(336,702,cs),
+(141,702,o),
+(94,382,o),
+(94,252,cs),
+(94,83,o),
+(172,-12,o),
+(318,-12,cs)
+);
+}
+);
+width = 733;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni161B;
+unicode = 5659;
+},
+{
+color = 9;
+glyphname = "jjuCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(501,-13,o),
+(606,106,o),
+(606,248,cs),
+(606,339,o),
+(552,400,o),
+(465,400,cs),
+(377,400,o),
+(317,342,o),
+(294,232,cs),
+(286,201,o),
+(283,170,o),
+(283,144,c),
+(334,144,l),
+(334,167,o),
+(336,193,o),
+(343,223,cs),
+(361,305,o),
+(401,350,o),
+(461,350,cs),
+(518,350,o),
+(551,309,o),
+(551,246,cs),
+(551,135,o),
+(472,42,o),
+(340,42,cs),
+(213,42,o),
+(142,114,o),
+(142,243,cs),
+(142,430,o),
+(249,634,o),
+(543,634,cs),
+(675,634,l),
+(687,690,l),
+(554,690,ls),
+(419,690,o),
+(319,655,o),
+(245,601,c),
+(166,702,l),
+(116,663,l),
+(198,559,l),
+(111,472,o),
+(81,349,o),
+(81,247,cs),
+(81,88,o),
+(177,-13,o),
+(336,-13,cs)
+);
+}
+);
+width = 676;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni161C;
+unicode = 5660;
+},
+{
+color = 9;
+glyphname = "jjoCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(606,27,l),
+(524,130,l),
+(611,217,o),
+(640,341,o),
+(640,442,cs),
+(640,602,o),
+(545,702,o),
+(385,702,cs),
+(220,702,o),
+(116,583,o),
+(116,441,cs),
+(116,351,o),
+(170,290,o),
+(257,290,cs),
+(345,290,o),
+(405,348,o),
+(428,458,cs),
+(436,489,o),
+(439,520,o),
+(439,546,c),
+(388,546,l),
+(387,523,o),
+(385,497,o),
+(379,467,cs),
+(360,384,o),
+(321,340,o),
+(261,340,cs),
+(204,340,o),
+(171,381,o),
+(171,443,cs),
+(171,554,o),
+(249,648,o),
+(382,648,cs),
+(509,648,o),
+(580,576,o),
+(580,446,cs),
+(580,260,o),
+(472,56,o),
+(179,56,cs),
+(46,56,l),
+(35,0,l),
+(167,0,ls),
+(302,0,o),
+(403,35,o),
+(476,89,c),
+(555,-13,l)
+);
+}
+);
+width = 675;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|jjuCarrier-canadian";
+note = uni161D;
+unicode = 5661;
+},
+{
+color = 9;
+glyphname = "jjeCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(643,-13,o),
+(690,309,o),
+(690,438,cs),
+(690,611,o),
+(609,702,o),
+(452,702,cs),
+(369,702,o),
+(297,675,o),
+(239,617,c),
+(170,701,l),
+(123,662,l),
+(197,570,l),
+(158,518,o),
+(130,448,o),
+(111,360,cs),
+(35,0,l),
+(97,0,l),
+(172,355,ls),
+(213,548,o),
+(306,645,o),
+(448,645,cs),
+(572,645,o),
+(631,578,o),
+(631,436,cs),
+(631,352,o),
+(602,40,o),
+(453,40,cs),
+(396,40,o),
+(364,76,o),
+(364,140,cs),
+(364,216,o),
+(399,324,o),
+(509,324,cs),
+(528,324,o),
+(541,322,o),
+(552,318,c),
+(561,367,l),
+(548,373,o),
+(529,375,o),
+(509,375,cs),
+(362,375,o),
+(310,238,o),
+(310,137,cs),
+(310,45,o),
+(361,-13,o),
+(448,-13,cs)
+);
+}
+);
+width = 738;
+}
+);
+metricRight = "jeCarrier-canadian";
+note = uni161E;
+unicode = 5662;
+},
+{
+color = 9;
+glyphname = "jjeeCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(643,-13,o),
+(690,309,o),
+(690,438,cs),
+(690,611,o),
+(609,702,o),
+(452,702,cs),
+(369,702,o),
+(297,675,o),
+(239,617,c),
+(170,701,l),
+(123,662,l),
+(197,570,l),
+(158,518,o),
+(130,448,o),
+(111,360,cs),
+(35,0,l),
+(97,0,l),
+(172,355,ls),
+(213,548,o),
+(306,645,o),
+(448,645,cs),
+(572,645,o),
+(631,578,o),
+(631,436,cs),
+(631,350,o),
+(603,40,o),
+(446,40,cs),
+(386,40,o),
+(351,78,o),
+(351,146,cs),
+(351,217,o),
+(379,313,o),
+(468,328,c),
+(448,237,l),
+(487,237,l),
+(532,453,l),
+(494,453,l),
+(476,368,l),
+(353,352,o),
+(310,229,o),
+(310,137,cs),
+(310,45,o),
+(361,-13,o),
+(448,-13,cs)
+);
+}
+);
+width = 738;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161F;
+unicode = 5663;
+},
+{
+color = 9;
+glyphname = "jjiCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(605,-13,o),
+(659,195,o),
+(681,351,cs),
+(710,575,o),
+(630,702,o),
+(451,702,cs),
+(365,702,o),
+(294,673,o),
+(238,618,c),
+(170,701,l),
+(123,662,l),
+(197,571,l),
+(158,518,o),
+(129,447,o),
+(111,360,cs),
+(35,0,l),
+(97,0,l),
+(172,355,ls),
+(213,548,o),
+(306,645,o),
+(448,645,cs),
+(588,645,o),
+(646,548,o),
+(622,355,cs),
+(605,234,o),
+(573,40,o),
+(446,40,cs),
+(378,40,o),
+(345,90,o),
+(355,176,cs),
+(360,236,o),
+(382,295,o),
+(439,315,c),
+(446,298,o),
+(465,285,o),
+(486,285,cs),
+(521,285,o),
+(545,313,o),
+(545,346,cs),
+(545,380,o),
+(520,405,o),
+(486,405,cs),
+(453,405,o),
+(431,380,o),
+(428,351,c),
+(355,324,o),
+(322,249,o),
+(314,173,cs),
+(300,60,o),
+(353,-13,o),
+(448,-13,cs)
+);
+}
+);
+width = 733;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1620;
+unicode = 5664;
+},
+{
+color = 9;
+glyphname = "jjaCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(414,-13,o),
+(488,14,o),
+(546,72,c),
+(613,-12,l),
+(662,28,l),
+(586,120,l),
+(625,172,o),
+(654,242,o),
+(672,329,cs),
+(749,690,l),
+(688,690,l),
+(612,334,ls),
+(571,142,o),
+(477,44,o),
+(335,44,cs),
+(212,44,o),
+(154,112,o),
+(154,254,cs),
+(154,338,o),
+(182,650,o),
+(331,650,cs),
+(387,650,o),
+(419,613,o),
+(419,550,cs),
+(419,473,o),
+(384,366,o),
+(275,366,cs),
+(256,366,o),
+(242,368,o),
+(233,372,c),
+(222,323,l),
+(236,317,o),
+(254,315,o),
+(274,315,cs),
+(422,315,o),
+(474,452,o),
+(474,553,cs),
+(474,644,o),
+(422,702,o),
+(335,702,cs),
+(140,702,o),
+(94,381,o),
+(94,252,cs),
+(94,78,o),
+(176,-13,o),
+(332,-13,cs)
+);
+}
+);
+width = 738;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "=|jjeCarrier-canadian";
+note = uni1621;
+unicode = 5665;
+},
+{
+color = 9;
+glyphname = "luCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(483,-13,o),
+(582,79,o),
+(621,266,cs),
+(711,690,l),
+(649,690,l),
+(560,271,ls),
+(527,118,o),
+(452,44,o),
+(327,44,cs),
+(205,44,o),
+(140,116,o),
+(140,237,cs),
+(140,406,o),
+(246,630,o),
+(460,639,c),
+(471,690,l),
+(160,690,l),
+(150,638,l),
+(354,638,l),
+(392,653,l),
+(192,631,o),
+(78,411,o),
+(78,234,cs),
+(78,83,o),
+(169,-13,o),
+(325,-13,cs)
+);
+}
+);
+width = 688;
+}
+);
+metricRight = "te-canadian";
+note = uni1622;
+unicode = 5666;
+},
+{
+color = 9;
+glyphname = "loCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(85,0,l),
+(174,418,ls),
+(207,572,o),
+(281,645,o),
+(407,645,cs),
+(529,645,o),
+(594,574,o),
+(594,453,cs),
+(594,284,o),
+(488,60,o),
+(274,51,c),
+(263,0,l),
+(574,0,l),
+(584,52,l),
+(381,52,l),
+(342,37,l),
+(542,59,o),
+(656,279,o),
+(656,456,cs),
+(656,607,o),
+(565,702,o),
+(409,702,cs),
+(251,702,o),
+(153,611,o),
+(113,424,cs),
+(23,0,l)
+);
+}
+);
+width = 687;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|luCarrier-canadian";
+note = uni1623;
+unicode = 5667;
+},
+{
+color = 9;
+glyphname = "leCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (355,346);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(232,0,ls),
+(537,0,o),
+(629,253,o),
+(629,443,cs),
+(629,602,o),
+(552,702,o),
+(420,702,cs),
+(312,702,o),
+(226,632,o),
+(180,505,c),
+(189,505,l),
+(229,690,l),
+(173,690,l),
+(108,385,l),
+(160,385,l),
+(201,552,o),
+(289,645,o),
+(405,645,cs),
+(509,645,o),
+(567,569,o),
+(567,440,cs),
+(567,277,o),
+(487,56,o),
+(240,56,cs),
+(39,56,l),
+(26,0,l)
+);
+}
+);
+width = 663;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1624;
+unicode = 5668;
+},
+{
+color = 9;
+glyphname = "leeCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "leCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (292,1);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 663;
+}
+);
+metricLeft = "leCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1625;
+unicode = 5669;
+},
+{
+color = 9;
+glyphname = "liCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "leCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (270,1);
+ref = dot_middle;
+}
+);
+width = 664;
+}
+);
+note = uni1626;
+unicode = 5670;
+},
+{
+color = 9;
+glyphname = "laCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(537,0,l),
+(549,56,l),
+(365,56,ls),
+(215,56,o),
+(144,126,o),
+(144,262,cs),
+(144,402,o),
+(217,645,o),
+(413,645,cs),
+(537,645,o),
+(596,544,o),
+(567,385,c),
+(619,385,l),
+(684,690,l),
+(628,690,l),
+(585,491,l),
+(595,490,l),
+(599,621,o),
+(528,702,o),
+(408,702,cs),
+(179,702,o),
+(82,430,o),
+(82,261,cs),
+(82,94,o),
+(175,0,o),
+(356,0,cs)
+);
+}
+);
+width = 663;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|leCarrier-canadian";
+note = uni1627;
+unicode = 5671;
+},
+{
+color = 1;
+glyphname = "dluCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(561,-13,o),
+(641,256,o),
+(641,407,cs),
+(641,544,o),
+(574,637,o),
+(458,657,c),
+(473,641,l),
+(699,641,l),
+(682,557,l),
+(730,557,l),
+(776,773,l),
+(728,773,l),
+(710,690,l),
+(410,690,l),
+(398,639,l),
+(521,626,o),
+(583,548,o),
+(583,418,cs),
+(583,298,o),
+(526,44,o),
+(309,44,cs),
+(173,44,o),
+(113,132,o),
+(146,288,cs),
+(232,690,l),
+(170,690,l),
+(85,292,ls),
+(45,103,o),
+(130,-13,o),
+(306,-13,cs)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "te-canadian";
+note = uni1628;
+unicode = 5672;
+},
+{
+color = 9;
+glyphname = "dloCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(594,-83,l),
+(640,132,l),
+(592,132,l),
+(575,49,l),
+(380,49,l),
+(372,43,l),
+(551,71,o),
+(656,283,o),
+(656,456,cs),
+(656,607,o),
+(565,702,o),
+(409,702,cs),
+(251,702,o),
+(153,611,o),
+(113,424,cs),
+(23,0,l),
+(85,0,l),
+(174,418,ls),
+(207,572,o),
+(281,645,o),
+(407,645,cs),
+(529,645,o),
+(594,574,o),
+(594,453,cs),
+(594,284,o),
+(488,60,o),
+(274,51,c),
+(263,0,l),
+(564,0,l),
+(547,-83,l)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "dluCarrier-canadian";
+note = uni1629;
+unicode = 5673;
+},
+{
+color = 9;
+glyphname = "dleCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (365,346);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(242,0,ls),
+(548,0,o),
+(639,253,o),
+(639,443,cs),
+(639,602,o),
+(561,702,o),
+(431,702,cs),
+(321,702,o),
+(226,626,o),
+(178,493,c),
+(187,493,l),
+(231,703,l),
+(312,703,l),
+(322,750,l),
+(119,750,l),
+(108,703,l),
+(186,703,l),
+(119,385,l),
+(171,385,l),
+(212,552,o),
+(299,645,o),
+(415,645,cs),
+(520,645,o),
+(578,569,o),
+(578,440,cs),
+(578,277,o),
+(497,56,o),
+(250,56,cs),
+(48,56,l),
+(37,0,l)
+);
+}
+);
+width = 673;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni162A;
+unicode = 5674;
+},
+{
+color = 9;
+glyphname = "dleeCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (302,1);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 674;
+}
+);
+note = uni162B;
+unicode = 5675;
+},
+{
+color = 9;
+glyphname = "dliCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (280,1);
+ref = dot_middle;
+}
+);
+width = 674;
+}
+);
+note = uni162C;
+unicode = 5676;
+},
+{
+color = 9;
+glyphname = "dlaCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(537,0,l),
+(549,56,l),
+(365,56,ls),
+(215,56,o),
+(144,126,o),
+(144,262,cs),
+(144,402,o),
+(217,645,o),
+(413,645,cs),
+(537,645,o),
+(596,544,o),
+(567,385,c),
+(619,385,l),
+(687,703,l),
+(763,703,l),
+(773,750,l),
+(570,750,l),
+(561,703,l),
+(638,703,l),
+(593,489,l),
+(602,488,l),
+(606,621,o),
+(528,702,o),
+(408,702,cs),
+(179,702,o),
+(82,430,o),
+(82,261,cs),
+(82,94,o),
+(175,0,o),
+(356,0,cs)
+);
+}
+);
+width = 673;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni162D;
+unicode = 5677;
+},
+{
+color = 9;
+glyphname = "lhuCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(594,-13,o),
+(684,230,o),
+(684,410,cs),
+(684,533,o),
+(633,622,o),
+(539,656,c),
+(555,637,l),
+(749,637,l),
+(760,690,l),
+(519,690,l),
+(507,639,l),
+(584,610,o),
+(625,533,o),
+(625,426,cs),
+(625,278,o),
+(561,44,o),
+(354,44,cs),
+(224,44,o),
+(151,123,o),
+(151,256,cs),
+(151,388,o),
+(217,600,o),
+(391,639,c),
+(402,690,l),
+(160,690,l),
+(149,637,l),
+(348,637,l),
+(372,662,l),
+(171,622,o),
+(89,408,o),
+(89,252,cs),
+(89,90,o),
+(187,-13,o),
+(353,-13,cs)
+);
+}
+);
+width = 727;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162E;
+unicode = 5678;
+},
+{
+color = 9;
+glyphname = "lhoCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(254,0,l),
+(266,51,l),
+(188,80,o),
+(148,156,o),
+(148,264,cs),
+(148,412,o),
+(212,645,o),
+(419,645,cs),
+(549,645,o),
+(622,567,o),
+(622,434,cs),
+(622,301,o),
+(555,90,o),
+(382,51,c),
+(371,0,l),
+(612,0,l),
+(624,53,l),
+(425,53,l),
+(401,28,l),
+(602,68,o),
+(684,282,o),
+(684,438,cs),
+(684,600,o),
+(585,702,o),
+(420,702,cs),
+(179,702,o),
+(89,460,o),
+(89,280,cs),
+(89,156,o),
+(140,68,o),
+(234,34,c),
+(217,53,l),
+(24,53,l),
+(13,0,l)
+);
+}
+);
+width = 726;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162F;
+unicode = 5679;
+},
+{
+color = 9;
+glyphname = "lheCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (373,345);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(563,-13,o),
+(658,256,o),
+(658,436,cs),
+(658,598,o),
+(573,702,o),
+(432,702,cs),
+(326,702,o),
+(239,640,o),
+(192,531,c),
+(198,530,l),
+(232,690,l),
+(177,690,l),
+(119,419,l),
+(171,419,l),
+(213,565,o),
+(301,645,o),
+(414,645,cs),
+(531,645,o),
+(596,567,o),
+(596,434,cs),
+(596,284,o),
+(522,44,o),
+(326,44,cs),
+(202,44,o),
+(124,138,o),
+(139,270,c),
+(87,270,l),
+(30,0,l),
+(85,0,l),
+(125,187,l),
+(115,185,l),
+(123,66,o),
+(210,-13,o),
+(333,-13,cs)
+);
+}
+);
+width = 693;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1630;
+unicode = 5680;
+},
+{
+color = 9;
+glyphname = "lheeCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (310,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 695;
+}
+);
+note = uni1631;
+unicode = 5681;
+},
+{
+color = 9;
+glyphname = "lhiCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (289,0);
+ref = dot_middle;
+}
+);
+width = 695;
+}
+);
+note = uni1632;
+unicode = 5682;
+},
+{
+color = 9;
+glyphname = "lhaCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(413,-13,o),
+(501,49,o),
+(548,158,c),
+(542,159,l),
+(507,0,l),
+(563,0,l),
+(620,270,l),
+(568,270,l),
+(526,125,o),
+(438,44,o),
+(325,44,cs),
+(209,44,o),
+(144,123,o),
+(144,256,cs),
+(144,406,o),
+(217,645,o),
+(412,645,cs),
+(537,645,o),
+(615,552,o),
+(600,419,c),
+(652,419,l),
+(709,690,l),
+(654,690,l),
+(614,502,l),
+(625,504,l),
+(616,624,o),
+(530,702,o),
+(407,702,cs),
+(176,702,o),
+(82,434,o),
+(82,254,cs),
+(82,92,o),
+(167,-13,o),
+(307,-13,cs)
+);
+}
+);
+width = 693;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1633;
+unicode = 5683;
+},
+{
+color = 9;
+glyphname = "tlhuCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(594,-13,o),
+(684,230,o),
+(684,410,cs),
+(684,530,o),
+(639,621,o),
+(546,656,c),
+(547,640,l),
+(740,640,l),
+(723,557,l),
+(770,557,l),
+(815,773,l),
+(768,773,l),
+(751,690,l),
+(519,690,l),
+(507,639,l),
+(584,610,o),
+(625,533,o),
+(625,426,cs),
+(625,278,o),
+(561,44,o),
+(354,44,cs),
+(224,44,o),
+(151,123,o),
+(151,256,cs),
+(151,388,o),
+(217,600,o),
+(391,639,c),
+(402,690,l),
+(160,690,l),
+(149,637,l),
+(349,637,l),
+(364,659,l),
+(160,615,o),
+(89,397,o),
+(89,252,cs),
+(89,90,o),
+(187,-13,o),
+(353,-13,cs)
+);
+}
+);
+width = 749;
+}
+);
+metricLeft = "lhuCarrier-canadian";
+note = uni1634;
+unicode = 5684;
+},
+{
+color = 9;
+glyphname = "tlhoCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(28,-83,l),
+(45,0,l),
+(277,0,l),
+(288,51,l),
+(211,80,o),
+(171,156,o),
+(171,264,cs),
+(171,412,o),
+(235,645,o),
+(442,645,cs),
+(571,645,o),
+(644,567,o),
+(644,434,cs),
+(644,301,o),
+(579,90,o),
+(405,51,c),
+(393,0,l),
+(635,0,l),
+(646,53,l),
+(446,53,l),
+(431,31,l),
+(636,74,o),
+(706,293,o),
+(706,438,cs),
+(706,600,o),
+(608,702,o),
+(443,702,cs),
+(202,702,o),
+(111,460,o),
+(111,280,cs),
+(111,159,o),
+(156,69,o),
+(249,34,c),
+(249,49,l),
+(56,49,l),
+(73,132,l),
+(25,132,l),
+(-20,-83,l)
+);
+}
+);
+width = 748;
+}
+);
+metricLeft = "=|tlhuCarrier-canadian";
+metricRight = "lhuCarrier-canadian";
+note = uni1635;
+unicode = 5685;
+},
+{
+color = 9;
+glyphname = "tlheCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (380,345);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(571,-13,o),
+(665,256,o),
+(665,436,cs),
+(665,598,o),
+(580,702,o),
+(440,702,cs),
+(326,702,o),
+(234,634,o),
+(185,514,c),
+(196,522,l),
+(235,703,l),
+(312,703,l),
+(323,750,l),
+(119,750,l),
+(108,703,l),
+(186,703,l),
+(127,419,l),
+(179,419,l),
+(220,565,o),
+(309,645,o),
+(422,645,cs),
+(538,645,o),
+(604,567,o),
+(604,434,cs),
+(604,284,o),
+(529,44,o),
+(334,44,cs),
+(210,44,o),
+(131,138,o),
+(147,270,c),
+(95,270,l),
+(38,0,l),
+(93,0,l),
+(132,187,l),
+(122,185,l),
+(130,66,o),
+(216,-13,o),
+(341,-13,cs)
+);
+}
+);
+width = 701;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1636;
+unicode = 5686;
+},
+{
+color = 9;
+glyphname = "tlheeCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (317,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 701;
+}
+);
+note = uni1637;
+unicode = 5687;
+},
+{
+color = 9;
+glyphname = "tlhiCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (295,0);
+ref = dot_middle;
+}
+);
+width = 701;
+}
+);
+note = uni1638;
+unicode = 5688;
+},
+{
+color = 9;
+glyphname = "tlhaCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(413,-13,o),
+(501,49,o),
+(548,158,c),
+(542,159,l),
+(508,0,l),
+(563,0,l),
+(621,270,l),
+(569,270,l),
+(526,125,o),
+(439,44,o),
+(325,44,cs),
+(209,44,o),
+(144,123,o),
+(144,256,cs),
+(144,406,o),
+(217,645,o),
+(412,645,cs),
+(537,645,o),
+(615,552,o),
+(600,419,c),
+(652,419,l),
+(713,703,l),
+(790,703,l),
+(801,750,l),
+(597,750,l),
+(587,703,l),
+(665,703,l),
+(621,500,l),
+(629,501,l),
+(619,625,o),
+(531,702,o),
+(407,702,cs),
+(176,702,o),
+(82,434,o),
+(82,254,cs),
+(82,92,o),
+(167,-13,o),
+(307,-13,cs)
+);
+}
+);
+width = 701;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni1639;
+unicode = 5689;
+},
+{
+color = 9;
+glyphname = "tluCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(315,-13,o),
+(371,31,o),
+(408,122,c),
+(391,122,l),
+(399,38,o),
+(454,-13,o),
+(540,-13,cs),
+(736,-13,o),
+(791,270,o),
+(791,412,cs),
+(791,535,o),
+(744,617,o),
+(656,649,c),
+(643,641,l),
+(849,641,l),
+(831,557,l),
+(879,557,l),
+(924,773,l),
+(877,773,l),
+(859,690,l),
+(574,690,l),
+(562,639,l),
+(676,626,o),
+(732,556,o),
+(732,425,cs),
+(732,309,o),
+(690,43,o),
+(539,43,cs),
+(457,43,o),
+(422,103,o),
+(444,208,cs),
+(464,298,l),
+(405,298,l),
+(386,210,ls),
+(362,98,o),
+(318,43,o),
+(242,43,cs),
+(172,43,o),
+(136,90,o),
+(136,185,cs),
+(136,301,o),
+(194,635,o),
+(445,639,c),
+(456,690,l),
+(160,690,l),
+(150,637,l),
+(337,637,l),
+(327,645,l),
+(142,586,o),
+(75,330,o),
+(75,183,cs),
+(75,58,o),
+(131,-13,o),
+(234,-13,cs)
+);
+}
+);
+width = 858;
+}
+);
+metricRight = "tlhuCarrier-canadian";
+note = uni163A;
+unicode = 5690;
+},
+{
+color = 1;
+glyphname = "tloCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(742,-83,l),
+(788,132,l),
+(740,132,l),
+(723,49,l),
+(539,49,l),
+(550,42,l),
+(738,98,o),
+(808,356,o),
+(808,507,cs),
+(808,632,o),
+(751,702,o),
+(648,702,cs),
+(567,702,o),
+(511,658,o),
+(474,566,c),
+(491,565,l),
+(484,651,o),
+(429,702,o),
+(342,702,cs),
+(147,702,o),
+(91,420,o),
+(91,277,cs),
+(91,157,o),
+(137,76,o),
+(221,43,c),
+(236,52,l),
+(24,52,l),
+(13,0,l),
+(309,0,l),
+(320,51,l),
+(207,64,o),
+(150,133,o),
+(150,265,cs),
+(150,381,o),
+(192,646,o),
+(344,646,cs),
+(425,646,o),
+(460,586,o),
+(438,482,cs),
+(419,391,l),
+(478,391,l),
+(496,480,ls),
+(520,592,o),
+(565,646,o),
+(639,646,cs),
+(710,646,o),
+(746,600,o),
+(746,504,cs),
+(746,388,o),
+(689,55,o),
+(437,51,c),
+(426,0,l),
+(712,0,l),
+(695,-83,l)
+);
+}
+);
+width = 857;
+}
+);
+metricLeft = "tluCarrier-canadian";
+metricRight = "tlhuCarrier-canadian";
+note = uni163B;
+unicode = 5691;
+},
+{
+color = 9;
+glyphname = "tleCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (294,345);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(514,-13,o),
+(619,72,o),
+(619,208,cs),
+(619,283,o),
+(576,340,o),
+(507,351,c),
+(503,337,l),
+(613,347,o),
+(688,429,o),
+(688,531,cs),
+(688,633,o),
+(600,702,o),
+(462,702,cs),
+(334,702,o),
+(239,641,o),
+(189,529,c),
+(195,519,l),
+(234,703,l),
+(312,703,l),
+(322,750,l),
+(119,750,l),
+(108,703,l),
+(186,703,l),
+(126,419,l),
+(178,419,l),
+(214,573,o),
+(302,646,o),
+(446,646,cs),
+(559,646,o),
+(626,599,o),
+(626,523,cs),
+(626,423,o),
+(547,372,o),
+(440,372,cs),
+(398,372,l),
+(386,319,l),
+(427,319,ls),
+(511,319,o),
+(559,279,o),
+(559,212,cs),
+(559,105,o),
+(479,43,o),
+(362,43,cs),
+(210,43,o),
+(126,130,o),
+(146,270,c),
+(94,270,l),
+(37,0,l),
+(93,0,l),
+(133,191,l),
+(120,180,l),
+(126,63,o),
+(223,-13,o),
+(368,-13,cs)
+);
+}
+);
+width = 706;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni163C;
+unicode = 5692;
+},
+{
+color = 9;
+glyphname = "tleeCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (231,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 706;
+}
+);
+note = uni163D;
+unicode = 5693;
+},
+{
+color = 9;
+glyphname = "tliCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (213,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 706;
+}
+);
+note = uni163E;
+unicode = 5694;
+},
+{
+color = 9;
+glyphname = "tlaCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(409,-13,o),
+(498,39,o),
+(552,133,c),
+(546,146,l),
+(514,0,l),
+(570,0,l),
+(628,270,l),
+(576,270,l),
+(539,117,o),
+(451,43,o),
+(307,43,cs),
+(194,43,o),
+(128,91,o),
+(128,167,cs),
+(128,267,o),
+(206,318,o),
+(314,318,cs),
+(355,318,l),
+(367,371,l),
+(327,371,ls),
+(242,371,o),
+(194,411,o),
+(194,478,cs),
+(194,584,o),
+(274,646,o),
+(392,646,cs),
+(544,646,o),
+(628,559,o),
+(608,419,c),
+(660,419,l),
+(719,703,l),
+(796,703,l),
+(807,750,l),
+(603,750,l),
+(593,703,l),
+(671,703,l),
+(629,504,l),
+(637,513,l),
+(626,629,o),
+(528,702,o),
+(385,702,cs),
+(240,702,o),
+(134,617,o),
+(134,482,cs),
+(134,409,o),
+(176,354,o),
+(241,341,c),
+(243,352,l),
+(138,339,o),
+(66,259,o),
+(66,158,cs),
+(66,57,o),
+(153,-13,o),
+(292,-13,cs)
+);
+}
+);
+width = 707;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni163F;
+unicode = 5695;
+},
+{
+color = 9;
+glyphname = "zuCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(532,-13,o),
+(658,113,o),
+(658,298,cs),
+(658,390,o),
+(621,473,o),
+(621,539,cs),
+(621,599,o),
+(654,636,o),
+(716,636,cs),
+(747,636,l),
+(757,690,l),
+(717,690,ls),
+(618,690,o),
+(562,639,o),
+(562,541,cs),
+(562,467,o),
+(598,389,o),
+(598,301,cs),
+(598,150,o),
+(502,44,o),
+(339,44,cs),
+(209,44,o),
+(129,105,o),
+(129,201,cs),
+(129,351,o),
+(303,480,o),
+(303,600,cs),
+(303,655,o),
+(264,690,o),
+(198,690,cs),
+(157,690,l),
+(146,636,l),
+(180,636,ls),
+(223,636,o),
+(243,621,o),
+(243,591,cs),
+(243,497,o),
+(69,364,o),
+(69,195,cs),
+(69,71,o),
+(170,-13,o),
+(331,-13,cs)
+);
+}
+);
+width = 722;
+}
+);
+metricRight = "=|";
+note = uni1640;
+unicode = 5696;
+},
+{
+color = 9;
+glyphname = "zoCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(50,0,ls),
+(150,0,o),
+(205,51,o),
+(205,149,cs),
+(205,223,o),
+(169,300,o),
+(169,388,cs),
+(169,540,o),
+(265,645,o),
+(429,645,cs),
+(558,645,o),
+(638,584,o),
+(638,489,cs),
+(638,339,o),
+(465,210,o),
+(465,90,cs),
+(465,35,o),
+(503,0,o),
+(570,0,cs),
+(610,0,l),
+(621,54,l),
+(587,54,ls),
+(544,54,o),
+(525,69,o),
+(525,99,cs),
+(525,193,o),
+(699,326,o),
+(699,495,cs),
+(699,618,o),
+(597,702,o),
+(436,702,cs),
+(235,702,o),
+(109,577,o),
+(109,391,cs),
+(109,299,o),
+(147,216,o),
+(147,151,cs),
+(147,91,o),
+(113,54,o),
+(51,54,cs),
+(21,54,l),
+(10,0,l)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1641;
+unicode = 5697;
+},
+{
+color = 9;
+glyphname = "zeCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (383,345);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(554,-13,o),
+(648,326,o),
+(648,496,cs),
+(648,626,o),
+(595,702,o),
+(499,702,cs),
+(390,702,o),
+(286,599,o),
+(234,599,cs),
+(206,599,o),
+(196,620,o),
+(205,662,cs),
+(212,690,l),
+(156,690,l),
+(147,650,ls),
+(133,585,o),
+(158,544,o),
+(213,544,cs),
+(295,544,o),
+(391,645,o),
+(481,645,cs),
+(550,645,o),
+(585,590,o),
+(585,489,cs),
+(585,350,o),
+(509,44,o),
+(349,44,cs),
+(257,44,o),
+(205,146,o),
+(124,146,cs),
+(71,146,o),
+(31,107,o),
+(17,40,cs),
+(9,0,l),
+(65,0,l),
+(71,28,ls),
+(79,68,o),
+(101,91,o),
+(128,91,cs),
+(183,91,o),
+(245,-13,o),
+(355,-13,cs)
+);
+}
+);
+width = 672;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1642;
+unicode = 5698;
+},
+{
+color = 9;
+glyphname = "zeeCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (320,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 672;
+}
+);
+note = uni1643;
+unicode = 5699;
+},
+{
+color = 9;
+glyphname = "ziCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (298,0);
+ref = dot_middle;
+}
+);
+width = 672;
+}
+);
+note = uni1644;
+unicode = 5700;
+},
+{
+color = 9;
+glyphname = "zaCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(328,-13,o),
+(433,91,o),
+(485,91,cs),
+(513,91,o),
+(523,70,o),
+(514,28,cs),
+(507,0,l),
+(563,0,l),
+(572,40,ls),
+(585,104,o),
+(560,146,o),
+(506,146,cs),
+(424,146,o),
+(327,44,o),
+(238,44,cs),
+(169,44,o),
+(133,99,o),
+(133,201,cs),
+(133,340,o),
+(210,645,o),
+(370,645,cs),
+(462,645,o),
+(514,544,o),
+(595,544,cs),
+(647,544,o),
+(688,582,o),
+(701,650,cs),
+(710,690,l),
+(654,690,l),
+(648,662,ls),
+(639,622,o),
+(617,599,o),
+(590,599,cs),
+(536,599,o),
+(473,702,o),
+(364,702,cs),
+(164,702,o),
+(71,364,o),
+(71,194,cs),
+(71,64,o),
+(125,-13,o),
+(219,-13,cs)
+);
+}
+);
+width = 673;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|zeCarrier-canadian";
+note = uni1645;
+unicode = 5701;
+},
+{
+color = 6;
+glyphname = "zCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(343,183,l),
+(353,224,l),
+(113,224,l),
+(111,198,l),
+(409,503,l),
+(413,527,l),
+(129,527,l),
+(121,486,l),
+(357,486,l),
+(359,512,l),
+(62,207,l),
+(56,183,l)
+);
+}
+);
+width = 423;
+}
+);
+metricRight = "=|";
+note = uni1646;
+unicode = 5702;
+},
+{
+color = 6;
+glyphname = "initialzCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(202,96,l),
+(220,183,l),
+(343,183,l),
+(353,224,l),
+(107,224,l),
+(116,203,l),
+(409,503,l),
+(413,527,l),
+(294,527,l),
+(312,614,l),
+(268,614,l),
+(249,527,l),
+(129,527,l),
+(121,486,l),
+(362,486,l),
+(354,506,l),
+(62,207,l),
+(56,183,l),
+(176,183,l),
+(157,96,l)
+);
+}
+);
+width = 423;
+}
+);
+metricLeft = "zCarrier-canadian";
+metricRight = "zCarrier-canadian";
+note = uni1647;
+unicode = 5703;
+},
+{
+color = 9;
+glyphname = "dzuCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(532,-13,o),
+(658,113,o),
+(658,298,cs),
+(658,390,o),
+(621,473,o),
+(621,539,cs),
+(621,599,o),
+(654,636,o),
+(716,636,cs),
+(747,636,l),
+(757,690,l),
+(717,690,ls),
+(620,690,o),
+(564,639,o),
+(563,541,cs),
+(563,467,o),
+(599,387,o),
+(598,301,cs),
+(598,150,o),
+(502,44,o),
+(339,44,cs),
+(209,44,o),
+(129,105,o),
+(129,201,cs),
+(129,351,o),
+(302,480,o),
+(302,600,cs),
+(302,655,o),
+(264,690,o),
+(198,690,cs),
+(157,690,l),
+(146,636,l),
+(180,636,ls),
+(223,636,o),
+(243,621,o),
+(243,591,cs),
+(243,497,o),
+(69,364,o),
+(69,195,cs),
+(69,71,o),
+(170,-13,o),
+(331,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(432,490,l),
+(468,656,l),
+(535,656,l),
+(543,690,l),
+(371,690,l),
+(363,656,l),
+(431,656,l),
+(396,490,l)
+);
+}
+);
+width = 722;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1648;
+unicode = 5704;
+},
+{
+color = 9;
+glyphname = "dzoCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(50,0,ls),
+(147,0,o),
+(203,51,o),
+(204,149,cs),
+(205,223,o),
+(169,302,o),
+(169,388,cs),
+(170,540,o),
+(265,645,o),
+(429,645,cs),
+(558,645,o),
+(638,584,o),
+(638,489,cs),
+(638,339,o),
+(466,210,o),
+(466,90,cs),
+(466,35,o),
+(503,0,o),
+(570,0,cs),
+(610,0,l),
+(621,54,l),
+(587,54,ls),
+(544,54,o),
+(525,69,o),
+(525,99,cs),
+(525,193,o),
+(699,326,o),
+(699,495,cs),
+(699,618,o),
+(597,702,o),
+(436,702,cs),
+(235,702,o),
+(109,577,o),
+(109,391,cs),
+(109,299,o),
+(147,216,o),
+(147,151,cs),
+(147,91,o),
+(113,54,o),
+(51,54,cs),
+(21,54,l),
+(10,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(397,0,l),
+(405,34,l),
+(336,34,l),
+(371,200,l),
+(335,200,l),
+(300,34,l),
+(232,34,l),
+(224,0,l)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1649;
+unicode = 5705;
+},
+{
+color = 9;
+glyphname = "dzeCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (392,345);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(577,-13,o),
+(669,326,o),
+(669,496,cs),
+(669,626,o),
+(616,702,o),
+(521,702,cs),
+(412,702,o),
+(307,599,o),
+(255,599,cs),
+(228,599,o),
+(217,620,o),
+(227,662,cs),
+(233,690,l),
+(177,690,l),
+(169,650,ls),
+(155,585,o),
+(181,544,o),
+(235,544,cs),
+(317,544,o),
+(413,645,o),
+(503,645,cs),
+(572,645,o),
+(608,590,o),
+(608,489,cs),
+(608,350,o),
+(530,44,o),
+(371,44,cs),
+(279,44,o),
+(226,146,o),
+(146,146,cs),
+(93,146,o),
+(53,107,o),
+(39,40,cs),
+(30,0,l),
+(86,0,l),
+(93,28,ls),
+(101,68,o),
+(123,91,o),
+(150,91,cs),
+(205,91,o),
+(268,-13,o),
+(377,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(121,241,l),
+(138,327,l),
+(269,327,l),
+(276,363,l),
+(147,363,l),
+(164,449,l),
+(126,449,l),
+(82,241,l)
+);
+}
+);
+width = 693;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164A;
+unicode = 5706;
+},
+{
+color = 9;
+glyphname = "dzeeCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "dzeCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (329,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 693;
+}
+);
+metricLeft = "dzeCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164B;
+unicode = 5707;
+},
+{
+color = 9;
+glyphname = "dziCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "dzeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (307,0);
+ref = dot_middle;
+}
+);
+width = 695;
+}
+);
+note = uni164C;
+unicode = 5708;
+},
+{
+color = 9;
+glyphname = "dzaCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(329,-13,o),
+(434,91,o),
+(486,91,cs),
+(514,91,o),
+(524,70,o),
+(514,28,cs),
+(508,0,l),
+(564,0,l),
+(573,40,ls),
+(586,104,o),
+(560,146,o),
+(506,146,cs),
+(424,146,o),
+(327,44,o),
+(238,44,cs),
+(170,44,o),
+(133,99,o),
+(133,201,cs),
+(133,340,o),
+(211,645,o),
+(370,645,cs),
+(462,645,o),
+(515,544,o),
+(596,544,cs),
+(648,544,o),
+(688,582,o),
+(702,650,cs),
+(711,690,l),
+(655,690,l),
+(649,662,ls),
+(639,622,o),
+(618,599,o),
+(591,599,cs),
+(536,599,o),
+(473,702,o),
+(365,702,cs),
+(164,702,o),
+(71,364,o),
+(71,194,cs),
+(71,64,o),
+(125,-13,o),
+(220,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(615,241,l),
+(660,449,l),
+(620,449,l),
+(603,363,l),
+(472,363,l),
+(465,327,l),
+(595,327,l),
+(577,241,l)
+);
+}
+);
+width = 695;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dzeCarrier-canadian";
+note = uni164D;
+unicode = 5709;
+},
+{
+color = 9;
+glyphname = "suCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(302,-13,o),
+(368,39,o),
+(409,144,c),
+(386,144,l),
+(390,44,o),
+(443,-13,o),
+(539,-13,cs),
+(698,-13,o),
+(758,134,o),
+(760,268,cs),
+(761,364,o),
+(729,464,o),
+(730,536,cs),
+(731,595,o),
+(758,636,o),
+(821,636,cs),
+(854,636,l),
+(866,690,l),
+(818,690,ls),
+(720,690,o),
+(674,631,o),
+(672,537,cs),
+(670,461,o),
+(701,360,o),
+(700,267,cs),
+(699,167,o),
+(660,43,o),
+(539,43,cs),
+(431,43,o),
+(424,143,o),
+(440,221,cs),
+(540,690,l),
+(483,690,l),
+(383,221,ls),
+(358,103,o),
+(303,43,o),
+(221,43,cs),
+(154,43,o),
+(116,83,o),
+(116,152,cs),
+(116,315,o),
+(302,476,o),
+(302,601,cs),
+(302,657,o),
+(265,690,o),
+(200,690,cs),
+(157,690,l),
+(146,636,l),
+(176,636,ls),
+(219,636,o),
+(241,620,o),
+(241,587,cs),
+(241,480,o),
+(54,329,o),
+(54,146,cs),
+(54,49,o),
+(112,-13,o),
+(212,-13,cs)
+);
+}
+);
+width = 829;
+}
+);
+metricRight = "=|";
+note = uni164E;
+unicode = 5710;
+},
+{
+color = 9;
+glyphname = "soCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(57,0,ls),
+(156,0,o),
+(201,59,o),
+(204,153,cs),
+(205,229,o),
+(175,329,o),
+(176,423,cs),
+(176,523,o),
+(216,646,o),
+(336,646,cs),
+(444,646,o),
+(451,547,o),
+(435,469,cs),
+(335,0,l),
+(393,0,l),
+(493,469,ls),
+(517,586,o),
+(572,646,o),
+(655,646,cs),
+(722,646,o),
+(760,607,o),
+(760,538,cs),
+(760,375,o),
+(574,213,o),
+(574,89,cs),
+(574,33,o),
+(610,0,o),
+(676,0,cs),
+(718,0,l),
+(729,54,l),
+(700,54,ls),
+(656,54,o),
+(635,70,o),
+(635,102,cs),
+(635,210,o),
+(822,360,o),
+(822,544,cs),
+(822,640,o),
+(763,702,o),
+(664,702,cs),
+(574,702,o),
+(508,651,o),
+(467,546,c),
+(489,546,l),
+(485,645,o),
+(432,702,o),
+(337,702,cs),
+(178,702,o),
+(118,555,o),
+(115,422,cs),
+(114,326,o),
+(146,226,o),
+(145,154,cs),
+(144,95,o),
+(117,54,o),
+(55,54,cs),
+(21,54,l),
+(10,0,l)
+);
+}
+);
+width = 828;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5711;
+},
+{
+color = 9;
+glyphname = "seCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(539,-13,o),
+(608,102,o),
+(608,204,cs),
+(608,276,o),
+(569,332,o),
+(502,353,c),
+(498,333,l),
+(617,353,o),
+(681,448,o),
+(681,550,cs),
+(681,639,o),
+(621,702,o),
+(531,702,cs),
+(417,702,o),
+(312,599,o),
+(254,599,cs),
+(225,599,o),
+(213,619,o),
+(223,661,cs),
+(230,690,l),
+(174,690,l),
+(165,651,ls),
+(153,587,o),
+(181,545,o),
+(237,545,cs),
+(320,545,o),
+(417,646,o),
+(516,646,cs),
+(580,646,o),
+(619,606,o),
+(619,543,cs),
+(619,450,o),
+(555,371,o),
+(440,371,cs),
+(106,371,l),
+(96,319,l),
+(432,319,ls),
+(507,319,o),
+(548,276,o),
+(548,211,cs),
+(548,134,o),
+(502,43,o),
+(409,43,cs),
+(310,43,o),
+(235,145,o),
+(144,145,cs),
+(88,145,o),
+(50,109,o),
+(36,39,cs),
+(27,0,l),
+(83,0,l),
+(89,28,ls),
+(99,71,o),
+(118,91,o),
+(149,91,cs),
+(217,91,o),
+(300,-13,o),
+(414,-13,cs)
+);
+}
+);
+width = 696;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni1650;
+unicode = 5712;
+},
+{
+color = 9;
+glyphname = "seeCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(539,-13,o),
+(608,102,o),
+(608,204,cs),
+(608,274,o),
+(571,330,o),
+(507,351,c),
+(504,335,l),
+(619,356,o),
+(681,449,o),
+(681,550,cs),
+(681,639,o),
+(621,702,o),
+(531,702,cs),
+(417,702,o),
+(312,599,o),
+(254,599,cs),
+(225,599,o),
+(213,619,o),
+(223,661,cs),
+(230,690,l),
+(174,690,l),
+(165,651,ls),
+(153,587,o),
+(181,545,o),
+(237,545,cs),
+(320,545,o),
+(417,646,o),
+(516,646,cs),
+(580,646,o),
+(619,606,o),
+(619,543,cs),
+(619,450,o),
+(555,371,o),
+(440,371,cs),
+(369,371,l),
+(382,344,l),
+(404,453,l),
+(363,453,l),
+(346,371,l),
+(106,371,l),
+(96,320,l),
+(334,320,l),
+(315,226,l),
+(355,226,l),
+(381,347,l),
+(358,320,l),
+(438,320,ls),
+(505,322,o),
+(548,277,o),
+(548,211,cs),
+(548,134,o),
+(502,43,o),
+(409,43,cs),
+(310,43,o),
+(235,145,o),
+(144,145,cs),
+(88,145,o),
+(50,109,o),
+(36,39,cs),
+(27,0,l),
+(83,0,l),
+(89,28,ls),
+(99,71,o),
+(118,91,o),
+(149,91,cs),
+(217,91,o),
+(300,-13,o),
+(414,-13,cs)
+);
+}
+);
+width = 696;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1651;
+unicode = 5713;
+},
+{
+color = 9;
+glyphname = "siCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(539,-13,o),
+(608,102,o),
+(608,204,cs),
+(608,274,o),
+(571,330,o),
+(507,351,c),
+(504,335,l),
+(619,356,o),
+(681,449,o),
+(681,550,cs),
+(681,639,o),
+(621,702,o),
+(531,702,cs),
+(417,702,o),
+(312,599,o),
+(254,599,cs),
+(225,599,o),
+(213,619,o),
+(223,661,cs),
+(230,690,l),
+(174,690,l),
+(165,651,ls),
+(153,587,o),
+(181,545,o),
+(237,545,cs),
+(320,545,o),
+(417,646,o),
+(516,646,cs),
+(580,646,o),
+(620,606,o),
+(620,543,cs),
+(620,450,o),
+(557,370,o),
+(442,370,cs),
+(384,370,l),
+(410,351,l),
+(408,384,o),
+(381,409,o),
+(348,409,cs),
+(323,409,o),
+(300,393,o),
+(292,371,c),
+(106,371,l),
+(96,320,l),
+(293,320,l),
+(301,298,o),
+(324,282,o),
+(349,282,cs),
+(381,282,o),
+(407,306,o),
+(410,339,c),
+(384,321,l),
+(435,321,ls),
+(510,321,o),
+(549,276,o),
+(549,211,cs),
+(549,134,o),
+(502,43,o),
+(409,43,cs),
+(310,43,o),
+(235,145,o),
+(144,145,cs),
+(88,145,o),
+(50,109,o),
+(36,39,cs),
+(27,0,l),
+(83,0,l),
+(89,28,ls),
+(99,71,o),
+(118,91,o),
+(149,91,cs),
+(217,91,o),
+(300,-13,o),
+(414,-13,cs)
+);
+}
+);
+width = 696;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1652;
+unicode = 5714;
+},
+{
+color = 9;
+glyphname = "saCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(325,-13,o),
+(430,91,o),
+(488,91,cs),
+(516,91,o),
+(528,71,o),
+(519,29,cs),
+(512,0,l),
+(568,0,l),
+(576,39,ls),
+(589,102,o),
+(561,145,o),
+(505,145,cs),
+(422,145,o),
+(325,43,o),
+(226,43,cs),
+(162,43,o),
+(123,84,o),
+(123,147,cs),
+(123,240,o),
+(185,319,o),
+(301,319,cs),
+(636,319,l),
+(646,371,l),
+(310,371,ls),
+(235,371,o),
+(194,413,o),
+(194,479,cs),
+(194,555,o),
+(240,646,o),
+(333,646,cs),
+(432,646,o),
+(507,545,o),
+(598,545,cs),
+(654,545,o),
+(692,581,o),
+(706,651,cs),
+(715,690,l),
+(659,690,l),
+(653,662,ls),
+(643,619,o),
+(623,599,o),
+(593,599,cs),
+(525,599,o),
+(441,702,o),
+(327,702,cs),
+(203,702,o),
+(134,587,o),
+(134,486,cs),
+(134,413,o),
+(173,357,o),
+(240,337,c),
+(243,356,l),
+(125,337,o),
+(61,242,o),
+(61,140,cs),
+(61,50,o),
+(121,-13,o),
+(211,-13,cs)
+);
+}
+);
+width = 695;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1653;
+unicode = 5715;
+},
+{
+color = 9;
+glyphname = "shuCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(298,-13,o),
+(362,35,o),
+(404,132,c),
+(388,134,l),
+(394,41,o),
+(447,-13,o),
+(539,-13,cs),
+(698,-13,o),
+(758,134,o),
+(760,268,cs),
+(761,364,o),
+(729,464,o),
+(730,536,cs),
+(731,595,o),
+(758,636,o),
+(821,636,cs),
+(854,636,l),
+(866,690,l),
+(818,690,ls),
+(726,690,o),
+(679,640,o),
+(673,555,cs),
+(672,545,o),
+(671,532,o),
+(673,521,c),
+(691,554,l),
+(512,554,l),
+(540,690,l),
+(483,690,l),
+(454,554,l),
+(275,554,l),
+(286,529,l),
+(297,554,o),
+(302,579,o),
+(302,601,cs),
+(302,657,o),
+(265,690,o),
+(200,690,cs),
+(157,690,l),
+(146,636,l),
+(176,636,ls),
+(219,636,o),
+(241,620,o),
+(241,587,cs),
+(241,480,o),
+(54,329,o),
+(54,146,cs),
+(54,49,o),
+(112,-13,o),
+(212,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(154,43,o),
+(116,83,o),
+(116,152,cs),
+(116,277,o),
+(225,397,o),
+(275,503,c),
+(443,503,l),
+(383,221,ls),
+(358,103,o),
+(303,43,o),
+(221,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(431,43,o),
+(424,143,o),
+(440,221,cs),
+(500,503,l),
+(673,503,l),
+(678,432,o),
+(700,348,o),
+(700,267,cs),
+(699,167,o),
+(660,43,o),
+(539,43,cs)
+);
+}
+);
+width = 829;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1654;
+unicode = 5716;
+},
+{
+color = 9;
+glyphname = "shoCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(57,0,ls),
+(149,0,o),
+(196,49,o),
+(202,134,cs),
+(203,145,o),
+(204,157,o),
+(203,169,c),
+(184,135,l),
+(364,135,l),
+(335,0,l),
+(393,0,l),
+(421,135,l),
+(600,135,l),
+(589,160,l),
+(580,135,o),
+(574,111,o),
+(574,89,cs),
+(574,33,o),
+(610,0,o),
+(676,0,cs),
+(718,0,l),
+(729,54,l),
+(700,54,ls),
+(656,54,o),
+(635,70,o),
+(635,102,cs),
+(635,210,o),
+(822,360,o),
+(822,544,cs),
+(822,640,o),
+(763,702,o),
+(664,702,cs),
+(578,702,o),
+(514,655,o),
+(471,557,c),
+(488,555,l),
+(482,649,o),
+(428,702,o),
+(337,702,cs),
+(178,702,o),
+(118,555,o),
+(115,422,cs),
+(114,326,o),
+(146,226,o),
+(145,154,cs),
+(144,95,o),
+(117,54,o),
+(55,54,cs),
+(21,54,l),
+(10,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(197,258,o),
+(175,342,o),
+(176,423,cs),
+(176,523,o),
+(216,646,o),
+(336,646,cs),
+(444,646,o),
+(451,547,o),
+(435,469,cs),
+(375,186,l),
+(203,186,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(493,469,ls),
+(517,586,o),
+(572,646,o),
+(655,646,cs),
+(722,646,o),
+(760,607,o),
+(760,538,cs),
+(760,412,o),
+(650,293,o),
+(600,186,c),
+(433,186,l)
+);
+}
+);
+width = 828;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1655;
+unicode = 5717;
+},
+{
+color = 9;
+glyphname = "sheCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(539,-13,o),
+(608,102,o),
+(608,204,cs),
+(608,274,o),
+(571,330,o),
+(507,351,c),
+(504,335,l),
+(619,356,o),
+(681,449,o),
+(681,550,cs),
+(681,639,o),
+(621,702,o),
+(531,702,cs),
+(417,702,o),
+(312,599,o),
+(254,599,cs),
+(225,599,o),
+(213,619,o),
+(223,661,cs),
+(230,690,l),
+(174,690,l),
+(165,651,ls),
+(153,587,o),
+(181,546,o),
+(237,546,cs),
+(255,546,o),
+(276,551,o),
+(294,558,c),
+(266,582,l),
+(221,371,l),
+(106,371,l),
+(96,319,l),
+(210,319,l),
+(165,108,l),
+(202,131,l),
+(183,140,o),
+(163,144,o),
+(144,144,cs),
+(88,144,o),
+(50,109,o),
+(36,39,cs),
+(27,0,l),
+(83,0,l),
+(89,28,ls),
+(99,71,o),
+(118,91,o),
+(149,91,cs),
+(217,91,o),
+(300,-13,o),
+(414,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(261,319,l),
+(432,319,ls),
+(507,319,o),
+(548,276,o),
+(548,211,cs),
+(548,134,o),
+(502,43,o),
+(409,43,cs),
+(338,43,o),
+(279,95,o),
+(219,124,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(313,566,l),
+(376,595,o),
+(445,646,o),
+(516,646,cs),
+(580,646,o),
+(619,606,o),
+(619,543,cs),
+(619,450,o),
+(555,371,o),
+(440,371,cs),
+(271,371,l)
+);
+}
+);
+width = 696;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1656;
+unicode = 5718;
+},
+{
+color = 9;
+glyphname = "sheeCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(539,-13,o),
+(608,102,o),
+(608,204,cs),
+(608,274,o),
+(571,330,o),
+(507,351,c),
+(504,335,l),
+(619,356,o),
+(681,449,o),
+(681,550,cs),
+(681,639,o),
+(621,702,o),
+(531,702,cs),
+(417,702,o),
+(312,599,o),
+(254,599,cs),
+(225,599,o),
+(213,619,o),
+(223,661,cs),
+(230,690,l),
+(174,690,l),
+(165,651,ls),
+(153,587,o),
+(181,546,o),
+(237,546,cs),
+(253,546,o),
+(270,550,o),
+(287,556,c),
+(266,582,l),
+(220,368,l),
+(105,368,l),
+(96,323,l),
+(211,323,l),
+(166,108,l),
+(198,132,l),
+(180,140,o),
+(162,144,o),
+(144,144,cs),
+(88,144,o),
+(50,109,o),
+(36,39,cs),
+(27,0,l),
+(83,0,l),
+(89,28,ls),
+(99,71,o),
+(118,91,o),
+(149,91,cs),
+(217,91,o),
+(300,-13,o),
+(414,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(337,43,o),
+(278,97,o),
+(215,126,c),
+(257,323,l),
+(379,323,l),
+(358,227,l),
+(394,227,l),
+(418,344,l),
+(403,323,l),
+(434,323,ls),
+(509,323,o),
+(549,276,o),
+(549,211,cs),
+(549,134,o),
+(502,43,o),
+(409,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(442,453,l),
+(406,453,l),
+(388,368,l),
+(267,368,l),
+(308,565,l),
+(374,594,o),
+(444,647,o),
+(516,647,cs),
+(580,647,o),
+(620,606,o),
+(620,543,cs),
+(620,450,o),
+(556,368,o),
+(441,368,cs),
+(412,368,l),
+(419,347,l)
+);
+}
+);
+width = 696;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1657;
+unicode = 5719;
+},
+{
+color = 9;
+glyphname = "shiCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(165,651,ls),
+(153,587,o),
+(181,546,o),
+(237,546,cs),
+(253,546,o),
+(270,550,o),
+(288,557,c),
+(266,582,l),
+(220,368,l),
+(105,368,l),
+(96,323,l),
+(211,323,l),
+(165,108,l),
+(197,132,l),
+(180,140,o),
+(161,144,o),
+(144,144,cs),
+(88,144,o),
+(50,109,o),
+(36,39,cs),
+(27,0,l),
+(83,0,l),
+(89,28,ls),
+(99,71,o),
+(118,91,o),
+(149,91,cs),
+(217,91,o),
+(300,-13,o),
+(414,-13,cs),
+(539,-13,o),
+(608,102,o),
+(608,204,cs),
+(608,274,o),
+(571,330,o),
+(507,351,c),
+(504,335,l),
+(619,356,o),
+(681,449,o),
+(681,550,cs),
+(681,639,o),
+(621,702,o),
+(531,702,cs),
+(417,702,o),
+(312,599,o),
+(254,599,cs),
+(225,599,o),
+(213,619,o),
+(223,661,cs),
+(230,690,l),
+(174,690,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(257,323,l),
+(345,323,l),
+(353,298,o),
+(375,282,o),
+(401,282,cs),
+(434,282,o),
+(457,308,o),
+(462,338,c),
+(416,323,l),
+(436,323,ls),
+(510,323,o),
+(550,276,o),
+(550,211,cs),
+(550,134,o),
+(502,43,o),
+(409,43,cs),
+(337,43,o),
+(278,96,o),
+(215,126,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(308,565,l),
+(374,594,o),
+(444,647,o),
+(516,647,cs),
+(580,647,o),
+(621,606,o),
+(621,543,cs),
+(621,450,o),
+(557,368,o),
+(443,368,cs),
+(416,368,l),
+(461,353,l),
+(460,384,o),
+(434,409,o),
+(401,409,cs),
+(374,409,o),
+(352,391,o),
+(344,368,c),
+(267,368,l)
+);
+}
+);
+width = 696;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1658;
+unicode = 5720;
+},
+{
+color = 9;
+glyphname = "shaCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(325,-13,o),
+(430,91,o),
+(488,91,cs),
+(516,91,o),
+(528,71,o),
+(519,29,cs),
+(512,0,l),
+(568,0,l),
+(576,39,ls),
+(589,102,o),
+(561,144,o),
+(505,144,cs),
+(486,144,o),
+(466,139,o),
+(448,131,c),
+(476,108,l),
+(521,319,l),
+(636,319,l),
+(646,371,l),
+(531,371,l),
+(577,582,l),
+(540,558,l),
+(559,550,o),
+(579,546,o),
+(598,546,cs),
+(654,546,o),
+(692,581,o),
+(706,651,cs),
+(715,690,l),
+(659,690,l),
+(653,662,ls),
+(643,619,o),
+(623,599,o),
+(593,599,cs),
+(525,599,o),
+(441,702,o),
+(327,702,cs),
+(203,702,o),
+(134,587,o),
+(134,486,cs),
+(134,415,o),
+(171,359,o),
+(235,339,c),
+(238,355,l),
+(123,333,o),
+(61,241,o),
+(61,140,cs),
+(61,50,o),
+(121,-13,o),
+(211,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(162,43,o),
+(123,84,o),
+(123,147,cs),
+(123,240,o),
+(185,319,o),
+(301,319,cs),
+(470,319,l),
+(429,124,l),
+(365,95,o),
+(297,43,o),
+(226,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(235,371,o),
+(194,413,o),
+(194,479,cs),
+(194,555,o),
+(240,646,o),
+(333,646,cs),
+(404,646,o),
+(463,595,o),
+(523,566,c),
+(481,371,l),
+(310,371,ls)
+);
+}
+);
+width = 695;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1659;
+unicode = 5721;
+},
+{
+color = 6;
+glyphname = "shCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(189,96,l),
+(211,196,l),
+(175,183,l),
+(208,183,ls),
+(293,183,o),
+(337,225,o),
+(337,296,cs),
+(337,343,o),
+(306,374,o),
+(247,374,cs),
+(209,374,ls),
+(168,374,o),
+(150,390,o),
+(150,418,cs),
+(150,462,o),
+(177,490,o),
+(233,490,cs),
+(376,490,l),
+(384,527,l),
+(281,527,l),
+(299,614,l),
+(256,614,l),
+(235,513,l),
+(270,527,l),
+(238,527,ls),
+(153,527,o),
+(109,486,o),
+(109,414,cs),
+(109,367,o),
+(139,336,o),
+(198,336,cs),
+(238,336,ls),
+(278,336,o),
+(296,320,o),
+(296,293,cs),
+(296,248,o),
+(270,220,o),
+(213,220,cs),
+(70,220,l),
+(62,183,l),
+(164,183,l),
+(146,96,l)
+);
+}
+);
+width = 396;
+}
+);
+metricRight = "=|";
+note = uni18F5;
+unicode = 5722;
+},
+{
+color = 9;
+glyphname = "tsuCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(298,-13,o),
+(361,35,o),
+(404,132,c),
+(388,134,l),
+(394,41,o),
+(447,-13,o),
+(539,-13,cs),
+(698,-13,o),
+(758,134,o),
+(760,268,cs),
+(761,364,o),
+(729,464,o),
+(730,536,cs),
+(731,595,o),
+(758,636,o),
+(821,636,cs),
+(854,636,l),
+(866,690,l),
+(818,690,ls),
+(720,690,o),
+(674,631,o),
+(672,537,cs),
+(671,489,o),
+(687,433,o),
+(695,371,c),
+(471,371,l),
+(529,643,l),
+(613,643,l),
+(624,690,l),
+(400,690,l),
+(389,643,l),
+(473,643,l),
+(415,371,l),
+(193,371,l),
+(242,457,o),
+(301,533,o),
+(301,601,cs),
+(301,657,o),
+(265,690,o),
+(200,690,cs),
+(157,690,l),
+(146,636,l),
+(176,636,ls),
+(219,636,o),
+(241,620,o),
+(241,587,cs),
+(241,480,o),
+(54,329,o),
+(54,146,cs),
+(54,49,o),
+(112,-13,o),
+(212,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(154,43,o),
+(116,83,o),
+(116,152,cs),
+(116,208,o),
+(137,265,o),
+(167,319,c),
+(405,319,l),
+(384,221,ls),
+(358,103,o),
+(303,43,o),
+(221,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(431,43,o),
+(423,143,o),
+(440,221,cs),
+(461,319,l),
+(698,319,l),
+(699,300,o),
+(700,281,o),
+(700,263,cs),
+(699,167,o),
+(660,43,o),
+(539,43,cs)
+);
+}
+);
+width = 829;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165B;
+unicode = 5723;
+},
+{
+color = 9;
+glyphname = "tsoCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(57,0,ls),
+(156,0,o),
+(201,59,o),
+(203,153,cs),
+(204,201,o),
+(188,257,o),
+(181,319,c),
+(404,319,l),
+(346,46,l),
+(262,46,l),
+(252,0,l),
+(476,0,l),
+(486,46,l),
+(402,46,l),
+(460,319,l),
+(682,319,l),
+(633,233,o),
+(574,156,o),
+(574,89,cs),
+(574,33,o),
+(610,0,o),
+(676,0,cs),
+(718,0,l),
+(729,54,l),
+(700,54,ls),
+(656,54,o),
+(635,70,o),
+(635,102,cs),
+(635,210,o),
+(822,360,o),
+(822,544,cs),
+(822,640,o),
+(763,702,o),
+(664,702,cs),
+(578,702,o),
+(514,655,o),
+(471,557,c),
+(488,555,l),
+(482,649,o),
+(428,702,o),
+(337,702,cs),
+(178,702,o),
+(118,555,o),
+(115,422,cs),
+(114,326,o),
+(146,226,o),
+(145,154,cs),
+(144,95,o),
+(117,54,o),
+(55,54,cs),
+(21,54,l),
+(10,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(176,389,o),
+(175,409,o),
+(176,427,cs),
+(176,523,o),
+(216,646,o),
+(336,646,cs),
+(444,646,o),
+(452,547,o),
+(436,469,cs),
+(414,371,l),
+(178,371,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(492,469,ls),
+(517,586,o),
+(572,646,o),
+(655,646,cs),
+(722,646,o),
+(760,607,o),
+(760,538,cs),
+(760,482,o),
+(738,425,o),
+(709,371,c),
+(471,371,l)
+);
+}
+);
+width = 828;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165C;
+unicode = 5724;
+},
+{
+color = 9;
+glyphname = "tseCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(543,-13,o),
+(611,102,o),
+(611,204,cs),
+(611,274,o),
+(575,330,o),
+(511,351,c),
+(508,335,l),
+(622,356,o),
+(685,449,o),
+(685,550,cs),
+(685,639,o),
+(625,702,o),
+(535,702,cs),
+(421,702,o),
+(317,599,o),
+(259,599,cs),
+(230,599,o),
+(218,619,o),
+(228,661,cs),
+(235,690,l),
+(179,690,l),
+(170,651,ls),
+(157,587,o),
+(185,547,o),
+(241,547,cs),
+(270,547,o),
+(303,559,o),
+(336,578,c),
+(320,598,l),
+(272,368,l),
+(150,368,l),
+(171,467,l),
+(130,467,l),
+(79,222,l),
+(119,222,l),
+(140,322,l),
+(262,322,l),
+(213,95,l),
+(239,115,l),
+(210,130,o),
+(178,143,o),
+(149,143,cs),
+(93,143,o),
+(55,109,o),
+(41,39,cs),
+(32,0,l),
+(88,0,l),
+(94,28,ls),
+(103,71,o),
+(123,91,o),
+(154,91,cs),
+(222,91,o),
+(304,-13,o),
+(418,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(357,43,o),
+(309,75,o),
+(262,102,c),
+(308,322,l),
+(436,322,ls),
+(511,322,o),
+(552,277,o),
+(552,211,cs),
+(552,134,o),
+(506,43,o),
+(412,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(365,590,l),
+(414,617,o),
+(467,646,o),
+(520,646,cs),
+(583,646,o),
+(623,606,o),
+(623,543,cs),
+(623,450,o),
+(560,368,o),
+(444,368,cs),
+(319,368,l)
+);
+}
+);
+width = 700;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni165D;
+unicode = 5725;
+},
+{
+color = 9;
+glyphname = "tseeCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(543,-13,o),
+(611,102,o),
+(611,204,cs),
+(611,274,o),
+(575,330,o),
+(511,351,c),
+(508,335,l),
+(622,356,o),
+(685,449,o),
+(685,550,cs),
+(685,639,o),
+(625,702,o),
+(535,702,cs),
+(421,702,o),
+(317,599,o),
+(259,599,cs),
+(230,599,o),
+(218,619,o),
+(228,661,cs),
+(235,690,l),
+(179,690,l),
+(170,651,ls),
+(157,587,o),
+(185,547,o),
+(241,547,cs),
+(270,547,o),
+(303,559,o),
+(336,578,c),
+(319,598,l),
+(270,368,l),
+(149,368,l),
+(170,467,l),
+(130,467,l),
+(79,222,l),
+(119,222,l),
+(139,322,l),
+(260,322,l),
+(213,95,l),
+(239,115,l),
+(210,130,o),
+(178,143,o),
+(149,143,cs),
+(93,143,o),
+(55,109,o),
+(41,39,cs),
+(32,0,l),
+(88,0,l),
+(94,28,ls),
+(103,71,o),
+(123,91,o),
+(154,91,cs),
+(222,91,o),
+(304,-13,o),
+(418,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(356,43,o),
+(306,77,o),
+(257,105,c),
+(302,322,l),
+(404,322,l),
+(384,225,l),
+(419,225,l),
+(442,333,l),
+(427,322,l),
+(436,322,ls),
+(511,322,o),
+(552,277,o),
+(552,211,cs),
+(552,133,o),
+(506,43,o),
+(412,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(469,454,l),
+(433,454,l),
+(414,368,l),
+(313,368,l),
+(359,588,l),
+(409,614,o),
+(466,646,o),
+(520,646,cs),
+(583,646,o),
+(624,606,o),
+(624,543,cs),
+(624,450,o),
+(560,368,o),
+(445,368,cs),
+(434,368,l),
+(448,358,l)
+);
+}
+);
+width = 700;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165E;
+unicode = 5726;
+},
+{
+color = 9;
+glyphname = "tsiCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(543,-12,o),
+(611,103,o),
+(611,204,cs),
+(611,275,o),
+(576,330,o),
+(511,352,c),
+(508,336,l),
+(623,356,o),
+(685,449,o),
+(685,550,cs),
+(685,640,o),
+(625,702,o),
+(536,702,cs),
+(421,702,o),
+(317,599,o),
+(259,599,cs),
+(230,599,o),
+(218,619,o),
+(228,661,cs),
+(235,690,l),
+(179,690,l),
+(170,651,ls),
+(157,587,o),
+(185,548,o),
+(241,548,cs),
+(269,548,o),
+(299,560,o),
+(330,577,c),
+(313,598,l),
+(266,368,l),
+(149,368,l),
+(170,467,l),
+(130,467,l),
+(79,223,l),
+(119,223,l),
+(139,323,l),
+(255,323,l),
+(207,96,l),
+(232,117,l),
+(204,131,o),
+(176,143,o),
+(149,143,cs),
+(93,143,o),
+(55,110,o),
+(41,40,cs),
+(32,0,l),
+(88,0,l),
+(94,28,ls),
+(103,71,o),
+(123,92,o),
+(154,92,cs),
+(222,92,o),
+(304,-12,o),
+(418,-12,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(355,44,o),
+(301,80,o),
+(252,107,c),
+(297,323,l),
+(375,323,l),
+(383,298,o),
+(405,282,o),
+(430,282,cs),
+(461,282,o),
+(482,304,o),
+(488,331,c),
+(418,323,l),
+(437,323,ls),
+(511,323,o),
+(553,278,o),
+(553,211,cs),
+(553,133,o),
+(506,44,o),
+(413,44,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(484,388,o),
+(459,409,o),
+(431,409,cs),
+(405,409,o),
+(383,391,o),
+(376,368,c),
+(307,368,l),
+(354,586,l),
+(404,611,o),
+(465,646,o),
+(521,646,cs),
+(583,646,o),
+(624,606,o),
+(624,543,cs),
+(624,450,o),
+(560,368,o),
+(445,368,cs),
+(424,368,l),
+(490,359,l)
+);
+}
+);
+width = 700;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165F;
+unicode = 5727;
+},
+{
+color = 9;
+glyphname = "tsaCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(325,-12,o),
+(429,92,o),
+(488,92,cs),
+(516,92,o),
+(527,71,o),
+(518,30,cs),
+(512,0,l),
+(567,0,l),
+(576,40,ls),
+(589,103,o),
+(560,143,o),
+(505,143,cs),
+(475,143,o),
+(442,130,o),
+(410,113,c),
+(425,93,l),
+(473,322,l),
+(596,322,l),
+(575,224,l),
+(615,224,l),
+(668,468,l),
+(627,468,l),
+(606,368,l),
+(484,368,l),
+(531,595,l),
+(507,576,l),
+(536,560,o),
+(568,548,o),
+(597,548,cs),
+(653,548,o),
+(691,581,o),
+(706,651,cs),
+(714,690,l),
+(658,690,l),
+(652,663,ls),
+(642,620,o),
+(623,599,o),
+(593,599,cs),
+(525,599,o),
+(441,702,o),
+(327,702,cs),
+(203,702,o),
+(134,587,o),
+(134,487,cs),
+(134,415,o),
+(171,360,o),
+(235,339,c),
+(238,355,l),
+(123,334,o),
+(61,242,o),
+(61,140,cs),
+(61,50,o),
+(121,-12,o),
+(211,-12,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(162,44,o),
+(123,85,o),
+(123,148,cs),
+(123,241,o),
+(185,322,o),
+(301,322,cs),
+(427,322,l),
+(381,99,l),
+(331,73,o),
+(278,44,o),
+(226,44,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(235,368,o),
+(194,412,o),
+(194,480,cs),
+(194,555,o),
+(240,646,o),
+(332,646,cs),
+(388,646,o),
+(437,614,o),
+(484,587,c),
+(438,368,l),
+(310,368,ls)
+);
+}
+);
+width = 700;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1660;
+unicode = 5728;
+},
+{
+color = 9;
+glyphname = "chuCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(298,-13,o),
+(362,35,o),
+(404,132,c),
+(388,134,l),
+(394,41,o),
+(447,-13,o),
+(539,-13,cs),
+(698,-13,o),
+(758,134,o),
+(760,268,cs),
+(761,364,o),
+(729,464,o),
+(730,536,cs),
+(731,595,o),
+(758,636,o),
+(821,636,cs),
+(854,636,l),
+(866,690,l),
+(818,690,ls),
+(720,690,o),
+(674,631,o),
+(672,537,cs),
+(670,461,o),
+(701,360,o),
+(700,267,cs),
+(699,167,o),
+(660,43,o),
+(539,43,cs),
+(431,43,o),
+(424,143,o),
+(440,221,cs),
+(530,643,l),
+(613,643,l),
+(624,690,l),
+(400,690,l),
+(389,643,l),
+(472,643,l),
+(383,221,ls),
+(358,103,o),
+(303,43,o),
+(221,43,cs),
+(154,43,o),
+(116,83,o),
+(116,152,cs),
+(116,315,o),
+(301,476,o),
+(301,601,cs),
+(301,657,o),
+(265,690,o),
+(200,690,cs),
+(157,690,l),
+(146,636,l),
+(176,636,ls),
+(219,636,o),
+(241,620,o),
+(241,587,cs),
+(241,480,o),
+(54,329,o),
+(54,146,cs),
+(54,49,o),
+(112,-13,o),
+(212,-13,cs)
+);
+}
+);
+width = 829;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164E;
+unicode = 5729;
+},
+{
+color = 9;
+glyphname = "choCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(57,0,ls),
+(156,0,o),
+(201,59,o),
+(203,153,cs),
+(205,229,o),
+(175,329,o),
+(176,423,cs),
+(176,523,o),
+(216,646,o),
+(336,646,cs),
+(444,646,o),
+(451,547,o),
+(435,469,cs),
+(346,46,l),
+(262,46,l),
+(252,0,l),
+(476,0,l),
+(486,46,l),
+(403,46,l),
+(493,469,ls),
+(517,586,o),
+(572,646,o),
+(655,646,cs),
+(722,646,o),
+(760,607,o),
+(760,538,cs),
+(760,375,o),
+(574,213,o),
+(574,89,cs),
+(574,33,o),
+(610,0,o),
+(676,0,cs),
+(718,0,l),
+(729,54,l),
+(700,54,ls),
+(656,54,o),
+(635,70,o),
+(635,102,cs),
+(635,210,o),
+(822,360,o),
+(822,544,cs),
+(822,640,o),
+(763,702,o),
+(664,702,cs),
+(578,702,o),
+(514,655,o),
+(471,557,c),
+(488,555,l),
+(482,649,o),
+(428,702,o),
+(337,702,cs),
+(178,702,o),
+(118,555,o),
+(115,422,cs),
+(114,326,o),
+(146,226,o),
+(145,154,cs),
+(144,95,o),
+(117,54,o),
+(55,54,cs),
+(21,54,l),
+(10,0,l)
+);
+}
+);
+width = 828;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5730;
+},
+{
+color = 9;
+glyphname = "cheCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(543,-13,o),
+(611,102,o),
+(611,204,cs),
+(611,274,o),
+(575,330,o),
+(511,351,c),
+(508,335,l),
+(622,356,o),
+(685,449,o),
+(685,550,cs),
+(685,639,o),
+(625,702,o),
+(535,702,cs),
+(421,702,o),
+(317,599,o),
+(259,599,cs),
+(230,599,o),
+(218,619,o),
+(228,661,cs),
+(235,690,l),
+(179,690,l),
+(170,651,ls),
+(157,587,o),
+(185,547,o),
+(242,547,cs),
+(325,547,o),
+(420,646,o),
+(520,646,cs),
+(583,646,o),
+(623,606,o),
+(623,543,cs),
+(623,450,o),
+(559,371,o),
+(444,371,cs),
+(151,371,l),
+(171,467,l),
+(130,467,l),
+(79,222,l),
+(119,222,l),
+(140,319,l),
+(436,319,ls),
+(511,319,o),
+(552,276,o),
+(552,211,cs),
+(552,134,o),
+(506,43,o),
+(412,43,cs),
+(314,43,o),
+(240,143,o),
+(149,143,cs),
+(93,143,o),
+(54,107,o),
+(41,39,cs),
+(32,0,l),
+(88,0,l),
+(94,28,ls),
+(103,71,o),
+(123,91,o),
+(154,91,cs),
+(222,91,o),
+(304,-13,o),
+(418,-13,cs)
+);
+}
+);
+width = 700;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni1663;
+unicode = 5731;
+},
+{
+color = 9;
+glyphname = "cheeCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(543,-13,o),
+(611,102,o),
+(611,204,cs),
+(611,274,o),
+(575,330,o),
+(511,351,c),
+(508,335,l),
+(622,356,o),
+(685,449,o),
+(685,550,cs),
+(685,639,o),
+(625,702,o),
+(535,702,cs),
+(421,702,o),
+(317,599,o),
+(259,599,cs),
+(230,599,o),
+(218,619,o),
+(228,661,cs),
+(235,690,l),
+(179,690,l),
+(170,651,ls),
+(157,587,o),
+(185,547,o),
+(242,547,cs),
+(325,547,o),
+(420,646,o),
+(520,646,cs),
+(583,646,o),
+(623,606,o),
+(623,543,cs),
+(623,450,o),
+(559,368,o),
+(444,368,cs),
+(380,368,l),
+(394,356,l),
+(414,452,l),
+(375,452,l),
+(356,368,l),
+(150,368,l),
+(171,467,l),
+(130,467,l),
+(79,222,l),
+(119,222,l),
+(140,323,l),
+(347,323,l),
+(327,226,l),
+(366,226,l),
+(390,336,l),
+(370,323,l),
+(438,323,ls),
+(512,323,o),
+(552,276,o),
+(552,211,cs),
+(552,134,o),
+(506,43,o),
+(412,43,cs),
+(314,43,o),
+(240,143,o),
+(149,143,cs),
+(93,143,o),
+(54,107,o),
+(41,39,cs),
+(32,0,l),
+(88,0,l),
+(94,28,ls),
+(103,71,o),
+(123,91,o),
+(154,91,cs),
+(222,91,o),
+(304,-13,o),
+(418,-13,cs)
+);
+}
+);
+width = 700;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1664;
+unicode = 5732;
+},
+{
+color = 9;
+glyphname = "chiCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(542,-13,o),
+(611,102,o),
+(611,204,cs),
+(611,274,o),
+(574,330,o),
+(510,351,c),
+(507,335,l),
+(621,356,o),
+(684,449,o),
+(684,550,cs),
+(684,639,o),
+(624,702,o),
+(534,702,cs),
+(420,702,o),
+(316,599,o),
+(258,599,cs),
+(229,599,o),
+(217,619,o),
+(227,661,cs),
+(234,690,l),
+(178,690,l),
+(169,651,ls),
+(156,587,o),
+(185,547,o),
+(241,547,cs),
+(324,547,o),
+(419,646,o),
+(519,646,cs),
+(582,646,o),
+(622,606,o),
+(622,543,cs),
+(622,450,o),
+(558,368,o),
+(444,368,cs),
+(394,368,l),
+(414,355,l),
+(412,385,o),
+(385,409,o),
+(354,409,cs),
+(326,409,o),
+(305,391,o),
+(297,368,c),
+(150,368,l),
+(171,467,l),
+(130,467,l),
+(78,223,l),
+(119,223,l),
+(140,323,l),
+(297,323,l),
+(306,298,o),
+(327,282,o),
+(354,282,cs),
+(385,282,o),
+(410,305,o),
+(414,335,c),
+(388,323,l),
+(438,323,ls),
+(511,323,o),
+(551,277,o),
+(551,211,cs),
+(551,134,o),
+(505,43,o),
+(412,43,cs),
+(314,43,o),
+(239,143,o),
+(148,143,cs),
+(92,143,o),
+(53,107,o),
+(40,39,cs),
+(31,0,l),
+(87,0,l),
+(93,28,ls),
+(102,71,o),
+(122,91,o),
+(153,91,cs),
+(221,91,o),
+(303,-13,o),
+(417,-13,cs)
+);
+}
+);
+width = 699;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1665;
+unicode = 5733;
+},
+{
+color = 9;
+glyphname = "chaCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(325,-12,o),
+(429,92,o),
+(488,92,cs),
+(516,92,o),
+(527,71,o),
+(518,30,cs),
+(512,1,l),
+(567,1,l),
+(576,40,ls),
+(589,103,o),
+(560,144,o),
+(504,144,cs),
+(421,144,o),
+(326,44,o),
+(226,44,cs),
+(163,44,o),
+(123,85,o),
+(123,149,cs),
+(123,241,o),
+(186,320,o),
+(301,320,cs),
+(595,320,l),
+(575,224,l),
+(615,224,l),
+(667,469,l),
+(627,469,l),
+(607,372,l),
+(310,372,ls),
+(235,372,o),
+(194,414,o),
+(194,481,cs),
+(194,556,o),
+(240,647,o),
+(333,647,cs),
+(432,647,o),
+(507,548,o),
+(597,548,cs),
+(653,548,o),
+(692,583,o),
+(705,652,cs),
+(714,691,l),
+(658,691,l),
+(652,663,ls),
+(642,620,o),
+(623,600,o),
+(592,600,cs),
+(525,600,o),
+(441,703,o),
+(327,703,cs),
+(204,703,o),
+(134,588,o),
+(134,487,cs),
+(134,416,o),
+(171,360,o),
+(235,340,c),
+(238,355,l),
+(124,334,o),
+(61,242,o),
+(61,141,cs),
+(61,51,o),
+(121,-12,o),
+(211,-12,cs)
+);
+}
+);
+width = 699;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1666;
+unicode = 5734;
+},
+{
+color = 9;
+glyphname = "ttsuCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(298,-13,o),
+(361,35,o),
+(404,132,c),
+(388,134,l),
+(394,41,o),
+(447,-13,o),
+(539,-13,cs),
+(698,-13,o),
+(758,134,o),
+(760,268,cs),
+(761,364,o),
+(729,464,o),
+(730,536,cs),
+(731,595,o),
+(758,636,o),
+(821,636,cs),
+(854,636,l),
+(866,690,l),
+(818,690,ls),
+(720,690,o),
+(674,631,o),
+(672,537,cs),
+(671,516,o),
+(674,495,o),
+(675,475,c),
+(698,524,l),
+(476,388,l),
+(530,643,l),
+(613,643,l),
+(624,690,l),
+(400,690,l),
+(389,643,l),
+(472,643,l),
+(418,388,l),
+(247,525,l),
+(260,473,l),
+(284,519,o),
+(301,562,o),
+(301,601,cs),
+(301,657,o),
+(265,690,o),
+(200,690,cs),
+(157,690,l),
+(146,636,l),
+(176,636,ls),
+(219,636,o),
+(241,620,o),
+(241,587,cs),
+(241,480,o),
+(54,329,o),
+(54,146,cs),
+(54,49,o),
+(112,-13,o),
+(212,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(154,43,o),
+(116,83,o),
+(116,152,cs),
+(116,261,o),
+(197,361,o),
+(250,454,c),
+(407,330,l),
+(383,221,ls),
+(358,103,o),
+(303,43,o),
+(221,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(431,43,o),
+(424,143,o),
+(440,221,cs),
+(462,324,l),
+(677,451,l),
+(686,394,o),
+(700,330,o),
+(700,267,cs),
+(699,167,o),
+(660,43,o),
+(539,43,cs)
+);
+}
+);
+width = 829;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1667;
+unicode = 5735;
+},
+{
+color = 9;
+glyphname = "ttsoCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(57,0,ls),
+(156,0,o),
+(201,59,o),
+(203,153,cs),
+(204,174,o),
+(202,195,o),
+(201,214,c),
+(177,166,l),
+(400,301,l),
+(346,46,l),
+(262,46,l),
+(252,0,l),
+(476,0,l),
+(486,46,l),
+(403,46,l),
+(457,301,l),
+(628,165,l),
+(615,216,l),
+(591,171,o),
+(574,128,o),
+(574,89,cs),
+(574,33,o),
+(610,0,o),
+(676,0,cs),
+(718,0,l),
+(729,54,l),
+(700,54,ls),
+(656,54,o),
+(635,70,o),
+(635,102,cs),
+(635,210,o),
+(822,360,o),
+(822,544,cs),
+(822,640,o),
+(763,702,o),
+(664,702,cs),
+(578,702,o),
+(514,655,o),
+(471,557,c),
+(488,555,l),
+(482,649,o),
+(428,702,o),
+(337,702,cs),
+(178,702,o),
+(118,555,o),
+(115,422,cs),
+(114,326,o),
+(146,226,o),
+(145,154,cs),
+(144,95,o),
+(117,54,o),
+(55,54,cs),
+(21,54,l),
+(10,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(190,296,o),
+(175,359,o),
+(176,423,cs),
+(176,523,o),
+(216,646,o),
+(336,646,cs),
+(444,646,o),
+(451,547,o),
+(435,469,cs),
+(413,366,l),
+(198,239,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(469,359,l),
+(493,469,ls),
+(517,586,o),
+(572,646,o),
+(655,646,cs),
+(722,646,o),
+(760,607,o),
+(760,538,cs),
+(760,429,o),
+(678,328,o),
+(625,236,c)
+);
+}
+);
+width = 828;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1668;
+unicode = 5736;
+},
+{
+color = 9;
+glyphname = "ttseCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(541,-13,o),
+(611,102,o),
+(611,203,cs),
+(611,274,o),
+(574,330,o),
+(510,351,c),
+(507,335,l),
+(621,356,o),
+(684,448,o),
+(684,550,cs),
+(684,639,o),
+(624,702,o),
+(534,702,cs),
+(420,702,o),
+(316,599,o),
+(257,599,cs),
+(229,599,o),
+(217,619,o),
+(227,661,cs),
+(234,690,l),
+(178,690,l),
+(169,651,ls),
+(156,587,o),
+(185,547,o),
+(241,547,cs),
+(248,547,o),
+(256,547,o),
+(264,549,c),
+(229,576,l),
+(273,368,l),
+(149,368,l),
+(170,467,l),
+(130,467,l),
+(78,222,l),
+(119,222,l),
+(140,323,l),
+(265,323,l),
+(133,117,l),
+(178,140,l),
+(169,142,o),
+(158,143,o),
+(148,143,cs),
+(91,143,o),
+(54,109,o),
+(40,39,cs),
+(31,0,l),
+(87,0,l),
+(93,28,ls),
+(102,71,o),
+(122,91,o),
+(153,91,cs),
+(220,91,o),
+(303,-13,o),
+(417,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(328,43,o),
+(264,113,o),
+(196,134,c),
+(316,323,l),
+(436,323,ls),
+(510,323,o),
+(552,277,o),
+(552,211,cs),
+(552,134,o),
+(505,43,o),
+(412,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(280,554,l),
+(351,571,o),
+(433,647,o),
+(519,647,cs),
+(582,647,o),
+(623,606,o),
+(623,542,cs),
+(623,450,o),
+(558,368,o),
+(443,368,cs),
+(320,368,l)
+);
+}
+);
+width = 699;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1669;
+unicode = 5737;
+},
+{
+color = 9;
+glyphname = "ttseeCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(541,-13,o),
+(611,102,o),
+(611,203,cs),
+(611,274,o),
+(574,330,o),
+(510,351,c),
+(507,335,l),
+(621,356,o),
+(684,448,o),
+(684,550,cs),
+(684,639,o),
+(624,702,o),
+(534,702,cs),
+(420,702,o),
+(316,599,o),
+(257,599,cs),
+(229,599,o),
+(217,619,o),
+(227,661,cs),
+(234,690,l),
+(178,690,l),
+(169,651,ls),
+(156,587,o),
+(185,547,o),
+(241,547,cs),
+(248,547,o),
+(256,547,o),
+(264,549,c),
+(229,576,l),
+(273,368,l),
+(149,368,l),
+(170,467,l),
+(130,467,l),
+(78,222,l),
+(119,222,l),
+(140,323,l),
+(265,323,l),
+(132,117,l),
+(178,140,l),
+(169,142,o),
+(158,143,o),
+(148,143,cs),
+(91,143,o),
+(54,109,o),
+(40,39,cs),
+(31,0,l),
+(87,0,l),
+(93,28,ls),
+(102,71,o),
+(122,91,o),
+(153,91,cs),
+(220,91,o),
+(303,-13,o),
+(417,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(328,43,o),
+(262,115,o),
+(194,135,c),
+(314,323,l),
+(395,323,l),
+(374,225,l),
+(411,225,l),
+(434,333,l),
+(420,323,l),
+(436,323,ls),
+(510,323,o),
+(552,277,o),
+(552,211,cs),
+(552,134,o),
+(505,43,o),
+(412,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(459,454,l),
+(422,454,l),
+(404,368,l),
+(318,368,l),
+(278,553,l),
+(349,569,o),
+(432,647,o),
+(519,647,cs),
+(582,647,o),
+(623,606,o),
+(623,542,cs),
+(623,450,o),
+(558,368,o),
+(443,368,cs),
+(428,368,l),
+(439,359,l)
+);
+}
+);
+width = 699;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166A;
+unicode = 5738;
+},
+{
+color = 9;
+glyphname = "ttsiCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(541,-13,o),
+(611,102,o),
+(611,203,cs),
+(611,274,o),
+(574,330,o),
+(510,351,c),
+(507,335,l),
+(621,356,o),
+(684,448,o),
+(684,550,cs),
+(684,639,o),
+(624,702,o),
+(534,702,cs),
+(420,702,o),
+(316,599,o),
+(257,599,cs),
+(229,599,o),
+(217,619,o),
+(227,661,cs),
+(234,690,l),
+(178,690,l),
+(169,651,ls),
+(156,587,o),
+(185,547,o),
+(241,547,cs),
+(248,547,o),
+(256,547,o),
+(264,549,c),
+(229,576,l),
+(273,368,l),
+(149,368,l),
+(170,467,l),
+(130,467,l),
+(78,222,l),
+(119,222,l),
+(140,323,l),
+(265,323,l),
+(133,117,l),
+(178,140,l),
+(169,142,o),
+(158,143,o),
+(148,143,cs),
+(91,143,o),
+(54,109,o),
+(40,39,cs),
+(31,0,l),
+(87,0,l),
+(93,28,ls),
+(102,71,o),
+(122,91,o),
+(153,91,cs),
+(220,91,o),
+(303,-13,o),
+(417,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(328,43,o),
+(259,116,o),
+(192,136,c),
+(311,323,l),
+(350,323,l),
+(358,298,o),
+(382,282,o),
+(405,282,cs),
+(435,282,o),
+(459,304,o),
+(464,333,c),
+(420,323,l),
+(441,323,ls),
+(513,323,o),
+(552,277,o),
+(552,211,cs),
+(552,134,o),
+(505,43,o),
+(412,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(457,390,o),
+(433,409,o),
+(405,409,cs),
+(381,409,o),
+(356,393,o),
+(350,368,c),
+(313,368,l),
+(274,551,l),
+(345,567,o),
+(432,647,o),
+(519,647,cs),
+(582,647,o),
+(623,606,o),
+(623,542,cs),
+(623,450,o),
+(561,368,o),
+(446,368,cs),
+(428,368,l),
+(464,359,l)
+);
+}
+);
+width = 699;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166B;
+unicode = 5739;
+},
+{
+color = 9;
+glyphname = "ttsaCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(325,-13,o),
+(428,91,o),
+(487,91,cs),
+(515,91,o),
+(527,71,o),
+(518,29,cs),
+(511,0,l),
+(567,0,l),
+(575,39,ls),
+(588,102,o),
+(560,143,o),
+(504,143,cs),
+(497,143,o),
+(489,143,o),
+(481,141,c),
+(516,114,l),
+(470,322,l),
+(595,322,l),
+(574,223,l),
+(614,223,l),
+(667,468,l),
+(626,468,l),
+(605,367,l),
+(479,367,l),
+(611,573,l),
+(566,550,l),
+(576,548,o),
+(586,547,o),
+(597,547,cs),
+(653,547,o),
+(691,581,o),
+(705,651,cs),
+(714,690,l),
+(658,690,l),
+(651,662,ls),
+(642,619,o),
+(622,599,o),
+(592,599,cs),
+(524,599,o),
+(441,702,o),
+(327,702,cs),
+(203,702,o),
+(134,587,o),
+(134,487,cs),
+(134,415,o),
+(171,359,o),
+(235,339,c),
+(238,355,l),
+(123,333,o),
+(61,242,o),
+(61,140,cs),
+(61,50,o),
+(121,-13,o),
+(211,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(162,43,o),
+(122,84,o),
+(122,148,cs),
+(122,240,o),
+(186,322,o),
+(301,322,cs),
+(425,322,l),
+(464,136,l),
+(394,119,o),
+(312,43,o),
+(226,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(235,367,o),
+(193,412,o),
+(193,479,cs),
+(193,555,o),
+(240,647,o),
+(333,647,cs),
+(415,647,o),
+(481,577,o),
+(549,555,c),
+(429,367,l),
+(309,367,ls)
+);
+}
+);
+width = 699;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni166C;
+unicode = 5740;
+},
+{
+glyphname = "qai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (318,0);
+ref = "ke-canadian";
+}
+);
+width = 886;
+}
+);
+note = uni166F;
+unicode = 5743;
+},
+{
+glyphname = "ngai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (623,0);
+ref = "ce-canadian";
+}
+);
+width = 1187;
+}
+);
+note = uni1670;
+unicode = 5744;
+},
+{
+glyphname = "nngi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (899,0);
+ref = "ci-canadian";
+}
+);
+width = 1463;
+}
+);
+note = uni1671;
+unicode = 5745;
+},
+{
+glyphname = "nngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (899,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (1123,0);
+ref = dot_top;
+}
+);
+width = 1463;
+}
+);
+note = uni1672;
+unicode = 5746;
+},
+{
+glyphname = "nngo-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (899,0);
+ref = "ce-canadian";
+}
+);
+width = 1463;
+}
+);
+note = uni1673;
+unicode = 5747;
+},
+{
+glyphname = "nngoo-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (899,0);
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (1118,0);
+ref = dot_top;
+}
+);
+width = 1463;
+}
+);
+note = uni1674;
+unicode = 5748;
+},
+{
+glyphname = "nnga-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (899,0);
+ref = "ca-canadian";
+}
+);
+width = 1463;
+}
+);
+note = uni1675;
+unicode = 5749;
+},
+{
+glyphname = "nngaa-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (899,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (942,0);
+ref = dot_top;
+}
+);
+width = 1463;
+}
+);
+note = uni1676;
+unicode = 5750;
+},
+{
+glyphname = "thweeWoodScree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (587,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 801;
+}
+);
+note = uni1677;
+unicode = 5751;
+},
+{
+glyphname = "thwiWoodScree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (587,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 801;
+}
+);
+note = uni1678;
+unicode = 5752;
+},
+{
+glyphname = "thwiiWoodScree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (85,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (587,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 801;
+}
+);
+note = uni1679;
+unicode = 5753;
+},
+{
+glyphname = "thwoWoodScree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (587,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 801;
+}
+);
+note = uni167A;
+unicode = 5754;
+},
+{
+glyphname = "thwooWoodScree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (378,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (587,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 801;
+}
+);
+note = uni167B;
+unicode = 5755;
+},
+{
+glyphname = "thwaWoodScree-canadian";
+lastChange = "2023-01-13 15:55:09 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = middle_right_can;
+pos = (589,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 802;
+}
+);
+note = uni167C;
+unicode = 5756;
+},
+{
+glyphname = "thwaaWoodScree-canadian";
+lastChange = "2023-01-13 15:55:09 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (86,0);
+ref = dot_top;
+},
+{
+anchor = middle_right_can;
+pos = (589,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 802;
+}
+);
+note = uni167D;
+unicode = 5757;
+},
+{
+glyphname = "wBlackfoot-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(446,564,l),
+(455,604,l),
+(147,604,l),
+(138,564,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(417,431,l),
+(426,470,l),
+(118,470,l),
+(109,431,l)
+);
+}
+);
+width = 445;
+}
+);
+metricRight = "=|";
+note = uni167F;
+unicode = 5759;
+},
+{
+glyphname = "oy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-12,0);
+ref = ring_top.canadian;
+}
+);
+width = 665;
+}
+);
+note = uni18B0;
+unicode = 6320;
+},
+{
+glyphname = "ay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (438,0);
+ref = ring_top.canadian;
+}
+);
+width = 665;
+}
+);
+note = uni18B1;
+unicode = 6321;
+},
+{
+glyphname = "aay-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (187,0);
+ref = ring_top.canadian;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (496,0);
+ref = dot_top;
+}
+);
+width = 665;
+}
+);
+note = uni18B2;
+unicode = 6322;
+},
+{
+glyphname = "way-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (650,0);
+ref = ring_top.canadian;
+}
+);
+width = 878;
+}
+);
+note = uni18B3;
+unicode = 6323;
+},
+{
+glyphname = "poy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-35,0);
+ref = ring_top.canadian;
+}
+);
+width = 636;
+}
+);
+note = uni18B4;
+unicode = 6324;
+},
+{
+glyphname = "pay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (431,0);
+ref = ring_top.canadian;
+}
+);
+width = 636;
+}
+);
+note = uni18B5;
+unicode = 6325;
+},
+{
+glyphname = "pwoy-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (179,0);
+ref = ring_top.canadian;
+}
+);
+width = 848;
+}
+);
+note = uni18B6;
+unicode = 6326;
+},
+{
+glyphname = "tay-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (202,0);
+ref = ring_top.canadian;
+}
+);
+width = 585;
+}
+);
+note = uni18B7;
+unicode = 6327;
+},
+{
+glyphname = "kay-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-15,0);
+ref = ring_top.canadian;
+}
+);
+width = 568;
+}
+);
+note = uni18B8;
+unicode = 6328;
+},
+{
+glyphname = "kway-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (197,0);
+ref = ring_top.canadian;
+}
+);
+width = 781;
+}
+);
+note = uni18B9;
+unicode = 6329;
+},
+{
+glyphname = "may-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-8,0);
+ref = ring_top.canadian;
+}
+);
+width = 502;
+}
+);
+note = uni18BA;
+unicode = 6330;
+},
+{
+glyphname = "noy-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (335,-200);
+ref = ring_top.canadian;
+}
+);
+width = 787;
+}
+);
+note = uni18BB;
+unicode = 6331;
+},
+{
+glyphname = "nay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (128,-200);
+ref = ring_top.canadian;
+}
+);
+width = 787;
+}
+);
+note = uni18BC;
+unicode = 6332;
+},
+{
+glyphname = "lay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (128,-200);
+ref = ring_top.canadian;
+}
+);
+width = 787;
+}
+);
+note = uni18BD;
+unicode = 6333;
+},
+{
+glyphname = "soy-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (286,0);
+ref = ring_top.canadian;
+}
+);
+width = 517;
+}
+);
+note = uni18BE;
+unicode = 6334;
+},
+{
+glyphname = "say-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-8,0);
+ref = ring_top.canadian;
+}
+);
+width = 517;
+}
+);
+note = uni18BF;
+unicode = 6335;
+},
+{
+glyphname = "shoy-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (297,-200);
+ref = ring_top.canadian;
+}
+);
+width = 919;
+}
+);
+note = uni18C0;
+unicode = 6336;
+},
+{
+glyphname = "shay-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (298,-200);
+ref = ring_top.canadian;
+}
+);
+width = 919;
+}
+);
+note = uni18C1;
+unicode = 6337;
+},
+{
+glyphname = "shwoy-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (509,-200);
+ref = ring_top.canadian;
+}
+);
+width = 1132;
+}
+);
+note = uni18C2;
+unicode = 6338;
+},
+{
+glyphname = "yoy-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (321,0);
+ref = ring_top.canadian;
+}
+);
+width = 550;
+}
+);
+note = uni18C3;
+unicode = 6339;
+},
+{
+glyphname = "yay-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-10,0);
+ref = ring_top.canadian;
+}
+);
+width = 550;
+}
+);
+note = uni18C4;
+unicode = 6340;
+},
+{
+glyphname = "ray-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (176,0);
+ref = ring_top.canadian;
+}
+);
+width = 522;
+}
+);
+note = uni18C5;
+unicode = 6341;
+},
+{
+glyphname = "nwi-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ni-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni18C6;
+unicode = 6342;
+},
+{
+glyphname = "nwiOjibway-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (787,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni18C7;
+unicode = 6343;
+},
+{
+glyphname = "nwii-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (403,-200);
+ref = dot_top;
+}
+);
+width = 1001;
+}
+);
+note = uni18C8;
+unicode = 6344;
+},
+{
+glyphname = "nwiiOjibway-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (190,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (787,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni18C9;
+unicode = 6345;
+},
+{
+glyphname = "nwo-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "no-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni18CA;
+unicode = 6346;
+},
+{
+glyphname = "nwoOjibway-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (787,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni18CB;
+unicode = 6347;
+},
+{
+glyphname = "nwoo-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (606,-200);
+ref = dot_top;
+}
+);
+width = 1001;
+}
+);
+note = uni18CC;
+unicode = 6348;
+},
+{
+glyphname = "nwooOjibway-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (393,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (787,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni18CD;
+unicode = 6349;
+},
+{
+glyphname = "rwee-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "reRCree-canadian";
+}
+);
+width = 1043;
+}
+);
+note = uni18CE;
+unicode = 6350;
+},
+{
+glyphname = "rwi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ri-canadian";
+}
+);
+width = 1043;
+}
+);
+note = uni18CF;
+unicode = 6351;
+},
+{
+glyphname = "rwii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (398,-200);
+ref = dot_top;
+}
+);
+width = 1043;
+}
+);
+note = uni18D0;
+unicode = 6352;
+},
+{
+glyphname = "rwo-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ro-canadian";
+}
+);
+width = 734;
+}
+);
+note = uni18D1;
+unicode = 6353;
+},
+{
+glyphname = "rwoo-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (376,0);
+ref = dot_top;
+}
+);
+width = 734;
+}
+);
+note = uni18D2;
+unicode = 6354;
+},
+{
+glyphname = "rwa-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ra-canadian";
+}
+);
+width = 734;
+}
+);
+note = uni18D3;
+unicode = 6355;
+},
+{
+glyphname = "pOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(122,345,l),
+(314,646,l),
+(280,646,l),
+(345,345,l),
+(385,345,l),
+(388,356,l),
+(312,690,l),
+(297,690,l),
+(78,356,l),
+(75,345,l)
+);
+}
+);
+width = 415;
+}
+);
+metricLeft = "kkCarrier-canadian";
+note = uni18D4;
+unicode = 6356;
+},
+{
+glyphname = "tOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 410;
+}
+);
+metricRight = "=|";
+note = uni1422;
+unicode = 6357;
+},
+{
+glyphname = "kOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(136,345,l),
+(172,515,l),
+(159,515,l),
+(158,469,o),
+(194,434,o),
+(245,434,cs),
+(328,434,o),
+(373,522,o),
+(373,591,cs),
+(373,654,o),
+(334,696,o),
+(269,696,cs),
+(203,696,o),
+(155,653,o),
+(138,572,cs),
+(90,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(202,470,o),
+(178,497,o),
+(178,539,cs),
+(178,587,o),
+(207,659,o),
+(269,659,cs),
+(308,659,o),
+(331,634,o),
+(331,591,cs),
+(331,541,o),
+(301,470,o),
+(241,470,cs)
+);
+}
+);
+width = 359;
+}
+);
+metricLeft = "k-canadian";
+metricRight = "k-canadian";
+note = uni18D6;
+unicode = 6358;
+},
+{
+glyphname = "cOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(136,345,l),
+(185,581,ls),
+(197,634,o),
+(228,657,o),
+(270,657,cs),
+(323,657,o),
+(341,623,o),
+(331,573,cs),
+(326,550,l),
+(369,550,l),
+(373,567,ls),
+(389,641,o),
+(351,696,o),
+(271,696,cs),
+(201,696,o),
+(155,655,o),
+(140,580,cs),
+(90,345,l)
+);
+}
+);
+width = 351;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni18D7;
+unicode = 6359;
+},
+{
+glyphname = "mOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(137,345,l),
+(201,647,l),
+(364,647,l),
+(374,690,l),
+(164,690,l),
+(91,345,l)
+);
+}
+);
+width = 326;
+}
+);
+metricLeft = "m-canadian";
+metricRight = "m-canadian";
+note = uni18D8;
+unicode = 6360;
+},
+{
+glyphname = "nOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(318,428,o),
+(363,509,o),
+(363,582,cs),
+(363,622,o),
+(343,651,o),
+(323,664,c),
+(317,647,l),
+(506,647,l),
+(515,690,l),
+(261,690,ls),
+(171,690,o),
+(126,609,o),
+(126,535,cs),
+(126,470,o),
+(167,428,o),
+(232,428,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(191,464,o),
+(167,492,o),
+(167,535,cs),
+(167,578,o),
+(190,653,o),
+(257,653,cs),
+(297,653,o),
+(322,626,o),
+(322,582,cs),
+(322,540,o),
+(299,464,o),
+(233,464,cs)
+);
+}
+);
+width = 468;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "n-canadian";
+note = uni18D9;
+unicode = 6361;
+},
+{
+glyphname = "sOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(136,345,l),
+(165,485,l),
+(135,462,l),
+(165,462,ls),
+(274,462,o),
+(337,518,o),
+(360,632,cs),
+(373,690,l),
+(326,690,l),
+(316,637,ls),
+(296,542,o),
+(248,501,o),
+(158,501,cs),
+(123,501,l),
+(90,345,l)
+);
+}
+);
+width = 343;
+}
+);
+metricLeft = "s-canadian";
+metricRight = "s-canadian";
+note = uni18DA;
+unicode = 6362;
+},
+{
+color = 1;
+glyphname = "shOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(267,339,o),
+(306,381,o),
+(330,460,cs),
+(365,577,ls),
+(382,631,o),
+(406,659,o),
+(452,659,cs),
+(500,659,o),
+(522,628,o),
+(511,576,cs),
+(506,550,l),
+(549,550,l),
+(553,572,ls),
+(567,645,o),
+(529,696,o),
+(453,696,cs),
+(384,696,o),
+(343,655,o),
+(320,576,cs),
+(285,459,ls),
+(269,405,o),
+(243,377,o),
+(198,377,cs),
+(150,377,o),
+(128,408,o),
+(139,459,cs),
+(144,486,l),
+(101,486,l),
+(97,464,ls),
+(83,390,o),
+(121,339,o),
+(197,339,cs)
+);
+}
+);
+width = 530;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "c-canadian";
+note = uni18DB;
+unicode = 6363;
+},
+{
+color = 9;
+glyphname = "easternw-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (-22,-307);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (111,0);
+ref = "glottalstop-canadian";
+}
+);
+width = 542;
+}
+);
+note = uni18DC;
+unicode = 6364;
+},
+{
+color = 9;
+glyphname = "westernw-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (692,-307);
+ref = dot_top;
+scale = (-1,1);
+},
+{
+alignment = -1;
+ref = "glottalstop-canadian";
+}
+);
+width = 546;
+}
+);
+metricLeft = "glottalstop-canadian";
+note = uni18DD;
+unicode = 6365;
+},
+{
+glyphname = "rweRCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "reRCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (831,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1043;
+}
+);
+note = uni18E0;
+unicode = 6368;
+},
+{
+glyphname = "looWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+}
+);
+width = 522;
+}
+);
+note = uni18E1;
+unicode = 6369;
+},
+{
+glyphname = "laaWestCree-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (348,0);
+ref = dot_top;
+}
+);
+width = 521;
+}
+);
+note = uni18E2;
+unicode = 6370;
+},
+{
+glyphname = "thwe-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "the-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (697,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 910;
+}
+);
+note = uni18E3;
+unicode = 6371;
+},
+{
+glyphname = "thwa-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (652,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 865;
+}
+);
+note = uni18E4;
+unicode = 6372;
+},
+{
+glyphname = "tthwe-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "tthe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (689,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 901;
+}
+);
+note = uni18E5;
+unicode = 6373;
+},
+{
+glyphname = "tthoo-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ttho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (236,0);
+ref = dot_top;
+}
+);
+width = 606;
+}
+);
+note = uni18E6;
+unicode = 6374;
+},
+{
+glyphname = "tthaa-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ttha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (251,0);
+ref = dot_top;
+}
+);
+width = 606;
+}
+);
+note = uni18E7;
+unicode = 6375;
+},
+{
+glyphname = "tlhwe-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "tlhe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (573,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 785;
+}
+);
+note = uni18E8;
+unicode = 6376;
+},
+{
+glyphname = "tlhoo-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "tlho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (242,0);
+ref = dot_top;
+}
+);
+width = 573;
+}
+);
+note = uni18E9;
+unicode = 6377;
+},
+{
+glyphname = "shweSayisi-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "sheSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (573,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 785;
+}
+);
+note = uni18EA;
+unicode = 6378;
+},
+{
+glyphname = "shooSayisi-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "shoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (408,0);
+ref = dot_top;
+}
+);
+width = 573;
+}
+);
+note = uni18EB;
+unicode = 6379;
+},
+{
+color = 9;
+glyphname = "hooSayisi-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "hoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (466,0);
+ref = dot_top;
+}
+);
+width = 639;
+}
+);
+note = uni18EC;
+unicode = 6380;
+},
+{
+color = 9;
+glyphname = "gwuCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "guCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (836,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1048;
+}
+);
+note = uni18ED;
+unicode = 6381;
+},
+{
+color = 9;
+glyphname = "deneGeeCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "geCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (279,0);
+ref = dot_top;
+}
+);
+width = 677;
+}
+);
+note = uni18EE;
+unicode = 6382;
+},
+{
+color = 9;
+glyphname = "gaaCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (291,0);
+ref = dot_top;
+}
+);
+width = 677;
+}
+);
+note = uni18EF;
+unicode = 6383;
+},
+{
+color = 9;
+glyphname = "gwaCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (677,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 890;
+}
+);
+note = uni18F0;
+unicode = 6384;
+},
+{
+color = 9;
+glyphname = "juuSayisi-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "juSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (300,0);
+ref = dot_top;
+}
+);
+width = 690;
+}
+);
+note = uni18F1;
+unicode = 6385;
+},
+{
+color = 9;
+glyphname = "jwaCarrier-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "jaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (734,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 948;
+}
+);
+note = uni18F2;
+unicode = 6386;
+},
+{
+glyphname = "lBeaverDene-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "pWestCree-canadian";
+}
+);
+width = 181;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+unicode = 6387;
+},
+{
+glyphname = "rBeaverDene-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(137,345,l),
+(182,556,ls),
+(195,618,o),
+(226,649,o),
+(271,649,cs),
+(281,649,l),
+(291,696,l),
+(284,696,ls),
+(234,696,o),
+(196,664,o),
+(185,611,c),
+(190,613,l),
+(207,690,l),
+(164,690,l),
+(91,345,l)
+);
+}
+);
+width = 224;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni18F4;
+unicode = 6388;
+},
+{
+color = 6;
+glyphname = "sDentalCarrier-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(208,183,ls),
+(293,183,o),
+(337,224,o),
+(337,296,cs),
+(337,343,o),
+(306,374,o),
+(247,374,cs),
+(209,374,ls),
+(168,374,o),
+(150,390,o),
+(150,418,cs),
+(150,462,o),
+(177,491,o),
+(233,491,cs),
+(376,491,l),
+(384,527,l),
+(239,527,ls),
+(153,527,o),
+(109,486,o),
+(109,414,cs),
+(109,367,o),
+(139,336,o),
+(198,336,cs),
+(238,336,ls),
+(278,336,o),
+(296,320,o),
+(296,293,cs),
+(296,248,o),
+(269,220,o),
+(213,220,cs),
+(70,220,l),
+(62,183,l)
+);
+}
+);
+width = 396;
+}
+);
+metricLeft = "shCarrier-canadian";
+metricRight = "=|";
+note = uni18F5;
+unicode = 6389;
+},
+{
+glyphname = "pWestCree-canadian.base";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-74,-345);
+ref = "pWestCree-canadian";
+}
+);
+width = 181;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.base";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-74,-345);
+ref = "c-canadian";
+}
+);
+width = 351;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "thSayisi-canadian.base";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-73,-345);
+ref = "thSayisi-canadian";
+}
+);
+width = 352;
+}
+);
+metricLeft = "=|c-canadian";
+note = uni14A2;
+},
+{
+glyphname = "mWestCree-canadian.base";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-73,-345);
+ref = "mWestCree-canadian";
+}
+);
+width = 361;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+glyphname = "pWestCree-canadian.mid";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-162);
+ref = "pWestCree-canadian";
+}
+);
+width = 182;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.mid";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-162);
+ref = "c-canadian";
+}
+);
+width = 352;
+}
+);
+metricLeft = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "mWestCree-canadian.mid";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-34,-162);
+ref = "mWestCree-canadian";
+}
+);
+width = 362;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+color = 11;
+glyphname = "ngaai-canadian.nunavik";
+lastChange = "2023-01-13 15:55:09 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (627,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (795,0);
+ref = ring_top.canadian;
+}
+);
+width = 1191;
+}
+);
+note = uni158E;
+},
+{
+color = 11;
+glyphname = "ngi-canadian.nunavik";
+lastChange = "2023-01-13 15:55:09 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (627,0);
+ref = "ci-canadian";
+}
+);
+width = 1191;
+}
+);
+note = uni158F;
+},
+{
+color = 11;
+glyphname = "ngii-canadian.nunavik";
+lastChange = "2023-01-13 15:55:09 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (627,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (853,0);
+ref = dot_top;
+}
+);
+width = 1191;
+}
+);
+note = uni1590;
+},
+{
+color = 11;
+glyphname = "ngo-canadian.nunavik";
+lastChange = "2023-01-13 15:55:09 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (627,0);
+ref = "co-canadian";
+}
+);
+width = 1190;
+}
+);
+note = uni1591;
+},
+{
+color = 11;
+glyphname = "ngoo-canadian.nunavik";
+lastChange = "2023-01-13 15:55:09 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "ngo-canadian.nunavik";
+},
+{
+anchor = top_right_can;
+pos = (1025,0);
+ref = dot_top;
+}
+);
+width = 1190;
+}
+);
+note = uni1592;
+},
+{
+color = 11;
+glyphname = "nga-canadian.nunavik";
+lastChange = "2023-01-13 15:55:09 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (627,0);
+ref = "ca-canadian";
+}
+);
+width = 1190;
+}
+);
+note = uni1593;
+},
+{
+color = 11;
+glyphname = "ngaa-canadian.nunavik";
+lastChange = "2023-01-13 15:55:09 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (627,0);
+ref = "ca-canadian";
+},
+{
+anchor = top_left_can;
+pos = (670,0);
+ref = dot_top;
+}
+);
+width = 1190;
+}
+);
+note = uni1594;
+},
+{
+color = 11;
+glyphname = "ng-canadian.nunavik";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(535,153,o),
+(581,239,o),
+(581,312,cs),
+(581,373,o),
+(544,414,o),
+(486,414,cs),
+(449,414,o),
+(416,396,o),
+(398,363,c),
+(404,353,l),
+(431,477,l),
+(297,477,l),
+(300,459,l),
+(345,483,o),
+(364,546,o),
+(364,588,cs),
+(364,653,o),
+(323,696,o),
+(258,696,cs),
+(171,696,o),
+(127,614,o),
+(127,542,cs),
+(127,476,o),
+(168,434,o),
+(234,434,cs),
+(400,434,l),
+(381,459,l),
+(346,298,ls),
+(330,223,o),
+(364,153,o),
+(446,153,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(410,189,o),
+(383,215,o),
+(383,259,cs),
+(383,308,o),
+(413,379,o),
+(475,379,cs),
+(515,379,o),
+(540,353,o),
+(540,309,cs),
+(540,259,o),
+(510,189,o),
+(449,189,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(192,470,o),
+(168,498,o),
+(168,541,cs),
+(168,593,o),
+(197,660,o),
+(257,660,cs),
+(298,660,o),
+(324,632,o),
+(324,588,cs),
+(324,537,o),
+(293,470,o),
+(234,470,cs)
+);
+}
+);
+width = 627;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+color = 11;
+glyphname = "ngai-canadian.nunavik";
+lastChange = "2023-01-13 15:55:09 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (627,0);
+ref = "ce-canadian";
+}
+);
+width = 1192;
+}
+);
+note = uni1670;
+},
+{
+color = 11;
+glyphname = "ke-canadian.square";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (423,690);
+},
+{
+name = top_left_can;
+pos = (199,690);
+},
+{
+name = top_right_can;
+pos = (651,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(534,0,l),
+(681,690,l),
+(458,690,ls),
+(215,690,o),
+(100,539,o),
+(100,357,cs),
+(100,219,o),
+(191,136,o),
+(348,136,cs),
+(501,136,l),
+(472,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(230,191,o),
+(161,252,o),
+(161,361,cs),
+(161,503,o),
+(247,635,o),
+(446,635,cs),
+(608,635,l),
+(514,191,l),
+(358,191,ls)
+);
+}
+);
+width = 664;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146B;
+},
+{
+color = 11;
+glyphname = "ki-canadian.square";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (437,690);
+},
+{
+name = top_left_can;
+pos = (209,690);
+},
+{
+name = top_right_can;
+pos = (664,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(92,0,l),
+(121,136,l),
+(285,136,ls),
+(526,136,o),
+(639,289,o),
+(639,467,cs),
+(639,607,o),
+(548,690,o),
+(392,690,cs),
+(177,690,l),
+(30,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(227,635,l),
+(383,635,ls),
+(510,635,o),
+(579,573,o),
+(579,465,cs),
+(579,323,o),
+(494,191,o),
+(297,191,cs),
+(133,191,l)
+);
+}
+);
+width = 664;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni146D;
+},
+{
+color = 11;
+glyphname = "kii-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (277,0);
+ref = dot_top;
+}
+);
+width = 666;
+}
+);
+note = uni146E;
+},
+{
+color = 11;
+glyphname = "ko-canadian.square";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (422,690);
+},
+{
+name = top_left_can;
+pos = (198,690);
+},
+{
+name = top_right_can;
+pos = (650,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(533,0,l),
+(680,690,l),
+(618,690,l),
+(590,554,l),
+(425,554,ls),
+(185,554,o),
+(71,401,o),
+(71,223,cs),
+(71,83,o),
+(162,0,o),
+(318,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(201,55,o),
+(132,117,o),
+(132,225,cs),
+(132,367,o),
+(216,498,o),
+(414,498,cs),
+(578,498,l),
+(484,55,l),
+(327,55,ls)
+);
+}
+);
+width = 663;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146F;
+},
+{
+color = 11;
+glyphname = "koo-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (492,0);
+ref = dot_top;
+}
+);
+width = 666;
+}
+);
+note = uni1470;
+},
+{
+color = 11;
+glyphname = "ka-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (437,690);
+},
+{
+name = top_left_can;
+pos = (209,690);
+},
+{
+name = top_right_can;
+pos = (665,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(254,0,ls),
+(496,0,o),
+(611,151,o),
+(611,332,cs),
+(611,470,o),
+(520,554,o),
+(363,554,cs),
+(211,554,l),
+(239,690,l),
+(177,690,l),
+(30,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(198,498,l),
+(353,498,ls),
+(481,498,o),
+(550,438,o),
+(550,328,cs),
+(550,186,o),
+(464,55,o),
+(266,55,cs),
+(104,55,l)
+);
+}
+);
+width = 665;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1472;
+},
+{
+color = 11;
+glyphname = "kaa-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+}
+);
+width = 666;
+}
+);
+note = uni1473;
+},
+{
+color = 11;
+glyphname = "kweWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (666,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 878;
+}
+);
+note = uni1475;
+},
+{
+color = 11;
+glyphname = "kwiiWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (277,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (666,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 878;
+}
+);
+note = uni1479;
+},
+{
+color = 11;
+glyphname = "kwoWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (666,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 878;
+}
+);
+note = uni147B;
+},
+{
+color = 11;
+glyphname = "kwooWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (492,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (666,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 878;
+}
+);
+note = uni147D;
+},
+{
+color = 11;
+glyphname = "kwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (666,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 878;
+}
+);
+note = uni147F;
+},
+{
+color = 11;
+glyphname = "kwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (666,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 878;
+}
+);
+note = uni1481;
+},
+{
+color = 11;
+glyphname = "ce-canadian.square";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (436,690);
+},
+{
+name = top_left_can;
+pos = (195,690);
+},
+{
+name = top_right_can;
+pos = (676,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(559,0,l),
+(643,395,ls),
+(683,582,o),
+(591,702,o),
+(410,702,cs),
+(251,702,o),
+(146,609,o),
+(110,437,cs),
+(100,391,l),
+(162,391,l),
+(171,433,ls),
+(200,573,o),
+(281,645,o),
+(406,645,cs),
+(551,645,o),
+(616,554,o),
+(582,395,cs),
+(497,0,l)
+);
+}
+);
+width = 682;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni1489;
+},
+{
+color = 11;
+glyphname = "ci-canadian.square";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (440,690);
+},
+{
+name = top_left_can;
+pos = (201,690);
+},
+{
+name = top_right_can;
+pos = (682,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(85,0,l),
+(176,427,ls),
+(206,571,o),
+(288,645,o),
+(414,645,cs),
+(551,645,o),
+(623,560,o),
+(595,427,cs),
+(586,391,l),
+(648,391,l),
+(655,423,ls),
+(690,588,o),
+(591,702,o),
+(417,702,cs),
+(259,702,o),
+(153,609,o),
+(116,438,cs),
+(23,0,l)
+);
+}
+);
+width = 682;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+},
+{
+color = 11;
+glyphname = "cii-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (282,0);
+ref = dot_top;
+}
+);
+width = 683;
+}
+);
+note = uni148C;
+},
+{
+color = 11;
+glyphname = "co-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (436,690);
+},
+{
+name = top_left_can;
+pos = (195,690);
+},
+{
+name = top_right_can;
+pos = (676,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(470,-13,o),
+(577,81,o),
+(613,252,cs),
+(706,690,l),
+(644,690,l),
+(554,263,ls),
+(524,119,o),
+(441,44,o),
+(315,44,cs),
+(179,44,o),
+(105,129,o),
+(134,263,cs),
+(142,298,l),
+(81,298,l),
+(74,267,ls),
+(40,101,o),
+(138,-13,o),
+(312,-13,cs)
+);
+}
+);
+width = 683;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+},
+{
+color = 11;
+glyphname = "coo-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (517,0);
+ref = dot_top;
+}
+);
+width = 683;
+}
+);
+note = uni148E;
+},
+{
+color = 11;
+glyphname = "ca-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (440,690);
+},
+{
+name = top_left_can;
+pos = (201,690);
+},
+{
+name = top_right_can;
+pos = (681,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(478,-13,o),
+(583,81,o),
+(618,253,cs),
+(628,298,l),
+(567,298,l),
+(558,257,ls),
+(528,117,o),
+(448,44,o),
+(324,44,cs),
+(179,44,o),
+(114,136,o),
+(147,295,cs),
+(232,690,l),
+(170,690,l),
+(86,295,ls),
+(46,108,o),
+(138,-13,o),
+(320,-13,cs)
+);
+}
+);
+width = 682;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+},
+{
+color = 11;
+glyphname = "caa-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (43,0);
+ref = dot_top;
+}
+);
+width = 683;
+}
+);
+note = uni1491;
+},
+{
+color = 11;
+glyphname = "me-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (370,690);
+},
+{
+name = top_double;
+pos = (568,690);
+},
+{
+name = top_left_can;
+pos = (169,690);
+},
+{
+name = top_right_can;
+pos = (568,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(452,0,l),
+(599,690,l),
+(138,690,l),
+(127,634,l),
+(526,634,l),
+(390,0,l)
+);
+}
+);
+width = 582;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+},
+{
+color = 11;
+glyphname = "mi-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (408,690);
+},
+{
+name = top_left_can;
+pos = (209,690);
+},
+{
+name = top_right_can;
+pos = (607,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(92,0,l),
+(227,634,l),
+(625,634,l),
+(638,690,l),
+(177,690,l),
+(30,0,l)
+);
+}
+);
+width = 582;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+},
+{
+color = 11;
+glyphname = "mii-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (249,0);
+ref = dot_top;
+}
+);
+width = 582;
+}
+);
+note = uni14A6;
+},
+{
+color = 11;
+glyphname = "mo-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (370,690);
+},
+{
+name = top_double;
+pos = (568,690);
+},
+{
+name = top_left_can;
+pos = (169,690);
+},
+{
+name = top_right_can;
+pos = (568,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(452,0,l),
+(599,690,l),
+(537,690,l),
+(402,56,l),
+(3,56,l),
+(-9,0,l)
+);
+}
+);
+width = 582;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+},
+{
+color = 11;
+glyphname = "moo-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (410,0);
+ref = dot_top;
+}
+);
+width = 582;
+}
+);
+note = uni14A8;
+},
+{
+color = 11;
+glyphname = "ma-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (408,690);
+},
+{
+name = top_left_can;
+pos = (209,690);
+},
+{
+name = top_right_can;
+pos = (607,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(491,0,l),
+(502,56,l),
+(104,56,l),
+(239,690,l),
+(177,690,l),
+(30,0,l)
+);
+}
+);
+width = 582;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+},
+{
+color = 11;
+glyphname = "maa-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+}
+);
+width = 582;
+}
+);
+note = uni14AB;
+},
+{
+color = 11;
+glyphname = "ne-canadian.square";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (527,690);
+},
+{
+name = top_left_can;
+pos = (333,690);
+},
+{
+name = top_right_can;
+pos = (727,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(542,-13,o),
+(625,66,o),
+(660,230,cs),
+(758,690,l),
+(159,690,l),
+(148,634,l),
+(290,634,l),
+(209,252,ls),
+(174,87,o),
+(246,-13,o),
+(404,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(291,45,o),
+(242,116,o),
+(269,243,cs),
+(352,634,l),
+(685,634,l),
+(599,232,ls),
+(572,105,o),
+(511,45,o),
+(407,45,cs)
+);
+}
+);
+width = 734;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C0;
+},
+{
+color = 11;
+glyphname = "ni-canadian.square";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (397,690);
+},
+{
+name = top_left_can;
+pos = (201,690);
+},
+{
+name = top_right_can;
+pos = (594,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(410,-13,o),
+(493,66,o),
+(527,230,cs),
+(613,634,l),
+(756,634,l),
+(768,690,l),
+(170,690,l),
+(77,252,ls),
+(42,87,o),
+(115,-13,o),
+(272,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(159,45,o),
+(109,116,o),
+(136,243,cs),
+(219,634,l),
+(553,634,l),
+(467,232,ls),
+(440,105,o),
+(379,45,o),
+(275,45,cs)
+);
+}
+);
+width = 733;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+},
+{
+color = 11;
+glyphname = "nii-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (239,0);
+ref = dot_top;
+}
+);
+width = 733;
+}
+);
+note = uni14C3;
+},
+{
+color = 11;
+glyphname = "no-canadian.square";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (530,690);
+},
+{
+name = top_double;
+pos = (540,690);
+},
+{
+name = top_left_can;
+pos = (333,690);
+},
+{
+name = top_right_can;
+pos = (725,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(611,0,l),
+(703,438,ls),
+(738,603,o),
+(666,702,o),
+(508,702,cs),
+(370,702,o),
+(288,624,o),
+(253,460,cs),
+(167,56,l),
+(24,56,l),
+(13,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(314,458,ls),
+(341,584,o),
+(401,644,o),
+(505,644,cs),
+(621,644,o),
+(670,574,o),
+(643,446,cs),
+(560,56,l),
+(228,56,l)
+);
+}
+);
+width = 734;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C4;
+},
+{
+color = 11;
+glyphname = "noo-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (370,0);
+ref = dot_top;
+}
+);
+width = 733;
+}
+);
+note = uni14C5;
+},
+{
+color = 11;
+glyphname = "na-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (398,690);
+},
+{
+name = top_double;
+pos = (408,690);
+},
+{
+name = top_left_can;
+pos = (201,690);
+},
+{
+name = top_right_can;
+pos = (595,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(621,0,l),
+(633,56,l),
+(491,56,l),
+(572,438,ls),
+(607,603,o),
+(534,702,o),
+(377,702,cs),
+(240,702,o),
+(156,624,o),
+(121,460,cs),
+(23,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(182,458,ls),
+(209,584,o),
+(270,644,o),
+(374,644,cs),
+(490,644,o),
+(539,574,o),
+(512,446,cs),
+(429,56,l),
+(97,56,l)
+);
+}
+);
+width = 733;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+},
+{
+color = 11;
+glyphname = "naa-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (239,0);
+ref = dot_top;
+}
+);
+width = 733;
+}
+);
+note = uni14C8;
+},
+{
+color = 11;
+glyphname = "nweWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (733,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 946;
+}
+);
+note = uni14CA;
+},
+{
+color = 11;
+glyphname = "nwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (733,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 946;
+}
+);
+note = uni14CC;
+},
+{
+color = 11;
+glyphname = "nwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (239,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (733,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 946;
+}
+);
+note = uni14CE;
+},
+{
+color = 11;
+glyphname = "se-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (205,690);
+},
+{
+name = top_right_can;
+pos = (651,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(534,0,l),
+(582,230,l),
+(391,230,ls),
+(222,230,o),
+(156,318,o),
+(195,497,cs),
+(236,690,l),
+(174,690,l),
+(133,497,ls),
+(90,294,o),
+(184,175,o),
+(381,175,cs),
+(530,175,l),
+(514,195,l),
+(472,0,l)
+);
+}
+);
+width = 665;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14ED;
+},
+{
+color = 11;
+glyphname = "si-canadian.square";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (209,690);
+},
+{
+name = top_right_can;
+pos = (655,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(94,0,l),
+(135,195,l),
+(110,175,l),
+(258,175,ls),
+(472,175,o),
+(598,280,o),
+(642,494,cs),
+(685,690,l),
+(623,690,l),
+(582,495,ls),
+(545,322,o),
+(436,230,o),
+(270,230,cs),
+(80,230,l),
+(32,0,l)
+);
+}
+);
+width = 665;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+},
+{
+color = 11;
+glyphname = "sii-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (496,0);
+ref = dot_top;
+}
+);
+width = 665;
+}
+);
+note = uni14F0;
+},
+{
+color = 11;
+glyphname = "so-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (650,690);
+},
+{
+name = top_left_can;
+pos = (205,690);
+},
+{
+name = top_right_can;
+pos = (650,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(89,0,l),
+(130,195,ls),
+(167,368,o),
+(276,460,o),
+(442,460,cs),
+(632,460,l),
+(680,690,l),
+(619,690,l),
+(577,495,l),
+(602,515,l),
+(454,515,ls),
+(240,515,o),
+(114,410,o),
+(69,196,cs),
+(27,0,l)
+);
+}
+);
+width = 665;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+},
+{
+color = 11;
+glyphname = "soo-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (491,0);
+ref = dot_top;
+}
+);
+width = 665;
+}
+);
+note = uni14F2;
+},
+{
+color = 11;
+glyphname = "sa-canadian.square";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (210,690);
+},
+{
+name = top_right_can;
+pos = (653,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(537,0,l),
+(578,193,ls),
+(621,396,o),
+(528,515,o),
+(330,515,cs),
+(182,515,l),
+(197,495,l),
+(239,690,l),
+(178,690,l),
+(129,460,l),
+(320,460,ls),
+(490,460,o),
+(555,372,o),
+(517,193,cs),
+(475,0,l)
+);
+}
+);
+width = 664;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+},
+{
+color = 11;
+glyphname = "saa-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+}
+);
+width = 665;
+}
+);
+note = uni14F5;
+},
+{
+color = 11;
+glyphname = "sho-canadian.square";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (425,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(527,0,l),
+(538,53,l),
+(250,53,ls),
+(164,53,o),
+(120,88,o),
+(120,156,cs),
+(120,249,o),
+(178,319,o),
+(304,319,cs),
+(401,319,ls),
+(569,319,o),
+(649,408,o),
+(649,536,cs),
+(649,631,o),
+(585,690,o),
+(475,690,cs),
+(176,690,l),
+(165,637,l),
+(457,637,ls),
+(544,637,o),
+(588,601,o),
+(588,534,cs),
+(588,439,o),
+(530,372,o),
+(403,372,cs),
+(306,372,ls),
+(138,372,o),
+(58,282,o),
+(58,154,cs),
+(58,59,o),
+(123,0,o),
+(232,0,cs)
+);
+}
+);
+width = 660;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+color = 11;
+glyphname = "shoo-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (267,0);
+ref = dot_top;
+}
+);
+width = 661;
+}
+);
+note = g728;
+},
+{
+color = 11;
+glyphname = "sha-canadian.square";
+lastChange = "2023-01-13 15:55:07 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (438,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(330,0,ls),
+(502,0,o),
+(582,89,o),
+(582,222,cs),
+(582,317,o),
+(519,371,o),
+(409,371,cs),
+(318,371,ls),
+(231,371,o),
+(186,403,o),
+(186,469,cs),
+(186,567,o),
+(243,637,o),
+(373,637,cs),
+(664,637,l),
+(675,690,l),
+(374,690,ls),
+(208,690,o),
+(125,602,o),
+(125,468,cs),
+(125,373,o),
+(188,318,o),
+(297,318,cs),
+(389,318,ls),
+(476,318,o),
+(521,287,o),
+(521,221,cs),
+(521,122,o),
+(462,53,o),
+(332,53,cs),
+(41,53,l),
+(29,0,l)
+);
+}
+);
+width = 661;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+color = 11;
+glyphname = "shaa-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (279,0);
+ref = dot_top;
+}
+);
+width = 661;
+}
+);
+note = g730;
+},
+{
+color = 11;
+glyphname = "ye-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (176,690);
+},
+{
+name = top_right_can;
+pos = (680,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(564,0,l),
+(612,230,l),
+(128,230,l),
+(128,194,l),
+(712,655,l),
+(675,701,l),
+(40,199,l),
+(35,175,l),
+(539,175,l),
+(502,0,l)
+);
+}
+);
+width = 692;
+}
+);
+metricLeft = "ye-canadian";
+note = uni1526;
+},
+{
+color = 11;
+glyphname = "yi-canadian.square";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (204,690);
+},
+{
+name = top_right_can;
+pos = (708,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(89,0,l),
+(126,175,l),
+(631,175,l),
+(636,199,l),
+(202,701,l),
+(155,661,l),
+(553,197,l),
+(560,230,l),
+(75,230,l),
+(27,0,l)
+);
+}
+);
+width = 692;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni1528;
+},
+{
+color = 11;
+glyphname = "yii-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (46,0);
+ref = dot_top;
+}
+);
+width = 692;
+}
+);
+note = uni1529;
+},
+{
+color = 11;
+glyphname = "yo-canadian.square";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (680,690);
+},
+{
+name = top_left_can;
+pos = (176,690);
+},
+{
+name = top_right_can;
+pos = (680,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(583,29,l),
+(184,493,l),
+(178,460,l),
+(663,460,l),
+(711,690,l),
+(649,690,l),
+(612,515,l),
+(107,515,l),
+(102,491,l),
+(536,-12,l)
+);
+}
+);
+width = 692;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152A;
+},
+{
+color = 11;
+glyphname = "yoo-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (522,0);
+ref = dot_top;
+}
+);
+width = 692;
+}
+);
+note = uni152B;
+},
+{
+color = 11;
+glyphname = "ya-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (203,690);
+},
+{
+name = top_right_can;
+pos = (707,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(698,491,l),
+(703,515,l),
+(198,515,l),
+(236,690,l),
+(174,690,l),
+(126,460,l),
+(610,460,l),
+(609,496,l),
+(25,35,l),
+(62,-12,l)
+);
+}
+);
+width = 692;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152D;
+},
+{
+color = 11;
+glyphname = "yaa-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (44,0);
+ref = dot_top;
+}
+);
+width = 692;
+}
+);
+note = uni152E;
+},
+{
+color = 11;
+glyphname = "re-canadian.square";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (398,690);
+},
+{
+name = top_left_can;
+pos = (201,690);
+},
+{
+name = top_right_can;
+pos = (595,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(410,-13,o),
+(493,66,o),
+(527,230,cs),
+(613,634,l),
+(756,634,l),
+(768,690,l),
+(564,690,l),
+(467,232,ls),
+(440,105,o),
+(379,45,o),
+(275,45,cs),
+(159,45,o),
+(109,116,o),
+(136,243,cs),
+(231,690,l),
+(170,690,l),
+(77,252,ls),
+(42,87,o),
+(115,-13,o),
+(272,-13,cs)
+);
+}
+);
+width = 733;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1542;
+},
+{
+color = 11;
+glyphname = "reRCree-canadian.square";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (530,690);
+},
+{
+name = top_left_can;
+pos = (333,690);
+},
+{
+name = top_right_can;
+pos = (727,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(542,-13,o),
+(625,66,o),
+(660,230,cs),
+(758,690,l),
+(697,690,l),
+(599,232,ls),
+(572,105,o),
+(511,45,o),
+(407,45,cs),
+(291,45,o),
+(242,116,o),
+(269,243,cs),
+(363,690,l),
+(159,690,l),
+(148,634,l),
+(290,634,l),
+(209,252,ls),
+(174,87,o),
+(246,-13,o),
+(404,-13,cs)
+);
+}
+);
+width = 734;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni1543;
+},
+{
+color = 11;
+glyphname = "leWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (530,690);
+},
+{
+name = top_left_can;
+pos = (333,690);
+},
+{
+name = top_right_can;
+pos = (727,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(216,0,l),
+(314,458,ls),
+(341,584,o),
+(402,644,o),
+(505,644,cs),
+(621,644,o),
+(671,574,o),
+(644,446,cs),
+(550,0,l),
+(611,0,l),
+(703,438,ls),
+(739,603,o),
+(666,702,o),
+(508,702,cs),
+(371,702,o),
+(288,623,o),
+(253,460,cs),
+(167,56,l),
+(24,56,l),
+(13,0,l)
+);
+}
+);
+width = 738;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+},
+{
+color = 11;
+glyphname = "ri-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (398,690);
+},
+{
+name = top_left_can;
+pos = (205,690);
+},
+{
+name = top_right_can;
+pos = (595,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(85,0,l),
+(182,458,ls),
+(209,584,o),
+(270,644,o),
+(374,644,cs),
+(490,644,o),
+(539,574,o),
+(512,446,cs),
+(417,0,l),
+(621,0,l),
+(633,56,l),
+(491,56,l),
+(572,438,ls),
+(607,603,o),
+(534,702,o),
+(377,702,cs),
+(240,702,o),
+(156,624,o),
+(121,460,cs),
+(23,0,l)
+);
+}
+);
+width = 733;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+},
+{
+color = 11;
+glyphname = "rii-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (239,0);
+ref = dot_top;
+}
+);
+width = 733;
+}
+);
+note = uni1547;
+},
+{
+color = 11;
+glyphname = "ro-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (428,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(92,0,l),
+(127,163,l),
+(93,136,l),
+(270,136,ls),
+(507,136,o),
+(621,288,o),
+(621,469,cs),
+(621,607,o),
+(529,690,o),
+(374,690,cs),
+(177,690,l),
+(165,635,l),
+(364,635,ls),
+(492,635,o),
+(559,573,o),
+(559,464,cs),
+(559,322,o),
+(475,191,o),
+(274,191,cs),
+(71,191,l),
+(30,0,l)
+);
+}
+);
+width = 646;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1548;
+},
+{
+color = 11;
+glyphname = "loWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (428,690);
+},
+{
+name = top_left_can;
+pos = (209,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(243,0,ls),
+(478,0,o),
+(592,152,o),
+(592,332,cs),
+(592,470,o),
+(502,554,o),
+(345,554,cs),
+(182,554,l),
+(204,526,l),
+(240,690,l),
+(178,690,l),
+(136,498,l),
+(335,498,ls),
+(465,498,o),
+(531,438,o),
+(531,328,cs),
+(531,186,o),
+(446,55,o),
+(248,55,cs),
+(43,55,l),
+(31,0,l)
+);
+}
+);
+width = 645;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+},
+{
+color = 11;
+glyphname = "ra-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (412,690);
+},
+{
+name = top_right_can;
+pos = (631,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(514,0,l),
+(554,191,l),
+(355,191,ls),
+(227,191,o),
+(160,252,o),
+(160,361,cs),
+(160,503,o),
+(245,635,o),
+(443,635,cs),
+(649,635,l),
+(661,690,l),
+(447,690,ls),
+(213,690,o),
+(99,538,o),
+(99,357,cs),
+(99,219,o),
+(189,136,o),
+(346,136,cs),
+(510,136,l),
+(487,163,l),
+(452,0,l)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+},
+{
+color = 11;
+glyphname = "raa-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (252,0);
+ref = dot_top;
+}
+);
+width = 645;
+}
+);
+note = uni154C;
+},
+{
+color = 11;
+glyphname = "laWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (630,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(514,0,l),
+(526,55,l),
+(326,55,ls),
+(198,55,o),
+(130,117,o),
+(130,226,cs),
+(130,368,o),
+(215,498,o),
+(415,498,cs),
+(619,498,l),
+(661,690,l),
+(599,690,l),
+(564,526,l),
+(598,554,l),
+(421,554,ls),
+(183,554,o),
+(70,402,o),
+(70,221,cs),
+(70,83,o),
+(160,0,o),
+(316,0,cs)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+},
+{
+color = 11;
+glyphname = "reWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(554,0,l),
+(821,191,l),
+(788,238,l),
+(550,68,l),
+(571,51,l),
+(643,395,ls),
+(683,582,o),
+(592,702,o),
+(410,702,cs),
+(253,702,o),
+(146,610,o),
+(110,437,cs),
+(100,391,l),
+(162,391,l),
+(171,433,ls),
+(200,573,o),
+(281,645,o),
+(406,645,cs),
+(551,645,o),
+(616,554,o),
+(582,395,cs),
+(498,0,l)
+);
+}
+);
+width = 860;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+},
+{
+color = 11;
+glyphname = "riWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(262,0,l),
+(353,427,ls),
+(384,571,o),
+(465,645,o),
+(591,645,cs),
+(727,645,o),
+(800,560,o),
+(772,427,cs),
+(764,391,l),
+(825,391,l),
+(832,423,ls),
+(866,588,o),
+(768,702,o),
+(594,702,cs),
+(436,702,o),
+(329,610,o),
+(293,438,cs),
+(211,51,l),
+(235,57,l),
+(62,233,l),
+(19,191,l),
+(207,0,l)
+);
+}
+);
+width = 859;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+},
+{
+color = 11;
+glyphname = "roWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(470,-13,o),
+(576,80,o),
+(612,252,cs),
+(695,639,l),
+(670,633,l),
+(844,457,l),
+(887,498,l),
+(699,690,l),
+(644,690,l),
+(553,263,ls),
+(523,119,o),
+(440,44,o),
+(315,44,cs),
+(179,44,o),
+(105,129,o),
+(134,263,cs),
+(142,298,l),
+(80,298,l),
+(74,267,ls),
+(40,101,o),
+(137,-13,o),
+(312,-13,cs)
+);
+}
+);
+width = 860;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+},
+{
+color = 11;
+glyphname = "raWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(653,-13,o),
+(760,80,o),
+(796,253,cs),
+(805,298,l),
+(744,298,l),
+(735,257,ls),
+(706,117,o),
+(625,44,o),
+(500,44,cs),
+(355,44,o),
+(290,136,o),
+(324,295,cs),
+(408,690,l),
+(353,690,l),
+(85,498,l),
+(118,452,l),
+(356,622,l),
+(335,639,l),
+(263,295,ls),
+(223,108,o),
+(314,-13,o),
+(497,-13,cs)
+);
+}
+);
+width = 859;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+},
+{
+color = 11;
+glyphname = "theThCree-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (176,690);
+},
+{
+name = top_right_can;
+pos = (680,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(564,0,l),
+(579,71,l),
+(663,71,l),
+(670,107,l),
+(586,107,l),
+(612,230,l),
+(148,230,l),
+(154,213,l),
+(712,655,l),
+(675,701,l),
+(40,199,l),
+(35,175,l),
+(539,175,l),
+(526,107,l),
+(280,107,l),
+(272,71,l),
+(517,71,l),
+(502,0,l)
+);
+}
+);
+width = 733;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15A7;
+},
+{
+color = 11;
+glyphname = "thiThCree-canadian.square";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (236,690);
+},
+{
+name = top_right_can;
+pos = (740,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(131,0,l),
+(146,71,l),
+(389,71,l),
+(397,107,l),
+(154,107,l),
+(168,175,l),
+(673,175,l),
+(678,199,l),
+(244,701,l),
+(198,661,l),
+(583,210,l),
+(593,230,l),
+(118,230,l),
+(92,107,l),
+(8,107,l),
+(0,71,l),
+(84,71,l),
+(70,0,l)
+);
+}
+);
+width = 734;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+},
+{
+color = 11;
+glyphname = "thiiThCree-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (76,0);
+ref = dot_top;
+}
+);
+width = 733;
+}
+);
+note = uni15A9;
+},
+{
+color = 11;
+glyphname = "thoThCree-canadian.square";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (175,690);
+},
+{
+name = top_right_can;
+pos = (679,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(582,29,l),
+(197,480,l),
+(187,460,l),
+(662,460,l),
+(688,582,l),
+(772,582,l),
+(779,619,l),
+(696,619,l),
+(710,690,l),
+(648,690,l),
+(634,619,l),
+(389,619,l),
+(383,582,l),
+(625,582,l),
+(612,515,l),
+(107,515,l),
+(102,491,l),
+(535,-12,l)
+);
+}
+);
+width = 733;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+},
+{
+color = 11;
+glyphname = "thooThCree-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (521,0);
+ref = dot_top;
+}
+);
+width = 733;
+}
+);
+note = uni15AB;
+},
+{
+color = 11;
+glyphname = "thaThCree-canadian.square";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (246,690);
+},
+{
+name = top_right_can;
+pos = (751,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(740,491,l),
+(745,515,l),
+(240,515,l),
+(254,582,l),
+(499,582,l),
+(506,619,l),
+(263,619,l),
+(277,690,l),
+(215,690,l),
+(201,619,l),
+(117,619,l),
+(109,582,l),
+(193,582,l),
+(167,460,l),
+(632,460,l),
+(626,477,l),
+(67,35,l),
+(103,-12,l)
+);
+}
+);
+width = 734;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+},
+{
+color = 11;
+glyphname = "thaaThCree-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (88,0);
+ref = dot_top;
+}
+);
+width = 733;
+}
+);
+note = uni15AD;
+},
+{
+color = 11;
+glyphname = "thweeWoodScree-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (733,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 947;
+}
+);
+note = uni1677;
+},
+{
+color = 11;
+glyphname = "thwiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (733,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 947;
+}
+);
+note = uni1678;
+},
+{
+color = 11;
+glyphname = "thwiiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (76,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (733,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 947;
+}
+);
+note = uni1679;
+},
+{
+color = 11;
+glyphname = "thwoWoodScree-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (733,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 947;
+}
+);
+note = uni167A;
+},
+{
+color = 11;
+glyphname = "thwooWoodScree-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (521,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (733,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 947;
+}
+);
+note = uni167B;
+},
+{
+color = 11;
+glyphname = "thwaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (733,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 947;
+}
+);
+note = uni167C;
+},
+{
+color = 11;
+glyphname = "thwaaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (88,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (733,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 947;
+}
+);
+note = uni167D;
+},
+{
+color = 11;
+glyphname = "nwiOjibway-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (733,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 946;
+}
+);
+note = uni18C7;
+},
+{
+color = 11;
+glyphname = "nwiiOjibway-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (239,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (733,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 946;
+}
+);
+note = uni18C9;
+},
+{
+color = 11;
+glyphname = "nwoOjibway-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (733,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 946;
+}
+);
+note = uni18CB;
+},
+{
+color = 11;
+glyphname = "nwooOjibway-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (370,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (733,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 946;
+}
+);
+note = uni18CD;
+},
+{
+color = 11;
+glyphname = "looWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+}
+);
+width = 645;
+}
+);
+note = uni18E1;
+},
+{
+color = 11;
+glyphname = "laaWestCree-canadian.square";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (472,0);
+ref = dot_top;
+}
+);
+width = 645;
+}
+);
+note = uni18E2;
+},
+{
+color = 0;
+glyphname = zero;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(549,541,o),
+(501,700,o),
+(327,700,cs),
+(150,700,o),
+(102,526,o),
+(102,347,cs),
+(102,106,o),
+(183,-10,o),
+(326,-10,cs),
+(475,-10,o),
+(549,108,o),
+(549,347,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(166,489,o),
+(190,647,o),
+(327,647,cs),
+(471,647,o),
+(485,479,o),
+(485,347,cs),
+(485,159,o),
+(443,43,o),
+(326,43,cs),
+(214,43,o),
+(166,157,o),
+(166,347,cs)
+);
+}
+);
+width = 608;
+}
+);
+unicode = 48;
+},
+{
+color = 0;
+glyphname = one;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(283,690,l),
+(83,539,l),
+(118,497,l),
+(227,579,ls),
+(249,595,o),
+(262,607,o),
+(277,621,c),
+(276,599,o),
+(276,576,o),
+(276,551,cs),
+(276,0,l),
+(339,0,l),
+(339,690,l)
+);
+}
+);
+width = 458;
+}
+);
+unicode = 49;
+},
+{
+color = 0;
+glyphname = two;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(543,0,l),
+(543,54,l),
+(188,54,l),
+(188,56,l),
+(355,230,ls),
+(423,298,o),
+(471,353,o),
+(497,414,cs),
+(509,444,o),
+(515,479,o),
+(515,519,cs),
+(515,628,o),
+(436,699,o),
+(321,699,cs),
+(248,699,o),
+(181,675,o),
+(120,622,c),
+(155,580,l),
+(208,623,o),
+(264,644,o),
+(316,644,cs),
+(400,644,o),
+(452,596,o),
+(452,512,cs),
+(452,450,o),
+(432,403,o),
+(391,351,cs),
+(370,325,o),
+(344,295,o),
+(311,261,cs),
+(106,45,l),
+(106,0,l)
+);
+}
+);
+width = 593;
+}
+);
+unicode = 50;
+},
+{
+color = 0;
+glyphname = three;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(526,639,o),
+(447,699,o),
+(327,699,cs),
+(234,699,o),
+(166,670,o),
+(109,628,c),
+(137,583,l),
+(191,622,o),
+(251,646,o),
+(321,646,cs),
+(408,646,o),
+(465,607,o),
+(465,524,cs),
+(465,427,o),
+(380,384,o),
+(280,384,cs),
+(209,384,l),
+(209,332,l),
+(280,332,ls),
+(399,332,o),
+(481,298,o),
+(481,192,cs),
+(481,101,o),
+(420,43,o),
+(293,43,cs),
+(226,43,o),
+(155,61,o),
+(102,87,c),
+(102,30,l),
+(155,7,o),
+(219,-10,o),
+(298,-10,cs),
+(454,-10,o),
+(548,69,o),
+(548,189,cs),
+(548,292,o),
+(486,346,o),
+(379,360,c),
+(379,362,l),
+(463,380,o),
+(526,442,o),
+(526,534,cs)
+);
+}
+);
+width = 598;
+}
+);
+unicode = 51;
+},
+{
+color = 0;
+glyphname = four;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,226,l),
+(440,693,l),
+(379,693,l),
+(36,220,l),
+(36,175,l),
+(378,175,l),
+(378,0,l),
+(440,0,l),
+(440,175,l),
+(556,175,l),
+(556,226,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(99,226,l),
+(321,528,ls),
+(347,565,o),
+(356,581,o),
+(377,614,c),
+(379,614,l),
+(379,593,o),
+(378,559,o),
+(378,523,cs),
+(378,226,l)
+);
+}
+);
+width = 582;
+}
+);
+unicode = 52;
+},
+{
+color = 0;
+glyphname = five;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(244,421,o),
+(206,411,o),
+(177,404,c),
+(197,635,l),
+(482,635,l),
+(482,690,l),
+(143,690,l),
+(115,367,l),
+(145,348,l),
+(187,361,o),
+(230,369,o),
+(283,369,cs),
+(401,369,o),
+(461,310,o),
+(461,213,cs),
+(461,105,o),
+(386,43,o),
+(270,43,cs),
+(202,43,o),
+(139,63,o),
+(95,88,c),
+(95,30,l),
+(138,7,o),
+(198,-10,o),
+(273,-10,cs),
+(433,-10,o),
+(526,77,o),
+(526,214,cs),
+(526,347,o),
+(440,421,o),
+(305,421,cs)
+);
+}
+);
+width = 569;
+}
+);
+unicode = 53;
+},
+{
+color = 0;
+glyphname = six;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(88,134,o),
+(156,-10,o),
+(320,-10,cs),
+(454,-10,o),
+(535,79,o),
+(535,221,cs),
+(535,352,o),
+(462,433,o),
+(335,433,cs),
+(242,433,o),
+(178,387,o),
+(149,327,c),
+(146,327,l),
+(152,514,o),
+(218,648,o),
+(393,648,cs),
+(434,648,o),
+(466,643,o),
+(490,636,c),
+(490,690,l),
+(464,696,o),
+(430,701,o),
+(394,701,cs),
+(168,701,o),
+(88,523,o),
+(88,293,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(192,43,o),
+(156,166,o),
+(156,247,cs),
+(156,322,o),
+(239,381,o),
+(324,381,cs),
+(425,381,o),
+(473,320,o),
+(473,221,cs),
+(473,110,o),
+(418,43,o),
+(319,43,cs)
+);
+}
+);
+width = 582;
+}
+);
+unicode = 54;
+},
+{
+color = 0;
+glyphname = seven;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(563,651,l),
+(563,690,l),
+(113,690,l),
+(113,635,l),
+(495,635,l),
+(219,0,l),
+(286,0,l)
+);
+}
+);
+width = 587;
+}
+);
+unicode = 55;
+},
+{
+color = 0;
+glyphname = eight;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(458,-10,o),
+(551,59,o),
+(551,177,cs),
+(551,274,o),
+(481,329,o),
+(378,368,c),
+(469,405,o),
+(528,455,o),
+(528,539,cs),
+(528,642,o),
+(450,699,o),
+(329,699,cs),
+(212,699,o),
+(129,638,o),
+(129,538,cs),
+(129,441,o),
+(205,397,o),
+(276,366,c),
+(175,330,o),
+(108,275,o),
+(108,172,cs),
+(108,64,o),
+(191,-10,o),
+(326,-10,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(231,41,o),
+(168,92,o),
+(168,174,cs),
+(168,268,o),
+(246,311,o),
+(327,338,c),
+(438,297,o),
+(491,251,o),
+(491,178,cs),
+(491,88,o),
+(424,41,o),
+(326,41,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(246,426,o),
+(190,465,o),
+(190,534,cs),
+(190,609,o),
+(250,649,o),
+(329,649,cs),
+(415,649,o),
+(468,611,o),
+(468,535,cs),
+(468,469,o),
+(419,432,o),
+(330,395,c)
+);
+}
+);
+width = 611;
+}
+);
+unicode = 56;
+},
+{
+color = 0;
+glyphname = nine;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(548,562,o),
+(481,699,o),
+(316,699,cs),
+(183,699,o),
+(100,611,o),
+(100,469,cs),
+(100,339,o),
+(174,257,o),
+(298,257,cs),
+(390,257,o),
+(458,301,o),
+(487,364,c),
+(490,364,l),
+(485,173,o),
+(413,42,o),
+(241,42,cs),
+(202,42,o),
+(164,47,o),
+(140,55,c),
+(140,0,l),
+(166,-7,o),
+(207,-12,o),
+(242,-12,cs),
+(470,-12,o),
+(548,172,o),
+(548,396,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(445,646,o),
+(481,523,o),
+(481,443,cs),
+(481,370,o),
+(395,309,o),
+(313,309,cs),
+(213,309,o),
+(163,372,o),
+(163,470,cs),
+(163,582,o),
+(217,646,o),
+(318,646,cs)
+);
+}
+);
+width = 607;
+}
+);
+unicode = 57;
+},
+{
+glyphname = zero.canadian;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(472,-12,o),
+(547,317,o),
+(547,476,cs),
+(547,620,o),
+(483,702,o),
+(365,702,cs),
+(145,702,o),
+(71,374,o),
+(71,213,cs),
+(71,70,o),
+(135,-12,o),
+(252,-12,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(174,45,o),
+(131,103,o),
+(131,213,cs),
+(131,336,o),
+(187,645,o),
+(362,645,cs),
+(444,645,o),
+(487,587,o),
+(487,478,cs),
+(487,355,o),
+(430,45,o),
+(256,45,cs)
+);
+}
+);
+width = 571;
+}
+);
+metricRight = "=|";
+},
+{
+glyphname = one.canadian;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(213,0,l),
+(360,690,l),
+(304,690,l),
+(93,538,l),
+(125,494,l),
+(331,641,l),
+(289,648,l),
+(151,0,l)
+);
+}
+);
+width = 343;
+}
+);
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = two.canadian;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(463,56,l),
+(116,56,l),
+(114,30,l),
+(394,270,ls),
+(487,349,o),
+(550,428,o),
+(550,532,cs),
+(550,635,o),
+(479,702,o),
+(364,702,cs),
+(233,702,o),
+(144,618,o),
+(111,454,c),
+(172,454,l),
+(198,583,o),
+(262,647,o),
+(359,647,cs),
+(441,647,o),
+(489,602,o),
+(489,529,cs),
+(489,440,o),
+(428,370,o),
+(349,302,cs),
+(43,43,l),
+(35,0,l),
+(451,0,l)
+);
+}
+);
+width = 561;
+}
+);
+note = uni14BF;
+},
+{
+glyphname = three.canadian;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(418,-13,o),
+(501,86,o),
+(501,209,cs),
+(501,284,o),
+(462,337,o),
+(393,351,c),
+(388,332,l),
+(505,342,o),
+(562,441,o),
+(562,536,cs),
+(562,635,o),
+(490,702,o),
+(371,702,cs),
+(240,702,o),
+(154,625,o),
+(126,470,c),
+(186,470,l),
+(210,590,o),
+(270,647,o),
+(366,647,cs),
+(451,647,o),
+(500,603,o),
+(500,529,cs),
+(500,444,o),
+(451,372,o),
+(342,372,cs),
+(304,372,l),
+(294,319,l),
+(333,319,ls),
+(403,319,o),
+(440,280,o),
+(440,214,cs),
+(440,124,o),
+(385,43,o),
+(271,43,cs),
+(154,43,o),
+(113,115,o),
+(128,219,c),
+(66,219,l),
+(48,87,o),
+(114,-13,o),
+(271,-13,cs)
+);
+}
+);
+width = 589;
+}
+);
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = four.canadian;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(379,0,l),
+(416,175,l),
+(522,175,l),
+(533,228,l),
+(427,228,l),
+(526,693,l),
+(474,693,l),
+(42,215,l),
+(33,175,l),
+(355,175,l),
+(319,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(480,633,l),
+(454,633,l),
+(367,228,l),
+(98,228,l),
+(100,213,l)
+);
+}
+);
+width = 569;
+}
+);
+},
+{
+glyphname = five.canadian;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(433,-13,o),
+(512,105,o),
+(512,229,cs),
+(512,334,o),
+(444,397,o),
+(327,397,cs),
+(188,397,l),
+(204,377,l),
+(287,655,l),
+(262,635,l),
+(580,635,l),
+(591,690,l),
+(237,690,l),
+(139,357,l),
+(150,342,l),
+(312,342,ls),
+(402,342,o),
+(451,302,o),
+(451,225,cs),
+(451,132,o),
+(396,43,o),
+(278,43,cs),
+(173,43,o),
+(117,102,o),
+(130,192,c),
+(70,192,l),
+(53,73,o),
+(134,-13,o),
+(276,-13,cs)
+);
+}
+);
+width = 584;
+}
+);
+},
+{
+glyphname = six.canadian;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(416,-13,o),
+(504,101,o),
+(504,230,cs),
+(504,339,o),
+(434,412,o),
+(321,412,cs),
+(226,412,o),
+(155,363,o),
+(120,270,c),
+(134,253,l),
+(137,290,o),
+(142,321,o),
+(150,364,cs),
+(184,530,o),
+(250,647,o),
+(373,647,cs),
+(470,647,o),
+(502,583,o),
+(499,502,c),
+(560,502,l),
+(568,613,o),
+(505,702,o),
+(375,702,cs),
+(136,702,o),
+(70,352,o),
+(70,209,cs),
+(70,151,o),
+(81,103,o),
+(104,69,cs),
+(137,17,o),
+(198,-13,o),
+(272,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(186,42,o),
+(133,93,o),
+(133,175,cs),
+(133,270,o),
+(197,359,o),
+(307,359,cs),
+(392,359,o),
+(444,309,o),
+(444,227,cs),
+(444,133,o),
+(384,42,o),
+(272,42,cs)
+);
+}
+);
+width = 565;
+}
+);
+metricLeft = zero.canadian;
+},
+{
+glyphname = seven.canadian;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(138,0,l),
+(520,651,l),
+(528,690,l),
+(125,690,l),
+(113,634,l),
+(458,634,l),
+(458,657,l),
+(81,19,l),
+(78,0,l)
+);
+}
+);
+width = 466;
+}
+);
+},
+{
+glyphname = eight.canadian;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(419,-13,o),
+(510,79,o),
+(512,195,cs),
+(514,270,o),
+(468,329,o),
+(396,348,c),
+(388,331,l),
+(495,341,o),
+(565,426,o),
+(566,529,cs),
+(569,632,o),
+(494,702,o),
+(370,702,cs),
+(233,702,o),
+(151,611,o),
+(149,495,cs),
+(147,422,o),
+(186,363,o),
+(256,341,c),
+(253,360,l),
+(131,350,o),
+(66,258,o),
+(64,161,cs),
+(62,57,o),
+(145,-13,o),
+(277,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(179,41,o),
+(124,86,o),
+(125,161,cs),
+(126,253,o),
+(190,320,o),
+(297,320,cs),
+(398,320,o),
+(453,274,o),
+(452,199,cs),
+(451,109,o),
+(388,41,o),
+(280,41,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(259,371,o),
+(209,416,o),
+(209,492,cs),
+(210,578,o),
+(264,649,o),
+(367,649,cs),
+(455,649,o),
+(506,604,o),
+(505,529,cs),
+(505,443,o),
+(450,371,o),
+(347,371,cs)
+);
+}
+);
+width = 601;
+}
+);
+metricLeft = "=|";
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = nine.canadian;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(476,-13,o),
+(543,338,o),
+(543,481,cs),
+(543,539,o),
+(531,586,o),
+(509,621,cs),
+(475,672,o),
+(414,702,o),
+(340,702,cs),
+(197,702,o),
+(108,588,o),
+(108,460,cs),
+(108,351,o),
+(179,277,o),
+(292,277,cs),
+(386,277,o),
+(457,327,o),
+(493,420,c),
+(479,437,l),
+(475,400,o),
+(471,369,o),
+(463,326,cs),
+(428,159,o),
+(362,43,o),
+(240,43,cs),
+(142,43,o),
+(110,106,o),
+(113,187,c),
+(52,187,l),
+(44,76,o),
+(107,-13,o),
+(238,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(220,330,o),
+(168,381,o),
+(168,463,cs),
+(168,556,o),
+(228,648,o),
+(340,648,cs),
+(426,648,o),
+(479,597,o),
+(479,515,cs),
+(479,420,o),
+(416,330,o),
+(305,330,cs)
+);
+}
+);
+width = 566;
+}
+);
+metricLeft = "=|six.canadian";
+metricRight = "=|six.canadian";
+},
+{
+glyphname = CR;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+width = 252;
+}
+);
+note = CR;
+unicode = 13;
+},
+{
+color = 0;
+glyphname = .notdef;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(584,690,l),
+(187,690,l),
+(187,0,l),
+(584,0,l),
+(584,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(535,640,l),
+(535,49,l),
+(237,49,l),
+(237,640,l),
+(237,640,l)
+);
+}
+);
+width = 676;
+}
+);
+note = ".notdef";
+},
+{
+glyphname = .null;
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+width = 0;
+}
+);
+note = NULL;
+},
+{
+glyphname = space;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+width = 254;
+}
+);
+note = space;
+unicode = 32;
+},
+{
+glyphname = nbspace;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+width = 252;
+}
+);
+note = uni00A0;
+unicode = 160;
+},
+{
+glyphname = space.canadian;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+width = 487;
+}
+);
+note = space;
+},
+{
+glyphname = "hyphen-canadian";
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(412,402,l),
+(421,441,l),
+(112,441,l),
+(103,402,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(384,269,l),
+(392,308,l),
+(83,308,l),
+(74,269,l)
+);
+}
+);
+width = 444;
+}
+);
+metricRight = "=|";
+note = uni1400;
+unicode = 5120;
+},
+{
+glyphname = "chi-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(67,0,l),
+(297,313,l),
+(271,318,l),
+(370,0,l),
+(424,0,l),
+(428,19,l),
+(314,373,l),
+(307,325,l),
+(563,670,l),
+(568,690,l),
+(507,690,l),
+(284,384,l),
+(308,381,l),
+(211,690,l),
+(157,690,l),
+(154,670,l),
+(266,327,l),
+(273,375,l),
+(10,19,l),
+(6,0,l)
+);
+}
+);
+width = 530;
+}
+);
+metricRight = "=|";
+note = uni166D;
+unicode = 5741;
+},
+{
+glyphname = "fullstop-canadian";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(50,0,l),
+(156,146,l),
+(144,149,l),
+(190,0,l),
+(228,0,l),
+(230,10,l),
+(172,186,l),
+(168,159,l),
+(298,334,l),
+(300,345,l),
+(257,345,l),
+(152,201,l),
+(166,198,l),
+(121,345,l),
+(83,345,l),
+(80,334,l),
+(137,164,l),
+(141,189,l),
+(9,10,l),
+(7,0,l)
+);
+}
+);
+width = 335;
+}
+);
+note = uni1541;
+unicode = 5742;
+},
+{
+glyphname = period;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(26,7,o),
+(39,-9,o),
+(69,-9,cs),
+(95,-9,o),
+(111,11,o),
+(114,41,cs),
+(117,64,o),
+(104,79,o),
+(73,79,cs),
+(44,79,o),
+(32,57,o),
+(29,30,cs)
+);
+}
+);
+width = 221;
+}
+);
+note = period;
+unicode = 46;
+},
+{
+glyphname = comma;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(0,-127,l),
+(43,-58,o),
+(87,36,o),
+(117,107,c),
+(115,119,l),
+(58,119,l),
+(32,44,o),
+(0,-33,o),
+(-46,-127,c)
+);
+}
+);
+width = 197;
+}
+);
+note = comma;
+unicode = 44;
+},
+{
+glyphname = hyphen;
+kernLeft = hyphen;
+kernRight = hyphen;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(253,235,l),
+(264,288,l),
+(47,288,l),
+(37,235,l)
+);
+}
+);
+width = 290;
+}
+);
+unicode = 45;
+},
+{
+glyphname = quotesinglbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-47,-571);
+ref = quoteright;
+}
+);
+width = 214;
+}
+);
+unicode = 8218;
+},
+{
+glyphname = quotedblbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-90,-571);
+ref = quotedblright;
+}
+);
+width = 401;
+}
+);
+unicode = 8222;
+},
+{
+glyphname = quotedblleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(292,443,l),
+(314,519,o),
+(354,610,o),
+(401,690,c),
+(358,690,l),
+(311,621,o),
+(268,534,o),
+(236,453,c),
+(240,443,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(133,443,l),
+(156,520,o),
+(195,609,o),
+(243,690,c),
+(201,690,l),
+(153,621,o),
+(110,534,o),
+(78,453,c),
+(82,443,l)
+);
+}
+);
+width = 334;
+}
+);
+unicode = 8220;
+},
+{
+glyphname = quotedblright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(274,443,l),
+(323,513,o),
+(366,601,o),
+(397,680,c),
+(393,690,l),
+(341,690,l),
+(318,613,o),
+(279,524,o),
+(232,443,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(116,443,l),
+(165,513,o),
+(208,601,o),
+(240,680,c),
+(235,690,l),
+(184,690,l),
+(160,614,o),
+(121,523,o),
+(73,443,c)
+);
+}
+);
+width = 334;
+}
+);
+unicode = 8221;
+},
+{
+glyphname = quoteleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(134,443,l),
+(157,519,o),
+(198,610,o),
+(244,690,c),
+(202,690,l),
+(154,621,o),
+(110,534,o),
+(78,453,c),
+(82,443,l)
+);
+}
+);
+width = 178;
+}
+);
+unicode = 8216;
+},
+{
+glyphname = quoteright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(118,443,l),
+(165,513,o),
+(210,601,o),
+(241,680,c),
+(237,690,l),
+(184,690,l),
+(160,614,o),
+(122,523,o),
+(74,443,c)
+);
+}
+);
+width = 178;
+}
+);
+unicode = 8217;
+},
+{
+glyphname = dottedCircle;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(203,504,o),
+(190,494,o),
+(190,479,cs),
+(190,467,o),
+(203,454,o),
+(215,454,cs),
+(230,454,o),
+(241,467,o),
+(241,479,cs),
+(241,494,o),
+(230,504,o),
+(215,504,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(365,504,o),
+(353,494,o),
+(353,479,cs),
+(353,467,o),
+(365,454,o),
+(378,454,cs),
+(392,454,o),
+(403,467,o),
+(403,479,cs),
+(403,494,o),
+(392,504,o),
+(378,504,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(203,108,o),
+(190,98,o),
+(190,83,cs),
+(190,71,o),
+(203,58,o),
+(215,58,cs),
+(230,58,o),
+(241,71,o),
+(241,83,cs),
+(241,98,o),
+(230,108,o),
+(215,108,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(365,108,o),
+(353,98,o),
+(353,83,cs),
+(353,71,o),
+(365,58,o),
+(378,58,cs),
+(392,58,o),
+(403,71,o),
+(403,83,cs),
+(403,98,o),
+(392,108,o),
+(378,108,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(284,522,o),
+(271,511,o),
+(271,497,cs),
+(271,484,o),
+(284,471,o),
+(297,471,cs),
+(311,471,o),
+(322,484,o),
+(322,497,cs),
+(322,511,o),
+(311,522,o),
+(297,522,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(284,91,o),
+(271,80,o),
+(271,66,cs),
+(271,53,o),
+(284,41,o),
+(297,41,cs),
+(311,41,o),
+(322,53,o),
+(322,66,cs),
+(322,80,o),
+(311,91,o),
+(297,91,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(56,269,o),
+(69,256,o),
+(81,256,cs),
+(96,256,o),
+(106,269,o),
+(106,281,cs),
+(106,296,o),
+(96,306,o),
+(81,306,cs),
+(69,306,o),
+(56,296,o),
+(56,281,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(487,269,o),
+(499,256,o),
+(512,256,cs),
+(526,256,o),
+(537,269,o),
+(537,281,cs),
+(537,296,o),
+(526,306,o),
+(512,306,cs),
+(499,306,o),
+(487,296,o),
+(487,281,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(119,116,o),
+(131,103,o),
+(144,103,cs),
+(158,103,o),
+(169,116,o),
+(169,128,cs),
+(169,143,o),
+(158,154,o),
+(144,154,cs),
+(131,154,o),
+(119,143,o),
+(119,128,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(119,421,o),
+(131,409,o),
+(144,409,cs),
+(158,409,o),
+(169,421,o),
+(169,434,cs),
+(169,448,o),
+(158,459,o),
+(144,459,cs),
+(131,459,o),
+(119,448,o),
+(119,434,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(424,116,o),
+(437,103,o),
+(449,103,cs),
+(464,103,o),
+(474,116,o),
+(474,128,cs),
+(474,143,o),
+(464,154,o),
+(449,154,cs),
+(437,154,o),
+(424,143,o),
+(424,128,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(424,421,o),
+(437,409,o),
+(449,409,cs),
+(464,409,o),
+(474,421,o),
+(474,434,cs),
+(474,448,o),
+(464,459,o),
+(449,459,cs),
+(437,459,o),
+(424,448,o),
+(424,434,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(73,187,o),
+(86,175,o),
+(99,175,cs),
+(113,175,o),
+(124,187,o),
+(124,200,cs),
+(124,214,o),
+(113,225,o),
+(99,225,cs),
+(86,225,o),
+(73,214,o),
+(73,200,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(73,350,o),
+(86,337,o),
+(99,337,cs),
+(113,337,o),
+(124,350,o),
+(124,362,cs),
+(124,377,o),
+(113,387,o),
+(99,387,cs),
+(86,387,o),
+(73,377,o),
+(73,362,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(469,187,o),
+(482,175,o),
+(495,175,cs),
+(509,175,o),
+(520,187,o),
+(520,200,cs),
+(520,214,o),
+(509,225,o),
+(495,225,cs),
+(482,225,o),
+(469,214,o),
+(469,200,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(469,350,o),
+(482,337,o),
+(495,337,cs),
+(509,337,o),
+(520,350,o),
+(520,362,cs),
+(520,377,o),
+(509,387,o),
+(495,387,cs),
+(482,387,o),
+(469,377,o),
+(469,362,cs)
+);
+}
+);
+width = 583;
+}
+);
+note = uni25CC;
+unicode = 9676;
+},
+{
+glyphname = dotaccentcomb;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(144,709,o),
+(130,695,o),
+(126,667,cs),
+(121,639,o),
+(133,625,o),
+(161,625,cs),
+(186,625,o),
+(200,639,o),
+(205,666,cs),
+(210,694,o),
+(197,709,o),
+(169,709,cs)
+);
+}
+);
+width = 148;
+}
+);
+note = uni0307;
+unicode = 775;
+},
+{
+glyphname = dotaccent;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(191,625,o),
+(203,644,o),
+(206,668,cs),
+(211,694,o),
+(198,709,o),
+(169,709,cs),
+(142,709,o),
+(129,692,o),
+(127,666,cs),
+(123,639,o),
+(133,625,o),
+(162,625,cs)
+);
+}
+);
+width = 150;
+}
+);
+note = dotaccent;
+unicode = 729;
+},
+{
+glyphname = caron;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(298,623,o),
+(348,677,o),
+(401,730,c),
+(403,738,l),
+(357,738,l),
+(320,706,o),
+(280,668,o),
+(245,629,c),
+(226,666,o),
+(206,706,o),
+(181,738,c),
+(142,738,l),
+(140,730,l),
+(168,687,o),
+(193,637,o),
+(210,585,c),
+(269,585,l),
+(269,585,l)
+);
+}
+);
+width = 331;
+}
+);
+note = caron;
+unicode = 711;
+},
+{
+glyphname = breve;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(312,585,o),
+(358,625,o),
+(382,709,c),
+(340,709,l),
+(324,656,o),
+(293,629,o),
+(244,629,cs),
+(194,629,o),
+(171,657,o),
+(174,709,c),
+(134,709,l),
+(126,634,o),
+(165,585,o),
+(242,585,cs)
+);
+}
+);
+width = 315;
+}
+);
+note = breve;
+unicode = 728;
+},
+{
+glyphname = ring;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(277,588,o),
+(320,630,o),
+(320,691,cs),
+(320,748,o),
+(277,792,o),
+(226,792,cs),
+(173,792,o),
+(132,750,o),
+(132,691,cs),
+(132,629,o),
+(174,588,o),
+(226,588,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(191,625,o),
+(168,655,o),
+(168,691,cs),
+(168,727,o),
+(193,756,o),
+(226,756,cs),
+(257,756,o),
+(283,727,o),
+(283,691,cs),
+(283,655,o),
+(259,625,o),
+(226,625,cs)
+);
+}
+);
+width = 258;
+}
+);
+note = ring;
+unicode = 730;
+},
+{
+glyphname = ogonek;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(41,-214,o),
+(58,-212,o),
+(74,-206,c),
+(83,-164,l),
+(71,-168,o),
+(54,-172,o),
+(43,-172,cs),
+(14,-172,o),
+(1,-156,o),
+(4,-124,cs),
+(8,-84,o),
+(37,-47,o),
+(102,0,c),
+(75,14,l),
+(2,-33,o),
+(-38,-81,o),
+(-43,-132,cs),
+(-48,-182,o),
+(-21,-214,o),
+(24,-214,cs)
+);
+}
+);
+width = 204;
+}
+);
+note = ogonek;
+unicode = 731;
+},
+{
+glyphname = ring_top.canadian;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (216,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(303,757,o),
+(348,796,o),
+(348,853,cs),
+(348,909,o),
+(303,948,o),
+(250,948,cs),
+(197,948,o),
+(155,909,o),
+(155,853,cs),
+(155,796,o),
+(197,757,o),
+(250,757,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(213,790,o),
+(189,816,o),
+(189,853,cs),
+(189,889,o),
+(213,915,o),
+(251,915,cs),
+(288,915,o),
+(312,889,o),
+(312,853,cs),
+(312,816,o),
+(288,790,o),
+(251,790,cs)
+);
+}
+);
+width = 240;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (85,345);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(109,302,o),
+(128,321,o),
+(128,345,cs),
+(128,369,o),
+(109,387,o),
+(85,387,cs),
+(61,387,o),
+(43,369,o),
+(43,345,cs),
+(43,321,o),
+(61,302,o),
+(85,302,cs)
+);
+}
+);
+width = 124;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (80,345);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(102,306,o),
+(119,323,o),
+(119,345,cs),
+(119,367,o),
+(102,384,o),
+(80,384,cs),
+(59,384,o),
+(42,367,o),
+(42,345,cs),
+(42,323,o),
+(59,306,o),
+(80,306,cs)
+);
+}
+);
+width = 115;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_small;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (76,345);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(96,311,o),
+(110,326,o),
+(110,345,cs),
+(110,364,o),
+(96,379,o),
+(76,379,cs),
+(57,379,o),
+(42,364,o),
+(42,345,cs),
+(42,326,o),
+(57,311,o),
+(76,311,cs)
+);
+}
+);
+width = 106;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_top;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (158,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(213,788,o),
+(232,807,o),
+(232,831,cs),
+(232,855,o),
+(213,874,o),
+(188,874,cs),
+(164,874,o),
+(145,855,o),
+(145,831,cs),
+(145,807,o),
+(164,788,o),
+(188,788,cs)
+);
+}
+);
+width = 124;
+}
+);
+note = g725;
+},
+{
+glyphname = doubledot_middle;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(173,388,o),
+(191,407,o),
+(191,432,cs),
+(191,456,o),
+(173,474,o),
+(149,474,cs),
+(125,474,o),
+(105,456,o),
+(105,432,cs),
+(105,407,o),
+(125,388,o),
+(149,388,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(136,215,o),
+(155,234,o),
+(155,258,cs),
+(155,283,o),
+(136,301,o),
+(112,301,cs),
+(88,301,o),
+(69,283,o),
+(69,258,cs),
+(69,234,o),
+(88,215,o),
+(112,215,cs)
+);
+}
+);
+width = 213;
+}
+);
+metricRight = "=|";
+note = g725;
+},
+{
+glyphname = doubledot_top;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top_double;
+pos = (316,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(369,788,o),
+(388,807,o),
+(388,831,cs),
+(388,855,o),
+(369,874,o),
+(345,874,cs),
+(321,874,o),
+(301,855,o),
+(301,831,cs),
+(301,807,o),
+(321,788,o),
+(345,788,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(210,788,o),
+(229,807,o),
+(229,831,cs),
+(229,855,o),
+(210,874,o),
+(185,874,cs),
+(161,874,o),
+(143,855,o),
+(143,831,cs),
+(143,807,o),
+(161,788,o),
+(185,788,cs)
+);
+}
+);
+width = 277;
+}
+);
+note = g725;
+},
+{
+glyphname = g727;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (425,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(527,0,l),
+(538,53,l),
+(250,53,ls),
+(164,53,o),
+(120,88,o),
+(120,156,cs),
+(120,249,o),
+(178,319,o),
+(304,319,cs),
+(401,319,ls),
+(569,319,o),
+(649,408,o),
+(649,536,cs),
+(649,631,o),
+(585,690,o),
+(475,690,cs),
+(176,690,l),
+(165,637,l),
+(457,637,ls),
+(544,637,o),
+(588,601,o),
+(588,534,cs),
+(588,439,o),
+(530,372,o),
+(403,372,cs),
+(306,372,ls),
+(138,372,o),
+(58,282,o),
+(58,154,cs),
+(58,59,o),
+(123,0,o),
+(232,0,cs)
+);
+}
+);
+width = 660;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+glyphname = g728;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (267,0);
+ref = dot_top;
+}
+);
+width = 661;
+}
+);
+note = g728;
+},
+{
+glyphname = g729;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (438,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(330,0,ls),
+(502,0,o),
+(582,89,o),
+(582,222,cs),
+(582,317,o),
+(519,371,o),
+(409,371,cs),
+(318,371,ls),
+(231,371,o),
+(186,403,o),
+(186,469,cs),
+(186,567,o),
+(243,637,o),
+(373,637,cs),
+(664,637,l),
+(675,690,l),
+(374,690,ls),
+(208,690,o),
+(125,602,o),
+(125,468,cs),
+(125,373,o),
+(188,318,o),
+(297,318,cs),
+(389,318,ls),
+(476,318,o),
+(521,287,o),
+(521,221,cs),
+(521,122,o),
+(462,53,o),
+(332,53,cs),
+(41,53,l),
+(29,0,l)
+);
+}
+);
+width = 661;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+glyphname = g730;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (279,0);
+ref = dot_top;
+}
+);
+width = 661;
+}
+);
+note = g730;
+},
+{
+glyphname = g731;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = g727;
+}
+);
+width = 873;
+}
+);
+note = g731;
+},
+{
+glyphname = g732;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (661,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 873;
+}
+);
+note = g732;
+},
+{
+glyphname = g733;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (479,0);
+ref = dot_top;
+}
+);
+width = 873;
+}
+);
+note = g733;
+},
+{
+glyphname = g734;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (267,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (661,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 873;
+}
+);
+note = g734;
+},
+{
+glyphname = g735;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = g729;
+}
+);
+width = 873;
+}
+);
+note = g735;
+},
+{
+glyphname = g736;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (661,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 873;
+}
+);
+note = g736;
+},
+{
+glyphname = g737;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (492,0);
+ref = dot_top;
+}
+);
+width = 873;
+}
+);
+note = g737;
+},
+{
+glyphname = g738;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (279,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (661,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 873;
+}
+);
+note = g738;
+},
+{
+glyphname = g739;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(545,215,o),
+(589,298,o),
+(589,369,cs),
+(589,435,o),
+(548,477,o),
+(482,477,cs),
+(292,477,l),
+(305,462,l),
+(347,487,o),
+(364,548,o),
+(364,588,cs),
+(364,653,o),
+(323,696,o),
+(258,696,cs),
+(171,696,o),
+(127,613,o),
+(127,542,cs),
+(127,476,o),
+(169,434,o),
+(235,434,cs),
+(424,434,l),
+(411,449,l),
+(369,423,o),
+(352,362,o),
+(352,323,cs),
+(352,258,o),
+(393,215,o),
+(459,215,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(192,470,o),
+(168,498,o),
+(168,541,cs),
+(168,593,o),
+(198,660,o),
+(257,660,cs),
+(298,660,o),
+(324,632,o),
+(324,588,cs),
+(324,537,o),
+(294,470,o),
+(234,470,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(418,251,o),
+(393,279,o),
+(393,323,cs),
+(393,374,o),
+(422,440,o),
+(483,440,cs),
+(524,440,o),
+(549,412,o),
+(549,370,cs),
+(549,318,o),
+(519,251,o),
+(459,251,cs)
+);
+}
+);
+width = 623;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+glyphname = g740;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (210,0);
+ref = ring_top.canadian;
+}
+);
+width = 661;
+}
+);
+note = g740;
+},
+{
+glyphname = g741;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (221,0);
+ref = ring_top.canadian;
+}
+);
+width = 661;
+}
+);
+note = g741;
+},
+{
+glyphname = g742;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (422,0);
+ref = ring_top.canadian;
+}
+);
+width = 873;
+}
+);
+note = g742;
+},
+{
+glyphname = stroke_middle;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (63,345);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(61,236,l),
+(106,454,l),
+(65,454,l),
+(19,236,l)
+);
+}
+);
+width = 79;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (59,345);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(56,249,l),
+(97,440,l),
+(63,440,l),
+(22,249,l)
+);
+}
+);
+width = 72;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_small;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (57,345);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(52,251,l),
+(92,439,l),
+(62,439,l),
+(22,251,l)
+);
+}
+);
+width = 68;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_threequart;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (63,345);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(60,237,l),
+(106,453,l),
+(66,453,l),
+(20,237,l)
+);
+}
+);
+width = 79;
+}
+);
+note = g723;
+},
+{
+color = 8;
+glyphname = uni11AB0;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (243,690);
+},
+{
+name = top_right_can;
+pos = (541,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(127,0,l),
+(153,117,l),
+(397,117,l),
+(406,157,l),
+(161,157,l),
+(187,280,l),
+(142,258,l),
+(181,258,ls),
+(371,258,o),
+(500,360,o),
+(548,579,cs),
+(572,690,l),
+(510,690,l),
+(487,585,ls),
+(448,404,o),
+(342,314,o),
+(184,314,cs),
+(133,314,l),
+(99,157,l),
+(18,157,l),
+(10,117,l),
+(91,117,l),
+(66,0,l)
+);
+}
+);
+width = 552;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB1;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB0;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (384,0);
+ref = dot_top;
+}
+);
+width = 554;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB2;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (205,690);
+},
+{
+name = top_right_can;
+pos = (502,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(89,0,l),
+(112,104,ls),
+(151,286,o),
+(257,376,o),
+(415,376,cs),
+(467,376,l),
+(499,532,l),
+(581,532,l),
+(589,573,l),
+(508,573,l),
+(533,690,l),
+(471,690,l),
+(446,573,l),
+(202,573,l),
+(194,532,l),
+(438,532,l),
+(412,410,l),
+(458,432,l),
+(419,432,ls),
+(228,432,o),
+(99,329,o),
+(51,111,cs),
+(27,0,l)
+);
+}
+);
+width = 553;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "theThCree-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB3;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB2;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (344,0);
+ref = dot_top;
+}
+);
+width = 554;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB4;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (244,690);
+},
+{
+name = top_right_can;
+pos = (542,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(426,0,l),
+(448,106,ls),
+(491,308,o),
+(392,432,o),
+(195,432,cs),
+(175,432,l),
+(215,410,l),
+(242,532,l),
+(486,532,l),
+(494,573,l),
+(250,573,l),
+(275,690,l),
+(213,690,l),
+(189,573,l),
+(107,573,l),
+(99,532,l),
+(180,532,l),
+(147,376,l),
+(182,376,ls),
+(351,376,o),
+(426,285,o),
+(386,102,cs),
+(364,0,l)
+);
+}
+);
+width = 553;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB5;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB4;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (86,0);
+ref = dot_top;
+}
+);
+width = 554;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB6;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (209,690);
+},
+{
+name = top_right_can;
+pos = (506,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(93,1,l),
+(153,282,l),
+(105,259,l),
+(133,259,ls),
+(339,259,o),
+(466,367,o),
+(513,582,cs),
+(531,666,l),
+(487,648,l),
+(673,457,l),
+(717,499,l),
+(530,691,l),
+(474,691,l),
+(452,587,ls),
+(413,410,o),
+(304,315,o),
+(134,315,cs),
+(98,315,l),
+(31,1,l)
+);
+}
+);
+width = 690;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB7;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB6;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (348,0);
+ref = dot_top;
+}
+);
+width = 690;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB8;
+kernRight = soright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (378,690);
+},
+{
+name = top_right_can;
+pos = (675,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(263,0,l),
+(285,103,ls),
+(324,281,o),
+(433,376,o),
+(603,376,cs),
+(639,376,l),
+(706,690,l),
+(644,690,l),
+(584,409,l),
+(632,432,l),
+(604,432,ls),
+(397,432,o),
+(272,328,o),
+(224,108,cs),
+(206,25,l),
+(250,43,l),
+(63,234,l),
+(19,191,l),
+(207,0,l)
+);
+}
+);
+width = 690;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB9;
+kernRight = soright;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB8;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (515,0);
+ref = dot_top;
+}
+);
+width = 690;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABA;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (209,690);
+},
+{
+name = top_right_can;
+pos = (507,690);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(385,0,l),
+(652,191,l),
+(620,237,l),
+(366,56,l),
+(398,38,l),
+(410,92,ls),
+(451,293,o),
+(354,432,o),
+(169,432,cs),
+(144,432,l),
+(180,406,l),
+(240,690,l),
+(179,690,l),
+(111,376,l),
+(145,376,ls),
+(318,376,o),
+(388,272,o),
+(347,83,cs),
+(329,0,l)
+);
+}
+);
+width = 691;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABB;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = uni11ABA;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+}
+);
+width = 690;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABC;
+lastChange = "2023-01-13 15:55:06 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(443,0,l),
+(455,56,l),
+(71,56,l),
+(71,29,l),
+(589,645,l),
+(599,690,l),
+(151,690,l),
+(139,634,l),
+(524,634,l),
+(524,661,l),
+(5,44,l),
+(-5,0,l)
+);
+}
+);
+width = 547;
+}
+);
+metricRight = "=|";
+},
+{
+color = 8;
+glyphname = uni11ABD;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(452,0,l),
+(462,44,l),
+(195,661,l),
+(194,634,l),
+(579,634,l),
+(590,690,l),
+(142,690,l),
+(132,645,l),
+(400,29,l),
+(400,56,l),
+(15,56,l),
+(4,0,l)
+);
+}
+);
+width = 548;
+}
+);
+metricLeft = "=|uni11ABC";
+metricRight = "=|uni11ABC";
+},
+{
+color = 8;
+glyphname = uni11ABE;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(92,0,l),
+(225,628,l),
+(194,628,l),
+(460,0,l),
+(515,0,l),
+(662,690,l),
+(601,690,l),
+(468,62,l),
+(497,62,l),
+(233,690,l),
+(177,690,l),
+(30,0,l)
+);
+}
+);
+width = 645;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABF;
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(86,0,l),
+(630,632,l),
+(588,632,l),
+(454,0,l),
+(515,0,l),
+(662,690,l),
+(607,690,l),
+(62,58,l),
+(104,58,l),
+(239,690,l),
+(177,690,l),
+(30,0,l)
+);
+}
+);
+width = 645;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = "raiseddoubledotFinal-canadian.cree";
+lastChange = "2023-01-13 15:55:03 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(222,615,o),
+(241,635,o),
+(241,659,cs),
+(241,683,o),
+(222,702,o),
+(197,702,cs),
+(173,702,o),
+(155,683,o),
+(155,659,cs),
+(155,635,o),
+(173,615,o),
+(197,615,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(185,442,o),
+(204,462,o),
+(204,486,cs),
+(204,510,o),
+(185,528,o),
+(161,528,cs),
+(136,528,o),
+(118,510,o),
+(118,486,cs),
+(118,462,o),
+(136,442,o),
+(161,442,cs)
+);
+}
+);
+width = 215;
+}
+);
+note = g725;
+}
+);
+instances = (
+{
+axesValues = (
+65,
+89,
+12
+);
+instanceInterpolations = {
+"DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4" = 1;
+};
+name = "RC L Italic";
+}
+);
+kerningLTR = {
+"DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4" = {
+"@MMK_L_caright" = {
+"@MMK_R_ecanleft" = -77.28;
+"@MMK_R_mwestleft" = -27.048;
+"@MMK_R_neleft" = -61.824;
+};
+"@MMK_L_ciright" = {
+"@MMK_R_icanleft" = -77.28;
+"@MMK_R_noleft" = -104.328;
+};
+"@MMK_L_ecanright" = {
+"@MMK_R_coleft" = -77.28;
+"@MMK_R_moleft" = -79.212;
+"@MMK_R_sileft" = -47.334;
+};
+"@MMK_L_icanright" = {
+"@MMK_R_celeft" = -77.28;
+"@MMK_R_meleft" = -79.212;
+"@MMK_R_mwestleft" = -62.79;
+"@MMK_R_saleft" = -41.538;
+"she-canadian" = -79.212;
+};
+"@MMK_L_maright" = {
+"@MMK_R_acanleft" = -80.178;
+"@MMK_R_ecanleft" = -79.212;
+"@MMK_R_mwestleft" = -52.164;
+"@MMK_R_neleft" = -61.824;
+};
+"@MMK_L_miright" = {
+"@MMK_R_acanleft" = -80.178;
+"@MMK_R_icanleft" = -79.212;
+"@MMK_R_moleft" = -102.396;
+"@MMK_R_noleft" = -104.328;
+"@MMK_R_yeleft" = -105.294;
+};
+"@MMK_L_mwestright" = {
+"@MMK_R_coleft" = -27.048;
+"@MMK_R_icanleft" = -62.79;
+"@MMK_R_moleft" = -52.164;
+"@MMK_R_noleft" = -82.11;
+"@MMK_R_sileft" = -17.388;
+"@MMK_R_yeleft" = -28.98;
+};
+"@MMK_L_naright" = {
+"@MMK_R_acanleft" = -98.532;
+"@MMK_R_celeft" = -104.328;
+"@MMK_R_meleft" = -104.328;
+"@MMK_R_mwestleft" = -82.11;
+"@MMK_R_neleft" = -123.648;
+"@MMK_R_saleft" = -79.212;
+};
+"@MMK_L_niright" = {
+"@MMK_R_coleft" = -61.824;
+"@MMK_R_moleft" = -61.824;
+"@MMK_R_noleft" = -123.648;
+"@MMK_R_sileft" = -5.796;
+};
+"@MMK_L_ocanright" = {
+"@MMK_R_meleft" = -80.178;
+"@MMK_R_moleft" = -80.178;
+"@MMK_R_noleft" = -98.532;
+};
+"@MMK_L_seright" = {
+"@MMK_R_ecanleft" = -47.334;
+"@MMK_R_mwestleft" = -17.388;
+"@MMK_R_neleft" = -3.864;
+};
+"@MMK_L_soright" = {
+"@MMK_R_icanleft" = -41.538;
+"@MMK_R_noleft" = -79.212;
+};
+"@MMK_L_yiright" = {
+"@MMK_R_meleft" = -105.294;
+"@MMK_R_mwestleft" = -28.98;
+};
+"shi-canadian" = {
+"@MMK_R_icanleft" = -79.212;
+};
+};
+};
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "italic angle";
+}
+);
+properties = (
+{
+key = copyrights;
+values = (
+{
+language = ENG;
+value = "Copyright 2018 Google Inc. All Rights Reserved.";
+}
+);
+},
+{
+key = manufacturers;
+values = (
+{
+language = ENG;
+value = "Monotype Imaging Inc.";
+}
+);
+},
+{
+key = designers;
+values = (
+{
+language = ENG;
+value = "Monotype Design Team";
+}
+);
+},
+{
+key = description;
+value = "Designed by Monotype design team.";
+},
+{
+key = trademarks;
+values = (
+{
+language = ENG;
+value = "Noto is a trademark of Google Inc.";
+}
+);
+},
+{
+key = licenseURL;
+value = "http://scripts.sil.org/OFL";
+},
+{
+key = licenses;
+values = (
+{
+language = ENG;
+value = "This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.";
+}
+);
+},
+{
+key = manufacturerURL;
+value = "http://www.google.com/get/noto/";
+},
+{
+key = designerURL;
+value = "http://www.monotype.com/studio";
+}
+);
+settings = {
+disablesNiceNames = 1;
+};
+stems = (
+{
+name = "New Stem";
+}
+);
+unitsPerEm = 966;
+userData = {
+GSDontShowVersionAlert = 1;
+};
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/sources/Exported instances UCAS SansCanadianAboriginal Resized/Sans Canadian Aboriginal-RC L roman.glyphs
+++ b/sources/Exported instances UCAS SansCanadianAboriginal Resized/Sans Canadian Aboriginal-RC L roman.glyphs
@@ -1,0 +1,37333 @@
+{
+.appVersion = "3151";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+},
+{
+name = Width;
+tag = wdth;
+},
+{
+name = Slant;
+tag = slnt;
+}
+);
+classes = (
+{
+code = "zero one two three four five six seven eight nine ";
+name = Num;
+},
+{
+code = "zero.canadian one.canadian two.canadian three.canadian four.canadian five.canadian six.canadian seven.canadian eight.canadian nine.canadian 
+";
+name = Num_can;
+},
+{
+code = "ke-canadian.square ki-canadian.square kii-canadian.square ko-canadian.square koo-canadian.square ka-canadian.square kaa-canadian.square kweWestCree-canadian.square kwiiWestCree-canadian.square kwoWestCree-canadian.square kwooWestCree-canadian.square kwaWestCree-canadian.square kwaaWestCree-canadian.square ce-canadian.square ci-canadian.square cii-canadian.square co-canadian.square coo-canadian.square ca-canadian.square caa-canadian.square me-canadian.square mi-canadian.square mii-canadian.square mo-canadian.square moo-canadian.square ma-canadian.square maa-canadian.square ne-canadian.square ni-canadian.square nii-canadian.square no-canadian.square noo-canadian.square na-canadian.square naa-canadian.square nweWestCree-canadian.square nwaWestCree-canadian.square nwaaWestCree-canadian.square se-canadian.square si-canadian.square sii-canadian.square so-canadian.square soo-canadian.square sa-canadian.square saa-canadian.square sho-canadian.square shoo-canadian.square sha-canadian.square shaa-canadian.square ye-canadian.square yi-canadian.square yii-canadian.square yo-canadian.square yoo-canadian.square ya-canadian.square yaa-canadian.square re-canadian.square reRCree-canadian.square leWestCree-canadian.square ri-canadian.square rii-canadian.square ro-canadian.square loWestCree-canadian.square ra-canadian.square raa-canadian.square laWestCree-canadian.square reWestCree-canadian.square riWestCree-canadian.square roWestCree-canadian.square raWestCree-canadian.square theThCree-canadian.square thiThCree-canadian.square thiiThCree-canadian.square thoThCree-canadian.square thooThCree-canadian.square thaThCree-canadian.square thaaThCree-canadian.square thweeWoodScree-canadian.square thwiWoodScree-canadian.square thwiiWoodScree-canadian.square thwoWoodScree-canadian.square thwooWoodScree-canadian.square thwaWoodScree-canadian.square thwaaWoodScree-canadian.square nwiOjibway-canadian.square nwiiOjibway-canadian.square nwoOjibway-canadian.square nwooOjibway-canadian.square looWestCree-canadian.square laaWestCree-canadian.square ";
+name = Dene_square;
+},
+{
+code = "ke-canadian ki-canadian kii-canadian ko-canadian koo-canadian ka-canadian kaa-canadian kweWestCree-canadian kwiiWestCree-canadian kwoWestCree-canadian kwooWestCree-canadian kwaWestCree-canadian kwaaWestCree-canadian ce-canadian ci-canadian cii-canadian co-canadian coo-canadian ca-canadian caa-canadian me-canadian mi-canadian mii-canadian mo-canadian moo-canadian ma-canadian maa-canadian ne-canadian ni-canadian nii-canadian no-canadian noo-canadian na-canadian naa-canadian nweWestCree-canadian nwaWestCree-canadian nwaaWestCree-canadian se-canadian si-canadian sii-canadian so-canadian soo-canadian sa-canadian saa-canadian sho-canadian shoo-canadian sha-canadian shaa-canadian ye-canadian yi-canadian yii-canadian yo-canadian yoo-canadian ya-canadian yaa-canadian re-canadian reRCree-canadian leWestCree-canadian ri-canadian rii-canadian ro-canadian loWestCree-canadian ra-canadian raa-canadian laWestCree-canadian reWestCree-canadian riWestCree-canadian roWestCree-canadian raWestCree-canadian theThCree-canadian thiThCree-canadian thiiThCree-canadian thoThCree-canadian thooThCree-canadian thaThCree-canadian thaaThCree-canadian thweeWoodScree-canadian thwiWoodScree-canadian thwiiWoodScree-canadian thwoWoodScree-canadian thwooWoodScree-canadian thwaWoodScree-canadian thwaaWoodScree-canadian nwiOjibway-canadian nwiiOjibway-canadian nwoOjibway-canadian nwooOjibway-canadian looWestCree-canadian laaWestCree-canadian 
+";
+name = Dene_round;
+},
+{
+code = "acuteFinal-canadian.mid graveFinal-canadian.mid ringTophalfFinal-canadian.mid ringRighthalfFinal-canadian.mid ringFinal-canadian.mid doubleacuteFinal-canadian.mid doubleshortverticalstrokesFinal-canadian.mid shorthorizontalstrokeFinal-canadian.mid downtackFinal-canadian.mid pWestCree-canadian.mid c-canadian.mid mWestCree-canadian.mid ";
+name = Final_mid;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian ringFinal-canadian doubleacuteFinal-canadian doubleshortverticalstrokesFinal-canadian shorthorizontalstrokeFinal-canadian downtackFinal-canadian pWestCree-canadian c-canadian mWestCree-canadian ";
+name = Final_mid_ori;
+},
+{
+code = "acuteFinal-canadian.base graveFinal-canadian.base ringBottomhalfFinal-canadian.base ringTophalfFinal-canadian.base ringRighthalfFinal-canadian.base plusFinal-canadian.base pWestCree-canadian.base c-canadian.base thSayisi-canadian.base mWestCree-canadian.base ";
+name = Final_base;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringBottomhalfFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian plusFinal-canadian pWestCree-canadian c-canadian thSayisi-canadian mWestCree-canadian ";
+name = Final_base_ori;
+},
+{
+code = "ng-canadian ngai-canadian ngaai-canadian ngi-canadian ngii-canadian ngo-canadian ngoo-canadian nga-canadian ngaa-canadian ";
+name = Nunavik;
+},
+{
+code = "ng-canadian.nunavik ngai-canadian.nunavik ngaai-canadian.nunavik ngi-canadian.nunavik ngii-canadian.nunavik ngo-canadian.nunavik ngoo-canadian.nunavik nga-canadian.nunavik ngaa-canadian.nunavik ";
+name = Nunavik_alt;
+}
+);
+customParameters = (
+{
+name = vendorID;
+value = GOOG;
+},
+{
+name = panose;
+value = (
+2,
+11,
+5,
+2,
+4,
+5,
+4,
+2,
+2,
+4
+);
+},
+{
+name = unicodeRanges;
+value = (
+0,
+1,
+2,
+5,
+6,
+45,
+77
+);
+},
+{
+name = codePageRanges;
+value = (
+"1252"
+);
+},
+{
+name = fsType;
+value = (
+);
+}
+);
+date = "2022-06-21 10:06:40 +0000";
+familyName = "Sans Canadian Aboriginal";
+featurePrefixes = (
+{
+automatic = 1;
+code = "languagesystem DFLT dflt;
+
+languagesystem cans dflt;
+";
+name = Languagesystems;
+}
+);
+features = (
+{
+automatic = 1;
+code = "feature ss01;
+feature ss02;
+feature ss03;
+feature ss04;
+";
+tag = aalt;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+tag = salt;
+},
+{
+code = "lookup space_can {
+sub space by space.canadian;
+} space_can;
+
+lookup num_can {
+sub @Num by @Num_can;
+} num_can;
+";
+labels = (
+{
+language = dflt;
+value = "CAN Space and numerals";
+}
+);
+tag = ss01;
+},
+{
+code = "lookup dene_square {
+sub @Dene_round by @Dene_square;
+} dene_square;
+
+";
+labels = (
+{
+language = dflt;
+value = "Dene Square";
+}
+);
+tag = ss02;
+},
+{
+code = "lookup nunavik_alt {
+sub @Nunavik by @Nunavik_alt;
+} nunavik_alt;
+
+";
+labels = (
+{
+language = dflt;
+value = "Nunanvik Alt";
+}
+);
+tag = ss03;
+},
+{
+code = "lookup final_mid {
+sub @Final_mid_ori by @Final_mid;
+} final_mid;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final mid";
+}
+);
+tag = ss04;
+},
+{
+code = "lookup final_base {
+sub @Final_base_ori by @Final_base;
+} final_base;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final base";
+}
+);
+tag = ss05;
+},
+{
+code = "lookup plaincree_first {
+sub wiWestCree-canadian' plusFinal-canadian by i-canadian;
+} plaincree_first;
+
+lookup plaincree_second {
+sub i-canadian plusFinal-canadian' by raiseddoubledotFinal-canadian.cree;
+} plaincree_second;
+
+lookup plaincree_third {
+sub middledotFinal-canadian plusFinal-canadian by raiseddoubledotFinal-canadian.cree;
+} plaincree_third;
+";
+labels = (
+{
+language = dflt;
+value = Plaincree;
+}
+);
+tag = ss06;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+labels = (
+{
+language = dflt;
+value = "";
+}
+);
+tag = ss07;
+}
+);
+fontMaster = (
+{
+axesValues = (
+0,
+0,
+0
+);
+customParameters = (
+{
+name = typoAscender;
+value = 1033;
+},
+{
+name = typoDescender;
+value = -283;
+},
+{
+name = typoLineGap;
+value = 0;
+},
+{
+name = winAscent;
+value = 1033;
+},
+{
+name = winDescent;
+value = 283;
+},
+{
+name = hheaAscender;
+value = 1033;
+},
+{
+name = hheaDescender;
+value = -283;
+},
+{
+name = strikeoutPosition;
+value = 283;
+},
+{
+name = strikeoutSize;
+value = 48;
+}
+);
+guides = (
+{
+lockAngle = 1;
+locked = 1;
+pos = (222,345);
+}
+);
+id = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+metricValues = (
+{
+over = 16;
+pos = 1033;
+},
+{
+over = 16;
+pos = 690;
+},
+{
+over = 16;
+pos = 472;
+},
+{
+over = -16;
+},
+{
+over = -16;
+pos = -283;
+},
+{
+}
+);
+name = "RC L roman";
+stemValues = (
+62
+);
+}
+);
+glyphs = (
+{
+glyphname = idotless;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(136,516,l),
+(75,516,l),
+(75,0,l),
+(136,0,l)
+);
+}
+);
+width = 212;
+}
+);
+note = dotlessi;
+unicode = 305;
+},
+{
+glyphname = "acuteFinal-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,345,l),
+(250,690,l),
+(199,690,l),
+(46,345,l)
+);
+}
+);
+width = 296;
+}
+);
+metricRight = "=|";
+note = uni141F;
+unicode = 5151;
+},
+{
+glyphname = "graveFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(250,345,l),
+(97,690,l),
+(46,690,l),
+(199,345,l)
+);
+}
+);
+width = 296;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+unicode = 5152;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(291,339,o),
+(343,394,o),
+(343,495,cs),
+(343,690,l),
+(297,690,l),
+(297,494,ls),
+(297,416,o),
+(265,382,o),
+(206,382,cs),
+(147,382,o),
+(114,418,o),
+(114,494,cs),
+(114,690,l),
+(68,690,l),
+(68,493,ls),
+(68,395,o),
+(121,339,o),
+(205,339,cs)
+);
+}
+);
+width = 411;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1421;
+unicode = 5153;
+},
+{
+glyphname = "ringTophalfFinal-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(114,345,l),
+(114,541,ls),
+(114,616,o),
+(147,653,o),
+(206,653,cs),
+(265,653,o),
+(297,618,o),
+(297,541,cs),
+(297,345,l),
+(343,345,l),
+(343,540,ls),
+(343,640,o),
+(291,696,o),
+(205,696,cs),
+(121,696,o),
+(68,639,o),
+(68,542,cs),
+(68,345,l)
+);
+}
+);
+width = 411;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+unicode = 5154;
+},
+{
+glyphname = "ringRighthalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(128,345,ls),
+(235,345,o),
+(295,411,o),
+(295,517,cs),
+(295,624,o),
+(235,690,o),
+(127,690,cs),
+(63,690,l),
+(63,647,l),
+(126,647,ls),
+(207,647,o),
+(248,600,o),
+(248,517,cs),
+(248,434,o),
+(207,387,o),
+(126,387,cs),
+(63,387,l),
+(63,345,l)
+);
+}
+);
+width = 361;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+unicode = 5155;
+},
+{
+glyphname = "ringFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(334,359,o),
+(407,431,o),
+(407,527,cs),
+(407,624,o),
+(333,696,o),
+(236,696,cs),
+(139,696,o),
+(66,624,o),
+(66,527,cs),
+(66,431,o),
+(137,359,o),
+(236,359,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(161,399,o),
+(109,453,o),
+(109,527,cs),
+(109,602,o),
+(162,655,o),
+(236,655,cs),
+(309,655,o),
+(363,602,o),
+(363,527,cs),
+(363,453,o),
+(310,399,o),
+(236,399,cs)
+);
+}
+);
+width = 472;
+}
+);
+note = uni1424;
+unicode = 5156;
+},
+{
+glyphname = "doubleacuteFinal-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(250,690,l),
+(199,690,l),
+(46,345,l),
+(97,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(381,690,l),
+(330,690,l),
+(178,345,l),
+(228,345,l)
+);
+}
+);
+width = 427;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricRight = "=|";
+note = uni1425;
+unicode = 5157;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(114,690,l),
+(68,690,l),
+(68,345,l),
+(114,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(232,690,l),
+(185,690,l),
+(185,345,l),
+(232,345,l)
+);
+}
+);
+width = 300;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "pWestCree-canadian";
+note = uni1426;
+unicode = 5158;
+},
+{
+glyphname = "middledotFinal-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(130,311,o),
+(150,330,o),
+(150,355,cs),
+(150,379,o),
+(130,398,o),
+(106,398,cs),
+(82,398,o),
+(64,379,o),
+(64,355,cs),
+(64,330,o),
+(82,311,o),
+(106,311,cs)
+);
+}
+);
+width = 213;
+}
+);
+note = uni1427;
+unicode = 5159;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(376,498,l),
+(376,544,l),
+(66,544,l),
+(66,498,l)
+);
+}
+);
+width = 442;
+}
+);
+metricRight = "=|";
+note = uni1428;
+unicode = 5160;
+},
+{
+glyphname = "plusFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(243,366,l),
+(243,507,l),
+(376,507,l),
+(376,552,l),
+(243,552,l),
+(243,690,l),
+(199,690,l),
+(199,552,l),
+(66,552,l),
+(66,507,l),
+(199,507,l),
+(199,366,l)
+);
+}
+);
+width = 442;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+unicode = 5161;
+},
+{
+glyphname = "downtackFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(244,345,l),
+(244,646,l),
+(376,646,l),
+(376,690,l),
+(66,690,l),
+(66,646,l),
+(198,646,l),
+(198,345,l)
+);
+}
+);
+width = 442;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni142A;
+unicode = 5162;
+},
+{
+glyphname = "thFinalWoodScree-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(246,345,l),
+(246,430,l),
+(378,430,l),
+(378,469,l),
+(246,469,l),
+(246,565,l),
+(378,565,l),
+(378,605,l),
+(246,605,l),
+(246,690,l),
+(201,690,l),
+(201,605,l),
+(68,605,l),
+(68,565,l),
+(201,565,l),
+(201,469,l),
+(68,469,l),
+(68,430,l),
+(201,430,l),
+(201,345,l)
+);
+}
+);
+width = 446;
+}
+);
+metricLeft = "hyphen-canadian";
+metricRight = "hyphen-canadian";
+note = uni167E;
+unicode = 5758;
+},
+{
+glyphname = "ringSmallFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(217,511,o),
+(261,551,o),
+(261,607,cs),
+(261,663,o),
+(217,702,o),
+(164,702,cs),
+(111,702,o),
+(68,663,o),
+(68,607,cs),
+(68,551,o),
+(111,511,o),
+(164,511,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(127,545,o),
+(102,571,o),
+(102,607,cs),
+(102,642,o),
+(128,669,o),
+(164,669,cs),
+(201,669,o),
+(225,642,o),
+(225,607,cs),
+(225,571,o),
+(202,545,o),
+(164,545,cs)
+);
+}
+);
+width = 328;
+}
+);
+note = g725;
+unicode = 6366;
+},
+{
+glyphname = "raiseddotFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(132,615,o),
+(151,635,o),
+(151,659,cs),
+(151,683,o),
+(132,702,o),
+(108,702,cs),
+(83,702,o),
+(65,683,o),
+(65,659,cs),
+(65,635,o),
+(83,615,o),
+(108,615,cs)
+);
+}
+);
+width = 215;
+}
+);
+note = g725;
+unicode = 6367;
+},
+{
+glyphname = "acuteFinal-canadian.base";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "acuteFinal-canadian";
+}
+);
+width = 296;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.base";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "graveFinal-canadian";
+}
+);
+width = 296;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian.base";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 411;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1421;
+},
+{
+glyphname = "ringTophalfFinal-canadian.base";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 411;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.base";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 361;
+}
+);
+metricLeft = "==|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "plusFinal-canadian.base";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(243,0,l),
+(243,141,l),
+(376,141,l),
+(376,185,l),
+(243,185,l),
+(243,324,l),
+(199,324,l),
+(199,185,l),
+(66,185,l),
+(66,141,l),
+(199,141,l),
+(199,0,l)
+);
+}
+);
+width = 442;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+},
+{
+glyphname = "acuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "acuteFinal-canadian";
+}
+);
+width = 296;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.mid";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "graveFinal-canadian";
+}
+);
+width = 296;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringTophalfFinal-canadian.mid";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-172);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 411;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.mid";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 361;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "ringFinal-canadian.mid";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-183);
+ref = "ringFinal-canadian";
+}
+);
+width = 472;
+}
+);
+metricLeft = "ringFinal-canadian";
+metricWidth = "ringFinal-canadian";
+note = uni1424;
+},
+{
+glyphname = "doubleacuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "doubleacuteFinal-canadian";
+}
+);
+width = 427;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "doubleacuteFinal-canadian";
+note = uni1425;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian.mid";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "doubleshortverticalstrokesFinal-canadian";
+}
+);
+width = 300;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricWidth = "doubleshortverticalstrokesFinal-canadian";
+note = uni1426;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian.mid";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-167);
+ref = "shorthorizontalstrokeFinal-canadian";
+}
+);
+width = 442;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "shorthorizontalstrokeFinal-canadian";
+note = uni1428;
+},
+{
+glyphname = "downtackFinal-canadian.mid";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "downtackFinal-canadian";
+}
+);
+width = 442;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "downtackFinal-canadian";
+note = uni142A;
+},
+{
+glyphname = "e-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (342,454);
+},
+{
+name = top_center_can;
+pos = (342,690);
+},
+{
+name = top_left_can;
+pos = (121,690);
+},
+{
+name = top_right_can;
+pos = (564,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(359,0,l),
+(655,670,l),
+(655,690,l),
+(36,690,l),
+(36,670,l),
+(331,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(356,71,l),
+(105,654,l),
+(99,638,l),
+(592,638,l),
+(587,654,l),
+(336,71,l)
+);
+}
+);
+width = 691;
+}
+);
+metricRight = "=|";
+note = uni1401;
+unicode = 5121;
+},
+{
+glyphname = "aai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (225,0);
+ref = ring_top.canadian;
+}
+);
+width = 691;
+}
+);
+note = uni1402;
+unicode = 5122;
+},
+{
+glyphname = "i-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (345,403);
+},
+{
+name = top_center_can;
+pos = (346,690);
+},
+{
+name = top_left_can;
+pos = (122,690);
+},
+{
+name = top_right_can;
+pos = (564,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(655,0,l),
+(655,19,l),
+(359,690,l),
+(331,690,l),
+(36,19,l),
+(36,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(355,619,l),
+(334,619,l),
+(586,36,l),
+(592,52,l),
+(99,52,l),
+(103,36,l)
+);
+}
+);
+width = 691;
+}
+);
+metricLeft = "e-canadian";
+metricWidth = "e-canadian";
+note = uni1403;
+unicode = 5123;
+},
+{
+glyphname = "ii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (284,0);
+ref = dot_top;
+}
+);
+width = 691;
+}
+);
+note = uni1404;
+unicode = 5124;
+},
+{
+glyphname = "o-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (269,345);
+},
+{
+name = top_center_can;
+pos = (354,690);
+},
+{
+name = top_double;
+pos = (439,690);
+},
+{
+name = top_left_can;
+pos = (107,690);
+},
+{
+name = top_right_can;
+pos = (592,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,0,l),
+(629,331,l),
+(629,358,l),
+(99,690,l),
+(80,690,l),
+(80,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(134,620,l),
+(117,618,l),
+(569,334,l),
+(569,356,l),
+(117,72,l),
+(134,70,l)
+);
+}
+);
+width = 665;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1405;
+unicode = 5125;
+},
+{
+glyphname = "oo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (45,0);
+ref = dot_top;
+}
+);
+width = 665;
+}
+);
+note = uni1406;
+unicode = 5126;
+},
+{
+glyphname = "yCreeoo-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (220,0);
+ref = doubledot_top;
+}
+);
+width = 665;
+}
+);
+note = uni1407;
+unicode = 5127;
+},
+{
+glyphname = "eeCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,0,l),
+(629,331,l),
+(629,358,l),
+(99,690,l),
+(80,690,l),
+(80,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(133,620,l),
+(117,619,l),
+(569,336,l),
+(569,355,l),
+(117,71,l),
+(133,70,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(283,439,l),
+(253,439,l),
+(253,251,l),
+(283,251,l)
+);
+}
+);
+width = 665;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "o-canadian";
+note = uni1408;
+unicode = 5128;
+},
+{
+glyphname = "iCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (215,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 665;
+}
+);
+note = uni1409;
+unicode = 5129;
+},
+{
+glyphname = "a-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (390,345);
+},
+{
+name = top_center_can;
+pos = (307,690);
+},
+{
+name = top_left_can;
+pos = (65,690);
+},
+{
+name = top_right_can;
+pos = (557,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(584,0,l),
+(584,690,l),
+(565,690,l),
+(37,358,l),
+(37,331,l),
+(565,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(548,71,l),
+(96,355,l),
+(96,334,l),
+(547,618,l),
+(530,621,l),
+(530,69,l)
+);
+}
+);
+width = 664;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni140A;
+unicode = 5130;
+},
+{
+glyphname = "aa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (496,0);
+ref = dot_top;
+}
+);
+width = 665;
+}
+);
+note = uni140B;
+unicode = 5131;
+},
+{
+glyphname = "we-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "e-canadian";
+}
+);
+width = 903;
+}
+);
+note = uni140C;
+unicode = 5132;
+},
+{
+glyphname = "weWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (691,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 903;
+}
+);
+note = uni140D;
+unicode = 5133;
+},
+{
+glyphname = "wi-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "i-canadian";
+}
+);
+width = 903;
+}
+);
+note = uni140E;
+unicode = 5134;
+},
+{
+glyphname = "wiWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (691,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 903;
+}
+);
+note = uni140F;
+unicode = 5135;
+},
+{
+glyphname = "wii-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (497,0);
+ref = dot_top;
+}
+);
+width = 903;
+}
+);
+note = uni1410;
+unicode = 5136;
+},
+{
+glyphname = "wiiWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (284,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (691,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 903;
+}
+);
+note = uni1411;
+unicode = 5137;
+},
+{
+glyphname = "wo-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "o-canadian";
+}
+);
+width = 878;
+}
+);
+note = uni1412;
+unicode = 5138;
+},
+{
+glyphname = "woWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (665,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 878;
+}
+);
+note = uni1413;
+unicode = 5139;
+},
+{
+glyphname = "woo-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (504,0);
+ref = dot_top;
+}
+);
+width = 878;
+}
+);
+note = uni1414;
+unicode = 5140;
+},
+{
+glyphname = "wooWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (45,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (665,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 878;
+}
+);
+note = uni1415;
+unicode = 5141;
+},
+{
+glyphname = "wooNaskapi-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (214,-96);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (385,-201);
+ref = dot_top;
+}
+);
+width = 665;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricWidth = "o-canadian";
+note = uni1416;
+unicode = 5142;
+},
+{
+glyphname = "wa-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "a-canadian";
+}
+);
+width = 878;
+}
+);
+note = uni1417;
+unicode = 5143;
+},
+{
+glyphname = "waWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (665,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 878;
+}
+);
+note = uni1418;
+unicode = 5144;
+},
+{
+glyphname = "waa-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (708,0);
+ref = dot_top;
+}
+);
+width = 878;
+}
+);
+note = uni1419;
+unicode = 5145;
+},
+{
+glyphname = "waaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (496,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (665,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 878;
+}
+);
+note = uni141A;
+unicode = 5146;
+},
+{
+glyphname = "waaNaskapi-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (156,-201);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (327,-96);
+ref = dot_top;
+}
+);
+width = 664;
+}
+);
+metricWidth = "a-canadian";
+note = uni141B;
+unicode = 5147;
+},
+{
+glyphname = "ai-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(261,339,o),
+(301,374,o),
+(317,439,c),
+(300,439,l),
+(317,373,o),
+(359,339,o),
+(420,339,cs),
+(499,339,o),
+(551,390,o),
+(551,493,cs),
+(551,690,l),
+(506,690,l),
+(506,493,ls),
+(506,411,o),
+(472,380,o),
+(419,380,cs),
+(366,380,o),
+(331,412,o),
+(331,492,cs),
+(331,690,l),
+(287,690,l),
+(287,493,ls),
+(287,411,o),
+(252,380,o),
+(199,380,cs),
+(146,380,o),
+(112,412,o),
+(112,492,cs),
+(112,690,l),
+(68,690,l),
+(68,491,ls),
+(68,390,o),
+(121,339,o),
+(198,339,cs)
+);
+}
+);
+width = 619;
+}
+);
+metricRight = "=|";
+note = uni141C;
+unicode = 5148;
+},
+{
+glyphname = "ycreew-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(345,510,o),
+(381,549,o),
+(381,603,cs),
+(381,658,o),
+(345,696,o),
+(297,696,cs),
+(249,696,o),
+(213,658,o),
+(213,603,cs),
+(213,549,o),
+(249,510,o),
+(297,510,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(198,339,o),
+(234,378,o),
+(234,432,cs),
+(234,487,o),
+(198,525,o),
+(151,525,cs),
+(102,525,o),
+(67,487,o),
+(67,432,cs),
+(67,378,o),
+(102,339,o),
+(150,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(118,367,o),
+(96,393,o),
+(96,432,cs),
+(96,470,o),
+(118,497,o),
+(150,497,cs),
+(182,497,o),
+(204,470,o),
+(204,432,cs),
+(204,393,o),
+(182,367,o),
+(150,367,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(265,538,o),
+(242,564,o),
+(242,603,cs),
+(242,641,o),
+(265,668,o),
+(297,668,cs),
+(328,668,o),
+(351,641,o),
+(351,603,cs),
+(351,564,o),
+(328,538,o),
+(297,538,cs)
+);
+}
+);
+width = 448;
+}
+);
+metricRight = "=|";
+note = uni141D;
+unicode = 5149;
+},
+{
+glyphname = "glottalstop-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(371,345,l),
+(371,356,l),
+(224,690,l),
+(209,690,l),
+(61,356,l),
+(61,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(229,649,l),
+(204,649,l),
+(327,363,l),
+(338,382,l),
+(95,382,l),
+(104,363,l)
+);
+}
+);
+width = 432;
+}
+);
+metricRight = "=|";
+note = uni141E;
+unicode = 5150;
+},
+{
+glyphname = "en-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+pos = (691,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 986;
+}
+);
+note = uni142B;
+unicode = 5163;
+},
+{
+glyphname = "in-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+pos = (481,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 777;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142C;
+unicode = 5164;
+},
+{
+glyphname = "on-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (528,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 824;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142D;
+unicode = 5165;
+},
+{
+glyphname = "an-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (619,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 915;
+}
+);
+metricRight = "graveFinal-canadian";
+note = uni142E;
+unicode = 5166;
+},
+{
+glyphname = "pe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (342,454);
+},
+{
+name = top_center_can;
+pos = (342,690);
+},
+{
+name = top_left_can;
+pos = (121,690);
+},
+{
+name = top_right_can;
+pos = (564,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(359,0,l),
+(655,670,l),
+(655,690,l),
+(599,690,l),
+(331,72,l),
+(361,72,l),
+(94,690,l),
+(36,690,l),
+(36,670,l),
+(331,0,l)
+);
+}
+);
+width = 691;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni142F;
+unicode = 5167;
+},
+{
+glyphname = "paai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (225,0);
+ref = ring_top.canadian;
+}
+);
+width = 691;
+}
+);
+note = uni1430;
+unicode = 5168;
+},
+{
+glyphname = "pi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (343,403);
+},
+{
+name = top_center_can;
+pos = (346,690);
+},
+{
+name = top_left_can;
+pos = (124,690);
+},
+{
+name = top_right_can;
+pos = (567,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(92,0,l),
+(360,617,l),
+(330,617,l),
+(597,0,l),
+(655,0,l),
+(655,19,l),
+(359,690,l),
+(331,690,l),
+(36,19,l),
+(36,0,l)
+);
+}
+);
+width = 691;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni1431;
+unicode = 5169;
+},
+{
+glyphname = "pii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (284,0);
+ref = dot_top;
+}
+);
+width = 691;
+}
+);
+note = uni1432;
+unicode = 5170;
+},
+{
+glyphname = "po-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (220,345);
+},
+{
+name = top_center_can;
+pos = (327,690);
+},
+{
+name = top_double;
+pos = (418,690);
+},
+{
+name = top_left_can;
+pos = (85,690);
+},
+{
+name = top_right_can;
+pos = (563,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(76,0,l),
+(599,331,l),
+(599,358,l),
+(76,690,l),
+(57,690,l),
+(57,635,l),
+(536,330,l),
+(536,359,l),
+(57,56,l),
+(57,0,l)
+);
+}
+);
+width = 635;
+}
+);
+metricRight = "o-canadian";
+note = uni1433;
+unicode = 5171;
+},
+{
+glyphname = "poo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (23,0);
+ref = dot_top;
+}
+);
+width = 636;
+}
+);
+note = uni1434;
+unicode = 5172;
+},
+{
+glyphname = "ycreepoo-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (200,0);
+ref = doubledot_top;
+}
+);
+width = 636;
+}
+);
+note = uni1435;
+unicode = 5173;
+},
+{
+glyphname = "heeCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (185,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 636;
+}
+);
+note = uni1436;
+unicode = 5174;
+},
+{
+glyphname = "hiCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (162,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 636;
+}
+);
+note = uni1437;
+unicode = 5175;
+},
+{
+glyphname = "pa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (281,345);
+},
+{
+name = top_center_can;
+pos = (308,690);
+},
+{
+name = top_left_can;
+pos = (65,690);
+},
+{
+name = top_right_can;
+pos = (551,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(578,0,l),
+(578,55,l),
+(99,359,l),
+(99,330,l),
+(578,634,l),
+(578,690,l),
+(559,690,l),
+(37,358,l),
+(37,331,l),
+(559,0,l)
+);
+}
+);
+width = 635;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1438;
+unicode = 5176;
+},
+{
+glyphname = "paa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (488,0);
+ref = dot_top;
+}
+);
+width = 636;
+}
+);
+note = uni1439;
+unicode = 5177;
+},
+{
+glyphname = "pwe-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "pe-canadian";
+}
+);
+width = 903;
+}
+);
+note = uni143A;
+unicode = 5178;
+},
+{
+glyphname = "pweWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "pe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (691,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 903;
+}
+);
+note = uni143B;
+unicode = 5179;
+},
+{
+glyphname = "pwi-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "pi-canadian";
+}
+);
+width = 903;
+}
+);
+note = uni143C;
+unicode = 5180;
+},
+{
+glyphname = "pwiWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (691,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 903;
+}
+);
+note = uni143D;
+unicode = 5181;
+},
+{
+glyphname = "pwii-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (497,0);
+ref = dot_top;
+}
+);
+width = 903;
+}
+);
+note = uni143E;
+unicode = 5182;
+},
+{
+glyphname = "pwiiWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (284,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (691,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 903;
+}
+);
+note = uni143F;
+unicode = 5183;
+},
+{
+glyphname = "pwo-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "po-canadian";
+}
+);
+width = 848;
+}
+);
+note = uni1440;
+unicode = 5184;
+},
+{
+glyphname = "pwoWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (636,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 848;
+}
+);
+note = uni1441;
+unicode = 5185;
+},
+{
+glyphname = "pwoo-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (478,0);
+ref = dot_top;
+}
+);
+width = 848;
+}
+);
+note = uni1442;
+unicode = 5186;
+},
+{
+glyphname = "pwooWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (23,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (636,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 848;
+}
+);
+note = uni1443;
+unicode = 5187;
+},
+{
+glyphname = "pwa-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "pa-canadian";
+}
+);
+width = 848;
+}
+);
+note = uni1444;
+unicode = 5188;
+},
+{
+glyphname = "pwaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (636,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 848;
+}
+);
+note = uni1445;
+unicode = 5189;
+},
+{
+glyphname = "pwaa-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (701,0);
+ref = dot_top;
+}
+);
+width = 848;
+}
+);
+note = uni1446;
+unicode = 5190;
+},
+{
+glyphname = "pwaaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (488,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (636,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 848;
+}
+);
+note = uni1447;
+unicode = 5191;
+},
+{
+glyphname = "ycreepwaa-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+pos = (153,-201);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (324,-96);
+ref = dot_top;
+}
+);
+width = 635;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1448;
+unicode = 5192;
+},
+{
+glyphname = "p-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(337,345,l),
+(337,385,l),
+(106,533,l),
+(106,502,l),
+(337,648,l),
+(337,690,l),
+(325,690,l),
+(68,526,l),
+(68,509,l),
+(325,345,l)
+);
+}
+);
+width = 405;
+}
+);
+note = uni1449;
+unicode = 5193;
+},
+{
+glyphname = "pWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(114,345,l),
+(114,690,l),
+(68,690,l),
+(68,345,l)
+);
+}
+);
+width = 182;
+}
+);
+metricRight = "=|";
+note = uni144A;
+unicode = 5194;
+},
+{
+color = 6;
+glyphname = "hCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(114,183,l),
+(114,319,ls),
+(114,365,o),
+(141,392,o),
+(185,392,cs),
+(224,392,o),
+(245,367,o),
+(245,316,cs),
+(245,183,l),
+(292,183,l),
+(292,325,ls),
+(292,396,o),
+(249,434,o),
+(191,434,cs),
+(142,434,o),
+(104,404,o),
+(99,360,c),
+(114,355,l),
+(114,527,l),
+(68,527,l),
+(68,183,l)
+);
+}
+);
+width = 338;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144B;
+unicode = 5195;
+},
+{
+glyphname = "te-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (344,345);
+},
+{
+name = top_center_can;
+pos = (344,690);
+},
+{
+name = top_left_can;
+pos = (104,690);
+},
+{
+name = top_right_can;
+pos = (584,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(512,-13,o),
+(615,99,o),
+(615,293,cs),
+(615,690,l),
+(554,690,l),
+(554,290,ls),
+(554,129,o),
+(477,45,o),
+(344,45,cs),
+(214,45,o),
+(135,130,o),
+(135,290,cs),
+(135,690,l),
+(73,690,l),
+(73,289,ls),
+(73,98,o),
+(179,-13,o),
+(344,-13,cs)
+);
+}
+);
+width = 688;
+}
+);
+metricRight = "=|";
+note = uni144C;
+unicode = 5196;
+},
+{
+glyphname = "taai-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (224,0);
+ref = ring_top.canadian;
+}
+);
+width = 689;
+}
+);
+note = uni144D;
+unicode = 5197;
+},
+{
+glyphname = "ti-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (344,345);
+},
+{
+name = middle_right_can;
+pos = (774,345);
+},
+{
+name = top_center_can;
+pos = (344,690);
+},
+{
+name = top_left_can;
+pos = (104,690);
+},
+{
+name = top_right_can;
+pos = (584,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(135,0,l),
+(135,400,ls),
+(135,560,o),
+(213,644,o),
+(345,644,cs),
+(474,644,o),
+(554,559,o),
+(554,400,cs),
+(554,0,l),
+(615,0,l),
+(615,401,ls),
+(615,591,o),
+(511,702,o),
+(346,702,cs),
+(178,702,o),
+(73,592,o),
+(73,397,cs),
+(73,0,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni144E;
+unicode = 5198;
+},
+{
+glyphname = "tii-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (282,0);
+ref = dot_top;
+}
+);
+width = 689;
+}
+);
+note = uni144F;
+unicode = 5199;
+},
+{
+glyphname = "to-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (259,345);
+},
+{
+name = middle_right_can;
+pos = (676,345);
+},
+{
+name = top_center_can;
+pos = (264,690);
+},
+{
+name = top_double;
+pos = (318,690);
+},
+{
+name = top_left_can;
+pos = (87,690);
+},
+{
+name = top_right_can;
+pos = (491,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(203,0,ls),
+(406,0,o),
+(519,129,o),
+(519,346,cs),
+(519,562,o),
+(406,690,o),
+(199,690,cs),
+(59,690,l),
+(59,634,l),
+(199,634,ls),
+(369,634,o),
+(457,530,o),
+(457,346,cs),
+(457,161,o),
+(369,56,o),
+(201,56,cs),
+(59,56,l),
+(59,0,l)
+);
+}
+);
+width = 585;
+}
+);
+note = uni1450;
+unicode = 5200;
+},
+{
+glyphname = "too-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (202,0);
+ref = dot_top;
+}
+);
+width = 585;
+}
+);
+note = uni1451;
+unicode = 5201;
+},
+{
+glyphname = "ycreetoo-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (99,0);
+ref = doubledot_top;
+}
+);
+width = 585;
+}
+);
+note = uni1452;
+unicode = 5202;
+},
+{
+glyphname = "deeCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (219,0);
+ref = stroke_middle;
+}
+);
+width = 585;
+}
+);
+note = uni1453;
+unicode = 5203;
+},
+{
+glyphname = "diCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (196,0);
+ref = dot_middle;
+}
+);
+width = 585;
+}
+);
+note = uni1454;
+unicode = 5204;
+},
+{
+glyphname = "ta-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (326,345);
+},
+{
+name = top_center_can;
+pos = (322,690);
+},
+{
+name = top_left_can;
+pos = (94,690);
+},
+{
+name = top_right_can;
+pos = (497,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(525,0,l),
+(525,56,l),
+(385,56,ls),
+(215,56,o),
+(127,160,o),
+(127,345,cs),
+(127,529,o),
+(215,634,o),
+(384,634,cs),
+(525,634,l),
+(525,690,l),
+(384,690,ls),
+(179,690,o),
+(66,561,o),
+(66,345,cs),
+(66,128,o),
+(179,0,o),
+(383,0,cs)
+);
+}
+);
+width = 584;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|to-canadian";
+note = uni1455;
+unicode = 5205;
+},
+{
+glyphname = "taa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (261,0);
+ref = dot_top;
+}
+);
+width = 585;
+}
+);
+note = uni1456;
+unicode = 5206;
+},
+{
+glyphname = "twe-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "te-canadian";
+}
+);
+width = 901;
+}
+);
+note = uni1457;
+unicode = 5207;
+},
+{
+glyphname = "tweWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (689,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 901;
+}
+);
+note = uni1458;
+unicode = 5208;
+},
+{
+glyphname = "twi-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ti-canadian";
+}
+);
+width = 901;
+}
+);
+note = uni1459;
+unicode = 5209;
+},
+{
+glyphname = "twiWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (689,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 901;
+}
+);
+note = uni145A;
+unicode = 5210;
+},
+{
+glyphname = "twii-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (495,0);
+ref = dot_top;
+}
+);
+width = 901;
+}
+);
+note = uni145B;
+unicode = 5211;
+},
+{
+glyphname = "twiiWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (282,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (689,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 901;
+}
+);
+note = uni145C;
+unicode = 5212;
+},
+{
+glyphname = "two-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "to-canadian";
+}
+);
+width = 798;
+}
+);
+note = uni145D;
+unicode = 5213;
+},
+{
+glyphname = "twoWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (585,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 798;
+}
+);
+note = uni145E;
+unicode = 5214;
+},
+{
+glyphname = "twoo-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (414,0);
+ref = dot_top;
+}
+);
+width = 798;
+}
+);
+note = uni145F;
+unicode = 5215;
+},
+{
+glyphname = "twooWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (202,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (585,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 798;
+}
+);
+note = uni1460;
+unicode = 5216;
+},
+{
+glyphname = "twa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ta-canadian";
+}
+);
+width = 798;
+}
+);
+note = uni1461;
+unicode = 5217;
+},
+{
+glyphname = "twaWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (585,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 798;
+}
+);
+note = uni1462;
+unicode = 5218;
+},
+{
+glyphname = "twaa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (473,0);
+ref = dot_top;
+}
+);
+width = 798;
+}
+);
+note = uni1463;
+unicode = 5219;
+},
+{
+glyphname = "twaaWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (261,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (585,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 798;
+}
+);
+note = uni1464;
+unicode = 5220;
+},
+{
+glyphname = "twaaNaskapi-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ta-canadian";
+}
+);
+width = 799;
+}
+);
+note = uni1465;
+unicode = 5221;
+},
+{
+glyphname = "t-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(298,345,l),
+(298,387,l),
+(235,387,ls),
+(154,387,o),
+(112,433,o),
+(112,517,cs),
+(112,600,o),
+(154,647,o),
+(235,647,cs),
+(298,647,l),
+(298,690,l),
+(231,690,ls),
+(126,690,o),
+(66,624,o),
+(66,517,cs),
+(66,410,o),
+(126,345,o),
+(233,345,cs)
+);
+}
+);
+width = 361;
+}
+);
+note = uni1466;
+unicode = 5222;
+},
+{
+glyphname = "tte-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+pos = (689,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 869;
+}
+);
+note = uni1467;
+unicode = 5223;
+},
+{
+glyphname = "tti-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+pos = (689,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 869;
+}
+);
+note = uni1468;
+unicode = 5224;
+},
+{
+glyphname = "tto-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+pos = (585,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 767;
+}
+);
+note = uni1469;
+unicode = 5225;
+},
+{
+glyphname = "tta-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+pos = (585,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 767;
+}
+);
+note = uni146A;
+unicode = 5226;
+},
+{
+glyphname = "ke-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (302,441);
+},
+{
+name = top_center_can;
+pos = (281,690);
+},
+{
+name = top_left_can;
+pos = (99,690);
+},
+{
+name = top_right_can;
+pos = (464,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(495,0,l),
+(495,448,ls),
+(495,607,o),
+(414,702,o),
+(283,702,cs),
+(152,702,o),
+(68,607,o),
+(68,451,cs),
+(68,300,o),
+(151,206,o),
+(275,206,cs),
+(361,206,o),
+(425,257,o),
+(440,327,c),
+(433,341,l),
+(433,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(187,260,o),
+(128,330,o),
+(128,454,cs),
+(128,578,o),
+(186,648,o),
+(281,648,cs),
+(378,648,o),
+(434,579,o),
+(434,454,cs),
+(434,330,o),
+(376,260,o),
+(281,260,cs)
+);
+}
+);
+width = 568;
+}
+);
+metricRight = "te-canadian";
+note = uni146B;
+unicode = 5227;
+},
+{
+glyphname = "kaai-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (166,0);
+ref = ring_top.canadian;
+}
+);
+width = 568;
+}
+);
+note = uni146C;
+unicode = 5228;
+},
+{
+glyphname = "ki-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (307,441);
+},
+{
+name = top_center_can;
+pos = (286,690);
+},
+{
+name = top_left_can;
+pos = (104,690);
+},
+{
+name = top_right_can;
+pos = (469,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(135,0,l),
+(135,341,l),
+(128,327,l),
+(143,257,o),
+(207,206,o),
+(293,206,cs),
+(417,206,o),
+(500,301,o),
+(500,453,cs),
+(500,607,o),
+(416,702,o),
+(287,702,cs),
+(155,702,o),
+(73,607,o),
+(73,448,cs),
+(73,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(192,260,o),
+(134,330,o),
+(134,454,cs),
+(134,579,o),
+(190,648,o),
+(286,648,cs),
+(382,648,o),
+(440,578,o),
+(440,454,cs),
+(440,330,o),
+(381,260,o),
+(286,260,cs)
+);
+}
+);
+width = 568;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni146D;
+unicode = 5229;
+},
+{
+glyphname = "kii-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (224,0);
+ref = dot_top;
+}
+);
+width = 568;
+}
+);
+note = uni146E;
+unicode = 5230;
+},
+{
+glyphname = "ko-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (302,397);
+},
+{
+name = top_center_can;
+pos = (281,690);
+},
+{
+name = top_double;
+pos = (465,690);
+},
+{
+name = top_left_can;
+pos = (99,690);
+},
+{
+name = top_right_can;
+pos = (464,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(414,-13,o),
+(495,83,o),
+(495,242,cs),
+(495,690,l),
+(433,690,l),
+(433,349,l),
+(440,363,l),
+(425,433,o),
+(361,484,o),
+(275,484,cs),
+(151,484,o),
+(68,387,o),
+(68,236,cs),
+(68,82,o),
+(150,-13,o),
+(281,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(186,42,o),
+(128,112,o),
+(128,236,cs),
+(128,359,o),
+(187,430,o),
+(281,430,cs),
+(376,430,o),
+(434,359,o),
+(434,236,cs),
+(434,111,o),
+(378,42,o),
+(281,42,cs)
+);
+}
+);
+width = 568;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni146F;
+unicode = 5231;
+},
+{
+glyphname = "koo-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (402,0);
+ref = dot_top;
+}
+);
+width = 568;
+}
+);
+note = uni1470;
+unicode = 5232;
+},
+{
+glyphname = "ycreekoo-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (245,0);
+ref = doubledot_top;
+}
+);
+width = 568;
+}
+);
+note = uni1471;
+unicode = 5233;
+},
+{
+glyphname = "ka-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (307,398);
+},
+{
+name = top_center_can;
+pos = (287,690);
+},
+{
+name = top_left_can;
+pos = (104,690);
+},
+{
+name = top_right_can;
+pos = (469,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(416,-13,o),
+(500,83,o),
+(500,238,cs),
+(500,388,o),
+(417,484,o),
+(294,484,cs),
+(208,484,o),
+(143,433,o),
+(128,363,c),
+(135,349,l),
+(135,690,l),
+(73,690,l),
+(73,242,ls),
+(73,83,o),
+(153,-13,o),
+(285,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(190,42,o),
+(134,111,o),
+(134,236,cs),
+(134,359,o),
+(192,430,o),
+(286,430,cs),
+(381,430,o),
+(440,359,o),
+(440,236,cs),
+(440,112,o),
+(382,42,o),
+(286,42,cs)
+);
+}
+);
+width = 568;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "==|ke-canadian";
+note = uni1472;
+unicode = 5234;
+},
+{
+glyphname = "kaa-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (43,0);
+ref = dot_top;
+}
+);
+width = 568;
+}
+);
+note = uni1473;
+unicode = 5235;
+},
+{
+glyphname = "kwe-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ke-canadian";
+}
+);
+width = 781;
+}
+);
+note = uni1474;
+unicode = 5236;
+},
+{
+glyphname = "kweWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (568,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 781;
+}
+);
+note = uni1475;
+unicode = 5237;
+},
+{
+glyphname = "kwi-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ki-canadian";
+}
+);
+width = 781;
+}
+);
+note = uni1476;
+unicode = 5238;
+},
+{
+glyphname = "kwiWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (568,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 781;
+}
+);
+note = uni1477;
+unicode = 5239;
+},
+{
+glyphname = "kwii-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (438,0);
+ref = dot_top;
+}
+);
+width = 781;
+}
+);
+note = uni1478;
+unicode = 5240;
+},
+{
+glyphname = "kwiiWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (224,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (568,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 781;
+}
+);
+note = uni1479;
+unicode = 5241;
+},
+{
+glyphname = "kwo-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ko-canadian";
+}
+);
+width = 781;
+}
+);
+note = uni147A;
+unicode = 5242;
+},
+{
+glyphname = "kwoWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (568,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 781;
+}
+);
+note = uni147B;
+unicode = 5243;
+},
+{
+glyphname = "kwoo-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (614,0);
+ref = dot_top;
+}
+);
+width = 781;
+}
+);
+note = uni147C;
+unicode = 5244;
+},
+{
+glyphname = "kwooWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (402,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (568,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 781;
+}
+);
+note = uni147D;
+unicode = 5245;
+},
+{
+glyphname = "kwa-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ka-canadian";
+}
+);
+width = 781;
+}
+);
+note = uni147E;
+unicode = 5246;
+},
+{
+glyphname = "kwaWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (568,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 781;
+}
+);
+note = uni147F;
+unicode = 5247;
+},
+{
+glyphname = "kwaa-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (255,0);
+ref = dot_top;
+}
+);
+width = 781;
+}
+);
+note = uni1480;
+unicode = 5248;
+},
+{
+glyphname = "kwaaWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (43,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (568,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 781;
+}
+);
+note = uni1481;
+unicode = 5249;
+},
+{
+glyphname = "kwaaNaskapi-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ka-canadian";
+}
+);
+width = 781;
+}
+);
+note = uni1482;
+unicode = 5250;
+},
+{
+glyphname = "k-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(252,339,o),
+(303,388,o),
+(303,471,cs),
+(303,552,o),
+(255,601,o),
+(192,601,cs),
+(145,601,o),
+(108,568,o),
+(101,523,c),
+(114,517,l),
+(114,690,l),
+(68,690,l),
+(68,471,ls),
+(68,388,o),
+(115,339,o),
+(186,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(139,376,o),
+(110,408,o),
+(110,470,cs),
+(110,530,o),
+(142,564,o),
+(185,564,cs),
+(230,564,o),
+(261,530,o),
+(261,471,cs),
+(261,411,o),
+(231,376,o),
+(186,376,cs)
+);
+}
+);
+width = 361;
+}
+);
+note = uni1483;
+unicode = 5251;
+},
+{
+glyphname = "kw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(245,339,o),
+(294,388,o),
+(294,471,cs),
+(294,690,l),
+(247,690,l),
+(247,517,l),
+(260,523,l),
+(253,568,o),
+(216,601,o),
+(169,601,cs),
+(105,601,o),
+(58,552,o),
+(58,471,cs),
+(58,388,o),
+(108,339,o),
+(175,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(130,376,o),
+(100,411,o),
+(100,471,cs),
+(100,530,o),
+(131,564,o),
+(176,564,cs),
+(219,564,o),
+(250,530,o),
+(250,470,cs),
+(250,408,o),
+(222,376,o),
+(175,376,cs)
+);
+}
+);
+width = 362;
+}
+);
+metricLeft = "=|k-canadian";
+metricRight = "=|k-canadian";
+note = uni1484;
+unicode = 5252;
+},
+{
+glyphname = "southslaveykeh-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+pos = (568,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 749;
+}
+);
+note = uni1485;
+unicode = 5253;
+},
+{
+glyphname = "southslaveykih-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+pos = (568,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 749;
+}
+);
+note = uni1486;
+unicode = 5254;
+},
+{
+glyphname = "southslaveykoh-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+pos = (568,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 749;
+}
+);
+note = uni1487;
+unicode = 5255;
+},
+{
+glyphname = "southslaveykah-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+pos = (568,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 749;
+}
+);
+note = uni1488;
+unicode = 5256;
+},
+{
+glyphname = "ce-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (300,419);
+},
+{
+name = top_center_can;
+pos = (281,690);
+},
+{
+name = top_left_can;
+pos = (99,690);
+},
+{
+name = top_right_can;
+pos = (461,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(492,0,l),
+(492,456,ls),
+(492,610,o),
+(412,702,o),
+(282,702,cs),
+(148,702,o),
+(68,610,o),
+(68,458,cs),
+(68,391,l),
+(128,391,l),
+(128,463,ls),
+(128,579,o),
+(184,647,o),
+(281,647,cs),
+(375,647,o),
+(430,579,o),
+(430,462,cs),
+(430,0,l)
+);
+}
+);
+width = 565;
+}
+);
+metricRight = "te-canadian";
+note = uni1489;
+unicode = 5257;
+},
+{
+glyphname = "caai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (167,0);
+ref = ring_top.canadian;
+}
+);
+width = 564;
+}
+);
+note = uni148A;
+unicode = 5258;
+},
+{
+glyphname = "ci-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (303,419);
+},
+{
+name = top_center_can;
+pos = (287,690);
+},
+{
+name = top_left_can;
+pos = (104,690);
+},
+{
+name = top_right_can;
+pos = (468,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(135,0,l),
+(135,462,ls),
+(135,579,o),
+(189,647,o),
+(286,647,cs),
+(383,647,o),
+(436,580,o),
+(436,463,cs),
+(436,391,l),
+(497,391,l),
+(497,458,ls),
+(497,609,o),
+(419,702,o),
+(287,702,cs),
+(152,702,o),
+(73,609,o),
+(73,455,cs),
+(73,0,l)
+);
+}
+);
+width = 565;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+unicode = 5259;
+},
+{
+glyphname = "cii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (225,0);
+ref = dot_top;
+}
+);
+width = 564;
+}
+);
+note = uni148C;
+unicode = 5260;
+},
+{
+glyphname = "co-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (300,419);
+},
+{
+name = top_center_can;
+pos = (280,690);
+},
+{
+name = top_double;
+pos = (461,690);
+},
+{
+name = top_left_can;
+pos = (99,690);
+},
+{
+name = top_right_can;
+pos = (461,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(412,-13,o),
+(492,78,o),
+(492,235,cs),
+(492,690,l),
+(430,690,l),
+(430,228,ls),
+(430,108,o),
+(375,43,o),
+(281,43,cs),
+(182,43,o),
+(128,110,o),
+(128,230,cs),
+(128,298,l),
+(68,298,l),
+(68,231,ls),
+(68,80,o),
+(145,-13,o),
+(282,-13,cs)
+);
+}
+);
+width = 565;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+unicode = 5261;
+},
+{
+glyphname = "coo-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (399,0);
+ref = dot_top;
+}
+);
+width = 564;
+}
+);
+note = uni148E;
+unicode = 5262;
+},
+{
+glyphname = "ycreecoo-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (242,0);
+ref = doubledot_top;
+}
+);
+width = 564;
+}
+);
+note = uni148F;
+unicode = 5263;
+},
+{
+glyphname = "ca-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (303,419);
+},
+{
+name = top_center_can;
+pos = (287,690);
+},
+{
+name = top_left_can;
+pos = (104,690);
+},
+{
+name = top_right_can;
+pos = (468,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(419,-13,o),
+(497,79,o),
+(497,232,cs),
+(497,298,l),
+(436,298,l),
+(436,229,ls),
+(436,108,o),
+(384,43,o),
+(286,43,cs),
+(188,43,o),
+(135,110,o),
+(135,229,cs),
+(135,690,l),
+(73,690,l),
+(73,234,ls),
+(73,78,o),
+(151,-13,o),
+(286,-13,cs)
+);
+}
+);
+width = 565;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+unicode = 5264;
+},
+{
+glyphname = "caa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (43,0);
+ref = dot_top;
+}
+);
+width = 564;
+}
+);
+note = uni1491;
+unicode = 5265;
+},
+{
+glyphname = "cwe-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ce-canadian";
+}
+);
+width = 777;
+}
+);
+note = uni1492;
+unicode = 5266;
+},
+{
+glyphname = "cweWestCree-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (564,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 777;
+}
+);
+note = uni1493;
+unicode = 5267;
+},
+{
+glyphname = "cwi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ci-canadian";
+}
+);
+width = 777;
+}
+);
+note = uni1494;
+unicode = 5268;
+},
+{
+glyphname = "cwiWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (564,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 777;
+}
+);
+note = uni1495;
+unicode = 5269;
+},
+{
+glyphname = "cwii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (438,0);
+ref = dot_top;
+}
+);
+width = 777;
+}
+);
+note = uni1496;
+unicode = 5270;
+},
+{
+glyphname = "cwiiWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (225,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (564,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 777;
+}
+);
+note = uni1497;
+unicode = 5271;
+},
+{
+glyphname = "cwo-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "co-canadian";
+}
+);
+width = 777;
+}
+);
+note = uni1498;
+unicode = 5272;
+},
+{
+glyphname = "cwoWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (564,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 777;
+}
+);
+note = uni1499;
+unicode = 5273;
+},
+{
+glyphname = "cwoo-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (611,0);
+ref = dot_top;
+}
+);
+width = 777;
+}
+);
+note = uni149A;
+unicode = 5274;
+},
+{
+glyphname = "cwooWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (399,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (564,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 777;
+}
+);
+note = uni149B;
+unicode = 5275;
+},
+{
+glyphname = "cwa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ca-canadian";
+}
+);
+width = 777;
+}
+);
+note = uni149C;
+unicode = 5276;
+},
+{
+glyphname = "cwaWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (564,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 777;
+}
+);
+note = uni149D;
+unicode = 5277;
+},
+{
+glyphname = "cwaa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (255,0);
+ref = dot_top;
+}
+);
+width = 777;
+}
+);
+note = uni149E;
+unicode = 5278;
+},
+{
+glyphname = "cwaaWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (43,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (564,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 777;
+}
+);
+note = uni149F;
+unicode = 5279;
+},
+{
+glyphname = "cwaaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ca-canadian";
+}
+);
+width = 778;
+}
+);
+note = uni14A0;
+unicode = 5280;
+},
+{
+glyphname = "c-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(255,339,o),
+(304,384,o),
+(304,465,cs),
+(304,485,l),
+(261,485,l),
+(261,460,ls),
+(261,406,o),
+(232,378,o),
+(186,378,cs),
+(140,378,o),
+(114,406,o),
+(114,468,cs),
+(114,690,l),
+(68,690,l),
+(68,472,ls),
+(68,384,o),
+(113,339,o),
+(186,339,cs)
+);
+}
+);
+width = 352;
+}
+);
+note = uni14A1;
+unicode = 5281;
+},
+{
+glyphname = "thSayisi-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(240,339,o),
+(285,384,o),
+(285,472,cs),
+(285,690,l),
+(239,690,l),
+(239,468,ls),
+(239,406,o),
+(213,378,o),
+(166,378,cs),
+(121,378,o),
+(92,406,o),
+(92,460,cs),
+(92,485,l),
+(48,485,l),
+(48,465,ls),
+(48,384,o),
+(98,339,o),
+(166,339,cs)
+);
+}
+);
+width = 353;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "=|c-canadian";
+note = uni14A2;
+unicode = 5282;
+},
+{
+glyphname = "me-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (201,345);
+},
+{
+name = top_center_can;
+pos = (233,690);
+},
+{
+name = top_left_can;
+pos = (72,690);
+},
+{
+name = top_right_can;
+pos = (391,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(422,0,l),
+(422,690,l),
+(42,690,l),
+(42,634,l),
+(360,634,l),
+(360,0,l)
+);
+}
+);
+width = 502;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+unicode = 5283;
+},
+{
+glyphname = "maai-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (151,0);
+ref = ring_top.canadian;
+}
+);
+width = 502;
+}
+);
+note = uni14A4;
+unicode = 5284;
+},
+{
+glyphname = "mi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (302,345);
+},
+{
+name = top_center_can;
+pos = (270,690);
+},
+{
+name = top_left_can;
+pos = (112,690);
+},
+{
+name = top_right_can;
+pos = (430,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,0,l),
+(142,634,l),
+(461,634,l),
+(461,690,l),
+(80,690,l),
+(80,0,l)
+);
+}
+);
+width = 503;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+unicode = 5285;
+},
+{
+glyphname = "mii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (209,0);
+ref = dot_top;
+}
+);
+width = 502;
+}
+);
+note = uni14A6;
+unicode = 5286;
+},
+{
+glyphname = "mo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (201,345);
+},
+{
+name = top_center_can;
+pos = (233,690);
+},
+{
+name = top_double;
+pos = (391,690);
+},
+{
+name = top_left_can;
+pos = (72,690);
+},
+{
+name = top_right_can;
+pos = (391,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(422,0,l),
+(422,690,l),
+(360,690,l),
+(360,56,l),
+(42,56,l),
+(42,0,l)
+);
+}
+);
+width = 502;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+unicode = 5287;
+},
+{
+glyphname = "moo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (329,0);
+ref = dot_top;
+}
+);
+width = 502;
+}
+);
+note = uni14A8;
+unicode = 5288;
+},
+{
+glyphname = "ycreemoo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (173,0);
+ref = doubledot_top;
+}
+);
+width = 502;
+}
+);
+note = uni14A9;
+unicode = 5289;
+},
+{
+glyphname = "ma-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (302,345);
+},
+{
+name = top_center_can;
+pos = (270,690);
+},
+{
+name = top_left_can;
+pos = (112,690);
+},
+{
+name = top_right_can;
+pos = (430,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(461,0,l),
+(461,56,l),
+(142,56,l),
+(142,690,l),
+(80,690,l),
+(80,0,l)
+);
+}
+);
+width = 503;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+unicode = 5290;
+},
+{
+glyphname = "maa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+}
+);
+width = 502;
+}
+);
+note = uni14AB;
+unicode = 5291;
+},
+{
+glyphname = "mwe-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "me-canadian";
+}
+);
+width = 716;
+}
+);
+note = uni14AC;
+unicode = 5292;
+},
+{
+glyphname = "mweWestCree-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "me-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (502,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 716;
+}
+);
+note = uni14AD;
+unicode = 5293;
+},
+{
+glyphname = "mwi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "mi-canadian";
+}
+);
+width = 716;
+}
+);
+note = uni14AE;
+unicode = 5294;
+},
+{
+glyphname = "mwiWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (502,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 716;
+}
+);
+note = uni14AF;
+unicode = 5295;
+},
+{
+glyphname = "mwii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (421,0);
+ref = dot_top;
+}
+);
+width = 716;
+}
+);
+note = uni14B0;
+unicode = 5296;
+},
+{
+glyphname = "mwiiWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (209,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (502,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 716;
+}
+);
+note = uni14B1;
+unicode = 5297;
+},
+{
+glyphname = "mwo-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "mo-canadian";
+}
+);
+width = 716;
+}
+);
+note = uni14B2;
+unicode = 5298;
+},
+{
+glyphname = "mwoWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (502,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 716;
+}
+);
+note = uni14B3;
+unicode = 5299;
+},
+{
+glyphname = "mwoo-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (542,0);
+ref = dot_top;
+}
+);
+width = 716;
+}
+);
+note = uni14B4;
+unicode = 5300;
+},
+{
+glyphname = "mwooWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (329,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (502,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 716;
+}
+);
+note = uni14B5;
+unicode = 5301;
+},
+{
+glyphname = "mwa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ma-canadian";
+}
+);
+width = 716;
+}
+);
+note = uni14B6;
+unicode = 5302;
+},
+{
+glyphname = "mwaWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (502,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 716;
+}
+);
+note = uni14B7;
+unicode = 5303;
+},
+{
+glyphname = "mwaa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (263,0);
+ref = dot_top;
+}
+);
+width = 716;
+}
+);
+note = uni14B8;
+unicode = 5304;
+},
+{
+glyphname = "mwaaWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (502,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 716;
+}
+);
+note = uni14B9;
+unicode = 5305;
+},
+{
+glyphname = "mwaaNaskapi-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ma-canadian";
+}
+);
+width = 716;
+}
+);
+note = uni14BA;
+unicode = 5306;
+},
+{
+glyphname = "m-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(276,387,l),
+(114,387,l),
+(114,690,l),
+(68,690,l),
+(68,345,l),
+(276,345,l)
+);
+}
+);
+width = 326;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni14BB;
+unicode = 5307;
+},
+{
+glyphname = "mWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+ref = "t-canadian";
+}
+);
+width = 361;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "t-canadian";
+note = uni14BC;
+unicode = 5308;
+},
+{
+glyphname = "mh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(260,345,l),
+(260,690,l),
+(214,690,l),
+(214,387,l),
+(50,387,l),
+(50,345,l)
+);
+}
+);
+width = 328;
+}
+);
+metricLeft = "=|m-canadian";
+metricRight = "=|m-canadian";
+note = uni14BD;
+unicode = 5309;
+},
+{
+glyphname = "mAthapascan-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(294,345,l),
+(294,384,l),
+(121,384,l),
+(121,362,l),
+(230,482,ls),
+(265,522,o),
+(275,555,o),
+(275,595,cs),
+(275,655,o),
+(235,696,o),
+(170,696,cs),
+(100,696,o),
+(59,649,o),
+(59,574,c),
+(100,574,l),
+(100,632,o),
+(125,659,o),
+(170,659,cs),
+(212,659,o),
+(234,636,o),
+(234,594,cs),
+(234,559,o),
+(225,535,o),
+(191,497,cs),
+(72,366,l),
+(72,345,l)
+);
+}
+);
+width = 345;
+}
+);
+note = uni14BE;
+unicode = 5310;
+},
+{
+glyphname = "mSayisi-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = two.canadian;
+}
+);
+width = 561;
+}
+);
+note = uni14BF;
+unicode = 5311;
+},
+{
+glyphname = "ne-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (500,245);
+},
+{
+name = top_center_can;
+pos = (492,490);
+},
+{
+name = top_left_can;
+pos = (93,490);
+},
+{
+name = top_right_can;
+pos = (690,490);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(633,-13,o),
+(720,80,o),
+(720,231,cs),
+(720,381,o),
+(635,472,o),
+(492,472,cs),
+(62,472,l),
+(62,416,l),
+(399,416,l),
+(393,432,l),
+(319,401,o),
+(281,320,o),
+(281,228,cs),
+(281,79,o),
+(367,-13,o),
+(500,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(400,42,o),
+(342,112,o),
+(342,230,cs),
+(342,345,o),
+(400,418,o),
+(498,418,cs),
+(600,418,o),
+(659,348,o),
+(659,230,cs),
+(659,113,o),
+(601,42,o),
+(500,42,cs)
+);
+}
+);
+width = 788;
+}
+);
+metricRight = "=|ke-canadian";
+note = uni14C0;
+unicode = 5312;
+},
+{
+glyphname = "naai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (177,-200);
+ref = ring_top.canadian;
+}
+);
+width = 787;
+}
+);
+note = uni14C1;
+unicode = 5313;
+},
+{
+glyphname = "ni-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (288,245);
+},
+{
+name = top_center_can;
+pos = (297,490);
+},
+{
+name = top_left_can;
+pos = (99,490);
+},
+{
+name = top_right_can;
+pos = (696,490);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(421,-13,o),
+(506,79,o),
+(506,229,cs),
+(506,321,o),
+(469,402,o),
+(393,433,c),
+(389,416,l),
+(725,416,l),
+(725,472,l),
+(296,472,ls),
+(152,472,o),
+(68,378,o),
+(68,229,cs),
+(68,80,o),
+(155,-13,o),
+(287,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(186,42,o),
+(128,113,o),
+(128,230,cs),
+(128,348,o),
+(187,418,o),
+(289,418,cs),
+(387,418,o),
+(445,346,o),
+(445,230,cs),
+(445,112,o),
+(388,42,o),
+(287,42,cs)
+);
+}
+);
+width = 787;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+unicode = 5314;
+},
+{
+glyphname = "nii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (235,-200);
+ref = dot_top;
+}
+);
+width = 787;
+}
+);
+note = uni14C3;
+unicode = 5315;
+},
+{
+glyphname = "no-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (499,245);
+},
+{
+name = top_center_can;
+pos = (497,490);
+},
+{
+name = top_double;
+pos = (500,490);
+},
+{
+name = top_left_can;
+pos = (93,490);
+},
+{
+name = top_right_can;
+pos = (690,490);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(495,0,ls),
+(636,0,o),
+(720,92,o),
+(720,242,cs),
+(720,392,o),
+(634,484,o),
+(500,484,cs),
+(367,484,o),
+(281,392,o),
+(281,243,cs),
+(281,153,o),
+(319,71,o),
+(392,40,c),
+(399,56,l),
+(62,56,l),
+(62,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(400,54,o),
+(342,127,o),
+(342,242,cs),
+(342,360,o),
+(400,430,o),
+(500,430,cs),
+(601,430,o),
+(659,359,o),
+(659,242,cs),
+(659,124,o),
+(600,54,o),
+(498,54,cs)
+);
+}
+);
+width = 788;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14C4;
+unicode = 5316;
+},
+{
+glyphname = "noo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (434,-200);
+ref = dot_top;
+}
+);
+width = 787;
+}
+);
+note = uni14C5;
+unicode = 5317;
+},
+{
+glyphname = "ycreenoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (282,-200);
+ref = doubledot_top;
+}
+);
+width = 787;
+}
+);
+note = uni14C6;
+unicode = 5318;
+},
+{
+glyphname = "na-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (288,245);
+},
+{
+name = top_center_can;
+pos = (291,490);
+},
+{
+name = top_double;
+pos = (432,490);
+},
+{
+name = top_left_can;
+pos = (99,490);
+},
+{
+name = top_right_can;
+pos = (696,490);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(725,0,l),
+(725,56,l),
+(389,56,l),
+(394,40,l),
+(469,71,o),
+(506,152,o),
+(506,243,cs),
+(506,393,o),
+(421,484,o),
+(287,484,cs),
+(155,484,o),
+(68,392,o),
+(68,242,cs),
+(68,93,o),
+(152,0,o),
+(294,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(187,54,o),
+(128,124,o),
+(128,242,cs),
+(128,359,o),
+(186,430,o),
+(287,430,cs),
+(388,430,o),
+(445,360,o),
+(445,242,cs),
+(445,127,o),
+(387,54,o),
+(289,54,cs)
+);
+}
+);
+width = 787;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+unicode = 5319;
+},
+{
+glyphname = "naa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (229,-200);
+ref = dot_top;
+}
+);
+width = 787;
+}
+);
+note = uni14C8;
+unicode = 5320;
+},
+{
+glyphname = "nwe-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ne-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni14C9;
+unicode = 5321;
+},
+{
+glyphname = "nweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (787,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni14CA;
+unicode = 5322;
+},
+{
+glyphname = "nwa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "na-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni14CB;
+unicode = 5323;
+},
+{
+glyphname = "nwaWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (787,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni14CC;
+unicode = 5324;
+},
+{
+glyphname = "nwaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (441,-200);
+ref = dot_top;
+}
+);
+width = 1001;
+}
+);
+note = uni14CD;
+unicode = 5325;
+},
+{
+glyphname = "nwaaWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (229,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (787,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni14CE;
+unicode = 5326;
+},
+{
+glyphname = "nwaaNaskapi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (213,-200);
+ref = doubledot_top;
+}
+);
+width = 787;
+}
+);
+note = uni14CF;
+unicode = 5327;
+},
+{
+glyphname = "n-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(418,434,l),
+(418,477,l),
+(230,477,l),
+(232,457,l),
+(270,470,o),
+(292,517,o),
+(292,567,cs),
+(292,646,o),
+(244,696,o),
+(175,696,cs),
+(106,696,o),
+(58,646,o),
+(58,566,cs),
+(58,486,o),
+(105,434,o),
+(181,434,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(130,470,o),
+(99,506,o),
+(99,566,cs),
+(99,625,o),
+(130,660,o),
+(176,660,cs),
+(220,660,o),
+(250,625,o),
+(250,565,cs),
+(250,505,o),
+(220,470,o),
+(175,470,cs)
+);
+}
+);
+width = 468;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni14D0;
+unicode = 5328;
+},
+{
+color = 6;
+glyphname = "ngCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-161);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 411;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "=|";
+note = uni14D1;
+unicode = 5329;
+},
+{
+glyphname = "nh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(289,434,ls),
+(364,434,o),
+(412,486,o),
+(412,566,cs),
+(412,646,o),
+(363,696,o),
+(295,696,cs),
+(225,696,o),
+(177,646,o),
+(177,567,cs),
+(177,517,o),
+(200,470,o),
+(238,457,c),
+(240,477,l),
+(50,477,l),
+(50,434,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(249,470,o),
+(219,505,o),
+(219,565,cs),
+(219,625,o),
+(249,660,o),
+(294,660,cs),
+(339,660,o),
+(370,625,o),
+(370,566,cs),
+(370,506,o),
+(339,470,o),
+(295,470,cs)
+);
+}
+);
+width = 470;
+}
+);
+metricLeft = "=|n-canadian";
+metricRight = "=|n-canadian";
+note = uni14D2;
+unicode = 5330;
+},
+{
+glyphname = "le-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (499,245);
+},
+{
+name = top_center_can;
+pos = (492,490);
+},
+{
+name = top_left_can;
+pos = (93,490);
+},
+{
+name = top_right_can;
+pos = (690,490);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(483,0,ls),
+(630,0,o),
+(720,90,o),
+(720,236,cs),
+(720,383,o),
+(635,472,o),
+(480,472,cs),
+(62,472,l),
+(62,415,l),
+(481,415,ls),
+(596,415,o),
+(659,350,o),
+(659,235,cs),
+(659,122,o),
+(594,55,o),
+(480,55,cs),
+(439,55,l),
+(439,0,l)
+);
+}
+);
+width = 788;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D3;
+unicode = 5331;
+},
+{
+glyphname = "laai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (177,-200);
+ref = ring_top.canadian;
+}
+);
+width = 787;
+}
+);
+note = uni14D4;
+unicode = 5332;
+},
+{
+glyphname = "li-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (288,245);
+},
+{
+name = top_center_can;
+pos = (297,490);
+},
+{
+name = top_left_can;
+pos = (99,490);
+},
+{
+name = top_right_can;
+pos = (696,490);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(350,0,l),
+(350,55,l),
+(309,55,ls),
+(191,55,o),
+(129,122,o),
+(129,234,cs),
+(129,344,o),
+(185,415,o),
+(308,415,cs),
+(725,415,l),
+(725,472,l),
+(307,472,ls),
+(151,472,o),
+(68,377,o),
+(68,235,cs),
+(68,90,o),
+(156,0,o),
+(304,0,cs)
+);
+}
+);
+width = 787;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14D5;
+unicode = 5333;
+},
+{
+glyphname = "lii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (235,-200);
+ref = dot_top;
+}
+);
+width = 787;
+}
+);
+note = uni14D6;
+unicode = 5334;
+},
+{
+glyphname = "lo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (499,245);
+},
+{
+name = top_center_can;
+pos = (497,490);
+},
+{
+name = top_double;
+pos = (483,490);
+},
+{
+name = top_left_can;
+pos = (93,490);
+},
+{
+name = top_right_can;
+pos = (690,490);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(478,0,ls),
+(633,0,o),
+(720,90,o),
+(720,237,cs),
+(720,383,o),
+(631,472,o),
+(483,472,cs),
+(439,472,l),
+(439,416,l),
+(479,416,ls),
+(596,416,o),
+(659,351,o),
+(659,237,cs),
+(659,123,o),
+(596,56,o),
+(479,56,cs),
+(62,56,l),
+(62,0,l)
+);
+}
+);
+width = 788;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D7;
+unicode = 5335;
+},
+{
+glyphname = "loo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (434,-200);
+ref = dot_top;
+}
+);
+width = 787;
+}
+);
+note = uni14D8;
+unicode = 5336;
+},
+{
+glyphname = "ycreeloo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (265,-200);
+ref = doubledot_top;
+}
+);
+width = 787;
+}
+);
+note = uni14D9;
+unicode = 5337;
+},
+{
+glyphname = "la-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (288,245);
+},
+{
+name = top_center_can;
+pos = (291,490);
+},
+{
+name = top_left_can;
+pos = (99,490);
+},
+{
+name = top_right_can;
+pos = (696,490);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(725,0,l),
+(725,56,l),
+(311,56,ls),
+(193,56,o),
+(129,122,o),
+(129,238,cs),
+(129,351,o),
+(190,416,o),
+(306,416,cs),
+(350,416,l),
+(350,472,l),
+(306,472,ls),
+(154,472,o),
+(68,382,o),
+(68,237,cs),
+(68,88,o),
+(156,0,o),
+(310,0,cs)
+);
+}
+);
+width = 787;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14DA;
+unicode = 5338;
+},
+{
+glyphname = "laa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (229,-200);
+ref = dot_top;
+}
+);
+width = 787;
+}
+);
+note = uni14DB;
+unicode = 5339;
+},
+{
+glyphname = "lwe-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "le-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni14DC;
+unicode = 5340;
+},
+{
+glyphname = "lweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "le-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (787,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni14DD;
+unicode = 5341;
+},
+{
+glyphname = "lwi-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "li-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni14DE;
+unicode = 5342;
+},
+{
+glyphname = "lwiWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (787,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni14DF;
+unicode = 5343;
+},
+{
+glyphname = "lwii-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (447,-200);
+ref = dot_top;
+}
+);
+width = 1001;
+}
+);
+note = uni14E0;
+unicode = 5344;
+},
+{
+glyphname = "lwiiWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (235,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (787,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni14E1;
+unicode = 5345;
+},
+{
+glyphname = "lwo-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "lo-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni14E2;
+unicode = 5346;
+},
+{
+glyphname = "lwoWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (787,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni14E3;
+unicode = 5347;
+},
+{
+glyphname = "lwoo-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (647,-200);
+ref = dot_top;
+}
+);
+width = 1001;
+}
+);
+note = uni14E4;
+unicode = 5348;
+},
+{
+glyphname = "lwooWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (434,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (787,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni14E5;
+unicode = 5349;
+},
+{
+glyphname = "lwa-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "la-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni14E6;
+unicode = 5350;
+},
+{
+glyphname = "lwaWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (787,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni14E7;
+unicode = 5351;
+},
+{
+glyphname = "lwaa-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (441,-200);
+ref = dot_top;
+}
+);
+width = 1001;
+}
+);
+note = uni14E8;
+unicode = 5352;
+},
+{
+glyphname = "lwaaWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (229,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (787,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni14E9;
+unicode = 5353;
+},
+{
+glyphname = "l-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(418,345,l),
+(418,387,l),
+(240,387,ls),
+(154,387,o),
+(111,434,o),
+(111,518,cs),
+(111,601,o),
+(154,647,o),
+(237,647,cs),
+(250,647,l),
+(250,690,l),
+(234,690,ls),
+(126,690,o),
+(66,624,o),
+(66,517,cs),
+(66,411,o),
+(126,345,o),
+(236,345,cs)
+);
+}
+);
+width = 468;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "m-canadian";
+note = uni14EA;
+unicode = 5354;
+},
+{
+glyphname = "lWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(301,345,l),
+(301,376,l),
+(104,454,l),
+(104,432,l),
+(301,505,l),
+(301,528,l),
+(104,603,l),
+(104,581,l),
+(301,659,l),
+(301,690,l),
+(291,690,l),
+(68,602,l),
+(68,582,l),
+(266,508,l),
+(266,526,l),
+(68,452,l),
+(68,433,l),
+(291,345,l)
+);
+}
+);
+width = 369;
+}
+);
+metricRight = "=|";
+note = uni14EB;
+unicode = 5355;
+},
+{
+glyphname = "mediall-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(560,-13,l),
+(560,34,l),
+(132,200,l),
+(132,171,l),
+(560,328,l),
+(560,360,l),
+(132,519,l),
+(132,491,l),
+(560,657,l),
+(560,702,l),
+(542,702,l),
+(75,521,l),
+(75,491,l),
+(503,332,l),
+(503,356,l),
+(75,199,l),
+(75,169,l),
+(542,-13,l)
+);
+}
+);
+width = 635;
+}
+);
+metricRight = "=|";
+note = uni14EC;
+unicode = 5356;
+},
+{
+glyphname = "se-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (108,690);
+},
+{
+name = top_right_can;
+pos = (406,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(437,0,l),
+(437,314,l),
+(400,314,ls),
+(229,314,o),
+(139,404,o),
+(139,586,cs),
+(139,690,l),
+(77,690,l),
+(77,581,ls),
+(77,374,o),
+(193,258,o),
+(389,258,cs),
+(418,258,l),
+(375,283,l),
+(375,0,l)
+);
+}
+);
+width = 517;
+}
+);
+note = uni14ED;
+unicode = 5357;
+},
+{
+glyphname = "saai-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (289,0);
+ref = ring_top.canadian;
+}
+);
+width = 517;
+}
+);
+note = uni14EE;
+unicode = 5358;
+},
+{
+glyphname = "si-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (112,690);
+},
+{
+name = top_right_can;
+pos = (409,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,0,l),
+(142,283,l),
+(99,258,l),
+(128,258,ls),
+(324,258,o),
+(440,374,o),
+(440,581,cs),
+(440,690,l),
+(378,690,l),
+(378,586,ls),
+(378,404,o),
+(288,314,o),
+(117,314,cs),
+(80,314,l),
+(80,0,l)
+);
+}
+);
+width = 517;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+unicode = 5359;
+},
+{
+glyphname = "sii-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (347,0);
+ref = dot_top;
+}
+);
+width = 517;
+}
+);
+note = uni14F0;
+unicode = 5360;
+},
+{
+glyphname = "so-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (406,690);
+},
+{
+name = top_left_can;
+pos = (108,690);
+},
+{
+name = top_right_can;
+pos = (406,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(139,0,l),
+(139,103,ls),
+(139,286,o),
+(229,376,o),
+(400,376,cs),
+(437,376,l),
+(437,690,l),
+(375,690,l),
+(375,407,l),
+(418,432,l),
+(389,432,ls),
+(193,432,o),
+(77,316,o),
+(77,109,cs),
+(77,0,l)
+);
+}
+);
+width = 517;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+unicode = 5361;
+},
+{
+glyphname = "soo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (344,0);
+ref = dot_top;
+}
+);
+width = 517;
+}
+);
+note = uni14F2;
+unicode = 5362;
+},
+{
+glyphname = "ycreesoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (187,0);
+ref = doubledot_top;
+}
+);
+width = 517;
+}
+);
+note = uni14F3;
+unicode = 5363;
+},
+{
+glyphname = "sa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (112,690);
+},
+{
+name = top_right_can;
+pos = (409,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,0,l),
+(440,109,ls),
+(440,316,o),
+(324,432,o),
+(128,432,cs),
+(99,432,l),
+(142,407,l),
+(142,690,l),
+(80,690,l),
+(80,376,l),
+(117,376,ls),
+(288,376,o),
+(378,286,o),
+(378,103,cs),
+(378,0,l)
+);
+}
+);
+width = 517;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+unicode = 5364;
+},
+{
+glyphname = "saa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+}
+);
+width = 517;
+}
+);
+note = uni14F5;
+unicode = 5365;
+},
+{
+glyphname = "swe-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "se-canadian";
+}
+);
+width = 729;
+}
+);
+note = uni14F6;
+unicode = 5366;
+},
+{
+glyphname = "sweWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "se-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (517,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 729;
+}
+);
+note = uni14F7;
+unicode = 5367;
+},
+{
+glyphname = "swi-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "si-canadian";
+}
+);
+width = 729;
+}
+);
+note = uni14F8;
+unicode = 5368;
+},
+{
+glyphname = "swiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (517,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 729;
+}
+);
+note = uni14F9;
+unicode = 5369;
+},
+{
+glyphname = "swii-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (559,0);
+ref = dot_top;
+}
+);
+width = 729;
+}
+);
+note = uni14FA;
+unicode = 5370;
+},
+{
+glyphname = "swiiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (347,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (517,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 729;
+}
+);
+note = uni14FB;
+unicode = 5371;
+},
+{
+glyphname = "swo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "so-canadian";
+}
+);
+width = 729;
+}
+);
+note = uni14FC;
+unicode = 5372;
+},
+{
+glyphname = "swoWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (517,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 729;
+}
+);
+note = uni14FD;
+unicode = 5373;
+},
+{
+glyphname = "swoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (556,0);
+ref = dot_top;
+}
+);
+width = 729;
+}
+);
+note = uni14FE;
+unicode = 5374;
+},
+{
+glyphname = "swooWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (344,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (517,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 729;
+}
+);
+note = uni14FF;
+unicode = 5375;
+},
+{
+glyphname = "swa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "sa-canadian";
+}
+);
+width = 729;
+}
+);
+note = uni1500;
+unicode = 5376;
+},
+{
+glyphname = "swaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (517,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 729;
+}
+);
+note = uni1501;
+unicode = 5377;
+},
+{
+glyphname = "swaa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (263,0);
+ref = dot_top;
+}
+);
+width = 729;
+}
+);
+note = uni1502;
+unicode = 5378;
+},
+{
+glyphname = "swaaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (517,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 729;
+}
+);
+note = uni1503;
+unicode = 5379;
+},
+{
+glyphname = "swaaNaskapi-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "sa-canadian";
+}
+);
+width = 730;
+}
+);
+note = uni1504;
+unicode = 5380;
+},
+{
+glyphname = "s-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(277,345,l),
+(277,402,ls),
+(277,505,o),
+(222,573,o),
+(119,573,cs),
+(89,573,l),
+(114,549,l),
+(114,690,l),
+(68,690,l),
+(68,533,l),
+(104,533,ls),
+(192,533,o),
+(232,487,o),
+(232,399,cs),
+(232,345,l)
+);
+}
+);
+width = 345;
+}
+);
+metricRight = "=|";
+note = uni1505;
+unicode = 5381;
+},
+{
+color = 6;
+glyphname = "sAthapascan-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(258,177,o),
+(301,216,o),
+(301,270,cs),
+(301,312,o),
+(280,340,o),
+(232,358,cs),
+(160,384,ls),
+(126,398,o),
+(115,414,o),
+(115,440,cs),
+(115,474,o),
+(140,497,o),
+(186,497,cs),
+(234,497,o),
+(260,476,o),
+(261,429,c),
+(302,429,l),
+(301,493,o),
+(260,533,o),
+(186,533,cs),
+(116,533,o),
+(73,495,o),
+(73,440,cs),
+(73,398,o),
+(97,368,o),
+(142,351,cs),
+(213,325,ls),
+(247,311,o),
+(260,297,o),
+(260,269,cs),
+(260,233,o),
+(233,213,o),
+(186,213,cs),
+(137,213,o),
+(110,233,o),
+(109,284,c),
+(68,284,l),
+(69,215,o),
+(109,177,o),
+(185,177,cs)
+);
+}
+);
+width = 370;
+}
+);
+metricRight = "=|";
+note = uni1506;
+unicode = 5382;
+},
+{
+glyphname = "sw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(114,345,l),
+(114,399,ls),
+(114,487,o),
+(154,533,o),
+(242,533,cs),
+(277,533,l),
+(277,690,l),
+(232,690,l),
+(232,549,l),
+(257,573,l),
+(226,573,ls),
+(123,573,o),
+(68,505,o),
+(68,402,cs),
+(68,345,l)
+);
+}
+);
+width = 345;
+}
+);
+metricLeft = "=|s-canadian";
+metricRight = "=|s-canadian";
+note = uni1507;
+unicode = 5383;
+},
+{
+glyphname = "sBlackfoot-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(285,345,l),
+(285,387,l),
+(203,387,ls),
+(142,387,o),
+(114,416,o),
+(114,482,cs),
+(114,690,l),
+(68,690,l),
+(68,478,ls),
+(68,391,o),
+(112,345,o),
+(199,345,c)
+);
+}
+);
+width = 335;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "m-canadian";
+note = uni1508;
+unicode = 5384;
+},
+{
+glyphname = "moosecreesk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(253,217,o),
+(303,269,o),
+(303,361,cs),
+(303,498,o),
+(246,572,o),
+(125,572,cs),
+(95,572,l),
+(114,548,l),
+(114,690,l),
+(69,690,l),
+(69,533,l),
+(118,533,ls),
+(217,533,o),
+(249,485,o),
+(256,409,c),
+(272,400,l),
+(265,444,o),
+(228,478,o),
+(182,478,cs),
+(116,478,o),
+(68,429,o),
+(68,350,cs),
+(68,267,o),
+(119,217,o),
+(185,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(140,253,o),
+(109,289,o),
+(109,350,cs),
+(109,409,o),
+(140,443,o),
+(185,443,cs),
+(229,443,o),
+(261,409,o),
+(261,349,cs),
+(261,290,o),
+(233,253,o),
+(185,253,cs)
+);
+}
+);
+width = 371;
+}
+);
+metricRight = "=|";
+note = uni1509;
+unicode = 5385;
+},
+{
+glyphname = "skwNaskapi-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(252,217,o),
+(303,267,o),
+(303,350,cs),
+(303,429,o),
+(255,478,o),
+(189,478,cs),
+(142,478,o),
+(106,444,o),
+(99,400,c),
+(115,409,l),
+(122,485,o),
+(154,533,o),
+(253,533,cs),
+(302,533,l),
+(302,690,l),
+(256,690,l),
+(256,548,l),
+(276,572,l),
+(246,572,ls),
+(125,572,o),
+(68,498,o),
+(68,361,cs),
+(68,269,o),
+(118,217,o),
+(185,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(139,253,o),
+(110,290,o),
+(110,349,cs),
+(110,409,o),
+(142,443,o),
+(185,443,cs),
+(230,443,o),
+(261,409,o),
+(261,350,cs),
+(261,289,o),
+(231,253,o),
+(185,253,cs)
+);
+}
+);
+width = 371;
+}
+);
+metricLeft = "=|moosecreesk-canadian";
+metricRight = "=|moosecreesk-canadian";
+note = uni150A;
+unicode = 5386;
+},
+{
+glyphname = "swNaskapi-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(295,178,l),
+(295,232,ls),
+(295,332,o),
+(240,399,o),
+(136,399,cs),
+(108,399,l),
+(128,376,l),
+(128,513,l),
+(82,513,l),
+(82,360,l),
+(122,360,ls),
+(209,360,o),
+(249,316,o),
+(249,229,cs),
+(249,178,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(295,62,o),
+(313,80,o),
+(313,104,cs),
+(313,128,o),
+(295,146,o),
+(271,146,cs),
+(249,146,o),
+(230,128,o),
+(230,104,cs),
+(230,80,o),
+(249,62,o),
+(271,62,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(128,545,o),
+(147,563,o),
+(147,586,cs),
+(147,610,o),
+(128,628,o),
+(104,628,cs),
+(82,628,o),
+(63,610,o),
+(63,586,cs),
+(63,563,o),
+(82,545,o),
+(104,545,cs)
+);
+}
+);
+width = 376;
+}
+);
+metricRight = "=|";
+note = uni150B;
+unicode = 5387;
+},
+{
+glyphname = "spwaNaskapi-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(578,0,l),
+(578,56,l),
+(99,359,l),
+(99,330,l),
+(578,634,l),
+(578,690,l),
+(559,690,l),
+(37,358,l),
+(37,331,l),
+(559,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(154,489,o),
+(172,507,o),
+(172,530,cs),
+(172,554,o),
+(154,573,o),
+(130,573,cs),
+(108,573,o),
+(89,554,o),
+(89,530,cs),
+(89,507,o),
+(108,489,o),
+(130,489,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(329,597,l),
+(329,639,ls),
+(329,712,o),
+(291,759,o),
+(215,759,cs),
+(193,759,l),
+(219,740,l),
+(219,837,l),
+(175,837,l),
+(175,723,l),
+(203,723,ls),
+(260,723,o),
+(284,692,o),
+(284,637,cs),
+(284,597,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(488,699,o),
+(507,717,o),
+(507,741,cs),
+(507,764,o),
+(488,782,o),
+(465,782,cs),
+(442,782,o),
+(423,764,o),
+(423,741,cs),
+(423,717,o),
+(442,699,o),
+(465,699,cs)
+);
+}
+);
+width = 635;
+}
+);
+metricRight = "pa-canadian";
+metricWidth = "pa-canadian";
+note = uni150C;
+unicode = 5388;
+},
+{
+glyphname = "stwaNaskapi-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (377,0);
+ref = "ta-canadian";
+}
+);
+width = 962;
+}
+);
+note = uni150D;
+unicode = 5389;
+},
+{
+glyphname = "skwaNaskapi-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (377,0);
+ref = "ka-canadian";
+}
+);
+width = 945;
+}
+);
+note = uni150E;
+unicode = 5390;
+},
+{
+glyphname = "scwaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (377,0);
+ref = "ca-canadian";
+}
+);
+width = 941;
+}
+);
+note = uni150F;
+unicode = 5391;
+},
+{
+glyphname = "she-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (274,690);
+},
+{
+name = top_right_can;
+pos = (665,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(753,-13,o),
+(828,76,o),
+(828,235,cs),
+(828,298,l),
+(766,298,l),
+(766,232,ls),
+(766,106,o),
+(717,43,o),
+(628,43,cs),
+(535,43,o),
+(493,107,o),
+(485,233,cs),
+(472,455,ls),
+(463,613,o),
+(399,702,o),
+(273,702,cs),
+(146,702,o),
+(69,612,o),
+(69,455,cs),
+(69,391,l),
+(130,391,l),
+(130,460,ls),
+(130,582,o),
+(182,647,o),
+(271,647,cs),
+(359,647,o),
+(405,582,o),
+(412,458,cs),
+(424,235,ls),
+(434,74,o),
+(497,-13,o),
+(627,-13,cs)
+);
+}
+);
+width = 897;
+}
+);
+metricRight = "=|";
+note = uni1510;
+unicode = 5392;
+},
+{
+glyphname = "shi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (235,690);
+},
+{
+name = top_right_can;
+pos = (625,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(400,-13,o),
+(463,74,o),
+(472,235,cs),
+(485,458,ls),
+(493,582,o),
+(537,647,o),
+(626,647,cs),
+(715,647,o),
+(766,582,o),
+(766,460,cs),
+(766,391,l),
+(828,391,l),
+(828,455,ls),
+(828,612,o),
+(751,702,o),
+(623,702,cs),
+(497,702,o),
+(434,613,o),
+(424,455,cs),
+(412,233,ls),
+(404,107,o),
+(361,43,o),
+(269,43,cs),
+(180,43,o),
+(130,106,o),
+(130,232,cs),
+(130,298,l),
+(69,298,l),
+(69,235,ls),
+(69,76,o),
+(144,-13,o),
+(270,-13,cs)
+);
+}
+);
+width = 897;
+}
+);
+metricLeft = "she-canadian";
+metricRight = "she-canadian";
+note = uni1511;
+unicode = 5393;
+},
+{
+glyphname = "shii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (563,0);
+ref = dot_top;
+}
+);
+width = 896;
+}
+);
+note = uni1512;
+unicode = 5394;
+},
+{
+glyphname = "sho-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (460,490);
+},
+{
+name = top_left_can;
+pos = (271,490);
+},
+{
+name = top_right_can;
+pos = (647,490);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(330,42,l),
+(198,42,o),
+(128,87,o),
+(128,174,cs),
+(128,242,o),
+(167,287,o),
+(251,287,cs),
+(383,287,o),
+(519,129,o),
+(672,129,cs),
+(785,129,o),
+(851,197,o),
+(851,297,cs),
+(851,416,o),
+(754,485,o),
+(591,484,c),
+(589,431,l),
+(722,431,o),
+(790,384,o),
+(790,298,cs),
+(790,230,o),
+(752,185,o),
+(668,185,cs),
+(537,185,o),
+(400,342,o),
+(246,342,cs),
+(133,342,o),
+(68,274,o),
+(68,176,cs),
+(68,55,o),
+(165,-13,o),
+(328,-13,c)
+);
+}
+);
+width = 919;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1513;
+unicode = 5395;
+},
+{
+glyphname = "shoo-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (397,-200);
+ref = dot_top;
+}
+);
+width = 919;
+}
+);
+note = uni1514;
+unicode = 5396;
+},
+{
+glyphname = "sha-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (460,490);
+},
+{
+name = top_left_can;
+pos = (271,490);
+},
+{
+name = top_right_can;
+pos = (648,490);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(754,-14,o),
+(851,55,o),
+(851,176,cs),
+(851,274,o),
+(786,342,o),
+(672,342,cs),
+(519,342,o),
+(383,185,o),
+(251,185,cs),
+(167,185,o),
+(128,230,o),
+(128,298,cs),
+(128,384,o),
+(198,432,o),
+(330,431,c),
+(328,484,l),
+(165,485,o),
+(68,416,o),
+(68,297,cs),
+(68,197,o),
+(132,129,o),
+(246,129,cs),
+(400,129,o),
+(537,287,o),
+(668,287,cs),
+(752,287,o),
+(790,242,o),
+(790,174,cs),
+(790,87,o),
+(722,41,o),
+(589,42,c),
+(591,-13,l)
+);
+}
+);
+width = 919;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1515;
+unicode = 5397;
+},
+{
+glyphname = "shaa-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (398,-200);
+ref = dot_top;
+}
+);
+width = 919;
+}
+);
+note = uni1516;
+unicode = 5398;
+},
+{
+glyphname = "shwe-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "she-canadian";
+}
+);
+width = 1109;
+}
+);
+note = uni1517;
+unicode = 5399;
+},
+{
+glyphname = "shweWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "she-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (896,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1109;
+}
+);
+note = uni1518;
+unicode = 5400;
+},
+{
+glyphname = "shwi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "shi-canadian";
+}
+);
+width = 1109;
+}
+);
+note = uni1519;
+unicode = 5401;
+},
+{
+glyphname = "shwiWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (896,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1109;
+}
+);
+note = uni151A;
+unicode = 5402;
+},
+{
+glyphname = "shwii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (776,0);
+ref = dot_top;
+}
+);
+width = 1109;
+}
+);
+note = uni151B;
+unicode = 5403;
+},
+{
+glyphname = "shwiiWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (563,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (896,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1109;
+}
+);
+note = uni151C;
+unicode = 5404;
+},
+{
+glyphname = "shwo-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "sho-canadian";
+}
+);
+width = 1132;
+}
+);
+note = uni151D;
+unicode = 5405;
+},
+{
+glyphname = "shwoWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (919,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1132;
+}
+);
+note = uni151E;
+unicode = 5406;
+},
+{
+glyphname = "shwoo-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (611,-200);
+ref = dot_top;
+}
+);
+width = 1132;
+}
+);
+note = uni151F;
+unicode = 5407;
+},
+{
+glyphname = "shwooWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (397,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (919,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1132;
+}
+);
+note = uni1520;
+unicode = 5408;
+},
+{
+glyphname = "shwa-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "sha-canadian";
+}
+);
+width = 1132;
+}
+);
+note = uni1521;
+unicode = 5409;
+},
+{
+glyphname = "shwaWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (919,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1132;
+}
+);
+note = uni1522;
+unicode = 5410;
+},
+{
+glyphname = "shwaa-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (611,-200);
+ref = dot_top;
+}
+);
+width = 1132;
+}
+);
+note = uni1523;
+unicode = 5411;
+},
+{
+glyphname = "shwaaWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (398,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (919,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1132;
+}
+);
+note = uni1524;
+unicode = 5412;
+},
+{
+glyphname = "sh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(567,291,o),
+(641,345,o),
+(641,440,cs),
+(641,515,o),
+(589,569,o),
+(504,569,cs),
+(388,569,o),
+(305,463,o),
+(206,463,cs),
+(146,463,o),
+(112,496,o),
+(112,549,cs),
+(112,616,o),
+(166,655,o),
+(264,655,c),
+(262,697,l),
+(141,697,o),
+(66,642,o),
+(66,548,cs),
+(66,472,o),
+(119,418,o),
+(203,418,cs),
+(319,418,o),
+(403,526,o),
+(501,526,cs),
+(562,526,o),
+(595,492,o),
+(595,439,cs),
+(595,371,o),
+(541,332,o),
+(443,332,c),
+(445,291,l)
+);
+}
+);
+width = 707;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni1525;
+unicode = 5413;
+},
+{
+glyphname = "ye-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (611,345);
+},
+{
+name = top_left_can;
+pos = (78,690);
+},
+{
+name = top_right_can;
+pos = (440,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(470,0,l),
+(470,310,l),
+(118,310,l),
+(121,278,l),
+(484,664,l),
+(441,701,l),
+(47,280,l),
+(47,255,l),
+(409,255,l),
+(409,0,l)
+);
+}
+);
+width = 550;
+}
+);
+note = uni1526;
+unicode = 5414;
+},
+{
+glyphname = "yaai-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-10,0);
+ref = ring_top.canadian;
+}
+);
+width = 550;
+}
+);
+note = uni1527;
+unicode = 5415;
+},
+{
+glyphname = "yi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (111,690);
+},
+{
+name = top_right_can;
+pos = (473,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,0,l),
+(142,255,l),
+(503,255,l),
+(503,280,l),
+(110,701,l),
+(69,664,l),
+(432,279,l),
+(433,310,l),
+(80,310,l),
+(80,0,l)
+);
+}
+);
+width = 550;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni1528;
+unicode = 5416;
+},
+{
+glyphname = "yii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (48,0);
+ref = dot_top;
+}
+);
+width = 550;
+}
+);
+note = uni1529;
+unicode = 5417;
+},
+{
+glyphname = "yo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (611,345);
+},
+{
+name = top_double;
+pos = (440,690);
+},
+{
+name = top_left_can;
+pos = (78,690);
+},
+{
+name = top_right_can;
+pos = (440,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(483,26,l),
+(120,411,l),
+(118,380,l),
+(470,380,l),
+(470,690,l),
+(409,690,l),
+(409,435,l),
+(47,435,l),
+(47,410,l),
+(441,-12,l)
+);
+}
+);
+width = 550;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152A;
+unicode = 5418;
+},
+{
+glyphname = "yoo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (378,0);
+ref = dot_top;
+}
+);
+width = 550;
+}
+);
+note = uni152B;
+unicode = 5419;
+},
+{
+glyphname = "ycreeyoo-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (222,0);
+ref = doubledot_top;
+}
+);
+width = 550;
+}
+);
+note = uni152C;
+unicode = 5420;
+},
+{
+glyphname = "ya-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (111,690);
+},
+{
+name = top_right_can;
+pos = (473,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(503,410,l),
+(503,435,l),
+(142,435,l),
+(142,690,l),
+(80,690,l),
+(80,380,l),
+(433,380,l),
+(431,412,l),
+(68,26,l),
+(110,-12,l)
+);
+}
+);
+width = 550;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152D;
+unicode = 5421;
+},
+{
+glyphname = "yaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (48,0);
+ref = dot_top;
+}
+);
+width = 550;
+}
+);
+note = uni152E;
+unicode = 5422;
+},
+{
+glyphname = "ywe-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ye-canadian";
+}
+);
+width = 763;
+}
+);
+note = uni152F;
+unicode = 5423;
+},
+{
+glyphname = "yweWestCree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ye-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (550,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 763;
+}
+);
+note = uni1530;
+unicode = 5424;
+},
+{
+glyphname = "ywi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "yi-canadian";
+}
+);
+width = 763;
+}
+);
+note = uni1531;
+unicode = 5425;
+},
+{
+glyphname = "ywiWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (550,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 763;
+}
+);
+note = uni1532;
+unicode = 5426;
+},
+{
+glyphname = "ywii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (261,0);
+ref = dot_top;
+}
+);
+width = 763;
+}
+);
+note = uni1533;
+unicode = 5427;
+},
+{
+glyphname = "ywiiWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (48,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (550,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 763;
+}
+);
+note = uni1534;
+unicode = 5428;
+},
+{
+glyphname = "ywo-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "yo-canadian";
+}
+);
+width = 763;
+}
+);
+note = uni1535;
+unicode = 5429;
+},
+{
+glyphname = "ywoWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (550,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 763;
+}
+);
+note = uni1536;
+unicode = 5430;
+},
+{
+glyphname = "ywoo-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (591,0);
+ref = dot_top;
+}
+);
+width = 763;
+}
+);
+note = uni1537;
+unicode = 5431;
+},
+{
+glyphname = "ywooWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (378,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (550,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 763;
+}
+);
+note = uni1538;
+unicode = 5432;
+},
+{
+glyphname = "ywa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ya-canadian";
+}
+);
+width = 763;
+}
+);
+note = uni1539;
+unicode = 5433;
+},
+{
+glyphname = "ywaWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (550,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 763;
+}
+);
+note = uni153A;
+unicode = 5434;
+},
+{
+glyphname = "ywaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (261,0);
+ref = dot_top;
+}
+);
+width = 763;
+}
+);
+note = uni153B;
+unicode = 5435;
+},
+{
+glyphname = "ywaaWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (48,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (550,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 763;
+}
+);
+note = uni153C;
+unicode = 5436;
+},
+{
+glyphname = "ywaaNaskapi-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ya-canadian";
+}
+);
+width = 763;
+}
+);
+note = uni153D;
+unicode = 5437;
+},
+{
+glyphname = "y-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(293,546,l),
+(293,562,l),
+(115,562,l),
+(115,690,l),
+(69,690,l),
+(69,524,l),
+(246,524,l),
+(245,553,l),
+(68,362,l),
+(99,336,l)
+);
+}
+);
+width = 334;
+}
+);
+note = uni153E;
+unicode = 5438;
+},
+{
+glyphname = "biblecreey-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(170,639,l),
+(145,639,l),
+(240,345,l),
+(266,345,l),
+(360,639,l),
+(335,639,l),
+(405,345,l),
+(445,345,l),
+(445,357,l),
+(367,690,l),
+(336,690,l),
+(241,394,l),
+(265,394,l),
+(169,690,l),
+(138,690,l),
+(60,357,l),
+(60,345,l),
+(100,345,l)
+);
+}
+);
+width = 505;
+}
+);
+metricRight = "=|";
+note = uni153F;
+unicode = 5439;
+},
+{
+glyphname = "yWestCree-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(243,189,l),
+(243,330,l),
+(376,330,l),
+(376,374,l),
+(243,374,l),
+(243,513,l),
+(199,513,l),
+(199,374,l),
+(66,374,l),
+(66,330,l),
+(199,330,l),
+(199,189,l)
+);
+}
+);
+width = 442;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1540;
+unicode = 5440;
+},
+{
+glyphname = "yiSayisi-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,183);
+ref = "fullstop-canadian";
+}
+);
+width = 335;
+}
+);
+metricLeft = "fullstop-canadian";
+metricWidth = "fullstop-canadian";
+note = uni1541;
+unicode = 5441;
+},
+{
+glyphname = "re-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (290,490);
+},
+{
+name = top_left_can;
+pos = (108,490);
+},
+{
+name = top_right_can;
+pos = (738,490);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(424,-13,o),
+(501,79,o),
+(501,229,cs),
+(501,416,l),
+(769,416,l),
+(769,472,l),
+(440,472,l),
+(440,229,ls),
+(440,109,o),
+(388,43,o),
+(290,43,cs),
+(191,43,o),
+(138,110,o),
+(138,229,cs),
+(138,472,l),
+(76,472,l),
+(76,229,ls),
+(76,78,o),
+(156,-13,o),
+(290,-13,cs)
+);
+}
+);
+width = 831;
+}
+);
+metricRight = "=|ne-canadian";
+note = uni1542;
+unicode = 5442;
+},
+{
+glyphname = "reRCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (541,490);
+},
+{
+name = top_left_can;
+pos = (93,490);
+},
+{
+name = top_right_can;
+pos = (723,490);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(676,-13,o),
+(753,78,o),
+(753,229,cs),
+(753,472,l),
+(692,472,l),
+(692,229,ls),
+(692,110,o),
+(640,43,o),
+(542,43,cs),
+(443,43,o),
+(390,107,o),
+(390,226,cs),
+(390,472,l),
+(62,472,l),
+(62,416,l),
+(329,416,l),
+(329,227,ls),
+(329,77,o),
+(408,-13,o),
+(542,-13,cs)
+);
+}
+);
+width = 829;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1543;
+unicode = 5443;
+},
+{
+glyphname = "leWestCree-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (541,490);
+},
+{
+name = top_left_can;
+pos = (93,490);
+},
+{
+name = top_right_can;
+pos = (723,490);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(390,0,l),
+(390,242,ls),
+(390,362,o),
+(442,430,o),
+(541,430,cs),
+(639,430,o),
+(692,362,o),
+(692,243,cs),
+(692,0,l),
+(753,0,l),
+(753,243,ls),
+(753,393,o),
+(676,484,o),
+(542,484,cs),
+(408,484,o),
+(329,392,o),
+(329,242,cs),
+(329,56,l),
+(62,56,l),
+(62,0,l)
+);
+}
+);
+width = 829;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+unicode = 5444;
+},
+{
+glyphname = "raai-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (170,-200);
+ref = ring_top.canadian;
+}
+);
+width = 831;
+}
+);
+note = uni1545;
+unicode = 5445;
+},
+{
+glyphname = "ri-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (290,490);
+},
+{
+name = top_left_can;
+pos = (108,490);
+},
+{
+name = top_right_can;
+pos = (738,490);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(138,0,l),
+(138,243,ls),
+(138,362,o),
+(190,430,o),
+(289,430,cs),
+(387,430,o),
+(440,365,o),
+(440,245,cs),
+(440,0,l),
+(769,0,l),
+(769,56,l),
+(501,56,l),
+(501,245,ls),
+(501,395,o),
+(424,484,o),
+(289,484,cs),
+(156,484,o),
+(76,393,o),
+(76,242,cs),
+(76,0,l)
+);
+}
+);
+width = 831;
+}
+);
+metricLeft = "re-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+unicode = 5446;
+},
+{
+glyphname = "rii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (228,-200);
+ref = dot_top;
+}
+);
+width = 831;
+}
+);
+note = uni1547;
+unicode = 5447;
+},
+{
+glyphname = "ro-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (225,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,0,l),
+(142,276,l),
+(124,255,l),
+(227,255,ls),
+(369,255,o),
+(457,342,o),
+(457,471,cs),
+(457,604,o),
+(374,690,o),
+(218,690,cs),
+(80,690,l),
+(80,634,l),
+(219,634,ls),
+(334,634,o),
+(395,571,o),
+(395,472,cs),
+(395,374,o),
+(332,311,o),
+(220,311,cs),
+(80,311,l),
+(80,0,l)
+);
+}
+);
+width = 522;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1548;
+unicode = 5448;
+},
+{
+glyphname = "roo-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (163,0);
+ref = dot_top;
+}
+);
+width = 522;
+}
+);
+note = uni1549;
+unicode = 5449;
+},
+{
+glyphname = "loWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (252,690);
+},
+{
+name = top_left_can;
+pos = (112,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(218,0,ls),
+(374,0,o),
+(457,86,o),
+(457,218,cs),
+(457,348,o),
+(369,435,o),
+(227,435,cs),
+(124,435,l),
+(142,413,l),
+(142,690,l),
+(80,690,l),
+(80,379,l),
+(220,379,ls),
+(332,379,o),
+(395,316,o),
+(395,217,cs),
+(395,119,o),
+(334,56,o),
+(219,56,cs),
+(80,56,l),
+(80,0,l)
+);
+}
+);
+width = 522;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+unicode = 5450;
+},
+{
+glyphname = "ra-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (296,690);
+},
+{
+name = top_right_can;
+pos = (411,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,0,l),
+(440,311,l),
+(301,311,ls),
+(188,311,o),
+(126,374,o),
+(126,472,cs),
+(126,571,o),
+(187,634,o),
+(301,634,cs),
+(440,634,l),
+(440,690,l),
+(303,690,ls),
+(148,690,o),
+(65,604,o),
+(65,471,cs),
+(65,342,o),
+(153,255,o),
+(295,255,cs),
+(398,255,l),
+(380,276,l),
+(380,0,l)
+);
+}
+);
+width = 520;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+unicode = 5451;
+},
+{
+glyphname = "raa-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (234,0);
+ref = dot_top;
+}
+);
+width = 522;
+}
+);
+note = uni154C;
+unicode = 5452;
+},
+{
+glyphname = "laWestCree-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (411,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,0,l),
+(440,56,l),
+(301,56,ls),
+(187,56,o),
+(126,119,o),
+(126,217,cs),
+(126,316,o),
+(188,379,o),
+(301,379,cs),
+(440,379,l),
+(440,690,l),
+(380,690,l),
+(380,413,l),
+(398,435,l),
+(295,435,ls),
+(153,435,o),
+(65,348,o),
+(65,218,cs),
+(65,86,o),
+(148,0,o),
+(303,0,cs)
+);
+}
+);
+width = 520;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+unicode = 5453;
+},
+{
+glyphname = "rwaa-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (446,0);
+ref = dot_top;
+}
+);
+width = 734;
+}
+);
+note = uni154E;
+unicode = 5454;
+},
+{
+glyphname = "rwaaWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (234,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (522,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 734;
+}
+);
+note = uni154F;
+unicode = 5455;
+},
+{
+glyphname = "r-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(250,345,l),
+(250,509,l),
+(182,509,ls),
+(128,509,o),
+(101,534,o),
+(101,580,cs),
+(101,625,o),
+(127,651,o),
+(182,651,cs),
+(250,651,l),
+(250,690,l),
+(183,690,ls),
+(102,690,o),
+(58,648,o),
+(58,580,cs),
+(58,513,o),
+(103,470,o),
+(178,470,cs),
+(230,470,l),
+(204,490,l),
+(204,345,l)
+);
+}
+);
+width = 318;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni1550;
+unicode = 5456;
+},
+{
+glyphname = "rWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(78,345,l),
+(301,433,l),
+(301,452,l),
+(102,526,l),
+(102,508,l),
+(301,582,l),
+(301,602,l),
+(78,690,l),
+(68,690,l),
+(68,659,l),
+(264,581,l),
+(264,603,l),
+(68,528,l),
+(68,505,l),
+(264,432,l),
+(264,454,l),
+(68,376,l),
+(68,345,l)
+);
+}
+);
+width = 369;
+}
+);
+metricLeft = "=|lWestCree-canadian";
+metricRight = "=|lWestCree-canadian";
+note = uni1551;
+unicode = 5457;
+},
+{
+glyphname = "rMedial-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(94,-13,l),
+(565,169,l),
+(565,198,l),
+(134,355,l),
+(134,333,l),
+(565,492,l),
+(565,521,l),
+(94,702,l),
+(75,702,l),
+(75,657,l),
+(507,491,l),
+(507,519,l),
+(75,360,l),
+(75,328,l),
+(507,171,l),
+(507,200,l),
+(75,34,l),
+(75,-13,l)
+);
+}
+);
+width = 640;
+}
+);
+metricLeft = "mediall-canadian";
+metricRight = "mediall-canadian";
+note = uni1552;
+unicode = 5458;
+},
+{
+glyphname = "fe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(370,0,l),
+(697,670,l),
+(697,690,l),
+(645,690,l),
+(345,66,l),
+(360,66,l),
+(202,360,l),
+(172,353,l),
+(197,329,o),
+(225,320,o),
+(256,320,cs),
+(344,320,o),
+(407,397,o),
+(407,511,cs),
+(407,627,o),
+(347,702,o),
+(251,702,cs),
+(156,702,o),
+(96,627,o),
+(96,515,cs),
+(96,467,o),
+(107,417,o),
+(141,358,cs),
+(341,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(186,367,o),
+(148,425,o),
+(148,514,cs),
+(148,602,o),
+(185,654,o),
+(251,654,cs),
+(318,654,o),
+(355,603,o),
+(355,511,cs),
+(355,419,o),
+(317,367,o),
+(252,367,cs)
+);
+}
+);
+width = 733;
+}
+);
+metricRight = "e-canadian";
+note = uni1553;
+unicode = 5459;
+},
+{
+glyphname = "faai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (237,0);
+ref = ring_top.canadian;
+}
+);
+width = 733;
+}
+);
+note = uni1554;
+unicode = 5460;
+},
+{
+glyphname = "fi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (356,690);
+},
+{
+name = top_left_can;
+pos = (127,690);
+},
+{
+name = top_right_can;
+pos = (614,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(347,-13,o),
+(407,63,o),
+(407,179,cs),
+(407,293,o),
+(344,370,o),
+(256,370,cs),
+(225,370,o),
+(197,360,o),
+(172,337,c),
+(202,329,l),
+(360,624,l),
+(345,624,l),
+(645,0,l),
+(697,0,l),
+(697,19,l),
+(370,690,l),
+(341,690,l),
+(141,331,ls),
+(107,272,o),
+(96,223,o),
+(96,175,cs),
+(96,63,o),
+(156,-13,o),
+(251,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(185,36,o),
+(148,88,o),
+(148,176,cs),
+(148,265,o),
+(186,323,o),
+(252,323,cs),
+(317,323,o),
+(355,270,o),
+(355,179,cs),
+(355,87,o),
+(318,36,o),
+(251,36,cs)
+);
+}
+);
+width = 733;
+}
+);
+metricLeft = "fe-canadian";
+metricRight = "e-canadian";
+note = uni1555;
+unicode = 5461;
+},
+{
+glyphname = "fii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (295,0);
+ref = dot_top;
+}
+);
+width = 733;
+}
+);
+note = uni1556;
+unicode = 5462;
+},
+{
+glyphname = "fo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (216,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(115,0,l),
+(636,331,l),
+(636,358,l),
+(327,656,ls),
+(297,687,o),
+(257,702,o),
+(215,702,cs),
+(124,702,o),
+(61,631,o),
+(61,510,cs),
+(61,395,o),
+(121,320,o),
+(214,320,cs),
+(308,320,o),
+(366,396,o),
+(366,510,cs),
+(366,558,o),
+(355,599,o),
+(337,627,c),
+(321,590,l),
+(578,342,l),
+(578,357,l),
+(96,51,l),
+(96,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(151,367,o),
+(113,419,o),
+(113,511,cs),
+(113,604,o),
+(151,654,o),
+(216,654,cs),
+(282,654,o),
+(319,605,o),
+(319,511,cs),
+(319,419,o),
+(281,367,o),
+(216,367,cs)
+);
+}
+);
+width = 672;
+}
+);
+metricRight = "o-canadian";
+note = uni1557;
+unicode = 5463;
+},
+{
+glyphname = "foo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "fo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (155,0);
+ref = dot_top;
+}
+);
+width = 671;
+}
+);
+note = uni1558;
+unicode = 5464;
+},
+{
+glyphname = "fa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (456,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(576,0,l),
+(576,51,l),
+(92,358,l),
+(94,343,l),
+(351,592,l),
+(334,627,l),
+(317,599,o),
+(305,558,o),
+(305,510,cs),
+(305,396,o),
+(364,320,o),
+(457,320,cs),
+(551,320,o),
+(611,395,o),
+(611,510,cs),
+(611,631,o),
+(548,702,o),
+(456,702,cs),
+(414,702,o),
+(375,687,o),
+(345,656,cs),
+(37,358,l),
+(37,331,l),
+(557,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(390,367,o),
+(354,419,o),
+(354,511,cs),
+(354,604,o),
+(390,654,o),
+(456,654,cs),
+(522,654,o),
+(558,604,o),
+(558,511,cs),
+(558,418,o),
+(522,367,o),
+(456,367,cs)
+);
+}
+);
+width = 672;
+}
+);
+metricRight = "=|fo-canadian";
+note = uni1559;
+unicode = 5465;
+},
+{
+glyphname = "faa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (393,0);
+ref = dot_top;
+}
+);
+width = 671;
+}
+);
+note = uni155A;
+unicode = 5466;
+},
+{
+glyphname = "fwaa-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (607,0);
+ref = dot_top;
+}
+);
+width = 885;
+}
+);
+note = uni155B;
+unicode = 5467;
+},
+{
+glyphname = "fwaaWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (393,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (671,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 885;
+}
+);
+note = uni155C;
+unicode = 5468;
+},
+{
+glyphname = "f-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(332,345,l),
+(332,376,l),
+(98,526,l),
+(98,516,l),
+(217,631,l),
+(213,658,l),
+(203,643,o),
+(197,623,o),
+(197,599,cs),
+(197,539,o),
+(228,504,o),
+(273,504,cs),
+(319,504,o),
+(349,540,o),
+(349,600,cs),
+(349,662,o),
+(317,696,o),
+(272,696,cs),
+(252,696,o),
+(232,687,o),
+(212,668,cs),
+(63,526,l),
+(63,509,l),
+(320,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(243,533,o),
+(227,556,o),
+(227,600,cs),
+(227,642,o),
+(243,667,o),
+(272,667,cs),
+(301,667,o),
+(318,644,o),
+(318,600,cs),
+(318,555,o),
+(301,533,o),
+(272,533,cs)
+);
+}
+);
+width = 410;
+}
+);
+note = uni155D;
+unicode = 5469;
+},
+{
+glyphname = "the-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (782,345);
+},
+{
+name = top_center_can;
+pos = (349,690);
+},
+{
+name = top_left_can;
+pos = (103,690);
+},
+{
+name = top_right_can;
+pos = (593,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(521,-13,o),
+(624,99,o),
+(624,293,cs),
+(624,690,l),
+(562,690,l),
+(562,289,ls),
+(562,128,o),
+(485,44,o),
+(349,44,cs),
+(214,44,o),
+(133,128,o),
+(133,285,cs),
+(133,430,l),
+(111,415,l),
+(123,355,o),
+(173,316,o),
+(233,316,cs),
+(324,316,o),
+(383,391,o),
+(383,509,cs),
+(383,627,o),
+(325,702,o),
+(229,702,cs),
+(131,702,o),
+(73,627,o),
+(73,499,cs),
+(73,297,ls),
+(73,99,o),
+(179,-13,o),
+(349,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(162,364,o),
+(125,414,o),
+(125,509,cs),
+(125,602,o),
+(162,654,o),
+(228,654,cs),
+(294,654,o),
+(330,602,o),
+(330,509,cs),
+(330,415,o),
+(294,364,o),
+(228,364,cs)
+);
+}
+);
+width = 697;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155E;
+unicode = 5470;
+},
+{
+glyphname = "theNCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(522,-13,o),
+(624,99,o),
+(624,298,cs),
+(624,499,ls),
+(624,627,o),
+(566,702,o),
+(469,702,cs),
+(373,702,o),
+(315,627,o),
+(315,509,cs),
+(315,392,o),
+(374,316,o),
+(465,316,cs),
+(525,316,o),
+(575,355,o),
+(586,415,c),
+(564,430,l),
+(564,285,ls),
+(564,127,o),
+(485,44,o),
+(349,44,cs),
+(214,44,o),
+(135,129,o),
+(135,288,cs),
+(135,690,l),
+(73,690,l),
+(73,289,ls),
+(73,98,o),
+(179,-13,o),
+(349,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(404,364,o),
+(367,417,o),
+(367,509,cs),
+(367,602,o),
+(404,654,o),
+(469,654,cs),
+(535,654,o),
+(572,602,o),
+(572,509,cs),
+(572,415,o),
+(534,364,o),
+(469,364,cs)
+);
+}
+);
+width = 697;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155F;
+unicode = 5471;
+},
+{
+glyphname = "thi-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (347,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(325,-13,o),
+(383,63,o),
+(383,181,cs),
+(383,298,o),
+(324,374,o),
+(233,374,cs),
+(173,374,o),
+(123,334,o),
+(111,274,c),
+(133,260,l),
+(133,405,ls),
+(133,563,o),
+(213,645,o),
+(349,645,cs),
+(483,645,o),
+(562,560,o),
+(562,402,cs),
+(562,0,l),
+(624,0,l),
+(624,401,ls),
+(624,592,o),
+(519,702,o),
+(349,702,cs),
+(176,702,o),
+(73,591,o),
+(73,391,cs),
+(73,190,ls),
+(73,63,o),
+(131,-13,o),
+(229,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(162,36,o),
+(125,88,o),
+(125,181,cs),
+(125,274,o),
+(162,326,o),
+(228,326,cs),
+(294,326,o),
+(330,272,o),
+(330,181,cs),
+(330,88,o),
+(294,36,o),
+(228,36,cs)
+);
+}
+);
+width = 697;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1560;
+unicode = 5472;
+},
+{
+glyphname = "thiNCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (347,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(566,-13,o),
+(624,63,o),
+(624,190,cs),
+(624,391,ls),
+(624,591,o),
+(522,702,o),
+(349,702,cs),
+(179,702,o),
+(73,592,o),
+(73,401,cs),
+(73,0,l),
+(135,0,l),
+(135,402,ls),
+(135,560,o),
+(214,645,o),
+(349,645,cs),
+(485,645,o),
+(564,563,o),
+(564,405,cs),
+(564,260,l),
+(586,274,l),
+(575,334,o),
+(525,374,o),
+(465,374,cs),
+(374,374,o),
+(315,298,o),
+(315,181,cs),
+(315,63,o),
+(373,-13,o),
+(469,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(404,36,o),
+(367,88,o),
+(367,181,cs),
+(367,272,o),
+(404,326,o),
+(469,326,cs),
+(534,326,o),
+(572,274,o),
+(572,181,cs),
+(572,88,o),
+(535,36,o),
+(469,36,cs)
+);
+}
+);
+width = 697;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1561;
+unicode = 5473;
+},
+{
+glyphname = "thii-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "thi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (285,0);
+ref = dot_top;
+}
+);
+width = 697;
+}
+);
+note = uni1562;
+unicode = 5474;
+},
+{
+glyphname = "thiiNCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "thiNCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (285,0);
+ref = dot_top;
+}
+);
+width = 697;
+}
+);
+note = uni1563;
+unicode = 5475;
+},
+{
+glyphname = "tho-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (297,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(262,0,ls),
+(473,0,o),
+(584,125,o),
+(584,351,cs),
+(584,563,o),
+(481,702,o),
+(298,702,cs),
+(164,702,o),
+(73,622,o),
+(73,484,cs),
+(73,366,o),
+(134,294,o),
+(228,294,cs),
+(322,294,o),
+(381,364,o),
+(381,481,cs),
+(381,578,o),
+(333,660,o),
+(236,665,c),
+(202,635,l),
+(225,647,o),
+(258,655,o),
+(290,655,cs),
+(449,655,o),
+(524,537,o),
+(524,354,cs),
+(524,157,o),
+(437,56,o),
+(259,56,cs),
+(105,56,l),
+(105,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(162,341,o),
+(126,391,o),
+(126,487,cs),
+(126,582,o),
+(171,633,o),
+(229,633,cs),
+(288,633,o),
+(331,582,o),
+(331,487,cs),
+(331,391,o),
+(295,341,o),
+(228,341,cs)
+);
+}
+);
+width = 650;
+}
+);
+metricRight = "to-canadian";
+note = uni1564;
+unicode = 5476;
+},
+{
+glyphname = "thoo-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "tho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (235,0);
+ref = dot_top;
+}
+);
+width = 652;
+}
+);
+note = uni1565;
+unicode = 5477;
+},
+{
+glyphname = "tha-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (354,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(545,0,l),
+(545,56,l),
+(392,56,ls),
+(213,56,o),
+(127,157,o),
+(127,354,cs),
+(127,537,o),
+(202,655,o),
+(360,655,cs),
+(393,655,o),
+(425,647,o),
+(449,635,c),
+(415,665,l),
+(318,660,o),
+(270,578,o),
+(270,481,cs),
+(270,364,o),
+(329,294,o),
+(422,294,cs),
+(517,294,o),
+(577,366,o),
+(577,484,cs),
+(577,622,o),
+(486,702,o),
+(353,702,cs),
+(170,702,o),
+(66,563,o),
+(66,351,cs),
+(66,126,o),
+(177,0,o),
+(389,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(356,341,o),
+(320,391,o),
+(320,487,cs),
+(320,582,o),
+(363,633,o),
+(422,633,cs),
+(479,633,o),
+(525,582,o),
+(525,487,cs),
+(525,391,o),
+(488,341,o),
+(422,341,cs)
+);
+}
+);
+width = 650;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tho-canadian";
+note = uni1566;
+unicode = 5478;
+},
+{
+glyphname = "thaa-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (294,0);
+ref = dot_top;
+}
+);
+width = 652;
+}
+);
+note = uni1567;
+unicode = 5479;
+},
+{
+glyphname = "thwaa-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (506,0);
+ref = dot_top;
+}
+);
+width = 865;
+}
+);
+note = uni1568;
+unicode = 5480;
+},
+{
+glyphname = "thwaaWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (294,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (652,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 865;
+}
+);
+note = uni1569;
+unicode = 5481;
+},
+{
+glyphname = "th-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(305,345,l),
+(305,384,l),
+(235,384,ls),
+(147,384,o),
+(106,432,o),
+(106,520,cs),
+(106,607,o),
+(143,665,o),
+(217,665,cs),
+(235,665,o),
+(250,661,o),
+(262,656,c),
+(240,676,l),
+(191,673,o),
+(169,636,o),
+(169,586,cs),
+(169,526,o),
+(199,492,o),
+(245,492,cs),
+(291,492,o),
+(321,526,o),
+(321,586,cs),
+(321,658,o),
+(277,696,o),
+(212,696,cs),
+(120,696,o),
+(66,625,o),
+(66,518,cs),
+(66,411,o),
+(122,345,o),
+(233,345,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(215,521,o),
+(199,543,o),
+(199,586,cs),
+(199,630,o),
+(215,653,o),
+(244,653,cs),
+(273,653,o),
+(290,632,o),
+(290,586,cs),
+(290,542,o),
+(273,521,o),
+(245,521,cs)
+);
+}
+);
+width = 382;
+}
+);
+metricLeft = "t-canadian";
+note = uni156A;
+unicode = 5482;
+},
+{
+glyphname = "tthe-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (774,345);
+},
+{
+name = top_center_can;
+pos = (344,690);
+},
+{
+name = top_left_can;
+pos = (104,690);
+},
+{
+name = top_right_can;
+pos = (584,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(512,-13,o),
+(615,99,o),
+(615,293,cs),
+(615,690,l),
+(555,690,l),
+(555,290,ls),
+(555,129,o),
+(477,45,o),
+(344,45,cs),
+(214,45,o),
+(133,130,o),
+(133,289,cs),
+(133,690,l),
+(73,690,l),
+(73,289,ls),
+(73,98,o),
+(179,-13,o),
+(344,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(370,391,l),
+(370,690,l),
+(319,690,l),
+(319,391,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156B;
+unicode = 5483;
+},
+{
+glyphname = "tthi-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(133,0,l),
+(133,400,ls),
+(133,560,o),
+(213,644,o),
+(345,644,cs),
+(474,644,o),
+(555,559,o),
+(555,401,cs),
+(555,0,l),
+(615,0,l),
+(615,401,ls),
+(615,591,o),
+(510,702,o),
+(346,702,cs),
+(177,702,o),
+(73,592,o),
+(73,397,cs),
+(73,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(370,0,l),
+(370,298,l),
+(319,298,l),
+(319,0,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156C;
+unicode = 5484;
+},
+{
+glyphname = "ttho-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (309,690);
+},
+{
+name = top_left_can;
+pos = (109,690);
+},
+{
+name = top_right_can;
+pos = (508,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(223,0,ls),
+(426,0,o),
+(539,129,o),
+(539,346,cs),
+(539,562,o),
+(426,690,o),
+(218,690,cs),
+(79,690,l),
+(79,634,l),
+(218,634,ls),
+(389,634,o),
+(477,530,o),
+(477,346,cs),
+(477,161,o),
+(389,56,o),
+(220,56,cs),
+(79,56,l),
+(79,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(306,320,l),
+(306,371,l),
+(79,371,l),
+(79,320,l)
+);
+}
+);
+width = 605;
+}
+);
+metricRight = "to-canadian";
+note = uni156D;
+unicode = 5485;
+},
+{
+glyphname = "ttha-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (314,690);
+},
+{
+name = top_left_can;
+pos = (97,690);
+},
+{
+name = top_right_can;
+pos = (496,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(525,0,l),
+(525,56,l),
+(385,56,ls),
+(215,56,o),
+(127,160,o),
+(127,345,cs),
+(127,529,o),
+(215,634,o),
+(384,634,cs),
+(525,634,l),
+(525,690,l),
+(384,690,ls),
+(179,690,o),
+(66,561,o),
+(66,345,cs),
+(66,128,o),
+(179,0,o),
+(383,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(525,320,l),
+(525,371,l),
+(298,371,l),
+(298,320,l)
+);
+}
+);
+width = 604;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|ttho-canadian";
+note = uni156E;
+unicode = 5486;
+},
+{
+glyphname = "tth-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(614,488,l),
+(599,488,l),
+(691,358,l),
+(724,383,l),
+(630,514,l),
+(626,497,l),
+(771,550,l),
+(757,588,l),
+(612,535,l),
+(627,526,l),
+(627,690,l),
+(586,690,l),
+(586,526,l),
+(601,535,l),
+(456,588,l),
+(442,550,l),
+(587,497,l),
+(582,514,l),
+(489,383,l),
+(523,358,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(224,488,l),
+(209,488,l),
+(302,358,l),
+(335,383,l),
+(241,514,l),
+(236,497,l),
+(381,550,l),
+(367,588,l),
+(223,535,l),
+(237,526,l),
+(237,690,l),
+(196,690,l),
+(196,526,l),
+(211,535,l),
+(66,588,l),
+(53,550,l),
+(198,497,l),
+(193,514,l),
+(98,383,l),
+(131,358,l)
+);
+}
+);
+width = 824;
+}
+);
+metricRight = "=|";
+note = uni156F;
+unicode = 5487;
+},
+{
+glyphname = "tye-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(512,-13,o),
+(615,99,o),
+(615,293,cs),
+(615,690,l),
+(555,690,l),
+(555,291,ls),
+(555,129,o),
+(477,45,o),
+(344,45,cs),
+(214,45,o),
+(133,130,o),
+(133,290,cs),
+(133,690,l),
+(73,690,l),
+(73,289,ls),
+(73,98,o),
+(179,-13,o),
+(344,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(415,412,o),
+(458,457,o),
+(458,544,cs),
+(458,690,l),
+(422,690,l),
+(422,546,ls),
+(422,480,o),
+(396,448,o),
+(344,448,cs),
+(293,448,o),
+(267,481,o),
+(267,546,cs),
+(267,690,l),
+(231,690,l),
+(231,544,ls),
+(231,457,o),
+(274,412,o),
+(344,412,cs)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1570;
+unicode = 5488;
+},
+{
+glyphname = "tyi-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(133,0,l),
+(133,399,ls),
+(133,560,o),
+(213,644,o),
+(345,644,cs),
+(474,644,o),
+(555,559,o),
+(555,400,cs),
+(555,0,l),
+(615,0,l),
+(615,401,ls),
+(615,591,o),
+(510,702,o),
+(346,702,cs),
+(177,702,o),
+(73,592,o),
+(73,397,cs),
+(73,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(267,0,l),
+(267,144,ls),
+(267,209,o),
+(293,242,o),
+(345,242,cs),
+(395,242,o),
+(422,209,o),
+(422,144,cs),
+(422,0,l),
+(458,0,l),
+(458,146,ls),
+(458,233,o),
+(413,278,o),
+(344,278,cs),
+(273,278,o),
+(231,233,o),
+(231,146,cs),
+(231,0,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1571;
+unicode = 5489;
+},
+{
+glyphname = "tyo-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(225,0,ls),
+(427,0,o),
+(540,129,o),
+(540,346,cs),
+(540,562,o),
+(427,690,o),
+(220,690,cs),
+(80,690,l),
+(80,634,l),
+(218,634,ls),
+(390,634,o),
+(478,530,o),
+(478,346,cs),
+(478,161,o),
+(390,56,o),
+(220,56,cs),
+(80,56,l),
+(80,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(163,210,ls),
+(252,210,o),
+(299,260,o),
+(299,345,cs),
+(299,430,o),
+(251,480,o),
+(163,480,cs),
+(80,480,l),
+(80,442,l),
+(158,442,ls),
+(229,442,o),
+(260,409,o),
+(260,345,cs),
+(260,281,o),
+(229,247,o),
+(159,247,cs),
+(80,247,l),
+(80,210,l)
+);
+}
+);
+width = 606;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1572;
+unicode = 5490;
+},
+{
+glyphname = "tya-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(525,0,l),
+(525,56,l),
+(387,56,ls),
+(215,56,o),
+(127,160,o),
+(127,345,cs),
+(127,529,o),
+(215,634,o),
+(386,634,cs),
+(525,634,l),
+(525,690,l),
+(384,690,ls),
+(180,690,o),
+(66,561,o),
+(66,345,cs),
+(66,128,o),
+(180,0,o),
+(383,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(525,210,l),
+(525,247,l),
+(447,247,ls),
+(378,247,o),
+(347,281,o),
+(347,345,cs),
+(347,409,o),
+(378,442,o),
+(447,442,cs),
+(525,442,l),
+(525,480,l),
+(442,480,ls),
+(354,480,o),
+(306,430,o),
+(306,345,cs),
+(306,260,o),
+(354,210,o),
+(442,210,cs)
+);
+}
+);
+width = 605;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1573;
+unicode = 5491;
+},
+{
+glyphname = "heNunavik-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(489,0,l),
+(717,191,l),
+(682,234,l),
+(455,43,l),
+(495,42,l),
+(495,448,ls),
+(495,607,o),
+(414,702,o),
+(283,702,cs),
+(152,702,o),
+(68,607,o),
+(68,451,cs),
+(68,300,o),
+(151,206,o),
+(275,206,cs),
+(361,206,o),
+(425,257,o),
+(440,327,c),
+(434,341,l),
+(434,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(187,260,o),
+(128,330,o),
+(128,454,cs),
+(128,578,o),
+(186,648,o),
+(281,648,cs),
+(378,648,o),
+(434,579,o),
+(434,454,cs),
+(434,330,o),
+(376,260,o),
+(281,260,cs)
+);
+}
+);
+width = 745;
+}
+);
+metricLeft = "ke-canadian";
+note = uni1574;
+unicode = 5492;
+},
+{
+glyphname = "hiNunavik-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (463,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(311,0,l),
+(311,341,l),
+(304,327,l),
+(320,257,o),
+(384,206,o),
+(469,206,cs),
+(594,206,o),
+(676,301,o),
+(676,453,cs),
+(676,607,o),
+(594,702,o),
+(463,702,cs),
+(330,702,o),
+(249,607,o),
+(249,448,cs),
+(249,44,l),
+(289,43,l),
+(62,234,l),
+(28,191,l),
+(256,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(368,260,o),
+(310,330,o),
+(310,454,cs),
+(310,579,o),
+(367,648,o),
+(463,648,cs),
+(558,648,o),
+(615,578,o),
+(615,454,cs),
+(615,330,o),
+(556,260,o),
+(463,260,cs)
+);
+}
+);
+width = 744;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1575;
+unicode = 5493;
+},
+{
+glyphname = "hiiNunavik-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "hiNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (401,0);
+ref = dot_top;
+}
+);
+width = 745;
+}
+);
+note = uni1576;
+unicode = 5494;
+},
+{
+glyphname = "hoNunavik-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (281,690);
+},
+{
+name = top_right_can;
+pos = (464,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(414,-13,o),
+(495,83,o),
+(495,242,cs),
+(495,648,l),
+(455,646,l),
+(682,456,l),
+(717,498,l),
+(489,690,l),
+(434,690,l),
+(434,349,l),
+(440,363,l),
+(425,433,o),
+(361,484,o),
+(275,484,cs),
+(151,484,o),
+(68,387,o),
+(68,237,cs),
+(68,82,o),
+(151,-13,o),
+(282,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(186,42,o),
+(128,112,o),
+(128,236,cs),
+(128,359,o),
+(187,430,o),
+(281,430,cs),
+(376,430,o),
+(434,359,o),
+(434,236,cs),
+(434,111,o),
+(378,42,o),
+(281,42,cs)
+);
+}
+);
+width = 745;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "heNunavik-canadian";
+note = uni1577;
+unicode = 5495;
+},
+{
+glyphname = "hooNunavik-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "hoNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (402,0);
+ref = dot_top;
+}
+);
+width = 745;
+}
+);
+note = uni1578;
+unicode = 5496;
+},
+{
+glyphname = "haNunavik-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (464,690);
+},
+{
+name = top_left_can;
+pos = (280,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(593,-13,o),
+(676,83,o),
+(676,238,cs),
+(676,388,o),
+(594,484,o),
+(470,484,cs),
+(384,484,o),
+(320,433,o),
+(304,363,c),
+(311,349,l),
+(311,690,l),
+(256,690,l),
+(28,498,l),
+(62,456,l),
+(289,646,l),
+(249,645,l),
+(249,242,ls),
+(249,83,o),
+(329,-13,o),
+(462,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(367,42,o),
+(310,111,o),
+(310,236,cs),
+(310,359,o),
+(368,430,o),
+(463,430,cs),
+(556,430,o),
+(615,359,o),
+(615,236,cs),
+(615,112,o),
+(558,42,o),
+(463,42,cs)
+);
+}
+);
+width = 744;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1579;
+unicode = 5497;
+},
+{
+glyphname = "haaNunavik-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "haNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (218,0);
+ref = dot_top;
+}
+);
+width = 745;
+}
+);
+note = uni157A;
+unicode = 5498;
+},
+{
+glyphname = "hNunavik-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(342,339,o),
+(392,388,o),
+(392,471,cs),
+(392,552,o),
+(345,601,o),
+(281,601,cs),
+(234,601,o),
+(197,568,o),
+(190,523,c),
+(203,523,l),
+(203,690,l),
+(159,690,l),
+(46,594,l),
+(69,567,l),
+(183,663,l),
+(156,663,l),
+(156,471,ls),
+(156,388,o),
+(205,339,o),
+(275,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(228,376,o),
+(200,408,o),
+(200,470,cs),
+(200,530,o),
+(231,564,o),
+(274,564,cs),
+(319,564,o),
+(351,530,o),
+(351,471,cs),
+(351,411,o),
+(320,376,o),
+(275,376,cs)
+);
+}
+);
+width = 450;
+}
+);
+metricRight = "k-canadian";
+note = uni157B;
+unicode = 5499;
+},
+{
+color = 4;
+glyphname = "nunavuth-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,330,l),
+(517,330,l),
+(517,0,l),
+(579,0,l),
+(579,690,l),
+(517,690,l),
+(517,385,l),
+(142,385,l),
+(142,690,l),
+(80,690,l),
+(80,0,l),
+(142,0,l)
+);
+}
+);
+width = 659;
+}
+);
+metricRight = "=|";
+note = uni157C;
+unicode = 5500;
+},
+{
+glyphname = "hk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,345);
+ref = "fullstop-canadian";
+}
+);
+width = 335;
+}
+);
+metricLeft = "fullstop-canadian";
+note = uni157D;
+unicode = 5501;
+},
+{
+glyphname = "qaai-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (318,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (484,0);
+ref = ring_top.canadian;
+}
+);
+width = 886;
+}
+);
+note = uni157E;
+unicode = 5502;
+},
+{
+glyphname = "qi-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (318,0);
+ref = "ki-canadian";
+}
+);
+width = 886;
+}
+);
+note = uni157F;
+unicode = 5503;
+},
+{
+glyphname = "qii-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (318,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (542,0);
+ref = dot_top;
+}
+);
+width = 886;
+}
+);
+note = uni1580;
+unicode = 5504;
+},
+{
+glyphname = "qo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (318,0);
+ref = "ko-canadian";
+}
+);
+width = 886;
+}
+);
+note = uni1581;
+unicode = 5505;
+},
+{
+glyphname = "qoo-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (318,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (720,0);
+ref = dot_top;
+}
+);
+width = 886;
+}
+);
+note = uni1582;
+unicode = 5506;
+},
+{
+glyphname = "qa-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (318,0);
+ref = "ka-canadian";
+}
+);
+width = 886;
+}
+);
+note = uni1583;
+unicode = 5507;
+},
+{
+glyphname = "qaa-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (318,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (360,0);
+ref = dot_top;
+}
+);
+width = 886;
+}
+);
+note = uni1584;
+unicode = 5508;
+},
+{
+glyphname = "q-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (318,0);
+ref = "k-canadian";
+}
+);
+width = 679;
+}
+);
+note = uni1585;
+unicode = 5509;
+},
+{
+glyphname = "tlhe-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (286,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(171,0,l),
+(307,267,l),
+(255,243,l),
+(263,242,o),
+(270,242,o),
+(278,242,cs),
+(362,242,o),
+(424,286,o),
+(442,345,c),
+(439,363,l),
+(439,0,l),
+(499,0,l),
+(499,468,ls),
+(499,611,o),
+(419,702,o),
+(287,702,cs),
+(152,702,o),
+(71,609,o),
+(71,470,cs),
+(71,350,o),
+(135,268,o),
+(233,250,c),
+(105,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(189,296,o),
+(131,361,o),
+(131,471,cs),
+(131,582,o),
+(189,648,o),
+(285,648,cs),
+(382,648,o),
+(439,583,o),
+(439,472,cs),
+(439,361,o),
+(381,296,o),
+(285,296,cs)
+);
+}
+);
+width = 572;
+}
+);
+metricRight = "te-canadian";
+note = uni1586;
+unicode = 5510;
+},
+{
+glyphname = "tlhi-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(134,0,l),
+(134,363,l),
+(129,347,l),
+(146,287,o),
+(209,242,o),
+(295,242,c),
+(266,267,l),
+(402,0,l),
+(468,0,l),
+(340,250,l),
+(438,268,o),
+(502,350,o),
+(502,470,cs),
+(502,609,o),
+(421,702,o),
+(286,702,cs),
+(154,702,o),
+(73,611,o),
+(73,468,cs),
+(73,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(192,296,o),
+(134,361,o),
+(134,472,cs),
+(134,583,o),
+(190,648,o),
+(288,648,cs),
+(384,648,o),
+(441,582,o),
+(441,471,cs),
+(441,361,o),
+(384,296,o),
+(288,296,cs)
+);
+}
+);
+width = 573;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|tlhe-canadian";
+note = uni1587;
+unicode = 5511;
+},
+{
+glyphname = "tlho-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (305,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(419,-13,o),
+(499,78,o),
+(499,222,cs),
+(499,690,l),
+(439,690,l),
+(439,327,l),
+(443,343,l),
+(427,403,o),
+(364,448,o),
+(278,448,c),
+(307,423,l),
+(171,690,l),
+(105,690,l),
+(233,440,l),
+(135,422,o),
+(71,340,o),
+(71,219,cs),
+(71,81,o),
+(152,-13,o),
+(287,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(189,42,o),
+(131,107,o),
+(131,218,cs),
+(131,328,o),
+(189,394,o),
+(285,394,cs),
+(381,394,o),
+(439,328,o),
+(439,217,cs),
+(439,106,o),
+(382,42,o),
+(285,42,cs)
+);
+}
+);
+width = 572;
+}
+);
+metricLeft = "tlhe-canadian";
+metricRight = "te-canadian";
+note = uni1588;
+unicode = 5512;
+},
+{
+glyphname = "tlha-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(421,-13,o),
+(502,81,o),
+(502,219,cs),
+(502,340,o),
+(438,422,o),
+(340,440,c),
+(468,690,l),
+(402,690,l),
+(266,423,l),
+(318,446,l),
+(310,447,o),
+(302,448,o),
+(295,448,cs),
+(209,448,o),
+(146,403,o),
+(129,343,c),
+(134,327,l),
+(134,690,l),
+(73,690,l),
+(73,222,ls),
+(73,78,o),
+(154,-13,o),
+(286,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(190,42,o),
+(134,106,o),
+(134,217,cs),
+(134,328,o),
+(192,394,o),
+(288,394,cs),
+(384,394,o),
+(441,328,o),
+(441,218,cs),
+(441,107,o),
+(384,42,o),
+(288,42,cs)
+);
+}
+);
+width = 573;
+}
+);
+metricLeft = "te-canadian";
+note = uni1589;
+unicode = 5513;
+},
+{
+glyphname = "reWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(485,0,l),
+(713,191,l),
+(678,234,l),
+(451,43,l),
+(491,42,l),
+(491,456,ls),
+(491,610,o),
+(412,702,o),
+(282,702,cs),
+(148,702,o),
+(68,610,o),
+(68,458,cs),
+(68,391,l),
+(128,391,l),
+(128,463,ls),
+(128,579,o),
+(184,647,o),
+(281,647,cs),
+(375,647,o),
+(430,579,o),
+(430,462,cs),
+(430,0,l)
+);
+}
+);
+width = 741;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+unicode = 5514;
+},
+{
+glyphname = "riWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(311,0,l),
+(311,462,ls),
+(311,579,o),
+(366,647,o),
+(462,647,cs),
+(559,647,o),
+(611,580,o),
+(611,463,cs),
+(611,391,l),
+(672,391,l),
+(672,458,ls),
+(672,609,o),
+(595,702,o),
+(463,702,cs),
+(328,702,o),
+(249,609,o),
+(249,455,cs),
+(249,42,l),
+(289,43,l),
+(62,234,l),
+(28,191,l),
+(256,0,l)
+);
+}
+);
+width = 740;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+unicode = 5515;
+},
+{
+glyphname = "roWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(412,-13,o),
+(491,78,o),
+(491,235,cs),
+(491,648,l),
+(451,646,l),
+(678,456,l),
+(713,498,l),
+(485,690,l),
+(430,690,l),
+(430,228,ls),
+(430,108,o),
+(375,43,o),
+(281,43,cs),
+(182,43,o),
+(128,110,o),
+(128,230,cs),
+(128,298,l),
+(68,298,l),
+(68,231,ls),
+(68,80,o),
+(145,-13,o),
+(281,-13,cs)
+);
+}
+);
+width = 741;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+unicode = 5516;
+},
+{
+glyphname = "raWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(595,-13,o),
+(672,79,o),
+(672,232,cs),
+(672,298,l),
+(611,298,l),
+(611,229,ls),
+(611,108,o),
+(559,43,o),
+(462,43,cs),
+(364,43,o),
+(311,109,o),
+(311,227,cs),
+(311,690,l),
+(256,690,l),
+(28,498,l),
+(62,456,l),
+(289,646,l),
+(249,648,l),
+(249,234,ls),
+(249,78,o),
+(327,-13,o),
+(462,-13,cs)
+);
+}
+);
+width = 740;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+unicode = 5517;
+},
+{
+glyphname = "ngaai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (625,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (792,0);
+ref = ring_top.canadian;
+}
+);
+width = 1189;
+}
+);
+note = uni158E;
+unicode = 5518;
+},
+{
+glyphname = "ngi-canadian";
+kernLeft = mwestleft;
+kernRight = ciright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (625,0);
+ref = "ci-canadian";
+}
+);
+width = 1189;
+}
+);
+note = uni158F;
+unicode = 5519;
+},
+{
+glyphname = "ngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (625,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (850,0);
+ref = dot_top;
+}
+);
+width = 1189;
+}
+);
+note = uni1590;
+unicode = 5520;
+},
+{
+glyphname = "ngo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:54:49 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (599,0);
+ref = "co-canadian";
+}
+);
+width = 1164;
+}
+);
+note = uni1591;
+unicode = 5521;
+},
+{
+glyphname = "ngoo-canadian";
+lastChange = "2023-01-13 15:54:49 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+ref = "ngo-canadian";
+},
+{
+anchor = top_right_can;
+pos = (998,0);
+ref = dot_top;
+}
+);
+width = 1164;
+}
+);
+note = uni1592;
+unicode = 5522;
+},
+{
+glyphname = "nga-canadian";
+kernLeft = mwestleft;
+kernRight = caright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (625,0);
+ref = "ca-canadian";
+}
+);
+width = 1189;
+}
+);
+note = uni1593;
+unicode = 5523;
+},
+{
+glyphname = "ngaa-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (625,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (668,0);
+ref = dot_top;
+}
+);
+width = 1189;
+}
+);
+note = uni1594;
+unicode = 5524;
+},
+{
+glyphname = "ng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(529,217,o),
+(578,261,o),
+(578,341,cs),
+(578,363,l),
+(534,363,l),
+(534,336,ls),
+(534,282,o),
+(505,255,o),
+(460,255,cs),
+(413,255,o),
+(386,283,o),
+(386,344,cs),
+(386,477,l),
+(231,477,l),
+(233,458,l),
+(270,471,o),
+(292,518,o),
+(292,567,cs),
+(292,646,o),
+(244,696,o),
+(175,696,cs),
+(106,696,o),
+(58,646,o),
+(58,566,cs),
+(58,486,o),
+(105,434,o),
+(181,434,cs),
+(355,434,l),
+(341,449,l),
+(341,349,ls),
+(341,262,o),
+(386,217,o),
+(460,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(130,470,o),
+(99,506,o),
+(99,566,cs),
+(99,625,o),
+(130,660,o),
+(176,660,cs),
+(220,660,o),
+(250,625,o),
+(250,565,cs),
+(250,505,o),
+(220,470,o),
+(175,470,cs)
+);
+}
+);
+width = 626;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1595;
+unicode = 5525;
+},
+{
+glyphname = "nng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(807,217,o),
+(855,261,o),
+(855,341,cs),
+(855,363,l),
+(811,363,l),
+(811,336,ls),
+(811,282,o),
+(782,255,o),
+(737,255,cs),
+(692,255,o),
+(665,283,o),
+(665,344,cs),
+(665,477,l),
+(511,477,l),
+(513,458,l),
+(550,471,o),
+(572,518,o),
+(572,567,cs),
+(572,647,o),
+(525,696,o),
+(454,696,cs),
+(385,696,o),
+(338,646,o),
+(338,567,cs),
+(338,517,o),
+(360,471,o),
+(397,457,c),
+(399,477,l),
+(231,477,l),
+(233,458,l),
+(270,471,o),
+(292,518,o),
+(292,567,cs),
+(292,646,o),
+(244,696,o),
+(175,696,cs),
+(106,696,o),
+(58,646,o),
+(58,566,cs),
+(58,486,o),
+(105,434,o),
+(181,434,cs),
+(618,434,l),
+(618,349,ls),
+(618,262,o),
+(664,217,o),
+(738,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(130,470,o),
+(99,506,o),
+(99,566,cs),
+(99,625,o),
+(130,660,o),
+(176,660,cs),
+(220,660,o),
+(250,625,o),
+(250,565,cs),
+(250,505,o),
+(220,470,o),
+(175,470,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(410,470,o),
+(380,506,o),
+(380,566,cs),
+(380,625,o),
+(411,660,o),
+(456,660,cs),
+(499,660,o),
+(530,625,o),
+(530,565,cs),
+(530,505,o),
+(500,470,o),
+(455,470,cs)
+);
+}
+);
+width = 903;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1596;
+unicode = 5526;
+},
+{
+glyphname = "sheSayisi-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (657,345);
+},
+{
+name = top_center_can;
+pos = (287,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(499,0,l),
+(499,449,ls),
+(499,608,o),
+(422,702,o),
+(287,702,cs),
+(152,702,o),
+(68,606,o),
+(68,441,cs),
+(68,288,o),
+(132,207,o),
+(229,207,cs),
+(313,207,o),
+(370,270,o),
+(366,411,c),
+(327,411,l),
+(328,295,o),
+(288,260,o),
+(236,260,cs),
+(168,260,o),
+(128,318,o),
+(128,442,cs),
+(128,579,o),
+(186,648,o),
+(285,648,cs),
+(384,648,o),
+(439,579,o),
+(439,451,cs),
+(439,0,l)
+);
+}
+);
+width = 572;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1597;
+unicode = 5527;
+},
+{
+glyphname = "shiSayisi-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(135,0,l),
+(135,451,ls),
+(135,579,o),
+(189,648,o),
+(289,648,cs),
+(387,648,o),
+(445,581,o),
+(445,444,cs),
+(445,321,o),
+(405,260,o),
+(337,260,cs),
+(286,260,o),
+(244,295,o),
+(245,411,c),
+(207,411,l),
+(204,270,o),
+(261,207,o),
+(344,207,cs),
+(440,207,o),
+(505,290,o),
+(505,443,cs),
+(505,608,o),
+(423,702,o),
+(289,702,cs),
+(153,702,o),
+(73,608,o),
+(73,449,cs),
+(73,0,l)
+);
+}
+);
+width = 573;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni1598;
+unicode = 5528;
+},
+{
+glyphname = "shoSayisi-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (284,690);
+},
+{
+name = top_left_can;
+pos = (98,690);
+},
+{
+name = top_right_can;
+pos = (469,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(420,-13,o),
+(499,82,o),
+(499,241,cs),
+(499,690,l),
+(439,690,l),
+(439,239,ls),
+(439,111,o),
+(384,42,o),
+(284,42,cs),
+(186,42,o),
+(128,109,o),
+(128,245,cs),
+(128,369,o),
+(168,430,o),
+(236,430,cs),
+(288,430,o),
+(328,395,o),
+(327,279,c),
+(366,279,l),
+(370,419,o),
+(313,483,o),
+(229,483,cs),
+(132,483,o),
+(68,400,o),
+(68,244,cs),
+(68,81,o),
+(150,-13,o),
+(284,-13,cs)
+);
+}
+);
+width = 572;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1599;
+unicode = 5529;
+},
+{
+glyphname = "shaSayisi-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(421,-13,o),
+(505,84,o),
+(505,248,cs),
+(505,402,o),
+(441,483,o),
+(345,483,cs),
+(262,483,o),
+(204,419,o),
+(207,279,c),
+(245,279,l),
+(244,395,o),
+(286,430,o),
+(337,430,cs),
+(405,430,o),
+(445,372,o),
+(445,247,cs),
+(445,111,o),
+(386,42,o),
+(288,42,cs),
+(188,42,o),
+(135,111,o),
+(135,239,cs),
+(135,690,l),
+(73,690,l),
+(73,241,ls),
+(73,82,o),
+(152,-13,o),
+(286,-13,cs)
+);
+}
+);
+width = 573;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni159A;
+unicode = 5530;
+},
+{
+glyphname = "theWoodScree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(642,-13,o),
+(729,80,o),
+(729,231,cs),
+(729,381,o),
+(644,472,o),
+(501,472,cs),
+(71,472,l),
+(71,419,l),
+(409,419,l),
+(403,432,l),
+(328,401,o),
+(291,320,o),
+(291,228,cs),
+(291,79,o),
+(377,-13,o),
+(510,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(410,42,o),
+(352,112,o),
+(352,230,cs),
+(352,346,o),
+(410,418,o),
+(508,418,cs),
+(610,418,o),
+(668,348,o),
+(668,230,cs),
+(668,113,o),
+(611,42,o),
+(510,42,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(719,637,l),
+(719,690,l),
+(71,690,l),
+(71,637,l)
+);
+}
+);
+width = 801;
+}
+);
+note = uni159B;
+unicode = 5531;
+},
+{
+glyphname = "thiWoodScree-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(425,-13,o),
+(510,79,o),
+(510,229,cs),
+(510,321,o),
+(471,402,o),
+(397,433,c),
+(392,419,l),
+(729,419,l),
+(729,472,l),
+(299,472,ls),
+(156,472,o),
+(71,379,o),
+(71,230,cs),
+(71,80,o),
+(157,-13,o),
+(291,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(190,42,o),
+(132,113,o),
+(132,230,cs),
+(132,348,o),
+(191,418,o),
+(293,418,cs),
+(391,418,o),
+(449,346,o),
+(449,230,cs),
+(449,112,o),
+(391,42,o),
+(291,42,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(729,637,l),
+(729,690,l),
+(82,690,l),
+(82,637,l)
+);
+}
+);
+width = 801;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159C;
+unicode = 5532;
+},
+{
+glyphname = "thoWoodScree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(504,0,ls),
+(645,0,o),
+(729,92,o),
+(729,242,cs),
+(729,392,o),
+(643,484,o),
+(510,484,cs),
+(377,484,o),
+(291,392,o),
+(291,243,cs),
+(291,153,o),
+(328,71,o),
+(402,40,c),
+(409,53,l),
+(71,53,l),
+(71,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(410,54,o),
+(352,127,o),
+(352,242,cs),
+(352,360,o),
+(410,430,o),
+(510,430,cs),
+(611,430,o),
+(668,359,o),
+(668,242,cs),
+(668,124,o),
+(610,54,o),
+(508,54,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(719,637,l),
+(719,690,l),
+(71,690,l),
+(71,637,l)
+);
+}
+);
+width = 801;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159D;
+unicode = 5533;
+},
+{
+glyphname = "thaWoodScree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(729,0,l),
+(729,53,l),
+(392,53,l),
+(398,40,l),
+(471,71,o),
+(510,152,o),
+(510,243,cs),
+(510,393,o),
+(425,484,o),
+(291,484,cs),
+(157,484,o),
+(71,392,o),
+(71,242,cs),
+(71,93,o),
+(156,0,o),
+(298,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(191,54,o),
+(132,124,o),
+(132,242,cs),
+(132,359,o),
+(190,430,o),
+(291,430,cs),
+(391,430,o),
+(449,360,o),
+(449,242,cs),
+(449,127,o),
+(391,54,o),
+(293,54,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(729,637,l),
+(729,690,l),
+(82,690,l),
+(82,637,l)
+);
+}
+);
+width = 801;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159E;
+unicode = 5534;
+},
+{
+glyphname = "thWoodScree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(428,345,l),
+(428,385,l),
+(240,385,l),
+(242,368,l),
+(279,382,o),
+(301,427,o),
+(301,478,cs),
+(301,557,o),
+(254,607,o),
+(185,607,cs),
+(116,607,o),
+(68,556,o),
+(68,476,cs),
+(68,396,o),
+(115,345,o),
+(190,345,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(140,381,o),
+(109,416,o),
+(109,476,cs),
+(109,536,o),
+(140,570,o),
+(185,570,cs),
+(230,570,o),
+(260,536,o),
+(260,476,cs),
+(260,416,o),
+(230,381,o),
+(185,381,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(427,676,l),
+(427,717,l),
+(72,717,l),
+(72,676,l)
+);
+}
+);
+width = 496;
+}
+);
+metricRight = "=|";
+note = uni159F;
+unicode = 5535;
+},
+{
+glyphname = "lhi-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (462,690);
+},
+{
+name = top_right_can;
+pos = (547,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(350,0,l),
+(350,55,l),
+(309,55,ls),
+(191,55,o),
+(129,122,o),
+(129,234,cs),
+(129,344,o),
+(185,415,o),
+(308,415,cs),
+(725,415,l),
+(725,467,l),
+(554,722,l),
+(508,690,l),
+(680,435,l),
+(678,472,l),
+(307,472,ls),
+(151,472,o),
+(68,377,o),
+(68,234,cs),
+(68,90,o),
+(156,0,o),
+(304,0,cs)
+);
+}
+);
+width = 787;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A0;
+unicode = 5536;
+},
+{
+glyphname = "lhii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "lhi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (400,0);
+ref = dot_top;
+}
+);
+width = 787;
+}
+);
+note = uni15A1;
+unicode = 5537;
+},
+{
+glyphname = "lho-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (383,490);
+},
+{
+name = top_right_can;
+pos = (494,490);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(279,-218,l),
+(108,37,l),
+(109,0,l),
+(478,0,ls),
+(633,0,o),
+(720,90,o),
+(720,237,cs),
+(720,383,o),
+(631,471,o),
+(483,471,cs),
+(439,471,l),
+(439,416,l),
+(479,416,ls),
+(596,416,o),
+(659,350,o),
+(659,238,cs),
+(659,123,o),
+(596,56,o),
+(479,56,cs),
+(62,56,l),
+(62,6,l),
+(234,-249,l)
+);
+}
+);
+width = 788;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni15A2;
+unicode = 5538;
+},
+{
+glyphname = "lhoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "lho-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (432,-200);
+ref = dot_top;
+}
+);
+width = 787;
+}
+);
+note = uni15A3;
+unicode = 5539;
+},
+{
+glyphname = "lha-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (408,490);
+},
+{
+name = top_left_can;
+pos = (296,490);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(725,6,l),
+(725,56,l),
+(311,56,ls),
+(193,56,o),
+(129,122,o),
+(129,238,cs),
+(129,351,o),
+(190,416,o),
+(306,416,cs),
+(350,416,l),
+(350,472,l),
+(306,472,ls),
+(154,472,o),
+(68,382,o),
+(68,237,cs),
+(68,88,o),
+(156,0,o),
+(310,0,cs),
+(678,0,l),
+(680,38,l),
+(508,-218,l),
+(554,-249,l)
+);
+}
+);
+width = 787;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A4;
+unicode = 5540;
+},
+{
+glyphname = "lhaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "lha-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (234,-200);
+ref = dot_top;
+}
+);
+width = 787;
+}
+);
+note = uni15A5;
+unicode = 5541;
+},
+{
+glyphname = "lh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(434,350,l),
+(434,387,l),
+(239,387,ls),
+(151,387,o),
+(111,436,o),
+(111,518,cs),
+(111,600,o),
+(151,647,o),
+(235,647,cs),
+(248,647,l),
+(248,690,l),
+(233,690,ls),
+(124,690,o),
+(66,622,o),
+(66,518,cs),
+(66,412,o),
+(124,345,o),
+(235,345,cs),
+(405,345,l),
+(401,372,l),
+(308,230,l),
+(341,208,l)
+);
+}
+);
+width = 500;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni15A6;
+unicode = 5542;
+},
+{
+glyphname = "theThCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (78,690);
+},
+{
+name = top_right_can;
+pos = (440,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(470,0,l),
+(470,117,l),
+(552,117,l),
+(552,157,l),
+(470,157,l),
+(470,310,l),
+(123,310,l),
+(121,278,l),
+(484,664,l),
+(441,701,l),
+(47,280,l),
+(47,255,l),
+(409,255,l),
+(409,157,l),
+(165,157,l),
+(165,117,l),
+(409,117,l),
+(409,0,l)
+);
+}
+);
+width = 587;
+}
+);
+metricLeft = "ye-canadian";
+note = uni15A7;
+unicode = 5543;
+},
+{
+glyphname = "thiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (147,690);
+},
+{
+name = top_right_can;
+pos = (509,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(178,0,l),
+(178,117,l),
+(422,117,l),
+(422,157,l),
+(178,157,l),
+(178,255,l),
+(539,255,l),
+(539,280,l),
+(146,701,l),
+(104,664,l),
+(468,277,l),
+(466,310,l),
+(116,310,l),
+(116,157,l),
+(35,157,l),
+(35,117,l),
+(116,117,l),
+(116,0,l)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+unicode = 5544;
+},
+{
+glyphname = "thiiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (86,0);
+ref = dot_top;
+}
+);
+width = 587;
+}
+);
+note = uni15A9;
+unicode = 5545;
+},
+{
+glyphname = "thoThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (78,690);
+},
+{
+name = top_right_can;
+pos = (440,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(483,26,l),
+(120,411,l),
+(122,380,l),
+(470,380,l),
+(470,532,l),
+(552,532,l),
+(552,573,l),
+(470,573,l),
+(470,690,l),
+(409,690,l),
+(409,573,l),
+(165,573,l),
+(165,532,l),
+(409,532,l),
+(409,435,l),
+(47,435,l),
+(47,410,l),
+(441,-12,l)
+);
+}
+);
+width = 587;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+unicode = 5546;
+},
+{
+glyphname = "thooThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (378,0);
+ref = dot_top;
+}
+);
+width = 587;
+}
+);
+note = uni15AB;
+unicode = 5547;
+},
+{
+glyphname = "thaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (147,690);
+},
+{
+name = top_right_can;
+pos = (509,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(539,410,l),
+(539,435,l),
+(178,435,l),
+(178,532,l),
+(422,532,l),
+(422,573,l),
+(178,573,l),
+(178,690,l),
+(116,690,l),
+(116,573,l),
+(35,573,l),
+(35,532,l),
+(116,532,l),
+(116,380,l),
+(466,380,l),
+(468,411,l),
+(104,26,l),
+(146,-12,l)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+unicode = 5548;
+},
+{
+glyphname = "thaaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:54:49 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (85,0);
+ref = dot_top;
+}
+);
+width = 586;
+}
+);
+note = uni15AD;
+unicode = 5549;
+},
+{
+glyphname = "thThCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(321,546,l),
+(321,562,l),
+(143,562,l),
+(143,612,l),
+(262,612,l),
+(262,639,l),
+(143,639,l),
+(143,690,l),
+(97,690,l),
+(97,639,l),
+(56,639,l),
+(56,612,l),
+(97,612,l),
+(97,524,l),
+(274,524,l),
+(269,549,l),
+(96,362,l),
+(127,336,l)
+);
+}
+);
+width = 362;
+}
+);
+metricRight = "y-canadian";
+note = uni15AE;
+unicode = 5550;
+},
+{
+glyphname = "bAivilik-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(425,-13,o),
+(508,84,o),
+(508,237,cs),
+(508,387,o),
+(424,484,o),
+(302,484,cs),
+(215,484,o),
+(152,433,o),
+(135,363,c),
+(142,349,l),
+(142,690,l),
+(80,690,l),
+(80,0,l),
+(140,0,l),
+(140,124,l),
+(135,110,l),
+(152,40,o),
+(215,-13,o),
+(303,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,42,o),
+(142,112,o),
+(142,236,cs),
+(142,359,o),
+(200,430,o),
+(295,430,cs),
+(388,430,o),
+(447,359,o),
+(447,236,cs),
+(447,112,o),
+(389,42,o),
+(295,42,cs)
+);
+}
+);
+width = 576;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|ke-canadian";
+note = uni15AF;
+unicode = 5551;
+},
+{
+glyphname = "eBlackfoot-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,0,l),
+(142,409,l),
+(171,373,o),
+(213,353,o),
+(264,353,cs),
+(359,353,o),
+(427,427,o),
+(427,527,cs),
+(427,628,o),
+(359,702,o),
+(264,702,cs),
+(213,702,o),
+(168,680,o),
+(140,644,c),
+(140,690,l),
+(80,690,l),
+(80,0,l)
+);
+}
+);
+width = 472;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B0;
+unicode = 5552;
+},
+{
+glyphname = "iBlackfoot-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(260,-13,o),
+(303,10,o),
+(331,45,c),
+(331,0,l),
+(391,0,l),
+(391,690,l),
+(329,690,l),
+(329,281,l),
+(301,317,o),
+(258,337,o),
+(208,337,cs),
+(112,337,o),
+(45,263,o),
+(45,162,cs),
+(45,62,o),
+(112,-13,o),
+(208,-13,cs)
+);
+}
+);
+width = 471;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B1;
+unicode = 5553;
+},
+{
+glyphname = "oBlackfoot-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(359,-13,o),
+(427,62,o),
+(427,162,cs),
+(427,263,o),
+(359,337,o),
+(264,337,cs),
+(213,337,o),
+(171,317,o),
+(142,281,c),
+(142,690,l),
+(80,690,l),
+(80,0,l),
+(140,0,l),
+(140,45,l),
+(168,10,o),
+(213,-13,o),
+(264,-13,cs)
+);
+}
+);
+width = 472;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "eBlackfoot-canadian";
+note = uni15B2;
+unicode = 5554;
+},
+{
+glyphname = "aBlackfoot-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(391,0,l),
+(391,690,l),
+(331,690,l),
+(331,644,l),
+(303,680,o),
+(260,702,o),
+(208,702,cs),
+(112,702,o),
+(45,628,o),
+(45,527,cs),
+(45,427,o),
+(112,353,o),
+(208,353,cs),
+(258,353,o),
+(301,373,o),
+(329,409,c),
+(329,0,l)
+);
+}
+);
+width = 471;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B3;
+unicode = 5555;
+},
+{
+glyphname = "weBlackfoot-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,319,l),
+(492,319,l),
+(492,372,l),
+(142,372,l),
+(142,637,l),
+(492,637,l),
+(492,690,l),
+(80,690,l),
+(80,0,l),
+(142,0,l)
+);
+}
+);
+width = 552;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B4;
+unicode = 5556;
+},
+{
+glyphname = "wiBlackfoot-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(471,0,l),
+(471,690,l),
+(410,690,l),
+(410,371,l),
+(60,371,l),
+(60,318,l),
+(410,318,l),
+(410,53,l),
+(60,53,l),
+(60,0,l)
+);
+}
+);
+width = 551;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B5;
+unicode = 5557;
+},
+{
+glyphname = "woBlackfoot-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(492,0,l),
+(492,53,l),
+(142,53,l),
+(142,318,l),
+(492,318,l),
+(492,371,l),
+(142,371,l),
+(142,690,l),
+(80,690,l),
+(80,0,l)
+);
+}
+);
+width = 552;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "weBlackfoot-canadian";
+note = uni15B6;
+unicode = 5558;
+},
+{
+glyphname = "waBlackfoot-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(471,0,l),
+(471,690,l),
+(60,690,l),
+(60,637,l),
+(410,637,l),
+(410,372,l),
+(60,372,l),
+(60,319,l),
+(410,319,l),
+(410,0,l)
+);
+}
+);
+width = 551;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B7;
+unicode = 5559;
+},
+{
+glyphname = "neBlackfoot-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,0,l),
+(142,641,l),
+(187,641,l),
+(164,678,l),
+(164,656,ls),
+(164,501,o),
+(243,408,o),
+(376,408,cs),
+(507,408,o),
+(590,501,o),
+(590,651,cs),
+(590,690,l),
+(530,690,l),
+(530,649,ls),
+(530,531,o),
+(473,462,o),
+(377,462,cs),
+(281,462,o),
+(225,530,o),
+(225,648,cs),
+(225,690,l),
+(80,690,l),
+(80,0,l)
+);
+}
+);
+width = 635;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B8;
+unicode = 5560;
+},
+{
+glyphname = "niBlackfoot-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(106,0,l),
+(106,41,ls),
+(106,158,o),
+(163,228,o),
+(259,228,cs),
+(356,228,o),
+(412,159,o),
+(412,42,cs),
+(412,0,l),
+(555,0,l),
+(555,690,l),
+(494,690,l),
+(494,48,l),
+(449,48,l),
+(472,12,l),
+(472,34,ls),
+(472,188,o),
+(393,282,o),
+(260,282,cs),
+(129,282,o),
+(45,188,o),
+(45,39,cs),
+(45,0,l)
+);
+}
+);
+width = 635;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B9;
+unicode = 5561;
+},
+{
+glyphname = "noBlackfoot-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(225,0,l),
+(225,42,ls),
+(225,159,o),
+(281,228,o),
+(377,228,cs),
+(473,228,o),
+(530,158,o),
+(530,41,cs),
+(530,0,l),
+(590,0,l),
+(590,39,ls),
+(590,188,o),
+(507,282,o),
+(376,282,cs),
+(243,282,o),
+(164,188,o),
+(164,34,cs),
+(164,12,l),
+(187,48,l),
+(142,48,l),
+(142,690,l),
+(80,690,l),
+(80,0,l)
+);
+}
+);
+width = 635;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "neBlackfoot-canadian";
+note = uni15BA;
+unicode = 5562;
+},
+{
+glyphname = "naBlackfoot-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(555,0,l),
+(555,690,l),
+(412,690,l),
+(412,648,ls),
+(412,530,o),
+(356,462,o),
+(259,462,cs),
+(163,462,o),
+(106,531,o),
+(106,649,cs),
+(106,690,l),
+(45,690,l),
+(45,651,ls),
+(45,501,o),
+(129,408,o),
+(260,408,cs),
+(393,408,o),
+(472,501,o),
+(472,656,cs),
+(472,678,l),
+(449,641,l),
+(494,641,l),
+(494,0,l)
+);
+}
+);
+width = 635;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BB;
+unicode = 5563;
+},
+{
+glyphname = "keBlackfoot-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,0,l),
+(142,623,l),
+(116,623,l),
+(307,258,l),
+(337,258,l),
+(565,690,l),
+(500,690,l),
+(306,318,l),
+(332,318,l),
+(138,690,l),
+(80,690,l),
+(80,0,l)
+);
+}
+);
+width = 594;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15BC;
+unicode = 5564;
+},
+{
+glyphname = "kiBlackfoot-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(94,0,l),
+(288,372,l),
+(262,372,l),
+(457,0,l),
+(514,0,l),
+(514,690,l),
+(452,690,l),
+(452,67,l),
+(479,67,l),
+(288,432,l),
+(257,432,l),
+(29,0,l)
+);
+}
+);
+width = 594;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BD;
+unicode = 5565;
+},
+{
+glyphname = "koBlackfoot-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(138,0,l),
+(332,372,l),
+(306,372,l),
+(500,0,l),
+(565,0,l),
+(337,432,l),
+(307,432,l),
+(116,67,l),
+(142,67,l),
+(142,690,l),
+(80,690,l),
+(80,0,l)
+);
+}
+);
+width = 594;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "keBlackfoot-canadian";
+note = uni15BE;
+unicode = 5566;
+},
+{
+glyphname = "kaBlackfoot-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(514,0,l),
+(514,690,l),
+(457,690,l),
+(262,318,l),
+(288,318,l),
+(94,690,l),
+(29,690,l),
+(257,258,l),
+(288,258,l),
+(479,623,l),
+(452,623,l),
+(452,0,l)
+);
+}
+);
+width = 594;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BF;
+unicode = 5567;
+},
+{
+color = 9;
+glyphname = "heSayisi-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_right_can;
+pos = (527,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(557,0,l),
+(557,690,l),
+(497,690,l),
+(497,245,l),
+(509,245,l),
+(501,510,o),
+(416,702,o),
+(252,702,cs),
+(129,702,o),
+(61,618,o),
+(61,457,cs),
+(61,422,o),
+(65,381,o),
+(73,340,c),
+(132,340,l),
+(124,380,o),
+(121,421,o),
+(121,453,cs),
+(121,587,o),
+(172,647,o),
+(263,647,cs),
+(412,647,o),
+(496,443,o),
+(497,0,c)
+);
+}
+);
+width = 637;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni15C0;
+unicode = 5568;
+},
+{
+color = 9;
+glyphname = "hiSayisi-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,0,l),
+(143,443,o),
+(227,647,o),
+(376,647,cs),
+(467,647,o),
+(518,587,o),
+(518,453,cs),
+(518,421,o),
+(515,380,o),
+(506,340,c),
+(565,340,l),
+(574,381,o),
+(578,422,o),
+(578,457,cs),
+(578,618,o),
+(509,702,o),
+(386,702,cs),
+(222,702,o),
+(137,510,o),
+(129,245,c),
+(142,245,l),
+(142,690,l),
+(80,690,l),
+(80,0,l)
+);
+}
+);
+width = 639;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C1;
+unicode = 5569;
+},
+{
+color = 9;
+glyphname = "hoSayisi-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (315,690);
+},
+{
+name = top_left_can;
+pos = (102,690);
+},
+{
+name = top_right_can;
+pos = (527,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(416,-13,o),
+(501,180,o),
+(509,444,c),
+(497,444,l),
+(497,0,l),
+(557,0,l),
+(557,690,l),
+(497,690,l),
+(496,246,o),
+(412,43,o),
+(263,43,cs),
+(172,43,o),
+(121,102,o),
+(121,237,cs),
+(121,269,o),
+(124,310,o),
+(132,350,c),
+(73,350,l),
+(65,309,o),
+(61,268,o),
+(61,233,cs),
+(61,71,o),
+(129,-13,o),
+(252,-13,cs)
+);
+}
+);
+width = 637;
+}
+);
+metricLeft = "heSayisi-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15C2;
+unicode = 5570;
+},
+{
+color = 9;
+glyphname = "haSayisi-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(509,-13,o),
+(578,71,o),
+(578,233,cs),
+(578,268,o),
+(574,309,o),
+(565,350,c),
+(506,350,l),
+(515,310,o),
+(518,269,o),
+(518,237,cs),
+(518,102,o),
+(467,43,o),
+(376,43,cs),
+(227,43,o),
+(143,246,o),
+(142,690,c),
+(80,690,l),
+(80,0,l),
+(142,0,l),
+(142,444,l),
+(129,444,l),
+(137,180,o),
+(222,-13,o),
+(386,-13,cs)
+);
+}
+);
+width = 639;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C3;
+unicode = 5571;
+},
+{
+color = 9;
+glyphname = "ghuCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(359,0,l),
+(655,670,l),
+(655,690,l),
+(603,690,l),
+(498,447,l),
+(531,461,l),
+(160,461,l),
+(194,447,l),
+(90,690,l),
+(36,690,l),
+(36,670,l),
+(331,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(513,412,l),
+(491,424,l),
+(334,64,l),
+(358,64,l),
+(202,425,l),
+(181,412,l)
+);
+}
+);
+width = 691;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C4;
+unicode = 5572;
+},
+{
+color = 9;
+glyphname = "ghoCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(90,0,l),
+(194,242,l),
+(160,229,l),
+(531,229,l),
+(498,242,l),
+(603,0,l),
+(655,0,l),
+(655,19,l),
+(359,690,l),
+(331,690,l),
+(36,19,l),
+(36,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(358,626,l),
+(334,626,l),
+(491,266,l),
+(513,277,l),
+(181,277,l),
+(202,265,l)
+);
+}
+);
+width = 691;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C5;
+unicode = 5573;
+},
+{
+color = 9;
+glyphname = "gheCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (75,345);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(76,0,l),
+(599,331,l),
+(599,358,l),
+(76,690,l),
+(57,690,l),
+(57,639,l),
+(219,536,l),
+(212,562,l),
+(212,123,l),
+(219,155,l),
+(57,51,l),
+(57,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(260,544,l),
+(246,525,l),
+(550,330,l),
+(550,359,l),
+(246,166,l),
+(260,147,l)
+);
+}
+);
+width = 635;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15C6;
+unicode = 5574;
+},
+{
+color = 9;
+glyphname = "gheeCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (39,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 636;
+}
+);
+note = uni15C7;
+unicode = 5575;
+},
+{
+color = 9;
+glyphname = "ghiCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (17,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 636;
+}
+);
+note = uni15C8;
+unicode = 5576;
+},
+{
+color = 9;
+glyphname = "ghaCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(577,0,l),
+(577,50,l),
+(417,153,l),
+(426,124,l),
+(426,566,l),
+(417,537,l),
+(577,639,l),
+(577,690,l),
+(558,690,l),
+(36,358,l),
+(36,331,l),
+(558,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(391,164,l),
+(85,359,l),
+(85,330,l),
+(391,526,l),
+(378,541,l),
+(378,150,l)
+);
+}
+);
+width = 634;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15C9;
+unicode = 5577;
+},
+{
+color = 9;
+glyphname = "ruCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(359,0,l),
+(655,670,l),
+(655,690,l),
+(603,690,l),
+(562,596,l),
+(581,608,l),
+(110,608,l),
+(130,595,l),
+(90,690,l),
+(36,690,l),
+(36,670,l),
+(331,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(565,557,l),
+(554,574,l),
+(335,65,l),
+(358,65,l),
+(139,573,l),
+(126,557,l)
+);
+}
+);
+width = 691;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CA;
+unicode = 5578;
+},
+{
+color = 9;
+glyphname = "roCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(89,0,l),
+(129,94,l),
+(110,82,l),
+(581,82,l),
+(562,95,l),
+(603,0,l),
+(655,0,l),
+(655,19,l),
+(359,690,l),
+(331,690,l),
+(36,19,l),
+(36,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(357,627,l),
+(334,627,l),
+(553,117,l),
+(565,132,l),
+(127,132,l),
+(137,116,l)
+);
+}
+);
+width = 691;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CB;
+unicode = 5579;
+},
+{
+color = 9;
+glyphname = "reCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(76,0,l),
+(599,331,l),
+(599,358,l),
+(76,690,l),
+(57,690,l),
+(57,639,l),
+(134,590,l),
+(124,611,l),
+(124,77,l),
+(134,99,l),
+(57,50,l),
+(57,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(173,594,l),
+(161,577,l),
+(548,330,l),
+(548,359,l),
+(161,114,l),
+(173,96,l)
+);
+}
+);
+width = 635;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CC;
+unicode = 5580;
+},
+{
+color = 9;
+glyphname = "reeCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(76,0,l),
+(599,331,l),
+(599,358,l),
+(76,690,l),
+(57,690,l),
+(57,644,l),
+(134,595,l),
+(124,614,l),
+(124,73,l),
+(134,95,l),
+(57,45,l),
+(57,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(168,597,l),
+(157,584,l),
+(557,330,l),
+(557,359,l),
+(157,105,l),
+(168,96,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(268,254,l),
+(268,438,l),
+(235,438,l),
+(235,254,l)
+);
+}
+);
+width = 635;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CD;
+unicode = 5581;
+},
+{
+color = 9;
+glyphname = "riCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(76,0,l),
+(599,331,l),
+(599,358,l),
+(76,690,l),
+(57,690,l),
+(57,644,l),
+(134,595,l),
+(124,614,l),
+(124,73,l),
+(134,95,l),
+(57,45,l),
+(57,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(292,308,o),
+(308,324,o),
+(308,345,cs),
+(308,366,o),
+(292,382,o),
+(271,382,cs),
+(251,382,o),
+(235,366,o),
+(235,345,cs),
+(235,324,o),
+(251,308,o),
+(271,308,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(168,596,l),
+(157,583,l),
+(557,330,l),
+(557,359,l),
+(157,106,l),
+(168,97,l)
+);
+}
+);
+width = 635;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CE;
+unicode = 5582;
+},
+{
+color = 9;
+glyphname = "raCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(577,0,l),
+(577,51,l),
+(501,99,l),
+(511,74,l),
+(511,615,l),
+(501,590,l),
+(577,639,l),
+(577,690,l),
+(557,690,l),
+(36,358,l),
+(36,331,l),
+(557,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(474,578,l),
+(462,594,l),
+(462,97,l),
+(474,113,l),
+(87,359,l),
+(87,330,l)
+);
+}
+);
+width = 634;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15CF;
+unicode = 5583;
+},
+{
+color = 9;
+glyphname = "wuCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(362,0,l),
+(660,670,l),
+(660,690,l),
+(611,690,l),
+(358,101,l),
+(375,101,l),
+(375,690,l),
+(324,690,l),
+(324,101,l),
+(340,101,l),
+(87,690,l),
+(36,690,l),
+(36,670,l),
+(333,0,l)
+);
+}
+);
+width = 696;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D0;
+unicode = 5584;
+},
+{
+color = 9;
+glyphname = "woCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(86,0,l),
+(338,588,l),
+(323,588,l),
+(323,0,l),
+(373,0,l),
+(373,588,l),
+(356,588,l),
+(610,0,l),
+(660,0,l),
+(660,19,l),
+(362,690,l),
+(333,690,l),
+(36,19,l),
+(36,0,l)
+);
+}
+);
+width = 696;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D1;
+unicode = 5585;
+},
+{
+color = 9;
+glyphname = "weCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,0,l),
+(619,331,l),
+(619,358,l),
+(97,690,l),
+(77,690,l),
+(77,639,l),
+(529,355,l),
+(529,370,l),
+(78,370,l),
+(78,321,l),
+(529,321,l),
+(529,335,l),
+(77,50,l),
+(77,0,l)
+);
+}
+);
+width = 655;
+}
+);
+metricRight = "o-canadian";
+note = uni15D2;
+unicode = 5586;
+},
+{
+color = 9;
+glyphname = "weeCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,0,l),
+(619,331,l),
+(619,358,l),
+(97,690,l),
+(77,690,l),
+(77,643,l),
+(540,353,l),
+(544,366,l),
+(199,366,l),
+(199,450,l),
+(160,450,l),
+(160,366,l),
+(77,366,l),
+(77,325,l),
+(160,325,l),
+(160,241,l),
+(199,241,l),
+(199,325,l),
+(546,325,l),
+(542,338,l),
+(77,46,l),
+(77,0,l)
+);
+}
+);
+width = 655;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D3;
+unicode = 5587;
+},
+{
+color = 9;
+glyphname = "wiCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,0,l),
+(619,331,l),
+(619,358,l),
+(97,690,l),
+(77,690,l),
+(77,643,l),
+(540,353,l),
+(545,366,l),
+(266,366,l),
+(258,389,o),
+(236,406,o),
+(211,406,cs),
+(185,406,o),
+(163,389,o),
+(156,366,c),
+(77,366,l),
+(77,325,l),
+(156,325,l),
+(164,302,o),
+(185,285,o),
+(211,285,cs),
+(236,285,o),
+(257,302,o),
+(265,325,c),
+(547,325,l),
+(542,338,l),
+(77,46,l),
+(77,0,l)
+);
+}
+);
+width = 655;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D4;
+unicode = 5588;
+},
+{
+color = 9;
+glyphname = "waCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(577,0,l),
+(577,50,l),
+(126,335,l),
+(126,320,l),
+(576,320,l),
+(576,369,l),
+(126,369,l),
+(126,355,l),
+(577,639,l),
+(577,690,l),
+(558,690,l),
+(36,358,l),
+(36,331,l),
+(558,0,l)
+);
+}
+);
+width = 654;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15D5;
+unicode = 5589;
+},
+{
+color = 9;
+glyphname = "hwuCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(362,0,l),
+(660,670,l),
+(660,690,l),
+(612,690,l),
+(511,454,l),
+(535,467,l),
+(370,467,l),
+(370,690,l),
+(327,690,l),
+(327,467,l),
+(160,467,l),
+(185,455,l),
+(84,690,l),
+(36,690,l),
+(36,670,l),
+(333,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(329,428,l),
+(329,89,l),
+(341,91,l),
+(190,440,l),
+(176,428,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(367,428,l),
+(521,428,l),
+(507,440,l),
+(355,91,l),
+(367,88,l)
+);
+}
+);
+width = 696;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D6;
+unicode = 5590;
+},
+{
+color = 9;
+glyphname = "hwoCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(84,0,l),
+(186,236,l),
+(161,222,l),
+(327,222,l),
+(327,0,l),
+(370,0,l),
+(370,222,l),
+(537,222,l),
+(511,236,l),
+(612,0,l),
+(660,0,l),
+(660,19,l),
+(362,690,l),
+(333,690,l),
+(36,19,l),
+(36,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(336,590,l),
+(328,592,l),
+(328,263,l),
+(180,263,l),
+(189,249,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(519,263,l),
+(367,263,l),
+(367,593,l),
+(359,591,l),
+(506,249,l)
+);
+}
+);
+width = 696;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D7;
+unicode = 5591;
+},
+{
+color = 9;
+glyphname = "hweCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,0,l),
+(619,331,l),
+(619,358,l),
+(97,690,l),
+(77,690,l),
+(77,643,l),
+(230,548,l),
+(230,367,l),
+(77,367,l),
+(77,324,l),
+(230,324,l),
+(230,142,l),
+(77,45,l),
+(77,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(267,327,l),
+(529,327,l),
+(267,161,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(267,528,l),
+(526,364,l),
+(267,364,l)
+);
+}
+);
+width = 655;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D8;
+unicode = 5592;
+},
+{
+color = 9;
+glyphname = "hweeCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,0,l),
+(619,331,l),
+(619,358,l),
+(97,690,l),
+(77,690,l),
+(77,644,l),
+(242,543,l),
+(242,365,l),
+(183,365,l),
+(183,448,l),
+(148,448,l),
+(148,365,l),
+(77,365,l),
+(77,326,l),
+(148,326,l),
+(148,242,l),
+(183,242,l),
+(183,326,l),
+(242,326,l),
+(242,147,l),
+(77,45,l),
+(77,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(275,327,l),
+(531,327,l),
+(275,165,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(275,524,l),
+(529,363,l),
+(275,363,l)
+);
+}
+);
+width = 655;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D9;
+unicode = 5593;
+},
+{
+color = 9;
+glyphname = "hwiCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,0,l),
+(619,331,l),
+(619,358,l),
+(97,690,l),
+(77,690,l),
+(77,644,l),
+(242,543,l),
+(242,363,l),
+(212,363,l),
+(205,384,o),
+(185,400,o),
+(161,400,cs),
+(138,400,o),
+(120,384,o),
+(113,363,c),
+(77,363,l),
+(77,327,l),
+(113,327,l),
+(120,307,o),
+(139,291,o),
+(162,291,cs),
+(185,291,o),
+(204,307,o),
+(211,327,c),
+(242,327,l),
+(242,147,l),
+(77,45,l),
+(77,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(275,327,l),
+(531,327,l),
+(275,165,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(275,524,l),
+(529,363,l),
+(275,363,l)
+);
+}
+);
+width = 655;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15DA;
+unicode = 5594;
+},
+{
+color = 9;
+glyphname = "hwaCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(577,0,l),
+(577,46,l),
+(424,142,l),
+(424,323,l),
+(577,323,l),
+(577,366,l),
+(424,366,l),
+(424,548,l),
+(577,643,l),
+(577,690,l),
+(558,690,l),
+(36,358,l),
+(36,331,l),
+(558,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(128,326,l),
+(387,326,l),
+(387,161,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(387,528,l),
+(387,363,l),
+(126,363,l)
+);
+}
+);
+width = 654;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15DB;
+unicode = 5595;
+},
+{
+color = 9;
+glyphname = "thuCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(512,-13,o),
+(615,99,o),
+(615,293,cs),
+(615,690,l),
+(73,690,l),
+(73,289,ls),
+(73,98,o),
+(179,-13,o),
+(344,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(134,634,l),
+(554,634,l),
+(554,290,ls),
+(554,129,o),
+(477,45,o),
+(344,45,cs),
+(214,45,o),
+(134,130,o),
+(134,290,cs)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DC;
+unicode = 5596;
+},
+{
+color = 9;
+glyphname = "thoCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(615,0,l),
+(615,401,ls),
+(615,591,o),
+(510,702,o),
+(346,702,cs),
+(177,702,o),
+(73,592,o),
+(73,397,cs),
+(73,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(134,400,ls),
+(134,560,o),
+(213,644,o),
+(345,644,cs),
+(474,644,o),
+(554,559,o),
+(554,400,cs),
+(554,56,l),
+(134,56,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DD;
+unicode = 5597;
+},
+{
+color = 9;
+glyphname = "theCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (332,345);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(285,0,ls),
+(488,0,o),
+(601,129,o),
+(601,346,cs),
+(601,562,o),
+(488,690,o),
+(281,690,cs),
+(80,690,l),
+(80,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(142,656,l),
+(121,635,l),
+(281,635,ls),
+(452,635,o),
+(539,531,o),
+(539,346,cs),
+(539,161,o),
+(452,55,o),
+(283,55,cs),
+(121,55,l),
+(142,34,l)
+);
+}
+);
+width = 667;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "to-canadian";
+note = uni15DE;
+unicode = 5598;
+},
+{
+color = 9;
+glyphname = "theeCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (293,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 668;
+}
+);
+note = uni15DF;
+unicode = 5599;
+},
+{
+color = 9;
+glyphname = "thiCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (270,0);
+ref = dot_middle;
+}
+);
+width = 668;
+}
+);
+note = uni15E0;
+unicode = 5600;
+},
+{
+color = 9;
+glyphname = "thaCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(586,0,l),
+(586,690,l),
+(384,690,ls),
+(179,690,o),
+(66,561,o),
+(66,345,cs),
+(66,128,o),
+(179,0,o),
+(383,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(127,529,o),
+(214,635,o),
+(384,635,cs),
+(546,635,l),
+(525,656,l),
+(525,34,l),
+(546,55,l),
+(385,55,ls),
+(214,55,o),
+(127,159,o),
+(127,345,cs)
+);
+}
+);
+width = 666;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15E1;
+unicode = 5601;
+},
+{
+color = 9;
+glyphname = "ttuCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(512,-13,o),
+(615,99,o),
+(615,293,cs),
+(615,690,l),
+(588,690,l),
+(336,502,l),
+(354,502,l),
+(101,690,l),
+(73,690,l),
+(73,289,ls),
+(73,98,o),
+(179,-13,o),
+(344,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(214,45,o),
+(134,130,o),
+(134,290,cs),
+(134,641,l),
+(83,640,l),
+(335,453,l),
+(354,453,l),
+(606,640,l),
+(554,641,l),
+(554,290,ls),
+(554,129,o),
+(477,45,o),
+(344,45,cs)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E2;
+unicode = 5602;
+},
+{
+color = 9;
+glyphname = "ttoCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,0,l),
+(353,187,l),
+(335,187,l),
+(586,0,l),
+(615,0,l),
+(615,401,ls),
+(615,592,o),
+(510,702,o),
+(344,702,cs),
+(176,702,o),
+(73,591,o),
+(73,397,cs),
+(73,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(474,644,o),
+(554,559,o),
+(554,400,cs),
+(554,48,l),
+(606,49,l),
+(353,237,l),
+(335,237,l),
+(83,49,l),
+(134,48,l),
+(134,400,ls),
+(134,560,o),
+(212,644,o),
+(345,644,cs)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E3;
+unicode = 5603;
+},
+{
+color = 9;
+glyphname = "tteCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (384,345);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(295,0,ls),
+(497,0,o),
+(611,129,o),
+(611,346,cs),
+(611,562,o),
+(497,690,o),
+(290,690,cs),
+(72,690,l),
+(72,670,l),
+(196,333,l),
+(196,356,l),
+(72,19,l),
+(72,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(250,335,l),
+(250,352,l),
+(128,684,l),
+(128,635,l),
+(291,635,ls),
+(462,635,o),
+(549,531,o),
+(549,346,cs),
+(549,161,o),
+(462,55,o),
+(293,55,cs),
+(128,55,l),
+(128,4,l)
+);
+}
+);
+width = 677;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15E4;
+unicode = 5604;
+},
+{
+color = 9;
+glyphname = "tteeCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (347,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 677;
+}
+);
+note = uni15E5;
+unicode = 5605;
+},
+{
+color = 9;
+glyphname = "ttiCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (330,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 677;
+}
+);
+note = uni15E6;
+unicode = 5606;
+},
+{
+color = 9;
+glyphname = "ttaCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(603,0,l),
+(603,19,l),
+(480,356,l),
+(480,333,l),
+(603,670,l),
+(603,690,l),
+(384,690,ls),
+(179,690,o),
+(66,561,o),
+(66,345,cs),
+(66,128,o),
+(179,0,o),
+(383,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(548,55,l),
+(385,55,ls),
+(214,55,o),
+(127,159,o),
+(127,345,cs),
+(127,529,o),
+(214,635,o),
+(384,635,cs),
+(548,635,l),
+(548,686,l),
+(426,355,l),
+(426,338,l),
+(548,7,l)
+);
+}
+);
+width = 675;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tteCarrier-canadian";
+note = uni15E7;
+unicode = 5607;
+},
+{
+color = 9;
+glyphname = "puCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(512,-13,o),
+(615,99,o),
+(615,293,cs),
+(615,690,l),
+(554,690,l),
+(554,517,l),
+(135,517,l),
+(135,690,l),
+(73,690,l),
+(73,289,ls),
+(73,98,o),
+(179,-13,o),
+(344,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(214,45,o),
+(135,130,o),
+(135,290,cs),
+(135,463,l),
+(554,463,l),
+(554,290,ls),
+(554,129,o),
+(477,45,o),
+(344,45,cs)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E8;
+unicode = 5608;
+},
+{
+color = 9;
+glyphname = "poCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(135,0,l),
+(135,173,l),
+(554,173,l),
+(554,0,l),
+(615,0,l),
+(615,401,ls),
+(615,591,o),
+(511,702,o),
+(346,702,cs),
+(178,702,o),
+(73,592,o),
+(73,397,cs),
+(73,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(135,400,ls),
+(135,560,o),
+(213,644,o),
+(345,644,cs),
+(474,644,o),
+(554,559,o),
+(554,400,cs),
+(554,227,l),
+(135,227,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E9;
+unicode = 5609;
+},
+{
+color = 9;
+glyphname = "peCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (372,345);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(289,0,ls),
+(492,0,o),
+(605,129,o),
+(605,346,cs),
+(605,562,o),
+(492,690,o),
+(284,690,cs),
+(67,690,l),
+(67,635,l),
+(157,635,l),
+(157,55,l),
+(67,55,l),
+(67,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(218,656,l),
+(194,635,l),
+(285,635,ls),
+(456,635,o),
+(543,531,o),
+(543,346,cs),
+(543,161,o),
+(456,55,o),
+(287,55,cs),
+(194,55,l),
+(218,34,l)
+);
+}
+);
+width = 671;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15EA;
+unicode = 5610;
+},
+{
+color = 9;
+glyphname = "peeCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (335,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 671;
+}
+);
+note = uni15EB;
+unicode = 5611;
+},
+{
+color = 9;
+glyphname = "piCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (319,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 671;
+}
+);
+note = uni15EC;
+unicode = 5612;
+},
+{
+color = 9;
+glyphname = "paCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(603,0,l),
+(603,55,l),
+(513,55,l),
+(513,635,l),
+(603,635,l),
+(603,690,l),
+(385,690,ls),
+(179,690,o),
+(66,562,o),
+(66,346,cs),
+(66,129,o),
+(179,0,o),
+(382,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(475,55,l),
+(383,55,ls),
+(214,55,o),
+(127,161,o),
+(127,346,cs),
+(127,531,o),
+(214,635,o),
+(385,635,cs),
+(475,635,l),
+(452,656,l),
+(452,34,l)
+);
+}
+);
+width = 670;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|peCarrier-canadian";
+note = uni15ED;
+unicode = 5613;
+},
+{
+color = 6;
+glyphname = "pCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(376,183,l),
+(376,226,l),
+(244,226,l),
+(244,527,l),
+(198,527,l),
+(198,226,l),
+(66,226,l),
+(66,183,l)
+);
+}
+);
+width = 442;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni15EE;
+unicode = 5614;
+},
+{
+color = 9;
+glyphname = "guCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (419,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(347,-13,o),
+(409,40,o),
+(431,134,c),
+(408,134,l),
+(433,39,o),
+(494,-13,o),
+(578,-13,cs),
+(691,-13,o),
+(760,69,o),
+(760,207,cs),
+(760,690,l),
+(700,690,l),
+(700,209,ls),
+(700,101,o),
+(655,43,o),
+(575,43,cs),
+(497,43,o),
+(448,103,o),
+(448,208,cs),
+(448,690,l),
+(390,690,l),
+(390,208,ls),
+(390,100,o),
+(342,43,o),
+(263,43,cs),
+(182,43,o),
+(135,100,o),
+(135,209,cs),
+(135,690,l),
+(75,690,l),
+(75,209,ls),
+(75,68,o),
+(146,-13,o),
+(260,-13,cs)
+);
+}
+);
+width = 835;
+}
+);
+metricRight = "=|";
+note = uni15EF;
+unicode = 5615;
+},
+{
+color = 9;
+glyphname = "goCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(135,0,l),
+(135,481,ls),
+(135,588,o),
+(181,646,o),
+(262,646,cs),
+(341,646,o),
+(389,588,o),
+(389,482,cs),
+(389,0,l),
+(447,0,l),
+(447,482,ls),
+(447,587,o),
+(496,646,o),
+(574,646,cs),
+(655,646,o),
+(700,588,o),
+(700,481,cs),
+(700,0,l),
+(760,0,l),
+(760,482,ls),
+(760,621,o),
+(690,702,o),
+(577,702,cs),
+(492,702,o),
+(430,650,o),
+(407,555,c),
+(430,555,l),
+(406,651,o),
+(345,702,o),
+(259,702,cs),
+(145,702,o),
+(75,621,o),
+(75,482,cs),
+(75,0,l)
+);
+}
+);
+width = 835;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F0;
+unicode = 5616;
+},
+{
+color = 9;
+glyphname = "geCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (341,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(393,0,ls),
+(529,0,o),
+(601,67,o),
+(601,182,cs),
+(601,266,o),
+(551,329,o),
+(471,354,c),
+(471,336,l),
+(553,358,o),
+(601,419,o),
+(601,506,cs),
+(601,622,o),
+(528,690,o),
+(393,690,cs),
+(80,690,l),
+(80,638,l),
+(384,638,ls),
+(490,638,o),
+(539,592,o),
+(539,505,cs),
+(539,418,o),
+(484,371,o),
+(385,371,cs),
+(80,371,l),
+(80,320,l),
+(386,320,ls),
+(485,320,o),
+(539,270,o),
+(539,184,cs),
+(539,98,o),
+(490,52,o),
+(384,52,cs),
+(80,52,l),
+(80,0,l)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15F1;
+unicode = 5617;
+},
+{
+color = 9;
+glyphname = "geeCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(393,0,ls),
+(529,0,o),
+(601,67,o),
+(601,182,cs),
+(601,266,o),
+(551,329,o),
+(471,354,c),
+(471,336,l),
+(553,358,o),
+(601,419,o),
+(601,506,cs),
+(601,622,o),
+(528,690,o),
+(393,690,cs),
+(80,690,l),
+(80,638,l),
+(384,638,ls),
+(490,638,o),
+(539,592,o),
+(539,505,cs),
+(539,418,o),
+(484,371,o),
+(385,371,cs),
+(328,371,l),
+(328,458,l),
+(288,458,l),
+(288,371,l),
+(80,371,l),
+(80,320,l),
+(288,320,l),
+(288,234,l),
+(328,234,l),
+(328,320,l),
+(386,320,ls),
+(485,320,o),
+(539,270,o),
+(539,184,cs),
+(539,98,o),
+(490,52,o),
+(384,52,cs),
+(80,52,l),
+(80,0,l)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F2;
+unicode = 5618;
+},
+{
+color = 9;
+glyphname = "giCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(393,0,ls),
+(529,0,o),
+(601,67,o),
+(601,182,cs),
+(601,268,o),
+(548,333,o),
+(464,354,c),
+(463,336,l),
+(549,355,o),
+(601,417,o),
+(601,506,cs),
+(601,622,o),
+(528,690,o),
+(393,690,cs),
+(80,690,l),
+(80,638,l),
+(384,638,ls),
+(490,638,o),
+(539,592,o),
+(539,505,cs),
+(539,418,o),
+(484,371,o),
+(387,371,cs),
+(349,371,l),
+(371,363,l),
+(363,391,o),
+(338,411,o),
+(309,411,cs),
+(283,411,o),
+(261,394,o),
+(251,371,c),
+(80,371,l),
+(80,320,l),
+(252,320,l),
+(261,297,o),
+(284,280,o),
+(310,280,cs),
+(338,280,o),
+(362,299,o),
+(371,327,c),
+(349,320,l),
+(388,320,ls),
+(485,320,o),
+(539,270,o),
+(539,184,cs),
+(539,98,o),
+(490,52,o),
+(384,52,cs),
+(80,52,l),
+(80,0,l)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F3;
+unicode = 5619;
+},
+{
+color = 9;
+glyphname = "gaCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (354,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(597,0,l),
+(597,52,l),
+(294,52,ls),
+(187,52,o),
+(138,98,o),
+(138,184,cs),
+(138,270,o),
+(192,320,o),
+(291,320,cs),
+(597,320,l),
+(597,371,l),
+(292,371,ls),
+(193,371,o),
+(138,418,o),
+(138,505,cs),
+(138,592,o),
+(187,638,o),
+(294,638,cs),
+(597,638,l),
+(597,690,l),
+(284,690,ls),
+(149,690,o),
+(76,622,o),
+(76,506,cs),
+(76,419,o),
+(125,358,o),
+(206,337,c),
+(206,355,l),
+(127,330,o),
+(76,266,o),
+(76,182,cs),
+(76,67,o),
+(148,0,o),
+(284,0,cs)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|geCarrier-canadian";
+note = uni15F4;
+unicode = 5620;
+},
+{
+color = 9;
+glyphname = "khuCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(347,-13,o),
+(409,40,o),
+(431,134,c),
+(408,134,l),
+(434,39,o),
+(495,-13,o),
+(579,-13,cs),
+(692,-13,o),
+(760,69,o),
+(760,207,cs),
+(760,690,l),
+(75,690,l),
+(75,209,ls),
+(75,68,o),
+(146,-13,o),
+(260,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(182,43,o),
+(135,100,o),
+(135,209,cs),
+(135,636,l),
+(390,636,l),
+(390,208,ls),
+(390,100,o),
+(343,43,o),
+(263,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(497,43,o),
+(448,103,o),
+(448,208,cs),
+(448,636,l),
+(700,636,l),
+(700,209,ls),
+(700,101,o),
+(655,43,o),
+(575,43,cs)
+);
+}
+);
+width = 835;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F5;
+unicode = 5621;
+},
+{
+color = 9;
+glyphname = "khoCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(760,0,l),
+(760,482,ls),
+(760,621,o),
+(691,702,o),
+(578,702,cs),
+(493,702,o),
+(432,651,o),
+(407,555,c),
+(430,555,l),
+(407,650,o),
+(345,702,o),
+(259,702,cs),
+(146,702,o),
+(75,622,o),
+(75,482,cs),
+(75,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(135,481,ls),
+(135,588,o),
+(181,646,o),
+(262,646,cs),
+(341,646,o),
+(389,588,o),
+(389,482,cs),
+(389,54,l),
+(135,54,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(447,482,ls),
+(447,587,o),
+(496,646,o),
+(575,646,cs),
+(655,646,o),
+(700,588,o),
+(700,481,cs),
+(700,54,l),
+(447,54,l)
+);
+}
+);
+width = 835;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F6;
+unicode = 5622;
+},
+{
+color = 9;
+glyphname = "kheCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(395,0,ls),
+(531,0,o),
+(603,67,o),
+(603,182,cs),
+(603,266,o),
+(554,329,o),
+(473,354,c),
+(473,336,l),
+(554,358,o),
+(603,419,o),
+(603,506,cs),
+(603,622,o),
+(530,690,o),
+(395,690,cs),
+(80,690,l),
+(80,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(142,320,l),
+(388,320,ls),
+(487,320,o),
+(541,270,o),
+(541,184,cs),
+(541,98,o),
+(492,52,o),
+(385,52,cs),
+(142,52,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(142,638,l),
+(385,638,ls),
+(492,638,o),
+(541,592,o),
+(541,505,cs),
+(541,418,o),
+(486,371,o),
+(387,371,cs),
+(142,371,l)
+);
+}
+);
+width = 679;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F7;
+unicode = 5623;
+},
+{
+color = 9;
+glyphname = "kheeCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(395,0,ls),
+(531,0,o),
+(603,67,o),
+(603,182,cs),
+(603,267,o),
+(552,332,o),
+(469,354,c),
+(469,336,l),
+(553,355,o),
+(603,418,o),
+(603,506,cs),
+(603,622,o),
+(530,690,o),
+(395,690,cs),
+(80,690,l),
+(80,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(142,320,l),
+(302,320,l),
+(302,231,l),
+(346,231,l),
+(346,334,l),
+(329,320,l),
+(390,320,ls),
+(488,320,o),
+(541,270,o),
+(541,184,cs),
+(541,98,o),
+(492,52,o),
+(385,52,cs),
+(142,52,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(346,460,l),
+(302,460,l),
+(302,371,l),
+(142,371,l),
+(142,638,l),
+(385,638,ls),
+(492,638,o),
+(541,592,o),
+(541,505,cs),
+(541,417,o),
+(487,371,o),
+(389,371,cs),
+(329,371,l),
+(346,356,l)
+);
+}
+);
+width = 679;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F8;
+unicode = 5624;
+},
+{
+color = 9;
+glyphname = "khiCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(395,0,ls),
+(531,0,o),
+(603,67,o),
+(603,182,cs),
+(603,266,o),
+(554,328,o),
+(474,353,c),
+(473,336,l),
+(554,358,o),
+(603,419,o),
+(603,506,cs),
+(603,622,o),
+(530,690,o),
+(395,690,cs),
+(80,690,l),
+(80,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(142,321,l),
+(265,321,l),
+(273,298,o),
+(296,280,o),
+(323,280,cs),
+(355,280,o),
+(382,306,o),
+(385,339,c),
+(353,321,l),
+(391,321,ls),
+(488,321,o),
+(541,270,o),
+(541,185,cs),
+(541,98,o),
+(492,52,o),
+(385,52,cs),
+(142,52,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(385,638,ls),
+(492,638,o),
+(541,592,o),
+(541,504,cs),
+(541,417,o),
+(487,370,o),
+(390,370,cs),
+(354,370,l),
+(386,352,l),
+(384,385,o),
+(355,411,o),
+(322,411,cs),
+(289,411,o),
+(262,384,o),
+(259,352,c),
+(281,370,l),
+(142,370,l),
+(142,638,l)
+);
+}
+);
+width = 679;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F9;
+unicode = 5625;
+},
+{
+color = 9;
+glyphname = "khaCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(599,0,l),
+(599,690,l),
+(284,690,ls),
+(149,690,o),
+(76,622,o),
+(76,506,cs),
+(76,419,o),
+(125,358,o),
+(207,337,c),
+(206,354,l),
+(127,330,o),
+(76,266,o),
+(76,182,cs),
+(76,67,o),
+(148,0,o),
+(284,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(187,52,o),
+(138,98,o),
+(138,184,cs),
+(138,270,o),
+(192,320,o),
+(291,320,cs),
+(537,320,l),
+(537,52,l),
+(294,52,ls)
+);
+},
+{
+closed = 1;
+nodes = (
+(193,371,o),
+(138,418,o),
+(138,505,cs),
+(138,592,o),
+(187,638,o),
+(294,638,cs),
+(537,638,l),
+(537,371,l),
+(292,371,ls)
+);
+}
+);
+width = 679;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15FA;
+unicode = 5626;
+},
+{
+color = 9;
+glyphname = "kkuCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(351,-13,o),
+(413,44,o),
+(433,147,c),
+(406,147,l),
+(428,43,o),
+(491,-13,o),
+(578,-13,cs),
+(691,-13,o),
+(760,69,o),
+(760,207,cs),
+(760,690,l),
+(732,690,l),
+(437,517,l),
+(437,458,l),
+(738,634,l),
+(700,637,l),
+(700,209,ls),
+(700,101,o),
+(655,43,o),
+(575,43,cs),
+(497,43,o),
+(448,103,o),
+(448,208,cs),
+(448,690,l),
+(390,690,l),
+(390,208,ls),
+(390,100,o),
+(342,43,o),
+(263,43,cs),
+(182,43,o),
+(135,100,o),
+(135,209,cs),
+(135,637,l),
+(98,633,l),
+(399,459,l),
+(399,518,l),
+(104,690,l),
+(75,690,l),
+(75,209,ls),
+(75,68,o),
+(146,-13,o),
+(260,-13,cs)
+);
+}
+);
+width = 835;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FB;
+unicode = 5627;
+},
+{
+color = 9;
+glyphname = "kkoCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(103,0,l),
+(399,173,l),
+(399,232,l),
+(97,56,l),
+(135,53,l),
+(135,481,ls),
+(135,588,o),
+(180,646,o),
+(260,646,cs),
+(338,646,o),
+(386,586,o),
+(386,482,cs),
+(386,0,l),
+(445,0,l),
+(445,482,ls),
+(445,589,o),
+(493,646,o),
+(572,646,cs),
+(654,646,o),
+(700,589,o),
+(700,481,cs),
+(700,53,l),
+(738,57,l),
+(437,231,l),
+(437,172,l),
+(731,0,l),
+(760,0,l),
+(760,481,ls),
+(760,622,o),
+(689,702,o),
+(576,702,cs),
+(485,702,o),
+(421,645,o),
+(403,543,c),
+(430,543,l),
+(408,646,o),
+(345,702,o),
+(257,702,cs),
+(144,702,o),
+(75,621,o),
+(75,483,cs),
+(75,0,l)
+);
+}
+);
+width = 835;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FC;
+unicode = 5628;
+},
+{
+color = 9;
+glyphname = "kkeCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(410,0,ls),
+(545,0,o),
+(616,67,o),
+(616,182,cs),
+(616,265,o),
+(567,329,o),
+(488,353,c),
+(487,336,l),
+(569,358,o),
+(616,419,o),
+(616,506,cs),
+(616,622,o),
+(544,690,o),
+(410,690,cs),
+(77,690,l),
+(77,670,l),
+(186,371,l),
+(83,371,l),
+(83,320,l),
+(186,320,l),
+(77,19,l),
+(77,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(249,320,l),
+(403,320,ls),
+(501,320,o),
+(555,270,o),
+(555,184,cs),
+(555,98,o),
+(506,52,o),
+(399,52,cs),
+(124,52,l),
+(142,26,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(141,664,l),
+(123,638,l),
+(399,638,ls),
+(505,638,o),
+(555,592,o),
+(555,505,cs),
+(555,418,o),
+(500,371,o),
+(402,371,cs),
+(247,371,l)
+);
+}
+);
+width = 692;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni15FD;
+unicode = 5629;
+},
+{
+color = 9;
+glyphname = "kkeeCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(410,0,ls),
+(545,0,o),
+(616,67,o),
+(616,182,cs),
+(616,265,o),
+(567,329,o),
+(488,353,c),
+(487,336,l),
+(569,358,o),
+(616,419,o),
+(616,506,cs),
+(616,622,o),
+(544,690,o),
+(410,690,cs),
+(77,690,l),
+(77,670,l),
+(186,371,l),
+(83,371,l),
+(83,320,l),
+(186,320,l),
+(77,19,l),
+(77,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(248,321,l),
+(336,321,l),
+(336,234,l),
+(380,234,l),
+(380,335,l),
+(361,321,l),
+(406,321,ls),
+(501,321,o),
+(555,270,o),
+(555,185,cs),
+(555,98,o),
+(506,52,o),
+(399,52,cs),
+(124,52,l),
+(142,26,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(380,458,l),
+(336,458,l),
+(336,370,l),
+(247,370,l),
+(141,664,l),
+(123,638,l),
+(399,638,ls),
+(505,638,o),
+(555,591,o),
+(555,504,cs),
+(555,417,o),
+(501,370,o),
+(405,370,cs),
+(361,370,l),
+(380,356,l)
+);
+}
+);
+width = 692;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FE;
+unicode = 5630;
+},
+{
+color = 9;
+glyphname = "kkiCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(410,0,ls),
+(545,0,o),
+(616,67,o),
+(616,182,cs),
+(616,265,o),
+(567,329,o),
+(488,353,c),
+(487,336,l),
+(569,358,o),
+(616,419,o),
+(616,506,cs),
+(616,622,o),
+(544,690,o),
+(410,690,cs),
+(77,690,l),
+(77,670,l),
+(186,371,l),
+(83,371,l),
+(83,320,l),
+(186,320,l),
+(77,19,l),
+(77,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(249,322,l),
+(296,322,l),
+(304,298,o),
+(327,280,o),
+(354,280,cs),
+(387,280,o),
+(412,306,o),
+(416,338,c),
+(382,322,l),
+(406,322,ls),
+(501,322,o),
+(555,270,o),
+(555,184,cs),
+(555,98,o),
+(506,52,o),
+(399,52,cs),
+(124,52,l),
+(142,26,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(414,384,o),
+(387,411,o),
+(354,411,cs),
+(327,411,o),
+(304,393,o),
+(296,369,c),
+(247,369,l),
+(141,664,l),
+(123,638,l),
+(399,638,ls),
+(505,638,o),
+(555,591,o),
+(555,504,cs),
+(555,417,o),
+(501,369,o),
+(405,369,cs),
+(382,369,l),
+(416,353,l)
+);
+}
+);
+width = 692;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FF;
+unicode = 5631;
+},
+{
+color = 9;
+glyphname = "kkaCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(616,0,l),
+(616,19,l),
+(507,320,l),
+(601,320,l),
+(601,371,l),
+(507,371,l),
+(616,670,l),
+(616,690,l),
+(284,690,ls),
+(149,690,o),
+(76,622,o),
+(76,506,cs),
+(76,419,o),
+(125,358,o),
+(207,337,c),
+(206,354,l),
+(127,330,o),
+(76,265,o),
+(76,182,cs),
+(76,67,o),
+(148,0,o),
+(284,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(570,52,l),
+(294,52,ls),
+(187,52,o),
+(138,98,o),
+(138,184,cs),
+(138,270,o),
+(192,320,o),
+(291,320,cs),
+(444,320,l),
+(552,26,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(193,371,o),
+(138,418,o),
+(138,505,cs),
+(138,592,o),
+(187,638,o),
+(294,638,cs),
+(570,638,l),
+(552,664,l),
+(445,371,l),
+(292,371,ls)
+);
+}
+);
+width = 693;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|kkeCarrier-canadian";
+note = uni1600;
+unicode = 5632;
+},
+{
+color = 6;
+glyphname = "kkCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(215,183,l),
+(363,516,l),
+(363,527,l),
+(321,527,l),
+(191,227,l),
+(226,227,l),
+(97,527,l),
+(53,527,l),
+(53,516,l),
+(201,183,l)
+);
+}
+);
+width = 416;
+}
+);
+note = uni1601;
+unicode = 5633;
+},
+{
+color = 9;
+glyphname = "nuCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(517,-13,o),
+(615,88,o),
+(615,260,cs),
+(615,298,l),
+(554,298,l),
+(554,257,ls),
+(554,116,o),
+(476,44,o),
+(351,44,cs),
+(209,44,o),
+(135,125,o),
+(135,286,cs),
+(135,690,l),
+(73,690,l),
+(73,282,ls),
+(73,91,o),
+(174,-13,o),
+(350,-13,cs)
+);
+}
+);
+width = 686;
+}
+);
+metricLeft = "te-canadian";
+note = uni1602;
+unicode = 5634;
+},
+{
+color = 9;
+glyphname = "noCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(612,0,l),
+(612,408,ls),
+(612,599,o),
+(513,702,o),
+(336,702,cs),
+(169,702,o),
+(71,602,o),
+(71,430,cs),
+(71,391,l),
+(131,391,l),
+(131,433,ls),
+(131,574,o),
+(210,645,o),
+(335,645,cs),
+(477,645,o),
+(551,565,o),
+(551,404,cs),
+(551,0,l)
+);
+}
+);
+width = 685;
+}
+);
+metricLeft = "=|nuCarrier-canadian";
+metricRight = "te-canadian";
+note = uni1603;
+unicode = 5635;
+},
+{
+color = 9;
+glyphname = "neCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (289,345);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(289,0,ls),
+(487,0,o),
+(601,129,o),
+(601,346,cs),
+(601,562,o),
+(488,690,o),
+(281,690,cs),
+(55,690,l),
+(55,634,l),
+(281,634,ls),
+(451,634,o),
+(539,530,o),
+(539,346,cs),
+(539,161,o),
+(450,56,o),
+(286,56,cs),
+(267,56,l),
+(267,0,l)
+);
+}
+);
+width = 667;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1604;
+unicode = 5636;
+},
+{
+color = 9;
+glyphname = "neeCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+ref = "neCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (249,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 667;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1605;
+unicode = 5637;
+},
+{
+color = 9;
+glyphname = "niCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "neCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (226,0);
+ref = dot_middle;
+}
+);
+width = 668;
+}
+);
+note = uni1606;
+unicode = 5638;
+},
+{
+color = 9;
+glyphname = "naCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(611,0,l),
+(611,56,l),
+(385,56,ls),
+(215,56,o),
+(127,160,o),
+(127,345,cs),
+(127,529,o),
+(216,634,o),
+(381,634,cs),
+(400,634,l),
+(400,690,l),
+(378,690,ls),
+(180,690,o),
+(66,561,o),
+(66,345,cs),
+(66,128,o),
+(179,0,o),
+(383,0,cs)
+);
+}
+);
+width = 666;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni1607;
+unicode = 5639;
+},
+{
+color = 9;
+glyphname = "muCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(347,-13,o),
+(409,40,o),
+(431,134,c),
+(408,134,l),
+(433,39,o),
+(494,-13,o),
+(578,-13,cs),
+(691,-13,o),
+(760,69,o),
+(760,207,cs),
+(760,388,l),
+(700,388,l),
+(700,209,ls),
+(700,101,o),
+(655,43,o),
+(575,43,cs),
+(497,43,o),
+(448,103,o),
+(448,208,cs),
+(448,388,l),
+(390,388,l),
+(390,208,ls),
+(390,100,o),
+(342,43,o),
+(263,43,cs),
+(182,43,o),
+(135,100,o),
+(135,209,cs),
+(135,690,l),
+(75,690,l),
+(75,209,ls),
+(75,68,o),
+(146,-13,o),
+(260,-13,cs)
+);
+}
+);
+width = 835;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "=|";
+note = uni1608;
+unicode = 5640;
+},
+{
+color = 9;
+glyphname = "moCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(760,0,l),
+(760,482,ls),
+(760,621,o),
+(690,702,o),
+(577,702,cs),
+(492,702,o),
+(430,650,o),
+(407,555,c),
+(430,555,l),
+(406,651,o),
+(345,702,o),
+(259,702,cs),
+(145,702,o),
+(75,621,o),
+(75,483,cs),
+(75,301,l),
+(135,301,l),
+(135,481,ls),
+(135,588,o),
+(181,646,o),
+(262,646,cs),
+(341,646,o),
+(389,586,o),
+(389,482,cs),
+(389,301,l),
+(447,301,l),
+(447,482,ls),
+(447,587,o),
+(496,646,o),
+(574,646,cs),
+(655,646,o),
+(700,588,o),
+(700,481,cs),
+(700,0,l)
+);
+}
+);
+width = 835;
+}
+);
+metricLeft = "=|muCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni1609;
+unicode = 5641;
+},
+{
+color = 9;
+glyphname = "meCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(393,0,ls),
+(529,0,o),
+(601,67,o),
+(601,182,cs),
+(601,266,o),
+(552,329,o),
+(471,354,c),
+(471,336,l),
+(553,358,o),
+(601,419,o),
+(601,506,cs),
+(601,622,o),
+(528,690,o),
+(393,690,cs),
+(55,690,l),
+(55,638,l),
+(384,638,ls),
+(490,638,o),
+(539,592,o),
+(539,505,cs),
+(539,418,o),
+(484,371,o),
+(385,371,cs),
+(277,371,l),
+(277,320,l),
+(386,320,ls),
+(485,320,o),
+(539,270,o),
+(539,184,cs),
+(539,98,o),
+(490,52,o),
+(384,52,cs),
+(277,52,l),
+(277,0,l)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160A;
+unicode = 5642;
+},
+{
+color = 9;
+glyphname = "meeCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(393,0,ls),
+(529,0,o),
+(601,67,o),
+(601,182,cs),
+(601,266,o),
+(551,329,o),
+(471,353,c),
+(471,336,l),
+(553,358,o),
+(601,419,o),
+(601,506,cs),
+(601,622,o),
+(528,690,o),
+(393,690,cs),
+(55,690,l),
+(55,638,l),
+(384,638,ls),
+(490,638,o),
+(539,591,o),
+(539,504,cs),
+(539,417,o),
+(485,370,o),
+(386,370,cs),
+(322,370,l),
+(322,458,l),
+(277,458,l),
+(277,233,l),
+(322,233,l),
+(322,320,l),
+(387,320,ls),
+(486,320,o),
+(539,270,o),
+(539,184,cs),
+(539,98,o),
+(490,52,o),
+(384,52,cs),
+(277,52,l),
+(277,0,l)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160B;
+unicode = 5643;
+},
+{
+color = 9;
+glyphname = "miCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(393,0,ls),
+(529,0,o),
+(601,67,o),
+(601,182,cs),
+(601,266,o),
+(551,329,o),
+(471,353,c),
+(471,336,l),
+(553,358,o),
+(601,419,o),
+(601,506,cs),
+(601,622,o),
+(528,690,o),
+(393,690,cs),
+(55,690,l),
+(55,638,l),
+(384,638,ls),
+(490,638,o),
+(539,591,o),
+(539,504,cs),
+(539,417,o),
+(485,370,o),
+(389,370,cs),
+(330,370,l),
+(363,353,l),
+(360,385,o),
+(333,411,o),
+(299,411,cs),
+(264,411,o),
+(236,382,o),
+(236,346,cs),
+(236,310,o),
+(264,280,o),
+(299,280,cs),
+(333,280,o),
+(359,306,o),
+(363,338,c),
+(329,320,l),
+(390,320,ls),
+(486,320,o),
+(539,270,o),
+(539,184,cs),
+(539,98,o),
+(490,52,o),
+(384,52,cs),
+(277,52,l),
+(277,0,l)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160C;
+unicode = 5644;
+},
+{
+color = 9;
+glyphname = "maCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(622,0,l),
+(622,52,l),
+(294,52,ls),
+(188,52,o),
+(138,97,o),
+(138,184,cs),
+(138,270,o),
+(192,319,o),
+(291,319,cs),
+(400,319,l),
+(400,371,l),
+(292,371,ls),
+(193,371,o),
+(138,418,o),
+(138,505,cs),
+(138,591,o),
+(187,638,o),
+(294,638,cs),
+(400,638,l),
+(400,690,l),
+(284,690,ls),
+(149,690,o),
+(76,622,o),
+(76,506,cs),
+(76,420,o),
+(126,359,o),
+(206,337,c),
+(206,355,l),
+(126,331,o),
+(76,266,o),
+(76,182,cs),
+(76,67,o),
+(149,0,o),
+(284,0,cs)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni160D;
+unicode = 5645;
+},
+{
+color = 9;
+glyphname = "yuCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(547,-13,o),
+(654,121,o),
+(654,393,cs),
+(654,602,o),
+(588,702,o),
+(473,702,cs),
+(378,702,o),
+(315,628,o),
+(315,507,cs),
+(315,388,o),
+(376,314,o),
+(475,315,cs),
+(492,315,o),
+(510,317,o),
+(522,323,c),
+(522,372,l),
+(513,369,o),
+(500,366,o),
+(481,366,cs),
+(406,366,o),
+(370,417,o),
+(370,509,cs),
+(370,598,o),
+(407,650,o),
+(472,650,cs),
+(554,650,o),
+(594,577,o),
+(594,394,cs),
+(594,144,o),
+(509,44,o),
+(358,44,cs),
+(217,44,o),
+(135,127,o),
+(135,297,cs),
+(135,690,l),
+(73,690,l),
+(73,295,ls),
+(73,94,o),
+(184,-13,o),
+(355,-13,cs)
+);
+}
+);
+width = 727;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160E;
+unicode = 5646;
+},
+{
+color = 9;
+glyphname = "yoCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(350,-13,o),
+(412,62,o),
+(412,183,cs),
+(412,301,o),
+(351,375,o),
+(251,375,cs),
+(236,375,o),
+(216,373,o),
+(205,367,c),
+(205,318,l),
+(214,321,o),
+(226,324,o),
+(245,324,cs),
+(321,324,o),
+(357,272,o),
+(357,181,cs),
+(357,92,o),
+(321,40,o),
+(255,40,cs),
+(174,40,o),
+(132,113,o),
+(132,296,cs),
+(132,546,o),
+(217,645,o),
+(369,645,cs),
+(509,645,o),
+(592,563,o),
+(592,393,cs),
+(592,0,l),
+(654,0,l),
+(654,395,ls),
+(654,596,o),
+(544,702,o),
+(371,702,cs),
+(180,702,o),
+(73,569,o),
+(73,297,cs),
+(73,88,o),
+(138,-13,o),
+(254,-13,cs)
+);
+}
+);
+width = 727;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160F;
+unicode = 5647;
+},
+{
+color = 9;
+glyphname = "yeCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(498,-13,o),
+(603,128,o),
+(603,344,cs),
+(603,563,o),
+(490,690,o),
+(272,690,cs),
+(83,690,l),
+(83,634,l),
+(275,634,ls),
+(454,634,o),
+(542,530,o),
+(542,342,cs),
+(542,156,o),
+(468,42,o),
+(307,42,cs),
+(176,42,o),
+(123,117,o),
+(123,207,cs),
+(123,298,o),
+(163,350,o),
+(227,350,cs),
+(294,350,o),
+(329,298,o),
+(329,214,cs),
+(329,183,o),
+(327,165,o),
+(323,144,c),
+(373,144,l),
+(379,171,o),
+(381,186,o),
+(381,219,cs),
+(381,327,o),
+(324,400,o),
+(227,400,cs),
+(129,400,o),
+(67,326,o),
+(67,207,cs),
+(67,89,o),
+(145,-13,o),
+(306,-13,cs)
+);
+}
+);
+width = 669;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1610;
+unicode = 5648;
+},
+{
+color = 9;
+glyphname = "yeeCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(498,-13,o),
+(603,128,o),
+(603,344,cs),
+(603,563,o),
+(490,690,o),
+(272,690,cs),
+(83,690,l),
+(83,634,l),
+(275,634,ls),
+(454,634,o),
+(542,530,o),
+(542,342,cs),
+(542,156,o),
+(468,42,o),
+(306,42,cs),
+(176,42,o),
+(123,115,o),
+(123,213,cs),
+(123,298,o),
+(161,350,o),
+(219,350,cs),
+(280,350,o),
+(316,301,o),
+(316,221,cs),
+(316,174,l),
+(355,174,l),
+(355,502,l),
+(316,502,l),
+(316,290,l),
+(326,290,l),
+(315,361,o),
+(272,400,o),
+(209,400,cs),
+(126,400,o),
+(67,327,o),
+(67,213,cs),
+(67,87,o),
+(144,-13,o),
+(306,-13,cs)
+);
+}
+);
+width = 669;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1611;
+unicode = 5649;
+},
+{
+color = 9;
+glyphname = "yiCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(498,-13,o),
+(603,128,o),
+(603,344,cs),
+(603,563,o),
+(490,690,o),
+(272,690,cs),
+(83,690,l),
+(83,634,l),
+(275,634,ls),
+(454,634,o),
+(542,530,o),
+(542,342,cs),
+(542,156,o),
+(468,42,o),
+(309,42,cs),
+(176,42,o),
+(123,112,o),
+(123,194,cs),
+(123,279,o),
+(165,326,o),
+(237,325,c),
+(212,340,l),
+(214,310,o),
+(241,285,o),
+(272,285,cs),
+(307,285,o),
+(332,313,o),
+(332,346,cs),
+(332,380,o),
+(307,405,o),
+(272,405,cs),
+(247,405,o),
+(227,390,o),
+(218,371,c),
+(125,365,o),
+(67,297,o),
+(67,191,cs),
+(67,85,o),
+(145,-13,o),
+(306,-13,cs)
+);
+}
+);
+width = 669;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1612;
+unicode = 5650;
+},
+{
+color = 9;
+glyphname = "yaCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(586,0,l),
+(586,56,l),
+(394,56,ls),
+(214,56,o),
+(127,159,o),
+(127,348,cs),
+(127,534,o),
+(202,648,o),
+(365,648,cs),
+(494,648,o),
+(547,573,o),
+(547,483,cs),
+(547,391,o),
+(506,340,o),
+(441,340,cs),
+(376,340,o),
+(340,392,o),
+(340,475,cs),
+(340,507,o),
+(343,525,o),
+(347,546,c),
+(297,546,l),
+(291,519,o),
+(288,503,o),
+(288,470,cs),
+(288,362,o),
+(346,290,o),
+(441,290,cs),
+(539,290,o),
+(602,364,o),
+(602,483,cs),
+(602,601,o),
+(525,702,o),
+(365,702,cs),
+(171,702,o),
+(66,561,o),
+(66,346,cs),
+(66,127,o),
+(180,0,o),
+(397,0,cs)
+);
+}
+);
+width = 669;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|yeCarrier-canadian";
+note = uni1613;
+unicode = 5651;
+},
+{
+color = 9;
+glyphname = "juCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(531,-13,o),
+(622,79,o),
+(622,218,cs),
+(622,326,o),
+(560,400,o),
+(464,400,cs),
+(368,400,o),
+(308,327,o),
+(308,219,cs),
+(308,186,o),
+(311,170,o),
+(317,144,c),
+(367,144,l),
+(363,164,o),
+(360,184,o),
+(360,214,cs),
+(360,298,o),
+(399,350,o),
+(464,350,cs),
+(528,350,o),
+(567,298,o),
+(567,217,cs),
+(567,108,o),
+(502,42,o),
+(373,42,cs),
+(220,42,o),
+(137,133,o),
+(137,306,cs),
+(137,528,o),
+(277,634,o),
+(523,634,cs),
+(606,634,l),
+(606,690,l),
+(68,690,l),
+(68,635,l),
+(400,635,l),
+(468,661,l),
+(222,661,o),
+(76,530,o),
+(76,304,cs),
+(76,108,o),
+(189,-13,o),
+(371,-13,cs)
+);
+}
+);
+width = 689;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni1614;
+unicode = 5652;
+},
+{
+color = 9;
+glyphname = "juSayisi-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (352,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(499,-13,o),
+(613,108,o),
+(613,304,cs),
+(613,530,o),
+(468,661,o),
+(221,661,c),
+(290,635,l),
+(622,635,l),
+(622,690,l),
+(83,690,l),
+(83,634,l),
+(166,634,ls),
+(412,634,o),
+(553,528,o),
+(553,306,cs),
+(553,133,o),
+(469,42,o),
+(316,42,cs),
+(187,42,o),
+(123,108,o),
+(123,217,cs),
+(123,298,o),
+(161,350,o),
+(226,350,cs),
+(291,350,o),
+(329,298,o),
+(329,214,cs),
+(329,184,o),
+(327,164,o),
+(323,144,c),
+(373,144,l),
+(379,170,o),
+(381,186,o),
+(381,219,cs),
+(381,327,o),
+(321,400,o),
+(226,400,cs),
+(128,400,o),
+(67,326,o),
+(67,218,cs),
+(67,79,o),
+(157,-13,o),
+(319,-13,cs)
+);
+}
+);
+width = 690;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1615;
+unicode = 5653;
+},
+{
+color = 9;
+glyphname = "joCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(622,0,l),
+(622,55,l),
+(290,55,l),
+(221,29,l),
+(468,29,o),
+(613,159,o),
+(613,385,cs),
+(613,582,o),
+(499,702,o),
+(319,702,cs),
+(157,702,o),
+(67,611,o),
+(67,471,cs),
+(67,364,o),
+(128,290,o),
+(226,290,cs),
+(321,290,o),
+(381,362,o),
+(381,470,cs),
+(381,503,o),
+(379,520,o),
+(373,546,c),
+(323,546,l),
+(327,526,o),
+(329,506,o),
+(329,475,cs),
+(329,392,o),
+(291,340,o),
+(226,340,cs),
+(161,340,o),
+(123,392,o),
+(123,472,cs),
+(123,582,o),
+(187,648,o),
+(316,648,cs),
+(469,648,o),
+(553,556,o),
+(553,384,cs),
+(553,161,o),
+(412,56,o),
+(166,56,cs),
+(83,56,l),
+(83,0,l)
+);
+}
+);
+width = 690;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1616;
+unicode = 5654;
+},
+{
+color = 9;
+glyphname = "jeCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(596,-13,o),
+(662,88,o),
+(662,297,cs),
+(662,566,o),
+(553,702,o),
+(384,702,cs),
+(218,702,o),
+(127,582,o),
+(123,354,c),
+(142,379,l),
+(142,690,l),
+(80,690,l),
+(80,0,l),
+(142,0,l),
+(142,274,ls),
+(142,531,o),
+(223,645,o),
+(378,645,cs),
+(516,645,o),
+(602,540,o),
+(602,296,cs),
+(602,113,o),
+(561,40,o),
+(480,40,cs),
+(414,40,o),
+(377,92,o),
+(377,181,cs),
+(377,272,o),
+(413,324,o),
+(490,324,cs),
+(508,324,o),
+(520,321,o),
+(529,318,c),
+(529,367,l),
+(518,373,o),
+(498,375,o),
+(484,375,cs),
+(384,375,o),
+(322,301,o),
+(322,183,cs),
+(322,62,o),
+(385,-13,o),
+(481,-13,cs)
+);
+}
+);
+width = 735;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "te-canadian";
+note = uni1617;
+unicode = 5655;
+},
+{
+color = 9;
+glyphname = "jeeCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(596,-13,o),
+(662,88,o),
+(662,297,cs),
+(662,566,o),
+(553,702,o),
+(384,702,cs),
+(251,702,o),
+(165,627,o),
+(134,480,c),
+(142,472,l),
+(142,690,l),
+(80,690,l),
+(80,0,l),
+(142,0,l),
+(142,274,ls),
+(142,531,o),
+(223,645,o),
+(378,645,cs),
+(516,645,o),
+(602,540,o),
+(602,296,cs),
+(602,118,o),
+(560,40,o),
+(472,40,cs),
+(402,40,o),
+(362,95,o),
+(362,185,cs),
+(362,272,o),
+(395,317,o),
+(449,329,c),
+(449,237,l),
+(487,237,l),
+(487,454,l),
+(449,454,l),
+(449,368,l),
+(375,355,o),
+(322,293,o),
+(322,181,cs),
+(322,61,o),
+(384,-13,o),
+(479,-13,cs)
+);
+}
+);
+width = 735;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1618;
+unicode = 5656;
+},
+{
+color = 9;
+glyphname = "jiCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(596,-13,o),
+(662,88,o),
+(662,297,cs),
+(662,566,o),
+(553,702,o),
+(384,702,cs),
+(251,702,o),
+(165,627,o),
+(134,480,c),
+(142,473,l),
+(142,690,l),
+(80,690,l),
+(80,0,l),
+(142,0,l),
+(142,274,ls),
+(142,531,o),
+(223,645,o),
+(378,645,cs),
+(516,645,o),
+(602,540,o),
+(602,296,cs),
+(602,118,o),
+(560,40,o),
+(472,40,cs),
+(402,40,o),
+(362,95,o),
+(362,185,cs),
+(362,250,o),
+(381,288,o),
+(412,308,c),
+(420,295,o),
+(435,285,o),
+(452,285,cs),
+(486,285,o),
+(511,313,o),
+(511,346,cs),
+(511,380,o),
+(486,405,o),
+(451,405,cs),
+(415,405,o),
+(391,375,o),
+(393,342,c),
+(350,315,o),
+(322,262,o),
+(322,181,cs),
+(322,61,o),
+(384,-13,o),
+(479,-13,cs)
+);
+}
+);
+width = 735;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1619;
+unicode = 5657;
+},
+{
+color = 9;
+glyphname = "jiSayisi-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(553,-13,o),
+(662,124,o),
+(662,393,cs),
+(662,602,o),
+(596,702,o),
+(481,702,cs),
+(385,702,o),
+(322,628,o),
+(322,507,cs),
+(322,388,o),
+(384,315,o),
+(484,315,cs),
+(498,315,o),
+(518,317,o),
+(529,323,c),
+(529,372,l),
+(520,369,o),
+(508,366,o),
+(490,366,cs),
+(413,366,o),
+(377,417,o),
+(377,509,cs),
+(377,598,o),
+(414,650,o),
+(479,650,cs),
+(560,650,o),
+(602,577,o),
+(602,394,cs),
+(602,150,o),
+(516,44,o),
+(378,44,cs),
+(223,44,o),
+(142,158,o),
+(142,415,cs),
+(142,690,l),
+(80,690,l),
+(80,0,l),
+(142,0,l),
+(142,311,l),
+(123,336,l),
+(127,107,o),
+(218,-13,o),
+(384,-13,cs)
+);
+}
+);
+width = 735;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161A;
+unicode = 5658;
+},
+{
+color = 9;
+glyphname = "jaCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (359,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(516,-13,o),
+(608,107,o),
+(611,336,c),
+(593,311,l),
+(593,0,l),
+(654,0,l),
+(654,690,l),
+(592,690,l),
+(592,415,ls),
+(592,158,o),
+(512,44,o),
+(357,44,cs),
+(219,44,o),
+(132,150,o),
+(132,394,cs),
+(132,577,o),
+(174,650,o),
+(255,650,cs),
+(320,650,o),
+(357,598,o),
+(357,509,cs),
+(357,417,o),
+(321,366,o),
+(244,366,cs),
+(226,366,o),
+(214,369,o),
+(205,372,c),
+(205,323,l),
+(216,317,o),
+(236,315,o),
+(251,315,cs),
+(351,315,o),
+(412,388,o),
+(412,507,cs),
+(412,628,o),
+(350,702,o),
+(254,702,cs),
+(138,702,o),
+(73,602,o),
+(73,393,cs),
+(73,124,o),
+(182,-13,o),
+(350,-13,cs)
+);
+}
+);
+width = 734;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni161B;
+unicode = 5659;
+},
+{
+color = 9;
+glyphname = "jjuCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(530,-13,o),
+(609,89,o),
+(609,207,cs),
+(609,326,o),
+(546,400,o),
+(448,400,cs),
+(352,400,o),
+(294,327,o),
+(294,219,cs),
+(294,187,o),
+(297,170,o),
+(302,144,c),
+(353,144,l),
+(349,164,o),
+(346,184,o),
+(346,214,cs),
+(346,298,o),
+(382,350,o),
+(447,350,cs),
+(511,350,o),
+(553,297,o),
+(553,208,cs),
+(553,116,o),
+(497,42,o),
+(369,42,cs),
+(212,42,o),
+(134,148,o),
+(134,315,cs),
+(134,523,o),
+(248,634,o),
+(467,634,cs),
+(592,634,l),
+(592,690,l),
+(467,690,ls),
+(340,690,o),
+(242,655,o),
+(177,591,c),
+(66,702,l),
+(25,662,l),
+(139,549,l),
+(95,490,o),
+(72,411,o),
+(72,316,cs),
+(72,122,o),
+(181,-13,o),
+(368,-13,cs)
+);
+}
+);
+width = 676;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni161C;
+unicode = 5660;
+},
+{
+color = 9;
+glyphname = "jjoCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(650,28,l),
+(537,141,l),
+(581,200,o),
+(603,279,o),
+(603,374,cs),
+(603,568,o),
+(496,702,o),
+(308,702,cs),
+(147,702,o),
+(67,601,o),
+(67,482,cs),
+(67,364,o),
+(129,290,o),
+(227,290,cs),
+(325,290,o),
+(382,362,o),
+(382,470,cs),
+(382,502,o),
+(380,520,o),
+(374,546,c),
+(323,546,l),
+(327,526,o),
+(329,506,o),
+(329,475,cs),
+(329,392,o),
+(294,340,o),
+(228,340,cs),
+(165,340,o),
+(123,393,o),
+(123,482,cs),
+(123,574,o),
+(177,648,o),
+(308,648,cs),
+(464,648,o),
+(542,542,o),
+(542,375,cs),
+(542,167,o),
+(427,56,o),
+(209,56,cs),
+(83,56,l),
+(83,0,l),
+(210,0,ls),
+(335,0,o),
+(434,35,o),
+(498,99,c),
+(610,-13,l)
+);
+}
+);
+width = 675;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|jjuCarrier-canadian";
+note = uni161D;
+unicode = 5661;
+},
+{
+color = 9;
+glyphname = "jjeCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(601,-13,o),
+(666,88,o),
+(666,297,cs),
+(666,569,o),
+(561,702,o),
+(372,702,cs),
+(285,702,o),
+(214,669,o),
+(164,610,c),
+(71,702,l),
+(31,661,l),
+(132,561,l),
+(101,506,o),
+(85,435,o),
+(85,348,cs),
+(85,0,l),
+(147,0,l),
+(147,348,ls),
+(147,545,o),
+(229,645,o),
+(372,645,cs),
+(521,645,o),
+(606,546,o),
+(606,296,cs),
+(606,113,o),
+(565,40,o),
+(484,40,cs),
+(418,40,o),
+(382,92,o),
+(382,181,cs),
+(382,272,o),
+(417,324,o),
+(493,324,cs),
+(512,324,o),
+(525,321,o),
+(534,318,c),
+(534,367,l),
+(523,373,o),
+(503,375,o),
+(487,375,cs),
+(387,375,o),
+(327,301,o),
+(327,183,cs),
+(327,62,o),
+(389,-13,o),
+(485,-13,cs)
+);
+}
+);
+width = 739;
+}
+);
+metricRight = "jeCarrier-canadian";
+note = uni161E;
+unicode = 5662;
+},
+{
+color = 9;
+glyphname = "jjeeCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(601,-13,o),
+(666,88,o),
+(666,297,cs),
+(666,569,o),
+(561,702,o),
+(372,702,cs),
+(285,702,o),
+(214,669,o),
+(164,610,c),
+(71,702,l),
+(31,661,l),
+(132,561,l),
+(101,506,o),
+(85,435,o),
+(85,348,cs),
+(85,0,l),
+(147,0,l),
+(147,348,ls),
+(147,545,o),
+(229,645,o),
+(372,645,cs),
+(521,645,o),
+(606,546,o),
+(606,296,cs),
+(606,118,o),
+(564,40,o),
+(476,40,cs),
+(406,40,o),
+(366,95,o),
+(366,185,cs),
+(366,270,o),
+(398,315,o),
+(448,327,c),
+(448,237,l),
+(487,237,l),
+(487,453,l),
+(448,453,l),
+(448,368,l),
+(377,355,o),
+(327,290,o),
+(327,181,cs),
+(327,61,o),
+(388,-13,o),
+(484,-13,cs)
+);
+}
+);
+width = 739;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161F;
+unicode = 5663;
+},
+{
+color = 9;
+glyphname = "jjiCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(601,-13,o),
+(666,88,o),
+(666,297,cs),
+(666,569,o),
+(561,702,o),
+(372,702,cs),
+(285,702,o),
+(214,669,o),
+(164,610,c),
+(71,702,l),
+(31,661,l),
+(132,561,l),
+(101,506,o),
+(85,435,o),
+(85,348,cs),
+(85,0,l),
+(147,0,l),
+(147,348,ls),
+(147,545,o),
+(229,645,o),
+(372,645,cs),
+(521,645,o),
+(606,546,o),
+(606,296,cs),
+(606,118,o),
+(564,40,o),
+(476,40,cs),
+(406,40,o),
+(366,95,o),
+(366,185,cs),
+(366,253,o),
+(387,293,o),
+(420,311,c),
+(429,297,o),
+(445,285,o),
+(464,285,cs),
+(497,285,o),
+(523,313,o),
+(523,346,cs),
+(523,380,o),
+(497,405,o),
+(464,405,cs),
+(430,405,o),
+(406,378,o),
+(406,348,c),
+(357,323,o),
+(327,267,o),
+(327,181,cs),
+(327,61,o),
+(388,-13,o),
+(484,-13,cs)
+);
+}
+);
+width = 739;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1620;
+unicode = 5664;
+},
+{
+color = 9;
+glyphname = "jjaCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(453,-13,o),
+(525,20,o),
+(575,80,c),
+(668,-13,l),
+(708,29,l),
+(607,128,l),
+(638,184,o),
+(654,255,o),
+(654,342,cs),
+(654,690,l),
+(592,690,l),
+(592,342,ls),
+(592,145,o),
+(509,44,o),
+(367,44,cs),
+(217,44,o),
+(132,144,o),
+(132,394,cs),
+(132,577,o),
+(174,650,o),
+(255,650,cs),
+(321,650,o),
+(357,598,o),
+(357,509,cs),
+(357,417,o),
+(321,366,o),
+(245,366,cs),
+(226,366,o),
+(214,369,o),
+(205,372,c),
+(205,323,l),
+(216,317,o),
+(236,315,o),
+(251,315,cs),
+(351,315,o),
+(412,388,o),
+(412,507,cs),
+(412,628,o),
+(350,702,o),
+(254,702,cs),
+(138,702,o),
+(73,602,o),
+(73,393,cs),
+(73,121,o),
+(178,-13,o),
+(366,-13,cs)
+);
+}
+);
+width = 739;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "=|jjeCarrier-canadian";
+note = uni1621;
+unicode = 5665;
+},
+{
+color = 9;
+glyphname = "luCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(511,-13,o),
+(614,88,o),
+(614,282,cs),
+(614,690,l),
+(553,690,l),
+(553,280,ls),
+(553,120,o),
+(474,44,o),
+(352,44,cs),
+(208,44,o),
+(134,147,o),
+(134,326,cs),
+(134,525,o),
+(215,632,o),
+(374,639,c),
+(374,690,l),
+(64,690,l),
+(64,638,l),
+(285,638,l),
+(320,659,l),
+(174,643,o),
+(72,539,o),
+(72,318,cs),
+(72,112,o),
+(172,-13,o),
+(350,-13,cs)
+);
+}
+);
+width = 687;
+}
+);
+metricRight = "te-canadian";
+note = uni1622;
+unicode = 5666;
+},
+{
+color = 9;
+glyphname = "loCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(135,0,l),
+(135,410,ls),
+(135,570,o),
+(213,645,o),
+(337,645,cs),
+(480,645,o),
+(554,543,o),
+(554,364,cs),
+(554,165,o),
+(472,58,o),
+(313,51,c),
+(313,0,l),
+(624,0,l),
+(624,52,l),
+(403,52,l),
+(368,31,l),
+(514,46,o),
+(615,151,o),
+(615,372,cs),
+(615,578,o),
+(516,702,o),
+(337,702,cs),
+(177,702,o),
+(73,602,o),
+(73,408,cs),
+(73,0,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|luCarrier-canadian";
+note = uni1623;
+unicode = 5667;
+},
+{
+color = 9;
+glyphname = "leCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (331,346);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(273,0,ls),
+(486,0,o),
+(597,128,o),
+(597,357,cs),
+(597,579,o),
+(494,702,o),
+(342,702,cs),
+(220,702,o),
+(144,618,o),
+(124,503,c),
+(132,503,l),
+(132,690,l),
+(76,690,l),
+(76,385,l),
+(128,385,l),
+(132,541,o),
+(205,645,o),
+(330,645,cs),
+(456,645,o),
+(535,548,o),
+(535,356,cs),
+(535,161,o),
+(449,56,o),
+(273,56,cs),
+(76,56,l),
+(76,0,l)
+);
+}
+);
+width = 663;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1624;
+unicode = 5668;
+},
+{
+color = 9;
+glyphname = "leeCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+ref = "leCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (291,1);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 663;
+}
+);
+metricLeft = "leCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1625;
+unicode = 5669;
+},
+{
+color = 9;
+glyphname = "liCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "leCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (270,1);
+ref = dot_middle;
+}
+);
+width = 664;
+}
+);
+note = uni1626;
+unicode = 5670;
+},
+{
+color = 9;
+glyphname = "laCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(586,0,l),
+(586,56,l),
+(388,56,ls),
+(213,56,o),
+(127,161,o),
+(127,356,cs),
+(127,548,o),
+(208,645,o),
+(333,645,cs),
+(459,645,o),
+(530,541,o),
+(534,385,c),
+(586,385,l),
+(586,690,l),
+(530,690,l),
+(530,503,l),
+(539,503,l),
+(519,618,o),
+(442,702,o),
+(322,702,cs),
+(170,702,o),
+(66,579,o),
+(66,357,cs),
+(66,128,o),
+(177,0,o),
+(389,0,cs)
+);
+}
+);
+width = 662;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|leCarrier-canadian";
+note = uni1627;
+unicode = 5671;
+},
+{
+color = 1;
+glyphname = "dluCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(516,-13,o),
+(615,112,o),
+(615,318,cs),
+(615,512,o),
+(538,616,o),
+(425,647,c),
+(413,641,l),
+(614,641,l),
+(614,557,l),
+(663,557,l),
+(663,773,l),
+(614,773,l),
+(614,690,l),
+(313,690,l),
+(313,639,l),
+(472,632,o),
+(554,525,o),
+(554,326,cs),
+(554,147,o),
+(480,44,o),
+(342,44,cs),
+(213,44,o),
+(135,122,o),
+(135,282,cs),
+(135,690,l),
+(73,690,l),
+(73,285,ls),
+(73,90,o),
+(177,-13,o),
+(341,-13,cs)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "te-canadian";
+note = uni1628;
+unicode = 5672;
+},
+{
+color = 9;
+glyphname = "dloCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(663,-83,l),
+(663,132,l),
+(614,132,l),
+(614,48,l),
+(413,48,l),
+(425,43,l),
+(538,73,o),
+(615,178,o),
+(615,372,cs),
+(615,578,o),
+(516,702,o),
+(343,702,cs),
+(175,702,o),
+(73,600,o),
+(73,405,cs),
+(73,0,l),
+(135,0,l),
+(135,408,ls),
+(135,568,o),
+(213,645,o),
+(342,645,cs),
+(480,645,o),
+(554,543,o),
+(554,364,cs),
+(554,165,o),
+(472,58,o),
+(313,51,c),
+(313,0,l),
+(614,0,l),
+(614,-83,l)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "dluCarrier-canadian";
+note = uni1629;
+unicode = 5673;
+},
+{
+color = 9;
+glyphname = "dleCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (342,346);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(284,0,ls),
+(496,0,o),
+(607,128,o),
+(607,357,cs),
+(607,579,o),
+(503,702,o),
+(353,702,cs),
+(238,702,o),
+(157,629,o),
+(128,509,c),
+(135,502,l),
+(135,703,l),
+(213,703,l),
+(213,750,l),
+(10,750,l),
+(10,703,l),
+(87,703,l),
+(87,385,l),
+(139,385,l),
+(143,541,o),
+(215,645,o),
+(341,645,cs),
+(467,645,o),
+(546,548,o),
+(546,356,cs),
+(546,161,o),
+(460,56,o),
+(284,56,cs),
+(87,56,l),
+(87,0,l)
+);
+}
+);
+width = 673;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni162A;
+unicode = 5674;
+},
+{
+color = 9;
+glyphname = "dleeCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (303,1);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 674;
+}
+);
+note = uni162B;
+unicode = 5675;
+},
+{
+color = 9;
+glyphname = "dliCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (280,1);
+ref = dot_middle;
+}
+);
+width = 674;
+}
+);
+note = uni162C;
+unicode = 5676;
+},
+{
+color = 9;
+glyphname = "dlaCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(586,0,l),
+(586,56,l),
+(388,56,ls),
+(214,56,o),
+(127,158,o),
+(127,356,cs),
+(127,548,o),
+(207,645,o),
+(331,645,cs),
+(458,645,o),
+(530,541,o),
+(534,385,c),
+(586,385,l),
+(586,703,l),
+(664,703,l),
+(664,750,l),
+(461,750,l),
+(461,703,l),
+(538,703,l),
+(538,502,l),
+(545,509,l),
+(516,629,o),
+(436,702,o),
+(321,702,cs),
+(169,702,o),
+(66,579,o),
+(66,357,cs),
+(66,127,o),
+(179,0,o),
+(389,0,cs)
+);
+}
+);
+width = 674;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni162D;
+unicode = 5677;
+},
+{
+color = 9;
+glyphname = "lhuCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(554,-13,o),
+(655,111,o),
+(655,323,cs),
+(655,525,o),
+(566,625,o),
+(450,659,c),
+(469,637,l),
+(664,637,l),
+(664,690,l),
+(422,690,l),
+(422,639,l),
+(519,609,o),
+(593,513,o),
+(593,330,cs),
+(593,142,o),
+(518,44,o),
+(363,44,cs),
+(210,44,o),
+(134,142,o),
+(134,330,cs),
+(134,513,o),
+(210,609,o),
+(305,639,c),
+(305,690,l),
+(64,690,l),
+(64,637,l),
+(258,637,l),
+(277,659,l),
+(161,625,o),
+(72,526,o),
+(72,323,cs),
+(72,111,o),
+(174,-13,o),
+(363,-13,cs)
+);
+}
+);
+width = 728;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162E;
+unicode = 5678;
+},
+{
+color = 9;
+glyphname = "lhoCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(305,0,l),
+(305,51,l),
+(209,81,o),
+(134,177,o),
+(134,359,cs),
+(134,548,o),
+(210,645,o),
+(363,645,cs),
+(518,645,o),
+(593,548,o),
+(593,359,cs),
+(593,177,o),
+(518,81,o),
+(422,51,c),
+(422,0,l),
+(664,0,l),
+(664,53,l),
+(469,53,l),
+(449,31,l),
+(566,65,o),
+(655,164,o),
+(655,367,cs),
+(655,579,o),
+(554,702,o),
+(363,702,cs),
+(173,702,o),
+(72,579,o),
+(72,367,cs),
+(72,165,o),
+(161,65,o),
+(277,31,c),
+(258,53,l),
+(64,53,l),
+(64,0,l)
+);
+}
+);
+width = 728;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162F;
+unicode = 5679;
+},
+{
+color = 9;
+glyphname = "lheCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (350,345);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(519,-13,o),
+(628,111,o),
+(628,345,cs),
+(628,579,o),
+(519,702,o),
+(358,702,cs),
+(231,702,o),
+(153,621,o),
+(130,521,c),
+(136,521,l),
+(136,690,l),
+(80,690,l),
+(80,419,l),
+(132,419,l),
+(143,544,o),
+(213,645,o),
+(349,645,cs),
+(476,645,o),
+(566,548,o),
+(566,345,cs),
+(566,142,o),
+(481,44,o),
+(349,44,cs),
+(213,44,o),
+(143,146,o),
+(132,270,c),
+(80,270,l),
+(80,0,l),
+(136,0,l),
+(136,169,l),
+(130,169,l),
+(153,69,o),
+(231,-13,o),
+(358,-13,cs)
+);
+}
+);
+width = 694;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1630;
+unicode = 5680;
+},
+{
+color = 9;
+glyphname = "lheeCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (310,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 695;
+}
+);
+note = uni1631;
+unicode = 5681;
+},
+{
+color = 9;
+glyphname = "lhiCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (288,0);
+ref = dot_middle;
+}
+);
+width = 695;
+}
+);
+note = uni1632;
+unicode = 5682;
+},
+{
+color = 9;
+glyphname = "lhaCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(463,-13,o),
+(541,69,o),
+(563,169,c),
+(557,169,l),
+(557,0,l),
+(613,0,l),
+(613,270,l),
+(561,270,l),
+(551,146,o),
+(480,44,o),
+(345,44,cs),
+(217,44,o),
+(127,142,o),
+(127,345,cs),
+(127,548,o),
+(212,645,o),
+(345,645,cs),
+(480,645,o),
+(551,544,o),
+(561,419,c),
+(613,419,l),
+(613,690,l),
+(557,690,l),
+(557,521,l),
+(563,521,l),
+(541,621,o),
+(463,702,o),
+(335,702,cs),
+(175,702,o),
+(66,579,o),
+(66,345,cs),
+(66,111,o),
+(175,-13,o),
+(335,-13,cs)
+);
+}
+);
+width = 693;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1633;
+unicode = 5683;
+},
+{
+color = 9;
+glyphname = "tlhuCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(554,-13,o),
+(655,111,o),
+(655,323,cs),
+(655,506,o),
+(582,606,o),
+(485,648,c),
+(471,641,l),
+(654,641,l),
+(654,557,l),
+(702,557,l),
+(702,773,l),
+(654,773,l),
+(654,690,l),
+(422,690,l),
+(422,639,l),
+(519,609,o),
+(593,513,o),
+(593,330,cs),
+(593,142,o),
+(518,44,o),
+(363,44,cs),
+(210,44,o),
+(134,142,o),
+(134,330,cs),
+(134,513,o),
+(209,609,o),
+(305,639,c),
+(305,690,l),
+(64,690,l),
+(64,637,l),
+(249,637,l),
+(235,644,l),
+(141,601,o),
+(72,502,o),
+(72,323,cs),
+(72,111,o),
+(174,-13,o),
+(363,-13,cs)
+);
+}
+);
+width = 749;
+}
+);
+metricLeft = "lhuCarrier-canadian";
+note = uni1634;
+unicode = 5684;
+},
+{
+color = 9;
+glyphname = "tlhoCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(95,-83,l),
+(95,0,l),
+(327,0,l),
+(327,51,l),
+(231,81,o),
+(156,177,o),
+(156,359,cs),
+(156,548,o),
+(231,645,o),
+(385,645,cs),
+(539,645,o),
+(615,548,o),
+(615,359,cs),
+(615,177,o),
+(540,81,o),
+(443,51,c),
+(443,0,l),
+(685,0,l),
+(685,53,l),
+(499,53,l),
+(514,45,l),
+(608,89,o),
+(676,187,o),
+(676,367,cs),
+(676,579,o),
+(576,702,o),
+(385,702,cs),
+(195,702,o),
+(94,579,o),
+(94,367,cs),
+(94,184,o),
+(167,84,o),
+(265,42,c),
+(278,48,l),
+(95,48,l),
+(95,132,l),
+(47,132,l),
+(47,-83,l)
+);
+}
+);
+width = 749;
+}
+);
+metricLeft = "=|tlhuCarrier-canadian";
+metricRight = "lhuCarrier-canadian";
+note = uni1635;
+unicode = 5685;
+},
+{
+color = 9;
+glyphname = "tlheCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (356,345);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(526,-13,o),
+(634,111,o),
+(634,345,cs),
+(634,579,o),
+(526,702,o),
+(365,702,cs),
+(242,702,o),
+(158,625,o),
+(128,518,c),
+(135,510,l),
+(135,703,l),
+(213,703,l),
+(213,750,l),
+(10,750,l),
+(10,703,l),
+(87,703,l),
+(87,419,l),
+(139,419,l),
+(150,544,o),
+(219,645,o),
+(355,645,cs),
+(482,645,o),
+(573,549,o),
+(573,345,cs),
+(573,142,o),
+(482,44,o),
+(355,44,cs),
+(219,44,o),
+(150,146,o),
+(139,270,c),
+(87,270,l),
+(87,0,l),
+(143,0,l),
+(143,176,l),
+(138,164,l),
+(161,70,o),
+(240,-13,o),
+(365,-13,cs)
+);
+}
+);
+width = 700;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1636;
+unicode = 5686;
+},
+{
+color = 9;
+glyphname = "tlheeCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (317,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 701;
+}
+);
+note = uni1637;
+unicode = 5687;
+},
+{
+color = 9;
+glyphname = "tlhiCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (295,0);
+ref = dot_middle;
+}
+);
+width = 701;
+}
+);
+note = uni1638;
+unicode = 5688;
+},
+{
+color = 9;
+glyphname = "tlhaCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(461,-13,o),
+(540,66,o),
+(562,165,c),
+(557,177,l),
+(557,0,l),
+(613,0,l),
+(613,270,l),
+(561,270,l),
+(551,146,o),
+(480,44,o),
+(345,44,cs),
+(217,44,o),
+(127,142,o),
+(127,345,cs),
+(127,549,o),
+(212,645,o),
+(345,645,cs),
+(480,645,o),
+(551,544,o),
+(561,419,c),
+(613,419,l),
+(613,703,l),
+(691,703,l),
+(691,750,l),
+(487,750,l),
+(487,703,l),
+(564,703,l),
+(564,509,l),
+(572,517,l),
+(542,628,o),
+(459,702,o),
+(335,702,cs),
+(175,702,o),
+(66,579,o),
+(66,345,cs),
+(66,111,o),
+(175,-13,o),
+(335,-13,cs)
+);
+}
+);
+width = 701;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni1639;
+unicode = 5689;
+},
+{
+color = 9;
+glyphname = "tluCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(345,-13,o),
+(404,37,o),
+(426,129,c),
+(410,129,l),
+(433,37,o),
+(491,-13,o),
+(570,-13,cs),
+(692,-13,o),
+(764,78,o),
+(764,288,cs),
+(764,506,o),
+(694,611,o),
+(587,648,c),
+(574,641,l),
+(763,641,l),
+(763,557,l),
+(811,557,l),
+(811,773,l),
+(763,773,l),
+(763,690,l),
+(476,690,l),
+(476,639,l),
+(626,635,o),
+(702,525,o),
+(702,291,cs),
+(702,109,o),
+(653,43,o),
+(566,43,cs),
+(496,43,o),
+(447,101,o),
+(447,217,cs),
+(447,298,l),
+(388,298,l),
+(388,217,ls),
+(388,101,o),
+(340,43,o),
+(270,43,cs),
+(184,43,o),
+(134,109,o),
+(134,291,cs),
+(134,525,o),
+(211,635,o),
+(359,639,c),
+(359,690,l),
+(64,690,l),
+(64,637,l),
+(255,637,l),
+(242,644,l),
+(140,607,o),
+(72,501,o),
+(72,288,cs),
+(72,78,o),
+(144,-13,o),
+(267,-13,cs)
+);
+}
+);
+width = 858;
+}
+);
+metricRight = "tlhuCarrier-canadian";
+note = uni163A;
+unicode = 5690;
+},
+{
+color = 1;
+glyphname = "tloCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(811,-83,l),
+(811,132,l),
+(763,132,l),
+(763,48,l),
+(574,48,l),
+(587,42,l),
+(694,78,o),
+(764,184,o),
+(764,402,cs),
+(764,611,o),
+(692,702,o),
+(570,702,cs),
+(491,702,o),
+(433,653,o),
+(410,560,c),
+(426,560,l),
+(404,653,o),
+(345,702,o),
+(267,702,cs),
+(144,702,o),
+(72,611,o),
+(72,402,cs),
+(72,188,o),
+(140,83,o),
+(242,45,c),
+(255,53,l),
+(64,53,l),
+(64,0,l),
+(359,0,l),
+(359,51,l),
+(211,55,o),
+(134,165,o),
+(134,399,cs),
+(134,581,o),
+(184,646,o),
+(270,646,cs),
+(340,646,o),
+(388,588,o),
+(388,472,cs),
+(388,391,l),
+(447,391,l),
+(447,472,ls),
+(447,588,o),
+(496,646,o),
+(566,646,cs),
+(653,646,o),
+(702,581,o),
+(702,399,cs),
+(702,165,o),
+(626,55,o),
+(476,51,c),
+(476,0,l),
+(763,0,l),
+(763,-83,l)
+);
+}
+);
+width = 858;
+}
+);
+metricLeft = "tluCarrier-canadian";
+metricRight = "tlhuCarrier-canadian";
+note = uni163B;
+unicode = 5691;
+},
+{
+color = 9;
+glyphname = "tleCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (270,345);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(554,-13,o),
+(629,68,o),
+(629,182,cs),
+(629,268,o),
+(580,332,o),
+(491,352,c),
+(491,338,l),
+(580,356,o),
+(629,421,o),
+(629,508,cs),
+(629,622,o),
+(554,702,o),
+(396,702,cs),
+(243,702,o),
+(158,631,o),
+(128,529,c),
+(135,519,l),
+(135,703,l),
+(213,703,l),
+(213,750,l),
+(10,750,l),
+(10,703,l),
+(87,703,l),
+(87,419,l),
+(139,419,l),
+(143,552,o),
+(213,646,o),
+(385,646,cs),
+(514,646,o),
+(568,591,o),
+(568,503,cs),
+(568,419,o),
+(511,372,o),
+(411,372,cs),
+(369,372,l),
+(369,319,l),
+(411,319,ls),
+(515,319,o),
+(568,270,o),
+(568,186,cs),
+(568,99,o),
+(509,43,o),
+(385,43,cs),
+(213,43,o),
+(143,138,o),
+(139,270,c),
+(87,270,l),
+(87,0,l),
+(143,0,l),
+(143,162,l),
+(135,152,l),
+(166,55,o),
+(246,-13,o),
+(396,-13,cs)
+);
+}
+);
+width = 705;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni163C;
+unicode = 5692;
+},
+{
+color = 9;
+glyphname = "tleeCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (230,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 706;
+}
+);
+note = uni163D;
+unicode = 5693;
+},
+{
+color = 9;
+glyphname = "tliCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (213,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 706;
+}
+);
+note = uni163E;
+unicode = 5694;
+},
+{
+color = 9;
+glyphname = "tlaCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(460,-13,o),
+(539,55,o),
+(571,152,c),
+(563,162,l),
+(563,0,l),
+(618,0,l),
+(618,270,l),
+(567,270,l),
+(562,138,o),
+(493,43,o),
+(321,43,cs),
+(197,43,o),
+(138,99,o),
+(138,186,cs),
+(138,270,o),
+(191,319,o),
+(295,319,cs),
+(355,319,l),
+(355,372,l),
+(295,372,ls),
+(195,372,o),
+(138,419,o),
+(138,503,cs),
+(138,591,o),
+(192,646,o),
+(320,646,cs),
+(493,646,o),
+(562,552,o),
+(567,419,c),
+(618,419,l),
+(618,703,l),
+(696,703,l),
+(696,750,l),
+(493,750,l),
+(493,703,l),
+(571,703,l),
+(571,519,l),
+(577,529,l),
+(547,631,o),
+(463,702,o),
+(309,702,cs),
+(151,702,o),
+(76,622,o),
+(76,508,cs),
+(76,421,o),
+(126,356,o),
+(214,338,c),
+(214,352,l),
+(127,332,o),
+(76,268,o),
+(76,182,cs),
+(76,68,o),
+(151,-13,o),
+(309,-13,cs)
+);
+}
+);
+width = 706;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni163F;
+unicode = 5695;
+},
+{
+color = 9;
+glyphname = "zuCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(541,-13,o),
+(652,87,o),
+(652,241,cs),
+(652,365,o),
+(554,490,o),
+(554,569,cs),
+(554,604,o),
+(570,636,o),
+(630,636,cs),
+(661,636,l),
+(661,690,l),
+(618,690,ls),
+(530,690,o),
+(494,641,o),
+(494,575,cs),
+(494,482,o),
+(590,367,o),
+(590,248,cs),
+(590,121,o),
+(506,44,o),
+(360,44,cs),
+(215,44,o),
+(131,121,o),
+(131,248,cs),
+(131,367,o),
+(228,482,o),
+(228,575,cs),
+(228,641,o),
+(191,690,o),
+(103,690,cs),
+(61,690,l),
+(61,636,l),
+(92,636,ls),
+(152,636,o),
+(168,604,o),
+(168,569,cs),
+(168,490,o),
+(70,365,o),
+(70,241,cs),
+(70,87,o),
+(181,-13,o),
+(360,-13,cs)
+);
+}
+);
+width = 722;
+}
+);
+metricRight = "=|";
+note = uni1640;
+unicode = 5696;
+},
+{
+color = 9;
+glyphname = "zoCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(103,0,ls),
+(191,0,o),
+(228,48,o),
+(228,115,cs),
+(228,208,o),
+(131,323,o),
+(131,441,cs),
+(131,569,o),
+(215,645,o),
+(361,645,cs),
+(507,645,o),
+(590,569,o),
+(590,441,cs),
+(590,323,o),
+(494,208,o),
+(494,115,cs),
+(494,48,o),
+(530,0,o),
+(618,0,cs),
+(661,0,l),
+(661,54,l),
+(631,54,ls),
+(570,54,o),
+(554,86,o),
+(554,121,cs),
+(554,200,o),
+(652,325,o),
+(652,449,cs),
+(652,603,o),
+(542,702,o),
+(361,702,cs),
+(181,702,o),
+(70,603,o),
+(70,449,cs),
+(70,325,o),
+(168,200,o),
+(168,121,cs),
+(168,86,o),
+(152,54,o),
+(92,54,cs),
+(61,54,l),
+(61,0,l)
+);
+}
+);
+width = 722;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1641;
+unicode = 5697;
+},
+{
+color = 9;
+glyphname = "zeCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (355,345);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(519,-13,o),
+(606,105,o),
+(606,345,cs),
+(606,584,o),
+(519,702,o),
+(395,702,cs),
+(296,702,o),
+(211,599,o),
+(162,599,cs),
+(137,599,o),
+(114,613,o),
+(114,662,cs),
+(114,690,l),
+(59,690,l),
+(59,650,ls),
+(59,581,o),
+(96,544,o),
+(151,544,cs),
+(222,544,o),
+(298,645,o),
+(384,645,cs),
+(478,645,o),
+(544,555,o),
+(544,345,cs),
+(544,134,o),
+(478,44,o),
+(384,44,cs),
+(298,44,o),
+(222,146,o),
+(151,146,cs),
+(96,146,o),
+(59,109,o),
+(59,40,cs),
+(59,0,l),
+(114,0,l),
+(114,28,ls),
+(114,76,o),
+(137,91,o),
+(162,91,cs),
+(211,91,o),
+(296,-13,o),
+(395,-13,cs)
+);
+}
+);
+width = 672;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1642;
+unicode = 5698;
+},
+{
+color = 9;
+glyphname = "zeeCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (315,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 672;
+}
+);
+note = uni1643;
+unicode = 5699;
+},
+{
+color = 9;
+glyphname = "ziCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (293,0);
+ref = dot_middle;
+}
+);
+width = 672;
+}
+);
+note = uni1644;
+unicode = 5700;
+},
+{
+color = 9;
+glyphname = "zaCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(376,-13,o),
+(461,91,o),
+(510,91,cs),
+(535,91,o),
+(557,76,o),
+(557,28,cs),
+(557,0,l),
+(613,0,l),
+(613,40,ls),
+(613,109,o),
+(576,146,o),
+(522,146,cs),
+(449,146,o),
+(373,44,o),
+(287,44,cs),
+(194,44,o),
+(127,134,o),
+(127,345,cs),
+(127,555,o),
+(194,645,o),
+(287,645,cs),
+(373,645,o),
+(449,544,o),
+(522,544,cs),
+(576,544,o),
+(613,581,o),
+(613,650,cs),
+(613,690,l),
+(557,690,l),
+(557,662,ls),
+(557,613,o),
+(535,599,o),
+(510,599,cs),
+(461,599,o),
+(376,702,o),
+(277,702,cs),
+(154,702,o),
+(66,584,o),
+(66,345,cs),
+(66,105,o),
+(153,-13,o),
+(277,-13,cs)
+);
+}
+);
+width = 672;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|zeCarrier-canadian";
+note = uni1645;
+unicode = 5701;
+},
+{
+color = 6;
+glyphname = "zCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(355,183,l),
+(355,224,l),
+(115,224,l),
+(115,198,l),
+(352,503,l),
+(352,527,l),
+(68,527,l),
+(68,486,l),
+(304,486,l),
+(304,512,l),
+(68,207,l),
+(68,183,l)
+);
+}
+);
+width = 423;
+}
+);
+metricRight = "=|";
+note = uni1646;
+unicode = 5702;
+},
+{
+color = 6;
+glyphname = "initialzCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(187,183,l),
+(187,96,l),
+(232,96,l),
+(232,183,l),
+(355,183,l),
+(355,224,l),
+(107,224,l),
+(118,201,l),
+(352,503,l),
+(352,527,l),
+(232,527,l),
+(232,614,l),
+(187,614,l),
+(187,527,l),
+(68,527,l),
+(68,486,l),
+(312,486,l),
+(300,508,l),
+(68,207,l),
+(68,183,l)
+);
+}
+);
+width = 423;
+}
+);
+metricLeft = "zCarrier-canadian";
+metricRight = "zCarrier-canadian";
+note = uni1647;
+unicode = 5703;
+},
+{
+color = 9;
+glyphname = "dzuCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(541,-13,o),
+(652,87,o),
+(652,241,cs),
+(652,365,o),
+(554,490,o),
+(554,569,cs),
+(554,604,o),
+(570,636,o),
+(630,636,cs),
+(661,636,l),
+(661,690,l),
+(619,690,ls),
+(532,690,o),
+(495,641,o),
+(495,575,cs),
+(495,482,o),
+(590,368,o),
+(590,248,cs),
+(590,121,o),
+(506,44,o),
+(360,44,cs),
+(214,44,o),
+(131,121,o),
+(131,248,cs),
+(131,368,o),
+(227,482,o),
+(227,575,cs),
+(227,641,o),
+(189,690,o),
+(102,690,cs),
+(61,690,l),
+(61,636,l),
+(92,636,ls),
+(152,636,o),
+(168,604,o),
+(168,569,cs),
+(168,490,o),
+(70,365,o),
+(70,241,cs),
+(70,87,o),
+(181,-13,o),
+(360,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(379,490,l),
+(379,656,l),
+(447,656,l),
+(447,690,l),
+(274,690,l),
+(274,656,l),
+(343,656,l),
+(343,490,l)
+);
+}
+);
+width = 722;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1648;
+unicode = 5704;
+},
+{
+color = 9;
+glyphname = "dzoCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(102,0,ls),
+(189,0,o),
+(227,48,o),
+(227,115,cs),
+(227,208,o),
+(131,322,o),
+(131,441,cs),
+(131,569,o),
+(215,645,o),
+(361,645,cs),
+(507,645,o),
+(590,569,o),
+(590,441,cs),
+(590,322,o),
+(495,208,o),
+(495,115,cs),
+(495,48,o),
+(532,0,o),
+(619,0,cs),
+(661,0,l),
+(661,54,l),
+(631,54,ls),
+(570,54,o),
+(554,86,o),
+(554,121,cs),
+(554,200,o),
+(652,325,o),
+(652,449,cs),
+(652,603,o),
+(542,702,o),
+(361,702,cs),
+(181,702,o),
+(70,603,o),
+(70,449,cs),
+(70,325,o),
+(168,200,o),
+(168,121,cs),
+(168,86,o),
+(152,54,o),
+(92,54,cs),
+(61,54,l),
+(61,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(447,0,l),
+(447,34,l),
+(379,34,l),
+(379,200,l),
+(343,200,l),
+(343,34,l),
+(275,34,l),
+(275,0,l)
+);
+}
+);
+width = 722;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1649;
+unicode = 5705;
+},
+{
+color = 9;
+glyphname = "dzeCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (369,345);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(540,-13,o),
+(628,105,o),
+(628,345,cs),
+(628,584,o),
+(541,702,o),
+(416,702,cs),
+(318,702,o),
+(233,599,o),
+(184,599,cs),
+(158,599,o),
+(136,613,o),
+(136,662,cs),
+(136,690,l),
+(80,690,l),
+(80,650,ls),
+(80,581,o),
+(118,544,o),
+(173,544,cs),
+(244,544,o),
+(321,645,o),
+(407,645,cs),
+(499,645,o),
+(566,555,o),
+(566,345,cs),
+(566,134,o),
+(499,44,o),
+(407,44,cs),
+(321,44,o),
+(244,146,o),
+(173,146,cs),
+(118,146,o),
+(80,109,o),
+(80,40,cs),
+(80,0,l),
+(136,0,l),
+(136,28,ls),
+(136,75,o),
+(158,90,o),
+(184,90,cs),
+(233,90,o),
+(318,-13,o),
+(416,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(119,241,l),
+(119,327,l),
+(249,327,l),
+(249,363,l),
+(119,363,l),
+(119,449,l),
+(80,449,l),
+(80,241,l)
+);
+}
+);
+width = 694;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164A;
+unicode = 5706;
+},
+{
+color = 9;
+glyphname = "dzeeCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+ref = "dzeCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (329,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 694;
+}
+);
+metricLeft = "dzeCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164B;
+unicode = 5707;
+},
+{
+color = 9;
+glyphname = "dziCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "dzeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (307,0);
+ref = dot_middle;
+}
+);
+width = 695;
+}
+);
+note = uni164C;
+unicode = 5708;
+},
+{
+color = 9;
+glyphname = "dzaCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(376,-13,o),
+(461,90,o),
+(510,90,cs),
+(535,90,o),
+(557,75,o),
+(557,28,cs),
+(557,0,l),
+(613,0,l),
+(613,40,ls),
+(613,109,o),
+(576,146,o),
+(522,146,cs),
+(449,146,o),
+(373,44,o),
+(287,44,cs),
+(194,44,o),
+(127,134,o),
+(127,345,cs),
+(127,555,o),
+(194,645,o),
+(287,645,cs),
+(373,645,o),
+(449,544,o),
+(522,544,cs),
+(576,544,o),
+(613,581,o),
+(613,650,cs),
+(613,690,l),
+(557,690,l),
+(557,662,ls),
+(557,613,o),
+(535,599,o),
+(510,599,cs),
+(461,599,o),
+(376,702,o),
+(277,702,cs),
+(154,702,o),
+(66,584,o),
+(66,345,cs),
+(66,105,o),
+(154,-13,o),
+(277,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(613,241,l),
+(613,449,l),
+(575,449,l),
+(575,363,l),
+(444,363,l),
+(444,327,l),
+(575,327,l),
+(575,241,l)
+);
+}
+);
+width = 693;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dzeCarrier-canadian";
+note = uni164D;
+unicode = 5709;
+},
+{
+color = 9;
+glyphname = "suCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(343,-13,o),
+(404,43,o),
+(425,143,c),
+(405,143,l),
+(426,43,o),
+(488,-13,o),
+(579,-13,cs),
+(697,-13,o),
+(761,73,o),
+(761,195,cs),
+(761,333,o),
+(663,479,o),
+(663,569,cs),
+(663,604,o),
+(680,636,o),
+(739,636,cs),
+(769,636,l),
+(769,690,l),
+(727,690,ls),
+(639,690,o),
+(604,641,o),
+(604,575,cs),
+(604,472,o),
+(699,328,o),
+(699,201,cs),
+(699,104,o),
+(658,43,o),
+(575,43,cs),
+(492,43,o),
+(443,105,o),
+(443,223,cs),
+(443,690,l),
+(386,690,l),
+(386,223,ls),
+(386,105,o),
+(338,43,o),
+(256,43,cs),
+(173,43,o),
+(130,104,o),
+(130,201,cs),
+(130,328,o),
+(227,472,o),
+(227,575,cs),
+(227,641,o),
+(190,690,o),
+(102,690,cs),
+(61,690,l),
+(61,636,l),
+(91,636,ls),
+(151,636,o),
+(167,604,o),
+(167,569,cs),
+(167,479,o),
+(70,333,o),
+(70,195,cs),
+(70,73,o),
+(133,-13,o),
+(252,-13,cs)
+);
+}
+);
+width = 830;
+}
+);
+metricRight = "=|";
+note = uni164E;
+unicode = 5710;
+},
+{
+color = 9;
+glyphname = "soCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(102,0,ls),
+(190,0,o),
+(226,48,o),
+(226,115,cs),
+(226,217,o),
+(130,361,o),
+(130,489,cs),
+(130,585,o),
+(173,646,o),
+(255,646,cs),
+(338,646,o),
+(386,584,o),
+(386,467,cs),
+(386,0,l),
+(443,0,l),
+(443,467,ls),
+(443,584,o),
+(492,646,o),
+(575,646,cs),
+(657,646,o),
+(699,585,o),
+(699,489,cs),
+(699,361,o),
+(604,217,o),
+(604,115,cs),
+(604,48,o),
+(639,0,o),
+(727,0,cs),
+(769,0,l),
+(769,54,l),
+(739,54,ls),
+(680,54,o),
+(663,86,o),
+(663,121,cs),
+(663,211,o),
+(760,356,o),
+(760,495,cs),
+(760,616,o),
+(696,702,o),
+(579,702,cs),
+(488,702,o),
+(426,646,o),
+(405,547,c),
+(425,547,l),
+(404,646,o),
+(342,702,o),
+(251,702,cs),
+(132,702,o),
+(69,616,o),
+(69,495,cs),
+(69,356,o),
+(167,211,o),
+(167,121,cs),
+(167,86,o),
+(151,54,o),
+(91,54,cs),
+(61,54,l),
+(61,0,l)
+);
+}
+);
+width = 830;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5711;
+},
+{
+color = 9;
+glyphname = "seCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(554,-13,o),
+(619,62,o),
+(619,173,cs),
+(619,273,o),
+(561,341,o),
+(462,354,c),
+(462,336,l),
+(561,348,o),
+(619,415,o),
+(619,517,cs),
+(619,628,o),
+(554,702,o),
+(451,702,cs),
+(351,702,o),
+(236,599,o),
+(179,599,cs),
+(156,599,o),
+(133,613,o),
+(133,662,cs),
+(133,690,l),
+(77,690,l),
+(77,651,ls),
+(77,582,o),
+(114,545,o),
+(168,545,cs),
+(245,545,o),
+(353,646,o),
+(440,646,cs),
+(514,646,o),
+(558,596,o),
+(558,512,cs),
+(558,419,o),
+(498,371,o),
+(399,371,cs),
+(77,371,l),
+(77,319,l),
+(399,319,ls),
+(499,319,o),
+(558,270,o),
+(558,178,cs),
+(558,94,o),
+(514,43,o),
+(440,43,cs),
+(353,43,o),
+(245,145,o),
+(168,145,cs),
+(114,145,o),
+(77,108,o),
+(77,39,cs),
+(77,0,l),
+(133,0,l),
+(133,28,ls),
+(133,76,o),
+(156,91,o),
+(179,91,cs),
+(236,91,o),
+(351,-13,o),
+(451,-13,cs)
+);
+}
+);
+width = 695;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni1650;
+unicode = 5712;
+},
+{
+color = 9;
+glyphname = "seeCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(554,-13,o),
+(619,62,o),
+(619,173,cs),
+(619,268,o),
+(568,332,o),
+(479,352,c),
+(479,338,l),
+(568,356,o),
+(619,421,o),
+(619,517,cs),
+(619,628,o),
+(554,702,o),
+(451,702,cs),
+(351,702,o),
+(236,599,o),
+(179,599,cs),
+(156,599,o),
+(133,613,o),
+(133,662,cs),
+(133,690,l),
+(77,690,l),
+(77,651,ls),
+(77,582,o),
+(114,545,o),
+(168,545,cs),
+(245,545,o),
+(353,646,o),
+(440,646,cs),
+(514,646,o),
+(558,596,o),
+(558,512,cs),
+(558,419,o),
+(498,371,o),
+(402,371,cs),
+(341,371,l),
+(356,349,l),
+(356,453,l),
+(317,453,l),
+(317,371,l),
+(77,371,l),
+(77,320,l),
+(317,320,l),
+(317,226,l),
+(356,226,l),
+(356,341,l),
+(341,320,l),
+(402,320,ls),
+(499,320,o),
+(558,270,o),
+(558,178,cs),
+(558,94,o),
+(514,43,o),
+(440,43,cs),
+(353,43,o),
+(245,145,o),
+(168,145,cs),
+(114,145,o),
+(77,108,o),
+(77,39,cs),
+(77,0,l),
+(133,0,l),
+(133,28,ls),
+(133,76,o),
+(156,91,o),
+(179,91,cs),
+(236,91,o),
+(351,-13,o),
+(451,-13,cs)
+);
+}
+);
+width = 695;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1651;
+unicode = 5713;
+},
+{
+color = 9;
+glyphname = "siCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(554,-13,o),
+(619,62,o),
+(619,173,cs),
+(619,268,o),
+(567,332,o),
+(481,352,c),
+(481,338,l),
+(568,356,o),
+(619,421,o),
+(619,517,cs),
+(619,628,o),
+(554,702,o),
+(451,702,cs),
+(351,702,o),
+(236,599,o),
+(179,599,cs),
+(156,599,o),
+(133,613,o),
+(133,662,cs),
+(133,690,l),
+(77,690,l),
+(77,651,ls),
+(77,582,o),
+(114,545,o),
+(168,545,cs),
+(245,545,o),
+(353,646,o),
+(440,646,cs),
+(515,646,o),
+(559,596,o),
+(559,512,cs),
+(559,418,o),
+(500,370,o),
+(411,370,cs),
+(364,370,l),
+(386,352,l),
+(384,384,o),
+(358,409,o),
+(325,409,cs),
+(299,409,o),
+(277,393,o),
+(269,371,c),
+(77,371,l),
+(77,320,l),
+(270,320,l),
+(278,298,o),
+(300,282,o),
+(326,282,cs),
+(357,282,o),
+(383,306,o),
+(386,338,c),
+(363,321,l),
+(411,321,ls),
+(501,321,o),
+(559,271,o),
+(559,178,cs),
+(559,94,o),
+(515,43,o),
+(440,43,cs),
+(353,43,o),
+(245,145,o),
+(168,145,cs),
+(114,145,o),
+(77,108,o),
+(77,39,cs),
+(77,0,l),
+(133,0,l),
+(133,28,ls),
+(133,76,o),
+(156,91,o),
+(179,91,cs),
+(236,91,o),
+(351,-13,o),
+(451,-13,cs)
+);
+}
+);
+width = 695;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1652;
+unicode = 5714;
+},
+{
+color = 9;
+glyphname = "saCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(345,-13,o),
+(461,91,o),
+(517,91,cs),
+(541,91,o),
+(563,76,o),
+(563,28,cs),
+(563,0,l),
+(619,0,l),
+(619,39,ls),
+(619,108,o),
+(582,145,o),
+(527,145,cs),
+(450,145,o),
+(344,43,o),
+(257,43,cs),
+(183,43,o),
+(138,94,o),
+(138,178,cs),
+(138,270,o),
+(196,319,o),
+(297,319,cs),
+(619,319,l),
+(619,371,l),
+(297,371,ls),
+(197,371,o),
+(138,419,o),
+(138,512,cs),
+(138,596,o),
+(183,646,o),
+(257,646,cs),
+(344,646,o),
+(450,545,o),
+(527,545,cs),
+(582,545,o),
+(619,582,o),
+(619,651,cs),
+(619,690,l),
+(563,690,l),
+(563,662,ls),
+(563,613,o),
+(541,599,o),
+(517,599,cs),
+(461,599,o),
+(345,702,o),
+(245,702,cs),
+(142,702,o),
+(76,628,o),
+(76,517,cs),
+(76,415,o),
+(134,348,o),
+(235,336,c),
+(235,354,l),
+(135,341,o),
+(76,273,o),
+(76,173,cs),
+(76,62,o),
+(142,-13,o),
+(244,-13,cs)
+);
+}
+);
+width = 696;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1653;
+unicode = 5715;
+},
+{
+color = 9;
+glyphname = "shuCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(340,-13,o),
+(400,40,o),
+(423,134,c),
+(408,134,l),
+(430,40,o),
+(491,-13,o),
+(579,-13,cs),
+(697,-13,o),
+(761,73,o),
+(761,195,cs),
+(761,333,o),
+(663,479,o),
+(663,569,cs),
+(663,604,o),
+(680,636,o),
+(739,636,cs),
+(769,636,l),
+(769,690,l),
+(727,690,ls),
+(639,690,o),
+(604,641,o),
+(604,575,cs),
+(604,557,o),
+(608,538,o),
+(611,520,c),
+(624,554,l),
+(443,554,l),
+(443,690,l),
+(386,690,l),
+(386,554,l),
+(207,554,l),
+(219,520,l),
+(223,538,o),
+(226,557,o),
+(226,575,cs),
+(226,641,o),
+(190,690,o),
+(102,690,cs),
+(61,690,l),
+(61,636,l),
+(91,636,ls),
+(151,636,o),
+(167,604,o),
+(167,569,cs),
+(167,479,o),
+(70,333,o),
+(70,195,cs),
+(70,73,o),
+(133,-13,o),
+(252,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(173,43,o),
+(130,104,o),
+(130,201,cs),
+(130,301,o),
+(190,412,o),
+(215,503,c),
+(386,503,l),
+(386,223,ls),
+(386,105,o),
+(338,43,o),
+(256,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(492,43,o),
+(443,105,o),
+(443,223,cs),
+(443,503,l),
+(615,503,l),
+(639,412,o),
+(699,301,o),
+(699,201,cs),
+(699,104,o),
+(658,43,o),
+(575,43,cs)
+);
+}
+);
+width = 830;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1654;
+unicode = 5716;
+},
+{
+color = 9;
+glyphname = "shoCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(102,0,ls),
+(190,0,o),
+(226,48,o),
+(226,115,cs),
+(226,132,o),
+(223,152,o),
+(219,170,c),
+(207,135,l),
+(386,135,l),
+(386,0,l),
+(443,0,l),
+(443,135,l),
+(623,135,l),
+(611,170,l),
+(607,152,o),
+(604,132,o),
+(604,115,cs),
+(604,48,o),
+(639,0,o),
+(727,0,cs),
+(769,0,l),
+(769,54,l),
+(739,54,ls),
+(680,54,o),
+(663,86,o),
+(663,121,cs),
+(663,211,o),
+(760,356,o),
+(760,495,cs),
+(760,616,o),
+(696,702,o),
+(579,702,cs),
+(490,702,o),
+(430,650,o),
+(407,555,c),
+(423,555,l),
+(400,650,o),
+(340,702,o),
+(251,702,cs),
+(132,702,o),
+(69,616,o),
+(69,495,cs),
+(69,356,o),
+(167,211,o),
+(167,121,cs),
+(167,86,o),
+(151,54,o),
+(91,54,cs),
+(61,54,l),
+(61,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(190,278,o),
+(130,388,o),
+(130,489,cs),
+(130,585,o),
+(173,646,o),
+(255,646,cs),
+(338,646,o),
+(386,584,o),
+(386,467,cs),
+(386,186,l),
+(214,186,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(443,467,ls),
+(443,584,o),
+(492,646,o),
+(575,646,cs),
+(657,646,o),
+(699,585,o),
+(699,489,cs),
+(699,388,o),
+(639,278,o),
+(614,186,c),
+(443,186,l)
+);
+}
+);
+width = 830;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1655;
+unicode = 5717;
+},
+{
+color = 9;
+glyphname = "sheCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(554,-13,o),
+(619,62,o),
+(619,173,cs),
+(619,268,o),
+(568,332,o),
+(479,352,c),
+(479,338,l),
+(568,356,o),
+(619,421,o),
+(619,517,cs),
+(619,628,o),
+(554,702,o),
+(451,702,cs),
+(351,702,o),
+(236,599,o),
+(179,599,cs),
+(156,599,o),
+(133,613,o),
+(133,662,cs),
+(133,690,l),
+(77,690,l),
+(77,651,ls),
+(77,582,o),
+(114,546,o),
+(168,546,cs),
+(186,546,o),
+(205,551,o),
+(224,558,c),
+(192,570,l),
+(192,371,l),
+(77,371,l),
+(77,319,l),
+(192,319,l),
+(192,120,l),
+(224,131,l),
+(205,139,o),
+(186,144,o),
+(168,144,cs),
+(114,144,o),
+(77,108,o),
+(77,39,cs),
+(77,0,l),
+(133,0,l),
+(133,28,ls),
+(133,76,o),
+(156,91,o),
+(179,91,cs),
+(236,91,o),
+(351,-13,o),
+(451,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(242,319,l),
+(399,319,ls),
+(499,319,o),
+(558,270,o),
+(558,178,cs),
+(558,94,o),
+(514,43,o),
+(440,43,cs),
+(377,43,o),
+(305,95,o),
+(242,124,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(242,566,l),
+(305,595,o),
+(377,646,o),
+(440,646,cs),
+(514,646,o),
+(558,596,o),
+(558,512,cs),
+(558,419,o),
+(498,371,o),
+(399,371,cs),
+(242,371,l)
+);
+}
+);
+width = 695;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1656;
+unicode = 5718;
+},
+{
+color = 9;
+glyphname = "sheeCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(554,-13,o),
+(619,62,o),
+(619,173,cs),
+(619,268,o),
+(568,332,o),
+(479,352,c),
+(479,338,l),
+(568,356,o),
+(619,421,o),
+(619,517,cs),
+(619,628,o),
+(554,702,o),
+(451,702,cs),
+(351,702,o),
+(236,599,o),
+(179,599,cs),
+(156,599,o),
+(133,613,o),
+(133,662,cs),
+(133,690,l),
+(77,690,l),
+(77,651,ls),
+(77,582,o),
+(114,546,o),
+(168,546,cs),
+(185,546,o),
+(205,551,o),
+(223,557,c),
+(192,571,l),
+(192,368,l),
+(77,368,l),
+(77,323,l),
+(192,323,l),
+(192,119,l),
+(223,132,l),
+(205,139,o),
+(185,144,o),
+(168,144,cs),
+(114,144,o),
+(77,108,o),
+(77,39,cs),
+(77,0,l),
+(133,0,l),
+(133,28,ls),
+(133,76,o),
+(156,91,o),
+(179,91,cs),
+(236,91,o),
+(351,-13,o),
+(451,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(377,43,o),
+(302,96,o),
+(239,126,c),
+(239,323,l),
+(359,323,l),
+(359,227,l),
+(395,227,l),
+(395,336,l),
+(382,323,l),
+(405,323,ls),
+(501,323,o),
+(559,271,o),
+(559,180,cs),
+(559,94,o),
+(515,43,o),
+(440,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(395,453,l),
+(359,453,l),
+(359,368,l),
+(239,368,l),
+(239,564,l),
+(302,594,o),
+(377,647,o),
+(440,647,cs),
+(515,647,o),
+(559,596,o),
+(559,510,cs),
+(559,418,o),
+(500,368,o),
+(405,368,cs),
+(382,368,l),
+(395,354,l)
+);
+}
+);
+width = 695;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1657;
+unicode = 5719;
+},
+{
+color = 9;
+glyphname = "shiCarrier-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(77,651,ls),
+(77,582,o),
+(114,546,o),
+(168,546,cs),
+(185,546,o),
+(203,550,o),
+(221,557,c),
+(192,572,l),
+(192,368,l),
+(77,368,l),
+(77,323,l),
+(192,323,l),
+(192,118,l),
+(221,132,l),
+(203,140,o),
+(185,144,o),
+(168,144,cs),
+(114,144,o),
+(77,108,o),
+(77,39,cs),
+(77,0,l),
+(133,0,l),
+(133,28,ls),
+(133,76,o),
+(156,91,o),
+(179,91,cs),
+(236,91,o),
+(351,-13,o),
+(451,-13,cs),
+(554,-13,o),
+(619,62,o),
+(619,173,cs),
+(619,268,o),
+(567,332,o),
+(481,352,c),
+(481,338,l),
+(568,356,o),
+(619,421,o),
+(619,517,cs),
+(619,628,o),
+(554,702,o),
+(451,702,cs),
+(351,702,o),
+(236,599,o),
+(179,599,cs),
+(156,599,o),
+(133,613,o),
+(133,662,cs),
+(133,690,l),
+(77,690,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(239,323,l),
+(321,323,l),
+(330,298,o),
+(353,282,o),
+(378,282,cs),
+(411,282,o),
+(436,308,o),
+(438,340,c),
+(387,322,l),
+(412,322,ls),
+(502,322,o),
+(559,270,o),
+(559,180,cs),
+(559,94,o),
+(515,43,o),
+(440,43,cs),
+(377,43,o),
+(302,96,o),
+(239,126,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(239,564,l),
+(302,594,o),
+(377,647,o),
+(440,647,cs),
+(515,647,o),
+(559,596,o),
+(559,510,cs),
+(559,419,o),
+(501,368,o),
+(412,368,cs),
+(388,368,l),
+(439,350,l),
+(438,383,o),
+(411,409,o),
+(377,409,cs),
+(352,409,o),
+(329,393,o),
+(321,368,c),
+(239,368,l)
+);
+}
+);
+width = 695;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1658;
+unicode = 5720;
+},
+{
+color = 9;
+glyphname = "shaCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(345,-13,o),
+(461,91,o),
+(517,91,cs),
+(541,91,o),
+(563,76,o),
+(563,28,cs),
+(563,0,l),
+(619,0,l),
+(619,39,ls),
+(619,108,o),
+(582,144,o),
+(527,144,cs),
+(510,144,o),
+(491,139,o),
+(472,131,c),
+(504,120,l),
+(504,319,l),
+(619,319,l),
+(619,371,l),
+(504,371,l),
+(504,570,l),
+(472,558,l),
+(491,551,o),
+(510,546,o),
+(527,546,cs),
+(582,546,o),
+(619,582,o),
+(619,651,cs),
+(619,690,l),
+(563,690,l),
+(563,662,ls),
+(563,613,o),
+(541,599,o),
+(517,599,cs),
+(461,599,o),
+(345,702,o),
+(245,702,cs),
+(142,702,o),
+(76,628,o),
+(76,517,cs),
+(76,421,o),
+(128,356,o),
+(216,338,c),
+(216,352,l),
+(128,332,o),
+(76,268,o),
+(76,173,cs),
+(76,62,o),
+(142,-13,o),
+(244,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(183,43,o),
+(138,94,o),
+(138,178,cs),
+(138,270,o),
+(196,319,o),
+(297,319,cs),
+(453,319,l),
+(453,124,l),
+(390,95,o),
+(319,43,o),
+(257,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(197,371,o),
+(138,419,o),
+(138,512,cs),
+(138,596,o),
+(183,646,o),
+(257,646,cs),
+(319,646,o),
+(390,595,o),
+(453,566,c),
+(453,371,l),
+(297,371,ls)
+);
+}
+);
+width = 696;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1659;
+unicode = 5721;
+},
+{
+color = 6;
+glyphname = "shCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(220,96,l),
+(220,196,l),
+(196,183,l),
+(218,183,ls),
+(291,183,o),
+(327,217,o),
+(327,277,cs),
+(327,337,o),
+(292,374,o),
+(220,374,cs),
+(180,374,ls),
+(134,374,o),
+(109,390,o),
+(109,432,cs),
+(109,473,o),
+(135,490,o),
+(180,490,cs),
+(322,490,l),
+(322,527,l),
+(220,527,l),
+(220,614,l),
+(176,614,l),
+(176,512,l),
+(199,527,l),
+(177,527,ls),
+(104,527,o),
+(68,493,o),
+(68,433,cs),
+(68,373,o),
+(103,336,o),
+(175,336,cs),
+(215,336,ls),
+(261,336,o),
+(286,319,o),
+(286,278,cs),
+(286,238,o),
+(260,220,o),
+(215,220,cs),
+(73,220,l),
+(73,183,l),
+(176,183,l),
+(176,96,l)
+);
+}
+);
+width = 395;
+}
+);
+metricRight = "=|";
+note = uni18F5;
+unicode = 5722;
+},
+{
+color = 9;
+glyphname = "tsuCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(340,-13,o),
+(400,40,o),
+(423,134,c),
+(408,134,l),
+(430,40,o),
+(491,-13,o),
+(579,-13,cs),
+(697,-13,o),
+(761,73,o),
+(761,195,cs),
+(761,333,o),
+(663,479,o),
+(663,569,cs),
+(663,604,o),
+(680,636,o),
+(739,636,cs),
+(769,636,l),
+(769,690,l),
+(727,690,ls),
+(640,690,o),
+(605,642,o),
+(605,575,cs),
+(605,519,o),
+(639,447,o),
+(666,371,c),
+(443,371,l),
+(443,643,l),
+(527,643,l),
+(527,690,l),
+(302,690,l),
+(302,643,l),
+(387,643,l),
+(387,371,l),
+(165,371,l),
+(191,447,o),
+(226,519,o),
+(226,575,cs),
+(226,642,o),
+(189,690,o),
+(102,690,cs),
+(61,690,l),
+(61,636,l),
+(91,636,ls),
+(151,636,o),
+(167,604,o),
+(167,569,cs),
+(167,479,o),
+(70,333,o),
+(70,195,cs),
+(70,73,o),
+(133,-13,o),
+(252,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(173,43,o),
+(130,104,o),
+(130,201,cs),
+(130,240,o),
+(139,279,o),
+(151,319,c),
+(387,319,l),
+(387,223,ls),
+(387,105,o),
+(338,43,o),
+(256,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(492,43,o),
+(443,105,o),
+(443,223,cs),
+(443,319,l),
+(679,319,l),
+(691,279,o),
+(699,240,o),
+(699,201,cs),
+(699,104,o),
+(657,43,o),
+(575,43,cs)
+);
+}
+);
+width = 830;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165B;
+unicode = 5723;
+},
+{
+color = 9;
+glyphname = "tsoCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(102,0,ls),
+(189,0,o),
+(225,47,o),
+(225,115,cs),
+(225,171,o),
+(190,242,o),
+(164,319,c),
+(387,319,l),
+(387,46,l),
+(303,46,l),
+(303,0,l),
+(527,0,l),
+(527,46,l),
+(442,46,l),
+(442,319,l),
+(666,319,l),
+(639,242,o),
+(605,171,o),
+(605,115,cs),
+(605,47,o),
+(640,0,o),
+(727,0,cs),
+(769,0,l),
+(769,54,l),
+(739,54,ls),
+(680,54,o),
+(663,86,o),
+(663,121,cs),
+(663,211,o),
+(760,356,o),
+(760,495,cs),
+(760,616,o),
+(696,702,o),
+(579,702,cs),
+(490,702,o),
+(430,650,o),
+(407,555,c),
+(423,555,l),
+(400,650,o),
+(340,702,o),
+(251,702,cs),
+(132,702,o),
+(69,616,o),
+(69,495,cs),
+(69,356,o),
+(167,211,o),
+(167,121,cs),
+(167,86,o),
+(151,54,o),
+(91,54,cs),
+(61,54,l),
+(61,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(139,411,o),
+(130,450,o),
+(130,489,cs),
+(130,585,o),
+(173,646,o),
+(255,646,cs),
+(338,646,o),
+(387,584,o),
+(387,467,cs),
+(387,371,l),
+(151,371,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(442,467,ls),
+(442,584,o),
+(492,646,o),
+(574,646,cs),
+(657,646,o),
+(699,585,o),
+(699,489,cs),
+(699,450,o),
+(691,411,o),
+(679,371,c),
+(442,371,l)
+);
+}
+);
+width = 830;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165C;
+unicode = 5724;
+},
+{
+color = 9;
+glyphname = "tseCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(557,-13,o),
+(623,62,o),
+(623,173,cs),
+(623,268,o),
+(572,332,o),
+(483,352,c),
+(483,338,l),
+(572,356,o),
+(623,421,o),
+(623,517,cs),
+(623,628,o),
+(557,702,o),
+(455,702,cs),
+(355,702,o),
+(239,599,o),
+(183,599,cs),
+(159,599,o),
+(136,613,o),
+(136,662,cs),
+(136,690,l),
+(81,690,l),
+(81,653,ls),
+(81,582,o),
+(118,547,o),
+(172,547,cs),
+(201,547,o),
+(234,560,o),
+(268,578,c),
+(244,585,l),
+(244,368,l),
+(121,368,l),
+(121,467,l),
+(81,467,l),
+(81,223,l),
+(121,223,l),
+(121,322,l),
+(244,322,l),
+(244,104,l),
+(268,112,l),
+(234,129,o),
+(201,143,o),
+(172,143,cs),
+(118,143,o),
+(81,107,o),
+(81,37,cs),
+(81,0,l),
+(136,0,l),
+(136,28,ls),
+(136,76,o),
+(159,91,o),
+(183,91,cs),
+(239,91,o),
+(355,-13,o),
+(455,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(395,43,o),
+(341,74,o),
+(290,100,c),
+(290,322,l),
+(403,322,ls),
+(503,322,o),
+(562,270,o),
+(562,178,cs),
+(562,94,o),
+(518,43,o),
+(443,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(290,589,l),
+(341,615,o),
+(395,646,o),
+(443,646,cs),
+(518,646,o),
+(562,596,o),
+(562,512,cs),
+(562,419,o),
+(502,368,o),
+(403,368,cs),
+(290,368,l)
+);
+}
+);
+width = 699;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni165D;
+unicode = 5725;
+},
+{
+color = 9;
+glyphname = "tseeCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(557,-13,o),
+(623,62,o),
+(623,173,cs),
+(623,268,o),
+(572,332,o),
+(483,352,c),
+(483,338,l),
+(572,356,o),
+(623,421,o),
+(623,517,cs),
+(623,628,o),
+(557,702,o),
+(455,702,cs),
+(355,702,o),
+(239,599,o),
+(183,599,cs),
+(159,599,o),
+(136,613,o),
+(136,662,cs),
+(136,690,l),
+(81,690,l),
+(81,653,ls),
+(81,582,o),
+(118,547,o),
+(172,547,cs),
+(198,547,o),
+(229,559,o),
+(261,576,c),
+(242,585,l),
+(242,368,l),
+(121,368,l),
+(121,467,l),
+(81,467,l),
+(81,223,l),
+(121,223,l),
+(121,322,l),
+(242,322,l),
+(242,102,l),
+(261,114,l),
+(229,130,o),
+(198,143,o),
+(172,143,cs),
+(118,143,o),
+(81,107,o),
+(81,37,cs),
+(81,0,l),
+(136,0,l),
+(136,28,ls),
+(136,76,o),
+(159,91,o),
+(183,91,cs),
+(239,91,o),
+(355,-13,o),
+(455,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(394,43,o),
+(337,76,o),
+(284,103,c),
+(284,322,l),
+(386,322,l),
+(386,225,l),
+(422,225,l),
+(422,343,l),
+(389,322,l),
+(410,322,ls),
+(506,322,o),
+(562,270,o),
+(562,180,cs),
+(562,94,o),
+(518,43,o),
+(443,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(422,454,l),
+(386,454,l),
+(386,368,l),
+(284,368,l),
+(284,586,l),
+(337,613,o),
+(394,646,o),
+(443,646,cs),
+(518,646,o),
+(562,596,o),
+(562,510,cs),
+(562,419,o),
+(506,368,o),
+(410,368,cs),
+(389,368,l),
+(422,347,l)
+);
+}
+);
+width = 699;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165E;
+unicode = 5726;
+},
+{
+color = 9;
+glyphname = "tsiCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(557,-13,o),
+(623,62,o),
+(623,173,cs),
+(623,268,o),
+(571,332,o),
+(485,352,c),
+(485,338,l),
+(572,356,o),
+(623,421,o),
+(623,517,cs),
+(623,628,o),
+(557,702,o),
+(455,702,cs),
+(355,702,o),
+(239,599,o),
+(183,599,cs),
+(159,599,o),
+(136,613,o),
+(136,662,cs),
+(136,690,l),
+(81,690,l),
+(81,653,ls),
+(81,582,o),
+(118,547,o),
+(172,547,cs),
+(197,547,o),
+(227,559,o),
+(257,575,c),
+(237,592,l),
+(237,368,l),
+(121,368,l),
+(121,467,l),
+(81,467,l),
+(81,223,l),
+(121,223,l),
+(121,323,l),
+(237,323,l),
+(237,98,l),
+(257,115,l),
+(226,130,o),
+(197,143,o),
+(172,143,cs),
+(118,143,o),
+(81,107,o),
+(81,37,cs),
+(81,0,l),
+(136,0,l),
+(136,28,ls),
+(136,76,o),
+(159,91,o),
+(183,91,cs),
+(239,91,o),
+(355,-13,o),
+(455,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(392,43,o),
+(333,78,o),
+(279,106,c),
+(279,323,l),
+(353,323,l),
+(360,298,o),
+(383,282,o),
+(408,282,cs),
+(440,282,o),
+(465,308,o),
+(467,340,c),
+(403,323,l),
+(418,323,ls),
+(508,323,o),
+(562,271,o),
+(562,180,cs),
+(562,94,o),
+(518,43,o),
+(443,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(466,383,o),
+(440,409,o),
+(408,409,cs),
+(382,409,o),
+(359,392,o),
+(352,368,c),
+(279,368,l),
+(279,583,l),
+(333,611,o),
+(392,646,o),
+(443,646,cs),
+(518,646,o),
+(562,596,o),
+(562,510,cs),
+(562,418,o),
+(507,368,o),
+(418,368,cs),
+(404,368,l),
+(468,350,l)
+);
+}
+);
+width = 699;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165F;
+unicode = 5727;
+},
+{
+color = 9;
+glyphname = "tsaCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(345,-13,o),
+(461,91,o),
+(517,91,cs),
+(541,91,o),
+(563,76,o),
+(563,28,cs),
+(563,0,l),
+(619,0,l),
+(619,37,ls),
+(619,107,o),
+(582,143,o),
+(527,143,cs),
+(499,143,o),
+(467,129,o),
+(433,112,c),
+(456,104,l),
+(456,322,l),
+(579,322,l),
+(579,223,l),
+(619,223,l),
+(619,467,l),
+(579,467,l),
+(579,368,l),
+(456,368,l),
+(456,585,l),
+(432,578,l),
+(467,560,o),
+(498,547,o),
+(527,547,cs),
+(582,547,o),
+(619,582,o),
+(619,653,cs),
+(619,690,l),
+(563,690,l),
+(563,662,ls),
+(563,613,o),
+(541,599,o),
+(517,599,cs),
+(461,599,o),
+(345,702,o),
+(245,702,cs),
+(142,702,o),
+(76,628,o),
+(76,517,cs),
+(76,421,o),
+(128,356,o),
+(216,338,c),
+(216,352,l),
+(128,332,o),
+(76,268,o),
+(76,173,cs),
+(76,62,o),
+(142,-13,o),
+(244,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(183,43,o),
+(137,94,o),
+(137,178,cs),
+(137,270,o),
+(196,322,o),
+(297,322,cs),
+(410,322,l),
+(410,100,l),
+(359,74,o),
+(304,43,o),
+(256,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(197,368,o),
+(137,419,o),
+(137,512,cs),
+(137,596,o),
+(183,646,o),
+(257,646,cs),
+(304,646,o),
+(359,615,o),
+(410,589,c),
+(410,368,l),
+(297,368,ls)
+);
+}
+);
+width = 700;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1660;
+unicode = 5728;
+},
+{
+color = 9;
+glyphname = "chuCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(340,-13,o),
+(400,40,o),
+(423,134,c),
+(408,134,l),
+(430,40,o),
+(491,-13,o),
+(579,-13,cs),
+(697,-13,o),
+(761,73,o),
+(761,195,cs),
+(761,333,o),
+(663,479,o),
+(663,569,cs),
+(663,604,o),
+(680,636,o),
+(739,636,cs),
+(769,636,l),
+(769,690,l),
+(727,690,ls),
+(640,690,o),
+(605,642,o),
+(605,575,cs),
+(605,471,o),
+(699,328,o),
+(699,201,cs),
+(699,104,o),
+(657,43,o),
+(575,43,cs),
+(492,43,o),
+(443,105,o),
+(443,223,cs),
+(443,643,l),
+(527,643,l),
+(527,690,l),
+(302,690,l),
+(302,643,l),
+(386,643,l),
+(386,223,ls),
+(386,105,o),
+(338,43,o),
+(256,43,cs),
+(173,43,o),
+(130,104,o),
+(130,201,cs),
+(130,328,o),
+(226,471,o),
+(226,575,cs),
+(226,642,o),
+(189,690,o),
+(102,690,cs),
+(61,690,l),
+(61,636,l),
+(91,636,ls),
+(151,636,o),
+(167,604,o),
+(167,569,cs),
+(167,479,o),
+(70,333,o),
+(70,195,cs),
+(70,73,o),
+(133,-13,o),
+(252,-13,cs)
+);
+}
+);
+width = 830;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164E;
+unicode = 5729;
+},
+{
+color = 9;
+glyphname = "choCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(102,0,ls),
+(189,0,o),
+(225,47,o),
+(225,115,cs),
+(225,218,o),
+(130,361,o),
+(130,489,cs),
+(130,585,o),
+(173,646,o),
+(255,646,cs),
+(338,646,o),
+(386,584,o),
+(386,467,cs),
+(386,46,l),
+(303,46,l),
+(303,0,l),
+(527,0,l),
+(527,46,l),
+(443,46,l),
+(443,467,ls),
+(443,584,o),
+(492,646,o),
+(574,646,cs),
+(657,646,o),
+(699,585,o),
+(699,489,cs),
+(699,361,o),
+(605,218,o),
+(605,115,cs),
+(605,47,o),
+(640,0,o),
+(727,0,cs),
+(769,0,l),
+(769,54,l),
+(739,54,ls),
+(680,54,o),
+(663,86,o),
+(663,121,cs),
+(663,211,o),
+(760,356,o),
+(760,495,cs),
+(760,616,o),
+(696,702,o),
+(579,702,cs),
+(490,702,o),
+(430,650,o),
+(407,555,c),
+(423,555,l),
+(400,650,o),
+(340,702,o),
+(251,702,cs),
+(132,702,o),
+(69,616,o),
+(69,495,cs),
+(69,356,o),
+(167,211,o),
+(167,121,cs),
+(167,86,o),
+(151,54,o),
+(91,54,cs),
+(61,54,l),
+(61,0,l)
+);
+}
+);
+width = 830;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5730;
+},
+{
+color = 9;
+glyphname = "cheCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(557,-13,o),
+(623,62,o),
+(623,173,cs),
+(623,268,o),
+(572,332,o),
+(483,352,c),
+(483,338,l),
+(572,356,o),
+(623,421,o),
+(623,517,cs),
+(623,628,o),
+(557,702,o),
+(455,702,cs),
+(355,702,o),
+(239,599,o),
+(183,599,cs),
+(159,599,o),
+(136,613,o),
+(136,662,cs),
+(136,690,l),
+(81,690,l),
+(81,652,ls),
+(81,582,o),
+(118,547,o),
+(172,547,cs),
+(249,547,o),
+(355,646,o),
+(442,646,cs),
+(517,646,o),
+(562,596,o),
+(562,512,cs),
+(562,419,o),
+(502,371,o),
+(403,371,cs),
+(121,371,l),
+(121,467,l),
+(81,467,l),
+(81,223,l),
+(121,223,l),
+(121,319,l),
+(403,319,ls),
+(503,319,o),
+(562,270,o),
+(562,178,cs),
+(562,94,o),
+(517,43,o),
+(443,43,cs),
+(355,43,o),
+(249,143,o),
+(172,143,cs),
+(118,143,o),
+(81,107,o),
+(81,38,cs),
+(81,0,l),
+(136,0,l),
+(136,28,ls),
+(136,76,o),
+(159,91,o),
+(183,91,cs),
+(239,91,o),
+(355,-13,o),
+(455,-13,cs)
+);
+}
+);
+width = 699;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni1663;
+unicode = 5731;
+},
+{
+color = 9;
+glyphname = "cheeCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(557,-13,o),
+(623,62,o),
+(623,173,cs),
+(623,268,o),
+(572,332,o),
+(483,352,c),
+(483,338,l),
+(572,356,o),
+(623,421,o),
+(623,517,cs),
+(623,628,o),
+(557,702,o),
+(455,702,cs),
+(355,702,o),
+(239,599,o),
+(183,599,cs),
+(159,599,o),
+(136,613,o),
+(136,662,cs),
+(136,690,l),
+(81,690,l),
+(81,652,ls),
+(81,582,o),
+(118,547,o),
+(172,547,cs),
+(250,547,o),
+(356,647,o),
+(443,647,cs),
+(519,647,o),
+(563,596,o),
+(563,511,cs),
+(563,418,o),
+(504,368,o),
+(408,368,cs),
+(352,368,l),
+(369,355,l),
+(369,453,l),
+(328,453,l),
+(328,368,l),
+(121,368,l),
+(121,467,l),
+(81,467,l),
+(81,223,l),
+(121,223,l),
+(121,323,l),
+(328,323,l),
+(328,226,l),
+(369,226,l),
+(369,335,l),
+(352,323,l),
+(408,323,ls),
+(505,323,o),
+(563,271,o),
+(563,179,cs),
+(563,94,o),
+(519,43,o),
+(444,43,cs),
+(356,43,o),
+(250,143,o),
+(172,143,cs),
+(118,143,o),
+(81,107,o),
+(81,38,cs),
+(81,0,l),
+(136,0,l),
+(136,28,ls),
+(136,76,o),
+(159,91,o),
+(183,91,cs),
+(239,91,o),
+(355,-13,o),
+(455,-13,cs)
+);
+}
+);
+width = 699;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1664;
+unicode = 5732;
+},
+{
+color = 9;
+glyphname = "chiCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(557,-13,o),
+(623,62,o),
+(623,173,cs),
+(623,268,o),
+(571,332,o),
+(485,352,c),
+(485,338,l),
+(572,356,o),
+(623,421,o),
+(623,517,cs),
+(623,628,o),
+(557,702,o),
+(455,702,cs),
+(355,702,o),
+(239,599,o),
+(183,599,cs),
+(159,599,o),
+(136,613,o),
+(136,662,cs),
+(136,690,l),
+(81,690,l),
+(81,652,ls),
+(81,582,o),
+(118,547,o),
+(172,547,cs),
+(250,547,o),
+(356,647,o),
+(443,647,cs),
+(519,647,o),
+(563,596,o),
+(563,511,cs),
+(563,418,o),
+(504,368,o),
+(413,368,cs),
+(373,368,l),
+(396,349,l),
+(395,384,o),
+(368,409,o),
+(334,409,cs),
+(307,409,o),
+(285,391,o),
+(276,368,c),
+(121,368,l),
+(121,467,l),
+(81,467,l),
+(81,223,l),
+(121,223,l),
+(121,323,l),
+(277,323,l),
+(286,298,o),
+(308,282,o),
+(334,282,cs),
+(368,282,o),
+(393,308,o),
+(397,341,c),
+(372,323,l),
+(413,323,ls),
+(505,323,o),
+(563,271,o),
+(563,179,cs),
+(563,94,o),
+(519,43,o),
+(444,43,cs),
+(356,43,o),
+(250,143,o),
+(172,143,cs),
+(118,143,o),
+(81,107,o),
+(81,38,cs),
+(81,0,l),
+(136,0,l),
+(136,28,ls),
+(136,76,o),
+(159,91,o),
+(183,91,cs),
+(239,91,o),
+(355,-13,o),
+(455,-13,cs)
+);
+}
+);
+width = 699;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1665;
+unicode = 5733;
+},
+{
+color = 9;
+glyphname = "chaCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(345,-13,o),
+(461,91,o),
+(517,91,cs),
+(541,91,o),
+(563,76,o),
+(563,28,cs),
+(563,0,l),
+(619,0,l),
+(619,38,ls),
+(619,107,o),
+(582,143,o),
+(527,143,cs),
+(450,143,o),
+(344,43,o),
+(257,43,cs),
+(183,43,o),
+(138,94,o),
+(138,178,cs),
+(138,270,o),
+(197,319,o),
+(297,319,cs),
+(579,319,l),
+(579,223,l),
+(619,223,l),
+(619,467,l),
+(579,467,l),
+(579,371,l),
+(297,371,ls),
+(196,371,o),
+(138,419,o),
+(138,512,cs),
+(138,596,o),
+(183,646,o),
+(257,646,cs),
+(344,646,o),
+(450,547,o),
+(527,547,cs),
+(582,547,o),
+(619,582,o),
+(619,652,cs),
+(619,690,l),
+(563,690,l),
+(563,662,ls),
+(563,613,o),
+(541,599,o),
+(517,599,cs),
+(461,599,o),
+(345,702,o),
+(244,702,cs),
+(142,702,o),
+(76,628,o),
+(76,517,cs),
+(76,421,o),
+(128,356,o),
+(216,338,c),
+(216,352,l),
+(128,332,o),
+(76,268,o),
+(76,173,cs),
+(76,62,o),
+(142,-13,o),
+(245,-13,cs)
+);
+}
+);
+width = 700;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1666;
+unicode = 5734;
+},
+{
+color = 9;
+glyphname = "ttsuCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(340,-13,o),
+(400,40,o),
+(423,134,c),
+(408,134,l),
+(430,40,o),
+(491,-13,o),
+(579,-13,cs),
+(697,-13,o),
+(761,73,o),
+(761,195,cs),
+(761,333,o),
+(663,479,o),
+(663,569,cs),
+(663,604,o),
+(680,636,o),
+(739,636,cs),
+(769,636,l),
+(769,690,l),
+(727,690,ls),
+(640,690,o),
+(605,642,o),
+(605,575,cs),
+(605,547,o),
+(612,514,o),
+(621,480,c),
+(641,525,l),
+(443,387,l),
+(443,643,l),
+(527,643,l),
+(527,690,l),
+(302,690,l),
+(302,643,l),
+(387,643,l),
+(387,387,l),
+(188,525,l),
+(209,480,l),
+(218,514,o),
+(226,547,o),
+(226,575,cs),
+(226,642,o),
+(189,690,o),
+(102,690,cs),
+(61,690,l),
+(61,636,l),
+(91,636,ls),
+(151,636,o),
+(167,604,o),
+(167,569,cs),
+(167,479,o),
+(70,333,o),
+(70,195,cs),
+(70,73,o),
+(133,-13,o),
+(252,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(173,43,o),
+(130,104,o),
+(130,201,cs),
+(130,286,o),
+(174,376,o),
+(201,456,c),
+(387,328,l),
+(387,223,ls),
+(387,105,o),
+(338,43,o),
+(256,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(492,43,o),
+(443,105,o),
+(443,223,cs),
+(443,328,l),
+(629,456,l),
+(656,376,o),
+(699,286,o),
+(699,201,cs),
+(699,104,o),
+(657,43,o),
+(575,43,cs)
+);
+}
+);
+width = 830;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1667;
+unicode = 5735;
+},
+{
+color = 9;
+glyphname = "ttsoCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(102,0,ls),
+(189,0,o),
+(226,47,o),
+(226,115,cs),
+(226,143,o),
+(218,176,o),
+(209,210,c),
+(188,165,l),
+(387,302,l),
+(387,46,l),
+(302,46,l),
+(302,0,l),
+(527,0,l),
+(527,46,l),
+(443,46,l),
+(443,302,l),
+(641,165,l),
+(621,210,l),
+(612,176,o),
+(605,143,o),
+(605,115,cs),
+(605,47,o),
+(640,0,o),
+(727,0,cs),
+(769,0,l),
+(769,54,l),
+(739,54,ls),
+(680,54,o),
+(663,86,o),
+(663,121,cs),
+(663,211,o),
+(761,356,o),
+(761,495,cs),
+(761,616,o),
+(697,702,o),
+(579,702,cs),
+(491,702,o),
+(430,650,o),
+(408,555,c),
+(423,555,l),
+(400,650,o),
+(340,702,o),
+(252,702,cs),
+(133,702,o),
+(70,616,o),
+(70,495,cs),
+(70,356,o),
+(167,211,o),
+(167,121,cs),
+(167,86,o),
+(151,54,o),
+(91,54,cs),
+(61,54,l),
+(61,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(174,314,o),
+(130,404,o),
+(130,489,cs),
+(130,585,o),
+(173,646,o),
+(256,646,cs),
+(338,646,o),
+(387,584,o),
+(387,467,cs),
+(387,361,l),
+(201,234,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(443,361,l),
+(443,467,ls),
+(443,584,o),
+(492,646,o),
+(575,646,cs),
+(657,646,o),
+(699,585,o),
+(699,489,cs),
+(699,404,o),
+(656,314,o),
+(629,234,c)
+);
+}
+);
+width = 830;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1668;
+unicode = 5736;
+},
+{
+color = 9;
+glyphname = "ttseCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(557,-13,o),
+(623,62,o),
+(623,173,cs),
+(623,268,o),
+(571,332,o),
+(485,352,c),
+(485,338,l),
+(572,356,o),
+(623,421,o),
+(623,517,cs),
+(623,628,o),
+(557,702,o),
+(455,702,cs),
+(355,702,o),
+(239,599,o),
+(183,599,cs),
+(159,599,o),
+(136,613,o),
+(136,662,cs),
+(136,690,l),
+(81,690,l),
+(81,652,ls),
+(81,582,o),
+(118,547,o),
+(172,547,cs),
+(183,547,o),
+(193,548,o),
+(202,554,c),
+(157,574,l),
+(246,368,l),
+(121,368,l),
+(121,467,l),
+(81,467,l),
+(81,223,l),
+(121,223,l),
+(121,323,l),
+(246,323,l),
+(157,116,l),
+(202,136,l),
+(192,142,o),
+(183,143,o),
+(172,143,cs),
+(118,143,o),
+(81,107,o),
+(81,38,cs),
+(81,0,l),
+(136,0,l),
+(136,28,ls),
+(136,76,o),
+(159,91,o),
+(183,91,cs),
+(239,91,o),
+(355,-13,o),
+(455,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(369,43,o),
+(280,117,o),
+(213,135,c),
+(293,323,l),
+(413,323,ls),
+(505,323,o),
+(563,271,o),
+(563,179,cs),
+(563,94,o),
+(519,43,o),
+(444,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(213,554,l),
+(280,573,o),
+(369,647,o),
+(443,647,cs),
+(519,647,o),
+(563,596,o),
+(563,511,cs),
+(563,418,o),
+(504,368,o),
+(413,368,cs),
+(293,368,l)
+);
+}
+);
+width = 699;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1669;
+unicode = 5737;
+},
+{
+color = 9;
+glyphname = "ttseeCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(557,-13,o),
+(623,62,o),
+(623,173,cs),
+(623,268,o),
+(571,332,o),
+(485,352,c),
+(485,338,l),
+(572,356,o),
+(623,421,o),
+(623,517,cs),
+(623,628,o),
+(557,702,o),
+(455,702,cs),
+(355,702,o),
+(239,599,o),
+(183,599,cs),
+(159,599,o),
+(136,613,o),
+(136,662,cs),
+(136,690,l),
+(81,690,l),
+(81,652,ls),
+(81,582,o),
+(118,547,o),
+(172,547,cs),
+(183,547,o),
+(193,548,o),
+(200,554,c),
+(156,573,l),
+(245,368,l),
+(121,368,l),
+(121,467,l),
+(81,467,l),
+(81,223,l),
+(121,223,l),
+(121,323,l),
+(245,323,l),
+(156,117,l),
+(200,135,l),
+(193,142,o),
+(183,143,o),
+(172,143,cs),
+(118,143,o),
+(81,107,o),
+(81,38,cs),
+(81,0,l),
+(136,0,l),
+(136,28,ls),
+(136,76,o),
+(159,91,o),
+(183,91,cs),
+(239,91,o),
+(355,-13,o),
+(455,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(369,43,o),
+(280,118,o),
+(212,136,c),
+(291,323,l),
+(377,323,l),
+(377,225,l),
+(413,225,l),
+(413,336,l),
+(398,323,l),
+(413,323,ls),
+(505,323,o),
+(563,271,o),
+(563,179,cs),
+(563,94,o),
+(519,43,o),
+(444,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(413,454,l),
+(377,454,l),
+(377,368,l),
+(291,368,l),
+(212,554,l),
+(280,572,o),
+(369,647,o),
+(443,647,cs),
+(519,647,o),
+(563,596,o),
+(563,511,cs),
+(563,418,o),
+(504,368,o),
+(413,368,cs),
+(398,368,l),
+(413,354,l)
+);
+}
+);
+width = 699;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166A;
+unicode = 5738;
+},
+{
+color = 9;
+glyphname = "ttsiCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(557,-13,o),
+(623,62,o),
+(623,173,cs),
+(623,268,o),
+(571,332,o),
+(485,352,c),
+(485,338,l),
+(572,356,o),
+(623,421,o),
+(623,517,cs),
+(623,628,o),
+(557,702,o),
+(455,702,cs),
+(355,702,o),
+(239,599,o),
+(183,599,cs),
+(159,599,o),
+(136,613,o),
+(136,662,cs),
+(136,690,l),
+(81,690,l),
+(81,652,ls),
+(81,582,o),
+(118,547,o),
+(172,547,cs),
+(181,547,o),
+(188,547,o),
+(197,553,c),
+(161,564,l),
+(245,368,l),
+(121,368,l),
+(121,467,l),
+(81,467,l),
+(81,223,l),
+(121,223,l),
+(121,323,l),
+(245,323,l),
+(160,125,l),
+(197,137,l),
+(188,143,o),
+(181,143,o),
+(172,143,cs),
+(118,143,o),
+(81,107,o),
+(81,38,cs),
+(81,0,l),
+(136,0,l),
+(136,28,ls),
+(136,76,o),
+(159,91,o),
+(183,91,cs),
+(239,91,o),
+(355,-13,o),
+(455,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(368,43,o),
+(276,120,o),
+(208,137,c),
+(286,323,l),
+(327,323,l),
+(335,298,o),
+(357,282,o),
+(383,282,cs),
+(413,282,o),
+(439,306,o),
+(441,338,c),
+(404,323,l),
+(417,323,ls),
+(507,323,o),
+(563,271,o),
+(563,179,cs),
+(563,94,o),
+(519,43,o),
+(444,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(440,384,o),
+(414,409,o),
+(383,409,cs),
+(356,409,o),
+(334,391,o),
+(327,368,c),
+(286,368,l),
+(208,553,l),
+(276,570,o),
+(368,647,o),
+(443,647,cs),
+(519,647,o),
+(563,596,o),
+(563,511,cs),
+(563,418,o),
+(506,368,o),
+(417,368,cs),
+(405,368,l),
+(441,352,l)
+);
+}
+);
+width = 699;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166B;
+unicode = 5739;
+},
+{
+color = 9;
+glyphname = "ttsaCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(345,-13,o),
+(461,91,o),
+(517,91,cs),
+(541,91,o),
+(563,76,o),
+(563,28,cs),
+(563,0,l),
+(619,0,l),
+(619,38,ls),
+(619,107,o),
+(582,143,o),
+(527,143,cs),
+(517,143,o),
+(507,142,o),
+(497,136,c),
+(543,116,l),
+(454,323,l),
+(579,323,l),
+(579,223,l),
+(619,223,l),
+(619,467,l),
+(579,467,l),
+(579,368,l),
+(454,368,l),
+(543,574,l),
+(497,554,l),
+(507,548,o),
+(517,547,o),
+(527,547,cs),
+(582,547,o),
+(619,582,o),
+(619,652,cs),
+(619,690,l),
+(563,690,l),
+(563,662,ls),
+(563,613,o),
+(541,599,o),
+(517,599,cs),
+(461,599,o),
+(345,702,o),
+(245,702,cs),
+(142,702,o),
+(76,628,o),
+(76,517,cs),
+(76,421,o),
+(128,356,o),
+(214,338,c),
+(214,352,l),
+(128,332,o),
+(76,268,o),
+(76,173,cs),
+(76,62,o),
+(142,-13,o),
+(244,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(182,43,o),
+(137,94,o),
+(137,179,cs),
+(137,271,o),
+(194,323,o),
+(286,323,cs),
+(408,323,l),
+(487,135,l),
+(419,117,o),
+(330,43,o),
+(256,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(195,368,o),
+(137,418,o),
+(137,511,cs),
+(137,596,o),
+(182,647,o),
+(256,647,cs),
+(330,647,o),
+(419,573,o),
+(487,554,c),
+(408,368,l),
+(286,368,ls)
+);
+}
+);
+width = 700;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni166C;
+unicode = 5740;
+},
+{
+glyphname = "qai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (318,0);
+ref = "ke-canadian";
+}
+);
+width = 886;
+}
+);
+note = uni166F;
+unicode = 5743;
+},
+{
+glyphname = "ngai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (623,0);
+ref = "ce-canadian";
+}
+);
+width = 1187;
+}
+);
+note = uni1670;
+unicode = 5744;
+},
+{
+glyphname = "nngi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (904,0);
+ref = "ci-canadian";
+}
+);
+width = 1467;
+}
+);
+note = uni1671;
+unicode = 5745;
+},
+{
+glyphname = "nngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (904,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (1128,0);
+ref = dot_top;
+}
+);
+width = 1467;
+}
+);
+note = uni1672;
+unicode = 5746;
+},
+{
+glyphname = "nngo-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (904,0);
+ref = "ce-canadian";
+}
+);
+width = 1467;
+}
+);
+note = uni1673;
+unicode = 5747;
+},
+{
+glyphname = "nngoo-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (904,0);
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (1122,0);
+ref = dot_top;
+}
+);
+width = 1467;
+}
+);
+note = uni1674;
+unicode = 5748;
+},
+{
+glyphname = "nnga-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (904,0);
+ref = "ca-canadian";
+}
+);
+width = 1467;
+}
+);
+note = uni1675;
+unicode = 5749;
+},
+{
+glyphname = "nngaa-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (904,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (946,0);
+ref = dot_top;
+}
+);
+width = 1467;
+}
+);
+note = uni1676;
+unicode = 5750;
+},
+{
+glyphname = "thweeWoodScree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (587,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 801;
+}
+);
+note = uni1677;
+unicode = 5751;
+},
+{
+glyphname = "thwiWoodScree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (587,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 801;
+}
+);
+note = uni1678;
+unicode = 5752;
+},
+{
+glyphname = "thwiiWoodScree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (86,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (587,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 801;
+}
+);
+note = uni1679;
+unicode = 5753;
+},
+{
+glyphname = "thwoWoodScree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (587,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 801;
+}
+);
+note = uni167A;
+unicode = 5754;
+},
+{
+glyphname = "thwooWoodScree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (378,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (587,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 801;
+}
+);
+note = uni167B;
+unicode = 5755;
+},
+{
+glyphname = "thwaWoodScree-canadian";
+lastChange = "2023-01-13 15:54:49 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = middle_right_can;
+pos = (586,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 799;
+}
+);
+note = uni167C;
+unicode = 5756;
+},
+{
+glyphname = "thwaaWoodScree-canadian";
+lastChange = "2023-01-13 15:54:49 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (85,0);
+ref = dot_top;
+},
+{
+anchor = middle_right_can;
+pos = (586,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 799;
+}
+);
+note = uni167D;
+unicode = 5757;
+},
+{
+glyphname = "wBlackfoot-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(377,564,l),
+(377,604,l),
+(68,604,l),
+(68,564,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(377,431,l),
+(377,470,l),
+(68,470,l),
+(68,431,l)
+);
+}
+);
+width = 445;
+}
+);
+metricRight = "=|";
+note = uni167F;
+unicode = 5759;
+},
+{
+glyphname = "oy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-13,0);
+ref = ring_top.canadian;
+}
+);
+width = 665;
+}
+);
+note = uni18B0;
+unicode = 6320;
+},
+{
+glyphname = "ay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (438,0);
+ref = ring_top.canadian;
+}
+);
+width = 665;
+}
+);
+note = uni18B1;
+unicode = 6321;
+},
+{
+glyphname = "aay-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (187,0);
+ref = ring_top.canadian;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (496,0);
+ref = dot_top;
+}
+);
+width = 665;
+}
+);
+note = uni18B2;
+unicode = 6322;
+},
+{
+glyphname = "way-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (650,0);
+ref = ring_top.canadian;
+}
+);
+width = 878;
+}
+);
+note = uni18B3;
+unicode = 6323;
+},
+{
+glyphname = "poy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-35,0);
+ref = ring_top.canadian;
+}
+);
+width = 636;
+}
+);
+note = uni18B4;
+unicode = 6324;
+},
+{
+glyphname = "pay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (430,0);
+ref = ring_top.canadian;
+}
+);
+width = 636;
+}
+);
+note = uni18B5;
+unicode = 6325;
+},
+{
+glyphname = "pwoy-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (178,0);
+ref = ring_top.canadian;
+}
+);
+width = 848;
+}
+);
+note = uni18B6;
+unicode = 6326;
+},
+{
+glyphname = "tay-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (203,0);
+ref = ring_top.canadian;
+}
+);
+width = 585;
+}
+);
+note = uni18B7;
+unicode = 6327;
+},
+{
+glyphname = "kay-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-15,0);
+ref = ring_top.canadian;
+}
+);
+width = 568;
+}
+);
+note = uni18B8;
+unicode = 6328;
+},
+{
+glyphname = "kway-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (197,0);
+ref = ring_top.canadian;
+}
+);
+width = 781;
+}
+);
+note = uni18B9;
+unicode = 6329;
+},
+{
+glyphname = "may-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-9,0);
+ref = ring_top.canadian;
+}
+);
+width = 502;
+}
+);
+note = uni18BA;
+unicode = 6330;
+},
+{
+glyphname = "noy-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (376,-200);
+ref = ring_top.canadian;
+}
+);
+width = 787;
+}
+);
+note = uni18BB;
+unicode = 6331;
+},
+{
+glyphname = "nay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (171,-200);
+ref = ring_top.canadian;
+}
+);
+width = 787;
+}
+);
+note = uni18BC;
+unicode = 6332;
+},
+{
+glyphname = "lay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (171,-200);
+ref = ring_top.canadian;
+}
+);
+width = 787;
+}
+);
+note = uni18BD;
+unicode = 6333;
+},
+{
+glyphname = "soy-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (285,0);
+ref = ring_top.canadian;
+}
+);
+width = 517;
+}
+);
+note = uni18BE;
+unicode = 6334;
+},
+{
+glyphname = "say-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-9,0);
+ref = ring_top.canadian;
+}
+);
+width = 517;
+}
+);
+note = uni18BF;
+unicode = 6335;
+},
+{
+glyphname = "shoy-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (339,-200);
+ref = ring_top.canadian;
+}
+);
+width = 919;
+}
+);
+note = uni18C0;
+unicode = 6336;
+},
+{
+glyphname = "shay-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (340,-200);
+ref = ring_top.canadian;
+}
+);
+width = 919;
+}
+);
+note = uni18C1;
+unicode = 6337;
+},
+{
+glyphname = "shwoy-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (553,-200);
+ref = ring_top.canadian;
+}
+);
+width = 1132;
+}
+);
+note = uni18C2;
+unicode = 6338;
+},
+{
+glyphname = "yoy-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (320,0);
+ref = ring_top.canadian;
+}
+);
+width = 550;
+}
+);
+note = uni18C3;
+unicode = 6339;
+},
+{
+glyphname = "yay-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-10,0);
+ref = ring_top.canadian;
+}
+);
+width = 550;
+}
+);
+note = uni18C4;
+unicode = 6340;
+},
+{
+glyphname = "ray-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (176,0);
+ref = ring_top.canadian;
+}
+);
+width = 522;
+}
+);
+note = uni18C5;
+unicode = 6341;
+},
+{
+glyphname = "nwi-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ni-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni18C6;
+unicode = 6342;
+},
+{
+glyphname = "nwiOjibway-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (787,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni18C7;
+unicode = 6343;
+},
+{
+glyphname = "nwii-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (447,-200);
+ref = dot_top;
+}
+);
+width = 1001;
+}
+);
+note = uni18C8;
+unicode = 6344;
+},
+{
+glyphname = "nwiiOjibway-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (235,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (787,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni18C9;
+unicode = 6345;
+},
+{
+glyphname = "nwo-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "no-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni18CA;
+unicode = 6346;
+},
+{
+glyphname = "nwoOjibway-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (787,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni18CB;
+unicode = 6347;
+},
+{
+glyphname = "nwoo-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (647,-200);
+ref = dot_top;
+}
+);
+width = 1001;
+}
+);
+note = uni18CC;
+unicode = 6348;
+},
+{
+glyphname = "nwooOjibway-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (434,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (787,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1001;
+}
+);
+note = uni18CD;
+unicode = 6349;
+},
+{
+glyphname = "rwee-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "reRCree-canadian";
+}
+);
+width = 1043;
+}
+);
+note = uni18CE;
+unicode = 6350;
+},
+{
+glyphname = "rwi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ri-canadian";
+}
+);
+width = 1043;
+}
+);
+note = uni18CF;
+unicode = 6351;
+},
+{
+glyphname = "rwii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (440,-200);
+ref = dot_top;
+}
+);
+width = 1043;
+}
+);
+note = uni18D0;
+unicode = 6352;
+},
+{
+glyphname = "rwo-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ro-canadian";
+}
+);
+width = 734;
+}
+);
+note = uni18D1;
+unicode = 6353;
+},
+{
+glyphname = "rwoo-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (376,0);
+ref = dot_top;
+}
+);
+width = 734;
+}
+);
+note = uni18D2;
+unicode = 6354;
+},
+{
+glyphname = "rwa-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = "ra-canadian";
+}
+);
+width = 734;
+}
+);
+note = uni18D3;
+unicode = 6355;
+},
+{
+glyphname = "pOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(96,345,l),
+(225,646,l),
+(192,646,l),
+(322,345,l),
+(363,345,l),
+(363,356,l),
+(215,690,l),
+(201,690,l),
+(53,356,l),
+(53,345,l)
+);
+}
+);
+width = 416;
+}
+);
+metricLeft = "kkCarrier-canadian";
+note = uni18D4;
+unicode = 6356;
+},
+{
+glyphname = "tOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 411;
+}
+);
+metricRight = "=|";
+note = uni1422;
+unicode = 6357;
+},
+{
+glyphname = "kOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(114,345,l),
+(114,518,l),
+(101,512,l),
+(108,466,o),
+(145,434,o),
+(192,434,cs),
+(255,434,o),
+(303,483,o),
+(303,562,cs),
+(303,645,o),
+(252,696,o),
+(186,696,cs),
+(115,696,o),
+(68,645,o),
+(68,563,cs),
+(68,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(142,469,o),
+(110,504,o),
+(110,564,cs),
+(110,627,o),
+(139,659,o),
+(186,659,cs),
+(231,659,o),
+(262,624,o),
+(262,563,cs),
+(262,503,o),
+(230,469,o),
+(185,469,cs)
+);
+}
+);
+width = 361;
+}
+);
+metricLeft = "k-canadian";
+metricRight = "k-canadian";
+note = uni18D6;
+unicode = 6358;
+},
+{
+glyphname = "cOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(114,345,l),
+(114,567,ls),
+(114,629,o),
+(140,657,o),
+(186,657,cs),
+(232,657,o),
+(261,629,o),
+(261,575,cs),
+(261,550,l),
+(304,550,l),
+(304,570,ls),
+(304,650,o),
+(255,696,o),
+(186,696,cs),
+(113,696,o),
+(68,650,o),
+(68,562,cs),
+(68,345,l)
+);
+}
+);
+width = 352;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni18D7;
+unicode = 6359;
+},
+{
+glyphname = "mOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(114,345,l),
+(114,647,l),
+(276,647,l),
+(276,690,l),
+(68,690,l),
+(68,345,l)
+);
+}
+);
+width = 326;
+}
+);
+metricLeft = "m-canadian";
+metricRight = "m-canadian";
+note = uni18D8;
+unicode = 6360;
+},
+{
+glyphname = "nOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(244,428,o),
+(292,477,o),
+(292,556,cs),
+(292,607,o),
+(270,653,o),
+(232,667,c),
+(230,647,l),
+(418,647,l),
+(418,690,l),
+(181,690,ls),
+(105,690,o),
+(58,638,o),
+(58,557,cs),
+(58,477,o),
+(106,428,o),
+(175,428,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(130,465,o),
+(99,498,o),
+(99,557,cs),
+(99,618,o),
+(130,653,o),
+(175,653,cs),
+(220,653,o),
+(250,618,o),
+(250,558,cs),
+(250,498,o),
+(220,465,o),
+(176,465,cs)
+);
+}
+);
+width = 468;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "n-canadian";
+note = uni18D9;
+unicode = 6361;
+},
+{
+glyphname = "sOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(114,345,l),
+(114,486,l),
+(89,462,l),
+(119,462,ls),
+(222,462,o),
+(277,529,o),
+(277,633,cs),
+(277,690,l),
+(232,690,l),
+(232,636,ls),
+(232,548,o),
+(192,501,o),
+(104,501,cs),
+(68,501,l),
+(68,345,l)
+);
+}
+);
+width = 345;
+}
+);
+metricLeft = "s-canadian";
+metricRight = "s-canadian";
+note = uni18DA;
+unicode = 6362;
+},
+{
+color = 1;
+glyphname = "shOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(238,339,o),
+(276,384,o),
+(284,469,cs),
+(293,569,ls),
+(299,628,o),
+(319,658,o),
+(365,658,cs),
+(411,658,o),
+(440,630,o),
+(440,575,cs),
+(440,550,l),
+(482,550,l),
+(482,571,ls),
+(482,651,o),
+(434,696,o),
+(366,696,cs),
+(293,696,o),
+(255,650,o),
+(247,565,cs),
+(238,466,ls),
+(232,407,o),
+(212,377,o),
+(165,377,cs),
+(120,377,o),
+(92,405,o),
+(92,460,cs),
+(92,485,l),
+(48,485,l),
+(48,464,ls),
+(48,384,o),
+(97,339,o),
+(164,339,cs)
+);
+}
+);
+width = 530;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "c-canadian";
+note = uni18DB;
+unicode = 6363;
+},
+{
+color = 9;
+glyphname = "easternw-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (43,-307);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (110,0);
+ref = "glottalstop-canadian";
+}
+);
+width = 542;
+}
+);
+note = uni18DC;
+unicode = 6364;
+},
+{
+color = 9;
+glyphname = "westernw-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (504,-307);
+ref = dot_top;
+scale = (-1,1);
+},
+{
+alignment = -1;
+pos = (432,0);
+ref = "glottalstop-canadian";
+scale = (-1,1);
+}
+);
+width = 546;
+}
+);
+metricLeft = "glottalstop-canadian";
+note = uni18DD;
+unicode = 6365;
+},
+{
+glyphname = "rweRCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "reRCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (831,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1043;
+}
+);
+note = uni18E0;
+unicode = 6368;
+},
+{
+glyphname = "looWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+}
+);
+width = 522;
+}
+);
+note = uni18E1;
+unicode = 6369;
+},
+{
+glyphname = "laaWestCree-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (348,0);
+ref = dot_top;
+}
+);
+width = 522;
+}
+);
+note = uni18E2;
+unicode = 6370;
+},
+{
+glyphname = "thwe-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "the-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (697,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 910;
+}
+);
+note = uni18E3;
+unicode = 6371;
+},
+{
+glyphname = "thwa-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (652,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 865;
+}
+);
+note = uni18E4;
+unicode = 6372;
+},
+{
+glyphname = "tthwe-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "tthe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (689,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 901;
+}
+);
+note = uni18E5;
+unicode = 6373;
+},
+{
+glyphname = "tthoo-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ttho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (247,0);
+ref = dot_top;
+}
+);
+width = 606;
+}
+);
+note = uni18E6;
+unicode = 6374;
+},
+{
+glyphname = "tthaa-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ttha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (253,0);
+ref = dot_top;
+}
+);
+width = 606;
+}
+);
+note = uni18E7;
+unicode = 6375;
+},
+{
+glyphname = "tlhwe-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "tlhe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (573,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 785;
+}
+);
+note = uni18E8;
+unicode = 6376;
+},
+{
+glyphname = "tlhoo-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "tlho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (243,0);
+ref = dot_top;
+}
+);
+width = 573;
+}
+);
+note = uni18E9;
+unicode = 6377;
+},
+{
+glyphname = "shweSayisi-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "sheSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (573,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 785;
+}
+);
+note = uni18EA;
+unicode = 6378;
+},
+{
+glyphname = "shooSayisi-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "shoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (408,0);
+ref = dot_top;
+}
+);
+width = 573;
+}
+);
+note = uni18EB;
+unicode = 6379;
+},
+{
+color = 9;
+glyphname = "hooSayisi-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "hoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (466,0);
+ref = dot_top;
+}
+);
+width = 639;
+}
+);
+note = uni18EC;
+unicode = 6380;
+},
+{
+color = 9;
+glyphname = "gwuCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "guCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (836,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1048;
+}
+);
+note = uni18ED;
+unicode = 6381;
+},
+{
+color = 9;
+glyphname = "deneGeeCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "geCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (279,0);
+ref = dot_top;
+}
+);
+width = 677;
+}
+);
+note = uni18EE;
+unicode = 6382;
+},
+{
+color = 9;
+glyphname = "gaaCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (292,0);
+ref = dot_top;
+}
+);
+width = 677;
+}
+);
+note = uni18EF;
+unicode = 6383;
+},
+{
+color = 9;
+glyphname = "gwaCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (677,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 890;
+}
+);
+note = uni18F0;
+unicode = 6384;
+},
+{
+color = 9;
+glyphname = "juuSayisi-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "juSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (290,0);
+ref = dot_top;
+}
+);
+width = 690;
+}
+);
+note = uni18F1;
+unicode = 6385;
+},
+{
+color = 9;
+glyphname = "jwaCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "jaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (734,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 948;
+}
+);
+note = uni18F2;
+unicode = 6386;
+},
+{
+glyphname = "lBeaverDene-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+ref = "pWestCree-canadian";
+}
+);
+width = 182;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+unicode = 6387;
+},
+{
+glyphname = "rBeaverDene-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(114,345,l),
+(114,556,ls),
+(114,616,o),
+(135,649,o),
+(185,649,cs),
+(193,649,l),
+(193,696,l),
+(185,696,ls),
+(137,696,o),
+(105,658,o),
+(104,614,c),
+(110,614,l),
+(110,690,l),
+(68,690,l),
+(68,345,l)
+);
+}
+);
+width = 224;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni18F4;
+unicode = 6388;
+},
+{
+color = 6;
+glyphname = "sDentalCarrier-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(216,183,ls),
+(291,183,o),
+(327,218,o),
+(327,277,cs),
+(327,337,o),
+(292,374,o),
+(219,374,cs),
+(180,374,ls),
+(134,374,o),
+(109,391,o),
+(109,432,cs),
+(109,472,o),
+(135,490,o),
+(180,490,cs),
+(322,490,l),
+(322,527,l),
+(179,527,ls),
+(104,527,o),
+(68,492,o),
+(68,433,cs),
+(68,374,o),
+(103,336,o),
+(176,336,cs),
+(215,336,ls),
+(261,336,o),
+(286,319,o),
+(286,278,cs),
+(286,238,o),
+(260,220,o),
+(215,220,cs),
+(73,220,l),
+(73,183,l)
+);
+}
+);
+width = 395;
+}
+);
+metricLeft = "shCarrier-canadian";
+metricRight = "=|";
+note = uni18F5;
+unicode = 6389;
+},
+{
+glyphname = "pWestCree-canadian.base";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "pWestCree-canadian";
+}
+);
+width = 182;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.base";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "c-canadian";
+}
+);
+width = 352;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "thSayisi-canadian.base";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "thSayisi-canadian";
+}
+);
+width = 352;
+}
+);
+metricLeft = "=|c-canadian";
+note = uni14A2;
+},
+{
+glyphname = "mWestCree-canadian.base";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "mWestCree-canadian";
+}
+);
+width = 361;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+glyphname = "pWestCree-canadian.mid";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "pWestCree-canadian";
+}
+);
+width = 182;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.mid";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "c-canadian";
+}
+);
+width = 352;
+}
+);
+metricLeft = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "mWestCree-canadian.mid";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "mWestCree-canadian";
+}
+);
+width = 361;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+color = 11;
+glyphname = "ngaai-canadian.nunavik";
+lastChange = "2023-01-13 15:54:49 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (628,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (795,0);
+ref = ring_top.canadian;
+}
+);
+width = 1193;
+}
+);
+note = uni158E;
+},
+{
+color = 11;
+glyphname = "ngi-canadian.nunavik";
+lastChange = "2023-01-13 15:54:49 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (628,0);
+ref = "ci-canadian";
+}
+);
+width = 1193;
+}
+);
+note = uni158F;
+},
+{
+color = 11;
+glyphname = "ngii-canadian.nunavik";
+lastChange = "2023-01-13 15:54:49 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (628,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (853,0);
+ref = dot_top;
+}
+);
+width = 1193;
+}
+);
+note = uni1590;
+},
+{
+color = 11;
+glyphname = "ngo-canadian.nunavik";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (628,0);
+ref = "co-canadian";
+}
+);
+width = 1193;
+}
+);
+note = uni1591;
+},
+{
+color = 11;
+glyphname = "ngoo-canadian.nunavik";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+ref = "ngo-canadian.nunavik";
+},
+{
+anchor = top_right_can;
+pos = (1027,0);
+ref = dot_top;
+}
+);
+width = 1193;
+}
+);
+note = uni1592;
+},
+{
+color = 11;
+glyphname = "nga-canadian.nunavik";
+lastChange = "2023-01-13 15:54:49 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (628,0);
+ref = "ca-canadian";
+}
+);
+width = 1193;
+}
+);
+note = uni1593;
+},
+{
+color = 11;
+glyphname = "ngaa-canadian.nunavik";
+lastChange = "2023-01-13 15:54:49 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (628,0);
+ref = "ca-canadian";
+},
+{
+anchor = top_left_can;
+pos = (670,0);
+ref = dot_top;
+}
+);
+width = 1193;
+}
+);
+note = uni1594;
+},
+{
+color = 11;
+glyphname = "ng-canadian.nunavik";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(519,153,o),
+(570,202,o),
+(570,285,cs),
+(570,365,o),
+(522,414,o),
+(459,414,cs),
+(412,414,o),
+(378,384,o),
+(370,338,c),
+(380,340,l),
+(380,477,l),
+(235,477,l),
+(237,463,l),
+(271,476,o),
+(292,520,o),
+(292,567,cs),
+(292,646,o),
+(244,696,o),
+(175,696,cs),
+(106,696,o),
+(58,646,o),
+(58,566,cs),
+(58,486,o),
+(105,434,o),
+(181,434,cs),
+(361,434,l),
+(334,462,l),
+(334,285,ls),
+(334,202,o),
+(382,153,o),
+(452,153,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(405,189,o),
+(377,221,o),
+(377,284,cs),
+(377,344,o),
+(409,378,o),
+(452,378,cs),
+(497,378,o),
+(527,344,o),
+(527,285,cs),
+(527,224,o),
+(497,189,o),
+(452,189,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(130,470,o),
+(99,506,o),
+(99,566,cs),
+(99,625,o),
+(130,660,o),
+(176,660,cs),
+(220,660,o),
+(250,625,o),
+(250,565,cs),
+(250,505,o),
+(220,470,o),
+(175,470,cs)
+);
+}
+);
+width = 628;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+color = 11;
+glyphname = "ngai-canadian.nunavik";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (628,0);
+ref = "ce-canadian";
+}
+);
+width = 1193;
+}
+);
+note = uni1670;
+},
+{
+color = 11;
+glyphname = "ke-canadian.square";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (326,690);
+},
+{
+name = top_left_can;
+pos = (101,690);
+},
+{
+name = top_right_can;
+pos = (553,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(583,0,l),
+(583,690,l),
+(364,690,ls),
+(172,690,o),
+(66,586,o),
+(66,412,cs),
+(66,240,o),
+(172,136,o),
+(364,136,cs),
+(522,136,l),
+(522,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(209,191,o),
+(127,271,o),
+(127,412,cs),
+(127,554,o),
+(209,635,o),
+(362,635,cs),
+(522,635,l),
+(522,191,l),
+(362,191,ls)
+);
+}
+);
+width = 663;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146B;
+},
+{
+color = 11;
+glyphname = "ki-canadian.square";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (340,690);
+},
+{
+name = top_left_can;
+pos = (112,690);
+},
+{
+name = top_right_can;
+pos = (568,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,0,l),
+(142,136,l),
+(300,136,ls),
+(493,136,o),
+(598,240,o),
+(598,412,cs),
+(598,586,o),
+(493,690,o),
+(300,690,cs),
+(80,690,l),
+(80,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(142,635,l),
+(302,635,ls),
+(456,635,o),
+(537,554,o),
+(537,412,cs),
+(537,271,o),
+(456,191,o),
+(302,191,cs),
+(142,191,l)
+);
+}
+);
+width = 664;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni146D;
+},
+{
+color = 11;
+glyphname = "kii-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (277,0);
+ref = dot_top;
+}
+);
+width = 666;
+}
+);
+note = uni146E;
+},
+{
+color = 11;
+glyphname = "ko-canadian.square";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (326,690);
+},
+{
+name = top_left_can;
+pos = (101,690);
+},
+{
+name = top_right_can;
+pos = (553,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(583,0,l),
+(583,690,l),
+(522,690,l),
+(522,554,l),
+(364,554,ls),
+(172,554,o),
+(66,450,o),
+(66,277,cs),
+(66,103,o),
+(172,0,o),
+(364,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(209,55,o),
+(127,136,o),
+(127,277,cs),
+(127,418,o),
+(209,498,o),
+(362,498,cs),
+(522,498,l),
+(522,55,l),
+(362,55,ls)
+);
+}
+);
+width = 663;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146F;
+},
+{
+color = 11;
+glyphname = "koo-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (492,0);
+ref = dot_top;
+}
+);
+width = 666;
+}
+);
+note = uni1470;
+},
+{
+color = 11;
+glyphname = "ka-canadian.square";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (340,690);
+},
+{
+name = top_left_can;
+pos = (112,690);
+},
+{
+name = top_right_can;
+pos = (568,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(300,0,ls),
+(493,0,o),
+(598,103,o),
+(598,277,cs),
+(598,450,o),
+(493,554,o),
+(300,554,cs),
+(142,554,l),
+(142,690,l),
+(80,690,l),
+(80,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(142,498,l),
+(302,498,ls),
+(456,498,o),
+(537,418,o),
+(537,277,cs),
+(537,136,o),
+(456,55,o),
+(302,55,cs),
+(142,55,l)
+);
+}
+);
+width = 664;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1472;
+},
+{
+color = 11;
+glyphname = "kaa-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+}
+);
+width = 666;
+}
+);
+note = uni1473;
+},
+{
+color = 11;
+glyphname = "kweWestCree-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (666,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 878;
+}
+);
+note = uni1475;
+},
+{
+color = 11;
+glyphname = "kwiiWestCree-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (277,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (666,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 878;
+}
+);
+note = uni1479;
+},
+{
+color = 11;
+glyphname = "kwoWestCree-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (666,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 878;
+}
+);
+note = uni147B;
+},
+{
+color = 11;
+glyphname = "kwooWestCree-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (492,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (666,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 878;
+}
+);
+note = uni147D;
+},
+{
+color = 11;
+glyphname = "kwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (666,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 878;
+}
+);
+note = uni147F;
+},
+{
+color = 11;
+glyphname = "kwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (666,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 878;
+}
+);
+note = uni1481;
+},
+{
+color = 11;
+glyphname = "ce-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (339,690);
+},
+{
+name = top_left_can;
+pos = (99,690);
+},
+{
+name = top_right_can;
+pos = (580,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(610,0,l),
+(610,408,ls),
+(610,599,o),
+(510,702,o),
+(333,702,cs),
+(166,702,o),
+(68,602,o),
+(68,430,cs),
+(68,391,l),
+(128,391,l),
+(128,433,ls),
+(128,574,o),
+(207,645,o),
+(332,645,cs),
+(474,645,o),
+(548,565,o),
+(548,404,cs),
+(548,0,l)
+);
+}
+);
+width = 683;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni1489;
+},
+{
+color = 11;
+glyphname = "ci-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (344,690);
+},
+{
+name = top_left_can;
+pos = (104,690);
+},
+{
+name = top_right_can;
+pos = (584,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(135,0,l),
+(135,404,ls),
+(135,565,o),
+(209,645,o),
+(351,645,cs),
+(476,645,o),
+(554,574,o),
+(554,433,cs),
+(554,391,l),
+(615,391,l),
+(615,430,ls),
+(615,602,o),
+(517,702,o),
+(350,702,cs),
+(173,702,o),
+(73,599,o),
+(73,408,cs),
+(73,0,l)
+);
+}
+);
+width = 683;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+},
+{
+color = 11;
+glyphname = "cii-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (282,0);
+ref = dot_top;
+}
+);
+width = 683;
+}
+);
+note = uni148C;
+},
+{
+color = 11;
+glyphname = "co-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (339,690);
+},
+{
+name = top_left_can;
+pos = (99,690);
+},
+{
+name = top_right_can;
+pos = (580,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(510,-13,o),
+(610,91,o),
+(610,282,cs),
+(610,690,l),
+(548,690,l),
+(548,286,ls),
+(548,125,o),
+(474,44,o),
+(332,44,cs),
+(207,44,o),
+(128,116,o),
+(128,257,cs),
+(128,298,l),
+(68,298,l),
+(68,260,ls),
+(68,88,o),
+(166,-13,o),
+(333,-13,cs)
+);
+}
+);
+width = 683;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+},
+{
+color = 11;
+glyphname = "coo-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (517,0);
+ref = dot_top;
+}
+);
+width = 683;
+}
+);
+note = uni148E;
+},
+{
+color = 11;
+glyphname = "ca-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (344,690);
+},
+{
+name = top_left_can;
+pos = (104,690);
+},
+{
+name = top_right_can;
+pos = (584,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(517,-13,o),
+(615,88,o),
+(615,260,cs),
+(615,298,l),
+(554,298,l),
+(554,257,ls),
+(554,116,o),
+(476,44,o),
+(351,44,cs),
+(209,44,o),
+(135,125,o),
+(135,286,cs),
+(135,690,l),
+(73,690,l),
+(73,282,ls),
+(73,91,o),
+(173,-13,o),
+(350,-13,cs)
+);
+}
+);
+width = 683;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+},
+{
+color = 11;
+glyphname = "caa-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (43,0);
+ref = dot_top;
+}
+);
+width = 683;
+}
+);
+note = uni1491;
+},
+{
+color = 11;
+glyphname = "me-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (273,690);
+},
+{
+name = top_double;
+pos = (471,690);
+},
+{
+name = top_left_can;
+pos = (72,690);
+},
+{
+name = top_right_can;
+pos = (471,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(502,0,l),
+(502,690,l),
+(42,690,l),
+(42,634,l),
+(440,634,l),
+(440,0,l)
+);
+}
+);
+width = 582;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+},
+{
+color = 11;
+glyphname = "mi-canadian.square";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (311,690);
+},
+{
+name = top_left_can;
+pos = (112,690);
+},
+{
+name = top_right_can;
+pos = (510,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,0,l),
+(142,634,l),
+(541,634,l),
+(541,690,l),
+(80,690,l),
+(80,0,l)
+);
+}
+);
+width = 583;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+},
+{
+color = 11;
+glyphname = "mii-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (249,0);
+ref = dot_top;
+}
+);
+width = 582;
+}
+);
+note = uni14A6;
+},
+{
+color = 11;
+glyphname = "mo-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (273,690);
+},
+{
+name = top_double;
+pos = (471,690);
+},
+{
+name = top_left_can;
+pos = (72,690);
+},
+{
+name = top_right_can;
+pos = (471,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(502,0,l),
+(502,690,l),
+(440,690,l),
+(440,56,l),
+(42,56,l),
+(42,0,l)
+);
+}
+);
+width = 582;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+},
+{
+color = 11;
+glyphname = "moo-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (410,0);
+ref = dot_top;
+}
+);
+width = 582;
+}
+);
+note = uni14A8;
+},
+{
+color = 11;
+glyphname = "ma-canadian.square";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (311,690);
+},
+{
+name = top_left_can;
+pos = (112,690);
+},
+{
+name = top_right_can;
+pos = (510,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(541,0,l),
+(541,56,l),
+(142,56,l),
+(142,690,l),
+(80,690,l),
+(80,0,l)
+);
+}
+);
+width = 583;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+},
+{
+color = 11;
+glyphname = "maa-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+}
+);
+width = 582;
+}
+);
+note = uni14AB;
+},
+{
+color = 11;
+glyphname = "ne-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (430,690);
+},
+{
+name = top_left_can;
+pos = (236,690);
+},
+{
+name = top_right_can;
+pos = (630,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(577,-13,o),
+(660,80,o),
+(660,248,cs),
+(660,690,l),
+(62,690,l),
+(62,634,l),
+(205,634,l),
+(205,249,ls),
+(205,80,o),
+(289,-13,o),
+(433,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(324,45,o),
+(267,113,o),
+(267,244,cs),
+(267,634,l),
+(599,634,l),
+(599,244,ls),
+(599,114,o),
+(541,45,o),
+(433,45,cs)
+);
+}
+);
+width = 733;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C0;
+},
+{
+color = 11;
+glyphname = "ni-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (300,690);
+},
+{
+name = top_left_can;
+pos = (104,690);
+},
+{
+name = top_right_can;
+pos = (498,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(444,-13,o),
+(528,80,o),
+(528,249,cs),
+(528,634,l),
+(671,634,l),
+(671,690,l),
+(73,690,l),
+(73,248,ls),
+(73,80,o),
+(156,-13,o),
+(300,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(192,45,o),
+(134,114,o),
+(134,244,cs),
+(134,634,l),
+(467,634,l),
+(467,244,ls),
+(467,113,o),
+(410,45,o),
+(300,45,cs)
+);
+}
+);
+width = 733;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+},
+{
+color = 11;
+glyphname = "nii-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (239,0);
+ref = dot_top;
+}
+);
+width = 733;
+}
+);
+note = uni14C3;
+},
+{
+color = 11;
+glyphname = "no-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (433,690);
+},
+{
+name = top_double;
+pos = (442,690);
+},
+{
+name = top_left_can;
+pos = (236,690);
+},
+{
+name = top_right_can;
+pos = (627,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(660,0,l),
+(660,441,ls),
+(660,610,o),
+(577,702,o),
+(433,702,cs),
+(289,702,o),
+(205,610,o),
+(205,440,cs),
+(205,56,l),
+(62,56,l),
+(62,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(267,445,ls),
+(267,577,o),
+(324,644,o),
+(433,644,cs),
+(541,644,o),
+(599,576,o),
+(599,445,cs),
+(599,56,l),
+(267,56,l)
+);
+}
+);
+width = 733;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C4;
+},
+{
+color = 11;
+glyphname = "noo-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (371,0);
+ref = dot_top;
+}
+);
+width = 733;
+}
+);
+note = uni14C5;
+},
+{
+color = 11;
+glyphname = "na-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (300,690);
+},
+{
+name = top_double;
+pos = (310,690);
+},
+{
+name = top_left_can;
+pos = (104,690);
+},
+{
+name = top_right_can;
+pos = (498,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(671,0,l),
+(671,56,l),
+(528,56,l),
+(528,440,ls),
+(528,610,o),
+(444,702,o),
+(300,702,cs),
+(156,702,o),
+(73,610,o),
+(73,441,cs),
+(73,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(134,445,ls),
+(134,576,o),
+(192,644,o),
+(300,644,cs),
+(410,644,o),
+(467,577,o),
+(467,445,cs),
+(467,56,l),
+(134,56,l)
+);
+}
+);
+width = 733;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+},
+{
+color = 11;
+glyphname = "naa-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (239,0);
+ref = dot_top;
+}
+);
+width = 733;
+}
+);
+note = uni14C8;
+},
+{
+color = 11;
+glyphname = "nweWestCree-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (733,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 946;
+}
+);
+note = uni14CA;
+},
+{
+color = 11;
+glyphname = "nwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (733,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 946;
+}
+);
+note = uni14CC;
+},
+{
+color = 11;
+glyphname = "nwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (239,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (733,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 946;
+}
+);
+note = uni14CE;
+},
+{
+color = 11;
+glyphname = "se-canadian.square";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (108,690);
+},
+{
+name = top_right_can;
+pos = (554,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(584,0,l),
+(584,230,l),
+(394,230,ls),
+(225,230,o),
+(139,322,o),
+(139,497,cs),
+(139,690,l),
+(77,690,l),
+(77,496,ls),
+(77,290,o),
+(188,175,o),
+(396,175,cs),
+(543,175,l),
+(523,195,l),
+(523,0,l)
+);
+}
+);
+width = 664;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14ED;
+},
+{
+color = 11;
+glyphname = "si-canadian.square";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (112,690);
+},
+{
+name = top_right_can;
+pos = (557,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,0,l),
+(142,195,l),
+(122,175,l),
+(270,175,ls),
+(476,175,o),
+(587,290,o),
+(587,494,cs),
+(587,690,l),
+(526,690,l),
+(526,495,ls),
+(526,322,o),
+(440,230,o),
+(271,230,cs),
+(80,230,l),
+(80,0,l)
+);
+}
+);
+width = 664;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+},
+{
+color = 11;
+glyphname = "sii-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (496,0);
+ref = dot_top;
+}
+);
+width = 665;
+}
+);
+note = uni14F0;
+},
+{
+color = 11;
+glyphname = "so-canadian.square";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (554,690);
+},
+{
+name = top_left_can;
+pos = (108,690);
+},
+{
+name = top_right_can;
+pos = (554,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(139,0,l),
+(139,193,ls),
+(139,368,o),
+(225,460,o),
+(394,460,cs),
+(584,460,l),
+(584,690,l),
+(523,690,l),
+(523,495,l),
+(543,515,l),
+(396,515,ls),
+(188,515,o),
+(77,400,o),
+(77,194,cs),
+(77,0,l)
+);
+}
+);
+width = 664;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+},
+{
+color = 11;
+glyphname = "soo-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (492,0);
+ref = dot_top;
+}
+);
+width = 665;
+}
+);
+note = uni14F2;
+},
+{
+color = 11;
+glyphname = "sa-canadian.square";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (113,690);
+},
+{
+name = top_right_can;
+pos = (556,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(587,0,l),
+(587,194,ls),
+(587,400,o),
+(476,515,o),
+(270,515,cs),
+(122,515,l),
+(142,495,l),
+(142,690,l),
+(80,690,l),
+(80,460,l),
+(270,460,ls),
+(440,460,o),
+(526,368,o),
+(526,193,cs),
+(526,0,l)
+);
+}
+);
+width = 664;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+},
+{
+color = 11;
+glyphname = "saa-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+}
+);
+width = 665;
+}
+);
+note = uni14F5;
+},
+{
+color = 11;
+glyphname = "sho-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (330,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(580,0,l),
+(580,53,l),
+(288,53,ls),
+(175,53,o),
+(132,99,o),
+(132,185,cs),
+(132,272,o),
+(175,319,o),
+(288,319,cs),
+(384,319,ls),
+(528,319,o),
+(590,387,o),
+(590,505,cs),
+(590,621,o),
+(528,690,o),
+(384,690,cs),
+(82,690,l),
+(82,637,l),
+(373,637,ls),
+(486,637,o),
+(528,590,o),
+(528,505,cs),
+(528,419,o),
+(486,372,o),
+(374,372,cs),
+(278,372,ls),
+(132,372,o),
+(71,302,o),
+(71,185,cs),
+(71,69,o),
+(132,0,o),
+(278,0,cs)
+);
+}
+);
+width = 661;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+color = 11;
+glyphname = "shoo-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (269,0);
+ref = dot_top;
+}
+);
+width = 661;
+}
+);
+note = g728;
+},
+{
+color = 11;
+glyphname = "sha-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (331,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(384,0,ls),
+(525,0,o),
+(590,69,o),
+(590,185,cs),
+(590,302,o),
+(525,371,o),
+(384,371,cs),
+(288,371,ls),
+(175,371,o),
+(132,419,o),
+(132,504,cs),
+(132,590,o),
+(175,637,o),
+(288,637,cs),
+(580,637,l),
+(580,690,l),
+(277,690,ls),
+(136,690,o),
+(71,621,o),
+(71,504,cs),
+(71,387,o),
+(136,318,o),
+(277,318,cs),
+(373,318,ls),
+(486,318,o),
+(528,272,o),
+(528,185,cs),
+(528,99,o),
+(486,53,o),
+(373,53,cs),
+(81,53,l),
+(81,0,l)
+);
+}
+);
+width = 661;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+color = 11;
+glyphname = "shaa-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (270,0);
+ref = dot_top;
+}
+);
+width = 661;
+}
+);
+note = g730;
+},
+{
+color = 11;
+glyphname = "ye-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (79,690);
+},
+{
+name = top_right_can;
+pos = (583,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(614,0,l),
+(614,230,l),
+(129,230,l),
+(130,195,l),
+(626,660,l),
+(585,701,l),
+(47,199,l),
+(47,175,l),
+(553,175,l),
+(553,0,l)
+);
+}
+);
+width = 692;
+}
+);
+metricLeft = "ye-canadian";
+note = uni1526;
+},
+{
+color = 11;
+glyphname = "yi-canadian.square";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (110,690);
+},
+{
+name = top_right_can;
+pos = (614,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(140,0,l),
+(140,175,l),
+(645,175,l),
+(645,199,l),
+(107,701,l),
+(68,660,l),
+(562,195,l),
+(563,230,l),
+(79,230,l),
+(79,0,l)
+);
+}
+);
+width = 692;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni1528;
+},
+{
+color = 11;
+glyphname = "yii-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (46,0);
+ref = dot_top;
+}
+);
+width = 692;
+}
+);
+note = uni1529;
+},
+{
+color = 11;
+glyphname = "yo-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (583,690);
+},
+{
+name = top_left_can;
+pos = (79,690);
+},
+{
+name = top_right_can;
+pos = (583,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(626,30,l),
+(130,495,l),
+(129,460,l),
+(614,460,l),
+(614,690,l),
+(553,690,l),
+(553,515,l),
+(47,515,l),
+(47,491,l),
+(585,-12,l)
+);
+}
+);
+width = 692;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152A;
+},
+{
+color = 11;
+glyphname = "yoo-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (522,0);
+ref = dot_top;
+}
+);
+width = 692;
+}
+);
+note = uni152B;
+},
+{
+color = 11;
+glyphname = "ya-canadian.square";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (110,690);
+},
+{
+name = top_right_can;
+pos = (614,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(645,491,l),
+(645,515,l),
+(140,515,l),
+(140,690,l),
+(79,690,l),
+(79,460,l),
+(563,460,l),
+(562,495,l),
+(68,30,l),
+(107,-12,l)
+);
+}
+);
+width = 692;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152D;
+},
+{
+color = 11;
+glyphname = "yaa-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (47,0);
+ref = dot_top;
+}
+);
+width = 692;
+}
+);
+note = uni152E;
+},
+{
+color = 11;
+glyphname = "re-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (300,690);
+},
+{
+name = top_left_can;
+pos = (104,690);
+},
+{
+name = top_right_can;
+pos = (498,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(445,-13,o),
+(528,80,o),
+(528,249,cs),
+(528,634,l),
+(671,634,l),
+(671,690,l),
+(467,690,l),
+(467,244,ls),
+(467,113,o),
+(410,45,o),
+(300,45,cs),
+(192,45,o),
+(134,114,o),
+(134,244,cs),
+(134,690,l),
+(73,690,l),
+(73,248,ls),
+(73,80,o),
+(156,-13,o),
+(300,-13,cs)
+);
+}
+);
+width = 733;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1542;
+},
+{
+color = 11;
+glyphname = "reRCree-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (433,690);
+},
+{
+name = top_left_can;
+pos = (236,690);
+},
+{
+name = top_right_can;
+pos = (630,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(577,-13,o),
+(660,80,o),
+(660,248,cs),
+(660,690,l),
+(599,690,l),
+(599,244,ls),
+(599,114,o),
+(541,45,o),
+(433,45,cs),
+(324,45,o),
+(267,113,o),
+(267,244,cs),
+(267,690,l),
+(62,690,l),
+(62,634,l),
+(205,634,l),
+(205,249,ls),
+(205,80,o),
+(288,-13,o),
+(433,-13,cs)
+);
+}
+);
+width = 733;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni1543;
+},
+{
+color = 11;
+glyphname = "leWestCree-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (433,690);
+},
+{
+name = top_left_can;
+pos = (236,690);
+},
+{
+name = top_right_can;
+pos = (630,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(267,0,l),
+(267,445,ls),
+(267,577,o),
+(324,644,o),
+(433,644,cs),
+(541,644,o),
+(599,576,o),
+(599,445,cs),
+(599,0,l),
+(660,0,l),
+(660,441,ls),
+(660,610,o),
+(577,702,o),
+(433,702,cs),
+(288,702,o),
+(205,610,o),
+(205,440,cs),
+(205,56,l),
+(62,56,l),
+(62,0,l)
+);
+}
+);
+width = 736;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+},
+{
+color = 11;
+glyphname = "ri-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (300,690);
+},
+{
+name = top_left_can;
+pos = (108,690);
+},
+{
+name = top_right_can;
+pos = (498,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(134,0,l),
+(134,445,ls),
+(134,576,o),
+(192,644,o),
+(300,644,cs),
+(410,644,o),
+(467,577,o),
+(467,445,cs),
+(467,0,l),
+(671,0,l),
+(671,56,l),
+(528,56,l),
+(528,440,ls),
+(528,610,o),
+(445,702,o),
+(300,702,cs),
+(156,702,o),
+(73,610,o),
+(73,441,cs),
+(73,0,l)
+);
+}
+);
+width = 733;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+},
+{
+color = 11;
+glyphname = "rii-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (239,0);
+ref = dot_top;
+}
+);
+width = 733;
+}
+);
+note = uni1547;
+},
+{
+color = 11;
+glyphname = "ro-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (331,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,0,l),
+(142,157,l),
+(119,136,l),
+(282,136,ls),
+(475,136,o),
+(581,240,o),
+(581,412,cs),
+(581,586,o),
+(475,690,o),
+(282,690,cs),
+(80,690,l),
+(80,635,l),
+(285,635,ls),
+(439,635,o),
+(519,554,o),
+(519,412,cs),
+(519,271,o),
+(439,191,o),
+(285,191,cs),
+(80,191,l),
+(80,0,l)
+);
+}
+);
+width = 647;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1548;
+},
+{
+color = 11;
+glyphname = "loWestCree-canadian.square";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (330,690);
+},
+{
+name = top_left_can;
+pos = (112,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(282,0,ls),
+(475,0,o),
+(581,103,o),
+(581,277,cs),
+(581,450,o),
+(475,554,o),
+(282,554,cs),
+(119,554,l),
+(142,532,l),
+(142,690,l),
+(80,690,l),
+(80,498,l),
+(285,498,ls),
+(439,498,o),
+(519,418,o),
+(519,277,cs),
+(519,136,o),
+(439,55,o),
+(285,55,cs),
+(80,55,l),
+(80,0,l)
+);
+}
+);
+width = 646;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+},
+{
+color = 11;
+glyphname = "ra-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (315,690);
+},
+{
+name = top_right_can;
+pos = (534,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(565,0,l),
+(565,191,l),
+(361,191,ls),
+(207,191,o),
+(127,271,o),
+(127,412,cs),
+(127,554,o),
+(207,635,o),
+(361,635,cs),
+(565,635,l),
+(565,690,l),
+(363,690,ls),
+(170,690,o),
+(65,586,o),
+(65,412,cs),
+(65,240,o),
+(170,136,o),
+(363,136,cs),
+(526,136,l),
+(503,157,l),
+(503,0,l)
+);
+}
+);
+width = 645;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+},
+{
+color = 11;
+glyphname = "raa-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (253,0);
+ref = dot_top;
+}
+);
+width = 645;
+}
+);
+note = uni154C;
+},
+{
+color = 11;
+glyphname = "laWestCree-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (534,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(565,0,l),
+(565,55,l),
+(361,55,ls),
+(207,55,o),
+(127,136,o),
+(127,277,cs),
+(127,418,o),
+(207,498,o),
+(361,498,cs),
+(565,498,l),
+(565,690,l),
+(503,690,l),
+(503,532,l),
+(526,554,l),
+(363,554,ls),
+(170,554,o),
+(65,450,o),
+(65,277,cs),
+(65,103,o),
+(170,0,o),
+(363,0,cs)
+);
+}
+);
+width = 645;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+},
+{
+color = 11;
+glyphname = "reWestCree-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(603,0,l),
+(831,191,l),
+(797,234,l),
+(570,43,l),
+(610,43,l),
+(610,408,ls),
+(610,599,o),
+(510,702,o),
+(333,702,cs),
+(166,702,o),
+(68,602,o),
+(68,430,cs),
+(68,391,l),
+(128,391,l),
+(128,433,ls),
+(128,574,o),
+(207,645,o),
+(332,645,cs),
+(474,645,o),
+(548,565,o),
+(548,404,cs),
+(548,0,l)
+);
+}
+);
+width = 859;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+},
+{
+color = 11;
+glyphname = "riWestCree-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(311,0,l),
+(311,404,ls),
+(311,565,o),
+(384,645,o),
+(526,645,cs),
+(652,645,o),
+(730,574,o),
+(730,433,cs),
+(730,391,l),
+(791,391,l),
+(791,430,ls),
+(791,602,o),
+(693,702,o),
+(526,702,cs),
+(349,702,o),
+(249,599,o),
+(249,408,cs),
+(249,43,l),
+(289,43,l),
+(62,234,l),
+(28,191,l),
+(256,0,l)
+);
+}
+);
+width = 859;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+},
+{
+color = 11;
+glyphname = "roWestCree-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(510,-13,o),
+(610,91,o),
+(610,282,cs),
+(610,646,l),
+(570,646,l),
+(797,456,l),
+(831,498,l),
+(603,690,l),
+(548,690,l),
+(548,286,ls),
+(548,125,o),
+(474,44,o),
+(332,44,cs),
+(207,44,o),
+(128,116,o),
+(128,257,cs),
+(128,298,l),
+(68,298,l),
+(68,260,ls),
+(68,88,o),
+(166,-13,o),
+(333,-13,cs)
+);
+}
+);
+width = 859;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+},
+{
+color = 11;
+glyphname = "raWestCree-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(693,-13,o),
+(791,88,o),
+(791,260,cs),
+(791,298,l),
+(730,298,l),
+(730,257,ls),
+(730,116,o),
+(652,44,o),
+(526,44,cs),
+(384,44,o),
+(311,125,o),
+(311,286,cs),
+(311,690,l),
+(256,690,l),
+(28,498,l),
+(62,456,l),
+(289,646,l),
+(249,646,l),
+(249,282,ls),
+(249,91,o),
+(349,-13,o),
+(526,-13,cs)
+);
+}
+);
+width = 859;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+},
+{
+color = 11;
+glyphname = "theThCree-canadian.square";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (79,690);
+},
+{
+name = top_right_can;
+pos = (583,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(553,71,l),
+(553,0,l),
+(614,0,l),
+(614,71,l),
+(697,71,l),
+(697,107,l),
+(614,107,l),
+(614,230,l),
+(129,230,l),
+(130,195,l),
+(626,660,l),
+(585,701,l),
+(47,199,l),
+(47,175,l),
+(553,175,l),
+(553,107,l),
+(308,107,l),
+(308,71,l)
+);
+}
+);
+width = 732;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15A7;
+},
+{
+color = 11;
+glyphname = "thiThCree-canadian.square";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (138,690);
+},
+{
+name = top_right_can;
+pos = (642,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(180,0,l),
+(180,71,l),
+(424,71,l),
+(424,107,l),
+(180,107,l),
+(180,175,l),
+(685,175,l),
+(685,199,l),
+(147,701,l),
+(107,660,l),
+(602,195,l),
+(603,230,l),
+(119,230,l),
+(119,107,l),
+(35,107,l),
+(35,71,l),
+(119,71,l),
+(119,0,l)
+);
+}
+);
+width = 732;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+},
+{
+color = 11;
+glyphname = "thiiThCree-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (76,0);
+ref = dot_top;
+}
+);
+width = 733;
+}
+);
+note = uni15A9;
+},
+{
+color = 11;
+glyphname = "thoThCree-canadian.square";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (79,690);
+},
+{
+name = top_right_can;
+pos = (583,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(626,30,l),
+(130,495,l),
+(129,460,l),
+(614,460,l),
+(614,582,l),
+(697,582,l),
+(697,619,l),
+(614,619,l),
+(614,690,l),
+(553,690,l),
+(553,619,l),
+(308,619,l),
+(308,582,l),
+(553,582,l),
+(553,515,l),
+(47,515,l),
+(47,491,l),
+(585,-12,l)
+);
+}
+);
+width = 732;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+},
+{
+color = 11;
+glyphname = "thooThCree-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (522,0);
+ref = dot_top;
+}
+);
+width = 733;
+}
+);
+note = uni15AB;
+},
+{
+color = 11;
+glyphname = "thaThCree-canadian.square";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (150,690);
+},
+{
+name = top_right_can;
+pos = (654,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(685,491,l),
+(685,515,l),
+(180,515,l),
+(180,582,l),
+(424,582,l),
+(424,619,l),
+(180,619,l),
+(180,690,l),
+(119,690,l),
+(119,619,l),
+(35,619,l),
+(35,582,l),
+(119,582,l),
+(119,460,l),
+(603,460,l),
+(602,495,l),
+(107,30,l),
+(147,-12,l)
+);
+}
+);
+width = 732;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+},
+{
+color = 11;
+glyphname = "thaaThCree-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (89,0);
+ref = dot_top;
+}
+);
+width = 733;
+}
+);
+note = uni15AD;
+},
+{
+color = 11;
+glyphname = "thweeWoodScree-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (733,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 947;
+}
+);
+note = uni1677;
+},
+{
+color = 11;
+glyphname = "thwiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (733,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 947;
+}
+);
+note = uni1678;
+},
+{
+color = 11;
+glyphname = "thwiiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (76,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (733,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 947;
+}
+);
+note = uni1679;
+},
+{
+color = 11;
+glyphname = "thwoWoodScree-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (733,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 947;
+}
+);
+note = uni167A;
+},
+{
+color = 11;
+glyphname = "thwooWoodScree-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (522,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (733,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 947;
+}
+);
+note = uni167B;
+},
+{
+color = 11;
+glyphname = "thwaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (733,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 947;
+}
+);
+note = uni167C;
+},
+{
+color = 11;
+glyphname = "thwaaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (89,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (733,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 947;
+}
+);
+note = uni167D;
+},
+{
+color = 11;
+glyphname = "nwiOjibway-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (733,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 946;
+}
+);
+note = uni18C7;
+},
+{
+color = 11;
+glyphname = "nwiiOjibway-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (239,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (733,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 946;
+}
+);
+note = uni18C9;
+},
+{
+color = 11;
+glyphname = "nwoOjibway-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (733,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 946;
+}
+);
+note = uni18CB;
+},
+{
+color = 11;
+glyphname = "nwooOjibway-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (371,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (733,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 946;
+}
+);
+note = uni18CD;
+},
+{
+color = 11;
+glyphname = "looWestCree-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+}
+);
+width = 645;
+}
+);
+note = uni18E1;
+},
+{
+color = 11;
+glyphname = "laaWestCree-canadian.square";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (472,0);
+ref = dot_top;
+}
+);
+width = 645;
+}
+);
+note = uni18E2;
+},
+{
+color = 0;
+glyphname = zero;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(506,541,o),
+(459,700,o),
+(284,700,cs),
+(107,700,o),
+(60,526,o),
+(60,347,cs),
+(60,106,o),
+(141,-10,o),
+(283,-10,cs),
+(433,-10,o),
+(506,108,o),
+(506,347,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(124,489,o),
+(148,647,o),
+(284,647,cs),
+(429,647,o),
+(442,479,o),
+(442,347,cs),
+(442,159,o),
+(401,43,o),
+(283,43,cs),
+(172,43,o),
+(124,157,o),
+(124,347,cs)
+);
+}
+);
+width = 565;
+}
+);
+unicode = 48;
+},
+{
+color = 0;
+glyphname = one;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(219,690,l),
+(19,539,l),
+(54,497,l),
+(163,579,ls),
+(185,595,o),
+(197,607,o),
+(213,621,c),
+(212,599,o),
+(212,576,o),
+(212,551,cs),
+(212,0,l),
+(275,0,l),
+(275,690,l)
+);
+}
+);
+width = 394;
+}
+);
+unicode = 49;
+},
+{
+color = 0;
+glyphname = two;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(476,0,l),
+(476,54,l),
+(122,54,l),
+(122,56,l),
+(288,230,ls),
+(356,298,o),
+(405,353,o),
+(430,414,cs),
+(442,444,o),
+(448,479,o),
+(448,519,cs),
+(448,628,o),
+(369,699,o),
+(254,699,cs),
+(182,699,o),
+(114,675,o),
+(53,622,c),
+(88,580,l),
+(141,623,o),
+(197,644,o),
+(249,644,cs),
+(334,644,o),
+(385,596,o),
+(385,512,cs),
+(385,450,o),
+(365,403,o),
+(325,351,cs),
+(303,325,o),
+(277,295,o),
+(244,261,cs),
+(40,45,l),
+(40,0,l)
+);
+}
+);
+width = 526;
+}
+);
+unicode = 50;
+},
+{
+color = 0;
+glyphname = three;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(449,639,o),
+(370,699,o),
+(250,699,cs),
+(156,699,o),
+(89,670,o),
+(32,628,c),
+(60,583,l),
+(114,622,o),
+(174,646,o),
+(243,646,cs),
+(330,646,o),
+(387,607,o),
+(387,524,cs),
+(387,427,o),
+(302,384,o),
+(203,384,cs),
+(131,384,l),
+(131,332,l),
+(203,332,ls),
+(322,332,o),
+(404,298,o),
+(404,192,cs),
+(404,101,o),
+(343,43,o),
+(215,43,cs),
+(149,43,o),
+(77,61,o),
+(25,87,c),
+(25,30,l),
+(77,7,o),
+(142,-10,o),
+(221,-10,cs),
+(377,-10,o),
+(470,69,o),
+(470,189,cs),
+(470,292,o),
+(409,346,o),
+(301,360,c),
+(301,362,l),
+(385,380,o),
+(449,443,o),
+(449,534,cs)
+);
+}
+);
+width = 521;
+}
+);
+unicode = 51;
+},
+{
+color = 0;
+glyphname = four;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(442,226,l),
+(442,693,l),
+(382,693,l),
+(39,220,l),
+(39,175,l),
+(381,175,l),
+(381,0,l),
+(442,0,l),
+(442,175,l),
+(560,175,l),
+(560,226,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(102,226,l),
+(324,528,ls),
+(351,565,o),
+(359,581,o),
+(380,614,c),
+(383,614,l),
+(383,593,o),
+(381,559,o),
+(381,523,cs),
+(381,226,l)
+);
+}
+);
+width = 584;
+}
+);
+unicode = 52;
+},
+{
+color = 0;
+glyphname = five;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(196,421,o),
+(158,411,o),
+(128,404,c),
+(150,635,l),
+(435,635,l),
+(435,690,l),
+(96,690,l),
+(67,367,l),
+(98,348,l),
+(139,361,o),
+(183,369,o),
+(236,369,cs),
+(354,369,o),
+(413,310,o),
+(413,213,cs),
+(413,105,o),
+(338,43,o),
+(221,43,cs),
+(155,43,o),
+(92,63,o),
+(46,88,c),
+(46,30,l),
+(91,7,o),
+(151,-10,o),
+(225,-10,cs),
+(384,-10,o),
+(477,77,o),
+(477,214,cs),
+(477,347,o),
+(391,421,o),
+(258,421,cs)
+);
+}
+);
+width = 522;
+}
+);
+unicode = 53;
+},
+{
+color = 0;
+glyphname = six;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(58,134,o),
+(126,-10,o),
+(290,-10,cs),
+(423,-10,o),
+(504,79,o),
+(504,221,cs),
+(504,352,o),
+(431,433,o),
+(305,433,cs),
+(213,433,o),
+(147,387,o),
+(118,327,c),
+(115,327,l),
+(121,514,o),
+(187,648,o),
+(362,648,cs),
+(403,648,o),
+(435,643,o),
+(459,636,c),
+(459,690,l),
+(433,696,o),
+(399,701,o),
+(363,701,cs),
+(137,701,o),
+(58,523,o),
+(58,293,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(161,43,o),
+(125,166,o),
+(125,247,cs),
+(125,322,o),
+(208,381,o),
+(293,381,cs),
+(394,381,o),
+(442,320,o),
+(442,221,cs),
+(442,110,o),
+(387,43,o),
+(289,43,cs)
+);
+}
+);
+width = 551;
+}
+);
+unicode = 54;
+},
+{
+color = 0;
+glyphname = seven;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(467,651,l),
+(467,690,l),
+(16,690,l),
+(16,635,l),
+(398,635,l),
+(123,0,l),
+(189,0,l)
+);
+}
+);
+width = 491;
+}
+);
+unicode = 55;
+},
+{
+color = 0;
+glyphname = eight;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(411,-10,o),
+(504,59,o),
+(504,177,cs),
+(504,274,o),
+(435,329,o),
+(331,368,c),
+(422,405,o),
+(481,455,o),
+(481,539,cs),
+(481,642,o),
+(403,699,o),
+(283,699,cs),
+(164,699,o),
+(83,638,o),
+(83,538,cs),
+(83,441,o),
+(158,397,o),
+(229,366,c),
+(128,330,o),
+(62,275,o),
+(62,172,cs),
+(62,64,o),
+(145,-10,o),
+(279,-10,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(185,41,o),
+(122,92,o),
+(122,174,cs),
+(122,268,o),
+(200,311,o),
+(280,338,c),
+(391,297,o),
+(444,251,o),
+(444,178,cs),
+(444,88,o),
+(377,41,o),
+(279,41,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,426,o),
+(144,465,o),
+(144,534,cs),
+(144,609,o),
+(204,649,o),
+(282,649,cs),
+(369,649,o),
+(420,611,o),
+(420,535,cs),
+(420,469,o),
+(373,432,o),
+(284,395,c)
+);
+}
+);
+width = 564;
+}
+);
+unicode = 56;
+},
+{
+color = 0;
+glyphname = nine;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(491,562,o),
+(424,699,o),
+(259,699,cs),
+(126,699,o),
+(43,611,o),
+(43,469,cs),
+(43,339,o),
+(117,257,o),
+(242,257,cs),
+(333,257,o),
+(401,301,o),
+(430,364,c),
+(433,364,l),
+(427,173,o),
+(356,42,o),
+(184,42,cs),
+(144,42,o),
+(106,47,o),
+(83,55,c),
+(83,0,l),
+(109,-7,o),
+(150,-12,o),
+(185,-12,cs),
+(413,-12,o),
+(491,172,o),
+(491,396,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(388,646,o),
+(424,523,o),
+(424,443,cs),
+(424,370,o),
+(338,309,o),
+(256,309,cs),
+(156,309,o),
+(106,372,o),
+(106,470,cs),
+(106,582,o),
+(160,646,o),
+(260,646,cs)
+);
+}
+);
+width = 549;
+}
+);
+unicode = 57;
+},
+{
+glyphname = zero.canadian;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(510,586,o),
+(427,702,o),
+(286,702,cs),
+(144,702,o),
+(62,586,o),
+(62,345,cs),
+(62,103,o),
+(144,-12,o),
+(286,-12,cs),
+(427,-12,o),
+(510,103,o),
+(510,345,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(124,552,o),
+(179,645,o),
+(286,645,cs),
+(393,645,o),
+(448,553,o),
+(448,345,cs),
+(448,137,o),
+(393,44,o),
+(286,44,cs),
+(179,44,o),
+(124,138,o),
+(124,345,cs)
+);
+}
+);
+width = 572;
+}
+);
+metricRight = "=|";
+},
+{
+glyphname = one.canadian;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(264,0,l),
+(264,690,l),
+(208,690,l),
+(28,538,l),
+(63,497,l),
+(242,646,l),
+(202,648,l),
+(202,0,l)
+);
+}
+);
+width = 344;
+}
+);
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = two.canadian;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(501,56,l),
+(155,56,l),
+(156,35,l),
+(382,276,ls),
+(475,373,o),
+(492,437,o),
+(492,509,cs),
+(492,620,o),
+(418,702,o),
+(289,702,cs),
+(145,702,o),
+(66,608,o),
+(65,454,c),
+(127,454,l),
+(127,577,o),
+(182,647,o),
+(288,647,cs),
+(384,647,o),
+(430,587,o),
+(430,508,cs),
+(430,446,o),
+(415,391,o),
+(331,303,cs),
+(85,43,l),
+(85,0,l),
+(501,0,l)
+);
+}
+);
+width = 561;
+}
+);
+note = uni14BF;
+},
+{
+glyphname = three.canadian;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(432,-13,o),
+(512,58,o),
+(512,184,cs),
+(512,275,o),
+(462,343,o),
+(371,357,c),
+(371,335,l),
+(455,349,o),
+(503,415,o),
+(503,506,cs),
+(503,631,o),
+(426,702,o),
+(301,702,cs),
+(162,702,o),
+(78,613,o),
+(76,470,c),
+(138,470,l),
+(138,582,o),
+(196,647,o),
+(300,647,cs),
+(391,647,o),
+(441,599,o),
+(441,504,cs),
+(441,416,o),
+(398,372,o),
+(314,372,cs),
+(277,372,l),
+(277,319,l),
+(318,319,ls),
+(405,319,o),
+(450,273,o),
+(450,185,cs),
+(450,89,o),
+(397,43,o),
+(298,43,cs),
+(187,43,o),
+(131,104,o),
+(130,219,c),
+(70,219,l),
+(71,71,o),
+(152,-13,o),
+(298,-13,cs)
+);
+}
+);
+width = 588;
+}
+);
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = four.canadian;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(429,0,l),
+(429,175,l),
+(535,175,l),
+(535,228,l),
+(429,228,l),
+(429,693,l),
+(378,693,l),
+(45,215,l),
+(45,175,l),
+(369,175,l),
+(369,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(392,633,l),
+(369,633,l),
+(369,228,l),
+(99,228,l),
+(101,213,l)
+);
+}
+);
+width = 569;
+}
+);
+},
+{
+glyphname = five.canadian;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,-13,o),
+(520,67,o),
+(520,195,cs),
+(520,327,o),
+(440,397,o),
+(298,397,cs),
+(154,397,l),
+(173,377,l),
+(197,655,l),
+(177,635,l),
+(497,635,l),
+(497,690,l),
+(140,690,l),
+(113,356,l),
+(127,342,l),
+(289,342,ls),
+(405,342,o),
+(459,296,o),
+(459,193,cs),
+(459,96,o),
+(405,43,o),
+(304,43,cs),
+(189,43,o),
+(140,99,o),
+(140,192,c),
+(78,192,l),
+(80,66,o),
+(155,-13,o),
+(304,-13,cs)
+);
+}
+);
+width = 584;
+}
+);
+},
+{
+glyphname = six.canadian;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(428,-13,o),
+(513,73,o),
+(513,201,cs),
+(513,330,o),
+(432,412,o),
+(307,412,cs),
+(209,412,o),
+(129,357,o),
+(112,251,c),
+(128,237,l),
+(124,285,o),
+(123,311,o),
+(123,357,cs),
+(123,554,o),
+(178,647,o),
+(298,647,cs),
+(396,647,o),
+(440,584,o),
+(446,502,c),
+(507,502,l),
+(497,617,o),
+(431,702,o),
+(300,702,cs),
+(146,702,o),
+(62,587,o),
+(62,347,cs),
+(62,193,o),
+(84,109,o),
+(133,54,cs),
+(177,6,o),
+(232,-13,o),
+(300,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(196,42,o),
+(138,104,o),
+(138,204,cs),
+(138,298,o),
+(205,359,o),
+(300,359,cs),
+(399,359,o),
+(453,298,o),
+(453,200,cs),
+(453,103,o),
+(393,42,o),
+(298,42,cs)
+);
+}
+);
+width = 566;
+}
+);
+metricLeft = zero.canadian;
+},
+{
+glyphname = seven.canadian;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(432,651,l),
+(432,690,l),
+(28,690,l),
+(28,634,l),
+(373,634,l),
+(372,657,l),
+(128,19,l),
+(128,0,l),
+(187,0,l)
+);
+}
+);
+width = 466;
+}
+);
+},
+{
+glyphname = eight.canadian;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(438,-13,o),
+(525,61,o),
+(525,179,cs),
+(525,278,o),
+(458,342,o),
+(375,355,c),
+(370,337,l),
+(445,348,o),
+(509,411,o),
+(509,511,cs),
+(509,629,o),
+(429,702,o),
+(300,702,cs),
+(173,702,o),
+(92,629,o),
+(92,511,cs),
+(92,411,o),
+(156,348,o),
+(232,337,c),
+(227,355,l),
+(144,342,o),
+(76,278,o),
+(76,179,cs),
+(76,61,o),
+(163,-13,o),
+(300,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,41,o),
+(138,88,o),
+(138,181,cs),
+(138,273,o),
+(200,320,o),
+(300,320,cs),
+(402,320,o),
+(463,273,o),
+(463,181,cs),
+(463,88,o),
+(402,41,o),
+(300,41,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(209,371,o),
+(154,416,o),
+(154,509,cs),
+(154,601,o),
+(207,649,o),
+(300,649,cs),
+(395,649,o),
+(448,601,o),
+(448,509,cs),
+(448,416,o),
+(392,371,o),
+(300,371,cs)
+);
+}
+);
+width = 601;
+}
+);
+metricLeft = "=|";
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = nine.canadian;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(420,-13,o),
+(504,102,o),
+(504,343,cs),
+(504,497,o),
+(482,581,o),
+(433,636,cs),
+(389,684,o),
+(334,702,o),
+(266,702,cs),
+(139,702,o),
+(53,616,o),
+(53,489,cs),
+(53,359,o),
+(135,277,o),
+(259,277,cs),
+(358,277,o),
+(437,332,o),
+(454,439,c),
+(439,453,l),
+(442,405,o),
+(443,379,o),
+(443,332,cs),
+(443,135,o),
+(388,43,o),
+(268,43,cs),
+(171,43,o),
+(128,105,o),
+(121,187,c),
+(59,187,l),
+(69,72,o),
+(135,-13,o),
+(266,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(167,330,o),
+(114,391,o),
+(114,490,cs),
+(114,586,o),
+(173,648,o),
+(268,648,cs),
+(370,648,o),
+(429,585,o),
+(429,486,cs),
+(429,392,o),
+(361,330,o),
+(267,330,cs)
+);
+}
+);
+width = 566;
+}
+);
+metricLeft = "=|six.canadian";
+metricRight = "=|six.canadian";
+},
+{
+glyphname = CR;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+width = 252;
+}
+);
+note = CR;
+unicode = 13;
+},
+{
+color = 0;
+glyphname = .notdef;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(488,690,l),
+(91,690,l),
+(91,0,l),
+(488,0,l),
+(488,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(439,640,l),
+(439,49,l),
+(140,49,l),
+(140,640,l),
+(140,640,l)
+);
+}
+);
+width = 580;
+}
+);
+note = ".notdef";
+},
+{
+glyphname = .null;
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+width = 0;
+}
+);
+note = NULL;
+},
+{
+glyphname = space;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+width = 254;
+}
+);
+note = space;
+unicode = 32;
+},
+{
+glyphname = nbspace;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+width = 252;
+}
+);
+note = uni00A0;
+unicode = 160;
+},
+{
+glyphname = space.canadian;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+width = 487;
+}
+);
+note = space;
+},
+{
+glyphname = "hyphen-canadian";
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(377,402,l),
+(377,441,l),
+(68,441,l),
+(68,402,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(377,269,l),
+(377,308,l),
+(68,308,l),
+(68,269,l)
+);
+}
+);
+width = 445;
+}
+);
+metricRight = "=|";
+note = uni1400;
+unicode = 5120;
+},
+{
+glyphname = "chi-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(112,0,l),
+(278,316,l),
+(252,316,l),
+(418,0,l),
+(473,0,l),
+(473,19,l),
+(285,373,l),
+(285,325,l),
+(470,670,l),
+(470,690,l),
+(414,690,l),
+(252,382,l),
+(278,382,l),
+(116,690,l),
+(60,690,l),
+(60,670,l),
+(244,326,l),
+(244,374,l),
+(56,19,l),
+(56,0,l)
+);
+}
+);
+width = 529;
+}
+);
+metricRight = "=|";
+note = uni166D;
+unicode = 5741;
+},
+{
+glyphname = "fullstop-canadian";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(278,0,l),
+(278,10,l),
+(185,183,l),
+(186,165,l),
+(276,334,l),
+(276,345,l),
+(237,345,l),
+(158,193,l),
+(177,195,l),
+(99,345,l),
+(59,345,l),
+(59,334,l),
+(149,168,l),
+(149,185,l),
+(57,10,l),
+(57,0,l),
+(97,0,l),
+(178,157,l),
+(157,156,l),
+(239,0,l)
+);
+}
+);
+width = 335;
+}
+);
+note = uni1541;
+unicode = 5742;
+},
+{
+glyphname = period;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(71,8,o),
+(86,-9,o),
+(114,-9,cs),
+(144,-9,o),
+(156,8,o),
+(156,36,cs),
+(156,63,o),
+(144,79,o),
+(114,79,cs),
+(86,79,o),
+(71,63,o),
+(71,36,cs)
+);
+}
+);
+width = 221;
+}
+);
+note = period;
+unicode = 46;
+},
+{
+glyphname = comma;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(77,-127,l),
+(106,-58,o),
+(129,35,o),
+(145,107,c),
+(141,119,l),
+(83,119,l),
+(73,44,o),
+(57,-33,o),
+(31,-127,c)
+);
+}
+);
+width = 197;
+}
+);
+note = comma;
+unicode = 44;
+},
+{
+glyphname = hyphen;
+kernLeft = hyphen;
+kernRight = hyphen;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(253,288,l),
+(37,288,l),
+(37,235,l),
+(253,235,l)
+);
+}
+);
+width = 290;
+}
+);
+unicode = 45;
+},
+{
+glyphname = quotesinglbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (33,-571);
+ref = quoteright;
+}
+);
+width = 235;
+}
+);
+unicode = 8218;
+},
+{
+glyphname = quotedblbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (33,-571);
+ref = quotedblright;
+}
+);
+width = 401;
+}
+);
+unicode = 8222;
+},
+{
+glyphname = quotedblleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(247,443,l),
+(255,514,o),
+(275,609,o),
+(305,690,c),
+(263,690,l),
+(231,621,o),
+(204,536,o),
+(189,453,c),
+(196,443,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(90,443,l),
+(98,514,o),
+(118,609,o),
+(147,690,c),
+(105,690,l),
+(73,621,o),
+(46,535,o),
+(32,453,c),
+(38,443,l)
+);
+}
+);
+width = 334;
+}
+);
+unicode = 8220;
+},
+{
+glyphname = quotedblright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(230,443,l),
+(262,513,o),
+(289,602,o),
+(302,680,c),
+(297,690,l),
+(244,690,l),
+(239,617,o),
+(219,526,o),
+(187,443,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(71,443,l),
+(104,513,o),
+(131,602,o),
+(145,680,c),
+(138,690,l),
+(87,690,l),
+(81,620,o),
+(60,523,o),
+(30,443,c)
+);
+}
+);
+width = 334;
+}
+);
+unicode = 8221;
+},
+{
+glyphname = quoteleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(91,443,l),
+(99,514,o),
+(119,609,o),
+(148,690,c),
+(105,690,l),
+(73,621,o),
+(46,535,o),
+(32,453,c),
+(38,443,l)
+);
+}
+);
+width = 178;
+}
+);
+unicode = 8216;
+},
+{
+glyphname = quoteright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(72,443,l),
+(104,513,o),
+(132,603,o),
+(146,680,c),
+(139,690,l),
+(87,690,l),
+(81,620,o),
+(60,523,o),
+(30,443,c)
+);
+}
+);
+width = 178;
+}
+);
+unicode = 8217;
+},
+{
+glyphname = dottedCircle;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(193,504,o),
+(181,494,o),
+(181,479,cs),
+(181,467,o),
+(193,454,o),
+(206,454,cs),
+(220,454,o),
+(231,467,o),
+(231,479,cs),
+(231,494,o),
+(220,504,o),
+(206,504,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(355,504,o),
+(343,494,o),
+(343,479,cs),
+(343,467,o),
+(355,454,o),
+(368,454,cs),
+(383,454,o),
+(393,467,o),
+(393,479,cs),
+(393,494,o),
+(383,504,o),
+(368,504,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(193,108,o),
+(181,98,o),
+(181,83,cs),
+(181,71,o),
+(193,58,o),
+(206,58,cs),
+(220,58,o),
+(231,71,o),
+(231,83,cs),
+(231,98,o),
+(220,108,o),
+(206,108,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(355,108,o),
+(343,98,o),
+(343,83,cs),
+(343,71,o),
+(355,58,o),
+(368,58,cs),
+(383,58,o),
+(393,71,o),
+(393,83,cs),
+(393,98,o),
+(383,108,o),
+(368,108,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(274,522,o),
+(262,511,o),
+(262,497,cs),
+(262,484,o),
+(274,471,o),
+(287,471,cs),
+(301,471,o),
+(312,484,o),
+(312,497,cs),
+(312,511,o),
+(301,522,o),
+(287,522,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(274,91,o),
+(262,80,o),
+(262,66,cs),
+(262,53,o),
+(274,41,o),
+(287,41,cs),
+(301,41,o),
+(312,53,o),
+(312,66,cs),
+(312,80,o),
+(301,91,o),
+(287,91,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(46,269,o),
+(59,256,o),
+(71,256,cs),
+(86,256,o),
+(97,269,o),
+(97,281,cs),
+(97,296,o),
+(86,306,o),
+(71,306,cs),
+(59,306,o),
+(46,296,o),
+(46,281,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(477,269,o),
+(490,256,o),
+(502,256,cs),
+(517,256,o),
+(527,269,o),
+(527,281,cs),
+(527,296,o),
+(517,306,o),
+(502,306,cs),
+(490,306,o),
+(477,296,o),
+(477,281,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(109,116,o),
+(122,103,o),
+(134,103,cs),
+(149,103,o),
+(159,116,o),
+(159,128,cs),
+(159,143,o),
+(149,154,o),
+(134,154,cs),
+(122,154,o),
+(109,143,o),
+(109,128,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(109,421,o),
+(122,409,o),
+(134,409,cs),
+(149,409,o),
+(159,421,o),
+(159,434,cs),
+(159,448,o),
+(149,459,o),
+(134,459,cs),
+(122,459,o),
+(109,448,o),
+(109,434,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(414,116,o),
+(427,103,o),
+(440,103,cs),
+(454,103,o),
+(465,116,o),
+(465,128,cs),
+(465,143,o),
+(454,154,o),
+(440,154,cs),
+(427,154,o),
+(414,143,o),
+(414,128,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(414,421,o),
+(427,409,o),
+(440,409,cs),
+(454,409,o),
+(465,421,o),
+(465,434,cs),
+(465,448,o),
+(454,459,o),
+(440,459,cs),
+(427,459,o),
+(414,448,o),
+(414,434,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(64,187,o),
+(76,175,o),
+(89,175,cs),
+(103,175,o),
+(114,187,o),
+(114,200,cs),
+(114,214,o),
+(103,225,o),
+(89,225,cs),
+(76,225,o),
+(64,214,o),
+(64,200,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(64,350,o),
+(76,337,o),
+(89,337,cs),
+(103,337,o),
+(114,350,o),
+(114,362,cs),
+(114,377,o),
+(103,387,o),
+(89,387,cs),
+(76,387,o),
+(64,377,o),
+(64,362,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(460,187,o),
+(472,175,o),
+(485,175,cs),
+(499,175,o),
+(510,187,o),
+(510,200,cs),
+(510,214,o),
+(499,225,o),
+(485,225,cs),
+(472,225,o),
+(460,214,o),
+(460,200,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(460,350,o),
+(472,337,o),
+(485,337,cs),
+(499,337,o),
+(510,350,o),
+(510,362,cs),
+(510,377,o),
+(499,387,o),
+(485,387,cs),
+(472,387,o),
+(460,377,o),
+(460,362,cs)
+);
+}
+);
+width = 574;
+}
+);
+note = uni25CC;
+unicode = 9676;
+},
+{
+glyphname = dotaccentcomb;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(47,709,o),
+(34,694,o),
+(34,667,cs),
+(34,640,o),
+(47,625,o),
+(73,625,cs),
+(100,625,o),
+(114,639,o),
+(114,667,cs),
+(114,694,o),
+(100,709,o),
+(73,709,cs)
+);
+}
+);
+width = 148;
+}
+);
+note = uni0307;
+unicode = 775;
+},
+{
+glyphname = dotaccent;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(101,625,o),
+(115,639,o),
+(115,667,cs),
+(115,694,o),
+(101,709,o),
+(74,709,cs),
+(48,709,o),
+(35,694,o),
+(35,667,cs),
+(35,639,o),
+(48,625,o),
+(74,625,cs)
+);
+}
+);
+width = 150;
+}
+);
+note = dotaccent;
+unicode = 729;
+},
+{
+glyphname = caron;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(214,623,o),
+(253,677,o),
+(297,730,c),
+(297,738,l),
+(254,738,l),
+(223,706,o),
+(192,668,o),
+(164,629,c),
+(138,666,o),
+(108,706,o),
+(77,738,c),
+(35,738,l),
+(35,730,l),
+(72,686,o),
+(109,636,o),
+(135,585,c),
+(194,585,l),
+(194,585,l)
+);
+}
+);
+width = 331;
+}
+);
+note = caron;
+unicode = 711;
+},
+{
+glyphname = breve;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(230,585,o),
+(273,629,o),
+(281,709,c),
+(240,709,l),
+(234,657,o),
+(208,629,o),
+(156,629,cs),
+(105,629,o),
+(81,657,o),
+(74,709,c),
+(35,709,l),
+(40,628,o),
+(83,585,o),
+(156,585,cs)
+);
+}
+);
+width = 315;
+}
+);
+note = breve;
+unicode = 728;
+},
+{
+glyphname = ring;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(180,588,o),
+(222,630,o),
+(222,691,cs),
+(222,748,o),
+(180,792,o),
+(128,792,cs),
+(75,792,o),
+(35,750,o),
+(35,691,cs),
+(35,629,o),
+(76,588,o),
+(128,588,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(94,625,o),
+(71,654,o),
+(71,691,cs),
+(71,727,o),
+(96,756,o),
+(128,756,cs),
+(159,756,o),
+(185,727,o),
+(185,691,cs),
+(185,654,o),
+(162,625,o),
+(128,625,cs)
+);
+}
+);
+width = 256;
+}
+);
+note = ring;
+unicode = 730;
+},
+{
+glyphname = ogonek;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(138,-214,o),
+(156,-211,o),
+(169,-206,c),
+(169,-164,l),
+(159,-168,o),
+(141,-172,o),
+(126,-172,cs),
+(96,-172,o),
+(80,-154,o),
+(80,-119,cs),
+(80,-74,o),
+(114,-36,o),
+(153,0,c),
+(124,14,l),
+(62,-37,o),
+(35,-82,o),
+(35,-128,cs),
+(35,-185,o),
+(71,-214,o),
+(118,-214,cs)
+);
+}
+);
+width = 204;
+}
+);
+note = ogonek;
+unicode = 731;
+},
+{
+glyphname = ring_top.canadian;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (120,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(173,757,o),
+(216,796,o),
+(216,853,cs),
+(216,909,o),
+(173,948,o),
+(120,948,cs),
+(67,948,o),
+(23,909,o),
+(23,853,cs),
+(23,796,o),
+(67,757,o),
+(120,757,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(82,790,o),
+(59,816,o),
+(59,853,cs),
+(59,889,o),
+(83,915,o),
+(120,915,cs),
+(156,915,o),
+(182,889,o),
+(182,853,cs),
+(182,816,o),
+(157,790,o),
+(120,790,cs)
+);
+}
+);
+width = 240;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (62,345);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(86,302,o),
+(105,321,o),
+(105,345,cs),
+(105,369,o),
+(86,387,o),
+(62,387,cs),
+(38,387,o),
+(19,369,o),
+(19,345,cs),
+(19,321,o),
+(38,302,o),
+(62,302,cs)
+);
+}
+);
+width = 124;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (58,345);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(79,306,o),
+(96,323,o),
+(96,345,cs),
+(96,367,o),
+(79,384,o),
+(58,384,cs),
+(36,384,o),
+(19,367,o),
+(19,345,cs),
+(19,323,o),
+(36,306,o),
+(58,306,cs)
+);
+}
+);
+width = 115;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_small;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (53,345);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(72,311,o),
+(87,326,o),
+(87,345,cs),
+(87,364,o),
+(72,379,o),
+(53,379,cs),
+(34,379,o),
+(19,364,o),
+(19,345,cs),
+(19,326,o),
+(34,311,o),
+(53,311,cs)
+);
+}
+);
+width = 106;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_top;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (62,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(86,788,o),
+(105,807,o),
+(105,831,cs),
+(105,855,o),
+(86,874,o),
+(62,874,cs),
+(38,874,o),
+(19,855,o),
+(19,831,cs),
+(19,807,o),
+(38,788,o),
+(62,788,cs)
+);
+}
+);
+width = 124;
+}
+);
+note = g725;
+},
+{
+glyphname = doubledot_middle;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(131,388,o),
+(150,407,o),
+(150,432,cs),
+(150,456,o),
+(131,474,o),
+(107,474,cs),
+(82,474,o),
+(64,456,o),
+(64,432,cs),
+(64,407,o),
+(82,388,o),
+(107,388,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(131,215,o),
+(150,234,o),
+(150,258,cs),
+(150,283,o),
+(131,301,o),
+(107,301,cs),
+(82,301,o),
+(64,283,o),
+(64,258,cs),
+(64,234,o),
+(82,215,o),
+(107,215,cs)
+);
+}
+);
+width = 214;
+}
+);
+metricRight = "=|";
+note = g725;
+},
+{
+glyphname = doubledot_top;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top_double;
+pos = (218,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(242,788,o),
+(262,807,o),
+(262,831,cs),
+(262,855,o),
+(242,874,o),
+(218,874,cs),
+(194,874,o),
+(176,855,o),
+(176,831,cs),
+(176,807,o),
+(194,788,o),
+(218,788,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(83,788,o),
+(102,807,o),
+(102,831,cs),
+(102,855,o),
+(83,874,o),
+(59,874,cs),
+(35,874,o),
+(16,855,o),
+(16,831,cs),
+(16,807,o),
+(35,788,o),
+(59,788,cs)
+);
+}
+);
+width = 277;
+}
+);
+note = g725;
+},
+{
+glyphname = g727;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (330,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(580,0,l),
+(580,53,l),
+(288,53,ls),
+(175,53,o),
+(132,99,o),
+(132,185,cs),
+(132,272,o),
+(175,319,o),
+(288,319,cs),
+(384,319,ls),
+(525,319,o),
+(590,387,o),
+(590,505,cs),
+(590,621,o),
+(525,690,o),
+(384,690,cs),
+(82,690,l),
+(82,637,l),
+(373,637,ls),
+(486,637,o),
+(528,590,o),
+(528,505,cs),
+(528,419,o),
+(486,372,o),
+(374,372,cs),
+(278,372,ls),
+(136,372,o),
+(71,302,o),
+(71,185,cs),
+(71,69,o),
+(136,0,o),
+(278,0,cs)
+);
+}
+);
+width = 661;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+glyphname = g728;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (269,0);
+ref = dot_top;
+}
+);
+width = 661;
+}
+);
+note = g728;
+},
+{
+glyphname = g729;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (331,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(384,0,ls),
+(525,0,o),
+(590,69,o),
+(590,185,cs),
+(590,302,o),
+(525,371,o),
+(384,371,cs),
+(288,371,ls),
+(175,371,o),
+(132,419,o),
+(132,504,cs),
+(132,590,o),
+(175,637,o),
+(288,637,cs),
+(580,637,l),
+(580,690,l),
+(277,690,ls),
+(136,690,o),
+(71,621,o),
+(71,504,cs),
+(71,387,o),
+(136,318,o),
+(277,318,cs),
+(373,318,ls),
+(486,318,o),
+(528,272,o),
+(528,185,cs),
+(528,99,o),
+(486,53,o),
+(373,53,cs),
+(81,53,l),
+(81,0,l)
+);
+}
+);
+width = 661;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+glyphname = g730;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (270,0);
+ref = dot_top;
+}
+);
+width = 661;
+}
+);
+note = g730;
+},
+{
+glyphname = g731;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = g727;
+}
+);
+width = 873;
+}
+);
+note = g731;
+},
+{
+glyphname = g732;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (661,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 873;
+}
+);
+note = g732;
+},
+{
+glyphname = g733;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (481,0);
+ref = dot_top;
+}
+);
+width = 873;
+}
+);
+note = g733;
+},
+{
+glyphname = g734;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (269,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (661,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 873;
+}
+);
+note = g734;
+},
+{
+glyphname = g735;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = g729;
+}
+);
+width = 873;
+}
+);
+note = g735;
+},
+{
+glyphname = g736;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (661,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 873;
+}
+);
+note = g736;
+},
+{
+glyphname = g737;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (482,0);
+ref = dot_top;
+}
+);
+width = 873;
+}
+);
+note = g737;
+},
+{
+glyphname = g738;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (270,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (661,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 873;
+}
+);
+note = g738;
+},
+{
+glyphname = g739;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(517,215,o),
+(565,268,o),
+(565,345,cs),
+(565,423,o),
+(518,477,o),
+(443,477,cs),
+(230,477,l),
+(232,457,l),
+(268,469,o),
+(292,517,o),
+(292,567,cs),
+(292,644,o),
+(244,696,o),
+(175,696,cs),
+(106,696,o),
+(58,643,o),
+(58,566,cs),
+(58,488,o),
+(105,434,o),
+(180,434,cs),
+(393,434,l),
+(391,454,l),
+(355,440,o),
+(331,394,o),
+(331,344,cs),
+(331,267,o),
+(379,215,o),
+(448,215,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(130,470,o),
+(99,508,o),
+(99,566,cs),
+(99,623,o),
+(130,659,o),
+(176,659,cs),
+(219,659,o),
+(251,622,o),
+(251,565,cs),
+(251,508,o),
+(220,470,o),
+(175,470,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(404,251,o),
+(373,288,o),
+(373,346,cs),
+(373,403,o),
+(403,440,o),
+(448,440,cs),
+(494,440,o),
+(525,403,o),
+(525,345,cs),
+(525,288,o),
+(493,251,o),
+(447,251,cs)
+);
+}
+);
+width = 623;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+glyphname = g740;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (211,0);
+ref = ring_top.canadian;
+}
+);
+width = 661;
+}
+);
+note = g740;
+},
+{
+glyphname = g741;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (212,0);
+ref = ring_top.canadian;
+}
+);
+width = 661;
+}
+);
+note = g741;
+},
+{
+glyphname = g742;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (423,0);
+ref = ring_top.canadian;
+}
+);
+width = 873;
+}
+);
+note = g742;
+},
+{
+glyphname = stroke_middle;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (40,345);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(60,454,l),
+(18,454,l),
+(18,236,l),
+(60,236,l)
+);
+}
+);
+width = 79;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (36,345);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(53,440,l),
+(18,440,l),
+(18,249,l),
+(53,249,l)
+);
+}
+);
+width = 72;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_small;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (34,345);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(49,439,l),
+(18,439,l),
+(18,251,l),
+(49,251,l)
+);
+}
+);
+width = 68;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_threequart;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (40,345);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(60,453,l),
+(19,453,l),
+(19,237,l),
+(60,237,l)
+);
+}
+);
+width = 79;
+}
+);
+note = g723;
+},
+{
+color = 8;
+glyphname = uni11AB0;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (147,690);
+},
+{
+name = top_right_can;
+pos = (444,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(178,0,l),
+(178,117,l),
+(422,117,l),
+(422,157,l),
+(178,157,l),
+(178,283,l),
+(133,258,l),
+(161,258,ls),
+(356,258,o),
+(475,387,o),
+(475,602,cs),
+(475,690,l),
+(413,690,l),
+(413,609,ls),
+(413,416,o),
+(320,314,o),
+(150,314,cs),
+(116,314,l),
+(116,157,l),
+(35,157,l),
+(35,117,l),
+(116,117,l),
+(116,0,l)
+);
+}
+);
+width = 552;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB1;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB0;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (384,0);
+ref = dot_top;
+}
+);
+width = 554;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB2;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (108,690);
+},
+{
+name = top_right_can;
+pos = (406,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(139,0,l),
+(139,81,ls),
+(139,273,o),
+(233,376,o),
+(403,376,cs),
+(437,376,l),
+(437,532,l),
+(518,532,l),
+(518,573,l),
+(437,573,l),
+(437,690,l),
+(375,690,l),
+(375,573,l),
+(131,573,l),
+(131,532,l),
+(375,532,l),
+(375,407,l),
+(418,432,l),
+(391,432,ls),
+(196,432,o),
+(77,302,o),
+(77,88,cs),
+(77,0,l)
+);
+}
+);
+width = 553;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "theThCree-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB3;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB2;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (344,0);
+ref = dot_top;
+}
+);
+width = 554;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB4;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (147,690);
+},
+{
+name = top_right_can;
+pos = (444,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(475,0,l),
+(475,88,ls),
+(475,302,o),
+(356,432,o),
+(161,432,cs),
+(133,432,l),
+(178,407,l),
+(178,532,l),
+(422,532,l),
+(422,573,l),
+(178,573,l),
+(178,690,l),
+(116,690,l),
+(116,573,l),
+(35,573,l),
+(35,532,l),
+(116,532,l),
+(116,376,l),
+(150,376,ls),
+(320,376,o),
+(413,273,o),
+(413,81,cs),
+(413,0,l)
+);
+}
+);
+width = 552;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB5;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB4;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (86,0);
+ref = dot_top;
+}
+);
+width = 554;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB6;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (111,690);
+},
+{
+name = top_right_can;
+pos = (409,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,0,l),
+(142,283,l),
+(99,258,l),
+(127,258,ls),
+(321,258,o),
+(440,387,o),
+(440,602,cs),
+(440,663,l),
+(400,648,l),
+(628,456,l),
+(662,498,l),
+(434,690,l),
+(378,690,l),
+(378,609,ls),
+(378,416,o),
+(284,314,o),
+(115,314,cs),
+(80,314,l),
+(80,0,l)
+);
+}
+);
+width = 690;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB7;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB6;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (347,0);
+ref = dot_top;
+}
+);
+width = 690;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB8;
+kernRight = soright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (280,690);
+},
+{
+name = top_right_can;
+pos = (578,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(311,0,l),
+(311,81,ls),
+(311,273,o),
+(406,376,o),
+(575,376,cs),
+(609,376,l),
+(609,690,l),
+(547,690,l),
+(547,407,l),
+(591,432,l),
+(563,432,ls),
+(368,432,o),
+(250,302,o),
+(250,88,cs),
+(250,27,l),
+(290,42,l),
+(62,234,l),
+(28,191,l),
+(256,0,l)
+);
+}
+);
+width = 689;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB9;
+kernRight = soright;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB8;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (516,0);
+ref = dot_top;
+}
+);
+width = 690;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABA;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (111,690);
+},
+{
+name = top_right_can;
+pos = (409,690);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(434,0,l),
+(662,191,l),
+(628,234,l),
+(400,42,l),
+(440,27,l),
+(440,88,ls),
+(440,302,o),
+(321,432,o),
+(127,432,cs),
+(99,432,l),
+(142,407,l),
+(142,690,l),
+(80,690,l),
+(80,376,l),
+(115,376,ls),
+(284,376,o),
+(378,273,o),
+(378,81,cs),
+(378,0,l)
+);
+}
+);
+width = 690;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABB;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = uni11ABA;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+}
+);
+width = 690;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABC;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(494,0,l),
+(494,56,l),
+(108,56,l),
+(108,29,l),
+(502,645,l),
+(502,690,l),
+(54,690,l),
+(54,634,l),
+(440,634,l),
+(440,661,l),
+(45,44,l),
+(45,0,l)
+);
+}
+);
+width = 547;
+}
+);
+metricRight = "=|";
+},
+{
+color = 8;
+glyphname = uni11ABD;
+lastChange = "2023-01-13 15:54:47 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(502,0,l),
+(502,44,l),
+(109,661,l),
+(109,634,l),
+(494,634,l),
+(494,690,l),
+(45,690,l),
+(45,645,l),
+(439,29,l),
+(439,56,l),
+(54,56,l),
+(54,0,l)
+);
+}
+);
+width = 547;
+}
+);
+metricLeft = "=|uni11ABC";
+metricRight = "=|uni11ABC";
+},
+{
+color = 8;
+glyphname = uni11ABE;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,0,l),
+(142,628,l),
+(108,628,l),
+(510,0,l),
+(565,0,l),
+(565,690,l),
+(504,690,l),
+(504,62,l),
+(538,62,l),
+(135,690,l),
+(80,690,l),
+(80,0,l)
+);
+}
+);
+width = 645;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABF;
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(135,0,l),
+(538,632,l),
+(504,632,l),
+(504,0,l),
+(565,0,l),
+(565,690,l),
+(510,690,l),
+(108,58,l),
+(142,58,l),
+(142,690,l),
+(80,690,l),
+(80,0,l)
+);
+}
+);
+width = 645;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = "raiseddoubledotFinal-canadian.cree";
+lastChange = "2023-01-13 15:54:43 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(132,615,o),
+(151,635,o),
+(151,659,cs),
+(151,683,o),
+(132,702,o),
+(108,702,cs),
+(83,702,o),
+(65,683,o),
+(65,659,cs),
+(65,635,o),
+(83,615,o),
+(108,615,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(132,442,o),
+(151,462,o),
+(151,486,cs),
+(151,510,o),
+(132,528,o),
+(108,528,cs),
+(83,528,o),
+(65,510,o),
+(65,486,cs),
+(65,462,o),
+(83,442,o),
+(108,442,cs)
+);
+}
+);
+width = 215;
+}
+);
+note = g725;
+}
+);
+instances = (
+{
+axesValues = (
+65,
+89,
+0
+);
+instanceInterpolations = {
+"C6C6CC8B-76AD-4983-B2A6-35FF5D496205" = 1;
+};
+name = "RC L roman";
+}
+);
+kerningLTR = {
+"C6C6CC8B-76AD-4983-B2A6-35FF5D496205" = {
+"@MMK_L_caright" = {
+"@MMK_R_ecanleft" = -77.28;
+"@MMK_R_mwestleft" = -27.048;
+"@MMK_R_neleft" = -61.824;
+};
+"@MMK_L_ciright" = {
+"@MMK_R_icanleft" = -77.28;
+"@MMK_R_noleft" = -104.328;
+};
+"@MMK_L_ecanright" = {
+"@MMK_R_coleft" = -77.28;
+"@MMK_R_moleft" = -79.212;
+"@MMK_R_sileft" = -47.334;
+};
+"@MMK_L_icanright" = {
+"@MMK_R_celeft" = -77.28;
+"@MMK_R_meleft" = -79.212;
+"@MMK_R_mwestleft" = -62.79;
+"@MMK_R_saleft" = -41.538;
+"she-canadian" = -79.212;
+};
+"@MMK_L_maright" = {
+"@MMK_R_acanleft" = -80.178;
+"@MMK_R_ecanleft" = -79.212;
+"@MMK_R_mwestleft" = -52.164;
+"@MMK_R_neleft" = -61.824;
+};
+"@MMK_L_miright" = {
+"@MMK_R_acanleft" = -80.178;
+"@MMK_R_icanleft" = -79.212;
+"@MMK_R_moleft" = -102.396;
+"@MMK_R_noleft" = -104.328;
+"@MMK_R_yeleft" = -105.294;
+};
+"@MMK_L_mwestright" = {
+"@MMK_R_coleft" = -27.048;
+"@MMK_R_icanleft" = -62.79;
+"@MMK_R_moleft" = -52.164;
+"@MMK_R_noleft" = -82.11;
+"@MMK_R_sileft" = -17.388;
+"@MMK_R_yeleft" = -28.98;
+};
+"@MMK_L_naright" = {
+"@MMK_R_acanleft" = -98.532;
+"@MMK_R_celeft" = -104.328;
+"@MMK_R_meleft" = -104.328;
+"@MMK_R_mwestleft" = -82.11;
+"@MMK_R_neleft" = -123.648;
+"@MMK_R_saleft" = -79.212;
+};
+"@MMK_L_niright" = {
+"@MMK_R_coleft" = -61.824;
+"@MMK_R_moleft" = -61.824;
+"@MMK_R_noleft" = -123.648;
+"@MMK_R_sileft" = -5.796;
+};
+"@MMK_L_ocanright" = {
+"@MMK_R_meleft" = -80.178;
+"@MMK_R_moleft" = -80.178;
+"@MMK_R_noleft" = -98.532;
+};
+"@MMK_L_seright" = {
+"@MMK_R_ecanleft" = -47.334;
+"@MMK_R_mwestleft" = -17.388;
+"@MMK_R_neleft" = -3.864;
+};
+"@MMK_L_soright" = {
+"@MMK_R_icanleft" = -41.538;
+"@MMK_R_noleft" = -79.212;
+};
+"@MMK_L_yiright" = {
+"@MMK_R_meleft" = -105.294;
+"@MMK_R_mwestleft" = -28.98;
+};
+"shi-canadian" = {
+"@MMK_R_icanleft" = -79.212;
+};
+};
+};
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "italic angle";
+}
+);
+properties = (
+{
+key = copyrights;
+values = (
+{
+language = ENG;
+value = "Copyright 2018 Google Inc. All Rights Reserved.";
+}
+);
+},
+{
+key = manufacturers;
+values = (
+{
+language = ENG;
+value = "Monotype Imaging Inc.";
+}
+);
+},
+{
+key = designers;
+values = (
+{
+language = ENG;
+value = "Monotype Design Team";
+}
+);
+},
+{
+key = description;
+value = "Designed by Monotype design team.";
+},
+{
+key = trademarks;
+values = (
+{
+language = ENG;
+value = "Noto is a trademark of Google Inc.";
+}
+);
+},
+{
+key = licenseURL;
+value = "http://scripts.sil.org/OFL";
+},
+{
+key = licenses;
+values = (
+{
+language = ENG;
+value = "This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.";
+}
+);
+},
+{
+key = manufacturerURL;
+value = "http://www.google.com/get/noto/";
+},
+{
+key = designerURL;
+value = "http://www.monotype.com/studio";
+}
+);
+settings = {
+disablesNiceNames = 1;
+};
+stems = (
+{
+name = "New Stem";
+}
+);
+unitsPerEm = 966;
+userData = {
+GSDontShowVersionAlert = 1;
+};
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/sources/Exported instances UCAS SansCanadianAboriginal Resized/Sans Canadian Aboriginal-RC R Italic.glyphs
+++ b/sources/Exported instances UCAS SansCanadianAboriginal Resized/Sans Canadian Aboriginal-RC R Italic.glyphs
@@ -1,0 +1,37331 @@
+{
+.appVersion = "3151";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+},
+{
+name = Width;
+tag = wdth;
+},
+{
+name = Slant;
+tag = slnt;
+}
+);
+classes = (
+{
+code = "zero one two three four five six seven eight nine ";
+name = Num;
+},
+{
+code = "zero.canadian one.canadian two.canadian three.canadian four.canadian five.canadian six.canadian seven.canadian eight.canadian nine.canadian 
+";
+name = Num_can;
+},
+{
+code = "ke-canadian.square ki-canadian.square kii-canadian.square ko-canadian.square koo-canadian.square ka-canadian.square kaa-canadian.square kweWestCree-canadian.square kwiiWestCree-canadian.square kwoWestCree-canadian.square kwooWestCree-canadian.square kwaWestCree-canadian.square kwaaWestCree-canadian.square ce-canadian.square ci-canadian.square cii-canadian.square co-canadian.square coo-canadian.square ca-canadian.square caa-canadian.square me-canadian.square mi-canadian.square mii-canadian.square mo-canadian.square moo-canadian.square ma-canadian.square maa-canadian.square ne-canadian.square ni-canadian.square nii-canadian.square no-canadian.square noo-canadian.square na-canadian.square naa-canadian.square nweWestCree-canadian.square nwaWestCree-canadian.square nwaaWestCree-canadian.square se-canadian.square si-canadian.square sii-canadian.square so-canadian.square soo-canadian.square sa-canadian.square saa-canadian.square sho-canadian.square shoo-canadian.square sha-canadian.square shaa-canadian.square ye-canadian.square yi-canadian.square yii-canadian.square yo-canadian.square yoo-canadian.square ya-canadian.square yaa-canadian.square re-canadian.square reRCree-canadian.square leWestCree-canadian.square ri-canadian.square rii-canadian.square ro-canadian.square loWestCree-canadian.square ra-canadian.square raa-canadian.square laWestCree-canadian.square reWestCree-canadian.square riWestCree-canadian.square roWestCree-canadian.square raWestCree-canadian.square theThCree-canadian.square thiThCree-canadian.square thiiThCree-canadian.square thoThCree-canadian.square thooThCree-canadian.square thaThCree-canadian.square thaaThCree-canadian.square thweeWoodScree-canadian.square thwiWoodScree-canadian.square thwiiWoodScree-canadian.square thwoWoodScree-canadian.square thwooWoodScree-canadian.square thwaWoodScree-canadian.square thwaaWoodScree-canadian.square nwiOjibway-canadian.square nwiiOjibway-canadian.square nwoOjibway-canadian.square nwooOjibway-canadian.square looWestCree-canadian.square laaWestCree-canadian.square ";
+name = Dene_square;
+},
+{
+code = "ke-canadian ki-canadian kii-canadian ko-canadian koo-canadian ka-canadian kaa-canadian kweWestCree-canadian kwiiWestCree-canadian kwoWestCree-canadian kwooWestCree-canadian kwaWestCree-canadian kwaaWestCree-canadian ce-canadian ci-canadian cii-canadian co-canadian coo-canadian ca-canadian caa-canadian me-canadian mi-canadian mii-canadian mo-canadian moo-canadian ma-canadian maa-canadian ne-canadian ni-canadian nii-canadian no-canadian noo-canadian na-canadian naa-canadian nweWestCree-canadian nwaWestCree-canadian nwaaWestCree-canadian se-canadian si-canadian sii-canadian so-canadian soo-canadian sa-canadian saa-canadian sho-canadian shoo-canadian sha-canadian shaa-canadian ye-canadian yi-canadian yii-canadian yo-canadian yoo-canadian ya-canadian yaa-canadian re-canadian reRCree-canadian leWestCree-canadian ri-canadian rii-canadian ro-canadian loWestCree-canadian ra-canadian raa-canadian laWestCree-canadian reWestCree-canadian riWestCree-canadian roWestCree-canadian raWestCree-canadian theThCree-canadian thiThCree-canadian thiiThCree-canadian thoThCree-canadian thooThCree-canadian thaThCree-canadian thaaThCree-canadian thweeWoodScree-canadian thwiWoodScree-canadian thwiiWoodScree-canadian thwoWoodScree-canadian thwooWoodScree-canadian thwaWoodScree-canadian thwaaWoodScree-canadian nwiOjibway-canadian nwiiOjibway-canadian nwoOjibway-canadian nwooOjibway-canadian looWestCree-canadian laaWestCree-canadian 
+";
+name = Dene_round;
+},
+{
+code = "acuteFinal-canadian.mid graveFinal-canadian.mid ringTophalfFinal-canadian.mid ringRighthalfFinal-canadian.mid ringFinal-canadian.mid doubleacuteFinal-canadian.mid doubleshortverticalstrokesFinal-canadian.mid shorthorizontalstrokeFinal-canadian.mid downtackFinal-canadian.mid pWestCree-canadian.mid c-canadian.mid mWestCree-canadian.mid ";
+name = Final_mid;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian ringFinal-canadian doubleacuteFinal-canadian doubleshortverticalstrokesFinal-canadian shorthorizontalstrokeFinal-canadian downtackFinal-canadian pWestCree-canadian c-canadian mWestCree-canadian ";
+name = Final_mid_ori;
+},
+{
+code = "acuteFinal-canadian.base graveFinal-canadian.base ringBottomhalfFinal-canadian.base ringTophalfFinal-canadian.base ringRighthalfFinal-canadian.base plusFinal-canadian.base pWestCree-canadian.base c-canadian.base thSayisi-canadian.base mWestCree-canadian.base ";
+name = Final_base;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringBottomhalfFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian plusFinal-canadian pWestCree-canadian c-canadian thSayisi-canadian mWestCree-canadian ";
+name = Final_base_ori;
+},
+{
+code = "ng-canadian ngai-canadian ngaai-canadian ngi-canadian ngii-canadian ngo-canadian ngoo-canadian nga-canadian ngaa-canadian ";
+name = Nunavik;
+},
+{
+code = "ng-canadian.nunavik ngai-canadian.nunavik ngaai-canadian.nunavik ngi-canadian.nunavik ngii-canadian.nunavik ngo-canadian.nunavik ngoo-canadian.nunavik nga-canadian.nunavik ngaa-canadian.nunavik ";
+name = Nunavik_alt;
+}
+);
+customParameters = (
+{
+name = vendorID;
+value = GOOG;
+},
+{
+name = panose;
+value = (
+2,
+11,
+5,
+2,
+4,
+5,
+4,
+2,
+2,
+4
+);
+},
+{
+name = unicodeRanges;
+value = (
+0,
+1,
+2,
+5,
+6,
+45,
+77
+);
+},
+{
+name = codePageRanges;
+value = (
+"1252"
+);
+},
+{
+name = fsType;
+value = (
+);
+}
+);
+date = "2022-06-21 10:06:40 +0000";
+familyName = "Sans Canadian Aboriginal";
+featurePrefixes = (
+{
+automatic = 1;
+code = "languagesystem DFLT dflt;
+
+languagesystem cans dflt;
+";
+name = Languagesystems;
+}
+);
+features = (
+{
+automatic = 1;
+code = "feature ss01;
+feature ss02;
+feature ss03;
+feature ss04;
+";
+tag = aalt;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+tag = salt;
+},
+{
+code = "lookup space_can {
+sub space by space.canadian;
+} space_can;
+
+lookup num_can {
+sub @Num by @Num_can;
+} num_can;
+";
+labels = (
+{
+language = dflt;
+value = "CAN Space and numerals";
+}
+);
+tag = ss01;
+},
+{
+code = "lookup dene_square {
+sub @Dene_round by @Dene_square;
+} dene_square;
+
+";
+labels = (
+{
+language = dflt;
+value = "Dene Square";
+}
+);
+tag = ss02;
+},
+{
+code = "lookup nunavik_alt {
+sub @Nunavik by @Nunavik_alt;
+} nunavik_alt;
+
+";
+labels = (
+{
+language = dflt;
+value = "Nunanvik Alt";
+}
+);
+tag = ss03;
+},
+{
+code = "lookup final_mid {
+sub @Final_mid_ori by @Final_mid;
+} final_mid;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final mid";
+}
+);
+tag = ss04;
+},
+{
+code = "lookup final_base {
+sub @Final_base_ori by @Final_base;
+} final_base;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final base";
+}
+);
+tag = ss05;
+},
+{
+code = "lookup plaincree_first {
+sub wiWestCree-canadian' plusFinal-canadian by i-canadian;
+} plaincree_first;
+
+lookup plaincree_second {
+sub i-canadian plusFinal-canadian' by raiseddoubledotFinal-canadian.cree;
+} plaincree_second;
+
+lookup plaincree_third {
+sub middledotFinal-canadian plusFinal-canadian by raiseddoubledotFinal-canadian.cree;
+} plaincree_third;
+";
+labels = (
+{
+language = dflt;
+value = Plaincree;
+}
+);
+tag = ss06;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+labels = (
+{
+language = dflt;
+value = "";
+}
+);
+tag = ss07;
+}
+);
+fontMaster = (
+{
+axesValues = (
+0,
+0,
+0
+);
+customParameters = (
+{
+name = typoAscender;
+value = 1033;
+},
+{
+name = typoDescender;
+value = -283;
+},
+{
+name = typoLineGap;
+value = 0;
+},
+{
+name = winAscent;
+value = 1033;
+},
+{
+name = winDescent;
+value = 283;
+},
+{
+name = hheaAscender;
+value = 1033;
+},
+{
+name = hheaDescender;
+value = -283;
+},
+{
+name = strikeoutPosition;
+value = 287;
+},
+{
+name = strikeoutSize;
+value = 48;
+},
+{
+name = "Master Icon Glyph Name";
+value = s;
+}
+);
+guides = (
+{
+lockAngle = 1;
+locked = 1;
+pos = (747,345);
+},
+{
+locked = 1;
+pos = (-52,-12);
+},
+{
+locked = 1;
+pos = (109,701);
+},
+{
+locked = 1;
+pos = (750,357);
+},
+{
+locked = 1;
+pos = (746,332);
+}
+);
+id = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+metricValues = (
+{
+over = 18;
+pos = 1033;
+},
+{
+over = 18;
+pos = 690;
+},
+{
+over = 18;
+pos = 479;
+},
+{
+over = -18;
+},
+{
+over = -18;
+pos = -283;
+},
+{
+pos = 12;
+}
+);
+name = "RC L Italic";
+stemValues = (
+96
+);
+}
+);
+glyphs = (
+{
+glyphname = idotless;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(116,0,l),
+(226,521,l),
+(131,521,l),
+(20,0,l)
+);
+}
+);
+width = 239;
+}
+);
+note = dotlessi;
+unicode = 305;
+},
+{
+glyphname = "acuteFinal-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(144,345,l),
+(373,690,l),
+(292,690,l),
+(63,345,l)
+);
+}
+);
+width = 318;
+}
+);
+metricRight = "=|";
+note = uni141F;
+unicode = 5151;
+},
+{
+glyphname = "graveFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(300,345,l),
+(210,690,l),
+(137,690,l),
+(228,345,l)
+);
+}
+);
+width = 319;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+unicode = 5152;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(341,339,o),
+(392,390,o),
+(412,478,cs),
+(456,690,l),
+(388,690,l),
+(346,491,ls),
+(332,429,o),
+(304,402,o),
+(251,402,cs),
+(195,402,o),
+(174,434,o),
+(186,496,cs),
+(228,690,l),
+(159,690,l),
+(120,499,ls),
+(99,400,o),
+(145,339,o),
+(246,339,cs)
+);
+}
+);
+width = 424;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1421;
+unicode = 5153;
+},
+{
+glyphname = "ringTophalfFinal-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(154,345,l),
+(196,544,ls),
+(209,606,o),
+(238,633,o),
+(291,633,cs),
+(347,633,o),
+(368,601,o),
+(354,539,cs),
+(314,345,l),
+(382,345,l),
+(422,535,ls),
+(443,635,o),
+(397,696,o),
+(296,696,cs),
+(201,696,o),
+(150,644,o),
+(130,556,cs),
+(85,345,l)
+);
+}
+);
+width = 423;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+unicode = 5154;
+},
+{
+glyphname = "ringRighthalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(161,345,ls),
+(300,345,o),
+(370,440,o),
+(370,554,cs),
+(370,638,o),
+(317,690,o),
+(226,690,cs),
+(157,690,l),
+(144,626,l),
+(216,626,ls),
+(273,626,o),
+(301,598,o),
+(301,548,cs),
+(301,485,o),
+(271,409,o),
+(170,409,cs),
+(98,409,l),
+(84,345,l)
+);
+}
+);
+width = 369;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+unicode = 5155;
+},
+{
+glyphname = "ringFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(395,355,o),
+(469,428,o),
+(469,526,cs),
+(469,623,o),
+(393,696,o),
+(295,696,cs),
+(196,696,o),
+(122,623,o),
+(122,526,cs),
+(122,428,o),
+(194,355,o),
+(295,355,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(229,414,o),
+(185,462,o),
+(185,526,cs),
+(185,589,o),
+(230,637,o),
+(295,637,cs),
+(358,637,o),
+(404,589,o),
+(404,526,cs),
+(404,462,o),
+(359,414,o),
+(295,414,cs)
+);
+}
+);
+width = 468;
+}
+);
+note = uni1424;
+unicode = 5156;
+},
+{
+glyphname = "doubleacuteFinal-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,345,l),
+(373,690,l),
+(294,690,l),
+(63,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(294,345,l),
+(524,690,l),
+(444,690,l),
+(213,345,l)
+);
+}
+);
+width = 469;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricRight = "=|";
+note = uni1425;
+unicode = 5157;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(155,345,l),
+(228,690,l),
+(159,690,l),
+(86,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(289,345,l),
+(362,690,l),
+(295,690,l),
+(221,345,l)
+);
+}
+);
+width = 330;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "pWestCree-canadian";
+note = uni1426;
+unicode = 5158;
+},
+{
+glyphname = "middledotFinal-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(167,299,o),
+(191,324,o),
+(191,355,cs),
+(191,385,o),
+(167,410,o),
+(136,410,cs),
+(106,410,o),
+(82,385,o),
+(82,355,cs),
+(82,324,o),
+(106,299,o),
+(136,299,cs)
+);
+}
+);
+width = 224;
+}
+);
+note = uni1427;
+unicode = 5159;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(436,489,l),
+(450,557,l),
+(130,557,l),
+(115,489,l)
+);
+}
+);
+width = 445;
+}
+);
+metricRight = "=|";
+note = uni1428;
+unicode = 5160;
+},
+{
+glyphname = "plusFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(283,362,l),
+(311,496,l),
+(438,496,l),
+(451,559,l),
+(325,559,l),
+(353,690,l),
+(285,690,l),
+(258,559,l),
+(130,559,l),
+(117,496,l),
+(244,496,l),
+(215,362,l)
+);
+}
+);
+width = 445;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+unicode = 5161;
+},
+{
+glyphname = "downtackFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(280,345,l),
+(339,625,l),
+(465,625,l),
+(479,690,l),
+(158,690,l),
+(144,625,l),
+(270,625,l),
+(212,345,l)
+);
+}
+);
+width = 445;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni142A;
+unicode = 5162;
+},
+{
+glyphname = "thFinalWoodScree-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(282,345,l),
+(298,420,l),
+(422,420,l),
+(435,476,l),
+(310,476,l),
+(327,558,l),
+(452,558,l),
+(464,614,l),
+(340,614,l),
+(355,690,l),
+(287,690,l),
+(271,614,l),
+(144,614,l),
+(132,558,l),
+(259,558,l),
+(242,476,l),
+(115,476,l),
+(102,420,l),
+(230,420,l),
+(213,345,l)
+);
+}
+);
+width = 449;
+}
+);
+metricLeft = "hyphen-canadian";
+metricRight = "hyphen-canadian";
+note = uni167E;
+unicode = 5758;
+},
+{
+glyphname = "ringSmallFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(301,499,o),
+(350,541,o),
+(350,601,cs),
+(350,661,o),
+(301,702,o),
+(244,702,cs),
+(188,702,o),
+(141,661,o),
+(141,601,cs),
+(141,541,o),
+(188,499,o),
+(244,499,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(211,544,o),
+(189,569,o),
+(189,601,cs),
+(189,633,o),
+(213,658,o),
+(245,658,cs),
+(279,658,o),
+(301,633,o),
+(301,601,cs),
+(301,569,o),
+(279,544,o),
+(245,544,cs)
+);
+}
+);
+width = 337;
+}
+);
+note = g725;
+unicode = 6366;
+},
+{
+glyphname = "raiseddotFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(231,593,o),
+(255,617,o),
+(255,648,cs),
+(255,678,o),
+(231,702,o),
+(200,702,cs),
+(169,702,o),
+(145,678,o),
+(145,648,cs),
+(145,617,o),
+(169,593,o),
+(200,593,cs)
+);
+}
+);
+width = 226;
+}
+);
+note = g725;
+unicode = 6367;
+},
+{
+glyphname = "acuteFinal-canadian.base";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-73,-345);
+ref = "acuteFinal-canadian";
+}
+);
+width = 318;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.base";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-73,-345);
+ref = "graveFinal-canadian";
+}
+);
+width = 318;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian.base";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-74,-345);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 424;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1421;
+},
+{
+glyphname = "ringTophalfFinal-canadian.base";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-73,-345);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 423;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.base";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-73,-345);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 369;
+}
+);
+metricLeft = "==|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "plusFinal-canadian.base";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(206,0,l),
+(234,133,l),
+(360,133,l),
+(374,197,l),
+(248,197,l),
+(275,327,l),
+(209,327,l),
+(181,197,l),
+(53,197,l),
+(40,133,l),
+(167,133,l),
+(139,0,l)
+);
+}
+);
+width = 445;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+},
+{
+glyphname = "acuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-34,-162);
+ref = "acuteFinal-canadian";
+}
+);
+width = 318;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.mid";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-162);
+ref = "graveFinal-canadian";
+}
+);
+width = 318;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringTophalfFinal-canadian.mid";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-37,-172);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 424;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.mid";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-162);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 369;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "ringFinal-canadian.mid";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-38,-181);
+ref = "ringFinal-canadian";
+}
+);
+width = 468;
+}
+);
+metricLeft = "ringFinal-canadian";
+metricWidth = "ringFinal-canadian";
+note = uni1424;
+},
+{
+glyphname = "doubleacuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-34,-162);
+ref = "doubleacuteFinal-canadian";
+}
+);
+width = 469;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "doubleacuteFinal-canadian";
+note = uni1425;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian.mid";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-162);
+ref = "doubleshortverticalstrokesFinal-canadian";
+}
+);
+width = 330;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricWidth = "doubleshortverticalstrokesFinal-canadian";
+note = uni1426;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian.mid";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "shorthorizontalstrokeFinal-canadian";
+}
+);
+width = 445;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "shorthorizontalstrokeFinal-canadian";
+note = uni1428;
+},
+{
+glyphname = "downtackFinal-canadian.mid";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-34,-162);
+ref = "downtackFinal-canadian";
+}
+);
+width = 445;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "downtackFinal-canadian";
+note = uni142A;
+},
+{
+glyphname = "e-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (401,454);
+},
+{
+name = top_center_can;
+pos = (452,690);
+},
+{
+name = top_left_can;
+pos = (225,690);
+},
+{
+name = top_right_can;
+pos = (679,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(326,0,l),
+(774,664,l),
+(780,690,l),
+(128,690,l),
+(123,664,l),
+(290,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(343,113,l),
+(221,633,l),
+(206,611,l),
+(668,611,l),
+(650,633,l),
+(309,113,l)
+);
+}
+);
+width = 716;
+}
+);
+metricRight = "=|";
+note = uni1401;
+unicode = 5121;
+},
+{
+glyphname = "aai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (234,0);
+ref = ring_top.canadian;
+}
+);
+width = 717;
+}
+);
+note = uni1402;
+unicode = 5122;
+},
+{
+glyphname = "i-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (388,355);
+},
+{
+name = top_center_can;
+pos = (454,690);
+},
+{
+name = top_left_can;
+pos = (227,690);
+},
+{
+name = top_right_can;
+pos = (681,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(436,690,l),
+(-13,26,l),
+(-18,0,l),
+(633,0,l),
+(639,26,l),
+(471,690,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(418,577,l),
+(540,57,l),
+(555,79,l),
+(93,79,l),
+(111,57,l),
+(452,577,l)
+);
+}
+);
+width = 716;
+}
+);
+metricLeft = "e-canadian";
+metricWidth = "e-canadian";
+note = uni1403;
+unicode = 5123;
+},
+{
+glyphname = "ii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (285,0);
+ref = dot_top;
+}
+);
+width = 717;
+}
+);
+note = uni1404;
+unicode = 5124;
+},
+{
+glyphname = "o-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (298,354);
+},
+{
+name = top_center_can;
+pos = (455,690);
+},
+{
+name = top_double;
+pos = (550,690);
+},
+{
+name = top_left_can;
+pos = (213,690);
+},
+{
+name = top_right_can;
+pos = (695,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(50,0,l),
+(662,327,l),
+(669,362,l),
+(197,690,l),
+(172,690,l),
+(25,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(232,588,l),
+(203,592,l),
+(560,342,l),
+(563,363,l),
+(102,114,l),
+(129,106,l)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1405;
+unicode = 5125;
+},
+{
+glyphname = "oo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (43,0);
+ref = dot_top;
+}
+);
+width = 677;
+}
+);
+note = uni1406;
+unicode = 5126;
+},
+{
+glyphname = "yCreeoo-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (213,0);
+ref = doubledot_top;
+}
+);
+width = 677;
+}
+);
+note = uni1407;
+unicode = 5127;
+},
+{
+glyphname = "eeCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(50,0,l),
+(662,327,l),
+(669,362,l),
+(197,690,l),
+(172,690,l),
+(25,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(230,588,l),
+(208,589,l),
+(562,342,l),
+(567,364,l),
+(106,116,l),
+(128,106,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(297,269,l),
+(331,433,l),
+(294,433,l),
+(259,269,l)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "o-canadian";
+note = uni1408;
+unicode = 5128;
+},
+{
+glyphname = "iCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (219,9);
+ref = dot_middle_optic_small;
+}
+);
+width = 677;
+}
+);
+note = uni1409;
+unicode = 5129;
+},
+{
+glyphname = "a-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:54:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (413,341);
+},
+{
+name = top_center_can;
+pos = (409,690);
+},
+{
+name = top_left_can;
+pos = (173,690);
+},
+{
+name = top_right_can;
+pos = (655,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(671,690,l),
+(60,362,l),
+(52,327,l),
+(525,0,l),
+(551,0,l),
+(697,690,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(490,101,l),
+(519,98,l),
+(161,348,l),
+(158,327,l),
+(619,576,l),
+(592,583,l)
+);
+}
+);
+width = 678;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni140A;
+unicode = 5130;
+},
+{
+glyphname = "aa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (486,0);
+ref = dot_top;
+}
+);
+width = 677;
+}
+);
+note = uni140B;
+unicode = 5131;
+},
+{
+glyphname = "we-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "e-canadian";
+}
+);
+width = 941;
+}
+);
+note = uni140C;
+unicode = 5132;
+},
+{
+glyphname = "weWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (717,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 941;
+}
+);
+note = uni140D;
+unicode = 5133;
+},
+{
+glyphname = "wi-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "i-canadian";
+}
+);
+width = 941;
+}
+);
+note = uni140E;
+unicode = 5134;
+},
+{
+glyphname = "wiWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (717,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 941;
+}
+);
+note = uni140F;
+unicode = 5135;
+},
+{
+glyphname = "wii-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (509,0);
+ref = dot_top;
+}
+);
+width = 941;
+}
+);
+note = uni1410;
+unicode = 5136;
+},
+{
+glyphname = "wiiWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (285,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (717,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 941;
+}
+);
+note = uni1411;
+unicode = 5137;
+},
+{
+glyphname = "wo-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "o-canadian";
+}
+);
+width = 901;
+}
+);
+note = uni1412;
+unicode = 5138;
+},
+{
+glyphname = "woWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (677,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 901;
+}
+);
+note = uni1413;
+unicode = 5139;
+},
+{
+glyphname = "woo-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (510,0);
+ref = dot_top;
+}
+);
+width = 901;
+}
+);
+note = uni1414;
+unicode = 5140;
+},
+{
+glyphname = "wooWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (43,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (677,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 901;
+}
+);
+note = uni1415;
+unicode = 5141;
+},
+{
+glyphname = "wooNaskapi-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (181,-96);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (338,-203);
+ref = dot_top;
+}
+);
+width = 677;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricWidth = "o-canadian";
+note = uni1416;
+unicode = 5142;
+},
+{
+glyphname = "wa-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "a-canadian";
+}
+);
+width = 901;
+}
+);
+note = uni1417;
+unicode = 5143;
+},
+{
+glyphname = "waWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (677,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 901;
+}
+);
+note = uni1418;
+unicode = 5144;
+},
+{
+glyphname = "waa-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (710,0);
+ref = dot_top;
+}
+);
+width = 901;
+}
+);
+note = uni1419;
+unicode = 5145;
+},
+{
+glyphname = "waaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (486,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (677,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 901;
+}
+);
+note = uni141A;
+unicode = 5146;
+},
+{
+glyphname = "waaNaskapi-canadian";
+lastChange = "2023-01-13 15:54:25 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (126,-201);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (321,-96);
+ref = dot_top;
+}
+);
+width = 678;
+}
+);
+metricWidth = "a-canadian";
+note = uni141B;
+unicode = 5147;
+},
+{
+glyphname = "ai-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(296,339,o),
+(336,368,o),
+(365,427,c),
+(346,430,l),
+(351,370,o),
+(388,339,o),
+(455,339,cs),
+(545,339,o),
+(593,386,o),
+(616,492,cs),
+(658,690,l),
+(593,690,l),
+(552,490,ls),
+(538,426,o),
+(510,399,o),
+(458,399,cs),
+(405,399,o),
+(385,428,o),
+(399,491,cs),
+(441,690,l),
+(377,690,l),
+(334,491,ls),
+(321,427,o),
+(292,399,o),
+(242,399,cs),
+(190,399,o),
+(169,430,o),
+(182,490,cs),
+(224,690,l),
+(159,690,l),
+(118,492,ls),
+(99,399,o),
+(144,339,o),
+(234,339,cs)
+);
+}
+);
+width = 625;
+}
+);
+metricRight = "=|";
+note = uni141C;
+unicode = 5148;
+},
+{
+glyphname = "ycreew-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(423,510,o),
+(460,549,o),
+(460,603,cs),
+(460,658,o),
+(424,696,o),
+(375,696,cs),
+(325,696,o),
+(288,658,o),
+(288,603,cs),
+(288,549,o),
+(325,510,o),
+(374,510,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(241,339,o),
+(276,378,o),
+(276,432,cs),
+(276,487,o),
+(241,525,o),
+(191,525,cs),
+(142,525,o),
+(104,487,o),
+(104,432,cs),
+(104,378,o),
+(141,339,o),
+(190,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(162,375,o),
+(143,398,o),
+(143,432,cs),
+(143,466,o),
+(162,489,o),
+(190,489,cs),
+(219,489,o),
+(239,466,o),
+(239,432,cs),
+(239,398,o),
+(219,375,o),
+(190,375,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(345,546,o),
+(327,569,o),
+(327,603,cs),
+(327,637,o),
+(346,660,o),
+(374,660,cs),
+(402,660,o),
+(421,637,o),
+(421,603,cs),
+(421,569,o),
+(402,546,o),
+(374,546,cs)
+);
+}
+);
+width = 446;
+}
+);
+metricRight = "=|";
+note = uni141D;
+unicode = 5149;
+},
+{
+glyphname = "glottalstop-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(403,345,l),
+(407,359,l),
+(323,690,l),
+(304,690,l),
+(80,359,l),
+(77,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(321,626,l),
+(287,627,l),
+(347,374,l),
+(363,396,l),
+(140,396,l),
+(153,374,l)
+);
+}
+);
+width = 437;
+}
+);
+metricRight = "=|";
+note = uni141E;
+unicode = 5150;
+},
+{
+glyphname = "en-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+pos = (717,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni142B;
+unicode = 5163;
+},
+{
+glyphname = "in-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+pos = (490,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 808;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142C;
+unicode = 5164;
+},
+{
+glyphname = "on-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (534,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 852;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142D;
+unicode = 5165;
+},
+{
+glyphname = "an-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (632,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 950;
+}
+);
+metricRight = "graveFinal-canadian";
+note = uni142E;
+unicode = 5166;
+},
+{
+glyphname = "pe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (397,454);
+},
+{
+name = top_center_can;
+pos = (454,690);
+},
+{
+name = top_left_can;
+pos = (225,690);
+},
+{
+name = top_right_can;
+pos = (679,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(325,0,l),
+(774,664,l),
+(780,690,l),
+(680,690,l),
+(298,114,l),
+(352,114,l),
+(214,690,l),
+(128,690,l),
+(123,664,l),
+(290,0,l)
+);
+}
+);
+width = 716;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni142F;
+unicode = 5167;
+},
+{
+glyphname = "paai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (234,0);
+ref = ring_top.canadian;
+}
+);
+width = 717;
+}
+);
+note = uni1430;
+unicode = 5168;
+},
+{
+glyphname = "pi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (389,355);
+},
+{
+name = top_center_can;
+pos = (454,690);
+},
+{
+name = top_left_can;
+pos = (225,690);
+},
+{
+name = top_right_can;
+pos = (679,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(437,690,l),
+(-13,26,l),
+(-18,0,l),
+(81,0,l),
+(464,576,l),
+(410,576,l),
+(547,0,l),
+(633,0,l),
+(639,26,l),
+(471,690,l)
+);
+}
+);
+width = 716;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni1431;
+unicode = 5169;
+},
+{
+glyphname = "pii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (285,0);
+ref = dot_top;
+}
+);
+width = 717;
+}
+);
+note = uni1432;
+unicode = 5170;
+},
+{
+glyphname = "po-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (231,355);
+},
+{
+name = top_center_can;
+pos = (429,690);
+},
+{
+name = top_double;
+pos = (529,690);
+},
+{
+name = top_left_can;
+pos = (191,690);
+},
+{
+name = top_right_can;
+pos = (667,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+name = "Thin Slanted";
+shapes = (
+{
+closed = 1;
+nodes = (
+(28,0,l),
+(635,327,l),
+(641,362,l),
+(175,690,l),
+(149,690,l),
+(132,610,l),
+(526,332,l),
+(535,376,l),
+(23,99,l),
+(3,0,l)
+);
+}
+);
+width = 650;
+}
+);
+metricRight = "o-canadian";
+note = uni1433;
+unicode = 5171;
+},
+{
+glyphname = "poo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (21,0);
+ref = dot_top;
+}
+);
+width = 649;
+}
+);
+note = uni1434;
+unicode = 5172;
+},
+{
+glyphname = "ycreepoo-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (192,0);
+ref = doubledot_top;
+}
+);
+width = 649;
+}
+);
+note = uni1435;
+unicode = 5173;
+},
+{
+glyphname = "heeCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (167,11);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 649;
+}
+);
+note = uni1436;
+unicode = 5174;
+},
+{
+glyphname = "hiCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (145,14);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 649;
+}
+);
+note = uni1437;
+unicode = 5175;
+},
+{
+glyphname = "pa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (348,345);
+},
+{
+name = top_center_can;
+pos = (412,690);
+},
+{
+name = top_left_can;
+pos = (174,690);
+},
+{
+name = top_right_can;
+pos = (650,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(666,690,l),
+(60,362,l),
+(53,327,l),
+(520,0,l),
+(545,0,l),
+(562,80,l),
+(168,357,l),
+(159,314,l),
+(670,590,l),
+(692,690,l)
+);
+}
+);
+width = 649;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1438;
+unicode = 5176;
+},
+{
+glyphname = "paa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (481,0);
+ref = dot_top;
+}
+);
+width = 649;
+}
+);
+note = uni1439;
+unicode = 5177;
+},
+{
+glyphname = "pwe-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "pe-canadian";
+}
+);
+width = 941;
+}
+);
+note = uni143A;
+unicode = 5178;
+},
+{
+glyphname = "pweWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "pe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (717,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 941;
+}
+);
+note = uni143B;
+unicode = 5179;
+},
+{
+glyphname = "pwi-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "pi-canadian";
+}
+);
+width = 941;
+}
+);
+note = uni143C;
+unicode = 5180;
+},
+{
+glyphname = "pwiWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (717,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 941;
+}
+);
+note = uni143D;
+unicode = 5181;
+},
+{
+glyphname = "pwii-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (509,0);
+ref = dot_top;
+}
+);
+width = 941;
+}
+);
+note = uni143E;
+unicode = 5182;
+},
+{
+glyphname = "pwiiWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (285,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (717,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 941;
+}
+);
+note = uni143F;
+unicode = 5183;
+},
+{
+glyphname = "pwo-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "po-canadian";
+}
+);
+width = 874;
+}
+);
+note = uni1440;
+unicode = 5184;
+},
+{
+glyphname = "pwoWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (649,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 874;
+}
+);
+note = uni1441;
+unicode = 5185;
+},
+{
+glyphname = "pwoo-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (484,0);
+ref = dot_top;
+}
+);
+width = 874;
+}
+);
+note = uni1442;
+unicode = 5186;
+},
+{
+glyphname = "pwooWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (21,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (649,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 874;
+}
+);
+note = uni1443;
+unicode = 5187;
+},
+{
+glyphname = "pwa-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "pa-canadian";
+}
+);
+width = 874;
+}
+);
+note = uni1444;
+unicode = 5188;
+},
+{
+glyphname = "pwaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (649,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 874;
+}
+);
+note = uni1445;
+unicode = 5189;
+},
+{
+glyphname = "pwaa-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (705,0);
+ref = dot_top;
+}
+);
+width = 874;
+}
+);
+note = uni1446;
+unicode = 5190;
+},
+{
+glyphname = "pwaaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (481,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (649,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 874;
+}
+);
+note = uni1447;
+unicode = 5191;
+},
+{
+glyphname = "ycreepwaa-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+pos = (122,-201);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (317,-96);
+ref = dot_top;
+}
+);
+width = 649;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1448;
+unicode = 5192;
+},
+{
+glyphname = "p-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(366,345,l),
+(378,401,l),
+(186,536,l),
+(175,487,l),
+(425,621,l),
+(440,690,l),
+(424,690,l),
+(125,527,l),
+(121,508,l),
+(351,345,l)
+);
+}
+);
+width = 409;
+}
+);
+note = uni1449;
+unicode = 5193;
+},
+{
+glyphname = "pWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(155,345,l),
+(228,690,l),
+(159,690,l),
+(86,345,l)
+);
+}
+);
+width = 196;
+}
+);
+metricRight = "=|";
+note = uni144A;
+unicode = 5194;
+},
+{
+color = 6;
+glyphname = "hCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(120,183,l),
+(146,308,ls),
+(155,350,o),
+(181,373,o),
+(214,373,cs),
+(255,373,o),
+(271,348,o),
+(262,303,cs),
+(236,183,l),
+(303,183,l),
+(331,315,ls),
+(347,386,o),
+(309,435,o),
+(239,435,cs),
+(193,435,o),
+(152,409,o),
+(140,372,c),
+(157,362,l),
+(193,527,l),
+(125,527,l),
+(51,183,l)
+);
+}
+);
+width = 358;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144B;
+unicode = 5195;
+},
+{
+glyphname = "te-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (378,345);
+},
+{
+name = top_center_can;
+pos = (451,690);
+},
+{
+name = top_left_can;
+pos = (212,690);
+},
+{
+name = top_right_can;
+pos = (692,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(509,-13,o),
+(611,82,o),
+(652,277,cs),
+(740,690,l),
+(644,690,l),
+(557,280,ls),
+(526,139,o),
+(458,75,o),
+(338,75,cs),
+(200,75,o),
+(145,150,o),
+(178,300,cs),
+(260,690,l),
+(164,690,l),
+(82,306,ls),
+(40,103,o),
+(136,-13,o),
+(330,-13,cs)
+);
+}
+);
+width = 712;
+}
+);
+metricRight = "=|";
+note = uni144C;
+unicode = 5196;
+},
+{
+glyphname = "taai-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (232,0);
+ref = ring_top.canadian;
+}
+);
+width = 713;
+}
+);
+note = uni144D;
+unicode = 5197;
+},
+{
+glyphname = "ti-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (379,345);
+},
+{
+name = middle_right_can;
+pos = (826,345);
+},
+{
+name = top_center_can;
+pos = (452,690);
+},
+{
+name = top_left_can;
+pos = (213,690);
+},
+{
+name = top_right_can;
+pos = (693,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(113,0,l),
+(201,410,ls),
+(231,551,o),
+(300,614,o),
+(419,614,cs),
+(557,614,o),
+(612,540,o),
+(580,389,cs),
+(498,0,l),
+(593,0,l),
+(675,384,ls),
+(718,586,o),
+(621,702,o),
+(427,702,cs),
+(248,702,o),
+(147,608,o),
+(105,412,cs),
+(17,0,l)
+);
+}
+);
+width = 712;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni144E;
+unicode = 5198;
+},
+{
+glyphname = "tii-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (283,0);
+ref = dot_top;
+}
+);
+width = 713;
+}
+);
+note = uni144F;
+unicode = 5199;
+},
+{
+glyphname = "to-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (276,345);
+},
+{
+name = middle_right_can;
+pos = (726,345);
+},
+{
+name = top_center_can;
+pos = (371,690);
+},
+{
+name = top_double;
+pos = (440,690);
+},
+{
+name = top_left_can;
+pos = (195,690);
+},
+{
+name = top_right_can;
+pos = (599,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(169,0,ls),
+(488,0,o),
+(573,253,o),
+(573,424,cs),
+(573,591,o),
+(472,690,o),
+(294,690,cs),
+(153,690,l),
+(134,603,l),
+(281,603,ls),
+(410,603,o),
+(477,538,o),
+(477,417,cs),
+(477,284,o),
+(413,87,o),
+(179,87,cs),
+(24,87,l),
+(6,0,l)
+);
+}
+);
+width = 607;
+}
+);
+note = uni1450;
+unicode = 5200;
+},
+{
+glyphname = "too-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (201,0);
+ref = dot_top;
+}
+);
+width = 607;
+}
+);
+note = uni1451;
+unicode = 5201;
+},
+{
+glyphname = "ycreetoo-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (102,0);
+ref = doubledot_top;
+}
+);
+width = 607;
+}
+);
+note = uni1452;
+unicode = 5202;
+},
+{
+glyphname = "deeCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (206,0);
+ref = stroke_middle;
+}
+);
+width = 607;
+}
+);
+note = uni1453;
+unicode = 5203;
+},
+{
+glyphname = "diCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (181,0);
+ref = dot_middle;
+}
+);
+width = 607;
+}
+);
+note = uni1454;
+unicode = 5204;
+},
+{
+glyphname = "ta-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (376,345);
+},
+{
+name = top_center_can;
+pos = (428,690);
+},
+{
+name = top_left_can;
+pos = (199,690);
+},
+{
+name = top_right_can;
+pos = (603,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(499,0,l),
+(518,87,l),
+(371,87,ls),
+(242,87,o),
+(176,152,o),
+(176,272,cs),
+(176,408,o),
+(241,603,o),
+(472,603,cs),
+(628,603,l),
+(646,690,l),
+(482,690,ls),
+(165,690,o),
+(79,439,o),
+(79,266,cs),
+(79,99,o),
+(179,0,o),
+(357,0,cs)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|to-canadian";
+note = uni1455;
+unicode = 5205;
+},
+{
+glyphname = "taa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (259,0);
+ref = dot_top;
+}
+);
+width = 607;
+}
+);
+note = uni1456;
+unicode = 5206;
+},
+{
+glyphname = "twe-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "te-canadian";
+}
+);
+width = 937;
+}
+);
+note = uni1457;
+unicode = 5207;
+},
+{
+glyphname = "tweWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (713,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 937;
+}
+);
+note = uni1458;
+unicode = 5208;
+},
+{
+glyphname = "twi-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ti-canadian";
+}
+);
+width = 937;
+}
+);
+note = uni1459;
+unicode = 5209;
+},
+{
+glyphname = "twiWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (713,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 937;
+}
+);
+note = uni145A;
+unicode = 5210;
+},
+{
+glyphname = "twii-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (507,0);
+ref = dot_top;
+}
+);
+width = 937;
+}
+);
+note = uni145B;
+unicode = 5211;
+},
+{
+glyphname = "twiiWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (283,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (713,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 937;
+}
+);
+note = uni145C;
+unicode = 5212;
+},
+{
+glyphname = "two-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "to-canadian";
+}
+);
+width = 832;
+}
+);
+note = uni145D;
+unicode = 5213;
+},
+{
+glyphname = "twoWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 832;
+}
+);
+note = uni145E;
+unicode = 5214;
+},
+{
+glyphname = "twoo-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (426,0);
+ref = dot_top;
+}
+);
+width = 832;
+}
+);
+note = uni145F;
+unicode = 5215;
+},
+{
+glyphname = "twooWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (201,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 832;
+}
+);
+note = uni1460;
+unicode = 5216;
+},
+{
+glyphname = "twa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ta-canadian";
+}
+);
+width = 832;
+}
+);
+note = uni1461;
+unicode = 5217;
+},
+{
+glyphname = "twaWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 832;
+}
+);
+note = uni1462;
+unicode = 5218;
+},
+{
+glyphname = "twaa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (483,0);
+ref = dot_top;
+}
+);
+width = 832;
+}
+);
+note = uni1463;
+unicode = 5219;
+},
+{
+glyphname = "twaaWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (259,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 832;
+}
+);
+note = uni1464;
+unicode = 5220;
+},
+{
+glyphname = "twaaNaskapi-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ta-canadian";
+}
+);
+width = 831;
+}
+);
+note = uni1465;
+unicode = 5221;
+},
+{
+glyphname = "t-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(329,345,l),
+(344,409,l),
+(270,409,ls),
+(213,409,o),
+(185,437,o),
+(185,487,cs),
+(185,551,o),
+(216,626,o),
+(317,626,cs),
+(389,626,l),
+(403,690,l),
+(326,690,ls),
+(187,690,o),
+(117,595,o),
+(117,481,cs),
+(117,397,o),
+(169,345,o),
+(261,345,cs)
+);
+}
+);
+width = 369;
+}
+);
+note = uni1466;
+unicode = 5222;
+},
+{
+glyphname = "tte-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+pos = (713,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 909;
+}
+);
+note = uni1467;
+unicode = 5223;
+},
+{
+glyphname = "tti-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+pos = (713,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 909;
+}
+);
+note = uni1468;
+unicode = 5224;
+},
+{
+glyphname = "tto-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+pos = (607,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 804;
+}
+);
+note = uni1469;
+unicode = 5225;
+},
+{
+glyphname = "tta-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+pos = (607,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 804;
+}
+);
+note = uni146A;
+unicode = 5226;
+},
+{
+glyphname = "ke-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (345,441);
+},
+{
+name = top_center_can;
+pos = (383,690);
+},
+{
+name = top_left_can;
+pos = (201,690);
+},
+{
+name = top_right_can;
+pos = (554,695);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(467,0,l),
+(554,412,ls),
+(584,556,o),
+(536,702,o),
+(361,702,cs),
+(184,702,o),
+(102,538,o),
+(102,400,cs),
+(102,278,o),
+(176,198,o),
+(291,198,cs),
+(364,198,o),
+(423,235,o),
+(451,298,c),
+(437,312,l),
+(371,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(239,280,o),
+(195,327,o),
+(195,406,cs),
+(195,484,o),
+(236,620,o),
+(354,620,cs),
+(427,620,o),
+(470,573,o),
+(470,494,cs),
+(470,414,o),
+(430,280,o),
+(312,280,cs)
+);
+}
+);
+width = 586;
+}
+);
+metricRight = "te-canadian";
+note = uni146B;
+unicode = 5227;
+},
+{
+glyphname = "kaai-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (169,0);
+ref = ring_top.canadian;
+}
+);
+width = 586;
+}
+);
+note = uni146C;
+unicode = 5228;
+},
+{
+glyphname = "ki-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (356,441);
+},
+{
+name = top_center_can;
+pos = (389,690);
+},
+{
+name = top_left_can;
+pos = (212,690);
+},
+{
+name = top_right_can;
+pos = (575,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(113,0,l),
+(184,330,l),
+(171,325,l),
+(169,259,o),
+(233,198,o),
+(326,198,cs),
+(499,198,o),
+(573,369,o),
+(573,496,cs),
+(573,623,o),
+(495,702,o),
+(369,702,cs),
+(240,702,o),
+(149,621,o),
+(119,476,cs),
+(17,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(248,280,o),
+(205,327,o),
+(205,406,cs),
+(205,483,o),
+(244,620,o),
+(362,620,cs),
+(436,620,o),
+(480,573,o),
+(480,495,cs),
+(480,417,o),
+(440,280,o),
+(322,280,cs)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni146D;
+unicode = 5229;
+},
+{
+glyphname = "kii-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (219,0);
+ref = dot_top;
+}
+);
+width = 586;
+}
+);
+note = uni146E;
+unicode = 5230;
+},
+{
+glyphname = "ko-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (329,355);
+},
+{
+name = top_center_can;
+pos = (384,690);
+},
+{
+name = top_double;
+pos = (566,690);
+},
+{
+name = top_left_can;
+pos = (203,690);
+},
+{
+name = top_right_can;
+pos = (566,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(391,-13,o),
+(482,69,o),
+(513,213,cs),
+(614,690,l),
+(518,690,l),
+(447,359,l),
+(461,365,l),
+(463,431,o),
+(399,492,o),
+(306,492,cs),
+(130,492,o),
+(58,320,o),
+(58,194,cs),
+(58,67,o),
+(136,-13,o),
+(266,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(195,70,o),
+(152,116,o),
+(152,195,cs),
+(152,272,o),
+(193,410,o),
+(310,410,cs),
+(384,410,o),
+(426,362,o),
+(426,284,cs),
+(426,206,o),
+(387,70,o),
+(269,70,cs)
+);
+}
+);
+width = 587;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni146F;
+unicode = 5231;
+},
+{
+glyphname = "koo-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (395,0);
+ref = dot_top;
+}
+);
+width = 586;
+}
+);
+note = uni1470;
+unicode = 5232;
+},
+{
+glyphname = "ycreekoo-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (227,0);
+ref = doubledot_top;
+}
+);
+width = 586;
+}
+);
+note = uni1471;
+unicode = 5233;
+},
+{
+glyphname = "ka-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (337,357);
+},
+{
+name = top_center_can;
+pos = (393,690);
+},
+{
+name = top_left_can;
+pos = (212,690);
+},
+{
+name = top_right_can;
+pos = (575,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(447,-13,o),
+(529,152,o),
+(529,289,cs),
+(529,412,o),
+(455,492,o),
+(340,492,cs),
+(267,492,o),
+(209,455,o),
+(180,392,c),
+(194,378,l),
+(260,690,l),
+(164,690,l),
+(76,278,ls),
+(40,102,o),
+(120,-13,o),
+(272,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(204,70,o),
+(160,117,o),
+(160,196,cs),
+(160,275,o),
+(201,410,o),
+(319,410,cs),
+(392,410,o),
+(436,362,o),
+(436,284,cs),
+(436,207,o),
+(395,70,o),
+(277,70,cs)
+);
+}
+);
+width = 587;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "==|ke-canadian";
+note = uni1472;
+unicode = 5234;
+},
+{
+glyphname = "kaa-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (43,0);
+ref = dot_top;
+}
+);
+width = 586;
+}
+);
+note = uni1473;
+unicode = 5235;
+},
+{
+glyphname = "kwe-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ke-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni1474;
+unicode = 5236;
+},
+{
+glyphname = "kweWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (586,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni1475;
+unicode = 5237;
+},
+{
+glyphname = "kwi-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ki-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni1476;
+unicode = 5238;
+},
+{
+glyphname = "kwiWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (586,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni1477;
+unicode = 5239;
+},
+{
+glyphname = "kwii-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (444,0);
+ref = dot_top;
+}
+);
+width = 810;
+}
+);
+note = uni1478;
+unicode = 5240;
+},
+{
+glyphname = "kwiiWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (219,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (586,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni1479;
+unicode = 5241;
+},
+{
+glyphname = "kwo-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ko-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni147A;
+unicode = 5242;
+},
+{
+glyphname = "kwoWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (586,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni147B;
+unicode = 5243;
+},
+{
+glyphname = "kwoo-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (619,0);
+ref = dot_top;
+}
+);
+width = 810;
+}
+);
+note = uni147C;
+unicode = 5244;
+},
+{
+glyphname = "kwooWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (395,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (586,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni147D;
+unicode = 5245;
+},
+{
+glyphname = "kwa-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ka-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni147E;
+unicode = 5246;
+},
+{
+glyphname = "kwaWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (586,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni147F;
+unicode = 5247;
+},
+{
+glyphname = "kwaa-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (267,0);
+ref = dot_top;
+}
+);
+width = 810;
+}
+);
+note = uni1480;
+unicode = 5248;
+},
+{
+glyphname = "kwaaWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (43,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (586,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni1481;
+unicode = 5249;
+},
+{
+glyphname = "kwaaNaskapi-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ka-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni1482;
+unicode = 5250;
+},
+{
+glyphname = "k-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(318,339,o),
+(369,422,o),
+(369,497,cs),
+(369,559,o),
+(331,601,o),
+(270,601,cs),
+(227,601,o),
+(193,576,o),
+(176,538,c),
+(195,535,l),
+(228,690,l),
+(159,690,l),
+(117,490,ls),
+(101,413,o),
+(129,339,o),
+(226,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(196,390,o),
+(175,413,o),
+(175,449,cs),
+(175,494,o),
+(202,551,o),
+(252,551,cs),
+(286,551,o),
+(307,528,o),
+(307,492,cs),
+(307,447,o),
+(280,390,o),
+(230,390,cs)
+);
+}
+);
+width = 373;
+}
+);
+note = uni1483;
+unicode = 5251;
+},
+{
+glyphname = "kw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(289,339,o),
+(340,383,o),
+(357,465,cs),
+(406,690,l),
+(337,690,l),
+(303,531,l),
+(319,531,l),
+(318,571,o),
+(283,601,o),
+(236,601,cs),
+(152,601,o),
+(103,521,o),
+(103,448,cs),
+(103,383,o),
+(148,339,o),
+(217,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(185,390,o),
+(164,412,o),
+(164,449,cs),
+(164,493,o),
+(191,550,o),
+(242,550,cs),
+(275,550,o),
+(298,526,o),
+(298,491,cs),
+(298,448,o),
+(270,390,o),
+(219,390,cs)
+);
+}
+);
+width = 373;
+}
+);
+metricLeft = "=|k-canadian";
+metricRight = "=|k-canadian";
+note = uni1484;
+unicode = 5252;
+},
+{
+glyphname = "southslaveykeh-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+pos = (586,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 782;
+}
+);
+note = uni1485;
+unicode = 5253;
+},
+{
+glyphname = "southslaveykih-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+pos = (586,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 782;
+}
+);
+note = uni1486;
+unicode = 5254;
+},
+{
+glyphname = "southslaveykoh-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+pos = (586,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 782;
+}
+);
+note = uni1487;
+unicode = 5255;
+},
+{
+glyphname = "southslaveykah-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+pos = (586,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 782;
+}
+);
+note = uni1488;
+unicode = 5256;
+},
+{
+glyphname = "ce-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (335,399);
+},
+{
+name = top_center_can;
+pos = (384,690);
+},
+{
+name = top_left_can;
+pos = (203,690);
+},
+{
+name = top_right_can;
+pos = (561,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(462,0,l),
+(554,435,ls),
+(588,593,o),
+(511,702,o),
+(360,702,cs),
+(224,702,o),
+(142,623,o),
+(107,465,cs),
+(91,387,l),
+(185,387,l),
+(202,462,ls),
+(224,570,o),
+(272,618,o),
+(353,618,cs),
+(445,618,o),
+(483,552,o),
+(460,445,cs),
+(366,0,l)
+);
+}
+);
+width = 581;
+}
+);
+metricRight = "te-canadian";
+note = uni1489;
+unicode = 5257;
+},
+{
+glyphname = "caai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (173,0);
+ref = ring_top.canadian;
+}
+);
+width = 581;
+}
+);
+note = uni148A;
+unicode = 5258;
+},
+{
+glyphname = "ci-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (338,399);
+},
+{
+name = top_center_can;
+pos = (394,690);
+},
+{
+name = top_left_can;
+pos = (212,690);
+},
+{
+name = top_right_can;
+pos = (571,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(113,0,l),
+(211,462,ls),
+(234,570,o),
+(282,618,o),
+(362,618,cs),
+(456,618,o),
+(492,552,o),
+(469,445,cs),
+(458,387,l),
+(553,387,l),
+(563,435,ls),
+(598,593,o),
+(520,702,o),
+(369,702,cs),
+(233,702,o),
+(151,623,o),
+(116,465,cs),
+(17,0,l)
+);
+}
+);
+width = 581;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+unicode = 5259;
+},
+{
+glyphname = "cii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (225,0);
+ref = dot_top;
+}
+);
+width = 581;
+}
+);
+note = uni148C;
+unicode = 5260;
+},
+{
+glyphname = "co-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (335,399);
+},
+{
+name = top_center_can;
+pos = (384,690);
+},
+{
+name = top_double;
+pos = (561,690);
+},
+{
+name = top_left_can;
+pos = (203,690);
+},
+{
+name = top_right_can;
+pos = (561,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(393,-13,o),
+(475,67,o),
+(509,225,cs),
+(609,690,l),
+(513,690,l),
+(414,228,ls),
+(392,120,o),
+(344,71,o),
+(264,71,cs),
+(170,71,o),
+(134,138,o),
+(156,244,cs),
+(168,302,l),
+(72,302,l),
+(63,255,ls),
+(28,97,o),
+(106,-13,o),
+(257,-13,cs)
+);
+}
+);
+width = 581;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+unicode = 5261;
+},
+{
+glyphname = "coo-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (391,0);
+ref = dot_top;
+}
+);
+width = 581;
+}
+);
+note = uni148E;
+unicode = 5262;
+},
+{
+glyphname = "ycreecoo-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (223,0);
+ref = doubledot_top;
+}
+);
+width = 581;
+}
+);
+note = uni148F;
+unicode = 5263;
+},
+{
+glyphname = "ca-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (339,399);
+},
+{
+name = top_center_can;
+pos = (394,690);
+},
+{
+name = top_left_can;
+pos = (213,690);
+},
+{
+name = top_right_can;
+pos = (570,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(402,-13,o),
+(484,67,o),
+(518,225,cs),
+(534,302,l),
+(440,302,l),
+(424,228,ls),
+(401,120,o),
+(354,71,o),
+(273,71,cs),
+(180,71,o),
+(143,138,o),
+(165,244,cs),
+(260,690,l),
+(164,690,l),
+(72,255,ls),
+(38,97,o),
+(115,-13,o),
+(266,-13,cs)
+);
+}
+);
+width = 580;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+unicode = 5264;
+},
+{
+glyphname = "caa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (43,0);
+ref = dot_top;
+}
+);
+width = 581;
+}
+);
+note = uni1491;
+unicode = 5265;
+},
+{
+glyphname = "cwe-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ce-canadian";
+}
+);
+width = 806;
+}
+);
+note = uni1492;
+unicode = 5266;
+},
+{
+glyphname = "cweWestCree-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (581,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 806;
+}
+);
+note = uni1493;
+unicode = 5267;
+},
+{
+glyphname = "cwi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+pos = (224,0);
+ref = "ci-canadian";
+}
+);
+width = 805;
+}
+);
+note = uni1494;
+unicode = 5268;
+},
+{
+glyphname = "cwiWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "ci-canadian";
+},
+{
+anchor = middle_right_can;
+pos = (581,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 805;
+}
+);
+note = uni1495;
+unicode = 5269;
+},
+{
+glyphname = "cwii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+pos = (224,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (449,0);
+ref = dot_top;
+}
+);
+width = 805;
+}
+);
+note = uni1496;
+unicode = 5270;
+},
+{
+glyphname = "cwiiWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (225,0);
+ref = dot_top;
+},
+{
+anchor = middle_right_can;
+pos = (581,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 805;
+}
+);
+note = uni1497;
+unicode = 5271;
+},
+{
+glyphname = "cwo-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "co-canadian";
+}
+);
+width = 806;
+}
+);
+note = uni1498;
+unicode = 5272;
+},
+{
+glyphname = "cwoWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (581,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 806;
+}
+);
+note = uni1499;
+unicode = 5273;
+},
+{
+glyphname = "cwoo-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (616,0);
+ref = dot_top;
+}
+);
+width = 806;
+}
+);
+note = uni149A;
+unicode = 5274;
+},
+{
+glyphname = "cwooWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (391,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (581,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 806;
+}
+);
+note = uni149B;
+unicode = 5275;
+},
+{
+glyphname = "cwa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ca-canadian";
+}
+);
+width = 806;
+}
+);
+note = uni149C;
+unicode = 5276;
+},
+{
+glyphname = "cwaWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (581,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 806;
+}
+);
+note = uni149D;
+unicode = 5277;
+},
+{
+glyphname = "cwaa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (268,0);
+ref = dot_top;
+}
+);
+width = 806;
+}
+);
+note = uni149E;
+unicode = 5278;
+},
+{
+glyphname = "cwaaWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (43,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (581,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 806;
+}
+);
+note = uni149F;
+unicode = 5279;
+},
+{
+glyphname = "cwaaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ca-canadian";
+}
+);
+width = 805;
+}
+);
+note = uni14A0;
+unicode = 5280;
+},
+{
+glyphname = "c-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(298,339,o),
+(350,382,o),
+(366,458,cs),
+(372,487,l),
+(308,487,l),
+(301,456,ls),
+(292,414,o),
+(268,393,o),
+(231,393,cs),
+(188,393,o),
+(171,419,o),
+(182,469,cs),
+(228,690,l),
+(160,690,l),
+(115,479,ls),
+(98,393,o),
+(140,339,o),
+(227,339,cs)
+);
+}
+);
+width = 363;
+}
+);
+note = uni14A1;
+unicode = 5281;
+},
+{
+glyphname = "thSayisi-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(280,339,o),
+(328,382,o),
+(346,458,cs),
+(395,690,l),
+(327,690,l),
+(277,458,ls),
+(268,413,o),
+(242,393,o),
+(206,393,cs),
+(163,393,o),
+(146,421,o),
+(155,464,cs),
+(159,487,l),
+(96,487,l),
+(93,470,ls),
+(76,395,o),
+(119,339,o),
+(203,339,cs)
+);
+}
+);
+width = 364;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "=|c-canadian";
+note = uni14A2;
+unicode = 5282;
+},
+{
+glyphname = "me-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:54:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (220,345);
+},
+{
+name = top_center_can;
+pos = (344,690);
+},
+{
+name = top_left_can;
+pos = (184,690);
+},
+{
+name = top_right_can;
+pos = (499,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(401,0,l),
+(548,690,l),
+(136,690,l),
+(118,603,l),
+(434,603,l),
+(305,0,l)
+);
+}
+);
+width = 528;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+unicode = 5283;
+},
+{
+glyphname = "maai-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (157,0);
+ref = ring_top.canadian;
+}
+);
+width = 528;
+}
+);
+note = uni14A4;
+unicode = 5284;
+},
+{
+glyphname = "mi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (353,345);
+},
+{
+name = top_center_can;
+pos = (378,690);
+},
+{
+name = top_left_can;
+pos = (220,690);
+},
+{
+name = top_right_can;
+pos = (535,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,0,l),
+(249,603,l),
+(565,603,l),
+(583,690,l),
+(172,690,l),
+(25,0,l)
+);
+}
+);
+width = 528;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+unicode = 5285;
+},
+{
+glyphname = "mii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (209,0);
+ref = dot_top;
+}
+);
+width = 528;
+}
+);
+note = uni14A6;
+unicode = 5286;
+},
+{
+glyphname = "mo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:54:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (221,345);
+},
+{
+name = top_center_can;
+pos = (344,690);
+},
+{
+name = top_double;
+pos = (500,690);
+},
+{
+name = top_left_can;
+pos = (184,690);
+},
+{
+name = top_right_can;
+pos = (500,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(401,0,l),
+(548,690,l),
+(452,690,l),
+(324,87,l),
+(8,87,l),
+(-11,0,l)
+);
+}
+);
+width = 528;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+unicode = 5287;
+},
+{
+glyphname = "moo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (330,0);
+ref = dot_top;
+}
+);
+width = 528;
+}
+);
+note = uni14A8;
+unicode = 5288;
+},
+{
+glyphname = "ycreemoo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (163,0);
+ref = doubledot_top;
+}
+);
+width = 528;
+}
+);
+note = uni14A9;
+unicode = 5289;
+},
+{
+glyphname = "ma-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (353,345);
+},
+{
+name = top_center_can;
+pos = (378,690);
+},
+{
+name = top_left_can;
+pos = (220,690);
+},
+{
+name = top_right_can;
+pos = (535,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(437,0,l),
+(455,87,l),
+(139,87,l),
+(268,690,l),
+(172,690,l),
+(25,0,l)
+);
+}
+);
+width = 528;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+unicode = 5290;
+},
+{
+glyphname = "maa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+}
+);
+width = 528;
+}
+);
+note = uni14AB;
+unicode = 5291;
+},
+{
+glyphname = "mwe-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "me-canadian";
+}
+);
+width = 753;
+}
+);
+note = uni14AC;
+unicode = 5292;
+},
+{
+glyphname = "mweWestCree-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "me-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (528,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 753;
+}
+);
+note = uni14AD;
+unicode = 5293;
+},
+{
+glyphname = "mwi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "mi-canadian";
+}
+);
+width = 753;
+}
+);
+note = uni14AE;
+unicode = 5294;
+},
+{
+glyphname = "mwiWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (528,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 753;
+}
+);
+note = uni14AF;
+unicode = 5295;
+},
+{
+glyphname = "mwii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (433,0);
+ref = dot_top;
+}
+);
+width = 753;
+}
+);
+note = uni14B0;
+unicode = 5296;
+},
+{
+glyphname = "mwiiWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (209,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (528,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 753;
+}
+);
+note = uni14B1;
+unicode = 5297;
+},
+{
+glyphname = "mwo-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "mo-canadian";
+}
+);
+width = 753;
+}
+);
+note = uni14B2;
+unicode = 5298;
+},
+{
+glyphname = "mwoWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (528,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 753;
+}
+);
+note = uni14B3;
+unicode = 5299;
+},
+{
+glyphname = "mwoo-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (555,0);
+ref = dot_top;
+}
+);
+width = 753;
+}
+);
+note = uni14B4;
+unicode = 5300;
+},
+{
+glyphname = "mwooWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (330,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (528,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 753;
+}
+);
+note = uni14B5;
+unicode = 5301;
+},
+{
+glyphname = "mwa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ma-canadian";
+}
+);
+width = 753;
+}
+);
+note = uni14B6;
+unicode = 5302;
+},
+{
+glyphname = "mwaWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (528,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 753;
+}
+);
+note = uni14B7;
+unicode = 5303;
+},
+{
+glyphname = "mwaa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (274,0);
+ref = dot_top;
+}
+);
+width = 753;
+}
+);
+note = uni14B8;
+unicode = 5304;
+},
+{
+glyphname = "mwaaWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (528,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 753;
+}
+);
+note = uni14B9;
+unicode = 5305;
+},
+{
+glyphname = "mwaaNaskapi-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ma-canadian";
+}
+);
+width = 752;
+}
+);
+note = uni14BA;
+unicode = 5306;
+},
+{
+glyphname = "m-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(311,345,l),
+(325,409,l),
+(168,409,l),
+(228,690,l),
+(159,690,l),
+(86,345,l)
+);
+}
+);
+width = 337;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni14BB;
+unicode = 5307;
+},
+{
+glyphname = "mWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "t-canadian";
+}
+);
+width = 369;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "t-canadian";
+note = uni14BC;
+unicode = 5308;
+},
+{
+glyphname = "mh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(296,345,l),
+(369,690,l),
+(300,690,l),
+(241,409,l),
+(84,409,l),
+(70,345,l)
+);
+}
+);
+width = 337;
+}
+);
+metricLeft = "=|m-canadian";
+metricRight = "=|m-canadian";
+note = uni14BD;
+unicode = 5309;
+},
+{
+glyphname = "mAthapascan-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(326,345,l),
+(338,400,l),
+(169,400,l),
+(167,370,l),
+(299,482,ls),
+(342,518,o),
+(364,554,o),
+(364,601,cs),
+(364,657,o),
+(324,696,o),
+(259,696,cs),
+(189,696,o),
+(140,658,o),
+(125,572,c),
+(185,572,l),
+(195,623,o),
+(219,644,o),
+(254,644,cs),
+(285,644,o),
+(303,627,o),
+(303,598,cs),
+(303,564,o),
+(285,538,o),
+(244,504,cs),
+(98,379,l),
+(90,345,l)
+);
+}
+);
+width = 353;
+}
+);
+note = uni14BE;
+unicode = 5310;
+},
+{
+glyphname = "mSayisi-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = two.canadian;
+}
+);
+width = 581;
+}
+);
+note = uni14BF;
+unicode = 5311;
+},
+{
+glyphname = "ne-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (511,245);
+},
+{
+name = top_center_can;
+pos = (554,497);
+},
+{
+name = top_left_can;
+pos = (158,497);
+},
+{
+name = top_right_can;
+pos = (753,497);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(655,-13,o),
+(746,137,o),
+(746,274,cs),
+(746,398,o),
+(664,479,o),
+(528,479,cs),
+(106,479,l),
+(88,393,l),
+(416,393,l),
+(414,431,l),
+(308,392,o),
+(272,274,o),
+(272,190,cs),
+(272,69,o),
+(355,-13,o),
+(488,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(412,70,o),
+(365,119,o),
+(365,195,cs),
+(365,282,o),
+(416,397,o),
+(526,397,cs),
+(607,397,o),
+(652,348,o),
+(652,271,cs),
+(652,185,o),
+(602,70,o),
+(492,70,cs)
+);
+}
+);
+width = 806;
+}
+);
+metricRight = "=|ke-canadian";
+note = uni14C0;
+unicode = 5312;
+},
+{
+glyphname = "naai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (141,-192);
+ref = ring_top.canadian;
+}
+);
+width = 805;
+}
+);
+note = uni14C1;
+unicode = 5313;
+},
+{
+glyphname = "ni-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (296,245);
+},
+{
+name = top_center_can;
+pos = (362,497);
+},
+{
+name = top_left_can;
+pos = (161,497);
+},
+{
+name = top_right_can;
+pos = (757,497);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,-13,o),
+(531,137,o),
+(531,274,cs),
+(531,332,o),
+(506,380,o),
+(469,404,c),
+(453,393,l),
+(783,393,l),
+(802,479,l),
+(322,479,ls),
+(147,479,o),
+(57,330,o),
+(57,192,cs),
+(57,69,o),
+(141,-13,o),
+(273,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(197,70,o),
+(151,119,o),
+(151,195,cs),
+(151,282,o),
+(202,397,o),
+(312,397,cs),
+(392,397,o),
+(438,348,o),
+(438,271,cs),
+(438,185,o),
+(387,70,o),
+(277,70,cs)
+);
+}
+);
+width = 806;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+unicode = 5314;
+},
+{
+glyphname = "nii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (192,-192);
+ref = dot_top;
+}
+);
+width = 805;
+}
+);
+note = uni14C3;
+unicode = 5315;
+},
+{
+glyphname = "no-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (512,245);
+},
+{
+name = top_center_can;
+pos = (563,497);
+},
+{
+name = top_double;
+pos = (566,497);
+},
+{
+name = top_left_can;
+pos = (158,497);
+},
+{
+name = top_right_can;
+pos = (754,497);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(484,0,ls),
+(659,0,o),
+(749,148,o),
+(749,287,cs),
+(749,411,o),
+(665,492,o),
+(532,492,cs),
+(365,492,o),
+(274,342,o),
+(274,204,cs),
+(274,147,o),
+(299,99,o),
+(336,75,c),
+(353,86,l),
+(22,86,l),
+(4,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(413,82,o),
+(368,131,o),
+(368,208,cs),
+(368,295,o),
+(418,410,o),
+(528,410,cs),
+(609,410,o),
+(655,360,o),
+(655,284,cs),
+(655,197,o),
+(604,82,o),
+(494,82,cs)
+);
+}
+);
+width = 806;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14C4;
+unicode = 5316;
+},
+{
+glyphname = "noo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (394,-192);
+ref = dot_top;
+}
+);
+width = 805;
+}
+);
+note = uni14C5;
+unicode = 5317;
+},
+{
+glyphname = "ycreenoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (229,-192);
+ref = doubledot_top;
+}
+);
+width = 805;
+}
+);
+note = uni14C6;
+unicode = 5318;
+},
+{
+glyphname = "na-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (297,245);
+},
+{
+name = top_center_can;
+pos = (352,497);
+},
+{
+name = top_double;
+pos = (508,497);
+},
+{
+name = top_left_can;
+pos = (161,497);
+},
+{
+name = top_right_can;
+pos = (757,497);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(699,0,l),
+(718,86,l),
+(389,86,l),
+(391,48,l),
+(497,87,o),
+(533,205,o),
+(533,288,cs),
+(533,411,o),
+(450,492,o),
+(318,492,cs),
+(151,492,o),
+(60,342,o),
+(60,205,cs),
+(60,81,o),
+(142,0,o),
+(277,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,82,o),
+(154,131,o),
+(154,208,cs),
+(154,295,o),
+(204,410,o),
+(314,410,cs),
+(394,410,o),
+(440,360,o),
+(440,284,cs),
+(440,197,o),
+(389,82,o),
+(279,82,cs)
+);
+}
+);
+width = 806;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+unicode = 5319;
+},
+{
+glyphname = "naa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (182,-192);
+ref = dot_top;
+}
+);
+width = 805;
+}
+);
+note = uni14C8;
+unicode = 5320;
+},
+{
+glyphname = "nwe-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ne-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni14C9;
+unicode = 5321;
+},
+{
+glyphname = "nweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (805,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni14CA;
+unicode = 5322;
+},
+{
+glyphname = "nwa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "na-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni14CB;
+unicode = 5323;
+},
+{
+glyphname = "nwaWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (805,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni14CC;
+unicode = 5324;
+},
+{
+glyphname = "nwaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (406,-192);
+ref = dot_top;
+}
+);
+width = 1029;
+}
+);
+note = uni14CD;
+unicode = 5325;
+},
+{
+glyphname = "nwaaWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (182,-192);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (805,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni14CE;
+unicode = 5326;
+},
+{
+glyphname = "nwaaNaskapi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (169,-192);
+ref = doubledot_top;
+}
+);
+width = 805;
+}
+);
+note = uni14CF;
+unicode = 5327;
+},
+{
+glyphname = "n-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(471,435,l),
+(486,497,l),
+(309,497,l),
+(304,459,l),
+(356,478,o),
+(378,543,o),
+(378,585,cs),
+(378,652,o),
+(332,696,o),
+(262,696,cs),
+(175,696,o),
+(124,623,o),
+(124,547,cs),
+(124,479,o),
+(168,435,o),
+(239,435,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(205,485,o),
+(184,509,o),
+(184,546,cs),
+(184,584,o),
+(205,645,o),
+(261,645,cs),
+(297,645,o),
+(318,621,o),
+(318,585,cs),
+(318,547,o),
+(297,485,o),
+(241,485,cs)
+);
+}
+);
+width = 478;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni14D0;
+unicode = 5328;
+},
+{
+color = 6;
+glyphname = "ngCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-34,-161);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 425;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "=|";
+note = uni14D1;
+unicode = 5329;
+},
+{
+glyphname = "nh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(351,435,ls),
+(442,435,o),
+(493,507,o),
+(493,585,cs),
+(493,651,o),
+(448,696,o),
+(378,696,cs),
+(291,696,o),
+(240,623,o),
+(240,547,cs),
+(240,511,o),
+(257,484,o),
+(274,471,c),
+(284,497,l),
+(102,497,l),
+(89,435,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(321,485,o),
+(299,509,o),
+(299,546,cs),
+(299,584,o),
+(321,645,o),
+(376,645,cs),
+(412,645,o),
+(433,621,o),
+(433,585,cs),
+(433,547,o),
+(412,485,o),
+(356,485,cs)
+);
+}
+);
+width = 478;
+}
+);
+metricLeft = "=|n-canadian";
+metricRight = "=|n-canadian";
+note = uni14D2;
+unicode = 5330;
+},
+{
+glyphname = "le-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (511,245);
+},
+{
+name = top_center_can;
+pos = (554,497);
+},
+{
+name = top_left_can;
+pos = (158,497);
+},
+{
+name = top_right_can;
+pos = (753,497);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(445,0,ls),
+(659,0,o),
+(747,137,o),
+(747,281,cs),
+(747,402,o),
+(667,479,o),
+(533,479,cs),
+(106,479,l),
+(88,392,l),
+(516,392,ls),
+(604,392,o),
+(651,349,o),
+(651,273,cs),
+(651,183,o),
+(602,85,o),
+(456,85,cs),
+(410,85,l),
+(391,0,l)
+);
+}
+);
+width = 806;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D3;
+unicode = 5331;
+},
+{
+glyphname = "laai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (142,-192);
+ref = ring_top.canadian;
+}
+);
+width = 805;
+}
+);
+note = uni14D4;
+unicode = 5332;
+},
+{
+glyphname = "li-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (298,245);
+},
+{
+name = top_center_can;
+pos = (363,497);
+},
+{
+name = top_left_can;
+pos = (163,497);
+},
+{
+name = top_right_can;
+pos = (757,497);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(313,0,l),
+(331,85,l),
+(288,85,ls),
+(202,85,o),
+(154,129,o),
+(154,205,cs),
+(154,294,o),
+(204,392,o),
+(350,392,cs),
+(783,392,l),
+(801,479,l),
+(358,479,ls),
+(152,479,o),
+(59,348,o),
+(59,202,cs),
+(59,82,o),
+(140,0,o),
+(269,0,cs)
+);
+}
+);
+width = 806;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14D5;
+unicode = 5333;
+},
+{
+glyphname = "lii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (193,-192);
+ref = dot_top;
+}
+);
+width = 805;
+}
+);
+note = uni14D6;
+unicode = 5334;
+},
+{
+glyphname = "lo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (511,245);
+},
+{
+name = top_center_can;
+pos = (562,497);
+},
+{
+name = top_double;
+pos = (551,497);
+},
+{
+name = top_left_can;
+pos = (157,497);
+},
+{
+name = top_right_can;
+pos = (753,497);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(447,0,ls),
+(654,0,o),
+(747,131,o),
+(747,277,cs),
+(747,397,o),
+(666,479,o),
+(537,479,cs),
+(493,479,l),
+(474,394,l),
+(518,394,ls),
+(604,394,o),
+(652,350,o),
+(652,274,cs),
+(652,185,o),
+(602,87,o),
+(456,87,cs),
+(23,87,l),
+(5,0,l)
+);
+}
+);
+width = 806;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D7;
+unicode = 5335;
+},
+{
+glyphname = "loo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (392,-192);
+ref = dot_top;
+}
+);
+width = 805;
+}
+);
+note = uni14D8;
+unicode = 5336;
+},
+{
+glyphname = "ycreeloo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (213,-192);
+ref = doubledot_top;
+}
+);
+width = 805;
+}
+);
+note = uni14D9;
+unicode = 5337;
+},
+{
+glyphname = "la-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (298,245);
+},
+{
+name = top_center_can;
+pos = (353,497);
+},
+{
+name = top_left_can;
+pos = (163,497);
+},
+{
+name = top_right_can;
+pos = (757,497);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(699,0,l),
+(718,87,l),
+(290,87,ls),
+(202,87,o),
+(156,129,o),
+(156,206,cs),
+(156,297,o),
+(204,394,o),
+(350,394,cs),
+(396,394,l),
+(414,479,l),
+(361,479,ls),
+(147,479,o),
+(59,342,o),
+(59,198,cs),
+(59,77,o),
+(139,0,o),
+(272,0,cs)
+);
+}
+);
+width = 805;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14DA;
+unicode = 5338;
+},
+{
+glyphname = "laa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (183,-192);
+ref = dot_top;
+}
+);
+width = 805;
+}
+);
+note = uni14DB;
+unicode = 5339;
+},
+{
+glyphname = "lwe-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "le-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni14DC;
+unicode = 5340;
+},
+{
+glyphname = "lweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "le-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (805,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni14DD;
+unicode = 5341;
+},
+{
+glyphname = "lwi-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "li-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni14DE;
+unicode = 5342;
+},
+{
+glyphname = "lwiWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (805,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni14DF;
+unicode = 5343;
+},
+{
+glyphname = "lwii-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (417,-192);
+ref = dot_top;
+}
+);
+width = 1029;
+}
+);
+note = uni14E0;
+unicode = 5344;
+},
+{
+glyphname = "lwiiWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (193,-192);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (805,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni14E1;
+unicode = 5345;
+},
+{
+glyphname = "lwo-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "lo-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni14E2;
+unicode = 5346;
+},
+{
+glyphname = "lwoWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (805,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni14E3;
+unicode = 5347;
+},
+{
+glyphname = "lwoo-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (616,-192);
+ref = dot_top;
+}
+);
+width = 1029;
+}
+);
+note = uni14E4;
+unicode = 5348;
+},
+{
+glyphname = "lwooWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (392,-192);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (805,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni14E5;
+unicode = 5349;
+},
+{
+glyphname = "lwa-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "la-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni14E6;
+unicode = 5350;
+},
+{
+glyphname = "lwaWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (805,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni14E7;
+unicode = 5351;
+},
+{
+glyphname = "lwaa-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (407,-192);
+ref = dot_top;
+}
+);
+width = 1029;
+}
+);
+note = uni14E8;
+unicode = 5352;
+},
+{
+glyphname = "lwaaWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (183,-192);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (805,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni14E9;
+unicode = 5353;
+},
+{
+glyphname = "l-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(447,345,l),
+(461,409,l),
+(271,409,ls),
+(215,409,o),
+(185,437,o),
+(185,487,cs),
+(185,549,o),
+(214,628,o),
+(314,628,cs),
+(336,628,l),
+(349,690,l),
+(321,690,ls),
+(185,690,o),
+(117,594,o),
+(117,481,cs),
+(117,396,o),
+(172,345,o),
+(267,345,cs)
+);
+}
+);
+width = 473;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "m-canadian";
+note = uni14EA;
+unicode = 5354;
+},
+{
+glyphname = "lWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(327,345,l),
+(335,386,l),
+(168,459,l),
+(160,426,l),
+(359,498,l),
+(365,528,l),
+(197,600,l),
+(190,567,l),
+(389,640,l),
+(400,690,l),
+(386,690,l),
+(141,600,l),
+(136,576,l),
+(309,505,l),
+(315,529,l),
+(111,459,l),
+(105,434,l),
+(313,345,l)
+);
+}
+);
+width = 369;
+}
+);
+metricRight = "=|";
+note = uni14EB;
+unicode = 5355;
+},
+{
+glyphname = "mediall-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(515,-13,l),
+(528,51,l),
+(159,209,l),
+(150,162,l),
+(585,319,l),
+(594,360,l),
+(224,511,l),
+(215,469,l),
+(650,625,l),
+(667,702,l),
+(641,702,l),
+(128,517,l),
+(121,479,l),
+(492,327,l),
+(499,362,l),
+(64,211,l),
+(56,173,l),
+(490,-13,l)
+);
+}
+);
+width = 638;
+}
+);
+metricRight = "=|";
+note = uni14EC;
+unicode = 5356;
+},
+{
+glyphname = "se-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (217,690);
+},
+{
+name = top_right_can;
+pos = (512,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(412,0,l),
+(483,332,l),
+(444,332,ls),
+(276,332,o),
+(206,415,o),
+(245,595,cs),
+(266,690,l),
+(169,690,l),
+(148,588,ls),
+(103,380,o),
+(209,246,o),
+(424,246,cs),
+(445,246,l),
+(376,279,l),
+(317,0,l)
+);
+}
+);
+width = 539;
+}
+);
+note = uni14ED;
+unicode = 5357;
+},
+{
+glyphname = "saai-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (294,0);
+ref = ring_top.canadian;
+}
+);
+width = 539;
+}
+);
+note = uni14EE;
+unicode = 5358;
+},
+{
+glyphname = "si-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (220,690);
+},
+{
+name = top_right_can;
+pos = (515,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(122,0,l),
+(182,281,l),
+(102,246,l),
+(144,246,ls),
+(353,246,o),
+(489,352,o),
+(539,584,cs),
+(562,690,l),
+(466,690,l),
+(445,593,ls),
+(407,420,o),
+(305,332,o),
+(148,332,cs),
+(96,332,l),
+(25,0,l)
+);
+}
+);
+width = 539;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+unicode = 5359;
+},
+{
+glyphname = "sii-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (345,0);
+ref = dot_top;
+}
+);
+width = 539;
+}
+);
+note = uni14F0;
+unicode = 5360;
+},
+{
+glyphname = "so-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (512,690);
+},
+{
+name = top_left_can;
+pos = (217,690);
+},
+{
+name = top_right_can;
+pos = (512,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(119,0,l),
+(140,97,ls),
+(178,270,o),
+(279,357,o),
+(437,357,cs),
+(489,357,l),
+(559,690,l),
+(464,690,l),
+(404,409,l),
+(482,443,l),
+(440,443,ls),
+(233,443,o),
+(96,338,o),
+(45,105,cs),
+(22,0,l)
+);
+}
+);
+width = 540;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+unicode = 5361;
+},
+{
+glyphname = "soo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (342,0);
+ref = dot_top;
+}
+);
+width = 539;
+}
+);
+note = uni14F2;
+unicode = 5362;
+},
+{
+glyphname = "ycreesoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (174,0);
+ref = doubledot_top;
+}
+);
+width = 539;
+}
+);
+note = uni14F3;
+unicode = 5363;
+},
+{
+glyphname = "sa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (220,690);
+},
+{
+name = top_right_can;
+pos = (514,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(415,0,l),
+(437,101,ls),
+(481,310,o),
+(376,443,o),
+(160,443,cs),
+(139,443,l),
+(209,411,l),
+(268,690,l),
+(172,690,l),
+(101,357,l),
+(140,357,ls),
+(307,357,o),
+(379,274,o),
+(339,95,cs),
+(319,0,l)
+);
+}
+);
+width = 539;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+unicode = 5364;
+},
+{
+glyphname = "saa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+}
+);
+width = 539;
+}
+);
+note = uni14F5;
+unicode = 5365;
+},
+{
+glyphname = "swe-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "se-canadian";
+}
+);
+width = 764;
+}
+);
+note = uni14F6;
+unicode = 5366;
+},
+{
+glyphname = "sweWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "se-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (539,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 764;
+}
+);
+note = uni14F7;
+unicode = 5367;
+},
+{
+glyphname = "swi-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "si-canadian";
+}
+);
+width = 764;
+}
+);
+note = uni14F8;
+unicode = 5368;
+},
+{
+glyphname = "swiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (539,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 764;
+}
+);
+note = uni14F9;
+unicode = 5369;
+},
+{
+glyphname = "swii-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (569,0);
+ref = dot_top;
+}
+);
+width = 764;
+}
+);
+note = uni14FA;
+unicode = 5370;
+},
+{
+glyphname = "swiiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (345,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (539,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 764;
+}
+);
+note = uni14FB;
+unicode = 5371;
+},
+{
+glyphname = "swo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "so-canadian";
+}
+);
+width = 764;
+}
+);
+note = uni14FC;
+unicode = 5372;
+},
+{
+glyphname = "swoWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (539,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 764;
+}
+);
+note = uni14FD;
+unicode = 5373;
+},
+{
+glyphname = "swoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (566,0);
+ref = dot_top;
+}
+);
+width = 764;
+}
+);
+note = uni14FE;
+unicode = 5374;
+},
+{
+glyphname = "swooWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (342,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (539,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 764;
+}
+);
+note = uni14FF;
+unicode = 5375;
+},
+{
+glyphname = "swa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "sa-canadian";
+}
+);
+width = 764;
+}
+);
+note = uni1500;
+unicode = 5376;
+},
+{
+glyphname = "swaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (539,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 764;
+}
+);
+note = uni1501;
+unicode = 5377;
+},
+{
+glyphname = "swaa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (275,0);
+ref = dot_top;
+}
+);
+width = 764;
+}
+);
+note = uni1502;
+unicode = 5378;
+},
+{
+glyphname = "swaaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (539,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 764;
+}
+);
+note = uni1503;
+unicode = 5379;
+},
+{
+glyphname = "swaaNaskapi-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "sa-canadian";
+}
+);
+width = 763;
+}
+);
+note = uni1504;
+unicode = 5380;
+},
+{
+glyphname = "s-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(315,345,l),
+(327,395,ls),
+(350,507,o),
+(294,580,o),
+(184,580,cs),
+(163,580,l),
+(198,549,l),
+(228,690,l),
+(159,690,l),
+(125,525,l),
+(159,525,ls),
+(242,525,o),
+(276,482,o),
+(259,398,cs),
+(247,345,l)
+);
+}
+);
+width = 357;
+}
+);
+metricRight = "=|";
+note = uni1505;
+unicode = 5381;
+},
+{
+color = 6;
+glyphname = "sAthapascan-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(280,177,o),
+(325,225,o),
+(325,285,cs),
+(325,324,o),
+(302,352,o),
+(263,366,cs),
+(201,387,ls),
+(177,396,o),
+(167,411,o),
+(167,429,cs),
+(167,461,o),
+(190,484,o),
+(237,484,cs),
+(280,484,o),
+(301,464,o),
+(294,424,c),
+(354,424,l),
+(365,492,o),
+(318,533,o),
+(241,533,cs),
+(151,533,o),
+(107,485,o),
+(107,424,cs),
+(107,384,o),
+(133,355,o),
+(168,342,cs),
+(230,321,ls),
+(255,311,o),
+(265,298,o),
+(265,279,cs),
+(265,247,o),
+(241,226,o),
+(195,226,cs),
+(145,226,o),
+(127,247,o),
+(133,288,c),
+(73,288,l),
+(62,220,o),
+(103,177,o),
+(192,177,cs)
+);
+}
+);
+width = 381;
+}
+);
+metricRight = "=|";
+note = uni1506;
+unicode = 5382;
+},
+{
+glyphname = "sw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(153,345,l),
+(163,395,ls),
+(183,486,o),
+(228,525,o),
+(317,525,cs),
+(352,525,l),
+(386,690,l),
+(319,690,l),
+(289,550,l),
+(337,580,l),
+(302,580,ls),
+(190,580,o),
+(121,520,o),
+(97,400,cs),
+(85,345,l)
+);
+}
+);
+width = 354;
+}
+);
+metricLeft = "=|s-canadian";
+metricRight = "=|s-canadian";
+note = uni1507;
+unicode = 5383;
+},
+{
+glyphname = "sBlackfoot-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(322,345,l),
+(335,409,l),
+(248,409,ls),
+(196,409,o),
+(174,435,o),
+(185,492,cs),
+(228,690,l),
+(159,690,l),
+(118,493,ls),
+(99,401,o),
+(142,345,o),
+(238,345,cs)
+);
+}
+);
+width = 348;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "m-canadian";
+note = uni1508;
+unicode = 5384;
+},
+{
+glyphname = "moosecreesk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(307,217,o),
+(350,321,o),
+(350,421,cs),
+(350,523,o),
+(300,580,o),
+(191,580,cs),
+(174,580,l),
+(199,550,l),
+(229,690,l),
+(160,690,l),
+(126,525,l),
+(173,525,ls),
+(259,525,o),
+(290,496,o),
+(286,412,c),
+(303,418,l),
+(296,452,o),
+(267,477,o),
+(218,477,cs),
+(130,477,o),
+(87,397,o),
+(87,328,cs),
+(87,262,o),
+(131,217,o),
+(202,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(167,268,o),
+(147,292,o),
+(147,328,cs),
+(147,372,o),
+(174,429,o),
+(225,429,cs),
+(260,429,o),
+(281,406,o),
+(281,370,cs),
+(281,323,o),
+(251,268,o),
+(205,268,cs)
+);
+}
+);
+width = 383;
+}
+);
+metricRight = "=|";
+note = uni1509;
+unicode = 5385;
+},
+{
+glyphname = "skwNaskapi-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(296,217,o),
+(343,298,o),
+(343,373,cs),
+(343,436,o),
+(305,477,o),
+(246,477,cs),
+(205,477,o),
+(170,454,o),
+(154,413,c),
+(170,423,l),
+(195,492,o),
+(242,525,o),
+(325,525,cs),
+(377,525,l),
+(411,690,l),
+(343,690,l),
+(313,549,l),
+(353,580,l),
+(321,580,ls),
+(153,580,o),
+(90,436,o),
+(90,335,cs),
+(90,265,o),
+(132,217,o),
+(205,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(170,268,o),
+(151,292,o),
+(151,328,cs),
+(151,372,o),
+(177,429,o),
+(227,429,cs),
+(262,429,o),
+(282,406,o),
+(282,370,cs),
+(282,323,o),
+(253,268,o),
+(207,268,cs)
+);
+}
+);
+width = 383;
+}
+);
+metricLeft = "=|moosecreesk-canadian";
+metricRight = "=|moosecreesk-canadian";
+note = uni150A;
+unicode = 5386;
+},
+{
+glyphname = "swNaskapi-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(298,183,l),
+(308,227,ls),
+(331,336,o),
+(279,406,o),
+(170,406,cs),
+(146,406,l),
+(173,375,l),
+(202,508,l),
+(133,508,l),
+(100,351,l),
+(144,351,ls),
+(225,351,o),
+(259,314,o),
+(241,229,cs),
+(231,183,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(274,42,o),
+(298,66,o),
+(298,95,cs),
+(298,124,o),
+(274,148,o),
+(245,148,cs),
+(216,148,o),
+(192,124,o),
+(192,95,cs),
+(192,66,o),
+(216,42,o),
+(245,42,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(216,542,o),
+(240,566,o),
+(240,595,cs),
+(240,625,o),
+(216,648,o),
+(186,648,cs),
+(158,648,o),
+(134,625,o),
+(134,595,cs),
+(134,566,o),
+(158,542,o),
+(186,542,cs)
+);
+}
+);
+width = 387;
+}
+);
+metricRight = "=|";
+note = uni150B;
+unicode = 5387;
+},
+{
+glyphname = "spwaNaskapi-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(545,0,l),
+(562,80,l),
+(168,357,l),
+(159,314,l),
+(670,590,l),
+(692,690,l),
+(666,690,l),
+(60,362,l),
+(53,327,l),
+(520,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(220,492,o),
+(243,516,o),
+(243,545,cs),
+(243,575,o),
+(219,598,o),
+(190,598,cs),
+(161,598,o),
+(137,575,o),
+(137,545,cs),
+(137,515,o),
+(161,492,o),
+(190,492,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(423,603,l),
+(432,644,ls),
+(448,724,o),
+(411,776,o),
+(334,776,cs),
+(311,776,l),
+(346,751,l),
+(367,850,l),
+(300,850,l),
+(274,725,l),
+(302,725,ls),
+(357,725,o),
+(377,697,o),
+(364,640,cs),
+(356,603,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(618,704,o),
+(641,728,o),
+(641,758,cs),
+(641,788,o),
+(618,811,o),
+(588,811,cs),
+(559,811,o),
+(535,788,o),
+(535,758,cs),
+(535,728,o),
+(559,704,o),
+(588,704,cs)
+);
+}
+);
+width = 649;
+}
+);
+metricRight = "pa-canadian";
+metricWidth = "pa-canadian";
+note = uni150C;
+unicode = 5388;
+},
+{
+glyphname = "stwaNaskapi-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (387,0);
+ref = "ta-canadian";
+}
+);
+width = 995;
+}
+);
+note = uni150D;
+unicode = 5389;
+},
+{
+glyphname = "skwaNaskapi-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (387,0);
+ref = "ka-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni150E;
+unicode = 5390;
+},
+{
+glyphname = "scwaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (387,0);
+ref = "ca-canadian";
+}
+);
+width = 969;
+}
+);
+note = uni150F;
+unicode = 5391;
+},
+{
+glyphname = "she-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (378,690);
+},
+{
+name = top_right_can;
+pos = (795,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(729,-13,o),
+(810,75,o),
+(842,229,cs),
+(858,302,l),
+(762,302,l),
+(748,231,ls),
+(725,124,o),
+(680,71,o),
+(604,71,cs),
+(521,71,o),
+(489,128,o),
+(506,243,cs),
+(536,435,ls),
+(562,608,o),
+(495,702,o),
+(352,702,cs),
+(220,702,o),
+(139,614,o),
+(107,461,cs),
+(92,387,l),
+(187,387,l),
+(203,459,ls),
+(225,566,o),
+(270,618,o),
+(346,618,cs),
+(429,618,o),
+(461,561,o),
+(443,446,cs),
+(413,256,ls),
+(387,82,o),
+(455,-13,o),
+(598,-13,cs)
+);
+}
+);
+width = 905;
+}
+);
+metricRight = "=|";
+note = uni1510;
+unicode = 5392;
+},
+{
+glyphname = "shi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (303,690);
+},
+{
+name = top_right_can;
+pos = (721,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(377,-13,o),
+(449,66,o),
+(494,236,cs),
+(550,448,ls),
+(581,567,o),
+(621,618,o),
+(697,618,cs),
+(780,618,o),
+(818,562,o),
+(792,444,cs),
+(781,387,l),
+(876,387,l),
+(885,432,ls),
+(921,598,o),
+(845,702,o),
+(701,702,cs),
+(573,702,o),
+(500,623,o),
+(456,454,cs),
+(400,242,ls),
+(369,124,o),
+(328,71,o),
+(251,71,cs),
+(170,71,o),
+(131,127,o),
+(157,245,cs),
+(169,302,l),
+(73,302,l),
+(64,258,ls),
+(29,91,o),
+(104,-13,o),
+(248,-13,cs)
+);
+}
+);
+width = 905;
+}
+);
+metricLeft = "she-canadian";
+metricRight = "she-canadian";
+note = uni1511;
+unicode = 5393;
+},
+{
+glyphname = "shii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (551,0);
+ref = dot_top;
+}
+);
+width = 905;
+}
+);
+note = uni1512;
+unicode = 5394;
+},
+{
+glyphname = "sho-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (519,497);
+},
+{
+name = top_left_can;
+pos = (333,497);
+},
+{
+name = top_right_can;
+pos = (704,497);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(306,69,l),
+(200,69,o),
+(142,106,o),
+(142,167,cs),
+(142,226,o),
+(180,274,o),
+(258,274,cs),
+(394,274,o),
+(505,121,o),
+(679,121,cs),
+(805,121,o),
+(880,203,o),
+(880,314,cs),
+(880,421,o),
+(790,491,o),
+(639,492,c),
+(623,411,l),
+(729,410,o),
+(787,373,o),
+(787,311,cs),
+(787,253,o),
+(750,205,o),
+(672,205,cs),
+(535,205,o),
+(424,358,o),
+(250,358,cs),
+(125,358,o),
+(49,275,o),
+(49,165,cs),
+(49,57,o),
+(140,-13,o),
+(290,-13,c)
+);
+}
+);
+width = 929;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1513;
+unicode = 5395;
+},
+{
+glyphname = "shoo-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (349,-192);
+ref = dot_top;
+}
+);
+width = 927;
+}
+);
+note = uni1514;
+unicode = 5396;
+},
+{
+glyphname = "sha-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (521,497);
+},
+{
+name = top_left_can;
+pos = (334,497);
+},
+{
+name = top_right_can;
+pos = (706,497);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(715,-17,o),
+(858,49,o),
+(858,204,cs),
+(858,296,o),
+(792,358,o),
+(682,358,cs),
+(527,358,o),
+(380,205,o),
+(262,205,cs),
+(202,205,o),
+(167,235,o),
+(167,283,cs),
+(167,373,o),
+(250,412,o),
+(361,411,c),
+(379,492,l),
+(216,497,o),
+(73,430,o),
+(73,275,cs),
+(73,184,o),
+(139,121,o),
+(249,121,cs),
+(405,121,o),
+(552,274,o),
+(670,274,cs),
+(730,274,o),
+(764,243,o),
+(764,196,cs),
+(764,106,o),
+(682,68,o),
+(569,69,c),
+(552,-13,l)
+);
+}
+);
+width = 931;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1515;
+unicode = 5397;
+},
+{
+glyphname = "shaa-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (349,-192);
+ref = dot_top;
+}
+);
+width = 927;
+}
+);
+note = uni1516;
+unicode = 5398;
+},
+{
+glyphname = "shwe-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "she-canadian";
+}
+);
+width = 1129;
+}
+);
+note = uni1517;
+unicode = 5399;
+},
+{
+glyphname = "shweWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "she-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (905,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1129;
+}
+);
+note = uni1518;
+unicode = 5400;
+},
+{
+glyphname = "shwi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "shi-canadian";
+}
+);
+width = 1129;
+}
+);
+note = uni1519;
+unicode = 5401;
+},
+{
+glyphname = "shwiWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (905,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1129;
+}
+);
+note = uni151A;
+unicode = 5402;
+},
+{
+glyphname = "shwii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (775,0);
+ref = dot_top;
+}
+);
+width = 1129;
+}
+);
+note = uni151B;
+unicode = 5403;
+},
+{
+glyphname = "shwiiWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (551,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (905,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1129;
+}
+);
+note = uni151C;
+unicode = 5404;
+},
+{
+glyphname = "shwo-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "sho-canadian";
+}
+);
+width = 1152;
+}
+);
+note = uni151D;
+unicode = 5405;
+},
+{
+glyphname = "shwoWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (927,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1152;
+}
+);
+note = uni151E;
+unicode = 5406;
+},
+{
+glyphname = "shwoo-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (573,-192);
+ref = dot_top;
+}
+);
+width = 1152;
+}
+);
+note = uni151F;
+unicode = 5407;
+},
+{
+glyphname = "shwooWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (349,-192);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (927,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1152;
+}
+);
+note = uni1520;
+unicode = 5408;
+},
+{
+glyphname = "shwa-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "sha-canadian";
+}
+);
+width = 1152;
+}
+);
+note = uni1521;
+unicode = 5409;
+},
+{
+glyphname = "shwaWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (927,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1152;
+}
+);
+note = uni1522;
+unicode = 5410;
+},
+{
+glyphname = "shwaa-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (573,-192);
+ref = dot_top;
+}
+);
+width = 1152;
+}
+);
+note = uni1523;
+unicode = 5411;
+},
+{
+glyphname = "shwaaWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (349,-192);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (927,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1152;
+}
+);
+note = uni1524;
+unicode = 5412;
+},
+{
+glyphname = "sh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(595,282,o),
+(702,340,o),
+(702,459,cs),
+(702,529,o),
+(653,579,o),
+(569,579,cs),
+(455,579,o),
+(353,472,o),
+(264,472,cs),
+(219,472,o),
+(194,496,o),
+(194,532,cs),
+(194,602,o),
+(257,639,o),
+(350,637,c),
+(362,697,l),
+(233,704,o),
+(125,647,o),
+(125,526,cs),
+(125,457,o),
+(175,408,o),
+(259,408,cs),
+(373,408,o),
+(475,514,o),
+(564,514,cs),
+(608,514,o),
+(634,491,o),
+(634,454,cs),
+(634,385,o),
+(572,347,o),
+(478,350,c),
+(467,289,l)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni1525;
+unicode = 5413;
+},
+{
+glyphname = "ye-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (663,345);
+},
+{
+name = top_left_can;
+pos = (185,690);
+},
+{
+name = top_right_can;
+pos = (544,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(443,0,l),
+(513,326,l),
+(178,326,l),
+(179,276,l),
+(592,639,l),
+(534,701,l),
+(48,270,l),
+(43,241,l),
+(399,241,l),
+(348,0,l)
+);
+}
+);
+width = 570;
+}
+);
+note = uni1526;
+unicode = 5414;
+},
+{
+glyphname = "yaai-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (3,0);
+ref = ring_top.canadian;
+}
+);
+width = 570;
+}
+);
+note = uni1527;
+unicode = 5415;
+},
+{
+glyphname = "yi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (223,690);
+},
+{
+name = top_right_can;
+pos = (581,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(120,0,l),
+(171,241,l),
+(527,241,l),
+(534,270,l),
+(218,701,l),
+(149,650,l),
+(425,278,l),
+(430,326,l),
+(93,326,l),
+(24,0,l)
+);
+}
+);
+width = 570;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni1528;
+unicode = 5416;
+},
+{
+glyphname = "yii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (54,0);
+ref = dot_top;
+}
+);
+width = 570;
+}
+);
+note = uni1529;
+unicode = 5417;
+},
+{
+glyphname = "yo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (662,345);
+},
+{
+name = top_double;
+pos = (543,690);
+},
+{
+name = top_left_can;
+pos = (185,690);
+},
+{
+name = top_right_can;
+pos = (543,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(466,40,l),
+(189,412,l),
+(185,364,l),
+(522,364,l),
+(590,690,l),
+(495,690,l),
+(443,449,l),
+(87,449,l),
+(80,419,l),
+(396,-12,l)
+);
+}
+);
+width = 570;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152A;
+unicode = 5418;
+},
+{
+glyphname = "yoo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (373,0);
+ref = dot_top;
+}
+);
+width = 570;
+}
+);
+note = uni152B;
+unicode = 5419;
+},
+{
+glyphname = "ycreeyoo-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (205,0);
+ref = doubledot_top;
+}
+);
+width = 570;
+}
+);
+note = uni152C;
+unicode = 5420;
+},
+{
+glyphname = "ya-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (219,690);
+},
+{
+name = top_right_can;
+pos = (576,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(566,419,l),
+(573,449,l),
+(215,449,l),
+(268,690,l),
+(171,690,l),
+(101,364,l),
+(438,364,l),
+(436,413,l),
+(22,50,l),
+(80,-12,l)
+);
+}
+);
+width = 570;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152D;
+unicode = 5421;
+},
+{
+glyphname = "yaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+}
+);
+width = 570;
+}
+);
+note = uni152E;
+unicode = 5422;
+},
+{
+glyphname = "ywe-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ye-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni152F;
+unicode = 5423;
+},
+{
+glyphname = "yweWestCree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ye-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (570,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni1530;
+unicode = 5424;
+},
+{
+glyphname = "ywi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "yi-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni1531;
+unicode = 5425;
+},
+{
+glyphname = "ywiWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (570,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni1532;
+unicode = 5426;
+},
+{
+glyphname = "ywii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (278,0);
+ref = dot_top;
+}
+);
+width = 794;
+}
+);
+note = uni1533;
+unicode = 5427;
+},
+{
+glyphname = "ywiiWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (54,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (570,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni1534;
+unicode = 5428;
+},
+{
+glyphname = "ywo-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "yo-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni1535;
+unicode = 5429;
+},
+{
+glyphname = "ywoWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (570,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni1536;
+unicode = 5430;
+},
+{
+glyphname = "ywoo-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (598,0);
+ref = dot_top;
+}
+);
+width = 794;
+}
+);
+note = uni1537;
+unicode = 5431;
+},
+{
+glyphname = "ywooWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (373,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (570,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni1538;
+unicode = 5432;
+},
+{
+glyphname = "ywa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ya-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni1539;
+unicode = 5433;
+},
+{
+glyphname = "ywaWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (570,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni153A;
+unicode = 5434;
+},
+{
+glyphname = "ywaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (274,0);
+ref = dot_top;
+}
+);
+width = 794;
+}
+);
+note = uni153B;
+unicode = 5435;
+},
+{
+glyphname = "ywaaWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (570,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni153C;
+unicode = 5436;
+},
+{
+glyphname = "ywaaNaskapi-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ya-canadian";
+}
+);
+width = 793;
+}
+);
+note = uni153D;
+unicode = 5437;
+},
+{
+glyphname = "y-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(371,550,l),
+(376,569,l),
+(204,569,l),
+(229,690,l),
+(161,690,l),
+(124,514,l),
+(294,514,l),
+(290,554,l),
+(95,378,l),
+(136,335,l)
+);
+}
+);
+width = 342;
+}
+);
+note = uni153E;
+unicode = 5438;
+},
+{
+glyphname = "biblecreey-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(143,345,l),
+(266,618,l),
+(228,618,l),
+(265,345,l),
+(306,345,l),
+(462,618,l),
+(419,618,l),
+(429,345,l),
+(488,345,l),
+(492,361,l),
+(482,690,l),
+(437,690,l),
+(277,408,l),
+(315,408,l),
+(277,690,l),
+(232,690,l),
+(82,361,l),
+(78,345,l)
+);
+}
+);
+width = 522;
+}
+);
+metricRight = "=|";
+note = uni153F;
+unicode = 5439;
+},
+{
+glyphname = "yWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(246,191,l),
+(274,324,l),
+(401,324,l),
+(415,388,l),
+(288,388,l),
+(316,519,l),
+(249,519,l),
+(221,388,l),
+(94,388,l),
+(80,324,l),
+(208,324,l),
+(179,191,l)
+);
+}
+);
+width = 445;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1540;
+unicode = 5440;
+},
+{
+glyphname = "yiSayisi-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (39,183);
+ref = "fullstop-canadian";
+}
+);
+width = 355;
+}
+);
+metricLeft = "fullstop-canadian";
+metricWidth = "fullstop-canadian";
+note = uni1541;
+unicode = 5441;
+},
+{
+glyphname = "re-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (355,497);
+},
+{
+name = top_left_can;
+pos = (173,497);
+},
+{
+name = top_right_can;
+pos = (801,497);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(406,-13,o),
+(491,65,o),
+(525,220,cs),
+(561,393,l),
+(828,393,l),
+(846,479,l),
+(486,479,l),
+(431,224,ls),
+(409,120,o),
+(359,71,o),
+(280,71,cs),
+(185,71,o),
+(144,128,o),
+(167,236,cs),
+(219,479,l),
+(123,479,l),
+(72,244,ls),
+(40,88,o),
+(121,-13,o),
+(274,-13,cs)
+);
+}
+);
+width = 850;
+}
+);
+metricRight = "=|ne-canadian";
+note = uni1542;
+unicode = 5442;
+},
+{
+glyphname = "reRCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (604,497);
+},
+{
+name = top_left_can;
+pos = (157,497);
+},
+{
+name = top_right_can;
+pos = (785,497);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(656,-13,o),
+(741,65,o),
+(774,220,cs),
+(830,479,l),
+(733,479,l),
+(679,224,ls),
+(657,120,o),
+(608,71,o),
+(528,71,cs),
+(434,71,o),
+(392,129,o),
+(414,236,cs),
+(467,479,l),
+(106,479,l),
+(88,393,l),
+(355,393,l),
+(323,244,ls),
+(290,88,o),
+(370,-13,o),
+(525,-13,cs)
+);
+}
+);
+width = 850;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1543;
+unicode = 5443;
+},
+{
+glyphname = "leWestCree-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (604,497);
+},
+{
+name = top_left_can;
+pos = (157,497);
+},
+{
+name = top_right_can;
+pos = (785,497);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(365,0,l),
+(419,255,ls),
+(441,358,o),
+(491,409,o),
+(570,409,cs),
+(665,409,o),
+(706,351,o),
+(683,243,cs),
+(632,0,l),
+(727,0,l),
+(778,235,ls),
+(810,391,o),
+(730,492,o),
+(576,492,cs),
+(444,492,o),
+(359,414,o),
+(327,259,cs),
+(289,86,l),
+(22,86,l),
+(4,0,l)
+);
+}
+);
+width = 850;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+unicode = 5444;
+},
+{
+glyphname = "raai-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (136,-192);
+ref = ring_top.canadian;
+}
+);
+width = 850;
+}
+);
+note = uni1545;
+unicode = 5445;
+},
+{
+glyphname = "ri-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (355,497);
+},
+{
+name = top_left_can;
+pos = (174,497);
+},
+{
+name = top_right_can;
+pos = (802,497);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(116,0,l),
+(170,255,ls),
+(192,358,o),
+(242,409,o),
+(326,409,cs),
+(416,409,o),
+(457,350,o),
+(435,243,cs),
+(383,0,l),
+(743,0,l),
+(761,86,l),
+(495,86,l),
+(526,235,ls),
+(560,391,o),
+(479,492,o),
+(330,492,cs),
+(193,492,o),
+(108,414,o),
+(75,259,cs),
+(20,0,l)
+);
+}
+);
+width = 849;
+}
+);
+metricLeft = "re-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+unicode = 5446;
+},
+{
+glyphname = "rii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (186,-192);
+ref = dot_top;
+}
+);
+width = 850;
+}
+);
+note = uni1547;
+unicode = 5447;
+},
+{
+glyphname = "ro-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (332,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,0,l),
+(181,283,l),
+(129,241,l),
+(247,241,ls),
+(432,241,o),
+(534,349,o),
+(534,500,cs),
+(534,614,o),
+(454,690,o),
+(326,690,cs),
+(172,690,l),
+(154,604,l),
+(311,604,ls),
+(393,604,o),
+(440,562,o),
+(440,494,cs),
+(440,394,o),
+(372,326,o),
+(257,326,cs),
+(95,326,l),
+(25,0,l)
+);
+}
+);
+width = 543;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1548;
+unicode = 5448;
+},
+{
+glyphname = "roo-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (163,0);
+ref = dot_top;
+}
+);
+width = 543;
+}
+);
+note = uni1549;
+unicode = 5449;
+},
+{
+glyphname = "loWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (352,690);
+},
+{
+name = top_left_can;
+pos = (220,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(197,0,ls),
+(382,0,o),
+(483,108,o),
+(483,259,cs),
+(483,374,o),
+(404,449,o),
+(275,449,cs),
+(173,449,l),
+(208,405,l),
+(268,690,l),
+(172,690,l),
+(102,364,l),
+(261,364,ls),
+(343,364,o),
+(389,322,o),
+(389,254,cs),
+(389,154,o),
+(321,86,o),
+(206,86,cs),
+(43,86,l),
+(25,0,l)
+);
+}
+);
+width = 543;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+unicode = 5450;
+},
+{
+glyphname = "ra-canadian";
+lastChange = "2023-01-13 15:54:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (402,690);
+},
+{
+name = top_right_can;
+pos = (515,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(415,0,l),
+(485,326,l),
+(328,326,ls),
+(245,326,o),
+(199,368,o),
+(199,436,cs),
+(199,536,o),
+(267,604,o),
+(382,604,cs),
+(544,604,l),
+(562,690,l),
+(391,690,ls),
+(207,690,o),
+(105,582,o),
+(105,431,cs),
+(105,316,o),
+(185,241,o),
+(313,241,cs),
+(414,241,l),
+(380,285,l),
+(320,0,l)
+);
+}
+);
+width = 543;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+unicode = 5451;
+},
+{
+glyphname = "raa-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (232,0);
+ref = dot_top;
+}
+);
+width = 543;
+}
+);
+note = uni154C;
+unicode = 5452;
+},
+{
+glyphname = "laWestCree-canadian";
+lastChange = "2023-01-13 15:54:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (515,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(415,0,l),
+(434,86,l),
+(275,86,ls),
+(193,86,o),
+(148,128,o),
+(148,196,cs),
+(148,296,o),
+(215,364,o),
+(330,364,cs),
+(493,364,l),
+(562,690,l),
+(467,690,l),
+(407,407,l),
+(458,449,l),
+(339,449,ls),
+(155,449,o),
+(53,341,o),
+(53,189,cs),
+(53,75,o),
+(132,0,o),
+(261,0,cs)
+);
+}
+);
+width = 543;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+unicode = 5453;
+},
+{
+glyphname = "rwaa-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (456,0);
+ref = dot_top;
+}
+);
+width = 767;
+}
+);
+note = uni154E;
+unicode = 5454;
+},
+{
+glyphname = "rwaaWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (232,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (543,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 767;
+}
+);
+note = uni154F;
+unicode = 5455;
+},
+{
+glyphname = "r-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(288,345,l),
+(325,517,l),
+(246,517,ls),
+(208,517,o),
+(189,533,o),
+(189,563,cs),
+(189,609,o),
+(215,636,o),
+(270,636,cs),
+(350,636,l),
+(361,690,l),
+(282,690,ls),
+(187,690,o),
+(127,646,o),
+(127,559,cs),
+(127,501,o),
+(166,463,o),
+(235,463,cs),
+(281,463,l),
+(250,488,l),
+(219,345,l)
+);
+}
+);
+width = 329;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni1550;
+unicode = 5456;
+},
+{
+glyphname = "rWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(160,690,l),
+(152,648,l),
+(319,576,l),
+(327,609,l),
+(128,536,l),
+(121,506,l),
+(289,435,l),
+(297,468,l),
+(98,394,l),
+(87,345,l),
+(99,345,l),
+(346,435,l),
+(351,459,l),
+(178,529,l),
+(172,505,l),
+(376,576,l),
+(382,601,l),
+(173,690,l)
+);
+}
+);
+width = 369;
+}
+);
+metricLeft = "=|lWestCree-canadian";
+metricRight = "=|lWestCree-canadian";
+note = uni1551;
+unicode = 5457;
+},
+{
+glyphname = "rMedial-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(42,-13,l),
+(553,173,l),
+(561,211,l),
+(191,362,l),
+(184,327,l),
+(619,479,l),
+(627,517,l),
+(193,702,l),
+(168,702,l),
+(154,639,l),
+(523,481,l),
+(532,527,l),
+(98,371,l),
+(89,329,l),
+(458,179,l),
+(468,221,l),
+(32,65,l),
+(15,-13,l)
+);
+}
+);
+width = 637;
+}
+);
+metricLeft = "mediall-canadian";
+metricRight = "mediall-canadian";
+note = uni1552;
+unicode = 5458;
+},
+{
+glyphname = "fe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(336,0,l),
+(819,664,l),
+(825,690,l),
+(738,690,l),
+(324,107,l),
+(340,106,l),
+(255,360,l),
+(197,361,l),
+(221,332,o),
+(252,318,o),
+(294,318,cs),
+(420,318,o),
+(485,448,o),
+(485,549,cs),
+(485,639,o),
+(431,702,o),
+(335,702,cs),
+(205,702,o),
+(142,575,o),
+(142,469,cs),
+(142,430,o),
+(150,393,o),
+(166,353,cs),
+(300,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(248,385,o),
+(221,418,o),
+(221,474,cs),
+(221,530,o),
+(249,631,o),
+(331,631,cs),
+(379,631,o),
+(407,597,o),
+(407,543,cs),
+(407,486,o),
+(379,385,o),
+(297,385,cs)
+);
+}
+);
+width = 761;
+}
+);
+metricRight = "e-canadian";
+note = uni1553;
+unicode = 5459;
+},
+{
+glyphname = "faai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (240,0);
+ref = ring_top.canadian;
+}
+);
+width = 762;
+}
+);
+note = uni1554;
+unicode = 5460;
+},
+{
+glyphname = "fi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (460,690);
+},
+{
+name = top_left_can;
+pos = (227,690);
+},
+{
+name = top_right_can;
+pos = (720,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(358,-13,o),
+(414,120,o),
+(414,215,cs),
+(414,308,o),
+(359,375,o),
+(276,375,cs),
+(246,375,o),
+(217,363,o),
+(191,341,c),
+(256,338,l),
+(452,582,l),
+(427,583,l),
+(604,0,l),
+(678,0,l),
+(684,26,l),
+(478,690,l),
+(442,690,l),
+(152,342,ls),
+(102,283,o),
+(72,216,o),
+(72,143,cs),
+(72,50,o),
+(130,-13,o),
+(222,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(178,59,o),
+(151,92,o),
+(151,148,cs),
+(151,204,o),
+(179,304,o),
+(261,304,cs),
+(309,304,o),
+(336,270,o),
+(336,215,cs),
+(336,158,o),
+(308,59,o),
+(226,59,cs)
+);
+}
+);
+width = 761;
+}
+);
+metricLeft = "fe-canadian";
+metricRight = "e-canadian";
+note = uni1555;
+unicode = 5461;
+},
+{
+glyphname = "fii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (291,0);
+ref = dot_top;
+}
+);
+width = 762;
+}
+);
+note = uni1556;
+unicode = 5462;
+},
+{
+glyphname = "fo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (320,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(66,0,l),
+(669,327,l),
+(677,361,l),
+(429,639,ls),
+(392,681,o),
+(353,702,o),
+(300,702,cs),
+(174,702,o),
+(113,576,o),
+(110,478,cs),
+(107,381,o),
+(163,315,o),
+(253,315,cs),
+(371,315,o),
+(440,422,o),
+(442,529,cs),
+(443,556,o),
+(440,582,o),
+(433,603,c),
+(398,558,l),
+(582,352,l),
+(586,369,l),
+(58,85,l),
+(40,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(214,385,o),
+(187,421,o),
+(188,482,cs),
+(190,540,o),
+(218,632,o),
+(298,632,cs),
+(347,632,o),
+(375,595,o),
+(373,536,cs),
+(372,476,o),
+(344,385,o),
+(264,385,cs)
+);
+}
+);
+width = 685;
+}
+);
+metricRight = "o-canadian";
+note = uni1557;
+unicode = 5463;
+},
+{
+glyphname = "foo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "fo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (151,0);
+ref = dot_top;
+}
+);
+width = 685;
+}
+);
+note = uni1558;
+unicode = 5464;
+},
+{
+glyphname = "fa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (555,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(542,0,l),
+(557,72,l),
+(152,357,l),
+(149,337,l),
+(420,555,l),
+(402,618,l),
+(371,576,o),
+(353,514,o),
+(353,467,cs),
+(353,377,o),
+(412,313,o),
+(504,313,cs),
+(627,313,o),
+(689,445,o),
+(689,543,cs),
+(689,639,o),
+(632,702,o),
+(541,702,cs),
+(497,702,o),
+(457,687,o),
+(416,652,cs),
+(60,361,l),
+(53,327,l),
+(516,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(453,384,o),
+(426,418,o),
+(426,474,cs),
+(426,529,o),
+(454,631,o),
+(536,631,cs),
+(584,631,o),
+(612,597,o),
+(612,543,cs),
+(612,486,o),
+(584,384,o),
+(501,384,cs)
+);
+}
+);
+width = 685;
+}
+);
+metricRight = "=|fo-canadian";
+note = uni1559;
+unicode = 5465;
+},
+{
+glyphname = "faa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (386,0);
+ref = dot_top;
+}
+);
+width = 685;
+}
+);
+note = uni155A;
+unicode = 5466;
+},
+{
+glyphname = "fwaa-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (611,0);
+ref = dot_top;
+}
+);
+width = 909;
+}
+);
+note = uni155B;
+unicode = 5467;
+},
+{
+glyphname = "fwaaWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (386,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (685,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 909;
+}
+);
+note = uni155C;
+unicode = 5468;
+},
+{
+glyphname = "f-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(360,345,l),
+(370,390,l),
+(171,528,l),
+(168,510,l),
+(298,618,l),
+(295,660,l),
+(278,641,o),
+(266,605,o),
+(266,578,cs),
+(266,533,o),
+(296,501,o),
+(339,501,cs),
+(400,501,o),
+(432,563,o),
+(432,617,cs),
+(432,667,o),
+(405,696,o),
+(361,696,cs),
+(337,696,o),
+(314,687,o),
+(290,667,cs),
+(119,526,l),
+(115,507,l),
+(345,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(319,540,o),
+(306,555,o),
+(306,581,cs),
+(306,616,o),
+(327,656,o),
+(358,656,cs),
+(379,656,o),
+(391,641,o),
+(391,616,cs),
+(391,582,o),
+(373,540,o),
+(340,540,cs)
+);
+}
+);
+width = 412;
+}
+);
+note = uni155D;
+unicode = 5469;
+},
+{
+glyphname = "the-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (838,345);
+},
+{
+name = top_center_can;
+pos = (460,690);
+},
+{
+name = top_left_can;
+pos = (213,690);
+},
+{
+name = top_right_can;
+pos = (704,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(517,-13,o),
+(618,81,o),
+(661,277,cs),
+(749,690,l),
+(652,690,l),
+(565,278,ls),
+(534,137,o),
+(466,73,o),
+(338,73,cs),
+(178,73,o),
+(147,167,o),
+(175,298,cs),
+(202,420,l),
+(162,397,l),
+(174,348,o),
+(213,307,o),
+(274,307,cs),
+(402,307,o),
+(461,435,o),
+(465,538,cs),
+(469,637,o),
+(413,702,o),
+(318,702,cs),
+(215,702,o),
+(151,632,o),
+(126,510,cs),
+(84,316,ls),
+(43,128,o),
+(112,-13,o),
+(337,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(228,379,o),
+(201,412,o),
+(201,469,cs),
+(201,526,o),
+(229,631,o),
+(312,631,cs),
+(359,631,o),
+(386,597,o),
+(386,542,cs),
+(386,484,o),
+(359,379,o),
+(275,379,cs)
+);
+}
+);
+width = 721;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155E;
+unicode = 5470;
+},
+{
+glyphname = "theNCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(519,-13,o),
+(620,83,o),
+(663,284,cs),
+(703,471,ls),
+(731,606,o),
+(679,702,o),
+(564,702,cs),
+(433,702,o),
+(371,572,o),
+(371,464,cs),
+(371,378,o),
+(416,307,o),
+(508,307,cs),
+(556,307,o),
+(598,331,o),
+(623,372,c),
+(594,404,l),
+(567,276,ls),
+(537,135,o),
+(467,72,o),
+(341,72,cs),
+(193,72,o),
+(147,156,o),
+(178,302,cs),
+(260,690,l),
+(164,690,l),
+(82,306,ls),
+(40,104,o),
+(135,-13,o),
+(335,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(476,379,o),
+(449,412,o),
+(449,469,cs),
+(449,526,o),
+(478,631,o),
+(560,631,cs),
+(608,631,o),
+(635,597,o),
+(635,542,cs),
+(635,484,o),
+(607,379,o),
+(524,379,cs)
+);
+}
+);
+width = 722;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155F;
+unicode = 5471;
+},
+{
+glyphname = "thi-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (455,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(334,-13,o),
+(396,118,o),
+(396,226,cs),
+(396,312,o),
+(350,383,o),
+(258,383,cs),
+(210,383,o),
+(168,358,o),
+(144,318,c),
+(173,286,l),
+(200,413,ls),
+(230,554,o),
+(300,617,o),
+(426,617,cs),
+(573,617,o),
+(620,534,o),
+(588,387,cs),
+(506,0,l),
+(603,0,l),
+(684,384,ls),
+(726,585,o),
+(632,702,o),
+(432,702,cs),
+(248,702,o),
+(147,607,o),
+(103,406,cs),
+(64,218,ls),
+(36,84,o),
+(87,-13,o),
+(203,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(159,59,o),
+(132,93,o),
+(132,148,cs),
+(132,206,o),
+(159,311,o),
+(242,311,cs),
+(290,311,o),
+(317,277,o),
+(317,220,cs),
+(317,164,o),
+(289,59,o),
+(207,59,cs)
+);
+}
+);
+width = 722;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1560;
+unicode = 5472;
+},
+{
+glyphname = "thiNCree-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (455,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(551,-13,o),
+(614,58,o),
+(640,180,cs),
+(682,374,ls),
+(723,562,o),
+(654,702,o),
+(429,702,cs),
+(249,702,o),
+(147,609,o),
+(105,412,cs),
+(17,0,l),
+(113,0,l),
+(201,412,ls),
+(231,553,o),
+(300,616,o),
+(428,616,cs),
+(588,616,o),
+(619,523,o),
+(590,391,cs),
+(564,270,l),
+(604,293,l),
+(592,342,o),
+(554,383,o),
+(492,383,cs),
+(364,383,o),
+(305,255,o),
+(301,152,cs),
+(298,53,o),
+(353,-13,o),
+(447,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(407,59,o),
+(379,93,o),
+(379,148,cs),
+(379,206,o),
+(407,311,o),
+(490,311,cs),
+(538,311,o),
+(565,277,o),
+(565,220,cs),
+(565,164,o),
+(536,59,o),
+(454,59,cs)
+);
+}
+);
+width = 721;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1561;
+unicode = 5473;
+},
+{
+glyphname = "thii-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "thi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (285,0);
+ref = dot_top;
+}
+);
+width = 722;
+}
+);
+note = uni1562;
+unicode = 5474;
+},
+{
+glyphname = "thiiNCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "thiNCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (285,0);
+ref = dot_top;
+}
+);
+width = 722;
+}
+);
+note = uni1563;
+unicode = 5475;
+},
+{
+glyphname = "tho-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (401,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(236,0,ls),
+(524,0,o),
+(638,221,o),
+(638,421,cs),
+(638,593,o),
+(533,702,o),
+(377,702,cs),
+(209,702,o),
+(116,581,o),
+(116,442,cs),
+(116,348,o),
+(172,285,o),
+(263,285,cs),
+(384,285,o),
+(449,408,o),
+(449,511,cs),
+(449,595,o),
+(400,651,o),
+(318,652,c),
+(308,622,l),
+(324,630,o),
+(346,635,o),
+(372,635,cs),
+(471,634,o),
+(545,557,o),
+(545,426,cs),
+(545,295,o),
+(489,87,o),
+(244,87,cs),
+(69,87,l),
+(50,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(220,356,o),
+(194,389,o),
+(194,443,cs),
+(194,499,o),
+(222,611,o),
+(306,611,cs),
+(353,611,o),
+(379,578,o),
+(379,525,cs),
+(379,469,o),
+(350,356,o),
+(267,356,cs)
+);
+}
+);
+width = 672;
+}
+);
+metricRight = "to-canadian";
+note = uni1564;
+unicode = 5476;
+},
+{
+glyphname = "thoo-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "tho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (232,0);
+ref = dot_top;
+}
+);
+width = 672;
+}
+);
+note = uni1565;
+unicode = 5477;
+},
+{
+glyphname = "tha-canadian";
+lastChange = "2023-01-13 15:54:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (465,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(521,0,l),
+(539,87,l),
+(374,87,ls),
+(244,87,o),
+(174,156,o),
+(174,279,cs),
+(174,407,o),
+(244,631,o),
+(437,631,cs),
+(470,631,o),
+(505,624,o),
+(531,611,c),
+(511,649,l),
+(389,661,o),
+(322,542,o),
+(322,435,cs),
+(322,346,o),
+(376,285,o),
+(466,285,cs),
+(588,285,o),
+(658,404,o),
+(658,516,cs),
+(658,631,o),
+(575,702,o),
+(440,702,cs),
+(185,702,o),
+(78,448,o),
+(78,269,cs),
+(78,102,o),
+(179,0,o),
+(354,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(423,356,o),
+(396,389,o),
+(396,443,cs),
+(396,499,o),
+(424,611,o),
+(508,611,cs),
+(554,611,o),
+(581,578,o),
+(581,525,cs),
+(581,469,o),
+(553,356,o),
+(469,356,cs)
+);
+}
+);
+width = 671;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tho-canadian";
+note = uni1566;
+unicode = 5478;
+},
+{
+glyphname = "thaa-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (296,0);
+ref = dot_top;
+}
+);
+width = 672;
+}
+);
+note = uni1567;
+unicode = 5479;
+},
+{
+glyphname = "thwaa-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (521,0);
+ref = dot_top;
+}
+);
+width = 896;
+}
+);
+note = uni1568;
+unicode = 5480;
+},
+{
+glyphname = "thwaaWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (296,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (672,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 896;
+}
+);
+note = uni1569;
+unicode = 5481;
+},
+{
+glyphname = "th-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(339,345,l),
+(351,401,l),
+(271,401,ls),
+(209,401,o),
+(178,431,o),
+(178,487,cs),
+(178,550,o),
+(213,653,o),
+(304,653,cs),
+(319,653,o),
+(338,649,o),
+(350,643,c),
+(331,666,l),
+(266,669,o),
+(242,608,o),
+(242,564,cs),
+(242,518,o),
+(269,487,o),
+(312,487,cs),
+(378,487,o),
+(407,556,o),
+(407,604,cs),
+(407,660,o),
+(367,696,o),
+(299,696,cs),
+(173,696,o),
+(117,571,o),
+(117,481,cs),
+(117,396,o),
+(171,345,o),
+(259,345,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(292,526,o),
+(280,541,o),
+(280,565,cs),
+(280,594,o),
+(294,641,o),
+(330,641,cs),
+(353,641,o),
+(365,627,o),
+(365,603,cs),
+(365,574,o),
+(352,526,o),
+(314,526,cs)
+);
+}
+);
+width = 389;
+}
+);
+metricLeft = "t-canadian";
+note = uni156A;
+unicode = 5482;
+},
+{
+glyphname = "tthe-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (826,345);
+},
+{
+name = top_center_can;
+pos = (452,690);
+},
+{
+name = top_left_can;
+pos = (213,690);
+},
+{
+name = top_right_can;
+pos = (693,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(508,-13,o),
+(611,79,o),
+(653,279,cs),
+(740,690,l),
+(646,690,l),
+(559,280,ls),
+(528,138,o),
+(459,75,o),
+(337,75,cs),
+(199,75,o),
+(143,150,o),
+(176,300,cs),
+(258,690,l),
+(164,690,l),
+(82,306,ls),
+(40,103,o),
+(136,-13,o),
+(331,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(427,387,l),
+(492,690,l),
+(412,690,l),
+(348,387,l)
+);
+}
+);
+width = 713;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156B;
+unicode = 5483;
+},
+{
+glyphname = "tthi-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(111,0,l),
+(198,410,ls),
+(229,552,o),
+(298,614,o),
+(420,614,cs),
+(558,614,o),
+(614,540,o),
+(582,389,cs),
+(499,0,l),
+(593,0,l),
+(675,384,ls),
+(718,586,o),
+(621,702,o),
+(426,702,cs),
+(249,702,o),
+(147,611,o),
+(104,411,cs),
+(17,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(345,0,l),
+(410,302,l),
+(330,302,l),
+(266,0,l)
+);
+}
+);
+width = 712;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156C;
+unicode = 5484;
+},
+{
+glyphname = "ttho-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (396,690);
+},
+{
+name = top_left_can;
+pos = (210,690);
+},
+{
+name = top_right_can;
+pos = (613,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(185,0,ls),
+(504,0,o),
+(589,253,o),
+(589,424,cs),
+(589,591,o),
+(489,690,o),
+(310,690,cs),
+(168,690,l),
+(151,603,l),
+(297,603,ls),
+(426,603,o),
+(493,538,o),
+(493,417,cs),
+(493,284,o),
+(430,87,o),
+(195,87,cs),
+(40,87,l),
+(22,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(323,306,l),
+(339,385,l),
+(103,385,l),
+(87,306,l)
+);
+}
+);
+width = 623;
+}
+);
+metricRight = "to-canadian";
+note = uni156D;
+unicode = 5485;
+},
+{
+glyphname = "ttha-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (413,690);
+},
+{
+name = top_left_can;
+pos = (204,690);
+},
+{
+name = top_right_can;
+pos = (597,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(499,0,l),
+(518,87,l),
+(371,87,ls),
+(242,87,o),
+(176,152,o),
+(176,272,cs),
+(176,408,o),
+(241,603,o),
+(472,603,cs),
+(628,603,l),
+(646,690,l),
+(482,690,ls),
+(165,690,o),
+(79,439,o),
+(79,266,cs),
+(79,99,o),
+(179,0,o),
+(357,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(563,306,l),
+(580,385,l),
+(344,385,l),
+(328,306,l)
+);
+}
+);
+width = 623;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|ttho-canadian";
+note = uni156E;
+unicode = 5486;
+},
+{
+glyphname = "tth-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(282,477,l),
+(256,477,l),
+(323,347,l),
+(376,375,l),
+(307,510,l),
+(293,485,l),
+(454,538,l),
+(437,592,l),
+(286,542,l),
+(305,527,l),
+(339,690,l),
+(280,690,l),
+(245,527,l),
+(270,540,l),
+(130,592,l),
+(110,539,l),
+(242,490,l),
+(239,515,l),
+(119,387,l),
+(162,347,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(689,477,l),
+(662,477,l),
+(728,347,l),
+(782,375,l),
+(713,510,l),
+(698,485,l),
+(861,538,l),
+(842,592,l),
+(692,542,l),
+(711,527,l),
+(746,690,l),
+(686,690,l),
+(651,527,l),
+(675,540,l),
+(536,592,l),
+(516,539,l),
+(647,490,l),
+(644,515,l),
+(525,387,l),
+(568,347,l)
+);
+}
+);
+width = 844;
+}
+);
+metricRight = "=|";
+note = uni156F;
+unicode = 5487;
+},
+{
+glyphname = "tye-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(510,-13,o),
+(611,82,o),
+(653,279,cs),
+(740,690,l),
+(647,690,l),
+(561,289,ls),
+(530,141,o),
+(460,75,o),
+(335,75,cs),
+(198,75,o),
+(143,150,o),
+(175,300,cs),
+(258,690,l),
+(164,690,l),
+(82,306,ls),
+(40,103,o),
+(135,-13,o),
+(332,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(472,412,o),
+(514,451,o),
+(532,532,cs),
+(566,690,l),
+(516,690,l),
+(484,540,ls),
+(472,486,o),
+(448,462,o),
+(405,462,cs),
+(360,462,o),
+(346,487,o),
+(357,542,cs),
+(388,690,l),
+(338,690,l),
+(307,541,ls),
+(290,461,o),
+(327,412,o),
+(403,412,cs)
+);
+}
+);
+width = 713;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1570;
+unicode = 5488;
+},
+{
+glyphname = "tyi-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(111,0,l),
+(196,401,ls),
+(227,549,o),
+(298,614,o),
+(422,614,cs),
+(559,614,o),
+(615,540,o),
+(582,389,cs),
+(500,0,l),
+(593,0,l),
+(675,384,ls),
+(718,586,o),
+(622,702,o),
+(425,702,cs),
+(247,702,o),
+(147,608,o),
+(104,411,cs),
+(17,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(242,0,l),
+(273,150,ls),
+(285,204,o),
+(309,228,o),
+(353,228,cs),
+(397,228,o),
+(412,203,o),
+(400,148,cs),
+(369,0,l),
+(419,0,l),
+(450,149,ls),
+(468,229,o),
+(431,278,o),
+(355,278,cs),
+(286,278,o),
+(243,239,o),
+(226,157,cs),
+(192,0,l)
+);
+}
+);
+width = 712;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1571;
+unicode = 5489;
+},
+{
+glyphname = "tyo-canadian";
+lastChange = "2023-01-13 15:54:25 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(188,0,ls),
+(507,0,o),
+(593,253,o),
+(593,424,cs),
+(593,591,o),
+(492,690,o),
+(313,690,cs),
+(173,690,l),
+(155,604,l),
+(300,604,ls),
+(429,604,o),
+(497,538,o),
+(497,417,cs),
+(497,273,o),
+(423,86,o),
+(198,86,cs),
+(43,86,l),
+(26,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(163,213,ls),
+(271,213,o),
+(325,281,o),
+(327,364,cs),
+(329,434,o),
+(286,476,o),
+(211,476,cs),
+(127,476,l),
+(116,426,l),
+(198,426,ls),
+(246,426,o),
+(271,403,o),
+(270,362,cs),
+(270,312,o),
+(241,264,o),
+(168,264,cs),
+(82,264,l),
+(71,213,l)
+);
+}
+);
+width = 627;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1572;
+unicode = 5490;
+},
+{
+glyphname = "tya-canadian";
+lastChange = "2023-01-13 15:54:25 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(498,0,l),
+(516,86,l),
+(371,86,ls),
+(242,86,o),
+(174,152,o),
+(174,272,cs),
+(174,416,o),
+(248,604,o),
+(473,604,cs),
+(627,604,l),
+(644,690,l),
+(483,690,ls),
+(164,690,o),
+(78,437,o),
+(78,266,cs),
+(78,99,o),
+(180,0,o),
+(358,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(544,213,l),
+(554,264,l),
+(473,264,ls),
+(425,264,o),
+(400,287,o),
+(401,327,cs),
+(402,378,o),
+(431,426,o),
+(503,426,cs),
+(589,426,l),
+(600,476,l),
+(508,476,ls),
+(400,476,o),
+(347,409,o),
+(345,326,cs),
+(342,256,o),
+(385,213,o),
+(461,213,cs)
+);
+}
+);
+width = 626;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1573;
+unicode = 5491;
+},
+{
+glyphname = "heNunavik-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(456,0,l),
+(734,194,l),
+(686,265,l),
+(451,102,l),
+(483,77,l),
+(554,412,ls),
+(584,554,o),
+(536,702,o),
+(361,702,cs),
+(184,702,o),
+(102,538,o),
+(102,400,cs),
+(102,278,o),
+(176,198,o),
+(291,198,cs),
+(365,198,o),
+(424,236,o),
+(452,298,c),
+(433,292,l),
+(371,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(239,280,o),
+(195,327,o),
+(195,406,cs),
+(195,483,o),
+(236,620,o),
+(354,620,cs),
+(427,620,o),
+(470,573,o),
+(470,494,cs),
+(470,414,o),
+(430,280,o),
+(312,280,cs)
+);
+}
+);
+width = 770;
+}
+);
+metricLeft = "ke-canadian";
+note = uni1574;
+unicode = 5492;
+},
+{
+glyphname = "hiNunavik-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (579,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(298,0,l),
+(370,334,l),
+(356,325,l),
+(355,259,o),
+(418,198,o),
+(511,198,cs),
+(685,198,o),
+(758,370,o),
+(758,496,cs),
+(758,623,o),
+(680,702,o),
+(554,702,cs),
+(425,702,o),
+(334,621,o),
+(303,476,cs),
+(218,74,l),
+(254,84,l),
+(77,256,l),
+(16,194,l),
+(213,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(434,280,o),
+(390,327,o),
+(390,406,cs),
+(390,483,o),
+(430,620,o),
+(548,620,cs),
+(621,620,o),
+(665,573,o),
+(665,495,cs),
+(665,417,o),
+(625,280,o),
+(507,280,cs)
+);
+}
+);
+width = 771;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1575;
+unicode = 5493;
+},
+{
+glyphname = "hiiNunavik-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "hiNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (408,0);
+ref = dot_top;
+}
+);
+width = 770;
+}
+);
+note = uni1576;
+unicode = 5494;
+},
+{
+glyphname = "hoNunavik-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (384,690);
+},
+{
+name = top_right_can;
+pos = (566,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(390,-13,o),
+(481,69,o),
+(512,213,cs),
+(597,615,l),
+(561,606,l),
+(738,434,l),
+(799,496,l),
+(603,690,l),
+(517,690,l),
+(446,355,l),
+(460,365,l),
+(462,431,o),
+(398,492,o),
+(305,492,cs),
+(130,492,o),
+(58,320,o),
+(58,194,cs),
+(58,67,o),
+(135,-13,o),
+(261,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(194,70,o),
+(151,117,o),
+(151,195,cs),
+(151,272,o),
+(191,410,o),
+(309,410,cs),
+(383,410,o),
+(425,362,o),
+(425,284,cs),
+(425,207,o),
+(385,70,o),
+(268,70,cs)
+);
+}
+);
+width = 770;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "heNunavik-canadian";
+note = uni1577;
+unicode = 5495;
+},
+{
+glyphname = "hooNunavik-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "hoNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (397,0);
+ref = dot_top;
+}
+);
+width = 770;
+}
+);
+note = uni1578;
+unicode = 5496;
+},
+{
+glyphname = "haNunavik-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (579,690);
+},
+{
+name = top_left_can;
+pos = (397,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(633,-13,o),
+(714,152,o),
+(714,290,cs),
+(714,412,o),
+(640,492,o),
+(525,492,cs),
+(450,492,o),
+(391,454,o),
+(364,391,c),
+(383,398,l),
+(445,690,l),
+(359,690,l),
+(81,496,l),
+(129,425,l),
+(364,587,l),
+(332,612,l),
+(262,277,ls),
+(232,136,o),
+(280,-13,o),
+(454,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(388,70,o),
+(346,117,o),
+(346,196,cs),
+(346,275,o),
+(386,410,o),
+(503,410,cs),
+(577,410,o),
+(620,362,o),
+(620,284,cs),
+(620,207,o),
+(581,70,o),
+(463,70,cs)
+);
+}
+);
+width = 771;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1579;
+unicode = 5497;
+},
+{
+glyphname = "haaNunavik-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "haNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (227,0);
+ref = dot_top;
+}
+);
+width = 770;
+}
+);
+note = uni157A;
+unicode = 5498;
+},
+{
+glyphname = "hNunavik-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(409,339,o),
+(461,422,o),
+(461,497,cs),
+(461,558,o),
+(422,601,o),
+(363,601,cs),
+(326,601,o),
+(294,584,o),
+(277,552,c),
+(287,539,l),
+(320,690,l),
+(257,690,l),
+(116,592,l),
+(148,549,l),
+(276,639,l),
+(246,666,l),
+(209,487,ls),
+(190,404,o),
+(232,339,o),
+(317,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(287,390,o),
+(266,412,o),
+(266,449,cs),
+(266,498,o),
+(294,550,o),
+(344,550,cs),
+(378,550,o),
+(400,527,o),
+(400,491,cs),
+(400,442,o),
+(371,390,o),
+(321,390,cs)
+);
+}
+);
+width = 465;
+}
+);
+metricRight = "k-canadian";
+note = uni157B;
+unicode = 5499;
+},
+{
+color = 4;
+glyphname = "nunavuth-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,0,l),
+(187,315,l),
+(531,315,l),
+(465,0,l),
+(560,0,l),
+(707,690,l),
+(611,690,l),
+(550,400,l),
+(206,400,l),
+(268,690,l),
+(172,690,l),
+(25,0,l)
+);
+}
+);
+width = 687;
+}
+);
+metricRight = "=|";
+note = uni157C;
+unicode = 5500;
+},
+{
+glyphname = "hk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (73,345);
+ref = "fullstop-canadian";
+}
+);
+width = 355;
+}
+);
+metricLeft = "fullstop-canadian";
+note = uni157D;
+unicode = 5501;
+},
+{
+glyphname = "qaai-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (329,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (498,0);
+ref = ring_top.canadian;
+}
+);
+width = 916;
+}
+);
+note = uni157E;
+unicode = 5502;
+},
+{
+glyphname = "qi-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (329,0);
+ref = "ki-canadian";
+}
+);
+width = 916;
+}
+);
+note = uni157F;
+unicode = 5503;
+},
+{
+glyphname = "qii-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (329,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (550,0);
+ref = dot_top;
+}
+);
+width = 916;
+}
+);
+note = uni1580;
+unicode = 5504;
+},
+{
+glyphname = "qo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (329,0);
+ref = "ko-canadian";
+}
+);
+width = 916;
+}
+);
+note = uni1581;
+unicode = 5505;
+},
+{
+glyphname = "qoo-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (329,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (725,0);
+ref = dot_top;
+}
+);
+width = 916;
+}
+);
+note = uni1582;
+unicode = 5506;
+},
+{
+glyphname = "qa-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (329,0);
+ref = "ka-canadian";
+}
+);
+width = 916;
+}
+);
+note = uni1583;
+unicode = 5507;
+},
+{
+glyphname = "qaa-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (329,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (372,0);
+ref = dot_top;
+}
+);
+width = 916;
+}
+);
+note = uni1584;
+unicode = 5508;
+},
+{
+glyphname = "q-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (329,0);
+ref = "k-canadian";
+}
+);
+width = 702;
+}
+);
+note = uni1585;
+unicode = 5509;
+},
+{
+glyphname = "tlhe-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (394,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,0,l),
+(336,270,l),
+(270,233,l),
+(279,233,o),
+(291,232,o),
+(300,232,cs),
+(370,232,o),
+(428,261,o),
+(458,314,c),
+(453,339,l),
+(382,0,l),
+(476,0,l),
+(570,441,ls),
+(601,586,o),
+(530,702,o),
+(372,702,cs),
+(207,702,o),
+(113,571,o),
+(113,427,cs),
+(113,346,o),
+(155,280,o),
+(224,254,c),
+(41,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(250,315,o),
+(206,363,o),
+(206,437,cs),
+(206,520,o),
+(258,620,o),
+(363,620,cs),
+(440,620,o),
+(484,575,o),
+(484,503,cs),
+(484,417,o),
+(430,315,o),
+(324,315,cs)
+);
+}
+);
+width = 595;
+}
+);
+metricRight = "te-canadian";
+note = uni1586;
+unicode = 5510;
+},
+{
+glyphname = "tlhi-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(112,0,l),
+(189,362,l),
+(155,348,l),
+(176,283,o),
+(238,238,o),
+(319,234,c),
+(270,273,l),
+(352,0,l),
+(453,0,l),
+(382,242,l),
+(503,259,o),
+(580,384,o),
+(580,502,cs),
+(580,621,o),
+(498,702,o),
+(368,702,cs),
+(239,702,o),
+(150,624,o),
+(118,476,cs),
+(17,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(254,315,o),
+(209,359,o),
+(209,434,cs),
+(209,517,o),
+(260,620,o),
+(366,620,cs),
+(442,620,o),
+(487,575,o),
+(487,502,cs),
+(487,419,o),
+(435,315,o),
+(328,315,cs)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|tlhe-canadian";
+note = uni1587;
+unicode = 5511;
+},
+{
+glyphname = "tlho-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (410,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(402,-13,o),
+(491,66,o),
+(523,213,cs),
+(624,690,l),
+(528,690,l),
+(452,327,l),
+(487,342,l),
+(465,407,o),
+(403,452,o),
+(322,456,c),
+(371,416,l),
+(290,690,l),
+(187,690,l),
+(260,447,l),
+(138,431,o),
+(61,305,o),
+(61,187,cs),
+(61,69,o),
+(142,-13,o),
+(272,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(198,70,o),
+(155,115,o),
+(155,187,cs),
+(155,270,o),
+(206,375,o),
+(312,375,cs),
+(387,375,o),
+(432,330,o),
+(432,256,cs),
+(432,173,o),
+(381,70,o),
+(274,70,cs)
+);
+}
+);
+width = 597;
+}
+);
+metricLeft = "tlhe-canadian";
+metricRight = "te-canadian";
+note = uni1588;
+unicode = 5512;
+},
+{
+glyphname = "tlha-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(434,-13,o),
+(527,119,o),
+(527,263,cs),
+(527,344,o),
+(486,410,o),
+(416,436,c),
+(600,690,l),
+(498,690,l),
+(304,420,l),
+(371,457,l),
+(361,457,o),
+(350,458,o),
+(340,458,cs),
+(271,458,o),
+(213,429,o),
+(183,376,c),
+(187,351,l),
+(259,690,l),
+(164,690,l),
+(71,248,ls),
+(40,103,o),
+(110,-13,o),
+(269,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,70,o),
+(157,115,o),
+(157,186,cs),
+(157,272,o),
+(211,375,o),
+(317,375,cs),
+(390,375,o),
+(435,327,o),
+(435,253,cs),
+(435,170,o),
+(383,70,o),
+(277,70,cs)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "te-canadian";
+note = uni1589;
+unicode = 5513;
+},
+{
+glyphname = "reWestCree-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(451,0,l),
+(729,195,l),
+(679,266,l),
+(446,103,l),
+(478,78,l),
+(554,435,ls),
+(587,593,o),
+(511,702,o),
+(360,702,cs),
+(224,702,o),
+(142,623,o),
+(107,465,cs),
+(91,387,l),
+(185,387,l),
+(202,462,ls),
+(224,570,o),
+(272,618,o),
+(353,618,cs),
+(446,618,o),
+(483,552,o),
+(460,445,cs),
+(366,0,l)
+);
+}
+);
+width = 764;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+unicode = 5514;
+},
+{
+glyphname = "riWestCree-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(299,0,l),
+(396,462,ls),
+(418,570,o),
+(467,618,o),
+(547,618,cs),
+(640,618,o),
+(678,552,o),
+(655,445,cs),
+(642,387,l),
+(738,387,l),
+(748,435,ls),
+(782,593,o),
+(704,702,o),
+(554,702,cs),
+(417,702,o),
+(336,623,o),
+(301,465,cs),
+(219,76,l),
+(257,88,l),
+(83,260,l),
+(17,195,l),
+(213,0,l)
+);
+}
+);
+width = 766;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+unicode = 5515;
+},
+{
+glyphname = "roWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(393,-13,o),
+(474,67,o),
+(509,225,cs),
+(591,613,l),
+(554,602,l),
+(727,430,l),
+(793,495,l),
+(598,690,l),
+(513,690,l),
+(414,228,ls),
+(392,120,o),
+(344,71,o),
+(264,71,cs),
+(170,71,o),
+(132,138,o),
+(156,244,cs),
+(168,302,l),
+(72,302,l),
+(63,255,ls),
+(28,97,o),
+(106,-13,o),
+(257,-13,cs)
+);
+}
+);
+width = 765;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+unicode = 5516;
+},
+{
+glyphname = "raWestCree-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(585,-13,o),
+(668,67,o),
+(702,225,cs),
+(719,302,l),
+(624,302,l),
+(608,228,ls),
+(585,120,o),
+(537,71,o),
+(457,71,cs),
+(363,71,o),
+(327,138,o),
+(350,244,cs),
+(443,690,l),
+(358,690,l),
+(80,495,l),
+(130,424,l),
+(363,586,l),
+(331,611,l),
+(256,255,ls),
+(222,97,o),
+(298,-13,o),
+(449,-13,cs)
+);
+}
+);
+width = 765;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+unicode = 5517;
+},
+{
+glyphname = "ngaai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:54:30 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (638,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (812,0);
+ref = ring_top.canadian;
+}
+);
+width = 1219;
+}
+);
+note = uni158E;
+unicode = 5518;
+},
+{
+glyphname = "ngi-canadian";
+kernLeft = mwestleft;
+kernRight = ciright;
+lastChange = "2023-01-13 15:54:30 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (638,0);
+ref = "ci-canadian";
+}
+);
+width = 1219;
+}
+);
+note = uni158F;
+unicode = 5519;
+},
+{
+glyphname = "ngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:54:30 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (638,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (863,0);
+ref = dot_top;
+}
+);
+width = 1219;
+}
+);
+note = uni1590;
+unicode = 5520;
+},
+{
+glyphname = "ngo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (610,0);
+ref = "co-canadian";
+}
+);
+width = 1191;
+}
+);
+note = uni1591;
+unicode = 5521;
+},
+{
+glyphname = "ngoo-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "ngo-canadian";
+},
+{
+anchor = top_right_can;
+pos = (1002,0);
+ref = dot_top;
+}
+);
+width = 1191;
+}
+);
+note = uni1592;
+unicode = 5522;
+},
+{
+glyphname = "nga-canadian";
+kernLeft = mwestleft;
+kernRight = caright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (639,0);
+ref = "ca-canadian";
+}
+);
+width = 1220;
+}
+);
+note = uni1593;
+unicode = 5523;
+},
+{
+glyphname = "ngaa-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (639,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (682,0);
+ref = dot_top;
+}
+);
+width = 1220;
+}
+);
+note = uni1594;
+unicode = 5524;
+},
+{
+glyphname = "ng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(548,217,o),
+(600,262,o),
+(617,343,cs),
+(622,365,l),
+(558,365,l),
+(553,339,ls),
+(542,295,o),
+(517,271,o),
+(478,271,cs),
+(437,271,o),
+(419,298,o),
+(430,345,cs),
+(463,497,l),
+(314,497,l),
+(315,463,l),
+(356,484,o),
+(376,540,o),
+(377,582,cs),
+(379,649,o),
+(334,696,o),
+(262,696,cs),
+(177,696,o),
+(127,626,o),
+(124,552,cs),
+(122,481,o),
+(167,435,o),
+(239,435,cs),
+(400,435,l),
+(385,457,l),
+(364,357,ls),
+(347,274,o),
+(389,217,o),
+(472,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(205,485,o),
+(184,510,o),
+(185,550,cs),
+(185,588,o),
+(207,645,o),
+(261,645,cs),
+(297,645,o),
+(318,620,o),
+(317,582,cs),
+(316,542,o),
+(295,485,o),
+(241,485,cs)
+);
+}
+);
+width = 638;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1595;
+unicode = 5525;
+},
+{
+glyphname = "nng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(838,217,o),
+(888,262,o),
+(905,343,cs),
+(911,365,l),
+(846,365,l),
+(840,339,ls),
+(830,295,o),
+(805,271,o),
+(767,271,cs),
+(724,271,o),
+(708,298,o),
+(718,345,cs),
+(751,497,l),
+(609,497,l),
+(607,463,l),
+(649,485,o),
+(669,545,o),
+(669,584,cs),
+(668,652,o),
+(625,696,o),
+(553,696,cs),
+(467,696,o),
+(415,623,o),
+(415,547,cs),
+(415,514,o),
+(427,488,o),
+(446,469,c),
+(458,497,l),
+(317,497,l),
+(315,463,l),
+(357,486,o),
+(378,545,o),
+(378,584,cs),
+(378,651,o),
+(332,696,o),
+(262,696,cs),
+(175,696,o),
+(124,623,o),
+(124,547,cs),
+(124,479,o),
+(168,435,o),
+(239,435,cs),
+(669,435,l),
+(653,357,ls),
+(635,273,o),
+(680,217,o),
+(763,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(205,485,o),
+(184,509,o),
+(184,546,cs),
+(184,584,o),
+(205,645,o),
+(261,645,cs),
+(297,645,o),
+(318,621,o),
+(318,585,cs),
+(318,547,o),
+(297,485,o),
+(241,485,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(496,485,o),
+(475,509,o),
+(475,546,cs),
+(475,584,o),
+(496,645,o),
+(553,645,cs),
+(588,645,o),
+(610,621,o),
+(610,585,cs),
+(610,547,o),
+(588,485,o),
+(532,485,cs)
+);
+}
+);
+width = 927;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1596;
+unicode = 5526;
+},
+{
+glyphname = "sheSayisi-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (704,345);
+},
+{
+name = top_center_can;
+pos = (392,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(473,0,l),
+(564,428,ls),
+(597,581,o),
+(537,702,o),
+(374,702,cs),
+(177,702,o),
+(97,512,o),
+(97,371,cs),
+(97,265,o),
+(149,199,o),
+(237,199,cs),
+(327,199,o),
+(381,268,o),
+(407,412,c),
+(351,412,l),
+(333,320,o),
+(303,279,o),
+(255,279,cs),
+(213,279,o),
+(188,311,o),
+(188,369,cs),
+(188,456,o),
+(232,620,o),
+(364,620,cs),
+(469,620,o),
+(491,533,o),
+(468,426,cs),
+(378,0,l)
+);
+}
+);
+width = 592;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1597;
+unicode = 5527;
+},
+{
+glyphname = "shiSayisi-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(113,0,l),
+(211,459,ls),
+(234,566,o),
+(287,620,o),
+(368,620,cs),
+(444,620,o),
+(487,574,o),
+(487,494,cs),
+(487,429,o),
+(452,279,o),
+(369,279,cs),
+(315,279,o),
+(294,326,o),
+(315,412,c),
+(259,412,l),
+(224,285,o),
+(272,199,o),
+(375,199,cs),
+(521,199,o),
+(579,387,o),
+(579,496,cs),
+(579,623,o),
+(501,702,o),
+(371,702,cs),
+(239,702,o),
+(149,621,o),
+(118,472,cs),
+(17,0,l)
+);
+}
+);
+width = 593;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni1598;
+unicode = 5528;
+},
+{
+glyphname = "shoSayisi-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (388,690);
+},
+{
+name = top_left_can;
+pos = (203,690);
+},
+{
+name = top_right_can;
+pos = (573,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(399,-13,o),
+(488,69,o),
+(520,217,cs),
+(620,690,l),
+(524,690,l),
+(426,231,ls),
+(404,124,o),
+(351,70,o),
+(270,70,cs),
+(193,70,o),
+(151,116,o),
+(151,196,cs),
+(151,261,o),
+(185,411,o),
+(269,411,cs),
+(323,411,o),
+(344,364,o),
+(323,278,c),
+(379,278,l),
+(413,405,o),
+(365,491,o),
+(263,491,cs),
+(117,491,o),
+(59,302,o),
+(59,194,cs),
+(59,67,o),
+(136,-13,o),
+(267,-13,cs)
+);
+}
+);
+width = 593;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1599;
+unicode = 5529;
+},
+{
+glyphname = "shaSayisi-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(462,-13,o),
+(540,178,o),
+(540,319,cs),
+(540,425,o),
+(489,491,o),
+(401,491,cs),
+(311,491,o),
+(257,422,o),
+(231,278,c),
+(287,278,l),
+(304,370,o),
+(334,411,o),
+(383,411,cs),
+(425,411,o),
+(449,379,o),
+(449,321,cs),
+(449,234,o),
+(406,70,o),
+(273,70,cs),
+(169,70,o),
+(147,156,o),
+(170,264,cs),
+(260,690,l),
+(164,690,l),
+(73,262,ls),
+(41,109,o),
+(100,-13,o),
+(265,-13,cs)
+);
+}
+);
+width = 592;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni159A;
+unicode = 5530;
+},
+{
+glyphname = "theWoodScree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(668,-13,o),
+(755,141,o),
+(755,273,cs),
+(755,396,o),
+(673,479,o),
+(540,479,cs),
+(116,479,l),
+(99,400,l),
+(427,400,l),
+(422,432,l),
+(317,392,o),
+(281,276,o),
+(281,194,cs),
+(281,71,o),
+(364,-13,o),
+(494,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(422,70,o),
+(375,122,o),
+(375,199,cs),
+(375,287,o),
+(430,397,o),
+(536,397,cs),
+(614,397,o),
+(662,347,o),
+(662,270,cs),
+(662,183,o),
+(609,70,o),
+(498,70,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(823,611,l),
+(839,690,l),
+(161,690,l),
+(145,611,l)
+);
+}
+);
+width = 820;
+}
+);
+note = uni159B;
+unicode = 5531;
+},
+{
+glyphname = "thiWoodScree-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(448,-13,o),
+(537,140,o),
+(537,273,cs),
+(537,331,o),
+(514,380,o),
+(475,408,c),
+(459,400,l),
+(788,400,l),
+(805,479,l),
+(329,479,ls),
+(152,479,o),
+(63,332,o),
+(63,194,cs),
+(63,71,o),
+(146,-13,o),
+(275,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(204,70,o),
+(156,122,o),
+(156,199,cs),
+(156,287,o),
+(212,397,o),
+(319,397,cs),
+(396,397,o),
+(443,347,o),
+(443,270,cs),
+(443,183,o),
+(390,70,o),
+(280,70,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(833,611,l),
+(850,690,l),
+(172,690,l),
+(156,611,l)
+);
+}
+);
+width = 819;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159C;
+unicode = 5532;
+},
+{
+glyphname = "thoWoodScree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(491,0,ls),
+(668,0,o),
+(757,147,o),
+(757,285,cs),
+(757,408,o),
+(673,492,o),
+(544,492,cs),
+(372,492,o),
+(283,339,o),
+(283,206,cs),
+(283,147,o),
+(306,99,o),
+(345,71,c),
+(361,79,l),
+(31,79,l),
+(14,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(423,82,o),
+(376,132,o),
+(376,210,cs),
+(376,297,o),
+(430,410,o),
+(540,410,cs),
+(616,410,o),
+(664,357,o),
+(664,279,cs),
+(664,191,o),
+(609,82,o),
+(501,82,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(822,611,l),
+(839,690,l),
+(161,690,l),
+(144,611,l)
+);
+}
+);
+width = 820;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159D;
+unicode = 5533;
+},
+{
+glyphname = "thaWoodScree-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(703,0,l),
+(721,79,l),
+(392,79,l),
+(397,47,l),
+(502,87,o),
+(539,203,o),
+(539,285,cs),
+(539,407,o),
+(456,492,o),
+(327,492,cs),
+(153,492,o),
+(65,338,o),
+(65,206,cs),
+(65,83,o),
+(147,0,o),
+(280,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(206,82,o),
+(158,132,o),
+(158,210,cs),
+(158,297,o),
+(212,410,o),
+(322,410,cs),
+(398,410,o),
+(445,357,o),
+(445,279,cs),
+(445,191,o),
+(390,82,o),
+(283,82,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(833,611,l),
+(850,690,l),
+(172,690,l),
+(155,611,l)
+);
+}
+);
+width = 820;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159E;
+unicode = 5534;
+},
+{
+glyphname = "thWoodScree-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(463,344,l),
+(475,403,l),
+(298,403,l),
+(295,368,l),
+(347,387,o),
+(368,452,o),
+(368,496,cs),
+(368,561,o),
+(323,607,o),
+(252,607,cs),
+(165,607,o),
+(114,532,o),
+(114,457,cs),
+(114,389,o),
+(159,344,o),
+(229,344,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(195,395,o),
+(174,419,o),
+(174,456,cs),
+(174,494,o),
+(195,555,o),
+(251,555,cs),
+(287,555,o),
+(308,531,o),
+(308,495,cs),
+(308,456,o),
+(287,395,o),
+(231,395,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(527,663,l),
+(540,722,l),
+(171,722,l),
+(158,663,l)
+);
+}
+);
+width = 505;
+}
+);
+metricRight = "=|";
+note = uni159F;
+unicode = 5535;
+},
+{
+glyphname = "lhi-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (554,690);
+},
+{
+name = top_right_can;
+pos = (651,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(313,0,l),
+(331,85,l),
+(288,85,ls),
+(202,85,o),
+(154,129,o),
+(154,205,cs),
+(154,294,o),
+(203,392,o),
+(350,392,cs),
+(783,392,l),
+(799,469,l),
+(676,728,l),
+(592,688,l),
+(710,440,l),
+(736,479,l),
+(358,479,ls),
+(152,479,o),
+(59,348,o),
+(59,202,cs),
+(59,82,o),
+(140,0,o),
+(269,0,cs)
+);
+}
+);
+width = 806;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A0;
+unicode = 5536;
+},
+{
+glyphname = "lhii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "lhi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (384,0);
+ref = dot_top;
+}
+);
+width = 805;
+}
+);
+note = uni15A1;
+unicode = 5537;
+},
+{
+glyphname = "lho-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (448,497);
+},
+{
+name = top_right_can;
+pos = (559,497);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(213,-209,l),
+(95,39,l),
+(69,0,l),
+(446,0,ls),
+(653,0,o),
+(746,130,o),
+(746,276,cs),
+(746,397,o),
+(665,479,o),
+(536,479,cs),
+(492,479,l),
+(473,394,l),
+(517,394,ls),
+(603,394,o),
+(651,349,o),
+(651,274,cs),
+(651,185,o),
+(602,86,o),
+(455,86,cs),
+(22,86,l),
+(6,10,l),
+(128,-249,l)
+);
+}
+);
+width = 806;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni15A2;
+unicode = 5538;
+},
+{
+glyphname = "lhoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "lho-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (390,-193);
+ref = dot_top;
+}
+);
+width = 805;
+}
+);
+note = uni15A3;
+unicode = 5539;
+},
+{
+glyphname = "lha-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (469,497);
+},
+{
+name = top_left_can;
+pos = (356,497);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(701,10,l),
+(718,87,l),
+(290,87,ls),
+(202,87,o),
+(156,129,o),
+(156,206,cs),
+(156,297,o),
+(204,394,o),
+(350,394,cs),
+(397,394,l),
+(414,479,l),
+(361,479,ls),
+(147,479,o),
+(59,342,o),
+(59,198,cs),
+(59,77,o),
+(139,0,o),
+(272,0,cs),
+(632,0,l),
+(611,38,l),
+(405,-192,l),
+(469,-249,l)
+);
+}
+);
+width = 805;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A4;
+unicode = 5540;
+},
+{
+glyphname = "lhaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "lha-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (186,-193);
+ref = dot_top;
+}
+);
+width = 805;
+}
+);
+note = uni15A5;
+unicode = 5541;
+},
+{
+glyphname = "lh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(465,352,l),
+(477,409,l),
+(271,409,ls),
+(215,409,o),
+(185,437,o),
+(185,487,cs),
+(185,549,o),
+(214,628,o),
+(314,628,cs),
+(336,628,l),
+(349,690,l),
+(321,690,ls),
+(185,690,o),
+(117,594,o),
+(117,481,cs),
+(117,396,o),
+(172,345,o),
+(267,345,cs),
+(425,345,l),
+(404,385,l),
+(287,253,l),
+(336,208,l)
+);
+}
+);
+width = 501;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni15A6;
+unicode = 5542;
+},
+{
+glyphname = "theThCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (185,690);
+},
+{
+name = top_right_can;
+pos = (543,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(370,102,l),
+(348,0,l),
+(443,0,l),
+(466,102,l),
+(545,102,l),
+(556,158,l),
+(477,158,l),
+(513,326,l),
+(190,326,l),
+(202,296,l),
+(592,639,l),
+(534,701,l),
+(48,270,l),
+(43,241,l),
+(399,241,l),
+(382,158,l),
+(144,158,l),
+(132,102,l)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "ye-canadian";
+note = uni15A7;
+unicode = 5543;
+},
+{
+glyphname = "thiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (257,690);
+},
+{
+name = top_right_can;
+pos = (614,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(158,0,l),
+(181,102,l),
+(417,102,l),
+(429,158,l),
+(192,158,l),
+(210,241,l),
+(566,241,l),
+(573,270,l),
+(256,701,l),
+(187,650,l),
+(453,290,l),
+(470,326,l),
+(131,326,l),
+(96,158,l),
+(16,158,l),
+(5,102,l),
+(84,102,l),
+(62,0,l)
+);
+}
+);
+width = 609;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+unicode = 5544;
+},
+{
+glyphname = "thiiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (86,0);
+ref = dot_top;
+}
+);
+width = 607;
+}
+);
+note = uni15A9;
+unicode = 5545;
+},
+{
+glyphname = "thoThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (185,690);
+},
+{
+name = top_right_can;
+pos = (543,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(466,40,l),
+(200,400,l),
+(182,364,l),
+(521,364,l),
+(556,531,l),
+(636,531,l),
+(647,587,l),
+(568,587,l),
+(590,690,l),
+(494,690,l),
+(472,587,l),
+(235,587,l),
+(223,531,l),
+(460,531,l),
+(442,449,l),
+(87,449,l),
+(80,419,l),
+(396,-12,l)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+unicode = 5546;
+},
+{
+glyphname = "thooThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (373,0);
+ref = dot_top;
+}
+);
+width = 607;
+}
+);
+note = uni15AB;
+unicode = 5547;
+},
+{
+glyphname = "thaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (257,690);
+},
+{
+name = top_right_can;
+pos = (614,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(605,419,l),
+(611,449,l),
+(253,449,l),
+(270,531,l),
+(508,531,l),
+(520,587,l),
+(282,587,l),
+(304,690,l),
+(209,690,l),
+(186,587,l),
+(107,587,l),
+(96,531,l),
+(175,531,l),
+(139,364,l),
+(463,364,l),
+(451,394,l),
+(60,50,l),
+(118,-12,l)
+);
+}
+);
+width = 609;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+unicode = 5548;
+},
+{
+glyphname = "thaaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:54:30 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (88,0);
+ref = dot_top;
+}
+);
+width = 609;
+}
+);
+note = uni15AD;
+unicode = 5549;
+},
+{
+glyphname = "thThCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(172,613,l),
+(151,514,l),
+(318,514,l),
+(305,544,l),
+(121,378,l),
+(163,335,l),
+(398,550,l),
+(403,569,l),
+(231,569,l),
+(240,613,l),
+(353,613,l),
+(359,645,l),
+(246,645,l),
+(256,690,l),
+(188,690,l),
+(179,645,l),
+(139,645,l),
+(132,613,l)
+);
+}
+);
+width = 369;
+}
+);
+metricRight = "y-canadian";
+note = uni15AE;
+unicode = 5550;
+},
+{
+glyphname = "bAivilik-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(454,-13,o),
+(538,152,o),
+(538,289,cs),
+(538,411,o),
+(463,492,o),
+(348,492,cs),
+(275,492,o),
+(219,455,o),
+(192,399,c),
+(203,384,l),
+(268,690,l),
+(172,690,l),
+(25,0,l),
+(117,0,l),
+(142,118,l),
+(132,105,l),
+(144,33,o),
+(203,-13,o),
+(288,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(213,70,o),
+(169,117,o),
+(169,196,cs),
+(169,275,o),
+(210,410,o),
+(327,410,cs),
+(401,410,o),
+(444,362,o),
+(444,284,cs),
+(444,207,o),
+(404,70,o),
+(286,70,cs)
+);
+}
+);
+width = 595;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|ke-canadian";
+note = uni15AF;
+unicode = 5551;
+},
+{
+glyphname = "eBlackfoot-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,0,l),
+(210,416,l),
+(234,374,o),
+(279,349,o),
+(336,349,cs),
+(455,349,o),
+(526,455,o),
+(526,554,cs),
+(526,640,o),
+(468,702,o),
+(378,702,cs),
+(331,702,o),
+(288,685,o),
+(257,656,c),
+(264,690,l),
+(172,690,l),
+(25,0,l)
+);
+}
+);
+width = 506;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B0;
+unicode = 5552;
+},
+{
+glyphname = "iBlackfoot-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(218,-13,o),
+(262,5,o),
+(294,34,c),
+(287,0,l),
+(379,0,l),
+(526,690,l),
+(430,690,l),
+(341,273,l),
+(317,316,o),
+(271,341,o),
+(214,341,cs),
+(96,341,o),
+(25,235,o),
+(25,136,cs),
+(25,49,o),
+(83,-13,o),
+(173,-13,cs)
+);
+}
+);
+width = 506;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B1;
+unicode = 5553;
+},
+{
+glyphname = "oBlackfoot-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(378,-13,o),
+(448,90,o),
+(448,190,cs),
+(448,278,o),
+(390,341,o),
+(302,341,cs),
+(258,341,o),
+(215,325,o),
+(184,297,c),
+(268,690,l),
+(172,690,l),
+(25,0,l),
+(117,0,l),
+(130,63,l),
+(153,15,o),
+(200,-13,o),
+(261,-13,cs)
+);
+}
+);
+width = 505;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "eBlackfoot-canadian";
+note = uni15B2;
+unicode = 5554;
+},
+{
+glyphname = "aBlackfoot-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(379,0,l),
+(526,690,l),
+(433,690,l),
+(420,627,l),
+(397,674,o),
+(350,702,o),
+(290,702,cs),
+(173,702,o),
+(102,600,o),
+(102,499,cs),
+(102,412,o),
+(159,349,o),
+(247,349,cs),
+(293,349,o),
+(335,365,o),
+(366,393,c),
+(283,0,l)
+);
+}
+);
+width = 506;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B3;
+unicode = 5555;
+},
+{
+glyphname = "weBlackfoot-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,0,l),
+(185,303,l),
+(532,303,l),
+(549,384,l),
+(203,384,l),
+(250,609,l),
+(597,609,l),
+(613,690,l),
+(172,690,l),
+(25,0,l)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B4;
+unicode = 5556;
+},
+{
+glyphname = "wiBlackfoot-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(449,0,l),
+(596,690,l),
+(500,690,l),
+(436,386,l),
+(89,386,l),
+(72,305,l),
+(418,305,l),
+(371,81,l),
+(24,81,l),
+(8,0,l)
+);
+}
+);
+width = 576;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B5;
+unicode = 5557;
+},
+{
+glyphname = "woBlackfoot-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(468,0,l),
+(484,81,l),
+(138,81,l),
+(185,305,l),
+(532,305,l),
+(550,386,l),
+(203,386,l),
+(268,690,l),
+(172,690,l),
+(25,0,l)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "weBlackfoot-canadian";
+note = uni15B6;
+unicode = 5558;
+},
+{
+glyphname = "waBlackfoot-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(449,0,l),
+(596,690,l),
+(154,690,l),
+(137,609,l),
+(483,609,l),
+(436,384,l),
+(89,384,l),
+(71,303,l),
+(418,303,l),
+(354,0,l)
+);
+}
+);
+width = 576;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B7;
+unicode = 5559;
+},
+{
+glyphname = "neBlackfoot-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,0,l),
+(252,617,l),
+(299,617,l),
+(283,677,l),
+(278,654,ls),
+(245,503,o),
+(326,399,o),
+(476,399,cs),
+(610,399,o),
+(699,479,o),
+(730,627,cs),
+(744,690,l),
+(649,690,l),
+(637,629,ls),
+(617,531,o),
+(564,482,o),
+(482,482,cs),
+(391,482,o),
+(350,542,o),
+(370,639,cs),
+(381,690,l),
+(172,690,l),
+(25,0,l)
+);
+}
+);
+width = 687;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B8;
+unicode = 5560;
+},
+{
+glyphname = "niBlackfoot-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(82,0,l),
+(95,61,ls),
+(115,158,o),
+(168,208,o),
+(250,208,cs),
+(341,208,o),
+(383,148,o),
+(362,50,cs),
+(352,0,l),
+(560,0,l),
+(707,690,l),
+(611,690,l),
+(479,72,l),
+(432,72,l),
+(448,13,l),
+(453,36,ls),
+(486,186,o),
+(407,291,o),
+(256,291,cs),
+(123,291,o),
+(32,211,o),
+(1,63,cs),
+(-12,0,l)
+);
+}
+);
+width = 687;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B9;
+unicode = 5561;
+},
+{
+glyphname = "noBlackfoot-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(234,0,l),
+(246,58,ls),
+(268,158,o),
+(317,208,o),
+(399,208,cs),
+(491,208,o),
+(533,147,o),
+(513,47,cs),
+(502,0,l),
+(597,0,l),
+(605,37,ls),
+(635,188,o),
+(555,292,o),
+(406,292,cs),
+(273,292,o),
+(185,212,o),
+(150,51,cs),
+(142,14,l),
+(184,72,l),
+(136,72,l),
+(268,690,l),
+(172,690,l),
+(25,0,l)
+);
+}
+);
+width = 687;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "neBlackfoot-canadian";
+note = uni15BA;
+unicode = 5562;
+},
+{
+glyphname = "naBlackfoot-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(561,0,l),
+(708,690,l),
+(499,690,l),
+(487,632,ls),
+(466,531,o),
+(416,482,o),
+(334,482,cs),
+(243,482,o),
+(199,543,o),
+(220,642,cs),
+(230,690,l),
+(135,690,l),
+(129,653,ls),
+(98,501,o),
+(178,398,o),
+(328,398,cs),
+(460,398,o),
+(548,478,o),
+(583,639,cs),
+(590,676,l),
+(549,617,l),
+(597,617,l),
+(466,0,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BB;
+unicode = 5563;
+},
+{
+glyphname = "keBlackfoot-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,0,l),
+(245,582,l),
+(211,582,l),
+(316,255,l),
+(357,255,l),
+(688,690,l),
+(575,690,l),
+(334,368,l),
+(362,365,l),
+(260,690,l),
+(172,690,l),
+(25,0,l)
+);
+}
+);
+width = 613;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15BC;
+unicode = 5564;
+},
+{
+glyphname = "kiBlackfoot-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(83,0,l),
+(324,322,l),
+(295,325,l),
+(397,0,l),
+(486,0,l),
+(633,690,l),
+(537,690,l),
+(412,108,l),
+(447,108,l),
+(341,435,l),
+(299,435,l),
+(-30,0,l)
+);
+}
+);
+width = 613;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BD;
+unicode = 5565;
+},
+{
+glyphname = "koBlackfoot-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(114,0,l),
+(381,337,l),
+(327,343,l),
+(441,0,l),
+(541,0,l),
+(395,435,l),
+(354,435,l),
+(106,107,l),
+(144,107,l),
+(268,690,l),
+(172,690,l),
+(25,0,l)
+);
+}
+);
+width = 613;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "keBlackfoot-canadian";
+note = uni15BE;
+unicode = 5566;
+},
+{
+glyphname = "kaBlackfoot-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(486,1,l),
+(633,691,l),
+(543,691,l),
+(277,354,l),
+(330,347,l),
+(216,691,l),
+(117,691,l),
+(262,256,l),
+(304,256,l),
+(551,582,l),
+(514,582,l),
+(390,1,l)
+);
+}
+);
+width = 613;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BF;
+unicode = 5567;
+},
+{
+color = 9;
+glyphname = "heSayisi-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_right_can;
+pos = (643,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(544,0,l),
+(691,690,l),
+(596,690,l),
+(506,269,l),
+(525,268,l),
+(573,536,o),
+(500,702,o),
+(333,702,cs),
+(219,702,o),
+(141,625,o),
+(106,478,cs),
+(97,434,o),
+(91,388,o),
+(89,336,c),
+(181,336,l),
+(184,384,o),
+(188,422,o),
+(196,457,cs),
+(220,563,o),
+(270,618,o),
+(346,618,cs),
+(497,618,o),
+(533,403,o),
+(448,0,c)
+);
+}
+);
+width = 671;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni15C0;
+unicode = 5568;
+},
+{
+color = 9;
+glyphname = "hiSayisi-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,0,l),
+(207,403,o),
+(328,618,o),
+(469,618,cs),
+(554,618,o),
+(587,545,o),
+(560,421,cs),
+(554,389,o),
+(545,363,o),
+(534,336,c),
+(626,336,l),
+(639,368,o),
+(649,397,o),
+(655,424,cs),
+(689,592,o),
+(627,702,o),
+(497,702,cs),
+(352,702,o),
+(227,552,o),
+(167,298,c),
+(183,297,l),
+(267,690,l),
+(172,690,l),
+(25,0,l)
+);
+}
+);
+width = 671;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C1;
+unicode = 5569;
+},
+{
+color = 9;
+glyphname = "hoSayisi-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (426,690);
+},
+{
+name = top_left_can;
+pos = (209,690);
+},
+{
+name = top_right_can;
+pos = (643,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(363,-13,o),
+(488,138,o),
+(549,392,c),
+(532,393,l),
+(449,0,l),
+(544,0,l),
+(691,690,l),
+(595,690,l),
+(509,287,o),
+(387,71,o),
+(246,71,cs),
+(162,71,o),
+(128,145,o),
+(155,269,cs),
+(162,300,o),
+(171,327,o),
+(182,354,c),
+(90,354,l),
+(76,322,o),
+(67,293,o),
+(61,266,cs),
+(27,98,o),
+(89,-13,o),
+(218,-13,cs)
+);
+}
+);
+width = 671;
+}
+);
+metricLeft = "heSayisi-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15C2;
+unicode = 5570;
+},
+{
+color = 9;
+glyphname = "haSayisi-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(497,-13,o),
+(575,65,o),
+(610,212,cs),
+(619,256,o),
+(625,301,o),
+(627,354,c),
+(534,354,l),
+(532,306,o),
+(527,268,o),
+(519,233,cs),
+(496,127,o),
+(444,71,o),
+(370,71,cs),
+(219,71,o),
+(183,287,o),
+(268,690,c),
+(172,690,l),
+(25,0,l),
+(120,0,l),
+(209,421,l),
+(191,422,l),
+(142,154,o),
+(215,-13,o),
+(382,-13,cs)
+);
+}
+);
+width = 671;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C3;
+unicode = 5571;
+},
+{
+color = 9;
+glyphname = "ghuCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(326,0,l),
+(774,664,l),
+(780,690,l),
+(691,690,l),
+(542,467,l),
+(576,485,l),
+(229,485,l),
+(258,467,l),
+(207,690,l),
+(128,690,l),
+(123,664,l),
+(290,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(530,412,l),
+(519,427,l),
+(308,107,l),
+(345,101,l),
+(267,429,l),
+(247,412,l)
+);
+}
+);
+width = 716;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C4;
+unicode = 5572;
+},
+{
+color = 9;
+glyphname = "ghoCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(71,0,l),
+(220,223,l),
+(185,205,l),
+(532,205,l),
+(503,223,l),
+(554,0,l),
+(633,0,l),
+(639,26,l),
+(471,690,l),
+(436,690,l),
+(-13,26,l),
+(-18,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(510,302,l),
+(244,304,l),
+(256,264,l),
+(457,558,l),
+(402,562,l),
+(480,259,l)
+);
+}
+);
+width = 716;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C5;
+unicode = 5573;
+},
+{
+color = 9;
+glyphname = "gheCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (102,354);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(28,0,l),
+(634,327,l),
+(641,362,l),
+(175,690,l),
+(149,690,l),
+(134,619,l),
+(278,518,l),
+(272,572,l),
+(180,137,l),
+(206,188,l),
+(21,89,l),
+(2,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(337,534,l),
+(312,503,l),
+(558,328,l),
+(561,374,l),
+(248,205,l),
+(260,173,l)
+);
+}
+);
+width = 649;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15C6;
+unicode = 5574;
+},
+{
+color = 9;
+glyphname = "gheeCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (39,9);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 649;
+}
+);
+note = uni15C7;
+unicode = 5575;
+},
+{
+color = 9;
+glyphname = "ghiCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (15,9);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 649;
+}
+);
+note = uni15C8;
+unicode = 5576;
+},
+{
+color = 9;
+glyphname = "ghaCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(546,0,l),
+(561,71,l),
+(417,172,l),
+(423,118,l),
+(516,553,l),
+(490,501,l),
+(674,601,l),
+(693,690,l),
+(668,690,l),
+(61,363,l),
+(53,327,l),
+(520,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(384,186,l),
+(142,357,l),
+(139,319,l),
+(447,485,l),
+(434,510,l),
+(359,163,l)
+);
+}
+);
+width = 650;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15C9;
+unicode = 5577;
+},
+{
+color = 9;
+glyphname = "ruCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(326,0,l),
+(774,664,l),
+(780,690,l),
+(690,690,l),
+(627,597,l),
+(667,614,l),
+(198,614,l),
+(228,596,l),
+(206,690,l),
+(128,690,l),
+(123,664,l),
+(290,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(619,539,l),
+(603,555,l),
+(309,110,l),
+(345,104,l),
+(237,557,l),
+(215,539,l)
+);
+}
+);
+width = 716;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CA;
+unicode = 5578;
+},
+{
+color = 9;
+glyphname = "roCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(437,690,l),
+(-13,26,l),
+(-18,0,l),
+(71,0,l),
+(134,93,l),
+(95,75,l),
+(563,75,l),
+(534,94,l),
+(555,0,l),
+(633,0,l),
+(639,26,l),
+(471,690,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(143,151,l),
+(159,134,l),
+(453,580,l),
+(416,585,l),
+(525,132,l),
+(546,151,l)
+);
+}
+);
+width = 716;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CB;
+unicode = 5579;
+},
+{
+color = 9;
+glyphname = "reCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(28,0,l),
+(635,327,l),
+(641,362,l),
+(175,690,l),
+(149,690,l),
+(134,620,l),
+(207,569,l),
+(198,624,l),
+(83,84,l),
+(112,135,l),
+(21,86,l),
+(3,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(265,582,l),
+(240,550,l),
+(553,328,l),
+(554,372,l),
+(156,156,l),
+(167,127,l)
+);
+}
+);
+width = 650;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CC;
+unicode = 5580;
+},
+{
+color = 9;
+glyphname = "reeCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(28,0,l),
+(635,327,l),
+(641,362,l),
+(175,690,l),
+(149,690,l),
+(136,630,l),
+(205,582,l),
+(200,633,l),
+(81,74,l),
+(104,125,l),
+(18,77,l),
+(2,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(259,598,l),
+(231,569,l),
+(574,329,l),
+(576,373,l),
+(144,140,l),
+(156,108,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(288,269,l),
+(324,435,l),
+(280,435,l),
+(244,269,l)
+);
+}
+);
+width = 650;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CD;
+unicode = 5581;
+},
+{
+color = 9;
+glyphname = "riCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(28,0,l),
+(635,327,l),
+(641,362,l),
+(175,690,l),
+(149,690,l),
+(136,630,l),
+(205,581,l),
+(200,633,l),
+(81,74,l),
+(109,127,l),
+(18,77,l),
+(2,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(348,312,o),
+(367,329,o),
+(367,354,cs),
+(367,378,o),
+(348,396,o),
+(326,396,cs),
+(302,396,o),
+(283,378,o),
+(283,354,cs),
+(283,329,o),
+(302,312,o),
+(326,312,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(259,598,l),
+(231,569,l),
+(574,329,l),
+(576,373,l),
+(145,141,l),
+(156,108,l)
+);
+}
+);
+width = 650;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CE;
+unicode = 5582;
+},
+{
+color = 9;
+glyphname = "raCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(545,0,l),
+(560,70,l),
+(488,121,l),
+(497,66,l),
+(611,606,l),
+(582,554,l),
+(673,604,l),
+(692,690,l),
+(667,690,l),
+(60,362,l),
+(53,327,l),
+(520,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(455,140,l),
+(142,361,l),
+(140,318,l),
+(539,533,l),
+(527,563,l),
+(430,108,l)
+);
+}
+);
+width = 649;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15CF;
+unicode = 5583;
+},
+{
+color = 9;
+glyphname = "wuCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(329,0,l),
+(782,664,l),
+(788,690,l),
+(702,690,l),
+(360,171,l),
+(382,171,l),
+(492,690,l),
+(413,690,l),
+(303,170,l),
+(326,170,l),
+(201,690,l),
+(128,690,l),
+(123,664,l),
+(294,0,l)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D0;
+unicode = 5584;
+},
+{
+color = 9;
+glyphname = "woCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(69,0,l),
+(410,519,l),
+(388,519,l),
+(278,0,l),
+(356,0,l),
+(468,520,l),
+(444,520,l),
+(569,0,l),
+(641,0,l),
+(647,26,l),
+(476,690,l),
+(440,690,l),
+(-13,26,l),
+(-18,0,l)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D1;
+unicode = 5585;
+},
+{
+color = 9;
+glyphname = "weCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(48,0,l),
+(655,327,l),
+(662,362,l),
+(195,690,l),
+(169,690,l),
+(155,619,l),
+(508,373,l),
+(514,390,l),
+(106,390,l),
+(90,317,l),
+(501,317,l),
+(502,332,l),
+(42,86,l),
+(23,0,l)
+);
+}
+);
+width = 670;
+}
+);
+metricRight = "o-canadian";
+note = uni15D2;
+unicode = 5586;
+},
+{
+color = 9;
+glyphname = "weeCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(48,0,l),
+(655,327,l),
+(662,362,l),
+(195,690,l),
+(170,690,l),
+(156,627,l),
+(531,366,l),
+(538,384,l),
+(236,384,l),
+(252,462,l),
+(198,462,l),
+(182,384,l),
+(104,384,l),
+(92,324,l),
+(168,324,l),
+(152,245,l),
+(207,245,l),
+(222,324,l),
+(528,324,l),
+(526,338,l),
+(40,78,l),
+(23,0,l)
+);
+}
+);
+width = 670;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D3;
+unicode = 5587;
+},
+{
+color = 9;
+glyphname = "wiCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(48,0,l),
+(655,327,l),
+(662,362,l),
+(195,690,l),
+(170,690,l),
+(156,627,l),
+(526,371,l),
+(537,384,l),
+(300,384,l),
+(290,411,o),
+(265,430,o),
+(234,430,cs),
+(203,430,o),
+(178,411,o),
+(168,384,c),
+(104,384,l),
+(93,327,l),
+(169,327,l),
+(181,302,o),
+(205,285,o),
+(235,285,cs),
+(264,285,o),
+(288,302,o),
+(298,327,c),
+(527,327,l),
+(522,336,l),
+(40,79,l),
+(23,0,l)
+);
+}
+);
+width = 670;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D4;
+unicode = 5588;
+},
+{
+color = 9;
+glyphname = "waCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(545,0,l),
+(560,71,l),
+(207,317,l),
+(201,299,l),
+(609,299,l),
+(624,373,l),
+(213,373,l),
+(213,357,l),
+(673,604,l),
+(692,690,l),
+(667,690,l),
+(60,362,l),
+(53,327,l),
+(520,0,l)
+);
+}
+);
+width = 669;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15D5;
+unicode = 5589;
+},
+{
+color = 9;
+glyphname = "hwuCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(329,0,l),
+(782,664,l),
+(788,690,l),
+(707,690,l),
+(568,481,l),
+(594,497,l),
+(442,497,l),
+(484,690,l),
+(421,690,l),
+(380,497,l),
+(227,497,l),
+(245,485,l),
+(196,690,l),
+(128,690,l),
+(123,664,l),
+(294,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(327,133,l),
+(249,459,l),
+(239,441,l),
+(373,441,l),
+(308,132,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(425,441,l),
+(561,441,l),
+(556,458,l),
+(344,136,l),
+(359,129,l)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D6;
+unicode = 5590;
+},
+{
+color = 9;
+glyphname = "hwoCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(63,0,l),
+(202,209,l),
+(177,193,l),
+(327,193,l),
+(286,0,l),
+(349,0,l),
+(390,193,l),
+(543,193,l),
+(525,205,l),
+(574,0,l),
+(641,0,l),
+(647,26,l),
+(476,690,l),
+(440,690,l),
+(-13,26,l),
+(-18,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(426,554,l),
+(411,560,l),
+(345,248,l),
+(209,248,l),
+(213,232,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(531,248,l),
+(397,248,l),
+(462,557,l),
+(442,556,l),
+(521,231,l)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D7;
+unicode = 5591;
+},
+{
+color = 9;
+glyphname = "hweCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(48,0,l),
+(655,327,l),
+(662,362,l),
+(195,690,l),
+(169,690,l),
+(156,628,l),
+(283,540,l),
+(251,386,l),
+(105,386,l),
+(92,323,l),
+(238,323,l),
+(205,167,l),
+(40,79,l),
+(22,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(288,327,l),
+(519,327,l),
+(259,190,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(327,515,l),
+(523,381,l),
+(299,381,l)
+);
+}
+);
+width = 670;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D8;
+unicode = 5592;
+},
+{
+color = 9;
+glyphname = "hweeCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(48,0,l),
+(655,327,l),
+(662,362,l),
+(195,690,l),
+(169,690,l),
+(156,629,l),
+(303,530,l),
+(271,382,l),
+(215,382,l),
+(232,459,l),
+(185,459,l),
+(169,382,l),
+(104,382,l),
+(93,327,l),
+(157,327,l),
+(141,249,l),
+(187,249,l),
+(203,327,l),
+(260,327,l),
+(228,176,l),
+(40,78,l),
+(22,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(305,330,l),
+(525,330,l),
+(278,199,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(343,506,l),
+(529,377,l),
+(316,377,l)
+);
+}
+);
+width = 670;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D9;
+unicode = 5593;
+},
+{
+color = 9;
+glyphname = "hwiCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(48,0,l),
+(655,327,l),
+(662,362,l),
+(195,690,l),
+(169,690,l),
+(156,629,l),
+(303,530,l),
+(270,377,l),
+(240,377,l),
+(232,400,o),
+(210,415,o),
+(185,415,cs),
+(159,415,o),
+(140,399,o),
+(131,377,c),
+(103,377,l),
+(93,330,l),
+(130,330,l),
+(139,308,o),
+(160,292,o),
+(185,292,cs),
+(210,292,o),
+(231,308,o),
+(239,330,c),
+(261,330,l),
+(228,176,l),
+(40,78,l),
+(22,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(306,330,l),
+(525,330,l),
+(278,199,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(343,506,l),
+(529,377,l),
+(316,377,l)
+);
+}
+);
+width = 670;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15DA;
+unicode = 5594;
+},
+{
+color = 9;
+glyphname = "hwaCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(667,690,l),
+(60,362,l),
+(53,327,l),
+(520,0,l),
+(545,0,l),
+(558,62,l),
+(431,150,l),
+(464,303,l),
+(610,303,l),
+(623,367,l),
+(477,367,l),
+(510,523,l),
+(675,611,l),
+(692,690,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(427,362,l),
+(196,362,l),
+(456,499,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(387,175,l),
+(192,309,l),
+(415,309,l)
+);
+}
+);
+width = 670;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15DB;
+unicode = 5595;
+},
+{
+color = 9;
+glyphname = "thuCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(509,-13,o),
+(611,82,o),
+(652,277,cs),
+(740,690,l),
+(164,690,l),
+(82,306,ls),
+(40,103,o),
+(136,-13,o),
+(330,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(242,605,l),
+(626,605,l),
+(557,280,ls),
+(526,139,o),
+(458,75,o),
+(338,75,cs),
+(200,75,o),
+(145,150,o),
+(178,300,cs)
+);
+}
+);
+width = 712;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DC;
+unicode = 5596;
+},
+{
+color = 9;
+glyphname = "thoCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(593,0,l),
+(675,384,ls),
+(718,586,o),
+(621,702,o),
+(427,702,cs),
+(248,702,o),
+(147,608,o),
+(105,412,cs),
+(17,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(201,410,ls),
+(231,551,o),
+(300,614,o),
+(419,614,cs),
+(557,614,o),
+(612,540,o),
+(580,389,cs),
+(515,85,l),
+(131,85,l)
+);
+}
+);
+width = 712;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DD;
+unicode = 5597;
+},
+{
+color = 9;
+glyphname = "theCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (371,345);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(258,0,ls),
+(572,0,o),
+(666,246,o),
+(666,425,cs),
+(666,591,o),
+(565,690,o),
+(386,690,cs),
+(172,690,l),
+(25,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(256,635,l),
+(221,605,l),
+(368,605,ls),
+(499,605,o),
+(571,539,o),
+(571,418,cs),
+(571,272,o),
+(492,85,o),
+(263,85,cs),
+(115,85,l),
+(132,56,l)
+);
+}
+);
+width = 699;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "to-canadian";
+note = uni15DE;
+unicode = 5598;
+},
+{
+color = 9;
+glyphname = "theeCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (300,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 699;
+}
+);
+note = uni15DF;
+unicode = 5599;
+},
+{
+color = 9;
+glyphname = "thiCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (275,0);
+ref = dot_middle;
+}
+);
+width = 699;
+}
+);
+note = uni15E0;
+unicode = 5600;
+},
+{
+color = 9;
+glyphname = "thaCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(572,0,l),
+(719,690,l),
+(486,690,ls),
+(171,690,o),
+(78,443,o),
+(78,265,cs),
+(78,99,o),
+(179,0,o),
+(356,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(173,417,o),
+(252,605,o),
+(480,605,cs),
+(629,605,l),
+(611,634,l),
+(488,55,l),
+(523,85,l),
+(376,85,ls),
+(243,85,o),
+(173,151,o),
+(173,271,cs)
+);
+}
+);
+width = 699;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15E1;
+unicode = 5601;
+},
+{
+color = 9;
+glyphname = "ttuCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(509,-13,o),
+(611,79,o),
+(653,280,cs),
+(740,690,l),
+(706,690,l),
+(376,499,l),
+(452,486,l),
+(200,690,l),
+(164,690,l),
+(82,304,ls),
+(39,102,o),
+(135,-13,o),
+(332,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(201,75,o),
+(146,150,o),
+(177,298,cs),
+(242,603,l),
+(194,590,l),
+(388,430,l),
+(410,430,l),
+(656,576,l),
+(625,601,l),
+(559,288,ls),
+(527,140,o),
+(458,75,o),
+(334,75,cs)
+);
+}
+);
+width = 712;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E2;
+unicode = 5602;
+},
+{
+color = 9;
+glyphname = "ttoCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(51,0,l),
+(382,190,l),
+(306,204,l),
+(557,0,l),
+(593,0,l),
+(675,385,ls),
+(719,587,o),
+(622,702,o),
+(425,702,cs),
+(248,702,o),
+(147,611,o),
+(104,410,cs),
+(17,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(556,614,o),
+(612,540,o),
+(581,391,cs),
+(516,87,l),
+(563,99,l),
+(370,260,l),
+(348,260,l),
+(102,114,l),
+(132,89,l),
+(199,402,ls),
+(230,550,o),
+(300,614,o),
+(423,614,cs)
+);
+}
+);
+width = 712;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E3;
+unicode = 5603;
+},
+{
+color = 9;
+glyphname = "tteCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (422,345);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(268,0,ls),
+(558,0,o),
+(675,224,o),
+(675,424,cs),
+(675,591,o),
+(575,690,o),
+(397,690,cs),
+(163,690,l),
+(157,664,l),
+(218,308,l),
+(227,387,l),
+(23,26,l),
+(17,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(299,334,l),
+(303,353,l),
+(253,647,l),
+(219,605,l),
+(377,605,ls),
+(510,605,o),
+(581,539,o),
+(581,417,cs),
+(581,272,o),
+(501,85,o),
+(272,85,cs),
+(114,85,l),
+(137,47,l)
+);
+}
+);
+width = 708;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15E4;
+unicode = 5604;
+},
+{
+color = 9;
+glyphname = "tteeCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (358,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 709;
+}
+);
+note = uni15E5;
+unicode = 5605;
+},
+{
+color = 9;
+glyphname = "ttiCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (344,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 709;
+}
+);
+note = uni15E6;
+unicode = 5606;
+},
+{
+color = 9;
+glyphname = "ttaCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(590,0,l),
+(596,26,l),
+(535,382,l),
+(526,302,l),
+(731,664,l),
+(737,690,l),
+(486,690,ls),
+(195,690,o),
+(78,466,o),
+(78,266,cs),
+(78,99,o),
+(180,0,o),
+(356,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(534,85,l),
+(377,85,ls),
+(244,85,o),
+(173,151,o),
+(173,272,cs),
+(173,417,o),
+(252,605,o),
+(481,605,cs),
+(640,605,l),
+(616,642,l),
+(455,355,l),
+(451,337,l),
+(501,43,l)
+);
+}
+);
+width = 708;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tteCarrier-canadian";
+note = uni15E7;
+unicode = 5607;
+},
+{
+color = 9;
+glyphname = "puCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(509,-13,o),
+(611,82,o),
+(652,277,cs),
+(740,690,l),
+(644,690,l),
+(611,530,l),
+(226,530,l),
+(260,690,l),
+(164,690,l),
+(82,306,ls),
+(40,103,o),
+(136,-13,o),
+(330,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,75,o),
+(145,150,o),
+(178,300,cs),
+(209,446,l),
+(592,446,l),
+(557,280,ls),
+(526,139,o),
+(458,75,o),
+(338,75,cs)
+);
+}
+);
+width = 712;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E8;
+unicode = 5608;
+},
+{
+color = 9;
+glyphname = "poCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(113,0,l),
+(147,159,l),
+(531,159,l),
+(498,0,l),
+(593,0,l),
+(675,384,ls),
+(718,586,o),
+(621,702,o),
+(427,702,cs),
+(248,702,o),
+(147,608,o),
+(105,412,cs),
+(17,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(201,410,ls),
+(231,551,o),
+(300,614,o),
+(419,614,cs),
+(557,614,o),
+(612,540,o),
+(580,389,cs),
+(550,243,l),
+(165,243,l)
+);
+}
+);
+width = 712;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E9;
+unicode = 5609;
+},
+{
+color = 9;
+glyphname = "peCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (409,345);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(264,0,ls),
+(577,0,o),
+(670,245,o),
+(670,425,cs),
+(670,591,o),
+(570,690,o),
+(393,690,cs),
+(159,690,l),
+(142,605,l),
+(230,605,l),
+(119,85,l),
+(31,85,l),
+(14,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(334,647,l),
+(269,605,l),
+(373,605,ls),
+(505,605,o),
+(576,539,o),
+(576,418,cs),
+(576,272,o),
+(497,85,o),
+(269,85,cs),
+(158,85,l),
+(206,43,l)
+);
+}
+);
+width = 703;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15EA;
+unicode = 5610;
+},
+{
+color = 9;
+glyphname = "peeCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (344,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 704;
+}
+);
+note = uni15EB;
+unicode = 5611;
+},
+{
+color = 9;
+glyphname = "piCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (330,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 704;
+}
+);
+note = uni15EC;
+unicode = 5612;
+},
+{
+color = 9;
+glyphname = "paCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(590,0,l),
+(608,85,l),
+(520,85,l),
+(631,605,l),
+(719,605,l),
+(736,690,l),
+(486,690,ls),
+(173,690,o),
+(78,444,o),
+(78,265,cs),
+(78,99,o),
+(179,0,o),
+(356,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(480,85,l),
+(377,85,ls),
+(244,85,o),
+(173,151,o),
+(173,271,cs),
+(173,417,o),
+(252,605,o),
+(481,605,cs),
+(591,605,l),
+(544,647,l),
+(415,43,l)
+);
+}
+);
+width = 704;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|peCarrier-canadian";
+note = uni15ED;
+unicode = 5613;
+},
+{
+color = 6;
+glyphname = "pCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(371,183,l),
+(384,247,l),
+(259,247,l),
+(319,527,l),
+(250,527,l),
+(191,247,l),
+(64,247,l),
+(50,183,l)
+);
+}
+);
+width = 445;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni15EE;
+unicode = 5614;
+},
+{
+color = 9;
+glyphname = "guCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (526,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(320,-13,o),
+(387,37,o),
+(429,133,c),
+(389,133,l),
+(403,40,o),
+(463,-13,o),
+(557,-13,cs),
+(673,-13,o),
+(747,58,o),
+(777,195,cs),
+(881,690,l),
+(789,690,l),
+(684,198,ls),
+(667,115,o),
+(623,72,o),
+(555,72,cs),
+(483,72,o),
+(450,123,o),
+(469,209,cs),
+(570,690,l),
+(480,690,l),
+(378,210,ls),
+(358,120,o),
+(313,72,o),
+(242,72,cs),
+(167,72,o),
+(138,121,o),
+(158,214,cs),
+(259,690,l),
+(167,690,l),
+(68,221,ls),
+(36,74,o),
+(96,-13,o),
+(227,-13,cs)
+);
+}
+);
+width = 857;
+}
+);
+metricRight = "=|";
+note = uni15EF;
+unicode = 5615;
+},
+{
+color = 9;
+glyphname = "goCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(112,0,l),
+(217,492,ls),
+(235,575,o),
+(278,617,o),
+(346,617,cs),
+(418,617,o),
+(451,567,o),
+(433,481,cs),
+(330,0,l),
+(421,0,l),
+(524,480,ls),
+(543,570,o),
+(588,617,o),
+(659,617,cs),
+(733,617,o),
+(762,569,o),
+(743,475,cs),
+(641,0,l),
+(734,0,l),
+(834,469,ls),
+(865,615,o),
+(806,702,o),
+(674,702,cs),
+(581,702,o),
+(514,653,o),
+(472,556,c),
+(512,556,l),
+(498,650,o),
+(439,702,o),
+(344,702,cs),
+(228,702,o),
+(155,632,o),
+(125,495,cs),
+(20,0,l)
+);
+}
+);
+width = 856;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F0;
+unicode = 5616;
+},
+{
+color = 9;
+glyphname = "geCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (453,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(374,0,ls),
+(530,0,o),
+(625,75,o),
+(625,210,cs),
+(625,279,o),
+(590,332,o),
+(526,355,c),
+(521,325,l),
+(639,348,o),
+(693,434,o),
+(693,528,cs),
+(693,626,o),
+(621,690,o),
+(511,690,cs),
+(172,690,l),
+(156,611,l),
+(489,611,ls),
+(558,611,o),
+(597,577,o),
+(597,520,cs),
+(597,434,o),
+(542,384,o),
+(441,384,cs),
+(107,384,l),
+(91,306,l),
+(426,306,ls),
+(495,306,o),
+(531,272,o),
+(531,214,cs),
+(531,135,o),
+(486,79,o),
+(376,79,cs),
+(43,79,l),
+(25,0,l)
+);
+}
+);
+width = 708;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15F1;
+unicode = 5617;
+},
+{
+color = 9;
+glyphname = "geeCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(374,0,ls),
+(530,0,o),
+(625,75,o),
+(625,210,cs),
+(625,279,o),
+(590,332,o),
+(526,355,c),
+(521,325,l),
+(639,348,o),
+(693,434,o),
+(693,528,cs),
+(693,626,o),
+(621,690,o),
+(511,690,cs),
+(172,690,l),
+(156,611,l),
+(489,611,ls),
+(558,611,o),
+(597,577,o),
+(597,520,cs),
+(597,434,o),
+(542,384,o),
+(441,384,cs),
+(375,384,l),
+(392,467,l),
+(333,467,l),
+(316,384,l),
+(107,384,l),
+(91,306,l),
+(298,306,l),
+(281,224,l),
+(340,224,l),
+(357,306,l),
+(426,306,ls),
+(495,306,o),
+(531,272,o),
+(531,214,cs),
+(531,135,o),
+(486,79,o),
+(376,79,cs),
+(43,79,l),
+(25,0,l)
+);
+}
+);
+width = 708;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F2;
+unicode = 5618;
+},
+{
+color = 9;
+glyphname = "giCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(374,0,ls),
+(530,0,o),
+(625,75,o),
+(625,210,cs),
+(625,278,o),
+(590,332,o),
+(527,355,c),
+(523,326,l),
+(639,349,o),
+(693,435,o),
+(693,528,cs),
+(693,626,o),
+(621,690,o),
+(511,690,cs),
+(172,690,l),
+(156,611,l),
+(489,611,ls),
+(558,611,o),
+(597,577,o),
+(597,520,cs),
+(597,434,o),
+(542,384,o),
+(441,384,cs),
+(388,384,l),
+(421,357,l),
+(416,397,o),
+(383,428,o),
+(340,428,cs),
+(309,428,o),
+(282,410,o),
+(270,384,c),
+(107,384,l),
+(91,306,l),
+(270,306,l),
+(283,281,o),
+(309,263,o),
+(341,263,cs),
+(382,263,o),
+(413,294,o),
+(420,332,c),
+(383,306,l),
+(426,306,ls),
+(495,306,o),
+(531,272,o),
+(531,214,cs),
+(531,135,o),
+(486,79,o),
+(376,79,cs),
+(43,79,l),
+(25,0,l)
+);
+}
+);
+width = 708;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F3;
+unicode = 5619;
+},
+{
+color = 9;
+glyphname = "gaCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (465,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(581,0,l),
+(597,79,l),
+(264,79,ls),
+(193,79,o),
+(156,113,o),
+(156,170,cs),
+(156,256,o),
+(211,305,o),
+(311,305,cs),
+(646,305,l),
+(663,384,l),
+(327,384,ls),
+(258,384,o),
+(221,417,o),
+(221,475,cs),
+(221,554,o),
+(267,611,o),
+(377,611,cs),
+(710,611,l),
+(727,690,l),
+(379,690,ls),
+(222,690,o),
+(128,614,o),
+(128,480,cs),
+(128,411,o),
+(162,357,o),
+(226,334,c),
+(232,365,l),
+(113,342,o),
+(60,256,o),
+(60,161,cs),
+(60,64,o),
+(131,0,o),
+(242,0,cs)
+);
+}
+);
+width = 708;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|geCarrier-canadian";
+note = uni15F4;
+unicode = 5620;
+},
+{
+color = 9;
+glyphname = "khuCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(316,-13,o),
+(382,33,o),
+(422,122,c),
+(392,124,l),
+(408,37,o),
+(466,-13,o),
+(557,-13,cs),
+(673,-13,o),
+(747,58,o),
+(777,195,cs),
+(881,690,l),
+(167,690,l),
+(68,221,ls),
+(36,74,o),
+(96,-13,o),
+(227,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(167,72,o),
+(138,121,o),
+(158,214,cs),
+(242,607,l),
+(463,607,l),
+(378,210,ls),
+(358,120,o),
+(313,72,o),
+(242,72,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(483,72,o),
+(450,123,o),
+(469,209,cs),
+(553,607,l),
+(772,607,l),
+(684,198,ls),
+(667,115,o),
+(623,72,o),
+(555,72,cs)
+);
+}
+);
+width = 857;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F5;
+unicode = 5621;
+},
+{
+color = 9;
+glyphname = "khoCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(734,0,l),
+(834,469,ls),
+(865,615,o),
+(806,702,o),
+(674,702,cs),
+(585,702,o),
+(520,657,o),
+(479,568,c),
+(509,566,l),
+(494,653,o),
+(436,702,o),
+(344,702,cs),
+(228,702,o),
+(155,632,o),
+(125,495,cs),
+(20,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(216,492,ls),
+(235,575,o),
+(278,617,o),
+(346,617,cs),
+(418,617,o),
+(451,567,o),
+(433,481,cs),
+(348,83,l),
+(129,83,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(524,480,ls),
+(543,570,o),
+(588,617,o),
+(659,617,cs),
+(733,617,o),
+(762,569,o),
+(743,475,cs),
+(660,83,l),
+(439,83,l)
+);
+}
+);
+width = 856;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F6;
+unicode = 5622;
+},
+{
+color = 9;
+glyphname = "kheCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(378,0,ls),
+(534,0,o),
+(629,76,o),
+(629,211,cs),
+(629,279,o),
+(594,331,o),
+(531,355,c),
+(526,326,l),
+(646,349,o),
+(696,439,o),
+(696,528,cs),
+(696,626,o),
+(625,690,o),
+(515,690,cs),
+(172,690,l),
+(25,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(185,306,l),
+(430,306,ls),
+(497,306,o),
+(536,272,o),
+(536,214,cs),
+(536,134,o),
+(489,78,o),
+(380,78,cs),
+(137,78,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(251,611,l),
+(493,611,ls),
+(563,611,o),
+(601,577,o),
+(601,520,cs),
+(601,436,o),
+(547,384,o),
+(445,384,cs),
+(202,384,l)
+);
+}
+);
+width = 712;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F7;
+unicode = 5623;
+},
+{
+color = 9;
+glyphname = "kheeCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(378,0,ls),
+(534,0,o),
+(629,76,o),
+(629,211,cs),
+(629,279,o),
+(594,331,o),
+(531,355,c),
+(526,326,l),
+(646,349,o),
+(696,439,o),
+(696,528,cs),
+(696,626,o),
+(625,690,o),
+(515,690,cs),
+(172,690,l),
+(25,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(185,307,l),
+(327,307,l),
+(308,222,l),
+(372,222,l),
+(393,324,l),
+(367,307,l),
+(430,307,ls),
+(497,307,o),
+(536,273,o),
+(536,215,cs),
+(536,135,o),
+(489,78,o),
+(380,78,cs),
+(137,78,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(424,469,l),
+(360,469,l),
+(342,384,l),
+(202,384,l),
+(251,611,l),
+(493,611,ls),
+(563,611,o),
+(601,577,o),
+(601,520,cs),
+(601,436,o),
+(547,384,o),
+(445,384,cs),
+(384,384,l),
+(403,367,l)
+);
+}
+);
+width = 712;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F8;
+unicode = 5624;
+},
+{
+color = 9;
+glyphname = "khiCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(378,0,ls),
+(534,0,o),
+(629,76,o),
+(629,211,cs),
+(629,278,o),
+(595,331,o),
+(531,355,c),
+(526,325,l),
+(647,349,o),
+(696,439,o),
+(696,528,cs),
+(696,626,o),
+(625,690,o),
+(515,690,cs),
+(172,690,l),
+(25,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(186,309,l),
+(294,309,l),
+(306,282,o),
+(334,263,o),
+(366,263,cs),
+(408,263,o),
+(440,296,o),
+(445,336,c),
+(389,309,l),
+(431,309,ls),
+(499,309,o),
+(536,274,o),
+(536,215,cs),
+(536,135,o),
+(489,78,o),
+(380,78,cs),
+(137,78,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(493,611,ls),
+(563,611,o),
+(601,577,o),
+(601,519,cs),
+(601,435,o),
+(549,382,o),
+(447,382,cs),
+(393,382,l),
+(446,354,l),
+(442,396,o),
+(409,428,o),
+(365,428,cs),
+(323,428,o),
+(289,396,o),
+(286,354,c),
+(320,382,l),
+(202,382,l),
+(251,611,l)
+);
+}
+);
+width = 712;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F9;
+unicode = 5625;
+},
+{
+color = 9;
+glyphname = "khaCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(585,0,l),
+(732,690,l),
+(380,690,ls),
+(223,690,o),
+(128,613,o),
+(128,479,cs),
+(128,411,o),
+(163,358,o),
+(226,335,c),
+(230,364,l),
+(110,341,o),
+(60,251,o),
+(60,161,cs),
+(60,64,o),
+(131,0,o),
+(242,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(194,78,o),
+(156,113,o),
+(156,170,cs),
+(156,254,o),
+(210,306,o),
+(312,306,cs),
+(554,306,l),
+(506,78,l),
+(264,78,ls)
+);
+},
+{
+closed = 1;
+nodes = (
+(259,384,o),
+(221,417,o),
+(221,475,cs),
+(221,555,o),
+(269,611,o),
+(378,611,cs),
+(620,611,l),
+(572,384,l),
+(327,384,ls)
+);
+}
+);
+width = 712;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15FA;
+unicode = 5626;
+},
+{
+color = 9;
+glyphname = "kkuCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(314,-13,o),
+(381,31,o),
+(423,123,c),
+(392,123,l),
+(408,38,o),
+(465,-13,o),
+(557,-13,cs),
+(673,-13,o),
+(747,58,o),
+(777,195,cs),
+(881,690,l),
+(846,690,l),
+(521,533,l),
+(501,436,l),
+(803,579,l),
+(772,611,l),
+(684,198,ls),
+(668,115,o),
+(623,72,o),
+(555,72,cs),
+(479,72,o),
+(450,128,o),
+(468,209,cs),
+(570,690,l),
+(480,690,l),
+(378,210,ls),
+(358,118,o),
+(311,72,o),
+(242,72,cs),
+(167,72,o),
+(138,121,o),
+(158,214,cs),
+(242,614,l),
+(196,594,l),
+(442,444,l),
+(462,532,l),
+(202,690,l),
+(167,690,l),
+(68,221,ls),
+(36,73,o),
+(97,-13,o),
+(227,-13,cs)
+);
+}
+);
+width = 857;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FB;
+unicode = 5627;
+},
+{
+color = 9;
+glyphname = "kkoCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(55,0,l),
+(381,156,l),
+(399,254,l),
+(98,111,l),
+(129,78,l),
+(217,492,ls),
+(234,575,o),
+(277,617,o),
+(345,617,cs),
+(421,617,o),
+(450,562,o),
+(433,481,cs),
+(330,0,l),
+(421,0,l),
+(523,480,ls),
+(543,572,o),
+(589,617,o),
+(659,617,cs),
+(733,617,o),
+(762,569,o),
+(743,475,cs),
+(658,75,l),
+(704,96,l),
+(458,245,l),
+(439,157,l),
+(698,0,l),
+(734,0,l),
+(834,469,ls),
+(865,616,o),
+(805,702,o),
+(674,702,cs),
+(586,702,o),
+(520,659,o),
+(478,567,c),
+(508,567,l),
+(494,652,o),
+(437,702,o),
+(344,702,cs),
+(227,702,o),
+(155,632,o),
+(125,495,cs),
+(20,0,l)
+);
+}
+);
+width = 856;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FC;
+unicode = 5628;
+},
+{
+color = 9;
+glyphname = "kkeCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(391,0,ls),
+(548,0,o),
+(642,75,o),
+(642,210,cs),
+(642,278,o),
+(609,331,o),
+(544,355,c),
+(540,326,l),
+(661,349,o),
+(711,438,o),
+(711,528,cs),
+(711,627,o),
+(639,690,o),
+(528,690,cs),
+(168,690,l),
+(162,664,l),
+(210,384,l),
+(114,384,l),
+(98,306,l),
+(188,306,l),
+(27,26,l),
+(21,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(287,306,l),
+(444,306,ls),
+(512,306,o),
+(550,272,o),
+(550,214,cs),
+(550,135,o),
+(504,79,o),
+(394,79,cs),
+(113,79,l),
+(137,43,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(257,653,l),
+(223,611,l),
+(506,611,ls),
+(577,611,o),
+(615,577,o),
+(615,520,cs),
+(615,434,o),
+(559,384,o),
+(459,384,cs),
+(302,384,l)
+);
+}
+);
+width = 726;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni15FD;
+unicode = 5629;
+},
+{
+color = 9;
+glyphname = "kkeeCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(391,0,ls),
+(548,0,o),
+(642,75,o),
+(642,210,cs),
+(642,278,o),
+(609,331,o),
+(544,355,c),
+(540,326,l),
+(661,349,o),
+(711,438,o),
+(711,528,cs),
+(711,627,o),
+(639,690,o),
+(528,690,cs),
+(168,690,l),
+(162,664,l),
+(210,384,l),
+(114,384,l),
+(98,306,l),
+(188,306,l),
+(27,26,l),
+(21,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(288,308,l),
+(361,308,l),
+(343,222,l),
+(408,222,l),
+(429,328,l),
+(405,308,l),
+(446,308,ls),
+(514,308,o),
+(550,272,o),
+(550,214,cs),
+(550,135,o),
+(504,79,o),
+(394,79,cs),
+(113,79,l),
+(137,43,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(460,469,l),
+(395,469,l),
+(377,383,l),
+(303,383,l),
+(257,653,l),
+(223,611,l),
+(506,611,ls),
+(577,611,o),
+(615,577,o),
+(615,520,cs),
+(615,434,o),
+(559,383,o),
+(461,383,cs),
+(420,383,l),
+(438,366,l)
+);
+}
+);
+width = 726;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FE;
+unicode = 5630;
+},
+{
+color = 9;
+glyphname = "kkiCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(391,0,ls),
+(548,0,o),
+(642,75,o),
+(642,210,cs),
+(642,278,o),
+(609,331,o),
+(544,355,c),
+(540,326,l),
+(661,349,o),
+(711,438,o),
+(711,528,cs),
+(711,627,o),
+(639,690,o),
+(528,690,cs),
+(168,690,l),
+(162,664,l),
+(210,384,l),
+(114,384,l),
+(98,306,l),
+(188,306,l),
+(27,26,l),
+(21,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(289,309,l),
+(326,309,l),
+(338,282,o),
+(365,263,o),
+(397,263,cs),
+(437,263,o),
+(468,293,o),
+(473,330,c),
+(417,309,l),
+(446,309,ls),
+(515,309,o),
+(550,272,o),
+(550,214,cs),
+(550,135,o),
+(504,79,o),
+(394,79,cs),
+(113,79,l),
+(137,43,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(470,398,o),
+(438,428,o),
+(396,428,cs),
+(364,428,o),
+(336,409,o),
+(325,381,c),
+(303,381,l),
+(257,653,l),
+(223,611,l),
+(506,611,ls),
+(577,611,o),
+(615,577,o),
+(615,520,cs),
+(615,434,o),
+(560,381,o),
+(461,381,cs),
+(418,381,l),
+(475,358,l)
+);
+}
+);
+width = 726;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FF;
+unicode = 5631;
+},
+{
+color = 9;
+glyphname = "kkaCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(602,0,l),
+(608,26,l),
+(561,305,l),
+(657,305,l),
+(673,384,l),
+(582,384,l),
+(743,664,l),
+(749,690,l),
+(379,690,ls),
+(222,690,o),
+(128,614,o),
+(128,480,cs),
+(128,412,o),
+(161,358,o),
+(227,335,c),
+(231,364,l),
+(110,341,o),
+(60,252,o),
+(60,161,cs),
+(60,63,o),
+(131,0,o),
+(242,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(548,79,l),
+(265,79,ls),
+(193,79,o),
+(156,113,o),
+(156,170,cs),
+(156,256,o),
+(212,305,o),
+(311,305,cs),
+(468,305,l),
+(514,37,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(258,384,o),
+(221,417,o),
+(221,475,cs),
+(221,554,o),
+(267,611,o),
+(377,611,cs),
+(658,611,l),
+(633,647,l),
+(483,384,l),
+(327,384,ls)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|kkeCarrier-canadian";
+note = uni1600;
+unicode = 5632;
+},
+{
+color = 6;
+glyphname = "kkCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(367,527,l),
+(186,251,l),
+(236,251,l),
+(171,527,l),
+(110,527,l),
+(106,513,l),
+(190,183,l),
+(209,183,l),
+(433,513,l),
+(436,527,l)
+);
+}
+);
+width = 423;
+}
+);
+note = uni1601;
+unicode = 5633;
+},
+{
+color = 9;
+glyphname = "nuCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(501,-13,o),
+(611,83,o),
+(648,258,cs),
+(658,303,l),
+(562,303,l),
+(554,266,ls),
+(527,139,o),
+(455,74,o),
+(341,74,cs),
+(207,74,o),
+(147,159,o),
+(179,307,cs),
+(260,690,l),
+(164,690,l),
+(83,311,ls),
+(42,115,o),
+(140,-13,o),
+(335,-13,cs)
+);
+}
+);
+width = 708;
+}
+);
+metricLeft = "te-canadian";
+note = uni1602;
+unicode = 5634;
+},
+{
+color = 9;
+glyphname = "noCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(588,0,l),
+(668,379,ls),
+(711,575,o),
+(612,702,o),
+(417,702,cs),
+(251,702,o),
+(141,607,o),
+(104,432,cs),
+(95,386,l),
+(189,386,l),
+(198,424,ls),
+(225,551,o),
+(298,615,o),
+(412,615,cs),
+(546,615,o),
+(605,530,o),
+(574,383,cs),
+(493,0,l)
+);
+}
+);
+width = 707;
+}
+);
+metricLeft = "=|nuCarrier-canadian";
+metricRight = "te-canadian";
+note = uni1603;
+unicode = 5635;
+},
+{
+color = 9;
+glyphname = "neCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (337,344);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(264,0,ls),
+(571,0,o),
+(667,241,o),
+(667,423,cs),
+(667,590,o),
+(566,690,o),
+(387,690,cs),
+(147,690,l),
+(128,603,l),
+(375,603,ls),
+(502,603,o),
+(572,536,o),
+(572,416,cs),
+(572,284,o),
+(504,86,o),
+(273,86,cs),
+(253,86,l),
+(235,0,l)
+);
+}
+);
+width = 701;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1604;
+unicode = 5636;
+},
+{
+color = 9;
+glyphname = "neeCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "neCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (266,-1);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 701;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1605;
+unicode = 5637;
+},
+{
+color = 9;
+glyphname = "niCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "neCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (242,-1);
+ref = dot_middle;
+}
+);
+width = 700;
+}
+);
+note = uni1606;
+unicode = 5638;
+},
+{
+color = 9;
+glyphname = "naCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(599,0,l),
+(617,87,l),
+(371,87,ls),
+(243,87,o),
+(174,154,o),
+(174,273,cs),
+(174,406,o),
+(241,604,o),
+(471,604,cs),
+(493,604,l),
+(511,690,l),
+(482,690,ls),
+(175,690,o),
+(79,449,o),
+(79,267,cs),
+(79,99,o),
+(180,0,o),
+(357,0,cs)
+);
+}
+);
+width = 701;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni1607;
+unicode = 5639;
+},
+{
+color = 9;
+glyphname = "muCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(318,-13,o),
+(387,35,o),
+(429,133,c),
+(389,133,l),
+(403,43,o),
+(461,-13,o),
+(557,-13,cs),
+(673,-13,o),
+(747,58,o),
+(777,195,cs),
+(818,390,l),
+(723,390,l),
+(682,198,ls),
+(665,115,o),
+(621,72,o),
+(556,72,cs),
+(481,72,o),
+(452,128,o),
+(469,208,cs),
+(508,390,l),
+(415,390,l),
+(377,210,ls),
+(356,117,o),
+(310,72,o),
+(242,72,cs),
+(169,72,o),
+(140,120,o),
+(160,214,cs),
+(262,690,l),
+(167,690,l),
+(68,221,ls),
+(36,73,o),
+(96,-13,o),
+(227,-13,cs)
+);
+}
+);
+width = 857;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "=|";
+note = uni1608;
+unicode = 5640;
+},
+{
+color = 9;
+glyphname = "moCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(734,0,l),
+(834,469,ls),
+(866,616,o),
+(806,702,o),
+(674,702,cs),
+(583,702,o),
+(514,655,o),
+(472,556,c),
+(511,556,l),
+(498,647,o),
+(440,702,o),
+(344,702,cs),
+(228,702,o),
+(155,632,o),
+(126,495,cs),
+(84,299,l),
+(179,299,l),
+(219,492,ls),
+(237,575,o),
+(280,617,o),
+(345,617,cs),
+(420,617,o),
+(449,562,o),
+(432,482,cs),
+(393,299,l),
+(486,299,l),
+(525,480,ls),
+(545,573,o),
+(591,617,o),
+(659,617,cs),
+(732,617,o),
+(760,570,o),
+(740,475,cs),
+(639,0,l)
+);
+}
+);
+width = 856;
+}
+);
+metricLeft = "=|muCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni1609;
+unicode = 5641;
+},
+{
+color = 9;
+glyphname = "meCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(375,0,ls),
+(531,0,o),
+(626,75,o),
+(626,210,cs),
+(626,279,o),
+(591,332,o),
+(528,355,c),
+(523,325,l),
+(640,348,o),
+(695,434,o),
+(695,528,cs),
+(695,626,o),
+(623,690,o),
+(512,690,cs),
+(147,690,l),
+(130,611,l),
+(491,611,ls),
+(560,611,o),
+(599,577,o),
+(599,520,cs),
+(599,434,o),
+(543,384,o),
+(443,384,cs),
+(317,384,l),
+(300,306,l),
+(427,306,ls),
+(496,306,o),
+(533,272,o),
+(533,214,cs),
+(533,135,o),
+(488,79,o),
+(378,79,cs),
+(252,79,l),
+(236,0,l)
+);
+}
+);
+width = 710;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160A;
+unicode = 5642;
+},
+{
+color = 9;
+glyphname = "meeCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(375,0,ls),
+(531,0,o),
+(626,75,o),
+(626,210,cs),
+(626,279,o),
+(591,332,o),
+(528,355,c),
+(523,325,l),
+(640,348,o),
+(695,434,o),
+(695,528,cs),
+(695,626,o),
+(623,690,o),
+(512,690,cs),
+(147,690,l),
+(130,611,l),
+(491,611,ls),
+(560,611,o),
+(599,577,o),
+(599,520,cs),
+(599,434,o),
+(543,383,o),
+(443,383,cs),
+(382,383,l),
+(399,465,l),
+(333,465,l),
+(283,226,l),
+(349,226,l),
+(365,307,l),
+(428,307,ls),
+(497,307,o),
+(533,272,o),
+(533,214,cs),
+(533,135,o),
+(488,79,o),
+(378,79,cs),
+(252,79,l),
+(236,0,l)
+);
+}
+);
+width = 710;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160B;
+unicode = 5643;
+},
+{
+color = 9;
+glyphname = "miCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(375,0,ls),
+(529,0,o),
+(613,70,o),
+(624,188,cs),
+(632,268,o),
+(598,328,o),
+(528,355,c),
+(523,325,l),
+(633,346,o),
+(684,422,o),
+(692,507,cs),
+(704,616,o),
+(631,690,o),
+(512,690,cs),
+(147,690,l),
+(130,611,l),
+(490,611,ls),
+(563,611,o),
+(602,574,o),
+(598,512,cs),
+(594,428,o),
+(539,383,o),
+(442,383,cs),
+(370,383,l),
+(422,355,l),
+(417,397,o),
+(384,429,o),
+(341,429,cs),
+(295,429,o),
+(260,391,o),
+(260,347,cs),
+(260,301,o),
+(296,264,o),
+(341,264,cs),
+(383,264,o),
+(415,295,o),
+(421,335,c),
+(369,307,l),
+(427,307,ls),
+(498,307,o),
+(536,271,o),
+(532,207,cs),
+(528,128,o),
+(481,79,o),
+(378,79,cs),
+(252,79,l),
+(236,0,l)
+);
+}
+);
+width = 708;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160C;
+unicode = 5644;
+},
+{
+color = 9;
+glyphname = "maCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(608,0,l),
+(625,79,l),
+(264,79,ls),
+(193,79,o),
+(156,113,o),
+(156,170,cs),
+(156,256,o),
+(211,305,o),
+(311,305,cs),
+(437,305,l),
+(453,384,l),
+(327,384,ls),
+(258,384,o),
+(221,417,o),
+(221,475,cs),
+(221,554,o),
+(267,611,o),
+(377,611,cs),
+(502,611,l),
+(519,690,l),
+(379,690,ls),
+(222,690,o),
+(128,614,o),
+(128,480,cs),
+(128,411,o),
+(162,357,o),
+(226,334,c),
+(232,365,l),
+(113,342,o),
+(60,256,o),
+(60,161,cs),
+(60,64,o),
+(131,0,o),
+(242,0,cs)
+);
+}
+);
+width = 710;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni160D;
+unicode = 5645;
+},
+{
+color = 9;
+glyphname = "yuCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(538,-13,o),
+(659,106,o),
+(711,358,cs),
+(752,549,o),
+(719,702,o),
+(565,702,cs),
+(423,702,o),
+(365,562,o),
+(365,457,cs),
+(365,364,o),
+(416,304,o),
+(501,304,cs),
+(515,304,o),
+(527,307,o),
+(545,311,c),
+(561,387,l),
+(552,384,o),
+(540,384,o),
+(528,384,cs),
+(477,384,o),
+(450,412,o),
+(450,465,cs),
+(450,519,o),
+(475,623,o),
+(557,623,cs),
+(649,623,o),
+(651,515,o),
+(623,377,cs),
+(581,165,o),
+(500,75,o),
+(353,75,cs),
+(201,75,o),
+(150,172,o),
+(182,320,cs),
+(261,690,l),
+(164,690,l),
+(86,321,ls),
+(45,128,o),
+(132,-13,o),
+(345,-13,cs)
+);
+}
+);
+width = 754;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160E;
+unicode = 5646;
+},
+{
+color = 9;
+glyphname = "yoCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(376,-13,o),
+(433,128,o),
+(433,233,cs),
+(433,326,o),
+(383,385,o),
+(298,385,cs),
+(284,385,o),
+(272,383,o),
+(254,379,c),
+(238,302,l),
+(247,305,o),
+(258,306,o),
+(270,306,cs),
+(322,306,o),
+(349,278,o),
+(349,225,cs),
+(349,171,o),
+(324,67,o),
+(241,67,cs),
+(150,67,o),
+(147,175,o),
+(175,313,cs),
+(217,525,o),
+(298,614,o),
+(446,614,cs),
+(598,614,o),
+(648,518,o),
+(617,370,cs),
+(538,0,l),
+(635,0,l),
+(713,369,ls),
+(753,562,o),
+(666,702,o),
+(454,702,cs),
+(260,702,o),
+(139,583,o),
+(87,331,cs),
+(46,141,o),
+(80,-13,o),
+(234,-13,cs)
+);
+}
+);
+width = 754;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160F;
+unicode = 5647;
+},
+{
+color = 9;
+glyphname = "yeCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(548,-13,o),
+(666,218,o),
+(666,412,cs),
+(666,586,o),
+(559,690,o),
+(374,690,cs),
+(172,690,l),
+(154,603,l),
+(357,603,ls),
+(496,603,o),
+(569,532,o),
+(569,406,cs),
+(569,265,o),
+(501,70,o),
+(307,70,cs),
+(202,70,o),
+(142,116,o),
+(142,193,cs),
+(142,254,o),
+(175,330,o),
+(246,330,cs),
+(293,330,o),
+(320,300,o),
+(320,249,cs),
+(320,218,o),
+(312,186,o),
+(300,158,c),
+(378,158,l),
+(392,192,o),
+(401,229,o),
+(401,264,cs),
+(401,352,o),
+(344,408,o),
+(250,408,cs),
+(128,408,o),
+(56,297,o),
+(56,184,cs),
+(56,65,o),
+(150,-13,o),
+(303,-13,cs)
+);
+}
+);
+width = 702;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1610;
+unicode = 5648;
+},
+{
+color = 9;
+glyphname = "yeeCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(548,-13,o),
+(667,218,o),
+(667,413,cs),
+(667,586,o),
+(560,690,o),
+(375,690,cs),
+(173,690,l),
+(155,603,l),
+(358,603,ls),
+(497,603,o),
+(570,532,o),
+(570,405,cs),
+(570,285,o),
+(515,70,o),
+(308,70,cs),
+(203,70,o),
+(143,114,o),
+(143,191,cs),
+(143,249,o),
+(175,330,o),
+(250,330,cs),
+(310,330,o),
+(325,280,o),
+(312,222,cs),
+(302,180,l),
+(362,180,l),
+(429,496,l),
+(370,496,l),
+(330,309,l),
+(339,308,l),
+(343,370,o),
+(305,408,o),
+(239,408,cs),
+(121,408,o),
+(57,291,o),
+(57,186,cs),
+(57,65,o),
+(151,-13,o),
+(306,-13,cs)
+);
+}
+);
+width = 702;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1611;
+unicode = 5649;
+},
+{
+color = 9;
+glyphname = "yiCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(536,-13,o),
+(666,196,o),
+(666,413,cs),
+(666,586,o),
+(559,690,o),
+(374,690,cs),
+(173,690,l),
+(155,603,l),
+(358,603,ls),
+(497,603,o),
+(569,532,o),
+(569,405,cs),
+(569,254,o),
+(497,70,o),
+(308,70,cs),
+(202,70,o),
+(141,115,o),
+(141,190,cs),
+(141,261,o),
+(182,321,o),
+(273,314,c),
+(246,343,l),
+(247,304,o),
+(279,273,o),
+(320,273,cs),
+(360,273,o),
+(391,305,o),
+(391,346,cs),
+(391,386,o),
+(360,416,o),
+(319,416,cs),
+(292,416,o),
+(270,403,o),
+(258,383,c),
+(131,378,o),
+(56,297,o),
+(56,181,cs),
+(56,65,o),
+(150,-13,o),
+(304,-13,cs)
+);
+}
+);
+width = 702;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1612;
+unicode = 5650;
+},
+{
+color = 9;
+glyphname = "yaCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(573,0,l),
+(591,87,l),
+(387,87,ls),
+(249,87,o),
+(177,157,o),
+(177,284,cs),
+(177,425,o),
+(243,620,o),
+(439,620,cs),
+(543,620,o),
+(604,574,o),
+(604,497,cs),
+(604,436,o),
+(570,359,o),
+(499,359,cs),
+(452,359,o),
+(425,389,o),
+(425,440,cs),
+(425,471,o),
+(434,503,o),
+(444,531,c),
+(367,531,l),
+(353,497,o),
+(344,461,o),
+(344,426,cs),
+(344,338,o),
+(402,282,o),
+(495,282,cs),
+(617,282,o),
+(689,393,o),
+(689,506,cs),
+(689,625,o),
+(595,702,o),
+(441,702,cs),
+(197,702,o),
+(80,471,o),
+(80,278,cs),
+(80,103,o),
+(185,0,o),
+(372,0,cs)
+);
+}
+);
+width = 700;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|yeCarrier-canadian";
+note = uni1613;
+unicode = 5651;
+},
+{
+color = 9;
+glyphname = "juCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(536,-13,o),
+(653,99,o),
+(653,248,cs),
+(653,343,o),
+(595,408,o),
+(500,408,cs),
+(384,408,o),
+(324,311,o),
+(312,207,cs),
+(309,190,o),
+(308,174,o),
+(309,158,c),
+(386,158,l),
+(386,168,o),
+(387,182,o),
+(389,198,cs),
+(397,266,o),
+(428,330,o),
+(495,330,cs),
+(542,330,o),
+(568,298,o),
+(568,246,cs),
+(568,148,o),
+(498,70,o),
+(378,70,cs),
+(248,70,o),
+(175,135,o),
+(175,249,cs),
+(175,459,o),
+(347,603,o),
+(611,603,cs),
+(722,603,l),
+(740,690,l),
+(163,690,l),
+(146,607,l),
+(460,607,l),
+(545,641,l),
+(278,639,o),
+(79,484,o),
+(79,248,cs),
+(79,93,o),
+(192,-13,o),
+(366,-13,cs)
+);
+}
+);
+width = 719;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni1614;
+unicode = 5652;
+},
+{
+color = 9;
+glyphname = "juSayisi-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (468,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(545,-13,o),
+(661,172,o),
+(667,354,cs),
+(671,533,o),
+(554,639,o),
+(330,643,c),
+(421,607,l),
+(729,607,l),
+(748,690,l),
+(169,690,l),
+(152,603,l),
+(269,603,ls),
+(477,603,o),
+(577,520,o),
+(573,360,cs),
+(570,241,o),
+(516,70,o),
+(313,70,cs),
+(200,70,o),
+(140,117,o),
+(142,196,cs),
+(143,264,o),
+(182,330,o),
+(247,330,cs),
+(295,330,o),
+(319,299,o),
+(319,245,cs),
+(318,217,o),
+(310,184,o),
+(299,158,c),
+(377,158,l),
+(392,194,o),
+(399,231,o),
+(399,259,cs),
+(402,350,o),
+(346,408,o),
+(251,408,cs),
+(137,408,o),
+(60,308,o),
+(57,192,cs),
+(52,69,o),
+(146,-13,o),
+(310,-13,cs)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1615;
+unicode = 5653;
+},
+{
+color = 9;
+glyphname = "joCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(600,0,l),
+(617,83,l),
+(303,83,l),
+(218,48,l),
+(485,51,o),
+(684,206,o),
+(684,441,cs),
+(684,597,o),
+(571,702,o),
+(398,702,cs),
+(227,702,o),
+(111,590,o),
+(111,441,cs),
+(111,347,o),
+(168,282,o),
+(263,282,cs),
+(379,282,o),
+(440,379,o),
+(451,483,cs),
+(454,499,o),
+(455,516,o),
+(454,531,c),
+(377,531,l),
+(377,522,o),
+(377,508,o),
+(374,492,cs),
+(366,424,o),
+(335,359,o),
+(269,359,cs),
+(221,359,o),
+(195,391,o),
+(195,443,cs),
+(195,542,o),
+(265,620,o),
+(386,620,cs),
+(515,620,o),
+(588,554,o),
+(588,440,cs),
+(588,231,o),
+(416,87,o),
+(153,87,cs),
+(42,87,l),
+(23,0,l)
+);
+}
+);
+width = 718;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1616;
+unicode = 5654;
+},
+{
+color = 9;
+glyphname = "jeCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(662,-13,o),
+(716,287,o),
+(716,427,cs),
+(716,601,o),
+(634,702,o),
+(483,702,cs),
+(350,702,o),
+(253,621,o),
+(199,463,c),
+(215,450,l),
+(267,690,l),
+(172,690,l),
+(25,0,l),
+(121,0,l),
+(181,281,ls),
+(227,500,o),
+(324,615,o),
+(463,615,cs),
+(572,615,o),
+(624,550,o),
+(624,422,cs),
+(624,344,o),
+(596,67,o),
+(466,67,cs),
+(417,67,o),
+(389,98,o),
+(389,152,cs),
+(389,218,o),
+(422,306,o),
+(516,306,cs),
+(528,306,o),
+(540,305,o),
+(551,302,c),
+(566,379,l),
+(548,383,o),
+(530,385,o),
+(511,385,cs),
+(362,385,o),
+(305,251,o),
+(305,145,cs),
+(305,48,o),
+(363,-13,o),
+(459,-13,cs)
+);
+}
+);
+width = 760;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "te-canadian";
+note = uni1617;
+unicode = 5655;
+},
+{
+color = 9;
+glyphname = "jeeCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(662,-13,o),
+(716,287,o),
+(716,426,cs),
+(716,601,o),
+(634,702,o),
+(483,702,cs),
+(350,702,o),
+(253,620,o),
+(199,462,c),
+(215,449,l),
+(267,690,l),
+(172,690,l),
+(25,0,l),
+(121,0,l),
+(180,279,ls),
+(227,500,o),
+(324,615,o),
+(463,615,cs),
+(572,615,o),
+(625,550,o),
+(625,422,cs),
+(625,330,o),
+(593,67,o),
+(453,67,cs),
+(396,67,o),
+(364,101,o),
+(364,161,cs),
+(364,221,o),
+(388,302,o),
+(465,318,c),
+(446,232,l),
+(499,232,l),
+(548,457,l),
+(494,457,l),
+(476,375,l),
+(350,355,o),
+(305,238,o),
+(305,144,cs),
+(305,48,o),
+(364,-13,o),
+(459,-13,cs)
+);
+}
+);
+width = 760;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1618;
+unicode = 5656;
+},
+{
+color = 9;
+glyphname = "jiCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(662,-13,o),
+(716,287,o),
+(716,426,cs),
+(716,601,o),
+(634,702,o),
+(483,702,cs),
+(350,702,o),
+(253,620,o),
+(199,462,c),
+(215,449,l),
+(267,690,l),
+(172,690,l),
+(25,0,l),
+(121,0,l),
+(180,279,ls),
+(227,500,o),
+(324,615,o),
+(463,615,cs),
+(572,615,o),
+(625,550,o),
+(625,422,cs),
+(625,330,o),
+(593,67,o),
+(453,67,cs),
+(396,67,o),
+(364,101,o),
+(364,161,cs),
+(364,209,o),
+(380,272,o),
+(430,298,c),
+(440,283,o),
+(457,273,o),
+(477,273,cs),
+(518,273,o),
+(547,306,o),
+(547,346,cs),
+(547,385,o),
+(517,416,o),
+(476,416,cs),
+(437,416,o),
+(407,384,o),
+(407,344,c),
+(331,305,o),
+(305,215,o),
+(305,144,cs),
+(305,48,o),
+(364,-13,o),
+(459,-13,cs)
+);
+}
+);
+width = 760;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1619;
+unicode = 5657;
+},
+{
+color = 9;
+glyphname = "jiSayisi-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(636,-13,o),
+(735,319,o),
+(735,500,cs),
+(735,631,o),
+(680,702,o),
+(576,702,cs),
+(432,702,o),
+(372,556,o),
+(372,454,cs),
+(372,361,o),
+(424,304,o),
+(504,304,cs),
+(523,304,o),
+(541,307,o),
+(552,312,c),
+(568,388,l),
+(558,384,o),
+(547,384,o),
+(534,384,cs),
+(483,384,o),
+(456,410,o),
+(456,463,cs),
+(456,511,o),
+(481,623,o),
+(568,623,cs),
+(620,623,o),
+(645,585,o),
+(645,507,cs),
+(645,382,o),
+(583,74,o),
+(369,74,cs),
+(185,74,o),
+(176,259,o),
+(211,422,cs),
+(268,690,l),
+(172,690,l),
+(25,0,l),
+(120,0,l),
+(183,298,l),
+(165,306,l),
+(134,142,o),
+(190,-13,o),
+(373,-13,cs)
+);
+}
+);
+width = 762;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161A;
+unicode = 5658;
+},
+{
+color = 9;
+glyphname = "jaCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (469,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(456,-13,o),
+(553,70,o),
+(607,227,c),
+(590,241,l),
+(539,0,l),
+(635,0,l),
+(781,690,l),
+(685,690,l),
+(625,409,ls),
+(579,189,o),
+(482,74,o),
+(343,74,cs),
+(235,74,o),
+(182,140,o),
+(182,268,cs),
+(182,347,o),
+(210,624,o),
+(340,624,cs),
+(388,624,o),
+(416,592,o),
+(416,539,cs),
+(416,471,o),
+(384,384,o),
+(291,384,cs),
+(277,384,o),
+(266,385,o),
+(255,388,c),
+(240,312,l),
+(258,307,o),
+(275,305,o),
+(295,305,cs),
+(443,305,o),
+(500,439,o),
+(500,545,cs),
+(500,642,o),
+(443,703,o),
+(347,703,cs),
+(144,703,o),
+(89,403,o),
+(89,263,cs),
+(89,90,o),
+(172,-13,o),
+(323,-13,cs)
+);
+}
+);
+width = 762;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni161B;
+unicode = 5659;
+},
+{
+color = 9;
+glyphname = "jjuCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(526,-13,o),
+(640,99,o),
+(640,249,cs),
+(640,344,o),
+(582,408,o),
+(487,408,cs),
+(392,408,o),
+(326,346,o),
+(302,237,cs),
+(296,210,o),
+(293,183,o),
+(293,158,c),
+(371,158,l),
+(371,177,o),
+(374,199,o),
+(379,224,cs),
+(394,293,o),
+(428,330,o),
+(480,330,cs),
+(527,330,o),
+(555,298,o),
+(555,245,cs),
+(555,147,o),
+(484,69,o),
+(364,69,cs),
+(241,69,o),
+(173,137,o),
+(173,255,cs),
+(173,442,o),
+(289,603,o),
+(554,603,cs),
+(704,603,l),
+(723,690,l),
+(568,690,ls),
+(438,690,o),
+(333,658,o),
+(256,606,c),
+(181,702,l),
+(102,641,l),
+(181,543,l),
+(107,464,o),
+(78,356,o),
+(78,259,cs),
+(78,96,o),
+(185,-13,o),
+(356,-13,cs)
+);
+}
+);
+width = 706;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni161C;
+unicode = 5660;
+},
+{
+color = 9;
+glyphname = "jjoCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(648,48,l),
+(570,147,l),
+(643,226,o),
+(672,333,o),
+(672,431,cs),
+(672,594,o),
+(566,702,o),
+(394,702,cs),
+(224,702,o),
+(111,590,o),
+(111,440,cs),
+(111,346,o),
+(170,282,o),
+(264,282,cs),
+(359,282,o),
+(425,344,o),
+(449,453,cs),
+(455,480,o),
+(458,507,o),
+(458,531,c),
+(381,531,l),
+(380,513,o),
+(377,491,o),
+(372,466,cs),
+(356,397,o),
+(323,359,o),
+(270,359,cs),
+(223,359,o),
+(195,392,o),
+(195,444,cs),
+(195,543,o),
+(267,621,o),
+(386,621,cs),
+(511,621,o),
+(578,553,o),
+(578,435,cs),
+(578,247,o),
+(462,87,o),
+(196,87,cs),
+(46,87,l),
+(28,0,l),
+(183,0,ls),
+(314,0,o),
+(417,32,o),
+(495,84,c),
+(571,-13,l)
+);
+}
+);
+width = 706;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|jjuCarrier-canadian";
+note = uni161D;
+unicode = 5661;
+},
+{
+color = 9;
+glyphname = "jjeCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(670,-13,o),
+(725,289,o),
+(725,427,cs),
+(725,605,o),
+(637,702,o),
+(470,702,cs),
+(386,702,o),
+(312,676,o),
+(252,621,c),
+(186,702,l),
+(111,640,l),
+(187,546,l),
+(151,494,o),
+(123,425,o),
+(104,340,cs),
+(33,0,l),
+(128,0,l),
+(199,329,ls),
+(239,519,o),
+(329,615,o),
+(465,615,cs),
+(578,615,o),
+(632,552,o),
+(632,422,cs),
+(632,344,o),
+(604,67,o),
+(474,67,cs),
+(425,67,o),
+(397,98,o),
+(397,152,cs),
+(397,219,o),
+(430,306,o),
+(523,306,cs),
+(538,306,o),
+(550,305,o),
+(558,302,c),
+(574,379,l),
+(560,383,o),
+(540,385,o),
+(522,385,cs),
+(372,385,o),
+(313,251,o),
+(313,145,cs),
+(313,48,o),
+(370,-13,o),
+(467,-13,cs)
+);
+}
+);
+width = 769;
+}
+);
+metricRight = "jeCarrier-canadian";
+note = uni161E;
+unicode = 5662;
+},
+{
+color = 9;
+glyphname = "jjeeCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(670,-13,o),
+(725,289,o),
+(725,427,cs),
+(725,605,o),
+(637,702,o),
+(470,702,cs),
+(386,702,o),
+(312,676,o),
+(252,621,c),
+(186,702,l),
+(111,640,l),
+(187,546,l),
+(151,494,o),
+(123,425,o),
+(104,340,cs),
+(33,0,l),
+(128,0,l),
+(199,329,ls),
+(239,519,o),
+(329,615,o),
+(465,615,cs),
+(578,615,o),
+(632,552,o),
+(632,422,cs),
+(632,341,o),
+(605,67,o),
+(462,67,cs),
+(406,67,o),
+(372,100,o),
+(372,161,cs),
+(372,226,o),
+(396,301,o),
+(468,318,c),
+(449,232,l),
+(503,232,l),
+(551,456,l),
+(497,456,l),
+(480,374,l),
+(359,355,o),
+(313,241,o),
+(313,145,cs),
+(313,48,o),
+(370,-13,o),
+(467,-13,cs)
+);
+}
+);
+width = 769;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161F;
+unicode = 5663;
+},
+{
+color = 9;
+glyphname = "jjiCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(622,-13,o),
+(689,175,o),
+(714,334,cs),
+(748,564,o),
+(661,702,o),
+(469,702,cs),
+(383,702,o),
+(309,675,o),
+(251,622,c),
+(186,702,l),
+(111,640,l),
+(186,548,l),
+(150,494,o),
+(123,424,o),
+(104,340,cs),
+(32,0,l),
+(128,0,l),
+(198,329,ls),
+(239,519,o),
+(329,615,o),
+(465,615,cs),
+(595,615,o),
+(648,524,o),
+(623,342,cs),
+(606,228,o),
+(573,67,o),
+(461,67,cs),
+(396,67,o),
+(365,112,o),
+(375,188,cs),
+(379,236,o),
+(395,282,o),
+(440,300,c),
+(449,284,o),
+(469,273,o),
+(491,273,cs),
+(531,273,o),
+(560,306,o),
+(560,346,cs),
+(560,385,o),
+(530,416,o),
+(491,416,cs),
+(449,416,o),
+(422,384,o),
+(420,349,c),
+(355,320,o),
+(326,253,o),
+(318,184,cs),
+(300,65,o),
+(360,-13,o),
+(467,-13,cs)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1620;
+unicode = 5664;
+},
+{
+color = 9;
+glyphname = "jjaCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(427,-13,o),
+(501,14,o),
+(561,69,c),
+(627,-13,l),
+(702,49,l),
+(626,144,l),
+(663,197,o),
+(691,265,o),
+(708,350,cs),
+(781,690,l),
+(685,690,l),
+(614,360,ls),
+(574,171,o),
+(483,74,o),
+(349,74,cs),
+(236,74,o),
+(182,138,o),
+(182,268,cs),
+(182,346,o),
+(209,623,o),
+(339,623,cs),
+(388,623,o),
+(416,592,o),
+(416,538,cs),
+(416,470,o),
+(384,384,o),
+(291,384,cs),
+(274,384,o),
+(264,384,o),
+(255,387,c),
+(240,311,l),
+(253,307,o),
+(272,304,o),
+(292,304,cs),
+(441,304,o),
+(499,439,o),
+(499,545,cs),
+(499,641,o),
+(442,702,o),
+(347,702,cs),
+(143,702,o),
+(89,401,o),
+(89,263,cs),
+(89,85,o),
+(177,-13,o),
+(343,-13,cs)
+);
+}
+);
+width = 768;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "=|jjeCarrier-canadian";
+note = uni1621;
+unicode = 5665;
+},
+{
+color = 9;
+glyphname = "luCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(506,-13,o),
+(612,83,o),
+(653,270,cs),
+(742,690,l),
+(645,690,l),
+(559,282,ls),
+(529,143,o),
+(459,74,o),
+(344,74,cs),
+(233,74,o),
+(172,138,o),
+(172,248,cs),
+(172,406,o),
+(273,601,o),
+(466,612,c),
+(482,690,l),
+(156,690,l),
+(140,610,l),
+(339,610,l),
+(411,637,l),
+(202,619,o),
+(76,427,o),
+(76,241,cs),
+(76,87,o),
+(176,-13,o),
+(341,-13,cs)
+);
+}
+);
+width = 715;
+}
+);
+metricRight = "te-canadian";
+note = uni1622;
+unicode = 5666;
+},
+{
+color = 9;
+glyphname = "loCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(114,0,l),
+(200,408,ls),
+(230,547,o),
+(300,615,o),
+(415,615,cs),
+(526,615,o),
+(586,552,o),
+(586,441,cs),
+(586,284,o),
+(485,89,o),
+(294,77,c),
+(277,0,l),
+(602,0,l),
+(619,80,l),
+(420,80,l),
+(349,53,l),
+(557,71,o),
+(683,263,o),
+(683,449,cs),
+(683,603,o),
+(583,702,o),
+(418,702,cs),
+(252,702,o),
+(147,607,o),
+(106,419,cs),
+(17,0,l)
+);
+}
+);
+width = 713;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|luCarrier-canadian";
+note = uni1623;
+unicode = 5667;
+},
+{
+color = 9;
+glyphname = "leCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (368,348);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(254,0,ls),
+(572,0,o),
+(662,248,o),
+(662,435,cs),
+(662,596,o),
+(579,702,o),
+(441,702,cs),
+(336,702,o),
+(251,639,o),
+(209,526,c),
+(219,526,l),
+(254,690,l),
+(167,690,l),
+(102,382,l),
+(184,382,l),
+(222,531,o),
+(303,615,o),
+(412,615,cs),
+(511,615,o),
+(567,544,o),
+(567,427,cs),
+(567,273,o),
+(487,87,o),
+(264,87,cs),
+(39,87,l),
+(20,0,l)
+);
+}
+);
+width = 694;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1624;
+unicode = 5668;
+},
+{
+color = 9;
+glyphname = "leeCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "leCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (297,3);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 694;
+}
+);
+metricLeft = "leCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1625;
+unicode = 5669;
+},
+{
+color = 9;
+glyphname = "liCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "leCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (272,3);
+ref = dot_middle;
+}
+);
+width = 695;
+}
+);
+note = uni1626;
+unicode = 5670;
+},
+{
+color = 9;
+glyphname = "laCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(573,0,l),
+(591,87,l),
+(385,87,ls),
+(243,87,o),
+(175,152,o),
+(175,275,cs),
+(175,402,o),
+(242,615,o),
+(423,615,cs),
+(539,615,o),
+(597,525,o),
+(573,382,c),
+(654,382,l),
+(720,690,l),
+(633,690,l),
+(595,509,l),
+(605,508,l),
+(603,628,o),
+(531,702,o),
+(414,702,cs),
+(182,702,o),
+(79,443,o),
+(79,270,cs),
+(79,99,o),
+(179,0,o),
+(372,0,cs)
+);
+}
+);
+width = 695;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|leCarrier-canadian";
+note = uni1627;
+unicode = 5671;
+},
+{
+color = 1;
+glyphname = "dluCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(583,-13,o),
+(668,235,o),
+(668,390,cs),
+(668,528,o),
+(594,620,o),
+(465,642,c),
+(498,616,l),
+(718,616,l),
+(700,535,l),
+(773,535,l),
+(823,771,l),
+(751,771,l),
+(733,690,l),
+(423,690,l),
+(407,611,l),
+(517,599,o),
+(577,526,o),
+(577,408,cs),
+(577,293,o),
+(522,74,o),
+(328,74,cs),
+(203,74,o),
+(148,156,o),
+(178,299,cs),
+(260,690,l),
+(164,690,l),
+(82,303,ls),
+(41,109,o),
+(135,-13,o),
+(324,-13,cs)
+);
+}
+);
+width = 760;
+}
+);
+metricLeft = "te-canadian";
+note = uni1628;
+unicode = 5672;
+},
+{
+color = 9;
+glyphname = "dloCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(642,-81,l),
+(693,155,l),
+(620,155,l),
+(603,74,l),
+(417,74,l),
+(412,65,l),
+(578,97,o),
+(683,275,o),
+(683,449,cs),
+(683,603,o),
+(583,702,o),
+(418,702,cs),
+(252,702,o),
+(147,607,o),
+(106,419,cs),
+(17,0,l),
+(114,0,l),
+(200,408,ls),
+(230,547,o),
+(300,615,o),
+(415,615,cs),
+(526,615,o),
+(586,552,o),
+(586,441,cs),
+(586,284,o),
+(485,89,o),
+(294,77,c),
+(277,0,l),
+(588,0,l),
+(570,-81,l)
+);
+}
+);
+width = 761;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "dluCarrier-canadian";
+note = uni1629;
+unicode = 5673;
+},
+{
+color = 9;
+glyphname = "dleCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (380,348);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(266,0,ls),
+(584,0,o),
+(674,248,o),
+(674,435,cs),
+(674,596,o),
+(590,702,o),
+(453,702,cs),
+(345,702,o),
+(242,628,o),
+(195,500,c),
+(206,500,l),
+(247,699,l),
+(331,699,l),
+(346,769,l),
+(118,769,l),
+(103,699,l),
+(182,699,l),
+(114,382,l),
+(195,382,l),
+(234,531,o),
+(315,615,o),
+(423,615,cs),
+(523,615,o),
+(579,544,o),
+(579,427,cs),
+(579,273,o),
+(499,87,o),
+(275,87,cs),
+(51,87,l),
+(33,0,l)
+);
+}
+);
+width = 706;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni162A;
+unicode = 5674;
+},
+{
+color = 9;
+glyphname = "dleeCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (308,3);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 707;
+}
+);
+note = uni162B;
+unicode = 5675;
+},
+{
+color = 9;
+glyphname = "dliCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (284,3);
+ref = dot_middle;
+}
+);
+width = 707;
+}
+);
+note = uni162C;
+unicode = 5676;
+},
+{
+color = 9;
+glyphname = "dlaCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(573,0,l),
+(591,87,l),
+(385,87,ls),
+(243,87,o),
+(175,152,o),
+(175,275,cs),
+(175,402,o),
+(242,615,o),
+(423,615,cs),
+(539,615,o),
+(597,525,o),
+(573,382,c),
+(654,382,l),
+(722,699,l),
+(799,699,l),
+(813,769,l),
+(586,769,l),
+(572,699,l),
+(650,699,l),
+(609,507,l),
+(618,505,l),
+(616,628,o),
+(531,702,o),
+(414,702,cs),
+(182,702,o),
+(79,443,o),
+(79,270,cs),
+(79,99,o),
+(179,0,o),
+(372,0,cs)
+);
+}
+);
+width = 706;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni162D;
+unicode = 5677;
+},
+{
+color = 9;
+glyphname = "lhuCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(602,-13,o),
+(703,205,o),
+(703,389,cs),
+(703,517,o),
+(645,610,o),
+(541,639,c),
+(572,608,l),
+(765,608,l),
+(782,690,l),
+(527,690,l),
+(511,612,l),
+(577,582,o),
+(611,510,o),
+(611,416,cs),
+(611,281,o),
+(552,74,o),
+(367,74,cs),
+(250,74,o),
+(183,146,o),
+(183,266,cs),
+(183,384,o),
+(243,570,o),
+(395,612,c),
+(412,690,l),
+(156,690,l),
+(139,608,l),
+(337,608,l),
+(381,643,l),
+(180,611,o),
+(87,418,o),
+(87,256,cs),
+(87,93,o),
+(193,-13,o),
+(366,-13,cs)
+);
+}
+);
+width = 747;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162E;
+unicode = 5678;
+},
+{
+color = 9;
+glyphname = "lhoCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(265,0,l),
+(281,77,l),
+(216,108,o),
+(182,180,o),
+(182,273,cs),
+(182,409,o),
+(241,615,o),
+(425,615,cs),
+(542,615,o),
+(610,544,o),
+(610,424,cs),
+(610,305,o),
+(550,120,o),
+(398,77,c),
+(381,0,l),
+(636,0,l),
+(653,82,l),
+(456,82,l),
+(412,46,l),
+(612,79,o),
+(706,271,o),
+(706,434,cs),
+(706,597,o),
+(600,702,o),
+(427,702,cs),
+(191,702,o),
+(89,485,o),
+(89,300,cs),
+(89,173,o),
+(148,80,o),
+(251,50,c),
+(220,82,l),
+(27,82,l),
+(10,0,l)
+);
+}
+);
+width = 747;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162F;
+unicode = 5679;
+},
+{
+color = 9;
+glyphname = "lheCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (384,345);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(591,-13,o),
+(690,245,o),
+(690,428,cs),
+(690,594,o),
+(600,702,o),
+(454,702,cs),
+(351,702,o),
+(265,646,o),
+(221,547,c),
+(228,546,l),
+(258,690,l),
+(172,690,l),
+(113,415,l),
+(194,415,l),
+(237,545,o),
+(319,615,o),
+(423,615,cs),
+(532,615,o),
+(594,543,o),
+(594,421,cs),
+(594,283,o),
+(523,74,o),
+(346,74,cs),
+(231,74,o),
+(157,156,o),
+(165,274,c),
+(83,274,l),
+(25,0,l),
+(111,0,l),
+(148,173,l),
+(134,170,l),
+(147,60,o),
+(236,-13,o),
+(358,-13,cs)
+);
+}
+);
+width = 723;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1630;
+unicode = 5680;
+},
+{
+color = 9;
+glyphname = "lheeCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (314,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 724;
+}
+);
+note = uni1631;
+unicode = 5681;
+},
+{
+color = 9;
+glyphname = "lhiCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (289,0);
+ref = dot_middle;
+}
+);
+width = 724;
+}
+);
+note = uni1632;
+unicode = 5682;
+},
+{
+color = 9;
+glyphname = "lhaCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(417,-13,o),
+(503,43,o),
+(548,143,c),
+(541,144,l),
+(510,0,l),
+(596,0,l),
+(655,274,l),
+(574,274,l),
+(531,145,o),
+(449,74,o),
+(345,74,cs),
+(236,74,o),
+(174,147,o),
+(174,269,cs),
+(174,407,o),
+(245,615,o),
+(422,615,cs),
+(537,615,o),
+(611,533,o),
+(604,415,c),
+(685,415,l),
+(743,690,l),
+(657,690,l),
+(620,517,l),
+(634,520,l),
+(621,630,o),
+(532,702,o),
+(411,702,cs),
+(178,702,o),
+(78,444,o),
+(78,262,cs),
+(78,96,o),
+(168,-13,o),
+(314,-13,cs)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1633;
+unicode = 5683;
+},
+{
+color = 9;
+glyphname = "tlhuCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(602,-13,o),
+(703,205,o),
+(703,389,cs),
+(703,512,o),
+(657,607,o),
+(554,639,c),
+(555,615,l),
+(752,615,l),
+(734,535,l),
+(807,535,l),
+(856,771,l),
+(784,771,l),
+(767,690,l),
+(527,690,l),
+(511,612,l),
+(577,582,o),
+(611,510,o),
+(611,416,cs),
+(611,281,o),
+(552,74,o),
+(367,74,cs),
+(250,74,o),
+(183,146,o),
+(183,266,cs),
+(183,384,o),
+(243,570,o),
+(395,612,c),
+(412,690,l),
+(156,690,l),
+(139,608,l),
+(337,608,l),
+(369,639,l),
+(159,600,o),
+(87,399,o),
+(87,256,cs),
+(87,93,o),
+(193,-13,o),
+(366,-13,cs)
+);
+}
+);
+width = 785;
+}
+);
+metricLeft = "lhuCarrier-canadian";
+note = uni1634;
+unicode = 5684;
+},
+{
+color = 9;
+glyphname = "tlhoCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(45,-81,l),
+(63,0,l),
+(302,0,l),
+(319,77,l),
+(253,108,o),
+(218,180,o),
+(218,273,cs),
+(218,409,o),
+(278,615,o),
+(463,615,cs),
+(580,615,o),
+(647,544,o),
+(647,424,cs),
+(647,305,o),
+(586,120,o),
+(435,77,c),
+(418,0,l),
+(673,0,l),
+(691,82,l),
+(493,82,l),
+(461,50,l),
+(670,90,o),
+(743,291,o),
+(743,434,cs),
+(743,597,o),
+(637,702,o),
+(464,702,cs),
+(228,702,o),
+(127,485,o),
+(127,300,cs),
+(127,178,o),
+(173,83,o),
+(275,50,c),
+(274,74,l),
+(78,74,l),
+(96,155,l),
+(23,155,l),
+(-26,-81,l)
+);
+}
+);
+width = 784;
+}
+);
+metricLeft = "=|tlhuCarrier-canadian";
+metricRight = "lhuCarrier-canadian";
+note = uni1635;
+unicode = 5685;
+},
+{
+color = 9;
+glyphname = "tlheCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (392,345);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(598,-13,o),
+(697,245,o),
+(697,428,cs),
+(697,594,o),
+(608,702,o),
+(462,702,cs),
+(346,702,o),
+(250,633,o),
+(200,514,c),
+(218,527,l),
+(254,699,l),
+(332,699,l),
+(347,769,l),
+(118,769,l),
+(103,699,l),
+(182,699,l),
+(121,415,l),
+(202,415,l),
+(244,545,o),
+(327,615,o),
+(431,615,cs),
+(540,615,o),
+(602,543,o),
+(602,421,cs),
+(602,283,o),
+(530,74,o),
+(353,74,cs),
+(239,74,o),
+(164,156,o),
+(172,274,c),
+(91,274,l),
+(33,0,l),
+(119,0,l),
+(156,173,l),
+(142,170,l),
+(155,60,o),
+(243,-13,o),
+(366,-13,cs)
+);
+}
+);
+width = 730;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1636;
+unicode = 5686;
+},
+{
+color = 9;
+glyphname = "tlheeCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (321,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 731;
+}
+);
+note = uni1637;
+unicode = 5687;
+},
+{
+color = 9;
+glyphname = "tlhiCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (297,0);
+ref = dot_middle;
+}
+);
+width = 731;
+}
+);
+note = uni1638;
+unicode = 5688;
+},
+{
+color = 9;
+glyphname = "tlhaCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(417,-13,o),
+(503,43,o),
+(548,143,c),
+(541,144,l),
+(510,0,l),
+(597,0,l),
+(655,274,l),
+(574,274,l),
+(531,145,o),
+(449,74,o),
+(345,74,cs),
+(236,74,o),
+(174,147,o),
+(174,269,cs),
+(174,407,o),
+(245,615,o),
+(422,615,cs),
+(538,615,o),
+(611,533,o),
+(604,415,c),
+(685,415,l),
+(746,699,l),
+(824,699,l),
+(838,769,l),
+(610,769,l),
+(595,699,l),
+(672,699,l),
+(633,514,l),
+(640,515,l),
+(624,632,o),
+(534,702,o),
+(411,702,cs),
+(178,702,o),
+(78,444,o),
+(78,262,cs),
+(78,96,o),
+(168,-13,o),
+(314,-13,cs)
+);
+}
+);
+width = 731;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni1639;
+unicode = 5689;
+},
+{
+color = 9;
+glyphname = "tluCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(327,-13,o),
+(387,30,o),
+(426,116,c),
+(398,117,l),
+(411,35,o),
+(469,-13,o),
+(558,-13,cs),
+(760,-13,o),
+(816,249,o),
+(816,392,cs),
+(816,514,o),
+(768,596,o),
+(680,629,c),
+(660,616,l),
+(867,616,l),
+(850,535,l),
+(923,535,l),
+(973,771,l),
+(900,771,l),
+(883,690,l),
+(586,690,l),
+(569,611,l),
+(673,599,o),
+(725,533,o),
+(725,413,cs),
+(725,311,o),
+(688,72,o),
+(555,72,cs),
+(486,72,o),
+(455,124,o),
+(474,212,cs),
+(494,302,l),
+(401,302,l),
+(383,213,ls),
+(362,118,o),
+(324,72,o),
+(260,72,cs),
+(199,72,o),
+(168,112,o),
+(168,194,cs),
+(168,310,o),
+(229,607,o),
+(453,611,c),
+(469,690,l),
+(157,690,l),
+(140,608,l),
+(331,608,l),
+(314,622,l),
+(140,560,o),
+(72,337,o),
+(72,189,cs),
+(72,62,o),
+(134,-13,o),
+(244,-13,cs)
+);
+}
+);
+width = 901;
+}
+);
+metricRight = "tlhuCarrier-canadian";
+note = uni163A;
+unicode = 5690;
+},
+{
+color = 1;
+glyphname = "tloCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(790,-81,l),
+(840,155,l),
+(769,155,l),
+(752,74,l),
+(566,74,l),
+(582,62,l),
+(763,120,o),
+(837,347,o),
+(837,500,cs),
+(837,628,o),
+(774,702,o),
+(664,702,cs),
+(581,702,o),
+(521,659,o),
+(482,572,c),
+(510,571,l),
+(497,654,o),
+(439,702,o),
+(350,702,cs),
+(148,702,o),
+(92,440,o),
+(92,298,cs),
+(92,182,o),
+(137,101,o),
+(217,67,c),
+(240,81,l),
+(27,81,l),
+(10,0,l),
+(323,0,l),
+(339,78,l),
+(235,91,o),
+(184,156,o),
+(184,276,cs),
+(184,379,o),
+(220,617,o),
+(353,617,cs),
+(422,617,o),
+(453,566,o),
+(434,478,cs),
+(414,387,l),
+(507,387,l),
+(525,476,ls),
+(546,572,o),
+(584,617,o),
+(648,617,cs),
+(709,617,o),
+(740,578,o),
+(740,496,cs),
+(740,380,o),
+(679,83,o),
+(455,78,c),
+(439,0,l),
+(736,0,l),
+(719,-81,l)
+);
+}
+);
+width = 899;
+}
+);
+metricLeft = "tluCarrier-canadian";
+metricRight = "tlhuCarrier-canadian";
+note = uni163B;
+unicode = 5691;
+},
+{
+color = 9;
+glyphname = "tleCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (311,345);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(536,-13,o),
+(649,72,o),
+(649,212,cs),
+(649,286,o),
+(608,343,o),
+(541,355,c),
+(536,333,l),
+(643,346,o),
+(717,428,o),
+(717,529,cs),
+(717,632,o),
+(628,702,o),
+(488,702,cs),
+(363,702,o),
+(265,645,o),
+(211,539,c),
+(216,530,l),
+(252,699,l),
+(331,699,l),
+(346,769,l),
+(118,769,l),
+(103,699,l),
+(181,699,l),
+(120,415,l),
+(201,415,l),
+(238,551,o),
+(323,616,o),
+(458,616,cs),
+(560,616,o),
+(619,577,o),
+(619,511,cs),
+(619,426,o),
+(551,385,o),
+(459,385,cs),
+(416,385,l),
+(399,305,l),
+(440,305,ls),
+(514,305,o),
+(556,273,o),
+(556,216,cs),
+(556,123,o),
+(481,73,o),
+(378,73,cs),
+(236,73,o),
+(156,149,o),
+(171,274,c),
+(90,274,l),
+(32,0,l),
+(119,0,l),
+(156,174,l),
+(140,164,l),
+(151,56,o),
+(247,-13,o),
+(387,-13,cs)
+);
+}
+);
+width = 731;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni163C;
+unicode = 5692;
+},
+{
+color = 9;
+glyphname = "tleeCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (241,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 731;
+}
+);
+note = uni163D;
+unicode = 5693;
+},
+{
+color = 9;
+glyphname = "tliCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (225,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 731;
+}
+);
+note = uni163E;
+unicode = 5694;
+},
+{
+color = 9;
+glyphname = "tlaCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(404,-13,o),
+(497,36,o),
+(553,127,c),
+(543,147,l),
+(511,0,l),
+(598,0,l),
+(657,274,l),
+(576,274,l),
+(539,139,o),
+(454,73,o),
+(319,73,cs),
+(216,73,o),
+(157,113,o),
+(157,179,cs),
+(157,264,o),
+(226,304,o),
+(318,304,cs),
+(360,304,l),
+(378,384,l),
+(336,384,ls),
+(262,384,o),
+(220,416,o),
+(220,473,cs),
+(220,567,o),
+(295,616,o),
+(399,616,cs),
+(541,616,o),
+(620,541,o),
+(606,415,c),
+(687,415,l),
+(747,699,l),
+(824,699,l),
+(839,769,l),
+(611,769,l),
+(596,699,l),
+(674,699,l),
+(632,497,l),
+(645,511,l),
+(634,629,o),
+(534,702,o),
+(389,702,cs),
+(240,702,o),
+(128,617,o),
+(128,478,cs),
+(128,406,o),
+(168,350,o),
+(231,335,c),
+(236,355,l),
+(131,341,o),
+(59,261,o),
+(59,160,cs),
+(59,58,o),
+(149,-13,o),
+(288,-13,cs)
+);
+}
+);
+width = 731;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni163F;
+unicode = 5695;
+},
+{
+color = 9;
+glyphname = "zuCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(548,-13,o),
+(681,104,o),
+(681,294,cs),
+(681,380,o),
+(648,457,o),
+(648,520,cs),
+(648,574,o),
+(676,607,o),
+(734,607,cs),
+(764,607,l),
+(781,690,l),
+(734,690,ls),
+(620,690,o),
+(557,634,o),
+(557,524,cs),
+(557,453,o),
+(588,381,o),
+(588,299,cs),
+(588,163,o),
+(500,74,o),
+(355,74,cs),
+(238,74,o),
+(165,129,o),
+(165,215,cs),
+(165,351,o),
+(322,463,o),
+(322,584,cs),
+(322,648,o),
+(275,690,o),
+(199,690,cs),
+(155,690,l),
+(137,607,l),
+(172,607,ls),
+(211,607,o),
+(228,593,o),
+(228,566,cs),
+(228,484,o),
+(71,367,o),
+(71,203,cs),
+(71,74,o),
+(178,-13,o),
+(347,-13,cs)
+);
+}
+);
+width = 745;
+}
+);
+metricRight = "=|";
+note = uni1640;
+unicode = 5696;
+},
+{
+color = 9;
+glyphname = "zoCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(56,0,ls),
+(170,0,o),
+(233,56,o),
+(233,166,cs),
+(233,237,o),
+(202,309,o),
+(202,390,cs),
+(202,526,o),
+(290,615,o),
+(435,615,cs),
+(553,615,o),
+(625,560,o),
+(625,474,cs),
+(625,339,o),
+(469,227,o),
+(469,105,cs),
+(469,42,o),
+(515,0,o),
+(590,0,cs),
+(636,0,l),
+(653,83,l),
+(618,83,ls),
+(580,83,o),
+(562,97,o),
+(562,124,cs),
+(562,206,o),
+(720,323,o),
+(720,487,cs),
+(720,615,o),
+(612,702,o),
+(443,702,cs),
+(242,702,o),
+(109,585,o),
+(109,396,cs),
+(109,310,o),
+(142,233,o),
+(142,170,cs),
+(142,116,o),
+(113,83,o),
+(56,83,cs),
+(26,83,l),
+(9,0,l)
+);
+}
+);
+width = 746;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1641;
+unicode = 5697;
+},
+{
+color = 9;
+glyphname = "zeCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (388,345);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(582,-13,o),
+(677,315,o),
+(677,489,cs),
+(677,624,o),
+(619,702,o),
+(516,702,cs),
+(403,702,o),
+(303,605,o),
+(254,605,cs),
+(229,605,o),
+(220,625,o),
+(229,664,cs),
+(235,690,l),
+(148,690,l),
+(138,644,ls),
+(122,567,o),
+(152,520,o),
+(218,520,cs),
+(309,520,o),
+(401,615,o),
+(486,615,cs),
+(548,615,o),
+(580,566,o),
+(580,475,cs),
+(580,350,o),
+(513,74,o),
+(364,74,cs),
+(277,74,o),
+(227,170,o),
+(139,170,cs),
+(75,170,o),
+(27,125,o),
+(11,45,cs),
+(1,0,l),
+(88,0,l),
+(93,26,ls),
+(101,64,o),
+(121,85,o),
+(146,85,cs),
+(198,85,o),
+(261,-13,o),
+(373,-13,cs)
+);
+}
+);
+width = 699;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1642;
+unicode = 5698;
+},
+{
+color = 9;
+glyphname = "zeeCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (317,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 700;
+}
+);
+note = uni1643;
+unicode = 5699;
+},
+{
+color = 9;
+glyphname = "ziCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (293,0);
+ref = dot_middle;
+}
+);
+width = 700;
+}
+);
+note = uni1644;
+unicode = 5700;
+},
+{
+color = 9;
+glyphname = "zaCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(341,-13,o),
+(440,85,o),
+(490,85,cs),
+(515,85,o),
+(524,65,o),
+(515,26,cs),
+(509,0,l),
+(596,0,l),
+(606,45,ls),
+(622,123,o),
+(591,170,o),
+(526,170,cs),
+(434,170,o),
+(342,74,o),
+(258,74,cs),
+(196,74,o),
+(164,124,o),
+(164,214,cs),
+(164,340,o),
+(231,615,o),
+(379,615,cs),
+(467,615,o),
+(517,520,o),
+(604,520,cs),
+(668,520,o),
+(716,565,o),
+(733,644,cs),
+(743,690,l),
+(656,690,l),
+(650,664,ls),
+(641,626,o),
+(623,605,o),
+(598,605,cs),
+(545,605,o),
+(483,702,o),
+(371,702,cs),
+(161,702,o),
+(67,375,o),
+(67,201,cs),
+(67,66,o),
+(124,-13,o),
+(228,-13,cs)
+);
+}
+);
+width = 699;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|zeCarrier-canadian";
+note = uni1645;
+unicode = 5701;
+},
+{
+color = 6;
+glyphname = "zCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(351,183,l),
+(364,242,l),
+(137,242,l),
+(134,207,l),
+(413,493,l),
+(421,527,l),
+(126,527,l),
+(112,468,l),
+(336,468,l),
+(339,503,l),
+(60,217,l),
+(52,183,l)
+);
+}
+);
+width = 426;
+}
+);
+metricRight = "=|";
+note = uni1646;
+unicode = 5702;
+},
+{
+color = 6;
+glyphname = "initialzCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(214,96,l),
+(233,183,l),
+(351,183,l),
+(364,242,l),
+(125,242,l),
+(138,211,l),
+(413,493,l),
+(421,527,l),
+(306,527,l),
+(325,614,l),
+(259,614,l),
+(241,527,l),
+(126,527,l),
+(112,468,l),
+(348,468,l),
+(334,498,l),
+(60,217,l),
+(52,183,l),
+(167,183,l),
+(149,96,l)
+);
+}
+);
+width = 426;
+}
+);
+metricLeft = "zCarrier-canadian";
+metricRight = "zCarrier-canadian";
+note = uni1647;
+unicode = 5703;
+},
+{
+color = 9;
+glyphname = "dzuCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(548,-13,o),
+(681,104,o),
+(681,294,cs),
+(681,380,o),
+(648,457,o),
+(648,520,cs),
+(648,574,o),
+(676,607,o),
+(734,607,cs),
+(764,607,l),
+(781,690,l),
+(734,690,ls),
+(624,690,o),
+(560,634,o),
+(558,524,cs),
+(558,453,o),
+(589,378,o),
+(588,299,cs),
+(587,163,o),
+(500,74,o),
+(355,74,cs),
+(238,74,o),
+(165,129,o),
+(165,215,cs),
+(165,351,o),
+(320,463,o),
+(320,584,cs),
+(320,648,o),
+(275,690,o),
+(199,690,cs),
+(155,690,l),
+(137,607,l),
+(172,607,ls),
+(211,607,o),
+(228,593,o),
+(228,566,cs),
+(228,484,o),
+(71,367,o),
+(71,203,cs),
+(71,74,o),
+(178,-13,o),
+(347,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(446,482,l),
+(480,643,l),
+(543,643,l),
+(554,690,l),
+(380,690,l),
+(369,643,l),
+(432,643,l),
+(397,482,l)
+);
+}
+);
+width = 745;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1648;
+unicode = 5704;
+},
+{
+color = 9;
+glyphname = "dzoCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(56,0,ls),
+(166,0,o),
+(230,56,o),
+(232,166,cs),
+(232,237,o),
+(201,312,o),
+(202,390,cs),
+(202,526,o),
+(290,615,o),
+(435,615,cs),
+(553,615,o),
+(625,560,o),
+(625,474,cs),
+(625,339,o),
+(470,227,o),
+(470,105,cs),
+(470,42,o),
+(515,0,o),
+(590,0,cs),
+(636,0,l),
+(653,83,l),
+(618,83,ls),
+(580,83,o),
+(562,97,o),
+(562,124,cs),
+(562,206,o),
+(720,323,o),
+(720,487,cs),
+(720,615,o),
+(612,702,o),
+(443,702,cs),
+(242,702,o),
+(109,585,o),
+(109,396,cs),
+(109,310,o),
+(142,233,o),
+(142,170,cs),
+(142,116,o),
+(113,83,o),
+(56,83,cs),
+(26,83,l),
+(9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(411,0,l),
+(421,46,l),
+(358,46,l),
+(392,208,l),
+(344,208,l),
+(309,46,l),
+(247,46,l),
+(237,0,l)
+);
+}
+);
+width = 746;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1649;
+unicode = 5705;
+},
+{
+color = 9;
+glyphname = "dzeCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (403,345);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(607,-13,o),
+(702,315,o),
+(702,489,cs),
+(702,624,o),
+(644,702,o),
+(540,702,cs),
+(427,702,o),
+(328,605,o),
+(278,605,cs),
+(253,605,o),
+(244,625,o),
+(253,664,cs),
+(259,690,l),
+(173,690,l),
+(163,644,ls),
+(147,567,o),
+(177,520,o),
+(243,520,cs),
+(334,520,o),
+(426,615,o),
+(510,615,cs),
+(572,615,o),
+(605,566,o),
+(605,475,cs),
+(605,350,o),
+(537,74,o),
+(389,74,cs),
+(301,74,o),
+(251,170,o),
+(164,170,cs),
+(100,170,o),
+(52,125,o),
+(36,45,cs),
+(26,0,l),
+(112,0,l),
+(118,26,ls),
+(127,64,o),
+(146,85,o),
+(171,85,cs),
+(223,85,o),
+(285,-13,o),
+(397,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(131,242,l),
+(148,319,l),
+(274,319,l),
+(286,371,l),
+(158,371,l),
+(175,448,l),
+(122,448,l),
+(77,242,l)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164A;
+unicode = 5706;
+},
+{
+color = 9;
+glyphname = "dzeeCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "dzeCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (332,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 724;
+}
+);
+metricLeft = "dzeCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164B;
+unicode = 5707;
+},
+{
+color = 9;
+glyphname = "dziCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "dzeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (306,0);
+ref = dot_middle;
+}
+);
+width = 724;
+}
+);
+note = uni164C;
+unicode = 5708;
+},
+{
+color = 9;
+glyphname = "dzaCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(341,-13,o),
+(440,85,o),
+(491,85,cs),
+(515,85,o),
+(525,65,o),
+(515,26,cs),
+(510,0,l),
+(596,0,l),
+(606,45,ls),
+(622,123,o),
+(592,170,o),
+(526,170,cs),
+(435,170,o),
+(343,74,o),
+(259,74,cs),
+(197,74,o),
+(164,124,o),
+(164,214,cs),
+(164,340,o),
+(231,615,o),
+(380,615,cs),
+(467,615,o),
+(517,520,o),
+(605,520,cs),
+(668,520,o),
+(717,565,o),
+(733,644,cs),
+(743,690,l),
+(657,690,l),
+(651,664,ls),
+(642,626,o),
+(623,605,o),
+(598,605,cs),
+(546,605,o),
+(483,702,o),
+(371,702,cs),
+(161,702,o),
+(67,375,o),
+(67,201,cs),
+(67,66,o),
+(125,-13,o),
+(228,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(647,242,l),
+(692,448,l),
+(638,448,l),
+(621,371,l),
+(494,371,l),
+(483,319,l),
+(610,319,l),
+(593,242,l)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dzeCarrier-canadian";
+note = uni164D;
+unicode = 5709;
+},
+{
+color = 9;
+glyphname = "suCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(319,-13,o),
+(388,38,o),
+(431,141,c),
+(392,141,l),
+(403,42,o),
+(458,-13,o),
+(556,-13,cs),
+(722,-13,o),
+(785,126,o),
+(789,262,cs),
+(791,355,o),
+(763,453,o),
+(765,520,cs),
+(766,574,o),
+(792,607,o),
+(847,607,cs),
+(878,607,l),
+(896,690,l),
+(839,690,ls),
+(725,690,o),
+(677,621,o),
+(673,522,cs),
+(671,446,o),
+(697,345,o),
+(696,260,cs),
+(695,175,o),
+(661,72,o),
+(557,72,cs),
+(464,72,o),
+(457,156,o),
+(470,221,cs),
+(570,690,l),
+(480,690,l),
+(381,221,ls),
+(360,123,o),
+(313,72,o),
+(242,72,cs),
+(183,72,o),
+(150,107,o),
+(150,166,cs),
+(150,307,o),
+(321,465,o),
+(321,587,cs),
+(321,651,o),
+(278,690,o),
+(207,690,cs),
+(155,690,l),
+(137,607,l),
+(165,607,ls),
+(205,607,o),
+(224,593,o),
+(224,563,cs),
+(224,468,o),
+(53,326,o),
+(53,154,cs),
+(53,53,o),
+(117,-13,o),
+(224,-13,cs)
+);
+}
+);
+width = 859;
+}
+);
+metricRight = "=|";
+note = uni164E;
+unicode = 5710;
+},
+{
+color = 9;
+glyphname = "soCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(65,0,ls),
+(180,0,o),
+(227,69,o),
+(231,168,cs),
+(233,243,o),
+(207,345,o),
+(209,430,cs),
+(209,515,o),
+(243,617,o),
+(347,617,cs),
+(440,617,o),
+(447,534,o),
+(433,469,cs),
+(334,0,l),
+(424,0,l),
+(524,469,ls),
+(544,567,o),
+(591,617,o),
+(662,617,cs),
+(721,617,o),
+(754,582,o),
+(754,524,cs),
+(754,383,o),
+(583,225,o),
+(583,102,cs),
+(583,39,o),
+(626,0,o),
+(697,0,cs),
+(750,0,l),
+(767,83,l),
+(738,83,ls),
+(699,83,o),
+(680,97,o),
+(680,127,cs),
+(680,222,o),
+(851,364,o),
+(851,536,cs),
+(851,637,o),
+(787,702,o),
+(679,702,cs),
+(585,702,o),
+(516,652,o),
+(473,549,c),
+(512,549,l),
+(501,648,o),
+(446,702,o),
+(348,702,cs),
+(183,702,o),
+(119,564,o),
+(115,428,cs),
+(113,335,o),
+(141,237,o),
+(139,170,cs),
+(138,116,o),
+(112,83,o),
+(57,83,cs),
+(26,83,l),
+(8,0,l)
+);
+}
+);
+width = 860;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5711;
+},
+{
+color = 9;
+glyphname = "seCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(564,-13,o),
+(637,101,o),
+(637,205,cs),
+(637,277,o),
+(599,334,o),
+(530,357,c),
+(526,325,l),
+(641,349,o),
+(708,438,o),
+(708,542,cs),
+(708,636,o),
+(644,702,o),
+(551,702,cs),
+(437,702,o),
+(330,605,o),
+(277,605,cs),
+(251,605,o),
+(241,623,o),
+(249,662,cs),
+(255,690,l),
+(168,690,l),
+(159,646,ls),
+(144,572,o),
+(180,523,o),
+(247,523,cs),
+(336,523,o),
+(432,616,o),
+(522,616,cs),
+(577,616,o),
+(611,582,o),
+(611,527,cs),
+(611,447,o),
+(556,384,o),
+(458,384,cs),
+(103,384,l),
+(87,306,l),
+(443,306,ls),
+(508,306,o),
+(544,270,o),
+(544,213,cs),
+(544,149,o),
+(505,73,o),
+(424,73,cs),
+(334,73,o),
+(261,167,o),
+(161,167,cs),
+(93,167,o),
+(48,127,o),
+(31,43,cs),
+(22,0,l),
+(109,0,l),
+(114,26,ls),
+(124,66,o),
+(141,85,o),
+(169,85,cs),
+(236,85,o),
+(317,-13,o),
+(434,-13,cs)
+);
+}
+);
+width = 720;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni1650;
+unicode = 5712;
+},
+{
+color = 9;
+glyphname = "seeCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(564,-13,o),
+(637,101,o),
+(637,205,cs),
+(637,275,o),
+(601,331,o),
+(536,355,c),
+(531,328,l),
+(644,353,o),
+(708,440,o),
+(708,542,cs),
+(708,636,o),
+(644,702,o),
+(551,702,cs),
+(437,702,o),
+(330,605,o),
+(277,605,cs),
+(251,605,o),
+(241,623,o),
+(249,662,cs),
+(255,690,l),
+(168,690,l),
+(159,646,ls),
+(144,572,o),
+(180,523,o),
+(247,523,cs),
+(336,523,o),
+(432,616,o),
+(522,616,cs),
+(577,616,o),
+(611,582,o),
+(611,527,cs),
+(611,447,o),
+(556,384,o),
+(458,384,cs),
+(392,384,l),
+(407,341,l),
+(432,462,l),
+(374,462,l),
+(357,384,l),
+(103,384,l),
+(87,306,l),
+(340,306,l),
+(323,220,l),
+(381,220,l),
+(407,349,l),
+(376,306,l),
+(447,306,ls),
+(507,308,o),
+(544,270,o),
+(544,213,cs),
+(544,149,o),
+(505,73,o),
+(424,73,cs),
+(334,73,o),
+(261,167,o),
+(161,167,cs),
+(93,167,o),
+(48,127,o),
+(31,43,cs),
+(22,0,l),
+(109,0,l),
+(114,26,ls),
+(124,66,o),
+(141,85,o),
+(169,85,cs),
+(236,85,o),
+(317,-13,o),
+(434,-13,cs)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1651;
+unicode = 5713;
+},
+{
+color = 9;
+glyphname = "siCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(564,-13,o),
+(637,101,o),
+(637,205,cs),
+(637,275,o),
+(601,331,o),
+(536,355,c),
+(531,328,l),
+(644,353,o),
+(708,440,o),
+(708,542,cs),
+(708,636,o),
+(644,702,o),
+(551,702,cs),
+(437,702,o),
+(330,605,o),
+(277,605,cs),
+(251,605,o),
+(241,623,o),
+(249,662,cs),
+(255,690,l),
+(168,690,l),
+(159,646,ls),
+(144,572,o),
+(180,523,o),
+(247,523,cs),
+(336,523,o),
+(432,618,o),
+(522,618,cs),
+(577,618,o),
+(614,582,o),
+(614,527,cs),
+(614,447,o),
+(559,382,o),
+(461,382,cs),
+(395,382,l),
+(432,353,l),
+(429,395,o),
+(397,425,o),
+(355,425,cs),
+(326,425,o),
+(300,408,o),
+(289,384,c),
+(103,384,l),
+(87,306,l),
+(290,306,l),
+(301,283,o),
+(327,266,o),
+(355,266,cs),
+(395,266,o),
+(428,297,o),
+(431,336,c),
+(394,308,l),
+(448,308,ls),
+(513,308,o),
+(547,270,o),
+(547,213,cs),
+(547,149,o),
+(505,71,o),
+(424,71,cs),
+(334,71,o),
+(261,167,o),
+(161,167,cs),
+(93,167,o),
+(48,127,o),
+(31,43,cs),
+(22,0,l),
+(109,0,l),
+(114,26,ls),
+(124,66,o),
+(141,85,o),
+(169,85,cs),
+(236,85,o),
+(317,-13,o),
+(434,-13,cs)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1652;
+unicode = 5714;
+},
+{
+color = 9;
+glyphname = "saCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(328,-13,o),
+(435,85,o),
+(488,85,cs),
+(515,85,o),
+(526,67,o),
+(517,28,cs),
+(510,0,l),
+(597,0,l),
+(606,43,ls),
+(621,118,o),
+(586,167,o),
+(519,167,cs),
+(429,167,o),
+(334,73,o),
+(243,73,cs),
+(188,73,o),
+(154,108,o),
+(154,162,cs),
+(154,242,o),
+(209,305,o),
+(307,305,cs),
+(662,305,l),
+(678,384,l),
+(323,384,ls),
+(257,384,o),
+(221,420,o),
+(221,477,cs),
+(221,541,o),
+(260,616,o),
+(341,616,cs),
+(432,616,o),
+(504,523,o),
+(604,523,cs),
+(672,523,o),
+(717,563,o),
+(734,646,cs),
+(743,690,l),
+(657,690,l),
+(651,664,ls),
+(641,624,o),
+(624,605,o),
+(596,605,cs),
+(529,605,o),
+(448,702,o),
+(331,702,cs),
+(201,702,o),
+(129,588,o),
+(129,485,cs),
+(129,412,o),
+(167,355,o),
+(235,332,c),
+(241,365,l),
+(125,341,o),
+(57,252,o),
+(57,148,cs),
+(57,54,o),
+(121,-13,o),
+(215,-13,cs)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1653;
+unicode = 5715;
+},
+{
+color = 9;
+glyphname = "shuCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(313,-13,o),
+(380,33,o),
+(424,126,c),
+(395,128,l),
+(408,37,o),
+(463,-13,o),
+(556,-13,cs),
+(722,-13,o),
+(785,126,o),
+(789,262,cs),
+(791,355,o),
+(763,453,o),
+(765,520,cs),
+(766,574,o),
+(792,607,o),
+(847,607,cs),
+(878,607,l),
+(896,690,l),
+(839,690,ls),
+(729,690,o),
+(680,627,o),
+(674,532,cs),
+(673,523,o),
+(673,512,o),
+(674,500,c),
+(699,561,l),
+(544,561,l),
+(570,690,l),
+(480,690,l),
+(453,561,l),
+(294,561,l),
+(306,519,l),
+(316,543,o),
+(321,565,o),
+(321,587,cs),
+(321,651,o),
+(278,690,o),
+(207,690,cs),
+(155,690,l),
+(137,607,l),
+(165,607,ls),
+(205,607,o),
+(224,593,o),
+(224,563,cs),
+(224,468,o),
+(53,326,o),
+(53,154,cs),
+(53,53,o),
+(117,-13,o),
+(224,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(183,72,o),
+(150,107,o),
+(150,166,cs),
+(150,272,o),
+(245,382,o),
+(293,482,c),
+(437,482,l),
+(381,221,ls),
+(360,123,o),
+(313,72,o),
+(242,72,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(464,72,o),
+(457,156,o),
+(470,221,cs),
+(526,482,l),
+(673,482,l),
+(678,412,o),
+(696,332,o),
+(696,260,cs),
+(695,175,o),
+(661,72,o),
+(557,72,cs)
+);
+}
+);
+width = 859;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1654;
+unicode = 5716;
+},
+{
+color = 9;
+glyphname = "shoCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(65,0,ls),
+(175,0,o),
+(224,63,o),
+(230,157,cs),
+(231,167,o),
+(231,178,o),
+(230,189,c),
+(204,128,l),
+(360,128,l),
+(334,0,l),
+(424,0,l),
+(451,128,l),
+(611,128,l),
+(597,172,l),
+(588,147,o),
+(583,125,o),
+(583,102,cs),
+(583,39,o),
+(626,0,o),
+(697,0,cs),
+(750,0,l),
+(767,83,l),
+(739,83,ls),
+(699,83,o),
+(680,97,o),
+(680,127,cs),
+(680,222,o),
+(851,364,o),
+(851,536,cs),
+(851,637,o),
+(787,702,o),
+(679,702,cs),
+(590,702,o),
+(524,657,o),
+(480,564,c),
+(509,562,l),
+(497,653,o),
+(441,702,o),
+(348,702,cs),
+(183,702,o),
+(119,564,o),
+(115,428,cs),
+(113,335,o),
+(141,237,o),
+(139,170,cs),
+(138,116,o),
+(112,83,o),
+(57,83,cs),
+(26,83,l),
+(8,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(226,277,o),
+(207,357,o),
+(209,430,cs),
+(209,515,o),
+(243,617,o),
+(347,617,cs),
+(440,617,o),
+(447,534,o),
+(433,469,cs),
+(378,208,l),
+(230,208,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(524,469,ls),
+(544,567,o),
+(591,617,o),
+(662,617,cs),
+(721,617,o),
+(754,582,o),
+(754,524,cs),
+(754,417,o),
+(659,308,o),
+(611,208,c),
+(468,208,l)
+);
+}
+);
+width = 860;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1655;
+unicode = 5717;
+},
+{
+color = 9;
+glyphname = "sheCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(564,-13,o),
+(637,101,o),
+(637,205,cs),
+(637,275,o),
+(601,331,o),
+(536,355,c),
+(531,328,l),
+(644,353,o),
+(708,440,o),
+(708,542,cs),
+(708,636,o),
+(644,702,o),
+(551,702,cs),
+(437,702,o),
+(330,605,o),
+(277,605,cs),
+(251,605,o),
+(241,623,o),
+(249,662,cs),
+(255,690,l),
+(168,690,l),
+(159,646,ls),
+(144,572,o),
+(180,524,o),
+(247,524,cs),
+(268,524,o),
+(291,528,o),
+(307,535,c),
+(257,573,l),
+(216,384,l),
+(103,384,l),
+(87,306,l),
+(200,306,l),
+(160,116,l),
+(222,155,l),
+(202,162,o),
+(183,166,o),
+(161,166,cs),
+(93,166,o),
+(48,127,o),
+(31,43,cs),
+(22,0,l),
+(109,0,l),
+(114,26,ls),
+(124,66,o),
+(141,85,o),
+(169,85,cs),
+(236,85,o),
+(317,-13,o),
+(434,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(277,306,l),
+(443,306,ls),
+(508,306,o),
+(544,270,o),
+(544,213,cs),
+(544,149,o),
+(505,73,o),
+(424,73,cs),
+(360,73,o),
+(304,120,o),
+(242,147,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(327,543,l),
+(391,570,o),
+(458,616,o),
+(522,616,cs),
+(577,616,o),
+(611,582,o),
+(611,527,cs),
+(611,447,o),
+(556,384,o),
+(458,384,cs),
+(294,384,l)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1656;
+unicode = 5718;
+},
+{
+color = 9;
+glyphname = "sheeCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(564,-13,o),
+(637,101,o),
+(637,205,cs),
+(637,275,o),
+(601,331,o),
+(536,355,c),
+(531,328,l),
+(644,353,o),
+(708,440,o),
+(708,542,cs),
+(708,636,o),
+(644,702,o),
+(551,702,cs),
+(437,702,o),
+(330,605,o),
+(277,605,cs),
+(251,605,o),
+(241,623,o),
+(249,662,cs),
+(255,690,l),
+(168,690,l),
+(159,646,ls),
+(144,572,o),
+(180,524,o),
+(247,524,cs),
+(263,524,o),
+(278,527,o),
+(295,533,c),
+(257,573,l),
+(215,379,l),
+(102,379,l),
+(88,312,l),
+(201,312,l),
+(160,116,l),
+(214,156,l),
+(197,162,o),
+(180,166,o),
+(161,166,cs),
+(93,166,o),
+(48,127,o),
+(31,43,cs),
+(22,0,l),
+(109,0,l),
+(114,26,ls),
+(124,66,o),
+(141,85,o),
+(169,85,cs),
+(236,85,o),
+(317,-13,o),
+(434,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(358,71,o),
+(301,122,o),
+(236,149,c),
+(270,312,l),
+(380,312,l),
+(360,221,l),
+(410,221,l),
+(436,346,l),
+(417,312,l),
+(446,312,ls),
+(512,312,o),
+(547,270,o),
+(547,213,cs),
+(547,149,o),
+(505,71,o),
+(424,71,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(460,462,l),
+(412,462,l),
+(393,379,l),
+(285,379,l),
+(320,541,l),
+(387,568,o),
+(456,618,o),
+(522,618,cs),
+(577,618,o),
+(614,582,o),
+(614,527,cs),
+(614,447,o),
+(557,379,o),
+(459,379,cs),
+(432,379,l),
+(436,345,l)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1657;
+unicode = 5719;
+},
+{
+color = 9;
+glyphname = "shiCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(159,646,ls),
+(144,572,o),
+(180,524,o),
+(247,524,cs),
+(263,524,o),
+(279,527,o),
+(296,533,c),
+(257,573,l),
+(215,379,l),
+(102,379,l),
+(89,312,l),
+(201,312,l),
+(160,116,l),
+(213,156,l),
+(196,162,o),
+(180,166,o),
+(161,166,cs),
+(93,166,o),
+(48,127,o),
+(31,43,cs),
+(22,0,l),
+(109,0,l),
+(114,26,ls),
+(124,66,o),
+(141,85,o),
+(169,85,cs),
+(236,85,o),
+(317,-13,o),
+(434,-13,cs),
+(564,-13,o),
+(637,101,o),
+(637,205,cs),
+(637,275,o),
+(601,331,o),
+(536,355,c),
+(531,328,l),
+(644,353,o),
+(708,440,o),
+(708,542,cs),
+(708,636,o),
+(644,702,o),
+(551,702,cs),
+(437,702,o),
+(330,605,o),
+(277,605,cs),
+(251,605,o),
+(241,623,o),
+(249,662,cs),
+(255,690,l),
+(168,690,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(270,312,l),
+(343,312,l),
+(354,285,o),
+(380,266,o),
+(412,266,cs),
+(453,266,o),
+(480,299,o),
+(486,336,c),
+(426,312,l),
+(450,312,ls),
+(514,312,o),
+(547,270,o),
+(547,213,cs),
+(547,149,o),
+(505,71,o),
+(424,71,cs),
+(358,71,o),
+(301,122,o),
+(236,149,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(319,541,l),
+(387,568,o),
+(456,618,o),
+(522,618,cs),
+(577,618,o),
+(614,582,o),
+(614,527,cs),
+(614,447,o),
+(559,379,o),
+(463,379,cs),
+(426,379,l),
+(485,354,l),
+(483,391,o),
+(453,425,o),
+(411,425,cs),
+(380,425,o),
+(353,406,o),
+(342,379,c),
+(285,379,l)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1658;
+unicode = 5720;
+},
+{
+color = 9;
+glyphname = "shaCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(328,-13,o),
+(435,85,o),
+(488,85,cs),
+(515,85,o),
+(526,67,o),
+(517,28,cs),
+(510,0,l),
+(597,0,l),
+(606,43,ls),
+(621,118,o),
+(586,166,o),
+(519,166,cs),
+(498,166,o),
+(474,161,o),
+(459,155,c),
+(509,117,l),
+(549,305,l),
+(662,305,l),
+(678,384,l),
+(565,384,l),
+(606,574,l),
+(544,535,l),
+(563,527,o),
+(583,524,o),
+(604,524,cs),
+(672,524,o),
+(717,563,o),
+(734,646,cs),
+(743,690,l),
+(657,690,l),
+(651,664,ls),
+(641,624,o),
+(624,605,o),
+(596,605,cs),
+(529,605,o),
+(448,702,o),
+(331,702,cs),
+(201,702,o),
+(129,588,o),
+(129,485,cs),
+(129,414,o),
+(164,358,o),
+(229,334,c),
+(234,361,l),
+(121,337,o),
+(57,250,o),
+(57,148,cs),
+(57,54,o),
+(121,-13,o),
+(214,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(188,73,o),
+(154,108,o),
+(154,162,cs),
+(154,242,o),
+(209,305,o),
+(307,305,cs),
+(472,305,l),
+(439,147,l),
+(374,120,o),
+(307,73,o),
+(243,73,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(257,384,o),
+(221,420,o),
+(221,477,cs),
+(221,541,o),
+(260,616,o),
+(341,616,cs),
+(406,616,o),
+(461,570,o),
+(523,543,c),
+(489,384,l),
+(323,384,ls)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1659;
+unicode = 5721;
+},
+{
+color = 6;
+glyphname = "shCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(206,96,l),
+(228,199,l),
+(169,183,l),
+(218,183,ls),
+(304,183,o),
+(354,224,o),
+(354,298,cs),
+(354,349,o),
+(320,382,o),
+(258,382,cs),
+(213,382,ls),
+(180,382,o),
+(164,395,o),
+(164,417,cs),
+(164,455,o),
+(188,475,o),
+(233,475,cs),
+(388,475,l),
+(400,527,l),
+(298,527,l),
+(316,614,l),
+(251,614,l),
+(229,509,l),
+(285,527,l),
+(240,527,ls),
+(154,527,o),
+(103,486,o),
+(103,412,cs),
+(103,362,o),
+(138,329,o),
+(200,329,cs),
+(243,329,ls),
+(278,329,o),
+(294,316,o),
+(294,293,cs),
+(294,256,o),
+(270,235,o),
+(225,235,cs),
+(70,235,l),
+(58,183,l),
+(159,183,l),
+(141,96,l)
+);
+}
+);
+width = 408;
+}
+);
+metricRight = "=|";
+note = uni18F5;
+unicode = 5722;
+},
+{
+color = 9;
+glyphname = "tsuCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(313,-13,o),
+(380,33,o),
+(424,126,c),
+(395,128,l),
+(408,37,o),
+(463,-13,o),
+(556,-13,cs),
+(722,-13,o),
+(785,126,o),
+(789,262,cs),
+(791,355,o),
+(763,453,o),
+(765,520,cs),
+(766,574,o),
+(792,607,o),
+(847,607,cs),
+(878,607,l),
+(896,690,l),
+(839,690,ls),
+(725,690,o),
+(677,621,o),
+(674,522,cs),
+(673,482,o),
+(685,435,o),
+(691,384,c),
+(504,384,l),
+(554,621,l),
+(630,621,l),
+(644,690,l),
+(407,690,l),
+(391,621,l),
+(467,621,l),
+(416,384,l),
+(231,384,l),
+(272,460,o),
+(321,526,o),
+(321,587,cs),
+(321,651,o),
+(278,690,o),
+(207,690,cs),
+(155,690,l),
+(137,607,l),
+(165,607,ls),
+(205,607,o),
+(224,593,o),
+(224,563,cs),
+(224,468,o),
+(53,326,o),
+(53,154,cs),
+(53,53,o),
+(117,-13,o),
+(224,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(183,72,o),
+(150,107,o),
+(150,166,cs),
+(150,212,o),
+(167,259,o),
+(191,305,c),
+(400,305,l),
+(382,221,ls),
+(361,123,o),
+(313,72,o),
+(242,72,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(464,72,o),
+(456,156,o),
+(469,221,cs),
+(487,305,l),
+(695,305,l),
+(696,287,o),
+(696,270,o),
+(696,253,cs),
+(695,174,o),
+(661,72,o),
+(557,72,cs)
+);
+}
+);
+width = 859;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165B;
+unicode = 5723;
+},
+{
+color = 9;
+glyphname = "tsoCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(65,0,ls),
+(180,0,o),
+(227,69,o),
+(230,168,cs),
+(231,208,o),
+(219,255,o),
+(213,305,c),
+(400,305,l),
+(350,69,l),
+(274,69,l),
+(260,0,l),
+(497,0,l),
+(513,69,l),
+(438,69,l),
+(488,305,l),
+(673,305,l),
+(632,230,o),
+(583,163,o),
+(583,102,cs),
+(583,39,o),
+(626,0,o),
+(697,0,cs),
+(750,0,l),
+(767,83,l),
+(739,83,ls),
+(699,83,o),
+(680,97,o),
+(680,127,cs),
+(680,222,o),
+(851,364,o),
+(851,536,cs),
+(851,637,o),
+(787,702,o),
+(679,702,cs),
+(590,702,o),
+(525,657,o),
+(480,564,c),
+(509,562,l),
+(497,653,o),
+(441,702,o),
+(348,702,cs),
+(183,702,o),
+(119,564,o),
+(115,428,cs),
+(113,335,o),
+(141,237,o),
+(139,170,cs),
+(138,116,o),
+(112,83,o),
+(57,83,cs),
+(26,83,l),
+(8,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(208,403,o),
+(208,420,o),
+(209,437,cs),
+(209,516,o),
+(243,617,o),
+(347,617,cs),
+(440,617,o),
+(448,534,o),
+(435,469,cs),
+(416,384,l),
+(210,384,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(523,469,ls),
+(543,567,o),
+(591,617,o),
+(662,617,cs),
+(721,617,o),
+(754,582,o),
+(754,524,cs),
+(754,478,o),
+(737,431,o),
+(713,384,c),
+(504,384,l)
+);
+}
+);
+width = 860;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165C;
+unicode = 5724;
+},
+{
+color = 9;
+glyphname = "tseCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(568,-13,o),
+(640,101,o),
+(640,205,cs),
+(640,275,o),
+(604,331,o),
+(540,355,c),
+(535,328,l),
+(647,353,o),
+(712,440,o),
+(712,542,cs),
+(712,636,o),
+(648,702,o),
+(554,702,cs),
+(440,702,o),
+(334,605,o),
+(281,605,cs),
+(255,605,o),
+(244,623,o),
+(253,662,cs),
+(259,690,l),
+(173,690,l),
+(163,646,ls),
+(148,572,o),
+(184,526,o),
+(249,526,cs),
+(279,526,o),
+(311,536,o),
+(343,552,c),
+(316,584,l),
+(272,379,l),
+(163,379,l),
+(182,465,l),
+(125,465,l),
+(73,224,l),
+(131,224,l),
+(150,311,l),
+(258,311,l),
+(214,107,l),
+(254,140,l),
+(227,154,o),
+(193,164,o),
+(166,164,cs),
+(97,164,o),
+(53,127,o),
+(36,43,cs),
+(26,0,l),
+(113,0,l),
+(119,26,ls),
+(128,66,o),
+(145,85,o),
+(174,85,cs),
+(241,85,o),
+(321,-13,o),
+(438,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(378,73,o),
+(333,101,o),
+(288,126,c),
+(327,311,l),
+(447,311,ls),
+(513,311,o),
+(549,271,o),
+(549,213,cs),
+(549,149,o),
+(509,73,o),
+(428,73,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(382,567,l),
+(429,591,o),
+(478,616,o),
+(526,616,cs),
+(581,616,o),
+(615,582,o),
+(615,527,cs),
+(615,447,o),
+(560,379,o),
+(462,379,cs),
+(342,379,l)
+);
+}
+);
+width = 724;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni165D;
+unicode = 5725;
+},
+{
+color = 9;
+glyphname = "tseeCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(568,-13,o),
+(640,101,o),
+(640,205,cs),
+(640,275,o),
+(604,331,o),
+(540,355,c),
+(535,328,l),
+(647,353,o),
+(712,440,o),
+(712,542,cs),
+(712,636,o),
+(648,702,o),
+(554,702,cs),
+(440,702,o),
+(334,605,o),
+(281,605,cs),
+(255,605,o),
+(244,623,o),
+(253,662,cs),
+(259,690,l),
+(173,690,l),
+(163,646,ls),
+(148,572,o),
+(184,526,o),
+(249,526,cs),
+(279,526,o),
+(311,536,o),
+(343,552,c),
+(313,584,l),
+(270,379,l),
+(162,379,l),
+(181,465,l),
+(125,465,l),
+(73,224,l),
+(129,224,l),
+(148,312,l),
+(255,312,l),
+(212,107,l),
+(254,140,l),
+(227,154,o),
+(193,164,o),
+(166,164,cs),
+(97,164,o),
+(53,127,o),
+(36,43,cs),
+(26,0,l),
+(113,0,l),
+(119,26,ls),
+(128,66,o),
+(145,85,o),
+(174,85,cs),
+(241,85,o),
+(321,-13,o),
+(438,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(377,73,o),
+(329,104,o),
+(278,130,c),
+(317,312,l),
+(404,312,l),
+(384,219,l),
+(434,219,l),
+(456,326,l),
+(436,312,l),
+(447,312,ls),
+(513,312,o),
+(549,271,o),
+(549,213,cs),
+(549,147,o),
+(508,73,o),
+(428,73,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(486,464,l),
+(437,464,l),
+(418,379,l),
+(331,379,l),
+(370,562,l),
+(419,586,o),
+(476,616,o),
+(526,616,cs),
+(581,616,o),
+(616,582,o),
+(616,527,cs),
+(616,447,o),
+(560,379,o),
+(462,379,cs),
+(446,379,l),
+(466,368,l)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165E;
+unicode = 5726;
+},
+{
+color = 9;
+glyphname = "tsiCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(568,-13,o),
+(640,102,o),
+(640,206,cs),
+(640,275,o),
+(605,331,o),
+(540,355,c),
+(536,328,l),
+(648,353,o),
+(712,440,o),
+(712,543,cs),
+(712,637,o),
+(648,703,o),
+(554,703,cs),
+(440,703,o),
+(334,606,o),
+(281,606,cs),
+(255,606,o),
+(244,624,o),
+(253,662,cs),
+(259,690,l),
+(173,690,l),
+(163,647,ls),
+(148,573,o),
+(184,526,o),
+(249,526,cs),
+(275,526,o),
+(302,536,o),
+(329,549,c),
+(301,585,l),
+(258,379,l),
+(162,379,l),
+(181,465,l),
+(125,465,l),
+(73,225,l),
+(129,225,l),
+(148,312,l),
+(243,312,l),
+(200,107,l),
+(242,143,l),
+(216,156,o),
+(190,164,o),
+(166,164,cs),
+(97,164,o),
+(53,127,o),
+(36,43,cs),
+(26,0,l),
+(113,0,l),
+(119,26,ls),
+(128,67,o),
+(145,85,o),
+(174,85,cs),
+(241,85,o),
+(322,-13,o),
+(438,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(374,73,o),
+(319,110,o),
+(268,134,c),
+(304,312,l),
+(369,312,l),
+(380,285,o),
+(406,266,o),
+(436,266,cs),
+(473,266,o),
+(497,293,o),
+(505,322,c),
+(429,312,l),
+(447,312,ls),
+(513,312,o),
+(549,272,o),
+(549,213,cs),
+(549,147,o),
+(509,73,o),
+(429,73,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(498,403,o),
+(469,425,o),
+(437,425,cs),
+(407,425,o),
+(380,406,o),
+(370,379,c),
+(319,379,l),
+(357,559,l),
+(407,581,o),
+(473,617,o),
+(526,617,cs),
+(582,617,o),
+(616,582,o),
+(616,528,cs),
+(616,448,o),
+(561,379,o),
+(463,379,cs),
+(439,379,l),
+(508,369,l)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165F;
+unicode = 5727;
+},
+{
+color = 9;
+glyphname = "tsaCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(328,-13,o),
+(435,85,o),
+(488,85,cs),
+(514,85,o),
+(525,67,o),
+(516,28,cs),
+(510,0,l),
+(597,0,l),
+(606,43,ls),
+(621,118,o),
+(585,164,o),
+(520,164,cs),
+(490,164,o),
+(458,154,o),
+(426,139,c),
+(453,105,l),
+(497,311,l),
+(606,311,l),
+(587,225,l),
+(645,225,l),
+(696,466,l),
+(639,466,l),
+(620,379,l),
+(511,379,l),
+(555,582,l),
+(515,550,l),
+(542,537,o),
+(576,526,o),
+(604,526,cs),
+(672,526,o),
+(717,563,o),
+(734,647,cs),
+(743,690,l),
+(656,690,l),
+(651,665,ls),
+(641,624,o),
+(624,606,o),
+(596,606,cs),
+(529,606,o),
+(448,703,o),
+(331,703,cs),
+(201,703,o),
+(129,588,o),
+(129,485,cs),
+(129,415,o),
+(165,359,o),
+(229,335,c),
+(234,362,l),
+(121,338,o),
+(57,250,o),
+(57,148,cs),
+(57,54,o),
+(121,-13,o),
+(215,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(188,73,o),
+(154,108,o),
+(154,162,cs),
+(154,242,o),
+(209,311,o),
+(307,311,cs),
+(427,311,l),
+(387,123,l),
+(340,99,o),
+(291,73,o),
+(243,73,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(256,379,o),
+(220,418,o),
+(220,477,cs),
+(220,542,o),
+(260,617,o),
+(341,617,cs),
+(391,617,o),
+(436,589,o),
+(481,564,c),
+(442,379,l),
+(322,379,ls)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1660;
+unicode = 5728;
+},
+{
+color = 9;
+glyphname = "chuCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(313,-13,o),
+(380,33,o),
+(424,126,c),
+(395,128,l),
+(408,37,o),
+(463,-13,o),
+(556,-13,cs),
+(722,-13,o),
+(785,126,o),
+(789,262,cs),
+(791,355,o),
+(763,453,o),
+(765,520,cs),
+(766,574,o),
+(792,607,o),
+(847,607,cs),
+(878,607,l),
+(896,690,l),
+(839,690,ls),
+(725,690,o),
+(677,621,o),
+(674,522,cs),
+(671,446,o),
+(697,345,o),
+(696,260,cs),
+(695,175,o),
+(661,72,o),
+(557,72,cs),
+(464,72,o),
+(457,156,o),
+(470,221,cs),
+(555,621,l),
+(630,621,l),
+(644,690,l),
+(407,690,l),
+(391,621,l),
+(466,621,l),
+(381,221,ls),
+(360,123,o),
+(313,72,o),
+(242,72,cs),
+(183,72,o),
+(150,107,o),
+(150,166,cs),
+(150,307,o),
+(321,465,o),
+(321,587,cs),
+(321,651,o),
+(278,690,o),
+(207,690,cs),
+(155,690,l),
+(137,607,l),
+(165,607,ls),
+(205,607,o),
+(224,593,o),
+(224,563,cs),
+(224,468,o),
+(53,326,o),
+(53,154,cs),
+(53,53,o),
+(117,-13,o),
+(224,-13,cs)
+);
+}
+);
+width = 859;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164E;
+unicode = 5729;
+},
+{
+color = 9;
+glyphname = "choCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(65,0,ls),
+(180,0,o),
+(227,69,o),
+(230,168,cs),
+(233,243,o),
+(207,345,o),
+(209,430,cs),
+(209,515,o),
+(243,617,o),
+(347,617,cs),
+(440,617,o),
+(447,534,o),
+(433,469,cs),
+(349,69,l),
+(274,69,l),
+(260,0,l),
+(497,0,l),
+(513,69,l),
+(439,69,l),
+(524,469,ls),
+(544,567,o),
+(591,617,o),
+(662,617,cs),
+(721,617,o),
+(754,582,o),
+(754,524,cs),
+(754,383,o),
+(583,225,o),
+(583,102,cs),
+(583,39,o),
+(626,0,o),
+(697,0,cs),
+(750,0,l),
+(767,83,l),
+(739,83,ls),
+(699,83,o),
+(680,97,o),
+(680,127,cs),
+(680,222,o),
+(851,364,o),
+(851,536,cs),
+(851,637,o),
+(787,702,o),
+(679,702,cs),
+(590,702,o),
+(524,657,o),
+(480,564,c),
+(509,562,l),
+(497,653,o),
+(441,702,o),
+(348,702,cs),
+(183,702,o),
+(119,564,o),
+(115,428,cs),
+(113,335,o),
+(141,237,o),
+(139,170,cs),
+(138,116,o),
+(112,83,o),
+(57,83,cs),
+(26,83,l),
+(8,0,l)
+);
+}
+);
+width = 860;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5730;
+},
+{
+color = 9;
+glyphname = "cheCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(568,-13,o),
+(640,101,o),
+(640,205,cs),
+(640,275,o),
+(604,331,o),
+(540,355,c),
+(535,328,l),
+(647,353,o),
+(712,440,o),
+(712,542,cs),
+(712,636,o),
+(648,702,o),
+(554,702,cs),
+(440,702,o),
+(334,605,o),
+(281,605,cs),
+(255,605,o),
+(244,623,o),
+(253,662,cs),
+(259,690,l),
+(173,690,l),
+(163,646,ls),
+(148,572,o),
+(184,526,o),
+(251,526,cs),
+(341,526,o),
+(435,616,o),
+(526,616,cs),
+(581,616,o),
+(615,582,o),
+(615,527,cs),
+(615,447,o),
+(559,384,o),
+(462,384,cs),
+(165,384,l),
+(182,465,l),
+(125,465,l),
+(73,224,l),
+(131,224,l),
+(148,306,l),
+(446,306,ls),
+(512,306,o),
+(548,270,o),
+(548,213,cs),
+(548,149,o),
+(509,73,o),
+(428,73,cs),
+(337,73,o),
+(265,164,o),
+(166,164,cs),
+(97,164,o),
+(51,121,o),
+(36,43,cs),
+(26,0,l),
+(113,0,l),
+(119,26,ls),
+(128,66,o),
+(145,85,o),
+(174,85,cs),
+(241,85,o),
+(321,-13,o),
+(438,-13,cs)
+);
+}
+);
+width = 724;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni1663;
+unicode = 5731;
+},
+{
+color = 9;
+glyphname = "cheeCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(568,-13,o),
+(640,101,o),
+(640,205,cs),
+(640,275,o),
+(604,331,o),
+(540,355,c),
+(535,328,l),
+(647,353,o),
+(712,440,o),
+(712,542,cs),
+(712,636,o),
+(648,702,o),
+(554,702,cs),
+(440,702,o),
+(334,605,o),
+(281,605,cs),
+(255,605,o),
+(244,623,o),
+(253,662,cs),
+(259,690,l),
+(173,690,l),
+(163,646,ls),
+(148,572,o),
+(184,526,o),
+(251,526,cs),
+(341,526,o),
+(435,617,o),
+(526,617,cs),
+(581,617,o),
+(616,582,o),
+(616,527,cs),
+(616,447,o),
+(559,379,o),
+(461,379,cs),
+(399,379,l),
+(420,366,l),
+(440,462,l),
+(383,462,l),
+(364,379,l),
+(163,379,l),
+(182,465,l),
+(125,465,l),
+(73,224,l),
+(131,224,l),
+(150,312,l),
+(351,312,l),
+(331,220,l),
+(388,220,l),
+(412,329,l),
+(385,312,l),
+(449,312,ls),
+(515,312,o),
+(549,270,o),
+(549,213,cs),
+(549,149,o),
+(509,72,o),
+(428,72,cs),
+(337,72,o),
+(265,164,o),
+(166,164,cs),
+(97,164,o),
+(51,121,o),
+(36,43,cs),
+(26,0,l),
+(113,0,l),
+(119,26,ls),
+(128,66,o),
+(145,85,o),
+(174,85,cs),
+(241,85,o),
+(321,-13,o),
+(438,-13,cs)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1664;
+unicode = 5732;
+},
+{
+color = 9;
+glyphname = "chiCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(568,-13,o),
+(640,101,o),
+(640,205,cs),
+(640,275,o),
+(604,331,o),
+(540,355,c),
+(535,328,l),
+(647,353,o),
+(712,440,o),
+(712,542,cs),
+(712,636,o),
+(648,702,o),
+(554,702,cs),
+(440,702,o),
+(334,605,o),
+(281,605,cs),
+(255,605,o),
+(244,623,o),
+(253,662,cs),
+(259,690,l),
+(173,690,l),
+(163,646,ls),
+(148,572,o),
+(184,526,o),
+(251,526,cs),
+(341,526,o),
+(435,617,o),
+(526,617,cs),
+(581,617,o),
+(616,582,o),
+(616,527,cs),
+(616,447,o),
+(559,379,o),
+(463,379,cs),
+(410,379,l),
+(439,360,l),
+(435,397,o),
+(402,425,o),
+(363,425,cs),
+(330,425,o),
+(305,405,o),
+(294,379,c),
+(163,379,l),
+(183,465,l),
+(125,465,l),
+(73,225,l),
+(131,225,l),
+(150,312,l),
+(294,312,l),
+(307,284,o),
+(333,266,o),
+(363,266,cs),
+(403,266,o),
+(431,295,o),
+(439,330,c),
+(399,312,l),
+(451,312,ls),
+(514,312,o),
+(549,270,o),
+(549,213,cs),
+(549,149,o),
+(509,72,o),
+(428,72,cs),
+(338,72,o),
+(265,164,o),
+(166,164,cs),
+(97,164,o),
+(51,121,o),
+(36,43,cs),
+(26,0,l),
+(113,0,l),
+(119,26,ls),
+(128,66,o),
+(145,85,o),
+(174,85,cs),
+(241,85,o),
+(322,-13,o),
+(438,-13,cs)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1665;
+unicode = 5733;
+},
+{
+color = 9;
+glyphname = "chaCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(329,-12,o),
+(435,86,o),
+(488,86,cs),
+(514,86,o),
+(525,68,o),
+(516,29,cs),
+(510,1,l),
+(597,1,l),
+(606,44,ls),
+(621,119,o),
+(585,165,o),
+(518,165,cs),
+(428,165,o),
+(334,74,o),
+(244,74,cs),
+(188,74,o),
+(154,109,o),
+(154,163,cs),
+(154,243,o),
+(210,307,o),
+(308,307,cs),
+(605,307,l),
+(587,226,l),
+(645,226,l),
+(696,467,l),
+(639,467,l),
+(621,385,l),
+(323,385,ls),
+(257,385,o),
+(221,421,o),
+(221,478,cs),
+(221,542,o),
+(261,618,o),
+(342,618,cs),
+(432,618,o),
+(504,526,o),
+(603,526,cs),
+(672,526,o),
+(718,570,o),
+(734,648,cs),
+(743,691,l),
+(656,691,l),
+(650,666,ls),
+(641,625,o),
+(624,606,o),
+(595,606,cs),
+(529,606,o),
+(448,704,o),
+(332,704,cs),
+(201,704,o),
+(128,589,o),
+(128,486,cs),
+(128,415,o),
+(165,359,o),
+(230,335,c),
+(234,363,l),
+(122,338,o),
+(57,251,o),
+(57,149,cs),
+(57,55,o),
+(122,-12,o),
+(215,-12,cs)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1666;
+unicode = 5734;
+},
+{
+color = 9;
+glyphname = "ttsuCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(313,-13,o),
+(380,33,o),
+(424,126,c),
+(395,128,l),
+(408,37,o),
+(463,-13,o),
+(556,-13,cs),
+(722,-13,o),
+(785,126,o),
+(789,262,cs),
+(791,355,o),
+(763,453,o),
+(765,520,cs),
+(766,574,o),
+(792,607,o),
+(847,607,cs),
+(878,607,l),
+(896,690,l),
+(839,690,ls),
+(725,690,o),
+(677,621,o),
+(674,522,cs),
+(673,497,o),
+(675,471,o),
+(675,449,c),
+(713,531,l),
+(511,411,l),
+(555,621,l),
+(630,621,l),
+(644,690,l),
+(407,690,l),
+(391,621,l),
+(466,621,l),
+(421,412,l),
+(257,541,l),
+(277,453,l),
+(301,500,o),
+(321,546,o),
+(321,587,cs),
+(321,651,o),
+(278,690,o),
+(207,690,cs),
+(155,690,l),
+(137,607,l),
+(165,607,ls),
+(205,607,o),
+(224,593,o),
+(224,563,cs),
+(224,468,o),
+(53,326,o),
+(53,154,cs),
+(53,53,o),
+(117,-13,o),
+(224,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(183,72,o),
+(150,107,o),
+(150,166,cs),
+(150,257,o),
+(217,344,o),
+(265,428,c),
+(402,321,l),
+(381,221,ls),
+(360,123,o),
+(313,72,o),
+(242,72,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(464,72,o),
+(457,156,o),
+(470,221,cs),
+(490,312,l),
+(678,421,l),
+(685,369,o),
+(696,314,o),
+(696,260,cs),
+(695,175,o),
+(661,72,o),
+(557,72,cs)
+);
+}
+);
+width = 859;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1667;
+unicode = 5735;
+},
+{
+color = 9;
+glyphname = "ttsoCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(65,0,ls),
+(180,0,o),
+(227,69,o),
+(230,168,cs),
+(231,193,o),
+(229,218,o),
+(229,241,c),
+(191,158,l),
+(393,279,l),
+(349,69,l),
+(274,69,l),
+(260,0,l),
+(497,0,l),
+(513,69,l),
+(439,69,l),
+(483,278,l),
+(647,149,l),
+(627,237,l),
+(603,189,o),
+(583,144,o),
+(583,102,cs),
+(583,39,o),
+(626,0,o),
+(697,0,cs),
+(750,0,l),
+(767,83,l),
+(739,83,ls),
+(699,83,o),
+(680,97,o),
+(680,127,cs),
+(680,222,o),
+(851,364,o),
+(851,536,cs),
+(851,637,o),
+(787,702,o),
+(679,702,cs),
+(590,702,o),
+(525,657,o),
+(480,564,c),
+(509,562,l),
+(497,653,o),
+(441,702,o),
+(348,702,cs),
+(183,702,o),
+(119,564,o),
+(115,428,cs),
+(113,335,o),
+(141,237,o),
+(139,170,cs),
+(138,116,o),
+(112,83,o),
+(57,83,cs),
+(26,83,l),
+(8,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(219,321,o),
+(208,376,o),
+(209,430,cs),
+(209,515,o),
+(243,617,o),
+(347,617,cs),
+(440,617,o),
+(447,534,o),
+(433,469,cs),
+(414,378,l),
+(226,269,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(502,369,l),
+(524,469,ls),
+(544,567,o),
+(591,617,o),
+(662,617,cs),
+(721,617,o),
+(754,582,o),
+(754,524,cs),
+(754,433,o),
+(687,346,o),
+(639,262,c)
+);
+}
+);
+width = 860;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1668;
+unicode = 5736;
+},
+{
+color = 9;
+glyphname = "ttseCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(568,-13,o),
+(640,101,o),
+(640,205,cs),
+(640,275,o),
+(604,331,o),
+(539,355,c),
+(535,328,l),
+(647,353,o),
+(712,440,o),
+(712,542,cs),
+(712,636,o),
+(648,702,o),
+(554,702,cs),
+(440,702,o),
+(334,605,o),
+(281,605,cs),
+(255,605,o),
+(244,623,o),
+(253,662,cs),
+(259,690,l),
+(173,690,l),
+(163,646,ls),
+(148,573,o),
+(183,526,o),
+(251,526,cs),
+(262,526,o),
+(271,526,o),
+(282,528,c),
+(229,571,l),
+(272,379,l),
+(163,379,l),
+(183,465,l),
+(125,465,l),
+(73,224,l),
+(131,224,l),
+(150,312,l),
+(260,312,l),
+(137,125,l),
+(206,160,l),
+(193,163,o),
+(180,164,o),
+(166,164,cs),
+(96,164,o),
+(52,126,o),
+(36,43,cs),
+(26,0,l),
+(113,0,l),
+(119,26,ls),
+(128,66,o),
+(145,85,o),
+(174,85,cs),
+(240,85,o),
+(321,-13,o),
+(438,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(355,71,o),
+(296,130,o),
+(232,152,c),
+(335,312,l),
+(448,312,ls),
+(513,312,o),
+(550,272,o),
+(550,214,cs),
+(550,148,o),
+(508,71,o),
+(427,71,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(308,536,l),
+(376,554,o),
+(450,618,o),
+(525,618,cs),
+(581,618,o),
+(616,582,o),
+(616,527,cs),
+(616,447,o),
+(558,379,o),
+(461,379,cs),
+(343,379,l)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1669;
+unicode = 5737;
+},
+{
+color = 9;
+glyphname = "ttseeCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(568,-13,o),
+(640,101,o),
+(640,205,cs),
+(640,275,o),
+(604,331,o),
+(539,355,c),
+(535,328,l),
+(647,353,o),
+(712,440,o),
+(712,542,cs),
+(712,636,o),
+(648,702,o),
+(554,702,cs),
+(440,702,o),
+(334,605,o),
+(281,605,cs),
+(255,605,o),
+(244,623,o),
+(253,662,cs),
+(259,690,l),
+(173,690,l),
+(163,646,ls),
+(148,573,o),
+(183,526,o),
+(251,526,cs),
+(262,526,o),
+(271,526,o),
+(282,528,c),
+(228,571,l),
+(271,379,l),
+(163,379,l),
+(183,465,l),
+(125,465,l),
+(73,224,l),
+(131,224,l),
+(150,312,l),
+(259,312,l),
+(135,125,l),
+(206,160,l),
+(193,163,o),
+(180,164,o),
+(166,164,cs),
+(96,164,o),
+(52,126,o),
+(36,43,cs),
+(26,0,l),
+(113,0,l),
+(119,26,ls),
+(128,66,o),
+(145,85,o),
+(174,85,cs),
+(240,85,o),
+(321,-13,o),
+(438,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(355,71,o),
+(294,132,o),
+(229,153,c),
+(332,312,l),
+(398,312,l),
+(379,218,l),
+(429,218,l),
+(452,327,l),
+(432,312,l),
+(448,312,ls),
+(513,312,o),
+(550,272,o),
+(550,214,cs),
+(550,148,o),
+(508,71,o),
+(427,71,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(481,464,l),
+(431,464,l),
+(412,379,l),
+(339,379,l),
+(304,534,l),
+(373,553,o),
+(450,618,o),
+(525,618,cs),
+(581,618,o),
+(616,582,o),
+(616,527,cs),
+(616,447,o),
+(558,379,o),
+(461,379,cs),
+(443,379,l),
+(460,367,l)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166A;
+unicode = 5738;
+},
+{
+color = 9;
+glyphname = "ttsiCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(568,-13,o),
+(640,101,o),
+(640,205,cs),
+(640,275,o),
+(604,331,o),
+(539,355,c),
+(535,328,l),
+(647,353,o),
+(712,440,o),
+(712,542,cs),
+(712,636,o),
+(648,702,o),
+(554,702,cs),
+(440,702,o),
+(334,605,o),
+(281,605,cs),
+(255,605,o),
+(244,623,o),
+(253,662,cs),
+(259,690,l),
+(173,690,l),
+(163,646,ls),
+(148,573,o),
+(183,526,o),
+(251,526,cs),
+(262,526,o),
+(271,526,o),
+(282,528,c),
+(228,571,l),
+(271,379,l),
+(163,379,l),
+(183,465,l),
+(125,465,l),
+(73,224,l),
+(131,224,l),
+(150,312,l),
+(260,312,l),
+(137,125,l),
+(206,160,l),
+(193,163,o),
+(180,164,o),
+(166,164,cs),
+(96,164,o),
+(52,126,o),
+(36,43,cs),
+(26,0,l),
+(113,0,l),
+(119,26,ls),
+(128,66,o),
+(145,85,o),
+(174,85,cs),
+(240,85,o),
+(321,-13,o),
+(438,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(355,71,o),
+(288,135,o),
+(224,155,c),
+(326,312,l),
+(355,312,l),
+(366,283,o),
+(394,266,o),
+(421,266,cs),
+(458,266,o),
+(485,295,o),
+(492,327,c),
+(432,312,l),
+(460,312,ls),
+(519,312,o),
+(550,272,o),
+(550,214,cs),
+(550,148,o),
+(508,71,o),
+(427,71,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(482,402,o),
+(455,425,o),
+(420,425,cs),
+(394,425,o),
+(364,408,o),
+(355,379,c),
+(328,379,l),
+(295,531,l),
+(363,548,o),
+(450,618,o),
+(525,618,cs),
+(581,618,o),
+(616,582,o),
+(616,527,cs),
+(616,447,o),
+(565,379,o),
+(468,379,cs),
+(443,379,l),
+(491,367,l)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166B;
+unicode = 5739;
+},
+{
+color = 9;
+glyphname = "ttsaCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(329,-13,o),
+(434,85,o),
+(487,85,cs),
+(514,85,o),
+(525,67,o),
+(516,28,cs),
+(510,0,l),
+(596,0,l),
+(605,43,ls),
+(620,117,o),
+(586,164,o),
+(518,164,cs),
+(507,164,o),
+(498,163,o),
+(487,161,c),
+(540,119,l),
+(497,311,l),
+(605,311,l),
+(586,225,l),
+(644,225,l),
+(695,466,l),
+(638,466,l),
+(618,378,l),
+(509,378,l),
+(632,565,l),
+(563,529,l),
+(576,526,o),
+(589,526,o),
+(603,526,cs),
+(673,526,o),
+(716,564,o),
+(733,646,cs),
+(742,690,l),
+(656,690,l),
+(650,664,ls),
+(641,624,o),
+(624,605,o),
+(595,605,cs),
+(528,605,o),
+(448,702,o),
+(331,702,cs),
+(201,702,o),
+(129,588,o),
+(129,485,cs),
+(129,414,o),
+(165,358,o),
+(230,334,c),
+(234,361,l),
+(121,337,o),
+(57,250,o),
+(57,148,cs),
+(57,54,o),
+(121,-13,o),
+(215,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(188,71,o),
+(153,107,o),
+(153,162,cs),
+(153,242,o),
+(211,311,o),
+(308,311,cs),
+(426,311,l),
+(461,154,l),
+(393,135,o),
+(319,71,o),
+(244,71,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(256,378,o),
+(219,417,o),
+(219,475,cs),
+(219,542,o),
+(261,618,o),
+(342,618,cs),
+(413,618,o),
+(473,559,o),
+(537,538,c),
+(434,378,l),
+(321,378,ls)
+);
+}
+);
+width = 723;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni166C;
+unicode = 5740;
+},
+{
+glyphname = "qai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (329,0);
+ref = "ke-canadian";
+}
+);
+width = 916;
+}
+);
+note = uni166F;
+unicode = 5743;
+},
+{
+glyphname = "ngai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (636,0);
+ref = "ce-canadian";
+}
+);
+width = 1216;
+}
+);
+note = uni1670;
+unicode = 5744;
+},
+{
+glyphname = "nngi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (922,0);
+ref = "ci-canadian";
+}
+);
+width = 1501;
+}
+);
+note = uni1671;
+unicode = 5745;
+},
+{
+glyphname = "nngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (922,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (1146,0);
+ref = dot_top;
+}
+);
+width = 1501;
+}
+);
+note = uni1672;
+unicode = 5746;
+},
+{
+glyphname = "nngo-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (922,0);
+ref = "ce-canadian";
+}
+);
+width = 1501;
+}
+);
+note = uni1673;
+unicode = 5747;
+},
+{
+glyphname = "nngoo-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (922,0);
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (1136,0);
+ref = dot_top;
+}
+);
+width = 1501;
+}
+);
+note = uni1674;
+unicode = 5748;
+},
+{
+glyphname = "nnga-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (922,0);
+ref = "ca-canadian";
+}
+);
+width = 1501;
+}
+);
+note = uni1675;
+unicode = 5749;
+},
+{
+glyphname = "nngaa-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (922,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (964,0);
+ref = dot_top;
+}
+);
+width = 1501;
+}
+);
+note = uni1676;
+unicode = 5750;
+},
+{
+glyphname = "thweeWoodScree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 832;
+}
+);
+note = uni1677;
+unicode = 5751;
+},
+{
+glyphname = "thwiWoodScree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 832;
+}
+);
+note = uni1678;
+unicode = 5752;
+},
+{
+glyphname = "thwiiWoodScree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (86,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 832;
+}
+);
+note = uni1679;
+unicode = 5753;
+},
+{
+glyphname = "thwoWoodScree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 832;
+}
+);
+note = uni167A;
+unicode = 5754;
+},
+{
+glyphname = "thwooWoodScree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (373,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 832;
+}
+);
+note = uni167B;
+unicode = 5755;
+},
+{
+glyphname = "thwaWoodScree-canadian";
+lastChange = "2023-01-13 15:54:30 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = middle_right_can;
+pos = (609,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 833;
+}
+);
+note = uni167C;
+unicode = 5756;
+},
+{
+glyphname = "thwaaWoodScree-canadian";
+lastChange = "2023-01-13 15:54:30 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (88,0);
+ref = dot_top;
+},
+{
+anchor = middle_right_can;
+pos = (609,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 833;
+}
+);
+note = uni167D;
+unicode = 5757;
+},
+{
+glyphname = "wBlackfoot-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(450,557,l),
+(463,614,l),
+(144,614,l),
+(132,557,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(421,420,l),
+(433,477,l),
+(115,477,l),
+(102,420,l)
+);
+}
+);
+width = 447;
+}
+);
+metricRight = "=|";
+note = uni167F;
+unicode = 5759;
+},
+{
+glyphname = "oy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-7,0);
+ref = ring_top.canadian;
+}
+);
+width = 677;
+}
+);
+note = uni18B0;
+unicode = 6320;
+},
+{
+glyphname = "ay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (435,0);
+ref = ring_top.canadian;
+}
+);
+width = 677;
+}
+);
+note = uni18B1;
+unicode = 6321;
+},
+{
+glyphname = "aay-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (188,0);
+ref = ring_top.canadian;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (486,0);
+ref = dot_top;
+}
+);
+width = 677;
+}
+);
+note = uni18B2;
+unicode = 6322;
+},
+{
+glyphname = "way-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (660,0);
+ref = ring_top.canadian;
+}
+);
+width = 901;
+}
+);
+note = uni18B3;
+unicode = 6323;
+},
+{
+glyphname = "poy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-29,0);
+ref = ring_top.canadian;
+}
+);
+width = 649;
+}
+);
+note = uni18B4;
+unicode = 6324;
+},
+{
+glyphname = "pay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (430,0);
+ref = ring_top.canadian;
+}
+);
+width = 649;
+}
+);
+note = uni18B5;
+unicode = 6325;
+},
+{
+glyphname = "pwoy-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (195,0);
+ref = ring_top.canadian;
+}
+);
+width = 874;
+}
+);
+note = uni18B6;
+unicode = 6326;
+},
+{
+glyphname = "tay-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (208,0);
+ref = ring_top.canadian;
+}
+);
+width = 607;
+}
+);
+note = uni18B7;
+unicode = 6327;
+},
+{
+glyphname = "kay-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-9,0);
+ref = ring_top.canadian;
+}
+);
+width = 586;
+}
+);
+note = uni18B8;
+unicode = 6328;
+},
+{
+glyphname = "kway-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (216,0);
+ref = ring_top.canadian;
+}
+);
+width = 810;
+}
+);
+note = uni18B9;
+unicode = 6329;
+},
+{
+glyphname = "may-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+ref = ring_top.canadian;
+}
+);
+width = 528;
+}
+);
+note = uni18BA;
+unicode = 6330;
+},
+{
+glyphname = "noy-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (343,-192);
+ref = ring_top.canadian;
+}
+);
+width = 805;
+}
+);
+note = uni18BB;
+unicode = 6331;
+},
+{
+glyphname = "nay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (130,-192);
+ref = ring_top.canadian;
+}
+);
+width = 805;
+}
+);
+note = uni18BC;
+unicode = 6332;
+},
+{
+glyphname = "lay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (131,-192);
+ref = ring_top.canadian;
+}
+);
+width = 805;
+}
+);
+note = uni18BD;
+unicode = 6333;
+},
+{
+glyphname = "soy-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (292,0);
+ref = ring_top.canadian;
+}
+);
+width = 539;
+}
+);
+note = uni18BE;
+unicode = 6334;
+},
+{
+glyphname = "say-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+ref = ring_top.canadian;
+}
+);
+width = 539;
+}
+);
+note = uni18BF;
+unicode = 6335;
+},
+{
+glyphname = "shoy-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (298,-192);
+ref = ring_top.canadian;
+}
+);
+width = 927;
+}
+);
+note = uni18C0;
+unicode = 6336;
+},
+{
+glyphname = "shay-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (298,-192);
+ref = ring_top.canadian;
+}
+);
+width = 927;
+}
+);
+note = uni18C1;
+unicode = 6337;
+},
+{
+glyphname = "shwoy-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (523,-192);
+ref = ring_top.canadian;
+}
+);
+width = 1152;
+}
+);
+note = uni18C2;
+unicode = 6338;
+},
+{
+glyphname = "yoy-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (323,0);
+ref = ring_top.canadian;
+}
+);
+width = 570;
+}
+);
+note = uni18C3;
+unicode = 6339;
+},
+{
+glyphname = "yay-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-1,0);
+ref = ring_top.canadian;
+}
+);
+width = 570;
+}
+);
+note = uni18C4;
+unicode = 6340;
+},
+{
+glyphname = "ray-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (182,0);
+ref = ring_top.canadian;
+}
+);
+width = 543;
+}
+);
+note = uni18C5;
+unicode = 6341;
+},
+{
+glyphname = "nwi-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ni-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni18C6;
+unicode = 6342;
+},
+{
+glyphname = "nwiOjibway-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (805,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni18C7;
+unicode = 6343;
+},
+{
+glyphname = "nwii-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (416,-192);
+ref = dot_top;
+}
+);
+width = 1029;
+}
+);
+note = uni18C8;
+unicode = 6344;
+},
+{
+glyphname = "nwiiOjibway-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (192,-192);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (805,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni18C9;
+unicode = 6345;
+},
+{
+glyphname = "nwo-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "no-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni18CA;
+unicode = 6346;
+},
+{
+glyphname = "nwoOjibway-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (805,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni18CB;
+unicode = 6347;
+},
+{
+glyphname = "nwoo-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (618,-192);
+ref = dot_top;
+}
+);
+width = 1029;
+}
+);
+note = uni18CC;
+unicode = 6348;
+},
+{
+glyphname = "nwooOjibway-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (394,-192);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (805,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni18CD;
+unicode = 6349;
+},
+{
+glyphname = "rwee-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "reRCree-canadian";
+}
+);
+width = 1075;
+}
+);
+note = uni18CE;
+unicode = 6350;
+},
+{
+glyphname = "rwi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ri-canadian";
+}
+);
+width = 1075;
+}
+);
+note = uni18CF;
+unicode = 6351;
+},
+{
+glyphname = "rwii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (411,-192);
+ref = dot_top;
+}
+);
+width = 1075;
+}
+);
+note = uni18D0;
+unicode = 6352;
+},
+{
+glyphname = "rwo-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ro-canadian";
+}
+);
+width = 767;
+}
+);
+note = uni18D1;
+unicode = 6353;
+},
+{
+glyphname = "rwoo-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (387,0);
+ref = dot_top;
+}
+);
+width = 767;
+}
+);
+note = uni18D2;
+unicode = 6354;
+},
+{
+glyphname = "rwa-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ra-canadian";
+}
+);
+width = 767;
+}
+);
+note = uni18D3;
+unicode = 6355;
+},
+{
+glyphname = "pOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(138,345,l),
+(320,621,l),
+(269,621,l),
+(335,345,l),
+(396,345,l),
+(399,359,l),
+(316,690,l),
+(297,690,l),
+(73,359,l),
+(70,345,l)
+);
+}
+);
+width = 422;
+}
+);
+metricLeft = "kkCarrier-canadian";
+note = uni18D4;
+unicode = 6356;
+},
+{
+glyphname = "tOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 423;
+}
+);
+metricRight = "=|";
+note = uni1422;
+unicode = 6357;
+},
+{
+glyphname = "kOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(154,345,l),
+(187,503,l),
+(172,503,l),
+(173,464,o),
+(208,434,o),
+(255,434,cs),
+(339,434,o),
+(387,514,o),
+(387,586,cs),
+(387,652,o),
+(344,696,o),
+(273,696,cs),
+(202,696,o),
+(151,652,o),
+(133,570,cs),
+(86,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(215,485,o),
+(193,508,o),
+(193,544,cs),
+(193,586,o),
+(220,644,o),
+(271,644,cs),
+(306,644,o),
+(326,622,o),
+(326,585,cs),
+(326,542,o),
+(299,485,o),
+(249,485,cs)
+);
+}
+);
+width = 372;
+}
+);
+metricLeft = "k-canadian";
+metricRight = "k-canadian";
+note = uni18D6;
+unicode = 6358;
+},
+{
+glyphname = "cOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(155,345,l),
+(204,577,ls),
+(213,621,o),
+(240,641,o),
+(275,641,cs),
+(318,641,o),
+(335,613,o),
+(327,571,cs),
+(322,548,l),
+(385,548,l),
+(388,564,ls),
+(406,639,o),
+(362,696,o),
+(278,696,cs),
+(201,696,o),
+(153,653,o),
+(136,577,cs),
+(86,345,l)
+);
+}
+);
+width = 362;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni18D7;
+unicode = 6359;
+},
+{
+glyphname = "mOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(155,345,l),
+(214,626,l),
+(372,626,l),
+(385,690,l),
+(159,690,l),
+(86,345,l)
+);
+}
+);
+width = 338;
+}
+);
+metricLeft = "m-canadian";
+metricRight = "m-canadian";
+note = uni18D8;
+unicode = 6360;
+},
+{
+glyphname = "nOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(326,428,o),
+(377,501,o),
+(377,578,cs),
+(377,613,o),
+(359,639,o),
+(342,653,c),
+(332,626,l),
+(514,626,l),
+(527,690,l),
+(266,690,ls),
+(174,690,o),
+(123,616,o),
+(123,539,cs),
+(123,472,o),
+(168,428,o),
+(239,428,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(205,478,o),
+(184,502,o),
+(184,539,cs),
+(184,578,o),
+(205,639,o),
+(260,639,cs),
+(296,639,o),
+(317,614,o),
+(317,579,cs),
+(317,540,o),
+(296,478,o),
+(241,478,cs)
+);
+}
+);
+width = 479;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "n-canadian";
+note = uni18D9;
+unicode = 6361;
+},
+{
+glyphname = "sOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(154,345,l),
+(184,485,l),
+(135,455,l),
+(170,455,ls),
+(283,455,o),
+(352,515,o),
+(376,635,cs),
+(387,690,l),
+(320,690,l),
+(309,639,ls),
+(290,549,o),
+(244,510,o),
+(155,510,cs),
+(121,510,l),
+(85,345,l)
+);
+}
+);
+width = 355;
+}
+);
+metricLeft = "s-canadian";
+metricRight = "s-canadian";
+note = uni18DA;
+unicode = 6362;
+},
+{
+color = 1;
+glyphname = "shOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(276,340,o),
+(321,382,o),
+(344,464,cs),
+(377,574,ls),
+(390,620,o),
+(411,643,o),
+(450,643,cs),
+(491,643,o),
+(508,617,o),
+(499,574,cs),
+(495,548,l),
+(557,548,l),
+(561,569,ls),
+(577,644,o),
+(533,696,o),
+(451,696,cs),
+(377,696,o),
+(332,655,o),
+(309,572,cs),
+(276,462,ls),
+(263,415,o),
+(242,392,o),
+(203,392,cs),
+(162,392,o),
+(145,418,o),
+(154,462,cs),
+(158,488,l),
+(96,488,l),
+(92,467,ls),
+(76,391,o),
+(120,340,o),
+(202,340,cs)
+);
+}
+);
+width = 534;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "c-canadian";
+note = uni18DB;
+unicode = 6363;
+},
+{
+color = 9;
+glyphname = "easternw-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (-29,-307);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (131,0);
+ref = "glottalstop-canadian";
+}
+);
+width = 565;
+}
+);
+note = uni18DC;
+unicode = 6364;
+},
+{
+color = 9;
+glyphname = "westernw-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (719,-307);
+ref = dot_top;
+scale = (-1,1);
+},
+{
+alignment = -1;
+ref = "glottalstop-canadian";
+}
+);
+width = 567;
+}
+);
+metricLeft = "glottalstop-canadian";
+note = uni18DD;
+unicode = 6365;
+},
+{
+glyphname = "rweRCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "reRCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (850,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1075;
+}
+);
+note = uni18E0;
+unicode = 6368;
+},
+{
+glyphname = "looWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+}
+);
+width = 543;
+}
+);
+note = uni18E1;
+unicode = 6369;
+},
+{
+glyphname = "laaWestCree-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (345,0);
+ref = dot_top;
+}
+);
+width = 542;
+}
+);
+note = uni18E2;
+unicode = 6370;
+},
+{
+glyphname = "thwe-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "the-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (722,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 946;
+}
+);
+note = uni18E3;
+unicode = 6371;
+},
+{
+glyphname = "thwa-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (672,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 896;
+}
+);
+note = uni18E4;
+unicode = 6372;
+},
+{
+glyphname = "tthwe-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "tthe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (713,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 937;
+}
+);
+note = uni18E5;
+unicode = 6373;
+},
+{
+glyphname = "tthoo-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ttho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (227,0);
+ref = dot_top;
+}
+);
+width = 623;
+}
+);
+note = uni18E6;
+unicode = 6374;
+},
+{
+glyphname = "tthaa-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ttha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (244,0);
+ref = dot_top;
+}
+);
+width = 623;
+}
+);
+note = uni18E7;
+unicode = 6375;
+},
+{
+glyphname = "tlhwe-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "tlhe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (596,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 820;
+}
+);
+note = uni18E8;
+unicode = 6376;
+},
+{
+glyphname = "tlhoo-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "tlho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (240,0);
+ref = dot_top;
+}
+);
+width = 596;
+}
+);
+note = uni18E9;
+unicode = 6377;
+},
+{
+glyphname = "shweSayisi-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "sheSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (592,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni18EA;
+unicode = 6378;
+},
+{
+glyphname = "shooSayisi-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "shoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (402,0);
+ref = dot_top;
+}
+);
+width = 592;
+}
+);
+note = uni18EB;
+unicode = 6379;
+},
+{
+color = 9;
+glyphname = "hooSayisi-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "hoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (474,0);
+ref = dot_top;
+}
+);
+width = 670;
+}
+);
+note = uni18EC;
+unicode = 6380;
+},
+{
+color = 9;
+glyphname = "gwuCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "guCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (856,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1081;
+}
+);
+note = uni18ED;
+unicode = 6381;
+},
+{
+color = 9;
+glyphname = "deneGeeCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "geCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (284,0);
+ref = dot_top;
+}
+);
+width = 708;
+}
+);
+note = uni18EE;
+unicode = 6382;
+},
+{
+color = 9;
+glyphname = "gaaCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (296,0);
+ref = dot_top;
+}
+);
+width = 708;
+}
+);
+note = uni18EF;
+unicode = 6383;
+},
+{
+color = 9;
+glyphname = "gwaCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (708,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 932;
+}
+);
+note = uni18F0;
+unicode = 6384;
+},
+{
+color = 9;
+glyphname = "juuSayisi-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "juSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (298,0);
+ref = dot_top;
+}
+);
+width = 719;
+}
+);
+note = uni18F1;
+unicode = 6385;
+},
+{
+color = 9;
+glyphname = "jwaCarrier-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "jaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (762,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 986;
+}
+);
+note = uni18F2;
+unicode = 6386;
+},
+{
+glyphname = "lBeaverDene-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "pWestCree-canadian";
+}
+);
+width = 196;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+unicode = 6387;
+},
+{
+glyphname = "rBeaverDene-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(155,345,l),
+(196,540,ls),
+(209,598,o),
+(239,626,o),
+(285,626,cs),
+(295,626,l),
+(310,696,l),
+(302,696,ls),
+(250,696,o),
+(213,664,o),
+(201,608,c),
+(206,611,l),
+(223,690,l),
+(159,690,l),
+(86,345,l)
+);
+}
+);
+width = 243;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni18F4;
+unicode = 6388;
+},
+{
+color = 6;
+glyphname = "sDentalCarrier-canadian";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(217,183,ls),
+(304,183,o),
+(354,224,o),
+(354,298,cs),
+(354,349,o),
+(320,382,o),
+(258,382,cs),
+(213,382,ls),
+(180,382,o),
+(164,395,o),
+(164,417,cs),
+(164,455,o),
+(188,475,o),
+(233,475,cs),
+(388,475,l),
+(400,527,l),
+(241,527,ls),
+(154,527,o),
+(103,486,o),
+(103,412,cs),
+(103,361,o),
+(137,329,o),
+(199,329,cs),
+(243,329,ls),
+(278,329,o),
+(294,316,o),
+(294,293,cs),
+(294,256,o),
+(269,235,o),
+(224,235,cs),
+(70,235,l),
+(58,183,l)
+);
+}
+);
+width = 408;
+}
+);
+metricLeft = "shCarrier-canadian";
+metricRight = "=|";
+note = uni18F5;
+unicode = 6389;
+},
+{
+glyphname = "pWestCree-canadian.base";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-74,-345);
+ref = "pWestCree-canadian";
+}
+);
+width = 195;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.base";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-73,-345);
+ref = "c-canadian";
+}
+);
+width = 363;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "thSayisi-canadian.base";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-74,-345);
+ref = "thSayisi-canadian";
+}
+);
+width = 362;
+}
+);
+metricLeft = "=|c-canadian";
+note = uni14A2;
+},
+{
+glyphname = "mWestCree-canadian.base";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-73,-345);
+ref = "mWestCree-canadian";
+}
+);
+width = 369;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+glyphname = "pWestCree-canadian.mid";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-162);
+ref = "pWestCree-canadian";
+}
+);
+width = 196;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.mid";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-162);
+ref = "c-canadian";
+}
+);
+width = 363;
+}
+);
+metricLeft = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "mWestCree-canadian.mid";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-34,-162);
+ref = "mWestCree-canadian";
+}
+);
+width = 370;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+color = 11;
+glyphname = "ngaai-canadian.nunavik";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (648,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (822,0);
+ref = ring_top.canadian;
+}
+);
+width = 1229;
+}
+);
+note = uni158E;
+},
+{
+color = 11;
+glyphname = "ngi-canadian.nunavik";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (648,0);
+ref = "ci-canadian";
+}
+);
+width = 1229;
+}
+);
+note = uni158F;
+},
+{
+color = 11;
+glyphname = "ngii-canadian.nunavik";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (648,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (873,0);
+ref = dot_top;
+}
+);
+width = 1229;
+}
+);
+note = uni1590;
+},
+{
+color = 11;
+glyphname = "ngo-canadian.nunavik";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (648,0);
+ref = "co-canadian";
+}
+);
+width = 1229;
+}
+);
+note = uni1591;
+},
+{
+color = 11;
+glyphname = "ngoo-canadian.nunavik";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "ngo-canadian.nunavik";
+},
+{
+anchor = top_right_can;
+pos = (1040,0);
+ref = dot_top;
+}
+);
+width = 1229;
+}
+);
+note = uni1592;
+},
+{
+color = 11;
+glyphname = "nga-canadian.nunavik";
+lastChange = "2023-01-13 15:54:30 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (648,0);
+ref = "ca-canadian";
+}
+);
+width = 1228;
+}
+);
+note = uni1593;
+},
+{
+color = 11;
+glyphname = "ngaa-canadian.nunavik";
+lastChange = "2023-01-13 15:54:30 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (648,0);
+ref = "ca-canadian";
+},
+{
+anchor = top_left_can;
+pos = (692,0);
+ref = dot_top;
+}
+);
+width = 1228;
+}
+);
+note = uni1594;
+},
+{
+color = 11;
+glyphname = "ng-canadian.nunavik";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(553,158,o),
+(605,240,o),
+(605,316,cs),
+(605,378,o),
+(566,420,o),
+(506,420,cs),
+(469,420,o),
+(437,403,o),
+(420,371,c),
+(430,354,l),
+(461,497,l),
+(316,497,l),
+(316,465,l),
+(358,488,o),
+(378,545,o),
+(378,586,cs),
+(378,651,o),
+(332,696,o),
+(261,696,cs),
+(172,696,o),
+(124,622,o),
+(124,547,cs),
+(124,479,o),
+(168,435,o),
+(239,435,cs),
+(417,435,l),
+(387,472,l),
+(352,307,ls),
+(335,229,o),
+(374,158,o),
+(462,158,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(432,211,o),
+(410,233,o),
+(410,270,cs),
+(410,313,o),
+(437,370,o),
+(487,370,cs),
+(522,370,o),
+(544,348,o),
+(544,311,cs),
+(544,267,o),
+(516,211,o),
+(466,211,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(205,485,o),
+(183,509,o),
+(183,546,cs),
+(183,591,o),
+(210,645,o),
+(260,645,cs),
+(296,645,o),
+(318,621,o),
+(318,584,cs),
+(318,540,o),
+(291,485,o),
+(241,485,cs)
+);
+}
+);
+width = 648;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+color = 11;
+glyphname = "ngai-canadian.nunavik";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (648,0);
+ref = "ce-canadian";
+}
+);
+width = 1229;
+}
+);
+note = uni1670;
+},
+{
+color = 11;
+glyphname = "ke-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (437,690);
+},
+{
+name = top_left_can;
+pos = (215,690);
+},
+{
+name = top_right_can;
+pos = (668,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(569,0,l),
+(716,690,l),
+(462,690,ls),
+(225,690,o),
+(96,556,o),
+(96,361,cs),
+(96,220,o),
+(190,134,o),
+(350,134,cs),
+(501,134,l),
+(473,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(251,218,o),
+(190,272,o),
+(190,368,cs),
+(190,499,o),
+(272,605,o),
+(441,605,cs),
+(602,605,l),
+(520,218,l),
+(366,218,ls)
+);
+}
+);
+width = 696;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146B;
+},
+{
+color = 11;
+glyphname = "ki-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (451,690);
+},
+{
+name = top_left_can;
+pos = (220,690);
+},
+{
+name = top_right_can;
+pos = (682,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,0,l),
+(149,134,l),
+(313,134,ls),
+(544,134,o),
+(673,269,o),
+(673,460,cs),
+(673,603,o),
+(578,690,o),
+(419,690,cs),
+(172,690,l),
+(25,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(249,605,l),
+(404,605,ls),
+(517,605,o),
+(579,551,o),
+(579,455,cs),
+(579,325,o),
+(497,218,o),
+(331,218,cs),
+(167,218,l)
+);
+}
+);
+width = 696;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni146D;
+},
+{
+color = 11;
+glyphname = "kii-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (282,0);
+ref = dot_top;
+}
+);
+width = 697;
+}
+);
+note = uni146E;
+},
+{
+color = 11;
+glyphname = "ko-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (437,690);
+},
+{
+name = top_left_can;
+pos = (215,690);
+},
+{
+name = top_right_can;
+pos = (668,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(569,0,l),
+(716,690,l),
+(620,690,l),
+(592,555,l),
+(428,555,ls),
+(197,555,o),
+(68,421,o),
+(68,230,cs),
+(68,87,o),
+(162,0,o),
+(322,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(223,85,o),
+(162,139,o),
+(162,235,cs),
+(162,365,o),
+(243,471,o),
+(410,471,cs),
+(574,471,l),
+(492,85,l),
+(337,85,ls)
+);
+}
+);
+width = 696;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146F;
+},
+{
+color = 11;
+glyphname = "koo-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (500,0);
+ref = dot_top;
+}
+);
+width = 697;
+}
+);
+note = uni1470;
+},
+{
+color = 11;
+glyphname = "ka-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (451,690);
+},
+{
+name = top_left_can;
+pos = (220,690);
+},
+{
+name = top_right_can;
+pos = (683,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(279,0,ls),
+(515,0,o),
+(645,133,o),
+(645,328,cs),
+(645,469,o),
+(551,555,o),
+(390,555,cs),
+(240,555,l),
+(268,690,l),
+(172,690,l),
+(25,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(221,471,l),
+(374,471,ls),
+(489,471,o),
+(550,417,o),
+(550,322,cs),
+(550,190,o),
+(469,85,o),
+(299,85,cs),
+(139,85,l)
+);
+}
+);
+width = 696;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1472;
+},
+{
+color = 11;
+glyphname = "kaa-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+}
+);
+width = 697;
+}
+);
+note = uni1473;
+},
+{
+color = 11;
+glyphname = "kweWestCree-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (697,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 922;
+}
+);
+note = uni1475;
+},
+{
+color = 11;
+glyphname = "kwiiWestCree-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (282,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (697,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 922;
+}
+);
+note = uni1479;
+},
+{
+color = 11;
+glyphname = "kwoWestCree-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (697,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 922;
+}
+);
+note = uni147B;
+},
+{
+color = 11;
+glyphname = "kwooWestCree-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (500,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (697,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 922;
+}
+);
+note = uni147D;
+},
+{
+color = 11;
+glyphname = "kwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (697,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 922;
+}
+);
+note = uni147F;
+},
+{
+color = 11;
+glyphname = "kwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (697,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 922;
+}
+);
+note = uni1481;
+},
+{
+color = 11;
+glyphname = "ce-canadian.square";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (443,690);
+},
+{
+name = top_left_can;
+pos = (203,690);
+},
+{
+name = top_right_can;
+pos = (684,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(584,0,l),
+(665,379,ls),
+(707,575,o),
+(609,702,o),
+(413,702,cs),
+(247,702,o),
+(137,607,o),
+(100,432,cs),
+(91,386,l),
+(186,386,l),
+(194,424,ls),
+(221,551,o),
+(294,615,o),
+(408,615,cs),
+(542,615,o),
+(601,530,o),
+(570,383,cs),
+(489,0,l)
+);
+}
+);
+width = 703;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni1489;
+},
+{
+color = 11;
+glyphname = "ci-canadian.square";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (452,690);
+},
+{
+name = top_left_can;
+pos = (213,690);
+},
+{
+name = top_right_can;
+pos = (694,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(114,0,l),
+(201,412,ls),
+(230,548,o),
+(305,615,o),
+(423,615,cs),
+(548,615,o),
+(612,539,o),
+(587,417,cs),
+(581,386,l),
+(675,386,l),
+(681,412,ls),
+(717,584,o),
+(612,702,o),
+(427,702,cs),
+(259,702,o),
+(147,607,o),
+(109,432,cs),
+(17,0,l)
+);
+}
+);
+width = 703;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+},
+{
+color = 11;
+glyphname = "cii-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (283,0);
+ref = dot_top;
+}
+);
+width = 703;
+}
+);
+note = uni148C;
+},
+{
+color = 11;
+glyphname = "co-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (443,690);
+},
+{
+name = top_left_can;
+pos = (203,690);
+},
+{
+name = top_right_can;
+pos = (684,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(490,-13,o),
+(602,83,o),
+(639,258,cs),
+(731,690,l),
+(636,690,l),
+(548,277,ls),
+(519,142,o),
+(443,74,o),
+(326,74,cs),
+(201,74,o),
+(135,151,o),
+(161,272,cs),
+(168,303,l),
+(72,303,l),
+(67,277,ls),
+(31,105,o),
+(137,-13,o),
+(322,-13,cs)
+);
+}
+);
+width = 703;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+},
+{
+color = 11;
+glyphname = "coo-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (514,0);
+ref = dot_top;
+}
+);
+width = 703;
+}
+);
+note = uni148E;
+},
+{
+color = 11;
+glyphname = "ca-canadian.square";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (452,690);
+},
+{
+name = top_left_can;
+pos = (213,690);
+},
+{
+name = top_right_can;
+pos = (693,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(501,-13,o),
+(611,83,o),
+(648,258,cs),
+(658,303,l),
+(562,303,l),
+(554,266,ls),
+(527,139,o),
+(455,74,o),
+(341,74,cs),
+(207,74,o),
+(147,159,o),
+(179,307,cs),
+(260,690,l),
+(164,690,l),
+(83,311,ls),
+(42,115,o),
+(140,-13,o),
+(335,-13,cs)
+);
+}
+);
+width = 704;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+},
+{
+color = 11;
+glyphname = "caa-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (43,0);
+ref = dot_top;
+}
+);
+width = 703;
+}
+);
+note = uni1491;
+},
+{
+color = 11;
+glyphname = "me-canadian.square";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (383,690);
+},
+{
+name = top_double;
+pos = (577,690);
+},
+{
+name = top_left_can;
+pos = (184,690);
+},
+{
+name = top_right_can;
+pos = (577,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(477,0,l),
+(624,690,l),
+(136,690,l),
+(118,603,l),
+(510,603,l),
+(382,0,l)
+);
+}
+);
+width = 604;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+},
+{
+color = 11;
+glyphname = "mi-canadian.square";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (415,690);
+},
+{
+name = top_left_can;
+pos = (220,690);
+},
+{
+name = top_right_can;
+pos = (611,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,0,l),
+(249,603,l),
+(641,603,l),
+(660,690,l),
+(172,690,l),
+(25,0,l)
+);
+}
+);
+width = 604;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+},
+{
+color = 11;
+glyphname = "mii-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (246,0);
+ref = dot_top;
+}
+);
+width = 605;
+}
+);
+note = uni14A6;
+},
+{
+color = 11;
+glyphname = "mo-canadian.square";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (383,690);
+},
+{
+name = top_double;
+pos = (577,690);
+},
+{
+name = top_left_can;
+pos = (184,690);
+},
+{
+name = top_right_can;
+pos = (577,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(477,0,l),
+(624,690,l),
+(528,690,l),
+(400,87,l),
+(8,87,l),
+(-11,0,l)
+);
+}
+);
+width = 604;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+},
+{
+color = 11;
+glyphname = "moo-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (407,0);
+ref = dot_top;
+}
+);
+width = 605;
+}
+);
+note = uni14A8;
+},
+{
+color = 11;
+glyphname = "ma-canadian.square";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (415,690);
+},
+{
+name = top_left_can;
+pos = (220,690);
+},
+{
+name = top_right_can;
+pos = (611,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(513,0,l),
+(531,87,l),
+(139,87,l),
+(268,690,l),
+(172,690,l),
+(25,0,l)
+);
+}
+);
+width = 604;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+},
+{
+color = 11;
+glyphname = "maa-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+}
+);
+width = 605;
+}
+);
+note = uni14AB;
+},
+{
+color = 11;
+glyphname = "ne-canadian.square";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (533,690);
+},
+{
+name = top_left_can;
+pos = (342,690);
+},
+{
+name = top_right_can;
+pos = (729,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(556,-13,o),
+(645,70,o),
+(681,238,cs),
+(778,690,l),
+(152,690,l),
+(133,605,l),
+(275,605,l),
+(203,267,ls),
+(166,94,o),
+(244,-13,o),
+(411,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(315,75,o),
+(271,138,o),
+(296,251,cs),
+(371,605,l),
+(664,605,l),
+(585,239,ls),
+(562,128,o),
+(508,75,o),
+(417,75,cs)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C0;
+},
+{
+color = 11;
+glyphname = "ni-canadian.square";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (406,690);
+},
+{
+name = top_left_can;
+pos = (212,690);
+},
+{
+name = top_right_can;
+pos = (600,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(427,-13,o),
+(516,70,o),
+(552,238,cs),
+(630,605,l),
+(772,605,l),
+(790,690,l),
+(164,690,l),
+(74,267,ls),
+(38,94,o),
+(117,-13,o),
+(282,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(186,75,o),
+(143,139,o),
+(167,251,cs),
+(242,605,l),
+(534,605,l),
+(456,239,ls),
+(433,128,o),
+(380,75,o),
+(289,75,cs)
+);
+}
+);
+width = 749;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+},
+{
+color = 11;
+glyphname = "nii-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (237,0);
+ref = dot_top;
+}
+);
+width = 750;
+}
+);
+note = uni14C3;
+},
+{
+color = 11;
+glyphname = "no-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (535,690);
+},
+{
+name = top_double;
+pos = (545,690);
+},
+{
+name = top_left_can;
+pos = (342,690);
+},
+{
+name = top_right_can;
+pos = (725,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(630,0,l),
+(720,423,ls),
+(756,596,o),
+(678,702,o),
+(512,702,cs),
+(367,702,o),
+(278,620,o),
+(242,452,cs),
+(164,85,l),
+(22,85,l),
+(5,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(338,451,ls),
+(361,562,o),
+(414,614,o),
+(505,614,cs),
+(608,614,o),
+(651,551,o),
+(627,439,cs),
+(553,85,l),
+(260,85,l)
+);
+}
+);
+width = 749;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C4;
+},
+{
+color = 11;
+glyphname = "noo-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (366,0);
+ref = dot_top;
+}
+);
+width = 750;
+}
+);
+note = uni14C5;
+},
+{
+color = 11;
+glyphname = "na-canadian.square";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (407,690);
+},
+{
+name = top_double;
+pos = (416,690);
+},
+{
+name = top_left_can;
+pos = (213,690);
+},
+{
+name = top_right_can;
+pos = (601,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(643,0,l),
+(662,85,l),
+(520,85,l),
+(592,423,ls),
+(629,596,o),
+(550,702,o),
+(385,702,cs),
+(239,702,o),
+(150,620,o),
+(114,452,cs),
+(17,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(210,451,ls),
+(233,562,o),
+(287,614,o),
+(378,614,cs),
+(479,614,o),
+(524,552,o),
+(499,439,cs),
+(424,85,l),
+(131,85,l)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+},
+{
+color = 11;
+glyphname = "naa-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (237,0);
+ref = dot_top;
+}
+);
+width = 750;
+}
+);
+note = uni14C8;
+},
+{
+color = 11;
+glyphname = "nweWestCree-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (750,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni14CA;
+},
+{
+color = 11;
+glyphname = "nwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (750,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni14CC;
+},
+{
+color = 11;
+glyphname = "nwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (237,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (750,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni14CE;
+},
+{
+color = 11;
+glyphname = "se-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (217,690);
+},
+{
+name = top_right_can;
+pos = (668,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(568,0,l),
+(623,257,l),
+(400,257,ls),
+(247,257,o),
+(189,333,o),
+(224,496,cs),
+(266,690,l),
+(169,690,l),
+(128,496,ls),
+(86,296,o),
+(185,173,o),
+(383,173,cs),
+(535,173,l),
+(515,200,l),
+(472,0,l)
+);
+}
+);
+width = 695;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14ED;
+},
+{
+color = 11;
+glyphname = "si-canadian.square";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (220,690);
+},
+{
+name = top_right_can;
+pos = (671,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(122,0,l),
+(165,200,l),
+(132,173,l),
+(283,173,ls),
+(505,173,o),
+(630,274,o),
+(675,490,cs),
+(718,690,l),
+(622,690,l),
+(580,493,ls),
+(548,339,o),
+(448,257,o),
+(299,257,cs),
+(80,257,l),
+(26,0,l)
+);
+}
+);
+width = 695;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+},
+{
+color = 11;
+glyphname = "sii-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (501,0);
+ref = dot_top;
+}
+);
+width = 695;
+}
+);
+note = uni14F0;
+},
+{
+color = 11;
+glyphname = "so-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (667,690);
+},
+{
+name = top_left_can;
+pos = (217,690);
+},
+{
+name = top_right_can;
+pos = (667,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(119,0,l),
+(160,197,ls),
+(193,351,o),
+(292,433,o),
+(440,433,cs),
+(660,433,l),
+(715,690,l),
+(618,690,l),
+(576,490,l),
+(609,517,l),
+(458,517,ls),
+(236,517,o),
+(111,415,o),
+(65,200,cs),
+(22,0,l)
+);
+}
+);
+width = 695;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+},
+{
+color = 11;
+glyphname = "soo-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (497,0);
+ref = dot_top;
+}
+);
+width = 695;
+}
+);
+note = uni14F2;
+},
+{
+color = 11;
+glyphname = "sa-canadian.square";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (220,690);
+},
+{
+name = top_right_can;
+pos = (669,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(571,0,l),
+(611,194,ls),
+(654,394,o),
+(554,517,o),
+(356,517,cs),
+(204,517,l),
+(225,490,l),
+(268,690,l),
+(172,690,l),
+(117,433,l),
+(340,433,ls),
+(493,433,o),
+(551,356,o),
+(516,194,cs),
+(474,0,l)
+);
+}
+);
+width = 695;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+},
+{
+color = 11;
+glyphname = "saa-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+}
+);
+width = 695;
+}
+);
+note = uni14F5;
+},
+{
+color = 11;
+glyphname = "sho-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (440,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(561,0,l),
+(579,80,l),
+(265,80,ls),
+(188,80,o),
+(149,110,o),
+(149,168,cs),
+(149,251,o),
+(204,305,o),
+(310,305,cs),
+(423,305,ls),
+(591,305,o),
+(682,387,o),
+(682,528,cs),
+(682,628,o),
+(614,690,o),
+(500,690,cs),
+(171,690,l),
+(155,610,l),
+(471,610,ls),
+(548,610,o),
+(586,580,o),
+(586,522,cs),
+(586,438,o),
+(532,384,o),
+(425,384,cs),
+(313,384,ls),
+(144,384,o),
+(53,301,o),
+(53,162,cs),
+(53,63,o),
+(122,0,o),
+(236,0,cs)
+);
+}
+);
+width = 690;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+color = 11;
+glyphname = "shoo-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (271,0);
+ref = dot_top;
+}
+);
+width = 691;
+}
+);
+note = g728;
+},
+{
+color = 11;
+glyphname = "sha-canadian.square";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (464,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(356,0,ls),
+(527,0,o),
+(617,83,o),
+(617,227,cs),
+(617,326,o),
+(551,384,o),
+(436,384,cs),
+(327,384,ls),
+(251,384,o),
+(213,412,o),
+(213,469,cs),
+(213,555,o),
+(265,610,o),
+(374,610,cs),
+(691,610,l),
+(708,690,l),
+(376,690,ls),
+(209,690,o),
+(117,608,o),
+(117,464,cs),
+(117,364,o),
+(184,305,o),
+(298,305,cs),
+(406,305,ls),
+(483,305,o),
+(522,277,o),
+(522,221,cs),
+(522,134,o),
+(468,80,o),
+(357,80,cs),
+(40,80,l),
+(23,0,l)
+);
+}
+);
+width = 689;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+color = 11;
+glyphname = "shaa-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (295,0);
+ref = dot_top;
+}
+);
+width = 691;
+}
+);
+note = g730;
+},
+{
+color = 11;
+glyphname = "ye-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (186,690);
+},
+{
+name = top_right_can;
+pos = (695,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(595,0,l),
+(650,257,l),
+(183,257,l),
+(184,205,l),
+(737,631,l),
+(682,701,l),
+(34,203,l),
+(28,173,l),
+(536,173,l),
+(499,0,l)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "ye-canadian";
+note = uni1526;
+},
+{
+color = 11;
+glyphname = "yi-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (215,690);
+},
+{
+name = top_right_can;
+pos = (724,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(117,0,l),
+(154,173,l),
+(663,173,l),
+(668,203,l),
+(215,701,l),
+(143,638,l),
+(532,207,l),
+(543,257,l),
+(75,257,l),
+(21,0,l)
+);
+}
+);
+width = 719;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni1528;
+},
+{
+color = 11;
+glyphname = "yii-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (46,0);
+ref = dot_top;
+}
+);
+width = 719;
+}
+);
+note = uni1529;
+},
+{
+color = 11;
+glyphname = "yo-canadian.square";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (695,690);
+},
+{
+name = top_left_can;
+pos = (186,690);
+},
+{
+name = top_right_can;
+pos = (695,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(620,52,l),
+(231,483,l),
+(221,433,l),
+(688,433,l),
+(743,690,l),
+(646,690,l),
+(610,517,l),
+(101,517,l),
+(95,487,l),
+(549,-12,l)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152A;
+},
+{
+color = 11;
+glyphname = "yoo-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (526,0);
+ref = dot_top;
+}
+);
+width = 719;
+}
+);
+note = uni152B;
+},
+{
+color = 11;
+glyphname = "ya-canadian.square";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (215,690);
+},
+{
+name = top_right_can;
+pos = (723,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(730,487,l),
+(736,517,l),
+(228,517,l),
+(265,690,l),
+(168,690,l),
+(114,433,l),
+(581,433,l),
+(581,485,l),
+(26,59,l),
+(81,-12,l)
+);
+}
+);
+width = 719;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152D;
+},
+{
+color = 11;
+glyphname = "yaa-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (44,0);
+ref = dot_top;
+}
+);
+width = 719;
+}
+);
+note = uni152E;
+},
+{
+color = 11;
+glyphname = "re-canadian.square";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (406,690);
+},
+{
+name = top_left_can;
+pos = (213,690);
+},
+{
+name = top_right_can;
+pos = (601,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(427,-13,o),
+(516,70,o),
+(552,238,cs),
+(630,605,l),
+(772,605,l),
+(790,690,l),
+(553,690,l),
+(456,239,ls),
+(433,128,o),
+(380,75,o),
+(289,75,cs),
+(186,75,o),
+(143,139,o),
+(167,251,cs),
+(260,690,l),
+(164,690,l),
+(74,267,ls),
+(38,94,o),
+(117,-13,o),
+(282,-13,cs)
+);
+}
+);
+width = 749;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1542;
+},
+{
+color = 11;
+glyphname = "reRCree-canadian.square";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (535,690);
+},
+{
+name = top_left_can;
+pos = (342,690);
+},
+{
+name = top_right_can;
+pos = (729,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(556,-13,o),
+(645,70,o),
+(681,238,cs),
+(778,690,l),
+(682,690,l),
+(585,239,ls),
+(562,128,o),
+(508,75,o),
+(417,75,cs),
+(315,75,o),
+(271,138,o),
+(296,251,cs),
+(388,690,l),
+(152,690,l),
+(133,605,l),
+(275,605,l),
+(203,267,ls),
+(166,94,o),
+(244,-13,o),
+(411,-13,cs)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni1543;
+},
+{
+color = 11;
+glyphname = "leWestCree-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (535,690);
+},
+{
+name = top_left_can;
+pos = (342,690);
+},
+{
+name = top_right_can;
+pos = (729,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(242,0,l),
+(338,451,ls),
+(362,562,o),
+(414,614,o),
+(506,614,cs),
+(608,614,o),
+(651,551,o),
+(628,438,cs),
+(534,0,l),
+(631,0,l),
+(721,423,ls),
+(756,596,o),
+(678,702,o),
+(512,702,cs),
+(367,702,o),
+(278,620,o),
+(242,452,cs),
+(164,85,l),
+(22,85,l),
+(5,0,l)
+);
+}
+);
+width = 753;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+},
+{
+color = 11;
+glyphname = "ri-canadian.square";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (407,690);
+},
+{
+name = top_left_can;
+pos = (216,690);
+},
+{
+name = top_right_can;
+pos = (601,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(113,0,l),
+(210,451,ls),
+(233,562,o),
+(287,614,o),
+(378,614,cs),
+(479,614,o),
+(524,552,o),
+(499,439,cs),
+(406,0,l),
+(643,0,l),
+(662,85,l),
+(520,85,l),
+(592,423,ls),
+(629,596,o),
+(550,702,o),
+(385,702,cs),
+(239,702,o),
+(150,620,o),
+(114,452,cs),
+(17,0,l)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+},
+{
+color = 11;
+glyphname = "rii-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (237,0);
+ref = dot_top;
+}
+);
+width = 750;
+}
+);
+note = uni1547;
+},
+{
+color = 11;
+glyphname = "ro-canadian.square";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (443,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,0,l),
+(158,176,l),
+(106,134,l),
+(299,134,ls),
+(526,134,o),
+(656,268,o),
+(656,462,cs),
+(656,603,o),
+(560,690,o),
+(401,690,cs),
+(172,690,l),
+(154,605,l),
+(386,605,ls),
+(499,605,o),
+(560,551,o),
+(560,455,cs),
+(560,324,o),
+(479,218,o),
+(307,218,cs),
+(71,218,l),
+(25,0,l)
+);
+}
+);
+width = 679;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1548;
+},
+{
+color = 11;
+glyphname = "loWestCree-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (443,690);
+},
+{
+name = top_left_can;
+pos = (221,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(272,0,ls),
+(498,0,o),
+(628,133,o),
+(628,328,cs),
+(628,469,o),
+(534,555,o),
+(374,555,cs),
+(196,555,l),
+(231,514,l),
+(269,690,l),
+(173,690,l),
+(126,471,l),
+(358,471,ls),
+(473,471,o),
+(533,417,o),
+(533,322,cs),
+(533,190,o),
+(452,85,o),
+(281,85,cs),
+(43,85,l),
+(26,0,l)
+);
+}
+);
+width = 675;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+},
+{
+color = 11;
+glyphname = "ra-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (424,690);
+},
+{
+name = top_right_can;
+pos = (647,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(548,0,l),
+(594,218,l),
+(361,218,ls),
+(247,218,o),
+(187,272,o),
+(187,368,cs),
+(187,499,o),
+(269,605,o),
+(440,605,cs),
+(676,605,l),
+(695,690,l),
+(448,690,ls),
+(221,690,o),
+(92,556,o),
+(92,361,cs),
+(92,220,o),
+(186,134,o),
+(347,134,cs),
+(524,134,l),
+(489,176,l),
+(451,0,l)
+);
+}
+);
+width = 675;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+},
+{
+color = 11;
+glyphname = "raa-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (255,0);
+ref = dot_top;
+}
+);
+width = 675;
+}
+);
+note = uni154C;
+},
+{
+color = 11;
+glyphname = "laWestCree-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (647,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(548,0,l),
+(566,85,l),
+(333,85,ls),
+(219,85,o),
+(159,139,o),
+(159,235,cs),
+(159,366,o),
+(241,471,o),
+(412,471,cs),
+(648,471,l),
+(695,690,l),
+(599,690,l),
+(561,514,l),
+(614,555,l),
+(419,555,ls),
+(193,555,o),
+(64,422,o),
+(64,228,cs),
+(64,87,o),
+(158,0,o),
+(318,0,cs)
+);
+}
+);
+width = 675;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+},
+{
+color = 11;
+glyphname = "reWestCree-canadian.square";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(574,0,l),
+(852,195,l),
+(802,266,l),
+(569,103,l),
+(601,77,l),
+(666,379,ls),
+(707,576,o),
+(609,702,o),
+(414,702,cs),
+(252,702,o),
+(137,609,o),
+(100,432,cs),
+(91,386,l),
+(186,386,l),
+(194,424,ls),
+(221,551,o),
+(294,615,o),
+(408,615,cs),
+(542,615,o),
+(601,530,o),
+(570,383,cs),
+(489,0,l)
+);
+}
+);
+width = 887;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+},
+{
+color = 11;
+glyphname = "riWestCree-canadian.square";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(299,0,l),
+(385,412,ls),
+(414,548,o),
+(490,615,o),
+(608,615,cs),
+(732,615,o),
+(798,539,o),
+(772,417,cs),
+(765,386,l),
+(860,386,l),
+(866,412,ls),
+(901,584,o),
+(796,702,o),
+(612,702,cs),
+(445,702,o),
+(331,608,o),
+(294,432,cs),
+(218,77,l),
+(257,88,l),
+(83,260,l),
+(17,195,l),
+(213,0,l)
+);
+}
+);
+width = 888;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+},
+{
+color = 11;
+glyphname = "roWestCree-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(487,-13,o),
+(602,82,o),
+(639,258,cs),
+(715,612,l),
+(675,602,l),
+(850,430,l),
+(916,495,l),
+(720,690,l),
+(635,690,l),
+(547,277,ls),
+(518,142,o),
+(443,74,o),
+(326,74,cs),
+(201,74,o),
+(135,151,o),
+(161,272,cs),
+(168,303,l),
+(72,303,l),
+(67,277,ls),
+(31,105,o),
+(136,-13,o),
+(321,-13,cs)
+);
+}
+);
+width = 888;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+},
+{
+color = 11;
+glyphname = "raWestCree-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(680,-13,o),
+(795,81,o),
+(832,258,cs),
+(841,303,l),
+(747,303,l),
+(738,266,ls),
+(711,139,o),
+(639,74,o),
+(525,74,cs),
+(390,74,o),
+(330,159,o),
+(362,307,cs),
+(443,690,l),
+(358,690,l),
+(80,495,l),
+(130,424,l),
+(363,586,l),
+(331,612,l),
+(267,311,ls),
+(225,114,o),
+(324,-13,o),
+(518,-13,cs)
+);
+}
+);
+width = 887;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+},
+{
+color = 11;
+glyphname = "theThCree-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (186,690);
+},
+{
+name = top_right_can;
+pos = (695,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(595,0,l),
+(609,64,l),
+(692,64,l),
+(702,111,l),
+(619,111,l),
+(650,257,l),
+(211,257,l),
+(220,231,l),
+(737,631,l),
+(682,701,l),
+(34,203,l),
+(28,173,l),
+(536,173,l),
+(524,111,l),
+(285,111,l),
+(275,64,l),
+(513,64,l),
+(499,0,l)
+);
+}
+);
+width = 762;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15A7;
+},
+{
+color = 11;
+glyphname = "thiThCree-canadian.square";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (252,690);
+},
+{
+name = top_right_can;
+pos = (760,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(162,0,l),
+(176,64,l),
+(413,64,l),
+(423,111,l),
+(186,111,l),
+(199,173,l),
+(707,173,l),
+(714,203,l),
+(260,701,l),
+(188,638,l),
+(557,226,l),
+(571,257,l),
+(121,257,l),
+(90,111,l),
+(7,111,l),
+(-4,64,l),
+(79,64,l),
+(66,0,l)
+);
+}
+);
+width = 764;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+},
+{
+color = 11;
+glyphname = "thiiThCree-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (82,0);
+ref = dot_top;
+}
+);
+width = 762;
+}
+);
+note = uni15A9;
+},
+{
+color = 11;
+glyphname = "thoThCree-canadian.square";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (186,690);
+},
+{
+name = top_right_can;
+pos = (695,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(619,52,l),
+(251,464,l),
+(238,433,l),
+(688,433,l),
+(719,579,l),
+(802,579,l),
+(811,626,l),
+(728,626,l),
+(742,690,l),
+(645,690,l),
+(633,626,l),
+(395,626,l),
+(385,579,l),
+(622,579,l),
+(609,517,l),
+(101,517,l),
+(95,487,l),
+(548,-12,l)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+},
+{
+color = 11;
+glyphname = "thooThCree-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (525,0);
+ref = dot_top;
+}
+);
+width = 762;
+}
+);
+note = uni15AB;
+},
+{
+color = 11;
+glyphname = "thaThCree-canadian.square";
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (261,690);
+},
+{
+name = top_right_can;
+pos = (769,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(774,487,l),
+(781,517,l),
+(271,517,l),
+(285,579,l),
+(523,579,l),
+(533,626,l),
+(296,626,l),
+(308,690,l),
+(213,690,l),
+(199,626,l),
+(116,626,l),
+(105,579,l),
+(188,579,l),
+(157,433,l),
+(597,433,l),
+(587,459,l),
+(71,59,l),
+(126,-12,l)
+);
+}
+);
+width = 764;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+},
+{
+color = 11;
+glyphname = "thaaThCree-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (91,0);
+ref = dot_top;
+}
+);
+width = 762;
+}
+);
+note = uni15AD;
+},
+{
+color = 11;
+glyphname = "thweeWoodScree-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (762,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 987;
+}
+);
+note = uni1677;
+},
+{
+color = 11;
+glyphname = "thwiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (762,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 987;
+}
+);
+note = uni1678;
+},
+{
+color = 11;
+glyphname = "thwiiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (82,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (762,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 987;
+}
+);
+note = uni1679;
+},
+{
+color = 11;
+glyphname = "thwoWoodScree-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (762,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 987;
+}
+);
+note = uni167A;
+},
+{
+color = 11;
+glyphname = "thwooWoodScree-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (525,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (762,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 987;
+}
+);
+note = uni167B;
+},
+{
+color = 11;
+glyphname = "thwaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (762,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 987;
+}
+);
+note = uni167C;
+},
+{
+color = 11;
+glyphname = "thwaaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (91,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (762,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 987;
+}
+);
+note = uni167D;
+},
+{
+color = 11;
+glyphname = "nwiOjibway-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (750,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni18C7;
+},
+{
+color = 11;
+glyphname = "nwiiOjibway-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (237,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (750,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni18C9;
+},
+{
+color = 11;
+glyphname = "nwoOjibway-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (750,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni18CB;
+},
+{
+color = 11;
+glyphname = "nwooOjibway-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (366,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (750,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni18CD;
+},
+{
+color = 11;
+glyphname = "looWestCree-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+}
+);
+width = 675;
+}
+);
+note = uni18E1;
+},
+{
+color = 11;
+glyphname = "laaWestCree-canadian.square";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (478,0);
+ref = dot_top;
+}
+);
+width = 675;
+}
+);
+note = uni18E2;
+},
+{
+color = 0;
+glyphname = zero;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(558,552,o),
+(501,700,o),
+(329,700,cs),
+(156,700,o),
+(99,542,o),
+(99,346,cs),
+(99,108,o),
+(180,-10,o),
+(328,-10,cs),
+(484,-10,o),
+(558,106,o),
+(558,346,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(196,467,o),
+(213,620,o),
+(329,620,cs),
+(452,620,o),
+(461,460,o),
+(461,346,cs),
+(461,192,o),
+(432,71,o),
+(328,71,cs),
+(230,71,o),
+(196,191,o),
+(196,346,cs)
+);
+}
+);
+width = 615;
+}
+);
+unicode = 48;
+},
+{
+color = 0;
+glyphname = one;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(288,690,l),
+(77,527,l),
+(129,463,l),
+(230,540,ls),
+(250,555,o),
+(263,568,o),
+(278,583,c),
+(277,552,o),
+(276,523,o),
+(276,492,cs),
+(276,0,l),
+(376,0,l),
+(376,690,l)
+);
+}
+);
+width = 495;
+}
+);
+unicode = 49;
+},
+{
+color = 0;
+glyphname = two;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(562,0,l),
+(562,82,l),
+(234,82,l),
+(234,85,l),
+(367,222,ls),
+(441,295,o),
+(493,350,o),
+(520,412,cs),
+(532,442,o),
+(538,477,o),
+(538,517,cs),
+(538,626,o),
+(456,699,o),
+(334,699,cs),
+(245,699,o),
+(179,668,o),
+(115,613,c),
+(169,549,l),
+(223,594,o),
+(274,615,o),
+(325,615,cs),
+(395,615,o),
+(441,577,o),
+(441,504,cs),
+(441,450,o),
+(423,409,o),
+(383,359,cs),
+(361,334,o),
+(335,304,o),
+(302,270,cs),
+(107,68,l),
+(107,0,l)
+);
+}
+);
+width = 611;
+}
+);
+unicode = 50;
+},
+{
+color = 0;
+glyphname = three;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(543,639,o),
+(462,699,o),
+(335,699,cs),
+(235,699,o),
+(167,670,o),
+(110,629,c),
+(153,561,l),
+(198,594,o),
+(256,619,o),
+(323,619,cs),
+(398,619,o),
+(448,586,o),
+(448,516,cs),
+(448,429,o),
+(364,394,o),
+(275,394,cs),
+(212,394,l),
+(212,318,l),
+(275,318,ls),
+(391,318,o),
+(461,288,o),
+(461,197,cs),
+(461,120,o),
+(411,70,o),
+(293,70,cs),
+(231,70,o),
+(160,87,o),
+(105,114,c),
+(105,30,l),
+(159,7,o),
+(222,-10,o),
+(304,-10,cs),
+(461,-10,o),
+(564,65,o),
+(564,191,cs),
+(564,293,o),
+(502,347,o),
+(394,360,c),
+(394,362,l),
+(479,382,o),
+(543,443,o),
+(543,536,cs)
+);
+}
+);
+width = 611;
+}
+);
+unicode = 51;
+},
+{
+color = 0;
+glyphname = four;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(453,239,l),
+(453,692,l),
+(360,692,l),
+(34,235,l),
+(34,163,l),
+(356,163,l),
+(356,0,l),
+(453,0,l),
+(453,163,l),
+(558,163,l),
+(558,239,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(125,239,l),
+(305,489,ls),
+(328,522,o),
+(338,537,o),
+(355,569,c),
+(358,569,l),
+(358,554,o),
+(356,520,o),
+(356,474,cs),
+(356,239,l)
+);
+}
+);
+width = 585;
+}
+);
+unicode = 52;
+},
+{
+color = 0;
+glyphname = five;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(267,430,o),
+(235,421,o),
+(208,415,c),
+(225,607,l),
+(497,607,l),
+(497,690,l),
+(142,690,l),
+(114,355,l),
+(156,332,l),
+(193,344,o),
+(233,352,o),
+(281,352,cs),
+(387,352,o),
+(440,301,o),
+(440,216,cs),
+(440,123,o),
+(376,70,o),
+(273,70,cs),
+(209,70,o),
+(142,90,o),
+(97,114,c),
+(97,30,l),
+(142,6,o),
+(204,-10,o),
+(280,-10,cs),
+(447,-10,o),
+(540,76,o),
+(540,218,cs),
+(540,353,o),
+(453,430,o),
+(324,430,cs)
+);
+}
+);
+width = 585;
+}
+);
+unicode = 53;
+},
+{
+color = 0;
+glyphname = six;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(85,128,o),
+(160,-10,o),
+(325,-10,cs),
+(464,-10,o),
+(548,80,o),
+(548,226,cs),
+(548,359,o),
+(474,440,o),
+(350,440,cs),
+(263,440,o),
+(205,398,o),
+(178,342,c),
+(174,342,l),
+(180,508,o),
+(241,622,o),
+(405,622,cs),
+(447,622,o),
+(478,617,o),
+(503,611,c),
+(503,690,l),
+(477,696,o),
+(440,700,o),
+(407,700,cs),
+(170,700,o),
+(85,528,o),
+(85,293,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(219,70,o),
+(185,170,o),
+(185,245,cs),
+(185,309,o),
+(253,362,o),
+(327,362,cs),
+(412,362,o),
+(453,310,o),
+(453,224,cs),
+(453,127,o),
+(406,70,o),
+(324,70,cs)
+);
+}
+);
+width = 591;
+}
+);
+unicode = 54;
+},
+{
+color = 0;
+glyphname = seven;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(579,631,l),
+(579,690,l),
+(115,690,l),
+(115,607,l),
+(473,607,l),
+(210,0,l),
+(311,0,l)
+);
+}
+);
+width = 603;
+}
+);
+unicode = 55;
+},
+{
+color = 0;
+glyphname = eight;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(464,-10,o),
+(560,57,o),
+(560,179,cs),
+(560,274,o),
+(490,329,o),
+(397,366,c),
+(482,403,o),
+(538,453,o),
+(538,537,cs),
+(538,642,o),
+(456,699,o),
+(331,699,cs),
+(207,699,o),
+(122,639,o),
+(122,536,cs),
+(122,444,o),
+(189,397,o),
+(257,364,c),
+(164,328,o),
+(100,275,o),
+(100,175,cs),
+(100,66,o),
+(183,-10,o),
+(327,-10,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(245,64,o),
+(192,108,o),
+(192,178,cs),
+(192,257,o),
+(259,297,o),
+(328,322,c),
+(419,286,o),
+(469,244,o),
+(469,180,cs),
+(469,104,o),
+(413,64,o),
+(327,64,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(262,437,o),
+(215,470,o),
+(215,528,cs),
+(215,591,o),
+(265,626,o),
+(330,626,cs),
+(401,626,o),
+(445,592,o),
+(445,529,cs),
+(445,471,o),
+(403,440,o),
+(331,409,c)
+);
+}
+);
+width = 614;
+}
+);
+unicode = 56;
+},
+{
+color = 0;
+glyphname = nine;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(559,567,o),
+(486,699,o),
+(321,699,cs),
+(182,699,o),
+(97,611,o),
+(97,466,cs),
+(97,331,o),
+(170,249,o),
+(293,249,cs),
+(380,249,o),
+(440,291,o),
+(467,349,c),
+(470,349,l),
+(465,175,o),
+(395,68,o),
+(235,68,cs),
+(197,68,o),
+(162,72,o),
+(138,79,c),
+(138,-2,l),
+(164,-8,o),
+(205,-11,o),
+(239,-11,cs),
+(475,-11,o),
+(559,164,o),
+(559,394,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(427,619,o),
+(459,517,o),
+(459,445,cs),
+(459,382,o),
+(389,327,o),
+(319,327,cs),
+(235,327,o),
+(192,382,o),
+(192,467,cs),
+(192,565,o),
+(239,619,o),
+(323,619,cs)
+);
+}
+);
+width = 615;
+}
+);
+unicode = 57;
+},
+{
+glyphname = zero.canadian;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(495,-12,o),
+(573,300,o),
+(573,466,cs),
+(573,615,o),
+(502,702,o),
+(375,702,cs),
+(146,702,o),
+(68,390,o),
+(68,226,cs),
+(68,75,o),
+(138,-12,o),
+(267,-12,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,75,o),
+(161,128,o),
+(161,225,cs),
+(161,336,o),
+(212,615,o),
+(368,615,cs),
+(441,615,o),
+(479,563,o),
+(479,466,cs),
+(479,355,o),
+(429,75,o),
+(272,75,cs)
+);
+}
+);
+width = 596;
+}
+);
+metricRight = "=|";
+},
+{
+glyphname = one.canadian;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(250,0,l),
+(397,690,l),
+(311,690,l),
+(82,528,l),
+(131,459,l),
+(353,613,l),
+(287,626,l),
+(154,0,l)
+);
+}
+);
+width = 377;
+}
+);
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = two.canadian;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(494,87,l),
+(157,87,l),
+(154,47,l),
+(416,266,ls),
+(511,343,o),
+(571,420,o),
+(571,524,cs),
+(571,630,o),
+(495,702,o),
+(371,702,cs),
+(233,702,o),
+(137,616,o),
+(102,452,c),
+(198,452,l),
+(221,563,o),
+(277,618,o),
+(363,618,cs),
+(436,618,o),
+(476,579,o),
+(476,517,cs),
+(476,437,o),
+(422,377,o),
+(347,316,cs),
+(43,65,l),
+(29,0,l),
+(475,0,l)
+);
+}
+);
+width = 581;
+}
+);
+note = uni14BF;
+},
+{
+glyphname = three.canadian;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(435,-13,o),
+(522,83,o),
+(522,210,cs),
+(522,285,o),
+(481,338,o),
+(412,355,c),
+(404,324,l),
+(520,336,o),
+(582,432,o),
+(582,530,cs),
+(582,630,o),
+(505,702,o),
+(376,702,cs),
+(235,702,o),
+(141,621,o),
+(114,467,c),
+(209,467,l),
+(229,567,o),
+(281,618,o),
+(367,618,cs),
+(441,618,o),
+(485,580,o),
+(485,517,cs),
+(485,443,o),
+(441,385,o),
+(351,385,cs),
+(311,385,l),
+(295,304,l),
+(334,304,ls),
+(396,304,o),
+(428,273,o),
+(428,217,cs),
+(428,138,o),
+(378,71,o),
+(281,71,cs),
+(181,71,o),
+(141,133,o),
+(154,223,c),
+(58,223,l),
+(42,86,o),
+(117,-13,o),
+(279,-13,cs)
+);
+}
+);
+width = 605;
+}
+);
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = four.canadian;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(404,0,l),
+(439,163,l),
+(539,163,l),
+(555,242,l),
+(455,242,l),
+(551,692,l),
+(472,692,l),
+(40,226,l),
+(26,163,l),
+(344,163,l),
+(309,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(476,600,l),
+(439,600,l),
+(362,242,l),
+(123,242,l),
+(127,219,l)
+);
+}
+);
+width = 587;
+}
+);
+},
+{
+glyphname = five.canadian;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(450,-13,o),
+(535,106,o),
+(535,236,cs),
+(535,344,o),
+(463,411,o),
+(341,411,cs),
+(211,411,l),
+(233,384,l),
+(307,635,l),
+(271,606,l),
+(591,606,l),
+(609,690,l),
+(231,690,l),
+(130,350,l),
+(147,327,l),
+(315,327,ls),
+(395,327,o),
+(440,293,o),
+(440,226,cs),
+(440,144,o),
+(389,71,o),
+(288,71,cs),
+(198,71,o),
+(148,122,o),
+(158,198,c),
+(64,198,l),
+(48,73,o),
+(138,-13,o),
+(286,-13,cs)
+);
+}
+);
+width = 601;
+}
+);
+},
+{
+glyphname = six.canadian;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,-13,o),
+(536,95,o),
+(536,233,cs),
+(536,345,o),
+(461,420,o),
+(341,420,cs),
+(253,420,o),
+(187,380,o),
+(149,300,c),
+(168,270,l),
+(170,301,o),
+(174,327,o),
+(182,365,cs),
+(213,520,o),
+(272,618,o),
+(381,618,cs),
+(469,618,o),
+(499,565,o),
+(497,495,c),
+(591,495,l),
+(600,615,o),
+(522,702,o),
+(385,702,cs),
+(146,702,o),
+(68,394,o),
+(68,222,cs),
+(68,159,o),
+(81,110,o),
+(106,72,cs),
+(141,19,o),
+(207,-13,o),
+(290,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(213,68,o),
+(164,113,o),
+(164,185,cs),
+(164,267,o),
+(220,340,o),
+(318,340,cs),
+(395,340,o),
+(443,297,o),
+(443,224,cs),
+(443,143,o),
+(388,68,o),
+(291,68,cs)
+);
+}
+);
+width = 591;
+}
+);
+metricLeft = zero.canadian;
+},
+{
+glyphname = seven.canadian;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(165,0,l),
+(538,631,l),
+(551,690,l),
+(126,690,l),
+(107,603,l),
+(438,603,l),
+(440,634,l),
+(74,26,l),
+(70,0,l)
+);
+}
+);
+width = 488;
+}
+);
+},
+{
+glyphname = eight.canadian;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(433,-13,o),
+(534,71,o),
+(537,195,cs),
+(540,272,o),
+(495,332,o),
+(418,353,c),
+(405,324,l),
+(514,332,o),
+(587,414,o),
+(590,519,cs),
+(593,628,o),
+(512,702,o),
+(376,702,cs),
+(238,702,o),
+(146,617,o),
+(143,495,cs),
+(140,420,o),
+(181,359,o),
+(253,336,c),
+(252,367,l),
+(134,357,o),
+(62,271,o),
+(60,172,cs),
+(56,63,o),
+(147,-13,o),
+(290,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(202,67,o),
+(153,107,o),
+(155,173,cs),
+(156,255,o),
+(215,306,o),
+(305,306,cs),
+(396,306,o),
+(445,266,o),
+(443,200,cs),
+(442,120,o),
+(384,67,o),
+(293,67,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(280,384,o),
+(235,425,o),
+(236,491,cs),
+(237,566,o),
+(286,623,o),
+(373,623,cs),
+(450,623,o),
+(496,582,o),
+(495,517,cs),
+(494,441,o),
+(445,384,o),
+(357,384,cs)
+);
+}
+);
+width = 621;
+}
+);
+metricLeft = "=|";
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = nine.canadian;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(491,-13,o),
+(569,296,o),
+(569,468,cs),
+(569,530,o),
+(556,580,o),
+(531,617,cs),
+(496,670,o),
+(430,702,o),
+(348,702,cs),
+(197,702,o),
+(100,595,o),
+(100,457,cs),
+(100,345,o),
+(176,270,o),
+(297,270,cs),
+(384,270,o),
+(449,310,o),
+(489,389,c),
+(470,420,l),
+(467,388,o),
+(463,362,o),
+(456,325,cs),
+(424,170,o),
+(364,71,o),
+(256,71,cs),
+(168,71,o),
+(138,125,o),
+(140,195,c),
+(45,195,l),
+(37,74,o),
+(115,-13,o),
+(252,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(242,350,o),
+(194,393,o),
+(194,466,cs),
+(194,547,o),
+(248,622,o),
+(346,622,cs),
+(424,622,o),
+(473,577,o),
+(473,505,cs),
+(473,423,o),
+(416,350,o),
+(320,350,cs)
+);
+}
+);
+width = 592;
+}
+);
+metricLeft = "=|six.canadian";
+metricRight = "=|six.canadian";
+},
+{
+glyphname = CR;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+width = 258;
+}
+);
+note = CR;
+unicode = 13;
+},
+{
+color = 0;
+glyphname = .notdef;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(583,690,l),
+(186,690,l),
+(186,0,l),
+(583,0,l),
+(583,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(534,640,l),
+(534,49,l),
+(236,49,l),
+(236,640,l),
+(236,640,l)
+);
+}
+);
+width = 675;
+}
+);
+note = ".notdef";
+},
+{
+glyphname = .null;
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+width = 0;
+}
+);
+note = NULL;
+},
+{
+glyphname = space;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+width = 259;
+}
+);
+note = space;
+unicode = 32;
+},
+{
+glyphname = nbspace;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+width = 258;
+}
+);
+note = uni00A0;
+unicode = 160;
+},
+{
+glyphname = space.canadian;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+width = 505;
+}
+);
+note = space;
+},
+{
+glyphname = "hyphen-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(416,395,l),
+(428,452,l),
+(109,452,l),
+(98,395,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(387,258,l),
+(399,315,l),
+(80,315,l),
+(68,258,l)
+);
+}
+);
+width = 447;
+}
+);
+metricRight = "=|";
+note = uni1400;
+unicode = 5120;
+},
+{
+glyphname = "chi-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(95,0,l),
+(316,295,l),
+(275,301,l),
+(376,0,l),
+(460,0,l),
+(466,26,l),
+(341,385,l),
+(330,311,l),
+(599,664,l),
+(605,690,l),
+(508,690,l),
+(294,402,l),
+(333,396,l),
+(235,690,l),
+(151,690,l),
+(145,664,l),
+(268,314,l),
+(279,388,l),
+(5,26,l),
+(-1,0,l)
+);
+}
+);
+width = 561;
+}
+);
+metricRight = "=|";
+note = uni166D;
+unicode = 5741;
+},
+{
+glyphname = "fullstop-canadian";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(68,0,l),
+(164,131,l),
+(149,134,l),
+(193,0,l),
+(249,0,l),
+(251,13,l),
+(189,189,l),
+(185,156,l),
+(318,331,l),
+(322,345,l),
+(258,345,l),
+(161,213,l),
+(180,210,l),
+(135,345,l),
+(79,345,l),
+(75,331,l),
+(136,162,l),
+(142,192,l),
+(6,13,l),
+(4,0,l)
+);
+}
+);
+width = 355;
+}
+);
+note = uni1541;
+unicode = 5742;
+},
+{
+glyphname = period;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(16,13,o),
+(36,-10,o),
+(77,-10,cs),
+(110,-10,o),
+(131,13,o),
+(137,48,cs),
+(143,83,o),
+(125,104,o),
+(82,104,cs),
+(46,104,o),
+(27,81,o),
+(22,46,cs)
+);
+}
+);
+width = 237;
+}
+);
+note = period;
+unicode = 46;
+},
+{
+glyphname = comma;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(20,-128,l),
+(67,-58,o),
+(112,41,o),
+(144,114,c),
+(141,125,l),
+(56,125,l),
+(30,50,o),
+(-5,-35,o),
+(-49,-128,c)
+);
+}
+);
+width = 224;
+}
+);
+note = comma;
+unicode = 44;
+},
+{
+glyphname = hyphen;
+kernLeft = hyphen;
+kernRight = hyphen;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(256,221,l),
+(272,300,l),
+(44,300,l),
+(28,221,l)
+);
+}
+);
+width = 292;
+}
+);
+unicode = 45;
+},
+{
+glyphname = quotesinglbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-42,-565);
+ref = quoteright;
+}
+);
+width = 236;
+}
+);
+unicode = 8218;
+},
+{
+glyphname = quotedblbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-89,-565);
+ref = quotedblright;
+}
+);
+width = 444;
+}
+);
+unicode = 8222;
+},
+{
+glyphname = quotedblleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(334,436,l),
+(357,512,o),
+(397,606,o),
+(442,690,c),
+(375,690,l),
+(327,618,o),
+(281,526,o),
+(248,444,c),
+(252,436,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(154,436,l),
+(178,512,o),
+(216,605,o),
+(262,690,c),
+(195,690,l),
+(146,618,o),
+(101,526,o),
+(68,444,c),
+(71,436,l)
+);
+}
+);
+width = 371;
+}
+);
+unicode = 8220;
+},
+{
+glyphname = quotedblright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(313,436,l),
+(363,507,o),
+(409,601,o),
+(440,680,c),
+(437,690,l),
+(355,690,l),
+(331,613,o),
+(292,519,o),
+(246,436,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(132,436,l),
+(183,507,o),
+(228,601,o),
+(260,680,c),
+(256,690,l),
+(174,690,l),
+(151,613,o),
+(111,519,o),
+(66,436,c)
+);
+}
+);
+width = 371;
+}
+);
+unicode = 8221;
+},
+{
+glyphname = quoteleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(155,436,l),
+(179,512,o),
+(218,606,o),
+(264,690,c),
+(195,690,l),
+(147,618,o),
+(101,526,o),
+(68,444,c),
+(71,436,l)
+);
+}
+);
+width = 192;
+}
+);
+unicode = 8216;
+},
+{
+glyphname = quoteright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(134,436,l),
+(184,507,o),
+(230,601,o),
+(262,680,c),
+(258,690,l),
+(175,690,l),
+(151,613,o),
+(111,519,o),
+(66,436,c)
+);
+}
+);
+width = 192;
+}
+);
+unicode = 8217;
+},
+{
+glyphname = dottedCircle;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(203,504,o),
+(190,494,o),
+(190,479,cs),
+(190,467,o),
+(203,454,o),
+(215,454,cs),
+(230,454,o),
+(241,467,o),
+(241,479,cs),
+(241,494,o),
+(230,504,o),
+(215,504,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(365,504,o),
+(353,494,o),
+(353,479,cs),
+(353,467,o),
+(365,454,o),
+(378,454,cs),
+(392,454,o),
+(403,467,o),
+(403,479,cs),
+(403,494,o),
+(392,504,o),
+(378,504,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(203,108,o),
+(190,98,o),
+(190,83,cs),
+(190,71,o),
+(203,58,o),
+(215,58,cs),
+(230,58,o),
+(241,71,o),
+(241,83,cs),
+(241,98,o),
+(230,108,o),
+(215,108,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(365,108,o),
+(353,98,o),
+(353,83,cs),
+(353,71,o),
+(365,58,o),
+(378,58,cs),
+(392,58,o),
+(403,71,o),
+(403,83,cs),
+(403,98,o),
+(392,108,o),
+(378,108,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(284,522,o),
+(271,511,o),
+(271,497,cs),
+(271,484,o),
+(284,471,o),
+(297,471,cs),
+(311,471,o),
+(322,484,o),
+(322,497,cs),
+(322,511,o),
+(311,522,o),
+(297,522,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(284,91,o),
+(271,80,o),
+(271,66,cs),
+(271,53,o),
+(284,41,o),
+(297,41,cs),
+(311,41,o),
+(322,53,o),
+(322,66,cs),
+(322,80,o),
+(311,91,o),
+(297,91,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(56,269,o),
+(69,256,o),
+(81,256,cs),
+(96,256,o),
+(106,269,o),
+(106,281,cs),
+(106,296,o),
+(96,306,o),
+(81,306,cs),
+(69,306,o),
+(56,296,o),
+(56,281,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(487,269,o),
+(499,256,o),
+(512,256,cs),
+(526,256,o),
+(537,269,o),
+(537,281,cs),
+(537,296,o),
+(526,306,o),
+(512,306,cs),
+(499,306,o),
+(487,296,o),
+(487,281,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(119,116,o),
+(131,103,o),
+(144,103,cs),
+(158,103,o),
+(169,116,o),
+(169,128,cs),
+(169,143,o),
+(158,154,o),
+(144,154,cs),
+(131,154,o),
+(119,143,o),
+(119,128,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(119,421,o),
+(131,409,o),
+(144,409,cs),
+(158,409,o),
+(169,421,o),
+(169,434,cs),
+(169,448,o),
+(158,459,o),
+(144,459,cs),
+(131,459,o),
+(119,448,o),
+(119,434,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(424,116,o),
+(437,103,o),
+(449,103,cs),
+(464,103,o),
+(474,116,o),
+(474,128,cs),
+(474,143,o),
+(464,154,o),
+(449,154,cs),
+(437,154,o),
+(424,143,o),
+(424,128,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(424,421,o),
+(437,409,o),
+(449,409,cs),
+(464,409,o),
+(474,421,o),
+(474,434,cs),
+(474,448,o),
+(464,459,o),
+(449,459,cs),
+(437,459,o),
+(424,448,o),
+(424,434,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(73,187,o),
+(86,175,o),
+(99,175,cs),
+(113,175,o),
+(124,187,o),
+(124,200,cs),
+(124,214,o),
+(113,225,o),
+(99,225,cs),
+(86,225,o),
+(73,214,o),
+(73,200,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(73,350,o),
+(86,337,o),
+(99,337,cs),
+(113,337,o),
+(124,350,o),
+(124,362,cs),
+(124,377,o),
+(113,387,o),
+(99,387,cs),
+(86,387,o),
+(73,377,o),
+(73,362,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(469,187,o),
+(482,175,o),
+(495,175,cs),
+(509,175,o),
+(520,187,o),
+(520,200,cs),
+(520,214,o),
+(509,225,o),
+(495,225,cs),
+(482,225,o),
+(469,214,o),
+(469,200,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(469,350,o),
+(482,337,o),
+(495,337,cs),
+(509,337,o),
+(520,350,o),
+(520,362,cs),
+(520,377,o),
+(509,387,o),
+(495,387,cs),
+(482,387,o),
+(469,377,o),
+(469,362,cs)
+);
+}
+);
+width = 583;
+}
+);
+note = uni25CC;
+unicode = 9676;
+},
+{
+glyphname = dotaccentcomb;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(151,720,o),
+(132,704,o),
+(127,670,cs),
+(119,634,o),
+(137,614,o),
+(177,614,cs),
+(212,614,o),
+(230,630,o),
+(236,663,cs),
+(243,700,o),
+(226,720,o),
+(185,720,cs)
+);
+}
+);
+width = 181;
+}
+);
+note = uni0307;
+unicode = 775;
+},
+{
+glyphname = dotaccent;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(215,614,o),
+(233,635,o),
+(238,667,cs),
+(243,700,o),
+(226,720,o),
+(185,720,cs),
+(150,720,o),
+(132,701,o),
+(128,668,cs),
+(121,634,o),
+(138,614,o),
+(178,614,cs)
+);
+}
+);
+width = 183;
+}
+);
+note = dotaccent;
+unicode = 729;
+},
+{
+glyphname = caron;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(339,623,o),
+(390,677,o),
+(444,729,c),
+(447,738,l),
+(378,738,l),
+(340,710,o),
+(303,676,o),
+(268,639,c),
+(246,675,o),
+(226,710,o),
+(201,738,c),
+(142,738,l),
+(139,729,l),
+(168,687,o),
+(197,636,o),
+(214,585,c),
+(308,585,l),
+(308,585,l)
+);
+}
+);
+width = 377;
+}
+);
+note = caron;
+unicode = 711;
+},
+{
+glyphname = breve;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(343,585,o),
+(396,632,o),
+(420,723,c),
+(361,723,l),
+(343,672,o),
+(313,648,o),
+(265,648,cs),
+(214,648,o),
+(192,673,o),
+(194,723,c),
+(138,723,l),
+(127,639,o),
+(174,585,o),
+(262,585,cs)
+);
+}
+);
+width = 353;
+}
+);
+note = breve;
+unicode = 728;
+},
+{
+glyphname = ring;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(291,587,o),
+(336,630,o),
+(336,695,cs),
+(336,755,o),
+(291,801,o),
+(234,801,cs),
+(176,801,o),
+(132,757,o),
+(132,694,cs),
+(132,629,o),
+(177,587,o),
+(234,587,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(202,636,o),
+(182,662,o),
+(182,694,cs),
+(182,727,o),
+(205,753,o),
+(234,753,cs),
+(262,753,o),
+(286,727,o),
+(286,694,cs),
+(286,662,o),
+(264,636,o),
+(234,636,cs)
+);
+}
+);
+width = 276;
+}
+);
+note = ring;
+unicode = 730;
+},
+{
+glyphname = ogonek;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(55,-219,o),
+(75,-216,o),
+(94,-210,c),
+(107,-151,l),
+(94,-156,o),
+(74,-159,o),
+(62,-159,cs),
+(35,-159,o),
+(22,-144,o),
+(26,-116,cs),
+(30,-78,o),
+(56,-46,o),
+(119,0,c),
+(81,16,l),
+(4,-31,o),
+(-36,-78,o),
+(-43,-129,cs),
+(-50,-183,o),
+(-18,-219,o),
+(36,-219,cs)
+);
+}
+);
+width = 226;
+}
+);
+note = ogonek;
+unicode = 731;
+},
+{
+glyphname = ring_top.canadian;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (220,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(312,757,o),
+(360,799,o),
+(360,859,cs),
+(360,919,o),
+(312,961,o),
+(256,961,cs),
+(199,961,o),
+(152,919,o),
+(152,859,cs),
+(152,799,o),
+(199,757,o),
+(256,757,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(221,802,o),
+(200,827,o),
+(200,859,cs),
+(200,891,o),
+(223,916,o),
+(256,916,cs),
+(290,916,o),
+(312,891,o),
+(312,859,cs),
+(312,827,o),
+(290,802,o),
+(256,802,cs)
+);
+}
+);
+width = 249;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (96,345);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(127,291,o),
+(151,314,o),
+(151,345,cs),
+(151,376,o),
+(127,399,o),
+(96,399,cs),
+(66,399,o),
+(42,376,o),
+(42,345,cs),
+(42,314,o),
+(66,291,o),
+(96,291,cs)
+);
+}
+);
+width = 147;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (87,345);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(113,298,o),
+(133,319,o),
+(133,345,cs),
+(133,371,o),
+(113,391,o),
+(87,391,cs),
+(61,391,o),
+(41,371,o),
+(41,345,cs),
+(41,319,o),
+(61,298,o),
+(87,298,cs)
+);
+}
+);
+width = 129;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_small;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (78,345);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,307,o),
+(116,324,o),
+(116,345,cs),
+(116,366,o),
+(99,383,o),
+(78,383,cs),
+(57,383,o),
+(41,366,o),
+(41,345,cs),
+(41,324,o),
+(57,307,o),
+(78,307,cs)
+);
+}
+);
+width = 112;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_top;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (169,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(231,780,o),
+(255,804,o),
+(255,835,cs),
+(255,865,o),
+(231,889,o),
+(200,889,cs),
+(169,889,o),
+(145,865,o),
+(145,835,cs),
+(145,804,o),
+(169,780,o),
+(200,780,cs)
+);
+}
+);
+width = 147;
+}
+);
+note = g725;
+},
+{
+glyphname = doubledot_middle;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(185,382,o),
+(209,406,o),
+(209,436,cs),
+(209,467,o),
+(185,491,o),
+(154,491,cs),
+(124,491,o),
+(99,467,o),
+(99,436,cs),
+(99,405,o),
+(124,382,o),
+(154,382,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(146,199,o),
+(170,223,o),
+(170,254,cs),
+(170,284,o),
+(146,308,o),
+(115,308,cs),
+(84,308,o),
+(60,285,o),
+(60,254,cs),
+(60,223,o),
+(84,199,o),
+(115,199,cs)
+);
+}
+);
+width = 224;
+}
+);
+metricRight = "=|";
+note = g725;
+},
+{
+glyphname = doubledot_top;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top_double;
+pos = (337,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(398,780,o),
+(423,804,o),
+(423,835,cs),
+(423,865,o),
+(398,889,o),
+(368,889,cs),
+(337,889,o),
+(313,865,o),
+(313,835,cs),
+(313,804,o),
+(337,780,o),
+(368,780,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(224,780,o),
+(248,804,o),
+(248,835,cs),
+(248,865,o),
+(224,889,o),
+(194,889,cs),
+(163,889,o),
+(139,865,o),
+(139,835,cs),
+(139,804,o),
+(163,780,o),
+(194,780,cs)
+);
+}
+);
+width = 309;
+}
+);
+note = g725;
+},
+{
+glyphname = g727;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (440,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(561,0,l),
+(579,80,l),
+(265,80,ls),
+(188,80,o),
+(149,110,o),
+(149,168,cs),
+(149,251,o),
+(204,305,o),
+(310,305,cs),
+(423,305,ls),
+(591,305,o),
+(682,387,o),
+(682,528,cs),
+(682,628,o),
+(614,690,o),
+(500,690,cs),
+(171,690,l),
+(155,610,l),
+(471,610,ls),
+(548,610,o),
+(586,580,o),
+(586,522,cs),
+(586,438,o),
+(532,384,o),
+(425,384,cs),
+(313,384,ls),
+(144,384,o),
+(53,301,o),
+(53,162,cs),
+(53,63,o),
+(122,0,o),
+(236,0,cs)
+);
+}
+);
+width = 690;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+glyphname = g728;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (271,0);
+ref = dot_top;
+}
+);
+width = 691;
+}
+);
+note = g728;
+},
+{
+glyphname = g729;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (464,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(356,0,ls),
+(527,0,o),
+(617,83,o),
+(617,227,cs),
+(617,326,o),
+(551,384,o),
+(436,384,cs),
+(327,384,ls),
+(251,384,o),
+(213,412,o),
+(213,469,cs),
+(213,555,o),
+(265,610,o),
+(374,610,cs),
+(691,610,l),
+(708,690,l),
+(376,690,ls),
+(209,690,o),
+(117,608,o),
+(117,464,cs),
+(117,364,o),
+(184,305,o),
+(298,305,cs),
+(406,305,ls),
+(483,305,o),
+(522,277,o),
+(522,221,cs),
+(522,134,o),
+(468,80,o),
+(357,80,cs),
+(40,80,l),
+(23,0,l)
+);
+}
+);
+width = 689;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+glyphname = g730;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (295,0);
+ref = dot_top;
+}
+);
+width = 691;
+}
+);
+note = g730;
+},
+{
+glyphname = g731;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = g727;
+}
+);
+width = 915;
+}
+);
+note = g731;
+},
+{
+glyphname = g732;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (691,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 915;
+}
+);
+note = g732;
+},
+{
+glyphname = g733;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (496,0);
+ref = dot_top;
+}
+);
+width = 915;
+}
+);
+note = g733;
+},
+{
+glyphname = g734;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (271,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (691,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 915;
+}
+);
+note = g734;
+},
+{
+glyphname = g735;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = g729;
+}
+);
+width = 915;
+}
+);
+note = g735;
+},
+{
+glyphname = g736;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (691,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 915;
+}
+);
+note = g736;
+},
+{
+glyphname = g737;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (519,0);
+ref = dot_top;
+}
+);
+width = 915;
+}
+);
+note = g737;
+},
+{
+glyphname = g738;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (295,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (691,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 915;
+}
+);
+note = g738;
+},
+{
+glyphname = g739;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(564,236,o),
+(614,310,o),
+(614,385,cs),
+(614,453,o),
+(569,497,o),
+(498,497,cs),
+(304,497,l),
+(327,470,l),
+(362,497,o),
+(378,549,o),
+(378,585,cs),
+(378,652,o),
+(332,696,o),
+(261,696,cs),
+(174,696,o),
+(124,621,o),
+(124,547,cs),
+(124,479,o),
+(169,435,o),
+(239,435,cs),
+(434,435,l),
+(411,462,l),
+(374,434,o),
+(360,382,o),
+(360,347,cs),
+(360,280,o),
+(406,236,o),
+(476,236,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(205,485,o),
+(184,509,o),
+(184,546,cs),
+(184,591,o),
+(211,645,o),
+(260,645,cs),
+(296,645,o),
+(318,621,o),
+(318,584,cs),
+(318,540,o),
+(291,485,o),
+(241,485,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(442,287,o),
+(420,311,o),
+(420,348,cs),
+(420,392,o),
+(446,447,o),
+(497,447,cs),
+(532,447,o),
+(554,422,o),
+(554,386,cs),
+(554,341,o),
+(527,287,o),
+(477,287,cs)
+);
+}
+);
+width = 642;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+glyphname = g740;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (220,0);
+ref = ring_top.canadian;
+}
+);
+width = 691;
+}
+);
+note = g740;
+},
+{
+glyphname = g741;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (244,0);
+ref = ring_top.canadian;
+}
+);
+width = 691;
+}
+);
+note = g741;
+},
+{
+glyphname = g742;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (444,0);
+ref = ring_top.canadian;
+}
+);
+width = 915;
+}
+);
+note = g742;
+},
+{
+glyphname = stroke_middle;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (71,345);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(76,233,l),
+(124,458,l),
+(65,458,l),
+(17,233,l)
+);
+}
+);
+width = 97;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (64,345);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(69,258,l),
+(105,432,l),
+(59,432,l),
+(22,258,l)
+);
+}
+);
+width = 83;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_small;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (60,345);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(61,263,l),
+(96,427,l),
+(58,427,l),
+(23,263,l)
+);
+}
+);
+width = 74;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_threequart;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (71,345);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(76,235,l),
+(123,455,l),
+(66,455,l),
+(18,235,l)
+);
+}
+);
+width = 97;
+}
+);
+note = g723;
+},
+{
+color = 8;
+glyphname = uni11AB0;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (257,690);
+},
+{
+name = top_right_can;
+pos = (552,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(158,0,l),
+(181,102,l),
+(418,102,l),
+(430,158,l),
+(192,158,l),
+(218,279,l),
+(142,246,l),
+(182,246,ls),
+(389,246,o),
+(527,352,o),
+(577,584,cs),
+(599,690,l),
+(503,690,l),
+(482,593,ls),
+(444,420,o),
+(343,332,o),
+(186,332,cs),
+(133,332,l),
+(97,158,l),
+(16,158,l),
+(5,102,l),
+(84,102,l),
+(63,0,l)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB1;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB0;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (381,0);
+ref = dot_top;
+}
+);
+width = 576;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB2;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (216,690);
+},
+{
+name = top_right_can;
+pos = (511,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(119,0,l),
+(140,97,ls),
+(178,270,o),
+(279,357,o),
+(437,357,cs),
+(489,357,l),
+(526,531,l),
+(605,531,l),
+(617,587,l),
+(538,587,l),
+(559,690,l),
+(463,690,l),
+(441,587,l),
+(204,587,l),
+(192,531,l),
+(429,531,l),
+(404,411,l),
+(480,443,l),
+(440,443,ls),
+(232,443,o),
+(96,338,o),
+(45,105,cs),
+(22,0,l)
+);
+}
+);
+width = 576;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "theThCree-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB3;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB2;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (342,0);
+ref = dot_top;
+}
+);
+width = 576;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB4;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (257,690);
+},
+{
+name = top_right_can;
+pos = (552,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(452,0,l),
+(474,101,ls),
+(519,310,o),
+(413,443,o),
+(198,443,cs),
+(177,443,l),
+(246,412,l),
+(271,531,l),
+(509,531,l),
+(521,587,l),
+(283,587,l),
+(305,690,l),
+(209,690,l),
+(187,587,l),
+(107,587,l),
+(96,531,l),
+(175,531,l),
+(138,357,l),
+(178,357,ls),
+(345,357,o),
+(416,274,o),
+(377,95,cs),
+(356,0,l)
+);
+}
+);
+width = 576;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB5;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB4;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (87,0);
+ref = dot_top;
+}
+);
+width = 576;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB6;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (220,690);
+},
+{
+name = top_right_can;
+pos = (515,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(122,1,l),
+(181,280,l),
+(104,247,l),
+(135,247,ls),
+(359,247,o),
+(490,358,o),
+(540,589,cs),
+(555,657,l),
+(485,624,l),
+(680,429,l),
+(747,496,l),
+(553,691,l),
+(467,691,l),
+(446,597,ls),
+(409,425,o),
+(300,333,o),
+(134,333,cs),
+(96,333,l),
+(25,1,l)
+);
+}
+);
+width = 718;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB7;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB6;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (345,0);
+ref = dot_top;
+}
+);
+width = 718;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB8;
+kernRight = soright;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (397,690);
+},
+{
+name = top_right_can;
+pos = (692,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(299,0,l),
+(320,94,ls),
+(356,266,o),
+(465,357,o),
+(631,357,cs),
+(669,357,l),
+(740,690,l),
+(644,690,l),
+(584,411,l),
+(662,443,l),
+(630,443,ls),
+(406,443,o),
+(276,336,o),
+(225,101,cs),
+(211,34,l),
+(280,67,l),
+(84,262,l),
+(17,195,l),
+(213,0,l)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB9;
+kernRight = soright;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB8;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (521,0);
+ref = dot_top;
+}
+);
+width = 718;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABA;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (220,690);
+},
+{
+name = top_right_can;
+pos = (515,690);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(405,0,l),
+(683,195,l),
+(634,266,l),
+(375,86,l),
+(425,50,l),
+(435,97,ls),
+(477,299,o),
+(374,443,o),
+(178,443,cs),
+(148,443,l),
+(208,406,l),
+(268,690,l),
+(172,690,l),
+(101,357,l),
+(137,357,ls),
+(314,357,o),
+(378,270,o),
+(337,84,cs),
+(319,0,l)
+);
+}
+);
+width = 718;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABB;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = uni11ABA;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+}
+);
+width = 718;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABC;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(469,0,l),
+(487,87,l),
+(111,87,l),
+(113,51,l),
+(610,622,l),
+(624,690,l),
+(146,690,l),
+(128,603,l),
+(503,603,l),
+(500,639,l),
+(4,68,l),
+(-11,0,l)
+);
+}
+);
+width = 569;
+}
+);
+metricRight = "=|";
+},
+{
+color = 8;
+glyphname = uni11ABD;
+lastChange = "2023-01-13 15:54:24 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(476,0,l),
+(491,68,l),
+(221,639,l),
+(220,603,l),
+(596,603,l),
+(613,690,l),
+(136,690,l),
+(122,622,l),
+(390,51,l),
+(391,87,l),
+(15,87,l),
+(-3,0,l)
+);
+}
+);
+width = 567;
+}
+);
+metricLeft = "=|uni11ABC";
+metricRight = "=|uni11ABC";
+},
+{
+color = 8;
+glyphname = uni11ABE;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(120,0,l),
+(247,602,l),
+(195,602,l),
+(458,0,l),
+(543,0,l),
+(690,690,l),
+(595,690,l),
+(467,88,l),
+(520,88,l),
+(257,690,l),
+(172,690,l),
+(25,0,l)
+);
+}
+);
+width = 670;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABF;
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(110,0,l),
+(643,604,l),
+(576,604,l),
+(447,0,l),
+(543,0,l),
+(690,690,l),
+(605,690,l),
+(71,85,l),
+(138,86,l),
+(268,690,l),
+(172,690,l),
+(25,0,l)
+);
+}
+);
+width = 670;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = "raiseddoubledotFinal-canadian.cree";
+lastChange = "2023-01-13 15:54:20 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(230,593,o),
+(254,617,o),
+(254,648,cs),
+(254,678,o),
+(230,702,o),
+(200,702,cs),
+(169,702,o),
+(145,679,o),
+(145,648,cs),
+(145,617,o),
+(169,593,o),
+(200,593,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(192,411,o),
+(216,435,o),
+(216,466,cs),
+(216,497,o),
+(192,521,o),
+(161,521,cs),
+(130,521,o),
+(106,497,o),
+(106,466,cs),
+(106,435,o),
+(130,411,o),
+(161,411,cs)
+);
+}
+);
+width = 226;
+}
+);
+note = g725;
+}
+);
+instances = (
+{
+axesValues = (
+101,
+91,
+12
+);
+instanceInterpolations = {
+"96DCC2AB-F6C9-4D02-A366-260ACDE51568" = 1;
+};
+name = "RC L Italic";
+}
+);
+kerningLTR = {
+"96DCC2AB-F6C9-4D02-A366-260ACDE51568" = {
+"@MMK_L_caright" = {
+"@MMK_R_ecanleft" = -77.28;
+"@MMK_R_mwestleft" = -28.014;
+"@MMK_R_neleft" = -55.062;
+};
+"@MMK_L_ciright" = {
+"@MMK_R_icanleft" = -77.28;
+"@MMK_R_noleft" = -96.6;
+};
+"@MMK_L_ecanright" = {
+"@MMK_R_coleft" = -77.28;
+"@MMK_R_moleft" = -80.178;
+"@MMK_R_sileft" = -47.334;
+};
+"@MMK_L_icanright" = {
+"@MMK_R_celeft" = -77.28;
+"@MMK_R_meleft" = -80.178;
+"@MMK_R_mwestleft" = -71.484;
+"@MMK_R_saleft" = -41.538;
+"she-canadian" = -80.178;
+};
+"@MMK_L_maright" = {
+"@MMK_R_acanleft" = -76.314;
+"@MMK_R_ecanleft" = -80.178;
+"@MMK_R_mwestleft" = -51.198;
+"@MMK_R_neleft" = -55.062;
+};
+"@MMK_L_miright" = {
+"@MMK_R_acanleft" = -76.314;
+"@MMK_R_icanleft" = -80.178;
+"@MMK_R_moleft" = -101.43;
+"@MMK_R_noleft" = -96.6;
+"@MMK_R_yeleft" = -107.226;
+};
+"@MMK_L_mwestright" = {
+"@MMK_R_coleft" = -28.014;
+"@MMK_R_icanleft" = -71.484;
+"@MMK_R_moleft" = -51.198;
+"@MMK_R_noleft" = -78.246;
+"@MMK_R_sileft" = -18.354;
+"@MMK_R_yeleft" = -32.844;
+};
+"@MMK_L_naright" = {
+"@MMK_R_acanleft" = -89.838;
+"@MMK_R_celeft" = -96.6;
+"@MMK_R_meleft" = -96.6;
+"@MMK_R_mwestleft" = -78.246;
+"@MMK_R_neleft" = -111.09;
+"@MMK_R_saleft" = -68.586;
+};
+"@MMK_L_niright" = {
+"@MMK_R_coleft" = -55.062;
+"@MMK_R_moleft" = -55.062;
+"@MMK_R_noleft" = -111.09;
+"@MMK_R_sileft" = -4.83;
+};
+"@MMK_L_ocanright" = {
+"@MMK_R_meleft" = -76.314;
+"@MMK_R_moleft" = -76.314;
+"@MMK_R_noleft" = -89.838;
+};
+"@MMK_L_seright" = {
+"@MMK_R_ecanleft" = -47.334;
+"@MMK_R_mwestleft" = -18.354;
+"@MMK_R_neleft" = -2.898;
+};
+"@MMK_L_soright" = {
+"@MMK_R_icanleft" = -41.538;
+"@MMK_R_noleft" = -68.586;
+};
+"@MMK_L_yiright" = {
+"@MMK_R_meleft" = -107.226;
+"@MMK_R_mwestleft" = -32.844;
+};
+"shi-canadian" = {
+"@MMK_R_icanleft" = -80.178;
+};
+};
+};
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "italic angle";
+}
+);
+properties = (
+{
+key = copyrights;
+values = (
+{
+language = ENG;
+value = "Copyright 2018 Google Inc. All Rights Reserved.";
+}
+);
+},
+{
+key = manufacturers;
+values = (
+{
+language = ENG;
+value = "Monotype Imaging Inc.";
+}
+);
+},
+{
+key = designers;
+values = (
+{
+language = ENG;
+value = "Monotype Design Team";
+}
+);
+},
+{
+key = description;
+value = "Designed by Monotype design team.";
+},
+{
+key = trademarks;
+values = (
+{
+language = ENG;
+value = "Noto is a trademark of Google Inc.";
+}
+);
+},
+{
+key = licenseURL;
+value = "http://scripts.sil.org/OFL";
+},
+{
+key = licenses;
+values = (
+{
+language = ENG;
+value = "This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.";
+}
+);
+},
+{
+key = manufacturerURL;
+value = "http://www.google.com/get/noto/";
+},
+{
+key = designerURL;
+value = "http://www.monotype.com/studio";
+}
+);
+settings = {
+disablesNiceNames = 1;
+};
+stems = (
+{
+name = "New Stem";
+}
+);
+unitsPerEm = 966;
+userData = {
+GSDontShowVersionAlert = 1;
+};
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/sources/Exported instances UCAS SansCanadianAboriginal Resized/Sans Canadian Aboriginal-RC R roman.glyphs
+++ b/sources/Exported instances UCAS SansCanadianAboriginal Resized/Sans Canadian Aboriginal-RC R roman.glyphs
@@ -1,0 +1,37333 @@
+{
+.appVersion = "3151";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+},
+{
+name = Width;
+tag = wdth;
+},
+{
+name = Slant;
+tag = slnt;
+}
+);
+classes = (
+{
+code = "zero one two three four five six seven eight nine ";
+name = Num;
+},
+{
+code = "zero.canadian one.canadian two.canadian three.canadian four.canadian five.canadian six.canadian seven.canadian eight.canadian nine.canadian 
+";
+name = Num_can;
+},
+{
+code = "ke-canadian.square ki-canadian.square kii-canadian.square ko-canadian.square koo-canadian.square ka-canadian.square kaa-canadian.square kweWestCree-canadian.square kwiiWestCree-canadian.square kwoWestCree-canadian.square kwooWestCree-canadian.square kwaWestCree-canadian.square kwaaWestCree-canadian.square ce-canadian.square ci-canadian.square cii-canadian.square co-canadian.square coo-canadian.square ca-canadian.square caa-canadian.square me-canadian.square mi-canadian.square mii-canadian.square mo-canadian.square moo-canadian.square ma-canadian.square maa-canadian.square ne-canadian.square ni-canadian.square nii-canadian.square no-canadian.square noo-canadian.square na-canadian.square naa-canadian.square nweWestCree-canadian.square nwaWestCree-canadian.square nwaaWestCree-canadian.square se-canadian.square si-canadian.square sii-canadian.square so-canadian.square soo-canadian.square sa-canadian.square saa-canadian.square sho-canadian.square shoo-canadian.square sha-canadian.square shaa-canadian.square ye-canadian.square yi-canadian.square yii-canadian.square yo-canadian.square yoo-canadian.square ya-canadian.square yaa-canadian.square re-canadian.square reRCree-canadian.square leWestCree-canadian.square ri-canadian.square rii-canadian.square ro-canadian.square loWestCree-canadian.square ra-canadian.square raa-canadian.square laWestCree-canadian.square reWestCree-canadian.square riWestCree-canadian.square roWestCree-canadian.square raWestCree-canadian.square theThCree-canadian.square thiThCree-canadian.square thiiThCree-canadian.square thoThCree-canadian.square thooThCree-canadian.square thaThCree-canadian.square thaaThCree-canadian.square thweeWoodScree-canadian.square thwiWoodScree-canadian.square thwiiWoodScree-canadian.square thwoWoodScree-canadian.square thwooWoodScree-canadian.square thwaWoodScree-canadian.square thwaaWoodScree-canadian.square nwiOjibway-canadian.square nwiiOjibway-canadian.square nwoOjibway-canadian.square nwooOjibway-canadian.square looWestCree-canadian.square laaWestCree-canadian.square ";
+name = Dene_square;
+},
+{
+code = "ke-canadian ki-canadian kii-canadian ko-canadian koo-canadian ka-canadian kaa-canadian kweWestCree-canadian kwiiWestCree-canadian kwoWestCree-canadian kwooWestCree-canadian kwaWestCree-canadian kwaaWestCree-canadian ce-canadian ci-canadian cii-canadian co-canadian coo-canadian ca-canadian caa-canadian me-canadian mi-canadian mii-canadian mo-canadian moo-canadian ma-canadian maa-canadian ne-canadian ni-canadian nii-canadian no-canadian noo-canadian na-canadian naa-canadian nweWestCree-canadian nwaWestCree-canadian nwaaWestCree-canadian se-canadian si-canadian sii-canadian so-canadian soo-canadian sa-canadian saa-canadian sho-canadian shoo-canadian sha-canadian shaa-canadian ye-canadian yi-canadian yii-canadian yo-canadian yoo-canadian ya-canadian yaa-canadian re-canadian reRCree-canadian leWestCree-canadian ri-canadian rii-canadian ro-canadian loWestCree-canadian ra-canadian raa-canadian laWestCree-canadian reWestCree-canadian riWestCree-canadian roWestCree-canadian raWestCree-canadian theThCree-canadian thiThCree-canadian thiiThCree-canadian thoThCree-canadian thooThCree-canadian thaThCree-canadian thaaThCree-canadian thweeWoodScree-canadian thwiWoodScree-canadian thwiiWoodScree-canadian thwoWoodScree-canadian thwooWoodScree-canadian thwaWoodScree-canadian thwaaWoodScree-canadian nwiOjibway-canadian nwiiOjibway-canadian nwoOjibway-canadian nwooOjibway-canadian looWestCree-canadian laaWestCree-canadian 
+";
+name = Dene_round;
+},
+{
+code = "acuteFinal-canadian.mid graveFinal-canadian.mid ringTophalfFinal-canadian.mid ringRighthalfFinal-canadian.mid ringFinal-canadian.mid doubleacuteFinal-canadian.mid doubleshortverticalstrokesFinal-canadian.mid shorthorizontalstrokeFinal-canadian.mid downtackFinal-canadian.mid pWestCree-canadian.mid c-canadian.mid mWestCree-canadian.mid ";
+name = Final_mid;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian ringFinal-canadian doubleacuteFinal-canadian doubleshortverticalstrokesFinal-canadian shorthorizontalstrokeFinal-canadian downtackFinal-canadian pWestCree-canadian c-canadian mWestCree-canadian ";
+name = Final_mid_ori;
+},
+{
+code = "acuteFinal-canadian.base graveFinal-canadian.base ringBottomhalfFinal-canadian.base ringTophalfFinal-canadian.base ringRighthalfFinal-canadian.base plusFinal-canadian.base pWestCree-canadian.base c-canadian.base thSayisi-canadian.base mWestCree-canadian.base ";
+name = Final_base;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringBottomhalfFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian plusFinal-canadian pWestCree-canadian c-canadian thSayisi-canadian mWestCree-canadian ";
+name = Final_base_ori;
+},
+{
+code = "ng-canadian ngai-canadian ngaai-canadian ngi-canadian ngii-canadian ngo-canadian ngoo-canadian nga-canadian ngaa-canadian ";
+name = Nunavik;
+},
+{
+code = "ng-canadian.nunavik ngai-canadian.nunavik ngaai-canadian.nunavik ngi-canadian.nunavik ngii-canadian.nunavik ngo-canadian.nunavik ngoo-canadian.nunavik nga-canadian.nunavik ngaa-canadian.nunavik ";
+name = Nunavik_alt;
+}
+);
+customParameters = (
+{
+name = vendorID;
+value = GOOG;
+},
+{
+name = panose;
+value = (
+2,
+11,
+5,
+2,
+4,
+5,
+4,
+2,
+2,
+4
+);
+},
+{
+name = unicodeRanges;
+value = (
+0,
+1,
+2,
+5,
+6,
+45,
+77
+);
+},
+{
+name = codePageRanges;
+value = (
+"1252"
+);
+},
+{
+name = fsType;
+value = (
+);
+}
+);
+date = "2022-06-21 10:06:40 +0000";
+familyName = "Sans Canadian Aboriginal";
+featurePrefixes = (
+{
+automatic = 1;
+code = "languagesystem DFLT dflt;
+
+languagesystem cans dflt;
+";
+name = Languagesystems;
+}
+);
+features = (
+{
+automatic = 1;
+code = "feature ss01;
+feature ss02;
+feature ss03;
+feature ss04;
+";
+tag = aalt;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+tag = salt;
+},
+{
+code = "lookup space_can {
+sub space by space.canadian;
+} space_can;
+
+lookup num_can {
+sub @Num by @Num_can;
+} num_can;
+";
+labels = (
+{
+language = dflt;
+value = "CAN Space and numerals";
+}
+);
+tag = ss01;
+},
+{
+code = "lookup dene_square {
+sub @Dene_round by @Dene_square;
+} dene_square;
+
+";
+labels = (
+{
+language = dflt;
+value = "Dene Square";
+}
+);
+tag = ss02;
+},
+{
+code = "lookup nunavik_alt {
+sub @Nunavik by @Nunavik_alt;
+} nunavik_alt;
+
+";
+labels = (
+{
+language = dflt;
+value = "Nunanvik Alt";
+}
+);
+tag = ss03;
+},
+{
+code = "lookup final_mid {
+sub @Final_mid_ori by @Final_mid;
+} final_mid;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final mid";
+}
+);
+tag = ss04;
+},
+{
+code = "lookup final_base {
+sub @Final_base_ori by @Final_base;
+} final_base;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final base";
+}
+);
+tag = ss05;
+},
+{
+code = "lookup plaincree_first {
+sub wiWestCree-canadian' plusFinal-canadian by i-canadian;
+} plaincree_first;
+
+lookup plaincree_second {
+sub i-canadian plusFinal-canadian' by raiseddoubledotFinal-canadian.cree;
+} plaincree_second;
+
+lookup plaincree_third {
+sub middledotFinal-canadian plusFinal-canadian by raiseddoubledotFinal-canadian.cree;
+} plaincree_third;
+";
+labels = (
+{
+language = dflt;
+value = Plaincree;
+}
+);
+tag = ss06;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+labels = (
+{
+language = dflt;
+value = "";
+}
+);
+tag = ss07;
+}
+);
+fontMaster = (
+{
+axesValues = (
+0,
+0,
+0
+);
+customParameters = (
+{
+name = typoAscender;
+value = 1033;
+},
+{
+name = typoDescender;
+value = -283;
+},
+{
+name = typoLineGap;
+value = 0;
+},
+{
+name = winAscent;
+value = 1033;
+},
+{
+name = winDescent;
+value = 283;
+},
+{
+name = hheaAscender;
+value = 1033;
+},
+{
+name = hheaDescender;
+value = -283;
+},
+{
+name = strikeoutPosition;
+value = 287;
+},
+{
+name = strikeoutSize;
+value = 48;
+}
+);
+guides = (
+{
+lockAngle = 1;
+locked = 1;
+pos = (222,345);
+}
+);
+id = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+metricValues = (
+{
+over = 18;
+pos = 1033;
+},
+{
+over = 18;
+pos = 690;
+},
+{
+over = 18;
+pos = 479;
+},
+{
+over = -18;
+},
+{
+over = -18;
+pos = -283;
+},
+{
+}
+);
+name = "RC L roman";
+stemValues = (
+96
+);
+}
+);
+glyphs = (
+{
+glyphname = idotless;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(167,521,l),
+(71,521,l),
+(71,0,l),
+(167,0,l)
+);
+}
+);
+width = 239;
+}
+);
+note = dotlessi;
+unicode = 305;
+},
+{
+glyphname = "acuteFinal-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(117,345,l),
+(277,690,l),
+(201,690,l),
+(41,345,l)
+);
+}
+);
+width = 318;
+}
+);
+metricRight = "=|";
+note = uni141F;
+unicode = 5151;
+},
+{
+glyphname = "graveFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(277,345,l),
+(117,690,l),
+(41,690,l),
+(201,345,l)
+);
+}
+);
+width = 318;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+unicode = 5152;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(304,339,o),
+(360,396,o),
+(360,500,cs),
+(360,690,l),
+(292,690,l),
+(292,500,ls),
+(292,433,o),
+(264,402,o),
+(213,402,cs),
+(161,402,o),
+(132,434,o),
+(132,500,cs),
+(132,690,l),
+(64,690,l),
+(64,499,ls),
+(64,397,o),
+(122,339,o),
+(213,339,cs)
+);
+}
+);
+width = 424;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1421;
+unicode = 5153;
+},
+{
+glyphname = "ringTophalfFinal-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(132,345,l),
+(132,534,ls),
+(132,601,o),
+(161,633,o),
+(213,633,cs),
+(264,633,o),
+(292,602,o),
+(292,534,cs),
+(292,345,l),
+(360,345,l),
+(360,534,ls),
+(360,639,o),
+(304,696,o),
+(213,696,cs),
+(122,696,o),
+(64,638,o),
+(64,535,cs),
+(64,345,l)
+);
+}
+);
+width = 424;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+unicode = 5154;
+},
+{
+glyphname = "ringRighthalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(136,345,ls),
+(246,345,o),
+(308,411,o),
+(308,517,cs),
+(308,624,o),
+(246,690,o),
+(135,690,cs),
+(61,690,l),
+(61,626,l),
+(131,626,ls),
+(203,626,o),
+(240,587,o),
+(240,517,cs),
+(240,446,o),
+(203,409,o),
+(131,409,cs),
+(61,409,l),
+(61,345,l)
+);
+}
+);
+width = 369;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+unicode = 5155;
+},
+{
+glyphname = "ringFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(333,355,o),
+(407,428,o),
+(407,526,cs),
+(407,623,o),
+(332,696,o),
+(234,696,cs),
+(134,696,o),
+(60,623,o),
+(60,526,cs),
+(60,428,o),
+(133,355,o),
+(234,355,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(168,414,o),
+(125,462,o),
+(125,526,cs),
+(125,589,o),
+(169,637,o),
+(234,637,cs),
+(297,637,o),
+(343,589,o),
+(343,526,cs),
+(343,462,o),
+(298,414,o),
+(234,414,cs)
+);
+}
+);
+width = 468;
+}
+);
+note = uni1424;
+unicode = 5156;
+},
+{
+glyphname = "doubleacuteFinal-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(277,690,l),
+(201,690,l),
+(41,345,l),
+(117,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(428,690,l),
+(352,690,l),
+(191,345,l),
+(268,345,l)
+);
+}
+);
+width = 469;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricRight = "=|";
+note = uni1425;
+unicode = 5157;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(132,690,l),
+(64,690,l),
+(64,345,l),
+(132,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(267,690,l),
+(198,690,l),
+(198,345,l),
+(267,345,l)
+);
+}
+);
+width = 331;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "pWestCree-canadian";
+note = uni1426;
+unicode = 5158;
+},
+{
+glyphname = "middledotFinal-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(143,299,o),
+(167,324,o),
+(167,355,cs),
+(167,385,o),
+(143,410,o),
+(112,410,cs),
+(81,410,o),
+(57,385,o),
+(57,355,cs),
+(57,324,o),
+(81,299,o),
+(112,299,cs)
+);
+}
+);
+width = 224;
+}
+);
+note = uni1427;
+unicode = 5159;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(383,489,l),
+(383,557,l),
+(62,557,l),
+(62,489,l)
+);
+}
+);
+width = 445;
+}
+);
+metricRight = "=|";
+note = uni1428;
+unicode = 5160;
+},
+{
+glyphname = "plusFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(257,362,l),
+(257,496,l),
+(384,496,l),
+(384,559,l),
+(257,559,l),
+(257,690,l),
+(189,690,l),
+(189,559,l),
+(62,559,l),
+(62,496,l),
+(189,496,l),
+(189,362,l)
+);
+}
+);
+width = 446;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+unicode = 5161;
+},
+{
+glyphname = "downtackFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(257,345,l),
+(257,625,l),
+(384,625,l),
+(384,690,l),
+(62,690,l),
+(62,625,l),
+(189,625,l),
+(189,345,l)
+);
+}
+);
+width = 446;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni142A;
+unicode = 5162;
+},
+{
+glyphname = "thFinalWoodScree-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(259,345,l),
+(259,420,l),
+(384,420,l),
+(384,476,l),
+(259,476,l),
+(259,558,l),
+(384,558,l),
+(384,614,l),
+(259,614,l),
+(259,690,l),
+(191,690,l),
+(191,614,l),
+(64,614,l),
+(64,558,l),
+(191,558,l),
+(191,476,l),
+(64,476,l),
+(64,420,l),
+(191,420,l),
+(191,345,l)
+);
+}
+);
+width = 448;
+}
+);
+metricLeft = "hyphen-canadian";
+metricRight = "hyphen-canadian";
+note = uni167E;
+unicode = 5758;
+},
+{
+glyphname = "ringSmallFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(224,499,o),
+(272,541,o),
+(272,601,cs),
+(272,661,o),
+(224,702,o),
+(168,702,cs),
+(111,702,o),
+(64,661,o),
+(64,601,cs),
+(64,541,o),
+(111,499,o),
+(168,499,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(133,544,o),
+(112,569,o),
+(112,601,cs),
+(112,633,o),
+(135,658,o),
+(168,658,cs),
+(202,658,o),
+(224,633,o),
+(224,601,cs),
+(224,569,o),
+(202,544,o),
+(168,544,cs)
+);
+}
+);
+width = 337;
+}
+);
+note = g725;
+unicode = 6366;
+},
+{
+glyphname = "raiseddotFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(144,593,o),
+(168,617,o),
+(168,648,cs),
+(168,678,o),
+(144,702,o),
+(113,702,cs),
+(82,702,o),
+(58,678,o),
+(58,648,cs),
+(58,617,o),
+(82,593,o),
+(113,593,cs)
+);
+}
+);
+width = 226;
+}
+);
+note = g725;
+unicode = 6367;
+},
+{
+glyphname = "acuteFinal-canadian.base";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "acuteFinal-canadian";
+}
+);
+width = 318;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.base";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "graveFinal-canadian";
+}
+);
+width = 318;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian.base";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 424;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1421;
+},
+{
+glyphname = "ringTophalfFinal-canadian.base";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 424;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.base";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 369;
+}
+);
+metricLeft = "==|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "plusFinal-canadian.base";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(257,0,l),
+(257,133,l),
+(384,133,l),
+(384,197,l),
+(257,197,l),
+(257,327,l),
+(189,327,l),
+(189,197,l),
+(62,197,l),
+(62,133,l),
+(189,133,l),
+(189,0,l)
+);
+}
+);
+width = 446;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+},
+{
+glyphname = "acuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "acuteFinal-canadian";
+}
+);
+width = 318;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.mid";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "graveFinal-canadian";
+}
+);
+width = 318;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringTophalfFinal-canadian.mid";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-172);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 424;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.mid";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 369;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "ringFinal-canadian.mid";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-181);
+ref = "ringFinal-canadian";
+}
+);
+width = 468;
+}
+);
+metricLeft = "ringFinal-canadian";
+metricWidth = "ringFinal-canadian";
+note = uni1424;
+},
+{
+glyphname = "doubleacuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "doubleacuteFinal-canadian";
+}
+);
+width = 469;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "doubleacuteFinal-canadian";
+note = uni1425;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian.mid";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "doubleshortverticalstrokesFinal-canadian";
+}
+);
+width = 331;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricWidth = "doubleshortverticalstrokesFinal-canadian";
+note = uni1426;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian.mid";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "shorthorizontalstrokeFinal-canadian";
+}
+);
+width = 445;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "shorthorizontalstrokeFinal-canadian";
+note = uni1428;
+},
+{
+glyphname = "downtackFinal-canadian.mid";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "downtackFinal-canadian";
+}
+);
+width = 446;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "downtackFinal-canadian";
+note = uni142A;
+},
+{
+glyphname = "e-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (355,454);
+},
+{
+name = top_center_can;
+pos = (355,690);
+},
+{
+name = top_left_can;
+pos = (129,690);
+},
+{
+name = top_right_can;
+pos = (583,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(376,0,l),
+(684,664,l),
+(684,690,l),
+(32,690,l),
+(32,664,l),
+(340,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(375,116,l),
+(143,633,l),
+(130,611,l),
+(585,611,l),
+(577,633,l),
+(345,116,l)
+);
+}
+);
+width = 716;
+}
+);
+metricRight = "=|";
+note = uni1401;
+unicode = 5121;
+},
+{
+glyphname = "aai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (234,0);
+ref = ring_top.canadian;
+}
+);
+width = 717;
+}
+);
+note = uni1402;
+unicode = 5122;
+},
+{
+glyphname = "i-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (357,355);
+},
+{
+name = top_center_can;
+pos = (358,690);
+},
+{
+name = top_left_can;
+pos = (129,690);
+},
+{
+name = top_right_can;
+pos = (583,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(684,0,l),
+(684,26,l),
+(376,690,l),
+(340,690,l),
+(32,26,l),
+(32,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(372,574,l),
+(342,574,l),
+(574,57,l),
+(585,79,l),
+(130,79,l),
+(140,57,l)
+);
+}
+);
+width = 716;
+}
+);
+metricLeft = "e-canadian";
+metricWidth = "e-canadian";
+note = uni1403;
+unicode = 5123;
+},
+{
+glyphname = "ii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (285,0);
+ref = dot_top;
+}
+);
+width = 717;
+}
+);
+note = uni1404;
+unicode = 5124;
+},
+{
+glyphname = "o-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (272,345);
+},
+{
+name = top_center_can;
+pos = (358,690);
+},
+{
+name = top_double;
+pos = (453,690);
+},
+{
+name = top_left_can;
+pos = (117,690);
+},
+{
+name = top_right_can;
+pos = (598,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(101,0,l),
+(643,327,l),
+(643,362,l),
+(101,690,l),
+(75,690,l),
+(75,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(158,583,l),
+(133,580,l),
+(542,331,l),
+(542,359,l),
+(133,112,l),
+(158,107,l)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1405;
+unicode = 5125;
+},
+{
+glyphname = "oo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (43,0);
+ref = dot_top;
+}
+);
+width = 677;
+}
+);
+note = uni1406;
+unicode = 5126;
+},
+{
+glyphname = "yCreeoo-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (212,0);
+ref = doubledot_top;
+}
+);
+width = 677;
+}
+);
+note = uni1407;
+unicode = 5127;
+},
+{
+glyphname = "eeCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(101,0,l),
+(643,327,l),
+(643,362,l),
+(101,690,l),
+(75,690,l),
+(75,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(156,583,l),
+(133,582,l),
+(542,333,l),
+(542,357,l),
+(133,110,l),
+(156,107,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(290,427,l),
+(252,427,l),
+(252,263,l),
+(290,263,l)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "o-canadian";
+note = uni1408;
+unicode = 5128;
+},
+{
+glyphname = "iCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (216,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 677;
+}
+);
+note = uni1409;
+unicode = 5129;
+},
+{
+glyphname = "a-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (400,345);
+},
+{
+name = top_center_can;
+pos = (313,690);
+},
+{
+name = top_left_can;
+pos = (77,690);
+},
+{
+name = top_right_can;
+pos = (559,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(601,0,l),
+(601,690,l),
+(576,690,l),
+(34,362,l),
+(34,327,l),
+(576,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(543,111,l),
+(135,359,l),
+(135,331,l),
+(543,580,l),
+(519,583,l),
+(519,107,l)
+);
+}
+);
+width = 676;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni140A;
+unicode = 5130;
+},
+{
+glyphname = "aa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (486,0);
+ref = dot_top;
+}
+);
+width = 677;
+}
+);
+note = uni140B;
+unicode = 5131;
+},
+{
+glyphname = "we-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "e-canadian";
+}
+);
+width = 941;
+}
+);
+note = uni140C;
+unicode = 5132;
+},
+{
+glyphname = "weWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (717,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 941;
+}
+);
+note = uni140D;
+unicode = 5133;
+},
+{
+glyphname = "wi-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "i-canadian";
+}
+);
+width = 941;
+}
+);
+note = uni140E;
+unicode = 5134;
+},
+{
+glyphname = "wiWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (717,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 941;
+}
+);
+note = uni140F;
+unicode = 5135;
+},
+{
+glyphname = "wii-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (509,0);
+ref = dot_top;
+}
+);
+width = 941;
+}
+);
+note = uni1410;
+unicode = 5136;
+},
+{
+glyphname = "wiiWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (285,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (717,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 941;
+}
+);
+note = uni1411;
+unicode = 5137;
+},
+{
+glyphname = "wo-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "o-canadian";
+}
+);
+width = 901;
+}
+);
+note = uni1412;
+unicode = 5138;
+},
+{
+glyphname = "woWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (677,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 901;
+}
+);
+note = uni1413;
+unicode = 5139;
+},
+{
+glyphname = "woo-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (509,0);
+ref = dot_top;
+}
+);
+width = 901;
+}
+);
+note = uni1414;
+unicode = 5140;
+},
+{
+glyphname = "wooWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (43,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (677,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 901;
+}
+);
+note = uni1415;
+unicode = 5141;
+},
+{
+glyphname = "wooNaskapi-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (211,-96);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (386,-201);
+ref = dot_top;
+}
+);
+width = 677;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricWidth = "o-canadian";
+note = uni1416;
+unicode = 5142;
+},
+{
+glyphname = "wa-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "a-canadian";
+}
+);
+width = 901;
+}
+);
+note = uni1417;
+unicode = 5143;
+},
+{
+glyphname = "waWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (677,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 901;
+}
+);
+note = uni1418;
+unicode = 5144;
+},
+{
+glyphname = "waa-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (710,0);
+ref = dot_top;
+}
+);
+width = 901;
+}
+);
+note = uni1419;
+unicode = 5145;
+},
+{
+glyphname = "waaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (486,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (677,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 901;
+}
+);
+note = uni141A;
+unicode = 5146;
+},
+{
+glyphname = "waaNaskapi-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (143,-201);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (319,-96);
+ref = dot_top;
+}
+);
+width = 676;
+}
+);
+metricWidth = "a-canadian";
+note = uni141B;
+unicode = 5147;
+},
+{
+glyphname = "ai-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(264,339,o),
+(304,369,o),
+(324,429,c),
+(302,429,l),
+(322,369,o),
+(364,339,o),
+(424,339,cs),
+(508,339,o),
+(562,393,o),
+(562,497,cs),
+(562,690,l),
+(497,690,l),
+(497,497,ls),
+(497,426,o),
+(469,399,o),
+(421,399,cs),
+(375,399,o),
+(345,428,o),
+(345,496,cs),
+(345,690,l),
+(281,690,l),
+(281,497,ls),
+(281,426,o),
+(251,399,o),
+(204,399,cs),
+(157,399,o),
+(128,428,o),
+(128,496,cs),
+(128,690,l),
+(64,690,l),
+(64,495,ls),
+(64,393,o),
+(119,339,o),
+(203,339,cs)
+);
+}
+);
+width = 626;
+}
+);
+metricRight = "=|";
+note = uni141C;
+unicode = 5148;
+},
+{
+glyphname = "ycreew-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(349,510,o),
+(385,549,o),
+(385,603,cs),
+(385,658,o),
+(349,696,o),
+(299,696,cs),
+(250,696,o),
+(213,658,o),
+(213,603,cs),
+(213,549,o),
+(250,510,o),
+(299,510,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(196,339,o),
+(233,378,o),
+(233,432,cs),
+(233,487,o),
+(197,525,o),
+(148,525,cs),
+(98,525,o),
+(61,487,o),
+(61,432,cs),
+(61,378,o),
+(98,339,o),
+(147,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(119,375,o),
+(99,398,o),
+(99,432,cs),
+(99,466,o),
+(119,489,o),
+(147,489,cs),
+(175,489,o),
+(194,466,o),
+(194,432,cs),
+(194,398,o),
+(175,375,o),
+(147,375,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(270,546,o),
+(252,569,o),
+(252,603,cs),
+(252,637,o),
+(270,660,o),
+(299,660,cs),
+(327,660,o),
+(347,637,o),
+(347,603,cs),
+(347,569,o),
+(327,546,o),
+(299,546,cs)
+);
+}
+);
+width = 446;
+}
+);
+metricRight = "=|";
+note = uni141D;
+unicode = 5149;
+},
+{
+glyphname = "glottalstop-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(381,345,l),
+(381,359,l),
+(227,690,l),
+(209,690,l),
+(55,359,l),
+(55,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(234,627,l),
+(201,627,l),
+(315,374,l),
+(329,396,l),
+(106,396,l),
+(119,374,l)
+);
+}
+);
+width = 436;
+}
+);
+metricRight = "=|";
+note = uni141E;
+unicode = 5150;
+},
+{
+glyphname = "en-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+pos = (717,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 1035;
+}
+);
+note = uni142B;
+unicode = 5163;
+},
+{
+glyphname = "in-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+pos = (490,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 808;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142C;
+unicode = 5164;
+},
+{
+glyphname = "on-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (534,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 852;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142D;
+unicode = 5165;
+},
+{
+glyphname = "an-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (632,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 950;
+}
+);
+metricRight = "graveFinal-canadian";
+note = uni142E;
+unicode = 5166;
+},
+{
+glyphname = "pe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (355,454);
+},
+{
+name = top_center_can;
+pos = (355,690);
+},
+{
+name = top_left_can;
+pos = (129,690);
+},
+{
+name = top_right_can;
+pos = (583,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(376,0,l),
+(684,664,l),
+(684,690,l),
+(596,690,l),
+(335,115,l),
+(384,115,l),
+(126,690,l),
+(32,690,l),
+(32,664,l),
+(340,0,l)
+);
+}
+);
+width = 716;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni142F;
+unicode = 5167;
+},
+{
+glyphname = "paai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (234,0);
+ref = ring_top.canadian;
+}
+);
+width = 717;
+}
+);
+note = uni1430;
+unicode = 5168;
+},
+{
+glyphname = "pi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (356,355);
+},
+{
+name = top_center_can;
+pos = (358,690);
+},
+{
+name = top_left_can;
+pos = (131,690);
+},
+{
+name = top_right_can;
+pos = (585,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(122,0,l),
+(384,575,l),
+(333,575,l),
+(592,0,l),
+(684,0,l),
+(684,26,l),
+(376,690,l),
+(340,690,l),
+(32,26,l),
+(32,0,l)
+);
+}
+);
+width = 716;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni1431;
+unicode = 5169;
+},
+{
+glyphname = "pii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (285,0);
+ref = dot_top;
+}
+);
+width = 717;
+}
+);
+note = uni1432;
+unicode = 5170;
+},
+{
+glyphname = "po-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (207,345);
+},
+{
+name = top_center_can;
+pos = (333,690);
+},
+{
+name = top_double;
+pos = (434,690);
+},
+{
+name = top_left_can;
+pos = (96,690);
+},
+{
+name = top_right_can;
+pos = (571,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(78,0,l),
+(615,327,l),
+(615,362,l),
+(78,690,l),
+(53,690,l),
+(53,601,l),
+(508,324,l),
+(508,367,l),
+(53,90,l),
+(53,0,l)
+);
+}
+);
+width = 649;
+}
+);
+metricRight = "o-canadian";
+note = uni1433;
+unicode = 5171;
+},
+{
+glyphname = "poo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (21,0);
+ref = dot_top;
+}
+);
+width = 649;
+}
+);
+note = uni1434;
+unicode = 5172;
+},
+{
+glyphname = "ycreepoo-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (192,0);
+ref = doubledot_top;
+}
+);
+width = 649;
+}
+);
+note = uni1435;
+unicode = 5173;
+},
+{
+glyphname = "heeCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (165,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 649;
+}
+);
+note = uni1436;
+unicode = 5174;
+},
+{
+glyphname = "hiCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (142,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 649;
+}
+);
+note = uni1437;
+unicode = 5175;
+},
+{
+glyphname = "pa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (325,345);
+},
+{
+name = top_center_can;
+pos = (317,690);
+},
+{
+name = top_left_can;
+pos = (77,690);
+},
+{
+name = top_right_can;
+pos = (554,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(596,0,l),
+(596,89,l),
+(141,366,l),
+(141,323,l),
+(596,600,l),
+(596,690,l),
+(571,690,l),
+(34,362,l),
+(34,327,l),
+(571,0,l)
+);
+}
+);
+width = 649;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1438;
+unicode = 5176;
+},
+{
+glyphname = "paa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (481,0);
+ref = dot_top;
+}
+);
+width = 649;
+}
+);
+note = uni1439;
+unicode = 5177;
+},
+{
+glyphname = "pwe-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "pe-canadian";
+}
+);
+width = 941;
+}
+);
+note = uni143A;
+unicode = 5178;
+},
+{
+glyphname = "pweWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "pe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (717,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 941;
+}
+);
+note = uni143B;
+unicode = 5179;
+},
+{
+glyphname = "pwi-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "pi-canadian";
+}
+);
+width = 941;
+}
+);
+note = uni143C;
+unicode = 5180;
+},
+{
+glyphname = "pwiWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (717,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 941;
+}
+);
+note = uni143D;
+unicode = 5181;
+},
+{
+glyphname = "pwii-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (509,0);
+ref = dot_top;
+}
+);
+width = 941;
+}
+);
+note = uni143E;
+unicode = 5182;
+},
+{
+glyphname = "pwiiWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (285,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (717,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 941;
+}
+);
+note = uni143F;
+unicode = 5183;
+},
+{
+glyphname = "pwo-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "po-canadian";
+}
+);
+width = 874;
+}
+);
+note = uni1440;
+unicode = 5184;
+},
+{
+glyphname = "pwoWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (649,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 874;
+}
+);
+note = uni1441;
+unicode = 5185;
+},
+{
+glyphname = "pwoo-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (484,0);
+ref = dot_top;
+}
+);
+width = 874;
+}
+);
+note = uni1442;
+unicode = 5186;
+},
+{
+glyphname = "pwooWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (21,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (649,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 874;
+}
+);
+note = uni1443;
+unicode = 5187;
+},
+{
+glyphname = "pwa-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "pa-canadian";
+}
+);
+width = 874;
+}
+);
+note = uni1444;
+unicode = 5188;
+},
+{
+glyphname = "pwaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (649,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 874;
+}
+);
+note = uni1445;
+unicode = 5189;
+},
+{
+glyphname = "pwaa-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (705,0);
+ref = dot_top;
+}
+);
+width = 874;
+}
+);
+note = uni1446;
+unicode = 5190;
+},
+{
+glyphname = "pwaaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (481,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (649,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 874;
+}
+);
+note = uni1447;
+unicode = 5191;
+},
+{
+glyphname = "ycreepwaa-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+pos = (140,-201);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (317,-96);
+ref = dot_top;
+}
+);
+width = 649;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1448;
+unicode = 5192;
+},
+{
+glyphname = "p-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(344,345,l),
+(344,407,l),
+(123,542,l),
+(123,493,l),
+(344,627,l),
+(344,690,l),
+(329,690,l),
+(64,527,l),
+(64,508,l),
+(329,345,l)
+);
+}
+);
+width = 409;
+}
+);
+note = uni1449;
+unicode = 5193;
+},
+{
+glyphname = "pWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(132,345,l),
+(132,690,l),
+(64,690,l),
+(64,345,l)
+);
+}
+);
+width = 196;
+}
+);
+metricRight = "=|";
+note = uni144A;
+unicode = 5194;
+},
+{
+color = 6;
+glyphname = "hCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(132,183,l),
+(132,306,ls),
+(132,349,o),
+(156,373,o),
+(194,373,cs),
+(230,373,o),
+(248,351,o),
+(248,304,cs),
+(248,183,l),
+(317,183,l),
+(317,317,ls),
+(317,396,o),
+(268,435,o),
+(207,435,cs),
+(159,435,o),
+(121,407,o),
+(115,368,c),
+(132,357,l),
+(132,527,l),
+(64,527,l),
+(64,183,l)
+);
+}
+);
+width = 359;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144B;
+unicode = 5195;
+},
+{
+glyphname = "te-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (356,345);
+},
+{
+name = top_center_can;
+pos = (356,690);
+},
+{
+name = top_left_can;
+pos = (117,690);
+},
+{
+name = top_right_can;
+pos = (597,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(536,-13,o),
+(644,102,o),
+(644,302,cs),
+(644,690,l),
+(549,690,l),
+(549,300,ls),
+(549,152,o),
+(479,75,o),
+(356,75,cs),
+(237,75,o),
+(164,154,o),
+(164,300,cs),
+(164,690,l),
+(69,690,l),
+(69,299,ls),
+(69,101,o),
+(178,-13,o),
+(356,-13,cs)
+);
+}
+);
+width = 713;
+}
+);
+metricRight = "=|";
+note = uni144C;
+unicode = 5196;
+},
+{
+glyphname = "taai-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (232,0);
+ref = ring_top.canadian;
+}
+);
+width = 713;
+}
+);
+note = uni144D;
+unicode = 5197;
+},
+{
+glyphname = "ti-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (356,345);
+},
+{
+name = middle_right_can;
+pos = (803,345);
+},
+{
+name = top_center_can;
+pos = (356,690);
+},
+{
+name = top_left_can;
+pos = (117,690);
+},
+{
+name = top_right_can;
+pos = (597,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(164,0,l),
+(164,389,ls),
+(164,536,o),
+(237,614,o),
+(358,614,cs),
+(477,614,o),
+(549,536,o),
+(549,389,cs),
+(549,0,l),
+(644,0,l),
+(644,390,ls),
+(644,588,o),
+(535,702,o),
+(359,702,cs),
+(180,702,o),
+(69,588,o),
+(69,387,cs),
+(69,0,l)
+);
+}
+);
+width = 713;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni144E;
+unicode = 5198;
+},
+{
+glyphname = "tii-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (283,0);
+ref = dot_top;
+}
+);
+width = 713;
+}
+);
+note = uni144F;
+unicode = 5199;
+},
+{
+glyphname = "to-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (253,345);
+},
+{
+name = middle_right_can;
+pos = (703,345);
+},
+{
+name = top_center_can;
+pos = (274,690);
+},
+{
+name = top_double;
+pos = (343,690);
+},
+{
+name = top_left_can;
+pos = (99,690);
+},
+{
+name = top_right_can;
+pos = (502,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(214,0,ls),
+(425,0,o),
+(545,128,o),
+(545,346,cs),
+(545,563,o),
+(425,690,o),
+(212,690,cs),
+(56,690,l),
+(56,603,l),
+(209,603,ls),
+(364,603,o),
+(448,513,o),
+(448,346,cs),
+(448,179,o),
+(364,87,o),
+(211,87,cs),
+(56,87,l),
+(56,0,l)
+);
+}
+);
+width = 607;
+}
+);
+note = uni1450;
+unicode = 5200;
+},
+{
+glyphname = "too-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (201,0);
+ref = dot_top;
+}
+);
+width = 607;
+}
+);
+note = uni1451;
+unicode = 5201;
+},
+{
+glyphname = "ycreetoo-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (101,0);
+ref = doubledot_top;
+}
+);
+width = 607;
+}
+);
+note = uni1452;
+unicode = 5202;
+},
+{
+glyphname = "deeCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (205,0);
+ref = stroke_middle;
+}
+);
+width = 607;
+}
+);
+note = uni1453;
+unicode = 5203;
+},
+{
+glyphname = "diCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (180,0);
+ref = dot_middle;
+}
+);
+width = 607;
+}
+);
+note = uni1454;
+unicode = 5204;
+},
+{
+glyphname = "ta-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (354,345);
+},
+{
+name = top_center_can;
+pos = (332,690);
+},
+{
+name = top_left_can;
+pos = (103,690);
+},
+{
+name = top_right_can;
+pos = (507,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(550,0,l),
+(550,87,l),
+(397,87,ls),
+(242,87,o),
+(157,178,o),
+(157,345,cs),
+(157,512,o),
+(242,603,o),
+(396,603,cs),
+(550,603,l),
+(550,690,l),
+(393,690,ls),
+(182,690,o),
+(62,562,o),
+(62,345,cs),
+(62,128,o),
+(182,0,o),
+(392,0,cs)
+);
+}
+);
+width = 606;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|to-canadian";
+note = uni1455;
+unicode = 5205;
+},
+{
+glyphname = "taa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (260,0);
+ref = dot_top;
+}
+);
+width = 607;
+}
+);
+note = uni1456;
+unicode = 5206;
+},
+{
+glyphname = "twe-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "te-canadian";
+}
+);
+width = 937;
+}
+);
+note = uni1457;
+unicode = 5207;
+},
+{
+glyphname = "tweWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (713,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 937;
+}
+);
+note = uni1458;
+unicode = 5208;
+},
+{
+glyphname = "twi-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ti-canadian";
+}
+);
+width = 937;
+}
+);
+note = uni1459;
+unicode = 5209;
+},
+{
+glyphname = "twiWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (713,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 937;
+}
+);
+note = uni145A;
+unicode = 5210;
+},
+{
+glyphname = "twii-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (507,0);
+ref = dot_top;
+}
+);
+width = 937;
+}
+);
+note = uni145B;
+unicode = 5211;
+},
+{
+glyphname = "twiiWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (283,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (713,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 937;
+}
+);
+note = uni145C;
+unicode = 5212;
+},
+{
+glyphname = "two-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "to-canadian";
+}
+);
+width = 832;
+}
+);
+note = uni145D;
+unicode = 5213;
+},
+{
+glyphname = "twoWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 832;
+}
+);
+note = uni145E;
+unicode = 5214;
+},
+{
+glyphname = "twoo-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (425,0);
+ref = dot_top;
+}
+);
+width = 832;
+}
+);
+note = uni145F;
+unicode = 5215;
+},
+{
+glyphname = "twooWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (201,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 832;
+}
+);
+note = uni1460;
+unicode = 5216;
+},
+{
+glyphname = "twa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ta-canadian";
+}
+);
+width = 832;
+}
+);
+note = uni1461;
+unicode = 5217;
+},
+{
+glyphname = "twaWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 832;
+}
+);
+note = uni1462;
+unicode = 5218;
+},
+{
+glyphname = "twaa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (484,0);
+ref = dot_top;
+}
+);
+width = 832;
+}
+);
+note = uni1463;
+unicode = 5219;
+},
+{
+glyphname = "twaaWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (260,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 832;
+}
+);
+note = uni1464;
+unicode = 5220;
+},
+{
+glyphname = "twaaNaskapi-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ta-canadian";
+}
+);
+width = 831;
+}
+);
+note = uni1465;
+unicode = 5221;
+},
+{
+glyphname = "t-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(308,345,l),
+(308,409,l),
+(237,409,ls),
+(165,409,o),
+(128,446,o),
+(128,517,cs),
+(128,586,o),
+(165,626,o),
+(237,626,cs),
+(308,626,l),
+(308,690,l),
+(232,690,ls),
+(122,690,o),
+(60,623,o),
+(60,517,cs),
+(60,411,o),
+(122,345,o),
+(233,345,cs)
+);
+}
+);
+width = 369;
+}
+);
+note = uni1466;
+unicode = 5222;
+},
+{
+glyphname = "tte-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+pos = (713,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 909;
+}
+);
+note = uni1467;
+unicode = 5223;
+},
+{
+glyphname = "tti-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+pos = (713,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 909;
+}
+);
+note = uni1468;
+unicode = 5224;
+},
+{
+glyphname = "tto-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+pos = (607,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 804;
+}
+);
+note = uni1469;
+unicode = 5225;
+},
+{
+glyphname = "tta-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+pos = (607,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 804;
+}
+);
+note = uni146A;
+unicode = 5226;
+},
+{
+glyphname = "ke-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (304,441);
+},
+{
+name = top_center_can;
+pos = (289,690);
+},
+{
+name = top_left_can;
+pos = (107,690);
+},
+{
+name = top_right_can;
+pos = (470,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(518,0,l),
+(518,443,ls),
+(518,605,o),
+(432,702,o),
+(291,702,cs),
+(151,702,o),
+(60,604,o),
+(60,447,cs),
+(60,296,o),
+(148,198,o),
+(277,198,cs),
+(357,198,o),
+(417,242,o),
+(431,300,c),
+(421,313,l),
+(421,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(207,280,o),
+(155,341,o),
+(155,450,cs),
+(155,559,o),
+(205,620,o),
+(289,620,cs),
+(373,620,o),
+(423,560,o),
+(423,450,cs),
+(423,342,o),
+(371,280,o),
+(289,280,cs)
+);
+}
+);
+width = 587;
+}
+);
+metricRight = "te-canadian";
+note = uni146B;
+unicode = 5227;
+},
+{
+glyphname = "kaai-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (172,0);
+ref = ring_top.canadian;
+}
+);
+width = 586;
+}
+);
+note = uni146C;
+unicode = 5228;
+},
+{
+glyphname = "ki-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (312,441);
+},
+{
+name = top_center_can;
+pos = (297,690);
+},
+{
+name = top_left_can;
+pos = (116,690);
+},
+{
+name = top_right_can;
+pos = (479,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(164,0,l),
+(164,313,l),
+(155,300,l),
+(169,242,o),
+(229,198,o),
+(309,198,cs),
+(439,198,o),
+(526,297,o),
+(526,450,cs),
+(526,606,o),
+(436,702,o),
+(298,702,cs),
+(156,702,o),
+(69,604,o),
+(69,443,cs),
+(69,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(214,280,o),
+(162,342,o),
+(162,450,cs),
+(162,560,o),
+(213,620,o),
+(297,620,cs),
+(381,620,o),
+(432,559,o),
+(432,450,cs),
+(432,341,o),
+(379,280,o),
+(297,280,cs)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni146D;
+unicode = 5229;
+},
+{
+glyphname = "kii-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (223,0);
+ref = dot_top;
+}
+);
+width = 586;
+}
+);
+note = uni146E;
+unicode = 5230;
+},
+{
+glyphname = "ko-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (304,355);
+},
+{
+name = top_center_can;
+pos = (289,690);
+},
+{
+name = top_double;
+pos = (470,690);
+},
+{
+name = top_left_can;
+pos = (107,690);
+},
+{
+name = top_right_can;
+pos = (470,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(432,-13,o),
+(518,85,o),
+(518,246,cs),
+(518,690,l),
+(421,690,l),
+(421,377,l),
+(431,389,l),
+(417,447,o),
+(357,492,o),
+(278,492,cs),
+(148,492,o),
+(60,391,o),
+(60,238,cs),
+(60,84,o),
+(148,-13,o),
+(289,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(205,70,o),
+(155,130,o),
+(155,240,cs),
+(155,349,o),
+(207,410,o),
+(289,410,cs),
+(371,410,o),
+(423,348,o),
+(423,240,cs),
+(423,129,o),
+(373,70,o),
+(289,70,cs)
+);
+}
+);
+width = 587;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni146F;
+unicode = 5231;
+},
+{
+glyphname = "koo-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (396,0);
+ref = dot_top;
+}
+);
+width = 586;
+}
+);
+note = uni1470;
+unicode = 5232;
+},
+{
+glyphname = "ycreekoo-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (229,0);
+ref = doubledot_top;
+}
+);
+width = 586;
+}
+);
+note = uni1471;
+unicode = 5233;
+},
+{
+glyphname = "ka-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (312,357);
+},
+{
+name = top_center_can;
+pos = (298,690);
+},
+{
+name = top_left_can;
+pos = (116,690);
+},
+{
+name = top_right_can;
+pos = (479,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(435,-13,o),
+(526,84,o),
+(526,242,cs),
+(526,393,o),
+(439,492,o),
+(311,492,cs),
+(230,492,o),
+(170,447,o),
+(155,389,c),
+(164,377,l),
+(164,690,l),
+(69,690,l),
+(69,246,ls),
+(69,85,o),
+(154,-13,o),
+(296,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(213,70,o),
+(162,129,o),
+(162,240,cs),
+(162,348,o),
+(214,410,o),
+(297,410,cs),
+(379,410,o),
+(432,349,o),
+(432,240,cs),
+(432,130,o),
+(381,70,o),
+(297,70,cs)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "==|ke-canadian";
+note = uni1472;
+unicode = 5234;
+},
+{
+glyphname = "kaa-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (43,0);
+ref = dot_top;
+}
+);
+width = 586;
+}
+);
+note = uni1473;
+unicode = 5235;
+},
+{
+glyphname = "kwe-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ke-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni1474;
+unicode = 5236;
+},
+{
+glyphname = "kweWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (586,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni1475;
+unicode = 5237;
+},
+{
+glyphname = "kwi-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ki-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni1476;
+unicode = 5238;
+},
+{
+glyphname = "kwiWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (586,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni1477;
+unicode = 5239;
+},
+{
+glyphname = "kwii-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (448,0);
+ref = dot_top;
+}
+);
+width = 810;
+}
+);
+note = uni1478;
+unicode = 5240;
+},
+{
+glyphname = "kwiiWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (223,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (586,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni1479;
+unicode = 5241;
+},
+{
+glyphname = "kwo-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ko-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni147A;
+unicode = 5242;
+},
+{
+glyphname = "kwoWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (586,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni147B;
+unicode = 5243;
+},
+{
+glyphname = "kwoo-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (621,0);
+ref = dot_top;
+}
+);
+width = 810;
+}
+);
+note = uni147C;
+unicode = 5244;
+},
+{
+glyphname = "kwooWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (396,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (586,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni147D;
+unicode = 5245;
+},
+{
+glyphname = "kwa-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ka-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni147E;
+unicode = 5246;
+},
+{
+glyphname = "kwaWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (586,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni147F;
+unicode = 5247;
+},
+{
+glyphname = "kwaa-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (268,0);
+ref = dot_top;
+}
+);
+width = 810;
+}
+);
+note = uni1480;
+unicode = 5248;
+},
+{
+glyphname = "kwaaWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (43,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (586,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni1481;
+unicode = 5249;
+},
+{
+glyphname = "kwaaNaskapi-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ka-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni1482;
+unicode = 5250;
+},
+{
+glyphname = "k-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(264,339,o),
+(319,388,o),
+(319,472,cs),
+(319,552,o),
+(269,601,o),
+(204,601,cs),
+(158,601,o),
+(125,573,o),
+(117,534,c),
+(132,529,l),
+(132,690,l),
+(64,690,l),
+(64,473,ls),
+(64,390,o),
+(114,339,o),
+(193,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(152,390,o),
+(127,417,o),
+(127,470,cs),
+(127,522,o),
+(155,550,o),
+(191,550,cs),
+(230,550,o),
+(257,522,o),
+(257,470,cs),
+(257,419,o),
+(231,390,o),
+(192,390,cs)
+);
+}
+);
+width = 373;
+}
+);
+note = uni1483;
+unicode = 5251;
+},
+{
+glyphname = "kw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(258,339,o),
+(309,390,o),
+(309,473,cs),
+(309,690,l),
+(241,690,l),
+(241,529,l),
+(256,534,l),
+(248,573,o),
+(214,601,o),
+(169,601,cs),
+(104,601,o),
+(54,552,o),
+(54,472,cs),
+(54,388,o),
+(109,339,o),
+(180,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(142,390,o),
+(116,419,o),
+(116,470,cs),
+(116,522,o),
+(143,550,o),
+(181,550,cs),
+(218,550,o),
+(245,522,o),
+(245,470,cs),
+(245,417,o),
+(221,390,o),
+(181,390,cs)
+);
+}
+);
+width = 373;
+}
+);
+metricLeft = "=|k-canadian";
+metricRight = "=|k-canadian";
+note = uni1484;
+unicode = 5252;
+},
+{
+glyphname = "southslaveykeh-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+pos = (586,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 782;
+}
+);
+note = uni1485;
+unicode = 5253;
+},
+{
+glyphname = "southslaveykih-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+pos = (586,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 782;
+}
+);
+note = uni1486;
+unicode = 5254;
+},
+{
+glyphname = "southslaveykoh-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+pos = (586,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 782;
+}
+);
+note = uni1487;
+unicode = 5255;
+},
+{
+glyphname = "southslaveykah-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+pos = (586,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 782;
+}
+);
+note = uni1488;
+unicode = 5256;
+},
+{
+glyphname = "ce-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (301,399);
+},
+{
+name = top_center_can;
+pos = (289,690);
+},
+{
+name = top_left_can;
+pos = (107,690);
+},
+{
+name = top_right_can;
+pos = (465,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(513,0,l),
+(513,448,ls),
+(513,609,o),
+(429,702,o),
+(289,702,cs),
+(146,702,o),
+(59,608,o),
+(59,449,cs),
+(59,387,l),
+(155,387,l),
+(155,457,ls),
+(155,560,o),
+(202,618,o),
+(287,618,cs),
+(369,618,o),
+(416,560,o),
+(416,457,cs),
+(416,0,l)
+);
+}
+);
+width = 582;
+}
+);
+metricRight = "te-canadian";
+note = uni1489;
+unicode = 5257;
+},
+{
+glyphname = "caai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (173,0);
+ref = ring_top.canadian;
+}
+);
+width = 581;
+}
+);
+note = uni148A;
+unicode = 5258;
+},
+{
+glyphname = "ci-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (304,399);
+},
+{
+name = top_center_can;
+pos = (298,690);
+},
+{
+name = top_left_can;
+pos = (117,690);
+},
+{
+name = top_right_can;
+pos = (475,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(164,0,l),
+(164,457,ls),
+(164,560,o),
+(213,618,o),
+(297,618,cs),
+(381,618,o),
+(426,560,o),
+(426,458,cs),
+(426,387,l),
+(522,387,l),
+(522,449,ls),
+(522,608,o),
+(439,702,o),
+(298,702,cs),
+(153,702,o),
+(69,607,o),
+(69,448,cs),
+(69,0,l)
+);
+}
+);
+width = 581;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+unicode = 5259;
+},
+{
+glyphname = "cii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (225,0);
+ref = dot_top;
+}
+);
+width = 581;
+}
+);
+note = uni148C;
+unicode = 5260;
+},
+{
+glyphname = "co-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (301,399);
+},
+{
+name = top_center_can;
+pos = (288,690);
+},
+{
+name = top_double;
+pos = (465,690);
+},
+{
+name = top_left_can;
+pos = (107,690);
+},
+{
+name = top_right_can;
+pos = (465,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(428,-13,o),
+(513,79,o),
+(513,242,cs),
+(513,690,l),
+(416,690,l),
+(416,233,ls),
+(416,128,o),
+(369,71,o),
+(287,71,cs),
+(200,71,o),
+(155,129,o),
+(155,236,cs),
+(155,302,l),
+(59,302,l),
+(59,240,ls),
+(59,82,o),
+(142,-13,o),
+(289,-13,cs)
+);
+}
+);
+width = 582;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+unicode = 5261;
+},
+{
+glyphname = "coo-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (391,0);
+ref = dot_top;
+}
+);
+width = 581;
+}
+);
+note = uni148E;
+unicode = 5262;
+},
+{
+glyphname = "ycreecoo-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (224,0);
+ref = doubledot_top;
+}
+);
+width = 581;
+}
+);
+note = uni148F;
+unicode = 5263;
+},
+{
+glyphname = "ca-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (304,399);
+},
+{
+name = top_center_can;
+pos = (298,690);
+},
+{
+name = top_left_can;
+pos = (117,690);
+},
+{
+name = top_right_can;
+pos = (475,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(439,-13,o),
+(522,81,o),
+(522,241,cs),
+(522,302,l),
+(426,302,l),
+(426,235,ls),
+(426,128,o),
+(381,71,o),
+(297,71,cs),
+(211,71,o),
+(164,129,o),
+(164,235,cs),
+(164,690,l),
+(69,690,l),
+(69,242,ls),
+(69,80,o),
+(151,-13,o),
+(296,-13,cs)
+);
+}
+);
+width = 581;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+unicode = 5264;
+},
+{
+glyphname = "caa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (43,0);
+ref = dot_top;
+}
+);
+width = 581;
+}
+);
+note = uni1491;
+unicode = 5265;
+},
+{
+glyphname = "cwe-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ce-canadian";
+}
+);
+width = 806;
+}
+);
+note = uni1492;
+unicode = 5266;
+},
+{
+glyphname = "cweWestCree-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (581,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 806;
+}
+);
+note = uni1493;
+unicode = 5267;
+},
+{
+glyphname = "cwi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ci-canadian";
+}
+);
+width = 806;
+}
+);
+note = uni1494;
+unicode = 5268;
+},
+{
+glyphname = "cwiWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (581,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 806;
+}
+);
+note = uni1495;
+unicode = 5269;
+},
+{
+glyphname = "cwii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (449,0);
+ref = dot_top;
+}
+);
+width = 806;
+}
+);
+note = uni1496;
+unicode = 5270;
+},
+{
+glyphname = "cwiiWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (225,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (581,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 806;
+}
+);
+note = uni1497;
+unicode = 5271;
+},
+{
+glyphname = "cwo-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "co-canadian";
+}
+);
+width = 806;
+}
+);
+note = uni1498;
+unicode = 5272;
+},
+{
+glyphname = "cwoWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (581,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 806;
+}
+);
+note = uni1499;
+unicode = 5273;
+},
+{
+glyphname = "cwoo-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (616,0);
+ref = dot_top;
+}
+);
+width = 806;
+}
+);
+note = uni149A;
+unicode = 5274;
+},
+{
+glyphname = "cwooWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (391,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (581,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 806;
+}
+);
+note = uni149B;
+unicode = 5275;
+},
+{
+glyphname = "cwa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ca-canadian";
+}
+);
+width = 806;
+}
+);
+note = uni149C;
+unicode = 5276;
+},
+{
+glyphname = "cwaWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (581,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 806;
+}
+);
+note = uni149D;
+unicode = 5277;
+},
+{
+glyphname = "cwaa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (268,0);
+ref = dot_top;
+}
+);
+width = 806;
+}
+);
+note = uni149E;
+unicode = 5278;
+},
+{
+glyphname = "cwaaWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (43,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (581,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 806;
+}
+);
+note = uni149F;
+unicode = 5279;
+},
+{
+glyphname = "cwaaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ca-canadian";
+}
+);
+width = 805;
+}
+);
+note = uni14A0;
+unicode = 5280;
+},
+{
+glyphname = "c-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(269,339,o),
+(320,385,o),
+(320,468,cs),
+(320,487,l),
+(256,487,l),
+(256,463,ls),
+(256,417,o),
+(231,393,o),
+(193,393,cs),
+(155,393,o),
+(132,417,o),
+(132,468,cs),
+(132,690,l),
+(64,690,l),
+(64,476,ls),
+(64,386,o),
+(111,339,o),
+(193,339,cs)
+);
+}
+);
+width = 363;
+}
+);
+note = uni14A1;
+unicode = 5281;
+},
+{
+glyphname = "thSayisi-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(251,339,o),
+(298,386,o),
+(298,476,cs),
+(298,690,l),
+(231,690,l),
+(231,468,ls),
+(231,417,o),
+(209,393,o),
+(170,393,cs),
+(131,393,o),
+(107,417,o),
+(107,463,cs),
+(107,487,l),
+(43,487,l),
+(43,468,ls),
+(43,385,o),
+(95,339,o),
+(170,339,cs)
+);
+}
+);
+width = 362;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "=|c-canadian";
+note = uni14A2;
+unicode = 5282;
+},
+{
+glyphname = "me-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (198,345);
+},
+{
+name = top_center_can;
+pos = (248,690);
+},
+{
+name = top_left_can;
+pos = (88,690);
+},
+{
+name = top_right_can;
+pos = (405,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(452,0,l),
+(452,690,l),
+(40,690,l),
+(40,603,l),
+(356,603,l),
+(356,0,l)
+);
+}
+);
+width = 527;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+unicode = 5283;
+},
+{
+glyphname = "maai-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (157,0);
+ref = ring_top.canadian;
+}
+);
+width = 528;
+}
+);
+note = uni14A4;
+unicode = 5284;
+},
+{
+glyphname = "mi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (330,345);
+},
+{
+name = top_center_can;
+pos = (282,690);
+},
+{
+name = top_left_can;
+pos = (124,690);
+},
+{
+name = top_right_can;
+pos = (440,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(172,0,l),
+(172,603,l),
+(488,603,l),
+(488,690,l),
+(75,690,l),
+(75,0,l)
+);
+}
+);
+width = 528;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+unicode = 5285;
+},
+{
+glyphname = "mii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (209,0);
+ref = dot_top;
+}
+);
+width = 528;
+}
+);
+note = uni14A6;
+unicode = 5286;
+},
+{
+glyphname = "mo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (198,345);
+},
+{
+name = top_center_can;
+pos = (248,690);
+},
+{
+name = top_double;
+pos = (405,690);
+},
+{
+name = top_left_can;
+pos = (88,690);
+},
+{
+name = top_right_can;
+pos = (405,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(452,0,l),
+(452,690,l),
+(356,690,l),
+(356,87,l),
+(40,87,l),
+(40,0,l)
+);
+}
+);
+width = 527;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+unicode = 5287;
+},
+{
+glyphname = "moo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (331,0);
+ref = dot_top;
+}
+);
+width = 528;
+}
+);
+note = uni14A8;
+unicode = 5288;
+},
+{
+glyphname = "ycreemoo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (163,0);
+ref = doubledot_top;
+}
+);
+width = 528;
+}
+);
+note = uni14A9;
+unicode = 5289;
+},
+{
+glyphname = "ma-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (330,345);
+},
+{
+name = top_center_can;
+pos = (282,690);
+},
+{
+name = top_left_can;
+pos = (124,690);
+},
+{
+name = top_right_can;
+pos = (440,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(488,0,l),
+(488,87,l),
+(172,87,l),
+(172,690,l),
+(75,690,l),
+(75,0,l)
+);
+}
+);
+width = 528;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+unicode = 5290;
+},
+{
+glyphname = "maa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+}
+);
+width = 528;
+}
+);
+note = uni14AB;
+unicode = 5291;
+},
+{
+glyphname = "mwe-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "me-canadian";
+}
+);
+width = 753;
+}
+);
+note = uni14AC;
+unicode = 5292;
+},
+{
+glyphname = "mweWestCree-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "me-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (528,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 753;
+}
+);
+note = uni14AD;
+unicode = 5293;
+},
+{
+glyphname = "mwi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "mi-canadian";
+}
+);
+width = 753;
+}
+);
+note = uni14AE;
+unicode = 5294;
+},
+{
+glyphname = "mwiWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (528,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 753;
+}
+);
+note = uni14AF;
+unicode = 5295;
+},
+{
+glyphname = "mwii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (433,0);
+ref = dot_top;
+}
+);
+width = 753;
+}
+);
+note = uni14B0;
+unicode = 5296;
+},
+{
+glyphname = "mwiiWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (209,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (528,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 753;
+}
+);
+note = uni14B1;
+unicode = 5297;
+},
+{
+glyphname = "mwo-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "mo-canadian";
+}
+);
+width = 753;
+}
+);
+note = uni14B2;
+unicode = 5298;
+},
+{
+glyphname = "mwoWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (528,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 753;
+}
+);
+note = uni14B3;
+unicode = 5299;
+},
+{
+glyphname = "mwoo-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (555,0);
+ref = dot_top;
+}
+);
+width = 753;
+}
+);
+note = uni14B4;
+unicode = 5300;
+},
+{
+glyphname = "mwooWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (331,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (528,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 753;
+}
+);
+note = uni14B5;
+unicode = 5301;
+},
+{
+glyphname = "mwa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ma-canadian";
+}
+);
+width = 753;
+}
+);
+note = uni14B6;
+unicode = 5302;
+},
+{
+glyphname = "mwaWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (528,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 753;
+}
+);
+note = uni14B7;
+unicode = 5303;
+},
+{
+glyphname = "mwaa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (275,0);
+ref = dot_top;
+}
+);
+width = 753;
+}
+);
+note = uni14B8;
+unicode = 5304;
+},
+{
+glyphname = "mwaaWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (528,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 753;
+}
+);
+note = uni14B9;
+unicode = 5305;
+},
+{
+glyphname = "mwaaNaskapi-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ma-canadian";
+}
+);
+width = 752;
+}
+);
+note = uni14BA;
+unicode = 5306;
+},
+{
+glyphname = "m-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(290,409,l),
+(132,409,l),
+(132,690,l),
+(64,690,l),
+(64,345,l),
+(290,345,l)
+);
+}
+);
+width = 337;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni14BB;
+unicode = 5307;
+},
+{
+glyphname = "mWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+ref = "t-canadian";
+}
+);
+width = 369;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "t-canadian";
+note = uni14BC;
+unicode = 5308;
+},
+{
+glyphname = "mh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(273,345,l),
+(273,690,l),
+(205,690,l),
+(205,409,l),
+(47,409,l),
+(47,345,l)
+);
+}
+);
+width = 337;
+}
+);
+metricLeft = "=|m-canadian";
+metricRight = "=|m-canadian";
+note = uni14BD;
+unicode = 5309;
+},
+{
+glyphname = "mAthapascan-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(304,345,l),
+(304,400,l),
+(136,400,l),
+(137,371,l),
+(242,481,ls),
+(276,518,o),
+(290,553,o),
+(290,592,cs),
+(290,654,o),
+(246,696,o),
+(176,696,cs),
+(99,696,o),
+(55,647,o),
+(54,572,c),
+(115,572,l),
+(115,620,o),
+(135,644,o),
+(175,644,cs),
+(210,644,o),
+(229,625,o),
+(229,590,cs),
+(229,559,o),
+(219,537,o),
+(187,502,cs),
+(68,379,l),
+(68,345,l)
+);
+}
+);
+width = 353;
+}
+);
+note = uni14BE;
+unicode = 5310;
+},
+{
+glyphname = "mSayisi-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = two.canadian;
+}
+);
+width = 581;
+}
+);
+note = uni14BF;
+unicode = 5311;
+},
+{
+glyphname = "ne-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (510,245);
+},
+{
+name = top_center_can;
+pos = (498,497);
+},
+{
+name = top_left_can;
+pos = (103,497);
+},
+{
+name = top_right_can;
+pos = (698,497);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(651,-13,o),
+(745,82,o),
+(745,234,cs),
+(745,387,o),
+(653,479,o),
+(498,479,cs),
+(55,479,l),
+(55,393,l),
+(381,393,l),
+(369,415,l),
+(307,383,o),
+(276,309,o),
+(276,229,cs),
+(276,79,o),
+(367,-13,o),
+(510,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(421,70,o),
+(370,132,o),
+(370,233,cs),
+(370,332,o),
+(421,397,o),
+(509,397,cs),
+(599,397,o),
+(650,333,o),
+(650,233,cs),
+(650,132,o),
+(599,70,o),
+(510,70,cs)
+);
+}
+);
+width = 805;
+}
+);
+metricRight = "=|ke-canadian";
+note = uni14C0;
+unicode = 5312;
+},
+{
+glyphname = "naai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (183,-192);
+ref = ring_top.canadian;
+}
+);
+width = 805;
+}
+);
+note = uni14C1;
+unicode = 5313;
+},
+{
+glyphname = "ni-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (296,245);
+},
+{
+name = top_center_can;
+pos = (308,497);
+},
+{
+name = top_left_can;
+pos = (107,497);
+},
+{
+name = top_right_can;
+pos = (701,497);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(438,-13,o),
+(528,79,o),
+(528,230,cs),
+(528,310,o),
+(497,384,o),
+(435,416,c),
+(424,393,l),
+(750,393,l),
+(750,479,l),
+(308,479,ls),
+(151,479,o),
+(60,382,o),
+(60,232,cs),
+(60,81,o),
+(154,-13,o),
+(295,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(206,70,o),
+(155,132,o),
+(155,234,cs),
+(155,334,o),
+(206,397,o),
+(296,397,cs),
+(384,397,o),
+(435,332,o),
+(435,234,cs),
+(435,132,o),
+(384,70,o),
+(295,70,cs)
+);
+}
+);
+width = 805;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+unicode = 5314;
+},
+{
+glyphname = "nii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (235,-192);
+ref = dot_top;
+}
+);
+width = 805;
+}
+);
+note = uni14C3;
+unicode = 5315;
+},
+{
+glyphname = "no-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (510,245);
+},
+{
+name = top_center_can;
+pos = (507,497);
+},
+{
+name = top_double;
+pos = (510,497);
+},
+{
+name = top_left_can;
+pos = (103,497);
+},
+{
+name = top_right_can;
+pos = (698,497);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(502,0,ls),
+(654,0,o),
+(745,94,o),
+(745,245,cs),
+(745,397,o),
+(652,492,o),
+(510,492,cs),
+(368,492,o),
+(276,398,o),
+(276,249,cs),
+(276,170,o),
+(307,97,o),
+(369,64,c),
+(381,86,l),
+(55,86,l),
+(55,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(421,82,o),
+(370,147,o),
+(370,245,cs),
+(370,347,o),
+(421,410,o),
+(510,410,cs),
+(599,410,o),
+(650,347,o),
+(650,245,cs),
+(650,145,o),
+(599,82,o),
+(509,82,cs)
+);
+}
+);
+width = 805;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14C4;
+unicode = 5316;
+},
+{
+glyphname = "noo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (434,-192);
+ref = dot_top;
+}
+);
+width = 805;
+}
+);
+note = uni14C5;
+unicode = 5317;
+},
+{
+glyphname = "ycreenoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (269,-192);
+ref = doubledot_top;
+}
+);
+width = 805;
+}
+);
+note = uni14C6;
+unicode = 5318;
+},
+{
+glyphname = "na-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (296,245);
+},
+{
+name = top_center_can;
+pos = (298,497);
+},
+{
+name = top_double;
+pos = (453,497);
+},
+{
+name = top_left_can;
+pos = (107,497);
+},
+{
+name = top_right_can;
+pos = (701,497);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(750,0,l),
+(750,86,l),
+(424,86,l),
+(436,62,l),
+(497,96,o),
+(528,169,o),
+(528,249,cs),
+(528,399,o),
+(438,492,o),
+(295,492,cs),
+(154,492,o),
+(60,397,o),
+(60,244,cs),
+(60,96,o),
+(150,0,o),
+(304,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(206,82,o),
+(155,145,o),
+(155,245,cs),
+(155,347,o),
+(206,410,o),
+(295,410,cs),
+(384,410,o),
+(435,347,o),
+(435,245,cs),
+(435,147,o),
+(384,82,o),
+(296,82,cs)
+);
+}
+);
+width = 805;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+unicode = 5319;
+},
+{
+glyphname = "naa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (224,-192);
+ref = dot_top;
+}
+);
+width = 805;
+}
+);
+note = uni14C8;
+unicode = 5320;
+},
+{
+glyphname = "nwe-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ne-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni14C9;
+unicode = 5321;
+},
+{
+glyphname = "nweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (805,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni14CA;
+unicode = 5322;
+},
+{
+glyphname = "nwa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "na-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni14CB;
+unicode = 5323;
+},
+{
+glyphname = "nwaWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (805,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni14CC;
+unicode = 5324;
+},
+{
+glyphname = "nwaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (448,-192);
+ref = dot_top;
+}
+);
+width = 1029;
+}
+);
+note = uni14CD;
+unicode = 5325;
+},
+{
+glyphname = "nwaaWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (224,-192);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (805,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni14CE;
+unicode = 5326;
+},
+{
+glyphname = "nwaaNaskapi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (212,-192);
+ref = doubledot_top;
+}
+);
+width = 805;
+}
+);
+note = uni14CF;
+unicode = 5327;
+},
+{
+glyphname = "n-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(431,435,l),
+(431,497,l),
+(249,497,l),
+(252,469,l),
+(284,481,o),
+(306,522,o),
+(306,569,cs),
+(306,646,o),
+(257,696,o),
+(181,696,cs),
+(105,696,o),
+(54,645,o),
+(54,566,cs),
+(54,487,o),
+(104,435,o),
+(186,435,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(142,485,o),
+(115,515,o),
+(115,566,cs),
+(115,616,o),
+(142,645,o),
+(181,645,cs),
+(219,645,o),
+(245,616,o),
+(245,565,cs),
+(245,515,o),
+(219,485,o),
+(181,485,cs)
+);
+}
+);
+width = 478;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni14D0;
+unicode = 5328;
+},
+{
+color = 6;
+glyphname = "ngCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-161);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 424;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "=|";
+note = uni14D1;
+unicode = 5329;
+},
+{
+glyphname = "nh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(293,435,ls),
+(374,435,o),
+(424,487,o),
+(424,566,cs),
+(424,645,o),
+(373,696,o),
+(298,696,cs),
+(221,696,o),
+(172,646,o),
+(172,569,cs),
+(172,522,o),
+(194,481,o),
+(226,469,c),
+(229,497,l),
+(47,497,l),
+(47,435,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(259,485,o),
+(233,515,o),
+(233,565,cs),
+(233,616,o),
+(260,645,o),
+(298,645,cs),
+(336,645,o),
+(363,616,o),
+(363,566,cs),
+(363,515,o),
+(336,485,o),
+(298,485,cs)
+);
+}
+);
+width = 478;
+}
+);
+metricLeft = "=|n-canadian";
+metricRight = "=|n-canadian";
+note = uni14D2;
+unicode = 5330;
+},
+{
+glyphname = "le-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (510,245);
+},
+{
+name = top_center_can;
+pos = (499,497);
+},
+{
+name = top_left_can;
+pos = (103,497);
+},
+{
+name = top_right_can;
+pos = (697,497);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(495,0,ls),
+(648,0,o),
+(745,91,o),
+(745,240,cs),
+(745,388,o),
+(655,479,o),
+(493,479,cs),
+(55,479,l),
+(55,392,l),
+(492,392,ls),
+(593,392,o),
+(650,336,o),
+(650,239,cs),
+(650,141,o),
+(591,85,o),
+(490,85,cs),
+(441,85,l),
+(441,0,l)
+);
+}
+);
+width = 805;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D3;
+unicode = 5331;
+},
+{
+glyphname = "laai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (183,-192);
+ref = ring_top.canadian;
+}
+);
+width = 805;
+}
+);
+note = uni14D4;
+unicode = 5332;
+},
+{
+glyphname = "li-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (296,245);
+},
+{
+name = top_center_can;
+pos = (308,497);
+},
+{
+name = top_left_can;
+pos = (107,497);
+},
+{
+name = top_right_can;
+pos = (701,497);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(363,0,l),
+(363,85,l),
+(315,85,ls),
+(211,85,o),
+(156,141,o),
+(156,238,cs),
+(156,331,o),
+(206,392,o),
+(314,392,cs),
+(750,392,l),
+(750,479,l),
+(312,479,ls),
+(151,479,o),
+(60,384,o),
+(60,238,cs),
+(60,91,o),
+(156,0,o),
+(310,0,cs)
+);
+}
+);
+width = 805;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14D5;
+unicode = 5333;
+},
+{
+glyphname = "lii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (235,-192);
+ref = dot_top;
+}
+);
+width = 805;
+}
+);
+note = uni14D6;
+unicode = 5334;
+},
+{
+glyphname = "lo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (510,245);
+},
+{
+name = top_center_can;
+pos = (507,497);
+},
+{
+name = top_double;
+pos = (496,497);
+},
+{
+name = top_left_can;
+pos = (103,497);
+},
+{
+name = top_right_can;
+pos = (697,497);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(491,0,ls),
+(652,0,o),
+(745,91,o),
+(745,241,cs),
+(745,389,o),
+(649,479,o),
+(496,479,cs),
+(441,479,l),
+(441,394,l),
+(490,394,ls),
+(594,394,o),
+(650,338,o),
+(650,242,cs),
+(650,143,o),
+(594,87,o),
+(491,87,cs),
+(55,87,l),
+(55,0,l)
+);
+}
+);
+width = 805;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D7;
+unicode = 5335;
+},
+{
+glyphname = "loo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (434,-192);
+ref = dot_top;
+}
+);
+width = 805;
+}
+);
+note = uni14D8;
+unicode = 5336;
+},
+{
+glyphname = "ycreeloo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (254,-192);
+ref = doubledot_top;
+}
+);
+width = 805;
+}
+);
+note = uni14D9;
+unicode = 5337;
+},
+{
+glyphname = "la-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (296,245);
+},
+{
+name = top_center_can;
+pos = (298,497);
+},
+{
+name = top_left_can;
+pos = (107,497);
+},
+{
+name = top_right_can;
+pos = (701,497);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(750,0,l),
+(750,87,l),
+(316,87,ls),
+(211,87,o),
+(156,143,o),
+(156,241,cs),
+(156,338,o),
+(210,394,o),
+(312,394,cs),
+(363,394,l),
+(363,479,l),
+(311,479,ls),
+(153,479,o),
+(60,387,o),
+(60,240,cs),
+(60,89,o),
+(155,0,o),
+(314,0,cs)
+);
+}
+);
+width = 805;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14DA;
+unicode = 5338;
+},
+{
+glyphname = "laa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (224,-192);
+ref = dot_top;
+}
+);
+width = 805;
+}
+);
+note = uni14DB;
+unicode = 5339;
+},
+{
+glyphname = "lwe-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "le-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni14DC;
+unicode = 5340;
+},
+{
+glyphname = "lweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "le-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (805,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni14DD;
+unicode = 5341;
+},
+{
+glyphname = "lwi-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "li-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni14DE;
+unicode = 5342;
+},
+{
+glyphname = "lwiWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (805,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni14DF;
+unicode = 5343;
+},
+{
+glyphname = "lwii-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (459,-192);
+ref = dot_top;
+}
+);
+width = 1029;
+}
+);
+note = uni14E0;
+unicode = 5344;
+},
+{
+glyphname = "lwiiWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (235,-192);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (805,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni14E1;
+unicode = 5345;
+},
+{
+glyphname = "lwo-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "lo-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni14E2;
+unicode = 5346;
+},
+{
+glyphname = "lwoWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (805,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni14E3;
+unicode = 5347;
+},
+{
+glyphname = "lwoo-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (658,-192);
+ref = dot_top;
+}
+);
+width = 1029;
+}
+);
+note = uni14E4;
+unicode = 5348;
+},
+{
+glyphname = "lwooWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (434,-192);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (805,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni14E5;
+unicode = 5349;
+},
+{
+glyphname = "lwa-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "la-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni14E6;
+unicode = 5350;
+},
+{
+glyphname = "lwaWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (805,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni14E7;
+unicode = 5351;
+},
+{
+glyphname = "lwaa-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (448,-192);
+ref = dot_top;
+}
+);
+width = 1029;
+}
+);
+note = uni14E8;
+unicode = 5352;
+},
+{
+glyphname = "lwaaWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (224,-192);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (805,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni14E9;
+unicode = 5353;
+},
+{
+glyphname = "l-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(426,345,l),
+(426,409,l),
+(242,409,ls),
+(165,409,o),
+(128,446,o),
+(128,518,cs),
+(128,588,o),
+(165,628,o),
+(239,628,cs),
+(253,628,l),
+(253,690,l),
+(234,690,ls),
+(124,690,o),
+(60,624,o),
+(60,517,cs),
+(60,411,o),
+(124,345,o),
+(235,345,cs)
+);
+}
+);
+width = 473;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "m-canadian";
+note = uni14EA;
+unicode = 5354;
+},
+{
+glyphname = "lWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(304,345,l),
+(304,389,l),
+(119,464,l),
+(119,431,l),
+(304,502,l),
+(304,532,l),
+(119,604,l),
+(119,571,l),
+(304,644,l),
+(304,690,l),
+(291,690,l),
+(64,600,l),
+(64,576,l),
+(253,504,l),
+(253,529,l),
+(64,459,l),
+(64,434,l),
+(291,345,l)
+);
+}
+);
+width = 368;
+}
+);
+metricRight = "=|";
+note = uni14EB;
+unicode = 5355;
+},
+{
+glyphname = "mediall-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(569,-13,l),
+(569,58,l),
+(165,215,l),
+(165,172,l),
+(569,324,l),
+(569,365,l),
+(165,518,l),
+(165,474,l),
+(569,632,l),
+(569,702,l),
+(544,702,l),
+(70,517,l),
+(70,479,l),
+(473,327,l),
+(473,362,l),
+(70,211,l),
+(70,173,l),
+(544,-13,l)
+);
+}
+);
+width = 639;
+}
+);
+metricRight = "=|";
+note = uni14EC;
+unicode = 5356;
+},
+{
+glyphname = "se-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (122,690);
+},
+{
+name = top_right_can;
+pos = (416,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(464,0,l),
+(464,332,l),
+(425,332,ls),
+(257,332,o),
+(170,414,o),
+(170,596,cs),
+(170,690,l),
+(73,690,l),
+(73,586,ls),
+(73,367,o),
+(197,246,o),
+(407,246,cs),
+(439,246,l),
+(368,281,l),
+(368,0,l)
+);
+}
+);
+width = 539;
+}
+);
+note = uni14ED;
+unicode = 5357;
+},
+{
+glyphname = "saai-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (294,0);
+ref = ring_top.canadian;
+}
+);
+width = 539;
+}
+);
+note = uni14EE;
+unicode = 5358;
+},
+{
+glyphname = "si-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (124,690);
+},
+{
+name = top_right_can;
+pos = (418,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(172,0,l),
+(172,281,l),
+(100,246,l),
+(133,246,ls),
+(342,246,o),
+(466,367,o),
+(466,586,cs),
+(466,690,l),
+(370,690,l),
+(370,596,ls),
+(370,414,o),
+(283,332,o),
+(114,332,cs),
+(75,332,l),
+(75,0,l)
+);
+}
+);
+width = 539;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+unicode = 5359;
+},
+{
+glyphname = "sii-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (345,0);
+ref = dot_top;
+}
+);
+width = 539;
+}
+);
+note = uni14F0;
+unicode = 5360;
+},
+{
+glyphname = "so-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (416,690);
+},
+{
+name = top_left_can;
+pos = (122,690);
+},
+{
+name = top_right_can;
+pos = (415,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(170,0,l),
+(170,94,ls),
+(170,275,o),
+(257,357,o),
+(425,357,cs),
+(464,357,l),
+(464,690,l),
+(368,690,l),
+(368,409,l),
+(439,443,l),
+(407,443,ls),
+(197,443,o),
+(73,323,o),
+(73,103,cs),
+(73,0,l)
+);
+}
+);
+width = 539;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+unicode = 5361;
+},
+{
+glyphname = "soo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (342,0);
+ref = dot_top;
+}
+);
+width = 539;
+}
+);
+note = uni14F2;
+unicode = 5362;
+},
+{
+glyphname = "ycreesoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (175,0);
+ref = doubledot_top;
+}
+);
+width = 539;
+}
+);
+note = uni14F3;
+unicode = 5363;
+},
+{
+glyphname = "sa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (125,690);
+},
+{
+name = top_right_can;
+pos = (418,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(466,0,l),
+(466,103,ls),
+(466,323,o),
+(342,443,o),
+(133,443,cs),
+(100,443,l),
+(172,409,l),
+(172,690,l),
+(75,690,l),
+(75,357,l),
+(114,357,ls),
+(283,357,o),
+(370,275,o),
+(370,94,cs),
+(370,0,l)
+);
+}
+);
+width = 539;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+unicode = 5364;
+},
+{
+glyphname = "saa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+}
+);
+width = 539;
+}
+);
+note = uni14F5;
+unicode = 5365;
+},
+{
+glyphname = "swe-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "se-canadian";
+}
+);
+width = 764;
+}
+);
+note = uni14F6;
+unicode = 5366;
+},
+{
+glyphname = "sweWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "se-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (539,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 764;
+}
+);
+note = uni14F7;
+unicode = 5367;
+},
+{
+glyphname = "swi-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "si-canadian";
+}
+);
+width = 764;
+}
+);
+note = uni14F8;
+unicode = 5368;
+},
+{
+glyphname = "swiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (539,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 764;
+}
+);
+note = uni14F9;
+unicode = 5369;
+},
+{
+glyphname = "swii-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (569,0);
+ref = dot_top;
+}
+);
+width = 764;
+}
+);
+note = uni14FA;
+unicode = 5370;
+},
+{
+glyphname = "swiiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (345,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (539,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 764;
+}
+);
+note = uni14FB;
+unicode = 5371;
+},
+{
+glyphname = "swo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "so-canadian";
+}
+);
+width = 764;
+}
+);
+note = uni14FC;
+unicode = 5372;
+},
+{
+glyphname = "swoWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (539,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 764;
+}
+);
+note = uni14FD;
+unicode = 5373;
+},
+{
+glyphname = "swoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (567,0);
+ref = dot_top;
+}
+);
+width = 764;
+}
+);
+note = uni14FE;
+unicode = 5374;
+},
+{
+glyphname = "swooWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (342,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (539,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 764;
+}
+);
+note = uni14FF;
+unicode = 5375;
+},
+{
+glyphname = "swa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "sa-canadian";
+}
+);
+width = 764;
+}
+);
+note = uni1500;
+unicode = 5376;
+},
+{
+glyphname = "swaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (539,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 764;
+}
+);
+note = uni1501;
+unicode = 5377;
+},
+{
+glyphname = "swaa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (275,0);
+ref = dot_top;
+}
+);
+width = 764;
+}
+);
+note = uni1502;
+unicode = 5378;
+},
+{
+glyphname = "swaaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (539,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 764;
+}
+);
+note = uni1503;
+unicode = 5379;
+},
+{
+glyphname = "swaaNaskapi-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "sa-canadian";
+}
+);
+width = 763;
+}
+);
+note = uni1504;
+unicode = 5380;
+},
+{
+glyphname = "s-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(294,345,l),
+(294,400,ls),
+(294,509,o),
+(233,580,o),
+(127,580,cs),
+(91,580,l),
+(132,549,l),
+(132,690,l),
+(64,690,l),
+(64,525,l),
+(101,525,ls),
+(186,525,o),
+(225,482,o),
+(225,396,cs),
+(225,345,l)
+);
+}
+);
+width = 358;
+}
+);
+metricRight = "=|";
+note = uni1505;
+unicode = 5381;
+},
+{
+color = 6;
+glyphname = "sAthapascan-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(269,177,o),
+(316,218,o),
+(316,274,cs),
+(316,317,o),
+(294,347,o),
+(242,365,cs),
+(169,390,ls),
+(139,402,o),
+(129,414,o),
+(129,436,cs),
+(129,465,o),
+(151,484,o),
+(191,484,cs),
+(232,484,o),
+(255,466,o),
+(256,424,c),
+(316,424,l),
+(315,493,o),
+(269,533,o),
+(191,533,cs),
+(117,533,o),
+(70,493,o),
+(70,436,cs),
+(70,392,o),
+(94,360,o),
+(141,344,cs),
+(215,319,ls),
+(244,307,o),
+(256,296,o),
+(256,272,cs),
+(256,243,o),
+(233,226,o),
+(192,226,cs),
+(149,226,o),
+(126,244,o),
+(124,288,c),
+(64,288,l),
+(66,216,o),
+(111,177,o),
+(191,177,cs)
+);
+}
+);
+width = 380;
+}
+);
+metricRight = "=|";
+note = uni1506;
+unicode = 5382;
+},
+{
+glyphname = "sw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(132,345,l),
+(132,396,ls),
+(132,482,o),
+(171,525,o),
+(256,525,cs),
+(294,525,l),
+(294,690,l),
+(225,690,l),
+(225,549,l),
+(267,580,l),
+(231,580,ls),
+(125,580,o),
+(64,509,o),
+(64,400,cs),
+(64,345,l)
+);
+}
+);
+width = 358;
+}
+);
+metricLeft = "=|s-canadian";
+metricRight = "=|s-canadian";
+note = uni1507;
+unicode = 5383;
+},
+{
+glyphname = "sBlackfoot-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(299,345,l),
+(299,409,l),
+(213,409,ls),
+(158,409,o),
+(132,435,o),
+(132,493,cs),
+(132,690,l),
+(64,690,l),
+(64,485,ls),
+(64,394,o),
+(113,345,o),
+(204,345,c)
+);
+}
+);
+width = 346;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "m-canadian";
+note = uni1508;
+unicode = 5384;
+},
+{
+glyphname = "moosecreesk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(264,217,o),
+(319,270,o),
+(319,367,cs),
+(319,503,o),
+(257,580,o),
+(133,580,cs),
+(101,580,l),
+(134,549,l),
+(134,690,l),
+(66,690,l),
+(66,525,l),
+(116,525,ls),
+(213,525,o),
+(243,484,o),
+(251,417,c),
+(271,411,l),
+(263,448,o),
+(230,477,o),
+(185,477,cs),
+(115,477,o),
+(65,427,o),
+(65,350,cs),
+(65,267,o),
+(120,217,o),
+(189,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(152,268,o),
+(125,298,o),
+(125,349,cs),
+(125,400,o),
+(153,429,o),
+(191,429,cs),
+(229,429,o),
+(256,399,o),
+(256,349,cs),
+(256,298,o),
+(231,268,o),
+(190,268,cs)
+);
+}
+);
+width = 384;
+}
+);
+metricRight = "=|";
+note = uni1509;
+unicode = 5385;
+},
+{
+glyphname = "skwNaskapi-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(264,217,o),
+(319,267,o),
+(319,350,cs),
+(319,427,o),
+(269,477,o),
+(198,477,cs),
+(154,477,o),
+(121,448,o),
+(112,411,c),
+(132,417,l),
+(140,484,o),
+(170,525,o),
+(268,525,cs),
+(318,525,l),
+(318,690,l),
+(249,690,l),
+(249,549,l),
+(282,580,l),
+(250,580,ls),
+(127,580,o),
+(65,503,o),
+(65,367,cs),
+(65,270,o),
+(120,217,o),
+(193,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(153,268,o),
+(128,298,o),
+(128,349,cs),
+(128,399,o),
+(156,429,o),
+(192,429,cs),
+(231,429,o),
+(258,400,o),
+(258,349,cs),
+(258,298,o),
+(231,268,o),
+(193,268,cs)
+);
+}
+);
+width = 384;
+}
+);
+metricLeft = "=|moosecreesk-canadian";
+metricRight = "=|moosecreesk-canadian";
+note = uni150A;
+unicode = 5386;
+},
+{
+glyphname = "swNaskapi-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(311,183,l),
+(311,232,ls),
+(311,336,o),
+(250,406,o),
+(144,406,cs),
+(114,406,l),
+(145,376,l),
+(145,508,l),
+(76,508,l),
+(76,351,l),
+(119,351,ls),
+(204,351,o),
+(242,311,o),
+(242,229,cs),
+(242,183,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(306,41,o),
+(330,65,o),
+(330,95,cs),
+(330,125,o),
+(306,148,o),
+(277,148,cs),
+(247,148,o),
+(224,125,o),
+(224,95,cs),
+(224,65,o),
+(247,41,o),
+(277,41,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(140,542,o),
+(164,566,o),
+(164,596,cs),
+(164,626,o),
+(140,649,o),
+(111,649,cs),
+(81,649,o),
+(58,626,o),
+(58,596,cs),
+(58,566,o),
+(81,542,o),
+(111,542,cs)
+);
+}
+);
+width = 388;
+}
+);
+metricRight = "=|";
+note = uni150B;
+unicode = 5387;
+},
+{
+glyphname = "spwaNaskapi-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(596,0,l),
+(596,89,l),
+(141,366,l),
+(141,323,l),
+(596,600,l),
+(596,690,l),
+(571,690,l),
+(34,362,l),
+(34,327,l),
+(571,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(156,492,o),
+(180,515,o),
+(180,545,cs),
+(180,575,o),
+(156,598,o),
+(127,598,cs),
+(98,598,o),
+(73,575,o),
+(73,545,cs),
+(73,515,o),
+(98,492,o),
+(127,492,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(347,603,l),
+(347,644,ls),
+(347,725,o),
+(303,776,o),
+(223,776,cs),
+(198,776,l),
+(239,751,l),
+(239,850,l),
+(172,850,l),
+(172,725,l),
+(200,725,ls),
+(254,725,o),
+(280,696,o),
+(280,640,cs),
+(280,603,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(508,704,o),
+(532,728,o),
+(532,758,cs),
+(532,788,o),
+(508,811,o),
+(479,811,cs),
+(450,811,o),
+(426,788,o),
+(426,758,cs),
+(426,728,o),
+(450,704,o),
+(479,704,cs)
+);
+}
+);
+width = 649;
+}
+);
+metricRight = "pa-canadian";
+metricWidth = "pa-canadian";
+note = uni150C;
+unicode = 5388;
+},
+{
+glyphname = "stwaNaskapi-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (387,0);
+ref = "ta-canadian";
+}
+);
+width = 995;
+}
+);
+note = uni150D;
+unicode = 5389;
+},
+{
+glyphname = "skwaNaskapi-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (387,0);
+ref = "ka-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni150E;
+unicode = 5390;
+},
+{
+glyphname = "scwaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (387,0);
+ref = "ca-canadian";
+}
+);
+width = 969;
+}
+);
+note = uni150F;
+unicode = 5391;
+},
+{
+glyphname = "she-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (282,690);
+},
+{
+name = top_right_can;
+pos = (699,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(764,-13,o),
+(845,79,o),
+(845,242,cs),
+(845,302,l),
+(750,302,l),
+(750,237,ls),
+(750,127,o),
+(706,71,o),
+(630,71,cs),
+(550,71,o),
+(512,128,o),
+(505,238,cs),
+(494,451,ls),
+(484,611,o),
+(415,702,o),
+(281,702,cs),
+(144,702,o),
+(60,610,o),
+(60,448,cs),
+(60,387,l),
+(155,387,l),
+(155,456,ls),
+(155,561,o),
+(200,618,o),
+(277,618,cs),
+(355,618,o),
+(393,562,o),
+(399,455,cs),
+(411,239,ls),
+(420,77,o),
+(488,-13,o),
+(627,-13,cs)
+);
+}
+);
+width = 905;
+}
+);
+metricRight = "=|";
+note = uni1510;
+unicode = 5392;
+},
+{
+glyphname = "shi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (208,690);
+},
+{
+name = top_right_can;
+pos = (625,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(417,-13,o),
+(485,77,o),
+(494,239,cs),
+(505,455,ls),
+(512,562,o),
+(551,618,o),
+(627,618,cs),
+(705,618,o),
+(750,561,o),
+(750,456,cs),
+(750,387,l),
+(845,387,l),
+(845,448,ls),
+(845,610,o),
+(761,702,o),
+(623,702,cs),
+(489,702,o),
+(420,611,o),
+(411,451,cs),
+(399,238,ls),
+(392,128,o),
+(355,71,o),
+(275,71,cs),
+(198,71,o),
+(155,127,o),
+(155,237,cs),
+(155,302,l),
+(60,302,l),
+(60,242,ls),
+(60,79,o),
+(141,-13,o),
+(277,-13,cs)
+);
+}
+);
+width = 905;
+}
+);
+metricLeft = "she-canadian";
+metricRight = "she-canadian";
+note = uni1511;
+unicode = 5393;
+},
+{
+glyphname = "shii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (552,0);
+ref = dot_top;
+}
+);
+width = 905;
+}
+);
+note = uni1512;
+unicode = 5394;
+},
+{
+glyphname = "sho-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (464,497);
+},
+{
+name = top_left_can;
+pos = (278,497);
+},
+{
+name = top_right_can;
+pos = (649,497);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(345,69,l),
+(219,69,o),
+(155,107,o),
+(155,182,cs),
+(155,238,o),
+(187,274,o),
+(258,274,cs),
+(384,274,o),
+(517,121,o),
+(678,121,cs),
+(796,121,o),
+(867,189,o),
+(867,294,cs),
+(867,420,o),
+(763,493,o),
+(586,492,c),
+(583,411,l),
+(708,411,o),
+(774,372,o),
+(774,298,cs),
+(774,241,o),
+(740,205,o),
+(669,205,cs),
+(545,205,o),
+(411,358,o),
+(250,358,cs),
+(132,358,o),
+(60,289,o),
+(60,185,cs),
+(60,59,o),
+(165,-14,o),
+(341,-13,c)
+);
+}
+);
+width = 927;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1513;
+unicode = 5395;
+},
+{
+glyphname = "shoo-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (390,-192);
+ref = dot_top;
+}
+);
+width = 927;
+}
+);
+note = uni1514;
+unicode = 5396;
+},
+{
+glyphname = "sha-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (464,497);
+},
+{
+name = top_left_can;
+pos = (278,497);
+},
+{
+name = top_right_can;
+pos = (649,497);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(763,-14,o),
+(867,59,o),
+(867,185,cs),
+(867,289,o),
+(798,358,o),
+(678,358,cs),
+(517,358,o),
+(384,205,o),
+(258,205,cs),
+(187,205,o),
+(155,241,o),
+(155,298,cs),
+(155,372,o),
+(219,412,o),
+(345,411,c),
+(341,492,l),
+(165,494,o),
+(60,420,o),
+(60,295,cs),
+(60,189,o),
+(130,121,o),
+(250,121,cs),
+(411,121,o),
+(545,274,o),
+(669,274,cs),
+(740,274,o),
+(774,238,o),
+(774,182,cs),
+(774,107,o),
+(708,67,o),
+(583,69,c),
+(586,-13,l)
+);
+}
+);
+width = 927;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1515;
+unicode = 5397;
+},
+{
+glyphname = "shaa-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (390,-192);
+ref = dot_top;
+}
+);
+width = 927;
+}
+);
+note = uni1516;
+unicode = 5398;
+},
+{
+glyphname = "shwe-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "she-canadian";
+}
+);
+width = 1129;
+}
+);
+note = uni1517;
+unicode = 5399;
+},
+{
+glyphname = "shweWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "she-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (905,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1129;
+}
+);
+note = uni1518;
+unicode = 5400;
+},
+{
+glyphname = "shwi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "shi-canadian";
+}
+);
+width = 1129;
+}
+);
+note = uni1519;
+unicode = 5401;
+},
+{
+glyphname = "shwiWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (905,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1129;
+}
+);
+note = uni151A;
+unicode = 5402;
+},
+{
+glyphname = "shwii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (776,0);
+ref = dot_top;
+}
+);
+width = 1129;
+}
+);
+note = uni151B;
+unicode = 5403;
+},
+{
+glyphname = "shwiiWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (552,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (905,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1129;
+}
+);
+note = uni151C;
+unicode = 5404;
+},
+{
+glyphname = "shwo-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "sho-canadian";
+}
+);
+width = 1152;
+}
+);
+note = uni151D;
+unicode = 5405;
+},
+{
+glyphname = "shwoWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (927,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1152;
+}
+);
+note = uni151E;
+unicode = 5406;
+},
+{
+glyphname = "shwoo-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (614,-192);
+ref = dot_top;
+}
+);
+width = 1152;
+}
+);
+note = uni151F;
+unicode = 5407;
+},
+{
+glyphname = "shwooWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (390,-192);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (927,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1152;
+}
+);
+note = uni1520;
+unicode = 5408;
+},
+{
+glyphname = "shwa-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "sha-canadian";
+}
+);
+width = 1152;
+}
+);
+note = uni1521;
+unicode = 5409;
+},
+{
+glyphname = "shwaWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (927,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1152;
+}
+);
+note = uni1522;
+unicode = 5410;
+},
+{
+glyphname = "shwaa-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (615,-192);
+ref = dot_top;
+}
+);
+width = 1152;
+}
+);
+note = uni1523;
+unicode = 5411;
+},
+{
+glyphname = "shwaaWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (390,-192);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (927,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1152;
+}
+);
+note = uni1524;
+unicode = 5412;
+},
+{
+glyphname = "sh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(576,289,o),
+(659,345,o),
+(659,443,cs),
+(659,522,o),
+(604,579,o),
+(513,579,cs),
+(392,579,o),
+(306,472,o),
+(212,472,cs),
+(158,472,o),
+(130,500,o),
+(130,545,cs),
+(130,604,o),
+(182,637,o),
+(274,637,c),
+(271,697,l),
+(143,697,o),
+(60,641,o),
+(60,543,cs),
+(60,465,o),
+(116,408,o),
+(206,408,cs),
+(327,408,o),
+(413,514,o),
+(508,514,cs),
+(561,514,o),
+(589,486,o),
+(589,441,cs),
+(589,383,o),
+(538,350,o),
+(445,350,c),
+(447,289,l)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni1525;
+unicode = 5413;
+},
+{
+glyphname = "ye-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (639,345);
+},
+{
+name = top_left_can;
+pos = (89,690);
+},
+{
+name = top_right_can;
+pos = (447,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(495,0,l),
+(495,326,l),
+(159,326,l),
+(161,276,l),
+(510,643,l),
+(445,701,l),
+(42,270,l),
+(42,241,l),
+(399,241,l),
+(399,0,l)
+);
+}
+);
+width = 570;
+}
+);
+note = uni1526;
+unicode = 5414;
+},
+{
+glyphname = "yaai-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-2,0);
+ref = ring_top.canadian;
+}
+);
+width = 570;
+}
+);
+note = uni1527;
+unicode = 5415;
+},
+{
+glyphname = "yi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (124,690);
+},
+{
+name = top_right_can;
+pos = (481,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(172,0,l),
+(172,241,l),
+(528,241,l),
+(528,270,l),
+(126,701,l),
+(62,644,l),
+(411,277,l),
+(412,326,l),
+(76,326,l),
+(76,0,l)
+);
+}
+);
+width = 570;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni1528;
+unicode = 5416;
+},
+{
+glyphname = "yii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+}
+);
+width = 570;
+}
+);
+note = uni1529;
+unicode = 5417;
+},
+{
+glyphname = "yo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (639,345);
+},
+{
+name = top_double;
+pos = (447,690);
+},
+{
+name = top_left_can;
+pos = (89,690);
+},
+{
+name = top_right_can;
+pos = (447,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(509,45,l),
+(160,412,l),
+(158,364,l),
+(495,364,l),
+(495,690,l),
+(399,690,l),
+(399,449,l),
+(42,449,l),
+(42,419,l),
+(445,-12,l)
+);
+}
+);
+width = 570;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152A;
+unicode = 5418;
+},
+{
+glyphname = "yoo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (374,0);
+ref = dot_top;
+}
+);
+width = 570;
+}
+);
+note = uni152B;
+unicode = 5419;
+},
+{
+glyphname = "ycreeyoo-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (206,0);
+ref = doubledot_top;
+}
+);
+width = 570;
+}
+);
+note = uni152C;
+unicode = 5420;
+},
+{
+glyphname = "ya-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (125,690);
+},
+{
+name = top_right_can;
+pos = (481,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(528,419,l),
+(528,449,l),
+(172,449,l),
+(172,690,l),
+(76,690,l),
+(76,364,l),
+(412,364,l),
+(410,413,l),
+(61,46,l),
+(126,-12,l)
+);
+}
+);
+width = 570;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152D;
+unicode = 5421;
+},
+{
+glyphname = "yaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+}
+);
+width = 570;
+}
+);
+note = uni152E;
+unicode = 5422;
+},
+{
+glyphname = "ywe-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ye-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni152F;
+unicode = 5423;
+},
+{
+glyphname = "yweWestCree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ye-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (570,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni1530;
+unicode = 5424;
+},
+{
+glyphname = "ywi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "yi-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni1531;
+unicode = 5425;
+},
+{
+glyphname = "ywiWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (570,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni1532;
+unicode = 5426;
+},
+{
+glyphname = "ywii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (274,0);
+ref = dot_top;
+}
+);
+width = 794;
+}
+);
+note = uni1533;
+unicode = 5427;
+},
+{
+glyphname = "ywiiWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (570,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni1534;
+unicode = 5428;
+},
+{
+glyphname = "ywo-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "yo-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni1535;
+unicode = 5429;
+},
+{
+glyphname = "ywoWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (570,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni1536;
+unicode = 5430;
+},
+{
+glyphname = "ywoo-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (598,0);
+ref = dot_top;
+}
+);
+width = 794;
+}
+);
+note = uni1537;
+unicode = 5431;
+},
+{
+glyphname = "ywooWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (374,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (570,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni1538;
+unicode = 5432;
+},
+{
+glyphname = "ywa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ya-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni1539;
+unicode = 5433;
+},
+{
+glyphname = "ywaWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (570,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni153A;
+unicode = 5434;
+},
+{
+glyphname = "ywaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (274,0);
+ref = dot_top;
+}
+);
+width = 794;
+}
+);
+note = uni153B;
+unicode = 5435;
+},
+{
+glyphname = "ywaaWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (570,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni153C;
+unicode = 5436;
+},
+{
+glyphname = "ywaaNaskapi-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ya-canadian";
+}
+);
+width = 793;
+}
+);
+note = uni153D;
+unicode = 5437;
+},
+{
+glyphname = "y-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(305,550,l),
+(305,569,l),
+(133,569,l),
+(133,690,l),
+(66,690,l),
+(66,514,l),
+(235,514,l),
+(234,556,l),
+(64,374,l),
+(110,336,l)
+);
+}
+);
+width = 342;
+}
+);
+note = uni153E;
+unicode = 5438;
+},
+{
+glyphname = "biblecreey-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(184,618,l),
+(146,618,l),
+(241,345,l),
+(281,345,l),
+(376,618,l),
+(338,618,l),
+(406,345,l),
+(466,345,l),
+(466,361,l),
+(386,690,l),
+(341,690,l),
+(243,410,l),
+(278,410,l),
+(181,690,l),
+(136,690,l),
+(56,361,l),
+(56,345,l),
+(116,345,l)
+);
+}
+);
+width = 522;
+}
+);
+metricRight = "=|";
+note = uni153F;
+unicode = 5439;
+},
+{
+glyphname = "yWestCree-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(257,188,l),
+(257,322,l),
+(384,322,l),
+(384,386,l),
+(257,386,l),
+(257,516,l),
+(189,516,l),
+(189,386,l),
+(62,386,l),
+(62,322,l),
+(189,322,l),
+(189,188,l)
+);
+}
+);
+width = 446;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1540;
+unicode = 5440;
+},
+{
+glyphname = "yiSayisi-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,183);
+ref = "fullstop-canadian";
+}
+);
+width = 355;
+}
+);
+metricLeft = "fullstop-canadian";
+metricWidth = "fullstop-canadian";
+note = uni1541;
+unicode = 5441;
+},
+{
+glyphname = "re-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (301,497);
+},
+{
+name = top_left_can;
+pos = (120,497);
+},
+{
+name = top_right_can;
+pos = (748,497);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(444,-13,o),
+(528,82,o),
+(528,235,cs),
+(528,393,l),
+(795,393,l),
+(795,479,l),
+(435,479,l),
+(435,236,ls),
+(435,129,o),
+(387,71,o),
+(301,71,cs),
+(214,71,o),
+(168,129,o),
+(168,236,cs),
+(168,479,l),
+(71,479,l),
+(71,235,ls),
+(71,81,o),
+(157,-13,o),
+(301,-13,cs)
+);
+}
+);
+width = 850;
+}
+);
+metricRight = "=|ne-canadian";
+note = uni1542;
+unicode = 5442;
+},
+{
+glyphname = "reRCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (549,497);
+},
+{
+name = top_left_can;
+pos = (102,497);
+},
+{
+name = top_right_can;
+pos = (730,497);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(694,-13,o),
+(779,81,o),
+(779,235,cs),
+(779,479,l),
+(683,479,l),
+(683,236,ls),
+(683,129,o),
+(637,71,o),
+(550,71,cs),
+(464,71,o),
+(415,128,o),
+(415,233,cs),
+(415,479,l),
+(55,479,l),
+(55,393,l),
+(322,393,l),
+(322,233,ls),
+(322,81,o),
+(407,-13,o),
+(550,-13,cs)
+);
+}
+);
+width = 850;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1543;
+unicode = 5443;
+},
+{
+glyphname = "leWestCree-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (549,497);
+},
+{
+name = top_left_can;
+pos = (102,497);
+},
+{
+name = top_right_can;
+pos = (730,497);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(415,0,l),
+(415,241,ls),
+(415,350,o),
+(463,409,o),
+(550,409,cs),
+(637,409,o),
+(683,349,o),
+(683,243,cs),
+(683,0,l),
+(779,0,l),
+(779,244,ls),
+(779,398,o),
+(696,492,o),
+(551,492,cs),
+(408,492,o),
+(322,396,o),
+(322,242,cs),
+(322,86,l),
+(55,86,l),
+(55,0,l)
+);
+}
+);
+width = 850;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+unicode = 5444;
+},
+{
+glyphname = "raai-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (177,-192);
+ref = ring_top.canadian;
+}
+);
+width = 850;
+}
+);
+note = uni1545;
+unicode = 5445;
+},
+{
+glyphname = "ri-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (301,497);
+},
+{
+name = top_left_can;
+pos = (120,497);
+},
+{
+name = top_right_can;
+pos = (748,497);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(168,0,l),
+(168,243,ls),
+(168,349,o),
+(213,409,o),
+(300,409,cs),
+(387,409,o),
+(435,352,o),
+(435,246,cs),
+(435,0,l),
+(795,0,l),
+(795,86,l),
+(528,86,l),
+(528,247,ls),
+(528,399,o),
+(446,492,o),
+(301,492,cs),
+(158,492,o),
+(71,398,o),
+(71,242,cs),
+(71,0,l)
+);
+}
+);
+width = 850;
+}
+);
+metricLeft = "re-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+unicode = 5446;
+},
+{
+glyphname = "rii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (228,-192);
+ref = dot_top;
+}
+);
+width = 850;
+}
+);
+note = uni1547;
+unicode = 5447;
+},
+{
+glyphname = "ro-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (237,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(172,0,l),
+(172,269,l),
+(145,241,l),
+(244,241,ls),
+(392,241,o),
+(485,330,o),
+(485,464,cs),
+(485,603,o),
+(396,690,o),
+(231,690,cs),
+(75,690,l),
+(75,604,l),
+(233,604,ls),
+(334,604,o),
+(389,551,o),
+(389,465,cs),
+(389,380,o),
+(333,326,o),
+(234,326,cs),
+(75,326,l),
+(75,0,l)
+);
+}
+);
+width = 543;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1548;
+unicode = 5448;
+},
+{
+glyphname = "roo-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (163,0);
+ref = dot_top;
+}
+);
+width = 543;
+}
+);
+note = uni1549;
+unicode = 5449;
+},
+{
+glyphname = "loWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (255,690);
+},
+{
+name = top_left_can;
+pos = (124,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(231,0,ls),
+(396,0,o),
+(485,87,o),
+(485,226,cs),
+(485,360,o),
+(392,449,o),
+(244,449,cs),
+(145,449,l),
+(172,422,l),
+(172,690,l),
+(75,690,l),
+(75,364,l),
+(234,364,ls),
+(333,364,o),
+(389,310,o),
+(389,225,cs),
+(389,139,o),
+(334,86,o),
+(233,86,cs),
+(75,86,l),
+(75,0,l)
+);
+}
+);
+width = 543;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+unicode = 5450;
+},
+{
+glyphname = "ra-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (306,690);
+},
+{
+name = top_right_can;
+pos = (419,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(467,0,l),
+(467,326,l),
+(309,326,ls),
+(210,326,o),
+(154,380,o),
+(154,465,cs),
+(154,551,o),
+(209,604,o),
+(310,604,cs),
+(467,604,l),
+(467,690,l),
+(312,690,ls),
+(147,690,o),
+(58,603,o),
+(58,464,cs),
+(58,330,o),
+(151,241,o),
+(298,241,cs),
+(398,241,l),
+(371,269,l),
+(371,0,l)
+);
+}
+);
+width = 542;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+unicode = 5451;
+},
+{
+glyphname = "raa-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (233,0);
+ref = dot_top;
+}
+);
+width = 543;
+}
+);
+note = uni154C;
+unicode = 5452;
+},
+{
+glyphname = "laWestCree-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (419,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(467,0,l),
+(467,86,l),
+(310,86,ls),
+(209,86,o),
+(154,139,o),
+(154,225,cs),
+(154,310,o),
+(210,364,o),
+(309,364,cs),
+(467,364,l),
+(467,690,l),
+(371,690,l),
+(371,422,l),
+(398,449,l),
+(298,449,ls),
+(151,449,o),
+(58,360,o),
+(58,226,cs),
+(58,87,o),
+(147,0,o),
+(312,0,cs)
+);
+}
+);
+width = 542;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+unicode = 5453;
+},
+{
+glyphname = "rwaa-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (457,0);
+ref = dot_top;
+}
+);
+width = 767;
+}
+);
+note = uni154E;
+unicode = 5454;
+},
+{
+glyphname = "rwaaWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (233,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (543,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 767;
+}
+);
+note = uni154F;
+unicode = 5455;
+},
+{
+glyphname = "r-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(266,345,l),
+(266,517,l),
+(186,517,ls),
+(140,517,o),
+(118,538,o),
+(118,576,cs),
+(118,613,o),
+(140,636,o),
+(187,636,cs),
+(266,636,l),
+(266,690,l),
+(187,690,ls),
+(101,690,o),
+(54,647,o),
+(54,576,cs),
+(54,507,o),
+(102,463,o),
+(180,463,cs),
+(233,463,l),
+(197,487,l),
+(197,345,l)
+);
+}
+);
+width = 329;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni1550;
+unicode = 5456;
+},
+{
+glyphname = "rWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(77,345,l),
+(304,434,l),
+(304,459,l),
+(116,529,l),
+(116,504,l),
+(304,576,l),
+(304,600,l),
+(77,690,l),
+(64,690,l),
+(64,644,l),
+(249,571,l),
+(249,604,l),
+(64,532,l),
+(64,502,l),
+(249,431,l),
+(249,464,l),
+(64,389,l),
+(64,345,l)
+);
+}
+);
+width = 368;
+}
+);
+metricLeft = "=|lWestCree-canadian";
+metricRight = "=|lWestCree-canadian";
+note = uni1551;
+unicode = 5457;
+},
+{
+glyphname = "rMedial-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(95,-13,l),
+(574,173,l),
+(574,210,l),
+(168,360,l),
+(168,328,l),
+(574,480,l),
+(574,517,l),
+(95,702,l),
+(70,702,l),
+(70,633,l),
+(478,475,l),
+(478,519,l),
+(70,366,l),
+(70,323,l),
+(478,171,l),
+(478,215,l),
+(70,58,l),
+(70,-13,l)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "mediall-canadian";
+metricRight = "mediall-canadian";
+note = uni1552;
+unicode = 5458;
+},
+{
+glyphname = "fe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(386,0,l),
+(729,664,l),
+(729,690,l),
+(647,690,l),
+(352,106,l),
+(376,106,l),
+(234,356,l),
+(174,351,l),
+(200,326,o),
+(228,314,o),
+(263,314,cs),
+(352,314,o),
+(423,394,o),
+(423,509,cs),
+(423,624,o),
+(358,702,o),
+(255,702,cs),
+(152,702,o),
+(87,624,o),
+(87,514,cs),
+(87,464,o),
+(100,413,o),
+(136,355,cs),
+(351,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,384,o),
+(166,433,o),
+(166,511,cs),
+(166,587,o),
+(199,631,o),
+(255,631,cs),
+(311,631,o),
+(344,588,o),
+(344,509,cs),
+(344,429,o),
+(311,384,o),
+(255,384,cs)
+);
+}
+);
+width = 761;
+}
+);
+metricRight = "e-canadian";
+note = uni1553;
+unicode = 5459;
+},
+{
+glyphname = "faai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (245,0);
+ref = ring_top.canadian;
+}
+);
+width = 762;
+}
+);
+note = uni1554;
+unicode = 5460;
+},
+{
+glyphname = "fi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (370,690);
+},
+{
+name = top_left_can;
+pos = (135,690);
+},
+{
+name = top_right_can;
+pos = (628,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(358,-13,o),
+(423,66,o),
+(423,181,cs),
+(423,296,o),
+(352,376,o),
+(263,376,cs),
+(228,376,o),
+(200,364,o),
+(174,339,c),
+(234,333,l),
+(376,583,l),
+(352,583,l),
+(647,0,l),
+(729,0,l),
+(729,26,l),
+(386,690,l),
+(351,690,l),
+(135,334,ls),
+(100,275,o),
+(87,226,o),
+(87,176,cs),
+(87,66,o),
+(152,-13,o),
+(255,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,59,o),
+(166,102,o),
+(166,179,cs),
+(166,257,o),
+(200,305,o),
+(255,305,cs),
+(311,305,o),
+(344,261,o),
+(344,181,cs),
+(344,101,o),
+(311,59,o),
+(255,59,cs)
+);
+}
+);
+width = 761;
+}
+);
+metricLeft = "fe-canadian";
+metricRight = "e-canadian";
+note = uni1555;
+unicode = 5461;
+},
+{
+glyphname = "fii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (297,0);
+ref = dot_top;
+}
+);
+width = 762;
+}
+);
+note = uni1556;
+unicode = 5462;
+},
+{
+glyphname = "fo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (224,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(117,0,l),
+(651,327,l),
+(651,361,l),
+(344,653,ls),
+(309,687,o),
+(267,702,o),
+(223,702,cs),
+(128,702,o),
+(56,630,o),
+(56,507,cs),
+(56,392,o),
+(121,314,o),
+(221,314,cs),
+(321,314,o),
+(384,392,o),
+(384,507,cs),
+(384,547,o),
+(372,588,o),
+(356,616,c),
+(329,557,l),
+(557,343,l),
+(556,364,l),
+(91,80,l),
+(91,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(167,385,o),
+(134,429,o),
+(134,508,cs),
+(134,588,o),
+(167,631,o),
+(223,631,cs),
+(279,631,o),
+(311,590,o),
+(311,509,cs),
+(311,429,o),
+(279,385,o),
+(223,385,cs)
+);
+}
+);
+width = 685;
+}
+);
+metricRight = "o-canadian";
+note = uni1557;
+unicode = 5463;
+},
+{
+glyphname = "foo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "fo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (151,0);
+ref = dot_top;
+}
+);
+width = 685;
+}
+);
+note = uni1558;
+unicode = 5464;
+},
+{
+glyphname = "fa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (461,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(594,0,l),
+(594,79,l),
+(127,365,l),
+(128,345,l),
+(355,560,l),
+(328,616,l),
+(312,588,o),
+(301,547,o),
+(301,507,cs),
+(301,392,o),
+(364,314,o),
+(464,314,cs),
+(564,314,o),
+(629,392,o),
+(629,507,cs),
+(629,630,o),
+(557,702,o),
+(462,702,cs),
+(418,702,o),
+(376,687,o),
+(341,653,cs),
+(34,361,l),
+(34,327,l),
+(568,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(406,384,o),
+(373,429,o),
+(373,509,cs),
+(373,589,o),
+(406,631,o),
+(461,631,cs),
+(517,631,o),
+(550,588,o),
+(550,508,cs),
+(550,428,o),
+(517,384,o),
+(462,384,cs)
+);
+}
+);
+width = 685;
+}
+);
+metricRight = "=|fo-canadian";
+note = uni1559;
+unicode = 5465;
+},
+{
+glyphname = "faa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (387,0);
+ref = dot_top;
+}
+);
+width = 685;
+}
+);
+note = uni155A;
+unicode = 5466;
+},
+{
+glyphname = "fwaa-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (611,0);
+ref = dot_top;
+}
+);
+width = 909;
+}
+);
+note = uni155B;
+unicode = 5467;
+},
+{
+glyphname = "fwaaWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (387,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (685,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 909;
+}
+);
+note = uni155C;
+unicode = 5468;
+},
+{
+glyphname = "f-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(338,345,l),
+(338,387,l),
+(110,527,l),
+(110,516,l),
+(216,617,l),
+(207,652,l),
+(198,639,o),
+(192,617,o),
+(192,596,cs),
+(192,538,o),
+(226,501,o),
+(273,501,cs),
+(323,501,o),
+(355,538,o),
+(355,598,cs),
+(355,663,o),
+(318,696,o),
+(272,696,cs),
+(251,696,o),
+(228,687,o),
+(207,667,cs),
+(58,526,l),
+(58,507,l),
+(323,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(247,540,o),
+(233,560,o),
+(233,598,cs),
+(233,637,o),
+(247,656,o),
+(272,656,cs),
+(298,656,o),
+(313,638,o),
+(313,598,cs),
+(313,559,o),
+(298,540,o),
+(273,540,cs)
+);
+}
+);
+width = 412;
+}
+);
+note = uni155D;
+unicode = 5469;
+},
+{
+glyphname = "the-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (812,345);
+},
+{
+name = top_center_can;
+pos = (360,690);
+},
+{
+name = top_left_can;
+pos = (115,690);
+},
+{
+name = top_right_can;
+pos = (606,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(544,-13,o),
+(653,102,o),
+(653,302,cs),
+(653,690,l),
+(557,690,l),
+(557,298,ls),
+(557,151,o),
+(487,73,o),
+(360,73,cs),
+(238,73,o),
+(163,147,o),
+(163,290,cs),
+(163,419,l),
+(128,391,l),
+(143,339,o),
+(189,307,o),
+(243,307,cs),
+(340,307,o),
+(403,384,o),
+(403,505,cs),
+(403,624,o),
+(341,702,o),
+(238,702,cs),
+(131,702,o),
+(69,623,o),
+(69,486,cs),
+(69,314,ls),
+(69,102,o),
+(179,-13,o),
+(361,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(180,379,o),
+(147,422,o),
+(147,505,cs),
+(147,587,o),
+(180,631,o),
+(236,631,cs),
+(292,631,o),
+(324,587,o),
+(324,505,cs),
+(324,423,o),
+(292,379,o),
+(236,379,cs)
+);
+}
+);
+width = 722;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155E;
+unicode = 5470;
+},
+{
+glyphname = "theNCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(546,-13,o),
+(653,102,o),
+(653,314,cs),
+(653,486,ls),
+(653,623,o),
+(590,702,o),
+(484,702,cs),
+(381,702,o),
+(319,624,o),
+(319,505,cs),
+(319,385,o),
+(382,307,o),
+(478,307,cs),
+(532,307,o),
+(579,339,o),
+(593,391,c),
+(558,419,l),
+(558,290,ls),
+(558,146,o),
+(486,72,o),
+(361,72,cs),
+(237,72,o),
+(164,152,o),
+(164,298,cs),
+(164,690,l),
+(69,690,l),
+(69,299,ls),
+(69,101,o),
+(178,-13,o),
+(360,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(430,379,o),
+(398,424,o),
+(398,505,cs),
+(398,587,o),
+(430,631,o),
+(486,631,cs),
+(542,631,o),
+(575,587,o),
+(575,505,cs),
+(575,422,o),
+(542,379,o),
+(486,379,cs)
+);
+}
+);
+width = 722;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155F;
+unicode = 5471;
+},
+{
+glyphname = "thi-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (358,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(341,-13,o),
+(403,66,o),
+(403,185,cs),
+(403,304,o),
+(340,383,o),
+(243,383,cs),
+(189,383,o),
+(143,351,o),
+(128,298,c),
+(163,270,l),
+(163,400,ls),
+(163,544,o),
+(236,617,o),
+(360,617,cs),
+(485,617,o),
+(557,538,o),
+(557,392,cs),
+(557,0,l),
+(653,0,l),
+(653,390,ls),
+(653,588,o),
+(544,702,o),
+(361,702,cs),
+(176,702,o),
+(69,587,o),
+(69,376,cs),
+(69,204,ls),
+(69,67,o),
+(131,-13,o),
+(238,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(180,59,o),
+(147,102,o),
+(147,185,cs),
+(147,268,o),
+(180,311,o),
+(236,311,cs),
+(292,311,o),
+(324,266,o),
+(324,185,cs),
+(324,102,o),
+(292,59,o),
+(236,59,cs)
+);
+}
+);
+width = 722;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1560;
+unicode = 5472;
+},
+{
+glyphname = "thiNCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (358,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(590,-13,o),
+(653,67,o),
+(653,204,cs),
+(653,376,ls),
+(653,587,o),
+(546,702,o),
+(360,702,cs),
+(178,702,o),
+(69,588,o),
+(69,390,cs),
+(69,0,l),
+(164,0,l),
+(164,392,ls),
+(164,538,o),
+(237,617,o),
+(361,617,cs),
+(486,617,o),
+(558,544,o),
+(558,400,cs),
+(558,270,l),
+(593,298,l),
+(579,351,o),
+(532,383,o),
+(478,383,cs),
+(382,383,o),
+(319,304,o),
+(319,185,cs),
+(319,66,o),
+(381,-13,o),
+(484,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(430,59,o),
+(398,102,o),
+(398,185,cs),
+(398,266,o),
+(430,311,o),
+(486,311,cs),
+(542,311,o),
+(575,268,o),
+(575,185,cs),
+(575,102,o),
+(542,59,o),
+(486,59,cs)
+);
+}
+);
+width = 722;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1561;
+unicode = 5473;
+},
+{
+glyphname = "thii-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "thi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (285,0);
+ref = dot_top;
+}
+);
+width = 722;
+}
+);
+note = uni1562;
+unicode = 5474;
+},
+{
+glyphname = "thiiNCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "thiNCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (285,0);
+ref = dot_top;
+}
+);
+width = 722;
+}
+);
+note = uni1563;
+unicode = 5475;
+},
+{
+glyphname = "tho-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (304,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(275,0,ls),
+(492,0,o),
+(610,125,o),
+(610,351,cs),
+(610,563,o),
+(495,702,o),
+(305,702,cs),
+(159,702,o),
+(67,616,o),
+(67,480,cs),
+(67,360,o),
+(132,285,o),
+(235,285,cs),
+(335,285,o),
+(396,357,o),
+(396,472,cs),
+(396,564,o),
+(350,647,o),
+(249,653,c),
+(218,616,l),
+(238,626,o),
+(267,632,o),
+(293,632,cs),
+(440,632,o),
+(515,524,o),
+(515,355,cs),
+(515,176,o),
+(433,87,o),
+(270,87,cs),
+(99,87,l),
+(99,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(178,356,o),
+(146,399,o),
+(146,484,cs),
+(146,568,o),
+(185,611,o),
+(234,611,cs),
+(285,611,o),
+(323,568,o),
+(323,483,cs),
+(323,399,o),
+(291,356,o),
+(234,356,cs)
+);
+}
+);
+width = 672;
+}
+);
+metricRight = "to-canadian";
+note = uni1564;
+unicode = 5476;
+},
+{
+glyphname = "thoo-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "tho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (231,0);
+ref = dot_top;
+}
+);
+width = 672;
+}
+);
+note = uni1565;
+unicode = 5477;
+},
+{
+glyphname = "tha-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (369,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(572,0,l),
+(572,87,l),
+(402,87,ls),
+(239,87,o),
+(156,176,o),
+(156,355,cs),
+(156,524,o),
+(231,632,o),
+(379,632,cs),
+(405,632,o),
+(434,626,o),
+(452,616,c),
+(422,653,l),
+(322,647,o),
+(275,564,o),
+(275,472,cs),
+(275,357,o),
+(337,285,o),
+(437,285,cs),
+(539,285,o),
+(605,361,o),
+(605,480,cs),
+(605,617,o),
+(511,702,o),
+(367,702,cs),
+(178,702,o),
+(62,563,o),
+(62,351,cs),
+(62,126,o),
+(179,0,o),
+(396,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(381,356,o),
+(349,399,o),
+(349,483,cs),
+(349,568,o),
+(386,611,o),
+(438,611,cs),
+(487,611,o),
+(526,568,o),
+(526,484,cs),
+(526,399,o),
+(494,356,o),
+(438,356,cs)
+);
+}
+);
+width = 672;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tho-canadian";
+note = uni1566;
+unicode = 5478;
+},
+{
+glyphname = "thaa-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (297,0);
+ref = dot_top;
+}
+);
+width = 672;
+}
+);
+note = uni1567;
+unicode = 5479;
+},
+{
+glyphname = "thwaa-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (521,0);
+ref = dot_top;
+}
+);
+width = 896;
+}
+);
+note = uni1568;
+unicode = 5480;
+},
+{
+glyphname = "thwaaWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (297,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (672,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 896;
+}
+);
+note = uni1569;
+unicode = 5481;
+},
+{
+glyphname = "th-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(315,345,l),
+(315,401,l),
+(238,401,ls),
+(156,401,o),
+(119,441,o),
+(119,522,cs),
+(119,601,o),
+(156,654,o),
+(227,654,cs),
+(241,654,o),
+(254,651,o),
+(263,647,c),
+(240,669,l),
+(191,667,o),
+(169,629,o),
+(169,583,cs),
+(169,524,o),
+(202,487,o),
+(250,487,cs),
+(298,487,o),
+(331,524,o),
+(331,583,cs),
+(331,655,o),
+(285,696,o),
+(214,696,cs),
+(120,696,o),
+(60,626,o),
+(60,517,cs),
+(60,411,o),
+(120,345,o),
+(234,345,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(224,526,o),
+(210,546,o),
+(210,583,cs),
+(210,622,o),
+(224,641,o),
+(249,641,cs),
+(274,641,o),
+(289,623,o),
+(289,583,cs),
+(289,545,o),
+(274,526,o),
+(249,526,cs)
+);
+}
+);
+width = 388;
+}
+);
+metricLeft = "t-canadian";
+note = uni156A;
+unicode = 5482;
+},
+{
+glyphname = "tthe-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (803,345);
+},
+{
+name = top_center_can;
+pos = (356,690);
+},
+{
+name = top_left_can;
+pos = (117,690);
+},
+{
+name = top_right_can;
+pos = (597,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(536,-13,o),
+(644,102,o),
+(644,302,cs),
+(644,690,l),
+(551,690,l),
+(551,300,ls),
+(551,152,o),
+(479,75,o),
+(356,75,cs),
+(237,75,o),
+(162,154,o),
+(162,299,cs),
+(162,690,l),
+(69,690,l),
+(69,299,ls),
+(69,101,o),
+(178,-13,o),
+(356,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(396,387,l),
+(396,690,l),
+(317,690,l),
+(317,387,l)
+);
+}
+);
+width = 713;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156B;
+unicode = 5483;
+},
+{
+glyphname = "tthi-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(162,0,l),
+(162,389,ls),
+(162,536,o),
+(237,614,o),
+(358,614,cs),
+(477,614,o),
+(551,536,o),
+(551,390,cs),
+(551,0,l),
+(644,0,l),
+(644,390,ls),
+(644,588,o),
+(535,702,o),
+(359,702,cs),
+(179,702,o),
+(69,588,o),
+(69,387,cs),
+(69,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(396,0,l),
+(396,302,l),
+(317,302,l),
+(317,0,l)
+);
+}
+);
+width = 713;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156C;
+unicode = 5484;
+},
+{
+glyphname = "ttho-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (317,690);
+},
+{
+name = top_left_can;
+pos = (120,690);
+},
+{
+name = top_right_can;
+pos = (513,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(231,0,ls),
+(440,0,o),
+(560,128,o),
+(560,346,cs),
+(560,563,o),
+(440,690,o),
+(228,690,cs),
+(72,690,l),
+(72,603,l),
+(225,603,ls),
+(380,603,o),
+(465,513,o),
+(465,346,cs),
+(465,179,o),
+(380,87,o),
+(226,87,cs),
+(72,87,l),
+(72,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(308,306,l),
+(308,385,l),
+(72,385,l),
+(72,306,l)
+);
+}
+);
+width = 622;
+}
+);
+metricRight = "to-canadian";
+note = uni156D;
+unicode = 5485;
+},
+{
+glyphname = "ttha-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (319,690);
+},
+{
+name = top_left_can;
+pos = (109,690);
+},
+{
+name = top_right_can;
+pos = (502,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(550,0,l),
+(550,87,l),
+(397,87,ls),
+(242,87,o),
+(157,178,o),
+(157,345,cs),
+(157,512,o),
+(242,603,o),
+(396,603,cs),
+(550,603,l),
+(550,690,l),
+(393,690,ls),
+(182,690,o),
+(62,562,o),
+(62,345,cs),
+(62,128,o),
+(182,0,o),
+(392,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(550,306,l),
+(550,385,l),
+(314,385,l),
+(314,306,l)
+);
+}
+);
+width = 622;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|ttho-canadian";
+note = uni156E;
+unicode = 5486;
+},
+{
+glyphname = "tth-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(637,477,l),
+(611,477,l),
+(704,347,l),
+(752,382,l),
+(658,512,l),
+(650,487,l),
+(797,538,l),
+(779,593,l),
+(632,541,l),
+(654,527,l),
+(654,690,l),
+(595,690,l),
+(595,527,l),
+(616,541,l),
+(470,593,l),
+(451,538,l),
+(598,487,l),
+(591,512,l),
+(497,382,l),
+(544,347,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(232,477,l),
+(207,477,l),
+(300,347,l),
+(348,382,l),
+(253,512,l),
+(245,487,l),
+(392,538,l),
+(373,593,l),
+(227,541,l),
+(248,527,l),
+(248,690,l),
+(190,690,l),
+(190,527,l),
+(212,541,l),
+(65,593,l),
+(46,538,l),
+(193,487,l),
+(185,512,l),
+(91,382,l),
+(138,347,l)
+);
+}
+);
+width = 843;
+}
+);
+metricRight = "=|";
+note = uni156F;
+unicode = 5487;
+},
+{
+glyphname = "tye-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(536,-13,o),
+(644,102,o),
+(644,302,cs),
+(644,690,l),
+(551,690,l),
+(551,302,ls),
+(551,152,o),
+(479,75,o),
+(356,75,cs),
+(237,75,o),
+(161,154,o),
+(161,301,cs),
+(161,690,l),
+(69,690,l),
+(69,299,ls),
+(69,101,o),
+(178,-13,o),
+(356,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(428,412,o),
+(469,457,o),
+(469,539,cs),
+(469,690,l),
+(420,690,l),
+(420,541,ls),
+(420,489,o),
+(399,462,o),
+(356,462,cs),
+(314,462,o),
+(293,489,o),
+(293,541,cs),
+(293,690,l),
+(242,690,l),
+(242,539,ls),
+(242,456,o),
+(286,412,o),
+(356,412,cs)
+);
+}
+);
+width = 713;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1570;
+unicode = 5488;
+},
+{
+glyphname = "tyi-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(162,0,l),
+(162,387,ls),
+(162,536,o),
+(237,614,o),
+(358,614,cs),
+(477,614,o),
+(551,536,o),
+(551,388,cs),
+(551,0,l),
+(644,0,l),
+(644,390,ls),
+(644,588,o),
+(535,702,o),
+(359,702,cs),
+(179,702,o),
+(69,588,o),
+(69,387,cs),
+(69,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(293,0,l),
+(293,148,ls),
+(293,201,o),
+(314,228,o),
+(356,228,cs),
+(398,228,o),
+(420,201,o),
+(420,148,cs),
+(420,0,l),
+(469,0,l),
+(469,151,ls),
+(469,234,o),
+(426,278,o),
+(355,278,cs),
+(285,278,o),
+(242,233,o),
+(242,151,cs),
+(242,0,l)
+);
+}
+);
+width = 713;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1571;
+unicode = 5489;
+},
+{
+glyphname = "tyo-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(234,0,ls),
+(442,0,o),
+(564,128,o),
+(564,346,cs),
+(564,563,o),
+(442,690,o),
+(231,690,cs),
+(75,690,l),
+(75,604,l),
+(226,604,ls),
+(384,604,o),
+(468,513,o),
+(468,346,cs),
+(468,179,o),
+(384,86,o),
+(227,86,cs),
+(75,86,l),
+(75,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(166,213,ls),
+(254,213,o),
+(301,263,o),
+(301,345,cs),
+(301,428,o),
+(253,476,o),
+(166,476,cs),
+(75,476,l),
+(75,426,l),
+(159,426,ls),
+(219,426,o),
+(245,397,o),
+(245,345,cs),
+(245,293,o),
+(219,264,o),
+(159,264,cs),
+(75,264,l),
+(75,213,l)
+);
+}
+);
+width = 626;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1572;
+unicode = 5490;
+},
+{
+glyphname = "tya-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(550,0,l),
+(550,86,l),
+(400,86,ls),
+(242,86,o),
+(157,177,o),
+(157,345,cs),
+(157,512,o),
+(242,604,o),
+(399,604,cs),
+(550,604,l),
+(550,690,l),
+(393,690,ls),
+(183,690,o),
+(62,562,o),
+(62,345,cs),
+(62,128,o),
+(183,0,o),
+(392,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(550,213,l),
+(550,264,l),
+(467,264,ls),
+(407,264,o),
+(381,293,o),
+(381,345,cs),
+(381,397,o),
+(407,426,o),
+(466,426,cs),
+(550,426,l),
+(550,476,l),
+(459,476,ls),
+(372,476,o),
+(324,427,o),
+(324,345,cs),
+(324,262,o),
+(372,213,o),
+(459,213,cs)
+);
+}
+);
+width = 625;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1573;
+unicode = 5491;
+},
+{
+glyphname = "heNunavik-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(507,0,l),
+(745,195,l),
+(693,261,l),
+(457,68,l),
+(518,64,l),
+(518,443,ls),
+(518,605,o),
+(432,702,o),
+(291,702,cs),
+(151,702,o),
+(60,604,o),
+(60,447,cs),
+(60,296,o),
+(148,198,o),
+(277,198,cs),
+(357,198,o),
+(417,242,o),
+(431,300,c),
+(422,313,l),
+(422,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(207,280,o),
+(155,341,o),
+(155,450,cs),
+(155,559,o),
+(205,620,o),
+(289,620,cs),
+(373,620,o),
+(423,560,o),
+(423,450,cs),
+(423,342,o),
+(371,280,o),
+(289,280,cs)
+);
+}
+);
+width = 770;
+}
+);
+metricLeft = "ke-canadian";
+note = uni1574;
+unicode = 5492;
+},
+{
+glyphname = "hiNunavik-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (481,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(347,0,l),
+(347,313,l),
+(339,300,l),
+(353,242,o),
+(412,198,o),
+(493,198,cs),
+(622,198,o),
+(710,297,o),
+(710,449,cs),
+(710,606,o),
+(620,702,o),
+(481,702,cs),
+(340,702,o),
+(252,605,o),
+(252,443,cs),
+(252,71,l),
+(313,68,l),
+(77,261,l),
+(25,195,l),
+(262,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(399,280,o),
+(346,342,o),
+(346,450,cs),
+(346,560,o),
+(397,620,o),
+(481,620,cs),
+(564,620,o),
+(615,559,o),
+(615,450,cs),
+(615,341,o),
+(562,280,o),
+(481,280,cs)
+);
+}
+);
+width = 770;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1575;
+unicode = 5493;
+},
+{
+glyphname = "hiiNunavik-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "hiNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (408,0);
+ref = dot_top;
+}
+);
+width = 770;
+}
+);
+note = uni1576;
+unicode = 5494;
+},
+{
+glyphname = "hoNunavik-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (289,690);
+},
+{
+name = top_right_can;
+pos = (470,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(432,-13,o),
+(518,85,o),
+(518,246,cs),
+(518,626,l),
+(457,622,l),
+(693,429,l),
+(745,495,l),
+(507,690,l),
+(422,690,l),
+(422,377,l),
+(431,389,l),
+(417,447,o),
+(357,492,o),
+(278,492,cs),
+(148,492,o),
+(60,391,o),
+(60,240,cs),
+(60,84,o),
+(149,-13,o),
+(289,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(205,70,o),
+(155,130,o),
+(155,240,cs),
+(155,349,o),
+(207,410,o),
+(289,410,cs),
+(371,410,o),
+(423,348,o),
+(423,240,cs),
+(423,129,o),
+(373,70,o),
+(289,70,cs)
+);
+}
+);
+width = 770;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "heNunavik-canadian";
+note = uni1577;
+unicode = 5495;
+},
+{
+glyphname = "hooNunavik-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "hoNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (397,0);
+ref = dot_top;
+}
+);
+width = 770;
+}
+);
+note = uni1578;
+unicode = 5496;
+},
+{
+glyphname = "haNunavik-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (481,690);
+},
+{
+name = top_left_can;
+pos = (299,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(618,-13,o),
+(710,84,o),
+(710,242,cs),
+(710,393,o),
+(622,492,o),
+(495,492,cs),
+(414,492,o),
+(354,447,o),
+(339,389,c),
+(347,377,l),
+(347,690,l),
+(262,690,l),
+(25,495,l),
+(77,429,l),
+(313,622,l),
+(252,619,l),
+(252,246,ls),
+(252,85,o),
+(337,-13,o),
+(479,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(397,70,o),
+(346,129,o),
+(346,240,cs),
+(346,348,o),
+(399,410,o),
+(481,410,cs),
+(562,410,o),
+(615,349,o),
+(615,240,cs),
+(615,130,o),
+(564,70,o),
+(481,70,cs)
+);
+}
+);
+width = 770;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1579;
+unicode = 5497;
+},
+{
+glyphname = "haaNunavik-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "haNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (226,0);
+ref = dot_top;
+}
+);
+width = 770;
+}
+);
+note = uni157A;
+unicode = 5498;
+},
+{
+glyphname = "hNunavik-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(355,339,o),
+(411,388,o),
+(411,472,cs),
+(411,552,o),
+(360,601,o),
+(296,601,cs),
+(250,601,o),
+(216,573,o),
+(209,534,c),
+(224,534,l),
+(224,690,l),
+(161,690,l),
+(43,592,l),
+(74,554,l),
+(193,651,l),
+(156,653,l),
+(156,473,ls),
+(156,390,o),
+(207,339,o),
+(285,339,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(243,390,o),
+(219,417,o),
+(219,470,cs),
+(219,522,o),
+(246,550,o),
+(284,550,cs),
+(322,550,o),
+(350,522,o),
+(350,470,cs),
+(350,419,o),
+(323,390,o),
+(284,390,cs)
+);
+}
+);
+width = 465;
+}
+);
+metricRight = "k-canadian";
+note = uni157B;
+unicode = 5499;
+},
+{
+color = 4;
+glyphname = "nunavuth-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(172,315,l),
+(515,315,l),
+(515,0,l),
+(611,0,l),
+(611,690,l),
+(515,690,l),
+(515,400,l),
+(172,400,l),
+(172,690,l),
+(75,690,l),
+(75,0,l),
+(172,0,l)
+);
+}
+);
+width = 686;
+}
+);
+metricRight = "=|";
+note = uni157C;
+unicode = 5500;
+},
+{
+glyphname = "hk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,345);
+ref = "fullstop-canadian";
+}
+);
+width = 355;
+}
+);
+metricLeft = "fullstop-canadian";
+note = uni157D;
+unicode = 5501;
+},
+{
+glyphname = "qaai-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (329,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (501,0);
+ref = ring_top.canadian;
+}
+);
+width = 916;
+}
+);
+note = uni157E;
+unicode = 5502;
+},
+{
+glyphname = "qi-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (329,0);
+ref = "ki-canadian";
+}
+);
+width = 916;
+}
+);
+note = uni157F;
+unicode = 5503;
+},
+{
+glyphname = "qii-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (329,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (554,0);
+ref = dot_top;
+}
+);
+width = 916;
+}
+);
+note = uni1580;
+unicode = 5504;
+},
+{
+glyphname = "qo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (329,0);
+ref = "ko-canadian";
+}
+);
+width = 916;
+}
+);
+note = uni1581;
+unicode = 5505;
+},
+{
+glyphname = "qoo-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (329,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (726,0);
+ref = dot_top;
+}
+);
+width = 916;
+}
+);
+note = uni1582;
+unicode = 5506;
+},
+{
+glyphname = "qa-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (329,0);
+ref = "ka-canadian";
+}
+);
+width = 916;
+}
+);
+note = uni1583;
+unicode = 5507;
+},
+{
+glyphname = "qaa-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (329,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (372,0);
+ref = dot_top;
+}
+);
+width = 916;
+}
+);
+note = uni1584;
+unicode = 5508;
+},
+{
+glyphname = "q-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (329,0);
+ref = "k-canadian";
+}
+);
+width = 702;
+}
+);
+note = uni1585;
+unicode = 5509;
+},
+{
+glyphname = "tlhe-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (298,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(193,0,l),
+(330,270,l),
+(254,235,l),
+(264,233,o),
+(274,232,o),
+(284,232,cs),
+(363,232,o),
+(422,271,o),
+(438,320,c),
+(432,352,l),
+(432,0,l),
+(527,0,l),
+(527,458,ls),
+(527,610,o),
+(441,702,o),
+(298,702,cs),
+(151,702,o),
+(66,604,o),
+(66,466,cs),
+(66,351,o),
+(125,270,o),
+(217,247,c),
+(91,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(212,315,o),
+(159,371,o),
+(159,467,cs),
+(159,563,o),
+(212,620,o),
+(297,620,cs),
+(382,620,o),
+(433,564,o),
+(433,468,cs),
+(433,371,o),
+(381,315,o),
+(297,315,cs)
+);
+}
+);
+width = 596;
+}
+);
+metricRight = "te-canadian";
+note = uni1586;
+unicode = 5510;
+},
+{
+glyphname = "tlhi-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(163,0,l),
+(163,352,l),
+(156,324,l),
+(167,274,o),
+(228,232,o),
+(311,232,c),
+(265,270,l),
+(403,0,l),
+(504,0,l),
+(379,247,l),
+(470,270,o),
+(530,351,o),
+(530,466,cs),
+(530,604,o),
+(444,702,o),
+(298,702,cs),
+(155,702,o),
+(69,610,o),
+(69,458,cs),
+(69,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(214,315,o),
+(162,371,o),
+(162,468,cs),
+(162,564,o),
+(213,620,o),
+(299,620,cs),
+(384,620,o),
+(436,563,o),
+(436,467,cs),
+(436,371,o),
+(384,315,o),
+(299,315,cs)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|tlhe-canadian";
+note = uni1587;
+unicode = 5511;
+},
+{
+glyphname = "tlho-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (314,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(441,-13,o),
+(527,80,o),
+(527,232,cs),
+(527,690,l),
+(432,690,l),
+(432,338,l),
+(440,366,l),
+(428,415,o),
+(367,458,o),
+(284,458,c),
+(330,420,l),
+(193,690,l),
+(91,690,l),
+(217,442,l),
+(125,419,o),
+(66,339,o),
+(66,224,cs),
+(66,86,o),
+(151,-13,o),
+(298,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(212,70,o),
+(159,127,o),
+(159,223,cs),
+(159,319,o),
+(212,375,o),
+(297,375,cs),
+(381,375,o),
+(433,319,o),
+(433,222,cs),
+(433,126,o),
+(382,70,o),
+(297,70,cs)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "tlhe-canadian";
+metricRight = "te-canadian";
+note = uni1588;
+unicode = 5512;
+},
+{
+glyphname = "tlha-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(444,-13,o),
+(530,86,o),
+(530,224,cs),
+(530,339,o),
+(470,419,o),
+(379,442,c),
+(504,690,l),
+(403,690,l),
+(265,420,l),
+(342,455,l),
+(331,457,o),
+(322,458,o),
+(311,458,cs),
+(228,458,o),
+(167,415,o),
+(156,366,c),
+(163,338,l),
+(163,690,l),
+(69,690,l),
+(69,232,ls),
+(69,80,o),
+(155,-13,o),
+(298,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(213,70,o),
+(162,126,o),
+(162,222,cs),
+(162,319,o),
+(214,375,o),
+(299,375,cs),
+(384,375,o),
+(436,319,o),
+(436,223,cs),
+(436,127,o),
+(384,70,o),
+(299,70,cs)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "te-canadian";
+note = uni1589;
+unicode = 5513;
+},
+{
+glyphname = "reWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(502,0,l),
+(739,195,l),
+(687,261,l),
+(451,68,l),
+(512,64,l),
+(512,448,ls),
+(512,609,o),
+(429,702,o),
+(289,702,cs),
+(146,702,o),
+(59,608,o),
+(59,449,cs),
+(59,387,l),
+(155,387,l),
+(155,457,ls),
+(155,560,o),
+(202,618,o),
+(287,618,cs),
+(369,618,o),
+(416,560,o),
+(416,457,cs),
+(416,0,l)
+);
+}
+);
+width = 764;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+unicode = 5514;
+},
+{
+glyphname = "riWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(347,0,l),
+(347,457,ls),
+(347,560,o),
+(396,618,o),
+(479,618,cs),
+(564,618,o),
+(610,560,o),
+(610,457,cs),
+(610,387,l),
+(704,387,l),
+(704,449,ls),
+(704,608,o),
+(621,702,o),
+(480,702,cs),
+(336,702,o),
+(252,607,o),
+(252,448,cs),
+(252,64,l),
+(313,68,l),
+(77,261,l),
+(25,195,l),
+(262,0,l)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+unicode = 5515;
+},
+{
+glyphname = "roWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(428,-13,o),
+(512,79,o),
+(512,242,cs),
+(512,626,l),
+(451,622,l),
+(687,429,l),
+(739,495,l),
+(502,690,l),
+(416,690,l),
+(416,233,ls),
+(416,128,o),
+(369,71,o),
+(287,71,cs),
+(200,71,o),
+(155,129,o),
+(155,236,cs),
+(155,302,l),
+(59,302,l),
+(59,240,ls),
+(59,82,o),
+(142,-13,o),
+(289,-13,cs)
+);
+}
+);
+width = 764;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+unicode = 5516;
+},
+{
+glyphname = "raWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(621,-13,o),
+(704,81,o),
+(704,241,cs),
+(704,302,l),
+(610,302,l),
+(610,235,ls),
+(610,128,o),
+(563,71,o),
+(479,71,cs),
+(393,71,o),
+(347,128,o),
+(347,232,cs),
+(347,690,l),
+(262,690,l),
+(25,495,l),
+(77,429,l),
+(313,622,l),
+(252,626,l),
+(252,242,ls),
+(252,80,o),
+(334,-13,o),
+(479,-13,cs)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+unicode = 5517;
+},
+{
+glyphname = "ngaai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (639,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (812,0);
+ref = ring_top.canadian;
+}
+);
+width = 1220;
+}
+);
+note = uni158E;
+unicode = 5518;
+},
+{
+glyphname = "ngi-canadian";
+kernLeft = mwestleft;
+kernRight = ciright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (639,0);
+ref = "ci-canadian";
+}
+);
+width = 1220;
+}
+);
+note = uni158F;
+unicode = 5519;
+},
+{
+glyphname = "ngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (639,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (864,0);
+ref = dot_top;
+}
+);
+width = 1220;
+}
+);
+note = uni1590;
+unicode = 5520;
+},
+{
+glyphname = "ngo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:53:53 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (611,0);
+ref = "co-canadian";
+}
+);
+width = 1193;
+}
+);
+note = uni1591;
+unicode = 5521;
+},
+{
+glyphname = "ngoo-canadian";
+lastChange = "2023-01-13 15:53:53 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+ref = "ngo-canadian";
+},
+{
+anchor = top_right_can;
+pos = (1003,0);
+ref = dot_top;
+}
+);
+width = 1193;
+}
+);
+note = uni1592;
+unicode = 5522;
+},
+{
+glyphname = "nga-canadian";
+kernLeft = mwestleft;
+kernRight = caright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (639,0);
+ref = "ca-canadian";
+}
+);
+width = 1220;
+}
+);
+note = uni1593;
+unicode = 5523;
+},
+{
+glyphname = "ngaa-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (639,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (682,0);
+ref = dot_top;
+}
+);
+width = 1220;
+}
+);
+note = uni1594;
+unicode = 5524;
+},
+{
+glyphname = "ng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(545,217,o),
+(596,263,o),
+(596,344,cs),
+(596,365,l),
+(531,365,l),
+(531,340,ls),
+(531,295,o),
+(507,271,o),
+(469,271,cs),
+(430,271,o),
+(408,296,o),
+(408,345,cs),
+(408,497,l),
+(250,497,l),
+(254,469,l),
+(286,482,o),
+(306,523,o),
+(306,569,cs),
+(306,646,o),
+(257,696,o),
+(181,696,cs),
+(105,696,o),
+(54,645,o),
+(54,566,cs),
+(54,487,o),
+(104,435,o),
+(186,435,cs),
+(355,435,l),
+(339,453,l),
+(339,354,ls),
+(339,264,o),
+(387,217,o),
+(469,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(142,485,o),
+(115,515,o),
+(115,566,cs),
+(115,616,o),
+(142,645,o),
+(181,645,cs),
+(219,645,o),
+(245,616,o),
+(245,565,cs),
+(245,515,o),
+(219,485,o),
+(181,485,cs)
+);
+}
+);
+width = 639;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1595;
+unicode = 5525;
+},
+{
+glyphname = "nng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(833,217,o),
+(884,263,o),
+(884,344,cs),
+(884,365,l),
+(820,365,l),
+(820,340,ls),
+(820,295,o),
+(795,271,o),
+(757,271,cs),
+(718,271,o),
+(696,296,o),
+(696,345,cs),
+(696,497,l),
+(544,497,l),
+(548,469,l),
+(579,482,o),
+(600,523,o),
+(600,569,cs),
+(600,647,o),
+(550,696,o),
+(473,696,cs),
+(398,696,o),
+(348,646,o),
+(348,568,cs),
+(348,523,o),
+(369,482,o),
+(399,469,c),
+(404,497,l),
+(251,497,l),
+(254,469,l),
+(286,482,o),
+(306,523,o),
+(306,569,cs),
+(306,646,o),
+(257,696,o),
+(181,696,cs),
+(105,696,o),
+(54,645,o),
+(54,566,cs),
+(54,487,o),
+(104,435,o),
+(186,435,cs),
+(628,435,l),
+(628,354,ls),
+(628,264,o),
+(675,217,o),
+(757,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(142,485,o),
+(115,515,o),
+(115,566,cs),
+(115,616,o),
+(142,645,o),
+(181,645,cs),
+(219,645,o),
+(245,616,o),
+(245,565,cs),
+(245,515,o),
+(219,485,o),
+(181,485,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(435,485,o),
+(409,515,o),
+(409,566,cs),
+(409,616,o),
+(435,645,o),
+(474,645,cs),
+(512,645,o),
+(539,616,o),
+(539,565,cs),
+(539,515,o),
+(513,485,o),
+(473,485,cs)
+);
+}
+);
+width = 927;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1596;
+unicode = 5526;
+},
+{
+glyphname = "sheSayisi-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (681,345);
+},
+{
+name = top_center_can;
+pos = (296,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(524,0,l),
+(524,444,ls),
+(524,606,o),
+(440,702,o),
+(296,702,cs),
+(150,702,o),
+(60,602,o),
+(60,436,cs),
+(60,279,o),
+(129,199,o),
+(227,199,cs),
+(320,199,o),
+(374,271,o),
+(369,412,c),
+(313,412,l),
+(315,310,o),
+(283,279,o),
+(241,279,cs),
+(186,279,o),
+(153,326,o),
+(153,438,cs),
+(153,559,o),
+(206,620,o),
+(293,620,cs),
+(380,620,o),
+(428,560,o),
+(428,445,cs),
+(428,0,l)
+);
+}
+);
+width = 593;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1597;
+unicode = 5527;
+},
+{
+glyphname = "shiSayisi-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(164,0,l),
+(164,445,ls),
+(164,560,o),
+(213,620,o),
+(300,620,cs),
+(387,620,o),
+(440,561,o),
+(440,440,cs),
+(440,327,o),
+(406,279,o),
+(352,279,cs),
+(308,279,o),
+(276,310,o),
+(278,412,c),
+(223,412,l),
+(217,271,o),
+(271,199,o),
+(364,199,cs),
+(462,199,o),
+(532,281,o),
+(532,438,cs),
+(532,604,o),
+(445,702,o),
+(301,702,cs),
+(155,702,o),
+(69,606,o),
+(69,444,cs),
+(69,0,l)
+);
+}
+);
+width = 592;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni1598;
+unicode = 5528;
+},
+{
+glyphname = "shoSayisi-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (291,690);
+},
+{
+name = top_left_can;
+pos = (106,690);
+},
+{
+name = top_right_can;
+pos = (476,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(438,-13,o),
+(524,84,o),
+(524,245,cs),
+(524,690,l),
+(428,690,l),
+(428,244,ls),
+(428,129,o),
+(378,70,o),
+(291,70,cs),
+(204,70,o),
+(153,128,o),
+(153,250,cs),
+(153,362,o),
+(186,411,o),
+(241,411,cs),
+(283,411,o),
+(315,380,o),
+(313,278,c),
+(369,278,l),
+(374,418,o),
+(321,491,o),
+(227,491,cs),
+(129,491,o),
+(60,409,o),
+(60,249,cs),
+(60,85,o),
+(146,-13,o),
+(290,-13,cs)
+);
+}
+);
+width = 593;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1599;
+unicode = 5529;
+},
+{
+glyphname = "shaSayisi-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(441,-13,o),
+(532,88,o),
+(532,254,cs),
+(532,411,o),
+(464,491,o),
+(366,491,cs),
+(273,491,o),
+(217,418,o),
+(223,278,c),
+(278,278,l),
+(276,380,o),
+(308,411,o),
+(352,411,cs),
+(406,411,o),
+(440,364,o),
+(440,252,cs),
+(440,130,o),
+(385,70,o),
+(299,70,cs),
+(212,70,o),
+(164,129,o),
+(164,244,cs),
+(164,690,l),
+(69,690,l),
+(69,245,ls),
+(69,84,o),
+(152,-13,o),
+(296,-13,cs)
+);
+}
+);
+width = 592;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni159A;
+unicode = 5530;
+},
+{
+glyphname = "theWoodScree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(661,-13,o),
+(754,82,o),
+(754,234,cs),
+(754,387,o),
+(663,479,o),
+(508,479,cs),
+(66,479,l),
+(66,400,l),
+(391,400,l),
+(379,415,l),
+(317,383,o),
+(286,309,o),
+(286,229,cs),
+(286,79,o),
+(378,-13,o),
+(520,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(431,70,o),
+(381,132,o),
+(381,234,cs),
+(381,332,o),
+(431,397,o),
+(519,397,cs),
+(609,397,o),
+(661,334,o),
+(661,234,cs),
+(661,132,o),
+(610,70,o),
+(520,70,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(743,611,l),
+(743,690,l),
+(66,690,l),
+(66,611,l)
+);
+}
+);
+width = 820;
+}
+);
+note = uni159B;
+unicode = 5531;
+},
+{
+glyphname = "thiWoodScree-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(442,-13,o),
+(534,79,o),
+(534,230,cs),
+(534,310,o),
+(502,384,o),
+(440,416,c),
+(429,400,l),
+(754,400,l),
+(754,479,l),
+(313,479,ls),
+(156,479,o),
+(66,382,o),
+(66,232,cs),
+(66,82,o),
+(158,-13,o),
+(300,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(211,70,o),
+(159,132,o),
+(159,234,cs),
+(159,334,o),
+(212,397,o),
+(301,397,cs),
+(389,397,o),
+(440,332,o),
+(440,234,cs),
+(440,132,o),
+(389,70,o),
+(300,70,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(754,611,l),
+(754,690,l),
+(77,690,l),
+(77,611,l)
+);
+}
+);
+width = 820;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159C;
+unicode = 5532;
+},
+{
+glyphname = "thoWoodScree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(512,0,ls),
+(664,0,o),
+(754,94,o),
+(754,245,cs),
+(754,397,o),
+(662,492,o),
+(520,492,cs),
+(378,492,o),
+(286,398,o),
+(286,249,cs),
+(286,170,o),
+(317,97,o),
+(379,64,c),
+(391,79,l),
+(66,79,l),
+(66,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(431,82,o),
+(381,147,o),
+(381,245,cs),
+(381,347,o),
+(431,410,o),
+(520,410,cs),
+(610,410,o),
+(661,347,o),
+(661,245,cs),
+(661,145,o),
+(609,82,o),
+(519,82,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(743,611,l),
+(743,690,l),
+(66,690,l),
+(66,611,l)
+);
+}
+);
+width = 820;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159D;
+unicode = 5533;
+},
+{
+glyphname = "thaWoodScree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(754,0,l),
+(754,79,l),
+(429,79,l),
+(440,62,l),
+(502,96,o),
+(534,169,o),
+(534,249,cs),
+(534,399,o),
+(442,492,o),
+(300,492,cs),
+(158,492,o),
+(66,397,o),
+(66,244,cs),
+(66,96,o),
+(156,0,o),
+(309,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(212,82,o),
+(159,145,o),
+(159,245,cs),
+(159,347,o),
+(211,410,o),
+(300,410,cs),
+(389,410,o),
+(440,347,o),
+(440,245,cs),
+(440,147,o),
+(389,82,o),
+(301,82,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(754,611,l),
+(754,690,l),
+(77,690,l),
+(77,611,l)
+);
+}
+);
+width = 820;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159E;
+unicode = 5534;
+},
+{
+glyphname = "thWoodScree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,345,l),
+(440,404,l),
+(259,404,l),
+(262,379,l),
+(294,390,o),
+(316,432,o),
+(316,479,cs),
+(316,556,o),
+(267,607,o),
+(190,607,cs),
+(115,607,o),
+(64,555,o),
+(64,476,cs),
+(64,397,o),
+(114,345,o),
+(196,345,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(152,395,o),
+(125,425,o),
+(125,476,cs),
+(125,526,o),
+(152,555,o),
+(190,555,cs),
+(229,555,o),
+(255,526,o),
+(255,475,cs),
+(255,425,o),
+(229,395,o),
+(190,395,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(439,663,l),
+(439,722,l),
+(69,722,l),
+(69,663,l)
+);
+}
+);
+width = 504;
+}
+);
+metricRight = "=|";
+note = uni159F;
+unicode = 5535;
+},
+{
+glyphname = "lhi-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (458,690);
+},
+{
+name = top_right_can;
+pos = (554,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(363,0,l),
+(363,85,l),
+(315,85,ls),
+(211,85,o),
+(156,141,o),
+(156,238,cs),
+(156,331,o),
+(206,392,o),
+(314,392,cs),
+(750,392,l),
+(750,469,l),
+(571,728,l),
+(500,680,l),
+(679,421,l),
+(675,479,l),
+(312,479,ls),
+(151,479,o),
+(60,384,o),
+(60,238,cs),
+(60,91,o),
+(156,0,o),
+(310,0,cs)
+);
+}
+);
+width = 805;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A0;
+unicode = 5536;
+},
+{
+glyphname = "lhii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "lhi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (384,0);
+ref = dot_top;
+}
+);
+width = 805;
+}
+);
+note = uni15A1;
+unicode = 5537;
+},
+{
+glyphname = "lho-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (394,497);
+},
+{
+name = top_right_can;
+pos = (505,497);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(304,-201,l),
+(126,58,l),
+(129,0,l),
+(491,0,ls),
+(652,0,o),
+(745,91,o),
+(745,241,cs),
+(745,389,o),
+(649,479,o),
+(496,479,cs),
+(441,479,l),
+(441,394,l),
+(490,394,ls),
+(594,394,o),
+(650,338,o),
+(650,242,cs),
+(650,144,o),
+(594,86,o),
+(491,86,cs),
+(55,86,l),
+(55,10,l),
+(234,-249,l)
+);
+}
+);
+width = 805;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni15A2;
+unicode = 5538;
+},
+{
+glyphname = "lhoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "lho-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (432,-193);
+ref = dot_top;
+}
+);
+width = 805;
+}
+);
+note = uni15A3;
+unicode = 5539;
+},
+{
+glyphname = "lha-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (412,497);
+},
+{
+name = top_left_can;
+pos = (301,497);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(750,10,l),
+(750,87,l),
+(316,87,ls),
+(211,87,o),
+(156,143,o),
+(156,242,cs),
+(156,338,o),
+(210,394,o),
+(312,394,cs),
+(363,394,l),
+(363,479,l),
+(311,479,ls),
+(153,479,o),
+(60,387,o),
+(60,240,cs),
+(60,89,o),
+(155,0,o),
+(314,0,cs),
+(675,0,l),
+(679,58,l),
+(500,-201,l),
+(571,-249,l)
+);
+}
+);
+width = 805;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A4;
+unicode = 5540;
+},
+{
+glyphname = "lhaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "lha-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (228,-193);
+ref = dot_top;
+}
+);
+width = 805;
+}
+);
+note = uni15A5;
+unicode = 5541;
+},
+{
+glyphname = "lh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,352,l),
+(440,409,l),
+(240,409,ls),
+(164,409,o),
+(128,447,o),
+(128,518,cs),
+(128,588,o),
+(164,628,o),
+(237,628,cs),
+(252,628,l),
+(252,690,l),
+(233,690,ls),
+(122,690,o),
+(60,622,o),
+(60,518,cs),
+(60,412,o),
+(122,345,o),
+(236,345,cs),
+(398,345,l),
+(393,384,l),
+(295,241,l),
+(342,208,l)
+);
+}
+);
+width = 500;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni15A6;
+unicode = 5542;
+},
+{
+glyphname = "theThCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (89,690);
+},
+{
+name = top_right_can;
+pos = (447,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(495,0,l),
+(495,102,l),
+(574,102,l),
+(574,158,l),
+(495,158,l),
+(495,326,l),
+(164,326,l),
+(161,276,l),
+(510,643,l),
+(445,701,l),
+(42,270,l),
+(42,241,l),
+(399,241,l),
+(399,158,l),
+(161,158,l),
+(161,102,l),
+(399,102,l),
+(399,0,l)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "ye-canadian";
+note = uni15A7;
+unicode = 5543;
+},
+{
+glyphname = "thiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (160,690);
+},
+{
+name = top_right_can;
+pos = (518,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(209,0,l),
+(209,102,l),
+(445,102,l),
+(445,158,l),
+(209,158,l),
+(209,241,l),
+(565,241,l),
+(565,270,l),
+(161,701,l),
+(99,644,l),
+(448,274,l),
+(444,326,l),
+(112,326,l),
+(112,158,l),
+(33,158,l),
+(33,102,l),
+(112,102,l),
+(112,0,l)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+unicode = 5544;
+},
+{
+glyphname = "thiiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (87,0);
+ref = dot_top;
+}
+);
+width = 607;
+}
+);
+note = uni15A9;
+unicode = 5545;
+},
+{
+glyphname = "thoThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (89,690);
+},
+{
+name = top_right_can;
+pos = (447,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(509,45,l),
+(160,412,l),
+(163,364,l),
+(495,364,l),
+(495,531,l),
+(574,531,l),
+(574,587,l),
+(495,587,l),
+(495,690,l),
+(399,690,l),
+(399,587,l),
+(161,587,l),
+(161,531,l),
+(399,531,l),
+(399,449,l),
+(42,449,l),
+(42,419,l),
+(445,-12,l)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+unicode = 5546;
+},
+{
+glyphname = "thooThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (374,0);
+ref = dot_top;
+}
+);
+width = 607;
+}
+);
+note = uni15AB;
+unicode = 5547;
+},
+{
+glyphname = "thaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (160,690);
+},
+{
+name = top_right_can;
+pos = (518,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(565,419,l),
+(565,449,l),
+(209,449,l),
+(209,531,l),
+(445,531,l),
+(445,587,l),
+(209,587,l),
+(209,690,l),
+(112,690,l),
+(112,587,l),
+(33,587,l),
+(33,531,l),
+(112,531,l),
+(112,364,l),
+(444,364,l),
+(446,412,l),
+(99,45,l),
+(161,-12,l)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+unicode = 5548;
+},
+{
+glyphname = "thaaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (87,0);
+ref = dot_top;
+}
+);
+width = 607;
+}
+);
+note = uni15AD;
+unicode = 5549;
+},
+{
+glyphname = "thThCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(332,550,l),
+(332,569,l),
+(160,569,l),
+(160,613,l),
+(272,613,l),
+(272,645,l),
+(160,645,l),
+(160,690,l),
+(92,690,l),
+(92,645,l),
+(52,645,l),
+(52,613,l),
+(92,613,l),
+(92,514,l),
+(267,514,l),
+(258,554,l),
+(91,374,l),
+(137,336,l)
+);
+}
+);
+width = 369;
+}
+);
+metricRight = "y-canadian";
+note = uni15AE;
+unicode = 5550;
+},
+{
+glyphname = "bAivilik-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(447,-13,o),
+(535,87,o),
+(535,241,cs),
+(535,390,o),
+(449,492,o),
+(321,492,cs),
+(239,492,o),
+(179,447,o),
+(164,389,c),
+(172,371,l),
+(172,690,l),
+(75,690,l),
+(75,0,l),
+(168,0,l),
+(168,107,l),
+(162,92,l),
+(179,33,o),
+(239,-13,o),
+(322,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(222,70,o),
+(171,130,o),
+(171,240,cs),
+(171,348,o),
+(223,410,o),
+(306,410,cs),
+(387,410,o),
+(440,349,o),
+(440,240,cs),
+(440,130,o),
+(388,70,o),
+(306,70,cs)
+);
+}
+);
+width = 595;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|ke-canadian";
+note = uni15AF;
+unicode = 5551;
+},
+{
+glyphname = "eBlackfoot-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(172,0,l),
+(172,405,l),
+(201,370,o),
+(245,349,o),
+(297,349,cs),
+(395,349,o),
+(464,424,o),
+(464,526,cs),
+(464,628,o),
+(395,702,o),
+(297,702,cs),
+(242,702,o),
+(197,680,o),
+(168,642,c),
+(168,690,l),
+(75,690,l),
+(75,0,l)
+);
+}
+);
+width = 506;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B0;
+unicode = 5552;
+},
+{
+glyphname = "iBlackfoot-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(262,-13,o),
+(308,10,o),
+(336,47,c),
+(336,0,l),
+(429,0,l),
+(429,690,l),
+(332,690,l),
+(332,285,l),
+(303,320,o),
+(260,341,o),
+(208,341,cs),
+(109,341,o),
+(42,266,o),
+(42,163,cs),
+(42,62,o),
+(109,-13,o),
+(208,-13,cs)
+);
+}
+);
+width = 504;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B1;
+unicode = 5553;
+},
+{
+glyphname = "oBlackfoot-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(395,-13,o),
+(464,62,o),
+(464,163,cs),
+(464,266,o),
+(395,341,o),
+(297,341,cs),
+(245,341,o),
+(201,320,o),
+(172,285,c),
+(172,690,l),
+(75,690,l),
+(75,0,l),
+(168,0,l),
+(168,47,l),
+(197,10,o),
+(242,-13,o),
+(297,-13,cs)
+);
+}
+);
+width = 506;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "eBlackfoot-canadian";
+note = uni15B2;
+unicode = 5554;
+},
+{
+glyphname = "aBlackfoot-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(429,0,l),
+(429,690,l),
+(336,690,l),
+(336,642,l),
+(308,680,o),
+(262,702,o),
+(208,702,cs),
+(109,702,o),
+(42,628,o),
+(42,526,cs),
+(42,424,o),
+(109,349,o),
+(208,349,cs),
+(260,349,o),
+(303,370,o),
+(332,405,c),
+(332,0,l)
+);
+}
+);
+width = 504;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B3;
+unicode = 5555;
+},
+{
+glyphname = "weBlackfoot-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(172,303,l),
+(519,303,l),
+(519,384,l),
+(172,384,l),
+(172,609,l),
+(519,609,l),
+(519,690,l),
+(75,690,l),
+(75,0,l),
+(172,0,l)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B4;
+unicode = 5556;
+},
+{
+glyphname = "wiBlackfoot-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(500,0,l),
+(500,690,l),
+(405,690,l),
+(405,386,l),
+(58,386,l),
+(58,305,l),
+(405,305,l),
+(405,81,l),
+(58,81,l),
+(58,0,l)
+);
+}
+);
+width = 575;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B5;
+unicode = 5557;
+},
+{
+glyphname = "woBlackfoot-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(519,0,l),
+(519,81,l),
+(172,81,l),
+(172,305,l),
+(519,305,l),
+(519,386,l),
+(172,386,l),
+(172,690,l),
+(75,690,l),
+(75,0,l)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "weBlackfoot-canadian";
+note = uni15B6;
+unicode = 5558;
+},
+{
+glyphname = "waBlackfoot-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(500,0,l),
+(500,690,l),
+(58,690,l),
+(58,609,l),
+(405,609,l),
+(405,384,l),
+(58,384,l),
+(58,303,l),
+(405,303,l),
+(405,0,l)
+);
+}
+);
+width = 575;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B7;
+unicode = 5559;
+},
+{
+glyphname = "neBlackfoot-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(172,0,l),
+(172,617,l),
+(219,617,l),
+(190,677,l),
+(190,655,ls),
+(190,497,o),
+(275,399,o),
+(418,399,cs),
+(557,399,o),
+(648,496,o),
+(648,650,cs),
+(648,690,l),
+(554,690,l),
+(554,645,ls),
+(554,543,o),
+(503,482,o),
+(419,482,cs),
+(334,482,o),
+(285,542,o),
+(285,645,cs),
+(285,690,l),
+(75,690,l),
+(75,0,l)
+);
+}
+);
+width = 687;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B8;
+unicode = 5560;
+},
+{
+glyphname = "niBlackfoot-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(133,0,l),
+(133,44,ls),
+(133,147,o),
+(184,208,o),
+(268,208,cs),
+(353,208,o),
+(403,148,o),
+(403,44,cs),
+(403,0,l),
+(611,0,l),
+(611,690,l),
+(515,690,l),
+(515,72,l),
+(468,72,l),
+(497,13,l),
+(497,35,ls),
+(497,193,o),
+(412,291,o),
+(270,291,cs),
+(130,291,o),
+(39,194,o),
+(39,40,cs),
+(39,0,l)
+);
+}
+);
+width = 686;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B9;
+unicode = 5561;
+},
+{
+glyphname = "noBlackfoot-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(285,0,l),
+(285,44,ls),
+(285,148,o),
+(334,208,o),
+(419,208,cs),
+(503,208,o),
+(554,147,o),
+(554,44,cs),
+(554,0,l),
+(648,0,l),
+(648,40,ls),
+(648,194,o),
+(557,291,o),
+(418,291,cs),
+(275,291,o),
+(190,193,o),
+(190,35,cs),
+(190,13,l),
+(219,72,l),
+(172,72,l),
+(172,690,l),
+(75,690,l),
+(75,0,l)
+);
+}
+);
+width = 687;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "neBlackfoot-canadian";
+note = uni15BA;
+unicode = 5562;
+},
+{
+glyphname = "naBlackfoot-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(611,0,l),
+(611,690,l),
+(403,690,l),
+(403,645,ls),
+(403,542,o),
+(353,482,o),
+(268,482,cs),
+(184,482,o),
+(133,543,o),
+(133,645,cs),
+(133,690,l),
+(39,690,l),
+(39,650,ls),
+(39,496,o),
+(130,399,o),
+(270,399,cs),
+(412,399,o),
+(497,497,o),
+(497,655,cs),
+(497,677,l),
+(468,617,l),
+(515,617,l),
+(515,0,l)
+);
+}
+);
+width = 686;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BB;
+unicode = 5563;
+},
+{
+glyphname = "keBlackfoot-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(172,0,l),
+(172,582,l),
+(134,582,l),
+(313,255,l),
+(355,255,l),
+(591,690,l),
+(492,690,l),
+(307,350,l),
+(349,350,l),
+(165,690,l),
+(75,690,l),
+(75,0,l)
+);
+}
+);
+width = 613;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15BC;
+unicode = 5564;
+},
+{
+glyphname = "kiBlackfoot-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(123,0,l),
+(306,340,l),
+(265,340,l),
+(449,0,l),
+(538,0,l),
+(538,690,l),
+(441,690,l),
+(441,107,l),
+(479,107,l),
+(301,435,l),
+(260,435,l),
+(22,0,l)
+);
+}
+);
+width = 613;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BD;
+unicode = 5565;
+},
+{
+glyphname = "koBlackfoot-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(165,0,l),
+(349,340,l),
+(307,340,l),
+(492,0,l),
+(591,0,l),
+(355,435,l),
+(313,435,l),
+(134,107,l),
+(172,107,l),
+(172,690,l),
+(75,690,l),
+(75,0,l)
+);
+}
+);
+width = 613;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "keBlackfoot-canadian";
+note = uni15BE;
+unicode = 5566;
+},
+{
+glyphname = "kaBlackfoot-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(538,0,l),
+(538,690,l),
+(449,690,l),
+(265,350,l),
+(306,350,l),
+(123,690,l),
+(22,690,l),
+(260,255,l),
+(301,255,l),
+(479,582,l),
+(441,582,l),
+(441,0,l)
+);
+}
+);
+width = 613;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BF;
+unicode = 5567;
+},
+{
+color = 9;
+glyphname = "heSayisi-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_right_can;
+pos = (548,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(595,0,l),
+(595,690,l),
+(499,690,l),
+(499,286,l),
+(517,286,l),
+(508,530,o),
+(416,702,o),
+(258,702,cs),
+(128,702,o),
+(55,611,o),
+(55,449,cs),
+(55,415,o),
+(59,376,o),
+(68,336,c),
+(159,336,l),
+(152,374,o),
+(149,412,o),
+(149,441,cs),
+(149,562,o),
+(195,618,o),
+(277,618,cs),
+(412,618,o),
+(497,440,o),
+(499,0,c)
+);
+}
+);
+width = 670;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni15C0;
+unicode = 5568;
+},
+{
+color = 9;
+glyphname = "hiSayisi-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(172,0,l),
+(174,440,o),
+(259,618,o),
+(394,618,cs),
+(475,618,o),
+(523,562,o),
+(523,441,cs),
+(523,412,o),
+(519,374,o),
+(512,336,c),
+(604,336,l),
+(612,376,o),
+(615,415,o),
+(615,449,cs),
+(615,611,o),
+(543,702,o),
+(412,702,cs),
+(255,702,o),
+(162,530,o),
+(154,286,c),
+(171,286,l),
+(171,690,l),
+(75,690,l),
+(75,0,l)
+);
+}
+);
+width = 670;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C1;
+unicode = 5569;
+},
+{
+color = 9;
+glyphname = "hoSayisi-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (330,690);
+},
+{
+name = top_left_can;
+pos = (113,690);
+},
+{
+name = top_right_can;
+pos = (548,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(416,-13,o),
+(508,159,o),
+(517,404,c),
+(499,404,l),
+(499,0,l),
+(595,0,l),
+(595,690,l),
+(499,690,l),
+(497,249,o),
+(412,71,o),
+(277,71,cs),
+(195,71,o),
+(149,128,o),
+(149,248,cs),
+(149,278,o),
+(152,316,o),
+(159,354,c),
+(68,354,l),
+(59,314,o),
+(55,274,o),
+(55,241,cs),
+(55,78,o),
+(128,-13,o),
+(258,-13,cs)
+);
+}
+);
+width = 670;
+}
+);
+metricLeft = "heSayisi-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15C2;
+unicode = 5570;
+},
+{
+color = 9;
+glyphname = "haSayisi-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(543,-13,o),
+(615,78,o),
+(615,241,cs),
+(615,274,o),
+(612,314,o),
+(604,354,c),
+(512,354,l),
+(519,316,o),
+(523,278,o),
+(523,248,cs),
+(523,128,o),
+(475,71,o),
+(394,71,cs),
+(259,71,o),
+(174,249,o),
+(172,690,c),
+(75,690,l),
+(75,0,l),
+(171,0,l),
+(171,404,l),
+(154,404,l),
+(162,159,o),
+(255,-13,o),
+(412,-13,cs)
+);
+}
+);
+width = 670;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C3;
+unicode = 5571;
+},
+{
+color = 9;
+glyphname = "ghuCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(376,0,l),
+(684,664,l),
+(684,690,l),
+(604,690,l),
+(503,469,l),
+(554,485,l),
+(165,485,l),
+(217,468,l),
+(117,690,l),
+(32,690,l),
+(32,664,l),
+(340,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(525,412,l),
+(488,426,l),
+(341,102,l),
+(379,102,l),
+(233,427,l),
+(197,412,l)
+);
+}
+);
+width = 716;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C4;
+unicode = 5572;
+},
+{
+color = 9;
+glyphname = "ghoCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(117,0,l),
+(217,222,l),
+(165,205,l),
+(554,205,l),
+(503,220,l),
+(604,0,l),
+(684,0,l),
+(684,26,l),
+(376,690,l),
+(340,690,l),
+(32,26,l),
+(32,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(379,587,l),
+(341,587,l),
+(488,264,l),
+(525,278,l),
+(197,278,l),
+(233,263,l)
+);
+}
+);
+width = 716;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C5;
+unicode = 5573;
+},
+{
+color = 9;
+glyphname = "gheCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (76,345);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(78,0,l),
+(615,327,l),
+(615,362,l),
+(78,690,l),
+(53,690,l),
+(53,611,l),
+(210,515,l),
+(202,548,l),
+(202,131,l),
+(210,176,l),
+(53,79,l),
+(53,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(274,527,l),
+(258,495,l),
+(534,324,l),
+(535,367,l),
+(258,197,l),
+(274,164,l)
+);
+}
+);
+width = 649;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15C6;
+unicode = 5574;
+},
+{
+color = 9;
+glyphname = "gheeCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (35,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 649;
+}
+);
+note = uni15C7;
+unicode = 5575;
+},
+{
+color = 9;
+glyphname = "ghiCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (12,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 649;
+}
+);
+note = uni15C8;
+unicode = 5576;
+},
+{
+color = 9;
+glyphname = "ghaCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(596,0,l),
+(596,78,l),
+(446,172,l),
+(454,133,l),
+(454,556,l),
+(446,518,l),
+(596,611,l),
+(596,690,l),
+(571,690,l),
+(34,362,l),
+(34,327,l),
+(571,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(398,193,l),
+(116,367,l),
+(116,323,l),
+(398,497,l),
+(382,525,l),
+(382,167,l)
+);
+}
+);
+width = 649;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15C9;
+unicode = 5577;
+},
+{
+color = 9;
+glyphname = "ruCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(376,0,l),
+(684,664,l),
+(684,690,l),
+(604,690,l),
+(564,603,l),
+(584,614,l),
+(132,614,l),
+(156,602,l),
+(117,690,l),
+(32,690,l),
+(32,664,l),
+(340,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(562,539,l),
+(548,560,l),
+(341,104,l),
+(380,104,l),
+(175,558,l),
+(155,539,l)
+);
+}
+);
+width = 716;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CA;
+unicode = 5578;
+},
+{
+color = 9;
+glyphname = "roCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(116,0,l),
+(156,87,l),
+(133,75,l),
+(584,75,l),
+(562,88,l),
+(603,0,l),
+(684,0,l),
+(684,26,l),
+(376,690,l),
+(340,690,l),
+(32,26,l),
+(32,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(377,588,l),
+(339,588,l),
+(545,131,l),
+(562,151,l),
+(156,151,l),
+(171,129,l)
+);
+}
+);
+width = 716;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CB;
+unicode = 5579;
+},
+{
+color = 9;
+glyphname = "reCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(79,0,l),
+(615,327,l),
+(615,362,l),
+(79,690,l),
+(53,690,l),
+(53,611,l),
+(129,564,l),
+(116,589,l),
+(116,100,l),
+(129,127,l),
+(53,79,l),
+(53,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(191,568,l),
+(179,540,l),
+(531,323,l),
+(531,367,l),
+(179,151,l),
+(191,121,l)
+);
+}
+);
+width = 649;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CC;
+unicode = 5580;
+},
+{
+color = 9;
+glyphname = "reeCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(79,0,l),
+(615,327,l),
+(615,362,l),
+(79,690,l),
+(53,690,l),
+(53,621,l),
+(129,573,l),
+(116,595,l),
+(116,91,l),
+(129,116,l),
+(53,69,l),
+(53,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(183,575,l),
+(171,554,l),
+(551,324,l),
+(551,367,l),
+(170,134,l),
+(183,121,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(281,263,l),
+(281,429,l),
+(239,429,l),
+(239,263,l)
+);
+}
+);
+width = 649;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CD;
+unicode = 5581;
+},
+{
+color = 9;
+glyphname = "riCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(79,0,l),
+(615,327,l),
+(615,362,l),
+(79,690,l),
+(53,690,l),
+(53,621,l),
+(129,573,l),
+(116,595,l),
+(116,92,l),
+(129,116,l),
+(53,69,l),
+(53,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(301,303,o),
+(321,321,o),
+(321,345,cs),
+(321,369,o),
+(301,386,o),
+(278,386,cs),
+(256,386,o),
+(237,369,o),
+(237,345,cs),
+(237,321,o),
+(256,303,o),
+(278,303,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(183,574,l),
+(171,554,l),
+(551,324,l),
+(551,367,l),
+(170,135,l),
+(183,122,l)
+);
+}
+);
+width = 649;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CE;
+unicode = 5582;
+},
+{
+color = 9;
+glyphname = "raCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(596,0,l),
+(596,79,l),
+(524,125,l),
+(533,95,l),
+(533,596,l),
+(524,565,l),
+(596,611,l),
+(596,690,l),
+(571,690,l),
+(34,362,l),
+(34,327,l),
+(571,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(475,542,l),
+(458,569,l),
+(458,122,l),
+(475,149,l),
+(119,367,l),
+(119,324,l)
+);
+}
+);
+width = 649;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15CF;
+unicode = 5583;
+},
+{
+color = 9;
+glyphname = "wuCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(381,0,l),
+(693,664,l),
+(693,690,l),
+(617,690,l),
+(381,161,l),
+(404,161,l),
+(404,690,l),
+(327,690,l),
+(327,161,l),
+(351,161,l),
+(113,690,l),
+(32,690,l),
+(32,664,l),
+(345,0,l)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D0;
+unicode = 5584;
+},
+{
+color = 9;
+glyphname = "woCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(111,0,l),
+(348,528,l),
+(325,528,l),
+(325,0,l),
+(401,0,l),
+(401,528,l),
+(378,528,l),
+(615,0,l),
+(693,0,l),
+(693,26,l),
+(381,690,l),
+(345,690,l),
+(32,26,l),
+(32,0,l)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D1;
+unicode = 5585;
+},
+{
+color = 9;
+glyphname = "weCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,0,l),
+(636,327,l),
+(636,362,l),
+(99,690,l),
+(73,690,l),
+(73,611,l),
+(487,362,l),
+(487,383,l),
+(75,383,l),
+(75,308,l),
+(486,308,l),
+(486,327,l),
+(73,78,l),
+(73,0,l)
+);
+}
+);
+width = 670;
+}
+);
+metricRight = "o-canadian";
+note = uni15D2;
+unicode = 5586;
+},
+{
+color = 9;
+glyphname = "weeCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,0,l),
+(636,327,l),
+(636,362,l),
+(99,690,l),
+(73,690,l),
+(73,619,l),
+(515,354,l),
+(522,375,l),
+(205,375,l),
+(205,454,l),
+(151,454,l),
+(151,375,l),
+(73,375,l),
+(73,316,l),
+(151,316,l),
+(151,237,l),
+(205,237,l),
+(205,316,l),
+(523,316,l),
+(516,336,l),
+(73,71,l),
+(73,0,l)
+);
+}
+);
+width = 670;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D3;
+unicode = 5587;
+},
+{
+color = 9;
+glyphname = "wiCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,0,l),
+(636,327,l),
+(636,362,l),
+(99,690,l),
+(73,690,l),
+(73,620,l),
+(516,354,l),
+(522,375,l),
+(274,375,l),
+(264,400,o),
+(239,417,o),
+(210,417,cs),
+(180,417,o),
+(155,400,o),
+(145,375,c),
+(73,375,l),
+(73,316,l),
+(145,316,l),
+(156,291,o),
+(181,272,o),
+(210,272,cs),
+(239,272,o),
+(263,291,o),
+(273,316,c),
+(523,316,l),
+(517,336,l),
+(73,70,l),
+(73,0,l)
+);
+}
+);
+width = 670;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D4;
+unicode = 5588;
+},
+{
+color = 9;
+glyphname = "waCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(596,0,l),
+(596,77,l),
+(183,327,l),
+(183,307,l),
+(595,307,l),
+(595,382,l),
+(184,382,l),
+(184,362,l),
+(596,611,l),
+(596,690,l),
+(571,690,l),
+(34,362,l),
+(34,327,l),
+(571,0,l)
+);
+}
+);
+width = 669;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15D5;
+unicode = 5589;
+},
+{
+color = 9;
+glyphname = "hwuCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(381,0,l),
+(693,664,l),
+(693,690,l),
+(621,690,l),
+(526,481,l),
+(560,497,l),
+(395,497,l),
+(395,690,l),
+(332,690,l),
+(332,497,l),
+(166,497,l),
+(202,482,l),
+(106,690,l),
+(32,690,l),
+(32,664,l),
+(345,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(338,441,l),
+(338,126,l),
+(355,130,l),
+(210,457,l),
+(189,441,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(390,441,l),
+(538,441,l),
+(520,457,l),
+(372,128,l),
+(390,125,l)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D6;
+unicode = 5590;
+},
+{
+color = 9;
+glyphname = "hwoCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(106,0,l),
+(202,209,l),
+(168,192,l),
+(332,192,l),
+(332,0,l),
+(395,0,l),
+(395,192,l),
+(562,192,l),
+(526,209,l),
+(621,0,l),
+(693,0,l),
+(693,26,l),
+(381,690,l),
+(345,690,l),
+(32,26,l),
+(32,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(347,543,l),
+(337,546,l),
+(337,249,l),
+(195,249,l),
+(209,233,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(536,249,l),
+(389,249,l),
+(389,548,l),
+(380,545,l),
+(520,233,l)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D7;
+unicode = 5591;
+},
+{
+color = 9;
+glyphname = "hweCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,0,l),
+(636,327,l),
+(636,362,l),
+(99,690,l),
+(73,690,l),
+(73,619,l),
+(220,531,l),
+(220,377,l),
+(73,377,l),
+(73,314,l),
+(220,314,l),
+(220,158,l),
+(73,70,l),
+(73,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(270,319,l),
+(499,319,l),
+(270,182,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(270,507,l),
+(497,372,l),
+(270,372,l)
+);
+}
+);
+width = 670;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D8;
+unicode = 5592;
+},
+{
+color = 9;
+glyphname = "hweeCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,0,l),
+(636,327,l),
+(636,362,l),
+(99,690,l),
+(73,690,l),
+(73,621,l),
+(242,522,l),
+(242,373,l),
+(185,373,l),
+(185,450,l),
+(139,450,l),
+(139,373,l),
+(73,373,l),
+(73,318,l),
+(139,318,l),
+(139,241,l),
+(185,241,l),
+(185,318,l),
+(242,318,l),
+(242,167,l),
+(73,69,l),
+(73,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(286,322,l),
+(504,322,l),
+(286,190,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(286,499,l),
+(502,369,l),
+(286,369,l)
+);
+}
+);
+width = 670;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D9;
+unicode = 5593;
+},
+{
+color = 9;
+glyphname = "hwiCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,0,l),
+(636,327,l),
+(636,362,l),
+(99,690,l),
+(73,690,l),
+(73,621,l),
+(242,522,l),
+(242,369,l),
+(215,369,l),
+(208,391,o),
+(186,407,o),
+(160,407,cs),
+(136,407,o),
+(115,391,o),
+(106,369,c),
+(73,369,l),
+(73,322,l),
+(107,322,l),
+(115,299,o),
+(136,284,o),
+(161,284,cs),
+(185,284,o),
+(207,299,o),
+(214,322,c),
+(242,322,l),
+(242,167,l),
+(73,69,l),
+(73,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(286,322,l),
+(504,322,l),
+(286,190,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(286,499,l),
+(502,369,l),
+(286,369,l)
+);
+}
+);
+width = 670;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15DA;
+unicode = 5594;
+},
+{
+color = 9;
+glyphname = "hwaCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(596,0,l),
+(596,70,l),
+(449,158,l),
+(449,313,l),
+(596,313,l),
+(596,376,l),
+(449,376,l),
+(449,531,l),
+(596,619,l),
+(596,690,l),
+(571,690,l),
+(34,362,l),
+(34,327,l),
+(571,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(172,318,l),
+(400,318,l),
+(400,182,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(400,508,l),
+(400,371,l),
+(171,371,l)
+);
+}
+);
+width = 669;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15DB;
+unicode = 5595;
+},
+{
+color = 9;
+glyphname = "thuCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(536,-13,o),
+(644,102,o),
+(644,302,cs),
+(644,690,l),
+(69,690,l),
+(69,299,ls),
+(69,101,o),
+(178,-13,o),
+(356,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(164,605,l),
+(549,605,l),
+(549,300,ls),
+(549,152,o),
+(479,75,o),
+(356,75,cs),
+(237,75,o),
+(164,154,o),
+(164,300,cs)
+);
+}
+);
+width = 713;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DC;
+unicode = 5596;
+},
+{
+color = 9;
+glyphname = "thoCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(644,0,l),
+(644,390,ls),
+(644,588,o),
+(535,702,o),
+(359,702,cs),
+(179,702,o),
+(69,588,o),
+(69,387,cs),
+(69,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(164,389,ls),
+(164,536,o),
+(237,614,o),
+(358,614,cs),
+(477,614,o),
+(549,536,o),
+(549,389,cs),
+(549,85,l),
+(164,85,l)
+);
+}
+);
+width = 713;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DD;
+unicode = 5597;
+},
+{
+color = 9;
+glyphname = "theCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (348,345);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(307,0,ls),
+(517,0,o),
+(637,128,o),
+(637,346,cs),
+(637,563,o),
+(517,690,o),
+(303,690,cs),
+(75,690,l),
+(75,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(172,633,l),
+(144,605,l),
+(301,605,ls),
+(458,605,o),
+(540,514,o),
+(540,346,cs),
+(540,179,o),
+(458,85,o),
+(302,85,cs),
+(144,85,l),
+(172,57,l)
+);
+}
+);
+width = 699;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "to-canadian";
+note = uni15DE;
+unicode = 5598;
+},
+{
+color = 9;
+glyphname = "theeCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (299,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 699;
+}
+);
+note = uni15DF;
+unicode = 5599;
+},
+{
+color = 9;
+glyphname = "thiCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (274,0);
+ref = dot_middle;
+}
+);
+width = 699;
+}
+);
+note = uni15E0;
+unicode = 5600;
+},
+{
+color = 9;
+glyphname = "thaCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(622,0,l),
+(622,690,l),
+(393,690,ls),
+(182,690,o),
+(62,562,o),
+(62,345,cs),
+(62,128,o),
+(182,0,o),
+(392,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(157,512,o),
+(241,605,o),
+(396,605,cs),
+(554,605,l),
+(526,633,l),
+(526,57,l),
+(554,85,l),
+(396,85,ls),
+(241,85,o),
+(157,177,o),
+(157,345,cs)
+);
+}
+);
+width = 697;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15E1;
+unicode = 5601;
+},
+{
+color = 9;
+glyphname = "ttuCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(536,-13,o),
+(644,102,o),
+(644,302,cs),
+(644,690,l),
+(611,690,l),
+(344,507,l),
+(370,507,l),
+(104,690,l),
+(69,690,l),
+(69,299,ls),
+(69,101,o),
+(178,-13,o),
+(356,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(237,75,o),
+(164,154,o),
+(164,300,cs),
+(164,614,l),
+(80,611,l),
+(346,430,l),
+(367,430,l),
+(634,611,l),
+(549,614,l),
+(549,300,ls),
+(549,152,o),
+(479,75,o),
+(356,75,cs)
+);
+}
+);
+width = 713;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E2;
+unicode = 5602;
+},
+{
+color = 9;
+glyphname = "ttoCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(102,0,l),
+(369,183,l),
+(343,183,l),
+(609,0,l),
+(644,0,l),
+(644,390,ls),
+(644,588,o),
+(534,702,o),
+(355,702,cs),
+(177,702,o),
+(69,587,o),
+(69,387,cs),
+(69,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(476,614,o),
+(549,536,o),
+(549,389,cs),
+(549,75,l),
+(633,78,l),
+(366,260,l),
+(346,260,l),
+(79,78,l),
+(164,75,l),
+(164,389,ls),
+(164,538,o),
+(234,614,o),
+(356,614,cs)
+);
+}
+);
+width = 713;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E3;
+unicode = 5603;
+},
+{
+color = 9;
+glyphname = "tteCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (399,345);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(317,0,ls),
+(526,0,o),
+(646,128,o),
+(646,346,cs),
+(646,563,o),
+(526,690,o),
+(313,690,cs),
+(68,690,l),
+(68,664,l),
+(193,331,l),
+(193,358,l),
+(68,26,l),
+(68,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(279,334,l),
+(279,353,l),
+(156,683,l),
+(155,605,l),
+(311,605,ls),
+(468,605,o),
+(551,514,o),
+(551,346,cs),
+(551,179,o),
+(468,85,o),
+(312,85,cs),
+(155,85,l),
+(156,5,l)
+);
+}
+);
+width = 708;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15E4;
+unicode = 5604;
+},
+{
+color = 9;
+glyphname = "tteeCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (357,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 709;
+}
+);
+note = uni15E5;
+unicode = 5605;
+},
+{
+color = 9;
+glyphname = "ttiCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (343,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 709;
+}
+);
+note = uni15E6;
+unicode = 5606;
+},
+{
+color = 9;
+glyphname = "ttaCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(640,0,l),
+(640,26,l),
+(515,358,l),
+(515,331,l),
+(640,664,l),
+(640,690,l),
+(393,690,ls),
+(182,690,o),
+(62,562,o),
+(62,345,cs),
+(62,128,o),
+(182,0,o),
+(392,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(554,85,l),
+(396,85,ls),
+(241,85,o),
+(157,177,o),
+(157,345,cs),
+(157,512,o),
+(241,605,o),
+(396,605,cs),
+(554,605,l),
+(553,685,l),
+(428,355,l),
+(428,337,l),
+(553,8,l)
+);
+}
+);
+width = 708;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tteCarrier-canadian";
+note = uni15E7;
+unicode = 5607;
+},
+{
+color = 9;
+glyphname = "puCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(536,-13,o),
+(644,102,o),
+(644,302,cs),
+(644,690,l),
+(549,690,l),
+(549,530,l),
+(164,530,l),
+(164,690,l),
+(69,690,l),
+(69,299,ls),
+(69,101,o),
+(178,-13,o),
+(356,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(237,75,o),
+(164,154,o),
+(164,300,cs),
+(164,446,l),
+(549,446,l),
+(549,300,ls),
+(549,152,o),
+(479,75,o),
+(356,75,cs)
+);
+}
+);
+width = 713;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E8;
+unicode = 5608;
+},
+{
+color = 9;
+glyphname = "poCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(164,0,l),
+(164,159,l),
+(549,159,l),
+(549,0,l),
+(644,0,l),
+(644,390,ls),
+(644,588,o),
+(535,702,o),
+(359,702,cs),
+(180,702,o),
+(69,588,o),
+(69,387,cs),
+(69,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(164,389,ls),
+(164,536,o),
+(237,614,o),
+(358,614,cs),
+(477,614,o),
+(549,536,o),
+(549,389,cs),
+(549,243,l),
+(164,243,l)
+);
+}
+);
+width = 713;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E9;
+unicode = 5609;
+},
+{
+color = 9;
+glyphname = "peCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (387,345);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(312,0,ls),
+(522,0,o),
+(641,128,o),
+(641,346,cs),
+(641,563,o),
+(522,690,o),
+(309,690,cs),
+(64,690,l),
+(64,605,l),
+(152,605,l),
+(152,85,l),
+(64,85,l),
+(64,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(246,633,l),
+(215,605,l),
+(307,605,ls),
+(464,605,o),
+(546,514,o),
+(546,346,cs),
+(546,179,o),
+(464,85,o),
+(308,85,cs),
+(215,85,l),
+(246,57,l)
+);
+}
+);
+width = 703;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15EA;
+unicode = 5610;
+},
+{
+color = 9;
+glyphname = "peeCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (346,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 704;
+}
+);
+note = uni15EB;
+unicode = 5611;
+},
+{
+color = 9;
+glyphname = "piCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (331,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 704;
+}
+);
+note = uni15EC;
+unicode = 5612;
+},
+{
+color = 9;
+glyphname = "paCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(640,0,l),
+(640,85,l),
+(552,85,l),
+(552,605,l),
+(640,605,l),
+(640,690,l),
+(394,690,ls),
+(182,690,o),
+(62,563,o),
+(62,346,cs),
+(62,128,o),
+(182,0,o),
+(391,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(488,85,l),
+(395,85,ls),
+(241,85,o),
+(157,179,o),
+(157,346,cs),
+(157,514,o),
+(241,605,o),
+(397,605,cs),
+(488,605,l),
+(457,633,l),
+(457,57,l)
+);
+}
+);
+width = 704;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|peCarrier-canadian";
+note = uni15ED;
+unicode = 5613;
+},
+{
+color = 6;
+glyphname = "pCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(384,183,l),
+(384,247,l),
+(257,247,l),
+(257,527,l),
+(189,527,l),
+(189,247,l),
+(62,247,l),
+(62,183,l)
+);
+}
+);
+width = 446;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni15EE;
+unicode = 5614;
+},
+{
+color = 9;
+glyphname = "guCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (430,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(360,-13,o),
+(424,39,o),
+(450,133,c),
+(410,133,l),
+(440,37,o),
+(502,-13,o),
+(590,-13,cs),
+(713,-13,o),
+(785,72,o),
+(785,213,cs),
+(785,690,l),
+(693,690,l),
+(693,214,ls),
+(693,123,o),
+(655,72,o),
+(585,72,cs),
+(517,72,o),
+(475,124,o),
+(475,213,cs),
+(475,690,l),
+(384,690,l),
+(384,213,ls),
+(384,122,o),
+(344,72,o),
+(274,72,cs),
+(204,72,o),
+(163,122,o),
+(163,214,cs),
+(163,690,l),
+(71,690,l),
+(71,214,ls),
+(71,71,o),
+(147,-13,o),
+(269,-13,cs)
+);
+}
+);
+width = 856;
+}
+);
+metricRight = "=|";
+note = uni15EF;
+unicode = 5615;
+},
+{
+color = 9;
+glyphname = "goCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(163,0,l),
+(163,475,ls),
+(163,567,o),
+(202,617,o),
+(272,617,cs),
+(341,617,o),
+(383,567,o),
+(383,476,cs),
+(383,0,l),
+(473,0,l),
+(473,476,ls),
+(473,566,o),
+(515,617,o),
+(582,617,cs),
+(653,617,o),
+(693,567,o),
+(693,475,cs),
+(693,0,l),
+(785,0,l),
+(785,475,ls),
+(785,618,o),
+(709,702,o),
+(589,702,cs),
+(498,702,o),
+(435,651,o),
+(409,556,c),
+(449,556,l),
+(419,653,o),
+(356,702,o),
+(267,702,cs),
+(144,702,o),
+(71,618,o),
+(71,475,cs),
+(71,0,l)
+);
+}
+);
+width = 856;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F0;
+unicode = 5616;
+},
+{
+color = 9;
+glyphname = "geCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (356,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(421,0,ls),
+(563,0,o),
+(637,68,o),
+(637,186,cs),
+(637,269,o),
+(586,333,o),
+(507,360,c),
+(507,329,l),
+(588,353,o),
+(637,414,o),
+(637,501,cs),
+(637,620,o),
+(561,690,o),
+(421,690,cs),
+(75,690,l),
+(75,611,l),
+(405,611,ls),
+(497,611,o),
+(540,572,o),
+(540,498,cs),
+(540,424,o),
+(494,384,o),
+(407,384,cs),
+(75,384,l),
+(75,306,l),
+(408,306,ls),
+(494,306,o),
+(540,265,o),
+(540,190,cs),
+(540,118,o),
+(497,79,o),
+(405,79,cs),
+(75,79,l),
+(75,0,l)
+);
+}
+);
+width = 708;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15F1;
+unicode = 5617;
+},
+{
+color = 9;
+glyphname = "geeCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(421,0,ls),
+(563,0,o),
+(637,68,o),
+(637,186,cs),
+(637,269,o),
+(586,333,o),
+(507,360,c),
+(507,329,l),
+(588,353,o),
+(637,414,o),
+(637,501,cs),
+(637,620,o),
+(561,690,o),
+(421,690,cs),
+(75,690,l),
+(75,611,l),
+(405,611,ls),
+(497,611,o),
+(540,572,o),
+(540,498,cs),
+(540,424,o),
+(494,384,o),
+(407,384,cs),
+(341,384,l),
+(341,467,l),
+(284,467,l),
+(284,384,l),
+(75,384,l),
+(75,307,l),
+(284,307,l),
+(284,224,l),
+(341,224,l),
+(341,307,l),
+(408,307,ls),
+(494,307,o),
+(540,265,o),
+(540,190,cs),
+(540,118,o),
+(497,79,o),
+(405,79,cs),
+(75,79,l),
+(75,0,l)
+);
+}
+);
+width = 708;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F2;
+unicode = 5618;
+},
+{
+color = 9;
+glyphname = "giCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(421,0,ls),
+(563,0,o),
+(637,68,o),
+(637,186,cs),
+(637,269,o),
+(586,332,o),
+(508,356,c),
+(507,332,l),
+(588,355,o),
+(637,415,o),
+(637,501,cs),
+(637,620,o),
+(561,690,o),
+(421,690,cs),
+(75,690,l),
+(75,611,l),
+(405,611,ls),
+(497,611,o),
+(540,572,o),
+(540,498,cs),
+(540,424,o),
+(494,384,o),
+(410,384,cs),
+(362,384,l),
+(394,371,l),
+(384,405,o),
+(354,428,o),
+(317,428,cs),
+(286,428,o),
+(259,410,o),
+(246,384,c),
+(75,384,l),
+(75,307,l),
+(246,307,l),
+(259,281,o),
+(286,263,o),
+(318,263,cs),
+(354,263,o),
+(383,287,o),
+(394,320,c),
+(362,307,l),
+(411,307,ls),
+(494,307,o),
+(540,265,o),
+(540,190,cs),
+(540,118,o),
+(497,79,o),
+(405,79,cs),
+(75,79,l),
+(75,0,l)
+);
+}
+);
+width = 708;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F3;
+unicode = 5619;
+},
+{
+color = 9;
+glyphname = "gaCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (370,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(633,0,l),
+(633,79,l),
+(303,79,ls),
+(211,79,o),
+(168,118,o),
+(168,190,cs),
+(168,265,o),
+(214,306,o),
+(300,306,cs),
+(633,306,l),
+(633,384,l),
+(301,384,ls),
+(214,384,o),
+(168,424,o),
+(168,498,cs),
+(168,572,o),
+(211,611,o),
+(303,611,cs),
+(633,611,l),
+(633,690,l),
+(287,690,ls),
+(147,690,o),
+(71,620,o),
+(71,501,cs),
+(71,414,o),
+(120,355,o),
+(201,330,c),
+(201,361,l),
+(122,334,o),
+(71,269,o),
+(71,186,cs),
+(71,68,o),
+(145,0,o),
+(287,0,cs)
+);
+}
+);
+width = 708;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|geCarrier-canadian";
+note = uni15F4;
+unicode = 5620;
+},
+{
+color = 9;
+glyphname = "khuCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(360,-13,o),
+(424,39,o),
+(450,133,c),
+(410,133,l),
+(440,37,o),
+(502,-13,o),
+(590,-13,cs),
+(713,-13,o),
+(785,72,o),
+(785,213,cs),
+(785,690,l),
+(71,690,l),
+(71,214,ls),
+(71,71,o),
+(147,-13,o),
+(269,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(204,72,o),
+(163,122,o),
+(163,214,cs),
+(163,607,l),
+(384,607,l),
+(384,213,ls),
+(384,122,o),
+(344,72,o),
+(274,72,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(517,72,o),
+(475,124,o),
+(475,213,cs),
+(475,607,l),
+(693,607,l),
+(693,214,ls),
+(693,123,o),
+(655,72,o),
+(585,72,cs)
+);
+}
+);
+width = 856;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F5;
+unicode = 5621;
+},
+{
+color = 9;
+glyphname = "khoCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(785,0,l),
+(785,475,ls),
+(785,617,o),
+(712,702,o),
+(590,702,cs),
+(501,702,o),
+(438,653,o),
+(409,556,c),
+(449,556,l),
+(422,651,o),
+(359,702,o),
+(268,702,cs),
+(147,702,o),
+(71,619,o),
+(71,475,cs),
+(71,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(163,475,ls),
+(163,568,o),
+(204,617,o),
+(274,617,cs),
+(343,617,o),
+(384,567,o),
+(384,476,cs),
+(384,83,l),
+(163,83,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(474,476,ls),
+(474,566,o),
+(516,617,o),
+(584,617,cs),
+(655,617,o),
+(693,567,o),
+(693,475,cs),
+(693,83,l),
+(474,83,l)
+);
+}
+);
+width = 856;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F6;
+unicode = 5622;
+},
+{
+color = 9;
+glyphname = "kheCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(425,0,ls),
+(567,0,o),
+(640,68,o),
+(640,186,cs),
+(640,269,o),
+(590,333,o),
+(511,360,c),
+(511,329,l),
+(592,353,o),
+(640,414,o),
+(640,501,cs),
+(640,620,o),
+(566,690,o),
+(425,690,cs),
+(75,690,l),
+(75,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(172,307,l),
+(412,307,ls),
+(497,307,o),
+(545,265,o),
+(545,190,cs),
+(545,118,o),
+(501,78,o),
+(409,78,cs),
+(172,78,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(172,611,l),
+(409,611,ls),
+(501,611,o),
+(545,572,o),
+(545,498,cs),
+(545,424,o),
+(497,384,o),
+(411,384,cs),
+(172,384,l)
+);
+}
+);
+width = 711;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F7;
+unicode = 5623;
+},
+{
+color = 9;
+glyphname = "kheeCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(425,0,ls),
+(567,0,o),
+(640,68,o),
+(640,186,cs),
+(640,269,o),
+(590,333,o),
+(510,358,c),
+(510,330,l),
+(592,353,o),
+(640,414,o),
+(640,501,cs),
+(640,620,o),
+(566,690,o),
+(425,690,cs),
+(75,690,l),
+(75,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(172,308,l),
+(312,308,l),
+(312,222,l),
+(376,222,l),
+(376,329,l),
+(350,308,l),
+(414,308,ls),
+(499,308,o),
+(545,266,o),
+(545,191,cs),
+(545,118,o),
+(501,78,o),
+(409,78,cs),
+(172,78,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(376,469,l),
+(312,469,l),
+(312,384,l),
+(172,384,l),
+(172,611,l),
+(409,611,ls),
+(501,611,o),
+(545,572,o),
+(545,498,cs),
+(545,423,o),
+(498,384,o),
+(413,384,cs),
+(350,384,l),
+(376,361,l)
+);
+}
+);
+width = 711;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F8;
+unicode = 5624;
+},
+{
+color = 9;
+glyphname = "khiCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(425,0,ls),
+(567,0,o),
+(640,68,o),
+(640,186,cs),
+(640,269,o),
+(592,331,o),
+(514,358,c),
+(513,330,l),
+(593,354,o),
+(640,415,o),
+(640,501,cs),
+(640,620,o),
+(566,690,o),
+(425,690,cs),
+(75,690,l),
+(75,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(172,309,l),
+(270,309,l),
+(283,282,o),
+(310,263,o),
+(342,263,cs),
+(384,263,o),
+(417,296,o),
+(422,336,c),
+(370,309,l),
+(415,309,ls),
+(499,309,o),
+(545,267,o),
+(545,191,cs),
+(545,117,o),
+(501,78,o),
+(409,78,cs),
+(172,78,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(409,611,ls),
+(501,611,o),
+(545,572,o),
+(545,497,cs),
+(545,422,o),
+(498,382,o),
+(414,382,cs),
+(371,382,l),
+(423,354,l),
+(418,396,o),
+(384,428,o),
+(342,428,cs),
+(299,428,o),
+(266,396,o),
+(262,355,c),
+(295,382,l),
+(172,382,l),
+(172,611,l)
+);
+}
+);
+width = 711;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F9;
+unicode = 5625;
+},
+{
+color = 9;
+glyphname = "khaCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(637,0,l),
+(637,690,l),
+(287,690,ls),
+(147,690,o),
+(71,620,o),
+(71,501,cs),
+(71,415,o),
+(119,355,o),
+(200,332,c),
+(198,359,l),
+(121,333,o),
+(71,269,o),
+(71,186,cs),
+(71,68,o),
+(145,0,o),
+(287,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(211,78,o),
+(168,118,o),
+(168,190,cs),
+(168,265,o),
+(214,307,o),
+(300,307,cs),
+(541,307,l),
+(541,78,l),
+(303,78,ls)
+);
+},
+{
+closed = 1;
+nodes = (
+(214,384,o),
+(168,424,o),
+(168,498,cs),
+(168,572,o),
+(211,611,o),
+(303,611,cs),
+(541,611,l),
+(541,384,l),
+(301,384,ls)
+);
+}
+);
+width = 712;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15FA;
+unicode = 5626;
+},
+{
+color = 9;
+glyphname = "kkuCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(363,-13,o),
+(428,43,o),
+(451,143,c),
+(408,143,l),
+(435,41,o),
+(499,-13,o),
+(590,-13,cs),
+(713,-13,o),
+(785,72,o),
+(785,213,cs),
+(785,690,l),
+(751,690,l),
+(459,529,l),
+(459,440,l),
+(755,600,l),
+(693,606,l),
+(693,214,ls),
+(693,123,o),
+(655,72,o),
+(585,72,cs),
+(517,72,o),
+(475,124,o),
+(475,213,cs),
+(475,690,l),
+(384,690,l),
+(384,213,ls),
+(384,122,o),
+(344,72,o),
+(274,72,cs),
+(204,72,o),
+(163,122,o),
+(163,214,cs),
+(163,606,l),
+(101,600,l),
+(398,440,l),
+(398,529,l),
+(106,690,l),
+(71,690,l),
+(71,214,ls),
+(71,71,o),
+(147,-13,o),
+(269,-13,cs)
+);
+}
+);
+width = 856;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FB;
+unicode = 5627;
+},
+{
+color = 9;
+glyphname = "kkoCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(105,0,l),
+(398,160,l),
+(398,250,l),
+(100,90,l),
+(163,84,l),
+(163,475,ls),
+(163,567,o),
+(202,617,o),
+(271,617,cs),
+(340,617,o),
+(382,566,o),
+(382,476,cs),
+(382,0,l),
+(471,0,l),
+(471,476,ls),
+(471,568,o),
+(513,617,o),
+(582,617,cs),
+(653,617,o),
+(693,568,o),
+(693,475,cs),
+(693,84,l),
+(754,90,l),
+(458,250,l),
+(458,160,l),
+(750,0,l),
+(785,0,l),
+(785,475,ls),
+(785,619,o),
+(709,702,o),
+(588,702,cs),
+(493,702,o),
+(428,647,o),
+(405,547,c),
+(449,547,l),
+(421,649,o),
+(356,702,o),
+(266,702,cs),
+(144,702,o),
+(71,617,o),
+(71,476,cs),
+(71,0,l)
+);
+}
+);
+width = 856;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FC;
+unicode = 5628;
+},
+{
+color = 9;
+glyphname = "kkeCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,0,ls),
+(582,0,o),
+(655,68,o),
+(655,186,cs),
+(655,269,o),
+(605,332,o),
+(528,358,c),
+(527,330,l),
+(608,354,o),
+(655,415,o),
+(655,501,cs),
+(655,620,o),
+(580,690,o),
+(440,690,cs),
+(71,690,l),
+(71,664,l),
+(177,384,l),
+(82,384,l),
+(82,306,l),
+(177,306,l),
+(71,26,l),
+(71,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(273,306,l),
+(426,306,ls),
+(512,306,o),
+(558,265,o),
+(558,190,cs),
+(558,118,o),
+(516,79,o),
+(423,79,cs),
+(146,79,l),
+(173,39,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(172,651,l),
+(144,611,l),
+(423,611,ls),
+(516,611,o),
+(558,572,o),
+(558,498,cs),
+(558,424,o),
+(511,384,o),
+(425,384,cs),
+(272,384,l)
+);
+}
+);
+width = 726;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni15FD;
+unicode = 5629;
+},
+{
+color = 9;
+glyphname = "kkeeCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,0,ls),
+(582,0,o),
+(655,68,o),
+(655,186,cs),
+(655,269,o),
+(605,332,o),
+(528,358,c),
+(527,330,l),
+(608,354,o),
+(655,415,o),
+(655,501,cs),
+(655,620,o),
+(580,690,o),
+(440,690,cs),
+(71,690,l),
+(71,664,l),
+(177,384,l),
+(82,384,l),
+(82,306,l),
+(177,306,l),
+(71,26,l),
+(71,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(273,308,l),
+(347,308,l),
+(347,224,l),
+(411,224,l),
+(411,327,l),
+(386,308,l),
+(431,308,ls),
+(513,308,o),
+(558,267,o),
+(558,191,cs),
+(558,118,o),
+(516,79,o),
+(423,79,cs),
+(145,79,l),
+(173,39,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(411,467,l),
+(347,467,l),
+(347,383,l),
+(272,383,l),
+(171,651,l),
+(144,611,l),
+(423,611,ls),
+(516,611,o),
+(558,572,o),
+(558,497,cs),
+(558,422,o),
+(513,383,o),
+(431,383,cs),
+(386,383,l),
+(411,365,l)
+);
+}
+);
+width = 726;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FE;
+unicode = 5630;
+},
+{
+color = 9;
+glyphname = "kkiCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,0,ls),
+(582,0,o),
+(655,68,o),
+(655,186,cs),
+(655,269,o),
+(605,332,o),
+(528,358,c),
+(527,330,l),
+(608,354,o),
+(655,415,o),
+(655,501,cs),
+(655,620,o),
+(580,690,o),
+(440,690,cs),
+(71,690,l),
+(71,664,l),
+(177,384,l),
+(82,384,l),
+(82,306,l),
+(177,306,l),
+(71,26,l),
+(71,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(273,310,l),
+(304,310,l),
+(316,282,o),
+(343,263,o),
+(376,263,cs),
+(418,263,o),
+(450,297,o),
+(454,335,c),
+(406,310,l),
+(431,310,ls),
+(513,310,o),
+(558,267,o),
+(558,191,cs),
+(558,118,o),
+(516,79,o),
+(423,79,cs),
+(145,79,l),
+(173,39,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(451,396,o),
+(419,428,o),
+(376,428,cs),
+(343,428,o),
+(316,409,o),
+(304,382,c),
+(272,382,l),
+(171,651,l),
+(144,611,l),
+(423,611,ls),
+(516,611,o),
+(558,572,o),
+(558,497,cs),
+(558,422,o),
+(513,382,o),
+(431,382,cs),
+(407,382,l),
+(455,355,l)
+);
+}
+);
+width = 726;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FF;
+unicode = 5631;
+},
+{
+color = 9;
+glyphname = "kkaCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(654,0,l),
+(654,26,l),
+(550,306,l),
+(637,306,l),
+(637,384,l),
+(550,384,l),
+(654,664,l),
+(654,690,l),
+(287,690,ls),
+(147,690,o),
+(71,620,o),
+(71,501,cs),
+(71,415,o),
+(119,355,o),
+(200,332,c),
+(198,359,l),
+(121,333,o),
+(71,269,o),
+(71,186,cs),
+(71,68,o),
+(145,0,o),
+(287,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(582,79,l),
+(303,79,ls),
+(211,79,o),
+(168,118,o),
+(168,190,cs),
+(168,265,o),
+(214,306,o),
+(300,306,cs),
+(453,306,l),
+(554,39,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(214,384,o),
+(168,424,o),
+(168,498,cs),
+(168,572,o),
+(211,611,o),
+(303,611,cs),
+(581,611,l),
+(554,651,l),
+(453,384,l),
+(301,384,ls)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|kkeCarrier-canadian";
+note = uni1600;
+unicode = 5632;
+},
+{
+color = 6;
+glyphname = "kkCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(221,183,l),
+(375,513,l),
+(375,527,l),
+(309,527,l),
+(185,252,l),
+(238,252,l),
+(115,527,l),
+(48,527,l),
+(48,513,l),
+(202,183,l)
+);
+}
+);
+width = 423;
+}
+);
+note = uni1601;
+unicode = 5633;
+},
+{
+color = 9;
+glyphname = "nuCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(542,-13,o),
+(644,94,o),
+(644,270,cs),
+(644,303,l),
+(549,303,l),
+(549,267,ls),
+(549,140,o),
+(479,74,o),
+(363,74,cs),
+(230,74,o),
+(164,148,o),
+(164,299,cs),
+(164,690,l),
+(69,690,l),
+(69,295,ls),
+(69,95,o),
+(174,-13,o),
+(361,-13,cs)
+);
+}
+);
+width = 707;
+}
+);
+metricLeft = "te-canadian";
+note = uni1602;
+unicode = 5634;
+},
+{
+color = 9;
+glyphname = "noCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(639,0,l),
+(639,395,ls),
+(639,595,o),
+(534,702,o),
+(346,702,cs),
+(166,702,o),
+(63,596,o),
+(63,419,cs),
+(63,386,l),
+(158,386,l),
+(158,423,ls),
+(158,550,o),
+(229,615,o),
+(345,615,cs),
+(477,615,o),
+(543,542,o),
+(543,390,cs),
+(543,0,l)
+);
+}
+);
+width = 708;
+}
+);
+metricLeft = "=|nuCarrier-canadian";
+metricRight = "te-canadian";
+note = uni1603;
+unicode = 5635;
+},
+{
+color = 9;
+glyphname = "neCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (316,344);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(310,0,ls),
+(518,0,o),
+(639,128,o),
+(639,346,cs),
+(639,563,o),
+(519,690,o),
+(305,690,cs),
+(51,690,l),
+(51,603,l),
+(303,603,ls),
+(458,603,o),
+(543,512,o),
+(543,345,cs),
+(543,179,o),
+(458,86,o),
+(306,86,cs),
+(286,86,l),
+(286,0,l)
+);
+}
+);
+width = 701;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1604;
+unicode = 5636;
+},
+{
+color = 9;
+glyphname = "neeCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+ref = "neCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (268,-1);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 701;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1605;
+unicode = 5637;
+},
+{
+color = 9;
+glyphname = "niCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "neCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (242,-1);
+ref = dot_middle;
+}
+);
+width = 700;
+}
+);
+note = uni1606;
+unicode = 5638;
+},
+{
+color = 9;
+glyphname = "naCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(649,0,l),
+(649,87,l),
+(396,87,ls),
+(242,87,o),
+(157,179,o),
+(157,345,cs),
+(157,512,o),
+(242,604,o),
+(393,604,cs),
+(414,604,l),
+(414,690,l),
+(389,690,ls),
+(182,690,o),
+(62,562,o),
+(62,345,cs),
+(62,128,o),
+(182,0,o),
+(392,0,cs)
+);
+}
+);
+width = 700;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni1607;
+unicode = 5639;
+},
+{
+color = 9;
+glyphname = "muCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(360,-13,o),
+(424,39,o),
+(450,133,c),
+(410,133,l),
+(440,37,o),
+(502,-13,o),
+(590,-13,cs),
+(713,-13,o),
+(785,72,o),
+(785,213,cs),
+(785,390,l),
+(693,390,l),
+(693,214,ls),
+(693,123,o),
+(655,72,o),
+(585,72,cs),
+(517,72,o),
+(475,124,o),
+(475,213,cs),
+(475,390,l),
+(384,390,l),
+(384,213,ls),
+(384,122,o),
+(344,72,o),
+(274,72,cs),
+(204,72,o),
+(163,122,o),
+(163,214,cs),
+(163,690,l),
+(71,690,l),
+(71,214,ls),
+(71,71,o),
+(147,-13,o),
+(269,-13,cs)
+);
+}
+);
+width = 856;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "=|";
+note = uni1608;
+unicode = 5640;
+},
+{
+color = 9;
+glyphname = "moCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(785,0,l),
+(785,475,ls),
+(785,618,o),
+(709,702,o),
+(589,702,cs),
+(498,702,o),
+(435,651,o),
+(409,556,c),
+(449,556,l),
+(419,653,o),
+(356,702,o),
+(267,702,cs),
+(144,702,o),
+(71,618,o),
+(71,476,cs),
+(71,299,l),
+(163,299,l),
+(163,475,ls),
+(163,567,o),
+(202,617,o),
+(272,617,cs),
+(341,617,o),
+(383,566,o),
+(383,476,cs),
+(383,299,l),
+(473,299,l),
+(473,476,ls),
+(473,566,o),
+(515,617,o),
+(582,617,cs),
+(653,617,o),
+(693,567,o),
+(693,475,cs),
+(693,0,l)
+);
+}
+);
+width = 856;
+}
+);
+metricLeft = "=|muCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni1609;
+unicode = 5641;
+},
+{
+color = 9;
+glyphname = "meCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(423,0,ls),
+(565,0,o),
+(639,68,o),
+(639,186,cs),
+(639,269,o),
+(588,333,o),
+(508,360,c),
+(508,329,l),
+(590,353,o),
+(639,414,o),
+(639,501,cs),
+(639,620,o),
+(563,690,o),
+(423,690,cs),
+(51,690,l),
+(51,611,l),
+(407,611,ls),
+(499,611,o),
+(542,572,o),
+(542,498,cs),
+(542,424,o),
+(495,384,o),
+(409,384,cs),
+(286,384,l),
+(286,306,l),
+(410,306,ls),
+(496,306,o),
+(542,265,o),
+(542,190,cs),
+(542,118,o),
+(499,79,o),
+(407,79,cs),
+(286,79,l),
+(286,0,l)
+);
+}
+);
+width = 710;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160A;
+unicode = 5642;
+},
+{
+color = 9;
+glyphname = "meeCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(423,0,ls),
+(565,0,o),
+(639,68,o),
+(639,186,cs),
+(639,269,o),
+(588,332,o),
+(512,358,c),
+(510,330,l),
+(591,354,o),
+(639,415,o),
+(639,501,cs),
+(639,620,o),
+(563,690,o),
+(423,690,cs),
+(51,690,l),
+(51,611,l),
+(407,611,ls),
+(499,611,o),
+(542,572,o),
+(542,497,cs),
+(542,422,o),
+(496,383,o),
+(411,383,cs),
+(351,383,l),
+(351,465,l),
+(286,465,l),
+(286,226,l),
+(351,226,l),
+(351,308,l),
+(412,308,ls),
+(497,308,o),
+(542,267,o),
+(542,191,cs),
+(542,118,o),
+(499,79,o),
+(407,79,cs),
+(286,79,l),
+(286,0,l)
+);
+}
+);
+width = 710;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160B;
+unicode = 5643;
+},
+{
+color = 9;
+glyphname = "miCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(423,0,ls),
+(565,0,o),
+(639,68,o),
+(639,186,cs),
+(639,269,o),
+(588,332,o),
+(512,358,c),
+(510,330,l),
+(591,354,o),
+(639,415,o),
+(639,501,cs),
+(639,620,o),
+(563,690,o),
+(423,690,cs),
+(51,690,l),
+(51,611,l),
+(407,611,ls),
+(499,611,o),
+(542,572,o),
+(542,497,cs),
+(542,422,o),
+(496,383,o),
+(415,383,cs),
+(347,383,l),
+(399,355,l),
+(394,397,o),
+(360,428,o),
+(318,428,cs),
+(271,428,o),
+(237,391,o),
+(237,346,cs),
+(237,300,o),
+(272,263,o),
+(318,263,cs),
+(360,263,o),
+(393,296,o),
+(398,335,c),
+(346,308,l),
+(415,308,ls),
+(497,308,o),
+(542,267,o),
+(542,191,cs),
+(542,118,o),
+(499,79,o),
+(407,79,cs),
+(286,79,l),
+(286,0,l)
+);
+}
+);
+width = 710;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160C;
+unicode = 5644;
+},
+{
+color = 9;
+glyphname = "maCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(659,0,l),
+(659,79,l),
+(303,79,ls),
+(211,79,o),
+(168,117,o),
+(168,190,cs),
+(168,265,o),
+(214,306,o),
+(300,306,cs),
+(424,306,l),
+(424,384,l),
+(301,384,ls),
+(215,384,o),
+(168,424,o),
+(168,498,cs),
+(168,572,o),
+(211,611,o),
+(303,611,cs),
+(424,611,l),
+(424,690,l),
+(287,690,ls),
+(146,690,o),
+(71,620,o),
+(71,502,cs),
+(71,415,o),
+(121,355,o),
+(201,331,c),
+(201,361,l),
+(121,335,o),
+(71,270,o),
+(71,186,cs),
+(71,69,o),
+(145,0,o),
+(287,0,cs)
+);
+}
+);
+width = 710;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni160D;
+unicode = 5645;
+},
+{
+color = 9;
+glyphname = "yuCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(571,-13,o),
+(686,127,o),
+(686,389,cs),
+(686,601,o),
+(611,702,o),
+(489,702,cs),
+(385,702,o),
+(313,627,o),
+(313,501,cs),
+(313,380,o),
+(382,304,o),
+(485,304,cs),
+(499,304,o),
+(518,307,o),
+(529,311,c),
+(529,387,l),
+(521,385,o),
+(511,384,o),
+(495,384,cs),
+(430,384,o),
+(398,426,o),
+(398,504,cs),
+(398,580,o),
+(430,623,o),
+(486,623,cs),
+(555,623,o),
+(594,562,o),
+(594,392,cs),
+(594,165,o),
+(513,74,o),
+(374,74,cs),
+(242,74,o),
+(164,152,o),
+(164,314,cs),
+(164,690,l),
+(69,690,l),
+(69,309,ls),
+(69,100,o),
+(187,-13,o),
+(370,-13,cs)
+);
+}
+);
+width = 755;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160E;
+unicode = 5646;
+},
+{
+color = 9;
+glyphname = "yoCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(369,-13,o),
+(441,63,o),
+(441,188,cs),
+(441,310,o),
+(373,385,o),
+(270,385,cs),
+(255,385,o),
+(237,383,o),
+(225,379,c),
+(225,302,l),
+(234,304,o),
+(243,306,o),
+(260,306,cs),
+(325,306,o),
+(356,264,o),
+(356,185,cs),
+(356,110,o),
+(325,67,o),
+(269,67,cs),
+(199,67,o),
+(160,128,o),
+(160,298,cs),
+(160,525,o),
+(242,615,o),
+(381,615,cs),
+(513,615,o),
+(590,538,o),
+(590,376,cs),
+(590,0,l),
+(686,0,l),
+(686,381,ls),
+(686,589,o),
+(567,702,o),
+(384,702,cs),
+(184,702,o),
+(69,563,o),
+(69,300,cs),
+(69,89,o),
+(144,-13,o),
+(266,-13,cs)
+);
+}
+);
+width = 755;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160F;
+unicode = 5647;
+},
+{
+color = 9;
+glyphname = "yeCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(523,-13,o),
+(639,127,o),
+(639,342,cs),
+(639,565,o),
+(516,690,o),
+(289,690,cs),
+(77,690,l),
+(77,603,l),
+(293,603,ls),
+(460,603,o),
+(543,513,o),
+(543,339,cs),
+(543,168,o),
+(473,70,o),
+(319,70,cs),
+(196,70,o),
+(147,132,o),
+(147,213,cs),
+(147,289,o),
+(182,330,o),
+(236,330,cs),
+(292,330,o),
+(324,287,o),
+(324,216,cs),
+(324,190,o),
+(322,175,o),
+(319,158,c),
+(396,158,l),
+(401,182,o),
+(403,197,o),
+(403,224,cs),
+(403,331,o),
+(341,408,o),
+(237,408,cs),
+(130,408,o),
+(62,329,o),
+(62,212,cs),
+(62,88,o),
+(150,-13,o),
+(319,-13,cs)
+);
+}
+);
+width = 701;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1610;
+unicode = 5648;
+},
+{
+color = 9;
+glyphname = "yeeCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(523,-13,o),
+(639,127,o),
+(639,342,cs),
+(639,565,o),
+(516,690,o),
+(289,690,cs),
+(77,690,l),
+(77,603,l),
+(293,603,ls),
+(460,603,o),
+(543,513,o),
+(543,339,cs),
+(543,168,o),
+(473,70,o),
+(319,70,cs),
+(196,70,o),
+(147,130,o),
+(147,217,cs),
+(147,288,o),
+(181,330,o),
+(230,330,cs),
+(282,330,o),
+(313,290,o),
+(313,221,cs),
+(313,180,l),
+(370,180,l),
+(370,496,l),
+(313,496,l),
+(313,300,l),
+(325,300,l),
+(317,369,o),
+(275,408,o),
+(210,408,cs),
+(124,408,o),
+(62,331,o),
+(62,216,cs),
+(62,86,o),
+(149,-13,o),
+(319,-13,cs)
+);
+}
+);
+width = 701;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1611;
+unicode = 5649;
+},
+{
+color = 9;
+glyphname = "yiCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(523,-13,o),
+(639,127,o),
+(639,342,cs),
+(639,565,o),
+(516,690,o),
+(289,690,cs),
+(77,690,l),
+(77,603,l),
+(293,603,ls),
+(460,603,o),
+(543,513,o),
+(543,339,cs),
+(543,168,o),
+(473,70,o),
+(323,70,cs),
+(197,70,o),
+(147,129,o),
+(147,204,cs),
+(147,281,o),
+(187,318,o),
+(260,315,c),
+(217,339,l),
+(221,303,o),
+(251,273,o),
+(291,273,cs),
+(332,273,o),
+(362,306,o),
+(362,346,cs),
+(362,386,o),
+(331,416,o),
+(290,416,cs),
+(263,416,o),
+(241,403,o),
+(229,383,c),
+(124,377,o),
+(62,305,o),
+(62,199,cs),
+(62,84,o),
+(150,-13,o),
+(319,-13,cs)
+);
+}
+);
+width = 701;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1612;
+unicode = 5650;
+},
+{
+color = 9;
+glyphname = "yaCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(622,0,l),
+(622,87,l),
+(408,87,ls),
+(240,87,o),
+(157,177,o),
+(157,351,cs),
+(157,522,o),
+(227,620,o),
+(383,620,cs),
+(503,620,o),
+(554,557,o),
+(554,477,cs),
+(554,401,o),
+(518,359,o),
+(464,359,cs),
+(408,359,o),
+(377,403,o),
+(377,473,cs),
+(377,499,o),
+(379,515,o),
+(382,531,c),
+(304,531,l),
+(299,509,o),
+(298,493,o),
+(298,466,cs),
+(298,358,o),
+(359,282,o),
+(464,282,cs),
+(570,282,o),
+(638,360,o),
+(638,478,cs),
+(638,602,o),
+(551,702,o),
+(383,702,cs),
+(178,702,o),
+(62,563,o),
+(62,348,cs),
+(62,125,o),
+(185,0,o),
+(412,0,cs)
+);
+}
+);
+width = 700;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|yeCarrier-canadian";
+note = uni1613;
+unicode = 5651;
+},
+{
+color = 9;
+glyphname = "juCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(558,-13,o),
+(656,80,o),
+(656,220,cs),
+(656,329,o),
+(589,408,o),
+(483,408,cs),
+(380,408,o),
+(316,331,o),
+(316,224,cs),
+(316,197,o),
+(318,181,o),
+(323,158,c),
+(400,158,l),
+(397,175,o),
+(395,191,o),
+(395,216,cs),
+(395,287,o),
+(429,330,o),
+(483,330,cs),
+(538,330,o),
+(572,288,o),
+(572,221,cs),
+(572,126,o),
+(513,70,o),
+(392,70,cs),
+(243,70,o),
+(167,152,o),
+(167,306,cs),
+(167,511,o),
+(300,603,o),
+(530,603,cs),
+(640,603,l),
+(640,690,l),
+(64,690,l),
+(64,607,l),
+(377,607,l),
+(461,642,l),
+(212,642,o),
+(72,515,o),
+(72,302,cs),
+(72,110,o),
+(194,-13,o),
+(389,-13,cs)
+);
+}
+);
+width = 718;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni1614;
+unicode = 5652;
+},
+{
+color = 9;
+glyphname = "juSayisi-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (365,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(525,-13,o),
+(646,110,o),
+(646,302,cs),
+(646,515,o),
+(507,642,o),
+(258,642,c),
+(342,607,l),
+(655,607,l),
+(655,690,l),
+(77,690,l),
+(77,603,l),
+(188,603,ls),
+(418,603,o),
+(551,511,o),
+(551,306,cs),
+(551,152,o),
+(474,70,o),
+(326,70,cs),
+(206,70,o),
+(147,126,o),
+(147,221,cs),
+(147,288,o),
+(181,330,o),
+(235,330,cs),
+(290,330,o),
+(324,287,o),
+(324,216,cs),
+(324,191,o),
+(322,175,o),
+(319,158,c),
+(396,158,l),
+(401,181,o),
+(403,197,o),
+(403,224,cs),
+(403,331,o),
+(338,408,o),
+(236,408,cs),
+(129,408,o),
+(62,329,o),
+(62,220,cs),
+(62,80,o),
+(159,-13,o),
+(329,-13,cs)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1615;
+unicode = 5653;
+},
+{
+color = 9;
+glyphname = "joCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(655,0,l),
+(655,83,l),
+(342,83,l),
+(258,47,l),
+(507,47,o),
+(646,175,o),
+(646,387,cs),
+(646,580,o),
+(525,702,o),
+(329,702,cs),
+(159,702,o),
+(62,610,o),
+(62,469,cs),
+(62,360,o),
+(129,282,o),
+(236,282,cs),
+(338,282,o),
+(403,358,o),
+(403,466,cs),
+(403,493,o),
+(401,509,o),
+(396,531,c),
+(319,531,l),
+(322,515,o),
+(324,498,o),
+(324,473,cs),
+(324,403,o),
+(290,359,o),
+(235,359,cs),
+(181,359,o),
+(147,402,o),
+(147,469,cs),
+(147,564,o),
+(206,620,o),
+(326,620,cs),
+(474,620,o),
+(551,538,o),
+(551,384,cs),
+(551,179,o),
+(418,87,o),
+(188,87,cs),
+(77,87,l),
+(77,0,l)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1616;
+unicode = 5654;
+},
+{
+color = 9;
+glyphname = "jeCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(618,-13,o),
+(694,89,o),
+(694,300,cs),
+(694,566,o),
+(578,702,o),
+(407,702,cs),
+(250,702,o),
+(157,598,o),
+(150,392,c),
+(171,412,l),
+(171,690,l),
+(75,690,l),
+(75,0,l),
+(172,0,l),
+(172,269,ls),
+(172,511,o),
+(248,615,o),
+(393,615,cs),
+(521,615,o),
+(601,521,o),
+(601,298,cs),
+(601,128,o),
+(563,67,o),
+(495,67,cs),
+(439,67,o),
+(406,110,o),
+(406,185,cs),
+(406,264,o),
+(438,306,o),
+(503,306,cs),
+(518,306,o),
+(528,304,o),
+(537,302,c),
+(537,379,l),
+(525,383,o),
+(507,385,o),
+(493,385,cs),
+(389,385,o),
+(321,310,o),
+(321,188,cs),
+(321,63,o),
+(393,-13,o),
+(497,-13,cs)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "te-canadian";
+note = uni1617;
+unicode = 5655;
+},
+{
+color = 9;
+glyphname = "jeeCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(618,-13,o),
+(694,89,o),
+(694,300,cs),
+(694,566,o),
+(578,702,o),
+(407,702,cs),
+(278,702,o),
+(190,634,o),
+(159,495,c),
+(171,482,l),
+(171,690,l),
+(75,690,l),
+(75,0,l),
+(172,0,l),
+(172,269,ls),
+(172,511,o),
+(248,615,o),
+(393,615,cs),
+(521,615,o),
+(601,521,o),
+(601,298,cs),
+(601,137,o),
+(562,67,o),
+(480,67,cs),
+(413,67,o),
+(377,115,o),
+(377,194,cs),
+(377,265,o),
+(403,303,o),
+(448,318,c),
+(448,232,l),
+(501,232,l),
+(501,457,l),
+(448,457,l),
+(448,375,l),
+(374,357,o),
+(321,294,o),
+(321,185,cs),
+(321,62,o),
+(390,-13,o),
+(494,-13,cs)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1618;
+unicode = 5656;
+},
+{
+color = 9;
+glyphname = "jiCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(618,-13,o),
+(694,89,o),
+(694,300,cs),
+(694,566,o),
+(578,702,o),
+(407,702,cs),
+(278,702,o),
+(190,634,o),
+(159,495,c),
+(171,482,l),
+(171,690,l),
+(75,690,l),
+(75,0,l),
+(172,0,l),
+(172,269,ls),
+(172,511,o),
+(248,615,o),
+(393,615,cs),
+(521,615,o),
+(601,521,o),
+(601,298,cs),
+(601,137,o),
+(562,67,o),
+(480,67,cs),
+(413,67,o),
+(377,115,o),
+(377,194,cs),
+(377,243,o),
+(390,273,o),
+(414,291,c),
+(423,280,o),
+(437,273,o),
+(451,273,cs),
+(493,273,o),
+(522,306,o),
+(522,346,cs),
+(522,385,o),
+(492,416,o),
+(451,416,cs),
+(405,416,o),
+(376,376,o),
+(382,335,c),
+(345,306,o),
+(321,257,o),
+(321,185,cs),
+(321,62,o),
+(390,-13,o),
+(494,-13,cs)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1619;
+unicode = 5657;
+},
+{
+color = 9;
+glyphname = "jiSayisi-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(578,-13,o),
+(694,124,o),
+(694,389,cs),
+(694,601,o),
+(618,702,o),
+(497,702,cs),
+(393,702,o),
+(321,627,o),
+(321,501,cs),
+(321,380,o),
+(389,304,o),
+(493,304,cs),
+(507,304,o),
+(525,307,o),
+(537,311,c),
+(537,387,l),
+(528,385,o),
+(518,384,o),
+(503,384,cs),
+(438,384,o),
+(406,426,o),
+(406,504,cs),
+(406,580,o),
+(438,623,o),
+(493,623,cs),
+(563,623,o),
+(601,562,o),
+(601,391,cs),
+(601,169,o),
+(521,74,o),
+(393,74,cs),
+(248,74,o),
+(172,179,o),
+(172,421,cs),
+(172,690,l),
+(75,690,l),
+(75,0,l),
+(171,0,l),
+(171,278,l),
+(150,298,l),
+(157,92,o),
+(250,-13,o),
+(407,-13,cs)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161A;
+unicode = 5658;
+},
+{
+color = 9;
+glyphname = "jaCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (374,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(512,-13,o),
+(605,92,o),
+(612,298,c),
+(591,278,l),
+(591,0,l),
+(686,0,l),
+(686,690,l),
+(590,690,l),
+(590,421,ls),
+(590,179,o),
+(513,74,o),
+(369,74,cs),
+(242,74,o),
+(160,169,o),
+(160,391,cs),
+(160,562,o),
+(199,623,o),
+(269,623,cs),
+(325,623,o),
+(356,580,o),
+(356,504,cs),
+(356,426,o),
+(325,384,o),
+(259,384,cs),
+(244,384,o),
+(234,385,o),
+(225,387,c),
+(225,311,l),
+(237,307,o),
+(255,304,o),
+(269,304,cs),
+(373,304,o),
+(441,380,o),
+(441,501,cs),
+(441,627,o),
+(369,702,o),
+(266,702,cs),
+(144,702,o),
+(69,601,o),
+(69,389,cs),
+(69,124,o),
+(185,-13,o),
+(355,-13,cs)
+);
+}
+);
+width = 761;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni161B;
+unicode = 5659;
+},
+{
+color = 9;
+glyphname = "jjuCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(555,-13,o),
+(644,88,o),
+(644,212,cs),
+(644,329,o),
+(576,408,o),
+(469,408,cs),
+(364,408,o),
+(301,331,o),
+(301,224,cs),
+(301,197,o),
+(303,181,o),
+(309,158,c),
+(386,158,l),
+(384,175,o),
+(381,192,o),
+(381,216,cs),
+(381,287,o),
+(412,330,o),
+(469,330,cs),
+(522,330,o),
+(557,288,o),
+(557,213,cs),
+(557,132,o),
+(503,69,o),
+(386,69,cs),
+(233,69,o),
+(163,163,o),
+(163,313,cs),
+(163,499,o),
+(270,603,o),
+(486,603,cs),
+(629,603,l),
+(629,690,l),
+(481,690,ls),
+(355,690,o),
+(255,656,o),
+(187,595,c),
+(80,702,l),
+(17,640,l),
+(128,530,l),
+(88,473,o),
+(68,400,o),
+(68,316,cs),
+(68,122,o),
+(183,-13,o),
+(385,-13,cs)
+);
+}
+);
+width = 706;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni161C;
+unicode = 5660;
+},
+{
+color = 9;
+glyphname = "jjoCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(689,49,l),
+(579,159,l),
+(618,216,o),
+(639,290,o),
+(639,374,cs),
+(639,568,o),
+(524,702,o),
+(324,702,cs),
+(154,702,o),
+(62,602,o),
+(62,477,cs),
+(62,360,o),
+(129,282,o),
+(237,282,cs),
+(342,282,o),
+(405,358,o),
+(405,466,cs),
+(405,493,o),
+(403,509,o),
+(397,531,c),
+(320,531,l),
+(323,515,o),
+(325,497,o),
+(325,473,cs),
+(325,403,o),
+(294,359,o),
+(238,359,cs),
+(184,359,o),
+(149,402,o),
+(149,476,cs),
+(149,557,o),
+(200,621,o),
+(323,621,cs),
+(473,621,o),
+(543,526,o),
+(543,377,cs),
+(543,190,o),
+(436,87,o),
+(219,87,cs),
+(77,87,l),
+(77,0,l),
+(225,0,ls),
+(352,0,o),
+(451,34,o),
+(519,95,c),
+(626,-13,l)
+);
+}
+);
+width = 706;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|jjuCarrier-canadian";
+note = uni161D;
+unicode = 5661;
+},
+{
+color = 9;
+glyphname = "jjeCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(626,-13,o),
+(701,89,o),
+(701,300,cs),
+(701,563,o),
+(590,702,o),
+(393,702,cs),
+(305,702,o),
+(232,671,o),
+(178,612,c),
+(86,702,l),
+(25,639,l),
+(128,538,l),
+(99,483,o),
+(83,412,o),
+(83,328,cs),
+(83,0,l),
+(180,0,l),
+(180,327,ls),
+(180,519,o),
+(256,615,o),
+(393,615,cs),
+(527,615,o),
+(609,525,o),
+(609,298,cs),
+(609,128,o),
+(571,67,o),
+(501,67,cs),
+(445,67,o),
+(412,110,o),
+(412,185,cs),
+(412,264,o),
+(445,306,o),
+(510,306,cs),
+(526,306,o),
+(536,304,o),
+(545,302,c),
+(545,379,l),
+(532,383,o),
+(515,385,o),
+(500,385,cs),
+(397,385,o),
+(328,310,o),
+(328,188,cs),
+(328,63,o),
+(401,-13,o),
+(504,-13,cs)
+);
+}
+);
+width = 770;
+}
+);
+metricRight = "jeCarrier-canadian";
+note = uni161E;
+unicode = 5662;
+},
+{
+color = 9;
+glyphname = "jjeeCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(626,-13,o),
+(701,89,o),
+(701,300,cs),
+(701,563,o),
+(590,702,o),
+(393,702,cs),
+(305,702,o),
+(232,671,o),
+(178,612,c),
+(86,702,l),
+(25,639,l),
+(128,538,l),
+(99,483,o),
+(83,412,o),
+(83,328,cs),
+(83,0,l),
+(180,0,l),
+(180,327,ls),
+(180,519,o),
+(256,615,o),
+(393,615,cs),
+(527,615,o),
+(609,525,o),
+(609,298,cs),
+(609,137,o),
+(570,67,o),
+(487,67,cs),
+(420,67,o),
+(384,115,o),
+(384,194,cs),
+(384,264,o),
+(411,302,o),
+(452,316,c),
+(452,232,l),
+(505,232,l),
+(505,456,l),
+(452,456,l),
+(452,374,l),
+(380,357,o),
+(328,292,o),
+(328,185,cs),
+(328,62,o),
+(398,-13,o),
+(500,-13,cs)
+);
+}
+);
+width = 770;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161F;
+unicode = 5663;
+},
+{
+color = 9;
+glyphname = "jjiCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(626,-13,o),
+(701,89,o),
+(701,300,cs),
+(701,563,o),
+(590,702,o),
+(393,702,cs),
+(305,702,o),
+(232,671,o),
+(178,612,c),
+(86,702,l),
+(25,639,l),
+(128,538,l),
+(99,483,o),
+(83,412,o),
+(83,328,cs),
+(83,0,l),
+(180,0,l),
+(180,327,ls),
+(180,519,o),
+(256,615,o),
+(393,615,cs),
+(527,615,o),
+(609,525,o),
+(609,298,cs),
+(609,137,o),
+(570,67,o),
+(487,67,cs),
+(420,67,o),
+(384,115,o),
+(384,194,cs),
+(384,246,o),
+(400,278,o),
+(426,294,c),
+(436,282,o),
+(451,273,o),
+(469,273,cs),
+(510,273,o),
+(539,306,o),
+(539,346,cs),
+(539,385,o),
+(509,416,o),
+(469,416,cs),
+(426,416,o),
+(397,382,o),
+(399,344,c),
+(355,316,o),
+(328,263,o),
+(328,185,cs),
+(328,62,o),
+(398,-13,o),
+(500,-13,cs)
+);
+}
+);
+width = 770;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1620;
+unicode = 5664;
+},
+{
+color = 9;
+glyphname = "jjaCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(464,-13,o),
+(538,18,o),
+(591,77,c),
+(683,-13,l),
+(745,51,l),
+(642,152,l),
+(670,207,o),
+(686,277,o),
+(686,361,cs),
+(686,690,l),
+(590,690,l),
+(590,363,ls),
+(590,171,o),
+(513,74,o),
+(377,74,cs),
+(242,74,o),
+(160,165,o),
+(160,392,cs),
+(160,562,o),
+(199,623,o),
+(269,623,cs),
+(325,623,o),
+(356,580,o),
+(356,504,cs),
+(356,426,o),
+(325,384,o),
+(260,384,cs),
+(244,384,o),
+(234,385,o),
+(225,387,c),
+(225,311,l),
+(237,307,o),
+(255,304,o),
+(270,304,cs),
+(373,304,o),
+(441,380,o),
+(441,501,cs),
+(441,627,o),
+(369,702,o),
+(266,702,cs),
+(144,702,o),
+(69,601,o),
+(69,389,cs),
+(69,127,o),
+(179,-13,o),
+(376,-13,cs)
+);
+}
+);
+width = 770;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "=|jjeCarrier-canadian";
+note = uni1621;
+unicode = 5665;
+},
+{
+color = 9;
+glyphname = "luCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(538,-13,o),
+(646,95,o),
+(646,294,cs),
+(646,690,l),
+(550,690,l),
+(550,293,ls),
+(550,145,o),
+(479,74,o),
+(365,74,cs),
+(234,74,o),
+(165,164,o),
+(165,325,cs),
+(165,503,o),
+(240,604,o),
+(386,612,c),
+(386,690,l),
+(61,690,l),
+(61,610,l),
+(273,610,l),
+(339,643,l),
+(173,628,o),
+(70,524,o),
+(70,311,cs),
+(70,111,o),
+(176,-13,o),
+(361,-13,cs)
+);
+}
+);
+width = 715;
+}
+);
+metricRight = "te-canadian";
+note = uni1622;
+unicode = 5666;
+},
+{
+color = 9;
+glyphname = "loCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(164,0,l),
+(164,397,ls),
+(164,545,o),
+(235,615,o),
+(353,615,cs),
+(480,615,o),
+(549,526,o),
+(549,365,cs),
+(549,186,o),
+(475,86,o),
+(327,77,c),
+(327,0,l),
+(653,0,l),
+(653,80,l),
+(440,80,l),
+(375,46,l),
+(541,62,o),
+(644,166,o),
+(644,379,cs),
+(644,579,o),
+(538,702,o),
+(353,702,cs),
+(176,702,o),
+(69,595,o),
+(69,396,cs),
+(69,0,l)
+);
+}
+);
+width = 714;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|luCarrier-canadian";
+note = uni1623;
+unicode = 5667;
+},
+{
+color = 9;
+glyphname = "leCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (345,348);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(297,0,ls),
+(514,0,o),
+(633,128,o),
+(633,357,cs),
+(633,579,o),
+(521,702,o),
+(367,702,cs),
+(248,702,o),
+(169,627,o),
+(149,523,c),
+(157,523,l),
+(157,690,l),
+(71,690,l),
+(71,382,l),
+(153,382,l),
+(158,526,o),
+(230,615,o),
+(345,615,cs),
+(459,615,o),
+(537,529,o),
+(537,355,cs),
+(537,179,o),
+(455,87,o),
+(295,87,cs),
+(71,87,l),
+(71,0,l)
+);
+}
+);
+width = 695;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1624;
+unicode = 5668;
+},
+{
+color = 9;
+glyphname = "leeCarrier-canadian";
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+ref = "leCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (297,3);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 695;
+}
+);
+metricLeft = "leCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1625;
+unicode = 5669;
+},
+{
+color = 9;
+glyphname = "liCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "leCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (271,3);
+ref = dot_middle;
+}
+);
+width = 695;
+}
+);
+note = uni1626;
+unicode = 5670;
+},
+{
+color = 9;
+glyphname = "laCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(622,0,l),
+(622,87,l),
+(399,87,ls),
+(239,87,o),
+(157,179,o),
+(157,355,cs),
+(157,529,o),
+(236,615,o),
+(351,615,cs),
+(465,615,o),
+(535,526,o),
+(541,382,c),
+(622,382,l),
+(622,690,l),
+(536,690,l),
+(536,523,l),
+(545,523,l),
+(525,627,o),
+(447,702,o),
+(328,702,cs),
+(174,702,o),
+(62,579,o),
+(62,357,cs),
+(62,128,o),
+(181,0,o),
+(397,0,cs)
+);
+}
+);
+width = 693;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|leCarrier-canadian";
+note = uni1627;
+unicode = 5671;
+},
+{
+color = 1;
+glyphname = "dluCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(538,-13,o),
+(644,111,o),
+(644,311,cs),
+(644,492,o),
+(571,592,o),
+(456,628,c),
+(439,616,l),
+(639,616,l),
+(639,535,l),
+(710,535,l),
+(710,771,l),
+(639,771,l),
+(639,690,l),
+(327,690,l),
+(327,611,l),
+(475,604,o),
+(549,503,o),
+(549,325,cs),
+(549,164,o),
+(480,74,o),
+(355,74,cs),
+(235,74,o),
+(164,147,o),
+(164,295,cs),
+(164,690,l),
+(69,690,l),
+(69,296,ls),
+(69,97,o),
+(176,-13,o),
+(355,-13,cs)
+);
+}
+);
+width = 760;
+}
+);
+metricLeft = "te-canadian";
+note = uni1628;
+unicode = 5672;
+},
+{
+color = 9;
+glyphname = "dloCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(710,-81,l),
+(710,155,l),
+(639,155,l),
+(639,73,l),
+(439,73,l),
+(456,62,l),
+(571,98,o),
+(644,198,o),
+(644,379,cs),
+(644,579,o),
+(538,702,o),
+(357,702,cs),
+(173,702,o),
+(69,593,o),
+(69,394,cs),
+(69,0,l),
+(164,0,l),
+(164,395,ls),
+(164,543,o),
+(235,615,o),
+(355,615,cs),
+(480,615,o),
+(549,526,o),
+(549,365,cs),
+(549,186,o),
+(475,86,o),
+(327,78,c),
+(327,0,l),
+(639,0,l),
+(639,-81,l)
+);
+}
+);
+width = 760;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "dluCarrier-canadian";
+note = uni1629;
+unicode = 5673;
+},
+{
+color = 9;
+glyphname = "dleCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (356,348);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(308,0,ls),
+(526,0,o),
+(644,128,o),
+(644,357,cs),
+(644,579,o),
+(533,702,o),
+(379,702,cs),
+(264,702,o),
+(177,636,o),
+(143,510,c),
+(156,499,l),
+(156,699,l),
+(234,699,l),
+(234,769,l),
+(6,769,l),
+(6,699,l),
+(83,699,l),
+(83,382,l),
+(164,382,l),
+(170,526,o),
+(242,615,o),
+(356,615,cs),
+(471,615,o),
+(549,529,o),
+(549,355,cs),
+(549,179,o),
+(467,87,o),
+(306,87,cs),
+(83,87,l),
+(83,0,l)
+);
+}
+);
+width = 706;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni162A;
+unicode = 5674;
+},
+{
+color = 9;
+glyphname = "dleeCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (308,3);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 707;
+}
+);
+note = uni162B;
+unicode = 5675;
+},
+{
+color = 9;
+glyphname = "dliCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (283,3);
+ref = dot_middle;
+}
+);
+width = 707;
+}
+);
+note = uni162C;
+unicode = 5676;
+},
+{
+color = 9;
+glyphname = "dlaCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(622,0,l),
+(622,87,l),
+(399,87,ls),
+(241,87,o),
+(157,177,o),
+(157,355,cs),
+(157,529,o),
+(235,615,o),
+(350,615,cs),
+(464,615,o),
+(535,526,o),
+(541,382,c),
+(622,382,l),
+(622,699,l),
+(700,699,l),
+(700,769,l),
+(472,769,l),
+(472,699,l),
+(551,699,l),
+(551,499,l),
+(563,510,l),
+(529,636,o),
+(442,702,o),
+(327,702,cs),
+(173,702,o),
+(62,579,o),
+(62,357,cs),
+(62,126,o),
+(182,0,o),
+(397,0,cs)
+);
+}
+);
+width = 706;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni162D;
+unicode = 5677;
+},
+{
+color = 9;
+glyphname = "lhuCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(571,-13,o),
+(678,112,o),
+(678,316,cs),
+(678,516,o),
+(582,613,o),
+(455,641,c),
+(493,608,l),
+(687,608,l),
+(687,690,l),
+(432,690,l),
+(432,612,l),
+(513,582,o),
+(582,495,o),
+(582,330,cs),
+(582,161,o),
+(513,74,o),
+(374,74,cs),
+(235,74,o),
+(166,161,o),
+(166,330,cs),
+(166,495,o),
+(235,582,o),
+(316,612,c),
+(316,690,l),
+(61,690,l),
+(61,608,l),
+(254,608,l),
+(293,641,l),
+(165,613,o),
+(70,516,o),
+(70,316,cs),
+(70,112,o),
+(177,-13,o),
+(374,-13,cs)
+);
+}
+);
+width = 748;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162E;
+unicode = 5678;
+},
+{
+color = 9;
+glyphname = "lhoCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(316,0,l),
+(316,77,l),
+(235,108,o),
+(166,195,o),
+(166,359,cs),
+(166,528,o),
+(235,615,o),
+(374,615,cs),
+(513,615,o),
+(582,528,o),
+(582,359,cs),
+(582,195,o),
+(513,108,o),
+(432,77,c),
+(432,0,l),
+(687,0,l),
+(687,82,l),
+(494,82,l),
+(455,48,l),
+(582,76,o),
+(678,174,o),
+(678,374,cs),
+(678,578,o),
+(571,702,o),
+(374,702,cs),
+(177,702,o),
+(70,578,o),
+(70,374,cs),
+(70,174,o),
+(165,76,o),
+(293,48,c),
+(255,82,l),
+(61,82,l),
+(61,0,l)
+);
+}
+);
+width = 748;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162F;
+unicode = 5679;
+},
+{
+color = 9;
+glyphname = "lheCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (361,345);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(545,-13,o),
+(661,111,o),
+(661,345,cs),
+(661,579,o),
+(545,702,o),
+(382,702,cs),
+(258,702,o),
+(179,628,o),
+(156,535,c),
+(162,534,l),
+(162,690,l),
+(75,690,l),
+(75,415,l),
+(156,415,l),
+(171,526,o),
+(239,615,o),
+(361,615,cs),
+(478,615,o),
+(565,530,o),
+(565,345,cs),
+(565,159,o),
+(482,74,o),
+(361,74,cs),
+(239,74,o),
+(171,163,o),
+(156,274,c),
+(75,274,l),
+(75,0,l),
+(162,0,l),
+(162,156,l),
+(156,155,l),
+(179,62,o),
+(258,-13,o),
+(382,-13,cs)
+);
+}
+);
+width = 723;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1630;
+unicode = 5680;
+},
+{
+color = 9;
+glyphname = "lheeCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (314,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 724;
+}
+);
+note = uni1631;
+unicode = 5681;
+},
+{
+color = 9;
+glyphname = "lhiCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (288,0);
+ref = dot_middle;
+}
+);
+width = 724;
+}
+);
+note = uni1632;
+unicode = 5682;
+},
+{
+color = 9;
+glyphname = "lhaCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(465,-13,o),
+(544,62,o),
+(567,155,c),
+(560,156,l),
+(560,0,l),
+(647,0,l),
+(647,274,l),
+(566,274,l),
+(552,163,o),
+(484,74,o),
+(361,74,cs),
+(244,74,o),
+(157,159,o),
+(157,345,cs),
+(157,530,o),
+(241,615,o),
+(361,615,cs),
+(484,615,o),
+(552,526,o),
+(566,415,c),
+(647,415,l),
+(647,690,l),
+(560,690,l),
+(560,534,l),
+(567,535,l),
+(544,628,o),
+(465,702,o),
+(341,702,cs),
+(178,702,o),
+(62,579,o),
+(62,345,cs),
+(62,111,o),
+(178,-13,o),
+(341,-13,cs)
+);
+}
+);
+width = 722;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1633;
+unicode = 5683;
+},
+{
+color = 9;
+glyphname = "tlhuCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(571,-13,o),
+(678,112,o),
+(678,316,cs),
+(678,490,o),
+(605,586,o),
+(507,627,c),
+(486,616,l),
+(671,616,l),
+(671,535,l),
+(744,535,l),
+(744,771,l),
+(671,771,l),
+(671,690,l),
+(432,690,l),
+(432,612,l),
+(514,582,o),
+(582,495,o),
+(582,330,cs),
+(582,161,o),
+(513,74,o),
+(374,74,cs),
+(235,74,o),
+(166,161,o),
+(166,330,cs),
+(166,495,o),
+(234,582,o),
+(316,612,c),
+(316,690,l),
+(61,690,l),
+(61,608,l),
+(249,608,l),
+(227,621,l),
+(135,578,o),
+(70,484,o),
+(70,316,cs),
+(70,112,o),
+(177,-13,o),
+(374,-13,cs)
+);
+}
+);
+width = 785;
+}
+);
+metricLeft = "lhuCarrier-canadian";
+note = uni1634;
+unicode = 5684;
+},
+{
+color = 9;
+glyphname = "tlhoCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(112,-81,l),
+(112,0,l),
+(352,0,l),
+(352,77,l),
+(270,108,o),
+(202,195,o),
+(202,359,cs),
+(202,528,o),
+(271,615,o),
+(411,615,cs),
+(549,615,o),
+(618,528,o),
+(618,359,cs),
+(618,195,o),
+(550,108,o),
+(468,77,c),
+(468,0,l),
+(723,0,l),
+(723,82,l),
+(535,82,l),
+(557,69,l),
+(648,112,o),
+(714,206,o),
+(714,374,cs),
+(714,578,o),
+(608,702,o),
+(411,702,cs),
+(212,702,o),
+(106,578,o),
+(106,374,cs),
+(106,200,o),
+(179,103,o),
+(277,63,c),
+(297,73,l),
+(112,73,l),
+(112,155,l),
+(41,155,l),
+(41,-81,l)
+);
+}
+);
+width = 784;
+}
+);
+metricLeft = "=|tlhuCarrier-canadian";
+metricRight = "lhuCarrier-canadian";
+note = uni1635;
+unicode = 5685;
+},
+{
+color = 9;
+glyphname = "tlheCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (369,345);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(553,-13,o),
+(668,111,o),
+(668,345,cs),
+(668,579,o),
+(553,702,o),
+(390,702,cs),
+(268,702,o),
+(179,632,o),
+(144,517,c),
+(156,505,l),
+(156,699,l),
+(235,699,l),
+(235,769,l),
+(6,769,l),
+(6,699,l),
+(83,699,l),
+(83,415,l),
+(164,415,l),
+(179,526,o),
+(246,615,o),
+(369,615,cs),
+(486,615,o),
+(573,531,o),
+(573,345,cs),
+(573,159,o),
+(486,74,o),
+(369,74,cs),
+(246,74,o),
+(179,163,o),
+(164,274,c),
+(83,274,l),
+(83,0,l),
+(170,0,l),
+(170,177,l),
+(162,158,l),
+(183,66,o),
+(265,-13,o),
+(390,-13,cs)
+);
+}
+);
+width = 730;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1636;
+unicode = 5686;
+},
+{
+color = 9;
+glyphname = "tlheeCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (322,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 731;
+}
+);
+note = uni1637;
+unicode = 5687;
+},
+{
+color = 9;
+glyphname = "tlhiCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (296,0);
+ref = dot_middle;
+}
+);
+width = 731;
+}
+);
+note = uni1638;
+unicode = 5688;
+},
+{
+color = 9;
+glyphname = "tlhaCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(466,-13,o),
+(549,63,o),
+(568,159,c),
+(560,178,l),
+(560,0,l),
+(647,0,l),
+(647,274,l),
+(566,274,l),
+(552,163,o),
+(484,74,o),
+(361,74,cs),
+(244,74,o),
+(157,159,o),
+(157,345,cs),
+(157,531,o),
+(241,615,o),
+(361,615,cs),
+(484,615,o),
+(552,526,o),
+(566,415,c),
+(647,415,l),
+(647,699,l),
+(725,699,l),
+(725,769,l),
+(496,769,l),
+(496,699,l),
+(574,699,l),
+(574,504,l),
+(586,516,l),
+(553,635,o),
+(463,702,o),
+(341,702,cs),
+(178,702,o),
+(62,579,o),
+(62,345,cs),
+(62,111,o),
+(178,-13,o),
+(341,-13,cs)
+);
+}
+);
+width = 731;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni1639;
+unicode = 5689;
+},
+{
+color = 9;
+glyphname = "tluCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(359,-13,o),
+(420,34,o),
+(446,124,c),
+(417,124,l),
+(444,34,o),
+(504,-13,o),
+(586,-13,cs),
+(719,-13,o),
+(794,82,o),
+(794,279,cs),
+(794,483,o),
+(725,588,o),
+(616,628,c),
+(596,616,l),
+(788,616,l),
+(788,535,l),
+(860,535,l),
+(860,771,l),
+(788,771,l),
+(788,690,l),
+(490,690,l),
+(490,611,l),
+(628,608,o),
+(697,502,o),
+(697,287,cs),
+(697,130,o),
+(656,72,o),
+(581,72,cs),
+(519,72,o),
+(478,124,o),
+(478,223,cs),
+(478,302,l),
+(385,302,l),
+(385,223,ls),
+(385,124,o),
+(345,72,o),
+(283,72,cs),
+(208,72,o),
+(166,130,o),
+(166,287,cs),
+(166,502,o),
+(236,608,o),
+(374,611,c),
+(374,690,l),
+(61,690,l),
+(61,608,l),
+(256,608,l),
+(234,621,l),
+(133,580,o),
+(71,475,o),
+(71,279,cs),
+(71,82,o),
+(145,-13,o),
+(277,-13,cs)
+);
+}
+);
+width = 901;
+}
+);
+metricRight = "tlhuCarrier-canadian";
+note = uni163A;
+unicode = 5690;
+},
+{
+color = 1;
+glyphname = "tloCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(860,-81,l),
+(860,155,l),
+(788,155,l),
+(788,73,l),
+(596,73,l),
+(616,62,l),
+(725,101,o),
+(794,207,o),
+(794,411,cs),
+(794,608,o),
+(719,702,o),
+(586,702,cs),
+(504,702,o),
+(444,656,o),
+(417,566,c),
+(446,566,l),
+(420,656,o),
+(359,702,o),
+(277,702,cs),
+(145,702,o),
+(71,608,o),
+(71,411,cs),
+(71,214,o),
+(133,110,o),
+(234,69,c),
+(256,82,l),
+(61,82,l),
+(61,0,l),
+(374,0,l),
+(374,78,l),
+(236,82,o),
+(166,187,o),
+(166,403,cs),
+(166,559,o),
+(208,617,o),
+(283,617,cs),
+(345,617,o),
+(385,566,o),
+(385,467,cs),
+(385,387,l),
+(478,387,l),
+(478,467,ls),
+(478,566,o),
+(519,617,o),
+(581,617,cs),
+(656,617,o),
+(697,559,o),
+(697,403,cs),
+(697,187,o),
+(628,82,o),
+(490,78,c),
+(490,0,l),
+(788,0,l),
+(788,-81,l)
+);
+}
+);
+width = 901;
+}
+);
+metricLeft = "tluCarrier-canadian";
+metricRight = "tlhuCarrier-canadian";
+note = uni163B;
+unicode = 5691;
+},
+{
+color = 9;
+glyphname = "tleCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (288,345);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(585,-13,o),
+(660,73,o),
+(660,185,cs),
+(660,270,o),
+(610,336,o),
+(524,356,c),
+(524,334,l),
+(611,352,o),
+(660,418,o),
+(660,504,cs),
+(660,616,o),
+(585,702,o),
+(419,702,cs),
+(270,702,o),
+(177,636,o),
+(145,526,c),
+(156,511,l),
+(156,699,l),
+(234,699,l),
+(234,769,l),
+(6,769,l),
+(6,699,l),
+(83,699,l),
+(83,415,l),
+(164,415,l),
+(171,534,o),
+(240,616,o),
+(399,616,cs),
+(515,616,o),
+(564,570,o),
+(564,495,cs),
+(564,424,o),
+(516,385,o),
+(428,385,cs),
+(385,385,l),
+(385,305,l),
+(428,305,ls),
+(520,305,o),
+(564,266,o),
+(564,195,cs),
+(564,120,o),
+(511,73,o),
+(398,73,cs),
+(240,73,o),
+(171,156,o),
+(164,274,c),
+(83,274,l),
+(83,0,l),
+(170,0,l),
+(170,163,l),
+(156,147,l),
+(191,46,o),
+(275,-13,o),
+(419,-13,cs)
+);
+}
+);
+width = 731;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni163C;
+unicode = 5692;
+},
+{
+color = 9;
+glyphname = "tleeCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (241,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 731;
+}
+);
+note = uni163D;
+unicode = 5693;
+},
+{
+color = 9;
+glyphname = "tliCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (223,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 731;
+}
+);
+note = uni163E;
+unicode = 5694;
+},
+{
+color = 9;
+glyphname = "tlaCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(456,-13,o),
+(540,46,o),
+(575,147,c),
+(561,163,l),
+(561,0,l),
+(648,0,l),
+(648,274,l),
+(567,274,l),
+(560,156,o),
+(492,73,o),
+(333,73,cs),
+(220,73,o),
+(167,120,o),
+(167,195,cs),
+(167,266,o),
+(212,305,o),
+(303,305,cs),
+(360,305,l),
+(360,385,l),
+(303,385,ls),
+(215,385,o),
+(167,424,o),
+(167,495,cs),
+(167,570,o),
+(216,616,o),
+(333,616,cs),
+(492,616,o),
+(560,534,o),
+(567,415,c),
+(648,415,l),
+(648,699,l),
+(726,699,l),
+(726,769,l),
+(498,769,l),
+(498,699,l),
+(576,699,l),
+(576,511,l),
+(586,526,l),
+(554,636,o),
+(461,702,o),
+(312,702,cs),
+(147,702,o),
+(71,616,o),
+(71,504,cs),
+(71,418,o),
+(121,353,o),
+(208,333,c),
+(208,356,l),
+(122,336,o),
+(71,270,o),
+(71,185,cs),
+(71,73,o),
+(147,-13,o),
+(312,-13,cs)
+);
+}
+);
+width = 732;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni163F;
+unicode = 5695;
+},
+{
+color = 9;
+glyphname = "zuCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(563,-13,o),
+(676,88,o),
+(676,241,cs),
+(676,359,o),
+(585,479,o),
+(585,547,cs),
+(585,581,o),
+(602,607,o),
+(655,607,cs),
+(686,607,l),
+(686,690,l),
+(635,690,ls),
+(534,690,o),
+(492,635,o),
+(492,560,cs),
+(492,469,o),
+(580,363,o),
+(580,254,cs),
+(580,142,o),
+(505,74,o),
+(372,74,cs),
+(239,74,o),
+(164,142,o),
+(164,254,cs),
+(164,363,o),
+(252,469,o),
+(252,560,cs),
+(252,635,o),
+(210,690,o),
+(109,690,cs),
+(59,690,l),
+(59,607,l),
+(90,607,ls),
+(142,607,o),
+(158,581,o),
+(158,547,cs),
+(158,479,o),
+(68,359,o),
+(68,241,cs),
+(68,88,o),
+(181,-13,o),
+(372,-13,cs)
+);
+}
+);
+width = 745;
+}
+);
+metricRight = "=|";
+note = uni1640;
+unicode = 5696;
+},
+{
+color = 9;
+glyphname = "zoCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(109,0,ls),
+(210,0,o),
+(252,55,o),
+(252,129,cs),
+(252,221,o),
+(164,327,o),
+(164,436,cs),
+(164,548,o),
+(239,615,o),
+(372,615,cs),
+(506,615,o),
+(581,548,o),
+(581,436,cs),
+(581,327,o),
+(492,221,o),
+(492,129,cs),
+(492,55,o),
+(535,0,o),
+(635,0,cs),
+(686,0,l),
+(686,83,l),
+(655,83,ls),
+(602,83,o),
+(585,109,o),
+(585,143,cs),
+(585,211,o),
+(676,330,o),
+(676,449,cs),
+(676,602,o),
+(563,702,o),
+(372,702,cs),
+(181,702,o),
+(69,602,o),
+(69,449,cs),
+(69,330,o),
+(158,211,o),
+(158,143,cs),
+(158,109,o),
+(142,83,o),
+(90,83,cs),
+(59,83,l),
+(59,0,l)
+);
+}
+);
+width = 745;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1641;
+unicode = 5697;
+},
+{
+color = 9;
+glyphname = "zeCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (362,345);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(547,-13,o),
+(638,108,o),
+(638,345,cs),
+(638,582,o),
+(547,702,o),
+(413,702,cs),
+(310,702,o),
+(229,605,o),
+(183,605,cs),
+(157,605,o),
+(138,620,o),
+(138,664,cs),
+(138,690,l),
+(52,690,l),
+(52,644,ls),
+(52,562,o),
+(96,520,o),
+(161,520,cs),
+(241,520,o),
+(313,615,o),
+(394,615,cs),
+(481,615,o),
+(541,535,o),
+(541,345,cs),
+(541,155,o),
+(481,74,o),
+(394,74,cs),
+(313,74,o),
+(241,170,o),
+(161,170,cs),
+(96,170,o),
+(52,128,o),
+(52,45,cs),
+(52,0,l),
+(138,0,l),
+(138,26,ls),
+(138,70,o),
+(157,85,o),
+(183,85,cs),
+(229,85,o),
+(310,-13,o),
+(413,-13,cs)
+);
+}
+);
+width = 700;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1642;
+unicode = 5698;
+},
+{
+color = 9;
+glyphname = "zeeCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (314,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 700;
+}
+);
+note = uni1643;
+unicode = 5699;
+},
+{
+color = 9;
+glyphname = "ziCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (289,0);
+ref = dot_middle;
+}
+);
+width = 700;
+}
+);
+note = uni1644;
+unicode = 5700;
+},
+{
+color = 9;
+glyphname = "zaCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(388,-13,o),
+(470,85,o),
+(517,85,cs),
+(542,85,o),
+(560,70,o),
+(560,26,cs),
+(560,0,l),
+(647,0,l),
+(647,45,ls),
+(647,128,o),
+(604,170,o),
+(537,170,cs),
+(458,170,o),
+(386,74,o),
+(305,74,cs),
+(217,74,o),
+(157,155,o),
+(157,345,cs),
+(157,535,o),
+(217,615,o),
+(305,615,cs),
+(386,615,o),
+(458,520,o),
+(537,520,cs),
+(604,520,o),
+(647,562,o),
+(647,644,cs),
+(647,690,l),
+(560,690,l),
+(560,664,ls),
+(560,620,o),
+(542,605,o),
+(517,605,cs),
+(470,605,o),
+(388,702,o),
+(286,702,cs),
+(153,702,o),
+(62,582,o),
+(62,345,cs),
+(62,108,o),
+(153,-13,o),
+(286,-13,cs)
+);
+}
+);
+width = 699;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|zeCarrier-canadian";
+note = uni1645;
+unicode = 5701;
+},
+{
+color = 6;
+glyphname = "zCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(363,183,l),
+(363,242,l),
+(136,242,l),
+(136,207,l),
+(359,493,l),
+(359,527,l),
+(64,527,l),
+(64,468,l),
+(288,468,l),
+(288,503,l),
+(64,217,l),
+(64,183,l)
+);
+}
+);
+width = 427;
+}
+);
+metricRight = "=|";
+note = uni1646;
+unicode = 5702;
+},
+{
+color = 6;
+glyphname = "initialzCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(179,183,l),
+(179,96,l),
+(244,96,l),
+(244,183,l),
+(363,183,l),
+(363,242,l),
+(120,242,l),
+(137,208,l),
+(359,493,l),
+(359,527,l),
+(244,527,l),
+(244,614,l),
+(179,614,l),
+(179,527,l),
+(64,527,l),
+(64,468,l),
+(303,468,l),
+(286,501,l),
+(64,217,l),
+(64,183,l)
+);
+}
+);
+width = 427;
+}
+);
+metricLeft = "zCarrier-canadian";
+metricRight = "zCarrier-canadian";
+note = uni1647;
+unicode = 5703;
+},
+{
+color = 9;
+glyphname = "dzuCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(563,-13,o),
+(676,88,o),
+(676,241,cs),
+(676,359,o),
+(585,479,o),
+(585,547,cs),
+(585,581,o),
+(602,607,o),
+(655,607,cs),
+(686,607,l),
+(686,690,l),
+(637,690,ls),
+(537,690,o),
+(494,635,o),
+(494,560,cs),
+(494,469,o),
+(580,365,o),
+(580,254,cs),
+(580,142,o),
+(506,74,o),
+(372,74,cs),
+(238,74,o),
+(164,142,o),
+(164,254,cs),
+(164,365,o),
+(250,469,o),
+(250,560,cs),
+(250,635,o),
+(207,690,o),
+(108,690,cs),
+(59,690,l),
+(59,607,l),
+(90,607,ls),
+(142,607,o),
+(158,581,o),
+(158,547,cs),
+(158,479,o),
+(68,359,o),
+(68,241,cs),
+(68,88,o),
+(181,-13,o),
+(372,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(397,482,l),
+(397,643,l),
+(459,643,l),
+(459,690,l),
+(285,690,l),
+(285,643,l),
+(348,643,l),
+(348,482,l)
+);
+}
+);
+width = 745;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1648;
+unicode = 5704;
+},
+{
+color = 9;
+glyphname = "dzoCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(108,0,ls),
+(207,0,o),
+(250,55,o),
+(250,129,cs),
+(250,221,o),
+(164,325,o),
+(164,436,cs),
+(164,548,o),
+(239,615,o),
+(372,615,cs),
+(506,615,o),
+(581,548,o),
+(581,436,cs),
+(581,325,o),
+(494,221,o),
+(494,129,cs),
+(494,55,o),
+(537,0,o),
+(637,0,cs),
+(686,0,l),
+(686,83,l),
+(655,83,ls),
+(602,83,o),
+(585,109,o),
+(585,143,cs),
+(585,211,o),
+(676,330,o),
+(676,449,cs),
+(676,602,o),
+(563,702,o),
+(372,702,cs),
+(181,702,o),
+(69,602,o),
+(69,449,cs),
+(69,330,o),
+(158,211,o),
+(158,143,cs),
+(158,109,o),
+(142,83,o),
+(90,83,cs),
+(59,83,l),
+(59,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(459,0,l),
+(459,46,l),
+(397,46,l),
+(397,208,l),
+(348,208,l),
+(348,46,l),
+(285,46,l),
+(285,0,l)
+);
+}
+);
+width = 745;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1649;
+unicode = 5705;
+},
+{
+color = 9;
+glyphname = "dzeCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (380,345);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(570,-13,o),
+(661,108,o),
+(661,345,cs),
+(661,582,o),
+(571,702,o),
+(437,702,cs),
+(334,702,o),
+(252,605,o),
+(206,605,cs),
+(181,605,o),
+(162,620,o),
+(162,664,cs),
+(162,690,l),
+(75,690,l),
+(75,644,ls),
+(75,562,o),
+(120,520,o),
+(185,520,cs),
+(265,520,o),
+(336,615,o),
+(417,615,cs),
+(505,615,o),
+(565,535,o),
+(565,345,cs),
+(565,155,o),
+(505,74,o),
+(417,74,cs),
+(336,74,o),
+(265,170,o),
+(185,170,cs),
+(120,170,o),
+(75,128,o),
+(75,45,cs),
+(75,0,l),
+(162,0,l),
+(162,26,ls),
+(162,69,o),
+(181,84,o),
+(206,84,cs),
+(252,84,o),
+(334,-13,o),
+(437,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(129,242,l),
+(129,319,l),
+(257,319,l),
+(257,371,l),
+(129,371,l),
+(129,448,l),
+(75,448,l),
+(75,242,l)
+);
+}
+);
+width = 723;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164A;
+unicode = 5706;
+},
+{
+color = 9;
+glyphname = "dzeeCarrier-canadian";
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+ref = "dzeCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (332,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 723;
+}
+);
+metricLeft = "dzeCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164B;
+unicode = 5707;
+},
+{
+color = 9;
+glyphname = "dziCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "dzeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (306,0);
+ref = dot_middle;
+}
+);
+width = 724;
+}
+);
+note = uni164C;
+unicode = 5708;
+},
+{
+color = 9;
+glyphname = "dzaCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(388,-13,o),
+(470,84,o),
+(517,84,cs),
+(542,84,o),
+(560,69,o),
+(560,26,cs),
+(560,0,l),
+(647,0,l),
+(647,45,ls),
+(647,128,o),
+(604,170,o),
+(537,170,cs),
+(458,170,o),
+(386,74,o),
+(305,74,cs),
+(217,74,o),
+(157,155,o),
+(157,345,cs),
+(157,535,o),
+(217,615,o),
+(305,615,cs),
+(386,615,o),
+(458,520,o),
+(537,520,cs),
+(604,520,o),
+(647,562,o),
+(647,644,cs),
+(647,690,l),
+(560,690,l),
+(560,664,ls),
+(560,620,o),
+(542,605,o),
+(517,605,cs),
+(470,605,o),
+(388,702,o),
+(286,702,cs),
+(153,702,o),
+(62,582,o),
+(62,345,cs),
+(62,108,o),
+(153,-13,o),
+(286,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(647,242,l),
+(647,448,l),
+(593,448,l),
+(593,371,l),
+(467,371,l),
+(467,319,l),
+(593,319,l),
+(593,242,l)
+);
+}
+);
+width = 722;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dzeCarrier-canadian";
+note = uni164D;
+unicode = 5709;
+},
+{
+color = 9;
+glyphname = "suCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(357,-13,o),
+(423,42,o),
+(447,140,c),
+(412,140,l),
+(437,42,o),
+(502,-13,o),
+(595,-13,cs),
+(725,-13,o),
+(792,76,o),
+(792,196,cs),
+(792,328,o),
+(703,466,o),
+(703,548,cs),
+(703,581,o),
+(719,607,o),
+(771,607,cs),
+(800,607,l),
+(800,690,l),
+(752,690,ls),
+(651,690,o),
+(610,636,o),
+(610,559,cs),
+(610,457,o),
+(696,320,o),
+(696,207,cs),
+(696,125,o),
+(660,72,o),
+(588,72,cs),
+(516,72,o),
+(474,125,o),
+(474,226,cs),
+(474,690,l),
+(384,690,l),
+(384,226,ls),
+(384,126,o),
+(343,72,o),
+(271,72,cs),
+(199,72,o),
+(163,125,o),
+(163,207,cs),
+(163,320,o),
+(249,457,o),
+(249,559,cs),
+(249,636,o),
+(208,690,o),
+(107,690,cs),
+(59,690,l),
+(59,607,l),
+(88,607,ls),
+(140,607,o),
+(156,581,o),
+(156,548,cs),
+(156,466,o),
+(68,328,o),
+(68,196,cs),
+(68,76,o),
+(135,-13,o),
+(264,-13,cs)
+);
+}
+);
+width = 859;
+}
+);
+metricRight = "=|";
+note = uni164E;
+unicode = 5710;
+},
+{
+color = 9;
+glyphname = "soCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(107,0,ls),
+(208,0,o),
+(249,54,o),
+(249,130,cs),
+(249,233,o),
+(163,370,o),
+(163,483,cs),
+(163,565,o),
+(199,617,o),
+(270,617,cs),
+(343,617,o),
+(384,565,o),
+(384,464,cs),
+(384,0,l),
+(474,0,l),
+(474,464,ls),
+(474,564,o),
+(516,617,o),
+(588,617,cs),
+(660,617,o),
+(696,565,o),
+(696,483,cs),
+(696,370,o),
+(610,233,o),
+(610,130,cs),
+(610,54,o),
+(651,0,o),
+(752,0,cs),
+(800,0,l),
+(800,83,l),
+(771,83,ls),
+(719,83,o),
+(702,109,o),
+(702,142,cs),
+(702,224,o),
+(791,361,o),
+(791,494,cs),
+(791,613,o),
+(725,702,o),
+(595,702,cs),
+(502,702,o),
+(437,648,o),
+(412,550,c),
+(447,550,l),
+(423,648,o),
+(356,702,o),
+(264,702,cs),
+(135,702,o),
+(68,613,o),
+(68,494,cs),
+(68,361,o),
+(156,224,o),
+(156,142,cs),
+(156,109,o),
+(140,83,o),
+(88,83,cs),
+(59,83,l),
+(59,0,l)
+);
+}
+);
+width = 859;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5711;
+},
+{
+color = 9;
+glyphname = "seCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(581,-13,o),
+(649,67,o),
+(649,177,cs),
+(649,274,o),
+(592,343,o),
+(497,358,c),
+(497,331,l),
+(593,345,o),
+(649,413,o),
+(649,513,cs),
+(649,623,o),
+(581,702,o),
+(469,702,cs),
+(367,702,o),
+(254,605,o),
+(202,605,cs),
+(178,605,o),
+(159,620,o),
+(159,664,cs),
+(159,690,l),
+(72,690,l),
+(72,646,ls),
+(72,564,o),
+(116,523,o),
+(182,523,cs),
+(264,523,o),
+(365,616,o),
+(447,616,cs),
+(514,616,o),
+(554,574,o),
+(554,503,cs),
+(554,425,o),
+(502,384,o),
+(413,384,cs),
+(72,384,l),
+(72,306,l),
+(413,306,ls),
+(503,306,o),
+(554,265,o),
+(554,186,cs),
+(554,116,o),
+(514,73,o),
+(447,73,cs),
+(365,73,o),
+(264,167,o),
+(182,167,cs),
+(116,167,o),
+(72,126,o),
+(72,43,cs),
+(72,0,l),
+(159,0,l),
+(159,26,ls),
+(159,70,o),
+(178,85,o),
+(202,85,cs),
+(254,85,o),
+(367,-13,o),
+(470,-13,cs)
+);
+}
+);
+width = 720;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni1650;
+unicode = 5712;
+},
+{
+color = 9;
+glyphname = "seeCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(581,-13,o),
+(649,67,o),
+(649,177,cs),
+(649,269,o),
+(598,336,o),
+(512,355,c),
+(512,334,l),
+(598,353,o),
+(649,418,o),
+(649,513,cs),
+(649,623,o),
+(581,702,o),
+(469,702,cs),
+(367,702,o),
+(254,605,o),
+(202,605,cs),
+(178,605,o),
+(159,620,o),
+(159,664,cs),
+(159,690,l),
+(72,690,l),
+(72,646,ls),
+(72,564,o),
+(116,523,o),
+(182,523,cs),
+(264,523,o),
+(365,616,o),
+(447,616,cs),
+(514,616,o),
+(554,574,o),
+(554,503,cs),
+(554,425,o),
+(502,384,o),
+(419,384,cs),
+(363,384,l),
+(384,351,l),
+(384,462,l),
+(326,462,l),
+(326,384,l),
+(72,384,l),
+(72,306,l),
+(326,306,l),
+(326,220,l),
+(384,220,l),
+(384,338,l),
+(363,306,l),
+(419,306,ls),
+(503,306,o),
+(554,265,o),
+(554,186,cs),
+(554,116,o),
+(514,73,o),
+(447,73,cs),
+(365,73,o),
+(264,167,o),
+(182,167,cs),
+(116,167,o),
+(72,126,o),
+(72,43,cs),
+(72,0,l),
+(159,0,l),
+(159,26,ls),
+(159,70,o),
+(178,85,o),
+(202,85,cs),
+(254,85,o),
+(367,-13,o),
+(470,-13,cs)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1651;
+unicode = 5713;
+},
+{
+color = 9;
+glyphname = "siCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(581,-13,o),
+(649,67,o),
+(649,177,cs),
+(649,269,o),
+(597,336,o),
+(513,355,c),
+(513,334,l),
+(598,353,o),
+(649,418,o),
+(649,513,cs),
+(649,623,o),
+(581,702,o),
+(469,702,cs),
+(367,702,o),
+(254,605,o),
+(202,605,cs),
+(178,605,o),
+(159,620,o),
+(159,664,cs),
+(159,690,l),
+(72,690,l),
+(72,646,ls),
+(72,564,o),
+(116,523,o),
+(182,523,cs),
+(264,523,o),
+(365,618,o),
+(449,618,cs),
+(517,618,o),
+(555,575,o),
+(555,502,cs),
+(555,422,o),
+(506,382,o),
+(429,382,cs),
+(377,382,l),
+(410,355,l),
+(407,394,o),
+(374,425,o),
+(332,425,cs),
+(303,425,o),
+(278,408,o),
+(266,384,c),
+(72,384,l),
+(72,306,l),
+(267,306,l),
+(279,283,o),
+(304,266,o),
+(333,266,cs),
+(374,266,o),
+(404,297,o),
+(409,336,c),
+(376,308,l),
+(429,308,ls),
+(507,308,o),
+(555,268,o),
+(555,187,cs),
+(555,115,o),
+(517,71,o),
+(449,71,cs),
+(366,71,o),
+(264,167,o),
+(182,167,cs),
+(116,167,o),
+(72,126,o),
+(72,43,cs),
+(72,0,l),
+(159,0,l),
+(159,26,ls),
+(159,70,o),
+(178,85,o),
+(202,85,cs),
+(254,85,o),
+(367,-13,o),
+(470,-13,cs)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1652;
+unicode = 5714;
+},
+{
+color = 9;
+glyphname = "saCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(355,-13,o),
+(468,85,o),
+(519,85,cs),
+(543,85,o),
+(562,70,o),
+(562,26,cs),
+(562,0,l),
+(648,0,l),
+(648,43,ls),
+(648,126,o),
+(605,167,o),
+(539,167,cs),
+(457,167,o),
+(355,73,o),
+(273,73,cs),
+(207,73,o),
+(167,116,o),
+(167,186,cs),
+(167,265,o),
+(217,306,o),
+(307,306,cs),
+(648,306,l),
+(648,384,l),
+(307,384,ls),
+(218,384,o),
+(167,425,o),
+(167,503,cs),
+(167,574,o),
+(207,616,o),
+(273,616,cs),
+(355,616,o),
+(457,523,o),
+(539,523,cs),
+(605,523,o),
+(648,564,o),
+(648,646,cs),
+(648,690,l),
+(562,690,l),
+(562,664,ls),
+(562,620,o),
+(543,605,o),
+(519,605,cs),
+(468,605,o),
+(355,702,o),
+(251,702,cs),
+(140,702,o),
+(71,623,o),
+(71,513,cs),
+(71,413,o),
+(128,345,o),
+(224,331,c),
+(224,358,l),
+(129,343,o),
+(71,274,o),
+(71,177,cs),
+(71,67,o),
+(140,-13,o),
+(251,-13,cs)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1653;
+unicode = 5715;
+},
+{
+color = 9;
+glyphname = "shuCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(354,-13,o),
+(416,37,o),
+(443,128,c),
+(416,128,l),
+(442,37,o),
+(506,-13,o),
+(595,-13,cs),
+(725,-13,o),
+(792,76,o),
+(792,196,cs),
+(792,328,o),
+(703,466,o),
+(703,548,cs),
+(703,581,o),
+(719,607,o),
+(771,607,cs),
+(800,607,l),
+(800,690,l),
+(752,690,ls),
+(651,690,o),
+(611,636,o),
+(611,559,cs),
+(611,541,o),
+(614,519,o),
+(617,500,c),
+(634,561,l),
+(474,561,l),
+(474,690,l),
+(384,690,l),
+(384,561,l),
+(225,561,l),
+(242,500,l),
+(245,519,o),
+(248,541,o),
+(248,559,cs),
+(248,636,o),
+(208,690,o),
+(107,690,cs),
+(59,690,l),
+(59,607,l),
+(88,607,ls),
+(140,607,o),
+(156,581,o),
+(156,548,cs),
+(156,466,o),
+(68,328,o),
+(68,196,cs),
+(68,76,o),
+(135,-13,o),
+(264,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,72,o),
+(163,125,o),
+(163,207,cs),
+(163,295,o),
+(214,395,o),
+(238,482,c),
+(384,482,l),
+(384,226,ls),
+(384,126,o),
+(343,72,o),
+(271,72,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(516,72,o),
+(474,125,o),
+(474,226,cs),
+(474,482,l),
+(622,482,l),
+(644,395,o),
+(696,295,o),
+(696,207,cs),
+(696,125,o),
+(660,72,o),
+(588,72,cs)
+);
+}
+);
+width = 859;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1654;
+unicode = 5716;
+},
+{
+color = 9;
+glyphname = "shoCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(107,0,ls),
+(208,0,o),
+(248,54,o),
+(248,130,cs),
+(248,149,o),
+(244,171,o),
+(242,189,c),
+(225,128,l),
+(384,128,l),
+(384,0,l),
+(474,0,l),
+(474,128,l),
+(634,128,l),
+(617,189,l),
+(614,171,o),
+(611,149,o),
+(611,130,cs),
+(611,54,o),
+(651,0,o),
+(752,0,cs),
+(800,0,l),
+(800,83,l),
+(771,83,ls),
+(719,83,o),
+(702,109,o),
+(702,142,cs),
+(702,224,o),
+(791,361,o),
+(791,494,cs),
+(791,613,o),
+(725,702,o),
+(595,702,cs),
+(506,702,o),
+(442,653,o),
+(415,561,c),
+(443,561,l),
+(416,653,o),
+(353,702,o),
+(264,702,cs),
+(135,702,o),
+(68,613,o),
+(68,494,cs),
+(68,361,o),
+(156,224,o),
+(156,142,cs),
+(156,109,o),
+(140,83,o),
+(88,83,cs),
+(59,83,l),
+(59,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(214,295,o),
+(163,395,o),
+(163,483,cs),
+(163,565,o),
+(199,617,o),
+(270,617,cs),
+(343,617,o),
+(384,565,o),
+(384,464,cs),
+(384,208,l),
+(238,208,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(474,464,ls),
+(474,564,o),
+(516,617,o),
+(588,617,cs),
+(660,617,o),
+(696,565,o),
+(696,483,cs),
+(696,395,o),
+(644,295,o),
+(622,208,c),
+(474,208,l)
+);
+}
+);
+width = 859;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1655;
+unicode = 5717;
+},
+{
+color = 9;
+glyphname = "sheCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(581,-13,o),
+(649,67,o),
+(649,177,cs),
+(649,269,o),
+(598,336,o),
+(512,355,c),
+(512,334,l),
+(598,353,o),
+(649,418,o),
+(649,513,cs),
+(649,623,o),
+(581,702,o),
+(469,702,cs),
+(367,702,o),
+(254,605,o),
+(202,605,cs),
+(178,605,o),
+(159,620,o),
+(159,664,cs),
+(159,690,l),
+(72,690,l),
+(72,646,ls),
+(72,564,o),
+(116,524,o),
+(182,524,cs),
+(201,524,o),
+(220,528,o),
+(241,535,c),
+(185,551,l),
+(185,384,l),
+(72,384,l),
+(72,306,l),
+(185,306,l),
+(185,139,l),
+(240,155,l),
+(220,161,o),
+(201,166,o),
+(182,166,cs),
+(116,166,o),
+(72,126,o),
+(72,43,cs),
+(72,0,l),
+(159,0,l),
+(159,26,ls),
+(159,70,o),
+(178,85,o),
+(202,85,cs),
+(254,85,o),
+(367,-13,o),
+(470,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(262,306,l),
+(413,306,ls),
+(503,306,o),
+(554,265,o),
+(554,186,cs),
+(554,116,o),
+(514,73,o),
+(447,73,cs),
+(390,73,o),
+(324,118,o),
+(262,145,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(262,545,l),
+(324,572,o),
+(390,616,o),
+(447,616,cs),
+(514,616,o),
+(554,574,o),
+(554,503,cs),
+(554,425,o),
+(502,384,o),
+(413,384,cs),
+(262,384,l)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1656;
+unicode = 5718;
+},
+{
+color = 9;
+glyphname = "sheeCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(581,-13,o),
+(649,67,o),
+(649,177,cs),
+(649,269,o),
+(598,336,o),
+(512,355,c),
+(512,334,l),
+(598,353,o),
+(649,418,o),
+(649,513,cs),
+(649,623,o),
+(581,702,o),
+(469,702,cs),
+(367,702,o),
+(254,605,o),
+(202,605,cs),
+(178,605,o),
+(159,620,o),
+(159,664,cs),
+(159,690,l),
+(72,690,l),
+(72,646,ls),
+(72,564,o),
+(116,524,o),
+(182,524,cs),
+(200,524,o),
+(220,528,o),
+(240,535,c),
+(185,553,l),
+(185,379,l),
+(72,379,l),
+(72,312,l),
+(185,312,l),
+(185,137,l),
+(240,155,l),
+(220,161,o),
+(200,166,o),
+(182,166,cs),
+(116,166,o),
+(72,126,o),
+(72,43,cs),
+(72,0,l),
+(159,0,l),
+(159,26,ls),
+(159,70,o),
+(178,85,o),
+(202,85,cs),
+(254,85,o),
+(367,-13,o),
+(470,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(390,71,o),
+(319,121,o),
+(255,149,c),
+(255,312,l),
+(363,312,l),
+(363,221,l),
+(412,221,l),
+(412,329,l),
+(395,312,l),
+(424,312,ls),
+(506,312,o),
+(555,267,o),
+(555,190,cs),
+(555,115,o),
+(516,71,o),
+(449,71,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(412,462,l),
+(363,462,l),
+(363,379,l),
+(255,379,l),
+(255,541,l),
+(319,569,o),
+(390,618,o),
+(449,618,cs),
+(516,618,o),
+(555,575,o),
+(555,499,cs),
+(555,423,o),
+(506,379,o),
+(424,379,cs),
+(395,379,l),
+(412,361,l)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1657;
+unicode = 5719;
+},
+{
+color = 9;
+glyphname = "shiCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(72,646,ls),
+(72,564,o),
+(116,524,o),
+(182,524,cs),
+(199,524,o),
+(216,527,o),
+(236,534,c),
+(185,555,l),
+(185,379,l),
+(72,379,l),
+(72,312,l),
+(185,312,l),
+(185,134,l),
+(236,156,l),
+(216,162,o),
+(199,166,o),
+(182,166,cs),
+(116,166,o),
+(72,126,o),
+(72,43,cs),
+(72,0,l),
+(159,0,l),
+(159,26,ls),
+(159,70,o),
+(178,85,o),
+(202,85,cs),
+(254,85,o),
+(367,-13,o),
+(470,-13,cs),
+(581,-13,o),
+(649,67,o),
+(649,177,cs),
+(649,269,o),
+(597,336,o),
+(513,355,c),
+(513,334,l),
+(598,353,o),
+(649,418,o),
+(649,513,cs),
+(649,623,o),
+(581,702,o),
+(469,702,cs),
+(367,702,o),
+(254,605,o),
+(202,605,cs),
+(178,605,o),
+(159,620,o),
+(159,664,cs),
+(159,690,l),
+(72,690,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(255,312,l),
+(320,312,l),
+(332,283,o),
+(358,266,o),
+(387,266,cs),
+(429,266,o),
+(460,299,o),
+(463,339,c),
+(401,312,l),
+(432,312,ls),
+(508,312,o),
+(555,264,o),
+(555,190,cs),
+(555,115,o),
+(516,71,o),
+(449,71,cs),
+(390,71,o),
+(319,121,o),
+(255,148,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(255,542,l),
+(319,569,o),
+(390,618,o),
+(449,618,cs),
+(516,618,o),
+(555,575,o),
+(555,499,cs),
+(555,424,o),
+(508,379,o),
+(432,379,cs),
+(402,379,l),
+(463,351,l),
+(462,391,o),
+(430,425,o),
+(387,425,cs),
+(357,425,o),
+(331,408,o),
+(319,379,c),
+(255,379,l)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1658;
+unicode = 5720;
+},
+{
+color = 9;
+glyphname = "shaCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(355,-13,o),
+(468,85,o),
+(519,85,cs),
+(543,85,o),
+(562,70,o),
+(562,26,cs),
+(562,0,l),
+(648,0,l),
+(648,43,ls),
+(648,126,o),
+(605,166,o),
+(539,166,cs),
+(520,166,o),
+(500,161,o),
+(481,155,c),
+(535,139,l),
+(535,306,l),
+(648,306,l),
+(648,384,l),
+(535,384,l),
+(535,551,l),
+(480,535,l),
+(500,528,o),
+(520,524,o),
+(539,524,cs),
+(605,524,o),
+(648,564,o),
+(648,646,cs),
+(648,690,l),
+(562,690,l),
+(562,664,ls),
+(562,620,o),
+(543,605,o),
+(519,605,cs),
+(468,605,o),
+(355,702,o),
+(251,702,cs),
+(140,702,o),
+(71,623,o),
+(71,513,cs),
+(71,418,o),
+(123,353,o),
+(210,334,c),
+(209,355,l),
+(123,336,o),
+(71,269,o),
+(71,177,cs),
+(71,67,o),
+(140,-13,o),
+(251,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(207,73,o),
+(167,116,o),
+(167,186,cs),
+(167,265,o),
+(217,306,o),
+(307,306,cs),
+(459,306,l),
+(459,145,l),
+(397,118,o),
+(330,73,o),
+(273,73,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(218,384,o),
+(167,425,o),
+(167,503,cs),
+(167,574,o),
+(207,616,o),
+(273,616,cs),
+(330,616,o),
+(397,572,o),
+(459,545,c),
+(459,384,l),
+(307,384,ls)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1659;
+unicode = 5721;
+},
+{
+color = 6;
+glyphname = "shCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(237,96,l),
+(237,199,l),
+(202,183,l),
+(229,183,ls),
+(305,183,o),
+(345,218,o),
+(345,281,cs),
+(345,343,o),
+(306,382,o),
+(232,382,cs),
+(185,382,ls),
+(146,382,o),
+(125,394,o),
+(125,429,cs),
+(125,463,o),
+(147,475,o),
+(185,475,cs),
+(338,475,l),
+(338,527,l),
+(237,527,l),
+(237,614,l),
+(172,614,l),
+(172,508,l),
+(206,527,l),
+(180,527,ls),
+(103,527,o),
+(64,492,o),
+(64,429,cs),
+(64,367,o),
+(102,329,o),
+(177,329,cs),
+(224,329,ls),
+(263,329,o),
+(284,315,o),
+(284,281,cs),
+(284,248,o),
+(263,235,o),
+(224,235,cs),
+(71,235,l),
+(71,183,l),
+(172,183,l),
+(172,96,l)
+);
+}
+);
+width = 409;
+}
+);
+metricRight = "=|";
+note = uni18F5;
+unicode = 5722;
+},
+{
+color = 9;
+glyphname = "tsuCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(354,-13,o),
+(416,37,o),
+(443,128,c),
+(416,128,l),
+(442,37,o),
+(506,-13,o),
+(595,-13,cs),
+(725,-13,o),
+(792,76,o),
+(792,196,cs),
+(792,328,o),
+(703,466,o),
+(703,548,cs),
+(703,581,o),
+(719,607,o),
+(771,607,cs),
+(800,607,l),
+(800,690,l),
+(752,690,ls),
+(652,690,o),
+(611,637,o),
+(611,560,cs),
+(611,510,o),
+(639,449,o),
+(660,384,c),
+(473,384,l),
+(473,621,l),
+(549,621,l),
+(549,690,l),
+(310,690,l),
+(310,621,l),
+(386,621,l),
+(386,384,l),
+(199,384,l),
+(220,449,o),
+(247,510,o),
+(247,560,cs),
+(247,637,o),
+(207,690,o),
+(107,690,cs),
+(59,690,l),
+(59,607,l),
+(88,607,ls),
+(140,607,o),
+(156,581,o),
+(156,548,cs),
+(156,466,o),
+(68,328,o),
+(68,196,cs),
+(68,76,o),
+(135,-13,o),
+(264,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,72,o),
+(163,125,o),
+(163,207,cs),
+(163,238,o),
+(170,271,o),
+(179,305,c),
+(386,305,l),
+(386,226,ls),
+(386,126,o),
+(344,72,o),
+(271,72,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(516,72,o),
+(473,125,o),
+(473,226,cs),
+(473,305,l),
+(680,305,l),
+(690,271,o),
+(696,238,o),
+(696,207,cs),
+(696,125,o),
+(660,72,o),
+(588,72,cs)
+);
+}
+);
+width = 859;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165B;
+unicode = 5723;
+},
+{
+color = 9;
+glyphname = "tsoCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(107,0,ls),
+(207,0,o),
+(247,53,o),
+(247,129,cs),
+(247,180,o),
+(220,241,o),
+(199,305,c),
+(386,305,l),
+(386,69,l),
+(310,69,l),
+(310,0,l),
+(549,0,l),
+(549,69,l),
+(473,69,l),
+(473,305,l),
+(660,305,l),
+(639,241,o),
+(611,180,o),
+(611,129,cs),
+(611,53,o),
+(652,0,o),
+(752,0,cs),
+(800,0,l),
+(800,83,l),
+(771,83,ls),
+(719,83,o),
+(702,109,o),
+(702,142,cs),
+(702,224,o),
+(791,361,o),
+(791,494,cs),
+(791,613,o),
+(725,702,o),
+(595,702,cs),
+(506,702,o),
+(442,653,o),
+(415,561,c),
+(443,561,l),
+(416,653,o),
+(353,702,o),
+(264,702,cs),
+(135,702,o),
+(68,613,o),
+(68,494,cs),
+(68,361,o),
+(156,224,o),
+(156,142,cs),
+(156,109,o),
+(140,83,o),
+(88,83,cs),
+(59,83,l),
+(59,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(170,418,o),
+(163,452,o),
+(163,483,cs),
+(163,565,o),
+(199,617,o),
+(271,617,cs),
+(343,617,o),
+(386,565,o),
+(386,464,cs),
+(386,384,l),
+(179,384,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(473,464,ls),
+(473,564,o),
+(516,617,o),
+(587,617,cs),
+(660,617,o),
+(696,565,o),
+(696,483,cs),
+(696,452,o),
+(690,418,o),
+(680,384,c),
+(473,384,l)
+);
+}
+);
+width = 859;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165C;
+unicode = 5724;
+},
+{
+color = 9;
+glyphname = "tseCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(584,-13,o),
+(653,67,o),
+(653,177,cs),
+(653,269,o),
+(602,336,o),
+(516,355,c),
+(515,334,l),
+(602,353,o),
+(653,418,o),
+(653,513,cs),
+(653,623,o),
+(584,702,o),
+(473,702,cs),
+(370,702,o),
+(257,605,o),
+(206,605,cs),
+(181,605,o),
+(162,620,o),
+(162,664,cs),
+(162,690,l),
+(76,690,l),
+(76,650,ls),
+(76,567,o),
+(120,526,o),
+(185,526,cs),
+(215,526,o),
+(248,538,o),
+(283,554,c),
+(242,561,l),
+(242,379,l),
+(133,379,l),
+(133,465,l),
+(76,465,l),
+(76,225,l),
+(133,225,l),
+(133,311,l),
+(242,311,l),
+(242,128,l),
+(282,136,l),
+(248,152,o),
+(215,164,o),
+(185,164,cs),
+(120,164,o),
+(76,123,o),
+(76,40,cs),
+(76,0,l),
+(162,0,l),
+(162,26,ls),
+(162,70,o),
+(181,85,o),
+(206,85,cs),
+(257,85,o),
+(370,-13,o),
+(473,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(409,73,o),
+(359,99,o),
+(312,123,c),
+(312,311,l),
+(417,311,ls),
+(507,311,o),
+(557,265,o),
+(557,186,cs),
+(557,116,o),
+(518,73,o),
+(452,73,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(312,567,l),
+(359,590,o),
+(409,616,o),
+(451,616,cs),
+(518,616,o),
+(557,574,o),
+(557,503,cs),
+(557,425,o),
+(507,379,o),
+(417,379,cs),
+(312,379,l)
+);
+}
+);
+width = 724;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni165D;
+unicode = 5725;
+},
+{
+color = 9;
+glyphname = "tseeCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(584,-13,o),
+(653,67,o),
+(653,177,cs),
+(653,269,o),
+(602,336,o),
+(516,355,c),
+(515,334,l),
+(602,353,o),
+(653,418,o),
+(653,513,cs),
+(653,623,o),
+(584,702,o),
+(473,702,cs),
+(370,702,o),
+(257,605,o),
+(206,605,cs),
+(181,605,o),
+(162,620,o),
+(162,664,cs),
+(162,690,l),
+(76,690,l),
+(76,650,ls),
+(76,567,o),
+(120,526,o),
+(185,526,cs),
+(212,526,o),
+(240,536,o),
+(270,550,c),
+(241,561,l),
+(241,379,l),
+(132,379,l),
+(132,465,l),
+(76,465,l),
+(76,225,l),
+(132,225,l),
+(132,312,l),
+(241,312,l),
+(241,125,l),
+(270,140,l),
+(240,154,o),
+(211,164,o),
+(185,164,cs),
+(120,164,o),
+(76,123,o),
+(76,40,cs),
+(76,0,l),
+(162,0,l),
+(162,26,ls),
+(162,70,o),
+(181,85,o),
+(206,85,cs),
+(257,85,o),
+(370,-13,o),
+(473,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(406,73,o),
+(353,102,o),
+(301,128,c),
+(301,312,l),
+(388,312,l),
+(388,218,l),
+(438,218,l),
+(438,345,l),
+(394,312,l),
+(431,312,ls),
+(513,312,o),
+(558,265,o),
+(558,191,cs),
+(558,116,o),
+(519,73,o),
+(452,73,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(438,464,l),
+(388,464,l),
+(388,379,l),
+(301,379,l),
+(301,562,l),
+(353,587,o),
+(406,616,o),
+(451,616,cs),
+(519,616,o),
+(558,574,o),
+(558,498,cs),
+(558,425,o),
+(512,379,o),
+(431,379,cs),
+(394,379,l),
+(438,345,l)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165E;
+unicode = 5726;
+},
+{
+color = 9;
+glyphname = "tsiCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(584,-13,o),
+(653,67,o),
+(653,177,cs),
+(653,269,o),
+(601,336,o),
+(517,355,c),
+(517,334,l),
+(602,353,o),
+(653,418,o),
+(653,513,cs),
+(653,623,o),
+(584,702,o),
+(473,702,cs),
+(370,702,o),
+(257,605,o),
+(206,605,cs),
+(181,605,o),
+(162,620,o),
+(162,664,cs),
+(162,690,l),
+(76,690,l),
+(76,650,ls),
+(76,566,o),
+(120,526,o),
+(185,526,cs),
+(209,526,o),
+(235,536,o),
+(261,548,c),
+(228,579,l),
+(228,379,l),
+(132,379,l),
+(132,465,l),
+(76,465,l),
+(76,225,l),
+(132,225,l),
+(132,312,l),
+(228,312,l),
+(228,111,l),
+(260,143,l),
+(233,155,o),
+(208,164,o),
+(185,164,cs),
+(120,164,o),
+(76,124,o),
+(76,40,cs),
+(76,0,l),
+(162,0,l),
+(162,26,ls),
+(162,70,o),
+(181,85,o),
+(206,85,cs),
+(257,85,o),
+(370,-13,o),
+(473,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(402,73,o),
+(345,106,o),
+(289,131,c),
+(289,312,l),
+(348,312,l),
+(358,284,o),
+(384,266,o),
+(414,266,cs),
+(456,266,o),
+(484,300,o),
+(487,339,c),
+(422,312,l),
+(440,312,ls),
+(515,312,o),
+(558,267,o),
+(558,191,cs),
+(558,116,o),
+(519,73,o),
+(452,73,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(486,391,o),
+(456,425,o),
+(414,425,cs),
+(384,425,o),
+(358,407,o),
+(348,379,c),
+(289,379,l),
+(289,558,l),
+(345,583,o),
+(402,616,o),
+(451,616,cs),
+(519,616,o),
+(558,574,o),
+(558,498,cs),
+(558,423,o),
+(515,378,o),
+(440,378,cs),
+(423,378,l),
+(488,350,l)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165F;
+unicode = 5727;
+},
+{
+color = 9;
+glyphname = "tsaCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(355,-13,o),
+(468,85,o),
+(519,85,cs),
+(543,85,o),
+(562,70,o),
+(562,26,cs),
+(562,0,l),
+(648,0,l),
+(648,40,ls),
+(648,123,o),
+(605,164,o),
+(539,164,cs),
+(509,164,o),
+(476,152,o),
+(442,136,c),
+(481,128,l),
+(481,311,l),
+(590,311,l),
+(590,225,l),
+(648,225,l),
+(648,465,l),
+(590,465,l),
+(590,379,l),
+(481,379,l),
+(481,561,l),
+(441,554,l),
+(475,538,o),
+(508,526,o),
+(539,526,cs),
+(605,526,o),
+(648,567,o),
+(648,650,cs),
+(648,690,l),
+(562,690,l),
+(562,664,ls),
+(562,620,o),
+(543,605,o),
+(519,605,cs),
+(468,605,o),
+(355,702,o),
+(251,702,cs),
+(140,702,o),
+(71,623,o),
+(71,513,cs),
+(71,418,o),
+(123,353,o),
+(210,334,c),
+(209,355,l),
+(123,336,o),
+(71,269,o),
+(71,177,cs),
+(71,67,o),
+(140,-13,o),
+(251,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(206,73,o),
+(167,116,o),
+(167,186,cs),
+(167,265,o),
+(217,311,o),
+(307,311,cs),
+(412,311,l),
+(412,123,l),
+(365,99,o),
+(316,73,o),
+(272,73,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(217,379,o),
+(167,425,o),
+(167,503,cs),
+(167,574,o),
+(206,616,o),
+(272,616,cs),
+(316,616,o),
+(365,590,o),
+(412,567,c),
+(412,379,l),
+(307,379,ls)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1660;
+unicode = 5728;
+},
+{
+color = 9;
+glyphname = "chuCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(354,-13,o),
+(416,37,o),
+(443,128,c),
+(416,128,l),
+(442,37,o),
+(506,-13,o),
+(595,-13,cs),
+(725,-13,o),
+(792,76,o),
+(792,196,cs),
+(792,328,o),
+(703,466,o),
+(703,548,cs),
+(703,581,o),
+(719,607,o),
+(771,607,cs),
+(800,607,l),
+(800,690,l),
+(752,690,ls),
+(652,690,o),
+(611,637,o),
+(611,560,cs),
+(611,455,o),
+(696,320,o),
+(696,207,cs),
+(696,125,o),
+(660,72,o),
+(588,72,cs),
+(516,72,o),
+(474,125,o),
+(474,226,cs),
+(474,621,l),
+(549,621,l),
+(549,690,l),
+(310,690,l),
+(310,621,l),
+(385,621,l),
+(385,226,ls),
+(385,126,o),
+(344,72,o),
+(271,72,cs),
+(200,72,o),
+(163,125,o),
+(163,207,cs),
+(163,320,o),
+(247,455,o),
+(247,560,cs),
+(247,637,o),
+(207,690,o),
+(107,690,cs),
+(59,690,l),
+(59,607,l),
+(88,607,ls),
+(140,607,o),
+(156,581,o),
+(156,548,cs),
+(156,466,o),
+(68,328,o),
+(68,196,cs),
+(68,76,o),
+(135,-13,o),
+(264,-13,cs)
+);
+}
+);
+width = 859;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164E;
+unicode = 5729;
+},
+{
+color = 9;
+glyphname = "choCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(107,0,ls),
+(207,0,o),
+(247,53,o),
+(247,129,cs),
+(247,235,o),
+(163,370,o),
+(163,483,cs),
+(163,565,o),
+(199,617,o),
+(271,617,cs),
+(343,617,o),
+(385,565,o),
+(385,464,cs),
+(385,69,l),
+(310,69,l),
+(310,0,l),
+(549,0,l),
+(549,69,l),
+(473,69,l),
+(473,464,ls),
+(473,564,o),
+(516,617,o),
+(587,617,cs),
+(660,617,o),
+(696,565,o),
+(696,483,cs),
+(696,370,o),
+(611,235,o),
+(611,129,cs),
+(611,53,o),
+(652,0,o),
+(752,0,cs),
+(800,0,l),
+(800,83,l),
+(771,83,ls),
+(719,83,o),
+(702,109,o),
+(702,142,cs),
+(702,224,o),
+(791,361,o),
+(791,494,cs),
+(791,613,o),
+(725,702,o),
+(595,702,cs),
+(506,702,o),
+(442,653,o),
+(415,561,c),
+(443,561,l),
+(416,653,o),
+(353,702,o),
+(264,702,cs),
+(135,702,o),
+(68,613,o),
+(68,494,cs),
+(68,361,o),
+(156,224,o),
+(156,142,cs),
+(156,109,o),
+(140,83,o),
+(88,83,cs),
+(59,83,l),
+(59,0,l)
+);
+}
+);
+width = 859;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5730;
+},
+{
+color = 9;
+glyphname = "cheCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(584,-13,o),
+(653,67,o),
+(653,177,cs),
+(653,269,o),
+(602,336,o),
+(516,355,c),
+(515,334,l),
+(602,353,o),
+(653,418,o),
+(653,513,cs),
+(653,623,o),
+(584,702,o),
+(473,702,cs),
+(370,702,o),
+(257,605,o),
+(206,605,cs),
+(181,605,o),
+(162,620,o),
+(162,664,cs),
+(162,690,l),
+(76,690,l),
+(76,649,ls),
+(76,567,o),
+(120,526,o),
+(185,526,cs),
+(268,526,o),
+(369,616,o),
+(451,616,cs),
+(518,616,o),
+(557,574,o),
+(557,503,cs),
+(557,425,o),
+(506,384,o),
+(417,384,cs),
+(133,384,l),
+(133,465,l),
+(76,465,l),
+(76,225,l),
+(133,225,l),
+(133,306,l),
+(417,306,ls),
+(507,306,o),
+(557,265,o),
+(557,186,cs),
+(557,116,o),
+(518,73,o),
+(451,73,cs),
+(369,73,o),
+(268,164,o),
+(185,164,cs),
+(120,164,o),
+(76,123,o),
+(76,41,cs),
+(76,0,l),
+(162,0,l),
+(162,26,ls),
+(162,70,o),
+(181,85,o),
+(206,85,cs),
+(257,85,o),
+(370,-13,o),
+(473,-13,cs)
+);
+}
+);
+width = 724;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni1663;
+unicode = 5731;
+},
+{
+color = 9;
+glyphname = "cheeCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(584,-13,o),
+(653,67,o),
+(653,177,cs),
+(653,269,o),
+(602,336,o),
+(516,355,c),
+(515,334,l),
+(602,353,o),
+(653,418,o),
+(653,513,cs),
+(653,623,o),
+(584,702,o),
+(473,702,cs),
+(370,702,o),
+(257,605,o),
+(206,605,cs),
+(181,605,o),
+(162,620,o),
+(162,664,cs),
+(162,690,l),
+(76,690,l),
+(76,649,ls),
+(76,567,o),
+(120,526,o),
+(185,526,cs),
+(268,526,o),
+(370,618,o),
+(453,618,cs),
+(520,618,o),
+(559,575,o),
+(559,501,cs),
+(559,423,o),
+(509,379,o),
+(427,379,cs),
+(370,379,l),
+(393,364,l),
+(393,462,l),
+(335,462,l),
+(335,379,l),
+(133,379,l),
+(133,465,l),
+(76,465,l),
+(76,225,l),
+(133,225,l),
+(133,312,l),
+(335,312,l),
+(335,220,l),
+(393,220,l),
+(393,326,l),
+(370,312,l),
+(427,312,ls),
+(510,312,o),
+(559,267,o),
+(559,188,cs),
+(559,115,o),
+(520,71,o),
+(453,71,cs),
+(370,71,o),
+(268,164,o),
+(185,164,cs),
+(120,164,o),
+(76,123,o),
+(76,41,cs),
+(76,0,l),
+(162,0,l),
+(162,26,ls),
+(162,70,o),
+(181,85,o),
+(206,85,cs),
+(257,85,o),
+(370,-13,o),
+(473,-13,cs)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1664;
+unicode = 5732;
+},
+{
+color = 9;
+glyphname = "chiCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(584,-13,o),
+(653,67,o),
+(653,177,cs),
+(653,269,o),
+(601,336,o),
+(517,355,c),
+(517,334,l),
+(602,353,o),
+(653,418,o),
+(653,513,cs),
+(653,623,o),
+(584,702,o),
+(473,702,cs),
+(370,702,o),
+(257,605,o),
+(206,605,cs),
+(181,605,o),
+(162,620,o),
+(162,664,cs),
+(162,690,l),
+(76,690,l),
+(76,649,ls),
+(76,567,o),
+(120,526,o),
+(185,526,cs),
+(268,526,o),
+(370,618,o),
+(453,618,cs),
+(520,618,o),
+(559,575,o),
+(559,501,cs),
+(559,423,o),
+(509,379,o),
+(432,379,cs),
+(388,379,l),
+(420,349,l),
+(418,392,o),
+(385,425,o),
+(343,425,cs),
+(311,425,o),
+(284,406,o),
+(272,379,c),
+(133,379,l),
+(133,465,l),
+(76,465,l),
+(76,225,l),
+(133,225,l),
+(133,312,l),
+(273,312,l),
+(285,285,o),
+(312,266,o),
+(343,266,cs),
+(385,266,o),
+(416,299,o),
+(420,340,c),
+(387,312,l),
+(432,312,ls),
+(510,312,o),
+(559,267,o),
+(559,188,cs),
+(559,115,o),
+(520,71,o),
+(453,71,cs),
+(370,71,o),
+(268,164,o),
+(185,164,cs),
+(120,164,o),
+(76,123,o),
+(76,41,cs),
+(76,0,l),
+(162,0,l),
+(162,26,ls),
+(162,70,o),
+(181,85,o),
+(206,85,cs),
+(257,85,o),
+(370,-13,o),
+(473,-13,cs)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1665;
+unicode = 5733;
+},
+{
+color = 9;
+glyphname = "chaCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(355,-13,o),
+(468,85,o),
+(519,85,cs),
+(543,85,o),
+(562,70,o),
+(562,26,cs),
+(562,0,l),
+(648,0,l),
+(648,41,ls),
+(648,123,o),
+(605,164,o),
+(539,164,cs),
+(457,164,o),
+(355,73,o),
+(273,73,cs),
+(207,73,o),
+(167,116,o),
+(167,186,cs),
+(167,265,o),
+(218,306,o),
+(307,306,cs),
+(590,306,l),
+(590,225,l),
+(648,225,l),
+(648,465,l),
+(590,465,l),
+(590,384,l),
+(307,384,ls),
+(217,384,o),
+(167,425,o),
+(167,503,cs),
+(167,574,o),
+(207,616,o),
+(273,616,cs),
+(355,616,o),
+(457,526,o),
+(539,526,cs),
+(605,526,o),
+(648,567,o),
+(648,649,cs),
+(648,690,l),
+(562,690,l),
+(562,664,ls),
+(562,620,o),
+(543,605,o),
+(519,605,cs),
+(468,605,o),
+(355,702,o),
+(251,702,cs),
+(140,702,o),
+(71,623,o),
+(71,513,cs),
+(71,418,o),
+(123,353,o),
+(210,334,c),
+(209,355,l),
+(123,336,o),
+(71,269,o),
+(71,177,cs),
+(71,67,o),
+(140,-13,o),
+(251,-13,cs)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1666;
+unicode = 5734;
+},
+{
+color = 9;
+glyphname = "ttsuCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(354,-13,o),
+(416,37,o),
+(443,128,c),
+(416,128,l),
+(442,37,o),
+(506,-13,o),
+(595,-13,cs),
+(725,-13,o),
+(792,76,o),
+(792,196,cs),
+(792,328,o),
+(703,466,o),
+(703,548,cs),
+(703,581,o),
+(719,607,o),
+(771,607,cs),
+(800,607,l),
+(800,690,l),
+(752,690,ls),
+(652,690,o),
+(611,637,o),
+(611,560,cs),
+(611,530,o),
+(618,497,o),
+(627,464,c),
+(660,537,l),
+(473,410,l),
+(473,621,l),
+(549,621,l),
+(549,690,l),
+(310,690,l),
+(310,621,l),
+(386,621,l),
+(386,410,l),
+(199,537,l),
+(233,464,l),
+(241,498,o),
+(247,530,o),
+(247,560,cs),
+(247,637,o),
+(207,690,o),
+(107,690,cs),
+(59,690,l),
+(59,607,l),
+(88,607,ls),
+(140,607,o),
+(156,581,o),
+(156,548,cs),
+(156,466,o),
+(68,328,o),
+(68,196,cs),
+(68,76,o),
+(135,-13,o),
+(264,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,72,o),
+(163,125,o),
+(163,207,cs),
+(163,279,o),
+(199,357,o),
+(222,429,c),
+(386,320,l),
+(386,226,ls),
+(386,126,o),
+(344,72,o),
+(271,72,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(516,72,o),
+(473,125,o),
+(473,226,cs),
+(473,320,l),
+(637,429,l),
+(661,357,o),
+(696,278,o),
+(696,207,cs),
+(696,125,o),
+(660,72,o),
+(588,72,cs)
+);
+}
+);
+width = 859;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1667;
+unicode = 5735;
+},
+{
+color = 9;
+glyphname = "ttsoCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(107,0,ls),
+(207,0,o),
+(247,53,o),
+(247,129,cs),
+(247,159,o),
+(241,191,o),
+(233,226,c),
+(199,153,l),
+(386,280,l),
+(386,69,l),
+(310,69,l),
+(310,0,l),
+(549,0,l),
+(549,69,l),
+(473,69,l),
+(473,280,l),
+(660,153,l),
+(627,226,l),
+(618,192,o),
+(611,159,o),
+(611,129,cs),
+(611,53,o),
+(652,0,o),
+(752,0,cs),
+(800,0,l),
+(800,83,l),
+(771,83,ls),
+(719,83,o),
+(703,109,o),
+(703,142,cs),
+(703,224,o),
+(792,361,o),
+(792,494,cs),
+(792,613,o),
+(725,702,o),
+(595,702,cs),
+(506,702,o),
+(442,653,o),
+(416,561,c),
+(443,561,l),
+(416,653,o),
+(354,702,o),
+(264,702,cs),
+(135,702,o),
+(68,613,o),
+(68,494,cs),
+(68,361,o),
+(156,224,o),
+(156,142,cs),
+(156,109,o),
+(140,83,o),
+(88,83,cs),
+(59,83,l),
+(59,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,332,o),
+(163,411,o),
+(163,483,cs),
+(163,565,o),
+(200,617,o),
+(271,617,cs),
+(344,617,o),
+(386,564,o),
+(386,464,cs),
+(386,370,l),
+(222,261,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(473,370,l),
+(473,464,ls),
+(473,565,o),
+(516,617,o),
+(588,617,cs),
+(660,617,o),
+(696,565,o),
+(696,483,cs),
+(696,412,o),
+(661,332,o),
+(637,261,c)
+);
+}
+);
+width = 859;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1668;
+unicode = 5736;
+},
+{
+color = 9;
+glyphname = "ttseCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(584,-13,o),
+(653,67,o),
+(653,177,cs),
+(653,269,o),
+(601,336,o),
+(517,355,c),
+(517,334,l),
+(602,353,o),
+(653,418,o),
+(653,513,cs),
+(653,623,o),
+(584,702,o),
+(473,702,cs),
+(370,702,o),
+(257,605,o),
+(206,605,cs),
+(181,605,o),
+(162,620,o),
+(162,664,cs),
+(162,690,l),
+(76,690,l),
+(76,649,ls),
+(76,567,o),
+(120,526,o),
+(185,526,cs),
+(200,526,o),
+(213,527,o),
+(228,534,c),
+(158,568,l),
+(242,379,l),
+(133,379,l),
+(133,465,l),
+(76,465,l),
+(76,225,l),
+(133,225,l),
+(133,312,l),
+(242,312,l),
+(158,122,l),
+(228,156,l),
+(213,162,o),
+(200,164,o),
+(185,164,cs),
+(120,164,o),
+(76,123,o),
+(76,41,cs),
+(76,0,l),
+(162,0,l),
+(162,26,ls),
+(162,70,o),
+(181,85,o),
+(206,85,cs),
+(257,85,o),
+(370,-13,o),
+(473,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(386,71,o),
+(307,132,o),
+(243,152,c),
+(313,312,l),
+(432,312,ls),
+(510,312,o),
+(559,267,o),
+(559,188,cs),
+(559,115,o),
+(520,71,o),
+(453,71,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(243,538,l),
+(307,557,o),
+(386,618,o),
+(453,618,cs),
+(520,618,o),
+(559,575,o),
+(559,501,cs),
+(559,423,o),
+(509,379,o),
+(432,379,cs),
+(313,379,l)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1669;
+unicode = 5737;
+},
+{
+color = 9;
+glyphname = "ttseeCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(584,-13,o),
+(653,67,o),
+(653,177,cs),
+(653,269,o),
+(601,336,o),
+(517,355,c),
+(517,334,l),
+(602,353,o),
+(653,418,o),
+(653,513,cs),
+(653,623,o),
+(584,702,o),
+(473,702,cs),
+(370,702,o),
+(257,605,o),
+(206,605,cs),
+(181,605,o),
+(162,620,o),
+(162,664,cs),
+(162,690,l),
+(76,690,l),
+(76,649,ls),
+(76,567,o),
+(120,526,o),
+(185,526,cs),
+(201,526,o),
+(215,527,o),
+(224,535,c),
+(157,566,l),
+(242,379,l),
+(133,379,l),
+(133,465,l),
+(76,465,l),
+(76,225,l),
+(133,225,l),
+(133,312,l),
+(242,312,l),
+(157,124,l),
+(224,155,l),
+(215,162,o),
+(201,164,o),
+(185,164,cs),
+(120,164,o),
+(76,123,o),
+(76,41,cs),
+(76,0,l),
+(162,0,l),
+(162,26,ls),
+(162,70,o),
+(181,85,o),
+(206,85,cs),
+(257,85,o),
+(370,-13,o),
+(473,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(385,71,o),
+(306,133,o),
+(241,153,c),
+(310,312,l),
+(383,312,l),
+(383,218,l),
+(433,218,l),
+(433,329,l),
+(412,312,l),
+(432,312,ls),
+(510,312,o),
+(559,267,o),
+(559,188,cs),
+(559,115,o),
+(520,71,o),
+(453,71,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(433,464,l),
+(383,464,l),
+(383,379,l),
+(310,379,l),
+(241,537,l),
+(306,556,o),
+(385,618,o),
+(453,618,cs),
+(520,618,o),
+(559,575,o),
+(559,501,cs),
+(559,423,o),
+(509,379,o),
+(432,379,cs),
+(412,379,l),
+(433,361,l)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166A;
+unicode = 5738;
+},
+{
+color = 9;
+glyphname = "ttsiCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(584,-13,o),
+(653,67,o),
+(653,177,cs),
+(653,269,o),
+(601,336,o),
+(517,355,c),
+(517,334,l),
+(602,353,o),
+(653,418,o),
+(653,513,cs),
+(653,623,o),
+(584,702,o),
+(473,702,cs),
+(370,702,o),
+(257,605,o),
+(206,605,cs),
+(181,605,o),
+(162,620,o),
+(162,664,cs),
+(162,690,l),
+(76,690,l),
+(76,649,ls),
+(76,567,o),
+(120,526,o),
+(185,526,cs),
+(196,526,o),
+(206,526,o),
+(218,531,c),
+(166,549,l),
+(242,379,l),
+(133,379,l),
+(133,465,l),
+(76,465,l),
+(76,225,l),
+(133,225,l),
+(133,312,l),
+(242,312,l),
+(165,138,l),
+(218,158,l),
+(206,163,o),
+(196,164,o),
+(185,164,cs),
+(120,164,o),
+(76,123,o),
+(76,41,cs),
+(76,0,l),
+(162,0,l),
+(162,26,ls),
+(162,70,o),
+(181,85,o),
+(206,85,cs),
+(257,85,o),
+(370,-13,o),
+(473,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(384,71,o),
+(300,137,o),
+(233,156,c),
+(300,312,l),
+(331,312,l),
+(343,285,o),
+(368,266,o),
+(398,266,cs),
+(437,266,o),
+(467,297,o),
+(469,336,c),
+(421,312,l),
+(440,312,ls),
+(514,312,o),
+(559,267,o),
+(559,188,cs),
+(559,115,o),
+(520,71,o),
+(453,71,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(469,394,o),
+(438,425,o),
+(398,425,cs),
+(367,425,o),
+(342,406,o),
+(331,379,c),
+(300,379,l),
+(233,533,l),
+(300,553,o),
+(384,618,o),
+(453,618,cs),
+(520,618,o),
+(559,575,o),
+(559,501,cs),
+(559,423,o),
+(514,379,o),
+(440,379,cs),
+(422,379,l),
+(470,354,l)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166B;
+unicode = 5739;
+},
+{
+color = 9;
+glyphname = "ttsaCarrier-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(355,-13,o),
+(468,85,o),
+(519,85,cs),
+(543,85,o),
+(562,70,o),
+(562,26,cs),
+(562,0,l),
+(648,0,l),
+(648,41,ls),
+(648,123,o),
+(605,164,o),
+(539,164,cs),
+(524,164,o),
+(511,162,o),
+(497,156,c),
+(566,122,l),
+(481,312,l),
+(590,312,l),
+(590,225,l),
+(648,225,l),
+(648,465,l),
+(590,465,l),
+(590,379,l),
+(481,379,l),
+(566,568,l),
+(497,534,l),
+(511,527,o),
+(524,526,o),
+(539,526,cs),
+(605,526,o),
+(648,567,o),
+(648,649,cs),
+(648,690,l),
+(562,690,l),
+(562,664,ls),
+(562,620,o),
+(543,605,o),
+(519,605,cs),
+(468,605,o),
+(355,702,o),
+(251,702,cs),
+(140,702,o),
+(71,623,o),
+(71,513,cs),
+(71,418,o),
+(123,353,o),
+(208,334,c),
+(208,355,l),
+(124,336,o),
+(71,269,o),
+(71,177,cs),
+(71,67,o),
+(140,-13,o),
+(251,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(205,71,o),
+(165,115,o),
+(165,188,cs),
+(165,267,o),
+(214,312,o),
+(293,312,cs),
+(412,312,l),
+(481,152,l),
+(417,132,o),
+(338,71,o),
+(271,71,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(214,379,o),
+(165,423,o),
+(165,501,cs),
+(165,575,o),
+(205,618,o),
+(271,618,cs),
+(338,618,o),
+(417,557,o),
+(481,538,c),
+(412,379,l),
+(293,379,ls)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni166C;
+unicode = 5740;
+},
+{
+glyphname = "qai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (329,0);
+ref = "ke-canadian";
+}
+);
+width = 916;
+}
+);
+note = uni166F;
+unicode = 5743;
+},
+{
+glyphname = "ngai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (636,0);
+ref = "ce-canadian";
+}
+);
+width = 1216;
+}
+);
+note = uni1670;
+unicode = 5744;
+},
+{
+glyphname = "nngi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (920,0);
+ref = "ci-canadian";
+}
+);
+width = 1498;
+}
+);
+note = uni1671;
+unicode = 5745;
+},
+{
+glyphname = "nngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (920,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (1143,0);
+ref = dot_top;
+}
+);
+width = 1498;
+}
+);
+note = uni1672;
+unicode = 5746;
+},
+{
+glyphname = "nngo-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (920,0);
+ref = "ce-canadian";
+}
+);
+width = 1498;
+}
+);
+note = uni1673;
+unicode = 5747;
+},
+{
+glyphname = "nngoo-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (920,0);
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (1133,0);
+ref = dot_top;
+}
+);
+width = 1498;
+}
+);
+note = uni1674;
+unicode = 5748;
+},
+{
+glyphname = "nnga-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (920,0);
+ref = "ca-canadian";
+}
+);
+width = 1498;
+}
+);
+note = uni1675;
+unicode = 5749;
+},
+{
+glyphname = "nngaa-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (920,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (961,0);
+ref = dot_top;
+}
+);
+width = 1498;
+}
+);
+note = uni1676;
+unicode = 5750;
+},
+{
+glyphname = "thweeWoodScree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 832;
+}
+);
+note = uni1677;
+unicode = 5751;
+},
+{
+glyphname = "thwiWoodScree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 832;
+}
+);
+note = uni1678;
+unicode = 5752;
+},
+{
+glyphname = "thwiiWoodScree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (87,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 832;
+}
+);
+note = uni1679;
+unicode = 5753;
+},
+{
+glyphname = "thwoWoodScree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 832;
+}
+);
+note = uni167A;
+unicode = 5754;
+},
+{
+glyphname = "thwooWoodScree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (374,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 832;
+}
+);
+note = uni167B;
+unicode = 5755;
+},
+{
+glyphname = "thwaWoodScree-canadian";
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 831;
+}
+);
+note = uni167C;
+unicode = 5756;
+},
+{
+glyphname = "thwaaWoodScree-canadian";
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (87,0);
+ref = dot_top;
+},
+{
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 831;
+}
+);
+note = uni167D;
+unicode = 5757;
+},
+{
+glyphname = "wBlackfoot-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(384,557,l),
+(384,614,l),
+(64,614,l),
+(64,557,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(384,420,l),
+(384,477,l),
+(64,477,l),
+(64,420,l)
+);
+}
+);
+width = 448;
+}
+);
+metricRight = "=|";
+note = uni167F;
+unicode = 5759;
+},
+{
+glyphname = "oy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-8,0);
+ref = ring_top.canadian;
+}
+);
+width = 677;
+}
+);
+note = uni18B0;
+unicode = 6320;
+},
+{
+glyphname = "ay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (435,0);
+ref = ring_top.canadian;
+}
+);
+width = 677;
+}
+);
+note = uni18B1;
+unicode = 6321;
+},
+{
+glyphname = "aay-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (187,0);
+ref = ring_top.canadian;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (486,0);
+ref = dot_top;
+}
+);
+width = 677;
+}
+);
+note = uni18B2;
+unicode = 6322;
+},
+{
+glyphname = "way-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (659,0);
+ref = ring_top.canadian;
+}
+);
+width = 901;
+}
+);
+note = uni18B3;
+unicode = 6323;
+},
+{
+glyphname = "poy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-30,0);
+ref = ring_top.canadian;
+}
+);
+width = 649;
+}
+);
+note = uni18B4;
+unicode = 6324;
+},
+{
+glyphname = "pay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (430,0);
+ref = ring_top.canadian;
+}
+);
+width = 649;
+}
+);
+note = uni18B5;
+unicode = 6325;
+},
+{
+glyphname = "pwoy-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (195,0);
+ref = ring_top.canadian;
+}
+);
+width = 874;
+}
+);
+note = uni18B6;
+unicode = 6326;
+},
+{
+glyphname = "tay-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (209,0);
+ref = ring_top.canadian;
+}
+);
+width = 607;
+}
+);
+note = uni18B7;
+unicode = 6327;
+},
+{
+glyphname = "kay-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-9,0);
+ref = ring_top.canadian;
+}
+);
+width = 586;
+}
+);
+note = uni18B8;
+unicode = 6328;
+},
+{
+glyphname = "kway-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (216,0);
+ref = ring_top.canadian;
+}
+);
+width = 810;
+}
+);
+note = uni18B9;
+unicode = 6329;
+},
+{
+glyphname = "may-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-1,0);
+ref = ring_top.canadian;
+}
+);
+width = 528;
+}
+);
+note = uni18BA;
+unicode = 6330;
+},
+{
+glyphname = "noy-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (383,-192);
+ref = ring_top.canadian;
+}
+);
+width = 805;
+}
+);
+note = uni18BB;
+unicode = 6331;
+},
+{
+glyphname = "nay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (172,-192);
+ref = ring_top.canadian;
+}
+);
+width = 805;
+}
+);
+note = uni18BC;
+unicode = 6332;
+},
+{
+glyphname = "lay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (172,-192);
+ref = ring_top.canadian;
+}
+);
+width = 805;
+}
+);
+note = uni18BD;
+unicode = 6333;
+},
+{
+glyphname = "soy-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (291,0);
+ref = ring_top.canadian;
+}
+);
+width = 539;
+}
+);
+note = uni18BE;
+unicode = 6334;
+},
+{
+glyphname = "say-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-1,0);
+ref = ring_top.canadian;
+}
+);
+width = 539;
+}
+);
+note = uni18BF;
+unicode = 6335;
+},
+{
+glyphname = "shoy-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (339,-192);
+ref = ring_top.canadian;
+}
+);
+width = 927;
+}
+);
+note = uni18C0;
+unicode = 6336;
+},
+{
+glyphname = "shay-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (339,-192);
+ref = ring_top.canadian;
+}
+);
+width = 927;
+}
+);
+note = uni18C1;
+unicode = 6337;
+},
+{
+glyphname = "shwoy-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (563,-192);
+ref = ring_top.canadian;
+}
+);
+width = 1152;
+}
+);
+note = uni18C2;
+unicode = 6338;
+},
+{
+glyphname = "yoy-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (322,0);
+ref = ring_top.canadian;
+}
+);
+width = 570;
+}
+);
+note = uni18C3;
+unicode = 6339;
+},
+{
+glyphname = "yay-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-1,0);
+ref = ring_top.canadian;
+}
+);
+width = 570;
+}
+);
+note = uni18C4;
+unicode = 6340;
+},
+{
+glyphname = "ray-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (182,0);
+ref = ring_top.canadian;
+}
+);
+width = 543;
+}
+);
+note = uni18C5;
+unicode = 6341;
+},
+{
+glyphname = "nwi-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ni-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni18C6;
+unicode = 6342;
+},
+{
+glyphname = "nwiOjibway-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (805,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni18C7;
+unicode = 6343;
+},
+{
+glyphname = "nwii-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (459,-192);
+ref = dot_top;
+}
+);
+width = 1029;
+}
+);
+note = uni18C8;
+unicode = 6344;
+},
+{
+glyphname = "nwiiOjibway-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (235,-192);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (805,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni18C9;
+unicode = 6345;
+},
+{
+glyphname = "nwo-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "no-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni18CA;
+unicode = 6346;
+},
+{
+glyphname = "nwoOjibway-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (805,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni18CB;
+unicode = 6347;
+},
+{
+glyphname = "nwoo-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (658,-192);
+ref = dot_top;
+}
+);
+width = 1029;
+}
+);
+note = uni18CC;
+unicode = 6348;
+},
+{
+glyphname = "nwooOjibway-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (434,-192);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (805,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni18CD;
+unicode = 6349;
+},
+{
+glyphname = "rwee-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "reRCree-canadian";
+}
+);
+width = 1075;
+}
+);
+note = uni18CE;
+unicode = 6350;
+},
+{
+glyphname = "rwi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ri-canadian";
+}
+);
+width = 1075;
+}
+);
+note = uni18CF;
+unicode = 6351;
+},
+{
+glyphname = "rwii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (452,-192);
+ref = dot_top;
+}
+);
+width = 1075;
+}
+);
+note = uni18D0;
+unicode = 6352;
+},
+{
+glyphname = "rwo-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ro-canadian";
+}
+);
+width = 767;
+}
+);
+note = uni18D1;
+unicode = 6353;
+},
+{
+glyphname = "rwoo-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (387,0);
+ref = dot_top;
+}
+);
+width = 767;
+}
+);
+note = uni18D2;
+unicode = 6354;
+},
+{
+glyphname = "rwa-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = "ra-canadian";
+}
+);
+width = 767;
+}
+);
+note = uni18D3;
+unicode = 6355;
+},
+{
+glyphname = "pOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(113,345,l),
+(236,621,l),
+(188,621,l),
+(311,345,l),
+(375,345,l),
+(375,359,l),
+(221,690,l),
+(202,690,l),
+(48,359,l),
+(48,345,l)
+);
+}
+);
+width = 423;
+}
+);
+metricLeft = "kkCarrier-canadian";
+note = uni18D4;
+unicode = 6356;
+},
+{
+glyphname = "tOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 424;
+}
+);
+metricRight = "=|";
+note = uni1422;
+unicode = 6357;
+},
+{
+glyphname = "kOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(132,345,l),
+(132,504,l),
+(117,500,l),
+(125,462,o),
+(158,434,o),
+(204,434,cs),
+(269,434,o),
+(319,483,o),
+(319,562,cs),
+(319,646,o),
+(264,696,o),
+(193,696,cs),
+(114,696,o),
+(64,643,o),
+(64,561,cs),
+(64,345,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(155,484,o),
+(127,513,o),
+(127,564,cs),
+(127,617,o),
+(152,644,o),
+(192,644,cs),
+(231,644,o),
+(257,615,o),
+(257,564,cs),
+(257,513,o),
+(230,484,o),
+(191,484,cs)
+);
+}
+);
+width = 373;
+}
+);
+metricLeft = "k-canadian";
+metricRight = "k-canadian";
+note = uni18D6;
+unicode = 6358;
+},
+{
+glyphname = "cOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(132,345,l),
+(132,567,ls),
+(132,617,o),
+(155,641,o),
+(193,641,cs),
+(231,641,o),
+(256,617,o),
+(256,572,cs),
+(256,548,l),
+(320,548,l),
+(320,567,ls),
+(320,649,o),
+(269,696,o),
+(193,696,cs),
+(111,696,o),
+(64,648,o),
+(64,558,cs),
+(64,345,l)
+);
+}
+);
+width = 363;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni18D7;
+unicode = 6359;
+},
+{
+glyphname = "mOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(132,345,l),
+(132,626,l),
+(290,626,l),
+(290,690,l),
+(64,690,l),
+(64,345,l)
+);
+}
+);
+width = 337;
+}
+);
+metricLeft = "m-canadian";
+metricRight = "m-canadian";
+note = uni18D8;
+unicode = 6360;
+},
+{
+glyphname = "nOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(257,428,o),
+(306,477,o),
+(306,555,cs),
+(306,603,o),
+(284,643,o),
+(252,656,c),
+(249,626,l),
+(431,626,l),
+(431,690,l),
+(186,690,ls),
+(104,690,o),
+(54,638,o),
+(54,558,cs),
+(54,479,o),
+(105,428,o),
+(181,428,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(142,479,o),
+(115,508,o),
+(115,558,cs),
+(115,610,o),
+(142,639,o),
+(181,639,cs),
+(219,639,o),
+(245,610,o),
+(245,558,cs),
+(245,508,o),
+(219,479,o),
+(181,479,cs)
+);
+}
+);
+width = 478;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "n-canadian";
+note = uni18D9;
+unicode = 6361;
+},
+{
+glyphname = "sOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(132,345,l),
+(132,486,l),
+(91,455,l),
+(127,455,ls),
+(233,455,o),
+(294,526,o),
+(294,635,cs),
+(294,690,l),
+(225,690,l),
+(225,639,ls),
+(225,553,o),
+(186,510,o),
+(101,510,cs),
+(64,510,l),
+(64,345,l)
+);
+}
+);
+width = 358;
+}
+);
+metricLeft = "s-canadian";
+metricRight = "s-canadian";
+note = uni18DA;
+unicode = 6362;
+},
+{
+color = 1;
+glyphname = "shOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(247,339,o),
+(290,386,o),
+(297,471,cs),
+(305,568,ls),
+(310,617,o),
+(327,643,o),
+(367,643,cs),
+(407,643,o),
+(429,618,o),
+(429,571,cs),
+(429,548,l),
+(492,548,l),
+(492,568,ls),
+(492,650,o),
+(441,696,o),
+(367,696,cs),
+(288,696,o),
+(245,648,o),
+(238,563,cs),
+(230,467,ls),
+(225,417,o),
+(208,391,o),
+(168,391,cs),
+(128,391,o),
+(105,416,o),
+(105,464,cs),
+(105,487,l),
+(43,487,l),
+(43,467,ls),
+(43,384,o),
+(93,339,o),
+(167,339,cs)
+);
+}
+);
+width = 535;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "c-canadian";
+note = uni18DB;
+unicode = 6363;
+},
+{
+color = 9;
+glyphname = "easternw-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (36,-307);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (130,0);
+ref = "glottalstop-canadian";
+}
+);
+width = 565;
+}
+);
+note = uni18DC;
+unicode = 6364;
+},
+{
+color = 9;
+glyphname = "westernw-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (531,-307);
+ref = dot_top;
+scale = (-1,1);
+},
+{
+alignment = -1;
+pos = (436,0);
+ref = "glottalstop-canadian";
+scale = (-1,1);
+}
+);
+width = 567;
+}
+);
+metricLeft = "glottalstop-canadian";
+note = uni18DD;
+unicode = 6365;
+},
+{
+glyphname = "rweRCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "reRCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (850,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1075;
+}
+);
+note = uni18E0;
+unicode = 6368;
+},
+{
+glyphname = "looWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+}
+);
+width = 543;
+}
+);
+note = uni18E1;
+unicode = 6369;
+},
+{
+glyphname = "laaWestCree-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (346,0);
+ref = dot_top;
+}
+);
+width = 543;
+}
+);
+note = uni18E2;
+unicode = 6370;
+},
+{
+glyphname = "thwe-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "the-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (722,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 946;
+}
+);
+note = uni18E3;
+unicode = 6371;
+},
+{
+glyphname = "thwa-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (672,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 896;
+}
+);
+note = uni18E4;
+unicode = 6372;
+},
+{
+glyphname = "tthwe-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "tthe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (713,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 937;
+}
+);
+note = uni18E5;
+unicode = 6373;
+},
+{
+glyphname = "tthoo-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ttho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (243,0);
+ref = dot_top;
+}
+);
+width = 623;
+}
+);
+note = uni18E6;
+unicode = 6374;
+},
+{
+glyphname = "tthaa-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ttha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (246,0);
+ref = dot_top;
+}
+);
+width = 623;
+}
+);
+note = uni18E7;
+unicode = 6375;
+},
+{
+glyphname = "tlhwe-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "tlhe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (596,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 820;
+}
+);
+note = uni18E8;
+unicode = 6376;
+},
+{
+glyphname = "tlhoo-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "tlho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (241,0);
+ref = dot_top;
+}
+);
+width = 596;
+}
+);
+note = uni18E9;
+unicode = 6377;
+},
+{
+glyphname = "shweSayisi-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "sheSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (592,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni18EA;
+unicode = 6378;
+},
+{
+glyphname = "shooSayisi-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "shoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (403,0);
+ref = dot_top;
+}
+);
+width = 592;
+}
+);
+note = uni18EB;
+unicode = 6379;
+},
+{
+color = 9;
+glyphname = "hooSayisi-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "hoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (474,0);
+ref = dot_top;
+}
+);
+width = 670;
+}
+);
+note = uni18EC;
+unicode = 6380;
+},
+{
+color = 9;
+glyphname = "gwuCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "guCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (856,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1081;
+}
+);
+note = uni18ED;
+unicode = 6381;
+},
+{
+color = 9;
+glyphname = "deneGeeCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "geCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (283,0);
+ref = dot_top;
+}
+);
+width = 708;
+}
+);
+note = uni18EE;
+unicode = 6382;
+},
+{
+color = 9;
+glyphname = "gaaCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (297,0);
+ref = dot_top;
+}
+);
+width = 708;
+}
+);
+note = uni18EF;
+unicode = 6383;
+},
+{
+color = 9;
+glyphname = "gwaCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (708,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 932;
+}
+);
+note = uni18F0;
+unicode = 6384;
+},
+{
+color = 9;
+glyphname = "juuSayisi-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "juSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (292,0);
+ref = dot_top;
+}
+);
+width = 719;
+}
+);
+note = uni18F1;
+unicode = 6385;
+},
+{
+color = 9;
+glyphname = "jwaCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "jaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (762,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 986;
+}
+);
+note = uni18F2;
+unicode = 6386;
+},
+{
+glyphname = "lBeaverDene-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+ref = "pWestCree-canadian";
+}
+);
+width = 196;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+unicode = 6387;
+},
+{
+glyphname = "rBeaverDene-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(132,345,l),
+(132,539,ls),
+(132,595,o),
+(154,626,o),
+(203,626,cs),
+(213,626,l),
+(213,696,l),
+(204,696,ls),
+(155,696,o),
+(123,658,o),
+(121,611,c),
+(128,611,l),
+(128,690,l),
+(64,690,l),
+(64,345,l)
+);
+}
+);
+width = 243;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni18F4;
+unicode = 6388;
+},
+{
+color = 6;
+glyphname = "sDentalCarrier-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(226,183,ls),
+(305,183,o),
+(345,219,o),
+(345,281,cs),
+(345,342,o),
+(306,382,o),
+(229,382,cs),
+(185,382,ls),
+(146,382,o),
+(125,395,o),
+(125,428,cs),
+(125,461,o),
+(147,475,o),
+(185,475,cs),
+(338,475,l),
+(338,527,l),
+(183,527,ls),
+(103,527,o),
+(64,491,o),
+(64,429,cs),
+(64,369,o),
+(102,329,o),
+(180,329,cs),
+(224,329,ls),
+(263,329,o),
+(284,315,o),
+(284,282,cs),
+(284,249,o),
+(263,235,o),
+(224,235,cs),
+(71,235,l),
+(71,183,l)
+);
+}
+);
+width = 409;
+}
+);
+metricLeft = "shCarrier-canadian";
+metricRight = "=|";
+note = uni18F5;
+unicode = 6389;
+},
+{
+glyphname = "pWestCree-canadian.base";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "pWestCree-canadian";
+}
+);
+width = 196;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.base";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "c-canadian";
+}
+);
+width = 363;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "thSayisi-canadian.base";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "thSayisi-canadian";
+}
+);
+width = 363;
+}
+);
+metricLeft = "=|c-canadian";
+note = uni14A2;
+},
+{
+glyphname = "mWestCree-canadian.base";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-345);
+ref = "mWestCree-canadian";
+}
+);
+width = 369;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+glyphname = "pWestCree-canadian.mid";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "pWestCree-canadian";
+}
+);
+width = 196;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.mid";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "c-canadian";
+}
+);
+width = 363;
+}
+);
+metricLeft = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "mWestCree-canadian.mid";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-162);
+ref = "mWestCree-canadian";
+}
+);
+width = 369;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+color = 11;
+glyphname = "ngaai-canadian.nunavik";
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (646,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (819,0);
+ref = ring_top.canadian;
+}
+);
+width = 1227;
+}
+);
+note = uni158E;
+},
+{
+color = 11;
+glyphname = "ngi-canadian.nunavik";
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (646,0);
+ref = "ci-canadian";
+}
+);
+width = 1227;
+}
+);
+note = uni158F;
+},
+{
+color = 11;
+glyphname = "ngii-canadian.nunavik";
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (646,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (871,0);
+ref = dot_top;
+}
+);
+width = 1227;
+}
+);
+note = uni1590;
+},
+{
+color = 11;
+glyphname = "ngo-canadian.nunavik";
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (646,0);
+ref = "co-canadian";
+}
+);
+width = 1228;
+}
+);
+note = uni1591;
+},
+{
+color = 11;
+glyphname = "ngoo-canadian.nunavik";
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+ref = "ngo-canadian.nunavik";
+},
+{
+anchor = top_right_can;
+pos = (1038,0);
+ref = dot_top;
+}
+);
+width = 1228;
+}
+);
+note = uni1592;
+},
+{
+color = 11;
+glyphname = "nga-canadian.nunavik";
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (646,0);
+ref = "ca-canadian";
+}
+);
+width = 1227;
+}
+);
+note = uni1593;
+},
+{
+color = 11;
+glyphname = "ngaa-canadian.nunavik";
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (646,0);
+ref = "ca-canadian";
+},
+{
+anchor = top_left_can;
+pos = (690,0);
+ref = dot_top;
+}
+);
+width = 1227;
+}
+);
+note = uni1594;
+},
+{
+color = 11;
+glyphname = "ng-canadian.nunavik";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(538,158,o),
+(592,208,o),
+(592,292,cs),
+(592,371,o),
+(543,420,o),
+(477,420,cs),
+(437,420,o),
+(405,395,o),
+(396,359,c),
+(407,357,l),
+(407,497,l),
+(258,497,l),
+(263,479,l),
+(290,493,o),
+(306,529,o),
+(306,569,cs),
+(306,646,o),
+(257,696,o),
+(181,696,cs),
+(105,696,o),
+(54,645,o),
+(54,566,cs),
+(54,487,o),
+(104,435,o),
+(186,435,cs),
+(382,435,l),
+(338,477,l),
+(338,293,ls),
+(338,211,o),
+(388,158,o),
+(467,158,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(426,210,o),
+(401,237,o),
+(401,290,cs),
+(401,341,o),
+(429,369,o),
+(466,369,cs),
+(504,369,o),
+(531,341,o),
+(531,290,cs),
+(531,239,o),
+(504,210,o),
+(467,210,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(142,485,o),
+(115,515,o),
+(115,566,cs),
+(115,616,o),
+(142,645,o),
+(181,645,cs),
+(219,645,o),
+(245,616,o),
+(245,565,cs),
+(245,515,o),
+(219,485,o),
+(181,485,cs)
+);
+}
+);
+width = 646;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+color = 11;
+glyphname = "ngai-canadian.nunavik";
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (646,0);
+ref = "ce-canadian";
+}
+);
+width = 1228;
+}
+);
+note = uni1670;
+},
+{
+color = 11;
+glyphname = "ke-canadian.square";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (341,690);
+},
+{
+name = top_left_can;
+pos = (120,690);
+},
+{
+name = top_right_can;
+pos = (573,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(620,0,l),
+(620,690,l),
+(370,690,ls),
+(173,690,o),
+(62,585,o),
+(62,412,cs),
+(62,238,o),
+(173,134,o),
+(370,134,cs),
+(525,134,l),
+(525,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(230,218,o),
+(157,289,o),
+(157,412,cs),
+(157,535,o),
+(230,605,o),
+(366,605,cs),
+(525,605,l),
+(525,218,l),
+(366,218,ls)
+);
+}
+);
+width = 695;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146B;
+},
+{
+color = 11;
+glyphname = "ki-canadian.square";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (355,690);
+},
+{
+name = top_left_can;
+pos = (124,690);
+},
+{
+name = top_right_can;
+pos = (586,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(172,0,l),
+(172,134,l),
+(327,134,ls),
+(524,134,o),
+(635,238,o),
+(635,412,cs),
+(635,585,o),
+(524,690,o),
+(327,690,cs),
+(75,690,l),
+(75,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(172,605,l),
+(329,605,ls),
+(467,605,o),
+(538,535,o),
+(538,412,cs),
+(538,289,o),
+(467,218,o),
+(329,218,cs),
+(172,218,l)
+);
+}
+);
+width = 697;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni146D;
+},
+{
+color = 11;
+glyphname = "kii-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (282,0);
+ref = dot_top;
+}
+);
+width = 697;
+}
+);
+note = uni146E;
+},
+{
+color = 11;
+glyphname = "ko-canadian.square";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (341,690);
+},
+{
+name = top_left_can;
+pos = (120,690);
+},
+{
+name = top_right_can;
+pos = (573,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(620,0,l),
+(620,690,l),
+(525,690,l),
+(525,555,l),
+(370,555,ls),
+(173,555,o),
+(62,452,o),
+(62,278,cs),
+(62,104,o),
+(173,0,o),
+(370,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(230,85,o),
+(157,155,o),
+(157,278,cs),
+(157,401,o),
+(230,471,o),
+(366,471,cs),
+(525,471,l),
+(525,85,l),
+(366,85,ls)
+);
+}
+);
+width = 695;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146F;
+},
+{
+color = 11;
+glyphname = "koo-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (500,0);
+ref = dot_top;
+}
+);
+width = 697;
+}
+);
+note = uni1470;
+},
+{
+color = 11;
+glyphname = "ka-canadian.square";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (355,690);
+},
+{
+name = top_left_can;
+pos = (124,690);
+},
+{
+name = top_right_can;
+pos = (586,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(327,0,ls),
+(524,0,o),
+(635,104,o),
+(635,278,cs),
+(635,452,o),
+(524,555,o),
+(327,555,cs),
+(172,555,l),
+(172,690,l),
+(75,690,l),
+(75,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(172,471,l),
+(329,471,ls),
+(467,471,o),
+(538,401,o),
+(538,278,cs),
+(538,155,o),
+(467,85,o),
+(329,85,cs),
+(172,85,l)
+);
+}
+);
+width = 697;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1472;
+},
+{
+color = 11;
+glyphname = "kaa-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+}
+);
+width = 697;
+}
+);
+note = uni1473;
+},
+{
+color = 11;
+glyphname = "kweWestCree-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (697,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 922;
+}
+);
+note = uni1475;
+},
+{
+color = 11;
+glyphname = "kwiiWestCree-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (282,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (697,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 922;
+}
+);
+note = uni1479;
+},
+{
+color = 11;
+glyphname = "kwoWestCree-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (697,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 922;
+}
+);
+note = uni147B;
+},
+{
+color = 11;
+glyphname = "kwooWestCree-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (500,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (697,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 922;
+}
+);
+note = uni147D;
+},
+{
+color = 11;
+glyphname = "kwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (697,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 922;
+}
+);
+note = uni147F;
+},
+{
+color = 11;
+glyphname = "kwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (697,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 922;
+}
+);
+note = uni1481;
+},
+{
+color = 11;
+glyphname = "ce-canadian.square";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (348,690);
+},
+{
+name = top_left_can;
+pos = (107,690);
+},
+{
+name = top_right_can;
+pos = (587,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(636,0,l),
+(636,395,ls),
+(636,595,o),
+(530,702,o),
+(342,702,cs),
+(162,702,o),
+(59,596,o),
+(59,419,cs),
+(59,386,l),
+(155,386,l),
+(155,423,ls),
+(155,550,o),
+(225,615,o),
+(341,615,cs),
+(473,615,o),
+(539,542,o),
+(539,390,cs),
+(539,0,l)
+);
+}
+);
+width = 705;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni1489;
+},
+{
+color = 11;
+glyphname = "ci-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (356,690);
+},
+{
+name = top_left_can;
+pos = (117,690);
+},
+{
+name = top_right_can;
+pos = (597,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(164,0,l),
+(164,390,ls),
+(164,542,o),
+(230,615,o),
+(363,615,cs),
+(479,615,o),
+(549,550,o),
+(549,423,cs),
+(549,386,l),
+(644,386,l),
+(644,419,ls),
+(644,596,o),
+(542,702,o),
+(361,702,cs),
+(174,702,o),
+(69,595,o),
+(69,395,cs),
+(69,0,l)
+);
+}
+);
+width = 703;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+},
+{
+color = 11;
+glyphname = "cii-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (283,0);
+ref = dot_top;
+}
+);
+width = 703;
+}
+);
+note = uni148C;
+},
+{
+color = 11;
+glyphname = "co-canadian.square";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (348,690);
+},
+{
+name = top_left_can;
+pos = (107,690);
+},
+{
+name = top_right_can;
+pos = (587,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(530,-13,o),
+(636,95,o),
+(636,295,cs),
+(636,690,l),
+(539,690,l),
+(539,299,ls),
+(539,148,o),
+(473,74,o),
+(341,74,cs),
+(225,74,o),
+(155,140,o),
+(155,267,cs),
+(155,303,l),
+(59,303,l),
+(59,270,ls),
+(59,94,o),
+(162,-13,o),
+(342,-13,cs)
+);
+}
+);
+width = 705;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+},
+{
+color = 11;
+glyphname = "coo-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (514,0);
+ref = dot_top;
+}
+);
+width = 703;
+}
+);
+note = uni148E;
+},
+{
+color = 11;
+glyphname = "ca-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (356,690);
+},
+{
+name = top_left_can;
+pos = (117,690);
+},
+{
+name = top_right_can;
+pos = (597,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(542,-13,o),
+(644,94,o),
+(644,270,cs),
+(644,303,l),
+(549,303,l),
+(549,267,ls),
+(549,140,o),
+(479,74,o),
+(363,74,cs),
+(230,74,o),
+(164,148,o),
+(164,299,cs),
+(164,690,l),
+(69,690,l),
+(69,295,ls),
+(69,95,o),
+(174,-13,o),
+(361,-13,cs)
+);
+}
+);
+width = 703;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+},
+{
+color = 11;
+glyphname = "caa-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (43,0);
+ref = dot_top;
+}
+);
+width = 703;
+}
+);
+note = uni1491;
+},
+{
+color = 11;
+glyphname = "me-canadian.square";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (287,690);
+},
+{
+name = top_double;
+pos = (481,690);
+},
+{
+name = top_left_can;
+pos = (88,690);
+},
+{
+name = top_right_can;
+pos = (481,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(528,0,l),
+(528,690,l),
+(40,690,l),
+(40,603,l),
+(433,603,l),
+(433,0,l)
+);
+}
+);
+width = 603;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+},
+{
+color = 11;
+glyphname = "mi-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (320,690);
+},
+{
+name = top_left_can;
+pos = (124,690);
+},
+{
+name = top_right_can;
+pos = (516,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(172,0,l),
+(172,603,l),
+(564,603,l),
+(564,690,l),
+(75,690,l),
+(75,0,l)
+);
+}
+);
+width = 604;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+},
+{
+color = 11;
+glyphname = "mii-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (246,0);
+ref = dot_top;
+}
+);
+width = 605;
+}
+);
+note = uni14A6;
+},
+{
+color = 11;
+glyphname = "mo-canadian.square";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (287,690);
+},
+{
+name = top_double;
+pos = (481,690);
+},
+{
+name = top_left_can;
+pos = (88,690);
+},
+{
+name = top_right_can;
+pos = (481,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(528,0,l),
+(528,690,l),
+(433,690,l),
+(433,87,l),
+(40,87,l),
+(40,0,l)
+);
+}
+);
+width = 603;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+},
+{
+color = 11;
+glyphname = "moo-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (407,0);
+ref = dot_top;
+}
+);
+width = 605;
+}
+);
+note = uni14A8;
+},
+{
+color = 11;
+glyphname = "ma-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (320,690);
+},
+{
+name = top_left_can;
+pos = (124,690);
+},
+{
+name = top_right_can;
+pos = (516,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(564,0,l),
+(564,87,l),
+(172,87,l),
+(172,690,l),
+(75,690,l),
+(75,0,l)
+);
+}
+);
+width = 604;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+},
+{
+color = 11;
+glyphname = "maa-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+}
+);
+width = 605;
+}
+);
+note = uni14AB;
+},
+{
+color = 11;
+glyphname = "ne-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (438,690);
+},
+{
+name = top_left_can;
+pos = (246,690);
+},
+{
+name = top_right_can;
+pos = (634,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(592,-13,o),
+(682,84,o),
+(682,258,cs),
+(682,690,l),
+(55,690,l),
+(55,605,l),
+(198,605,l),
+(198,258,ls),
+(198,84,o),
+(287,-13,o),
+(440,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(344,75,o),
+(294,135,o),
+(294,249,cs),
+(294,605,l),
+(585,605,l),
+(585,249,ls),
+(585,135,o),
+(535,75,o),
+(440,75,cs)
+);
+}
+);
+width = 751;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C0;
+},
+{
+color = 11;
+glyphname = "ni-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (310,690);
+},
+{
+name = top_left_can;
+pos = (116,690);
+},
+{
+name = top_right_can;
+pos = (504,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(463,-13,o),
+(552,84,o),
+(552,258,cs),
+(552,605,l),
+(695,605,l),
+(695,690,l),
+(69,690,l),
+(69,258,ls),
+(69,84,o),
+(157,-13,o),
+(310,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(214,75,o),
+(164,135,o),
+(164,249,cs),
+(164,605,l),
+(456,605,l),
+(456,249,ls),
+(456,135,o),
+(406,75,o),
+(310,75,cs)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+},
+{
+color = 11;
+glyphname = "nii-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (237,0);
+ref = dot_top;
+}
+);
+width = 750;
+}
+);
+note = uni14C3;
+},
+{
+color = 11;
+glyphname = "no-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (440,690);
+},
+{
+name = top_double;
+pos = (449,690);
+},
+{
+name = top_left_can;
+pos = (246,690);
+},
+{
+name = top_right_can;
+pos = (629,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(682,0,l),
+(682,432,ls),
+(682,606,o),
+(592,702,o),
+(440,702,cs),
+(287,702,o),
+(198,606,o),
+(198,432,cs),
+(198,85,l),
+(55,85,l),
+(55,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(294,440,ls),
+(294,554,o),
+(344,614,o),
+(440,614,cs),
+(535,614,o),
+(585,554,o),
+(585,440,cs),
+(585,85,l),
+(294,85,l)
+);
+}
+);
+width = 751;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C4;
+},
+{
+color = 11;
+glyphname = "noo-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (366,0);
+ref = dot_top;
+}
+);
+width = 750;
+}
+);
+note = uni14C5;
+},
+{
+color = 11;
+glyphname = "na-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (310,690);
+},
+{
+name = top_double;
+pos = (320,690);
+},
+{
+name = top_left_can;
+pos = (116,690);
+},
+{
+name = top_right_can;
+pos = (504,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(695,0,l),
+(695,85,l),
+(552,85,l),
+(552,432,ls),
+(552,606,o),
+(463,702,o),
+(310,702,cs),
+(157,702,o),
+(69,606,o),
+(69,432,cs),
+(69,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(164,440,ls),
+(164,554,o),
+(214,614,o),
+(310,614,cs),
+(406,614,o),
+(456,554,o),
+(456,440,cs),
+(456,85,l),
+(164,85,l)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+},
+{
+color = 11;
+glyphname = "naa-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (237,0);
+ref = dot_top;
+}
+);
+width = 750;
+}
+);
+note = uni14C8;
+},
+{
+color = 11;
+glyphname = "nweWestCree-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (750,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni14CA;
+},
+{
+color = 11;
+glyphname = "nwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (750,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni14CC;
+},
+{
+color = 11;
+glyphname = "nwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (237,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (750,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni14CE;
+},
+{
+color = 11;
+glyphname = "se-canadian.square";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (122,690);
+},
+{
+name = top_right_can;
+pos = (573,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(619,0,l),
+(619,257,l),
+(400,257,ls),
+(247,257,o),
+(170,339,o),
+(170,496,cs),
+(170,690,l),
+(73,690,l),
+(73,493,ls),
+(73,289,o),
+(190,173,o),
+(402,173,cs),
+(550,173,l),
+(523,200,l),
+(523,0,l)
+);
+}
+);
+width = 694;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14ED;
+},
+{
+color = 11;
+glyphname = "si-canadian.square";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (125,690);
+},
+{
+name = top_right_can;
+pos = (576,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(172,0,l),
+(172,200,l),
+(145,173,l),
+(294,173,ls),
+(505,173,o),
+(621,289,o),
+(621,490,cs),
+(621,690,l),
+(526,690,l),
+(526,493,ls),
+(526,339,o),
+(448,257,o),
+(297,257,cs),
+(75,257,l),
+(75,0,l)
+);
+}
+);
+width = 694;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+},
+{
+color = 11;
+glyphname = "sii-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (502,0);
+ref = dot_top;
+}
+);
+width = 695;
+}
+);
+note = uni14F0;
+},
+{
+color = 11;
+glyphname = "so-canadian.square";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (572,690);
+},
+{
+name = top_left_can;
+pos = (122,690);
+},
+{
+name = top_right_can;
+pos = (572,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(170,0,l),
+(170,194,ls),
+(170,351,o),
+(247,433,o),
+(400,433,cs),
+(619,433,l),
+(619,690,l),
+(523,690,l),
+(523,490,l),
+(550,517,l),
+(402,517,ls),
+(190,517,o),
+(73,401,o),
+(73,197,cs),
+(73,0,l)
+);
+}
+);
+width = 694;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+},
+{
+color = 11;
+glyphname = "soo-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (497,0);
+ref = dot_top;
+}
+);
+width = 695;
+}
+);
+note = uni14F2;
+},
+{
+color = 11;
+glyphname = "sa-canadian.square";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (125,690);
+},
+{
+name = top_right_can;
+pos = (574,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(621,0,l),
+(621,197,ls),
+(621,401,o),
+(505,517,o),
+(294,517,cs),
+(145,517,l),
+(172,490,l),
+(172,690,l),
+(75,690,l),
+(75,433,l),
+(296,433,ls),
+(448,433,o),
+(526,351,o),
+(526,194,cs),
+(526,0,l)
+);
+}
+);
+width = 694;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+},
+{
+color = 11;
+glyphname = "saa-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+}
+);
+width = 695;
+}
+);
+note = uni14F5;
+},
+{
+color = 11;
+glyphname = "sho-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (346,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(613,0,l),
+(613,80,l),
+(298,80,ls),
+(200,80,o),
+(161,119,o),
+(161,192,cs),
+(161,267,o),
+(200,305,o),
+(298,305,cs),
+(408,305,ls),
+(559,305,o),
+(626,376,o),
+(626,498,cs),
+(626,620,o),
+(559,690,o),
+(408,690,cs),
+(77,690,l),
+(77,610,l),
+(392,610,ls),
+(491,610,o),
+(529,571,o),
+(529,498,cs),
+(529,427,o),
+(491,384,o),
+(392,384,cs),
+(283,384,ls),
+(131,384,o),
+(65,314,o),
+(65,192,cs),
+(65,70,o),
+(131,0,o),
+(283,0,cs)
+);
+}
+);
+width = 691;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+color = 11;
+glyphname = "shoo-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (272,0);
+ref = dot_top;
+}
+);
+width = 691;
+}
+);
+note = g728;
+},
+{
+color = 11;
+glyphname = "sha-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (346,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(408,0,ls),
+(555,0,o),
+(626,70,o),
+(626,191,cs),
+(626,314,o),
+(555,384,o),
+(408,384,cs),
+(298,384,ls),
+(200,384,o),
+(160,427,o),
+(160,497,cs),
+(160,571,o),
+(200,610,o),
+(298,610,cs),
+(613,610,l),
+(613,690,l),
+(283,690,ls),
+(134,690,o),
+(65,620,o),
+(65,497,cs),
+(65,376,o),
+(134,305,o),
+(283,305,cs),
+(392,305,ls),
+(491,305,o),
+(529,267,o),
+(529,191,cs),
+(529,119,o),
+(491,80,o),
+(392,80,cs),
+(76,80,l),
+(76,0,l)
+);
+}
+);
+width = 691;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+color = 11;
+glyphname = "shaa-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (272,0);
+ref = dot_top;
+}
+);
+width = 691;
+}
+);
+note = g730;
+},
+{
+color = 11;
+glyphname = "ye-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (91,690);
+},
+{
+name = top_right_can;
+pos = (599,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(646,0,l),
+(646,257,l),
+(180,257,l),
+(180,206,l),
+(659,638,l),
+(599,701,l),
+(42,203,l),
+(42,173,l),
+(551,173,l),
+(551,0,l)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "ye-canadian";
+note = uni1526;
+},
+{
+color = 11;
+glyphname = "yi-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (120,690);
+},
+{
+name = top_right_can;
+pos = (628,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(168,0,l),
+(168,173,l),
+(677,173,l),
+(677,203,l),
+(120,701,l),
+(60,638,l),
+(538,206,l),
+(539,257,l),
+(72,257,l),
+(72,0,l)
+);
+}
+);
+width = 719;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni1528;
+},
+{
+color = 11;
+glyphname = "yii-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (46,0);
+ref = dot_top;
+}
+);
+width = 719;
+}
+);
+note = uni1529;
+},
+{
+color = 11;
+glyphname = "yo-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (599,690);
+},
+{
+name = top_left_can;
+pos = (91,690);
+},
+{
+name = top_right_can;
+pos = (599,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(659,52,l),
+(180,484,l),
+(180,433,l),
+(646,433,l),
+(646,690,l),
+(551,690,l),
+(551,517,l),
+(42,517,l),
+(42,487,l),
+(599,-12,l)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152A;
+},
+{
+color = 11;
+glyphname = "yoo-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (526,0);
+ref = dot_top;
+}
+);
+width = 719;
+}
+);
+note = uni152B;
+},
+{
+color = 11;
+glyphname = "ya-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (121,690);
+},
+{
+name = top_right_can;
+pos = (628,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(677,487,l),
+(677,517,l),
+(168,517,l),
+(168,690,l),
+(72,690,l),
+(72,433,l),
+(539,433,l),
+(538,484,l),
+(60,52,l),
+(120,-12,l)
+);
+}
+);
+width = 719;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152D;
+},
+{
+color = 11;
+glyphname = "yaa-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (46,0);
+ref = dot_top;
+}
+);
+width = 719;
+}
+);
+note = uni152E;
+},
+{
+color = 11;
+glyphname = "re-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (310,690);
+},
+{
+name = top_left_can;
+pos = (116,690);
+},
+{
+name = top_right_can;
+pos = (504,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(463,-13,o),
+(552,84,o),
+(552,258,cs),
+(552,605,l),
+(695,605,l),
+(695,690,l),
+(456,690,l),
+(456,249,ls),
+(456,135,o),
+(406,75,o),
+(310,75,cs),
+(214,75,o),
+(164,135,o),
+(164,249,cs),
+(164,690,l),
+(69,690,l),
+(69,258,ls),
+(69,84,o),
+(157,-13,o),
+(310,-13,cs)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1542;
+},
+{
+color = 11;
+glyphname = "reRCree-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (440,690);
+},
+{
+name = top_left_can;
+pos = (246,690);
+},
+{
+name = top_right_can;
+pos = (634,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(592,-13,o),
+(682,84,o),
+(682,258,cs),
+(682,690,l),
+(585,690,l),
+(585,249,ls),
+(585,135,o),
+(535,75,o),
+(440,75,cs),
+(344,75,o),
+(294,135,o),
+(294,249,cs),
+(294,690,l),
+(55,690,l),
+(55,605,l),
+(198,605,l),
+(198,258,ls),
+(198,84,o),
+(287,-13,o),
+(440,-13,cs)
+);
+}
+);
+width = 751;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni1543;
+},
+{
+color = 11;
+glyphname = "leWestCree-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (440,690);
+},
+{
+name = top_left_can;
+pos = (246,690);
+},
+{
+name = top_right_can;
+pos = (634,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(294,0,l),
+(294,440,ls),
+(294,554,o),
+(344,614,o),
+(440,614,cs),
+(535,614,o),
+(585,554,o),
+(585,440,cs),
+(585,0,l),
+(682,0,l),
+(682,432,ls),
+(682,605,o),
+(592,702,o),
+(440,702,cs),
+(287,702,o),
+(198,605,o),
+(198,432,cs),
+(198,85,l),
+(55,85,l),
+(55,0,l)
+);
+}
+);
+width = 753;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+},
+{
+color = 11;
+glyphname = "ri-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (310,690);
+},
+{
+name = top_left_can;
+pos = (120,690);
+},
+{
+name = top_right_can;
+pos = (504,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(164,0,l),
+(164,440,ls),
+(164,554,o),
+(214,614,o),
+(310,614,cs),
+(406,614,o),
+(456,554,o),
+(456,440,cs),
+(456,0,l),
+(695,0,l),
+(695,85,l),
+(552,85,l),
+(552,432,ls),
+(552,606,o),
+(463,702,o),
+(310,702,cs),
+(157,702,o),
+(69,606,o),
+(69,432,cs),
+(69,0,l)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+},
+{
+color = 11;
+glyphname = "rii-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (237,0);
+ref = dot_top;
+}
+);
+width = 750;
+}
+);
+note = uni1547;
+},
+{
+color = 11;
+glyphname = "ro-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (347,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(172,0,l),
+(172,162,l),
+(142,134,l),
+(308,134,ls),
+(505,134,o),
+(616,238,o),
+(616,412,cs),
+(616,585,o),
+(505,690,o),
+(308,690,cs),
+(75,690,l),
+(75,605,l),
+(312,605,ls),
+(448,605,o),
+(521,535,o),
+(521,412,cs),
+(521,289,o),
+(448,218,o),
+(312,218,cs),
+(75,218,l),
+(75,0,l)
+);
+}
+);
+width = 678;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1548;
+},
+{
+color = 11;
+glyphname = "loWestCree-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (347,690);
+},
+{
+name = top_left_can;
+pos = (124,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(308,0,ls),
+(505,0,o),
+(616,104,o),
+(616,278,cs),
+(616,452,o),
+(505,555,o),
+(308,555,cs),
+(142,555,l),
+(172,527,l),
+(172,690,l),
+(75,690,l),
+(75,471,l),
+(312,471,ls),
+(448,471,o),
+(521,401,o),
+(521,278,cs),
+(521,155,o),
+(448,85,o),
+(312,85,cs),
+(75,85,l),
+(75,0,l)
+);
+}
+);
+width = 674;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+},
+{
+color = 11;
+glyphname = "ra-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (328,690);
+},
+{
+name = top_right_can;
+pos = (552,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(599,0,l),
+(599,218,l),
+(363,218,ls),
+(226,218,o),
+(155,289,o),
+(155,412,cs),
+(155,535,o),
+(226,605,o),
+(363,605,cs),
+(599,605,l),
+(599,690,l),
+(366,690,ls),
+(169,690,o),
+(58,585,o),
+(58,412,cs),
+(58,238,o),
+(169,134,o),
+(366,134,cs),
+(533,134,l),
+(503,162,l),
+(503,0,l)
+);
+}
+);
+width = 674;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+},
+{
+color = 11;
+glyphname = "raa-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (255,0);
+ref = dot_top;
+}
+);
+width = 675;
+}
+);
+note = uni154C;
+},
+{
+color = 11;
+glyphname = "laWestCree-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (552,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(599,0,l),
+(599,85,l),
+(363,85,ls),
+(226,85,o),
+(155,155,o),
+(155,278,cs),
+(155,401,o),
+(226,471,o),
+(363,471,cs),
+(599,471,l),
+(599,690,l),
+(503,690,l),
+(503,527,l),
+(533,555,l),
+(366,555,ls),
+(169,555,o),
+(58,452,o),
+(58,278,cs),
+(58,104,o),
+(169,0,o),
+(366,0,cs)
+);
+}
+);
+width = 674;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+},
+{
+color = 11;
+glyphname = "reWestCree-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(625,0,l),
+(862,195,l),
+(810,261,l),
+(574,68,l),
+(636,67,l),
+(636,395,ls),
+(636,595,o),
+(530,702,o),
+(342,702,cs),
+(162,702,o),
+(59,596,o),
+(59,419,cs),
+(59,386,l),
+(155,386,l),
+(155,423,ls),
+(155,550,o),
+(225,615,o),
+(341,615,cs),
+(473,615,o),
+(539,542,o),
+(539,390,cs),
+(539,0,l)
+);
+}
+);
+width = 887;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+},
+{
+color = 11;
+glyphname = "riWestCree-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(347,0,l),
+(347,390,ls),
+(347,542,o),
+(413,615,o),
+(546,615,cs),
+(662,615,o),
+(732,550,o),
+(732,423,cs),
+(732,386,l),
+(827,386,l),
+(827,419,ls),
+(827,596,o),
+(725,702,o),
+(544,702,cs),
+(356,702,o),
+(251,595,o),
+(251,395,cs),
+(251,67,l),
+(313,68,l),
+(77,261,l),
+(25,195,l),
+(262,0,l)
+);
+}
+);
+width = 886;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+},
+{
+color = 11;
+glyphname = "roWestCree-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(530,-13,o),
+(636,95,o),
+(636,295,cs),
+(636,623,l),
+(574,622,l),
+(810,429,l),
+(862,495,l),
+(625,690,l),
+(539,690,l),
+(539,299,ls),
+(539,148,o),
+(473,74,o),
+(341,74,cs),
+(225,74,o),
+(155,140,o),
+(155,267,cs),
+(155,303,l),
+(59,303,l),
+(59,270,ls),
+(59,94,o),
+(162,-13,o),
+(342,-13,cs)
+);
+}
+);
+width = 887;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+},
+{
+color = 11;
+glyphname = "raWestCree-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(725,-13,o),
+(827,94,o),
+(827,270,cs),
+(827,303,l),
+(732,303,l),
+(732,267,ls),
+(732,140,o),
+(662,74,o),
+(546,74,cs),
+(413,74,o),
+(347,148,o),
+(347,299,cs),
+(347,690,l),
+(262,690,l),
+(25,495,l),
+(77,429,l),
+(313,622,l),
+(251,623,l),
+(251,295,ls),
+(251,95,o),
+(356,-13,o),
+(544,-13,cs)
+);
+}
+);
+width = 886;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+},
+{
+color = 11;
+glyphname = "theThCree-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (91,690);
+},
+{
+name = top_right_can;
+pos = (599,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(551,64,l),
+(551,0,l),
+(646,0,l),
+(646,64,l),
+(729,64,l),
+(729,111,l),
+(646,111,l),
+(646,257,l),
+(180,257,l),
+(180,206,l),
+(659,638,l),
+(599,701,l),
+(42,203,l),
+(42,173,l),
+(551,173,l),
+(551,111,l),
+(313,111,l),
+(313,64,l)
+);
+}
+);
+width = 762;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15A7;
+},
+{
+color = 11;
+glyphname = "thiThCree-canadian.square";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (156,690);
+},
+{
+name = top_right_can;
+pos = (664,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(213,0,l),
+(213,64,l),
+(449,64,l),
+(449,111,l),
+(213,111,l),
+(213,173,l),
+(721,173,l),
+(721,203,l),
+(164,701,l),
+(103,638,l),
+(582,206,l),
+(583,257,l),
+(116,257,l),
+(116,111,l),
+(33,111,l),
+(33,64,l),
+(116,64,l),
+(116,0,l)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+},
+{
+color = 11;
+glyphname = "thiiThCree-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (82,0);
+ref = dot_top;
+}
+);
+width = 762;
+}
+);
+note = uni15A9;
+},
+{
+color = 11;
+glyphname = "thoThCree-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (91,690);
+},
+{
+name = top_right_can;
+pos = (599,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(659,52,l),
+(180,484,l),
+(180,433,l),
+(646,433,l),
+(646,579,l),
+(729,579,l),
+(729,626,l),
+(646,626,l),
+(646,690,l),
+(551,690,l),
+(551,626,l),
+(313,626,l),
+(313,579,l),
+(551,579,l),
+(551,517,l),
+(42,517,l),
+(42,487,l),
+(599,-12,l)
+);
+}
+);
+width = 762;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+},
+{
+color = 11;
+glyphname = "thooThCree-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (526,0);
+ref = dot_top;
+}
+);
+width = 762;
+}
+);
+note = uni15AB;
+},
+{
+color = 11;
+glyphname = "thaThCree-canadian.square";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (164,690);
+},
+{
+name = top_right_can;
+pos = (672,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(721,487,l),
+(721,517,l),
+(213,517,l),
+(213,579,l),
+(449,579,l),
+(449,626,l),
+(213,626,l),
+(213,690,l),
+(116,690,l),
+(116,626,l),
+(33,626,l),
+(33,579,l),
+(116,579,l),
+(116,433,l),
+(583,433,l),
+(582,484,l),
+(103,52,l),
+(164,-12,l)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+},
+{
+color = 11;
+glyphname = "thaaThCree-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (91,0);
+ref = dot_top;
+}
+);
+width = 762;
+}
+);
+note = uni15AD;
+},
+{
+color = 11;
+glyphname = "thweeWoodScree-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (762,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 987;
+}
+);
+note = uni1677;
+},
+{
+color = 11;
+glyphname = "thwiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (762,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 987;
+}
+);
+note = uni1678;
+},
+{
+color = 11;
+glyphname = "thwiiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (82,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (762,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 987;
+}
+);
+note = uni1679;
+},
+{
+color = 11;
+glyphname = "thwoWoodScree-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (762,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 987;
+}
+);
+note = uni167A;
+},
+{
+color = 11;
+glyphname = "thwooWoodScree-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (526,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (762,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 987;
+}
+);
+note = uni167B;
+},
+{
+color = 11;
+glyphname = "thwaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (762,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 987;
+}
+);
+note = uni167C;
+},
+{
+color = 11;
+glyphname = "thwaaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (91,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (762,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 987;
+}
+);
+note = uni167D;
+},
+{
+color = 11;
+glyphname = "nwiOjibway-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (750,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni18C7;
+},
+{
+color = 11;
+glyphname = "nwiiOjibway-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (237,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (750,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni18C9;
+},
+{
+color = 11;
+glyphname = "nwoOjibway-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (750,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni18CB;
+},
+{
+color = 11;
+glyphname = "nwooOjibway-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (366,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (750,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni18CD;
+},
+{
+color = 11;
+glyphname = "looWestCree-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+}
+);
+width = 675;
+}
+);
+note = uni18E1;
+},
+{
+color = 11;
+glyphname = "laaWestCree-canadian.square";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (478,0);
+ref = dot_top;
+}
+);
+width = 675;
+}
+);
+note = uni18E2;
+},
+{
+color = 0;
+glyphname = zero;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(518,552,o),
+(460,700,o),
+(288,700,cs),
+(114,700,o),
+(57,542,o),
+(57,346,cs),
+(57,108,o),
+(139,-10,o),
+(288,-10,cs),
+(442,-10,o),
+(518,106,o),
+(518,346,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(155,467,o),
+(171,620,o),
+(288,620,cs),
+(411,620,o),
+(420,460,o),
+(420,346,cs),
+(420,192,o),
+(390,71,o),
+(288,71,cs),
+(188,71,o),
+(155,191,o),
+(155,346,cs)
+);
+}
+);
+width = 574;
+}
+);
+unicode = 48;
+},
+{
+color = 0;
+glyphname = one;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(227,690,l),
+(16,527,l),
+(69,463,l),
+(169,540,ls),
+(189,555,o),
+(202,568,o),
+(217,583,c),
+(216,552,o),
+(215,523,o),
+(215,492,cs),
+(215,0,l),
+(314,0,l),
+(314,690,l)
+);
+}
+);
+width = 434;
+}
+);
+unicode = 49;
+},
+{
+color = 0;
+glyphname = two;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(494,0,l),
+(494,82,l),
+(166,82,l),
+(166,85,l),
+(299,222,ls),
+(373,295,o),
+(425,350,o),
+(451,412,cs),
+(464,442,o),
+(470,477,o),
+(470,517,cs),
+(470,626,o),
+(387,699,o),
+(266,699,cs),
+(178,699,o),
+(110,668,o),
+(47,613,c),
+(100,549,l),
+(155,594,o),
+(207,615,o),
+(256,615,cs),
+(327,615,o),
+(373,577,o),
+(373,504,cs),
+(373,450,o),
+(355,409,o),
+(314,359,cs),
+(294,334,o),
+(267,304,o),
+(234,270,cs),
+(40,68,l),
+(40,0,l)
+);
+}
+);
+width = 543;
+}
+);
+unicode = 50;
+},
+{
+color = 0;
+glyphname = three;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(466,639,o),
+(384,699,o),
+(258,699,cs),
+(156,699,o),
+(89,670,o),
+(32,629,c),
+(74,561,l),
+(121,594,o),
+(178,619,o),
+(244,619,cs),
+(320,619,o),
+(370,585,o),
+(370,516,cs),
+(370,429,o),
+(286,394,o),
+(197,394,cs),
+(133,394,l),
+(133,318,l),
+(197,318,ls),
+(313,318,o),
+(384,287,o),
+(384,197,cs),
+(384,119,o),
+(332,70,o),
+(214,70,cs),
+(153,70,o),
+(82,87,o),
+(27,114,c),
+(27,30,l),
+(81,7,o),
+(144,-10,o),
+(226,-10,cs),
+(383,-10,o),
+(486,65,o),
+(486,191,cs),
+(486,293,o),
+(425,347,o),
+(316,360,c),
+(316,362,l),
+(401,382,o),
+(466,443,o),
+(466,536,cs)
+);
+}
+);
+width = 533;
+}
+);
+unicode = 51;
+},
+{
+color = 0;
+glyphname = four;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(454,239,l),
+(454,692,l),
+(361,692,l),
+(35,235,l),
+(35,163,l),
+(357,163,l),
+(357,0,l),
+(454,0,l),
+(454,163,l),
+(559,163,l),
+(559,239,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(126,239,l),
+(306,489,ls),
+(330,522,o),
+(339,537,o),
+(356,569,c),
+(359,569,l),
+(359,554,o),
+(357,520,o),
+(357,474,cs),
+(357,239,l)
+);
+}
+);
+width = 586;
+}
+);
+unicode = 52;
+},
+{
+color = 0;
+glyphname = five;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(216,430,o),
+(185,421,o),
+(157,415,c),
+(175,607,l),
+(446,607,l),
+(446,690,l),
+(92,690,l),
+(64,355,l),
+(105,332,l),
+(143,344,o),
+(183,352,o),
+(231,352,cs),
+(337,352,o),
+(390,301,o),
+(390,216,cs),
+(390,123,o),
+(326,70,o),
+(223,70,cs),
+(158,70,o),
+(92,90,o),
+(46,114,c),
+(46,30,l),
+(92,6,o),
+(154,-10,o),
+(230,-10,cs),
+(397,-10,o),
+(490,76,o),
+(490,218,cs),
+(490,353,o),
+(403,430,o),
+(273,430,cs)
+);
+}
+);
+width = 536;
+}
+);
+unicode = 53;
+},
+{
+color = 0;
+glyphname = six;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(56,128,o),
+(130,-10,o),
+(296,-10,cs),
+(434,-10,o),
+(519,80,o),
+(519,226,cs),
+(519,359,o),
+(445,440,o),
+(321,440,cs),
+(233,440,o),
+(176,398,o),
+(148,342,c),
+(144,342,l),
+(150,508,o),
+(212,622,o),
+(375,622,cs),
+(417,622,o),
+(449,617,o),
+(473,611,c),
+(473,690,l),
+(447,696,o),
+(411,700,o),
+(377,700,cs),
+(140,700,o),
+(56,528,o),
+(56,293,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(189,70,o),
+(156,170,o),
+(156,245,cs),
+(156,309,o),
+(223,362,o),
+(297,362,cs),
+(383,362,o),
+(423,310,o),
+(423,224,cs),
+(423,127,o),
+(376,70,o),
+(294,70,cs)
+);
+}
+);
+width = 561;
+}
+);
+unicode = 54;
+},
+{
+color = 0;
+glyphname = seven;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(483,631,l),
+(483,690,l),
+(19,690,l),
+(19,607,l),
+(378,607,l),
+(113,0,l),
+(215,0,l)
+);
+}
+);
+width = 507;
+}
+);
+unicode = 55;
+},
+{
+color = 0;
+glyphname = eight;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(417,-10,o),
+(514,57,o),
+(514,179,cs),
+(514,274,o),
+(443,329,o),
+(352,366,c),
+(437,403,o),
+(493,453,o),
+(493,537,cs),
+(493,642,o),
+(410,699,o),
+(285,699,cs),
+(160,699,o),
+(76,639,o),
+(76,536,cs),
+(76,444,o),
+(144,397,o),
+(211,364,c),
+(118,328,o),
+(55,275,o),
+(55,175,cs),
+(55,66,o),
+(136,-10,o),
+(282,-10,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,64,o),
+(146,108,o),
+(146,178,cs),
+(146,257,o),
+(213,297,o),
+(282,322,c),
+(374,286,o),
+(423,244,o),
+(423,180,cs),
+(423,104,o),
+(368,64,o),
+(281,64,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(216,437,o),
+(169,470,o),
+(169,528,cs),
+(169,591,o),
+(219,626,o),
+(284,626,cs),
+(355,626,o),
+(400,592,o),
+(400,529,cs),
+(400,471,o),
+(356,440,o),
+(285,409,c)
+);
+}
+);
+width = 568;
+}
+);
+unicode = 56;
+},
+{
+color = 0;
+glyphname = nine;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(504,567,o),
+(431,699,o),
+(265,699,cs),
+(126,699,o),
+(42,611,o),
+(42,466,cs),
+(42,331,o),
+(115,249,o),
+(237,249,cs),
+(325,249,o),
+(384,291,o),
+(412,349,c),
+(415,349,l),
+(409,175,o),
+(340,68,o),
+(179,68,cs),
+(141,68,o),
+(107,72,o),
+(82,79,c),
+(82,-2,l),
+(108,-8,o),
+(150,-11,o),
+(184,-11,cs),
+(420,-11,o),
+(504,164,o),
+(504,394,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(372,619,o),
+(404,517,o),
+(404,445,cs),
+(404,382,o),
+(334,327,o),
+(264,327,cs),
+(180,327,o),
+(136,382,o),
+(136,467,cs),
+(136,565,o),
+(184,619,o),
+(267,619,cs)
+);
+}
+);
+width = 560;
+}
+);
+unicode = 57;
+},
+{
+glyphname = zero.canadian;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(539,584,o),
+(447,702,o),
+(298,702,cs),
+(148,702,o),
+(57,584,o),
+(57,345,cs),
+(57,105,o),
+(148,-12,o),
+(298,-12,cs),
+(447,-12,o),
+(539,105,o),
+(539,345,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(153,532,o),
+(203,616,o),
+(298,616,cs),
+(393,616,o),
+(443,532,o),
+(443,345,cs),
+(443,157,o),
+(393,75,o),
+(298,75,cs),
+(202,75,o),
+(153,157,o),
+(153,345,cs)
+);
+}
+);
+width = 596;
+}
+);
+metricRight = "=|";
+},
+{
+glyphname = one.canadian;
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(301,0,l),
+(301,690,l),
+(215,690,l),
+(20,528,l),
+(73,463,l),
+(266,622,l),
+(206,626,l),
+(206,0,l)
+);
+}
+);
+width = 376;
+}
+);
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = two.canadian;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(526,87,l),
+(190,87,l),
+(191,55,l),
+(404,272,ls),
+(497,365,o),
+(516,429,o),
+(516,501,cs),
+(516,618,o),
+(435,702,o),
+(298,702,cs),
+(147,702,o),
+(59,605,o),
+(58,452,c),
+(153,452,l),
+(153,557,o),
+(203,618,o),
+(296,618,cs),
+(379,618,o),
+(419,568,o),
+(419,498,cs),
+(419,443,o),
+(406,393,o),
+(327,314,cs),
+(79,65,l),
+(79,0,l),
+(526,0,l)
+);
+}
+);
+width = 581;
+}
+);
+note = uni14BF;
+},
+{
+glyphname = three.canadian;
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(445,-13,o),
+(534,62,o),
+(534,187,cs),
+(534,277,o),
+(483,347,o),
+(389,362,c),
+(388,329,l),
+(476,345,o),
+(525,413,o),
+(525,501,cs),
+(525,627,o),
+(440,702,o),
+(308,702,cs),
+(159,702,o),
+(72,609,o),
+(69,467,c),
+(163,467,l),
+(164,560,o),
+(213,618,o),
+(306,618,cs),
+(385,618,o),
+(429,576,o),
+(429,497,cs),
+(429,422,o),
+(390,385,o),
+(318,385,cs),
+(282,385,l),
+(282,304,l),
+(322,304,ls),
+(397,304,o),
+(438,267,o),
+(438,191,cs),
+(438,111,o),
+(391,71,o),
+(303,71,cs),
+(205,71,o),
+(157,127,o),
+(156,223,c),
+(61,223,l),
+(64,76,o),
+(149,-13,o),
+(304,-13,cs)
+);
+}
+);
+width = 605;
+}
+);
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = four.canadian;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(454,0,l),
+(454,163,l),
+(555,163,l),
+(555,242,l),
+(454,242,l),
+(454,692,l),
+(377,692,l),
+(43,226,l),
+(43,163,l),
+(360,163,l),
+(360,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(394,600,l),
+(361,600,l),
+(361,242,l),
+(123,242,l),
+(125,219,l)
+);
+}
+);
+width = 587;
+}
+);
+},
+{
+glyphname = five.canadian;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(457,-13,o),
+(542,72,o),
+(542,204,cs),
+(542,338,o),
+(458,411,o),
+(309,411,cs),
+(174,411,l),
+(202,384,l),
+(223,633,l),
+(193,606,l),
+(516,606,l),
+(516,690,l),
+(135,690,l),
+(107,349,l),
+(128,327,l),
+(296,327,ls),
+(398,327,o),
+(447,288,o),
+(447,201,cs),
+(447,118,o),
+(398,71,o),
+(311,71,cs),
+(213,71,o),
+(169,120,o),
+(167,198,c),
+(72,198,l),
+(76,68,o),
+(157,-13,o),
+(311,-13,cs)
+);
+}
+);
+width = 601;
+}
+);
+},
+{
+glyphname = six.canadian;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(452,-13,o),
+(542,74,o),
+(542,206,cs),
+(542,338,o),
+(455,420,o),
+(326,420,cs),
+(232,420,o),
+(158,375,o),
+(135,284,c),
+(157,258,l),
+(154,298,o),
+(153,322,o),
+(153,369,cs),
+(153,536,o),
+(201,619,o),
+(311,619,cs),
+(395,619,o),
+(437,565,o),
+(443,495,c),
+(538,495,l),
+(526,617,o),
+(451,702,o),
+(314,702,cs),
+(152,702,o),
+(57,586,o),
+(57,349,cs),
+(57,201,o),
+(80,114,o),
+(133,56,cs),
+(179,8,o),
+(239,-13,o),
+(312,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(219,68,o),
+(166,122,o),
+(166,209,cs),
+(166,289,o),
+(225,340,o),
+(311,340,cs),
+(401,340,o),
+(449,289,o),
+(449,205,cs),
+(449,121,o),
+(396,68,o),
+(310,68,cs)
+);
+}
+);
+width = 591;
+}
+);
+metricLeft = zero.canadian;
+},
+{
+glyphname = seven.canadian;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(455,631,l),
+(455,690,l),
+(30,690,l),
+(30,603,l),
+(360,603,l),
+(360,634,l),
+(121,26,l),
+(121,0,l),
+(214,0,l)
+);
+}
+);
+width = 488;
+}
+);
+},
+{
+glyphname = eight.canadian;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(458,-13,o),
+(552,65,o),
+(552,183,cs),
+(552,282,o),
+(486,347,o),
+(397,360,c),
+(391,331,l),
+(473,344,o),
+(536,408,o),
+(536,507,cs),
+(536,625,o),
+(448,702,o),
+(312,702,cs),
+(175,702,o),
+(87,625,o),
+(87,507,cs),
+(87,408,o),
+(150,344,o),
+(232,331,c),
+(227,360,l),
+(137,347,o),
+(71,282,o),
+(71,183,cs),
+(71,65,o),
+(166,-13,o),
+(312,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(221,67,o),
+(167,108,o),
+(167,187,cs),
+(167,267,o),
+(221,306,o),
+(311,306,cs),
+(402,306,o),
+(456,267,o),
+(456,187,cs),
+(456,108,o),
+(402,67,o),
+(312,67,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(230,384,o),
+(183,423,o),
+(183,502,cs),
+(183,581,o),
+(229,623,o),
+(312,623,cs),
+(395,623,o),
+(440,581,o),
+(440,502,cs),
+(440,423,o),
+(393,384,o),
+(311,384,cs)
+);
+}
+);
+width = 623;
+}
+);
+metricLeft = "=|";
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = nine.canadian;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,-13,o),
+(534,103,o),
+(534,341,cs),
+(534,489,o),
+(511,576,o),
+(458,634,cs),
+(412,682,o),
+(353,702,o),
+(279,702,cs),
+(139,702,o),
+(49,615,o),
+(49,484,cs),
+(49,352,o),
+(136,270,o),
+(266,270,cs),
+(359,270,o),
+(433,315,o),
+(456,406,c),
+(434,432,l),
+(438,391,o),
+(439,368,o),
+(439,321,cs),
+(439,154,o),
+(390,72,o),
+(280,72,cs),
+(196,72,o),
+(155,125,o),
+(148,195,c),
+(53,195,l),
+(65,72,o),
+(140,-13,o),
+(277,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(190,350,o),
+(142,401,o),
+(142,485,cs),
+(142,569,o),
+(195,622,o),
+(281,622,cs),
+(372,622,o),
+(425,568,o),
+(425,481,cs),
+(425,401,o),
+(366,350,o),
+(280,350,cs)
+);
+}
+);
+width = 591;
+}
+);
+metricLeft = "=|six.canadian";
+metricRight = "=|six.canadian";
+},
+{
+glyphname = CR;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+width = 258;
+}
+);
+note = CR;
+unicode = 13;
+},
+{
+color = 0;
+glyphname = .notdef;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(488,690,l),
+(91,690,l),
+(91,0,l),
+(488,0,l),
+(488,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(439,640,l),
+(439,49,l),
+(140,49,l),
+(140,640,l),
+(140,640,l)
+);
+}
+);
+width = 580;
+}
+);
+note = ".notdef";
+},
+{
+glyphname = .null;
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+width = 0;
+}
+);
+note = NULL;
+},
+{
+glyphname = space;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+width = 259;
+}
+);
+note = space;
+unicode = 32;
+},
+{
+glyphname = nbspace;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+width = 258;
+}
+);
+note = uni00A0;
+unicode = 160;
+},
+{
+glyphname = space.canadian;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+width = 505;
+}
+);
+note = space;
+},
+{
+glyphname = "hyphen-canadian";
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(384,395,l),
+(384,452,l),
+(64,452,l),
+(64,395,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(384,258,l),
+(384,315,l),
+(64,315,l),
+(64,258,l)
+);
+}
+);
+width = 448;
+}
+);
+metricRight = "=|";
+note = uni1400;
+unicode = 5120;
+},
+{
+glyphname = "chi-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(138,0,l),
+(302,301,l),
+(261,301,l),
+(423,0,l),
+(511,0,l),
+(511,26,l),
+(311,386,l),
+(311,312,l),
+(507,664,l),
+(507,690,l),
+(419,690,l),
+(260,396,l),
+(301,396,l),
+(141,690,l),
+(53,690,l),
+(53,664,l),
+(249,312,l),
+(249,386,l),
+(49,26,l),
+(49,0,l)
+);
+}
+);
+width = 560;
+}
+);
+metricRight = "=|";
+note = uni166D;
+unicode = 5741;
+},
+{
+glyphname = "fullstop-canadian";
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(299,0,l),
+(299,13,l),
+(204,185,l),
+(205,161,l),
+(298,331,l),
+(298,345,l),
+(240,345,l),
+(164,201,l),
+(190,205,l),
+(115,345,l),
+(56,345,l),
+(56,331,l),
+(149,166,l),
+(150,189,l),
+(54,13,l),
+(54,0,l),
+(113,0,l),
+(192,153,l),
+(162,148,l),
+(242,0,l)
+);
+}
+);
+width = 355;
+}
+);
+note = uni1541;
+unicode = 5742;
+},
+{
+glyphname = period;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(62,10,o),
+(85,-10,o),
+(121,-10,cs),
+(157,-10,o),
+(179,10,o),
+(179,47,cs),
+(179,86,o),
+(157,104,o),
+(121,104,cs),
+(85,104,o),
+(62,86,o),
+(62,47,cs)
+);
+}
+);
+width = 237;
+}
+);
+note = period;
+unicode = 46;
+},
+{
+glyphname = comma;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,-128,l),
+(129,-57,o),
+(155,41,o),
+(171,114,c),
+(166,125,l),
+(80,125,l),
+(71,50,o),
+(54,-35,o),
+(30,-128,c)
+);
+}
+);
+width = 224;
+}
+);
+note = comma;
+unicode = 44;
+},
+{
+glyphname = hyphen;
+kernLeft = hyphen;
+kernRight = hyphen;
+lastChange = "2023-01-13 15:53:22 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(260,300,l),
+(32,300,l),
+(32,221,l),
+(260,221,l)
+);
+}
+);
+width = 292;
+}
+);
+unicode = 45;
+},
+{
+glyphname = quotesinglbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (31,-565);
+ref = quoteright;
+}
+);
+width = 258;
+}
+);
+unicode = 8218;
+},
+{
+glyphname = quotedblbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (31,-565);
+ref = quotedblright;
+}
+);
+width = 444;
+}
+);
+unicode = 8222;
+},
+{
+glyphname = quotedblleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(292,436,l),
+(300,509,o),
+(320,603,o),
+(347,690,c),
+(280,690,l),
+(248,619,o),
+(221,530,o),
+(204,444,c),
+(211,436,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(112,436,l),
+(121,509,o),
+(140,603,o),
+(166,690,c),
+(99,690,l),
+(69,619,o),
+(41,530,o),
+(24,444,c),
+(30,436,l)
+);
+}
+);
+width = 371;
+}
+);
+unicode = 8220;
+},
+{
+glyphname = quotedblright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(271,436,l),
+(304,507,o),
+(331,602,o),
+(347,680,c),
+(341,690,l),
+(259,690,l),
+(252,615,o),
+(234,521,o),
+(205,436,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(91,436,l),
+(124,507,o),
+(152,602,o),
+(167,680,c),
+(160,690,l),
+(78,690,l),
+(72,618,o),
+(52,519,o),
+(24,436,c)
+);
+}
+);
+width = 371;
+}
+);
+unicode = 8221;
+},
+{
+glyphname = quoteleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(113,436,l),
+(122,509,o),
+(141,603,o),
+(168,690,c),
+(99,690,l),
+(69,619,o),
+(41,530,o),
+(24,444,c),
+(30,436,l)
+);
+}
+);
+width = 192;
+}
+);
+unicode = 8216;
+},
+{
+glyphname = quoteright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(93,436,l),
+(126,507,o),
+(153,602,o),
+(168,680,c),
+(161,690,l),
+(78,690,l),
+(72,618,o),
+(52,519,o),
+(24,436,c)
+);
+}
+);
+width = 192;
+}
+);
+unicode = 8217;
+},
+{
+glyphname = dottedCircle;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(193,504,o),
+(181,494,o),
+(181,479,cs),
+(181,467,o),
+(193,454,o),
+(206,454,cs),
+(220,454,o),
+(231,467,o),
+(231,479,cs),
+(231,494,o),
+(220,504,o),
+(206,504,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(355,504,o),
+(343,494,o),
+(343,479,cs),
+(343,467,o),
+(355,454,o),
+(368,454,cs),
+(383,454,o),
+(393,467,o),
+(393,479,cs),
+(393,494,o),
+(383,504,o),
+(368,504,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(193,108,o),
+(181,98,o),
+(181,83,cs),
+(181,71,o),
+(193,58,o),
+(206,58,cs),
+(220,58,o),
+(231,71,o),
+(231,83,cs),
+(231,98,o),
+(220,108,o),
+(206,108,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(355,108,o),
+(343,98,o),
+(343,83,cs),
+(343,71,o),
+(355,58,o),
+(368,58,cs),
+(383,58,o),
+(393,71,o),
+(393,83,cs),
+(393,98,o),
+(383,108,o),
+(368,108,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(274,522,o),
+(262,511,o),
+(262,497,cs),
+(262,484,o),
+(274,471,o),
+(287,471,cs),
+(301,471,o),
+(312,484,o),
+(312,497,cs),
+(312,511,o),
+(301,522,o),
+(287,522,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(274,91,o),
+(262,80,o),
+(262,66,cs),
+(262,53,o),
+(274,41,o),
+(287,41,cs),
+(301,41,o),
+(312,53,o),
+(312,66,cs),
+(312,80,o),
+(301,91,o),
+(287,91,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(46,269,o),
+(59,256,o),
+(71,256,cs),
+(86,256,o),
+(97,269,o),
+(97,281,cs),
+(97,296,o),
+(86,306,o),
+(71,306,cs),
+(59,306,o),
+(46,296,o),
+(46,281,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(477,269,o),
+(490,256,o),
+(502,256,cs),
+(517,256,o),
+(527,269,o),
+(527,281,cs),
+(527,296,o),
+(517,306,o),
+(502,306,cs),
+(490,306,o),
+(477,296,o),
+(477,281,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(109,116,o),
+(122,103,o),
+(134,103,cs),
+(149,103,o),
+(159,116,o),
+(159,128,cs),
+(159,143,o),
+(149,154,o),
+(134,154,cs),
+(122,154,o),
+(109,143,o),
+(109,128,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(109,421,o),
+(122,409,o),
+(134,409,cs),
+(149,409,o),
+(159,421,o),
+(159,434,cs),
+(159,448,o),
+(149,459,o),
+(134,459,cs),
+(122,459,o),
+(109,448,o),
+(109,434,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(414,116,o),
+(427,103,o),
+(440,103,cs),
+(454,103,o),
+(465,116,o),
+(465,128,cs),
+(465,143,o),
+(454,154,o),
+(440,154,cs),
+(427,154,o),
+(414,143,o),
+(414,128,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(414,421,o),
+(427,409,o),
+(440,409,cs),
+(454,409,o),
+(465,421,o),
+(465,434,cs),
+(465,448,o),
+(454,459,o),
+(440,459,cs),
+(427,459,o),
+(414,448,o),
+(414,434,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(64,187,o),
+(76,175,o),
+(89,175,cs),
+(103,175,o),
+(114,187,o),
+(114,200,cs),
+(114,214,o),
+(103,225,o),
+(89,225,cs),
+(76,225,o),
+(64,214,o),
+(64,200,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(64,350,o),
+(76,337,o),
+(89,337,cs),
+(103,337,o),
+(114,350,o),
+(114,362,cs),
+(114,377,o),
+(103,387,o),
+(89,387,cs),
+(76,387,o),
+(64,377,o),
+(64,362,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(460,187,o),
+(472,175,o),
+(485,175,cs),
+(499,175,o),
+(510,187,o),
+(510,200,cs),
+(510,214,o),
+(499,225,o),
+(485,225,cs),
+(472,225,o),
+(460,214,o),
+(460,200,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(460,350,o),
+(472,337,o),
+(485,337,cs),
+(499,337,o),
+(510,350,o),
+(510,362,cs),
+(510,377,o),
+(499,387,o),
+(485,387,cs),
+(472,387,o),
+(460,377,o),
+(460,362,cs)
+);
+}
+);
+width = 574;
+}
+);
+note = uni25CC;
+unicode = 9676;
+},
+{
+glyphname = dotaccentcomb;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(56,720,o),
+(35,704,o),
+(35,667,cs),
+(35,630,o),
+(56,614,o),
+(90,614,cs),
+(125,614,o),
+(147,630,o),
+(147,667,cs),
+(147,704,o),
+(125,720,o),
+(90,720,cs)
+);
+}
+);
+width = 181;
+}
+);
+note = uni0307;
+unicode = 775;
+},
+{
+glyphname = dotaccent;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(126,614,o),
+(148,630,o),
+(148,667,cs),
+(148,704,o),
+(126,720,o),
+(91,720,cs),
+(57,720,o),
+(36,704,o),
+(36,667,cs),
+(36,630,o),
+(57,614,o),
+(91,614,cs)
+);
+}
+);
+width = 183;
+}
+);
+note = dotaccent;
+unicode = 729;
+},
+{
+glyphname = caron;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(257,623,o),
+(297,677,o),
+(341,729,c),
+(341,738,l),
+(277,738,l),
+(246,710,o),
+(216,675,o),
+(187,639,c),
+(159,674,o),
+(131,709,o),
+(99,738,c),
+(36,738,l),
+(36,729,l),
+(73,686,o),
+(114,635,o),
+(141,585,c),
+(235,585,l),
+(235,585,l)
+);
+}
+);
+width = 377;
+}
+);
+note = caron;
+unicode = 711;
+},
+{
+glyphname = breve;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(260,585,o),
+(310,637,o),
+(317,723,c),
+(259,723,l),
+(251,671,o),
+(222,648,o),
+(175,648,cs),
+(125,648,o),
+(100,670,o),
+(92,723,c),
+(36,723,l),
+(41,635,o),
+(89,585,o),
+(175,585,cs)
+);
+}
+);
+width = 353;
+}
+);
+note = breve;
+unicode = 728;
+},
+{
+glyphname = ring;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(193,587,o),
+(240,630,o),
+(240,695,cs),
+(240,755,o),
+(193,801,o),
+(136,801,cs),
+(78,801,o),
+(36,757,o),
+(36,694,cs),
+(36,629,o),
+(79,587,o),
+(136,587,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(105,636,o),
+(84,661,o),
+(84,694,cs),
+(84,727,o),
+(107,753,o),
+(136,753,cs),
+(165,753,o),
+(188,727,o),
+(188,694,cs),
+(188,662,o),
+(167,636,o),
+(136,636,cs)
+);
+}
+);
+width = 274;
+}
+);
+note = ring;
+unicode = 730;
+},
+{
+glyphname = ogonek;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(155,-219,o),
+(175,-214,o),
+(190,-210,c),
+(190,-151,l),
+(180,-155,o),
+(159,-159,o),
+(144,-159,cs),
+(117,-159,o),
+(101,-143,o),
+(101,-112,cs),
+(101,-71,o),
+(130,-38,o),
+(170,0,c),
+(129,16,l),
+(63,-35,o),
+(36,-80,o),
+(36,-127,cs),
+(36,-186,o),
+(77,-219,o),
+(130,-219,cs)
+);
+}
+);
+width = 226;
+}
+);
+note = ogonek;
+unicode = 731;
+},
+{
+glyphname = ring_top.canadian;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (125,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(181,757,o),
+(229,799,o),
+(229,859,cs),
+(229,919,o),
+(181,961,o),
+(125,961,cs),
+(68,961,o),
+(20,919,o),
+(20,859,cs),
+(20,799,o),
+(68,757,o),
+(125,757,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(90,802,o),
+(69,827,o),
+(69,859,cs),
+(69,891,o),
+(92,916,o),
+(125,916,cs),
+(158,916,o),
+(181,891,o),
+(181,859,cs),
+(181,827,o),
+(158,802,o),
+(125,802,cs)
+);
+}
+);
+width = 249;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (73,345);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(104,291,o),
+(128,314,o),
+(128,345,cs),
+(128,376,o),
+(104,399,o),
+(73,399,cs),
+(43,399,o),
+(19,376,o),
+(19,345,cs),
+(19,314,o),
+(43,291,o),
+(73,291,cs)
+);
+}
+);
+width = 147;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (65,345);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(91,298,o),
+(111,319,o),
+(111,345,cs),
+(111,371,o),
+(91,391,o),
+(65,391,cs),
+(39,391,o),
+(18,371,o),
+(18,345,cs),
+(18,319,o),
+(39,298,o),
+(65,298,cs)
+);
+}
+);
+width = 129;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_small;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (56,345);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(77,307,o),
+(94,324,o),
+(94,345,cs),
+(94,366,o),
+(77,383,o),
+(56,383,cs),
+(35,383,o),
+(18,366,o),
+(18,345,cs),
+(18,324,o),
+(35,307,o),
+(56,307,cs)
+);
+}
+);
+width = 112;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_top;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (73,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(104,780,o),
+(128,804,o),
+(128,835,cs),
+(128,865,o),
+(104,889,o),
+(73,889,cs),
+(43,889,o),
+(18,865,o),
+(18,835,cs),
+(18,804,o),
+(43,780,o),
+(73,780,cs)
+);
+}
+);
+width = 147;
+}
+);
+note = g725;
+},
+{
+glyphname = doubledot_middle;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(143,382,o),
+(167,406,o),
+(167,436,cs),
+(167,467,o),
+(143,491,o),
+(112,491,cs),
+(81,491,o),
+(57,467,o),
+(57,436,cs),
+(57,405,o),
+(81,382,o),
+(112,382,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(143,199,o),
+(167,223,o),
+(167,254,cs),
+(167,284,o),
+(143,308,o),
+(112,308,cs),
+(81,308,o),
+(57,285,o),
+(57,254,cs),
+(57,223,o),
+(81,199,o),
+(112,199,cs)
+);
+}
+);
+width = 224;
+}
+);
+metricRight = "=|";
+note = g725;
+},
+{
+glyphname = doubledot_top;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top_double;
+pos = (242,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(272,780,o),
+(297,804,o),
+(297,835,cs),
+(297,865,o),
+(272,889,o),
+(242,889,cs),
+(211,889,o),
+(186,865,o),
+(186,835,cs),
+(186,804,o),
+(211,780,o),
+(242,780,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(99,780,o),
+(123,804,o),
+(123,835,cs),
+(123,865,o),
+(99,889,o),
+(68,889,cs),
+(37,889,o),
+(13,865,o),
+(13,835,cs),
+(13,804,o),
+(37,780,o),
+(68,780,cs)
+);
+}
+);
+width = 309;
+}
+);
+note = g725;
+},
+{
+glyphname = g727;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (346,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(613,0,l),
+(613,80,l),
+(298,80,ls),
+(200,80,o),
+(161,119,o),
+(161,192,cs),
+(161,267,o),
+(200,305,o),
+(298,305,cs),
+(408,305,ls),
+(555,305,o),
+(626,376,o),
+(626,498,cs),
+(626,620,o),
+(555,690,o),
+(408,690,cs),
+(77,690,l),
+(77,610,l),
+(392,610,ls),
+(491,610,o),
+(529,571,o),
+(529,498,cs),
+(529,427,o),
+(491,384,o),
+(392,384,cs),
+(283,384,ls),
+(134,384,o),
+(65,314,o),
+(65,192,cs),
+(65,70,o),
+(134,0,o),
+(283,0,cs)
+);
+}
+);
+width = 691;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+glyphname = g728;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (272,0);
+ref = dot_top;
+}
+);
+width = 691;
+}
+);
+note = g728;
+},
+{
+glyphname = g729;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (346,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(408,0,ls),
+(555,0,o),
+(626,70,o),
+(626,191,cs),
+(626,314,o),
+(555,384,o),
+(408,384,cs),
+(298,384,ls),
+(200,384,o),
+(160,427,o),
+(160,497,cs),
+(160,571,o),
+(200,610,o),
+(298,610,cs),
+(613,610,l),
+(613,690,l),
+(283,690,ls),
+(134,690,o),
+(65,620,o),
+(65,497,cs),
+(65,376,o),
+(134,305,o),
+(283,305,cs),
+(392,305,ls),
+(491,305,o),
+(529,267,o),
+(529,191,cs),
+(529,119,o),
+(491,80,o),
+(392,80,cs),
+(76,80,l),
+(76,0,l)
+);
+}
+);
+width = 691;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+glyphname = g730;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (272,0);
+ref = dot_top;
+}
+);
+width = 691;
+}
+);
+note = g730;
+},
+{
+glyphname = g731;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = g727;
+}
+);
+width = 915;
+}
+);
+note = g731;
+},
+{
+glyphname = g732;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (691,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 915;
+}
+);
+note = g732;
+},
+{
+glyphname = g733;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (497,0);
+ref = dot_top;
+}
+);
+width = 915;
+}
+);
+note = g733;
+},
+{
+glyphname = g734;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (272,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (691,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 915;
+}
+);
+note = g734;
+},
+{
+glyphname = g735;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = g729;
+}
+);
+width = 915;
+}
+);
+note = g735;
+},
+{
+glyphname = g736;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (691,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 915;
+}
+);
+note = g736;
+},
+{
+glyphname = g737;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (497,0);
+ref = dot_top;
+}
+);
+width = 915;
+}
+);
+note = g737;
+},
+{
+glyphname = g738;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (272,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (691,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 915;
+}
+);
+note = g738;
+},
+{
+glyphname = g739;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(536,236,o),
+(587,288,o),
+(587,366,cs),
+(587,443,o),
+(537,497,o),
+(456,497,cs),
+(249,497,l),
+(252,469,l),
+(283,480,o),
+(306,522,o),
+(306,569,cs),
+(306,645,o),
+(257,696,o),
+(181,696,cs),
+(105,696,o),
+(54,644,o),
+(54,566,cs),
+(54,488,o),
+(104,435,o),
+(185,435,cs),
+(392,435,l),
+(389,464,l),
+(358,451,o),
+(335,410,o),
+(335,363,cs),
+(335,287,o),
+(385,236,o),
+(461,236,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(142,485,o),
+(115,516,o),
+(115,566,cs),
+(115,615,o),
+(142,645,o),
+(181,645,cs),
+(218,645,o),
+(245,614,o),
+(245,565,cs),
+(245,517,o),
+(220,485,o),
+(181,485,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(423,287,o),
+(396,318,o),
+(396,367,cs),
+(396,415,o),
+(422,446,o),
+(461,446,cs),
+(499,446,o),
+(526,415,o),
+(526,366,cs),
+(526,317,o),
+(499,287,o),
+(461,287,cs)
+);
+}
+);
+width = 641;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+glyphname = g740;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (221,0);
+ref = ring_top.canadian;
+}
+);
+width = 691;
+}
+);
+note = g740;
+},
+{
+glyphname = g741;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (221,0);
+ref = ring_top.canadian;
+}
+);
+width = 691;
+}
+);
+note = g741;
+},
+{
+glyphname = g742;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (445,0);
+ref = ring_top.canadian;
+}
+);
+width = 915;
+}
+);
+note = g742;
+},
+{
+glyphname = stroke_middle;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (48,345);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(77,458,l),
+(18,458,l),
+(18,233,l),
+(77,233,l)
+);
+}
+);
+width = 97;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (42,345);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(65,432,l),
+(18,432,l),
+(18,258,l),
+(65,258,l)
+);
+}
+);
+width = 83;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_small;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (38,345);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(56,427,l),
+(18,427,l),
+(18,263,l),
+(56,263,l)
+);
+}
+);
+width = 74;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_threequart;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (48,345);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(77,455,l),
+(19,455,l),
+(19,235,l),
+(77,235,l)
+);
+}
+);
+width = 97;
+}
+);
+note = g723;
+},
+{
+color = 8;
+glyphname = uni11AB0;
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (160,690);
+},
+{
+name = top_right_can;
+pos = (455,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(209,0,l),
+(209,102,l),
+(445,102,l),
+(445,158,l),
+(209,158,l),
+(209,281,l),
+(137,246,l),
+(169,246,ls),
+(377,246,o),
+(502,376,o),
+(502,599,cs),
+(502,690,l),
+(407,690,l),
+(407,609,ls),
+(407,422,o),
+(317,332,o),
+(149,332,cs),
+(112,332,l),
+(112,158,l),
+(33,158,l),
+(33,102,l),
+(112,102,l),
+(112,0,l)
+);
+}
+);
+width = 575;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB1;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB0;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (382,0);
+ref = dot_top;
+}
+);
+width = 576;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB2;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (122,690);
+},
+{
+name = top_right_can;
+pos = (416,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(170,0,l),
+(170,81,ls),
+(170,268,o),
+(259,357,o),
+(427,357,cs),
+(464,357,l),
+(464,531,l),
+(543,531,l),
+(543,587,l),
+(464,587,l),
+(464,690,l),
+(368,690,l),
+(368,587,l),
+(130,587,l),
+(130,531,l),
+(368,531,l),
+(368,409,l),
+(439,443,l),
+(408,443,ls),
+(199,443,o),
+(73,314,o),
+(73,91,cs),
+(73,0,l)
+);
+}
+);
+width = 576;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "theThCree-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB3;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB2;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (342,0);
+ref = dot_top;
+}
+);
+width = 576;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB4;
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (160,690);
+},
+{
+name = top_right_can;
+pos = (455,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(502,0,l),
+(502,91,ls),
+(502,314,o),
+(377,443,o),
+(169,443,cs),
+(137,443,l),
+(209,409,l),
+(209,531,l),
+(445,531,l),
+(445,587,l),
+(209,587,l),
+(209,690,l),
+(112,690,l),
+(112,587,l),
+(33,587,l),
+(33,531,l),
+(112,531,l),
+(112,357,l),
+(149,357,ls),
+(317,357,o),
+(407,268,o),
+(407,81,cs),
+(407,0,l)
+);
+}
+);
+width = 575;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB5;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB4;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (87,0);
+ref = dot_top;
+}
+);
+width = 576;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB6;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (124,690);
+},
+{
+name = top_right_can;
+pos = (418,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(172,0,l),
+(172,281,l),
+(100,246,l),
+(132,246,ls),
+(340,246,o),
+(466,376,o),
+(466,599,cs),
+(466,654,l),
+(405,625,l),
+(641,430,l),
+(694,495,l),
+(456,690,l),
+(370,690,l),
+(370,609,ls),
+(370,422,o),
+(281,332,o),
+(113,332,cs),
+(75,332,l),
+(75,0,l)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB7;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB6;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (345,0);
+ref = dot_top;
+}
+);
+width = 718;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB8;
+kernRight = soright;
+lastChange = "2023-01-13 15:53:52 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (299,690);
+},
+{
+name = top_right_can;
+pos = (594,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(348,0,l),
+(348,81,ls),
+(348,268,o),
+(438,357,o),
+(606,357,cs),
+(642,357,l),
+(642,690,l),
+(546,690,l),
+(546,409,l),
+(617,443,l),
+(585,443,ls),
+(378,443,o),
+(252,314,o),
+(252,91,cs),
+(252,36,l),
+(314,65,l),
+(76,260,l),
+(25,195,l),
+(262,0,l)
+);
+}
+);
+width = 717;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB9;
+kernRight = soright;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB8;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (521,0);
+ref = dot_top;
+}
+);
+width = 718;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABA;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (124,690);
+},
+{
+name = top_right_can;
+pos = (418,690);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(456,0,l),
+(694,195,l),
+(641,260,l),
+(405,65,l),
+(466,36,l),
+(466,91,ls),
+(466,314,o),
+(340,443,o),
+(132,443,cs),
+(100,443,l),
+(172,409,l),
+(172,690,l),
+(75,690,l),
+(75,357,l),
+(113,357,ls),
+(281,357,o),
+(370,268,o),
+(370,81,cs),
+(370,0,l)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABB;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = uni11ABA;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+}
+);
+width = 718;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABC;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(519,0,l),
+(519,87,l),
+(143,87,l),
+(143,51,l),
+(528,622,l),
+(528,690,l),
+(49,690,l),
+(49,603,l),
+(425,603,l),
+(425,639,l),
+(41,68,l),
+(41,0,l)
+);
+}
+);
+width = 569;
+}
+);
+metricRight = "=|";
+},
+{
+color = 8;
+glyphname = uni11ABD;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(528,0,l),
+(528,68,l),
+(144,639,l),
+(144,603,l),
+(520,603,l),
+(520,690,l),
+(41,690,l),
+(41,622,l),
+(425,51,l),
+(425,87,l),
+(49,87,l),
+(49,0,l)
+);
+}
+);
+width = 569;
+}
+);
+metricLeft = "=|uni11ABC";
+metricRight = "=|uni11ABC";
+},
+{
+color = 8;
+glyphname = uni11ABE;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(171,0,l),
+(171,602,l),
+(115,602,l),
+(509,0,l),
+(594,0,l),
+(594,690,l),
+(498,690,l),
+(498,88,l),
+(554,88,l),
+(161,690,l),
+(75,690,l),
+(75,0,l)
+);
+}
+);
+width = 669;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABF;
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(161,0,l),
+(554,604,l),
+(498,604,l),
+(498,0,l),
+(594,0,l),
+(594,690,l),
+(509,690,l),
+(115,86,l),
+(171,86,l),
+(171,690,l),
+(75,690,l),
+(75,0,l)
+);
+}
+);
+width = 669;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = "raiseddoubledotFinal-canadian.cree";
+lastChange = "2023-01-13 15:53:23 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(144,593,o),
+(168,617,o),
+(168,648,cs),
+(168,678,o),
+(144,702,o),
+(113,702,cs),
+(82,702,o),
+(58,679,o),
+(58,648,cs),
+(58,617,o),
+(82,593,o),
+(113,593,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(144,411,o),
+(168,435,o),
+(168,466,cs),
+(168,497,o),
+(144,521,o),
+(113,521,cs),
+(82,521,o),
+(58,497,o),
+(58,466,cs),
+(58,435,o),
+(82,411,o),
+(113,411,cs)
+);
+}
+);
+width = 226;
+}
+);
+note = g725;
+}
+);
+instances = (
+{
+axesValues = (
+101,
+91,
+0
+);
+instanceInterpolations = {
+"F8006AA5-6E21-4BD1-AC52-9C52C7F343AA" = 1;
+};
+name = "RC L roman";
+}
+);
+kerningLTR = {
+"F8006AA5-6E21-4BD1-AC52-9C52C7F343AA" = {
+"@MMK_L_caright" = {
+"@MMK_R_ecanleft" = -77.28;
+"@MMK_R_mwestleft" = -28.014;
+"@MMK_R_neleft" = -55.062;
+};
+"@MMK_L_ciright" = {
+"@MMK_R_icanleft" = -77.28;
+"@MMK_R_noleft" = -96.6;
+};
+"@MMK_L_ecanright" = {
+"@MMK_R_coleft" = -77.28;
+"@MMK_R_moleft" = -80.178;
+"@MMK_R_sileft" = -47.334;
+};
+"@MMK_L_icanright" = {
+"@MMK_R_celeft" = -77.28;
+"@MMK_R_meleft" = -80.178;
+"@MMK_R_mwestleft" = -71.484;
+"@MMK_R_saleft" = -41.538;
+"she-canadian" = -80.178;
+};
+"@MMK_L_maright" = {
+"@MMK_R_acanleft" = -76.314;
+"@MMK_R_ecanleft" = -80.178;
+"@MMK_R_mwestleft" = -51.198;
+"@MMK_R_neleft" = -55.062;
+};
+"@MMK_L_miright" = {
+"@MMK_R_acanleft" = -76.314;
+"@MMK_R_icanleft" = -80.178;
+"@MMK_R_moleft" = -101.43;
+"@MMK_R_noleft" = -96.6;
+"@MMK_R_yeleft" = -107.226;
+};
+"@MMK_L_mwestright" = {
+"@MMK_R_coleft" = -28.014;
+"@MMK_R_icanleft" = -71.484;
+"@MMK_R_moleft" = -51.198;
+"@MMK_R_noleft" = -78.246;
+"@MMK_R_sileft" = -18.354;
+"@MMK_R_yeleft" = -32.844;
+};
+"@MMK_L_naright" = {
+"@MMK_R_acanleft" = -89.838;
+"@MMK_R_celeft" = -96.6;
+"@MMK_R_meleft" = -96.6;
+"@MMK_R_mwestleft" = -78.246;
+"@MMK_R_neleft" = -111.09;
+"@MMK_R_saleft" = -68.586;
+};
+"@MMK_L_niright" = {
+"@MMK_R_coleft" = -55.062;
+"@MMK_R_moleft" = -55.062;
+"@MMK_R_noleft" = -111.09;
+"@MMK_R_sileft" = -4.83;
+};
+"@MMK_L_ocanright" = {
+"@MMK_R_meleft" = -76.314;
+"@MMK_R_moleft" = -76.314;
+"@MMK_R_noleft" = -89.838;
+};
+"@MMK_L_seright" = {
+"@MMK_R_ecanleft" = -47.334;
+"@MMK_R_mwestleft" = -18.354;
+"@MMK_R_neleft" = -2.898;
+};
+"@MMK_L_soright" = {
+"@MMK_R_icanleft" = -41.538;
+"@MMK_R_noleft" = -68.586;
+};
+"@MMK_L_yiright" = {
+"@MMK_R_meleft" = -107.226;
+"@MMK_R_mwestleft" = -32.844;
+};
+"shi-canadian" = {
+"@MMK_R_icanleft" = -80.178;
+};
+};
+};
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "italic angle";
+}
+);
+properties = (
+{
+key = copyrights;
+values = (
+{
+language = ENG;
+value = "Copyright 2018 Google Inc. All Rights Reserved.";
+}
+);
+},
+{
+key = manufacturers;
+values = (
+{
+language = ENG;
+value = "Monotype Imaging Inc.";
+}
+);
+},
+{
+key = designers;
+values = (
+{
+language = ENG;
+value = "Monotype Design Team";
+}
+);
+},
+{
+key = description;
+value = "Designed by Monotype design team.";
+},
+{
+key = trademarks;
+values = (
+{
+language = ENG;
+value = "Noto is a trademark of Google Inc.";
+}
+);
+},
+{
+key = licenseURL;
+value = "http://scripts.sil.org/OFL";
+},
+{
+key = licenses;
+values = (
+{
+language = ENG;
+value = "This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.";
+}
+);
+},
+{
+key = manufacturerURL;
+value = "http://www.google.com/get/noto/";
+},
+{
+key = designerURL;
+value = "http://www.monotype.com/studio";
+}
+);
+settings = {
+disablesNiceNames = 1;
+};
+stems = (
+{
+name = "New Stem";
+}
+);
+unitsPerEm = 966;
+userData = {
+GSDontShowVersionAlert = 1;
+};
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/sources/Exported instances UCAS SansCanadianAboriginal/Sans Canadian Aboriginal-RC B Italic.glyphs
+++ b/sources/Exported instances UCAS SansCanadianAboriginal/Sans Canadian Aboriginal-RC B Italic.glyphs
@@ -1,0 +1,37309 @@
+{
+.appVersion = "3151";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+},
+{
+name = Width;
+tag = wdth;
+},
+{
+name = Slant;
+tag = slnt;
+}
+);
+classes = (
+{
+code = "zero one two three four five six seven eight nine ";
+name = Num;
+},
+{
+code = "zero.canadian one.canadian two.canadian three.canadian four.canadian five.canadian six.canadian seven.canadian eight.canadian nine.canadian 
+";
+name = Num_can;
+},
+{
+code = "ke-canadian.square ki-canadian.square kii-canadian.square ko-canadian.square koo-canadian.square ka-canadian.square kaa-canadian.square kweWestCree-canadian.square kwiiWestCree-canadian.square kwoWestCree-canadian.square kwooWestCree-canadian.square kwaWestCree-canadian.square kwaaWestCree-canadian.square ce-canadian.square ci-canadian.square cii-canadian.square co-canadian.square coo-canadian.square ca-canadian.square caa-canadian.square me-canadian.square mi-canadian.square mii-canadian.square mo-canadian.square moo-canadian.square ma-canadian.square maa-canadian.square ne-canadian.square ni-canadian.square nii-canadian.square no-canadian.square noo-canadian.square na-canadian.square naa-canadian.square nweWestCree-canadian.square nwaWestCree-canadian.square nwaaWestCree-canadian.square se-canadian.square si-canadian.square sii-canadian.square so-canadian.square soo-canadian.square sa-canadian.square saa-canadian.square sho-canadian.square shoo-canadian.square sha-canadian.square shaa-canadian.square ye-canadian.square yi-canadian.square yii-canadian.square yo-canadian.square yoo-canadian.square ya-canadian.square yaa-canadian.square re-canadian.square reRCree-canadian.square leWestCree-canadian.square ri-canadian.square rii-canadian.square ro-canadian.square loWestCree-canadian.square ra-canadian.square raa-canadian.square laWestCree-canadian.square reWestCree-canadian.square riWestCree-canadian.square roWestCree-canadian.square raWestCree-canadian.square theThCree-canadian.square thiThCree-canadian.square thiiThCree-canadian.square thoThCree-canadian.square thooThCree-canadian.square thaThCree-canadian.square thaaThCree-canadian.square thweeWoodScree-canadian.square thwiWoodScree-canadian.square thwiiWoodScree-canadian.square thwoWoodScree-canadian.square thwooWoodScree-canadian.square thwaWoodScree-canadian.square thwaaWoodScree-canadian.square nwiOjibway-canadian.square nwiiOjibway-canadian.square nwoOjibway-canadian.square nwooOjibway-canadian.square looWestCree-canadian.square laaWestCree-canadian.square ";
+name = Dene_square;
+},
+{
+code = "ke-canadian ki-canadian kii-canadian ko-canadian koo-canadian ka-canadian kaa-canadian kweWestCree-canadian kwiiWestCree-canadian kwoWestCree-canadian kwooWestCree-canadian kwaWestCree-canadian kwaaWestCree-canadian ce-canadian ci-canadian cii-canadian co-canadian coo-canadian ca-canadian caa-canadian me-canadian mi-canadian mii-canadian mo-canadian moo-canadian ma-canadian maa-canadian ne-canadian ni-canadian nii-canadian no-canadian noo-canadian na-canadian naa-canadian nweWestCree-canadian nwaWestCree-canadian nwaaWestCree-canadian se-canadian si-canadian sii-canadian so-canadian soo-canadian sa-canadian saa-canadian sho-canadian shoo-canadian sha-canadian shaa-canadian ye-canadian yi-canadian yii-canadian yo-canadian yoo-canadian ya-canadian yaa-canadian re-canadian reRCree-canadian leWestCree-canadian ri-canadian rii-canadian ro-canadian loWestCree-canadian ra-canadian raa-canadian laWestCree-canadian reWestCree-canadian riWestCree-canadian roWestCree-canadian raWestCree-canadian theThCree-canadian thiThCree-canadian thiiThCree-canadian thoThCree-canadian thooThCree-canadian thaThCree-canadian thaaThCree-canadian thweeWoodScree-canadian thwiWoodScree-canadian thwiiWoodScree-canadian thwoWoodScree-canadian thwooWoodScree-canadian thwaWoodScree-canadian thwaaWoodScree-canadian nwiOjibway-canadian nwiiOjibway-canadian nwoOjibway-canadian nwooOjibway-canadian looWestCree-canadian laaWestCree-canadian 
+";
+name = Dene_round;
+},
+{
+code = "acuteFinal-canadian.mid graveFinal-canadian.mid ringTophalfFinal-canadian.mid ringRighthalfFinal-canadian.mid ringFinal-canadian.mid doubleacuteFinal-canadian.mid doubleshortverticalstrokesFinal-canadian.mid shorthorizontalstrokeFinal-canadian.mid downtackFinal-canadian.mid pWestCree-canadian.mid c-canadian.mid mWestCree-canadian.mid ";
+name = Final_mid;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian ringFinal-canadian doubleacuteFinal-canadian doubleshortverticalstrokesFinal-canadian shorthorizontalstrokeFinal-canadian downtackFinal-canadian pWestCree-canadian c-canadian mWestCree-canadian ";
+name = Final_mid_ori;
+},
+{
+code = "acuteFinal-canadian.base graveFinal-canadian.base ringBottomhalfFinal-canadian.base ringTophalfFinal-canadian.base ringRighthalfFinal-canadian.base plusFinal-canadian.base pWestCree-canadian.base c-canadian.base thSayisi-canadian.base mWestCree-canadian.base ";
+name = Final_base;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringBottomhalfFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian plusFinal-canadian pWestCree-canadian c-canadian thSayisi-canadian mWestCree-canadian ";
+name = Final_base_ori;
+},
+{
+code = "ng-canadian ngai-canadian ngaai-canadian ngi-canadian ngii-canadian ngo-canadian ngoo-canadian nga-canadian ngaa-canadian ";
+name = Nunavik;
+},
+{
+code = "ng-canadian.nunavik ngai-canadian.nunavik ngaai-canadian.nunavik ngi-canadian.nunavik ngii-canadian.nunavik ngo-canadian.nunavik ngoo-canadian.nunavik nga-canadian.nunavik ngaa-canadian.nunavik ";
+name = Nunavik_alt;
+}
+);
+customParameters = (
+{
+name = vendorID;
+value = GOOG;
+},
+{
+name = panose;
+value = (
+2,
+11,
+5,
+2,
+4,
+5,
+4,
+2,
+2,
+4
+);
+},
+{
+name = unicodeRanges;
+value = (
+0,
+1,
+2,
+5,
+6,
+45,
+77
+);
+},
+{
+name = codePageRanges;
+value = (
+"1252"
+);
+},
+{
+name = fsType;
+value = (
+);
+}
+);
+date = "2022-06-21 10:06:40 +0000";
+familyName = "Sans Canadian Aboriginal";
+featurePrefixes = (
+{
+automatic = 1;
+code = "languagesystem DFLT dflt;
+
+languagesystem cans dflt;
+";
+name = Languagesystems;
+}
+);
+features = (
+{
+automatic = 1;
+code = "feature ss01;
+feature ss02;
+feature ss03;
+feature ss04;
+";
+tag = aalt;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+tag = salt;
+},
+{
+code = "lookup space_can {
+sub space by space.canadian;
+} space_can;
+
+lookup num_can {
+sub @Num by @Num_can;
+} num_can;
+";
+labels = (
+{
+language = dflt;
+value = "CAN Space and numerals";
+}
+);
+tag = ss01;
+},
+{
+code = "lookup dene_square {
+sub @Dene_round by @Dene_square;
+} dene_square;
+
+";
+labels = (
+{
+language = dflt;
+value = "Dene Square";
+}
+);
+tag = ss02;
+},
+{
+code = "lookup nunavik_alt {
+sub @Nunavik by @Nunavik_alt;
+} nunavik_alt;
+
+";
+labels = (
+{
+language = dflt;
+value = "Nunanvik Alt";
+}
+);
+tag = ss03;
+},
+{
+code = "lookup final_mid {
+sub @Final_mid_ori by @Final_mid;
+} final_mid;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final mid";
+}
+);
+tag = ss04;
+},
+{
+code = "lookup final_base {
+sub @Final_base_ori by @Final_base;
+} final_base;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final base";
+}
+);
+tag = ss05;
+},
+{
+code = "lookup plaincree_first {
+sub wiWestCree-canadian' plusFinal-canadian by i-canadian;
+} plaincree_first;
+
+lookup plaincree_second {
+sub i-canadian plusFinal-canadian' by raiseddoubledotFinal-canadian.cree;
+} plaincree_second;
+
+lookup plaincree_third {
+sub middledotFinal-canadian plusFinal-canadian by raiseddoubledotFinal-canadian.cree;
+} plaincree_third;
+";
+labels = (
+{
+language = dflt;
+value = Plaincree;
+}
+);
+tag = ss06;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+labels = (
+{
+language = dflt;
+value = "";
+}
+);
+tag = ss07;
+}
+);
+fontMaster = (
+{
+axesValues = (
+0,
+0,
+0
+);
+customParameters = (
+{
+name = typoAscender;
+value = 1069;
+},
+{
+name = typoDescender;
+value = -293;
+},
+{
+name = typoLineGap;
+value = 0;
+},
+{
+name = winAscent;
+value = 1069;
+},
+{
+name = winDescent;
+value = 293;
+},
+{
+name = hheaAscender;
+value = 1069;
+},
+{
+name = hheaDescender;
+value = -293;
+},
+{
+name = strikeoutPosition;
+value = 305.26947;
+},
+{
+name = strikeoutSize;
+value = 50;
+},
+{
+name = "Master Icon Glyph Name";
+value = s;
+}
+);
+guides = (
+{
+locked = 1;
+pos = (432,357);
+},
+{
+locked = 1;
+pos = (100,729);
+}
+);
+id = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+metricValues = (
+{
+over = 24;
+pos = 1069;
+},
+{
+over = 24;
+pos = 714;
+},
+{
+over = 24;
+pos = 509;
+},
+{
+over = -24;
+},
+{
+over = -24;
+pos = -293;
+},
+{
+pos = 12;
+}
+);
+name = "RC B Italic";
+stemValues = (
+166
+);
+}
+);
+glyphs = (
+{
+glyphname = idotless;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(172,0,l),
+(289,549,l),
+(125,549,l),
+(8,0,l)
+);
+}
+);
+width = 289;
+}
+);
+note = dotlessi;
+unicode = 305;
+},
+{
+glyphname = "acuteFinal-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(184,357,l),
+(426,714,l),
+(290,714,l),
+(48,357,l)
+);
+}
+);
+width = 354;
+}
+);
+metricRight = "=|";
+note = uni141F;
+unicode = 5151;
+},
+{
+glyphname = "graveFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(350,357,l),
+(246,714,l),
+(124,714,l),
+(228,357,l)
+);
+}
+);
+width = 354;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+unicode = 5152;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(364,351,o),
+(422,409,o),
+(442,504,cs),
+(487,714,l),
+(374,714,l),
+(332,518,ls),
+(323,477,o),
+(304,454,o),
+(268,454,cs),
+(231,454,o),
+(215,477,o),
+(225,520,cs),
+(266,714,l),
+(153,714,l),
+(114,529,ls),
+(91,421,o),
+(143,351,o),
+(257,351,cs)
+);
+}
+);
+width = 444;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1421;
+unicode = 5153;
+},
+{
+glyphname = "ringTophalfFinal-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(190,357,l),
+(232,553,ls),
+(241,594,o),
+(260,617,o),
+(296,617,cs),
+(333,617,o),
+(349,594,o),
+(339,551,cs),
+(298,357,l),
+(411,357,l),
+(450,542,ls),
+(473,650,o),
+(421,720,o),
+(307,720,cs),
+(200,720,o),
+(142,662,o),
+(122,567,cs),
+(77,357,l)
+);
+}
+);
+width = 444;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+unicode = 5154;
+},
+{
+glyphname = "ringRighthalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(165,357,ls),
+(310,357,o),
+(392,442,o),
+(392,567,cs),
+(392,657,o),
+(331,714,o),
+(230,714,cs),
+(153,714,l),
+(131,609,l),
+(212,609,ls),
+(256,609,o),
+(277,588,o),
+(277,554,cs),
+(277,501,o),
+(248,462,o),
+(181,462,cs),
+(100,462,l),
+(77,357,l)
+);
+}
+);
+width = 378;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+unicode = 5155;
+},
+{
+glyphname = "ringFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(396,369,o),
+(470,444,o),
+(470,545,cs),
+(470,645,o),
+(394,720,o),
+(291,720,cs),
+(187,720,o),
+(110,646,o),
+(110,545,cs),
+(110,444,o),
+(185,369,o),
+(291,369,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(244,465,o),
+(216,500,o),
+(216,545,cs),
+(216,589,o),
+(244,624,o),
+(291,624,cs),
+(335,624,o),
+(365,589,o),
+(365,545,cs),
+(365,500,o),
+(336,465,o),
+(291,465,cs)
+);
+}
+);
+width = 456;
+}
+);
+note = uni1424;
+unicode = 5156;
+},
+{
+glyphname = "doubleacuteFinal-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(181,357,l),
+(426,714,l),
+(293,714,l),
+(48,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(369,357,l),
+(614,714,l),
+(481,714,l),
+(236,357,l)
+);
+}
+);
+width = 542;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricRight = "=|";
+note = uni1425;
+unicode = 5157;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(190,357,l),
+(266,714,l),
+(153,714,l),
+(77,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(355,357,l),
+(431,714,l),
+(318,714,l),
+(242,357,l)
+);
+}
+);
+width = 388;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "pWestCree-canadian";
+note = uni1426;
+unicode = 5158;
+},
+{
+glyphname = "middledotFinal-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(190,288,o),
+(225,323,o),
+(225,367,cs),
+(225,411,o),
+(190,446,o),
+(146,446,cs),
+(103,446,o),
+(67,411,o),
+(67,367,cs),
+(67,323,o),
+(103,288,o),
+(146,288,cs)
+);
+}
+);
+width = 245;
+}
+);
+note = uni1427;
+unicode = 5159;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,488,l),
+(465,603,l),
+(129,603,l),
+(105,488,l)
+);
+}
+);
+width = 446;
+}
+);
+metricRight = "=|";
+note = uni1428;
+unicode = 5160;
+},
+{
+glyphname = "plusFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(306,377,l),
+(331,493,l),
+(443,493,l),
+(466,601,l),
+(353,601,l),
+(377,714,l),
+(267,714,l),
+(243,601,l),
+(129,601,l),
+(107,493,l),
+(220,493,l),
+(195,377,l)
+);
+}
+);
+width = 447;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+unicode = 5161;
+},
+{
+glyphname = "downtackFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(302,357,l),
+(355,607,l),
+(467,607,l),
+(490,714,l),
+(153,714,l),
+(130,607,l),
+(242,607,l),
+(189,357,l)
+);
+}
+);
+width = 447;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni142A;
+unicode = 5162;
+},
+{
+glyphname = "thFinalWoodScree-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(303,357,l),
+(316,414,l),
+(425,414,l),
+(444,506,l),
+(335,506,l),
+(347,565,l),
+(457,565,l),
+(476,657,l),
+(367,657,l),
+(379,714,l),
+(266,714,l),
+(254,657,l),
+(141,657,l),
+(122,565,l),
+(234,565,l),
+(222,506,l),
+(109,506,l),
+(90,414,l),
+(203,414,l),
+(190,357,l)
+);
+}
+);
+width = 446;
+}
+);
+metricLeft = "hyphen-canadian";
+metricRight = "hyphen-canadian";
+note = uni167E;
+unicode = 5758;
+},
+{
+glyphname = "ringSmallFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(315,499,o),
+(372,546,o),
+(372,614,cs),
+(372,681,o),
+(315,729,o),
+(251,729,cs),
+(187,729,o),
+(132,681,o),
+(132,614,cs),
+(132,546,o),
+(186,499,o),
+(251,499,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(223,567,o),
+(207,588,o),
+(207,614,cs),
+(207,639,o),
+(226,660,o),
+(252,660,cs),
+(279,660,o),
+(298,639,o),
+(298,614,cs),
+(298,588,o),
+(279,567,o),
+(252,567,cs)
+);
+}
+);
+width = 351;
+}
+);
+note = g725;
+unicode = 6366;
+},
+{
+glyphname = "raiseddotFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(250,571,o),
+(286,606,o),
+(286,650,cs),
+(286,693,o),
+(250,729,o),
+(207,729,cs),
+(163,729,o),
+(128,693,o),
+(128,650,cs),
+(128,606,o),
+(163,571,o),
+(207,571,cs)
+);
+}
+);
+width = 245;
+}
+);
+note = g725;
+unicode = 6367;
+},
+{
+glyphname = "acuteFinal-canadian.base";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-356);
+ref = "acuteFinal-canadian";
+}
+);
+width = 354;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.base";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "graveFinal-canadian";
+}
+);
+width = 354;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian.base";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 444;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1421;
+},
+{
+glyphname = "ringTophalfFinal-canadian.base";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 444;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.base";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 378;
+}
+);
+metricLeft = "==|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "plusFinal-canadian.base";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(226,0,l),
+(250,116,l),
+(363,116,l),
+(386,224,l),
+(273,224,l),
+(297,337,l),
+(187,337,l),
+(163,224,l),
+(49,224,l),
+(26,116,l),
+(140,116,l),
+(115,0,l)
+);
+}
+);
+width = 447;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+},
+{
+glyphname = "acuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-167);
+ref = "acuteFinal-canadian";
+}
+);
+width = 354;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.mid";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "graveFinal-canadian";
+}
+);
+width = 354;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringTophalfFinal-canadian.mid";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-38,-178);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 444;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.mid";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-168);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 378;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "ringFinal-canadian.mid";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-40,-188);
+ref = "ringFinal-canadian";
+}
+);
+width = 456;
+}
+);
+metricLeft = "ringFinal-canadian";
+metricWidth = "ringFinal-canadian";
+note = uni1424;
+},
+{
+glyphname = "doubleacuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "doubleacuteFinal-canadian";
+}
+);
+width = 542;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "doubleacuteFinal-canadian";
+note = uni1425;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian.mid";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "doubleshortverticalstrokesFinal-canadian";
+}
+);
+width = 388;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricWidth = "doubleshortverticalstrokesFinal-canadian";
+note = uni1426;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian.mid";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-38,-179);
+ref = "shorthorizontalstrokeFinal-canadian";
+}
+);
+width = 446;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "shorthorizontalstrokeFinal-canadian";
+note = uni1428;
+},
+{
+glyphname = "downtackFinal-canadian.mid";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-168);
+ref = "downtackFinal-canadian";
+}
+);
+width = 447;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "downtackFinal-canadian";
+note = uni142A;
+},
+{
+glyphname = "e-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (421,470);
+},
+{
+name = top_center_can;
+pos = (476,714);
+},
+{
+name = top_left_can;
+pos = (243,714);
+},
+{
+name = top_right_can;
+pos = (709,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(348,0,l),
+(819,674,l),
+(828,714,l),
+(123,714,l),
+(115,674,l),
+(300,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(386,203,l),
+(284,614,l),
+(260,581,l),
+(632,581,l),
+(605,614,l),
+(329,203,l)
+);
+}
+);
+width = 755;
+}
+);
+metricRight = "=|";
+note = uni1401;
+unicode = 5121;
+},
+{
+glyphname = "aai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (241,0);
+ref = ring_top.canadian;
+}
+);
+width = 756;
+}
+);
+note = uni1402;
+unicode = 5122;
+},
+{
+glyphname = "i-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (392,275);
+},
+{
+name = top_center_can;
+pos = (475,714);
+},
+{
+name = top_left_can;
+pos = (243,714);
+},
+{
+name = top_right_can;
+pos = (709,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(451,714,l),
+(-20,40,l),
+(-29,0,l),
+(676,0,l),
+(685,40,l),
+(500,714,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(413,511,l),
+(515,100,l),
+(539,133,l),
+(167,133,l),
+(194,100,l),
+(470,511,l)
+);
+}
+);
+width = 755;
+}
+);
+metricLeft = "e-canadian";
+metricWidth = "e-canadian";
+note = uni1403;
+unicode = 5123;
+},
+{
+glyphname = "ii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (280,0);
+ref = dot_top;
+}
+);
+width = 756;
+}
+);
+note = uni1404;
+unicode = 5124;
+},
+{
+glyphname = "o-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (306,373);
+},
+{
+name = top_center_can;
+pos = (459,714);
+},
+{
+name = top_double;
+pos = (573,714);
+},
+{
+name = top_left_can;
+pos = (231,714);
+},
+{
+name = top_right_can;
+pos = (696,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(49,0,l),
+(678,332,l),
+(689,382,l),
+(201,714,l),
+(162,714,l),
+(10,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(264,534,l),
+(215,547,l),
+(497,354,l),
+(499,384,l),
+(143,195,l),
+(189,184,l)
+);
+}
+);
+width = 690;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1405;
+unicode = 5125;
+},
+{
+glyphname = "oo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+}
+);
+width = 690;
+}
+);
+note = uni1406;
+unicode = 5126;
+},
+{
+glyphname = "yCreeoo-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (187,0);
+ref = doubledot_top;
+}
+);
+width = 690;
+}
+);
+note = uni1407;
+unicode = 5127;
+},
+{
+glyphname = "eeCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(49,0,l),
+(678,332,l),
+(689,382,l),
+(201,714,l),
+(162,714,l),
+(10,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(259,534,l),
+(225,541,l),
+(500,354,l),
+(507,387,l),
+(152,199,l),
+(185,184,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(312,305,l),
+(339,432,l),
+(285,432,l),
+(258,305,l)
+);
+}
+);
+width = 690;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "o-canadian";
+note = uni1408;
+unicode = 5128;
+},
+{
+glyphname = "iCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (221,16);
+ref = dot_middle_optic_small;
+}
+);
+width = 690;
+}
+);
+note = uni1409;
+unicode = 5129;
+},
+{
+glyphname = "a-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (417,350);
+},
+{
+name = top_center_can;
+pos = (414,714);
+},
+{
+name = top_left_can;
+pos = (200,714);
+},
+{
+name = top_right_can;
+pos = (652,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(684,714,l),
+(56,382,l),
+(45,332,l),
+(532,0,l),
+(572,0,l),
+(724,714,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(470,180,l),
+(519,167,l),
+(237,360,l),
+(235,330,l),
+(591,519,l),
+(544,530,l)
+);
+}
+);
+width = 690;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni140A;
+unicode = 5130;
+},
+{
+glyphname = "aa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (457,0);
+ref = dot_top;
+}
+);
+width = 690;
+}
+);
+note = uni140B;
+unicode = 5131;
+},
+{
+glyphname = "we-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "e-canadian";
+}
+);
+width = 1000;
+}
+);
+note = uni140C;
+unicode = 5132;
+},
+{
+glyphname = "weWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (756,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1000;
+}
+);
+note = uni140D;
+unicode = 5133;
+},
+{
+glyphname = "wi-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "i-canadian";
+}
+);
+width = 1000;
+}
+);
+note = uni140E;
+unicode = 5134;
+},
+{
+glyphname = "wiWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (756,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1000;
+}
+);
+note = uni140F;
+unicode = 5135;
+},
+{
+glyphname = "wii-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (525,0);
+ref = dot_top;
+}
+);
+width = 1000;
+}
+);
+note = uni1410;
+unicode = 5136;
+},
+{
+glyphname = "wiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (280,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (756,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1000;
+}
+);
+note = uni1411;
+unicode = 5137;
+},
+{
+glyphname = "wo-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "o-canadian";
+}
+);
+width = 935;
+}
+);
+note = uni1412;
+unicode = 5138;
+},
+{
+glyphname = "woWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (690,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 935;
+}
+);
+note = uni1413;
+unicode = 5139;
+},
+{
+glyphname = "woo-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (508,0);
+ref = dot_top;
+}
+);
+width = 935;
+}
+);
+note = uni1414;
+unicode = 5140;
+},
+{
+glyphname = "wooWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (690,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 935;
+}
+);
+note = uni1415;
+unicode = 5141;
+},
+{
+glyphname = "wooNaskapi-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (160,-98);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (330,-213);
+ref = dot_top;
+}
+);
+width = 690;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricWidth = "o-canadian";
+note = uni1416;
+unicode = 5142;
+},
+{
+glyphname = "wa-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "a-canadian";
+}
+);
+width = 935;
+}
+);
+note = uni1417;
+unicode = 5143;
+},
+{
+glyphname = "waWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (690,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 935;
+}
+);
+note = uni1418;
+unicode = 5144;
+},
+{
+glyphname = "waa-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (702,0);
+ref = dot_top;
+}
+);
+width = 935;
+}
+);
+note = uni1419;
+unicode = 5145;
+},
+{
+glyphname = "waaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (457,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (690,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 935;
+}
+);
+note = uni141A;
+unicode = 5146;
+},
+{
+glyphname = "waaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:50 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (91,-207);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (297,-98);
+ref = dot_top;
+}
+);
+width = 690;
+}
+);
+metricWidth = "a-canadian";
+note = uni141B;
+unicode = 5147;
+},
+{
+glyphname = "ai-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(297,351,o),
+(337,373,o),
+(370,422,c),
+(341,423,l),
+(354,375,o),
+(394,351,o),
+(456,351,cs),
+(554,351,o),
+(607,400,o),
+(631,512,cs),
+(674,714,l),
+(568,714,l),
+(523,507,ls),
+(515,467,o),
+(495,448,o),
+(462,448,cs),
+(427,448,o),
+(414,468,o),
+(422,510,cs),
+(466,714,l),
+(361,714,l),
+(317,507,ls),
+(308,466,o),
+(289,448,o),
+(256,448,cs),
+(222,448,o),
+(207,469,o),
+(216,510,cs),
+(259,714,l),
+(153,714,l),
+(110,514,ls),
+(89,417,o),
+(144,351,o),
+(238,351,cs)
+);
+}
+);
+width = 631;
+}
+);
+metricRight = "=|";
+note = uni141C;
+unicode = 5148;
+},
+{
+glyphname = "ycreew-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(428,528,o),
+(465,567,o),
+(465,625,cs),
+(465,682,o),
+(427,720,o),
+(376,720,cs),
+(324,720,o),
+(286,682,o),
+(286,625,cs),
+(286,567,o),
+(323,528,o),
+(376,528,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(235,351,o),
+(272,390,o),
+(272,448,cs),
+(272,505,o),
+(234,543,o),
+(183,543,cs),
+(131,543,o),
+(93,505,o),
+(93,448,cs),
+(93,390,o),
+(130,351,o),
+(183,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(162,403,o),
+(149,420,o),
+(149,448,cs),
+(149,475,o),
+(162,491,o),
+(183,491,cs),
+(203,491,o),
+(216,475,o),
+(216,448,cs),
+(216,420,o),
+(203,403,o),
+(183,403,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(355,580,o),
+(342,597,o),
+(342,625,cs),
+(342,652,o),
+(355,668,o),
+(376,668,cs),
+(395,668,o),
+(409,652,o),
+(409,625,cs),
+(409,597,o),
+(395,580,o),
+(376,580,cs)
+);
+}
+);
+width = 438;
+}
+);
+metricRight = "=|";
+note = uni141D;
+unicode = 5149;
+},
+{
+glyphname = "glottalstop-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(416,357,l),
+(420,378,l),
+(328,714,l),
+(303,714,l),
+(67,378,l),
+(63,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(322,605,l),
+(273,606,l),
+(323,407,l),
+(346,439,l),
+(169,439,l),
+(187,407,l)
+);
+}
+);
+width = 435;
+}
+);
+metricRight = "=|";
+note = uni141E;
+unicode = 5150;
+},
+{
+glyphname = "en-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+pos = (756,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 1111;
+}
+);
+note = uni142B;
+unicode = 5163;
+},
+{
+glyphname = "in-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+pos = (499,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 853;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142C;
+unicode = 5164;
+},
+{
+glyphname = "on-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (536,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 890;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142D;
+unicode = 5165;
+},
+{
+glyphname = "an-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (650,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 1004;
+}
+);
+metricRight = "graveFinal-canadian";
+note = uni142E;
+unicode = 5166;
+},
+{
+glyphname = "pe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (412,470);
+},
+{
+name = top_center_can;
+pos = (475,714);
+},
+{
+name = top_left_can;
+pos = (243,714);
+},
+{
+name = top_right_can;
+pos = (709,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(348,0,l),
+(819,674,l),
+(828,714,l),
+(657,714,l),
+(307,202,l),
+(403,202,l),
+(273,714,l),
+(123,714,l),
+(115,674,l),
+(299,0,l)
+);
+}
+);
+width = 755;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni142F;
+unicode = 5167;
+},
+{
+glyphname = "paai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (242,0);
+ref = ring_top.canadian;
+}
+);
+width = 756;
+}
+);
+note = uni1430;
+unicode = 5168;
+},
+{
+glyphname = "pi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (393,275);
+},
+{
+name = top_center_can;
+pos = (476,714);
+},
+{
+name = top_left_can;
+pos = (243,714);
+},
+{
+name = top_right_can;
+pos = (709,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(451,714,l),
+(-20,40,l),
+(-29,0,l),
+(142,0,l),
+(492,512,l),
+(396,512,l),
+(526,0,l),
+(676,0,l),
+(685,40,l),
+(500,714,l)
+);
+}
+);
+width = 756;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni1431;
+unicode = 5169;
+},
+{
+glyphname = "pii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (281,0);
+ref = dot_top;
+}
+);
+width = 756;
+}
+);
+note = uni1432;
+unicode = 5170;
+},
+{
+glyphname = "po-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (200,375);
+},
+{
+name = top_center_can;
+pos = (436,714);
+},
+{
+name = top_double;
+pos = (557,714);
+},
+{
+name = top_left_can;
+pos = (212,714);
+},
+{
+name = top_right_can;
+pos = (674,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+name = "Thin Slanted";
+shapes = (
+{
+closed = 1;
+nodes = (
+(29,0,l),
+(655,332,l),
+(666,382,l),
+(180,714,l),
+(141,714,l),
+(111,572,l),
+(461,336,l),
+(475,409,l),
+(26,174,l),
+(-11,0,l)
+);
+}
+);
+width = 667;
+}
+);
+metricRight = "o-canadian";
+note = uni1433;
+unicode = 5171;
+},
+{
+glyphname = "poo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (17,0);
+ref = dot_top;
+}
+);
+width = 668;
+}
+);
+note = uni1434;
+unicode = 5172;
+},
+{
+glyphname = "ycreepoo-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (171,0);
+ref = doubledot_top;
+}
+);
+width = 668;
+}
+);
+note = uni1435;
+unicode = 5173;
+},
+{
+glyphname = "heeCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (125,18);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 668;
+}
+);
+note = uni1436;
+unicode = 5174;
+},
+{
+glyphname = "hiCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (99,23);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 668;
+}
+);
+note = uni1437;
+unicode = 5175;
+},
+{
+glyphname = "pa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (435,357);
+},
+{
+name = top_center_can;
+pos = (428,714);
+},
+{
+name = top_left_can;
+pos = (201,714);
+},
+{
+name = top_right_can;
+pos = (651,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(682,714,l),
+(56,382,l),
+(45,332,l),
+(531,0,l),
+(570,0,l),
+(600,142,l),
+(250,378,l),
+(237,305,l),
+(684,540,l),
+(721,714,l)
+);
+}
+);
+width = 667;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1438;
+unicode = 5176;
+},
+{
+glyphname = "paa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (456,0);
+ref = dot_top;
+}
+);
+width = 668;
+}
+);
+note = uni1439;
+unicode = 5177;
+},
+{
+glyphname = "pwe-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "pe-canadian";
+}
+);
+width = 1000;
+}
+);
+note = uni143A;
+unicode = 5178;
+},
+{
+glyphname = "pweWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "pe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (756,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1000;
+}
+);
+note = uni143B;
+unicode = 5179;
+},
+{
+glyphname = "pwi-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "pi-canadian";
+}
+);
+width = 1000;
+}
+);
+note = uni143C;
+unicode = 5180;
+},
+{
+glyphname = "pwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (756,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1000;
+}
+);
+note = uni143D;
+unicode = 5181;
+},
+{
+glyphname = "pwii-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (526,0);
+ref = dot_top;
+}
+);
+width = 1000;
+}
+);
+note = uni143E;
+unicode = 5182;
+},
+{
+glyphname = "pwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (281,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (756,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1000;
+}
+);
+note = uni143F;
+unicode = 5183;
+},
+{
+glyphname = "pwo-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "po-canadian";
+}
+);
+width = 912;
+}
+);
+note = uni1440;
+unicode = 5184;
+},
+{
+glyphname = "pwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (668,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 912;
+}
+);
+note = uni1441;
+unicode = 5185;
+},
+{
+glyphname = "pwoo-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (486,0);
+ref = dot_top;
+}
+);
+width = 912;
+}
+);
+note = uni1442;
+unicode = 5186;
+},
+{
+glyphname = "pwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (17,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (668,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 912;
+}
+);
+note = uni1443;
+unicode = 5187;
+},
+{
+glyphname = "pwa-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "pa-canadian";
+}
+);
+width = 912;
+}
+);
+note = uni1444;
+unicode = 5188;
+},
+{
+glyphname = "pwaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (668,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 912;
+}
+);
+note = uni1445;
+unicode = 5189;
+},
+{
+glyphname = "pwaa-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (701,0);
+ref = dot_top;
+}
+);
+width = 912;
+}
+);
+note = uni1446;
+unicode = 5190;
+},
+{
+glyphname = "pwaaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (456,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (668,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 912;
+}
+);
+note = uni1447;
+unicode = 5191;
+},
+{
+glyphname = "ycreepwaa-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+pos = (87,-207);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (293,-98);
+ref = dot_top;
+}
+);
+width = 667;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1448;
+unicode = 5192;
+},
+{
+glyphname = "p-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(373,357,l),
+(393,452,l),
+(221,569,l),
+(201,483,l),
+(424,600,l),
+(449,714,l),
+(429,714,l),
+(118,549,l),
+(112,523,l),
+(353,357,l)
+);
+}
+);
+width = 406;
+}
+);
+note = uni1449;
+unicode = 5193;
+},
+{
+glyphname = "pWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(190,357,l),
+(266,714,l),
+(153,714,l),
+(77,357,l)
+);
+}
+);
+width = 223;
+}
+);
+metricRight = "=|";
+note = uni144A;
+unicode = 5194;
+},
+{
+color = 6;
+glyphname = "hCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(154,189,l),
+(177,299,ls),
+(184,333,o),
+(201,350,o),
+(221,350,cs),
+(255,350,o),
+(266,331,o),
+(258,296,cs),
+(235,189,l),
+(348,189,l),
+(375,317,ls),
+(392,395,o),
+(349,452,o),
+(269,452,cs),
+(224,452,o),
+(181,430,o),
+(168,398,c),
+(194,378,l),
+(230,546,l),
+(117,546,l),
+(41,189,l)
+);
+}
+);
+width = 397;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144B;
+unicode = 5195;
+},
+{
+glyphname = "te-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (396,357);
+},
+{
+name = top_center_can;
+pos = (472,714);
+},
+{
+name = top_left_can;
+pos = (238,714);
+},
+{
+name = top_right_can;
+pos = (707,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(547,-15,o),
+(657,85,o),
+(702,295,cs),
+(791,714,l),
+(625,714,l),
+(536,299,ls),
+(512,186,o),
+(457,135,o),
+(365,135,cs),
+(254,135,o),
+(212,198,o),
+(237,318,cs),
+(321,714,l),
+(155,714,l),
+(73,330,ls),
+(28,115,o),
+(139,-15,o),
+(351,-15,cs)
+);
+}
+);
+width = 750;
+}
+);
+metricRight = "=|";
+note = uni144C;
+unicode = 5196;
+},
+{
+glyphname = "taai-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (239,0);
+ref = ring_top.canadian;
+}
+);
+width = 751;
+}
+);
+note = uni144D;
+unicode = 5197;
+},
+{
+glyphname = "ti-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (397,357);
+},
+{
+name = middle_right_can;
+pos = (866,357);
+},
+{
+name = top_center_can;
+pos = (473,714);
+},
+{
+name = top_left_can;
+pos = (239,714);
+},
+{
+name = top_right_can;
+pos = (708,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(169,0,l),
+(258,415,ls),
+(282,528,o),
+(337,579,o),
+(429,579,cs),
+(540,579,o),
+(582,516,o),
+(557,396,cs),
+(473,0,l),
+(639,0,l),
+(721,384,ls),
+(766,599,o),
+(655,729,o),
+(443,729,cs),
+(247,729,o),
+(137,629,o),
+(92,419,cs),
+(3,0,l)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni144E;
+unicode = 5198;
+},
+{
+glyphname = "tii-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (278,0);
+ref = dot_top;
+}
+);
+width = 751;
+}
+);
+note = uni144F;
+unicode = 5199;
+},
+{
+glyphname = "to-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (258,357);
+},
+{
+name = middle_right_can;
+pos = (761,357);
+},
+{
+name = top_center_can;
+pos = (390,714);
+},
+{
+name = top_double;
+pos = (485,714);
+},
+{
+name = top_left_can;
+pos = (219,714);
+},
+{
+name = top_right_can;
+pos = (614,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(181,0,ls),
+(524,0,o),
+(613,251,o),
+(613,426,cs),
+(613,605,o),
+(498,714,o),
+(298,714,cs),
+(147,714,l),
+(116,565,l),
+(273,565,ls),
+(388,565,o),
+(446,510,o),
+(446,410,cs),
+(446,293,o),
+(388,149,o),
+(196,149,cs),
+(27,149,l),
+(-4,0,l)
+);
+}
+);
+width = 639;
+}
+);
+note = uni1450;
+unicode = 5200;
+},
+{
+glyphname = "too-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (195,0);
+ref = dot_top;
+}
+);
+width = 639;
+}
+);
+note = uni1451;
+unicode = 5201;
+},
+{
+glyphname = "ycreetoo-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (99,0);
+ref = doubledot_top;
+}
+);
+width = 639;
+}
+);
+note = uni1452;
+unicode = 5202;
+},
+{
+glyphname = "deeCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (171,0);
+ref = stroke_middle;
+}
+);
+width = 639;
+}
+);
+note = uni1453;
+unicode = 5203;
+},
+{
+glyphname = "diCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (140,0);
+ref = dot_middle;
+}
+);
+width = 639;
+}
+);
+note = uni1454;
+unicode = 5204;
+},
+{
+glyphname = "ta-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (424,357);
+},
+{
+name = top_center_can;
+pos = (445,714);
+},
+{
+name = top_left_can;
+pos = (220,714);
+},
+{
+name = top_right_can;
+pos = (614,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(535,0,l),
+(566,149,l),
+(409,149,ls),
+(294,149,o),
+(236,204,o),
+(236,304,cs),
+(236,426,o),
+(300,565,o),
+(486,565,cs),
+(655,565,l),
+(686,714,l),
+(501,714,ls),
+(163,714,o),
+(70,468,o),
+(70,288,cs),
+(70,109,o),
+(184,0,o),
+(384,0,cs)
+);
+}
+);
+width = 638;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|to-canadian";
+note = uni1455;
+unicode = 5205;
+},
+{
+glyphname = "taa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (251,0);
+ref = dot_top;
+}
+);
+width = 639;
+}
+);
+note = uni1456;
+unicode = 5206;
+},
+{
+glyphname = "twe-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "te-canadian";
+}
+);
+width = 996;
+}
+);
+note = uni1457;
+unicode = 5207;
+},
+{
+glyphname = "tweWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (751,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 996;
+}
+);
+note = uni1458;
+unicode = 5208;
+},
+{
+glyphname = "twi-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ti-canadian";
+}
+);
+width = 996;
+}
+);
+note = uni1459;
+unicode = 5209;
+},
+{
+glyphname = "twiWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (751,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 996;
+}
+);
+note = uni145A;
+unicode = 5210;
+},
+{
+glyphname = "twii-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (523,0);
+ref = dot_top;
+}
+);
+width = 996;
+}
+);
+note = uni145B;
+unicode = 5211;
+},
+{
+glyphname = "twiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (278,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (751,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 996;
+}
+);
+note = uni145C;
+unicode = 5212;
+},
+{
+glyphname = "two-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "to-canadian";
+}
+);
+width = 884;
+}
+);
+note = uni145D;
+unicode = 5213;
+},
+{
+glyphname = "twoWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (639,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 884;
+}
+);
+note = uni145E;
+unicode = 5214;
+},
+{
+glyphname = "twoo-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (439,0);
+ref = dot_top;
+}
+);
+width = 884;
+}
+);
+note = uni145F;
+unicode = 5215;
+},
+{
+glyphname = "twooWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (195,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (639,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 884;
+}
+);
+note = uni1460;
+unicode = 5216;
+},
+{
+glyphname = "twa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ta-canadian";
+}
+);
+width = 884;
+}
+);
+note = uni1461;
+unicode = 5217;
+},
+{
+glyphname = "twaWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (639,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 884;
+}
+);
+note = uni1462;
+unicode = 5218;
+},
+{
+glyphname = "twaa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (496,0);
+ref = dot_top;
+}
+);
+width = 884;
+}
+);
+note = uni1463;
+unicode = 5219;
+},
+{
+glyphname = "twaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (251,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (639,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 884;
+}
+);
+note = uni1464;
+unicode = 5220;
+},
+{
+glyphname = "twaaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ta-canadian";
+}
+);
+width = 884;
+}
+);
+note = uni1465;
+unicode = 5221;
+},
+{
+glyphname = "t-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(345,357,l),
+(367,462,l),
+(286,462,ls),
+(241,462,o),
+(221,483,o),
+(221,517,cs),
+(221,568,o),
+(248,609,o),
+(318,609,cs),
+(398,609,l),
+(421,714,l),
+(333,714,ls),
+(188,714,o),
+(106,626,o),
+(106,504,cs),
+(106,414,o),
+(166,357,o),
+(267,357,cs)
+);
+}
+);
+width = 378;
+}
+);
+note = uni1466;
+unicode = 5222;
+},
+{
+glyphname = "tte-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+pos = (751,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni1467;
+unicode = 5223;
+},
+{
+glyphname = "tti-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+pos = (751,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni1468;
+unicode = 5224;
+},
+{
+glyphname = "tto-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+pos = (639,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 863;
+}
+);
+note = uni1469;
+unicode = 5225;
+},
+{
+glyphname = "tta-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+pos = (639,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 863;
+}
+);
+note = uni146A;
+unicode = 5226;
+},
+{
+glyphname = "ke-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (345,457);
+},
+{
+name = top_center_can;
+pos = (395,714);
+},
+{
+name = top_left_can;
+pos = (220,714);
+},
+{
+name = top_right_can;
+pos = (552,723);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(502,0,l),
+(590,414,ls),
+(623,571,o),
+(569,729,o),
+(374,729,cs),
+(186,729,o),
+(83,569,o),
+(83,406,cs),
+(83,277,o),
+(162,190,o),
+(283,190,cs),
+(340,190,o),
+(390,213,o),
+(412,252,c),
+(392,264,l),
+(336,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(275,330,o),
+(245,363,o),
+(245,419,cs),
+(245,473,o),
+(272,589,o),
+(358,589,cs),
+(409,589,o),
+(439,555,o),
+(439,499,cs),
+(439,445,o),
+(412,330,o),
+(325,330,cs)
+);
+}
+);
+width = 613;
+}
+);
+metricRight = "te-canadian";
+note = uni146B;
+unicode = 5227;
+},
+{
+glyphname = "kaai-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (177,0);
+ref = ring_top.canadian;
+}
+);
+width = 614;
+}
+);
+note = uni146C;
+unicode = 5228;
+},
+{
+glyphname = "ki-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (361,457);
+},
+{
+name = top_center_can;
+pos = (411,714);
+},
+{
+name = top_left_can;
+pos = (238,714);
+},
+{
+name = top_right_can;
+pos = (588,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(169,0,l),
+(229,281,l),
+(211,266,l),
+(214,225,o),
+(276,190,o),
+(350,190,cs),
+(531,190,o),
+(617,364,o),
+(617,503,cs),
+(617,642,o),
+(528,729,o),
+(388,729,cs),
+(241,729,o),
+(139,639,o),
+(105,481,cs),
+(3,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(292,330,o),
+(262,363,o),
+(262,419,cs),
+(262,473,o),
+(291,589,o),
+(376,589,cs),
+(426,589,o),
+(457,555,o),
+(457,499,cs),
+(457,446,o),
+(429,330,o),
+(342,330,cs)
+);
+}
+);
+width = 614;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni146D;
+unicode = 5229;
+},
+{
+glyphname = "kii-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (216,0);
+ref = dot_top;
+}
+);
+width = 614;
+}
+);
+note = uni146E;
+unicode = 5230;
+},
+{
+glyphname = "ko-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (310,287);
+},
+{
+name = top_center_can;
+pos = (397,714);
+},
+{
+name = top_double;
+pos = (571,714);
+},
+{
+name = top_left_can;
+pos = (221,714);
+},
+{
+name = top_right_can;
+pos = (571,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(416,-15,o),
+(518,75,o),
+(552,233,cs),
+(654,714,l),
+(487.994,714,l),
+(428,433,l),
+(446,448,l),
+(443,489,o),
+(382,524,o),
+(307,524,cs),
+(127,524,o),
+(41,349,o),
+(41,210,cs),
+(41,72,o),
+(129,-15,o),
+(275,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(231,125,o),
+(201,158,o),
+(201,214,cs),
+(201,268,o),
+(231,384,o),
+(315,384,cs),
+(365,384,o),
+(395,351,o),
+(395,295,cs),
+(395,241,o),
+(368,125,o),
+(282,125,cs)
+);
+}
+);
+width = 614;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni146F;
+unicode = 5231;
+},
+{
+glyphname = "koo-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (376,0);
+ref = dot_top;
+}
+);
+width = 614;
+}
+);
+note = uni1470;
+unicode = 5232;
+},
+{
+glyphname = "ycreekoo-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (185,0);
+ref = doubledot_top;
+}
+);
+width = 614;
+}
+);
+note = uni1471;
+unicode = 5233;
+},
+{
+glyphname = "ka-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (326,291);
+},
+{
+name = top_center_can;
+pos = (412,714);
+},
+{
+name = top_left_can;
+pos = (238,714);
+},
+{
+name = top_right_can;
+pos = (588,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(471,-15,o),
+(575,145,o),
+(575,307,cs),
+(575,437,o),
+(496,524,o),
+(374,524,cs),
+(317,524,o),
+(268,501,o),
+(245,462,c),
+(265,450,l),
+(321,714,l),
+(155,714,l),
+(68,302,ls),
+(27,110,o),
+(116,-15,o),
+(289,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(248,125,o),
+(219,159,o),
+(219,215,cs),
+(219,269,o),
+(246,384,o),
+(332,384,cs),
+(383,384,o),
+(413,351,o),
+(413,295,cs),
+(413,242,o),
+(386,125,o),
+(299,125,cs)
+);
+}
+);
+width = 614;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "==|ke-canadian";
+note = uni1472;
+unicode = 5234;
+},
+{
+glyphname = "kaa-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (43,0);
+ref = dot_top;
+}
+);
+width = 614;
+}
+);
+note = uni1473;
+unicode = 5235;
+},
+{
+glyphname = "kwe-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ke-canadian";
+}
+);
+width = 859;
+}
+);
+note = uni1474;
+unicode = 5236;
+},
+{
+glyphname = "kweWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (614,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 859;
+}
+);
+note = uni1475;
+unicode = 5237;
+},
+{
+glyphname = "kwi-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ki-canadian";
+}
+);
+width = 859;
+}
+);
+note = uni1476;
+unicode = 5238;
+},
+{
+glyphname = "kwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (614,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 859;
+}
+);
+note = uni1477;
+unicode = 5239;
+},
+{
+glyphname = "kwii-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (461,0);
+ref = dot_top;
+}
+);
+width = 859;
+}
+);
+note = uni1478;
+unicode = 5240;
+},
+{
+glyphname = "kwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (216,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (614,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 859;
+}
+);
+note = uni1479;
+unicode = 5241;
+},
+{
+glyphname = "kwo-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ko-canadian";
+}
+);
+width = 859;
+}
+);
+note = uni147A;
+unicode = 5242;
+},
+{
+glyphname = "kwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (614,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 859;
+}
+);
+note = uni147B;
+unicode = 5243;
+},
+{
+glyphname = "kwoo-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (621,0);
+ref = dot_top;
+}
+);
+width = 859;
+}
+);
+note = uni147C;
+unicode = 5244;
+},
+{
+glyphname = "kwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (376,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (614,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 859;
+}
+);
+note = uni147D;
+unicode = 5245;
+},
+{
+glyphname = "kwa-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ka-canadian";
+}
+);
+width = 859;
+}
+);
+note = uni147E;
+unicode = 5246;
+},
+{
+glyphname = "kwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (614,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 859;
+}
+);
+note = uni147F;
+unicode = 5247;
+},
+{
+glyphname = "kwaa-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (288,0);
+ref = dot_top;
+}
+);
+width = 859;
+}
+);
+note = uni1480;
+unicode = 5248;
+},
+{
+glyphname = "kwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (43,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (614,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 859;
+}
+);
+note = uni1481;
+unicode = 5249;
+},
+{
+glyphname = "kwaaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ka-canadian";
+}
+);
+width = 859;
+}
+);
+note = uni1482;
+unicode = 5250;
+},
+{
+glyphname = "k-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(339,351,o),
+(395,434,o),
+(395,515,cs),
+(395,578,o),
+(356,622,o),
+(290,622,cs),
+(254,622,o),
+(225,606,o),
+(210,580,c),
+(236,577,l),
+(266,714,l),
+(153,714,l),
+(110,512,ls),
+(92,426,o),
+(129,351,o),
+(236,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(222,433,o),
+(207,448,o),
+(207,472,cs),
+(207,502,o),
+(227,543,o),
+(258,543,cs),
+(280,543,o),
+(294,528,o),
+(294,503,cs),
+(294,473,o),
+(274,433,o),
+(243,433,cs)
+);
+}
+);
+width = 389;
+}
+);
+note = uni1483;
+unicode = 5251;
+},
+{
+glyphname = "kw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(307,351,o),
+(364,396,o),
+(383,485,cs),
+(431,714,l),
+(318,714,l),
+(288,573,l),
+(310,574,l),
+(307,600,o),
+(274,622,o),
+(234,622,cs),
+(147,622,o),
+(95,545,o),
+(95,470,cs),
+(95,399,o),
+(145,351,o),
+(226,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(207,431,o),
+(193,446,o),
+(193,471,cs),
+(193,501,o),
+(213,541,o),
+(244,541,cs),
+(266,541,o),
+(281,526,o),
+(281,502,cs),
+(281,472,o),
+(261,431,o),
+(230,431,cs)
+);
+}
+);
+width = 389;
+}
+);
+metricLeft = "=|k-canadian";
+metricRight = "=|k-canadian";
+note = uni1484;
+unicode = 5252;
+},
+{
+glyphname = "southslaveykeh-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+pos = (614,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni1485;
+unicode = 5253;
+},
+{
+glyphname = "southslaveykih-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+pos = (614,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni1486;
+unicode = 5254;
+},
+{
+glyphname = "southslaveykoh-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+pos = (614,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni1487;
+unicode = 5255;
+},
+{
+glyphname = "southslaveykah-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+pos = (614,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni1488;
+unicode = 5256;
+},
+{
+glyphname = "ce-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (324,373);
+},
+{
+name = top_center_can;
+pos = (396,714);
+},
+{
+name = top_left_can;
+pos = (222,714);
+},
+{
+name = top_right_can;
+pos = (564,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(494,0,l),
+(589,445,ls),
+(624,614,o),
+(535,729,o),
+(369,729,cs),
+(218,729,o),
+(125,642,o),
+(89,477,cs),
+(71,393,l),
+(235,393,l),
+(253,475,ls),
+(268,551,o),
+(301,585,o),
+(355,585,cs),
+(417,585,o),
+(443,541,o),
+(427,466,cs),
+(328,0,l)
+);
+}
+);
+width = 606;
+}
+);
+metricRight = "te-canadian";
+note = uni1489;
+unicode = 5257;
+},
+{
+glyphname = "caai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (179,0);
+ref = ring_top.canadian;
+}
+);
+width = 606;
+}
+);
+note = uni148A;
+unicode = 5258;
+},
+{
+glyphname = "ci-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (329,373);
+},
+{
+name = top_center_can;
+pos = (413,714);
+},
+{
+name = top_left_can;
+pos = (238,714);
+},
+{
+name = top_right_can;
+pos = (581,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(169,0,l),
+(270,475,ls),
+(286,551,o),
+(318,585,o),
+(372,585,cs),
+(434,585,o),
+(460,541,o),
+(445,466,cs),
+(429,393,l),
+(594,393,l),
+(605,445,ls),
+(641,614,o),
+(551,729,o),
+(385,729,cs),
+(234,729,o),
+(140,642,o),
+(105,477,cs),
+(3,0,l)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+unicode = 5259;
+},
+{
+glyphname = "cii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:59 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (218,0);
+ref = dot_top;
+}
+);
+width = 607;
+}
+);
+note = uni148C;
+unicode = 5260;
+},
+{
+glyphname = "co-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (324,373);
+},
+{
+name = top_center_can;
+pos = (396,714);
+},
+{
+name = top_double;
+pos = (564,714);
+},
+{
+name = top_left_can;
+pos = (222,714);
+},
+{
+name = top_right_can;
+pos = (564,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(415,-15,o),
+(509,72,o),
+(544,237,cs),
+(646,714,l),
+(480,714,l),
+(379,239,ls),
+(363,163,o),
+(331,129,o),
+(277,129,cs),
+(215,129,o),
+(190,173,o),
+(205,248,cs),
+(220,321,l),
+(56,321,l),
+(45,269,ls),
+(9,100,o),
+(99,-15,o),
+(264,-15,cs)
+);
+}
+);
+width = 605;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+unicode = 5261;
+},
+{
+glyphname = "coo-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (368,0);
+ref = dot_top;
+}
+);
+width = 606;
+}
+);
+note = uni148E;
+unicode = 5262;
+},
+{
+glyphname = "ycreecoo-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (178,0);
+ref = doubledot_top;
+}
+);
+width = 606;
+}
+);
+note = uni148F;
+unicode = 5263;
+},
+{
+glyphname = "ca-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (329,373);
+},
+{
+name = top_center_can;
+pos = (414,714);
+},
+{
+name = top_left_can;
+pos = (239,714);
+},
+{
+name = top_right_can;
+pos = (580,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(431,-15,o),
+(525,72,o),
+(560,237,cs),
+(578,321,l),
+(414,321,l),
+(397,239,ls),
+(381,163,o),
+(348,129,o),
+(295,129,cs),
+(233,129,o),
+(207,173,o),
+(223,248,cs),
+(321,714,l),
+(155,714,l),
+(61,269,ls),
+(25,100,o),
+(115,-15,o),
+(280,-15,cs)
+);
+}
+);
+width = 606;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+unicode = 5264;
+},
+{
+glyphname = "caa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (44,0);
+ref = dot_top;
+}
+);
+width = 606;
+}
+);
+note = uni1491;
+unicode = 5265;
+},
+{
+glyphname = "cwe-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ce-canadian";
+}
+);
+width = 851;
+}
+);
+note = uni1492;
+unicode = 5266;
+},
+{
+glyphname = "cweWestCree-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (606,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 851;
+}
+);
+note = uni1493;
+unicode = 5267;
+},
+{
+glyphname = "cwi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:59 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+pos = (245,0);
+ref = "ci-canadian";
+}
+);
+width = 852;
+}
+);
+note = uni1494;
+unicode = 5268;
+},
+{
+glyphname = "cwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:59 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "ci-canadian";
+},
+{
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 852;
+}
+);
+note = uni1495;
+unicode = 5269;
+},
+{
+glyphname = "cwii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:59 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+pos = (245,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (463,0);
+ref = dot_top;
+}
+);
+width = 852;
+}
+);
+note = uni1496;
+unicode = 5270;
+},
+{
+glyphname = "cwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:59 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (218,0);
+ref = dot_top;
+},
+{
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 852;
+}
+);
+note = uni1497;
+unicode = 5271;
+},
+{
+glyphname = "cwo-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "co-canadian";
+}
+);
+width = 851;
+}
+);
+note = uni1498;
+unicode = 5272;
+},
+{
+glyphname = "cwoWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (606,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 851;
+}
+);
+note = uni1499;
+unicode = 5273;
+},
+{
+glyphname = "cwoo-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (613,0);
+ref = dot_top;
+}
+);
+width = 851;
+}
+);
+note = uni149A;
+unicode = 5274;
+},
+{
+glyphname = "cwooWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (368,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (606,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 851;
+}
+);
+note = uni149B;
+unicode = 5275;
+},
+{
+glyphname = "cwa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ca-canadian";
+}
+);
+width = 851;
+}
+);
+note = uni149C;
+unicode = 5276;
+},
+{
+glyphname = "cwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (606,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 851;
+}
+);
+note = uni149D;
+unicode = 5277;
+},
+{
+glyphname = "cwaa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (288,0);
+ref = dot_top;
+}
+);
+width = 851;
+}
+);
+note = uni149E;
+unicode = 5278;
+},
+{
+glyphname = "cwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (44,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (606,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 851;
+}
+);
+note = uni149F;
+unicode = 5279;
+},
+{
+glyphname = "cwaaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ca-canadian";
+}
+);
+width = 851;
+}
+);
+note = uni14A0;
+unicode = 5280;
+},
+{
+glyphname = "c-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(320,351,o),
+(378,398,o),
+(395,480,cs),
+(401,508,l),
+(295,508,l),
+(288,477,ls),
+(283,451,o),
+(269,438,o),
+(247,438,cs),
+(222,438,o),
+(211,454,o),
+(217,483,cs),
+(266,714,l),
+(153,714,l),
+(109,506,ls),
+(89,412,o),
+(138,351,o),
+(240,351,cs)
+);
+}
+);
+width = 379;
+}
+);
+note = uni14A1;
+unicode = 5281;
+},
+{
+glyphname = "thSayisi-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(296,351,o),
+(353,398,o),
+(370,480,cs),
+(420,714,l),
+(307,714,l),
+(257,478,ls),
+(252,451,o),
+(235,438,o),
+(215,438,cs),
+(190,438,o),
+(179,454,o),
+(185,482,cs),
+(191,508,l),
+(86,508,l),
+(82,492,ls),
+(65,412,o),
+(113,351,o),
+(209,351,cs)
+);
+}
+);
+width = 377;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "=|c-canadian";
+note = uni14A2;
+unicode = 5282;
+},
+{
+glyphname = "me-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:28:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (211,357);
+},
+{
+name = top_center_can;
+pos = (373,714);
+},
+{
+name = top_left_can;
+pos = (216,714);
+},
+{
+name = top_right_can;
+pos = (521,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(452,0,l),
+(604,714,l),
+(134,714,l),
+(103,565,l),
+(406,565,l),
+(286,0,l)
+);
+}
+);
+width = 570;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+unicode = 5283;
+},
+{
+glyphname = "maai-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (163,0);
+ref = ring_top.canadian;
+}
+);
+width = 571;
+}
+);
+note = uni14A4;
+unicode = 5284;
+},
+{
+glyphname = "mi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (405,357);
+},
+{
+name = top_center_can;
+pos = (397,714);
+},
+{
+name = top_left_can;
+pos = (246,714);
+},
+{
+name = top_right_can;
+pos = (550,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(176,0,l),
+(297,565,l),
+(601,565,l),
+(632,714,l),
+(162,714,l),
+(10,0,l)
+);
+}
+);
+width = 571;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+unicode = 5285;
+},
+{
+glyphname = "mii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (202,0);
+ref = dot_top;
+}
+);
+width = 571;
+}
+);
+note = uni14A6;
+unicode = 5286;
+},
+{
+glyphname = "mo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (211,357);
+},
+{
+name = top_center_can;
+pos = (374,714);
+},
+{
+name = top_double;
+pos = (522,714);
+},
+{
+name = top_left_can;
+pos = (217,714);
+},
+{
+name = top_right_can;
+pos = (522,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(452,0,l),
+(604,714,l),
+(438,714,l),
+(318,149,l),
+(14,149,l),
+(-17,0,l)
+);
+}
+);
+width = 570;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+unicode = 5287;
+},
+{
+glyphname = "moo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (327,0);
+ref = dot_top;
+}
+);
+width = 571;
+}
+);
+note = uni14A8;
+unicode = 5288;
+},
+{
+glyphname = "ycreemoo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (136,0);
+ref = doubledot_top;
+}
+);
+width = 571;
+}
+);
+note = uni14A9;
+unicode = 5289;
+},
+{
+glyphname = "ma-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (405,357);
+},
+{
+name = top_center_can;
+pos = (397,714);
+},
+{
+name = top_left_can;
+pos = (246,714);
+},
+{
+name = top_right_can;
+pos = (549,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(480,0,l),
+(512,149,l),
+(208,149,l),
+(328,714,l),
+(162,714,l),
+(10,0,l)
+);
+}
+);
+width = 570;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+unicode = 5290;
+},
+{
+glyphname = "maa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+}
+);
+width = 571;
+}
+);
+note = uni14AB;
+unicode = 5291;
+},
+{
+glyphname = "mwe-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "me-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni14AC;
+unicode = 5292;
+},
+{
+glyphname = "mweWestCree-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "me-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (571,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni14AD;
+unicode = 5293;
+},
+{
+glyphname = "mwi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "mi-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni14AE;
+unicode = 5294;
+},
+{
+glyphname = "mwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (571,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni14AF;
+unicode = 5295;
+},
+{
+glyphname = "mwii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (447,0);
+ref = dot_top;
+}
+);
+width = 816;
+}
+);
+note = uni14B0;
+unicode = 5296;
+},
+{
+glyphname = "mwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (202,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (571,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni14B1;
+unicode = 5297;
+},
+{
+glyphname = "mwo-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "mo-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni14B2;
+unicode = 5298;
+},
+{
+glyphname = "mwoWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (571,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni14B3;
+unicode = 5299;
+},
+{
+glyphname = "mwoo-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (571,0);
+ref = dot_top;
+}
+);
+width = 816;
+}
+);
+note = uni14B4;
+unicode = 5300;
+},
+{
+glyphname = "mwooWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (327,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (571,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni14B5;
+unicode = 5301;
+},
+{
+glyphname = "mwa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ma-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni14B6;
+unicode = 5302;
+},
+{
+glyphname = "mwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (571,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni14B7;
+unicode = 5303;
+},
+{
+glyphname = "mwaa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (295,0);
+ref = dot_top;
+}
+);
+width = 816;
+}
+);
+note = uni14B8;
+unicode = 5304;
+},
+{
+glyphname = "mwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (571,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni14B9;
+unicode = 5305;
+},
+{
+glyphname = "mwaaNaskapi-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ma-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni14BA;
+unicode = 5306;
+},
+{
+glyphname = "m-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(332,357,l),
+(354,462,l),
+(212,462,l),
+(266,714,l),
+(153,714,l),
+(77,357,l)
+);
+}
+);
+width = 352;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni14BB;
+unicode = 5307;
+},
+{
+glyphname = "mWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "t-canadian";
+}
+);
+width = 378;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "t-canadian";
+note = uni14BC;
+unicode = 5308;
+},
+{
+glyphname = "mh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(319,357,l),
+(395,714,l),
+(282,714,l),
+(228,462,l),
+(86,462,l),
+(64,357,l)
+);
+}
+);
+width = 352;
+}
+);
+metricLeft = "=|m-canadian";
+metricRight = "=|m-canadian";
+note = uni14BD;
+unicode = 5309;
+},
+{
+glyphname = "mAthapascan-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(342,357,l),
+(360,446,l),
+(205,446,l),
+(202,402,l),
+(321,498,ls),
+(362,532,o),
+(386,571,o),
+(386,617,cs),
+(386,677,o),
+(339,720,o),
+(266,720,cs),
+(186,720,o),
+(132,680,o),
+(113,588,c),
+(213,588,l),
+(219,624,o),
+(236,640,o),
+(257,640,cs),
+(277,640,o),
+(288,628,o),
+(288,611,cs),
+(288,586,o),
+(267,561,o),
+(233,533,cs),
+(90,416,l),
+(77,357,l)
+);
+}
+);
+width = 363;
+}
+);
+note = uni14BE;
+unicode = 5310;
+},
+{
+glyphname = "mSayisi-canadian";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = two.canadian;
+}
+);
+width = 609;
+}
+);
+note = uni14BF;
+unicode = 5311;
+},
+{
+glyphname = "ne-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (522,254);
+},
+{
+name = top_center_can;
+pos = (563,529);
+},
+{
+name = top_left_can;
+pos = (183,529);
+},
+{
+name = top_right_can;
+pos = (761,529);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(679,-15,o),
+(784,135,o),
+(784,285,cs),
+(784,419,o),
+(690,509,o),
+(544,509,cs),
+(96,509,l),
+(65,362,l),
+(364,362,l),
+(358,423,l),
+(286,371,o),
+(259,281,o),
+(259,207,cs),
+(259,74,o),
+(355,-15,o),
+(501,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(454,125,o),
+(420,161,o),
+(420,217,cs),
+(420,280,o),
+(460,369,o),
+(534,369,cs),
+(588,369,o),
+(622,333,o),
+(622,278,cs),
+(622,214,o),
+(582,125,o),
+(508,125,cs)
+);
+}
+);
+width = 827;
+}
+);
+metricRight = "=|ke-canadian";
+note = uni14C0;
+unicode = 5312;
+},
+{
+glyphname = "naai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (150,-185);
+ref = ring_top.canadian;
+}
+);
+width = 826;
+}
+);
+note = uni14C1;
+unicode = 5313;
+},
+{
+glyphname = "ni-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (304,254);
+},
+{
+name = top_center_can;
+pos = (384,529);
+},
+{
+name = top_left_can;
+pos = (182,529);
+},
+{
+name = top_right_can;
+pos = (761,529);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(460,-15,o),
+(565,135,o),
+(565,286,cs),
+(565,323,o),
+(554,358,o),
+(537,382,c),
+(506,362,l),
+(808,362,l),
+(839,509,l),
+(330,509,ls),
+(145,509,o),
+(40,360,o),
+(40,210,cs),
+(40,73,o),
+(136,-15,o),
+(282,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(235,125,o),
+(201,161,o),
+(201,217,cs),
+(201,280,o),
+(241,369,o),
+(316,369,cs),
+(370,369,o),
+(403,333,o),
+(403,278,cs),
+(403,214,o),
+(363,125,o),
+(289,125,cs)
+);
+}
+);
+width = 827;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+unicode = 5314;
+},
+{
+glyphname = "nii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (189,-185);
+ref = dot_top;
+}
+);
+width = 826;
+}
+);
+note = uni14C3;
+unicode = 5315;
+},
+{
+glyphname = "no-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (522,254);
+},
+{
+name = top_center_can;
+pos = (581,529);
+},
+{
+name = top_double;
+pos = (582,529);
+},
+{
+name = top_left_can;
+pos = (184,529);
+},
+{
+name = top_right_can;
+pos = (763,529);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(497,0,ls),
+(683,0,o),
+(788,149,o),
+(788,299,cs),
+(788,436,o),
+(691,524,o),
+(546,524,cs),
+(368,524,o),
+(263,374,o),
+(263,224,cs),
+(263,186,o),
+(273,151,o),
+(290,127,c),
+(321,147,l),
+(19,147,l),
+(-12,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(458,140,o),
+(424,176,o),
+(424,232,cs),
+(424,295,o),
+(464,384,o),
+(538,384,cs),
+(592,384,o),
+(626,348,o),
+(626,292,cs),
+(626,229,o),
+(586,140,o),
+(512,140,cs)
+);
+}
+);
+width = 828;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14C4;
+unicode = 5316;
+},
+{
+glyphname = "noo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (385,-185);
+ref = dot_top;
+}
+);
+width = 826;
+}
+);
+note = uni14C5;
+unicode = 5317;
+},
+{
+glyphname = "ycreenoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (195,-185);
+ref = doubledot_top;
+}
+);
+width = 826;
+}
+);
+note = uni14C6;
+unicode = 5318;
+},
+{
+glyphname = "na-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (304,254);
+},
+{
+name = top_center_can;
+pos = (362,529);
+},
+{
+name = top_double;
+pos = (547,529);
+},
+{
+name = top_left_can;
+pos = (181,529);
+},
+{
+name = top_right_can;
+pos = (760,529);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(730,0,l),
+(762,147,l),
+(462,147,l),
+(468,86,l),
+(540,138,o),
+(567,229,o),
+(567,302,cs),
+(567,435,o),
+(471,524,o),
+(326,524,cs),
+(148,524,o),
+(43,374,o),
+(43,225,cs),
+(43,90,o),
+(137,0,o),
+(282,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(238,140,o),
+(204,176,o),
+(204,232,cs),
+(204,295,o),
+(244,384,o),
+(319,384,cs),
+(373,384,o),
+(406,348,o),
+(406,292,cs),
+(406,229,o),
+(366,140,o),
+(292,140,cs)
+);
+}
+);
+width = 827;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+unicode = 5319;
+},
+{
+glyphname = "naa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (167,-185);
+ref = dot_top;
+}
+);
+width = 826;
+}
+);
+note = uni14C8;
+unicode = 5320;
+},
+{
+glyphname = "nwe-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ne-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni14C9;
+unicode = 5321;
+},
+{
+glyphname = "nweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (826,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni14CA;
+unicode = 5322;
+},
+{
+glyphname = "nwa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "na-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni14CB;
+unicode = 5323;
+},
+{
+glyphname = "nwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (826,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni14CC;
+unicode = 5324;
+},
+{
+glyphname = "nwaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (412,-185);
+ref = dot_top;
+}
+);
+width = 1071;
+}
+);
+note = uni14CD;
+unicode = 5325;
+},
+{
+glyphname = "nwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (167,-185);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (826,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni14CE;
+unicode = 5326;
+},
+{
+glyphname = "nwaaNaskapi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (161,-185);
+ref = doubledot_top;
+}
+);
+width = 826;
+}
+);
+note = uni14CF;
+unicode = 5327;
+},
+{
+glyphname = "n-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(488,450,l),
+(511,555,l),
+(348,555,l),
+(340,488,l),
+(381,510,o),
+(401,563,o),
+(401,604,cs),
+(401,674,o),
+(349,722,o),
+(269,722,cs),
+(178,722,o),
+(116,654,o),
+(116,571,cs),
+(116,500,o),
+(168,450,o),
+(246,450,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(229,531,o),
+(214,547,o),
+(214,571,cs),
+(214,601,o),
+(232,641,o),
+(266,641,cs),
+(289,641,o),
+(303,625,o),
+(303,601,cs),
+(303,571,o),
+(285,531,o),
+(252,531,cs)
+);
+}
+);
+width = 489;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni14D0;
+unicode = 5328;
+},
+{
+color = 6;
+glyphname = "ngCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-167);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 444;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "=|";
+note = uni14D1;
+unicode = 5329;
+},
+{
+glyphname = "nh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(355,450,ls),
+(453,450,o),
+(513,516,o),
+(513,602,cs),
+(513,672,o),
+(462,722,o),
+(381,722,cs),
+(290,722,o),
+(229,654,o),
+(229,571,cs),
+(229,548,o),
+(237,525,o),
+(252,509,c),
+(269,555,l),
+(106,555,l),
+(84,450,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(341,531,o),
+(327,547,o),
+(327,571,cs),
+(327,601,o),
+(344,641,o),
+(378,641,cs),
+(401,641,o),
+(415,625,o),
+(415,601,cs),
+(415,571,o),
+(398,531,o),
+(364,531,cs)
+);
+}
+);
+width = 488;
+}
+);
+metricLeft = "=|n-canadian";
+metricRight = "=|n-canadian";
+note = uni14D2;
+unicode = 5330;
+},
+{
+glyphname = "le-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (522,254);
+},
+{
+name = top_center_can;
+pos = (564,529);
+},
+{
+name = top_left_can;
+pos = (183,529);
+},
+{
+name = top_right_can;
+pos = (761,529);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(450,0,ls),
+(664,0,o),
+(785,116,o),
+(785,292,cs),
+(785,424,o),
+(692,509,o),
+(545,509,cs),
+(96,509,l),
+(65,361,l),
+(516,361,ls),
+(582,361,o),
+(618,329,o),
+(618,275,cs),
+(618,199,o),
+(569,145,o),
+(470,145,cs),
+(419,145,l),
+(388,0,l)
+);
+}
+);
+width = 827;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D3;
+unicode = 5331;
+},
+{
+glyphname = "laai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (151,-185);
+ref = ring_top.canadian;
+}
+);
+width = 826;
+}
+);
+note = uni14D4;
+unicode = 5332;
+},
+{
+glyphname = "li-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (306,254);
+},
+{
+name = top_center_can;
+pos = (385,529);
+},
+{
+name = top_left_can;
+pos = (183,529);
+},
+{
+name = top_right_can;
+pos = (761,529);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(331,0,l),
+(362,145,l),
+(308,145,ls),
+(244,145,o),
+(207,178,o),
+(207,232,cs),
+(207,303,o),
+(254,361,o),
+(352,361,cs),
+(807,361,l),
+(839,509,l),
+(367,509,ls),
+(167,509,o),
+(43,399,o),
+(43,224,cs),
+(43,93,o),
+(136,0,o),
+(279,0,cs)
+);
+}
+);
+width = 827;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14D5;
+unicode = 5333;
+},
+{
+glyphname = "lii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (189,-185);
+ref = dot_top;
+}
+);
+width = 826;
+}
+);
+note = uni14D6;
+unicode = 5334;
+},
+{
+glyphname = "lo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (520,254);
+},
+{
+name = top_center_can;
+pos = (579,529);
+},
+{
+name = top_double;
+pos = (566,529);
+},
+{
+name = top_left_can;
+pos = (183,529);
+},
+{
+name = top_right_can;
+pos = (760,529);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(460,0,ls),
+(659,0,o),
+(783,110,o),
+(783,285,cs),
+(783,416,o),
+(691,509,o),
+(547,509,cs),
+(495,509,l),
+(465,365,l),
+(518,365,ls),
+(582,365,o),
+(620,332,o),
+(620,277,cs),
+(620,206,o),
+(572,148,o),
+(474,148,cs),
+(19,148,l),
+(-12,0,l)
+);
+}
+);
+width = 826;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D7;
+unicode = 5335;
+},
+{
+glyphname = "loo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (384,-185);
+ref = dot_top;
+}
+);
+width = 826;
+}
+);
+note = uni14D8;
+unicode = 5336;
+},
+{
+glyphname = "ycreeloo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (180,-185);
+ref = doubledot_top;
+}
+);
+width = 826;
+}
+);
+note = uni14D9;
+unicode = 5337;
+},
+{
+glyphname = "la-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (305,254);
+},
+{
+name = top_center_can;
+pos = (363,529);
+},
+{
+name = top_left_can;
+pos = (182,529);
+},
+{
+name = top_right_can;
+pos = (760,529);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(730,0,l),
+(762,148,l),
+(310,148,ls),
+(244,148,o),
+(208,180,o),
+(208,234,cs),
+(208,310,o),
+(257,365,o),
+(356,365,cs),
+(407,365,l),
+(438,509,l),
+(377,509,ls),
+(162,509,o),
+(42,393,o),
+(42,217,cs),
+(42,85,o),
+(134,0,o),
+(282,0,cs)
+);
+}
+);
+width = 827;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14DA;
+unicode = 5338;
+},
+{
+glyphname = "laa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (168,-185);
+ref = dot_top;
+}
+);
+width = 826;
+}
+);
+note = uni14DB;
+unicode = 5339;
+},
+{
+glyphname = "lwe-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "le-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni14DC;
+unicode = 5340;
+},
+{
+glyphname = "lweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "le-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (826,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni14DD;
+unicode = 5341;
+},
+{
+glyphname = "lwi-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "li-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni14DE;
+unicode = 5342;
+},
+{
+glyphname = "lwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (826,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni14DF;
+unicode = 5343;
+},
+{
+glyphname = "lwii-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (434,-185);
+ref = dot_top;
+}
+);
+width = 1071;
+}
+);
+note = uni14E0;
+unicode = 5344;
+},
+{
+glyphname = "lwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (189,-185);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (826,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni14E1;
+unicode = 5345;
+},
+{
+glyphname = "lwo-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "lo-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni14E2;
+unicode = 5346;
+},
+{
+glyphname = "lwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (826,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni14E3;
+unicode = 5347;
+},
+{
+glyphname = "lwoo-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (629,-185);
+ref = dot_top;
+}
+);
+width = 1071;
+}
+);
+note = uni14E4;
+unicode = 5348;
+},
+{
+glyphname = "lwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (384,-185);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (826,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni14E5;
+unicode = 5349;
+},
+{
+glyphname = "lwa-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "la-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni14E6;
+unicode = 5350;
+},
+{
+glyphname = "lwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (826,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni14E7;
+unicode = 5351;
+},
+{
+glyphname = "lwaa-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (413,-185);
+ref = dot_top;
+}
+);
+width = 1071;
+}
+);
+note = uni14E8;
+unicode = 5352;
+},
+{
+glyphname = "lwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (168,-185);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (826,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni14E9;
+unicode = 5353;
+},
+{
+glyphname = "l-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(452,357,l),
+(475,462,l),
+(286,462,ls),
+(243,462,o),
+(219,483,o),
+(219,519,cs),
+(219,564,o),
+(245,613,o),
+(312,613,cs),
+(334,613,l),
+(355,714,l),
+(324,714,ls),
+(183,714,o),
+(106,624,o),
+(106,506,cs),
+(106,414,o),
+(170,357,o),
+(276,357,cs)
+);
+}
+);
+width = 473;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "m-canadian";
+note = uni14EA;
+unicode = 5354;
+},
+{
+glyphname = "lWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(326,357,l),
+(340,424,l),
+(197,491,l),
+(186,437,l),
+(358,507,l),
+(367,552,l),
+(225,620,l),
+(212,565,l),
+(385,634,l),
+(402,714,l),
+(383,714,l),
+(133,618,l),
+(126,584,l),
+(276,515,l),
+(285,555,l),
+(105,487,l),
+(98,453,l),
+(307,357,l)
+);
+}
+);
+width = 360;
+}
+);
+metricRight = "=|";
+note = uni14EB;
+unicode = 5355;
+},
+{
+glyphname = "mediall-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(519,-15,l),
+(542,97,l),
+(227,242,l),
+(210,162,l),
+(589,315,l),
+(602,379,l),
+(286,522,l),
+(270,449,l),
+(648,594,l),
+(676,729,l),
+(637,729,l),
+(116,529,l),
+(104,472,l),
+(422,326,l),
+(434,386,l),
+(55,242,l),
+(43,185,l),
+(479,-15,l)
+);
+}
+);
+width = 634;
+}
+);
+metricRight = "=|";
+note = uni14EC;
+unicode = 5356;
+},
+{
+glyphname = "se-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (245,714);
+},
+{
+name = top_right_can;
+pos = (527,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(457,0,l),
+(538,379,l),
+(493,379,ls),
+(330,379,o),
+(269,444,o),
+(307,619,cs),
+(328,714,l),
+(162,714,l),
+(139,609,ls),
+(90,381,o),
+(206,232,o),
+(457,232,cs),
+(478,232,l),
+(352,283,l),
+(291,0,l)
+);
+}
+);
+width = 577;
+}
+);
+note = uni14ED;
+unicode = 5357;
+},
+{
+glyphname = "saai-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (294,0);
+ref = ring_top.canadian;
+}
+);
+width = 577;
+}
+);
+note = uni14EE;
+unicode = 5358;
+},
+{
+glyphname = "si-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (246,714);
+},
+{
+name = top_right_can;
+pos = (528,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(177,0,l),
+(238,287,l),
+(100,232,l),
+(141,232,ls),
+(383,232,o),
+(530,343,o),
+(586,603,cs),
+(610,714,l),
+(444,714,l),
+(423,618,ls),
+(389,462,o),
+(299,379,o),
+(146,379,cs),
+(92,379,l),
+(11,0,l)
+);
+}
+);
+width = 576;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+unicode = 5359;
+},
+{
+glyphname = "sii-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (333,0);
+ref = dot_top;
+}
+);
+width = 577;
+}
+);
+note = uni14F0;
+unicode = 5360;
+},
+{
+glyphname = "so-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (527,714);
+},
+{
+name = top_left_can;
+pos = (245,714);
+},
+{
+name = top_right_can;
+pos = (527,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(176,0,l),
+(197,96,ls),
+(231,252,o),
+(321,335,o),
+(475,335,cs),
+(529,335,l),
+(609,714,l),
+(443,714,l),
+(382,427,l),
+(521,482,l),
+(480,482,ls),
+(238,482,o),
+(90,371,o),
+(34,111,cs),
+(10,0,l)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+unicode = 5361;
+},
+{
+glyphname = "soo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (332,0);
+ref = dot_top;
+}
+);
+width = 577;
+}
+);
+note = uni14F2;
+unicode = 5362;
+},
+{
+glyphname = "ycreesoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (141,0);
+ref = doubledot_top;
+}
+);
+width = 577;
+}
+);
+note = uni14F3;
+unicode = 5363;
+},
+{
+glyphname = "sa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (247,714);
+},
+{
+name = top_right_can;
+pos = (528,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(459,0,l),
+(481,105,ls),
+(531,333,o),
+(415,482,o),
+(164,482,cs),
+(143,482,l),
+(269,431,l),
+(330,714,l),
+(163,714,l),
+(83,335,l),
+(128,335,ls),
+(290,335,o),
+(351,270,o),
+(313,95,cs),
+(293,0,l)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+unicode = 5364;
+},
+{
+glyphname = "saa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+}
+);
+width = 577;
+}
+);
+note = uni14F5;
+unicode = 5365;
+},
+{
+glyphname = "swe-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "se-canadian";
+}
+);
+width = 821;
+}
+);
+note = uni14F6;
+unicode = 5366;
+},
+{
+glyphname = "sweWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "se-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (577,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 821;
+}
+);
+note = uni14F7;
+unicode = 5367;
+},
+{
+glyphname = "swi-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "si-canadian";
+}
+);
+width = 821;
+}
+);
+note = uni14F8;
+unicode = 5368;
+},
+{
+glyphname = "swiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (577,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 821;
+}
+);
+note = uni14F9;
+unicode = 5369;
+},
+{
+glyphname = "swii-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (578,0);
+ref = dot_top;
+}
+);
+width = 821;
+}
+);
+note = uni14FA;
+unicode = 5370;
+},
+{
+glyphname = "swiiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (333,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (577,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 821;
+}
+);
+note = uni14FB;
+unicode = 5371;
+},
+{
+glyphname = "swo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "so-canadian";
+}
+);
+width = 821;
+}
+);
+note = uni14FC;
+unicode = 5372;
+},
+{
+glyphname = "swoWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (577,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 821;
+}
+);
+note = uni14FD;
+unicode = 5373;
+},
+{
+glyphname = "swoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (576,0);
+ref = dot_top;
+}
+);
+width = 821;
+}
+);
+note = uni14FE;
+unicode = 5374;
+},
+{
+glyphname = "swooWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (332,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (577,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 821;
+}
+);
+note = uni14FF;
+unicode = 5375;
+},
+{
+glyphname = "swa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "sa-canadian";
+}
+);
+width = 821;
+}
+);
+note = uni1500;
+unicode = 5376;
+},
+{
+glyphname = "swaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (577,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 821;
+}
+);
+note = uni1501;
+unicode = 5377;
+},
+{
+glyphname = "swaa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (295,0);
+ref = dot_top;
+}
+);
+width = 821;
+}
+);
+note = uni1502;
+unicode = 5378;
+},
+{
+glyphname = "swaaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (577,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 821;
+}
+);
+note = uni1503;
+unicode = 5379;
+},
+{
+glyphname = "swaaNaskapi-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "sa-canadian";
+}
+);
+width = 821;
+}
+);
+note = uni1504;
+unicode = 5380;
+},
+{
+glyphname = "s-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(341,357,l),
+(352,409,ls),
+(378,530,o),
+(319,614,o),
+(200,614,cs),
+(170,614,l),
+(235,570,l),
+(266,714,l),
+(153,714,l),
+(113,525,l),
+(155,525,ls),
+(229,525,o),
+(256,489,o),
+(240,412,cs),
+(228,357,l)
+);
+}
+);
+width = 374;
+}
+);
+metricRight = "=|";
+note = uni1505;
+unicode = 5381;
+},
+{
+color = 6;
+glyphname = "sAthapascan-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(299,183,o),
+(349,237,o),
+(349,303,cs),
+(349,348,o),
+(323,378,o),
+(280,393,cs),
+(219,413,ls),
+(202,418,o),
+(195,429,o),
+(195,439,cs),
+(195,460,o),
+(210,473,o),
+(240,473,cs),
+(269,473,o),
+(284,460,o),
+(278,430,c),
+(376,430,l),
+(390,511,o),
+(329,552,o),
+(247,552,cs),
+(148,552,o),
+(97,499,o),
+(97,429,cs),
+(97,386,o),
+(125,354,o),
+(165,341,cs),
+(226,321,ls),
+(244,314,o),
+(251,305,o),
+(251,293,cs),
+(251,274,o),
+(235,262,o),
+(206,262,cs),
+(172,262,o),
+(158,275,o),
+(163,305,c),
+(65,305,l),
+(52,227,o),
+(106,183,o),
+(202,183,cs)
+);
+}
+);
+width = 395;
+}
+);
+metricRight = "=|";
+note = uni1506;
+unicode = 5382;
+},
+{
+glyphname = "sw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(190,357,l),
+(201,410,ls),
+(218,491,o),
+(260,525,o),
+(342,525,cs),
+(377,525,l),
+(417,714,l),
+(304,714,l),
+(273,569,l),
+(358,614,l),
+(314,614,ls),
+(195,614,o),
+(117,544,o),
+(89,415,cs),
+(77,357,l)
+);
+}
+);
+width = 375;
+}
+);
+metricLeft = "=|s-canadian";
+metricRight = "=|s-canadian";
+note = uni1507;
+unicode = 5383;
+},
+{
+glyphname = "sBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(346,357,l),
+(368,462,l),
+(275,462,ls),
+(235,462,o),
+(216,483,o),
+(226,526,cs),
+(266,714,l),
+(153,714,l),
+(114,529,ls),
+(92,425,o),
+(145,357,o),
+(254,357,cs)
+);
+}
+);
+width = 366;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "m-canadian";
+note = uni1508;
+unicode = 5384;
+},
+{
+glyphname = "moosecreesk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(335,225,o),
+(376,344,o),
+(376,442,cs),
+(376,548,o),
+(319,613,o),
+(205,613,cs),
+(189,613,l),
+(237,570,l),
+(268,714,l),
+(155,714,l),
+(115,526,l),
+(164,526,ls),
+(237,526,o),
+(276,514,o),
+(272,444,c),
+(301,447,l),
+(291,473,o),
+(260,493,o),
+(216,493,cs),
+(121,493,o),
+(78,413,o),
+(78,346,cs),
+(78,274,o),
+(129,225,o),
+(210,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(190,305,o),
+(176,321,o),
+(176,345,cs),
+(176,375,o),
+(196,416,o),
+(227,416,cs),
+(250,416,o),
+(264,401,o),
+(264,376,cs),
+(264,345,o),
+(244,305,o),
+(213,305,cs)
+);
+}
+);
+width = 399;
+}
+);
+metricRight = "=|";
+note = uni1509;
+unicode = 5385;
+},
+{
+glyphname = "skwNaskapi-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(318,225,o),
+(368,305,o),
+(368,384,cs),
+(368,449,o),
+(328,493,o),
+(267,493,cs),
+(230,493,o),
+(203,477,o),
+(188,450,c),
+(206,452,l),
+(227,506,o),
+(266,526,o),
+(347,526,cs),
+(397,526,l),
+(437,714,l),
+(324,714,l),
+(293,567,l),
+(361,613,l),
+(333,613,ls),
+(157,613,o),
+(83,473,o),
+(83,358,cs),
+(83,279,o),
+(131,225,o),
+(217,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(195,305,o),
+(181,321,o),
+(181,345,cs),
+(181,375,o),
+(201,416,o),
+(232,416,cs),
+(255,416,o),
+(269,401,o),
+(269,376,cs),
+(269,345,o),
+(249,305,o),
+(218,305,cs)
+);
+}
+);
+width = 400;
+}
+);
+metricLeft = "=|moosecreesk-canadian";
+metricRight = "=|moosecreesk-canadian";
+note = uni150A;
+unicode = 5386;
+},
+{
+glyphname = "swNaskapi-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(327,198,l),
+(335,238,ls),
+(360,352,o),
+(300,431,o),
+(186,431,cs),
+(155,431,l),
+(206,389,l),
+(233,517,l),
+(120,517,l),
+(84,345,l),
+(137,345,ls),
+(205,345,o),
+(240,314,o),
+(223,241,cs),
+(214,198,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(287,2,o),
+(321,37,o),
+(321,79,cs),
+(321,122,o),
+(287,157,o),
+(244,157,cs),
+(202,157,o),
+(168,122,o),
+(168,79,cs),
+(168,37,o),
+(202,2,o),
+(244,2,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(246,557,o),
+(281,592,o),
+(281,635,cs),
+(281,678,o),
+(246,712,o),
+(204,712,cs),
+(161,712,o),
+(127,678,o),
+(127,635,cs),
+(127,592,o),
+(161,557,o),
+(204,557,cs)
+);
+}
+);
+width = 404;
+}
+);
+metricRight = "=|";
+note = uni150B;
+unicode = 5387;
+},
+{
+glyphname = "spwaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(570,0,l),
+(600,142,l),
+(250,378,l),
+(237,305,l),
+(684,540,l),
+(721,714,l),
+(682,714,l),
+(56,382,l),
+(45,332,l),
+(531,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(230,515,o),
+(265,550,o),
+(265,592,cs),
+(265,635,o),
+(230,670,o),
+(188,670,cs),
+(146,670,o),
+(111,635,o),
+(111,592,cs),
+(111,549,o),
+(146,515,o),
+(188,515,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(458,636,l),
+(468,684,ls),
+(487,771,o),
+(441,834,o),
+(357,834,cs),
+(328,834,l),
+(389,797,l),
+(413,906,l),
+(302,906,l),
+(270,753,l),
+(296,753,ls),
+(348,753,o),
+(367,725,o),
+(356,675,cs),
+(348,636,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(661,740,o),
+(696,775,o),
+(696,818,cs),
+(696,860,o),
+(661,895,o),
+(619,895,cs),
+(577,895,o),
+(542,860,o),
+(542,818,cs),
+(542,775,o),
+(577,740,o),
+(619,740,cs)
+);
+}
+);
+width = 667;
+}
+);
+metricRight = "pa-canadian";
+metricWidth = "pa-canadian";
+note = uni150C;
+unicode = 5388;
+},
+{
+glyphname = "stwaNaskapi-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (404,0);
+ref = "ta-canadian";
+}
+);
+width = 1044;
+}
+);
+note = uni150D;
+unicode = 5389;
+},
+{
+glyphname = "skwaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (404,0);
+ref = "ka-canadian";
+}
+);
+width = 1019;
+}
+);
+note = uni150E;
+unicode = 5390;
+},
+{
+glyphname = "scwaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (404,0);
+ref = "ca-canadian";
+}
+);
+width = 1011;
+}
+);
+note = uni150F;
+unicode = 5391;
+},
+{
+glyphname = "she-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (391,714);
+},
+{
+name = top_right_can;
+pos = (855,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(738,-15,o),
+(829,82,o),
+(862,239,cs),
+(879,321,l),
+(715,321,l),
+(697,240,ls),
+(681,162,o),
+(652,129,o),
+(602,129,cs),
+(546,129,o),
+(528,170,o),
+(540,250,cs),
+(571,443,ls),
+(598,626,o),
+(521,729,o),
+(361,729,cs),
+(213,729,o),
+(122,632,o),
+(89,475,cs),
+(72,393,l),
+(236,393,l),
+(253,474,ls),
+(270,552,o),
+(298,585,o),
+(348,585,cs),
+(404,585,o),
+(422,544,o),
+(411,464,cs),
+(380,271,ls),
+(353,88,o),
+(430,-15,o),
+(590,-15,cs)
+);
+}
+);
+width = 907;
+}
+);
+metricRight = "=|";
+note = uni1510;
+unicode = 5392;
+},
+{
+glyphname = "shi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (249,714);
+},
+{
+name = top_right_can;
+pos = (712,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(402,-15,o),
+(487,67,o),
+(532,250,cs),
+(585,467,ls),
+(606,550,o),
+(635,585,o),
+(684,585,cs),
+(739,585,o),
+(763,547,o),
+(745,464,cs),
+(730,393,l),
+(895,393,l),
+(905,438,ls),
+(941,612,o),
+(856,729,o),
+(691,729,cs),
+(550,729,o),
+(466,647,o),
+(421,465,cs),
+(366,247,ls),
+(346,164,o),
+(317,129,o),
+(268,129,cs),
+(213,129,o),
+(189,167,o),
+(207,250,cs),
+(222,321,l),
+(57,321,l),
+(47,276,ls),
+(12,101,o),
+(96,-15,o),
+(261,-15,cs)
+);
+}
+);
+width = 908;
+}
+);
+metricLeft = "she-canadian";
+metricRight = "she-canadian";
+note = uni1511;
+unicode = 5393;
+},
+{
+glyphname = "shii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (515,0);
+ref = dot_top;
+}
+);
+width = 907;
+}
+);
+note = uni1512;
+unicode = 5394;
+},
+{
+glyphname = "sho-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (523,529);
+},
+{
+name = top_left_can;
+pos = (346,529);
+},
+{
+name = top_right_can;
+pos = (698,529);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(339,124,l),
+(244,125,o),
+(194,151,o),
+(194,196,cs),
+(194,234,o),
+(221,259,o),
+(270,259,cs),
+(388,259,o),
+(488,106,o),
+(674,106,cs),
+(808,106,o),
+(896,193,o),
+(896,320,cs),
+(896,442,o),
+(792,522,o),
+(619,524,c),
+(591,385,l),
+(685,384,o),
+(735,358,o),
+(735,314,cs),
+(735,275,o),
+(708,250,o),
+(660,250,cs),
+(542,250,o),
+(441,403,o),
+(256,403,cs),
+(120,403,o),
+(34,315,o),
+(34,190,cs),
+(34,68,o),
+(137,-13,o),
+(310,-15,c)
+);
+}
+);
+width = 930;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1513;
+unicode = 5395;
+},
+{
+glyphname = "shoo-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (327,-185);
+ref = dot_top;
+}
+);
+width = 930;
+}
+);
+note = uni1514;
+unicode = 5396;
+},
+{
+glyphname = "sha-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (523,529);
+},
+{
+name = top_left_can;
+pos = (347,529);
+},
+{
+name = top_right_can;
+pos = (699,529);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(704,-23,o),
+(876,48,o),
+(876,226,cs),
+(876,330,o),
+(803,403,o),
+(678,403,cs),
+(512,403,o),
+(373,250,o),
+(276,250,cs),
+(239,250,o),
+(217,269,o),
+(217,299,cs),
+(217,362,o),
+(280,388,o),
+(381,385,c),
+(411,524,l),
+(226,532,o),
+(54,462,o),
+(54,283,cs),
+(54,179,o),
+(127,106,o),
+(252,106,cs),
+(417,106,o),
+(556,259,o),
+(653,259,cs),
+(691,259,o),
+(713,240,o),
+(713,211,cs),
+(713,147,o),
+(648,121,o),
+(548,124,c),
+(518,-15,l)
+);
+}
+);
+width = 930;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1515;
+unicode = 5397;
+},
+{
+glyphname = "shaa-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (328,-185);
+ref = dot_top;
+}
+);
+width = 930;
+}
+);
+note = uni1516;
+unicode = 5398;
+},
+{
+glyphname = "shwe-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "she-canadian";
+}
+);
+width = 1152;
+}
+);
+note = uni1517;
+unicode = 5399;
+},
+{
+glyphname = "shweWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "she-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (907,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1152;
+}
+);
+note = uni1518;
+unicode = 5400;
+},
+{
+glyphname = "shwi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "shi-canadian";
+}
+);
+width = 1152;
+}
+);
+note = uni1519;
+unicode = 5401;
+},
+{
+glyphname = "shwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (907,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1152;
+}
+);
+note = uni151A;
+unicode = 5402;
+},
+{
+glyphname = "shwii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (760,0);
+ref = dot_top;
+}
+);
+width = 1152;
+}
+);
+note = uni151B;
+unicode = 5403;
+},
+{
+glyphname = "shwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (515,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (907,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1152;
+}
+);
+note = uni151C;
+unicode = 5404;
+},
+{
+glyphname = "shwo-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "sho-canadian";
+}
+);
+width = 1175;
+}
+);
+note = uni151D;
+unicode = 5405;
+},
+{
+glyphname = "shwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (930,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1175;
+}
+);
+note = uni151E;
+unicode = 5406;
+},
+{
+glyphname = "shwoo-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (572,-185);
+ref = dot_top;
+}
+);
+width = 1175;
+}
+);
+note = uni151F;
+unicode = 5407;
+},
+{
+glyphname = "shwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (327,-185);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (930,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1175;
+}
+);
+note = uni1520;
+unicode = 5408;
+},
+{
+glyphname = "shwa-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "sha-canadian";
+}
+);
+width = 1175;
+}
+);
+note = uni1521;
+unicode = 5409;
+},
+{
+glyphname = "shwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (930,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1175;
+}
+);
+note = uni1522;
+unicode = 5410;
+},
+{
+glyphname = "shwaa-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (572,-185);
+ref = dot_top;
+}
+);
+width = 1175;
+}
+);
+note = uni1523;
+unicode = 5411;
+},
+{
+glyphname = "shwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (328,-185);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (930,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1175;
+}
+);
+note = uni1524;
+unicode = 5412;
+},
+{
+glyphname = "sh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(597,286,o),
+(725,345,o),
+(725,482,cs),
+(725,560,o),
+(668,617,o),
+(574,617,cs),
+(456,617,o),
+(347,509,o),
+(273,509,cs),
+(243,509,o),
+(226,524,o),
+(226,548,cs),
+(226,595,o),
+(277,627,o),
+(364,623,c),
+(385,724,l),
+(241,732,o),
+(111,674,o),
+(111,536,cs),
+(111,458,o),
+(167,401,o),
+(262,401,cs),
+(379,401,o),
+(489,509,o),
+(562,509,cs),
+(592,509,o),
+(610,494,o),
+(610,470,cs),
+(610,423,o),
+(560,391,o),
+(473,395,c),
+(452,294,l)
+);
+}
+);
+width = 728;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni1525;
+unicode = 5413;
+},
+{
+glyphname = "ye-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (705,357);
+},
+{
+name = top_left_can;
+pos = (210,714);
+},
+{
+name = top_right_can;
+pos = (552,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(482,0,l),
+(559,365,l),
+(266,365,l),
+(266,286,l),
+(630,621,l),
+(528.992,726,l),
+(32,262,l),
+(23,221,l),
+(363,221,l),
+(316,0,l)
+);
+}
+);
+width = 600;
+}
+);
+note = uni1526;
+unicode = 5414;
+},
+{
+glyphname = "yaai-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (13,0);
+ref = ring_top.canadian;
+}
+);
+width = 600;
+}
+);
+note = uni1527;
+unicode = 5415;
+},
+{
+glyphname = "yi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (247,714);
+},
+{
+name = top_right_can;
+pos = (588,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(177,0,l),
+(224,221,l),
+(563,221,l),
+(572,262,l),
+(247,726,l),
+(128,640,l),
+(376,289,l),
+(384,365,l),
+(88,365,l),
+(11,0,l)
+);
+}
+);
+width = 600;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni1528;
+unicode = 5416;
+},
+{
+glyphname = "yii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (52,0);
+ref = dot_top;
+}
+);
+width = 600;
+}
+);
+note = uni1529;
+unicode = 5417;
+},
+{
+glyphname = "yo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (705,357);
+},
+{
+name = top_double;
+pos = (551,714);
+},
+{
+name = top_left_can;
+pos = (210,714);
+},
+{
+name = top_right_can;
+pos = (551,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(516,74,l),
+(268,425,l),
+(260,349,l),
+(556,349,l),
+(633,714,l),
+(467,714,l),
+(420,493,l),
+(81,493,l),
+(72,452,l),
+(397,-12,l)
+);
+}
+);
+width = 600;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152A;
+unicode = 5418;
+},
+{
+glyphname = "yoo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (356,0);
+ref = dot_top;
+}
+);
+width = 600;
+}
+);
+note = uni152B;
+unicode = 5419;
+},
+{
+glyphname = "ycreeyoo-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (165,0);
+ref = doubledot_top;
+}
+);
+width = 600;
+}
+);
+note = uni152C;
+unicode = 5420;
+},
+{
+glyphname = "ya-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (247,714);
+},
+{
+name = top_right_can;
+pos = (586,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(612,452,l),
+(621,493,l),
+(281,493,l),
+(329,714,l),
+(162,714,l),
+(85,349,l),
+(378,349,l),
+(378,428,l),
+(15,93,l),
+(115,-12,l)
+);
+}
+);
+width = 600;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152D;
+unicode = 5421;
+},
+{
+glyphname = "yaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+}
+);
+width = 600;
+}
+);
+note = uni152E;
+unicode = 5422;
+},
+{
+glyphname = "ywe-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ye-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni152F;
+unicode = 5423;
+},
+{
+glyphname = "yweWestCree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ye-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (600,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni1530;
+unicode = 5424;
+},
+{
+glyphname = "ywi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "yi-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni1531;
+unicode = 5425;
+},
+{
+glyphname = "ywiWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (600,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni1532;
+unicode = 5426;
+},
+{
+glyphname = "ywii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (296,0);
+ref = dot_top;
+}
+);
+width = 845;
+}
+);
+note = uni1533;
+unicode = 5427;
+},
+{
+glyphname = "ywiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (52,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (600,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni1534;
+unicode = 5428;
+},
+{
+glyphname = "ywo-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "yo-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni1535;
+unicode = 5429;
+},
+{
+glyphname = "ywoWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (600,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni1536;
+unicode = 5430;
+},
+{
+glyphname = "ywoo-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (600,0);
+ref = dot_top;
+}
+);
+width = 845;
+}
+);
+note = uni1537;
+unicode = 5431;
+},
+{
+glyphname = "ywooWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (356,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (600,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni1538;
+unicode = 5432;
+},
+{
+glyphname = "ywa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ya-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni1539;
+unicode = 5433;
+},
+{
+glyphname = "ywaWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (600,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni153A;
+unicode = 5434;
+},
+{
+glyphname = "ywaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (296,0);
+ref = dot_top;
+}
+);
+width = 845;
+}
+);
+note = uni153B;
+unicode = 5435;
+},
+{
+glyphname = "ywaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (600,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni153C;
+unicode = 5436;
+},
+{
+glyphname = "ywaaNaskapi-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ya-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni153D;
+unicode = 5437;
+},
+{
+glyphname = "y-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(396,575,l),
+(402,603,l),
+(244,603,l),
+(268,714,l),
+(155,714,l),
+(112,514,l),
+(262,514,l),
+(263,580,l),
+(90,414,l),
+(160,346,l)
+);
+}
+);
+width = 351;
+}
+);
+note = uni153E;
+unicode = 5438;
+},
+{
+glyphname = "biblecreey-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(174,357,l),
+(282,602,l),
+(221,602,l),
+(262,357,l),
+(334,357,l),
+(483,602,l),
+(414,602,l),
+(423,357,l),
+(522,357,l),
+(528,383,l),
+(517,714,l),
+(441,714,l),
+(283,450,l),
+(344,450,l),
+(301,714,l),
+(225,714,l),
+(73,383,l),
+(67,357,l)
+);
+}
+);
+width = 546;
+}
+);
+metricRight = "=|";
+note = uni153F;
+unicode = 5439;
+},
+{
+glyphname = "yWestCree-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(267,199,l),
+(292,315,l),
+(405,315,l),
+(428,422,l),
+(315,422,l),
+(339,536,l),
+(229,536,l),
+(205,422,l),
+(91,422,l),
+(69,315,l),
+(182,315,l),
+(157,199,l)
+);
+}
+);
+width = 447;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1540;
+unicode = 5440;
+},
+{
+glyphname = "yiSayisi-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (40,189);
+ref = "fullstop-canadian";
+}
+);
+width = 391;
+}
+);
+metricLeft = "fullstop-canadian";
+metricWidth = "fullstop-canadian";
+note = uni1541;
+unicode = 5441;
+},
+{
+glyphname = "re-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (376,529);
+},
+{
+name = top_left_can;
+pos = (200,529);
+},
+{
+name = top_right_can;
+pos = (809,529);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(439,-15,o),
+(536,68,o),
+(570,227,cs),
+(599,362,l),
+(858,362,l),
+(889,509,l),
+(468,509,l),
+(409,232,ls),
+(394,162,o),
+(358,128,o),
+(304,128,cs),
+(237,128,o),
+(209,168,o),
+(225,244,cs),
+(281,509,l),
+(115,509,l),
+(62,259,ls),
+(27,97,o),
+(121,-15,o),
+(293,-15,cs)
+);
+}
+);
+width = 877;
+}
+);
+metricRight = "=|ne-canadian";
+note = uni1542;
+unicode = 5442;
+},
+{
+glyphname = "reRCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (614,529);
+},
+{
+name = top_left_can;
+pos = (182,529);
+},
+{
+name = top_right_can;
+pos = (791,529);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(679,-15,o),
+(776,68,o),
+(810,227,cs),
+(870,509,l),
+(704,509,l),
+(645,232,ls),
+(630,162,o),
+(594,128,o),
+(540,128,cs),
+(472,128,o),
+(444,169,o),
+(460,244,cs),
+(517,509,l),
+(96,509,l),
+(65,362,l),
+(324,362,l),
+(302,259,ls),
+(267,97,o),
+(361,-15,o),
+(533,-15,cs)
+);
+}
+);
+width = 877;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1543;
+unicode = 5443;
+},
+{
+glyphname = "leWestCree-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (616,529);
+},
+{
+name = top_left_can;
+pos = (183,529);
+},
+{
+name = top_right_can;
+pos = (792,529);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(409,0,l),
+(468,278,ls),
+(483,347,o),
+(519,381,o),
+(573,381,cs),
+(641,381,o),
+(669,341,o),
+(653,265,cs),
+(596,0,l),
+(762,0,l),
+(815,250,ls),
+(850,412,o),
+(756,524,o),
+(585,524,cs),
+(438,524,o),
+(341,441,o),
+(307,282,cs),
+(279,147,l),
+(19,147,l),
+(-12,0,l)
+);
+}
+);
+width = 877;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+unicode = 5444;
+},
+{
+glyphname = "raai-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (144,-185);
+ref = ring_top.canadian;
+}
+);
+width = 876;
+}
+);
+note = uni1545;
+unicode = 5445;
+},
+{
+glyphname = "ri-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (379,529);
+},
+{
+name = top_left_can;
+pos = (203,529);
+},
+{
+name = top_right_can;
+pos = (812,529);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(174,0,l),
+(233,278,ls),
+(247,347,o),
+(284,381,o),
+(339,381,cs),
+(405,381,o),
+(433,341,o),
+(417,265,cs),
+(360,0,l),
+(781,0,l),
+(812,147,l),
+(554,147,l),
+(576,250,ls),
+(610,412,o),
+(516,524,o),
+(349,524,cs),
+(198,524,o),
+(102,441,o),
+(68,282,cs),
+(7,0,l)
+);
+}
+);
+width = 877;
+}
+);
+metricLeft = "re-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+unicode = 5446;
+},
+{
+glyphname = "rii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (183,-185);
+ref = dot_top;
+}
+);
+width = 876;
+}
+);
+note = uni1547;
+unicode = 5447;
+},
+{
+glyphname = "ro-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (353,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(177,0,l),
+(239,294,l),
+(153,221,l),
+(270,221,ls),
+(474,221,o),
+(579,337,o),
+(579,500,cs),
+(579,629,o),
+(488,714,o),
+(341,714,cs),
+(162,714,l),
+(131,567,l),
+(317,567,ls),
+(381,567,o),
+(415,536,o),
+(415,486,cs),
+(415,409,o),
+(366,367,o),
+(279,367,cs),
+(89,367,l),
+(10,0,l)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1548;
+unicode = 5448;
+},
+{
+glyphname = "roo-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (158,0);
+ref = dot_top;
+}
+);
+width = 577;
+}
+);
+note = uni1549;
+unicode = 5449;
+},
+{
+glyphname = "loWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (356,714);
+},
+{
+name = top_left_can;
+pos = (246,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(223,0,ls),
+(427,0,o),
+(532,115,o),
+(532,279,cs),
+(532,407,o),
+(441,493,o),
+(295,493,cs),
+(208,493,l),
+(266,419,l),
+(328,714,l),
+(162,714,l),
+(85,348,l),
+(271,348,ls),
+(335,348,o),
+(369,317,o),
+(369,266,cs),
+(369,190,o),
+(319,147,o),
+(233,147,cs),
+(42,147,l),
+(11,0,l)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+unicode = 5450;
+},
+{
+glyphname = "ra-canadian";
+lastChange = "2023-01-13 15:28:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (418,714);
+},
+{
+name = top_right_can;
+pos = (526,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(457,0,l),
+(534,366,l),
+(349,366,ls),
+(285,366,o),
+(251,397,o),
+(251,448,cs),
+(251,524,o),
+(300,567,o),
+(387,567,cs),
+(577,567,l),
+(608,714,l),
+(397,714,ls),
+(193,714,o),
+(88,599,o),
+(88,435,cs),
+(88,307,o),
+(178,221,o),
+(325,221,cs),
+(411,221,l),
+(353,295,l),
+(291,0,l)
+);
+}
+);
+width = 575;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+unicode = 5451;
+},
+{
+glyphname = "raa-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (224,0);
+ref = dot_top;
+}
+);
+width = 577;
+}
+);
+note = uni154C;
+unicode = 5452;
+},
+{
+glyphname = "laWestCree-canadian";
+lastChange = "2023-01-13 15:28:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (527,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(458,0,l),
+(489,147,l),
+(303,147,ls),
+(239,147,o),
+(204,178,o),
+(204,228,cs),
+(204,305,o),
+(254,347,o),
+(340,347,cs),
+(531,347,l),
+(609,714,l),
+(443,714,l),
+(381,420,l),
+(467,493,l),
+(350,493,ls),
+(146,493,o),
+(41,377,o),
+(41,214,cs),
+(41,85,o),
+(132,0,o),
+(279,0,cs)
+);
+}
+);
+width = 576;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+unicode = 5453;
+},
+{
+glyphname = "rwaa-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (468,0);
+ref = dot_top;
+}
+);
+width = 822;
+}
+);
+note = uni154E;
+unicode = 5454;
+},
+{
+glyphname = "rwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (224,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (577,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni154F;
+unicode = 5455;
+},
+{
+glyphname = "r-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(313,357,l),
+(354,550,l),
+(260,550,ls),
+(234,550,o),
+(222,563,o),
+(222,582,cs),
+(222,612,o),
+(242,626,o),
+(276,626,cs),
+(370,626,l),
+(388,714,l),
+(295,714,ls),
+(192,714,o),
+(117,671,o),
+(117,573,cs),
+(117,509,o),
+(163,464,o),
+(240,464,cs),
+(281,464,l),
+(230,499,l),
+(200,357,l)
+);
+}
+);
+width = 346;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni1550;
+unicode = 5456;
+},
+{
+glyphname = "rWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(154,714,l),
+(140,647,l),
+(283,580,l),
+(294,634,l),
+(122,564,l),
+(113,519,l),
+(255,451,l),
+(268,506,l),
+(95,437,l),
+(78,357,l),
+(97,357,l),
+(347,453,l),
+(354,487,l),
+(204,556,l),
+(195,516,l),
+(375,584,l),
+(382,618,l),
+(173,714,l)
+);
+}
+);
+width = 361;
+}
+);
+metricLeft = "=|lWestCree-canadian";
+metricRight = "=|lWestCree-canadian";
+note = uni1551;
+unicode = 5457;
+},
+{
+glyphname = "rMedial-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(41,-15,l),
+(562,185,l),
+(574,242,l),
+(256,388,l),
+(244,328,l),
+(623,472,l),
+(635,529,l),
+(199,729,l),
+(159,729,l),
+(136,617,l),
+(451,472,l),
+(468,552,l),
+(89,399,l),
+(76,335,l),
+(392,192,l),
+(408,265,l),
+(30,120,l),
+(2,-15,l)
+);
+}
+);
+width = 635;
+}
+);
+metricLeft = "mediall-canadian";
+metricRight = "mediall-canadian";
+note = uni1552;
+unicode = 5458;
+},
+{
+glyphname = "fe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(360,0,l),
+(873,674,l),
+(881,714,l),
+(731,714,l),
+(348,191,l),
+(374,191,l),
+(309,361,l),
+(199,370,l),
+(224,338,o),
+(255,323,o),
+(301,323,cs),
+(429,323,o),
+(512,447,o),
+(512,563,cs),
+(512,660,o),
+(451,729,o),
+(341,729,cs),
+(202,729,o),
+(126,602,o),
+(126,483,cs),
+(126,440,o),
+(136,400,o),
+(156,355,cs),
+(311,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(276,433,o),
+(258,455,o),
+(258,492,cs),
+(258,530,o),
+(279,609,o),
+(333,609,cs),
+(363,609,o),
+(381,588,o),
+(381,552,cs),
+(381,512,o),
+(361,433,o),
+(306,433,cs)
+);
+}
+);
+width = 809;
+}
+);
+metricRight = "e-canadian";
+note = uni1553;
+unicode = 5459;
+},
+{
+glyphname = "faai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (246,0);
+ref = ring_top.canadian;
+}
+);
+width = 809;
+}
+);
+note = uni1554;
+unicode = 5460;
+},
+{
+glyphname = "fi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (480,714);
+},
+{
+name = top_left_can;
+pos = (243,714);
+},
+{
+name = top_right_can;
+pos = (737,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(374,-15,o),
+(439,116,o),
+(439,222,cs),
+(439,322,o),
+(377,397,o),
+(291,397,cs),
+(256,397,o),
+(224,383,o),
+(194,356,c),
+(321,355,l),
+(462,523,l),
+(421,524,l),
+(601,0,l),
+(729,0,l),
+(737,40,l),
+(504,714,l),
+(455,714,l),
+(147,367,ls),
+(90,301,o),
+(55,231,o),
+(55,155,cs),
+(55,56,o),
+(122,-15,o),
+(226,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(204,105,o),
+(186,126,o),
+(186,163,cs),
+(186,202,o),
+(207,281,o),
+(261,281,cs),
+(291,281,o),
+(309,259,o),
+(309,223,cs),
+(309,183,o),
+(288,105,o),
+(234,105,cs)
+);
+}
+);
+width = 808;
+}
+);
+metricLeft = "fe-canadian";
+metricRight = "e-canadian";
+note = uni1555;
+unicode = 5461;
+},
+{
+glyphname = "fii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (284,0);
+ref = dot_top;
+}
+);
+width = 809;
+}
+);
+note = uni1556;
+unicode = 5462;
+},
+{
+glyphname = "fo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (333,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(65,0,l),
+(687,332,l),
+(697,381,l),
+(457,654,ls),
+(412,705,o),
+(370,729,o),
+(310,729,cs),
+(183,729,o),
+(106,616,o),
+(100,502,cs),
+(92,392,o),
+(156,316,o),
+(258,316,cs),
+(381,316,o),
+(460,413,o),
+(466,532,cs),
+(468,556,o),
+(467,580,o),
+(464,600,c),
+(398,523,l),
+(532,370,l),
+(542,400,l),
+(57,146,l),
+(26,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(245,433,o),
+(228,460,o),
+(232,507,cs),
+(235,552,o),
+(255,610,o),
+(304,610,cs),
+(337,610,o),
+(354,583,o),
+(350,536,cs),
+(347,491,o),
+(328,433,o),
+(278,433,cs)
+);
+}
+);
+width = 699;
+}
+);
+metricRight = "o-canadian";
+note = uni1557;
+unicode = 5463;
+},
+{
+glyphname = "foo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "fo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (138,0);
+ref = dot_top;
+}
+);
+width = 699;
+}
+);
+note = uni1558;
+unicode = 5464;
+},
+{
+glyphname = "fa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (559,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(563,0,l),
+(589,125,l),
+(221,378,l),
+(215,348,l),
+(410,506,l),
+(388,630,l),
+(361,590,o),
+(339,527,o),
+(339,478,cs),
+(339,383,o),
+(407,312,o),
+(513,312,cs),
+(638,312,o),
+(714,444,o),
+(714,554,cs),
+(714,657,o),
+(648,729,o),
+(545,729,cs),
+(493,729,o),
+(448,710,o),
+(401,670,cs),
+(56,381,l),
+(46,332,l),
+(523,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(479,432,o),
+(461,454,o),
+(461,490,cs),
+(461,529,o),
+(482,609,o),
+(536,609,cs),
+(566,609,o),
+(584,587,o),
+(584,551,cs),
+(584,511,o),
+(564,432,o),
+(510,432,cs)
+);
+}
+);
+width = 700;
+}
+);
+metricRight = "=|fo-canadian";
+note = uni1559;
+unicode = 5465;
+},
+{
+glyphname = "faa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (364,0);
+ref = dot_top;
+}
+);
+width = 699;
+}
+);
+note = uni155A;
+unicode = 5466;
+},
+{
+glyphname = "fwaa-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (609,0);
+ref = dot_top;
+}
+);
+width = 944;
+}
+);
+note = uni155B;
+unicode = 5467;
+},
+{
+glyphname = "fwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (364,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (699,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 944;
+}
+);
+note = uni155C;
+unicode = 5468;
+},
+{
+glyphname = "f-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(364,357,l),
+(379,429,l),
+(194,553,l),
+(190,528,l),
+(287,613,l),
+(278,674,l),
+(265,657,o),
+(252,623,o),
+(252,596,cs),
+(252,549,o),
+(286,512,o),
+(334,512,cs),
+(398,512,o),
+(436,570,o),
+(436,634,cs),
+(436,688,o),
+(404,720,o),
+(356,720,cs),
+(329,720,o),
+(303,711,o),
+(276,688,cs),
+(108,546,l),
+(103,521,l),
+(344,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(322,572,o),
+(313,583,o),
+(313,600,cs),
+(313,627,o),
+(328,660,o),
+(350,660,cs),
+(364,660,o),
+(373,649,o),
+(373,630,cs),
+(373,608,o),
+(360,572,o),
+(336,572,cs)
+);
+}
+);
+width = 408;
+}
+);
+note = uni155D;
+unicode = 5469;
+},
+{
+glyphname = "the-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (876,357);
+},
+{
+name = top_center_can;
+pos = (479,714);
+},
+{
+name = top_left_can;
+pos = (237,714);
+},
+{
+name = top_right_can;
+pos = (718,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(556,-15,o),
+(666,83,o),
+(711,295,cs),
+(800,714,l),
+(634,714,l),
+(545,296,ls),
+(521,184,o),
+(466,132,o),
+(361,132,cs),
+(237,132,o),
+(211,205,o),
+(236,314,cs),
+(259,414,l),
+(184,366,l),
+(202,327,o),
+(238,302,o),
+(287,302,cs),
+(417,302,o),
+(489,418,o),
+(497,541,cs),
+(505,655,o),
+(443,729,o),
+(331,729,cs),
+(214,729,o),
+(142,651,o),
+(112,511,cs),
+(78,348,ls),
+(34,139,o),
+(117,-15,o),
+(357,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(261,422,o),
+(244,444,o),
+(244,482,cs),
+(244,522,o),
+(265,609,o),
+(320,609,cs),
+(349,609,o),
+(366,587,o),
+(366,550,cs),
+(366,509,o),
+(346,422,o),
+(291,422,cs)
+);
+}
+);
+width = 759;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155E;
+unicode = 5470;
+},
+{
+glyphname = "theNCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(557,-15,o),
+(667,88,o),
+(714,311,cs),
+(749,471,ls),
+(780,615,o),
+(728,729,o),
+(591,729,cs),
+(450,729,o),
+(375,598,o),
+(375,472,cs),
+(375,375,o),
+(428,302,o),
+(524,302,cs),
+(564,302,o),
+(599,317,o),
+(625,346,c),
+(570,405,l),
+(546,292,ls),
+(522,180,o),
+(467,131,o),
+(369,131,cs),
+(243,131,o),
+(214,209,o),
+(238,320,cs),
+(321,714,l),
+(155,714,l),
+(73,330,ls),
+(28,118,o),
+(137,-15,o),
+(356,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(524,422,o),
+(508,444,o),
+(508,482,cs),
+(508,522,o),
+(528,609,o),
+(583,609,cs),
+(613,609,o),
+(629,587,o),
+(629,550,cs),
+(629,509,o),
+(609,422,o),
+(554,422,cs)
+);
+}
+);
+width = 760;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155F;
+unicode = 5471;
+},
+{
+glyphname = "thi-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (474,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(353,-15,o),
+(429,116,o),
+(429,242,cs),
+(429,339,o),
+(375,412,o),
+(280,412,cs),
+(240,412,o),
+(205,397,o),
+(178,368,c),
+(233,309,l),
+(258,422,ls),
+(281,534,o),
+(337,583,o),
+(435,583,cs),
+(561,583,o),
+(589,505,o),
+(565,394,cs),
+(482,0,l),
+(648,0,l),
+(730,384,ls),
+(775,596,o),
+(667,729,o),
+(448,729,cs),
+(247,729,o),
+(137,626,o),
+(90,403,cs),
+(55,243,ls),
+(24,99,o),
+(76,-15,o),
+(213,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(191,105,o),
+(175,127,o),
+(175,164,cs),
+(175,205,o),
+(195,292,o),
+(250,292,cs),
+(280,292,o),
+(296,270,o),
+(296,232,cs),
+(296,192,o),
+(276,105,o),
+(221,105,cs)
+);
+}
+);
+width = 759;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1560;
+unicode = 5472;
+},
+{
+glyphname = "thiNCree-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (474,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(590,-15,o),
+(662,63,o),
+(691,203,cs),
+(726,366,ls),
+(771,575,o),
+(687,729,o),
+(447,729,cs),
+(248,729,o),
+(137,631,o),
+(92,419,cs),
+(3,0,l),
+(169,0,l),
+(258,418,ls),
+(283,530,o),
+(337,582,o),
+(442,582,cs),
+(567,582,o),
+(593,509,o),
+(568,400,cs),
+(545,300,l),
+(619,348,l),
+(601,387,o),
+(566,412,o),
+(517,412,cs),
+(387,412,o),
+(315,296,o),
+(307,173,cs),
+(299,59,o),
+(361,-15,o),
+(473,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(454,105,o),
+(438,127,o),
+(438,164,cs),
+(438,205,o),
+(458,292,o),
+(513,292,cs),
+(543,292,o),
+(560,270,o),
+(560,232,cs),
+(560,192,o),
+(539,105,o),
+(484,105,cs)
+);
+}
+);
+width = 759;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1561;
+unicode = 5473;
+},
+{
+glyphname = "thii-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "thi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (279,0);
+ref = dot_top;
+}
+);
+width = 760;
+}
+);
+note = uni1562;
+unicode = 5474;
+},
+{
+glyphname = "thiiNCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "thiNCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (279,0);
+ref = dot_top;
+}
+);
+width = 760;
+}
+);
+note = uni1563;
+unicode = 5475;
+},
+{
+glyphname = "tho-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (411,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(253,0,ls),
+(539,0,o),
+(675,203,o),
+(675,426,cs),
+(675,611,o),
+(554,729,o),
+(384,729,cs),
+(211,729,o),
+(99,608,o),
+(99,453,cs),
+(99,349,o),
+(165,279,o),
+(268,279,cs),
+(399,279,o),
+(471,400,o),
+(471,511,cs),
+(471,587,o),
+(431,644,o),
+(353,656,c),
+(326,609,l),
+(338,613,o),
+(355,617,o),
+(373,617,cs),
+(446,616,o),
+(515,550,o),
+(515,432,cs),
+(515,314,o),
+(467,149,o),
+(267,149,cs),
+(63,149,l),
+(32,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(247,398,o),
+(231,419,o),
+(231,455,cs),
+(231,496,o),
+(251,592,o),
+(310,592,cs),
+(340,592,o),
+(355,571,o),
+(355,535,cs),
+(355,497,o),
+(335,398,o),
+(276,398,cs)
+);
+}
+);
+width = 701;
+}
+);
+metricRight = "to-canadian";
+note = uni1564;
+unicode = 5476;
+},
+{
+glyphname = "thoo-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "tho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (216,0);
+ref = dot_top;
+}
+);
+width = 702;
+}
+);
+note = uni1565;
+unicode = 5477;
+},
+{
+glyphname = "tha-canadian";
+lastChange = "2023-01-13 15:28:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (489,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(560,0,l),
+(591,149,l),
+(396,149,ls),
+(291,149,o),
+(233,206,o),
+(233,308,cs),
+(233,412,o),
+(296,610,o),
+(457,610,cs),
+(481,610,o),
+(506,605,o),
+(525,597,c),
+(505,652,l),
+(387,651,o),
+(323,539,o),
+(323,438,cs),
+(323,344,o),
+(384,279,o),
+(486,279,cs),
+(618,279,o),
+(701,391,o),
+(701,519,cs),
+(701,646,o),
+(606,729,o),
+(459,729,cs),
+(190,729,o),
+(68,475,o),
+(68,284,cs),
+(68,111,o),
+(177,0,o),
+(364,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(463,398,o),
+(447,419,o),
+(447,455,cs),
+(447,496,o),
+(467,592,o),
+(526,592,cs),
+(556,592,o),
+(571,571,o),
+(571,535,cs),
+(571,497,o),
+(551,398,o),
+(492,398,cs)
+);
+}
+);
+width = 701;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tho-canadian";
+note = uni1566;
+unicode = 5478;
+},
+{
+glyphname = "thaa-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (295,0);
+ref = dot_top;
+}
+);
+width = 702;
+}
+);
+note = uni1567;
+unicode = 5479;
+},
+{
+glyphname = "thwaa-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (539,0);
+ref = dot_top;
+}
+);
+width = 947;
+}
+);
+note = uni1568;
+unicode = 5480;
+},
+{
+glyphname = "thwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (295,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (702,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 947;
+}
+);
+note = uni1569;
+unicode = 5481;
+},
+{
+glyphname = "th-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(350,357,l),
+(369,447,l),
+(282,447,ls),
+(230,447,o),
+(203,470,o),
+(203,515,cs),
+(203,571,o),
+(238,654,o),
+(316,654,cs),
+(324,654,o),
+(342,651,o),
+(347,650,c),
+(327,677,l),
+(260,677,o),
+(238,617,o),
+(238,580,cs),
+(238,528,o),
+(269,495,o),
+(318,495,cs),
+(388,495,o),
+(421,566,o),
+(421,620,cs),
+(421,680,o),
+(378,720,o),
+(305,720,cs),
+(173,720,o),
+(105,599,o),
+(105,502,cs),
+(105,414,o),
+(165,357,o),
+(262,357,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(305,554,o),
+(297,564,o),
+(297,582,cs),
+(297,607,o),
+(310,642,o),
+(333,642,cs),
+(348,642,o),
+(356,632,o),
+(356,614,cs),
+(356,589,o),
+(344,554,o),
+(320,554,cs)
+);
+}
+);
+width = 396;
+}
+);
+metricLeft = "t-canadian";
+note = uni156A;
+unicode = 5482;
+},
+{
+glyphname = "tthe-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (866,357);
+},
+{
+name = top_center_can;
+pos = (473,714);
+},
+{
+name = top_left_can;
+pos = (239,714);
+},
+{
+name = top_right_can;
+pos = (708,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(547,-15,o),
+(657,84,o),
+(702,296,cs),
+(791,714,l),
+(629,714,l),
+(540,299,ls),
+(516,186,o),
+(460,135,o),
+(365,135,cs),
+(251,135,o),
+(207,198,o),
+(233,318,cs),
+(317,714,l),
+(155,714,l),
+(73,330,ls),
+(28,115,o),
+(139,-15,o),
+(351,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(471,393,l),
+(540,714,l),
+(406,714,l),
+(338,393,l)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156B;
+unicode = 5483;
+},
+{
+glyphname = "tthi-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(165,0,l),
+(254,415,ls),
+(278,528,o),
+(334,579,o),
+(429,579,cs),
+(543,579,o),
+(587,516,o),
+(561,396,cs),
+(477,0,l),
+(639,0,l),
+(721,384,ls),
+(766,599,o),
+(655,729,o),
+(443,729,cs),
+(247,729,o),
+(137,630,o),
+(92,418,cs),
+(3,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(388,0,l),
+(456,321,l),
+(323,321,l),
+(254,0,l)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156C;
+unicode = 5484;
+},
+{
+glyphname = "ttho-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (398,714);
+},
+{
+name = top_left_can;
+pos = (225,714);
+},
+{
+name = top_right_can;
+pos = (619,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(190,0,ls),
+(533,0,o),
+(622,251,o),
+(622,426,cs),
+(622,605,o),
+(507,714,o),
+(307,714,cs),
+(156,714,l),
+(125,565,l),
+(282,565,ls),
+(397,565,o),
+(455,510,o),
+(455,410,cs),
+(455,293,o),
+(397,149,o),
+(205,149,cs),
+(36,149,l),
+(5,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(313,290,l),
+(342,426,l),
+(95,426,l),
+(66,290,l)
+);
+}
+);
+width = 648;
+}
+);
+metricRight = "to-canadian";
+note = uni156D;
+unicode = 5485;
+},
+{
+glyphname = "ttha-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (418,714);
+},
+{
+name = top_left_can;
+pos = (230,714);
+},
+{
+name = top_right_can;
+pos = (603,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(535,0,l),
+(566,149,l),
+(409,149,ls),
+(294,149,o),
+(236,204,o),
+(236,304,cs),
+(236,426,o),
+(300,565,o),
+(486,565,cs),
+(655,565,l),
+(687,714,l),
+(501,714,ls),
+(163,714,o),
+(70,468,o),
+(70,288,cs),
+(70,109,o),
+(184,0,o),
+(384,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(596,290,l),
+(624,426,l),
+(377,426,l),
+(348,290,l)
+);
+}
+);
+width = 647;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|ttho-canadian";
+note = uni156E;
+unicode = 5486;
+},
+{
+glyphname = "tth-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(291,475,l),
+(246,476,l),
+(312,344,l),
+(399,388,l),
+(329,527,l),
+(303,484,l),
+(468,540,l),
+(440,627,l),
+(291,576,l),
+(324,550,l),
+(359,714,l),
+(263,714,l),
+(228,550,l),
+(269,573,l),
+(127,627,l),
+(94,540,l),
+(224,491,l),
+(219,536,l),
+(100,408,l),
+(169,344,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(723,475,l),
+(677,476,l),
+(744,344,l),
+(831,388,l),
+(760,527,l),
+(735,484,l),
+(900,540,l),
+(871,627,l),
+(722,576,l),
+(755,550,l),
+(790,714,l),
+(694,714,l),
+(659,550,l),
+(700,573,l),
+(559,627,l),
+(525,540,l),
+(655,491,l),
+(650,536,l),
+(532,408,l),
+(600,344,l)
+);
+}
+);
+width = 872;
+}
+);
+metricRight = "=|";
+note = uni156F;
+unicode = 5487;
+},
+{
+glyphname = "tye-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(549,-15,o),
+(657,85,o),
+(703,300,cs),
+(791,714,l),
+(630,714,l),
+(546,316,ls),
+(519,191,o),
+(462,135,o),
+(361,135,cs),
+(251,135,o),
+(206,198,o),
+(232,318,cs),
+(316,714,l),
+(155,714,l),
+(73,330,ls),
+(28,117,o),
+(138,-15,o),
+(355,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(488,424,o),
+(529,461,o),
+(544,532,cs),
+(583,714,l),
+(507,714,l),
+(471,544,ls),
+(465,516,o),
+(452,503,o),
+(429,503,cs),
+(405,503,o),
+(397,517,o),
+(403,546,cs),
+(438,714,l),
+(362,714,l),
+(326,545,ls),
+(311,472,o),
+(350,424,o),
+(424,424,cs)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1570;
+unicode = 5488;
+},
+{
+glyphname = "tyi-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(164,0,l),
+(248,398,ls),
+(275,523,o),
+(332,579,o),
+(433,579,cs),
+(543,579,o),
+(588,516,o),
+(562,396,cs),
+(478,0,l),
+(639,0,l),
+(721,384,ls),
+(766,597,o),
+(656,729,o),
+(439,729,cs),
+(245,729,o),
+(137,629,o),
+(91,414,cs),
+(3,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(287,0,l),
+(323,170,ls),
+(329,198,o),
+(342,211,o),
+(365,211,cs),
+(389,211,o),
+(397,197,o),
+(391,168,cs),
+(356,0,l),
+(432,0,l),
+(468,169,ls),
+(483,242,o),
+(444,290,o),
+(370,290,cs),
+(306,290,o),
+(265,253,o),
+(250,182,cs),
+(211,0,l)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1571;
+unicode = 5489;
+},
+{
+glyphname = "tyo-canadian";
+lastChange = "2023-01-13 15:28:50 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(196,0,ls),
+(538,0,o),
+(628,251,o),
+(628,426,cs),
+(628,605,o),
+(513,714,o),
+(312,714,cs),
+(162,714,l),
+(131,568,l),
+(289,568,ls),
+(402,568,o),
+(461,510,o),
+(461,410,cs),
+(461,270,o),
+(381,146,o),
+(210,146,cs),
+(42,146,l),
+(11,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(155,226,ls),
+(260,226,o),
+(318,282,o),
+(322,368,cs),
+(327,441,o),
+(282,488,o),
+(203,488,cs),
+(114,488,l),
+(97,407,l),
+(184,407,ls),
+(217,407,o),
+(234,392,o),
+(232,364,cs),
+(230,329,o),
+(208,307,o),
+(163,307,cs),
+(76,307,l),
+(59,226,l)
+);
+}
+);
+width = 654;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1572;
+unicode = 5490;
+},
+{
+glyphname = "tya-canadian";
+lastChange = "2023-01-13 15:28:50 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(535,0,l),
+(566,146,l),
+(409,146,ls),
+(295,146,o),
+(236,204,o),
+(236,304,cs),
+(236,444,o),
+(316,568,o),
+(488,568,cs),
+(655,568,l),
+(686,714,l),
+(502,714,ls),
+(159,714,o),
+(70,463,o),
+(70,288,cs),
+(70,109,o),
+(185,0,o),
+(385,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(583,226,l),
+(600,307,l),
+(513,307,ls),
+(481,307,o),
+(464,322,o),
+(466,350,cs),
+(467,385,o),
+(490,407,o),
+(535,407,cs),
+(621,407,l),
+(638,488,l),
+(542,488,ls),
+(438,488,o),
+(380,432,o),
+(375,346,cs),
+(370,273,o),
+(415,226,o),
+(495,226,cs)
+);
+}
+);
+width = 653;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1573;
+unicode = 5491;
+},
+{
+glyphname = "heNunavik-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(484,0,l),
+(779,206,l),
+(695,327,l),
+(476,175,l),
+(529,132,l),
+(590,414,ls),
+(623,570,o),
+(569,729,o),
+(374,729,cs),
+(186,729,o),
+(83,569,o),
+(83,406,cs),
+(83,277,o),
+(162,190,o),
+(283,190,cs),
+(342,190,o),
+(392,213,o),
+(414,254,c),
+(391,258,l),
+(336,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(275,330,o),
+(245,363,o),
+(245,419,cs),
+(245,473,o),
+(272,589,o),
+(358,589,cs),
+(409,589,o),
+(439,555,o),
+(439,499,cs),
+(439,445,o),
+(412,330,o),
+(325,330,cs)
+);
+}
+);
+width = 808;
+}
+);
+metricLeft = "ke-canadian";
+note = uni1574;
+unicode = 5492;
+},
+{
+glyphname = "hiNunavik-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (608,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(364,0,l),
+(426,289,l),
+(406,266,l),
+(409,225,o),
+(471,190,o),
+(545,190,cs),
+(726,190,o),
+(811,365,o),
+(811,503,cs),
+(811,642,o),
+(723,729,o),
+(583,729,cs),
+(436,729,o),
+(334,639,o),
+(300,480,cs),
+(226,130,l),
+(286,145,l),
+(114,313,l),
+(9,206,l),
+(217,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(486,330,o),
+(457,363,o),
+(457,419,cs),
+(457,473,o),
+(486,589,o),
+(571,589,cs),
+(621,589,o),
+(651,555,o),
+(651,499,cs),
+(651,446,o),
+(624,330,o),
+(537,330,cs)
+);
+}
+);
+width = 808;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1575;
+unicode = 5493;
+},
+{
+glyphname = "hiiNunavik-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "hiNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (412,0);
+ref = dot_top;
+}
+);
+width = 808;
+}
+);
+note = uni1576;
+unicode = 5494;
+},
+{
+glyphname = "hoNunavik-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (396,714);
+},
+{
+name = top_right_can;
+pos = (572,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(416,-15,o),
+(519,75,o),
+(553,234,cs),
+(627,584,l),
+(566,569,l),
+(738,401,l),
+(844,508,l),
+(635,714,l),
+(488,714,l),
+(427,425,l),
+(447,448,l),
+(443,489,o),
+(382,524,o),
+(307,524,cs),
+(127,524,o),
+(41,349,o),
+(41,211,cs),
+(41,72,o),
+(129,-15,o),
+(270,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(232,125,o),
+(201,159,o),
+(201,215,cs),
+(201,268,o),
+(229,384,o),
+(315,384,cs),
+(366,384,o),
+(396,351,o),
+(396,295,cs),
+(396,241,o),
+(367,125,o),
+(282,125,cs)
+);
+}
+);
+width = 809;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "heNunavik-canadian";
+note = uni1577;
+unicode = 5495;
+},
+{
+glyphname = "hooNunavik-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "hoNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (377,0);
+ref = dot_top;
+}
+);
+width = 808;
+}
+);
+note = uni1578;
+unicode = 5496;
+},
+{
+glyphname = "haNunavik-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (608,714);
+},
+{
+name = top_left_can;
+pos = (433,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(666,-15,o),
+(769,145,o),
+(769,308,cs),
+(769,437,o),
+(691,524,o),
+(569,524,cs),
+(510,524,o),
+(460,501,o),
+(438,460,c),
+(461,456,l),
+(516,714,l),
+(368,714,l),
+(73,508,l),
+(157,387,l),
+(376,539,l),
+(323,582,l),
+(262,300,ls),
+(229,144,o),
+(283,-15,o),
+(478,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(443,125,o),
+(413,159,o),
+(413,215,cs),
+(413,269,o),
+(441,384,o),
+(527,384,cs),
+(578,384,o),
+(607,351,o),
+(607,295,cs),
+(607,241,o),
+(580,125,o),
+(494,125,cs)
+);
+}
+);
+width = 808;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1579;
+unicode = 5497;
+},
+{
+glyphname = "haaNunavik-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "haNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (238,0);
+ref = dot_top;
+}
+);
+width = 808;
+}
+);
+note = uni157A;
+unicode = 5498;
+},
+{
+glyphname = "hNunavik-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(430,351,o),
+(489,434,o),
+(489,515,cs),
+(489,577,o),
+(449,622,o),
+(388,622,cs),
+(352,622,o),
+(320,608,o),
+(307,575,c),
+(326,554,l),
+(360,714,l),
+(257,714,l),
+(107,610,l),
+(157,541,l),
+(291,637,l),
+(242,682,l),
+(205,509,ls),
+(185,416,o),
+(235,351,o),
+(329,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(315,432,o),
+(300,447,o),
+(300,472,cs),
+(300,509,o),
+(322,541,o),
+(352,541,cs),
+(375,541,o),
+(390,527,o),
+(390,502,cs),
+(390,466,o),
+(368,432,o),
+(337,432,cs)
+);
+}
+);
+width = 482;
+}
+);
+metricRight = "k-canadian";
+note = uni157B;
+unicode = 5499;
+},
+{
+color = 4;
+glyphname = "nunavuth-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(176,0,l),
+(239,295,l),
+(510,295,l),
+(448,0,l),
+(614,0,l),
+(766,714,l),
+(600,714,l),
+(542,441,l),
+(270,441,l),
+(328,714,l),
+(162,714,l),
+(10,0,l)
+);
+}
+);
+width = 732;
+}
+);
+metricRight = "=|";
+note = uni157C;
+unicode = 5500;
+},
+{
+glyphname = "hk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (76,357);
+ref = "fullstop-canadian";
+}
+);
+width = 391;
+}
+);
+metricLeft = "fullstop-canadian";
+note = uni157D;
+unicode = 5501;
+},
+{
+glyphname = "qaai-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (346,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (523,0);
+ref = ring_top.canadian;
+}
+);
+width = 960;
+}
+);
+note = uni157E;
+unicode = 5502;
+},
+{
+glyphname = "qi-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (346,0);
+ref = "ki-canadian";
+}
+);
+width = 960;
+}
+);
+note = uni157F;
+unicode = 5503;
+},
+{
+glyphname = "qii-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (346,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (562,0);
+ref = dot_top;
+}
+);
+width = 960;
+}
+);
+note = uni1580;
+unicode = 5504;
+},
+{
+glyphname = "qo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (346,0);
+ref = "ko-canadian";
+}
+);
+width = 960;
+}
+);
+note = uni1581;
+unicode = 5505;
+},
+{
+glyphname = "qoo-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (346,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (722,0);
+ref = dot_top;
+}
+);
+width = 960;
+}
+);
+note = uni1582;
+unicode = 5506;
+},
+{
+glyphname = "qa-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (346,0);
+ref = "ka-canadian";
+}
+);
+width = 960;
+}
+);
+note = uni1583;
+unicode = 5507;
+},
+{
+glyphname = "qaa-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (346,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (389,0);
+ref = dot_top;
+}
+);
+width = 960;
+}
+);
+note = uni1584;
+unicode = 5508;
+},
+{
+glyphname = "q-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (346,0);
+ref = "k-canadian";
+}
+);
+width = 735;
+}
+);
+note = uni1585;
+unicode = 5509;
+},
+{
+glyphname = "tlhe-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (416,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(182,0,l),
+(378,287,l),
+(263,223,l),
+(273,222,o),
+(285,221,o),
+(296,221,cs),
+(359,221,o),
+(412,242,o),
+(433,283,c),
+(426,329,l),
+(357,0,l),
+(521,0,l),
+(615,444,ls),
+(649,603,o),
+(569,729,o),
+(392,729,cs),
+(205,729,o),
+(101,588,o),
+(101,431,cs),
+(101,364,o),
+(129,299,o),
+(186,262,c),
+(7,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(292,362,o),
+(260,397,o),
+(260,448,cs),
+(260,506,o),
+(297,589,o),
+(374,589,cs),
+(429,589,o),
+(461,554,o),
+(461,503,cs),
+(461,445,o),
+(424,362,o),
+(346,362,cs)
+);
+}
+);
+width = 632;
+}
+);
+metricRight = "te-canadian";
+note = uni1586;
+unicode = 5510;
+},
+{
+glyphname = "tlhi-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(168,0,l),
+(241,344,l),
+(174,318,l),
+(207,262,o),
+(271,226,o),
+(349,225,c),
+(265,289,l),
+(342,0,l),
+(517,0,l),
+(454,242,l),
+(558,275,o),
+(627,396,o),
+(627,505,cs),
+(627,637,o),
+(532,729,o),
+(385,729,cs),
+(237,729,o),
+(140,641,o),
+(104,476,cs),
+(3,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(298,362,o),
+(266,394,o),
+(266,447,cs),
+(266,503,o),
+(301,589,o),
+(380,589,cs),
+(434,589,o),
+(466,556,o),
+(466,503,cs),
+(466,447,o),
+(431,362,o),
+(352,362,cs)
+);
+}
+);
+width = 636;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|tlhe-canadian";
+note = uni1587;
+unicode = 5511;
+},
+{
+glyphname = "tlho-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (426,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(442,-15,o),
+(539,73,o),
+(575,238,cs),
+(676,714,l),
+(511,714,l),
+(439,370,l),
+(505,396,l),
+(472,452,o),
+(408,488,o),
+(330,489,c),
+(414,425,l),
+(337,714,l),
+(162,714,l),
+(225,472,l),
+(121,439,o),
+(53,318,o),
+(53,209,cs),
+(53,77,o),
+(147,-15,o),
+(294,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(245,125,o),
+(213,158,o),
+(213,211,cs),
+(213,267,o),
+(248,352,o),
+(327,352,cs),
+(381,352,o),
+(413,320,o),
+(413,267,cs),
+(413,211,o),
+(378,125,o),
+(299,125,cs)
+);
+}
+);
+width = 636;
+}
+);
+metricLeft = "tlhe-canadian";
+metricRight = "te-canadian";
+note = uni1588;
+unicode = 5512;
+},
+{
+glyphname = "tlha-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(471,-15,o),
+(575,126,o),
+(575,283,cs),
+(575,350,o),
+(547,415,o),
+(490,452,c),
+(669,714,l),
+(494,714,l),
+(298,427,l),
+(414,491,l),
+(403,492,o),
+(391,493,o),
+(381,493,cs),
+(317,493,o),
+(265,472,o),
+(244,431,c),
+(250,385,l),
+(320,714,l),
+(155,714,l),
+(61,270,ls),
+(27,111,o),
+(108,-15,o),
+(284,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(247,125,o),
+(216,160,o),
+(216,211,cs),
+(216,269,o),
+(252,352,o),
+(330,352,cs),
+(384,352,o),
+(416,317,o),
+(416,266,cs),
+(416,208,o),
+(380,125,o),
+(302,125,cs)
+);
+}
+);
+width = 633;
+}
+);
+metricLeft = "te-canadian";
+note = uni1589;
+unicode = 5513;
+},
+{
+glyphname = "reWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(474,0,l),
+(770,208,l),
+(684,329,l),
+(467,178,l),
+(521,134,l),
+(587,445,ls),
+(623,614,o),
+(535,729,o),
+(369,729,cs),
+(218,729,o),
+(125,642,o),
+(89,477,cs),
+(71,393,l),
+(235,393,l),
+(253,475,ls),
+(268,551,o),
+(300,585,o),
+(355,585,cs),
+(417,585,o),
+(443,541,o),
+(427,466,cs),
+(328,0,l)
+);
+}
+);
+width = 799;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+unicode = 5514;
+},
+{
+glyphname = "riWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(362,0,l),
+(462,475,ls),
+(478,551,o),
+(511,585,o),
+(565,585,cs),
+(627,585,o),
+(653,541,o),
+(637,466,cs),
+(622,393,l),
+(786,393,l),
+(797,445,ls),
+(833,614,o),
+(743,729,o),
+(578,729,cs),
+(426,729,o),
+(334,642,o),
+(299,477,cs),
+(226,133,l),
+(291,153,l),
+(122,320,l),
+(9,208,l),
+(215,0,l)
+);
+}
+);
+width = 799;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+unicode = 5515;
+},
+{
+glyphname = "roWestCree-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(415,-15,o),
+(508,72,o),
+(543,237,cs),
+(616,581,l),
+(551,561,l),
+(720,394,l),
+(833,506,l),
+(626,714,l),
+(480,714,l),
+(379,239,ls),
+(363,163,o),
+(331,129,o),
+(277,129,cs),
+(215,129,o),
+(189,173,o),
+(205,248,cs),
+(220,321,l),
+(56,321,l),
+(45,269,ls),
+(9,100,o),
+(99,-15,o),
+(264,-15,cs)
+);
+}
+);
+width = 799;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+unicode = 5516;
+},
+{
+glyphname = "raWestCree-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(624,-15,o),
+(717,72,o),
+(753,237,cs),
+(771,321,l),
+(606,321,l),
+(589,239,ls),
+(573,163,o),
+(541,129,o),
+(487,129,cs),
+(425,129,o),
+(399,173,o),
+(415,248,cs),
+(513,714,l),
+(367,714,l),
+(72,506,l),
+(157,385,l),
+(374,536,l),
+(320,580,l),
+(255,269,ls),
+(219,100,o),
+(307,-15,o),
+(472,-15,cs)
+);
+}
+);
+width = 799;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+unicode = 5517;
+},
+{
+glyphname = "ngaai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:59 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (652,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (831,0);
+ref = ring_top.canadian;
+}
+);
+width = 1259;
+}
+);
+note = uni158E;
+unicode = 5518;
+},
+{
+glyphname = "ngi-canadian";
+kernLeft = mwestleft;
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:59 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (652,0);
+ref = "ci-canadian";
+}
+);
+width = 1259;
+}
+);
+note = uni158F;
+unicode = 5519;
+},
+{
+glyphname = "ngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:59 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (652,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (870,0);
+ref = dot_top;
+}
+);
+width = 1259;
+}
+);
+note = uni1590;
+unicode = 5520;
+},
+{
+glyphname = "ngo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:59 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (624,0);
+ref = "co-canadian";
+}
+);
+width = 1229;
+}
+);
+note = uni1591;
+unicode = 5521;
+},
+{
+glyphname = "ngoo-canadian";
+lastChange = "2023-01-13 15:28:59 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "ngo-canadian";
+},
+{
+anchor = top_right_can;
+pos = (993,0);
+ref = dot_top;
+}
+);
+width = 1229;
+}
+);
+note = uni1592;
+unicode = 5522;
+},
+{
+glyphname = "nga-canadian";
+kernLeft = mwestleft;
+kernRight = caright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (653,0);
+ref = "ca-canadian";
+}
+);
+width = 1260;
+}
+);
+note = uni1593;
+unicode = 5523;
+},
+{
+glyphname = "ngaa-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (653,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (697,0);
+ref = dot_top;
+}
+);
+width = 1260;
+}
+);
+note = uni1594;
+unicode = 5524;
+},
+{
+glyphname = "ng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(566,225,o),
+(624,272,o),
+(642,356,cs),
+(647,382,l),
+(541,382,l),
+(535,352,ls),
+(529,325,o),
+(515,312,o),
+(492,312,cs),
+(467,312,o),
+(456,328,o),
+(463,357,cs),
+(505,555,l),
+(345,555,l),
+(343,490,l),
+(378,509,o),
+(397,555,o),
+(399,595,cs),
+(403,669,o),
+(352,722,o),
+(267,722,cs),
+(183,722,o),
+(121,664,o),
+(117,582,cs),
+(111,504,o),
+(163,450,o),
+(245,450,cs),
+(398,450,l),
+(377,487,l),
+(355,380,ls),
+(335,288,o),
+(385,225,o),
+(481,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(226,531,o),
+(212,549,o),
+(214,578,cs),
+(216,611,o),
+(234,641,o),
+(265,641,cs),
+(289,641,o),
+(303,623,o),
+(301,593,cs),
+(299,561,o),
+(281,531,o),
+(251,531,cs)
+);
+}
+);
+width = 652;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1595;
+unicode = 5525;
+},
+{
+glyphname = "nng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(877,225,o),
+(931,272,o),
+(949,356,cs),
+(955,382,l),
+(849,382,l),
+(842,352,ls),
+(836,325,o),
+(822,312,o),
+(800,312,cs),
+(774,312,o),
+(764,328,o),
+(770,357,cs),
+(813,555,l),
+(667,555,l),
+(658,490,l),
+(696,512,o),
+(715,564,o),
+(715,601,cs),
+(714,674,o),
+(664,722,o),
+(583,722,cs),
+(492,722,o),
+(431,654,o),
+(431,571,cs),
+(431,544,o),
+(438,523,o),
+(452,503,c),
+(469,555,l),
+(353,555,l),
+(343,490,l),
+(382,512,o),
+(401,564,o),
+(401,601,cs),
+(401,673,o),
+(349,722,o),
+(269,722,cs),
+(178,722,o),
+(116,654,o),
+(116,571,cs),
+(116,500,o),
+(168,450,o),
+(246,450,cs),
+(677,450,l),
+(662,380,ls),
+(641,287,o),
+(696,225,o),
+(792,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(229,531,o),
+(214,547,o),
+(214,571,cs),
+(214,601,o),
+(232,641,o),
+(266,641,cs),
+(289,641,o),
+(303,625,o),
+(303,601,cs),
+(303,571,o),
+(285,531,o),
+(252,531,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(543,531,o),
+(529,547,o),
+(529,571,cs),
+(529,601,o),
+(546,641,o),
+(580,641,cs),
+(603,641,o),
+(617,625,o),
+(617,601,cs),
+(617,571,o),
+(600,531,o),
+(566,531,cs)
+);
+}
+);
+width = 960;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1596;
+unicode = 5526;
+},
+{
+glyphname = "sheSayisi-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (735,357);
+},
+{
+name = top_center_can;
+pos = (408,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(510,0,l),
+(603,437,ls),
+(639,608,o),
+(558,729,o),
+(385,729,cs),
+(168,729,o),
+(78,535,o),
+(78,377,cs),
+(78,263,o),
+(135,190,o),
+(230,190,cs),
+(326,190,o),
+(379,265,o),
+(405,428,c),
+(319,428,l),
+(306,354,o),
+(291,326,o),
+(266,326,cs),
+(246,326,o),
+(235,342,o),
+(235,376,cs),
+(235,438,o),
+(265,589,o),
+(365,589,cs),
+(445,589,o),
+(453,514,o),
+(435,428,cs),
+(344,0,l)
+);
+}
+);
+width = 621;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1597;
+unicode = 5527;
+},
+{
+glyphname = "shiSayisi-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(169,0,l),
+(267,459,ls),
+(286,547,o),
+(323,589,o),
+(383,589,cs),
+(436,589,o),
+(465,556,o),
+(465,495,cs),
+(465,454,o),
+(442,326,o),
+(393,326,cs),
+(365,326,o),
+(358,355,o),
+(377,428,c),
+(291,428,l),
+(248,282,o),
+(295,190,o),
+(407,190,cs),
+(562,190,o),
+(623,384,o),
+(623,500,cs),
+(623,640,o),
+(535,729,o),
+(388,729,cs),
+(239,729,o),
+(140,642,o),
+(106,481,cs),
+(3,0,l)
+);
+}
+);
+width = 622;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni1598;
+unicode = 5528;
+},
+{
+glyphname = "shoSayisi-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (400,714);
+},
+{
+name = top_left_can;
+pos = (220,714);
+},
+{
+name = top_right_can;
+pos = (579,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(426,-15,o),
+(525,72,o),
+(559,233,cs),
+(662,714,l),
+(496,714,l),
+(398,255,ls),
+(379,167,o),
+(342,125,o),
+(283,125,cs),
+(229,125,o),
+(201,158,o),
+(201,219,cs),
+(201,260,o),
+(223,388,o),
+(272,388,cs),
+(300,388,o),
+(307,359,o),
+(288,286,c),
+(375,286,l),
+(417,432,o),
+(370,524,o),
+(258,524,cs),
+(104,524,o),
+(42,330,o),
+(42,214,cs),
+(42,74,o),
+(130,-15,o),
+(277,-15,cs)
+);
+}
+);
+width = 621;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1599;
+unicode = 5529;
+},
+{
+glyphname = "shaSayisi-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(498,-15,o),
+(588,179,o),
+(588,337,cs),
+(588,451,o),
+(530,524,o),
+(436,524,cs),
+(340,524,o),
+(287,449,o),
+(261,286,c),
+(347,286,l),
+(359,360,o),
+(374,388,o),
+(399,388,cs),
+(419,388,o),
+(431,372,o),
+(431,338,cs),
+(431,276,o),
+(401,125,o),
+(300,125,cs),
+(220,125,o),
+(213,200,o),
+(231,286,cs),
+(322,714,l),
+(156,714,l),
+(62,277,ls),
+(27,106,o),
+(108,-15,o),
+(281,-15,cs)
+);
+}
+);
+width = 622;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni159A;
+unicode = 5530;
+},
+{
+glyphname = "theWoodScree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(696,-15,o),
+(794,146,o),
+(794,286,cs),
+(794,419,o),
+(703,509,o),
+(554,509,cs),
+(106,509,l),
+(78,375,l),
+(377,375,l),
+(359,423,l),
+(295,371,o),
+(267,279,o),
+(267,208,cs),
+(267,77,o),
+(361,-15,o),
+(506,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(462,125,o),
+(428,162,o),
+(428,218,cs),
+(428,282,o),
+(471,370,o),
+(545,370,cs),
+(599,370,o),
+(633,334,o),
+(633,278,cs),
+(633,214,o),
+(590,125,o),
+(516,125,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(851,580,l),
+(879,714,l),
+(150,714,l),
+(122,580,l)
+);
+}
+);
+width = 846;
+}
+);
+note = uni159B;
+unicode = 5531;
+},
+{
+glyphname = "thiWoodScree-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(478,-15,o),
+(577,143,o),
+(577,287,cs),
+(577,326,o),
+(568,361,o),
+(549,389,c),
+(520,375,l),
+(820,375,l),
+(848,509,l),
+(345,509,ls),
+(145,509,o),
+(50,350,o),
+(50,209,cs),
+(50,77,o),
+(145,-15,o),
+(290,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(246,125,o),
+(212,162,o),
+(212,218,cs),
+(212,282,o),
+(255,370,o),
+(328,370,cs),
+(382,370,o),
+(416,334,o),
+(416,278,cs),
+(416,214,o),
+(373,125,o),
+(299,125,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(864,580,l),
+(892,714,l),
+(163,714,l),
+(135,580,l)
+);
+}
+);
+width = 847;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159C;
+unicode = 5532;
+},
+{
+glyphname = "thoWoodScree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(502,0,ls),
+(702,0,o),
+(797,160,o),
+(797,301,cs),
+(797,432,o),
+(702,524,o),
+(557,524,cs),
+(369,524,o),
+(269,366,o),
+(269,223,cs),
+(269,184,o),
+(279,148,o),
+(297,120,c),
+(326,134,l),
+(26,134,l),
+(-2,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(464,139,o),
+(431,175,o),
+(431,231,cs),
+(431,296,o),
+(473,384,o),
+(548,384,cs),
+(601,384,o),
+(635,347,o),
+(635,291,cs),
+(635,227,o),
+(592,139,o),
+(518,139,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(850,580,l),
+(878,714,l),
+(150,714,l),
+(121,580,l)
+);
+}
+);
+width = 846;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159D;
+unicode = 5533;
+},
+{
+glyphname = "thaWoodScree-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(739,0,l),
+(768,134,l),
+(469,134,l),
+(486,86,l),
+(551,139,o),
+(579,230,o),
+(579,301,cs),
+(579,432,o),
+(485,524,o),
+(339,524,cs),
+(149,524,o),
+(52,363,o),
+(52,223,cs),
+(52,91,o),
+(143,0,o),
+(292,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(247,139,o),
+(213,175,o),
+(213,231,cs),
+(213,296,o),
+(256,384,o),
+(330,384,cs),
+(383,384,o),
+(417,347,o),
+(417,291,cs),
+(417,227,o),
+(374,139,o),
+(301,139,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(862,580,l),
+(890,714,l),
+(161,714,l),
+(133,580,l)
+);
+}
+);
+width = 846;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159E;
+unicode = 5534;
+},
+{
+glyphname = "thWoodScree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(479,356,l),
+(499,452,l),
+(336,452,l),
+(330,394,l),
+(371,416,o),
+(391,468,o),
+(391,509,cs),
+(391,579,o),
+(338,627,o),
+(258,627,cs),
+(167,627,o),
+(106,560,o),
+(106,477,cs),
+(106,405,o),
+(158,356,o),
+(235,356,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(218,436,o),
+(204,452,o),
+(204,476,cs),
+(204,506,o),
+(222,547,o),
+(255,547,cs),
+(278,547,o),
+(293,530,o),
+(293,506,cs),
+(293,476,o),
+(275,436,o),
+(241,436,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(538,661,l),
+(559,758,l),
+(166,758,l),
+(146,661,l)
+);
+}
+);
+width = 512;
+}
+);
+metricRight = "=|";
+note = uni159F;
+unicode = 5535;
+},
+{
+glyphname = "lhi-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (539,714);
+},
+{
+name = top_right_can;
+pos = (659,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(331,0,l),
+(362,145,l),
+(308,145,ls),
+(244,145,o),
+(207,178,o),
+(207,232,cs),
+(207,303,o),
+(253,361,o),
+(352,361,cs),
+(807,361,l),
+(835,492,l),
+(705,767,l),
+(560,698,l),
+(681,440,l),
+(728,509,l),
+(367,509,ls),
+(167,509,o),
+(43,399,o),
+(43,225,cs),
+(43,93,o),
+(136,0,o),
+(279,0,cs)
+);
+}
+);
+width = 827;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A0;
+unicode = 5536;
+},
+{
+glyphname = "lhii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "lhi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (344,0);
+ref = dot_top;
+}
+);
+width = 826;
+}
+);
+note = uni15A1;
+unicode = 5537;
+},
+{
+glyphname = "lho-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (471,528);
+},
+{
+name = top_right_can;
+pos = (579,528);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(268,-188,l),
+(147,69,l),
+(99,0,l),
+(461,0,ls),
+(660,0,o),
+(784,110,o),
+(784,284,cs),
+(784,416,o),
+(692,509,o),
+(548,509,cs),
+(496,509,l),
+(466,365,l),
+(519,365,ls),
+(583,365,o),
+(621,331,o),
+(621,277,cs),
+(621,206,o),
+(574,148,o),
+(475,148,cs),
+(20,148,l),
+(-8,17,l),
+(123,-257,l)
+);
+}
+);
+width = 827;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni15A2;
+unicode = 5538;
+},
+{
+glyphname = "lhoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "lho-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (383,-186);
+ref = dot_top;
+}
+);
+width = 826;
+}
+);
+note = uni15A3;
+unicode = 5539;
+},
+{
+glyphname = "lha-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (474,528);
+},
+{
+name = top_left_can;
+pos = (367,528);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(734,17,l),
+(762,148,l),
+(310,148,ls),
+(244,148,o),
+(208,180,o),
+(208,235,cs),
+(208,310,o),
+(257,365,o),
+(356,365,cs),
+(408,365,l),
+(439,509,l),
+(377,509,ls),
+(162,509,o),
+(42,393,o),
+(42,217,cs),
+(42,85,o),
+(134,0,o),
+(282,0,cs),
+(616,0,l),
+(579,65,l),
+(378,-160,l),
+(487,-258,l)
+);
+}
+);
+width = 827;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A4;
+unicode = 5540;
+},
+{
+glyphname = "lhaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "lha-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (171,-186);
+ref = dot_top;
+}
+);
+width = 826;
+}
+);
+note = uni15A5;
+unicode = 5541;
+},
+{
+glyphname = "lh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(468,369,l),
+(488,462,l),
+(286,462,ls),
+(243,462,o),
+(219,483,o),
+(219,519,cs),
+(219,564,o),
+(245,613,o),
+(312,613,cs),
+(334,613,l),
+(355,714,l),
+(324,714,ls),
+(183,714,o),
+(106,624,o),
+(106,506,cs),
+(106,414,o),
+(170,357,o),
+(276,357,cs),
+(408,357,l),
+(370,427,l),
+(246,290,l),
+(328,215,l)
+);
+}
+);
+width = 491;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni15A6;
+unicode = 5542;
+},
+{
+glyphname = "theThCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (210,714);
+},
+{
+name = top_right_can;
+pos = (551,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(332,77,l),
+(316,0,l),
+(482,0,l),
+(498,77,l),
+(571,77,l),
+(590,165,l),
+(517,165,l),
+(559,365,l),
+(280,365,l),
+(301,314,l),
+(630,621,l),
+(528.992,726,l),
+(32,262,l),
+(23,221,l),
+(363,221,l),
+(351,165,l),
+(132,165,l),
+(113,77,l)
+);
+}
+);
+width = 637;
+}
+);
+metricLeft = "ye-canadian";
+note = uni15A7;
+unicode = 5543;
+},
+{
+glyphname = "thiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (282,714);
+},
+{
+name = top_right_can;
+pos = (623,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(214,0,l),
+(230,77,l),
+(449,77,l),
+(467,165,l),
+(249,165,l),
+(261,221,l),
+(600,221,l),
+(609,262,l),
+(284,726,l),
+(165,640,l),
+(398,304,l),
+(430,365,l),
+(125,365,l),
+(82,165,l),
+(9,165,l),
+(-10,77,l),
+(64,77,l),
+(47,0,l)
+);
+}
+);
+width = 637;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+unicode = 5544;
+},
+{
+glyphname = "thiiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (87,0);
+ref = dot_top;
+}
+);
+width = 637;
+}
+);
+note = uni15A9;
+unicode = 5545;
+},
+{
+glyphname = "thoThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (209,714);
+},
+{
+name = top_right_can;
+pos = (550,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(516,74,l),
+(283,410,l),
+(251,349,l),
+(555,349,l),
+(598,549,l),
+(672,549,l),
+(690,637,l),
+(616,637,l),
+(633,714,l),
+(467,714,l),
+(450,637,l),
+(231,637,l),
+(213,549,l),
+(432,549,l),
+(420,493,l),
+(81,493,l),
+(72,452,l),
+(396,-12,l)
+);
+}
+);
+width = 637;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+unicode = 5546;
+},
+{
+glyphname = "thooThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (355,0);
+ref = dot_top;
+}
+);
+width = 637;
+}
+);
+note = uni15AB;
+unicode = 5547;
+},
+{
+glyphname = "thaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (282,714);
+},
+{
+name = top_right_can;
+pos = (623,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(649,452,l),
+(658,493,l),
+(318,493,l),
+(330,549,l),
+(549,549,l),
+(567,637,l),
+(348,637,l),
+(365,714,l),
+(199,714,l),
+(182,637,l),
+(109,637,l),
+(91,549,l),
+(164,549,l),
+(121,349,l),
+(400,349,l),
+(380,400,l),
+(51,93,l),
+(151,-12,l)
+);
+}
+);
+width = 637;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+unicode = 5548;
+},
+{
+glyphname = "thaaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (87,0);
+ref = dot_top;
+}
+);
+width = 637;
+}
+);
+note = uni15AD;
+unicode = 5549;
+},
+{
+glyphname = "thThCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(161,636,l),
+(135,514,l),
+(291,514,l),
+(270,566,l),
+(113,414,l),
+(183,346,l),
+(418,575,l),
+(424,603,l),
+(267,603,l),
+(274,636,l),
+(370,636,l),
+(380,681,l),
+(283,681,l),
+(290,714,l),
+(177,714,l),
+(170,681,l),
+(133,681,l),
+(124,636,l)
+);
+}
+);
+width = 373;
+}
+);
+metricRight = "y-canadian";
+note = uni15AE;
+unicode = 5550;
+},
+{
+glyphname = "bAivilik-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(477,-15,o),
+(584,145,o),
+(584,307,cs),
+(584,434,o),
+(504,524,o),
+(383,524,cs),
+(326,524,o),
+(277,501,o),
+(255,464,c),
+(271,439,l),
+(328,714,l),
+(162,714,l),
+(11,0,l),
+(169,0,l),
+(186,79,l),
+(173,65,l),
+(189,16,o),
+(242,-15,o),
+(313,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(258,125,o),
+(228,159,o),
+(228,215,cs),
+(228,269,o),
+(255,384,o),
+(341,384,cs),
+(392,384,o),
+(422,351,o),
+(422,295,cs),
+(422,242,o),
+(395,125,o),
+(308,125,cs)
+);
+}
+);
+width = 623;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|ke-canadian";
+note = uni15AF;
+unicode = 5551;
+},
+{
+glyphname = "eBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(176,0,l),
+(267,425,l),
+(292,382,o),
+(340,354,o),
+(401,354,cs),
+(525,354,o),
+(599,467,o),
+(599,572,cs),
+(599,664,o),
+(538,729,o),
+(445,729,cs),
+(394,729,o),
+(346,709,o),
+(312,675,c),
+(321,714,l),
+(162,714,l),
+(10,0,l)
+);
+}
+);
+width = 575;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B0;
+unicode = 5552;
+},
+{
+glyphname = "iBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(224,-15,o),
+(272,5,o),
+(306,39,c),
+(297,0,l),
+(456.006,0,l),
+(608.006,714,l),
+(442,714,l),
+(351,289,l),
+(326,332,o),
+(278,360,o),
+(218,360,cs),
+(93,360,o),
+(19,247,o),
+(19,142,cs),
+(19,50,o),
+(80,-15,o),
+(173,-15,cs)
+);
+}
+);
+width = 574;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B1;
+unicode = 5553;
+},
+{
+glyphname = "oBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(447,-15,o),
+(521,97,o),
+(521,203,cs),
+(521,295,o),
+(461,360,o),
+(368,360,cs),
+(320,360,o),
+(276,343,o),
+(243,315,c),
+(328,714,l),
+(162,714,l),
+(10,0,l),
+(169,0,l),
+(184,70,l),
+(206,18,o),
+(258,-15,o),
+(323,-15,cs)
+);
+}
+);
+width = 575;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "eBlackfoot-canadian";
+note = uni15B2;
+unicode = 5554;
+},
+{
+glyphname = "aBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(457,0,l),
+(609,714,l),
+(450,714,l),
+(435,644,l),
+(413,696,o),
+(361,729,o),
+(296,729,cs),
+(172,729,o),
+(98,617,o),
+(98,511,cs),
+(98,419,o),
+(158,354,o),
+(251,354,cs),
+(299,354,o),
+(343,371,o),
+(376,399,c),
+(291,0,l)
+);
+}
+);
+width = 575;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B3;
+unicode = 5555;
+},
+{
+glyphname = "weBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(176,0,l),
+(237,286,l),
+(572,286,l),
+(600,423,l),
+(266,423,l),
+(299,576,l),
+(633,576,l),
+(662,714,l),
+(162,714,l),
+(10,0,l)
+);
+}
+);
+width = 617;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B4;
+unicode = 5556;
+},
+{
+glyphname = "wiBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(498,0,l),
+(650,714,l),
+(484,714,l),
+(423,428,l),
+(89,428,l),
+(60,291,l),
+(394,291,l),
+(361,138,l),
+(27,138,l),
+(-2,0,l)
+);
+}
+);
+width = 616;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B5;
+unicode = 5557;
+},
+{
+glyphname = "woBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(510,0,l),
+(539,138,l),
+(206,138,l),
+(238,291,l),
+(572,291,l),
+(601,428,l),
+(268,428,l),
+(328,714,l),
+(162,714,l),
+(10,0,l)
+);
+}
+);
+width = 616;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "weBlackfoot-canadian";
+note = uni15B6;
+unicode = 5558;
+},
+{
+glyphname = "waBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(499,0,l),
+(651,714,l),
+(150,714,l),
+(122,576,l),
+(455,576,l),
+(423,423,l),
+(89,423,l),
+(60,286,l),
+(393,286,l),
+(333,0,l)
+);
+}
+);
+width = 617;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B7;
+unicode = 5559;
+},
+{
+glyphname = "neBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(176,0,l),
+(302,594,l),
+(355,594,l),
+(337,696,l),
+(332,674,ls),
+(295,511,o),
+(387,397,o),
+(555,397,cs),
+(704,397,o),
+(805,483,o),
+(838,640,cs),
+(854,714,l),
+(690.996,714,l),
+(675,638,ls),
+(662,573,o),
+(624,539,o),
+(566,539,cs),
+(503,539,o),
+(474,580,o),
+(489,651,cs),
+(503,714,l),
+(162,714,l),
+(10,0,l)
+);
+}
+);
+width = 785;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B8;
+unicode = 5560;
+},
+{
+glyphname = "niBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(138,0,l),
+(154,76,ls),
+(167,141,o),
+(204,175,o),
+(262,175,cs),
+(326,175,o),
+(354,134,o),
+(339,63,cs),
+(326,0,l),
+(666,0,l),
+(818,714,l),
+(652,714,l),
+(526,120,l),
+(473,120,l),
+(492,18,l),
+(497,40,ls),
+(534,203,o),
+(442,317,o),
+(273,317,cs),
+(125,317,o),
+(24,231,o),
+(-9,74,cs),
+(-25,0,l)
+);
+}
+);
+width = 784;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B9;
+unicode = 5561;
+},
+{
+glyphname = "noBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(351,0,l),
+(367,75,ls),
+(382,142,o),
+(418,176,o),
+(475,176,cs),
+(539,176,o),
+(567,135,o),
+(552,64,cs),
+(539,0,l),
+(702,0,l),
+(711,45,ls),
+(744,206,o),
+(653,318,o),
+(486,318,cs),
+(339,318,o),
+(240,234,o),
+(201,57,cs),
+(192,19,l),
+(255,120,l),
+(202,120,l),
+(328,714,l),
+(162,714,l),
+(10,0,l)
+);
+}
+);
+width = 785;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "neBlackfoot-canadian";
+note = uni15BA;
+unicode = 5562;
+},
+{
+glyphname = "naBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(666,0,l),
+(818,714,l),
+(478,714,l),
+(461,639,ls),
+(447,572,o),
+(411,538,o),
+(353,538,cs),
+(290,538,o),
+(261,579,o),
+(276,650,cs),
+(289,714,l),
+(127,714,l),
+(117,669,ls),
+(85,508,o),
+(176,396,o),
+(342,396,cs),
+(489,396,o),
+(589,480,o),
+(628,657,cs),
+(636,695,l),
+(574,594,l),
+(626,594,l),
+(500,0,l)
+);
+}
+);
+width = 784;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BB;
+unicode = 5563;
+},
+{
+glyphname = "keBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(176,0,l),
+(288,522,l),
+(232,522,l),
+(321,258,l),
+(386,258,l),
+(734,714,l),
+(541.008,714,l),
+(349,459,l),
+(397,455,l),
+(315,714,l),
+(162,714,l),
+(10,0,l)
+);
+}
+);
+width = 645;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15BC;
+unicode = 5564;
+},
+{
+glyphname = "kiBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(148,0,l),
+(341,255,l),
+(293,259,l),
+(374,0,l),
+(527,0,l),
+(679,714,l),
+(513,714,l),
+(401,192,l),
+(457,192,l),
+(368,456,l),
+(303,456,l),
+(-45,0,l)
+);
+}
+);
+width = 645;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BD;
+unicode = 5565;
+},
+{
+glyphname = "koBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(163,0,l),
+(403,283,l),
+(310,295,l),
+(411,0,l),
+(582,0,l),
+(428,456,l),
+(363,456,l),
+(160,192,l),
+(217,192,l),
+(328,714,l),
+(162,714,l),
+(10,0,l)
+);
+}
+);
+width = 645;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "keBlackfoot-canadian";
+note = uni15BE;
+unicode = 5566;
+},
+{
+glyphname = "kaBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(527,0,l),
+(679,714,l),
+(526,714,l),
+(286,431,l),
+(379,419,l),
+(278,714,l),
+(107,714,l),
+(262,258,l),
+(327,258,l),
+(530,522,l),
+(472,522,l),
+(361,0,l)
+);
+}
+);
+width = 645;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BF;
+unicode = 5567;
+},
+{
+color = 9;
+glyphname = "heSayisi-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_right_can;
+pos = (676,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(606,0,l),
+(758,714,l),
+(595,714,l),
+(521,367,l),
+(547,367,l),
+(591,584,o),
+(508,729,o),
+(345,729,cs),
+(220,729,o),
+(131,642,o),
+(93,486,cs),
+(83,441,o),
+(76,394,o),
+(74,340,c),
+(233,340,l),
+(236,389,o),
+(240,423,o),
+(248,455,cs),
+(270,540,o),
+(311,584,o),
+(368,584,cs),
+(494,584,o),
+(522,385,o),
+(440,0,c)
+);
+}
+);
+width = 724;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni15C0;
+unicode = 5568;
+},
+{
+color = 9;
+glyphname = "hiSayisi-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(176,0,l),
+(258,374,o),
+(369,584,o),
+(488,584,cs),
+(554,584,o),
+(578,522,o),
+(555,414,cs),
+(548,386,o),
+(541,363,o),
+(534,340,c),
+(692,340,l),
+(703,368,o),
+(711,394,o),
+(717,420,cs),
+(755,603,o),
+(685,729,o),
+(546,729,cs),
+(402,729,o),
+(277,592,o),
+(231,382,c),
+(255,382,l),
+(326,714,l),
+(162,714,l),
+(10,0,l)
+);
+}
+);
+width = 726;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C1;
+unicode = 5569;
+},
+{
+color = 9;
+glyphname = "hoSayisi-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (455,714);
+},
+{
+name = top_left_can;
+pos = (232,714);
+},
+{
+name = top_right_can;
+pos = (677,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(368,-15,o),
+(493,122,o),
+(539,332,c),
+(514,332,l),
+(444,0,l),
+(607,0,l),
+(759,714,l),
+(593,714,l),
+(512,340,o),
+(400,130,o),
+(281,130,cs),
+(215,130,o),
+(191,192,o),
+(215,300,cs),
+(221,328,o),
+(228,351,o),
+(236,374,c),
+(77,374,l),
+(66,346,o),
+(58,320,o),
+(52,294,cs),
+(14,111,o),
+(84,-15,o),
+(224,-15,cs)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "heSayisi-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15C2;
+unicode = 5570;
+},
+{
+color = 9;
+glyphname = "haSayisi-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(549,-15,o),
+(638,72,o),
+(676,228,cs),
+(686,273,o),
+(692,320,o),
+(694,374,c),
+(536,374,l),
+(533,325,o),
+(528,291,o),
+(520,259,cs),
+(499,174,o),
+(458,130,o),
+(400,130,cs),
+(274,130,o),
+(246,329,o),
+(328,714,c),
+(162,714,l),
+(10,0,l),
+(174,0,l),
+(247,347,l),
+(221,347,l),
+(178,130,o),
+(260,-15,o),
+(424,-15,cs)
+);
+}
+);
+width = 726;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C3;
+unicode = 5571;
+},
+{
+color = 9;
+glyphname = "ghuCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(348,0,l),
+(819,674,l),
+(828,714,l),
+(675,714,l),
+(543,521,l),
+(594,549,l),
+(260,549,l),
+(304,523,l),
+(258,714,l),
+(123,714,l),
+(115,674,l),
+(300,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(519,425,l),
+(500,447,l),
+(327,193,l),
+(390,183,l),
+(321,450,l),
+(291,425,l)
+);
+}
+);
+width = 755;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C4;
+unicode = 5572;
+},
+{
+color = 9;
+glyphname = "ghoCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(124,0,l),
+(257,193,l),
+(205,165,l),
+(539,165,l),
+(495,191,l),
+(542,0,l),
+(676,0,l),
+(685,40,l),
+(500,714,l),
+(451,714,l),
+(-20,40,l),
+(-29,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(500,342,l),
+(311,345,l),
+(329,269,l),
+(480,468,l),
+(378,475,l),
+(447,261,l)
+);
+}
+);
+width = 756;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C5;
+unicode = 5573;
+},
+{
+color = 9;
+glyphname = "gheCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (104,371);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(28,0,l),
+(655,332,l),
+(666,382,l),
+(180,714,l),
+(141,714,l),
+(115,592,l),
+(255,494,l),
+(249,586,l),
+(159,161,l),
+(199,247,l),
+(22,153,l),
+(-11,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(358,526,l),
+(319,469,l),
+(519,329,l),
+(525,406,l),
+(276,275,l),
+(293,220,l)
+);
+}
+);
+width = 667;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15C6;
+unicode = 5574;
+},
+{
+color = 9;
+glyphname = "gheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (29,14);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 668;
+}
+);
+note = uni15C7;
+unicode = 5575;
+},
+{
+color = 9;
+glyphname = "ghiCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (3,14);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 668;
+}
+);
+note = uni15C8;
+unicode = 5576;
+},
+{
+color = 9;
+glyphname = "ghaCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(569,0,l),
+(595,122,l),
+(455,220,l),
+(461,128,l),
+(551,553,l),
+(511,467,l),
+(688,561,l),
+(721,714,l),
+(682,714,l),
+(55,382,l),
+(44,332,l),
+(530,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(391,245,l),
+(201,376,l),
+(196,315,l),
+(434,439,l),
+(414,482,l),
+(356,206,l)
+);
+}
+);
+width = 666;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15C9;
+unicode = 5577;
+},
+{
+color = 9;
+glyphname = "ruCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(348,0,l),
+(819,674,l),
+(828,714,l),
+(674,714,l),
+(612,624,l),
+(671,649,l),
+(234,649,l),
+(279,624,l),
+(257,714,l),
+(123,714,l),
+(115,674,l),
+(300,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(593,522,l),
+(566,547,l),
+(329,198,l),
+(390,188,l),
+(296,548,l),
+(263,522,l)
+);
+}
+);
+width = 755;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CA;
+unicode = 5578;
+},
+{
+color = 9;
+glyphname = "roCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(451,714,l),
+(-20,40,l),
+(-29,0,l),
+(126,0,l),
+(188,90,l),
+(128,65,l),
+(565,65,l),
+(521,90,l),
+(542,0,l),
+(676,0,l),
+(685,40,l),
+(500,714,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(207,192,l),
+(234,167,l),
+(471,516,l),
+(410,526,l),
+(503,166,l),
+(536,192,l)
+);
+}
+);
+width = 756;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CB;
+unicode = 5579;
+},
+{
+color = 9;
+glyphname = "reCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(29,0,l),
+(655,332,l),
+(666,382,l),
+(180,714,l),
+(141,714,l),
+(115,593,l),
+(190,540,l),
+(181,633,l),
+(70,112,l),
+(114,198,l),
+(21,148,l),
+(-11,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(292,562,l),
+(253,503,l),
+(508,328,l),
+(512,404,l),
+(194,236,l),
+(211,182,l)
+);
+}
+);
+width = 667;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CC;
+unicode = 5580;
+},
+{
+color = 9;
+glyphname = "reeCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(29,0,l),
+(655,332,l),
+(666,382,l),
+(181,714,l),
+(141,714,l),
+(120,613,l),
+(186,564,l),
+(184,650,l),
+(66,94,l),
+(100,177,l),
+(17,132,l),
+(-11,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(282,595,l),
+(236,542,l),
+(550,330,l),
+(554,406,l),
+(171,204,l),
+(186,147,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(316,302,l),
+(345,439,l),
+(282,439,l),
+(253,302,l)
+);
+}
+);
+width = 667;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CD;
+unicode = 5581;
+},
+{
+color = 9;
+glyphname = "riCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(29,0,l),
+(655,332,l),
+(666,382,l),
+(181,714,l),
+(141,714,l),
+(120,613,l),
+(187,563,l),
+(184,650,l),
+(66,94,l),
+(109,182,l),
+(17,132,l),
+(-11,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(350,322,o),
+(376,344,o),
+(376,375,cs),
+(376,406,o),
+(350,428,o),
+(322,428,cs),
+(294,428,o),
+(268,406,o),
+(268,375,cs),
+(268,344,o),
+(294,322,o),
+(322,322,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(282,595,l),
+(236,542,l),
+(550,330,l),
+(554,406,l),
+(173,205,l),
+(186,147,l)
+);
+}
+);
+width = 667;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CE;
+unicode = 5582;
+},
+{
+color = 9;
+glyphname = "raCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(569,0,l),
+(595,121,l),
+(520,174,l),
+(529,81,l),
+(640,602,l),
+(596,516,l),
+(689,566,l),
+(721,714,l),
+(681,714,l),
+(55,382,l),
+(44,332,l),
+(530,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(457,211,l),
+(202,386,l),
+(198,310,l),
+(516,478,l),
+(499,532,l),
+(418,152,l)
+);
+}
+);
+width = 666;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15CF;
+unicode = 5583;
+},
+{
+color = 9;
+glyphname = "wuCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(357.006,0,l),
+(837,674,l),
+(845,714,l),
+(698.996,714,l),
+(413,289,l),
+(450,289,l),
+(540,714,l),
+(410,714,l),
+(319,289,l),
+(359,289,l),
+(248,714,l),
+(123,714,l),
+(115,674,l),
+(308,0,l)
+);
+}
+);
+width = 773;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D0;
+unicode = 5584;
+},
+{
+color = 9;
+glyphname = "woCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(118,0,l),
+(404,425,l),
+(367,425,l),
+(276,0,l),
+(407,0,l),
+(498,425,l),
+(457,425,l),
+(569,0,l),
+(693,0,l),
+(702,40,l),
+(509,714,l),
+(460,714,l),
+(-20,40,l),
+(-29,0,l)
+);
+}
+);
+width = 773;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D1;
+unicode = 5585;
+},
+{
+color = 9;
+glyphname = "weCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(49,0,l),
+(676,332,l),
+(687,382,l),
+(201,714,l),
+(162,714,l),
+(136,592,l),
+(422,404,l),
+(431,432,l),
+(103,432,l),
+(76,308,l),
+(404,308,l),
+(409,334,l),
+(42,148,l),
+(11,0,l)
+);
+}
+);
+width = 688;
+}
+);
+metricRight = "o-canadian";
+note = uni15D2;
+unicode = 5586;
+},
+{
+color = 9;
+glyphname = "weeCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(50,0,l),
+(676,332,l),
+(687,382,l),
+(202,714,l),
+(163,714,l),
+(140,608,l),
+(469,390,l),
+(480,419,l),
+(252,419,l),
+(267,488,l),
+(181,488,l),
+(166,419,l),
+(99,419,l),
+(79,322,l),
+(145,322,l),
+(131,253,l),
+(217,253,l),
+(231,322,l),
+(460,322,l),
+(456,347,l),
+(39,134,l),
+(11,0,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D3;
+unicode = 5587;
+},
+{
+color = 9;
+glyphname = "wiCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(50,0,l),
+(676,332,l),
+(687,382,l),
+(202,714,l),
+(163,714,l),
+(140,608,l),
+(456,400,l),
+(477,420,l),
+(319,420,l),
+(303,453,o),
+(271,476,o),
+(231,476,cs),
+(192,476,o),
+(159,453,o),
+(144,420,c),
+(100,420,l),
+(80,330,l),
+(147,330,l),
+(163,300,o),
+(195,280,o),
+(232,280,cs),
+(268,280,o),
+(299,301,o),
+(314,330,c),
+(456,330,l),
+(447,341,l),
+(39,134,l),
+(11,0,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D4;
+unicode = 5588;
+},
+{
+color = 9;
+glyphname = "waCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(569,0,l),
+(595,122,l),
+(309,310,l),
+(301,282,l),
+(628,282,l),
+(655,406,l),
+(327,406,l),
+(322,380,l),
+(689,566,l),
+(720,714,l),
+(682,714,l),
+(55,382,l),
+(44,332,l),
+(530,0,l)
+);
+}
+);
+width = 687;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15D5;
+unicode = 5589;
+},
+{
+color = 9;
+glyphname = "hwuCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(357.006,0,l),
+(837,674,l),
+(845,714,l),
+(709,714,l),
+(596,550,l),
+(630,571,l),
+(494,571,l),
+(525,714,l),
+(424,714,l),
+(393,571,l),
+(255,571,l),
+(279,558,l),
+(237,714,l),
+(123,714,l),
+(115,674,l),
+(308,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(362,216,l),
+(287,507,l),
+(273,484,l),
+(385,484,l),
+(328,215,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(466,484,l),
+(579,484,l),
+(575,507,l),
+(382,221,l),
+(409,210,l)
+);
+}
+);
+width = 773;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D6;
+unicode = 5590;
+},
+{
+color = 9;
+glyphname = "hwoCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(107,0,l),
+(220,164,l),
+(187,143,l),
+(322,143,l),
+(291,0,l),
+(393,0,l),
+(423,143,l),
+(561,143,l),
+(537,156,l),
+(579,0,l),
+(693,0,l),
+(702,40,l),
+(508,714,l),
+(459,714,l),
+(-20,40,l),
+(-29,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(434,493,l),
+(408,504,l),
+(351,230,l),
+(237,230,l),
+(241,207,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(544,230,l),
+(432,230,l),
+(488,499,l),
+(455,498,l),
+(529,207,l)
+);
+}
+);
+width = 773;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D7;
+unicode = 5591;
+},
+{
+color = 9;
+glyphname = "hweCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(49,0,l),
+(676,332,l),
+(687,382,l),
+(201,714,l),
+(162,714,l),
+(140,609,l),
+(254,534,l),
+(230,423,l),
+(101,423,l),
+(78,319,l),
+(208,319,l),
+(185,209,l),
+(38,134,l),
+(10,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(287,330,l),
+(450,330,l),
+(269,242,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(323,498,l),
+(459,413,l),
+(305,413,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D8;
+unicode = 5592;
+},
+{
+color = 9;
+glyphname = "hweeCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(49,0,l),
+(676,332,l),
+(687,382,l),
+(201,714,l),
+(162,714,l),
+(140,612,l),
+(293,515,l),
+(271,414,l),
+(222,414,l),
+(236,480,l),
+(167,480,l),
+(153,414,l),
+(98,414,l),
+(80,327,l),
+(134,327,l),
+(121,261,l),
+(190,261,l),
+(203,327,l),
+(253,327,l),
+(231,226,l),
+(38,132,l),
+(10,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(322,336,l),
+(462,336,l),
+(306,259,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(353,480,l),
+(471,406,l),
+(337,406,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D9;
+unicode = 5593;
+},
+{
+color = 9;
+glyphname = "hwiCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(49,0,l),
+(676,332,l),
+(687,382,l),
+(201,714,l),
+(162,714,l),
+(141,612,l),
+(293,514,l),
+(270,406,l),
+(245,406,l),
+(234,430,o),
+(209,447,o),
+(181,447,cs),
+(152,447,o),
+(129,430,o),
+(117,406,c),
+(97,406,l),
+(82,335,l),
+(116,335,l),
+(128,311,o),
+(152,294,o),
+(180,294,cs),
+(208,294,o),
+(232,311,o),
+(244,335,c),
+(255,335,l),
+(232,226,l),
+(38,132,l),
+(10,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(323,335,l),
+(461,335,l),
+(307,259,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(353,481,l),
+(471,406,l),
+(337,406,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15DA;
+unicode = 5594;
+},
+{
+color = 9;
+glyphname = "hwaCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(682,714,l),
+(55,382,l),
+(44,332,l),
+(530,0,l),
+(569,0,l),
+(591,105,l),
+(477,180,l),
+(501,291,l),
+(630,291,l),
+(652,395,l),
+(523,395,l),
+(546,505,l),
+(693,580,l),
+(721,714,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(444,384,l),
+(281,384,l),
+(462,472,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(408,216,l),
+(272,301,l),
+(426,301,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15DB;
+unicode = 5595;
+},
+{
+color = 9;
+glyphname = "thuCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(547,-15,o),
+(657,85,o),
+(702,295,cs),
+(791,714,l),
+(155,714,l),
+(73,330,ls),
+(28,115,o),
+(139,-15,o),
+(351,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(291,569,l),
+(593,569,l),
+(536,299,ls),
+(512,186,o),
+(457,135,o),
+(365,135,cs),
+(254,135,o),
+(212,198,o),
+(237,318,cs)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DC;
+unicode = 5596;
+},
+{
+color = 9;
+glyphname = "thoCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(639,0,l),
+(721,384,ls),
+(766,599,o),
+(655,729,o),
+(443,729,cs),
+(247,729,o),
+(137,629,o),
+(92,419,cs),
+(3,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(258,415,ls),
+(282,528,o),
+(337,579,o),
+(429,579,cs),
+(540,579,o),
+(582,516,o),
+(557,396,cs),
+(503,145,l),
+(201,145,l)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DD;
+unicode = 5597;
+},
+{
+color = 9;
+glyphname = "theCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (397,357);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(290,0,ls),
+(619,0,o),
+(725,232,o),
+(725,427,cs),
+(725,606,o),
+(612,714,o),
+(411,714,cs),
+(162,714,l),
+(10,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(308,620,l),
+(249,569,l),
+(376,569,ls),
+(496,569,o),
+(561,514,o),
+(561,411,cs),
+(561,273,o),
+(477,145,o),
+(296,145,cs),
+(166,145,l),
+(197,96,l)
+);
+}
+);
+width = 751;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "to-canadian";
+note = uni15DE;
+unicode = 5598;
+},
+{
+color = 9;
+glyphname = "theeCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (309,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 752;
+}
+);
+note = uni15DF;
+unicode = 5599;
+},
+{
+color = 9;
+glyphname = "thiCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (278,0);
+ref = dot_middle;
+}
+);
+width = 752;
+}
+);
+note = uni15E0;
+unicode = 5600;
+},
+{
+color = 9;
+glyphname = "thaCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(633,0,l),
+(785,714,l),
+(505,714,ls),
+(176,714,o),
+(70,482,o),
+(70,287,cs),
+(70,108,o),
+(183,0,o),
+(383,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(234,441,o),
+(318,569,o),
+(499,569,cs),
+(629,569,l),
+(598,618,l),
+(487,94,l),
+(545,145,l),
+(418,145,ls),
+(298,145,o),
+(234,200,o),
+(234,303,cs)
+);
+}
+);
+width = 751;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15E1;
+unicode = 5601;
+},
+{
+color = 9;
+glyphname = "ttuCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(549,-15,o),
+(657,83,o),
+(703,301,cs),
+(791,714,l),
+(743,714,l),
+(368,522,l),
+(501,497,l),
+(205.002,714,l),
+(155,714,l),
+(73,329,ls),
+(28,115,o),
+(137,-15,o),
+(355,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(256,135,o),
+(213,200,o),
+(237,317,cs),
+(288,560,l),
+(204,536,l),
+(393,400,l),
+(421,400,l),
+(646,515,l),
+(592,559,l),
+(540,315,ls),
+(514,189,o),
+(458,135,o),
+(361,135,cs)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E2;
+unicode = 5602;
+},
+{
+color = 9;
+glyphname = "ttoCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(51,0,l),
+(426,192,l),
+(293,217,l),
+(589,0,l),
+(639,0,l),
+(721,385,ls),
+(766,599,o),
+(657,729,o),
+(439,729,cs),
+(245,729,o),
+(137,631,o),
+(91,413,cs),
+(3,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(538,579,o),
+(581,514,o),
+(557,397,cs),
+(506,154,l),
+(590,178,l),
+(401,314,l),
+(373,314,l),
+(148,199,l),
+(202,155,l),
+(254,399,ls),
+(280,525,o),
+(336,579,o),
+(433,579,cs)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E3;
+unicode = 5603;
+},
+{
+color = 9;
+glyphname = "tteCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (448,357);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(300,0,ls),
+(587,0,o),
+(735,194,o),
+(735,427,cs),
+(735,606,o),
+(622,714,o),
+(424,714,cs),
+(155,714,l),
+(146,674,l),
+(213,292,l),
+(227,430,l),
+(12,40,l),
+(3,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(355,343,l),
+(360,368,l),
+(311,643,l),
+(254,569,l),
+(386,569,ls),
+(506,569,o),
+(571,513,o),
+(571,410,cs),
+(571,274,o),
+(487,145,o),
+(306,145,cs),
+(170,145,l),
+(212,80,l)
+);
+}
+);
+width = 761;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15E4;
+unicode = 5604;
+},
+{
+color = 9;
+glyphname = "tteeCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (373,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 762;
+}
+);
+note = uni15E5;
+unicode = 5605;
+},
+{
+color = 9;
+glyphname = "ttiCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (363,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 762;
+}
+);
+note = uni15E6;
+unicode = 5606;
+},
+{
+color = 9;
+glyphname = "ttaCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(651,0,l),
+(660,40,l),
+(592,422,l),
+(578,284,l),
+(794,674,l),
+(803,714,l),
+(506,714,ls),
+(218,714,o),
+(70,520,o),
+(70,287,cs),
+(70,108,o),
+(184,0,o),
+(381,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(552,145,l),
+(419,145,ls),
+(299,145,o),
+(234,201,o),
+(234,304,cs),
+(234,440,o),
+(319,569,o),
+(500,569,cs),
+(635,569,l),
+(593,634,l),
+(451,371,l),
+(446,346,l),
+(495,71,l)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tteCarrier-canadian";
+note = uni15E7;
+unicode = 5607;
+},
+{
+color = 9;
+glyphname = "puCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(547,-15,o),
+(657,85,o),
+(702,295,cs),
+(791,714,l),
+(625,714,l),
+(595,575,l),
+(292,575,l),
+(321,714,l),
+(155,714,l),
+(73,330,ls),
+(28,115,o),
+(139,-15,o),
+(351,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(254,135,o),
+(212,198,o),
+(237,318,cs),
+(261,429,l),
+(564,429,l),
+(536,299,ls),
+(512,186,o),
+(457,135,o),
+(365,135,cs)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E8;
+unicode = 5608;
+},
+{
+color = 9;
+glyphname = "poCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(169,0,l),
+(199,139,l),
+(502,139,l),
+(473,0,l),
+(639,0,l),
+(721,384,ls),
+(766,599,o),
+(655,729,o),
+(443,729,cs),
+(247,729,o),
+(137,629,o),
+(92,419,cs),
+(3,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(258,415,ls),
+(282,528,o),
+(337,579,o),
+(429,579,cs),
+(540,579,o),
+(582,516,o),
+(557,396,cs),
+(533,285,l),
+(230,285,l)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E9;
+unicode = 5609;
+},
+{
+color = 9;
+glyphname = "peCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (434,357);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(299,0,ls),
+(628,0,o),
+(734,232,o),
+(734,427,cs),
+(734,606,o),
+(621,714,o),
+(423,714,cs),
+(154,714,l),
+(123,569,l),
+(205,569,l),
+(115,145,l),
+(33,145,l),
+(2,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(385,642,l),
+(267,569,l),
+(385,569,ls),
+(505,569,o),
+(569,513,o),
+(569,411,cs),
+(569,274,o),
+(487,145,o),
+(305,145,cs),
+(177,145,l),
+(265,72,l)
+);
+}
+);
+width = 760;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15EA;
+unicode = 5610;
+},
+{
+color = 9;
+glyphname = "peeCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (359,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 761;
+}
+);
+note = uni15EB;
+unicode = 5611;
+},
+{
+color = 9;
+glyphname = "piCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (349,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 761;
+}
+);
+note = uni15EC;
+unicode = 5612;
+},
+{
+color = 9;
+glyphname = "paCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(650,0,l),
+(681,145,l),
+(600,145,l),
+(689,569,l),
+(772,569,l),
+(802,714,l),
+(505,714,ls),
+(177,714,o),
+(70,482,o),
+(70,287,cs),
+(70,108,o),
+(183,0,o),
+(381,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(538,145,l),
+(419,145,ls),
+(299,145,o),
+(235,201,o),
+(235,303,cs),
+(235,440,o),
+(318,569,o),
+(500,569,cs),
+(628,569,l),
+(540,642,l),
+(419,72,l)
+);
+}
+);
+width = 761;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|peCarrier-canadian";
+note = uni15ED;
+unicode = 5613;
+},
+{
+color = 6;
+glyphname = "pCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(377.006,189,l),
+(400,296,l),
+(289,296,l),
+(342,546,l),
+(229,546,l),
+(176,296,l),
+(64,296,l),
+(41,189,l)
+);
+}
+);
+width = 446;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni15EE;
+unicode = 5614;
+},
+{
+color = 9;
+glyphname = "guCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (540,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(335,-15,o),
+(406,34,o),
+(455,132,c),
+(383,132,l),
+(409,33,o),
+(469,-15,o),
+(571,-15,cs),
+(705,-15,o),
+(782,62,o),
+(814,217,cs),
+(920,714,l),
+(761,714,l),
+(656,218,ls),
+(644,159,o),
+(616,131,o),
+(569,131,cs),
+(521,131,o),
+(500,162,o),
+(512,219,cs),
+(617,714,l),
+(461,714,l),
+(356,219,ls),
+(344,161,o),
+(314,131,o),
+(267,131,cs),
+(219,131,o),
+(200,163,o),
+(212,222,cs),
+(317,714,l),
+(158,714,l),
+(56,232,ls),
+(24,80,o),
+(92,-15,o),
+(237,-15,cs)
+);
+}
+);
+width = 882;
+}
+);
+metricRight = "=|";
+note = uni15EF;
+unicode = 5615;
+},
+{
+color = 9;
+glyphname = "goCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(165,0,l),
+(270,496,ls),
+(283,555,o),
+(310,583,o),
+(357,583,cs),
+(405,583,o),
+(426,552,o),
+(414,495,cs),
+(309,0,l),
+(465,0,l),
+(570,495,ls),
+(582,553,o),
+(612,583,o),
+(659,583,cs),
+(707,583,o),
+(726,551,o),
+(714,492,cs),
+(609,0,l),
+(768,0,l),
+(870,482,ls),
+(902,634,o),
+(834,729,o),
+(689,729,cs),
+(591,729,o),
+(520,680,o),
+(471,582,c),
+(544,582,l),
+(517,681,o),
+(457,729,o),
+(356,729,cs),
+(222,729,o),
+(145,652,o),
+(112,497,cs),
+(6,0,l)
+);
+}
+);
+width = 882;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F0;
+unicode = 5616;
+},
+{
+color = 9;
+glyphname = "geCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (481,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(415,0,ls),
+(575,0,o),
+(685,76,o),
+(685,223,cs),
+(685,291,o),
+(652,345,o),
+(588,378,c),
+(576,320,l),
+(692,352,o),
+(753,433,o),
+(753,537,cs),
+(753,645,o),
+(670,714,o),
+(551,714,cs),
+(162,714,l),
+(133,580,l),
+(513,580,ls),
+(561,580,o),
+(587,556,o),
+(587,517,cs),
+(587,459,o),
+(549,423,o),
+(480,423,cs),
+(100,423,l),
+(72,291,l),
+(452,291,ls),
+(499,291,o),
+(525,268,o),
+(525,229,cs),
+(525,176,o),
+(494,134,o),
+(418,134,cs),
+(38,134,l),
+(10,0,l)
+);
+}
+);
+width = 759;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15F1;
+unicode = 5617;
+},
+{
+color = 9;
+glyphname = "geeCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(415,0,ls),
+(575,0,o),
+(685,76,o),
+(685,223,cs),
+(685,291,o),
+(652,345,o),
+(588,378,c),
+(576,320,l),
+(692,352,o),
+(753,433,o),
+(753,537,cs),
+(753,645,o),
+(670,714,o),
+(551,714,cs),
+(162,714,l),
+(133,580,l),
+(513,580,ls),
+(561,580,o),
+(587,556,o),
+(587,517,cs),
+(587,459,o),
+(549,423,o),
+(480,423,cs),
+(401,423,l),
+(418,501,l),
+(323,501,l),
+(306,423,l),
+(100,423,l),
+(72,291,l),
+(278,291,l),
+(262,214,l),
+(357,214,l),
+(373,291,l),
+(452,291,ls),
+(499,291,o),
+(525,268,o),
+(525,229,cs),
+(525,176,o),
+(494,134,o),
+(418,134,cs),
+(38,134,l),
+(10,0,l)
+);
+}
+);
+width = 759;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F2;
+unicode = 5618;
+},
+{
+color = 9;
+glyphname = "giCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(415,0,ls),
+(575,0,o),
+(685,76,o),
+(685,223,cs),
+(685,290,o),
+(653,344,o),
+(589,379,c),
+(579,322,l),
+(693,353,o),
+(753,435,o),
+(753,537,cs),
+(753,645,o),
+(670,714,o),
+(551,714,cs),
+(162,714,l),
+(133,580,l),
+(513,580,ls),
+(561,580,o),
+(587,556,o),
+(587,517,cs),
+(587,459,o),
+(549,423,o),
+(480,423,cs),
+(411,423,l),
+(464,378,l),
+(455,433,o),
+(409,475,o),
+(350,475,cs),
+(308,475,o),
+(274,454,o),
+(254,423,c),
+(100,423,l),
+(72,291,l),
+(254,291,l),
+(274,260,o),
+(309,240,o),
+(350,240,cs),
+(408,240,o),
+(452,283,o),
+(463,336,c),
+(401,291,l),
+(452,291,ls),
+(499,291,o),
+(525,268,o),
+(525,229,cs),
+(525,176,o),
+(494,134,o),
+(418,134,cs),
+(38,134,l),
+(10,0,l)
+);
+}
+);
+width = 759;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F3;
+unicode = 5619;
+},
+{
+color = 9;
+glyphname = "gaCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (494,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(641,0,l),
+(669,134,l),
+(290,134,ls),
+(242,134,o),
+(215,158,o),
+(215,197,cs),
+(215,255,o),
+(254,291,o),
+(323,291,cs),
+(703,291,l),
+(731,423,l),
+(351,423,ls),
+(304,423,o),
+(277,446,o),
+(277,485,cs),
+(277,538,o),
+(309,580,o),
+(385,580,cs),
+(765,580,l),
+(793,714,l),
+(388,714,ls),
+(228,714,o),
+(117,638,o),
+(117,491,cs),
+(117,423,o),
+(150,369,o),
+(215,336,c),
+(227,394,l),
+(111,362,o),
+(50,281,o),
+(50,177,cs),
+(50,69,o),
+(132,0,o),
+(252,0,cs)
+);
+}
+);
+width = 760;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|geCarrier-canadian";
+note = uni15F4;
+unicode = 5620;
+},
+{
+color = 9;
+glyphname = "khuCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(327,-15,o),
+(396,28,o),
+(444,112,c),
+(388,115,l),
+(417,28,o),
+(475,-15,o),
+(571,-15,cs),
+(705,-15,o),
+(782,62,o),
+(814,217,cs),
+(920,714,l),
+(158,714,l),
+(56,232,ls),
+(24,80,o),
+(92,-15,o),
+(237,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(219,131,o),
+(200,163,o),
+(212,222,cs),
+(286,573,l),
+(431,573,l),
+(356,219,ls),
+(344,161,o),
+(314,131,o),
+(267,131,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(521,131,o),
+(500,162,o),
+(512,219,cs),
+(588,573,l),
+(731,573,l),
+(656,218,ls),
+(644,159,o),
+(616,131,o),
+(569,131,cs)
+);
+}
+);
+width = 882;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F5;
+unicode = 5621;
+},
+{
+color = 9;
+glyphname = "khoCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(768,0,l),
+(870,482,ls),
+(902,634,o),
+(834,729,o),
+(689,729,cs),
+(599,729,o),
+(530,686,o),
+(482,602,c),
+(538,599,l),
+(509,686,o),
+(451,729,o),
+(356,729,cs),
+(221,729,o),
+(145,652,o),
+(112,497,cs),
+(6,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(270,496,ls),
+(282,555,o),
+(310,583,o),
+(357,583,cs),
+(405,583,o),
+(426,552,o),
+(414,495,cs),
+(338,141,l),
+(195,141,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(570,495,ls),
+(582,553,o),
+(612,583,o),
+(659,583,cs),
+(707,583,o),
+(726,551,o),
+(714,492,cs),
+(640,141,l),
+(495,141,l)
+);
+}
+);
+width = 882;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F6;
+unicode = 5622;
+},
+{
+color = 9;
+glyphname = "kheCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(424,0,ls),
+(584,0,o),
+(695,76,o),
+(695,223,cs),
+(695,290,o),
+(662,342,o),
+(599,376,c),
+(590,322,l),
+(708,355,o),
+(762,442,o),
+(762,537,cs),
+(762,645,o),
+(679,714,o),
+(559,714,cs),
+(162,714,l),
+(10,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(238,292,l),
+(460,292,ls),
+(507,292,o),
+(534,268,o),
+(534,229,cs),
+(534,174,o),
+(499,132,o),
+(426,132,cs),
+(203,132,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(300,582,l),
+(522,582,ls),
+(570,582,o),
+(596,557,o),
+(596,517,cs),
+(596,463,o),
+(561,422,o),
+(489,422,cs),
+(265,422,l)
+);
+}
+);
+width = 769;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F7;
+unicode = 5623;
+},
+{
+color = 9;
+glyphname = "kheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(424,0,ls),
+(584,0,o),
+(695,76,o),
+(695,223,cs),
+(695,290,o),
+(662,342,o),
+(599,376,c),
+(590,322,l),
+(708,355,o),
+(762,442,o),
+(762,537,cs),
+(762,645,o),
+(679,714,o),
+(559,714,cs),
+(162,714,l),
+(10,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(238,294,l),
+(334,294,l),
+(317,213,l),
+(420,213,l),
+(442,316,l),
+(403,294,l),
+(460,294,ls),
+(507,294,o),
+(534,269,o),
+(534,230,cs),
+(534,175,o),
+(499,132,o),
+(426,132,cs),
+(203,132,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(481,502,l),
+(378,502,l),
+(361,421,l),
+(265,421,l),
+(300,582,l),
+(522,582,ls),
+(570,582,o),
+(596,557,o),
+(596,517,cs),
+(596,463,o),
+(561,421,o),
+(489,421,cs),
+(430,421,l),
+(460,400,l)
+);
+}
+);
+width = 769;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F8;
+unicode = 5624;
+},
+{
+color = 9;
+glyphname = "khiCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(424,0,ls),
+(584,0,o),
+(695,76,o),
+(695,223,cs),
+(695,289,o),
+(662,343,o),
+(597,376,c),
+(586,320,l),
+(708,354,o),
+(762,442,o),
+(762,537,cs),
+(762,645,o),
+(679,714,o),
+(559,714,cs),
+(162,714,l),
+(10,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(239,297,l),
+(302,297,l),
+(322,263,o),
+(358,240,o),
+(401,240,cs),
+(461,240,o),
+(507,287,o),
+(513,344,c),
+(417,297,l),
+(464,297,ls),
+(511,297,o),
+(534,270,o),
+(534,230,cs),
+(534,175,o),
+(499,132,o),
+(426,132,cs),
+(203,132,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(522,582,ls),
+(570,582,o),
+(596,556,o),
+(596,516,cs),
+(596,461,o),
+(564,418,o),
+(492,418,cs),
+(422,418,l),
+(515,370,l),
+(508,430,o),
+(461,475,o),
+(401,475,cs),
+(340,475,o),
+(292,430,o),
+(287,370,c),
+(342,418,l),
+(265,418,l),
+(300,582,l)
+);
+}
+);
+width = 769;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F9;
+unicode = 5625;
+},
+{
+color = 9;
+glyphname = "khaCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(650,0,l),
+(802,714,l),
+(388,714,ls),
+(228,714,o),
+(117,638,o),
+(117,491,cs),
+(117,424,o),
+(149,372,o),
+(213,338,c),
+(222,392,l),
+(104,359,o),
+(50,272,o),
+(50,177,cs),
+(50,69,o),
+(132,0,o),
+(252,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(242,132,o),
+(215,157,o),
+(215,197,cs),
+(215,251,o),
+(251,292,o),
+(323,292,cs),
+(546,292,l),
+(512,132,l),
+(290,132,ls)
+);
+},
+{
+closed = 1;
+nodes = (
+(304,422,o),
+(278,446,o),
+(278,485,cs),
+(278,540,o),
+(313,582,o),
+(386,582,cs),
+(608,582,l),
+(574,422,l),
+(352,422,ls)
+);
+}
+);
+width = 768;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15FA;
+unicode = 5626;
+},
+{
+color = 9;
+glyphname = "kkuCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(327,-15,o),
+(395,26,o),
+(445,112,c),
+(388,114,l),
+(417,28,o),
+(475,-15,o),
+(571,-15,cs),
+(705,-15,o),
+(781,61,o),
+(814,217,cs),
+(920,714,l),
+(872,714,l),
+(562,582,l),
+(529,416,l),
+(785,519,l),
+(732,578,l),
+(656,218,ls),
+(644,159,o),
+(616,131,o),
+(569,131,cs),
+(521,131,o),
+(500,164,o),
+(511,219,cs),
+(617,714,l),
+(462,714,l),
+(357,219,ls),
+(344,161,o),
+(314,131,o),
+(267,131,cs),
+(219,131,o),
+(200,163,o),
+(212,222,cs),
+(288,579,l),
+(208,542,l),
+(425,428,l),
+(458,580,l),
+(207,714,l),
+(158,714,l),
+(56,232,ls),
+(23,79,o),
+(93,-15,o),
+(237,-15,cs)
+);
+}
+);
+width = 882;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FB;
+unicode = 5627;
+},
+{
+color = 9;
+glyphname = "kkoCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(54,0,l),
+(364,132,l),
+(397,298,l),
+(141,195,l),
+(194,136,l),
+(270,496,ls),
+(282,555,o),
+(310,583,o),
+(357,583,cs),
+(405,583,o),
+(426,550,o),
+(415,495,cs),
+(309,0,l),
+(464,0,l),
+(569,495,ls),
+(582,553,o),
+(612,583,o),
+(659,583,cs),
+(707,583,o),
+(726,551,o),
+(714,492,cs),
+(638,135,l),
+(718,172,l),
+(501,286,l),
+(468,134,l),
+(719,0,l),
+(768,0,l),
+(870,482,ls),
+(903,635,o),
+(833,729,o),
+(689,729,cs),
+(599,729,o),
+(531,688,o),
+(481,602,c),
+(538,600,l),
+(509,686,o),
+(451,729,o),
+(355,729,cs),
+(221,729,o),
+(145,653,o),
+(112,497,cs),
+(6,0,l)
+);
+}
+);
+width = 882;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FC;
+unicode = 5628;
+},
+{
+color = 9;
+glyphname = "kkeCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(438,0,ls),
+(598,0,o),
+(709,75,o),
+(709,223,cs),
+(709,290,o),
+(677,342,o),
+(613,376,c),
+(604,322,l),
+(722,355,o),
+(776,442,o),
+(776,537,cs),
+(776,645,o),
+(694,714,o),
+(574,714,cs),
+(159,714,l),
+(150,674,l),
+(194,423,l),
+(117,423,l),
+(89,291,l),
+(157,291,l),
+(16,40,l),
+(7,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(327,291,l),
+(475,291,ls),
+(522,291,o),
+(549,268,o),
+(549,229,cs),
+(549,177,o),
+(517,134,o),
+(441,134,cs),
+(164,134,l),
+(205,69,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(313,654,l),
+(253,580,l),
+(536,580,ls),
+(584,580,o),
+(611,557,o),
+(611,517,cs),
+(611,459,o),
+(572,423,o),
+(503,423,cs),
+(354,423,l)
+);
+}
+);
+width = 783;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni15FD;
+unicode = 5629;
+},
+{
+color = 9;
+glyphname = "kkeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(438,0,ls),
+(598,0,o),
+(709,75,o),
+(709,223,cs),
+(709,290,o),
+(677,342,o),
+(613,376,c),
+(604,322,l),
+(722,355,o),
+(776,442,o),
+(776,537,cs),
+(776,645,o),
+(694,714,o),
+(574,714,cs),
+(159,714,l),
+(150,674,l),
+(194,423,l),
+(117,423,l),
+(89,291,l),
+(157,291,l),
+(16,40,l),
+(7,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(329,295,l),
+(372,295,l),
+(355,213,l),
+(458,213,l),
+(482,326,l),
+(446,295,l),
+(481,295,ls),
+(525,295,o),
+(549,268,o),
+(549,229,cs),
+(549,177,o),
+(517,134,o),
+(441,134,cs),
+(164,134,l),
+(205,69,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(519,502,l),
+(416,502,l),
+(398,419,l),
+(355,419,l),
+(313,654,l),
+(253,580,l),
+(536,580,ls),
+(584,580,o),
+(611,557,o),
+(611,517,cs),
+(611,459,o),
+(572,419,o),
+(506,419,cs),
+(471,419,l),
+(497,397,l)
+);
+}
+);
+width = 783;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FE;
+unicode = 5630;
+},
+{
+color = 9;
+glyphname = "kkiCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(438,0,ls),
+(598,0,o),
+(709,75,o),
+(709,223,cs),
+(709,290,o),
+(677,342,o),
+(613,376,c),
+(604,322,l),
+(722,355,o),
+(776,442,o),
+(776,537,cs),
+(776,645,o),
+(694,714,o),
+(574,714,cs),
+(159,714,l),
+(150,674,l),
+(194,423,l),
+(117,423,l),
+(89,291,l),
+(157,291,l),
+(16,40,l),
+(7,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(330,298,l),
+(334,298,l),
+(353,263,o),
+(389,240,o),
+(432,240,cs),
+(487,240,o),
+(530,280,o),
+(539,330,c),
+(445,298,l),
+(481,298,ls),
+(528,298,o),
+(549,268,o),
+(549,229,cs),
+(549,177,o),
+(517,134,o),
+(441,134,cs),
+(164,134,l),
+(205,69,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(533,434,o),
+(489,475,o),
+(432,475,cs),
+(389,475,o),
+(352,451,o),
+(334,416,c),
+(356,416,l),
+(313,654,l),
+(253,580,l),
+(536,580,ls),
+(584,580,o),
+(611,557,o),
+(611,517,cs),
+(611,459,o),
+(575,416,o),
+(506,416,cs),
+(447,416,l),
+(542,380,l)
+);
+}
+);
+width = 783;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FF;
+unicode = 5631;
+},
+{
+color = 9;
+glyphname = "kkaCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(667,0,l),
+(676,40,l),
+(632,291,l),
+(710,291,l),
+(737,423,l),
+(669,423,l),
+(811,674,l),
+(819,714,l),
+(388,714,ls),
+(228,714,o),
+(117,639,o),
+(117,491,cs),
+(117,424,o),
+(149,372,o),
+(213,338,c),
+(222,392,l),
+(104,359,o),
+(50,272,o),
+(50,177,cs),
+(50,69,o),
+(132,0,o),
+(252,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(573,134,l),
+(290,134,ls),
+(242,134,o),
+(215,157,o),
+(215,197,cs),
+(215,255,o),
+(254,291,o),
+(323,291,cs),
+(472,291,l),
+(513,60,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(304,423,o),
+(277,446,o),
+(277,485,cs),
+(277,537,o),
+(309,580,o),
+(385,580,cs),
+(662,580,l),
+(621,645,l),
+(499,423,l),
+(351,423,ls)
+);
+}
+);
+width = 783;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|kkeCarrier-canadian";
+note = uni1600;
+unicode = 5632;
+},
+{
+color = 6;
+glyphname = "kkCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(337,546,l),
+(180,310,l),
+(260,310,l),
+(202,546,l),
+(98,546,l),
+(94,526,l),
+(186,189,l),
+(211,189,l),
+(447,526,l),
+(451,546,l)
+);
+}
+);
+width = 425;
+}
+);
+note = uni1601;
+unicode = 5633;
+},
+{
+color = 9;
+glyphname = "nuCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(538,-15,o),
+(656,87,o),
+(696,272,cs),
+(708,324,l),
+(543,324,l),
+(535,285,ls),
+(513,185,o),
+(458,135,o),
+(368,135,cs),
+(259,135,o),
+(213,204,o),
+(240,328,cs),
+(321,714,l),
+(155,714,l),
+(76,340,ls),
+(30,126,o),
+(140,-15,o),
+(356,-15,cs)
+);
+}
+);
+width = 741;
+}
+);
+metricLeft = "te-canadian";
+note = uni1602;
+unicode = 5634;
+},
+{
+color = 9;
+glyphname = "noCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(630,0,l),
+(709,374,ls),
+(755,588,o),
+(645,729,o),
+(429,729,cs),
+(247,729,o),
+(129,627,o),
+(89,442,cs),
+(77,390,l),
+(242,390,l),
+(250,429,ls),
+(272,529,o),
+(327,579,o),
+(417,579,cs),
+(526,579,o),
+(572,510,o),
+(545,386,cs),
+(464,0,l)
+);
+}
+);
+width = 741;
+}
+);
+metricLeft = "=|nuCarrier-canadian";
+metricRight = "te-canadian";
+note = uni1603;
+unicode = 5635;
+},
+{
+color = 9;
+glyphname = "neCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (384,356);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(296,0,ls),
+(619,0,o),
+(729,226,o),
+(729,425,cs),
+(729,605,o),
+(615,714,o),
+(416,714,cs),
+(140,714,l),
+(108,565,l),
+(392,565,ls),
+(503,565,o),
+(564,508,o),
+(564,409,cs),
+(564,294,o),
+(500,147,o),
+(313,147,cs),
+(293,147,l),
+(262,0,l)
+);
+}
+);
+width = 756;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1604;
+unicode = 5636;
+},
+{
+color = 9;
+glyphname = "neeCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "neCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (296,-1);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 756;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1605;
+unicode = 5637;
+},
+{
+color = 9;
+glyphname = "niCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "neCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (265,-1);
+ref = dot_middle;
+}
+);
+width = 756;
+}
+);
+note = uni1606;
+unicode = 5638;
+},
+{
+color = 9;
+glyphname = "naCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(659,0,l),
+(690,149,l),
+(406,149,ls),
+(295,149,o),
+(234,206,o),
+(234,305,cs),
+(234,420,o),
+(298,567,o),
+(485,567,cs),
+(505,567,l),
+(536,714,l),
+(502,714,ls),
+(179,714,o),
+(70,488,o),
+(70,289,cs),
+(70,109,o),
+(183,0,o),
+(383,0,cs)
+);
+}
+);
+width = 755;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni1607;
+unicode = 5639;
+},
+{
+color = 9;
+glyphname = "muCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(334,-15,o),
+(407,31,o),
+(455,132,c),
+(383,132,l),
+(409,36,o),
+(469,-15,o),
+(571,-15,cs),
+(705,-15,o),
+(781,62,o),
+(814,217,cs),
+(856,409,l),
+(692,409,l),
+(652,218,ls),
+(639,159,o),
+(612,131,o),
+(571,131,cs),
+(523,131,o),
+(503,165,o),
+(515,218,cs),
+(555,409,l),
+(394,409,l),
+(354,219,ls),
+(341,160,o),
+(311,131,o),
+(268,131,cs),
+(223,131,o),
+(205,163,o),
+(217,222,cs),
+(321,714,l),
+(158,714,l),
+(56,232,ls),
+(24,80,o),
+(92,-15,o),
+(237,-15,cs)
+);
+}
+);
+width = 883;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "=|";
+note = uni1608;
+unicode = 5640;
+},
+{
+color = 9;
+glyphname = "moCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(768,0,l),
+(870,482,ls),
+(902,634,o),
+(834,729,o),
+(689,729,cs),
+(592,729,o),
+(519,683,o),
+(471,582,c),
+(543,582,l),
+(518,678,o),
+(457,729,o),
+(356,729,cs),
+(221,729,o),
+(146,652,o),
+(113,497,cs),
+(71,305,l),
+(235,305,l),
+(275,496,ls),
+(288,555,o),
+(314,583,o),
+(356,583,cs),
+(403,583,o),
+(423,549,o),
+(411,496,cs),
+(371,305,l),
+(532,305,l),
+(572,495,ls),
+(585,554,o),
+(615,583,o),
+(658,583,cs),
+(703,583,o),
+(721,551,o),
+(709,492,cs),
+(605,0,l)
+);
+}
+);
+width = 882;
+}
+);
+metricLeft = "=|muCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni1609;
+unicode = 5641;
+},
+{
+color = 9;
+glyphname = "meCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(420,0,ls),
+(580,0,o),
+(691,76,o),
+(691,223,cs),
+(691,291,o),
+(658,345,o),
+(593,378,c),
+(582,320,l),
+(697,352,o),
+(758,433,o),
+(758,537,cs),
+(758,645,o),
+(676,714,o),
+(556,714,cs),
+(140,714,l),
+(111,580,l),
+(519,580,ls),
+(566,580,o),
+(593,556,o),
+(593,517,cs),
+(593,459,o),
+(554,423,o),
+(485,423,cs),
+(333,423,l),
+(305,291,l),
+(457,291,ls),
+(504,291,o),
+(531,268,o),
+(531,229,cs),
+(531,176,o),
+(499,134,o),
+(423,134,cs),
+(271,134,l),
+(243,0,l)
+);
+}
+);
+width = 765;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160A;
+unicode = 5642;
+},
+{
+color = 9;
+glyphname = "meeCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(420,0,ls),
+(580,0,o),
+(691,76,o),
+(691,223,cs),
+(691,291,o),
+(658,345,o),
+(593,378,c),
+(582,320,l),
+(697,352,o),
+(758,433,o),
+(758,537,cs),
+(758,645,o),
+(676,714,o),
+(556,714,cs),
+(140,714,l),
+(111,580,l),
+(519,580,ls),
+(566,580,o),
+(593,556,o),
+(593,517,cs),
+(593,459,o),
+(554,420,o),
+(486,420,cs),
+(438,420,l),
+(453,493,l),
+(347,493,l),
+(289,221,l),
+(396,221,l),
+(411,294,l),
+(459,294,ls),
+(505,294,o),
+(531,268,o),
+(531,229,cs),
+(531,176,o),
+(499,134,o),
+(423,134,cs),
+(271,134,l),
+(243,0,l)
+);
+}
+);
+width = 765;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160B;
+unicode = 5643;
+},
+{
+color = 9;
+glyphname = "miCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(419,0,ls),
+(575,0,o),
+(665,63,o),
+(686,181,cs),
+(702,269,o),
+(670,338,o),
+(593,378,c),
+(581,320,l),
+(682,347,o),
+(738,409,o),
+(753,496,cs),
+(778,625,o),
+(692,714,o),
+(555,714,cs),
+(140,714,l),
+(111,580,l),
+(518,580,ls),
+(571,580,o),
+(598,550,o),
+(590,502,cs),
+(583,447,o),
+(546,420,o),
+(485,420,cs),
+(396,420,l),
+(488,371,l),
+(479,432,o),
+(433,475,o),
+(372,475,cs),
+(306,475,o),
+(257,421,o),
+(257,357,cs),
+(257,291,o),
+(306,240,o),
+(372,240,cs),
+(432,240,o),
+(478,284,o),
+(487,341,c),
+(395,294,l),
+(457,294,ls),
+(510,294,o),
+(537,265,o),
+(529,213,cs),
+(521,161,o),
+(486,134,o),
+(422,134,cs),
+(270,134,l),
+(242,0,l)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160C;
+unicode = 5644;
+},
+{
+color = 9;
+glyphname = "maCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(669,0,l),
+(697,134,l),
+(290,134,ls),
+(242,134,o),
+(215,158,o),
+(215,197,cs),
+(215,255,o),
+(254,291,o),
+(323,291,cs),
+(475,291,l),
+(503,423,l),
+(351,423,ls),
+(304,423,o),
+(277,446,o),
+(277,485,cs),
+(277,538,o),
+(309,580,o),
+(385,580,cs),
+(537,580,l),
+(565,714,l),
+(388,714,ls),
+(228,714,o),
+(117,638,o),
+(117,491,cs),
+(117,423,o),
+(150,369,o),
+(215,336,c),
+(227,394,l),
+(111,362,o),
+(50,281,o),
+(50,177,cs),
+(50,69,o),
+(132,0,o),
+(252,0,cs)
+);
+}
+);
+width = 765;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni160D;
+unicode = 5645;
+},
+{
+color = 9;
+glyphname = "yuCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(574,-15,o),
+(712,118,o),
+(764,362,cs),
+(811,584,o),
+(748,729,o),
+(584,729,cs),
+(427,729,o),
+(356,592,o),
+(356,467,cs),
+(356,365,o),
+(413,296,o),
+(503,296,cs),
+(515,296,o),
+(525,298,o),
+(545,301,c),
+(572,431,l),
+(568,430,o),
+(563,430,o),
+(557,430,cs),
+(519,430,o),
+(501,448,o),
+(501,483,cs),
+(501,520,o),
+(518,595,o),
+(571,595,cs),
+(629,595,o),
+(638,521,o),
+(612,398,cs),
+(575,216,o),
+(508,135,o),
+(391,135,cs),
+(269,135,o),
+(216,223,o),
+(245,356,cs),
+(321,714,l),
+(155,714,l),
+(79,359,ls),
+(33,141,o),
+(149,-15,o),
+(373,-15,cs)
+);
+}
+);
+width = 798;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160E;
+unicode = 5646;
+},
+{
+color = 9;
+glyphname = "yoCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(415,-15,o),
+(486,122,o),
+(486,247,cs),
+(486,349,o),
+(430,418,o),
+(339,418,cs),
+(328,418,o),
+(317,416,o),
+(297,413,c),
+(270,283,l),
+(275,284,o),
+(279,284,o),
+(286,284,cs),
+(323,284,o),
+(342,266,o),
+(342,231,cs),
+(342,194,o),
+(325,119,o),
+(272,119,cs),
+(214,119,o),
+(204,193,o),
+(230,316,cs),
+(267,498,o),
+(335,579,o),
+(452,579,cs),
+(573,579,o),
+(626,491,o),
+(598,358,cs),
+(522,0,l),
+(688,0,l),
+(763,355,ls),
+(810,573,o),
+(694,729,o),
+(470,729,cs),
+(269,729,o),
+(130,596,o),
+(78,352,cs),
+(31,130,o),
+(94,-15,o),
+(259,-15,cs)
+);
+}
+);
+width = 799;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160F;
+unicode = 5647;
+},
+{
+color = 9;
+glyphname = "yeCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(594,-15,o),
+(723,214,o),
+(723,420,cs),
+(723,605,o),
+(608,714,o),
+(404,714,cs),
+(162,714,l),
+(131,565,l),
+(376,565,ls),
+(495,565,o),
+(557,509,o),
+(557,407,cs),
+(557,276,o),
+(504,125,o),
+(334,125,cs),
+(242,125,o),
+(190,159,o),
+(190,218,cs),
+(190,254,o),
+(208,306,o),
+(256,306,cs),
+(286,306,o),
+(303,287,o),
+(303,253,cs),
+(303,234,o),
+(298,209,o),
+(291,191,c),
+(422,191,l),
+(433,219,o),
+(441,252,o),
+(441,281,cs),
+(441,375,o),
+(373,437,o),
+(265,437,cs),
+(124,437,o),
+(44,317,o),
+(44,199,cs),
+(44,68,o),
+(152,-15,o),
+(328,-15,cs)
+);
+}
+);
+width = 750;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1610;
+unicode = 5648;
+},
+{
+color = 9;
+glyphname = "yeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(591,-15,o),
+(723,211,o),
+(723,420,cs),
+(723,605,o),
+(606,714,o),
+(404,714,cs),
+(162,714,l),
+(131,565,l),
+(376,565,ls),
+(495,565,o),
+(556,509,o),
+(556,402,cs),
+(556,314,o),
+(527,125,o),
+(334,125,cs),
+(242,125,o),
+(190,158,o),
+(190,216,cs),
+(190,252,o),
+(208,306,o),
+(257,306,cs),
+(295,306,o),
+(311,276,o),
+(301,234,cs),
+(293,196,l),
+(388,196,l),
+(453,500,l),
+(358,500,l),
+(322,335,l),
+(337,334,l),
+(347,396,o),
+(307,437,o),
+(236,437,cs),
+(113,437,o),
+(46,317,o),
+(46,205,cs),
+(46,71,o),
+(152,-15,o),
+(331,-15,cs)
+);
+}
+);
+width = 750;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1611;
+unicode = 5649;
+},
+{
+color = 9;
+glyphname = "yiCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(589,-15,o),
+(723,206,o),
+(723,420,cs),
+(723,605,o),
+(607,714,o),
+(404,714,cs),
+(162,714,l),
+(131,565,l),
+(376,565,ls),
+(495,565,o),
+(556,509,o),
+(556,402,cs),
+(556,306,o),
+(522,125,o),
+(334,125,cs),
+(241,125,o),
+(189,159,o),
+(189,218,cs),
+(189,271,o),
+(220,319,o),
+(299,307,c),
+(256,356,l),
+(256,303,o),
+(299,261,o),
+(354,261,cs),
+(410,261,o),
+(452,303,o),
+(452,358,cs),
+(452,412,o),
+(410,453,o),
+(354,453,cs),
+(322,453,o),
+(295,440,o),
+(278,418,c),
+(135,412,o),
+(43,330,o),
+(43,198,cs),
+(43,72,o),
+(152,-15,o),
+(328,-15,cs)
+);
+}
+);
+width = 750;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1612;
+unicode = 5650;
+},
+{
+color = 9;
+glyphname = "yaCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(633,0,l),
+(664,149,l),
+(419,149,ls),
+(299,149,o),
+(238,205,o),
+(238,307,cs),
+(238,438,o),
+(291,589,o),
+(460,589,cs),
+(552,589,o),
+(604,555,o),
+(604,496,cs),
+(604,460,o),
+(586,408,o),
+(539,408,cs),
+(508,408,o),
+(492,427,o),
+(492,461,cs),
+(492,481,o),
+(497,505,o),
+(503,523,c),
+(372,523,l),
+(361,495,o),
+(354,462,o),
+(354,433,cs),
+(354,339,o),
+(422,277,o),
+(529,277,cs),
+(671,277,o),
+(750,397,o),
+(750,515,cs),
+(750,646,o),
+(643,729,o),
+(466,729,cs),
+(200,729,o),
+(71,500,o),
+(71,294,cs),
+(71,109,o),
+(187,0,o),
+(390,0,cs)
+);
+}
+);
+width = 751;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|yeCarrier-canadian";
+note = uni1613;
+unicode = 5651;
+},
+{
+color = 9;
+glyphname = "juCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(572,-15,o),
+(708,96,o),
+(708,260,cs),
+(708,364,o),
+(641,437,o),
+(532,437,cs),
+(411,437,o),
+(337,348,o),
+(322,241,cs),
+(319,225,o),
+(318,208,o),
+(319,191,c),
+(450,191,l),
+(450,200,o),
+(452,214,o),
+(455,229,cs),
+(463,272,o),
+(485,306,o),
+(521,306,cs),
+(548,306,o),
+(564,287,o),
+(564,254,cs),
+(564,182,o),
+(510,125,o),
+(412,125,cs),
+(299,125,o),
+(237,178,o),
+(237,273,cs),
+(237,461,o),
+(393,565,o),
+(607,565,cs),
+(766,565,l),
+(798,714,l),
+(153,714,l),
+(122,572,l),
+(390,572,l),
+(516,629,l),
+(272,623,o),
+(73,493,o),
+(73,266,cs),
+(73,104,o),
+(201,-15,o),
+(391,-15,cs)
+);
+}
+);
+width = 763;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni1614;
+unicode = 5652;
+},
+{
+color = 9;
+glyphname = "juSayisi-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (483,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(564,-15,o),
+(703,150,o),
+(714,344,cs),
+(725,520,o),
+(612,625,o),
+(392,631,c),
+(508,572,l),
+(776,572,l),
+(806,714,l),
+(160,714,l),
+(128,565,l),
+(300,565,ls),
+(482,565,o),
+(563,495,o),
+(552,357,cs),
+(546,266,o),
+(515,125,o),
+(336,125,cs),
+(238,125,o),
+(187,161,o),
+(191,226,cs),
+(193,265,o),
+(213,306,o),
+(254,306,cs),
+(287,306,o),
+(301,285,o),
+(299,245,cs),
+(299,227,o),
+(295,208,o),
+(288,191,c),
+(419,191,l),
+(430,217,o),
+(436,244,o),
+(437,270,cs),
+(443,370,o),
+(376,437,o),
+(264,437,cs),
+(139,437,o),
+(53,343,o),
+(46,219,cs),
+(37,79,o),
+(146,-15,o),
+(331,-15,cs)
+);
+}
+);
+width = 764;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1615;
+unicode = 5653;
+},
+{
+color = 9;
+glyphname = "joCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(654,0,l),
+(684,142,l),
+(416,142,l),
+(291,85,l),
+(534,91,o),
+(734,221,o),
+(734,448,cs),
+(734,610,o),
+(605,729,o),
+(416,729,cs),
+(234,729,o),
+(99,618,o),
+(99,454,cs),
+(99,350,o),
+(166,277,o),
+(275,277,cs),
+(396,277,o),
+(469,366,o),
+(485,473,cs),
+(487,489,o),
+(488,506,o),
+(488,523,c),
+(356,523,l),
+(356,514,o),
+(355,500,o),
+(352,485,cs),
+(343,442,o),
+(321,408,o),
+(286,408,cs),
+(258,408,o),
+(243,427,o),
+(243,460,cs),
+(243,532,o),
+(297,589,o),
+(394,589,cs),
+(508,589,o),
+(569,536,o),
+(569,441,cs),
+(569,253,o),
+(414,149,o),
+(200,149,cs),
+(40,149,l),
+(9,0,l)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1616;
+unicode = 5654;
+},
+{
+color = 9;
+glyphname = "jeCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(699,-15,o),
+(770,263,o),
+(770,430,cs),
+(770,611,o),
+(680,729,o),
+(524,729,cs),
+(398,729,o),
+(303,650,o),
+(254,507,c),
+(281,503,l),
+(327,714,l),
+(162,714,l),
+(10,0,l),
+(176,0,l),
+(237,284,ls),
+(277,473,o),
+(365,579,o),
+(484,579,cs),
+(569,579,o),
+(612,524,o),
+(612,419,cs),
+(612,347,o),
+(582,119,o),
+(492,119,cs),
+(460,119,o),
+(442,140,o),
+(442,174,cs),
+(442,225,o),
+(470,284,o),
+(531,284,cs),
+(538,284,o),
+(545,284,o),
+(550,283,c),
+(576,413,l),
+(555,416,o),
+(539,418,o),
+(523,418,cs),
+(368,418,o),
+(299,281,o),
+(299,162,cs),
+(299,53,o),
+(366,-15,o),
+(478,-15,cs)
+);
+}
+);
+width = 805;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "te-canadian";
+note = uni1617;
+unicode = 5655;
+},
+{
+color = 9;
+glyphname = "jeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(698,-15,o),
+(770,263,o),
+(770,428,cs),
+(770,611,o),
+(680,729,o),
+(524,729,cs),
+(397,729,o),
+(303,650,o),
+(254,505,c),
+(281,503,l),
+(327,714,l),
+(162,714,l),
+(10,0,l),
+(176,0,l),
+(236,278,ls),
+(278,473,o),
+(364,579,o),
+(483,579,cs),
+(569,579,o),
+(613,524,o),
+(613,419,cs),
+(613,318,o),
+(575,119,o),
+(466,119,cs),
+(418,119,o),
+(391,147,o),
+(391,195,cs),
+(391,239,o),
+(407,288,o),
+(448,308,c),
+(432,232,l),
+(515,232,l),
+(567,478,l),
+(484,478,l),
+(467,398,l),
+(347,370,o),
+(299,258,o),
+(299,160,cs),
+(299,55,o),
+(368,-15,o),
+(479,-15,cs)
+);
+}
+);
+width = 805;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1618;
+unicode = 5656;
+},
+{
+color = 9;
+glyphname = "jiCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(698,-15,o),
+(770,263,o),
+(770,428,cs),
+(770,611,o),
+(680,729,o),
+(524,729,cs),
+(397,729,o),
+(303,650,o),
+(254,505,c),
+(281,503,l),
+(327,714,l),
+(162,714,l),
+(10,0,l),
+(176,0,l),
+(236,278,ls),
+(278,473,o),
+(364,579,o),
+(483,579,cs),
+(569,579,o),
+(613,524,o),
+(613,419,cs),
+(613,318,o),
+(575,119,o),
+(466,119,cs),
+(418,119,o),
+(391,147,o),
+(391,195,cs),
+(391,222,o),
+(398,255,o),
+(417,275,c),
+(431,266,o),
+(448,259,o),
+(468,259,cs),
+(522,259,o),
+(561,303,o),
+(561,356,cs),
+(561,411,o),
+(521,451,o),
+(467,451,cs),
+(411,451,o),
+(370,404,o),
+(374,345,c),
+(320,299,o),
+(299,226,o),
+(299,160,cs),
+(299,55,o),
+(368,-15,o),
+(479,-15,cs)
+);
+}
+);
+width = 805;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1619;
+unicode = 5657;
+},
+{
+color = 9;
+glyphname = "jiSayisi-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(673,-15,o),
+(787,301,o),
+(787,497,cs),
+(787,643,o),
+(719,729,o),
+(595,729,cs),
+(437,729,o),
+(364,584,o),
+(364,463,cs),
+(364,363,o),
+(421,296,o),
+(512,296,cs),
+(529,296,o),
+(543,298,o),
+(552,301,c),
+(580,431,l),
+(573,430,o),
+(568,430,o),
+(563,430,cs),
+(526,430,o),
+(507,447,o),
+(507,482,cs),
+(507,516,o),
+(526,595,o),
+(580,595,cs),
+(615,595,o),
+(633,565,o),
+(633,508,cs),
+(633,415,o),
+(586,135,o),
+(404,135,cs),
+(244,135,o),
+(241,302,o),
+(272,447,cs),
+(328,714,l),
+(162,714,l),
+(10,0,l),
+(175,0,l),
+(226,245,l),
+(201,247,l),
+(182,104,o),
+(257,-15,o),
+(412,-15,cs)
+);
+}
+);
+width = 806;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161A;
+unicode = 5658;
+},
+{
+color = 9;
+glyphname = "jaCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (493,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(451,-14,o),
+(546,64,o),
+(595,208,c),
+(567,212,l),
+(522,1,l),
+(687,1,l),
+(839,715,l),
+(673,715,l),
+(612,431,ls),
+(572,242,o),
+(484,136,o),
+(365,136,cs),
+(280,136,o),
+(237,190,o),
+(237,295,cs),
+(237,368,o),
+(267,596,o),
+(357,596,cs),
+(389,596,o),
+(407,575,o),
+(407,540,cs),
+(407,489,o),
+(379,431,o),
+(318,431,cs),
+(311,431,o),
+(304,431,o),
+(299,432,c),
+(273,302,l),
+(294,299,o),
+(310,297,o),
+(326,297,cs),
+(481,297,o),
+(550,434,o),
+(550,553,cs),
+(550,662,o),
+(483,729,o),
+(371,729,cs),
+(150,729,o),
+(79,452,o),
+(79,285,cs),
+(79,103,o),
+(169,-14,o),
+(325,-14,cs)
+);
+}
+);
+width = 805;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni161B;
+unicode = 5659;
+},
+{
+color = 9;
+glyphname = "jjuCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(572,-15,o),
+(700,98,o),
+(700,262,cs),
+(700,366,o),
+(632,437,o),
+(524,437,cs),
+(417,437,o),
+(339,368,o),
+(315,257,cs),
+(310,235,o),
+(307,213,o),
+(307,191,c),
+(439,191,l),
+(440,200,o),
+(442,218,o),
+(446,235,cs),
+(457,279,o),
+(479,306,o),
+(512,306,cs),
+(540,306,o),
+(555,287,o),
+(555,255,cs),
+(555,183,o),
+(503,124,o),
+(403,124,cs),
+(293,124,o),
+(234,182,o),
+(234,280,cs),
+(234,470,o),
+(366,565,o),
+(577,565,cs),
+(756,565,l),
+(787,714,l),
+(596,714,ls),
+(476,714,o),
+(369,689,o),
+(284,641,c),
+(216,729,l),
+(82,624,l),
+(153,532,l),
+(99,465,o),
+(72,377,o),
+(72,283,cs),
+(72,110,o),
+(195,-15,o),
+(389,-15,cs)
+);
+}
+);
+width = 755;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni161C;
+unicode = 5660;
+},
+{
+color = 9;
+glyphname = "jjoCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(718,90,l),
+(646,182,l),
+(700,249,o),
+(727,337,o),
+(727,431,cs),
+(727,604,o),
+(604,729,o),
+(411,729,cs),
+(228,729,o),
+(99,616,o),
+(99,452,cs),
+(99,348,o),
+(167,277,o),
+(275,277,cs),
+(383,277,o),
+(461,346,o),
+(485,457,cs),
+(490,479,o),
+(492,501,o),
+(493,523,c),
+(361,523,l),
+(360,514,o),
+(357,496,o),
+(353,479,cs),
+(343,435,o),
+(321,408,o),
+(288,408,cs),
+(260,408,o),
+(244,427,o),
+(244,459,cs),
+(244,531,o),
+(297,590,o),
+(397,590,cs),
+(507,590,o),
+(565,532,o),
+(565,434,cs),
+(565,244,o),
+(433,149,o),
+(222,149,cs),
+(44,149,l),
+(12,0,l),
+(204,0,ls),
+(323,0,o),
+(430,25,o),
+(516,73,c),
+(584,-15,l)
+);
+}
+);
+width = 756;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|jjuCarrier-canadian";
+note = uni161D;
+unicode = 5661;
+},
+{
+color = 9;
+glyphname = "jjeCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(713,-15,o),
+(784,266,o),
+(784,429,cs),
+(784,617,o),
+(685,729,o),
+(502,729,cs),
+(419,729,o),
+(344,703,o),
+(281,655,c),
+(219,729,l),
+(89,619,l),
+(167,525,l),
+(135,471,o),
+(110,407,o),
+(95,332,cs),
+(24,0,l),
+(190,0,l),
+(256,310,ls),
+(294,485,o),
+(376,579,o),
+(492,579,cs),
+(582,579,o),
+(626,525,o),
+(626,419,cs),
+(626,348,o),
+(596,119,o),
+(505,119,cs),
+(474,119,o),
+(456,140,o),
+(456,175,cs),
+(456,226,o),
+(484,284,o),
+(542,284,cs),
+(550,284,o),
+(557,284,o),
+(564,283,c),
+(590,413,l),
+(576,416,o),
+(554,418,o),
+(537,418,cs),
+(382,418,o),
+(313,281,o),
+(313,162,cs),
+(313,54,o),
+(379,-15,o),
+(492,-15,cs)
+);
+}
+);
+width = 819;
+}
+);
+metricRight = "jeCarrier-canadian";
+note = uni161E;
+unicode = 5662;
+},
+{
+color = 9;
+glyphname = "jjeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(713,-15,o),
+(784,266,o),
+(784,429,cs),
+(784,617,o),
+(685,729,o),
+(502,729,cs),
+(419,729,o),
+(344,703,o),
+(281,655,c),
+(219,729,l),
+(89,619,l),
+(167,525,l),
+(135,471,o),
+(110,407,o),
+(95,332,cs),
+(24,0,l),
+(190,0,l),
+(256,310,ls),
+(294,485,o),
+(376,579,o),
+(492,579,cs),
+(582,579,o),
+(626,525,o),
+(626,419,cs),
+(626,341,o),
+(598,119,o),
+(482,119,cs),
+(435,119,o),
+(404,146,o),
+(404,196,cs),
+(404,246,o),
+(422,291,o),
+(461,309,c),
+(445,232,l),
+(528,232,l),
+(580,476,l),
+(497,476,l),
+(480,397,l),
+(365,372,o),
+(313,265,o),
+(313,162,cs),
+(313,54,o),
+(379,-15,o),
+(492,-15,cs)
+);
+}
+);
+width = 819;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161F;
+unicode = 5663;
+},
+{
+color = 9;
+glyphname = "jjiCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(640,-15,o),
+(732,114,o),
+(770,299,cs),
+(821,560,o),
+(721,729,o),
+(499,729,cs),
+(415,729,o),
+(341,704,o),
+(279,657,c),
+(219,729,l),
+(89,619,l),
+(167,527,l),
+(134,472,o),
+(110,407,o),
+(94,332,cs),
+(23,0,l),
+(189,0,l),
+(256,310,ls),
+(293,485,o),
+(375,579,o),
+(492,579,cs),
+(606,579,o),
+(648,489,o),
+(614,313,cs),
+(590,197,o),
+(554,119,o),
+(479,119,cs),
+(422,119,o),
+(395,159,o),
+(408,226,cs),
+(411,248,o),
+(418,269,o),
+(434,280,c),
+(449,267,o),
+(469,259,o),
+(492,259,cs),
+(547,259,o),
+(585,304,o),
+(585,356,cs),
+(585,410,o),
+(544.998,451.004,o),
+(491,451,cs),
+(433,451,o),
+(398,402,o),
+(398,354,c),
+(355,323,o),
+(329,273,o),
+(318,214,cs),
+(291,78,o),
+(364,-15,o),
+(492,-15,cs)
+);
+}
+);
+width = 818;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1620;
+unicode = 5664;
+},
+{
+color = 9;
+glyphname = "jjaCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(442,-15,o),
+(518,11,o),
+(581,59,c),
+(642,-15,l),
+(772,95,l),
+(694,189,l),
+(726,243,o),
+(751,307,o),
+(767,382,cs),
+(838,714,l),
+(672,714,l),
+(605,404,ls),
+(568,229,o),
+(485,135,o),
+(369,135,cs),
+(280,135,o),
+(236,189,o),
+(236,295,cs),
+(236,366,o),
+(266,595,o),
+(356,595,cs),
+(388,595,o),
+(406,574,o),
+(406,539,cs),
+(406,488,o),
+(378,430,o),
+(320,430,cs),
+(311,430,o),
+(305,430,o),
+(298,431,c),
+(272,301,l),
+(286,298,o),
+(308,296,o),
+(324,296,cs),
+(480,296,o),
+(549,433,o),
+(549,552,cs),
+(549,660,o),
+(482,729,o),
+(369,729,cs),
+(149,729,o),
+(78,448,o),
+(78,285,cs),
+(78,97,o),
+(177,-15,o),
+(360,-15,cs)
+);
+}
+);
+width = 818;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "=|jjeCarrier-canadian";
+note = uni1621;
+unicode = 5665;
+},
+{
+color = 9;
+glyphname = "luCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(544,-15,o),
+(663,88,o),
+(704,279,cs),
+(796,714,l),
+(630,714,l),
+(542,301,ls),
+(519,192,o),
+(460,135,o),
+(371,135,cs),
+(286,135,o),
+(237,185,o),
+(237,273,cs),
+(237,403,o),
+(319,562,o),
+(472,581,c),
+(501,714,l),
+(152,714,l),
+(122,577,l),
+(310,577,l),
+(448,628,l),
+(217,621,o),
+(71,462,o),
+(71,257,cs),
+(71,95,o),
+(185,-15,o),
+(366,-15,cs)
+);
+}
+);
+width = 756;
+}
+);
+metricRight = "te-canadian";
+note = uni1622;
+unicode = 5666;
+},
+{
+color = 9;
+glyphname = "loCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(169,0,l),
+(256,413,ls),
+(279,522,o),
+(338,579,o),
+(428,579,cs),
+(513,579,o),
+(561,529,o),
+(561,441,cs),
+(561,311,o),
+(479,152,o),
+(326,133,c),
+(297,0,l),
+(647,0,l),
+(676,137,l),
+(488,137,l),
+(351,86,l),
+(581,93,o),
+(728,252,o),
+(728,457,cs),
+(728,619,o),
+(613,729,o),
+(433,729,cs),
+(255,729,o),
+(136,626,o),
+(95,435,cs),
+(3,0,l)
+);
+}
+);
+width = 754;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|luCarrier-canadian";
+note = uni1623;
+unicode = 5667;
+},
+{
+color = 9;
+glyphname = "leCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (388,363);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(289,0,ls),
+(638,0,o),
+(722,257,o),
+(722,439,cs),
+(722,609,o),
+(629,729,o),
+(483,729,cs),
+(386,729,o),
+(305,676,o),
+(267,588,c),
+(280,587,l),
+(307,714,l),
+(158,714,l),
+(89,387,l),
+(229,387,l),
+(264,511,o),
+(333,579,o),
+(424,579,cs),
+(508,579,o),
+(557,518,o),
+(557,422,cs),
+(557,287,o),
+(484,149,o),
+(300,149,cs),
+(38,149,l),
+(6,0,l)
+);
+}
+);
+width = 747;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1624;
+unicode = 5668;
+},
+{
+color = 9;
+glyphname = "leeCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "leCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (300,6);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 747;
+}
+);
+metricLeft = "leCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1625;
+unicode = 5669;
+},
+{
+color = 9;
+glyphname = "liCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "leCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (269,6);
+ref = dot_middle;
+}
+);
+width = 748;
+}
+);
+note = uni1626;
+unicode = 5670;
+},
+{
+color = 9;
+glyphname = "laCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(633,0,l),
+(665,149,l),
+(423,149,ls),
+(295,149,o),
+(237,204,o),
+(237,305,cs),
+(237,407,o),
+(288,579,o),
+(441,579,cs),
+(539,579,o),
+(590,506,o),
+(575,387,c),
+(716,387,l),
+(785,714,l),
+(636,714,l),
+(604,565,l),
+(616,562,l),
+(606,664,o),
+(533,729,o),
+(426,729,cs),
+(184,729,o),
+(70,476,o),
+(70,291,cs),
+(70,109,o),
+(185,0,o),
+(398,0,cs)
+);
+}
+);
+width = 748;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|leCarrier-canadian";
+note = uni1627;
+unicode = 5671;
+},
+{
+color = 1;
+glyphname = "dluCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(620,-15,o),
+(710,218,o),
+(710,380,cs),
+(710,521,o),
+(628,609,o),
+(477,638,c),
+(543,589,l),
+(748,589,l),
+(731,510,l),
+(851,510,l),
+(912,793,l),
+(791,793,l),
+(774,714,l),
+(450,714,l),
+(422,581,l),
+(506,566,o),
+(553,505,o),
+(553,409,cs),
+(553,312,o),
+(508,135,o),
+(358,135,cs),
+(258,135,o),
+(214,205,o),
+(239,324,cs),
+(321,714,l),
+(155,714,l),
+(73,328,ls),
+(29,119,o),
+(138,-15,o),
+(348,-15,cs)
+);
+}
+);
+width = 830;
+}
+);
+metricLeft = "te-canadian";
+note = uni1628;
+unicode = 5672;
+},
+{
+color = 9;
+glyphname = "dloCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(725,-79,l),
+(786,204,l),
+(665,204,l),
+(648,125,l),
+(482,125,l),
+(469,108,l),
+(618,143,o),
+(728,272,o),
+(728,457,cs),
+(728,619,o),
+(613,729,o),
+(433,729,cs),
+(255,729,o),
+(136,626,o),
+(95,435,cs),
+(3,0,l),
+(169,0,l),
+(256,413,ls),
+(279,522,o),
+(338,579,o),
+(428,579,cs),
+(513,579,o),
+(561,529,o),
+(561,441,cs),
+(561,311,o),
+(479,152,o),
+(326,133,c),
+(297,0,l),
+(622,0,l),
+(605,-79,l)
+);
+}
+);
+width = 829;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "dluCarrier-canadian";
+note = uni1629;
+unicode = 5673;
+},
+{
+color = 9;
+glyphname = "dleCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (404,363);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(304,0,ls),
+(653,0,o),
+(737,257,o),
+(737,439,cs),
+(737,609,o),
+(644,729,o),
+(498,729,cs),
+(394,729,o),
+(280,656,o),
+(234,538,c),
+(247,539,l),
+(285,718,l),
+(372,718,l),
+(396,834,l),
+(121,834,l),
+(97,718,l),
+(174,718,l),
+(104,387,l),
+(244,387,l),
+(279,511,o),
+(348,579,o),
+(439,579,cs),
+(523,579,o),
+(572,518,o),
+(572,422,cs),
+(572,287,o),
+(499,149,o),
+(315,149,cs),
+(53,149,l),
+(21,0,l)
+);
+}
+);
+width = 762;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni162A;
+unicode = 5674;
+},
+{
+color = 9;
+glyphname = "dleeCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (315,6);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 763;
+}
+);
+note = uni162B;
+unicode = 5675;
+},
+{
+color = 9;
+glyphname = "dliCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (285,6);
+ref = dot_middle;
+}
+);
+width = 763;
+}
+);
+note = uni162C;
+unicode = 5676;
+},
+{
+color = 9;
+glyphname = "dlaCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(633,0,l),
+(665,149,l),
+(423,149,ls),
+(295,149,o),
+(237,204,o),
+(237,305,cs),
+(237,407,o),
+(288,579,o),
+(441,579,cs),
+(539,579,o),
+(590,506,o),
+(575,387,c),
+(716,387,l),
+(786,718,l),
+(863,718,l),
+(888,834,l),
+(612,834,l),
+(588,718,l),
+(666,718,l),
+(632,560,l),
+(643,557,l),
+(633,664,o),
+(533,729,o),
+(426,729,cs),
+(184,729,o),
+(70,476,o),
+(70,291,cs),
+(70,109,o),
+(185,0,o),
+(398,0,cs)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni162D;
+unicode = 5677;
+},
+{
+color = 9;
+glyphname = "lhuCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(609,-15,o),
+(730,175,o),
+(730,371,cs),
+(730,507,o),
+(659,607,o),
+(540,629,c),
+(600,574,l),
+(788,574,l),
+(817,714,l),
+(540,714,l),
+(512,581,l),
+(551,551,o),
+(572,492,o),
+(572,422,cs),
+(572,313,o),
+(523,135,o),
+(382,135,cs),
+(294,135,o),
+(244,189,o),
+(244,283,cs),
+(244,375,o),
+(291,528,o),
+(399,581,c),
+(428,714,l),
+(151,714,l),
+(121,574,l),
+(310,574,l),
+(394,632,l),
+(193,606,o),
+(77,441,o),
+(77,262,cs),
+(77,96,o),
+(194,-15,o),
+(380,-15,cs)
+);
+}
+);
+width = 773;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162E;
+unicode = 5678;
+},
+{
+color = 9;
+glyphname = "lhoCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(277,0,l),
+(305,133,l),
+(266,163,o),
+(245,222,o),
+(245,292,cs),
+(245,401,o),
+(294,579,o),
+(435,579,cs),
+(523,579,o),
+(573,525,o),
+(573,431,cs),
+(573,339,o),
+(526,186,o),
+(418,133,c),
+(389,0,l),
+(666,0,l),
+(696,140,l),
+(507,140,l),
+(423,82,l),
+(624,108,o),
+(739,273,o),
+(739,452,cs),
+(739,618,o),
+(623,729,o),
+(437,729,cs),
+(208,729,o),
+(87,539,o),
+(87,343,cs),
+(87,207,o),
+(158,107,o),
+(277,85,c),
+(217,140,l),
+(29,140,l),
+(0,0,l)
+);
+}
+);
+width = 773;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162F;
+unicode = 5679;
+},
+{
+color = 9;
+glyphname = "lheCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (401,357);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(636,-15,o),
+(745,244,o),
+(745,435,cs),
+(745,611,o),
+(649,729,o),
+(496,729,cs),
+(400,729,o),
+(319,681,o),
+(279,599,c),
+(287,598,l),
+(311,714,l),
+(162,714,l),
+(100,422,l),
+(240,422,l),
+(283,527,o),
+(351,579,o),
+(436,579,cs),
+(528,579,o),
+(580,520,o),
+(580,419,cs),
+(580,305,o),
+(515,135,o),
+(372,135,cs),
+(278,135,o),
+(218,196,o),
+(213,292,c),
+(73,292,l),
+(11,0,l),
+(159,0,l),
+(191,149,l),
+(172,146,l),
+(190,49,o),
+(278,-15,o),
+(398,-15,cs)
+);
+}
+);
+width = 770;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1630;
+unicode = 5680;
+},
+{
+color = 9;
+glyphname = "lheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (313,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 771;
+}
+);
+note = uni1631;
+unicode = 5681;
+},
+{
+color = 9;
+glyphname = "lhiCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (283,0);
+ref = dot_middle;
+}
+);
+width = 771;
+}
+);
+note = uni1632;
+unicode = 5682;
+},
+{
+color = 9;
+glyphname = "lhaCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(413,-15,o),
+(494,33,o),
+(534,115,c),
+(526,116,l),
+(501,0,l),
+(650,0,l),
+(713,292,l),
+(572,292,l),
+(530,187,o),
+(461,135,o),
+(377,135,cs),
+(285,135,o),
+(233,194,o),
+(233,295,cs),
+(233,409,o),
+(298,579,o),
+(441,579,cs),
+(535,579,o),
+(595,518,o),
+(599,422,c),
+(740,422,l),
+(802,714,l),
+(653,714,l),
+(622,565,l),
+(641,568,l),
+(623,665,o),
+(535,729,o),
+(418,729,cs),
+(177,729,o),
+(68,470,o),
+(68,279,cs),
+(68,103,o),
+(164,-15,o),
+(317,-15,cs)
+);
+}
+);
+width = 769;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1633;
+unicode = 5683;
+},
+{
+color = 9;
+glyphname = "tlhuCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(609,-15,o),
+(730,175,o),
+(730,371,cs),
+(730,497,o),
+(684,601,o),
+(565,629,c),
+(567,589,l),
+(766,589,l),
+(748,510,l),
+(869,510,l),
+(929,793,l),
+(809,793,l),
+(791,714,l),
+(540,714,l),
+(512,581,l),
+(551,551,o),
+(572,492,o),
+(572,422,cs),
+(572,313,o),
+(523,135,o),
+(382,135,cs),
+(294,135,o),
+(244,189,o),
+(244,283,cs),
+(244,375,o),
+(291,528,o),
+(399,581,c),
+(428,714,l),
+(151,714,l),
+(121,574,l),
+(312,574,l),
+(368,623,l),
+(153,584,o),
+(77,403,o),
+(77,262,cs),
+(77,96,o),
+(194,-15,o),
+(380,-15,cs)
+);
+}
+);
+width = 843;
+}
+);
+metricLeft = "lhuCarrier-canadian";
+note = uni1634;
+unicode = 5684;
+},
+{
+color = 9;
+glyphname = "tlhoCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(78,-79,l),
+(95,0,l),
+(346,0,l),
+(374,133,l),
+(335,163,o),
+(314,222,o),
+(314,292,cs),
+(314,401,o),
+(363,579,o),
+(504,579,cs),
+(592,579,o),
+(642,525,o),
+(642,431,cs),
+(642,339,o),
+(595,186,o),
+(487,133,c),
+(458,0,l),
+(735,0,l),
+(765,140,l),
+(574,140,l),
+(517,91,l),
+(733,130,o),
+(808,311,o),
+(808,452,cs),
+(808,618,o),
+(691,729,o),
+(506,729,cs),
+(277,729,o),
+(156,539,o),
+(156,343,cs),
+(156,217,o),
+(202,113,o),
+(321,85,c),
+(319,125,l),
+(121,125,l),
+(138,204,l),
+(18,204,l),
+(-43,-79,l)
+);
+}
+);
+width = 842;
+}
+);
+metricLeft = "=|tlhuCarrier-canadian";
+metricRight = "lhuCarrier-canadian";
+note = uni1635;
+unicode = 5685;
+},
+{
+color = 9;
+glyphname = "tlheCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (413,357);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(647,-15,o),
+(757,244,o),
+(757,435,cs),
+(757,611,o),
+(660,729,o),
+(507,729,cs),
+(385,729,o),
+(286,653,o),
+(235,533,c),
+(265,564,l),
+(297,718,l),
+(374,718,l),
+(399,834,l),
+(122,834,l),
+(97,718,l),
+(175,718,l),
+(112,422,l),
+(252,422,l),
+(294,527,o),
+(363,579,o),
+(447,579,cs),
+(539,579,o),
+(592,520,o),
+(592,419,cs),
+(592,305,o),
+(527,135,o),
+(383,135,cs),
+(289,135,o),
+(229,196,o),
+(225,292,c),
+(84,292,l),
+(22,0,l),
+(171,0,l),
+(202,149,l),
+(183,146,l),
+(201,49,o),
+(290,-15,o),
+(409,-15,cs)
+);
+}
+);
+width = 782;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1636;
+unicode = 5686;
+},
+{
+color = 9;
+glyphname = "tlheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (323,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 782;
+}
+);
+note = uni1637;
+unicode = 5687;
+},
+{
+color = 9;
+glyphname = "tlhiCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (293,0);
+ref = dot_middle;
+}
+);
+width = 782;
+}
+);
+note = uni1638;
+unicode = 5688;
+},
+{
+color = 9;
+glyphname = "tlhaCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(413,-15,o),
+(495,33,o),
+(534,115,c),
+(526,116,l),
+(502,0,l),
+(651,0,l),
+(713,292,l),
+(573,292,l),
+(531,187,o),
+(462,135,o),
+(377,135,cs),
+(285,135,o),
+(233,194,o),
+(233,295,cs),
+(233,409,o),
+(298,579,o),
+(441,579,cs),
+(536,579,o),
+(595,518,o),
+(600,422,c),
+(741,422,l),
+(804,718,l),
+(881,718,l),
+(906,834,l),
+(629,834,l),
+(604,718,l),
+(681,718,l),
+(647,559,l),
+(655,558,l),
+(630,669,o),
+(538,729,o),
+(418,729,cs),
+(177,729,o),
+(68,470,o),
+(68,279,cs),
+(68,103,o),
+(164,-15,o),
+(317,-15,cs)
+);
+}
+);
+width = 781;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni1639;
+unicode = 5689;
+},
+{
+color = 9;
+glyphname = "tluCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(342,-15,o),
+(409,27,o),
+(454,107,c),
+(401,109,l),
+(424,28,o),
+(486,-15,o),
+(579,-15,cs),
+(794,-15,o),
+(854,232,o),
+(854,377,cs),
+(854,495,o),
+(807,576,o),
+(722,613,c),
+(687,589,l),
+(895,589,l),
+(878,510,l),
+(998,510,l),
+(1058,793,l),
+(938,793,l),
+(921,714,l),
+(606,714,l),
+(577,581,l),
+(658,568,o),
+(698,516,o),
+(698,418,cs),
+(698,341,o),
+(667,131,o),
+(575,131,cs),
+(531,131,o),
+(513,163,o),
+(525,220,cs),
+(546,321,l),
+(386,321,l),
+(365,221,ls),
+(353,160,o),
+(328,131,o),
+(287,131,cs),
+(248,131,o),
+(228,157,o),
+(228,211,cs),
+(228,319,o),
+(295,576,o),
+(464,581,c),
+(493,714,l),
+(152,714,l),
+(122,574,l),
+(320,574,l),
+(291,600,l),
+(133,530,o),
+(63,352,o),
+(63,201,cs),
+(63,67,o),
+(135,-15,o),
+(257,-15,cs)
+);
+}
+);
+width = 972;
+}
+);
+metricRight = "tlhuCarrier-canadian";
+note = uni163A;
+unicode = 5690;
+},
+{
+color = 1;
+glyphname = "tloCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(873,-79,l),
+(933,204,l),
+(813,204,l),
+(796,125,l),
+(607,125,l),
+(635,102,l),
+(804,166,o),
+(884,351,o),
+(884,513,cs),
+(884,647,o),
+(812,729,o),
+(691,729,cs),
+(605,729,o),
+(538,687,o),
+(494,607,c),
+(547,605,l),
+(523,686,o),
+(462,729,o),
+(368,729,cs),
+(153,729,o),
+(93,482,o),
+(93,337,cs),
+(93,230,o),
+(133,152,o),
+(203,112,c),
+(243,140,l),
+(30,140,l),
+(1,0,l),
+(342,0,l),
+(370,133,l),
+(289,146,o),
+(249,198,o),
+(249,296,cs),
+(249,373,o),
+(280,583,o),
+(372,583,cs),
+(416,583,o),
+(434,551,o),
+(422,494,cs),
+(401,393,l),
+(561,393,l),
+(582,493,ls),
+(594,554,o),
+(620,583,o),
+(660,583,cs),
+(699,583,o),
+(719,557,o),
+(719,503,cs),
+(719,395,o),
+(652,138,o),
+(483,133,c),
+(454,0,l),
+(770,0,l),
+(753,-79,l)
+);
+}
+);
+width = 972;
+}
+);
+metricLeft = "tluCarrier-canadian";
+metricRight = "tlhuCarrier-canadian";
+note = uni163B;
+unicode = 5691;
+},
+{
+color = 9;
+glyphname = "tleCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (346,357);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(575,-15,o),
+(701,78,o),
+(701,229,cs),
+(701,304,o),
+(663,363,o),
+(599,378,c),
+(590,338,l),
+(696,355,o),
+(769,443,o),
+(769,545,cs),
+(769,652,o),
+(679,729,o),
+(541,729,cs),
+(422,729,o),
+(319,674,o),
+(257,576,c),
+(264,574,l),
+(294,718,l),
+(373,718,l),
+(397,834,l),
+(122,834,l),
+(97,718,l),
+(174,718,l),
+(111,422,l),
+(250,422,l),
+(287,527,o),
+(365,581,o),
+(479,581,cs),
+(556,581,o),
+(599,554,o),
+(599,508,cs),
+(599,451,o),
+(553,425,o),
+(492,425,cs),
+(451,425,l),
+(422,290,l),
+(463,290,ls),
+(513,290,o),
+(541,271,o),
+(541,234,cs),
+(541,165,o),
+(479,133,o),
+(400,133,cs),
+(281,133,o),
+(217,189,o),
+(223,292,c),
+(84,292,l),
+(22,0,l),
+(171,0,l),
+(200,139,l),
+(181,137,l),
+(198,43,o),
+(290,-15,o),
+(417,-15,cs)
+);
+}
+);
+width = 773;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni163C;
+unicode = 5692;
+},
+{
+color = 9;
+glyphname = "tleeCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (257,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 772;
+}
+);
+note = uni163D;
+unicode = 5693;
+},
+{
+color = 9;
+glyphname = "tliCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (245,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 772;
+}
+);
+note = uni163E;
+unicode = 5694;
+},
+{
+color = 9;
+glyphname = "tlaCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(387,-15,o),
+(483,32,o),
+(546,115,c),
+(528,152,l),
+(495,0,l),
+(645,0,l),
+(707,292,l),
+(568,292,l),
+(531,187,o),
+(453,133,o),
+(339,133,cs),
+(261,133,o),
+(219,160,o),
+(219,206,cs),
+(219,263,o),
+(264,289,o),
+(325,289,cs),
+(367,289,l),
+(396,424,l),
+(355,424,ls),
+(305,424,o),
+(277,443,o),
+(277,480,cs),
+(277,549,o),
+(338,581,o),
+(418,581,cs),
+(537,581,o),
+(601,525,o),
+(596,422,c),
+(735,422,l),
+(797,718,l),
+(874,718,l),
+(899,834,l),
+(623,834,l),
+(598,718,l),
+(677,718,l),
+(632,505,l),
+(657,529,l),
+(647,653,o),
+(547,729,o),
+(400,729,cs),
+(242,729,o),
+(116,636,o),
+(116,485,cs),
+(116,412,o),
+(154,353,o),
+(215,337,c),
+(224,375,l),
+(120,356,o),
+(48,270,o),
+(48,169,cs),
+(48,62,o),
+(139,-15,o),
+(277,-15,cs)
+);
+}
+);
+width = 774;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni163F;
+unicode = 5695;
+},
+{
+color = 9;
+glyphname = "zuCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(574,-14,o),
+(714,99,o),
+(714,300,cs),
+(714,371,o),
+(695,440,o),
+(695,499,cs),
+(695,543,o),
+(713,572,o),
+(762,572,cs),
+(790,572,l),
+(820,714,l),
+(761,714,ls),
+(614,714,o),
+(538,646,o),
+(538,505,cs),
+(538,441,o),
+(555,378,o),
+(555,308,cs),
+(555,200,o),
+(490,135,o),
+(380,135,cs),
+(289,135,o),
+(235,178,o),
+(235,246,cs),
+(235,354,o),
+(360,451,o),
+(360,577,cs),
+(360,660,o),
+(301,714,o),
+(205,714,cs),
+(151,714,l),
+(121,572,l),
+(157,572,ls),
+(187,572,o),
+(198,561,o),
+(198,540,cs),
+(198,479,o),
+(70,377,o),
+(70,219,cs),
+(70,81,o),
+(186,-14,o),
+(367,-14,cs)
+);
+}
+);
+width = 776;
+}
+);
+metricRight = "=|";
+note = uni1640;
+unicode = 5696;
+},
+{
+color = 9;
+glyphname = "zoCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(58,0,ls),
+(205,0,o),
+(281,68,o),
+(281,209,cs),
+(281,273,o),
+(264,336,o),
+(264,406,cs),
+(264,514,o),
+(329,579,o),
+(439,579,cs),
+(530,579,o),
+(584,536,o),
+(584,468,cs),
+(584,360,o),
+(459,263,o),
+(459,137,cs),
+(459,54,o),
+(518,0,o),
+(614,0,cs),
+(668,0,l),
+(698,142,l),
+(662,142,ls),
+(632,142,o),
+(621,153,o),
+(622,174,cs),
+(621,235,o),
+(749,337,o),
+(749,495,cs),
+(749,633,o),
+(633,728,o),
+(452,728,cs),
+(245.004,727.998,o),
+(105,615,o),
+(105,414,cs),
+(105,343,o),
+(124,274,o),
+(124,215,cs),
+(124,171,o),
+(106,142,o),
+(57,142,cs),
+(29,142,l),
+(-1,0,l)
+);
+}
+);
+width = 775;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1641;
+unicode = 5697;
+},
+{
+color = 9;
+glyphname = "zeCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (393,357);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(632,-15,o),
+(729,316,o),
+(729,499,cs),
+(729,645,o),
+(665,729,o),
+(548,729,cs),
+(428,729,o),
+(339,638,o),
+(297,638,cs),
+(278,638,o),
+(271,654,o),
+(279,690,cs),
+(285,714,l),
+(136,714,l),
+(123,653,ls),
+(101,552,o),
+(140,491,o),
+(229,491,cs),
+(339,491,o),
+(421,579,o),
+(491,579,cs),
+(537,579,o),
+(561,542,o),
+(561,471,cs),
+(561,372,o),
+(511,135,o),
+(388,135,cs),
+(312,135,o),
+(268,223,o),
+(167,223,cs),
+(82,223,o),
+(19,165,o),
+(-3,61,cs),
+(-16,0,l),
+(133,0,l),
+(138,24,ls),
+(146,60,o),
+(159,76,o),
+(180,76,cs),
+(226,76,o),
+(286,-15,o),
+(403,-15,cs)
+);
+}
+);
+width = 743;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1642;
+unicode = 5698;
+},
+{
+color = 9;
+glyphname = "zeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (305,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 744;
+}
+);
+note = uni1643;
+unicode = 5699;
+},
+{
+color = 9;
+glyphname = "ziCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (274,0);
+ref = dot_middle;
+}
+);
+width = 744;
+}
+);
+note = uni1644;
+unicode = 5700;
+},
+{
+color = 9;
+glyphname = "zaCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(358,-15,o),
+(447,76,o),
+(489,76,cs),
+(508,76,o),
+(515,60,o),
+(507,24,cs),
+(501,0,l),
+(650,0,l),
+(663,61,ls),
+(685,162,o),
+(646,223,o),
+(557,223,cs),
+(447,223,o),
+(365,135,o),
+(295,135,cs),
+(249,135,o),
+(226,172,o),
+(226,243,cs),
+(226,342,o),
+(275,579,o),
+(398,579,cs),
+(474,579,o),
+(518,491,o),
+(619,491,cs),
+(704,491,o),
+(767,549,o),
+(789,653,cs),
+(802,714,l),
+(653,714,l),
+(648,690,ls),
+(640,654,o),
+(627,638,o),
+(606,638,cs),
+(560,638,o),
+(500,729,o),
+(383,729,cs),
+(154,729,o),
+(57,398,o),
+(57,215,cs),
+(57,69,o),
+(121,-15,o),
+(238,-15,cs)
+);
+}
+);
+width = 742;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|zeCarrier-canadian";
+note = uni1645;
+unicode = 5701;
+},
+{
+color = 6;
+glyphname = "zCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(359,189,l),
+(380,288,l),
+(183,288,l),
+(178,231,l),
+(419,489,l),
+(432,546,l),
+(118,546,l),
+(96,447,l),
+(290,447,l),
+(295,504,l),
+(54,246,l),
+(42,189,l)
+);
+}
+);
+width = 428;
+}
+);
+metricRight = "=|";
+note = uni1646;
+unicode = 5702;
+},
+{
+color = 6;
+glyphname = "initialzCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(234,99,l),
+(253,189,l),
+(359,189,l),
+(380,288,l),
+(157,288,l),
+(181,233,l),
+(419,489,l),
+(432,546,l),
+(329,546,l),
+(348,636,l),
+(240,636,l),
+(221,546,l),
+(118,546,l),
+(96,447,l),
+(317,447,l),
+(292,502,l),
+(54,246,l),
+(42,189,l),
+(145,189,l),
+(126,99,l)
+);
+}
+);
+width = 428;
+}
+);
+metricLeft = "zCarrier-canadian";
+metricRight = "zCarrier-canadian";
+note = uni1647;
+unicode = 5703;
+},
+{
+color = 9;
+glyphname = "dzuCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(574,-14,o),
+(714,99,o),
+(714,300,cs),
+(714,371,o),
+(695,440,o),
+(695,499,cs),
+(695,543,o),
+(713,572,o),
+(762,572,cs),
+(790,572,l),
+(820,714,l),
+(761,714,ls),
+(622,714,o),
+(546,646,o),
+(541,505,cs),
+(540,441,o),
+(557,372,o),
+(556,308,cs),
+(555,200,o),
+(490,135,o),
+(380,135,cs),
+(289,135,o),
+(235,178,o),
+(235,246,cs),
+(235,354,o),
+(356,451,o),
+(356,577,cs),
+(356,660,o),
+(300,714,o),
+(205,714,cs),
+(151,714,l),
+(121,572,l),
+(157,572,ls),
+(187,572,o),
+(198,561,o),
+(198,540,cs),
+(198,479,o),
+(70,377,o),
+(70,219,cs),
+(70,81,o),
+(186,-14,o),
+(367,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(471,482,l),
+(504,642,l),
+(553,642,l),
+(569,714,l),
+(396,714,l),
+(381,642,l),
+(430,642,l),
+(396,482,l)
+);
+}
+);
+width = 776;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1648;
+unicode = 5704;
+},
+{
+color = 9;
+glyphname = "dzoCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(58,0,ls),
+(197,0,o),
+(273,68,o),
+(278,209,cs),
+(279,273,o),
+(262,342,o),
+(263,406,cs),
+(265,514,o),
+(329,579,o),
+(439,579,cs),
+(530,579,o),
+(584,536,o),
+(584,468,cs),
+(584,360,o),
+(463,263,o),
+(463,137,cs),
+(463,54,o),
+(519,0,o),
+(614,0,cs),
+(668,0,l),
+(698,142,l),
+(662,142,ls),
+(632,142,o),
+(621,153,o),
+(621,174,cs),
+(621,235,o),
+(749,337,o),
+(749,495,cs),
+(749,633,o),
+(633,728,o),
+(452,728,cs),
+(245.004,727.998,o),
+(105,615,o),
+(105,414,cs),
+(105,343,o),
+(124,274,o),
+(124,215,cs),
+(124,171,o),
+(106,142,o),
+(57,142,cs),
+(29,142,l),
+(-1,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(423,0,l),
+(438,72,l),
+(389,72,l),
+(423,232,l),
+(348,232,l),
+(315,72,l),
+(266,72,l),
+(250,0,l)
+);
+}
+);
+width = 775;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1649;
+unicode = 5705;
+},
+{
+color = 9;
+glyphname = "dzeCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (416,357);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(658,-15,o),
+(756,316,o),
+(756,499,cs),
+(756,645,o),
+(692,729,o),
+(575,729,cs),
+(455,729,o),
+(366,638,o),
+(324,638,cs),
+(304,638,o),
+(298,654,o),
+(306,690,cs),
+(311,714,l),
+(162,714,l),
+(149,653,ls),
+(127,552,o),
+(167,491,o),
+(256,491,cs),
+(366,491,o),
+(448,579,o),
+(517,579,cs),
+(563,579,o),
+(588,542,o),
+(588,471,cs),
+(588,372,o),
+(538,135,o),
+(414,135,cs),
+(339,135,o),
+(294,223,o),
+(194,223,cs),
+(109,223,o),
+(46,165,o),
+(23,61,cs),
+(10,0,l),
+(159,0,l),
+(164,24,ls),
+(172,60,o),
+(186,76,o),
+(207,76,cs),
+(253,76,o),
+(313,-15,o),
+(430,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(149,251,l),
+(162,315,l),
+(282,315,l),
+(300,399,l),
+(181,399,l),
+(194,463,l),
+(109,463,l),
+(64,251,l)
+);
+}
+);
+width = 770;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164A;
+unicode = 5706;
+},
+{
+color = 9;
+glyphname = "dzeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "dzeCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (328,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 770;
+}
+);
+metricLeft = "dzeCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164B;
+unicode = 5707;
+},
+{
+color = 9;
+glyphname = "dziCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "dzeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (297,0);
+ref = dot_middle;
+}
+);
+width = 771;
+}
+);
+note = uni164C;
+unicode = 5708;
+},
+{
+color = 9;
+glyphname = "dzaCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(358,-15,o),
+(447,76,o),
+(489,76,cs),
+(509,76,o),
+(515,60,o),
+(507,24,cs),
+(502,0,l),
+(651,0,l),
+(664,61,ls),
+(685,162,o),
+(646,223,o),
+(557,223,cs),
+(447,223,o),
+(365,135,o),
+(295,135,cs),
+(249,135,o),
+(226,172,o),
+(226,243,cs),
+(226,342,o),
+(275,579,o),
+(399,579,cs),
+(474,579,o),
+(519,491,o),
+(619,491,cs),
+(704,491,o),
+(767,549,o),
+(790,653,cs),
+(803,714,l),
+(654,714,l),
+(649,690,ls),
+(641,654,o),
+(627,638,o),
+(606,638,cs),
+(560,638,o),
+(500,729,o),
+(383,729,cs),
+(155,729,o),
+(57,398,o),
+(57,215,cs),
+(57,69,o),
+(121,-15,o),
+(238,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(704,251,l),
+(749,463,l),
+(664,463,l),
+(650,399,l),
+(531,399,l),
+(513,315,l),
+(632,315,l),
+(619,251,l)
+);
+}
+);
+width = 769;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dzeCarrier-canadian";
+note = uni164D;
+unicode = 5709;
+},
+{
+color = 9;
+glyphname = "suCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(344,-15,o),
+(421,37,o),
+(465,140,c),
+(396,140,l),
+(418,36,o),
+(475,-15,o),
+(581,-15,cs),
+(755,-15,o),
+(825,111,o),
+(832,256,cs),
+(838,340,o),
+(821,444,o),
+(825,503,cs),
+(827,549,o),
+(850,572,o),
+(892,572,cs),
+(916,572,l),
+(946,714,l),
+(873,714,ls),
+(727,714,o),
+(675,623,o),
+(668,508,cs),
+(663,434,o),
+(676,322,o),
+(672,256,cs),
+(670,196,o),
+(648,131,o),
+(580,131,cs),
+(519,131,o),
+(514,183,o),
+(523,227,cs),
+(626,714,l),
+(471,714,l),
+(368,225,ls),
+(355,162,o),
+(325,131,o),
+(278,131,cs),
+(238,131,o),
+(215,155,o),
+(215,194,cs),
+(215,290,o),
+(358,465,o),
+(358,585,cs),
+(358,664,o),
+(306,714,o),
+(221,714,cs),
+(151,714,l),
+(121,572,l),
+(146,572,ls),
+(175,572,o),
+(190,560,o),
+(190,537,cs),
+(190,461,o),
+(49,316,o),
+(49,169,cs),
+(49,60,o),
+(123,-15,o),
+(242,-15,cs)
+);
+}
+);
+width = 902;
+}
+);
+metricRight = "=|";
+note = uni164E;
+unicode = 5710;
+},
+{
+color = 9;
+glyphname = "soCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(72,0,ls),
+(218,0,o),
+(270,91,o),
+(277,206,cs),
+(282,280,o),
+(269,392,o),
+(273,458,cs),
+(275,518,o),
+(297,583,o),
+(365,583,cs),
+(426,583,o),
+(431,531,o),
+(422,487,cs),
+(319,0,l),
+(474,0,l),
+(577,489,ls),
+(590,552,o),
+(620,583,o),
+(667,583,cs),
+(707,583,o),
+(730,559,o),
+(730,520,cs),
+(730,424,o),
+(587,249,o),
+(587,129,cs),
+(587,50,o),
+(639,0,o),
+(724,0,cs),
+(793,0,l),
+(823,142,l),
+(799,142,ls),
+(769,142,o),
+(755,154,o),
+(755,177,cs),
+(755,253,o),
+(896,398,o),
+(896,545,cs),
+(896,654,o),
+(822,729,o),
+(703,729,cs),
+(601,729,o),
+(524,677,o),
+(480,574,c),
+(549,574,l),
+(527,678,o),
+(470,729,o),
+(364,729,cs),
+(190,729,o),
+(120,603,o),
+(112,458,cs),
+(107,374,o),
+(124,270,o),
+(120,211,cs),
+(118,165,o),
+(95,142,o),
+(53,142,cs),
+(29,142,l),
+(-1,0,l)
+);
+}
+);
+width = 900;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5711;
+},
+{
+color = 9;
+glyphname = "seCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(606,-15,o),
+(686,110,o),
+(686,219,cs),
+(686,293,o),
+(647,352,o),
+(576,381,c),
+(566,321,l),
+(685,353,o),
+(756,443,o),
+(756,551,cs),
+(756,653,o),
+(686,729,o),
+(584,729,cs),
+(472,729,o),
+(367,638,o),
+(326,638,cs),
+(303,638,o),
+(296,652,o),
+(303,685,cs),
+(309,714,l),
+(160,714,l),
+(149,657,ls),
+(128,561,o),
+(176,497,o),
+(266,497,cs),
+(370,497,o),
+(459,581,o),
+(529,581,cs),
+(567,581,o),
+(589,558,o),
+(589,522,cs),
+(589,466,o),
+(552,423,o),
+(483,423,cs),
+(99,423,l),
+(71,291,l),
+(455,291,ls),
+(501,291,o),
+(526,268,o),
+(526,229,cs),
+(526,187,o),
+(501,133,o),
+(442,133,cs),
+(370,133,o),
+(308,217,o),
+(193,217,cs),
+(100,217,o),
+(44,165,o),
+(21,57,cs),
+(10,0,l),
+(158,0,l),
+(164,24,ls),
+(172,61,o),
+(185,76,o),
+(209,76,cs),
+(269,76,o),
+(340,-15,o),
+(461,-15,cs)
+);
+}
+);
+width = 760;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni1650;
+unicode = 5712;
+},
+{
+color = 9;
+glyphname = "seeCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(606,-15,o),
+(686,110,o),
+(686,219,cs),
+(686,290,o),
+(650,347,o),
+(584,376,c),
+(576,327,l),
+(691,358,o),
+(756,446,o),
+(756,551,cs),
+(756,653,o),
+(686,729,o),
+(584,729,cs),
+(472,729,o),
+(367,638,o),
+(326,638,cs),
+(303,638,o),
+(296,652,o),
+(303,685,cs),
+(309,714,l),
+(160,714,l),
+(149,657,ls),
+(128,561,o),
+(176,497,o),
+(266,497,cs),
+(370,497,o),
+(459,581,o),
+(529,581,cs),
+(567,581,o),
+(589,558,o),
+(589,522,cs),
+(589,466,o),
+(551,422,o),
+(483,422,cs),
+(430,422,l),
+(449,349,l),
+(480,496,l),
+(388,496,l),
+(373,422,l),
+(98,422,l),
+(71,292,l),
+(345,292,l),
+(329,216,l),
+(421,216,l),
+(452,365,l),
+(402,292,l),
+(457,292,ls),
+(501,293,o),
+(526,268,o),
+(526,229,cs),
+(526,187,o),
+(501,133,o),
+(442,133,cs),
+(370,133,o),
+(308,217,o),
+(193,217,cs),
+(100,217,o),
+(44,165,o),
+(21,57,cs),
+(10,0,l),
+(158,0,l),
+(164,24,ls),
+(172,61,o),
+(185,76,o),
+(209,76,cs),
+(269,76,o),
+(340,-15,o),
+(461,-15,cs)
+);
+}
+);
+width = 760;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1651;
+unicode = 5713;
+},
+{
+color = 9;
+glyphname = "siCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(606,-15,o),
+(686,110,o),
+(686,219,cs),
+(686,290,o),
+(650,347,o),
+(584,376,c),
+(576,327,l),
+(691,358,o),
+(756,446,o),
+(756,551,cs),
+(756,653,o),
+(686,729,o),
+(584,729,cs),
+(472,729,o),
+(367,638,o),
+(326,638,cs),
+(303,638,o),
+(296,652,o),
+(303,685,cs),
+(309,714,l),
+(160,714,l),
+(149,657,ls),
+(128,561,o),
+(176,497,o),
+(266,497,cs),
+(370,497,o),
+(459,584,o),
+(529,584,cs),
+(567,584,o),
+(594,558,o),
+(594,522,cs),
+(594,466,o),
+(558,418,o),
+(489,418,cs),
+(408,418,l),
+(468,369,l),
+(465,428,o),
+(421,469,o),
+(363,469,cs),
+(325,469,o),
+(293,450,o),
+(274,422,c),
+(98,422,l),
+(71,292,l),
+(274,292,l),
+(294,264,o),
+(326,246,o),
+(363,246,cs),
+(418,246,o),
+(464,289,o),
+(468,344,c),
+(406,296,l),
+(465,296,ls),
+(511,296,o),
+(531,268,o),
+(531,229,cs),
+(531,187,o),
+(501,130,o),
+(442,130,cs),
+(370,130,o),
+(308,217,o),
+(193,217,cs),
+(100,217,o),
+(44,165,o),
+(21,57,cs),
+(10,0,l),
+(158,0,l),
+(164,24,ls),
+(172,61,o),
+(185,76,o),
+(209,76,cs),
+(269,76,o),
+(340,-15,o),
+(461,-15,cs)
+);
+}
+);
+width = 760;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1652;
+unicode = 5714;
+},
+{
+color = 9;
+glyphname = "saCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(331,-15,o),
+(436,76,o),
+(477,76,cs),
+(499,76,o),
+(507,62,o),
+(500,29,cs),
+(493,0,l),
+(642,0,l),
+(654,57,ls),
+(674,153,o),
+(627,217,o),
+(536,217,cs),
+(433,217,o),
+(344,133,o),
+(274,133,cs),
+(236,133,o),
+(214,156,o),
+(214,192,cs),
+(214,248,o),
+(251,291,o),
+(320,291,cs),
+(704,291,l),
+(732,423,l),
+(348,423,ls),
+(302,423,o),
+(276,446,o),
+(276,485,cs),
+(276,527,o),
+(302,581,o),
+(361,581,cs),
+(433,581,o),
+(495,497,o),
+(609,497,cs),
+(703,497,o),
+(759,549,o),
+(781,657,cs),
+(793,714,l),
+(644,714,l),
+(639,690,ls),
+(631,653,o),
+(618,638,o),
+(593,638,cs),
+(534,638,o),
+(463,729,o),
+(342,729,cs),
+(197,729,o),
+(117,604,o),
+(117,495,cs),
+(117,421,o),
+(156,362,o),
+(227,333,c),
+(237,393,l),
+(118,361,o),
+(47,271,o),
+(47,163,cs),
+(47,61,o),
+(117,-15,o),
+(218,-15,cs)
+);
+}
+);
+width = 758;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1653;
+unicode = 5715;
+},
+{
+color = 9;
+glyphname = "shuCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(335,-15,o),
+(407,28,o),
+(454,113,c),
+(402,118,l),
+(425,29,o),
+(483,-15,o),
+(581,-15,cs),
+(755,-15,o),
+(825,111,o),
+(832,256,cs),
+(838,340,o),
+(821,444,o),
+(825,503,cs),
+(827,549,o),
+(850,572,o),
+(892,572,cs),
+(916,572,l),
+(946,714,l),
+(873,714,ls),
+(728,714,o),
+(676,624,o),
+(668,511,cs),
+(667,503,o),
+(667,493,o),
+(667,483,c),
+(708,594,l),
+(602,594,l),
+(626,714,l),
+(471,714,l),
+(447,594,l),
+(329,594,l),
+(347,517,l),
+(354,542,o),
+(358,564,o),
+(358,585,cs),
+(358,664,o),
+(306,714,o),
+(221,714,cs),
+(151,714,l),
+(121,572,l),
+(146,572,ls),
+(175,572,o),
+(190,560,o),
+(190,537,cs),
+(190,461,o),
+(49,316,o),
+(49,169,cs),
+(49,60,o),
+(123,-15,o),
+(242,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(238,131,o),
+(215,155,o),
+(215,194,cs),
+(215,262,o),
+(284,363,o),
+(326,460,c),
+(418,460,l),
+(368,225,ls),
+(355,162,o),
+(325,131,o),
+(278,131,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(519,131,o),
+(514,183,o),
+(523,227,cs),
+(573,460,l),
+(665,460,l),
+(666,389,o),
+(675,311,o),
+(672,256,cs),
+(670,196,o),
+(648,131,o),
+(580,131,cs)
+);
+}
+);
+width = 902;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1654;
+unicode = 5716;
+},
+{
+color = 9;
+glyphname = "shoCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(72,0,ls),
+(216,0,o),
+(269,90,o),
+(277,203,cs),
+(278,211,o),
+(278,221,o),
+(278,231,c),
+(237,120,l),
+(343,120,l),
+(319,0,l),
+(474,0,l),
+(498,120,l),
+(616,120,l),
+(598,197,l),
+(591,172,o),
+(587,150,o),
+(587,129,cs),
+(587,50,o),
+(639,0,o),
+(724,0,cs),
+(793,0,l),
+(824,142,l),
+(799,142,ls),
+(770,142,o),
+(755,154,o),
+(755,177,cs),
+(755,253,o),
+(896,398,o),
+(896,545,cs),
+(896,654,o),
+(822,729,o),
+(703,729,cs),
+(610,729,o),
+(538,686,o),
+(491,601,c),
+(543,596,l),
+(520,685,o),
+(462,729,o),
+(364,729,cs),
+(190,729,o),
+(120,603,o),
+(112,458,cs),
+(107,374,o),
+(124,270,o),
+(120,211,cs),
+(118,165,o),
+(95,142,o),
+(53,142,cs),
+(29,142,l),
+(-1,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(279,325,o),
+(270,403,o),
+(273,458,cs),
+(275,518,o),
+(297,583,o),
+(365,583,cs),
+(426,583,o),
+(431,531,o),
+(422,487,cs),
+(372,254,l),
+(280,254,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(577,489,ls),
+(590,552,o),
+(620,583,o),
+(667,583,cs),
+(707,583,o),
+(730,559,o),
+(730,520,cs),
+(730,452,o),
+(661,351,o),
+(619,254,c),
+(527,254,l)
+);
+}
+);
+width = 901;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1655;
+unicode = 5717;
+},
+{
+color = 9;
+glyphname = "sheCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(606,-15,o),
+(686,110,o),
+(686,219,cs),
+(686,290,o),
+(650,347,o),
+(584,376,c),
+(576,327,l),
+(691,358,o),
+(756,446,o),
+(756,551,cs),
+(756,653,o),
+(686,729,o),
+(584,729,cs),
+(472,729,o),
+(367,638,o),
+(326,638,cs),
+(303,638,o),
+(296,652,o),
+(303,685,cs),
+(309,714,l),
+(160,714,l),
+(149,657,ls),
+(128,561,o),
+(176,499,o),
+(266,499,cs),
+(291,499,o),
+(318,504,o),
+(330,508,c),
+(237,576,l),
+(205,423,l),
+(99,423,l),
+(71,291,l),
+(177,291,l),
+(144,136,l),
+(257,206,l),
+(236,212,o),
+(216,215,o),
+(193,215,cs),
+(100,215,o),
+(44,165,o),
+(21,57,cs),
+(10,0,l),
+(158,0,l),
+(164,24,ls),
+(172,61,o),
+(185,76,o),
+(209,76,cs),
+(269,76,o),
+(340,-15,o),
+(461,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(307,291,l),
+(455,291,ls),
+(501,291,o),
+(526,268,o),
+(526,229,cs),
+(526,187,o),
+(501,133,o),
+(442,133,cs),
+(392,133,o),
+(347,171,o),
+(286,195,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(354,518,l),
+(420,541,o),
+(479,581,o),
+(529,581,cs),
+(567,581,o),
+(589,558,o),
+(589,522,cs),
+(589,466,o),
+(552,423,o),
+(483,423,cs),
+(335,423,l)
+);
+}
+);
+width = 760;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1656;
+unicode = 5718;
+},
+{
+color = 9;
+glyphname = "sheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(606,-15,o),
+(686,110,o),
+(686,219,cs),
+(686,290,o),
+(650,347,o),
+(584,376,c),
+(576,327,l),
+(691,358,o),
+(756,446,o),
+(756,551,cs),
+(756,653,o),
+(686,729,o),
+(584,729,cs),
+(472,729,o),
+(367,638,o),
+(326,638,cs),
+(303,638,o),
+(296,652,o),
+(303,685,cs),
+(309,714,l),
+(160,714,l),
+(149,657,ls),
+(128,561,o),
+(176,500,o),
+(266,500,cs),
+(280,500,o),
+(294,502,o),
+(306,504,c),
+(238,576,l),
+(203,411,l),
+(96,411,l),
+(73,303,l),
+(180,303,l),
+(145,137,l),
+(242,208,l),
+(226,212,o),
+(211,214,o),
+(193,214,cs),
+(100,214,o),
+(44,165,o),
+(21,57,cs),
+(10,0,l),
+(158,0,l),
+(164,24,ls),
+(172,61,o),
+(185,76,o),
+(209,76,cs),
+(269,76,o),
+(340,-15,o),
+(461,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(389,129,o),
+(341,176,o),
+(272,200,c),
+(294,303,l),
+(376,303,l),
+(357,218,l),
+(432,218,l),
+(462,357,l),
+(439,303,l),
+(462,303,ls),
+(509,303,o),
+(531,268,o),
+(531,229,cs),
+(531,187,o),
+(501,129,o),
+(442,129,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(491,494,l),
+(416,494,l),
+(398,411,l),
+(317,411,l),
+(339,512,l),
+(412,536,o),
+(476,585,o),
+(529,585,cs),
+(567,585,o),
+(594,558,o),
+(594,522,cs),
+(594,466,o),
+(554,411,o),
+(485,411,cs),
+(461,411,l),
+(462,358,l)
+);
+}
+);
+width = 760;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1657;
+unicode = 5719;
+},
+{
+color = 9;
+glyphname = "shiCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(149,657,ls),
+(128,561,o),
+(176,500,o),
+(266,500,cs),
+(281,500,o),
+(295,502,o),
+(309,505,c),
+(238,576,l),
+(203,411,l),
+(97,411,l),
+(73,303,l),
+(179,303,l),
+(144,137,l),
+(240,209,l),
+(225,212,o),
+(210,214,o),
+(193,214,cs),
+(100,214,o),
+(44,165,o),
+(21,57,cs),
+(10,0,l),
+(158,0,l),
+(164,24,ls),
+(172,61,o),
+(185,76,o),
+(209,76,cs),
+(269,76,o),
+(340,-15,o),
+(461,-15,cs),
+(606,-15,o),
+(686,110,o),
+(686,219,cs),
+(686,290,o),
+(650,347,o),
+(584,376,c),
+(576,327,l),
+(691,358,o),
+(756,446,o),
+(756,551,cs),
+(756,653,o),
+(686,729,o),
+(584,729,cs),
+(472,729,o),
+(367,638,o),
+(326,638,cs),
+(303,638,o),
+(296,652,o),
+(303,685,cs),
+(309,714,l),
+(160,714,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(294,303,l),
+(333,303,l),
+(350,268,o),
+(384,246,o),
+(425,246,cs),
+(483,246,o),
+(520,293,o),
+(528,342,c),
+(437,303,l),
+(470,303,ls),
+(513,303,o),
+(532,267,o),
+(532,229,cs),
+(532,187,o),
+(501,129,o),
+(442,129,cs),
+(389,129,o),
+(341,176,o),
+(272,200,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(339,512,l),
+(412,536,o),
+(476,585,o),
+(529,585,cs),
+(567,585,o),
+(594,558,o),
+(594,522,cs),
+(594,466,o),
+(559,411,o),
+(493,411,cs),
+(437,411,l),
+(527,371,l),
+(523,421,o),
+(485,469,o),
+(425,469,cs),
+(384,469,o),
+(349,446,o),
+(332,411,c),
+(317,411,l)
+);
+}
+);
+width = 760;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1658;
+unicode = 5720;
+},
+{
+color = 9;
+glyphname = "shaCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(330,-15,o),
+(436,76,o),
+(477,76,cs),
+(499,76,o),
+(507,62,o),
+(500,29,cs),
+(493,0,l),
+(642,0,l),
+(654,57,ls),
+(674,153,o),
+(627,215,o),
+(536,215,cs),
+(512,215,o),
+(484,210,o),
+(473,206,c),
+(565,138,l),
+(598,291,l),
+(704,291,l),
+(732,423,l),
+(626,423,l),
+(659,578,l),
+(546,508,l),
+(566,502,o),
+(586,499,o),
+(609,499,cs),
+(703,499,o),
+(759,549,o),
+(781,657,cs),
+(793,714,l),
+(644,714,l),
+(639,690,ls),
+(631,653,o),
+(618,638,o),
+(593,638,cs),
+(534,638,o),
+(463,729,o),
+(342,729,cs),
+(196,729,o),
+(117,604,o),
+(117,495,cs),
+(117,424,o),
+(153,367,o),
+(218,338,c),
+(226,387,l),
+(112,356,o),
+(47,268,o),
+(47,163,cs),
+(47,61,o),
+(117,-15,o),
+(218,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(236,133,o),
+(214,156,o),
+(214,192,cs),
+(214,248,o),
+(251,291,o),
+(320,291,cs),
+(468,291,l),
+(448,196,l),
+(383,173,o),
+(323,133,o),
+(274,133,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(301,423,o),
+(276,446,o),
+(276,485,cs),
+(276,527,o),
+(302,581,o),
+(360,581,cs),
+(411,581,o),
+(456,543,o),
+(516,519,c),
+(496,423,l),
+(347,423,ls)
+);
+}
+);
+width = 758;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1659;
+unicode = 5721;
+},
+{
+color = 6;
+glyphname = "shCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(235,99,l),
+(259,211,l),
+(156,189,l),
+(232,189,ls),
+(324,189,o),
+(382,234,o),
+(382,315,cs),
+(382,372,o),
+(342,409,o),
+(275,409,cs),
+(224,409,ls),
+(204,409,o),
+(193,417,o),
+(193,432,cs),
+(193,453,o),
+(209,463,o),
+(233,463,cs),
+(410,463,l),
+(428,546,l),
+(330,546,l),
+(349,636,l),
+(243,636,l),
+(218,520,l),
+(315,546,l),
+(246,546,ls),
+(153,546,o),
+(94,502,o),
+(94,420,cs),
+(94,364,o),
+(134,327,o),
+(201,327,cs),
+(251,327,ls),
+(272,327,o),
+(283,319,o),
+(283,304,cs),
+(283,282,o),
+(269,272,o),
+(243,272,cs),
+(66,272,l),
+(48,189,l),
+(148,189,l),
+(129,99,l)
+);
+}
+);
+width = 428;
+}
+);
+metricRight = "=|";
+note = uni18F5;
+unicode = 5722;
+},
+{
+color = 9;
+glyphname = "tsuCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(335,-15,o),
+(407,28,o),
+(454,113,c),
+(402,118,l),
+(425,29,o),
+(483,-15,o),
+(581,-15,cs),
+(755,-15,o),
+(825,111,o),
+(832,256,cs),
+(838,340,o),
+(821,444,o),
+(825,503,cs),
+(827,549,o),
+(850,572,o),
+(892,572,cs),
+(916,572,l),
+(946,714,l),
+(873,714,ls),
+(727,714,o),
+(676,623,o),
+(669,508,cs),
+(667,485,o),
+(669,456,o),
+(669,424,c),
+(563,424,l),
+(600,599,l),
+(656,599,l),
+(681,714,l),
+(417,714,l),
+(393,599,l),
+(449,599,l),
+(412,424,l),
+(306,424,l),
+(333,483,o),
+(357,538,o),
+(357,585,cs),
+(357,664,o),
+(306,714,o),
+(221,714,cs),
+(151,714,l),
+(121,572,l),
+(146,572,ls),
+(175,572,o),
+(190,560,o),
+(190,537,cs),
+(190,461,o),
+(49,316,o),
+(49,169,cs),
+(49,60,o),
+(123,-15,o),
+(242,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(238,131,o),
+(215,155,o),
+(215,194,cs),
+(215,220,o),
+(226,253,o),
+(241,290,c),
+(383,290,l),
+(369.996,225.006,ls),
+(357,162,o),
+(325,131,o),
+(278,131,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(519,131,o),
+(512,183,o),
+(521,227,cs),
+(534,290,l),
+(675,290,l),
+(674,272,o),
+(673,255,o),
+(672,243,cs),
+(670,193,o),
+(648,131,o),
+(580,131,cs)
+);
+}
+);
+width = 902;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165B;
+unicode = 5723;
+},
+{
+color = 9;
+glyphname = "tsoCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(72,0,ls),
+(218,0,o),
+(269,91,o),
+(276,206,cs),
+(278,229,o),
+(276,258,o),
+(276,290,c),
+(382,290,l),
+(345,115,l),
+(289,115,l),
+(264,0,l),
+(528,0,l),
+(552,115,l),
+(496,115,l),
+(533,290,l),
+(639,290,l),
+(612,231,o),
+(588,176,o),
+(588,129,cs),
+(588,50,o),
+(639,0,o),
+(724,0,cs),
+(793,0,l),
+(824,142,l),
+(799,142,ls),
+(770,142,o),
+(755,154,o),
+(755,177,cs),
+(755,253,o),
+(896,398,o),
+(896,545,cs),
+(896,654,o),
+(822,729,o),
+(703,729,cs),
+(610,729,o),
+(538,686,o),
+(491,601,c),
+(543,596,l),
+(520,685,o),
+(462,729,o),
+(364,729,cs),
+(190,729,o),
+(120,603,o),
+(112,458,cs),
+(107,374,o),
+(124,270,o),
+(120,211,cs),
+(118,165,o),
+(95,142,o),
+(53,142,cs),
+(29,142,l),
+(-1,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(271,442,o),
+(272,459,o),
+(273,471,cs),
+(275,521,o),
+(297,583,o),
+(365,583,cs),
+(426,583,o),
+(433,531,o),
+(424,487,cs),
+(411,424,l),
+(270,424,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(575,489,ls),
+(588,552,o),
+(620,583,o),
+(667,583,cs),
+(707,583,o),
+(730,559,o),
+(730,520,cs),
+(730,494,o),
+(719,461,o),
+(704,424,c),
+(561,424,l)
+);
+}
+);
+width = 901;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165C;
+unicode = 5724;
+},
+{
+color = 9;
+glyphname = "tseCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(609,-15,o),
+(689,110,o),
+(689,219,cs),
+(689,290,o),
+(653,347,o),
+(587,376,c),
+(579,327,l),
+(694,358,o),
+(759,446,o),
+(759,551,cs),
+(759,653,o),
+(689,729,o),
+(587,729,cs),
+(475,729,o),
+(370,638,o),
+(329,638,cs),
+(307,638,o),
+(299,652,o),
+(306,685,cs),
+(312,714,l),
+(163,714,l),
+(152,657,ls),
+(131,561,o),
+(179,504,o),
+(267,504,cs),
+(296,504,o),
+(325,509,o),
+(352,519,c),
+(305,579,l),
+(270,412,l),
+(191,412,l),
+(204,476,l),
+(112,476,l),
+(62,237,l),
+(154,237,l),
+(167,302,l),
+(246,302,l),
+(211,136,l),
+(280,195,l),
+(258,203,o),
+(222,210,o),
+(196,210,cs),
+(103,210,o),
+(47,165,o),
+(24,57,cs),
+(13,0,l),
+(162,0,l),
+(167,24,ls),
+(175,61,o),
+(188,76,o),
+(212,76,cs),
+(272,76,o),
+(343,-15,o),
+(464,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(408,133,o),
+(374,154,o),
+(333,173,c),
+(360,302,l),
+(459,302,ls),
+(505,302,o),
+(531,272,o),
+(531,229,cs),
+(531,187,o),
+(505,133,o),
+(446,133,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(411,542,l),
+(456,561,o),
+(497,581,o),
+(532,581,cs),
+(570,581,o),
+(593,558,o),
+(593,522,cs),
+(593,466,o),
+(555,412,o),
+(486,412,cs),
+(384,412,l)
+);
+}
+);
+width = 763;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni165D;
+unicode = 5725;
+},
+{
+color = 9;
+glyphname = "tseeCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(609,-15,o),
+(689,110,o),
+(689,219,cs),
+(689,290,o),
+(653,347,o),
+(587,376,c),
+(579,327,l),
+(694,358,o),
+(759,446,o),
+(759,551,cs),
+(759,653,o),
+(689,729,o),
+(587,729,cs),
+(475,729,o),
+(370,638,o),
+(329,638,cs),
+(307,638,o),
+(299,652,o),
+(306,685,cs),
+(312,714,l),
+(163,714,l),
+(152,657,ls),
+(131,561,o),
+(179,504,o),
+(267,504,cs),
+(296,504,o),
+(325,509,o),
+(352,519,c),
+(299,579,l),
+(264,412,l),
+(188,412,l),
+(201,476,l),
+(112,476,l),
+(62,237,l),
+(151,237,l),
+(164,302,l),
+(240,302,l),
+(205,136,l),
+(280,195,l),
+(258,203,o),
+(222,210,o),
+(196,210,cs),
+(103,210,o),
+(47,165,o),
+(24,57,cs),
+(13,0,l),
+(162,0,l),
+(167,24,ls),
+(175,61,o),
+(188,76,o),
+(212,76,cs),
+(272,76,o),
+(343,-15,o),
+(464,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(406,133,o),
+(365,160,o),
+(314,184,c),
+(340,302,l),
+(396,302,l),
+(378,213,l),
+(453,213,l),
+(475,321,l),
+(445,302,l),
+(460,302,ls),
+(505,302,o),
+(531,272,o),
+(531,229,cs),
+(531,183,o),
+(503,133,o),
+(446,133,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(513,499,l),
+(438,499,l),
+(420,412,l),
+(362,412,l),
+(388,532,l),
+(435,551,o),
+(493,581,o),
+(532,581,cs),
+(570,581,o),
+(594,558,o),
+(594,522,cs),
+(594,466,o),
+(556,412,o),
+(488,412,cs),
+(463,412,l),
+(492,398,l)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165E;
+unicode = 5726;
+},
+{
+color = 9;
+glyphname = "tsiCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(609,-14,o),
+(689,110,o),
+(689,220,cs),
+(689,290,o),
+(653,347,o),
+(587,376,c),
+(579,327,l),
+(694,358,o),
+(759,446,o),
+(759,552,cs),
+(759,653,o),
+(689,729,o),
+(587,729,cs),
+(475,729,o),
+(370,638,o),
+(329,638,cs),
+(307,638,o),
+(299,652,o),
+(306,685,cs),
+(312,714,l),
+(163,714,l),
+(152,657,ls),
+(131,561,o),
+(179,504,o),
+(267,504,cs),
+(288,504,o),
+(308,508,o),
+(326,514,c),
+(276,579,l),
+(241,412,l),
+(188,412,l),
+(201,477,l),
+(112,477,l),
+(62,237,l),
+(151,237,l),
+(164,303,l),
+(218,303,l),
+(182,136,l),
+(254,200,l),
+(235,206,o),
+(216,210,o),
+(196,210,cs),
+(103,210,o),
+(47,165,o),
+(24,57,cs),
+(13,0,l),
+(162,0,l),
+(167,24,ls),
+(175,61,o),
+(188,76,o),
+(212,76,cs),
+(272,76,o),
+(343,-14,o),
+(464,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(400,133,o),
+(345,171,o),
+(293,190,c),
+(316,303,l),
+(350,303,l),
+(365,268,o),
+(398,246,o),
+(438,246,cs),
+(487,246,o),
+(515,280,o),
+(530,314,c),
+(443,303,l),
+(460,303,ls),
+(505,303,o),
+(531,272,o),
+(531,229,cs),
+(531,183,o),
+(503,133,o),
+(446,133,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(520,443,o),
+(481,469,o),
+(441,469,cs),
+(403,469,o),
+(366,445,o),
+(353,412,c),
+(340,412,l),
+(364,524,l),
+(411,539,o),
+(486,582,o),
+(532,582,cs),
+(570,582,o),
+(594,558,o),
+(594,522,cs),
+(594,466,o),
+(556,412,o),
+(488,412,cs),
+(461,412,l),
+(535,399,l)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165F;
+unicode = 5727;
+},
+{
+color = 9;
+glyphname = "tsaCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(331,-14,o),
+(436,76,o),
+(477,76,cs),
+(499,76,o),
+(507,62,o),
+(500,29,cs),
+(494,0,l),
+(643,0,l),
+(654,57,ls),
+(675,153,o),
+(627,210,o),
+(539,210,cs),
+(510,210,o),
+(481,205,o),
+(454,195,c),
+(501,135,l),
+(536,302,l),
+(615,302,l),
+(602,238,l),
+(694,238,l),
+(744,477,l),
+(652,477,l),
+(639,412,l),
+(560,412,l),
+(595,578,l),
+(526,519,l),
+(548,511,o),
+(584,504,o),
+(610,504,cs),
+(703,504,o),
+(759,549,o),
+(782,657,cs),
+(793,714,l),
+(644,714,l),
+(639,690,ls),
+(631,653,o),
+(618,638,o),
+(594,638,cs),
+(534,638,o),
+(463,729,o),
+(342,729,cs),
+(197,729,o),
+(117,604,o),
+(117,495,cs),
+(117,424,o),
+(153,367,o),
+(219,338,c),
+(227,387,l),
+(112,356,o),
+(47,268,o),
+(47,163,cs),
+(47,61,o),
+(117,-14,o),
+(218,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(236,133,o),
+(213,156,o),
+(213,192,cs),
+(213,248,o),
+(251,302,o),
+(319,302,cs),
+(422,302,l),
+(395,172,l),
+(350,153,o),
+(309,133,o),
+(273,133,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(301,412,o),
+(275,442,o),
+(275,485,cs),
+(275,527,o),
+(301,582,o),
+(360,582,cs),
+(397,582,o),
+(432,560,o),
+(473,541,c),
+(446,412,l),
+(347,412,ls)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1660;
+unicode = 5728;
+},
+{
+color = 9;
+glyphname = "chuCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(335,-15,o),
+(407,28,o),
+(454,113,c),
+(402,118,l),
+(425,29,o),
+(483,-15,o),
+(581,-15,cs),
+(755,-15,o),
+(825,111,o),
+(832,256,cs),
+(838,340,o),
+(821,444,o),
+(825,503,cs),
+(827,549,o),
+(850,572,o),
+(892,572,cs),
+(916,572,l),
+(946,714,l),
+(873,714,ls),
+(727,714,o),
+(676,623,o),
+(669,508,cs),
+(664,434,o),
+(676,322,o),
+(672,256,cs),
+(670,196,o),
+(648,131,o),
+(580,131,cs),
+(519,131,o),
+(514,183,o),
+(523,227,cs),
+(602,599,l),
+(656,599,l),
+(681,714,l),
+(417,714,l),
+(393,599,l),
+(447,599,l),
+(368,225,ls),
+(355,162,o),
+(325,131,o),
+(278,131,cs),
+(238,131,o),
+(215,155,o),
+(215,194,cs),
+(215,290,o),
+(357,465,o),
+(357,585,cs),
+(357,664,o),
+(306,714,o),
+(221,714,cs),
+(151,714,l),
+(121,572,l),
+(146,572,ls),
+(175,572,o),
+(190,560,o),
+(190,537,cs),
+(190,461,o),
+(49,316,o),
+(49,169,cs),
+(49,60,o),
+(123,-15,o),
+(242,-15,cs)
+);
+}
+);
+width = 902;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164E;
+unicode = 5729;
+},
+{
+color = 9;
+glyphname = "choCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(72,0,ls),
+(218,0,o),
+(269,91,o),
+(276,206,cs),
+(281,280,o),
+(269,392,o),
+(273,458,cs),
+(275,518,o),
+(297,583,o),
+(365,583,cs),
+(426,583,o),
+(431,531,o),
+(422,487,cs),
+(343,115,l),
+(289,115,l),
+(264,0,l),
+(528,0,l),
+(552,115,l),
+(498,115,l),
+(577,489,ls),
+(590,552,o),
+(620,583,o),
+(667,583,cs),
+(707,583,o),
+(730,559,o),
+(730,520,cs),
+(730,424,o),
+(588,249,o),
+(588,129,cs),
+(588,50,o),
+(639,0,o),
+(724,0,cs),
+(793,0,l),
+(823,142,l),
+(799,142,ls),
+(770,142,o),
+(755,154,o),
+(755,177,cs),
+(755,253,o),
+(896,398,o),
+(896,545,cs),
+(896,654,o),
+(822,729,o),
+(703,729,cs),
+(610,729,o),
+(538,686,o),
+(491,601,c),
+(543,596,l),
+(520,685,o),
+(462,729,o),
+(364,729,cs),
+(190,729,o),
+(120,603,o),
+(112,458,cs),
+(107,374,o),
+(124,270,o),
+(120,211,cs),
+(118,165,o),
+(95,142,o),
+(53,142,cs),
+(29,142,l),
+(-1,0,l)
+);
+}
+);
+width = 900;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5730;
+},
+{
+color = 9;
+glyphname = "cheCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(609,-15,o),
+(689,110,o),
+(689,219,cs),
+(689,290,o),
+(653,347,o),
+(587,376,c),
+(579,327,l),
+(694,358,o),
+(759,446,o),
+(759,551,cs),
+(759,653,o),
+(689,729,o),
+(587,729,cs),
+(475,729,o),
+(370,638,o),
+(329,638,cs),
+(307,638,o),
+(299,652,o),
+(306,685,cs),
+(312,714,l),
+(163,714,l),
+(152,657,ls),
+(131,561,o),
+(179,503,o),
+(270,503,cs),
+(373,503,o),
+(461,581,o),
+(532,581,cs),
+(569,581,o),
+(592,558,o),
+(592,522,cs),
+(592,466,o),
+(555,423,o),
+(486,423,cs),
+(193,423,l),
+(204,476,l),
+(112,476,l),
+(62,237,l),
+(154,237,l),
+(165,291,l),
+(458,291,ls),
+(504,291,o),
+(529,268,o),
+(529,229,cs),
+(529,187,o),
+(503,133,o),
+(445,133,cs),
+(373,133,o),
+(311,211,o),
+(196,211,cs),
+(103,211,o),
+(45,154,o),
+(24,57,cs),
+(13,0,l),
+(162,0,l),
+(167,24,ls),
+(175,61,o),
+(188,76,o),
+(212,76,cs),
+(272,76,o),
+(343,-15,o),
+(464,-15,cs)
+);
+}
+);
+width = 763;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni1663;
+unicode = 5731;
+},
+{
+color = 9;
+glyphname = "cheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(609,-15,o),
+(689,110,o),
+(689,219,cs),
+(689,290,o),
+(653,347,o),
+(587,376,c),
+(579,327,l),
+(694,358,o),
+(759,446,o),
+(759,551,cs),
+(759,653,o),
+(689,729,o),
+(587,729,cs),
+(475,729,o),
+(370,638,o),
+(329,638,cs),
+(307,638,o),
+(299,652,o),
+(306,685,cs),
+(312,714,l),
+(163,714,l),
+(152,657,ls),
+(131,561,o),
+(179,502,o),
+(269,502,cs),
+(372,502,o),
+(461,583,o),
+(532,583,cs),
+(569,583,o),
+(593,558,o),
+(593,522,cs),
+(593,466,o),
+(555,411,o),
+(486,411,cs),
+(430,411,l),
+(463,396,l),
+(484,495,l),
+(392,495,l),
+(374,411,l),
+(190,411,l),
+(204,476,l),
+(112,476,l),
+(62,237,l),
+(154,237,l),
+(168,303,l),
+(351,303,l),
+(333,216,l),
+(425,216,l),
+(448,328,l),
+(409,303,l),
+(464,303,ls),
+(510,303,o),
+(531,268,o),
+(531,229,cs),
+(531,187,o),
+(504,131,o),
+(445,131,cs),
+(373,131,o),
+(310,212,o),
+(196,212,cs),
+(103,212,o),
+(45,154,o),
+(24,57,cs),
+(13,0,l),
+(162,0,l),
+(167,24,ls),
+(175,61,o),
+(188,76,o),
+(212,76,cs),
+(272,76,o),
+(343,-15,o),
+(464,-15,cs)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1664;
+unicode = 5732;
+},
+{
+color = 9;
+glyphname = "chiCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(609,-15,o),
+(689,110,o),
+(689,219,cs),
+(689,290,o),
+(653,347,o),
+(587,376,c),
+(579,327,l),
+(694,358,o),
+(759,446,o),
+(759,551,cs),
+(759,653,o),
+(689,729,o),
+(587,729,cs),
+(475,729,o),
+(370,638,o),
+(329,638,cs),
+(307,638,o),
+(299,652,o),
+(306,685,cs),
+(312,714,l),
+(163,714,l),
+(152,657,ls),
+(131,561,o),
+(179,502,o),
+(269,502,cs),
+(372,502,o),
+(461,583,o),
+(532,583,cs),
+(569,583,o),
+(593,558,o),
+(593,522,cs),
+(593,466,o),
+(555,411,o),
+(489,411,cs),
+(433,411,l),
+(479,383,l),
+(471,432,o),
+(427,469,o),
+(374,469,cs),
+(329,469,o),
+(297,445,o),
+(279,411,c),
+(190,411,l),
+(204,477,l),
+(113,477,l),
+(62,237,l),
+(154,237,l),
+(168,303,l),
+(279,303,l),
+(299,267,o),
+(333,246,o),
+(374,246,cs),
+(429,246,o),
+(466,284,o),
+(479,331,c),
+(412,303,l),
+(467,303,ls),
+(509,303,o),
+(531,270,o),
+(531,229,cs),
+(531,187,o),
+(504,131,o),
+(445,131,cs),
+(373,131,o),
+(310,212,o),
+(196,212,cs),
+(103,212,o),
+(45,154,o),
+(24,57,cs),
+(13,0,l),
+(162,0,l),
+(167,24,ls),
+(175,61,o),
+(188,76,o),
+(212,76,cs),
+(272,76,o),
+(343,-15,o),
+(464,-15,cs)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1665;
+unicode = 5733;
+},
+{
+color = 9;
+glyphname = "chaCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(332,-13,o),
+(437,78,o),
+(478,78,cs),
+(501,78,o),
+(508,64,o),
+(501,31,cs),
+(495,2,l),
+(644,2,l),
+(656,58,ls),
+(676,155,o),
+(628,213,o),
+(538,213,cs),
+(434,213,o),
+(346,134,o),
+(275,134,cs),
+(238,134,o),
+(215,158,o),
+(215,194,cs),
+(215,250,o),
+(253,293,o),
+(321,293,cs),
+(614,293,l),
+(603,239,l),
+(695,239,l),
+(745,478,l),
+(654,478,l),
+(642,425,l),
+(349,425,ls),
+(303,425,o),
+(278,448,o),
+(278,487,cs),
+(278,529,o),
+(304,583,o),
+(362,583,cs),
+(434,583,o),
+(496,504,o),
+(611,504,cs),
+(704,504,o),
+(762,562,o),
+(783,659,cs),
+(795,716,l),
+(646,716,l),
+(640,692,ls),
+(633,655,o),
+(619,640,o),
+(595,640,cs),
+(535,640,o),
+(464,730,o),
+(343,730,cs),
+(198,730,o),
+(118,606,o),
+(118,496,cs),
+(118,426,o),
+(154,369,o),
+(220,340,c),
+(228,389,l),
+(113,358,o),
+(48,270,o),
+(48,164,cs),
+(48,63,o),
+(118,-13,o),
+(220,-13,cs)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1666;
+unicode = 5734;
+},
+{
+color = 9;
+glyphname = "ttsuCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(335,-15,o),
+(407,28,o),
+(454,113,c),
+(402,118,l),
+(425,29,o),
+(483,-15,o),
+(581,-15,cs),
+(755,-15,o),
+(825,111,o),
+(832,256,cs),
+(838,340,o),
+(821,444,o),
+(825,503,cs),
+(827,549,o),
+(850,572,o),
+(892,572,cs),
+(916,572,l),
+(946,714,l),
+(873,714,ls),
+(727,714,o),
+(676,623,o),
+(669,508,cs),
+(667,475,o),
+(669,443,o),
+(666,418,c),
+(732,565,l),
+(574,467,l),
+(602,599,l),
+(656,599,l),
+(681,714,l),
+(417,714,l),
+(393,599,l),
+(447,599,l),
+(420,469,l),
+(276,588,l),
+(312,429,l),
+(336,486,o),
+(357,538,o),
+(357,585,cs),
+(357,664,o),
+(306,714,o),
+(221,714,cs),
+(151,714,l),
+(121,572,l),
+(146,572,ls),
+(175,572,o),
+(190,560,o),
+(190,537,cs),
+(190,461,o),
+(49,316,o),
+(49,169,cs),
+(49,60,o),
+(123,-15,o),
+(242,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(238,131,o),
+(215,155,o),
+(215,194,cs),
+(215,247,o),
+(257,316,o),
+(293,389,c),
+(387,315,l),
+(368,225,ls),
+(355,162,o),
+(325,131,o),
+(278,131,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(519,131,o),
+(514,183,o),
+(523,227,cs),
+(538,299,l),
+(668,375,l),
+(671,332,o),
+(674,290,o),
+(672,256,cs),
+(670,196,o),
+(648,131,o),
+(580,131,cs)
+);
+}
+);
+width = 902;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1667;
+unicode = 5735;
+},
+{
+color = 9;
+glyphname = "ttsoCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(72,0,ls),
+(218,0,o),
+(269,91,o),
+(276,206,cs),
+(278,239,o),
+(276,271,o),
+(279,296,c),
+(213,149,l),
+(371,247,l),
+(343,115,l),
+(289,115,l),
+(264,0,l),
+(528,0,l),
+(552,115,l),
+(498,115,l),
+(525,245,l),
+(669,126,l),
+(633,285,l),
+(609,228,o),
+(588,176,o),
+(588,129,cs),
+(588,50,o),
+(639,0,o),
+(724,0,cs),
+(793,0,l),
+(824,142,l),
+(799,142,ls),
+(770,142,o),
+(755,154,o),
+(755,177,cs),
+(755,253,o),
+(896,398,o),
+(896,545,cs),
+(896,654,o),
+(822,729,o),
+(703,729,cs),
+(610,729,o),
+(538,686,o),
+(491,601,c),
+(543,596,l),
+(520,685,o),
+(462,729,o),
+(364,729,cs),
+(190,729,o),
+(120,603,o),
+(112,458,cs),
+(107,374,o),
+(124,270,o),
+(120,211,cs),
+(118,165,o),
+(95,142,o),
+(53,142,cs),
+(29,142,l),
+(-1,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(274,382,o),
+(271,424,o),
+(273,458,cs),
+(275,518,o),
+(297,583,o),
+(365,583,cs),
+(426,583,o),
+(431,531,o),
+(422,487,cs),
+(407,415,l),
+(277,339,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(558,399,l),
+(577,489,ls),
+(590,552,o),
+(620,583,o),
+(667,583,cs),
+(707,583,o),
+(730,559,o),
+(730,520,cs),
+(730,467,o),
+(688,398,o),
+(652,325,c)
+);
+}
+);
+width = 901;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1668;
+unicode = 5736;
+},
+{
+color = 9;
+glyphname = "ttseCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(609,-15,o),
+(689,110,o),
+(689,219,cs),
+(689,290,o),
+(653,347,o),
+(587,376,c),
+(579,327,l),
+(694,358,o),
+(759,446,o),
+(759,551,cs),
+(759,652,o),
+(689,729,o),
+(587,729,cs),
+(475,729,o),
+(370,638,o),
+(329,638,cs),
+(306,638,o),
+(299,652,o),
+(306,685,cs),
+(312,714,l),
+(163,714,l),
+(151,657,ls),
+(132,562,o),
+(178,502,o),
+(269,502,cs),
+(285,502,o),
+(301,504,o),
+(316,508,c),
+(227,581,l),
+(266,411,l),
+(191,411,l),
+(205,476,l),
+(113,476,l),
+(62,237,l),
+(154,237,l),
+(168,303,l),
+(244,303,l),
+(139,142,l),
+(256,204,l),
+(237,209,o),
+(218,212,o),
+(196,212,cs),
+(101,212,o),
+(46,163,o),
+(24,57,cs),
+(12,0,l),
+(161,0,l),
+(167,24,ls),
+(174,61,o),
+(188,76,o),
+(212,76,cs),
+(272,76,o),
+(343,-15,o),
+(464,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(396,129,o),
+(352,166,o),
+(297,189,c),
+(369,303,l),
+(462,303,ls),
+(506,303,o),
+(533,273,o),
+(533,232,cs),
+(533,186,o),
+(502,129,o),
+(445,129,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(360,521,l),
+(422,543,o),
+(481,585,o),
+(531,585,cs),
+(570,585,o),
+(594,559,o),
+(594,520,cs),
+(594,466,o),
+(553,411,o),
+(486,411,cs),
+(383,411,l)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1669;
+unicode = 5737;
+},
+{
+color = 9;
+glyphname = "ttseeCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(609,-15,o),
+(689,110,o),
+(689,219,cs),
+(689,290,o),
+(653,347,o),
+(587,376,c),
+(579,327,l),
+(694,358,o),
+(759,446,o),
+(759,551,cs),
+(759,652,o),
+(689,729,o),
+(587,729,cs),
+(475,729,o),
+(370,638,o),
+(329,638,cs),
+(306,638,o),
+(299,652,o),
+(306,685,cs),
+(312,714,l),
+(163,714,l),
+(151,657,ls),
+(132,562,o),
+(178,502,o),
+(269,502,cs),
+(285,502,o),
+(301,504,o),
+(316,508,c),
+(225,581,l),
+(263,411,l),
+(191,411,l),
+(205,476,l),
+(113,476,l),
+(62,237,l),
+(154,237,l),
+(168,303,l),
+(242,303,l),
+(136,142,l),
+(256,204,l),
+(237,209,o),
+(218,212,o),
+(196,212,cs),
+(101,212,o),
+(46,163,o),
+(24,57,cs),
+(12,0,l),
+(161,0,l),
+(167,24,ls),
+(174,61,o),
+(188,76,o),
+(212,76,cs),
+(272,76,o),
+(343,-15,o),
+(464,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(396,129,o),
+(347,171,o),
+(292,193,c),
+(362,303,l),
+(397,303,l),
+(377,213,l),
+(455,213,l),
+(479,325,l),
+(446,303,l),
+(462,303,ls),
+(506,303,o),
+(533,273,o),
+(533,232,cs),
+(533,186,o),
+(502,129,o),
+(445,129,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(516,499,l),
+(438,499,l),
+(420,411,l),
+(376,411,l),
+(353,518,l),
+(415,538,o),
+(480,585,o),
+(531,585,cs),
+(570,585,o),
+(594,559,o),
+(594,520,cs),
+(594,466,o),
+(553,411,o),
+(486,411,cs),
+(467,411,l),
+(494,395,l)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166A;
+unicode = 5738;
+},
+{
+color = 9;
+glyphname = "ttsiCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(609,-15,o),
+(689,110,o),
+(689,219,cs),
+(689,290,o),
+(653,347,o),
+(587,376,c),
+(579,327,l),
+(694,358,o),
+(759,446,o),
+(759,551,cs),
+(759,652,o),
+(689,729,o),
+(587,729,cs),
+(475,729,o),
+(370,638,o),
+(329,638,cs),
+(306,638,o),
+(299,652,o),
+(306,685,cs),
+(312,714,l),
+(163,714,l),
+(151,657,ls),
+(132,562,o),
+(178,502,o),
+(269,502,cs),
+(285,502,o),
+(301,504,o),
+(316,508,c),
+(225,581,l),
+(263,411,l),
+(191,411,l),
+(205,476,l),
+(113,476,l),
+(62,237,l),
+(154,237,l),
+(168,303,l),
+(244,303,l),
+(139,142,l),
+(256,204,l),
+(237,209,o),
+(218,212,o),
+(196,212,cs),
+(101,212,o),
+(46,163,o),
+(24,57,cs),
+(12,0,l),
+(161,0,l),
+(167,24,ls),
+(174,61,o),
+(188,76,o),
+(212,76,cs),
+(272,76,o),
+(343,-15,o),
+(464,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(396,129,o),
+(337,176,o),
+(282,197,c),
+(350,303,l),
+(356,303,l),
+(372,266,o),
+(410,246,o),
+(444,246,cs),
+(495,246,o),
+(529,287,o),
+(538,325,c),
+(446,303,l),
+(485,303,ls),
+(517,303,o),
+(533,273,o),
+(533,232,cs),
+(533,186,o),
+(502,129,o),
+(445,129,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(523,439,o),
+(489,469,o),
+(444,469,cs),
+(410,469,o),
+(370,448,o),
+(356,411,c),
+(356,411,l),
+(335,512,l),
+(398,530,o),
+(480,585,o),
+(531,585,cs),
+(570,585,o),
+(594,559,o),
+(594,520,cs),
+(594,466,o),
+(564,411,o),
+(497,411,cs),
+(467,411,l),
+(538,395,l)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166B;
+unicode = 5739;
+},
+{
+color = 9;
+glyphname = "ttsaCarrier-canadian";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(331,-15,o),
+(436,76,o),
+(477,76,cs),
+(499,76,o),
+(507,62,o),
+(500,29,cs),
+(493,0,l),
+(642,0,l),
+(654,57,ls),
+(674,152,o),
+(628,212,o),
+(537,212,cs),
+(520,212,o),
+(505,210,o),
+(490,206,c),
+(579,133,l),
+(540,303,l),
+(615,303,l),
+(600,238,l),
+(692,238,l),
+(743,477,l),
+(651,477,l),
+(637,411,l),
+(562,411,l),
+(667,572,l),
+(550,510,l),
+(568,505,o),
+(588,502,o),
+(610,502,cs),
+(705,502,o),
+(759,551,o),
+(781,657,cs),
+(793,714,l),
+(644,714,l),
+(639,690,ls),
+(631,653,o),
+(617,638,o),
+(593,638,cs),
+(534,638,o),
+(463,729,o),
+(342,729,cs),
+(197,729,o),
+(117,604,o),
+(117,495,cs),
+(117,424,o),
+(153,367,o),
+(219,338,c),
+(227,387,l),
+(112,356,o),
+(47,268,o),
+(47,163,cs),
+(47,62,o),
+(117,-15,o),
+(219,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(236,129,o),
+(212,155,o),
+(212,194,cs),
+(212,248,o),
+(253,303,o),
+(320,303,cs),
+(423,303,l),
+(446,193,l),
+(383,171,o),
+(325,129,o),
+(275,129,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(300,411,o),
+(273,441,o),
+(273,482,cs),
+(273,528,o),
+(304,585,o),
+(361,585,cs),
+(409,585,o),
+(454,548,o),
+(509,525,c),
+(436,411,l),
+(344,411,ls)
+);
+}
+);
+width = 761;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni166C;
+unicode = 5740;
+},
+{
+glyphname = "qai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (346,0);
+ref = "ke-canadian";
+}
+);
+width = 960;
+}
+);
+note = uni166F;
+unicode = 5743;
+},
+{
+glyphname = "ngai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (646,0);
+ref = "ce-canadian";
+}
+);
+width = 1251;
+}
+);
+note = uni1670;
+unicode = 5744;
+},
+{
+glyphname = "nngi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (948,0);
+ref = "ci-canadian";
+}
+);
+width = 1552;
+}
+);
+note = uni1671;
+unicode = 5745;
+},
+{
+glyphname = "nngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (948,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (1165,0);
+ref = dot_top;
+}
+);
+width = 1552;
+}
+);
+note = uni1672;
+unicode = 5746;
+},
+{
+glyphname = "nngo-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (948,0);
+ref = "ce-canadian";
+}
+);
+width = 1552;
+}
+);
+note = uni1673;
+unicode = 5747;
+},
+{
+glyphname = "nngoo-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (948,0);
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (1148,0);
+ref = dot_top;
+}
+);
+width = 1552;
+}
+);
+note = uni1674;
+unicode = 5748;
+},
+{
+glyphname = "nnga-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (948,0);
+ref = "ca-canadian";
+}
+);
+width = 1552;
+}
+);
+note = uni1675;
+unicode = 5749;
+},
+{
+glyphname = "nngaa-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (948,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (991,0);
+ref = dot_top;
+}
+);
+width = 1552;
+}
+);
+note = uni1676;
+unicode = 5750;
+},
+{
+glyphname = "thweeWoodScree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 882;
+}
+);
+note = uni1677;
+unicode = 5751;
+},
+{
+glyphname = "thwiWoodScree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 882;
+}
+);
+note = uni1678;
+unicode = 5752;
+},
+{
+glyphname = "thwiiWoodScree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (87,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 882;
+}
+);
+note = uni1679;
+unicode = 5753;
+},
+{
+glyphname = "thwoWoodScree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 882;
+}
+);
+note = uni167A;
+unicode = 5754;
+},
+{
+glyphname = "thwooWoodScree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (355,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 882;
+}
+);
+note = uni167B;
+unicode = 5755;
+},
+{
+glyphname = "thwaWoodScree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 882;
+}
+);
+note = uni167C;
+unicode = 5756;
+},
+{
+glyphname = "thwaaWoodScree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (87,0);
+ref = dot_top;
+},
+{
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 882;
+}
+);
+note = uni167D;
+unicode = 5757;
+},
+{
+glyphname = "wBlackfoot-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(453,564,l),
+(473,656,l),
+(141,656,l),
+(122,564,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(422,415,l),
+(441,507,l),
+(109,507,l),
+(90,415,l)
+);
+}
+);
+width = 443;
+}
+);
+metricRight = "=|";
+note = uni167F;
+unicode = 5759;
+},
+{
+glyphname = "oy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-3,0);
+ref = ring_top.canadian;
+}
+);
+width = 690;
+}
+);
+note = uni18B0;
+unicode = 6320;
+},
+{
+glyphname = "ay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (418,0);
+ref = ring_top.canadian;
+}
+);
+width = 690;
+}
+);
+note = uni18B1;
+unicode = 6321;
+},
+{
+glyphname = "aay-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (180,0);
+ref = ring_top.canadian;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (457,0);
+ref = dot_top;
+}
+);
+width = 690;
+}
+);
+note = uni18B2;
+unicode = 6322;
+},
+{
+glyphname = "way-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (663,0);
+ref = ring_top.canadian;
+}
+);
+width = 935;
+}
+);
+note = uni18B3;
+unicode = 6323;
+},
+{
+glyphname = "poy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-22,0);
+ref = ring_top.canadian;
+}
+);
+width = 668;
+}
+);
+note = uni18B4;
+unicode = 6324;
+},
+{
+glyphname = "pay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (417,0);
+ref = ring_top.canadian;
+}
+);
+width = 668;
+}
+);
+note = uni18B5;
+unicode = 6325;
+},
+{
+glyphname = "pwoy-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (223,0);
+ref = ring_top.canadian;
+}
+);
+width = 912;
+}
+);
+note = uni18B6;
+unicode = 6326;
+},
+{
+glyphname = "tay-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (212,0);
+ref = ring_top.canadian;
+}
+);
+width = 639;
+}
+);
+note = uni18B7;
+unicode = 6327;
+},
+{
+glyphname = "kay-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (4,0);
+ref = ring_top.canadian;
+}
+);
+width = 614;
+}
+);
+note = uni18B8;
+unicode = 6328;
+},
+{
+glyphname = "kway-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (249,0);
+ref = ring_top.canadian;
+}
+);
+width = 859;
+}
+);
+note = uni18B9;
+unicode = 6329;
+},
+{
+glyphname = "may-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (12,0);
+ref = ring_top.canadian;
+}
+);
+width = 571;
+}
+);
+note = uni18BA;
+unicode = 6330;
+},
+{
+glyphname = "noy-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (346,-185);
+ref = ring_top.canadian;
+}
+);
+width = 826;
+}
+);
+note = uni18BB;
+unicode = 6331;
+},
+{
+glyphname = "nay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (128,-185);
+ref = ring_top.canadian;
+}
+);
+width = 826;
+}
+);
+note = uni18BC;
+unicode = 6332;
+},
+{
+glyphname = "lay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (129,-185);
+ref = ring_top.canadian;
+}
+);
+width = 826;
+}
+);
+note = uni18BD;
+unicode = 6333;
+},
+{
+glyphname = "soy-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (293,0);
+ref = ring_top.canadian;
+}
+);
+width = 577;
+}
+);
+note = uni18BE;
+unicode = 6334;
+},
+{
+glyphname = "say-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (12,0);
+ref = ring_top.canadian;
+}
+);
+width = 577;
+}
+);
+note = uni18BF;
+unicode = 6335;
+},
+{
+glyphname = "shoy-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (289,-185);
+ref = ring_top.canadian;
+}
+);
+width = 930;
+}
+);
+note = uni18C0;
+unicode = 6336;
+},
+{
+glyphname = "shay-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (289,-185);
+ref = ring_top.canadian;
+}
+);
+width = 930;
+}
+);
+note = uni18C1;
+unicode = 6337;
+},
+{
+glyphname = "shwoy-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (534,-185);
+ref = ring_top.canadian;
+}
+);
+width = 1175;
+}
+);
+note = uni18C2;
+unicode = 6338;
+},
+{
+glyphname = "yoy-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (317,0);
+ref = ring_top.canadian;
+}
+);
+width = 600;
+}
+);
+note = uni18C3;
+unicode = 6339;
+},
+{
+glyphname = "yay-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (13,0);
+ref = ring_top.canadian;
+}
+);
+width = 600;
+}
+);
+note = uni18C4;
+unicode = 6340;
+},
+{
+glyphname = "ray-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (185,0);
+ref = ring_top.canadian;
+}
+);
+width = 577;
+}
+);
+note = uni18C5;
+unicode = 6341;
+},
+{
+glyphname = "nwi-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ni-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni18C6;
+unicode = 6342;
+},
+{
+glyphname = "nwiOjibway-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (826,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni18C7;
+unicode = 6343;
+},
+{
+glyphname = "nwii-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (434,-185);
+ref = dot_top;
+}
+);
+width = 1071;
+}
+);
+note = uni18C8;
+unicode = 6344;
+},
+{
+glyphname = "nwiiOjibway-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (189,-185);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (826,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni18C9;
+unicode = 6345;
+},
+{
+glyphname = "nwo-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "no-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni18CA;
+unicode = 6346;
+},
+{
+glyphname = "nwoOjibway-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (826,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni18CB;
+unicode = 6347;
+},
+{
+glyphname = "nwoo-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (630,-185);
+ref = dot_top;
+}
+);
+width = 1071;
+}
+);
+note = uni18CC;
+unicode = 6348;
+},
+{
+glyphname = "nwooOjibway-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (385,-185);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (826,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni18CD;
+unicode = 6349;
+},
+{
+glyphname = "rwee-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "reRCree-canadian";
+}
+);
+width = 1121;
+}
+);
+note = uni18CE;
+unicode = 6350;
+},
+{
+glyphname = "rwi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ri-canadian";
+}
+);
+width = 1121;
+}
+);
+note = uni18CF;
+unicode = 6351;
+},
+{
+glyphname = "rwii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (428,-185);
+ref = dot_top;
+}
+);
+width = 1121;
+}
+);
+note = uni18D0;
+unicode = 6352;
+},
+{
+glyphname = "rwo-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ro-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni18D1;
+unicode = 6353;
+},
+{
+glyphname = "rwoo-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (403,0);
+ref = dot_top;
+}
+);
+width = 822;
+}
+);
+note = uni18D2;
+unicode = 6354;
+},
+{
+glyphname = "rwa-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ra-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni18D3;
+unicode = 6355;
+},
+{
+glyphname = "pOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(172,357,l),
+(329,593,l),
+(249,593,l),
+(307,357,l),
+(411,357,l),
+(415,377,l),
+(323,714,l),
+(298,714,l),
+(62,377,l),
+(58,357,l)
+);
+}
+);
+width = 425;
+}
+);
+metricLeft = "kkCarrier-canadian";
+note = uni18D4;
+unicode = 6356;
+},
+{
+glyphname = "tOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 444;
+}
+);
+metricRight = "=|";
+note = uni1422;
+unicode = 6357;
+},
+{
+glyphname = "kOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(190,357,l),
+(220,498,l),
+(199,497,l),
+(202,471,o),
+(234,449,o),
+(275,449,cs),
+(361,449,o),
+(414,526,o),
+(414,601,cs),
+(414,672,o),
+(363,720,o),
+(282,720,cs),
+(202,720,o),
+(145,675,o),
+(126,586,cs),
+(77,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(243,530,o),
+(228,545,o),
+(228,569,cs),
+(228,599,o),
+(248,640,o),
+(279,640,cs),
+(302,640,o),
+(316,625,o),
+(316,600,cs),
+(316,570,o),
+(295,530,o),
+(265,530,cs)
+);
+}
+);
+width = 389;
+}
+);
+metricLeft = "k-canadian";
+metricRight = "k-canadian";
+note = uni18D6;
+unicode = 6358;
+},
+{
+glyphname = "cOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(190,357,l),
+(240,593,ls),
+(246,620,o),
+(262,633,o),
+(282,633,cs),
+(308,633,o),
+(319,617,o),
+(313,589,cs),
+(307,563,l),
+(412,563,l),
+(416,579,ls),
+(433,659,o),
+(384,720,o),
+(288,720,cs),
+(201,720,o),
+(145,673,o),
+(127,591,cs),
+(77,357,l)
+);
+}
+);
+width = 379;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni18D7;
+unicode = 6359;
+},
+{
+glyphname = "mOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(190,357,l),
+(243,609,l),
+(385,609,l),
+(408,714,l),
+(153,714,l),
+(77,357,l)
+);
+}
+);
+width = 352;
+}
+);
+metricLeft = "m-canadian";
+metricRight = "m-canadian";
+note = uni18D8;
+unicode = 6360;
+},
+{
+glyphname = "nOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(337,442,o),
+(398,510,o),
+(398,593,cs),
+(398,616,o),
+(390,639,o),
+(375,655,c),
+(358,609,l),
+(521,609,l),
+(543,714,l),
+(272,714,ls),
+(174,714,o),
+(114,648,o),
+(114,562,cs),
+(114,492,o),
+(165,442,o),
+(246,442,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(226,523,o),
+(212,539,o),
+(212,563,cs),
+(212,593,o),
+(229,634,o),
+(263,634,cs),
+(286,634,o),
+(300,617,o),
+(300,593,cs),
+(300,563,o),
+(282,523,o),
+(249,523,cs)
+);
+}
+);
+width = 488;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "n-canadian";
+note = uni18D9;
+unicode = 6361;
+},
+{
+glyphname = "sOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(190,357,l),
+(221,502,l),
+(137,457,l),
+(181,457,ls),
+(299,457,o),
+(377,527,o),
+(405,656,cs),
+(417,714,l),
+(304,714,l),
+(293,661,ls),
+(276,580,o),
+(234,546,o),
+(152,546,cs),
+(117,546,l),
+(77,357,l)
+);
+}
+);
+width = 375;
+}
+);
+metricLeft = "s-canadian";
+metricRight = "s-canadian";
+note = uni18DA;
+unicode = 6362;
+},
+{
+color = 1;
+glyphname = "shOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(292,352,o),
+(345,396,o),
+(369,486,cs),
+(397,592,ls),
+(406,624,o),
+(419,638,o),
+(442,638,cs),
+(467,638,o),
+(478,620,o),
+(472,592,cs),
+(466,564,l),
+(569,564,l),
+(574,586,ls),
+(591,668,o),
+(538,721,o),
+(446,721,cs),
+(362,721,o),
+(309,678,o),
+(285,587,cs),
+(257,481,ls),
+(249,450,o),
+(235,436,o),
+(212,436,cs),
+(187,436,o),
+(177,453,o),
+(182,481,cs),
+(188,509,l),
+(86,509,l),
+(81,487,ls),
+(64,406,o),
+(117,352,o),
+(208,352,cs)
+);
+}
+);
+width = 536;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "c-canadian";
+note = uni18DB;
+unicode = 6363;
+},
+{
+color = 9;
+glyphname = "easternw-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (-46,-318);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (172,0);
+ref = "glottalstop-canadian";
+}
+);
+width = 604;
+}
+);
+note = uni18DC;
+unicode = 6364;
+},
+{
+color = 9;
+glyphname = "westernw-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (775,-318);
+ref = dot_top;
+scale = (-1,1);
+},
+{
+alignment = -1;
+ref = "glottalstop-canadian";
+}
+);
+width = 604;
+}
+);
+metricLeft = "glottalstop-canadian";
+note = uni18DD;
+unicode = 6365;
+},
+{
+glyphname = "rweRCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "reRCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (876,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1121;
+}
+);
+note = uni18E0;
+unicode = 6368;
+},
+{
+glyphname = "looWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+}
+);
+width = 577;
+}
+);
+note = uni18E1;
+unicode = 6369;
+},
+{
+glyphname = "laaWestCree-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (332,0);
+ref = dot_top;
+}
+);
+width = 577;
+}
+);
+note = uni18E2;
+unicode = 6370;
+},
+{
+glyphname = "thwe-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "the-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (760,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1005;
+}
+);
+note = uni18E3;
+unicode = 6371;
+},
+{
+glyphname = "thwa-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (702,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 947;
+}
+);
+note = uni18E4;
+unicode = 6372;
+},
+{
+glyphname = "tthwe-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "tthe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (751,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 996;
+}
+);
+note = uni18E5;
+unicode = 6373;
+},
+{
+glyphname = "tthoo-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ttho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (203,0);
+ref = dot_top;
+}
+);
+width = 649;
+}
+);
+note = uni18E6;
+unicode = 6374;
+},
+{
+glyphname = "tthaa-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ttha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (224,0);
+ref = dot_top;
+}
+);
+width = 649;
+}
+);
+note = uni18E7;
+unicode = 6375;
+},
+{
+glyphname = "tlhwe-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "tlhe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (633,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 878;
+}
+);
+note = uni18E8;
+unicode = 6376;
+},
+{
+glyphname = "tlhoo-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "tlho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (228,0);
+ref = dot_top;
+}
+);
+width = 633;
+}
+);
+note = uni18E9;
+unicode = 6377;
+},
+{
+glyphname = "shweSayisi-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "sheSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (622,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni18EA;
+unicode = 6378;
+},
+{
+glyphname = "shooSayisi-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "shoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (384,0);
+ref = dot_top;
+}
+);
+width = 622;
+}
+);
+note = uni18EB;
+unicode = 6379;
+},
+{
+color = 9;
+glyphname = "hooSayisi-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "hoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (481,0);
+ref = dot_top;
+}
+);
+width = 725;
+}
+);
+note = uni18EC;
+unicode = 6380;
+},
+{
+color = 9;
+glyphname = "gwuCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "guCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (883,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1128;
+}
+);
+note = uni18ED;
+unicode = 6381;
+},
+{
+color = 9;
+glyphname = "deneGeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "geCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (287,0);
+ref = dot_top;
+}
+);
+width = 760;
+}
+);
+note = uni18EE;
+unicode = 6382;
+},
+{
+color = 9;
+glyphname = "gaaCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (297,0);
+ref = dot_top;
+}
+);
+width = 760;
+}
+);
+note = uni18EF;
+unicode = 6383;
+},
+{
+color = 9;
+glyphname = "gwaCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (760,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1005;
+}
+);
+note = uni18F0;
+unicode = 6384;
+},
+{
+color = 9;
+glyphname = "juuSayisi-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "juSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (288,0);
+ref = dot_top;
+}
+);
+width = 763;
+}
+);
+note = uni18F1;
+unicode = 6385;
+},
+{
+color = 9;
+glyphname = "jwaCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "jaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (807,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1052;
+}
+);
+note = uni18F2;
+unicode = 6386;
+},
+{
+glyphname = "lBeaverDene-canadian";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "pWestCree-canadian";
+}
+);
+width = 223;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+unicode = 6387;
+},
+{
+glyphname = "rBeaverDene-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(190,357,l),
+(226,529,ls),
+(237,580,o),
+(264,604,o),
+(312,604,cs),
+(323,604,l),
+(348,720,l),
+(340,720,ls),
+(286,720,o),
+(247,686,o),
+(235,626,c),
+(238,626,l),
+(257,714,l),
+(153,714,l),
+(77,357,l)
+);
+}
+);
+width = 278;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni18F4;
+unicode = 6388;
+},
+{
+color = 6;
+glyphname = "sDentalCarrier-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(230,189,ls),
+(323,189,o),
+(382,233,o),
+(382,315,cs),
+(382,371,o),
+(342,409,o),
+(275,409,cs),
+(225,409,ls),
+(203,409,o),
+(192,417,o),
+(192,432,cs),
+(192,454,o),
+(209,463,o),
+(234,463,cs),
+(410,463,l),
+(428,546,l),
+(246,546,ls),
+(153,546,o),
+(94,502,o),
+(94,420,cs),
+(94,363,o),
+(134,326,o),
+(201,326,cs),
+(250,326,ls),
+(272,326,o),
+(283,318,o),
+(283,304,cs),
+(283,282,o),
+(266,272,o),
+(241,272,cs),
+(66,272,l),
+(48,189,l)
+);
+}
+);
+width = 428;
+}
+);
+metricLeft = "shCarrier-canadian";
+metricRight = "=|";
+note = uni18F5;
+unicode = 6389;
+},
+{
+glyphname = "pWestCree-canadian.base";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "pWestCree-canadian";
+}
+);
+width = 223;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.base";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "c-canadian";
+}
+);
+width = 379;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "thSayisi-canadian.base";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "thSayisi-canadian";
+}
+);
+width = 379;
+}
+);
+metricLeft = "=|c-canadian";
+note = uni14A2;
+},
+{
+glyphname = "mWestCree-canadian.base";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "mWestCree-canadian";
+}
+);
+width = 378;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+glyphname = "pWestCree-canadian.mid";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "pWestCree-canadian";
+}
+);
+width = 222;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.mid";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "c-canadian";
+}
+);
+width = 379;
+}
+);
+metricLeft = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "mWestCree-canadian.mid";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "mWestCree-canadian";
+}
+);
+width = 377;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+color = 11;
+glyphname = "ngaai-canadian.nunavik";
+lastChange = "2023-01-13 15:28:59 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (673,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (852,0);
+ref = ring_top.canadian;
+}
+);
+width = 1280;
+}
+);
+note = uni158E;
+},
+{
+color = 11;
+glyphname = "ngi-canadian.nunavik";
+lastChange = "2023-01-13 15:28:59 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (673,0);
+ref = "ci-canadian";
+}
+);
+width = 1280;
+}
+);
+note = uni158F;
+},
+{
+color = 11;
+glyphname = "ngii-canadian.nunavik";
+lastChange = "2023-01-13 15:28:59 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (673,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (891,0);
+ref = dot_top;
+}
+);
+width = 1280;
+}
+);
+note = uni1590;
+},
+{
+color = 11;
+glyphname = "ngo-canadian.nunavik";
+lastChange = "2023-01-13 15:28:59 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (673,0);
+ref = "co-canadian";
+}
+);
+width = 1278;
+}
+);
+note = uni1591;
+},
+{
+color = 11;
+glyphname = "ngoo-canadian.nunavik";
+lastChange = "2023-01-13 15:28:59 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "ngo-canadian.nunavik";
+},
+{
+anchor = top_right_can;
+pos = (1042,0);
+ref = dot_top;
+}
+);
+width = 1278;
+}
+);
+note = uni1592;
+},
+{
+color = 11;
+glyphname = "nga-canadian.nunavik";
+lastChange = "2023-01-13 15:28:59 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (673,0);
+ref = "ca-canadian";
+}
+);
+width = 1279;
+}
+);
+note = uni1593;
+},
+{
+color = 11;
+glyphname = "ngaa-canadian.nunavik";
+lastChange = "2023-01-13 15:28:59 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (673,0);
+ref = "ca-canadian";
+},
+{
+anchor = top_left_can;
+pos = (717,0);
+ref = dot_top;
+}
+);
+width = 1279;
+}
+);
+note = uni1594;
+},
+{
+color = 11;
+glyphname = "ng-canadian.nunavik";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(584,176,o),
+(642,257,o),
+(642,338,cs),
+(642,402,o),
+(601,447,o),
+(540,447,cs),
+(503,447,o),
+(471,431,o),
+(460,401,c),
+(477,371,l),
+(516,555,l),
+(350,555,l),
+(345,493,l),
+(383,516,o),
+(401,565,o),
+(401,604,cs),
+(401,673,o),
+(349,722,o),
+(268,722,cs),
+(174,722,o),
+(116,654,o),
+(116,571,cs),
+(116,500,o),
+(168,450,o),
+(245,450,cs),
+(445,450,l),
+(394,515,l),
+(357,336,ls),
+(338,250,o),
+(382,176,o),
+(483,176,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(469,257,o),
+(454,273,o),
+(454,297,cs),
+(454,327,o),
+(474,368,o),
+(505,368,cs),
+(527,368,o),
+(541,352,o),
+(541,328,cs),
+(541,298,o),
+(521,257,o),
+(491,257,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(229,531,o),
+(214,547,o),
+(214,571,cs),
+(214,601,o),
+(233,641,o),
+(266,641,cs),
+(289,641,o),
+(304,624,o),
+(304,600,cs),
+(304,570,o),
+(284,531,o),
+(252,531,cs)
+);
+}
+);
+width = 673;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+color = 11;
+glyphname = "ngai-canadian.nunavik";
+lastChange = "2023-01-13 15:28:59 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (673,0);
+ref = "ce-canadian";
+}
+);
+width = 1279;
+}
+);
+note = uni1670;
+},
+{
+color = 11;
+glyphname = "ke-canadian.square";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (465,714);
+},
+{
+name = top_left_can;
+pos = (251,714);
+},
+{
+name = top_right_can;
+pos = (698,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(629,0,l),
+(781,714,l),
+(480,714,ls),
+(238,714,o),
+(87,597,o),
+(87,381,cs),
+(87,231,o),
+(190,134,o),
+(359,134,cs),
+(491,134,l),
+(463,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(298,279,o),
+(251,320,o),
+(251,392,cs),
+(251,496,o),
+(315,569,o),
+(440,569,cs),
+(584,569,l),
+(522,279,l),
+(388,279,ls)
+);
+}
+);
+width = 747;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146B;
+},
+{
+color = 11;
+glyphname = "ki-canadian.square";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (479,714);
+},
+{
+name = top_left_can;
+pos = (246,714);
+},
+{
+name = top_right_can;
+pos = (711,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(176,0,l),
+(205,134,l),
+(350,134,ls),
+(581,134,o),
+(733,252,o),
+(733,467,cs),
+(733,617,o),
+(629,714,o),
+(460,714,cs),
+(162,714,l),
+(10,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(297,569,l),
+(435,569,ls),
+(521,569,o),
+(569,529,o),
+(569,456,cs),
+(569,352,o),
+(504,279,o),
+(385,279,cs),
+(236,279,l)
+);
+}
+);
+width = 748;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni146D;
+},
+{
+color = 11;
+glyphname = "kii-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (283,0);
+ref = dot_top;
+}
+);
+width = 749;
+}
+);
+note = uni146E;
+},
+{
+color = 11;
+glyphname = "ko-canadian.square";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (466,714);
+},
+{
+name = top_left_can;
+pos = (252,714);
+},
+{
+name = top_right_can;
+pos = (699,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(630,0,l),
+(782,714,l),
+(615.996,714,l),
+(588,580,l),
+(442,580,ls),
+(211,580,o),
+(59,462,o),
+(59,247,cs),
+(59,97,o),
+(163,0,o),
+(332,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(271,145,o),
+(224,185,o),
+(224,258,cs),
+(224,362,o),
+(288,435,o),
+(407,435,cs),
+(557,435,l),
+(495,145,l),
+(358,145,ls)
+);
+}
+);
+width = 748;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146F;
+},
+{
+color = 11;
+glyphname = "koo-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (504,0);
+ref = dot_top;
+}
+);
+width = 749;
+}
+);
+note = uni1470;
+},
+{
+color = 11;
+glyphname = "ka-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (479,714);
+},
+{
+name = top_left_can;
+pos = (246,714);
+},
+{
+name = top_right_can;
+pos = (712,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(311,0,ls),
+(553,0,o),
+(705,117,o),
+(705,333,cs),
+(705,483,o),
+(601,580,o),
+(432,580,cs),
+(300,580,l),
+(328,714,l),
+(162,714,l),
+(10,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(269,435,l),
+(404,435,ls),
+(493,435,o),
+(540,394,o),
+(540,322,cs),
+(540,218,o),
+(476,145,o),
+(351,145,cs),
+(207,145,l)
+);
+}
+);
+width = 749;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1472;
+},
+{
+color = 11;
+glyphname = "kaa-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+}
+);
+width = 749;
+}
+);
+note = uni1473;
+},
+{
+color = 11;
+glyphname = "kweWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (749,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 994;
+}
+);
+note = uni1475;
+},
+{
+color = 11;
+glyphname = "kwiiWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (283,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (749,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 994;
+}
+);
+note = uni1479;
+},
+{
+color = 11;
+glyphname = "kwoWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (749,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 994;
+}
+);
+note = uni147B;
+},
+{
+color = 11;
+glyphname = "kwooWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (504,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (749,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 994;
+}
+);
+note = uni147D;
+},
+{
+color = 11;
+glyphname = "kwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (749,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 994;
+}
+);
+note = uni147F;
+},
+{
+color = 11;
+glyphname = "kwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (749,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 994;
+}
+);
+note = uni1481;
+},
+{
+color = 11;
+glyphname = "ce-canadian.square";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (458,714);
+},
+{
+name = top_left_can;
+pos = (223,714);
+},
+{
+name = top_right_can;
+pos = (693,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(624,0,l),
+(703,374,ls),
+(749,588,o),
+(639,729,o),
+(423,729,cs),
+(241,729,o),
+(123,627,o),
+(83,442,cs),
+(71,390,l),
+(236,390,l),
+(244,429,ls),
+(266,529,o),
+(321,579,o),
+(411,579,cs),
+(520,579,o),
+(566,510,o),
+(539,386,cs),
+(458,0,l)
+);
+}
+);
+width = 735;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni1489;
+},
+{
+color = 11;
+glyphname = "ci-canadian.square";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (473,714);
+},
+{
+name = top_left_can;
+pos = (238,714);
+},
+{
+name = top_right_can;
+pos = (709,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(169,0,l),
+(256,410,ls),
+(281,525,o),
+(340,579,o),
+(437,579,cs),
+(536,579,o),
+(583,520,o),
+(562,419,cs),
+(556,390,l),
+(721,390,l),
+(725,412,ls),
+(765,599,o),
+(649,729,o),
+(445,729,cs),
+(259,729,o),
+(137,629,o),
+(97,443,cs),
+(3,0,l)
+);
+}
+);
+width = 734;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+},
+{
+color = 11;
+glyphname = "cii-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (278,0);
+ref = dot_top;
+}
+);
+width = 735;
+}
+);
+note = uni148C;
+},
+{
+color = 11;
+glyphname = "co-canadian.square";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (458,714);
+},
+{
+name = top_left_can;
+pos = (223,714);
+},
+{
+name = top_right_can;
+pos = (693,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(519,-15,o),
+(642,85,o),
+(682,271,cs),
+(776,714,l),
+(610,714,l),
+(522,304,ls),
+(498,189,o),
+(438,135,o),
+(342,135,cs),
+(242,135,o),
+(194,194,o),
+(215,295,cs),
+(222,324,l),
+(57,324,l),
+(53,302,ls),
+(13,115,o),
+(130,-15,o),
+(334,-15,cs)
+);
+}
+);
+width = 735;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+},
+{
+color = 11;
+glyphname = "coo-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (497,0);
+ref = dot_top;
+}
+);
+width = 735;
+}
+);
+note = uni148E;
+},
+{
+color = 11;
+glyphname = "ca-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (473,714);
+},
+{
+name = top_left_can;
+pos = (239,714);
+},
+{
+name = top_right_can;
+pos = (709,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(538,-15,o),
+(656,87,o),
+(696,272,cs),
+(708,324,l),
+(543,324,l),
+(535,285,ls),
+(513,185,o),
+(458,135,o),
+(368,135,cs),
+(259,135,o),
+(213,204,o),
+(240,328,cs),
+(321,714,l),
+(155,714,l),
+(76,340,ls),
+(30,126,o),
+(140,-15,o),
+(356,-15,cs)
+);
+}
+);
+width = 735;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+},
+{
+color = 11;
+glyphname = "caa-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (43,0);
+ref = dot_top;
+}
+);
+width = 735;
+}
+);
+note = uni1491;
+},
+{
+color = 11;
+glyphname = "me-canadian.square";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (407,714);
+},
+{
+name = top_double;
+pos = (589,714);
+},
+{
+name = top_left_can;
+pos = (216,714);
+},
+{
+name = top_right_can;
+pos = (589,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(520,0,l),
+(672,714,l),
+(134,714,l),
+(103,565,l),
+(473,565,l),
+(354,0,l)
+);
+}
+);
+width = 638;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+},
+{
+color = 11;
+glyphname = "mi-canadian.square";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (431,714);
+},
+{
+name = top_left_can;
+pos = (246,714);
+},
+{
+name = top_right_can;
+pos = (616,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(176,0,l),
+(297,565,l),
+(668,565,l),
+(699,714,l),
+(162,714,l),
+(10,0,l)
+);
+}
+);
+width = 638;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+},
+{
+color = 11;
+glyphname = "mii-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (236,0);
+ref = dot_top;
+}
+);
+width = 639;
+}
+);
+note = uni14A6;
+},
+{
+color = 11;
+glyphname = "mo-canadian.square";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (407,714);
+},
+{
+name = top_double;
+pos = (589,714);
+},
+{
+name = top_left_can;
+pos = (217,714);
+},
+{
+name = top_right_can;
+pos = (589,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(520,0,l),
+(672,714,l),
+(506,714,l),
+(385,149,l),
+(14,149,l),
+(-17,0,l)
+);
+}
+);
+width = 638;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+},
+{
+color = 11;
+glyphname = "moo-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (394,0);
+ref = dot_top;
+}
+);
+width = 639;
+}
+);
+note = uni14A8;
+},
+{
+color = 11;
+glyphname = "ma-canadian.square";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (431,714);
+},
+{
+name = top_left_can;
+pos = (246,714);
+},
+{
+name = top_right_can;
+pos = (616,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(548,0,l),
+(579,149,l),
+(208,149,l),
+(328,714,l),
+(162,714,l),
+(10,0,l)
+);
+}
+);
+width = 638;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+},
+{
+color = 11;
+glyphname = "maa-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+}
+);
+width = 639;
+}
+);
+note = uni14AB;
+},
+{
+color = 11;
+glyphname = "ne-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (546,714);
+},
+{
+name = top_left_can;
+pos = (362,714);
+},
+{
+name = top_right_can;
+pos = (732,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(579,-15,o),
+(678,75,o),
+(716,251,cs),
+(814,714,l),
+(140,714,l),
+(109,568,l),
+(247,568,l),
+(188,292,ls),
+(148,105,o),
+(238,-15,o),
+(419,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(362,136,o),
+(331,183,o),
+(348,264,cs),
+(412,568,l),
+(618,568,l),
+(550,250,ls),
+(533,172,o),
+(497,136,o),
+(433,136,cs)
+);
+}
+);
+width = 774;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C0;
+},
+{
+color = 11;
+glyphname = "ni-canadian.square";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (423,714);
+},
+{
+name = top_left_can;
+pos = (238,714);
+},
+{
+name = top_right_can;
+pos = (609,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(456,-15,o),
+(556,75,o),
+(594,251,cs),
+(661,568,l),
+(800,568,l),
+(830,714,l),
+(155,714,l),
+(66,292,ls),
+(26,105,o),
+(116,-15,o),
+(297,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(240,136,o),
+(209,184,o),
+(226,264,cs),
+(290,568,l),
+(495,568,l),
+(428,250,ls),
+(411,173,o),
+(375,136,o),
+(311,136,cs)
+);
+}
+);
+width = 775;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+},
+{
+color = 11;
+glyphname = "nii-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (228,0);
+ref = dot_top;
+}
+);
+width = 774;
+}
+);
+note = uni14C3;
+},
+{
+color = 11;
+glyphname = "no-canadian.square";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (547,714);
+},
+{
+name = top_double;
+pos = (557,714);
+},
+{
+name = top_left_can;
+pos = (363,714);
+},
+{
+name = top_right_can;
+pos = (723,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(663,0,l),
+(753,422,ls),
+(792,609,o),
+(702,729,o),
+(522,729,cs),
+(362,729,o),
+(263,639,o),
+(225,463,cs),
+(157,146,l),
+(19,146,l),
+(-11,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(391,464,ls),
+(408,541,o),
+(444,578,o),
+(508,578,cs),
+(579,578,o),
+(610,530,o),
+(593,450,cs),
+(528,146,l),
+(323,146,l)
+);
+}
+);
+width = 774;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C4;
+},
+{
+color = 11;
+glyphname = "noo-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (351,0);
+ref = dot_top;
+}
+);
+width = 774;
+}
+);
+note = uni14C5;
+},
+{
+color = 11;
+glyphname = "na-canadian.square";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (423,714);
+},
+{
+name = top_double;
+pos = (433,714);
+},
+{
+name = top_left_can;
+pos = (238,714);
+},
+{
+name = top_right_can;
+pos = (609,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(677,0,l),
+(709,146,l),
+(570,146,l),
+(629,422,ls),
+(669,609,o),
+(579,729,o),
+(398,729,cs),
+(239,729,o),
+(139,639,o),
+(101,463,cs),
+(3,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(267,464,ls),
+(284,542,o),
+(321,578,o),
+(384,578,cs),
+(455,578,o),
+(486,531,o),
+(469,450,cs),
+(405,146,l),
+(200,146,l)
+);
+}
+);
+width = 774;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+},
+{
+color = 11;
+glyphname = "naa-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (229,0);
+ref = dot_top;
+}
+);
+width = 774;
+}
+);
+note = uni14C8;
+},
+{
+color = 11;
+glyphname = "nweWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (774,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1019;
+}
+);
+note = uni14CA;
+},
+{
+color = 11;
+glyphname = "nwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (774,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1019;
+}
+);
+note = uni14CC;
+},
+{
+color = 11;
+glyphname = "nwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (229,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (774,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1019;
+}
+);
+note = uni14CE;
+},
+{
+color = 11;
+glyphname = "se-canadian.square";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (245,714);
+},
+{
+name = top_right_can;
+pos = (701,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(627,0,l),
+(695,319,l),
+(422,319,ls),
+(298,319,o),
+(255,372,o),
+(284,507,cs),
+(328,714,l),
+(162,714,l),
+(118,507,ls),
+(76,309,o),
+(191,174,o),
+(393,174,cs),
+(539,174,l),
+(507,215,l),
+(461,0,l)
+);
+}
+);
+width = 746;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14ED;
+},
+{
+color = 11;
+glyphname = "si-canadian.square";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (246,714);
+},
+{
+name = top_right_can;
+pos = (701,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(177,0,l),
+(223,216,l),
+(174,175,l),
+(317,175,ls),
+(560,175,o),
+(685,272,o),
+(733,494,cs),
+(780,714,l),
+(614,714,l),
+(568,500,ls),
+(543,383,o),
+(463,319,o),
+(345,319,cs),
+(79,319,l),
+(11,0,l)
+);
+}
+);
+width = 746;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+},
+{
+color = 11;
+glyphname = "sii-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (506,0);
+ref = dot_top;
+}
+);
+width = 747;
+}
+);
+note = uni14F0;
+},
+{
+color = 11;
+glyphname = "so-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (696,714);
+},
+{
+name = top_left_can;
+pos = (245,714);
+},
+{
+name = top_right_can;
+pos = (696,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(176,0,l),
+(222,214,ls),
+(247,331,o),
+(326,395,o),
+(445,395,cs),
+(712,395,l),
+(779,714,l),
+(613,714,l),
+(567,498,l),
+(617,539,l),
+(473,539,ls),
+(230,539,o),
+(104,442,o),
+(57,220,cs),
+(10,0,l)
+);
+}
+);
+width = 747;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+},
+{
+color = 11;
+glyphname = "soo-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (501,0);
+ref = dot_top;
+}
+);
+width = 747;
+}
+);
+note = uni14F2;
+},
+{
+color = 11;
+glyphname = "sa-canadian.square";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (247,714);
+},
+{
+name = top_right_can;
+pos = (698,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(629,0,l),
+(673,207,ls),
+(715,405,o),
+(600,540,o),
+(398,540,cs),
+(252,540,l),
+(284,499,l),
+(330,714,l),
+(163,714,l),
+(96,395,l),
+(368,395,ls),
+(493,395,o),
+(536,342,o),
+(507,207,cs),
+(463,0,l)
+);
+}
+);
+width = 747;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+},
+{
+color = 11;
+glyphname = "saa-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+}
+);
+width = 747;
+}
+);
+note = uni14F5;
+},
+{
+color = 11;
+glyphname = "sho-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (467,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(619,0,l),
+(648,135,l),
+(290,135,ls),
+(237,135,o),
+(208,156,o),
+(208,196,cs),
+(208,255,o),
+(248,291,o),
+(323,291,cs),
+(461,291,ls),
+(635,291,o),
+(741,372,o),
+(741,533,cs),
+(741,644,o),
+(666,714,o),
+(543,714,cs),
+(163,714,l),
+(135,579,l),
+(494,579,ls),
+(548,579,o),
+(576,558,o),
+(576,519,cs),
+(576,458,o),
+(536,424,o),
+(462,424,cs),
+(324,424,ls),
+(149,424,o),
+(43,341,o),
+(43,181,cs),
+(43,71,o),
+(119,0,o),
+(242,0,cs)
+);
+}
+);
+width = 740;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+color = 11;
+glyphname = "shoo-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (274,0);
+ref = dot_top;
+}
+);
+width = 740;
+}
+);
+note = g728;
+},
+{
+color = 11;
+glyphname = "sha-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (511,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(399,0,ls),
+(576,0,o),
+(680,83,o),
+(680,245,cs),
+(680,355,o),
+(607,424,o),
+(485,424,cs),
+(351,424,ls),
+(297,424,o),
+(269,444,o),
+(269,485,cs),
+(269,546,o),
+(308,579,o),
+(382,579,cs),
+(743,579,l),
+(771,714,l),
+(384,714,ls),
+(210,714,o),
+(104,632,o),
+(104,470,cs),
+(104,360,o),
+(177,291,o),
+(300,291,cs),
+(433,291,ls),
+(487,291,o),
+(514,271,o),
+(514,231,cs),
+(514,170,o),
+(476,135,o),
+(401,135,cs),
+(39,135,l),
+(10,0,l)
+);
+}
+);
+width = 740;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+color = 11;
+glyphname = "shaa-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (316,0);
+ref = dot_top;
+}
+);
+width = 740;
+}
+);
+note = g730;
+},
+{
+color = 11;
+glyphname = "ye-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (212,714);
+},
+{
+name = top_right_can;
+pos = (717,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(647,0,l),
+(715,319,l),
+(294,319,l),
+(294,234,l),
+(783,605,l),
+(689,726,l),
+(22,216,l),
+(13,174,l),
+(519,174,l),
+(481,0,l)
+);
+}
+);
+width = 761;
+}
+);
+metricLeft = "ye-canadian";
+note = uni1526;
+},
+{
+color = 11;
+glyphname = "yi-canadian.square";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (240,714);
+},
+{
+name = top_right_can;
+pos = (745,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(172,0,l),
+(209,174,l),
+(714,174,l),
+(723,216,l),
+(243,726,l),
+(119,617,l),
+(477,234,l),
+(494,319,l),
+(73,319,l),
+(5,0,l)
+);
+}
+);
+width = 761;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni1528;
+},
+{
+color = 11;
+glyphname = "yii-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (44,0);
+ref = dot_top;
+}
+);
+width = 761;
+}
+);
+note = uni1529;
+},
+{
+color = 11;
+glyphname = "yo-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (718,714);
+},
+{
+name = top_left_can;
+pos = (213,714);
+},
+{
+name = top_right_can;
+pos = (718,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(687,97,l),
+(328,480,l),
+(311,395,l),
+(733,395,l),
+(800,714,l),
+(634,714,l),
+(597,540,l),
+(91,540,l),
+(82,498,l),
+(562,-12,l)
+);
+}
+);
+width = 761;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152A;
+},
+{
+color = 11;
+glyphname = "yoo-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (522,0);
+ref = dot_top;
+}
+);
+width = 761;
+}
+);
+note = uni152B;
+},
+{
+color = 11;
+glyphname = "ya-canadian.square";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (240,714);
+},
+{
+name = top_right_can;
+pos = (744,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(783,498,l),
+(792,540,l),
+(286,540,l),
+(324,714,l),
+(158,714,l),
+(90,395,l),
+(511,395,l),
+(511,480,l),
+(22,109,l),
+(116,-12,l)
+);
+}
+);
+width = 761;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152D;
+},
+{
+color = 11;
+glyphname = "yaa-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (44,0);
+ref = dot_top;
+}
+);
+width = 761;
+}
+);
+note = uni152E;
+},
+{
+color = 11;
+glyphname = "re-canadian.square";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (423,714);
+},
+{
+name = top_left_can;
+pos = (238,714);
+},
+{
+name = top_right_can;
+pos = (609,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(456,-15,o),
+(556,75,o),
+(594,251,cs),
+(661,568,l),
+(800,568,l),
+(830,714,l),
+(526,714,l),
+(428,250,ls),
+(411,173,o),
+(375,136,o),
+(311,136,cs),
+(240,136,o),
+(209,184,o),
+(226,264,cs),
+(321,714,l),
+(155,714,l),
+(66,292,ls),
+(26,105,o),
+(116,-15,o),
+(297,-15,cs)
+);
+}
+);
+width = 775;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1542;
+},
+{
+color = 11;
+glyphname = "reRCree-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (546,714);
+},
+{
+name = top_left_can;
+pos = (362,714);
+},
+{
+name = top_right_can;
+pos = (732,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(579,-15,o),
+(678,75,o),
+(716,251,cs),
+(814,714,l),
+(649,714,l),
+(550,250,ls),
+(533,172,o),
+(497,136,o),
+(433,136,cs),
+(362,136,o),
+(331,183,o),
+(348,264,cs),
+(443,714,l),
+(140,714,l),
+(109,568,l),
+(247,568,l),
+(188,292,ls),
+(148,105,o),
+(238,-15,o),
+(419,-15,cs)
+);
+}
+);
+width = 774;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni1543;
+},
+{
+color = 11;
+glyphname = "leWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (547,714);
+},
+{
+name = top_left_can;
+pos = (362,714);
+},
+{
+name = top_right_can;
+pos = (733,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(292,0,l),
+(391,464,ls),
+(408,541,o),
+(444,577,o),
+(508,577,cs),
+(579,577,o),
+(610,530,o),
+(593,449,cs),
+(498,0,l),
+(663,0,l),
+(753,421,ls),
+(792,609,o),
+(703,728,o),
+(522,728,cs),
+(362,728,o),
+(263,639,o),
+(225,463,cs),
+(157,146,l),
+(19,146,l),
+(-11,0,l)
+);
+}
+);
+width = 779;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+},
+{
+color = 11;
+glyphname = "ri-canadian.square";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (423,714);
+},
+{
+name = top_left_can;
+pos = (241,714);
+},
+{
+name = top_right_can;
+pos = (609,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(168,0,l),
+(267,464,ls),
+(284,542,o),
+(321,578,o),
+(384,578,cs),
+(455,578,o),
+(486,531,o),
+(469,450,cs),
+(374,0,l),
+(677,0,l),
+(709,146,l),
+(570,146,l),
+(629,422,ls),
+(669,609,o),
+(579,729,o),
+(398,729,cs),
+(239,729,o),
+(139,639,o),
+(101,463,cs),
+(3,0,l)
+);
+}
+);
+width = 774;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+},
+{
+color = 11;
+glyphname = "rii-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (229,0);
+ref = dot_top;
+}
+);
+width = 774;
+}
+);
+note = uni1547;
+},
+{
+color = 11;
+glyphname = "ro-canadian.square";
+lastChange = "2023-01-13 15:28:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (470,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(176,0,l),
+(220,207,l),
+(129,134,l),
+(342,134,ls),
+(562,134,o),
+(714,252,o),
+(714,467,cs),
+(714,617,o),
+(610,714,o),
+(441,714,cs),
+(162,714,l),
+(131,569,l),
+(416,569,ls),
+(502,569,o),
+(549,528,o),
+(549,456,cs),
+(549,350,o),
+(484,279,o),
+(354,279,cs),
+(69,279,l),
+(10,0,l)
+);
+}
+);
+width = 729;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1548;
+},
+{
+color = 11;
+glyphname = "loWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (470,714);
+},
+{
+name = top_left_can;
+pos = (246,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(309,0,ls),
+(535.996,0,o),
+(687,117,o),
+(687,333,cs),
+(687,483,o),
+(584,580,o),
+(415,580,cs),
+(226,580,l),
+(284,507,l),
+(329,714,l),
+(163,714,l),
+(103,435,l),
+(389,435,ls),
+(476,435,o),
+(523,394,o),
+(523,322,cs),
+(523,218,o),
+(459,145,o),
+(328,145,cs),
+(41,145,l),
+(10,0,l)
+);
+}
+);
+width = 722;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+},
+{
+color = 11;
+glyphname = "ra-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (449,714);
+},
+{
+name = top_right_can;
+pos = (673,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(602,0,l),
+(663,279,l),
+(376,279,ls),
+(289,279,o),
+(242,320,o),
+(242,392,cs),
+(242,496,o),
+(307,569,o),
+(437,569,cs),
+(724,569,l),
+(755,714,l),
+(456,714,ls),
+(229,714,o),
+(78,597,o),
+(78,381,cs),
+(78,231,o),
+(182,134,o),
+(351,134,cs),
+(540,134,l),
+(481,207,l),
+(436,0,l)
+);
+}
+);
+width = 722;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+},
+{
+color = 11;
+glyphname = "raa-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (253,0);
+ref = dot_top;
+}
+);
+width = 722;
+}
+);
+note = uni154C;
+},
+{
+color = 11;
+glyphname = "laWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (673,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(603,0,l),
+(634,145,l),
+(348,145,ls),
+(261,145,o),
+(214,186,o),
+(214,258,cs),
+(214,364,o),
+(280,435,o),
+(409,435,cs),
+(696,435,l),
+(755,714,l),
+(589,714,l),
+(545,507,l),
+(636,580,l),
+(421,580,ls),
+(202,580,o),
+(50,462,o),
+(50,247,cs),
+(50,97,o),
+(153,0,o),
+(322,0,cs)
+);
+}
+);
+width = 722;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+},
+{
+color = 11;
+glyphname = "reWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:50 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(604,0,l),
+(899,208,l),
+(814,329,l),
+(597,179,l),
+(653,134,l),
+(703,374,ls),
+(749,589,o),
+(640,729,o),
+(424,729,cs),
+(253,729,o),
+(123,630,o),
+(83,442,cs),
+(71,390,l),
+(236,390,l),
+(244,429,ls),
+(266,529,o),
+(321,579,o),
+(411,579,cs),
+(520,579,o),
+(566,510,o),
+(539,386,cs),
+(458,0,l)
+);
+}
+);
+width = 928;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+},
+{
+color = 11;
+glyphname = "riWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:50 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(362,0,l),
+(449,410,ls),
+(474,525,o),
+(533,579,o),
+(629,579,cs),
+(729,579,o),
+(777,520,o),
+(756,419,cs),
+(750,390,l),
+(914,390,l),
+(919,412,ls),
+(958,599,o),
+(841,729,o),
+(638,729,cs),
+(458,729,o),
+(329,629,o),
+(290,443,cs),
+(224,133,l),
+(291,153,l),
+(122,320,l),
+(9,208,l),
+(216,0,l)
+);
+}
+);
+width = 928;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+},
+{
+color = 11;
+glyphname = "roWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:50 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(514,-15,o),
+(642,85,o),
+(682,271,cs),
+(748,581,l),
+(680,561,l),
+(850,394,l),
+(963,506,l),
+(756,714,l),
+(609,714,l),
+(522,304,ls),
+(497,189,o),
+(438,135,o),
+(342,135,cs),
+(242,135,o),
+(194,194,o),
+(215,295,cs),
+(222,324,l),
+(57,324,l),
+(53,302,ls),
+(13,115,o),
+(130,-15,o),
+(334,-15,cs)
+);
+}
+);
+width = 929;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+},
+{
+color = 11;
+glyphname = "raWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:50 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(717,-15,o),
+(847,84,o),
+(888,272,cs),
+(899,324,l),
+(735,324,l),
+(726,285,ls),
+(704,185,o),
+(649,135,o),
+(559,135,cs),
+(450,135,o),
+(405,204,o),
+(431,328,cs),
+(512,714,l),
+(366,714,l),
+(72,506,l),
+(157,385,l),
+(373,535,l),
+(318,580,l),
+(267,340,ls),
+(222,125,o),
+(330,-15,o),
+(547,-15,cs)
+);
+}
+);
+width = 926;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+},
+{
+color = 11;
+glyphname = "theThCree-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (212,714);
+},
+{
+name = top_right_can;
+pos = (717,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(647,0,l),
+(658,52,l),
+(740,52,l),
+(756,124,l),
+(674,124,l),
+(715,319,l),
+(335,319,l),
+(350,273,l),
+(783,605,l),
+(689,726,l),
+(22,216,l),
+(13,174,l),
+(519,174,l),
+(508,124,l),
+(288,124,l),
+(273,52,l),
+(492,52,l),
+(481,0,l)
+);
+}
+);
+width = 812;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15A7;
+},
+{
+color = 11;
+glyphname = "thiThCree-canadian.square";
+lastChange = "2023-01-13 15:28:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (288,714);
+},
+{
+name = top_right_can;
+pos = (793,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(221,0,l),
+(232,52,l),
+(452,52,l),
+(467,124,l),
+(248,124,l),
+(259,174,l),
+(764,174,l),
+(773,216,l),
+(293,726,l),
+(169,617,l),
+(495,265,l),
+(519,319,l),
+(123,319,l),
+(82,124,l),
+(0,124,l),
+(-15,52,l),
+(66,52,l),
+(55,0,l)
+);
+}
+);
+width = 811;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+},
+{
+color = 11;
+glyphname = "thiiThCree-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (93,0);
+ref = dot_top;
+}
+);
+width = 812;
+}
+);
+note = uni15A9;
+},
+{
+color = 11;
+glyphname = "thoThCree-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (212,714);
+},
+{
+name = top_right_can;
+pos = (717,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(686,97,l),
+(360,449,l),
+(336,395,l),
+(732,395,l),
+(773,590,l),
+(855,590,l),
+(870,662,l),
+(789,662,l),
+(800,714,l),
+(633,714,l),
+(622,662,l),
+(403,662,l),
+(388,590,l),
+(607,590,l),
+(596,540,l),
+(91,540,l),
+(82,498,l),
+(562,-12,l)
+);
+}
+);
+width = 812;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+},
+{
+color = 11;
+glyphname = "thooThCree-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (522,0);
+ref = dot_top;
+}
+);
+width = 812;
+}
+);
+note = uni15AB;
+},
+{
+color = 11;
+glyphname = "thaThCree-canadian.square";
+lastChange = "2023-01-13 15:28:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (292,714);
+},
+{
+name = top_right_can;
+pos = (796,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(834,498,l),
+(843,540,l),
+(337,540,l),
+(348,590,l),
+(567,590,l),
+(583,662,l),
+(364,662,l),
+(375,714,l),
+(208,714,l),
+(197,662,l),
+(115,662,l),
+(100,590,l),
+(182,590,l),
+(141,395,l),
+(521,395,l),
+(506,441,l),
+(72,109,l),
+(167,-12,l)
+);
+}
+);
+width = 812;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+},
+{
+color = 11;
+glyphname = "thaaThCree-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (96,0);
+ref = dot_top;
+}
+);
+width = 812;
+}
+);
+note = uni15AD;
+},
+{
+color = 11;
+glyphname = "thweeWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (812,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1057;
+}
+);
+note = uni1677;
+},
+{
+color = 11;
+glyphname = "thwiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (812,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1057;
+}
+);
+note = uni1678;
+},
+{
+color = 11;
+glyphname = "thwiiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (93,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (812,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1057;
+}
+);
+note = uni1679;
+},
+{
+color = 11;
+glyphname = "thwoWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (812,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1057;
+}
+);
+note = uni167A;
+},
+{
+color = 11;
+glyphname = "thwooWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (522,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (812,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1057;
+}
+);
+note = uni167B;
+},
+{
+color = 11;
+glyphname = "thwaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (812,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1057;
+}
+);
+note = uni167C;
+},
+{
+color = 11;
+glyphname = "thwaaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (96,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (812,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1057;
+}
+);
+note = uni167D;
+},
+{
+color = 11;
+glyphname = "nwiOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (774,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1019;
+}
+);
+note = uni18C7;
+},
+{
+color = 11;
+glyphname = "nwiiOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (228,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (774,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1019;
+}
+);
+note = uni18C9;
+},
+{
+color = 11;
+glyphname = "nwoOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (774,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1019;
+}
+);
+note = uni18CB;
+},
+{
+color = 11;
+glyphname = "nwooOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (351,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (774,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1019;
+}
+);
+note = uni18CD;
+},
+{
+color = 11;
+glyphname = "looWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+}
+);
+width = 722;
+}
+);
+note = uni18E1;
+},
+{
+color = 11;
+glyphname = "laaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (477,0);
+ref = dot_top;
+}
+);
+width = 722;
+}
+);
+note = uni18E2;
+},
+{
+color = 0;
+glyphname = zero;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(599,593,o),
+(519,724,o),
+(346,724,cs),
+(171,724,o),
+(93,592,o),
+(93,357,cs),
+(93,114,o),
+(180,-10,o),
+(346,-10,cs),
+(518,-10,o),
+(599,108,o),
+(599,357,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(261,439,o),
+(263,589,o),
+(346,589,cs),
+(431,589,o),
+(431,438,o),
+(431,357,cs),
+(431,265,o),
+(426,125,o),
+(346,125,cs),
+(268,125,o),
+(261,265,o),
+(261,357,cs)
+);
+}
+);
+width = 651;
+}
+);
+unicode = 48;
+},
+{
+color = 0;
+glyphname = one;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(307,714,l),
+(69,522,l),
+(157,414,l),
+(244,484,ls),
+(260,497,o),
+(273,511,o),
+(290,530,c),
+(288,480,o),
+(288,438,o),
+(288,394,cs),
+(288,0,l),
+(459,0,l),
+(459,714,l)
+);
+}
+);
+width = 584;
+}
+);
+unicode = 49;
+},
+{
+color = 0;
+glyphname = two;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(620,0,l),
+(620,140,l),
+(332,140,l),
+(332,144,l),
+(406,216,ls),
+(493,297,o),
+(552,356,o),
+(581,421,cs),
+(596,453,o),
+(603,490,o),
+(603,530,cs),
+(603,643,o),
+(510,724,o),
+(372,724,cs),
+(249,724,o),
+(180,679,o),
+(110,616,c),
+(203,507,l),
+(261,557,o),
+(306,582,o),
+(353,582,cs),
+(399,582,o),
+(435,559,o),
+(435,507,cs),
+(435,467,o),
+(420,435,o),
+(380,388,cs),
+(359,364,o),
+(331,334,o),
+(295,297,cs),
+(114,112,l),
+(113.994,0,l)
+);
+}
+);
+width = 668;
+}
+);
+unicode = 50;
+},
+{
+color = 0;
+glyphname = three;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(595,662,o),
+(507,724,o),
+(364,724,cs),
+(245,724,o),
+(176,692,o),
+(117,652,c),
+(188,538,l),
+(219,560,o),
+(275,588,o),
+(338,588,cs),
+(394,588,o),
+(431,566,o),
+(431,518,cs),
+(431,448,o),
+(347,430,o),
+(276,430,cs),
+(226,430,l),
+(226,302,l),
+(275,302,ls),
+(390,302,o),
+(438,277,o),
+(438,213,cs),
+(438,159,o),
+(404,124,o),
+(302,124,cs),
+(246,124,o),
+(176,139,o),
+(115,170,c),
+(115,29,l),
+(175,5,o),
+(236,-10,o),
+(326,-10,cs),
+(490,-10,o),
+(617,60,o),
+(617,203,cs),
+(617,304,o),
+(553,360,o),
+(438,373,c),
+(438,376,l),
+(528,399,o),
+(595,460,o),
+(595,558,cs)
+);
+}
+);
+width = 660;
+}
+);
+unicode = 51;
+},
+{
+color = 0;
+glyphname = four;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(495,273,l),
+(495,715,l),
+(338,715,l),
+(30,270,l),
+(30,146,l),
+(328,146,l),
+(328,0,l),
+(495,0,l),
+(495,146,l),
+(582,146,l),
+(582,273,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(178,273,l),
+(286,428,ls),
+(305,457,o),
+(313,471,o),
+(327,501,c),
+(332,501,l),
+(332,495,o),
+(328,460,o),
+(328,398,cs),
+(328,273,l)
+);
+}
+);
+width = 613;
+}
+);
+unicode = 52;
+},
+{
+color = 0;
+glyphname = five;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(320,462,o),
+(299,456,o),
+(276,451,c),
+(288,573,l),
+(541,573,l),
+(541,714,l),
+(144.006,714,l),
+(117,345,l),
+(180,313,l),
+(210,322,o),
+(247,331,o),
+(287,331,cs),
+(374,331,o),
+(417,293,o),
+(417,230,cs),
+(417,161,o),
+(370,124,o),
+(290,124,cs),
+(229,124,o),
+(153,145,o),
+(103,169,c),
+(103,29,l),
+(154,4,o),
+(221,-10,o),
+(303,-10,cs),
+(493,-10,o),
+(588,78,o),
+(588,235,cs),
+(588,378,o),
+(496,462,o),
+(370,462,cs)
+);
+}
+);
+width = 639;
+}
+);
+unicode = 53;
+},
+{
+color = 0;
+glyphname = six;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(82,119,o),
+(173,-10,o),
+(346,-10,cs),
+(498,-10,o),
+(592,84,o),
+(592,241,cs),
+(592,387,o),
+(517,471,o),
+(391,471,cs),
+(311,471,o),
+(266,433,o),
+(240,383,c),
+(235,383,l),
+(241,515,o),
+(294,592,o),
+(442,592,cs),
+(489,592,o),
+(520,588,o),
+(547,582,c),
+(547,716,l),
+(520,720,o),
+(475,724,o),
+(445,724,cs),
+(180,724,o),
+(82,560,o),
+(82,302,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(280,125,o),
+(251,183,o),
+(251,251,cs),
+(251,297,o),
+(289,340,o),
+(345,340,cs),
+(403,340,o),
+(428,302,o),
+(428,238,cs),
+(428,162,o),
+(395,125,o),
+(342,125,cs)
+);
+}
+);
+width = 630;
+}
+);
+unicode = 54;
+},
+{
+color = 0;
+glyphname = seven;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(629,614,l),
+(629,714,l),
+(123,714,l),
+(123,573,l),
+(449,573,l),
+(196,0,l),
+(372,0,l)
+);
+}
+);
+width = 654;
+}
+);
+unicode = 55;
+},
+{
+color = 0;
+glyphname = eight;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(492,-10,o),
+(599,54,o),
+(599,189,cs),
+(599,284,o),
+(523,339,o),
+(449,377,c),
+(525,413,o),
+(578,466,o),
+(578,552,cs),
+(578,667,o),
+(484,724,o),
+(346,724,cs),
+(204,724,o),
+(111,662,o),
+(111,552,cs),
+(111,466,o),
+(166,413,o),
+(228,374,c),
+(148,337,o),
+(90,287,o),
+(90,186,cs),
+(90,70,o),
+(170,-10,o),
+(344,-10,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(282,113,o),
+(245,145,o),
+(245,193,cs),
+(245,246,o),
+(291,278,o),
+(342,302,c),
+(399,274,o),
+(444,240,o),
+(444,190,cs),
+(444,141,o),
+(409,113,o),
+(342,113,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(301,471,o),
+(270,498,o),
+(270,537,cs),
+(270,577,o),
+(304,601,o),
+(345,601,cs),
+(387,601,o),
+(419,578,o),
+(419,537,cs),
+(419,494,o),
+(384,470,o),
+(344,450,c)
+);
+}
+);
+width = 643;
+}
+);
+unicode = 56;
+},
+{
+color = 0;
+glyphname = nine;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(602,594,o),
+(513,724,o),
+(339,724,cs),
+(186,724,o),
+(92,631,o),
+(92,474,cs),
+(92,327,o),
+(169,243,o),
+(290,243,cs),
+(374,243,o),
+(418,280,o),
+(444,331,c),
+(449,331,l),
+(442,186,o),
+(374,122,o),
+(232,122,cs),
+(194,122,o),
+(166,125,o),
+(138,131,c),
+(138,-4,l),
+(165,-9,o),
+(209,-10,o),
+(240,-10,cs),
+(502,-10,o),
+(602,154,o),
+(602,403,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(407,589,o),
+(433,524,o),
+(433,463,cs),
+(433,419,o),
+(392,374,o),
+(341,374,cs),
+(285,374,o),
+(256,413,o),
+(256,476,cs),
+(256,552,o),
+(288,589,o),
+(344,589,cs)
+);
+}
+);
+width = 656;
+}
+);
+unicode = 57;
+},
+{
+glyphname = zero.canadian;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(532,-12,o),
+(620,291,o),
+(620,468,cs),
+(620,632,o),
+(538,729,o),
+(391,729,cs),
+(145,729,o),
+(58,425,o),
+(58,248,cs),
+(58,84,o),
+(140,-12,o),
+(288,-12,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(246,136,o),
+(219,175,o),
+(219,249,cs),
+(219,334,o),
+(261,580,o),
+(378,580,cs),
+(431,580,o),
+(459,541,o),
+(459,468,cs),
+(459,382,o),
+(417,136,o),
+(299,136,cs)
+);
+}
+);
+width = 634;
+}
+);
+metricRight = "=|";
+},
+{
+glyphname = one.canadian;
+lastChange = "2023-01-13 15:28:50 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(323,0,l),
+(475,714,l),
+(327,714,l),
+(64,527,l),
+(149,407,l),
+(398,583,l),
+(286,605,l),
+(157,0,l)
+);
+}
+);
+width = 441;
+}
+);
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = two.canadian;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(544,149,l),
+(238,149,l),
+(230,84,l),
+(459,273,ls),
+(555,352,o),
+(609,428,o),
+(609,529,cs),
+(609,646,o),
+(523,729,o),
+(384,729,cs),
+(233,729,o),
+(124,637,o),
+(86,464,c),
+(251,464,l),
+(268,546,o),
+(307,585,o),
+(368,585,cs),
+(418,585,o),
+(444,557,o),
+(444,516,cs),
+(444,456,o),
+(403,410,o),
+(339,359,cs),
+(35,109,l),
+(12,0,l),
+(513,0,l)
+);
+}
+);
+width = 609;
+}
+);
+note = uni14BF;
+},
+{
+glyphname = three.canadian;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(465,-15,o),
+(557,87,o),
+(557,221,cs),
+(557,297,o),
+(516,353,o),
+(443,374,c),
+(429,320,l),
+(550,337,o),
+(616,436,o),
+(616,540,cs),
+(616,646,o),
+(532,729,o),
+(386,729,cs),
+(229,729,o),
+(118,637,o),
+(93,475,c),
+(257,475,l),
+(272,544,o),
+(308,585,o),
+(369,585,cs),
+(420,585,o),
+(449,557,o),
+(449,515,cs),
+(449,467,o),
+(423,426,o),
+(362,426,cs),
+(322,426,l),
+(292,289,l),
+(331,289,ls),
+(374,289,o),
+(395,268,o),
+(395,231,cs),
+(395,179,o),
+(359,129,o),
+(294,129,cs),
+(227,129,o),
+(196,178,o),
+(206,239,c),
+(41,239,l),
+(24,93,o),
+(115,-15,o),
+(291,-15,cs)
+);
+}
+);
+width = 631;
+}
+);
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = four.canadian;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(444,0,l),
+(475,147,l),
+(563,147,l),
+(591,281,l),
+(503,281,l),
+(596,715,l),
+(466,715,l),
+(34,253,l),
+(12,147,l),
+(312,147,l),
+(281,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(463,556,l),
+(402,556,l),
+(344,281,l),
+(169,281,l),
+(175,240,l)
+);
+}
+);
+width = 613;
+}
+);
+},
+{
+glyphname = five.canadian;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(486,-15,o),
+(573,124,o),
+(573,259,cs),
+(573,377,o),
+(493,451,o),
+(363,451,cs),
+(254,451,l),
+(292,413,l),
+(351,616,l),
+(290,570,l),
+(610,570,l),
+(641,714,l),
+(221,714,l),
+(114,346,l),
+(140,310,l),
+(313,310,ls),
+(375,310,o),
+(409,286,o),
+(409,239,cs),
+(409,184,o),
+(373,129,o),
+(303,129,cs),
+(240,129,o),
+(209,167,o),
+(215,218,c),
+(50,218,l),
+(35,81,o),
+(137,-15,o),
+(299,-15,cs)
+);
+}
+);
+width = 627;
+}
+);
+},
+{
+glyphname = six.canadian;
+lastChange = "2023-01-13 15:28:50 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(482,-15,o),
+(590,96,o),
+(590,252,cs),
+(590,370,o),
+(509,451,o),
+(377,451,cs),
+(306,451,o),
+(249,425,o),
+(203,370,c),
+(234,313,l),
+(235,337,o),
+(237,352,o),
+(243,383,cs),
+(272,526,o),
+(321,586,o),
+(394,586,cs),
+(464,586,o),
+(484,544,o),
+(482,497,c),
+(646,497,l),
+(657,636,o),
+(556,729,o),
+(403,729,cs),
+(157,729,o),
+(60,461,o),
+(60,247,cs),
+(60,177,o),
+(75,124,o),
+(104,81,cs),
+(142,23,o),
+(216,-15,o),
+(313,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(258,123,o),
+(221,154,o),
+(221,204,cs),
+(221,262,o),
+(260,316,o),
+(333,316,cs),
+(393,316,o),
+(429,284,o),
+(429,233,cs),
+(429,177,o),
+(390,123,o),
+(318,123,cs)
+);
+}
+);
+width = 633;
+}
+);
+metricLeft = zero.canadian;
+},
+{
+glyphname = seven.canadian;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(213,0,l),
+(570,614,l),
+(592,714,l),
+(130,714,l),
+(99,565,l),
+(390,565,l),
+(398,611,l),
+(56,40,l),
+(48,0,l)
+);
+}
+);
+width = 524;
+}
+);
+},
+{
+glyphname = eight.canadian;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(460,-15,o),
+(576,66,o),
+(583,202,cs),
+(590,286,o),
+(544,350,o),
+(458,375,c),
+(436,321,l),
+(551,330,o),
+(629,410,o),
+(635,518,cs),
+(643,641,o),
+(549,729,o),
+(392,729,cs),
+(246,729,o),
+(140,644,o),
+(133,512,cs),
+(127,430,o),
+(170,363,o),
+(248,339,c),
+(253,393,l),
+(140,384,o),
+(58,305,o),
+(52,199,cs),
+(44,77,o),
+(149,-15,o),
+(310,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(248,121,o),
+(212,152,o),
+(215,202,cs),
+(217,260,o),
+(262,291,o),
+(322,291,cs),
+(388,291,o),
+(425,259,o),
+(422,210,cs),
+(419,152,o),
+(374,121,o),
+(314,121,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(323,423,o),
+(291,455,o),
+(293,505,cs),
+(295,557,o),
+(330,593,o),
+(387,593,cs),
+(441,593,o),
+(473,561,o),
+(471,512,cs),
+(469,460,o),
+(434,423,o),
+(378,423,cs)
+);
+}
+);
+width = 658;
+}
+);
+metricLeft = "=|";
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = nine.canadian;
+lastChange = "2023-01-13 15:28:50 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(518,-15,o),
+(615,253,o),
+(615,467,cs),
+(615,537,o),
+(600,590,o),
+(571,633,cs),
+(533,691,o),
+(459,729,o),
+(362,729,cs),
+(194,729,o),
+(86,618,o),
+(86,462,cs),
+(86,344,o),
+(166,263,o),
+(298,263,cs),
+(369,263,o),
+(426,289,o),
+(472,344,c),
+(441,401,l),
+(440,377,o),
+(438,362,o),
+(432,331,cs),
+(403,188,o),
+(354,128,o),
+(281,128,cs),
+(211,128,o),
+(191,170,o),
+(193,217,c),
+(30,217,l),
+(18,78,o),
+(120,-15,o),
+(272,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(282,398,o),
+(246,430,o),
+(246,481,cs),
+(246,537,o),
+(285,591,o),
+(357,591,cs),
+(418,591,o),
+(455,560,o),
+(455,510,cs),
+(455,452,o),
+(415,398,o),
+(342,398,cs)
+);
+}
+);
+width = 631;
+}
+);
+metricLeft = "=|six.canadian";
+metricRight = "=|six.canadian";
+},
+{
+glyphname = CR;
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+width = 265;
+}
+);
+note = CR;
+unicode = 13;
+},
+{
+color = 0;
+glyphname = .notdef;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(603,714,l),
+(192,714,l),
+(192,0,l),
+(603,0,l),
+(603,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(552,663,l),
+(552,51,l),
+(243,51,l),
+(243,663,l),
+(243,663,l)
+);
+}
+);
+width = 698;
+}
+);
+note = ".notdef";
+},
+{
+glyphname = .null;
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+width = 0;
+}
+);
+note = NULL;
+},
+{
+glyphname = space;
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+width = 266;
+}
+);
+note = space;
+unicode = 32;
+},
+{
+glyphname = nbspace;
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+width = 265;
+}
+);
+note = uni00A0;
+unicode = 160;
+},
+{
+glyphname = space.canadian;
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+width = 534;
+}
+);
+note = space;
+},
+{
+glyphname = "hyphen-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(418,396,l),
+(437,488,l),
+(105,488,l),
+(86,396,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(386,247,l),
+(405,339,l),
+(73,339,l),
+(54,247,l)
+);
+}
+);
+width = 443;
+}
+);
+metricRight = "=|";
+note = uni1400;
+unicode = 5120;
+},
+{
+glyphname = "chi-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(149,0,l),
+(350,268,l),
+(281,279,l),
+(377,0,l),
+(525,0,l),
+(533,40,l),
+(393,424,l),
+(374,296,l),
+(665,674,l),
+(674,714,l),
+(507,714,l),
+(311,450,l),
+(379,440,l),
+(285,714,l),
+(137,714,l),
+(129,674,l),
+(268,299,l),
+(287,427,l),
+(-10,40,l),
+(-18,0,l)
+);
+}
+);
+width = 615;
+}
+);
+metricRight = "=|";
+note = uni166D;
+unicode = 5741;
+},
+{
+glyphname = "fullstop-canadian";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,0,l),
+(178,107,l),
+(157,110,l),
+(194,0,l),
+(287,0,l),
+(292,19,l),
+(222,201,l),
+(217,152,l),
+(358,337,l),
+(362,357,l),
+(257,357,l),
+(177,244,l),
+(205,238,l),
+(165,357,l),
+(72,357,l),
+(67,337,l),
+(132,165,l),
+(141,205,l),
+(-1,19,l),
+(-5,0,l)
+);
+}
+);
+width = 391;
+}
+);
+note = uni1541;
+unicode = 5742;
+},
+{
+glyphname = period;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(-3,24,o),
+(30,-11,o),
+(96,-11,cs),
+(145,-11,o),
+(176,16,o),
+(187,65,cs),
+(199,123,o),
+(168,158,o),
+(102,158,cs),
+(51,158,o),
+(19,130,o),
+(9,81,cs)
+);
+}
+);
+width = 272;
+}
+);
+note = period;
+unicode = 46;
+},
+{
+glyphname = comma;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(60,-138,l),
+(112,-59,o),
+(163,52,o),
+(199,131,c),
+(195,142,l),
+(51,142,l),
+(26,63,o),
+(-15,-41,o),
+(-57,-138,c)
+);
+}
+);
+width = 281;
+}
+);
+note = comma;
+unicode = 44;
+},
+{
+glyphname = hyphen;
+kernLeft = hyphen;
+kernRight = hyphen;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(260,202,l),
+(288,335,l),
+(41,335,l),
+(13,202,l)
+);
+}
+);
+width = 296;
+}
+);
+unicode = 45;
+},
+{
+glyphname = quotesinglbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-28,-572);
+ref = quoteright;
+}
+);
+width = 283;
+}
+);
+unicode = 8218;
+},
+{
+glyphname = quotedblbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+pos = (-91,-572);
+ref = quotedblright;
+}
+);
+width = 547;
+}
+);
+unicode = 8222;
+},
+{
+glyphname = quotedblleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(433,434,l),
+(458,514,o),
+(499,617,o),
+(542,713,c),
+(426,713,l),
+(374,636,o),
+(323,529,o),
+(285,445,c),
+(290,434,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(203,434,l),
+(228,514,o),
+(268,617,o),
+(312,713,c),
+(196,713,l),
+(144,636,o),
+(93,529,o),
+(55,445,c),
+(60,434,l)
+);
+}
+);
+width = 464;
+}
+);
+unicode = 8220;
+},
+{
+glyphname = quotedblright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(405,434,l),
+(458,512,o),
+(510,622,o),
+(546,702,c),
+(541,713,l),
+(398,713,l),
+(373,634,o),
+(332,528,o),
+(289,434,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(174,434,l),
+(227,512,o),
+(279,622,o),
+(315,702,c),
+(310,713,l),
+(167,713,l),
+(142,634,o),
+(100,528,o),
+(58,434,c)
+);
+}
+);
+width = 464;
+}
+);
+unicode = 8221;
+},
+{
+glyphname = quoteleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(205,434,l),
+(231,514,o),
+(272,617,o),
+(315,713,c),
+(196,713,l),
+(144,636,o),
+(93,529,o),
+(55,445,c),
+(60,434,l)
+);
+}
+);
+width = 237;
+}
+);
+unicode = 8216;
+},
+{
+glyphname = quoteright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(177,434,l),
+(230,512,o),
+(283,622,o),
+(319,702,c),
+(314,713,l),
+(168,713,l),
+(143,634,o),
+(101,528,o),
+(58,434,c)
+);
+}
+);
+width = 237;
+}
+);
+unicode = 8217;
+},
+{
+glyphname = dottedCircle;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(208,522,o),
+(195,511,o),
+(195,496,cs),
+(195,483,o),
+(208,470,o),
+(221,470,cs),
+(236,470,o),
+(247,483,o),
+(247,496,cs),
+(247,511,o),
+(236,522,o),
+(221,522,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(376,522,o),
+(363,511,o),
+(363,496,cs),
+(363,483,o),
+(376,470,o),
+(389,470,cs),
+(404,470,o),
+(415,483,o),
+(415,496,cs),
+(415,511,o),
+(404,522,o),
+(389,522,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(208,112,o),
+(195,101,o),
+(195,86,cs),
+(195,73,o),
+(208,60,o),
+(221,60,cs),
+(236,60,o),
+(247,73,o),
+(247,86,cs),
+(247,101,o),
+(236,112,o),
+(221,112,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(376,112,o),
+(363,101,o),
+(363,86,cs),
+(363,73,o),
+(376,60,o),
+(389,60,cs),
+(404,60,o),
+(415,73,o),
+(415,86,cs),
+(415,101,o),
+(404,112,o),
+(389,112,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(292,540,o),
+(279,529,o),
+(279,514,cs),
+(279,501,o),
+(292,488,o),
+(305,488,cs),
+(320,488,o),
+(331,501,o),
+(331,514,cs),
+(331,529,o),
+(320,540,o),
+(305,540,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(292,94,o),
+(279,83,o),
+(279,68,cs),
+(279,55,o),
+(292,42,o),
+(305,42,cs),
+(320,42,o),
+(331,55,o),
+(331,68,cs),
+(331,83,o),
+(320,94,o),
+(305,94,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(56,278,o),
+(69,265,o),
+(82,265,cs),
+(97,265,o),
+(108,278,o),
+(108,291,cs),
+(108,306,o),
+(97,317,o),
+(82,317,cs),
+(69,317,o),
+(56,306,o),
+(56,291,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(502,278,o),
+(515,265,o),
+(528,265,cs),
+(543,265,o),
+(554,278,o),
+(554,291,cs),
+(554,306,o),
+(543,317,o),
+(528,317,cs),
+(515,317,o),
+(502,306,o),
+(502,291,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(121,120,o),
+(134,107,o),
+(147,107,cs),
+(162,107,o),
+(173,120,o),
+(173,133,cs),
+(173,148,o),
+(162,159,o),
+(147,159,cs),
+(134,159,o),
+(121,148,o),
+(121,133,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(121,436,o),
+(134,423,o),
+(147,423,cs),
+(162,423,o),
+(173,436,o),
+(173,449,cs),
+(173,464,o),
+(162,475,o),
+(147,475,cs),
+(134,475,o),
+(121,464,o),
+(121,449,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(437,120,o),
+(450,107,o),
+(463,107,cs),
+(478,107,o),
+(489,120,o),
+(489,133,cs),
+(489,148,o),
+(478,159,o),
+(463,159,cs),
+(450,159,o),
+(437,148,o),
+(437,133,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(437,436,o),
+(450,423,o),
+(463,423,cs),
+(478,423,o),
+(489,436,o),
+(489,449,cs),
+(489,464,o),
+(478,475,o),
+(463,475,cs),
+(450,475,o),
+(437,464,o),
+(437,449,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(74,194,o),
+(87,181,o),
+(100,181,cs),
+(115,181,o),
+(126,194,o),
+(126,207,cs),
+(126,222,o),
+(115,233,o),
+(100,233,cs),
+(87,233,o),
+(74,222,o),
+(74,207,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(74,362,o),
+(87,349,o),
+(100,349,cs),
+(115,349,o),
+(126,362,o),
+(126,375,cs),
+(126,390,o),
+(115,401,o),
+(100,401,cs),
+(87,401,o),
+(74,390,o),
+(74,375,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(484,194,o),
+(497,181,o),
+(510,181,cs),
+(525,181,o),
+(536,194,o),
+(536,207,cs),
+(536,222,o),
+(525,233,o),
+(510,233,cs),
+(497,233,o),
+(484,222,o),
+(484,207,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(484,362,o),
+(497,349,o),
+(510,349,cs),
+(525,349,o),
+(536,362,o),
+(536,375,cs),
+(536,390,o),
+(525,401,o),
+(510,401,cs),
+(497,401,o),
+(484,390,o),
+(484,375,cs)
+);
+}
+);
+width = 602;
+}
+);
+note = uni25CC;
+unicode = 9676;
+},
+{
+glyphname = dotaccentcomb;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(168,767,o),
+(139,746,o),
+(130,700,cs),
+(119,645,o),
+(148,615,o),
+(211,615,cs),
+(265,615,o),
+(293,636,o),
+(302,682,cs),
+(314,737,o),
+(285,767,o),
+(221,767,cs)
+);
+}
+);
+width = 247;
+}
+);
+note = uni0307;
+unicode = 775;
+},
+{
+glyphname = dotaccent;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(267,615,o),
+(295,637,o),
+(303,683,cs),
+(314,737,o),
+(286,767,o),
+(222,767,cs),
+(168,767,o),
+(140,746,o),
+(131,699,cs),
+(120,645,o),
+(149,615,o),
+(213,615,cs)
+);
+}
+);
+width = 249;
+}
+);
+note = dotaccent;
+unicode = 729;
+},
+{
+glyphname = caron;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(424,647,o),
+(475,699,o),
+(533,753,c),
+(536,766,l),
+(419,766,l),
+(383,742,o),
+(351,717,o),
+(313,684,c),
+(288,717,o),
+(271,742,o),
+(244,766,c),
+(145,766,l),
+(142,753,l),
+(171,711,o),
+(206,655,o),
+(224,606,c),
+(389,606,l),
+(389,606,l)
+);
+}
+);
+width = 464;
+}
+);
+note = caron;
+unicode = 711;
+},
+{
+glyphname = breve;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(403,606,o),
+(472,665,o),
+(497,776,c),
+(403,776,l),
+(383,729,o),
+(355,708,o),
+(307,708,cs),
+(258,708,o),
+(236,728,o),
+(235,776,c),
+(147,776,l),
+(130,674,o),
+(191,606,o),
+(300,606,cs)
+);
+}
+);
+width = 423;
+}
+);
+note = breve;
+unicode = 728;
+},
+{
+glyphname = ring;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(319,605,o),
+(371,651,o),
+(371,725,cs),
+(371,798,o),
+(317,845,o),
+(252,845,cs),
+(183,845,o),
+(136,798,o),
+(136,724,cs),
+(136,651,o),
+(183,605,o),
+(252,605,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(227,678,o),
+(213,698,o),
+(213,724,cs),
+(213,753,o),
+(230,771,o),
+(252,771,cs),
+(274,771,o),
+(291,752,o),
+(291,724,cs),
+(291,698,o),
+(274,678,o),
+(252,678,cs)
+);
+}
+);
+width = 307;
+}
+);
+note = ring;
+unicode = 730;
+},
+{
+glyphname = ogonek;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(79,-236,o),
+(105,-233,o),
+(129,-224,c),
+(149,-130,l),
+(133,-135,o),
+(109,-140,o),
+(97,-140,cs),
+(73,-140,o),
+(62,-126,o),
+(67,-102,cs),
+(72,-71,o),
+(94,-43,o),
+(149,0,c),
+(89,23,l),
+(6,-30,o),
+(-35,-76,o),
+(-45,-128,cs),
+(-58,-192,o),
+(-17,-236,o),
+(53,-236,cs)
+);
+}
+);
+width = 267;
+}
+);
+note = ogonek;
+unicode = 731;
+},
+{
+glyphname = ring_top.canadian;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (234,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(336,784,o),
+(393,832,o),
+(393,899,cs),
+(393,966,o),
+(336,1014,o),
+(272,1014,cs),
+(208,1014,o),
+(153,967,o),
+(153,899,cs),
+(153,832,o),
+(208,784,o),
+(272,784,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(244,853,o),
+(228,874,o),
+(228,899,cs),
+(228,924,o),
+(247,945,o),
+(273,945,cs),
+(300,945,o),
+(319,924,o),
+(319,899,cs),
+(319,874,o),
+(300,853,o),
+(273,853,cs)
+);
+}
+);
+width = 273;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (119,357);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(162,279,o),
+(197,314,o),
+(197,357,cs),
+(197,400,o),
+(162,435,o),
+(119,435,cs),
+(76,435,o),
+(41,400,o),
+(41,357,cs),
+(41,314,o),
+(76,279,o),
+(119,279,cs)
+);
+}
+);
+width = 195;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (101,357);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(136,295,o),
+(163,322,o),
+(163,357,cs),
+(163,392,o),
+(136,419,o),
+(102,419,cs),
+(67,419,o),
+(40,392,o),
+(40,357,cs),
+(40,322,o),
+(67,295,o),
+(102,295,cs)
+);
+}
+);
+width = 160;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_small;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (84,357);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(110,312,o),
+(129,332,o),
+(129,357,cs),
+(129,382,o),
+(110,402,o),
+(84,402,cs),
+(59,402,o),
+(40,382,o),
+(40,357,cs),
+(40,332,o),
+(59,312,o),
+(84,312,cs)
+);
+}
+);
+width = 126;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_top;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (195,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(272,790,o),
+(307,826,o),
+(307,869,cs),
+(307,913,o),
+(272,948,o),
+(228,948,cs),
+(184,948,o),
+(149,913,o),
+(149,869,cs),
+(149,826,o),
+(184,790,o),
+(228,790,cs)
+);
+}
+);
+width = 195;
+}
+);
+note = g725;
+},
+{
+glyphname = doubledot_middle;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(210,381,o),
+(245,416,o),
+(245,459,cs),
+(245,503,o),
+(210,538,o),
+(166,538,cs),
+(123,538,o),
+(87,503,o),
+(87,459,cs),
+(87,415,o),
+(123,381,o),
+(166,381,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(166,176,o),
+(201,211,o),
+(201,255,cs),
+(201,298,o),
+(166,333,o),
+(123,333,cs),
+(79,333,o),
+(44,299,o),
+(44,255,cs),
+(44,211,o),
+(79,176,o),
+(123,176,cs)
+);
+}
+);
+width = 245;
+}
+);
+metricRight = "=|";
+note = g725;
+},
+{
+glyphname = doubledot_top;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top_double;
+pos = (386,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(462,790,o),
+(498,826,o),
+(498,869,cs),
+(498,913,o),
+(462,948,o),
+(418,948,cs),
+(375,948,o),
+(340,913,o),
+(340,869,cs),
+(340,826,o),
+(375,790,o),
+(418,790,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(260,790,o),
+(295,826,o),
+(295,869,cs),
+(295,913,o),
+(260,948,o),
+(217,948,cs),
+(173,948,o),
+(138,913,o),
+(138,869,cs),
+(138,826,o),
+(173,790,o),
+(217,790,cs)
+);
+}
+);
+width = 374;
+}
+);
+note = g725;
+},
+{
+glyphname = g727;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (469,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(619,0,l),
+(648,135,l),
+(290,135,ls),
+(237,135,o),
+(208,156,o),
+(208,196,cs),
+(208,255,o),
+(248,291,o),
+(323,291,cs),
+(461,291,ls),
+(635,291,o),
+(741,372,o),
+(741,533,cs),
+(741,644,o),
+(666,714,o),
+(543,714,cs),
+(163,714,l),
+(135,579,l),
+(494,579,ls),
+(548,579,o),
+(576,558,o),
+(576,519,cs),
+(576,458,o),
+(536,424,o),
+(462,424,cs),
+(324,424,ls),
+(149,424,o),
+(43,341,o),
+(43,181,cs),
+(43,71,o),
+(119,0,o),
+(242,0,cs)
+);
+}
+);
+width = 740;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+glyphname = g728;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (274,0);
+ref = dot_top;
+}
+);
+width = 740;
+}
+);
+note = g728;
+},
+{
+glyphname = g729;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (511,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(399,0,ls),
+(576,0,o),
+(680,83,o),
+(680,245,cs),
+(680,355,o),
+(607,424,o),
+(485,424,cs),
+(351,424,ls),
+(297,424,o),
+(269,444,o),
+(269,485,cs),
+(269,546,o),
+(308,579,o),
+(382,579,cs),
+(743,579,l),
+(771,714,l),
+(384,714,ls),
+(210,714,o),
+(104,632,o),
+(104,470,cs),
+(104,360,o),
+(177,291,o),
+(300,291,cs),
+(433,291,ls),
+(487,291,o),
+(514,271,o),
+(514,231,cs),
+(514,170,o),
+(476,135,o),
+(401,135,cs),
+(39,135,l),
+(10,0,l)
+);
+}
+);
+width = 740;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+glyphname = g730;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (316,0);
+ref = dot_top;
+}
+);
+width = 740;
+}
+);
+note = g730;
+},
+{
+glyphname = g731;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = g727;
+}
+);
+width = 985;
+}
+);
+note = g731;
+},
+{
+glyphname = g732;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (740,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 985;
+}
+);
+note = g732;
+},
+{
+glyphname = g733;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (519,0);
+ref = dot_top;
+}
+);
+width = 985;
+}
+);
+note = g733;
+},
+{
+glyphname = g734;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (274,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (740,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 985;
+}
+);
+note = g734;
+},
+{
+glyphname = g735;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = g729;
+}
+);
+width = 985;
+}
+);
+note = g735;
+},
+{
+glyphname = g736;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (740,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 985;
+}
+);
+note = g736;
+},
+{
+glyphname = g737;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (561,0);
+ref = dot_top;
+}
+);
+width = 985;
+}
+);
+note = g737;
+},
+{
+glyphname = g738;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (316,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (740,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 985;
+}
+);
+note = g738;
+},
+{
+glyphname = g739;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(594,283,o),
+(655,351,o),
+(655,434,cs),
+(655,505,o),
+(603,555,o),
+(525,555,cs),
+(329,555,l),
+(366,503,l),
+(391,533,o),
+(401,573,o),
+(401,604,cs),
+(401,673,o),
+(349,722,o),
+(268,722,cs),
+(177,722,o),
+(116,654,o),
+(116,571,cs),
+(116,500,o),
+(168,450,o),
+(246,450,cs),
+(443,450,l),
+(405,502,l),
+(378,468,o),
+(369,430,o),
+(369,402,cs),
+(369,332,o),
+(421,283,o),
+(503,283,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(229,531,o),
+(214,547,o),
+(214,571,cs),
+(214,601,o),
+(234,641,o),
+(266,641,cs),
+(289,641,o),
+(304,624,o),
+(304,600,cs),
+(304,570,o),
+(284,531,o),
+(252,531,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(482,364,o),
+(467,381,o),
+(467,405,cs),
+(467,435,o),
+(487,474,o),
+(519,474,cs),
+(542,474,o),
+(557,458,o),
+(557,434,cs),
+(557,404,o),
+(537,364,o),
+(505,364,cs)
+);
+}
+);
+width = 666;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+glyphname = g740;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (235,0);
+ref = ring_top.canadian;
+}
+);
+width = 740;
+}
+);
+note = g740;
+},
+{
+glyphname = g741;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (277,0);
+ref = ring_top.canadian;
+}
+);
+width = 740;
+}
+);
+note = g741;
+},
+{
+glyphname = g742;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (480,0);
+ref = ring_top.canadian;
+}
+);
+width = 985;
+}
+);
+note = g742;
+},
+{
+glyphname = stroke_middle;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (88,357);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(109,234,l),
+(162,480,l),
+(66,480,l),
+(14,234,l)
+);
+}
+);
+width = 132;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (75,357);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(94,284,l),
+(125,430,l),
+(55,430,l),
+(25,284,l)
+);
+}
+);
+width = 106;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_small;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (66,357);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(79,294,l),
+(106,420,l),
+(53,420,l),
+(27,294,l)
+);
+}
+);
+width = 89;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_threequart;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (88,357);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(109,238,l),
+(159,476,l),
+(67,476,l),
+(17,238,l)
+);
+}
+);
+width = 132;
+}
+);
+note = g723;
+},
+{
+color = 8;
+glyphname = uni11AB0;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (282,714);
+},
+{
+name = top_right_can;
+pos = (564,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(214,0,l),
+(230,77,l),
+(449,77,l),
+(467,165,l),
+(249,165,l),
+(275,287,l),
+(137,232,l),
+(177,232,ls),
+(419,232,o),
+(567,343,o),
+(623,603,cs),
+(647,714,l),
+(481,714,l),
+(460,618,ls),
+(425,462,o),
+(336,379,o),
+(182,379,cs),
+(128,379,l),
+(83,165,l),
+(9,165,l),
+(-10,77,l),
+(64,77,l),
+(48,0,l)
+);
+}
+);
+width = 613;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB1;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB0;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (369,0);
+ref = dot_top;
+}
+);
+width = 613;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB2;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (244,714);
+},
+{
+name = top_right_can;
+pos = (526,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(176,0,l),
+(197,96,ls),
+(231,252,o),
+(321,335,o),
+(474,335,cs),
+(528,335,l),
+(574,549,l),
+(648,549,l),
+(666,637,l),
+(592,637,l),
+(609,714,l),
+(442,714,l),
+(426,637,l),
+(208,637,l),
+(190,549,l),
+(407,549,l),
+(382,427,l),
+(519,482,l),
+(479,482,ls),
+(237,482,o),
+(90,371,o),
+(34,111,cs),
+(10,0,l)
+);
+}
+);
+width = 613;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "theThCree-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB3;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB2;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (331,0);
+ref = dot_top;
+}
+);
+width = 613;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB4;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (283,714);
+},
+{
+name = top_right_can;
+pos = (565,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(495,0,l),
+(517,105,ls),
+(566,333,o),
+(451,482,o),
+(200,482,cs),
+(179,482,l),
+(305,431,l),
+(330,549,l),
+(549,549,l),
+(567,637,l),
+(349,637,l),
+(365,714,l),
+(199,714,l),
+(183,637,l),
+(109,637,l),
+(91,549,l),
+(164,549,l),
+(119,335,l),
+(163,335,ls),
+(326,335,o),
+(387,270,o),
+(349,95,cs),
+(329,0,l)
+);
+}
+);
+width = 613;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB5;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB4;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (87,0);
+ref = dot_top;
+}
+);
+width = 613;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB6;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (246,714);
+},
+{
+name = top_right_can;
+pos = (528,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(177,1,l),
+(239,288,l),
+(101,233,l),
+(138,233,ls),
+(397,233,o),
+(532,349,o),
+(589,613,cs),
+(600,663,l),
+(477,602,l),
+(684,393,l),
+(799,507,l),
+(593,715,l),
+(445,715,l),
+(425,625,ls),
+(390,465,o),
+(291,380,o),
+(135,380,cs),
+(92,380,l),
+(11,1,l)
+);
+}
+);
+width = 764;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB7;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB6;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (333,0);
+ref = dot_top;
+}
+);
+width = 764;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB8;
+kernRight = soright;
+lastChange = "2023-01-13 15:28:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (432,714);
+},
+{
+name = top_right_can;
+pos = (714,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(364,0,l),
+(383,90,ls),
+(418,250,o),
+(518,335,o),
+(673,335,cs),
+(717,335,l),
+(797,714,l),
+(631,714,l),
+(570,427,l),
+(708,482,l),
+(670,482,ls),
+(411,482,o),
+(277,367,o),
+(219,102,cs),
+(209,52,l),
+(331,113,l),
+(124,322,l),
+(9,208,l),
+(215,0,l)
+);
+}
+);
+width = 765;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB9;
+kernRight = soright;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB8;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (519,0);
+ref = dot_top;
+}
+);
+width = 764;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABA;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:28:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (247,714);
+},
+{
+name = top_right_can;
+pos = (529,714);
+}
+);
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(441,0,l),
+(736,208,l),
+(650,330,l),
+(387,147,l),
+(476,82,l),
+(482,115,ls),
+(525,323,o),
+(416,481,o),
+(198,481,cs),
+(158,481,l),
+(266,418,l),
+(330,714,l),
+(163,714,l),
+(83,335,l),
+(125,335,ls),
+(305,335,o),
+(352,274,o),
+(313,92,cs),
+(293,0,l)
+);
+}
+);
+width = 765;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABB;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+alignment = -1;
+ref = uni11ABA;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+}
+);
+width = 764;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABC;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(509,0,l),
+(541,149,l),
+(191,149,l),
+(196,96,l),
+(646,600,l),
+(670,714,l),
+(138,714,l),
+(107,565,l),
+(456,565,l),
+(452,619,l),
+(2,114,l),
+(-23,0,l)
+);
+}
+);
+width = 604;
+}
+);
+metricRight = "=|";
+},
+{
+color = 8;
+glyphname = uni11ABD;
+lastChange = "2023-01-13 15:28:50 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(517,0,l),
+(542,114,l),
+(281,618,l),
+(279,565,l),
+(629,565,l),
+(660,714,l),
+(129,714,l),
+(104,600,l),
+(365,96,l),
+(366,149,l),
+(17,149,l),
+(-15,0,l)
+);
+}
+);
+width = 603;
+}
+);
+metricLeft = "=|uni11ABC";
+metricRight = "=|uni11ABC";
+},
+{
+color = 8;
+glyphname = uni11ABE;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(174,0,l),
+(296,571,l),
+(198,571,l),
+(441,0,l),
+(588,0,l),
+(740,714,l),
+(576,714,l),
+(454,143,l),
+(552,143,l),
+(309,714,l),
+(162,714,l),
+(10,0,l)
+);
+}
+);
+width = 706;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABF;
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(157,0,l),
+(665,572,l),
+(544,572,l),
+(423,0,l),
+(588,0,l),
+(740,714,l),
+(593,714,l),
+(84,142,l),
+(205,142,l),
+(327,714,l),
+(162,714,l),
+(10,0,l)
+);
+}
+);
+width = 706;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = "raiseddoubledotFinal-canadian.cree";
+lastChange = "2023-01-13 15:28:25 +0000";
+layers = (
+{
+layerId = "D19189FD-F605-4705-8DF9-B27AB1AA0ED8";
+shapes = (
+{
+closed = 1;
+nodes = (
+(250,571,o),
+(285,606,o),
+(285,650,cs),
+(285,693,o),
+(250,729,o),
+(206,729,cs),
+(163,729,o),
+(128,694,o),
+(128,650,cs),
+(128,606,o),
+(163,571,o),
+(206,571,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(207,366,o),
+(242,401,o),
+(242,445,cs),
+(242,489,o),
+(207,524,o),
+(163,524,cs),
+(120,524,o),
+(84,489,o),
+(84,445,cs),
+(84,401,o),
+(120,366,o),
+(163,366,cs)
+);
+}
+);
+width = 245;
+}
+);
+note = g725;
+}
+);
+instances = (
+{
+axesValues = (
+169,
+90,
+12
+);
+instanceInterpolations = {
+"D19189FD-F605-4705-8DF9-B27AB1AA0ED8" = 1;
+};
+name = "RC B Italic";
+}
+);
+kerningLTR = {
+"D19189FD-F605-4705-8DF9-B27AB1AA0ED8" = {
+"@MMK_L_caright" = {
+"@MMK_R_ecanleft" = -75;
+"@MMK_R_mwestleft" = -28;
+"@MMK_R_neleft" = -42;
+};
+"@MMK_L_ciright" = {
+"@MMK_R_icanleft" = -75;
+"@MMK_R_noleft" = -80;
+};
+"@MMK_L_ecanright" = {
+"@MMK_R_coleft" = -75;
+"@MMK_R_moleft" = -80;
+"@MMK_R_sileft" = -47;
+};
+"@MMK_L_icanright" = {
+"@MMK_R_celeft" = -75;
+"@MMK_R_meleft" = -80;
+"@MMK_R_mwestleft" = -84;
+"@MMK_R_saleft" = -39;
+"she-canadian" = -80;
+};
+"@MMK_L_maright" = {
+"@MMK_R_acanleft" = -67;
+"@MMK_R_ecanleft" = -80;
+"@MMK_R_mwestleft" = -48;
+"@MMK_R_neleft" = -42;
+};
+"@MMK_L_miright" = {
+"@MMK_R_acanleft" = -67;
+"@MMK_R_icanleft" = -80;
+"@MMK_R_moleft" = -99;
+"@MMK_R_noleft" = -80;
+"@MMK_R_yeleft" = -110;
+};
+"@MMK_L_mwestright" = {
+"@MMK_R_coleft" = -28;
+"@MMK_R_icanleft" = -84;
+"@MMK_R_moleft" = -48;
+"@MMK_R_noleft" = -71;
+"@MMK_R_sileft" = -20;
+"@MMK_R_yeleft" = -40;
+};
+"@MMK_L_naright" = {
+"@MMK_R_acanleft" = -72;
+"@MMK_R_celeft" = -80;
+"@MMK_R_meleft" = -80;
+"@MMK_R_mwestleft" = -71;
+"@MMK_R_neleft" = -84;
+"@MMK_R_saleft" = -45;
+};
+"@MMK_L_niright" = {
+"@MMK_R_coleft" = -42;
+"@MMK_R_moleft" = -42;
+"@MMK_R_noleft" = -84;
+"@MMK_R_sileft" = -1;
+};
+"@MMK_L_ocanright" = {
+"@MMK_R_meleft" = -67;
+"@MMK_R_moleft" = -67;
+"@MMK_R_noleft" = -72;
+};
+"@MMK_L_seright" = {
+"@MMK_R_ecanleft" = -47;
+"@MMK_R_mwestleft" = -20;
+"@MMK_R_neleft" = -1;
+};
+"@MMK_L_soright" = {
+"@MMK_R_icanleft" = -39;
+"@MMK_R_noleft" = -45;
+};
+"@MMK_L_yiright" = {
+"@MMK_R_meleft" = -110;
+"@MMK_R_mwestleft" = -40;
+};
+"shi-canadian" = {
+"@MMK_R_icanleft" = -80;
+};
+};
+};
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "italic angle";
+}
+);
+properties = (
+{
+key = copyrights;
+values = (
+{
+language = ENG;
+value = "Copyright 2018 Google Inc. All Rights Reserved.";
+}
+);
+},
+{
+key = manufacturers;
+values = (
+{
+language = ENG;
+value = "Monotype Imaging Inc.";
+}
+);
+},
+{
+key = designers;
+values = (
+{
+language = ENG;
+value = "Monotype Design Team";
+}
+);
+},
+{
+key = description;
+value = "Designed by Monotype design team.";
+},
+{
+key = trademarks;
+values = (
+{
+language = ENG;
+value = "Noto is a trademark of Google Inc.";
+}
+);
+},
+{
+key = licenseURL;
+value = "http://scripts.sil.org/OFL";
+},
+{
+key = licenses;
+values = (
+{
+language = ENG;
+value = "This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.";
+}
+);
+},
+{
+key = manufacturerURL;
+value = "http://www.google.com/get/noto/";
+},
+{
+key = designerURL;
+value = "http://www.monotype.com/studio";
+}
+);
+settings = {
+disablesNiceNames = 1;
+};
+stems = (
+{
+name = "New Stem";
+}
+);
+unitsPerEm = 1000;
+userData = {
+GSDontShowVersionAlert = 1;
+};
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/sources/Exported instances UCAS SansCanadianAboriginal/Sans Canadian Aboriginal-RC B roman.glyphs
+++ b/sources/Exported instances UCAS SansCanadianAboriginal/Sans Canadian Aboriginal-RC B roman.glyphs
@@ -1,0 +1,37305 @@
+{
+.appVersion = "3151";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+},
+{
+name = Width;
+tag = wdth;
+},
+{
+name = Slant;
+tag = slnt;
+}
+);
+classes = (
+{
+code = "zero one two three four five six seven eight nine ";
+name = Num;
+},
+{
+code = "zero.canadian one.canadian two.canadian three.canadian four.canadian five.canadian six.canadian seven.canadian eight.canadian nine.canadian 
+";
+name = Num_can;
+},
+{
+code = "ke-canadian.square ki-canadian.square kii-canadian.square ko-canadian.square koo-canadian.square ka-canadian.square kaa-canadian.square kweWestCree-canadian.square kwiiWestCree-canadian.square kwoWestCree-canadian.square kwooWestCree-canadian.square kwaWestCree-canadian.square kwaaWestCree-canadian.square ce-canadian.square ci-canadian.square cii-canadian.square co-canadian.square coo-canadian.square ca-canadian.square caa-canadian.square me-canadian.square mi-canadian.square mii-canadian.square mo-canadian.square moo-canadian.square ma-canadian.square maa-canadian.square ne-canadian.square ni-canadian.square nii-canadian.square no-canadian.square noo-canadian.square na-canadian.square naa-canadian.square nweWestCree-canadian.square nwaWestCree-canadian.square nwaaWestCree-canadian.square se-canadian.square si-canadian.square sii-canadian.square so-canadian.square soo-canadian.square sa-canadian.square saa-canadian.square sho-canadian.square shoo-canadian.square sha-canadian.square shaa-canadian.square ye-canadian.square yi-canadian.square yii-canadian.square yo-canadian.square yoo-canadian.square ya-canadian.square yaa-canadian.square re-canadian.square reRCree-canadian.square leWestCree-canadian.square ri-canadian.square rii-canadian.square ro-canadian.square loWestCree-canadian.square ra-canadian.square raa-canadian.square laWestCree-canadian.square reWestCree-canadian.square riWestCree-canadian.square roWestCree-canadian.square raWestCree-canadian.square theThCree-canadian.square thiThCree-canadian.square thiiThCree-canadian.square thoThCree-canadian.square thooThCree-canadian.square thaThCree-canadian.square thaaThCree-canadian.square thweeWoodScree-canadian.square thwiWoodScree-canadian.square thwiiWoodScree-canadian.square thwoWoodScree-canadian.square thwooWoodScree-canadian.square thwaWoodScree-canadian.square thwaaWoodScree-canadian.square nwiOjibway-canadian.square nwiiOjibway-canadian.square nwoOjibway-canadian.square nwooOjibway-canadian.square looWestCree-canadian.square laaWestCree-canadian.square ";
+name = Dene_square;
+},
+{
+code = "ke-canadian ki-canadian kii-canadian ko-canadian koo-canadian ka-canadian kaa-canadian kweWestCree-canadian kwiiWestCree-canadian kwoWestCree-canadian kwooWestCree-canadian kwaWestCree-canadian kwaaWestCree-canadian ce-canadian ci-canadian cii-canadian co-canadian coo-canadian ca-canadian caa-canadian me-canadian mi-canadian mii-canadian mo-canadian moo-canadian ma-canadian maa-canadian ne-canadian ni-canadian nii-canadian no-canadian noo-canadian na-canadian naa-canadian nweWestCree-canadian nwaWestCree-canadian nwaaWestCree-canadian se-canadian si-canadian sii-canadian so-canadian soo-canadian sa-canadian saa-canadian sho-canadian shoo-canadian sha-canadian shaa-canadian ye-canadian yi-canadian yii-canadian yo-canadian yoo-canadian ya-canadian yaa-canadian re-canadian reRCree-canadian leWestCree-canadian ri-canadian rii-canadian ro-canadian loWestCree-canadian ra-canadian raa-canadian laWestCree-canadian reWestCree-canadian riWestCree-canadian roWestCree-canadian raWestCree-canadian theThCree-canadian thiThCree-canadian thiiThCree-canadian thoThCree-canadian thooThCree-canadian thaThCree-canadian thaaThCree-canadian thweeWoodScree-canadian thwiWoodScree-canadian thwiiWoodScree-canadian thwoWoodScree-canadian thwooWoodScree-canadian thwaWoodScree-canadian thwaaWoodScree-canadian nwiOjibway-canadian nwiiOjibway-canadian nwoOjibway-canadian nwooOjibway-canadian looWestCree-canadian laaWestCree-canadian 
+";
+name = Dene_round;
+},
+{
+code = "acuteFinal-canadian.mid graveFinal-canadian.mid ringTophalfFinal-canadian.mid ringRighthalfFinal-canadian.mid ringFinal-canadian.mid doubleacuteFinal-canadian.mid doubleshortverticalstrokesFinal-canadian.mid shorthorizontalstrokeFinal-canadian.mid downtackFinal-canadian.mid pWestCree-canadian.mid c-canadian.mid mWestCree-canadian.mid ";
+name = Final_mid;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian ringFinal-canadian doubleacuteFinal-canadian doubleshortverticalstrokesFinal-canadian shorthorizontalstrokeFinal-canadian downtackFinal-canadian pWestCree-canadian c-canadian mWestCree-canadian ";
+name = Final_mid_ori;
+},
+{
+code = "acuteFinal-canadian.base graveFinal-canadian.base ringBottomhalfFinal-canadian.base ringTophalfFinal-canadian.base ringRighthalfFinal-canadian.base plusFinal-canadian.base pWestCree-canadian.base c-canadian.base thSayisi-canadian.base mWestCree-canadian.base ";
+name = Final_base;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringBottomhalfFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian plusFinal-canadian pWestCree-canadian c-canadian thSayisi-canadian mWestCree-canadian ";
+name = Final_base_ori;
+},
+{
+code = "ng-canadian ngai-canadian ngaai-canadian ngi-canadian ngii-canadian ngo-canadian ngoo-canadian nga-canadian ngaa-canadian ";
+name = Nunavik;
+},
+{
+code = "ng-canadian.nunavik ngai-canadian.nunavik ngaai-canadian.nunavik ngi-canadian.nunavik ngii-canadian.nunavik ngo-canadian.nunavik ngoo-canadian.nunavik nga-canadian.nunavik ngaa-canadian.nunavik ";
+name = Nunavik_alt;
+}
+);
+customParameters = (
+{
+name = vendorID;
+value = GOOG;
+},
+{
+name = panose;
+value = (
+2,
+11,
+5,
+2,
+4,
+5,
+4,
+2,
+2,
+4
+);
+},
+{
+name = unicodeRanges;
+value = (
+0,
+1,
+2,
+5,
+6,
+45,
+77
+);
+},
+{
+name = codePageRanges;
+value = (
+"1252"
+);
+},
+{
+name = fsType;
+value = (
+);
+}
+);
+date = "2022-06-21 10:06:40 +0000";
+familyName = "Sans Canadian Aboriginal";
+featurePrefixes = (
+{
+automatic = 1;
+code = "languagesystem DFLT dflt;
+
+languagesystem cans dflt;
+";
+name = Languagesystems;
+}
+);
+features = (
+{
+automatic = 1;
+code = "feature ss01;
+feature ss02;
+feature ss03;
+feature ss04;
+";
+tag = aalt;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+tag = salt;
+},
+{
+code = "lookup space_can {
+sub space by space.canadian;
+} space_can;
+
+lookup num_can {
+sub @Num by @Num_can;
+} num_can;
+";
+labels = (
+{
+language = dflt;
+value = "CAN Space and numerals";
+}
+);
+tag = ss01;
+},
+{
+code = "lookup dene_square {
+sub @Dene_round by @Dene_square;
+} dene_square;
+
+";
+labels = (
+{
+language = dflt;
+value = "Dene Square";
+}
+);
+tag = ss02;
+},
+{
+code = "lookup nunavik_alt {
+sub @Nunavik by @Nunavik_alt;
+} nunavik_alt;
+
+";
+labels = (
+{
+language = dflt;
+value = "Nunanvik Alt";
+}
+);
+tag = ss03;
+},
+{
+code = "lookup final_mid {
+sub @Final_mid_ori by @Final_mid;
+} final_mid;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final mid";
+}
+);
+tag = ss04;
+},
+{
+code = "lookup final_base {
+sub @Final_base_ori by @Final_base;
+} final_base;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final base";
+}
+);
+tag = ss05;
+},
+{
+code = "lookup plaincree_first {
+sub wiWestCree-canadian' plusFinal-canadian by i-canadian;
+} plaincree_first;
+
+lookup plaincree_second {
+sub i-canadian plusFinal-canadian' by raiseddoubledotFinal-canadian.cree;
+} plaincree_second;
+
+lookup plaincree_third {
+sub middledotFinal-canadian plusFinal-canadian by raiseddoubledotFinal-canadian.cree;
+} plaincree_third;
+";
+labels = (
+{
+language = dflt;
+value = Plaincree;
+}
+);
+tag = ss06;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+labels = (
+{
+language = dflt;
+value = "";
+}
+);
+tag = ss07;
+}
+);
+fontMaster = (
+{
+axesValues = (
+0,
+0,
+0
+);
+customParameters = (
+{
+name = typoAscender;
+value = 1069;
+},
+{
+name = typoDescender;
+value = -293;
+},
+{
+name = typoLineGap;
+value = 0;
+},
+{
+name = winAscent;
+value = 1069;
+},
+{
+name = winDescent;
+value = 293;
+},
+{
+name = hheaAscender;
+value = 1069;
+},
+{
+name = hheaDescender;
+value = -293;
+},
+{
+name = strikeoutPosition;
+value = 305.26947;
+},
+{
+name = strikeoutSize;
+value = 50;
+}
+);
+guides = (
+{
+locked = 1;
+pos = (432,357);
+}
+);
+id = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+metricValues = (
+{
+over = 24;
+pos = 1069;
+},
+{
+over = 24;
+pos = 714;
+},
+{
+over = 24;
+pos = 509;
+},
+{
+over = -24;
+},
+{
+over = -24;
+pos = -293;
+},
+{
+}
+);
+name = "RC B roman";
+stemValues = (
+166
+);
+}
+);
+glyphs = (
+{
+glyphname = idotless;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(227,549,l),
+(62,549,l),
+(62,0,l),
+(227,0,l)
+);
+}
+);
+width = 289;
+}
+);
+note = dotlessi;
+unicode = 305;
+},
+{
+glyphname = "acuteFinal-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(154,357,l),
+(328,714,l),
+(201,714,l),
+(27,357,l)
+);
+}
+);
+width = 355;
+}
+);
+metricRight = "=|";
+note = uni141F;
+unicode = 5151;
+},
+{
+glyphname = "graveFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(328,357,l),
+(154,714,l),
+(27,714,l),
+(201,357,l)
+);
+}
+);
+width = 355;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+unicode = 5152;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(325,351,o),
+(389,411,o),
+(389,525,cs),
+(389,714,l),
+(276,714,l),
+(276,525,ls),
+(276,477,o),
+(257,454,o),
+(223,454,cs),
+(187,454,o),
+(168,477,o),
+(168,525,cs),
+(168,714,l),
+(55,714,l),
+(55,524,ls),
+(55,413,o),
+(119,351,o),
+(222,351,cs)
+);
+}
+);
+width = 444;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1421;
+unicode = 5153;
+},
+{
+glyphname = "ringTophalfFinal-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(168,357,l),
+(168,546,ls),
+(168,594,o),
+(187,617,o),
+(223,617,cs),
+(257,617,o),
+(276,594,o),
+(276,546,cs),
+(276,357,l),
+(389,357,l),
+(389,546,ls),
+(389,660,o),
+(325,720,o),
+(222,720,cs),
+(119,720,o),
+(55,658,o),
+(55,547,cs),
+(55,357,l)
+);
+}
+);
+width = 444;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+unicode = 5154;
+},
+{
+glyphname = "ringRighthalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142.992,357,ls),
+(263,357,o),
+(330,425,o),
+(330,535,cs),
+(330,645,o),
+(263,714,o),
+(143,714,cs),
+(55,714,l),
+(55,609,l),
+(135,609,ls),
+(188,609,o),
+(216,583,o),
+(216,535,cs),
+(216,487,o),
+(188,462,o),
+(135,462,cs),
+(55,462,l),
+(55,357,l)
+);
+}
+);
+width = 378;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+unicode = 5155;
+},
+{
+glyphname = "ringFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(333,369,o),
+(408,444,o),
+(408,545,cs),
+(408,645,o),
+(332,720,o),
+(228,720,cs),
+(125,720,o),
+(48,646,o),
+(48,545,cs),
+(48,444,o),
+(123,369,o),
+(228,369,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(182,465,o),
+(154,500,o),
+(154,545,cs),
+(154,589,o),
+(182,624,o),
+(228,624,cs),
+(273,624,o),
+(303,589,o),
+(303,545,cs),
+(303,500,o),
+(274,465,o),
+(228,465,cs)
+);
+}
+);
+width = 456;
+}
+);
+note = uni1424;
+unicode = 5156;
+},
+{
+glyphname = "doubleacuteFinal-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(328,714,l),
+(201,714,l),
+(27,357,l),
+(154,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(516,714,l),
+(389,714,l),
+(215,357,l),
+(342,357,l)
+);
+}
+);
+width = 543;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricRight = "=|";
+note = uni1425;
+unicode = 5157;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(168,714,l),
+(55,714,l),
+(55,357,l),
+(168,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(334,714,l),
+(221,714,l),
+(221,357,l),
+(334,357,l)
+);
+}
+);
+width = 389;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "pWestCree-canadian";
+note = uni1426;
+unicode = 5158;
+},
+{
+glyphname = "middledotFinal-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(166,288,o),
+(201,323,o),
+(201,367,cs),
+(201,411,o),
+(166,446,o),
+(122,446,cs),
+(79,446,o),
+(44,411,o),
+(44,367,cs),
+(44,323,o),
+(79,288,o),
+(122,288,cs)
+);
+}
+);
+width = 245;
+}
+);
+note = uni1427;
+unicode = 5159;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(391,488,l),
+(391,603,l),
+(55,603,l),
+(55,488,l)
+);
+}
+);
+width = 446;
+}
+);
+metricRight = "=|";
+note = uni1428;
+unicode = 5160;
+},
+{
+glyphname = "plusFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(279,377,l),
+(279,493,l),
+(391,493,l),
+(391,601,l),
+(279,601,l),
+(279,714,l),
+(168,714,l),
+(168,601,l),
+(55,601,l),
+(55,493,l),
+(168,493,l),
+(168,377,l)
+);
+}
+);
+width = 446;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+unicode = 5161;
+},
+{
+glyphname = "downtackFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(280,357,l),
+(280,607,l),
+(391,607,l),
+(391,714,l),
+(55,714,l),
+(55,607,l),
+(167,607,l),
+(167,357,l)
+);
+}
+);
+width = 446;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni142A;
+unicode = 5162;
+},
+{
+glyphname = "thFinalWoodScree-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(281,357,l),
+(281,414,l),
+(391,414,l),
+(391,506,l),
+(281,506,l),
+(281,565,l),
+(391,565,l),
+(391,657,l),
+(281,657,l),
+(281,714,l),
+(168,714,l),
+(168,657,l),
+(55,657,l),
+(55,565,l),
+(168,565,l),
+(168,506,l),
+(55,506,l),
+(55,414,l),
+(168,414,l),
+(168,357,l)
+);
+}
+);
+width = 446;
+}
+);
+metricLeft = "hyphen-canadian";
+metricRight = "hyphen-canadian";
+note = uni167E;
+unicode = 5758;
+},
+{
+glyphname = "ringSmallFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(239,499,o),
+(296,546,o),
+(296,614,cs),
+(296,681,o),
+(239,729,o),
+(174,729,cs),
+(110,729,o),
+(55,681,o),
+(55,614,cs),
+(55,546,o),
+(110,499,o),
+(174,499,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(147,567,o),
+(130,588,o),
+(130,614,cs),
+(130,639,o),
+(149,660,o),
+(175,660,cs),
+(202,660,o),
+(221,639,o),
+(221,614,cs),
+(221,588,o),
+(202,567,o),
+(175,567,cs)
+);
+}
+);
+width = 351;
+}
+);
+note = g725;
+unicode = 6366;
+},
+{
+glyphname = "raiseddotFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(166,571,o),
+(201,606,o),
+(201,650,cs),
+(201,693,o),
+(166,729,o),
+(123,729,cs),
+(79,729,o),
+(44,693,o),
+(44,650,cs),
+(44,606,o),
+(79,571,o),
+(123,571,cs)
+);
+}
+);
+width = 245;
+}
+);
+note = g725;
+unicode = 6367;
+},
+{
+glyphname = "acuteFinal-canadian.base";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-356);
+ref = "acuteFinal-canadian";
+}
+);
+width = 355;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.base";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "graveFinal-canadian";
+}
+);
+width = 355;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian.base";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 444;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1421;
+},
+{
+glyphname = "ringTophalfFinal-canadian.base";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 444;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.base";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 378;
+}
+);
+metricLeft = "==|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "plusFinal-canadian.base";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(279,0,l),
+(279,116,l),
+(391,116,l),
+(391,224,l),
+(279,224,l),
+(279,337,l),
+(168,337,l),
+(168,224,l),
+(55,224,l),
+(55,116,l),
+(168,116,l),
+(168,0,l)
+);
+}
+);
+width = 446;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+},
+{
+glyphname = "acuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-167);
+ref = "acuteFinal-canadian";
+}
+);
+width = 355;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.mid";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "graveFinal-canadian";
+}
+);
+width = 355;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringTophalfFinal-canadian.mid";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-178);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 444;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.mid";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 378;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "ringFinal-canadian.mid";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-188);
+ref = "ringFinal-canadian";
+}
+);
+width = 456;
+}
+);
+metricLeft = "ringFinal-canadian";
+metricWidth = "ringFinal-canadian";
+note = uni1424;
+},
+{
+glyphname = "doubleacuteFinal-canadian.mid";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "doubleacuteFinal-canadian";
+}
+);
+width = 543;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "doubleacuteFinal-canadian";
+note = uni1425;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian.mid";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "doubleshortverticalstrokesFinal-canadian";
+}
+);
+width = 389;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricWidth = "doubleshortverticalstrokesFinal-canadian";
+note = uni1426;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian.mid";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-179);
+ref = "shorthorizontalstrokeFinal-canadian";
+}
+);
+width = 446;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "shorthorizontalstrokeFinal-canadian";
+note = uni1428;
+},
+{
+glyphname = "downtackFinal-canadian.mid";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "downtackFinal-canadian";
+}
+);
+width = 446;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "downtackFinal-canadian";
+note = uni142A;
+},
+{
+glyphname = "e-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (378,470);
+},
+{
+name = top_center_can;
+pos = (378,714);
+},
+{
+name = top_left_can;
+pos = (145,714);
+},
+{
+name = top_right_can;
+pos = (611,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(402,0,l),
+(731,674,l),
+(731,714,l),
+(25,714,l),
+(25,674,l),
+(353,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(407,209,l),
+(216,614,l),
+(192,581,l),
+(562,581,l),
+(545,614,l),
+(354,209,l)
+);
+}
+);
+width = 756;
+}
+);
+metricRight = "=|";
+note = uni1401;
+unicode = 5121;
+},
+{
+glyphname = "aai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (241,0);
+ref = ring_top.canadian;
+}
+);
+width = 756;
+}
+);
+note = uni1402;
+unicode = 5122;
+},
+{
+glyphname = "i-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (378,275);
+},
+{
+name = top_center_can;
+pos = (378,714);
+},
+{
+name = top_left_can;
+pos = (145,714);
+},
+{
+name = top_right_can;
+pos = (610,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(731,0,l),
+(731,40,l),
+(402,714,l),
+(353,714,l),
+(25,40,l),
+(25,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(402,505,l),
+(349,505,l),
+(540,100,l),
+(562,133,l),
+(191,133,l),
+(210,100,l)
+);
+}
+);
+width = 756;
+}
+);
+metricLeft = "e-canadian";
+metricWidth = "e-canadian";
+note = uni1403;
+unicode = 5123;
+},
+{
+glyphname = "ii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (280,0);
+ref = dot_top;
+}
+);
+width = 756;
+}
+);
+note = uni1404;
+unicode = 5124;
+},
+{
+glyphname = "o-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (277,357);
+},
+{
+name = top_center_can;
+pos = (361,714);
+},
+{
+name = top_double;
+pos = (475,714);
+},
+{
+name = top_left_can;
+pos = (133,714);
+},
+{
+name = top_right_can;
+pos = (599,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(104,0,l),
+(662,332,l),
+(662,382,l),
+(104,714,l),
+(65,714,l),
+(65,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(205,532,l),
+(165,524,l),
+(481,336,l),
+(481,381,l),
+(165,194,l),
+(205,184,l)
+);
+}
+);
+width = 690;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1405;
+unicode = 5125;
+},
+{
+glyphname = "oo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+}
+);
+width = 690;
+}
+);
+note = uni1406;
+unicode = 5126;
+},
+{
+glyphname = "yCreeoo-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (187,0);
+ref = doubledot_top;
+}
+);
+width = 690;
+}
+);
+note = uni1407;
+unicode = 5127;
+},
+{
+glyphname = "eeCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(104,0,l),
+(662,332,l),
+(662,382,l),
+(104,714,l),
+(65,714,l),
+(65,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,532,l),
+(165,528,l),
+(481,341,l),
+(481,377,l),
+(165,190,l),
+(200,184,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(301,420,l),
+(248,420,l),
+(248,294,l),
+(301,294,l)
+);
+}
+);
+width = 690;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "o-canadian";
+note = uni1408;
+unicode = 5128;
+},
+{
+glyphname = "iCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (214,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 690;
+}
+);
+note = uni1409;
+unicode = 5129;
+},
+{
+glyphname = "a-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (412,357);
+},
+{
+name = top_center_can;
+pos = (316,714);
+},
+{
+name = top_left_can;
+pos = (103,714);
+},
+{
+name = top_right_can;
+pos = (555,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(626,0,l),
+(626,714,l),
+(587,714,l),
+(29,382,l),
+(29,332,l),
+(587,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(525,193,l),
+(210,380,l),
+(210,335,l),
+(525,522,l),
+(486,532,l),
+(486,184,l)
+);
+}
+);
+width = 691;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni140A;
+unicode = 5130;
+},
+{
+glyphname = "aa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (457,0);
+ref = dot_top;
+}
+);
+width = 690;
+}
+);
+note = uni140B;
+unicode = 5131;
+},
+{
+glyphname = "we-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "e-canadian";
+}
+);
+width = 1000;
+}
+);
+note = uni140C;
+unicode = 5132;
+},
+{
+glyphname = "weWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (756,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1000;
+}
+);
+note = uni140D;
+unicode = 5133;
+},
+{
+glyphname = "wi-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "i-canadian";
+}
+);
+width = 1000;
+}
+);
+note = uni140E;
+unicode = 5134;
+},
+{
+glyphname = "wiWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (756,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1000;
+}
+);
+note = uni140F;
+unicode = 5135;
+},
+{
+glyphname = "wii-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (525,0);
+ref = dot_top;
+}
+);
+width = 1000;
+}
+);
+note = uni1410;
+unicode = 5136;
+},
+{
+glyphname = "wiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (280,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (756,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1000;
+}
+);
+note = uni1411;
+unicode = 5137;
+},
+{
+glyphname = "wo-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "o-canadian";
+}
+);
+width = 935;
+}
+);
+note = uni1412;
+unicode = 5138;
+},
+{
+glyphname = "woWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (690,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 935;
+}
+);
+note = uni1413;
+unicode = 5139;
+},
+{
+glyphname = "woo-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (508,0);
+ref = dot_top;
+}
+);
+width = 935;
+}
+);
+note = uni1414;
+unicode = 5140;
+},
+{
+glyphname = "wooWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (690,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 935;
+}
+);
+note = uni1415;
+unicode = 5141;
+},
+{
+glyphname = "wooNaskapi-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (201,-98);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (383,-207);
+ref = dot_top;
+}
+);
+width = 690;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricWidth = "o-canadian";
+note = uni1416;
+unicode = 5142;
+},
+{
+glyphname = "wa-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "a-canadian";
+}
+);
+width = 935;
+}
+);
+note = uni1417;
+unicode = 5143;
+},
+{
+glyphname = "waWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (690,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 935;
+}
+);
+note = uni1418;
+unicode = 5144;
+},
+{
+glyphname = "waa-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (702,0);
+ref = dot_top;
+}
+);
+width = 935;
+}
+);
+note = uni1419;
+unicode = 5145;
+},
+{
+glyphname = "waaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (457,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (690,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 935;
+}
+);
+note = uni141A;
+unicode = 5146;
+},
+{
+glyphname = "waaNaskapi-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (111,-207);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (294,-98);
+ref = dot_top;
+}
+);
+width = 691;
+}
+);
+metricWidth = "a-canadian";
+note = uni141B;
+unicode = 5147;
+},
+{
+glyphname = "ai-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(266,351,o),
+(305,373,o),
+(333,423,c),
+(299,423,l),
+(325,373,o),
+(367,351,o),
+(423,351,cs),
+(518,351,o),
+(576,411,o),
+(576,516,cs),
+(576,714,l),
+(470,714,l),
+(470,517,ls),
+(470,469,o),
+(453,448,o),
+(419,448,cs),
+(386,448,o),
+(368,470,o),
+(368,517,cs),
+(368,714,l),
+(263.004,714,l),
+(263,517,ls),
+(263,469,o),
+(245,448,o),
+(211,448,cs),
+(178,448,o),
+(161,471,o),
+(161,517,cs),
+(161,714,l),
+(55,714,l),
+(55,516,ls),
+(55,409,o),
+(115,351,o),
+(209,351,cs)
+);
+}
+);
+width = 631;
+}
+);
+metricRight = "=|";
+note = uni141C;
+unicode = 5148;
+},
+{
+glyphname = "ycreew-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(352,528,o),
+(389,567,o),
+(389,625,cs),
+(389,682,o),
+(351,720,o),
+(300,720,cs),
+(248,720,o),
+(210,682,o),
+(210,625,cs),
+(210,567,o),
+(247,528,o),
+(300,528,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(191,351,o),
+(229,390,o),
+(229,448,cs),
+(229,505,o),
+(191,543,o),
+(139,543,cs),
+(88,543,o),
+(50,505,o),
+(50,448,cs),
+(50,390,o),
+(87,351,o),
+(139,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(119,403,o),
+(105,420,o),
+(105,448,cs),
+(105,475,o),
+(119,491,o),
+(139,491,cs),
+(159,491,o),
+(173,475,o),
+(173,448,cs),
+(173,420,o),
+(159,403,o),
+(139,403,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(279,580,o),
+(266,597,o),
+(266,625,cs),
+(266,652,o),
+(279,668,o),
+(300,668,cs),
+(320,668,o),
+(333,652,o),
+(333,625,cs),
+(333,597,o),
+(320,580,o),
+(300,580,cs)
+);
+}
+);
+width = 439;
+}
+);
+metricRight = "=|";
+note = uni141D;
+unicode = 5149;
+},
+{
+glyphname = "glottalstop-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(393.992,357,l),
+(394,378,l),
+(230,714,l),
+(205,714,l),
+(41,378,l),
+(41,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(241,606,l),
+(193,606,l),
+(286,407,l),
+(307,439,l),
+(129,439,l),
+(147,407,l)
+);
+}
+);
+width = 435;
+}
+);
+metricRight = "=|";
+note = uni141E;
+unicode = 5150;
+},
+{
+glyphname = "en-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+pos = (756,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 1111;
+}
+);
+note = uni142B;
+unicode = 5163;
+},
+{
+glyphname = "in-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+pos = (499,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 854;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142C;
+unicode = 5164;
+},
+{
+glyphname = "on-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (536,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 891;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142D;
+unicode = 5165;
+},
+{
+glyphname = "an-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (650,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 1005;
+}
+);
+metricRight = "graveFinal-canadian";
+note = uni142E;
+unicode = 5166;
+},
+{
+glyphname = "pe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (378,470);
+},
+{
+name = top_center_can;
+pos = (378,714);
+},
+{
+name = top_left_can;
+pos = (145,714);
+},
+{
+name = top_right_can;
+pos = (611,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(402,0,l),
+(731,674,l),
+(731,714,l),
+(577,714,l),
+(336,203,l),
+(427,203,l),
+(187,714,l),
+(25,714,l),
+(25,674,l),
+(353,0,l)
+);
+}
+);
+width = 756;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni142F;
+unicode = 5167;
+},
+{
+glyphname = "paai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (241,0);
+ref = ring_top.canadian;
+}
+);
+width = 756;
+}
+);
+note = uni1430;
+unicode = 5168;
+},
+{
+glyphname = "pi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (377,275);
+},
+{
+name = top_center_can;
+pos = (378,714);
+},
+{
+name = top_left_can;
+pos = (144,714);
+},
+{
+name = top_right_can;
+pos = (611,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(181,0,l),
+(424,511,l),
+(332,511,l),
+(571,0,l),
+(731,0,l),
+(731,40,l),
+(402,714,l),
+(353,714,l),
+(25,40,l),
+(25,0,l)
+);
+}
+);
+width = 756;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni1431;
+unicode = 5169;
+},
+{
+glyphname = "pii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (280,0);
+ref = dot_top;
+}
+);
+width = 756;
+}
+);
+note = uni1432;
+unicode = 5170;
+},
+{
+glyphname = "po-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (176,357);
+},
+{
+name = top_center_can;
+pos = (339,714);
+},
+{
+name = top_double;
+pos = (459,714);
+},
+{
+name = top_left_can;
+pos = (114,714);
+},
+{
+name = top_right_can;
+pos = (576,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(82,0,l),
+(639,332,l),
+(639,382,l),
+(82,714,l),
+(43,714,l),
+(43,558,l),
+(445,321,l),
+(445,395,l),
+(43,158,l),
+(43,0,l)
+);
+}
+);
+width = 667;
+}
+);
+metricRight = "o-canadian";
+note = uni1433;
+unicode = 5171;
+},
+{
+glyphname = "poo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (17,0);
+ref = dot_top;
+}
+);
+width = 668;
+}
+);
+note = uni1434;
+unicode = 5172;
+},
+{
+glyphname = "ycreepoo-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (171,0);
+ref = doubledot_top;
+}
+);
+width = 668;
+}
+);
+note = uni1435;
+unicode = 5173;
+},
+{
+glyphname = "heeCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (123,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 668;
+}
+);
+note = uni1436;
+unicode = 5174;
+},
+{
+glyphname = "hiCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (95,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 668;
+}
+);
+note = uni1437;
+unicode = 5175;
+},
+{
+glyphname = "pa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (413,357);
+},
+{
+name = top_center_can;
+pos = (330,714);
+},
+{
+name = top_left_can;
+pos = (103,714);
+},
+{
+name = top_right_can;
+pos = (553,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(625,0,l),
+(625,156,l),
+(223,393,l),
+(223,319,l),
+(625,556,l),
+(625,714,l),
+(585,714,l),
+(29,382,l),
+(29,332,l),
+(585,0,l)
+);
+}
+);
+width = 668;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1438;
+unicode = 5176;
+},
+{
+glyphname = "paa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (456,0);
+ref = dot_top;
+}
+);
+width = 668;
+}
+);
+note = uni1439;
+unicode = 5177;
+},
+{
+glyphname = "pwe-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "pe-canadian";
+}
+);
+width = 1000;
+}
+);
+note = uni143A;
+unicode = 5178;
+},
+{
+glyphname = "pweWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "pe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (756,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1000;
+}
+);
+note = uni143B;
+unicode = 5179;
+},
+{
+glyphname = "pwi-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "pi-canadian";
+}
+);
+width = 1000;
+}
+);
+note = uni143C;
+unicode = 5180;
+},
+{
+glyphname = "pwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (756,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1000;
+}
+);
+note = uni143D;
+unicode = 5181;
+},
+{
+glyphname = "pwii-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (525,0);
+ref = dot_top;
+}
+);
+width = 1000;
+}
+);
+note = uni143E;
+unicode = 5182;
+},
+{
+glyphname = "pwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (280,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (756,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1000;
+}
+);
+note = uni143F;
+unicode = 5183;
+},
+{
+glyphname = "pwo-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "po-canadian";
+}
+);
+width = 912;
+}
+);
+note = uni1440;
+unicode = 5184;
+},
+{
+glyphname = "pwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (668,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 912;
+}
+);
+note = uni1441;
+unicode = 5185;
+},
+{
+glyphname = "pwoo-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (486,0);
+ref = dot_top;
+}
+);
+width = 912;
+}
+);
+note = uni1442;
+unicode = 5186;
+},
+{
+glyphname = "pwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (17,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (668,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 912;
+}
+);
+note = uni1443;
+unicode = 5187;
+},
+{
+glyphname = "pwa-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "pa-canadian";
+}
+);
+width = 912;
+}
+);
+note = uni1444;
+unicode = 5188;
+},
+{
+glyphname = "pwaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (668,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 912;
+}
+);
+note = uni1445;
+unicode = 5189;
+},
+{
+glyphname = "pwaa-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (701,0);
+ref = dot_top;
+}
+);
+width = 912;
+}
+);
+note = uni1446;
+unicode = 5190;
+},
+{
+glyphname = "pwaaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (456,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (668,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 912;
+}
+);
+note = uni1447;
+unicode = 5191;
+},
+{
+glyphname = "ycreepwaa-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+pos = (111,-207);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (293,-98);
+ref = dot_top;
+}
+);
+width = 668;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1448;
+unicode = 5192;
+},
+{
+glyphname = "p-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(351,357,l),
+(351,461,l),
+(153,579,l),
+(153,492,l),
+(351,609,l),
+(351,714,l),
+(331,714,l),
+(55,549,l),
+(55,523,l),
+(331,357,l)
+);
+}
+);
+width = 406;
+}
+);
+note = uni1449;
+unicode = 5193;
+},
+{
+glyphname = "pWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(168,357,l),
+(168,714,l),
+(55,714,l),
+(55,357,l)
+);
+}
+);
+width = 223;
+}
+);
+metricRight = "=|";
+note = uni144A;
+unicode = 5194;
+},
+{
+color = 6;
+glyphname = "hCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(168,189,l),
+(168,297,ls),
+(168,331,o),
+(184,350,o),
+(212,350,cs),
+(237,350,o),
+(250,332,o),
+(250,297,cs),
+(250,189,l),
+(363,189,l),
+(363,318,ls),
+(363,413,o),
+(300,452,o),
+(238,452,cs),
+(190,452,o),
+(152,427,o),
+(144,397,c),
+(168,376,l),
+(168,546,l),
+(55,546,l),
+(55,189,l)
+);
+}
+);
+width = 398;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144B;
+unicode = 5195;
+},
+{
+glyphname = "te-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (375,357);
+},
+{
+name = top_center_can;
+pos = (375,714);
+},
+{
+name = top_left_can;
+pos = (141,714);
+},
+{
+name = top_right_can;
+pos = (611,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(576,-15,o),
+(693,108,o),
+(693,320,cs),
+(693,714,l),
+(527,714,l),
+(527,320,ls),
+(527,195,o),
+(475,135,o),
+(375,135,cs),
+(278,135,o),
+(224,199,o),
+(224,320,cs),
+(224,714,l),
+(58,714,l),
+(58,319,ls),
+(58,106,o),
+(175,-15,o),
+(376,-15,cs)
+);
+}
+);
+width = 751;
+}
+);
+metricRight = "=|";
+note = uni144C;
+unicode = 5196;
+},
+{
+glyphname = "taai-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (239,0);
+ref = ring_top.canadian;
+}
+);
+width = 751;
+}
+);
+note = uni144D;
+unicode = 5197;
+},
+{
+glyphname = "ti-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (375,357);
+},
+{
+name = middle_right_can;
+pos = (844,357);
+},
+{
+name = top_center_can;
+pos = (375,714);
+},
+{
+name = top_left_can;
+pos = (141,714);
+},
+{
+name = top_right_can;
+pos = (611,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(224,0,l),
+(224,394,ls),
+(224,516,o),
+(281,579,o),
+(378,579,cs),
+(474,579,o),
+(527,515,o),
+(527,394,cs),
+(527,0,l),
+(693,0,l),
+(693,395,ls),
+(693,607,o),
+(577,729,o),
+(381,729,cs),
+(181,729,o),
+(58,607,o),
+(58,395,cs),
+(58,0,l)
+);
+}
+);
+width = 751;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni144E;
+unicode = 5198;
+},
+{
+glyphname = "tii-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (278,0);
+ref = dot_top;
+}
+);
+width = 751;
+}
+);
+note = uni144F;
+unicode = 5199;
+},
+{
+glyphname = "to-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (236,357);
+},
+{
+name = middle_right_can;
+pos = (738,357);
+},
+{
+name = top_center_can;
+pos = (291,714);
+},
+{
+name = top_double;
+pos = (387,714);
+},
+{
+name = top_left_can;
+pos = (121,714);
+},
+{
+name = top_right_can;
+pos = (516,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(225,0,ls),
+(454,0,o),
+(587,129,o),
+(587,358,cs),
+(587,587,o),
+(454,714,o),
+(225,714,cs),
+(49,714,l),
+(49,565,l),
+(217,565,ls),
+(345,565,o),
+(421,499,o),
+(421,358,cs),
+(421,217,o),
+(345,149,o),
+(218,149,cs),
+(49,149,l),
+(49,0,l)
+);
+}
+);
+width = 639;
+}
+);
+note = uni1450;
+unicode = 5200;
+},
+{
+glyphname = "too-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (194,0);
+ref = dot_top;
+}
+);
+width = 639;
+}
+);
+note = uni1451;
+unicode = 5201;
+},
+{
+glyphname = "ycreetoo-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (99,0);
+ref = doubledot_top;
+}
+);
+width = 639;
+}
+);
+note = uni1452;
+unicode = 5202;
+},
+{
+glyphname = "deeCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (170,0);
+ref = stroke_middle;
+}
+);
+width = 639;
+}
+);
+note = uni1453;
+unicode = 5203;
+},
+{
+glyphname = "diCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (139,0);
+ref = dot_middle;
+}
+);
+width = 639;
+}
+);
+note = uni1454;
+unicode = 5204;
+},
+{
+glyphname = "ta-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (404,357);
+},
+{
+name = top_center_can;
+pos = (349,714);
+},
+{
+name = top_left_can;
+pos = (124,714);
+},
+{
+name = top_right_can;
+pos = (519,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(590,0,l),
+(590,149,l),
+(422,149,ls),
+(294,149,o),
+(219,216,o),
+(219,357,cs),
+(219,498,o),
+(294,565,o),
+(422,565,cs),
+(590,565,l),
+(590,714,l),
+(415,714,ls),
+(186,714,o),
+(52,586,o),
+(52,357,cs),
+(52,128,o),
+(186,0,o),
+(414,0,cs)
+);
+}
+);
+width = 639;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|to-canadian";
+note = uni1455;
+unicode = 5205;
+},
+{
+glyphname = "taa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (252,0);
+ref = dot_top;
+}
+);
+width = 639;
+}
+);
+note = uni1456;
+unicode = 5206;
+},
+{
+glyphname = "twe-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "te-canadian";
+}
+);
+width = 996;
+}
+);
+note = uni1457;
+unicode = 5207;
+},
+{
+glyphname = "tweWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (751,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 996;
+}
+);
+note = uni1458;
+unicode = 5208;
+},
+{
+glyphname = "twi-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ti-canadian";
+}
+);
+width = 996;
+}
+);
+note = uni1459;
+unicode = 5209;
+},
+{
+glyphname = "twiWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (751,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 996;
+}
+);
+note = uni145A;
+unicode = 5210;
+},
+{
+glyphname = "twii-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (523,0);
+ref = dot_top;
+}
+);
+width = 996;
+}
+);
+note = uni145B;
+unicode = 5211;
+},
+{
+glyphname = "twiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (278,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (751,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 996;
+}
+);
+note = uni145C;
+unicode = 5212;
+},
+{
+glyphname = "two-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "to-canadian";
+}
+);
+width = 884;
+}
+);
+note = uni145D;
+unicode = 5213;
+},
+{
+glyphname = "twoWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (639,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 884;
+}
+);
+note = uni145E;
+unicode = 5214;
+},
+{
+glyphname = "twoo-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (439,0);
+ref = dot_top;
+}
+);
+width = 884;
+}
+);
+note = uni145F;
+unicode = 5215;
+},
+{
+glyphname = "twooWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (194,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (639,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 884;
+}
+);
+note = uni1460;
+unicode = 5216;
+},
+{
+glyphname = "twa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ta-canadian";
+}
+);
+width = 884;
+}
+);
+note = uni1461;
+unicode = 5217;
+},
+{
+glyphname = "twaWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (639,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 884;
+}
+);
+note = uni1462;
+unicode = 5218;
+},
+{
+glyphname = "twaa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (496,0);
+ref = dot_top;
+}
+);
+width = 884;
+}
+);
+note = uni1463;
+unicode = 5219;
+},
+{
+glyphname = "twaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (252,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (639,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 884;
+}
+);
+note = uni1464;
+unicode = 5220;
+},
+{
+glyphname = "twaaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ta-canadian";
+}
+);
+width = 884;
+}
+);
+note = uni1465;
+unicode = 5221;
+},
+{
+glyphname = "t-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(323,357,l),
+(323,462,l),
+(243,462,ls),
+(190,462,o),
+(162,487,o),
+(162,535,cs),
+(162,582,o),
+(190,609,o),
+(243,609,cs),
+(323,609,l),
+(323,714,l),
+(235,714,ls),
+(115,714,o),
+(48,645,o),
+(48,535,cs),
+(48,425,o),
+(115,357,o),
+(235,357,cs)
+);
+}
+);
+width = 378;
+}
+);
+note = uni1466;
+unicode = 5222;
+},
+{
+glyphname = "tte-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+pos = (751,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni1467;
+unicode = 5223;
+},
+{
+glyphname = "tti-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+pos = (751,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni1468;
+unicode = 5224;
+},
+{
+glyphname = "tto-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+pos = (639,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 863;
+}
+);
+note = uni1469;
+unicode = 5225;
+},
+{
+glyphname = "tta-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+pos = (639,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 863;
+}
+);
+note = uni146A;
+unicode = 5226;
+},
+{
+glyphname = "ke-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (304,457);
+},
+{
+name = top_center_can;
+pos = (300,714);
+},
+{
+name = top_left_can;
+pos = (125,714);
+},
+{
+name = top_right_can;
+pos = (474,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(557,0,l),
+(557,450,ls),
+(557,623,o),
+(462,729,o),
+(304,729,cs),
+(146,729,o),
+(43,622,o),
+(43,455,cs),
+(43,296,o),
+(139,190,o),
+(276,190,cs),
+(343,190,o),
+(393,222,o),
+(404,256,c),
+(391,269,l),
+(391,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(244,330,o),
+(206,373,o),
+(206,459,cs),
+(206,546,o),
+(241,589,o),
+(300,589,cs),
+(358,589,o),
+(394,546,o),
+(394,459,cs),
+(394,373,o),
+(355,330,o),
+(300,330,cs)
+);
+}
+);
+width = 615;
+}
+);
+metricRight = "te-canadian";
+note = uni146B;
+unicode = 5227;
+},
+{
+glyphname = "kaai-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (178,0);
+ref = ring_top.canadian;
+}
+);
+width = 614;
+}
+);
+note = uni146C;
+unicode = 5228;
+},
+{
+glyphname = "ki-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (319,457);
+},
+{
+name = top_center_can;
+pos = (315,714);
+},
+{
+name = top_left_can;
+pos = (140,714);
+},
+{
+name = top_right_can;
+pos = (490,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(224,0,l),
+(224,269,l),
+(210,256,l),
+(221,222,o),
+(271,190,o),
+(338,190,cs),
+(475,190,o),
+(571,297,o),
+(571,458,cs),
+(571,624,o),
+(469,729,o),
+(317,729,cs),
+(156,729,o),
+(58,620,o),
+(58,450,cs),
+(58,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(259,330,o),
+(220,373,o),
+(220,459,cs),
+(220,546,o),
+(256,589,o),
+(315,589,cs),
+(373,589,o),
+(409,546,o),
+(409,459,cs),
+(409,373,o),
+(370,330,o),
+(315,330,cs)
+);
+}
+);
+width = 614;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni146D;
+unicode = 5229;
+},
+{
+glyphname = "kii-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (217,0);
+ref = dot_top;
+}
+);
+width = 614;
+}
+);
+note = uni146E;
+unicode = 5230;
+},
+{
+glyphname = "ko-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (304,287);
+},
+{
+name = top_center_can;
+pos = (300,714);
+},
+{
+name = top_double;
+pos = (474,714);
+},
+{
+name = top_left_can;
+pos = (125,714);
+},
+{
+name = top_right_can;
+pos = (474,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(461,-15,o),
+(557,91,o),
+(557,264,cs),
+(557,714,l),
+(391,714,l),
+(391,445,l),
+(404,458,l),
+(393,492,o),
+(343,524,o),
+(278,524,cs),
+(139,524,o),
+(43,415,o),
+(43,252,cs),
+(43,89,o),
+(141,-15,o),
+(300,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(241,125,o),
+(206,168,o),
+(206,255,cs),
+(206,341,o),
+(244,384,o),
+(300,384,cs),
+(355,384,o),
+(394,341,o),
+(394,255,cs),
+(394,168,o),
+(358,125,o),
+(300,125,cs)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni146F;
+unicode = 5231;
+},
+{
+glyphname = "koo-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (377,0);
+ref = dot_top;
+}
+);
+width = 614;
+}
+);
+note = uni1470;
+unicode = 5232;
+},
+{
+glyphname = "ycreekoo-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (186,0);
+ref = doubledot_top;
+}
+);
+width = 614;
+}
+);
+note = uni1471;
+unicode = 5233;
+},
+{
+glyphname = "ka-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (319,291);
+},
+{
+name = top_center_can;
+pos = (315,714);
+},
+{
+name = top_left_can;
+pos = (141,714);
+},
+{
+name = top_right_can;
+pos = (490,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(467,-15,o),
+(571,90,o),
+(571,257,cs),
+(571,417,o),
+(475,524,o),
+(342,524,cs),
+(274,524,o),
+(224,492,o),
+(210,458,c),
+(224,445,l),
+(224,714,l),
+(58,714,l),
+(58,264,ls),
+(58,91,o),
+(152,-15,o),
+(313,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(256,125,o),
+(220,168,o),
+(220,255,cs),
+(220,341,o),
+(259,384,o),
+(315,384,cs),
+(370,384,o),
+(409,341,o),
+(409,255,cs),
+(409,168,o),
+(373,125,o),
+(315,125,cs)
+);
+}
+);
+width = 614;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "==|ke-canadian";
+note = uni1472;
+unicode = 5234;
+},
+{
+glyphname = "kaa-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (43,0);
+ref = dot_top;
+}
+);
+width = 614;
+}
+);
+note = uni1473;
+unicode = 5235;
+},
+{
+glyphname = "kwe-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ke-canadian";
+}
+);
+width = 859;
+}
+);
+note = uni1474;
+unicode = 5236;
+},
+{
+glyphname = "kweWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (614,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 859;
+}
+);
+note = uni1475;
+unicode = 5237;
+},
+{
+glyphname = "kwi-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ki-canadian";
+}
+);
+width = 859;
+}
+);
+note = uni1476;
+unicode = 5238;
+},
+{
+glyphname = "kwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (614,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 859;
+}
+);
+note = uni1477;
+unicode = 5239;
+},
+{
+glyphname = "kwii-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (462,0);
+ref = dot_top;
+}
+);
+width = 859;
+}
+);
+note = uni1478;
+unicode = 5240;
+},
+{
+glyphname = "kwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (217,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (614,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 859;
+}
+);
+note = uni1479;
+unicode = 5241;
+},
+{
+glyphname = "kwo-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ko-canadian";
+}
+);
+width = 859;
+}
+);
+note = uni147A;
+unicode = 5242;
+},
+{
+glyphname = "kwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (614,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 859;
+}
+);
+note = uni147B;
+unicode = 5243;
+},
+{
+glyphname = "kwoo-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (622,0);
+ref = dot_top;
+}
+);
+width = 859;
+}
+);
+note = uni147C;
+unicode = 5244;
+},
+{
+glyphname = "kwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (377,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (614,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 859;
+}
+);
+note = uni147D;
+unicode = 5245;
+},
+{
+glyphname = "kwa-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ka-canadian";
+}
+);
+width = 859;
+}
+);
+note = uni147E;
+unicode = 5246;
+},
+{
+glyphname = "kwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (614,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 859;
+}
+);
+note = uni147F;
+unicode = 5247;
+},
+{
+glyphname = "kwaa-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (288,0);
+ref = dot_top;
+}
+);
+width = 859;
+}
+);
+note = uni1480;
+unicode = 5248;
+},
+{
+glyphname = "kwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (43,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (614,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 859;
+}
+);
+note = uni1481;
+unicode = 5249;
+},
+{
+glyphname = "kwaaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ka-canadian";
+}
+);
+width = 859;
+}
+);
+note = uni1482;
+unicode = 5250;
+},
+{
+glyphname = "k-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(281,351,o),
+(344,400,o),
+(344,489,cs),
+(344,571,o),
+(291,622,o),
+(223,622,cs),
+(184,622,o),
+(154,601,o),
+(147,575,c),
+(168,574,l),
+(168,714,l),
+(55,714,l),
+(55,492,ls),
+(55,408,o),
+(110,351,o),
+(203,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(176,432,o),
+(158,449,o),
+(158,486,cs),
+(158,524,o),
+(177,541,o),
+(201,541,cs),
+(225,541,o),
+(244,524,o),
+(244,486,cs),
+(244,449,o),
+(225,432,o),
+(201,432,cs)
+);
+}
+);
+width = 389;
+}
+);
+note = uni1483;
+unicode = 5251;
+},
+{
+glyphname = "kw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(279,351,o),
+(334,408,o),
+(334,492,cs),
+(334,714,l),
+(221,714,l),
+(221,574,l),
+(243,575,l),
+(235,601,o),
+(205,622,o),
+(166,622,cs),
+(98,622,o),
+(45,571,o),
+(45,489,cs),
+(45,400,o),
+(108,351,o),
+(186,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(164,432,o),
+(145,449,o),
+(145,486,cs),
+(145,524,o),
+(164,541,o),
+(188,541,cs),
+(212,541,o),
+(231,524,o),
+(231,486,cs),
+(231,449,o),
+(213,432,o),
+(188,432,cs)
+);
+}
+);
+width = 389;
+}
+);
+metricLeft = "=|k-canadian";
+metricRight = "=|k-canadian";
+note = uni1484;
+unicode = 5252;
+},
+{
+glyphname = "southslaveykeh-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+pos = (614,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni1485;
+unicode = 5253;
+},
+{
+glyphname = "southslaveykih-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+pos = (614,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni1486;
+unicode = 5254;
+},
+{
+glyphname = "southslaveykoh-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+pos = (614,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni1487;
+unicode = 5255;
+},
+{
+glyphname = "southslaveykah-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+pos = (614,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni1488;
+unicode = 5256;
+},
+{
+glyphname = "ce-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (299,373);
+},
+{
+name = top_center_can;
+pos = (299,714);
+},
+{
+name = top_left_can;
+pos = (124,714);
+},
+{
+name = top_right_can;
+pos = (466,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(549,0,l),
+(549,454,ls),
+(549,629,o),
+(456,729,o),
+(299,729,cs),
+(139,729,o),
+(42,628,o),
+(42,453,cs),
+(42,393,l),
+(206,393,l),
+(206,470,ls),
+(206,545,o),
+(238,585,o),
+(295,585,cs),
+(351,585,o),
+(383,546,o),
+(383,469,cs),
+(383,0,l)
+);
+}
+);
+width = 607;
+}
+);
+metricRight = "te-canadian";
+note = uni1489;
+unicode = 5257;
+},
+{
+glyphname = "caai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (180,0);
+ref = ring_top.canadian;
+}
+);
+width = 606;
+}
+);
+note = uni148A;
+unicode = 5258;
+},
+{
+glyphname = "ci-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (304,373);
+},
+{
+name = top_center_can;
+pos = (316,714);
+},
+{
+name = top_left_can;
+pos = (141,714);
+},
+{
+name = top_right_can;
+pos = (483,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(224,0,l),
+(224,469,ls),
+(224,546,o),
+(257,585,o),
+(314,585,cs),
+(369,585,o),
+(400,546,o),
+(400,471,cs),
+(400,393,l),
+(565,393,l),
+(565,453,ls),
+(565,628,o),
+(472,729,o),
+(316,729,cs),
+(151,729,o),
+(58,625,o),
+(58,453,cs),
+(58,0,l)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+unicode = 5259;
+},
+{
+glyphname = "cii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (219,0);
+ref = dot_top;
+}
+);
+width = 606;
+}
+);
+note = uni148C;
+unicode = 5260;
+},
+{
+glyphname = "co-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (299,373);
+},
+{
+name = top_center_can;
+pos = (298,714);
+},
+{
+name = top_double;
+pos = (466,714);
+},
+{
+name = top_left_can;
+pos = (124,714);
+},
+{
+name = top_right_can;
+pos = (466,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(455,-15,o),
+(549,84,o),
+(549,260,cs),
+(549,714,l),
+(383,714,l),
+(383,243,ls),
+(383,166,o),
+(351,129,o),
+(295,129,cs),
+(236,129,o),
+(206,169,o),
+(206,250,cs),
+(206,321,l),
+(42,321,l),
+(42,261,ls),
+(42,86,o),
+(134,-15,o),
+(299,-15,cs)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+unicode = 5261;
+},
+{
+glyphname = "coo-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (369,0);
+ref = dot_top;
+}
+);
+width = 606;
+}
+);
+note = uni148E;
+unicode = 5262;
+},
+{
+glyphname = "ycreecoo-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (178,0);
+ref = doubledot_top;
+}
+);
+width = 606;
+}
+);
+note = uni148F;
+unicode = 5263;
+},
+{
+glyphname = "ca-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (304,373);
+},
+{
+name = top_center_can;
+pos = (316,714);
+},
+{
+name = top_left_can;
+pos = (141,714);
+},
+{
+name = top_right_can;
+pos = (483,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(470,-15,o),
+(565,86,o),
+(565,261,cs),
+(565,321,l),
+(400,321,l),
+(400,248,ls),
+(400,167,o),
+(370,129,o),
+(313,129,cs),
+(255,129,o),
+(224,168,o),
+(224,249,cs),
+(224,714,l),
+(58,714,l),
+(58,260,ls),
+(58,86,o),
+(147,-15,o),
+(312,-15,cs)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+unicode = 5264;
+},
+{
+glyphname = "caa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (44,0);
+ref = dot_top;
+}
+);
+width = 606;
+}
+);
+note = uni1491;
+unicode = 5265;
+},
+{
+glyphname = "cwe-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ce-canadian";
+}
+);
+width = 851;
+}
+);
+note = uni1492;
+unicode = 5266;
+},
+{
+glyphname = "cweWestCree-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (606,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 851;
+}
+);
+note = uni1493;
+unicode = 5267;
+},
+{
+glyphname = "cwi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ci-canadian";
+}
+);
+width = 851;
+}
+);
+note = uni1494;
+unicode = 5268;
+},
+{
+glyphname = "cwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (606,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 851;
+}
+);
+note = uni1495;
+unicode = 5269;
+},
+{
+glyphname = "cwii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (464,0);
+ref = dot_top;
+}
+);
+width = 851;
+}
+);
+note = uni1496;
+unicode = 5270;
+},
+{
+glyphname = "cwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (219,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (606,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 851;
+}
+);
+note = uni1497;
+unicode = 5271;
+},
+{
+glyphname = "cwo-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "co-canadian";
+}
+);
+width = 851;
+}
+);
+note = uni1498;
+unicode = 5272;
+},
+{
+glyphname = "cwoWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (606,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 851;
+}
+);
+note = uni1499;
+unicode = 5273;
+},
+{
+glyphname = "cwoo-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (613,0);
+ref = dot_top;
+}
+);
+width = 851;
+}
+);
+note = uni149A;
+unicode = 5274;
+},
+{
+glyphname = "cwooWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (369,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (606,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 851;
+}
+);
+note = uni149B;
+unicode = 5275;
+},
+{
+glyphname = "cwa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ca-canadian";
+}
+);
+width = 851;
+}
+);
+note = uni149C;
+unicode = 5276;
+},
+{
+glyphname = "cwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (606,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 851;
+}
+);
+note = uni149D;
+unicode = 5277;
+},
+{
+glyphname = "cwaa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (289,0);
+ref = dot_top;
+}
+);
+width = 851;
+}
+);
+note = uni149E;
+unicode = 5278;
+},
+{
+glyphname = "cwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (44,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (606,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 851;
+}
+);
+note = uni149F;
+unicode = 5279;
+},
+{
+glyphname = "cwaaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ca-canadian";
+}
+);
+width = 851;
+}
+);
+note = uni14A0;
+unicode = 5280;
+},
+{
+glyphname = "c-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(291,351,o),
+(347,402,o),
+(347,488,cs),
+(347,508,l),
+(241,508,l),
+(241,480,ls),
+(241,454,o),
+(227,438,o),
+(203,438,cs),
+(180,438,o),
+(168,454,o),
+(168,482,cs),
+(168,714,l),
+(55,714,l),
+(55,497,ls),
+(55,402,o),
+(106,351,o),
+(203,351,cs)
+);
+}
+);
+width = 379;
+}
+);
+note = uni14A1;
+unicode = 5281;
+},
+{
+glyphname = "thSayisi-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(273,351,o),
+(324,402,o),
+(324,497,cs),
+(324,714,l),
+(211,714,l),
+(211,482,ls),
+(211,454,o),
+(199,438,o),
+(176,438,cs),
+(152,438,o),
+(138,454,o),
+(138,480,cs),
+(138,508,l),
+(32,508,l),
+(32,488,ls),
+(32,402,o),
+(88,351,o),
+(178,351,cs)
+);
+}
+);
+width = 379;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "=|c-canadian";
+note = uni14A2;
+unicode = 5282;
+},
+{
+glyphname = "me-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (189,357);
+},
+{
+name = top_center_can;
+pos = (276,714);
+},
+{
+name = top_left_can;
+pos = (119,714);
+},
+{
+name = top_right_can;
+pos = (424,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(507,0,l),
+(507,714,l),
+(37,714,l),
+(37,565,l),
+(341,565,l),
+(341,0,l)
+);
+}
+);
+width = 572;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+unicode = 5283;
+},
+{
+glyphname = "maai-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (163,0);
+ref = ring_top.canadian;
+}
+);
+width = 571;
+}
+);
+note = uni14A4;
+unicode = 5284;
+},
+{
+glyphname = "mi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (383,357);
+},
+{
+name = top_center_can;
+pos = (300,714);
+},
+{
+name = top_left_can;
+pos = (148,714);
+},
+{
+name = top_right_can;
+pos = (452,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(231,0,l),
+(231,565,l),
+(535,565,l),
+(535,714,l),
+(65,714,l),
+(65,0,l)
+);
+}
+);
+width = 572;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+unicode = 5285;
+},
+{
+glyphname = "mii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (202,0);
+ref = dot_top;
+}
+);
+width = 571;
+}
+);
+note = uni14A6;
+unicode = 5286;
+},
+{
+glyphname = "mo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (189,357);
+},
+{
+name = top_center_can;
+pos = (276,714);
+},
+{
+name = top_double;
+pos = (424,714);
+},
+{
+name = top_left_can;
+pos = (119,714);
+},
+{
+name = top_right_can;
+pos = (424,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(507,0,l),
+(507,714,l),
+(341,714,l),
+(341,149,l),
+(37,149,l),
+(37,0,l)
+);
+}
+);
+width = 572;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+unicode = 5287;
+},
+{
+glyphname = "moo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (327,0);
+ref = dot_top;
+}
+);
+width = 571;
+}
+);
+note = uni14A8;
+unicode = 5288;
+},
+{
+glyphname = "ycreemoo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (136,0);
+ref = doubledot_top;
+}
+);
+width = 571;
+}
+);
+note = uni14A9;
+unicode = 5289;
+},
+{
+glyphname = "ma-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (383,357);
+},
+{
+name = top_center_can;
+pos = (300,714);
+},
+{
+name = top_left_can;
+pos = (148,714);
+},
+{
+name = top_right_can;
+pos = (451,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(535,0,l),
+(535,149,l),
+(231,149,l),
+(231,714,l),
+(65,714,l),
+(65,0,l)
+);
+}
+);
+width = 572;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+unicode = 5290;
+},
+{
+glyphname = "maa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+}
+);
+width = 571;
+}
+);
+note = uni14AB;
+unicode = 5291;
+},
+{
+glyphname = "mwe-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "me-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni14AC;
+unicode = 5292;
+},
+{
+glyphname = "mweWestCree-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "me-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (571,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni14AD;
+unicode = 5293;
+},
+{
+glyphname = "mwi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "mi-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni14AE;
+unicode = 5294;
+},
+{
+glyphname = "mwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (571,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni14AF;
+unicode = 5295;
+},
+{
+glyphname = "mwii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (447,0);
+ref = dot_top;
+}
+);
+width = 816;
+}
+);
+note = uni14B0;
+unicode = 5296;
+},
+{
+glyphname = "mwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (202,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (571,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni14B1;
+unicode = 5297;
+},
+{
+glyphname = "mwo-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "mo-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni14B2;
+unicode = 5298;
+},
+{
+glyphname = "mwoWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (571,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni14B3;
+unicode = 5299;
+},
+{
+glyphname = "mwoo-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (572,0);
+ref = dot_top;
+}
+);
+width = 816;
+}
+);
+note = uni14B4;
+unicode = 5300;
+},
+{
+glyphname = "mwooWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (327,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (571,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni14B5;
+unicode = 5301;
+},
+{
+glyphname = "mwa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ma-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni14B6;
+unicode = 5302;
+},
+{
+glyphname = "mwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (571,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni14B7;
+unicode = 5303;
+},
+{
+glyphname = "mwaa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (295,0);
+ref = dot_top;
+}
+);
+width = 816;
+}
+);
+note = uni14B8;
+unicode = 5304;
+},
+{
+glyphname = "mwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (571,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni14B9;
+unicode = 5305;
+},
+{
+glyphname = "mwaaNaskapi-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ma-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni14BA;
+unicode = 5306;
+},
+{
+glyphname = "m-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(310,462,l),
+(168,462,l),
+(168,714,l),
+(55,714,l),
+(55,357,l),
+(310,357,l)
+);
+}
+);
+width = 352;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni14BB;
+unicode = 5307;
+},
+{
+glyphname = "mWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+ref = "t-canadian";
+}
+);
+width = 378;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "t-canadian";
+note = uni14BC;
+unicode = 5308;
+},
+{
+glyphname = "mh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(297,357,l),
+(297,714,l),
+(184,714,l),
+(184,462,l),
+(42,462,l),
+(42,357,l)
+);
+}
+);
+width = 352;
+}
+);
+metricLeft = "=|m-canadian";
+metricRight = "=|m-canadian";
+note = uni14BD;
+unicode = 5309;
+},
+{
+glyphname = "mAthapascan-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(320,357,l),
+(320,446,l),
+(167,446,l),
+(168,402,l),
+(260,494,ls),
+(298,531,o),
+(313,570,o),
+(313,607,cs),
+(313,674,o),
+(268,720,o),
+(184,720,cs),
+(94,720,o),
+(45,666,o),
+(43,588,c),
+(142,588,l),
+(142,623,o),
+(155,640,o),
+(181,640,cs),
+(203,640,o),
+(214,627,o),
+(214,604,cs),
+(214,580,o),
+(205,562,o),
+(176,531,cs),
+(56,415,l),
+(56,357,l)
+);
+}
+);
+width = 363;
+}
+);
+note = uni14BE;
+unicode = 5310;
+},
+{
+glyphname = "mSayisi-canadian";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = two.canadian;
+}
+);
+width = 609;
+}
+);
+note = uni14BF;
+unicode = 5311;
+},
+{
+glyphname = "ne-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (522,254);
+},
+{
+name = top_center_can;
+pos = (504,529);
+},
+{
+name = top_left_can;
+pos = (124,529);
+},
+{
+name = top_right_can;
+pos = (703,529);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(676,-15,o),
+(784,86,o),
+(784,248,cs),
+(784,416,o),
+(679,509,o),
+(502,509,cs),
+(42,509,l),
+(42,362,l),
+(337,362,l),
+(314,398,l),
+(279,360,o),
+(261,298,o),
+(261,239,cs),
+(261,82,o),
+(363,-15,o),
+(522,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(458,125,o),
+(424,174,o),
+(424,247,cs),
+(424,320,o),
+(458,369,o),
+(521,369,cs),
+(585,369,o),
+(621,321,o),
+(621,247,cs),
+(621,173,o),
+(585,125,o),
+(522,125,cs)
+);
+}
+);
+width = 827;
+}
+);
+metricRight = "=|ke-canadian";
+note = uni14C0;
+unicode = 5312;
+},
+{
+glyphname = "naai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (190,-185);
+ref = ring_top.canadian;
+}
+);
+width = 826;
+}
+);
+note = uni14C1;
+unicode = 5313;
+},
+{
+glyphname = "ni-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (306,254);
+},
+{
+name = top_center_can;
+pos = (326,529);
+},
+{
+name = top_left_can;
+pos = (125,529);
+},
+{
+name = top_right_can;
+pos = (702,529);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(464,-15,o),
+(565,82,o),
+(565,241,cs),
+(565,301,o),
+(547,362,o),
+(513,400,c),
+(489,362,l),
+(785,362,l),
+(785,509,l),
+(327,509,ls),
+(145,509,o),
+(43,404,o),
+(43,244,cs),
+(43,85,o),
+(149,-15,o),
+(305,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(241,125,o),
+(206,173,o),
+(206,248,cs),
+(206,322,o),
+(241,370,o),
+(305,370,cs),
+(368,370,o),
+(403,321,o),
+(403,248,cs),
+(403,174,o),
+(368,125,o),
+(305,125,cs)
+);
+}
+);
+width = 827;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+unicode = 5314;
+},
+{
+glyphname = "nii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (229,-185);
+ref = dot_top;
+}
+);
+width = 826;
+}
+);
+note = uni14C3;
+unicode = 5315;
+},
+{
+glyphname = "no-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (521,254);
+},
+{
+name = top_center_can;
+pos = (521,529);
+},
+{
+name = top_double;
+pos = (522,529);
+},
+{
+name = top_left_can;
+pos = (124,529);
+},
+{
+name = top_right_can;
+pos = (703,529);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(508,0,ls),
+(681,0,o),
+(784,97,o),
+(784,261,cs),
+(784,423,o),
+(679,524,o),
+(522,524,cs),
+(363,524,o),
+(261,425,o),
+(261,269,cs),
+(261,210,o),
+(279,149,o),
+(315,111,c),
+(337,147,l),
+(42,147,l),
+(42,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(458,139,o),
+(424,188,o),
+(424,262,cs),
+(424,336,o),
+(458,384,o),
+(522,384,cs),
+(585,384,o),
+(621,336,o),
+(621,262,cs),
+(621,187,o),
+(585,139,o),
+(521,139,cs)
+);
+}
+);
+width = 827;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14C4;
+unicode = 5316;
+},
+{
+glyphname = "noo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (423,-185);
+ref = dot_top;
+}
+);
+width = 826;
+}
+);
+note = uni14C5;
+unicode = 5317;
+},
+{
+glyphname = "ycreenoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (234,-185);
+ref = doubledot_top;
+}
+);
+width = 826;
+}
+);
+note = uni14C6;
+unicode = 5318;
+},
+{
+glyphname = "na-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (306,254);
+},
+{
+name = top_center_can;
+pos = (306,529);
+},
+{
+name = top_double;
+pos = (491,529);
+},
+{
+name = top_left_can;
+pos = (125,529);
+},
+{
+name = top_right_can;
+pos = (702,529);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(785,0,l),
+(785,148,l),
+(489,148,l),
+(512,109,l),
+(547,147,o),
+(565,209,o),
+(565,268,cs),
+(565,427,o),
+(464,524,o),
+(305,524,cs),
+(149,524,o),
+(43,423,o),
+(43,261,cs),
+(43,101,o),
+(144,0,o),
+(321,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(241,139,o),
+(206,187,o),
+(206,262,cs),
+(206,336,o),
+(241,384,o),
+(305,384,cs),
+(368,384,o),
+(403,336,o),
+(403,262,cs),
+(403,188,o),
+(368,139,o),
+(305,139,cs)
+);
+}
+);
+width = 827;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+unicode = 5319;
+},
+{
+glyphname = "naa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (208,-185);
+ref = dot_top;
+}
+);
+width = 826;
+}
+);
+note = uni14C8;
+unicode = 5320;
+},
+{
+glyphname = "nwe-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ne-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni14C9;
+unicode = 5321;
+},
+{
+glyphname = "nweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (826,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni14CA;
+unicode = 5322;
+},
+{
+glyphname = "nwa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "na-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni14CB;
+unicode = 5323;
+},
+{
+glyphname = "nwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (826,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni14CC;
+unicode = 5324;
+},
+{
+glyphname = "nwaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (453,-185);
+ref = dot_top;
+}
+);
+width = 1071;
+}
+);
+note = uni14CD;
+unicode = 5325;
+},
+{
+glyphname = "nwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (208,-185);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (826,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni14CE;
+unicode = 5326;
+},
+{
+glyphname = "nwaaNaskapi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (203,-185);
+ref = doubledot_top;
+}
+);
+width = 826;
+}
+);
+note = uni14CF;
+unicode = 5327;
+},
+{
+glyphname = "n-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(447,450,l),
+(447,555,l),
+(285,555,l),
+(290,506,l),
+(311,517,o),
+(330,550,o),
+(330,591,cs),
+(330,670,o),
+(277,721,o),
+(188,721,cs),
+(101,721,o),
+(45,668,o),
+(45,585,cs),
+(45,505,o),
+(99,450,o),
+(193,450,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(163,531,o),
+(145,549,o),
+(145,585,cs),
+(145,622,o),
+(163,641,o),
+(188,641,cs),
+(213,641,o),
+(230,622,o),
+(230,585,cs),
+(230,550,o),
+(213,531,o),
+(188,531,cs)
+);
+}
+);
+width = 489;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni14D0;
+unicode = 5328;
+},
+{
+color = 6;
+glyphname = "ngCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-167);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 444;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "=|";
+note = uni14D1;
+unicode = 5329;
+},
+{
+glyphname = "nh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(296,450,ls),
+(390,450,o),
+(444,505,o),
+(444,585,cs),
+(444,668,o),
+(388,721,o),
+(301,721,cs),
+(212,721,o),
+(159,670,o),
+(159,591,cs),
+(159,550,o),
+(178,517,o),
+(199,506,c),
+(204,555,l),
+(42,555,l),
+(42,450,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(276,531,o),
+(259,550,o),
+(259,585,cs),
+(259,622,o),
+(276,641,o),
+(301,641,cs),
+(326,641,o),
+(344,622,o),
+(344,585,cs),
+(344,549,o),
+(326,531,o),
+(301,531,cs)
+);
+}
+);
+width = 489;
+}
+);
+metricLeft = "=|n-canadian";
+metricRight = "=|n-canadian";
+note = uni14D2;
+unicode = 5330;
+},
+{
+glyphname = "le-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (521,254);
+},
+{
+name = top_center_can;
+pos = (505,529);
+},
+{
+name = top_left_can;
+pos = (124,529);
+},
+{
+name = top_right_can;
+pos = (702,529);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(504,0,ls),
+(674,0,o),
+(784,93,o),
+(784,255,cs),
+(784,416,o),
+(683,509,o),
+(504,509,cs),
+(42,509,l),
+(42,361,l),
+(501,361,ls),
+(575,361,o),
+(619,324,o),
+(619,253,cs),
+(619,182,o),
+(573,145,o),
+(495,145,cs),
+(442,145,l),
+(442,0,l)
+);
+}
+);
+width = 827;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D3;
+unicode = 5331;
+},
+{
+glyphname = "laai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (190,-185);
+ref = ring_top.canadian;
+}
+);
+width = 826;
+}
+);
+note = uni14D4;
+unicode = 5332;
+},
+{
+glyphname = "li-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (306,254);
+},
+{
+name = top_center_can;
+pos = (326,529);
+},
+{
+name = top_left_can;
+pos = (125,529);
+},
+{
+name = top_right_can;
+pos = (702,529);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(385,0,l),
+(385,145,l),
+(330,145,ls),
+(251,145,o),
+(207,182,o),
+(207,252,cs),
+(207,321,o),
+(248,361,o),
+(327,361,cs),
+(785,361,l),
+(785,509,l),
+(322,509,ls),
+(151,509,o),
+(43,414,o),
+(43,253,cs),
+(43,93,o),
+(151,0,o),
+(323,0,cs)
+);
+}
+);
+width = 827;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14D5;
+unicode = 5333;
+},
+{
+glyphname = "lii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (229,-185);
+ref = dot_top;
+}
+);
+width = 826;
+}
+);
+note = uni14D6;
+unicode = 5334;
+},
+{
+glyphname = "lo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (521,254);
+},
+{
+name = top_center_can;
+pos = (521,529);
+},
+{
+name = top_double;
+pos = (508,529);
+},
+{
+name = top_left_can;
+pos = (124,529);
+},
+{
+name = top_right_can;
+pos = (702,529);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(502,0,ls),
+(677,0,o),
+(784,93,o),
+(784,255,cs),
+(784,418,o),
+(674,509,o),
+(508,509,cs),
+(442,509,l),
+(442,365,l),
+(497,365,ls),
+(578,365,o),
+(619,328,o),
+(619,257,cs),
+(619,186,o),
+(577,148,o),
+(501,148,cs),
+(42,148,l),
+(42,0,l)
+);
+}
+);
+width = 827;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D7;
+unicode = 5335;
+},
+{
+glyphname = "loo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (423,-185);
+ref = dot_top;
+}
+);
+width = 826;
+}
+);
+note = uni14D8;
+unicode = 5336;
+},
+{
+glyphname = "ycreeloo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (220,-185);
+ref = doubledot_top;
+}
+);
+width = 826;
+}
+);
+note = uni14D9;
+unicode = 5337;
+},
+{
+glyphname = "la-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (306,254);
+},
+{
+name = top_center_can;
+pos = (306,529);
+},
+{
+name = top_left_can;
+pos = (125,529);
+},
+{
+name = top_right_can;
+pos = (702,529);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(785,0,l),
+(785,148,l),
+(327,148,ls),
+(247,148,o),
+(207,186,o),
+(207,256,cs),
+(207,327,o),
+(250,365,o),
+(326,365,cs),
+(385,365,l),
+(385,509,l),
+(320,509,ls),
+(150,509,o),
+(43,413,o),
+(43,254,cs),
+(43,92,o),
+(150,0,o),
+(322,0,cs)
+);
+}
+);
+width = 827;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14DA;
+unicode = 5338;
+},
+{
+glyphname = "laa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (208,-185);
+ref = dot_top;
+}
+);
+width = 826;
+}
+);
+note = uni14DB;
+unicode = 5339;
+},
+{
+glyphname = "lwe-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "le-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni14DC;
+unicode = 5340;
+},
+{
+glyphname = "lweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "le-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (826,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni14DD;
+unicode = 5341;
+},
+{
+glyphname = "lwi-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "li-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni14DE;
+unicode = 5342;
+},
+{
+glyphname = "lwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (826,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni14DF;
+unicode = 5343;
+},
+{
+glyphname = "lwii-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (474,-185);
+ref = dot_top;
+}
+);
+width = 1071;
+}
+);
+note = uni14E0;
+unicode = 5344;
+},
+{
+glyphname = "lwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (229,-185);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (826,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni14E1;
+unicode = 5345;
+},
+{
+glyphname = "lwo-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "lo-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni14E2;
+unicode = 5346;
+},
+{
+glyphname = "lwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (826,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni14E3;
+unicode = 5347;
+},
+{
+glyphname = "lwoo-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (668,-185);
+ref = dot_top;
+}
+);
+width = 1071;
+}
+);
+note = uni14E4;
+unicode = 5348;
+},
+{
+glyphname = "lwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (423,-185);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (826,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni14E5;
+unicode = 5349;
+},
+{
+glyphname = "lwa-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "la-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni14E6;
+unicode = 5350;
+},
+{
+glyphname = "lwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (826,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni14E7;
+unicode = 5351;
+},
+{
+glyphname = "lwaa-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (453,-185);
+ref = dot_top;
+}
+);
+width = 1071;
+}
+);
+note = uni14E8;
+unicode = 5352;
+},
+{
+glyphname = "lwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (208,-185);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (826,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni14E9;
+unicode = 5353;
+},
+{
+glyphname = "l-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(432,357,l),
+(432,462,l),
+(244,462,ls),
+(190,462,o),
+(161,486,o),
+(161,536,cs),
+(161,585,o),
+(190,613,o),
+(243,613,cs),
+(258,613,l),
+(258,714,l),
+(234,714,ls),
+(118,714,o),
+(48,645,o),
+(48,535,cs),
+(48,425,o),
+(118,357,o),
+(234,357,cs)
+);
+}
+);
+width = 474;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "m-canadian";
+note = uni14EA;
+unicode = 5354;
+},
+{
+glyphname = "lWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(304,357,l),
+(304,430,l),
+(144,499,l),
+(144,445,l),
+(304,513,l),
+(304,558,l),
+(144,628,l),
+(144,571,l),
+(304,640,l),
+(304,714,l),
+(286,714,l),
+(55,618,l),
+(55,584,l),
+(221,515,l),
+(221,555,l),
+(55,487,l),
+(55,453,l),
+(286,357,l)
+);
+}
+);
+width = 359;
+}
+);
+metricRight = "=|";
+note = uni14EB;
+unicode = 5355;
+},
+{
+glyphname = "mediall-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(576,-15,l),
+(576,107,l),
+(227,253,l),
+(227,180,l),
+(576,325,l),
+(576,389,l),
+(227,534,l),
+(227,460,l),
+(576,607,l),
+(576,729,l),
+(537,729,l),
+(57,529,l),
+(57,472,l),
+(407,328,l),
+(407,386,l),
+(57,242,l),
+(57,185,l),
+(537,-15,l)
+);
+}
+);
+width = 633;
+}
+);
+metricRight = "=|";
+note = uni14EC;
+unicode = 5356;
+},
+{
+glyphname = "se-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (148,714);
+},
+{
+name = top_right_can;
+pos = (430,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(512,0,l),
+(512,379,l),
+(469,379,ls),
+(308,379,o),
+(230,443,o),
+(230,624,cs),
+(230,714,l),
+(64,714,l),
+(64,609,ls),
+(64,362,o),
+(201,232,o),
+(434,232,cs),
+(472,232,l),
+(346,287,l),
+(346,0,l)
+);
+}
+);
+width = 577;
+}
+);
+note = uni14ED;
+unicode = 5357;
+},
+{
+glyphname = "saai-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (293,0);
+ref = ring_top.canadian;
+}
+);
+width = 577;
+}
+);
+note = uni14EE;
+unicode = 5358;
+},
+{
+glyphname = "si-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (148,714);
+},
+{
+name = top_right_can;
+pos = (430,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(231,0,l),
+(231,287,l),
+(105,232,l),
+(143,232,ls),
+(376,232,o),
+(512,362,o),
+(512,609,cs),
+(512,714,l),
+(346,714,l),
+(346,624,ls),
+(346,443,o),
+(269,379,o),
+(108,379,cs),
+(65,379,l),
+(65,0,l)
+);
+}
+);
+width = 576;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+unicode = 5359;
+},
+{
+glyphname = "sii-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (332,0);
+ref = dot_top;
+}
+);
+width = 577;
+}
+);
+note = uni14F0;
+unicode = 5360;
+},
+{
+glyphname = "so-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (429,714);
+},
+{
+name = top_left_can;
+pos = (148,714);
+},
+{
+name = top_right_can;
+pos = (429,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(230,0,l),
+(230,90,ls),
+(230,271,o),
+(308,335,o),
+(469,335,cs),
+(512,335,l),
+(512,714,l),
+(346,714,l),
+(346,427,l),
+(472,482,l),
+(434,482,ls),
+(201,482,o),
+(64,352,o),
+(64,105,cs),
+(64,0,l)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+unicode = 5361;
+},
+{
+glyphname = "soo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (332,0);
+ref = dot_top;
+}
+);
+width = 577;
+}
+);
+note = uni14F2;
+unicode = 5362;
+},
+{
+glyphname = "ycreesoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (141,0);
+ref = doubledot_top;
+}
+);
+width = 577;
+}
+);
+note = uni14F3;
+unicode = 5363;
+},
+{
+glyphname = "sa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (148,714);
+},
+{
+name = top_right_can;
+pos = (430,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(512,0,l),
+(512,105,ls),
+(512,352,o),
+(376,482,o),
+(143,482,cs),
+(105,482,l),
+(231,427,l),
+(231,714,l),
+(65,714,l),
+(65,335,l),
+(108,335,ls),
+(269,335,o),
+(346,271,o),
+(346,90,cs),
+(346,0,l)
+);
+}
+);
+width = 576;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+unicode = 5364;
+},
+{
+glyphname = "saa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+}
+);
+width = 577;
+}
+);
+note = uni14F5;
+unicode = 5365;
+},
+{
+glyphname = "swe-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "se-canadian";
+}
+);
+width = 821;
+}
+);
+note = uni14F6;
+unicode = 5366;
+},
+{
+glyphname = "sweWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "se-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (577,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 821;
+}
+);
+note = uni14F7;
+unicode = 5367;
+},
+{
+glyphname = "swi-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "si-canadian";
+}
+);
+width = 821;
+}
+);
+note = uni14F8;
+unicode = 5368;
+},
+{
+glyphname = "swiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (577,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 821;
+}
+);
+note = uni14F9;
+unicode = 5369;
+},
+{
+glyphname = "swii-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (577,0);
+ref = dot_top;
+}
+);
+width = 821;
+}
+);
+note = uni14FA;
+unicode = 5370;
+},
+{
+glyphname = "swiiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (332,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (577,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 821;
+}
+);
+note = uni14FB;
+unicode = 5371;
+},
+{
+glyphname = "swo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "so-canadian";
+}
+);
+width = 821;
+}
+);
+note = uni14FC;
+unicode = 5372;
+},
+{
+glyphname = "swoWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (577,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 821;
+}
+);
+note = uni14FD;
+unicode = 5373;
+},
+{
+glyphname = "swoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (577,0);
+ref = dot_top;
+}
+);
+width = 821;
+}
+);
+note = uni14FE;
+unicode = 5374;
+},
+{
+glyphname = "swooWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (332,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (577,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 821;
+}
+);
+note = uni14FF;
+unicode = 5375;
+},
+{
+glyphname = "swa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "sa-canadian";
+}
+);
+width = 821;
+}
+);
+note = uni1500;
+unicode = 5376;
+},
+{
+glyphname = "swaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (577,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 821;
+}
+);
+note = uni1501;
+unicode = 5377;
+},
+{
+glyphname = "swaa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (296,0);
+ref = dot_top;
+}
+);
+width = 821;
+}
+);
+note = uni1502;
+unicode = 5378;
+},
+{
+glyphname = "swaaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (577,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 821;
+}
+);
+note = uni1503;
+unicode = 5379;
+},
+{
+glyphname = "swaaNaskapi-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "sa-canadian";
+}
+);
+width = 821;
+}
+);
+note = uni1504;
+unicode = 5380;
+},
+{
+glyphname = "s-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(320,357,l),
+(320,415,ls),
+(320,539,o),
+(249,614,o),
+(139,614,cs),
+(93,614,l),
+(168,570,l),
+(168,714,l),
+(55,714,l),
+(55,525,l),
+(93,525,ls),
+(170,525,o),
+(207,491,o),
+(207,411,cs),
+(207,357,l)
+);
+}
+);
+width = 375;
+}
+);
+metricRight = "=|";
+note = uni1505;
+unicode = 5381;
+},
+{
+color = 6;
+glyphname = "sAthapascan-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(287,183,o),
+(341,230,o),
+(341,292,cs),
+(341,337,o),
+(316,373,o),
+(260,391,cs),
+(185,415,ls),
+(165,423,o),
+(158,430,o),
+(158,444,cs),
+(158,461,o),
+(170,473,o),
+(197,473,cs),
+(225,473,o),
+(241,463,o),
+(242,430,c),
+(339,430,l),
+(338,509,o),
+(284,552,o),
+(199,552,cs),
+(116.008,552,o),
+(60,508,o),
+(60,443,cs),
+(60,397,o),
+(87,359,o),
+(139,342,cs),
+(214,318,ls),
+(235,311,o),
+(243,303,o),
+(243,289,cs),
+(243,271,o),
+(228,262,o),
+(203,262,cs),
+(171,262,o),
+(155,274,o),
+(153,305,c),
+(55,305,l),
+(57,226,o),
+(111,183,o),
+(201,183,cs)
+);
+}
+);
+width = 396;
+}
+);
+metricRight = "=|";
+note = uni1506;
+unicode = 5382;
+},
+{
+glyphname = "sw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(168,357,l),
+(168,411,ls),
+(168,491,o),
+(205,525,o),
+(282,525,cs),
+(320,525,l),
+(320,714,l),
+(207,714,l),
+(207,570,l),
+(282,614,l),
+(236,614,ls),
+(127,614,o),
+(55,539,o),
+(55,415,cs),
+(55,357,l)
+);
+}
+);
+width = 375;
+}
+);
+metricLeft = "=|s-canadian";
+metricRight = "=|s-canadian";
+note = uni1507;
+unicode = 5383;
+},
+{
+glyphname = "sBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(324,357,l),
+(324,462,l),
+(234,462,ls),
+(190,462,o),
+(168,483,o),
+(168,528,cs),
+(168,714,l),
+(55,714,l),
+(55,512,ls),
+(55,413,o),
+(112,357,o),
+(212,357,c)
+);
+}
+);
+width = 366;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "m-canadian";
+note = uni1508;
+unicode = 5384;
+},
+{
+glyphname = "moosecreesk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(281,225,o),
+(344,280,o),
+(344,392,cs),
+(344,531,o),
+(273,613,o),
+(145,613,cs),
+(114,613,l),
+(172,569,l),
+(172,714,l),
+(59,714,l),
+(59,526,l),
+(108,526,ls),
+(201,526,o),
+(227,499,o),
+(235,449,c),
+(263,447,l),
+(255,470,o),
+(228,493,o),
+(189,493,cs),
+(110,493,o),
+(56,439,o),
+(56,361,cs),
+(56,274,o),
+(119,225,o),
+(196,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(174,305,o),
+(155,323,o),
+(155,360,cs),
+(155,398,o),
+(174,416,o),
+(199,416,cs),
+(223,416,o),
+(241,398,o),
+(241,360,cs),
+(241,323,o),
+(224,305,o),
+(199,305,cs)
+);
+}
+);
+width = 400;
+}
+);
+metricRight = "=|";
+note = uni1509;
+unicode = 5385;
+},
+{
+glyphname = "skwNaskapi-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(281,225,o),
+(344,274,o),
+(344,361,cs),
+(344,439,o),
+(290,493,o),
+(211,493,cs),
+(172,493,o),
+(146,470,o),
+(137,447,c),
+(165,449,l),
+(173,499,o),
+(199,526,o),
+(292,526,cs),
+(341,526,l),
+(341,714,l),
+(228,714,l),
+(228,569,l),
+(286,613,l),
+(255,613,ls),
+(127,613,o),
+(56,531,o),
+(56,392,cs),
+(56,280,o),
+(119,225,o),
+(204,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(176,305,o),
+(159,323,o),
+(159,360,cs),
+(159,398,o),
+(177,416,o),
+(201,416,cs),
+(226,416,o),
+(245,398,o),
+(245,360,cs),
+(245,323,o),
+(226,305,o),
+(201,305,cs)
+);
+}
+);
+width = 400;
+}
+);
+metricLeft = "=|moosecreesk-canadian";
+metricRight = "=|moosecreesk-canadian";
+note = uni150A;
+unicode = 5386;
+},
+{
+glyphname = "swNaskapi-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(339,198,l),
+(339,246,ls),
+(339,358,o),
+(269,431,o),
+(159,431,cs),
+(124,431,l),
+(178,388,l),
+(178,517,l),
+(65,517,l),
+(65,345,l),
+(114,345,ls),
+(190,345,o),
+(226,316,o),
+(226,241,cs),
+(226,198,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(325,2,o),
+(360,37,o),
+(360,79,cs),
+(360,122,o),
+(325,157,o),
+(283,157,cs),
+(240,157,o),
+(206,122,o),
+(206,79,cs),
+(206,37,o),
+(240,2,o),
+(283,2,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(164,557,o),
+(199,592,o),
+(199,635,cs),
+(199,677,o),
+(164,712,o),
+(122,712,cs),
+(79,712,o),
+(45,677,o),
+(45,635,cs),
+(45,592,o),
+(79,557,o),
+(122,557,cs)
+);
+}
+);
+width = 405;
+}
+);
+metricRight = "=|";
+note = uni150B;
+unicode = 5387;
+},
+{
+glyphname = "spwaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(625,0,l),
+(625,157,l),
+(223,393,l),
+(223,319,l),
+(625,556,l),
+(625,714,l),
+(585,714,l),
+(29,382,l),
+(29,332,l),
+(585,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(159,515,o),
+(194,549,o),
+(194,592,cs),
+(194,635,o),
+(159,670,o),
+(117,670,cs),
+(75,670,o),
+(41,635,o),
+(41,592,cs),
+(41,549,o),
+(75,515,o),
+(117,515,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(378,636,l),
+(378,684,ls),
+(378,777,o),
+(325,834,o),
+(235,834,cs),
+(206,834,l),
+(275,797,l),
+(275,906,l),
+(165,906,l),
+(165,753,l),
+(191,753,ls),
+(239,753,o),
+(268,728,o),
+(268,675,cs),
+(268,636,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(543,740,o),
+(577,775,o),
+(577,818,cs),
+(577,860,o),
+(543,895,o),
+(500,895,cs),
+(458,895,o),
+(424,860,o),
+(424,818,cs),
+(424,775,o),
+(458,740,o),
+(500,740,cs)
+);
+}
+);
+width = 668;
+}
+);
+metricRight = "pa-canadian";
+metricWidth = "pa-canadian";
+note = uni150C;
+unicode = 5388;
+},
+{
+glyphname = "stwaNaskapi-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (404,0);
+ref = "ta-canadian";
+}
+);
+width = 1044;
+}
+);
+note = uni150D;
+unicode = 5389;
+},
+{
+glyphname = "skwaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (404,0);
+ref = "ka-canadian";
+}
+);
+width = 1019;
+}
+);
+note = uni150E;
+unicode = 5390;
+},
+{
+glyphname = "scwaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (404,0);
+ref = "ca-canadian";
+}
+);
+width = 1011;
+}
+);
+note = uni150F;
+unicode = 5391;
+},
+{
+glyphname = "she-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (294,714);
+},
+{
+name = top_right_can;
+pos = (758,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(774,-15,o),
+(866,85,o),
+(866,261,cs),
+(866,321,l),
+(701,321,l),
+(701,248,ls),
+(701,167,o),
+(673,129,o),
+(623,129,cs),
+(569,129,o),
+(545,168,o),
+(540,250,cs),
+(530,465,ls),
+(521,633,o),
+(446,729,o),
+(294,729,cs),
+(137,729,o),
+(41,629,o),
+(41,453,cs),
+(41,393,l),
+(206,393,l),
+(206,469,ls),
+(206,546,o),
+(235,585,o),
+(286,585,cs),
+(337,585,o),
+(363,547,o),
+(367,468,cs),
+(377,249,ls),
+(385,83,o),
+(458,-15,o),
+(618,-15,cs)
+);
+}
+);
+width = 907;
+}
+);
+metricRight = "=|";
+note = uni1510;
+unicode = 5392;
+},
+{
+glyphname = "shi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (151,714);
+},
+{
+name = top_right_can;
+pos = (613,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(449,-15,o),
+(522,83,o),
+(530,249,cs),
+(540,468,ls),
+(544,547,o),
+(570,585,o),
+(621,585,cs),
+(672,585,o),
+(701,546,o),
+(701,469,cs),
+(701,393,l),
+(866,393,l),
+(866,453,ls),
+(866,629,o),
+(770,729,o),
+(613,729,cs),
+(461,729,o),
+(386,633,o),
+(377,465,cs),
+(367,250,ls),
+(362,168,o),
+(338,129,o),
+(284,129,cs),
+(234,129,o),
+(206,167,o),
+(206,248,cs),
+(206,321,l),
+(41,321,l),
+(41,261,ls),
+(41,85,o),
+(134,-15,o),
+(289,-15,cs)
+);
+}
+);
+width = 907;
+}
+);
+metricLeft = "she-canadian";
+metricRight = "she-canadian";
+note = uni1511;
+unicode = 5393;
+},
+{
+glyphname = "shii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (516,0);
+ref = dot_top;
+}
+);
+width = 907;
+}
+);
+note = uni1512;
+unicode = 5394;
+},
+{
+glyphname = "sho-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (465,529);
+},
+{
+name = top_left_can;
+pos = (289,529);
+},
+{
+name = top_right_can;
+pos = (641,529);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(371,124,l),
+(263,123,o),
+(206,150,o),
+(206,204,cs),
+(206,239,o),
+(229,259,o),
+(272,259,cs),
+(382,259,o),
+(502,106,o),
+(675,106,cs),
+(802,106,o),
+(887,182,o),
+(887,298,cs),
+(887,440,o),
+(766,525,o),
+(564,524,c),
+(559,385,l),
+(667,386,o),
+(724,359,o),
+(724,306,cs),
+(724,271,o),
+(701,250,o),
+(658,250,cs),
+(548,250,o),
+(428,403,o),
+(254,403,cs),
+(128,403,o),
+(43,327,o),
+(43,211,cs),
+(43,69,o),
+(165,-16,o),
+(366,-15,c)
+);
+}
+);
+width = 930;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1513;
+unicode = 5395;
+},
+{
+glyphname = "shoo-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (368,-185);
+ref = dot_top;
+}
+);
+width = 930;
+}
+);
+note = uni1514;
+unicode = 5396;
+},
+{
+glyphname = "sha-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (465,529);
+},
+{
+name = top_left_can;
+pos = (289,529);
+},
+{
+name = top_right_can;
+pos = (641,529);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(766,-18,o),
+(887,69,o),
+(887,210,cs),
+(887,327,o),
+(806,403,o),
+(675,403,cs),
+(502,403,o),
+(382,250,o),
+(272,250,cs),
+(229,250,o),
+(206,271,o),
+(206,306,cs),
+(206,359,o),
+(263,388,o),
+(371,385,c),
+(366,524,l),
+(165,528,o),
+(43,440,o),
+(43,300,cs),
+(43,182,o),
+(124,106,o),
+(254,106,cs),
+(428,106,o),
+(548,259,o),
+(658,259,cs),
+(701,259,o),
+(724,239,o),
+(724,204,cs),
+(724,150,o),
+(667,121,o),
+(559,124,c),
+(564,-15,l)
+);
+}
+);
+width = 930;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1515;
+unicode = 5397;
+},
+{
+glyphname = "shaa-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (368,-185);
+ref = dot_top;
+}
+);
+width = 930;
+}
+);
+note = uni1516;
+unicode = 5398;
+},
+{
+glyphname = "shwe-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "she-canadian";
+}
+);
+width = 1152;
+}
+);
+note = uni1517;
+unicode = 5399;
+},
+{
+glyphname = "shweWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "she-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (907,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1152;
+}
+);
+note = uni1518;
+unicode = 5400;
+},
+{
+glyphname = "shwi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "shi-canadian";
+}
+);
+width = 1152;
+}
+);
+note = uni1519;
+unicode = 5401;
+},
+{
+glyphname = "shwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (907,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1152;
+}
+);
+note = uni151A;
+unicode = 5402;
+},
+{
+glyphname = "shwii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (761,0);
+ref = dot_top;
+}
+);
+width = 1152;
+}
+);
+note = uni151B;
+unicode = 5403;
+},
+{
+glyphname = "shwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (516,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (907,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1152;
+}
+);
+note = uni151C;
+unicode = 5404;
+},
+{
+glyphname = "shwo-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "sho-canadian";
+}
+);
+width = 1175;
+}
+);
+note = uni151D;
+unicode = 5405;
+},
+{
+glyphname = "shwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (930,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1175;
+}
+);
+note = uni151E;
+unicode = 5406;
+},
+{
+glyphname = "shwoo-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (612,-185);
+ref = dot_top;
+}
+);
+width = 1175;
+}
+);
+note = uni151F;
+unicode = 5407;
+},
+{
+glyphname = "shwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (368,-185);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (930,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1175;
+}
+);
+note = uni1520;
+unicode = 5408;
+},
+{
+glyphname = "shwa-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "sha-canadian";
+}
+);
+width = 1175;
+}
+);
+note = uni1521;
+unicode = 5409;
+},
+{
+glyphname = "shwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (930,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1175;
+}
+);
+note = uni1522;
+unicode = 5410;
+},
+{
+glyphname = "shwaa-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (612,-185);
+ref = dot_top;
+}
+);
+width = 1175;
+}
+);
+note = uni1523;
+unicode = 5411;
+},
+{
+glyphname = "shwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (368,-185);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (930,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1175;
+}
+);
+note = uni1524;
+unicode = 5412;
+},
+{
+glyphname = "sh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(583,294,o),
+(681,355,o),
+(681,465,cs),
+(681,553,o),
+(620,617,o),
+(519,617,cs),
+(391,617,o),
+(303,509,o),
+(220,509,cs),
+(183,509,o),
+(165,527,o),
+(165,556,cs),
+(165,599,o),
+(210,623,o),
+(295,623,c),
+(291,724,l),
+(147,724,o),
+(48,663,o),
+(48,553,cs),
+(48,465,o),
+(109,401,o),
+(210,401,cs),
+(338,401,o),
+(426,509,o),
+(509,509,cs),
+(546,509,o),
+(565,491,o),
+(565,462,cs),
+(565,419,o),
+(519,395,o),
+(434,395,c),
+(439,294,l)
+);
+}
+);
+width = 729;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni1525;
+unicode = 5413;
+},
+{
+glyphname = "ye-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (684,357);
+},
+{
+name = top_left_can;
+pos = (112,714);
+},
+{
+name = top_right_can;
+pos = (454,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(536,0,l),
+(536,365,l),
+(242,365,l),
+(246,286,l),
+(558,628,l),
+(446,726,l),
+(30,262,l),
+(30,221,l),
+(370,221,l),
+(370,0,l)
+);
+}
+);
+width = 600;
+}
+);
+note = uni1526;
+unicode = 5414;
+},
+{
+glyphname = "yaai-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (11,0);
+ref = ring_top.canadian;
+}
+);
+width = 600;
+}
+);
+note = uni1527;
+unicode = 5415;
+},
+{
+glyphname = "yi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (148,714);
+},
+{
+name = top_right_can;
+pos = (488,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(231,0,l),
+(231,221,l),
+(570,221,l),
+(570,262,l),
+(155,726,l),
+(45,629,l),
+(356,287,l),
+(360,365,l),
+(65,365,l),
+(65,0,l)
+);
+}
+);
+width = 600;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni1528;
+unicode = 5416;
+},
+{
+glyphname = "yii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+}
+);
+width = 600;
+}
+);
+note = uni1529;
+unicode = 5417;
+},
+{
+glyphname = "yo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (684,357);
+},
+{
+name = top_double;
+pos = (453,714);
+},
+{
+name = top_left_can;
+pos = (112,714);
+},
+{
+name = top_right_can;
+pos = (453,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(556,85,l),
+(245,427,l),
+(240,349,l),
+(536,349,l),
+(536,714,l),
+(370,714,l),
+(370,493,l),
+(30,493,l),
+(30,452,l),
+(446,-12,l)
+);
+}
+);
+width = 600;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152A;
+unicode = 5418;
+},
+{
+glyphname = "yoo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (356,0);
+ref = dot_top;
+}
+);
+width = 600;
+}
+);
+note = uni152B;
+unicode = 5419;
+},
+{
+glyphname = "ycreeyoo-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (165,0);
+ref = doubledot_top;
+}
+);
+width = 600;
+}
+);
+note = uni152C;
+unicode = 5420;
+},
+{
+glyphname = "ya-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (148,714);
+},
+{
+name = top_right_can;
+pos = (488,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(570,452,l),
+(570,493,l),
+(231,493,l),
+(231,714,l),
+(65,714,l),
+(65,349,l),
+(358,349,l),
+(354,428,l),
+(43,86,l),
+(155,-12,l)
+);
+}
+);
+width = 600;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152D;
+unicode = 5421;
+},
+{
+glyphname = "yaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+}
+);
+width = 600;
+}
+);
+note = uni152E;
+unicode = 5422;
+},
+{
+glyphname = "ywe-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ye-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni152F;
+unicode = 5423;
+},
+{
+glyphname = "yweWestCree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ye-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (600,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni1530;
+unicode = 5424;
+},
+{
+glyphname = "ywi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "yi-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni1531;
+unicode = 5425;
+},
+{
+glyphname = "ywiWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (600,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni1532;
+unicode = 5426;
+},
+{
+glyphname = "ywii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (295,0);
+ref = dot_top;
+}
+);
+width = 845;
+}
+);
+note = uni1533;
+unicode = 5427;
+},
+{
+glyphname = "ywiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (600,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni1534;
+unicode = 5428;
+},
+{
+glyphname = "ywo-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "yo-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni1535;
+unicode = 5429;
+},
+{
+glyphname = "ywoWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (600,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni1536;
+unicode = 5430;
+},
+{
+glyphname = "ywoo-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (601,0);
+ref = dot_top;
+}
+);
+width = 845;
+}
+);
+note = uni1537;
+unicode = 5431;
+},
+{
+glyphname = "ywooWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (356,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (600,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni1538;
+unicode = 5432;
+},
+{
+glyphname = "ywa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ya-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni1539;
+unicode = 5433;
+},
+{
+glyphname = "ywaWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (600,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni153A;
+unicode = 5434;
+},
+{
+glyphname = "ywaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (296,0);
+ref = dot_top;
+}
+);
+width = 845;
+}
+);
+note = uni153B;
+unicode = 5435;
+},
+{
+glyphname = "ywaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (600,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni153C;
+unicode = 5436;
+},
+{
+glyphname = "ywaaNaskapi-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ya-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni153D;
+unicode = 5437;
+},
+{
+glyphname = "y-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(328,575,l),
+(328,603,l),
+(170,603,l),
+(170,714,l),
+(57,714,l),
+(57,514,l),
+(208,514,l),
+(207,582,l),
+(55,407,l),
+(133,347,l)
+);
+}
+);
+width = 351;
+}
+);
+note = uni153E;
+unicode = 5438;
+},
+{
+glyphname = "biblecreey-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(208,602,l),
+(145,602,l),
+(238,357,l),
+(309,357,l),
+(402,602,l),
+(339,602,l),
+(401,357,l),
+(501,357,l),
+(501,383,l),
+(419,714,l),
+(343,714,l),
+(244,454,l),
+(302,454,l),
+(203,714,l),
+(127,714,l),
+(46,383,l),
+(46,357,l),
+(146,357,l)
+);
+}
+);
+width = 547;
+}
+);
+metricRight = "=|";
+note = uni153F;
+unicode = 5439;
+},
+{
+glyphname = "yWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(279,198,l),
+(279,315,l),
+(391,315,l),
+(391,422,l),
+(279,422,l),
+(279,535,l),
+(168,535,l),
+(168,422,l),
+(55,422,l),
+(55,315,l),
+(168,315,l),
+(168,198,l)
+);
+}
+);
+width = 446;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1540;
+unicode = 5440;
+},
+{
+glyphname = "yiSayisi-canadian";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,189);
+ref = "fullstop-canadian";
+}
+);
+width = 391;
+}
+);
+metricLeft = "fullstop-canadian";
+metricWidth = "fullstop-canadian";
+note = uni1541;
+unicode = 5441;
+},
+{
+glyphname = "re-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (320,529);
+},
+{
+name = top_left_can;
+pos = (144,529);
+},
+{
+name = top_right_can;
+pos = (753,529);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(481,-15,o),
+(576,89,o),
+(576,249,cs),
+(576,362,l),
+(835,362,l),
+(835,509,l),
+(414,509,l),
+(414,249,ls),
+(414,169,o),
+(380,128,o),
+(320,128,cs),
+(260,128,o),
+(227,170,o),
+(227,249,cs),
+(227,509,l),
+(61,509,l),
+(61,250,ls),
+(61,86,o),
+(159,-15,o),
+(320,-15,cs)
+);
+}
+);
+width = 877;
+}
+);
+metricRight = "=|ne-canadian";
+note = uni1542;
+unicode = 5442;
+},
+{
+glyphname = "reRCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (556,529);
+},
+{
+name = top_left_can;
+pos = (123,529);
+},
+{
+name = top_right_can;
+pos = (733,529);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(717,-15,o),
+(816,86,o),
+(816,250,cs),
+(816,509,l),
+(650,509,l),
+(650,249,ls),
+(650,170,o),
+(616,128,o),
+(556,128,cs),
+(496,128,o),
+(463,167,o),
+(463,247,cs),
+(463,509,l),
+(42,509,l),
+(42,362,l),
+(301,362,l),
+(301,248,ls),
+(301,88,o),
+(396,-15,o),
+(557,-15,cs)
+);
+}
+);
+width = 877;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1543;
+unicode = 5443;
+},
+{
+glyphname = "leWestCree-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (556,529);
+},
+{
+name = top_left_can;
+pos = (123,529);
+},
+{
+name = top_right_can;
+pos = (733,529);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(463,0,l),
+(463,254,ls),
+(463,340,o),
+(497,381,o),
+(558,381,cs),
+(617,381,o),
+(650,339,o),
+(650,260,cs),
+(650,0,l),
+(816,0,l),
+(816,260,ls),
+(816,424,o),
+(722,524,o),
+(559,524,cs),
+(400,524,o),
+(301,420,o),
+(301,254,cs),
+(301,147,l),
+(42,147,l),
+(42,0,l)
+);
+}
+);
+width = 877;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+unicode = 5444;
+},
+{
+glyphname = "raai-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (183,-185);
+ref = ring_top.canadian;
+}
+);
+width = 876;
+}
+);
+note = uni1545;
+unicode = 5445;
+},
+{
+glyphname = "ri-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (320,529);
+},
+{
+name = top_left_can;
+pos = (144,529);
+},
+{
+name = top_right_can;
+pos = (753,529);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(227,0,l),
+(227,260,ls),
+(227,339,o),
+(260,381,o),
+(320,381,cs),
+(380,381,o),
+(414,342,o),
+(414,262,cs),
+(414,0,l),
+(835,0,l),
+(835,147,l),
+(576,147,l),
+(576,262,ls),
+(576,422,o),
+(485,524,o),
+(321,524,cs),
+(162,524,o),
+(61,424,o),
+(61,257,cs),
+(61,0,l)
+);
+}
+);
+width = 877;
+}
+);
+metricLeft = "re-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+unicode = 5446;
+},
+{
+glyphname = "rii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (223,-185);
+ref = dot_top;
+}
+);
+width = 876;
+}
+);
+note = uni1547;
+unicode = 5447;
+},
+{
+glyphname = "ro-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (255,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(231,0,l),
+(231,262,l),
+(189,221,l),
+(273,221,ls),
+(431,221,o),
+(533,318,o),
+(533,465,cs),
+(533,623,o),
+(433,714,o),
+(248,714,cs),
+(65,714,l),
+(65,567,l),
+(250,567,ls),
+(326,567,o),
+(368,531,o),
+(368,467,cs),
+(368,403,o),
+(326,367,o),
+(250,367,cs),
+(65,367,l),
+(65,0,l)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1548;
+unicode = 5448;
+},
+{
+glyphname = "roo-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (158,0);
+ref = dot_top;
+}
+);
+width = 577;
+}
+);
+note = uni1549;
+unicode = 5449;
+},
+{
+glyphname = "loWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (257,714);
+},
+{
+name = top_left_can;
+pos = (148,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(248,0,ls),
+(433,0,o),
+(533,92,o),
+(533,249,cs),
+(533,397,o),
+(431,493,o),
+(273,493,cs),
+(189,493,l),
+(231,452,l),
+(231,714,l),
+(65,714,l),
+(65,348,l),
+(250,348,ls),
+(326,348,o),
+(368,311,o),
+(368,247,cs),
+(368,183,o),
+(326,147,o),
+(250,147,cs),
+(65,147,l),
+(65,0,l)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+unicode = 5450;
+},
+{
+glyphname = "ra-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (322,714);
+},
+{
+name = top_right_can;
+pos = (430,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(512,0,l),
+(512,367,l),
+(327,367,ls),
+(251,367,o),
+(209,403,o),
+(209,467,cs),
+(209,531,o),
+(251,567,o),
+(327,567,cs),
+(512,567,l),
+(512,714,l),
+(328,714,ls),
+(144,714,o),
+(44,623,o),
+(44,465,cs),
+(44,318,o),
+(146,221,o),
+(304,221,cs),
+(388,221,l),
+(346,262,l),
+(346,0,l)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+unicode = 5451;
+},
+{
+glyphname = "raa-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (224,0);
+ref = dot_top;
+}
+);
+width = 577;
+}
+);
+note = uni154C;
+unicode = 5452;
+},
+{
+glyphname = "laWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (430,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(512,0,l),
+(512,147,l),
+(327,147,ls),
+(251,147,o),
+(209,183,o),
+(209,247,cs),
+(209,311,o),
+(251,348,o),
+(327,348,cs),
+(512,348,l),
+(512,714,l),
+(346,714,l),
+(346,452,l),
+(388,493,l),
+(304,493,ls),
+(146,493,o),
+(44,397,o),
+(44,249,cs),
+(44,92,o),
+(144,0,o),
+(328,0,cs)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+unicode = 5453;
+},
+{
+glyphname = "rwaa-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (469,0);
+ref = dot_top;
+}
+);
+width = 822;
+}
+);
+note = uni154E;
+unicode = 5454;
+},
+{
+glyphname = "rwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (224,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (577,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni154F;
+unicode = 5455;
+},
+{
+glyphname = "r-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(291,357,l),
+(291,550,l),
+(198,550,ls),
+(166,550,o),
+(150,563,o),
+(150,588,cs),
+(150,612,o),
+(167,626,o),
+(198,626,cs),
+(291,626,l),
+(291,714,l),
+(196,714,ls),
+(99,714,o),
+(45,668,o),
+(45,587,cs),
+(45,513,o),
+(99,464,o),
+(184,464,cs),
+(234,464,l),
+(178,498,l),
+(178.002,357,l)
+);
+}
+);
+width = 346;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni1550;
+unicode = 5456;
+},
+{
+glyphname = "rWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(74,357,l),
+(304,453,l),
+(304,487,l),
+(139,555,l),
+(139,515,l),
+(304,584,l),
+(304,618,l),
+(74,714,l),
+(55,714,l),
+(55,640,l),
+(215,571,l),
+(215,628,l),
+(55,558,l),
+(55,513,l),
+(215,445,l),
+(215,499,l),
+(55,430,l),
+(55,357,l)
+);
+}
+);
+width = 359;
+}
+);
+metricLeft = "=|lWestCree-canadian";
+metricRight = "=|lWestCree-canadian";
+note = uni1551;
+unicode = 5457;
+},
+{
+glyphname = "rMedial-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(96,-15,l),
+(583,185,l),
+(583,239,l),
+(233,383,l),
+(233,331,l),
+(583,475,l),
+(583,529,l),
+(96,729,l),
+(57,729,l),
+(57,608,l),
+(414,462,l),
+(414,536,l),
+(57,391,l),
+(57,323,l),
+(414,178,l),
+(414,253,l),
+(57,106,l),
+(57,-15,l)
+);
+}
+);
+width = 640;
+}
+);
+metricLeft = "mediall-canadian";
+metricRight = "mediall-canadian";
+note = uni1552;
+unicode = 5458;
+},
+{
+glyphname = "fe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(413,0,l),
+(784,674,l),
+(784,714,l),
+(642,714,l),
+(359,191,l),
+(400,191,l),
+(297,360,l),
+(180,359,l),
+(205,329,o),
+(234,315,o),
+(274,315,cs),
+(367,315,o),
+(452,400,o),
+(452,524,cs),
+(452,641,o),
+(380,729,o),
+(262,729,cs),
+(144,729,o),
+(71,641,o),
+(71,530,cs),
+(71,473,o),
+(88,420,o),
+(127,360,cs),
+(364,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(227,433,o),
+(204,464,o),
+(204,524,cs),
+(204,582,o),
+(228,610,o),
+(262,610,cs),
+(297,610,o),
+(319,584,o),
+(319,523,cs),
+(319,461,o),
+(296,433,o),
+(262,433,cs)
+);
+}
+);
+width = 809;
+}
+);
+metricRight = "e-canadian";
+note = uni1553;
+unicode = 5459;
+},
+{
+glyphname = "faai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (254,0);
+ref = ring_top.canadian;
+}
+);
+width = 809;
+}
+);
+note = uni1554;
+unicode = 5460;
+},
+{
+glyphname = "fi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (391,714);
+},
+{
+name = top_left_can;
+pos = (152,714);
+},
+{
+name = top_right_can;
+pos = (646,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(380,-15,o),
+(452,73,o),
+(452,190,cs),
+(452,314,o),
+(367,399,o),
+(274,399,cs),
+(234,399,o),
+(205,385,o),
+(180,355,c),
+(297,354,l),
+(400,523,l),
+(359,523,l),
+(642,0,l),
+(784,0,l),
+(784,40,l),
+(413,714,l),
+(364,714,l),
+(126,352,ls),
+(87,293,o),
+(71,241,o),
+(71,184,cs),
+(71,73,o),
+(144,-15,o),
+(262,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(228,104,o),
+(204,132,o),
+(204,190,cs),
+(204,250,o),
+(227,281,o),
+(262,281,cs),
+(296,281,o),
+(319,253,o),
+(319,191,cs),
+(319,130,o),
+(297,104,o),
+(262,104,cs)
+);
+}
+);
+width = 809;
+}
+);
+metricLeft = "fe-canadian";
+metricRight = "e-canadian";
+note = uni1555;
+unicode = 5461;
+},
+{
+glyphname = "fii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (293,0);
+ref = dot_top;
+}
+);
+width = 809;
+}
+);
+note = uni1556;
+unicode = 5462;
+},
+{
+glyphname = "fo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (236,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(119,0,l),
+(670,332,l),
+(670,381,l),
+(372,670,ls),
+(329,713,o),
+(281,729,o),
+(234,729,cs),
+(130,729,o),
+(44,652,o),
+(44,519,cs),
+(44,399,o),
+(118,313,o),
+(230,313,cs),
+(341,313,o),
+(412,400,o),
+(412,519,cs),
+(412,545,o),
+(402,590,o),
+(390,618,c),
+(341,514,l),
+(505,357,l),
+(505,392,l),
+(80,139,l),
+(80,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,433,o),
+(177,460,o),
+(177,521,cs),
+(177,582,o),
+(200,610,o),
+(235,610,cs),
+(270,610,o),
+(291,585,o),
+(291,523,cs),
+(291,461,o),
+(269,433,o),
+(234,433,cs)
+);
+}
+);
+width = 698;
+}
+);
+metricRight = "o-canadian";
+note = uni1557;
+unicode = 5463;
+},
+{
+glyphname = "foo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "fo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (138,0);
+ref = dot_top;
+}
+);
+width = 699;
+}
+);
+note = uni1558;
+unicode = 5464;
+},
+{
+glyphname = "fa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (464,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(619,0,l),
+(619,137,l),
+(194,390,l),
+(194,361,l),
+(358,518,l),
+(309,618,l),
+(297,590,o),
+(287,545,o),
+(287,519,cs),
+(287,400,o),
+(358,313,o),
+(469,313,cs),
+(581,313,o),
+(655,399,o),
+(655,519,cs),
+(655,652,o),
+(569,729,o),
+(465,729,cs),
+(418,729,o),
+(370,713,o),
+(327,670,cs),
+(29,381,l),
+(29,332,l),
+(580,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(430,432,o),
+(408,461,o),
+(408,522,cs),
+(408,584,o),
+(429,609,o),
+(464,609,cs),
+(499,609,o),
+(522,582,o),
+(522,521,cs),
+(522,459,o),
+(499,432,o),
+(465,432,cs)
+);
+}
+);
+width = 699;
+}
+);
+metricRight = "=|fo-canadian";
+note = uni1559;
+unicode = 5465;
+},
+{
+glyphname = "faa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (366,0);
+ref = dot_top;
+}
+);
+width = 699;
+}
+);
+note = uni155A;
+unicode = 5466;
+},
+{
+glyphname = "fwaa-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (611,0);
+ref = dot_top;
+}
+);
+width = 944;
+}
+);
+note = uni155B;
+unicode = 5467;
+},
+{
+glyphname = "fwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (366,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (699,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 944;
+}
+);
+note = uni155C;
+unicode = 5468;
+},
+{
+glyphname = "f-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(342,357,l),
+(342,425,l),
+(131,549,l),
+(131,536,l),
+(209,614,l),
+(189,664,l),
+(182,651,o),
+(177,627,o),
+(177,612,cs),
+(177,552,o),
+(216,512,o),
+(268,512,cs),
+(322,512,o),
+(359,552,o),
+(359,615,cs),
+(359,688,o),
+(313,720,o),
+(265,720,cs),
+(243,720,o),
+(214,710,o),
+(191,688,cs),
+(46,546,l),
+(46,521,l),
+(322,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(249,572,o),
+(238,586,o),
+(238,615,cs),
+(238,647,o),
+(249,660,o),
+(266,660,cs),
+(283,660,o),
+(294,646,o),
+(294,615,cs),
+(294,586,o),
+(283,572,o),
+(267,572,cs)
+);
+}
+);
+width = 408;
+}
+);
+note = uni155D;
+unicode = 5469;
+},
+{
+glyphname = "the-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (854,357);
+},
+{
+name = top_center_can;
+pos = (380,714);
+},
+{
+name = top_left_can;
+pos = (138,714);
+},
+{
+name = top_right_can;
+pos = (620,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(583,-15,o),
+(703,108,o),
+(703,320,cs),
+(703,714,l),
+(536,714,l),
+(536,315,ls),
+(536,194,o),
+(482,132,o),
+(379,132,cs),
+(280,132,o),
+(222,185,o),
+(222,301,cs),
+(222,412,l),
+(160,358,l),
+(182,322,o),
+(219,302,o),
+(263,302,cs),
+(369,302,o),
+(439,387,o),
+(439,515,cs),
+(439,642,o),
+(371,729,o),
+(253,729,cs),
+(129,729,o),
+(58,639,o),
+(58,476,cs),
+(58,348,ls),
+(58,107,o),
+(176,-15,o),
+(380,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(212,421,o),
+(191,449,o),
+(191,515,cs),
+(191,581,o),
+(213,609,o),
+(248,609,cs),
+(283,609,o),
+(305,581,o),
+(305,517,cs),
+(305,452,o),
+(283,421,o),
+(247,421,cs)
+);
+}
+);
+width = 761;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155E;
+unicode = 5470;
+},
+{
+glyphname = "theNCree-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(587,-15,o),
+(703,108,o),
+(703,343,cs),
+(703,476,ls),
+(703,639,o),
+(631,729,o),
+(507,729,cs),
+(389,729,o),
+(321,642,o),
+(321,515,cs),
+(321,387,o),
+(392,302,o),
+(497,302,cs),
+(541,302,o),
+(578,322,o),
+(600,358,c),
+(538,412,l),
+(538,300,ls),
+(538,183,o),
+(481,131,o),
+(382,131,cs),
+(278,131,o),
+(224,195,o),
+(224,315,cs),
+(224,714,l),
+(58,714,l),
+(58,319,ls),
+(58,106,o),
+(175,-15,o),
+(380,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(477,421,o),
+(455,453,o),
+(455,517,cs),
+(455,581,o),
+(477,610,o),
+(512,610,cs),
+(547,610,o),
+(569,581,o),
+(569,515,cs),
+(569,450,o),
+(548,421,o),
+(513,421,cs)
+);
+}
+);
+width = 761;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155F;
+unicode = 5471;
+},
+{
+glyphname = "thi-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (376,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(371,-15,o),
+(439,72,o),
+(439,199,cs),
+(439,327,o),
+(369,412,o),
+(263,412,cs),
+(219,412,o),
+(182,392,o),
+(160,356,c),
+(222,302,l),
+(222,414,ls),
+(222,531,o),
+(279,583,o),
+(379,583,cs),
+(482,583,o),
+(536,519,o),
+(536,399,cs),
+(536,0,l),
+(703,0,l),
+(703,395,ls),
+(703,608,o),
+(585,729,o),
+(380,729,cs),
+(173,729,o),
+(58,606,o),
+(58,371,cs),
+(58,238,ls),
+(58,75,o),
+(129,-15,o),
+(253,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(213,104,o),
+(191,133,o),
+(191,199,cs),
+(191,264,o),
+(212,293,o),
+(247,293,cs),
+(283,293,o),
+(305,261,o),
+(305,197,cs),
+(305,133,o),
+(283,104,o),
+(248,104,cs)
+);
+}
+);
+width = 761;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1560;
+unicode = 5472;
+},
+{
+glyphname = "thiNCree-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (376,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(631,-15,o),
+(703,75,o),
+(703,238,cs),
+(703,371,ls),
+(703,606,o),
+(587,729,o),
+(380,729,cs),
+(175,729,o),
+(58,608,o),
+(58,395,cs),
+(58,0,l),
+(224,0,l),
+(224,399,ls),
+(224,519,o),
+(278,583,o),
+(382,583,cs),
+(481,583,o),
+(538,531,o),
+(538,414,cs),
+(538,302,l),
+(600,356,l),
+(578,392,o),
+(541,412,o),
+(497,412,cs),
+(392,412,o),
+(321,327,o),
+(321,199,cs),
+(321,72,o),
+(389,-15,o),
+(507,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(477,104,o),
+(455,133,o),
+(455,197,cs),
+(455,261,o),
+(477,293,o),
+(513,293,cs),
+(548,293,o),
+(569,264,o),
+(569,199,cs),
+(569,133,o),
+(547,104,o),
+(512,104,cs)
+);
+}
+);
+width = 761;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1561;
+unicode = 5473;
+},
+{
+glyphname = "thii-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "thi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (278,0);
+ref = dot_top;
+}
+);
+width = 760;
+}
+);
+note = uni1562;
+unicode = 5474;
+},
+{
+glyphname = "thiiNCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "thiNCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (278,0);
+ref = dot_top;
+}
+);
+width = 760;
+}
+);
+note = uni1563;
+unicode = 5475;
+},
+{
+glyphname = "tho-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (313,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(292,0,ls),
+(520,0,o),
+(650,128,o),
+(650,362,cs),
+(650,586,o),
+(513,729,o),
+(316,729,cs),
+(149,729,o),
+(51,629,o),
+(51,489,cs),
+(51,363,o),
+(127,279,o),
+(242,279,cs),
+(355,279,o),
+(422,356,o),
+(422,472,cs),
+(422,561,o),
+(377,646,o),
+(273,655,c),
+(249,605,l),
+(258,609,o),
+(279,612,o),
+(292,612,cs),
+(415,612,o),
+(487,518,o),
+(487,373,cs),
+(487,218,o),
+(415,149,o),
+(282,149,cs),
+(85,149,l),
+(85,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(207,398,o),
+(185,426,o),
+(185,495,cs),
+(185,563,o),
+(208,592,o),
+(241,592,cs),
+(275,592,o),
+(299,562,o),
+(299,494,cs),
+(299,427,o),
+(277,398,o),
+(242,398,cs)
+);
+}
+);
+width = 702;
+}
+);
+metricRight = "to-canadian";
+note = uni1564;
+unicode = 5476;
+},
+{
+glyphname = "thoo-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "tho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (216,0);
+ref = dot_top;
+}
+);
+width = 702;
+}
+);
+note = uni1565;
+unicode = 5477;
+},
+{
+glyphname = "tha-canadian";
+lastChange = "2023-01-13 15:30:29 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (393,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(617,0,l),
+(617,149,l),
+(420,149,ls),
+(287,149,o),
+(216,217,o),
+(216,372,cs),
+(216,518,o),
+(287,612,o),
+(411,612,cs),
+(423,612,o),
+(444,609,o),
+(453,605,c),
+(429,655,l),
+(326,646,o),
+(280,561,o),
+(280,472,cs),
+(280,356,o),
+(349,279,o),
+(460,279,cs),
+(575,279,o),
+(651,364,o),
+(651,489,cs),
+(651,630,o),
+(552,729,o),
+(389,729,cs),
+(190,729,o),
+(52,586,o),
+(52,362,cs),
+(52,130,o),
+(180,0,o),
+(410,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(425,398,o),
+(403,427,o),
+(403,494,cs),
+(403,562,o),
+(427,592,o),
+(461,592,cs),
+(494,592,o),
+(518,563,o),
+(518,495,cs),
+(518,426,o),
+(495,398,o),
+(461,398,cs)
+);
+}
+);
+width = 702;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tho-canadian";
+note = uni1566;
+unicode = 5478;
+},
+{
+glyphname = "thaa-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (295,0);
+ref = dot_top;
+}
+);
+width = 702;
+}
+);
+note = uni1567;
+unicode = 5479;
+},
+{
+glyphname = "thwaa-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (540,0);
+ref = dot_top;
+}
+);
+width = 947;
+}
+);
+note = uni1568;
+unicode = 5480;
+},
+{
+glyphname = "thwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (295,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (702,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 947;
+}
+);
+note = uni1569;
+unicode = 5481;
+},
+{
+glyphname = "th-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(329,357,l),
+(329,447,l),
+(243,447,ls),
+(176,447,o),
+(143,476,o),
+(143,543,cs),
+(143,611,o),
+(179,656,o),
+(242,656,cs),
+(248,656,o),
+(257,655,o),
+(261,654,c),
+(235,680,l),
+(189,676,o),
+(165,639,o),
+(165,598,cs),
+(165,535,o),
+(203,495,o),
+(256,495,cs),
+(309,495,o),
+(346,535,o),
+(346,599,cs),
+(346,675,o),
+(295,720,o),
+(218,720,cs),
+(119,720,o),
+(48,650,o),
+(48,535,cs),
+(48,424,o),
+(113,357,o),
+(236,357,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(237,554,o),
+(226,569,o),
+(226,598,cs),
+(226,629,o),
+(237,642,o),
+(254,642,cs),
+(270,642,o),
+(282,628,o),
+(282,597,cs),
+(282,568,o),
+(271,554,o),
+(254,554,cs)
+);
+}
+);
+width = 396;
+}
+);
+metricLeft = "t-canadian";
+note = uni156A;
+unicode = 5482;
+},
+{
+glyphname = "tthe-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (844,357);
+},
+{
+name = top_center_can;
+pos = (375,714);
+},
+{
+name = top_left_can;
+pos = (141,714);
+},
+{
+name = top_right_can;
+pos = (611,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(576,-15,o),
+(693,108,o),
+(693,320,cs),
+(693,714,l),
+(531,714,l),
+(531,319,ls),
+(531,195,o),
+(475,135,o),
+(375,135,cs),
+(278,135,o),
+(219,199,o),
+(219,319,cs),
+(219,714,l),
+(58,714,l),
+(58,319,ls),
+(58,106,o),
+(175,-15,o),
+(376,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(442,393,l),
+(442,714,l),
+(309,714,l),
+(309,393,l)
+);
+}
+);
+width = 751;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156B;
+unicode = 5483;
+},
+{
+glyphname = "tthi-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(219,0,l),
+(219,395,ls),
+(219,516,o),
+(281,579,o),
+(378,579,cs),
+(474,579,o),
+(531,515,o),
+(531,395,cs),
+(531,0,l),
+(693,0,l),
+(693,395,ls),
+(693,607,o),
+(576,729,o),
+(381,729,cs),
+(179,729,o),
+(58,607,o),
+(58,395,cs),
+(58,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(442,0,l),
+(442,321,l),
+(309,321,l),
+(309,0,l)
+);
+}
+);
+width = 751;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156C;
+unicode = 5484;
+},
+{
+glyphname = "ttho-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (328,714);
+},
+{
+name = top_left_can;
+pos = (141,714);
+},
+{
+name = top_right_can;
+pos = (514,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(234,0,ls),
+(463,0,o),
+(596,129,o),
+(596,358,cs),
+(596,587,o),
+(463,714,o),
+(234,714,cs),
+(58,714,l),
+(58,565,l),
+(226,565,ls),
+(354,565,o),
+(430,499,o),
+(430,358,cs),
+(430,217,o),
+(354,149,o),
+(227,149,cs),
+(58,149,l),
+(58,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(306,290,l),
+(306,426,l),
+(58,426,l),
+(58,290,l)
+);
+}
+);
+width = 648;
+}
+);
+metricRight = "to-canadian";
+note = uni156D;
+unicode = 5485;
+},
+{
+glyphname = "ttha-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (323,714);
+},
+{
+name = top_left_can;
+pos = (135,714);
+},
+{
+name = top_right_can;
+pos = (508,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(590,0,l),
+(590,149,l),
+(422,149,ls),
+(294,149,o),
+(219,216,o),
+(219,357,cs),
+(219,498,o),
+(294,565,o),
+(422,565,cs),
+(590,565,l),
+(590,714,l),
+(415,714,ls),
+(186,714,o),
+(52,586,o),
+(52,357,cs),
+(52,128,o),
+(186,0,o),
+(414,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(590,290,l),
+(590,426,l),
+(343,426,l),
+(343,290,l)
+);
+}
+);
+width = 648;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|ttho-canadian";
+note = uni156E;
+unicode = 5486;
+},
+{
+glyphname = "tth-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(672,476,l),
+(629,476,l),
+(722,344,l),
+(798,400,l),
+(704,530,l),
+(690,488,l),
+(839,539,l),
+(809,627,l),
+(661,575,l),
+(698,550,l),
+(698,714,l),
+(603,714,l),
+(603,550,l),
+(640,575,l),
+(492,627,l),
+(462,539,l),
+(611,488,l),
+(597,530,l),
+(503,400,l),
+(579,344,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(243,476,l),
+(200,476,l),
+(293,344,l),
+(370,400,l),
+(275,530,l),
+(262,488,l),
+(410,539,l),
+(380,627,l),
+(232,575,l),
+(269,550,l),
+(269,714,l),
+(174,714,l),
+(174,550,l),
+(211,575,l),
+(64,627,l),
+(33,539,l),
+(182,488,l),
+(168,530,l),
+(73,400,l),
+(150,344,l)
+);
+}
+);
+width = 872;
+}
+);
+metricRight = "=|";
+note = uni156F;
+unicode = 5487;
+},
+{
+glyphname = "tye-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(576,-15,o),
+(693,108,o),
+(693,320,cs),
+(693,714,l),
+(533,714,l),
+(533,323,ls),
+(533,195,o),
+(475,135,o),
+(375,135,cs),
+(278,135,o),
+(218,199,o),
+(218,323,cs),
+(218,714,l),
+(58,714,l),
+(58,319,ls),
+(58,106,o),
+(175,-15,o),
+(376,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(447,424,o),
+(486,470,o),
+(486,542,cs),
+(486,714,l),
+(409,714,l),
+(409,546,ls),
+(409,518,o),
+(399,503,o),
+(375,503,cs),
+(353,503,o),
+(341,518,o),
+(341,546,cs),
+(341,714,l),
+(265,714,l),
+(265,542,ls),
+(265,468,o),
+(306,424,o),
+(376,424,cs)
+);
+}
+);
+width = 751;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1570;
+unicode = 5488;
+},
+{
+glyphname = "tyi-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(219,0,l),
+(219,391,ls),
+(219,516,o),
+(281,579,o),
+(378,579,cs),
+(474,579,o),
+(532,515,o),
+(532,391,cs),
+(532,0,l),
+(693,0,l),
+(693,395,ls),
+(693,607,o),
+(576,729,o),
+(381,729,cs),
+(179,729,o),
+(58,607,o),
+(58,395,cs),
+(58,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(341,0,l),
+(341,167,ls),
+(341,196,o),
+(352,211,o),
+(375,211,cs),
+(398,211,o),
+(409,196,o),
+(409,167,cs),
+(409,0,l),
+(486,0,l),
+(486,172,ls),
+(486,246,o),
+(445,290,o),
+(375,290,cs),
+(304,290,o),
+(265,244,o),
+(265,172,cs),
+(265,0,l)
+);
+}
+);
+width = 751;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1571;
+unicode = 5489;
+},
+{
+glyphname = "tyo-canadian";
+lastChange = "2023-01-13 15:30:29 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(241,0,ls),
+(466,0,o),
+(602,129,o),
+(602,358,cs),
+(602,587,o),
+(466,714,o),
+(240,714,cs),
+(65,714,l),
+(65,568,l),
+(227,568,ls),
+(360,568,o),
+(436,500,o),
+(436,358,cs),
+(436,216,o),
+(360,146,o),
+(227,146,cs),
+(65,146,l),
+(65,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(164,226,ls),
+(250,226,o),
+(300,274,o),
+(300,357,cs),
+(300,440,o),
+(250,488,o),
+(164,488,cs),
+(65,488,l),
+(65,407,l),
+(153,407,ls),
+(193,407,o),
+(211,390,o),
+(211,357,cs),
+(211,324,o),
+(193,307,o),
+(153,307,cs),
+(65,307,l),
+(65,226,l)
+);
+}
+);
+width = 654;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1572;
+unicode = 5490;
+},
+{
+glyphname = "tya-canadian";
+lastChange = "2023-01-13 15:30:29 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(590,0,l),
+(590,146,l),
+(428,146,ls),
+(295,146,o),
+(219,215,o),
+(219,357,cs),
+(219,499,o),
+(295,568,o),
+(428,568,cs),
+(590,568,l),
+(590,714,l),
+(415,714,ls),
+(188,714,o),
+(52,586,o),
+(52,357,cs),
+(52,128,o),
+(188,0,o),
+(414,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(590,226,l),
+(590,307,l),
+(502,307,ls),
+(462,307,o),
+(444,324,o),
+(444,357,cs),
+(444,390,o),
+(462,407,o),
+(502,407,cs),
+(590,407,l),
+(590,488,l),
+(491,488,ls),
+(405,488,o),
+(354,440,o),
+(354,357,cs),
+(354,274,o),
+(405,226,o),
+(491,226,cs)
+);
+}
+);
+width = 655;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1573;
+unicode = 5491;
+},
+{
+glyphname = "heNunavik-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(539,0,l),
+(789,208,l),
+(699,320,l),
+(452,117,l),
+(557,109,l),
+(557,450,ls),
+(557,623,o),
+(462,729,o),
+(304,729,cs),
+(146,729,o),
+(43,622,o),
+(43,455,cs),
+(43,296,o),
+(139,190,o),
+(276,190,cs),
+(343,190,o),
+(393,222,o),
+(404,256,c),
+(392,269,l),
+(392,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(244,330,o),
+(206,373,o),
+(206,459,cs),
+(206,546,o),
+(241,589,o),
+(300,589,cs),
+(358,589,o),
+(394,546,o),
+(394,459,cs),
+(394,373,o),
+(355,330,o),
+(300,330,cs)
+);
+}
+);
+width = 808;
+}
+);
+metricLeft = "ke-canadian";
+note = uni1574;
+unicode = 5492;
+},
+{
+glyphname = "hiNunavik-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (509,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(416,0,l),
+(416,269,l),
+(405,256,l),
+(415,222,o),
+(465,190,o),
+(532,190,cs),
+(669,190,o),
+(766,297,o),
+(766,458,cs),
+(766,624,o),
+(663,729,o),
+(509,729,cs),
+(351,729,o),
+(252,623,o),
+(252,450,cs),
+(252,121,l),
+(356,117,l),
+(110,320,l),
+(19,208,l),
+(270,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(453,330,o),
+(414,373,o),
+(414,459,cs),
+(414,546,o),
+(451,589,o),
+(509,589,cs),
+(567,589,o),
+(603,546,o),
+(603,459,cs),
+(603,373,o),
+(564,330,o),
+(509,330,cs)
+);
+}
+);
+width = 809;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1575;
+unicode = 5493;
+},
+{
+glyphname = "hiiNunavik-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "hiNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (412,0);
+ref = dot_top;
+}
+);
+width = 808;
+}
+);
+note = uni1576;
+unicode = 5494;
+},
+{
+glyphname = "hoNunavik-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (299,714);
+},
+{
+name = top_right_can;
+pos = (475,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(462,-15,o),
+(557,91,o),
+(557,264,cs),
+(557,605,l),
+(452,597,l),
+(699,394,l),
+(789,506,l),
+(539,714,l),
+(392,714,l),
+(392,445,l),
+(404,458,l),
+(393,492,o),
+(343,524,o),
+(278,524,cs),
+(139,524,o),
+(43,415,o),
+(43,254,cs),
+(43,89,o),
+(142,-15,o),
+(300,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(241,125,o),
+(206,168,o),
+(206,255,cs),
+(206,341,o),
+(244,384,o),
+(300,384,cs),
+(355,384,o),
+(394,341,o),
+(394,255,cs),
+(394,168,o),
+(358,125,o),
+(300,125,cs)
+);
+}
+);
+width = 808;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "heNunavik-canadian";
+note = uni1577;
+unicode = 5495;
+},
+{
+glyphname = "hooNunavik-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "hoNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (377,0);
+ref = dot_top;
+}
+);
+width = 808;
+}
+);
+note = uni1578;
+unicode = 5496;
+},
+{
+glyphname = "haNunavik-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (509,714);
+},
+{
+name = top_left_can;
+pos = (334,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(661,-15,o),
+(766,90,o),
+(766,257,cs),
+(766,417,o),
+(669,524,o),
+(536,524,cs),
+(468,524,o),
+(418,492,o),
+(405,458,c),
+(416,445,l),
+(416,714,l),
+(270,714,l),
+(19,506,l),
+(110,394,l),
+(356,597,l),
+(252,593,l),
+(252,264,ls),
+(252,91,o),
+(346,-15,o),
+(507,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(451,125,o),
+(414,168,o),
+(414,255,cs),
+(414,341,o),
+(453,384,o),
+(509,384,cs),
+(564,384,o),
+(603,341,o),
+(603,255,cs),
+(603,168,o),
+(567,125,o),
+(509,125,cs)
+);
+}
+);
+width = 809;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1579;
+unicode = 5497;
+},
+{
+glyphname = "haaNunavik-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "haNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (237,0);
+ref = dot_top;
+}
+);
+width = 808;
+}
+);
+note = uni157A;
+unicode = 5498;
+},
+{
+glyphname = "hNunavik-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(377,351,o),
+(439,400,o),
+(439,489,cs),
+(439,571,o),
+(387,622,o),
+(319,622,cs),
+(279,622,o),
+(250,601,o),
+(242,575,c),
+(264,575,l),
+(264,714,l),
+(159,714,l),
+(35,610,l),
+(86,548,l),
+(210,652,l),
+(151,657,l),
+(151,492,ls),
+(151,408,o),
+(206,351,o),
+(299,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(271,431,o),
+(254,449,o),
+(254,486,cs),
+(254,524,o),
+(273,542,o),
+(296,542,cs),
+(321,542,o),
+(340,524,o),
+(340,486,cs),
+(340,449,o),
+(321,431,o),
+(296,431,cs)
+);
+}
+);
+width = 484;
+}
+);
+metricRight = "k-canadian";
+note = uni157B;
+unicode = 5499;
+},
+{
+color = 4;
+glyphname = "nunavuth-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(231,295,l),
+(502,295,l),
+(502.006,0,l),
+(668,0,l),
+(668,714,l),
+(502.006,714,l),
+(502,441,l),
+(231,441,l),
+(231,714,l),
+(65,714,l),
+(65,0,l),
+(231,0,l)
+);
+}
+);
+width = 733;
+}
+);
+metricRight = "=|";
+note = uni157C;
+unicode = 5500;
+},
+{
+glyphname = "hk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,357);
+ref = "fullstop-canadian";
+}
+);
+width = 391;
+}
+);
+metricLeft = "fullstop-canadian";
+note = uni157D;
+unicode = 5501;
+},
+{
+glyphname = "qaai-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (346,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (524,0);
+ref = ring_top.canadian;
+}
+);
+width = 960;
+}
+);
+note = uni157E;
+unicode = 5502;
+},
+{
+glyphname = "qi-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (346,0);
+ref = "ki-canadian";
+}
+);
+width = 960;
+}
+);
+note = uni157F;
+unicode = 5503;
+},
+{
+glyphname = "qii-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (346,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (563,0);
+ref = dot_top;
+}
+);
+width = 960;
+}
+);
+note = uni1580;
+unicode = 5504;
+},
+{
+glyphname = "qo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (346,0);
+ref = "ko-canadian";
+}
+);
+width = 960;
+}
+);
+note = uni1581;
+unicode = 5505;
+},
+{
+glyphname = "qoo-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (346,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (723,0);
+ref = dot_top;
+}
+);
+width = 960;
+}
+);
+note = uni1582;
+unicode = 5506;
+},
+{
+glyphname = "qa-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (346,0);
+ref = "ka-canadian";
+}
+);
+width = 960;
+}
+);
+note = uni1583;
+unicode = 5507;
+},
+{
+glyphname = "qaa-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (346,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (390,0);
+ref = dot_top;
+}
+);
+width = 960;
+}
+);
+note = uni1584;
+unicode = 5508;
+},
+{
+glyphname = "q-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (346,0);
+ref = "k-canadian";
+}
+);
+width = 735;
+}
+);
+note = uni1585;
+unicode = 5509;
+},
+{
+glyphname = "tlhe-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (318,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(237,0,l),
+(371,284,l),
+(246,227,l),
+(260,223,o),
+(275,222,o),
+(291,222,cs),
+(359,222,o),
+(410,252,o),
+(421,281,c),
+(411,340,l),
+(411,0,l),
+(575,0,l),
+(575,459,ls),
+(575,628,o),
+(481,729,o),
+(319,729,cs),
+(147,729,o),
+(54,616,o),
+(54,472,cs),
+(54,367,o),
+(102,288,o),
+(180,251,c),
+(61,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(254,362,o),
+(216,401,o),
+(216,474,cs),
+(216,549,o),
+(253,589,o),
+(315,589,cs),
+(376,589,o),
+(413,549,o),
+(413,475,cs),
+(413,401,o),
+(375,362,o),
+(315,362,cs)
+);
+}
+);
+width = 633;
+}
+);
+metricRight = "te-canadian";
+note = uni1586;
+unicode = 5510;
+},
+{
+glyphname = "tlhi-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(222,0,l),
+(222,340,l),
+(210,289,l),
+(211,258,o),
+(266,222,o),
+(342,222,c),
+(262,284,l),
+(397,0,l),
+(572,0,l),
+(453,251,l),
+(531,288,o),
+(579,367,o),
+(579,472,cs),
+(579,616,o),
+(487,729,o),
+(315,729,cs),
+(152,729,o),
+(58,628,o),
+(58,459,cs),
+(58,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(259,362,o),
+(220,401,o),
+(220,475,cs),
+(220,549,o),
+(258,589,o),
+(319,589,cs),
+(380,589,o),
+(417,549,o),
+(417,474,cs),
+(417,401,o),
+(379,362,o),
+(319,362,cs)
+);
+}
+);
+width = 633;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|tlhe-canadian";
+note = uni1587;
+unicode = 5511;
+},
+{
+glyphname = "tlho-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (326,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(481,-15,o),
+(575,86,o),
+(575,255,cs),
+(575,714,l),
+(411,714,l),
+(411,374,l),
+(423,425,l),
+(422,456,o),
+(367,492,o),
+(291,492,c),
+(371,430,l),
+(237,714,l),
+(61,714,l),
+(180,463,l),
+(102,426,o),
+(54,347,o),
+(54,242,cs),
+(54,98,o),
+(147,-15,o),
+(319,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(253,125,o),
+(216,165,o),
+(216,240,cs),
+(216,313,o),
+(254,352,o),
+(315,352,cs),
+(375,352,o),
+(413,313,o),
+(413,239,cs),
+(413,165,o),
+(376,125,o),
+(315,125,cs)
+);
+}
+);
+width = 633;
+}
+);
+metricLeft = "tlhe-canadian";
+metricRight = "te-canadian";
+note = uni1588;
+unicode = 5512;
+},
+{
+glyphname = "tlha-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(487,-15,o),
+(579,98,o),
+(579,242,cs),
+(579,347,o),
+(531,426,o),
+(453,463,c),
+(572,714,l),
+(397,714,l),
+(262,430,l),
+(387,487,l),
+(373,491,o),
+(358,492,o),
+(342,492,cs),
+(266,492,o),
+(211,456,o),
+(210,425,c),
+(222,374,l),
+(222,714,l),
+(58,714,l),
+(58,255,ls),
+(58,86,o),
+(152,-15,o),
+(315,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(258,125,o),
+(220,165,o),
+(220,239,cs),
+(220,313,o),
+(259,352,o),
+(319,352,cs),
+(379,352,o),
+(417,313,o),
+(417,240,cs),
+(417,165,o),
+(380,125,o),
+(319,125,cs)
+);
+}
+);
+width = 633;
+}
+);
+metricLeft = "te-canadian";
+note = uni1589;
+unicode = 5513;
+},
+{
+glyphname = "reWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(529,0,l),
+(780,208,l),
+(689,320,l),
+(443,117,l),
+(547,109,l),
+(547,454,ls),
+(547,629,o),
+(456,729,o),
+(299,729,cs),
+(139,729,o),
+(42,628,o),
+(42,453,cs),
+(42,393,l),
+(206,393,l),
+(206,470,ls),
+(206,545,o),
+(238,585,o),
+(295,585,cs),
+(351,585,o),
+(383,546,o),
+(383,469,cs),
+(383,0,l)
+);
+}
+);
+width = 799;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+unicode = 5514;
+},
+{
+glyphname = "riWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(416,0,l),
+(416,469,ls),
+(416,546,o),
+(450,585,o),
+(506,585,cs),
+(564,585,o),
+(593,546,o),
+(593,470,cs),
+(593,393,l),
+(757,393,l),
+(757,453,ls),
+(757,628,o),
+(665,729,o),
+(508,729,cs),
+(345,729,o),
+(252,625,o),
+(252,453,cs),
+(252,109,l),
+(356,117,l),
+(110,320,l),
+(19,208,l),
+(270,0,l)
+);
+}
+);
+width = 799;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+unicode = 5515;
+},
+{
+glyphname = "roWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(455,-15,o),
+(547,84,o),
+(547,260,cs),
+(547,605,l),
+(443,597,l),
+(689,394,l),
+(780,506,l),
+(529,714,l),
+(383,714,l),
+(383,243,ls),
+(383,166,o),
+(351,129,o),
+(295,129,cs),
+(236,129,o),
+(206,169,o),
+(206,250,cs),
+(206,321,l),
+(42,321,l),
+(42,261,ls),
+(42,86,o),
+(134,-15,o),
+(298,-15,cs)
+);
+}
+);
+width = 799;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+unicode = 5516;
+},
+{
+glyphname = "raWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(663,-15,o),
+(757,86,o),
+(757,261,cs),
+(757,321,l),
+(593,321,l),
+(593,248,ls),
+(593,167,o),
+(562,129,o),
+(506,129,cs),
+(447,129,o),
+(416,166,o),
+(416,243,cs),
+(416,714,l),
+(270,714,l),
+(19,506,l),
+(110,394,l),
+(356,597,l),
+(252,605,l),
+(252,260,ls),
+(252,86,o),
+(341,-15,o),
+(506,-15,cs)
+);
+}
+);
+width = 799;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+unicode = 5517;
+},
+{
+glyphname = "ngaai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (653,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (833,0);
+ref = ring_top.canadian;
+}
+);
+width = 1260;
+}
+);
+note = uni158E;
+unicode = 5518;
+},
+{
+glyphname = "ngi-canadian";
+kernLeft = mwestleft;
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (653,0);
+ref = "ci-canadian";
+}
+);
+width = 1260;
+}
+);
+note = uni158F;
+unicode = 5519;
+},
+{
+glyphname = "ngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (653,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (872,0);
+ref = dot_top;
+}
+);
+width = 1260;
+}
+);
+note = uni1590;
+unicode = 5520;
+},
+{
+glyphname = "ngo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:30:34 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (625,0);
+ref = "co-canadian";
+}
+);
+width = 1232;
+}
+);
+note = uni1591;
+unicode = 5521;
+},
+{
+glyphname = "ngoo-canadian";
+lastChange = "2023-01-13 15:30:34 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+ref = "ngo-canadian";
+},
+{
+anchor = top_right_can;
+pos = (994,0);
+ref = dot_top;
+}
+);
+width = 1232;
+}
+);
+note = uni1592;
+unicode = 5522;
+},
+{
+glyphname = "nga-canadian";
+kernLeft = mwestleft;
+kernRight = caright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (653,0);
+ref = "ca-canadian";
+}
+);
+width = 1260;
+}
+);
+note = uni1593;
+unicode = 5523;
+},
+{
+glyphname = "ngaa-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (653,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (697,0);
+ref = dot_top;
+}
+);
+width = 1260;
+}
+);
+note = uni1594;
+unicode = 5524;
+},
+{
+glyphname = "ng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(565,225,o),
+(621,276,o),
+(621,361,cs),
+(621,382,l),
+(515,382,l),
+(515,356,ls),
+(515,328,o),
+(501,312,o),
+(478,312,cs),
+(454,312,o),
+(442,328,o),
+(442,357,cs),
+(442,555,l),
+(287,555,l),
+(294,508,l),
+(313,521,o),
+(330,552,o),
+(330,591,cs),
+(330,670,o),
+(277,721,o),
+(188,721,cs),
+(101,721,o),
+(45,668,o),
+(45,585,cs),
+(45,505,o),
+(99,450,o),
+(193,450,cs),
+(350,450,l),
+(329,477,l),
+(329,371,ls),
+(329,275,o),
+(381,225,o),
+(478,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(163,531,o),
+(145,549,o),
+(145,585,cs),
+(145,622,o),
+(163,641,o),
+(188,641,cs),
+(213,641,o),
+(230,622,o),
+(230,585,cs),
+(230,550,o),
+(213,531,o),
+(188,531,cs)
+);
+}
+);
+width = 653;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1595;
+unicode = 5525;
+},
+{
+glyphname = "nng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(872,225,o),
+(927,276,o),
+(927,361,cs),
+(927,382,l),
+(822,382,l),
+(822,356,ls),
+(822,328,o),
+(808,312,o),
+(784,312,cs),
+(761,312,o),
+(749,328,o),
+(749,357,cs),
+(749,555,l),
+(603,555,l),
+(610,508,l),
+(629,521,o),
+(645,552,o),
+(645,591,cs),
+(645,671,o),
+(592,721,o),
+(504,721,cs),
+(415,721,o),
+(361,669,o),
+(361,589,cs),
+(361,552,o),
+(378,520,o),
+(396,507,c),
+(404,555,l),
+(287,555,l),
+(294,508,l),
+(313,521,o),
+(330,552,o),
+(330,591,cs),
+(330,670,o),
+(277,721,o),
+(188,721,cs),
+(101,721,o),
+(45,668,o),
+(45,585,cs),
+(45,505,o),
+(99,450,o),
+(193,450,cs),
+(636,450,l),
+(636,371,ls),
+(636,275,o),
+(687,225,o),
+(784,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(163,531,o),
+(145,549,o),
+(145,585,cs),
+(145,622,o),
+(163,641,o),
+(188,641,cs),
+(213,641,o),
+(230,622,o),
+(230,585,cs),
+(230,550,o),
+(213,531,o),
+(188,531,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(478,531,o),
+(461,549,o),
+(461,585,cs),
+(461,622,o),
+(478,641,o),
+(504,641,cs),
+(528,641,o),
+(546,622,o),
+(546,585,cs),
+(546,550,o),
+(529,531,o),
+(504,531,cs)
+);
+}
+);
+width = 959;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1596;
+unicode = 5526;
+},
+{
+glyphname = "sheSayisi-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (714,357);
+},
+{
+name = top_center_can;
+pos = (311,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(564,0,l),
+(564,453,ls),
+(564,623,o),
+(472,729,o),
+(311,729,cs),
+(145,729,o),
+(43,618,o),
+(43,440,cs),
+(43,271,o),
+(122,190,o),
+(221,190,cs),
+(330,190,o),
+(377,278,o),
+(368,428,c),
+(282,428,l),
+(285,348,o),
+(271,326,o),
+(247,326,cs),
+(222,326,o),
+(202,351,o),
+(202,444,cs),
+(202,545,o),
+(242,589,o),
+(304,589,cs),
+(365,589,o),
+(398,547,o),
+(398,449,cs),
+(398,0,l)
+);
+}
+);
+width = 622;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1597;
+unicode = 5527;
+},
+{
+glyphname = "shiSayisi-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(224,0,l),
+(224,449,ls),
+(224,547,o),
+(260,589,o),
+(321,589,cs),
+(383,589,o),
+(420,546,o),
+(420,445,cs),
+(420,351,o),
+(400,326,o),
+(375,326,cs),
+(351,326,o),
+(337,348,o),
+(340,428,c),
+(254,428,l),
+(245,278,o),
+(292,190,o),
+(401,190,cs),
+(500,190,o),
+(579,271,o),
+(579,440,cs),
+(579,618,o),
+(484,729,o),
+(322,729,cs),
+(155,729,o),
+(58,623,o),
+(58,453,cs),
+(58,0,l)
+);
+}
+);
+width = 622;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni1598;
+unicode = 5528;
+},
+{
+glyphname = "shoSayisi-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (302,714);
+},
+{
+name = top_left_can;
+pos = (123,714);
+},
+{
+name = top_right_can;
+pos = (482,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(467,-15,o),
+(564,91,o),
+(564,261,cs),
+(564,714,l),
+(398,714,l),
+(398,265,ls),
+(398,167,o),
+(362,125,o),
+(301,125,cs),
+(239,125,o),
+(202,168,o),
+(202,269,cs),
+(202,363,o),
+(222,388,o),
+(247,388,cs),
+(271,388,o),
+(285,366,o),
+(282,286,c),
+(368,286,l),
+(377,436,o),
+(331,524,o),
+(221,524,cs),
+(122,524,o),
+(43,443,o),
+(43,268,cs),
+(43,94,o),
+(138,-15,o),
+(300,-15,cs)
+);
+}
+);
+width = 622;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1599;
+unicode = 5529;
+},
+{
+glyphname = "shaSayisi-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(477,-15,o),
+(579,96,o),
+(579,274,cs),
+(579,443,o),
+(504,524,o),
+(405,524,cs),
+(296,524,o),
+(245,436,o),
+(254,286,c),
+(340,286,l),
+(337,366,o),
+(351,388,o),
+(375,388,cs),
+(400,388,o),
+(420,363,o),
+(420,270,cs),
+(420,169,o),
+(380,125,o),
+(318,125,cs),
+(257,125,o),
+(224,167,o),
+(224,265,cs),
+(224,714,l),
+(58,714,l),
+(58,261,ls),
+(58,91,o),
+(150,-15,o),
+(312,-15,cs)
+);
+}
+);
+width = 622;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni159A;
+unicode = 5530;
+},
+{
+glyphname = "theWoodScree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(686,-15,o),
+(794,86,o),
+(794,248,cs),
+(794,416,o),
+(689,509,o),
+(512,509,cs),
+(52,509,l),
+(52,375,l),
+(348,375,l),
+(324,398,l),
+(289,360,o),
+(271,298,o),
+(271,239,cs),
+(271,82,o),
+(373,-15,o),
+(532,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(468,125,o),
+(434,174,o),
+(434,248,cs),
+(434,321,o),
+(468,370,o),
+(532,370,cs),
+(596,370,o),
+(631,322,o),
+(631,248,cs),
+(631,173,o),
+(596,125,o),
+(532,125,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(781,580,l),
+(781,714,l),
+(52,714,l),
+(52,580,l)
+);
+}
+);
+width = 846;
+}
+);
+note = uni159B;
+unicode = 5531;
+},
+{
+glyphname = "thiWoodScree-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(473,-15,o),
+(575,82,o),
+(575,241,cs),
+(575,301,o),
+(556,362,o),
+(522,400,c),
+(498,375,l),
+(794,375,l),
+(794,509,l),
+(336,509,ls),
+(155,509,o),
+(52,406,o),
+(52,245,cs),
+(52,86,o),
+(158,-15,o),
+(314,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(250,125,o),
+(215,173,o),
+(215,248,cs),
+(215,322,o),
+(250,370,o),
+(314,370,cs),
+(377,370,o),
+(412,321,o),
+(412,248,cs),
+(412,174,o),
+(377,125,o),
+(314,125,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(794,580,l),
+(794,714,l),
+(65,714,l),
+(65,580,l)
+);
+}
+);
+width = 846;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159C;
+unicode = 5532;
+},
+{
+glyphname = "thoWoodScree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(518,0,ls),
+(691,0,o),
+(794,97,o),
+(794,261,cs),
+(794,423,o),
+(689,524,o),
+(532,524,cs),
+(373,524,o),
+(271,425,o),
+(271,269,cs),
+(271,210,o),
+(289,149,o),
+(325,111,c),
+(348,134,l),
+(52,134,l),
+(52,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(468,139,o),
+(434,188,o),
+(434,262,cs),
+(434,336,o),
+(468,384,o),
+(532,384,cs),
+(596,384,o),
+(631,336,o),
+(631,262,cs),
+(631,187,o),
+(596,139,o),
+(532,139,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(781,580,l),
+(781,714,l),
+(52,714,l),
+(52,580,l)
+);
+}
+);
+width = 846;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159D;
+unicode = 5533;
+},
+{
+glyphname = "thaWoodScree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(794,0,l),
+(794,134,l),
+(498,134,l),
+(521,109,l),
+(556,147,o),
+(575,209,o),
+(575,268,cs),
+(575,427,o),
+(473,524,o),
+(314,524,cs),
+(158,524,o),
+(52,423,o),
+(52,261,cs),
+(52,101,o),
+(153,0,o),
+(330,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(250,139,o),
+(215,187,o),
+(215,262,cs),
+(215,336,o),
+(250,384,o),
+(314,384,cs),
+(377,384,o),
+(412,336,o),
+(412,262,cs),
+(412,188,o),
+(377,139,o),
+(314,139,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(794,580,l),
+(794,714,l),
+(65,714,l),
+(65,580,l)
+);
+}
+);
+width = 846;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159E;
+unicode = 5534;
+},
+{
+glyphname = "thWoodScree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(457,356,l),
+(457,452,l),
+(295,452,l),
+(300,412,l),
+(321,423,o),
+(340,456,o),
+(340,497,cs),
+(340,576,o),
+(287,627,o),
+(198,627,cs),
+(111,627,o),
+(55,574,o),
+(55,491,cs),
+(55,411,o),
+(109,356,o),
+(203,356,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(173,437,o),
+(155,455,o),
+(155,491,cs),
+(155,528,o),
+(173,547,o),
+(198,547,cs),
+(223,547,o),
+(240,528,o),
+(240,491,cs),
+(240,456,o),
+(223,437,o),
+(198,437,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(452,661,l),
+(452,758,l),
+(60,758,l),
+(60,661,l)
+);
+}
+);
+width = 512;
+}
+);
+metricRight = "=|";
+note = uni159F;
+unicode = 5535;
+},
+{
+glyphname = "lhi-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (442,714);
+},
+{
+name = top_right_can;
+pos = (562,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(385,0,l),
+(385,145,l),
+(330,145,ls),
+(251,145,o),
+(207,182,o),
+(207,252,cs),
+(207,321,o),
+(248,361,o),
+(327,361,cs),
+(785,361,l),
+(785,492,l),
+(595,767,l),
+(475,685,l),
+(664,410,l),
+(656,509,l),
+(322,509,ls),
+(151,509,o),
+(43,414,o),
+(43,253,cs),
+(43,93,o),
+(151,0,o),
+(323,0,cs)
+);
+}
+);
+width = 827;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A0;
+unicode = 5536;
+},
+{
+glyphname = "lhii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "lhi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (345,0);
+ref = dot_top;
+}
+);
+width = 826;
+}
+);
+note = uni15A1;
+unicode = 5537;
+},
+{
+glyphname = "lho-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (411,528);
+},
+{
+name = top_right_can;
+pos = (520,528);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(352,-176,l),
+(162,99,l),
+(170,0,l),
+(502,0,ls),
+(677,0,o),
+(784,93,o),
+(784,255,cs),
+(784,418,o),
+(674,509,o),
+(508,509,cs),
+(442,509,l),
+(442,365,l),
+(497,365,ls),
+(578,365,o),
+(619,327,o),
+(619,257,cs),
+(619,188,o),
+(577,148,o),
+(500,148,cs),
+(42,148,l),
+(42,17,l),
+(231,-258,l)
+);
+}
+);
+width = 827;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni15A2;
+unicode = 5538;
+},
+{
+glyphname = "lhoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "lho-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (422,-186);
+ref = dot_top;
+}
+);
+width = 826;
+}
+);
+note = uni15A3;
+unicode = 5539;
+},
+{
+glyphname = "lha-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (416,528);
+},
+{
+name = top_left_can;
+pos = (309,528);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(785,17,l),
+(785,148,l),
+(327,148,ls),
+(247,148,o),
+(207,187,o),
+(207,256,cs),
+(207,327,o),
+(250,365,o),
+(326,365,cs),
+(385,365,l),
+(385,509,l),
+(320,509,ls),
+(150,509,o),
+(43,413,o),
+(43,254,cs),
+(43,92,o),
+(150,0,o),
+(322,0,cs),
+(656,0,l),
+(664,99,l),
+(475,-176,l),
+(595,-258,l)
+);
+}
+);
+width = 827;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A4;
+unicode = 5540;
+},
+{
+glyphname = "lhaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "lha-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (211,-186);
+ref = dot_top;
+}
+);
+width = 826;
+}
+);
+note = uni15A5;
+unicode = 5541;
+},
+{
+glyphname = "lh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(444,369,l),
+(444,462,l),
+(244,462,ls),
+(190,462,o),
+(161,487,o),
+(161,536,cs),
+(161,585,o),
+(190,613,o),
+(240,613,cs),
+(255,613,l),
+(255,714,l),
+(231,714,ls),
+(117,714,o),
+(48,643,o),
+(48,535,cs),
+(48,424,o),
+(117,357,o),
+(237,357,cs),
+(376,357,l),
+(368,422,l),
+(260,268,l),
+(337,215,l)
+);
+}
+);
+width = 492;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni15A6;
+unicode = 5542;
+},
+{
+glyphname = "theThCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (112,714);
+},
+{
+name = top_right_can;
+pos = (454,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(536,0,l),
+(536,77,l),
+(609,77,l),
+(609,165,l),
+(536,165,l),
+(536,365,l),
+(247,365,l),
+(246,286,l),
+(558,628,l),
+(446,726,l),
+(30,262,l),
+(30,221,l),
+(370,221,l),
+(370,165,l),
+(151,165,l),
+(151,77,l),
+(370,77,l),
+(370,0,l)
+);
+}
+);
+width = 637;
+}
+);
+metricLeft = "ye-canadian";
+note = uni15A7;
+unicode = 5543;
+},
+{
+glyphname = "thiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (184,714);
+},
+{
+name = top_right_can;
+pos = (525,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(268,0,l),
+(268,77,l),
+(486,77,l),
+(486,165,l),
+(268,165,l),
+(268,221,l),
+(607,221,l),
+(607,262,l),
+(191,726,l),
+(82,629,l),
+(397,281,l),
+(394,365,l),
+(101,365,l),
+(101,165,l),
+(28,165,l),
+(28,77,l),
+(101,77,l),
+(101,0,l)
+);
+}
+);
+width = 637;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+unicode = 5544;
+},
+{
+glyphname = "thiiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (87,0);
+ref = dot_top;
+}
+);
+width = 637;
+}
+);
+note = uni15A9;
+unicode = 5545;
+},
+{
+glyphname = "thoThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (112,714);
+},
+{
+name = top_right_can;
+pos = (453,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(556,85,l),
+(245,427,l),
+(244,349,l),
+(536,349,l),
+(536,549,l),
+(609,549,l),
+(609,637,l),
+(536,637,l),
+(536,714,l),
+(370,714,l),
+(370,637,l),
+(151,637,l),
+(151,549,l),
+(370,549,l),
+(370,493,l),
+(30,493,l),
+(30,452,l),
+(446,-12,l)
+);
+}
+);
+width = 637;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+unicode = 5546;
+},
+{
+glyphname = "thooThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (356,0);
+ref = dot_top;
+}
+);
+width = 637;
+}
+);
+note = uni15AB;
+unicode = 5547;
+},
+{
+glyphname = "thaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (185,714);
+},
+{
+name = top_right_can;
+pos = (525,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(607,452,l),
+(607,493,l),
+(268,493,l),
+(268,549,l),
+(486,549,l),
+(486,637,l),
+(268,637,l),
+(268,714,l),
+(101,714,l),
+(101,637,l),
+(28,637,l),
+(28,549,l),
+(101,549,l),
+(101,349,l),
+(394,349,l),
+(393,427,l),
+(82,85,l),
+(191,-12,l)
+);
+}
+);
+width = 637;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+unicode = 5548;
+},
+{
+glyphname = "thaaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (88,0);
+ref = dot_top;
+}
+);
+width = 637;
+}
+);
+note = uni15AD;
+unicode = 5549;
+},
+{
+glyphname = "thThCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(350,575,l),
+(350,603,l),
+(193,603,l),
+(193,636,l),
+(289,636,l),
+(289,681,l),
+(193,681,l),
+(193,714,l),
+(80,714,l),
+(80,681,l),
+(42,681,l),
+(42,636,l),
+(80,636,l),
+(80,514,l),
+(245,514,l),
+(229,582,l),
+(78,407,l),
+(155,347,l)
+);
+}
+);
+width = 373;
+}
+);
+metricRight = "y-canadian";
+note = uni15AE;
+unicode = 5550;
+},
+{
+glyphname = "bAivilik-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(484,-15,o),
+(581,95,o),
+(581,257,cs),
+(581,411,o),
+(495,524,o),
+(354,524,cs),
+(283,524,o),
+(233,492,o),
+(220,458,c),
+(231,430,l),
+(231,714,l),
+(65,714,l),
+(65,0,l),
+(222,0,l),
+(222,77,l),
+(217,56,l),
+(233,20,o),
+(282,-15,o),
+(354,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(266,125,o),
+(230,168,o),
+(230,255,cs),
+(230,341,o),
+(268,384,o),
+(324,384,cs),
+(379,384,o),
+(418,341,o),
+(418,255,cs),
+(418,168,o),
+(382,125,o),
+(324,125,cs)
+);
+}
+);
+width = 624;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|ke-canadian";
+note = uni15AF;
+unicode = 5551;
+},
+{
+glyphname = "eBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(231,0,l),
+(231,413,l),
+(261,377,o),
+(307,354,o),
+(362,354,cs),
+(467,354,o),
+(537,434,o),
+(537,542,cs),
+(537,650,o),
+(467,729,o),
+(362,729,cs),
+(303,729,o),
+(253,703,o),
+(224,660,c),
+(224,714,l),
+(65,714,l),
+(65,0,l)
+);
+}
+);
+width = 575;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B0;
+unicode = 5552;
+},
+{
+glyphname = "iBlackfoot-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(273,-15,o),
+(323,11,o),
+(352,54,c),
+(352,0,l),
+(511,0,l),
+(511,714,l),
+(345,714,l),
+(345,301,l),
+(314,337,o),
+(268,360,o),
+(213,360,cs),
+(109,360,o),
+(38,280,o),
+(38,172,cs),
+(38,64,o),
+(109,-15,o),
+(213,-15,cs)
+);
+}
+);
+width = 576;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B1;
+unicode = 5553;
+},
+{
+glyphname = "oBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(467,-15,o),
+(537,64,o),
+(537,172,cs),
+(537,280,o),
+(467,360,o),
+(362,360,cs),
+(307,360,o),
+(261,337,o),
+(231,301,c),
+(231,714,l),
+(65,714,l),
+(65,0,l),
+(224,0,l),
+(224,54,l),
+(253,11,o),
+(303,-15,o),
+(362,-15,cs)
+);
+}
+);
+width = 575;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "eBlackfoot-canadian";
+note = uni15B2;
+unicode = 5554;
+},
+{
+glyphname = "aBlackfoot-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(511,0,l),
+(511,714,l),
+(352,714,l),
+(352,660,l),
+(323,703,o),
+(273,729,o),
+(213,729,cs),
+(109,729,o),
+(38,650,o),
+(38,542,cs),
+(38,434,o),
+(109,354,o),
+(213,354,cs),
+(268,354,o),
+(314,377,o),
+(345,413,c),
+(345,0,l)
+);
+}
+);
+width = 576;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B3;
+unicode = 5555;
+},
+{
+glyphname = "weBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(231,286,l),
+(565,286,l),
+(565,423,l),
+(231,423,l),
+(231,576,l),
+(565,576,l),
+(565,714,l),
+(65,714,l),
+(65,0,l),
+(231,0,l)
+);
+}
+);
+width = 617;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B4;
+unicode = 5556;
+},
+{
+glyphname = "wiBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(552,0,l),
+(552,714,l),
+(386,714,l),
+(386,428,l),
+(52,428,l),
+(52,291,l),
+(386,291,l),
+(386,138,l),
+(52,138,l),
+(52,0,l)
+);
+}
+);
+width = 617;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B5;
+unicode = 5557;
+},
+{
+glyphname = "woBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(565,0,l),
+(565,138,l),
+(231,138,l),
+(231,291,l),
+(565,291,l),
+(565,428,l),
+(231,428,l),
+(231,714,l),
+(65,714,l),
+(65,0,l)
+);
+}
+);
+width = 617;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "weBlackfoot-canadian";
+note = uni15B6;
+unicode = 5558;
+},
+{
+glyphname = "waBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(552,0,l),
+(552,714,l),
+(52,714,l),
+(52,576,l),
+(386,576,l),
+(386,423,l),
+(52,423,l),
+(52,286,l),
+(386,286,l),
+(386,0,l)
+);
+}
+);
+width = 617;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B7;
+unicode = 5559;
+},
+{
+glyphname = "neBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(231,0,l),
+(231,594,l),
+(284,594,l),
+(243,696,l),
+(243,674,ls),
+(243,502,o),
+(337,397,o),
+(498,397,cs),
+(652,397,o),
+(756,501,o),
+(756,668,cs),
+(756,714,l),
+(594,714,l),
+(594,659,ls),
+(594,582,o),
+(558,538,o),
+(499,538,cs),
+(440,538,o),
+(405,582,o),
+(405,659,cs),
+(405,714,l),
+(65,714,l),
+(65,0,l)
+);
+}
+);
+width = 785;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B8;
+unicode = 5560;
+},
+{
+glyphname = "niBlackfoot-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(192,0,l),
+(192,55,ls),
+(192,132,o),
+(227,176,o),
+(286,176,cs),
+(345,176,o),
+(380,132,o),
+(380,55,cs),
+(380,0,l),
+(721,0,l),
+(721,714,l),
+(555,714,l),
+(555,120,l),
+(502,120,l),
+(543,18,l),
+(543,40,ls),
+(543,212,o),
+(449,317,o),
+(288,317,cs),
+(133,317,o),
+(29,213,o),
+(29,46,cs),
+(29,0,l)
+);
+}
+);
+width = 786;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B9;
+unicode = 5561;
+},
+{
+glyphname = "noBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(405,0,l),
+(405,55,ls),
+(405,132,o),
+(440,176,o),
+(499,176,cs),
+(558,176,o),
+(594,132,o),
+(594,55,cs),
+(594,0,l),
+(756,0,l),
+(756,46,ls),
+(756,213,o),
+(652,317,o),
+(498,317,cs),
+(337,317,o),
+(243,212,o),
+(243,40,cs),
+(243,18,l),
+(284,120,l),
+(231,120,l),
+(231,714,l),
+(65,714,l),
+(65,0,l)
+);
+}
+);
+width = 785;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "neBlackfoot-canadian";
+note = uni15BA;
+unicode = 5562;
+},
+{
+glyphname = "naBlackfoot-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(721,0,l),
+(721,714,l),
+(380,714,l),
+(380,659,ls),
+(380,582,o),
+(345,538,o),
+(286,538,cs),
+(227,538,o),
+(192,582,o),
+(192,659,cs),
+(192,714,l),
+(29,714,l),
+(29,668,ls),
+(29,501,o),
+(133,397,o),
+(288,397,cs),
+(449,397,o),
+(543,502,o),
+(543,674,cs),
+(543,696,l),
+(502,594,l),
+(555,594,l),
+(555,0,l)
+);
+}
+);
+width = 786;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BB;
+unicode = 5563;
+},
+{
+glyphname = "keBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(231,0,l),
+(231,522,l),
+(173,522,l),
+(320,258,l),
+(385,258,l),
+(637,714,l),
+(465,714,l),
+(306,425,l),
+(378,425,l),
+(219,714,l),
+(65,714,l),
+(65,0,l)
+);
+}
+);
+width = 645;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15BC;
+unicode = 5564;
+},
+{
+glyphname = "kiBlackfoot-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(180,0,l),
+(340,289,l),
+(267,289,l),
+(426,0,l),
+(581,0,l),
+(581,714,l),
+(415,714,l),
+(415,192,l),
+(473,192,l),
+(325,456,l),
+(260,456,l),
+(8,0,l)
+);
+}
+);
+width = 646;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BD;
+unicode = 5565;
+},
+{
+glyphname = "koBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(219,0,l),
+(378,289,l),
+(306,289,l),
+(465,0,l),
+(637,0,l),
+(385,456,l),
+(320,456,l),
+(173,192,l),
+(231,192,l),
+(231,714,l),
+(65,714,l),
+(65,0,l)
+);
+}
+);
+width = 645;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "keBlackfoot-canadian";
+note = uni15BE;
+unicode = 5566;
+},
+{
+glyphname = "kaBlackfoot-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(581,0,l),
+(581,714,l),
+(426,714,l),
+(267,425,l),
+(340,425,l),
+(180,714,l),
+(8,714,l),
+(260,258,l),
+(325,258,l),
+(473,522,l),
+(415,522,l),
+(415,0,l)
+);
+}
+);
+width = 646;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BF;
+unicode = 5567;
+},
+{
+color = 9;
+glyphname = "heSayisi-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_right_can;
+pos = (579,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(661,0,l),
+(661,714,l),
+(496,714,l),
+(496,382,l),
+(522,382,l),
+(513,595,o),
+(407,729,o),
+(266,729,cs),
+(121,729,o),
+(43,620,o),
+(43,451,cs),
+(43,416,o),
+(46,378,o),
+(54,340,c),
+(213,340,l),
+(207,375,o),
+(204,408,o),
+(204,434,cs),
+(204,535,o),
+(241,584,o),
+(302,584,cs),
+(404,584,o),
+(491,454,o),
+(495,0,c)
+);
+}
+);
+width = 726;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni15C0;
+unicode = 5568;
+},
+{
+color = 9;
+glyphname = "hiSayisi-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(231,0,l),
+(235,454,o),
+(321,584,o),
+(423,584,cs),
+(484,584,o),
+(521,535,o),
+(521,434,cs),
+(521,408,o),
+(518,375,o),
+(513,340,c),
+(671,340,l),
+(679,378,o),
+(682,416,o),
+(682,451,cs),
+(682,620,o),
+(604,729,o),
+(459,729,cs),
+(318,729,o),
+(213,595,o),
+(203,382,c),
+(229,382,l),
+(229,714,l),
+(65,714,l),
+(65,0,l)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C1;
+unicode = 5569;
+},
+{
+color = 9;
+glyphname = "hoSayisi-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (356,714);
+},
+{
+name = top_left_can;
+pos = (134,714);
+},
+{
+name = top_right_can;
+pos = (578,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(407,-15,o),
+(513,119,o),
+(522,332,c),
+(496,332,l),
+(496,0,l),
+(661,0,l),
+(661,714,l),
+(495,714,l),
+(491,260,o),
+(404,130,o),
+(302,130,cs),
+(241,130,o),
+(204,179,o),
+(204,280,cs),
+(204,306,o),
+(207,339,o),
+(213,374,c),
+(54,374,l),
+(46,336,o),
+(43,298,o),
+(43,263,cs),
+(43,94,o),
+(121,-15,o),
+(266,-15,cs)
+);
+}
+);
+width = 726;
+}
+);
+metricLeft = "heSayisi-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15C2;
+unicode = 5570;
+},
+{
+color = 9;
+glyphname = "haSayisi-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(604,-15,o),
+(682,94,o),
+(682,263,cs),
+(682,298,o),
+(679,336,o),
+(671,374,c),
+(513,374,l),
+(518,339,o),
+(521,306,o),
+(521,280,cs),
+(521,179,o),
+(484,130,o),
+(423,130,cs),
+(321,130,o),
+(235,260,o),
+(231,714,c),
+(65,714,l),
+(65,0,l),
+(229,0,l),
+(229,332,l),
+(203,332,l),
+(213,119,o),
+(318,-15,o),
+(459,-15,cs)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C3;
+unicode = 5571;
+},
+{
+color = 9;
+glyphname = "ghuCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(402,0,l),
+(731,674,l),
+(731,714,l),
+(593,714,l),
+(503,528,l),
+(587,549,l),
+(174,549,l),
+(260,525,l),
+(170,714,l),
+(25,714,l),
+(25,674,l),
+(353,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(539,425,l),
+(473,443,l),
+(348,185,l),
+(414,185,l),
+(290,447,l),
+(226,425,l)
+);
+}
+);
+width = 756;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C4;
+unicode = 5572;
+},
+{
+color = 9;
+glyphname = "ghoCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(170,0,l),
+(260,189,l),
+(174,165,l),
+(587,165,l),
+(503,186,l),
+(593,0,l),
+(731,0,l),
+(731,40,l),
+(402,714,l),
+(353,714,l),
+(25,40,l),
+(25,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(414,529,l),
+(348,529,l),
+(473,271,l),
+(539,289,l),
+(226,289,l),
+(290,267,l)
+);
+}
+);
+width = 756;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C5;
+unicode = 5573;
+},
+{
+color = 9;
+glyphname = "gheCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (77,357);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(82,0,l),
+(639,332,l),
+(639,382,l),
+(82,714,l),
+(43,714,l),
+(43,579,l),
+(185,493,l),
+(179,542,l),
+(179,151,l),
+(185,223,l),
+(43,138,l),
+(43,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(301,513,l),
+(276,454,l),
+(497,320,l),
+(498,396,l),
+(276,263,l),
+(301,203,l)
+);
+}
+);
+width = 667;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15C6;
+unicode = 5574;
+},
+{
+color = 9;
+glyphname = "gheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (24,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 668;
+}
+);
+note = uni15C7;
+unicode = 5575;
+},
+{
+color = 9;
+glyphname = "ghiCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (-3,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 668;
+}
+);
+note = uni15C8;
+unicode = 5576;
+},
+{
+color = 9;
+glyphname = "ghaCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(624,0,l),
+(624,135,l),
+(493,216,l),
+(500,157,l),
+(500,557,l),
+(493,498,l),
+(624,577,l),
+(624,714,l),
+(584,714,l),
+(28,382,l),
+(28,332,l),
+(584,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(402,256,l),
+(171,395,l),
+(171,319,l),
+(402,458,l),
+(378,507,l),
+(378,212,l)
+);
+}
+);
+width = 667;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15C9;
+unicode = 5577;
+},
+{
+color = 9;
+glyphname = "ruCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(402,0,l),
+(731,674,l),
+(731,714,l),
+(593,714,l),
+(555,636,l),
+(581,649,l),
+(176,649,l),
+(209,634,l),
+(171,714,l),
+(25,714,l),
+(25,674,l),
+(353,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(546,522,l),
+(524,554,l),
+(349,189,l),
+(415,188,l),
+(243,550,l),
+(210,522,l)
+);
+}
+);
+width = 756;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CA;
+unicode = 5578;
+},
+{
+color = 9;
+glyphname = "roCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(170,0,l),
+(207,78,l),
+(177,65,l),
+(581,65,l),
+(553,80,l),
+(592.006,0,l),
+(731,0,l),
+(731,40,l),
+(402,714,l),
+(353,714,l),
+(25,40,l),
+(25,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(410,531,l),
+(345,531,l),
+(520,164,l),
+(547,192,l),
+(211,192,l),
+(236,160,l)
+);
+}
+);
+width = 756;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CB;
+unicode = 5579;
+},
+{
+color = 9;
+glyphname = "reCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(82,0,l),
+(639,332,l),
+(639,382,l),
+(82,714,l),
+(43,714,l),
+(43,578,l),
+(118,532,l),
+(100,566,l),
+(100,147,l),
+(118,184,l),
+(43,138,l),
+(43,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(226,539,l),
+(210,487,l),
+(490,319,l),
+(490,395,l),
+(210,229,l),
+(226,174,l)
+);
+}
+);
+width = 667;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CC;
+unicode = 5580;
+},
+{
+color = 9;
+glyphname = "reeCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(82,0,l),
+(639,332,l),
+(639,382,l),
+(82,714,l),
+(43,714,l),
+(43,597,l),
+(118,550,l),
+(100,578,l),
+(100,130,l),
+(118,162,l),
+(43,117,l),
+(43,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(209.002,549.998,l),
+(195,516,l),
+(529,320,l),
+(529,395,l),
+(194,197,l),
+(209,175,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(306,288,l),
+(306,426,l),
+(243,426,l),
+(243,288,l)
+);
+}
+);
+width = 667;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CD;
+unicode = 5581;
+},
+{
+color = 9;
+glyphname = "riCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(82,0,l),
+(639,332,l),
+(639,382,l),
+(82,714,l),
+(43,714,l),
+(43,597,l),
+(118,550,l),
+(100,578,l),
+(100,130,l),
+(118,162,l),
+(43,117,l),
+(43,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(318,304,o),
+(344,326,o),
+(344,357,cs),
+(344,388,o),
+(318,410,o),
+(290,410,cs),
+(262,410,o),
+(236,388,o),
+(236,357,cs),
+(236,326,o),
+(262,304,o),
+(290,304,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(209,550,l),
+(195,516,l),
+(529,320,l),
+(529,395,l),
+(194,197,l),
+(209,175,l)
+);
+}
+);
+width = 667;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CE;
+unicode = 5582;
+},
+{
+color = 9;
+glyphname = "raCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(624,0,l),
+(624,137,l),
+(557,179,l),
+(567,133,l),
+(567,581,l),
+(557,535,l),
+(624,577,l),
+(624,714,l),
+(584,714,l),
+(28,382,l),
+(28,332,l),
+(584,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(464,491,l),
+(440,540,l),
+(440,175,l),
+(464,225,l),
+(178,396,l),
+(178,320,l)
+);
+}
+);
+width = 667;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15CF;
+unicode = 5583;
+},
+{
+color = 9;
+glyphname = "wuCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(411,0,l),
+(748,674,l),
+(748,714,l),
+(619,714,l),
+(420,286,l),
+(456,286,l),
+(456,714,l),
+(328,714,l),
+(328,286,l),
+(365,286,l),
+(162.996,714,l),
+(25,714,l),
+(25,674,l),
+(362,0,l)
+);
+}
+);
+width = 773;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D0;
+unicode = 5584;
+},
+{
+color = 9;
+glyphname = "woCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(160,0,l),
+(360,428,l),
+(324,428,l),
+(324,0,l),
+(451,0,l),
+(451,428,l),
+(413,428,l),
+(616,0,l),
+(748,0,l),
+(748,40,l),
+(411,714,l),
+(362,714,l),
+(25,40,l),
+(25,0,l)
+);
+}
+);
+width = 773;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D1;
+unicode = 5585;
+},
+{
+color = 9;
+glyphname = "weCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(103,0,l),
+(660,332,l),
+(660,382,l),
+(103,714,l),
+(64,714,l),
+(64,580,l),
+(394,391,l),
+(394,419,l),
+(67,419,l),
+(67,295,l),
+(393,295,l),
+(393,323,l),
+(64,135,l),
+(64,0,l)
+);
+}
+);
+width = 688;
+}
+);
+metricRight = "o-canadian";
+note = uni15D2;
+unicode = 5586;
+},
+{
+color = 9;
+glyphname = "weeCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(103,0,l),
+(660,332,l),
+(660,382,l),
+(103,714,l),
+(64,714,l),
+(64,595,l),
+(458,369,l),
+(468,405,l),
+(217,405,l),
+(217,474,l),
+(131,474,l),
+(131,405,l),
+(64,405,l),
+(64,309,l),
+(131,309,l),
+(131,240,l),
+(217,240,l),
+(217,309,l),
+(468,309,l),
+(458,345,l),
+(64,119,l),
+(64,0,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D3;
+unicode = 5587;
+},
+{
+color = 9;
+glyphname = "wiCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(103,0,l),
+(660,332,l),
+(660,382,l),
+(103,714,l),
+(64,714,l),
+(64,595,l),
+(459,369,l),
+(469,405,l),
+(289,405,l),
+(274,435,o),
+(242,455,o),
+(205,455,cs),
+(168,455,o),
+(136,435,o),
+(120,405,c),
+(64,405,l),
+(64,309,l),
+(120,309,l),
+(137,279,o),
+(168,259,o),
+(205,259,cs),
+(241,259,o),
+(272,280,o),
+(288,309,c),
+(469,309,l),
+(459,345,l),
+(64,119,l),
+(64,0,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D4;
+unicode = 5588;
+},
+{
+color = 9;
+glyphname = "waCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(624,0,l),
+(624,134,l),
+(294,323,l),
+(294,295,l),
+(620,295,l),
+(620,419,l),
+(295,419,l),
+(295,391,l),
+(624,579,l),
+(624,714,l),
+(585,714,l),
+(28,382,l),
+(28,332,l),
+(584,0,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15D5;
+unicode = 5589;
+},
+{
+color = 9;
+glyphname = "hwuCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(411,0,l),
+(748,674,l),
+(748,714,l),
+(627,714,l),
+(548,551,l),
+(598,571,l),
+(439,571,l),
+(439,714,l),
+(338,714,l),
+(338,571,l),
+(177,571,l),
+(230,553,l),
+(151,714,l),
+(25,714,l),
+(25,674,l),
+(362,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(348,485,l),
+(348,208,l),
+(379,215,l),
+(246,504,l),
+(211,485,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(429,485,l),
+(566,485,l),
+(535,503,l),
+(397,212,l),
+(429,205,l)
+);
+}
+);
+width = 773;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D6;
+unicode = 5590;
+},
+{
+color = 9;
+glyphname = "hwoCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(150,0,l),
+(231,162,l),
+(181,140,l),
+(338,140,l),
+(338,0,l),
+(439,0,l),
+(439,140,l),
+(604,140,l),
+(548,162,l),
+(627,0,l),
+(748,0,l),
+(748,40,l),
+(411,714,l),
+(362,714,l),
+(25,40,l),
+(25,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(364,468,l),
+(348,473,l),
+(348,232,l),
+(224,232,l),
+(245,210,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(561,232,l),
+(429,232,l),
+(429,476,l),
+(413,471,l),
+(534,211,l)
+);
+}
+);
+width = 773;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D7;
+unicode = 5591;
+},
+{
+color = 9;
+glyphname = "hweCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(103,0,l),
+(660,332,l),
+(660,382,l),
+(103,714,l),
+(64,714,l),
+(64,594,l),
+(196,518,l),
+(196,409,l),
+(64,409,l),
+(64,305,l),
+(196,305,l),
+(196,195,l),
+(64,119,l),
+(64,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(272,316,l),
+(434,316,l),
+(272,228,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(272,485,l),
+(432,398,l),
+(272,398,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D8;
+unicode = 5592;
+},
+{
+color = 9;
+glyphname = "hweeCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(103,0,l),
+(660,332,l),
+(660,382,l),
+(103,714,l),
+(64,714,l),
+(64,598,l),
+(237,500,l),
+(237,400,l),
+(188,400,l),
+(188,467,l),
+(119,467,l),
+(119,400,l),
+(64,400,l),
+(64,314,l),
+(119,314,l),
+(119,247,l),
+(188,247,l),
+(188,314,l),
+(237,314,l),
+(237,214,l),
+(64,116,l),
+(64,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(305,322,l),
+(442,322,l),
+(305,245,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(305,469,l),
+(442,392,l),
+(305,392,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D9;
+unicode = 5593;
+},
+{
+color = 9;
+glyphname = "hwiCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(103,0,l),
+(660,332,l),
+(660,382,l),
+(103,714,l),
+(64,714,l),
+(64,598,l),
+(237,500,l),
+(237,392,l),
+(222,392,l),
+(210,417,o),
+(186,434,o),
+(157,434,cs),
+(129,434,o),
+(104,417,o),
+(92,392,c),
+(64,392,l),
+(64,322,l),
+(92,322,l),
+(104,297,o),
+(129,280,o),
+(157,280,cs),
+(184,280,o),
+(209,297,o),
+(221,322,c),
+(237,322,l),
+(237,214,l),
+(64,116,l),
+(64,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(305,322,l),
+(442,322,l),
+(305,245,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(305,469,l),
+(442,392,l),
+(305,392,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15DA;
+unicode = 5594;
+},
+{
+color = 9;
+glyphname = "hwaCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(624,0,l),
+(624,119,l),
+(492,195,l),
+(492,305,l),
+(624,305,l),
+(624,409,l),
+(492,409,l),
+(492,518,l),
+(624,594,l),
+(624,714,l),
+(585,714,l),
+(28,382,l),
+(28,332,l),
+(584,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(254,316,l),
+(416,316,l),
+(416,228,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(416,485,l),
+(416,398,l),
+(255,398,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15DB;
+unicode = 5595;
+},
+{
+color = 9;
+glyphname = "thuCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(576,-15,o),
+(693,108,o),
+(693,320,cs),
+(693,714,l),
+(58,714,l),
+(58,319,ls),
+(58,106,o),
+(175,-15,o),
+(376,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(223,569,l),
+(528,569,l),
+(528,320,ls),
+(528,195,o),
+(475,135,o),
+(375,135,cs),
+(278,135,o),
+(223,199,o),
+(223,320,cs)
+);
+}
+);
+width = 751;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DC;
+unicode = 5596;
+},
+{
+color = 9;
+glyphname = "thoCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(693,0,l),
+(693,395,ls),
+(693,607,o),
+(576,729,o),
+(381,729,cs),
+(179,729,o),
+(58,607,o),
+(58,395,cs),
+(58,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(223,394,ls),
+(223,516,o),
+(281,579,o),
+(378,579,cs),
+(474,579,o),
+(528,515,o),
+(528,394,cs),
+(528,145,l),
+(223,145,l)
+);
+}
+);
+width = 751;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DD;
+unicode = 5597;
+},
+{
+color = 9;
+glyphname = "theCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (374,357);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(338,0,ls),
+(566,0,o),
+(699,129,o),
+(699,358,cs),
+(699,587,o),
+(566,714,o),
+(337,714,cs),
+(65,714,l),
+(65,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(231,610,l),
+(190,569,l),
+(330,569,ls),
+(461,569,o),
+(533,501,o),
+(533,358,cs),
+(533,216,o),
+(461,145,o),
+(330,145,cs),
+(190,145,l),
+(231,104,l)
+);
+}
+);
+width = 751;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "to-canadian";
+note = uni15DE;
+unicode = 5598;
+},
+{
+color = 9;
+glyphname = "theeCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (308,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 752;
+}
+);
+note = uni15DF;
+unicode = 5599;
+},
+{
+color = 9;
+glyphname = "thiCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (277,0);
+ref = dot_middle;
+}
+);
+width = 752;
+}
+);
+note = uni15E0;
+unicode = 5600;
+},
+{
+color = 9;
+glyphname = "thaCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(687,0,l),
+(687,714,l),
+(415,714,ls),
+(186,714,o),
+(52,585,o),
+(52,356,cs),
+(52,127,o),
+(186,0,o),
+(414,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(219,499,o),
+(290,569,o),
+(421,569,cs),
+(562,569,l),
+(521,610,l),
+(521,104,l),
+(562,145,l),
+(421,145,ls),
+(290,145,o),
+(219,214,o),
+(219,356,cs)
+);
+}
+);
+width = 752;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15E1;
+unicode = 5601;
+},
+{
+color = 9;
+glyphname = "ttuCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(576,-15,o),
+(693,108,o),
+(693,320,cs),
+(693,714,l),
+(645,714,l),
+(354,536,l),
+(398,536,l),
+(107,714,l),
+(58,714,l),
+(58,319,ls),
+(58,106,o),
+(175,-15,o),
+(376,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(278,135,o),
+(223,199,o),
+(223,320,cs),
+(223,582,l),
+(73,578,l),
+(362,400,l),
+(390,400,l),
+(680,578,l),
+(528,582,l),
+(528,320,ls),
+(528,195,o),
+(475,135,o),
+(375,135,cs)
+);
+}
+);
+width = 751;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E2;
+unicode = 5602;
+},
+{
+color = 9;
+glyphname = "ttoCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(106,0,l),
+(397,178,l),
+(353,178,l),
+(643,0,l),
+(693,0,l),
+(693,395,ls),
+(693,608,o),
+(576,729,o),
+(375,729,cs),
+(175,729,o),
+(58,606,o),
+(58,394,cs),
+(58,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(472,579,o),
+(528,515,o),
+(528,394,cs),
+(528,132,l),
+(678,136,l),
+(389,314,l),
+(361,314,l),
+(71,136,l),
+(223,132,l),
+(223,394,ls),
+(223,519,o),
+(275,579,o),
+(375,579,cs)
+);
+}
+);
+width = 751;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E3;
+unicode = 5603;
+},
+{
+color = 9;
+glyphname = "tteCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (425,357);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(348,0,ls),
+(576,0,o),
+(709,129,o),
+(709,358,cs),
+(709,587,o),
+(576,714,o),
+(347,714,cs),
+(57,714,l),
+(57,674,l),
+(184,338,l),
+(184,375,l),
+(57,40,l),
+(57,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(336,343,l),
+(336,368,l),
+(209,703,l),
+(207,569,l),
+(341,569,ls),
+(472,569,o),
+(545,501,o),
+(545,358,cs),
+(545,216,o),
+(472,145,o),
+(341,145,cs),
+(207,145,l),
+(209,7,l)
+);
+}
+);
+width = 761;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15E4;
+unicode = 5604;
+},
+{
+color = 9;
+glyphname = "tteeCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (372,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 762;
+}
+);
+note = uni15E5;
+unicode = 5605;
+},
+{
+color = 9;
+glyphname = "ttiCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (362,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 762;
+}
+);
+note = uni15E6;
+unicode = 5606;
+},
+{
+color = 9;
+glyphname = "ttaCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(705,0,l),
+(705,40,l),
+(578,376,l),
+(578,339,l),
+(705,674,l),
+(705,714,l),
+(415,714,ls),
+(186,714,o),
+(52,585,o),
+(52,356,cs),
+(52,127,o),
+(186,0,o),
+(414,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(555,145,l),
+(421,145,ls),
+(290,145,o),
+(217,214,o),
+(217,356,cs),
+(217,499,o),
+(290,569,o),
+(421,569,cs),
+(555,569,l),
+(553,707,l),
+(426,371,l),
+(426,346,l),
+(553,11,l)
+);
+}
+);
+width = 762;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tteCarrier-canadian";
+note = uni15E7;
+unicode = 5607;
+},
+{
+color = 9;
+glyphname = "puCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(576,-15,o),
+(693,108,o),
+(693,320,cs),
+(693,714,l),
+(527,714,l),
+(527,575,l),
+(224,575,l),
+(224,714,l),
+(58,714,l),
+(58,319,ls),
+(58,106,o),
+(175,-15,o),
+(376,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(278,135,o),
+(224,199,o),
+(224,320,cs),
+(224,429,l),
+(527,429,l),
+(527,320,ls),
+(527,195,o),
+(475,135,o),
+(375,135,cs)
+);
+}
+);
+width = 751;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E8;
+unicode = 5608;
+},
+{
+color = 9;
+glyphname = "poCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(224,0,l),
+(224,139,l),
+(527,139,l),
+(527,0,l),
+(693,0,l),
+(693,395,ls),
+(693,607,o),
+(577,729,o),
+(381,729,cs),
+(181,729,o),
+(58,607,o),
+(58,395,cs),
+(58,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(224,394,ls),
+(224,516,o),
+(281,579,o),
+(378,579,cs),
+(474,579,o),
+(527,515,o),
+(527,394,cs),
+(527,285,l),
+(224,285,l)
+);
+}
+);
+width = 751;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E9;
+unicode = 5609;
+},
+{
+color = 9;
+glyphname = "peCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (413,357);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(347,0,ls),
+(575,0,o),
+(708,129,o),
+(708,358,cs),
+(708,587,o),
+(575,714,o),
+(346,714,cs),
+(56,714,l),
+(56,569,l),
+(138,569,l),
+(138,145,l),
+(56,145,l),
+(56,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(302,610,l),
+(253,569,l),
+(340,569,ls),
+(471,569,o),
+(542,501,o),
+(542,358,cs),
+(542,216,o),
+(471,145,o),
+(340,145,cs),
+(253,145,l),
+(302,104,l)
+);
+}
+);
+width = 760;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15EA;
+unicode = 5610;
+},
+{
+color = 9;
+glyphname = "peeCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (360,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 761;
+}
+);
+note = uni15EB;
+unicode = 5611;
+},
+{
+color = 9;
+glyphname = "piCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (350,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 761;
+}
+);
+note = uni15EC;
+unicode = 5612;
+},
+{
+color = 9;
+glyphname = "paCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(705,0,l),
+(705,145,l),
+(623,145,l),
+(623,569,l),
+(705,569,l),
+(705,714,l),
+(415,714,ls),
+(186,714,o),
+(52,587,o),
+(52,358,cs),
+(52,129,o),
+(186,0,o),
+(414,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(508,145,l),
+(421,145,ls),
+(290,145,o),
+(219,216,o),
+(219,358,cs),
+(219,501,o),
+(290,569,o),
+(421,569,cs),
+(508,569,l),
+(458,610,l),
+(458,104,l)
+);
+}
+);
+width = 761;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|peCarrier-canadian";
+note = uni15ED;
+unicode = 5613;
+},
+{
+color = 6;
+glyphname = "pCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(391,189,l),
+(391,296,l),
+(280,296,l),
+(280,546,l),
+(167,546,l),
+(167,296,l),
+(55,296,l),
+(55,189,l)
+);
+}
+);
+width = 446;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni15EE;
+unicode = 5614;
+},
+{
+color = 9;
+glyphname = "guCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (442,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(381,-15,o),
+(448,35,o),
+(480,132,c),
+(404,132,l),
+(443,31,o),
+(509,-15,o),
+(604,-15,cs),
+(742,-15,o),
+(822,77,o),
+(822,226,cs),
+(822,714,l),
+(664,714,l),
+(664,227,ls),
+(664,164,o),
+(640,131,o),
+(594,131,cs),
+(548,131,o),
+(521,165,o),
+(521,224,cs),
+(521,714,l),
+(365,714,l),
+(365,224,ls),
+(365,164,o),
+(339,131,o),
+(293,131,cs),
+(245,131,o),
+(219,164,o),
+(219,227,cs),
+(219,714,l),
+(61,714,l),
+(61,226,ls),
+(61,76,o),
+(147,-15,o),
+(281,-15,cs)
+);
+}
+);
+width = 883;
+}
+);
+metricRight = "=|";
+note = uni15EF;
+unicode = 5615;
+},
+{
+color = 9;
+glyphname = "goCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(219,0,l),
+(219,487,ls),
+(219,550,o),
+(243,583,o),
+(289,583,cs),
+(336,583,o),
+(362,550,o),
+(362,490,cs),
+(362,0,l),
+(519,0,l),
+(519,490,ls),
+(519,549,o),
+(544,583,o),
+(590,583,cs),
+(638,583,o),
+(664,550,o),
+(664,487,cs),
+(664,0,l),
+(822,0,l),
+(822,488,ls),
+(822,638,o),
+(736,729,o),
+(602,729,cs),
+(503,729,o),
+(436,679,o),
+(404,582,c),
+(479,582,l),
+(441,683,o),
+(375,729,o),
+(279,729,cs),
+(141,729,o),
+(61,637,o),
+(61,488,cs),
+(61,0,l)
+);
+}
+);
+width = 883;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F0;
+unicode = 5616;
+},
+{
+color = 9;
+glyphname = "geCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (382,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(466,0,ls),
+(620,0,o),
+(699,72,o),
+(699,202,cs),
+(699,285,o),
+(648,353,o),
+(568,385,c),
+(568,328,l),
+(651,356,o),
+(699,419,o),
+(699,510,cs),
+(699,638,o),
+(617,714,o),
+(466,714,cs),
+(65,714,l),
+(65,580,l),
+(436,580,ls),
+(501,580,o),
+(533,554,o),
+(533,503,cs),
+(533,450,o),
+(500,424,o),
+(437,424,cs),
+(65,424,l),
+(65,292,l),
+(437,292,ls),
+(499,292,o),
+(533,266,o),
+(533,211,cs),
+(533,160,o),
+(500,134,o),
+(436,134,cs),
+(65,134,l),
+(65,0,l)
+);
+}
+);
+width = 760;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15F1;
+unicode = 5617;
+},
+{
+color = 9;
+glyphname = "geeCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(466,0,ls),
+(620,0,o),
+(699,72,o),
+(699,202,cs),
+(699,285,o),
+(648,353,o),
+(568,385,c),
+(568,328,l),
+(651,356,o),
+(699,419,o),
+(699,510,cs),
+(699,638,o),
+(617,714,o),
+(466,714,cs),
+(65,714,l),
+(65,580,l),
+(436,580,ls),
+(501,580,o),
+(533,554,o),
+(533,503,cs),
+(533,450,o),
+(500,422,o),
+(437,422,cs),
+(362,422,l),
+(362,501,l),
+(270,501,l),
+(270,422,l),
+(65,422,l),
+(65,293,l),
+(270,293,l),
+(270,214,l),
+(362,214,l),
+(362,293,l),
+(437,293,ls),
+(499,293,o),
+(533,266,o),
+(533,211,cs),
+(533,160,o),
+(500,134,o),
+(436,134,cs),
+(65,134,l),
+(65,0,l)
+);
+}
+);
+width = 760;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F2;
+unicode = 5618;
+},
+{
+color = 9;
+glyphname = "giCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(466,0,ls),
+(620,0,o),
+(699,72,o),
+(699,202,cs),
+(699,279,o),
+(655,342,o),
+(587,375,c),
+(586,336,l),
+(658,366,o),
+(699,425,o),
+(699,510,cs),
+(699,638,o),
+(617,714,o),
+(466,714,cs),
+(65,714,l),
+(65,580,l),
+(436,580,ls),
+(501,580,o),
+(533,554,o),
+(533,503,cs),
+(533,450,o),
+(500,422,o),
+(443,422,cs),
+(382,422,l),
+(434,400,l),
+(419,444,o),
+(378,475,o),
+(327,475,cs),
+(286,475,o),
+(251,454,o),
+(230,422,c),
+(65,422,l),
+(65,293,l),
+(230,293,l),
+(250,261,o),
+(286,240,o),
+(327,240,cs),
+(378,240,o),
+(418,272,o),
+(435,316,c),
+(382,293,l),
+(443,293,ls),
+(499,293,o),
+(533,266,o),
+(533,211,cs),
+(533,160,o),
+(500,134,o),
+(436,134,cs),
+(65,134,l),
+(65,0,l)
+);
+}
+);
+width = 760;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F3;
+unicode = 5619;
+},
+{
+color = 9;
+glyphname = "gaCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (396,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(695,0,l),
+(695,134,l),
+(323,134,ls),
+(259,134,o),
+(227,160,o),
+(227,211,cs),
+(227,266,o),
+(261,292,o),
+(322,292,cs),
+(695,292,l),
+(695,424,l),
+(322,424,ls),
+(260,424,o),
+(227,450,o),
+(227,503,cs),
+(227,554,o),
+(259,580,o),
+(323,580,cs),
+(695,580,l),
+(695,714,l),
+(294,714,ls),
+(143,714,o),
+(61,638,o),
+(61,510,cs),
+(61,419,o),
+(109,357,o),
+(192,330,c),
+(192,386,l),
+(112,354,o),
+(61,285,o),
+(61,202,cs),
+(61,72,o),
+(139,0,o),
+(294,0,cs)
+);
+}
+);
+width = 760;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|geCarrier-canadian";
+note = uni15F4;
+unicode = 5620;
+},
+{
+color = 9;
+glyphname = "khuCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(381,-15,o),
+(448,35,o),
+(480,132,c),
+(404,132,l),
+(443,31,o),
+(509,-15,o),
+(604,-15,cs),
+(742,-15,o),
+(822,77,o),
+(822,226,cs),
+(822,714,l),
+(61,714,l),
+(61,226,ls),
+(61,76,o),
+(147,-15,o),
+(281,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(246,131,o),
+(220,164,o),
+(220,227,cs),
+(220,573,l),
+(365,573,l),
+(365,224,ls),
+(365,164,o),
+(340,131,o),
+(294,131,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(547,131,o),
+(521,165,o),
+(521,224,cs),
+(521,573,l),
+(663,573,l),
+(663,227,ls),
+(663,164,o),
+(640,131,o),
+(593,131,cs)
+);
+}
+);
+width = 883;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F5;
+unicode = 5621;
+},
+{
+color = 9;
+glyphname = "khoCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(822,0,l),
+(822,488,ls),
+(822,636,o),
+(741,729,o),
+(604,729,cs),
+(508,729,o),
+(441,682,o),
+(404,582,c),
+(480,582,l),
+(446,679,o),
+(379,729,o),
+(280,729,cs),
+(146,729,o),
+(61,639,o),
+(61,488,cs),
+(61,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(220,487,ls),
+(220,550,o),
+(246,583,o),
+(293,583,cs),
+(339,583,o),
+(365,550,o),
+(365,490,cs),
+(365,141,l),
+(220,141,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(520,490,ls),
+(520,549,o),
+(546,583,o),
+(593,583,cs),
+(640,583,o),
+(663,550,o),
+(663,487,cs),
+(663,141,l),
+(520,141,l)
+);
+}
+);
+width = 883;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F6;
+unicode = 5622;
+},
+{
+color = 9;
+glyphname = "kheCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(474,0,ls),
+(628,0,o),
+(707,72,o),
+(707,202,cs),
+(707,285,o),
+(656,353,o),
+(576,385,c),
+(576,328,l),
+(659,356,o),
+(707,419,o),
+(707,510,cs),
+(707,638,o),
+(625,714,o),
+(474,714,cs),
+(65,714,l),
+(65,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(230,293,l),
+(445,293,ls),
+(507,293,o),
+(541,266,o),
+(541,211,cs),
+(541,160,o),
+(508,132,o),
+(444,132,cs),
+(230,132,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(230,582,l),
+(444,582,ls),
+(509,582,o),
+(541,554,o),
+(541,503,cs),
+(541,450,o),
+(508,423,o),
+(445,423,cs),
+(230,423,l)
+);
+}
+);
+width = 768;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F7;
+unicode = 5623;
+},
+{
+color = 9;
+glyphname = "kheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(474,0,ls),
+(628,0,o),
+(707,72,o),
+(707,202,cs),
+(707,283,o),
+(659,348,o),
+(583,381,c),
+(583,332,l),
+(661,360,o),
+(707,422,o),
+(707,510,cs),
+(707,638,o),
+(625,714,o),
+(474,714,cs),
+(65,714,l),
+(65,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(230,294,l),
+(326,294,l),
+(326,213,l),
+(429,213,l),
+(429,334,l),
+(384,294,l),
+(451,294,ls),
+(510,294,o),
+(541,267,o),
+(541,212,cs),
+(541,160,o),
+(508,132,o),
+(444,132,cs),
+(230,132,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(429,502,l),
+(326,502,l),
+(326,421,l),
+(230,421,l),
+(230,582,l),
+(444,582,ls),
+(509,582,o),
+(541,554,o),
+(541,503,cs),
+(541,448,o),
+(511,421,o),
+(451,421,cs),
+(384,421,l),
+(429,382,l)
+);
+}
+);
+width = 768;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F8;
+unicode = 5624;
+},
+{
+color = 9;
+glyphname = "khiCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(474,0,ls),
+(628,0,o),
+(707,72,o),
+(707,202,cs),
+(707,283,o),
+(658,349,o),
+(584,382,c),
+(582,331,l),
+(662,359,o),
+(707,421,o),
+(707,510,cs),
+(707,638,o),
+(625,714,o),
+(474,714,cs),
+(65,714,l),
+(65,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(230,297,l),
+(277,297,l),
+(297,263,o),
+(333,240,o),
+(376,240,cs),
+(437,240,o),
+(482,287,o),
+(489,344,c),
+(398,297,l),
+(454,297,ls),
+(510,297,o),
+(541,269,o),
+(541,213,cs),
+(541,159,o),
+(508,132,o),
+(444,132,cs),
+(230,132,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(444,582,ls),
+(509,582,o),
+(541,555,o),
+(541,501,cs),
+(541,446,o),
+(511,418,o),
+(454,418,cs),
+(399,418,l),
+(490,371,l),
+(482,430,o),
+(437,475,o),
+(376,475,cs),
+(316,475,o),
+(268,430,o),
+(261,371,c),
+(314,418,l),
+(230,418,l),
+(230,582,l)
+);
+}
+);
+width = 768;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F9;
+unicode = 5625;
+},
+{
+color = 9;
+glyphname = "khaCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(703,0,l),
+(703,714,l),
+(294,714,ls),
+(143,714,o),
+(61,638,o),
+(61,510,cs),
+(61,421,o),
+(106,360,o),
+(186,333,c),
+(183,384,l),
+(109,350,o),
+(61,283,o),
+(61,202,cs),
+(61,72,o),
+(139,0,o),
+(294,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(259,132,o),
+(227,160,o),
+(227,211,cs),
+(227,266,o),
+(261,293,o),
+(322,293,cs),
+(538,293,l),
+(538,132,l),
+(323,132,ls)
+);
+},
+{
+closed = 1;
+nodes = (
+(260,423,o),
+(227,450,o),
+(227,503,cs),
+(227,554,o),
+(259,582,o),
+(323,582,cs),
+(538,582,l),
+(538,423,l),
+(322,423,ls)
+);
+}
+);
+width = 768;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15FA;
+unicode = 5626;
+},
+{
+color = 9;
+glyphname = "kkuCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(381,-15,o),
+(449,36,o),
+(480,135,c),
+(404,135,l),
+(442,32,o),
+(508,-15,o),
+(604,-15,cs),
+(742,-15,o),
+(822,77,o),
+(822,226,cs),
+(822,714,l),
+(775,714,l),
+(494,572,l),
+(494,419,l),
+(768,553,l),
+(664,563,l),
+(664,227,ls),
+(664,164,o),
+(640,131,o),
+(594,131,cs),
+(547,131,o),
+(520,165,o),
+(520,224,cs),
+(520,714,l),
+(365,714,l),
+(365,224,ls),
+(365,164,o),
+(340,131,o),
+(293,131,cs),
+(246,131,o),
+(219,164,o),
+(219,227,cs),
+(219,563,l),
+(117,552,l),
+(389,420,l),
+(389,573,l),
+(110,714,l),
+(61,714,l),
+(61,226,ls),
+(61,76,o),
+(147,-15,o),
+(281,-15,cs)
+);
+}
+);
+width = 883;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FB;
+unicode = 5627;
+},
+{
+color = 9;
+glyphname = "kkoCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(108,0,l),
+(389,142,l),
+(389,295,l),
+(115,161,l),
+(219,151,l),
+(219,487,ls),
+(219,550,o),
+(243,583,o),
+(289,583,cs),
+(336,583,o),
+(362,549,o),
+(362,490,cs),
+(362,0,l),
+(518,0,l),
+(518,490,ls),
+(518,550,o),
+(543,583,o),
+(589,583,cs),
+(637,583,o),
+(664,550,o),
+(664,487,cs),
+(664,151,l),
+(766,162,l),
+(493,294,l),
+(493,141,l),
+(773,0,l),
+(822,0,l),
+(822,488,ls),
+(822,638,o),
+(736,729,o),
+(602,729,cs),
+(502,729,o),
+(434,678,o),
+(403,579,c),
+(479,579,l),
+(441,682,o),
+(375,729,o),
+(279,729,cs),
+(141,729,o),
+(61,637,o),
+(61,488,cs),
+(61,0,l)
+);
+}
+);
+width = 883;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FC;
+unicode = 5628;
+},
+{
+color = 9;
+glyphname = "kkeCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(488,0,ls),
+(643,0,o),
+(722,72,o),
+(722,202,cs),
+(722,283,o),
+(673,349,o),
+(599,382,c),
+(597,331,l),
+(676,359,o),
+(722,421,o),
+(722,510,cs),
+(722,638,o),
+(639,714,o),
+(488,714,cs),
+(60,714,l),
+(60,674,l),
+(155,424,l),
+(80,424,l),
+(80,292,l),
+(155,292,l),
+(60,40,l),
+(60,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(322,292,l),
+(460,292,ls),
+(521,292,o),
+(556,266,o),
+(556,211,cs),
+(556,160,o),
+(523,134,o),
+(459,134,cs),
+(188,134,l),
+(235,64,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(234,650,l),
+(186,580,l),
+(459,580,ls),
+(523,580,o),
+(556,554,o),
+(556,503,cs),
+(556,450,o),
+(522,424,o),
+(460,424,cs),
+(320,424,l)
+);
+}
+);
+width = 783;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni15FD;
+unicode = 5629;
+},
+{
+color = 9;
+glyphname = "kkeeCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(488,0,ls),
+(643,0,o),
+(722,72,o),
+(722,202,cs),
+(722,283,o),
+(673,349,o),
+(599,382,c),
+(597,331,l),
+(676,359,o),
+(722,421,o),
+(722,510,cs),
+(722,638,o),
+(639,714,o),
+(488,714,cs),
+(60,714,l),
+(60,674,l),
+(155,424,l),
+(80,424,l),
+(80,292,l),
+(155,292,l),
+(60,40,l),
+(60,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(321,296,l),
+(363,296,l),
+(363,214,l),
+(466,214,l),
+(466,322,l),
+(429,296,l),
+(471,296,ls),
+(524,296,o),
+(556,269,o),
+(556,213,cs),
+(556,161,o),
+(523,134,o),
+(459,134,cs),
+(186,134,l),
+(235,64,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(466,501,l),
+(363,501,l),
+(363,420,l),
+(319,420,l),
+(233,650,l),
+(185,580,l),
+(459,580,ls),
+(523,580,o),
+(556,554,o),
+(556,501,cs),
+(556,446,o),
+(525,420,o),
+(471,420,cs),
+(429,420,l),
+(466,397,l)
+);
+}
+);
+width = 783;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FE;
+unicode = 5630;
+},
+{
+color = 9;
+glyphname = "kkiCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(488,0,ls),
+(643,0,o),
+(722,72,o),
+(722,202,cs),
+(722,283,o),
+(673,349,o),
+(599,382,c),
+(597,331,l),
+(676,359,o),
+(722,421,o),
+(722,510,cs),
+(722,638,o),
+(639,714,o),
+(488,714,cs),
+(60,714,l),
+(60,674,l),
+(155,424,l),
+(80,424,l),
+(80,292,l),
+(155,292,l),
+(60,40,l),
+(60,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(322,299,l),
+(314,299,l),
+(333,263,o),
+(369,240,o),
+(413,240,cs),
+(474,240,o),
+(518,288,o),
+(523,341,c),
+(445,299,l),
+(471,299,ls),
+(524,299,o),
+(556,269,o),
+(556,211,cs),
+(556,161,o),
+(523,134,o),
+(459,134,cs),
+(186,134,l),
+(235,64,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(518,429,o),
+(475,475,o),
+(413,475,cs),
+(370,475,o),
+(334,452,o),
+(315,417,c),
+(320,417,l),
+(233,650,l),
+(185,580,l),
+(459,580,ls),
+(523,580,o),
+(556,554,o),
+(556,499,cs),
+(556,446,o),
+(525,417,o),
+(471,417,cs),
+(446,417,l),
+(525,374,l)
+);
+}
+);
+width = 783;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FF;
+unicode = 5631;
+},
+{
+color = 9;
+glyphname = "kkaCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(722,0,l),
+(722,40,l),
+(627,292,l),
+(700,292,l),
+(700,424,l),
+(627,424,l),
+(722,674,l),
+(722,714,l),
+(294,714,ls),
+(143,714,o),
+(61,638,o),
+(61,510,cs),
+(61,421,o),
+(106,360,o),
+(186,333,c),
+(183,384,l),
+(109,350,o),
+(61,283,o),
+(61,202,cs),
+(61,72,o),
+(139,0,o),
+(294,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(596,134,l),
+(323,134,ls),
+(259,134,o),
+(227,160,o),
+(227,211,cs),
+(227,266,o),
+(261,292,o),
+(322,292,cs),
+(461,292,l),
+(548,64,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(260,424,o),
+(227,450,o),
+(227,503,cs),
+(227,554,o),
+(259,580,o),
+(323,580,cs),
+(595,580,l),
+(547,650,l),
+(461,424,l),
+(322,424,ls)
+);
+}
+);
+width = 782;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|kkeCarrier-canadian";
+note = uni1600;
+unicode = 5632;
+},
+{
+color = 6;
+glyphname = "kkCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(225,189,l),
+(389,526,l),
+(389,546,l),
+(279,546,l),
+(170,310,l),
+(256,310,l),
+(148,546,l),
+(36,546,l),
+(36,526,l),
+(200,189,l)
+);
+}
+);
+width = 425;
+}
+);
+note = uni1601;
+unicode = 5633;
+},
+{
+color = 9;
+glyphname = "nuCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(583,-15,o),
+(693,104,o),
+(693,296,cs),
+(693,324,l),
+(529,324,l),
+(529,291,ls),
+(529,188,o),
+(475,135,o),
+(382,135,cs),
+(274,135,o),
+(224,194,o),
+(224,322,cs),
+(224,714,l),
+(58,714,l),
+(58,318,ls),
+(58,100,o),
+(173,-15,o),
+(378,-15,cs)
+);
+}
+);
+width = 741;
+}
+);
+metricLeft = "te-canadian";
+note = uni1602;
+unicode = 5634;
+},
+{
+color = 9;
+glyphname = "noCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(683,0,l),
+(683,396,ls),
+(683,614,o),
+(567,729,o),
+(362,729,cs),
+(158,729,o),
+(48,610,o),
+(48,418,cs),
+(48,390,l),
+(212,390,l),
+(212,423,ls),
+(212,526,o),
+(266,579,o),
+(359,579,cs),
+(467,579,o),
+(517,520,o),
+(517,392,cs),
+(517,0,l)
+);
+}
+);
+width = 741;
+}
+);
+metricLeft = "=|nuCarrier-canadian";
+metricRight = "te-canadian";
+note = uni1603;
+unicode = 5635;
+},
+{
+color = 9;
+glyphname = "neCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (362,356);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(343,0,ls),
+(570,0,o),
+(704,129,o),
+(704,358,cs),
+(704,587,o),
+(570,714,o),
+(341,714,cs),
+(42,714,l),
+(42,565,l),
+(335,565,ls),
+(463,565,o),
+(539,497,o),
+(539,357,cs),
+(539,216,o),
+(463,147,o),
+(336,147,cs),
+(316,147,l),
+(316,0,l)
+);
+}
+);
+width = 756;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1604;
+unicode = 5636;
+},
+{
+color = 9;
+glyphname = "neeCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+ref = "neCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (296,-1);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 756;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1605;
+unicode = 5637;
+},
+{
+color = 9;
+glyphname = "niCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "neCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (265,-1);
+ref = dot_middle;
+}
+);
+width = 756;
+}
+);
+note = uni1606;
+unicode = 5638;
+},
+{
+color = 9;
+glyphname = "naCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(714,0,l),
+(714,149,l),
+(421,149,ls),
+(293,149,o),
+(217,217,o),
+(217,357,cs),
+(217,498,o),
+(293,567,o),
+(420,567,cs),
+(440,567,l),
+(440,714,l),
+(413,714,ls),
+(186,714,o),
+(52,585,o),
+(52,356,cs),
+(52,127,o),
+(186,0,o),
+(414,0,cs)
+);
+}
+);
+width = 756;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni1607;
+unicode = 5639;
+},
+{
+color = 9;
+glyphname = "muCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(381,-15,o),
+(448,35,o),
+(480,132,c),
+(404,132,l),
+(443,31,o),
+(509,-15,o),
+(604,-15,cs),
+(742,-15,o),
+(822,77,o),
+(822,226,cs),
+(822,409,l),
+(664,409,l),
+(664,227,ls),
+(664,164,o),
+(640,131,o),
+(594,131,cs),
+(548,131,o),
+(521,165,o),
+(521,224,cs),
+(521,409,l),
+(365,409,l),
+(365,224,ls),
+(365,164,o),
+(339,131,o),
+(293,131,cs),
+(245,131,o),
+(219,164,o),
+(219,227,cs),
+(219,714,l),
+(61,714,l),
+(61,226,ls),
+(61,76,o),
+(147,-15,o),
+(281,-15,cs)
+);
+}
+);
+width = 883;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "=|";
+note = uni1608;
+unicode = 5640;
+},
+{
+color = 9;
+glyphname = "moCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(822,0,l),
+(822,488,ls),
+(822,638,o),
+(736,729,o),
+(602,729,cs),
+(503,729,o),
+(436,679,o),
+(404,582,c),
+(479,582,l),
+(441,683,o),
+(375,729,o),
+(279,729,cs),
+(141,729,o),
+(61,637,o),
+(61,488,cs),
+(61,305,l),
+(219,305,l),
+(219,487,ls),
+(219,550,o),
+(243,583,o),
+(289,583,cs),
+(336,583,o),
+(362,549,o),
+(362,490,cs),
+(362,305,l),
+(519,305,l),
+(519,490,ls),
+(519,549,o),
+(544,583,o),
+(590,583,cs),
+(638,583,o),
+(664,550,o),
+(664,487,cs),
+(664,0,l)
+);
+}
+);
+width = 883;
+}
+);
+metricLeft = "=|muCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni1609;
+unicode = 5641;
+},
+{
+color = 9;
+glyphname = "meCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(470,0,ls),
+(625,0,o),
+(704,72,o),
+(704,202,cs),
+(704,285,o),
+(652,353,o),
+(572,385,c),
+(572,328,l),
+(655,356,o),
+(704,419,o),
+(704,510,cs),
+(704,638,o),
+(621,714,o),
+(470,714,cs),
+(42,714,l),
+(42,580,l),
+(441,580,ls),
+(505,580,o),
+(538,554,o),
+(538,503,cs),
+(538,450,o),
+(504,424,o),
+(442,424,cs),
+(297,424,l),
+(297,292,l),
+(442,292,ls),
+(503,292,o),
+(538,266,o),
+(538,211,cs),
+(538,160,o),
+(505,134,o),
+(441,134,cs),
+(297,134,l),
+(297,0,l)
+);
+}
+);
+width = 765;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160A;
+unicode = 5642;
+},
+{
+color = 9;
+glyphname = "meeCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(470,0,ls),
+(625,0,o),
+(704,72,o),
+(704,202,cs),
+(704,283,o),
+(655,349,o),
+(581,382,c),
+(579,331,l),
+(658,359,o),
+(704,421,o),
+(704,510,cs),
+(704,638,o),
+(621,714,o),
+(470,714,cs),
+(42,714,l),
+(42,580,l),
+(441,580,ls),
+(505,580,o),
+(538,554,o),
+(538,501,cs),
+(538,447,o),
+(506,420,o),
+(447,420,cs),
+(403,420,l),
+(403,493,l),
+(297,493,l),
+(297,221,l),
+(403,221,l),
+(403,295,l),
+(446,295,ls),
+(506,295,o),
+(538,268,o),
+(538,213,cs),
+(538,161,o),
+(505,134,o),
+(441,134,cs),
+(297,134,l),
+(297,0,l)
+);
+}
+);
+width = 765;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160B;
+unicode = 5643;
+},
+{
+color = 9;
+glyphname = "miCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(470,0,ls),
+(625,0,o),
+(704,72,o),
+(704,202,cs),
+(704,283,o),
+(655,349,o),
+(581,382,c),
+(579,331,l),
+(658,359,o),
+(704,421,o),
+(704,510,cs),
+(704,638,o),
+(621,714,o),
+(470,714,cs),
+(42,714,l),
+(42,580,l),
+(440,580,ls),
+(505,580,o),
+(538,554,o),
+(538,501,cs),
+(538,447,o),
+(506,420,o),
+(455,420,cs),
+(373,420,l),
+(465,374,l),
+(457,432,o),
+(411,475,o),
+(350,475,cs),
+(284,475,o),
+(234,423,o),
+(234,358,cs),
+(234,292,o),
+(284,240,o),
+(350,240,cs),
+(410,240,o),
+(456,286,o),
+(463,341,c),
+(372,295,l),
+(455,295,ls),
+(506,295,o),
+(538,268,o),
+(538,213,cs),
+(538,161,o),
+(505,134,o),
+(441,134,cs),
+(297,134,l),
+(297,0,l)
+);
+}
+);
+width = 765;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160C;
+unicode = 5644;
+},
+{
+color = 9;
+glyphname = "maCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(722,0,l),
+(722,134,l),
+(323,134,ls),
+(259,134,o),
+(227,159,o),
+(227,211,cs),
+(227,265,o),
+(260,291,o),
+(322,291,cs),
+(468,291,l),
+(468,423,l),
+(323,423,ls),
+(260,423,o),
+(227,450,o),
+(227,503,cs),
+(227,554,o),
+(259,580,o),
+(323,580,cs),
+(468,580,l),
+(468,714,l),
+(294,714,ls),
+(142,714,o),
+(61,639,o),
+(61,511,cs),
+(61,421,o),
+(110,359,o),
+(192,330,c),
+(192,386,l),
+(111,356,o),
+(61,288,o),
+(61,202,cs),
+(61,73,o),
+(141,0,o),
+(294,0,cs)
+);
+}
+);
+width = 764;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni160D;
+unicode = 5645;
+},
+{
+color = 9;
+glyphname = "yuCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(613,-15,o),
+(742,139,o),
+(742,396,cs),
+(742,622,o),
+(647,729,o),
+(513,729,cs),
+(394,729,o),
+(305,648,o),
+(305,507,cs),
+(305,375,o),
+(387,296,o),
+(497,296,cs),
+(509,296,o),
+(524,298,o),
+(536,301,c),
+(536,431,l),
+(530,430,o),
+(523,430,o),
+(514,430,cs),
+(473,430,o),
+(450,458,o),
+(450,514,cs),
+(450,567,o),
+(472,595,o),
+(507,595,cs),
+(551,595,o),
+(583,555,o),
+(583,400,cs),
+(583,208,o),
+(512,135,o),
+(398,135,cs),
+(287,135,o),
+(224,202,o),
+(224,345,cs),
+(224,714,l),
+(58,714,l),
+(58,334,ls),
+(58,111,o),
+(193,-15,o),
+(390,-15,cs)
+);
+}
+);
+width = 800;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160E;
+unicode = 5646;
+},
+{
+color = 9;
+glyphname = "yoCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(406,-15,o),
+(494,66,o),
+(494,207,cs),
+(494,339,o),
+(413,418,o),
+(303,418,cs),
+(291,418,o),
+(276,416,o),
+(264,413,c),
+(264,283,l),
+(270,284,o),
+(277,284,o),
+(286,284,cs),
+(327,284,o),
+(350,256,o),
+(350,200,cs),
+(350,147,o),
+(328,119,o),
+(292,119,cs),
+(248,119,o),
+(217,159,o),
+(217,314,cs),
+(217,506,o),
+(287,579,o),
+(402,579,cs),
+(513,579,o),
+(576,512,o),
+(576,369,cs),
+(576,0,l),
+(742,0,l),
+(742,380,ls),
+(742,603,o),
+(607,729,o),
+(409,729,cs),
+(187,729,o),
+(58,575,o),
+(58,318,cs),
+(58,92,o),
+(152,-15,o),
+(287,-15,cs)
+);
+}
+);
+width = 800;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160F;
+unicode = 5647;
+},
+{
+color = 9;
+glyphname = "yeCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(562,-15,o),
+(698,125,o),
+(698,350,cs),
+(698,591,o),
+(560,714,o),
+(309,714,cs),
+(64,714,l),
+(64,565,l),
+(314,565,ls),
+(461,565,o),
+(533,499,o),
+(533,344,cs),
+(533,198,o),
+(475,125,o),
+(338,125,cs),
+(235,125,o),
+(194,167,o),
+(194,231,cs),
+(194,281,o),
+(216,306,o),
+(249,306,cs),
+(284,306,o),
+(305,279,o),
+(305,229,cs),
+(305,212,o),
+(304,201,o),
+(304,191,c),
+(435,191,l),
+(439,208,o),
+(440,223,o),
+(440,242,cs),
+(440,353,o),
+(370,437,o),
+(250,437,cs),
+(127,437,o),
+(50,350,o),
+(50,229,cs),
+(50,87,o),
+(155,-15,o),
+(339,-15,cs)
+);
+}
+);
+width = 750;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1610;
+unicode = 5648;
+},
+{
+color = 9;
+glyphname = "yeeCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(562,-15,o),
+(698,125,o),
+(698,350,cs),
+(698,591,o),
+(560,714,o),
+(309,714,cs),
+(64,714,l),
+(64,565,l),
+(314,565,ls),
+(461,565,o),
+(533,499,o),
+(533,345,cs),
+(533,198,o),
+(477,125,o),
+(337,125,cs),
+(235,125,o),
+(194,166,o),
+(194,232,cs),
+(194,280,o),
+(216,306,o),
+(247,306,cs),
+(281,306,o),
+(302,279,o),
+(302,232,cs),
+(302,196,l),
+(391,196,l),
+(391,500,l),
+(302,500,l),
+(302,331,l),
+(316,331,l),
+(314,397,o),
+(275,437,o),
+(209,437,cs),
+(116,437,o),
+(50,353,o),
+(50,230,cs),
+(50,87,o),
+(153,-15,o),
+(338,-15,cs)
+);
+}
+);
+width = 750;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1611;
+unicode = 5649;
+},
+{
+color = 9;
+glyphname = "yiCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(562,-15,o),
+(698,125,o),
+(698,350,cs),
+(698,591,o),
+(560,714,o),
+(309,714,cs),
+(64,714,l),
+(64,565,l),
+(314,565,ls),
+(461,565,o),
+(533,499,o),
+(533,344,cs),
+(533,198,o),
+(475,125,o),
+(345,125,cs),
+(236,125,o),
+(194,167,o),
+(194,231,cs),
+(194,294,o),
+(226,315,o),
+(297,308,c),
+(222,348,l),
+(227,300,o),
+(267,261,o),
+(321,261,cs),
+(378,261,o),
+(418,306,o),
+(418,358,cs),
+(418,412,o),
+(376,453,o),
+(320,453,cs),
+(289,453,o),
+(261,440,o),
+(244,419,c),
+(118,412,o),
+(50,333,o),
+(50,220,cs),
+(50,86,o),
+(155,-15,o),
+(339,-15,cs)
+);
+}
+);
+width = 750;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1612;
+unicode = 5650;
+},
+{
+color = 9;
+glyphname = "yaCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(687,0,l),
+(687,149,l),
+(436,149,ls),
+(290,149,o),
+(217,215,o),
+(217,370,cs),
+(217,516,o),
+(275,589,o),
+(414,589,cs),
+(516,589,o),
+(557,547,o),
+(557,483,cs),
+(557,433,o),
+(535,408,o),
+(502,408,cs),
+(467,408,o),
+(445,435,o),
+(445,485,cs),
+(445,502,o),
+(446,513,o),
+(447,523,c),
+(316,523,l),
+(312,506,o),
+(311,491,o),
+(311,472,cs),
+(311,361,o),
+(381,277,o),
+(501,277,cs),
+(624,277,o),
+(701,364,o),
+(701,485,cs),
+(701,627,o),
+(596,729,o),
+(412,729,cs),
+(189,729,o),
+(52,589,o),
+(52,364,cs),
+(52,123,o),
+(191,0,o),
+(442,0,cs)
+);
+}
+);
+width = 751;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|yeCarrier-canadian";
+note = uni1613;
+unicode = 5651;
+},
+{
+color = 9;
+glyphname = "juCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(606,-15,o),
+(714,85,o),
+(714,231,cs),
+(714,350,o),
+(637,437,o),
+(514,437,cs),
+(394,437,o),
+(323,353,o),
+(323,242,cs),
+(323,223,o),
+(325,208,o),
+(329,191,c),
+(460,191,l),
+(459,201,o),
+(458,213,o),
+(458,229,cs),
+(458,278,o),
+(480,306,o),
+(515,306,cs),
+(548,306,o),
+(569,280,o),
+(569,233,cs),
+(569,165,o),
+(526,125,o),
+(424,125,cs),
+(287,125,o),
+(228,192,o),
+(228,317,cs),
+(228,498,o),
+(344,565,o),
+(538,565,cs),
+(700,565,l),
+(700,714,l),
+(54,714,l),
+(54,572,l),
+(322,572,l),
+(437,629,l),
+(188,629,o),
+(63,504,o),
+(63,309,cs),
+(63,118,o),
+(198,-15,o),
+(418,-15,cs)
+);
+}
+);
+width = 764;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni1614;
+unicode = 5652;
+},
+{
+color = 9;
+glyphname = "juSayisi-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (384,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(565,-15,o),
+(700,118,o),
+(700,309,cs),
+(700,504,o),
+(576,629,o),
+(326,629,c),
+(442,572,l),
+(709,572,l),
+(709,714,l),
+(64,714,l),
+(64,565,l),
+(225,565,ls),
+(420,565,o),
+(536,498,o),
+(536,317,cs),
+(536,192,o),
+(476,125,o),
+(339,125,cs),
+(237,125,o),
+(194,165,o),
+(194,233,cs),
+(194,280,o),
+(216,306,o),
+(249,306,cs),
+(283,306,o),
+(305,278,o),
+(305,229,cs),
+(305,213,o),
+(304,201,o),
+(304,191,c),
+(435,191,l),
+(439,208,o),
+(440,223,o),
+(440,242,cs),
+(440,353,o),
+(369,437,o),
+(249,437,cs),
+(127,437,o),
+(50,350,o),
+(50,231,cs),
+(50,85,o),
+(157,-15,o),
+(345,-15,cs)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1615;
+unicode = 5653;
+},
+{
+color = 9;
+glyphname = "joCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(709,0,l),
+(709,142,l),
+(442,142,l),
+(326,85,l),
+(576,85,o),
+(700,210,o),
+(700,405,cs),
+(700,596,o),
+(565,729,o),
+(345,729,cs),
+(157,729,o),
+(50,629,o),
+(50,483,cs),
+(50,364,o),
+(127,277,o),
+(249,277,cs),
+(369,277,o),
+(440,361,o),
+(440,472,cs),
+(440,491,o),
+(439,506,o),
+(435,523,c),
+(304,523,l),
+(304,513,o),
+(305,501,o),
+(305,485,cs),
+(305,436,o),
+(283,408,o),
+(249,408,cs),
+(216,408,o),
+(194,434,o),
+(194,481,cs),
+(194,549,o),
+(237,589,o),
+(339,589,cs),
+(476,589,o),
+(536,522,o),
+(536,397,cs),
+(536,216,o),
+(420,149,o),
+(225,149,cs),
+(64,149,l),
+(64,0,l)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1616;
+unicode = 5654;
+},
+{
+color = 9;
+glyphname = "jeCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(654,-15,o),
+(749,92,o),
+(749,318,cs),
+(749,585,o),
+(620,729,o),
+(445,729,cs),
+(311,729,o),
+(217,649,o),
+(202,484,c),
+(229,489,l),
+(229,714,l),
+(65,714,l),
+(65,0,l),
+(231,0,l),
+(231,269,ls),
+(231,492,o),
+(299,579,o),
+(418,579,cs),
+(522,579,o),
+(590,503,o),
+(590,315,cs),
+(590,159,o),
+(559,119,o),
+(516,119,cs),
+(480,119,o),
+(457,147,o),
+(457,200,cs),
+(457,256,o),
+(480,284,o),
+(521,284,cs),
+(529,284,o),
+(537,284,o),
+(543,283,c),
+(543,413,l),
+(531,416,o),
+(516,418,o),
+(504,418,cs),
+(393,418,o),
+(312,339,o),
+(312,207,cs),
+(312,66,o),
+(401,-15,o),
+(520,-15,cs)
+);
+}
+);
+width = 807;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "te-canadian";
+note = uni1617;
+unicode = 5655;
+},
+{
+color = 9;
+glyphname = "jeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(654,-15,o),
+(749,92,o),
+(749,318,cs),
+(749,585,o),
+(620,729,o),
+(445,729,cs),
+(327,729,o),
+(239,669,o),
+(210,544,c),
+(229,522,l),
+(229,714,l),
+(65,714,l),
+(65,0,l),
+(231,0,l),
+(231,269,ls),
+(231,492,o),
+(299,579,o),
+(418,579,cs),
+(522,579,o),
+(590,503,o),
+(590,315,cs),
+(590,177,o),
+(557,119,o),
+(487,119,cs),
+(430,119,o),
+(401,157,o),
+(401,218,cs),
+(401,260,o),
+(413,290,o),
+(437,308,c),
+(437,232,l),
+(521,232,l),
+(521,478,l),
+(437,478,l),
+(437,398,l),
+(364,374,o),
+(312,305,o),
+(312,200,cs),
+(312,65,o),
+(395,-15,o),
+(514,-15,cs)
+);
+}
+);
+width = 807;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1618;
+unicode = 5656;
+},
+{
+color = 9;
+glyphname = "jiCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(654,-15,o),
+(749,92,o),
+(749,318,cs),
+(749,585,o),
+(620,729,o),
+(445,729,cs),
+(327,729,o),
+(239,669,o),
+(210,544,c),
+(229,522,l),
+(229,714,l),
+(65,714,l),
+(65,0,l),
+(231,0,l),
+(231,269,ls),
+(231,492,o),
+(299,579,o),
+(418,579,cs),
+(522,579,o),
+(590,503,o),
+(590,315,cs),
+(590,177,o),
+(557,119,o),
+(487,119,cs),
+(430,119,o),
+(401,157,o),
+(401,218,cs),
+(401,240,o),
+(405,255,o),
+(413,267,c),
+(422,262,o),
+(433,259,o),
+(444,259,cs),
+(500,259,o),
+(538,304,o),
+(538,356,cs),
+(538,410,o),
+(498,451,o),
+(444,451,cs),
+(377,451,o),
+(339,389,o),
+(353,332,c),
+(328,300,o),
+(312,256,o),
+(312,200,cs),
+(312,65,o),
+(395,-15,o),
+(514,-15,cs)
+);
+}
+);
+width = 807;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1619;
+unicode = 5657;
+},
+{
+color = 9;
+glyphname = "jiSayisi-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(620,-15,o),
+(749,129,o),
+(749,396,cs),
+(749,622,o),
+(654,729,o),
+(520,729,cs),
+(401,729,o),
+(312,648,o),
+(312,507,cs),
+(312,375,o),
+(393,296,o),
+(504,296,cs),
+(516,296,o),
+(531,298,o),
+(543,301,c),
+(543,431,l),
+(537,430,o),
+(529,430,o),
+(521,430,cs),
+(480,430,o),
+(457,458,o),
+(457,514,cs),
+(457,567,o),
+(479,595,o),
+(513,595,cs),
+(558,595,o),
+(590,555,o),
+(590,399,cs),
+(590,211,o),
+(522,135,o),
+(418,135,cs),
+(299,135,o),
+(231,222,o),
+(231,445,cs),
+(231,714,l),
+(65,714,l),
+(65,0,l),
+(229,0,l),
+(229,225,l),
+(202,230,l),
+(217,65,o),
+(311,-15,o),
+(445,-15,cs)
+);
+}
+);
+width = 807;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161A;
+unicode = 5658;
+},
+{
+color = 9;
+glyphname = "jaCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (397,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(496,-15,o),
+(590,65,o),
+(605,230,c),
+(578,225,l),
+(578,0,l),
+(742,0,l),
+(742,714,l),
+(576,714,l),
+(576,445,ls),
+(576,222,o),
+(508,135,o),
+(389,135,cs),
+(284,135,o),
+(217,211,o),
+(217,399,cs),
+(217,555,o),
+(248,595,o),
+(293,595,cs),
+(328,595,o),
+(350,567,o),
+(350,514,cs),
+(350,458,o),
+(327,430,o),
+(285,430,cs),
+(277,430,o),
+(270,430,o),
+(264,431,c),
+(264,301,l),
+(276,298,o),
+(291,296,o),
+(303,296,cs),
+(413,296,o),
+(494,375,o),
+(494,507,cs),
+(494,648,o),
+(406,729,o),
+(287,729,cs),
+(152,729,o),
+(58,622,o),
+(58,396,cs),
+(58,129,o),
+(187,-15,o),
+(362,-15,cs)
+);
+}
+);
+width = 807;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni161B;
+unicode = 5659;
+},
+{
+color = 9;
+glyphname = "jjuCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(598,-15,o),
+(705,87,o),
+(705,229,cs),
+(705,350,o),
+(628,437,o),
+(506,437,cs),
+(383,437,o),
+(312,353,o),
+(312,242,cs),
+(312,224,o),
+(314,208,o),
+(318,191,c),
+(449,191,l),
+(448,202,o),
+(447,215,o),
+(447,229,cs),
+(447,278,o),
+(469,306,o),
+(503,306,cs),
+(536,306,o),
+(558,281,o),
+(558,232,cs),
+(558,166,o),
+(509,124,o),
+(414,124,cs),
+(275,124,o),
+(221,195,o),
+(221,320,cs),
+(221,476,o),
+(316,565,o),
+(523,565,cs),
+(692,565,l),
+(692,714,l),
+(507,714,ls),
+(383,714,o),
+(283,683,o),
+(211,630,c),
+(113,729,l),
+(4,621,l),
+(106,518,l),
+(74,462,o),
+(57,396,o),
+(57,325,cs),
+(57,123,o),
+(185,-15,o),
+(412,-15,cs)
+);
+}
+);
+width = 755;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni161C;
+unicode = 5660;
+},
+{
+color = 9;
+glyphname = "jjoCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(751,93,l),
+(649,196,l),
+(681,252,o),
+(698,318,o),
+(698,389,cs),
+(698,591,o),
+(570,729,o),
+(349,729,cs),
+(163,729,o),
+(50,627,o),
+(50,484,cs),
+(50,364,o),
+(126,277,o),
+(250,277,cs),
+(372,277,o),
+(443,361,o),
+(443,472,cs),
+(443,490,o),
+(441,506,o),
+(438,523,c),
+(306,523,l),
+(307,512,o),
+(308,499,o),
+(308,485,cs),
+(308,436,o),
+(287,408,o),
+(252,408,cs),
+(219,408,o),
+(197,433,o),
+(197,482,cs),
+(197,548,o),
+(241,590,o),
+(345,590,cs),
+(480,590,o),
+(534,519,o),
+(534,394,cs),
+(534,238,o),
+(439,149,o),
+(232,149,cs),
+(64,149,l),
+(64,0,l),
+(248,0,ls),
+(372,0,o),
+(472,31,o),
+(544,84,c),
+(642,-15,l)
+);
+}
+);
+width = 755;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|jjuCarrier-canadian";
+note = uni161D;
+unicode = 5661;
+},
+{
+color = 9;
+glyphname = "jjeCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(668,-15,o),
+(762,92,o),
+(762,318,cs),
+(762,575,o),
+(641,729,o),
+(428,729,cs),
+(341,729,o),
+(263,700,o),
+(203,646,c),
+(117,729,l),
+(12,618,l),
+(115,518,l),
+(91,462,o),
+(78,395,o),
+(78,317,cs),
+(78,0,l),
+(244,0,l),
+(244,311,ls),
+(244,493,o),
+(307,579,o),
+(426,579,cs),
+(533,579,o),
+(603,506,o),
+(603,314,cs),
+(603,159,o),
+(572,119,o),
+(528,119,cs),
+(492,119,o),
+(470,147,o),
+(470,200,cs),
+(470,256,o),
+(493,284,o),
+(534,284,cs),
+(543,284,o),
+(550,284,o),
+(556,283,c),
+(556,413,l),
+(544,416,o),
+(529,418,o),
+(517,418,cs),
+(407,418,o),
+(326,339,o),
+(326,207,cs),
+(326,66,o),
+(414,-15,o),
+(533,-15,cs)
+);
+}
+);
+width = 820;
+}
+);
+metricRight = "jeCarrier-canadian";
+note = uni161E;
+unicode = 5662;
+},
+{
+color = 9;
+glyphname = "jjeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(667,-15,o),
+(762,92,o),
+(762,318,cs),
+(762,575,o),
+(641,729,o),
+(428,729,cs),
+(341,729,o),
+(263,700,o),
+(203,646,c),
+(117,729,l),
+(12,618,l),
+(115,518,l),
+(91,462,o),
+(78,395,o),
+(78,317,cs),
+(78,0,l),
+(244,0,l),
+(244,311,ls),
+(244,493,o),
+(307,579,o),
+(426,579,cs),
+(533,579,o),
+(603,506,o),
+(603,314,cs),
+(603,178,o),
+(570,119,o),
+(499,119,cs),
+(443,119,o),
+(414,157,o),
+(414,218,cs),
+(414,259,o),
+(427,288,o),
+(450,306,c),
+(450,232,l),
+(533,232,l),
+(533,476,l),
+(450,476,l),
+(450,398,l),
+(377,374,o),
+(326,304,o),
+(326,200,cs),
+(326,65,o),
+(409,-15,o),
+(527,-15,cs)
+);
+}
+);
+width = 820;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161F;
+unicode = 5663;
+},
+{
+color = 9;
+glyphname = "jjiCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(667,-15,o),
+(762,92,o),
+(762,318,cs),
+(762,575,o),
+(641,729,o),
+(428,729,cs),
+(341,729,o),
+(263,700,o),
+(203,646,c),
+(117,729,l),
+(12,618,l),
+(115,518,l),
+(91,462,o),
+(78,395,o),
+(78,317,cs),
+(78,0,l),
+(244,0,l),
+(244,311,ls),
+(244,493,o),
+(307,579,o),
+(426,579,cs),
+(533,579,o),
+(603,506,o),
+(603,314,cs),
+(603,178,o),
+(570,119,o),
+(499,119,cs),
+(443,119,o),
+(414,157,o),
+(414,218,cs),
+(414,242,o),
+(419,259,o),
+(429,271,c),
+(440,264,o),
+(454,259,o),
+(470,259,cs),
+(525,259,o),
+(563,304,o),
+(563,356,cs),
+(563,410,o),
+(524,451,o),
+(470,451,cs),
+(410,451,o),
+(371,399,o),
+(377,345,c),
+(345,312,o),
+(326,263,o),
+(326,200,cs),
+(326,65,o),
+(409,-15,o),
+(527,-15,cs)
+);
+}
+);
+width = 820;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1620;
+unicode = 5664;
+},
+{
+color = 9;
+glyphname = "jjaCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(479,-15,o),
+(557,14,o),
+(617,68,c),
+(703,-15,l),
+(809,96,l),
+(705,196,l),
+(729,252,o),
+(742,319,o),
+(742,397,cs),
+(742,714,l),
+(576,714,l),
+(576,403,ls),
+(576,221,o),
+(513,135,o),
+(394,135,cs),
+(287,135,o),
+(217,208,o),
+(217,400,cs),
+(217,555,o),
+(248,595,o),
+(292,595,cs),
+(328,595,o),
+(350,567,o),
+(350,514,cs),
+(350,458,o),
+(327,430,o),
+(286,430,cs),
+(277,430,o),
+(270,430,o),
+(264,431,c),
+(264,301,l),
+(276,298,o),
+(291,296,o),
+(303,296,cs),
+(413,296,o),
+(494,375,o),
+(494,507,cs),
+(494,648,o),
+(406,729,o),
+(287,729,cs),
+(152,729,o),
+(58,622,o),
+(58,396,cs),
+(58,139,o),
+(179,-15,o),
+(392,-15,cs)
+);
+}
+);
+width = 821;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "=|jjeCarrier-canadian";
+note = uni1621;
+unicode = 5665;
+},
+{
+color = 9;
+glyphname = "luCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(584,-15,o),
+(698,106,o),
+(698,318,cs),
+(698,714,l),
+(532,714,l),
+(532,318,ls),
+(532,195,o),
+(480,135,o),
+(386,135,cs),
+(282,135,o),
+(228,205,o),
+(228,335,cs),
+(228,478,o),
+(283,570,o),
+(403,581,c),
+(403,714,l),
+(54,714,l),
+(54,577,l),
+(245,577,l),
+(371,635,l),
+(167,617,o),
+(63,514,o),
+(63,308,cs),
+(63,112,o),
+(179,-15,o),
+(379,-15,cs)
+);
+}
+);
+width = 756;
+}
+);
+metricRight = "te-canadian";
+note = uni1622;
+unicode = 5666;
+},
+{
+color = 9;
+glyphname = "loCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(224,0,l),
+(224,396,ls),
+(224,519,o),
+(277,579,o),
+(376,579,cs),
+(475,579,o),
+(528,509,o),
+(528,379,cs),
+(528,236,o),
+(473,144,o),
+(353,133,c),
+(353,0,l),
+(702,0,l),
+(702,137,l),
+(511,137,l),
+(385,79,l),
+(589,97,o),
+(693,200,o),
+(693,406,cs),
+(693,602,o),
+(577,729,o),
+(377,729,cs),
+(172,729,o),
+(58,608,o),
+(58,396,cs),
+(58,0,l)
+);
+}
+);
+width = 756;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|luCarrier-canadian";
+note = uni1623;
+unicode = 5667;
+},
+{
+color = 9;
+glyphname = "leCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (365,363);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(332,0,ls),
+(562,0,o),
+(695,129,o),
+(695,370,cs),
+(695,603,o),
+(567,729,o),
+(413,729,cs),
+(298,729,o),
+(220,665,o),
+(198,579,c),
+(209,582,l),
+(209,714,l),
+(61,714,l),
+(61,387,l),
+(201,387,l),
+(210,516,o),
+(277,579,o),
+(367,579,cs),
+(457,579,o),
+(530,515,o),
+(530,367,cs),
+(530,217,o),
+(458,149,o),
+(326,149,cs),
+(61,149,l),
+(61,0,l)
+);
+}
+);
+width = 747;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1624;
+unicode = 5668;
+},
+{
+color = 9;
+glyphname = "leeCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+ref = "leCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (299,6);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 747;
+}
+);
+metricLeft = "leCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1625;
+unicode = 5669;
+},
+{
+color = 9;
+glyphname = "liCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "leCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (268,6);
+ref = dot_middle;
+}
+);
+width = 748;
+}
+);
+note = uni1626;
+unicode = 5670;
+},
+{
+color = 9;
+glyphname = "laCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(687,0,l),
+(687,149,l),
+(422,149,ls),
+(290,149,o),
+(217,217,o),
+(217,367,cs),
+(217,515,o),
+(291,579,o),
+(381,579,cs),
+(471,579,o),
+(538,516,o),
+(547,387,c),
+(687,387,l),
+(687,714,l),
+(538,714,l),
+(538,582,l),
+(549,579,l),
+(527,665,o),
+(450,729,o),
+(335,729,cs),
+(181,729,o),
+(52,603,o),
+(52,370,cs),
+(52,129,o),
+(185,0,o),
+(416,0,cs)
+);
+}
+);
+width = 748;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|leCarrier-canadian";
+note = uni1627;
+unicode = 5671;
+},
+{
+color = 1;
+glyphname = "dluCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(577,-15,o),
+(693,112,o),
+(693,308,cs),
+(693,470,o),
+(629,568,o),
+(508,610,c),
+(478,589,l),
+(677,589,l),
+(677,510,l),
+(797,510,l),
+(797,793,l),
+(677,793,l),
+(677,714,l),
+(353,714,l),
+(353,581,l),
+(473,570,o),
+(528,478,o),
+(528,335,cs),
+(528,205,o),
+(475,135,o),
+(376,135,cs),
+(277,135,o),
+(224,195,o),
+(224,318,cs),
+(224,714,l),
+(58,714,l),
+(58,318,ls),
+(58,106,o),
+(172,-15,o),
+(374,-15,cs)
+);
+}
+);
+width = 830;
+}
+);
+metricLeft = "te-canadian";
+note = uni1628;
+unicode = 5672;
+},
+{
+color = 9;
+glyphname = "dloCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(797,-79,l),
+(797,204,l),
+(677,204,l),
+(677,125,l),
+(478,125,l),
+(508,104,l),
+(629,146,o),
+(693,244,o),
+(693,406,cs),
+(693,602,o),
+(577,729,o),
+(380,729,cs),
+(166,729,o),
+(58,608,o),
+(58,396,cs),
+(58,0,l),
+(224,0,l),
+(224,396,ls),
+(224,519,o),
+(276,579,o),
+(376,579,cs),
+(475,579,o),
+(528,509,o),
+(528,379,cs),
+(528,236,o),
+(473,144,o),
+(353,133,c),
+(353,0,l),
+(677,0,l),
+(677,-79,l)
+);
+}
+);
+width = 830;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "dluCarrier-canadian";
+note = uni1629;
+unicode = 5673;
+},
+{
+color = 9;
+glyphname = "dleCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (380,363);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(347,0,ls),
+(577,0,o),
+(710,129,o),
+(710,370,cs),
+(710,603,o),
+(582,729,o),
+(426,729,cs),
+(312,729,o),
+(213,670,o),
+(174,529,c),
+(196,512,l),
+(196,718,l),
+(273,718,l),
+(273,834,l),
+(-2,834,l),
+(-2,718,l),
+(76,718,l),
+(76,387,l),
+(216,387,l),
+(225,516,o),
+(292,579,o),
+(382,579,cs),
+(472,579,o),
+(545,515,o),
+(545,367,cs),
+(545,217,o),
+(473,149,o),
+(341,149,cs),
+(76,149,l),
+(76,0,l)
+);
+}
+);
+width = 762;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni162A;
+unicode = 5674;
+},
+{
+color = 9;
+glyphname = "dleeCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (314,6);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 763;
+}
+);
+note = uni162B;
+unicode = 5675;
+},
+{
+color = 9;
+glyphname = "dliCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (283,6);
+ref = dot_middle;
+}
+);
+width = 763;
+}
+);
+note = uni162C;
+unicode = 5676;
+},
+{
+color = 9;
+glyphname = "dlaCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(687,0,l),
+(687,149,l),
+(422,149,ls),
+(290,149,o),
+(217,217,o),
+(217,367,cs),
+(217,515,o),
+(291,579,o),
+(380,579,cs),
+(471,579,o),
+(538,516,o),
+(547,387,c),
+(687,387,l),
+(687,718,l),
+(765,718,l),
+(765,834,l),
+(489,834,l),
+(489,718,l),
+(567,718,l),
+(567,512,l),
+(589,529,l),
+(550,670,o),
+(451,729,o),
+(337,729,cs),
+(180,729,o),
+(52,603,o),
+(52,370,cs),
+(52,128,o),
+(186,0,o),
+(416,0,cs)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni162D;
+unicode = 5677;
+},
+{
+color = 9;
+glyphname = "lhuCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(596,-15,o),
+(712,116,o),
+(712,312,cs),
+(712,512,o),
+(608,610,o),
+(458,630,c),
+(532,574,l),
+(721,574,l),
+(721,714,l),
+(444,714,l),
+(444,581,l),
+(496,547,o),
+(546,472,o),
+(546,340,cs),
+(546,204,o),
+(493,135,o),
+(387,135,cs),
+(282,135,o),
+(229,204,o),
+(229,340,cs),
+(229,472,o),
+(279,547,o),
+(331,581,c),
+(331,714,l),
+(54,714,l),
+(54,574,l),
+(243,574,l),
+(317,630,l),
+(167,610,o),
+(63,512,o),
+(63,312,cs),
+(63,116,o),
+(179,-15,o),
+(387,-15,cs)
+);
+}
+);
+width = 775;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162E;
+unicode = 5678;
+},
+{
+color = 9;
+glyphname = "lhoCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(331,0,l),
+(331,133,l),
+(279,167,o),
+(229,242,o),
+(229,374,cs),
+(229,510,o),
+(282,579,o),
+(387,579,cs),
+(493,579,o),
+(545,510,o),
+(545,374,cs),
+(545,242,o),
+(496,167,o),
+(444,133,c),
+(444,0,l),
+(721,0,l),
+(721,140,l),
+(532,140,l),
+(458,84,l),
+(608,104,o),
+(712,202,o),
+(712,402,cs),
+(712,598,o),
+(596,729,o),
+(387,729,cs),
+(178,729,o),
+(63,598,o),
+(63,402,cs),
+(63,202,o),
+(167,104,o),
+(317,84,c),
+(243,140,l),
+(54,140,l),
+(54,0,l)
+);
+}
+);
+width = 775;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162F;
+unicode = 5679;
+},
+{
+color = 9;
+glyphname = "lheCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (380,357);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(586,-15,o),
+(718,111,o),
+(718,357,cs),
+(718,603,o),
+(586,729,o),
+(423,729,cs),
+(308,729,o),
+(228,665,o),
+(206,583,c),
+(213,582,l),
+(213,714,l),
+(65,714,l),
+(65,422,l),
+(205,422,l),
+(225,511,o),
+(284,579,o),
+(381,579,cs),
+(474,579,o),
+(552,516,o),
+(552.008,357,cs),
+(552,198,o),
+(475,135,o),
+(381,135,cs),
+(284,135,o),
+(225,203,o),
+(205,292,c),
+(65,292,l),
+(65,0,l),
+(213,0,l),
+(213,132,l),
+(206,131,l),
+(228,49,o),
+(308,-15,o),
+(423,-15,cs)
+);
+}
+);
+width = 770;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1630;
+unicode = 5680;
+},
+{
+color = 9;
+glyphname = "lheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (314,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 771;
+}
+);
+note = uni1631;
+unicode = 5681;
+},
+{
+color = 9;
+glyphname = "lhiCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (282,0);
+ref = dot_middle;
+}
+);
+width = 771;
+}
+);
+note = uni1632;
+unicode = 5682;
+},
+{
+color = 9;
+glyphname = "lhaCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(463,-15,o),
+(542,49,o),
+(565,131,c),
+(557,132,l),
+(557,0,l),
+(706,0,l),
+(706,292,l),
+(566,292,l),
+(545,203,o),
+(487,135,o),
+(389,135,cs),
+(296,135,o),
+(219,198,o),
+(219,357,cs),
+(219,516,o),
+(295,579,o),
+(389,579,cs),
+(487,579,o),
+(545,511,o),
+(566,422,c),
+(706,422,l),
+(706,714,l),
+(557,714,l),
+(557,582,l),
+(565,583,l),
+(542,665,o),
+(463,729,o),
+(347,729,cs),
+(184,729,o),
+(52,603,o),
+(52,357,cs),
+(52,111,o),
+(184,-15,o),
+(347,-15,cs)
+);
+}
+);
+width = 771;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1633;
+unicode = 5683;
+},
+{
+color = 9;
+glyphname = "tlhuCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(596,-15,o),
+(712,116,o),
+(712,312,cs),
+(712,473,o),
+(641,568,o),
+(541,609,c),
+(506,589,l),
+(695,589,l),
+(695,510,l),
+(816,510,l),
+(816,793,l),
+(695,793,l),
+(695,714,l),
+(444,714,l),
+(444,581,l),
+(497,547,o),
+(546,472,o),
+(546,340,cs),
+(546,204,o),
+(493,135,o),
+(387,135,cs),
+(282,135,o),
+(229,204,o),
+(229,340,cs),
+(229,472,o),
+(278,547,o),
+(331,581,c),
+(331,714,l),
+(54,714,l),
+(54,574,l),
+(246,574,l),
+(207,598,l),
+(120,552,o),
+(63,461,o),
+(63,312,cs),
+(63,116,o),
+(179,-15,o),
+(387,-15,cs)
+);
+}
+);
+width = 844;
+}
+);
+metricLeft = "lhuCarrier-canadian";
+note = uni1634;
+unicode = 5684;
+},
+{
+color = 9;
+glyphname = "tlhoCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(149,-79,l),
+(149,0,l),
+(400,0,l),
+(400,133,l),
+(347,167,o),
+(298,242,o),
+(298,374,cs),
+(298,510,o),
+(351,579,o),
+(456,579,cs),
+(562,579,o),
+(615,510,o),
+(615,374,cs),
+(615,242,o),
+(565,167,o),
+(513,133,c),
+(513,0,l),
+(790,0,l),
+(790,140,l),
+(598,140,l),
+(637,116,l),
+(724,162,o),
+(781,253,o),
+(781,402,cs),
+(781,598,o),
+(665,729,o),
+(456,729,cs),
+(247,729,o),
+(132,598,o),
+(132,402,cs),
+(132,241,o),
+(202,146,o),
+(303,105,c),
+(338,125,l),
+(149,125,l),
+(149,204,l),
+(28,204,l),
+(28,-79,l)
+);
+}
+);
+width = 844;
+}
+);
+metricLeft = "=|tlhuCarrier-canadian";
+metricRight = "lhuCarrier-canadian";
+note = uni1635;
+unicode = 5685;
+},
+{
+color = 9;
+glyphname = "tlheCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (390,357);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(598,-15,o),
+(729,111,o),
+(729,357,cs),
+(729,603,o),
+(598,729,o),
+(435,729,cs),
+(317,729,o),
+(217,670,o),
+(176,533,c),
+(198,515,l),
+(198,718,l),
+(276,718,l),
+(276,834,l),
+(-2,834,l),
+(-2,718,l),
+(76,718,l),
+(76,422,l),
+(216,422,l),
+(236,511,o),
+(295,579,o),
+(392,579,cs),
+(485,579,o),
+(563,519,o),
+(563.002,357,cs),
+(563,198,o),
+(485,135,o),
+(392,135,cs),
+(295,135,o),
+(236,203,o),
+(216,292,c),
+(76,292,l),
+(76,0,l),
+(224,0,l),
+(224,184,l),
+(212,151,l),
+(226,60,o),
+(311,-15,o),
+(435,-15,cs)
+);
+}
+);
+width = 781;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1636;
+unicode = 5686;
+},
+{
+color = 9;
+glyphname = "tlheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (325,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 782;
+}
+);
+note = uni1637;
+unicode = 5687;
+},
+{
+color = 9;
+glyphname = "tlhiCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (293,0);
+ref = dot_middle;
+}
+);
+width = 782;
+}
+);
+note = uni1638;
+unicode = 5688;
+},
+{
+color = 9;
+glyphname = "tlhaCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(470,-15,o),
+(556,59,o),
+(569,152,c),
+(557,184,l),
+(557,0,l),
+(706,0,l),
+(706,292,l),
+(566,292,l),
+(545,203,o),
+(487,135,o),
+(389,135,cs),
+(296,135,o),
+(219,198,o),
+(219,357,cs),
+(219,519,o),
+(295,579,o),
+(389,579,cs),
+(487,579,o),
+(545,511,o),
+(566,422,c),
+(706,422,l),
+(706,718,l),
+(783,718,l),
+(783,834,l),
+(506,834,l),
+(506,718,l),
+(583,718,l),
+(583,514,l),
+(606,533,l),
+(565,671,o),
+(465,729,o),
+(346,729,cs),
+(184,729,o),
+(52,603,o),
+(52,357,cs),
+(52,111,o),
+(184,-15,o),
+(346,-15,cs)
+);
+}
+);
+width = 781;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni1639;
+unicode = 5689;
+},
+{
+color = 9;
+glyphname = "tluCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(382,-15,o),
+(445,27,o),
+(478,112,c),
+(426,112,l),
+(458,27,o),
+(522,-15,o),
+(609,-15,cs),
+(759,-15,o),
+(840,88,o),
+(840,273,cs),
+(840,456,o),
+(779,564,o),
+(661,611,c),
+(628,589,l),
+(824,589,l),
+(824,510,l),
+(944,510,l),
+(944,793,l),
+(824,793,l),
+(824,714,l),
+(508,714,l),
+(508,581,l),
+(620,576,o),
+(674,478,o),
+(674,288,cs),
+(674,172,o),
+(649,131,o),
+(598,131,cs),
+(556,131,o),
+(532,167,o),
+(532,235,cs),
+(532,321,l),
+(372,321,l),
+(372,235,ls),
+(372,167,o),
+(347,131,o),
+(306,131,cs),
+(254,131,o),
+(230,172,o),
+(230,288,cs),
+(230,478,o),
+(283,576,o),
+(395,581,c),
+(395,714,l),
+(55,714,l),
+(55,574,l),
+(255,574,l),
+(217,598,l),
+(116,547,o),
+(64,443,o),
+(64,273,cs),
+(64,88,o),
+(144,-15,o),
+(294,-15,cs)
+);
+}
+);
+width = 972;
+}
+);
+metricRight = "tlhuCarrier-canadian";
+note = uni163A;
+unicode = 5690;
+},
+{
+color = 1;
+glyphname = "tloCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(944,-79,l),
+(944,204,l),
+(824,204,l),
+(824,125,l),
+(628,125,l),
+(661,103,l),
+(779,150,o),
+(840,258,o),
+(840,441,cs),
+(840,626,o),
+(759,729,o),
+(609,729,cs),
+(522,729,o),
+(458,687,o),
+(426,602,c),
+(478,602,l),
+(445,687,o),
+(382,729,o),
+(294,729,cs),
+(144,729,o),
+(64,626,o),
+(64,441,cs),
+(64,271,o),
+(116,167,o),
+(217,116,c),
+(255,140,l),
+(55,140,l),
+(55,0,l),
+(395,0,l),
+(395,133,l),
+(283,138,o),
+(230,236,o),
+(230,426,cs),
+(230,542,o),
+(254,583,o),
+(306,583,cs),
+(347,583,o),
+(372,547,o),
+(372,479,cs),
+(372,393,l),
+(532,393,l),
+(532,479,ls),
+(532,547,o),
+(556,583,o),
+(598,583,cs),
+(649,583,o),
+(674,542,o),
+(674,426,cs),
+(674,236,o),
+(620,138,o),
+(508,133,c),
+(508,0,l),
+(824,0,l),
+(824,-79,l)
+);
+}
+);
+width = 972;
+}
+);
+metricLeft = "tluCarrier-canadian";
+metricRight = "tlhuCarrier-canadian";
+note = uni163B;
+unicode = 5691;
+},
+{
+color = 9;
+glyphname = "tleCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (323,357);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(633,-15,o),
+(711,83,o),
+(711,198,cs),
+(711,283,o),
+(659,355,o),
+(580,378,c),
+(580,337,l),
+(661,355,o),
+(711,427,o),
+(711,516,cs),
+(711,631,o),
+(633,729,o),
+(458,729,cs),
+(322,729,o),
+(212,667,o),
+(177,540,c),
+(196,516,l),
+(196,718,l),
+(273,718,l),
+(273,834,l),
+(-2,834,l),
+(-2,718,l),
+(76,718,l),
+(76,422,l),
+(215,422,l),
+(227,519,o),
+(288,581,o),
+(417,581,cs),
+(505,581,o),
+(546,549,o),
+(546,496,cs),
+(546,449,o),
+(518,425,o),
+(456,425,cs),
+(414,425,l),
+(414,290,l),
+(456,290,ls),
+(519,290,o),
+(546,265,o),
+(546,218,cs),
+(546,165,o),
+(504,133,o),
+(417,133,cs),
+(288,133,o),
+(227,195,o),
+(215,292,c),
+(76,292,l),
+(76,0,l),
+(224,0,l),
+(224,167,l),
+(201,140,l),
+(241,30,o),
+(332,-15,o),
+(458,-15,cs)
+);
+}
+);
+width = 772;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni163C;
+unicode = 5692;
+},
+{
+color = 9;
+glyphname = "tleeCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (257,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 772;
+}
+);
+note = uni163D;
+unicode = 5693;
+},
+{
+color = 9;
+glyphname = "tliCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (243,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 772;
+}
+);
+note = uni163E;
+unicode = 5694;
+},
+{
+color = 9;
+glyphname = "tlaCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,-15,o),
+(531,30,o),
+(571,140,c),
+(547,167,l),
+(547,0,l),
+(696,0,l),
+(696,292,l),
+(557,292,l),
+(545,195,o),
+(484,133,o),
+(355,133,cs),
+(268,133,o),
+(226,165,o),
+(226,218,cs),
+(226,265,o),
+(253,290,o),
+(316,290,cs),
+(361,290,l),
+(361,425,l),
+(316,425,ls),
+(254,425,o),
+(226,449,o),
+(226,496,cs),
+(226,549,o),
+(267,581,o),
+(355,581,cs),
+(484,581,o),
+(545,519,o),
+(557,422,c),
+(696,422,l),
+(696,718,l),
+(774,718,l),
+(774,834,l),
+(498,834,l),
+(498,718,l),
+(576,718,l),
+(576,516,l),
+(595,540,l),
+(560,667,o),
+(450,729,o),
+(314,729,cs),
+(139,729,o),
+(61,631,o),
+(61,517,cs),
+(61,427,o),
+(111,356,o),
+(192,337,c),
+(192,378,l),
+(113,355,o),
+(61,283,o),
+(61,198,cs),
+(61,83,o),
+(139,-15,o),
+(314,-15,cs)
+);
+}
+);
+width = 772;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni163F;
+unicode = 5695;
+},
+{
+color = 9;
+glyphname = "zuCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(596,-15,o),
+(712,89,o),
+(712,246,cs),
+(712,356,o),
+(640,475,o),
+(640,526,cs),
+(640,555,o),
+(655,572,o),
+(692,572,cs),
+(722,572,l),
+(722,714,l),
+(656,714,ls),
+(531,714,o),
+(478,646,o),
+(478,552,cs),
+(478,463,o),
+(546,364,o),
+(546,273,cs),
+(546,186,o),
+(493,135,o),
+(388,135,cs),
+(282,135,o),
+(229,186,o),
+(229,273,cs),
+(229,364,o),
+(297,463,o),
+(297,552,cs),
+(297,646,o),
+(244,714,o),
+(119,714,cs),
+(53,714,l),
+(53,572,l),
+(83,572,ls),
+(120,572,o),
+(136,555,o),
+(136,526,cs),
+(136,475,o),
+(63,356,o),
+(63,246,cs),
+(63,89,o),
+(179,-15,o),
+(388,-15,cs)
+);
+}
+);
+width = 775;
+}
+);
+metricRight = "=|";
+note = uni1640;
+unicode = 5696;
+},
+{
+color = 9;
+glyphname = "zoCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(119,0,ls),
+(244,0,o),
+(298,68,o),
+(298,162,cs),
+(298,251,o),
+(230,350,o),
+(230,441,cs),
+(230,528,o),
+(282,579,o),
+(388,579,cs),
+(494,579,o),
+(546,528,o),
+(546,441,cs),
+(546,350,o),
+(478,251,o),
+(478,162,cs),
+(478,68,o),
+(532,0,o),
+(656,0,cs),
+(722,0,l),
+(722,142,l),
+(692,142,ls),
+(655,142,o),
+(640,159,o),
+(640,188,cs),
+(640,239,o),
+(712,358,o),
+(712,468,cs),
+(712,625,o),
+(597,729,o),
+(388,729,cs),
+(179,729,o),
+(64,625,o),
+(64,468,cs),
+(64,358,o),
+(136,239,o),
+(136,188,cs),
+(136,159,o),
+(120,142,o),
+(84,142,cs),
+(53,142,l),
+(53,0,l)
+);
+}
+);
+width = 775;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1641;
+unicode = 5697;
+},
+{
+color = 9;
+glyphname = "zeCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (370,357);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(594,-15,o),
+(692,115,o),
+(692,357,cs),
+(692,598,o),
+(595,729,o),
+(445,729,cs),
+(337,729,o),
+(263,638,o),
+(222,638,cs),
+(197,638,o),
+(187,653,o),
+(187.002,689.994,cs),
+(187.002,714,l),
+(38,714,l),
+(38,653,ls),
+(38,546,o),
+(95,491,o),
+(181,491,cs),
+(274,491,o),
+(338,579,o),
+(407,579,cs),
+(479,579,o),
+(525,519,o),
+(525,357,cs),
+(525,195,o),
+(479,135,o),
+(407,135,cs),
+(338,135,o),
+(274,223,o),
+(181,223,cs),
+(95,223,o),
+(38,168,o),
+(38,61,cs),
+(38,0,l),
+(187.002,0,l),
+(187.002,24.006,ls),
+(187,61,o),
+(197,76,o),
+(222,76,cs),
+(263,76,o),
+(337,-15,o),
+(445,-15,cs)
+);
+}
+);
+width = 744;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1642;
+unicode = 5698;
+},
+{
+color = 9;
+glyphname = "zeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (305,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 744;
+}
+);
+note = uni1643;
+unicode = 5699;
+},
+{
+color = 9;
+glyphname = "ziCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (273,0);
+ref = dot_middle;
+}
+);
+width = 744;
+}
+);
+note = uni1644;
+unicode = 5700;
+},
+{
+color = 9;
+glyphname = "zaCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(407,-15,o),
+(481,76,o),
+(522,76,cs),
+(547,76,o),
+(557,61,o),
+(557,24,cs),
+(557,0,l),
+(706,0,l),
+(706,61,ls),
+(706,168,o),
+(649,223,o),
+(563,223,cs),
+(470,223,o),
+(406,135,o),
+(337,135,cs),
+(265,135,o),
+(219,195,o),
+(219,357,cs),
+(219,519,o),
+(265,579,o),
+(337,579,cs),
+(406,579,o),
+(470,491,o),
+(563,491,cs),
+(649,491,o),
+(706,546,o),
+(706,653,cs),
+(706,714,l),
+(557,714,l),
+(557,690,ls),
+(557,653,o),
+(547,638,o),
+(522,638,cs),
+(481,638,o),
+(407,729,o),
+(299,729,cs),
+(150,729,o),
+(52,599,o),
+(52,357,cs),
+(52,116,o),
+(149,-15,o),
+(299,-15,cs)
+);
+}
+);
+width = 744;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|zeCarrier-canadian";
+note = uni1645;
+unicode = 5701;
+},
+{
+color = 6;
+glyphname = "zCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(373,189,l),
+(373,288,l),
+(176,288,l),
+(176,231,l),
+(369,489,l),
+(369,546,l),
+(55,546,l),
+(55,447,l),
+(249,447,l),
+(249,504,l),
+(55,246,l),
+(55,189,l)
+);
+}
+);
+width = 428;
+}
+);
+metricRight = "=|";
+note = uni1646;
+unicode = 5702;
+},
+{
+color = 6;
+glyphname = "initialzCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(158,189,l),
+(158,99,l),
+(267,99,l),
+(267,189,l),
+(373,189,l),
+(373,288,l),
+(143,288,l),
+(174,228,l),
+(369,489,l),
+(369,546,l),
+(267,546,l),
+(267,636,l),
+(158,636,l),
+(158,546,l),
+(55,546,l),
+(55,447,l),
+(281,447,l),
+(251,507,l),
+(55,246,l),
+(55,189,l)
+);
+}
+);
+width = 428;
+}
+);
+metricLeft = "zCarrier-canadian";
+metricRight = "zCarrier-canadian";
+note = uni1647;
+unicode = 5703;
+},
+{
+color = 9;
+glyphname = "dzuCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(596,-15,o),
+(712,89,o),
+(712,246,cs),
+(712,356,o),
+(640,475,o),
+(640,526,cs),
+(640,555,o),
+(655,572,o),
+(692,572,cs),
+(722,572,l),
+(722,714,l),
+(659,714,ls),
+(537,714,o),
+(481,646,o),
+(481,552,cs),
+(481,463,o),
+(546,367,o),
+(546,273,cs),
+(546,186,o),
+(494,135,o),
+(388,135,cs),
+(282,135,o),
+(229,186,o),
+(229,273,cs),
+(229,367,o),
+(294,463,o),
+(294,552,cs),
+(294,646,o),
+(238,714,o),
+(117,714,cs),
+(53,714,l),
+(53,572,l),
+(83,572,ls),
+(120,572,o),
+(136,555,o),
+(136,526,cs),
+(136,475,o),
+(63,356,o),
+(63,246,cs),
+(63,89,o),
+(179,-15,o),
+(388,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(425,482,l),
+(425,642,l),
+(474,642,l),
+(474,714,l),
+(302,714,l),
+(302,642,l),
+(351,642,l),
+(351,482,l)
+);
+}
+);
+width = 775;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1648;
+unicode = 5704;
+},
+{
+color = 9;
+glyphname = "dzoCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(117,0,ls),
+(239,0,o),
+(294,68,o),
+(294,162,cs),
+(294,251,o),
+(230,347,o),
+(230,441,cs),
+(230,528,o),
+(282,579,o),
+(388,579,cs),
+(494,579,o),
+(546,528,o),
+(546,441,cs),
+(546,347,o),
+(482,251,o),
+(482,162,cs),
+(482,68,o),
+(537,0,o),
+(659,0,cs),
+(722,0,l),
+(722,142,l),
+(692,142,ls),
+(655,142,o),
+(640,159,o),
+(640,188,cs),
+(640,239,o),
+(712,358,o),
+(712,468,cs),
+(712,625,o),
+(597,729,o),
+(388,729,cs),
+(179,729,o),
+(64,625,o),
+(64,468,cs),
+(64,358,o),
+(136,239,o),
+(136,188,cs),
+(136,159,o),
+(120,142,o),
+(84,142,cs),
+(53,142,l),
+(53,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(474,0,l),
+(474,72,l),
+(425,72,l),
+(425,232,l),
+(350,232,l),
+(350,72,l),
+(301,72,l),
+(301,0,l)
+);
+}
+);
+width = 775;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1649;
+unicode = 5705;
+},
+{
+color = 9;
+glyphname = "dzeCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (394,357);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(621,-15,o),
+(718,115,o),
+(718,357,cs),
+(718,598,o),
+(621,729,o),
+(471,729,cs),
+(363,729,o),
+(290,638,o),
+(248,638,cs),
+(224,638,o),
+(214,653,o),
+(214,690,cs),
+(214,714,l),
+(65,714,l),
+(65,653,ls),
+(65,546,o),
+(121,493,o),
+(208,493,cs),
+(301,493,o),
+(364,579,o),
+(433,579,cs),
+(506,579,o),
+(552,519,o),
+(552.008,357,cs),
+(552,195,o),
+(506,135,o),
+(433,135,cs),
+(364,135,o),
+(301,221,o),
+(208,221,cs),
+(121,221,o),
+(65,168,o),
+(65,61,cs),
+(65,0,l),
+(214,0,l),
+(214,24,ls),
+(214,59,o),
+(224,74,o),
+(248,74,cs),
+(290,74,o),
+(363,-15,o),
+(471,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(150,251,l),
+(150,315,l),
+(269,315,l),
+(269,399,l),
+(150,399,l),
+(150,463,l),
+(65,463,l),
+(65,251,l)
+);
+}
+);
+width = 770;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164A;
+unicode = 5706;
+},
+{
+color = 9;
+glyphname = "dzeeCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+ref = "dzeCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (328,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 770;
+}
+);
+metricLeft = "dzeCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164B;
+unicode = 5707;
+},
+{
+color = 9;
+glyphname = "dziCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "dzeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (297,0);
+ref = dot_middle;
+}
+);
+width = 771;
+}
+);
+note = uni164C;
+unicode = 5708;
+},
+{
+color = 9;
+glyphname = "dzaCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(407,-15,o),
+(481,74,o),
+(522,74,cs),
+(547,74,o),
+(557,59,o),
+(557,24,cs),
+(557,0,l),
+(706,0,l),
+(706,61,ls),
+(706,168,o),
+(649,221,o),
+(563,221,cs),
+(470,221,o),
+(406,135,o),
+(337,135,cs),
+(265,135,o),
+(219,195,o),
+(219,357,cs),
+(219,519,o),
+(265,579,o),
+(337,579,cs),
+(406,579,o),
+(470,493,o),
+(563,493,cs),
+(649,493,o),
+(706,546,o),
+(706,653,cs),
+(706,714,l),
+(557,714,l),
+(557,690,ls),
+(557,653,o),
+(547,638,o),
+(522,638,cs),
+(481,638,o),
+(407,729,o),
+(299,729,cs),
+(150,729,o),
+(52,599,o),
+(52,357,cs),
+(52,116,o),
+(149,-15,o),
+(299,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(706,251,l),
+(706,463,l),
+(621,463,l),
+(621,399,l),
+(502,399,l),
+(502,315,l),
+(621,315,l),
+(621,251,l)
+);
+}
+);
+width = 771;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dzeCarrier-canadian";
+note = uni164D;
+unicode = 5709;
+},
+{
+color = 9;
+glyphname = "suCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(381,-15,o),
+(454,38,o),
+(483,139,c),
+(419,139,l),
+(449,38,o),
+(522,-15,o),
+(618,-15,cs),
+(765,-15,o),
+(840,80,o),
+(840,199,cs),
+(840,323,o),
+(771,455,o),
+(771,526,cs),
+(771,555,o),
+(786,572,o),
+(822,572,cs),
+(849,572,l),
+(849,714,l),
+(787,714,ls),
+(662,714,o),
+(611,646,o),
+(611,552,cs),
+(611,444,o),
+(676,307,o),
+(676,220,cs),
+(676,165,o),
+(652,131,o),
+(604,131,cs),
+(556,131,o),
+(529,166,o),
+(529,235,cs),
+(529,714,l),
+(374,714,l),
+(374,235,ls),
+(374,166,o),
+(347,131,o),
+(298,131,cs),
+(251,131,o),
+(227,165,o),
+(227,220,cs),
+(227,307,o),
+(292,444,o),
+(292,552,cs),
+(292,646,o),
+(240,714,o),
+(116,714,cs),
+(54,714,l),
+(54,572,l),
+(80,572,ls),
+(116,572,o),
+(131,555,o),
+(131,526,cs),
+(131,455,o),
+(63,323,o),
+(63,199,cs),
+(63,80,o),
+(138,-15,o),
+(284,-15,cs)
+);
+}
+);
+width = 903;
+}
+);
+metricRight = "=|";
+note = uni164E;
+unicode = 5710;
+},
+{
+color = 9;
+glyphname = "soCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(116,0,ls),
+(240,0,o),
+(292,68,o),
+(292,162,cs),
+(292,270,o),
+(227,407,o),
+(227,494,cs),
+(227,549,o),
+(250,583,o),
+(298,583,cs),
+(347,583,o),
+(374,548,o),
+(374,479,cs),
+(374,0,l),
+(529,0,l),
+(529,479,ls),
+(529,548,o),
+(556,583,o),
+(604,583,cs),
+(652,583,o),
+(675,549,o),
+(675,494,cs),
+(675,407,o),
+(611,270,o),
+(611,162,cs),
+(611,68,o),
+(662,0,o),
+(787,0,cs),
+(849,0,l),
+(849,142,l),
+(822,142,ls),
+(786,142,o),
+(771,159,o),
+(771,188,cs),
+(771,259,o),
+(840,391,o),
+(840,515,cs),
+(840,634,o),
+(765,729,o),
+(618,729,cs),
+(522,729,o),
+(449,676,o),
+(420,575,c),
+(484,575,l),
+(453,676,o),
+(380,729,o),
+(284,729,cs),
+(138,729,o),
+(63,634,o),
+(63,515,cs),
+(63,391,o),
+(131,259,o),
+(131,188,cs),
+(131,159,o),
+(116,142,o),
+(80,142,cs),
+(54,142,l),
+(54,0,l)
+);
+}
+);
+width = 903;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5711;
+},
+{
+color = 9;
+glyphname = "seCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(625,-15,o),
+(699,76,o),
+(699,191,cs),
+(699,285,o),
+(643,360,o),
+(557,379,c),
+(557,335,l),
+(645,351,o),
+(699,424,o),
+(699,523,cs),
+(699,638,o),
+(625,729,o),
+(499,729,cs),
+(390,729,o),
+(288,638,o),
+(246,638,cs),
+(222,638,o),
+(211,653,o),
+(211,690,cs),
+(211,714,l),
+(63,714,l),
+(63,657,ls),
+(63,550,o),
+(119,497,o),
+(206,497,cs),
+(297,497,o),
+(384,581,o),
+(455,581,cs),
+(505,581,o),
+(533,552,o),
+(533,503,cs),
+(533,452,o),
+(501,423,o),
+(435,423,cs),
+(63,423,l),
+(63,291,l),
+(435,291,ls),
+(501,291,o),
+(533,262,o),
+(533,211,cs),
+(533,162,o),
+(505,133,o),
+(455,133,cs),
+(384,133,o),
+(297,217,o),
+(206,217,cs),
+(119,217,o),
+(63,164,o),
+(63,57,cs),
+(63,0,l),
+(211,0,l),
+(211,24,ls),
+(211,61,o),
+(222,76,o),
+(246,76,cs),
+(288,76,o),
+(390,-15,o),
+(499,-15,cs)
+);
+}
+);
+width = 760;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni1650;
+unicode = 5712;
+},
+{
+color = 9;
+glyphname = "seeCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(625,-15,o),
+(699,76,o),
+(699,191,cs),
+(699,282,o),
+(648,354,o),
+(567,377,c),
+(567,337,l),
+(649,356,o),
+(699,428,o),
+(699,523,cs),
+(699,638,o),
+(625,729,o),
+(499,729,cs),
+(390,729,o),
+(288,638,o),
+(246,638,cs),
+(222,638,o),
+(211,653,o),
+(211,690,cs),
+(211,714,l),
+(63,714,l),
+(63,657,ls),
+(63,550,o),
+(119,497,o),
+(206,497,cs),
+(297,497,o),
+(384,581,o),
+(455,581,cs),
+(505,581,o),
+(533,552,o),
+(533,503,cs),
+(533,452,o),
+(501,422,o),
+(447,422,cs),
+(400,422,l),
+(428,367,l),
+(428,496,l),
+(337,496,l),
+(337,422,l),
+(63,422,l),
+(63,292,l),
+(337,292,l),
+(337,216,l),
+(428,216,l),
+(428,344,l),
+(400,292,l),
+(447,292,ls),
+(501,292,o),
+(533,262,o),
+(533,211,cs),
+(533,162,o),
+(505,133,o),
+(455,133,cs),
+(384,133,o),
+(297,217,o),
+(206,217,cs),
+(119,217,o),
+(63,164,o),
+(63,57,cs),
+(63,0,l),
+(211,0,l),
+(211,24,ls),
+(211,61,o),
+(222,76,o),
+(246,76,cs),
+(288,76,o),
+(390,-15,o),
+(499,-15,cs)
+);
+}
+);
+width = 760;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1651;
+unicode = 5713;
+},
+{
+color = 9;
+glyphname = "siCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(625,-15,o),
+(699,76,o),
+(699,191,cs),
+(699,282,o),
+(648,354,o),
+(568,377,c),
+(567,337,l),
+(649,356,o),
+(699,428,o),
+(699,523,cs),
+(699,638,o),
+(625,729,o),
+(499,729,cs),
+(390,729,o),
+(288,638,o),
+(246,638,cs),
+(222,638,o),
+(211,653,o),
+(211,690,cs),
+(211,714,l),
+(63,714,l),
+(63,657,ls),
+(63,550,o),
+(119,497,o),
+(206,497,cs),
+(297,497,o),
+(384,584,o),
+(458,584,cs),
+(509,584,o),
+(536,553,o),
+(536,502,cs),
+(536,445,o),
+(508,418,o),
+(458,418,cs),
+(393,418,l),
+(446,371,l),
+(441,426,o),
+(397,469,o),
+(340,469,cs),
+(302,469,o),
+(270,450,o),
+(250,422,c),
+(63,422,l),
+(63,292,l),
+(251,292,l),
+(270,264,o),
+(302,246,o),
+(340,246,cs),
+(397,246,o),
+(439,289,o),
+(445,343,c),
+(391,296,l),
+(458,296,ls),
+(508,296,o),
+(536,269,o),
+(536,212,cs),
+(536,161,o),
+(509,130,o),
+(458,130,cs),
+(386,130,o),
+(297,217,o),
+(206,217,cs),
+(119,217,o),
+(63,164,o),
+(63,57,cs),
+(63,0,l),
+(211,0,l),
+(211,24,ls),
+(211,61,o),
+(222,76,o),
+(246,76,cs),
+(288,76,o),
+(390,-15,o),
+(499,-15,cs)
+);
+}
+);
+width = 760;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1652;
+unicode = 5714;
+},
+{
+color = 9;
+glyphname = "saCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(369,-15,o),
+(471,76,o),
+(513,76,cs),
+(538,76,o),
+(548,61,o),
+(548,24,cs),
+(548,0,l),
+(697,0,l),
+(697,57,ls),
+(697,164,o),
+(640,217,o),
+(554,217,cs),
+(462,217,o),
+(375,133,o),
+(305,133,cs),
+(255,133,o),
+(226,162,o),
+(226,211,cs),
+(226,262,o),
+(259,291,o),
+(324,291,cs),
+(697,291,l),
+(697,423,l),
+(324,423,ls),
+(259,423,o),
+(226,452,o),
+(226,503,cs),
+(226,552,o),
+(255,581,o),
+(305,581,cs),
+(375,581,o),
+(462,497,o),
+(554,497,cs),
+(640,497,o),
+(697,550,o),
+(697,657,cs),
+(697,714,l),
+(548,714,l),
+(548,690,ls),
+(548,653,o),
+(538,638,o),
+(513,638,cs),
+(471,638,o),
+(369,729,o),
+(260,729,cs),
+(135,729,o),
+(61,638,o),
+(61,523,cs),
+(61,424,o),
+(114,351,o),
+(202,335,c),
+(202,379,l),
+(116,360,o),
+(61,285,o),
+(61,191,cs),
+(61,76,o),
+(135,-15,o),
+(260,-15,cs)
+);
+}
+);
+width = 760;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1653;
+unicode = 5715;
+},
+{
+color = 9;
+glyphname = "shuCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(374,-15,o),
+(444,32,o),
+(477,121,c),
+(426,121,l),
+(459,32,o),
+(528,-15,o),
+(618,-15,cs),
+(765,-15,o),
+(840,80,o),
+(840,199,cs),
+(840,323,o),
+(771,455,o),
+(771,526,cs),
+(771,555,o),
+(786,572,o),
+(822,572,cs),
+(849,572,l),
+(849,714,l),
+(787,714,ls),
+(662,714,o),
+(613,646,o),
+(613,552,cs),
+(613,530,o),
+(617,503,o),
+(620,482,c),
+(643,594,l),
+(529,594,l),
+(529,714,l),
+(374,714,l),
+(374,594,l),
+(259,594,l),
+(283,482,l),
+(286,503,o),
+(290,530,o),
+(290,552,cs),
+(290,646,o),
+(240,714,o),
+(116,714,cs),
+(54,714,l),
+(54,572,l),
+(80,572,ls),
+(116,572,o),
+(131,555,o),
+(131,526,cs),
+(131,455,o),
+(63,323,o),
+(63,199,cs),
+(63,80,o),
+(138,-15,o),
+(284,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(251,131,o),
+(227,165,o),
+(227,220,cs),
+(227,284,o),
+(261,375,o),
+(279,460,c),
+(374,460,l),
+(374,235,ls),
+(374,166,o),
+(347,131,o),
+(298,131,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(556,131,o),
+(529,166,o),
+(529,235,cs),
+(529,460,l),
+(624,460,l),
+(641,375,o),
+(676,284,o),
+(676,220,cs),
+(676,165,o),
+(652,131,o),
+(604,131,cs)
+);
+}
+);
+width = 903;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1654;
+unicode = 5716;
+},
+{
+color = 9;
+glyphname = "shoCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(116,0,ls),
+(240,0,o),
+(290,68,o),
+(290,162,cs),
+(290,184,o),
+(286,211,o),
+(283,232,c),
+(259,120,l),
+(374,120,l),
+(374,0,l),
+(529,0,l),
+(529,120,l),
+(643,120,l),
+(620,232,l),
+(617,211,o),
+(613,184,o),
+(613,162,cs),
+(613,68,o),
+(662,0,o),
+(787,0,cs),
+(849,0,l),
+(849,142,l),
+(822,142,ls),
+(786,142,o),
+(771,159,o),
+(771,188,cs),
+(771,259,o),
+(840,391,o),
+(840,515,cs),
+(840,634,o),
+(765,729,o),
+(618,729,cs),
+(528,729,o),
+(459,682,o),
+(426,593,c),
+(476,593,l),
+(444,682,o),
+(374,729,o),
+(284,729,cs),
+(138,729,o),
+(63,634,o),
+(63,515,cs),
+(63,391,o),
+(131,259,o),
+(131,188,cs),
+(131,159,o),
+(116,142,o),
+(80,142,cs),
+(54,142,l),
+(54,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(261,339,o),
+(227,430,o),
+(227,494,cs),
+(227,549,o),
+(250,583,o),
+(298,583,cs),
+(347,583,o),
+(374,548,o),
+(374,479,cs),
+(374,254,l),
+(279,254,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(529,479,ls),
+(529,548,o),
+(556,583,o),
+(604,583,cs),
+(652,583,o),
+(675,549,o),
+(675,494,cs),
+(675,430,o),
+(641,339,o),
+(624,254,c),
+(529,254,l)
+);
+}
+);
+width = 903;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1655;
+unicode = 5717;
+},
+{
+color = 9;
+glyphname = "sheCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(625,-15,o),
+(699,76,o),
+(699,191,cs),
+(699,282,o),
+(648,354,o),
+(567,377,c),
+(567,337,l),
+(649,356,o),
+(699,428,o),
+(699,523,cs),
+(699,638,o),
+(625,729,o),
+(499,729,cs),
+(390,729,o),
+(288,638,o),
+(246,638,cs),
+(222,638,o),
+(211,653,o),
+(211,690,cs),
+(211,714,l),
+(63,714,l),
+(63,657,ls),
+(63,550,o),
+(119,499,o),
+(206,499,cs),
+(228,499,o),
+(250,504,o),
+(270,511,c),
+(169,533,l),
+(169,423,l),
+(63,423,l),
+(63,291,l),
+(169,291,l),
+(169,181,l),
+(269,203,l),
+(249,210,o),
+(228,215,o),
+(206,215,cs),
+(119,215,o),
+(63,164,o),
+(63,57,cs),
+(63,0,l),
+(211,0,l),
+(211,24,ls),
+(211,61,o),
+(222,76,o),
+(246,76,cs),
+(288,76,o),
+(390,-15,o),
+(499,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(299,291,l),
+(435,291,ls),
+(501,291,o),
+(533,262,o),
+(533,211,cs),
+(533,162,o),
+(505,133,o),
+(455,133,cs),
+(409,133,o),
+(355,168,o),
+(299,191,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(299,523,l),
+(355,546,o),
+(409,581,o),
+(455,581,cs),
+(505,581,o),
+(533,552,o),
+(533,503,cs),
+(533,452,o),
+(501,423,o),
+(435,423,cs),
+(299,423,l)
+);
+}
+);
+width = 760;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1656;
+unicode = 5718;
+},
+{
+color = 9;
+glyphname = "sheeCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(625,-15,o),
+(699,76,o),
+(699,191,cs),
+(699,282,o),
+(648,354,o),
+(567,377,c),
+(567,337,l),
+(649,356,o),
+(699,428,o),
+(699,523,cs),
+(699,638,o),
+(625,729,o),
+(499,729,cs),
+(390,729,o),
+(288,638,o),
+(246,638,cs),
+(222,638,o),
+(211,653,o),
+(211,690,cs),
+(211,714,l),
+(63,714,l),
+(63,657,ls),
+(63,550,o),
+(119,499,o),
+(206,499,cs),
+(226,499,o),
+(248,504,o),
+(267,510,c),
+(169,537,l),
+(169,411,l),
+(63,411,l),
+(63,303,l),
+(169,303,l),
+(169,177,l),
+(267,204,l),
+(248,210,o),
+(227,215,o),
+(206,215,cs),
+(119,215,o),
+(63,164,o),
+(63,57,cs),
+(63,0,l),
+(211,0,l),
+(211,24,ls),
+(211,61,o),
+(222,76,o),
+(246,76,cs),
+(288,76,o),
+(390,-15,o),
+(499,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(409,129,o),
+(345,174,o),
+(283,199,c),
+(283,303,l),
+(364,303,l),
+(364,218,l),
+(439,218,l),
+(439,326,l),
+(416,303,l),
+(456,303,ls),
+(508,303,o),
+(537,267,o),
+(537,217,cs),
+(537,160,o),
+(509,129,o),
+(458,129,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(439,494,l),
+(364,494,l),
+(364,411,l),
+(283,411,l),
+(283,515,l),
+(345,540,o),
+(409,585,o),
+(458,585,cs),
+(509,585,o),
+(537,554,o),
+(537,497,cs),
+(537,447,o),
+(507,411,o),
+(456,411,cs),
+(416,411,l),
+(439,388,l)
+);
+}
+);
+width = 760;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1657;
+unicode = 5719;
+},
+{
+color = 9;
+glyphname = "shiCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(63,657,ls),
+(63,550,o),
+(119,499,o),
+(206,499,cs),
+(224,499,o),
+(241,503,o),
+(260,507,c),
+(169,542,l),
+(169,411,l),
+(63,411,l),
+(63,303,l),
+(169,303,l),
+(169,172,l),
+(260,207,l),
+(241,211,o),
+(224,215,o),
+(206,215,cs),
+(119,215,o),
+(63,164,o),
+(63,57,cs),
+(63,0,l),
+(211,0,l),
+(211,24,ls),
+(211,61,o),
+(222,76,o),
+(246,76,cs),
+(288,76,o),
+(390,-15,o),
+(499,-15,cs),
+(625,-15,o),
+(699,76,o),
+(699,191,cs),
+(699,282,o),
+(648,354,o),
+(568,377,c),
+(567,337,l),
+(649,356,o),
+(699,428,o),
+(699,523,cs),
+(699,638,o),
+(625,729,o),
+(499,729,cs),
+(390,729,o),
+(288,638,o),
+(246,638,cs),
+(222,638,o),
+(211,653,o),
+(211,690,cs),
+(211,714,l),
+(63,714,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(283,303,l),
+(310,303,l),
+(329,265,o),
+(364,246,o),
+(401,246,cs),
+(460,246,o),
+(502,295,o),
+(504,349,c),
+(419,303,l),
+(464,303,ls),
+(511,303,o),
+(537,262,o),
+(537,217,cs),
+(537,160,o),
+(509,129,o),
+(458,129,cs),
+(409,129,o),
+(345,173,o),
+(283,198,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(283,516,l),
+(345,541,o),
+(409,585,o),
+(458,585,cs),
+(509,585,o),
+(537,554,o),
+(537,497,cs),
+(537,448,o),
+(511,411,o),
+(464,411,cs),
+(420,411,l),
+(505,364,l),
+(504,421,o),
+(460,469,o),
+(401,469,cs),
+(363,469,o),
+(328,449,o),
+(309,411,c),
+(283,411,l)
+);
+}
+);
+width = 760;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1658;
+unicode = 5720;
+},
+{
+color = 9;
+glyphname = "shaCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(369,-15,o),
+(471,76,o),
+(513,76,cs),
+(538,76,o),
+(548,61,o),
+(548,24,cs),
+(548,0,l),
+(697,0,l),
+(697,57,ls),
+(697,164,o),
+(640,215,o),
+(554,215,cs),
+(531,215,o),
+(510,210,o),
+(490,203,c),
+(591,181,l),
+(591,291,l),
+(697,291,l),
+(697,423,l),
+(591,423,l),
+(591,533,l),
+(490,511,l),
+(510,504,o),
+(531,499,o),
+(554,499,cs),
+(640,499,o),
+(697,550,o),
+(697,657,cs),
+(697,714,l),
+(548,714,l),
+(548,690,ls),
+(548,653,o),
+(538,638,o),
+(513,638,cs),
+(471,638,o),
+(369,729,o),
+(260,729,cs),
+(135,729,o),
+(61,638,o),
+(61,523,cs),
+(61,428,o),
+(111,356,o),
+(193,337,c),
+(192,377,l),
+(112,354,o),
+(61,282,o),
+(61,191,cs),
+(61,76,o),
+(135,-15,o),
+(260,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(255,133,o),
+(226,162,o),
+(226,211,cs),
+(226,262,o),
+(259,291,o),
+(324,291,cs),
+(461,291,l),
+(461,191,l),
+(405,168,o),
+(351,133,o),
+(305,133,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(259,423,o),
+(226,452,o),
+(226,503,cs),
+(226,552,o),
+(255,581,o),
+(305,581,cs),
+(351,581,o),
+(405,546,o),
+(461,523,c),
+(461,423,l),
+(324,423,ls)
+);
+}
+);
+width = 760;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1659;
+unicode = 5721;
+},
+{
+color = 6;
+glyphname = "shCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(268,99,l),
+(268,210,l),
+(209,189,l),
+(244,189,ls),
+(328,189,o),
+(373,226,o),
+(373,297,cs),
+(373,366,o),
+(329,409,o),
+(250,409,cs),
+(194,409,ls),
+(169,409,o),
+(154,416,o),
+(154,437,cs),
+(154,458,o),
+(169,463,o),
+(194,463,cs),
+(366,463,l),
+(366,546,l),
+(268,546,l),
+(268,636,l),
+(162,636,l),
+(162,518,l),
+(218,546,l),
+(184,546,ls),
+(100,546,o),
+(55,509,o),
+(55,438,cs),
+(55,369,o),
+(99,327,o),
+(178,327,cs),
+(234,327,ls),
+(259,327,o),
+(274,319,o),
+(274,298,cs),
+(274,277,o),
+(260,272,o),
+(234,272,cs),
+(62,272,l),
+(62,189,l),
+(162,189,l),
+(162,99,l)
+);
+}
+);
+width = 428;
+}
+);
+metricRight = "=|";
+note = uni18F5;
+unicode = 5722;
+},
+{
+color = 9;
+glyphname = "tsuCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(374,-15,o),
+(444,32,o),
+(477,121,c),
+(426,121,l),
+(459,32,o),
+(528,-15,o),
+(618,-15,cs),
+(765,-15,o),
+(840,80,o),
+(840,199,cs),
+(840,323,o),
+(771,455,o),
+(771,526,cs),
+(771,555,o),
+(786,572,o),
+(822,572,cs),
+(849,572,l),
+(849,714,l),
+(787,714,ls),
+(664,714,o),
+(615,649,o),
+(615,554,cs),
+(615,514,o),
+(625,469,o),
+(637,424,c),
+(526,424,l),
+(526,599,l),
+(583,599,l),
+(583,714,l),
+(319,714,l),
+(319,599,l),
+(377,599,l),
+(377,424,l),
+(266,424,l),
+(277,469,o),
+(288,514,o),
+(288,554,cs),
+(288,649,o),
+(239,714,o),
+(116,714,cs),
+(54,714,l),
+(54,572,l),
+(80,572,ls),
+(116,572,o),
+(131,555,o),
+(131,526,cs),
+(131,455,o),
+(63,323,o),
+(63,199,cs),
+(63,80,o),
+(138,-15,o),
+(284,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(251,131,o),
+(227,165,o),
+(227,220,cs),
+(227,240,o),
+(231,264,o),
+(235,290,c),
+(377,290,l),
+(377,235,ls),
+(377,166,o),
+(348,131,o),
+(299,131,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(555,131,o),
+(526,166,o),
+(526,235,cs),
+(526,290,l),
+(667,290,l),
+(672,264,o),
+(676,240,o),
+(676,220,cs),
+(676,165,o),
+(651,131,o),
+(604,131,cs)
+);
+}
+);
+width = 903;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165B;
+unicode = 5723;
+},
+{
+color = 9;
+glyphname = "tsoCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(116,0,ls),
+(239,0,o),
+(288,65,o),
+(288,160,cs),
+(288,200,o),
+(277,245,o),
+(266,290,c),
+(377,290,l),
+(377,115,l),
+(319,115,l),
+(319,0,l),
+(583,0,l),
+(583,115,l),
+(526,115,l),
+(526,290,l),
+(637,290,l),
+(625,245,o),
+(615,200,o),
+(615,160,cs),
+(615,65,o),
+(664,0,o),
+(787,0,cs),
+(849,0,l),
+(849,142,l),
+(822,142,ls),
+(786,142,o),
+(771,159,o),
+(771,188,cs),
+(771,259,o),
+(840,391,o),
+(840,515,cs),
+(840,634,o),
+(765,729,o),
+(618,729,cs),
+(528,729,o),
+(459,682,o),
+(426,593,c),
+(477,593,l),
+(443,682,o),
+(374,729,o),
+(284,729,cs),
+(138,729,o),
+(63,634,o),
+(63,515,cs),
+(63,391,o),
+(131,259,o),
+(131,188,cs),
+(131,159,o),
+(116,142,o),
+(80,142,cs),
+(54,142,l),
+(54,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(231,450,o),
+(227,474,o),
+(227,494,cs),
+(227,549,o),
+(251,583,o),
+(299,583,cs),
+(347,583,o),
+(377,548,o),
+(377,479,cs),
+(377,424,l),
+(235,424,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(526,479,ls),
+(526,548,o),
+(555,583,o),
+(604,583,cs),
+(651,583,o),
+(675,549,o),
+(675,494,cs),
+(675,474,o),
+(672,450,o),
+(667,424,c),
+(526,424,l)
+);
+}
+);
+width = 903;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165C;
+unicode = 5724;
+},
+{
+color = 9;
+glyphname = "tseCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(627,-15,o),
+(702,76,o),
+(702,191,cs),
+(702,282,o),
+(651,354,o),
+(570,377,c),
+(570,337,l),
+(652,356,o),
+(702,428,o),
+(702,523,cs),
+(702,638,o),
+(627,729,o),
+(502,729,cs),
+(393,729,o),
+(291,638,o),
+(249,638,cs),
+(225,638,o),
+(214,653,o),
+(214,690,cs),
+(214,714,l),
+(65,714,l),
+(65,663,ls),
+(65,556,o),
+(122,504,o),
+(208,504,cs),
+(242,504,o),
+(275,514,o),
+(307,527,c),
+(236,536,l),
+(236,412,l),
+(157,412,l),
+(157,477,l),
+(65,477,l),
+(65,237,l),
+(157,237,l),
+(157,302,l),
+(236,302,l),
+(236,178,l),
+(305,188,l),
+(274,201,o),
+(241,210,o),
+(208,210,cs),
+(122,210,o),
+(65,158,o),
+(65,51,cs),
+(65,0,l),
+(214,0,l),
+(214,24,ls),
+(214,61,o),
+(225,76,o),
+(249,76,cs),
+(291,76,o),
+(393,-15,o),
+(502,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(426,133,o),
+(389,150,o),
+(351,167,c),
+(351,302,l),
+(439,302,ls),
+(505,302,o),
+(537,263,o),
+(537,211,cs),
+(537,163,o),
+(509,133,o),
+(459,133,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(351,547,l),
+(389,564,o),
+(426,581,o),
+(459,581,cs),
+(509,581,o),
+(537,551,o),
+(537,503,cs),
+(537,451,o),
+(505,412,o),
+(439,412,cs),
+(351,412,l)
+);
+}
+);
+width = 763;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni165D;
+unicode = 5725;
+},
+{
+color = 9;
+glyphname = "tseeCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(627,-15,o),
+(702,76,o),
+(702,191,cs),
+(702,282,o),
+(651,354,o),
+(570,377,c),
+(570,337,l),
+(652,356,o),
+(702,428,o),
+(702,523,cs),
+(702,638,o),
+(627,729,o),
+(502,729,cs),
+(393,729,o),
+(291,638,o),
+(249,638,cs),
+(225,638,o),
+(214,653,o),
+(214,690,cs),
+(214,714,l),
+(65,714,l),
+(65,663,ls),
+(65,556,o),
+(122,504,o),
+(208,504,cs),
+(233,504,o),
+(257,510,o),
+(282,519,c),
+(231,536,l),
+(231,412,l),
+(154,412,l),
+(154,477,l),
+(65,477,l),
+(65,237,l),
+(154,237,l),
+(154,302,l),
+(231,302,l),
+(231,172,l),
+(280,196,l),
+(256,204,o),
+(232,210,o),
+(208,210,cs),
+(122,210,o),
+(65,158,o),
+(65,51,cs),
+(65,0,l),
+(214,0,l),
+(214,24,ls),
+(214,61,o),
+(225,76,o),
+(249,76,cs),
+(291,76,o),
+(393,-15,o),
+(502,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(420,133,o),
+(376,157,o),
+(329,178,c),
+(329,302,l),
+(386,302,l),
+(386,213,l),
+(461,213,l),
+(461,358,l),
+(401,302,l),
+(465,302,ls),
+(516,302,o),
+(539,263,o),
+(539,220,cs),
+(539,162,o),
+(510,133,o),
+(459,133,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(461,499,l),
+(386,499,l),
+(386,412,l),
+(329,412,l),
+(329,536,l),
+(376,557,o),
+(420,581,o),
+(459,581,cs),
+(510,581,o),
+(539,552,o),
+(539,494,cs),
+(539,451,o),
+(516,412,o),
+(465,412,cs),
+(402,412,l),
+(461,356,l)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165E;
+unicode = 5726;
+},
+{
+color = 9;
+glyphname = "tsiCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(627,-15,o),
+(702,76,o),
+(702,191,cs),
+(702,282,o),
+(650,354,o),
+(570,377,c),
+(570,337,l),
+(652,356,o),
+(702,428,o),
+(702,523,cs),
+(702,638,o),
+(627,729,o),
+(502,729,cs),
+(393,729,o),
+(291,638,o),
+(249,638,cs),
+(225,638,o),
+(214,653,o),
+(214,690,cs),
+(214,714,l),
+(65,714,l),
+(65,663,ls),
+(65,554,o),
+(122,504,o),
+(208,504,cs),
+(228,504,o),
+(248,509,o),
+(266,515,c),
+(208,566,l),
+(208,412,l),
+(154,412,l),
+(154,477,l),
+(65,477,l),
+(65,237,l),
+(154,237,l),
+(154,303,l),
+(208,303,l),
+(208,148,l),
+(263,200,l),
+(245,206,o),
+(227,210,o),
+(208,210,cs),
+(122,210,o),
+(65,160,o),
+(65,51,cs),
+(65,0,l),
+(214,0,l),
+(214,24,ls),
+(214,61,o),
+(225,76,o),
+(249,76,cs),
+(291,76,o),
+(393,-15,o),
+(502,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(414,133,o),
+(362,164,o),
+(307,186,c),
+(307,303,l),
+(331,303,l),
+(348,267,o),
+(381,246,o),
+(420,246,cs),
+(478,246,o),
+(516,296,o),
+(519,348,c),
+(451,304,l),
+(476,304,ls),
+(521,304,o),
+(539,267,o),
+(539,220,cs),
+(539,163,o),
+(510,133,o),
+(459,133,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(517,420,o),
+(479,469,o),
+(420,469,cs),
+(381,469,o),
+(348,447,o),
+(332,412,c),
+(307,412,l),
+(307,528,l),
+(362,550,o),
+(414,581,o),
+(459,581,cs),
+(510,581,o),
+(539,551,o),
+(539,494,cs),
+(539,447,o),
+(521,410,o),
+(476,410,cs),
+(452,410,l),
+(520,363,l)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165F;
+unicode = 5727;
+},
+{
+color = 9;
+glyphname = "tsaCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(369,-15,o),
+(471,76,o),
+(513,76,cs),
+(538,76,o),
+(548,61,o),
+(548,24,cs),
+(548,0,l),
+(697,0,l),
+(697,51,ls),
+(697,158,o),
+(640,210,o),
+(554,210,cs),
+(521,210,o),
+(488,201,o),
+(457,188,c),
+(526,178,l),
+(526,302,l),
+(605,302,l),
+(605,237,l),
+(697,237,l),
+(697,477,l),
+(605,477,l),
+(605,412,l),
+(526,412,l),
+(526,536,l),
+(455,527,l),
+(488,514,o),
+(520,504,o),
+(554,504,cs),
+(640,504,o),
+(697,556,o),
+(697,663,cs),
+(697,714,l),
+(548,714,l),
+(548,690,ls),
+(548,653,o),
+(538,638,o),
+(513,638,cs),
+(471,638,o),
+(369,729,o),
+(260,729,cs),
+(135,729,o),
+(61,638,o),
+(61,523,cs),
+(61,428,o),
+(111,356,o),
+(193,337,c),
+(192,377,l),
+(112,354,o),
+(61,282,o),
+(61,191,cs),
+(61,76,o),
+(135,-15,o),
+(260,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(254,133,o),
+(225,163,o),
+(225,211,cs),
+(225,263,o),
+(257,302,o),
+(323,302,cs),
+(412,302,l),
+(412,167,l),
+(373,150,o),
+(336,133,o),
+(304,133,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(258,412,o),
+(225,451,o),
+(225,503,cs),
+(225,551,o),
+(254,581,o),
+(304,581,cs),
+(336,581,o),
+(373,564,o),
+(412,547,c),
+(412,412,l),
+(323,412,ls)
+);
+}
+);
+width = 762;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1660;
+unicode = 5728;
+},
+{
+color = 9;
+glyphname = "chuCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(374,-15,o),
+(444,32,o),
+(477,121,c),
+(426,121,l),
+(459,32,o),
+(528,-15,o),
+(618,-15,cs),
+(765,-15,o),
+(840,80,o),
+(840,199,cs),
+(840,323,o),
+(771,455,o),
+(771,526,cs),
+(771,555,o),
+(786,572,o),
+(822,572,cs),
+(849,572,l),
+(849,714,l),
+(787,714,ls),
+(664,714,o),
+(615,649,o),
+(615,554,cs),
+(615,441,o),
+(676,307,o),
+(676,220,cs),
+(676,165,o),
+(651,131,o),
+(604,131,cs),
+(555,131,o),
+(527,166,o),
+(527,235,cs),
+(527,599,l),
+(583,599,l),
+(583,714,l),
+(319,714,l),
+(319,599,l),
+(375,599,l),
+(375,235,ls),
+(375,166,o),
+(348,131,o),
+(299,131,cs),
+(251,131,o),
+(227,165,o),
+(227,220,cs),
+(227,307,o),
+(288,441,o),
+(288,554,cs),
+(288,649,o),
+(239,714,o),
+(116,714,cs),
+(54,714,l),
+(54,572,l),
+(80,572,ls),
+(116,572,o),
+(131,555,o),
+(131,526,cs),
+(131,455,o),
+(63,323,o),
+(63,199,cs),
+(63,80,o),
+(138,-15,o),
+(284,-15,cs)
+);
+}
+);
+width = 903;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164E;
+unicode = 5729;
+},
+{
+color = 9;
+glyphname = "choCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(116,0,ls),
+(239,0,o),
+(288,65,o),
+(288,160,cs),
+(288,273,o),
+(227,407,o),
+(227,494,cs),
+(227,549,o),
+(251,583,o),
+(299,583,cs),
+(347,583,o),
+(375,548,o),
+(375,479,cs),
+(375,115,l),
+(319,115,l),
+(319,0,l),
+(583,0,l),
+(583,115,l),
+(527,115,l),
+(527,479,ls),
+(527,548,o),
+(555,583,o),
+(604,583,cs),
+(651,583,o),
+(675,549,o),
+(675,494,cs),
+(675,407,o),
+(615,273,o),
+(615,160,cs),
+(615,65,o),
+(664,0,o),
+(787,0,cs),
+(849,0,l),
+(849,142,l),
+(822,142,ls),
+(786,142,o),
+(771,159,o),
+(771,188,cs),
+(771,259,o),
+(840,391,o),
+(840,515,cs),
+(840,634,o),
+(765,729,o),
+(618,729,cs),
+(528,729,o),
+(459,682,o),
+(426,593,c),
+(477,593,l),
+(443,682,o),
+(374,729,o),
+(284,729,cs),
+(138,729,o),
+(63,634,o),
+(63,515,cs),
+(63,391,o),
+(131,259,o),
+(131,188,cs),
+(131,159,o),
+(116,142,o),
+(80,142,cs),
+(54,142,l),
+(54,0,l)
+);
+}
+);
+width = 903;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5730;
+},
+{
+color = 9;
+glyphname = "cheCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(627,-15,o),
+(702,76,o),
+(702,191,cs),
+(702,282,o),
+(651,354,o),
+(570,377,c),
+(570,337,l),
+(652,356,o),
+(702,428,o),
+(702,523,cs),
+(702,638,o),
+(627,729,o),
+(502,729,cs),
+(393,729,o),
+(291,638,o),
+(249,638,cs),
+(225,638,o),
+(214,653,o),
+(214,690,cs),
+(214,714,l),
+(65,714,l),
+(65,662,ls),
+(65,554,o),
+(122,502,o),
+(208,502,cs),
+(300,502,o),
+(387,581,o),
+(458,581,cs),
+(508,581,o),
+(536,552,o),
+(536,503,cs),
+(536,452,o),
+(504,423,o),
+(438,423,cs),
+(157,423,l),
+(157,477,l),
+(65,477,l),
+(65,237,l),
+(157,237,l),
+(157,291,l),
+(438,291,ls),
+(504,291,o),
+(536,262,o),
+(536,211,cs),
+(536,162,o),
+(508,133,o),
+(458,133,cs),
+(387,133,o),
+(300,212,o),
+(208,212,cs),
+(122,212,o),
+(65,160,o),
+(65,52,cs),
+(65,0,l),
+(214,0,l),
+(214,24,ls),
+(214,61,o),
+(225,76,o),
+(249,76,cs),
+(291,76,o),
+(393,-15,o),
+(502,-15,cs)
+);
+}
+);
+width = 763;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni1663;
+unicode = 5731;
+},
+{
+color = 9;
+glyphname = "cheeCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(627,-15,o),
+(702,76,o),
+(702,191,cs),
+(702,282,o),
+(651,354,o),
+(570,377,c),
+(570,337,l),
+(652,356,o),
+(702,428,o),
+(702,523,cs),
+(702,638,o),
+(627,729,o),
+(502,729,cs),
+(393,729,o),
+(291,638,o),
+(249,638,cs),
+(225,638,o),
+(214,653,o),
+(214,690,cs),
+(214,714,l),
+(65,714,l),
+(65,662,ls),
+(65,554,o),
+(122,502,o),
+(208,502,cs),
+(301,502,o),
+(390,585,o),
+(461,585,cs),
+(512,585,o),
+(540,554,o),
+(540,499,cs),
+(540,447,o),
+(510,411,o),
+(459,411,cs),
+(398,411,l),
+(433,394,l),
+(433,496,l),
+(341,496,l),
+(341,411,l),
+(157,411,l),
+(157,477,l),
+(65,477,l),
+(65,237,l),
+(157,237,l),
+(157,303,l),
+(341,303,l),
+(341,216,l),
+(433,216,l),
+(433,320,l),
+(398,303,l),
+(459,303,ls),
+(511,303,o),
+(540,267,o),
+(540,215,cs),
+(540,160,o),
+(512,129,o),
+(461,129,cs),
+(390,129,o),
+(301,212,o),
+(208,212,cs),
+(122,212,o),
+(65,160,o),
+(65,52,cs),
+(65,0,l),
+(214,0,l),
+(214,24,ls),
+(214,61,o),
+(225,76,o),
+(249,76,cs),
+(291,76,o),
+(393,-15,o),
+(502,-15,cs)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1664;
+unicode = 5732;
+},
+{
+color = 9;
+glyphname = "chiCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(627,-15,o),
+(702,76,o),
+(702,191,cs),
+(702,282,o),
+(650,354,o),
+(570,377,c),
+(570,337,l),
+(652,356,o),
+(702,428,o),
+(702,523,cs),
+(702,638,o),
+(627,729,o),
+(502,729,cs),
+(393,729,o),
+(291,638,o),
+(249,638,cs),
+(225,638,o),
+(214,653,o),
+(214,690,cs),
+(214,714,l),
+(65,714,l),
+(65,662,ls),
+(65,554,o),
+(122,502,o),
+(208,502,cs),
+(301,502,o),
+(390,585,o),
+(461,585,cs),
+(512,585,o),
+(540,554,o),
+(540,499,cs),
+(540,447,o),
+(510,411,o),
+(460,411,cs),
+(407,411,l),
+(460,361,l),
+(457,423,o),
+(413,469,o),
+(352,469,cs),
+(310,469,o),
+(275,445,o),
+(257,411,c),
+(157,411,l),
+(157,477,l),
+(65,477,l),
+(65,237,l),
+(157,237,l),
+(157,303,l),
+(257,303,l),
+(276,268,o),
+(310,246,o),
+(353,246,cs),
+(412,246,o),
+(455,293,o),
+(461,351,c),
+(406,303,l),
+(460,303,ls),
+(511,303,o),
+(540,267,o),
+(540,215,cs),
+(540,160,o),
+(512,129,o),
+(461,129,cs),
+(390,129,o),
+(301,212,o),
+(208,212,cs),
+(122,212,o),
+(65,160,o),
+(65,52,cs),
+(65,0,l),
+(214,0,l),
+(214,24,ls),
+(214,61,o),
+(225,76,o),
+(249,76,cs),
+(291,76,o),
+(393,-15,o),
+(502,-15,cs)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1665;
+unicode = 5733;
+},
+{
+color = 9;
+glyphname = "chaCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(369,-15,o),
+(471,76,o),
+(513,76,cs),
+(538,76,o),
+(548,61,o),
+(548,24,cs),
+(548,0,l),
+(697,0,l),
+(697,52,ls),
+(697,160,o),
+(640,212,o),
+(554,212,cs),
+(462,212,o),
+(375,133,o),
+(305,133,cs),
+(255,133,o),
+(226,162,o),
+(226,211,cs),
+(226,262,o),
+(259,291,o),
+(324,291,cs),
+(605,291,l),
+(605,237,l),
+(697,237,l),
+(697,477,l),
+(605,477,l),
+(605,423,l),
+(324,423,ls),
+(259,423,o),
+(226,452,o),
+(226,503,cs),
+(226,552,o),
+(255,581,o),
+(305,581,cs),
+(375,581,o),
+(462,502,o),
+(554,502,cs),
+(640,502,o),
+(697,554,o),
+(697,662,cs),
+(697,714,l),
+(548,714,l),
+(548,690,ls),
+(548,653,o),
+(538,638,o),
+(513,638,cs),
+(471,638,o),
+(369,729,o),
+(260,729,cs),
+(135,729,o),
+(61,638,o),
+(61,523,cs),
+(61,428,o),
+(111,356,o),
+(193,337,c),
+(192,377,l),
+(112,354,o),
+(61,282,o),
+(61,191,cs),
+(61,76,o),
+(135,-15,o),
+(260,-15,cs)
+);
+}
+);
+width = 762;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1666;
+unicode = 5734;
+},
+{
+color = 9;
+glyphname = "ttsuCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(374,-15,o),
+(444,32,o),
+(477,121,c),
+(426,121,l),
+(459,32,o),
+(528,-15,o),
+(618,-15,cs),
+(765,-15,o),
+(840,80,o),
+(840,199,cs),
+(840,323,o),
+(771,455,o),
+(771,526,cs),
+(771,555,o),
+(786,572,o),
+(822,572,cs),
+(849,572,l),
+(849,714,l),
+(787,714,ls),
+(664,714,o),
+(615,649,o),
+(615,554,cs),
+(615,520,o),
+(620,483,o),
+(626,448,c),
+(685,579,l),
+(526,467,l),
+(526,599,l),
+(583,599,l),
+(583,714,l),
+(319,714,l),
+(319,599,l),
+(377,599,l),
+(377,466,l),
+(218,579,l),
+(277,448,l),
+(282,485,o),
+(288,520,o),
+(288,554,cs),
+(288,649,o),
+(239,714,o),
+(116,714,cs),
+(54,714,l),
+(54,572,l),
+(80,572,ls),
+(116,572,o),
+(131,555,o),
+(131,526,cs),
+(131,455,o),
+(63,323,o),
+(63,199,cs),
+(63,80,o),
+(138,-15,o),
+(284,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(251,131,o),
+(227,165,o),
+(227,220,cs),
+(227,268,o),
+(246,329,o),
+(262,391,c),
+(377,314,l),
+(377,235,ls),
+(377,166,o),
+(348,131,o),
+(299,131,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(555,131,o),
+(526,166,o),
+(526,235,cs),
+(526,314,l),
+(640,391,l),
+(656,328,o),
+(676,268,o),
+(676,220,cs),
+(676,165,o),
+(651,131,o),
+(604,131,cs)
+);
+}
+);
+width = 903;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1667;
+unicode = 5735;
+},
+{
+color = 9;
+glyphname = "ttsoCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(116,0,ls),
+(239,0,o),
+(288,65,o),
+(288,160,cs),
+(288,194,o),
+(282,229,o),
+(277,266,c),
+(218,135,l),
+(377,248,l),
+(377,115,l),
+(319,115,l),
+(319,0,l),
+(583,0,l),
+(583,115,l),
+(526,115,l),
+(526,247,l),
+(685,135,l),
+(626,266,l),
+(620,231,o),
+(615,194,o),
+(615,160,cs),
+(615,65,o),
+(664,0,o),
+(787,0,cs),
+(849,0,l),
+(849,142,l),
+(822,142,ls),
+(786,142,o),
+(771,159,o),
+(771,188,cs),
+(771,259,o),
+(840,391,o),
+(840,515,cs),
+(840,634,o),
+(765,729,o),
+(618,729,cs),
+(528,729,o),
+(459,682,o),
+(426,593,c),
+(477,593,l),
+(444,682,o),
+(374,729,o),
+(284,729,cs),
+(138,729,o),
+(63,634,o),
+(63,515,cs),
+(63,391,o),
+(131,259,o),
+(131,188,cs),
+(131,159,o),
+(116,142,o),
+(80,142,cs),
+(54,142,l),
+(54,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(246,385,o),
+(227,446,o),
+(227,494,cs),
+(227,549,o),
+(251,583,o),
+(299,583,cs),
+(348,583,o),
+(377,548,o),
+(377,479,cs),
+(377,400,l),
+(262,323,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(526,400,l),
+(526,479,ls),
+(526,548,o),
+(555,583,o),
+(604,583,cs),
+(651,583,o),
+(676,549,o),
+(676,494,cs),
+(676,446,o),
+(656,386,o),
+(640,323,c)
+);
+}
+);
+width = 903;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1668;
+unicode = 5736;
+},
+{
+color = 9;
+glyphname = "ttseCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(627,-15,o),
+(702,76,o),
+(702,191,cs),
+(702,282,o),
+(650,354,o),
+(570,377,c),
+(570,337,l),
+(652,356,o),
+(702,428,o),
+(702,523,cs),
+(702,638,o),
+(627,729,o),
+(502,729,cs),
+(393,729,o),
+(291,638,o),
+(249,638,cs),
+(225,638,o),
+(214,653,o),
+(214,690,cs),
+(214,714,l),
+(65,714,l),
+(65,662,ls),
+(65,554,o),
+(122,502,o),
+(208,502,cs),
+(232,502,o),
+(253,507,o),
+(274,515,c),
+(159,575,l),
+(233,411,l),
+(157,411,l),
+(157,477,l),
+(65,477,l),
+(65,237,l),
+(157,237,l),
+(157,303,l),
+(233,303,l),
+(159,139,l),
+(275,199,l),
+(253,207,o),
+(232,212,o),
+(208,212,cs),
+(122,212,o),
+(65,160,o),
+(65,52,cs),
+(65,0,l),
+(214,0,l),
+(214,24,ls),
+(214,61,o),
+(225,76,o),
+(249,76,cs),
+(291,76,o),
+(393,-15,o),
+(502,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(413,129,o),
+(357,167,o),
+(301,190,c),
+(350,303,l),
+(460,303,ls),
+(511,303,o),
+(540,267,o),
+(540,215,cs),
+(540,160,o),
+(512,129,o),
+(461,129,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(301,524,l),
+(357,547,o),
+(413,585,o),
+(461,585,cs),
+(512,585,o),
+(540,554,o),
+(540,499,cs),
+(540,447,o),
+(510,411,o),
+(460,411,cs),
+(350,411,l)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1669;
+unicode = 5737;
+},
+{
+color = 9;
+glyphname = "ttseeCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(627,-15,o),
+(702,76,o),
+(702,191,cs),
+(702,282,o),
+(650,354,o),
+(570,377,c),
+(570,337,l),
+(652,356,o),
+(702,428,o),
+(702,523,cs),
+(702,638,o),
+(627,729,o),
+(502,729,cs),
+(393,729,o),
+(291,638,o),
+(249,638,cs),
+(225,638,o),
+(214,653,o),
+(214,690,cs),
+(214,714,l),
+(65,714,l),
+(65,662,ls),
+(65,554,o),
+(122,502,o),
+(208,502,cs),
+(232,502,o),
+(255,507,o),
+(267,517,c),
+(157,573,l),
+(230,411,l),
+(157,411,l),
+(157,477,l),
+(65,477,l),
+(65,237,l),
+(157,237,l),
+(157,303,l),
+(230,303,l),
+(157,141,l),
+(266,197,l),
+(255,207,o),
+(232,212,o),
+(208,212,cs),
+(122,212,o),
+(65,160,o),
+(65,52,cs),
+(65,0,l),
+(214,0,l),
+(214,24,ls),
+(214,61,o),
+(225,76,o),
+(249,76,cs),
+(291,76,o),
+(393,-15,o),
+(502,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(411,129,o),
+(354,170,o),
+(296,192,c),
+(344,303,l),
+(386,303,l),
+(386,213,l),
+(463,213,l),
+(463,326,l),
+(433,303,l),
+(460,303,ls),
+(511,303,o),
+(540,267,o),
+(540,215,cs),
+(540,160,o),
+(512,129,o),
+(461,129,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(463,499,l),
+(386,499,l),
+(386,411,l),
+(344,411,l),
+(296,522,l),
+(354,544,o),
+(411,585,o),
+(461,585,cs),
+(512,585,o),
+(540,554,o),
+(540,499,cs),
+(540,447,o),
+(510,411,o),
+(460,411,cs),
+(433,411,l),
+(463,388,l)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166A;
+unicode = 5738;
+},
+{
+color = 9;
+glyphname = "ttsiCarrier-canadian";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(627,-15,o),
+(702,76,o),
+(702,191,cs),
+(702,282,o),
+(650,354,o),
+(570,377,c),
+(570,337,l),
+(652,356,o),
+(702,428,o),
+(702,523,cs),
+(702,638,o),
+(627,729,o),
+(502,729,cs),
+(393,729,o),
+(291,638,o),
+(249,638,cs),
+(225,638,o),
+(214,653,o),
+(214,690,cs),
+(214,714,l),
+(65,714,l),
+(65,662,ls),
+(65,554,o),
+(122,502,o),
+(208,502,cs),
+(224,502,o),
+(238,504,o),
+(256,510,c),
+(174,537,l),
+(230,411,l),
+(157,411,l),
+(157,477,l),
+(65,477,l),
+(65,237,l),
+(157,237,l),
+(157,303,l),
+(230,303,l),
+(172,171,l),
+(256,205,l),
+(238,210,o),
+(224,212,o),
+(208,212,cs),
+(122,212,o),
+(65,160,o),
+(65,52,cs),
+(65,0,l),
+(214,0,l),
+(214,24,ls),
+(214,61,o),
+(225,76,o),
+(249,76,cs),
+(291,76,o),
+(393,-15,o),
+(502,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(408,129,o),
+(342,177,o),
+(280,198,c),
+(325,303,l),
+(333,303,l),
+(350,268,o),
+(382,246,o),
+(422,246,cs),
+(474,246,o),
+(513,288,o),
+(518,342,c),
+(446,303,l),
+(474,303,ls),
+(519,303,o),
+(540,267,o),
+(540,215,cs),
+(540,160,o),
+(512,129,o),
+(461,129,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(516,428,o),
+(475,469,o),
+(422,469,cs),
+(382,469,o),
+(350,445,o),
+(333,411,c),
+(325,411,l),
+(280,516,l),
+(342,537,o),
+(408,585,o),
+(461,585,cs),
+(512,585,o),
+(540,554,o),
+(540,499,cs),
+(540,447,o),
+(519,411,o),
+(474,411,cs),
+(447,411,l),
+(519,371,l)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166B;
+unicode = 5739;
+},
+{
+color = 9;
+glyphname = "ttsaCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(369,-15,o),
+(471,76,o),
+(513,76,cs),
+(538,76,o),
+(548,61,o),
+(548,24,cs),
+(548,0,l),
+(697,0,l),
+(697,52,ls),
+(697,160,o),
+(640,212,o),
+(554,212,cs),
+(530,212,o),
+(510,207,o),
+(488,199,c),
+(603,139,l),
+(529,303,l),
+(605,303,l),
+(605,237,l),
+(697,237,l),
+(697,477,l),
+(605,477,l),
+(605,411,l),
+(529,411,l),
+(603,575,l),
+(488,515,l),
+(510,507,o),
+(530,502,o),
+(554,502,cs),
+(640,502,o),
+(697,554,o),
+(697,662,cs),
+(697,714,l),
+(548,714,l),
+(548,690,ls),
+(548,653,o),
+(538,638,o),
+(513,638,cs),
+(471,638,o),
+(369,729,o),
+(260,729,cs),
+(135,729,o),
+(61,638,o),
+(61,523,cs),
+(61,428,o),
+(111,356,o),
+(192,337,c),
+(192,377,l),
+(112,354,o),
+(61,282,o),
+(61,191,cs),
+(61,76,o),
+(135,-15,o),
+(260,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(251,129,o),
+(222,160,o),
+(222,215,cs),
+(222,267,o),
+(252,303,o),
+(303,303,cs),
+(413,303,l),
+(461,190,l),
+(405,167,o),
+(349,129,o),
+(301,129,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(252,411,o),
+(222,447,o),
+(222,499,cs),
+(222,554,o),
+(251,585,o),
+(301,585,cs),
+(349,585,o),
+(405,547,o),
+(461,524,c),
+(413,411,l),
+(303,411,ls)
+);
+}
+);
+width = 762;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni166C;
+unicode = 5740;
+},
+{
+glyphname = "qai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (346,0);
+ref = "ke-canadian";
+}
+);
+width = 960;
+}
+);
+note = uni166F;
+unicode = 5743;
+},
+{
+glyphname = "ngai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (646,0);
+ref = "ce-canadian";
+}
+);
+width = 1251;
+}
+);
+note = uni1670;
+unicode = 5744;
+},
+{
+glyphname = "nngi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (936,0);
+ref = "ci-canadian";
+}
+);
+width = 1538;
+}
+);
+note = uni1671;
+unicode = 5745;
+},
+{
+glyphname = "nngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (936,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (1153,0);
+ref = dot_top;
+}
+);
+width = 1538;
+}
+);
+note = uni1672;
+unicode = 5746;
+},
+{
+glyphname = "nngo-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (936,0);
+ref = "ce-canadian";
+}
+);
+width = 1538;
+}
+);
+note = uni1673;
+unicode = 5747;
+},
+{
+glyphname = "nngoo-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (936,0);
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (1135,0);
+ref = dot_top;
+}
+);
+width = 1538;
+}
+);
+note = uni1674;
+unicode = 5748;
+},
+{
+glyphname = "nnga-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (936,0);
+ref = "ca-canadian";
+}
+);
+width = 1538;
+}
+);
+note = uni1675;
+unicode = 5749;
+},
+{
+glyphname = "nngaa-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (936,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (978,0);
+ref = dot_top;
+}
+);
+width = 1538;
+}
+);
+note = uni1676;
+unicode = 5750;
+},
+{
+glyphname = "thweeWoodScree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 882;
+}
+);
+note = uni1677;
+unicode = 5751;
+},
+{
+glyphname = "thwiWoodScree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 882;
+}
+);
+note = uni1678;
+unicode = 5752;
+},
+{
+glyphname = "thwiiWoodScree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (87,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 882;
+}
+);
+note = uni1679;
+unicode = 5753;
+},
+{
+glyphname = "thwoWoodScree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 882;
+}
+);
+note = uni167A;
+unicode = 5754;
+},
+{
+glyphname = "thwooWoodScree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (356,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 882;
+}
+);
+note = uni167B;
+unicode = 5755;
+},
+{
+glyphname = "thwaWoodScree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 882;
+}
+);
+note = uni167C;
+unicode = 5756;
+},
+{
+glyphname = "thwaaWoodScree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (88,0);
+ref = dot_top;
+},
+{
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 882;
+}
+);
+note = uni167D;
+unicode = 5757;
+},
+{
+glyphname = "wBlackfoot-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(388,564,l),
+(388,656,l),
+(55,656,l),
+(55,564,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(388,415,l),
+(388,507,l),
+(55,507,l),
+(55,415,l)
+);
+}
+);
+width = 443;
+}
+);
+metricRight = "=|";
+note = uni167F;
+unicode = 5759;
+},
+{
+glyphname = "oy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-3,0);
+ref = ring_top.canadian;
+}
+);
+width = 690;
+}
+);
+note = uni18B0;
+unicode = 6320;
+},
+{
+glyphname = "ay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (418,0);
+ref = ring_top.canadian;
+}
+);
+width = 690;
+}
+);
+note = uni18B1;
+unicode = 6321;
+},
+{
+glyphname = "aay-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (180,0);
+ref = ring_top.canadian;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (457,0);
+ref = dot_top;
+}
+);
+width = 690;
+}
+);
+note = uni18B2;
+unicode = 6322;
+},
+{
+glyphname = "way-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (663,0);
+ref = ring_top.canadian;
+}
+);
+width = 935;
+}
+);
+note = uni18B3;
+unicode = 6323;
+},
+{
+glyphname = "poy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-22,0);
+ref = ring_top.canadian;
+}
+);
+width = 668;
+}
+);
+note = uni18B4;
+unicode = 6324;
+},
+{
+glyphname = "pay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (417,0);
+ref = ring_top.canadian;
+}
+);
+width = 668;
+}
+);
+note = uni18B5;
+unicode = 6325;
+},
+{
+glyphname = "pwoy-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (223,0);
+ref = ring_top.canadian;
+}
+);
+width = 912;
+}
+);
+note = uni18B6;
+unicode = 6326;
+},
+{
+glyphname = "tay-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (212,0);
+ref = ring_top.canadian;
+}
+);
+width = 639;
+}
+);
+note = uni18B7;
+unicode = 6327;
+},
+{
+glyphname = "kay-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (4,0);
+ref = ring_top.canadian;
+}
+);
+width = 614;
+}
+);
+note = uni18B8;
+unicode = 6328;
+},
+{
+glyphname = "kway-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (249,0);
+ref = ring_top.canadian;
+}
+);
+width = 859;
+}
+);
+note = uni18B9;
+unicode = 6329;
+},
+{
+glyphname = "may-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (11,0);
+ref = ring_top.canadian;
+}
+);
+width = 571;
+}
+);
+note = uni18BA;
+unicode = 6330;
+},
+{
+glyphname = "noy-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (384,-185);
+ref = ring_top.canadian;
+}
+);
+width = 826;
+}
+);
+note = uni18BB;
+unicode = 6331;
+},
+{
+glyphname = "nay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (169,-185);
+ref = ring_top.canadian;
+}
+);
+width = 826;
+}
+);
+note = uni18BC;
+unicode = 6332;
+},
+{
+glyphname = "lay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (169,-185);
+ref = ring_top.canadian;
+}
+);
+width = 826;
+}
+);
+note = uni18BD;
+unicode = 6333;
+},
+{
+glyphname = "soy-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (293,0);
+ref = ring_top.canadian;
+}
+);
+width = 577;
+}
+);
+note = uni18BE;
+unicode = 6334;
+},
+{
+glyphname = "say-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (12,0);
+ref = ring_top.canadian;
+}
+);
+width = 577;
+}
+);
+note = uni18BF;
+unicode = 6335;
+},
+{
+glyphname = "shoy-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (328,-185);
+ref = ring_top.canadian;
+}
+);
+width = 930;
+}
+);
+note = uni18C0;
+unicode = 6336;
+},
+{
+glyphname = "shay-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (328,-185);
+ref = ring_top.canadian;
+}
+);
+width = 930;
+}
+);
+note = uni18C1;
+unicode = 6337;
+},
+{
+glyphname = "shwoy-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (573,-185);
+ref = ring_top.canadian;
+}
+);
+width = 1175;
+}
+);
+note = uni18C2;
+unicode = 6338;
+},
+{
+glyphname = "yoy-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (317,0);
+ref = ring_top.canadian;
+}
+);
+width = 600;
+}
+);
+note = uni18C3;
+unicode = 6339;
+},
+{
+glyphname = "yay-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (12,0);
+ref = ring_top.canadian;
+}
+);
+width = 600;
+}
+);
+note = uni18C4;
+unicode = 6340;
+},
+{
+glyphname = "ray-canadian";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (185,0);
+ref = ring_top.canadian;
+}
+);
+width = 577;
+}
+);
+note = uni18C5;
+unicode = 6341;
+},
+{
+glyphname = "nwi-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ni-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni18C6;
+unicode = 6342;
+},
+{
+glyphname = "nwiOjibway-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (826,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni18C7;
+unicode = 6343;
+},
+{
+glyphname = "nwii-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (474,-185);
+ref = dot_top;
+}
+);
+width = 1071;
+}
+);
+note = uni18C8;
+unicode = 6344;
+},
+{
+glyphname = "nwiiOjibway-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (229,-185);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (826,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni18C9;
+unicode = 6345;
+},
+{
+glyphname = "nwo-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "no-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni18CA;
+unicode = 6346;
+},
+{
+glyphname = "nwoOjibway-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (826,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni18CB;
+unicode = 6347;
+},
+{
+glyphname = "nwoo-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (668,-185);
+ref = dot_top;
+}
+);
+width = 1071;
+}
+);
+note = uni18CC;
+unicode = 6348;
+},
+{
+glyphname = "nwooOjibway-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (423,-185);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (826,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni18CD;
+unicode = 6349;
+},
+{
+glyphname = "rwee-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "reRCree-canadian";
+}
+);
+width = 1121;
+}
+);
+note = uni18CE;
+unicode = 6350;
+},
+{
+glyphname = "rwi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ri-canadian";
+}
+);
+width = 1121;
+}
+);
+note = uni18CF;
+unicode = 6351;
+},
+{
+glyphname = "rwii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (467,-185);
+ref = dot_top;
+}
+);
+width = 1121;
+}
+);
+note = uni18D0;
+unicode = 6352;
+},
+{
+glyphname = "rwo-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ro-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni18D1;
+unicode = 6353;
+},
+{
+glyphname = "rwoo-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (403,0);
+ref = dot_top;
+}
+);
+width = 822;
+}
+);
+note = uni18D2;
+unicode = 6354;
+},
+{
+glyphname = "rwa-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = "ra-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni18D3;
+unicode = 6355;
+},
+{
+glyphname = "pOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(144,357,l),
+(252,593,l),
+(174,593,l),
+(283,357,l),
+(389,357,l),
+(389,377,l),
+(225,714,l),
+(200,714,l),
+(36,377,l),
+(36,357,l)
+);
+}
+);
+width = 425;
+}
+);
+metricLeft = "kkCarrier-canadian";
+note = uni18D4;
+unicode = 6356;
+},
+{
+glyphname = "tOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 444;
+}
+);
+metricRight = "=|";
+note = uni1422;
+unicode = 6357;
+},
+{
+glyphname = "kOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(168,357,l),
+(168,497,l),
+(147,496,l),
+(154,470,o),
+(184,449,o),
+(223,449,cs),
+(291,449,o),
+(344,500,o),
+(344,582,cs),
+(344,671,o),
+(281,720,o),
+(203,720,cs),
+(110,720,o),
+(55,663,o),
+(55,579,cs),
+(55,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(177,529,o),
+(158,547,o),
+(158,585,cs),
+(158,622,o),
+(176,639,o),
+(201,639,cs),
+(225,639,o),
+(244,622,o),
+(244,585,cs),
+(244,547,o),
+(225,529,o),
+(201,529,cs)
+);
+}
+);
+width = 389;
+}
+);
+metricLeft = "k-canadian";
+metricRight = "k-canadian";
+note = uni18D6;
+unicode = 6358;
+},
+{
+glyphname = "cOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(168,357,l),
+(168,589,ls),
+(168,617,o),
+(180,633,o),
+(203,633,cs),
+(227,633,o),
+(241,617,o),
+(241,591,cs),
+(241,563,l),
+(347,563,l),
+(347,583,ls),
+(347,669,o),
+(291,720,o),
+(203,720,cs),
+(106,720,o),
+(55,669,o),
+(55,574,cs),
+(55,357,l)
+);
+}
+);
+width = 379;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni18D7;
+unicode = 6359;
+},
+{
+glyphname = "mOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(168,357,l),
+(168,609,l),
+(310,609,l),
+(310,714,l),
+(55,714,l),
+(55,357,l)
+);
+}
+);
+width = 352;
+}
+);
+metricLeft = "m-canadian";
+metricRight = "m-canadian";
+note = uni18D8;
+unicode = 6360;
+},
+{
+glyphname = "nOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(277,443,o),
+(330,494,o),
+(330,573,cs),
+(330,614,o),
+(311,647,o),
+(290,658,c),
+(285,609,l),
+(447,609,l),
+(447,714,l),
+(193,714,ls),
+(99,714,o),
+(45,659,o),
+(45,579,cs),
+(45,497,o),
+(101,443,o),
+(188,443,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(163,523,o),
+(145,542,o),
+(145,579,cs),
+(145,615,o),
+(163,634,o),
+(188,634,cs),
+(213,634,o),
+(230,615,o),
+(230,579,cs),
+(230,543,o),
+(213,523,o),
+(188,523,cs)
+);
+}
+);
+width = 489;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "n-canadian";
+note = uni18D9;
+unicode = 6361;
+},
+{
+glyphname = "sOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(168,357,l),
+(168,501,l),
+(93,457,l),
+(139,457,ls),
+(249,457,o),
+(320,532,o),
+(320,656,cs),
+(320,714,l),
+(207,714,l),
+(207,660,ls),
+(207,580,o),
+(170,546,o),
+(93,546,cs),
+(55,546,l),
+(55,357,l)
+);
+}
+);
+width = 375;
+}
+);
+metricLeft = "s-canadian";
+metricRight = "s-canadian";
+note = uni18DA;
+unicode = 6362;
+},
+{
+color = 1;
+glyphname = "shOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(264,351,o),
+(313,402,o),
+(320,491,cs),
+(327,588,ls),
+(330,618,o),
+(339,637,o),
+(365,637,cs),
+(390,637,o),
+(401,618,o),
+(401,587,cs),
+(401,563,l),
+(504,563,l),
+(504,585,ls),
+(504,671,o),
+(452,720,o),
+(365,720,cs),
+(272,720,o),
+(223,669,o),
+(216,580,cs),
+(209,483,ls),
+(206,453,o),
+(197,434,o),
+(172,434,cs),
+(146,434,o),
+(135,453,o),
+(135,484,cs),
+(135,508,l),
+(32,508,l),
+(32,486,ls),
+(32,400,o),
+(85,351,o),
+(171,351,cs)
+);
+}
+);
+width = 536;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "c-canadian";
+note = uni18DB;
+unicode = 6363;
+},
+{
+color = 9;
+glyphname = "easternw-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (20,-318);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (172,0);
+ref = "glottalstop-canadian";
+}
+);
+width = 604;
+}
+);
+note = uni18DC;
+unicode = 6364;
+},
+{
+color = 9;
+glyphname = "westernw-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (582,-318);
+ref = dot_top;
+scale = (-1,1);
+},
+{
+alignment = -1;
+pos = (435,0);
+ref = "glottalstop-canadian";
+scale = (-1,1);
+}
+);
+width = 604;
+}
+);
+metricLeft = "glottalstop-canadian";
+note = uni18DD;
+unicode = 6365;
+},
+{
+glyphname = "rweRCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "reRCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (876,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1121;
+}
+);
+note = uni18E0;
+unicode = 6368;
+},
+{
+glyphname = "looWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+}
+);
+width = 577;
+}
+);
+note = uni18E1;
+unicode = 6369;
+},
+{
+glyphname = "laaWestCree-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (332,0);
+ref = dot_top;
+}
+);
+width = 577;
+}
+);
+note = uni18E2;
+unicode = 6370;
+},
+{
+glyphname = "thwe-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "the-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (760,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1005;
+}
+);
+note = uni18E3;
+unicode = 6371;
+},
+{
+glyphname = "thwa-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (702,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 947;
+}
+);
+note = uni18E4;
+unicode = 6372;
+},
+{
+glyphname = "tthwe-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "tthe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (751,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 996;
+}
+);
+note = uni18E5;
+unicode = 6373;
+},
+{
+glyphname = "tthoo-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ttho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (230,0);
+ref = dot_top;
+}
+);
+width = 649;
+}
+);
+note = uni18E6;
+unicode = 6374;
+},
+{
+glyphname = "tthaa-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ttha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (226,0);
+ref = dot_top;
+}
+);
+width = 649;
+}
+);
+note = uni18E7;
+unicode = 6375;
+},
+{
+glyphname = "tlhwe-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "tlhe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (633,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 878;
+}
+);
+note = uni18E8;
+unicode = 6376;
+},
+{
+glyphname = "tlhoo-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "tlho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (228,0);
+ref = dot_top;
+}
+);
+width = 633;
+}
+);
+note = uni18E9;
+unicode = 6377;
+},
+{
+glyphname = "shweSayisi-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "sheSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (622,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni18EA;
+unicode = 6378;
+},
+{
+glyphname = "shooSayisi-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "shoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (384,0);
+ref = dot_top;
+}
+);
+width = 622;
+}
+);
+note = uni18EB;
+unicode = 6379;
+},
+{
+color = 9;
+glyphname = "hooSayisi-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "hoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (481,0);
+ref = dot_top;
+}
+);
+width = 725;
+}
+);
+note = uni18EC;
+unicode = 6380;
+},
+{
+color = 9;
+glyphname = "gwuCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "guCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (883,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1128;
+}
+);
+note = uni18ED;
+unicode = 6381;
+},
+{
+color = 9;
+glyphname = "deneGeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "geCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (285,0);
+ref = dot_top;
+}
+);
+width = 760;
+}
+);
+note = uni18EE;
+unicode = 6382;
+},
+{
+color = 9;
+glyphname = "gaaCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (299,0);
+ref = dot_top;
+}
+);
+width = 760;
+}
+);
+note = uni18EF;
+unicode = 6383;
+},
+{
+color = 9;
+glyphname = "gwaCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (760,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1005;
+}
+);
+note = uni18F0;
+unicode = 6384;
+},
+{
+color = 9;
+glyphname = "juuSayisi-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "juSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (286,0);
+ref = dot_top;
+}
+);
+width = 763;
+}
+);
+note = uni18F1;
+unicode = 6385;
+},
+{
+color = 9;
+glyphname = "jwaCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "jaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (807,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1052;
+}
+);
+note = uni18F2;
+unicode = 6386;
+},
+{
+glyphname = "lBeaverDene-canadian";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+ref = "pWestCree-canadian";
+}
+);
+width = 223;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+unicode = 6387;
+},
+{
+glyphname = "rBeaverDene-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(168,357,l),
+(168,525,ls),
+(168,577,o),
+(189,604,o),
+(237,604,cs),
+(249,604,l),
+(249,720,l),
+(239,720,ls),
+(188,720,o),
+(155,680,o),
+(152,627,c),
+(159,627,l),
+(159,714,l),
+(55,714,l),
+(55,357,l)
+);
+}
+);
+width = 278;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni18F4;
+unicode = 6388;
+},
+{
+color = 6;
+glyphname = "sDentalCarrier-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(239,189,ls),
+(329,189,o),
+(373,229,o),
+(373,297,cs),
+(373,363,o),
+(330,409,o),
+(245,409,cs),
+(194,409,ls),
+(169,409,o),
+(154,417,o),
+(154,436,cs),
+(154,456,o),
+(169,463,o),
+(194,463,cs),
+(366,463,l),
+(366,546,l),
+(190,546,ls),
+(99,546,o),
+(55,506,o),
+(55,438,cs),
+(55,372,o),
+(98,326,o),
+(184,326,cs),
+(234,326,ls),
+(259,326,o),
+(274,318,o),
+(274,299,cs),
+(274,280,o),
+(260,272,o),
+(234,272,cs),
+(62,272,l),
+(62,189,l)
+);
+}
+);
+width = 428;
+}
+);
+metricLeft = "shCarrier-canadian";
+metricRight = "=|";
+note = uni18F5;
+unicode = 6389;
+},
+{
+glyphname = "pWestCree-canadian.base";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "pWestCree-canadian";
+}
+);
+width = 223;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.base";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "c-canadian";
+}
+);
+width = 379;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "thSayisi-canadian.base";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "thSayisi-canadian";
+}
+);
+width = 379;
+}
+);
+metricLeft = "=|c-canadian";
+note = uni14A2;
+},
+{
+glyphname = "mWestCree-canadian.base";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "mWestCree-canadian";
+}
+);
+width = 378;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+glyphname = "pWestCree-canadian.mid";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "pWestCree-canadian";
+}
+);
+width = 223;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.mid";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "c-canadian";
+}
+);
+width = 379;
+}
+);
+metricLeft = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "mWestCree-canadian.mid";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "mWestCree-canadian";
+}
+);
+width = 378;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+color = 11;
+glyphname = "ngaai-canadian.nunavik";
+lastChange = "2023-01-13 15:30:34 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (673,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (852,0);
+ref = ring_top.canadian;
+}
+);
+width = 1280;
+}
+);
+note = uni158E;
+},
+{
+color = 11;
+glyphname = "ngi-canadian.nunavik";
+lastChange = "2023-01-13 15:30:34 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (673,0);
+ref = "ci-canadian";
+}
+);
+width = 1280;
+}
+);
+note = uni158F;
+},
+{
+color = 11;
+glyphname = "ngii-canadian.nunavik";
+lastChange = "2023-01-13 15:30:34 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (673,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (892,0);
+ref = dot_top;
+}
+);
+width = 1280;
+}
+);
+note = uni1590;
+},
+{
+color = 11;
+glyphname = "ngo-canadian.nunavik";
+lastChange = "2023-01-13 15:30:34 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (673,0);
+ref = "co-canadian";
+}
+);
+width = 1280;
+}
+);
+note = uni1591;
+},
+{
+color = 11;
+glyphname = "ngoo-canadian.nunavik";
+lastChange = "2023-01-13 15:30:34 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+ref = "ngo-canadian.nunavik";
+},
+{
+anchor = top_right_can;
+pos = (1042,0);
+ref = dot_top;
+}
+);
+width = 1280;
+}
+);
+note = uni1592;
+},
+{
+color = 11;
+glyphname = "nga-canadian.nunavik";
+lastChange = "2023-01-13 15:30:34 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (673,0);
+ref = "ca-canadian";
+}
+);
+width = 1280;
+}
+);
+note = uni1593;
+},
+{
+color = 11;
+glyphname = "ngaa-canadian.nunavik";
+lastChange = "2023-01-13 15:30:34 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (673,0);
+ref = "ca-canadian";
+},
+{
+anchor = top_left_can;
+pos = (717,0);
+ref = dot_top;
+}
+);
+width = 1280;
+}
+);
+note = uni1594;
+},
+{
+color = 11;
+glyphname = "ng-canadian.nunavik";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(566,176,o),
+(628,225,o),
+(628,314,cs),
+(628,396,o),
+(576,447,o),
+(508,447,cs),
+(476,447,o),
+(452,432,o),
+(441,410,c),
+(453,402,l),
+(453,555,l),
+(301,555,l),
+(309,527,l),
+(321,539,o),
+(330,564,o),
+(330,591,cs),
+(330,670,o),
+(277,721,o),
+(188,721,cs),
+(101,721,o),
+(45,668,o),
+(45,585,cs),
+(45,505,o),
+(99,450,o),
+(193,450,cs),
+(414,450,l),
+(340,525,l),
+(340,316,ls),
+(340,232,o),
+(395,176,o),
+(488,176,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(461,256,o),
+(443,274,o),
+(443,311,cs),
+(443,349,o),
+(462,366,o),
+(485,366,cs),
+(510,366,o),
+(529,349,o),
+(529,311,cs),
+(529,274,o),
+(510,256,o),
+(486,256,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(163,531,o),
+(145,549,o),
+(145,585,cs),
+(145,622,o),
+(163,641,o),
+(188,641,cs),
+(213,641,o),
+(230,622,o),
+(230,585,cs),
+(230,550,o),
+(213,531,o),
+(188,531,cs)
+);
+}
+);
+width = 673;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+color = 11;
+glyphname = "ngai-canadian.nunavik";
+lastChange = "2023-01-13 15:30:34 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (673,0);
+ref = "ce-canadian";
+}
+);
+width = 1280;
+}
+);
+note = uni1670;
+},
+{
+color = 11;
+glyphname = "ke-canadian.square";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (369,714);
+},
+{
+name = top_left_can;
+pos = (154,714);
+},
+{
+name = top_right_can;
+pos = (602,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(685,0,l),
+(685,714,l),
+(386,714,ls),
+(175,714,o),
+(52,606,o),
+(52,424,cs),
+(52,242,o),
+(175,134,o),
+(386,134,cs),
+(518,134,l),
+(518,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(274,279,o),
+(219,330,o),
+(219,424,cs),
+(219,518,o),
+(274,569,o),
+(380,569,cs),
+(518,569,l),
+(518,279,l),
+(380,279,ls)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146B;
+},
+{
+color = 11;
+glyphname = "ki-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (381,714);
+},
+{
+name = top_left_can;
+pos = (148,714);
+},
+{
+name = top_right_can;
+pos = (614,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(231,0,l),
+(231,134,l),
+(363,134,ls),
+(574,134,o),
+(697,242,o),
+(697,424,cs),
+(697,606,o),
+(574,714,o),
+(363,714,cs),
+(65,714,l),
+(65,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(231,569,l),
+(369,569,ls),
+(475,569,o),
+(531,518,o),
+(531,424,cs),
+(531,330,o),
+(475,279,o),
+(369,279,cs),
+(231,279,l)
+);
+}
+);
+width = 749;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni146D;
+},
+{
+color = 11;
+glyphname = "kii-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (284,0);
+ref = dot_top;
+}
+);
+width = 749;
+}
+);
+note = uni146E;
+},
+{
+color = 11;
+glyphname = "ko-canadian.square";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (369,714);
+},
+{
+name = top_left_can;
+pos = (154,714);
+},
+{
+name = top_right_can;
+pos = (602,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(685,0,l),
+(685,714,l),
+(518,714,l),
+(518,580,l),
+(386,580,ls),
+(175,580,o),
+(52,472,o),
+(52,290,cs),
+(52,108,o),
+(175,0,o),
+(386,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(274,145,o),
+(219,196,o),
+(219,290,cs),
+(219,384,o),
+(274,435,o),
+(380,435,cs),
+(518,435,l),
+(518,145,l),
+(380,145,ls)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146F;
+},
+{
+color = 11;
+glyphname = "koo-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (505,0);
+ref = dot_top;
+}
+);
+width = 749;
+}
+);
+note = uni1470;
+},
+{
+color = 11;
+glyphname = "ka-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (381,714);
+},
+{
+name = top_left_can;
+pos = (148,714);
+},
+{
+name = top_right_can;
+pos = (614,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(363,0,ls),
+(574,0,o),
+(697,108,o),
+(697,290,cs),
+(697,472,o),
+(574,580,o),
+(363,580,cs),
+(231,580,l),
+(231,714,l),
+(65,714,l),
+(65,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(231,435,l),
+(369,435,ls),
+(475,435,o),
+(531,384,o),
+(531,290,cs),
+(531,196,o),
+(475,145,o),
+(369,145,cs),
+(231,145,l)
+);
+}
+);
+width = 749;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1472;
+},
+{
+color = 11;
+glyphname = "kaa-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+}
+);
+width = 749;
+}
+);
+note = uni1473;
+},
+{
+color = 11;
+glyphname = "kweWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (749,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 994;
+}
+);
+note = uni1475;
+},
+{
+color = 11;
+glyphname = "kwiiWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (284,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (749,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 994;
+}
+);
+note = uni1479;
+},
+{
+color = 11;
+glyphname = "kwoWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (749,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 994;
+}
+);
+note = uni147B;
+},
+{
+color = 11;
+glyphname = "kwooWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (505,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (749,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 994;
+}
+);
+note = uni147D;
+},
+{
+color = 11;
+glyphname = "kwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (749,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 994;
+}
+);
+note = uni147F;
+},
+{
+color = 11;
+glyphname = "kwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (749,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 994;
+}
+);
+note = uni1481;
+},
+{
+color = 11;
+glyphname = "ce-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (359,714);
+},
+{
+name = top_left_can;
+pos = (124,714);
+},
+{
+name = top_right_can;
+pos = (595,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(677,0,l),
+(677,396,ls),
+(677,614,o),
+(562,729,o),
+(356,729,cs),
+(152,729,o),
+(42,610,o),
+(42,418,cs),
+(42,390,l),
+(206,390,l),
+(206,423,ls),
+(206,526,o),
+(260,579,o),
+(353,579,cs),
+(461,579,o),
+(511,520,o),
+(511,392,cs),
+(511,0,l)
+);
+}
+);
+width = 735;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni1489;
+},
+{
+color = 11;
+glyphname = "ci-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (375,714);
+},
+{
+name = top_left_can;
+pos = (141,714);
+},
+{
+name = top_right_can;
+pos = (611,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(224,0,l),
+(224,392,ls),
+(224,520,o),
+(274,579,o),
+(382,579,cs),
+(475,579,o),
+(529,526,o),
+(529,423,cs),
+(529,390,l),
+(693,390,l),
+(693,418,ls),
+(693,610,o),
+(583,729,o),
+(378,729,cs),
+(173,729,o),
+(58,614,o),
+(58,396,cs),
+(58,0,l)
+);
+}
+);
+width = 735;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+},
+{
+color = 11;
+glyphname = "cii-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (278,0);
+ref = dot_top;
+}
+);
+width = 735;
+}
+);
+note = uni148C;
+},
+{
+color = 11;
+glyphname = "co-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (359,714);
+},
+{
+name = top_left_can;
+pos = (124,714);
+},
+{
+name = top_right_can;
+pos = (595,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(562,-15,o),
+(677,100,o),
+(677,318,cs),
+(677,714,l),
+(511,714,l),
+(511,322,ls),
+(511,194,o),
+(461,135,o),
+(353,135,cs),
+(260,135,o),
+(206,188,o),
+(206,291,cs),
+(206,324,l),
+(42,324,l),
+(42,296,ls),
+(42,104,o),
+(152,-15,o),
+(356,-15,cs)
+);
+}
+);
+width = 735;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+},
+{
+color = 11;
+glyphname = "coo-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (497,0);
+ref = dot_top;
+}
+);
+width = 735;
+}
+);
+note = uni148E;
+},
+{
+color = 11;
+glyphname = "ca-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (375,714);
+},
+{
+name = top_left_can;
+pos = (141,714);
+},
+{
+name = top_right_can;
+pos = (611,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(583,-15,o),
+(693,104,o),
+(693,296,cs),
+(693,324,l),
+(529,324,l),
+(529,291,ls),
+(529,188,o),
+(475,135,o),
+(382,135,cs),
+(274,135,o),
+(224,194,o),
+(224,322,cs),
+(224,714,l),
+(58,714,l),
+(58,318,ls),
+(58,100,o),
+(173,-15,o),
+(378,-15,cs)
+);
+}
+);
+width = 735;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+},
+{
+color = 11;
+glyphname = "caa-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (44,0);
+ref = dot_top;
+}
+);
+width = 735;
+}
+);
+note = uni1491;
+},
+{
+color = 11;
+glyphname = "me-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (310,714);
+},
+{
+name = top_double;
+pos = (491,714);
+},
+{
+name = top_left_can;
+pos = (119,714);
+},
+{
+name = top_right_can;
+pos = (491,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(574,0,l),
+(574,714,l),
+(37,714,l),
+(37,565,l),
+(408,565,l),
+(408,0,l)
+);
+}
+);
+width = 639;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+},
+{
+color = 11;
+glyphname = "mi-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (333,714);
+},
+{
+name = top_left_can;
+pos = (148,714);
+},
+{
+name = top_right_can;
+pos = (518,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(231,0,l),
+(231,565,l),
+(602,565,l),
+(601.998,714,l),
+(65,714,l),
+(65,0,l)
+);
+}
+);
+width = 639;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+},
+{
+color = 11;
+glyphname = "mii-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (236,0);
+ref = dot_top;
+}
+);
+width = 639;
+}
+);
+note = uni14A6;
+},
+{
+color = 11;
+glyphname = "mo-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (310,714);
+},
+{
+name = top_double;
+pos = (491,714);
+},
+{
+name = top_left_can;
+pos = (119,714);
+},
+{
+name = top_right_can;
+pos = (491,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(574,0,l),
+(574,714,l),
+(408,714,l),
+(408,149,l),
+(37,149,l),
+(37,0,l)
+);
+}
+);
+width = 639;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+},
+{
+color = 11;
+glyphname = "moo-canadian.square";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (394,0);
+ref = dot_top;
+}
+);
+width = 639;
+}
+);
+note = uni14A8;
+},
+{
+color = 11;
+glyphname = "ma-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (333,714);
+},
+{
+name = top_left_can;
+pos = (148,714);
+},
+{
+name = top_right_can;
+pos = (518,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(601.998,0,l),
+(602,149,l),
+(231,149,l),
+(231,714,l),
+(65,714,l),
+(65,0,l)
+);
+}
+);
+width = 639;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+},
+{
+color = 11;
+glyphname = "maa-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+}
+);
+width = 639;
+}
+);
+note = uni14AB;
+},
+{
+color = 11;
+glyphname = "ne-canadian.square";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (448,714);
+},
+{
+name = top_left_can;
+pos = (264,714);
+},
+{
+name = top_right_can;
+pos = (635,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(618,-15,o),
+(717,92,o),
+(717,274,cs),
+(717,714,l),
+(42,714,l),
+(42,568,l),
+(181,568,l),
+(181,275,ls),
+(181,92,o),
+(279,-15,o),
+(449,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(381,135,o),
+(346,177,o),
+(346,258,cs),
+(346,568,l),
+(551,568,l),
+(551,258,ls),
+(551,178,o),
+(517,135,o),
+(449,135,cs)
+);
+}
+);
+width = 775;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C0;
+},
+{
+color = 11;
+glyphname = "ni-canadian.square";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (326,714);
+},
+{
+name = top_left_can;
+pos = (141,714);
+},
+{
+name = top_right_can;
+pos = (511,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(495,-15,o),
+(594,92,o),
+(594,275,cs),
+(594,568,l),
+(733,568,l),
+(733,714,l),
+(58,714,l),
+(58,274,ls),
+(58,92,o),
+(156,-15,o),
+(326,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(258,135,o),
+(223,178,o),
+(223,258,cs),
+(223,568,l),
+(428,568,l),
+(428,258,ls),
+(428,177,o),
+(394,135,o),
+(326,135,cs)
+);
+}
+);
+width = 775;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+},
+{
+color = 11;
+glyphname = "nii-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (228,0);
+ref = dot_top;
+}
+);
+width = 774;
+}
+);
+note = uni14C3;
+},
+{
+color = 11;
+glyphname = "no-canadian.square";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (449,714);
+},
+{
+name = top_double;
+pos = (459,714);
+},
+{
+name = top_left_can;
+pos = (264,714);
+},
+{
+name = top_right_can;
+pos = (624,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(717,0,l),
+(717,440,ls),
+(717,622,o),
+(618,729,o),
+(449,729,cs),
+(279,729,o),
+(181,622,o),
+(181,439,cs),
+(181,146,l),
+(42,146,l),
+(42,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(346,456,ls),
+(346,537,o),
+(381,579,o),
+(449,579,cs),
+(517,579,o),
+(551,536,o),
+(551,456,cs),
+(551,146,l),
+(346,146,l)
+);
+}
+);
+width = 775;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C4;
+},
+{
+color = 11;
+glyphname = "noo-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (351,0);
+ref = dot_top;
+}
+);
+width = 774;
+}
+);
+note = uni14C5;
+},
+{
+color = 11;
+glyphname = "na-canadian.square";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (326,714);
+},
+{
+name = top_double;
+pos = (336,714);
+},
+{
+name = top_left_can;
+pos = (141,714);
+},
+{
+name = top_right_can;
+pos = (511,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(733,0,l),
+(733,146,l),
+(594,146,l),
+(594,439,ls),
+(594,622,o),
+(495,729,o),
+(326,729,cs),
+(156,729,o),
+(58,622,o),
+(58,440,cs),
+(58,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(223,456,ls),
+(223,536,o),
+(258,579,o),
+(326,579,cs),
+(394,579,o),
+(428,537,o),
+(428,456,cs),
+(428,146,l),
+(223,146,l)
+);
+}
+);
+width = 775;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+},
+{
+color = 11;
+glyphname = "naa-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (228,0);
+ref = dot_top;
+}
+);
+width = 774;
+}
+);
+note = uni14C8;
+},
+{
+color = 11;
+glyphname = "nweWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (774,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1019;
+}
+);
+note = uni14CA;
+},
+{
+color = 11;
+glyphname = "nwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (774,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1019;
+}
+);
+note = uni14CC;
+},
+{
+color = 11;
+glyphname = "nwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (228,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (774,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1019;
+}
+);
+note = uni14CE;
+},
+{
+color = 11;
+glyphname = "se-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (148,714);
+},
+{
+name = top_right_can;
+pos = (603,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(682,0,l),
+(682,319,l),
+(415,319,ls),
+(292,319,o),
+(230,383,o),
+(230,507,cs),
+(230,714,l),
+(64,714,l),
+(64,501,ls),
+(64,295,o),
+(193,174,o),
+(418,174,cs),
+(556,174,l),
+(516,215,l),
+(516,0,l)
+);
+}
+);
+width = 747;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14ED;
+},
+{
+color = 11;
+glyphname = "si-canadian.square";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (148,714);
+},
+{
+name = top_right_can;
+pos = (604,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(231,0,l),
+(231,215,l),
+(190,174,l),
+(329,174,ls),
+(553,174,o),
+(682,295,o),
+(682,494,cs),
+(682,714,l),
+(516,714,l),
+(516,500,ls),
+(516,383,o),
+(455,319,o),
+(335,319,cs),
+(65,319,l),
+(65,0,l)
+);
+}
+);
+width = 746;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+},
+{
+color = 11;
+glyphname = "sii-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (506,0);
+ref = dot_top;
+}
+);
+width = 747;
+}
+);
+note = uni14F0;
+},
+{
+color = 11;
+glyphname = "so-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (599,714);
+},
+{
+name = top_left_can;
+pos = (148,714);
+},
+{
+name = top_right_can;
+pos = (599,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(230,0,l),
+(230,207,ls),
+(230,331,o),
+(292,395,o),
+(415,395,cs),
+(682,395,l),
+(682,714,l),
+(516,714,l),
+(516,499,l),
+(556,540,l),
+(418,540,ls),
+(193,540,o),
+(64,419,o),
+(64,213,cs),
+(64,0,l)
+);
+}
+);
+width = 747;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+},
+{
+color = 11;
+glyphname = "soo-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (502,0);
+ref = dot_top;
+}
+);
+width = 747;
+}
+);
+note = uni14F2;
+},
+{
+color = 11;
+glyphname = "sa-canadian.square";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (148,714);
+},
+{
+name = top_right_can;
+pos = (600,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(682,0,l),
+(682,213,ls),
+(682,419,o),
+(553,540,o),
+(329,540,cs),
+(190,540,l),
+(231,499,l),
+(231,714,l),
+(65,714,l),
+(65,395,l),
+(332,395,ls),
+(455,395,o),
+(516,331,o),
+(516,207,cs),
+(516,0,l)
+);
+}
+);
+width = 746;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+},
+{
+color = 11;
+glyphname = "saa-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+}
+);
+width = 747;
+}
+);
+note = uni14F5;
+},
+{
+color = 11;
+glyphname = "sho-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (370,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(674,0,l),
+(674,135,l),
+(319,135,ls),
+(250,135,o),
+(219,160,o),
+(219,212,cs),
+(219,266,o),
+(250,291,o),
+(318,291,cs),
+(448,291,ls),
+(610,291,o),
+(687,366,o),
+(687,503,cs),
+(687,640,o),
+(610,714,o),
+(448,714,cs),
+(66,714,l),
+(66,579,l),
+(421,579,ls),
+(490,579,o),
+(521,554,o),
+(521,503,cs),
+(521,456,o),
+(490,424,o),
+(422,424,cs),
+(292,424,ls),
+(130,424,o),
+(53,348,o),
+(53,211,cs),
+(53,74,o),
+(130,0,o),
+(292,0,cs)
+);
+}
+);
+width = 740;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+color = 11;
+glyphname = "shoo-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (273,0);
+ref = dot_top;
+}
+);
+width = 740;
+}
+);
+note = g728;
+},
+{
+color = 11;
+glyphname = "sha-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (370,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(448,0,ls),
+(609,0,o),
+(687,74,o),
+(687,211,cs),
+(687,348,o),
+(609,424,o),
+(448,424,cs),
+(318,424,ls),
+(250,424,o),
+(219,456,o),
+(219,502,cs),
+(219,554,o),
+(250,579,o),
+(319,579,cs),
+(674,579,l),
+(674,714,l),
+(292,714,ls),
+(131,714,o),
+(53,640,o),
+(53,503,cs),
+(53,366,o),
+(131,291,o),
+(292,291,cs),
+(422,291,ls),
+(490,291,o),
+(521,266,o),
+(521,211,cs),
+(521,160,o),
+(490,135,o),
+(421,135,cs),
+(66,135,l),
+(66,0,l)
+);
+}
+);
+width = 740;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+color = 11;
+glyphname = "shaa-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (273,0);
+ref = dot_top;
+}
+);
+width = 740;
+}
+);
+note = g730;
+},
+{
+color = 11;
+glyphname = "ye-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (114,714);
+},
+{
+name = top_right_can;
+pos = (620,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(702,0,l),
+(702,319,l),
+(281,319,l),
+(281,234,l),
+(718,617,l),
+(615,726,l),
+(30,216,l),
+(30,174,l),
+(536,174,l),
+(536,0,l)
+);
+}
+);
+width = 761;
+}
+);
+metricLeft = "ye-canadian";
+note = uni1526;
+},
+{
+color = 11;
+glyphname = "yi-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (142,714);
+},
+{
+name = top_right_can;
+pos = (647,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(225,0,l),
+(225,174,l),
+(731,174,l),
+(731,216,l),
+(146,726,l),
+(43,617,l),
+(480,234,l),
+(480,319,l),
+(59,319,l),
+(59,0,l)
+);
+}
+);
+width = 761;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni1528;
+},
+{
+color = 11;
+glyphname = "yii-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (44,0);
+ref = dot_top;
+}
+);
+width = 761;
+}
+);
+note = uni1529;
+},
+{
+color = 11;
+glyphname = "yo-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (620,714);
+},
+{
+name = top_left_can;
+pos = (114,714);
+},
+{
+name = top_right_can;
+pos = (620,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(718,97,l),
+(281,480,l),
+(281,395,l),
+(702,395,l),
+(702,714,l),
+(536,714,l),
+(536,540,l),
+(30,540,l),
+(30,498,l),
+(615,-12,l)
+);
+}
+);
+width = 761;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152A;
+},
+{
+color = 11;
+glyphname = "yoo-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (522,0);
+ref = dot_top;
+}
+);
+width = 761;
+}
+);
+note = uni152B;
+},
+{
+color = 11;
+glyphname = "ya-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (142,714);
+},
+{
+name = top_right_can;
+pos = (647,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(731,498,l),
+(731,540,l),
+(225,540,l),
+(225,714,l),
+(59,714,l),
+(59,395,l),
+(480,395,l),
+(480,480,l),
+(43,97,l),
+(146,-12,l)
+);
+}
+);
+width = 761;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152D;
+},
+{
+color = 11;
+glyphname = "yaa-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (45,0);
+ref = dot_top;
+}
+);
+width = 761;
+}
+);
+note = uni152E;
+},
+{
+color = 11;
+glyphname = "re-canadian.square";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (326,714);
+},
+{
+name = top_left_can;
+pos = (141,714);
+},
+{
+name = top_right_can;
+pos = (511,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(496,-15,o),
+(594,92,o),
+(594,275,cs),
+(594,568,l),
+(733,568,l),
+(733,714,l),
+(428,714,l),
+(428,258,ls),
+(428,177,o),
+(394,135,o),
+(326,135,cs),
+(258,135,o),
+(223,178,o),
+(223,258,cs),
+(223,714,l),
+(58,714,l),
+(58,274,ls),
+(58,92,o),
+(156,-15,o),
+(326,-15,cs)
+);
+}
+);
+width = 775;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1542;
+},
+{
+color = 11;
+glyphname = "reRCree-canadian.square";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (449,714);
+},
+{
+name = top_left_can;
+pos = (264,714);
+},
+{
+name = top_right_can;
+pos = (635,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(618,-15,o),
+(717,92,o),
+(717,274,cs),
+(717,714,l),
+(551,714,l),
+(551,258,ls),
+(551,178,o),
+(517,135,o),
+(449,135,cs),
+(381,135,o),
+(346,177,o),
+(346,258,cs),
+(346,714,l),
+(42,714,l),
+(42,568,l),
+(181,568,l),
+(181,275,ls),
+(181,92,o),
+(278,-15,o),
+(449,-15,cs)
+);
+}
+);
+width = 775;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni1543;
+},
+{
+color = 11;
+glyphname = "leWestCree-canadian.square";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (449,714);
+},
+{
+name = top_left_can;
+pos = (264,714);
+},
+{
+name = top_right_can;
+pos = (635,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(346,0,l),
+(346,455,ls),
+(346,537,o),
+(381,578,o),
+(449,578,cs),
+(517,578,o),
+(551,536,o),
+(551,455,cs),
+(551,0,l),
+(717,0,l),
+(717,439,ls),
+(717,622,o),
+(618,728,o),
+(449,728,cs),
+(278,728,o),
+(181,622,o),
+(181,439,cs),
+(181,146,l),
+(42,146,l),
+(42,0,l)
+);
+}
+);
+width = 778;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+},
+{
+color = 11;
+glyphname = "ri-canadian.square";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (326,714);
+},
+{
+name = top_left_can;
+pos = (144,714);
+},
+{
+name = top_right_can;
+pos = (511,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(223,0,l),
+(223,456,ls),
+(223,536,o),
+(258,579,o),
+(326,579,cs),
+(394,579,o),
+(428,537,o),
+(428,456,cs),
+(428,0,l),
+(733,0,l),
+(733,146,l),
+(594,146,l),
+(594,439,ls),
+(594,622,o),
+(496,729,o),
+(326,729,cs),
+(156,729,o),
+(58,622,o),
+(58,440,cs),
+(58,0,l)
+);
+}
+);
+width = 775;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+},
+{
+color = 11;
+glyphname = "rii-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (228,0);
+ref = dot_top;
+}
+);
+width = 774;
+}
+);
+note = uni1547;
+},
+{
+color = 11;
+glyphname = "ro-canadian.square";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (372,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(231,0,l),
+(231,175,l),
+(184,134,l),
+(345,134,ls),
+(556,134,o),
+(678,242,o),
+(678,424,cs),
+(678,606,o),
+(556,714,o),
+(345,714,cs),
+(65,714,l),
+(65,569,l),
+(351,569,ls),
+(457,569,o),
+(512,518,o),
+(512,424,cs),
+(512,330,o),
+(457,279,o),
+(351,279,cs),
+(65,279,l),
+(65,0,l)
+);
+}
+);
+width = 730;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1548;
+},
+{
+color = 11;
+glyphname = "loWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (372,714);
+},
+{
+name = top_left_can;
+pos = (148,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(345,0,ls),
+(556,0,o),
+(678,108,o),
+(678,290,cs),
+(678,472,o),
+(556,580,o),
+(345,580,cs),
+(184,580,l),
+(231,539,l),
+(231,714,l),
+(65,714,l),
+(65,435,l),
+(351,435,ls),
+(457,435,o),
+(512,384,o),
+(512,290,cs),
+(512,196,o),
+(457,145,o),
+(351,145,cs),
+(65,145,l),
+(65,0,l)
+);
+}
+);
+width = 722;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+},
+{
+color = 11;
+glyphname = "ra-canadian.square";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (351,714);
+},
+{
+name = top_right_can;
+pos = (575,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(658,0,l),
+(658,279,l),
+(372,279,ls),
+(265,279,o),
+(210,330,o),
+(210,424,cs),
+(210,518,o),
+(265,569,o),
+(372,569,cs),
+(658,569,l),
+(658,714,l),
+(378,714,ls),
+(167,714,o),
+(44,606,o),
+(44,424,cs),
+(44,242,o),
+(167,134,o),
+(378,134,cs),
+(538,134,l),
+(492,175,l),
+(492,0,l)
+);
+}
+);
+width = 723;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+},
+{
+color = 11;
+glyphname = "raa-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (254,0);
+ref = dot_top;
+}
+);
+width = 722;
+}
+);
+note = uni154C;
+},
+{
+color = 11;
+glyphname = "laWestCree-canadian.square";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (575,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(658,0,l),
+(658,145,l),
+(372,145,ls),
+(265,145,o),
+(210,196,o),
+(210,290,cs),
+(210,384,o),
+(265,435,o),
+(372,435,cs),
+(658,435,l),
+(658,714,l),
+(492,714,l),
+(492,539,l),
+(538,580,l),
+(378,580,ls),
+(167,580,o),
+(44,472,o),
+(44,290,cs),
+(44,108,o),
+(167,0,o),
+(378,0,cs)
+);
+}
+);
+width = 723;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+},
+{
+color = 11;
+glyphname = "reWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(658,0,l),
+(908,208,l),
+(817,320,l),
+(571,117,l),
+(677,115,l),
+(677,396,ls),
+(677,614,o),
+(562,729,o),
+(356,729,cs),
+(152,729,o),
+(42,610,o),
+(42,418,cs),
+(42,390,l),
+(206,390,l),
+(206,423,ls),
+(206,526,o),
+(260,579,o),
+(353,579,cs),
+(461,579,o),
+(511,520,o),
+(511,392,cs),
+(511,0,l)
+);
+}
+);
+width = 927;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+},
+{
+color = 11;
+glyphname = "riWestCree-canadian.square";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(416,0,l),
+(416,392,ls),
+(416,520,o),
+(466,579,o),
+(574,579,cs),
+(668,579,o),
+(721,526,o),
+(721,423,cs),
+(721,390,l),
+(886,390,l),
+(886,418,ls),
+(886,610,o),
+(775,729,o),
+(571,729,cs),
+(366,729,o),
+(250,614,o),
+(250,396,cs),
+(250,115,l),
+(356,117,l),
+(110,320,l),
+(19,208,l),
+(270,0,l)
+);
+}
+);
+width = 928;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+},
+{
+color = 11;
+glyphname = "roWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(562,-15,o),
+(677,100,o),
+(677,318,cs),
+(677,599,l),
+(571,597,l),
+(817,394,l),
+(908,506,l),
+(658,714,l),
+(511,714,l),
+(511,322,ls),
+(511,194,o),
+(461,135,o),
+(353,135,cs),
+(260,135,o),
+(206,188,o),
+(206,291,cs),
+(206,324,l),
+(42,324,l),
+(42,296,ls),
+(42,104,o),
+(152,-15,o),
+(356,-15,cs)
+);
+}
+);
+width = 927;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+},
+{
+color = 11;
+glyphname = "raWestCree-canadian.square";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(775,-15,o),
+(886,104,o),
+(886,296,cs),
+(886,324,l),
+(721,324,l),
+(721,291,ls),
+(721,188,o),
+(668,135,o),
+(574,135,cs),
+(466,135,o),
+(416,194,o),
+(416,322,cs),
+(416,714,l),
+(270,714,l),
+(19,506,l),
+(110,394,l),
+(356,597,l),
+(250,599,l),
+(250,318,ls),
+(250,100,o),
+(366,-15,o),
+(571,-15,cs)
+);
+}
+);
+width = 928;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+},
+{
+color = 11;
+glyphname = "theThCree-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (114,714);
+},
+{
+name = top_right_can;
+pos = (620,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(536,52,l),
+(536,0,l),
+(702,0,l),
+(702,52,l),
+(784,52,l),
+(784,124,l),
+(702,124,l),
+(702,319,l),
+(281,319,l),
+(281,234,l),
+(718,617,l),
+(615,726,l),
+(30,216,l),
+(30,174,l),
+(536,174,l),
+(536,124,l),
+(317,124,l),
+(317,52,l)
+);
+}
+);
+width = 812;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15A7;
+},
+{
+color = 11;
+glyphname = "thiThCree-canadian.square";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (191,714);
+},
+{
+name = top_right_can;
+pos = (695,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(276,0,l),
+(276,52,l),
+(495,52,l),
+(495,124,l),
+(276,124,l),
+(276,174,l),
+(781,174,l),
+(781,216,l),
+(197,726,l),
+(94,617,l),
+(531,234,l),
+(531,319,l),
+(110,319,l),
+(110,124,l),
+(28,124,l),
+(28,52,l),
+(110,52,l),
+(110,0,l)
+);
+}
+);
+width = 811;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+},
+{
+color = 11;
+glyphname = "thiiThCree-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (94,0);
+ref = dot_top;
+}
+);
+width = 812;
+}
+);
+note = uni15A9;
+},
+{
+color = 11;
+glyphname = "thoThCree-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (114,714);
+},
+{
+name = top_right_can;
+pos = (620,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(718,97,l),
+(281,480,l),
+(281,395,l),
+(702,395,l),
+(702,590,l),
+(784,590,l),
+(784,662,l),
+(702,662,l),
+(702,714,l),
+(536,714,l),
+(536,662,l),
+(317,662,l),
+(317,590,l),
+(536,590,l),
+(536,540,l),
+(30,540,l),
+(30,498,l),
+(615,-12,l)
+);
+}
+);
+width = 812;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+},
+{
+color = 11;
+glyphname = "thooThCree-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (522,0);
+ref = dot_top;
+}
+);
+width = 812;
+}
+);
+note = uni15AB;
+},
+{
+color = 11;
+glyphname = "thaThCree-canadian.square";
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (193,714);
+},
+{
+name = top_right_can;
+pos = (697,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(781,498,l),
+(781,540,l),
+(276,540,l),
+(276,590,l),
+(495,590,l),
+(495,662,l),
+(276,662,l),
+(276,714,l),
+(110,714,l),
+(110,662,l),
+(28,662,l),
+(28,590,l),
+(110,590,l),
+(110,395,l),
+(531,395,l),
+(531,480,l),
+(94,97,l),
+(197,-12,l)
+);
+}
+);
+width = 811;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+},
+{
+color = 11;
+glyphname = "thaaThCree-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (96,0);
+ref = dot_top;
+}
+);
+width = 812;
+}
+);
+note = uni15AD;
+},
+{
+color = 11;
+glyphname = "thweeWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (812,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1057;
+}
+);
+note = uni1677;
+},
+{
+color = 11;
+glyphname = "thwiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (812,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1057;
+}
+);
+note = uni1678;
+},
+{
+color = 11;
+glyphname = "thwiiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (94,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (812,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1057;
+}
+);
+note = uni1679;
+},
+{
+color = 11;
+glyphname = "thwoWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (812,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1057;
+}
+);
+note = uni167A;
+},
+{
+color = 11;
+glyphname = "thwooWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (522,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (812,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1057;
+}
+);
+note = uni167B;
+},
+{
+color = 11;
+glyphname = "thwaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (812,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1057;
+}
+);
+note = uni167C;
+},
+{
+color = 11;
+glyphname = "thwaaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (96,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (812,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1057;
+}
+);
+note = uni167D;
+},
+{
+color = 11;
+glyphname = "nwiOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (774,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1019;
+}
+);
+note = uni18C7;
+},
+{
+color = 11;
+glyphname = "nwiiOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (228,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (774,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1019;
+}
+);
+note = uni18C9;
+},
+{
+color = 11;
+glyphname = "nwoOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (774,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1019;
+}
+);
+note = uni18CB;
+},
+{
+color = 11;
+glyphname = "nwooOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (351,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (774,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1019;
+}
+);
+note = uni18CD;
+},
+{
+color = 11;
+glyphname = "looWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+}
+);
+width = 722;
+}
+);
+note = uni18E1;
+},
+{
+color = 11;
+glyphname = "laaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (478,0);
+ref = dot_top;
+}
+);
+width = 722;
+}
+);
+note = uni18E2;
+},
+{
+color = 0;
+glyphname = zero;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(558,593,o),
+(478,724,o),
+(305,724,cs),
+(131,724,o),
+(52,592,o),
+(52,357,cs),
+(52,114,o),
+(139,-10,o),
+(305,-10,cs),
+(477,-10,o),
+(558,108,o),
+(558,357,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(221,439,o),
+(222,589,o),
+(305,589,cs),
+(390,589,o),
+(390,438,o),
+(390,357,cs),
+(390,265,o),
+(385,125,o),
+(305,125,cs),
+(227,125,o),
+(221,265,o),
+(221,357,cs)
+);
+}
+);
+width = 610;
+}
+);
+unicode = 48;
+},
+{
+color = 0;
+glyphname = one;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(250,714,l),
+(12,522,l),
+(100,414,l),
+(187,484,ls),
+(203,497,o),
+(216,511,o),
+(233,530,c),
+(231,480,o),
+(230,438,o),
+(230,394,cs),
+(230,0,l),
+(402,0,l),
+(402,714,l)
+);
+}
+);
+width = 527;
+}
+);
+unicode = 49;
+},
+{
+color = 0;
+glyphname = two;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(546,0,l),
+(546,140,l),
+(258,140,l),
+(258,144,l),
+(332,216,ls),
+(419,297,o),
+(478,356,o),
+(508,421,cs),
+(522,453,o),
+(529,490,o),
+(529,530,cs),
+(529,643,o),
+(436,724,o),
+(298,724,cs),
+(175,724,o),
+(106,679,o),
+(36,616,c),
+(129,507,l),
+(187,557,o),
+(232,582,o),
+(279,582,cs),
+(326,582,o),
+(362,559,o),
+(362,507,cs),
+(362,467,o),
+(346,435,o),
+(306,388,cs),
+(285,364,o),
+(257,334,o),
+(221,297,cs),
+(40,112,l),
+(40,0,l)
+);
+}
+);
+width = 595;
+}
+);
+unicode = 50;
+},
+{
+color = 0;
+glyphname = three;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(513,662,o),
+(424,724,o),
+(282,724,cs),
+(163,724,o),
+(93,692,o),
+(35,652,c),
+(105,538,l),
+(137,559,o),
+(193,588,o),
+(256,588,cs),
+(312,588,o),
+(349,566,o),
+(349,518,cs),
+(349,448,o),
+(265,430,o),
+(194,430,cs),
+(143,430,l),
+(143,302,l),
+(193,302,ls),
+(308,302,o),
+(356,277,o),
+(356,213,cs),
+(356,158,o),
+(321,124,o),
+(220,124,cs),
+(164,124,o),
+(94,139,o),
+(33,170,c),
+(33,29,l),
+(92,5,o),
+(154,-10,o),
+(244,-10,cs),
+(407,-10,o),
+(534,60,o),
+(534,203,cs),
+(534,305,o),
+(470,359,o),
+(356,373,c),
+(356,376,l),
+(445,400,o),
+(513,460,o),
+(513,558,cs)
+);
+}
+);
+width = 578;
+}
+);
+unicode = 51;
+},
+{
+color = 0;
+glyphname = four;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(491,273,l),
+(491,715,l),
+(335,715,l),
+(27,270,l),
+(27,146,l),
+(325,146,l),
+(325,0,l),
+(491,0,l),
+(491,146,l),
+(578,146,l),
+(578,273,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(175,273,l),
+(282,428,ls),
+(301,457,o),
+(310,471,o),
+(324,501,c),
+(329,501,l),
+(329,495,o),
+(325,460,o),
+(325,398,cs),
+(325,273,l)
+);
+}
+);
+width = 609;
+}
+);
+unicode = 52;
+},
+{
+color = 0;
+glyphname = five;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(263,462,o),
+(243,456,o),
+(220,451,c),
+(231,573,l),
+(484,573,l),
+(484,714,l),
+(88,714,l),
+(60,345,l),
+(124,313,l),
+(154,322,o),
+(191,331,o),
+(230,331,cs),
+(317,331,o),
+(361,293,o),
+(361,230,cs),
+(361,161,o),
+(313,124,o),
+(233,124,cs),
+(172,124,o),
+(96,146,o),
+(46,169,c),
+(46,29,l),
+(98,4,o),
+(165,-10,o),
+(247,-10,cs),
+(436,-10,o),
+(531,78,o),
+(531,235,cs),
+(531,378,o),
+(440,462,o),
+(313,462,cs)
+);
+}
+);
+width = 582;
+}
+);
+unicode = 53;
+},
+{
+color = 0;
+glyphname = six;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(53,119,o),
+(144,-10,o),
+(317,-10,cs),
+(470,-10,o),
+(564,84,o),
+(564,241,cs),
+(564,387,o),
+(488,471,o),
+(362,471,cs),
+(282,471,o),
+(237,433,o),
+(211,383,c),
+(206,383,l),
+(212,515,o),
+(265,592,o),
+(413,592,cs),
+(460,592,o),
+(492,588,o),
+(518,582,c),
+(518,716,l),
+(491,720,o),
+(446,724,o),
+(417,724,cs),
+(152,724,o),
+(53,560,o),
+(53,302,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(251,125,o),
+(222,183,o),
+(222,251,cs),
+(222,297,o),
+(261,340,o),
+(316,340,cs),
+(374,340,o),
+(400,302,o),
+(400,238,cs),
+(400,162,o),
+(366,125,o),
+(314,125,cs)
+);
+}
+);
+width = 602;
+}
+);
+unicode = 54;
+},
+{
+color = 0;
+glyphname = seven;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(532,614,l),
+(532,714,l),
+(26,714,l),
+(26,573,l),
+(351,573,l),
+(99,0,l),
+(274,0,l)
+);
+}
+);
+width = 556;
+}
+);
+unicode = 55;
+},
+{
+color = 0;
+glyphname = eight;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(445,-10,o),
+(553,54,o),
+(553,189,cs),
+(553,284,o),
+(477,339,o),
+(402,377,c),
+(479,413,o),
+(531,466,o),
+(531,552,cs),
+(531,667,o),
+(437,724,o),
+(299,724,cs),
+(158,724,o),
+(65,662,o),
+(65,552,cs),
+(65,466,o),
+(119,413,o),
+(182,374,c),
+(101,337,o),
+(44,287,o),
+(44,186,cs),
+(44,70,o),
+(124,-10,o),
+(297,-10,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(236,113,o),
+(199,145,o),
+(199,193,cs),
+(199,246,o),
+(244,278,o),
+(296,302,c),
+(352,274,o),
+(397,240,o),
+(397,190,cs),
+(397,141,o),
+(362,113,o),
+(295,113,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(255,471,o),
+(224,498,o),
+(224,537,cs),
+(224,577,o),
+(257,601,o),
+(299,601,cs),
+(340,601,o),
+(373,578,o),
+(373,537,cs),
+(373,494,o),
+(337,470,o),
+(297,450,c)
+);
+}
+);
+width = 596;
+}
+);
+unicode = 56;
+},
+{
+color = 0;
+glyphname = nine;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(548,594,o),
+(459,724,o),
+(285,724,cs),
+(132,724,o),
+(38,631,o),
+(38,474,cs),
+(38,327,o),
+(114,243,o),
+(236,243,cs),
+(320,243,o),
+(364,280,o),
+(390,331,c),
+(395,331,l),
+(388,186,o),
+(320,122,o),
+(178,122,cs),
+(140,122,o),
+(112,125,o),
+(84,131,c),
+(84,-4,l),
+(111,-9,o),
+(155,-10,o),
+(185,-10,cs),
+(448,-10,o),
+(548,154,o),
+(548,403,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(352,589,o),
+(379,524,o),
+(379,463,cs),
+(379,419,o),
+(338,374,o),
+(287,374,cs),
+(231,374,o),
+(202,413,o),
+(202,476,cs),
+(202,552,o),
+(233,589,o),
+(289,589,cs)
+);
+}
+);
+width = 601;
+}
+);
+unicode = 57;
+},
+{
+glyphname = zero.canadian;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(588,604,o),
+(482,729,o),
+(317,729,cs),
+(152,729,o),
+(46,604,o),
+(46,357,cs),
+(46,110,o),
+(152,-12,o),
+(317,-12,cs),
+(482,-12,o),
+(588,110,o),
+(588,357,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(211,514,o),
+(248,580,o),
+(317,580,cs),
+(386,580,o),
+(423,514,o),
+(423,357,cs),
+(423,200,o),
+(387,136,o),
+(317,136,cs),
+(247,136,o),
+(211,200,o),
+(211,357,cs)
+);
+}
+);
+width = 634;
+}
+);
+metricRight = "=|";
+},
+{
+glyphname = one.canadian;
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(378,0,l),
+(378,714,l),
+(229,714,l),
+(6,527,l),
+(96,415,l),
+(316,597,l),
+(211,605,l),
+(211,0,l)
+);
+}
+);
+width = 443;
+}
+);
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = two.canadian;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(567,149,l),
+(261,149,l),
+(262,97,l),
+(446,279,ls),
+(532,363,o),
+(555,433,o),
+(555,507,cs),
+(555,641,o),
+(458,729,o),
+(311,729,cs),
+(145,729,o),
+(44,623,o),
+(42,464,c),
+(206,464,l),
+(206,542,o),
+(242,585,o),
+(305,585,cs),
+(360,585,o),
+(389,552,o),
+(389,500,cs),
+(389,456,o),
+(374,411,o),
+(312,350,cs),
+(66,109,l),
+(66,0,l),
+(567,0,l)
+);
+}
+);
+width = 609;
+}
+);
+note = uni14BF;
+},
+{
+glyphname = three.canadian;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(468,-15,o),
+(570,71,o),
+(570,202,cs),
+(570,292,o),
+(519,366,o),
+(419,385,c),
+(416,330,l),
+(511,348,o),
+(561,424,o),
+(561,510,cs),
+(561,643,o),
+(465,729,o),
+(317,729,cs),
+(153,729,o),
+(59,623,o),
+(51,475,c),
+(215,475,l),
+(217,540,o),
+(247,585,o),
+(315,585,cs),
+(368,585,o),
+(395,555,o),
+(395,502,cs),
+(395,449,o),
+(370,426,o),
+(321,426,cs),
+(287,426,l),
+(287,289,l),
+(323,289,ls),
+(376,289,o),
+(403,263,o),
+(403,211,cs),
+(403,157,o),
+(372,129,o),
+(312,129,cs),
+(239,129,o),
+(210,174,o),
+(209,239,c),
+(44,239,l),
+(49,86,o),
+(142,-15,o),
+(314,-15,cs)
+);
+}
+);
+width = 631;
+}
+);
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = four.canadian;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(498,0,l),
+(498,147,l),
+(586,147,l),
+(586,281,l),
+(498,281,l),
+(498,715,l),
+(368,715,l),
+(34,253,l),
+(34,147,l),
+(335,147,l),
+(335,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(392,556,l),
+(338,556,l),
+(338,281,l),
+(164,281,l),
+(170,240,l)
+);
+}
+);
+width = 613;
+}
+);
+},
+{
+glyphname = five.canadian;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(482,-15,o),
+(578,84,o),
+(578,228,cs),
+(578,369,o),
+(486,451,o),
+(326,451,cs),
+(211,451,l),
+(258,410,l),
+(274,613,l),
+(223,570,l),
+(544,570,l),
+(544,714,l),
+(123,714,l),
+(94,346,l),
+(128,310,l),
+(301,310,ls),
+(378,310,o),
+(415,284,o),
+(415,223,cs),
+(415,164,o),
+(379,129,o),
+(320,129,cs),
+(257,129,o),
+(225,163,o),
+(222,218,c),
+(58,218,l),
+(65,72,o),
+(163,-15,o),
+(320,-15,cs)
+);
+}
+);
+width = 627;
+}
+);
+},
+{
+glyphname = six.canadian;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(492,-15,o),
+(592,80,o),
+(592,222,cs),
+(592,364,o),
+(495,451,o),
+(356,451,cs),
+(275,451,o),
+(215,421,o),
+(180,359,c),
+(215,309,l),
+(212,334,o),
+(211,353,o),
+(211,405,cs),
+(211,522,o),
+(247,586,o),
+(330,586,cs),
+(387,586,o),
+(423,549,o),
+(427,497,c),
+(592,497,l),
+(577,639,o),
+(485,729,o),
+(335,729,cs),
+(160,729,o),
+(46,606,o),
+(46,366,cs),
+(46,222,o),
+(70,128,o),
+(132,61,cs),
+(179,11,o),
+(247,-15,o),
+(331,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(264,123,o),
+(223,160,o),
+(223,223,cs),
+(223,280,o),
+(263,316,o),
+(329,316,cs),
+(395,316,o),
+(432,280,o),
+(432,219,cs),
+(432,159,o),
+(394,123,o),
+(328,123,cs)
+);
+}
+);
+width = 632;
+}
+);
+metricLeft = zero.canadian;
+},
+{
+glyphname = seven.canadian;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(494,614,l),
+(494,714,l),
+(32,714,l),
+(32,565,l),
+(328,565,l),
+(327,611,l),
+(102,40,l),
+(102,0,l),
+(267,0,l)
+);
+}
+);
+width = 524;
+}
+);
+},
+{
+glyphname = eight.canadian;
+lastChange = "2023-01-13 15:30:29 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(490,-15,o),
+(598,72,o),
+(598,198,cs),
+(598,299,o),
+(535,367,o),
+(434,384,c),
+(428,330,l),
+(522,347,o),
+(582,415,o),
+(582,516,cs),
+(582,642,o),
+(481,729,o),
+(329,729,cs),
+(178,729,o),
+(76,642,o),
+(76,516,cs),
+(76,415,o),
+(136,347,o),
+(230,330,c),
+(224,384,l),
+(124,367,o),
+(61,299,o),
+(61,198,cs),
+(61,72,o),
+(168,-15,o),
+(329,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(262,121,o),
+(226,151,o),
+(226,206,cs),
+(226,261,o),
+(262,291,o),
+(329,291,cs),
+(396,291,o),
+(433,261,o),
+(433,206,cs),
+(433,151,o),
+(396,121,o),
+(329,121,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(271,424,o),
+(241,452,o),
+(241,508,cs),
+(241,563,o),
+(271,593,o),
+(329,593,cs),
+(388,593,o),
+(418,563,o),
+(418,508,cs),
+(418,452,o),
+(388,424,o),
+(329,424,cs)
+);
+}
+);
+width = 659;
+}
+);
+metricLeft = "=|";
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = nine.canadian;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(472,-15,o),
+(586,108,o),
+(586,348,cs),
+(586,492,o),
+(562,586,o),
+(500,653,cs),
+(453,703,o),
+(385,729,o),
+(300,729,cs),
+(140,729,o),
+(40,634,o),
+(40,492,cs),
+(40,350,o),
+(137,263,o),
+(276,263,cs),
+(357,263,o),
+(417,293,o),
+(452,355,c),
+(417,405,l),
+(420,380,o),
+(421,361,o),
+(421,309,cs),
+(421,192,o),
+(385,131,o),
+(302,131,cs),
+(245,131,o),
+(209,165,o),
+(204,217,c),
+(40,217,l),
+(55,75,o),
+(147,-15,o),
+(296,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(237,398,o),
+(200,434,o),
+(200,495,cs),
+(200,555,o),
+(238,591,o),
+(303,591,cs),
+(368,591,o),
+(409,554,o),
+(409,491,cs),
+(409,434,o),
+(369,398,o),
+(303,398,cs)
+);
+}
+);
+width = 632;
+}
+);
+metricLeft = "=|six.canadian";
+metricRight = "=|six.canadian";
+},
+{
+glyphname = CR;
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+width = 265;
+}
+);
+note = CR;
+unicode = 13;
+},
+{
+color = 0;
+glyphname = .notdef;
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(505,714,l),
+(94,714,l),
+(94,0,l),
+(505,0,l),
+(505,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(454,663,l),
+(454,51,l),
+(145,51,l),
+(145,663,l),
+(145,663,l)
+);
+}
+);
+width = 600;
+}
+);
+note = ".notdef";
+},
+{
+glyphname = .null;
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+width = 0;
+}
+);
+note = NULL;
+},
+{
+glyphname = space;
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+width = 266;
+}
+);
+note = space;
+unicode = 32;
+},
+{
+glyphname = nbspace;
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+width = 265;
+}
+);
+note = uni00A0;
+unicode = 160;
+},
+{
+glyphname = space.canadian;
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+width = 534;
+}
+);
+note = space;
+},
+{
+glyphname = "hyphen-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(388,396,l),
+(388,488,l),
+(55,488,l),
+(55,396,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(388,247,l),
+(388,339,l),
+(55,339,l),
+(55,247,l)
+);
+}
+);
+width = 443;
+}
+);
+metricRight = "=|";
+note = uni1400;
+unicode = 5120;
+},
+{
+glyphname = "chi-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(190,0,l),
+(344,280,l),
+(273,280,l),
+(425,0,l),
+(579,0,l),
+(579,40,l),
+(361,427,l),
+(360,298,l),
+(576,674,l),
+(576,714,l),
+(422,714,l),
+(272,440,l),
+(343,440,l),
+(193,714,l),
+(39,714,l),
+(39,674,l),
+(254,297,l),
+(254,426,l),
+(36,40,l),
+(36,0,l)
+);
+}
+);
+width = 615;
+}
+);
+metricRight = "=|";
+note = uni166D;
+unicode = 5741;
+},
+{
+glyphname = "fullstop-canadian";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(342,0,l),
+(342,19,l),
+(240,197,l),
+(242,158,l),
+(341,337,l),
+(341,357,l),
+(243,357,l),
+(175,221,l),
+(216,229,l),
+(147,357,l),
+(50,357,l),
+(50,337,l),
+(148,167,l),
+(149,205,l),
+(49,19,l),
+(49,0,l),
+(146,0,l),
+(221,148,l),
+(170,139,l),
+(244,0,l)
+);
+}
+);
+width = 391;
+}
+);
+note = uni1541;
+unicode = 5742;
+},
+{
+glyphname = period;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(45,14,o),
+(86,-11,o),
+(138,-11,cs),
+(188,-11,o),
+(227,14,o),
+(227,73,cs),
+(227,134,o),
+(188,158,o),
+(138,158,cs),
+(86,158,o),
+(45,134,o),
+(45,73,cs)
+);
+}
+);
+width = 272;
+}
+);
+note = period;
+unicode = 46;
+},
+{
+glyphname = comma;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(143,-138,l),
+(178,-59,o),
+(207,52,o),
+(226,131,c),
+(219,142,l),
+(75,142,l),
+(67,63,o),
+(48,-41,o),
+(26,-138,c)
+);
+}
+);
+width = 281;
+}
+);
+note = comma;
+unicode = 44;
+},
+{
+glyphname = hyphen;
+kernLeft = hyphen;
+kernRight = hyphen;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(272,335,l),
+(24,335,l),
+(24,202,l),
+(272,202,l)
+);
+}
+);
+width = 296;
+}
+);
+unicode = 45;
+},
+{
+glyphname = quotesinglbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (30,-572);
+ref = quoteright;
+}
+);
+width = 311;
+}
+);
+unicode = 8218;
+},
+{
+glyphname = quotedblbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+pos = (30,-572);
+ref = quotedblright;
+}
+);
+width = 546;
+}
+);
+unicode = 8222;
+},
+{
+glyphname = quotedblleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(394,434,l),
+(404,516,o),
+(422,613,o),
+(444,713,c),
+(328,713,l),
+(295,638,o),
+(266,538,o),
+(244,445,c),
+(251,434,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(164,434,l),
+(174,516,o),
+(192,613,o),
+(214,713,c),
+(98,713,l),
+(65,638,o),
+(36,538,o),
+(14,445,c),
+(21,434,l)
+);
+}
+);
+width = 464;
+}
+);
+unicode = 8220;
+},
+{
+glyphname = quotedblright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(366,434,l),
+(402,512,o),
+(432,622,o),
+(450,702,c),
+(443,713,l),
+(300,713,l),
+(293,635,o),
+(274,529,o),
+(250,434,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(136,434,l),
+(172,512,o),
+(201,622,o),
+(220,702,c),
+(213,713,l),
+(70,713,l),
+(63,636,o),
+(43,528,o),
+(20,434,c)
+);
+}
+);
+width = 464;
+}
+);
+unicode = 8221;
+},
+{
+glyphname = quoteleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(167,434,l),
+(177,515,o),
+(194,613,o),
+(217,713,c),
+(98,713,l),
+(65,638,o),
+(36,538,o),
+(14,445,c),
+(21,434,l)
+);
+}
+);
+width = 237;
+}
+);
+unicode = 8216;
+},
+{
+glyphname = quoteright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(139,434,l),
+(175,512,o),
+(204,622,o),
+(223,702,c),
+(216,713,l),
+(70,713,l),
+(63,636,o),
+(43,528,o),
+(20,434,c)
+);
+}
+);
+width = 237;
+}
+);
+unicode = 8217;
+},
+{
+glyphname = dottedCircle;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,522,o),
+(187,511,o),
+(187,496,cs),
+(187,483,o),
+(200,470,o),
+(213,470,cs),
+(228,470,o),
+(239,483,o),
+(239,496,cs),
+(239,511,o),
+(228,522,o),
+(213,522,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(368,522,o),
+(355,511,o),
+(355,496,cs),
+(355,483,o),
+(368,470,o),
+(381,470,cs),
+(396,470,o),
+(407,483,o),
+(407,496,cs),
+(407,511,o),
+(396,522,o),
+(381,522,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,112,o),
+(187,101,o),
+(187,86,cs),
+(187,73,o),
+(200,60,o),
+(213,60,cs),
+(228,60,o),
+(239,73,o),
+(239,86,cs),
+(239,101,o),
+(228,112,o),
+(213,112,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(368,112,o),
+(355,101,o),
+(355,86,cs),
+(355,73,o),
+(368,60,o),
+(381,60,cs),
+(396,60,o),
+(407,73,o),
+(407,86,cs),
+(407,101,o),
+(396,112,o),
+(381,112,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(284,540,o),
+(271,529,o),
+(271,514,cs),
+(271,501,o),
+(284,488,o),
+(297,488,cs),
+(312,488,o),
+(323,501,o),
+(323,514,cs),
+(323,529,o),
+(312,540,o),
+(297,540,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(284,94,o),
+(271,83,o),
+(271,68,cs),
+(271,55,o),
+(284,42,o),
+(297,42,cs),
+(312,42,o),
+(323,55,o),
+(323,68,cs),
+(323,83,o),
+(312,94,o),
+(297,94,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(48,278,o),
+(61,265,o),
+(74,265,cs),
+(89,265,o),
+(100,278,o),
+(100,291,cs),
+(100,306,o),
+(89,317,o),
+(74,317,cs),
+(61,317,o),
+(48,306,o),
+(48,291,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(494,278,o),
+(507,265,o),
+(520,265,cs),
+(535,265,o),
+(546,278,o),
+(546,291,cs),
+(546,306,o),
+(535,317,o),
+(520,317,cs),
+(507,317,o),
+(494,306,o),
+(494,291,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(113,120,o),
+(126,107,o),
+(139,107,cs),
+(154,107,o),
+(165,120,o),
+(165,133,cs),
+(165,148,o),
+(154,159,o),
+(139,159,cs),
+(126,159,o),
+(113,148,o),
+(113,133,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(113,436,o),
+(126,423,o),
+(139,423,cs),
+(154,423,o),
+(165,436,o),
+(165,449,cs),
+(165,464,o),
+(154,475,o),
+(139,475,cs),
+(126,475,o),
+(113,464,o),
+(113,449,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(429,120,o),
+(442,107,o),
+(455,107,cs),
+(470,107,o),
+(481,120,o),
+(481,133,cs),
+(481,148,o),
+(470,159,o),
+(455,159,cs),
+(442,159,o),
+(429,148,o),
+(429,133,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(429,436,o),
+(442,423,o),
+(455,423,cs),
+(470,423,o),
+(481,436,o),
+(481,449,cs),
+(481,464,o),
+(470,475,o),
+(455,475,cs),
+(442,475,o),
+(429,464,o),
+(429,449,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(66,194,o),
+(79,181,o),
+(92,181,cs),
+(107,181,o),
+(118,194,o),
+(118,207,cs),
+(118,222,o),
+(107,233,o),
+(92,233,cs),
+(79,233,o),
+(66,222,o),
+(66,207,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(66,362,o),
+(79,349,o),
+(92,349,cs),
+(107,349,o),
+(118,362,o),
+(118,375,cs),
+(118,390,o),
+(107,401,o),
+(92,401,cs),
+(79,401,o),
+(66,390,o),
+(66,375,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(476,194,o),
+(489,181,o),
+(502,181,cs),
+(517,181,o),
+(528,194,o),
+(528,207,cs),
+(528,222,o),
+(517,233,o),
+(502,233,cs),
+(489,233,o),
+(476,222,o),
+(476,207,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(476,362,o),
+(489,349,o),
+(502,349,cs),
+(517,349,o),
+(528,362,o),
+(528,375,cs),
+(528,390,o),
+(517,401,o),
+(502,401,cs),
+(489,401,o),
+(476,390,o),
+(476,375,cs)
+);
+}
+);
+width = 594;
+}
+);
+note = uni25CC;
+unicode = 9676;
+},
+{
+glyphname = dotaccentcomb;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(74,767,o),
+(35,750,o),
+(35,691,cs),
+(35,633,o),
+(74,615,o),
+(123,615,cs),
+(171,615,o),
+(211,633,o),
+(211,691,cs),
+(211,751,o),
+(171,767,o),
+(123,767,cs)
+);
+}
+);
+width = 247;
+}
+);
+note = uni0307;
+unicode = 775;
+},
+{
+glyphname = dotaccent;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(171,615,o),
+(212,633,o),
+(212,691,cs),
+(212,751,o),
+(172,767,o),
+(124,767,cs),
+(75,767,o),
+(36,750,o),
+(36,691,cs),
+(36,633,o),
+(75,615,o),
+(124,615,cs)
+);
+}
+);
+width = 249;
+}
+);
+note = dotaccent;
+unicode = 729;
+},
+{
+glyphname = caron;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(340,646,o),
+(381,699,o),
+(427,753,c),
+(427,766,l),
+(321,766,l),
+(289,742,o),
+(263,717,o),
+(231,684,c),
+(200,716,o),
+(176,742,o),
+(145,766,c),
+(36,766,l),
+(36,753,l),
+(75,711,o),
+(122,655,o),
+(150,606,c),
+(315,606,l),
+(315,606,l)
+);
+}
+);
+width = 464;
+}
+);
+note = caron;
+unicode = 711;
+},
+{
+glyphname = breve;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(317,606,o),
+(380,672,o),
+(386,776,c),
+(294,776,l),
+(282,723,o),
+(249,708,o),
+(210,708,cs),
+(160,708,o),
+(138,720,o),
+(126,776,c),
+(36,776,l),
+(41,668,o),
+(99,606,o),
+(210,606,cs)
+);
+}
+);
+width = 423;
+}
+);
+note = breve;
+unicode = 728;
+},
+{
+glyphname = ring;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(218,605,o),
+(270,651,o),
+(270,725,cs),
+(270,798,o),
+(217,845,o),
+(152,845,cs),
+(83,845,o),
+(36,798,o),
+(36,724,cs),
+(36,651,o),
+(83,605,o),
+(152,605,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(127,678,o),
+(113,698,o),
+(113,724,cs),
+(113,753,o),
+(130,771,o),
+(152,771,cs),
+(173,771,o),
+(191,752,o),
+(191,724,cs),
+(191,698,o),
+(174,678,o),
+(152,678,cs)
+);
+}
+);
+width = 307;
+}
+);
+note = ring;
+unicode = 730;
+},
+{
+glyphname = ogonek;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(186,-236,o),
+(210,-231,o),
+(231,-224,c),
+(231,-130,l),
+(219,-135,o),
+(195,-140,o),
+(179,-140,cs),
+(158,-140,o),
+(143,-129,o),
+(143,-102,cs),
+(143,-69,o),
+(163,-42,o),
+(204,0,c),
+(139,23,l),
+(64,-33,o),
+(36,-80,o),
+(36,-128,cs),
+(36,-195,o),
+(89,-236,o),
+(156,-236,cs)
+);
+}
+);
+width = 267;
+}
+);
+note = ogonek;
+unicode = 731;
+},
+{
+glyphname = ring_top.canadian;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (137,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,784,o),
+(257,832,o),
+(257,899,cs),
+(257,966,o),
+(200,1014,o),
+(135,1014,cs),
+(71,1014,o),
+(16,967,o),
+(16,899,cs),
+(16,832,o),
+(71,784,o),
+(135,784,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(108,853,o),
+(91,874,o),
+(91,899,cs),
+(91,924,o),
+(110,945,o),
+(137,945,cs),
+(163,945,o),
+(182,924,o),
+(182,899,cs),
+(182,874,o),
+(163,853,o),
+(137,853,cs)
+);
+}
+);
+width = 273;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (97,357);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(141,279,o),
+(175,314,o),
+(175,357,cs),
+(175,400,o),
+(141,435,o),
+(97,435,cs),
+(54,435,o),
+(19,400,o),
+(19,357,cs),
+(19,314,o),
+(54,279,o),
+(97,279,cs)
+);
+}
+);
+width = 195;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (80,357);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(115,295,o),
+(142,322,o),
+(142,357,cs),
+(142,392,o),
+(115,419,o),
+(80,419,cs),
+(46,419,o),
+(19,392,o),
+(19,357,cs),
+(19,322,o),
+(46,295,o),
+(80,295,cs)
+);
+}
+);
+width = 161;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_small;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (63,357);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(88,312,o),
+(108,332,o),
+(108,357,cs),
+(108,382,o),
+(88,402,o),
+(63,402,cs),
+(38,402,o),
+(19,382,o),
+(19,357,cs),
+(19,332,o),
+(38,312,o),
+(63,312,cs)
+);
+}
+);
+width = 126;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_top;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (97,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(141,790,o),
+(176,826,o),
+(176,869,cs),
+(176,913,o),
+(141,948,o),
+(97,948,cs),
+(54,948,o),
+(19,913,o),
+(19,869,cs),
+(19,826,o),
+(54,790,o),
+(97,790,cs)
+);
+}
+);
+width = 195;
+}
+);
+note = g725;
+},
+{
+glyphname = doubledot_middle;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(166,381,o),
+(201,416,o),
+(201,459,cs),
+(201,503,o),
+(166,538,o),
+(122,538,cs),
+(79,538,o),
+(44,503,o),
+(44,459,cs),
+(44,415,o),
+(79,381,o),
+(122,381,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(166,176,o),
+(201,211,o),
+(201,255,cs),
+(201,298,o),
+(166,333,o),
+(122,333,cs),
+(79,333,o),
+(44,299,o),
+(44,255,cs),
+(44,211,o),
+(79,176,o),
+(122,176,cs)
+);
+}
+);
+width = 245;
+}
+);
+metricRight = "=|";
+note = g725;
+},
+{
+glyphname = doubledot_top;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top_double;
+pos = (288,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(332,790,o),
+(367,826,o),
+(367,869,cs),
+(367,913,o),
+(332,948,o),
+(288,948,cs),
+(244,948,o),
+(210,913,o),
+(210,869,cs),
+(210,826,o),
+(244,790,o),
+(288,790,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(130,790,o),
+(165,826,o),
+(165,869,cs),
+(165,913,o),
+(130,948,o),
+(86,948,cs),
+(42,948,o),
+(7,913,o),
+(7,869,cs),
+(7,826,o),
+(42,790,o),
+(86,790,cs)
+);
+}
+);
+width = 374;
+}
+);
+note = g725;
+},
+{
+glyphname = g727;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (370,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(674,0,l),
+(674,135,l),
+(319,135,ls),
+(250,135,o),
+(219,160,o),
+(219,212,cs),
+(219,266,o),
+(250,291,o),
+(318,291,cs),
+(448,291,ls),
+(609,291,o),
+(687,366,o),
+(687,503,cs),
+(687,640,o),
+(609,714,o),
+(448,714,cs),
+(66,714,l),
+(66,579,l),
+(421,579,ls),
+(490,579,o),
+(521,554,o),
+(521,503,cs),
+(521,456,o),
+(490,424,o),
+(422,424,cs),
+(292,424,ls),
+(131,424,o),
+(53,348,o),
+(53,211,cs),
+(53,74,o),
+(131,0,o),
+(292,0,cs)
+);
+}
+);
+width = 740;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+glyphname = g728;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (273,0);
+ref = dot_top;
+}
+);
+width = 740;
+}
+);
+note = g728;
+},
+{
+glyphname = g729;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (370,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(448,0,ls),
+(609,0,o),
+(687,74,o),
+(687,211,cs),
+(687,348,o),
+(609,424,o),
+(448,424,cs),
+(318,424,ls),
+(250,424,o),
+(219,456,o),
+(219,502,cs),
+(219,554,o),
+(250,579,o),
+(319,579,cs),
+(674,579,l),
+(674,714,l),
+(292,714,ls),
+(131,714,o),
+(53,640,o),
+(53,503,cs),
+(53,366,o),
+(131,291,o),
+(292,291,cs),
+(422,291,ls),
+(490,291,o),
+(521,266,o),
+(521,211,cs),
+(521,160,o),
+(490,135,o),
+(421,135,cs),
+(66,135,l),
+(66,0,l)
+);
+}
+);
+width = 740;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+glyphname = g730;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (273,0);
+ref = dot_top;
+}
+);
+width = 740;
+}
+);
+note = g730;
+},
+{
+glyphname = g731;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = g727;
+}
+);
+width = 985;
+}
+);
+note = g731;
+},
+{
+glyphname = g732;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (740,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 985;
+}
+);
+note = g732;
+},
+{
+glyphname = g733;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (518,0);
+ref = dot_top;
+}
+);
+width = 985;
+}
+);
+note = g733;
+},
+{
+glyphname = g734;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (273,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (740,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 985;
+}
+);
+note = g734;
+},
+{
+glyphname = g735;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = g729;
+}
+);
+width = 985;
+}
+);
+note = g735;
+},
+{
+glyphname = g736;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (740,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 985;
+}
+);
+note = g736;
+},
+{
+glyphname = g737;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (518,0);
+ref = dot_top;
+}
+);
+width = 985;
+}
+);
+note = g737;
+},
+{
+glyphname = g738;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (273,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (740,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 985;
+}
+);
+note = g738;
+},
+{
+glyphname = g739;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(565,284,o),
+(621,338,o),
+(621,420,cs),
+(621,500,o),
+(567,555,o),
+(473,555,cs),
+(285,555,l),
+(290,506,l),
+(310,517,o),
+(330,550,o),
+(330,591,cs),
+(330,669,o),
+(277,721,o),
+(188,721,cs),
+(101,721,o),
+(45,667,o),
+(45,585,cs),
+(45,505,o),
+(99,450,o),
+(193,450,cs),
+(381,450,l),
+(376,499,l),
+(356,488,o),
+(336,455,o),
+(336,414,cs),
+(336,336,o),
+(389,284,o),
+(478,284,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(163,531,o),
+(145,550,o),
+(145,585,cs),
+(145,622,o),
+(163,641,o),
+(188,641,cs),
+(213,641,o),
+(230,621,o),
+(230,585,cs),
+(230,550,o),
+(213,531,o),
+(188,531,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(453,364,o),
+(436,384,o),
+(436,420,cs),
+(436,455,o),
+(453,474,o),
+(478,474,cs),
+(503,474,o),
+(521,455,o),
+(521,420,cs),
+(521,383,o),
+(503,364,o),
+(478,364,cs)
+);
+}
+);
+width = 666;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+glyphname = g740;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (234,0);
+ref = ring_top.canadian;
+}
+);
+width = 740;
+}
+);
+note = g740;
+},
+{
+glyphname = g741;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (234,0);
+ref = ring_top.canadian;
+}
+);
+width = 740;
+}
+);
+note = g741;
+},
+{
+glyphname = g742;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (479,0);
+ref = ring_top.canadian;
+}
+);
+width = 985;
+}
+);
+note = g742;
+},
+{
+glyphname = stroke_middle;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (66,357);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(114,480,l),
+(18,480,l),
+(18,234,l),
+(114,234,l)
+);
+}
+);
+width = 132;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (53,357);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(88,430,l),
+(18,430,l),
+(18,284,l),
+(88,284,l)
+);
+}
+);
+width = 106;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_small;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (45,357);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(71,420,l),
+(18,420,l),
+(18,294,l),
+(71,294,l)
+);
+}
+);
+width = 89;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_threequart;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (66,357);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(112,476,l),
+(20,476,l),
+(20,238,l),
+(112,238,l)
+);
+}
+);
+width = 132;
+}
+);
+note = g723;
+},
+{
+color = 8;
+glyphname = uni11AB0;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (184,714);
+},
+{
+name = top_right_can;
+pos = (466,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(268,0,l),
+(268,77,l),
+(486,77,l),
+(486,165,l),
+(268,165,l),
+(268,287,l),
+(141,232,l),
+(179,232,ls),
+(412,232,o),
+(549,364,o),
+(549,612,cs),
+(549,714,l),
+(383,714,l),
+(383,628,ls),
+(383,445,o),
+(305,379,o),
+(144,379,cs),
+(101,379,l),
+(101,165,l),
+(28,165,l),
+(28,77,l),
+(101,77,l),
+(101,0,l)
+);
+}
+);
+width = 613;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB1;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB0;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (369,0);
+ref = dot_top;
+}
+);
+width = 613;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB2;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (147,714);
+},
+{
+name = top_right_can;
+pos = (429,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(230,0,l),
+(230,86,ls),
+(230,269,o),
+(309,335,o),
+(469,335,cs),
+(512,335,l),
+(512,549,l),
+(585,549,l),
+(585,637,l),
+(512,637,l),
+(512,714,l),
+(346,714,l),
+(346,637,l),
+(127,637,l),
+(127,549,l),
+(346,549,l),
+(346,427,l),
+(472,482,l),
+(434,482,ls),
+(202,482,o),
+(64,350,o),
+(64,102,cs),
+(64,0,l)
+);
+}
+);
+width = 613;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "theThCree-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB3;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB2;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (332,0);
+ref = dot_top;
+}
+);
+width = 613;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB4;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (185,714);
+},
+{
+name = top_right_can;
+pos = (467,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(549,0,l),
+(549,102,ls),
+(549,350,o),
+(412,482,o),
+(179,482,cs),
+(141,482,l),
+(268,427,l),
+(268,549,l),
+(486,549,l),
+(486,637,l),
+(268,637,l),
+(268,714,l),
+(101,714,l),
+(101,637,l),
+(28,637,l),
+(28,549,l),
+(101,549,l),
+(101,335,l),
+(144,335,ls),
+(305,335,o),
+(383,269,o),
+(383,86,cs),
+(383,0,l)
+);
+}
+);
+width = 613;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB5;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB4;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (88,0);
+ref = dot_top;
+}
+);
+width = 613;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB6;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (148,714);
+},
+{
+name = top_right_can;
+pos = (430,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(231,0,l),
+(231,288,l),
+(105,232,l),
+(143,232,ls),
+(375,232,o),
+(512,364,o),
+(512,612,cs),
+(512,661,l),
+(406,604,l),
+(656,396,l),
+(745,506,l),
+(495,714,l),
+(346,714,l),
+(346,628,ls),
+(346,445,o),
+(268,379,o),
+(107,379,cs),
+(65,379,l),
+(65,0,l)
+);
+}
+);
+width = 764;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB7;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB6;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (332,0);
+ref = dot_top;
+}
+);
+width = 764;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB8;
+kernRight = soright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (335,714);
+},
+{
+name = top_right_can;
+pos = (617,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(418,0,l),
+(418,86,ls),
+(418,269,o),
+(496,335,o),
+(657,335,cs),
+(699,335,l),
+(699,714,l),
+(533,714,l),
+(533,426,l),
+(660,482,l),
+(622,482,ls),
+(389,482,o),
+(252,350,o),
+(252,102,cs),
+(252,53,l),
+(359,110,l),
+(108,318,l),
+(19,208,l),
+(270,0,l)
+);
+}
+);
+width = 764;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB9;
+kernRight = soright;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB8;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (519,0);
+ref = dot_top;
+}
+);
+width = 764;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABA;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (148,714);
+},
+{
+name = top_right_can;
+pos = (430,714);
+}
+);
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(495,0,l),
+(745,208,l),
+(656,318,l),
+(406,110,l),
+(512,53,l),
+(512,102,ls),
+(512,350,o),
+(375,482,o),
+(143,482,cs),
+(105,482,l),
+(231,426,l),
+(231,714,l),
+(65,714,l),
+(65,335,l),
+(107,335,ls),
+(268,335,o),
+(346,269,o),
+(346,86,cs),
+(346,0,l)
+);
+}
+);
+width = 764;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABB;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+alignment = -1;
+ref = uni11ABA;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+}
+);
+width = 764;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABC;
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(563,0,l),
+(563,149,l),
+(214,149,l),
+(214,96,l),
+(573,600,l),
+(573,714,l),
+(41,714,l),
+(41,565,l),
+(390,565,l),
+(390,618,l),
+(32,114,l),
+(32,0,l)
+);
+}
+);
+width = 605;
+}
+);
+metricRight = "=|";
+},
+{
+color = 8;
+glyphname = uni11ABD;
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(573,0,l),
+(573,114,l),
+(214,618,l),
+(214,565,l),
+(564,565,l),
+(564,714,l),
+(32,714,l),
+(32,600,l),
+(390,96,l),
+(390,149,l),
+(41,149,l),
+(41,0,l)
+);
+}
+);
+width = 605;
+}
+);
+metricLeft = "=|uni11ABC";
+metricRight = "=|uni11ABC";
+},
+{
+color = 8;
+glyphname = uni11ABE;
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(228,0,l),
+(228,571,l),
+(128,571,l),
+(496,0,l),
+(642,0,l),
+(642,714,l),
+(478,714,l),
+(478,143,l),
+(579,143,l),
+(211,714,l),
+(65,714,l),
+(65,0,l)
+);
+}
+);
+width = 707;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABF;
+lastChange = "2023-01-13 15:30:28 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(211,0,l),
+(578,572,l),
+(477,572,l),
+(477,0,l),
+(642,0,l),
+(642,714,l),
+(496,714,l),
+(128,142,l),
+(230,142,l),
+(230,714,l),
+(65,714,l),
+(65,0,l)
+);
+}
+);
+width = 707;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = "raiseddoubledotFinal-canadian.cree";
+lastChange = "2023-01-13 15:28:15 +0000";
+layers = (
+{
+layerId = "9763B71A-4976-465B-BEF0-2F1E1DB14637";
+shapes = (
+{
+closed = 1;
+nodes = (
+(166,571,o),
+(201,606,o),
+(201,650,cs),
+(201,693,o),
+(166,729,o),
+(123,729,cs),
+(79,729,o),
+(44,694,o),
+(44,650,cs),
+(44,606,o),
+(79,571,o),
+(123,571,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(166,366,o),
+(201,401,o),
+(201,445,cs),
+(201,489,o),
+(166,524,o),
+(123,524,cs),
+(79,524,o),
+(44,489,o),
+(44,445,cs),
+(44,401,o),
+(79,366,o),
+(123,366,cs)
+);
+}
+);
+width = 245;
+}
+);
+note = g725;
+}
+);
+instances = (
+{
+axesValues = (
+169,
+90,
+0
+);
+instanceInterpolations = {
+"9763B71A-4976-465B-BEF0-2F1E1DB14637" = 1;
+};
+name = "RC B roman";
+}
+);
+kerningLTR = {
+"9763B71A-4976-465B-BEF0-2F1E1DB14637" = {
+"@MMK_L_caright" = {
+"@MMK_R_ecanleft" = -75;
+"@MMK_R_mwestleft" = -28;
+"@MMK_R_neleft" = -42;
+};
+"@MMK_L_ciright" = {
+"@MMK_R_icanleft" = -75;
+"@MMK_R_noleft" = -80;
+};
+"@MMK_L_ecanright" = {
+"@MMK_R_coleft" = -75;
+"@MMK_R_moleft" = -80;
+"@MMK_R_sileft" = -47;
+};
+"@MMK_L_icanright" = {
+"@MMK_R_celeft" = -75;
+"@MMK_R_meleft" = -80;
+"@MMK_R_mwestleft" = -84;
+"@MMK_R_saleft" = -39;
+"she-canadian" = -80;
+};
+"@MMK_L_maright" = {
+"@MMK_R_acanleft" = -67;
+"@MMK_R_ecanleft" = -80;
+"@MMK_R_mwestleft" = -48;
+"@MMK_R_neleft" = -42;
+};
+"@MMK_L_miright" = {
+"@MMK_R_acanleft" = -67;
+"@MMK_R_icanleft" = -80;
+"@MMK_R_moleft" = -99;
+"@MMK_R_noleft" = -80;
+"@MMK_R_yeleft" = -110;
+};
+"@MMK_L_mwestright" = {
+"@MMK_R_coleft" = -28;
+"@MMK_R_icanleft" = -84;
+"@MMK_R_moleft" = -48;
+"@MMK_R_noleft" = -71;
+"@MMK_R_sileft" = -20;
+"@MMK_R_yeleft" = -40;
+};
+"@MMK_L_naright" = {
+"@MMK_R_acanleft" = -72;
+"@MMK_R_celeft" = -80;
+"@MMK_R_meleft" = -80;
+"@MMK_R_mwestleft" = -71;
+"@MMK_R_neleft" = -84;
+"@MMK_R_saleft" = -45;
+};
+"@MMK_L_niright" = {
+"@MMK_R_coleft" = -42;
+"@MMK_R_moleft" = -42;
+"@MMK_R_noleft" = -84;
+"@MMK_R_sileft" = -1;
+};
+"@MMK_L_ocanright" = {
+"@MMK_R_meleft" = -67;
+"@MMK_R_moleft" = -67;
+"@MMK_R_noleft" = -72;
+};
+"@MMK_L_seright" = {
+"@MMK_R_ecanleft" = -47;
+"@MMK_R_mwestleft" = -20;
+"@MMK_R_neleft" = -1;
+};
+"@MMK_L_soright" = {
+"@MMK_R_icanleft" = -39;
+"@MMK_R_noleft" = -45;
+};
+"@MMK_L_yiright" = {
+"@MMK_R_meleft" = -110;
+"@MMK_R_mwestleft" = -40;
+};
+"shi-canadian" = {
+"@MMK_R_icanleft" = -80;
+};
+};
+};
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "italic angle";
+}
+);
+properties = (
+{
+key = copyrights;
+values = (
+{
+language = ENG;
+value = "Copyright 2018 Google Inc. All Rights Reserved.";
+}
+);
+},
+{
+key = manufacturers;
+values = (
+{
+language = ENG;
+value = "Monotype Imaging Inc.";
+}
+);
+},
+{
+key = designers;
+values = (
+{
+language = ENG;
+value = "Monotype Design Team";
+}
+);
+},
+{
+key = description;
+value = "Designed by Monotype design team.";
+},
+{
+key = trademarks;
+values = (
+{
+language = ENG;
+value = "Noto is a trademark of Google Inc.";
+}
+);
+},
+{
+key = licenseURL;
+value = "http://scripts.sil.org/OFL";
+},
+{
+key = licenses;
+values = (
+{
+language = ENG;
+value = "This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.";
+}
+);
+},
+{
+key = manufacturerURL;
+value = "http://www.google.com/get/noto/";
+},
+{
+key = designerURL;
+value = "http://www.monotype.com/studio";
+}
+);
+settings = {
+disablesNiceNames = 1;
+};
+stems = (
+{
+name = "New Stem";
+}
+);
+unitsPerEm = 1000;
+userData = {
+GSDontShowVersionAlert = 1;
+};
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/sources/Exported instances UCAS SansCanadianAboriginal/Sans Canadian Aboriginal-RC CB Italic.glyphs
+++ b/sources/Exported instances UCAS SansCanadianAboriginal/Sans Canadian Aboriginal-RC CB Italic.glyphs
@@ -1,0 +1,37312 @@
+{
+.appVersion = "3151";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+},
+{
+name = Width;
+tag = wdth;
+},
+{
+name = Slant;
+tag = slnt;
+}
+);
+classes = (
+{
+code = "zero one two three four five six seven eight nine ";
+name = Num;
+},
+{
+code = "zero.canadian one.canadian two.canadian three.canadian four.canadian five.canadian six.canadian seven.canadian eight.canadian nine.canadian 
+";
+name = Num_can;
+},
+{
+code = "ke-canadian.square ki-canadian.square kii-canadian.square ko-canadian.square koo-canadian.square ka-canadian.square kaa-canadian.square kweWestCree-canadian.square kwiiWestCree-canadian.square kwoWestCree-canadian.square kwooWestCree-canadian.square kwaWestCree-canadian.square kwaaWestCree-canadian.square ce-canadian.square ci-canadian.square cii-canadian.square co-canadian.square coo-canadian.square ca-canadian.square caa-canadian.square me-canadian.square mi-canadian.square mii-canadian.square mo-canadian.square moo-canadian.square ma-canadian.square maa-canadian.square ne-canadian.square ni-canadian.square nii-canadian.square no-canadian.square noo-canadian.square na-canadian.square naa-canadian.square nweWestCree-canadian.square nwaWestCree-canadian.square nwaaWestCree-canadian.square se-canadian.square si-canadian.square sii-canadian.square so-canadian.square soo-canadian.square sa-canadian.square saa-canadian.square sho-canadian.square shoo-canadian.square sha-canadian.square shaa-canadian.square ye-canadian.square yi-canadian.square yii-canadian.square yo-canadian.square yoo-canadian.square ya-canadian.square yaa-canadian.square re-canadian.square reRCree-canadian.square leWestCree-canadian.square ri-canadian.square rii-canadian.square ro-canadian.square loWestCree-canadian.square ra-canadian.square raa-canadian.square laWestCree-canadian.square reWestCree-canadian.square riWestCree-canadian.square roWestCree-canadian.square raWestCree-canadian.square theThCree-canadian.square thiThCree-canadian.square thiiThCree-canadian.square thoThCree-canadian.square thooThCree-canadian.square thaThCree-canadian.square thaaThCree-canadian.square thweeWoodScree-canadian.square thwiWoodScree-canadian.square thwiiWoodScree-canadian.square thwoWoodScree-canadian.square thwooWoodScree-canadian.square thwaWoodScree-canadian.square thwaaWoodScree-canadian.square nwiOjibway-canadian.square nwiiOjibway-canadian.square nwoOjibway-canadian.square nwooOjibway-canadian.square looWestCree-canadian.square laaWestCree-canadian.square ";
+name = Dene_square;
+},
+{
+code = "ke-canadian ki-canadian kii-canadian ko-canadian koo-canadian ka-canadian kaa-canadian kweWestCree-canadian kwiiWestCree-canadian kwoWestCree-canadian kwooWestCree-canadian kwaWestCree-canadian kwaaWestCree-canadian ce-canadian ci-canadian cii-canadian co-canadian coo-canadian ca-canadian caa-canadian me-canadian mi-canadian mii-canadian mo-canadian moo-canadian ma-canadian maa-canadian ne-canadian ni-canadian nii-canadian no-canadian noo-canadian na-canadian naa-canadian nweWestCree-canadian nwaWestCree-canadian nwaaWestCree-canadian se-canadian si-canadian sii-canadian so-canadian soo-canadian sa-canadian saa-canadian sho-canadian shoo-canadian sha-canadian shaa-canadian ye-canadian yi-canadian yii-canadian yo-canadian yoo-canadian ya-canadian yaa-canadian re-canadian reRCree-canadian leWestCree-canadian ri-canadian rii-canadian ro-canadian loWestCree-canadian ra-canadian raa-canadian laWestCree-canadian reWestCree-canadian riWestCree-canadian roWestCree-canadian raWestCree-canadian theThCree-canadian thiThCree-canadian thiiThCree-canadian thoThCree-canadian thooThCree-canadian thaThCree-canadian thaaThCree-canadian thweeWoodScree-canadian thwiWoodScree-canadian thwiiWoodScree-canadian thwoWoodScree-canadian thwooWoodScree-canadian thwaWoodScree-canadian thwaaWoodScree-canadian nwiOjibway-canadian nwiiOjibway-canadian nwoOjibway-canadian nwooOjibway-canadian looWestCree-canadian laaWestCree-canadian 
+";
+name = Dene_round;
+},
+{
+code = "acuteFinal-canadian.mid graveFinal-canadian.mid ringTophalfFinal-canadian.mid ringRighthalfFinal-canadian.mid ringFinal-canadian.mid doubleacuteFinal-canadian.mid doubleshortverticalstrokesFinal-canadian.mid shorthorizontalstrokeFinal-canadian.mid downtackFinal-canadian.mid pWestCree-canadian.mid c-canadian.mid mWestCree-canadian.mid ";
+name = Final_mid;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian ringFinal-canadian doubleacuteFinal-canadian doubleshortverticalstrokesFinal-canadian shorthorizontalstrokeFinal-canadian downtackFinal-canadian pWestCree-canadian c-canadian mWestCree-canadian ";
+name = Final_mid_ori;
+},
+{
+code = "acuteFinal-canadian.base graveFinal-canadian.base ringBottomhalfFinal-canadian.base ringTophalfFinal-canadian.base ringRighthalfFinal-canadian.base plusFinal-canadian.base pWestCree-canadian.base c-canadian.base thSayisi-canadian.base mWestCree-canadian.base ";
+name = Final_base;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringBottomhalfFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian plusFinal-canadian pWestCree-canadian c-canadian thSayisi-canadian mWestCree-canadian ";
+name = Final_base_ori;
+},
+{
+code = "ng-canadian ngai-canadian ngaai-canadian ngi-canadian ngii-canadian ngo-canadian ngoo-canadian nga-canadian ngaa-canadian ";
+name = Nunavik;
+},
+{
+code = "ng-canadian.nunavik ngai-canadian.nunavik ngaai-canadian.nunavik ngi-canadian.nunavik ngii-canadian.nunavik ngo-canadian.nunavik ngoo-canadian.nunavik nga-canadian.nunavik ngaa-canadian.nunavik ";
+name = Nunavik_alt;
+}
+);
+customParameters = (
+{
+name = vendorID;
+value = GOOG;
+},
+{
+name = panose;
+value = (
+2,
+11,
+5,
+2,
+4,
+5,
+4,
+2,
+2,
+4
+);
+},
+{
+name = unicodeRanges;
+value = (
+0,
+1,
+2,
+5,
+6,
+45,
+77
+);
+},
+{
+name = codePageRanges;
+value = (
+"1252"
+);
+},
+{
+name = fsType;
+value = (
+);
+}
+);
+date = "2022-06-21 10:06:40 +0000";
+familyName = "Sans Canadian Aboriginal";
+featurePrefixes = (
+{
+automatic = 1;
+code = "languagesystem DFLT dflt;
+
+languagesystem cans dflt;
+";
+name = Languagesystems;
+}
+);
+features = (
+{
+automatic = 1;
+code = "feature ss01;
+feature ss02;
+feature ss03;
+feature ss04;
+";
+tag = aalt;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+tag = salt;
+},
+{
+code = "lookup space_can {
+sub space by space.canadian;
+} space_can;
+
+lookup num_can {
+sub @Num by @Num_can;
+} num_can;
+";
+labels = (
+{
+language = dflt;
+value = "CAN Space and numerals";
+}
+);
+tag = ss01;
+},
+{
+code = "lookup dene_square {
+sub @Dene_round by @Dene_square;
+} dene_square;
+
+";
+labels = (
+{
+language = dflt;
+value = "Dene Square";
+}
+);
+tag = ss02;
+},
+{
+code = "lookup nunavik_alt {
+sub @Nunavik by @Nunavik_alt;
+} nunavik_alt;
+
+";
+labels = (
+{
+language = dflt;
+value = "Nunanvik Alt";
+}
+);
+tag = ss03;
+},
+{
+code = "lookup final_mid {
+sub @Final_mid_ori by @Final_mid;
+} final_mid;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final mid";
+}
+);
+tag = ss04;
+},
+{
+code = "lookup final_base {
+sub @Final_base_ori by @Final_base;
+} final_base;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final base";
+}
+);
+tag = ss05;
+},
+{
+code = "lookup plaincree_first {
+sub wiWestCree-canadian' plusFinal-canadian by i-canadian;
+} plaincree_first;
+
+lookup plaincree_second {
+sub i-canadian plusFinal-canadian' by raiseddoubledotFinal-canadian.cree;
+} plaincree_second;
+
+lookup plaincree_third {
+sub middledotFinal-canadian plusFinal-canadian by raiseddoubledotFinal-canadian.cree;
+} plaincree_third;
+";
+labels = (
+{
+language = dflt;
+value = Plaincree;
+}
+);
+tag = ss06;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+labels = (
+{
+language = dflt;
+value = "";
+}
+);
+tag = ss07;
+}
+);
+fontMaster = (
+{
+axesValues = (
+0,
+0,
+0
+);
+customParameters = (
+{
+name = typoAscender;
+value = 1069;
+},
+{
+name = typoDescender;
+value = -293;
+},
+{
+name = typoLineGap;
+value = 0;
+},
+{
+name = winAscent;
+value = 1069;
+},
+{
+name = winDescent;
+value = 293;
+},
+{
+name = hheaAscender;
+value = 1069;
+},
+{
+name = hheaDescender;
+value = -293;
+},
+{
+name = strikeoutPosition;
+value = 303.56287;
+},
+{
+name = strikeoutSize;
+value = 50;
+},
+{
+name = "Master Icon Glyph Name";
+value = s;
+}
+);
+guides = (
+{
+locked = 1;
+pos = (432,357);
+},
+{
+locked = 1;
+pos = (100,729);
+},
+{
+locked = 1;
+pos = (-57,-15);
+}
+);
+id = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+metricValues = (
+{
+over = 23;
+pos = 1069;
+},
+{
+over = 23;
+pos = 714;
+},
+{
+over = 23;
+pos = 506;
+},
+{
+over = -23;
+},
+{
+over = -23;
+pos = -293;
+},
+{
+pos = 12;
+}
+);
+name = "RC CB Italic";
+stemValues = (
+146
+);
+}
+);
+glyphs = (
+{
+glyphname = idotless;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(144,0,l),
+(260,547,l),
+(114,547,l),
+(-2,0,l)
+);
+}
+);
+width = 249;
+}
+);
+note = dotlessi;
+unicode = 305;
+},
+{
+glyphname = "acuteFinal-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(159,357,l),
+(374,714,l),
+(254,714,l),
+(39,357,l)
+);
+}
+);
+width = 293;
+}
+);
+metricRight = "=|";
+note = uni141F;
+unicode = 5151;
+},
+{
+glyphname = "graveFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(298,357,l),
+(223,714,l),
+(115,714,l),
+(190,357,l)
+);
+}
+);
+width = 293;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+unicode = 5152;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(312,351,o),
+(361,400,o),
+(379,486,cs),
+(427,714,l),
+(330,714,l),
+(282,489,ls),
+(275,454,o),
+(259,438,o),
+(230,438,cs),
+(198,438,o),
+(186,457,o),
+(194,491,cs),
+(241,714,l),
+(143,714,l),
+(98,504,ls),
+(79,411,o),
+(126,351,o),
+(221,351,cs)
+);
+}
+);
+width = 374;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1421;
+unicode = 5153;
+},
+{
+glyphname = "ringTophalfFinal-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(166,357,l),
+(213,582,ls),
+(221,617,o),
+(236,633,o),
+(266,633,cs),
+(297,633,o),
+(309,614,o),
+(302,580,cs),
+(255,357,l),
+(352,357,l),
+(397,567,ls),
+(417,660,o),
+(370,720,o),
+(274,720,cs),
+(183,720,o),
+(135,671,o),
+(116,585,cs),
+(68,357,l)
+);
+}
+);
+width = 375;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+unicode = 5154;
+},
+{
+glyphname = "ringRighthalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(122,357,ls),
+(271,357,o),
+(336,460,o),
+(336,573,cs),
+(336,663,o),
+(278,714,o),
+(186,714,cs),
+(142,714,l),
+(122,622,l),
+(171,622,ls),
+(213,622,o),
+(238,600,o),
+(238,559,cs),
+(238,505,o),
+(211,449,o),
+(136,449,cs),
+(86,449,l),
+(66,357,l)
+);
+}
+);
+width = 315;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+unicode = 5155;
+},
+{
+glyphname = "ringFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(368,396,o),
+(436,466,o),
+(436,559,cs),
+(436,651,o),
+(367,720,o),
+(272,720,cs),
+(175,720,o),
+(106,651,o),
+(106,559,cs),
+(106,466,o),
+(174,396,o),
+(272,396,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(224,479,o),
+(196,513,o),
+(196,559,cs),
+(196,604,o),
+(224,637,o),
+(272,637,cs),
+(317,637,o),
+(346,602,o),
+(346,559,cs),
+(346,513,o),
+(317,479,o),
+(272,479,cs)
+);
+}
+);
+width = 412;
+}
+);
+note = uni1424;
+unicode = 5156;
+},
+{
+glyphname = "doubleacuteFinal-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(155,357,l),
+(374,714,l),
+(258,714,l),
+(39,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(315,357,l),
+(534,714,l),
+(419,714,l),
+(200,357,l)
+);
+}
+);
+width = 453;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricRight = "=|";
+note = uni1425;
+unicode = 5157;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(165,357,l),
+(241,714,l),
+(143,714,l),
+(67,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(305,357,l),
+(381,714,l),
+(283,714,l),
+(207,357,l)
+);
+}
+);
+width = 328;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "pWestCree-canadian";
+note = uni1426;
+unicode = 5158;
+},
+{
+glyphname = "middledotFinal-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(169,297,o),
+(200,328,o),
+(200,367,cs),
+(200,406,o),
+(169,437,o),
+(130,437,cs),
+(91,437,o),
+(60,406,o),
+(60,367,cs),
+(60,328,o),
+(91,297,o),
+(130,297,cs)
+);
+}
+);
+width = 211;
+}
+);
+note = uni1427;
+unicode = 5159;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(387,507,l),
+(408,606,l),
+(120,606,l),
+(99,507,l)
+);
+}
+);
+width = 378;
+}
+);
+metricRight = "=|";
+note = uni1428;
+unicode = 5160;
+},
+{
+glyphname = "plusFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(269,407,l),
+(292,516,l),
+(389,516,l),
+(409,608,l),
+(311,608,l),
+(334,714,l),
+(241,714,l),
+(219,608,l),
+(121,608,l),
+(101,516,l),
+(199,516,l),
+(176,407,l)
+);
+}
+);
+width = 379;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+unicode = 5161;
+},
+{
+glyphname = "downtackFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(260,357,l),
+(316,621,l),
+(411,621,l),
+(431,714,l),
+(143,714,l),
+(123,621,l),
+(218,621,l),
+(162,357,l)
+);
+}
+);
+width = 378;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni142A;
+unicode = 5162;
+},
+{
+glyphname = "thFinalWoodScree-canadian";
+lastChange = "2023-01-13 15:31:52 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(260,357,l),
+(273,419,l),
+(367,419,l),
+(385,501,l),
+(291,501,l),
+(305,570,l),
+(399,570,l),
+(417,652,l),
+(323,652,l),
+(336,714,l),
+(238,714,l),
+(225,652,l),
+(129,652,l),
+(112,570,l),
+(208,570,l),
+(193,501,l),
+(97,501,l),
+(80,419,l),
+(176,419,l),
+(162,357,l)
+);
+}
+);
+width = 376;
+}
+);
+metricLeft = "hyphen-canadian";
+metricRight = "hyphen-canadian";
+note = uni167E;
+unicode = 5758;
+},
+{
+glyphname = "ringSmallFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(289,517,o),
+(339,562,o),
+(339,623,cs),
+(339,684,o),
+(289,728,o),
+(231,728,cs),
+(173,728,o),
+(124,685,o),
+(124,623,cs),
+(124,562,o),
+(173,517,o),
+(231,517,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(204,577,o),
+(187,598,o),
+(187,623,cs),
+(187,648,o),
+(205,669,o),
+(231,669,cs),
+(258,669,o),
+(276,648,o),
+(276,623,cs),
+(276,598,o),
+(258,577,o),
+(231,577,cs)
+);
+}
+);
+width = 305;
+}
+);
+note = g725;
+unicode = 6366;
+},
+{
+glyphname = "raiseddotFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(232,589,o),
+(263,620,o),
+(263,659,cs),
+(263,697,o),
+(232,728,o),
+(193,728,cs),
+(154,728,o),
+(123,697,o),
+(123,659,cs),
+(123,620,o),
+(154,589,o),
+(193,589,cs)
+);
+}
+);
+width = 213;
+}
+);
+note = g725;
+unicode = 6367;
+},
+{
+glyphname = "acuteFinal-canadian.base";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "acuteFinal-canadian";
+}
+);
+width = 293;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.base";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "graveFinal-canadian";
+}
+);
+width = 293;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian.base";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 374;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1421;
+},
+{
+glyphname = "ringTophalfFinal-canadian.base";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 375;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.base";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-75,-357);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 315;
+}
+);
+metricLeft = "==|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "plusFinal-canadian.base";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(182,0,l),
+(205,109,l),
+(302,109,l),
+(322,201,l),
+(225,201,l),
+(248,307,l),
+(155,307,l),
+(133,201,l),
+(34,201,l),
+(14,109,l),
+(113,109,l),
+(90,0,l)
+);
+}
+);
+width = 378;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+},
+{
+glyphname = "acuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "acuteFinal-canadian";
+}
+);
+width = 293;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.mid";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "graveFinal-canadian";
+}
+);
+width = 293;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringTophalfFinal-canadian.mid";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-38,-178);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 374;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.mid";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-168);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 315;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "ringFinal-canadian.mid";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-43,-203);
+ref = "ringFinal-canadian";
+}
+);
+width = 412;
+}
+);
+metricLeft = "ringFinal-canadian";
+metricWidth = "ringFinal-canadian";
+note = uni1424;
+},
+{
+glyphname = "doubleacuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "doubleacuteFinal-canadian";
+}
+);
+width = 453;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "doubleacuteFinal-canadian";
+note = uni1425;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian.mid";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "doubleshortverticalstrokesFinal-canadian";
+}
+);
+width = 328;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricWidth = "doubleshortverticalstrokesFinal-canadian";
+note = uni1426;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian.mid";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-40,-189);
+ref = "shorthorizontalstrokeFinal-canadian";
+}
+);
+width = 378;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "shorthorizontalstrokeFinal-canadian";
+note = uni1428;
+},
+{
+glyphname = "downtackFinal-canadian.mid";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-168);
+ref = "downtackFinal-canadian";
+}
+);
+width = 378;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "downtackFinal-canadian";
+note = uni142A;
+},
+{
+glyphname = "e-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (359,470);
+},
+{
+name = top_center_can;
+pos = (417,714);
+},
+{
+name = top_left_can;
+pos = (221,714);
+},
+{
+name = top_right_can;
+pos = (613,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(285,0,l),
+(708,678,l),
+(715,714,l),
+(117,714,l),
+(110,678,l),
+(243,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(331,163,l),
+(252,626,l),
+(222,597,l),
+(556,597,l),
+(530,626,l),
+(258,163,l)
+);
+}
+);
+width = 637;
+}
+);
+metricRight = "=|";
+note = uni1401;
+unicode = 5121;
+},
+{
+glyphname = "aai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (198,0);
+ref = ring_top.canadian;
+}
+);
+width = 636;
+}
+);
+note = uni1402;
+unicode = 5122;
+},
+{
+glyphname = "i-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (335,301);
+},
+{
+name = top_center_can;
+pos = (417,714);
+},
+{
+name = top_left_can;
+pos = (221,714);
+},
+{
+name = top_right_can;
+pos = (614,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(396,714,l),
+(-27,36,l),
+(-34,0,l),
+(564,0,l),
+(571,36,l),
+(438,714,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(350,551,l),
+(429,88,l),
+(459,117,l),
+(125,117,l),
+(150,88,l),
+(423,551,l)
+);
+}
+);
+width = 637;
+}
+);
+metricLeft = "e-canadian";
+metricWidth = "e-canadian";
+note = uni1403;
+unicode = 5123;
+},
+{
+glyphname = "ii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (232,0);
+ref = dot_top;
+}
+);
+width = 636;
+}
+);
+note = uni1404;
+unicode = 5124;
+},
+{
+glyphname = "o-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (273,372);
+},
+{
+name = top_center_can;
+pos = (401,714);
+},
+{
+name = top_double;
+pos = (502,714);
+},
+{
+name = top_left_can;
+pos = (209,714);
+},
+{
+name = top_right_can;
+pos = (604,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(33,0,l),
+(582,334,l),
+(592,380,l),
+(185,714,l),
+(151,714,l),
+(-1,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(237,551,l),
+(184,570,l),
+(447,352,l),
+(442,381,l),
+(107,173,l),
+(154,164,l)
+);
+}
+);
+width = 592;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1405;
+unicode = 5125;
+},
+{
+glyphname = "oo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (23,0);
+ref = dot_top;
+}
+);
+width = 592;
+}
+);
+note = uni1406;
+unicode = 5126;
+},
+{
+glyphname = "yCreeoo-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (139,0);
+ref = doubledot_top;
+}
+);
+width = 592;
+}
+);
+note = uni1407;
+unicode = 5127;
+},
+{
+glyphname = "eeCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(33,0,l),
+(582,334,l),
+(592,380,l),
+(185,714,l),
+(151,714,l),
+(-1,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(227,551,l),
+(207,556,l),
+(453,351,l),
+(461,388,l),
+(127,182,l),
+(144,164,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(272,301,l),
+(301,436,l),
+(254,436,l),
+(226,301,l)
+);
+}
+);
+width = 592;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "o-canadian";
+note = uni1408;
+unicode = 5128;
+},
+{
+glyphname = "iCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (196,15);
+ref = dot_middle_optic_small;
+}
+);
+width = 592;
+}
+);
+note = uni1409;
+unicode = 5129;
+},
+{
+glyphname = "a-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (364,355);
+},
+{
+name = top_center_can;
+pos = (356,714);
+},
+{
+name = top_left_can;
+pos = (194,714);
+},
+{
+name = top_right_can;
+pos = (574,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(603,714,l),
+(54,380,l),
+(44,334,l),
+(451,0,l),
+(485,0,l),
+(637,714,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(399,163,l),
+(452,144,l),
+(189,362,l),
+(194,333,l),
+(529,541,l),
+(482,550,l)
+);
+}
+);
+width = 592;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni140A;
+unicode = 5130;
+},
+{
+glyphname = "aa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (389,0);
+ref = dot_top;
+}
+);
+width = 592;
+}
+);
+note = uni140B;
+unicode = 5131;
+},
+{
+glyphname = "we-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "e-canadian";
+}
+);
+width = 847;
+}
+);
+note = uni140C;
+unicode = 5132;
+},
+{
+glyphname = "weWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (636,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 847;
+}
+);
+note = uni140D;
+unicode = 5133;
+},
+{
+glyphname = "wi-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "i-canadian";
+}
+);
+width = 847;
+}
+);
+note = uni140E;
+unicode = 5134;
+},
+{
+glyphname = "wiWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (636,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 847;
+}
+);
+note = uni140F;
+unicode = 5135;
+},
+{
+glyphname = "wii-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (443,0);
+ref = dot_top;
+}
+);
+width = 847;
+}
+);
+note = uni1410;
+unicode = 5136;
+},
+{
+glyphname = "wiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (232,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (636,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 847;
+}
+);
+note = uni1411;
+unicode = 5137;
+},
+{
+glyphname = "wo-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "o-canadian";
+}
+);
+width = 803;
+}
+);
+note = uni1412;
+unicode = 5138;
+},
+{
+glyphname = "woWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (592,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 803;
+}
+);
+note = uni1413;
+unicode = 5139;
+},
+{
+glyphname = "woo-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (427,0);
+ref = dot_top;
+}
+);
+width = 803;
+}
+);
+note = uni1414;
+unicode = 5140;
+},
+{
+glyphname = "wooWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (23,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (592,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 803;
+}
+);
+note = uni1415;
+unicode = 5141;
+},
+{
+glyphname = "wooNaskapi-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (138,-95);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (281,-212);
+ref = dot_top;
+}
+);
+width = 592;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricWidth = "o-canadian";
+note = uni1416;
+unicode = 5142;
+},
+{
+glyphname = "wa-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "a-canadian";
+}
+);
+width = 803;
+}
+);
+note = uni1417;
+unicode = 5143;
+},
+{
+glyphname = "waWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (592,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 803;
+}
+);
+note = uni1418;
+unicode = 5144;
+},
+{
+glyphname = "waa-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (600,0);
+ref = dot_top;
+}
+);
+width = 803;
+}
+);
+note = uni1419;
+unicode = 5145;
+},
+{
+glyphname = "waaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (389,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (592,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 803;
+}
+);
+note = uni141A;
+unicode = 5146;
+},
+{
+glyphname = "waaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (60,-207);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (244,-95);
+ref = dot_top;
+}
+);
+width = 592;
+}
+);
+metricWidth = "a-canadian";
+note = uni141B;
+unicode = 5147;
+},
+{
+glyphname = "ai-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(254,351,o),
+(292,376,o),
+(319,424,c),
+(292,424,l),
+(302,376,o),
+(337,351,o),
+(392,351,cs),
+(473,351,o),
+(518,395,o),
+(537,487,cs),
+(585,714,l),
+(494,714,l),
+(446,488,ls),
+(438,453,o),
+(422,437,o),
+(395,437,cs),
+(366,437,o),
+(354,454,o),
+(362,489,cs),
+(409,714,l),
+(319,714,l),
+(271,489,ls),
+(264,453,o),
+(247,437,o),
+(221,437,cs),
+(193,437,o),
+(179,455,o),
+(186,488,cs),
+(234,714,l),
+(143,714,l),
+(94,484,ls),
+(78,408,o),
+(121,351,o),
+(201,351,cs)
+);
+}
+);
+width = 532;
+}
+);
+metricRight = "=|";
+note = uni141C;
+unicode = 5148;
+},
+{
+glyphname = "ycreew-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(375,528,o),
+(406,565,o),
+(406,625,cs),
+(406,685,o),
+(374,720,o),
+(330,720,cs),
+(286,720,o),
+(255,685,o),
+(255,625,cs),
+(255,565,o),
+(285,528,o),
+(330,528,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(209,351,o),
+(240,388,o),
+(240,448,cs),
+(240,508,o),
+(208,543,o),
+(164,543,cs),
+(120,543,o),
+(88,508,o),
+(88,448,cs),
+(88,388,o),
+(119,351,o),
+(164,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(147,398,o),
+(137,413,o),
+(137,448,cs),
+(137,482,o),
+(147,496,o),
+(164,496,cs),
+(181,496,o),
+(191,482,o),
+(191,448,cs),
+(191,413,o),
+(181,398,o),
+(164,398,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(314,575,o),
+(303,590,o),
+(303,625,cs),
+(303,659,o),
+(314,673,o),
+(330,673,cs),
+(347,673,o),
+(358,659,o),
+(358,625,cs),
+(358,590,o),
+(347,575,o),
+(330,575,cs)
+);
+}
+);
+width = 373;
+}
+);
+metricRight = "=|";
+note = uni141D;
+unicode = 5149;
+},
+{
+glyphname = "glottalstop-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(358,357,l),
+(363,376,l),
+(295,714,l),
+(274,714,l),
+(63,376,l),
+(59,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(289,616,l),
+(246,617,l),
+(283,401,l),
+(301,428,l),
+(152,428,l),
+(161,401,l)
+);
+}
+);
+width = 374;
+}
+);
+metricRight = "=|";
+note = uni141E;
+unicode = 5150;
+},
+{
+glyphname = "en-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+pos = (636,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 930;
+}
+);
+note = uni142B;
+unicode = 5163;
+},
+{
+glyphname = "in-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+pos = (430,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 723;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142C;
+unicode = 5164;
+},
+{
+glyphname = "on-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (454,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 747;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142D;
+unicode = 5165;
+},
+{
+glyphname = "an-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (563,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 856;
+}
+);
+metricRight = "graveFinal-canadian";
+note = uni142E;
+unicode = 5166;
+},
+{
+glyphname = "pe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (357,470);
+},
+{
+name = top_center_can;
+pos = (416,714);
+},
+{
+name = top_left_can;
+pos = (221,714);
+},
+{
+name = top_right_can;
+pos = (613,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(285,0,l),
+(708,678,l),
+(715,714,l),
+(572,714,l),
+(243,173,l),
+(343,173,l),
+(244,714,l),
+(117,714,l),
+(110,678,l),
+(243,0,l)
+);
+}
+);
+width = 637;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni142F;
+unicode = 5167;
+},
+{
+glyphname = "paai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (198,0);
+ref = ring_top.canadian;
+}
+);
+width = 636;
+}
+);
+note = uni1430;
+unicode = 5168;
+},
+{
+glyphname = "pi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (337,301);
+},
+{
+name = top_center_can;
+pos = (417,714);
+},
+{
+name = top_left_can;
+pos = (221,714);
+},
+{
+name = top_right_can;
+pos = (613,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(396,714,l),
+(-27,36,l),
+(-34,0,l),
+(109,0,l),
+(438,541,l),
+(338,541,l),
+(436,0,l),
+(563,0,l),
+(571,36,l),
+(438,714,l)
+);
+}
+);
+width = 636;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni1431;
+unicode = 5169;
+},
+{
+glyphname = "pii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (232,0);
+ref = dot_top;
+}
+);
+width = 636;
+}
+);
+note = uni1432;
+unicode = 5170;
+},
+{
+glyphname = "po-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (176,373);
+},
+{
+name = top_center_can;
+pos = (384,714);
+},
+{
+name = top_double;
+pos = (497,714);
+},
+{
+name = top_left_can;
+pos = (197,714);
+},
+{
+name = top_right_can;
+pos = (586,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+name = "Thin Slanted";
+shapes = (
+{
+closed = 1;
+nodes = (
+(17,0,l),
+(563,334,l),
+(573,380,l),
+(169,714,l),
+(134,714,l),
+(107,588,l),
+(410,338,l),
+(423,403,l),
+(15,154,l),
+(-18,0,l)
+);
+}
+);
+width = 573;
+}
+);
+metricRight = "o-canadian";
+note = uni1433;
+unicode = 5171;
+},
+{
+glyphname = "poo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (12,0);
+ref = dot_top;
+}
+);
+width = 573;
+}
+);
+note = uni1434;
+unicode = 5172;
+},
+{
+glyphname = "ycreepoo-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (134,0);
+ref = doubledot_top;
+}
+);
+width = 573;
+}
+);
+note = uni1435;
+unicode = 5173;
+},
+{
+glyphname = "heeCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (107,16);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 573;
+}
+);
+note = uni1436;
+unicode = 5174;
+},
+{
+glyphname = "hiCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (83,21);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 573;
+}
+);
+note = uni1437;
+unicode = 5175;
+},
+{
+glyphname = "pa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (391,357);
+},
+{
+name = top_center_can;
+pos = (389,714);
+},
+{
+name = top_left_can;
+pos = (196,714);
+},
+{
+name = top_right_can;
+pos = (573,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(600,714,l),
+(54,380,l),
+(44,334,l),
+(448,0,l),
+(483,0,l),
+(510,126,l),
+(207,376,l),
+(195,311,l),
+(602,560,l),
+(634,714,l)
+);
+}
+);
+width = 573;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1438;
+unicode = 5176;
+},
+{
+glyphname = "paa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (388,0);
+ref = dot_top;
+}
+);
+width = 573;
+}
+);
+note = uni1439;
+unicode = 5177;
+},
+{
+glyphname = "pwe-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "pe-canadian";
+}
+);
+width = 847;
+}
+);
+note = uni143A;
+unicode = 5178;
+},
+{
+glyphname = "pweWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "pe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (636,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 847;
+}
+);
+note = uni143B;
+unicode = 5179;
+},
+{
+glyphname = "pwi-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "pi-canadian";
+}
+);
+width = 847;
+}
+);
+note = uni143C;
+unicode = 5180;
+},
+{
+glyphname = "pwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (636,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 847;
+}
+);
+note = uni143D;
+unicode = 5181;
+},
+{
+glyphname = "pwii-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (443,0);
+ref = dot_top;
+}
+);
+width = 847;
+}
+);
+note = uni143E;
+unicode = 5182;
+},
+{
+glyphname = "pwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (232,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (636,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 847;
+}
+);
+note = uni143F;
+unicode = 5183;
+},
+{
+glyphname = "pwo-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "po-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni1440;
+unicode = 5184;
+},
+{
+glyphname = "pwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (573,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni1441;
+unicode = 5185;
+},
+{
+glyphname = "pwoo-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (409,0);
+ref = dot_top;
+}
+);
+width = 784;
+}
+);
+note = uni1442;
+unicode = 5186;
+},
+{
+glyphname = "pwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (12,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (573,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni1443;
+unicode = 5187;
+},
+{
+glyphname = "pwa-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "pa-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni1444;
+unicode = 5188;
+},
+{
+glyphname = "pwaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (573,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni1445;
+unicode = 5189;
+},
+{
+glyphname = "pwaa-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (599,0);
+ref = dot_top;
+}
+);
+width = 784;
+}
+);
+note = uni1446;
+unicode = 5190;
+},
+{
+glyphname = "pwaaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (388,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (573,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni1447;
+unicode = 5191;
+},
+{
+glyphname = "ycreepwaa-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+pos = (52,-207);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (236,-95);
+ref = dot_top;
+}
+);
+width = 573;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1448;
+unicode = 5192;
+},
+{
+glyphname = "p-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(317,357,l),
+(335,441,l),
+(188,564,l),
+(172,491,l),
+(371,613,l),
+(393,714,l),
+(376,714,l),
+(107,548,l),
+(102,524,l),
+(300,357,l)
+);
+}
+);
+width = 340;
+}
+);
+note = uni1449;
+unicode = 5193;
+},
+{
+glyphname = "pWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(165,357,l),
+(241,714,l),
+(143,714,l),
+(67,357,l)
+);
+}
+);
+width = 188;
+}
+);
+metricRight = "=|";
+note = uni144A;
+unicode = 5194;
+},
+{
+color = 6;
+glyphname = "hCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(128,189,l),
+(155,317,ls),
+(162,350,o),
+(177,365,o),
+(198,365,cs),
+(224,365,o),
+(234,347,o),
+(227,317,cs),
+(200,189,l),
+(297,189,l),
+(328,333,ls),
+(342,401,o),
+(306,452,o),
+(238,452,cs),
+(198,452,o),
+(162,429,o),
+(151,395,c),
+(169,379,l),
+(204,546,l),
+(107,546,l),
+(31,189,l)
+);
+}
+);
+width = 341;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144B;
+unicode = 5195;
+},
+{
+glyphname = "te-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (342,357);
+},
+{
+name = top_center_can;
+pos = (418,714);
+},
+{
+name = top_left_can;
+pos = (222,714);
+},
+{
+name = top_right_can;
+pos = (615,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(458,-14,o),
+(552,73,o),
+(590,250,cs),
+(688,714,l),
+(540.994,714,l),
+(445,262,ls),
+(424,163,o),
+(380,121,o),
+(306,121,cs),
+(216,121,o),
+(181,175,o),
+(203,278,cs),
+(296,714,l),
+(148,714,l),
+(59,292,ls),
+(18,101,o),
+(111,-14,o),
+(295,-14,cs)
+);
+}
+);
+width = 641;
+}
+);
+metricRight = "=|";
+note = uni144C;
+unicode = 5196;
+},
+{
+glyphname = "taai-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (199,0);
+ref = ring_top.canadian;
+}
+);
+width = 641;
+}
+);
+note = uni144D;
+unicode = 5197;
+},
+{
+glyphname = "ti-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (342,357);
+},
+{
+name = middle_right_can;
+pos = (738,357);
+},
+{
+name = top_center_can;
+pos = (418,714);
+},
+{
+name = top_left_can;
+pos = (222,714);
+},
+{
+name = top_right_can;
+pos = (615,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(144,0,l),
+(240,452,ls),
+(261,551,o),
+(305,593,o),
+(379,593,cs),
+(469,593,o),
+(503,539,o),
+(481,436,cs),
+(388.994,0,l),
+(536,0,l),
+(626,422,ls),
+(667,613,o),
+(573,728,o),
+(390,728,cs),
+(227,728,o),
+(133,641,o),
+(95,464,cs),
+(-4,0,l)
+);
+}
+);
+width = 640;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni144E;
+unicode = 5198;
+},
+{
+glyphname = "tii-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (233,0);
+ref = dot_top;
+}
+);
+width = 641;
+}
+);
+note = uni144F;
+unicode = 5199;
+},
+{
+glyphname = "to-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (217,357);
+},
+{
+name = middle_right_can;
+pos = (643,357);
+},
+{
+name = top_center_can;
+pos = (343,714);
+},
+{
+name = top_double;
+pos = (418,714);
+},
+{
+name = top_left_can;
+pos = (200,714);
+},
+{
+name = top_right_can;
+pos = (531,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,0,ls),
+(451,0,o),
+(523,274,o),
+(523,435,cs),
+(523,609,o),
+(418,714,o),
+(231,714,cs),
+(136,714,l),
+(108,580,l),
+(206,580,ls),
+(318,580,o),
+(375,526,o),
+(375,423,cs),
+(375,320,o),
+(332,134,o),
+(129,134,cs),
+(13,134,l),
+(-15,0,l)
+);
+}
+);
+width = 540;
+}
+);
+note = uni1450;
+unicode = 5200;
+},
+{
+glyphname = "too-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (158,0);
+ref = dot_top;
+}
+);
+width = 540;
+}
+);
+note = uni1451;
+unicode = 5201;
+},
+{
+glyphname = "ycreetoo-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (56,0);
+ref = doubledot_top;
+}
+);
+width = 540;
+}
+);
+note = uni1452;
+unicode = 5202;
+},
+{
+glyphname = "deeCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (136,0);
+ref = stroke_middle;
+}
+);
+width = 540;
+}
+);
+note = uni1453;
+unicode = 5203;
+},
+{
+glyphname = "diCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (108,0);
+ref = dot_middle;
+}
+);
+width = 540;
+}
+);
+note = uni1454;
+unicode = 5204;
+},
+{
+glyphname = "ta-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (367,357);
+},
+{
+name = top_center_can;
+pos = (394,714);
+},
+{
+name = top_left_can;
+pos = (205,714);
+},
+{
+name = top_right_can;
+pos = (536,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(447,0,l),
+(475,134,l),
+(377,134,ls),
+(265,134,o),
+(209,188,o),
+(209,291,cs),
+(209,407,o),
+(264,580,o),
+(454,580,cs),
+(571,580,l),
+(599,714,l),
+(461,714,ls),
+(143,714,o),
+(61,451,o),
+(61,279,cs),
+(61,105,o),
+(165,0,o),
+(351,0,cs)
+);
+}
+);
+width = 539;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|to-canadian";
+note = uni1455;
+unicode = 5205;
+},
+{
+glyphname = "taa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (209,0);
+ref = dot_top;
+}
+);
+width = 540;
+}
+);
+note = uni1456;
+unicode = 5206;
+},
+{
+glyphname = "twe-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "te-canadian";
+}
+);
+width = 852;
+}
+);
+note = uni1457;
+unicode = 5207;
+},
+{
+glyphname = "tweWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (641,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 852;
+}
+);
+note = uni1458;
+unicode = 5208;
+},
+{
+glyphname = "twi-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ti-canadian";
+}
+);
+width = 852;
+}
+);
+note = uni1459;
+unicode = 5209;
+},
+{
+glyphname = "twiWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (641,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 852;
+}
+);
+note = uni145A;
+unicode = 5210;
+},
+{
+glyphname = "twii-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (444,0);
+ref = dot_top;
+}
+);
+width = 852;
+}
+);
+note = uni145B;
+unicode = 5211;
+},
+{
+glyphname = "twiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (233,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (641,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 852;
+}
+);
+note = uni145C;
+unicode = 5212;
+},
+{
+glyphname = "two-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "to-canadian";
+}
+);
+width = 750;
+}
+);
+note = uni145D;
+unicode = 5213;
+},
+{
+glyphname = "twoWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (540,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 750;
+}
+);
+note = uni145E;
+unicode = 5214;
+},
+{
+glyphname = "twoo-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (369,0);
+ref = dot_top;
+}
+);
+width = 750;
+}
+);
+note = uni145F;
+unicode = 5215;
+},
+{
+glyphname = "twooWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (158,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (540,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 750;
+}
+);
+note = uni1460;
+unicode = 5216;
+},
+{
+glyphname = "twa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ta-canadian";
+}
+);
+width = 750;
+}
+);
+note = uni1461;
+unicode = 5217;
+},
+{
+glyphname = "twaWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (540,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 750;
+}
+);
+note = uni1462;
+unicode = 5218;
+},
+{
+glyphname = "twaa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (420,0);
+ref = dot_top;
+}
+);
+width = 750;
+}
+);
+note = uni1463;
+unicode = 5219;
+},
+{
+glyphname = "twaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (209,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (540,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 750;
+}
+);
+note = uni1464;
+unicode = 5220;
+},
+{
+glyphname = "twaaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (214,0);
+ref = "ta-canadian";
+}
+);
+width = 754;
+}
+);
+note = uni1465;
+unicode = 5221;
+},
+{
+glyphname = "t-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(292,357,l),
+(312,449,l),
+(263,449,ls),
+(220,449,o),
+(196,472,o),
+(196,511,cs),
+(196,561,o),
+(221,622,o),
+(301,622,cs),
+(349,622,l),
+(368,714,l),
+(313,714,ls),
+(165,714,o),
+(98,610,o),
+(98,498,cs),
+(98,408,o),
+(156,357,o),
+(248,357,cs)
+);
+}
+);
+width = 315;
+}
+);
+note = uni1466;
+unicode = 5222;
+},
+{
+glyphname = "tte-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+pos = (641,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 828;
+}
+);
+note = uni1467;
+unicode = 5223;
+},
+{
+glyphname = "tti-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+pos = (641,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 828;
+}
+);
+note = uni1468;
+unicode = 5224;
+},
+{
+glyphname = "tto-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+pos = (540,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 727;
+}
+);
+note = uni1469;
+unicode = 5225;
+},
+{
+glyphname = "tta-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+pos = (540,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 727;
+}
+);
+note = uni146A;
+unicode = 5226;
+},
+{
+glyphname = "ke-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (308,457);
+},
+{
+name = top_center_can;
+pos = (357,714);
+},
+{
+name = top_left_can;
+pos = (210,714);
+},
+{
+name = top_right_can;
+pos = (501,716);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(425,0,l),
+(517,436,ls),
+(548,579,o),
+(510,728,o),
+(340,728,cs),
+(150,728,o),
+(78,533,o),
+(78,388,cs),
+(78,267,o),
+(138,193,o),
+(238,193,cs),
+(287,193,o),
+(328,217,o),
+(355,267,c),
+(336,275,l),
+(278,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(242,318,o),
+(221,344,o),
+(221,395,cs),
+(221,449,o),
+(247,604,o),
+(326,604,cs),
+(365,604,o),
+(386,578,o),
+(386,526,cs),
+(386,473,o),
+(360,318,o),
+(281,318,cs)
+);
+}
+);
+width = 529;
+}
+);
+metricRight = "te-canadian";
+note = uni146B;
+unicode = 5227;
+},
+{
+glyphname = "kaai-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (148,0);
+ref = ring_top.canadian;
+}
+);
+width = 529;
+}
+);
+note = uni146C;
+unicode = 5228;
+},
+{
+glyphname = "ki-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (318,457);
+},
+{
+name = top_center_can;
+pos = (367,714);
+},
+{
+name = top_left_can;
+pos = (222,714);
+},
+{
+name = top_right_can;
+pos = (516,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(144,0,l),
+(206,294,l),
+(187,270,l),
+(187,227,o),
+(233,193,o),
+(297,193,cs),
+(468,193,o),
+(539,395,o),
+(539,525,cs),
+(539,653,o),
+(468,728,o),
+(349,728,cs),
+(220,728,o),
+(133,642,o),
+(99,482,cs),
+(-4,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(253,318,o),
+(232,344,o),
+(232,395,cs),
+(232,448,o),
+(262,604,o),
+(338,604,cs),
+(376,604,o),
+(397,578,o),
+(397,527,cs),
+(397,473,o),
+(371,318,o),
+(292,318,cs)
+);
+}
+);
+width = 529;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni146D;
+unicode = 5229;
+},
+{
+glyphname = "kii-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (182,0);
+ref = dot_top;
+}
+);
+width = 529;
+}
+);
+note = uni146E;
+unicode = 5230;
+},
+{
+glyphname = "ko-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (277,309);
+},
+{
+name = top_center_can;
+pos = (359,714);
+},
+{
+name = top_double;
+pos = (505,714);
+},
+{
+name = top_left_can;
+pos = (211,714);
+},
+{
+name = top_right_can;
+pos = (505,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(355,-14,o),
+(441,72,o),
+(475,232,cs),
+(578,714,l),
+(430,714,l),
+(368,420,l),
+(387,444,l),
+(387,487,o),
+(341,521,o),
+(277,521,cs),
+(106,521,o),
+(35,318,o),
+(35,189,cs),
+(35,61,o),
+(106,-14,o),
+(226,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(198,110,o),
+(177,135,o),
+(177,187,cs),
+(177,240,o),
+(207,395,o),
+(282,395,cs),
+(320,395,o),
+(342,370,o),
+(342,319,cs),
+(342,264,o),
+(316,110,o),
+(237,110,cs)
+);
+}
+);
+width = 530;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni146F;
+unicode = 5231;
+},
+{
+glyphname = "koo-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (319,0);
+ref = dot_top;
+}
+);
+width = 529;
+}
+);
+note = uni1470;
+unicode = 5232;
+},
+{
+glyphname = "ycreekoo-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (141,0);
+ref = doubledot_top;
+}
+);
+width = 529;
+}
+);
+note = uni1471;
+unicode = 5233;
+},
+{
+glyphname = "ka-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (287,313);
+},
+{
+name = top_center_can;
+pos = (368,714);
+},
+{
+name = top_left_can;
+pos = (222,714);
+},
+{
+name = top_right_can;
+pos = (515,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(423,-14,o),
+(495,181,o),
+(495,326,cs),
+(495,447,o),
+(435,521,o),
+(335,521,cs),
+(287,521,o),
+(246,497,o),
+(219,447,c),
+(237,439,l),
+(296,714,l),
+(148,714,l),
+(56,279,ls),
+(17,98,o),
+(90,-14,o),
+(235,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(209,110,o),
+(188,136,o),
+(188,188,cs),
+(188,241,o),
+(213,396,o),
+(293,396,cs),
+(331,396,o),
+(352,370,o),
+(352,319,cs),
+(352,266,o),
+(327,110,o),
+(247,110,cs)
+);
+}
+);
+width = 529;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "==|ke-canadian";
+note = uni1472;
+unicode = 5234;
+},
+{
+glyphname = "kaa-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (37,0);
+ref = dot_top;
+}
+);
+width = 529;
+}
+);
+note = uni1473;
+unicode = 5235;
+},
+{
+glyphname = "kwe-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ke-canadian";
+}
+);
+width = 740;
+}
+);
+note = uni1474;
+unicode = 5236;
+},
+{
+glyphname = "kweWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (529,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 740;
+}
+);
+note = uni1475;
+unicode = 5237;
+},
+{
+glyphname = "kwi-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ki-canadian";
+}
+);
+width = 740;
+}
+);
+note = uni1476;
+unicode = 5238;
+},
+{
+glyphname = "kwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (529,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 740;
+}
+);
+note = uni1477;
+unicode = 5239;
+},
+{
+glyphname = "kwii-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (393,0);
+ref = dot_top;
+}
+);
+width = 740;
+}
+);
+note = uni1478;
+unicode = 5240;
+},
+{
+glyphname = "kwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (182,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (529,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 740;
+}
+);
+note = uni1479;
+unicode = 5241;
+},
+{
+glyphname = "kwo-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ko-canadian";
+}
+);
+width = 740;
+}
+);
+note = uni147A;
+unicode = 5242;
+},
+{
+glyphname = "kwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (529,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 740;
+}
+);
+note = uni147B;
+unicode = 5243;
+},
+{
+glyphname = "kwoo-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (530,0);
+ref = dot_top;
+}
+);
+width = 740;
+}
+);
+note = uni147C;
+unicode = 5244;
+},
+{
+glyphname = "kwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (319,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (529,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 740;
+}
+);
+note = uni147D;
+unicode = 5245;
+},
+{
+glyphname = "kwa-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ka-canadian";
+}
+);
+width = 740;
+}
+);
+note = uni147E;
+unicode = 5246;
+},
+{
+glyphname = "kwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (529,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 740;
+}
+);
+note = uni147F;
+unicode = 5247;
+},
+{
+glyphname = "kwaa-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (247,0);
+ref = dot_top;
+}
+);
+width = 740;
+}
+);
+note = uni1480;
+unicode = 5248;
+},
+{
+glyphname = "kwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (37,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (529,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 740;
+}
+);
+note = uni1481;
+unicode = 5249;
+},
+{
+glyphname = "kwaaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (214,0);
+ref = "ka-canadian";
+}
+);
+width = 744;
+}
+);
+note = uni1482;
+unicode = 5250;
+},
+{
+glyphname = "k-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(307,351,o),
+(346,457,o),
+(346,524,cs),
+(346,584,o),
+(314,622,o),
+(262,622,cs),
+(225.002,622,o),
+(198,601,o),
+(184,568,c),
+(210,569,l),
+(241,714,l),
+(143,714,l),
+(97,501,ls),
+(82,430,o),
+(102,351,o),
+(202,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(192,423,o),
+(182,435,o),
+(182,458,cs),
+(182,486,o),
+(198,551,o),
+(231,551,cs),
+(248,551,o),
+(257,538,o),
+(257,516,cs),
+(257,487,o),
+(241,423,o),
+(208,423,cs)
+);
+}
+);
+width = 328;
+}
+);
+note = uni1483;
+unicode = 5251;
+},
+{
+glyphname = "kw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(264,350,o),
+(312,394,o),
+(332,487,cs),
+(379,714,l),
+(282,714,l),
+(249,562,l),
+(269,563,l),
+(272,596,o),
+(245,622,o),
+(206,622,cs),
+(121,622,o),
+(83,523,o),
+(83,460,cs),
+(83,393,o),
+(123,350,o),
+(192,350,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(178,422,o),
+(168,435,o),
+(168,457,cs),
+(168,486,o),
+(184,550,o),
+(217,550,cs),
+(234,550,o),
+(244,538,o),
+(244,515,cs),
+(244,488,o),
+(228,422,o),
+(195,422,cs)
+);
+}
+);
+width = 326;
+}
+);
+metricLeft = "=|k-canadian";
+metricRight = "=|k-canadian";
+note = uni1484;
+unicode = 5252;
+},
+{
+glyphname = "southslaveykeh-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+pos = (529,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 717;
+}
+);
+note = uni1485;
+unicode = 5253;
+},
+{
+glyphname = "southslaveykih-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+pos = (529,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 717;
+}
+);
+note = uni1486;
+unicode = 5254;
+},
+{
+glyphname = "southslaveykoh-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+pos = (529,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 717;
+}
+);
+note = uni1487;
+unicode = 5255;
+},
+{
+glyphname = "southslaveykah-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+pos = (529,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 717;
+}
+);
+note = uni1488;
+unicode = 5256;
+},
+{
+glyphname = "ce-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (286,384);
+},
+{
+name = top_center_can;
+pos = (354,714);
+},
+{
+name = top_left_can;
+pos = (209,714);
+},
+{
+name = top_right_can;
+pos = (495,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(416,0,l),
+(516,469,ls),
+(550,630,o),
+(477,728,o),
+(335,728,cs),
+(200,728,o),
+(122,651,o),
+(87,489,cs),
+(67,395,l),
+(213,395,l),
+(236,504,ls),
+(251,571,o),
+(277,600,o),
+(318,600,cs),
+(368,600,o),
+(389,565,o),
+(375,498,cs),
+(269.003,0,l)
+);
+}
+);
+width = 520;
+}
+);
+metricRight = "te-canadian";
+note = uni1489;
+unicode = 5257;
+},
+{
+glyphname = "caai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (148,0);
+ref = ring_top.canadian;
+}
+);
+width = 521;
+}
+);
+note = uni148A;
+unicode = 5258;
+},
+{
+glyphname = "ci-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (298,384);
+},
+{
+name = top_center_can;
+pos = (367,714);
+},
+{
+name = top_left_can;
+pos = (222,714);
+},
+{
+name = top_right_can;
+pos = (511,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(144,0,l),
+(250,504,ls),
+(265,571,o),
+(290,600,o),
+(333,600,cs),
+(383,600,o),
+(403,565,o),
+(389,498,cs),
+(368,395,l),
+(513,395,l),
+(529,469,ls),
+(563,630,o),
+(490,728,o),
+(348,728,cs),
+(213,728,o),
+(135,651,o),
+(100,489,cs),
+(-4,0,l)
+);
+}
+);
+width = 520;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+unicode = 5259;
+},
+{
+glyphname = "cii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:31:56 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (182,0);
+ref = dot_top;
+}
+);
+width = 520;
+}
+);
+note = uni148C;
+unicode = 5260;
+},
+{
+glyphname = "co-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (287,384);
+},
+{
+name = top_center_can;
+pos = (353,714);
+},
+{
+name = top_double;
+pos = (495,714);
+},
+{
+name = top_left_can;
+pos = (209,714);
+},
+{
+name = top_right_can;
+pos = (495,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(352,-14,o),
+(430,63,o),
+(464,225,cs),
+(568,714,l),
+(421.003,714,l),
+(314,210,ls),
+(300,143,o),
+(274,114,o),
+(232,114,cs),
+(182,114,o),
+(161,149,o),
+(175,216,cs),
+(197,319,l),
+(51,319,l),
+(36,245,ls),
+(1,84,o),
+(75,-14,o),
+(216,-14,cs)
+);
+}
+);
+width = 520;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+unicode = 5261;
+},
+{
+glyphname = "coo-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (310,0);
+ref = dot_top;
+}
+);
+width = 521;
+}
+);
+note = uni148E;
+unicode = 5262;
+},
+{
+glyphname = "ycreecoo-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (133,0);
+ref = doubledot_top;
+}
+);
+width = 521;
+}
+);
+note = uni148F;
+unicode = 5263;
+},
+{
+glyphname = "ca-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (299,384);
+},
+{
+name = top_center_can;
+pos = (367,714);
+},
+{
+name = top_left_can;
+pos = (223,714);
+},
+{
+name = top_right_can;
+pos = (509,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(365,-14,o),
+(442,63,o),
+(477,225,cs),
+(497,319,l),
+(351,319,l),
+(328,210,ls),
+(314,143,o),
+(288,114,o),
+(246,114,cs),
+(197,114,o),
+(176,149,o),
+(190,216,cs),
+(296,714,l),
+(148,714,l),
+(49,245,ls),
+(15,84,o),
+(88,-14,o),
+(229,-14,cs)
+);
+}
+);
+width = 520;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+unicode = 5264;
+},
+{
+glyphname = "caa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (37,0);
+ref = dot_top;
+}
+);
+width = 521;
+}
+);
+note = uni1491;
+unicode = 5265;
+},
+{
+glyphname = "cwe-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ce-canadian";
+}
+);
+width = 732;
+}
+);
+note = uni1492;
+unicode = 5266;
+},
+{
+glyphname = "cweWestCree-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (521,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 732;
+}
+);
+note = uni1493;
+unicode = 5267;
+},
+{
+glyphname = "cwi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:31:56 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+pos = (211,0);
+ref = "ci-canadian";
+}
+);
+width = 731;
+}
+);
+note = uni1494;
+unicode = 5268;
+},
+{
+glyphname = "cwiWestCree-canadian";
+lastChange = "2023-01-13 15:31:56 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "ci-canadian";
+},
+{
+anchor = middle_right_can;
+pos = (520,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 731;
+}
+);
+note = uni1495;
+unicode = 5269;
+},
+{
+glyphname = "cwii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:31:56 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+pos = (211,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (393,0);
+ref = dot_top;
+}
+);
+width = 731;
+}
+);
+note = uni1496;
+unicode = 5270;
+},
+{
+glyphname = "cwiiWestCree-canadian";
+lastChange = "2023-01-13 15:31:56 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (182,0);
+ref = dot_top;
+},
+{
+anchor = middle_right_can;
+pos = (520,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 731;
+}
+);
+note = uni1497;
+unicode = 5271;
+},
+{
+glyphname = "cwo-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "co-canadian";
+}
+);
+width = 732;
+}
+);
+note = uni1498;
+unicode = 5272;
+},
+{
+glyphname = "cwoWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (521,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 732;
+}
+);
+note = uni1499;
+unicode = 5273;
+},
+{
+glyphname = "cwoo-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (521,0);
+ref = dot_top;
+}
+);
+width = 732;
+}
+);
+note = uni149A;
+unicode = 5274;
+},
+{
+glyphname = "cwooWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (310,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (521,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 732;
+}
+);
+note = uni149B;
+unicode = 5275;
+},
+{
+glyphname = "cwa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ca-canadian";
+}
+);
+width = 732;
+}
+);
+note = uni149C;
+unicode = 5276;
+},
+{
+glyphname = "cwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (521,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 732;
+}
+);
+note = uni149D;
+unicode = 5277;
+},
+{
+glyphname = "cwaa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (248,0);
+ref = dot_top;
+}
+);
+width = 732;
+}
+);
+note = uni149E;
+unicode = 5278;
+},
+{
+glyphname = "cwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (37,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (521,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 732;
+}
+);
+note = uni149F;
+unicode = 5279;
+},
+{
+glyphname = "cwaaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (214,0);
+ref = "ca-canadian";
+}
+);
+width = 735;
+}
+);
+note = uni14A0;
+unicode = 5280;
+},
+{
+glyphname = "c-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(277,351,o),
+(325,394,o),
+(341,474,cs),
+(348,507,l),
+(258,507,l),
+(249,465,ls),
+(244,441,o),
+(231,427,o),
+(212,427,cs),
+(191,427,o),
+(183,444,o),
+(188,469,cs),
+(241,714,l),
+(143,714,l),
+(97,496,ls),
+(78,408,o),
+(118,351,o),
+(206,351,cs)
+);
+}
+);
+width = 319;
+}
+);
+note = uni14A1;
+unicode = 5281;
+},
+{
+glyphname = "thSayisi-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(258,351,o),
+(304,394,o),
+(322,474,cs),
+(373,714,l),
+(275,714,l),
+(223,467,ls),
+(217,439,o),
+(203,427,o),
+(185,427,cs),
+(163,427,o),
+(156,444,o),
+(161,469,cs),
+(170,507,l),
+(80,507,l),
+(75,487,ls),
+(59,408,o),
+(98,351,o),
+(184,351,cs)
+);
+}
+);
+width = 320;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "=|c-canadian";
+note = uni14A2;
+unicode = 5282;
+},
+{
+glyphname = "me-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (182,357);
+},
+{
+name = top_center_can;
+pos = (334,714);
+},
+{
+name = top_left_can;
+pos = (203,714);
+},
+{
+name = top_right_can;
+pos = (457,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(379,0,l),
+(531,714,l),
+(130,714,l),
+(101,580,l),
+(354,580,l),
+(231,0,l)
+);
+}
+);
+width = 486;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+unicode = 5283;
+},
+{
+glyphname = "maai-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (133,0);
+ref = ring_top.canadian;
+}
+);
+width = 486;
+}
+);
+note = uni14A4;
+unicode = 5284;
+},
+{
+glyphname = "mi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (350,357);
+},
+{
+name = top_center_can;
+pos = (352,714);
+},
+{
+name = top_left_can;
+pos = (225,714);
+},
+{
+name = top_right_can;
+pos = (479,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(146,0,l),
+(270,580,l),
+(523,580,l),
+(552,714,l),
+(151,714,l),
+(-1,0,l)
+);
+}
+);
+width = 485;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+unicode = 5285;
+},
+{
+glyphname = "mii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (167,0);
+ref = dot_top;
+}
+);
+width = 486;
+}
+);
+note = uni14A6;
+unicode = 5286;
+},
+{
+glyphname = "mo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (181,357);
+},
+{
+name = top_center_can;
+pos = (334,714);
+},
+{
+name = top_double;
+pos = (457,714);
+},
+{
+name = top_left_can;
+pos = (203,714);
+},
+{
+name = top_right_can;
+pos = (457,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(379,0,l),
+(531,714,l),
+(383,714,l),
+(260,134,l),
+(6,134,l),
+(-22,0,l)
+);
+}
+);
+width = 486;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+unicode = 5287;
+},
+{
+glyphname = "moo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (272,0);
+ref = dot_top;
+}
+);
+width = 486;
+}
+);
+note = uni14A8;
+unicode = 5288;
+},
+{
+glyphname = "ycreemoo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (95,0);
+ref = doubledot_top;
+}
+);
+width = 486;
+}
+);
+note = uni14A9;
+unicode = 5289;
+},
+{
+glyphname = "ma-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (350,357);
+},
+{
+name = top_center_can;
+pos = (352,714);
+},
+{
+name = top_left_can;
+pos = (225,714);
+},
+{
+name = top_right_can;
+pos = (478,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(400,0,l),
+(428,134,l),
+(175,134,l),
+(298,714,l),
+(151,714,l),
+(-1,0,l)
+);
+}
+);
+width = 485;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+unicode = 5290;
+},
+{
+glyphname = "maa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (40,0);
+ref = dot_top;
+}
+);
+width = 486;
+}
+);
+note = uni14AB;
+unicode = 5291;
+},
+{
+glyphname = "mwe-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "me-canadian";
+}
+);
+width = 697;
+}
+);
+note = uni14AC;
+unicode = 5292;
+},
+{
+glyphname = "mweWestCree-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "me-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (486,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 697;
+}
+);
+note = uni14AD;
+unicode = 5293;
+},
+{
+glyphname = "mwi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "mi-canadian";
+}
+);
+width = 697;
+}
+);
+note = uni14AE;
+unicode = 5294;
+},
+{
+glyphname = "mwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (486,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 697;
+}
+);
+note = uni14AF;
+unicode = 5295;
+},
+{
+glyphname = "mwii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (378,0);
+ref = dot_top;
+}
+);
+width = 697;
+}
+);
+note = uni14B0;
+unicode = 5296;
+},
+{
+glyphname = "mwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (167,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (486,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 697;
+}
+);
+note = uni14B1;
+unicode = 5297;
+},
+{
+glyphname = "mwo-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "mo-canadian";
+}
+);
+width = 697;
+}
+);
+note = uni14B2;
+unicode = 5298;
+},
+{
+glyphname = "mwoWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (486,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 697;
+}
+);
+note = uni14B3;
+unicode = 5299;
+},
+{
+glyphname = "mwoo-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (483,0);
+ref = dot_top;
+}
+);
+width = 697;
+}
+);
+note = uni14B4;
+unicode = 5300;
+},
+{
+glyphname = "mwooWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (272,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (486,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 697;
+}
+);
+note = uni14B5;
+unicode = 5301;
+},
+{
+glyphname = "mwa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ma-canadian";
+}
+);
+width = 697;
+}
+);
+note = uni14B6;
+unicode = 5302;
+},
+{
+glyphname = "mwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (486,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 697;
+}
+);
+note = uni14B7;
+unicode = 5303;
+},
+{
+glyphname = "mwaa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (251,0);
+ref = dot_top;
+}
+);
+width = 697;
+}
+);
+note = uni14B8;
+unicode = 5304;
+},
+{
+glyphname = "mwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (40,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (486,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 697;
+}
+);
+note = uni14B9;
+unicode = 5305;
+},
+{
+glyphname = "mwaaNaskapi-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (214,0);
+ref = "ma-canadian";
+}
+);
+width = 700;
+}
+);
+note = uni14BA;
+unicode = 5306;
+},
+{
+glyphname = "m-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(287,357,l),
+(307,449,l),
+(184,449,l),
+(241,714,l),
+(143,714,l),
+(67,357,l)
+);
+}
+);
+width = 294;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni14BB;
+unicode = 5307;
+},
+{
+glyphname = "mWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "t-canadian";
+}
+);
+width = 315;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "t-canadian";
+note = uni14BC;
+unicode = 5308;
+},
+{
+glyphname = "mh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(272,357,l),
+(348,714,l),
+(251,714,l),
+(194,449,l),
+(71,449,l),
+(51,357,l)
+);
+}
+);
+width = 295;
+}
+);
+metricLeft = "=|m-canadian";
+metricRight = "=|m-canadian";
+note = uni14BD;
+unicode = 5309;
+},
+{
+glyphname = "mAthapascan-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(295,357,l),
+(312,439,l),
+(180,439,l),
+(176,398,l),
+(278,500,ls),
+(315,536,o),
+(344,578,o),
+(344,627,cs),
+(344,682,o),
+(306,720,o),
+(242,720,cs),
+(170,720,o),
+(124,679,o),
+(107,590,c),
+(193,590,l),
+(201,633,o),
+(215,651,o),
+(234,651,cs),
+(250,651,o),
+(259,641,o),
+(259,624,cs),
+(259,592,o),
+(231,557,o),
+(200,527,cs),
+(81,409,l),
+(70,357,l)
+);
+}
+);
+width = 309;
+}
+);
+note = uni14BE;
+unicode = 5310;
+},
+{
+glyphname = "mSayisi-canadian";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = two.canadian;
+}
+);
+width = 522;
+}
+);
+note = uni14BF;
+unicode = 5311;
+},
+{
+glyphname = "ne-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (445,254);
+},
+{
+name = top_center_can;
+pos = (487,526);
+},
+{
+name = top_left_can;
+pos = (170,526);
+},
+{
+name = top_right_can;
+pos = (654,526);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(596,-14,o),
+(671,175,o),
+(671,300,cs),
+(671,425,o),
+(595,506,o),
+(467,506,cs),
+(92,506,l),
+(64,374,l),
+(314,374,l),
+(313,424,l),
+(243,373,o),
+(218,263,o),
+(218,189,cs),
+(218,63,o),
+(294,-14,o),
+(416,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(382,110,o),
+(360,139,o),
+(360,191,cs),
+(360,245,o),
+(386,382,o),
+(465,382,cs),
+(506,382,o),
+(528,353,o),
+(528,301,cs),
+(528,247,o),
+(502,110,o),
+(423,110,cs)
+);
+}
+);
+width = 708;
+}
+);
+metricRight = "=|ke-canadian";
+note = uni14C0;
+unicode = 5312;
+},
+{
+glyphname = "naai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (120,-188);
+ref = ring_top.canadian;
+}
+);
+width = 708;
+}
+);
+note = uni14C1;
+unicode = 5313;
+},
+{
+glyphname = "ni-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (262,254);
+},
+{
+name = top_center_can;
+pos = (340,526);
+},
+{
+name = top_left_can;
+pos = (169,526);
+},
+{
+name = top_right_can;
+pos = (654,526);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(413,-14,o),
+(487,175,o),
+(487,302,cs),
+(487,342,o),
+(478,372,o),
+(460,395,c),
+(445,374,l),
+(695,374,l),
+(724,506,l),
+(299,506,ls),
+(108,506,o),
+(34,318,o),
+(34,192,cs),
+(34,63,o),
+(111,-14,o),
+(232,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,110,o),
+(176,139,o),
+(176,191,cs),
+(176,245,o),
+(203,382,o),
+(282,382,cs),
+(323,382,o),
+(345,353,o),
+(345,301,cs),
+(345,247,o),
+(319,110,o),
+(240,110,cs)
+);
+}
+);
+width = 708;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+unicode = 5314;
+},
+{
+glyphname = "nii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (154,-188);
+ref = dot_top;
+}
+);
+width = 708;
+}
+);
+note = uni14C3;
+unicode = 5315;
+},
+{
+glyphname = "no-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (444,254);
+},
+{
+name = top_center_can;
+pos = (502,526);
+},
+{
+name = top_double;
+pos = (504,526);
+},
+{
+name = top_left_can;
+pos = (170,526);
+},
+{
+name = top_right_can;
+pos = (655,526);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(409,0,ls),
+(600,0,o),
+(674,189,o),
+(674,314,cs),
+(674,444,o),
+(597,521,o),
+(475,521,cs),
+(295,521,o),
+(221,332,o),
+(221,204,cs),
+(221,165,o),
+(230,134,o),
+(248,111,c),
+(263,133,l),
+(12,133,l),
+(-16,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(385,125,o),
+(363,154,o),
+(363,205,cs),
+(363,259,o),
+(389,396,o),
+(468,396,cs),
+(509,396,o),
+(531,367,o),
+(531,316,cs),
+(531,262,o),
+(504,125,o),
+(426,125,cs)
+);
+}
+);
+width = 708;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14C4;
+unicode = 5316;
+},
+{
+glyphname = "noo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (317,-188);
+ref = dot_top;
+}
+);
+width = 708;
+}
+);
+note = uni14C5;
+unicode = 5317;
+},
+{
+glyphname = "ycreenoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (142,-188);
+ref = doubledot_top;
+}
+);
+width = 708;
+}
+);
+note = uni14C6;
+unicode = 5318;
+},
+{
+glyphname = "na-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (264,254);
+},
+{
+name = top_center_can;
+pos = (321,526);
+},
+{
+name = top_double;
+pos = (482,526);
+},
+{
+name = top_left_can;
+pos = (169,526);
+},
+{
+name = top_right_can;
+pos = (654,526);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(615,0,l),
+(643,133,l),
+(394,133,l),
+(395,82,l),
+(465,133,o),
+(490,243,o),
+(490,317,cs),
+(490,443,o),
+(414,521,o),
+(292,521,cs),
+(112,521,o),
+(37,332,o),
+(37,206,cs),
+(37,81,o),
+(113,0,o),
+(241,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(202,125,o),
+(179,154,o),
+(179,205,cs),
+(179,259,o),
+(206,396,o),
+(285,396,cs),
+(326,396,o),
+(348,367,o),
+(348,316,cs),
+(348,262,o),
+(322,125,o),
+(243,125,cs)
+);
+}
+);
+width = 707;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+unicode = 5319;
+},
+{
+glyphname = "naa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (135,-188);
+ref = dot_top;
+}
+);
+width = 708;
+}
+);
+note = uni14C8;
+unicode = 5320;
+},
+{
+glyphname = "nwe-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ne-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni14C9;
+unicode = 5321;
+},
+{
+glyphname = "nweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (708,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni14CA;
+unicode = 5322;
+},
+{
+glyphname = "nwa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "na-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni14CB;
+unicode = 5323;
+},
+{
+glyphname = "nwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (708,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni14CC;
+unicode = 5324;
+},
+{
+glyphname = "nwaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (346,-188);
+ref = dot_top;
+}
+);
+width = 919;
+}
+);
+note = uni14CD;
+unicode = 5325;
+},
+{
+glyphname = "nwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (135,-188);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (708,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni14CE;
+unicode = 5326;
+},
+{
+glyphname = "nwaaNaskapi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (119,-188);
+ref = doubledot_top;
+}
+);
+width = 708;
+}
+);
+note = uni14CF;
+unicode = 5327;
+},
+{
+glyphname = "n-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(418,449,l),
+(438,542,l),
+(301,542,l),
+(297,489,l),
+(332,513,o),
+(351,571,o),
+(351,612,cs),
+(351,678,o),
+(310,720,o),
+(243,720,cs),
+(152,720,o),
+(104,636,o),
+(104,560,cs),
+(104,493,o),
+(146,449,o),
+(215,449,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,520,o),
+(189,534,o),
+(189,558,cs),
+(189,588,o),
+(203,649,o),
+(238,649,cs),
+(256,649,o),
+(266,636,o),
+(266,611,cs),
+(266,581,o),
+(252,520,o),
+(216,520,cs)
+);
+}
+);
+width = 405;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni14D0;
+unicode = 5328;
+},
+{
+color = 6;
+glyphname = "ngCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-167);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 375;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "=|";
+note = uni14D1;
+unicode = 5329;
+},
+{
+glyphname = "nh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(298,449,ls),
+(395,449,o),
+(443,531,o),
+(443,612,cs),
+(443,677,o),
+(400,720,o),
+(335,720,cs),
+(243,720,o),
+(195,636,o),
+(195,560,cs),
+(195,539,o),
+(200,519,o),
+(212,504,c),
+(226,542,l),
+(90,542,l),
+(70,449,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(290,520,o),
+(280,534,o),
+(280,558,cs),
+(280,588,o),
+(295,649,o),
+(329,649,cs),
+(348,649,o),
+(358,636,o),
+(358,611,cs),
+(358,581,o),
+(343,520,o),
+(308,520,cs)
+);
+}
+);
+width = 406;
+}
+);
+metricLeft = "=|n-canadian";
+metricRight = "=|n-canadian";
+note = uni14D2;
+unicode = 5330;
+},
+{
+glyphname = "le-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (444,254);
+},
+{
+name = top_center_can;
+pos = (489,526);
+},
+{
+name = top_left_can;
+pos = (170,526);
+},
+{
+name = top_right_can;
+pos = (654,526);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(353,0,ls),
+(555,0,o),
+(669,120,o),
+(669,293,cs),
+(669,423,o),
+(584,506,o),
+(444,506,cs),
+(92,506,l),
+(64,373,l),
+(416,373,ls),
+(485,373,o),
+(523,339,o),
+(523,280,cs),
+(523,209,o),
+(483,129,o),
+(374,129,cs),
+(351,129,l),
+(323,0,l)
+);
+}
+);
+width = 708;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D3;
+unicode = 5331;
+},
+{
+glyphname = "laai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (122,-188);
+ref = ring_top.canadian;
+}
+);
+width = 708;
+}
+);
+note = uni14D4;
+unicode = 5332;
+},
+{
+glyphname = "li-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (266,254);
+},
+{
+name = top_center_can;
+pos = (342,526);
+},
+{
+name = top_left_can;
+pos = (172,526);
+},
+{
+name = top_right_can;
+pos = (655,526);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(279,0,l),
+(306,129,l),
+(282,129,ls),
+(223,129,o),
+(187,165,o),
+(187,224,cs),
+(187,292,o),
+(226,373,o),
+(335,373,cs),
+(696,373,l),
+(724,506,l),
+(347,506,ls),
+(153,506,o),
+(40,387,o),
+(40,220,cs),
+(40,92,o),
+(124,0,o),
+(252,0,cs)
+);
+}
+);
+width = 708;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14D5;
+unicode = 5333;
+},
+{
+glyphname = "lii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (156,-188);
+ref = dot_top;
+}
+);
+width = 708;
+}
+);
+note = uni14D6;
+unicode = 5334;
+},
+{
+glyphname = "lo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (443,254);
+},
+{
+name = top_center_can;
+pos = (501,526);
+},
+{
+name = top_double;
+pos = (472,526);
+},
+{
+name = top_left_can;
+pos = (170,526);
+},
+{
+name = top_right_can;
+pos = (654,526);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(362,0,ls),
+(555,0,o),
+(668,119,o),
+(668,287,cs),
+(668,414,o),
+(585,506,o),
+(457,506,cs),
+(430,506,l),
+(403,377,l),
+(426,377,ls),
+(486,377,o),
+(522,341,o),
+(522,282,cs),
+(522,214,o),
+(483,133,o),
+(374,133,cs),
+(13,133,l),
+(-16,0,l)
+);
+}
+);
+width = 708;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D7;
+unicode = 5335;
+},
+{
+glyphname = "loo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (316,-188);
+ref = dot_top;
+}
+);
+width = 708;
+}
+);
+note = uni14D8;
+unicode = 5336;
+},
+{
+glyphname = "ycreeloo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (109,-188);
+ref = doubledot_top;
+}
+);
+width = 708;
+}
+);
+note = uni14D9;
+unicode = 5337;
+},
+{
+glyphname = "la-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (265,254);
+},
+{
+name = top_center_can;
+pos = (322,526);
+},
+{
+name = top_left_can;
+pos = (170,526);
+},
+{
+name = top_right_can;
+pos = (654,526);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(615,0,l),
+(643,133,l),
+(292,133,ls),
+(222,133,o),
+(185,167,o),
+(185,226,cs),
+(185,298,o),
+(225,377,o),
+(334,377,cs),
+(357,377,l),
+(384,506,l),
+(354,506,ls),
+(153,506,o),
+(39,387,o),
+(39,213,cs),
+(39,84,o),
+(123,0,o),
+(264,0,cs)
+);
+}
+);
+width = 707;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14DA;
+unicode = 5338;
+},
+{
+glyphname = "laa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (136,-188);
+ref = dot_top;
+}
+);
+width = 708;
+}
+);
+note = uni14DB;
+unicode = 5339;
+},
+{
+glyphname = "lwe-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "le-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni14DC;
+unicode = 5340;
+},
+{
+glyphname = "lweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "le-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (708,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni14DD;
+unicode = 5341;
+},
+{
+glyphname = "lwi-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "li-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni14DE;
+unicode = 5342;
+},
+{
+glyphname = "lwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (708,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni14DF;
+unicode = 5343;
+},
+{
+glyphname = "lwii-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (367,-188);
+ref = dot_top;
+}
+);
+width = 919;
+}
+);
+note = uni14E0;
+unicode = 5344;
+},
+{
+glyphname = "lwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (156,-188);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (708,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni14E1;
+unicode = 5345;
+},
+{
+glyphname = "lwo-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "lo-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni14E2;
+unicode = 5346;
+},
+{
+glyphname = "lwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (708,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni14E3;
+unicode = 5347;
+},
+{
+glyphname = "lwoo-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (527,-188);
+ref = dot_top;
+}
+);
+width = 919;
+}
+);
+note = uni14E4;
+unicode = 5348;
+},
+{
+glyphname = "lwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (316,-188);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (708,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni14E5;
+unicode = 5349;
+},
+{
+glyphname = "lwa-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "la-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni14E6;
+unicode = 5350;
+},
+{
+glyphname = "lwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (708,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni14E7;
+unicode = 5351;
+},
+{
+glyphname = "lwaa-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (347,-188);
+ref = dot_top;
+}
+);
+width = 919;
+}
+);
+note = uni14E8;
+unicode = 5352;
+},
+{
+glyphname = "lwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (136,-188);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (708,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni14E9;
+unicode = 5353;
+},
+{
+glyphname = "l-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(385,357,l),
+(405,449,l),
+(263,449,ls),
+(220,449,o),
+(196,472,o),
+(196,512,cs),
+(196,561,o),
+(221,623,o),
+(297,623,cs),
+(306,623,l),
+(326,714,l),
+(311,714,ls),
+(163,714,o),
+(98,609,o),
+(98,499,cs),
+(98,408,o),
+(157,357,o),
+(256,357,cs)
+);
+}
+);
+width = 392;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "m-canadian";
+note = uni14EA;
+unicode = 5354;
+},
+{
+glyphname = "lWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(276,357,l),
+(289,417,l),
+(166,485,l),
+(154,434,l),
+(309,508,l),
+(318,552,l),
+(193,618,l),
+(183,572,l),
+(337,641,l),
+(352,714,l),
+(337,714,l),
+(123,619,l),
+(116,587,l),
+(244,517,l),
+(252,553,l),
+(94,483,l),
+(87,451,l),
+(261,357,l)
+);
+}
+);
+width = 300;
+}
+);
+metricRight = "=|";
+note = uni14EB;
+unicode = 5355;
+},
+{
+glyphname = "mediall-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(429,-14,l),
+(450,86,l),
+(179,235,l),
+(163,162,l),
+(500,317,l),
+(512,377,l),
+(239,518,l),
+(224,457,l),
+(561,607,l),
+(586,728,l),
+(552,728,l),
+(108,531,l),
+(96,478,l),
+(370,329,l),
+(381,382,l),
+(46,236,l),
+(34,183,l),
+(394,-14,l)
+);
+}
+);
+width = 534;
+}
+);
+metricRight = "=|";
+note = uni14EC;
+unicode = 5356;
+},
+{
+glyphname = "se-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (225,714);
+},
+{
+name = top_right_can;
+pos = (459,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(381,0,l),
+(460,372,l),
+(429,372,ls),
+(294,372,o),
+(237,427,o),
+(270,580,cs),
+(298,714,l),
+(151,714,l),
+(123,583,ls),
+(76,366,o),
+(179,240,o),
+(393,240,cs),
+(409,240,l),
+(294,285,l),
+(233,0,l)
+);
+}
+);
+width = 489;
+}
+);
+note = uni14ED;
+unicode = 5357;
+},
+{
+glyphname = "saai-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (241,0);
+ref = ring_top.canadian;
+}
+);
+width = 489;
+}
+);
+note = uni14EE;
+unicode = 5358;
+},
+{
+glyphname = "si-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (226,714);
+},
+{
+name = top_right_can;
+pos = (461,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(148,0,l),
+(209,287,l),
+(86,240,l),
+(122,240,ls),
+(336,240,o),
+(453,335,o),
+(503,568,cs),
+(534,714,l),
+(386,714,l),
+(357,578,ls),
+(328,443,o),
+(256,372,o),
+(128,372,cs),
+(79,372,l),
+(0,0,l)
+);
+}
+);
+width = 489;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+unicode = 5359;
+},
+{
+glyphname = "sii-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (275,0);
+ref = dot_top;
+}
+);
+width = 489;
+}
+);
+note = uni14F0;
+unicode = 5360;
+},
+{
+glyphname = "so-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (460,714);
+},
+{
+name = top_left_can;
+pos = (225,714);
+},
+{
+name = top_right_can;
+pos = (459,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(147,0,l),
+(176,136,ls),
+(205,271,o),
+(278,342,o),
+(405,342,cs),
+(454,342,l),
+(533,714,l),
+(385,714,l),
+(325,427,l),
+(447,474,l),
+(411,474,ls),
+(197,474,o),
+(80,379,o),
+(30,146,cs),
+(-1,0,l)
+);
+}
+);
+width = 489;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+unicode = 5361;
+},
+{
+glyphname = "soo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (274,0);
+ref = dot_top;
+}
+);
+width = 489;
+}
+);
+note = uni14F2;
+unicode = 5362;
+},
+{
+glyphname = "ycreesoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (97,0);
+ref = doubledot_top;
+}
+);
+width = 489;
+}
+);
+note = uni14F3;
+unicode = 5363;
+},
+{
+glyphname = "sa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (226,714);
+},
+{
+name = top_right_can;
+pos = (460,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(382,0,l),
+(410,131,ls),
+(456,348,o),
+(354,474,o),
+(139,474,cs),
+(124,474,l),
+(238,429,l),
+(299,714,l),
+(152,714,l),
+(73,342,l),
+(103,342,ls),
+(238,342,o),
+(295,287,o),
+(262,134,cs),
+(234,0,l)
+);
+}
+);
+width = 489;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+unicode = 5364;
+},
+{
+glyphname = "saa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (41,0);
+ref = dot_top;
+}
+);
+width = 489;
+}
+);
+note = uni14F5;
+unicode = 5365;
+},
+{
+glyphname = "swe-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "se-canadian";
+}
+);
+width = 699;
+}
+);
+note = uni14F6;
+unicode = 5366;
+},
+{
+glyphname = "sweWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "se-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (489,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 699;
+}
+);
+note = uni14F7;
+unicode = 5367;
+},
+{
+glyphname = "swi-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "si-canadian";
+}
+);
+width = 699;
+}
+);
+note = uni14F8;
+unicode = 5368;
+},
+{
+glyphname = "swiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (489,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 699;
+}
+);
+note = uni14F9;
+unicode = 5369;
+},
+{
+glyphname = "swii-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (486,0);
+ref = dot_top;
+}
+);
+width = 699;
+}
+);
+note = uni14FA;
+unicode = 5370;
+},
+{
+glyphname = "swiiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (275,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (489,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 699;
+}
+);
+note = uni14FB;
+unicode = 5371;
+},
+{
+glyphname = "swo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "so-canadian";
+}
+);
+width = 699;
+}
+);
+note = uni14FC;
+unicode = 5372;
+},
+{
+glyphname = "swoWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (489,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 699;
+}
+);
+note = uni14FD;
+unicode = 5373;
+},
+{
+glyphname = "swoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (485,0);
+ref = dot_top;
+}
+);
+width = 699;
+}
+);
+note = uni14FE;
+unicode = 5374;
+},
+{
+glyphname = "swooWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (274,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (489,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 699;
+}
+);
+note = uni14FF;
+unicode = 5375;
+},
+{
+glyphname = "swa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "sa-canadian";
+}
+);
+width = 699;
+}
+);
+note = uni1500;
+unicode = 5376;
+},
+{
+glyphname = "swaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (489,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 699;
+}
+);
+note = uni1501;
+unicode = 5377;
+},
+{
+glyphname = "swaa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (252,0);
+ref = dot_top;
+}
+);
+width = 699;
+}
+);
+note = uni1502;
+unicode = 5378;
+},
+{
+glyphname = "swaaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (41,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (489,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 699;
+}
+);
+note = uni1503;
+unicode = 5379;
+},
+{
+glyphname = "swaaNaskapi-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (214,0);
+ref = "sa-canadian";
+}
+);
+width = 703;
+}
+);
+note = uni1504;
+unicode = 5380;
+},
+{
+glyphname = "s-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(290,357,l),
+(305,429,ls),
+(327,536,o),
+(279,605,o),
+(177,605,cs),
+(152,605,l),
+(209,568,l),
+(241,714,l),
+(143,714,l),
+(103,529,l),
+(140,529,ls),
+(202,529,o),
+(222,497,o),
+(207,428,cs),
+(192,357,l)
+);
+}
+);
+width = 312;
+}
+);
+metricRight = "=|";
+note = uni1505;
+unicode = 5381;
+},
+{
+color = 6;
+glyphname = "sAthapascan-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(257,183,o),
+(307,231,o),
+(307,298,cs),
+(307,344,o),
+(284,375,o),
+(243,391,cs),
+(204,406,ls),
+(186,413,o),
+(176,425,o),
+(176,441,cs),
+(176,466,o),
+(191,481,o),
+(217,481,cs),
+(242,481,o),
+(254,466,o),
+(248,433,c),
+(336,433,l),
+(349,511,o),
+(296,552,o),
+(223,552,cs),
+(136,552,o),
+(88,504,o),
+(88,432,cs),
+(88,392,o),
+(111,358,o),
+(150,343,cs),
+(189,328,ls),
+(209,320,o),
+(218,308,o),
+(218,292,cs),
+(218,269,o),
+(203,254,o),
+(178,254,cs),
+(150,254,o),
+(135,267,o),
+(143,303,c),
+(55,303,l),
+(42,226,o),
+(91,183,o),
+(174,183,cs)
+);
+}
+);
+width = 344;
+}
+);
+metricRight = "=|";
+note = uni1506;
+unicode = 5382;
+},
+{
+glyphname = "sw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(163,357,l),
+(178,427,ls),
+(193,499,o),
+(227,529,o),
+(295,529,cs),
+(324,529,l),
+(364,714,l),
+(266,714,l),
+(235,569,l),
+(309,605,l),
+(271,605,ls),
+(169,605,o),
+(105,547,o),
+(82,434,cs),
+(66,357,l)
+);
+}
+);
+width = 310;
+}
+);
+metricLeft = "=|s-canadian";
+metricRight = "=|s-canadian";
+note = uni1507;
+unicode = 5383;
+},
+{
+glyphname = "sBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(296,357,l),
+(316,449,l),
+(241,449,ls),
+(204,449,o),
+(188,469,o),
+(197,508,cs),
+(241,714,l),
+(143,714,l),
+(102,518,ls),
+(81,420,o),
+(129,357,o),
+(228,357,cs)
+);
+}
+);
+width = 303;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "m-canadian";
+note = uni1508;
+unicode = 5384;
+},
+{
+glyphname = "moosecreesk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(293,225,o),
+(326,360,o),
+(326,449,cs),
+(326,548,o),
+(276,606,o),
+(182,606,cs),
+(169,606,l),
+(210,570,l),
+(241,714,l),
+(143,714,l),
+(104,530,l),
+(143,530,ls),
+(219,530,o),
+(238,508,o),
+(237,444,c),
+(256,440,l),
+(252,464,o),
+(232,493,o),
+(189,493,cs),
+(100,493,o),
+(67,393,o),
+(67,336,cs),
+(67,269,o),
+(108,225,o),
+(177,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(162,295,o),
+(153,308,o),
+(153,331,cs),
+(153,360,o),
+(169,426,o),
+(203,426,cs),
+(221,426,o),
+(231,413,o),
+(231,390,cs),
+(231,362,o),
+(214,295,o),
+(181,295,cs)
+);
+}
+);
+width = 338;
+}
+);
+metricRight = "=|";
+note = uni1509;
+unicode = 5385;
+},
+{
+glyphname = "skwNaskapi-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(274,225,o),
+(319,317,o),
+(319,393,cs),
+(319,453,o),
+(287,493,o),
+(236,493,cs),
+(201,493,o),
+(173,474,o),
+(164,444,c),
+(184,446,l),
+(207,508,o),
+(237,530,o),
+(314,530,cs),
+(352,530,l),
+(390,714,l),
+(293,714,l),
+(262,568,l),
+(324,606,l),
+(305,606,ls),
+(128,606,o),
+(71,444,o),
+(71,341,cs),
+(71,272,o),
+(109,225,o),
+(180,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(164,295,o),
+(155,308,o),
+(155,331,cs),
+(155,360,o),
+(171,426,o),
+(205,426,cs),
+(223,426,o),
+(233,413,o),
+(233,390,cs),
+(233,362,o),
+(216,295,o),
+(183,295,cs)
+);
+}
+);
+width = 339;
+}
+);
+metricLeft = "=|moosecreesk-canadian";
+metricRight = "=|moosecreesk-canadian";
+note = uni150A;
+unicode = 5386;
+},
+{
+glyphname = "swNaskapi-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(273,195,l),
+(284,247,ls),
+(307,356,o),
+(253,425,o),
+(156,425,cs),
+(132,425,l),
+(180,389,l),
+(208,519,l),
+(110,519,l),
+(75,349,l),
+(113,349,ls),
+(173,349,o),
+(202,322,o),
+(187,250,cs),
+(175,195,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(239,14,o),
+(270,45,o),
+(270,85,cs),
+(270,124,o),
+(239,155,o),
+(200,155,cs),
+(163,155,o),
+(131,124,o),
+(131,85,cs),
+(131,45,o),
+(163,14,o),
+(200,14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(222,559,o),
+(253,591,o),
+(253,629,cs),
+(253,669,o),
+(222,700,o),
+(183,700,cs),
+(145,700,o),
+(114,669,o),
+(114,629,cs),
+(114,591,o),
+(145,559,o),
+(183,559,cs)
+);
+}
+);
+width = 339;
+}
+);
+metricRight = "=|";
+note = uni150B;
+unicode = 5387;
+},
+{
+glyphname = "spwaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(483,0,l),
+(510,126,l),
+(207,376,l),
+(195,311,l),
+(602,560,l),
+(634,714,l),
+(600,714,l),
+(54,380,l),
+(44,334,l),
+(448,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(222,523,o),
+(253,555,o),
+(253,593,cs),
+(253,632,o),
+(221,664,o),
+(183,664,cs),
+(146,664,o),
+(114,632,o),
+(114,593,cs),
+(114,554,o),
+(146,523,o),
+(183,523,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(408,636,l),
+(420,692,ls),
+(437,770,o),
+(401,821,o),
+(325,821,cs),
+(294,821,l),
+(358,790,l),
+(381,896,l),
+(287,896,l),
+(256,750,l),
+(277,750,ls),
+(319,750,o),
+(334,728,o),
+(324,681,cs),
+(314,636,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(581,738,o),
+(613,770,o),
+(613,808,cs),
+(613,847,o),
+(581,879,o),
+(543,879,cs),
+(505,879,o),
+(474,847,o),
+(474,808,cs),
+(474,770,o),
+(505,738,o),
+(543,738,cs)
+);
+}
+);
+width = 573;
+}
+);
+metricRight = "pa-canadian";
+metricWidth = "pa-canadian";
+note = uni150C;
+unicode = 5388;
+},
+{
+glyphname = "stwaNaskapi-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (340,0);
+ref = "ta-canadian";
+}
+);
+width = 880;
+}
+);
+note = uni150D;
+unicode = 5389;
+},
+{
+glyphname = "skwaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (340,0);
+ref = "ka-canadian";
+}
+);
+width = 869;
+}
+);
+note = uni150E;
+unicode = 5390;
+},
+{
+glyphname = "scwaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (340,0);
+ref = "ca-canadian";
+}
+);
+width = 861;
+}
+);
+note = uni150F;
+unicode = 5391;
+},
+{
+glyphname = "she-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (352,714);
+},
+{
+name = top_right_can;
+pos = (728,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(623,-14,o),
+(698,70,o),
+(731,226,cs),
+(751,319,l),
+(605,319,l),
+(582,210,ls),
+(568,142,o),
+(545,114,o),
+(506,114,cs),
+(461,114,o),
+(446,148,o),
+(457,215,cs),
+(502,468,ls),
+(531,638,o),
+(463,728,o),
+(327,728,cs),
+(197,728,o),
+(121,644,o),
+(88,488,cs),
+(68,395,l),
+(214,395,l),
+(237,504,ls),
+(252,572,o),
+(274,600,o),
+(314,600,cs),
+(358,600,o),
+(373,566,o),
+(362,499,cs),
+(317,246,ls),
+(288,76,o),
+(357,-14,o),
+(493,-14,cs)
+);
+}
+);
+width = 775;
+}
+);
+metricRight = "=|";
+note = uni1510;
+unicode = 5392;
+},
+{
+glyphname = "shi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (243,714);
+},
+{
+name = top_right_can;
+pos = (619,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(336,-14,o),
+(408,56,o),
+(451,231,cs),
+(517,499,ls),
+(535,574,o),
+(556,600,o),
+(596,600,cs),
+(640,600,o),
+(657,566,o),
+(642,497,cs),
+(621,395,l),
+(767,395,l),
+(781,460,ls),
+(815,619,o),
+(748,728,o),
+(605,728,cs),
+(482,728,o),
+(412,658,o),
+(369,483,cs),
+(302,214,ls),
+(283,140,o),
+(262,114,o),
+(222,114,cs),
+(179,114,o),
+(162,148,o),
+(177,217,cs),
+(198,319,l),
+(52,319,l),
+(38,254,ls),
+(4,94,o),
+(71,-14,o),
+(214,-14,cs)
+);
+}
+);
+width = 775;
+}
+);
+metricLeft = "she-canadian";
+metricRight = "she-canadian";
+note = uni1511;
+unicode = 5393;
+},
+{
+glyphname = "shii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (434,0);
+ref = dot_top;
+}
+);
+width = 775;
+}
+);
+note = uni1512;
+unicode = 5394;
+},
+{
+glyphname = "sho-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (457,526);
+},
+{
+name = top_left_can;
+pos = (314,526);
+},
+{
+name = top_right_can;
+pos = (599,526);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(296,112,l),
+(220,115,o),
+(173,145,o),
+(173,192,cs),
+(173,233,o),
+(199,264,o),
+(246,264,cs),
+(344,264,o),
+(401,111,o),
+(562,111,cs),
+(692,111,o),
+(767,204,o),
+(767,320,cs),
+(767,437,o),
+(672,517,o),
+(528,521,c),
+(502,394,l),
+(578,391,o),
+(626,361,o),
+(626,314,cs),
+(626,273,o),
+(599,242,o),
+(552,242,cs),
+(454,242,o),
+(397,396,o),
+(236,396,cs),
+(101,396,o),
+(31,297,o),
+(31,187,cs),
+(31,70,o),
+(127,-10,o),
+(269,-14,c)
+);
+}
+);
+width = 797;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1513;
+unicode = 5395;
+},
+{
+glyphname = "shoo-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (271,-188);
+ref = dot_top;
+}
+);
+width = 796;
+}
+);
+note = uni1514;
+unicode = 5396;
+},
+{
+glyphname = "sha-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (457,526);
+},
+{
+name = top_left_can;
+pos = (314,526);
+},
+{
+name = top_right_can;
+pos = (599,526);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(605,-19,o),
+(746,65,o),
+(746,228,cs),
+(746,326,o),
+(681,396,o),
+(575,396,cs),
+(429,396,o),
+(330,242,o),
+(249,242,cs),
+(216,242,o),
+(197,262,o),
+(197,293,cs),
+(197,364,o),
+(265,394,o),
+(345,394,c),
+(373,521,l),
+(192,525,o),
+(50,441,o),
+(50,278,cs),
+(50,180,o),
+(116,111,o),
+(222,111,cs),
+(367,111,o),
+(467,264,o),
+(547,264,cs),
+(580,264,o),
+(600,245,o),
+(600,214,cs),
+(600,143,o),
+(532,112,o),
+(451,112,c),
+(424,-14,l)
+);
+}
+);
+width = 796;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1515;
+unicode = 5397;
+},
+{
+glyphname = "shaa-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (272,-188);
+ref = dot_top;
+}
+);
+width = 796;
+}
+);
+note = uni1516;
+unicode = 5398;
+},
+{
+glyphname = "shwe-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "she-canadian";
+}
+);
+width = 986;
+}
+);
+note = uni1517;
+unicode = 5399;
+},
+{
+glyphname = "shweWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "she-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (775,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 986;
+}
+);
+note = uni1518;
+unicode = 5400;
+},
+{
+glyphname = "shwi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "shi-canadian";
+}
+);
+width = 986;
+}
+);
+note = uni1519;
+unicode = 5401;
+},
+{
+glyphname = "shwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (775,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 986;
+}
+);
+note = uni151A;
+unicode = 5402;
+},
+{
+glyphname = "shwii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (644,0);
+ref = dot_top;
+}
+);
+width = 986;
+}
+);
+note = uni151B;
+unicode = 5403;
+},
+{
+glyphname = "shwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (434,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (775,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 986;
+}
+);
+note = uni151C;
+unicode = 5404;
+},
+{
+glyphname = "shwo-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "sho-canadian";
+}
+);
+width = 1007;
+}
+);
+note = uni151D;
+unicode = 5405;
+},
+{
+glyphname = "shwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (796,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1007;
+}
+);
+note = uni151E;
+unicode = 5406;
+},
+{
+glyphname = "shwoo-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (482,-188);
+ref = dot_top;
+}
+);
+width = 1007;
+}
+);
+note = uni151F;
+unicode = 5407;
+},
+{
+glyphname = "shwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (271,-188);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (796,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1007;
+}
+);
+note = uni1520;
+unicode = 5408;
+},
+{
+glyphname = "shwa-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "sha-canadian";
+}
+);
+width = 1007;
+}
+);
+note = uni1521;
+unicode = 5409;
+},
+{
+glyphname = "shwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (796,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1007;
+}
+);
+note = uni1522;
+unicode = 5410;
+},
+{
+glyphname = "shwaa-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (482,-188);
+ref = dot_top;
+}
+);
+width = 1007;
+}
+);
+note = uni1523;
+unicode = 5411;
+},
+{
+glyphname = "shwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (272,-188);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (796,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1007;
+}
+);
+note = uni1524;
+unicode = 5412;
+},
+{
+glyphname = "sh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(509,290,o),
+(617,353,o),
+(617,480,cs),
+(617,554,o),
+(565,608,o),
+(482,608,cs),
+(385,608,o),
+(313,508,o),
+(251,508,cs),
+(223,508,o),
+(207,524,o),
+(207,549,cs),
+(207,601,o),
+(256,636,o),
+(336,633,c),
+(356,723,l),
+(215,729,o),
+(106,666,o),
+(106,540,cs),
+(106,465,o),
+(158,411,o),
+(241,411,cs),
+(338,411,o),
+(410,511,o),
+(472,511,cs),
+(500,511,o),
+(516,495,o),
+(516,470,cs),
+(516,419,o),
+(468,382,o),
+(388,386,c),
+(368,295,l)
+);
+}
+);
+width = 613;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni1525;
+unicode = 5413;
+},
+{
+glyphname = "ye-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (601,357);
+},
+{
+name = top_left_can;
+pos = (198,714);
+},
+{
+name = top_right_can;
+pos = (482,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(404,0,l),
+(480,357,l),
+(238,357,l),
+(246,311,l),
+(551,637,l),
+(451,726,l),
+(30,267,l),
+(22,229,l),
+(305,229,l),
+(257,0,l)
+);
+}
+);
+width = 510;
+}
+);
+note = uni1526;
+unicode = 5414;
+},
+{
+glyphname = "yaai-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (6,0);
+ref = ring_top.canadian;
+}
+);
+width = 510;
+}
+);
+note = uni1527;
+unicode = 5415;
+},
+{
+glyphname = "yi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (225,714);
+},
+{
+name = top_right_can;
+pos = (509,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(146,0,l),
+(194,229,l),
+(477,229,l),
+(486,267,l),
+(234,726,l),
+(117,660,l),
+(310,316,l),
+(317,357,l),
+(74,357,l),
+(-2,0,l)
+);
+}
+);
+width = 510;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni1528;
+unicode = 5416;
+},
+{
+glyphname = "yii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (40,0);
+ref = dot_top;
+}
+);
+width = 510;
+}
+);
+note = uni1529;
+unicode = 5417;
+},
+{
+glyphname = "yo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (601,357);
+},
+{
+name = top_double;
+pos = (482,714);
+},
+{
+name = top_left_can;
+pos = (198,714);
+},
+{
+name = top_right_can;
+pos = (482,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(437,54,l),
+(244,398,l),
+(237,357,l),
+(480,357,l),
+(555,714,l),
+(408,714,l),
+(359,485,l),
+(77,485,l),
+(68,447,l),
+(320,-12,l)
+);
+}
+);
+width = 510;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152A;
+unicode = 5418;
+},
+{
+glyphname = "yoo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (297,0);
+ref = dot_top;
+}
+);
+width = 510;
+}
+);
+note = uni152B;
+unicode = 5419;
+},
+{
+glyphname = "ycreeyoo-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (120,0);
+ref = doubledot_top;
+}
+);
+width = 510;
+}
+);
+note = uni152C;
+unicode = 5420;
+},
+{
+glyphname = "ya-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (224,714);
+},
+{
+name = top_right_can;
+pos = (507,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(524,447,l),
+(532,485,l),
+(249,485,l),
+(297,714,l),
+(150,714,l),
+(74,357,l),
+(316,357,l),
+(308,403,l),
+(4,77,l),
+(103,-12,l)
+);
+}
+);
+width = 510;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152D;
+unicode = 5421;
+},
+{
+glyphname = "yaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (39,0);
+ref = dot_top;
+}
+);
+width = 510;
+}
+);
+note = uni152E;
+unicode = 5422;
+},
+{
+glyphname = "ywe-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ye-canadian";
+}
+);
+width = 721;
+}
+);
+note = uni152F;
+unicode = 5423;
+},
+{
+glyphname = "yweWestCree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ye-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (510,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 721;
+}
+);
+note = uni1530;
+unicode = 5424;
+},
+{
+glyphname = "ywi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "yi-canadian";
+}
+);
+width = 721;
+}
+);
+note = uni1531;
+unicode = 5425;
+},
+{
+glyphname = "ywiWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (510,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 721;
+}
+);
+note = uni1532;
+unicode = 5426;
+},
+{
+glyphname = "ywii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (251,0);
+ref = dot_top;
+}
+);
+width = 721;
+}
+);
+note = uni1533;
+unicode = 5427;
+},
+{
+glyphname = "ywiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (40,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (510,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 721;
+}
+);
+note = uni1534;
+unicode = 5428;
+},
+{
+glyphname = "ywo-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "yo-canadian";
+}
+);
+width = 721;
+}
+);
+note = uni1535;
+unicode = 5429;
+},
+{
+glyphname = "ywoWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (510,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 721;
+}
+);
+note = uni1536;
+unicode = 5430;
+},
+{
+glyphname = "ywoo-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (508,0);
+ref = dot_top;
+}
+);
+width = 721;
+}
+);
+note = uni1537;
+unicode = 5431;
+},
+{
+glyphname = "ywooWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (297,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (510,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 721;
+}
+);
+note = uni1538;
+unicode = 5432;
+},
+{
+glyphname = "ywa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ya-canadian";
+}
+);
+width = 721;
+}
+);
+note = uni1539;
+unicode = 5433;
+},
+{
+glyphname = "ywaWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (510,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 721;
+}
+);
+note = uni153A;
+unicode = 5434;
+},
+{
+glyphname = "ywaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (250,0);
+ref = dot_top;
+}
+);
+width = 721;
+}
+);
+note = uni153B;
+unicode = 5435;
+},
+{
+glyphname = "ywaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (39,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (510,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 721;
+}
+);
+note = uni153C;
+unicode = 5436;
+},
+{
+glyphname = "ywaaNaskapi-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (214,0);
+ref = "ya-canadian";
+}
+);
+width = 724;
+}
+);
+note = uni153D;
+unicode = 5437;
+},
+{
+glyphname = "y-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(348,573,l),
+(354,600,l),
+(221,600,l),
+(245,714,l),
+(147.994,714,l),
+(106,519,l),
+(233,519,l),
+(234,577,l),
+(78,405,l),
+(144,348,l)
+);
+}
+);
+width = 302;
+}
+);
+note = uni153E;
+unicode = 5438;
+},
+{
+glyphname = "biblecreey-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(150,357,l),
+(253,613,l),
+(200,613,l),
+(228,357,l),
+(286,357,l),
+(424,613,l),
+(367,613,l),
+(364,357,l),
+(451,357,l),
+(456,380,l),
+(458,714,l),
+(387,714,l),
+(240,440,l),
+(300,440,l),
+(273,714,l),
+(202,714,l),
+(62,380,l),
+(57,357,l)
+);
+}
+);
+width = 464;
+}
+);
+metricRight = "=|";
+note = uni153F;
+unicode = 5439;
+},
+{
+glyphname = "yWestCree-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(227,214,l),
+(250,322,l),
+(348,322,l),
+(368,415,l),
+(270,415,l),
+(293,521,l),
+(200,521,l),
+(178,415,l),
+(80,415,l),
+(60,322,l),
+(158,322,l),
+(135,214,l)
+);
+}
+);
+width = 379;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1540;
+unicode = 5440;
+},
+{
+glyphname = "yiSayisi-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (40,189);
+ref = "fullstop-canadian";
+}
+);
+width = 337;
+}
+);
+metricLeft = "fullstop-canadian";
+metricWidth = "fullstop-canadian";
+note = uni1541;
+unicode = 5441;
+},
+{
+glyphname = "re-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (329,526);
+},
+{
+name = top_left_can;
+pos = (182,526);
+},
+{
+name = top_right_can;
+pos = (691,526);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(370,-14,o),
+(448,59,o),
+(482,216,cs),
+(515,374,l),
+(732,374,l),
+(760,506,l),
+(400,506,l),
+(337,209,ls),
+(323,142,o),
+(296,114,o),
+(251,114,cs),
+(198,114,o),
+(176,149,o),
+(191,219,cs),
+(252,506,l),
+(105,506,l),
+(49,242,ls),
+(15,87,o),
+(91,-14,o),
+(243,-14,cs)
+);
+}
+);
+width = 744;
+}
+);
+metricRight = "=|ne-canadian";
+note = uni1542;
+unicode = 5442;
+},
+{
+glyphname = "reRCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (530,526);
+},
+{
+name = top_left_can;
+pos = (169,526);
+},
+{
+name = top_right_can;
+pos = (678,526);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(573,-14,o),
+(652,59,o),
+(685,216,cs),
+(747,506,l),
+(600,506,l),
+(537,209,ls),
+(522,142,o),
+(495,114,o),
+(450,114,cs),
+(398,114,o),
+(376,149,o),
+(391,219,cs),
+(452,506,l),
+(92,506,l),
+(64,374,l),
+(280,374,l),
+(252,242,ls),
+(219,87,o),
+(295,-14,o),
+(446,-14,cs)
+);
+}
+);
+width = 744;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1543;
+unicode = 5443;
+},
+{
+glyphname = "leWestCree-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (531,526);
+},
+{
+name = top_left_can;
+pos = (169,526);
+},
+{
+name = top_right_can;
+pos = (678,526);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(344,0,l),
+(408,297,ls),
+(422,364,o),
+(449,392,o),
+(494,392,cs),
+(546,392,o),
+(568,358,o),
+(553,288,cs),
+(492,0,l),
+(640,0,l),
+(696,264,ls),
+(729,420,o),
+(653,521,o),
+(502,521,cs),
+(375,521,o),
+(296,447,o),
+(263,290,cs),
+(229,133,l),
+(12,133,l),
+(-16,0,l)
+);
+}
+);
+width = 745;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+unicode = 5444;
+},
+{
+glyphname = "raai-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (110,-188);
+ref = ring_top.canadian;
+}
+);
+width = 744;
+}
+);
+note = uni1545;
+unicode = 5445;
+},
+{
+glyphname = "ri-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (330,526);
+},
+{
+name = top_left_can;
+pos = (183,526);
+},
+{
+name = top_right_can;
+pos = (691,526);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(145,0,l),
+(208,297,ls),
+(222,364,o),
+(249,392,o),
+(295,392,cs),
+(346,392,o),
+(368,357,o),
+(354,288,cs),
+(292,0,l),
+(652,0,l),
+(680,133,l),
+(464,133,l),
+(492,264,ls),
+(526,419,o),
+(450,521,o),
+(305,521,cs),
+(171,521,o),
+(93,447,o),
+(59,290,cs),
+(-3,0,l)
+);
+}
+);
+width = 744;
+}
+);
+metricLeft = "re-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+unicode = 5446;
+},
+{
+glyphname = "rii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (144,-188);
+ref = dot_top;
+}
+);
+width = 744;
+}
+);
+note = uni1547;
+unicode = 5447;
+},
+{
+glyphname = "ro-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (315,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(147,0,l),
+(209,294,l),
+(139,229,l),
+(217,229,ls),
+(431,229,o),
+(501,377,o),
+(501,511,cs),
+(501,635,o),
+(419,714,o),
+(284,714,cs),
+(151,714,l),
+(123,583,l),
+(257,583,ls),
+(321,583,o),
+(354,552,o),
+(354,496,cs),
+(354,417,o),
+(312,358,o),
+(211,358,cs),
+(76,358,l),
+(0,0,l)
+);
+}
+);
+width = 490;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1548;
+unicode = 5448;
+},
+{
+glyphname = "roo-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (130,0);
+ref = dot_top;
+}
+);
+width = 490;
+}
+);
+note = uni1549;
+unicode = 5449;
+},
+{
+glyphname = "loWestCree-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (315,714);
+},
+{
+name = top_left_can;
+pos = (225,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(169,0,ls),
+(382,0,o),
+(453,148,o),
+(453,282,cs),
+(453,406,o),
+(371,485,o),
+(235,485,cs),
+(185,485,l),
+(236,419,l),
+(298,714,l),
+(151,714,l),
+(75,357,l),
+(210,357,ls),
+(274,357,o),
+(307,326,o),
+(307,271,cs),
+(307,191,o),
+(264,132,o),
+(163,132,cs),
+(27,132,l),
+(-1,0,l)
+);
+}
+);
+width = 491;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+unicode = 5450;
+},
+{
+glyphname = "ra-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (370,714);
+},
+{
+name = top_right_can;
+pos = (460,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(383,0,l),
+(458,357,l),
+(325,357,ls),
+(261,357,o),
+(227,388,o),
+(227,443,cs),
+(227,523,o),
+(271,582,o),
+(371,582,cs),
+(506,582,l),
+(534,714,l),
+(365,714,ls),
+(152,714,o),
+(82,566,o),
+(82,432,cs),
+(82,308,o),
+(163,229,o),
+(299,229,cs),
+(349,229,l),
+(298,295,l),
+(235,0,l)
+);
+}
+);
+width = 490;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+unicode = 5451;
+},
+{
+glyphname = "raa-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (185,0);
+ref = dot_top;
+}
+);
+width = 490;
+}
+);
+note = uni154C;
+unicode = 5452;
+},
+{
+glyphname = "laWestCree-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (462,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(384,0,l),
+(412,131,l),
+(278,131,ls),
+(214,131,o),
+(181,162,o),
+(181,218,cs),
+(181,297,o),
+(223,356,o),
+(324,356,cs),
+(460,356,l),
+(536,714,l),
+(388,714,l),
+(326,420,l),
+(396,485,l),
+(318,485,ls),
+(105,485,o),
+(34,337,o),
+(34,203,cs),
+(34,79,o),
+(116,0,o),
+(252,0,cs)
+);
+}
+);
+width = 491;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+unicode = 5453;
+},
+{
+glyphname = "rwaa-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (396,0);
+ref = dot_top;
+}
+);
+width = 701;
+}
+);
+note = uni154E;
+unicode = 5454;
+},
+{
+glyphname = "rwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (185,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (490,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 701;
+}
+);
+note = uni154F;
+unicode = 5455;
+},
+{
+glyphname = "r-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(264,357,l),
+(304,545,l),
+(243,545,ls),
+(214,545,o),
+(200,558,o),
+(200,580,cs),
+(200,613,o),
+(219,635,o),
+(261,635,cs),
+(323,635,l),
+(340,714,l),
+(276,714,ls),
+(175,714,o),
+(107,667,o),
+(107,575,cs),
+(107,513,o),
+(151,468,o),
+(223,468,cs),
+(246,468,l),
+(195,491,l),
+(166,357,l)
+);
+}
+);
+width = 287;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni1550;
+unicode = 5456;
+},
+{
+glyphname = "rWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(143,714,l),
+(131,654,l),
+(254,586,l),
+(265,637,l),
+(111,563,l),
+(102,519,l),
+(226,453,l),
+(236,499,l),
+(83,430,l),
+(67,357,l),
+(83,357,l),
+(296,452,l),
+(303,484,l),
+(175,554,l),
+(167,518,l),
+(325,588,l),
+(332,620,l),
+(159,714,l)
+);
+}
+);
+width = 299;
+}
+);
+metricLeft = "=|lWestCree-canadian";
+metricRight = "=|lWestCree-canadian";
+note = uni1551;
+unicode = 5457;
+},
+{
+glyphname = "rMedial-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(27,-14,l),
+(470,183,l),
+(482,236,l),
+(209,385,l),
+(198,332,l),
+(533,478,l),
+(544,531,l),
+(184,728,l),
+(150,728,l),
+(128,628,l),
+(400,479,l),
+(415,552,l),
+(79,397,l),
+(66,337,l),
+(339,196,l),
+(355,257,l),
+(18,107,l),
+(-8,-14,l)
+);
+}
+);
+width = 534;
+}
+);
+metricLeft = "mediall-canadian";
+metricRight = "mediall-canadian";
+note = uni1552;
+unicode = 5458;
+},
+{
+glyphname = "fe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(300,0,l),
+(763,678,l),
+(771,714,l),
+(648,714,l),
+(290,169,l),
+(317,169,l),
+(268,363,l),
+(185,364,l),
+(203,343,o),
+(230,331,o),
+(266,331,cs),
+(391,331,o),
+(455,477,o),
+(455,576,cs),
+(455,667,o),
+(405,728,o),
+(315,728,cs),
+(182,728,o),
+(124,587,o),
+(124,479,cs),
+(124,443,o),
+(130,408,o),
+(144,367,cs),
+(258,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(248,423,o),
+(235,443,o),
+(235,478,cs),
+(235,519,o),
+(256,625,o),
+(307,625,cs),
+(331,625,o),
+(344,605,o),
+(344,571,cs),
+(344,529,o),
+(324,423,o),
+(273,423,cs)
+);
+}
+);
+width = 692;
+}
+);
+metricRight = "e-canadian";
+note = uni1553;
+unicode = 5459;
+},
+{
+glyphname = "faai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (206,0);
+ref = ring_top.canadian;
+}
+);
+width = 692;
+}
+);
+note = uni1554;
+unicode = 5460;
+},
+{
+glyphname = "fi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (425,714);
+},
+{
+name = top_left_can;
+pos = (222,714);
+},
+{
+name = top_right_can;
+pos = (644,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(331,-14,o),
+(382,128,o),
+(382,225,cs),
+(382,322,o),
+(330,387,o),
+(258,387,cs),
+(233,387,o),
+(203,375,o),
+(177,354,c),
+(273,354,l),
+(411,545,l),
+(377,545,l),
+(516,0,l),
+(619,0,l),
+(626,36,l),
+(446,714,l),
+(403,714,l),
+(138,363,ls),
+(85,292,o),
+(51,221,o),
+(51,139,cs),
+(51,48,o),
+(103,-14,o),
+(192,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(175,89,o),
+(162,109,o),
+(162,144,cs),
+(162,185,o),
+(183,291,o),
+(234,291,cs),
+(258,291,o),
+(271,271,o),
+(271,236,cs),
+(271,193,o),
+(250,89,o),
+(200,89,cs)
+);
+}
+);
+width = 692;
+}
+);
+metricLeft = "fe-canadian";
+metricRight = "e-canadian";
+note = uni1555;
+unicode = 5461;
+},
+{
+glyphname = "fii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (240,0);
+ref = dot_top;
+}
+);
+width = 692;
+}
+);
+note = uni1556;
+unicode = 5462;
+},
+{
+glyphname = "fo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (299,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(48,0,l),
+(582,334,l),
+(592,380,l),
+(407,653,ls),
+(374,703,o),
+(338,728,o),
+(283,728,cs),
+(178,728,o),
+(111,628,o),
+(96,520,cs),
+(78,403,o),
+(132,322,o),
+(226,322,cs),
+(324,322,o),
+(393,419,o),
+(407,524,cs),
+(411,554,o),
+(413,585,o),
+(411,610,c),
+(351,532,l),
+(469,360,l),
+(481,405,l),
+(42,130,l),
+(13,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(212,424,o),
+(201,456,o),
+(209,514,cs),
+(216,569,o),
+(235,628,o),
+(276,628,cs),
+(305,628,o),
+(316,596,o),
+(308,538,cs),
+(301,483,o),
+(282,424,o),
+(241,424,cs)
+);
+}
+);
+width = 592;
+}
+);
+metricRight = "o-canadian";
+note = uni1557;
+unicode = 5463;
+},
+{
+glyphname = "foo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "fo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (113,0);
+ref = dot_top;
+}
+);
+width = 592;
+}
+);
+note = uni1558;
+unicode = 5464;
+},
+{
+glyphname = "fa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (491,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(471,0,l),
+(494,111,l),
+(184,375,l),
+(178,347,l),
+(363,522,l),
+(337,635,l),
+(310,587,o),
+(291,522,o),
+(291,472,cs),
+(291,381,o),
+(344,319,o),
+(433,319,cs),
+(556,319,o),
+(616,470,o),
+(616,570,cs),
+(616,666,o),
+(564,728,o),
+(479,728,cs),
+(431,728,o),
+(389,709,o),
+(347,666,cs),
+(54,380,l),
+(44,334,l),
+(436,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(410,422,o),
+(397,442,o),
+(397,476,cs),
+(397,518,o),
+(418,624,o),
+(469,624,cs),
+(493,624,o),
+(506,605,o),
+(506,571,cs),
+(506,529,o),
+(486,422,o),
+(434,422,cs)
+);
+}
+);
+width = 593;
+}
+);
+metricRight = "=|fo-canadian";
+note = uni1559;
+unicode = 5465;
+},
+{
+glyphname = "faa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (306,0);
+ref = dot_top;
+}
+);
+width = 592;
+}
+);
+note = uni155A;
+unicode = 5466;
+},
+{
+glyphname = "fwaa-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (517,0);
+ref = dot_top;
+}
+);
+width = 803;
+}
+);
+note = uni155B;
+unicode = 5467;
+},
+{
+glyphname = "fwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (306,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (592,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 803;
+}
+);
+note = uni155C;
+unicode = 5468;
+},
+{
+glyphname = "f-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(307,357,l),
+(319,420,l),
+(166,550,l),
+(164,530,l),
+(254,620,l),
+(244,674,l),
+(231,652,o),
+(218,614,o),
+(218,588,cs),
+(218,545,o),
+(245,514,o),
+(286,514,cs),
+(344,514,o),
+(379,580,o),
+(379,645,cs),
+(379,692,o),
+(354.992,720,o),
+(314,720,cs),
+(289,720,o),
+(267,710,o),
+(243,687,cs),
+(97,545,l),
+(93,522,l),
+(290,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(276,566,o),
+(270,575,o),
+(270,591,cs),
+(270,613,o),
+(282,668,o),
+(306,668,cs),
+(318,668,o),
+(324,659,o),
+(324,642,cs),
+(324,621,o),
+(313,566,o),
+(288,566,cs)
+);
+}
+);
+width = 339;
+}
+);
+note = uni155D;
+unicode = 5469;
+},
+{
+glyphname = "the-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (746,357);
+},
+{
+name = top_center_can;
+pos = (423,714);
+},
+{
+name = top_left_can;
+pos = (220,714);
+},
+{
+name = top_right_can;
+pos = (624,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(465,-14,o),
+(559,69,o),
+(598,250,cs),
+(697,714,l),
+(549,714,l),
+(453,261,ls),
+(432,164,o),
+(388,120,o),
+(307,120,cs),
+(203,120,o),
+(180,187,o),
+(204,292,cs),
+(234,420,l),
+(160,379,l),
+(173,345,o),
+(203,316,o),
+(242,316,cs),
+(356,316,o),
+(418,414,o),
+(436,532,cs),
+(455,652,o),
+(403,728,o),
+(298,728,cs),
+(198,728,o),
+(136,657,o),
+(106,516,cs),
+(63,311,ls),
+(22,115,o),
+(99,-14,o),
+(300,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(231,421,o),
+(218,441,o),
+(218,476,cs),
+(218,517,o),
+(239,625,o),
+(290,625,cs),
+(314,625,o),
+(326,605,o),
+(326,570,cs),
+(326,528,o),
+(306,421,o),
+(255,421,cs)
+);
+}
+);
+width = 649;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155E;
+unicode = 5470;
+},
+{
+glyphname = "theNCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(468,-14,o),
+(559,74,o),
+(602,270,cs),
+(650,495,ls),
+(683,648,o),
+(620,728,o),
+(521,728,cs),
+(388,728,o),
+(330,586,o),
+(330,478,cs),
+(330,387,o),
+(375,316,o),
+(462,316,cs),
+(497,316,o),
+(532,333,o),
+(554,361,c),
+(487,414,l),
+(457,270,ls),
+(433,161,o),
+(390,117,o),
+(309,117,cs),
+(214,117,o),
+(182,177,o),
+(203,279,cs),
+(296,714,l),
+(148,714,l),
+(59,292,ls),
+(18,102,o),
+(111,-14,o),
+(298,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(454,421,o),
+(442,441,o),
+(442,476,cs),
+(442,517,o),
+(462,625,o),
+(513,625,cs),
+(536,625,o),
+(549,605,o),
+(549,570,cs),
+(549,528,o),
+(529,421,o),
+(478,421,cs)
+);
+}
+);
+width = 649;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155F;
+unicode = 5471;
+},
+{
+glyphname = "thi-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (419,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(305,-14,o),
+(363,128,o),
+(363,236,cs),
+(363,327,o),
+(318,398,o),
+(231,398,cs),
+(196,398,o),
+(161,381,o),
+(139,353,c),
+(206,300,l),
+(236,444,ls),
+(259,553,o),
+(303,597,o),
+(384,597,cs),
+(479,597,o),
+(511,537,o),
+(490,435,cs),
+(397,0,l),
+(545,0,l),
+(634,422,ls),
+(675,612,o),
+(582,728,o),
+(395,728,cs),
+(225,728,o),
+(133,640,o),
+(91,444,cs),
+(43,219,ls),
+(10,66,o),
+(73,-14,o),
+(172,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(156,89,o),
+(144,109,o),
+(144,144,cs),
+(144,186,o),
+(164,293,o),
+(215,293,cs),
+(239,293,o),
+(251,273,o),
+(251,238,cs),
+(251,197,o),
+(231,89,o),
+(180,89,cs)
+);
+}
+);
+width = 649;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1560;
+unicode = 5472;
+},
+{
+glyphname = "thiNCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (419,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(495,-14,o),
+(557,57,o),
+(587,198,cs),
+(630,403,ls),
+(671,599,o),
+(594,728,o),
+(393,728,cs),
+(228,728,o),
+(134,645,o),
+(95,464,cs),
+(-4,0,l),
+(144,0,l),
+(240,453,ls),
+(261,550,o),
+(305,594,o),
+(386,594,cs),
+(490,594,o),
+(513,527,o),
+(489,422,cs),
+(459,294,l),
+(533,335,l),
+(520,369,o),
+(490,398,o),
+(451,398,cs),
+(337,398,o),
+(275,300,o),
+(257,182,cs),
+(238,62,o),
+(290,-14,o),
+(395,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(379,89,o),
+(366,109,o),
+(366,144,cs),
+(366,186,o),
+(387,293,o),
+(438,293,cs),
+(462,293,o),
+(475,273,o),
+(475,238,cs),
+(475,197,o),
+(454,89,o),
+(403,89,cs)
+);
+}
+);
+width = 649;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1561;
+unicode = 5473;
+},
+{
+glyphname = "thii-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "thi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (233,0);
+ref = dot_top;
+}
+);
+width = 649;
+}
+);
+note = uni1562;
+unicode = 5474;
+},
+{
+glyphname = "thiiNCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "thiNCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (233,0);
+ref = dot_top;
+}
+);
+width = 649;
+}
+);
+note = uni1563;
+unicode = 5475;
+},
+{
+glyphname = "tho-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (365,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(197,0,ls),
+(489,0,o),
+(578,260,o),
+(578,444,cs),
+(578,616,o),
+(487,728,o),
+(341,728,cs),
+(178,728,o),
+(90,588,o),
+(90,446,cs),
+(90,351,o),
+(140,289,o),
+(225,289,cs),
+(354,289,o),
+(407,433,o),
+(407,531,cs),
+(407,605,o),
+(374,657,o),
+(316,667,c),
+(285,628,l),
+(294,633,o),
+(308,637,o),
+(324,637,cs),
+(393,636,o),
+(439,568,o),
+(439,459,cs),
+(439,345,o),
+(402,134,o),
+(204,134,cs),
+(47,134,l),
+(19,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(216,392,o),
+(204,410,o),
+(204,444,cs),
+(204,482,o),
+(227,611,o),
+(281,611,cs),
+(304,611,o),
+(316,593,o),
+(316,559,cs),
+(316,522,o),
+(293,392,o),
+(239,392,cs)
+);
+}
+);
+width = 594;
+}
+);
+metricRight = "to-canadian";
+note = uni1564;
+unicode = 5476;
+},
+{
+glyphname = "thoo-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "tho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (180,0);
+ref = dot_top;
+}
+);
+width = 594;
+}
+);
+note = uni1565;
+unicode = 5477;
+},
+{
+glyphname = "tha-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (433,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(467,0,l),
+(496,134,l),
+(356,134,ls),
+(255,134,o),
+(203,186,o),
+(203,288,cs),
+(203,394,o),
+(271,636,o),
+(413,636,cs),
+(434,636,o),
+(454,630,o),
+(470,618,c),
+(448,664,l),
+(332,667,o),
+(283,522,o),
+(283,433,cs),
+(283,344,o),
+(330,289,o),
+(413,289,cs),
+(530,289,o),
+(606,406,o),
+(606,534,cs),
+(606,654,o),
+(531,728,o),
+(410,728,cs),
+(171,728,o),
+(59,453,o),
+(59,274,cs),
+(59,107,o),
+(161,0,o),
+(328,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(394,392,o),
+(382,410,o),
+(382,444,cs),
+(382,482,o),
+(405,611,o),
+(460,611,cs),
+(483,611,o),
+(495,593,o),
+(495,559,cs),
+(495,522,o),
+(472,392,o),
+(418,392,cs)
+);
+}
+);
+width = 594;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tho-canadian";
+note = uni1566;
+unicode = 5478;
+},
+{
+glyphname = "thaa-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (247,0);
+ref = dot_top;
+}
+);
+width = 594;
+}
+);
+note = uni1567;
+unicode = 5479;
+},
+{
+glyphname = "thwaa-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (457,0);
+ref = dot_top;
+}
+);
+width = 804;
+}
+);
+note = uni1568;
+unicode = 5480;
+},
+{
+glyphname = "thwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (247,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (594,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 804;
+}
+);
+note = uni1569;
+unicode = 5481;
+},
+{
+glyphname = "th-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(300,357,l),
+(317,438,l),
+(253,438,ls),
+(206,438,o),
+(182,462,o),
+(182,508,cs),
+(182,560,o),
+(214,662,o),
+(285,662,cs),
+(293,662,o),
+(301,660,o),
+(307,658,c),
+(289,681,l),
+(236,681,o),
+(211,607,o),
+(211,571,cs),
+(211,527,o),
+(236,497,o),
+(276,497,cs),
+(342,497,o),
+(370,577,o),
+(370,625,cs),
+(370,683,o),
+(334,720,o),
+(273,720,cs),
+(153.008,720,o),
+(98,586,o),
+(98,500,cs),
+(98,413,o),
+(151,357,o),
+(238,357,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(264,548,o),
+(258,556,o),
+(258,572,cs),
+(258,595,o),
+(269,650,o),
+(295,650,cs),
+(307,650,o),
+(313,642,o),
+(313,626,cs),
+(313,604,o),
+(302,548,o),
+(276,548,cs)
+);
+}
+);
+width = 334;
+}
+);
+metricLeft = "t-canadian";
+note = uni156A;
+unicode = 5482;
+},
+{
+glyphname = "tthe-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (738,357);
+},
+{
+name = top_center_can;
+pos = (418,714);
+},
+{
+name = top_left_can;
+pos = (222,714);
+},
+{
+name = top_right_can;
+pos = (615,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(458,-14,o),
+(552,73,o),
+(590,250,cs),
+(688,714,l),
+(551,714,l),
+(454,262,ls),
+(433,163,o),
+(388,121,o),
+(306,121,cs),
+(209,121,o),
+(171,174,o),
+(193,278,cs),
+(286,714,l),
+(148,714,l),
+(59,292,ls),
+(18,101,o),
+(111,-14,o),
+(295,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(405,395,l),
+(473,714,l),
+(363,714,l),
+(295,395,l)
+);
+}
+);
+width = 641;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156B;
+unicode = 5483;
+},
+{
+glyphname = "tthi-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(134,0,l),
+(230,452,ls),
+(251,551,o),
+(297,593,o),
+(378,593,cs),
+(475,593,o),
+(514,540,o),
+(492,436,cs),
+(399,0,l),
+(536,0,l),
+(626,422,ls),
+(667,613,o),
+(573,728,o),
+(390,728,cs),
+(227,728,o),
+(133,641,o),
+(95,464,cs),
+(-4,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(322,0,l),
+(390,319,l),
+(279,319,l),
+(211,0,l)
+);
+}
+);
+width = 640;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156C;
+unicode = 5484;
+},
+{
+glyphname = "ttho-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (354,714);
+},
+{
+name = top_left_can;
+pos = (210,714);
+},
+{
+name = top_right_can;
+pos = (540,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(134,0,ls),
+(464,0,o),
+(535,274,o),
+(535,435,cs),
+(535,609,o),
+(430,714,o),
+(244,714,cs),
+(148,714,l),
+(120,580,l),
+(218,580,ls),
+(330,580,o),
+(387,526,o),
+(387,423,cs),
+(387,320,o),
+(344,134,o),
+(141,134,cs),
+(25,134,l),
+(-3,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(257,297,l),
+(283,419,l),
+(85,419,l),
+(60,297,l)
+);
+}
+);
+width = 552;
+}
+);
+metricRight = "to-canadian";
+note = uni156D;
+unicode = 5485;
+},
+{
+glyphname = "ttha-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (369,714);
+},
+{
+name = top_left_can;
+pos = (213,714);
+},
+{
+name = top_right_can;
+pos = (525,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(448,0,l),
+(476,134,l),
+(377,134,ls),
+(265,134,o),
+(209,188,o),
+(209,291,cs),
+(209,407,o),
+(264,580,o),
+(454,580,cs),
+(571,580,l),
+(599,714,l),
+(461,714,ls),
+(143,714,o),
+(61,451,o),
+(61,279,cs),
+(61,105,o),
+(165,0,o),
+(351,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(509,297,l),
+(535,419,l),
+(337,419,l),
+(311,297,l)
+);
+}
+);
+width = 552;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|ttho-canadian";
+note = uni156E;
+unicode = 5486;
+},
+{
+glyphname = "tth-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(265,496,l),
+(227,496,l),
+(287,373,l),
+(362,410,l),
+(299,540,l),
+(279,503,l),
+(421,557,l),
+(395,630,l),
+(266,580,l),
+(296,560,l),
+(328,714,l),
+(245,714,l),
+(212,560,l),
+(248,580,l),
+(128,630,l),
+(96,556,l),
+(208,510,l),
+(204,546,l),
+(96,426,l),
+(155,373,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(633,496,l),
+(595,496,l),
+(655,373,l),
+(730,410,l),
+(667,540,l),
+(647,503,l),
+(789,557,l),
+(763,630,l),
+(634,580,l),
+(663,560,l),
+(696,714,l),
+(613,714,l),
+(580,560,l),
+(615,580,l),
+(496,630,l),
+(464,556,l),
+(575,510,l),
+(572,546,l),
+(464,426,l),
+(522,373,l)
+);
+}
+);
+width = 756;
+}
+);
+metricRight = "=|";
+note = uni156F;
+unicode = 5487;
+},
+{
+glyphname = "tye-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(458,-14,o),
+(552,73,o),
+(590,251,cs),
+(688,714,l),
+(551,714,l),
+(456,265,ls),
+(434,164,o),
+(388,121,o),
+(305,121,cs),
+(209,121,o),
+(171,174,o),
+(193,278,cs),
+(286,714,l),
+(148,714,l),
+(59,292,ls),
+(18,101,o),
+(111,-14,o),
+(295,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(422,425,o),
+(456,456,o),
+(469,519,cs),
+(511,714,l),
+(449,714,l),
+(410,530,ls),
+(404,502,o),
+(392,490,o),
+(372,490,cs),
+(350,490,o),
+(343,502,o),
+(349,530,cs),
+(388,714,l),
+(326,714,l),
+(286,527,ls),
+(273,465,o),
+(305,425,o),
+(367,425,cs)
+);
+}
+);
+width = 640;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1570;
+unicode = 5488;
+},
+{
+glyphname = "tyi-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(134,0,l),
+(229,449,ls),
+(251,550,o),
+(296,593,o),
+(379,593,cs),
+(475,593,o),
+(514,540,o),
+(492,436,cs),
+(399,0,l),
+(536,0,l),
+(626,422,ls),
+(667,613,o),
+(574,728,o),
+(389,728,cs),
+(227,728,o),
+(133,641,o),
+(95,463,cs),
+(-4,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(236,0,l),
+(275,184,ls),
+(280,212,o),
+(293,224,o),
+(313,224,cs),
+(334,224,o),
+(342,212,o),
+(336,184,cs),
+(297,0,l),
+(359,0,l),
+(399,187,ls),
+(412,249,o),
+(380,289,o),
+(318,289,cs),
+(263,289,o),
+(229,258,o),
+(216,195,cs),
+(173.993,0,l)
+);
+}
+);
+width = 640;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1571;
+unicode = 5489;
+},
+{
+glyphname = "tyo-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(134,0,ls),
+(464,0,o),
+(538,274,o),
+(538,435,cs),
+(538,609,o),
+(431,714,o),
+(244,714,cs),
+(151,714,l),
+(123,583,l),
+(221,583,ls),
+(331,583,o),
+(390,526,o),
+(390,423,cs),
+(390,268,o),
+(297,131,o),
+(141,131,cs),
+(28,131,l),
+(0,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(107,223,ls),
+(211,223,o),
+(260,277,o),
+(271,357,cs),
+(282,438,o),
+(238,491,o),
+(159,491,cs),
+(104,491,l),
+(88,417,l),
+(142,417,ls),
+(179,417,o),
+(197,398,o),
+(193,363,cs),
+(189,326,o),
+(169,297,o),
+(115,297,cs),
+(63,297,l),
+(47,223,l)
+);
+}
+);
+width = 555;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1572;
+unicode = 5490;
+},
+{
+glyphname = "tya-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(447,0,l),
+(475,131,l),
+(377,131,ls),
+(267,131,o),
+(209,188,o),
+(209,291,cs),
+(209,446,o),
+(301,583,o),
+(458,583,cs),
+(570,583,l),
+(598,714,l),
+(464,714,ls),
+(134,714,o),
+(61,440,o),
+(61,279,cs),
+(61,105,o),
+(167,0,o),
+(354,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(494,223,l),
+(510,297,l),
+(456,297,ls),
+(419,297,o),
+(402,316,o),
+(405,351,cs),
+(409,388,o),
+(429,417,o),
+(483,417,cs),
+(535,417,l),
+(551,491,l),
+(491,491,ls),
+(387,491,o),
+(338,437,o),
+(327,357,cs),
+(316,276,o),
+(360,223,o),
+(439,223,cs)
+);
+}
+);
+width = 554;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1573;
+unicode = 5491;
+},
+{
+glyphname = "heNunavik-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(409,0,l),
+(664,203,l),
+(586,304,l),
+(408,164,l),
+(452,130,l),
+(517,436,ls),
+(548,579,o),
+(510,728,o),
+(340,728,cs),
+(150,728,o),
+(78,533,o),
+(78,388,cs),
+(78,267,o),
+(138,193,o),
+(238,193,cs),
+(287,193,o),
+(328,217,o),
+(355,267,c),
+(336,273,l),
+(278,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(242,318,o),
+(221,344,o),
+(221,395,cs),
+(221,448,o),
+(247,604,o),
+(326,604,cs),
+(365,604,o),
+(386,578,o),
+(386,526,cs),
+(386,473,o),
+(360,318,o),
+(281,318,cs)
+);
+}
+);
+width = 691;
+}
+);
+metricLeft = "ke-canadian";
+note = uni1574;
+unicode = 5492;
+},
+{
+glyphname = "hiNunavik-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (527,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(305,0,l),
+(372,312,l),
+(349,270,l),
+(348,227,o),
+(395,193,o),
+(459,193,cs),
+(630,193,o),
+(700,396,o),
+(700,525,cs),
+(700,653,o),
+(629,728,o),
+(511,728,cs),
+(382,728,o),
+(294,642,o),
+(261,482,cs),
+(185,125,l),
+(233,139,l),
+(106,289,l),
+(5,202,l),
+(175,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(415,318,o),
+(394,344,o),
+(394,395,cs),
+(394,448,o),
+(424,604,o),
+(499,604,cs),
+(537,604,o),
+(559,578,o),
+(559,527,cs),
+(559,473,o),
+(532,318,o),
+(453,318,cs)
+);
+}
+);
+width = 690;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1575;
+unicode = 5493;
+},
+{
+glyphname = "hiiNunavik-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "hiNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (342,0);
+ref = dot_top;
+}
+);
+width = 691;
+}
+);
+note = uni1576;
+unicode = 5494;
+},
+{
+glyphname = "hoNunavik-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (355,714);
+},
+{
+name = top_right_can;
+pos = (503,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(354,-14,o),
+(441,72,o),
+(475,232,cs),
+(550,589,l),
+(502,575,l),
+(630,425,l),
+(730,512,l),
+(560,714,l),
+(430,714,l),
+(363,402,l),
+(386,444,l),
+(387,487,o),
+(341,521,o),
+(276,521,cs),
+(106,521,o),
+(35,318,o),
+(35,189,cs),
+(35,61,o),
+(106,-14,o),
+(224,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(198,110,o),
+(176,136,o),
+(176,187,cs),
+(176,241,o),
+(203,396,o),
+(282,396,cs),
+(321,396,o),
+(342,370,o),
+(342,319,cs),
+(342,266,o),
+(312,110,o),
+(236,110,cs)
+);
+}
+);
+width = 691;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "heNunavik-canadian";
+note = uni1577;
+unicode = 5495;
+},
+{
+glyphname = "hooNunavik-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "hoNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (318,0);
+ref = dot_top;
+}
+);
+width = 691;
+}
+);
+note = uni1578;
+unicode = 5496;
+},
+{
+glyphname = "haNunavik-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (531,714);
+},
+{
+name = top_left_can;
+pos = (384,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(585,-14,o),
+(657,181,o),
+(657,326,cs),
+(657,447,o),
+(597,521,o),
+(496,521,cs),
+(447,521,o),
+(407,497,o),
+(380,447,c),
+(399,441,l),
+(457,714,l),
+(326,714,l),
+(71,511,l),
+(149,410,l),
+(327,550,l),
+(282,584,l),
+(217,278,ls),
+(187,135,o),
+(225,-14,o),
+(395,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(370,110,o),
+(349,136,o),
+(349,188,cs),
+(349,241,o),
+(375,396,o),
+(454,396,cs),
+(493,396,o),
+(514,370,o),
+(514,319,cs),
+(514,266,o),
+(488,110,o),
+(409,110,cs)
+);
+}
+);
+width = 691;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1579;
+unicode = 5497;
+},
+{
+glyphname = "haaNunavik-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "haNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (199,0);
+ref = dot_top;
+}
+);
+width = 691;
+}
+);
+note = uni157A;
+unicode = 5498;
+},
+{
+glyphname = "hNunavik-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(379,351,o),
+(422,459,o),
+(422,527,cs),
+(422,585,o),
+(390,622,o),
+(338,622,cs),
+(306,622,o),
+(282,608,o),
+(263,571,c),
+(279,546,l),
+(315,714,l),
+(227,714,l),
+(100,614,l),
+(146,557,l),
+(254,644,l),
+(216,693,l),
+(174,496,ls),
+(157,414,o),
+(193,351,o),
+(274,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(265,422,o),
+(255,434,o),
+(255,459,cs),
+(255,504,o),
+(275,551,o),
+(307,551,cs),
+(325,551,o),
+(336,540,o),
+(336,515,cs),
+(336,472,o),
+(315,422,o),
+(283,422,cs)
+);
+}
+);
+width = 403;
+}
+);
+metricRight = "k-canadian";
+note = uni157B;
+unicode = 5499;
+},
+{
+color = 4;
+glyphname = "nunavuth-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(146,0,l),
+(211,303,l),
+(430,303,l),
+(366,0,l),
+(513,0,l),
+(665,714,l),
+(518,714,l),
+(458,434,l),
+(239,434,l),
+(298,714,l),
+(151,714,l),
+(-1,0,l)
+);
+}
+);
+width = 620;
+}
+);
+metricRight = "=|";
+note = uni157C;
+unicode = 5500;
+},
+{
+glyphname = "hk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (76,357);
+ref = "fullstop-canadian";
+}
+);
+width = 338;
+}
+);
+metricLeft = "fullstop-canadian";
+note = uni157D;
+unicode = 5501;
+},
+{
+glyphname = "qaai-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (287,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (435,0);
+ref = ring_top.canadian;
+}
+);
+width = 816;
+}
+);
+note = uni157E;
+unicode = 5502;
+},
+{
+glyphname = "qi-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (287,0);
+ref = "ki-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni157F;
+unicode = 5503;
+},
+{
+glyphname = "qii-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (287,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (469,0);
+ref = dot_top;
+}
+);
+width = 816;
+}
+);
+note = uni1580;
+unicode = 5504;
+},
+{
+glyphname = "qo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (287,0);
+ref = "ko-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni1581;
+unicode = 5505;
+},
+{
+glyphname = "qoo-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (287,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (606,0);
+ref = dot_top;
+}
+);
+width = 816;
+}
+);
+note = uni1582;
+unicode = 5506;
+},
+{
+glyphname = "qa-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (287,0);
+ref = "ka-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni1583;
+unicode = 5507;
+},
+{
+glyphname = "qaa-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (287,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (324,0);
+ref = dot_top;
+}
+);
+width = 816;
+}
+);
+note = uni1584;
+unicode = 5508;
+},
+{
+glyphname = "q-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (287,0);
+ref = "k-canadian";
+}
+);
+width = 615;
+}
+);
+note = uni1585;
+unicode = 5509;
+},
+{
+glyphname = "tlhe-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (371,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(149,0,l),
+(318,287,l),
+(210,227,l),
+(220,225,o),
+(231,224,o),
+(241,224,cs),
+(291,224,o),
+(336,242,o),
+(374,285,c),
+(362,328,l),
+(292,0,l),
+(438,0,l),
+(536,460,ls),
+(564,591,o),
+(523,728,o),
+(356,728,cs),
+(172,728,o),
+(95,558,o),
+(95,418,cs),
+(95,358,o),
+(115,304,o),
+(157,271,c),
+(-4,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(253,350,o),
+(234,381,o),
+(234,426,cs),
+(234,481,o),
+(262,604,o),
+(339,604,cs),
+(381,604,o),
+(400,573,o),
+(400,529,cs),
+(400,474,o),
+(371,350,o),
+(295,350,cs)
+);
+}
+);
+width = 542;
+}
+);
+metricRight = "te-canadian";
+note = uni1586;
+unicode = 5510;
+},
+{
+glyphname = "tlhi-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,0,l),
+(213,337,l),
+(156,313,l),
+(187,258,o),
+(229,230,o),
+(294,228,c),
+(241,260,l),
+(285,0,l),
+(439,0,l),
+(396,253,l),
+(501,296,o),
+(546,432,o),
+(546,526,cs),
+(546,648,o),
+(472,728,o),
+(347,728,cs),
+(221,728,o),
+(134,649,o),
+(99,485,cs),
+(-4,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(259,350,o),
+(237,377,o),
+(237,425,cs),
+(237,478,o),
+(265,604,o),
+(342,604,cs),
+(383,604,o),
+(404,577,o),
+(404,529,cs),
+(404,475,o),
+(377,350,o),
+(300,350,cs)
+);
+}
+);
+width = 546;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|tlhe-canadian";
+note = uni1587;
+unicode = 5511;
+},
+{
+glyphname = "tlho-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (380,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(369,-14,o),
+(456,65,o),
+(491,229,cs),
+(594,714,l),
+(448,714,l),
+(377,377,l),
+(434,401,l),
+(403,456,o),
+(362,484,o),
+(296,486,c),
+(349,454,l),
+(305,714,l),
+(152,714,l),
+(194,461,l),
+(89,418,o),
+(44,282,o),
+(44,188,cs),
+(44,66,o),
+(118,-14,o),
+(243,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(208,110,o),
+(187,137,o),
+(187,185,cs),
+(187,239,o),
+(213,364,o),
+(291,364,cs),
+(331,364,o),
+(353,337,o),
+(353,289,cs),
+(353,236,o),
+(326,110,o),
+(249,110,cs)
+);
+}
+);
+width = 546;
+}
+);
+metricLeft = "tlhe-canadian";
+metricRight = "te-canadian";
+note = uni1588;
+unicode = 5512;
+},
+{
+glyphname = "tlha-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(415,-14,o),
+(491,156,o),
+(491,296,cs),
+(491,356,o),
+(472,410,o),
+(430,443,c),
+(591,714,l),
+(437,714,l),
+(269,427,l),
+(377,487,l),
+(367,489,o),
+(356,490,o),
+(346,490,cs),
+(295,490,o),
+(250,472,o),
+(213,429,c),
+(225,386,l),
+(294,714,l),
+(148,714,l),
+(51,254,ls),
+(23,123,o),
+(63,-14,o),
+(230,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(205,110,o),
+(187,141,o),
+(187,185,cs),
+(187,240,o),
+(215,364,o),
+(291,364,cs),
+(333,364,o),
+(353,333,o),
+(353,288,cs),
+(353,233,o),
+(324,110,o),
+(248,110,cs)
+);
+}
+);
+width = 543;
+}
+);
+metricLeft = "te-canadian";
+note = uni1589;
+unicode = 5513;
+},
+{
+glyphname = "reWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(399,0,l),
+(655,206,l),
+(575,305,l),
+(400,165,l),
+(443,132,l),
+(514,469,ls),
+(548,630,o),
+(477,728,o),
+(335,728,cs),
+(200,728,o),
+(122,651,o),
+(87,489,cs),
+(67,395,l),
+(213,395,l),
+(236,504,ls),
+(251,572,o),
+(275,600,o),
+(318,600,cs),
+(369,600,o),
+(389,564,o),
+(375,498,cs),
+(269.003,0,l)
+);
+}
+);
+width = 681;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+unicode = 5514;
+},
+{
+glyphname = "riWestCree-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(304,0,l),
+(410,504,ls),
+(425,571,o),
+(450,600,o),
+(493,600,cs),
+(543,600,o),
+(564,565,o),
+(549,498,cs),
+(527,395,l),
+(673,395,l),
+(689,469,ls),
+(723,630,o),
+(650,728,o),
+(508,728,cs),
+(373,728,o),
+(296,651,o),
+(261,489,cs),
+(185,131,l),
+(236,144,l),
+(113,294,l),
+(6,206,l),
+(174,0,l)
+);
+}
+);
+width = 680;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+unicode = 5515;
+},
+{
+glyphname = "roWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(352,-14,o),
+(429,63,o),
+(463,225,cs),
+(539,583,l),
+(489,570,l),
+(613,420,l),
+(719,508,l),
+(551,714,l),
+(421.003,714,l),
+(314,210,ls),
+(300,143,o),
+(274,114,o),
+(232,114,cs),
+(182,114,o),
+(161,149,o),
+(175,216,cs),
+(197,319,l),
+(51,319,l),
+(36,245,ls),
+(1,84,o),
+(75,-14,o),
+(216,-14,cs)
+);
+}
+);
+width = 681;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+unicode = 5516;
+},
+{
+glyphname = "raWestCree-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(525,-14,o),
+(603,63,o),
+(638,225,cs),
+(658,319,l),
+(512,319,l),
+(489,210,ls),
+(474,142,o),
+(450,114,o),
+(407,114,cs),
+(356,114,o),
+(336,150,o),
+(350,216,cs),
+(456,714,l),
+(326,714,l),
+(70,508,l),
+(150,409,l),
+(326,549,l),
+(282,582,l),
+(211,245,ls),
+(177,84,o),
+(248,-14,o),
+(390,-14,cs)
+);
+}
+);
+width = 681;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+unicode = 5517;
+},
+{
+glyphname = "ngaai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:31:56 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (550,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (698,0);
+ref = ring_top.canadian;
+}
+);
+width = 1070;
+}
+);
+note = uni158E;
+unicode = 5518;
+},
+{
+glyphname = "ngi-canadian";
+kernLeft = mwestleft;
+kernRight = ciright;
+lastChange = "2023-01-13 15:31:56 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (550,0);
+ref = "ci-canadian";
+}
+);
+width = 1070;
+}
+);
+note = uni158F;
+unicode = 5519;
+},
+{
+glyphname = "ngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:31:56 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (550,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (732,0);
+ref = dot_top;
+}
+);
+width = 1070;
+}
+);
+note = uni1590;
+unicode = 5520;
+},
+{
+glyphname = "ngo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:31:56 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (524,0);
+ref = "co-canadian";
+}
+);
+width = 1044;
+}
+);
+note = uni1591;
+unicode = 5521;
+},
+{
+glyphname = "ngoo-canadian";
+lastChange = "2023-01-13 15:31:56 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "ngo-canadian";
+},
+{
+anchor = top_right_can;
+pos = (834,0);
+ref = dot_top;
+}
+);
+width = 1044;
+}
+);
+note = uni1592;
+unicode = 5522;
+},
+{
+glyphname = "nga-canadian";
+kernLeft = mwestleft;
+kernRight = caright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (550,0);
+ref = "ca-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni1593;
+unicode = 5523;
+},
+{
+glyphname = "ngaa-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (550,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (588,0);
+ref = dot_top;
+}
+);
+width = 1071;
+}
+);
+note = uni1594;
+unicode = 5524;
+},
+{
+glyphname = "ng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(481,225,o),
+(529,268,o),
+(546,350,cs),
+(552,381,l),
+(462,381,l),
+(453,342,ls),
+(447,314,o),
+(435,301,o),
+(416,301,cs),
+(394,301,o),
+(386,316,o),
+(392,343,cs),
+(434,542,l),
+(296,542,l),
+(303,491,l),
+(327,510,o),
+(345,554,o),
+(349,593,cs),
+(359,666,o),
+(318,720,o),
+(243,720,cs),
+(166,720,o),
+(117,658,o),
+(106,585,cs),
+(94,503,o),
+(138,449,o),
+(215,449,cs),
+(355,449,l),
+(329,506,l),
+(300,370,ls),
+(281,281,o),
+(323,225,o),
+(407,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(196,520,o),
+(186,539,o),
+(190,575,cs),
+(195,611,o),
+(210,649,o),
+(238,649,cs),
+(259,649,o),
+(269,630,o),
+(264,595,cs),
+(260,559,o),
+(245,520,o),
+(216,520,cs)
+);
+}
+);
+width = 550;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1595;
+unicode = 5525;
+},
+{
+glyphname = "nng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(752,225,o),
+(799,268,o),
+(816,350,cs),
+(823,381,l),
+(733,381,l),
+(724,342,ls),
+(718,314,o),
+(706,301,o),
+(686,301,cs),
+(665,301,o),
+(656,316,o),
+(662,343,cs),
+(705,542,l),
+(581,542,l),
+(574,491,l),
+(605,517,o),
+(623,572,o),
+(623,611,cs),
+(623,678,o),
+(582,720,o),
+(515,720,cs),
+(424,720,o),
+(376,636,o),
+(376,560,cs),
+(376,537,o),
+(381,518,o),
+(393,500,c),
+(404,542,l),
+(311,542,l),
+(302,491,l),
+(333,517,o),
+(351,573,o),
+(351,611,cs),
+(351,675,o),
+(310,720,o),
+(243,720,cs),
+(152,720,o),
+(104,636,o),
+(104,560,cs),
+(104,493,o),
+(146,449,o),
+(215,449,cs),
+(587,449,l),
+(570,370,ls),
+(551,281,o),
+(594,225,o),
+(678,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,520,o),
+(189,534,o),
+(189,558,cs),
+(189,588,o),
+(203,649,o),
+(238,649,cs),
+(256,649,o),
+(266,636,o),
+(266,611,cs),
+(266,581,o),
+(252,520,o),
+(216,520,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(471,520,o),
+(461,534,o),
+(461,558,cs),
+(461,588,o),
+(475,649,o),
+(510,649,cs),
+(528,649,o),
+(538,636,o),
+(538,611,cs),
+(538,581,o),
+(524,520,o),
+(489,520,cs)
+);
+}
+);
+width = 821;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1596;
+unicode = 5526;
+},
+{
+glyphname = "sheSayisi-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (633,357);
+},
+{
+name = top_center_can;
+pos = (366,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(434,0,l),
+(529,444,ls),
+(565,618,o),
+(499,728,o),
+(351,728,cs),
+(146,728,o),
+(72,506,o),
+(72,359,cs),
+(72,255,o),
+(115,194,o),
+(195,194,cs),
+(277,194,o),
+(318,259,o),
+(347,428,c),
+(288,428,l),
+(274,343,o),
+(260,314,o),
+(236,314,cs),
+(218,314,o),
+(209,330,o),
+(209,361,cs),
+(209,413,o),
+(242,604,o),
+(331,604,cs),
+(390,604,o),
+(403,546,o),
+(381,443,cs),
+(286,0,l)
+);
+}
+);
+width = 538;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1597;
+unicode = 5527;
+},
+{
+glyphname = "shiSayisi-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(144,0,l),
+(242,460,ls),
+(263,561,o),
+(293,604,o),
+(343,604,cs),
+(386,604,o),
+(408,576,o),
+(408,520,cs),
+(408,476,o),
+(380,314,o),
+(335,314,cs),
+(308,314,o),
+(302,341,o),
+(323,428,c),
+(265,428,l),
+(225,272,o),
+(258,194,o),
+(356,194,cs),
+(493,194,o),
+(547,411,o),
+(547,517,cs),
+(547,649,o),
+(474,728,o),
+(347,728,cs),
+(219,728,o),
+(134,646,o),
+(100,488,cs),
+(-4,0,l)
+);
+}
+);
+width = 540;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni1598;
+unicode = 5528;
+},
+{
+glyphname = "shoSayisi-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (363,714);
+},
+{
+name = top_left_can;
+pos = (209,714);
+},
+{
+name = top_right_can;
+pos = (515,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(365,-14,o),
+(450,68,o),
+(484,226,cs),
+(588,714,l),
+(440,714,l),
+(342,254,ls),
+(321,153,o),
+(291,110,o),
+(241,110,cs),
+(198,110,o),
+(176,138,o),
+(176,194,cs),
+(176,238,o),
+(204,400,o),
+(249,400,cs),
+(276,400,o),
+(282,373,o),
+(261,286,c),
+(319,286,l),
+(359,442,o),
+(326,520,o),
+(228,520,cs),
+(91,520,o),
+(37,303,o),
+(37,197,cs),
+(37,65,o),
+(110,-14,o),
+(237,-14,cs)
+);
+}
+);
+width = 540;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1599;
+unicode = 5529;
+},
+{
+glyphname = "shaSayisi-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(437,-14,o),
+(511,208,o),
+(511,355,cs),
+(511,459,o),
+(468,520,o),
+(388,520,cs),
+(306,520,o),
+(264,455,o),
+(236,286,c),
+(294,286,l),
+(309,371,o),
+(323,400,o),
+(347,400,cs),
+(365,400,o),
+(374,384,o),
+(374,353,cs),
+(374,301,o),
+(341,110,o),
+(251,110,cs),
+(193,110,o),
+(180,168,o),
+(202,271,cs),
+(296,714,l),
+(149,714,l),
+(54,270,ls),
+(18,96,o),
+(83,-14,o),
+(232,-14,cs)
+);
+}
+);
+width = 539;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni159A;
+unicode = 5530;
+},
+{
+glyphname = "theWoodScree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(601,-14,o),
+(675,172,o),
+(675,300,cs),
+(675,426,o),
+(599,506,o),
+(471,506,cs),
+(97,506,l),
+(72,385,l),
+(321,385,l),
+(315,425,l),
+(248,374,o),
+(222,264,o),
+(222,192,cs),
+(222,68,o),
+(297,-14,o),
+(419,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(387,110,o),
+(364,140,o),
+(364,192,cs),
+(364,246,o),
+(392,384,o),
+(470,384,cs),
+(511,384,o),
+(533,355,o),
+(533,303,cs),
+(533,247,o),
+(505,110,o),
+(427,110,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(736,593,l),
+(761,714,l),
+(142,714,l),
+(116,593,l)
+);
+}
+);
+width = 716;
+}
+);
+note = uni159B;
+unicode = 5531;
+},
+{
+glyphname = "thiWoodScree-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(418,-14,o),
+(493,172,o),
+(493,300,cs),
+(493,340,o),
+(484,372,o),
+(467,396,c),
+(453,385,l),
+(702,385,l),
+(727,506,l),
+(313,506,ls),
+(105,506,o),
+(39,317,o),
+(39,192,cs),
+(39,68,o),
+(114,-14,o),
+(237,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(204,110,o),
+(182,140,o),
+(182,192,cs),
+(182,246,o),
+(209,384,o),
+(288,384,cs),
+(329,384,o),
+(351,355,o),
+(351,303,cs),
+(351,247,o),
+(323,110,o),
+(245,110,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(746,593,l),
+(772,714,l),
+(153,714,l),
+(127,593,l)
+);
+}
+);
+width = 717;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159C;
+unicode = 5532;
+},
+{
+glyphname = "thoWoodScree-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(404,0,ls),
+(612,0,o),
+(678,189,o),
+(678,315,cs),
+(678,438,o),
+(603,521,o),
+(481,521,cs),
+(299,521,o),
+(224,334,o),
+(224,206,cs),
+(224,167,o),
+(233,134,o),
+(250,110,c),
+(264,121,l),
+(16,121,l),
+(-10,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(389,123,o),
+(367,151,o),
+(367,203,cs),
+(367,260,o),
+(395,396,o),
+(472,396,cs),
+(513,396,o),
+(536,367,o),
+(536,315,cs),
+(536,260,o),
+(508,123,o),
+(430,123,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(735,593,l),
+(761,714,l),
+(141,714,l),
+(115,593,l)
+);
+}
+);
+width = 717;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159D;
+unicode = 5533;
+},
+{
+glyphname = "thaWoodScree-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(619,0,l),
+(645,121,l),
+(395,121,l),
+(401,81,l),
+(468,132,o),
+(495,242,o),
+(495,314,cs),
+(495,438,o),
+(419,521,o),
+(297,521,cs),
+(115,521,o),
+(41,334,o),
+(41,206,cs),
+(41,81,o),
+(117,0,o),
+(245,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(205,123,o),
+(183,151,o),
+(183,203,cs),
+(183,260,o),
+(211,396,o),
+(289,396,cs),
+(330,396,o),
+(352,367,o),
+(352,315,cs),
+(352,260,o),
+(325,123,o),
+(246,123,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(744,593,l),
+(770,714,l),
+(151,714,l),
+(125,593,l)
+);
+}
+);
+width = 716;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159E;
+unicode = 5534;
+},
+{
+glyphname = "thWoodScree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(409,356,l),
+(428,441,l),
+(292,441,l),
+(288,396,l),
+(323,420,o),
+(342,478,o),
+(342,519,cs),
+(342,585,o),
+(301,627,o),
+(234,627,cs),
+(143,627,o),
+(95,543,o),
+(95,467,cs),
+(95,399,o),
+(137,356,o),
+(206,356,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(190,427,o),
+(180,441,o),
+(180,465,cs),
+(180,495,o),
+(194,556,o),
+(229,556,cs),
+(247,556,o),
+(257,542,o),
+(257,518,cs),
+(257,488,o),
+(243,427,o),
+(208,427,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(465,670,l),
+(483,755,l),
+(155,755,l),
+(136,670,l)
+);
+}
+);
+width = 433;
+}
+);
+metricRight = "=|";
+note = uni159F;
+unicode = 5535;
+},
+{
+glyphname = "lhi-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (474,714);
+},
+{
+name = top_right_can;
+pos = (578,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(279,0,l),
+(306,129,l),
+(282,129,ls),
+(223,129,o),
+(187,166,o),
+(187,224,cs),
+(187,292,o),
+(226,373,o),
+(335,373,cs),
+(696,373,l),
+(721,491,l),
+(620,763,l),
+(485,712,l),
+(586,440,l),
+(639,506,l),
+(347,506,ls),
+(153,506,o),
+(40,387,o),
+(40,220,cs),
+(40,92,o),
+(124,0,o),
+(252,0,cs)
+);
+}
+);
+width = 708;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A0;
+unicode = 5536;
+},
+{
+glyphname = "lhii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "lhi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (288,0);
+ref = dot_top;
+}
+);
+width = 708;
+}
+);
+note = uni15A1;
+unicode = 5537;
+},
+{
+glyphname = "lho-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (408,524);
+},
+{
+name = top_right_can;
+pos = (499,524);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(223,-206,l),
+(122,66,l),
+(69,0,l),
+(361,0,ls),
+(554,0,o),
+(667,119,o),
+(667,286,cs),
+(667,414,o),
+(584,506,o),
+(456,506,cs),
+(429,506,l),
+(402,377,l),
+(425,377,ls),
+(485,377,o),
+(521,340,o),
+(521,282,cs),
+(521,214,o),
+(482,133,o),
+(373,133,cs),
+(12,133,l),
+(-13,15,l),
+(88,-257,l)
+);
+}
+);
+width = 707;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni15A2;
+unicode = 5538;
+},
+{
+glyphname = "lhoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "lho-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (315,-190);
+ref = dot_top;
+}
+);
+width = 708;
+}
+);
+note = uni15A3;
+unicode = 5539;
+},
+{
+glyphname = "lha-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (415,524);
+},
+{
+name = top_left_can;
+pos = (323,524);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(619,15,l),
+(644,133,l),
+(292,133,ls),
+(222,133,o),
+(185,167,o),
+(185,227,cs),
+(185,297,o),
+(224,377,o),
+(334,377,cs),
+(357,377,l),
+(385,506,l),
+(354,506,ls),
+(153,506,o),
+(39,387,o),
+(39,213,cs),
+(39,84,o),
+(123,0,o),
+(264,0,cs),
+(521,0,l),
+(483,61,l),
+(296,-175,l),
+(400,-258,l)
+);
+}
+);
+width = 708;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A4;
+unicode = 5540;
+},
+{
+glyphname = "lhaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "lha-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (137,-190);
+ref = dot_top;
+}
+);
+width = 708;
+}
+);
+note = uni15A5;
+unicode = 5541;
+},
+{
+glyphname = "lh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(399,367,l),
+(417,449,l),
+(263,449,ls),
+(220,449,o),
+(196,472,o),
+(196,512,cs),
+(196,561,o),
+(221,623,o),
+(297,623,cs),
+(306,623,l),
+(326,714,l),
+(311,714,ls),
+(163,714,o),
+(98,609,o),
+(98,499,cs),
+(98,408,o),
+(157,357,o),
+(256,357,cs),
+(354,357,l),
+(319,418,l),
+(204,274,l),
+(275,214,l)
+);
+}
+);
+width = 415;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni15A6;
+unicode = 5542;
+},
+{
+glyphname = "theThCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (198,714);
+},
+{
+name = top_right_can;
+pos = (482,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(275,85,l),
+(257,0,l),
+(404,0,l),
+(422,85,l),
+(482,85,l),
+(499,165,l),
+(439,165,l),
+(480,357,l),
+(225,357,l),
+(247,309,l),
+(551,637,l),
+(451,726,l),
+(30,267,l),
+(22,229,l),
+(305,229,l),
+(292,165,l),
+(110,165,l),
+(93,85,l)
+);
+}
+);
+width = 543;
+}
+);
+metricLeft = "ye-canadian";
+note = uni15A7;
+unicode = 5543;
+},
+{
+glyphname = "thiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (258,714);
+},
+{
+name = top_right_can;
+pos = (542,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(179,0,l),
+(197,85,l),
+(379,85,l),
+(395,165,l),
+(214,165,l),
+(227,229,l),
+(510,229,l),
+(518,267,l),
+(267,726,l),
+(150,660,l),
+(349,300,l),
+(383,357,l),
+(107,357,l),
+(66,165,l),
+(6,165,l),
+(-11,85,l),
+(50,85,l),
+(31,0,l)
+);
+}
+);
+width = 542;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+unicode = 5544;
+},
+{
+glyphname = "thiiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (72,0);
+ref = dot_top;
+}
+);
+width = 543;
+}
+);
+note = uni15A9;
+unicode = 5545;
+},
+{
+glyphname = "thoThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (198,714);
+},
+{
+name = top_right_can;
+pos = (482,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(437,54,l),
+(238,414,l),
+(204,357,l),
+(479,357,l),
+(520,549,l),
+(581,549,l),
+(598,629,l),
+(537,629,l),
+(555,714,l),
+(408,714,l),
+(389,629,l),
+(208,629,l),
+(191,549,l),
+(373,549,l),
+(359,485,l),
+(77,485,l),
+(68,447,l),
+(320,-12,l)
+);
+}
+);
+width = 543;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+unicode = 5546;
+},
+{
+glyphname = "thooThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (297,0);
+ref = dot_top;
+}
+);
+width = 543;
+}
+);
+note = uni15AB;
+unicode = 5547;
+},
+{
+glyphname = "thaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (258,714);
+},
+{
+name = top_right_can;
+pos = (542,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(558,447,l),
+(566,485,l),
+(283,485,l),
+(296,549,l),
+(478,549,l),
+(495,629,l),
+(313,629,l),
+(331,714,l),
+(184,714,l),
+(165,629,l),
+(105,629,l),
+(89,549,l),
+(149,549,l),
+(108,357,l),
+(363,357,l),
+(341,405,l),
+(37,77,l),
+(137,-12,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+unicode = 5548;
+},
+{
+glyphname = "thaaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:31:56 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (73,0);
+ref = dot_top;
+}
+);
+width = 544;
+}
+);
+note = uni15AD;
+unicode = 5549;
+},
+{
+glyphname = "thThCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(146,636,l),
+(121,519,l),
+(263,519,l),
+(241,568,l),
+(92,405,l),
+(159,348,l),
+(363,573,l),
+(369,600,l),
+(235,600,l),
+(243,636,l),
+(325,636,l),
+(334,677,l),
+(252,677,l),
+(260,714,l),
+(163,714,l),
+(155,677,l),
+(124,677,l),
+(115,636,l)
+);
+}
+);
+width = 317;
+}
+);
+metricRight = "y-canadian";
+note = uni15AE;
+unicode = 5550;
+},
+{
+glyphname = "bAivilik-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(424,-14,o),
+(500,181,o),
+(500,326,cs),
+(500,446,o),
+(439,521,o),
+(339,521,cs),
+(291,521,o),
+(251,497,o),
+(223,448,c),
+(239,437,l),
+(298,714,l),
+(151,714,l),
+(-1,0,l),
+(134,0,l),
+(152,84,l),
+(140,70,l),
+(150,16,o),
+(194,-14,o),
+(257,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(213,110,o),
+(192,136,o),
+(192,188,cs),
+(192,241,o),
+(218,396,o),
+(297,396,cs),
+(335,396,o),
+(357,370,o),
+(357,319,cs),
+(357,266,o),
+(331,110,o),
+(252,110,cs)
+);
+}
+);
+width = 534;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|ke-canadian";
+note = uni15AF;
+unicode = 5551;
+},
+{
+glyphname = "eBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(146,0,l),
+(237,424,l),
+(255,382,o),
+(298,356,o),
+(353,356,cs),
+(481,356,o),
+(538,487,o),
+(538,581,cs),
+(538,669,o),
+(487,728,o),
+(403,728,cs),
+(356,728,o),
+(311,708,o),
+(282,673,c),
+(290,714,l),
+(151,714,l),
+(-1,0,l)
+);
+}
+);
+width = 507;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B0;
+unicode = 5552;
+},
+{
+glyphname = "iBlackfoot-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(196,-14,o),
+(241,6,o),
+(270,41,c),
+(262,0,l),
+(401,0,l),
+(553,714,l),
+(406,714,l),
+(315,290,l),
+(297,332,o),
+(254,358,o),
+(199,358,cs),
+(71,358,o),
+(13,227,o),
+(13,133,cs),
+(13,45,o),
+(65,-14,o),
+(149,-14,cs)
+);
+}
+);
+width = 508;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B1;
+unicode = 5553;
+},
+{
+glyphname = "oBlackfoot-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(402,-14,o),
+(460,117,o),
+(460,211,cs),
+(460,299,o),
+(409,358,o),
+(326,358,cs),
+(283,358,o),
+(243,342,o),
+(213,314,c),
+(298,714,l),
+(151,714,l),
+(-1,0,l),
+(138,0,l),
+(153,68,l),
+(168,18,o),
+(214,-14,o),
+(275,-14,cs)
+);
+}
+);
+width = 508;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "eBlackfoot-canadian";
+note = uni15B2;
+unicode = 5554;
+},
+{
+glyphname = "aBlackfoot-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(400,0,l),
+(552,714,l),
+(413,714,l),
+(399,646,l),
+(384,696,o),
+(338,728,o),
+(277,728,cs),
+(149,728,o),
+(92,597,o),
+(92,503,cs),
+(92,415,o),
+(143,356,o),
+(225,356,cs),
+(269,356,o),
+(309,372,o),
+(338,400,c),
+(253,0,l)
+);
+}
+);
+width = 507;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B3;
+unicode = 5555;
+},
+{
+glyphname = "weBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(146,0,l),
+(209,292,l),
+(488,292,l),
+(514,418,l),
+(235,418,l),
+(272,589,l),
+(551,589,l),
+(577,714,l),
+(151,714,l),
+(-1,0,l)
+);
+}
+);
+width = 524;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B4;
+unicode = 5556;
+},
+{
+glyphname = "wiBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(417,0,l),
+(569,714,l),
+(421,714,l),
+(359,422,l),
+(81,422,l),
+(54,296,l),
+(332,296,l),
+(296,125,l),
+(17,125,l),
+(-9,0,l)
+);
+}
+);
+width = 524;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B5;
+unicode = 5557;
+},
+{
+glyphname = "woBlackfoot-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(425,0,l),
+(452,125,l),
+(173,125,l),
+(209,296,l),
+(488,296,l),
+(515,422,l),
+(236,422,l),
+(298,714,l),
+(151,714,l),
+(-1,0,l)
+);
+}
+);
+width = 523;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "weBlackfoot-canadian";
+note = uni15B6;
+unicode = 5558;
+},
+{
+glyphname = "waBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(417,0,l),
+(569,714,l),
+(142,714,l),
+(116,589,l),
+(395,589,l),
+(358,418,l),
+(79,418,l),
+(53,292,l),
+(332,292,l),
+(269,0,l)
+);
+}
+);
+width = 524;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B7;
+unicode = 5559;
+},
+{
+glyphname = "neBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(146,0,l),
+(275,607,l),
+(327,607,l),
+(306,690,l),
+(298,652,ls),
+(266,499,o),
+(339,400,o),
+(487,400,cs),
+(616,400,o),
+(699,477,o),
+(732,629,cs),
+(750,714,l),
+(606,714,l),
+(585,615,ls),
+(573,558,o),
+(544,530,o),
+(497,530,cs),
+(445,530,o),
+(423,565,o),
+(436,624,cs),
+(455,714,l),
+(151,714,l),
+(-1,0,l)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B8;
+unicode = 5560;
+},
+{
+glyphname = "niBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(115,0,l),
+(136,99,ls),
+(148,156,o),
+(177,184,o),
+(224,184,cs),
+(276,184,o),
+(298,149,o),
+(285,90,cs),
+(266,0,l),
+(570,0,l),
+(722,714,l),
+(575,714,l),
+(446,107,l),
+(394,107,l),
+(415,24,l),
+(423,62,ls),
+(455,215,o),
+(382,314,o),
+(234,314,cs),
+(105,314,o),
+(22,237,o),
+(-11,85,cs),
+(-29,0,l)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B9;
+unicode = 5561;
+},
+{
+glyphname = "noBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(303,0,l),
+(324,94,ls),
+(338,157,o),
+(364,186,o),
+(410,186,cs),
+(463,186,o),
+(484,149,o),
+(471,85,cs),
+(454,0,l),
+(598,0,l),
+(610,55,ls),
+(643,211,o),
+(567,314,o),
+(420,314,cs),
+(293,314,o),
+(212,237,o),
+(178,83,cs),
+(165,24,l),
+(221,107,l),
+(169,107,l),
+(298,714,l),
+(151,714,l),
+(-1,0,l)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "neBlackfoot-canadian";
+note = uni15BA;
+unicode = 5562;
+},
+{
+glyphname = "naBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(570,0,l),
+(722,714,l),
+(418,714,l),
+(397,620,ls),
+(383,557,o),
+(357,528,o),
+(311,528,cs),
+(258,528,o),
+(237,565,o),
+(250,629,cs),
+(267,714,l),
+(123,714,l),
+(111,659,ls),
+(78,503,o),
+(154,400,o),
+(301,400,cs),
+(428,400,o),
+(509,477,o),
+(543,631,cs),
+(556,690,l),
+(501,607,l),
+(552,607,l),
+(423,0,l)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BB;
+unicode = 5563;
+},
+{
+glyphname = "keBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(146,0,l),
+(262,544,l),
+(212,544,l),
+(284,260,l),
+(345,260,l),
+(651,714,l),
+(487,714,l),
+(298,430,l),
+(357,422,l),
+(286,714,l),
+(151,714,l),
+(-1,0,l)
+);
+}
+);
+width = 562;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15BC;
+unicode = 5564;
+},
+{
+glyphname = "kiBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(119,0,l),
+(308,285,l),
+(248,292,l),
+(319,0,l),
+(455,0,l),
+(607,714,l),
+(459,714,l),
+(344,171,l),
+(394,171,l),
+(322,455,l),
+(261,455,l),
+(-45,0,l)
+);
+}
+);
+width = 562;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BD;
+unicode = 5565;
+},
+{
+glyphname = "koBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(134,0,l),
+(350,291,l),
+(277,300,l),
+(349,0,l),
+(499,0,l),
+(386,454,l),
+(325,454,l),
+(133,170,l),
+(183,170,l),
+(298,714,l),
+(151,714,l),
+(-1,0,l)
+);
+}
+);
+width = 562;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "keBlackfoot-canadian";
+note = uni15BE;
+unicode = 5566;
+},
+{
+glyphname = "kaBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(455,0,l),
+(607,714,l),
+(471,714,l),
+(256,424,l),
+(329,414,l),
+(257,714,l),
+(107,714,l),
+(219,260,l),
+(281,260,l),
+(472,544,l),
+(423,544,l),
+(307,0,l)
+);
+}
+);
+width = 562;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BF;
+unicode = 5567;
+},
+{
+color = 9;
+glyphname = "heSayisi-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_right_can;
+pos = (588,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(509,0,l),
+(661,714,l),
+(515,714,l),
+(439,353,l),
+(462,353,l),
+(509,589,o),
+(452,728,o),
+(310,728,cs),
+(198,728,o),
+(120,642,o),
+(84,481,cs),
+(75,435,o),
+(69,393,o),
+(68,342,c),
+(208,342,l),
+(210,387,o),
+(214,424,o),
+(223,465,cs),
+(242,552,o),
+(279,600,o),
+(329,600,cs),
+(432,600,o),
+(448,411,o),
+(361,0,c)
+);
+}
+);
+width = 616;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni15C0;
+unicode = 5568;
+},
+{
+color = 9;
+glyphname = "hiSayisi-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(146,0,l),
+(230,385,o),
+(329,600,o),
+(425,600,cs),
+(479,600,o),
+(497,535,o),
+(474,421,cs),
+(466,387,o),
+(459,364,o),
+(450,342,c),
+(590,342,l),
+(602,372,o),
+(611,399,o),
+(618,429,cs),
+(655,611,o),
+(601,728,o),
+(481,728,cs),
+(356,728,o),
+(251,595,o),
+(201,372,c),
+(224,372,l),
+(297,714,l),
+(151,714,l),
+(-1,0,l)
+);
+}
+);
+width = 617;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C1;
+unicode = 5569;
+},
+{
+color = 9;
+glyphname = "hoSayisi-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (402,714);
+},
+{
+name = top_left_can;
+pos = (215,714);
+},
+{
+name = top_right_can;
+pos = (589,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(304,-14,o),
+(410,119,o),
+(459,342,c),
+(437,342,l),
+(364,0,l),
+(510,0,l),
+(662,714,l),
+(514,714,l),
+(431,329,o),
+(331,114,o),
+(236,114,cs),
+(181,114,o),
+(163,179,o),
+(187,293,cs),
+(195,327,o),
+(202,350,o),
+(211,372,c),
+(71,372,l),
+(59,342,o),
+(50,315,o),
+(43,285,cs),
+(5,103,o),
+(60,-14,o),
+(179,-14,cs)
+);
+}
+);
+width = 617;
+}
+);
+metricLeft = "heSayisi-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15C2;
+unicode = 5570;
+},
+{
+color = 9;
+glyphname = "haSayisi-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(461,-14,o),
+(539,72,o),
+(576,233,cs),
+(585,279,o),
+(590,321,o),
+(591,372,c),
+(452,372,l),
+(450,327,o),
+(446,290,o),
+(436,249,cs),
+(417,162,o),
+(381,114,o),
+(330,114,cs),
+(228,114,o),
+(212,303,o),
+(298,714,c),
+(151,714,l),
+(-1,0,l),
+(145,0,l),
+(221,361,l),
+(198,361,l),
+(151,125,o),
+(208,-14,o),
+(350,-14,cs)
+);
+}
+);
+width = 616;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C3;
+unicode = 5571;
+},
+{
+color = 9;
+glyphname = "ghuCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(285,0,l),
+(708,678,l),
+(715,714,l),
+(587,714,l),
+(468,514,l),
+(520,536,l),
+(224,536,l),
+(268,513,l),
+(234,714,l),
+(117,714,l),
+(110,678,l),
+(243,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(460,428,l),
+(435,451,l),
+(278,189,l),
+(325,181,l),
+(278,446,l),
+(242,428,l)
+);
+}
+);
+width = 637;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C4;
+unicode = 5572;
+},
+{
+color = 9;
+glyphname = "ghoCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(94,0,l),
+(215,200,l),
+(161,178,l),
+(457,178,l),
+(413,201,l),
+(447,0,l),
+(564,0,l),
+(571,36,l),
+(438,714,l),
+(396,714,l),
+(-27,36,l),
+(-34,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(421,405,l),
+(289,412,l),
+(315,269,l),
+(421,405,l),
+(288,407,l),
+(334,262,l)
+);
+}
+);
+width = 637;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C5;
+unicode = 5573;
+},
+{
+color = 9;
+glyphname = "gheCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (92,371);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(17,0,l),
+(564,334,l),
+(574,380,l),
+(169,714,l),
+(135,714,l),
+(112,608,l),
+(238,503,l),
+(229,592,l),
+(136,155,l),
+(176,235,l),
+(11,134,l),
+(-17,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(318,534,l),
+(279,487,l),
+(466,329,l),
+(472,405,l),
+(234,259,l),
+(250,214,l)
+);
+}
+);
+width = 574;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15C6;
+unicode = 5574;
+},
+{
+color = 9;
+glyphname = "gheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (22,14);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 573;
+}
+);
+note = uni15C7;
+unicode = 5575;
+},
+{
+color = 9;
+glyphname = "ghiCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (-2,14);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 573;
+}
+);
+note = uni15C8;
+unicode = 5576;
+},
+{
+color = 9;
+glyphname = "ghaCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(484,0,l),
+(507,106,l),
+(381,211,l),
+(390,122,l),
+(483,559,l),
+(442,479,l),
+(607,580,l),
+(636,714,l),
+(602,714,l),
+(54,380,l),
+(44,334,l),
+(449,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(339,227,l),
+(175,366,l),
+(172,325,l),
+(385,455,l),
+(362,471,l),
+(310,221,l)
+);
+}
+);
+width = 574;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15C9;
+unicode = 5577;
+},
+{
+color = 9;
+glyphname = "ruCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(285,0,l),
+(708,678,l),
+(715,714,l),
+(583,714,l),
+(527,620,l),
+(572,645,l),
+(211,645,l),
+(250,619,l),
+(234,714,l),
+(117,714,l),
+(110,678,l),
+(243,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(513,535,l),
+(499,561,l),
+(278,194,l),
+(325,186,l),
+(258,556,l),
+(227,535,l)
+);
+}
+);
+width = 637;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CA;
+unicode = 5578;
+},
+{
+color = 9;
+glyphname = "roCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(396,714,l),
+(-27,36,l),
+(-34,0,l),
+(98,0,l),
+(154,94,l),
+(109,69,l),
+(470,69,l),
+(431,95,l),
+(447,0,l),
+(563,0,l),
+(571,36,l),
+(438,714,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(168,179,l),
+(182,153,l),
+(403,520,l),
+(356,528,l),
+(423,158,l),
+(454,179,l)
+);
+}
+);
+width = 636;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CB;
+unicode = 5579;
+},
+{
+color = 9;
+glyphname = "reCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(18,0,l),
+(563,334,l),
+(573,380,l),
+(169,714,l),
+(134,714,l),
+(112,610,l),
+(182,550,l),
+(172,637,l),
+(58,105,l),
+(94,182,l),
+(10,129,l),
+(-18,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(261,563,l),
+(224,516,l),
+(448,328,l),
+(453,403,l),
+(166,223,l),
+(179,179,l)
+);
+}
+);
+width = 573;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CC;
+unicode = 5580;
+},
+{
+color = 9;
+glyphname = "reeCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(17,0,l),
+(563,334,l),
+(573,380,l),
+(169,714,l),
+(134,714,l),
+(115,625,l),
+(173,575,l),
+(174,650,l),
+(55,93,l),
+(86,168,l),
+(7,118,l),
+(-18,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(253,597,l),
+(218,550,l),
+(484,329,l),
+(489,404,l),
+(140,189,l),
+(156,143,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(271,298,l),
+(301,440,l),
+(254,440,l),
+(223,298,l)
+);
+}
+);
+width = 573;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CD;
+unicode = 5581;
+},
+{
+color = 9;
+glyphname = "riCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(17,0,l),
+(563,334,l),
+(573,380,l),
+(169,714,l),
+(134,714,l),
+(115,625,l),
+(176,572,l),
+(174,650,l),
+(55,93,l),
+(93,172,l),
+(7,118,l),
+(-18,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(312,328,o),
+(335,348,o),
+(335,374,cs),
+(335,401,o),
+(312,420,o),
+(287,420,cs),
+(263,420,o),
+(241,401,o),
+(241,374,cs),
+(241,348,o),
+(263,328,o),
+(287,328,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(253,597,l),
+(214,553,l),
+(484,329,l),
+(489,404,l),
+(143,192,l),
+(156,143,l)
+);
+}
+);
+width = 573;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CE;
+unicode = 5582;
+},
+{
+color = 9;
+glyphname = "raCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(483,0,l),
+(506,104,l),
+(436,164,l),
+(446,77,l),
+(559,609,l),
+(524,532,l),
+(608,585,l),
+(635,714,l),
+(600,714,l),
+(54,380,l),
+(44,334,l),
+(448,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(394,198,l),
+(170,386,l),
+(165,311,l),
+(452,491,l),
+(439,535,l),
+(357,151,l)
+);
+}
+);
+width = 574;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15CF;
+unicode = 5583;
+},
+{
+color = 9;
+glyphname = "wuCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(293,0,l),
+(723,678,l),
+(731,714,l),
+(606,714,l),
+(353,285,l),
+(383,285,l),
+(474,714,l),
+(363,714,l),
+(271,284,l),
+(302,284,l),
+(226,714,l),
+(117,714,l),
+(110,678,l),
+(251,0,l)
+);
+}
+);
+width = 652;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D0;
+unicode = 5584;
+},
+{
+color = 9;
+glyphname = "woCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(91,0,l),
+(343,429,l),
+(314,429,l),
+(222,0,l),
+(334,0,l),
+(425,430,l),
+(394,430,l),
+(471,0,l),
+(579,0,l),
+(586,36,l),
+(446,714,l),
+(403,714,l),
+(-27,36,l),
+(-34,0,l)
+);
+}
+);
+width = 652;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D1;
+unicode = 5585;
+},
+{
+color = 9;
+glyphname = "weCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(33.995,0,l),
+(580,334,l),
+(590,380,l),
+(185.995,714,l),
+(151,714,l),
+(129,608,l),
+(377,406,l),
+(384,427,l),
+(90,427,l),
+(66,316,l),
+(360,316,l),
+(368,335,l),
+(27,132,l),
+(0,0,l)
+);
+}
+);
+width = 590;
+}
+);
+metricRight = "o-canadian";
+note = uni15D2;
+unicode = 5586;
+},
+{
+color = 9;
+glyphname = "weeCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(34,0,l),
+(580,334,l),
+(590,380,l),
+(186,714,l),
+(152,714,l),
+(131,618,l),
+(430,376,l),
+(444,415,l),
+(226,415,l),
+(239,478,l),
+(164,478,l),
+(150,415,l),
+(88,415,l),
+(69,328,l),
+(132,328,l),
+(118,265,l),
+(194,265,l),
+(207,328,l),
+(427,328,l),
+(411,354,l),
+(25,122,l),
+(0,0,l)
+);
+}
+);
+width = 590;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D3;
+unicode = 5587;
+},
+{
+color = 9;
+glyphname = "wiCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(34,0,l),
+(580,334,l),
+(590,380,l),
+(186,714,l),
+(151,714,l),
+(131,618,l),
+(403,399,l),
+(417,419,l),
+(276,419,l),
+(263,445,o),
+(236,462,o),
+(204,462,cs),
+(172,462,o),
+(144,445,o),
+(131,419,c),
+(88,419,l),
+(70,333,l),
+(132,333,l),
+(146,308,o),
+(173,291,o),
+(204,291,cs),
+(234,291,o),
+(261,308,o),
+(275,333,c),
+(399,333,l),
+(391,342,l),
+(25,123,l),
+(0,0,l)
+);
+}
+);
+width = 590;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D4;
+unicode = 5588;
+},
+{
+color = 9;
+glyphname = "waCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(483,0,l),
+(505,106,l),
+(258,308,l),
+(251,287,l),
+(544,287,l),
+(568,398,l),
+(275,398,l),
+(267,379,l),
+(607,582,l),
+(634,714,l),
+(600,714,l),
+(54,380,l),
+(44,334,l),
+(448,0,l)
+);
+}
+);
+width = 590;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15D5;
+unicode = 5589;
+},
+{
+color = 9;
+glyphname = "hwuCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(293,0,l),
+(723,678,l),
+(731,714,l),
+(615,714,l),
+(508,538,l),
+(540,554,l),
+(426,554,l),
+(460,714,l),
+(374,714,l),
+(340,554,l),
+(222,554,l),
+(251,540,l),
+(217,714,l),
+(117,714,l),
+(110,678,l),
+(251,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(302,219,l),
+(252,500,l),
+(230,479,l),
+(331,479,l),
+(276,218,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(402,479,l),
+(500,479,l),
+(491,500,l),
+(326,224,l),
+(347,216,l)
+);
+}
+);
+width = 652;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D6;
+unicode = 5590;
+},
+{
+color = 9;
+glyphname = "hwoCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(81,0,l),
+(189,176,l),
+(156,160,l),
+(270,160,l),
+(236,0,l),
+(322,0,l),
+(356,160,l),
+(474,160,l),
+(446,174,l),
+(479,0,l),
+(579,0,l),
+(586,36,l),
+(445,714,l),
+(403,714,l),
+(-27,36,l),
+(-34,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(370,490,l),
+(350,498,l),
+(294,235,l),
+(196,235,l),
+(206,214,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(466,235,l),
+(365,235,l),
+(420,496,l),
+(394,495,l),
+(444,214,l)
+);
+}
+);
+width = 652;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D7;
+unicode = 5591;
+},
+{
+color = 9;
+glyphname = "hweCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(33,0,l),
+(580,334,l),
+(590,380,l),
+(185,714,l),
+(151,714,l),
+(131,618,l),
+(224,543,l),
+(197,415,l),
+(87,415,l),
+(68,323,l),
+(177,323,l),
+(151,198,l),
+(25,122,l),
+(-1,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(251,333,l),
+(403,333,l),
+(230,233,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(287,505,l),
+(413,405,l),
+(266,405,l)
+);
+}
+);
+width = 590;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D8;
+unicode = 5592;
+},
+{
+color = 9;
+glyphname = "hweeCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(33.995,0,l),
+(580,334,l),
+(590,380,l),
+(185,714,l),
+(151,714,l),
+(132,625,l),
+(261,521,l),
+(237,408,l),
+(195,408,l),
+(208,474,l),
+(148,474,l),
+(134,408,l),
+(86,408,l),
+(70,332,l),
+(118,332,l),
+(104,266,l),
+(164,266,l),
+(178,332,l),
+(221,332,l),
+(197,219,l),
+(24,116,l),
+(-1,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(285,339,l),
+(411,339,l),
+(267,252,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(316,485,l),
+(418,401,l),
+(299,401,l)
+);
+}
+);
+width = 590;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D9;
+unicode = 5593;
+},
+{
+color = 9;
+glyphname = "hwiCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(33.995,0,l),
+(580,334,l),
+(590,380,l),
+(185.995,714,l),
+(151,714,l),
+(133,625,l),
+(261,520,l),
+(236,401,l),
+(213,401,l),
+(203,422,o),
+(183,436,o),
+(159,436,cs),
+(135,436,o),
+(115,422,o),
+(104,401,c),
+(85,401,l),
+(71,338,l),
+(104,338,l),
+(114,317,o),
+(135,303,o),
+(158,303,cs),
+(181,303,o),
+(202,317,o),
+(213,338,c),
+(222,338,l),
+(197,219,l),
+(24,116,l),
+(-1,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(285,338,l),
+(409,338,l),
+(267,252,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(316,486,l),
+(419,401,l),
+(298,401,l)
+);
+}
+);
+width = 590;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15DA;
+unicode = 5594;
+},
+{
+color = 9;
+glyphname = "hwaCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(601,714,l),
+(54,380,l),
+(44,334,l),
+(449,0,l),
+(483,0,l),
+(503,96,l),
+(410,171,l),
+(437,299,l),
+(547,299,l),
+(566,391,l),
+(457,391,l),
+(483,516,l),
+(610,592,l),
+(635,714,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(383,381,l),
+(232,381,l),
+(405,481,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(347,209,l),
+(221,309,l),
+(368,309,l)
+);
+}
+);
+width = 591;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15DB;
+unicode = 5595;
+},
+{
+color = 9;
+glyphname = "thuCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(458,-14,o),
+(552,73,o),
+(590,250,cs),
+(688,714,l),
+(148,714,l),
+(59,292,ls),
+(18,101,o),
+(111,-14,o),
+(295,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(268,583,l),
+(513,583,l),
+(445,262,ls),
+(424,163,o),
+(380,121,o),
+(306,121,cs),
+(216,121,o),
+(181,175,o),
+(203,278,cs)
+);
+}
+);
+width = 641;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DC;
+unicode = 5596;
+},
+{
+color = 9;
+glyphname = "thoCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(536,0,l),
+(626,422,ls),
+(667,613,o),
+(573,728,o),
+(390,728,cs),
+(227,728,o),
+(133,641,o),
+(95,464,cs),
+(-4,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(240,452,ls),
+(261,551,o),
+(304,593,o),
+(379,593,cs),
+(469,593,o),
+(503,539,o),
+(481,436,cs),
+(417,131,l),
+(172,131,l)
+);
+}
+);
+width = 640;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DD;
+unicode = 5597;
+},
+{
+color = 9;
+glyphname = "theCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (343,357);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(211,0,ls),
+(519,0,o),
+(623,243,o),
+(623,438,cs),
+(623,612,o),
+(521,714,o),
+(334,714,cs),
+(151,714,l),
+(-1,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(283,645,l),
+(229,585,l),
+(309,585,ls),
+(418,585,o),
+(478,529,o),
+(478,425,cs),
+(478,303,o),
+(412,129,o),
+(221,129,cs),
+(143,129,l),
+(162,74,l)
+);
+}
+);
+width = 639;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "to-canadian";
+note = uni15DE;
+unicode = 5598;
+},
+{
+color = 9;
+glyphname = "theeCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (262,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 639;
+}
+);
+note = uni15DF;
+unicode = 5599;
+},
+{
+color = 9;
+glyphname = "thiCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (235,0);
+ref = dot_middle;
+}
+);
+width = 639;
+}
+);
+note = uni15E0;
+unicode = 5600;
+},
+{
+color = 9;
+glyphname = "thaCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(531,0,l),
+(683,714,l),
+(471,714,ls),
+(164,714,o),
+(60,471,o),
+(60,276,cs),
+(60,102,o),
+(162,0,o),
+(349,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(205,411,o),
+(270,585,o),
+(462,585,cs),
+(540,585,l),
+(521,640,l),
+(399,69,l),
+(453,129,l),
+(374,129,ls),
+(264,129,o),
+(205,185,o),
+(205,289,cs)
+);
+}
+);
+width = 638;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15E1;
+unicode = 5601;
+},
+{
+color = 9;
+glyphname = "ttuCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(458,-14,o),
+(551,70,o),
+(589,249,cs),
+(688,714,l),
+(647,714,l),
+(318,517,l),
+(424,505,l),
+(191,714,l),
+(148,714,l),
+(58,290,ls),
+(18,100,o),
+(108,-14,o),
+(294,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(216,121,o),
+(181,175,o),
+(203,276,cs),
+(264,563,l),
+(198,541,l),
+(342,412,l),
+(367,412,l),
+(560,529,l),
+(509,562,l),
+(445,264,ls),
+(424,164,o),
+(380,121,o),
+(303,121,cs)
+);
+}
+);
+width = 640;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E2;
+unicode = 5602;
+},
+{
+color = 9;
+glyphname = "ttoCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(38,0,l),
+(367,197,l),
+(261,209,l),
+(493,0,l),
+(536,0,l),
+(626,424,ls),
+(667,614,o),
+(576,728,o),
+(391,728,cs),
+(227,728,o),
+(134,644,o),
+(95,465,cs),
+(-4,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(468,593,o),
+(503,539,o),
+(482,438,cs),
+(421,151,l),
+(486,173,l),
+(343,302,l),
+(318,302,l),
+(125,185,l),
+(176,152,l),
+(239,450,ls),
+(261,550,o),
+(304,593,o),
+(381,593,cs)
+);
+}
+);
+width = 640;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E3;
+unicode = 5603;
+},
+{
+color = 9;
+glyphname = "tteCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (387,357);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(222,0,ls),
+(520,0,o),
+(634,234,o),
+(634,438,cs),
+(634,612,o),
+(532,714,o),
+(351,714,cs),
+(146.996,714,l),
+(139,678,l),
+(180,309,l),
+(200,433,l),
+(3,36,l),
+(-4,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(310,345,l),
+(314,365,l),
+(281,650,l),
+(230,585,l),
+(320,585,ls),
+(429,585,o),
+(489,528,o),
+(489,425,cs),
+(489,303,o),
+(423,129,o),
+(232,129,cs),
+(144,129,l),
+(174,70,l)
+);
+}
+);
+width = 650;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15E4;
+unicode = 5604;
+},
+{
+color = 9;
+glyphname = "tteeCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (319,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 650;
+}
+);
+note = uni15E5;
+unicode = 5605;
+},
+{
+color = 9;
+glyphname = "ttiCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (310,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 650;
+}
+);
+note = uni15E6;
+unicode = 5606;
+},
+{
+color = 9;
+glyphname = "ttaCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(546,0,l),
+(554,36,l),
+(513,405,l),
+(493,281,l),
+(690,678,l),
+(697,714,l),
+(471,714,ls),
+(173,714,o),
+(60,480,o),
+(60,276,cs),
+(60,102,o),
+(161,0,o),
+(342,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(463,129,l),
+(373,129,ls),
+(264,129,o),
+(205,186,o),
+(205,289,cs),
+(205,411,o),
+(270,585,o),
+(461,585,cs),
+(549,585,l),
+(519,644,l),
+(383,369,l),
+(379,349,l),
+(412,64,l)
+);
+}
+);
+width = 649;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tteCarrier-canadian";
+note = uni15E7;
+unicode = 5607;
+},
+{
+color = 9;
+glyphname = "puCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(458,-14,o),
+(552,73,o),
+(590,250,cs),
+(688,714,l),
+(540.994,714,l),
+(510,567,l),
+(265,567,l),
+(296,714,l),
+(148,714,l),
+(59,292,ls),
+(18,101,o),
+(111,-14,o),
+(295,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(216,121,o),
+(181,175,o),
+(203,278,cs),
+(237,437,l),
+(482,437,l),
+(445,262,ls),
+(424,163,o),
+(380,121,o),
+(306,121,cs)
+);
+}
+);
+width = 641;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E8;
+unicode = 5608;
+},
+{
+color = 9;
+glyphname = "poCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(144,0,l),
+(175,147,l),
+(420,147,l),
+(388.994,0,l),
+(536,0,l),
+(626,422,ls),
+(667,613,o),
+(573,728,o),
+(390,728,cs),
+(227,728,o),
+(133,641,o),
+(95,464,cs),
+(-4,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(240,452,ls),
+(261,551,o),
+(304,593,o),
+(379,593,cs),
+(469,593,o),
+(503,539,o),
+(481,436,cs),
+(448,277,l),
+(203,277,l)
+);
+}
+);
+width = 640;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E9;
+unicode = 5609;
+},
+{
+color = 9;
+glyphname = "peCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (373,357);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(221,0,ls),
+(528,0,o),
+(632,243,o),
+(632,438,cs),
+(632,612,o),
+(530,714,o),
+(349,714,cs),
+(146,714,l),
+(118,585,l),
+(186,585,l),
+(90,129,l),
+(21,129,l),
+(-6.005,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(346,649,l),
+(203,585,l),
+(318,585,ls),
+(427,585,o),
+(487,528,o),
+(487,425,cs),
+(487,305,o),
+(423,129,o),
+(230,129,cs),
+(106,129,l),
+(222,65,l)
+);
+}
+);
+width = 648;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15EA;
+unicode = 5610;
+},
+{
+color = 9;
+glyphname = "peeCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (304,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 648;
+}
+);
+note = uni15EB;
+unicode = 5611;
+},
+{
+color = 9;
+glyphname = "piCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (296,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 648;
+}
+);
+note = uni15EC;
+unicode = 5612;
+},
+{
+color = 9;
+glyphname = "paCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(546,0,l),
+(573,129,l),
+(506,129,l),
+(602,585,l),
+(670,585,l),
+(698,714,l),
+(471,714,ls),
+(164,714,o),
+(60,471,o),
+(60,276,cs),
+(60,102,o),
+(162,0,o),
+(343,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(489,129,l),
+(374,129,ls),
+(264,129,o),
+(205,186,o),
+(205,289,cs),
+(205,409,o),
+(269,585,o),
+(462,585,cs),
+(586,585,l),
+(470,649,l),
+(346,65,l)
+);
+}
+);
+width = 647;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|peCarrier-canadian";
+note = uni15ED;
+unicode = 5613;
+},
+{
+color = 6;
+glyphname = "pCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(319,189,l),
+(339,282,l),
+(244,282,l),
+(300,546,l),
+(202,546,l),
+(146,282,l),
+(51,282,l),
+(32,189,l)
+);
+}
+);
+width = 378;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni15EE;
+unicode = 5614;
+},
+{
+color = 9;
+glyphname = "guCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (470,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(271,-14,o),
+(334,30,o),
+(379,122,c),
+(320,122,l),
+(334,32,o),
+(386,-14,o),
+(473,-14,cs),
+(590,-14,o),
+(653,55,o),
+(681,188,cs),
+(793,714,l),
+(653,714,l),
+(542,191,ls),
+(532,142,o),
+(509,118,o),
+(473,118,cs),
+(436,118,o),
+(418,146,o),
+(428,194,cs),
+(539,714,l),
+(402,714,l),
+(291,192,ls),
+(281,143,o),
+(257,118,o),
+(221,118,cs),
+(183,118,o),
+(167,145,o),
+(177,194,cs),
+(288,714,l),
+(148,714,l),
+(39,199,ls),
+(11,68,o),
+(66,-14,o),
+(187,-14,cs)
+);
+}
+);
+width = 745;
+}
+);
+metricRight = "=|";
+note = uni15EF;
+unicode = 5615;
+},
+{
+color = 9;
+glyphname = "goCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(137,0,l),
+(247,523,ls),
+(258,572,o),
+(280,596,o),
+(316,596,cs),
+(354,596,o),
+(371,568,o),
+(361,520,cs),
+(250,0,l),
+(387,0,l),
+(497,522,ls),
+(508,571,o),
+(532,596,o),
+(568,596,cs),
+(606,596,o),
+(622,569,o),
+(611,520,cs),
+(501,0,l),
+(641,0,l),
+(750,515,ls),
+(778,646,o),
+(723,728,o),
+(602,728,cs),
+(517,728,o),
+(455,684,o),
+(409,592,c),
+(469,592,l),
+(455,682,o),
+(404,728,o),
+(316,728,cs),
+(199,728,o),
+(136,659,o),
+(108,526,cs),
+(-3,0,l)
+);
+}
+);
+width = 745;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F0;
+unicode = 5616;
+},
+{
+color = 9;
+glyphname = "geCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (423,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(318,0,ls),
+(486,0,o),
+(582,89,o),
+(582,224,cs),
+(582,292,o),
+(549,346,o),
+(485,376,c),
+(475,323,l),
+(592,354,o),
+(649,439,o),
+(649,540,cs),
+(649,646,o),
+(571,714,o),
+(455,714,cs),
+(152,714,l),
+(126,594,l),
+(425,594,ls),
+(475,594,o),
+(503,566,o),
+(503,522,cs),
+(503,461,o),
+(465,416,o),
+(388,416,cs),
+(88,416,l),
+(63,298,l),
+(362,298,ls),
+(412,298,o),
+(440,272,o),
+(440,229,cs),
+(440,185,o),
+(418,120,o),
+(325,120,cs),
+(25,120,l),
+(0,0,l)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15F1;
+unicode = 5617;
+},
+{
+color = 9;
+glyphname = "geeCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(318,0,ls),
+(486,0,o),
+(582,89,o),
+(582,224,cs),
+(582,292,o),
+(549,346,o),
+(485,376,c),
+(475,323,l),
+(592,354,o),
+(649,439,o),
+(649,540,cs),
+(649,646,o),
+(571,714,o),
+(455,714,cs),
+(152,714,l),
+(126,594,l),
+(425,594,ls),
+(475,594,o),
+(503,566,o),
+(503,522,cs),
+(503,461,o),
+(465,416,o),
+(388,416,cs),
+(348,416,l),
+(365,495,l),
+(282,495,l),
+(265,416,l),
+(88,416,l),
+(63,298,l),
+(240,298,l),
+(223,221,l),
+(307,221,l),
+(323,298,l),
+(362,298,ls),
+(412,298,o),
+(440,272,o),
+(440,229,cs),
+(440,185,o),
+(418,120,o),
+(325,120,cs),
+(25,120,l),
+(0,0,l)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F2;
+unicode = 5618;
+},
+{
+color = 9;
+glyphname = "giCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(318,0,ls),
+(486,0,o),
+(582,89,o),
+(582,224,cs),
+(582,291,o),
+(549,346,o),
+(485,376,c),
+(475,323,l),
+(592,354,o),
+(649,441,o),
+(649,540,cs),
+(649,646,o),
+(571,714,o),
+(455,714,cs),
+(152,714,l),
+(126,594,l),
+(425,594,ls),
+(475,594,o),
+(503,566,o),
+(503,522,cs),
+(503,461,o),
+(465,416,o),
+(388,416,cs),
+(359,416,l),
+(398,377,l),
+(391,422,o),
+(352,457,o),
+(303,457,cs),
+(269,457,o),
+(241,441,o),
+(225,416,c),
+(88,416,l),
+(63,298,l),
+(225,298,l),
+(241,273,o),
+(269,257,o),
+(303,257,cs),
+(352,257,o),
+(389,292,o),
+(397,338,c),
+(339,298,l),
+(362,298,ls),
+(412,298,o),
+(440,272,o),
+(440,229,cs),
+(440,185,o),
+(418,120,o),
+(325,120,cs),
+(25,120,l),
+(0,0,l)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F3;
+unicode = 5619;
+},
+{
+color = 9;
+glyphname = "gaCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (434,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(536,0,l),
+(562,120,l),
+(263,120,ls),
+(214,120,o),
+(185,148,o),
+(185,192,cs),
+(185,253,o),
+(223,298,o),
+(300,298,cs),
+(601,298,l),
+(626,416,l),
+(326,416,ls),
+(276,416,o),
+(248,442,o),
+(248,485,cs),
+(248,529,o),
+(270,594,o),
+(363,594,cs),
+(663,594,l),
+(688,714,l),
+(370,714,ls),
+(202,714,o),
+(106,625,o),
+(106,490,cs),
+(106,422,o),
+(139,368,o),
+(203,338,c),
+(214,391,l),
+(96,360,o),
+(39,275,o),
+(39,174,cs),
+(39,68,o),
+(117,0,o),
+(234,0,cs)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|geCarrier-canadian";
+note = uni15F4;
+unicode = 5620;
+},
+{
+color = 9;
+glyphname = "khuCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(266,-14,o),
+(326,25,o),
+(370,105,c),
+(322,108,l),
+(340,28,o),
+(390,-14,o),
+(473,-14,cs),
+(590,-14,o),
+(653,55,o),
+(681,188,cs),
+(793,714,l),
+(148,714,l),
+(39,199,ls),
+(11,68,o),
+(66,-14,o),
+(187,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(183,118,o),
+(167,145,o),
+(177,194,cs),
+(261,587,l),
+(375,587,l),
+(291,192,ls),
+(281,143,o),
+(257,118,o),
+(221,118,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(436,118,o),
+(418,146,o),
+(428,194,cs),
+(512,587,l),
+(626,587,l),
+(542,191,ls),
+(532,142,o),
+(509,118,o),
+(473,118,cs)
+);
+}
+);
+width = 745;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F5;
+unicode = 5621;
+},
+{
+color = 9;
+glyphname = "khoCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(641,0,l),
+(750,515,ls),
+(778,646,o),
+(723,728,o),
+(602,728,cs),
+(523,728,o),
+(463,689,o),
+(419,609,c),
+(467,606,l),
+(449,686,o),
+(398,728,o),
+(315,728,cs),
+(199,728,o),
+(136,659,o),
+(108,526,cs),
+(-3,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(247,523,ls),
+(257,572,o),
+(279,596,o),
+(315,596,cs),
+(353,596,o),
+(370,568,o),
+(360,520,cs),
+(277,127,l),
+(163,127,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(497,522,ls),
+(508,571,o),
+(532,596,o),
+(568,596,cs),
+(606,596,o),
+(622,569,o),
+(611,520,cs),
+(528,127,l),
+(414,127,l)
+);
+}
+);
+width = 745;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F6;
+unicode = 5622;
+},
+{
+color = 9;
+glyphname = "kheCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(325,0,ls),
+(493,0,o),
+(588,88,o),
+(588,224,cs),
+(588,290,o),
+(556,343,o),
+(494,373,c),
+(487,325,l),
+(615,361,o),
+(656,457,o),
+(656,540,cs),
+(656,646,o),
+(577,714,o),
+(460,714,cs),
+(151,714,l),
+(-1,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(209,299,l),
+(369,299,ls),
+(419,299,o),
+(446,273,o),
+(446,229,cs),
+(446,180,o),
+(419,118,o),
+(332,118,cs),
+(170,118,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(272,596,l),
+(431,596,ls),
+(481,596,o),
+(509,566,o),
+(509,522,cs),
+(509,469,o),
+(479,415,o),
+(394,415,cs),
+(233,415,l)
+);
+}
+);
+width = 650;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F7;
+unicode = 5623;
+},
+{
+color = 9;
+glyphname = "kheeCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(325,0,ls),
+(493,0,o),
+(588,88,o),
+(588,224,cs),
+(588,290,o),
+(556,343,o),
+(494,373,c),
+(487,325,l),
+(615,361,o),
+(656,457,o),
+(656,540,cs),
+(656,646,o),
+(577,714,o),
+(460,714,cs),
+(151,714,l),
+(-1,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(209,299,l),
+(289,299,l),
+(272,219,l),
+(351,219,l),
+(373,322,l),
+(335,299,l),
+(369,299,ls),
+(419,299,o),
+(446,273,o),
+(446,229,cs),
+(446,180,o),
+(419,118,o),
+(332,118,cs),
+(170,118,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(410,497,l),
+(331,497,l),
+(314,415,l),
+(233,415,l),
+(272,596,l),
+(431,596,ls),
+(481,596,o),
+(509,566,o),
+(509,522,cs),
+(509,469,o),
+(479,415,o),
+(394,415,cs),
+(359,415,l),
+(388,393,l)
+);
+}
+);
+width = 650;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F8;
+unicode = 5624;
+},
+{
+color = 9;
+glyphname = "khiCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(325,0,ls),
+(493,0,o),
+(588,88,o),
+(588,224,cs),
+(588,290,o),
+(557,343,o),
+(495,373,c),
+(479,323,l),
+(614,357,o),
+(656,456,o),
+(656,540,cs),
+(656,646,o),
+(577,714,o),
+(460,714,cs),
+(151,714,l),
+(-1,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(210,306,l),
+(265,306,l),
+(280,277,o),
+(311,257,o),
+(345,257,cs),
+(396,257,o),
+(434,298,o),
+(439,349,c),
+(346,306,l),
+(375,306,ls),
+(425,306,o),
+(446,278,o),
+(446,233,cs),
+(446,182,o),
+(419,118,o),
+(332,118,cs),
+(170,118,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(431,596,ls),
+(481,596,o),
+(509,565,o),
+(509,519,cs),
+(509,466,o),
+(485,409,o),
+(401,409,cs),
+(356,409,l),
+(440,365,l),
+(435,417,o),
+(397,457,o),
+(345,457,cs),
+(295,457,o),
+(254,417,o),
+(252,365,c),
+(289,409,l),
+(232,409,l),
+(272,596,l)
+);
+}
+);
+width = 651;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F9;
+unicode = 5625;
+},
+{
+color = 9;
+glyphname = "khaCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(545,0,l),
+(697,714,l),
+(371,714,ls),
+(203,714,o),
+(107,626,o),
+(107,490,cs),
+(107,424,o),
+(139,371,o),
+(201,341,c),
+(208,389,l),
+(80,353,o),
+(39,257,o),
+(39,174,cs),
+(39,68,o),
+(118,0,o),
+(235,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(214,118,o),
+(186,148,o),
+(186,192,cs),
+(186,245,o),
+(217,299,o),
+(301,299,cs),
+(462,299,l),
+(424,118,l),
+(264,118,ls)
+);
+},
+{
+closed = 1;
+nodes = (
+(277,415,o),
+(250,441,o),
+(250,485,cs),
+(250,534,o),
+(277,596,o),
+(364,596,cs),
+(526,596,l),
+(487,415,l),
+(327,415,ls)
+);
+}
+);
+width = 652;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15FA;
+unicode = 5626;
+},
+{
+color = 9;
+glyphname = "kkuCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(266,-14,o),
+(325,24,o),
+(370,105,c),
+(322,106,l),
+(340,28,o),
+(390,-14,o),
+(473,-14,cs),
+(590,-14,o),
+(653,54,o),
+(681,188,cs),
+(793,714,l),
+(751,714,l),
+(483,581,l),
+(454,432,l),
+(670,537,l),
+(625,584,l),
+(542,191,ls),
+(532,142,o),
+(509,118,o),
+(473,118,cs),
+(435,118,o),
+(417,147,o),
+(427,194,cs),
+(538,714,l),
+(403,714,l),
+(293,192,ls),
+(282,143,o),
+(257,118,o),
+(221,118,cs),
+(183,118,o),
+(167,145,o),
+(177,194,cs),
+(260,585,l),
+(193,559,l),
+(363,448,l),
+(392,583,l),
+(190,714,l),
+(148,714,l),
+(39,199,ls),
+(11,67,o),
+(66,-14,o),
+(187,-14,cs)
+);
+}
+);
+width = 745;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FB;
+unicode = 5627;
+},
+{
+color = 9;
+glyphname = "kkoCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(39,0,l),
+(306,133,l),
+(335,282,l),
+(119,177,l),
+(164,130,l),
+(247,523,ls),
+(258,572,o),
+(279,596,o),
+(315,596,cs),
+(353,596,o),
+(371,567,o),
+(362,520,cs),
+(251,0,l),
+(385,0,l),
+(496,522,ls),
+(506,571,o),
+(532,596,o),
+(568,596,cs),
+(606,596,o),
+(622,569,o),
+(611,520,cs),
+(528,129,l),
+(596,155,l),
+(425,266,l),
+(397,131,l),
+(598,0,l),
+(641,0,l),
+(750,515,ls),
+(778,647,o),
+(723,728,o),
+(602,728,cs),
+(523,728,o),
+(463,690,o),
+(419,609,c),
+(467,608,l),
+(449,686,o),
+(399,728,o),
+(315,728,cs),
+(199,728,o),
+(136,660,o),
+(108,526,cs),
+(-3,0,l)
+);
+}
+);
+width = 745;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FC;
+unicode = 5628;
+},
+{
+color = 9;
+glyphname = "kkeCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(338,0,ls),
+(506,0,o),
+(602,89,o),
+(602,224,cs),
+(602,292,o),
+(570,343,o),
+(508,373,c),
+(501,325,l),
+(629,361,o),
+(669,457,o),
+(669,540,cs),
+(669,646,o),
+(591,714,o),
+(474,714,cs),
+(149,714,l),
+(141,678,l),
+(170,416,l),
+(95,416,l),
+(70,298,l),
+(137,298,l),
+(5,36,l),
+(-3,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(284,298,l),
+(382,298,ls),
+(432,298,o),
+(460,272,o),
+(460,229,cs),
+(460,185,o),
+(438,120,o),
+(345,120,cs),
+(134,120,l),
+(166,61,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(280,661,l),
+(223,594,l),
+(445,594,ls),
+(495,594,o),
+(523,566,o),
+(523,522,cs),
+(523,461,o),
+(485,416,o),
+(408,416,cs),
+(309,416,l)
+);
+}
+);
+width = 664;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni15FD;
+unicode = 5629;
+},
+{
+color = 9;
+glyphname = "kkeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(338,0,ls),
+(506,0,o),
+(602,89,o),
+(602,224,cs),
+(602,292,o),
+(570,343,o),
+(508,373,c),
+(501,325,l),
+(629,361,o),
+(669,457,o),
+(669,540,cs),
+(669,646,o),
+(591,714,o),
+(474,714,cs),
+(149,714,l),
+(141,678,l),
+(170,416,l),
+(95,416,l),
+(70,298,l),
+(137,298,l),
+(5,36,l),
+(-3,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(286,303,l),
+(324,303,l),
+(306,218,l),
+(385,218,l),
+(409,330,l),
+(369,303,l),
+(395,303,ls),
+(439,303,o),
+(460,272,o),
+(460,229,cs),
+(460,185,o),
+(438,120,o),
+(345,120,cs),
+(134,120,l),
+(166,61,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(444,497,l),
+(365,497,l),
+(347,412,l),
+(309,412,l),
+(280,661,l),
+(223,594,l),
+(445,594,ls),
+(495,594,o),
+(523,566,o),
+(523,522,cs),
+(523,461,o),
+(485,412,o),
+(414,412,cs),
+(389,412,l),
+(423,394,l)
+);
+}
+);
+width = 664;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FE;
+unicode = 5630;
+},
+{
+color = 9;
+glyphname = "kkiCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(338,0,ls),
+(506,0,o),
+(602,89,o),
+(602,224,cs),
+(602,292,o),
+(570,343,o),
+(508,373,c),
+(501,325,l),
+(629,361,o),
+(669,457,o),
+(669,540,cs),
+(669,646,o),
+(591,714,o),
+(474,714,cs),
+(149,714,l),
+(141,678,l),
+(170,416,l),
+(95,416,l),
+(70,298,l),
+(137,298,l),
+(5,36,l),
+(-3,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(289,309,l),
+(291,309,l),
+(305,277,o),
+(335,257,o),
+(371,257,cs),
+(410,257,o),
+(442,283,o),
+(454,319,c),
+(364,309,l),
+(395,309,ls),
+(446,309,o),
+(460,272,o),
+(460,229,cs),
+(460,185,o),
+(438,120,o),
+(345,120,cs),
+(134,120,l),
+(166,61,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(448,429,o),
+(414,457,o),
+(371,457,cs),
+(335,457,o),
+(305,437,o),
+(291,405,c),
+(311,405,l),
+(280,661,l),
+(223,594,l),
+(445,594,ls),
+(495,594,o),
+(523,566,o),
+(523,522,cs),
+(523,461,o),
+(492,405,o),
+(414,405,cs),
+(365,405,l),
+(457,388,l)
+);
+}
+);
+width = 664;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FF;
+unicode = 5631;
+},
+{
+color = 9;
+glyphname = "kkaCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(559,0,l),
+(567,36,l),
+(538,298,l),
+(613,298,l),
+(638,416,l),
+(571,416,l),
+(703,678,l),
+(711,714,l),
+(370,714,ls),
+(202,714,o),
+(106,625,o),
+(106,490,cs),
+(106,422,o),
+(138,371,o),
+(200,341,c),
+(207,389,l),
+(79,353,o),
+(39,257,o),
+(39,174,cs),
+(39,68,o),
+(117,0,o),
+(234,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(485,120,l),
+(263,120,ls),
+(214,120,o),
+(185,148,o),
+(185,192,cs),
+(185,253,o),
+(223,298,o),
+(300,298,cs),
+(399,298,l),
+(428,53,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(276,416,o),
+(248,442,o),
+(248,485,cs),
+(248,529,o),
+(270,594,o),
+(363,594,cs),
+(574,594,l),
+(542,653,l),
+(424,416,l),
+(326,416,ls)
+);
+}
+);
+width = 664;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|kkeCarrier-canadian";
+note = uni1600;
+unicode = 5632;
+},
+{
+color = 6;
+glyphname = "kkCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(290,546,l),
+(150,299,l),
+(212,299,l),
+(177,546,l),
+(87,546,l),
+(84,528,l),
+(150,189,l),
+(172,189,l),
+(383,528,l),
+(387,546,l)
+);
+}
+);
+width = 350;
+}
+);
+note = uni1601;
+unicode = 5633;
+},
+{
+color = 9;
+glyphname = "nuCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(450,-14,o),
+(553,81,o),
+(590,251,cs),
+(604,319,l),
+(458,319,l),
+(445,259,ls),
+(426,167,o),
+(380,121,o),
+(304,121,cs),
+(218,120,o),
+(181,177,o),
+(203,277,cs),
+(296,714,l),
+(148,714,l),
+(57,286,ls),
+(19,106,o),
+(110,-14,o),
+(292,-14,cs)
+);
+}
+);
+width = 630;
+}
+);
+metricLeft = "te-canadian";
+note = uni1602;
+unicode = 5634;
+},
+{
+color = 9;
+glyphname = "noCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(526,0,l),
+(617,428,ls),
+(655,608,o),
+(564,728,o),
+(383,728,cs),
+(225,728,o),
+(122,633,o),
+(85,463,cs),
+(70,395,l),
+(216,395,l),
+(229,455,ls),
+(249,547,o),
+(295,593,o),
+(370,593,cs),
+(456,594,o),
+(493,537,o),
+(472,437,cs),
+(379,0,l)
+);
+}
+);
+width = 630;
+}
+);
+metricLeft = "=|nuCarrier-canadian";
+metricRight = "te-canadian";
+note = uni1603;
+unicode = 5635;
+},
+{
+color = 9;
+glyphname = "neCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (308,357);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(219,0,ls),
+(506,0,o),
+(625,220,o),
+(625,434,cs),
+(625,610,o),
+(520,714,o),
+(335,714,cs),
+(132,714,l),
+(104,580,l),
+(311,580,ls),
+(421,580,o),
+(479,525,o),
+(479,423,cs),
+(479,309,o),
+(424,134,o),
+(233,134,cs),
+(222,134,l),
+(194,0,l)
+);
+}
+);
+width = 642;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1604;
+unicode = 5636;
+},
+{
+color = 9;
+glyphname = "neeCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "neCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (227,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 642;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1605;
+unicode = 5637;
+},
+{
+color = 9;
+glyphname = "niCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "neCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (200,0);
+ref = dot_middle;
+}
+);
+width = 642;
+}
+);
+note = uni1606;
+unicode = 5638;
+},
+{
+color = 9;
+glyphname = "naCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(554,0,l),
+(582,134,l),
+(375,134,ls),
+(265,134,o),
+(207,189,o),
+(207,291,cs),
+(207,405,o),
+(263,580,o),
+(453,580,cs),
+(465,580,l),
+(493,714,l),
+(467,714,ls),
+(181,714,o),
+(61,494,o),
+(61,280,cs),
+(61,104,o),
+(166,0,o),
+(351,0,cs)
+);
+}
+);
+width = 642;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni1607;
+unicode = 5639;
+},
+{
+color = 9;
+glyphname = "muCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(271,-14,o),
+(334,29,o),
+(379,122,c),
+(320,122,l),
+(334,33,o),
+(386,-14,o),
+(473,-14,cs),
+(590,-14,o),
+(653,55,o),
+(681,188,cs),
+(728,408,l),
+(587,408,l),
+(541,191,ls),
+(531,142,o),
+(508,118,o),
+(474,118,cs),
+(436,118,o),
+(419,146,o),
+(429,193,cs),
+(474,408,l),
+(337,408,l),
+(291,192,ls),
+(280,143,o),
+(256,118,o),
+(221,118,cs),
+(184,118,o),
+(168,145,o),
+(178,194,cs),
+(289,714,l),
+(148,714,l),
+(39,199,ls),
+(11,68,o),
+(66,-14,o),
+(187,-14,cs)
+);
+}
+);
+width = 745;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "=|";
+note = uni1608;
+unicode = 5640;
+},
+{
+color = 9;
+glyphname = "moCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(641,0,l),
+(750,515,ls),
+(778,646,o),
+(723,728,o),
+(602,728,cs),
+(517,728,o),
+(455,685,o),
+(409,592,c),
+(469,592,l),
+(455,681,o),
+(403,728,o),
+(315,728,cs),
+(199,728,o),
+(137,659,o),
+(108,526,cs),
+(61,306,l),
+(202,306,l),
+(248,523,ls),
+(259,572,o),
+(280,596,o),
+(315,596,cs),
+(353,596,o),
+(370,568,o),
+(360,521,cs),
+(314,306,l),
+(452,306,l),
+(498,522,ls),
+(508,571,o),
+(532,596,o),
+(568,596,cs),
+(605,596,o),
+(621,569,o),
+(610,520,cs),
+(500,0,l)
+);
+}
+);
+width = 745;
+}
+);
+metricLeft = "=|muCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni1609;
+unicode = 5641;
+},
+{
+color = 9;
+glyphname = "meCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(321,0,ls),
+(489,0,o),
+(585,89,o),
+(585,224,cs),
+(585,292,o),
+(551,346,o),
+(487,376,c),
+(477,323,l),
+(595,354,o),
+(652,439,o),
+(652,540,cs),
+(652,646,o),
+(573,714,o),
+(457,714,cs),
+(132,714,l),
+(106,594,l),
+(428,594,ls),
+(477,594,o),
+(506,566,o),
+(506,522,cs),
+(506,461,o),
+(468,416,o),
+(391,416,cs),
+(284,416,l),
+(259,298,l),
+(365,298,ls),
+(415,298,o),
+(443,272,o),
+(443,229,cs),
+(443,185,o),
+(420,120,o),
+(328,120,cs),
+(221,120,l),
+(196,0,l)
+);
+}
+);
+width = 647;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160A;
+unicode = 5642;
+},
+{
+color = 9;
+glyphname = "meeCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(321,0,ls),
+(489,0,o),
+(585,89,o),
+(585,224,cs),
+(585,292,o),
+(551,346,o),
+(487,376,c),
+(477,323,l),
+(595,354,o),
+(652,439,o),
+(652,540,cs),
+(652,646,o),
+(573,714,o),
+(457,714,cs),
+(132,714,l),
+(106,594,l),
+(428,594,ls),
+(477,594,o),
+(506,566,o),
+(506,522,cs),
+(506,461,o),
+(468,413,o),
+(393,413,cs),
+(369,413,l),
+(386,489,l),
+(300,489,l),
+(244,225,l),
+(329,225,l),
+(346,301,l),
+(370,301,ls),
+(416,301,o),
+(443,272,o),
+(443,229,cs),
+(443,185,o),
+(420,120,o),
+(328,120,cs),
+(221,120,l),
+(196,0,l)
+);
+}
+);
+width = 647;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160B;
+unicode = 5643;
+},
+{
+color = 9;
+glyphname = "miCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(321,0,ls),
+(480,0,o),
+(562,74,o),
+(581,186,cs),
+(595,273,o),
+(563,339,o),
+(487,376,c),
+(477,323,l),
+(582,350,o),
+(634,417,o),
+(648,503,cs),
+(670,626,o),
+(590,714,o),
+(457,714,cs),
+(132,714,l),
+(106,594,l),
+(428,594,ls),
+(481,594,o),
+(511,560,o),
+(504,508,cs),
+(497,451,o),
+(460,413,o),
+(390,413,cs),
+(336,413,l),
+(416,371,l),
+(410,421,o),
+(372,458,o),
+(320,458,cs),
+(265,458,o),
+(223,411,o),
+(223,357,cs),
+(223,301,o),
+(265,257,o),
+(320,257,cs),
+(371,257,o),
+(409,294,o),
+(416,342,c),
+(334,301,l),
+(366,301,ls),
+(421,301,o),
+(449,270,o),
+(442,216,cs),
+(434,165,o),
+(404,120,o),
+(328,120,cs),
+(221,120,l),
+(196,0,l)
+);
+}
+);
+width = 645;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160C;
+unicode = 5644;
+},
+{
+color = 9;
+glyphname = "maCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(560,0,l),
+(586,120,l),
+(263,120,ls),
+(214,120,o),
+(185,148,o),
+(185,192,cs),
+(185,253,o),
+(223,298,o),
+(300,298,cs),
+(406,298,l),
+(431,416,l),
+(326,416,ls),
+(276,416,o),
+(248,442,o),
+(248,485,cs),
+(248,529,o),
+(270,594,o),
+(363,594,cs),
+(469,594,l),
+(495,714,l),
+(370,714,ls),
+(202,714,o),
+(106,625,o),
+(106,490,cs),
+(106,422,o),
+(139,368,o),
+(203,338,c),
+(214,391,l),
+(96,360,o),
+(39,275,o),
+(39,174,cs),
+(39,68,o),
+(117,0,o),
+(234,0,cs)
+);
+}
+);
+width = 648;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni160D;
+unicode = 5645;
+},
+{
+color = 9;
+glyphname = "yuCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(486,-14,o),
+(610,115,o),
+(665,370,cs),
+(713,600,o),
+(666,728,o),
+(526,728,cs),
+(372,728,o),
+(315,568,o),
+(315,459,cs),
+(315,365,o),
+(363,303,o),
+(440,303,cs),
+(453,303,o),
+(465,305,o),
+(475,309,c),
+(498,422,l),
+(493,421,o),
+(488,420,o),
+(482,420,cs),
+(455,420,o),
+(441,439,o),
+(441,474,cs),
+(441,513,o),
+(458,611,o),
+(509,611,cs),
+(557,611,o),
+(563,546,o),
+(535,414,cs),
+(492,208,o),
+(429,121,o),
+(314,121,cs),
+(220,121,o),
+(183,180,o),
+(205,285,cs),
+(296,714,l),
+(148,714,l),
+(60,296,ls),
+(21,111,o),
+(114,-14,o),
+(300,-14,cs)
+);
+}
+);
+width = 690;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160E;
+unicode = 5646;
+},
+{
+color = 9;
+glyphname = "yoCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(362,-14,o),
+(419,146,o),
+(419,255,cs),
+(419,349,o),
+(372,411,o),
+(295,411,cs),
+(282,411,o),
+(270,409,o),
+(260,405,c),
+(236,292,l),
+(241,293,o),
+(246,294,o),
+(252,294,cs),
+(279,294,o),
+(293,275,o),
+(293,240,cs),
+(293,201,o),
+(276,103,o),
+(225,103,cs),
+(178,103,o),
+(172,168,o),
+(199,300,cs),
+(242,506,o),
+(306,593,o),
+(420,593,cs),
+(514,593,o),
+(552,534,o),
+(530,429,cs),
+(439,0,l),
+(585.996,0,l),
+(675,418,ls),
+(714,603,o),
+(620,728,o),
+(435,728,cs),
+(249,728,o),
+(124,599,o),
+(69,344,cs),
+(21,114,o),
+(68,-14,o),
+(208,-14,cs)
+);
+}
+);
+width = 690;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160F;
+unicode = 5647;
+},
+{
+color = 9;
+glyphname = "yeCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(511,-14,o),
+(618,252,o),
+(618,432,cs),
+(618,615,o),
+(516,714,o),
+(330,714,cs),
+(149,714,l),
+(121,580,l),
+(305,580,ls),
+(414,580,o),
+(469,526,o),
+(469,418,cs),
+(469,308,o),
+(424,110,o),
+(268,110,cs),
+(197,110,o),
+(155,146,o),
+(155,209,cs),
+(155,245,o),
+(171,317,o),
+(222,317,cs),
+(247,317,o),
+(261,300,o),
+(261,266,cs),
+(261,241,o),
+(254,210,o),
+(245,185,c),
+(355,185,l),
+(367,217,o),
+(376,256,o),
+(376,290,cs),
+(376,378,o),
+(322,434,o),
+(230,434,cs),
+(89,434,o),
+(31,294,o),
+(31,189,cs),
+(31,66,o),
+(118,-14,o),
+(262,-14,cs)
+);
+}
+);
+width = 634;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1610;
+unicode = 5648;
+},
+{
+color = 9;
+glyphname = "yeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(511,-14,o),
+(618,253,o),
+(618,434,cs),
+(618,615,o),
+(513.991,714,o),
+(331,714,cs),
+(149,714,l),
+(121,580,l),
+(305,580,ls),
+(414,580,o),
+(469,526,o),
+(469,418,cs),
+(469,320,o),
+(428,110,o),
+(268,110,cs),
+(196,110,o),
+(155,144,o),
+(155,207,cs),
+(155,245,o),
+(172,317,o),
+(220,317,cs),
+(251,317,o),
+(263,288,o),
+(253,240,cs),
+(243,194,l),
+(327,194,l),
+(394,505,l),
+(309,505,l),
+(272,331,l),
+(287,330,l),
+(297,391,o),
+(261,434,o),
+(199,434,cs),
+(83,434,o),
+(33,294,o),
+(33,198,cs),
+(33,70,o),
+(118,-14,o),
+(267,-14,cs)
+);
+}
+);
+width = 634;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1611;
+unicode = 5649;
+},
+{
+color = 9;
+glyphname = "yiCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(513,-14,o),
+(618,251,o),
+(618,434,cs),
+(618,615,o),
+(516,714,o),
+(331,714,cs),
+(149,714,l),
+(121,580,l),
+(305,580,ls),
+(414,580,o),
+(469,526,o),
+(469,418,cs),
+(469,316,o),
+(426,110,o),
+(268,110,cs),
+(194,110,o),
+(153,147,o),
+(153,208,cs),
+(153,267,o),
+(181,319,o),
+(240,316,c),
+(208,356,l),
+(208,306,o),
+(250,269,o),
+(300,269,cs),
+(353,269,o),
+(392,308,o),
+(392,358,cs),
+(392,408,o),
+(353,446,o),
+(300,446,cs),
+(267,446,o),
+(239,431,o),
+(223,407,c),
+(98,396,o),
+(28,299,o),
+(28,187,cs),
+(28,68,o),
+(120,-14,o),
+(260,-14,cs)
+);
+}
+);
+width = 634;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1612;
+unicode = 5650;
+},
+{
+color = 9;
+glyphname = "yaCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(530,0,l),
+(559,134,l),
+(375,134,ls),
+(266,134,o),
+(210,188,o),
+(210,296,cs),
+(210,406,o),
+(255,604,o),
+(411,604,cs),
+(483,604,o),
+(524,568,o),
+(524,505,cs),
+(524,469,o),
+(509,397,o),
+(458,397,cs),
+(432,397,o),
+(419,414,o),
+(419,448,cs),
+(419,475,o),
+(426,504,o),
+(434,529,c),
+(325,529,l),
+(312,497,o),
+(303,458,o),
+(303,424,cs),
+(303,336,o),
+(358,280,o),
+(449,280,cs),
+(591,280,o),
+(649,420,o),
+(649,525,cs),
+(649,648,o),
+(561,728,o),
+(418,728,cs),
+(169,728,o),
+(61,462,o),
+(61,282,cs),
+(61,99,o),
+(164,0,o),
+(350,0,cs)
+);
+}
+);
+width = 636;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|yeCarrier-canadian";
+note = uni1613;
+unicode = 5651;
+},
+{
+color = 9;
+glyphname = "juCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(504,-14,o),
+(601,122,o),
+(601,266,cs),
+(601,366,o),
+(543,434,o),
+(448,434,cs),
+(332,434,o),
+(278,338,o),
+(270,239,cs),
+(268,218,o),
+(267,198,o),
+(269,185,c),
+(379,185,l),
+(379,200,o),
+(379,221,o),
+(384,246,cs),
+(392,287,o),
+(410,317,o),
+(439,317,cs),
+(465,317,o),
+(478,297,o),
+(478,262,cs),
+(478,195,o),
+(443,110,o),
+(338,110,cs),
+(249,110,o),
+(202,159,o),
+(202,248,cs),
+(202,421,o),
+(326,580,o),
+(562,580,cs),
+(663,580,l),
+(692,714,l),
+(141,714,l),
+(113,585,l),
+(346,585,l),
+(461,637,l),
+(215,624,o),
+(58,470,o),
+(58,246,cs),
+(58,89,o),
+(160,-14,o),
+(322,-14,cs)
+);
+}
+);
+width = 643;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni1614;
+unicode = 5652;
+},
+{
+color = 9;
+glyphname = "juSayisi-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (426,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(458,-14,o),
+(576,138,o),
+(600,319,cs),
+(626,507,o),
+(531,628,o),
+(333,642,c),
+(433,585,l),
+(669,585,l),
+(696,714,l),
+(145,714,l),
+(117,580,l),
+(220,580,ls),
+(409,580,o),
+(480,499,o),
+(457,335,cs),
+(443,225,o),
+(398,110,o),
+(272,110,cs),
+(189,110,o),
+(147,153,o),
+(156,229,cs),
+(160,269,o),
+(179,317,o),
+(216,317,cs),
+(246,317,o),
+(256,293,o),
+(252,248,cs),
+(251,227,o),
+(246,206,o),
+(238,185,c),
+(347,185,l),
+(358,211,o),
+(365,236,o),
+(368,265,cs),
+(380,367,o),
+(327,434,o),
+(226,434,cs),
+(117,434,o),
+(50,346,o),
+(35,236,cs),
+(13,90,o),
+(106,-14,o),
+(267,-14,cs)
+);
+}
+);
+width = 640;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1615;
+unicode = 5653;
+},
+{
+color = 9;
+glyphname = "joCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(546,0,l),
+(574,129,l),
+(341,129,l),
+(226,77,l),
+(472,90,o),
+(629,244,o),
+(629,468,cs),
+(629,625,o),
+(527,728,o),
+(365,728,cs),
+(183,728,o),
+(87,592,o),
+(87,448,cs),
+(87,348,o),
+(144,280,o),
+(239,280,cs),
+(355,280,o),
+(409,376,o),
+(417,475,cs),
+(419,496,o),
+(419,516,o),
+(418,529,c),
+(308,529,l),
+(308,514,o),
+(308,493,o),
+(303,468,cs),
+(295,427,o),
+(277,397,o),
+(248,397,cs),
+(222,397,o),
+(209,417,o),
+(209,452,cs),
+(209,519,o),
+(244,604,o),
+(349,604,cs),
+(438,604,o),
+(484,555,o),
+(484,466,cs),
+(484,293,o),
+(361,134,o),
+(125,134,cs),
+(24,134,l),
+(-5,0,l)
+);
+}
+);
+width = 642;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1616;
+unicode = 5654;
+},
+{
+color = 9;
+glyphname = "jeCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(607,-14,o),
+(666,292,o),
+(666,448,cs),
+(666,619,o),
+(594,728,o),
+(465,728,cs),
+(354,728,o),
+(269,647,o),
+(224,495,c),
+(250,493,l),
+(297,714,l),
+(151,714,l),
+(-1,0,l),
+(146,0,l),
+(215,323,ls),
+(251,496,o),
+(325,593,o),
+(422,593,cs),
+(493,593,o),
+(527,543,o),
+(527,443,cs),
+(527,366,o),
+(492,103,o),
+(415,103,cs),
+(390,103,o),
+(376,121,o),
+(376,155,cs),
+(376,199,o),
+(398,294,o),
+(457,294,cs),
+(463,294,o),
+(470,293,o),
+(474,292,c),
+(495,405,l),
+(482,409,o),
+(467,411,o),
+(450,411,cs),
+(308,411,o),
+(253,252,o),
+(253,148,cs),
+(253,48,o),
+(309,-14,o),
+(405,-14,cs)
+);
+}
+);
+width = 692;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "te-canadian";
+note = uni1617;
+unicode = 5655;
+},
+{
+color = 9;
+glyphname = "jeeCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(607,-14,o),
+(666,296,o),
+(666,446,cs),
+(666,619,o),
+(594,728,o),
+(465,728,cs),
+(353,728,o),
+(269,646,o),
+(224,494,c),
+(250,493,l),
+(297,714,l),
+(151,714,l),
+(-1,0,l),
+(146,0,l),
+(212,310,ls),
+(253,499,o),
+(322,593,o),
+(420,593,cs),
+(493,593,o),
+(527,543,o),
+(527,441,cs),
+(527,319,o),
+(488,103,o),
+(391,103,cs),
+(347,103,o),
+(324,131,o),
+(324,180,cs),
+(324,221,o),
+(340,289,o),
+(385,312,c),
+(369,238,l),
+(439,238,l),
+(486,465,l),
+(417,465,l),
+(401,388,l),
+(293,360,o),
+(252,229,o),
+(252,145,cs),
+(252,48,o),
+(309,-14,o),
+(405,-14,cs)
+);
+}
+);
+width = 692;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1618;
+unicode = 5656;
+},
+{
+color = 9;
+glyphname = "jiCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(607,-14,o),
+(666,296,o),
+(666,446,cs),
+(666,619,o),
+(594,728,o),
+(465,728,cs),
+(353,728,o),
+(269,646,o),
+(224,494,c),
+(250,493,l),
+(297,714,l),
+(151,714,l),
+(-1,0,l),
+(146,0,l),
+(212,310,ls),
+(253,499,o),
+(322,593,o),
+(420,593,cs),
+(493,593,o),
+(527,543,o),
+(527,441,cs),
+(527,319,o),
+(488,103,o),
+(391,103,cs),
+(347,103,o),
+(324,131,o),
+(324,180,cs),
+(324,210,o),
+(333,256,o),
+(359,281,c),
+(370,271,o),
+(386,264,o),
+(404,264,cs),
+(452,264,o),
+(486,303,o),
+(486,352,cs),
+(486,402,o),
+(451,439,o),
+(404,439,cs),
+(350,439,o),
+(314,389,o),
+(324,335,c),
+(272,287,o),
+(252,204,o),
+(252,145,cs),
+(252,48,o),
+(309,-14,o),
+(405,-14,cs)
+);
+}
+);
+width = 692;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1619;
+unicode = 5657;
+},
+{
+color = 9;
+glyphname = "jiSayisi-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(581,-14,o),
+(685,336,o),
+(685,521,cs),
+(685,656,o),
+(630,728,o),
+(525,728,cs),
+(372,728,o),
+(319,563,o),
+(319,458,cs),
+(319,362,o),
+(367,303,o),
+(440,303,cs),
+(457,303,o),
+(467,305,o),
+(475,309,c),
+(501,422,l),
+(496,421,o),
+(491,420,o),
+(484,420,cs),
+(458,421,o),
+(443,438,o),
+(443,475,cs),
+(443,509,o),
+(461,611,o),
+(513,611,cs),
+(540,611,o),
+(552,588,o),
+(552,538,cs),
+(552,454,o),
+(500,121,o),
+(334,121,cs),
+(202,121,o),
+(206,281,o),
+(232,402,cs),
+(298,714,l),
+(151,714,l),
+(-1,0,l),
+(145,0,l),
+(200,259,l),
+(171,262,l),
+(146,121,o),
+(198,-14,o),
+(345,-14,cs)
+);
+}
+);
+width = 693;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161A;
+unicode = 5658;
+},
+{
+color = 9;
+glyphname = "jaCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (437,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(383,-14,o),
+(468,68,o),
+(513,220,c),
+(487,222,l),
+(440,1,l),
+(586,1,l),
+(738,715,l),
+(591,715,l),
+(522,392,ls),
+(485,219,o),
+(412,121,o),
+(315,121,cs),
+(244,121,o),
+(210,172,o),
+(210,272,cs),
+(210,348,o),
+(245,612,o),
+(322,612,cs),
+(347,612,o),
+(361,593,o),
+(361,560,cs),
+(361,516,o),
+(339,421,o),
+(280,421,cs),
+(273,421,o),
+(267,422,o),
+(263,423,c),
+(242,310,l),
+(255,306,o),
+(270,304,o),
+(287,304,cs),
+(429,304,o),
+(484,462,o),
+(484,567,cs),
+(484,667,o),
+(428,729,o),
+(332,729,cs),
+(130,729,o),
+(71,423,o),
+(71,266,cs),
+(71,96,o),
+(143,-14,o),
+(272,-14,cs)
+);
+}
+);
+width = 693;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni161B;
+unicode = 5659;
+},
+{
+color = 9;
+glyphname = "jjuCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(491,-14,o),
+(598,120,o),
+(598,271,cs),
+(598,369,o),
+(540,434,o),
+(447,434,cs),
+(354,434,o),
+(293,370,o),
+(269,262,cs),
+(263,235,o),
+(260,206,o),
+(260,185,c),
+(370,185,l),
+(371,195,o),
+(374,219,o),
+(379,242,cs),
+(390,290,o),
+(409,317,o),
+(438,317,cs),
+(463,317,o),
+(475,297,o),
+(475,265,cs),
+(475,199,o),
+(438,107,o),
+(333,107,cs),
+(248,107,o),
+(203,158,o),
+(203,251,cs),
+(203,436,o),
+(314,580,o),
+(523,580,cs),
+(657,580,l),
+(686,714,l),
+(546,714,ls),
+(441,714,o),
+(347,688,o),
+(272,643,c),
+(207,728,l),
+(89,638,l),
+(159,548,l),
+(92,469,o),
+(60,362,o),
+(60,257,cs),
+(60,95,o),
+(159,-14,o),
+(318,-14,cs)
+);
+}
+);
+width = 639;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni161C;
+unicode = 5660;
+},
+{
+color = 9;
+glyphname = "jjoCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(594,76,l),
+(524,166,l),
+(591,245,o),
+(623,352,o),
+(623,457,cs),
+(623,619,o),
+(524,728,o),
+(364,728,cs),
+(192,728,o),
+(85,594,o),
+(85,443,cs),
+(85,345,o),
+(143,280,o),
+(235,280,cs),
+(328,280,o),
+(390,344,o),
+(414,452,cs),
+(420,479,o),
+(423,508,o),
+(423,529,c),
+(313,529,l),
+(312,519,o),
+(309,495,o),
+(304,472,cs),
+(293,424,o),
+(274,397,o),
+(245,397,cs),
+(220,397,o),
+(208,417,o),
+(208,449,cs),
+(208,515,o),
+(244,607,o),
+(350,607,cs),
+(435,607,o),
+(480,556,o),
+(480,463,cs),
+(480,278,o),
+(369,134,o),
+(159,134,cs),
+(25,134,l),
+(-3,0,l),
+(137,0,ls),
+(242,0,o),
+(335,26,o),
+(411,71,c),
+(476,-14,l)
+);
+}
+);
+width = 639;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|jjuCarrier-canadian";
+note = uni161D;
+unicode = 5661;
+},
+{
+color = 9;
+glyphname = "jjeCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(617,-14,o),
+(675,293,o),
+(675,446,cs),
+(675,628,o),
+(588,728,o),
+(431,728,cs),
+(363,728,o),
+(299,708,o),
+(245,665,c),
+(189,728,l),
+(80,627,l),
+(149,550,l),
+(124,506,o),
+(105,454,o),
+(91,392,cs),
+(8,0,l),
+(155,0,l),
+(238,389,ls),
+(267,524,o),
+(328,593,o),
+(421,593,cs),
+(499,593,o),
+(536,545,o),
+(536,443,cs),
+(536,369,o),
+(501,103,o),
+(424,103,cs),
+(398,103,o),
+(385,121,o),
+(385,156,cs),
+(385,199,o),
+(407,294,o),
+(464,294,cs),
+(472,294,o),
+(478,293,o),
+(483,292,c),
+(504,405,l),
+(493,409,o),
+(476,411,o),
+(460,411,cs),
+(317,411,o),
+(262,253,o),
+(262,149,cs),
+(262,48,o),
+(317,-14,o),
+(414,-14,cs)
+);
+}
+);
+width = 701;
+}
+);
+metricRight = "jeCarrier-canadian";
+note = uni161E;
+unicode = 5662;
+},
+{
+color = 9;
+glyphname = "jjeeCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(617,-14,o),
+(675,293,o),
+(675,446,cs),
+(675,628,o),
+(588,728,o),
+(431,728,cs),
+(363,728,o),
+(299,708,o),
+(245,665,c),
+(189,728,l),
+(80,627,l),
+(149,550,l),
+(124,506,o),
+(105,454,o),
+(91,392,cs),
+(8,0,l),
+(155,0,l),
+(238,389,ls),
+(267,524,o),
+(328,593,o),
+(421,593,cs),
+(499,593,o),
+(536,545,o),
+(536,443,cs),
+(536,352,o),
+(506,103,o),
+(404,103,cs),
+(362,103,o),
+(333,128,o),
+(333,181,cs),
+(333,236,o),
+(353,296,o),
+(394,314,c),
+(378,238,l),
+(447,238,l),
+(495,464,l),
+(426,464,l),
+(410,387,l),
+(305,360,o),
+(262,239,o),
+(262,149,cs),
+(262,48,o),
+(317,-14,o),
+(414,-14,cs)
+);
+}
+);
+width = 701;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161F;
+unicode = 5663;
+},
+{
+color = 9;
+glyphname = "jjiCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(538,-14,o),
+(617,94,o),
+(658,289,cs),
+(715,563,o),
+(629,728,o),
+(431,728,cs),
+(360,728,o),
+(297,707,o),
+(245,666,c),
+(189,728,l),
+(80,627,l),
+(149,551,l),
+(124,507,o),
+(104,453,o),
+(91,392,cs),
+(8,0,l),
+(155,0,l),
+(238,389,ls),
+(267,524,o),
+(328,593,o),
+(421,593,cs),
+(528,593,o),
+(562,498,o),
+(520,298,cs),
+(492,164,o),
+(461,103,o),
+(400,103,cs),
+(345,103,o),
+(323,149,o),
+(338,223,cs),
+(343,250,o),
+(352,271,o),
+(367,282,c),
+(379,271,o),
+(396,264,o),
+(415,264,cs),
+(463,264,o),
+(497,303,o),
+(497,352,cs),
+(497,401,o),
+(462,439,o),
+(415,439,cs),
+(353,439,o),
+(327,379,o),
+(335,335,c),
+(302,307,o),
+(279,262,o),
+(268,206,cs),
+(240,73,o),
+(300,-14,o),
+(413,-14,cs)
+);
+}
+);
+width = 700;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1620;
+unicode = 5664;
+},
+{
+color = 9;
+glyphname = "jjaCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(383,-14,o),
+(447,6,o),
+(501,49,c),
+(557,-14,l),
+(666,87,l),
+(597,164,l),
+(622,208,o),
+(641,260,o),
+(655,322,cs),
+(738,714,l),
+(591,714,l),
+(508,325,ls),
+(479,190,o),
+(418,121,o),
+(325,121,cs),
+(247,121,o),
+(210,169,o),
+(210,271,cs),
+(210,345,o),
+(245,611,o),
+(322,611,cs),
+(348,611,o),
+(361,593,o),
+(361,558,cs),
+(361,515,o),
+(339,420,o),
+(282,420,cs),
+(274,420,o),
+(268,421,o),
+(263,422,c),
+(242,309,l),
+(253,305,o),
+(270,303,o),
+(286,303,cs),
+(429,303,o),
+(484,461,o),
+(484,565,cs),
+(484,666,o),
+(428,728,o),
+(332,728,cs),
+(129,728,o),
+(71,421,o),
+(71,268,cs),
+(71,86,o),
+(158,-14,o),
+(315,-14,cs)
+);
+}
+);
+width = 702;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "=|jjeCarrier-canadian";
+note = uni1621;
+unicode = 5665;
+},
+{
+color = 9;
+glyphname = "luCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(458,-14,o),
+(553,71,o),
+(591,247,cs),
+(690,714,l),
+(543,714,l),
+(447,263,ls),
+(426,165,o),
+(383,121,o),
+(311,121,cs),
+(242,121,o),
+(206,164,o),
+(206,246,cs),
+(206,356,o),
+(263,568,o),
+(413,597,c),
+(439,714,l),
+(143,714,l),
+(117,593,l),
+(274,593,l),
+(386,638,l),
+(169,629,o),
+(57,418,o),
+(57,235,cs),
+(57,84,o),
+(147,-14,o),
+(307,-14,cs)
+);
+}
+);
+width = 642;
+}
+);
+metricRight = "te-canadian";
+note = uni1622;
+unicode = 5666;
+},
+{
+color = 9;
+glyphname = "loCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(144,0,l),
+(240,451,ls),
+(261,549,o),
+(304,593,o),
+(375,593,cs),
+(445,593,o),
+(480,550,o),
+(480,468,cs),
+(480,358,o),
+(423,146,o),
+(273,117,c),
+(248,0,l),
+(544,0,l),
+(570,121,l),
+(413,121,l),
+(301,76,l),
+(518,85,o),
+(630,296,o),
+(630,479,cs),
+(630,630,o),
+(539,728,o),
+(380,728,cs),
+(228,728,o),
+(133,643,o),
+(96,467,cs),
+(-4,0,l)
+);
+}
+);
+width = 643;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|luCarrier-canadian";
+note = uni1623;
+unicode = 5667;
+},
+{
+color = 9;
+glyphname = "leCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (330,358);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(219,0,ls),
+(550,0,o),
+(621,275,o),
+(621,456,cs),
+(621,618,o),
+(547,728,o),
+(429,728,cs),
+(346,728,o),
+(276,673,o),
+(235,575,c),
+(250,574,l),
+(280,714,l),
+(148,714,l),
+(79,389,l),
+(203,389,l),
+(233,516,o),
+(296,593,o),
+(372,593,cs),
+(437,593,o),
+(473,536,o),
+(473,440,cs),
+(473,318,o),
+(426,134,o),
+(222,134,cs),
+(24,134,l),
+(-4,0,l)
+);
+}
+);
+width = 636;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1624;
+unicode = 5668;
+},
+{
+color = 9;
+glyphname = "leeCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "leCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (249,1);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 636;
+}
+);
+metricLeft = "leCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1625;
+unicode = 5669;
+},
+{
+color = 9;
+glyphname = "liCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "leCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (221,1);
+ref = dot_middle;
+}
+);
+width = 636;
+}
+);
+note = uni1626;
+unicode = 5670;
+},
+{
+color = 9;
+glyphname = "laCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(534,0,l),
+(563,134,l),
+(381,134,ls),
+(266,134,o),
+(209,188,o),
+(209,291,cs),
+(209,387,o),
+(256,593,o),
+(390,593,cs),
+(473,593,o),
+(512,514,o),
+(492,389,c),
+(617,389,l),
+(686,714,l),
+(554,714,l),
+(520,559,l),
+(533,552,l),
+(532,662,o),
+(472,728,o),
+(380,728,cs),
+(160,728,o),
+(61,451,o),
+(61,280,cs),
+(61,105,o),
+(165,0,o),
+(356,0,cs)
+);
+}
+);
+width = 637;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|leCarrier-canadian";
+note = uni1627;
+unicode = 5671;
+},
+{
+color = 1;
+glyphname = "dluCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(537,-14,o),
+(609,254,o),
+(609,399,cs),
+(609,530,o),
+(545,610,o),
+(420,639,c),
+(454,603,l),
+(650,603,l),
+(632,522,l),
+(739,522,l),
+(796,794,l),
+(690,794,l),
+(673,714,l),
+(400,714,l),
+(374,596,l),
+(440,577,o),
+(471,524,o),
+(471,436,cs),
+(471,349,o),
+(434,121,o),
+(294,121,cs),
+(215,121,o),
+(183,182,o),
+(206,292,cs),
+(296,714,l),
+(148,714,l),
+(61,303,ls),
+(18,104,o),
+(104,-14,o),
+(282,-14,cs)
+);
+}
+);
+width = 708;
+}
+);
+metricLeft = "te-canadian";
+note = uni1628;
+unicode = 5672;
+},
+{
+color = 9;
+glyphname = "dloCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(611,-80,l),
+(669,192,l),
+(563,192,l),
+(545,111,l),
+(400,111,l),
+(327,87,l),
+(494,100,o),
+(630,259,o),
+(630,479,cs),
+(630,630,o),
+(539,728,o),
+(380,728,cs),
+(228,728,o),
+(133,643,o),
+(96,467,cs),
+(-4,0,l),
+(144,0,l),
+(240,451,ls),
+(261,549,o),
+(304,593,o),
+(375,593,cs),
+(445,593,o),
+(480,550,o),
+(480,468,cs),
+(480,358,o),
+(423,146,o),
+(273,117,c),
+(248,0,l),
+(522,0,l),
+(505,-80,l)
+);
+}
+);
+width = 708;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "dluCarrier-canadian";
+note = uni1629;
+unicode = 5673;
+},
+{
+color = 9;
+glyphname = "dleCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (347,358);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(235,0,ls),
+(566,0,o),
+(638,275,o),
+(638,456,cs),
+(638,618,o),
+(564,728,o),
+(446,728,cs),
+(358,728,o),
+(266,663,o),
+(223,547,c),
+(233,547,l),
+(269,721,l),
+(339,721,l),
+(361,824,l),
+(120,824,l),
+(98,721,l),
+(166,721,l),
+(95,389,l),
+(220,389,l),
+(249,516,o),
+(313,593,o),
+(388,593,cs),
+(454,593,o),
+(490,536,o),
+(490,440,cs),
+(490,318,o),
+(442,134,o),
+(238,134,cs),
+(40,134,l),
+(12,0,l)
+);
+}
+);
+width = 653;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni162A;
+unicode = 5674;
+},
+{
+color = 9;
+glyphname = "dleeCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (266,1);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 652;
+}
+);
+note = uni162B;
+unicode = 5675;
+},
+{
+color = 9;
+glyphname = "dliCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (239,1);
+ref = dot_middle;
+}
+);
+width = 652;
+}
+);
+note = uni162C;
+unicode = 5676;
+},
+{
+color = 9;
+glyphname = "dlaCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(534,0,l),
+(563,134,l),
+(381,134,ls),
+(266,134,o),
+(209,188,o),
+(209,291,cs),
+(209,387,o),
+(256,593,o),
+(390,593,cs),
+(473,593,o),
+(512,514,o),
+(492,389,c),
+(617,389,l),
+(687,721,l),
+(754,721,l),
+(776,824,l),
+(535,824,l),
+(514,721,l),
+(581,721,l),
+(544,546,l),
+(558,539,l),
+(558,662,o),
+(472,728,o),
+(380,728,cs),
+(160,728,o),
+(61,451,o),
+(61,280,cs),
+(61,105,o),
+(165,0,o),
+(356,0,cs)
+);
+}
+);
+width = 654;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni162D;
+unicode = 5677;
+},
+{
+color = 9;
+glyphname = "lhuCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(532,-14,o),
+(620,215,o),
+(620,388,cs),
+(620,515,o),
+(566,610,o),
+(474,639,c),
+(525,592,l),
+(681,592,l),
+(707,714,l),
+(472,714,l),
+(446,597,l),
+(473,573,o),
+(487,528,o),
+(487,471,cs),
+(487,366,o),
+(447,121,o),
+(311,121,cs),
+(245,121,o),
+(210,165,o),
+(210,249,cs),
+(210,338,o),
+(254,534,o),
+(353,597,c),
+(378.002,714,l),
+(143,714,l),
+(117,592,l),
+(275,592,l),
+(345,643,l),
+(158,607,o),
+(61,395,o),
+(61,233,cs),
+(61,83,o),
+(149,-14,o),
+(306,-14,cs)
+);
+}
+);
+width = 654;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162E;
+unicode = 5678;
+},
+{
+color = 9;
+glyphname = "lhoCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(226.002,0,l),
+(251,117,l),
+(225,141,o),
+(211,186,o),
+(211,243,cs),
+(211,348,o),
+(251,593,o),
+(386,593,cs),
+(452,593,o),
+(487,549,o),
+(487,465,cs),
+(487,376,o),
+(444,180,o),
+(345,117,c),
+(320,0,l),
+(555,0,l),
+(581,122,l),
+(423,122,l),
+(352,71,l),
+(540,107,o),
+(637,319,o),
+(637,481,cs),
+(637,631,o),
+(549,728,o),
+(392,728,cs),
+(165,728,o),
+(78,499,o),
+(78,326,cs),
+(78,199,o),
+(131,104,o),
+(224,75,c),
+(173,122,l),
+(17,122,l),
+(-9,0,l)
+);
+}
+);
+width = 654;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162F;
+unicode = 5679;
+},
+{
+color = 9;
+glyphname = "lheCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (343,357);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(542,-14,o),
+(641,272,o),
+(641,461,cs),
+(641,624,o),
+(567,728,o),
+(443,728,cs),
+(358,728,o),
+(290,679,o),
+(250,588,c),
+(257,586,l),
+(284,714,l),
+(152,714,l),
+(90,424,l),
+(214,424,l),
+(254,542,o),
+(313,593,o),
+(385,593,cs),
+(457,593,o),
+(496,542,o),
+(496,451,cs),
+(496,343,o),
+(440,121,o),
+(300,121,cs),
+(223,121,o),
+(182,183,o),
+(186,290,c),
+(61,290,l),
+(0,0,l),
+(132,0,l),
+(164,157,l),
+(153,157,l),
+(156,52,o),
+(222,-14,o),
+(330,-14,cs)
+);
+}
+);
+width = 654;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1630;
+unicode = 5680;
+},
+{
+color = 9;
+glyphname = "lheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (262,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 654;
+}
+);
+note = uni1631;
+unicode = 5681;
+},
+{
+color = 9;
+glyphname = "lhiCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (235,0);
+ref = dot_middle;
+}
+);
+width = 654;
+}
+);
+note = uni1632;
+unicode = 5682;
+},
+{
+color = 9;
+glyphname = "lhaCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(339,-14,o),
+(408,35,o),
+(447,126,c),
+(441,128,l),
+(414,0,l),
+(546,0,l),
+(608,290,l),
+(484,290,l),
+(444,172,o),
+(385,121,o),
+(313,121,cs),
+(241,121,o),
+(202,172,o),
+(202,263,cs),
+(202,371,o),
+(258,593,o),
+(398,593,cs),
+(474,593,o),
+(516,531,o),
+(512,424,c),
+(636,424,l),
+(698,714,l),
+(566,714,l),
+(533,557,l),
+(545,557,l),
+(542,662,o),
+(476,728,o),
+(375,728,cs),
+(156,728,o),
+(57,442,o),
+(57,253,cs),
+(57,90,o),
+(131,-14,o),
+(255,-14,cs)
+);
+}
+);
+width = 653;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1633;
+unicode = 5683;
+},
+{
+color = 9;
+glyphname = "tlhuCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(532,-14,o),
+(620,215,o),
+(620,388,cs),
+(620,503,o),
+(591,599,o),
+(497,639,c),
+(489,603,l),
+(661,603,l),
+(643,522,l),
+(749,522,l),
+(807,794,l),
+(701,794,l),
+(683,714,l),
+(472,714,l),
+(446,597,l),
+(473,573,o),
+(487,528,o),
+(487,471,cs),
+(487,366,o),
+(447,121,o),
+(311,121,cs),
+(245,121,o),
+(210,165,o),
+(210,249,cs),
+(210,338,o),
+(254,534,o),
+(353,597,c),
+(378.002,714,l),
+(143,714,l),
+(117,592,l),
+(297,592,l),
+(290,623,l),
+(132,562,o),
+(61,371,o),
+(61,233,cs),
+(61,83,o),
+(149,-14,o),
+(306,-14,cs)
+);
+}
+);
+width = 714;
+}
+);
+metricLeft = "lhuCarrier-canadian";
+note = uni1634;
+unicode = 5684;
+},
+{
+color = 9;
+glyphname = "tlhoCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(57,-80,l),
+(75,0,l),
+(287,0,l),
+(312,117,l),
+(285,141,o),
+(272,186,o),
+(272,243,cs),
+(272,348,o),
+(311,593,o),
+(447,593,cs),
+(513,593,o),
+(548,549,o),
+(548,465,cs),
+(548,376,o),
+(505,180,o),
+(406,117,c),
+(380,0,l),
+(616,0,l),
+(642,122,l),
+(461,122,l),
+(469,91,l),
+(627,152,o),
+(698,343,o),
+(698,481,cs),
+(698,631,o),
+(609,728,o),
+(452,728,cs),
+(226,728,o),
+(139,499,o),
+(139,326,cs),
+(139,211,o),
+(167,115,o),
+(261,75,c),
+(270,111,l),
+(98,111,l),
+(115,192,l),
+(9,192,l),
+(-49,-80,l)
+);
+}
+);
+width = 715;
+}
+);
+metricLeft = "=|tlhuCarrier-canadian";
+metricRight = "lhuCarrier-canadian";
+note = uni1635;
+unicode = 5685;
+},
+{
+color = 9;
+glyphname = "tlheCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (354,357);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(555,-14,o),
+(655,272,o),
+(655,461,cs),
+(655,624,o),
+(579,728,o),
+(456,728,cs),
+(339,728,o),
+(258,650,o),
+(214,525,c),
+(242,579,l),
+(272,721,l),
+(339,721,l),
+(360,824,l),
+(120,824,l),
+(98,721,l),
+(166,721,l),
+(102,424,l),
+(227,424,l),
+(266,542,o),
+(325,593,o),
+(397,593,cs),
+(469,593,o),
+(510,542,o),
+(510,451,cs),
+(510,343,o),
+(453,121,o),
+(313,121,cs),
+(236,121,o),
+(194,183,o),
+(198,290,c),
+(74,290,l),
+(12,0,l),
+(144,0,l),
+(177,157,l),
+(165,157,l),
+(168,52,o),
+(235,-14,o),
+(342,-14,cs)
+);
+}
+);
+width = 668;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1636;
+unicode = 5686;
+},
+{
+color = 9;
+glyphname = "tlheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (273,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 667;
+}
+);
+note = uni1637;
+unicode = 5687;
+},
+{
+color = 9;
+glyphname = "tlhiCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (246,0);
+ref = dot_middle;
+}
+);
+width = 667;
+}
+);
+note = uni1638;
+unicode = 5688;
+},
+{
+color = 9;
+glyphname = "tlhaCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(339,-14,o),
+(409,35,o),
+(449,126,c),
+(442,128,l),
+(416,0,l),
+(548,0,l),
+(610,290,l),
+(485,290,l),
+(445,172,o),
+(386,121,o),
+(313,121,cs),
+(241,121,o),
+(202,172,o),
+(202,263,cs),
+(202,371,o),
+(258,593,o),
+(398,593,cs),
+(476,593,o),
+(518,531,o),
+(513,424,c),
+(638,424,l),
+(701,721,l),
+(768,721,l),
+(791,824,l),
+(549,824,l),
+(527,721,l),
+(595,721,l),
+(557,544,l),
+(566,543,l),
+(560,668,o),
+(478,728,o),
+(375,728,cs),
+(156,728,o),
+(57,442,o),
+(57,253,cs),
+(57,90,o),
+(131,-14,o),
+(255,-14,cs)
+);
+}
+);
+width = 669;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni1639;
+unicode = 5689;
+},
+{
+color = 9;
+glyphname = "tluCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(282,-14,o),
+(337,24,o),
+(381,107,c),
+(334,108,l),
+(350,28,o),
+(400,-14,o),
+(480,-14,cs),
+(672,-14,o),
+(730,264,o),
+(730,407,cs),
+(730,518,o),
+(691,591,o),
+(622,624,c),
+(588,603,l),
+(771,603,l),
+(754,522,l),
+(860,522,l),
+(917,794,l),
+(811,794,l),
+(794,714,l),
+(527,714,l),
+(502,596,l),
+(563,588,o),
+(593,543,o),
+(593,454,cs),
+(593,380,o),
+(558,119,o),
+(477,119,cs),
+(443,119,o),
+(430,146,o),
+(441,198,cs),
+(466,319,l),
+(327,319,l),
+(302,198,ls),
+(290,145,o),
+(270,119,o),
+(239,119,cs),
+(209,119,o),
+(195,138,o),
+(195,185,cs),
+(195,261,o),
+(254,595,o),
+(408,596,c),
+(433,714,l),
+(144,714,l),
+(118,592,l),
+(300,592,l),
+(276,617,l),
+(104,542,o),
+(51,312,o),
+(51,177,cs),
+(51,53,o),
+(108,-14,o),
+(207,-14,cs)
+);
+}
+);
+width = 825;
+}
+);
+metricRight = "tlhuCarrier-canadian";
+note = uni163A;
+unicode = 5690;
+},
+{
+color = 1;
+glyphname = "tloCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(732,-80,l),
+(790,192,l),
+(684,192,l),
+(666,111,l),
+(494,111,l),
+(514,89,l),
+(701,159,o),
+(758,396,o),
+(758,537,cs),
+(758,661,o),
+(701,728,o),
+(602,728,cs),
+(527,728,o),
+(471,690,o),
+(428,607,c),
+(475,606,l),
+(459,686,o),
+(409,728,o),
+(329,728,cs),
+(137,728,o),
+(79,450,o),
+(79,307,cs),
+(79,204,o),
+(113,134,o),
+(173,98,c),
+(211,122,l),
+(18,122,l),
+(-8,0,l),
+(282,0,l),
+(307,118,l),
+(246,126,o),
+(216,171,o),
+(216,260,cs),
+(216,334,o),
+(251,595,o),
+(332,595,cs),
+(366,595,o),
+(379,568,o),
+(368,516,cs),
+(343,395,l),
+(482,395,l),
+(507,516,ls),
+(519,569,o),
+(539,595,o),
+(570,595,cs),
+(600,595,o),
+(614,576,o),
+(614,529,cs),
+(614,453,o),
+(556,119,o),
+(401,118,c),
+(376,0,l),
+(643,0,l),
+(626,-80,l)
+);
+}
+);
+width = 825;
+}
+);
+metricLeft = "tluCarrier-canadian";
+metricRight = "tlhuCarrier-canadian";
+note = uni163B;
+unicode = 5691;
+},
+{
+color = 9;
+glyphname = "tleCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (302,357);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(488,-14,o),
+(595,83,o),
+(595,226,cs),
+(595,303,o),
+(556,364,o),
+(493,372,c),
+(487,342,l),
+(593,353,o),
+(665,452,o),
+(665,554,cs),
+(665,655,o),
+(591,728,o),
+(474,728,cs),
+(371,728,o),
+(281,672,o),
+(231,570,c),
+(240,569,l),
+(272,721,l),
+(339,721,l),
+(361,824,l),
+(120,824,l),
+(98,721,l),
+(165,721,l),
+(103,424,l),
+(224,424,l),
+(253,537,o),
+(320,597,o),
+(413,597,cs),
+(477,597,o),
+(514,565,o),
+(514,516,cs),
+(514,462,o),
+(479,417,o),
+(417,417,cs),
+(393,417,l),
+(368,298,l),
+(391,298,ls),
+(428,298,o),
+(454,275,o),
+(454,234,cs),
+(454,167,o),
+(411,117,o),
+(330,117,cs),
+(229,117,o),
+(180,178,o),
+(195,290,c),
+(74,290,l),
+(13,0,l),
+(145,0,l),
+(177,151,l),
+(154,150,l),
+(156,49,o),
+(236,-14,o),
+(351,-14,cs)
+);
+}
+);
+width = 657;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni163C;
+unicode = 5692;
+},
+{
+color = 9;
+glyphname = "tleeCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (221,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 657;
+}
+);
+note = uni163D;
+unicode = 5693;
+},
+{
+color = 9;
+glyphname = "tliCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (209,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 657;
+}
+);
+note = uni163E;
+unicode = 5694;
+},
+{
+color = 9;
+glyphname = "tlaCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(318,-14,o),
+(400,30,o),
+(452,111,c),
+(435,140,l),
+(406,0,l),
+(537,0,l),
+(599,290,l),
+(478,290,l),
+(449,177,o),
+(382,117,o),
+(288,117,cs),
+(224,117,o),
+(187,149,o),
+(187,198,cs),
+(187,252,o),
+(222,297,o),
+(283,297,cs),
+(307,297,l),
+(333,416,l),
+(309,416,ls),
+(272,416,o),
+(246,439,o),
+(246,480,cs),
+(246,547,o),
+(290,597,o),
+(372,597,cs),
+(472,597,o),
+(521,536,o),
+(506,424,c),
+(628,424,l),
+(691,721,l),
+(758,721,l),
+(780,824,l),
+(539,824,l),
+(516,721,l),
+(584,721,l),
+(542,518,l),
+(556,537,l),
+(566,654,o),
+(483,728,o),
+(349,728,cs),
+(212,728,o),
+(106,631,o),
+(106,488,cs),
+(106,414,o),
+(142,356,o),
+(198,342,c),
+(207,371,l),
+(105,358,o),
+(35,260,o),
+(35,160,cs),
+(35,59,o),
+(110,-14,o),
+(227,-14,cs)
+);
+}
+);
+width = 658;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni163F;
+unicode = 5695;
+},
+{
+color = 9;
+glyphname = "zuCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(502,-14,o),
+(602,119,o),
+(602,313,cs),
+(602,370,o),
+(593,435,o),
+(593,506,cs),
+(593,558,o),
+(611,588,o),
+(662,588,cs),
+(682,588,l),
+(708,714,l),
+(648,714,ls),
+(514,714,o),
+(455,645,o),
+(455,500,cs),
+(455,441,o),
+(463,387,o),
+(463,308,cs),
+(463,200,o),
+(410,121,o),
+(309,121,cs),
+(238,121,o),
+(197,158,o),
+(197,218,cs),
+(197,319,o),
+(330,480,o),
+(330,595,cs),
+(330,669,o),
+(278,714,o),
+(191,714,cs),
+(142,714,l),
+(115,588,l),
+(145,588,ls),
+(174,588,o),
+(186,576,o),
+(186,554,cs),
+(186,491,o),
+(47,344,o),
+(47,191,cs),
+(47,69,o),
+(144,-14,o),
+(296,-14,cs)
+);
+}
+);
+width = 655;
+}
+);
+metricRight = "=|";
+note = uni1640;
+unicode = 5696;
+},
+{
+color = 9;
+glyphname = "zoCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(51,0,ls),
+(185,0,o),
+(244,69,o),
+(244,214,cs),
+(244,273,o),
+(236,327,o),
+(236,406,cs),
+(236,514,o),
+(289,593,o),
+(390,593,cs),
+(461,593,o),
+(502,556,o),
+(502,496,cs),
+(502,395,o),
+(369,234,o),
+(369,119,cs),
+(369,45,o),
+(421,0,o),
+(508,0,cs),
+(557,0,l),
+(584,126,l),
+(554,126,ls),
+(525,126,o),
+(513,138,o),
+(514,160,cs),
+(513,223,o),
+(653,370,o),
+(653,523,cs),
+(653,645,o),
+(555,728,o),
+(403,728,cs),
+(198,728,o),
+(98,595,o),
+(98,401,cs),
+(98,344,o),
+(106,279,o),
+(106,208,cs),
+(106,156,o),
+(88,126,o),
+(37,126,cs),
+(17,126,l),
+(-9,0,l)
+);
+}
+);
+width = 655;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1641;
+unicode = 5697;
+},
+{
+color = 9;
+glyphname = "zeCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (329,357);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(543,-14,o),
+(630,346,o),
+(630,519,cs),
+(630,652,o),
+(579,728,o),
+(486,728,cs),
+(385,728,o),
+(307,635,o),
+(271,635,cs),
+(253,635,o),
+(248,649,o),
+(257,688,cs),
+(263,714,l),
+(130,714,l),
+(115,644,ls),
+(97,557,o),
+(128,505,o),
+(200,505,cs),
+(294,505,o),
+(368,593,o),
+(426,593,cs),
+(463,593,o),
+(481,559,o),
+(481,493,cs),
+(481,397,o),
+(426,121,o),
+(318,121,cs),
+(257,121,o),
+(221,209,o),
+(131,209,cs),
+(61,209,o),
+(13,161,o),
+(-7,70,cs),
+(-22,0,l),
+(111,0,l),
+(116,26,ls),
+(125,65,o),
+(136,79,o),
+(155,79,cs),
+(193,79,o),
+(240,-14,o),
+(340,-14,cs)
+);
+}
+);
+width = 633;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1642;
+unicode = 5698;
+},
+{
+color = 9;
+glyphname = "zeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (248,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 633;
+}
+);
+note = uni1643;
+unicode = 5699;
+},
+{
+color = 9;
+glyphname = "ziCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (221,0);
+ref = dot_middle;
+}
+);
+width = 633;
+}
+);
+note = uni1644;
+unicode = 5700;
+},
+{
+color = 9;
+glyphname = "zaCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(293,-14,o),
+(370,79,o),
+(405,79,cs),
+(424,79,o),
+(429,65,o),
+(420,26,cs),
+(414,0,l),
+(546,0,l),
+(562,70,ls),
+(580,157,o),
+(549,209,o),
+(476,209,cs),
+(383,209,o),
+(309,121,o),
+(252,121,cs),
+(215,121,o),
+(196,155,o),
+(196,221,cs),
+(196,317,o),
+(251,593,o),
+(359,593,cs),
+(420,593,o),
+(456,505,o),
+(545,505,cs),
+(615,505,o),
+(664,553,o),
+(683,644,cs),
+(698,714,l),
+(566,714,l),
+(561,688,ls),
+(552,649,o),
+(541,635,o),
+(522,635,cs),
+(484,635,o),
+(437,728,o),
+(337,728,cs),
+(133,728,o),
+(47,368,o),
+(47,195,cs),
+(47,62,o),
+(98,-14,o),
+(191,-14,cs)
+);
+}
+);
+width = 633;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|zeCarrier-canadian";
+note = uni1645;
+unicode = 5701;
+},
+{
+color = 6;
+glyphname = "zCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(299.994,189,l),
+(320,280,l),
+(155,280,l),
+(146,226,l),
+(362,495,l),
+(373,546,l),
+(108,546,l),
+(88,455,l),
+(250,455,l),
+(259,509,l),
+(42,240,l),
+(32,189,l)
+);
+}
+);
+width = 359;
+}
+);
+metricRight = "=|";
+note = uni1646;
+unicode = 5702;
+},
+{
+color = 6;
+glyphname = "initialzCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(194,99,l),
+(213,189,l),
+(299.994,189,l),
+(320,280,l),
+(123,280,l),
+(148,228,l),
+(362,495,l),
+(373,546,l),
+(289,546,l),
+(308,636,l),
+(212,636,l),
+(193,546,l),
+(108,546,l),
+(88,455,l),
+(281,455,l),
+(256,507,l),
+(42,240,l),
+(32,189,l),
+(117,189,l),
+(98,99,l)
+);
+}
+);
+width = 359;
+}
+);
+metricLeft = "zCarrier-canadian";
+metricRight = "zCarrier-canadian";
+note = uni1647;
+unicode = 5703;
+},
+{
+color = 9;
+glyphname = "dzuCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(502,-14,o),
+(602,119,o),
+(602,313,cs),
+(602,370,o),
+(593,435,o),
+(593,506,cs),
+(593,558,o),
+(611,588,o),
+(662,588,cs),
+(682,588,l),
+(708,714,l),
+(648,714,ls),
+(534,714,o),
+(472,645,o),
+(462,500,cs),
+(459,441,o),
+(467,375,o),
+(465,308,cs),
+(461,200,o),
+(410,121,o),
+(309,121,cs),
+(238,121,o),
+(197,158,o),
+(197,218,cs),
+(197,319,o),
+(321,480,o),
+(321,595,cs),
+(321,669,o),
+(277,714,o),
+(191,714,cs),
+(142,714,l),
+(115,588,l),
+(145,588,ls),
+(174,588,o),
+(186,576,o),
+(186,554,cs),
+(186,491,o),
+(47,344,o),
+(47,191,cs),
+(47,69,o),
+(144,-14,o),
+(296,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(406,486,l),
+(443,659,l),
+(487,659,l),
+(499,714,l),
+(354,714,l),
+(342,659,l),
+(386,659,l),
+(349,486,l)
+);
+}
+);
+width = 655;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1648;
+unicode = 5704;
+},
+{
+color = 9;
+glyphname = "dzoCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(51,0,ls),
+(165,0,o),
+(227,69,o),
+(237,214,cs),
+(240,273,o),
+(232,339,o),
+(234,406,cs),
+(238,514,o),
+(289,593,o),
+(390,593,cs),
+(461,593,o),
+(502,556,o),
+(502,496,cs),
+(502,395,o),
+(378,234,o),
+(378,119,cs),
+(378,45,o),
+(422,0,o),
+(508,0,cs),
+(556,0,l),
+(583,126,l),
+(554,126,ls),
+(525,126,o),
+(513,138,o),
+(513,160,cs),
+(513,223,o),
+(653,370,o),
+(653,523,cs),
+(653,645,o),
+(555,728,o),
+(403,728,cs),
+(198,728,o),
+(98,595,o),
+(98,401,cs),
+(98,344,o),
+(106,279,o),
+(106,208,cs),
+(106,156,o),
+(88,126,o),
+(37,126,cs),
+(17,126,l),
+(-9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(345,0,l),
+(357,55,l),
+(313,55,l),
+(350,228,l),
+(293,228,l),
+(256,55,l),
+(212,55,l),
+(200,0,l)
+);
+}
+);
+width = 654;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1649;
+unicode = 5705;
+},
+{
+color = 9;
+glyphname = "dzeCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (356,357);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(564,-14,o),
+(651,346,o),
+(651,519,cs),
+(651,652,o),
+(600,728,o),
+(507,728,cs),
+(405,728,o),
+(327,635,o),
+(292,635,cs),
+(273,635,o),
+(269,649,o),
+(278,688,cs),
+(283,714,l),
+(151,714,l),
+(136,644,ls),
+(117,557,o),
+(149,505,o),
+(221,505,cs),
+(314,505,o),
+(389,593,o),
+(447,593,cs),
+(483,593,o),
+(502,559,o),
+(502,493,cs),
+(502,397,o),
+(447,121,o),
+(338,121,cs),
+(278,121,o),
+(241,209,o),
+(152,209,cs),
+(82,209,o),
+(33,161,o),
+(14,70,cs),
+(-1,0,l),
+(131,0,l),
+(137,26,ls),
+(145,65,o),
+(156,79,o),
+(175,79,cs),
+(213,79,o),
+(261,-14,o),
+(361,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(129,251,l),
+(143,319,l),
+(243,319,l),
+(260,395,l),
+(159,395,l),
+(173,463,l),
+(98,463,l),
+(53,251,l)
+);
+}
+);
+width = 654;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164A;
+unicode = 5706;
+},
+{
+color = 9;
+glyphname = "dzeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "dzeCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (275,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 654;
+}
+);
+metricLeft = "dzeCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164B;
+unicode = 5707;
+},
+{
+color = 9;
+glyphname = "dziCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "dzeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (247,0);
+ref = dot_middle;
+}
+);
+width = 654;
+}
+);
+note = uni164C;
+unicode = 5708;
+},
+{
+color = 9;
+glyphname = "dzaCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(293,-14,o),
+(371,79,o),
+(406,79,cs),
+(425,79,o),
+(429,65,o),
+(421,26,cs),
+(415,0,l),
+(547,0,l),
+(562,70,ls),
+(581,157,o),
+(550,209,o),
+(477,209,cs),
+(384,209,o),
+(309,121,o),
+(252,121,cs),
+(215,121,o),
+(196,155,o),
+(196,221,cs),
+(196,317,o),
+(251,593,o),
+(360,593,cs),
+(421,593,o),
+(457,505,o),
+(546,505,cs),
+(616,505,o),
+(665,553,o),
+(684,644,cs),
+(699,714,l),
+(567,714,l),
+(561,688,ls),
+(553,649,o),
+(542,635,o),
+(523,635,cs),
+(485,635,o),
+(437,728,o),
+(337,728,cs),
+(134,728,o),
+(47,368,o),
+(47,195,cs),
+(47,62,o),
+(98,-14,o),
+(191,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(600,251,l),
+(645,463,l),
+(570,463,l),
+(555,395,l),
+(455,395,l),
+(438,319,l),
+(539,319,l),
+(525,251,l)
+);
+}
+);
+width = 654;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dzeCarrier-canadian";
+note = uni164D;
+unicode = 5709;
+},
+{
+color = 9;
+glyphname = "suCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(281,-14,o),
+(352,41,o),
+(386,140,c),
+(335,140,l),
+(339,38,o),
+(391,-14,o),
+(491,-14,cs),
+(623,-14,o),
+(683,83,o),
+(700,214,cs),
+(712,297,o),
+(703,441,o),
+(713,512,cs),
+(718,558,o),
+(735,588,o),
+(773,588,cs),
+(790,588,l),
+(816,714,l),
+(761,714,ls),
+(648,714,o),
+(596,648,o),
+(580,538,cs),
+(568,461,o),
+(569,297,o),
+(561,231,cs),
+(557,175,o),
+(538,119,o),
+(483,119,cs),
+(431,119,o),
+(429,170,o),
+(438,211,cs),
+(544,714,l),
+(416,714,l),
+(308,207,ls),
+(296,147,o),
+(271,119,o),
+(231,119,cs),
+(199,119,o),
+(181,137,o),
+(181,172,cs),
+(181,251,o),
+(318,504,o),
+(318,607,cs),
+(318,677,o),
+(276,714,o),
+(198,714,cs),
+(143,714,l),
+(117,588,l),
+(133,588,ls),
+(158,588,o),
+(170,576,o),
+(170,551,cs),
+(170,470,o),
+(33,272,o),
+(33,144,cs),
+(33,49,o),
+(93,-14,o),
+(190,-14,cs)
+);
+}
+);
+width = 764;
+}
+);
+metricRight = "=|";
+note = uni164E;
+unicode = 5710;
+},
+{
+color = 9;
+glyphname = "soCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(46,0,ls),
+(160,0,o),
+(211,66,o),
+(227,176,cs),
+(239,253,o),
+(238,417,o),
+(246,483,cs),
+(250,539,o),
+(270,595,o),
+(324,595,cs),
+(377,595,o),
+(378,544,o),
+(370,503,cs),
+(263,0,l),
+(392,0,l),
+(499,507,ls),
+(512,567,o),
+(536,595,o),
+(576,595,cs),
+(609,595,o),
+(626,577,o),
+(626,542,cs),
+(626,463,o),
+(489,210,o),
+(489,107,cs),
+(489,37,o),
+(531,0,o),
+(610,0,cs),
+(663,0,l),
+(690,126,l),
+(673,126,ls),
+(648,126,o),
+(637,138,o),
+(637,163,cs),
+(637,244,o),
+(774,442,o),
+(774,570,cs),
+(774,665,o),
+(714,728,o),
+(617,728,cs),
+(526,728,o),
+(455,673,o),
+(421,574,c),
+(472,574,l),
+(468,676,o),
+(417,728,o),
+(316,728,cs),
+(184,728,o),
+(124,631,o),
+(107,500,cs),
+(95,417,o),
+(104,273,o),
+(94,202,cs),
+(89,156,o),
+(72,126,o),
+(34,126,cs),
+(18,126,l),
+(-9,0,l)
+);
+}
+);
+width = 762;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5711;
+},
+{
+color = 9;
+glyphname = "seCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(506,-14,o),
+(584,120,o),
+(584,231,cs),
+(584,307,o),
+(546,361,o),
+(480,373,c),
+(473,338,l),
+(603,356,o),
+(655,473,o),
+(655,566,cs),
+(655,661,o),
+(597,728,o),
+(508,728,cs),
+(404,728,o),
+(324,635,o),
+(289,635,cs),
+(274,635,o),
+(270,646,o),
+(276,676,cs),
+(284,714,l),
+(152,714,l),
+(137,645,ls),
+(119,558,o),
+(152,506,o),
+(225,506,cs),
+(322,506,o),
+(393,597,o),
+(455,597,cs),
+(488,597,o),
+(506,573,o),
+(506,536,cs),
+(506,476,o),
+(471,416,o),
+(396,416,cs),
+(88,416,l),
+(63,298,l),
+(370,298,ls),
+(417,298,o),
+(441,274,o),
+(441,232,cs),
+(441,190,o),
+(416,117,o),
+(358,117,cs),
+(297,117,o),
+(251,208,o),
+(154,208,cs),
+(82,208,o),
+(35,161,o),
+(15,69,cs),
+(0,0,l),
+(133,0,l),
+(138,26,ls),
+(146,64,o),
+(158,79,o),
+(177,79,cs),
+(225,79,o),
+(272,-14,o),
+(378,-14,cs)
+);
+}
+);
+width = 644;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni1650;
+unicode = 5712;
+},
+{
+color = 9;
+glyphname = "seeCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(505,-14,o),
+(583,120,o),
+(583,231,cs),
+(583,303,o),
+(547,357,o),
+(487,371,c),
+(475,340,l),
+(602,358,o),
+(654,474,o),
+(654,566,cs),
+(654,661,o),
+(596,728,o),
+(507,728,cs),
+(403,728,o),
+(323,635,o),
+(288,635,cs),
+(273,635,o),
+(269,646,o),
+(275,676,cs),
+(283,714,l),
+(151,714,l),
+(136,645,ls),
+(118,558,o),
+(151,506,o),
+(224,506,cs),
+(321,506,o),
+(392,597,o),
+(454,597,cs),
+(487,597,o),
+(505,573,o),
+(505,536,cs),
+(505,476,o),
+(470,413,o),
+(394,413,cs),
+(352,413,l),
+(372,348,l),
+(401,488,l),
+(324,488,l),
+(309,413,l),
+(87,413,l),
+(63,301,l),
+(285,301,l),
+(269,223,l),
+(345,223,l),
+(374,366,l),
+(328,301,l),
+(370,301,ls),
+(416,301,o),
+(440,274,o),
+(440,232,cs),
+(440,190,o),
+(415,117,o),
+(357,117,cs),
+(296,117,o),
+(250,208,o),
+(153,208,cs),
+(81,208,o),
+(34,161,o),
+(14,69,cs),
+(-1,0,l),
+(132,0,l),
+(137,26,ls),
+(145,64,o),
+(157,79,o),
+(176,79,cs),
+(224,79,o),
+(271,-14,o),
+(377,-14,cs)
+);
+}
+);
+width = 643;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1651;
+unicode = 5713;
+},
+{
+color = 9;
+glyphname = "siCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(505,-14,o),
+(583,120,o),
+(583,231,cs),
+(583,303,o),
+(547,357,o),
+(487,371,c),
+(475,340,l),
+(602,358,o),
+(654,474,o),
+(654,566,cs),
+(654,661,o),
+(596,728,o),
+(507,728,cs),
+(403,728,o),
+(323,635,o),
+(288,635,cs),
+(273,635,o),
+(269,646,o),
+(275,676,cs),
+(283,714,l),
+(151,714,l),
+(136,645,ls),
+(118,558,o),
+(151,506,o),
+(224,506,cs),
+(321,506,o),
+(392,597,o),
+(454,597,cs),
+(487,597,o),
+(508,573,o),
+(508,536,cs),
+(508,476,o),
+(477,409,o),
+(401,409,cs),
+(331,409,l),
+(391,365,l),
+(390,419,o),
+(350,456,o),
+(298,456,cs),
+(265,456,o),
+(236,439,o),
+(219,413,c),
+(87,413,l),
+(63,301,l),
+(220,301,l),
+(236,275,o),
+(265,259,o),
+(298,259,cs),
+(347,259,o),
+(389,297,o),
+(392,348,c),
+(331,305,l),
+(383,305,ls),
+(430,305,o),
+(444,274,o),
+(444,232,cs),
+(444,190,o),
+(415,117,o),
+(357,117,cs),
+(296,117,o),
+(250,208,o),
+(153,208,cs),
+(81,208,o),
+(34,161,o),
+(14,69,cs),
+(-1,0,l),
+(132,0,l),
+(137,26,ls),
+(145,64,o),
+(157,79,o),
+(176,79,cs),
+(224,79,o),
+(271,-14,o),
+(377,-14,cs)
+);
+}
+);
+width = 643;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1652;
+unicode = 5714;
+},
+{
+color = 9;
+glyphname = "saCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(285,-14,o),
+(365,79,o),
+(400,79,cs),
+(415,79,o),
+(419,68,o),
+(413,38,cs),
+(404,0,l),
+(537,0,l),
+(551,69,ls),
+(570,156,o),
+(537,208,o),
+(463,208,cs),
+(367,208,o),
+(295,117,o),
+(233,117,cs),
+(201,117,o),
+(182,141,o),
+(182,178,cs),
+(182,238,o),
+(217,298,o),
+(292,298,cs),
+(600,298,l),
+(625,416,l),
+(318,416,ls),
+(271,416,o),
+(247,440,o),
+(247,482,cs),
+(247,524,o),
+(272,597,o),
+(331,597,cs),
+(391,597,o),
+(438,506,o),
+(535,506,cs),
+(607,506,o),
+(654,553,o),
+(674,645,cs),
+(688,714,l),
+(556,714,l),
+(551,688,ls),
+(543,650,o),
+(531,635,o),
+(511,635,cs),
+(464,635,o),
+(416,728,o),
+(310,728,cs),
+(182,728,o),
+(105,594,o),
+(105,483,cs),
+(105,407,o),
+(143,353,o),
+(208,341,c),
+(215,376,l),
+(86,358,o),
+(33,241,o),
+(33,148,cs),
+(33,53,o),
+(91,-14,o),
+(180,-14,cs)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1653;
+unicode = 5715;
+},
+{
+color = 9;
+glyphname = "shuCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(272,-14,o),
+(337,30,o),
+(376,112,c),
+(338,116,l),
+(347,29,o),
+(399,-14,o),
+(491,-14,cs),
+(623,-14,o),
+(683,83,o),
+(700,214,cs),
+(712,297,o),
+(703,441,o),
+(713,512,cs),
+(718,558,o),
+(735,588,o),
+(773,588,cs),
+(790,588,l),
+(816,714,l),
+(761,714,ls),
+(653,714,o),
+(599,655,o),
+(581,551,cs),
+(578,539,o),
+(577,525,o),
+(576,510,c),
+(609,590,l),
+(518,590,l),
+(544,714,l),
+(416,714,l),
+(389,590,l),
+(294,590,l),
+(306,538,l),
+(314,565,o),
+(318,588,o),
+(318,607,cs),
+(318,677,o),
+(276,714,o),
+(198,714,cs),
+(143,714,l),
+(117,588,l),
+(133,588,ls),
+(158,588,o),
+(170,576,o),
+(170,551,cs),
+(170,470,o),
+(33,272,o),
+(33,144,cs),
+(33,49,o),
+(93,-14,o),
+(190,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,119,o),
+(181,137,o),
+(181,172,cs),
+(181,229,o),
+(248,363,o),
+(288,475,c),
+(365,475,l),
+(308,207,ls),
+(296,147,o),
+(271,119,o),
+(231,119,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(431,119,o),
+(429,170,o),
+(438,211,cs),
+(494,475,l),
+(572,475,l),
+(566,391,o),
+(567,285,o),
+(561,231,cs),
+(557,175,o),
+(538,119,o),
+(483,119,cs)
+);
+}
+);
+width = 764;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1654;
+unicode = 5716;
+},
+{
+color = 9;
+glyphname = "shoCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(46,0,ls),
+(154,0,o),
+(208,59,o),
+(226,163,cs),
+(229,175,o),
+(231,189,o),
+(232,204,c),
+(198,124,l),
+(289,124,l),
+(263,0,l),
+(392,0,l),
+(418,124,l),
+(513,124,l),
+(501,176,l),
+(494,149,o),
+(489,126,o),
+(489,107,cs),
+(489,37,o),
+(531,0,o),
+(610,0,cs),
+(664,0,l),
+(691,126,l),
+(674,126,ls),
+(649,126,o),
+(637,138,o),
+(637,163,cs),
+(637,244,o),
+(774,442,o),
+(774,570,cs),
+(774,665,o),
+(714,728,o),
+(617,728,cs),
+(535,728,o),
+(470,684,o),
+(432,602,c),
+(469,598,l),
+(460,685,o),
+(408,728,o),
+(316,728,cs),
+(184,728,o),
+(124,631,o),
+(107,500,cs),
+(95,417,o),
+(104,273,o),
+(94,202,cs),
+(89,156,o),
+(72,126,o),
+(34,126,cs),
+(18,126,l),
+(-9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(241,323,o),
+(240,429,o),
+(246,483,cs),
+(250,539,o),
+(270,595,o),
+(324,595,cs),
+(377,595,o),
+(378,544,o),
+(370,503,cs),
+(313,239,l),
+(235,239,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(499,507,ls),
+(512,567,o),
+(536,595,o),
+(576,595,cs),
+(609,595,o),
+(626,577,o),
+(626,542,cs),
+(626,485,o),
+(559,351,o),
+(520,239,c),
+(442,239,l)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1655;
+unicode = 5717;
+},
+{
+color = 9;
+glyphname = "sheCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(506,-14,o),
+(584,120,o),
+(584,231,cs),
+(584,303,o),
+(548,357,o),
+(488,371,c),
+(476,340,l),
+(603,358,o),
+(655,474,o),
+(655,566,cs),
+(655,661,o),
+(597,728,o),
+(508,728,cs),
+(404,728,o),
+(324,635,o),
+(289,635,cs),
+(274,635,o),
+(270,646,o),
+(276,676,cs),
+(284,714,l),
+(152,714,l),
+(137,645,ls),
+(119,558,o),
+(152,511,o),
+(225,511,cs),
+(244,511,o),
+(262,513,o),
+(276,518,c),
+(211,582,l),
+(176,416,l),
+(88,416,l),
+(63,298,l),
+(151,298,l),
+(116,130,l),
+(208,194,l),
+(191,200,o),
+(173,203,o),
+(154,203,cs),
+(82,203,o),
+(35,161,o),
+(15,69,cs),
+(0,0,l),
+(133,0,l),
+(138,26,ls),
+(146,64,o),
+(158,79,o),
+(177,79,cs),
+(225,79,o),
+(272,-14,o),
+(378,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(265,298,l),
+(370,298,ls),
+(417,298,o),
+(441,274,o),
+(441,232,cs),
+(441,190,o),
+(416,117,o),
+(358,117,cs),
+(317,117,o),
+(284,154,o),
+(240,179,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(315,533,l),
+(367,558,o),
+(413,597,o),
+(455,597,cs),
+(488,597,o),
+(506,573,o),
+(506,536,cs),
+(506,476,o),
+(471,416,o),
+(396,416,cs),
+(290,416,l)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1656;
+unicode = 5718;
+},
+{
+color = 9;
+glyphname = "sheeCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(505,-14,o),
+(583,120,o),
+(583,231,cs),
+(583,303,o),
+(547,357,o),
+(487,371,c),
+(475,340,l),
+(602,358,o),
+(654,474,o),
+(654,566,cs),
+(654,661,o),
+(596,728,o),
+(507,728,cs),
+(403,728,o),
+(323,635,o),
+(288,635,cs),
+(273,635,o),
+(269,646,o),
+(275,676,cs),
+(283,714,l),
+(151,714,l),
+(136,645,ls),
+(118,558,o),
+(151,511,o),
+(224,511,cs),
+(236,511,o),
+(248,512,o),
+(259,515,c),
+(211,579,l),
+(174,405,l),
+(85,405,l),
+(65,309,l),
+(153,309,l),
+(116,134,l),
+(190,198,l),
+(178,201,o),
+(166,203,o),
+(153,203,cs),
+(81,203,o),
+(34,161,o),
+(14,69,cs),
+(-1,0,l),
+(132,0,l),
+(137,26,ls),
+(145,64,o),
+(157,79,o),
+(176,79,cs),
+(224,79,o),
+(271,-14,o),
+(377,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(312,114,o),
+(274,165,o),
+(218,189,c),
+(243,309,l),
+(315,309,l),
+(297,223,l),
+(358,223,l),
+(381,332,l),
+(359,309,l),
+(377,309,ls),
+(424,309,o),
+(446,274,o),
+(446,232,cs),
+(446,190,o),
+(415,114,o),
+(357,114,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(414,488,l),
+(353,488,l),
+(335,405,l),
+(264,405,l),
+(289,523,l),
+(355,547,o),
+(407,600,o),
+(454,600,cs),
+(487,600,o),
+(509,573,o),
+(509,536,cs),
+(509,476,o),
+(472,405,o),
+(397,405,cs),
+(380,405,l),
+(393,385,l)
+);
+}
+);
+width = 643;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1657;
+unicode = 5719;
+},
+{
+color = 9;
+glyphname = "shiCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(136,645,ls),
+(118,558,o),
+(151,511,o),
+(224,511,cs),
+(237,511,o),
+(248,513,o),
+(261,516,c),
+(210,579,l),
+(173,405,l),
+(85,405,l),
+(65,309,l),
+(152,309,l),
+(115,134,l),
+(187,198,l),
+(177,201,o),
+(165,203,o),
+(153,203,cs),
+(81,203,o),
+(34,161,o),
+(14,69,cs),
+(-1,0,l),
+(132,0,l),
+(137,26,ls),
+(145,64,o),
+(157,79,o),
+(176,79,cs),
+(224,79,o),
+(271,-14,o),
+(377,-14,cs),
+(505,-14,o),
+(583,120,o),
+(583,231,cs),
+(583,303,o),
+(547,357,o),
+(487,371,c),
+(475,340,l),
+(602,358,o),
+(654,474,o),
+(654,566,cs),
+(654,661,o),
+(596,728,o),
+(507,728,cs),
+(403,728,o),
+(323,635,o),
+(288,635,cs),
+(273,635,o),
+(269,646,o),
+(275,676,cs),
+(283,714,l),
+(151,714,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(243,309,l),
+(278,309,l),
+(291,278,o),
+(320,259,o),
+(355,259,cs),
+(399,259,o),
+(430,292,o),
+(441,334,c),
+(369,309,l),
+(393,309,ls),
+(432,309,o),
+(446,271,o),
+(446,232,cs),
+(446,190,o),
+(415,114,o),
+(357,114,cs),
+(312,114,o),
+(274,164,o),
+(217,189,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(288,523,l),
+(354,548,o),
+(407,600,o),
+(454,600,cs),
+(487,600,o),
+(510,573,o),
+(510,536,cs),
+(510,476,o),
+(482,405,o),
+(413,405,cs),
+(368,405,l),
+(440,382,l),
+(431,425,o),
+(398,456,o),
+(355,456,cs),
+(323,456,o),
+(291,435,o),
+(278,405,c),
+(263,405,l)
+);
+}
+);
+width = 643;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1658;
+unicode = 5720;
+},
+{
+color = 9;
+glyphname = "shaCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(285,-14,o),
+(365,79,o),
+(400,79,cs),
+(415,79,o),
+(419,68,o),
+(413,38,cs),
+(404,0,l),
+(537,0,l),
+(551,69,ls),
+(570,156,o),
+(537,203,o),
+(463,203,cs),
+(445,203,o),
+(427,201,o),
+(413,196,c),
+(477,132,l),
+(513,298,l),
+(600,298,l),
+(625,416,l),
+(538,416,l),
+(573,584,l),
+(481,520,l),
+(497,514,o),
+(515,511,o),
+(535,511,cs),
+(607,511,o),
+(654,553,o),
+(674,645,cs),
+(688,714,l),
+(556,714,l),
+(551,688,ls),
+(543,650,o),
+(531,635,o),
+(511,635,cs),
+(464,635,o),
+(417,728,o),
+(310,728,cs),
+(182,728,o),
+(105,594,o),
+(105,483,cs),
+(105,411,o),
+(140,357,o),
+(201,343,c),
+(213,374,l),
+(85,356,o),
+(33,240,o),
+(33,148,cs),
+(33,53,o),
+(92,-14,o),
+(181,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(201,117,o),
+(182,141,o),
+(182,178,cs),
+(182,238,o),
+(218,298,o),
+(293,298,cs),
+(399,298,l),
+(374,181,l),
+(321,156,o),
+(276,117,o),
+(234,117,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(272,416,o),
+(247,440,o),
+(247,482,cs),
+(247,524,o),
+(273,597,o),
+(331,597,cs),
+(372,597,o),
+(405,560,o),
+(449,535,c),
+(424,416,l),
+(319,416,ls)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1659;
+unicode = 5721;
+},
+{
+color = 6;
+glyphname = "shCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(194,99,l),
+(218,208,l),
+(143,189,l),
+(181,189,ls),
+(273,189,o),
+(326,237,o),
+(326,317,cs),
+(326,371,o),
+(293,406,o),
+(235,406,cs),
+(208,406,ls),
+(185,406,o),
+(173,415,o),
+(173,432,cs),
+(173,454,o),
+(186,470,o),
+(215,470,cs),
+(356,470,l),
+(373,546,l),
+(289,546,l),
+(308,636,l),
+(217,636,l),
+(192,520,l),
+(267.003,546,l),
+(229,546,ls),
+(138,546,o),
+(84,499,o),
+(84,418,cs),
+(84,365,o),
+(117,330,o),
+(175,330,cs),
+(202,330,ls),
+(225,330,o),
+(237,321,o),
+(237,304,cs),
+(237,282,o),
+(224,266,o),
+(195,266,cs),
+(54,266,l),
+(37,189,l),
+(122,189,l),
+(103,99,l)
+);
+}
+);
+width = 361;
+}
+);
+metricRight = "=|";
+note = uni18F5;
+unicode = 5722;
+},
+{
+color = 9;
+glyphname = "tsuCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(272,-14,o),
+(337,30,o),
+(376,112,c),
+(338,116,l),
+(347,29,o),
+(399,-14,o),
+(491,-14,cs),
+(623,-14,o),
+(683,83,o),
+(700,214,cs),
+(712,297,o),
+(703,441,o),
+(713,512,cs),
+(718,558,o),
+(735,588,o),
+(773,588,cs),
+(790,588,l),
+(816,714,l),
+(761,714,ls),
+(648,714,o),
+(598,648,o),
+(582,538,cs),
+(578,506,o),
+(577,462,o),
+(575,415,c),
+(481,415,l),
+(523,615,l),
+(571,615,l),
+(592,714,l),
+(367,714,l),
+(347,615,l),
+(395,615,l),
+(353,415,l),
+(259,415,l),
+(288,490,o),
+(316,562,o),
+(316,607,cs),
+(316,677,o),
+(276,714,o),
+(198,714,cs),
+(143,714,l),
+(117,588,l),
+(133,588,ls),
+(158,588,o),
+(170,576,o),
+(170,551,cs),
+(170,470,o),
+(33,272,o),
+(33,144,cs),
+(33,49,o),
+(93,-14,o),
+(190,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,119,o),
+(181,137,o),
+(181,172,cs),
+(181,199,o),
+(196,246,o),
+(217,300,c),
+(328,300,l),
+(309,207,ls),
+(296,147,o),
+(271,119,o),
+(231,119,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(431,119,o),
+(428,170,o),
+(437,211,cs),
+(456,300,l),
+(568,300,l),
+(566,270,o),
+(564,244,o),
+(561,228,cs),
+(557,175,o),
+(538,119,o),
+(483,119,cs)
+);
+}
+);
+width = 764;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165B;
+unicode = 5723;
+},
+{
+color = 9;
+glyphname = "tsoCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(46,0,ls),
+(160,0,o),
+(210,66,o),
+(225,176,cs),
+(229,208,o),
+(230,252,o),
+(232,299,c),
+(327,299,l),
+(284,99,l),
+(236,99,l),
+(216,0,l),
+(440,0,l),
+(461,99,l),
+(412,99,l),
+(454,299,l),
+(549,299,l),
+(520,224,o),
+(491,152,o),
+(491,107,cs),
+(491,37,o),
+(531,0,o),
+(610,0,cs),
+(664,0,l),
+(691,126,l),
+(674,126,ls),
+(649,126,o),
+(637,138,o),
+(637,163,cs),
+(637,244,o),
+(774,442,o),
+(774,570,cs),
+(774,665,o),
+(714,728,o),
+(617,728,cs),
+(535,728,o),
+(470,684,o),
+(432,602,c),
+(469,598,l),
+(460,685,o),
+(408,728,o),
+(316,728,cs),
+(184,728,o),
+(124,631,o),
+(107,500,cs),
+(95,417,o),
+(104,273,o),
+(94,202,cs),
+(89,156,o),
+(72,126,o),
+(34,126,cs),
+(18,126,l),
+(-9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(241,444,o),
+(244,470,o),
+(246,486,cs),
+(250,539,o),
+(270,595,o),
+(324,595,cs),
+(377,595,o),
+(379,544,o),
+(370,503,cs),
+(351,414,l),
+(239,414,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(498,507,ls),
+(511,567,o),
+(536,595,o),
+(576,595,cs),
+(609,595,o),
+(626,577,o),
+(626,542,cs),
+(626,515,o),
+(611,468,o),
+(590,414,c),
+(479,414,l)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165C;
+unicode = 5724;
+},
+{
+color = 9;
+glyphname = "tseCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(508,-14,o),
+(585,120,o),
+(585,231,cs),
+(585,303,o),
+(550,357,o),
+(489,371,c),
+(477,340,l),
+(605,358,o),
+(656,474,o),
+(656,566,cs),
+(656,661,o),
+(598,728,o),
+(510,728,cs),
+(405,728,o),
+(326,635,o),
+(291,635,cs),
+(276,635,o),
+(272,646,o),
+(278,676,cs),
+(287,714,l),
+(154,714,l),
+(139,645,ls),
+(121,558,o),
+(154,514,o),
+(227,514,cs),
+(253,514,o),
+(277,520,o),
+(294,529,c),
+(270,579,l),
+(234,405,l),
+(164,405,l),
+(179,472,l),
+(102,472,l),
+(53,242,l),
+(130,242,l),
+(144,309,l),
+(213,309,l),
+(176,135,l),
+(220,185,l),
+(203,193,o),
+(182,200,o),
+(156,200,cs),
+(84,200,o),
+(37,161,o),
+(17,69,cs),
+(3,0,l),
+(135,0,l),
+(140,26,ls),
+(148,64,o),
+(160,79,o),
+(179,79,cs),
+(227,79,o),
+(274,-14,o),
+(380,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(330,117,o),
+(303,139,o),
+(271,159,c),
+(303,309,l),
+(373,309,ls),
+(420,309,o),
+(445,283,o),
+(445,232,cs),
+(445,190,o),
+(420,117,o),
+(362,117,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(356,555,l),
+(393,575,o),
+(426,597,o),
+(458,597,cs),
+(490,597,o),
+(508,573,o),
+(508,536,cs),
+(508,476,o),
+(474,405,o),
+(398,405,cs),
+(324,405,l)
+);
+}
+);
+width = 645;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni165D;
+unicode = 5725;
+},
+{
+color = 9;
+glyphname = "tseeCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(508,-14,o),
+(585,120,o),
+(585,231,cs),
+(585,303,o),
+(550,357,o),
+(489,371,c),
+(477,340,l),
+(605,358,o),
+(656,474,o),
+(656,566,cs),
+(656,661,o),
+(598,728,o),
+(510,728,cs),
+(405,728,o),
+(326,635,o),
+(291,635,cs),
+(276,635,o),
+(272,646,o),
+(278,676,cs),
+(287,714,l),
+(154,714,l),
+(139,645,ls),
+(121,558,o),
+(154,514,o),
+(227,514,cs),
+(253,514,o),
+(277,520,o),
+(294,529,c),
+(257,579,l),
+(220,403,l),
+(158,403,l),
+(172,472,l),
+(102,472,l),
+(53,242,l),
+(123,242,l),
+(138,311,l),
+(201,311,l),
+(163,135,l),
+(220,185,l),
+(203,193,o),
+(182,200,o),
+(156,200,cs),
+(84,200,o),
+(37,161,o),
+(17,69,cs),
+(3,0,l),
+(135,0,l),
+(140,26,ls),
+(148,64,o),
+(160,79,o),
+(179,79,cs),
+(227,79,o),
+(274,-14,o),
+(380,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(326,117,o),
+(283,153,o),
+(250,174,c),
+(279,311,l),
+(333,311,l),
+(313,215,l),
+(375,215,l),
+(400,331,l),
+(363,311,l),
+(375,311,ls),
+(420,311,o),
+(445,283,o),
+(445,232,cs),
+(445,181,o),
+(417,117,o),
+(362,117,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(434,496,l),
+(373,496,l),
+(354,403,l),
+(299,403,l),
+(328,542,l),
+(366,559,o),
+(417,597,o),
+(458,597,cs),
+(490,597,o),
+(511,573,o),
+(511,536,cs),
+(511,476,o),
+(476,403,o),
+(401,403,cs),
+(385,403,l),
+(412,391,l)
+);
+}
+);
+width = 645;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165E;
+unicode = 5726;
+},
+{
+color = 9;
+glyphname = "tsiCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(508,-14,o),
+(585,121,o),
+(585,231,cs),
+(585,303,o),
+(550,357,o),
+(489,371,c),
+(477,340,l),
+(605,358,o),
+(656,474,o),
+(656,566,cs),
+(656,661,o),
+(598,728,o),
+(510,728,cs),
+(405,728,o),
+(326,635,o),
+(291,635,cs),
+(276,635,o),
+(272,646,o),
+(278,677,cs),
+(287,714,l),
+(154,714,l),
+(139,645,ls),
+(121,558,o),
+(154,514,o),
+(227,514,cs),
+(251,514,o),
+(273,519,o),
+(289,528,c),
+(252,579,l),
+(215,403,l),
+(158,403,l),
+(172,472,l),
+(102,472,l),
+(53,242,l),
+(123,242,l),
+(138,311,l),
+(196,311,l),
+(158,135,l),
+(214,186,l),
+(198,194,o),
+(181,200,o),
+(156,200,cs),
+(84,200,o),
+(37,161,o),
+(17,69,cs),
+(3,0,l),
+(135,0,l),
+(140,26,ls),
+(148,64,o),
+(160,79,o),
+(179,79,cs),
+(227,79,o),
+(274,-14,o),
+(380,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(324,117,o),
+(279,155,o),
+(245,175,c),
+(274,311,l),
+(296,311,l),
+(306,281,o),
+(332,259,o),
+(366,259,cs),
+(399,259,o),
+(422,278,o),
+(437,315,c),
+(361,311,l),
+(375,311,ls),
+(420,311,o),
+(445,283,o),
+(445,232,cs),
+(445,181,o),
+(417,117,o),
+(362,117,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(439,429,o),
+(408,456,o),
+(373,456,cs),
+(342,456,o),
+(311,433,o),
+(303,403,c),
+(293,403,l),
+(323,540,l),
+(360,556,o),
+(416,597,o),
+(458,597,cs),
+(490,597,o),
+(511,573,o),
+(511,536,cs),
+(511,476,o),
+(476,403,o),
+(401,403,cs),
+(382,403,l),
+(447,391,l)
+);
+}
+);
+width = 645;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165F;
+unicode = 5727;
+},
+{
+color = 9;
+glyphname = "tsaCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(285,-14,o),
+(363,79,o),
+(399,79,cs),
+(413,79,o),
+(418,68,o),
+(411,38,cs),
+(403,0,l),
+(535,0,l),
+(550,69,ls),
+(569,156,o),
+(536,200,o),
+(463,200,cs),
+(436,200,o),
+(413,194,o),
+(395,185,c),
+(419,135,l),
+(456,309,l),
+(525,309,l),
+(511,242,l),
+(588,242,l),
+(637,472,l),
+(560,472,l),
+(545,405,l),
+(477,405,l),
+(514,579,l),
+(470,529,l),
+(487,521,o),
+(507,514,o),
+(533,514,cs),
+(606,514,o),
+(653,553,o),
+(672,645,cs),
+(687,714,l),
+(555,714,l),
+(549,688,ls),
+(541,650,o),
+(529,635,o),
+(510,635,cs),
+(463,635,o),
+(416,728,o),
+(310,728,cs),
+(182,728,o),
+(105,594,o),
+(105,483,cs),
+(105,411,o),
+(140,357,o),
+(201,343,c),
+(212,374,l),
+(85,356,o),
+(33,240,o),
+(33,148,cs),
+(33,53,o),
+(91,-14,o),
+(180,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,117,o),
+(181,141,o),
+(181,178,cs),
+(181,238,o),
+(216,309,o),
+(291,309,cs),
+(366,309,l),
+(334,159,l),
+(297,139,o),
+(263,117,o),
+(232,117,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(269,405,o),
+(244,431,o),
+(244,482,cs),
+(244,524,o),
+(270,597,o),
+(328,597,cs),
+(359,597,o),
+(386,575,o),
+(418,555,c),
+(386,405,l),
+(316,405,ls)
+);
+}
+);
+width = 645;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1660;
+unicode = 5728;
+},
+{
+color = 9;
+glyphname = "chuCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(272,-14,o),
+(337,30,o),
+(376,112,c),
+(338,116,l),
+(347,29,o),
+(399,-14,o),
+(491,-14,cs),
+(623,-14,o),
+(683,83,o),
+(700,214,cs),
+(712,297,o),
+(703,441,o),
+(713,512,cs),
+(718,558,o),
+(735,588,o),
+(773,588,cs),
+(790,588,l),
+(816,714,l),
+(761,714,ls),
+(648,714,o),
+(598,648,o),
+(582,538,cs),
+(570,461,o),
+(569,297,o),
+(561,231,cs),
+(557,175,o),
+(538,119,o),
+(483,119,cs),
+(431,119,o),
+(429,170,o),
+(438,211,cs),
+(523,615,l),
+(571,615,l),
+(592,714,l),
+(367,714,l),
+(347,615,l),
+(395,615,l),
+(308,207,ls),
+(296,147,o),
+(271,119,o),
+(231,119,cs),
+(199,119,o),
+(181,137,o),
+(181,172,cs),
+(181,251,o),
+(316,504,o),
+(316,607,cs),
+(316,677,o),
+(276,714,o),
+(198,714,cs),
+(143,714,l),
+(117,588,l),
+(133,588,ls),
+(158,588,o),
+(170,576,o),
+(170,551,cs),
+(170,470,o),
+(33,272,o),
+(33,144,cs),
+(33,49,o),
+(93,-14,o),
+(190,-14,cs)
+);
+}
+);
+width = 764;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164E;
+unicode = 5729;
+},
+{
+color = 9;
+glyphname = "choCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(46,0,ls),
+(160,0,o),
+(210,66,o),
+(225,176,cs),
+(237,253,o),
+(238,417,o),
+(246,483,cs),
+(250,539,o),
+(270,595,o),
+(324,595,cs),
+(377,595,o),
+(378,544,o),
+(370,503,cs),
+(284,99,l),
+(236,99,l),
+(216,0,l),
+(440,0,l),
+(461,99,l),
+(413,99,l),
+(499,507,ls),
+(512,567,o),
+(536,595,o),
+(576,595,cs),
+(609,595,o),
+(626,577,o),
+(626,542,cs),
+(626,463,o),
+(491,210,o),
+(491,107,cs),
+(491,37,o),
+(531,0,o),
+(610,0,cs),
+(663,0,l),
+(690,126,l),
+(674,126,ls),
+(649,126,o),
+(637,138,o),
+(637,163,cs),
+(637,244,o),
+(774,442,o),
+(774,570,cs),
+(774,665,o),
+(714,728,o),
+(617,728,cs),
+(535,728,o),
+(470,684,o),
+(432,602,c),
+(469,598,l),
+(460,685,o),
+(408,728,o),
+(316,728,cs),
+(184,728,o),
+(124,631,o),
+(107,500,cs),
+(95,417,o),
+(104,273,o),
+(94,202,cs),
+(89,156,o),
+(72,126,o),
+(34,126,cs),
+(18,126,l),
+(-9,0,l)
+);
+}
+);
+width = 762;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5730;
+},
+{
+color = 9;
+glyphname = "cheCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(508,-14,o),
+(585,120,o),
+(585,231,cs),
+(585,303,o),
+(550,357,o),
+(489,371,c),
+(477,340,l),
+(605,358,o),
+(656,474,o),
+(656,566,cs),
+(656,661,o),
+(598,728,o),
+(510,728,cs),
+(405,728,o),
+(326,635,o),
+(291,635,cs),
+(276,635,o),
+(272,646,o),
+(278,676,cs),
+(287,714,l),
+(154,714,l),
+(139,645,ls),
+(121,558,o),
+(154,512,o),
+(228,512,cs),
+(324,512,o),
+(395,597,o),
+(457,597,cs),
+(489,597,o),
+(507,573,o),
+(507,536,cs),
+(507,476,o),
+(473,416,o),
+(397,416,cs),
+(167,416,l),
+(179,472,l),
+(102,472,l),
+(53,242,l),
+(130,242,l),
+(141,298,l),
+(371,298,ls),
+(418,298,o),
+(443,274,o),
+(443,232,cs),
+(443,190,o),
+(417,117,o),
+(359,117,cs),
+(298,117,o),
+(253,202,o),
+(156,202,cs),
+(84,202,o),
+(36,158,o),
+(17,69,cs),
+(3,0,l),
+(135,0,l),
+(140,26,ls),
+(148,64,o),
+(160,79,o),
+(179,79,cs),
+(227,79,o),
+(274,-14,o),
+(380,-14,cs)
+);
+}
+);
+width = 645;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni1663;
+unicode = 5731;
+},
+{
+color = 9;
+glyphname = "cheeCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(508,-14,o),
+(585,120,o),
+(585,231,cs),
+(585,303,o),
+(550,357,o),
+(489,371,c),
+(477,340,l),
+(605,358,o),
+(656,474,o),
+(656,566,cs),
+(656,661,o),
+(598,728,o),
+(510,728,cs),
+(405,728,o),
+(326,635,o),
+(291,635,cs),
+(276,635,o),
+(272,646,o),
+(278,676,cs),
+(287,714,l),
+(154,714,l),
+(139,645,ls),
+(121,558,o),
+(153,511,o),
+(227,511,cs),
+(324,511,o),
+(394,599,o),
+(456,599,cs),
+(488,599,o),
+(510,573,o),
+(510,536,cs),
+(510,476,o),
+(476,405,o),
+(401,405,cs),
+(358,405,l),
+(384,385,l),
+(406,488,l),
+(329,488,l),
+(311,405,l),
+(164,405,l),
+(179,472,l),
+(102,472,l),
+(53,242,l),
+(130,242,l),
+(144,309,l),
+(292,309,l),
+(274,223,l),
+(350,223,l),
+(374,336,l),
+(342,309,l),
+(381,309,ls),
+(428,309,o),
+(445,274,o),
+(445,232,cs),
+(445,190,o),
+(418,115,o),
+(360,115,cs),
+(299,115,o),
+(252,203,o),
+(156,203,cs),
+(83,203,o),
+(36,158,o),
+(17,69,cs),
+(3,0,l),
+(135,0,l),
+(140,26,ls),
+(148,64,o),
+(160,79,o),
+(179,79,cs),
+(227,79,o),
+(274,-14,o),
+(380,-14,cs)
+);
+}
+);
+width = 645;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1664;
+unicode = 5732;
+},
+{
+color = 9;
+glyphname = "chiCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(508,-14,o),
+(585,120,o),
+(585,231,cs),
+(585,303,o),
+(550,357,o),
+(489,371,c),
+(477,340,l),
+(605,358,o),
+(656,474,o),
+(656,566,cs),
+(656,661,o),
+(598,728,o),
+(510,728,cs),
+(405,728,o),
+(326,635,o),
+(291,635,cs),
+(276,635,o),
+(272,646,o),
+(278,676,cs),
+(287,714,l),
+(154,714,l),
+(139,645,ls),
+(121,558,o),
+(153,511,o),
+(227,511,cs),
+(324,511,o),
+(394,599,o),
+(456,599,cs),
+(488,599,o),
+(510,573,o),
+(510,536,cs),
+(510,476,o),
+(476,405,o),
+(407,405,cs),
+(362,405,l),
+(405,383,l),
+(396,425,o),
+(359,456,o),
+(314,456,cs),
+(274,456,o),
+(246,435,o),
+(229,405,c),
+(164,405,l),
+(179,472,l),
+(102,472,l),
+(53,242,l),
+(130,242,l),
+(144,309,l),
+(230,309,l),
+(245,282,o),
+(272,259,o),
+(314,259,cs),
+(361,259,o),
+(395,290,o),
+(406,337,c),
+(347,309,l),
+(388,309,ls),
+(425,309,o),
+(445,280,o),
+(445,232,cs),
+(445,190,o),
+(418,115,o),
+(360,115,cs),
+(299,115,o),
+(252,203,o),
+(156,203,cs),
+(83,203,o),
+(36,158,o),
+(17,69,cs),
+(3,0,l),
+(135,0,l),
+(140,26,ls),
+(148,64,o),
+(160,79,o),
+(179,79,cs),
+(227,79,o),
+(274,-14,o),
+(380,-14,cs)
+);
+}
+);
+width = 645;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1665;
+unicode = 5733;
+},
+{
+color = 9;
+glyphname = "chaCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(285,-12,o),
+(364,81,o),
+(399,81,cs),
+(414,81,o),
+(418,70,o),
+(412,39,cs),
+(404,2,l),
+(536,2,l),
+(551,71,ls),
+(570,158,o),
+(537,204,o),
+(463,204,cs),
+(366,204,o),
+(296,119,o),
+(234,119,cs),
+(202,119,o),
+(183,143,o),
+(183,180,cs),
+(183,240,o),
+(218,300,o),
+(293,300,cs),
+(523,300,l),
+(512,244,l),
+(589,244,l),
+(637,474,l),
+(561,474,l),
+(549,418,l),
+(319,418,ls),
+(272,418,o),
+(248,442,o),
+(248,484,cs),
+(248,525,o),
+(273,599,o),
+(332,599,cs),
+(392,599,o),
+(438,514,o),
+(534,514,cs),
+(606,514,o),
+(654,558,o),
+(673,647,cs),
+(688,716,l),
+(556,716,l),
+(550,690,ls),
+(542,652,o),
+(530,637,o),
+(511,637,cs),
+(464,637,o),
+(417,730,o),
+(311,730,cs),
+(183,730,o),
+(105,595,o),
+(105,485,cs),
+(105,413,o),
+(141,359,o),
+(201,345,c),
+(213,376,l),
+(86,358,o),
+(34,242,o),
+(34,150,cs),
+(34,55,o),
+(92,-12,o),
+(181,-12,cs)
+);
+}
+);
+width = 646;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1666;
+unicode = 5734;
+},
+{
+color = 9;
+glyphname = "ttsuCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(272,-14,o),
+(337,30,o),
+(376,112,c),
+(338,116,l),
+(347,29,o),
+(399,-14,o),
+(491,-14,cs),
+(623,-14,o),
+(683,83,o),
+(700,214,cs),
+(712,297,o),
+(703,441,o),
+(713,512,cs),
+(718,558,o),
+(735,588,o),
+(773,588,cs),
+(790,588,l),
+(816,714,l),
+(761,714,ls),
+(648,714,o),
+(598,648,o),
+(582,538,cs),
+(577,506,o),
+(574,475,o),
+(570,444,c),
+(632,555,l),
+(489,453,l),
+(523,615,l),
+(571,615,l),
+(592,714,l),
+(367,714,l),
+(347,615,l),
+(395,615,l),
+(361,456,l),
+(247,566,l),
+(277,452,l),
+(299,514,o),
+(316,569,o),
+(316,607,cs),
+(316,677,o),
+(276,714,o),
+(198,714,cs),
+(143,714,l),
+(117,588,l),
+(133,588,ls),
+(158,588,o),
+(170,576,o),
+(170,551,cs),
+(170,470,o),
+(33,272,o),
+(33,144,cs),
+(33,49,o),
+(93,-14,o),
+(190,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,119,o),
+(181,137,o),
+(181,172,cs),
+(181,218,o),
+(222,304,o),
+(257,390,c),
+(332,319,l),
+(308,207,ls),
+(296,147,o),
+(271,119,o),
+(231,119,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(431,119,o),
+(429,170,o),
+(438,211,cs),
+(458,305,l),
+(567,379,l),
+(565,322,o),
+(564,267,o),
+(561,231,cs),
+(557,175,o),
+(538,119,o),
+(483,119,cs)
+);
+}
+);
+width = 764;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1667;
+unicode = 5735;
+},
+{
+color = 9;
+glyphname = "ttsoCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(46,0,ls),
+(160,0,o),
+(210,66,o),
+(225,176,cs),
+(230,208,o),
+(233,239,o),
+(237,270,c),
+(175,159,l),
+(318,261,l),
+(284,99,l),
+(236,99,l),
+(216,0,l),
+(440,0,l),
+(461,99,l),
+(413,99,l),
+(446,258,l),
+(560,148,l),
+(530,262,l),
+(508,200,o),
+(491,145,o),
+(491,107,cs),
+(491,37,o),
+(531,0,o),
+(610,0,cs),
+(664,0,l),
+(691,126,l),
+(674,126,ls),
+(649,126,o),
+(637,138,o),
+(637,163,cs),
+(637,244,o),
+(774,442,o),
+(774,570,cs),
+(774,665,o),
+(714,728,o),
+(617,728,cs),
+(535,728,o),
+(470,684,o),
+(432,602,c),
+(469,598,l),
+(460,685,o),
+(408,728,o),
+(316,728,cs),
+(184,728,o),
+(124,631,o),
+(107,500,cs),
+(95,417,o),
+(104,273,o),
+(94,202,cs),
+(89,156,o),
+(72,126,o),
+(34,126,cs),
+(18,126,l),
+(-9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(242,392,o),
+(243,447,o),
+(246,483,cs),
+(250,539,o),
+(270,595,o),
+(324,595,cs),
+(377,595,o),
+(378,544,o),
+(370,503,cs),
+(350,409,l),
+(240,335,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(475,395,l),
+(499,507,ls),
+(512,567,o),
+(536,595,o),
+(576,595,cs),
+(609,595,o),
+(626,577,o),
+(626,542,cs),
+(626,496,o),
+(585,410,o),
+(551,324,c)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1668;
+unicode = 5736;
+},
+{
+color = 9;
+glyphname = "ttseCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(506,-14,o),
+(585,120,o),
+(585,230,cs),
+(585,304,o),
+(550,356,o),
+(488,371,c),
+(476,340,l),
+(605,358,o),
+(656,472,o),
+(656,565,cs),
+(656,660,o),
+(598,728,o),
+(509,728,cs),
+(404,728,o),
+(326,635,o),
+(290,635,cs),
+(276,635,o),
+(271,646,o),
+(278,676,cs),
+(286,714,l),
+(154,714,l),
+(139,645,ls),
+(120,558,o),
+(152,511,o),
+(227,511,cs),
+(242,511,o),
+(255,513,o),
+(268,516,c),
+(205,582,l),
+(233,405,l),
+(164,405,l),
+(179,472,l),
+(102,472,l),
+(53,242,l),
+(130,242,l),
+(144,309,l),
+(213,309,l),
+(114,139,l),
+(207,195,l),
+(192,200,o),
+(175,203,o),
+(156,203,cs),
+(82,203,o),
+(36,159,o),
+(17,69,cs),
+(2,0,l),
+(134,0,l),
+(140,26,ls),
+(148,64,o),
+(160,79,o),
+(179,79,cs),
+(226,79,o),
+(273,-14,o),
+(379,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(318,114,o),
+(286,154,o),
+(244,176,c),
+(319,309,l),
+(386,309,ls),
+(426,309,o),
+(447,282,o),
+(447,241,cs),
+(447,196,o),
+(419,114,o),
+(359,114,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(313,534,l),
+(365,555,o),
+(412,600,o),
+(456,600,cs),
+(490,600,o),
+(510,573,o),
+(510,533,cs),
+(510,479,o),
+(476,405,o),
+(403,405,cs),
+(331,405,l)
+);
+}
+);
+width = 646;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1669;
+unicode = 5737;
+},
+{
+color = 9;
+glyphname = "ttseeCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(506,-14,o),
+(585,120,o),
+(585,230,cs),
+(585,304,o),
+(550,356,o),
+(488,371,c),
+(476,340,l),
+(605,358,o),
+(656,472,o),
+(656,565,cs),
+(656,660,o),
+(598,728,o),
+(509,728,cs),
+(404,728,o),
+(326,635,o),
+(290,635,cs),
+(276,635,o),
+(271,646,o),
+(278,676,cs),
+(286,714,l),
+(154,714,l),
+(139,645,ls),
+(120,558,o),
+(152,511,o),
+(227,511,cs),
+(242,511,o),
+(255,513,o),
+(268,516,c),
+(200,582,l),
+(227,405,l),
+(164,405,l),
+(179,472,l),
+(102,472,l),
+(53,242,l),
+(130,242,l),
+(144,309,l),
+(208,309,l),
+(109,139,l),
+(207,195,l),
+(192,200,o),
+(175,203,o),
+(156,203,cs),
+(82,203,o),
+(36,159,o),
+(17,69,cs),
+(2,0,l),
+(134,0,l),
+(140,26,ls),
+(148,64,o),
+(160,79,o),
+(179,79,cs),
+(226,79,o),
+(273,-14,o),
+(379,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(317,114,o),
+(274,165,o),
+(231,184,c),
+(303,309,l),
+(332,309,l),
+(312,215,l),
+(380,215,l),
+(403,326,l),
+(373,309,l),
+(386,309,ls),
+(426,309,o),
+(447,282,o),
+(447,241,cs),
+(447,196,o),
+(419,114,o),
+(359,114,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(439,496,l),
+(372,496,l),
+(352,405,l),
+(315,405,l),
+(297,525,l),
+(349,543,o),
+(409,600,o),
+(456,600,cs),
+(490,600,o),
+(510,573,o),
+(510,533,cs),
+(510,479,o),
+(476,405,o),
+(403,405,cs),
+(389,405,l),
+(416,387,l)
+);
+}
+);
+width = 646;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166A;
+unicode = 5738;
+},
+{
+color = 9;
+glyphname = "ttsiCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(506,-14,o),
+(585,120,o),
+(585,230,cs),
+(585,304,o),
+(550,356,o),
+(488,371,c),
+(476,340,l),
+(605,358,o),
+(656,472,o),
+(656,565,cs),
+(656,660,o),
+(598,728,o),
+(509,728,cs),
+(404,728,o),
+(326,635,o),
+(290,635,cs),
+(276,635,o),
+(271,646,o),
+(278,676,cs),
+(286,714,l),
+(154,714,l),
+(139,645,ls),
+(120,558,o),
+(152,511,o),
+(227,511,cs),
+(242,511,o),
+(255,513,o),
+(268,516,c),
+(200,582,l),
+(227,405,l),
+(164,405,l),
+(179,472,l),
+(102,472,l),
+(53,242,l),
+(130,242,l),
+(144,309,l),
+(208,309,l),
+(109,139,l),
+(207,195,l),
+(192,200,o),
+(175,203,o),
+(156,203,cs),
+(82,203,o),
+(36,159,o),
+(17,69,cs),
+(2,0,l),
+(134,0,l),
+(140,26,ls),
+(148,64,o),
+(160,79,o),
+(179,79,cs),
+(226,79,o),
+(273,-14,o),
+(379,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(317,114,o),
+(271,166,o),
+(229,185,c),
+(300,309,l),
+(297,309,l),
+(307,281,o),
+(339,259,o),
+(370,259,cs),
+(412,259,o),
+(438,292,o),
+(449,326,c),
+(373,309,l),
+(391,309,ls),
+(429,309,o),
+(447,282,o),
+(447,241,cs),
+(447,196,o),
+(419,114,o),
+(359,114,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(438,429,o),
+(409,456,o),
+(370,456,cs),
+(340,456,o),
+(307,435,o),
+(296,405,c),
+(310,405,l),
+(293,524,l),
+(345,541,o),
+(409,600,o),
+(456,600,cs),
+(490,600,o),
+(510,573,o),
+(510,533,cs),
+(510,479,o),
+(479,405,o),
+(405,405,cs),
+(389,405,l),
+(450,387,l)
+);
+}
+);
+width = 646;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166B;
+unicode = 5739;
+},
+{
+color = 9;
+glyphname = "ttsaCarrier-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(286,-14,o),
+(365,79,o),
+(400,79,cs),
+(415,79,o),
+(419,68,o),
+(413,38,cs),
+(405,0,l),
+(537,0,l),
+(552,69,ls),
+(570,156,o),
+(538,203,o),
+(464,203,cs),
+(449,203,o),
+(436,201,o),
+(423,198,c),
+(485,132,l),
+(458,309,l),
+(526,309,l),
+(512,242,l),
+(588,242,l),
+(637,472,l),
+(561,472,l),
+(546,405,l),
+(477,405,l),
+(576,575,l),
+(484,519,l),
+(499,514,o),
+(516,511,o),
+(535,511,cs),
+(609,511,o),
+(654,555,o),
+(674,645,cs),
+(689,714,l),
+(556,714,l),
+(551,688,ls),
+(543,650,o),
+(531,635,o),
+(512,635,cs),
+(464,635,o),
+(418,728,o),
+(312,728,cs),
+(184,728,o),
+(106,594,o),
+(106,484,cs),
+(106,410,o),
+(141,358,o),
+(203,343,c),
+(215,374,l),
+(86,356,o),
+(34,242,o),
+(34,149,cs),
+(34,54,o),
+(92,-14,o),
+(182,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(201,114,o),
+(181,141,o),
+(181,181,cs),
+(181,235,o),
+(214,309,o),
+(288,309,cs),
+(360,309,l),
+(378,180,l),
+(326,159,o),
+(279,114,o),
+(235,114,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(265,405,o),
+(243,432,o),
+(243,473,cs),
+(243,518,o),
+(271,600,o),
+(331,600,cs),
+(372,600,o),
+(405,560,o),
+(447,538,c),
+(372,405,l),
+(304,405,ls)
+);
+}
+);
+width = 646;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni166C;
+unicode = 5740;
+},
+{
+glyphname = "qai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (287,0);
+ref = "ke-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni166F;
+unicode = 5743;
+},
+{
+glyphname = "ngai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (535,0);
+ref = "ce-canadian";
+}
+);
+width = 1052;
+}
+);
+note = uni1670;
+unicode = 5744;
+},
+{
+glyphname = "nngi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (793,0);
+ref = "ci-canadian";
+}
+);
+width = 1310;
+}
+);
+note = uni1671;
+unicode = 5745;
+},
+{
+glyphname = "nngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (793,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (974,0);
+ref = dot_top;
+}
+);
+width = 1310;
+}
+);
+note = uni1672;
+unicode = 5746;
+},
+{
+glyphname = "nngo-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (793,0);
+ref = "ce-canadian";
+}
+);
+width = 1310;
+}
+);
+note = uni1673;
+unicode = 5747;
+},
+{
+glyphname = "nngoo-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (793,0);
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (960,0);
+ref = dot_top;
+}
+);
+width = 1310;
+}
+);
+note = uni1674;
+unicode = 5748;
+},
+{
+glyphname = "nnga-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (793,0);
+ref = "ca-canadian";
+}
+);
+width = 1310;
+}
+);
+note = uni1675;
+unicode = 5749;
+},
+{
+glyphname = "nngaa-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (793,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (830,0);
+ref = dot_top;
+}
+);
+width = 1310;
+}
+);
+note = uni1676;
+unicode = 5750;
+},
+{
+glyphname = "thweeWoodScree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (543,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 754;
+}
+);
+note = uni1677;
+unicode = 5751;
+},
+{
+glyphname = "thwiWoodScree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (543,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 754;
+}
+);
+note = uni1678;
+unicode = 5752;
+},
+{
+glyphname = "thwiiWoodScree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (72,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (543,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 754;
+}
+);
+note = uni1679;
+unicode = 5753;
+},
+{
+glyphname = "thwoWoodScree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (543,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 754;
+}
+);
+note = uni167A;
+unicode = 5754;
+},
+{
+glyphname = "thwooWoodScree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (297,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (543,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 754;
+}
+);
+note = uni167B;
+unicode = 5755;
+},
+{
+glyphname = "thwaWoodScree-canadian";
+lastChange = "2023-01-13 15:31:56 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = middle_right_can;
+pos = (544,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 755;
+}
+);
+note = uni167C;
+unicode = 5756;
+},
+{
+glyphname = "thwaaWoodScree-canadian";
+lastChange = "2023-01-13 15:31:56 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (73,0);
+ref = dot_top;
+},
+{
+anchor = middle_right_can;
+pos = (544,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 755;
+}
+);
+note = uni167D;
+unicode = 5757;
+},
+{
+glyphname = "wBlackfoot-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(392,567,l),
+(409,650,l),
+(130,650,l),
+(112,567,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(361,421,l),
+(378,504,l),
+(98,504,l),
+(81,421,l)
+);
+}
+);
+width = 370;
+}
+);
+metricRight = "=|";
+note = uni167F;
+unicode = 5759;
+},
+{
+glyphname = "oy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-11,0);
+ref = ring_top.canadian;
+}
+);
+width = 592;
+}
+);
+note = uni18B0;
+unicode = 6320;
+},
+{
+glyphname = "ay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (355,0);
+ref = ring_top.canadian;
+}
+);
+width = 592;
+}
+);
+note = uni18B1;
+unicode = 6321;
+},
+{
+glyphname = "aay-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (136,0);
+ref = ring_top.canadian;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (389,0);
+ref = dot_top;
+}
+);
+width = 592;
+}
+);
+note = uni18B2;
+unicode = 6322;
+},
+{
+glyphname = "way-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (566,0);
+ref = ring_top.canadian;
+}
+);
+width = 803;
+}
+);
+note = uni18B3;
+unicode = 6323;
+},
+{
+glyphname = "poy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-22,0);
+ref = ring_top.canadian;
+}
+);
+width = 573;
+}
+);
+note = uni18B4;
+unicode = 6324;
+},
+{
+glyphname = "pay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (354,0);
+ref = ring_top.canadian;
+}
+);
+width = 573;
+}
+);
+note = uni18B5;
+unicode = 6325;
+},
+{
+glyphname = "pwoy-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (189,0);
+ref = ring_top.canadian;
+}
+);
+width = 784;
+}
+);
+note = uni18B6;
+unicode = 6326;
+},
+{
+glyphname = "tay-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (175,0);
+ref = ring_top.canadian;
+}
+);
+width = 540;
+}
+);
+note = uni18B7;
+unicode = 6327;
+},
+{
+glyphname = "kay-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (2,0);
+ref = ring_top.canadian;
+}
+);
+width = 529;
+}
+);
+note = uni18B8;
+unicode = 6328;
+},
+{
+glyphname = "kway-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (213,0);
+ref = ring_top.canadian;
+}
+);
+width = 740;
+}
+);
+note = uni18B9;
+unicode = 6329;
+},
+{
+glyphname = "may-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (6,0);
+ref = ring_top.canadian;
+}
+);
+width = 486;
+}
+);
+note = uni18BA;
+unicode = 6330;
+},
+{
+glyphname = "noy-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (283,-188);
+ref = ring_top.canadian;
+}
+);
+width = 708;
+}
+);
+note = uni18BB;
+unicode = 6331;
+},
+{
+glyphname = "nay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (101,-188);
+ref = ring_top.canadian;
+}
+);
+width = 708;
+}
+);
+note = uni18BC;
+unicode = 6332;
+},
+{
+glyphname = "lay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (102,-188);
+ref = ring_top.canadian;
+}
+);
+width = 708;
+}
+);
+note = uni18BD;
+unicode = 6333;
+},
+{
+glyphname = "soy-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (240,0);
+ref = ring_top.canadian;
+}
+);
+width = 489;
+}
+);
+note = uni18BE;
+unicode = 6334;
+},
+{
+glyphname = "say-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (6,0);
+ref = ring_top.canadian;
+}
+);
+width = 489;
+}
+);
+note = uni18BF;
+unicode = 6335;
+},
+{
+glyphname = "shoy-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (237,-188);
+ref = ring_top.canadian;
+}
+);
+width = 796;
+}
+);
+note = uni18C0;
+unicode = 6336;
+},
+{
+glyphname = "shay-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (237,-188);
+ref = ring_top.canadian;
+}
+);
+width = 796;
+}
+);
+note = uni18C1;
+unicode = 6337;
+},
+{
+glyphname = "shwoy-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (448,-188);
+ref = ring_top.canadian;
+}
+);
+width = 1007;
+}
+);
+note = uni18C2;
+unicode = 6338;
+},
+{
+glyphname = "yoy-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (263,0);
+ref = ring_top.canadian;
+}
+);
+width = 510;
+}
+);
+note = uni18C3;
+unicode = 6339;
+},
+{
+glyphname = "yay-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (5,0);
+ref = ring_top.canadian;
+}
+);
+width = 510;
+}
+);
+note = uni18C4;
+unicode = 6340;
+},
+{
+glyphname = "ray-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (151,0);
+ref = ring_top.canadian;
+}
+);
+width = 490;
+}
+);
+note = uni18C5;
+unicode = 6341;
+},
+{
+glyphname = "nwi-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ni-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni18C6;
+unicode = 6342;
+},
+{
+glyphname = "nwiOjibway-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (708,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni18C7;
+unicode = 6343;
+},
+{
+glyphname = "nwii-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (365,-188);
+ref = dot_top;
+}
+);
+width = 919;
+}
+);
+note = uni18C8;
+unicode = 6344;
+},
+{
+glyphname = "nwiiOjibway-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (154,-188);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (708,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni18C9;
+unicode = 6345;
+},
+{
+glyphname = "nwo-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "no-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni18CA;
+unicode = 6346;
+},
+{
+glyphname = "nwoOjibway-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (708,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni18CB;
+unicode = 6347;
+},
+{
+glyphname = "nwoo-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (528,-188);
+ref = dot_top;
+}
+);
+width = 919;
+}
+);
+note = uni18CC;
+unicode = 6348;
+},
+{
+glyphname = "nwooOjibway-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (317,-188);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (708,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni18CD;
+unicode = 6349;
+},
+{
+glyphname = "rwee-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "reRCree-canadian";
+}
+);
+width = 955;
+}
+);
+note = uni18CE;
+unicode = 6350;
+},
+{
+glyphname = "rwi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ri-canadian";
+}
+);
+width = 955;
+}
+);
+note = uni18CF;
+unicode = 6351;
+},
+{
+glyphname = "rwii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (355,-188);
+ref = dot_top;
+}
+);
+width = 955;
+}
+);
+note = uni18D0;
+unicode = 6352;
+},
+{
+glyphname = "rwo-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ro-canadian";
+}
+);
+width = 701;
+}
+);
+note = uni18D1;
+unicode = 6353;
+},
+{
+glyphname = "rwoo-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (341,0);
+ref = dot_top;
+}
+);
+width = 701;
+}
+);
+note = uni18D2;
+unicode = 6354;
+},
+{
+glyphname = "rwa-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ra-canadian";
+}
+);
+width = 701;
+}
+);
+note = uni18D3;
+unicode = 6355;
+},
+{
+glyphname = "pOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(144,357,l),
+(283,604,l),
+(222,604,l),
+(257,357,l),
+(346,357,l),
+(350,375,l),
+(283,714,l),
+(262,714,l),
+(51,375,l),
+(47,357,l)
+);
+}
+);
+width = 349;
+}
+);
+metricLeft = "kkCarrier-canadian";
+note = uni18D4;
+unicode = 6356;
+},
+{
+glyphname = "tOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 375;
+}
+);
+metricRight = "=|";
+note = uni1422;
+unicode = 6357;
+},
+{
+glyphname = "kOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(163,357,l),
+(196,509,l),
+(176,508,l),
+(173,475,o),
+(200,449,o),
+(239,449,cs),
+(324,449,o),
+(363,548,o),
+(363,611,cs),
+(363,678,o),
+(322,721,o),
+(253,721,cs),
+(182,721,o),
+(133,677,o),
+(114,584,cs),
+(66,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(211,521,o),
+(201,533,o),
+(201,556,cs),
+(201,583,o),
+(217,649,o),
+(251,649,cs),
+(268,649,o),
+(278,636,o),
+(278,614,cs),
+(278,585,o),
+(261,521,o),
+(228,521,cs)
+);
+}
+);
+width = 326;
+}
+);
+metricLeft = "k-canadian";
+metricRight = "k-canadian";
+note = uni18D6;
+unicode = 6358;
+},
+{
+glyphname = "cOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(165,357,l),
+(217,604,ls),
+(223,632,o),
+(236,644,o),
+(255,644,cs),
+(276,644,o),
+(285,627,o),
+(279,602,cs),
+(271,564,l),
+(361,564,l),
+(365,584,ls),
+(381,663,o),
+(342,720,o),
+(256,720,cs),
+(182,720,o),
+(135,677,o),
+(118,597,cs),
+(67,357,l)
+);
+}
+);
+width = 320;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni18D7;
+unicode = 6359;
+},
+{
+glyphname = "mOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(165,357,l),
+(221,622,l),
+(344,622,l),
+(363,714,l),
+(143,714,l),
+(67,357,l)
+);
+}
+);
+width = 295;
+}
+);
+metricLeft = "m-canadian";
+metricRight = "m-canadian";
+note = uni18D8;
+unicode = 6360;
+},
+{
+glyphname = "nOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(302,443,o),
+(350,528,o),
+(350,604,cs),
+(350,624,o),
+(345,644,o),
+(333,659,c),
+(320,622,l),
+(455,622,l),
+(475,714,l),
+(247,714,ls),
+(150,714,o),
+(103,632,o),
+(103,551,cs),
+(103,486,o),
+(145,443,o),
+(211,443,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(198,514,o),
+(188,528,o),
+(188,552,cs),
+(188,582,o),
+(202,643,o),
+(237,643,cs),
+(255,643,o),
+(265,629,o),
+(265,605,cs),
+(265,575,o),
+(251,514,o),
+(216,514,cs)
+);
+}
+);
+width = 405;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "n-canadian";
+note = uni18D9;
+unicode = 6361;
+},
+{
+glyphname = "sOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(164,357,l),
+(194,502,l),
+(122,466,l),
+(160,466,ls),
+(262,466,o),
+(325,524,o),
+(349,637,cs),
+(365,714,l),
+(267,714,l),
+(253,644,ls),
+(238,572,o),
+(203,542,o),
+(135,542,cs),
+(105,542,l),
+(66,357,l)
+);
+}
+);
+width = 311;
+}
+);
+metricLeft = "s-canadian";
+metricRight = "s-canadian";
+note = uni18DA;
+unicode = 6362;
+},
+{
+color = 1;
+glyphname = "shOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(252,354,o),
+(296,396,o),
+(321,483,cs),
+(354,600,ls),
+(363,634,o),
+(374,647,o),
+(394,647,cs),
+(413,647,o),
+(422,634,o),
+(417,607,cs),
+(408,567,l),
+(497,567,l),
+(503,594,ls),
+(520,671,o),
+(478,723,o),
+(398,723,cs),
+(326,723,o),
+(281,681,o),
+(256,593,cs),
+(224,477,ls),
+(214,443,o),
+(203,429,o),
+(183,429,cs),
+(164,429,o),
+(155,443,o),
+(160,470,cs),
+(169,510,l),
+(80,510,l),
+(74,482,ls),
+(57,405,o),
+(100,354,o),
+(180,354,cs)
+);
+}
+);
+width = 456;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "c-canadian";
+note = uni18DB;
+unicode = 6363;
+},
+{
+color = 9;
+glyphname = "easternw-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (-50,-318);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (156,0);
+ref = "glottalstop-canadian";
+}
+);
+width = 525;
+}
+);
+note = uni18DC;
+unicode = 6364;
+},
+{
+color = 9;
+glyphname = "westernw-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (697,-318);
+ref = dot_top;
+scale = (-1,1);
+},
+{
+alignment = -1;
+ref = "glottalstop-canadian";
+}
+);
+width = 525;
+}
+);
+metricLeft = "glottalstop-canadian";
+note = uni18DD;
+unicode = 6365;
+},
+{
+glyphname = "rweRCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "reRCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (744,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 955;
+}
+);
+note = uni18E0;
+unicode = 6368;
+},
+{
+glyphname = "looWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (40,0);
+ref = dot_top;
+}
+);
+width = 490;
+}
+);
+note = uni18E1;
+unicode = 6369;
+},
+{
+glyphname = "laaWestCree-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (275,0);
+ref = dot_top;
+}
+);
+width = 490;
+}
+);
+note = uni18E2;
+unicode = 6370;
+},
+{
+glyphname = "thwe-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "the-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (649,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 860;
+}
+);
+note = uni18E3;
+unicode = 6371;
+},
+{
+glyphname = "thwa-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (594,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 804;
+}
+);
+note = uni18E4;
+unicode = 6372;
+},
+{
+glyphname = "tthwe-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "tthe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (641,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 852;
+}
+);
+note = uni18E5;
+unicode = 6373;
+},
+{
+glyphname = "tthoo-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ttho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (169,0);
+ref = dot_top;
+}
+);
+width = 552;
+}
+);
+note = uni18E6;
+unicode = 6374;
+},
+{
+glyphname = "tthaa-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ttha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (184,0);
+ref = dot_top;
+}
+);
+width = 552;
+}
+);
+note = uni18E7;
+unicode = 6375;
+},
+{
+glyphname = "tlhwe-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "tlhe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (543,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 754;
+}
+);
+note = uni18E8;
+unicode = 6376;
+},
+{
+glyphname = "tlhoo-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "tlho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (191,0);
+ref = dot_top;
+}
+);
+width = 543;
+}
+);
+note = uni18E9;
+unicode = 6377;
+},
+{
+glyphname = "shweSayisi-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "sheSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (539,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 750;
+}
+);
+note = uni18EA;
+unicode = 6378;
+},
+{
+glyphname = "shooSayisi-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "shoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (328,0);
+ref = dot_top;
+}
+);
+width = 539;
+}
+);
+note = uni18EB;
+unicode = 6379;
+},
+{
+color = 9;
+glyphname = "hooSayisi-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "hoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (403,0);
+ref = dot_top;
+}
+);
+width = 616;
+}
+);
+note = uni18EC;
+unicode = 6380;
+},
+{
+color = 9;
+glyphname = "gwuCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "guCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (745,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 956;
+}
+);
+note = uni18ED;
+unicode = 6381;
+},
+{
+color = 9;
+glyphname = "deneGeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "geCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (238,0);
+ref = dot_top;
+}
+);
+width = 644;
+}
+);
+note = uni18EE;
+unicode = 6382;
+},
+{
+color = 9;
+glyphname = "gaaCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (249,0);
+ref = dot_top;
+}
+);
+width = 644;
+}
+);
+note = uni18EF;
+unicode = 6383;
+},
+{
+color = 9;
+glyphname = "gwaCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (644,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 855;
+}
+);
+note = uni18F0;
+unicode = 6384;
+},
+{
+color = 9;
+glyphname = "juuSayisi-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "juSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (242,0);
+ref = dot_top;
+}
+);
+width = 642;
+}
+);
+note = uni18F1;
+unicode = 6385;
+},
+{
+color = 9;
+glyphname = "jwaCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "jaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (693,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 904;
+}
+);
+note = uni18F2;
+unicode = 6386;
+},
+{
+glyphname = "lBeaverDene-canadian";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "pWestCree-canadian";
+}
+);
+width = 188;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+unicode = 6387;
+},
+{
+glyphname = "rBeaverDene-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(165,357,l),
+(205,546,ls),
+(215,595,o),
+(240,618,o),
+(281,618,cs),
+(290,618,l),
+(311,720,l),
+(306,720,ls),
+(257,720,o),
+(223,688,o),
+(209,628,c),
+(214,628,l),
+(232,714,l),
+(143,714,l),
+(67,357,l)
+);
+}
+);
+width = 239;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni18F4;
+unicode = 6388;
+},
+{
+color = 6;
+glyphname = "sDentalCarrier-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(180,189,ls),
+(272,189,o),
+(326,236,o),
+(326,317,cs),
+(326,370,o),
+(292,406,o),
+(235,406,cs),
+(208,406,ls),
+(184,406,o),
+(172,415,o),
+(172,432,cs),
+(172,454,o),
+(186,470,o),
+(215,470,cs),
+(355,470,l),
+(372,546,l),
+(229,546,ls),
+(137,546,o),
+(84,498,o),
+(84,418,cs),
+(84,365,o),
+(117,330,o),
+(174,330,cs),
+(201,330,ls),
+(225,330,o),
+(236,321,o),
+(236,304,cs),
+(236,282,o),
+(223,266,o),
+(194,266,cs),
+(53,266,l),
+(37,189,l)
+);
+}
+);
+width = 361;
+}
+);
+metricLeft = "shCarrier-canadian";
+metricRight = "=|";
+note = uni18F5;
+unicode = 6389;
+},
+{
+glyphname = "pWestCree-canadian.base";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "pWestCree-canadian";
+}
+);
+width = 188;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.base";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "c-canadian";
+}
+);
+width = 319;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "thSayisi-canadian.base";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "thSayisi-canadian";
+}
+);
+width = 320;
+}
+);
+metricLeft = "=|c-canadian";
+note = uni14A2;
+},
+{
+glyphname = "mWestCree-canadian.base";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "mWestCree-canadian";
+}
+);
+width = 314;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+glyphname = "pWestCree-canadian.mid";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "pWestCree-canadian";
+}
+);
+width = 187;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.mid";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "c-canadian";
+}
+);
+width = 319;
+}
+);
+metricLeft = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "mWestCree-canadian.mid";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "mWestCree-canadian";
+}
+);
+width = 314;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+color = 11;
+glyphname = "ngaai-canadian.nunavik";
+lastChange = "2023-01-13 15:31:56 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (571,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (719,0);
+ref = ring_top.canadian;
+}
+);
+width = 1091;
+}
+);
+note = uni158E;
+},
+{
+color = 11;
+glyphname = "ngi-canadian.nunavik";
+lastChange = "2023-01-13 15:31:56 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (571,0);
+ref = "ci-canadian";
+}
+);
+width = 1091;
+}
+);
+note = uni158F;
+},
+{
+color = 11;
+glyphname = "ngii-canadian.nunavik";
+lastChange = "2023-01-13 15:31:56 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (571,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (753,0);
+ref = dot_top;
+}
+);
+width = 1091;
+}
+);
+note = uni1590;
+},
+{
+color = 11;
+glyphname = "ngo-canadian.nunavik";
+lastChange = "2023-01-13 15:31:56 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (571,0);
+ref = "co-canadian";
+}
+);
+width = 1091;
+}
+);
+note = uni1591;
+},
+{
+color = 11;
+glyphname = "ngoo-canadian.nunavik";
+lastChange = "2023-01-13 15:31:56 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "ngo-canadian.nunavik";
+},
+{
+anchor = top_right_can;
+pos = (881,0);
+ref = dot_top;
+}
+);
+width = 1091;
+}
+);
+note = uni1592;
+},
+{
+color = 11;
+glyphname = "nga-canadian.nunavik";
+lastChange = "2023-01-13 15:31:56 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (571,0);
+ref = "ca-canadian";
+}
+);
+width = 1091;
+}
+);
+note = uni1593;
+},
+{
+color = 11;
+glyphname = "ngaa-canadian.nunavik";
+lastChange = "2023-01-13 15:31:56 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (571,0);
+ref = "ca-canadian";
+},
+{
+anchor = top_left_can;
+pos = (609,0);
+ref = dot_top;
+}
+);
+width = 1091;
+}
+);
+note = uni1594;
+},
+{
+color = 11;
+glyphname = "ng-canadian.nunavik";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(512,173,o),
+(551,276,o),
+(551,345,cs),
+(551,405,o),
+(519,444,o),
+(466,444,cs),
+(432,444,o),
+(406,426,o),
+(392,397,c),
+(413,389,l),
+(447,542,l),
+(305,542,l),
+(306,498,l),
+(336,526,o),
+(351,575,o),
+(351,612,cs),
+(351,677,o),
+(311,720,o),
+(243,720,cs),
+(151,720,o),
+(104,636,o),
+(104,560,cs),
+(104,493,o),
+(146,449,o),
+(215,449,cs),
+(371,449,l),
+(339,495,l),
+(302,323,ls),
+(287,255,o),
+(309,173,o),
+(407,173,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(397,244,o),
+(386,258,o),
+(386,281,cs),
+(386,308,o),
+(402,373,o),
+(435,373,cs),
+(452,373,o),
+(462,360,o),
+(462,337,cs),
+(462,309,o),
+(446,244,o),
+(414,244,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,520,o),
+(188,534,o),
+(188,558,cs),
+(188,586,o),
+(203,649,o),
+(237,649,cs),
+(256,649,o),
+(266,635,o),
+(266,611,cs),
+(266,584,o),
+(251,520,o),
+(216,520,cs)
+);
+}
+);
+width = 571;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+color = 11;
+glyphname = "ngai-canadian.nunavik";
+lastChange = "2023-01-13 15:31:56 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (571,0);
+ref = "ce-canadian";
+}
+);
+width = 1091;
+}
+);
+note = uni1670;
+},
+{
+color = 11;
+glyphname = "ke-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (410,714);
+},
+{
+name = top_left_can;
+pos = (221,714);
+},
+{
+name = top_right_can;
+pos = (604,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(525,0,l),
+(677,714,l),
+(458,714,ls),
+(209,714,o),
+(78,571,o),
+(78,377,cs),
+(78,231,o),
+(178,135,o),
+(339,135,cs),
+(406,135,l),
+(378,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(271,265,o),
+(224,307,o),
+(224,384,cs),
+(224,481,o),
+(276,585,o),
+(424,585,cs),
+(502,585,l),
+(434,265,l),
+(365,265,ls)
+);
+}
+);
+width = 632;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146B;
+},
+{
+color = 11;
+glyphname = "ki-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (419,714);
+},
+{
+name = top_left_can;
+pos = (225,714);
+},
+{
+name = top_right_can;
+pos = (612,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(146,0,l),
+(175,135,l),
+(251,135,ls),
+(496,135,o),
+(627,279,o),
+(627,472,cs),
+(627,619,o),
+(527,714,o),
+(366,714,cs),
+(151,714,l),
+(-1,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(271,585,l),
+(346,585,ls),
+(434,585,o),
+(481,542,o),
+(481,465,cs),
+(481,369,o),
+(431,265,o),
+(283,265,cs),
+(203,265,l)
+);
+}
+);
+width = 632;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni146D;
+},
+{
+color = 11;
+glyphname = "kii-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (234,0);
+ref = dot_top;
+}
+);
+width = 632;
+}
+);
+note = uni146E;
+},
+{
+color = 11;
+glyphname = "ko-canadian.square";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (411,714);
+},
+{
+name = top_left_can;
+pos = (222,714);
+},
+{
+name = top_right_can;
+pos = (605,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(526,0,l),
+(678,714,l),
+(531,714,l),
+(502,579,l),
+(426,579,ls),
+(181,579,o),
+(50,435,o),
+(50,242,cs),
+(50,95,o),
+(150,0,o),
+(311,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(243,129,o),
+(196,172,o),
+(196,249,cs),
+(196,345,o),
+(246,449,o),
+(394,449,cs),
+(475,449,l),
+(406,129,l),
+(331,129,ls)
+);
+}
+);
+width = 633;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146F;
+},
+{
+color = 11;
+glyphname = "koo-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (419,0);
+ref = dot_top;
+}
+);
+width = 632;
+}
+);
+note = uni1470;
+},
+{
+color = 11;
+glyphname = "ka-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (419,714);
+},
+{
+name = top_left_can;
+pos = (225,714);
+},
+{
+name = top_right_can;
+pos = (613,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(218,0,ls),
+(467,0,o),
+(598,143,o),
+(598,337,cs),
+(598,483,o),
+(498,579,o),
+(337,579,cs),
+(270,579,l),
+(298,714,l),
+(151,714,l),
+(-1,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(242,449,l),
+(310,449,ls),
+(405,449,o),
+(453,407,o),
+(453,330,cs),
+(453,233,o),
+(400,129,o),
+(252,129,cs),
+(174,129,l)
+);
+}
+);
+width = 632;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1472;
+},
+{
+color = 11;
+glyphname = "kaa-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (40,0);
+ref = dot_top;
+}
+);
+width = 632;
+}
+);
+note = uni1473;
+},
+{
+color = 11;
+glyphname = "kweWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (632,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 843;
+}
+);
+note = uni1475;
+},
+{
+color = 11;
+glyphname = "kwiiWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (234,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (632,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 843;
+}
+);
+note = uni1479;
+},
+{
+color = 11;
+glyphname = "kwoWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (632,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 843;
+}
+);
+note = uni147B;
+},
+{
+color = 11;
+glyphname = "kwooWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (419,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (632,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 843;
+}
+);
+note = uni147D;
+},
+{
+color = 11;
+glyphname = "kwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (632,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 843;
+}
+);
+note = uni147F;
+},
+{
+color = 11;
+glyphname = "kwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (40,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (632,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 843;
+}
+);
+note = uni1481;
+},
+{
+color = 11;
+glyphname = "ce-canadian.square";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (405,714);
+},
+{
+name = top_left_can;
+pos = (209,714);
+},
+{
+name = top_right_can;
+pos = (602,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(523,0,l),
+(614,428,ls),
+(652,608,o),
+(561,728,o),
+(379,728,cs),
+(221,728,o),
+(119,633,o),
+(82,463,cs),
+(67,395,l),
+(213,395,l),
+(226,455,ls),
+(246,547,o),
+(292,593,o),
+(367,593,cs),
+(453,594,o),
+(490,537,o),
+(469,437,cs),
+(376,0,l)
+);
+}
+);
+width = 627;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni1489;
+},
+{
+color = 11;
+glyphname = "ci-canadian.square";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (418,714);
+},
+{
+name = top_left_can;
+pos = (223,714);
+},
+{
+name = top_right_can;
+pos = (616,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(144,0,l),
+(241,455,ls),
+(260,547,o),
+(309,593,o),
+(385,593,cs),
+(469,593,o),
+(505,539,o),
+(485,443,cs),
+(474,395,l),
+(620,395,l),
+(627,428,ls),
+(665,607,o),
+(570,729,o),
+(394,729,cs),
+(236,729,o),
+(132,636,o),
+(94,460,cs),
+(-4,0,l)
+);
+}
+);
+width = 627;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+},
+{
+color = 11;
+glyphname = "cii-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (233,0);
+ref = dot_top;
+}
+);
+width = 628;
+}
+);
+note = uni148C;
+},
+{
+color = 11;
+glyphname = "co-canadian.square";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (405,714);
+},
+{
+name = top_left_can;
+pos = (209,714);
+},
+{
+name = top_right_can;
+pos = (602,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(436,-15,o),
+(540,78,o),
+(577,254,cs),
+(675,714,l),
+(528,714,l),
+(431,259,ls),
+(411,167,o),
+(363,121,o),
+(286,121,cs),
+(203,121,o),
+(166,175,o),
+(187,271,cs),
+(197,319,l),
+(51,319,l),
+(44,286,ls),
+(7,107,o),
+(101,-15,o),
+(277,-15,cs)
+);
+}
+);
+width = 627;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+},
+{
+color = 11;
+glyphname = "coo-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (417,0);
+ref = dot_top;
+}
+);
+width = 628;
+}
+);
+note = uni148E;
+},
+{
+color = 11;
+glyphname = "ca-canadian.square";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (418,714);
+},
+{
+name = top_left_can;
+pos = (222,714);
+},
+{
+name = top_right_can;
+pos = (616,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(450,-14,o),
+(553,81,o),
+(589,251,cs),
+(604,319,l),
+(458,319,l),
+(445,259,ls),
+(425,167,o),
+(380,121,o),
+(304,121,cs),
+(218,120,o),
+(181,177,o),
+(203,277,cs),
+(296,714,l),
+(148,714,l),
+(57,286,ls),
+(19,106,o),
+(110,-14,o),
+(292,-14,cs)
+);
+}
+);
+width = 627;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+},
+{
+color = 11;
+glyphname = "caa-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (37,0);
+ref = dot_top;
+}
+);
+width = 628;
+}
+);
+note = uni1491;
+},
+{
+color = 11;
+glyphname = "me-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (363,714);
+},
+{
+name = top_double;
+pos = (515,714);
+},
+{
+name = top_left_can;
+pos = (202,714);
+},
+{
+name = top_right_can;
+pos = (515,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(437,0,l),
+(589,714,l),
+(130,714,l),
+(101,580,l),
+(413,580,l),
+(290,0,l)
+);
+}
+);
+width = 544;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+},
+{
+color = 11;
+glyphname = "mi-canadian.square";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (381,714);
+},
+{
+name = top_left_can;
+pos = (225,714);
+},
+{
+name = top_right_can;
+pos = (536,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(146,0,l),
+(270,580,l),
+(582,580,l),
+(610,714,l),
+(151,714,l),
+(-1,0,l)
+);
+}
+);
+width = 543;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+},
+{
+color = 11;
+glyphname = "mii-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (196,0);
+ref = dot_top;
+}
+);
+width = 544;
+}
+);
+note = uni14A6;
+},
+{
+color = 11;
+glyphname = "mo-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (363,714);
+},
+{
+name = top_double;
+pos = (516,714);
+},
+{
+name = top_left_can;
+pos = (203,714);
+},
+{
+name = top_right_can;
+pos = (516,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(437,0,l),
+(589,714,l),
+(442,714,l),
+(318,134,l),
+(6,134,l),
+(-22,0,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+},
+{
+color = 11;
+glyphname = "moo-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (331,0);
+ref = dot_top;
+}
+);
+width = 544;
+}
+);
+note = uni14A8;
+},
+{
+color = 11;
+glyphname = "ma-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (381,714);
+},
+{
+name = top_left_can;
+pos = (225,714);
+},
+{
+name = top_right_can;
+pos = (536,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(459,0,l),
+(487,134,l),
+(175,134,l),
+(298,714,l),
+(151,714,l),
+(-1,0,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+},
+{
+color = 11;
+glyphname = "maa-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (40,0);
+ref = dot_top;
+}
+);
+width = 544;
+}
+);
+note = uni14AB;
+},
+{
+color = 11;
+glyphname = "ne-canadian.square";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (490,714);
+},
+{
+name = top_left_can;
+pos = (329,714);
+},
+{
+name = top_right_can;
+pos = (653,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(501,-15,o),
+(587,64,o),
+(621,224,cs),
+(725,714,l),
+(136,714,l),
+(108,582,l),
+(228,582,l),
+(158,252,ls),
+(123,88,o),
+(201,-15,o),
+(361,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(311,121,o),
+(284,160,o),
+(299,229,cs),
+(374,582,l),
+(551,582,l),
+(475,223,ls),
+(460,153,o),
+(428,121,o),
+(373,121,cs)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C0;
+},
+{
+color = 11;
+glyphname = "ni-canadian.square";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (383,714);
+},
+{
+name = top_left_can;
+pos = (222,714);
+},
+{
+name = top_right_can;
+pos = (546,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(393,-15,o),
+(479,64,o),
+(514,224,cs),
+(590,582,l),
+(709,582,l),
+(737,714,l),
+(148,714,l),
+(50,252,ls),
+(16,88,o),
+(94,-15,o),
+(254,-15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(204,121,o),
+(177,161,o),
+(192,229,cs),
+(266,582,l),
+(444,582,l),
+(368,223,ls),
+(353,154,o),
+(321,121,o),
+(266,121,cs)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+},
+{
+color = 11;
+glyphname = "nii-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (198,0);
+ref = dot_top;
+}
+);
+width = 678;
+}
+);
+note = uni14C3;
+},
+{
+color = 11;
+glyphname = "no-canadian.square";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (491,714);
+},
+{
+name = top_double;
+pos = (501,714);
+},
+{
+name = top_left_can;
+pos = (329,714);
+},
+{
+name = top_right_can;
+pos = (630,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(573,0,l),
+(671,462,ls),
+(706,626,o),
+(628,729,o),
+(468,729,cs),
+(328,729,o),
+(242,650,o),
+(208,490,cs),
+(132,132,l),
+(12,132,l),
+(-16,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(354,491,ls),
+(369,560,o),
+(400,593,o),
+(456,593,cs),
+(518,593,o),
+(544,553,o),
+(530,485,cs),
+(455,132,l),
+(278,132,l)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C4;
+},
+{
+color = 11;
+glyphname = "noo-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (305,0);
+ref = dot_top;
+}
+);
+width = 678;
+}
+);
+note = uni14C5;
+},
+{
+color = 11;
+glyphname = "na-canadian.square";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (383,714);
+},
+{
+name = top_double;
+pos = (393,714);
+},
+{
+name = top_left_can;
+pos = (222,714);
+},
+{
+name = top_right_can;
+pos = (546,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(585,0,l),
+(613,132,l),
+(494,132,l),
+(564,462,ls),
+(599,626,o),
+(521,729,o),
+(361,729,cs),
+(221,729,o),
+(135,650,o),
+(101,490,cs),
+(-4,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(247,491,ls),
+(262,561,o),
+(294,593,o),
+(349,593,cs),
+(410,593,o),
+(438,554,o),
+(423,485,cs),
+(348,132,l),
+(171,132,l)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+},
+{
+color = 11;
+glyphname = "naa-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (198,0);
+ref = dot_top;
+}
+);
+width = 678;
+}
+);
+note = uni14C8;
+},
+{
+color = 11;
+glyphname = "nweWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (678,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 889;
+}
+);
+note = uni14CA;
+},
+{
+color = 11;
+glyphname = "nwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (678,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 889;
+}
+);
+note = uni14CC;
+},
+{
+color = 11;
+glyphname = "nwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (198,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (678,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 889;
+}
+);
+note = uni14CE;
+},
+{
+color = 11;
+glyphname = "se-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (225,714);
+},
+{
+name = top_right_can;
+pos = (615,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(528,0,l),
+(593,305,l),
+(400,305,ls),
+(266,305,o),
+(222,359,o),
+(252,495,cs),
+(298,714,l),
+(151,714,l),
+(104,495,ls),
+(63,302,o),
+(171,175,o),
+(374,175,cs),
+(457,175,l),
+(426,212,l),
+(381,0,l)
+);
+}
+);
+width = 636;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14ED;
+},
+{
+color = 11;
+glyphname = "si-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (226,714);
+},
+{
+name = top_right_can;
+pos = (616,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(147,0,l),
+(193,214,l),
+(147,176,l),
+(228,176,ls),
+(466,176,o),
+(585,266,o),
+(630,477,cs),
+(681,714,l),
+(534,714,l),
+(483,479,ls),
+(458,363,o),
+(382,305,o),
+(256,305,cs),
+(65,305,l),
+(0,0,l)
+);
+}
+);
+width = 636;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+},
+{
+color = 11;
+glyphname = "sii-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (431,0);
+ref = dot_top;
+}
+);
+width = 636;
+}
+);
+note = uni14F0;
+},
+{
+color = 11;
+glyphname = "so-canadian.square";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (608,714);
+},
+{
+name = top_left_can;
+pos = (226,714);
+},
+{
+name = top_right_can;
+pos = (608,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(147,0,l),
+(198,235,ls),
+(222,351,o),
+(299,409,o),
+(425,409,cs),
+(616,409,l),
+(681,714,l),
+(534,714,l),
+(488,500,l),
+(534,538,l),
+(453,538,ls),
+(215,538,o),
+(96,448,o),
+(50,237,cs),
+(0,0,l)
+);
+}
+);
+width = 637;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+},
+{
+color = 11;
+glyphname = "soo-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (422,0);
+ref = dot_top;
+}
+);
+width = 636;
+}
+);
+note = uni14F2;
+},
+{
+color = 11;
+glyphname = "sa-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (226,714);
+},
+{
+name = top_right_can;
+pos = (608,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(529,0,l),
+(576,219,ls),
+(617,412,o),
+(508,539,o),
+(306,539,cs),
+(223,539,l),
+(254,502,l),
+(299,714,l),
+(152,714,l),
+(87,409,l),
+(280,409,ls),
+(414,409,o),
+(457,355,o),
+(428,219,cs),
+(382,0,l)
+);
+}
+);
+width = 636;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+},
+{
+color = 11;
+glyphname = "saa-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (41,0);
+ref = dot_top;
+}
+);
+width = 636;
+}
+);
+note = uni14F5;
+},
+{
+color = 11;
+glyphname = "sho-canadian.square";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (413,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(520,0,l),
+(546,120,l),
+(263,120,ls),
+(211,120,o),
+(182,144,o),
+(182,190,cs),
+(182,247,o),
+(213,298,o),
+(299,298,cs),
+(381,298,ls),
+(553,298,o),
+(642,397,o),
+(642,539,cs),
+(642,645,o),
+(571,714,o),
+(461,714,cs),
+(154,714,l),
+(128,594,l),
+(413,594,ls),
+(466,594,o),
+(494,569,o),
+(494,524,cs),
+(494,466,o),
+(463,417,o),
+(377,417,cs),
+(296,417,ls),
+(122,417,o),
+(35,316,o),
+(35,175,cs),
+(35,69,o),
+(105,0,o),
+(216,0,cs)
+);
+}
+);
+width = 633;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+color = 11;
+glyphname = "shoo-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (229,0);
+ref = dot_top;
+}
+);
+width = 632;
+}
+);
+note = g728;
+},
+{
+color = 11;
+glyphname = "sha-canadian.square";
+lastChange = "2023-01-13 15:31:52 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (424,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(315,0,ls),
+(492,0,o),
+(579,99,o),
+(579,245,cs),
+(579,349,o),
+(512,417,o),
+(403,417,cs),
+(326,417,ls),
+(274,417,o),
+(245,440,o),
+(245,485,cs),
+(245,546,o),
+(277,594,o),
+(362,594,cs),
+(647,594,l),
+(672,714,l),
+(361,714,ls),
+(185,714,o),
+(98,614,o),
+(98,470,cs),
+(98,365,o),
+(164,298,o),
+(273,298,cs),
+(350,298,ls),
+(402,298,o),
+(431,274,o),
+(431,229,cs),
+(431,168,o),
+(399,120,o),
+(313,120,cs),
+(28,120,l),
+(3,0,l)
+);
+}
+);
+width = 633;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+color = 11;
+glyphname = "shaa-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (239,0);
+ref = dot_top;
+}
+);
+width = 632;
+}
+);
+note = g730;
+},
+{
+color = 11;
+glyphname = "ye-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (201,714);
+},
+{
+name = top_right_can;
+pos = (623,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(544,0,l),
+(609,304,l),
+(257,304,l),
+(262,241,l),
+(692,619,l),
+(598,726,l),
+(19,214,l),
+(11,175,l),
+(434,175,l),
+(396,0,l)
+);
+}
+);
+width = 650;
+}
+);
+metricLeft = "ye-canadian";
+note = uni1526;
+},
+{
+color = 11;
+glyphname = "yi-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (223,714);
+},
+{
+name = top_right_can;
+pos = (643,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(145,0,l),
+(182,175,l),
+(606,175,l),
+(614,214,l),
+(224,726,l),
+(105,633,l),
+(402,241,l),
+(413,304,l),
+(62,304,l),
+(-3,0,l)
+);
+}
+);
+width = 650;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni1528;
+},
+{
+color = 11;
+glyphname = "yii-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (38,0);
+ref = dot_top;
+}
+);
+width = 650;
+}
+);
+note = uni1529;
+},
+{
+color = 11;
+glyphname = "yo-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (623,714);
+},
+{
+name = top_left_can;
+pos = (202,714);
+},
+{
+name = top_right_can;
+pos = (623,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(589,81,l),
+(292,473,l),
+(281,410,l),
+(632,410,l),
+(697,714,l),
+(549,714,l),
+(512,539,l),
+(88,539,l),
+(80,500,l),
+(470,-12,l)
+);
+}
+);
+width = 650;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152A;
+},
+{
+color = 11;
+glyphname = "yoo-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (438,0);
+ref = dot_top;
+}
+);
+width = 650;
+}
+);
+note = uni152B;
+},
+{
+color = 11;
+glyphname = "ya-canadian.square";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (223,714);
+},
+{
+name = top_right_can;
+pos = (644,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(676,500,l),
+(684,539,l),
+(261,539,l),
+(298,714,l),
+(151,714,l),
+(86,410,l),
+(437,410,l),
+(432,473,l),
+(3,95,l),
+(96,-12,l)
+);
+}
+);
+width = 650;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152D;
+},
+{
+color = 11;
+glyphname = "yaa-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (37,0);
+ref = dot_top;
+}
+);
+width = 650;
+}
+);
+note = uni152E;
+},
+{
+color = 11;
+glyphname = "re-canadian.square";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (383,714);
+},
+{
+name = top_left_can;
+pos = (222,714);
+},
+{
+name = top_right_can;
+pos = (546,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(393,-15,o),
+(479,64,o),
+(514,224,cs),
+(590,582,l),
+(709,582,l),
+(737,714,l),
+(472,714,l),
+(368,223,ls),
+(353,154,o),
+(321,121,o),
+(266,121,cs),
+(204,121,o),
+(177,161,o),
+(192,229,cs),
+(294,714,l),
+(148,714,l),
+(50,252,ls),
+(16,88,o),
+(94,-15,o),
+(254,-15,cs)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1542;
+},
+{
+color = 11;
+glyphname = "reRCree-canadian.square";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (491,714);
+},
+{
+name = top_left_can;
+pos = (329,714);
+},
+{
+name = top_right_can;
+pos = (653,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(501,-15,o),
+(587,64,o),
+(621,224,cs),
+(725,714,l),
+(579,714,l),
+(475,223,ls),
+(460,153,o),
+(428,121,o),
+(373,121,cs),
+(311,121,o),
+(284,160,o),
+(299,229,cs),
+(402,714,l),
+(136,714,l),
+(108,582,l),
+(228,582,l),
+(158,252,ls),
+(123,88,o),
+(201,-15,o),
+(361,-15,cs)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni1543;
+},
+{
+color = 11;
+glyphname = "leWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (490,714);
+},
+{
+name = top_left_can;
+pos = (329,714);
+},
+{
+name = top_right_can;
+pos = (653,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(250,-1,l),
+(354,490,ls),
+(369,559,o),
+(400,592,o),
+(455,592,cs),
+(518,592,o),
+(544,553,o),
+(530,484,cs),
+(427,-1,l),
+(573,-1,l),
+(671,462,ls),
+(706,626,o),
+(628,729,o),
+(468,729,cs),
+(328,729,o),
+(242,649,o),
+(208,489,cs),
+(131,132,l),
+(12,132,l),
+(-16,-1,l)
+);
+}
+);
+width = 678;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+},
+{
+color = 11;
+glyphname = "ri-canadian.square";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (383,714);
+},
+{
+name = top_left_can;
+pos = (223,714);
+},
+{
+name = top_right_can;
+pos = (546,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(143,0,l),
+(247,491,ls),
+(262,561,o),
+(294,593,o),
+(349,593,cs),
+(410,593,o),
+(438,554,o),
+(423,485,cs),
+(320,0,l),
+(585,0,l),
+(613,132,l),
+(494,132,l),
+(564,462,ls),
+(599,626,o),
+(521,729,o),
+(361,729,cs),
+(221,729,o),
+(135,650,o),
+(101,490,cs),
+(-4,0,l)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+},
+{
+color = 11;
+glyphname = "rii-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (198,0);
+ref = dot_top;
+}
+);
+width = 678;
+}
+);
+note = uni1547;
+},
+{
+color = 11;
+glyphname = "ro-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (413,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(147,0,l),
+(189,200,l),
+(110,135,l),
+(250,135,ls),
+(481,135,o),
+(611,279,o),
+(611,472,cs),
+(611,619,o),
+(512,714,o),
+(351,714,cs),
+(152,714,l),
+(124,585,l),
+(331,585,ls),
+(419,585,o),
+(465,542,o),
+(465,465,cs),
+(465,368,o),
+(416,265,o),
+(265,265,cs),
+(56,265,l),
+(0,0,l)
+);
+}
+);
+width = 616;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1548;
+},
+{
+color = 11;
+glyphname = "loWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (411,714);
+},
+{
+name = top_left_can;
+pos = (226,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(216,0,ls),
+(453,0,o),
+(582,143,o),
+(582,337,cs),
+(582,483,o),
+(484,579,o),
+(322,579,cs),
+(205,579,l),
+(257,514,l),
+(299,714,l),
+(152,714,l),
+(95,449,l),
+(302,449,ls),
+(390,449,o),
+(436,407,o),
+(436,330,cs),
+(436,233,o),
+(387,129,o),
+(238,129,cs),
+(27,129,l),
+(0,0,l)
+);
+}
+);
+width = 609;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+},
+{
+color = 11;
+glyphname = "ra-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (394,714);
+},
+{
+name = top_right_can;
+pos = (580,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(501,0,l),
+(558,265,l),
+(351,265,ls),
+(263,265,o),
+(217,307,o),
+(217,384,cs),
+(217,481,o),
+(266,585,o),
+(416,585,cs),
+(626,585,l),
+(654,714,l),
+(437,714,ls),
+(200,714,o),
+(71,571,o),
+(71,377,cs),
+(71,231,o),
+(170,135,o),
+(331,135,cs),
+(448,135,l),
+(397,200,l),
+(354,0,l)
+);
+}
+);
+width = 609;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+},
+{
+color = 11;
+glyphname = "raa-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (209,0);
+ref = dot_top;
+}
+);
+width = 609;
+}
+);
+note = uni154C;
+},
+{
+color = 11;
+glyphname = "laWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (581,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(502,0,l),
+(529,129,l),
+(322,129,ls),
+(235,129,o),
+(188,172,o),
+(188,249,cs),
+(188,346,o),
+(238,449,o),
+(389,449,cs),
+(598,449,l),
+(654,714,l),
+(506,714,l),
+(464,514,l),
+(543,579,l),
+(404,579,ls),
+(173,579,o),
+(43,435,o),
+(43,242,cs),
+(43,95,o),
+(141,0,o),
+(302,0,cs)
+);
+}
+);
+width = 609;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+},
+{
+color = 11;
+glyphname = "reWestCree-canadian.square";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(506,0,l),
+(762,206,l),
+(682,305,l),
+(508,165,l),
+(552,132,l),
+(615,428,ls),
+(652,608,o),
+(564,728,o),
+(382,728,cs),
+(226,728,o),
+(120,639,o),
+(82,463,cs),
+(67,395,l),
+(213,395,l),
+(226,455,ls),
+(246,547,o),
+(292,593,o),
+(367,593,cs),
+(453,594,o),
+(490,537,o),
+(469,437,cs),
+(376,0,l)
+);
+}
+);
+width = 788;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+},
+{
+color = 11;
+glyphname = "riWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(304,0,l),
+(401,455,ls),
+(421,547,o),
+(468,593,o),
+(545,593,cs),
+(628,593,o),
+(665,539,o),
+(644,443,cs),
+(634,395,l),
+(780,395,l),
+(787,428,ls),
+(824,607,o),
+(730,729,o),
+(554,729,cs),
+(396,729,o),
+(291,636,o),
+(254,460,cs),
+(184,132,l),
+(237,143,l),
+(112,294,l),
+(6,206,l),
+(174,0,l)
+);
+}
+);
+width = 787;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+},
+{
+color = 11;
+glyphname = "roWestCree-canadian.square";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(435,-15,o),
+(540,78,o),
+(577,254,cs),
+(647,582,l),
+(594,571,l),
+(719,420,l),
+(826,508,l),
+(657,714,l),
+(527,714,l),
+(430,259,ls),
+(411,167,o),
+(363,121,o),
+(286,121,cs),
+(203,121,o),
+(166,175,o),
+(187,271,cs),
+(197,319,l),
+(51,319,l),
+(44,286,ls),
+(7,107,o),
+(101,-15,o),
+(277,-15,cs)
+);
+}
+);
+width = 788;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+},
+{
+color = 11;
+glyphname = "raWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(605,-14,o),
+(712,75,o),
+(749,251,cs),
+(764,319,l),
+(618,319,l),
+(605,259,ls),
+(585,167,o),
+(539,121,o),
+(464,121,cs),
+(378,120,o),
+(341,177,o),
+(362,277,cs),
+(455,714,l),
+(325,714,l),
+(70,508,l),
+(150,409,l),
+(324,549,l),
+(279,582,l),
+(217,286,ls),
+(179,106,o),
+(268,-14,o),
+(449,-14,cs)
+);
+}
+);
+width = 787;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+},
+{
+color = 11;
+glyphname = "theThCree-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (202,714);
+},
+{
+name = top_right_can;
+pos = (623,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(544,0,l),
+(555,55,l),
+(635,55,l),
+(650,122,l),
+(570,122,l),
+(609,304,l),
+(271,304,l),
+(287,261,l),
+(692,619,l),
+(598,726,l),
+(19,214,l),
+(11,175,l),
+(434,175,l),
+(422,122,l),
+(240,122,l),
+(226,55,l),
+(408,55,l),
+(396,0,l)
+);
+}
+);
+width = 703;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15A7;
+},
+{
+color = 11;
+glyphname = "thiThCree-canadian.square";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (275,714);
+},
+{
+name = top_right_can;
+pos = (695,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(198,0,l),
+(210,55,l),
+(393,55,l),
+(407,122,l),
+(225,122,l),
+(236,175,l),
+(660,175,l),
+(668,214,l),
+(278,726,l),
+(159,633,l),
+(445,252,l),
+(471,304,l),
+(116,304,l),
+(77,122,l),
+(-2,122,l),
+(-17,55,l),
+(63,55,l),
+(51,0,l)
+);
+}
+);
+width = 704;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+},
+{
+color = 11;
+glyphname = "thiiThCree-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (89,0);
+ref = dot_top;
+}
+);
+width = 703;
+}
+);
+note = uni15A9;
+},
+{
+color = 11;
+glyphname = "thoThCree-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (202,714);
+},
+{
+name = top_right_can;
+pos = (623,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(588,81,l),
+(302,462,l),
+(277,410,l),
+(631,410,l),
+(670,592,l),
+(750,592,l),
+(764,659,l),
+(685,659,l),
+(696,714,l),
+(549,714,l),
+(537,659,l),
+(355,659,l),
+(340,592,l),
+(523,592,l),
+(511,539,l),
+(88,539,l),
+(80,500,l),
+(470,-12,l)
+);
+}
+);
+width = 703;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+},
+{
+color = 11;
+glyphname = "thooThCree-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (438,0);
+ref = dot_top;
+}
+);
+width = 703;
+}
+);
+note = uni15AB;
+},
+{
+color = 11;
+glyphname = "thaThCree-canadian.square";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (277,714);
+},
+{
+name = top_right_can;
+pos = (697,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(728,500,l),
+(736,539,l),
+(312,539,l),
+(324,592,l),
+(506,592,l),
+(520,659,l),
+(338,659,l),
+(350,714,l),
+(202,714,l),
+(191,659,l),
+(111,659,l),
+(97,592,l),
+(176,592,l),
+(138,410,l),
+(476,410,l),
+(459,453,l),
+(55,95,l),
+(148,-12,l)
+);
+}
+);
+width = 702;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+},
+{
+color = 11;
+glyphname = "thaaThCree-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (92,0);
+ref = dot_top;
+}
+);
+width = 703;
+}
+);
+note = uni15AD;
+},
+{
+color = 11;
+glyphname = "thweeWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (703,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 914;
+}
+);
+note = uni1677;
+},
+{
+color = 11;
+glyphname = "thwiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (703,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 914;
+}
+);
+note = uni1678;
+},
+{
+color = 11;
+glyphname = "thwiiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (89,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (703,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 914;
+}
+);
+note = uni1679;
+},
+{
+color = 11;
+glyphname = "thwoWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (703,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 914;
+}
+);
+note = uni167A;
+},
+{
+color = 11;
+glyphname = "thwooWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (438,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (703,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 914;
+}
+);
+note = uni167B;
+},
+{
+color = 11;
+glyphname = "thwaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (703,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 914;
+}
+);
+note = uni167C;
+},
+{
+color = 11;
+glyphname = "thwaaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (92,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (703,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 914;
+}
+);
+note = uni167D;
+},
+{
+color = 11;
+glyphname = "nwiOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (678,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 889;
+}
+);
+note = uni18C7;
+},
+{
+color = 11;
+glyphname = "nwiiOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (198,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (678,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 889;
+}
+);
+note = uni18C9;
+},
+{
+color = 11;
+glyphname = "nwoOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (678,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 889;
+}
+);
+note = uni18CB;
+},
+{
+color = 11;
+glyphname = "nwooOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (305,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (678,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 889;
+}
+);
+note = uni18CD;
+},
+{
+color = 11;
+glyphname = "looWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (41,0);
+ref = dot_top;
+}
+);
+width = 609;
+}
+);
+note = uni18E1;
+},
+{
+color = 11;
+glyphname = "laaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (395,0);
+ref = dot_top;
+}
+);
+width = 609;
+}
+);
+note = uni18E2;
+},
+{
+color = 0;
+glyphname = zero;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(594,588,o),
+(519,724,o),
+(345,724,cs),
+(169,724,o),
+(95,585,o),
+(95,357,cs),
+(95,114,o),
+(182,-10,o),
+(345,-10,cs),
+(514,-10,o),
+(594,108,o),
+(594,357,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(248,449,o),
+(253,600,o),
+(345,600,cs),
+(439,600,o),
+(441,446,o),
+(441,357,cs),
+(441,250,o),
+(430,114,o),
+(345,114,cs),
+(261,114,o),
+(248,250,o),
+(248,357,cs)
+);
+}
+);
+width = 648;
+}
+);
+unicode = 48;
+},
+{
+color = 0;
+glyphname = one;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(305,714,l),
+(72,528,l),
+(152,428,l),
+(243,501,ls),
+(260,515,o),
+(273,528,o),
+(290,546,c),
+(288,500,o),
+(287,461,o),
+(287,419,cs),
+(287,0,l),
+(444,0,l),
+(444,714,l)
+);
+}
+);
+width = 568;
+}
+);
+unicode = 49;
+},
+{
+color = 0;
+glyphname = two;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(611,0,l),
+(611,128,l),
+(312,128,l),
+(312,132,l),
+(400,219,ls),
+(485,299,o),
+(543,358,o),
+(572,422,cs),
+(586,454,o),
+(593,491,o),
+(593,531,cs),
+(593,644,o),
+(502,724,o),
+(366,724,cs),
+(250,724,o),
+(181,682,o),
+(112,621,c),
+(197,521,l),
+(254,570,o),
+(301,594,o),
+(349,594,cs),
+(402,594,o),
+(440,567,o),
+(440,511,cs),
+(440,467,o),
+(424,432,o),
+(383,385,cs),
+(362,360,o),
+(334,330,o),
+(299,293,cs),
+(113,103,l),
+(113,0,l)
+);
+}
+);
+width = 660;
+}
+);
+unicode = 50;
+},
+{
+color = 0;
+glyphname = three;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(588,662,o),
+(500,724,o),
+(360,724,cs),
+(245,724,o),
+(175,693,o),
+(116,652,c),
+(181,548,l),
+(216,572,o),
+(273,599,o),
+(337,599,cs),
+(398,599,o),
+(438,575,o),
+(438,522,cs),
+(438,447,o),
+(354,425,o),
+(278,425,cs),
+(224,425,l),
+(224,308,l),
+(277,308,ls),
+(393,308,o),
+(447,282,o),
+(447,211,cs),
+(447,151,o),
+(409,112,o),
+(302,112,cs),
+(245,112,o),
+(174,129,o),
+(114,159,c),
+(114,30,l),
+(172,6,o),
+(235,-10,o),
+(324,-10,cs),
+(487,-10,o),
+(609,62,o),
+(609,202,cs),
+(609,304,o),
+(546,360,o),
+(431,373,c),
+(431,376,l),
+(521,398,o),
+(588,460,o),
+(588,557,cs)
+);
+}
+);
+width = 654;
+}
+);
+unicode = 51;
+},
+{
+color = 0;
+glyphname = four;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(489,267,l),
+(489,715,l),
+(346,715,l),
+(31,264,l),
+(31,151,l),
+(337,151,l),
+(337,0,l),
+(489,0,l),
+(489,151,l),
+(581,151,l),
+(581,267,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(168,267,l),
+(292,445,ls),
+(313,475,o),
+(321,490,o),
+(336,520,c),
+(341,520,l),
+(341,512,o),
+(337,477,o),
+(337,418,cs),
+(337,267,l)
+);
+}
+);
+width = 611;
+}
+);
+unicode = 52;
+},
+{
+color = 0;
+glyphname = five;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(310,458,o),
+(287,452,o),
+(263,447,c),
+(276,585,l),
+(535,585,l),
+(535,714,l),
+(145,714,l),
+(117,350,l),
+(176,320,l),
+(208,329,o),
+(246,338,o),
+(288,338,cs),
+(380,338,o),
+(426,298,o),
+(426,228,cs),
+(426,154,o),
+(374,112,o),
+(288,112,cs),
+(226,112,o),
+(152,134,o),
+(102,158,c),
+(102,30,l),
+(153,4,o),
+(219,-10,o),
+(300,-10,cs),
+(486,-10,o),
+(581,78,o),
+(581,233,cs),
+(581,375,o),
+(490,458,o),
+(362,458,cs)
+);
+}
+);
+width = 632;
+}
+);
+unicode = 53;
+},
+{
+color = 0;
+glyphname = six;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(84,122,o),
+(171,-10,o),
+(344,-10,cs),
+(494,-10,o),
+(587,84,o),
+(587,240,cs),
+(587,384,o),
+(511,467,o),
+(385,467,cs),
+(303,467,o),
+(254,428,o),
+(228,376,c),
+(223,376,l),
+(228,517,o),
+(284,604,o),
+(437,604,cs),
+(483,604,o),
+(515,599,o),
+(541,593,c),
+(541,715,l),
+(514,720,o),
+(471,724,o),
+(440,724,cs),
+(179,724,o),
+(84,557,o),
+(84,302,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(268,113,o),
+(238,182,o),
+(238,252,cs),
+(238,302,o),
+(283,347,o),
+(343,347,cs),
+(408,347,o),
+(437,306,o),
+(437,236,cs),
+(437,155,o),
+(400,113,o),
+(341,113,cs)
+);
+}
+);
+width = 626;
+}
+);
+unicode = 54;
+},
+{
+color = 0;
+glyphname = seven;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(623,623,l),
+(623,714,l),
+(122,714,l),
+(122,586,l),
+(458,586,l),
+(201,0,l),
+(361,0,l)
+);
+}
+);
+width = 647;
+}
+);
+unicode = 55;
+},
+{
+color = 0;
+glyphname = eight;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(489,-10,o),
+(595,55,o),
+(595,188,cs),
+(595,284,o),
+(520,340,o),
+(441,377,c),
+(519,414,o),
+(573,467,o),
+(573,553,cs),
+(573,666,o),
+(481,724,o),
+(345,724,cs),
+(206,724,o),
+(115,662,o),
+(115,553,cs),
+(115,465,o),
+(173,412,o),
+(236,375,c),
+(153,338,o),
+(93,286,o),
+(93,185,cs),
+(93,70,o),
+(175,-10,o),
+(343,-10,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(276,102,o),
+(235,137,o),
+(235,191,cs),
+(235,250,o),
+(286,284,o),
+(342,309,c),
+(407,279,o),
+(453,243,o),
+(453,189,cs),
+(453,134,o),
+(413,102,o),
+(341,102,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(295,467,o),
+(260,495,o),
+(260,539,cs),
+(260,585,o),
+(297,612,o),
+(344,612,cs),
+(393,612,o),
+(428,586,o),
+(428,540,cs),
+(428,493,o),
+(391,467,o),
+(344,444,c)
+);
+}
+);
+width = 641;
+}
+);
+unicode = 56;
+},
+{
+color = 0;
+glyphname = nine;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(597,593,o),
+(511,724,o),
+(338,724,cs),
+(186,724,o),
+(94,631,o),
+(94,476,cs),
+(94,331,o),
+(170,247,o),
+(293,247,cs),
+(378,247,o),
+(426,285,o),
+(453,338,c),
+(458,338,l),
+(450,185,o),
+(382,110,o),
+(234,110,cs),
+(196,110,o),
+(166,114,o),
+(139,120,c),
+(139,-4,l),
+(166,-9,o),
+(210,-10,o),
+(241,-10,cs),
+(500,-10,o),
+(597,158,o),
+(597,404,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(414,600,o),
+(442,526,o),
+(442,463,cs),
+(442,413,o),
+(395,366,o),
+(339,366,cs),
+(276,366,o),
+(243,409,o),
+(243,477,cs),
+(243,559,o),
+(279,600,o),
+(341,600,cs)
+);
+}
+);
+width = 651;
+}
+);
+unicode = 57;
+},
+{
+glyphname = zero.canadian;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(462,-12,o),
+(539,326,o),
+(539,493,cs),
+(539,645,o),
+(472,728,o),
+(348,728,cs),
+(121,728,o),
+(47,388,o),
+(47,222,cs),
+(47,72,o),
+(112,-12,o),
+(240,-12,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(208,120,o),
+(188,151,o),
+(188,214,cs),
+(188,295,o),
+(235,597,o),
+(338,597,cs),
+(377,597,o),
+(397,565,o),
+(397,501,cs),
+(397,420,o),
+(350,120,o),
+(247,120,cs)
+);
+}
+);
+width = 541;
+}
+);
+metricRight = "=|";
+},
+{
+glyphname = one.canadian;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(282,0,l),
+(434,714,l),
+(302.995,714,l),
+(66,522,l),
+(146,422,l),
+(366,599,l),
+(266,617,l),
+(135,0,l)
+);
+}
+);
+width = 389;
+}
+);
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = two.canadian;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(459,134,l),
+(200,134,l),
+(198,82,l),
+(403,291,ls),
+(484,373,o),
+(532,454,o),
+(532,547,cs),
+(532,655,o),
+(458,728,o),
+(342,728,cs),
+(209,728,o),
+(118,644,o),
+(82,465,c),
+(228,465,l),
+(246,562,o),
+(278,600,o),
+(328,600,cs),
+(367,600,o),
+(386,578,o),
+(386,540,cs),
+(386,479,o),
+(343,419,o),
+(291,367,cs),
+(24,95,l),
+(4,0,l),
+(431,0,l)
+);
+}
+);
+width = 522;
+}
+);
+note = uni14BF;
+},
+{
+glyphname = three.canadian;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(414,-14,o),
+(480,105,o),
+(480,223,cs),
+(480,303,o),
+(441,356,o),
+(371,376,c),
+(359,327,l),
+(494,339,o),
+(543,467,o),
+(543,556,cs),
+(543,660,o),
+(473,728,o),
+(353,728,cs),
+(215,728,o),
+(120,639,o),
+(92,477,c),
+(238,477,l),
+(256,560,o),
+(287,600,o),
+(335,600,cs),
+(373,600,o),
+(393,576,o),
+(393,535,cs),
+(393,488,o),
+(376,419,o),
+(305,419,cs),
+(273,419,l),
+(247,296,l),
+(279,296,ls),
+(315,296,o),
+(335,274,o),
+(335,233,cs),
+(335,189,o),
+(313,114,o),
+(247,114,cs),
+(180,114,o),
+(172,181,o),
+(183,237,c),
+(37,237,l),
+(12,104,o),
+(73,-14,o),
+(244,-14,cs)
+);
+}
+);
+width = 543;
+}
+);
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = four.canadian;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(367,0,l),
+(400,152,l),
+(475,152,l),
+(501,272,l),
+(425,272,l),
+(519,715,l),
+(402,715,l),
+(27,249,l),
+(6,152,l),
+(257,152,l),
+(225,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(396,569,l),
+(351,569,l),
+(288,272,l),
+(132,272,l),
+(139,237,l)
+);
+}
+);
+width = 515;
+}
+);
+},
+{
+glyphname = five.canadian;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(433,-14,o),
+(495,146,o),
+(495,264,cs),
+(495,376,o),
+(424,444,o),
+(299,444,cs),
+(217,444,l),
+(261,407,l),
+(322,622,l),
+(257,581,l),
+(539,581,l),
+(567,714,l),
+(205,714,l),
+(102,350,l),
+(123,318,l),
+(254,318,ls),
+(313,318,o),
+(346,294,o),
+(346,242,cs),
+(346,198,o),
+(325,114,o),
+(255,114,cs),
+(192,114,o),
+(179,167,o),
+(188,215,c),
+(42,215,l),
+(25,89,o),
+(97,-14,o),
+(248,-14,cs)
+);
+}
+);
+width = 539;
+}
+);
+},
+{
+glyphname = six.canadian;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(421,-14,o),
+(506,121,o),
+(506,261,cs),
+(506,372,o),
+(439,448,o),
+(332,448,cs),
+(267,448,o),
+(215,416,o),
+(176,356,c),
+(201,310,l),
+(204,335,o),
+(206,349,o),
+(216,394,cs),
+(247,541,o),
+(289,602,o),
+(350,602,cs),
+(414,602,o),
+(421,546,o),
+(416,500,c),
+(560,500,l),
+(570,630,o),
+(497,728,o),
+(360,728,cs),
+(117,728,o),
+(46,372,o),
+(46,220,cs),
+(46,164,o),
+(54,117,o),
+(76,80,cs),
+(109,21,o),
+(171,-14,o),
+(256,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(214,109,o),
+(187,139,o),
+(187,190,cs),
+(187,241,o),
+(215,326,o),
+(289,326,cs),
+(335,326,o),
+(361,296,o),
+(361,246,cs),
+(361,196,o),
+(335,109,o),
+(260,109,cs)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = zero.canadian;
+},
+{
+glyphname = seven.canadian;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(175,0,l),
+(493,623,l),
+(512,714,l),
+(123,714,l),
+(95,580,l),
+(335,580,l),
+(342,621,l),
+(38,36,l),
+(31,0,l)
+);
+}
+);
+width = 439;
+}
+);
+},
+{
+glyphname = eight.canadian;
+lastChange = "2023-01-13 15:31:52 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(389,-14,o),
+(478,73,o),
+(494,190,cs),
+(508,282,o),
+(465,351,o),
+(384,377,c),
+(367,328,l),
+(470,337,o),
+(536,414,o),
+(550,511,cs),
+(568,638,o),
+(487,728,o),
+(350,728,cs),
+(223,728,o),
+(136,639,o),
+(120,525,cs),
+(107,435,o),
+(147,362,o),
+(224,337,c),
+(229,387,l),
+(122,377,o),
+(54,300,o),
+(41,207,cs),
+(23,82,o),
+(115,-14,o),
+(257,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(204,108,o),
+(177,143,o),
+(184,199,cs),
+(190,254,o),
+(221,297,o),
+(279,297,cs),
+(333,297,o),
+(360,263,o),
+(353,207,cs),
+(348,152,o),
+(316,108,o),
+(259,108,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(278,417,o),
+(255,452,o),
+(260,506,cs),
+(265,559,o),
+(291,606,o),
+(344,606,cs),
+(389,606,o),
+(412,572,o),
+(407,517,cs),
+(402,464,o),
+(375,417,o),
+(323,417,cs)
+);
+}
+);
+width = 558;
+}
+);
+metricLeft = "=|";
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = nine.canadian;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(471,-14,o),
+(542,342,o),
+(542,494,cs),
+(542,550,o),
+(533,597,o),
+(512,634,cs),
+(479,693,o),
+(417,728,o),
+(331,728,cs),
+(167,728,o),
+(82,593,o),
+(82,453,cs),
+(82,342,o),
+(148,266,o),
+(256,266,cs),
+(321,266,o),
+(373,298,o),
+(412,358,c),
+(387,404,l),
+(384,379,o),
+(382,365,o),
+(372,320,cs),
+(341,173,o),
+(299,112,o),
+(238,112,cs),
+(174,112,o),
+(167,168,o),
+(172,214,c),
+(28,214,l),
+(18,84,o),
+(91,-14,o),
+(227,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(253,388,o),
+(226,418,o),
+(226,468,cs),
+(226,518,o),
+(253,605,o),
+(328,605,cs),
+(374,605,o),
+(401,575,o),
+(401,524,cs),
+(401,473,o),
+(373,388,o),
+(298,388,cs)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "=|six.canadian";
+metricRight = "=|six.canadian";
+},
+{
+glyphname = CR;
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+width = 223;
+}
+);
+note = CR;
+unicode = 13;
+},
+{
+color = 0;
+glyphname = .notdef;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(603,714,l),
+(192,714,l),
+(192,0,l),
+(603,0,l),
+(603,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(552,663,l),
+(552,51,l),
+(243,51,l),
+(243,663,l),
+(243,663,l)
+);
+}
+);
+width = 698;
+}
+);
+note = ".notdef";
+},
+{
+glyphname = .null;
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+width = 0;
+}
+);
+note = NULL;
+},
+{
+glyphname = space;
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+width = 225;
+}
+);
+note = space;
+unicode = 32;
+},
+{
+glyphname = nbspace;
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+width = 223;
+}
+);
+note = uni00A0;
+unicode = 160;
+},
+{
+glyphname = space.canadian;
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+width = 456;
+}
+);
+note = space;
+},
+{
+glyphname = "hyphen-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(357,399,l),
+(374,482,l),
+(94,482,l),
+(76,399,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(326,253,l),
+(343,336,l),
+(62,336,l),
+(45,253,l)
+);
+}
+);
+width = 370;
+}
+);
+metricRight = "=|";
+note = uni1400;
+unicode = 5120;
+},
+{
+glyphname = "chi-canadian";
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(122,0,l),
+(297,269,l),
+(246,278,l),
+(309,0,l),
+(443,0,l),
+(451,36,l),
+(349,423,l),
+(328,306,l),
+(585,678,l),
+(593,714,l),
+(448,714,l),
+(277,447,l),
+(326,439,l),
+(265,714,l),
+(132,714,l),
+(124,678,l),
+(227,300,l),
+(246,418,l),
+(-15,36,l),
+(-23,0,l)
+);
+}
+);
+width = 528;
+}
+);
+metricRight = "=|";
+note = uni166D;
+unicode = 5741;
+},
+{
+glyphname = "fullstop-canadian";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(81,0,l),
+(150,108,l),
+(130,116,l),
+(157,0,l),
+(242,0,l),
+(247,18,l),
+(194,197,l),
+(191,158,l),
+(314,338,l),
+(318,357,l),
+(224,357,l),
+(148,235,l),
+(179,225,l),
+(149,357,l),
+(64,357,l),
+(59,338,l),
+(109,167,l),
+(117,204,l),
+(-9,18,l),
+(-13,0,l)
+);
+}
+);
+width = 337;
+}
+);
+note = uni1541;
+unicode = 5742;
+},
+{
+glyphname = period;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(-2,22,o),
+(27,-11,o),
+(88,-11,cs),
+(134,-11,o),
+(164,15,o),
+(173,62,cs),
+(184,115,o),
+(156,147,o),
+(94,147,cs),
+(46,147,o),
+(17,120,o),
+(8,74,cs)
+);
+}
+);
+width = 256;
+}
+);
+note = period;
+unicode = 46;
+},
+{
+glyphname = comma;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(42,-137,l),
+(94,-59,o),
+(144,49,o),
+(179,128,c),
+(175,139,l),
+(47,139,l),
+(22,61,o),
+(-18,-40,o),
+(-61,-137,c)
+);
+}
+);
+width = 257;
+}
+);
+note = comma;
+unicode = 44;
+},
+{
+glyphname = hyphen;
+kernLeft = hyphen;
+kernRight = hyphen;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(226,208,l),
+(252,330,l),
+(43,330,l),
+(18,208,l)
+);
+}
+);
+width = 263;
+}
+);
+unicode = 45;
+},
+{
+glyphname = quotesinglbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-59,-575);
+ref = quoteright;
+}
+);
+width = 287;
+}
+);
+unicode = 8218;
+},
+{
+glyphname = quotedblbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+pos = (-91,-575);
+ref = quotedblright;
+}
+);
+width = 527;
+}
+);
+unicode = 8222;
+},
+{
+glyphname = quotedblleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(412,438,l),
+(438,518,o),
+(477,616,o),
+(522,713,c),
+(420,713,l),
+(371,638,o),
+(321,538,o),
+(281,448,c),
+(286,438,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(195,438,l),
+(221,519,o),
+(260,616,o),
+(305,713,c),
+(203,713,l),
+(154,638,o),
+(104,538,o),
+(64,448,c),
+(69,438,l)
+);
+}
+);
+width = 451;
+}
+);
+unicode = 8220;
+},
+{
+glyphname = quotedblright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(386,438,l),
+(438,515,o),
+(489,622,o),
+(524,703,c),
+(520,713,l),
+(393,713,l),
+(369,635,o),
+(328,531,o),
+(284,438,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(168,438,l),
+(221,515,o),
+(272,622,o),
+(307,703,c),
+(302,713,l),
+(176,713,l),
+(152,636,o),
+(110,530,o),
+(66,438,c)
+);
+}
+);
+width = 451;
+}
+);
+unicode = 8221;
+},
+{
+glyphname = quoteleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(202,438,l),
+(228,518,o),
+(267,616,o),
+(311,713,c),
+(203,713,l),
+(154,638,o),
+(104,538,o),
+(64,448,c),
+(69,438,l)
+);
+}
+);
+width = 241;
+}
+);
+unicode = 8216;
+},
+{
+glyphname = quoteright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(175,438,l),
+(227,515,o),
+(279,622,o),
+(314,703,c),
+(310,713,l),
+(176,713,l),
+(152,636,o),
+(110,530,o),
+(66,438,c)
+);
+}
+);
+width = 241;
+}
+);
+unicode = 8217;
+},
+{
+glyphname = dottedCircle;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(209,522,o),
+(196,511,o),
+(196,496,cs),
+(196,483,o),
+(209,470,o),
+(222,470,cs),
+(237,470,o),
+(248,483,o),
+(248,496,cs),
+(248,511,o),
+(237,522,o),
+(222,522,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(377,522,o),
+(364,511,o),
+(364,496,cs),
+(364,483,o),
+(377,470,o),
+(390,470,cs),
+(405,470,o),
+(416,483,o),
+(416,496,cs),
+(416,511,o),
+(405,522,o),
+(390,522,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(209,112,o),
+(196,101,o),
+(196,86,cs),
+(196,73,o),
+(209,60,o),
+(222,60,cs),
+(237,60,o),
+(248,73,o),
+(248,86,cs),
+(248,101,o),
+(237,112,o),
+(222,112,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(377,112,o),
+(364,101,o),
+(364,86,cs),
+(364,73,o),
+(377,60,o),
+(390,60,cs),
+(405,60,o),
+(416,73,o),
+(416,86,cs),
+(416,101,o),
+(405,112,o),
+(390,112,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(293,540,o),
+(280,529,o),
+(280,514,cs),
+(280,501,o),
+(293,488,o),
+(306,488,cs),
+(321,488,o),
+(332,501,o),
+(332,514,cs),
+(332,529,o),
+(321,540,o),
+(306,540,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(293,94,o),
+(280,83,o),
+(280,68,cs),
+(280,55,o),
+(293,42,o),
+(306,42,cs),
+(321,42,o),
+(332,55,o),
+(332,68,cs),
+(332,83,o),
+(321,94,o),
+(306,94,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(57,278,o),
+(70,265,o),
+(83,265,cs),
+(98,265,o),
+(109,278,o),
+(109,291,cs),
+(109,306,o),
+(98,317,o),
+(83,317,cs),
+(70,317,o),
+(57,306,o),
+(57,291,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(503,278,o),
+(516,265,o),
+(529,265,cs),
+(544,265,o),
+(555,278,o),
+(555,291,cs),
+(555,306,o),
+(544,317,o),
+(529,317,cs),
+(516,317,o),
+(503,306,o),
+(503,291,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(122,120,o),
+(135,107,o),
+(148,107,cs),
+(163,107,o),
+(174,120,o),
+(174,133,cs),
+(174,148,o),
+(163,159,o),
+(148,159,cs),
+(135,159,o),
+(122,148,o),
+(122,133,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(122,436,o),
+(135,423,o),
+(148,423,cs),
+(163,423,o),
+(174,436,o),
+(174,449,cs),
+(174,464,o),
+(163,475,o),
+(148,475,cs),
+(135,475,o),
+(122,464,o),
+(122,449,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(438,120,o),
+(451,107,o),
+(464,107,cs),
+(479,107,o),
+(490,120,o),
+(490,133,cs),
+(490,148,o),
+(479,159,o),
+(464,159,cs),
+(451,159,o),
+(438,148,o),
+(438,133,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(438,436,o),
+(451,423,o),
+(464,423,cs),
+(479,423,o),
+(490,436,o),
+(490,449,cs),
+(490,464,o),
+(479,475,o),
+(464,475,cs),
+(451,475,o),
+(438,464,o),
+(438,449,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(75,194,o),
+(88,181,o),
+(101,181,cs),
+(116,181,o),
+(127,194,o),
+(127,207,cs),
+(127,222,o),
+(116,233,o),
+(101,233,cs),
+(88,233,o),
+(75,222,o),
+(75,207,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(75,362,o),
+(88,349,o),
+(101,349,cs),
+(116,349,o),
+(127,362,o),
+(127,375,cs),
+(127,390,o),
+(116,401,o),
+(101,401,cs),
+(88,401,o),
+(75,390,o),
+(75,375,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(485,194,o),
+(498,181,o),
+(511,181,cs),
+(526,181,o),
+(537,194,o),
+(537,207,cs),
+(537,222,o),
+(526,233,o),
+(511,233,cs),
+(498,233,o),
+(485,222,o),
+(485,207,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(485,362,o),
+(498,349,o),
+(511,349,cs),
+(526,349,o),
+(537,362,o),
+(537,375,cs),
+(537,390,o),
+(526,401,o),
+(511,401,cs),
+(498,401,o),
+(485,390,o),
+(485,375,cs)
+);
+}
+);
+width = 603;
+}
+);
+note = uni25CC;
+unicode = 9676;
+},
+{
+glyphname = dotaccentcomb;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(159,761,o),
+(132,740,o),
+(124,697,cs),
+(114,649,o),
+(140,621,o),
+(195,621,cs),
+(242,621,o),
+(269,642,o),
+(276,685,cs),
+(286,734,o),
+(261,761,o),
+(206,761,cs)
+);
+}
+);
+width = 214;
+}
+);
+note = uni0307;
+unicode = 775;
+},
+{
+glyphname = dotaccent;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(244,621,o),
+(269,641,o),
+(277,683,cs),
+(288,733,o),
+(262,761,o),
+(206,761,cs),
+(160,761,o),
+(134,741,o),
+(126,699,cs),
+(115,649,o),
+(141,621,o),
+(197,621,cs)
+);
+}
+);
+width = 216;
+}
+);
+note = dotaccent;
+unicode = 729;
+},
+{
+glyphname = caron;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(378,645,o),
+(420,695,o),
+(474,753,c),
+(477,765,l),
+(375,765,l),
+(343,740,o),
+(317,713,o),
+(282,678,c),
+(262,712,o),
+(249,741,o),
+(228,765,c),
+(140,765,l),
+(137,753,l),
+(162,707,o),
+(188,655,o),
+(202,606,c),
+(348,606,l),
+(348,606,l)
+);
+}
+);
+width = 399;
+}
+);
+note = caron;
+unicode = 711;
+},
+{
+glyphname = breve;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(354,606,o),
+(416,663,o),
+(442,768,c),
+(357,768,l),
+(339,720,o),
+(312,697,o),
+(273,697,cs),
+(233,697,o),
+(216,719,o),
+(217,768,c),
+(140,768,l),
+(122,669,o),
+(171,606,o),
+(266,606,cs)
+);
+}
+);
+width = 363;
+}
+);
+note = breve;
+unicode = 728;
+},
+{
+glyphname = ring;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(286,606,o),
+(331,651,o),
+(331,723,cs),
+(331,793,o),
+(285,840,o),
+(229,840,cs),
+(170,840,o),
+(131,794,o),
+(131,723,cs),
+(131,652,o),
+(170,606,o),
+(229,606,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(209,672,o),
+(198,694,o),
+(198,723,cs),
+(198,753,o),
+(212,773,o),
+(229,773,cs),
+(247,773,o),
+(261,752,o),
+(261,723,cs),
+(261,695,o),
+(247,672,o),
+(229,672,cs)
+);
+}
+);
+width = 261;
+}
+);
+note = ring;
+unicode = 730;
+},
+{
+glyphname = ogonek;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(55,-234,o),
+(77,-230,o),
+(97,-222,c),
+(116,-137,l),
+(102,-143,o),
+(83,-147,o),
+(73,-147,cs),
+(51,-147,o),
+(42,-130,o),
+(48,-103,cs),
+(54,-71,o),
+(79,-36,o),
+(121,0,c),
+(68,21,l),
+(-4,-31,o),
+(-40,-77,o),
+(-50,-128,cs),
+(-63,-192,o),
+(-30,-234,o),
+(34,-234,cs)
+);
+}
+);
+width = 230;
+}
+);
+note = ogonek;
+unicode = 731;
+},
+{
+glyphname = ring_top.canadian;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (219,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(314,784,o),
+(364,828,o),
+(364,889,cs),
+(364,951,o),
+(314,995,o),
+(256,995,cs),
+(198,995,o),
+(149,951,o),
+(149,889,cs),
+(149,828,o),
+(198,784,o),
+(256,784,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(229,844,o),
+(212,864,o),
+(212,889,cs),
+(212,914,o),
+(230,935,o),
+(256,935,cs),
+(283,935,o),
+(301,914,o),
+(301,889,cs),
+(301,864,o),
+(283,844,o),
+(256,844,cs)
+);
+}
+);
+width = 243;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (108,357);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(146,289,o),
+(176,320,o),
+(176,357,cs),
+(176,394,o),
+(146,425,o),
+(108,425,cs),
+(71,425,o),
+(40,394,o),
+(40,357,cs),
+(40,320,o),
+(71,289,o),
+(108,289,cs)
+);
+}
+);
+width = 173;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (93,357);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(123,303,o),
+(147,326,o),
+(147,357,cs),
+(147,388,o),
+(123,411,o),
+(93,411,cs),
+(63,411,o),
+(39,388,o),
+(39,357,cs),
+(39,326,o),
+(63,303,o),
+(93,303,cs)
+);
+}
+);
+width = 142;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_small;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (77,357);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,318,o),
+(117,335,o),
+(117,357,cs),
+(117,379,o),
+(99,396,o),
+(77,396,cs),
+(55,396,o),
+(39,379,o),
+(39,357,cs),
+(39,335,o),
+(55,318,o),
+(77,318,cs)
+);
+}
+);
+width = 112;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_top;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (185,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(255,795,o),
+(287,826,o),
+(287,865,cs),
+(287,903,o),
+(255,935,o),
+(217,935,cs),
+(178,935,o),
+(147,903,o),
+(147,865,cs),
+(147,826,o),
+(178,795,o),
+(217,795,cs)
+);
+}
+);
+width = 173;
+}
+);
+note = g725;
+},
+{
+glyphname = doubledot_middle;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(188,383,o),
+(220,414,o),
+(220,452,cs),
+(220,491,o),
+(188,522,o),
+(150,522,cs),
+(111,522,o),
+(80,491,o),
+(80,452,cs),
+(80,413,o),
+(111,383,o),
+(150,383,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(148,192,o),
+(179,223,o),
+(179,262,cs),
+(179,300,o),
+(148,331,o),
+(109,331,cs),
+(71,331,o),
+(39,301,o),
+(39,262,cs),
+(39,223,o),
+(71,192,o),
+(109,192,cs)
+);
+}
+);
+width = 215;
+}
+);
+metricRight = "=|";
+note = g725;
+},
+{
+glyphname = doubledot_top;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top_double;
+pos = (363,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(432,795,o),
+(464,826,o),
+(464,865,cs),
+(464,903,o),
+(432,935,o),
+(394,935,cs),
+(355,935,o),
+(324,903,o),
+(324,865,cs),
+(324,826,o),
+(355,795,o),
+(394,795,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(253,795,o),
+(284,826,o),
+(284,865,cs),
+(284,903,o),
+(253,935,o),
+(214,935,cs),
+(176,935,o),
+(145,903,o),
+(145,865,cs),
+(145,826,o),
+(176,795,o),
+(214,795,cs)
+);
+}
+);
+width = 348;
+}
+);
+note = g725;
+},
+{
+glyphname = g727;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (414,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(520,0,l),
+(546,120,l),
+(263,120,ls),
+(211,120,o),
+(182,144,o),
+(182,190,cs),
+(182,247,o),
+(213,298,o),
+(299,298,cs),
+(381,298,ls),
+(553,298,o),
+(642,397,o),
+(642,539,cs),
+(642,645,o),
+(571,714,o),
+(461,714,cs),
+(154,714,l),
+(128,594,l),
+(413,594,ls),
+(466,594,o),
+(494,569,o),
+(494,524,cs),
+(494,466,o),
+(463,417,o),
+(377,417,cs),
+(296,417,ls),
+(122,417,o),
+(35,316,o),
+(35,175,cs),
+(35,69,o),
+(105,0,o),
+(216,0,cs)
+);
+}
+);
+width = 633;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+glyphname = g728;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (229,0);
+ref = dot_top;
+}
+);
+width = 632;
+}
+);
+note = g728;
+},
+{
+glyphname = g729;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (424,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(315,0,ls),
+(492,0,o),
+(579,99,o),
+(579,245,cs),
+(579,349,o),
+(512,417,o),
+(403,417,cs),
+(326,417,ls),
+(274,417,o),
+(245,440,o),
+(245,485,cs),
+(245,546,o),
+(277,594,o),
+(362,594,cs),
+(647,594,l),
+(672,714,l),
+(361,714,ls),
+(185,714,o),
+(98,614,o),
+(98,470,cs),
+(98,365,o),
+(164,298,o),
+(273,298,cs),
+(350,298,ls),
+(402,298,o),
+(431,274,o),
+(431,229,cs),
+(431,168,o),
+(399,120,o),
+(313,120,cs),
+(28,120,l),
+(3,0,l)
+);
+}
+);
+width = 633;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+glyphname = g730;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (239,0);
+ref = dot_top;
+}
+);
+width = 632;
+}
+);
+note = g730;
+},
+{
+glyphname = g731;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = g727;
+}
+);
+width = 843;
+}
+);
+note = g731;
+},
+{
+glyphname = g732;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (632,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 843;
+}
+);
+note = g732;
+},
+{
+glyphname = g733;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (440,0);
+ref = dot_top;
+}
+);
+width = 843;
+}
+);
+note = g733;
+},
+{
+glyphname = g734;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (229,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (632,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 843;
+}
+);
+note = g734;
+},
+{
+glyphname = g735;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = g729;
+}
+);
+width = 843;
+}
+);
+note = g735;
+},
+{
+glyphname = g736;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (632,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 843;
+}
+);
+note = g736;
+},
+{
+glyphname = g737;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (450,0);
+ref = dot_top;
+}
+);
+width = 843;
+}
+);
+note = g737;
+},
+{
+glyphname = g738;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (239,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (632,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 843;
+}
+);
+note = g738;
+},
+{
+glyphname = g739;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(509,270,o),
+(557,355,o),
+(557,431,cs),
+(557,498,o),
+(514,542,o),
+(446,542,cs),
+(299,542,l),
+(309,500,l),
+(341,534,o),
+(351,583,o),
+(351,613,cs),
+(351,677,o),
+(309,720,o),
+(243,720,cs),
+(152,720,o),
+(104,636,o),
+(104,560,cs),
+(104,493,o),
+(146,449,o),
+(215,449,cs),
+(361,449,l),
+(351,491,l),
+(317,455,o),
+(309,407,o),
+(309,379,cs),
+(309,314,o),
+(351,270,o),
+(418,270,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,520,o),
+(188,534,o),
+(188,558,cs),
+(188,586,o),
+(204,649,o),
+(238,649,cs),
+(256,649,o),
+(266,635,o),
+(266,611,cs),
+(266,584,o),
+(251,520,o),
+(217,520,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(405,342,o),
+(394,356,o),
+(394,380,cs),
+(394,407,o),
+(409,470,o),
+(444,470,cs),
+(462,470,o),
+(472,457,o),
+(472,433,cs),
+(472,405,o),
+(457,342,o),
+(423,342,cs)
+);
+}
+);
+width = 558;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+glyphname = g740;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (195,0);
+ref = ring_top.canadian;
+}
+);
+width = 632;
+}
+);
+note = g740;
+},
+{
+glyphname = g741;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (204,0);
+ref = ring_top.canadian;
+}
+);
+width = 632;
+}
+);
+note = g741;
+},
+{
+glyphname = g742;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (406,0);
+ref = ring_top.canadian;
+}
+);
+width = 843;
+}
+);
+note = g742;
+},
+{
+glyphname = stroke_middle;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (81,357);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,236,l),
+(149,478,l),
+(64,478,l),
+(13,236,l)
+);
+}
+);
+width = 117;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (69,357);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(83,279,l),
+(116,435,l),
+(55,435,l),
+(22,279,l)
+);
+}
+);
+width = 94;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_small;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (62,357);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(71,289,l),
+(99,425,l),
+(53,425,l),
+(24,289,l)
+);
+}
+);
+width = 79;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_threequart;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (81,357);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(94,239,l),
+(144,475,l),
+(67,475,l),
+(17,239,l)
+);
+}
+);
+width = 117;
+}
+);
+note = g723;
+},
+{
+color = 8;
+glyphname = uni11AB0;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (258,714);
+},
+{
+name = top_right_can;
+pos = (492,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(180,0,l),
+(198,85,l),
+(379,85,l),
+(396,165,l),
+(215,165,l),
+(240,286,l),
+(119,240,l),
+(154,240,ls),
+(368,240,o),
+(485,335,o),
+(535,568,cs),
+(566,714,l),
+(418,714,l),
+(389,578,ls),
+(360,443,o),
+(288,372,o),
+(160,372,cs),
+(111,372,l),
+(67,165,l),
+(6,165,l),
+(-11,85,l),
+(50,85,l),
+(32,0,l)
+);
+}
+);
+width = 521;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB1;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB0;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (307,0);
+ref = dot_top;
+}
+);
+width = 521;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB2;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (223,714);
+},
+{
+name = top_right_can;
+pos = (459,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(147,0,l),
+(176,136,ls),
+(205,271,o),
+(277,342,o),
+(405,342,cs),
+(453,342,l),
+(497,549,l),
+(559,549,l),
+(575,629,l),
+(514,629,l),
+(532,714,l),
+(385,714,l),
+(367,629,l),
+(186,629,l),
+(169,549,l),
+(350,549,l),
+(324,428,l),
+(446,474,l),
+(410,474,ls),
+(196,474,o),
+(80,379,o),
+(30,146,cs),
+(-1,0,l)
+);
+}
+);
+width = 521;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "theThCree-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB3;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB2;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (274,0);
+ref = dot_top;
+}
+);
+width = 521;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB4;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (259,714);
+},
+{
+name = top_right_can;
+pos = (494,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(415,0,l),
+(443,131,ls),
+(489,348,o),
+(387,474,o),
+(172,474,cs),
+(157,474,l),
+(271,429,l),
+(297,549,l),
+(479,549,l),
+(495,629,l),
+(314,629,l),
+(332,714,l),
+(185,714,l),
+(166,629,l),
+(105,629,l),
+(89,549,l),
+(150,549,l),
+(106,342,l),
+(136,342,ls),
+(271,342,o),
+(328,287,o),
+(295,134,cs),
+(267,0,l)
+);
+}
+);
+width = 522;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB5;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB4;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (73,0);
+ref = dot_top;
+}
+);
+width = 521;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB6;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (227,714);
+},
+{
+name = top_right_can;
+pos = (462,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(149,1,l),
+(210,288,l),
+(88,241,l),
+(121,241,ls),
+(345,241,o),
+(456,343,o),
+(507,582,cs),
+(525,667,l),
+(412,622,l),
+(578,419,l),
+(687,509,l),
+(519,715,l),
+(388,715,l),
+(361,592,ls),
+(329,445,o),
+(249,373,o),
+(118,373,cs),
+(80,373,l),
+(1,1,l)
+);
+}
+);
+width = 649;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB7;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB6;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (276,0);
+ref = dot_top;
+}
+);
+width = 648;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB8;
+kernRight = soright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (384,714);
+},
+{
+name = top_right_can;
+pos = (619,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(305,0,l),
+(332,123,ls),
+(364,270,o),
+(444,342,o),
+(575,342,cs),
+(613,342,l),
+(691.997,714,l),
+(545,714,l),
+(483,427,l),
+(606,474,l),
+(573,474,ls),
+(348,474,o),
+(238,372,o),
+(186,133,cs),
+(168,48,l),
+(281,93,l),
+(115,296,l),
+(6,206,l),
+(174,0,l)
+);
+}
+);
+width = 648;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB9;
+kernRight = soright;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB8;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (433,0);
+ref = dot_top;
+}
+);
+width = 648;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABA;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (226,714);
+},
+{
+name = top_right_can;
+pos = (461,714);
+}
+);
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(366,0,l),
+(622,206,l),
+(540,307,l),
+(340,147,l),
+(403,112,l),
+(411,148,ls),
+(446,318,o),
+(366,471,o),
+(180,471,cs),
+(145,471,l),
+(232,399,l),
+(299,714,l),
+(152,714,l),
+(73,342,l),
+(108,342,ls),
+(252,342,o),
+(294,278,o),
+(260,120,cs),
+(235,0,l)
+);
+}
+);
+width = 648;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABB;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+alignment = -1;
+ref = uni11ABA;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (40,0);
+ref = dot_top;
+}
+);
+width = 648;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABC;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(427,0,l),
+(456,134,l),
+(158,134,l),
+(158,84,l),
+(565,613,l),
+(587,714,l),
+(134,714,l),
+(105,580,l),
+(403,580,l),
+(404,630,l),
+(-4,101,l),
+(-25,0,l)
+);
+}
+);
+width = 517;
+}
+);
+metricRight = "=|";
+},
+{
+color = 8;
+glyphname = uni11ABD;
+lastChange = "2023-01-13 15:31:51 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(434,0,l),
+(456,101,l),
+(252,630,l),
+(252,580,l),
+(550,580,l),
+(578,714,l),
+(126,714,l),
+(105,613,l),
+(308,84,l),
+(308,134,l),
+(11,134,l),
+(-18,0,l)
+);
+}
+);
+width = 516;
+}
+);
+metricLeft = "=|uni11ABC";
+metricRight = "=|uni11ABC";
+},
+{
+color = 8;
+glyphname = uni11ABE;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(144,0,l),
+(269,588,l),
+(178,588,l),
+(360,0,l),
+(490,0,l),
+(642,714,l),
+(498,714,l),
+(372,126,l),
+(463,126,l),
+(281,714,l),
+(151,714,l),
+(-1,0,l)
+);
+}
+);
+width = 597;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABF;
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(129,0,l),
+(577,589,l),
+(470,589,l),
+(345,0,l),
+(490,0,l),
+(642,714,l),
+(512,714,l),
+(63,125,l),
+(170,125,l),
+(296,714,l),
+(151,714,l),
+(-1,0,l)
+);
+}
+);
+width = 597;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = "raiseddoubledotFinal-canadian.cree";
+lastChange = "2023-01-13 15:28:19 +0000";
+layers = (
+{
+layerId = "ABE41ABD-D787-4F86-A3B4-502CADE9F2A5";
+shapes = (
+{
+closed = 1;
+nodes = (
+(231,589,o),
+(262,620,o),
+(262,659,cs),
+(262,697,o),
+(231,728,o),
+(192,728,cs),
+(154,728,o),
+(123,698,o),
+(123,659,cs),
+(123,619,o),
+(154,589,o),
+(192,589,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(192,398,o),
+(223,430,o),
+(223,468,cs),
+(223,507,o),
+(192,538,o),
+(153,538,cs),
+(115,538,o),
+(83,507,o),
+(83,468,cs),
+(83,429,o),
+(115,398,o),
+(153,398,cs)
+);
+}
+);
+width = 213;
+}
+);
+note = g725;
+}
+);
+instances = (
+{
+axesValues = (
+154,
+75,
+12
+);
+instanceInterpolations = {
+"ABE41ABD-D787-4F86-A3B4-502CADE9F2A5" = 1;
+};
+name = "RC CB Italic";
+}
+);
+kerningLTR = {
+"ABE41ABD-D787-4F86-A3B4-502CADE9F2A5" = {
+"@MMK_L_caright" = {
+"@MMK_R_ecanleft" = -66;
+"@MMK_R_mwestleft" = -26;
+"@MMK_R_neleft" = -39;
+};
+"@MMK_L_ciright" = {
+"@MMK_R_icanleft" = -66;
+"@MMK_R_noleft" = -73;
+};
+"@MMK_L_ecanright" = {
+"@MMK_R_coleft" = -66;
+"@MMK_R_moleft" = -67;
+"@MMK_R_sileft" = -36;
+};
+"@MMK_L_icanright" = {
+"@MMK_R_celeft" = -66;
+"@MMK_R_meleft" = -67;
+"@MMK_R_mwestleft" = -53;
+"@MMK_R_saleft" = -30;
+"she-canadian" = -67;
+};
+"@MMK_L_maright" = {
+"@MMK_R_acanleft" = -58;
+"@MMK_R_ecanleft" = -67;
+"@MMK_R_mwestleft" = -44;
+"@MMK_R_neleft" = -39;
+};
+"@MMK_L_miright" = {
+"@MMK_R_acanleft" = -58;
+"@MMK_R_icanleft" = -67;
+"@MMK_R_moleft" = -92;
+"@MMK_R_noleft" = -73;
+"@MMK_R_yeleft" = -95;
+};
+"@MMK_L_mwestright" = {
+"@MMK_R_coleft" = -26;
+"@MMK_R_icanleft" = -53;
+"@MMK_R_moleft" = -44;
+"@MMK_R_noleft" = -70;
+"@MMK_R_sileft" = -13;
+"@MMK_R_yeleft" = -27;
+};
+"@MMK_L_naright" = {
+"@MMK_R_acanleft" = -67;
+"@MMK_R_celeft" = -73;
+"@MMK_R_meleft" = -73;
+"@MMK_R_mwestleft" = -70;
+"@MMK_R_neleft" = -78;
+"@MMK_R_saleft" = -42;
+};
+"@MMK_L_niright" = {
+"@MMK_R_coleft" = -39;
+"@MMK_R_moleft" = -39;
+"@MMK_R_noleft" = -78;
+"@MMK_R_sileft" = -1;
+};
+"@MMK_L_ocanright" = {
+"@MMK_R_meleft" = -58;
+"@MMK_R_moleft" = -58;
+"@MMK_R_noleft" = -67;
+};
+"@MMK_L_seright" = {
+"@MMK_R_ecanleft" = -36;
+"@MMK_R_mwestleft" = -13;
+"@MMK_R_neleft" = -1;
+};
+"@MMK_L_soright" = {
+"@MMK_R_icanleft" = -30;
+"@MMK_R_noleft" = -42;
+};
+"@MMK_L_yiright" = {
+"@MMK_R_meleft" = -95;
+"@MMK_R_mwestleft" = -27;
+};
+"shi-canadian" = {
+"@MMK_R_icanleft" = -67;
+};
+};
+};
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "italic angle";
+}
+);
+properties = (
+{
+key = copyrights;
+values = (
+{
+language = ENG;
+value = "Copyright 2018 Google Inc. All Rights Reserved.";
+}
+);
+},
+{
+key = manufacturers;
+values = (
+{
+language = ENG;
+value = "Monotype Imaging Inc.";
+}
+);
+},
+{
+key = designers;
+values = (
+{
+language = ENG;
+value = "Monotype Design Team";
+}
+);
+},
+{
+key = description;
+value = "Designed by Monotype design team.";
+},
+{
+key = trademarks;
+values = (
+{
+language = ENG;
+value = "Noto is a trademark of Google Inc.";
+}
+);
+},
+{
+key = licenseURL;
+value = "http://scripts.sil.org/OFL";
+},
+{
+key = licenses;
+values = (
+{
+language = ENG;
+value = "This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.";
+}
+);
+},
+{
+key = manufacturerURL;
+value = "http://www.google.com/get/noto/";
+},
+{
+key = designerURL;
+value = "http://www.monotype.com/studio";
+}
+);
+settings = {
+disablesNiceNames = 1;
+};
+stems = (
+{
+name = "New Stem";
+}
+);
+unitsPerEm = 1000;
+userData = {
+GSDontShowVersionAlert = 1;
+};
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/sources/Exported instances UCAS SansCanadianAboriginal/Sans Canadian Aboriginal-RC CB roman.glyphs
+++ b/sources/Exported instances UCAS SansCanadianAboriginal/Sans Canadian Aboriginal-RC CB roman.glyphs
@@ -1,0 +1,37305 @@
+{
+.appVersion = "3151";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+},
+{
+name = Width;
+tag = wdth;
+},
+{
+name = Slant;
+tag = slnt;
+}
+);
+classes = (
+{
+code = "zero one two three four five six seven eight nine ";
+name = Num;
+},
+{
+code = "zero.canadian one.canadian two.canadian three.canadian four.canadian five.canadian six.canadian seven.canadian eight.canadian nine.canadian 
+";
+name = Num_can;
+},
+{
+code = "ke-canadian.square ki-canadian.square kii-canadian.square ko-canadian.square koo-canadian.square ka-canadian.square kaa-canadian.square kweWestCree-canadian.square kwiiWestCree-canadian.square kwoWestCree-canadian.square kwooWestCree-canadian.square kwaWestCree-canadian.square kwaaWestCree-canadian.square ce-canadian.square ci-canadian.square cii-canadian.square co-canadian.square coo-canadian.square ca-canadian.square caa-canadian.square me-canadian.square mi-canadian.square mii-canadian.square mo-canadian.square moo-canadian.square ma-canadian.square maa-canadian.square ne-canadian.square ni-canadian.square nii-canadian.square no-canadian.square noo-canadian.square na-canadian.square naa-canadian.square nweWestCree-canadian.square nwaWestCree-canadian.square nwaaWestCree-canadian.square se-canadian.square si-canadian.square sii-canadian.square so-canadian.square soo-canadian.square sa-canadian.square saa-canadian.square sho-canadian.square shoo-canadian.square sha-canadian.square shaa-canadian.square ye-canadian.square yi-canadian.square yii-canadian.square yo-canadian.square yoo-canadian.square ya-canadian.square yaa-canadian.square re-canadian.square reRCree-canadian.square leWestCree-canadian.square ri-canadian.square rii-canadian.square ro-canadian.square loWestCree-canadian.square ra-canadian.square raa-canadian.square laWestCree-canadian.square reWestCree-canadian.square riWestCree-canadian.square roWestCree-canadian.square raWestCree-canadian.square theThCree-canadian.square thiThCree-canadian.square thiiThCree-canadian.square thoThCree-canadian.square thooThCree-canadian.square thaThCree-canadian.square thaaThCree-canadian.square thweeWoodScree-canadian.square thwiWoodScree-canadian.square thwiiWoodScree-canadian.square thwoWoodScree-canadian.square thwooWoodScree-canadian.square thwaWoodScree-canadian.square thwaaWoodScree-canadian.square nwiOjibway-canadian.square nwiiOjibway-canadian.square nwoOjibway-canadian.square nwooOjibway-canadian.square looWestCree-canadian.square laaWestCree-canadian.square ";
+name = Dene_square;
+},
+{
+code = "ke-canadian ki-canadian kii-canadian ko-canadian koo-canadian ka-canadian kaa-canadian kweWestCree-canadian kwiiWestCree-canadian kwoWestCree-canadian kwooWestCree-canadian kwaWestCree-canadian kwaaWestCree-canadian ce-canadian ci-canadian cii-canadian co-canadian coo-canadian ca-canadian caa-canadian me-canadian mi-canadian mii-canadian mo-canadian moo-canadian ma-canadian maa-canadian ne-canadian ni-canadian nii-canadian no-canadian noo-canadian na-canadian naa-canadian nweWestCree-canadian nwaWestCree-canadian nwaaWestCree-canadian se-canadian si-canadian sii-canadian so-canadian soo-canadian sa-canadian saa-canadian sho-canadian shoo-canadian sha-canadian shaa-canadian ye-canadian yi-canadian yii-canadian yo-canadian yoo-canadian ya-canadian yaa-canadian re-canadian reRCree-canadian leWestCree-canadian ri-canadian rii-canadian ro-canadian loWestCree-canadian ra-canadian raa-canadian laWestCree-canadian reWestCree-canadian riWestCree-canadian roWestCree-canadian raWestCree-canadian theThCree-canadian thiThCree-canadian thiiThCree-canadian thoThCree-canadian thooThCree-canadian thaThCree-canadian thaaThCree-canadian thweeWoodScree-canadian thwiWoodScree-canadian thwiiWoodScree-canadian thwoWoodScree-canadian thwooWoodScree-canadian thwaWoodScree-canadian thwaaWoodScree-canadian nwiOjibway-canadian nwiiOjibway-canadian nwoOjibway-canadian nwooOjibway-canadian looWestCree-canadian laaWestCree-canadian 
+";
+name = Dene_round;
+},
+{
+code = "acuteFinal-canadian.mid graveFinal-canadian.mid ringTophalfFinal-canadian.mid ringRighthalfFinal-canadian.mid ringFinal-canadian.mid doubleacuteFinal-canadian.mid doubleshortverticalstrokesFinal-canadian.mid shorthorizontalstrokeFinal-canadian.mid downtackFinal-canadian.mid pWestCree-canadian.mid c-canadian.mid mWestCree-canadian.mid ";
+name = Final_mid;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian ringFinal-canadian doubleacuteFinal-canadian doubleshortverticalstrokesFinal-canadian shorthorizontalstrokeFinal-canadian downtackFinal-canadian pWestCree-canadian c-canadian mWestCree-canadian ";
+name = Final_mid_ori;
+},
+{
+code = "acuteFinal-canadian.base graveFinal-canadian.base ringBottomhalfFinal-canadian.base ringTophalfFinal-canadian.base ringRighthalfFinal-canadian.base plusFinal-canadian.base pWestCree-canadian.base c-canadian.base thSayisi-canadian.base mWestCree-canadian.base ";
+name = Final_base;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringBottomhalfFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian plusFinal-canadian pWestCree-canadian c-canadian thSayisi-canadian mWestCree-canadian ";
+name = Final_base_ori;
+},
+{
+code = "ng-canadian ngai-canadian ngaai-canadian ngi-canadian ngii-canadian ngo-canadian ngoo-canadian nga-canadian ngaa-canadian ";
+name = Nunavik;
+},
+{
+code = "ng-canadian.nunavik ngai-canadian.nunavik ngaai-canadian.nunavik ngi-canadian.nunavik ngii-canadian.nunavik ngo-canadian.nunavik ngoo-canadian.nunavik nga-canadian.nunavik ngaa-canadian.nunavik ";
+name = Nunavik_alt;
+}
+);
+customParameters = (
+{
+name = vendorID;
+value = GOOG;
+},
+{
+name = panose;
+value = (
+2,
+11,
+5,
+2,
+4,
+5,
+4,
+2,
+2,
+4
+);
+},
+{
+name = unicodeRanges;
+value = (
+0,
+1,
+2,
+5,
+6,
+45,
+77
+);
+},
+{
+name = codePageRanges;
+value = (
+"1252"
+);
+},
+{
+name = fsType;
+value = (
+);
+}
+);
+date = "2022-06-21 10:06:40 +0000";
+familyName = "Sans Canadian Aboriginal";
+featurePrefixes = (
+{
+automatic = 1;
+code = "languagesystem DFLT dflt;
+
+languagesystem cans dflt;
+";
+name = Languagesystems;
+}
+);
+features = (
+{
+automatic = 1;
+code = "feature ss01;
+feature ss02;
+feature ss03;
+feature ss04;
+";
+tag = aalt;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+tag = salt;
+},
+{
+code = "lookup space_can {
+sub space by space.canadian;
+} space_can;
+
+lookup num_can {
+sub @Num by @Num_can;
+} num_can;
+";
+labels = (
+{
+language = dflt;
+value = "CAN Space and numerals";
+}
+);
+tag = ss01;
+},
+{
+code = "lookup dene_square {
+sub @Dene_round by @Dene_square;
+} dene_square;
+
+";
+labels = (
+{
+language = dflt;
+value = "Dene Square";
+}
+);
+tag = ss02;
+},
+{
+code = "lookup nunavik_alt {
+sub @Nunavik by @Nunavik_alt;
+} nunavik_alt;
+
+";
+labels = (
+{
+language = dflt;
+value = "Nunanvik Alt";
+}
+);
+tag = ss03;
+},
+{
+code = "lookup final_mid {
+sub @Final_mid_ori by @Final_mid;
+} final_mid;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final mid";
+}
+);
+tag = ss04;
+},
+{
+code = "lookup final_base {
+sub @Final_base_ori by @Final_base;
+} final_base;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final base";
+}
+);
+tag = ss05;
+},
+{
+code = "lookup plaincree_first {
+sub wiWestCree-canadian' plusFinal-canadian by i-canadian;
+} plaincree_first;
+
+lookup plaincree_second {
+sub i-canadian plusFinal-canadian' by raiseddoubledotFinal-canadian.cree;
+} plaincree_second;
+
+lookup plaincree_third {
+sub middledotFinal-canadian plusFinal-canadian by raiseddoubledotFinal-canadian.cree;
+} plaincree_third;
+";
+labels = (
+{
+language = dflt;
+value = Plaincree;
+}
+);
+tag = ss06;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+labels = (
+{
+language = dflt;
+value = "";
+}
+);
+tag = ss07;
+}
+);
+fontMaster = (
+{
+axesValues = (
+0,
+0,
+0
+);
+customParameters = (
+{
+name = typoAscender;
+value = 1069;
+},
+{
+name = typoDescender;
+value = -293;
+},
+{
+name = typoLineGap;
+value = 0;
+},
+{
+name = winAscent;
+value = 1069;
+},
+{
+name = winDescent;
+value = 293;
+},
+{
+name = hheaAscender;
+value = 1069;
+},
+{
+name = hheaDescender;
+value = -293;
+},
+{
+name = strikeoutPosition;
+value = 303.56287;
+},
+{
+name = strikeoutSize;
+value = 50;
+}
+);
+guides = (
+{
+locked = 1;
+pos = (432,357);
+}
+);
+id = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+metricValues = (
+{
+over = 23;
+pos = 1069;
+},
+{
+over = 23;
+pos = 714;
+},
+{
+over = 23;
+pos = 506;
+},
+{
+over = -23;
+},
+{
+over = -23;
+pos = -293;
+},
+{
+}
+);
+name = "RC CB roman";
+stemValues = (
+146
+);
+}
+);
+glyphs = (
+{
+glyphname = idotless;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(197,547,l),
+(51,547,l),
+(51,0,l),
+(197,0,l)
+);
+}
+);
+width = 248;
+}
+);
+note = dotlessi;
+unicode = 305;
+},
+{
+glyphname = "acuteFinal-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(128,357,l),
+(276,714,l),
+(166,714,l),
+(17,357,l)
+);
+}
+);
+width = 293;
+}
+);
+metricRight = "=|";
+note = uni141F;
+unicode = 5151;
+},
+{
+glyphname = "graveFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(276,357,l),
+(128,714,l),
+(17,714,l),
+(166,357,l)
+);
+}
+);
+width = 293;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+unicode = 5152;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(275,351,o),
+(330,404,o),
+(330,504,cs),
+(330,714,l),
+(232,714,l),
+(232,499,ls),
+(232,459,o),
+(217,438,o),
+(187,438,cs),
+(157,438,o),
+(143,459,o),
+(143,499,cs),
+(143,714,l),
+(45.005,714,l),
+(45,503,ls),
+(45,404,o),
+(101,351,o),
+(187,351,cs)
+);
+}
+);
+width = 375;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1421;
+unicode = 5153;
+},
+{
+glyphname = "ringTophalfFinal-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(143,357,l),
+(143,573,ls),
+(143,612,o),
+(157,633,o),
+(187,633,cs),
+(217,633,o),
+(232,612,o),
+(232,573,cs),
+(232,357,l),
+(330,357,l),
+(330,567,ls),
+(330,667,o),
+(275,720,o),
+(187,720,cs),
+(101,720,o),
+(45,667,o),
+(45,568,cs),
+(45.005,357,l)
+);
+}
+);
+width = 375;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+unicode = 5154;
+},
+{
+glyphname = "ringRighthalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,357,ls),
+(211,357,o),
+(274,426,o),
+(274,535,cs),
+(274,644,o),
+(211,714,o),
+(100,714,cs),
+(44,714,l),
+(44,622,l),
+(91,622,ls),
+(147,622,o),
+(176,590,o),
+(176,535,cs),
+(176,479,o),
+(147,449,o),
+(91,449,cs),
+(44,449,l),
+(44,357,l)
+);
+}
+);
+width = 315;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+unicode = 5155;
+},
+{
+glyphname = "ringFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(303,396,o),
+(371,466,o),
+(371,559,cs),
+(371,651,o),
+(302,720,o),
+(207,720,cs),
+(110,720,o),
+(41,651,o),
+(41,559,cs),
+(41,466,o),
+(109,396,o),
+(207,396,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(159,479,o),
+(131,513,o),
+(131,559,cs),
+(131,604,o),
+(159,637,o),
+(207,637,cs),
+(252,637,o),
+(281,602,o),
+(281,559,cs),
+(281,513,o),
+(252,479,o),
+(207,479,cs)
+);
+}
+);
+width = 412;
+}
+);
+note = uni1424;
+unicode = 5156;
+},
+{
+glyphname = "doubleacuteFinal-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(276,714,l),
+(166,714,l),
+(17,357,l),
+(128,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(436,714,l),
+(325,714,l),
+(178,357,l),
+(289,357,l)
+);
+}
+);
+width = 453;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricRight = "=|";
+note = uni1425;
+unicode = 5157;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(143,714,l),
+(45.005,714,l),
+(45.005,357,l),
+(143,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(283,714,l),
+(185,714,l),
+(185,357,l),
+(283,357,l)
+);
+}
+);
+width = 328;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "pWestCree-canadian";
+note = uni1426;
+unicode = 5158;
+},
+{
+glyphname = "middledotFinal-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(144,297,o),
+(175,328,o),
+(175,367,cs),
+(175,406,o),
+(144,437,o),
+(105,437,cs),
+(67,437,o),
+(36,406,o),
+(36,367,cs),
+(36,328,o),
+(67,297,o),
+(105,297,cs)
+);
+}
+);
+width = 211;
+}
+);
+note = uni1427;
+unicode = 5159;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(333,507,l),
+(333,606,l),
+(45,606,l),
+(45,507,l)
+);
+}
+);
+width = 378;
+}
+);
+metricRight = "=|";
+note = uni1428;
+unicode = 5160;
+},
+{
+glyphname = "plusFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(236,407,l),
+(236,516,l),
+(333,516,l),
+(333,608,l),
+(236,608,l),
+(236,714,l),
+(144,714,l),
+(144,608,l),
+(45,608,l),
+(45,516,l),
+(144,516,l),
+(144,407,l)
+);
+}
+);
+width = 378;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+unicode = 5161;
+},
+{
+glyphname = "downtackFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(238,357,l),
+(238,621,l),
+(333,621,l),
+(333,714,l),
+(45,714,l),
+(45,621,l),
+(141,621,l),
+(141,357,l)
+);
+}
+);
+width = 378;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni142A;
+unicode = 5162;
+},
+{
+glyphname = "thFinalWoodScree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(238,357,l),
+(238,419,l),
+(333,419,l),
+(333,501,l),
+(238,501,l),
+(238,570,l),
+(333,570,l),
+(333,652,l),
+(238,652,l),
+(238,714,l),
+(141,714,l),
+(141,652,l),
+(45,652,l),
+(45,570,l),
+(141,570,l),
+(141,501,l),
+(45,501,l),
+(45,419,l),
+(141,419,l),
+(141,357,l)
+);
+}
+);
+width = 378;
+}
+);
+metricLeft = "hyphen-canadian";
+metricRight = "hyphen-canadian";
+note = uni167E;
+unicode = 5758;
+},
+{
+glyphname = "ringSmallFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(210,517,o),
+(260,562,o),
+(260,623,cs),
+(260,684,o),
+(210,728,o),
+(152,728,cs),
+(95,728,o),
+(45,685,o),
+(45,623,cs),
+(45,562,o),
+(94,517,o),
+(152,517,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(126,577,o),
+(108,598,o),
+(108,623,cs),
+(108,648,o),
+(126,669,o),
+(153,669,cs),
+(179,669,o),
+(197,648,o),
+(197,623,cs),
+(197,598,o),
+(179,577,o),
+(153,577,cs)
+);
+}
+);
+width = 305;
+}
+);
+note = g725;
+unicode = 6366;
+},
+{
+glyphname = "raiseddotFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(145,589,o),
+(176,620,o),
+(176,659,cs),
+(176,697,o),
+(145,728,o),
+(106,728,cs),
+(68,728,o),
+(37,697,o),
+(37,659,cs),
+(37,620,o),
+(68,589,o),
+(106,589,cs)
+);
+}
+);
+width = 213;
+}
+);
+note = g725;
+unicode = 6367;
+},
+{
+glyphname = "acuteFinal-canadian.base";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "acuteFinal-canadian";
+}
+);
+width = 293;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.base";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "graveFinal-canadian";
+}
+);
+width = 293;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian.base";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 375;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1421;
+},
+{
+glyphname = "ringTophalfFinal-canadian.base";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 375;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.base";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 315;
+}
+);
+metricLeft = "==|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "plusFinal-canadian.base";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(236,0,l),
+(236,109,l),
+(333,109,l),
+(333,201,l),
+(236,201,l),
+(236,307,l),
+(144,307,l),
+(144,201,l),
+(45,201,l),
+(45,109,l),
+(144,109,l),
+(144,0,l)
+);
+}
+);
+width = 378;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+},
+{
+glyphname = "acuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "acuteFinal-canadian";
+}
+);
+width = 293;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.mid";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "graveFinal-canadian";
+}
+);
+width = 293;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringTophalfFinal-canadian.mid";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-178);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 375;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.mid";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 315;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "ringFinal-canadian.mid";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-203);
+ref = "ringFinal-canadian";
+}
+);
+width = 412;
+}
+);
+metricLeft = "ringFinal-canadian";
+metricWidth = "ringFinal-canadian";
+note = uni1424;
+},
+{
+glyphname = "doubleacuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "doubleacuteFinal-canadian";
+}
+);
+width = 453;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "doubleacuteFinal-canadian";
+note = uni1425;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian.mid";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "doubleshortverticalstrokesFinal-canadian";
+}
+);
+width = 328;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricWidth = "doubleshortverticalstrokesFinal-canadian";
+note = uni1426;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian.mid";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-189);
+ref = "shorthorizontalstrokeFinal-canadian";
+}
+);
+width = 378;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "shorthorizontalstrokeFinal-canadian";
+note = uni1428;
+},
+{
+glyphname = "downtackFinal-canadian.mid";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "downtackFinal-canadian";
+}
+);
+width = 378;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "downtackFinal-canadian";
+note = uni142A;
+},
+{
+glyphname = "e-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (319,470);
+},
+{
+name = top_center_can;
+pos = (319,714);
+},
+{
+name = top_left_can;
+pos = (123,714);
+},
+{
+name = top_right_can;
+pos = (515,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(339,0,l),
+(617,678,l),
+(617,714,l),
+(19,714,l),
+(19,678,l),
+(297,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(352,177,l),
+(176,626,l),
+(150,597,l),
+(483,597,l),
+(463,626,l),
+(287,177,l)
+);
+}
+);
+width = 636;
+}
+);
+metricRight = "=|";
+note = uni1401;
+unicode = 5121;
+},
+{
+glyphname = "aai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (197,0);
+ref = ring_top.canadian;
+}
+);
+width = 636;
+}
+);
+note = uni1402;
+unicode = 5122;
+},
+{
+glyphname = "i-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (317,301);
+},
+{
+name = top_center_can;
+pos = (318,714);
+},
+{
+name = top_left_can;
+pos = (122,714);
+},
+{
+name = top_right_can;
+pos = (514,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(617,0,l),
+(617,36,l),
+(339,714,l),
+(297,714,l),
+(19,36,l),
+(19,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(350,537,l),
+(284,537,l),
+(461,88,l),
+(481,117,l),
+(149,117,l),
+(173,88,l)
+);
+}
+);
+width = 636;
+}
+);
+metricLeft = "e-canadian";
+metricWidth = "e-canadian";
+note = uni1403;
+unicode = 5123;
+},
+{
+glyphname = "ii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (232,0);
+ref = dot_top;
+}
+);
+width = 636;
+}
+);
+note = uni1404;
+unicode = 5124;
+},
+{
+glyphname = "o-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (245,357);
+},
+{
+name = top_center_can;
+pos = (303,714);
+},
+{
+name = top_double;
+pos = (404,714);
+},
+{
+name = top_left_can;
+pos = (110,714);
+},
+{
+name = top_right_can;
+pos = (506,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(88,0,l),
+(565,334,l),
+(565,380,l),
+(88,714,l),
+(53,714,l),
+(53,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(174,550,l),
+(143,535,l),
+(433,330,l),
+(433,387,l),
+(143,181,l),
+(174,164,l)
+);
+}
+);
+width = 592;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1405;
+unicode = 5125;
+},
+{
+glyphname = "oo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (24,0);
+ref = dot_top;
+}
+);
+width = 592;
+}
+);
+note = uni1406;
+unicode = 5126;
+},
+{
+glyphname = "yCreeoo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (140,0);
+ref = doubledot_top;
+}
+);
+width = 592;
+}
+);
+note = uni1407;
+unicode = 5127;
+},
+{
+glyphname = "eeCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(88,0,l),
+(565,334,l),
+(565,380,l),
+(88,714,l),
+(53,714,l),
+(53,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(164,550,l),
+(143,545,l),
+(433,339,l),
+(433,377,l),
+(143,171,l),
+(164,164,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(262,425,l),
+(215,425,l),
+(215,289,l),
+(262,289,l)
+);
+}
+);
+width = 592;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "o-canadian";
+note = uni1408;
+unicode = 5128;
+},
+{
+glyphname = "iCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (190,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 592;
+}
+);
+note = uni1409;
+unicode = 5129;
+},
+{
+glyphname = "a-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (346,357);
+},
+{
+name = top_center_can;
+pos = (258,714);
+},
+{
+name = top_left_can;
+pos = (96,714);
+},
+{
+name = top_right_can;
+pos = (476,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(539,0,l),
+(539,714,l),
+(505,714,l),
+(27,380,l),
+(27,334,l),
+(505,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(449,180,l),
+(159,385,l),
+(159,328,l),
+(449,534,l),
+(419,550,l),
+(419,164,l)
+);
+}
+);
+width = 592;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni140A;
+unicode = 5130;
+},
+{
+glyphname = "aa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (389,0);
+ref = dot_top;
+}
+);
+width = 592;
+}
+);
+note = uni140B;
+unicode = 5131;
+},
+{
+glyphname = "we-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "e-canadian";
+}
+);
+width = 847;
+}
+);
+note = uni140C;
+unicode = 5132;
+},
+{
+glyphname = "weWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (636,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 847;
+}
+);
+note = uni140D;
+unicode = 5133;
+},
+{
+glyphname = "wi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "i-canadian";
+}
+);
+width = 847;
+}
+);
+note = uni140E;
+unicode = 5134;
+},
+{
+glyphname = "wiWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (636,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 847;
+}
+);
+note = uni140F;
+unicode = 5135;
+},
+{
+glyphname = "wii-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (443,0);
+ref = dot_top;
+}
+);
+width = 847;
+}
+);
+note = uni1410;
+unicode = 5136;
+},
+{
+glyphname = "wiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (232,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (636,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 847;
+}
+);
+note = uni1411;
+unicode = 5137;
+},
+{
+glyphname = "wo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "o-canadian";
+}
+);
+width = 803;
+}
+);
+note = uni1412;
+unicode = 5138;
+},
+{
+glyphname = "woWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (592,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 803;
+}
+);
+note = uni1413;
+unicode = 5139;
+},
+{
+glyphname = "woo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (428,0);
+ref = dot_top;
+}
+);
+width = 803;
+}
+);
+note = uni1414;
+unicode = 5140;
+},
+{
+glyphname = "wooWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (24,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (592,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 803;
+}
+);
+note = uni1415;
+unicode = 5141;
+},
+{
+glyphname = "wooNaskapi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (180,-95);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (335,-207);
+ref = dot_top;
+}
+);
+width = 592;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricWidth = "o-canadian";
+note = uni1416;
+unicode = 5142;
+},
+{
+glyphname = "wa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "a-canadian";
+}
+);
+width = 803;
+}
+);
+note = uni1417;
+unicode = 5143;
+},
+{
+glyphname = "waWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (592,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 803;
+}
+);
+note = uni1418;
+unicode = 5144;
+},
+{
+glyphname = "waa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (600,0);
+ref = dot_top;
+}
+);
+width = 803;
+}
+);
+note = uni1419;
+unicode = 5145;
+},
+{
+glyphname = "waaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (389,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (592,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 803;
+}
+);
+note = uni141A;
+unicode = 5146;
+},
+{
+glyphname = "waaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (81,-207);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (237,-95);
+ref = dot_top;
+}
+);
+width = 592;
+}
+);
+metricWidth = "a-canadian";
+note = uni141B;
+unicode = 5147;
+},
+{
+glyphname = "ai-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(225,351,o),
+(255,373,o),
+(281,424,c),
+(252,424,l),
+(276,372,o),
+(309,351,o),
+(359,351,cs),
+(436,351,o),
+(487,399,o),
+(487,497,cs),
+(487,714,l),
+(396,714,l),
+(396,500,ls),
+(396,453,o),
+(380,437,o),
+(354,437,cs),
+(327,437,o),
+(311,455,o),
+(311,500,cs),
+(311,714,l),
+(221,714,l),
+(221,500,ls),
+(221,454,o),
+(204,437,o),
+(178,437,cs),
+(151,437,o),
+(136,456,o),
+(136,500,cs),
+(136,714,l),
+(45.005,714,l),
+(45,497,ls),
+(45,399,o),
+(97,351,o),
+(174,351,cs)
+);
+}
+);
+width = 532;
+}
+);
+metricRight = "=|";
+note = uni141C;
+unicode = 5148;
+},
+{
+glyphname = "ycreew-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(300,528,o),
+(331,565,o),
+(331,625,cs),
+(331,685,o),
+(299,720,o),
+(255,720,cs),
+(211,720,o),
+(179,685,o),
+(179,625,cs),
+(179,565,o),
+(210,528,o),
+(255,528,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(164,351,o),
+(195,388,o),
+(195,448,cs),
+(195,508,o),
+(163,543,o),
+(119,543,cs),
+(75,543,o),
+(44,508,o),
+(44,448,cs),
+(44,388,o),
+(74,351,o),
+(119,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(103,398,o),
+(92,413,o),
+(92,448,cs),
+(92,482,o),
+(103,496,o),
+(119,496,cs),
+(136,496,o),
+(147,482,o),
+(147,448,cs),
+(147,413,o),
+(136,398,o),
+(119,398,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(238,575,o),
+(228,590,o),
+(228,625,cs),
+(228,659,o),
+(238,673,o),
+(255,673,cs),
+(272,673,o),
+(282,659,o),
+(282,625,cs),
+(282,590,o),
+(272,575,o),
+(255,575,cs)
+);
+}
+);
+width = 375;
+}
+);
+metricRight = "=|";
+note = uni141D;
+unicode = 5149;
+},
+{
+glyphname = "glottalstop-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(336,357,l),
+(336,376,l),
+(198,714,l),
+(176,714,l),
+(37,376,l),
+(37,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(209,617,l),
+(165,617,l),
+(248,401,l),
+(262,429,l),
+(113,429,l),
+(125,401,l)
+);
+}
+);
+width = 373;
+}
+);
+metricRight = "=|";
+note = uni141E;
+unicode = 5150;
+},
+{
+glyphname = "en-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+pos = (636,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 930;
+}
+);
+note = uni142B;
+unicode = 5163;
+},
+{
+glyphname = "in-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+pos = (430,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 723;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142C;
+unicode = 5164;
+},
+{
+glyphname = "on-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (454,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 747;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142D;
+unicode = 5165;
+},
+{
+glyphname = "an-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (563,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 856;
+}
+);
+metricRight = "graveFinal-canadian";
+note = uni142E;
+unicode = 5166;
+},
+{
+glyphname = "pe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (319,470);
+},
+{
+name = top_center_can;
+pos = (319,714);
+},
+{
+name = top_left_can;
+pos = (123,714);
+},
+{
+name = top_right_can;
+pos = (515,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(339,0,l),
+(617,678,l),
+(617,714,l),
+(487,714,l),
+(273,174,l),
+(368,174,l),
+(154,714,l),
+(19,714,l),
+(19,678,l),
+(297,0,l)
+);
+}
+);
+width = 636;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni142F;
+unicode = 5167;
+},
+{
+glyphname = "paai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (197,0);
+ref = ring_top.canadian;
+}
+);
+width = 636;
+}
+);
+note = uni1430;
+unicode = 5168;
+},
+{
+glyphname = "pi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (318,301);
+},
+{
+name = top_center_can;
+pos = (318,714);
+},
+{
+name = top_left_can;
+pos = (122,714);
+},
+{
+name = top_right_can;
+pos = (514,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(152,0,l),
+(365,540,l),
+(270,540,l),
+(483.992,0,l),
+(617,0,l),
+(617,36,l),
+(339,714,l),
+(297,714,l),
+(19,36,l),
+(19,0,l)
+);
+}
+);
+width = 636;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni1431;
+unicode = 5169;
+},
+{
+glyphname = "pii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (232,0);
+ref = dot_top;
+}
+);
+width = 636;
+}
+);
+note = uni1432;
+unicode = 5170;
+},
+{
+glyphname = "po-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (153,357);
+},
+{
+name = top_center_can;
+pos = (285,714);
+},
+{
+name = top_double;
+pos = (398,714);
+},
+{
+name = top_left_can;
+pos = (99,714);
+},
+{
+name = top_right_can;
+pos = (487,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(70,0,l),
+(546,334,l),
+(546,380,l),
+(70,714,l),
+(36,714,l),
+(36,576,l),
+(394,325,l),
+(394,391,l),
+(36,140,l),
+(36,0,l)
+);
+}
+);
+width = 573;
+}
+);
+metricRight = "o-canadian";
+note = uni1433;
+unicode = 5171;
+},
+{
+glyphname = "poo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (12,0);
+ref = dot_top;
+}
+);
+width = 573;
+}
+);
+note = uni1434;
+unicode = 5172;
+},
+{
+glyphname = "ycreepoo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (134,0);
+ref = doubledot_top;
+}
+);
+width = 573;
+}
+);
+note = uni1435;
+unicode = 5173;
+},
+{
+glyphname = "heeCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (106,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 573;
+}
+);
+note = uni1436;
+unicode = 5174;
+},
+{
+glyphname = "hiCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (81,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 573;
+}
+);
+note = uni1437;
+unicode = 5175;
+},
+{
+glyphname = "pa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (368,357);
+},
+{
+name = top_center_can;
+pos = (290,714);
+},
+{
+name = top_left_can;
+pos = (97,714);
+},
+{
+name = top_right_can;
+pos = (475,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(537,0,l),
+(537,138,l),
+(179,389,l),
+(179,323,l),
+(537,574,l),
+(537,714,l),
+(503,714,l),
+(27,380,l),
+(27,334,l),
+(503,0,l)
+);
+}
+);
+width = 573;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1438;
+unicode = 5176;
+},
+{
+glyphname = "paa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (388,0);
+ref = dot_top;
+}
+);
+width = 573;
+}
+);
+note = uni1439;
+unicode = 5177;
+},
+{
+glyphname = "pwe-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "pe-canadian";
+}
+);
+width = 847;
+}
+);
+note = uni143A;
+unicode = 5178;
+},
+{
+glyphname = "pweWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "pe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (636,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 847;
+}
+);
+note = uni143B;
+unicode = 5179;
+},
+{
+glyphname = "pwi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "pi-canadian";
+}
+);
+width = 847;
+}
+);
+note = uni143C;
+unicode = 5180;
+},
+{
+glyphname = "pwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (636,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 847;
+}
+);
+note = uni143D;
+unicode = 5181;
+},
+{
+glyphname = "pwii-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (443,0);
+ref = dot_top;
+}
+);
+width = 847;
+}
+);
+note = uni143E;
+unicode = 5182;
+},
+{
+glyphname = "pwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (232,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (636,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 847;
+}
+);
+note = uni143F;
+unicode = 5183;
+},
+{
+glyphname = "pwo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "po-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni1440;
+unicode = 5184;
+},
+{
+glyphname = "pwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (573,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni1441;
+unicode = 5185;
+},
+{
+glyphname = "pwoo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (409,0);
+ref = dot_top;
+}
+);
+width = 784;
+}
+);
+note = uni1442;
+unicode = 5186;
+},
+{
+glyphname = "pwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (12,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (573,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni1443;
+unicode = 5187;
+},
+{
+glyphname = "pwa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "pa-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni1444;
+unicode = 5188;
+},
+{
+glyphname = "pwaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (573,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni1445;
+unicode = 5189;
+},
+{
+glyphname = "pwaa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (599,0);
+ref = dot_top;
+}
+);
+width = 784;
+}
+);
+note = uni1446;
+unicode = 5190;
+},
+{
+glyphname = "pwaaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (388,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (573,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni1447;
+unicode = 5191;
+},
+{
+glyphname = "ycreepwaa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+pos = (81,-207);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (236,-95);
+ref = dot_top;
+}
+);
+width = 573;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1448;
+unicode = 5192;
+},
+{
+glyphname = "p-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(295,357,l),
+(295,448,l),
+(122,572,l),
+(122,498,l),
+(295,621,l),
+(295,714,l),
+(278,714,l),
+(45,548,l),
+(45,524,l),
+(278,357,l)
+);
+}
+);
+width = 340;
+}
+);
+note = uni1449;
+unicode = 5193;
+},
+{
+glyphname = "pWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(143,357,l),
+(143,714,l),
+(45.005,714,l),
+(45.005,357,l)
+);
+}
+);
+width = 188;
+}
+);
+metricRight = "=|";
+note = uni144A;
+unicode = 5194;
+},
+{
+color = 6;
+glyphname = "hCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(143,189,l),
+(143,315,ls),
+(143,346,o),
+(155,365,o),
+(180,365,cs),
+(203,365,o),
+(214,348,o),
+(214,319,cs),
+(214,189,l),
+(311,189,l),
+(311,335,ls),
+(311,421,o),
+(256,452,o),
+(208,452,cs),
+(163,452,o),
+(131,426,o),
+(123,394,c),
+(143,375,l),
+(143,546,l),
+(45.005,546,l),
+(45.005,189,l)
+);
+}
+);
+width = 342;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144B;
+unicode = 5195;
+},
+{
+glyphname = "te-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (320,357);
+},
+{
+name = top_center_can;
+pos = (320,714);
+},
+{
+name = top_left_can;
+pos = (125,714);
+},
+{
+name = top_right_can;
+pos = (517,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(494,-14,o),
+(590,88,o),
+(590,281,cs),
+(590,714,l),
+(443,714,l),
+(443,282,ls),
+(443,169,o),
+(401,121,o),
+(320,121,cs),
+(242,121,o),
+(198,172,o),
+(198,282,cs),
+(198,714,l),
+(50,714,l),
+(50,280,ls),
+(50,88,o),
+(150,-14,o),
+(321,-14,cs)
+);
+}
+);
+width = 640;
+}
+);
+metricRight = "=|";
+note = uni144C;
+unicode = 5196;
+},
+{
+glyphname = "taai-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (199,0);
+ref = ring_top.canadian;
+}
+);
+width = 641;
+}
+);
+note = uni144D;
+unicode = 5197;
+},
+{
+glyphname = "ti-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (320,357);
+},
+{
+name = middle_right_can;
+pos = (716,357);
+},
+{
+name = top_center_can;
+pos = (320,714);
+},
+{
+name = top_left_can;
+pos = (125,714);
+},
+{
+name = top_right_can;
+pos = (517,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(198,0,l),
+(198,432,ls),
+(198,544,o),
+(240,593,o),
+(321,593,cs),
+(399,593,o),
+(443,542,o),
+(443,432,cs),
+(443,0,l),
+(590,0,l),
+(590,434,ls),
+(590,626,o),
+(492,728,o),
+(321,728,cs),
+(154,728,o),
+(50,626,o),
+(50,434,cs),
+(50,0,l)
+);
+}
+);
+width = 640;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni144E;
+unicode = 5198;
+},
+{
+glyphname = "tii-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (234,0);
+ref = dot_top;
+}
+);
+width = 641;
+}
+);
+note = uni144F;
+unicode = 5199;
+},
+{
+glyphname = "to-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (194,357);
+},
+{
+name = middle_right_can;
+pos = (620,357);
+},
+{
+name = top_center_can;
+pos = (244,714);
+},
+{
+name = top_double;
+pos = (320,714);
+},
+{
+name = top_left_can;
+pos = (101,714);
+},
+{
+name = top_right_can;
+pos = (432,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(153,0,ls),
+(370,0,o),
+(495,120,o),
+(495,358,cs),
+(495,596,o),
+(370,714,o),
+(151,714,cs),
+(38,714,l),
+(38,580,l),
+(151,580,ls),
+(276,580,o),
+(348,515,o),
+(348,358,cs),
+(348,201,o),
+(276,134,o),
+(153,134,cs),
+(38,134,l),
+(38,0,l)
+);
+}
+);
+width = 540;
+}
+);
+note = uni1450;
+unicode = 5200;
+},
+{
+glyphname = "too-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (158,0);
+ref = dot_top;
+}
+);
+width = 540;
+}
+);
+note = uni1451;
+unicode = 5201;
+},
+{
+glyphname = "ycreetoo-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (56,0);
+ref = doubledot_top;
+}
+);
+width = 540;
+}
+);
+note = uni1452;
+unicode = 5202;
+},
+{
+glyphname = "deeCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (136,0);
+ref = stroke_middle;
+}
+);
+width = 540;
+}
+);
+note = uni1453;
+unicode = 5203;
+},
+{
+glyphname = "diCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (107,0);
+ref = dot_middle;
+}
+);
+width = 540;
+}
+);
+note = uni1454;
+unicode = 5204;
+},
+{
+glyphname = "ta-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (347,357);
+},
+{
+name = top_center_can;
+pos = (297,714);
+},
+{
+name = top_left_can;
+pos = (109,714);
+},
+{
+name = top_right_can;
+pos = (439,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(502,0,l),
+(502,134,l),
+(389,134,ls),
+(265,134,o),
+(193,199,o),
+(193,356,cs),
+(193,513,o),
+(265,580,o),
+(388,580,cs),
+(502,580,l),
+(502,714,l),
+(388,714,ls),
+(170,714,o),
+(45,594,o),
+(45,356,cs),
+(45,119,o),
+(170,0,o),
+(389,0,cs)
+);
+}
+);
+width = 540;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|to-canadian";
+note = uni1455;
+unicode = 5205;
+},
+{
+glyphname = "taa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (210,0);
+ref = dot_top;
+}
+);
+width = 540;
+}
+);
+note = uni1456;
+unicode = 5206;
+},
+{
+glyphname = "twe-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "te-canadian";
+}
+);
+width = 852;
+}
+);
+note = uni1457;
+unicode = 5207;
+},
+{
+glyphname = "tweWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (641,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 852;
+}
+);
+note = uni1458;
+unicode = 5208;
+},
+{
+glyphname = "twi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ti-canadian";
+}
+);
+width = 852;
+}
+);
+note = uni1459;
+unicode = 5209;
+},
+{
+glyphname = "twiWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (641,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 852;
+}
+);
+note = uni145A;
+unicode = 5210;
+},
+{
+glyphname = "twii-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (445,0);
+ref = dot_top;
+}
+);
+width = 852;
+}
+);
+note = uni145B;
+unicode = 5211;
+},
+{
+glyphname = "twiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (234,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (641,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 852;
+}
+);
+note = uni145C;
+unicode = 5212;
+},
+{
+glyphname = "two-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "to-canadian";
+}
+);
+width = 750;
+}
+);
+note = uni145D;
+unicode = 5213;
+},
+{
+glyphname = "twoWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (540,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 750;
+}
+);
+note = uni145E;
+unicode = 5214;
+},
+{
+glyphname = "twoo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (369,0);
+ref = dot_top;
+}
+);
+width = 750;
+}
+);
+note = uni145F;
+unicode = 5215;
+},
+{
+glyphname = "twooWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (158,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (540,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 750;
+}
+);
+note = uni1460;
+unicode = 5216;
+},
+{
+glyphname = "twa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ta-canadian";
+}
+);
+width = 750;
+}
+);
+note = uni1461;
+unicode = 5217;
+},
+{
+glyphname = "twaWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (540,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 750;
+}
+);
+note = uni1462;
+unicode = 5218;
+},
+{
+glyphname = "twaa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (421,0);
+ref = dot_top;
+}
+);
+width = 750;
+}
+);
+note = uni1463;
+unicode = 5219;
+},
+{
+glyphname = "twaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (210,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (540,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 750;
+}
+);
+note = uni1464;
+unicode = 5220;
+},
+{
+glyphname = "twaaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (214,0);
+ref = "ta-canadian";
+}
+);
+width = 754;
+}
+);
+note = uni1465;
+unicode = 5221;
+},
+{
+glyphname = "t-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(271,357,l),
+(271,449,l),
+(223,449,ls),
+(168,449,o),
+(139,479,o),
+(139,535,cs),
+(139,590,o),
+(168,622,o),
+(223,622,cs),
+(271,622,l),
+(271,714,l),
+(214,714,ls),
+(103,714,o),
+(41,644,o),
+(41,535,cs),
+(41,426,o),
+(103,357,o),
+(214,357,cs)
+);
+}
+);
+width = 315;
+}
+);
+note = uni1466;
+unicode = 5222;
+},
+{
+glyphname = "tte-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+pos = (641,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 828;
+}
+);
+note = uni1467;
+unicode = 5223;
+},
+{
+glyphname = "tti-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+pos = (641,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 828;
+}
+);
+note = uni1468;
+unicode = 5224;
+},
+{
+glyphname = "tto-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+pos = (540,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 727;
+}
+);
+note = uni1469;
+unicode = 5225;
+},
+{
+glyphname = "tta-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+pos = (540,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 727;
+}
+);
+note = uni146A;
+unicode = 5226;
+},
+{
+glyphname = "ke-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (265,457);
+},
+{
+name = top_center_can;
+pos = (260,714);
+},
+{
+name = top_left_can;
+pos = (112,714);
+},
+{
+name = top_right_can;
+pos = (406,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(479.002,0,l),
+(479,456,ls),
+(479,629,o),
+(403,728,o),
+(264,728,cs),
+(125,728,o),
+(40,626,o),
+(40,457,cs),
+(40,297,o),
+(120,193,o),
+(239,193,cs),
+(294,193,o),
+(335,226,o),
+(345,262,c),
+(332,284,l),
+(332,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(215,318,o),
+(184,360,o),
+(184,461,cs),
+(184,562,o),
+(212,604,o),
+(259,604,cs),
+(306,604,o),
+(335,563,o),
+(335,461,cs),
+(335,359,o),
+(304,318,o),
+(259,318,cs)
+);
+}
+);
+width = 529;
+}
+);
+metricRight = "te-canadian";
+note = uni146B;
+unicode = 5227;
+},
+{
+glyphname = "kaai-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (148,0);
+ref = ring_top.canadian;
+}
+);
+width = 529;
+}
+);
+note = uni146C;
+unicode = 5228;
+},
+{
+glyphname = "ki-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (275,457);
+},
+{
+name = top_center_can;
+pos = (270,714);
+},
+{
+name = top_left_can;
+pos = (124,714);
+},
+{
+name = top_right_can;
+pos = (418,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(198,0,l),
+(198,284,l),
+(185,262,l),
+(194,226,o),
+(235,193,o),
+(291,193,cs),
+(410,193,o),
+(490,298,o),
+(490,458,cs),
+(490,626,o),
+(405,728,o),
+(270,728,cs),
+(127,728,o),
+(50,623,o),
+(50,456,cs),
+(50,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(226,318,o),
+(195,359,o),
+(195,461,cs),
+(195,563,o),
+(223,604,o),
+(270,604,cs),
+(317,604,o),
+(345,562,o),
+(345,461,cs),
+(345,360,o),
+(315,318,o),
+(270,318,cs)
+);
+}
+);
+width = 530;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni146D;
+unicode = 5229;
+},
+{
+glyphname = "kii-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (183,0);
+ref = dot_top;
+}
+);
+width = 529;
+}
+);
+note = uni146E;
+unicode = 5230;
+},
+{
+glyphname = "ko-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (265,309);
+},
+{
+name = top_center_can;
+pos = (260,714);
+},
+{
+name = top_double;
+pos = (406,714);
+},
+{
+name = top_left_can;
+pos = (112,714);
+},
+{
+name = top_right_can;
+pos = (406,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(401,-14,o),
+(479,85,o),
+(479,258,cs),
+(479.002,714,l),
+(332,714,l),
+(332,430,l),
+(345,452,l),
+(335,488,o),
+(294,521,o),
+(239,521,cs),
+(120,521,o),
+(40,416,o),
+(40,250,cs),
+(40,88,o),
+(121,-14,o),
+(262,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(212,110,o),
+(184,152,o),
+(184,253,cs),
+(184,354,o),
+(215,396,o),
+(259,396,cs),
+(304,396,o),
+(335,355,o),
+(335,253,cs),
+(335,151,o),
+(306,110,o),
+(259,110,cs)
+);
+}
+);
+width = 529;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni146F;
+unicode = 5231;
+},
+{
+glyphname = "koo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (320,0);
+ref = dot_top;
+}
+);
+width = 529;
+}
+);
+note = uni1470;
+unicode = 5232;
+},
+{
+glyphname = "ycreekoo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (142,0);
+ref = doubledot_top;
+}
+);
+width = 529;
+}
+);
+note = uni1471;
+unicode = 5233;
+},
+{
+glyphname = "ka-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (275,313);
+},
+{
+name = top_center_can;
+pos = (270,714);
+},
+{
+name = top_left_can;
+pos = (124,714);
+},
+{
+name = top_right_can;
+pos = (418,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(404,-14,o),
+(490,88,o),
+(490,257,cs),
+(490,416,o),
+(410,521,o),
+(292,521,cs),
+(236,521,o),
+(195,488,o),
+(185,452,c),
+(198,430,l),
+(198,714,l),
+(50,714,l),
+(50,258,ls),
+(50,85,o),
+(126,-14,o),
+(266,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(223,110,o),
+(195,151,o),
+(195,253,cs),
+(195,355,o),
+(226,396,o),
+(270,396,cs),
+(315,396,o),
+(345,354,o),
+(345,253,cs),
+(345,152,o),
+(317,110,o),
+(270,110,cs)
+);
+}
+);
+width = 530;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "==|ke-canadian";
+note = uni1472;
+unicode = 5234;
+},
+{
+glyphname = "kaa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (37,0);
+ref = dot_top;
+}
+);
+width = 529;
+}
+);
+note = uni1473;
+unicode = 5235;
+},
+{
+glyphname = "kwe-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ke-canadian";
+}
+);
+width = 740;
+}
+);
+note = uni1474;
+unicode = 5236;
+},
+{
+glyphname = "kweWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (529,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 740;
+}
+);
+note = uni1475;
+unicode = 5237;
+},
+{
+glyphname = "kwi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ki-canadian";
+}
+);
+width = 740;
+}
+);
+note = uni1476;
+unicode = 5238;
+},
+{
+glyphname = "kwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (529,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 740;
+}
+);
+note = uni1477;
+unicode = 5239;
+},
+{
+glyphname = "kwii-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (394,0);
+ref = dot_top;
+}
+);
+width = 740;
+}
+);
+note = uni1478;
+unicode = 5240;
+},
+{
+glyphname = "kwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (183,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (529,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 740;
+}
+);
+note = uni1479;
+unicode = 5241;
+},
+{
+glyphname = "kwo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ko-canadian";
+}
+);
+width = 740;
+}
+);
+note = uni147A;
+unicode = 5242;
+},
+{
+glyphname = "kwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (529,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 740;
+}
+);
+note = uni147B;
+unicode = 5243;
+},
+{
+glyphname = "kwoo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (531,0);
+ref = dot_top;
+}
+);
+width = 740;
+}
+);
+note = uni147C;
+unicode = 5244;
+},
+{
+glyphname = "kwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (320,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (529,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 740;
+}
+);
+note = uni147D;
+unicode = 5245;
+},
+{
+glyphname = "kwa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ka-canadian";
+}
+);
+width = 740;
+}
+);
+note = uni147E;
+unicode = 5246;
+},
+{
+glyphname = "kwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (529,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 740;
+}
+);
+note = uni147F;
+unicode = 5247;
+},
+{
+glyphname = "kwaa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (248,0);
+ref = dot_top;
+}
+);
+width = 740;
+}
+);
+note = uni1480;
+unicode = 5248;
+},
+{
+glyphname = "kwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (37,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (529,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 740;
+}
+);
+note = uni1481;
+unicode = 5249;
+},
+{
+glyphname = "kwaaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (214,0);
+ref = "ka-canadian";
+}
+);
+width = 744;
+}
+);
+note = uni1482;
+unicode = 5250;
+},
+{
+glyphname = "k-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(238,351,o),
+(293,396,o),
+(293,492,cs),
+(293,575,o),
+(249,622,o),
+(191,622,cs),
+(155,622,o),
+(127,599,o),
+(122,565,c),
+(143,565,l),
+(143,714,l),
+(45.005,714,l),
+(45,487,ls),
+(45,404,o),
+(90,351,o),
+(171,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(149,422,o),
+(135,438,o),
+(135,486,cs),
+(135,534,o),
+(150,551,o),
+(170,551,cs),
+(190,551,o),
+(206,535,o),
+(206,486,cs),
+(206,438,o),
+(190,422,o),
+(170,422,cs)
+);
+}
+);
+width = 328;
+}
+);
+note = uni1483;
+unicode = 5251;
+},
+{
+glyphname = "kw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(237,351,o),
+(283,404,o),
+(283,487,cs),
+(283,714,l),
+(185,714,l),
+(185,565,l),
+(206,565,l),
+(200,599,o),
+(173,622,o),
+(136,622,cs),
+(79,622,o),
+(35,575,o),
+(35,492,cs),
+(35,396,o),
+(89,351,o),
+(157,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(138,422,o),
+(122,438,o),
+(122,486,cs),
+(122,535,o),
+(138,551,o),
+(158,551,cs),
+(177,551,o),
+(193,534,o),
+(193,486,cs),
+(193,438,o),
+(178,422,o),
+(158,422,cs)
+);
+}
+);
+width = 328;
+}
+);
+metricLeft = "=|k-canadian";
+metricRight = "=|k-canadian";
+note = uni1484;
+unicode = 5252;
+},
+{
+glyphname = "southslaveykeh-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+pos = (529,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 717;
+}
+);
+note = uni1485;
+unicode = 5253;
+},
+{
+glyphname = "southslaveykih-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+pos = (529,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 717;
+}
+);
+note = uni1486;
+unicode = 5254;
+},
+{
+glyphname = "southslaveykoh-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+pos = (529,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 717;
+}
+);
+note = uni1487;
+unicode = 5255;
+},
+{
+glyphname = "southslaveykah-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+pos = (529,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 717;
+}
+);
+note = uni1488;
+unicode = 5256;
+},
+{
+glyphname = "ce-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (259,384);
+},
+{
+name = top_center_can;
+pos = (256,714);
+},
+{
+name = top_left_can;
+pos = (111,714);
+},
+{
+name = top_right_can;
+pos = (397,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(470,0,l),
+(470,467,ls),
+(470,631,o),
+(395,728,o),
+(256,728,cs),
+(120,728,o),
+(37,637,o),
+(37,468,cs),
+(37,395,l),
+(183,395,l),
+(183,494,ls),
+(183,563,o),
+(207,600,o),
+(254,600,cs),
+(298,600,o),
+(323,565,o),
+(323,492,cs),
+(323,0,l)
+);
+}
+);
+width = 520;
+}
+);
+metricRight = "te-canadian";
+note = uni1489;
+unicode = 5257;
+},
+{
+glyphname = "caai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (148,0);
+ref = ring_top.canadian;
+}
+);
+width = 521;
+}
+);
+note = uni148A;
+unicode = 5258;
+},
+{
+glyphname = "ci-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (271,384);
+},
+{
+name = top_center_can;
+pos = (269,714);
+},
+{
+name = top_left_can;
+pos = (125,714);
+},
+{
+name = top_right_can;
+pos = (411,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(198,0,l),
+(198,492,ls),
+(198,565,o),
+(223,600,o),
+(268,600,cs),
+(314,600,o),
+(338,563,o),
+(338,494,cs),
+(338,395,l),
+(484,395,l),
+(484,468,ls),
+(484,637,o),
+(402,728,o),
+(269,728,cs),
+(125,728,o),
+(50,630,o),
+(50,467,cs),
+(50,0,l)
+);
+}
+);
+width = 521;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+unicode = 5259;
+},
+{
+glyphname = "cii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (183,0);
+ref = dot_top;
+}
+);
+width = 521;
+}
+);
+note = uni148C;
+unicode = 5260;
+},
+{
+glyphname = "co-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (259,384);
+},
+{
+name = top_center_can;
+pos = (255,714);
+},
+{
+name = top_double;
+pos = (397,714);
+},
+{
+name = top_left_can;
+pos = (111,714);
+},
+{
+name = top_right_can;
+pos = (397,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(395,-14,o),
+(470,83,o),
+(470,247,cs),
+(470,714,l),
+(323,714,l),
+(323,222,ls),
+(323,149,o),
+(298,114,o),
+(254,114,cs),
+(207,114,o),
+(183,151,o),
+(183,221,cs),
+(183,319,l),
+(37,319,l),
+(37,246,ls),
+(37,77,o),
+(118,-14,o),
+(258,-14,cs)
+);
+}
+);
+width = 520;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+unicode = 5261;
+},
+{
+glyphname = "coo-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (311,0);
+ref = dot_top;
+}
+);
+width = 521;
+}
+);
+note = uni148E;
+unicode = 5262;
+},
+{
+glyphname = "ycreecoo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (133,0);
+ref = doubledot_top;
+}
+);
+width = 521;
+}
+);
+note = uni148F;
+unicode = 5263;
+},
+{
+glyphname = "ca-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (271,384);
+},
+{
+name = top_center_can;
+pos = (269,714);
+},
+{
+name = top_left_can;
+pos = (125,714);
+},
+{
+name = top_right_can;
+pos = (411,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(402,-14,o),
+(484,77,o),
+(484,246,cs),
+(484,319,l),
+(338,319,l),
+(338,221,ls),
+(338,151,o),
+(314,114,o),
+(267,114,cs),
+(223,114,o),
+(198,149,o),
+(198,223,cs),
+(198,714,l),
+(50,714,l),
+(50,247,ls),
+(50,83,o),
+(125,-14,o),
+(266,-14,cs)
+);
+}
+);
+width = 521;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+unicode = 5264;
+},
+{
+glyphname = "caa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (38,0);
+ref = dot_top;
+}
+);
+width = 521;
+}
+);
+note = uni1491;
+unicode = 5265;
+},
+{
+glyphname = "cwe-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ce-canadian";
+}
+);
+width = 732;
+}
+);
+note = uni1492;
+unicode = 5266;
+},
+{
+glyphname = "cweWestCree-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (521,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 732;
+}
+);
+note = uni1493;
+unicode = 5267;
+},
+{
+glyphname = "cwi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ci-canadian";
+}
+);
+width = 732;
+}
+);
+note = uni1494;
+unicode = 5268;
+},
+{
+glyphname = "cwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (521,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 732;
+}
+);
+note = uni1495;
+unicode = 5269;
+},
+{
+glyphname = "cwii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (394,0);
+ref = dot_top;
+}
+);
+width = 732;
+}
+);
+note = uni1496;
+unicode = 5270;
+},
+{
+glyphname = "cwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (183,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (521,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 732;
+}
+);
+note = uni1497;
+unicode = 5271;
+},
+{
+glyphname = "cwo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "co-canadian";
+}
+);
+width = 732;
+}
+);
+note = uni1498;
+unicode = 5272;
+},
+{
+glyphname = "cwoWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (521,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 732;
+}
+);
+note = uni1499;
+unicode = 5273;
+},
+{
+glyphname = "cwoo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (522,0);
+ref = dot_top;
+}
+);
+width = 732;
+}
+);
+note = uni149A;
+unicode = 5274;
+},
+{
+glyphname = "cwooWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (311,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (521,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 732;
+}
+);
+note = uni149B;
+unicode = 5275;
+},
+{
+glyphname = "cwa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ca-canadian";
+}
+);
+width = 732;
+}
+);
+note = uni149C;
+unicode = 5276;
+},
+{
+glyphname = "cwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (521,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 732;
+}
+);
+note = uni149D;
+unicode = 5277;
+},
+{
+glyphname = "cwaa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (249,0);
+ref = dot_top;
+}
+);
+width = 732;
+}
+);
+note = uni149E;
+unicode = 5278;
+},
+{
+glyphname = "cwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (38,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (521,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 732;
+}
+);
+note = uni149F;
+unicode = 5279;
+},
+{
+glyphname = "cwaaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (214,0);
+ref = "ca-canadian";
+}
+);
+width = 735;
+}
+);
+note = uni14A0;
+unicode = 5280;
+},
+{
+glyphname = "c-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(247,351,o),
+(295,399,o),
+(295,483,cs),
+(295,507,l),
+(205,507,l),
+(205,468,ls),
+(205,443,o),
+(192,427,o),
+(173,427,cs),
+(152,427,o),
+(143,442,o),
+(143,470,cs),
+(143,714,l),
+(45.005,714,l),
+(45,487,ls),
+(45,398,o),
+(89,351,o),
+(171,351,cs)
+);
+}
+);
+width = 319;
+}
+);
+note = uni14A1;
+unicode = 5281;
+},
+{
+glyphname = "thSayisi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(230,351,o),
+(274,398,o),
+(274,487,cs),
+(274,714,l),
+(176,714,l),
+(176,470,ls),
+(176,442,o),
+(167,427,o),
+(146,427,cs),
+(126,427,o),
+(114,443,o),
+(114,468,cs),
+(114,507,l),
+(24,507,l),
+(24,483,ls),
+(24,399,o),
+(72,351,o),
+(152,351,cs)
+);
+}
+);
+width = 319;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "=|c-canadian";
+note = uni14A2;
+unicode = 5282;
+},
+{
+glyphname = "me-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (159,357);
+},
+{
+name = top_center_can;
+pos = (236,714);
+},
+{
+name = top_left_can;
+pos = (105,714);
+},
+{
+name = top_right_can;
+pos = (359,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(433,0,l),
+(433,714,l),
+(32,714,l),
+(32,580,l),
+(285,580,l),
+(285,0,l)
+);
+}
+);
+width = 486;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+unicode = 5283;
+},
+{
+glyphname = "maai-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (133,0);
+ref = ring_top.canadian;
+}
+);
+width = 486;
+}
+);
+note = uni14A4;
+unicode = 5284;
+},
+{
+glyphname = "mi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (328,357);
+},
+{
+name = top_center_can;
+pos = (254,714);
+},
+{
+name = top_left_can;
+pos = (127,714);
+},
+{
+name = top_right_can;
+pos = (381,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,0,l),
+(200,580,l),
+(454,580,l),
+(454,714,l),
+(53,714,l),
+(53,0,l)
+);
+}
+);
+width = 486;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+unicode = 5285;
+},
+{
+glyphname = "mii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (167,0);
+ref = dot_top;
+}
+);
+width = 486;
+}
+);
+note = uni14A6;
+unicode = 5286;
+},
+{
+glyphname = "mo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (159,357);
+},
+{
+name = top_center_can;
+pos = (236,714);
+},
+{
+name = top_double;
+pos = (360,714);
+},
+{
+name = top_left_can;
+pos = (105,714);
+},
+{
+name = top_right_can;
+pos = (359,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(433,0,l),
+(433,714,l),
+(285,714,l),
+(285,134,l),
+(32,134,l),
+(32,0,l)
+);
+}
+);
+width = 486;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+unicode = 5287;
+},
+{
+glyphname = "moo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (273,0);
+ref = dot_top;
+}
+);
+width = 486;
+}
+);
+note = uni14A8;
+unicode = 5288;
+},
+{
+glyphname = "ycreemoo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (96,0);
+ref = doubledot_top;
+}
+);
+width = 486;
+}
+);
+note = uni14A9;
+unicode = 5289;
+},
+{
+glyphname = "ma-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (328,357);
+},
+{
+name = top_center_can;
+pos = (254,714);
+},
+{
+name = top_left_can;
+pos = (127,714);
+},
+{
+name = top_right_can;
+pos = (380,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(454,0,l),
+(454,134,l),
+(200,134,l),
+(200,714,l),
+(53,714,l),
+(53,0,l)
+);
+}
+);
+width = 486;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+unicode = 5290;
+},
+{
+glyphname = "maa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (41,0);
+ref = dot_top;
+}
+);
+width = 486;
+}
+);
+note = uni14AB;
+unicode = 5291;
+},
+{
+glyphname = "mwe-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "me-canadian";
+}
+);
+width = 697;
+}
+);
+note = uni14AC;
+unicode = 5292;
+},
+{
+glyphname = "mweWestCree-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "me-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (486,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 697;
+}
+);
+note = uni14AD;
+unicode = 5293;
+},
+{
+glyphname = "mwi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "mi-canadian";
+}
+);
+width = 697;
+}
+);
+note = uni14AE;
+unicode = 5294;
+},
+{
+glyphname = "mwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (486,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 697;
+}
+);
+note = uni14AF;
+unicode = 5295;
+},
+{
+glyphname = "mwii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (378,0);
+ref = dot_top;
+}
+);
+width = 697;
+}
+);
+note = uni14B0;
+unicode = 5296;
+},
+{
+glyphname = "mwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (167,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (486,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 697;
+}
+);
+note = uni14B1;
+unicode = 5297;
+},
+{
+glyphname = "mwo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "mo-canadian";
+}
+);
+width = 697;
+}
+);
+note = uni14B2;
+unicode = 5298;
+},
+{
+glyphname = "mwoWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (486,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 697;
+}
+);
+note = uni14B3;
+unicode = 5299;
+},
+{
+glyphname = "mwoo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (484,0);
+ref = dot_top;
+}
+);
+width = 697;
+}
+);
+note = uni14B4;
+unicode = 5300;
+},
+{
+glyphname = "mwooWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (273,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (486,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 697;
+}
+);
+note = uni14B5;
+unicode = 5301;
+},
+{
+glyphname = "mwa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ma-canadian";
+}
+);
+width = 697;
+}
+);
+note = uni14B6;
+unicode = 5302;
+},
+{
+glyphname = "mwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (486,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 697;
+}
+);
+note = uni14B7;
+unicode = 5303;
+},
+{
+glyphname = "mwaa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (252,0);
+ref = dot_top;
+}
+);
+width = 697;
+}
+);
+note = uni14B8;
+unicode = 5304;
+},
+{
+glyphname = "mwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (41,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (486,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 697;
+}
+);
+note = uni14B9;
+unicode = 5305;
+},
+{
+glyphname = "mwaaNaskapi-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (214,0);
+ref = "ma-canadian";
+}
+);
+width = 700;
+}
+);
+note = uni14BA;
+unicode = 5306;
+},
+{
+glyphname = "m-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(266,449,l),
+(143,449,l),
+(143,714,l),
+(45.005,714,l),
+(45.005,357,l),
+(266,357,l)
+);
+}
+);
+width = 294;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni14BB;
+unicode = 5307;
+},
+{
+glyphname = "mWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+ref = "t-canadian";
+}
+);
+width = 315;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "t-canadian";
+note = uni14BC;
+unicode = 5308;
+},
+{
+glyphname = "mh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(248,357,l),
+(248,714,l),
+(151,714,l),
+(151,449,l),
+(28,449,l),
+(28,357,l)
+);
+}
+);
+width = 293;
+}
+);
+metricLeft = "=|m-canadian";
+metricRight = "=|m-canadian";
+note = uni14BD;
+unicode = 5309;
+},
+{
+glyphname = "mAthapascan-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(273,357,l),
+(273,439,l),
+(141,439,l),
+(144,399,l),
+(220,491,ls),
+(253,532,o),
+(268,574,o),
+(268,610,cs),
+(268,670,o),
+(235,720,o),
+(157,720,cs),
+(77,720,o),
+(36,667,o),
+(35,590,c),
+(122,590,l),
+(122,636,o),
+(133,651,o),
+(154,651,cs),
+(172,651,o),
+(181,637,o),
+(181,609,cs),
+(181,583,o),
+(176,561,o),
+(142,520,cs),
+(48,409,l),
+(48,357,l)
+);
+}
+);
+width = 309;
+}
+);
+note = uni14BE;
+unicode = 5310;
+},
+{
+glyphname = "mSayisi-canadian";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = two.canadian;
+}
+);
+width = 522;
+}
+);
+note = uni14BF;
+unicode = 5311;
+},
+{
+glyphname = "ne-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (445,254);
+},
+{
+name = top_center_can;
+pos = (429,526);
+},
+{
+name = top_left_can;
+pos = (112,526);
+},
+{
+name = top_right_can;
+pos = (596,526);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(577,-14,o),
+(668,75,o),
+(668,246,cs),
+(668,419,o),
+(580,506,o),
+(424,506,cs),
+(38,506,l),
+(38,374,l),
+(283,374,l),
+(272,408,l),
+(240,371,o),
+(223,305,o),
+(223,239,cs),
+(223,74,o),
+(309,-14,o),
+(445,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(396,110,o),
+(367,152,o),
+(367,246,cs),
+(367,338,o),
+(396,382,o),
+(445,382,cs),
+(494,382,o),
+(524,341,o),
+(524,246,cs),
+(524,152,o),
+(495,110,o),
+(445,110,cs)
+);
+}
+);
+width = 708;
+}
+);
+metricRight = "=|ke-canadian";
+note = uni14C0;
+unicode = 5312;
+},
+{
+glyphname = "naai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (161,-188);
+ref = ring_top.canadian;
+}
+);
+width = 708;
+}
+);
+note = uni14C1;
+unicode = 5313;
+},
+{
+glyphname = "ni-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (265,254);
+},
+{
+name = top_center_can;
+pos = (283,526);
+},
+{
+name = top_left_can;
+pos = (112,526);
+},
+{
+name = top_right_can;
+pos = (596,526);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(399,-14,o),
+(485,74,o),
+(485,239,cs),
+(485,305,o),
+(467,371,o),
+(435,408,c),
+(424,374,l),
+(669,374,l),
+(669,506,l),
+(284,506,ls),
+(128,506,o),
+(40,413,o),
+(40,243,cs),
+(40,74,o),
+(130,-14,o),
+(263,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(213,110,o),
+(184,152,o),
+(184,247,cs),
+(184,342,o),
+(214,384,o),
+(263,384,cs),
+(312,384,o),
+(341,340,o),
+(341,247,cs),
+(341,152,o),
+(312,110,o),
+(263,110,cs)
+);
+}
+);
+width = 707;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+unicode = 5314;
+},
+{
+glyphname = "nii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (196,-188);
+ref = dot_top;
+}
+);
+width = 708;
+}
+);
+note = uni14C3;
+unicode = 5315;
+},
+{
+glyphname = "no-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (443,254);
+},
+{
+name = top_center_can;
+pos = (443,526);
+},
+{
+name = top_double;
+pos = (445,526);
+},
+{
+name = top_left_can;
+pos = (112,526);
+},
+{
+name = top_right_can;
+pos = (596,526);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(426,0,ls),
+(580,0,o),
+(668,88,o),
+(668,260,cs),
+(668,431,o),
+(578,521,o),
+(445,521,cs),
+(309,521,o),
+(223,431,o),
+(223,267,cs),
+(223,202,o),
+(240,136,o),
+(273,99,c),
+(283,133,l),
+(38,133,l),
+(38,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(396,123,o),
+(367,167,o),
+(367,259,cs),
+(367,354,o),
+(396,396,o),
+(445,396,cs),
+(495,396,o),
+(524,355,o),
+(524,259,cs),
+(524,164,o),
+(494,123,o),
+(445,123,cs)
+);
+}
+);
+width = 708;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14C4;
+unicode = 5316;
+},
+{
+glyphname = "noo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (357,-188);
+ref = dot_top;
+}
+);
+width = 708;
+}
+);
+note = uni14C5;
+unicode = 5317;
+},
+{
+glyphname = "ycreenoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (181,-188);
+ref = doubledot_top;
+}
+);
+width = 708;
+}
+);
+note = uni14C6;
+unicode = 5318;
+},
+{
+glyphname = "na-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (265,254);
+},
+{
+name = top_center_can;
+pos = (264,526);
+},
+{
+name = top_double;
+pos = (426,526);
+},
+{
+name = top_left_can;
+pos = (112,526);
+},
+{
+name = top_right_can;
+pos = (596,526);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(669,0,l),
+(669,133,l),
+(424,133,l),
+(435,98,l),
+(467,135,o),
+(485,201,o),
+(485,267,cs),
+(485,432,o),
+(399,521,o),
+(263,521,cs),
+(130,521,o),
+(40,431,o),
+(40,260,cs),
+(40,89,o),
+(127,0,o),
+(283,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(214,123,o),
+(184,164,o),
+(184,259,cs),
+(184,355,o),
+(213,396,o),
+(263,396,cs),
+(312,396,o),
+(341,354,o),
+(341,259,cs),
+(341,167,o),
+(312,123,o),
+(263,123,cs)
+);
+}
+);
+width = 707;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+unicode = 5319;
+},
+{
+glyphname = "naa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (178,-188);
+ref = dot_top;
+}
+);
+width = 708;
+}
+);
+note = uni14C8;
+unicode = 5320;
+},
+{
+glyphname = "nwe-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ne-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni14C9;
+unicode = 5321;
+},
+{
+glyphname = "nweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (708,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni14CA;
+unicode = 5322;
+},
+{
+glyphname = "nwa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "na-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni14CB;
+unicode = 5323;
+},
+{
+glyphname = "nwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (708,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni14CC;
+unicode = 5324;
+},
+{
+glyphname = "nwaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (389,-188);
+ref = dot_top;
+}
+);
+width = 919;
+}
+);
+note = uni14CD;
+unicode = 5325;
+},
+{
+glyphname = "nwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (178,-188);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (708,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni14CE;
+unicode = 5326;
+},
+{
+glyphname = "nwaaNaskapi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (162,-188);
+ref = doubledot_top;
+}
+);
+width = 708;
+}
+);
+note = uni14CF;
+unicode = 5327;
+},
+{
+glyphname = "n-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(377,449,l),
+(377,542,l),
+(242,542,l),
+(247,499,l),
+(264,511,o),
+(278,547,o),
+(278,590,cs),
+(278,670,o),
+(235,720,o),
+(157,720,cs),
+(80,720,o),
+(35.005,668.007,o),
+(35,585,cs),
+(35,503,o),
+(80,449,o),
+(162,449,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(135,520,o),
+(121,539,o),
+(121,585,cs),
+(121,631,o),
+(135,649,o),
+(157,649,cs),
+(179,649,o),
+(192,629,o),
+(192,584,cs),
+(192,540,o),
+(179,520,o),
+(157,520,cs)
+);
+}
+);
+width = 406;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni14D0;
+unicode = 5328;
+},
+{
+color = 6;
+glyphname = "ngCarrier-canadian";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-167);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 375;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "=|";
+note = uni14D1;
+unicode = 5329;
+},
+{
+glyphname = "nh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(244,449,ls),
+(325,449,o),
+(371,503,o),
+(371,585,cs),
+(371,668,o),
+(326,720,o),
+(249,720,cs),
+(170,720,o),
+(128,670,o),
+(128,590,cs),
+(128,547,o),
+(142,511,o),
+(159,499,c),
+(164,542,l),
+(29,542,l),
+(29,449,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(227,520,o),
+(214,540,o),
+(214,584,cs),
+(214,629,o),
+(227,649,o),
+(249,649,cs),
+(271,649,o),
+(284,631,o),
+(284,585,cs),
+(284,539,o),
+(271,520,o),
+(249,520,cs)
+);
+}
+);
+width = 406;
+}
+);
+metricLeft = "=|n-canadian";
+metricRight = "=|n-canadian";
+note = uni14D2;
+unicode = 5330;
+},
+{
+glyphname = "le-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (444,254);
+},
+{
+name = top_center_can;
+pos = (431,526);
+},
+{
+name = top_left_can;
+pos = (112,526);
+},
+{
+name = top_right_can;
+pos = (596,526);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(413,0,ls),
+(570,0,o),
+(668,88,o),
+(668,253,cs),
+(668,418,o),
+(575,506,o),
+(413,506,cs),
+(38,506,l),
+(38,373,l),
+(405,373,ls),
+(480,373,o),
+(522,333,o),
+(522,251,cs),
+(522,170,o),
+(480,129,o),
+(401,129,cs),
+(377,129,l),
+(377,0,l)
+);
+}
+);
+width = 708;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D3;
+unicode = 5331;
+},
+{
+glyphname = "laai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (161,-188);
+ref = ring_top.canadian;
+}
+);
+width = 708;
+}
+);
+note = uni14D4;
+unicode = 5332;
+},
+{
+glyphname = "li-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (265,254);
+},
+{
+name = top_center_can;
+pos = (283,526);
+},
+{
+name = top_left_can;
+pos = (113,526);
+},
+{
+name = top_right_can;
+pos = (596,526);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(331,0,l),
+(331,129,l),
+(307,129,ls),
+(227,129,o),
+(186,170,o),
+(186,251,cs),
+(186,332,o),
+(226,373,o),
+(303,373,cs),
+(669,373,l),
+(669,506,l),
+(295,506,ls),
+(140,506,o),
+(40,418,o),
+(40,253,cs),
+(40,88,o),
+(138,0,o),
+(295,0,cs)
+);
+}
+);
+width = 707;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14D5;
+unicode = 5333;
+},
+{
+glyphname = "lii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (196,-188);
+ref = dot_top;
+}
+);
+width = 708;
+}
+);
+note = uni14D6;
+unicode = 5334;
+},
+{
+glyphname = "lo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (443,254);
+},
+{
+name = top_center_can;
+pos = (443,526);
+},
+{
+name = top_double;
+pos = (414,526);
+},
+{
+name = top_left_can;
+pos = (112,526);
+},
+{
+name = top_right_can;
+pos = (596,526);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(413,0,ls),
+(568,0,o),
+(668,88,o),
+(668,253,cs),
+(668,419,o),
+(570,506,o),
+(414,506,cs),
+(377,506,l),
+(377,377,l),
+(401,377,ls),
+(481,377,o),
+(522,337,o),
+(522,256,cs),
+(522,174,o),
+(481,133,o),
+(405,133,cs),
+(38,133,l),
+(38,0,l)
+);
+}
+);
+width = 708;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D7;
+unicode = 5335;
+},
+{
+glyphname = "loo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (357,-188);
+ref = dot_top;
+}
+);
+width = 708;
+}
+);
+note = uni14D8;
+unicode = 5336;
+},
+{
+glyphname = "ycreeloo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (150,-188);
+ref = doubledot_top;
+}
+);
+width = 708;
+}
+);
+note = uni14D9;
+unicode = 5337;
+},
+{
+glyphname = "la-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (265,254);
+},
+{
+name = top_center_can;
+pos = (264,526);
+},
+{
+name = top_left_can;
+pos = (113,526);
+},
+{
+name = top_right_can;
+pos = (596,526);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(669,0,l),
+(669,133,l),
+(303,133,ls),
+(227,133,o),
+(186,174,o),
+(186,255,cs),
+(186,336,o),
+(227,377,o),
+(306,377,cs),
+(331,377,l),
+(331,506,l),
+(294,506,ls),
+(137,506,o),
+(40,417,o),
+(40,253,cs),
+(40,88,o),
+(140,0,o),
+(295,0,cs)
+);
+}
+);
+width = 707;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14DA;
+unicode = 5338;
+},
+{
+glyphname = "laa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (178,-188);
+ref = dot_top;
+}
+);
+width = 708;
+}
+);
+note = uni14DB;
+unicode = 5339;
+},
+{
+glyphname = "lwe-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "le-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni14DC;
+unicode = 5340;
+},
+{
+glyphname = "lweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "le-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (708,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni14DD;
+unicode = 5341;
+},
+{
+glyphname = "lwi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "li-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni14DE;
+unicode = 5342;
+},
+{
+glyphname = "lwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (708,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni14DF;
+unicode = 5343;
+},
+{
+glyphname = "lwii-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (407,-188);
+ref = dot_top;
+}
+);
+width = 919;
+}
+);
+note = uni14E0;
+unicode = 5344;
+},
+{
+glyphname = "lwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (196,-188);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (708,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni14E1;
+unicode = 5345;
+},
+{
+glyphname = "lwo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "lo-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni14E2;
+unicode = 5346;
+},
+{
+glyphname = "lwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (708,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni14E3;
+unicode = 5347;
+},
+{
+glyphname = "lwoo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (568,-188);
+ref = dot_top;
+}
+);
+width = 919;
+}
+);
+note = uni14E4;
+unicode = 5348;
+},
+{
+glyphname = "lwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (357,-188);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (708,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni14E5;
+unicode = 5349;
+},
+{
+glyphname = "lwa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "la-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni14E6;
+unicode = 5350;
+},
+{
+glyphname = "lwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (708,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni14E7;
+unicode = 5351;
+},
+{
+glyphname = "lwaa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (389,-188);
+ref = dot_top;
+}
+);
+width = 919;
+}
+);
+note = uni14E8;
+unicode = 5352;
+},
+{
+glyphname = "lwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (178,-188);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (708,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni14E9;
+unicode = 5353;
+},
+{
+glyphname = "l-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(363,357,l),
+(363,449,l),
+(224,449,ls),
+(168,449,o),
+(138,479,o),
+(138,535,cs),
+(138,591,o),
+(168,623,o),
+(219,623,cs),
+(227,623,l),
+(227,714,l),
+(212,714,ls),
+(104,714,o),
+(41,644,o),
+(41,535,cs),
+(41,426,o),
+(104,357,o),
+(214,357,cs)
+);
+}
+);
+width = 391;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "m-canadian";
+note = uni14EA;
+unicode = 5354;
+},
+{
+glyphname = "lWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(255,357,l),
+(255,423,l),
+(113,493,l),
+(113,444,l),
+(255,514,l),
+(255,557,l),
+(113,629,l),
+(113,578,l),
+(255,647,l),
+(255,714,l),
+(239,714,l),
+(45,619,l),
+(45,587,l),
+(188,517,l),
+(188,553,l),
+(45,483,l),
+(45,451,l),
+(239,357,l)
+);
+}
+);
+width = 300;
+}
+);
+metricRight = "=|";
+note = uni14EB;
+unicode = 5355;
+},
+{
+glyphname = "mediall-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(486,-14,l),
+(486,96,l),
+(180,246,l),
+(180,180,l),
+(486,327,l),
+(486,387,l),
+(180,534,l),
+(180,468,l),
+(486,618,l),
+(486,728,l),
+(452,728,l),
+(49,531,l),
+(49,478,l),
+(355,330,l),
+(355,384,l),
+(49,236,l),
+(49,183,l),
+(452,-14,l)
+);
+}
+);
+width = 535;
+}
+);
+metricRight = "=|";
+note = uni14EC;
+unicode = 5356;
+},
+{
+glyphname = "se-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (127,714);
+},
+{
+name = top_right_can;
+pos = (362,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(435,0,l),
+(435,372,l),
+(397,372,ls),
+(266,372,o),
+(200,423,o),
+(200,591,cs),
+(200,714,l),
+(53,714,l),
+(53,581,ls),
+(53,352,o),
+(164,240,o),
+(366,240,cs),
+(400,240,l),
+(287,286,l),
+(287,0,l)
+);
+}
+);
+width = 489;
+}
+);
+note = uni14ED;
+unicode = 5357;
+},
+{
+glyphname = "saai-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (241,0);
+ref = ring_top.canadian;
+}
+);
+width = 489;
+}
+);
+note = uni14EE;
+unicode = 5358;
+},
+{
+glyphname = "si-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (128,714);
+},
+{
+name = top_right_can;
+pos = (362,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(201,0,l),
+(201,286,l),
+(89,240,l),
+(123,240,ls),
+(325,240,o),
+(436,352,o),
+(436,581,cs),
+(436,714,l),
+(288,714,l),
+(288,591,ls),
+(288,423,o),
+(223,372,o),
+(92,372,cs),
+(54,372,l),
+(54,0,l)
+);
+}
+);
+width = 489;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+unicode = 5359;
+},
+{
+glyphname = "sii-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (276,0);
+ref = dot_top;
+}
+);
+width = 489;
+}
+);
+note = uni14F0;
+unicode = 5360;
+},
+{
+glyphname = "so-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (362,714);
+},
+{
+name = top_left_can;
+pos = (127,714);
+},
+{
+name = top_right_can;
+pos = (361,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,0,l),
+(200,123,ls),
+(200,291,o),
+(266,342,o),
+(397,342,cs),
+(435,342,l),
+(435,714,l),
+(287,714,l),
+(287,428,l),
+(400,474,l),
+(366,474,ls),
+(164,474,o),
+(53,362,o),
+(53,133,cs),
+(53,0,l)
+);
+}
+);
+width = 489;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+unicode = 5361;
+},
+{
+glyphname = "soo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (275,0);
+ref = dot_top;
+}
+);
+width = 489;
+}
+);
+note = uni14F2;
+unicode = 5362;
+},
+{
+glyphname = "ycreesoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (98,0);
+ref = doubledot_top;
+}
+);
+width = 489;
+}
+);
+note = uni14F3;
+unicode = 5363;
+},
+{
+glyphname = "sa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (128,714);
+},
+{
+name = top_right_can;
+pos = (362,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(436,0,l),
+(436,133,ls),
+(436,362,o),
+(325,474,o),
+(123,474,cs),
+(89,474,l),
+(201,428,l),
+(201,714,l),
+(54,714,l),
+(54,342,l),
+(92,342,ls),
+(223,342,o),
+(288,291,o),
+(288,123,cs),
+(288,0,l)
+);
+}
+);
+width = 489;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+unicode = 5364;
+},
+{
+glyphname = "saa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (41,0);
+ref = dot_top;
+}
+);
+width = 489;
+}
+);
+note = uni14F5;
+unicode = 5365;
+},
+{
+glyphname = "swe-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "se-canadian";
+}
+);
+width = 699;
+}
+);
+note = uni14F6;
+unicode = 5366;
+},
+{
+glyphname = "sweWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "se-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (489,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 699;
+}
+);
+note = uni14F7;
+unicode = 5367;
+},
+{
+glyphname = "swi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "si-canadian";
+}
+);
+width = 699;
+}
+);
+note = uni14F8;
+unicode = 5368;
+},
+{
+glyphname = "swiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (489,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 699;
+}
+);
+note = uni14F9;
+unicode = 5369;
+},
+{
+glyphname = "swii-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (487,0);
+ref = dot_top;
+}
+);
+width = 699;
+}
+);
+note = uni14FA;
+unicode = 5370;
+},
+{
+glyphname = "swiiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (276,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (489,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 699;
+}
+);
+note = uni14FB;
+unicode = 5371;
+},
+{
+glyphname = "swo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "so-canadian";
+}
+);
+width = 699;
+}
+);
+note = uni14FC;
+unicode = 5372;
+},
+{
+glyphname = "swoWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (489,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 699;
+}
+);
+note = uni14FD;
+unicode = 5373;
+},
+{
+glyphname = "swoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (486,0);
+ref = dot_top;
+}
+);
+width = 699;
+}
+);
+note = uni14FE;
+unicode = 5374;
+},
+{
+glyphname = "swooWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (275,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (489,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 699;
+}
+);
+note = uni14FF;
+unicode = 5375;
+},
+{
+glyphname = "swa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "sa-canadian";
+}
+);
+width = 699;
+}
+);
+note = uni1500;
+unicode = 5376;
+},
+{
+glyphname = "swaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (489,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 699;
+}
+);
+note = uni1501;
+unicode = 5377;
+},
+{
+glyphname = "swaa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (252,0);
+ref = dot_top;
+}
+);
+width = 699;
+}
+);
+note = uni1502;
+unicode = 5378;
+},
+{
+glyphname = "swaaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (41,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (489,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 699;
+}
+);
+note = uni1503;
+unicode = 5379;
+},
+{
+glyphname = "swaaNaskapi-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (214,0);
+ref = "sa-canadian";
+}
+);
+width = 703;
+}
+);
+note = uni1504;
+unicode = 5380;
+},
+{
+glyphname = "s-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(268,357,l),
+(268,431,ls),
+(268,544,o),
+(208,605,o),
+(116,605,cs),
+(78,605,l),
+(143,568,l),
+(143,714,l),
+(45.005,714,l),
+(45,529,l),
+(75,529,ls),
+(141,529,o),
+(170,499,o),
+(170,427,cs),
+(170,357,l)
+);
+}
+);
+width = 313;
+}
+);
+metricRight = "=|";
+note = uni1505;
+unicode = 5381;
+},
+{
+color = 6;
+glyphname = "sAthapascan-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(253,183,o),
+(299,229,o),
+(299,290,cs),
+(299,334,o),
+(276,368,o),
+(223,389,cs),
+(170,409,ls),
+(147,419,o),
+(138,429,o),
+(138,448,cs),
+(138,469,o),
+(150,481,o),
+(173,481,cs),
+(195,481,o),
+(210,472,o),
+(210,433,c),
+(298,433,l),
+(298,511,o),
+(251,552,o),
+(173,552,cs),
+(99,552,o),
+(49,508,o),
+(49,446,cs),
+(49,400,o),
+(72,364,o),
+(122,345,cs),
+(176,325,ls),
+(200,315,o),
+(211,304,o),
+(211,285,cs),
+(211,264,o),
+(196,254,o),
+(175,254,cs),
+(148,254,o),
+(133,266,o),
+(133,303,c),
+(45,303,l),
+(45,225,o),
+(93,183,o),
+(173,183,cs)
+);
+}
+);
+width = 344;
+}
+);
+metricRight = "=|";
+note = uni1506;
+unicode = 5382;
+},
+{
+glyphname = "sw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(143,357,l),
+(143,427,ls),
+(143,499,o),
+(172,529,o),
+(238,529,cs),
+(268,529,l),
+(268,714,l),
+(170,714,l),
+(170,568,l),
+(235,605,l),
+(197,605,ls),
+(105,605,o),
+(45,544,o),
+(45,431,cs),
+(45.005,357,l)
+);
+}
+);
+width = 313;
+}
+);
+metricLeft = "=|s-canadian";
+metricRight = "=|s-canadian";
+note = uni1507;
+unicode = 5383;
+},
+{
+glyphname = "sBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(275,357,l),
+(275,449,l),
+(202,449,ls),
+(158,449,o),
+(143,466,o),
+(143,514,cs),
+(143,714,l),
+(45.005,714,l),
+(45,498,ls),
+(45,406,o),
+(94,357,o),
+(185,357,c)
+);
+}
+);
+width = 303;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "m-canadian";
+note = uni1508;
+unicode = 5384;
+},
+{
+glyphname = "moosecreesk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(240,225,o),
+(293,274,o),
+(293,386,cs),
+(293,531,o),
+(231,606,o),
+(116,606,cs),
+(94,606,l),
+(143,569,l),
+(143,714,l),
+(46,714,l),
+(46,530,l),
+(83,530,ls),
+(167,530,o),
+(188,504,o),
+(195,444,c),
+(219,441,l),
+(211,468,o),
+(189,493,o),
+(156,493,cs),
+(89,493,o),
+(46,441,o),
+(46,361,cs),
+(46,270,o),
+(103,225,o),
+(168,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(148,295,o),
+(133,313,o),
+(133,360,cs),
+(133,408,o),
+(149,426,o),
+(169,426,cs),
+(189,426,o),
+(204,408,o),
+(204,360,cs),
+(204,312,o),
+(190,295,o),
+(169,295,cs)
+);
+}
+);
+width = 339;
+}
+);
+metricRight = "=|";
+note = uni1509;
+unicode = 5385;
+},
+{
+glyphname = "skwNaskapi-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(236,225,o),
+(292,270,o),
+(292,361,cs),
+(292,441,o),
+(249,493,o),
+(183,493,cs),
+(150,493,o),
+(127,468,o),
+(120,441,c),
+(144,444,l),
+(151,504,o),
+(172,530,o),
+(256,530,cs),
+(293,530,l),
+(293,714,l),
+(195,714,l),
+(195,569,l),
+(244,606,l),
+(223,606,ls),
+(108,606,o),
+(46,531,o),
+(46,386,cs),
+(46,274,o),
+(99,225,o),
+(171,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(149,295,o),
+(135,312,o),
+(135,360,cs),
+(135,408,o),
+(150,426,o),
+(170,426,cs),
+(190,426,o),
+(206,408,o),
+(206,360,cs),
+(206,313,o),
+(190,295,o),
+(170,295,cs)
+);
+}
+);
+width = 339;
+}
+);
+metricLeft = "=|moosecreesk-canadian";
+metricRight = "=|moosecreesk-canadian";
+note = uni150A;
+unicode = 5386;
+},
+{
+glyphname = "swNaskapi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(286,195,l),
+(286,253,ls),
+(286,360,o),
+(226,425,o),
+(135,425,cs),
+(98,425,l),
+(152,389,l),
+(152,519,l),
+(55,519,l),
+(55,349,l),
+(99,349,ls),
+(159,349,o),
+(188,320,o),
+(188,249,cs),
+(188,195,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(276,14,o),
+(306,46,o),
+(306,85,cs),
+(306,124,o),
+(275,155,o),
+(237,155,cs),
+(199,155,o),
+(168,124,o),
+(168,85,cs),
+(168,46,o),
+(198,14,o),
+(237,14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(141,559,o),
+(173,590,o),
+(173,629,cs),
+(173,668,o),
+(142,701,o),
+(103,701,cs),
+(65,701,o),
+(34,668,o),
+(34,629,cs),
+(34,590,o),
+(65,559,o),
+(103,559,cs)
+);
+}
+);
+width = 340;
+}
+);
+metricRight = "=|";
+note = uni150B;
+unicode = 5387;
+},
+{
+glyphname = "spwaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(537,0,l),
+(537,138,l),
+(179,389,l),
+(179,323,l),
+(537,574,l),
+(537,714,l),
+(503,714,l),
+(27,380,l),
+(27,334,l),
+(503,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(150,523,o),
+(182,554,o),
+(182,593,cs),
+(182,632,o),
+(150,664,o),
+(112,664,cs),
+(74,664,o),
+(43,632,o),
+(43,593,cs),
+(43,554,o),
+(74,523,o),
+(112,523,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(327,636,l),
+(327,692,ls),
+(327,774,o),
+(286,821,o),
+(205,821,cs),
+(174,821,l),
+(244,790,l),
+(244,896,l),
+(151,896,l),
+(151,750,l),
+(172,750,ls),
+(208,750,o),
+(234,733,o),
+(234,681,cs),
+(234,636,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(463,738,o),
+(495,770,o),
+(495,808,cs),
+(495,847,o),
+(463,879,o),
+(426,879,cs),
+(388,879,o),
+(357,847,o),
+(357,808,cs),
+(357,770,o),
+(388,738,o),
+(426,738,cs)
+);
+}
+);
+width = 573;
+}
+);
+metricRight = "pa-canadian";
+metricWidth = "pa-canadian";
+note = uni150C;
+unicode = 5388;
+},
+{
+glyphname = "stwaNaskapi-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (340,0);
+ref = "ta-canadian";
+}
+);
+width = 880;
+}
+);
+note = uni150D;
+unicode = 5389;
+},
+{
+glyphname = "skwaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (340,0);
+ref = "ka-canadian";
+}
+);
+width = 869;
+}
+);
+note = uni150E;
+unicode = 5390;
+},
+{
+glyphname = "scwaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (340,0);
+ref = "ca-canadian";
+}
+);
+width = 861;
+}
+);
+note = uni150F;
+unicode = 5391;
+},
+{
+glyphname = "she-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (255,714);
+},
+{
+name = top_right_can;
+pos = (631,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(656,-14,o),
+(737,75,o),
+(737,248,cs),
+(737,319,l),
+(591,319,l),
+(591,223,ls),
+(591,149,o),
+(569,114,o),
+(530,114,cs),
+(489,114,o),
+(469,147,o),
+(465,226,cs),
+(455,491,ls),
+(449,639,o),
+(390,728,o),
+(254,728,cs),
+(120,728,o),
+(38,639,o),
+(38,466,cs),
+(38,395,l),
+(184,395,l),
+(184,492,ls),
+(184,565,o),
+(207,600,o),
+(246,600,cs),
+(287,600,o),
+(307,567,o),
+(310,489,cs),
+(321,223,ls),
+(327,75,o),
+(384,-14,o),
+(523,-14,cs)
+);
+}
+);
+width = 775;
+}
+);
+metricRight = "=|";
+note = uni1510;
+unicode = 5392;
+},
+{
+glyphname = "shi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (146,714);
+},
+{
+name = top_right_can;
+pos = (522,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(391,-14,o),
+(449,75,o),
+(455,223,cs),
+(465,489,ls),
+(469,567,o),
+(489,600,o),
+(530,600,cs),
+(568,600,o),
+(591,565,o),
+(591,492,cs),
+(591,395,l),
+(737,395,l),
+(737,466,ls),
+(737,639,o),
+(656,728,o),
+(522,728,cs),
+(385,728,o),
+(327,639,o),
+(321,491,cs),
+(310,226,ls),
+(307,147,o),
+(287,114,o),
+(245,114,cs),
+(207,114,o),
+(184,149,o),
+(184,223,cs),
+(184,319,l),
+(38,319,l),
+(38,248,ls),
+(38,75,o),
+(119,-14,o),
+(252,-14,cs)
+);
+}
+);
+width = 775;
+}
+);
+metricLeft = "she-canadian";
+metricRight = "she-canadian";
+note = uni1511;
+unicode = 5393;
+},
+{
+glyphname = "shii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (435,0);
+ref = dot_top;
+}
+);
+width = 775;
+}
+);
+note = uni1512;
+unicode = 5394;
+},
+{
+glyphname = "sho-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (398,526);
+},
+{
+name = top_left_can;
+pos = (256,526);
+},
+{
+name = top_right_can;
+pos = (541,526);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(330,112,l),
+(239,110,o),
+(185,142,o),
+(185,200,cs),
+(185,240,o),
+(208,264,o),
+(247,264,cs),
+(335,264,o),
+(421,111,o),
+(572,111,cs),
+(685,111,o),
+(756,189,o),
+(756,300,cs),
+(756,439,o),
+(647,524,o),
+(470,521,c),
+(466,394,l),
+(558,396,o),
+(612,365,o),
+(612,306,cs),
+(612,266,o),
+(588,242,o),
+(549,242,cs),
+(461,242,o),
+(375,396,o),
+(224,396,cs),
+(112,396,o),
+(40,317,o),
+(40,206,cs),
+(40,68,o),
+(149,-17,o),
+(326,-14,c)
+);
+}
+);
+width = 796;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1513;
+unicode = 5395;
+},
+{
+glyphname = "shoo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (312,-188);
+ref = dot_top;
+}
+);
+width = 796;
+}
+);
+note = uni1514;
+unicode = 5396;
+},
+{
+glyphname = "sha-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (399,526);
+},
+{
+name = top_left_can;
+pos = (256,526);
+},
+{
+name = top_right_can;
+pos = (541,526);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(647,-18,o),
+(756,68,o),
+(756,205,cs),
+(756,317,o),
+(685,396,o),
+(572,396,cs),
+(421,396,o),
+(335,242,o),
+(247,242,cs),
+(208,242,o),
+(185,266,o),
+(185,306,cs),
+(185,365,o),
+(239,397,o),
+(330,394,c),
+(326,521,l),
+(149,524,o),
+(40,439,o),
+(40,301,cs),
+(40,189,o),
+(111,111,o),
+(224,111,cs),
+(375,111,o),
+(461,264,o),
+(549,264,cs),
+(588,264,o),
+(612,240,o),
+(612,200,cs),
+(612,142,o),
+(558,109,o),
+(466,112,c),
+(470,-14,l)
+);
+}
+);
+width = 796;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1515;
+unicode = 5397;
+},
+{
+glyphname = "shaa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (312,-188);
+ref = dot_top;
+}
+);
+width = 796;
+}
+);
+note = uni1516;
+unicode = 5398;
+},
+{
+glyphname = "shwe-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "she-canadian";
+}
+);
+width = 986;
+}
+);
+note = uni1517;
+unicode = 5399;
+},
+{
+glyphname = "shweWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "she-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (775,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 986;
+}
+);
+note = uni1518;
+unicode = 5400;
+},
+{
+glyphname = "shwi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "shi-canadian";
+}
+);
+width = 986;
+}
+);
+note = uni1519;
+unicode = 5401;
+},
+{
+glyphname = "shwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (775,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 986;
+}
+);
+note = uni151A;
+unicode = 5402;
+},
+{
+glyphname = "shwii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (646,0);
+ref = dot_top;
+}
+);
+width = 986;
+}
+);
+note = uni151B;
+unicode = 5403;
+},
+{
+glyphname = "shwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (435,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (775,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 986;
+}
+);
+note = uni151C;
+unicode = 5404;
+},
+{
+glyphname = "shwo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "sho-canadian";
+}
+);
+width = 1007;
+}
+);
+note = uni151D;
+unicode = 5405;
+},
+{
+glyphname = "shwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (796,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1007;
+}
+);
+note = uni151E;
+unicode = 5406;
+},
+{
+glyphname = "shwoo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (523,-188);
+ref = dot_top;
+}
+);
+width = 1007;
+}
+);
+note = uni151F;
+unicode = 5407;
+},
+{
+glyphname = "shwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (312,-188);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (796,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1007;
+}
+);
+note = uni1520;
+unicode = 5408;
+},
+{
+glyphname = "shwa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "sha-canadian";
+}
+);
+width = 1007;
+}
+);
+note = uni1521;
+unicode = 5409;
+},
+{
+glyphname = "shwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (796,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1007;
+}
+);
+note = uni1522;
+unicode = 5410;
+},
+{
+glyphname = "shwaa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (523,-188);
+ref = dot_top;
+}
+);
+width = 1007;
+}
+);
+note = uni1523;
+unicode = 5411;
+},
+{
+glyphname = "shwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (312,-188);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (796,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1007;
+}
+);
+note = uni1524;
+unicode = 5412;
+},
+{
+glyphname = "sh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(485,295,o),
+(571,355,o),
+(571,459,cs),
+(571,548,o),
+(514,608,o),
+(428,608,cs),
+(323,608,o),
+(260,508,o),
+(194,508,cs),
+(159,508,o),
+(142,527,o),
+(142,560,cs),
+(142,605,o),
+(183,633,o),
+(258,633,c),
+(255,723,l),
+(127,723,o),
+(41,664,o),
+(41,559,cs),
+(41,471,o),
+(98,411,o),
+(184,411,cs),
+(289,411,o),
+(352,511,o),
+(418,511,cs),
+(453,511,o),
+(470,492,o),
+(470,458,cs),
+(470,413,o),
+(429,386,o),
+(354,386,c),
+(357,295,l)
+);
+}
+);
+width = 612;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni1525;
+unicode = 5413;
+},
+{
+glyphname = "ye-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (579,357);
+},
+{
+name = top_left_can;
+pos = (100,714);
+},
+{
+name = top_right_can;
+pos = (384,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(457,0,l),
+(457,357,l),
+(215,357,l),
+(224,311,l),
+(482,644,l),
+(377,726,l),
+(27,267,l),
+(27,229,l),
+(310,229,l),
+(310,0,l)
+);
+}
+);
+width = 510;
+}
+);
+note = uni1526;
+unicode = 5414;
+},
+{
+glyphname = "yaai-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (5,0);
+ref = ring_top.canadian;
+}
+);
+width = 510;
+}
+);
+note = uni1527;
+unicode = 5415;
+},
+{
+glyphname = "yi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (127,714);
+},
+{
+name = top_right_can;
+pos = (410,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,0,l),
+(200,229,l),
+(483,229,l),
+(483,267,l),
+(133,726,l),
+(28,644,l),
+(286,311,l),
+(295,357,l),
+(53,357,l),
+(53,0,l)
+);
+}
+);
+width = 510;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni1528;
+unicode = 5416;
+},
+{
+glyphname = "yii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (40,0);
+ref = dot_top;
+}
+);
+width = 510;
+}
+);
+note = uni1529;
+unicode = 5417;
+},
+{
+glyphname = "yo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (579,357);
+},
+{
+name = top_double;
+pos = (384,714);
+},
+{
+name = top_left_can;
+pos = (100,714);
+},
+{
+name = top_right_can;
+pos = (384,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(482,70,l),
+(224,403,l),
+(215,357,l),
+(457,357,l),
+(457,714,l),
+(310,714,l),
+(310,485,l),
+(27,485,l),
+(27,447,l),
+(377,-12,l)
+);
+}
+);
+width = 510;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152A;
+unicode = 5418;
+},
+{
+glyphname = "yoo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (298,0);
+ref = dot_top;
+}
+);
+width = 510;
+}
+);
+note = uni152B;
+unicode = 5419;
+},
+{
+glyphname = "ycreeyoo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (120,0);
+ref = doubledot_top;
+}
+);
+width = 510;
+}
+);
+note = uni152C;
+unicode = 5420;
+},
+{
+glyphname = "ya-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (127,714);
+},
+{
+name = top_right_can;
+pos = (410,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(483,447,l),
+(483,485,l),
+(200,485,l),
+(200,714,l),
+(53,714,l),
+(53,357,l),
+(295,357,l),
+(286,403,l),
+(28,70,l),
+(133,-12,l)
+);
+}
+);
+width = 510;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152D;
+unicode = 5421;
+},
+{
+glyphname = "yaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (40,0);
+ref = dot_top;
+}
+);
+width = 510;
+}
+);
+note = uni152E;
+unicode = 5422;
+},
+{
+glyphname = "ywe-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ye-canadian";
+}
+);
+width = 721;
+}
+);
+note = uni152F;
+unicode = 5423;
+},
+{
+glyphname = "yweWestCree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ye-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (510,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 721;
+}
+);
+note = uni1530;
+unicode = 5424;
+},
+{
+glyphname = "ywi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "yi-canadian";
+}
+);
+width = 721;
+}
+);
+note = uni1531;
+unicode = 5425;
+},
+{
+glyphname = "ywiWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (510,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 721;
+}
+);
+note = uni1532;
+unicode = 5426;
+},
+{
+glyphname = "ywii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (251,0);
+ref = dot_top;
+}
+);
+width = 721;
+}
+);
+note = uni1533;
+unicode = 5427;
+},
+{
+glyphname = "ywiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (40,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (510,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 721;
+}
+);
+note = uni1534;
+unicode = 5428;
+},
+{
+glyphname = "ywo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "yo-canadian";
+}
+);
+width = 721;
+}
+);
+note = uni1535;
+unicode = 5429;
+},
+{
+glyphname = "ywoWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (510,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 721;
+}
+);
+note = uni1536;
+unicode = 5430;
+},
+{
+glyphname = "ywoo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (509,0);
+ref = dot_top;
+}
+);
+width = 721;
+}
+);
+note = uni1537;
+unicode = 5431;
+},
+{
+glyphname = "ywooWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (298,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (510,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 721;
+}
+);
+note = uni1538;
+unicode = 5432;
+},
+{
+glyphname = "ywa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ya-canadian";
+}
+);
+width = 721;
+}
+);
+note = uni1539;
+unicode = 5433;
+},
+{
+glyphname = "ywaWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (510,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 721;
+}
+);
+note = uni153A;
+unicode = 5434;
+},
+{
+glyphname = "ywaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (251,0);
+ref = dot_top;
+}
+);
+width = 721;
+}
+);
+note = uni153B;
+unicode = 5435;
+},
+{
+glyphname = "ywaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (40,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (510,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 721;
+}
+);
+note = uni153C;
+unicode = 5436;
+},
+{
+glyphname = "ywaaNaskapi-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (214,0);
+ref = "ya-canadian";
+}
+);
+width = 724;
+}
+);
+note = uni153D;
+unicode = 5437;
+},
+{
+glyphname = "y-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(281,573,l),
+(281,600,l),
+(147,600,l),
+(147,714,l),
+(50,714,l),
+(50,519,l),
+(178,519,l),
+(177,578,l),
+(45,397,l),
+(117,348,l)
+);
+}
+);
+width = 302;
+}
+);
+note = uni153E;
+unicode = 5438;
+},
+{
+glyphname = "biblecreey-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(174,613,l),
+(123,613,l),
+(203,357,l),
+(261,357,l),
+(342,613,l),
+(290,613,l),
+(342,357,l),
+(429,357,l),
+(429,380,l),
+(360,714,l),
+(289,714,l),
+(203,441,l),
+(261,441,l),
+(175,714,l),
+(104,714,l),
+(35,380,l),
+(35,357,l),
+(123,357,l)
+);
+}
+);
+width = 464;
+}
+);
+metricRight = "=|";
+note = uni153F;
+unicode = 5439;
+},
+{
+glyphname = "yWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(236,211,l),
+(236,320,l),
+(333,320,l),
+(333,412,l),
+(236,412,l),
+(236,518,l),
+(144,518,l),
+(144,412,l),
+(45,412,l),
+(45,320,l),
+(144,320,l),
+(144,211,l)
+);
+}
+);
+width = 378;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1540;
+unicode = 5440;
+},
+{
+glyphname = "yiSayisi-canadian";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,189);
+ref = "fullstop-canadian";
+}
+);
+width = 337;
+}
+);
+metricLeft = "fullstop-canadian";
+metricWidth = "fullstop-canadian";
+note = uni1541;
+unicode = 5441;
+},
+{
+glyphname = "re-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (272,526);
+},
+{
+name = top_left_can;
+pos = (125,526);
+},
+{
+name = top_right_can;
+pos = (633,526);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(413,-14,o),
+(489,83,o),
+(489,242,cs),
+(489,374,l),
+(706,374,l),
+(706,506,l),
+(346,506,l),
+(346,221,ls),
+(346,148,o),
+(319,114,o),
+(272,114,cs),
+(224,114,o),
+(198,150,o),
+(198,220,cs),
+(198,506,l),
+(50,506,l),
+(50,242,ls),
+(50,75,o),
+(134,-14,o),
+(272,-14,cs)
+);
+}
+);
+width = 744;
+}
+);
+metricRight = "=|ne-canadian";
+note = uni1542;
+unicode = 5442;
+},
+{
+glyphname = "reRCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (473,526);
+},
+{
+name = top_left_can;
+pos = (111,526);
+},
+{
+name = top_right_can;
+pos = (621,526);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(611,-14,o),
+(694,75,o),
+(694,242,cs),
+(694,506,l),
+(547,506,l),
+(547,220,ls),
+(547,150,o),
+(521,114,o),
+(472,114,cs),
+(425,114,o),
+(399,147,o),
+(399,221,cs),
+(399,506,l),
+(38,506,l),
+(38,374,l),
+(255,374,l),
+(255,241,ls),
+(255,83,o),
+(332,-14,o),
+(473,-14,cs)
+);
+}
+);
+width = 744;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1543;
+unicode = 5443;
+},
+{
+glyphname = "leWestCree-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (473,526);
+},
+{
+name = top_left_can;
+pos = (111,526);
+},
+{
+name = top_right_can;
+pos = (621,526);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(399,0,l),
+(399,284,ls),
+(399,358,o),
+(425,392,o),
+(473,392,cs),
+(521,392,o),
+(547,357,o),
+(547,286,cs),
+(547,0,l),
+(694,0,l),
+(694,264,ls),
+(694,431,o),
+(612,521,o),
+(473,521,cs),
+(333,521,o),
+(255,424,o),
+(255,263,cs),
+(255,133,l),
+(38,133,l),
+(38,0,l)
+);
+}
+);
+width = 744;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+unicode = 5444;
+},
+{
+glyphname = "raai-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (150,-188);
+ref = ring_top.canadian;
+}
+);
+width = 744;
+}
+);
+note = uni1545;
+unicode = 5445;
+},
+{
+glyphname = "ri-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (272,526);
+},
+{
+name = top_left_can;
+pos = (125,526);
+},
+{
+name = top_right_can;
+pos = (633,526);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(198,0,l),
+(198,286,ls),
+(198,357,o),
+(224,392,o),
+(272,392,cs),
+(319,392,o),
+(346,359,o),
+(346,286,cs),
+(346,0,l),
+(706,0,l),
+(706,133,l),
+(489,133,l),
+(489,265,ls),
+(489,424,o),
+(414,521,o),
+(272,521,cs),
+(134,521,o),
+(50,431,o),
+(50,263,cs),
+(50,0,l)
+);
+}
+);
+width = 744;
+}
+);
+metricLeft = "re-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+unicode = 5446;
+},
+{
+glyphname = "rii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (185,-188);
+ref = dot_top;
+}
+);
+width = 744;
+}
+);
+note = uni1547;
+unicode = 5447;
+},
+{
+glyphname = "ro-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (216,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,1,l),
+(200,267,l),
+(163,229,l),
+(220,229,ls),
+(362,229,o),
+(453,325,o),
+(453,469,cs),
+(453,623,o),
+(367,714,o),
+(200,714,cs),
+(53,714,l),
+(53,583,l),
+(185,583,ls),
+(267,583,o),
+(306,541,o),
+(306,470,cs),
+(306,400,o),
+(267,358,o),
+(185,358,cs),
+(53,358,l),
+(53,1,l)
+);
+}
+);
+width = 490;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1548;
+unicode = 5448;
+},
+{
+glyphname = "roo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (130,0);
+ref = dot_top;
+}
+);
+width = 490;
+}
+);
+note = uni1549;
+unicode = 5449;
+},
+{
+glyphname = "loWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (216,714);
+},
+{
+name = top_left_can;
+pos = (127,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,1,ls),
+(367,1,o),
+(453,92,o),
+(453,245,cs),
+(453,390,o),
+(362,486,o),
+(220,486,cs),
+(163,486,l),
+(200,448,l),
+(200,714,l),
+(53,714,l),
+(53,357,l),
+(185,357,ls),
+(267,357,o),
+(306,315,o),
+(306,244,cs),
+(306,174,o),
+(267,132,o),
+(185,132,cs),
+(53,132,l),
+(53,1,l)
+);
+}
+);
+width = 490;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+unicode = 5450;
+},
+{
+glyphname = "ra-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (273,714);
+},
+{
+name = top_right_can;
+pos = (363,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(437,1,l),
+(437,358,l),
+(304,358,ls),
+(223,358,o),
+(184,400,o),
+(184,470,cs),
+(184,541,o),
+(223,583,o),
+(304,583,cs),
+(437,583,l),
+(437,714,l),
+(290,714,ls),
+(123,714,o),
+(37,623,o),
+(37,469,cs),
+(37,325,o),
+(127,229,o),
+(269,229,cs),
+(327,229,l),
+(289,267,l),
+(289,1,l)
+);
+}
+);
+width = 490;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+unicode = 5451;
+},
+{
+glyphname = "raa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (186,0);
+ref = dot_top;
+}
+);
+width = 490;
+}
+);
+note = uni154C;
+unicode = 5452;
+},
+{
+glyphname = "laWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (363,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(437,1,l),
+(437,132,l),
+(304,132,ls),
+(223,132,o),
+(184,174,o),
+(184,244,cs),
+(184,315,o),
+(223,357,o),
+(304,357,cs),
+(437,357,l),
+(437,714,l),
+(289,714,l),
+(289,448,l),
+(327,486,l),
+(269,486,ls),
+(127,486,o),
+(37,390,o),
+(37,245,cs),
+(37,92,o),
+(123,1,o),
+(290,1,cs)
+);
+}
+);
+width = 490;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+unicode = 5453;
+},
+{
+glyphname = "rwaa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (397,0);
+ref = dot_top;
+}
+);
+width = 701;
+}
+);
+note = uni154E;
+unicode = 5454;
+},
+{
+glyphname = "rwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (186,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (490,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 701;
+}
+);
+note = uni154F;
+unicode = 5455;
+},
+{
+glyphname = "r-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(242,357,l),
+(242,545,l),
+(180,545,ls),
+(146,545,o),
+(128,560,o),
+(128,590,cs),
+(128,619,o),
+(147,635,o),
+(181,635,cs),
+(242,635,l),
+(242,714,l),
+(175,714,ls),
+(85,714,o),
+(35,668,o),
+(35,590,cs),
+(35,517,o),
+(84,468,o),
+(165,468,cs),
+(194,468,l),
+(145,491,l),
+(145,357,l)
+);
+}
+);
+width = 287;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni1550;
+unicode = 5456;
+},
+{
+glyphname = "rWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(61,357,l),
+(255,451,l),
+(255,483,l),
+(112,553,l),
+(112,517,l),
+(255,587,l),
+(255,619,l),
+(61,714,l),
+(45.005,714,l),
+(45,647,l),
+(186,578,l),
+(186,629,l),
+(45,557,l),
+(45,514,l),
+(186,444,l),
+(186,493,l),
+(45,423,l),
+(45.005,357,l)
+);
+}
+);
+width = 300;
+}
+);
+metricLeft = "=|lWestCree-canadian";
+metricRight = "=|lWestCree-canadian";
+note = uni1551;
+unicode = 5457;
+},
+{
+glyphname = "rMedial-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(83,-14,l),
+(503,183,l),
+(503,230,l),
+(195,377,l),
+(195,336,l),
+(503,484,l),
+(503,531,l),
+(83,728,l),
+(49,728,l),
+(49,621,l),
+(371,470,l),
+(371,538,l),
+(49,391,l),
+(49,323,l),
+(371,176,l),
+(371,244,l),
+(49,94,l),
+(49,-14,l)
+);
+}
+);
+width = 552;
+}
+);
+metricLeft = "mediall-canadian";
+metricRight = "mediall-canadian";
+note = uni1552;
+unicode = 5458;
+},
+{
+glyphname = "fe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(354,0,l),
+(673,678,l),
+(673,714,l),
+(555,714,l),
+(308,169,l),
+(344,169,l),
+(251,362,l),
+(163,360,l),
+(184,335,o),
+(209,322,o),
+(243,322,cs),
+(322,322,o),
+(395,403,o),
+(395,527,cs),
+(395,643,o),
+(338,728,o),
+(232,728,cs),
+(127,728,o),
+(69,643,o),
+(69,536,cs),
+(69,475,o),
+(84,424,o),
+(118,361,cs),
+(311,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(202,422,o),
+(184,457,o),
+(184,532,cs),
+(184,600,o),
+(204,625,o),
+(233,625,cs),
+(262,625,o),
+(281,601,o),
+(281,525,cs),
+(281,450,o),
+(262,422,o),
+(233,422,cs)
+);
+}
+);
+width = 692;
+}
+);
+metricRight = "e-canadian";
+note = uni1553;
+unicode = 5459;
+},
+{
+glyphname = "faai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (213,0);
+ref = ring_top.canadian;
+}
+);
+width = 692;
+}
+);
+note = uni1554;
+unicode = 5460;
+},
+{
+glyphname = "fi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (334,714);
+},
+{
+name = top_left_can;
+pos = (130,714);
+},
+{
+name = top_right_can;
+pos = (552,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(338,-14,o),
+(395,71,o),
+(395,187,cs),
+(395,311,o),
+(322,392,o),
+(243,392,cs),
+(209,392,o),
+(184,379,o),
+(163,354,c),
+(251,352,l),
+(344,545,l),
+(308,545,l),
+(555,0,l),
+(673,0,l),
+(673,36,l),
+(354,714,l),
+(311,714,l),
+(118,352,ls),
+(84,290,o),
+(69,239,o),
+(69,178,cs),
+(69,71,o),
+(127,-14,o),
+(232,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(204,89,o),
+(184,114,o),
+(184,182,cs),
+(184,257,o),
+(202,292,o),
+(233,292,cs),
+(262,292,o),
+(281,264,o),
+(281,189,cs),
+(281,113,o),
+(262,89,o),
+(233,89,cs)
+);
+}
+);
+width = 692;
+}
+);
+metricLeft = "fe-canadian";
+metricRight = "e-canadian";
+note = uni1555;
+unicode = 5461;
+},
+{
+glyphname = "fii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (248,0);
+ref = dot_top;
+}
+);
+width = 692;
+}
+);
+note = uni1556;
+unicode = 5462;
+},
+{
+glyphname = "fo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (201,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(102,0,l),
+(565,334,l),
+(565,380,l),
+(322,667,ls),
+(283,714,o),
+(240,728,o),
+(196,728,cs),
+(96,728,o),
+(37,646,o),
+(37,521,cs),
+(37,402,o),
+(101,319,o),
+(198,319,cs),
+(292,319,o),
+(353,403,o),
+(353,521,cs),
+(353,554,o),
+(344,597,o),
+(334,624,c),
+(286,534,l),
+(434,360,l),
+(434,389,l),
+(67,124,l),
+(67,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(171,422,o),
+(152,447,o),
+(152,524,cs),
+(152,600,o),
+(171,625,o),
+(201,625,cs),
+(230,625,o),
+(249,601,o),
+(249,525,cs),
+(249,450,o),
+(230,422,o),
+(201,422,cs)
+);
+}
+);
+width = 592;
+}
+);
+metricRight = "o-canadian";
+note = uni1557;
+unicode = 5463;
+},
+{
+glyphname = "foo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "fo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (114,0);
+ref = dot_top;
+}
+);
+width = 592;
+}
+);
+note = uni1558;
+unicode = 5464;
+},
+{
+glyphname = "fa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (393,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(525,0,l),
+(525,124,l),
+(158,388,l),
+(158,361,l),
+(306,535,l),
+(258,624,l),
+(248,597,o),
+(239,554,o),
+(239,521,cs),
+(239,403,o),
+(300,319,o),
+(394,319,cs),
+(491,319,o),
+(555,402,o),
+(555,521,cs),
+(555,646,o),
+(496,728,o),
+(396,728,cs),
+(352,728,o),
+(309,714,o),
+(270,667,cs),
+(27,380,l),
+(27,334,l),
+(490,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(362,422,o),
+(343,449,o),
+(343,525,cs),
+(343,601,o),
+(362,625,o),
+(391,625,cs),
+(421,625,o),
+(440,600,o),
+(440,524,cs),
+(440,447,o),
+(421,422,o),
+(391,422,cs)
+);
+}
+);
+width = 592;
+}
+);
+metricRight = "=|fo-canadian";
+note = uni1559;
+unicode = 5465;
+},
+{
+glyphname = "faa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (306,0);
+ref = dot_top;
+}
+);
+width = 592;
+}
+);
+note = uni155A;
+unicode = 5466;
+},
+{
+glyphname = "fwaa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (517,0);
+ref = dot_top;
+}
+);
+width = 803;
+}
+);
+note = uni155B;
+unicode = 5467;
+},
+{
+glyphname = "fwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (306,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (592,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 803;
+}
+);
+note = uni155C;
+unicode = 5468;
+},
+{
+glyphname = "f-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(285,357,l),
+(285,418,l),
+(104,549,l),
+(104,538,l),
+(173,621,l),
+(154,668,l),
+(149,653,o),
+(145,631,o),
+(145,610,cs),
+(145,549,o),
+(179,514,o),
+(223,514,cs),
+(268,514,o),
+(299,549,o),
+(299,617,cs),
+(299,693,o),
+(260,720,o),
+(219,720,cs),
+(200,720,o),
+(176,710,o),
+(157,688,cs),
+(35,546,l),
+(35,522,l),
+(268,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(205,566,o),
+(196,580,o),
+(196,615,cs),
+(196,654,o),
+(205,668,o),
+(220,668,cs),
+(234,668,o),
+(243,655,o),
+(243,615,cs),
+(243,580,o),
+(236,566,o),
+(220,566,cs)
+);
+}
+);
+width = 339;
+}
+);
+note = uni155D;
+unicode = 5469;
+},
+{
+glyphname = "the-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (724,357);
+},
+{
+name = top_center_can;
+pos = (324,714);
+},
+{
+name = top_left_can;
+pos = (122,714);
+},
+{
+name = top_right_can;
+pos = (525,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(498,-14,o),
+(599,88,o),
+(599,281,cs),
+(599,714,l),
+(451,714,l),
+(451,278,ls),
+(451,170,o),
+(408,120,o),
+(324,120,cs),
+(243,120,o),
+(196,172,o),
+(196,281,cs),
+(196,418,l),
+(132,371,l),
+(149,339,o),
+(183,316,o),
+(219,316,cs),
+(314,316,o),
+(377,398,o),
+(377,522,cs),
+(377,644,o),
+(322,728,o),
+(217,728,cs),
+(107,728,o),
+(50,645,o),
+(50,477,cs),
+(50,320,ls),
+(50,94,o),
+(147,-14,o),
+(324,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(185,420,o),
+(165,445,o),
+(165,522,cs),
+(165,600,o),
+(185,625,o),
+(214,625,cs),
+(243,625,o),
+(262,600,o),
+(262,524,cs),
+(262,448,o),
+(244,420,o),
+(215,420,cs)
+);
+}
+);
+width = 649;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155E;
+unicode = 5470;
+},
+{
+glyphname = "theNCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(502,-14,o),
+(599,88,o),
+(599,309,cs),
+(599,477,ls),
+(599,645,o),
+(542,728,o),
+(432,728,cs),
+(327,728,o),
+(272,644,o),
+(272,522,cs),
+(272,398,o),
+(335,316,o),
+(430,316,cs),
+(466,316,o),
+(500,339,o),
+(517,371,c),
+(453,418,l),
+(453,278,ls),
+(453,168,o),
+(407,117,o),
+(325,117,cs),
+(241,117,o),
+(198,168,o),
+(198,275,cs),
+(198,714,l),
+(50,714,l),
+(50,280,ls),
+(50,88,o),
+(150,-14,o),
+(325,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(405,420,o),
+(387,448,o),
+(387,524,cs),
+(387,600,o),
+(405,625,o),
+(435,625,cs),
+(464,625,o),
+(484,600,o),
+(484,522,cs),
+(484,445,o),
+(464,420,o),
+(434,420,cs)
+);
+}
+);
+width = 649;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155F;
+unicode = 5471;
+},
+{
+glyphname = "thi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (320,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(322,-14,o),
+(377,70,o),
+(377,192,cs),
+(377,316,o),
+(314,398,o),
+(219,398,cs),
+(183,398,o),
+(149,375,o),
+(132,343,c),
+(196,296,l),
+(196,436,ls),
+(196,546,o),
+(242,597,o),
+(324,597,cs),
+(408,597,o),
+(451,546,o),
+(451,439,cs),
+(451,0,l),
+(599,0,l),
+(599,434,ls),
+(599,626,o),
+(499,728,o),
+(324,728,cs),
+(147,728,o),
+(50,626,o),
+(50,405,cs),
+(50,237,ls),
+(50,69,o),
+(107,-14,o),
+(217,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(185,89,o),
+(165,114,o),
+(165,192,cs),
+(165,269,o),
+(185,294,o),
+(215,294,cs),
+(244,294,o),
+(262,266,o),
+(262,190,cs),
+(262,114,o),
+(243,89,o),
+(214,89,cs)
+);
+}
+);
+width = 649;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1560;
+unicode = 5472;
+},
+{
+glyphname = "thiNCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (320,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(542,-14,o),
+(599,69,o),
+(599,237,cs),
+(599,405,ls),
+(599,626,o),
+(502,728,o),
+(325,728,cs),
+(150,728,o),
+(50,626,o),
+(50,434,cs),
+(50,0,l),
+(198,0,l),
+(198,439,ls),
+(198,546,o),
+(241,597,o),
+(325,597,cs),
+(407,597,o),
+(453,546,o),
+(453,436,cs),
+(453,296,l),
+(517,343,l),
+(500,375,o),
+(466,398,o),
+(430,398,cs),
+(335,398,o),
+(272,316,o),
+(272,192,cs),
+(272,70,o),
+(327,-14,o),
+(432,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(405,89,o),
+(387,114,o),
+(387,190,cs),
+(387,266,o),
+(405,294,o),
+(434,294,cs),
+(464,294,o),
+(484,269,o),
+(484,192,cs),
+(484,114,o),
+(464,89,o),
+(435,89,cs)
+);
+}
+);
+width = 649;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1561;
+unicode = 5473;
+},
+{
+glyphname = "thii-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "thi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (234,0);
+ref = dot_top;
+}
+);
+width = 649;
+}
+);
+note = uni1562;
+unicode = 5474;
+},
+{
+glyphname = "thiiNCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "thiNCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (234,0);
+ref = dot_top;
+}
+);
+width = 649;
+}
+);
+note = uni1563;
+unicode = 5475;
+},
+{
+glyphname = "tho-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (263,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(219,0,ls),
+(431,0,o),
+(549,120,o),
+(549,366,cs),
+(549,590,o),
+(436,728,o),
+(269,728,cs),
+(126,728,o),
+(40,632,o),
+(40,497,cs),
+(40,367,o),
+(103,289,o),
+(200,289,cs),
+(300,289,o),
+(353,366,o),
+(353,475,cs),
+(353,580,o),
+(315,662,o),
+(230,669,c),
+(200,625,l),
+(211,632,o),
+(230,635,o),
+(245,635,cs),
+(346,635,o),
+(406,530,o),
+(406,376,cs),
+(406,202,o),
+(343,134,o),
+(212,134,cs),
+(70,134,l),
+(70,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(175,392,o),
+(155,418,o),
+(155,501,cs),
+(155,584,o),
+(177,611,o),
+(205,611,cs),
+(233,611,o),
+(252,585,o),
+(252,502,cs),
+(252,421,o),
+(234,392,o),
+(204,392,cs)
+);
+}
+);
+width = 594;
+}
+);
+metricRight = "to-canadian";
+note = uni1564;
+unicode = 5476;
+},
+{
+glyphname = "thoo-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "tho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (177,0);
+ref = dot_top;
+}
+);
+width = 594;
+}
+);
+note = uni1565;
+unicode = 5477;
+},
+{
+glyphname = "tha-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (335,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(525,0,l),
+(525,134,l),
+(382,134,ls),
+(252,134,o),
+(189,202,o),
+(189,376,cs),
+(189,530,o),
+(248,635,o),
+(350,635,cs),
+(364,635,o),
+(384,632,o),
+(394,625,c),
+(364,669,l),
+(280,662,o),
+(241,580,o),
+(241,475,cs),
+(241,366,o),
+(295,289,o),
+(395,289,cs),
+(492,289,o),
+(554,367,o),
+(554,497,cs),
+(554,632,o),
+(468,728,o),
+(326,728,cs),
+(159,728,o),
+(45,590,o),
+(45,366,cs),
+(45,126,o),
+(158,0,o),
+(376,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(361,392,o),
+(342,421,o),
+(342,502,cs),
+(342,585,o),
+(362,611,o),
+(390,611,cs),
+(418,611,o),
+(439,584,o),
+(439,501,cs),
+(439,418,o),
+(420,392,o),
+(390,392,cs)
+);
+}
+);
+width = 594;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tho-canadian";
+note = uni1566;
+unicode = 5478;
+},
+{
+glyphname = "thaa-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (247,0);
+ref = dot_top;
+}
+);
+width = 594;
+}
+);
+note = uni1567;
+unicode = 5479;
+},
+{
+glyphname = "thwaa-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (458,0);
+ref = dot_top;
+}
+);
+width = 804;
+}
+);
+note = uni1568;
+unicode = 5480;
+},
+{
+glyphname = "thwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (247,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (594,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 804;
+}
+);
+note = uni1569;
+unicode = 5481;
+},
+{
+glyphname = "th-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(279,357,l),
+(279,438,l),
+(219,438,ls),
+(155,438,o),
+(122,471,o),
+(122,543,cs),
+(122,615,o),
+(153,662,o),
+(204,662,cs),
+(210,662,o),
+(217,661,o),
+(222,659,c),
+(198,684,l),
+(164,680,o),
+(140,643,o),
+(140,599,cs),
+(140,532,o),
+(172,497,o),
+(216,497,cs),
+(262,497,o),
+(294,533,o),
+(294,601,cs),
+(294,681,o),
+(248,720,o),
+(186,720,cs),
+(102,720,o),
+(41,655,o),
+(41,536,cs),
+(41,424,o),
+(99,357,o),
+(212,357,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,548,o),
+(191,562,o),
+(191,597,cs),
+(191,636,o),
+(200,650,o),
+(214,650,cs),
+(229,650,o),
+(238,637,o),
+(238,597,cs),
+(238,562,o),
+(230,548,o),
+(215,548,cs)
+);
+}
+);
+width = 334;
+}
+);
+metricLeft = "t-canadian";
+note = uni156A;
+unicode = 5482;
+},
+{
+glyphname = "tthe-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (716,357);
+},
+{
+name = top_center_can;
+pos = (320,714);
+},
+{
+name = top_left_can;
+pos = (125,714);
+},
+{
+name = top_right_can;
+pos = (517,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(494,-14,o),
+(590,88,o),
+(590,281,cs),
+(590,714,l),
+(453,714,l),
+(453,279,ls),
+(453,169,o),
+(401,121,o),
+(320,121,cs),
+(242,121,o),
+(188,172,o),
+(188,279,cs),
+(188,714,l),
+(50,714,l),
+(50,280,ls),
+(50,88,o),
+(150,-14,o),
+(321,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(375,395,l),
+(375,714,l),
+(265,714,l),
+(265,395,l)
+);
+}
+);
+width = 640;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156B;
+unicode = 5483;
+},
+{
+glyphname = "tthi-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(188,0,l),
+(188,435,ls),
+(188,544,o),
+(240,593,o),
+(321,593,cs),
+(399,593,o),
+(453,542,o),
+(453,435,cs),
+(453,0,l),
+(590,0,l),
+(590,434,ls),
+(590,626,o),
+(491,728,o),
+(321,728,cs),
+(148,728,o),
+(50,626,o),
+(50,434,cs),
+(50,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(375,0,l),
+(375,319,l),
+(265,319,l),
+(265,0,l)
+);
+}
+);
+width = 640;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156C;
+unicode = 5484;
+},
+{
+glyphname = "ttho-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (279,714);
+},
+{
+name = top_left_can;
+pos = (124,714);
+},
+{
+name = top_right_can;
+pos = (435,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(165,0,ls),
+(383,0,o),
+(507,120,o),
+(507,358,cs),
+(507,596,o),
+(383,714,o),
+(163,714,cs),
+(50,714,l),
+(50,580,l),
+(164,580,ls),
+(288,580,o),
+(359,515,o),
+(359,358,cs),
+(359,201,o),
+(288,134,o),
+(165,134,cs),
+(50,134,l),
+(50,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(248,297,l),
+(248,419,l),
+(50,419,l),
+(50,297,l)
+);
+}
+);
+width = 552;
+}
+);
+metricRight = "to-canadian";
+note = uni156D;
+unicode = 5485;
+},
+{
+glyphname = "ttha-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (274,714);
+},
+{
+name = top_left_can;
+pos = (119,714);
+},
+{
+name = top_right_can;
+pos = (430,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(502,0,l),
+(502,134,l),
+(389,134,ls),
+(265,134,o),
+(193,200,o),
+(193,357,cs),
+(193,514,o),
+(265,580,o),
+(388,580,cs),
+(502,580,l),
+(502,714,l),
+(388,714,ls),
+(170,714,o),
+(45,595,o),
+(45,357,cs),
+(45,120,o),
+(170,0,o),
+(389,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(502,297,l),
+(502,419,l),
+(305,419,l),
+(305,297,l)
+);
+}
+);
+width = 552;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|ttho-canadian";
+note = uni156E;
+unicode = 5486;
+},
+{
+glyphname = "tth-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(579,496,l),
+(543,496,l),
+(627,373,l),
+(693,422,l),
+(607,542,l),
+(596,508,l),
+(724,557,l),
+(696,630,l),
+(570,580,l),
+(603,560,l),
+(603,714,l),
+(520,714,l),
+(520,560,l),
+(552,580,l),
+(426,630,l),
+(398,557,l),
+(526,508,l),
+(515,542,l),
+(429,422,l),
+(496,373,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(213,496,l),
+(176,496,l),
+(261,373,l),
+(328,422,l),
+(240,542,l),
+(230,508,l),
+(358,557,l),
+(329,630,l),
+(204,580,l),
+(236,560,l),
+(236,714,l),
+(153,714,l),
+(153,560,l),
+(186,580,l),
+(60,630,l),
+(32,557,l),
+(160,508,l),
+(148,542,l),
+(62,422,l),
+(128,373,l)
+);
+}
+);
+width = 756;
+}
+);
+metricRight = "=|";
+note = uni156F;
+unicode = 5487;
+},
+{
+glyphname = "tye-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(494,-14,o),
+(590,88,o),
+(590,281,cs),
+(590,714,l),
+(453,714,l),
+(453,289,ls),
+(453,169,o),
+(401,121,o),
+(320,121,cs),
+(242,121,o),
+(188,172,o),
+(188,289,cs),
+(188,714,l),
+(50,714,l),
+(50,280,ls),
+(50,88,o),
+(150,-14,o),
+(321,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(381,425,o),
+(413,465,o),
+(413,527,cs),
+(413,714,l),
+(351,714,l),
+(351,530,ls),
+(351,503,o),
+(340,490,o),
+(320,490,cs),
+(301,490,o),
+(290,503,o),
+(290,530,cs),
+(290,714,l),
+(228,714,l),
+(228,527,ls),
+(228,464,o),
+(261,425,o),
+(321,425,cs)
+);
+}
+);
+width = 640;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1570;
+unicode = 5488;
+},
+{
+glyphname = "tyi-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(188,0,l),
+(188,425,ls),
+(188,544,o),
+(240,593,o),
+(321,593,cs),
+(399,593,o),
+(453,542,o),
+(453,425,cs),
+(453,0,l),
+(590,0,l),
+(590,434,ls),
+(590,626,o),
+(491,728,o),
+(321,728,cs),
+(148,728,o),
+(50,626,o),
+(50,434,cs),
+(50,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(290,0,l),
+(290,183,ls),
+(290,211,o),
+(301,224,o),
+(321,224,cs),
+(340,224,o),
+(351,211,o),
+(351,183,cs),
+(351,0,l),
+(413,0,l),
+(413,187,ls),
+(413,250,o),
+(380,289,o),
+(320,289,cs),
+(260,289,o),
+(228,249,o),
+(228,187,cs),
+(228,0,l)
+);
+}
+);
+width = 640;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1571;
+unicode = 5489;
+},
+{
+glyphname = "tyo-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(167,0,ls),
+(379,0,o),
+(510,120,o),
+(510,358,cs),
+(510,596,o),
+(379,714,o),
+(166,714,cs),
+(53,714,l),
+(53,583,l),
+(153,583,ls),
+(289,583,o),
+(363,517,o),
+(363,358,cs),
+(363,199,o),
+(289,131,o),
+(155,131,cs),
+(53,131,l),
+(53,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(118,223,ls),
+(200,223,o),
+(250,270,o),
+(250,357,cs),
+(250,445,o),
+(200,491,o),
+(118,491,cs),
+(53,491,l),
+(53,417,l),
+(107,417,ls),
+(152,417,o),
+(171,397,o),
+(171,357,cs),
+(171,317,o),
+(152,297,o),
+(107,297,cs),
+(53,297,l),
+(53,223,l)
+);
+}
+);
+width = 555;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1572;
+unicode = 5490;
+},
+{
+glyphname = "tya-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(502,0,l),
+(502,131,l),
+(402,131,ls),
+(266,131,o),
+(193,198,o),
+(193,357,cs),
+(193,516,o),
+(266,583,o),
+(401,583,cs),
+(502,583,l),
+(502,714,l),
+(388,714,ls),
+(177,714,o),
+(45,595,o),
+(45,357,cs),
+(45,120,o),
+(177,0,o),
+(389,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(502,223,l),
+(502,297,l),
+(449,297,ls),
+(403,297,o),
+(385,317,o),
+(385,357,cs),
+(385,397,o),
+(403,417,o),
+(448,417,cs),
+(502,417,l),
+(502,491,l),
+(437,491,ls),
+(355,491,o),
+(306,444,o),
+(306,357,cs),
+(306,269,o),
+(355,223,o),
+(437,223,cs)
+);
+}
+);
+width = 555;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1573;
+unicode = 5491;
+},
+{
+glyphname = "heNunavik-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(463,0,l),
+(675,206,l),
+(588,299,l),
+(386,104,l),
+(479,97,l),
+(479,456,ls),
+(479,629,o),
+(403,728,o),
+(264,728,cs),
+(125,728,o),
+(40,626,o),
+(40,457,cs),
+(40,297,o),
+(120,193,o),
+(239,193,cs),
+(294,193,o),
+(335,226,o),
+(345,262,c),
+(333,284,l),
+(333,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(215,318,o),
+(184,360,o),
+(184,461,cs),
+(184,562,o),
+(212,604,o),
+(259,604,cs),
+(306,604,o),
+(335,563,o),
+(335,461,cs),
+(335,359,o),
+(304,318,o),
+(259,318,cs)
+);
+}
+);
+width = 691;
+}
+);
+metricLeft = "ke-canadian";
+note = uni1574;
+unicode = 5492;
+},
+{
+glyphname = "hiNunavik-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (428,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(358,0,l),
+(358,284,l),
+(346,262,l),
+(356,226,o),
+(397,193,o),
+(452,193,cs),
+(571,193,o),
+(651,298,o),
+(651,457,cs),
+(651,626,o),
+(566,728,o),
+(428,728,cs),
+(289,728,o),
+(212,629,o),
+(212,456,cs),
+(212,100,l),
+(305,104,l),
+(103,299,l),
+(16,206,l),
+(228,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(387,318,o),
+(356,359,o),
+(356,461,cs),
+(356,563,o),
+(385,604,o),
+(431,604,cs),
+(479,604,o),
+(507,562,o),
+(507,461,cs),
+(507,360,o),
+(476,318,o),
+(431,318,cs)
+);
+}
+);
+width = 691;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1575;
+unicode = 5493;
+},
+{
+glyphname = "hiiNunavik-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "hiNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (342,0);
+ref = dot_top;
+}
+);
+width = 691;
+}
+);
+note = uni1576;
+unicode = 5494;
+},
+{
+glyphname = "hoNunavik-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (258,714);
+},
+{
+name = top_right_can;
+pos = (406,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(403,-14,o),
+(479,85,o),
+(479,258,cs),
+(479,617,l),
+(386,610,l),
+(588,415,l),
+(675,508,l),
+(463,714,l),
+(333,714,l),
+(333,430,l),
+(345,452,l),
+(335,488,o),
+(294,521,o),
+(239,521,cs),
+(120,521,o),
+(40,416,o),
+(40,256,cs),
+(40,88,o),
+(124,-14,o),
+(263,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(212,110,o),
+(184,152,o),
+(184,253,cs),
+(184,354,o),
+(215,396,o),
+(259,396,cs),
+(304,396,o),
+(335,355,o),
+(335,253,cs),
+(335,151,o),
+(306,110,o),
+(259,110,cs)
+);
+}
+);
+width = 691;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "heNunavik-canadian";
+note = uni1577;
+unicode = 5495;
+},
+{
+glyphname = "hooNunavik-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "hoNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (320,0);
+ref = dot_top;
+}
+);
+width = 691;
+}
+);
+note = uni1578;
+unicode = 5496;
+},
+{
+glyphname = "haNunavik-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (433,714);
+},
+{
+name = top_left_can;
+pos = (285,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(566,-14,o),
+(651,88,o),
+(651,257,cs),
+(651,416,o),
+(571,521,o),
+(453,521,cs),
+(397,521,o),
+(357,488,o),
+(346,452,c),
+(358,430,l),
+(358,714,l),
+(228,714,l),
+(16,508,l),
+(103,415,l),
+(305,610,l),
+(212,614,l),
+(212,258,ls),
+(212,85,o),
+(288,-14,o),
+(427,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(385,110,o),
+(356,151,o),
+(356,253,cs),
+(356,355,o),
+(387,396,o),
+(431,396,cs),
+(476,396,o),
+(507,354,o),
+(507,253,cs),
+(507,152,o),
+(479,110,o),
+(431,110,cs)
+);
+}
+);
+width = 691;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1579;
+unicode = 5497;
+},
+{
+glyphname = "haaNunavik-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "haNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (199,0);
+ref = dot_top;
+}
+);
+width = 691;
+}
+);
+note = uni157A;
+unicode = 5498;
+},
+{
+glyphname = "hNunavik-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(316,351,o),
+(370,396,o),
+(370,492,cs),
+(370,575,o),
+(326,622,o),
+(269,622,cs),
+(232,622,o),
+(205,599,o),
+(199,565,c),
+(220,565,l),
+(220,714,l),
+(130,714,l),
+(25,611,l),
+(73,562,l),
+(178,666,l),
+(122,666,l),
+(122,487,ls),
+(122,404,o),
+(168,351,o),
+(249,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(227,422,o),
+(212,438,o),
+(212,486,cs),
+(212,534,o),
+(228,551,o),
+(248,551,cs),
+(267,551,o),
+(284,535,o),
+(284,486,cs),
+(284,438,o),
+(268,422,o),
+(248,422,cs)
+);
+}
+);
+width = 405;
+}
+);
+metricRight = "k-canadian";
+note = uni157B;
+unicode = 5499;
+},
+{
+color = 4;
+glyphname = "nunavuth-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,303,l),
+(420,303,l),
+(420,0,l),
+(567,0,l),
+(567,714,l),
+(420,714,l),
+(420,434,l),
+(200,434,l),
+(200,714,l),
+(53,714,l),
+(53,0,l),
+(200,0,l)
+);
+}
+);
+width = 620;
+}
+);
+metricRight = "=|";
+note = uni157C;
+unicode = 5500;
+},
+{
+glyphname = "hk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,357);
+ref = "fullstop-canadian";
+}
+);
+width = 337;
+}
+);
+metricLeft = "fullstop-canadian";
+note = uni157D;
+unicode = 5501;
+},
+{
+glyphname = "qaai-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (287,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (436,0);
+ref = ring_top.canadian;
+}
+);
+width = 816;
+}
+);
+note = uni157E;
+unicode = 5502;
+},
+{
+glyphname = "qi-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (287,0);
+ref = "ki-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni157F;
+unicode = 5503;
+},
+{
+glyphname = "qii-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (287,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (470,0);
+ref = dot_top;
+}
+);
+width = 816;
+}
+);
+note = uni1580;
+unicode = 5504;
+},
+{
+glyphname = "qo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (287,0);
+ref = "ko-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni1581;
+unicode = 5505;
+},
+{
+glyphname = "qoo-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (287,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (607,0);
+ref = dot_top;
+}
+);
+width = 816;
+}
+);
+note = uni1582;
+unicode = 5506;
+},
+{
+glyphname = "qa-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (287,0);
+ref = "ka-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni1583;
+unicode = 5507;
+},
+{
+glyphname = "qaa-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (287,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (324,0);
+ref = dot_top;
+}
+);
+width = 816;
+}
+);
+note = uni1584;
+unicode = 5508;
+},
+{
+glyphname = "q-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (287,0);
+ref = "k-canadian";
+}
+);
+width = 615;
+}
+);
+note = uni1585;
+unicode = 5509;
+},
+{
+glyphname = "tlhe-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (273,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(203,0,l),
+(307,275,l),
+(199,233,l),
+(213,228,o),
+(231,226,o),
+(248,226,cs),
+(311,226,o),
+(352,263,o),
+(358,296,c),
+(347,339,l),
+(347,0,l),
+(492,0,l),
+(492,473,ls),
+(492,633,o),
+(415,728,o),
+(274,728,cs),
+(131,728,o),
+(47,628,o),
+(47,473,cs),
+(47,371,o),
+(86,295,o),
+(149,259,c),
+(50,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(223,350,o),
+(191,388,o),
+(191,477,cs),
+(191,566,o),
+(221,604,o),
+(270,604,cs),
+(318,604,o),
+(348,566,o),
+(348,477,cs),
+(348,388,o),
+(316,350,o),
+(270,350,cs)
+);
+}
+);
+width = 542;
+}
+);
+metricRight = "te-canadian";
+note = uni1586;
+unicode = 5510;
+},
+{
+glyphname = "tlhi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(196,0,l),
+(196,339,l),
+(184,298,l),
+(188,265,o),
+(230,226,o),
+(294,226,c),
+(235,275,l),
+(339,0,l),
+(493,0,l),
+(394,259,l),
+(457,295,o),
+(496,371,o),
+(496,473,cs),
+(496,628,o),
+(412,728,o),
+(269,728,cs),
+(127,728,o),
+(50,633,o),
+(50,473,cs),
+(50,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(227,350,o),
+(195,388,o),
+(195,477,cs),
+(195,566,o),
+(225,604,o),
+(273,604,cs),
+(322,604,o),
+(352,566,o),
+(352,477,cs),
+(352,388,o),
+(320,350,o),
+(273,350,cs)
+);
+}
+);
+width = 543;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|tlhe-canadian";
+note = uni1587;
+unicode = 5511;
+},
+{
+glyphname = "tlho-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (278,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(415,-14,o),
+(492,81,o),
+(492,241,cs),
+(492,714,l),
+(347,714,l),
+(347,375,l),
+(359,416,l),
+(355,449,o),
+(313,488,o),
+(248,488,c),
+(307,439,l),
+(203,714,l),
+(50,714,l),
+(149,455,l),
+(86,419,o),
+(47,343,o),
+(47,241,cs),
+(47,86,o),
+(131,-14,o),
+(274,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(221,110,o),
+(191,148,o),
+(191,237,cs),
+(191,326,o),
+(223,364,o),
+(270,364,cs),
+(316,364,o),
+(348,326,o),
+(348,237,cs),
+(348,148,o),
+(318,110,o),
+(270,110,cs)
+);
+}
+);
+width = 542;
+}
+);
+metricLeft = "tlhe-canadian";
+metricRight = "te-canadian";
+note = uni1588;
+unicode = 5512;
+},
+{
+glyphname = "tlha-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(412,-14,o),
+(496,86,o),
+(496,241,cs),
+(496,343,o),
+(457,419,o),
+(394,455,c),
+(493,714,l),
+(339,714,l),
+(235,439,l),
+(344,481,l),
+(329,486,o),
+(312,488,o),
+(294,488,cs),
+(230,488,o),
+(188,449,o),
+(184,416,c),
+(196,375,l),
+(196,714,l),
+(50,714,l),
+(50,241,ls),
+(50,81,o),
+(127,-14,o),
+(269,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(225,110,o),
+(195,148,o),
+(195,237,cs),
+(195,326,o),
+(227,364,o),
+(273,364,cs),
+(320,364,o),
+(352,326,o),
+(352,237,cs),
+(352,148,o),
+(322,110,o),
+(273,110,cs)
+);
+}
+);
+width = 543;
+}
+);
+metricLeft = "te-canadian";
+note = uni1589;
+unicode = 5513;
+},
+{
+glyphname = "reWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(453,0,l),
+(665,206,l),
+(578,299,l),
+(376,104,l),
+(469,97,l),
+(469,467,ls),
+(469,631,o),
+(395,728,o),
+(256,728,cs),
+(120,728,o),
+(37,637,o),
+(37,468,cs),
+(37,395,l),
+(183,395,l),
+(183,494,ls),
+(183,563,o),
+(207,600,o),
+(254,600,cs),
+(298,600,o),
+(323,565,o),
+(323,492,cs),
+(323,0,l)
+);
+}
+);
+width = 681;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+unicode = 5514;
+},
+{
+glyphname = "riWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(358,0,l),
+(358,492,ls),
+(358,565,o),
+(383,600,o),
+(428,600,cs),
+(474,600,o),
+(498,563,o),
+(498,494,cs),
+(498,395,l),
+(644,395,l),
+(644,468,ls),
+(644,637,o),
+(562,728,o),
+(426,728,cs),
+(286,728,o),
+(212,630,o),
+(212,467,cs),
+(212,97,l),
+(305,104,l),
+(103,299,l),
+(16,206,l),
+(228,0,l)
+);
+}
+);
+width = 681;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+unicode = 5515;
+},
+{
+glyphname = "roWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(395,-14,o),
+(469,83,o),
+(469,247,cs),
+(469,617,l),
+(376,610,l),
+(578,415,l),
+(665,508,l),
+(453,714,l),
+(323,714,l),
+(323,222,ls),
+(323,149,o),
+(298,114,o),
+(254,114,cs),
+(207,114,o),
+(183,151,o),
+(183,221,cs),
+(183,319,l),
+(37,319,l),
+(37,246,ls),
+(37,77,o),
+(118,-14,o),
+(256,-14,cs)
+);
+}
+);
+width = 681;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+unicode = 5516;
+},
+{
+glyphname = "raWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(562,-14,o),
+(644,77,o),
+(644,246,cs),
+(644,319,l),
+(498,319,l),
+(498,221,ls),
+(498,151,o),
+(474,114,o),
+(427,114,cs),
+(383,114,o),
+(358,149,o),
+(358,222,cs),
+(358,714,l),
+(228,714,l),
+(16,508,l),
+(103,415,l),
+(305,610,l),
+(212,617,l),
+(212,247,ls),
+(212,83,o),
+(285,-14,o),
+(426,-14,cs)
+);
+}
+);
+width = 681;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+unicode = 5517;
+},
+{
+glyphname = "ngaai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (550,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (698,0);
+ref = ring_top.canadian;
+}
+);
+width = 1071;
+}
+);
+note = uni158E;
+unicode = 5518;
+},
+{
+glyphname = "ngi-canadian";
+kernLeft = mwestleft;
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (550,0);
+ref = "ci-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni158F;
+unicode = 5519;
+},
+{
+glyphname = "ngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (550,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (733,0);
+ref = dot_top;
+}
+);
+width = 1071;
+}
+);
+note = uni1590;
+unicode = 5520;
+},
+{
+glyphname = "ngo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:31:19 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (524,0);
+ref = "co-canadian";
+}
+);
+width = 1044;
+}
+);
+note = uni1591;
+unicode = 5521;
+},
+{
+glyphname = "ngoo-canadian";
+lastChange = "2023-01-13 15:31:19 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+ref = "ngo-canadian";
+},
+{
+anchor = top_right_can;
+pos = (834,0);
+ref = dot_top;
+}
+);
+width = 1044;
+}
+);
+note = uni1592;
+unicode = 5522;
+},
+{
+glyphname = "nga-canadian";
+kernLeft = mwestleft;
+kernRight = caright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (550,0);
+ref = "ca-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni1593;
+unicode = 5523;
+},
+{
+glyphname = "ngaa-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (550,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (588,0);
+ref = dot_top;
+}
+);
+width = 1071;
+}
+);
+note = uni1594;
+unicode = 5524;
+},
+{
+glyphname = "ng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(479,225,o),
+(526,271,o),
+(526,355,cs),
+(526,381,l),
+(436,381,l),
+(436,346,ls),
+(436,315,o),
+(424,301,o),
+(403,301,cs),
+(383,301,o),
+(373,315,o),
+(373,347,cs),
+(373,542,l),
+(246,542,l),
+(248,500,l),
+(264,512,o),
+(278,548,o),
+(278,590,cs),
+(278,670,o),
+(235,720,o),
+(157,720,cs),
+(80,720,o),
+(35.005,668.007,o),
+(35,585,cs),
+(35,503,o),
+(80,449,o),
+(162,449,cs),
+(296,449,l),
+(276,473,l),
+(276,359,ls),
+(276,272,o),
+(320,225,o),
+(402,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(135,520,o),
+(121,539,o),
+(121,585,cs),
+(121,631,o),
+(135,649,o),
+(157,649,cs),
+(179,649,o),
+(192,629,o),
+(192,584,cs),
+(192,540,o),
+(179,520,o),
+(157,520,cs)
+);
+}
+);
+width = 550;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1595;
+unicode = 5525;
+},
+{
+glyphname = "nng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(749,225,o),
+(797,271,o),
+(797,355,cs),
+(797,381,l),
+(706,381,l),
+(706,346,ls),
+(706,315,o),
+(694,301,o),
+(674,301,cs),
+(654,301,o),
+(644,315,o),
+(644,347,cs),
+(644,542,l),
+(521,542,l),
+(521,500,l),
+(537,512,o),
+(551,548,o),
+(551,590,cs),
+(551,673,o),
+(508,720,o),
+(430,720,cs),
+(353,720,o),
+(308,668,o),
+(308,586,cs),
+(308,546,o),
+(322,509,o),
+(338,497,c),
+(339,542,l),
+(247,542,l),
+(248,500,l),
+(264,512,o),
+(278,548,o),
+(278,590,cs),
+(278,670,o),
+(235,720,o),
+(157,720,cs),
+(80,720,o),
+(35.005,668.007,o),
+(35,585,cs),
+(35,503,o),
+(80,449,o),
+(162,449,cs),
+(547,449,l),
+(547,359,ls),
+(547,272,o),
+(591,225,o),
+(673,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(135,520,o),
+(121,539,o),
+(121,585,cs),
+(121,631,o),
+(135,649,o),
+(157,649,cs),
+(179,649,o),
+(192,629,o),
+(192,584,cs),
+(192,540,o),
+(179,520,o),
+(157,520,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(408,520,o),
+(394,539,o),
+(394,585,cs),
+(394,631,o),
+(408,649,o),
+(430,649,cs),
+(452,649,o),
+(465,629,o),
+(465,584,cs),
+(465,540,o),
+(452,520,o),
+(430,520,cs)
+);
+}
+);
+width = 821;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1596;
+unicode = 5526;
+},
+{
+glyphname = "sheSayisi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (613,357);
+},
+{
+name = top_center_can;
+pos = (269,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(489,0,l),
+(489,462,ls),
+(489,629,o),
+(414,728,o),
+(269,728,cs),
+(126,728,o),
+(40,625,o),
+(40,447,cs),
+(40,275,o),
+(106,194,o),
+(191,194,cs),
+(278,194,o),
+(319,259,o),
+(311,428,c),
+(253,428,l),
+(257,332,o),
+(242,314,o),
+(222,314,cs),
+(197,314,o),
+(181,340,o),
+(181,451,cs),
+(181,562,o),
+(211,604,o),
+(264,604,cs),
+(315,604,o),
+(341,563,o),
+(341,452,cs),
+(341,0,l)
+);
+}
+);
+width = 539;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1597;
+unicode = 5527;
+},
+{
+glyphname = "shiSayisi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(198,0,l),
+(198,452,ls),
+(198,563,o),
+(225,604,o),
+(276,604,cs),
+(329,604,o),
+(359,562,o),
+(359,451,cs),
+(359,341,o),
+(342,314,o),
+(317,314,cs),
+(297,314,o),
+(283,332,o),
+(287,428,c),
+(228,428,l),
+(220,259,o),
+(261,194,o),
+(348,194,cs),
+(433,194,o),
+(499,275,o),
+(499,447,cs),
+(499,625,o),
+(414,728,o),
+(272,728,cs),
+(126,728,o),
+(50,629,o),
+(50,462,cs),
+(50,0,l)
+);
+}
+);
+width = 539;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni1598;
+unicode = 5528;
+},
+{
+glyphname = "shoSayisi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (264,714);
+},
+{
+name = top_left_can;
+pos = (110,714);
+},
+{
+name = top_right_can;
+pos = (416,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(413,-14,o),
+(489,85,o),
+(489,252,cs),
+(489,714,l),
+(341,714,l),
+(341,262,ls),
+(341,151,o),
+(315,110,o),
+(264,110,cs),
+(211,110,o),
+(181,152,o),
+(181,263,cs),
+(181,373,o),
+(197,400,o),
+(222,400,cs),
+(242,400,o),
+(257,382,o),
+(253,286,c),
+(311,286,l),
+(319,455,o),
+(279,520,o),
+(191,520,cs),
+(106,520,o),
+(40,439,o),
+(40,266,cs),
+(40,89,o),
+(125,-14,o),
+(267,-14,cs)
+);
+}
+);
+width = 539;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1599;
+unicode = 5529;
+},
+{
+glyphname = "shaSayisi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(413,-14,o),
+(499,89,o),
+(499,267,cs),
+(499,439,o),
+(434,520,o),
+(349,520,cs),
+(262,520,o),
+(220,455,o),
+(228,286,c),
+(287,286,l),
+(283,382,o),
+(297,400,o),
+(317,400,cs),
+(342,400,o),
+(359,374,o),
+(359,263,cs),
+(359,152,o),
+(328,110,o),
+(275,110,cs),
+(224,110,o),
+(198,151,o),
+(198,262,cs),
+(198,714,l),
+(50,714,l),
+(50,252,ls),
+(50,85,o),
+(125,-14,o),
+(270,-14,cs)
+);
+}
+);
+width = 539;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni159A;
+unicode = 5530;
+},
+{
+glyphname = "theWoodScree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(582,-14,o),
+(673,75,o),
+(673,246,cs),
+(673,419,o),
+(585,506,o),
+(429,506,cs),
+(43,506,l),
+(43,385,l),
+(288,385,l),
+(277,408,l),
+(245,371,o),
+(228,305,o),
+(228,239,cs),
+(228,74,o),
+(314,-14,o),
+(450,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(401,110,o),
+(372,152,o),
+(372,247,cs),
+(372,340,o),
+(401,384,o),
+(450,384,cs),
+(499,384,o),
+(529,342,o),
+(529,247,cs),
+(529,152,o),
+(499,110,o),
+(450,110,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(663,593,l),
+(663,714,l),
+(43,714,l),
+(43,593,l)
+);
+}
+);
+width = 716;
+}
+);
+note = uni159B;
+unicode = 5531;
+},
+{
+glyphname = "thiWoodScree-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(403,-14,o),
+(489,74,o),
+(489,239,cs),
+(489,305,o),
+(471,371,o),
+(439,408,c),
+(428,385,l),
+(673,385,l),
+(673,506,l),
+(288,506,ls),
+(131,506,o),
+(43,417,o),
+(43,246,cs),
+(43,75,o),
+(134,-14,o),
+(266,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(217,110,o),
+(188,152,o),
+(188,247,cs),
+(188,342,o),
+(217,384,o),
+(266,384,cs),
+(315,384,o),
+(344,340,o),
+(344,247,cs),
+(344,152,o),
+(316,110,o),
+(266,110,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(673,593,l),
+(673,714,l),
+(54,714,l),
+(54,593,l)
+);
+}
+);
+width = 716;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159C;
+unicode = 5532;
+},
+{
+glyphname = "thoWoodScree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(431,0,ls),
+(585,0,o),
+(673,88,o),
+(673,260,cs),
+(673,431,o),
+(583,521,o),
+(450,521,cs),
+(314,521,o),
+(228,431,o),
+(228,267,cs),
+(228,202,o),
+(245,136,o),
+(277,99,c),
+(288,121,l),
+(43,121,l),
+(43,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(401,123,o),
+(372,167,o),
+(372,259,cs),
+(372,354,o),
+(401,396,o),
+(450,396,cs),
+(499,396,o),
+(529,355,o),
+(529,259,cs),
+(529,164,o),
+(499,123,o),
+(450,123,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(663,593,l),
+(663,714,l),
+(43,714,l),
+(43,593,l)
+);
+}
+);
+width = 716;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159D;
+unicode = 5533;
+},
+{
+glyphname = "thaWoodScree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(673,0,l),
+(673,121,l),
+(428,121,l),
+(439,98,l),
+(471,135,o),
+(489,201,o),
+(489,267,cs),
+(489,432,o),
+(403,521,o),
+(266,521,cs),
+(134,521,o),
+(43,431,o),
+(43,260,cs),
+(43,89,o),
+(131,0,o),
+(286,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(217,123,o),
+(188,164,o),
+(188,259,cs),
+(188,355,o),
+(217,396,o),
+(266,396,cs),
+(316,396,o),
+(344,354,o),
+(344,259,cs),
+(344,167,o),
+(315,123,o),
+(266,123,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(673,593,l),
+(673,714,l),
+(54,714,l),
+(54,593,l)
+);
+}
+);
+width = 716;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159E;
+unicode = 5534;
+},
+{
+glyphname = "thWoodScree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(387,356,l),
+(387,441,l),
+(252,441,l),
+(257,406,l),
+(274,418,o),
+(288,454,o),
+(288,497,cs),
+(288,577,o),
+(245,627,o),
+(167,627,cs),
+(90,627,o),
+(45,575,o),
+(45,492,cs),
+(45,410,o),
+(90,356,o),
+(172,356,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(145,427,o),
+(131,446,o),
+(131,492,cs),
+(131,538,o),
+(145,556,o),
+(167,556,cs),
+(189,556,o),
+(202,536,o),
+(202,491,cs),
+(202,447,o),
+(189,427,o),
+(167,427,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(377,670,l),
+(377,755,l),
+(49,755,l),
+(49,670,l)
+);
+}
+);
+width = 432;
+}
+);
+metricRight = "=|";
+note = uni159F;
+unicode = 5535;
+},
+{
+glyphname = "lhi-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (374,714);
+},
+{
+name = top_right_can;
+pos = (478,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(331,0,l),
+(331,129,l),
+(307,129,ls),
+(227,129,o),
+(186,170,o),
+(186,250,cs),
+(186,332,o),
+(226,373,o),
+(303,373,cs),
+(669,373,l),
+(669,491,l),
+(509,763,l),
+(398,697,l),
+(558,425,l),
+(556,506,l),
+(295,506,ls),
+(140,506,o),
+(40,418,o),
+(40,252,cs),
+(40,88,o),
+(138,0,o),
+(295,0,cs)
+);
+}
+);
+width = 707;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A0;
+unicode = 5536;
+},
+{
+glyphname = "lhii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "lhi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (288,0);
+ref = dot_top;
+}
+);
+width = 708;
+}
+);
+note = uni15A1;
+unicode = 5537;
+},
+{
+glyphname = "lho-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (352,524);
+},
+{
+name = top_right_can;
+pos = (443,524);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(310,-192,l),
+(150,81,l),
+(151,0,l),
+(413,0,ls),
+(568,0,o),
+(668,88,o),
+(668,254,cs),
+(668,419,o),
+(570,506,o),
+(414,506,cs),
+(377,506,l),
+(377,377,l),
+(401,377,ls),
+(481,377,o),
+(522,336,o),
+(522,256,cs),
+(522,174,o),
+(481,133,o),
+(405,133,cs),
+(38,133,l),
+(38,15,l),
+(199,-258,l)
+);
+}
+);
+width = 708;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni15A2;
+unicode = 5538;
+},
+{
+glyphname = "lhoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "lho-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (356,-190);
+ref = dot_top;
+}
+);
+width = 708;
+}
+);
+note = uni15A3;
+unicode = 5539;
+},
+{
+glyphname = "lha-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (358,524);
+},
+{
+name = top_left_can;
+pos = (266,524);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(669,15,l),
+(669,133,l),
+(303,133,ls),
+(227,133,o),
+(186,174,o),
+(186,256,cs),
+(186,336,o),
+(227,377,o),
+(306,377,cs),
+(331,377,l),
+(331,506,l),
+(294,506,ls),
+(137,506,o),
+(40,418,o),
+(40,253,cs),
+(40,88,o),
+(140,0,o),
+(295,0,cs),
+(556,0,l),
+(558,82,l),
+(398,-192,l),
+(509,-258,l)
+);
+}
+);
+width = 707;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A4;
+unicode = 5540;
+},
+{
+glyphname = "lhaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "lha-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (179,-190);
+ref = dot_top;
+}
+);
+width = 708;
+}
+);
+note = uni15A5;
+unicode = 5541;
+},
+{
+glyphname = "lh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(375,367,l),
+(375,449,l),
+(222,449,ls),
+(166,449,o),
+(138,480,o),
+(138,535,cs),
+(138,591,o),
+(166,623,o),
+(213,623,cs),
+(222,623,l),
+(222,714,l),
+(206,714,ls),
+(100,714,o),
+(41,640,o),
+(41,536,cs),
+(41,426,o),
+(100,356,o),
+(221,356,cs),
+(311,356,l),
+(303,411,l),
+(210,259,l),
+(284,214,l)
+);
+}
+);
+width = 416;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni15A6;
+unicode = 5542;
+},
+{
+glyphname = "theThCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (100,714);
+},
+{
+name = top_right_can;
+pos = (384,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(457,0,l),
+(457,85,l),
+(518,85,l),
+(518,165,l),
+(457,165,l),
+(457,357,l),
+(196,357,l),
+(224,311,l),
+(482,644,l),
+(377,726,l),
+(27,267,l),
+(27,229,l),
+(310,229,l),
+(310,165,l),
+(129,165,l),
+(129,85,l),
+(310,85,l),
+(310,0,l)
+);
+}
+);
+width = 543;
+}
+);
+metricLeft = "ye-canadian";
+note = uni15A7;
+unicode = 5543;
+},
+{
+glyphname = "thiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (160,714);
+},
+{
+name = top_right_can;
+pos = (444,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(233,0,l),
+(233,85,l),
+(415,85,l),
+(415,165,l),
+(233,165,l),
+(233,229,l),
+(516,229,l),
+(516,267,l),
+(166,726,l),
+(61,644,l),
+(329,298,l),
+(347,357,l),
+(86,357,l),
+(86,165,l),
+(25,165,l),
+(25,85,l),
+(86,85,l),
+(86,0,l)
+);
+}
+);
+width = 543;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+unicode = 5544;
+},
+{
+glyphname = "thiiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (73,0);
+ref = dot_top;
+}
+);
+width = 543;
+}
+);
+note = uni15A9;
+unicode = 5545;
+},
+{
+glyphname = "thoThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (100,714);
+},
+{
+name = top_right_can;
+pos = (384,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(482,70,l),
+(224,403,l),
+(196,357,l),
+(457,357,l),
+(457,549,l),
+(518,549,l),
+(518,629,l),
+(457,629,l),
+(457,714,l),
+(310,714,l),
+(310,629,l),
+(129,629,l),
+(129,549,l),
+(310,549,l),
+(310,485,l),
+(27,485,l),
+(27,447,l),
+(377,-12,l)
+);
+}
+);
+width = 543;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+unicode = 5546;
+},
+{
+glyphname = "thooThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (298,0);
+ref = dot_top;
+}
+);
+width = 543;
+}
+);
+note = uni15AB;
+unicode = 5547;
+},
+{
+glyphname = "thaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (160,714);
+},
+{
+name = top_right_can;
+pos = (444,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(516,447,l),
+(516,485,l),
+(233,485,l),
+(233,549,l),
+(415,549,l),
+(415,629,l),
+(233,629,l),
+(233,714,l),
+(86,714,l),
+(86,629,l),
+(25,629,l),
+(25,549,l),
+(86,549,l),
+(86,357,l),
+(347,357,l),
+(319,403,l),
+(61,70,l),
+(166,-12,l)
+);
+}
+);
+width = 543;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+unicode = 5548;
+},
+{
+glyphname = "thaaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (73,0);
+ref = dot_top;
+}
+);
+width = 543;
+}
+);
+note = uni15AD;
+unicode = 5549;
+},
+{
+glyphname = "thThCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(295,573,l),
+(295,600,l),
+(162,600,l),
+(162,636,l),
+(243,636,l),
+(243,677,l),
+(162,677,l),
+(162,714,l),
+(65,714,l),
+(65,677,l),
+(33,677,l),
+(33,636,l),
+(65,636,l),
+(65,519,l),
+(215,519,l),
+(191,577,l),
+(59,397,l),
+(131,348,l)
+);
+}
+);
+width = 316;
+}
+);
+metricRight = "y-canadian";
+note = uni15AE;
+unicode = 5550;
+},
+{
+glyphname = "bAivilik-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(414,-14,o),
+(494,90,o),
+(494,257,cs),
+(494,415,o),
+(416,521,o),
+(302,521,cs),
+(240,521,o),
+(199,488,o),
+(189,452,c),
+(200,419,l),
+(200,714,l),
+(53,714,l),
+(53,0,l),
+(188,0,l),
+(188,77,l),
+(183,61,l),
+(199,19,o),
+(236,-14,o),
+(303,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(228,110,o),
+(199,151,o),
+(199,253,cs),
+(199,355,o),
+(230,396,o),
+(274,396,cs),
+(319,396,o),
+(350,354,o),
+(350,253,cs),
+(350,152,o),
+(321,110,o),
+(274,110,cs)
+);
+}
+);
+width = 534;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|ke-canadian";
+note = uni15AF;
+unicode = 5551;
+},
+{
+glyphname = "eBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,0,l),
+(200,414,l),
+(227,377,o),
+(268,356,o),
+(317,356,cs),
+(414,356,o),
+(474,435,o),
+(474,543,cs),
+(474,650,o),
+(414,728,o),
+(317,728,cs),
+(263,728,o),
+(217,702,o),
+(192,659,c),
+(192,714,l),
+(53,714,l),
+(53,0,l)
+);
+}
+);
+width = 507;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B0;
+unicode = 5552;
+},
+{
+glyphname = "iBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(244,-14,o),
+(290,12,o),
+(314,55,c),
+(314,0,l),
+(454,0,l),
+(454,714,l),
+(306,714,l),
+(306,300,l),
+(280,337,o),
+(239,358,o),
+(190,358,cs),
+(92,358,o),
+(33,279,o),
+(33,171,cs),
+(33,64,o),
+(92,-14,o),
+(190,-14,cs)
+);
+}
+);
+width = 507;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B1;
+unicode = 5553;
+},
+{
+glyphname = "oBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(414,-14,o),
+(474,64,o),
+(474,171,cs),
+(474,279,o),
+(414,358,o),
+(317,358,cs),
+(268,358,o),
+(227,337,o),
+(200,300,c),
+(200,714,l),
+(53,714,l),
+(53,0,l),
+(192,0,l),
+(192,55,l),
+(217,12,o),
+(263,-14,o),
+(317,-14,cs)
+);
+}
+);
+width = 507;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "eBlackfoot-canadian";
+note = uni15B2;
+unicode = 5554;
+},
+{
+glyphname = "aBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(454,0,l),
+(454,714,l),
+(314,714,l),
+(314,659,l),
+(290,702,o),
+(244,728,o),
+(190,728,cs),
+(92,728,o),
+(33,650,o),
+(33,543,cs),
+(33,435,o),
+(92,356,o),
+(190,356,cs),
+(239,356,o),
+(280,377,o),
+(306,414,c),
+(306,0,l)
+);
+}
+);
+width = 507;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B3;
+unicode = 5555;
+},
+{
+glyphname = "weBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,292,l),
+(479,292,l),
+(479,418,l),
+(200,418,l),
+(200,589,l),
+(479,589,l),
+(479,714,l),
+(53,714,l),
+(53,0,l),
+(200,0,l)
+);
+}
+);
+width = 524;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B4;
+unicode = 5556;
+},
+{
+glyphname = "wiBlackfoot-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(472,0,l),
+(472,714,l),
+(324,714,l),
+(324,422,l),
+(45,422,l),
+(45,296,l),
+(324,296,l),
+(324,125,l),
+(45,125,l),
+(45,0,l)
+);
+}
+);
+width = 525;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B5;
+unicode = 5557;
+},
+{
+glyphname = "woBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(479,0,l),
+(479,125,l),
+(200,125,l),
+(200,296,l),
+(479,296,l),
+(479,422,l),
+(200,422,l),
+(200,714,l),
+(53,714,l),
+(53,0,l)
+);
+}
+);
+width = 524;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "weBlackfoot-canadian";
+note = uni15B6;
+unicode = 5558;
+},
+{
+glyphname = "waBlackfoot-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(472,0,l),
+(472,714,l),
+(45,714,l),
+(45,589,l),
+(324,589,l),
+(324,418,l),
+(45,418,l),
+(45,292,l),
+(324,292,l),
+(324,0,l)
+);
+}
+);
+width = 525;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B7;
+unicode = 5559;
+},
+{
+glyphname = "neBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,0,l),
+(200,607,l),
+(252,607,l),
+(213,690,l),
+(213,669,ls),
+(213,498,o),
+(289,400,o),
+(429,400,cs),
+(567,400,o),
+(652,502,o),
+(652,667,cs),
+(652,714,l),
+(508,714,l),
+(508,651,ls),
+(508,572,o),
+(482,528,o),
+(433,528,cs),
+(383,528,o),
+(357,571,o),
+(357,650,cs),
+(357,714,l),
+(53,714,l),
+(53,0,l)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B8;
+unicode = 5560;
+},
+{
+glyphname = "niBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(169,0,l),
+(169,63,ls),
+(169,142,o),
+(195,186,o),
+(245,186,cs),
+(294,186,o),
+(320,143,o),
+(320,64,cs),
+(320,0,l),
+(624,0,l),
+(624,714,l),
+(477,714,l),
+(477,107,l),
+(425,107,l),
+(464,24,l),
+(464,45,ls),
+(464,216,o),
+(388,314,o),
+(249,314,cs),
+(110,314,o),
+(25,212,o),
+(25,47,cs),
+(25,0,l)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B9;
+unicode = 5561;
+},
+{
+glyphname = "noBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(357,0,l),
+(357,64,ls),
+(357,143,o),
+(383,186,o),
+(433,186,cs),
+(482,186,o),
+(508,142,o),
+(508,63,cs),
+(508,0,l),
+(652,0,l),
+(652,47,ls),
+(652,212,o),
+(567,314,o),
+(429,314,cs),
+(289,314,o),
+(213,216,o),
+(213,45,cs),
+(213,24,l),
+(252,107,l),
+(200,107,l),
+(200,714,l),
+(53,714,l),
+(53,0,l)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "neBlackfoot-canadian";
+note = uni15BA;
+unicode = 5562;
+},
+{
+glyphname = "naBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(624,0,l),
+(624,714,l),
+(320,714,l),
+(320,650,ls),
+(320,571,o),
+(294,528,o),
+(245,528,cs),
+(195,528,o),
+(169,572,o),
+(169,651,cs),
+(169,714,l),
+(25,714,l),
+(25,667,ls),
+(25,502,o),
+(110,400,o),
+(249,400,cs),
+(388,400,o),
+(464,498,o),
+(464,669,cs),
+(464,690,l),
+(425,607,l),
+(477,607,l),
+(477,0,l)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BB;
+unicode = 5563;
+},
+{
+glyphname = "keBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,0,l),
+(200,544,l),
+(153,544,l),
+(283,260,l),
+(344,260,l),
+(553,714,l),
+(406,714,l),
+(271,417.991,l),
+(326,418,l),
+(191,714,l),
+(53,714,l),
+(53,0,l)
+);
+}
+);
+width = 562;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15BC;
+unicode = 5564;
+},
+{
+glyphname = "kiBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(156,0,l),
+(291,296,l),
+(236,296,l),
+(371,0,l),
+(509,0,l),
+(509,714,l),
+(361,714,l),
+(361,170,l),
+(409,170,l),
+(279,454,l),
+(218,454,l),
+(9.007,0,l)
+);
+}
+);
+width = 562;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BD;
+unicode = 5565;
+},
+{
+glyphname = "koBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(191,0,l),
+(326,296,l),
+(271,296.009,l),
+(406,0,l),
+(553,0,l),
+(344,454,l),
+(283,454,l),
+(153,170,l),
+(200,170,l),
+(200,714,l),
+(53,714,l),
+(53,0,l)
+);
+}
+);
+width = 562;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "keBlackfoot-canadian";
+note = uni15BE;
+unicode = 5566;
+},
+{
+glyphname = "kaBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(509,0,l),
+(509,714,l),
+(371,714,l),
+(236,418,l),
+(291,418,l),
+(156,714,l),
+(9.007,714,l),
+(218,260,l),
+(279,260,l),
+(409,544,l),
+(361,544,l),
+(361,0,l)
+);
+}
+);
+width = 562;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BF;
+unicode = 5567;
+},
+{
+color = 9;
+glyphname = "heSayisi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_right_can;
+pos = (490,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(563,0,l),
+(563,714,l),
+(417,714,l),
+(417,366,l),
+(440,366,l),
+(436,604,o),
+(343,728,o),
+(225,728,cs),
+(109,728,o),
+(36,635,o),
+(36,455,cs),
+(36,419,o),
+(39,380,o),
+(46,342,c),
+(186,342,l),
+(181,373,o),
+(178,411,o),
+(178,436,cs),
+(178,557,o),
+(212,600,o),
+(261,600,cs),
+(342,600,o),
+(412,468,o),
+(415,0,c)
+);
+}
+);
+width = 616;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni15C0;
+unicode = 5568;
+},
+{
+color = 9;
+glyphname = "hiSayisi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,0,l),
+(204,468,o),
+(274,600,o),
+(355,600,cs),
+(404,600,o),
+(438,557,o),
+(438,436,cs),
+(438,411,o),
+(435,373,o),
+(430,342,c),
+(570,342,l),
+(577,380,o),
+(580,419,o),
+(580,455,cs),
+(580,635,o),
+(507,728,o),
+(391,728,cs),
+(273,728,o),
+(180,604,o),
+(176,366,c),
+(199,366,l),
+(199,714,l),
+(53,714,l),
+(53,0,l)
+);
+}
+);
+width = 616;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C1;
+unicode = 5569;
+},
+{
+color = 9;
+glyphname = "hoSayisi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (303,714);
+},
+{
+name = top_left_can;
+pos = (116,714);
+},
+{
+name = top_right_can;
+pos = (490,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(343,-14,o),
+(436,110,o),
+(440,348,c),
+(417,348,l),
+(417,0,l),
+(563,0,l),
+(563,714,l),
+(415,714,l),
+(412,246,o),
+(342,114,o),
+(261,114,cs),
+(212,114,o),
+(178,157,o),
+(178,278,cs),
+(178,303,o),
+(181,341,o),
+(186,372,c),
+(46,372,l),
+(39,334,o),
+(36,295,o),
+(36,259,cs),
+(36,79,o),
+(109,-14,o),
+(225,-14,cs)
+);
+}
+);
+width = 616;
+}
+);
+metricLeft = "heSayisi-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15C2;
+unicode = 5570;
+},
+{
+color = 9;
+glyphname = "haSayisi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(507,-14,o),
+(580,79,o),
+(580,259,cs),
+(580,295,o),
+(577,334,o),
+(570,372,c),
+(430,372,l),
+(435,341,o),
+(438,303,o),
+(438,278,cs),
+(438,157,o),
+(404,114,o),
+(355,114,cs),
+(274,114,o),
+(204,246,o),
+(200,714,c),
+(53,714,l),
+(53,0,l),
+(199,0,l),
+(199,348,l),
+(176,348,l),
+(180,110,o),
+(273,-14,o),
+(391,-14,cs)
+);
+}
+);
+width = 616;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C3;
+unicode = 5571;
+},
+{
+color = 9;
+glyphname = "ghuCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(339,0,l),
+(617,678,l),
+(617,714,l),
+(498,714,l),
+(420,516,l),
+(493,536,l),
+(147,536,l),
+(222,513,l),
+(142,714,l),
+(19,714,l),
+(19,678,l),
+(297,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(458,428,l),
+(398,442,l),
+(295,182,l),
+(345,182,l),
+(242,446,l),
+(183,428,l)
+);
+}
+);
+width = 636;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C4;
+unicode = 5572;
+},
+{
+color = 9;
+glyphname = "ghoCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,0,l),
+(222,201,l),
+(147,178,l),
+(493,178,l),
+(420,198,l),
+(498,0,l),
+(617,0,l),
+(617,36,l),
+(339,714,l),
+(297,714,l),
+(19,36,l),
+(19,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(345,532,l),
+(295,532,l),
+(398,272,l),
+(458,286,l),
+(183,286,l),
+(242,268,l)
+);
+}
+);
+width = 636;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C5;
+unicode = 5573;
+},
+{
+color = 9;
+glyphname = "gheCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (66,357);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(70,0,l),
+(546,334,l),
+(546,380,l),
+(70,714,l),
+(36,714,l),
+(36,594,l),
+(162,504,l),
+(156,568,l),
+(156,140,l),
+(162,208,l),
+(36,119,l),
+(36,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(257,519,l),
+(235,469,l),
+(444,320,l),
+(444,395,l),
+(235,247,l),
+(257,197,l)
+);
+}
+);
+width = 573;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15C6;
+unicode = 5574;
+},
+{
+color = 9;
+glyphname = "gheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (19,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 573;
+}
+);
+note = uni15C7;
+unicode = 5575;
+},
+{
+color = 9;
+glyphname = "ghiCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (-6,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 573;
+}
+);
+note = uni15C8;
+unicode = 5576;
+},
+{
+color = 9;
+glyphname = "ghaCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(537,0,l),
+(537,118,l),
+(413,207,l),
+(421,151,l),
+(421,563,l),
+(413,506,l),
+(537,594,l),
+(537,714,l),
+(503,714,l),
+(27,380,l),
+(27,334,l),
+(503,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(341,244,l),
+(130,394,l),
+(130,319,l),
+(341,469,l),
+(319,495,l),
+(319,228,l)
+);
+}
+);
+width = 573;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15C9;
+unicode = 5577;
+},
+{
+color = 9;
+glyphname = "ruCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(339,0,l),
+(617,678,l),
+(617,714,l),
+(499,714,l),
+(465,628,l),
+(495,645,l),
+(143,645,l),
+(178,627,l),
+(144,714,l),
+(19,714,l),
+(19,678,l),
+(297,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(464,535,l),
+(445,560,l),
+(298,183,l),
+(348,183,l),
+(200,559,l),
+(173,535,l)
+);
+}
+);
+width = 636;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CA;
+unicode = 5578;
+},
+{
+color = 9;
+glyphname = "roCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(143,0,l),
+(177,86,l),
+(145,69,l),
+(496,69,l),
+(463,87,l),
+(498,0,l),
+(617,0,l),
+(617,36,l),
+(339,714,l),
+(297,714,l),
+(19,36,l),
+(19,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(343,532,l),
+(293,532,l),
+(442,155,l),
+(467,179,l),
+(176,179,l),
+(196,154,l)
+);
+}
+);
+width = 636;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CB;
+unicode = 5579;
+},
+{
+color = 9;
+glyphname = "reCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(71,0,l),
+(546,334,l),
+(546,380,l),
+(71,714,l),
+(36,714,l),
+(36,591,l),
+(104,542,l),
+(89,577,l),
+(89,136,l),
+(104,172,l),
+(36,122,l),
+(36,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(195,550,l),
+(181,499,l),
+(433,319,l),
+(433,394,l),
+(181,214,l),
+(195,161,l)
+);
+}
+);
+width = 573;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CC;
+unicode = 5580;
+},
+{
+color = 9;
+glyphname = "reeCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(71,0,l),
+(546,334,l),
+(546,380,l),
+(71,714,l),
+(36,714,l),
+(36,610,l),
+(104,560,l),
+(89,579,l),
+(89,132,l),
+(104,152,l),
+(36,103,l),
+(36,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(179,553,l),
+(169,526,l),
+(462,319,l),
+(462,394,l),
+(167,185,l),
+(179,163,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(262,286,l),
+(262,428,l),
+(214,428,l),
+(214,286,l)
+);
+}
+);
+width = 573;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CD;
+unicode = 5581;
+},
+{
+color = 9;
+glyphname = "riCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(71,0,l),
+(546,334,l),
+(546,380,l),
+(71,714,l),
+(36,714,l),
+(36,610,l),
+(104,560,l),
+(89,579,l),
+(89,132,l),
+(104,152,l),
+(36,103,l),
+(36,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(278,311,o),
+(301,331,o),
+(301,357,cs),
+(301,383,o),
+(278,403,o),
+(254,403,cs),
+(230,403,o),
+(207,383,o),
+(207,357,cs),
+(207,331,o),
+(230,311,o),
+(254,311,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(179,553,l),
+(169,526,l),
+(462,319,l),
+(462,394,l),
+(167,185,l),
+(179,163,l)
+);
+}
+);
+width = 573;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CE;
+unicode = 5582;
+},
+{
+color = 9;
+glyphname = "raCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(537,0,l),
+(537,123,l),
+(471,172,l),
+(484,105,l),
+(484,610,l),
+(471,543,l),
+(537,592,l),
+(537,714,l),
+(502,714,l),
+(27,380,l),
+(27,334,l),
+(502,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(394,501,l),
+(379,553,l),
+(379,162,l),
+(394,214,l),
+(140,395,l),
+(140,320,l)
+);
+}
+);
+width = 573;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15CF;
+unicode = 5583;
+},
+{
+color = 9;
+glyphname = "wuCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(347,0,l),
+(633,678,l),
+(633,714,l),
+(522,714,l),
+(357,278,l),
+(386,278,l),
+(386,714,l),
+(277,714,l),
+(277,278,l),
+(307,278,l),
+(137,714,l),
+(19,714,l),
+(19,678,l),
+(305,0,l)
+);
+}
+);
+width = 652;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D0;
+unicode = 5584;
+},
+{
+color = 9;
+glyphname = "woCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(135,0,l),
+(303,436,l),
+(273,436,l),
+(273,0,l),
+(382,0,l),
+(382,436,l),
+(351,436,l),
+(521,0,l),
+(633,0,l),
+(633,36,l),
+(347,714,l),
+(305,714,l),
+(19,36,l),
+(19,0,l)
+);
+}
+);
+width = 652;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D1;
+unicode = 5585;
+},
+{
+color = 9;
+glyphname = "weCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(87,0,l),
+(563,334,l),
+(563,380,l),
+(87,714,l),
+(53,714,l),
+(53,595,l),
+(348,391,l),
+(348,412,l),
+(60,412,l),
+(60,302,l),
+(349,302,l),
+(349,322,l),
+(53,118,l),
+(53,0,l)
+);
+}
+);
+width = 590;
+}
+);
+metricRight = "o-canadian";
+note = uni15D2;
+unicode = 5586;
+},
+{
+color = 9;
+glyphname = "weeCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(87,0,l),
+(563,334,l),
+(563,380,l),
+(87,714,l),
+(53,714,l),
+(53,605,l),
+(405,365,l),
+(416,401,l),
+(192,401,l),
+(192,464,l),
+(116,464,l),
+(116,401,l),
+(53,401,l),
+(53,314,l),
+(116,314,l),
+(116,251,l),
+(192,251,l),
+(192,314,l),
+(416,314,l),
+(405,350,l),
+(53,108,l),
+(53,0,l)
+);
+}
+);
+width = 590;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D3;
+unicode = 5587;
+},
+{
+color = 9;
+glyphname = "wiCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(87,0,l),
+(563,334,l),
+(563,380,l),
+(87,714,l),
+(53,714,l),
+(53,605,l),
+(405,365,l),
+(416,401,l),
+(249,401,l),
+(235,426,o),
+(208,443,o),
+(177,443,cs),
+(145,443,o),
+(118,426,o),
+(104,401,c),
+(53,401,l),
+(53,314,l),
+(105,314,l),
+(119,289,o),
+(146,271,o),
+(177,271,cs),
+(207,271,o),
+(234,289,o),
+(248,314,c),
+(416,314,l),
+(405,350,l),
+(53,108,l),
+(53,0,l)
+);
+}
+);
+width = 590;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D4;
+unicode = 5588;
+},
+{
+color = 9;
+glyphname = "waCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(537,0,l),
+(537,119,l),
+(242,322,l),
+(242,302,l),
+(530,302,l),
+(530,412,l),
+(242,412,l),
+(242,391,l),
+(537,595,l),
+(537,714,l),
+(503,714,l),
+(27,380,l),
+(27,334,l),
+(503,0,l)
+);
+}
+);
+width = 590;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15D5;
+unicode = 5589;
+},
+{
+color = 9;
+glyphname = "hwuCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(347,0,l),
+(633,678,l),
+(633,714,l),
+(529,714,l),
+(460,546,l),
+(496,555,l),
+(370,555,l),
+(370,714,l),
+(285,714,l),
+(285,555,l),
+(153,555,l),
+(195,548,l),
+(127,714,l),
+(19,714,l),
+(19,678,l),
+(305,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(293,479,l),
+(293,210,l),
+(317,214,l),
+(212,487,l),
+(163,479,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(363,479,l),
+(487,479,l),
+(444,487,l),
+(339,214,l),
+(363,210,l)
+);
+}
+);
+width = 652;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D6;
+unicode = 5590;
+},
+{
+color = 9;
+glyphname = "hwoCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(126,0,l),
+(196,168,l),
+(163,153,l),
+(284,153,l),
+(284,0,l),
+(369,0,l),
+(369,153,l),
+(508,153,l),
+(461,166,l),
+(529,0,l),
+(633,0,l),
+(633,36,l),
+(347,714,l),
+(305,714,l),
+(19,36,l),
+(19,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(312,493,l),
+(292,497,l),
+(292,241,l),
+(193,241,l),
+(211,227,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(476,241,l),
+(362,241,l),
+(362,498,l),
+(341,494,l),
+(444,227,l)
+);
+}
+);
+width = 652;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D7;
+unicode = 5591;
+},
+{
+color = 9;
+glyphname = "hweCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(87,0,l),
+(563,334,l),
+(563,380,l),
+(87,714,l),
+(53,714,l),
+(53,605,l),
+(164,529,l),
+(164,403,l),
+(53,403,l),
+(53,311,l),
+(164,311,l),
+(164,184,l),
+(53,108,l),
+(53,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(234,321,l),
+(385,321,l),
+(234,220,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(234,493,l),
+(384,393,l),
+(234,393,l)
+);
+}
+);
+width = 590;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D8;
+unicode = 5592;
+},
+{
+color = 9;
+glyphname = "hweeCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(87,0,l),
+(563,334,l),
+(563,380,l),
+(87,714,l),
+(53,714,l),
+(53,611,l),
+(205,507,l),
+(205,396,l),
+(162,396,l),
+(162,461,l),
+(102,461,l),
+(102,396,l),
+(53,396,l),
+(53,319,l),
+(102,319,l),
+(102,253,l),
+(162,253,l),
+(162,319,l),
+(205,319,l),
+(205,205,l),
+(53,101,l),
+(53,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(267,326,l),
+(391,326,l),
+(267,239,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(267,474,l),
+(390,389,l),
+(267,389,l)
+);
+}
+);
+width = 590;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D9;
+unicode = 5593;
+},
+{
+color = 9;
+glyphname = "hwiCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(87,0,l),
+(563,334,l),
+(563,380,l),
+(87,714,l),
+(53,714,l),
+(53,611,l),
+(205,507,l),
+(205,389,l),
+(189,389,l),
+(179,410,o),
+(158,424,o),
+(134,424,cs),
+(110,424,o),
+(90,409,o),
+(79,389,c),
+(53,389,l),
+(53,326,l),
+(79,326,l),
+(90,305,o),
+(110,290,o),
+(134,290,cs),
+(156,290,o),
+(177,305,o),
+(188,326,c),
+(205,326,l),
+(205,205,l),
+(53,101,l),
+(53,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(267,326,l),
+(391,326,l),
+(267,239,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(267,474,l),
+(390,389,l),
+(267,389,l)
+);
+}
+);
+width = 590;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15DA;
+unicode = 5594;
+},
+{
+color = 9;
+glyphname = "hwaCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(537,0,l),
+(537,108,l),
+(427,184,l),
+(427,311,l),
+(537,311,l),
+(537,403,l),
+(427,403,l),
+(427,529,l),
+(537,605,l),
+(537,714,l),
+(503,714,l),
+(27,380,l),
+(27,334,l),
+(503,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(205,321,l),
+(356,321,l),
+(356,220,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(356,493,l),
+(356,393,l),
+(206,393,l)
+);
+}
+);
+width = 590;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15DB;
+unicode = 5595;
+},
+{
+color = 9;
+glyphname = "thuCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(494,-14,o),
+(590,88,o),
+(590,281,cs),
+(590,714,l),
+(50,714,l),
+(50,280,ls),
+(50,88,o),
+(150,-14,o),
+(321,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(196,583,l),
+(444,583,l),
+(444,282,ls),
+(444,169,o),
+(401,121,o),
+(320,121,cs),
+(242,121,o),
+(196,172,o),
+(196,282,cs)
+);
+}
+);
+width = 640;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DC;
+unicode = 5596;
+},
+{
+color = 9;
+glyphname = "thoCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(590,0,l),
+(590,434,ls),
+(590,626,o),
+(491,728,o),
+(321,728,cs),
+(148,728,o),
+(50,626,o),
+(50,434,cs),
+(50,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(196,432,ls),
+(196,544,o),
+(240,593,o),
+(321,593,cs),
+(399,593,o),
+(444,542,o),
+(444,432,cs),
+(444,131,l),
+(196,131,l)
+);
+}
+);
+width = 640;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DD;
+unicode = 5597;
+},
+{
+color = 9;
+glyphname = "theCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (318,357);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(252,0,ls),
+(469,0,o),
+(594,120,o),
+(594,358,cs),
+(594,596,o),
+(469,714,o),
+(250,714,cs),
+(53,714,l),
+(53,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,623,l),
+(162,585,l),
+(249,585,ls),
+(380,585,o),
+(447,518,o),
+(447,358,cs),
+(447,198,o),
+(380,129,o),
+(250,129,cs),
+(162,129,l),
+(200,91,l)
+);
+}
+);
+width = 639;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "to-canadian";
+note = uni15DE;
+unicode = 5598;
+},
+{
+color = 9;
+glyphname = "theeCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (260,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 639;
+}
+);
+note = uni15DF;
+unicode = 5599;
+},
+{
+color = 9;
+glyphname = "thiCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (232,0);
+ref = dot_middle;
+}
+);
+width = 639;
+}
+);
+note = uni15E0;
+unicode = 5600;
+},
+{
+color = 9;
+glyphname = "thaCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(587,0,l),
+(587,714,l),
+(388,714,ls),
+(170,714,o),
+(45,594,o),
+(45,356,cs),
+(45,118,o),
+(170,0,o),
+(389,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(193,516,o),
+(258,585,o),
+(388,585,cs),
+(477,585,l),
+(439,623,l),
+(439,91,l),
+(477,129,l),
+(389,129,ls),
+(258,129,o),
+(193,196,o),
+(193,356,cs)
+);
+}
+);
+width = 640;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15E1;
+unicode = 5601;
+},
+{
+color = 9;
+glyphname = "ttuCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(494,-14,o),
+(590,88,o),
+(590,281,cs),
+(590,714,l),
+(549,714,l),
+(302,533,l),
+(340,533,l),
+(93,714,l),
+(50,714,l),
+(50,280,ls),
+(50,88,o),
+(150,-14,o),
+(321,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(242,121,o),
+(196,172,o),
+(196,282,cs),
+(196,597,l),
+(63,593,l),
+(309,412,l),
+(333,412,l),
+(579,593,l),
+(444,597,l),
+(444,282,ls),
+(444,169,o),
+(401,121,o),
+(320,121,cs)
+);
+}
+);
+width = 640;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E2;
+unicode = 5602;
+},
+{
+color = 9;
+glyphname = "ttoCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(92,0,l),
+(339,181,l),
+(301,181,l),
+(547,0,l),
+(590,0,l),
+(590,434,ls),
+(590,626,o),
+(491,728,o),
+(320,728,cs),
+(147,728,o),
+(50,626,o),
+(50,433,cs),
+(50,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(399,593,o),
+(444,542,o),
+(444,432,cs),
+(444,117,l),
+(578,121,l),
+(332,302,l),
+(308,302,l),
+(62,121,l),
+(196,117,l),
+(196,432,ls),
+(196,545,o),
+(239,593,o),
+(321,593,cs)
+);
+}
+);
+width = 640;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E3;
+unicode = 5603;
+},
+{
+color = 9;
+glyphname = "tteCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (365,357);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(262,0,ls),
+(480,0,o),
+(605,120,o),
+(605,358,cs),
+(605,596,o),
+(480,714,o),
+(261,714,cs),
+(48,714,l),
+(48,678,l),
+(155,339,l),
+(155,374,l),
+(48,36,l),
+(48,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(290,345,l),
+(290,365,l),
+(182,704,l),
+(182,585,l),
+(261,585,ls),
+(392,585,o),
+(457,518,o),
+(457,358,cs),
+(457,198,o),
+(392,129,o),
+(262,129,cs),
+(182,129,l),
+(182,7,l)
+);
+}
+);
+width = 650;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15E4;
+unicode = 5604;
+},
+{
+color = 9;
+glyphname = "tteeCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (318,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 649;
+}
+);
+note = uni15E5;
+unicode = 5605;
+},
+{
+color = 9;
+glyphname = "ttiCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (310,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 649;
+}
+);
+note = uni15E6;
+unicode = 5606;
+},
+{
+color = 9;
+glyphname = "ttaCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(602,0,l),
+(602,36,l),
+(495,375,l),
+(495,340,l),
+(602,678,l),
+(602,714,l),
+(388,714,ls),
+(170,714,o),
+(45,594,o),
+(45,356,cs),
+(45,118,o),
+(170,0,o),
+(389,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(468,129,l),
+(389,129,ls),
+(258,129,o),
+(193,196,o),
+(193,356,cs),
+(193,516,o),
+(258,585,o),
+(388,585,cs),
+(468,585,l),
+(468,707,l),
+(360,369,l),
+(360,349,l),
+(468,10,l)
+);
+}
+);
+width = 650;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tteCarrier-canadian";
+note = uni15E7;
+unicode = 5607;
+},
+{
+color = 9;
+glyphname = "puCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(494,-14,o),
+(590,88,o),
+(590,281,cs),
+(590,714,l),
+(443,714,l),
+(443,567,l),
+(198,567,l),
+(198,714,l),
+(50,714,l),
+(50,280,ls),
+(50,88,o),
+(150,-14,o),
+(321,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(242,121,o),
+(198,172,o),
+(198,282,cs),
+(198,437,l),
+(443,437,l),
+(443,282,ls),
+(443,169,o),
+(401,121,o),
+(320,121,cs)
+);
+}
+);
+width = 640;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E8;
+unicode = 5608;
+},
+{
+color = 9;
+glyphname = "poCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(198,0,l),
+(198,147,l),
+(443,147,l),
+(443,0,l),
+(590,0,l),
+(590,434,ls),
+(590,626,o),
+(492,728,o),
+(321,728,cs),
+(154,728,o),
+(50,626,o),
+(50,434,cs),
+(50,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(198,432,ls),
+(198,544,o),
+(240,593,o),
+(321,593,cs),
+(399,593,o),
+(443,542,o),
+(443,432,cs),
+(443,277,l),
+(198,277,l)
+);
+}
+);
+width = 640;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E9;
+unicode = 5609;
+},
+{
+color = 9;
+glyphname = "peCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (351,357);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(261,0,ls),
+(479,0,o),
+(603,120,o),
+(603,358,cs),
+(603,596,o),
+(479,714,o),
+(259,714,cs),
+(47,714,l),
+(47,585,l),
+(116,585,l),
+(116,129,l),
+(47,129,l),
+(47,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(261,623,l),
+(204,585,l),
+(260,585,ls),
+(390,585,o),
+(456,518,o),
+(456,358,cs),
+(456,198,o),
+(390,129,o),
+(261,129,cs),
+(204,129,l),
+(261,91,l)
+);
+}
+);
+width = 648;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15EA;
+unicode = 5610;
+},
+{
+color = 9;
+glyphname = "peeCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (304,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 648;
+}
+);
+note = uni15EB;
+unicode = 5611;
+},
+{
+color = 9;
+glyphname = "piCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (296,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 648;
+}
+);
+note = uni15EC;
+unicode = 5612;
+},
+{
+color = 9;
+glyphname = "paCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(602,0,l),
+(602,129,l),
+(533,129,l),
+(533,585,l),
+(602,585,l),
+(602,714,l),
+(389,714,ls),
+(170,714,o),
+(45,596,o),
+(45,358,cs),
+(45,120,o),
+(170,0,o),
+(388,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(445,129,l),
+(388,129,ls),
+(258,129,o),
+(193,198,o),
+(193,358,cs),
+(193,518,o),
+(258,585,o),
+(389,585,cs),
+(445,585,l),
+(387,623,l),
+(387,91,l)
+);
+}
+);
+width = 649;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|peCarrier-canadian";
+note = uni15ED;
+unicode = 5613;
+},
+{
+color = 6;
+glyphname = "pCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(333,189,l),
+(333,282,l),
+(238,282,l),
+(238,546,l),
+(140,546,l),
+(140,282,l),
+(45,282,l),
+(45,189,l)
+);
+}
+);
+width = 378;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni15EE;
+unicode = 5614;
+},
+{
+color = 9;
+glyphname = "guCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (372,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(322,-14,o),
+(378,30,o),
+(406,122,c),
+(339,122,l),
+(372,28,o),
+(427,-14,o),
+(509,-14,cs),
+(621,-14,o),
+(695,61,o),
+(695,192,cs),
+(695,714,l),
+(555,714,l),
+(555,199,ls),
+(555,144,o),
+(535,118,o),
+(499,118,cs),
+(464,118,o),
+(441,145,o),
+(441,199,cs),
+(441,714,l),
+(304,714,l),
+(304,199,ls),
+(304,144,o),
+(283,118,o),
+(248,118,cs),
+(211,118,o),
+(190,144,o),
+(190,199,cs),
+(190,714,l),
+(50,714,l),
+(50,193,ls),
+(50,62,o),
+(126,-14,o),
+(238,-14,cs)
+);
+}
+);
+width = 745;
+}
+);
+metricRight = "=|";
+note = uni15EF;
+unicode = 5615;
+},
+{
+color = 9;
+glyphname = "goCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(190,0,l),
+(190,515,ls),
+(190,570,o),
+(210,596,o),
+(246,596,cs),
+(281,596,o),
+(304,570,o),
+(304,515,cs),
+(304,0,l),
+(441,0,l),
+(441,515,ls),
+(441,570,o),
+(462,596,o),
+(497,596,cs),
+(534,596,o),
+(555,570,o),
+(555,515,cs),
+(555,0,l),
+(695,0,l),
+(695,521,ls),
+(695,652,o),
+(619,728,o),
+(507,728,cs),
+(423,728,o),
+(367,684,o),
+(339,592,c),
+(406,592,l),
+(373,686,o),
+(318,728,o),
+(236,728,cs),
+(123,728,o),
+(50,653,o),
+(50,522,cs),
+(50,0,l)
+);
+}
+);
+width = 745;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F0;
+unicode = 5616;
+},
+{
+color = 9;
+glyphname = "geCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (324,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(376,0,ls),
+(516,0,o),
+(594,71,o),
+(594,199,cs),
+(594,283,o),
+(546,351,o),
+(473,381,c),
+(473,332,l),
+(549,359,o),
+(594,422,o),
+(594,513,cs),
+(594,640,o),
+(513,714,o),
+(376,714,cs),
+(53,714,l),
+(53,594,l),
+(346,594,ls),
+(410,594,o),
+(447,566,o),
+(447,507,cs),
+(447,446,o),
+(410,417,o),
+(347,417,cs),
+(53,417,l),
+(53,299,l),
+(347,299,ls),
+(409,299,o),
+(447,269,o),
+(447,208,cs),
+(447,148,o),
+(409,120,o),
+(346,120,cs),
+(53,120,l),
+(53,0,l)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15F1;
+unicode = 5617;
+},
+{
+color = 9;
+glyphname = "geeCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(376,0,ls),
+(516,0,o),
+(594,71,o),
+(594,199,cs),
+(594,283,o),
+(546,351,o),
+(473,381,c),
+(473,332,l),
+(549,359,o),
+(594,422,o),
+(594,513,cs),
+(594,640,o),
+(513,714,o),
+(376,714,cs),
+(53,714,l),
+(53,594,l),
+(346,594,ls),
+(410,594,o),
+(447,566,o),
+(447,507,cs),
+(447,446,o),
+(410,416,o),
+(347,416,cs),
+(306,416,l),
+(306,495,l),
+(229,495,l),
+(229,416,l),
+(53,416,l),
+(53,300,l),
+(229,300,l),
+(229,221,l),
+(306,221,l),
+(306,300,l),
+(347,300,ls),
+(409,300,o),
+(447,269,o),
+(447,208,cs),
+(447,148,o),
+(409,120,o),
+(346,120,cs),
+(53,120,l),
+(53,0,l)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F2;
+unicode = 5618;
+},
+{
+color = 9;
+glyphname = "giCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(376,0,ls),
+(516,0,o),
+(594,71,o),
+(594,199,cs),
+(594,282,o),
+(547,349,o),
+(476,379,c),
+(476,334,l),
+(550,361,o),
+(594,423,o),
+(594,513,cs),
+(594,640,o),
+(513,714,o),
+(376,714,cs),
+(53,714,l),
+(53,594,l),
+(346,594,ls),
+(410,594,o),
+(447,566,o),
+(447,507,cs),
+(447,446,o),
+(410,416,o),
+(360,416,cs),
+(320,416,l),
+(369,396,l),
+(355,432,o),
+(322,457,o),
+(280,457,cs),
+(247,457,o),
+(218,441,o),
+(201,416,c),
+(53,416,l),
+(53,300,l),
+(200,300,l),
+(217,274,o),
+(246,257,o),
+(280,257,cs),
+(322,257,o),
+(355,283,o),
+(369,320,c),
+(320,300,l),
+(359,300,ls),
+(409,300,o),
+(447,269,o),
+(447,208,cs),
+(447,148,o),
+(409,120,o),
+(346,120,cs),
+(53,120,l),
+(53,0,l)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F3;
+unicode = 5619;
+},
+{
+color = 9;
+glyphname = "gaCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (336,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(592,0,l),
+(592,120,l),
+(298,120,ls),
+(236,120,o),
+(198,148,o),
+(198,208,cs),
+(198,269,o),
+(236,299,o),
+(298,299,cs),
+(592,299,l),
+(592,417,l),
+(297,417,ls),
+(234,417,o),
+(198,446,o),
+(198,507,cs),
+(198,566,o),
+(235,594,o),
+(298,594,cs),
+(592,594,l),
+(592,714,l),
+(269,714,ls),
+(132,714,o),
+(50,640,o),
+(50,513,cs),
+(50,422,o),
+(96,359,o),
+(172,332,c),
+(172,382,l),
+(99,351,o),
+(50,283,o),
+(50,199,cs),
+(50,71,o),
+(129,0,o),
+(269,0,cs)
+);
+}
+);
+width = 645;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|geCarrier-canadian";
+note = uni15F4;
+unicode = 5620;
+},
+{
+color = 9;
+glyphname = "khuCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(322,-14,o),
+(379,30,o),
+(406,122,c),
+(339,122,l),
+(372,28,o),
+(427,-14,o),
+(509,-14,cs),
+(622,-14,o),
+(695,61,o),
+(695,192,cs),
+(695,714,l),
+(50,714,l),
+(50,193,ls),
+(50,62,o),
+(126,-14,o),
+(238,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(212,118,o),
+(191,144,o),
+(191,199,cs),
+(191,587,l),
+(306,587,l),
+(306,199,ls),
+(306,144,o),
+(285,118,o),
+(249,118,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(463,118,o),
+(440,145,o),
+(440,199,cs),
+(440,587,l),
+(554,587,l),
+(554,199,ls),
+(554,144,o),
+(534,118,o),
+(498,118,cs)
+);
+}
+);
+width = 745;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F5;
+unicode = 5621;
+},
+{
+color = 9;
+glyphname = "khoCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(695,0,l),
+(695,521,ls),
+(695,652,o),
+(620,728,o),
+(507,728,cs),
+(424,728,o),
+(368,685,o),
+(339,592,c),
+(406,592,l),
+(374,685,o),
+(319,728,o),
+(236,728,cs),
+(124,728,o),
+(50,654,o),
+(50,522,cs),
+(50,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(191,515,ls),
+(191,570,o),
+(212,596,o),
+(248,596,cs),
+(283,596,o),
+(305,570,o),
+(305,515,cs),
+(305,127,l),
+(191,127,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(440,515,ls),
+(440,570,o),
+(461,596,o),
+(497,596,cs),
+(533,596,o),
+(554,570,o),
+(554,515,cs),
+(554,127,l),
+(440,127,l)
+);
+}
+);
+width = 745;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F6;
+unicode = 5622;
+},
+{
+color = 9;
+glyphname = "kheCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(382,0,ls),
+(522,0,o),
+(601,71,o),
+(601,199,cs),
+(601,283,o),
+(552,351,o),
+(479,381,c),
+(479,332,l),
+(555,359,o),
+(601,422,o),
+(601,513,cs),
+(601,640,o),
+(519,714,o),
+(382,714,cs),
+(53,714,l),
+(53,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,299,l),
+(353,299,ls),
+(415,299,o),
+(453,269,o),
+(453,208,cs),
+(453,148,o),
+(415,118,o),
+(353,118,cs),
+(199,118,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,596,l),
+(353,596,ls),
+(416,596,o),
+(453,566,o),
+(453,507,cs),
+(453,446,o),
+(416,416,o),
+(353,416,cs),
+(199,416,l)
+);
+}
+);
+width = 651;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F7;
+unicode = 5623;
+},
+{
+color = 9;
+glyphname = "kheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(382,0,ls),
+(522,0,o),
+(601,71,o),
+(601,199,cs),
+(601,278,o),
+(558,341,o),
+(492,372,c),
+(492,339,l),
+(560,366,o),
+(601,428,o),
+(601,513,cs),
+(601,640,o),
+(519,714,o),
+(382,714,cs),
+(53,714,l),
+(53,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,300,l),
+(279,300,l),
+(279,218,l),
+(358,218,l),
+(358,335,l),
+(309,300,l),
+(366,300,ls),
+(421,300,o),
+(453,270,o),
+(453,208,cs),
+(453,148,o),
+(415,118,o),
+(353,118,cs),
+(199,118,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(358,497,l),
+(279,497,l),
+(279,416,l),
+(199,416,l),
+(199,596,l),
+(353,596,ls),
+(416,596,o),
+(453,566,o),
+(453,507,cs),
+(453,446,o),
+(423,416,o),
+(366,416,cs),
+(309,416,l),
+(358,380,l)
+);
+}
+);
+width = 651;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F8;
+unicode = 5624;
+},
+{
+color = 9;
+glyphname = "khiCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(382,0,ls),
+(522,0,o),
+(601,71,o),
+(601,199,cs),
+(601,282,o),
+(554,347,o),
+(485,379,c),
+(484,334,l),
+(557,360,o),
+(601,424,o),
+(601,513,cs),
+(601,640,o),
+(519,714,o),
+(382,714,cs),
+(53,714,l),
+(53,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,306,l),
+(236,306,l),
+(253,277,o),
+(283,257,o),
+(318,257,cs),
+(369,257,o),
+(406,299,o),
+(412,348,c),
+(332,306,l),
+(372,306,ls),
+(421,306,o),
+(453,275,o),
+(453,211,cs),
+(453,146,o),
+(415,118,o),
+(353,118,cs),
+(199,118,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(353,596,ls),
+(416,596,o),
+(453,568,o),
+(453,503,cs),
+(453,441,o),
+(423,409,o),
+(373,409,cs),
+(332,409,l),
+(412,366,l),
+(406,417,o),
+(369,457,o),
+(318,457,cs),
+(267,457,o),
+(228,417,o),
+(222,367,c),
+(259,409,l),
+(199,409,l),
+(199,596,l)
+);
+}
+);
+width = 651;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F9;
+unicode = 5625;
+},
+{
+color = 9;
+glyphname = "khaCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(598,0,l),
+(598,714,l),
+(269,714,ls),
+(132,714,o),
+(50,640,o),
+(50,513,cs),
+(50,424,o),
+(93,361,o),
+(167,334,c),
+(166,379,l),
+(97,348,o),
+(50,282,o),
+(50,199,cs),
+(50,71,o),
+(129,0,o),
+(269,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(236,118,o),
+(198,148,o),
+(198,208,cs),
+(198,269,o),
+(236,299,o),
+(298,299,cs),
+(452,299,l),
+(452,118,l),
+(298,118,ls)
+);
+},
+{
+closed = 1;
+nodes = (
+(234,416,o),
+(198,446,o),
+(198,507,cs),
+(198,566,o),
+(235,596,o),
+(298,596,cs),
+(452,596,l),
+(452,416,l),
+(297,416,ls)
+);
+}
+);
+width = 651;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15FA;
+unicode = 5626;
+},
+{
+color = 9;
+glyphname = "kkuCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(322,-14,o),
+(379,31,o),
+(406,123,c),
+(339,123,l),
+(371,29,o),
+(427,-14,o),
+(509,-14,cs),
+(621,-14,o),
+(695,61,o),
+(695,192,cs),
+(695,714,l),
+(653,714,l),
+(417,569,l),
+(417,433,l),
+(591,538,l),
+(555,558,l),
+(555,199,ls),
+(555,144,o),
+(534,118,o),
+(498,118,cs),
+(463,118,o),
+(440,145,o),
+(440,199,cs),
+(440,714,l),
+(306,714,l),
+(306,199,ls),
+(306,144,o),
+(284,118,o),
+(248,118,cs),
+(211,118,o),
+(190,144,o),
+(190,199,cs),
+(190,558,l),
+(155,538,l),
+(324,436,l),
+(324,573,l),
+(92,714,l),
+(50,714,l),
+(50,193,ls),
+(50,62,o),
+(126,-14,o),
+(238,-14,cs)
+);
+}
+);
+width = 745;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FB;
+unicode = 5627;
+},
+{
+color = 9;
+glyphname = "kkoCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(91,0,l),
+(328,145,l),
+(328,281,l),
+(154,176,l),
+(190,156,l),
+(190,515,ls),
+(190,570,o),
+(211,596,o),
+(246,596,cs),
+(281,596,o),
+(305,569,o),
+(305,515,cs),
+(305,0,l),
+(439,0,l),
+(439,515,ls),
+(439,570,o),
+(461,596,o),
+(497,596,cs),
+(533,596,o),
+(555,570,o),
+(555,515,cs),
+(555,156,l),
+(590,176,l),
+(421,278,l),
+(421,141,l),
+(652,0,l),
+(695,0,l),
+(695,521,ls),
+(695,652,o),
+(619,728,o),
+(507,728,cs),
+(423,728,o),
+(366,683,o),
+(338,591,c),
+(406,591,l),
+(373,685,o),
+(318,728,o),
+(236,728,cs),
+(123,728,o),
+(50,653,o),
+(50,522,cs),
+(50,0,l)
+);
+}
+);
+width = 745;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FC;
+unicode = 5628;
+},
+{
+color = 9;
+glyphname = "kkeCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(396,0,ls),
+(536,0,o),
+(614,71,o),
+(614,199,cs),
+(614,282,o),
+(568,347,o),
+(499,379,c),
+(497,334,l),
+(571,360,o),
+(614,424,o),
+(614,513,cs),
+(614,640,o),
+(533,714,o),
+(396,714,cs),
+(50,714,l),
+(50,678,l),
+(132,417,l),
+(61,417,l),
+(61,299,l),
+(133,299,l),
+(50,36,l),
+(50,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(280,299,l),
+(367,299,ls),
+(429,299,o),
+(467,269,o),
+(467,208,cs),
+(467,148,o),
+(429,120,o),
+(366,120,cs),
+(158,120,l),
+(203,57,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(201,657,l),
+(156,594,l),
+(366,594,ls),
+(429,594,o),
+(467,566,o),
+(467,507,cs),
+(467,446,o),
+(430,417,o),
+(367,417,cs),
+(278,417,l)
+);
+}
+);
+width = 664;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni15FD;
+unicode = 5629;
+},
+{
+color = 9;
+glyphname = "kkeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(396,0,ls),
+(536,0,o),
+(614,71,o),
+(614,199,cs),
+(614,282,o),
+(568,347,o),
+(499,379,c),
+(497,334,l),
+(571,360,o),
+(614,424,o),
+(614,513,cs),
+(614,640,o),
+(533,714,o),
+(396,714,cs),
+(50,714,l),
+(50,678,l),
+(132,417,l),
+(61,417,l),
+(61,299,l),
+(133,299,l),
+(50,36,l),
+(50,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(277,303,l),
+(313,303,l),
+(313,220,l),
+(392,220,l),
+(392,329,l),
+(341,303,l),
+(381,303,ls),
+(435,303,o),
+(467,273,o),
+(467,210,cs),
+(467,149,o),
+(429,120,o),
+(366,120,cs),
+(154,120,l),
+(200,57,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(392,495,l),
+(313,495,l),
+(313,413,l),
+(275,413,l),
+(198,657,l),
+(153,594,l),
+(366,594,ls),
+(429,594,o),
+(467,565,o),
+(467,505,cs),
+(467,442,o),
+(436,413,o),
+(381,413,cs),
+(341,413,l),
+(392,393,l)
+);
+}
+);
+width = 664;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FE;
+unicode = 5630;
+},
+{
+color = 9;
+glyphname = "kkiCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(396,0,ls),
+(536,0,o),
+(614,71,o),
+(614,199,cs),
+(614,282,o),
+(568,347,o),
+(499,379,c),
+(497,334,l),
+(571,360,o),
+(614,424,o),
+(614,513,cs),
+(614,640,o),
+(533,714,o),
+(396,714,cs),
+(50,714,l),
+(50,678,l),
+(132,417,l),
+(61,417,l),
+(61,299,l),
+(133,299,l),
+(50,36,l),
+(50,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(279,309,l),
+(269,309,l),
+(282,278,o),
+(312,257,o),
+(349,257,cs),
+(402,257,o),
+(435,302,o),
+(437,341,c),
+(361,309,l),
+(381,309,ls),
+(435,309,o),
+(467,273,o),
+(467,205,cs),
+(467,149,o),
+(429,120,o),
+(366,120,cs),
+(154,120,l),
+(200,57,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(435,415,o),
+(404,457,o),
+(349,457,cs),
+(312,457,o),
+(283,437,o),
+(269,406,c),
+(277,406,l),
+(198,657,l),
+(153,594,l),
+(366,594,ls),
+(429,594,o),
+(467,565,o),
+(467,500,cs),
+(467,442,o),
+(436,406,o),
+(381,406,cs),
+(362,406,l),
+(439,374,l)
+);
+}
+);
+width = 664;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FF;
+unicode = 5631;
+},
+{
+color = 9;
+glyphname = "kkaCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(614,0,l),
+(614,36,l),
+(532,299,l),
+(603,299,l),
+(603,417,l),
+(532,417,l),
+(614,678,l),
+(614,714,l),
+(269,714,ls),
+(132,714,o),
+(50,640,o),
+(50,513,cs),
+(50,424,o),
+(93,361,o),
+(167,334,c),
+(166,379,l),
+(97,348,o),
+(50,282,o),
+(50,199,cs),
+(50,71,o),
+(129,0,o),
+(269,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(507,120,l),
+(298,120,ls),
+(236,120,o),
+(198,148,o),
+(198,208,cs),
+(198,269,o),
+(236,299,o),
+(298,299,cs),
+(385,299,l),
+(462,57,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(234,417,o),
+(198,446,o),
+(198,507,cs),
+(198,566,o),
+(235,594,o),
+(298,594,cs),
+(508,594,l),
+(463,657,l),
+(386,417,l),
+(297,417,ls)
+);
+}
+);
+width = 664;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|kkeCarrier-canadian";
+note = uni1600;
+unicode = 5632;
+},
+{
+color = 6;
+glyphname = "kkCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(186,189,l),
+(325,528,l),
+(325,546,l),
+(229,546,l),
+(141,299,l),
+(210,299,l),
+(121,546,l),
+(25,546,l),
+(25,528,l),
+(164,189,l)
+);
+}
+);
+width = 350;
+}
+);
+note = uni1601;
+unicode = 5633;
+},
+{
+color = 9;
+glyphname = "nuCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(495,-14,o),
+(590,87,o),
+(590,274,cs),
+(590,319,l),
+(444,319,l),
+(444,265,ls),
+(444,167,o),
+(401,121,o),
+(322,121,cs),
+(241,121,o),
+(198,170,o),
+(198,273,cs),
+(198,714,l),
+(50,714,l),
+(50,279,ls),
+(50,87,o),
+(149,-14,o),
+(322,-14,cs)
+);
+}
+);
+width = 630;
+}
+);
+metricLeft = "te-canadian";
+note = uni1602;
+unicode = 5634;
+},
+{
+color = 9;
+glyphname = "noCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(580,0,l),
+(580,435,ls),
+(580,627,o),
+(481,728,o),
+(309,728,cs),
+(135,728,o),
+(40,627,o),
+(40,440,cs),
+(40,395,l),
+(186,395,l),
+(186,449,ls),
+(186,547,o),
+(229,593,o),
+(309,593,cs),
+(390,593,o),
+(433,544,o),
+(433,441,cs),
+(433,0,l)
+);
+}
+);
+width = 630;
+}
+);
+metricLeft = "=|nuCarrier-canadian";
+metricRight = "te-canadian";
+note = uni1603;
+unicode = 5635;
+},
+{
+color = 9;
+glyphname = "neCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (286,357);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(258,0,ls),
+(472,0,o),
+(598,120,o),
+(598,358,cs),
+(598,596,o),
+(473,714,o),
+(254,714,cs),
+(34,714,l),
+(34,580,l),
+(254,580,ls),
+(379,580,o),
+(451,515,o),
+(451,358,cs),
+(451,201,o),
+(377,134,o),
+(258,134,cs),
+(247,134,l),
+(247,0,l)
+);
+}
+);
+width = 643;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1604;
+unicode = 5636;
+},
+{
+color = 9;
+glyphname = "neeCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+ref = "neCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (228,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 643;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1605;
+unicode = 5637;
+},
+{
+color = 9;
+glyphname = "niCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "neCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (199,0);
+ref = dot_middle;
+}
+);
+width = 642;
+}
+);
+note = uni1606;
+unicode = 5638;
+},
+{
+color = 9;
+glyphname = "naCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(609,0,l),
+(609,134,l),
+(389,134,ls),
+(265,134,o),
+(193,199,o),
+(193,356,cs),
+(193,513,o),
+(266,580,o),
+(385,580,cs),
+(396,580,l),
+(396,714,l),
+(385,714,ls),
+(171,714,o),
+(45,594,o),
+(45,356,cs),
+(45,118,o),
+(170,0,o),
+(389,0,cs)
+);
+}
+);
+width = 643;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni1607;
+unicode = 5639;
+},
+{
+color = 9;
+glyphname = "muCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(322,-14,o),
+(378,30,o),
+(406,122,c),
+(339,122,l),
+(372,28,o),
+(427,-14,o),
+(509,-14,cs),
+(621,-14,o),
+(695,61,o),
+(695,192,cs),
+(695,408,l),
+(555,408,l),
+(555,199,ls),
+(555,144,o),
+(535,118,o),
+(499,118,cs),
+(464,118,o),
+(441,145,o),
+(441,199,cs),
+(441,408,l),
+(304,408,l),
+(304,199,ls),
+(304,144,o),
+(283,118,o),
+(248,118,cs),
+(211,118,o),
+(190,144,o),
+(190,199,cs),
+(190,714,l),
+(50,714,l),
+(50,193,ls),
+(50,62,o),
+(126,-14,o),
+(238,-14,cs)
+);
+}
+);
+width = 745;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "=|";
+note = uni1608;
+unicode = 5640;
+},
+{
+color = 9;
+glyphname = "moCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(695,0,l),
+(695,521,ls),
+(695,652,o),
+(619,728,o),
+(507,728,cs),
+(423,728,o),
+(367,684,o),
+(339,592,c),
+(406,592,l),
+(373,686,o),
+(318,728,o),
+(236,728,cs),
+(123,728,o),
+(50,653,o),
+(50,522,cs),
+(50,306,l),
+(190,306,l),
+(190,515,ls),
+(190,570,o),
+(210,596,o),
+(246,596,cs),
+(281,596,o),
+(304,569,o),
+(304,515,cs),
+(304,306,l),
+(441,306,l),
+(441,515,ls),
+(441,570,o),
+(462,596,o),
+(497,596,cs),
+(534,596,o),
+(555,570,o),
+(555,515,cs),
+(555,0,l)
+);
+}
+);
+width = 745;
+}
+);
+metricLeft = "=|muCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni1609;
+unicode = 5641;
+},
+{
+color = 9;
+glyphname = "meCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(379,0,ls),
+(520,0,o),
+(598,71,o),
+(598,199,cs),
+(598,283,o),
+(550,351,o),
+(477,381,c),
+(477,332,l),
+(553,359,o),
+(598,422,o),
+(598,513,cs),
+(598,640,o),
+(517,714,o),
+(379,714,cs),
+(34,714,l),
+(34,594,l),
+(350,594,ls),
+(413,594,o),
+(450,566,o),
+(450,507,cs),
+(450,446,o),
+(414,417,o),
+(351,417,cs),
+(250,417,l),
+(250,299,l),
+(350,299,ls),
+(412,299,o),
+(450,269,o),
+(450,208,cs),
+(450,148,o),
+(413,120,o),
+(350,120,cs),
+(250,120,l),
+(250,0,l)
+);
+}
+);
+width = 648;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160A;
+unicode = 5642;
+},
+{
+color = 9;
+glyphname = "meeCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(379,0,ls),
+(520,0,o),
+(598,71,o),
+(598,199,cs),
+(598,282,o),
+(552,347,o),
+(483,379,c),
+(481,334,l),
+(555,360,o),
+(598,424,o),
+(598,513,cs),
+(598,640,o),
+(517,714,o),
+(379,714,cs),
+(34,714,l),
+(34,594,l),
+(350,594,ls),
+(413,594,o),
+(450,565,o),
+(450,505,cs),
+(450,444,o),
+(418,414,o),
+(362,414,cs),
+(336,414,l),
+(336,489,l),
+(250,489,l),
+(250,225,l),
+(336,225,l),
+(336,302,l),
+(360,302,ls),
+(418,302,o),
+(450,272,o),
+(450,209,cs),
+(450,149,o),
+(413,120,o),
+(350,120,cs),
+(250,120,l),
+(250,0,l)
+);
+}
+);
+width = 648;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160B;
+unicode = 5643;
+},
+{
+color = 9;
+glyphname = "miCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(379,0,ls),
+(520,0,o),
+(598,71,o),
+(598,199,cs),
+(598,282,o),
+(552,347,o),
+(483,379,c),
+(481,334,l),
+(555,360,o),
+(598,424,o),
+(598,513,cs),
+(598,640,o),
+(517,714,o),
+(379,714,cs),
+(34,714,l),
+(34,594,l),
+(350,594,ls),
+(413,594,o),
+(450,565,o),
+(450,505,cs),
+(450,444,o),
+(418,414,o),
+(369,414,cs),
+(313,414,l),
+(395,374,l),
+(388,421,o),
+(350,457,o),
+(299,457,cs),
+(243,457,o),
+(201,413,o),
+(201,358,cs),
+(201,301,o),
+(243,257,o),
+(299,257,cs),
+(349,257,o),
+(387,296,o),
+(393,341,c),
+(312,302,l),
+(368,302,ls),
+(418,302,o),
+(450,272,o),
+(450,209,cs),
+(450,149,o),
+(413,120,o),
+(350,120,cs),
+(250,120,l),
+(250,0,l)
+);
+}
+);
+width = 648;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160C;
+unicode = 5644;
+},
+{
+color = 9;
+glyphname = "maCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(614.005,0,l),
+(614,120,l),
+(298,120,ls),
+(235,120,o),
+(198,148,o),
+(198,207,cs),
+(198,268,o),
+(235,297,o),
+(297,297,cs),
+(398,297,l),
+(398,416,l),
+(298,416,ls),
+(236,416,o),
+(198,445,o),
+(198,506,cs),
+(198,565,o),
+(236,594,o),
+(298,594,cs),
+(398,594,l),
+(398,714,l),
+(269,714,ls),
+(129,714,o),
+(50,643,o),
+(50,514,cs),
+(50,429,o),
+(98,362,o),
+(172,333,c),
+(172,382,l),
+(96,354,o),
+(50,290,o),
+(50,200,cs),
+(50,73,o),
+(131,0,o),
+(269,0,cs)
+);
+}
+);
+width = 648;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni160D;
+unicode = 5645;
+},
+{
+color = 9;
+glyphname = "yuCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(529,-14,o),
+(640,130,o),
+(640,396,cs),
+(640,630,o),
+(561,728,o),
+(442,728,cs),
+(334,728,o),
+(266,645,o),
+(266,509,cs),
+(266,379,o),
+(334,303,o),
+(427,303,cs),
+(439,303,o),
+(452,305,o),
+(463,309,c),
+(463,422,l),
+(458,421,o),
+(453,420,o),
+(444,420,cs),
+(411,420,o),
+(390,448,o),
+(390,516,cs),
+(390,582,o),
+(407,611,o),
+(438,611,cs),
+(477,611,o),
+(500,570,o),
+(500,401,cs),
+(500,191,o),
+(439,121,o),
+(336,121,cs),
+(249,121,o),
+(198,174,o),
+(198,285,cs),
+(198,714,l),
+(50,714,l),
+(50,289,ls),
+(50,89,o),
+(161,-14,o),
+(331,-14,cs)
+);
+}
+);
+width = 690;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160E;
+unicode = 5646;
+},
+{
+color = 9;
+glyphname = "yoCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(356,-14,o),
+(424,69,o),
+(424,205,cs),
+(424,335,o),
+(357,411,o),
+(263,411,cs),
+(251,411,o),
+(238,409,o),
+(228,405,c),
+(228,292,l),
+(233,293,o),
+(238,294,o),
+(246,294,cs),
+(279,294,o),
+(301,266,o),
+(301,198,cs),
+(301,132,o),
+(283,103,o),
+(252,103,cs),
+(214,103,o),
+(190,144,o),
+(190,313,cs),
+(190,523,o),
+(251,593,o),
+(355,593,cs),
+(442,593,o),
+(493,540,o),
+(493,429,cs),
+(493,0,l),
+(640,0,l),
+(640,425,ls),
+(640,625,o),
+(530,728,o),
+(360,728,cs),
+(162,728,o),
+(50,584,o),
+(50,318,cs),
+(50,84,o),
+(129,-14,o),
+(249,-14,cs)
+);
+}
+);
+width = 690;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160F;
+unicode = 5647;
+},
+{
+color = 9;
+glyphname = "yeCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(474,-14,o),
+(590,126,o),
+(590,347,cs),
+(590,597,o),
+(464,714,o),
+(234,714,cs),
+(48,714,l),
+(48,580,l),
+(237,580,ls),
+(371,580,o),
+(442,515,o),
+(442,343,cs),
+(442,193,o),
+(398,110,o),
+(286,110,cs),
+(199,110,o),
+(161,157,o),
+(161,229,cs),
+(161,290,o),
+(180,317,o),
+(210,317,cs),
+(241,317,o),
+(259,289,o),
+(259,230,cs),
+(259,210,o),
+(258,197,o),
+(257,185,c),
+(366,185,l),
+(370,202,o),
+(372,219,o),
+(372,241,cs),
+(372,352,o),
+(317,434,o),
+(210,434,cs),
+(102,434,o),
+(37,349,o),
+(37,227,cs),
+(37,91,o),
+(124,-14,o),
+(286,-14,cs)
+);
+}
+);
+width = 635;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1610;
+unicode = 5648;
+},
+{
+color = 9;
+glyphname = "yeeCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(474,-14,o),
+(590,126,o),
+(590,347,cs),
+(590,597,o),
+(464,714,o),
+(234,714,cs),
+(48,714,l),
+(48,580,l),
+(237,580,ls),
+(371,580,o),
+(442,515,o),
+(442,343,cs),
+(442,193,o),
+(398,110,o),
+(286,110,cs),
+(199,110,o),
+(161,157,o),
+(161,230,cs),
+(161,288,o),
+(180,317,o),
+(208,317,cs),
+(237,317,o),
+(255,288,o),
+(255,235,cs),
+(255,194,l),
+(326,194,l),
+(326,505,l),
+(255,505,l),
+(255,326,l),
+(269,326,l),
+(267,393,o),
+(234,434,o),
+(175,434,cs),
+(97,434,o),
+(37,356,o),
+(37,228,cs),
+(37,91,o),
+(124,-14,o),
+(285,-14,cs)
+);
+}
+);
+width = 635;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1611;
+unicode = 5649;
+},
+{
+color = 9;
+glyphname = "yiCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(474,-14,o),
+(590,126,o),
+(590,347,cs),
+(590,597,o),
+(464,714,o),
+(234,714,cs),
+(48,714,l),
+(48,580,l),
+(237,580,ls),
+(371,580,o),
+(442,515,o),
+(442,343,cs),
+(442,193,o),
+(398,110,o),
+(292,110,cs),
+(202,110,o),
+(161,159,o),
+(161,229,cs),
+(161,290,o),
+(184,316,o),
+(221,317,c),
+(177,341,l),
+(184,302,o),
+(221,269,o),
+(268,269,cs),
+(321,269,o),
+(359,309,o),
+(359,358,cs),
+(359,408,o),
+(321,446,o),
+(268,446,cs),
+(235,446,o),
+(207,430,o),
+(191,407,c),
+(97,397,o),
+(37,326,o),
+(37,215,cs),
+(37,90,o),
+(124,-14,o),
+(286,-14,cs)
+);
+}
+);
+width = 635;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1612;
+unicode = 5650;
+},
+{
+color = 9;
+glyphname = "yaCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(587,0,l),
+(587,134,l),
+(398,134,ls),
+(264,134,o),
+(193,199,o),
+(193,371,cs),
+(193,521,o),
+(237,604,o),
+(351,604,cs),
+(436,604,o),
+(474,557,o),
+(474,485,cs),
+(474,424,o),
+(455,397,o),
+(425,397,cs),
+(394,397,o),
+(376,425,o),
+(376,484,cs),
+(376,504,o),
+(377,517,o),
+(378,529,c),
+(269,529,l),
+(265,512,o),
+(263,495,o),
+(263,473,cs),
+(263,362,o),
+(318,280,o),
+(425,280,cs),
+(533,280,o),
+(598,365,o),
+(598,487,cs),
+(598,623,o),
+(511,728,o),
+(351,728,cs),
+(161,728,o),
+(45,588,o),
+(45,367,cs),
+(45,117,o),
+(171,0,o),
+(401,0,cs)
+);
+}
+);
+width = 635;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|yeCarrier-canadian";
+note = uni1613;
+unicode = 5651;
+},
+{
+color = 9;
+glyphname = "juCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(517,-14,o),
+(605,90,o),
+(605,228,cs),
+(605,349,o),
+(540,434,o),
+(433,434,cs),
+(325,434,o),
+(270,352,o),
+(270,241,cs),
+(270,219,o),
+(272,202,o),
+(276,185,c),
+(386,185,l),
+(385,197,o),
+(383,212,o),
+(383,230,cs),
+(383,288,o),
+(401,317,o),
+(432,317,cs),
+(462,317,o),
+(481,288,o),
+(481,230,cs),
+(481,156,o),
+(443,110,o),
+(355,110,cs),
+(245,110,o),
+(196,181,o),
+(196,306,cs),
+(196,514,o),
+(312,580,o),
+(489,580,cs),
+(594,580,l),
+(594,714,l),
+(42,714,l),
+(42,585,l),
+(275,585,l),
+(386,639,l),
+(178,639,o),
+(50,519,o),
+(50,301,cs),
+(50,113,o),
+(162,-14,o),
+(347,-14,cs)
+);
+}
+);
+width = 642;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni1614;
+unicode = 5652;
+},
+{
+color = 9;
+glyphname = "juSayisi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (323,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(480,-14,o),
+(592,113,o),
+(592,301,cs),
+(592,519,o),
+(464,639,o),
+(257,639,c),
+(367,585,l),
+(600,585,l),
+(600,714,l),
+(48,714,l),
+(48,580,l),
+(153,580,ls),
+(330,580,o),
+(446,514,o),
+(446,306,cs),
+(446,181,o),
+(397,110,o),
+(287,110,cs),
+(199,110,o),
+(161,156,o),
+(161,230,cs),
+(161,288,o),
+(180,317,o),
+(210,317,cs),
+(241,317,o),
+(259,288,o),
+(259,230,cs),
+(259,212,o),
+(258,197,o),
+(257,185,c),
+(366,185,l),
+(370,202,o),
+(372,219,o),
+(372,241,cs),
+(372,352,o),
+(317,434,o),
+(210,434,cs),
+(102,434,o),
+(37,349,o),
+(37,228,cs),
+(37,90,o),
+(125,-14,o),
+(295,-14,cs)
+);
+}
+);
+width = 642;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1615;
+unicode = 5653;
+},
+{
+color = 9;
+glyphname = "joCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(600,0,l),
+(600,129,l),
+(367,129,l),
+(257,75,l),
+(464,75,o),
+(592,195,o),
+(592,413,cs),
+(592,601,o),
+(480,728,o),
+(295,728,cs),
+(125,728,o),
+(37,624,o),
+(37,486,cs),
+(37,365,o),
+(102,280,o),
+(210,280,cs),
+(317,280,o),
+(372,362,o),
+(372,473,cs),
+(372,495,o),
+(370,512,o),
+(366,529,c),
+(257,529,l),
+(258,517,o),
+(259,502,o),
+(259,484,cs),
+(259,426,o),
+(241,397,o),
+(210,397,cs),
+(180,397,o),
+(161,426,o),
+(161,484,cs),
+(161,558,o),
+(199,604,o),
+(287,604,cs),
+(397,604,o),
+(446,533,o),
+(446,408,cs),
+(446,200,o),
+(330,134,o),
+(153,134,cs),
+(48,134,l),
+(48,0,l)
+);
+}
+);
+width = 642;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1616;
+unicode = 5654;
+},
+{
+color = 9;
+glyphname = "jeCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(564,-14,o),
+(643,84,o),
+(643,318,cs),
+(643,585,o),
+(532,728,o),
+(381,728,cs),
+(257,728,o),
+(181,640,o),
+(172,466,c),
+(199,470,l),
+(199,714,l),
+(53,714,l),
+(53,0,l),
+(200,0,l),
+(200,294,ls),
+(200,521,o),
+(263,593,o),
+(355,593,cs),
+(442,593,o),
+(503,513,o),
+(503,315,cs),
+(503,144,o),
+(479,103,o),
+(441,103,cs),
+(411,103,o),
+(392,132,o),
+(392,198,cs),
+(392,266,o),
+(414,294,o),
+(448,294,cs),
+(455,294,o),
+(460,293,o),
+(465,292,c),
+(465,405,l),
+(455,409,o),
+(442,411,o),
+(430,411,cs),
+(337,411,o),
+(269,335,o),
+(269,205,cs),
+(269,69,o),
+(337,-14,o),
+(444,-14,cs)
+);
+}
+);
+width = 693;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "te-canadian";
+note = uni1617;
+unicode = 5655;
+},
+{
+color = 9;
+glyphname = "jeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(563,-14,o),
+(643,85,o),
+(643,318,cs),
+(643,585,o),
+(532,728,o),
+(381,728,cs),
+(278,728,o),
+(208,669,o),
+(181,551,c),
+(199,534,l),
+(199,714,l),
+(53,714,l),
+(53,0,l),
+(200,0,l),
+(200,294,ls),
+(200,521,o),
+(263,593,o),
+(355,593,cs),
+(442,593,o),
+(503,513,o),
+(503,315,cs),
+(503,154,o),
+(473,103,o),
+(415,103,cs),
+(366,103,o),
+(336,143,o),
+(336,211,cs),
+(336,262,o),
+(349,297,o),
+(373,314,c),
+(373,238,l),
+(442,238,l),
+(442,465,l),
+(373,465,l),
+(373,388,l),
+(314,366,o),
+(269,301,o),
+(269,198,cs),
+(269,67,o),
+(335,-14,o),
+(443,-14,cs)
+);
+}
+);
+width = 693;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1618;
+unicode = 5656;
+},
+{
+color = 9;
+glyphname = "jiCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(563,-14,o),
+(643,85,o),
+(643,318,cs),
+(643,585,o),
+(532,728,o),
+(381,728,cs),
+(278,728,o),
+(208,669,o),
+(181,551,c),
+(199,534,l),
+(199,714,l),
+(53,714,l),
+(53,0,l),
+(200,0,l),
+(200,294,ls),
+(200,521,o),
+(263,593,o),
+(355,593,cs),
+(442,593,o),
+(503,513,o),
+(503,315,cs),
+(503,154,o),
+(473,103,o),
+(415,103,cs),
+(366,103,o),
+(336,143,o),
+(336,211,cs),
+(336,241,o),
+(342,261,o),
+(352,274,c),
+(360,268,o),
+(371,264,o),
+(383,264,cs),
+(430,264,o),
+(464,303,o),
+(464,352,cs),
+(464,401,o),
+(430,439,o),
+(383,439,cs),
+(318,439,o),
+(289,374,o),
+(305,325,c),
+(283,296,o),
+(269,254,o),
+(269,198,cs),
+(269,67,o),
+(335,-14,o),
+(443,-14,cs)
+);
+}
+);
+width = 693;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1619;
+unicode = 5657;
+},
+{
+color = 9;
+glyphname = "jiSayisi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(532,-14,o),
+(643,129,o),
+(643,396,cs),
+(643,630,o),
+(564,728,o),
+(444,728,cs),
+(337,728,o),
+(269,645,o),
+(269,509,cs),
+(269,379,o),
+(337,303,o),
+(430,303,cs),
+(442,303,o),
+(455,305,o),
+(465,309,c),
+(465,422,l),
+(460,421,o),
+(455,420,o),
+(448,420,cs),
+(414,420,o),
+(392,448,o),
+(392,516,cs),
+(392,582,o),
+(410,611,o),
+(441,611,cs),
+(479,611,o),
+(503,570,o),
+(503,399,cs),
+(503,201,o),
+(442,121,o),
+(355,121,cs),
+(263,121,o),
+(200,193,o),
+(200,420,cs),
+(200,714,l),
+(53,714,l),
+(53,0,l),
+(199,0,l),
+(199,244,l),
+(172,248,l),
+(181,74,o),
+(257,-14,o),
+(381,-14,cs)
+);
+}
+);
+width = 693;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161A;
+unicode = 5658;
+},
+{
+color = 9;
+glyphname = "jaCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (339,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(436,-14,o),
+(512,74,o),
+(522,248,c),
+(494,244,l),
+(494,0,l),
+(640,0,l),
+(640,714,l),
+(493,714,l),
+(493,420,ls),
+(493,193,o),
+(430,121,o),
+(338,121,cs),
+(251,121,o),
+(190,201,o),
+(190,399,cs),
+(190,570,o),
+(214,611,o),
+(252,611,cs),
+(283,611,o),
+(301,582,o),
+(301,516,cs),
+(301,448,o),
+(279,420,o),
+(245,420,cs),
+(238,420,o),
+(233,421,o),
+(228,422,c),
+(228,309,l),
+(238,305,o),
+(251,303,o),
+(263,303,cs),
+(357,303,o),
+(424,379,o),
+(424,509,cs),
+(424,645,o),
+(356,728,o),
+(249,728,cs),
+(129,728,o),
+(50,630,o),
+(50,396,cs),
+(50,129,o),
+(161,-14,o),
+(312,-14,cs)
+);
+}
+);
+width = 693;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni161B;
+unicode = 5659;
+},
+{
+color = 9;
+glyphname = "jjuCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(514,-14,o),
+(601,91,o),
+(601,227,cs),
+(601,349,o),
+(536,434,o),
+(429,434,cs),
+(321,434,o),
+(265,352,o),
+(265,241,cs),
+(265,220,o),
+(267,202,o),
+(271,185,c),
+(381,185,l),
+(380,197,o),
+(379,213,o),
+(379,230,cs),
+(379,287,o),
+(397,317,o),
+(427,317,cs),
+(457,317,o),
+(476,287,o),
+(476,229,cs),
+(476,155,o),
+(437,107,o),
+(352,107,cs),
+(242,107,o),
+(195,179,o),
+(195,312,cs),
+(195,503,o),
+(301,580,o),
+(471,580,cs),
+(590,580,l),
+(590,714,l),
+(459,714,ls),
+(352,714,o),
+(262,686,o),
+(195,635,c),
+(104,728,l),
+(7,635,l),
+(105,537,l),
+(68,477,o),
+(49,403,o),
+(49,318,cs),
+(49,115,o),
+(164,-14,o),
+(346,-14,cs)
+);
+}
+);
+width = 638;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni161C;
+unicode = 5660;
+},
+{
+color = 9;
+glyphname = "jjoCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(631,79,l),
+(534,177,l),
+(570,237,o),
+(589,311,o),
+(589,396,cs),
+(589,599,o),
+(475,728,o),
+(293,728,cs),
+(126,728,o),
+(37,623,o),
+(37,487,cs),
+(37,365,o),
+(102,280,o),
+(210,280,cs),
+(318,280,o),
+(373,362,o),
+(373,473,cs),
+(373,494,o),
+(371,512,o),
+(367,529,c),
+(257,529,l),
+(258,517,o),
+(260,501,o),
+(260,484,cs),
+(260,427,o),
+(241,397,o),
+(211,397,cs),
+(181,397,o),
+(162,427,o),
+(162,485,cs),
+(162,559,o),
+(200,607,o),
+(287,607,cs),
+(396,607,o),
+(444,535,o),
+(444,402,cs),
+(444,211,o),
+(337,134,o),
+(167,134,cs),
+(48,134,l),
+(48,0,l),
+(179,0,ls),
+(287,0,o),
+(376,28,o),
+(443,79,c),
+(535,-14,l)
+);
+}
+);
+width = 638;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|jjuCarrier-canadian";
+note = uni161D;
+unicode = 5661;
+},
+{
+color = 9;
+glyphname = "jjeCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(573,-14,o),
+(651,84,o),
+(651,318,cs),
+(651,584,o),
+(548,728,o),
+(358,728,cs),
+(284,728,o),
+(218,704,o),
+(168,657,c),
+(90,728,l),
+(1,628,l),
+(93,545,l),
+(73,496,o),
+(62,437,o),
+(62,367,cs),
+(62,0,l),
+(209,0,l),
+(209,372,ls),
+(209,521,o),
+(260,593,o),
+(355,593,cs),
+(451,593,o),
+(512,523,o),
+(512,313,cs),
+(512,144,o),
+(488,103,o),
+(450,103,cs),
+(419,103,o),
+(401,132,o),
+(401,198,cs),
+(401,266,o),
+(423,294,o),
+(456,294,cs),
+(464,294,o),
+(469,293,o),
+(474,292,c),
+(474,405,l),
+(464,409,o),
+(451,411,o),
+(438,411,cs),
+(345,411,o),
+(277,335,o),
+(277,205,cs),
+(277,69,o),
+(345,-14,o),
+(453,-14,cs)
+);
+}
+);
+width = 701;
+}
+);
+metricRight = "jeCarrier-canadian";
+note = uni161E;
+unicode = 5662;
+},
+{
+color = 9;
+glyphname = "jjeeCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(571,-14,o),
+(651,85,o),
+(651,318,cs),
+(651,584,o),
+(548,728,o),
+(358,728,cs),
+(284,728,o),
+(218,704,o),
+(168,657,c),
+(90,728,l),
+(1,628,l),
+(93,545,l),
+(73,496,o),
+(62,437,o),
+(62,367,cs),
+(62,0,l),
+(209,0,l),
+(209,372,ls),
+(209,521,o),
+(260,593,o),
+(354,593,cs),
+(451,593,o),
+(512,523,o),
+(512,313,cs),
+(512,154,o),
+(482,103,o),
+(424,103,cs),
+(375,103,o),
+(345,143,o),
+(345,211,cs),
+(345,263,o),
+(358,296,o),
+(381,313,c),
+(381,238,l),
+(450,238,l),
+(450,464,l),
+(381,464,l),
+(381,388,l),
+(323,367,o),
+(277,300,o),
+(277,198,cs),
+(277,67,o),
+(344,-14,o),
+(452,-14,cs)
+);
+}
+);
+width = 701;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161F;
+unicode = 5663;
+},
+{
+color = 9;
+glyphname = "jjiCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(571,-14,o),
+(651,85,o),
+(651,318,cs),
+(651,584,o),
+(548,728,o),
+(358,728,cs),
+(284,728,o),
+(218,704,o),
+(168,657,c),
+(90,728,l),
+(1,628,l),
+(93,545,l),
+(73,496,o),
+(62,437,o),
+(62,367,cs),
+(62,0,l),
+(209,0,l),
+(209,372,ls),
+(209,521,o),
+(260,593,o),
+(354,593,cs),
+(451,593,o),
+(512,523,o),
+(512,313,cs),
+(512,154,o),
+(482,103,o),
+(424,103,cs),
+(375,103,o),
+(345,143,o),
+(345,211,cs),
+(345,242,o),
+(351,262,o),
+(361,275,c),
+(370,268,o),
+(382,264,o),
+(394,264,cs),
+(442,264,o),
+(476,303,o),
+(476,352,cs),
+(476,401,o),
+(442,439,o),
+(394,439,cs),
+(334,439,o),
+(302,378,o),
+(316,328,c),
+(293,299,o),
+(277,256,o),
+(277,198,cs),
+(277,67,o),
+(344,-14,o),
+(452,-14,cs)
+);
+}
+);
+width = 701;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1620;
+unicode = 5664;
+},
+{
+color = 9;
+glyphname = "jjaCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(418,-14,o),
+(483,10,o),
+(533,57,c),
+(612,-14,l),
+(701,86,l),
+(609,169,l),
+(629,218,o),
+(640,277,o),
+(640,347,cs),
+(640,714,l),
+(493,714,l),
+(493,342,ls),
+(493,193,o),
+(442,121,o),
+(347,121,cs),
+(251,121,o),
+(190,191,o),
+(190,401,cs),
+(190,570,o),
+(214,611,o),
+(252,611,cs),
+(283,611,o),
+(301,582,o),
+(301,516,cs),
+(301,448,o),
+(279,420,o),
+(246,420,cs),
+(238,420,o),
+(233,421,o),
+(228,422,c),
+(228,309,l),
+(238,305,o),
+(251,303,o),
+(263,303,cs),
+(357,303,o),
+(424,379,o),
+(424,509,cs),
+(424,645,o),
+(356,728,o),
+(249,728,cs),
+(129,728,o),
+(50,630,o),
+(50,396,cs),
+(50,130,o),
+(154,-14,o),
+(344,-14,cs)
+);
+}
+);
+width = 702;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "=|jjeCarrier-canadian";
+note = uni1621;
+unicode = 5665;
+},
+{
+color = 9;
+glyphname = "luCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(495,-14,o),
+(592,86,o),
+(592,281,cs),
+(592,714,l),
+(445,714,l),
+(445,283,ls),
+(445,170,o),
+(400,121,o),
+(330,121,cs),
+(241,121,o),
+(200,190,o),
+(200,330,cs),
+(200,480,o),
+(241,575,o),
+(341,597,c),
+(341,714,l),
+(45,714,l),
+(45,593,l),
+(203,593,l),
+(304,639,l),
+(140,618,o),
+(52,517,o),
+(52,308,cs),
+(52,107,o),
+(148,-14,o),
+(325,-14,cs)
+);
+}
+);
+width = 642;
+}
+);
+metricRight = "te-canadian";
+note = uni1622;
+unicode = 5666;
+},
+{
+color = 9;
+glyphname = "loCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(198,0,l),
+(198,431,ls),
+(198,544,o),
+(242,593,o),
+(314,593,cs),
+(402,593,o),
+(443,524,o),
+(443,384,cs),
+(443,234,o),
+(402,139,o),
+(302,117,c),
+(302,0,l),
+(598,0,l),
+(598,121,l),
+(440,121,l),
+(339,75,l),
+(502,96,o),
+(590,197,o),
+(590,406,cs),
+(590,607,o),
+(495,728,o),
+(318,728,cs),
+(147,728,o),
+(50,628,o),
+(50,433,cs),
+(50,0,l)
+);
+}
+);
+width = 643;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|luCarrier-canadian";
+note = uni1623;
+unicode = 5667;
+},
+{
+color = 9;
+glyphname = "leCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (308,358);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(248,0,ls),
+(467,0,o),
+(592,120,o),
+(592,369,cs),
+(592,619,o),
+(471,728,o),
+(352,728,cs),
+(249,728,o),
+(189,660,o),
+(169,567,c),
+(182,573,l),
+(182,714,l),
+(50,714,l),
+(50,389,l),
+(175,389,l),
+(178,529,o),
+(236,593,o),
+(310,593,cs),
+(382,593,o),
+(444,535,o),
+(444,367,cs),
+(444,201,o),
+(379,134,o),
+(249,134,cs),
+(50,134,l),
+(50,0,l)
+);
+}
+);
+width = 637;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1624;
+unicode = 5668;
+},
+{
+color = 9;
+glyphname = "leeCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+ref = "leCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (250,1);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 637;
+}
+);
+metricLeft = "leCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1625;
+unicode = 5669;
+},
+{
+color = 9;
+glyphname = "liCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "leCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (222,1);
+ref = dot_middle;
+}
+);
+width = 636;
+}
+);
+note = uni1626;
+unicode = 5670;
+},
+{
+color = 9;
+glyphname = "laCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(587,0,l),
+(587,134,l),
+(388,134,ls),
+(258,134,o),
+(193,201,o),
+(193,367,cs),
+(193,535,o),
+(255,593,o),
+(327,593,cs),
+(401,593,o),
+(459,529,o),
+(462,389,c),
+(587,389,l),
+(587,714,l),
+(455,714,l),
+(455,573,l),
+(468,567,l),
+(448,660,o),
+(388,728,o),
+(285,728,cs),
+(166,728,o),
+(45,619,o),
+(45,369,cs),
+(45,120,o),
+(170,0,o),
+(389,0,cs)
+);
+}
+);
+width = 637;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|leCarrier-canadian";
+note = uni1627;
+unicode = 5671;
+},
+{
+color = 1;
+glyphname = "dluCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(495,-14,o),
+(590,107,o),
+(590,308,cs),
+(590,483,o),
+(530,582,o),
+(418,620,c),
+(389,603,l),
+(576,603,l),
+(576,522,l),
+(682,522,l),
+(682,794,l),
+(576,794,l),
+(576,714,l),
+(302,714,l),
+(302,596,l),
+(402,575,o),
+(443,480,o),
+(443,330,cs),
+(443,190,o),
+(402,121,o),
+(316,121,cs),
+(242,121,o),
+(198,170,o),
+(198,283,cs),
+(198,714,l),
+(50,714,l),
+(50,281,ls),
+(50,86,o),
+(147,-14,o),
+(318,-14,cs)
+);
+}
+);
+width = 708;
+}
+);
+metricLeft = "te-canadian";
+note = uni1628;
+unicode = 5672;
+},
+{
+color = 9;
+glyphname = "dloCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(682,-80,l),
+(682,192,l),
+(576,192,l),
+(576,111,l),
+(389,111,l),
+(418,94,l),
+(530,132,o),
+(590,231,o),
+(590,406,cs),
+(590,607,o),
+(495,728,o),
+(319,728,cs),
+(146,728,o),
+(50,628,o),
+(50,433,cs),
+(50,0,l),
+(198,0,l),
+(198,431,ls),
+(198,544,o),
+(242,593,o),
+(316,593,cs),
+(402,593,o),
+(443,524,o),
+(443,384,cs),
+(443,234,o),
+(402,139,o),
+(302,118,c),
+(302,0,l),
+(576,0,l),
+(576,-80,l)
+);
+}
+);
+width = 708;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "dluCarrier-canadian";
+note = uni1629;
+unicode = 5673;
+},
+{
+color = 9;
+glyphname = "dleCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (325,358);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(265,0,ls),
+(483,0,o),
+(608,120,o),
+(608,369,cs),
+(608,619,o),
+(487,728,o),
+(368,728,cs),
+(269,728,o),
+(185,665,o),
+(156,521,c),
+(173,513,l),
+(173,721,l),
+(240,721,l),
+(240,824,l),
+(-1,824,l),
+(-1,721,l),
+(67,721,l),
+(67,389,l),
+(192,389,l),
+(195,529,o),
+(253,593,o),
+(326,593,cs),
+(398,593,o),
+(461,535,o),
+(461,367,cs),
+(461,201,o),
+(395,134,o),
+(265,134,cs),
+(67,134,l),
+(67,0,l)
+);
+}
+);
+width = 653;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni162A;
+unicode = 5674;
+},
+{
+color = 9;
+glyphname = "dleeCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (266,1);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 652;
+}
+);
+note = uni162B;
+unicode = 5675;
+},
+{
+color = 9;
+glyphname = "dliCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (238,1);
+ref = dot_middle;
+}
+);
+width = 652;
+}
+);
+note = uni162C;
+unicode = 5676;
+},
+{
+color = 9;
+glyphname = "dlaCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(587,0,l),
+(587,134,l),
+(388,134,ls),
+(258,134,o),
+(193,201,o),
+(193,367,cs),
+(193,535,o),
+(256,593,o),
+(327,593,cs),
+(400,593,o),
+(459,529,o),
+(462,389,c),
+(587,389,l),
+(587,721,l),
+(654,721,l),
+(654,824,l),
+(413,824,l),
+(413,721,l),
+(480,721,l),
+(480,513,l),
+(497,521,l),
+(469,665,o),
+(384,728,o),
+(285,728,cs),
+(166,728,o),
+(45,619,o),
+(45,369,cs),
+(45,120,o),
+(170,0,o),
+(389,0,cs)
+);
+}
+);
+width = 653;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni162D;
+unicode = 5677;
+},
+{
+color = 9;
+glyphname = "lhuCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(504,-14,o),
+(601,111,o),
+(601,305,cs),
+(601,510,o),
+(513,617,o),
+(385,639,c),
+(451,592,l),
+(609,592,l),
+(609,714,l),
+(374,714,l),
+(374,597,l),
+(424,551,o),
+(454,462,o),
+(454,336,cs),
+(454,185,o),
+(411,121,o),
+(327,121,cs),
+(243,121,o),
+(200,185,o),
+(200,336,cs),
+(200,462,o),
+(230,551,o),
+(280,597,c),
+(280,714,l),
+(45,714,l),
+(45,592,l),
+(202,592,l),
+(269,639,l),
+(141,617,o),
+(53,510,o),
+(53,305,cs),
+(53,111,o),
+(150,-14,o),
+(327,-14,cs)
+);
+}
+);
+width = 654;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162E;
+unicode = 5678;
+},
+{
+color = 9;
+glyphname = "lhoCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(280,0,l),
+(280,117,l),
+(230,163,o),
+(200,252,o),
+(200,378,cs),
+(200,529,o),
+(242,593,o),
+(327,593,cs),
+(411,593,o),
+(453,529,o),
+(453,378,cs),
+(453,252,o),
+(424,163,o),
+(374,117,c),
+(374,0,l),
+(609,0,l),
+(609,122,l),
+(451,122,l),
+(385,75,l),
+(513,97,o),
+(601,204,o),
+(601,409,cs),
+(601,603,o),
+(504,728,o),
+(327,728,cs),
+(149,728,o),
+(53,603,o),
+(53,409,cs),
+(53,204,o),
+(141,97,o),
+(269,75,c),
+(203,122,l),
+(45,122,l),
+(45,0,l)
+);
+}
+);
+width = 654;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162F;
+unicode = 5679;
+},
+{
+color = 9;
+glyphname = "lheCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (320,357);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(486,-14,o),
+(609,95,o),
+(609,357,cs),
+(609,619,o),
+(486,728,o),
+(364,728,cs),
+(260,728,o),
+(198,662,o),
+(178,572,c),
+(185,572,l),
+(185,714,l),
+(53,714,l),
+(53,424,l),
+(178,424,l),
+(194,519,o),
+(237,593,o),
+(323,593,cs),
+(396,593,o),
+(462,536,o),
+(462,357,cs),
+(462,178,o),
+(396,121,o),
+(323,121,cs),
+(237,121,o),
+(194,195,o),
+(178,290,c),
+(53,290,l),
+(53,0,l),
+(185,0,l),
+(185,142,l),
+(178,142,l),
+(198,52,o),
+(260,-14,o),
+(364,-14,cs)
+);
+}
+);
+width = 654;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1630;
+unicode = 5680;
+},
+{
+color = 9;
+glyphname = "lheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (262,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 654;
+}
+);
+note = uni1631;
+unicode = 5681;
+},
+{
+color = 9;
+glyphname = "lhiCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (234,0);
+ref = dot_middle;
+}
+);
+width = 654;
+}
+);
+note = uni1632;
+unicode = 5682;
+},
+{
+color = 9;
+glyphname = "lhaCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(395,-14,o),
+(456,52,o),
+(476,142,c),
+(470,142,l),
+(470,0,l),
+(602,0,l),
+(602,290,l),
+(477,290,l),
+(460,195,o),
+(418,121,o),
+(332,121,cs),
+(259,121,o),
+(193,178,o),
+(193,357,cs),
+(193,536,o),
+(258,593,o),
+(332,593,cs),
+(418,593,o),
+(460,519,o),
+(477,424,c),
+(602,424,l),
+(602,714,l),
+(470,714,l),
+(470,572,l),
+(476,572,l),
+(456,662,o),
+(395,728,o),
+(290,728,cs),
+(168,728,o),
+(45,619,o),
+(45,357,cs),
+(45,95,o),
+(168,-14,o),
+(290,-14,cs)
+);
+}
+);
+width = 655;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1633;
+unicode = 5683;
+},
+{
+color = 9;
+glyphname = "tlhuCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(504,-14,o),
+(601,111,o),
+(601,305,cs),
+(601,474,o),
+(541,577,o),
+(450,621,c),
+(415,603,l),
+(586,603,l),
+(586,522,l),
+(692,522,l),
+(692,794,l),
+(586,794,l),
+(586,714,l),
+(374,714,l),
+(374,597,l),
+(425,551,o),
+(455,462,o),
+(455,336,cs),
+(455,185,o),
+(412,121,o),
+(327,121,cs),
+(242,121,o),
+(199,185,o),
+(199,336,cs),
+(199,462,o),
+(229,551,o),
+(280,597,c),
+(280,714,l),
+(45,714,l),
+(45,592,l),
+(224,592,l),
+(187,612,l),
+(105,565,o),
+(53,465,o),
+(53,305,cs),
+(53,111,o),
+(150,-14,o),
+(327,-14,cs)
+);
+}
+);
+width = 714;
+}
+);
+metricLeft = "lhuCarrier-canadian";
+note = uni1634;
+unicode = 5684;
+},
+{
+color = 9;
+glyphname = "tlhoCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(128,-80,l),
+(128,0,l),
+(341,0,l),
+(341,117,l),
+(289,163,o),
+(260,252,o),
+(260,378,cs),
+(260,529,o),
+(302,593,o),
+(388,593,cs),
+(472,593,o),
+(515,529,o),
+(515,378,cs),
+(515,252,o),
+(485,163,o),
+(434,117,c),
+(434,0,l),
+(670,0,l),
+(670,122,l),
+(490,122,l),
+(527,102,l),
+(610,149,o),
+(661,249,o),
+(661,409,cs),
+(661,603,o),
+(564,728,o),
+(388,728,cs),
+(210,728,o),
+(114,603,o),
+(114,409,cs),
+(114,240,o),
+(173,137,o),
+(265,93,c),
+(299,111,l),
+(128,111,l),
+(128,192,l),
+(22,192,l),
+(22,-80,l)
+);
+}
+);
+width = 715;
+}
+);
+metricLeft = "=|tlhuCarrier-canadian";
+metricRight = "lhuCarrier-canadian";
+note = uni1635;
+unicode = 5685;
+},
+{
+color = 9;
+glyphname = "tlheCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (334,357);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(500,-14,o),
+(623,95,o),
+(623,357,cs),
+(623,619,o),
+(500,728,o),
+(378,728,cs),
+(271,728,o),
+(187,666,o),
+(156,524,c),
+(173,515,l),
+(173,721,l),
+(241,721,l),
+(241,824,l),
+(-1,824,l),
+(-1,721,l),
+(67,721,l),
+(67,424,l),
+(192,424,l),
+(208,519,o),
+(250,593,o),
+(336,593,cs),
+(410,593,o),
+(476,543,o),
+(476,357,cs),
+(476,178,o),
+(410,121,o),
+(336,121,cs),
+(250,121,o),
+(208,195,o),
+(192,290,c),
+(67,290,l),
+(67,0,l),
+(199,0,l),
+(199,182,l),
+(188,161,l),
+(203,62,o),
+(267,-14,o),
+(378,-14,cs)
+);
+}
+);
+width = 668;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1636;
+unicode = 5686;
+},
+{
+color = 9;
+glyphname = "tlheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (276,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 667;
+}
+);
+note = uni1637;
+unicode = 5687;
+},
+{
+color = 9;
+glyphname = "tlhiCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (248,0);
+ref = dot_middle;
+}
+);
+width = 667;
+}
+);
+note = uni1638;
+unicode = 5688;
+},
+{
+color = 9;
+glyphname = "tlhaCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(402,-14,o),
+(465,62,o),
+(480,161,c),
+(470,183,l),
+(470,0,l),
+(602,0,l),
+(602,290,l),
+(477,290,l),
+(460,195,o),
+(418,121,o),
+(332,121,cs),
+(259,121,o),
+(193,178,o),
+(193,357,cs),
+(193,543,o),
+(258,593,o),
+(332,593,cs),
+(418,593,o),
+(460,519,o),
+(477,424,c),
+(602,424,l),
+(602,721,l),
+(669,721,l),
+(669,824,l),
+(427,824,l),
+(427,721,l),
+(495,721,l),
+(495,515,l),
+(512,524,l),
+(482,666,o),
+(397,728,o),
+(290,728,cs),
+(168,728,o),
+(45,619,o),
+(45,357,cs),
+(45,95,o),
+(168,-14,o),
+(290,-14,cs)
+);
+}
+);
+width = 668;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni1639;
+unicode = 5689;
+},
+{
+color = 9;
+glyphname = "tluCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(326,-14,o),
+(380,22,o),
+(405,103,c),
+(360,103,l),
+(385,22,o),
+(439,-14,o),
+(510,-14,cs),
+(641,-14,o),
+(711,82,o),
+(711,269,cs),
+(711,467,o),
+(659,576,o),
+(554,621,c),
+(521,603,l),
+(697,603,l),
+(697,522,l),
+(803,522,l),
+(803,794,l),
+(697,794,l),
+(697,714,l),
+(429,714,l),
+(429,596,l),
+(522,591,o),
+(564,491,o),
+(564,279,cs),
+(564,150,o),
+(541,119,o),
+(504,119,cs),
+(470,119,o),
+(452,149,o),
+(452,211,cs),
+(452,319,l),
+(313,319,l),
+(313,211,ls),
+(313,149,o),
+(294,119,o),
+(261,119,cs),
+(223,119,o),
+(201,150,o),
+(201,279,cs),
+(201,491,o),
+(243,591,o),
+(335,596,c),
+(335,714,l),
+(46,714,l),
+(46,592,l),
+(231,592,l),
+(195,613,l),
+(101,563,o),
+(54,458,o),
+(54,269,cs),
+(54,82,o),
+(124,-14,o),
+(254,-14,cs)
+);
+}
+);
+width = 825;
+}
+);
+metricRight = "tlhuCarrier-canadian";
+note = uni163A;
+unicode = 5690;
+},
+{
+color = 1;
+glyphname = "tloCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(803,-80,l),
+(803,192,l),
+(697,192,l),
+(697,111,l),
+(521,111,l),
+(554,93,l),
+(659,138,o),
+(711,247,o),
+(711,445,cs),
+(711,632,o),
+(641,728,o),
+(510,728,cs),
+(439,728,o),
+(385,692,o),
+(360,611,c),
+(405,611,l),
+(380,692,o),
+(326,728,o),
+(254,728,cs),
+(124,728,o),
+(54,632,o),
+(54,445,cs),
+(54,256,o),
+(101,151,o),
+(195,101,c),
+(231,122,l),
+(46,122,l),
+(46,0,l),
+(335,0,l),
+(335,118,l),
+(243,123,o),
+(201,223,o),
+(201,435,cs),
+(201,564,o),
+(223,595,o),
+(261,595,cs),
+(294,595,o),
+(313,565,o),
+(313,503,cs),
+(313,395,l),
+(452,395,l),
+(452,503,ls),
+(452,565,o),
+(470,595,o),
+(504,595,cs),
+(541,595,o),
+(564,564,o),
+(564,435,cs),
+(564,223,o),
+(522,123,o),
+(429,118,c),
+(429,0,l),
+(697,0,l),
+(697,-80,l)
+);
+}
+);
+width = 825;
+}
+);
+metricLeft = "tluCarrier-canadian";
+metricRight = "tlhuCarrier-canadian";
+note = uni163B;
+unicode = 5691;
+},
+{
+color = 9;
+glyphname = "tleCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (279,357);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(526,-14,o),
+(606,70,o),
+(606,188,cs),
+(606,286,o),
+(556,355,o),
+(479,371,c),
+(479,343,l),
+(556,358,o),
+(606,426,o),
+(606,526,cs),
+(606,644,o),
+(526,728,o),
+(392,728,cs),
+(283,728,o),
+(181,668,o),
+(158,540,c),
+(173,525,l),
+(173,721,l),
+(240,721,l),
+(240,824,l),
+(-1,824,l),
+(-1,721,l),
+(67,721,l),
+(67,424,l),
+(188,424,l),
+(192,534,o),
+(243,597,o),
+(347,597,cs),
+(422,597,o),
+(460,562,o),
+(460,501,cs),
+(460,447,o),
+(434,417,o),
+(383,417,cs),
+(358,417,l),
+(358,298,l),
+(383,298,ls),
+(435,298,o),
+(460,267,o),
+(460,214,cs),
+(460,153,o),
+(422,117,o),
+(347,117,cs),
+(243,117,o),
+(192,180,o),
+(188,290,c),
+(67,290,l),
+(67,0,l),
+(199,0,l),
+(199,156,l),
+(177,137,l),
+(209,33,o),
+(293,-14,o),
+(392,-14,cs)
+);
+}
+);
+width = 656;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni163C;
+unicode = 5692;
+},
+{
+color = 9;
+glyphname = "tleeCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (220,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 657;
+}
+);
+note = uni163D;
+unicode = 5693;
+},
+{
+color = 9;
+glyphname = "tliCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (208,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 657;
+}
+);
+note = uni163E;
+unicode = 5694;
+},
+{
+color = 9;
+glyphname = "tlaCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(363,-14,o),
+(448,33,o),
+(479,137,c),
+(458,156,l),
+(458,0,l),
+(590,0,l),
+(590,290,l),
+(468,290,l),
+(465,180,o),
+(413,117,o),
+(310,117,cs),
+(235,117,o),
+(196,153,o),
+(196,214,cs),
+(196,267,o),
+(222,298,o),
+(274,298,cs),
+(300,298,l),
+(300,417,l),
+(274,417,ls),
+(222,417,o),
+(196,447,o),
+(196,501,cs),
+(196,562,o),
+(234,597,o),
+(309,597,cs),
+(413,597,o),
+(465,534,o),
+(468,424,c),
+(590,424,l),
+(590,721,l),
+(657,721,l),
+(657,824,l),
+(416,824,l),
+(416,721,l),
+(484,721,l),
+(484,525,l),
+(499,540,l),
+(476,668,o),
+(374,728,o),
+(264,728,cs),
+(131,728,o),
+(50,644,o),
+(50,526,cs),
+(50,426,o),
+(100,358,o),
+(177,343,c),
+(177,371,l),
+(101,355,o),
+(50,286,o),
+(50,188,cs),
+(50,70,o),
+(131,-14,o),
+(264,-14,cs)
+);
+}
+);
+width = 656;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni163F;
+unicode = 5695;
+},
+{
+color = 9;
+glyphname = "zuCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(499,-14,o),
+(601,80,o),
+(601,230,cs),
+(601,338,o),
+(537,475,o),
+(537,538,cs),
+(537,568,o),
+(551,588,o),
+(585,588,cs),
+(610,588,l),
+(610,714,l),
+(548,714,ls),
+(443,714,o),
+(394,657,o),
+(394,565,cs),
+(394,476,o),
+(454,347,o),
+(454,253,cs),
+(454,172,o),
+(410,121,o),
+(327,121,cs),
+(244,121,o),
+(200,171,o),
+(200,253,cs),
+(200,347,o),
+(260,476,o),
+(260,565,cs),
+(260,657,o),
+(211,714,o),
+(106,714,cs),
+(44,714,l),
+(44,588,l),
+(69,588,ls),
+(103,588,o),
+(118,568,o),
+(118,538,cs),
+(118,475,o),
+(52,338,o),
+(52,230,cs),
+(52,80,o),
+(155,-14,o),
+(327,-14,cs)
+);
+}
+);
+width = 654;
+}
+);
+metricRight = "=|";
+note = uni1640;
+unicode = 5696;
+},
+{
+color = 9;
+glyphname = "zoCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(106,0,ls),
+(212,0,o),
+(261,57,o),
+(261,149,cs),
+(261,238,o),
+(200,367,o),
+(200,461,cs),
+(200,542,o),
+(245,593,o),
+(328,593,cs),
+(411,593,o),
+(455,543,o),
+(455,461,cs),
+(455,367,o),
+(394,238,o),
+(394,149,cs),
+(394,57,o),
+(444,0,o),
+(548,0,cs),
+(610,0,l),
+(610,126,l),
+(585,126,ls),
+(551,126,o),
+(537,146,o),
+(537,176,cs),
+(537,239,o),
+(602,376,o),
+(602,484,cs),
+(602,634,o),
+(499,728,o),
+(328,728,cs),
+(156,728,o),
+(53,634,o),
+(53,484,cs),
+(53,376,o),
+(118,239,o),
+(118,176,cs),
+(118,146,o),
+(104.005,126,o),
+(70,126,cs),
+(44,126,l),
+(44,0,l)
+);
+}
+);
+width = 654;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1641;
+unicode = 5697;
+},
+{
+color = 9;
+glyphname = "zeCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (306,357);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(502,-14,o),
+(589,105,o),
+(589,357,cs),
+(589,609,o),
+(503,728,o),
+(381,728,cs),
+(293,728,o),
+(227,635,o),
+(193,635,cs),
+(174,635,o),
+(165,647,o),
+(165,688,cs),
+(165,714,l),
+(32,714,l),
+(32,644,ls),
+(32,548,o),
+(81,505,o),
+(149,505,cs),
+(230,505,o),
+(287,593,o),
+(343,593,cs),
+(397,593,o),
+(441,542,o),
+(441,357,cs),
+(441,172,o),
+(397,121,o),
+(343,121,cs),
+(287,121,o),
+(230,209,o),
+(149,209,cs),
+(81,209,o),
+(32,166,o),
+(32,70,cs),
+(32,0,l),
+(165,0,l),
+(165,26,ls),
+(165,68,o),
+(174,79,o),
+(193,79,cs),
+(227,79,o),
+(293,-14,o),
+(381,-14,cs)
+);
+}
+);
+width = 634;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1642;
+unicode = 5698;
+},
+{
+color = 9;
+glyphname = "zeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (248,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 633;
+}
+);
+note = uni1643;
+unicode = 5699;
+},
+{
+color = 9;
+glyphname = "ziCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (219,0);
+ref = dot_middle;
+}
+);
+width = 633;
+}
+);
+note = uni1644;
+unicode = 5700;
+},
+{
+color = 9;
+glyphname = "zaCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(341,-14,o),
+(407,79,o),
+(441,79,cs),
+(460,79,o),
+(469,67,o),
+(469,26,cs),
+(469,0,l),
+(602,0,l),
+(602,70,ls),
+(602,166,o),
+(553,209,o),
+(485,209,cs),
+(404,209,o),
+(347,121,o),
+(291,121,cs),
+(237,121,o),
+(193,172,o),
+(193,357,cs),
+(193,542,o),
+(237,593,o),
+(291,593,cs),
+(347,593,o),
+(404,505,o),
+(485,505,cs),
+(553,505,o),
+(602,548,o),
+(602,644,cs),
+(602,714,l),
+(469,714,l),
+(469,688,ls),
+(469,646,o),
+(460,635,o),
+(441,635,cs),
+(407,635,o),
+(341,728,o),
+(253,728,cs),
+(132,728,o),
+(45,609,o),
+(45,357,cs),
+(45,105,o),
+(131,-14,o),
+(253,-14,cs)
+);
+}
+);
+width = 634;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|zeCarrier-canadian";
+note = uni1645;
+unicode = 5701;
+},
+{
+color = 6;
+glyphname = "zCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(314,189,l),
+(314,280,l),
+(149,280,l),
+(149,226,l),
+(310,495,l),
+(310,546,l),
+(45.005,546,l),
+(45,455,l),
+(207,455,l),
+(207,509,l),
+(45,240,l),
+(45.005,189,l)
+);
+}
+);
+width = 359;
+}
+);
+metricRight = "=|";
+note = uni1646;
+unicode = 5702;
+},
+{
+color = 6;
+glyphname = "initialzCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(130,189,l),
+(130,99,l),
+(226,99,l),
+(226,189,l),
+(314,189,l),
+(314,280,l),
+(115,280,l),
+(147,223,l),
+(310,495,l),
+(310,546,l),
+(226,546,l),
+(226,636,l),
+(130,636,l),
+(130,546,l),
+(45.005,546,l),
+(45,455,l),
+(241,455,l),
+(208,512,l),
+(45,240,l),
+(45.005,189,l)
+);
+}
+);
+width = 359;
+}
+);
+metricLeft = "zCarrier-canadian";
+metricRight = "zCarrier-canadian";
+note = uni1647;
+unicode = 5703;
+},
+{
+color = 9;
+glyphname = "dzuCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(499,-14,o),
+(601,80,o),
+(601,230,cs),
+(601,338,o),
+(537,475,o),
+(537,538,cs),
+(537,568,o),
+(551,588,o),
+(585,588,cs),
+(610,588,l),
+(610,714,l),
+(555,714,ls),
+(456,714,o),
+(401,657,o),
+(401,565,cs),
+(401,476,o),
+(454,353,o),
+(454,253,cs),
+(454,172,o),
+(411,121,o),
+(327,121,cs),
+(243,121,o),
+(200,171,o),
+(200,253,cs),
+(200,353,o),
+(253,476,o),
+(253,565,cs),
+(253,657,o),
+(198,714,o),
+(100,714,cs),
+(44,714,l),
+(44,588,l),
+(69,588,ls),
+(103,588,o),
+(118,568,o),
+(118,538,cs),
+(118,475,o),
+(52,338,o),
+(52,230,cs),
+(52,80,o),
+(155,-14,o),
+(327,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(356,486,l),
+(356,659,l),
+(400,659,l),
+(400,714,l),
+(255,714,l),
+(255,659,l),
+(299,659,l),
+(299,486,l)
+);
+}
+);
+width = 654;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1648;
+unicode = 5704;
+},
+{
+color = 9;
+glyphname = "dzoCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,0,ls),
+(199,0,o),
+(253,57,o),
+(253,149,cs),
+(253,238,o),
+(200,361,o),
+(200,461,cs),
+(200,542,o),
+(244,593,o),
+(328,593,cs),
+(411,593,o),
+(455,543,o),
+(455,461,cs),
+(455,361,o),
+(402,238,o),
+(402,149,cs),
+(402,57,o),
+(456,0,o),
+(555,0,cs),
+(610,0,l),
+(610,126,l),
+(585,126,ls),
+(551,126,o),
+(537,146,o),
+(537,176,cs),
+(537,239,o),
+(602,376,o),
+(602,484,cs),
+(602,634,o),
+(499,728,o),
+(328,728,cs),
+(156,728,o),
+(53,634,o),
+(53,484,cs),
+(53,376,o),
+(118,239,o),
+(118,176,cs),
+(118,146,o),
+(104.005,126,o),
+(70,126,cs),
+(44,126,l),
+(44,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(399,0,l),
+(399,55,l),
+(355,55,l),
+(355,228,l),
+(299,228,l),
+(299,55,l),
+(255,55,l),
+(255,0,l)
+);
+}
+);
+width = 654;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1649;
+unicode = 5705;
+},
+{
+color = 9;
+glyphname = "dzeCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (334,357);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(523,-14,o),
+(609,105,o),
+(609,357,cs),
+(609,609,o),
+(524,728,o),
+(401,728,cs),
+(314,728,o),
+(248,635,o),
+(213,635,cs),
+(194,635,o),
+(185,647,o),
+(185,688,cs),
+(185,714,l),
+(53,714,l),
+(53,644,ls),
+(53,548,o),
+(102,506,o),
+(170,506,cs),
+(251,506,o),
+(308,593,o),
+(364,593,cs),
+(417,593,o),
+(462,542,o),
+(462,357,cs),
+(462,172,o),
+(417,121,o),
+(364,121,cs),
+(308,121,o),
+(251,208,o),
+(170,208,cs),
+(102,208,o),
+(53,166,o),
+(53,70,cs),
+(53,0,l),
+(185,0,l),
+(185,26,ls),
+(185,63,o),
+(194,74,o),
+(213,74,cs),
+(248,74,o),
+(314,-14,o),
+(401,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(128,251,l),
+(128,319,l),
+(229,319,l),
+(229,395,l),
+(128,395,l),
+(128,463,l),
+(53,463,l),
+(53,251,l)
+);
+}
+);
+width = 654;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164A;
+unicode = 5706;
+},
+{
+color = 9;
+glyphname = "dzeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+ref = "dzeCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (276,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 654;
+}
+);
+metricLeft = "dzeCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164B;
+unicode = 5707;
+},
+{
+color = 9;
+glyphname = "dziCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "dzeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (247,0);
+ref = dot_middle;
+}
+);
+width = 654;
+}
+);
+note = uni164C;
+unicode = 5708;
+},
+{
+color = 9;
+glyphname = "dzaCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(341,-14,o),
+(407,74,o),
+(441,74,cs),
+(460,74,o),
+(469,63,o),
+(469,26,cs),
+(469,0,l),
+(602,0,l),
+(602,70,ls),
+(602,166,o),
+(553,208,o),
+(485,208,cs),
+(404,208,o),
+(347,121,o),
+(291,121,cs),
+(237,121,o),
+(193,172,o),
+(193,357,cs),
+(193,542,o),
+(237,593,o),
+(291,593,cs),
+(347,593,o),
+(404,506,o),
+(485,506,cs),
+(553,506,o),
+(602,548,o),
+(602,644,cs),
+(602,714,l),
+(469,714,l),
+(469,688,ls),
+(469,647,o),
+(460,635,o),
+(441,635,cs),
+(407,635,o),
+(341,728,o),
+(253,728,cs),
+(131,728,o),
+(45,609,o),
+(45,357,cs),
+(45,105,o),
+(132,-14,o),
+(253,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(602,251,l),
+(602,463,l),
+(526,463,l),
+(526,395,l),
+(426,395,l),
+(426,319,l),
+(526,319,l),
+(526,251,l)
+);
+}
+);
+width = 655;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dzeCarrier-canadian";
+note = uni164D;
+unicode = 5709;
+},
+{
+color = 9;
+glyphname = "suCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(326,-14,o),
+(385,38,o),
+(406,140,c),
+(358,140,l),
+(379,38,o),
+(438,-14,o),
+(527,-14,cs),
+(642,-14,o),
+(713,67,o),
+(713,185,cs),
+(713,301,o),
+(656,450,o),
+(656,540,cs),
+(656,568,o),
+(669,588,o),
+(701,588,cs),
+(718,588,l),
+(718,714,l),
+(666,714,ls),
+(561,714,o),
+(516,658,o),
+(516,564,cs),
+(516,458,o),
+(569,282,o),
+(569,199,cs),
+(569,147,o),
+(550,119,o),
+(511,119,cs),
+(470,119,o),
+(446,149,o),
+(446,213,cs),
+(446,714,l),
+(318,714,l),
+(318,213,ls),
+(318,149,o),
+(294,119,o),
+(254,119,cs),
+(215,119,o),
+(195,147,o),
+(195,199,cs),
+(195,282,o),
+(247,458,o),
+(247,564,cs),
+(247,658,o),
+(203,714,o),
+(98,714,cs),
+(45,714,l),
+(45,588,l),
+(62,588,ls),
+(94,588,o),
+(108,567,o),
+(108,540,cs),
+(108,450,o),
+(51,301,o),
+(51,185,cs),
+(51,67,o),
+(122,-14,o),
+(237,-14,cs)
+);
+}
+);
+width = 763;
+}
+);
+metricRight = "=|";
+note = uni164E;
+unicode = 5710;
+},
+{
+color = 9;
+glyphname = "soCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(98,0,ls),
+(203,0,o),
+(247,56,o),
+(247,150,cs),
+(247,256,o),
+(194,432,o),
+(194,515,cs),
+(194,567,o),
+(214,595,o),
+(253,595,cs),
+(293,595,o),
+(317,565,o),
+(317,501,cs),
+(317,0,l),
+(446,0,l),
+(446,501,ls),
+(446,565,o),
+(470,595,o),
+(510,595,cs),
+(549,595,o),
+(569,567,o),
+(569,515,cs),
+(569,432,o),
+(516,256,o),
+(516,150,cs),
+(516,56,o),
+(561,0,o),
+(666,0,cs),
+(718,0,l),
+(718,126,l),
+(701,126,ls),
+(669,126,o),
+(656,147,o),
+(656,174,cs),
+(656,264,o),
+(713,413,o),
+(713,529,cs),
+(713,647,o),
+(642,728,o),
+(527,728,cs),
+(438,728,o),
+(379,676,o),
+(358,574,c),
+(406,574,l),
+(384,676,o),
+(326,728,o),
+(237,728,cs),
+(122,728,o),
+(51,647,o),
+(51,529,cs),
+(51,413,o),
+(108,264,o),
+(108,174,cs),
+(108,146,o),
+(94,126,o),
+(62,126,cs),
+(45,126,l),
+(45,0,l)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5711;
+},
+{
+color = 9;
+glyphname = "seCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(524,-14,o),
+(594,69,o),
+(594,185,cs),
+(594,291,o),
+(539,362,o),
+(456,373,c),
+(456,341,l),
+(539,352,o),
+(594,422,o),
+(594,529,cs),
+(594,645,o),
+(524,728,o),
+(425,728,cs),
+(330,728,o),
+(250,635,o),
+(214,635,cs),
+(195,635,o),
+(186,647,o),
+(186,688,cs),
+(186,714,l),
+(54,714,l),
+(54,645,ls),
+(54,549,o),
+(103,506,o),
+(170,506,cs),
+(252,506,o),
+(324,597,o),
+(379,597,cs),
+(423,597,o),
+(448,562,o),
+(448,508,cs),
+(448,448,o),
+(416,416,o),
+(358,416,cs),
+(54,416,l),
+(54,298,l),
+(358,298,ls),
+(416,298,o),
+(448,266,o),
+(448,206,cs),
+(448,152,o),
+(423,117,o),
+(379,117,cs),
+(324,117,o),
+(252,208,o),
+(170,208,cs),
+(103,208,o),
+(54,165,o),
+(54,69,cs),
+(54,0,l),
+(186,0,l),
+(186,26,ls),
+(186,67,o),
+(195,79,o),
+(214,79,cs),
+(250,79,o),
+(330,-14,o),
+(425,-14,cs)
+);
+}
+);
+width = 644;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni1650;
+unicode = 5712;
+},
+{
+color = 9;
+glyphname = "seeCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(524,-14,o),
+(594,69,o),
+(594,185,cs),
+(594,286,o),
+(544,355,o),
+(468,371,c),
+(468,343,l),
+(544,358,o),
+(594,427,o),
+(594,529,cs),
+(594,645,o),
+(524,728,o),
+(425,728,cs),
+(330,728,o),
+(250,635,o),
+(214,635,cs),
+(195,635,o),
+(186,647,o),
+(186,688,cs),
+(186,714,l),
+(54,714,l),
+(54,645,ls),
+(54,549,o),
+(103,506,o),
+(170,506,cs),
+(252,506,o),
+(324,597,o),
+(379,597,cs),
+(423,597,o),
+(448,562,o),
+(448,508,cs),
+(448,448,o),
+(416,413,o),
+(361,413,cs),
+(320,413,l),
+(352,369,l),
+(352,488,l),
+(275,488,l),
+(275,413,l),
+(54,413,l),
+(54,301,l),
+(275,301,l),
+(275,223,l),
+(352,223,l),
+(352,338,l),
+(320,301,l),
+(361,301,ls),
+(416,301,o),
+(448,266,o),
+(448,206,cs),
+(448,152,o),
+(423,117,o),
+(379,117,cs),
+(324,117,o),
+(252,208,o),
+(170,208,cs),
+(103,208,o),
+(54,165,o),
+(54,69,cs),
+(54,0,l),
+(186,0,l),
+(186,26,ls),
+(186,67,o),
+(195,79,o),
+(214,79,cs),
+(250,79,o),
+(330,-14,o),
+(425,-14,cs)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1651;
+unicode = 5713;
+},
+{
+color = 9;
+glyphname = "siCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(524,-14,o),
+(594,69,o),
+(594,185,cs),
+(594,286,o),
+(544,355,o),
+(468,371,c),
+(468,343,l),
+(544,358,o),
+(594,427,o),
+(594,529,cs),
+(594,645,o),
+(524,728,o),
+(425,728,cs),
+(330,728,o),
+(250,635,o),
+(214,635,cs),
+(195,635,o),
+(186,647,o),
+(186,688,cs),
+(186,714,l),
+(54,714,l),
+(54,645,ls),
+(54,549,o),
+(103,506,o),
+(170,506,cs),
+(252,506,o),
+(324,597,o),
+(380,597,cs),
+(424,597,o),
+(449,561,o),
+(449,504,cs),
+(449,440,o),
+(423,410,o),
+(375,410,cs),
+(317,410,l),
+(371,367,l),
+(366,418,o),
+(327,456,o),
+(276,456,cs),
+(242,456,o),
+(213,439,o),
+(197,413,c),
+(54,413,l),
+(54,301,l),
+(197,301,l),
+(214,275,o),
+(243,259,o),
+(276,259,cs),
+(327,259,o),
+(364,297,o),
+(370,346,c),
+(315,304,l),
+(375,304,ls),
+(423,304,o),
+(449,274,o),
+(449,210,cs),
+(449,153,o),
+(424,117,o),
+(380,117,cs),
+(324,117,o),
+(252,208,o),
+(170,208,cs),
+(103,208,o),
+(54,165,o),
+(54,69,cs),
+(54,0,l),
+(186,0,l),
+(186,26,ls),
+(186,67,o),
+(195,79,o),
+(214,79,cs),
+(250,79,o),
+(330,-14,o),
+(425,-14,cs)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1652;
+unicode = 5714;
+},
+{
+color = 9;
+glyphname = "saCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(315,-14,o),
+(395,79,o),
+(431,79,cs),
+(450,79,o),
+(459,67,o),
+(459,26,cs),
+(459,0,l),
+(590.995,0,l),
+(591,69,ls),
+(591,165,o),
+(542,208,o),
+(474,208,cs),
+(393,208,o),
+(321,117,o),
+(265,117,cs),
+(221,117,o),
+(196,152,o),
+(196,206,cs),
+(196,266,o),
+(229,298,o),
+(287,298,cs),
+(591,298,l),
+(591,416,l),
+(287,416,ls),
+(229,416,o),
+(196,448,o),
+(196,508,cs),
+(196,562,o),
+(221,597,o),
+(266,597,cs),
+(321,597,o),
+(393,506,o),
+(474,506,cs),
+(542,506,o),
+(591,549,o),
+(591,645,cs),
+(590.995,714,l),
+(459,714,l),
+(459,688,ls),
+(459,647,o),
+(450,635,o),
+(431,635,cs),
+(395,635,o),
+(315,728,o),
+(220,728,cs),
+(121,728,o),
+(50,645,o),
+(50,529,cs),
+(50,422,o),
+(105,352,o),
+(189,341,c),
+(189,373,l),
+(106,362,o),
+(50,291,o),
+(50,185,cs),
+(50,69,o),
+(121,-14,o),
+(220,-14,cs)
+);
+}
+);
+width = 645;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1653;
+unicode = 5715;
+},
+{
+color = 9;
+glyphname = "shuCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(320,-14,o),
+(376,32,o),
+(402,121,c),
+(363,121,l),
+(387,32,o),
+(444,-14,o),
+(527,-14,cs),
+(642,-14,o),
+(713,67,o),
+(713,185,cs),
+(713,301,o),
+(656,450,o),
+(656,540,cs),
+(656,568,o),
+(669,588,o),
+(701,588,cs),
+(718,588,l),
+(718,714,l),
+(666,714,ls),
+(561,714,o),
+(518,658,o),
+(518,564,cs),
+(518,546,o),
+(520,525,o),
+(522,506,c),
+(540,590,l),
+(446,590,l),
+(446,714,l),
+(318,714,l),
+(318,590,l),
+(224,590,l),
+(242,506,l),
+(244,525,o),
+(246,546,o),
+(246,564,cs),
+(246,658,o),
+(203,714,o),
+(98,714,cs),
+(45,714,l),
+(45,588,l),
+(62,588,ls),
+(94,588,o),
+(108,567,o),
+(108,540,cs),
+(108,450,o),
+(51,301,o),
+(51,185,cs),
+(51,67,o),
+(122,-14,o),
+(237,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(215,119,o),
+(195,147,o),
+(195,199,cs),
+(195,262,o),
+(224,377,o),
+(239,475,c),
+(318,475,l),
+(318,213,ls),
+(318,149,o),
+(294,119,o),
+(254,119,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(470,119,o),
+(446,149,o),
+(446,213,cs),
+(446,475,l),
+(525,475,l),
+(540,377,o),
+(569,262,o),
+(569,199,cs),
+(569,147,o),
+(550,119,o),
+(511,119,cs)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1654;
+unicode = 5716;
+},
+{
+color = 9;
+glyphname = "shoCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(98,0,ls),
+(203,0,o),
+(246,56,o),
+(246,150,cs),
+(246,168,o),
+(244,189,o),
+(242,208,c),
+(224,124,l),
+(317,124,l),
+(317,0,l),
+(446,0,l),
+(446,124,l),
+(540,124,l),
+(522,208,l),
+(520,189,o),
+(518,168,o),
+(518,150,cs),
+(518,56,o),
+(561,0,o),
+(666,0,cs),
+(718,0,l),
+(718,126,l),
+(701,126,ls),
+(669,126,o),
+(656,147,o),
+(656,174,cs),
+(656,264,o),
+(713,413,o),
+(713,529,cs),
+(713,647,o),
+(642,728,o),
+(527,728,cs),
+(443,728,o),
+(387,682,o),
+(362,593,c),
+(401,593,l),
+(377,682,o),
+(320,728,o),
+(237,728,cs),
+(122,728,o),
+(51,647,o),
+(51,529,cs),
+(51,413,o),
+(108,264,o),
+(108,174,cs),
+(108,146,o),
+(94,126,o),
+(62,126,cs),
+(45,126,l),
+(45,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(224,337,o),
+(194,452,o),
+(194,515,cs),
+(194,567,o),
+(214,595,o),
+(253,595,cs),
+(293,595,o),
+(317,565,o),
+(317,501,cs),
+(317,239,l),
+(239,239,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(446,501,ls),
+(446,565,o),
+(470,595,o),
+(510,595,cs),
+(549,595,o),
+(569,567,o),
+(569,515,cs),
+(569,452,o),
+(539,337,o),
+(525,239,c),
+(446,239,l)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1655;
+unicode = 5717;
+},
+{
+color = 9;
+glyphname = "sheCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(524,-14,o),
+(594,69,o),
+(594,185,cs),
+(594,286,o),
+(544,355,o),
+(468,371,c),
+(468,343,l),
+(544,358,o),
+(594,427,o),
+(594,529,cs),
+(594,645,o),
+(524,728,o),
+(425,728,cs),
+(330,728,o),
+(250,635,o),
+(214,635,cs),
+(195,635,o),
+(186,647,o),
+(186,688,cs),
+(186,714,l),
+(54,714,l),
+(54,645,ls),
+(54,549,o),
+(103,511,o),
+(170,511,cs),
+(192,511,o),
+(212,517,o),
+(233,525,c),
+(142,545,l),
+(142,416,l),
+(54,416,l),
+(54,299,l),
+(142,299,l),
+(142,169,l),
+(231,190,l),
+(211,198,o),
+(192,203,o),
+(170,203,cs),
+(103,203,o),
+(54,165,o),
+(54,69,cs),
+(54,0,l),
+(186,0,l),
+(186,26,ls),
+(186,67,o),
+(195,79,o),
+(214,79,cs),
+(250,79,o),
+(330,-14,o),
+(425,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(256,299,l),
+(358,299,ls),
+(416,299,o),
+(448,266,o),
+(448,206,cs),
+(448,152,o),
+(423,117,o),
+(379,117,cs),
+(343,117,o),
+(301,152,o),
+(256,177,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(256,537,l),
+(301,562,o),
+(343,597,o),
+(379,597,cs),
+(423,597,o),
+(448,562,o),
+(448,508,cs),
+(448,448,o),
+(416,416,o),
+(358,416,cs),
+(256,416,l)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1656;
+unicode = 5718;
+},
+{
+color = 9;
+glyphname = "sheeCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(524,-14,o),
+(594,69,o),
+(594,185,cs),
+(594,286,o),
+(544,355,o),
+(468,371,c),
+(468,343,l),
+(544,358,o),
+(594,427,o),
+(594,529,cs),
+(594,645,o),
+(524,728,o),
+(425,728,cs),
+(330,728,o),
+(250,635,o),
+(214,635,cs),
+(195,635,o),
+(186,647,o),
+(186,688,cs),
+(186,714,l),
+(54,714,l),
+(54,645,ls),
+(54,549,o),
+(103,511,o),
+(170,511,cs),
+(186,511,o),
+(203,514,o),
+(218,520,c),
+(142,543,l),
+(142,405,l),
+(54,405,l),
+(54,309,l),
+(142,309,l),
+(142,171,l),
+(219,193,l),
+(203,200,o),
+(187,203,o),
+(170,203,cs),
+(103,203,o),
+(54,165,o),
+(54,69,cs),
+(54,0,l),
+(186,0,l),
+(186,26,ls),
+(186,67,o),
+(195,79,o),
+(214,79,cs),
+(250,79,o),
+(330,-14,o),
+(425,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(342,114,o),
+(290,164,o),
+(232,189,c),
+(232,309,l),
+(304,309,l),
+(304,223,l),
+(365,223,l),
+(365,329,l),
+(340,309,l),
+(377,309,ls),
+(427,309,o),
+(453,267,o),
+(453,212,cs),
+(453,150,o),
+(428,114,o),
+(383,114,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(365,488,l),
+(304,488,l),
+(304,405,l),
+(232,405,l),
+(232,525,l),
+(290,550,o),
+(342,600,o),
+(383,600,cs),
+(428,600,o),
+(453,564,o),
+(453,502,cs),
+(453,447,o),
+(426,405,o),
+(377,405,cs),
+(340,405,l),
+(365,385,l)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1657;
+unicode = 5719;
+},
+{
+color = 9;
+glyphname = "shiCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(54,645,ls),
+(54,549,o),
+(103,511,o),
+(170,511,cs),
+(183,511,o),
+(196,513,o),
+(209,516,c),
+(142,543,l),
+(142,405,l),
+(54,405,l),
+(54,309,l),
+(142,309,l),
+(142,171,l),
+(209,198,l),
+(197,201,o),
+(184,203,o),
+(170,203,cs),
+(103,203,o),
+(54,165,o),
+(54,69,cs),
+(54,0,l),
+(186,0,l),
+(186,26,ls),
+(186,67,o),
+(195,79,o),
+(214,79,cs),
+(250,79,o),
+(330,-14,o),
+(425,-14,cs),
+(524,-14,o),
+(594,69,o),
+(594,185,cs),
+(594,286,o),
+(544,355,o),
+(468,371,c),
+(468,343,l),
+(544,358,o),
+(594,427,o),
+(594,529,cs),
+(594,645,o),
+(524,728,o),
+(425,728,cs),
+(330,728,o),
+(250,635,o),
+(214,635,cs),
+(195,635,o),
+(186,647,o),
+(186,688,cs),
+(186,714,l),
+(54,714,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(232,309,l),
+(257,309,l),
+(273,275,o),
+(302,259,o),
+(334,259,cs),
+(383,259,o),
+(419,302,o),
+(419,347,c),
+(345,308,l),
+(388,308,ls),
+(430,308,o),
+(453,267,o),
+(453,212,cs),
+(453,150,o),
+(428,114,o),
+(383,114,cs),
+(342,114,o),
+(289,163,o),
+(232,189,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(232,525,l),
+(289,551,o),
+(342,600,o),
+(383,600,cs),
+(428,600,o),
+(453,564,o),
+(453,502,cs),
+(453,446,o),
+(429,406,o),
+(388,406,cs),
+(347,406,l),
+(420,366,l),
+(421,414,o),
+(383,456,o),
+(334,456,cs),
+(302,456,o),
+(272,439,o),
+(257,405,c),
+(232,405,l)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1658;
+unicode = 5720;
+},
+{
+color = 9;
+glyphname = "shaCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(315,-14,o),
+(395,79,o),
+(431,79,cs),
+(450,79,o),
+(459,67,o),
+(459,26,cs),
+(459,0,l),
+(590.995,0,l),
+(591,69,ls),
+(591,165,o),
+(542,203,o),
+(474,203,cs),
+(452,203,o),
+(433,197,o),
+(412,189,c),
+(503,169,l),
+(503,299,l),
+(591,299,l),
+(591,416,l),
+(503,416,l),
+(503,545,l),
+(413,524,l),
+(433,516,o),
+(453,511,o),
+(474,511,cs),
+(542,511,o),
+(591,549,o),
+(591,645,cs),
+(590.995,714,l),
+(459,714,l),
+(459,688,ls),
+(459,647,o),
+(450,635,o),
+(431,635,cs),
+(395,635,o),
+(315,728,o),
+(220,728,cs),
+(121,728,o),
+(50,645,o),
+(50,529,cs),
+(50,427,o),
+(100,358,o),
+(177,343,c),
+(177,371,l),
+(100,355,o),
+(50,286,o),
+(50,185,cs),
+(50,69,o),
+(121,-14,o),
+(220,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(221,117,o),
+(196,152,o),
+(196,206,cs),
+(196,266,o),
+(229,299,o),
+(287,299,cs),
+(389,299,l),
+(389,177,l),
+(344,152,o),
+(301,117,o),
+(265,117,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(229,416,o),
+(196,448,o),
+(196,508,cs),
+(196,562,o),
+(221,597,o),
+(266,597,cs),
+(301,597,o),
+(344,562,o),
+(389,537,c),
+(389,416,l),
+(287,416,ls)
+);
+}
+);
+width = 645;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1659;
+unicode = 5721;
+},
+{
+color = 6;
+glyphname = "shCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(227,99,l),
+(227,204,l),
+(157,189,l),
+(193,189,ls),
+(274,189,o),
+(316,228,o),
+(316,297,cs),
+(316,365,o),
+(276,406,o),
+(207,406,cs),
+(176,406,ls),
+(149,406,o),
+(134,414,o),
+(134,437,cs),
+(134,462,o),
+(150,470,o),
+(176,470,cs),
+(310,470,l),
+(310,546,l),
+(227,546,l),
+(227,636,l),
+(135,636,l),
+(135,522,l),
+(201,546,l),
+(168,546,ls),
+(87,546,o),
+(45,507,o),
+(45,438,cs),
+(45,371,o),
+(84,330,o),
+(154,330,cs),
+(185,330,ls),
+(211,330,o),
+(227,321,o),
+(227,298,cs),
+(227,274,o),
+(212,266,o),
+(185,266,cs),
+(51,266,l),
+(51,189,l),
+(135,189,l),
+(135,99,l)
+);
+}
+);
+width = 361;
+}
+);
+metricRight = "=|";
+note = uni18F5;
+unicode = 5722;
+},
+{
+color = 9;
+glyphname = "tsuCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(320,-14,o),
+(376,32,o),
+(402,121,c),
+(363,121,l),
+(387,32,o),
+(444,-14,o),
+(527,-14,cs),
+(642,-14,o),
+(713,67,o),
+(713,185,cs),
+(713,301,o),
+(656,450,o),
+(656,540,cs),
+(656,568,o),
+(669,588,o),
+(701,588,cs),
+(718,588,l),
+(718,714,l),
+(666,714,ls),
+(564,714,o),
+(521,664,o),
+(521,569,cs),
+(521,524,o),
+(532,470,o),
+(542,415,c),
+(444,415,l),
+(444,615,l),
+(494,615,l),
+(494,714,l),
+(269,714,l),
+(269,615,l),
+(320,615,l),
+(320,415,l),
+(222,415,l),
+(232,470,o),
+(243,524,o),
+(243,569,cs),
+(243,664,o),
+(200,714,o),
+(98,714,cs),
+(45,714,l),
+(45,588,l),
+(62,588,ls),
+(94,588,o),
+(108,567,o),
+(108,540,cs),
+(108,450,o),
+(51,301,o),
+(51,185,cs),
+(51,67,o),
+(122,-14,o),
+(237,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(216,119,o),
+(195,147,o),
+(195,199,cs),
+(195,225,o),
+(199,260,o),
+(205,300,c),
+(320,300,l),
+(320,213,ls),
+(320,149,o),
+(295,119,o),
+(255,119,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(469,119,o),
+(444,149,o),
+(444,213,cs),
+(444,300,l),
+(559,300,l),
+(565,260,o),
+(569,225,o),
+(569,199,cs),
+(569,147,o),
+(548,119,o),
+(509,119,cs)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165B;
+unicode = 5723;
+},
+{
+color = 9;
+glyphname = "tsoCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(98,0,ls),
+(200,0,o),
+(242,50,o),
+(242,145,cs),
+(242,190,o),
+(231,244,o),
+(221,299,c),
+(320,299,l),
+(320,99,l),
+(270,99,l),
+(270,0,l),
+(494,0,l),
+(494,99,l),
+(444,99,l),
+(444,299,l),
+(542,299,l),
+(532,244,o),
+(521,190,o),
+(521,145,cs),
+(521,50,o),
+(564,0,o),
+(666,0,cs),
+(718,0,l),
+(718,126,l),
+(701,126,ls),
+(669,126,o),
+(656,147,o),
+(656,174,cs),
+(656,264,o),
+(713,413,o),
+(713,529,cs),
+(713,647,o),
+(642,728,o),
+(527,728,cs),
+(443,728,o),
+(387,682,o),
+(363,593,c),
+(402,593,l),
+(376,682,o),
+(320,728,o),
+(237,728,cs),
+(122,728,o),
+(51,647,o),
+(51,529,cs),
+(51,413,o),
+(108,264,o),
+(108,174,cs),
+(108,146,o),
+(94,126,o),
+(62,126,cs),
+(45,126,l),
+(45,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,454,o),
+(194,489,o),
+(194,515,cs),
+(194,567,o),
+(215,595,o),
+(254,595,cs),
+(295,595,o),
+(320,565,o),
+(320,501,cs),
+(320,414,l),
+(205,414,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(444,501,ls),
+(444,565,o),
+(469,595,o),
+(509,595,cs),
+(548,595,o),
+(569,567,o),
+(569,515,cs),
+(569,489,o),
+(564,454,o),
+(558,414,c),
+(444,414,l)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165C;
+unicode = 5724;
+},
+{
+color = 9;
+glyphname = "tseCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(525,-14,o),
+(596,69,o),
+(596,185,cs),
+(596,286,o),
+(545,355,o),
+(469,371,c),
+(469,343,l),
+(546,358,o),
+(596,427,o),
+(596,529,cs),
+(596,645,o),
+(525,728,o),
+(426,728,cs),
+(331,728,o),
+(251,635,o),
+(215,635,cs),
+(196,635,o),
+(187,647,o),
+(187,688,cs),
+(187,714,l),
+(55,714,l),
+(55,649,ls),
+(55,553,o),
+(104,514,o),
+(172,514,cs),
+(198,514,o),
+(224,523,o),
+(249,536,c),
+(202,548,l),
+(202,405,l),
+(132,405,l),
+(132,472,l),
+(55,472,l),
+(55,242,l),
+(132,242,l),
+(132,309,l),
+(202,309,l),
+(202,166,l),
+(250,178,l),
+(225,191,o),
+(198,200,o),
+(172,200,cs),
+(104,200,o),
+(55,161,o),
+(55,65,cs),
+(55,0,l),
+(187,0,l),
+(187,26,ls),
+(187,67,o),
+(196,79,o),
+(215,79,cs),
+(251,79,o),
+(331,-14,o),
+(426,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(356,117,o),
+(325,136,o),
+(292,156,c),
+(292,309,l),
+(361,309,ls),
+(420,309,o),
+(452,269,o),
+(452,208,cs),
+(452,153,o),
+(427,117,o),
+(382,117,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(292,558,l),
+(325,578,o),
+(356,597,o),
+(382,597,cs),
+(427,597,o),
+(452,561,o),
+(452,506,cs),
+(452,445,o),
+(419,405,o),
+(361,405,cs),
+(292,405,l)
+);
+}
+);
+width = 646;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni165D;
+unicode = 5725;
+},
+{
+color = 9;
+glyphname = "tseeCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(525,-14,o),
+(596,69,o),
+(596,185,cs),
+(596,286,o),
+(545,355,o),
+(469,371,c),
+(469,343,l),
+(546,358,o),
+(596,427,o),
+(596,529,cs),
+(596,645,o),
+(525,728,o),
+(426,728,cs),
+(331,728,o),
+(251,635,o),
+(215,635,cs),
+(196,635,o),
+(187,647,o),
+(187,688,cs),
+(187,714,l),
+(55,714,l),
+(55,649,ls),
+(55,553,o),
+(104,514,o),
+(172,514,cs),
+(190,514,o),
+(209,521,o),
+(228,529,c),
+(189,556,l),
+(189,403,l),
+(125,403,l),
+(125,472,l),
+(55,472,l),
+(55,242,l),
+(125,242,l),
+(125,311,l),
+(189,311,l),
+(189,156,l),
+(224,187,l),
+(207,194,o),
+(189,200,o),
+(172,200,cs),
+(104,200,o),
+(55,161,o),
+(55,65,cs),
+(55,0,l),
+(187,0,l),
+(187,26,ls),
+(187,67,o),
+(196,79,o),
+(215,79,cs),
+(251,79,o),
+(331,-14,o),
+(426,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(350,117,o),
+(311,146,o),
+(267,170,c),
+(267,311,l),
+(322,311,l),
+(322,215,l),
+(383,215,l),
+(383,335,l),
+(354,311,l),
+(384,311,ls),
+(434,311,o),
+(455,269,o),
+(455,215,cs),
+(455,153,o),
+(430,117,o),
+(382,117,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(383,496,l),
+(322,496,l),
+(322,403,l),
+(267,403,l),
+(267,544,l),
+(311,568,o),
+(350,597,o),
+(382,597,cs),
+(430,597,o),
+(455,561,o),
+(455,499,cs),
+(455,445,o),
+(433,403,o),
+(384,403,cs),
+(354,403,l),
+(383,379,l)
+);
+}
+);
+width = 646;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165E;
+unicode = 5726;
+},
+{
+color = 9;
+glyphname = "tsiCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(525,-14,o),
+(596,69,o),
+(596,185,cs),
+(596,286,o),
+(545,355,o),
+(469,371,c),
+(469,343,l),
+(546,358,o),
+(596,427,o),
+(596,529,cs),
+(596,645,o),
+(525,728,o),
+(426,728,cs),
+(331,728,o),
+(251,635,o),
+(215,635,cs),
+(196,635,o),
+(187,647,o),
+(187,688,cs),
+(187,714,l),
+(55,714,l),
+(55,649,ls),
+(55,552,o),
+(104,514,o),
+(172,514,cs),
+(194,514,o),
+(215,522,o),
+(237,531,c),
+(184,547,l),
+(184,403,l),
+(125,403,l),
+(125,472,l),
+(55,472,l),
+(55,242,l),
+(125,242,l),
+(125,311,l),
+(184,311,l),
+(184,167,l),
+(236,184,l),
+(214,192,o),
+(193,200,o),
+(172,200,cs),
+(104,200,o),
+(55,162,o),
+(55,65,cs),
+(55,0,l),
+(187,0,l),
+(187,26,ls),
+(187,67,o),
+(196,79,o),
+(215,79,cs),
+(251,79,o),
+(331,-14,o),
+(426,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(348,117,o),
+(308,148,o),
+(262,171,c),
+(262,311,l),
+(284,311,l),
+(296,277,o),
+(323,259,o),
+(354,259,cs),
+(403,259,o),
+(428,305,o),
+(431,345,c),
+(368,311,l),
+(387,311,ls),
+(435,311,o),
+(455,270,o),
+(455,215,cs),
+(455,153,o),
+(430,117,o),
+(382,117,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(429,411,o),
+(404,456,o),
+(354,456,cs),
+(323,456,o),
+(296,438,o),
+(284,403,c),
+(262,403,l),
+(262,543,l),
+(308,566,o),
+(348,597,o),
+(382,597,cs),
+(430,597,o),
+(455,561,o),
+(455,499,cs),
+(455,444,o),
+(434,403,o),
+(387,403,cs),
+(369,403,l),
+(431,363,l)
+);
+}
+);
+width = 646;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165F;
+unicode = 5727;
+},
+{
+color = 9;
+glyphname = "tsaCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(315,-14,o),
+(395,79,o),
+(431,79,cs),
+(450,79,o),
+(459,67,o),
+(459,26,cs),
+(459,0,l),
+(590.995,0,l),
+(591,65,ls),
+(591,161,o),
+(542,200,o),
+(474,200,cs),
+(448,200,o),
+(421,191,o),
+(396,178,c),
+(444,166,l),
+(444,309,l),
+(514,309,l),
+(514,242,l),
+(591,242,l),
+(591,472,l),
+(514,472,l),
+(514,405,l),
+(444,405,l),
+(444,548,l),
+(396,536,l),
+(422,523,o),
+(448,514,o),
+(474,514,cs),
+(542,514,o),
+(591,553,o),
+(591,649,cs),
+(590.995,714,l),
+(459,714,l),
+(459,688,ls),
+(459,647,o),
+(450,635,o),
+(431,635,cs),
+(395,635,o),
+(315,728,o),
+(220,728,cs),
+(121,728,o),
+(50,645,o),
+(50,529,cs),
+(50,427,o),
+(100,358,o),
+(177,343,c),
+(177,371,l),
+(100,355,o),
+(50,286,o),
+(50,185,cs),
+(50,69,o),
+(121,-14,o),
+(220,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(219,117,o),
+(194,153,o),
+(194,208,cs),
+(194,269,o),
+(226,309,o),
+(285,309,cs),
+(354,309,l),
+(354,156,l),
+(321,136,o),
+(290,117,o),
+(264,117,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(227,405,o),
+(194,445,o),
+(194,506,cs),
+(194,561,o),
+(219,597,o),
+(264,597,cs),
+(290,597,o),
+(321,578,o),
+(354,558,c),
+(354,405,l),
+(285,405,ls)
+);
+}
+);
+width = 646;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1660;
+unicode = 5728;
+},
+{
+color = 9;
+glyphname = "chuCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(320,-14,o),
+(376,32,o),
+(402,121,c),
+(363,121,l),
+(387,32,o),
+(444,-14,o),
+(527,-14,cs),
+(642,-14,o),
+(713,67,o),
+(713,185,cs),
+(713,301,o),
+(656,450,o),
+(656,540,cs),
+(656,568,o),
+(669,588,o),
+(701,588,cs),
+(718,588,l),
+(718,714,l),
+(666,714,ls),
+(564,714,o),
+(521,664,o),
+(521,569,cs),
+(521,450,o),
+(569,282,o),
+(569,199,cs),
+(569,147,o),
+(548,119,o),
+(509,119,cs),
+(469,119,o),
+(444,149,o),
+(444,213,cs),
+(444,615,l),
+(494,615,l),
+(494,714,l),
+(269,714,l),
+(269,615,l),
+(320,615,l),
+(320,213,ls),
+(320,149,o),
+(295,119,o),
+(255,119,cs),
+(216,119,o),
+(195,147,o),
+(195,199,cs),
+(195,282,o),
+(243,450,o),
+(243,569,cs),
+(243,664,o),
+(200,714,o),
+(98,714,cs),
+(45,714,l),
+(45,588,l),
+(62,588,ls),
+(94,588,o),
+(108,567,o),
+(108,540,cs),
+(108,450,o),
+(51,301,o),
+(51,185,cs),
+(51,67,o),
+(122,-14,o),
+(237,-14,cs)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164E;
+unicode = 5729;
+},
+{
+color = 9;
+glyphname = "choCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(98,0,ls),
+(200,0,o),
+(242,50,o),
+(242,145,cs),
+(242,264,o),
+(194,432,o),
+(194,515,cs),
+(194,567,o),
+(215,595,o),
+(254,595,cs),
+(295,595,o),
+(320,565,o),
+(320,501,cs),
+(320,99,l),
+(270,99,l),
+(270,0,l),
+(494,0,l),
+(494,99,l),
+(444,99,l),
+(444,501,ls),
+(444,565,o),
+(469,595,o),
+(509,595,cs),
+(548,595,o),
+(569,567,o),
+(569,515,cs),
+(569,432,o),
+(521,264,o),
+(521,145,cs),
+(521,50,o),
+(564,0,o),
+(666,0,cs),
+(718,0,l),
+(718,126,l),
+(701,126,ls),
+(669,126,o),
+(656,147,o),
+(656,174,cs),
+(656,264,o),
+(713,413,o),
+(713,529,cs),
+(713,647,o),
+(642,728,o),
+(527,728,cs),
+(443,728,o),
+(387,682,o),
+(363,593,c),
+(402,593,l),
+(376,682,o),
+(320,728,o),
+(237,728,cs),
+(122,728,o),
+(51,647,o),
+(51,529,cs),
+(51,413,o),
+(108,264,o),
+(108,174,cs),
+(108,146,o),
+(94,126,o),
+(62,126,cs),
+(45,126,l),
+(45,0,l)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5730;
+},
+{
+color = 9;
+glyphname = "cheCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(525,-14,o),
+(596,69,o),
+(596,185,cs),
+(596,286,o),
+(545,355,o),
+(469,371,c),
+(469,343,l),
+(546,358,o),
+(596,427,o),
+(596,529,cs),
+(596,645,o),
+(525,728,o),
+(426,728,cs),
+(331,728,o),
+(251,635,o),
+(215,635,cs),
+(196,635,o),
+(187,647,o),
+(187,688,cs),
+(187,714,l),
+(55,714,l),
+(55,646,ls),
+(55,550,o),
+(104,511,o),
+(172,511,cs),
+(253,511,o),
+(325,597,o),
+(380,597,cs),
+(425,597,o),
+(450,562,o),
+(450,508,cs),
+(450,448,o),
+(417,416,o),
+(359,416,cs),
+(132,416,l),
+(132,472,l),
+(55,472,l),
+(55,242,l),
+(132,242,l),
+(132,299,l),
+(359,299,ls),
+(417,299,o),
+(450,266,o),
+(450,206,cs),
+(450,152,o),
+(425,117,o),
+(380,117,cs),
+(325,117,o),
+(253,203,o),
+(172,203,cs),
+(104,203,o),
+(55,164,o),
+(55,68,cs),
+(55,0,l),
+(187,0,l),
+(187,26,ls),
+(187,67,o),
+(196,79,o),
+(215,79,cs),
+(251,79,o),
+(331,-14,o),
+(426,-14,cs)
+);
+}
+);
+width = 646;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni1663;
+unicode = 5731;
+},
+{
+color = 9;
+glyphname = "cheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(525,-14,o),
+(596,69,o),
+(596,185,cs),
+(596,286,o),
+(545,355,o),
+(469,371,c),
+(469,343,l),
+(546,358,o),
+(596,427,o),
+(596,529,cs),
+(596,645,o),
+(525,728,o),
+(426,728,cs),
+(331,728,o),
+(251,635,o),
+(215,635,cs),
+(196,635,o),
+(187,647,o),
+(187,688,cs),
+(187,714,l),
+(55,714,l),
+(55,646,ls),
+(55,550,o),
+(104,511,o),
+(172,511,cs),
+(254,511,o),
+(328,600,o),
+(384,600,cs),
+(429,600,o),
+(454,564,o),
+(454,508,cs),
+(454,447,o),
+(428,405,o),
+(378,405,cs),
+(323,405,l),
+(356,387,l),
+(356,488,l),
+(280,488,l),
+(280,405,l),
+(132,405,l),
+(132,472,l),
+(55,472,l),
+(55,242,l),
+(132,242,l),
+(132,309,l),
+(280,309,l),
+(280,223,l),
+(356,223,l),
+(356,327,l),
+(323,309,l),
+(378,309,ls),
+(428,309,o),
+(454,267,o),
+(454,206,cs),
+(454,150,o),
+(429,114,o),
+(384,114,cs),
+(328,114,o),
+(254,203,o),
+(172,203,cs),
+(104,203,o),
+(55,164,o),
+(55,68,cs),
+(55,0,l),
+(187,0,l),
+(187,26,ls),
+(187,67,o),
+(196,79,o),
+(215,79,cs),
+(251,79,o),
+(331,-14,o),
+(426,-14,cs)
+);
+}
+);
+width = 646;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1664;
+unicode = 5732;
+},
+{
+color = 9;
+glyphname = "chiCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(525,-14,o),
+(596,69,o),
+(596,185,cs),
+(596,286,o),
+(545,355,o),
+(469,371,c),
+(469,343,l),
+(546,358,o),
+(596,427,o),
+(596,529,cs),
+(596,645,o),
+(525,728,o),
+(426,728,cs),
+(331,728,o),
+(251,635,o),
+(215,635,cs),
+(196,635,o),
+(187,647,o),
+(187,688,cs),
+(187,714,l),
+(55,714,l),
+(55,646,ls),
+(55,550,o),
+(104,511,o),
+(172,511,cs),
+(254,511,o),
+(328,600,o),
+(384,600,cs),
+(429,600,o),
+(454,564,o),
+(454,508,cs),
+(454,447,o),
+(428,405,o),
+(379,405,cs),
+(317,405,l),
+(386,361,l),
+(383,415,o),
+(345,456,o),
+(291,456,cs),
+(254,456,o),
+(223,435,o),
+(207,405,c),
+(132,405,l),
+(132,472,l),
+(55,472,l),
+(55,242,l),
+(132,242,l),
+(132,309,l),
+(207,309,l),
+(223,279,o),
+(254,259,o),
+(291,259,cs),
+(345,259,o),
+(382,301,o),
+(388,351,c),
+(316,309,l),
+(379,309,ls),
+(428,309,o),
+(454,267,o),
+(454,206,cs),
+(454,150,o),
+(429,114,o),
+(384,114,cs),
+(328,114,o),
+(254,203,o),
+(172,203,cs),
+(104,203,o),
+(55,164,o),
+(55,68,cs),
+(55,0,l),
+(187,0,l),
+(187,26,ls),
+(187,67,o),
+(196,79,o),
+(215,79,cs),
+(251,79,o),
+(331,-14,o),
+(426,-14,cs)
+);
+}
+);
+width = 646;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1665;
+unicode = 5733;
+},
+{
+color = 9;
+glyphname = "chaCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(315,-14,o),
+(395,79,o),
+(431,79,cs),
+(450,79,o),
+(459,67,o),
+(459,26,cs),
+(459,0,l),
+(590.995,0,l),
+(590.995,67.998,ls),
+(591,164,o),
+(542,203,o),
+(474,203,cs),
+(393,203,o),
+(321,117,o),
+(266,117,cs),
+(221,117,o),
+(196,152,o),
+(196,206,cs),
+(196,266,o),
+(229,299,o),
+(287,299,cs),
+(514,299,l),
+(514,242,l),
+(591,242,l),
+(591,472,l),
+(514,472,l),
+(514,416,l),
+(287,416,ls),
+(229,416,o),
+(196,448,o),
+(196,508,cs),
+(196,562,o),
+(221,597,o),
+(265,597,cs),
+(321,597,o),
+(393,511,o),
+(474,511,cs),
+(542,511,o),
+(591,550,o),
+(590.995,646.002,cs),
+(590.995,714,l),
+(459,714,l),
+(459,688,ls),
+(459,647,o),
+(450,635,o),
+(431,635,cs),
+(395,635,o),
+(315,728,o),
+(220,728,cs),
+(121,728,o),
+(50,645,o),
+(50,529,cs),
+(50,427,o),
+(100,358,o),
+(177,343,c),
+(177,371,l),
+(100,355,o),
+(50,286,o),
+(50,185,cs),
+(50,69,o),
+(121,-14,o),
+(220,-14,cs)
+);
+}
+);
+width = 646;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1666;
+unicode = 5734;
+},
+{
+color = 9;
+glyphname = "ttsuCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(320,-14,o),
+(376,32,o),
+(402,121,c),
+(363,121,l),
+(387,32,o),
+(444,-14,o),
+(527,-14,cs),
+(642,-14,o),
+(713,67,o),
+(713,185,cs),
+(713,301,o),
+(656,450,o),
+(656,540,cs),
+(656,568,o),
+(669,588,o),
+(701,588,cs),
+(718,588,l),
+(718,714,l),
+(666,714,ls),
+(564,714,o),
+(521,664,o),
+(521,569,cs),
+(521,533,o),
+(526,492,o),
+(529,450,c),
+(579,564,l),
+(444,455,l),
+(444,615,l),
+(494,615,l),
+(494,714,l),
+(269,714,l),
+(269,615,l),
+(320,615,l),
+(320,454,l),
+(186,564,l),
+(234,450,l),
+(238,493,o),
+(243,533,o),
+(243,569,cs),
+(243,664,o),
+(200,714,o),
+(98,714,cs),
+(45,714,l),
+(45,588,l),
+(62,588,ls),
+(94,588,o),
+(108,567,o),
+(108,540,cs),
+(108,450,o),
+(51,301,o),
+(51,185,cs),
+(51,67,o),
+(122,-14,o),
+(237,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(216,119,o),
+(195,147,o),
+(195,199,cs),
+(195,248,o),
+(212,320,o),
+(225,395,c),
+(320,320,l),
+(320,213,ls),
+(320,149,o),
+(295,119,o),
+(255,119,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(469,119,o),
+(444,149,o),
+(444,213,cs),
+(444,320,l),
+(539,395,l),
+(552,320,o),
+(569,248,o),
+(569,199,cs),
+(569,147,o),
+(548,119,o),
+(509,119,cs)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1667;
+unicode = 5735;
+},
+{
+color = 9;
+glyphname = "ttsoCarrier-canadian";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(98,0,ls),
+(200,0,o),
+(243,50,o),
+(243,145,cs),
+(243,181,o),
+(238,221,o),
+(234,264,c),
+(186,150,l),
+(320,260,l),
+(320,99,l),
+(269,99,l),
+(269,0,l),
+(494,0,l),
+(494,99,l),
+(444,99,l),
+(444,259,l),
+(579,150,l),
+(529,264,l),
+(526,222,o),
+(521,181,o),
+(521,145,cs),
+(521,50,o),
+(564,0,o),
+(666,0,cs),
+(718,0,l),
+(718,126,l),
+(701,126,ls),
+(669,126,o),
+(656,146,o),
+(656,174,cs),
+(656,264,o),
+(713,413,o),
+(713,529,cs),
+(713,647,o),
+(642,728,o),
+(527,728,cs),
+(444,728,o),
+(387,682,o),
+(363,593,c),
+(402,593,l),
+(376,682,o),
+(320,728,o),
+(237,728,cs),
+(122,728,o),
+(51,647,o),
+(51,529,cs),
+(51,413,o),
+(108,264,o),
+(108,174,cs),
+(108,147,o),
+(94,126,o),
+(62,126,cs),
+(45,126,l),
+(45,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(212,394,o),
+(195,466,o),
+(195,515,cs),
+(195,567,o),
+(216,595,o),
+(255,595,cs),
+(295,595,o),
+(320,565,o),
+(320,501,cs),
+(320,394,l),
+(225,319,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(444,394,l),
+(444,501,ls),
+(444,565,o),
+(469,595,o),
+(509,595,cs),
+(548,595,o),
+(569,567,o),
+(569,515,cs),
+(569,466,o),
+(552,394,o),
+(539,319,c)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1668;
+unicode = 5736;
+},
+{
+color = 9;
+glyphname = "ttseCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(525,-14,o),
+(596,69,o),
+(596,185,cs),
+(596,286,o),
+(545,355,o),
+(469,371,c),
+(469,343,l),
+(546,358,o),
+(596,427,o),
+(596,529,cs),
+(596,645,o),
+(525,728,o),
+(426,728,cs),
+(331,728,o),
+(251,635,o),
+(215,635,cs),
+(196,635,o),
+(187,647,o),
+(187,688,cs),
+(187,714,l),
+(55,714,l),
+(55,646,ls),
+(55,550,o),
+(104,511,o),
+(172,511,cs),
+(191,511,o),
+(209,516,o),
+(224,524,c),
+(136,579,l),
+(201,405,l),
+(132,405,l),
+(132,472,l),
+(55,472,l),
+(55,242,l),
+(132,242,l),
+(132,309,l),
+(201,309,l),
+(136,135,l),
+(225,190,l),
+(208,198,o),
+(191,203,o),
+(172,203,cs),
+(104,203,o),
+(55,164,o),
+(55,68,cs),
+(55,0,l),
+(187,0,l),
+(187,26,ls),
+(187,67,o),
+(196,79,o),
+(215,79,cs),
+(251,79,o),
+(331,-14,o),
+(426,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(345,114,o),
+(299,157,o),
+(252,179,c),
+(298,309,l),
+(379,309,ls),
+(428,309,o),
+(454,267,o),
+(454,206,cs),
+(454,150,o),
+(429,114,o),
+(384,114,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(252,535,l),
+(299,557,o),
+(345,600,o),
+(384,600,cs),
+(429,600,o),
+(454,564,o),
+(454,508,cs),
+(454,447,o),
+(428,405,o),
+(379,405,cs),
+(298,405,l)
+);
+}
+);
+width = 646;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1669;
+unicode = 5737;
+},
+{
+color = 9;
+glyphname = "ttseeCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(525,-14,o),
+(596,69,o),
+(596,185,cs),
+(596,286,o),
+(545,355,o),
+(469,371,c),
+(469,343,l),
+(546,358,o),
+(596,427,o),
+(596,529,cs),
+(596,645,o),
+(525,728,o),
+(426,728,cs),
+(331,728,o),
+(251,635,o),
+(215,635,cs),
+(196,635,o),
+(187,647,o),
+(187,688,cs),
+(187,714,l),
+(55,714,l),
+(55,646,ls),
+(55,550,o),
+(104,511,o),
+(172,511,cs),
+(186,511,o),
+(202,513,o),
+(210,520,c),
+(131,575,l),
+(195,405,l),
+(132,405,l),
+(132,472,l),
+(55,472,l),
+(55,242,l),
+(132,242,l),
+(132,309,l),
+(195,309,l),
+(131,139,l),
+(209,194,l),
+(201,201,o),
+(186,203,o),
+(172,203,cs),
+(104,203,o),
+(55,164,o),
+(55,68,cs),
+(55,0,l),
+(187,0,l),
+(187,26,ls),
+(187,67,o),
+(196,79,o),
+(215,79,cs),
+(251,79,o),
+(331,-14,o),
+(426,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(342,114,o),
+(293,162,o),
+(241,185,c),
+(286,309,l),
+(320,309,l),
+(320,215,l),
+(388,215,l),
+(388,329,l),
+(361,309,l),
+(379,309,ls),
+(428,309,o),
+(454,267,o),
+(454,206,cs),
+(454,150,o),
+(429,114,o),
+(384,114,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(388,496,l),
+(320,496,l),
+(320,405,l),
+(286,405,l),
+(241,529,l),
+(293,552,o),
+(342,600,o),
+(384,600,cs),
+(429,600,o),
+(454,564,o),
+(454,508,cs),
+(454,447,o),
+(428,405,o),
+(379,405,cs),
+(361,405,l),
+(388,385,l)
+);
+}
+);
+width = 646;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166A;
+unicode = 5738;
+},
+{
+color = 9;
+glyphname = "ttsiCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(525,-14,o),
+(596,69,o),
+(596,185,cs),
+(596,286,o),
+(545,355,o),
+(469,371,c),
+(469,343,l),
+(546,358,o),
+(596,427,o),
+(596,529,cs),
+(596,645,o),
+(525,728,o),
+(426,728,cs),
+(331,728,o),
+(251,635,o),
+(215,635,cs),
+(196,635,o),
+(187,647,o),
+(187,688,cs),
+(187,714,l),
+(55,714,l),
+(55,646,ls),
+(55,550,o),
+(104,511,o),
+(172,511,cs),
+(185,511,o),
+(195,512,o),
+(213,520,c),
+(145,537,l),
+(195,405,l),
+(132,405,l),
+(132,472,l),
+(55,472,l),
+(55,242,l),
+(132,242,l),
+(132,309,l),
+(195,309,l),
+(140,163,l),
+(211,195,l),
+(194,202,o),
+(184,203,o),
+(172,203,cs),
+(104,203,o),
+(55,164,o),
+(55,68,cs),
+(55,0,l),
+(187,0,l),
+(187,26,ls),
+(187,67,o),
+(196,79,o),
+(215,79,cs),
+(251,79,o),
+(331,-14,o),
+(426,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(342,114,o),
+(281,170,o),
+(229,191,c),
+(272,309,l),
+(274,309,l),
+(288,279,o),
+(315,259,o),
+(348,259,cs),
+(386,259,o),
+(417,288,o),
+(426,327,c),
+(359,309,l),
+(388,309,ls),
+(436,309,o),
+(454,267,o),
+(454,206,cs),
+(454,150,o),
+(429,114,o),
+(384,114,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(419,427,o),
+(388,456,o),
+(347,456,cs),
+(314,456,o),
+(287,435,o),
+(274,405,c),
+(272,405,l),
+(229,523,l),
+(281,544,o),
+(342,600,o),
+(384,600,cs),
+(429,600,o),
+(454,564,o),
+(454,508,cs),
+(454,447,o),
+(435,405,o),
+(388,405,cs),
+(360,405,l),
+(427,385,l)
+);
+}
+);
+width = 646;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166B;
+unicode = 5739;
+},
+{
+color = 9;
+glyphname = "ttsaCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(315,-14,o),
+(395,79,o),
+(431,79,cs),
+(450,79,o),
+(459,67,o),
+(459,26,cs),
+(459,0,l),
+(590.995,0,l),
+(590.995,67.998,ls),
+(591,164,o),
+(542,203,o),
+(474,203,cs),
+(455,203,o),
+(438,198,o),
+(421,190,c),
+(510,135,l),
+(445,309,l),
+(514,309,l),
+(514,242,l),
+(591,242,l),
+(591,472,l),
+(514,472,l),
+(514,405,l),
+(445,405,l),
+(510,579,l),
+(421,524,l),
+(437,516,o),
+(455,511,o),
+(474,511,cs),
+(542,511,o),
+(591,550,o),
+(590.995,646.002,cs),
+(590.995,714,l),
+(459,714,l),
+(459,688,ls),
+(459,647,o),
+(450,635,o),
+(431,635,cs),
+(395,635,o),
+(315,728,o),
+(220,728,cs),
+(121,728,o),
+(50,645,o),
+(50,529,cs),
+(50,427,o),
+(100,358,o),
+(177,343,c),
+(177,371,l),
+(100,355,o),
+(50,286,o),
+(50,185,cs),
+(50,69,o),
+(121,-14,o),
+(220,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(217,114,o),
+(192,150,o),
+(192,206,cs),
+(192,267,o),
+(218,309,o),
+(267,309,cs),
+(347,309,l),
+(394,179,l),
+(347,157,o),
+(301,114,o),
+(262,114,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(218,405,o),
+(192,447,o),
+(192,508,cs),
+(192,564,o),
+(217,600,o),
+(262,600,cs),
+(301,600,o),
+(347,557,o),
+(394,535,c),
+(347,405,l),
+(267,405,ls)
+);
+}
+);
+width = 646;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni166C;
+unicode = 5740;
+},
+{
+glyphname = "qai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (287,0);
+ref = "ke-canadian";
+}
+);
+width = 816;
+}
+);
+note = uni166F;
+unicode = 5743;
+},
+{
+glyphname = "ngai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (535,0);
+ref = "ce-canadian";
+}
+);
+width = 1052;
+}
+);
+note = uni1670;
+unicode = 5744;
+},
+{
+glyphname = "nngi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (796,0);
+ref = "ci-canadian";
+}
+);
+width = 1312;
+}
+);
+note = uni1671;
+unicode = 5745;
+},
+{
+glyphname = "nngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (796,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (977,0);
+ref = dot_top;
+}
+);
+width = 1312;
+}
+);
+note = uni1672;
+unicode = 5746;
+},
+{
+glyphname = "nngo-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (796,0);
+ref = "ce-canadian";
+}
+);
+width = 1312;
+}
+);
+note = uni1673;
+unicode = 5747;
+},
+{
+glyphname = "nngoo-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (796,0);
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (963,0);
+ref = dot_top;
+}
+);
+width = 1312;
+}
+);
+note = uni1674;
+unicode = 5748;
+},
+{
+glyphname = "nnga-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (796,0);
+ref = "ca-canadian";
+}
+);
+width = 1312;
+}
+);
+note = uni1675;
+unicode = 5749;
+},
+{
+glyphname = "nngaa-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (796,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (832,0);
+ref = dot_top;
+}
+);
+width = 1312;
+}
+);
+note = uni1676;
+unicode = 5750;
+},
+{
+glyphname = "thweeWoodScree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (543,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 754;
+}
+);
+note = uni1677;
+unicode = 5751;
+},
+{
+glyphname = "thwiWoodScree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (543,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 754;
+}
+);
+note = uni1678;
+unicode = 5752;
+},
+{
+glyphname = "thwiiWoodScree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (73,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (543,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 754;
+}
+);
+note = uni1679;
+unicode = 5753;
+},
+{
+glyphname = "thwoWoodScree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (543,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 754;
+}
+);
+note = uni167A;
+unicode = 5754;
+},
+{
+glyphname = "thwooWoodScree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (298,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (543,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 754;
+}
+);
+note = uni167B;
+unicode = 5755;
+},
+{
+glyphname = "thwaWoodScree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = middle_right_can;
+pos = (543,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 754;
+}
+);
+note = uni167C;
+unicode = 5756;
+},
+{
+glyphname = "thwaaWoodScree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (73,0);
+ref = dot_top;
+},
+{
+anchor = middle_right_can;
+pos = (543,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 754;
+}
+);
+note = uni167D;
+unicode = 5757;
+},
+{
+glyphname = "wBlackfoot-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(326,567,l),
+(326,650,l),
+(45,650,l),
+(45,567,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(326,421,l),
+(326,504,l),
+(45,504,l),
+(45,421,l)
+);
+}
+);
+width = 371;
+}
+);
+metricRight = "=|";
+note = uni167F;
+unicode = 5759;
+},
+{
+glyphname = "oy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-11,0);
+ref = ring_top.canadian;
+}
+);
+width = 592;
+}
+);
+note = uni18B0;
+unicode = 6320;
+},
+{
+glyphname = "ay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (355,0);
+ref = ring_top.canadian;
+}
+);
+width = 592;
+}
+);
+note = uni18B1;
+unicode = 6321;
+},
+{
+glyphname = "aay-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (136,0);
+ref = ring_top.canadian;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (389,0);
+ref = dot_top;
+}
+);
+width = 592;
+}
+);
+note = uni18B2;
+unicode = 6322;
+},
+{
+glyphname = "way-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (565,0);
+ref = ring_top.canadian;
+}
+);
+width = 803;
+}
+);
+note = uni18B3;
+unicode = 6323;
+},
+{
+glyphname = "poy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-22,0);
+ref = ring_top.canadian;
+}
+);
+width = 573;
+}
+);
+note = uni18B4;
+unicode = 6324;
+},
+{
+glyphname = "pay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (353,0);
+ref = ring_top.canadian;
+}
+);
+width = 573;
+}
+);
+note = uni18B5;
+unicode = 6325;
+},
+{
+glyphname = "pwoy-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (188,0);
+ref = ring_top.canadian;
+}
+);
+width = 784;
+}
+);
+note = uni18B6;
+unicode = 6326;
+},
+{
+glyphname = "tay-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (175,0);
+ref = ring_top.canadian;
+}
+);
+width = 540;
+}
+);
+note = uni18B7;
+unicode = 6327;
+},
+{
+glyphname = "kay-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (2,0);
+ref = ring_top.canadian;
+}
+);
+width = 529;
+}
+);
+note = uni18B8;
+unicode = 6328;
+},
+{
+glyphname = "kway-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (213,0);
+ref = ring_top.canadian;
+}
+);
+width = 740;
+}
+);
+note = uni18B9;
+unicode = 6329;
+},
+{
+glyphname = "may-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (6,0);
+ref = ring_top.canadian;
+}
+);
+width = 486;
+}
+);
+note = uni18BA;
+unicode = 6330;
+},
+{
+glyphname = "noy-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (322,-188);
+ref = ring_top.canadian;
+}
+);
+width = 708;
+}
+);
+note = uni18BB;
+unicode = 6331;
+},
+{
+glyphname = "nay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (143,-188);
+ref = ring_top.canadian;
+}
+);
+width = 708;
+}
+);
+note = uni18BC;
+unicode = 6332;
+},
+{
+glyphname = "lay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (143,-188);
+ref = ring_top.canadian;
+}
+);
+width = 708;
+}
+);
+note = uni18BD;
+unicode = 6333;
+},
+{
+glyphname = "soy-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (240,0);
+ref = ring_top.canadian;
+}
+);
+width = 489;
+}
+);
+note = uni18BE;
+unicode = 6334;
+},
+{
+glyphname = "say-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (6,0);
+ref = ring_top.canadian;
+}
+);
+width = 489;
+}
+);
+note = uni18BF;
+unicode = 6335;
+},
+{
+glyphname = "shoy-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (277,-188);
+ref = ring_top.canadian;
+}
+);
+width = 796;
+}
+);
+note = uni18C0;
+unicode = 6336;
+},
+{
+glyphname = "shay-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (277,-188);
+ref = ring_top.canadian;
+}
+);
+width = 796;
+}
+);
+note = uni18C1;
+unicode = 6337;
+},
+{
+glyphname = "shwoy-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (488,-188);
+ref = ring_top.canadian;
+}
+);
+width = 1007;
+}
+);
+note = uni18C2;
+unicode = 6338;
+},
+{
+glyphname = "yoy-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (263,0);
+ref = ring_top.canadian;
+}
+);
+width = 510;
+}
+);
+note = uni18C3;
+unicode = 6339;
+},
+{
+glyphname = "yay-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (5,0);
+ref = ring_top.canadian;
+}
+);
+width = 510;
+}
+);
+note = uni18C4;
+unicode = 6340;
+},
+{
+glyphname = "ray-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (152,0);
+ref = ring_top.canadian;
+}
+);
+width = 490;
+}
+);
+note = uni18C5;
+unicode = 6341;
+},
+{
+glyphname = "nwi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ni-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni18C6;
+unicode = 6342;
+},
+{
+glyphname = "nwiOjibway-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (708,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni18C7;
+unicode = 6343;
+},
+{
+glyphname = "nwii-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (407,-188);
+ref = dot_top;
+}
+);
+width = 919;
+}
+);
+note = uni18C8;
+unicode = 6344;
+},
+{
+glyphname = "nwiiOjibway-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (196,-188);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (708,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni18C9;
+unicode = 6345;
+},
+{
+glyphname = "nwo-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "no-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni18CA;
+unicode = 6346;
+},
+{
+glyphname = "nwoOjibway-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (708,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni18CB;
+unicode = 6347;
+},
+{
+glyphname = "nwoo-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (568,-188);
+ref = dot_top;
+}
+);
+width = 919;
+}
+);
+note = uni18CC;
+unicode = 6348;
+},
+{
+glyphname = "nwooOjibway-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (357,-188);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (708,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 919;
+}
+);
+note = uni18CD;
+unicode = 6349;
+},
+{
+glyphname = "rwee-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "reRCree-canadian";
+}
+);
+width = 955;
+}
+);
+note = uni18CE;
+unicode = 6350;
+},
+{
+glyphname = "rwi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ri-canadian";
+}
+);
+width = 955;
+}
+);
+note = uni18CF;
+unicode = 6351;
+},
+{
+glyphname = "rwii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (396,-188);
+ref = dot_top;
+}
+);
+width = 955;
+}
+);
+note = uni18D0;
+unicode = 6352;
+},
+{
+glyphname = "rwo-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ro-canadian";
+}
+);
+width = 701;
+}
+);
+note = uni18D1;
+unicode = 6353;
+},
+{
+glyphname = "rwoo-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (341,0);
+ref = dot_top;
+}
+);
+width = 701;
+}
+);
+note = uni18D2;
+unicode = 6354;
+},
+{
+glyphname = "rwa-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = "ra-canadian";
+}
+);
+width = 701;
+}
+);
+note = uni18D3;
+unicode = 6355;
+},
+{
+glyphname = "pOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(117,357,l),
+(207,604,l),
+(145,604,l),
+(233.009,357,l),
+(324,357,l),
+(324,375,l),
+(186,714,l),
+(164,714,l),
+(25,375,l),
+(25,357,l)
+);
+}
+);
+width = 350;
+}
+);
+metricLeft = "kkCarrier-canadian";
+note = uni18D4;
+unicode = 6356;
+},
+{
+glyphname = "tOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 375;
+}
+);
+metricRight = "=|";
+note = uni1422;
+unicode = 6357;
+},
+{
+glyphname = "kOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(143,357,l),
+(143,506,l),
+(122,506,l),
+(127,472,o),
+(155,449,o),
+(191,449,cs),
+(249,449,o),
+(293,496,o),
+(293,578,cs),
+(293,675,o),
+(238,720,o),
+(171,720,cs),
+(90,720,o),
+(45,666,o),
+(45,584,cs),
+(45,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(150,520,o),
+(134,537,o),
+(134,585,cs),
+(134,633,o),
+(149,649,o),
+(170,649,cs),
+(190,649,o),
+(206,632,o),
+(206,584,cs),
+(206,536,o),
+(190,520,o),
+(170,520,cs)
+);
+}
+);
+width = 328;
+}
+);
+metricLeft = "k-canadian";
+metricRight = "k-canadian";
+note = uni18D6;
+unicode = 6358;
+},
+{
+glyphname = "cOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(143,357,l),
+(143,601,ls),
+(143,629,o),
+(152,644,o),
+(173,644,cs),
+(192,644,o),
+(205,628,o),
+(205,603,cs),
+(205,564,l),
+(295,564,l),
+(295,588,ls),
+(295,672,o),
+(247,720,o),
+(171,720,cs),
+(89,720,o),
+(45,673,o),
+(45,584,cs),
+(45.005,357,l)
+);
+}
+);
+width = 319;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni18D7;
+unicode = 6359;
+},
+{
+glyphname = "mOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(143,357,l),
+(143,622,l),
+(266,622,l),
+(266,714,l),
+(45.005,714,l),
+(45.005,357,l)
+);
+}
+);
+width = 294;
+}
+);
+metricLeft = "m-canadian";
+metricRight = "m-canadian";
+note = uni18D8;
+unicode = 6360;
+},
+{
+glyphname = "nOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(235,443,o),
+(278,494,o),
+(278,573,cs),
+(278,616,o),
+(264,652,o),
+(247,664,c),
+(242,622,l),
+(377,622,l),
+(377,714,l),
+(162,714,ls),
+(80,714,o),
+(35,660,o),
+(35,579,cs),
+(35,495,o),
+(80,443,o),
+(157,443,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(135,514,o),
+(121,533,o),
+(121,579,cs),
+(121,624,o),
+(135,643,o),
+(157,643,cs),
+(179,643,o),
+(192,624,o),
+(192,579,cs),
+(192,534,o),
+(179,514,o),
+(157,514,cs)
+);
+}
+);
+width = 406;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "n-canadian";
+note = uni18D9;
+unicode = 6361;
+},
+{
+glyphname = "sOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(143,357,l),
+(143,503,l),
+(78,466,l),
+(116,466,ls),
+(208,466,o),
+(268,527,o),
+(268,640,cs),
+(268,714,l),
+(170,714,l),
+(170,644,ls),
+(170,572,o),
+(141,542,o),
+(75,542,cs),
+(45,542,l),
+(45.005,357,l)
+);
+}
+);
+width = 313;
+}
+);
+metricLeft = "s-canadian";
+metricRight = "s-canadian";
+note = uni18DA;
+unicode = 6362;
+},
+{
+color = 1;
+glyphname = "shOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(224,351,o),
+(266,398,o),
+(271,484,cs),
+(279,596,ls),
+(281,629,o),
+(289,645,o),
+(309,645,cs),
+(330,645,o),
+(340,629,o),
+(340,595,cs),
+(340,564,l),
+(430,564,l),
+(430,591,ls),
+(430,676,o),
+(387,720,o),
+(311,720,cs),
+(229.997,720,o),
+(188,673,o),
+(183,587,cs),
+(175,475,ls),
+(173,442,o),
+(165,426,o),
+(145,426,cs),
+(124,426,o),
+(114,442,o),
+(114,476,cs),
+(114,507,l),
+(24,507,l),
+(24,480,ls),
+(24,395,o),
+(67,351,o),
+(143,351,cs)
+);
+}
+);
+width = 454;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "c-canadian";
+note = uni18DB;
+unicode = 6363;
+},
+{
+color = 9;
+glyphname = "easternw-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (16,-318);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (156,0);
+ref = "glottalstop-canadian";
+}
+);
+width = 525;
+}
+);
+note = uni18DC;
+unicode = 6364;
+},
+{
+color = 9;
+glyphname = "westernw-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (504,-318);
+ref = dot_top;
+scale = (-1,1);
+},
+{
+alignment = -1;
+pos = (373,0);
+ref = "glottalstop-canadian";
+scale = (-1,1);
+}
+);
+width = 525;
+}
+);
+metricLeft = "glottalstop-canadian";
+note = uni18DD;
+unicode = 6365;
+},
+{
+glyphname = "rweRCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "reRCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (744,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 955;
+}
+);
+note = uni18E0;
+unicode = 6368;
+},
+{
+glyphname = "looWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (41,0);
+ref = dot_top;
+}
+);
+width = 490;
+}
+);
+note = uni18E1;
+unicode = 6369;
+},
+{
+glyphname = "laaWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (277,0);
+ref = dot_top;
+}
+);
+width = 490;
+}
+);
+note = uni18E2;
+unicode = 6370;
+},
+{
+glyphname = "thwe-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "the-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (649,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 860;
+}
+);
+note = uni18E3;
+unicode = 6371;
+},
+{
+glyphname = "thwa-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (594,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 804;
+}
+);
+note = uni18E4;
+unicode = 6372;
+},
+{
+glyphname = "tthwe-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "tthe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (641,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 852;
+}
+);
+note = uni18E5;
+unicode = 6373;
+},
+{
+glyphname = "tthoo-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ttho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (193,0);
+ref = dot_top;
+}
+);
+width = 552;
+}
+);
+note = uni18E6;
+unicode = 6374;
+},
+{
+glyphname = "tthaa-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ttha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (186,0);
+ref = dot_top;
+}
+);
+width = 552;
+}
+);
+note = uni18E7;
+unicode = 6375;
+},
+{
+glyphname = "tlhwe-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "tlhe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (543,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 754;
+}
+);
+note = uni18E8;
+unicode = 6376;
+},
+{
+glyphname = "tlhoo-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "tlho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (192,0);
+ref = dot_top;
+}
+);
+width = 543;
+}
+);
+note = uni18E9;
+unicode = 6377;
+},
+{
+glyphname = "shweSayisi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "sheSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (539,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 750;
+}
+);
+note = uni18EA;
+unicode = 6378;
+},
+{
+glyphname = "shooSayisi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "shoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (329,0);
+ref = dot_top;
+}
+);
+width = 539;
+}
+);
+note = uni18EB;
+unicode = 6379;
+},
+{
+color = 9;
+glyphname = "hooSayisi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "hoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (404,0);
+ref = dot_top;
+}
+);
+width = 616;
+}
+);
+note = uni18EC;
+unicode = 6380;
+},
+{
+color = 9;
+glyphname = "gwuCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "guCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (745,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 956;
+}
+);
+note = uni18ED;
+unicode = 6381;
+},
+{
+color = 9;
+glyphname = "deneGeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "geCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (238,0);
+ref = dot_top;
+}
+);
+width = 644;
+}
+);
+note = uni18EE;
+unicode = 6382;
+},
+{
+color = 9;
+glyphname = "gaaCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (250,0);
+ref = dot_top;
+}
+);
+width = 644;
+}
+);
+note = uni18EF;
+unicode = 6383;
+},
+{
+color = 9;
+glyphname = "gwaCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (644,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 855;
+}
+);
+note = uni18F0;
+unicode = 6384;
+},
+{
+color = 9;
+glyphname = "juuSayisi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "juSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (237,0);
+ref = dot_top;
+}
+);
+width = 642;
+}
+);
+note = uni18F1;
+unicode = 6385;
+},
+{
+color = 9;
+glyphname = "jwaCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "jaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (693,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 904;
+}
+);
+note = uni18F2;
+unicode = 6386;
+},
+{
+glyphname = "lBeaverDene-canadian";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+ref = "pWestCree-canadian";
+}
+);
+width = 188;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+unicode = 6387;
+},
+{
+glyphname = "rBeaverDene-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(143,357,l),
+(143,542,ls),
+(143,593,o),
+(163,618,o),
+(200,618,cs),
+(212,618,l),
+(212,720,l),
+(202,720,ls),
+(159,720,o),
+(131,680,o),
+(128,628,c),
+(134,628,l),
+(134,714,l),
+(45.005,714,l),
+(45.005,357,l)
+);
+}
+);
+width = 239;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni18F4;
+unicode = 6388;
+},
+{
+color = 6;
+glyphname = "sDentalCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(192,189,ls),
+(274,189,o),
+(316,229,o),
+(316,297,cs),
+(316,364,o),
+(277,406,o),
+(205,406,cs),
+(176,406,ls),
+(149,406,o),
+(134,414,o),
+(134,437,cs),
+(134,461,o),
+(150,470,o),
+(176,470,cs),
+(310,470,l),
+(310,546,l),
+(169,546,ls),
+(87,546,o),
+(45,506,o),
+(45,438,cs),
+(45,372,o),
+(84,330,o),
+(156,330,cs),
+(185,330,ls),
+(211,330,o),
+(227,321,o),
+(227,298,cs),
+(227,275,o),
+(212,266,o),
+(185,266,cs),
+(51,266,l),
+(51,189,l)
+);
+}
+);
+width = 361;
+}
+);
+metricLeft = "shCarrier-canadian";
+metricRight = "=|";
+note = uni18F5;
+unicode = 6389;
+},
+{
+glyphname = "pWestCree-canadian.base";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "pWestCree-canadian";
+}
+);
+width = 188;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.base";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "c-canadian";
+}
+);
+width = 319;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "thSayisi-canadian.base";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "thSayisi-canadian";
+}
+);
+width = 320;
+}
+);
+metricLeft = "=|c-canadian";
+note = uni14A2;
+},
+{
+glyphname = "mWestCree-canadian.base";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "mWestCree-canadian";
+}
+);
+width = 315;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+glyphname = "pWestCree-canadian.mid";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "pWestCree-canadian";
+}
+);
+width = 188;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.mid";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "c-canadian";
+}
+);
+width = 319;
+}
+);
+metricLeft = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "mWestCree-canadian.mid";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "mWestCree-canadian";
+}
+);
+width = 315;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+color = 11;
+glyphname = "ngaai-canadian.nunavik";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (572,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (720,0);
+ref = ring_top.canadian;
+}
+);
+width = 1093;
+}
+);
+note = uni158E;
+},
+{
+color = 11;
+glyphname = "ngi-canadian.nunavik";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (572,0);
+ref = "ci-canadian";
+}
+);
+width = 1093;
+}
+);
+note = uni158F;
+},
+{
+color = 11;
+glyphname = "ngii-canadian.nunavik";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (572,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (754,0);
+ref = dot_top;
+}
+);
+width = 1093;
+}
+);
+note = uni1590;
+},
+{
+color = 11;
+glyphname = "ngo-canadian.nunavik";
+lastChange = "2023-01-13 15:31:20 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (572,0);
+ref = "co-canadian";
+}
+);
+width = 1092;
+}
+);
+note = uni1591;
+},
+{
+color = 11;
+glyphname = "ngoo-canadian.nunavik";
+lastChange = "2023-01-13 15:31:20 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+ref = "ngo-canadian.nunavik";
+},
+{
+anchor = top_right_can;
+pos = (882,0);
+ref = dot_top;
+}
+);
+width = 1092;
+}
+);
+note = uni1592;
+},
+{
+color = 11;
+glyphname = "nga-canadian.nunavik";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (572,0);
+ref = "ca-canadian";
+}
+);
+width = 1093;
+}
+);
+note = uni1593;
+},
+{
+color = 11;
+glyphname = "ngaa-canadian.nunavik";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (572,0);
+ref = "ca-canadian";
+},
+{
+anchor = top_left_can;
+pos = (610,0);
+ref = dot_top;
+}
+);
+width = 1093;
+}
+);
+note = uni1594;
+},
+{
+color = 11;
+glyphname = "ng-canadian.nunavik";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(483,173,o),
+(537,218,o),
+(537,314,cs),
+(537,397,o),
+(493,444,o),
+(436,444,cs),
+(401,444,o),
+(375,423,o),
+(368,389,c),
+(387,388,l),
+(387,542,l),
+(245,542,l),
+(251,504,l),
+(266,516,o),
+(278,550,o),
+(278,590,cs),
+(278,670,o),
+(235,720,o),
+(157,720,cs),
+(80,720,o),
+(35.005,668.007,o),
+(35,585,cs),
+(35,503,o),
+(80,449,o),
+(162,449,cs),
+(355,449,l),
+(290,515,l),
+(290,309,ls),
+(290,227,o),
+(335,173,o),
+(416,173,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(394,244,o),
+(379,260,o),
+(379,308,cs),
+(379,356,o),
+(395,373,o),
+(415,373,cs),
+(435,373,o),
+(451,357,o),
+(451,309,cs),
+(451,261,o),
+(435,244,o),
+(415,244,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(135,520,o),
+(121,539,o),
+(121,585,cs),
+(121,631,o),
+(135,649,o),
+(157,649,cs),
+(179,649,o),
+(192,629,o),
+(192,584,cs),
+(192,540,o),
+(179,520,o),
+(157,520,cs)
+);
+}
+);
+width = 572;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+color = 11;
+glyphname = "ngai-canadian.nunavik";
+lastChange = "2023-01-13 15:31:20 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (572,0);
+ref = "ce-canadian";
+}
+);
+width = 1092;
+}
+);
+note = uni1670;
+},
+{
+color = 11;
+glyphname = "ke-canadian.square";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (313,714);
+},
+{
+name = top_left_can;
+pos = (124,714);
+},
+{
+name = top_right_can;
+pos = (507,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(580,0,l),
+(580,714,l),
+(365,714,ls),
+(161,714,o),
+(45,606,o),
+(45,424,cs),
+(45,243,o),
+(161,135,o),
+(365,135,cs),
+(433,135,l),
+(433,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(246,265,o),
+(193,321,o),
+(193,424,cs),
+(193,528,o),
+(246,585,o),
+(356,585,cs),
+(433,585,l),
+(433,265,l),
+(356,265,ls)
+);
+}
+);
+width = 633;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146B;
+},
+{
+color = 11;
+glyphname = "ki-canadian.square";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (321,714);
+},
+{
+name = top_left_can;
+pos = (127,714);
+},
+{
+name = top_right_can;
+pos = (515,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,0,l),
+(200,135,l),
+(269,135,ls),
+(473,135,o),
+(588,243,o),
+(588,424,cs),
+(588,606,o),
+(473,714,o),
+(269,714,cs),
+(53,714,l),
+(53,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,585,l),
+(277,585,ls),
+(387,585,o),
+(441,528,o),
+(441,424,cs),
+(441,321,o),
+(387,265,o),
+(277,265,cs),
+(200,265,l)
+);
+}
+);
+width = 633;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni146D;
+},
+{
+color = 11;
+glyphname = "kii-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (234,0);
+ref = dot_top;
+}
+);
+width = 632;
+}
+);
+note = uni146E;
+},
+{
+color = 11;
+glyphname = "ko-canadian.square";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (313,714);
+},
+{
+name = top_left_can;
+pos = (124,714);
+},
+{
+name = top_right_can;
+pos = (507,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(580,0,l),
+(580,714,l),
+(433,714,l),
+(433,579,l),
+(365,579,ls),
+(161,579,o),
+(45,471,o),
+(45,290,cs),
+(45,108,o),
+(161,0,o),
+(365,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(246,129,o),
+(193,186,o),
+(193,290,cs),
+(193,393,o),
+(246,449,o),
+(356,449,cs),
+(433,449,l),
+(433,129,l),
+(356,129,ls)
+);
+}
+);
+width = 633;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146F;
+},
+{
+color = 11;
+glyphname = "koo-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (420,0);
+ref = dot_top;
+}
+);
+width = 632;
+}
+);
+note = uni1470;
+},
+{
+color = 11;
+glyphname = "ka-canadian.square";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (321,714);
+},
+{
+name = top_left_can;
+pos = (127,714);
+},
+{
+name = top_right_can;
+pos = (515,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(269,0,ls),
+(473,0,o),
+(588,108,o),
+(588,290,cs),
+(588,471,o),
+(473,579,o),
+(269,579,cs),
+(200,579,l),
+(200,714,l),
+(53,714,l),
+(53,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,449,l),
+(277,449,ls),
+(387,449,o),
+(441,393,o),
+(441,290,cs),
+(441,186,o),
+(387,129,o),
+(277,129,cs),
+(200,129,l)
+);
+}
+);
+width = 633;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1472;
+},
+{
+color = 11;
+glyphname = "kaa-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (41,0);
+ref = dot_top;
+}
+);
+width = 632;
+}
+);
+note = uni1473;
+},
+{
+color = 11;
+glyphname = "kweWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (632,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 843;
+}
+);
+note = uni1475;
+},
+{
+color = 11;
+glyphname = "kwiiWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (234,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (632,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 843;
+}
+);
+note = uni1479;
+},
+{
+color = 11;
+glyphname = "kwoWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (632,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 843;
+}
+);
+note = uni147B;
+},
+{
+color = 11;
+glyphname = "kwooWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (420,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (632,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 843;
+}
+);
+note = uni147D;
+},
+{
+color = 11;
+glyphname = "kwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (632,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 843;
+}
+);
+note = uni147F;
+},
+{
+color = 11;
+glyphname = "kwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (41,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (632,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 843;
+}
+);
+note = uni1481;
+},
+{
+color = 11;
+glyphname = "ce-canadian.square";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (307,714);
+},
+{
+name = top_left_can;
+pos = (111,714);
+},
+{
+name = top_right_can;
+pos = (504,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(577,0,l),
+(577,435,ls),
+(577,627,o),
+(478,728,o),
+(306,728,cs),
+(132,728,o),
+(37,627,o),
+(37,440,cs),
+(37,395,l),
+(183,395,l),
+(183,449,ls),
+(183,547,o),
+(226,593,o),
+(306,593,cs),
+(387,593,o),
+(430,544,o),
+(430,441,cs),
+(430,0,l)
+);
+}
+);
+width = 627;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni1489;
+},
+{
+color = 11;
+glyphname = "ci-canadian.square";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (320,714);
+},
+{
+name = top_left_can;
+pos = (125,714);
+},
+{
+name = top_right_can;
+pos = (518,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(198,0,l),
+(198,441,ls),
+(198,544,o),
+(241,593,o),
+(322,593,cs),
+(401,593,o),
+(444,547,o),
+(444,449,cs),
+(444,395,l),
+(590,395,l),
+(590,440,ls),
+(590,627,o),
+(495,728,o),
+(322,728,cs),
+(149,728,o),
+(50,627,o),
+(50,435,cs),
+(50,0,l)
+);
+}
+);
+width = 627;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+},
+{
+color = 11;
+glyphname = "cii-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (234,0);
+ref = dot_top;
+}
+);
+width = 628;
+}
+);
+note = uni148C;
+},
+{
+color = 11;
+glyphname = "co-canadian.square";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (307,714);
+},
+{
+name = top_left_can;
+pos = (111,714);
+},
+{
+name = top_right_can;
+pos = (504,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(478,-14,o),
+(577,87,o),
+(577,279,cs),
+(577,714,l),
+(430,714,l),
+(430,273,ls),
+(430,170,o),
+(387,121,o),
+(306,121,cs),
+(226,121,o),
+(183,167,o),
+(183,265,cs),
+(183,319,l),
+(37,319,l),
+(37,274,ls),
+(37,87,o),
+(132,-14,o),
+(306,-14,cs)
+);
+}
+);
+width = 627;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+},
+{
+color = 11;
+glyphname = "coo-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (417,0);
+ref = dot_top;
+}
+);
+width = 628;
+}
+);
+note = uni148E;
+},
+{
+color = 11;
+glyphname = "ca-canadian.square";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (320,714);
+},
+{
+name = top_left_can;
+pos = (125,714);
+},
+{
+name = top_right_can;
+pos = (518,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(495,-14,o),
+(590,87,o),
+(590,274,cs),
+(590,319,l),
+(444,319,l),
+(444,265,ls),
+(444,167,o),
+(401,121,o),
+(322,121,cs),
+(241,121,o),
+(198,170,o),
+(198,273,cs),
+(198,714,l),
+(50,714,l),
+(50,279,ls),
+(50,87,o),
+(149,-14,o),
+(322,-14,cs)
+);
+}
+);
+width = 627;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+},
+{
+color = 11;
+glyphname = "caa-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (38,0);
+ref = dot_top;
+}
+);
+width = 628;
+}
+);
+note = uni1491;
+},
+{
+color = 11;
+glyphname = "me-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (266,714);
+},
+{
+name = top_double;
+pos = (418,714);
+},
+{
+name = top_left_can;
+pos = (105,714);
+},
+{
+name = top_right_can;
+pos = (418,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(491,0,l),
+(491,714,l),
+(32,714,l),
+(32,580,l),
+(344,580,l),
+(344,0,l)
+);
+}
+);
+width = 544;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+},
+{
+color = 11;
+glyphname = "mi-canadian.square";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (283,714);
+},
+{
+name = top_left_can;
+pos = (127,714);
+},
+{
+name = top_right_can;
+pos = (438,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,0,l),
+(200,580,l),
+(513,580,l),
+(513,714,l),
+(53,714,l),
+(53,0,l)
+);
+}
+);
+width = 545;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+},
+{
+color = 11;
+glyphname = "mii-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (197,0);
+ref = dot_top;
+}
+);
+width = 544;
+}
+);
+note = uni14A6;
+},
+{
+color = 11;
+glyphname = "mo-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (266,714);
+},
+{
+name = top_double;
+pos = (418,714);
+},
+{
+name = top_left_can;
+pos = (105,714);
+},
+{
+name = top_right_can;
+pos = (418,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(491,0,l),
+(491,714,l),
+(344,714,l),
+(344,134,l),
+(32,134,l),
+(32,0,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+},
+{
+color = 11;
+glyphname = "moo-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (331,0);
+ref = dot_top;
+}
+);
+width = 544;
+}
+);
+note = uni14A8;
+},
+{
+color = 11;
+glyphname = "ma-canadian.square";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (283,714);
+},
+{
+name = top_left_can;
+pos = (127,714);
+},
+{
+name = top_right_can;
+pos = (438,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(513,0,l),
+(513,134,l),
+(200,134,l),
+(200,714,l),
+(53,714,l),
+(53,0,l)
+);
+}
+);
+width = 545;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+},
+{
+color = 11;
+glyphname = "maa-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (41,0);
+ref = dot_top;
+}
+);
+width = 544;
+}
+);
+note = uni14AB;
+},
+{
+color = 11;
+glyphname = "ne-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (392,714);
+},
+{
+name = top_left_can;
+pos = (231,714);
+},
+{
+name = top_right_can;
+pos = (555,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(544,-14,o),
+(628,78,o),
+(628,240,cs),
+(628,714,l),
+(38,714,l),
+(38,582,l),
+(158,582,l),
+(158,241,ls),
+(158,78,o),
+(241,-14,o),
+(393,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(333,121,o),
+(304,158,o),
+(304,230,cs),
+(304,582,l),
+(481,582,l),
+(481,230,ls),
+(481,159,o),
+(452,121,o),
+(393,121,cs)
+);
+}
+);
+width = 678;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C0;
+},
+{
+color = 11;
+glyphname = "ni-canadian.square";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (285,714);
+},
+{
+name = top_left_can;
+pos = (124,714);
+},
+{
+name = top_right_can;
+pos = (447,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(437,-14,o),
+(520,78,o),
+(520,241,cs),
+(520,582,l),
+(639,582,l),
+(639,714,l),
+(50,714,l),
+(50,240,ls),
+(50,78,o),
+(134,-14,o),
+(285,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(225,121,o),
+(196,159,o),
+(196,230,cs),
+(196,582,l),
+(374,582,l),
+(374,230,ls),
+(374,158,o),
+(345,121,o),
+(285,121,cs)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+},
+{
+color = 11;
+glyphname = "nii-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (199,0);
+ref = dot_top;
+}
+);
+width = 678;
+}
+);
+note = uni14C3;
+},
+{
+color = 11;
+glyphname = "no-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (393,714);
+},
+{
+name = top_double;
+pos = (403,714);
+},
+{
+name = top_left_can;
+pos = (231,714);
+},
+{
+name = top_right_can;
+pos = (532,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(628,0,l),
+(628,474,ls),
+(628,636,o),
+(544,728,o),
+(393,728,cs),
+(241,728,o),
+(158,636,o),
+(158,473,cs),
+(158,132,l),
+(38,132,l),
+(38,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(304,484,ls),
+(304,556,o),
+(333,593,o),
+(393,593,cs),
+(452,593,o),
+(481,555,o),
+(481,484,cs),
+(481,132,l),
+(304,132,l)
+);
+}
+);
+width = 678;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C4;
+},
+{
+color = 11;
+glyphname = "noo-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (306,0);
+ref = dot_top;
+}
+);
+width = 678;
+}
+);
+note = uni14C5;
+},
+{
+color = 11;
+glyphname = "na-canadian.square";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (285,714);
+},
+{
+name = top_double;
+pos = (295,714);
+},
+{
+name = top_left_can;
+pos = (124,714);
+},
+{
+name = top_right_can;
+pos = (447,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(639,0,l),
+(639,132,l),
+(520,132,l),
+(520,473,ls),
+(520,636,o),
+(437,728,o),
+(285,728,cs),
+(134,728,o),
+(50,636,o),
+(50,474,cs),
+(50,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(196,484,ls),
+(196,555,o),
+(225,593,o),
+(285,593,cs),
+(345,593,o),
+(374,556,o),
+(374,484,cs),
+(374,132,l),
+(196,132,l)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+},
+{
+color = 11;
+glyphname = "naa-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (199,0);
+ref = dot_top;
+}
+);
+width = 678;
+}
+);
+note = uni14C8;
+},
+{
+color = 11;
+glyphname = "nweWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (678,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 889;
+}
+);
+note = uni14CA;
+},
+{
+color = 11;
+glyphname = "nwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (678,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 889;
+}
+);
+note = uni14CC;
+},
+{
+color = 11;
+glyphname = "nwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (199,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (678,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 889;
+}
+);
+note = uni14CE;
+},
+{
+color = 11;
+glyphname = "se-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (127,714);
+},
+{
+name = top_right_can;
+pos = (517,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(582,0,l),
+(582,305,l),
+(390,305,ls),
+(264,305,o),
+(200,366,o),
+(200,495,cs),
+(200,714,l),
+(53,714,l),
+(53,493,ls),
+(53,288,o),
+(178,175,o),
+(393,175,cs),
+(473,175,l),
+(435,212,l),
+(435.005,0,l)
+);
+}
+);
+width = 636;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14ED;
+},
+{
+color = 11;
+glyphname = "si-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (128,714);
+},
+{
+name = top_right_can;
+pos = (518,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(201,0,l),
+(201,212,l),
+(163,175,l),
+(244,175,ls),
+(458,175,o),
+(583,288,o),
+(583,477,cs),
+(583,714,l),
+(436,714,l),
+(436,479,ls),
+(436,366,o),
+(372,305,o),
+(252,305,cs),
+(54,305,l),
+(54,0,l)
+);
+}
+);
+width = 636;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+},
+{
+color = 11;
+glyphname = "sii-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (432,0);
+ref = dot_top;
+}
+);
+width = 636;
+}
+);
+note = uni14F0;
+},
+{
+color = 11;
+glyphname = "so-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (509,714);
+},
+{
+name = top_left_can;
+pos = (127,714);
+},
+{
+name = top_right_can;
+pos = (509,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,0,l),
+(200,219,ls),
+(200,348,o),
+(264,409,o),
+(390,409,cs),
+(582,409,l),
+(582,714,l),
+(435.005,714,l),
+(435,502,l),
+(473,539,l),
+(393,539,ls),
+(178,539,o),
+(53,426,o),
+(53,221,cs),
+(53,0,l)
+);
+}
+);
+width = 636;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+},
+{
+color = 11;
+glyphname = "soo-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (423,0);
+ref = dot_top;
+}
+);
+width = 636;
+}
+);
+note = uni14F2;
+},
+{
+color = 11;
+glyphname = "sa-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (128,714);
+},
+{
+name = top_right_can;
+pos = (510,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(583,0,l),
+(583,221,ls),
+(583,426,o),
+(458,539,o),
+(244,539,cs),
+(163,539,l),
+(201,502,l),
+(201,714,l),
+(54,714,l),
+(54,409,l),
+(246,409,ls),
+(372,409,o),
+(436,348,o),
+(436,219,cs),
+(436,0,l)
+);
+}
+);
+width = 636;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+},
+{
+color = 11;
+glyphname = "saa-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (42,0);
+ref = dot_top;
+}
+);
+width = 636;
+}
+);
+note = uni14F5;
+},
+{
+color = 11;
+glyphname = "sho-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (316,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(575,0,l),
+(575,120,l),
+(290,120,ls),
+(226,120,o),
+(193,149,o),
+(193,208,cs),
+(193,268,o),
+(224,298,o),
+(290,298,cs),
+(371,298,ls),
+(510,298,o),
+(587,374,o),
+(587,507,cs),
+(587,639,o),
+(510,714,o),
+(371,714,cs),
+(57,714,l),
+(57,594,l),
+(342,594,ls),
+(406,594,o),
+(439,565,o),
+(439,507,cs),
+(439,448,o),
+(408,417,o),
+(342,417,cs),
+(261,417,ls),
+(122,417,o),
+(45,340,o),
+(45,207,cs),
+(45,75,o),
+(122,0,o),
+(261,0,cs)
+);
+}
+);
+width = 632;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+color = 11;
+glyphname = "shoo-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (230,0);
+ref = dot_top;
+}
+);
+width = 632;
+}
+);
+note = g728;
+},
+{
+color = 11;
+glyphname = "sha-canadian.square";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (317,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(371,0,ls),
+(510,0,o),
+(586,75,o),
+(586,207,cs),
+(586,340,o),
+(510,417,o),
+(371,417,cs),
+(290,417,ls),
+(224,417,o),
+(193,448,o),
+(193,506,cs),
+(193,565,o),
+(225,594,o),
+(290,594,cs),
+(575,594,l),
+(575,714,l),
+(261,714,ls),
+(122,714,o),
+(45,639,o),
+(45,507,cs),
+(45,374,o),
+(122,298,o),
+(261,298,cs),
+(342,298,ls),
+(407,298,o),
+(439,268,o),
+(439,207,cs),
+(439,149,o),
+(406,120,o),
+(342,120,cs),
+(57,120,l),
+(57,0,l)
+);
+}
+);
+width = 631;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+color = 11;
+glyphname = "shaa-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (230,0);
+ref = dot_top;
+}
+);
+width = 632;
+}
+);
+note = g730;
+},
+{
+color = 11;
+glyphname = "ye-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (104,714);
+},
+{
+name = top_right_can;
+pos = (525,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(599,0,l),
+(599,304,l),
+(247,304,l),
+(247,241,l),
+(622,633,l),
+(519,726,l),
+(27,214,l),
+(27,175,l),
+(451,175,l),
+(451,0,l)
+);
+}
+);
+width = 650;
+}
+);
+metricLeft = "ye-canadian";
+note = uni1526;
+},
+{
+color = 11;
+glyphname = "yi-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (125,714);
+},
+{
+name = top_right_can;
+pos = (546,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(199,0,l),
+(199,175,l),
+(623,175,l),
+(623,214,l),
+(131,726,l),
+(28,633,l),
+(403,241,l),
+(403,304,l),
+(51,304,l),
+(51,0,l)
+);
+}
+);
+width = 650;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni1528;
+},
+{
+color = 11;
+glyphname = "yii-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (39,0);
+ref = dot_top;
+}
+);
+width = 650;
+}
+);
+note = uni1529;
+},
+{
+color = 11;
+glyphname = "yo-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (525,714);
+},
+{
+name = top_left_can;
+pos = (104,714);
+},
+{
+name = top_right_can;
+pos = (525,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(622,81,l),
+(247,473,l),
+(247,410,l),
+(599,410,l),
+(599,714,l),
+(451,714,l),
+(451,539,l),
+(27,539,l),
+(27,500,l),
+(519,-12,l)
+);
+}
+);
+width = 650;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152A;
+},
+{
+color = 11;
+glyphname = "yoo-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (439,0);
+ref = dot_top;
+}
+);
+width = 650;
+}
+);
+note = uni152B;
+},
+{
+color = 11;
+glyphname = "ya-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (126,714);
+},
+{
+name = top_right_can;
+pos = (546,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(623,500,l),
+(623,539,l),
+(199,539,l),
+(199,714,l),
+(51,714,l),
+(51,410,l),
+(403,410,l),
+(403,473,l),
+(28,81,l),
+(131,-12,l)
+);
+}
+);
+width = 650;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152D;
+},
+{
+color = 11;
+glyphname = "yaa-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (39,0);
+ref = dot_top;
+}
+);
+width = 650;
+}
+);
+note = uni152E;
+},
+{
+color = 11;
+glyphname = "re-canadian.square";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (285,714);
+},
+{
+name = top_left_can;
+pos = (124,714);
+},
+{
+name = top_right_can;
+pos = (447,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(439,-14,o),
+(520,78,o),
+(520,241,cs),
+(520,582,l),
+(639,582,l),
+(639,714,l),
+(374,714,l),
+(374,230,ls),
+(374,158,o),
+(345,121,o),
+(285,121,cs),
+(225,121,o),
+(196,159,o),
+(196,230,cs),
+(196,714,l),
+(50,714,l),
+(50,240,ls),
+(50,78,o),
+(134,-14,o),
+(285,-14,cs)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1542;
+},
+{
+color = 11;
+glyphname = "reRCree-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (393,714);
+},
+{
+name = top_left_can;
+pos = (231,714);
+},
+{
+name = top_right_can;
+pos = (555,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(544,-14,o),
+(628,78,o),
+(628,240,cs),
+(628,714,l),
+(481,714,l),
+(481,230,ls),
+(481,159,o),
+(452,121,o),
+(393,121,cs),
+(333,121,o),
+(304,158,o),
+(304,230,cs),
+(304,714,l),
+(38,714,l),
+(38,582,l),
+(158,582,l),
+(158,241,ls),
+(158,78,o),
+(239,-14,o),
+(393,-14,cs)
+);
+}
+);
+width = 678;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni1543;
+},
+{
+color = 11;
+glyphname = "leWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (393,714);
+},
+{
+name = top_left_can;
+pos = (231,714);
+},
+{
+name = top_right_can;
+pos = (555,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(304,-1,l),
+(304,483,ls),
+(304,556,o),
+(333,593,o),
+(393,593,cs),
+(452,593,o),
+(481,554,o),
+(481,483,cs),
+(481,-1,l),
+(628,-1,l),
+(628,473,ls),
+(628,635,o),
+(544,728,o),
+(393,728,cs),
+(239,728,o),
+(158,635,o),
+(158,472,cs),
+(158,132,l),
+(38,132,l),
+(38,-1,l)
+);
+}
+);
+width = 678;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+},
+{
+color = 11;
+glyphname = "ri-canadian.square";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (285,714);
+},
+{
+name = top_left_can;
+pos = (125,714);
+},
+{
+name = top_right_can;
+pos = (447,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(196,0,l),
+(196,484,ls),
+(196,555,o),
+(225,593,o),
+(285,593,cs),
+(345,593,o),
+(374,556,o),
+(374,484,cs),
+(374,0,l),
+(639,0,l),
+(639,132,l),
+(520,132,l),
+(520,473,ls),
+(520,636,o),
+(439,728,o),
+(285,728,cs),
+(134,728,o),
+(50,636,o),
+(50,474,cs),
+(50,0,l)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+},
+{
+color = 11;
+glyphname = "rii-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (199,0);
+ref = dot_top;
+}
+);
+width = 678;
+}
+);
+note = uni1547;
+},
+{
+color = 11;
+glyphname = "ro-canadian.square";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (314,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,0,l),
+(200,173,l),
+(149,135,l),
+(253,135,ls),
+(457,135,o),
+(572,243,o),
+(572,424,cs),
+(572,606,o),
+(457,714,o),
+(253,714,cs),
+(53,714,l),
+(53,585,l),
+(262,585,ls),
+(371,585,o),
+(425,528,o),
+(425,424,cs),
+(425,321,o),
+(371,265,o),
+(262,265,cs),
+(53,265,l),
+(53,0,l)
+);
+}
+);
+width = 617;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1548;
+},
+{
+color = 11;
+glyphname = "loWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (313,714);
+},
+{
+name = top_left_can;
+pos = (127,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(253,0,ls),
+(457,0,o),
+(572,108,o),
+(572,290,cs),
+(572,471,o),
+(457,579,o),
+(253,579,cs),
+(149,579,l),
+(200,541,l),
+(200,714,l),
+(53,714,l),
+(53,449,l),
+(262,449,ls),
+(371,449,o),
+(425,393,o),
+(425,290,cs),
+(425,186,o),
+(371,129,o),
+(262,129,cs),
+(53,129,l),
+(53,0,l)
+);
+}
+);
+width = 609;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+},
+{
+color = 11;
+glyphname = "ra-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (296,714);
+},
+{
+name = top_right_can;
+pos = (483,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(556,0,l),
+(556,265,l),
+(347,265,ls),
+(238,265,o),
+(184,321,o),
+(184,424,cs),
+(184,528,o),
+(238,585,o),
+(347,585,cs),
+(556,585,l),
+(556,714,l),
+(356,714,ls),
+(152,714,o),
+(37,606,o),
+(37,424,cs),
+(37,243,o),
+(152,135,o),
+(356,135,cs),
+(459,135,l),
+(408,173,l),
+(408,0,l)
+);
+}
+);
+width = 609;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+},
+{
+color = 11;
+glyphname = "raa-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (210,0);
+ref = dot_top;
+}
+);
+width = 609;
+}
+);
+note = uni154C;
+},
+{
+color = 11;
+glyphname = "laWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (483,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(556,0,l),
+(556,129,l),
+(347,129,ls),
+(238,129,o),
+(184,186,o),
+(184,290,cs),
+(184,393,o),
+(238,449,o),
+(347,449,cs),
+(556,449,l),
+(556,714,l),
+(408,714,l),
+(408,541,l),
+(459,579,l),
+(356,579,ls),
+(152,579,o),
+(37,471,o),
+(37,290,cs),
+(37,108,o),
+(152,0,o),
+(356,0,cs)
+);
+}
+);
+width = 609;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+},
+{
+color = 11;
+glyphname = "reWestCree-canadian.square";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(560,0,l),
+(772,206,l),
+(684,299,l),
+(482,104,l),
+(577,98,l),
+(577,435,ls),
+(577,627,o),
+(478,728,o),
+(306,728,cs),
+(132,728,o),
+(37,627,o),
+(37,440,cs),
+(37,395,l),
+(183,395,l),
+(183,449,ls),
+(183,547,o),
+(226,593,o),
+(306,593,cs),
+(387,593,o),
+(430,544,o),
+(430,441,cs),
+(430,0,l)
+);
+}
+);
+width = 788;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+},
+{
+color = 11;
+glyphname = "riWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(358,0,l),
+(358,441,ls),
+(358,544,o),
+(401,593,o),
+(482,593,cs),
+(561,593,o),
+(604,547,o),
+(604,449,cs),
+(604,395,l),
+(750,395,l),
+(750,440,ls),
+(750,627,o),
+(655,728,o),
+(482,728,cs),
+(309,728,o),
+(210,627,o),
+(210,435,cs),
+(210,98,l),
+(305,104,l),
+(103,299,l),
+(16,206,l),
+(228,0,l)
+);
+}
+);
+width = 787;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+},
+{
+color = 11;
+glyphname = "roWestCree-canadian.square";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(478,-14,o),
+(577,87,o),
+(577,279,cs),
+(577,616,l),
+(482,610,l),
+(684,415,l),
+(772,508,l),
+(560,714,l),
+(430,714,l),
+(430,273,ls),
+(430,170,o),
+(387,121,o),
+(306,121,cs),
+(226,121,o),
+(183,167,o),
+(183,265,cs),
+(183,319,l),
+(37,319,l),
+(37,274,ls),
+(37,87,o),
+(132,-14,o),
+(306,-14,cs)
+);
+}
+);
+width = 788;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+},
+{
+color = 11;
+glyphname = "raWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(655,-14,o),
+(750,87,o),
+(750,274,cs),
+(750,319,l),
+(604,319,l),
+(604,265,ls),
+(604,167,o),
+(561,121,o),
+(482,121,cs),
+(401,121,o),
+(358,170,o),
+(358,273,cs),
+(358,714,l),
+(228,714,l),
+(16,508,l),
+(103,415,l),
+(305,610,l),
+(210,616,l),
+(210,279,ls),
+(210,87,o),
+(309,-14,o),
+(482,-14,cs)
+);
+}
+);
+width = 787;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+},
+{
+color = 11;
+glyphname = "theThCree-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (104,714);
+},
+{
+name = top_right_can;
+pos = (525,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(451,55,l),
+(451,0,l),
+(599,0,l),
+(599,55,l),
+(678,55,l),
+(678,122,l),
+(599,122,l),
+(599,304,l),
+(247,304,l),
+(247,241,l),
+(622,633,l),
+(519,726,l),
+(27,214,l),
+(27,175,l),
+(451,175,l),
+(451,122,l),
+(268,122,l),
+(268,55,l)
+);
+}
+);
+width = 703;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15A7;
+},
+{
+color = 11;
+glyphname = "thiThCree-canadian.square";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (176,714);
+},
+{
+name = top_right_can;
+pos = (596,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(252,0,l),
+(252,55,l),
+(434,55,l),
+(434,122,l),
+(252,122,l),
+(252,175,l),
+(675,175,l),
+(675,214,l),
+(183,726,l),
+(81,633,l),
+(455,241,l),
+(455,304,l),
+(104,304,l),
+(104,122,l),
+(25,122,l),
+(25,55,l),
+(104,55,l),
+(104,0,l)
+);
+}
+);
+width = 702;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+},
+{
+color = 11;
+glyphname = "thiiThCree-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (89,0);
+ref = dot_top;
+}
+);
+width = 703;
+}
+);
+note = uni15A9;
+},
+{
+color = 11;
+glyphname = "thoThCree-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (104,714);
+},
+{
+name = top_right_can;
+pos = (525,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(622,81,l),
+(247,473,l),
+(247,410,l),
+(599,410,l),
+(599,592,l),
+(678,592,l),
+(678,659,l),
+(599,659,l),
+(599,714,l),
+(451,714,l),
+(451,659,l),
+(268,659,l),
+(268,592,l),
+(451,592,l),
+(451,539,l),
+(27,539,l),
+(27,500,l),
+(519,-12,l)
+);
+}
+);
+width = 703;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+},
+{
+color = 11;
+glyphname = "thooThCree-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (439,0);
+ref = dot_top;
+}
+);
+width = 703;
+}
+);
+note = uni15AB;
+},
+{
+color = 11;
+glyphname = "thaThCree-canadian.square";
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (178,714);
+},
+{
+name = top_right_can;
+pos = (599,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(675,500,l),
+(675,539,l),
+(252,539,l),
+(252,592,l),
+(434,592,l),
+(434,659,l),
+(252,659,l),
+(252,714,l),
+(104,714,l),
+(104,659,l),
+(25,659,l),
+(25,592,l),
+(104,592,l),
+(104,410,l),
+(455,410,l),
+(455,473,l),
+(81,81,l),
+(183,-12,l)
+);
+}
+);
+width = 702;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+},
+{
+color = 11;
+glyphname = "thaaThCree-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (92,0);
+ref = dot_top;
+}
+);
+width = 703;
+}
+);
+note = uni15AD;
+},
+{
+color = 11;
+glyphname = "thweeWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (703,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 914;
+}
+);
+note = uni1677;
+},
+{
+color = 11;
+glyphname = "thwiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (703,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 914;
+}
+);
+note = uni1678;
+},
+{
+color = 11;
+glyphname = "thwiiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (89,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (703,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 914;
+}
+);
+note = uni1679;
+},
+{
+color = 11;
+glyphname = "thwoWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (703,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 914;
+}
+);
+note = uni167A;
+},
+{
+color = 11;
+glyphname = "thwooWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (439,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (703,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 914;
+}
+);
+note = uni167B;
+},
+{
+color = 11;
+glyphname = "thwaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (703,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 914;
+}
+);
+note = uni167C;
+},
+{
+color = 11;
+glyphname = "thwaaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (92,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (703,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 914;
+}
+);
+note = uni167D;
+},
+{
+color = 11;
+glyphname = "nwiOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (678,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 889;
+}
+);
+note = uni18C7;
+},
+{
+color = 11;
+glyphname = "nwiiOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (199,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (678,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 889;
+}
+);
+note = uni18C9;
+},
+{
+color = 11;
+glyphname = "nwoOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (678,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 889;
+}
+);
+note = uni18CB;
+},
+{
+color = 11;
+glyphname = "nwooOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (306,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (678,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 889;
+}
+);
+note = uni18CD;
+},
+{
+color = 11;
+glyphname = "looWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (41,0);
+ref = dot_top;
+}
+);
+width = 609;
+}
+);
+note = uni18E1;
+},
+{
+color = 11;
+glyphname = "laaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (396,0);
+ref = dot_top;
+}
+);
+width = 609;
+}
+);
+note = uni18E2;
+},
+{
+color = 0;
+glyphname = zero;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(553,588,o),
+(478,724,o),
+(304,724,cs),
+(128,724,o),
+(54,585,o),
+(54,357,cs),
+(54,114,o),
+(140,-10,o),
+(304,-10,cs),
+(473,-10,o),
+(553,108,o),
+(553,357,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(207,449,o),
+(212,600,o),
+(304,600,cs),
+(398,600,o),
+(400,446,o),
+(400,357,cs),
+(400,250,o),
+(389,114,o),
+(304,114,cs),
+(220,114,o),
+(207,250,o),
+(207,357,cs)
+);
+}
+);
+width = 607;
+}
+);
+unicode = 48;
+},
+{
+color = 0;
+glyphname = one;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(246,714,l),
+(13,528,l),
+(93,428,l),
+(184,501,ls),
+(202,515,o),
+(215,528,o),
+(231,546,c),
+(230,500,o),
+(229,461,o),
+(229,419,cs),
+(229,0,l),
+(385,0,l),
+(385,714,l)
+);
+}
+);
+width = 509;
+}
+);
+unicode = 49;
+},
+{
+color = 0;
+glyphname = two;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(538,0,l),
+(538,128,l),
+(239,128,l),
+(239,132,l),
+(327,219,ls),
+(412,299,o),
+(470,358,o),
+(499,422,cs),
+(513,454,o),
+(520,491,o),
+(520,531,cs),
+(520,644,o),
+(429,724,o),
+(293,724,cs),
+(177,724,o),
+(108,682,o),
+(39,621,c),
+(124,521,l),
+(181,570,o),
+(228,594,o),
+(276,594,cs),
+(328,594,o),
+(367,567,o),
+(367,511,cs),
+(367,467,o),
+(351,432,o),
+(310,385,cs),
+(289,360,o),
+(261,330,o),
+(226,293,cs),
+(40,103,l),
+(40,0,l)
+);
+}
+);
+width = 587;
+}
+);
+unicode = 50;
+},
+{
+color = 0;
+glyphname = three;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(506,662,o),
+(418,724,o),
+(278,724,cs),
+(163,724,o),
+(93,693,o),
+(34,652,c),
+(99,548,l),
+(134,572,o),
+(191,599,o),
+(255,599,cs),
+(316,599,o),
+(356,575,o),
+(356,522,cs),
+(356,447,o),
+(272,425,o),
+(196,425,cs),
+(142,425,l),
+(142,308,l),
+(195,308,ls),
+(311,308,o),
+(365,281,o),
+(365,211,cs),
+(365,151,o),
+(326,112,o),
+(220,112,cs),
+(162,112,o),
+(92,129,o),
+(32,159,c),
+(32,30,l),
+(91,6,o),
+(153,-10,o),
+(242,-10,cs),
+(405,-10,o),
+(527,62,o),
+(527,202,cs),
+(527,304,o),
+(463,359,o),
+(349,373,c),
+(349,376,l),
+(439,399,o),
+(506,460,o),
+(506,557,cs)
+);
+}
+);
+width = 572;
+}
+);
+unicode = 51;
+},
+{
+color = 0;
+glyphname = four;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(487,267,l),
+(487,715,l),
+(344,715,l),
+(29,264,l),
+(29,151,l),
+(335,151,l),
+(335,0,l),
+(487,0,l),
+(487,151,l),
+(578,151,l),
+(578,267,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(165,267,l),
+(290,445,ls),
+(310,475,o),
+(319,490,o),
+(334,520,c),
+(338,520,l),
+(338,512,o),
+(335,477,o),
+(335,418,cs),
+(335,267,l)
+);
+}
+);
+width = 609;
+}
+);
+unicode = 52;
+},
+{
+color = 0;
+glyphname = five;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(255,458,o),
+(232,452,o),
+(208,447,c),
+(220,585,l),
+(479,585,l),
+(479,714,l),
+(89,714,l),
+(62,350,l),
+(120,320,l),
+(152,329,o),
+(190,338,o),
+(232,338,cs),
+(324,338,o),
+(370,297,o),
+(370,228,cs),
+(370,154,o),
+(319,112,o),
+(233,112,cs),
+(171,112,o),
+(96,134,o),
+(47,158,c),
+(47,30,l),
+(98,4,o),
+(164,-10,o),
+(245,-10,cs),
+(430,-10,o),
+(526,78,o),
+(526,233,cs),
+(526,375,o),
+(435,458,o),
+(306,458,cs)
+);
+}
+);
+width = 576;
+}
+);
+unicode = 53;
+},
+{
+color = 0;
+glyphname = six;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(54,122,o),
+(142,-10,o),
+(314,-10,cs),
+(465,-10,o),
+(558,84,o),
+(558,240,cs),
+(558,384,o),
+(482,467,o),
+(355,467,cs),
+(273,467,o),
+(225,428,o),
+(199,376,c),
+(194,376,l),
+(199,517,o),
+(255,604,o),
+(408,604,cs),
+(454,604,o),
+(486,599,o),
+(512,593,c),
+(512,715,l),
+(485,720,o),
+(442,724,o),
+(411,724,cs),
+(150,724,o),
+(54,557,o),
+(54,302,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(239,113,o),
+(209,182,o),
+(209,252,cs),
+(209,302,o),
+(254,347,o),
+(314,347,cs),
+(379,347,o),
+(408,306,o),
+(408,236,cs),
+(408,155,o),
+(371,113,o),
+(311,113,cs)
+);
+}
+);
+width = 597;
+}
+);
+unicode = 54;
+},
+{
+color = 0;
+glyphname = seven;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(525,623,l),
+(525,714,l),
+(24,714,l),
+(24,586,l),
+(360,586,l),
+(103,0,l),
+(263,0,l)
+);
+}
+);
+width = 549;
+}
+);
+unicode = 55;
+},
+{
+color = 0;
+glyphname = eight;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(443,-10,o),
+(548,55,o),
+(548,188,cs),
+(548,284,o),
+(473,340,o),
+(394,377,c),
+(473,414,o),
+(527,467,o),
+(527,553,cs),
+(527,666,o),
+(435,724,o),
+(298,724,cs),
+(160,724,o),
+(68,662,o),
+(68,553,cs),
+(68,465,o),
+(126,412,o),
+(190,375,c),
+(106,338,o),
+(46,286,o),
+(46,185,cs),
+(46,70,o),
+(128,-10,o),
+(296,-10,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(229,102,o),
+(188,137,o),
+(188,191,cs),
+(188,250,o),
+(239,284,o),
+(295,309,c),
+(360,279,o),
+(406,243,o),
+(406,189,cs),
+(406,134,o),
+(367,102,o),
+(294,102,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(248,467,o),
+(213,495,o),
+(213,539,cs),
+(213,585,o),
+(250,612,o),
+(298,612,cs),
+(346,612,o),
+(382,586,o),
+(382,540,cs),
+(382,493,o),
+(344,467,o),
+(297,444,c)
+);
+}
+);
+width = 594;
+}
+);
+unicode = 56;
+},
+{
+color = 0;
+glyphname = nine;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(542,593,o),
+(456,724,o),
+(283,724,cs),
+(131,724,o),
+(39,631,o),
+(39,476,cs),
+(39,331,o),
+(115,247,o),
+(238,247,cs),
+(323,247,o),
+(371,285,o),
+(398,338,c),
+(403,338,l),
+(396,185,o),
+(327,110,o),
+(179,110,cs),
+(142,110,o),
+(112,114,o),
+(84,120,c),
+(84,-4,l),
+(111,-9,o),
+(155,-10,o),
+(186,-10,cs),
+(445,-10,o),
+(542,158,o),
+(542,404,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(359,600,o),
+(387,526,o),
+(387,463,cs),
+(387,413,o),
+(340,366,o),
+(284,366,cs),
+(221,366,o),
+(188,409,o),
+(188,477,cs),
+(188,559,o),
+(224,600,o),
+(287,600,cs)
+);
+}
+);
+width = 597;
+}
+);
+unicode = 57;
+},
+{
+glyphname = zero.canadian;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(503,606,o),
+(419,728,o),
+(270,728,cs),
+(122,728,o),
+(38,606,o),
+(38,357,cs),
+(38,108,o),
+(122,-12,o),
+(270,-12,cs),
+(419,-12,o),
+(503,108,o),
+(503,357,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(185,530,o),
+(213,597,o),
+(271,597,cs),
+(328,597,o),
+(355,530,o),
+(355,357,cs),
+(355,184,o),
+(329,120,o),
+(271,120,cs),
+(212,120,o),
+(185,184,o),
+(185,357,cs)
+);
+}
+);
+width = 541;
+}
+);
+metricRight = "=|";
+},
+{
+glyphname = one.canadian;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(337,0,l),
+(337,714,l),
+(205,714,l),
+(8,522,l),
+(96,429,l),
+(282,610,l),
+(189,617,l),
+(189,0,l)
+);
+}
+);
+width = 390;
+}
+);
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = two.canadian;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(485,134,l),
+(226,134,l),
+(228,86,l),
+(387,287,ls),
+(456,374,o),
+(476,447,o),
+(476,515,cs),
+(476,648,o),
+(390,728,o),
+(265,728,cs),
+(120,728,o),
+(38,630,o),
+(37,465,c),
+(183,465,l),
+(183,559,o),
+(210,600,o),
+(261,600,cs),
+(305,600,o),
+(329,568,o),
+(329,514,cs),
+(329,466,o),
+(310,412,o),
+(259,348,cs),
+(58,95,l),
+(58,0,l),
+(485,0,l)
+);
+}
+);
+width = 522;
+}
+);
+note = uni14BF;
+},
+{
+glyphname = three.canadian;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(406,-14,o),
+(493,66,o),
+(493,195,cs),
+(493,293,o),
+(445,365,o),
+(346,382,c),
+(345,333,l),
+(438,349,o),
+(485,426,o),
+(485,516,cs),
+(485,650,o),
+(403,728,o),
+(274,728,cs),
+(131,728,o),
+(49,627,o),
+(46,477,c),
+(192,477,l),
+(193,559,o),
+(219,600,o),
+(270,600,cs),
+(315,600,o),
+(337,570,o),
+(337,506,cs),
+(337,444,o),
+(314,419,o),
+(269,419,cs),
+(238,419,l),
+(238,296,l),
+(270,296,ls),
+(318,296,o),
+(343,269,o),
+(343,207,cs),
+(343,144,o),
+(318,114,o),
+(269,114,cs),
+(214,114,o),
+(188,155,o),
+(187,237,c),
+(41,237,l),
+(42,76,o),
+(122,-14,o),
+(273,-14,cs)
+);
+}
+);
+width = 543;
+}
+);
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = four.canadian;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(421,0,l),
+(421,152,l),
+(497,152,l),
+(497,272,l),
+(421,272,l),
+(421,715,l),
+(304,715,l),
+(27,249,l),
+(27,152,l),
+(279,152,l),
+(279,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(327,569,l),
+(284,569,l),
+(284,272,l),
+(127,272,l),
+(139,237,l)
+);
+}
+);
+width = 515;
+}
+);
+},
+{
+glyphname = five.canadian;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(408,-14,o),
+(499,72,o),
+(499,222,cs),
+(499,365,o),
+(418,444,o),
+(274,444,cs),
+(176,444,l),
+(228,407,l),
+(243,622,l),
+(187,581,l),
+(469,581,l),
+(469,714,l),
+(106,714,l),
+(81,350,l),
+(109,318,l),
+(241,318,ls),
+(320,318,o),
+(352,288,o),
+(352,216,cs),
+(352,146,o),
+(323,114,o),
+(276,114,cs),
+(225,114,o),
+(196,147,o),
+(196,215,c),
+(50,215,l),
+(53,65,o),
+(142,-14,o),
+(276,-14,cs)
+);
+}
+);
+width = 539;
+}
+);
+},
+{
+glyphname = six.canadian;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(422,-14,o),
+(511,81,o),
+(511,218,cs),
+(511,358,o),
+(428,448,o),
+(309,448,cs),
+(235,448,o),
+(183,414,o),
+(155,344,c),
+(189,302,l),
+(186,327,o),
+(186,342,o),
+(186,400,cs),
+(186,542,o),
+(216,602,o),
+(283,602,cs),
+(333,602,o),
+(360,564,o),
+(363,500,c),
+(509,500,l),
+(497,641,o),
+(419,728,o),
+(288,728,cs),
+(135,728,o),
+(38,607,o),
+(38,365,cs),
+(38,215,o),
+(61,124,o),
+(113,59,cs),
+(153,10,o),
+(213,-14,o),
+(289,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(228,109,o),
+(196,151,o),
+(196,222,cs),
+(196,286,o),
+(229,326,o),
+(283,326,cs),
+(337,326,o),
+(367,286,o),
+(367,218,cs),
+(367,150,o),
+(335,109,o),
+(283,109,cs)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = zero.canadian;
+},
+{
+glyphname = seven.canadian;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(414,623,l),
+(414,714,l),
+(25,714,l),
+(25,580,l),
+(269,580,l),
+(268,621,l),
+(85,36,l),
+(85,0,l),
+(229,0,l)
+);
+}
+);
+width = 439;
+}
+);
+},
+{
+glyphname = eight.canadian;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(419,-14,o),
+(510,69,o),
+(510,195,cs),
+(510,299,o),
+(453,365,o),
+(359,382,c),
+(354,333,l),
+(442,348,o),
+(497,416,o),
+(497,519,cs),
+(497,645,o),
+(410,728,o),
+(280,728,cs),
+(150,728,o),
+(63,645,o),
+(63,519,cs),
+(63,416,o),
+(119,348,o),
+(206,333,c),
+(201,382,l),
+(107,365,o),
+(50,299,o),
+(50,195,cs),
+(50,69,o),
+(141,-14,o),
+(280,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(227,108,o),
+(196,141,o),
+(196,203,cs),
+(196,265,o),
+(227,297,o),
+(280,297,cs),
+(333,297,o),
+(364,265,o),
+(364,203,cs),
+(364,141,o),
+(333,108,o),
+(280,108,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(233,417,o),
+(208,448,o),
+(208,511,cs),
+(208,574,o),
+(233,606,o),
+(280,606,cs),
+(327,606,o),
+(353,574,o),
+(353,511,cs),
+(353,448,o),
+(327,417,o),
+(280,417,cs)
+);
+}
+);
+width = 560;
+}
+);
+metricLeft = "=|";
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = nine.canadian;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(409,-14,o),
+(506,107,o),
+(506,349,cs),
+(506,499,o),
+(483,590,o),
+(430,655,cs),
+(390,704,o),
+(330,728,o),
+(254,728,cs),
+(122,728,o),
+(33,633,o),
+(33,496,cs),
+(33,356,o),
+(116,266,o),
+(235,266,cs),
+(309,266,o),
+(361,300,o),
+(389,370,c),
+(355,412,l),
+(358,387,o),
+(358,372,o),
+(358,314,cs),
+(358,172,o),
+(328,113,o),
+(260,113,cs),
+(211,113,o),
+(183,150,o),
+(180,214,c),
+(34,214,l),
+(47,73,o),
+(124,-14,o),
+(255,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(207,388,o),
+(177,428,o),
+(177,496,cs),
+(177,564,o),
+(208,605,o),
+(261,605,cs),
+(316,605,o),
+(347,563,o),
+(347,492,cs),
+(347,428,o),
+(314,388,o),
+(261,388,cs)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "=|six.canadian";
+metricRight = "=|six.canadian";
+},
+{
+glyphname = CR;
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+width = 223;
+}
+);
+note = CR;
+unicode = 13;
+},
+{
+color = 0;
+glyphname = .notdef;
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(505,714,l),
+(94,714,l),
+(94,0,l),
+(505,0,l),
+(505,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(454,663,l),
+(454,51,l),
+(145,51,l),
+(145,663,l),
+(145,663,l)
+);
+}
+);
+width = 600;
+}
+);
+note = ".notdef";
+},
+{
+glyphname = .null;
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+width = 0;
+}
+);
+note = NULL;
+},
+{
+glyphname = space;
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+width = 225;
+}
+);
+note = space;
+unicode = 32;
+},
+{
+glyphname = nbspace;
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+width = 223;
+}
+);
+note = uni00A0;
+unicode = 160;
+},
+{
+glyphname = space.canadian;
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+width = 456;
+}
+);
+note = space;
+},
+{
+glyphname = "hyphen-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(326,399,l),
+(326,482,l),
+(45,482,l),
+(45,399,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(326,253,l),
+(326,336,l),
+(45,336,l),
+(45,253,l)
+);
+}
+);
+width = 371;
+}
+);
+metricRight = "=|";
+note = uni1400;
+unicode = 5120;
+},
+{
+glyphname = "chi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(169,0,l),
+(291,275,l),
+(238,275,l),
+(358,0,l),
+(497,0,l),
+(497,36,l),
+(314,421,l),
+(314,303,l),
+(495,678,l),
+(495,714,l),
+(356,714,l),
+(237,442,l),
+(289,442,l),
+(171,714,l),
+(33,714,l),
+(33,678,l),
+(213,303,l),
+(213,421,l),
+(30,36,l),
+(30,0,l)
+);
+}
+);
+width = 527;
+}
+);
+metricRight = "=|";
+note = uni166D;
+unicode = 5741;
+},
+{
+glyphname = "fullstop-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(297,0,l),
+(297,18,l),
+(208,196,l),
+(211,160,l),
+(296,338,l),
+(296,357,l),
+(206,357,l),
+(149,216,l),
+(188,223,l),
+(130,357,l),
+(41,357,l),
+(41,338,l),
+(125,167,l),
+(127,203,l),
+(40,18,l),
+(40,0,l),
+(130,0,l),
+(193,152,l),
+(145,144,l),
+(207,0,l)
+);
+}
+);
+width = 337;
+}
+);
+note = uni1541;
+unicode = 5742;
+},
+{
+glyphname = period;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(46,14,o),
+(83,-11,o),
+(131,-11,cs),
+(179,-11,o),
+(214,14,o),
+(214,67,cs),
+(214,124,o),
+(179,147,o),
+(131,147,cs),
+(83,147,o),
+(46,124,o),
+(46,67,cs)
+);
+}
+);
+width = 256;
+}
+);
+note = period;
+unicode = 46;
+},
+{
+glyphname = comma;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(125,-137,l),
+(160,-59,o),
+(187,49,o),
+(206,128,c),
+(200,139,l),
+(72,139,l),
+(63,61,o),
+(45,-40,o),
+(22,-137,c)
+);
+}
+);
+width = 257;
+}
+);
+note = comma;
+unicode = 44;
+},
+{
+glyphname = hyphen;
+kernLeft = hyphen;
+kernRight = hyphen;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(236,330,l),
+(27,330,l),
+(27,208,l),
+(236,208,l)
+);
+}
+);
+width = 263;
+}
+);
+unicode = 45;
+},
+{
+glyphname = quotesinglbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (30,-575);
+ref = quoteright;
+}
+);
+width = 302;
+}
+);
+unicode = 8218;
+},
+{
+glyphname = quotedblbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+pos = (30,-575);
+ref = quotedblright;
+}
+);
+width = 527;
+}
+);
+unicode = 8222;
+},
+{
+glyphname = quotedblleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(372,438,l),
+(382,518,o),
+(400,615,o),
+(424,713,c),
+(322,713,l),
+(289,639,o),
+(260,540,o),
+(239,448,c),
+(246,438,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(156,438,l),
+(165,518,o),
+(183,615,o),
+(207,713,c),
+(105,713,l),
+(73,639,o),
+(43,540,o),
+(23,448,c),
+(29,438,l)
+);
+}
+);
+width = 451;
+}
+);
+unicode = 8220;
+},
+{
+glyphname = quotedblright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(346,438,l),
+(382,515,o),
+(410,622,o),
+(429,703,c),
+(422,713,l),
+(295,713,l),
+(288,635,o),
+(269,531,o),
+(244,438,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(129,438,l),
+(165,515,o),
+(194,622,o),
+(212,703,c),
+(205,713,l),
+(79,713,l),
+(71,636,o),
+(52,530,o),
+(27,438,c)
+);
+}
+);
+width = 451;
+}
+);
+unicode = 8221;
+},
+{
+glyphname = quoteleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(162,438,l),
+(172,518,o),
+(190,616,o),
+(213,713,c),
+(105,713,l),
+(73,639,o),
+(43,540,o),
+(23,448,c),
+(29,438,l)
+);
+}
+);
+width = 241;
+}
+);
+unicode = 8216;
+},
+{
+glyphname = quoteright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(135,438,l),
+(171,515,o),
+(200,623,o),
+(218,703,c),
+(211,713,l),
+(79,713,l),
+(71,636,o),
+(52,530,o),
+(27,438,c)
+);
+}
+);
+width = 241;
+}
+);
+unicode = 8217;
+},
+{
+glyphname = dottedCircle;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,522,o),
+(187,511,o),
+(187,496,cs),
+(187,483,o),
+(200,470,o),
+(213,470,cs),
+(228,470,o),
+(239,483,o),
+(239,496,cs),
+(239,511,o),
+(228,522,o),
+(213,522,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(368,522,o),
+(355,511,o),
+(355,496,cs),
+(355,483,o),
+(368,470,o),
+(381,470,cs),
+(396,470,o),
+(407,483,o),
+(407,496,cs),
+(407,511,o),
+(396,522,o),
+(381,522,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,112,o),
+(187,101,o),
+(187,86,cs),
+(187,73,o),
+(200,60,o),
+(213,60,cs),
+(228,60,o),
+(239,73,o),
+(239,86,cs),
+(239,101,o),
+(228,112,o),
+(213,112,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(368,112,o),
+(355,101,o),
+(355,86,cs),
+(355,73,o),
+(368,60,o),
+(381,60,cs),
+(396,60,o),
+(407,73,o),
+(407,86,cs),
+(407,101,o),
+(396,112,o),
+(381,112,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(284,540,o),
+(271,529,o),
+(271,514,cs),
+(271,501,o),
+(284,488,o),
+(297,488,cs),
+(312,488,o),
+(323,501,o),
+(323,514,cs),
+(323,529,o),
+(312,540,o),
+(297,540,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(284,94,o),
+(271,83,o),
+(271,68,cs),
+(271,55,o),
+(284,42,o),
+(297,42,cs),
+(312,42,o),
+(323,55,o),
+(323,68,cs),
+(323,83,o),
+(312,94,o),
+(297,94,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(48,278,o),
+(61,265,o),
+(74,265,cs),
+(89,265,o),
+(100,278,o),
+(100,291,cs),
+(100,306,o),
+(89,317,o),
+(74,317,cs),
+(61,317,o),
+(48,306,o),
+(48,291,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(494,278,o),
+(507,265,o),
+(520,265,cs),
+(535,265,o),
+(546,278,o),
+(546,291,cs),
+(546,306,o),
+(535,317,o),
+(520,317,cs),
+(507,317,o),
+(494,306,o),
+(494,291,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(113,120,o),
+(126,107,o),
+(139,107,cs),
+(154,107,o),
+(165,120,o),
+(165,133,cs),
+(165,148,o),
+(154,159,o),
+(139,159,cs),
+(126,159,o),
+(113,148,o),
+(113,133,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(113,436,o),
+(126,423,o),
+(139,423,cs),
+(154,423,o),
+(165,436,o),
+(165,449,cs),
+(165,464,o),
+(154,475,o),
+(139,475,cs),
+(126,475,o),
+(113,464,o),
+(113,449,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(429,120,o),
+(442,107,o),
+(455,107,cs),
+(470,107,o),
+(481,120,o),
+(481,133,cs),
+(481,148,o),
+(470,159,o),
+(455,159,cs),
+(442,159,o),
+(429,148,o),
+(429,133,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(429,436,o),
+(442,423,o),
+(455,423,cs),
+(470,423,o),
+(481,436,o),
+(481,449,cs),
+(481,464,o),
+(470,475,o),
+(455,475,cs),
+(442,475,o),
+(429,464,o),
+(429,449,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(66,194,o),
+(79,181,o),
+(92,181,cs),
+(107,181,o),
+(118,194,o),
+(118,207,cs),
+(118,222,o),
+(107,233,o),
+(92,233,cs),
+(79,233,o),
+(66,222,o),
+(66,207,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(66,362,o),
+(79,349,o),
+(92,349,cs),
+(107,349,o),
+(118,362,o),
+(118,375,cs),
+(118,390,o),
+(107,401,o),
+(92,401,cs),
+(79,401,o),
+(66,390,o),
+(66,375,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(476,194,o),
+(489,181,o),
+(502,181,cs),
+(517,181,o),
+(528,194,o),
+(528,207,cs),
+(528,222,o),
+(517,233,o),
+(502,233,cs),
+(489,233,o),
+(476,222,o),
+(476,207,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(476,362,o),
+(489,349,o),
+(502,349,cs),
+(517,349,o),
+(528,362,o),
+(528,375,cs),
+(528,390,o),
+(517,401,o),
+(502,401,cs),
+(489,401,o),
+(476,390,o),
+(476,375,cs)
+);
+}
+);
+width = 594;
+}
+);
+note = uni25CC;
+unicode = 9676;
+},
+{
+glyphname = dotaccentcomb;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(65,761,o),
+(30,745,o),
+(30,691,cs),
+(30,639,o),
+(64,621,o),
+(107,621,cs),
+(149,621,o),
+(185,639,o),
+(185,691,cs),
+(185,745,o),
+(148,761,o),
+(107,761,cs)
+);
+}
+);
+width = 214;
+}
+);
+note = uni0307;
+unicode = 775;
+},
+{
+glyphname = dotaccent;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(149,621,o),
+(186,638,o),
+(186,691,cs),
+(186,745,o),
+(149,761,o),
+(108,761,cs),
+(66,761,o),
+(31,745,o),
+(31,691,cs),
+(31,639,o),
+(65,621,o),
+(108,621,cs)
+);
+}
+);
+width = 216;
+}
+);
+note = dotaccent;
+unicode = 729;
+},
+{
+glyphname = caron;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(295,645,o),
+(326,695,o),
+(369,753,c),
+(369,765,l),
+(274,765,l),
+(247,740,o),
+(227,713,o),
+(199,678,c),
+(172,712,o),
+(152,741,o),
+(127,765,c),
+(31,765,l),
+(31,753,l),
+(65,707,o),
+(103,655,o),
+(127,606,c),
+(274,606,l),
+(274,606,l)
+);
+}
+);
+width = 399;
+}
+);
+note = caron;
+unicode = 711;
+},
+{
+glyphname = breve;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(272,606,o),
+(327,668,o),
+(332,768,c),
+(250,768,l),
+(240,715,o),
+(212,697,o),
+(180,697,cs),
+(139,697,o),
+(121,713,o),
+(110,768,c),
+(31,768,l),
+(35,663,o),
+(87,606,o),
+(180,606,cs)
+);
+}
+);
+width = 363;
+}
+);
+note = breve;
+unicode = 728;
+},
+{
+glyphname = ring;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(186,606,o),
+(231,651,o),
+(231,723,cs),
+(231,793,o),
+(185,840,o),
+(129,840,cs),
+(70,840,o),
+(31,794,o),
+(31,723,cs),
+(31,652,o),
+(70,606,o),
+(129,606,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(109,672,o),
+(98,694,o),
+(98,723,cs),
+(98,753,o),
+(112,773,o),
+(129,773,cs),
+(147,773,o),
+(161,752,o),
+(161,723,cs),
+(161,695,o),
+(147,672,o),
+(129,672,cs)
+);
+}
+);
+width = 261;
+}
+);
+note = ring;
+unicode = 730;
+},
+{
+glyphname = ogonek;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(156,-234,o),
+(178,-230,o),
+(199,-222,c),
+(199,-137,l),
+(188,-142,o),
+(168,-147,o),
+(154,-147,cs),
+(137,-147,o),
+(125,-134,o),
+(125,-106,cs),
+(125,-71,o),
+(140,-41,o),
+(175,0,c),
+(118,21,l),
+(54,-34,o),
+(31,-80,o),
+(31,-129,cs),
+(31,-195,o),
+(76,-234,o),
+(134,-234,cs)
+);
+}
+);
+width = 229;
+}
+);
+note = ogonek;
+unicode = 731;
+},
+{
+glyphname = ring_top.canadian;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (121,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(179,784,o),
+(229,828,o),
+(229,889,cs),
+(229,951,o),
+(179,995,o),
+(121,995,cs),
+(63,995,o),
+(14,951,o),
+(14,889,cs),
+(14,828,o),
+(63,784,o),
+(121,784,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(94,844,o),
+(77,864,o),
+(77,889,cs),
+(77,914,o),
+(95,935,o),
+(121,935,cs),
+(148,935,o),
+(166,914,o),
+(166,889,cs),
+(166,864,o),
+(148,844,o),
+(121,844,cs)
+);
+}
+);
+width = 243;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (87,357);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(124,289,o),
+(154,320,o),
+(154,357,cs),
+(154,394,o),
+(124,425,o),
+(87,425,cs),
+(49,425,o),
+(19,394,o),
+(19,357,cs),
+(19,320,o),
+(49,289,o),
+(87,289,cs)
+);
+}
+);
+width = 173;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (71,357);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(101,303,o),
+(126,326,o),
+(126,357,cs),
+(126,388,o),
+(101,411,o),
+(71,411,cs),
+(41,411,o),
+(17,388,o),
+(17,357,cs),
+(17,326,o),
+(41,303,o),
+(71,303,cs)
+);
+}
+);
+width = 142;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_small;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (55,357);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(78,318,o),
+(95,335,o),
+(95,357,cs),
+(95,379,o),
+(78,396,o),
+(55,396,cs),
+(34,396,o),
+(17,379,o),
+(17,357,cs),
+(17,335,o),
+(34,318,o),
+(55,318,cs)
+);
+}
+);
+width = 112;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_top;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (87,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(125,795,o),
+(156,826,o),
+(156,865,cs),
+(156,903,o),
+(125,935,o),
+(87,935,cs),
+(48,935,o),
+(17,903,o),
+(17,865,cs),
+(17,826,o),
+(48,795,o),
+(87,795,cs)
+);
+}
+);
+width = 173;
+}
+);
+note = g725;
+},
+{
+glyphname = doubledot_middle;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(146,383,o),
+(177,414,o),
+(177,452,cs),
+(177,491,o),
+(146,522,o),
+(107,522,cs),
+(69,522,o),
+(37,491,o),
+(37,452,cs),
+(37,413,o),
+(69,383,o),
+(107,383,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(146,192,o),
+(177,223,o),
+(177,262,cs),
+(177,300,o),
+(146,331,o),
+(107,331,cs),
+(69,331,o),
+(37,301,o),
+(37,262,cs),
+(37,223,o),
+(69,192,o),
+(107,192,cs)
+);
+}
+);
+width = 214;
+}
+);
+metricRight = "=|";
+note = g725;
+},
+{
+glyphname = doubledot_top;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top_double;
+pos = (264,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(302,795,o),
+(334,826,o),
+(334,865,cs),
+(334,903,o),
+(302,935,o),
+(264,935,cs),
+(225,935,o),
+(195,903,o),
+(195,865,cs),
+(195,826,o),
+(225,795,o),
+(264,795,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(123,795,o),
+(154,826,o),
+(154,865,cs),
+(154,903,o),
+(123,935,o),
+(84,935,cs),
+(45,935,o),
+(14,903,o),
+(14,865,cs),
+(14,826,o),
+(45,795,o),
+(84,795,cs)
+);
+}
+);
+width = 348;
+}
+);
+note = g725;
+},
+{
+glyphname = g727;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (316,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(575,0,l),
+(575,120,l),
+(290,120,ls),
+(226,120,o),
+(193,149,o),
+(193,208,cs),
+(193,268,o),
+(224,298,o),
+(290,298,cs),
+(371,298,ls),
+(510,298,o),
+(587,374,o),
+(587,507,cs),
+(587,639,o),
+(510,714,o),
+(371,714,cs),
+(57,714,l),
+(57,594,l),
+(342,594,ls),
+(406,594,o),
+(439,565,o),
+(439,507,cs),
+(439,448,o),
+(408,417,o),
+(342,417,cs),
+(261,417,ls),
+(122,417,o),
+(45,340,o),
+(45,207,cs),
+(45,75,o),
+(122,0,o),
+(261,0,cs)
+);
+}
+);
+width = 632;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+glyphname = g728;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (230,0);
+ref = dot_top;
+}
+);
+width = 632;
+}
+);
+note = g728;
+},
+{
+glyphname = g729;
+lastChange = "2023-01-13 15:31:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (317,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(371,0,ls),
+(510,0,o),
+(586,75,o),
+(586,207,cs),
+(586,340,o),
+(510,417,o),
+(371,417,cs),
+(290,417,ls),
+(224,417,o),
+(193,448,o),
+(193,506,cs),
+(193,565,o),
+(225,594,o),
+(290,594,cs),
+(575,594,l),
+(575,714,l),
+(261,714,ls),
+(122,714,o),
+(45,639,o),
+(45,507,cs),
+(45,374,o),
+(122,298,o),
+(261,298,cs),
+(342,298,ls),
+(407,298,o),
+(439,268,o),
+(439,207,cs),
+(439,149,o),
+(406,120,o),
+(342,120,cs),
+(57,120,l),
+(57,0,l)
+);
+}
+);
+width = 631;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+glyphname = g730;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (230,0);
+ref = dot_top;
+}
+);
+width = 632;
+}
+);
+note = g730;
+},
+{
+glyphname = g731;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = g727;
+}
+);
+width = 843;
+}
+);
+note = g731;
+},
+{
+glyphname = g732;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (632,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 843;
+}
+);
+note = g732;
+},
+{
+glyphname = g733;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (441,0);
+ref = dot_top;
+}
+);
+width = 843;
+}
+);
+note = g733;
+},
+{
+glyphname = g734;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (230,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (632,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 843;
+}
+);
+note = g734;
+},
+{
+glyphname = g735;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = g729;
+}
+);
+width = 843;
+}
+);
+note = g735;
+},
+{
+glyphname = g736;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (632,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 843;
+}
+);
+note = g736;
+},
+{
+glyphname = g737;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (441,0);
+ref = dot_top;
+}
+);
+width = 843;
+}
+);
+note = g737;
+},
+{
+glyphname = g738;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (230,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (632,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 843;
+}
+);
+note = g738;
+},
+{
+glyphname = g739;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(479,271,o),
+(524,325,o),
+(524,406,cs),
+(524,486,o),
+(478,542,o),
+(398,542,cs),
+(242,542,l),
+(247,499,l),
+(263,511,o),
+(278,547,o),
+(278,590,cs),
+(278,668,o),
+(235,720,o),
+(157,720,cs),
+(80,720,o),
+(35,666,o),
+(35,585,cs),
+(35,504,o),
+(81,449,o),
+(161,449,cs),
+(318,449,l),
+(312,492,l),
+(296,480,o),
+(281,443,o),
+(281,401,cs),
+(281,323,o),
+(324,271,o),
+(402,271,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(135,521,o),
+(121,540,o),
+(121,585,cs),
+(121,629,o),
+(135,649,o),
+(157,649,cs),
+(179,649,o),
+(192,627,o),
+(192,584,cs),
+(192,542,o),
+(179,521,o),
+(157,521,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(381,342,o),
+(367,363,o),
+(367,406,cs),
+(367,449,o),
+(380,470,o),
+(402,470,cs),
+(424,470,o),
+(438,450,o),
+(438,406,cs),
+(438,362,o),
+(424,342,o),
+(402,342,cs)
+);
+}
+);
+width = 559;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+glyphname = g740;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (195,0);
+ref = ring_top.canadian;
+}
+);
+width = 632;
+}
+);
+note = g740;
+},
+{
+glyphname = g741;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (195,0);
+ref = ring_top.canadian;
+}
+);
+width = 632;
+}
+);
+note = g741;
+},
+{
+glyphname = g742;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (211,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (406,0);
+ref = ring_top.canadian;
+}
+);
+width = 843;
+}
+);
+note = g742;
+},
+{
+glyphname = stroke_middle;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (58,357);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(101,478,l),
+(16,478,l),
+(16,236,l),
+(101,236,l)
+);
+}
+);
+width = 117;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (47,357);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(78,435,l),
+(16,435,l),
+(16,279,l),
+(78,279,l)
+);
+}
+);
+width = 94;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_small;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (39,357);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(63,425,l),
+(16,425,l),
+(16,289,l),
+(63,289,l)
+);
+}
+);
+width = 79;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_threequart;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (58,357);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,475,l),
+(20,475,l),
+(20,239,l),
+(97,239,l)
+);
+}
+);
+width = 117;
+}
+);
+note = g723;
+},
+{
+color = 8;
+glyphname = uni11AB0;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (160,714);
+},
+{
+name = top_right_can;
+pos = (394,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(233,0,l),
+(233,85,l),
+(415,85,l),
+(415,165,l),
+(233,165,l),
+(233,286,l),
+(121,240,l),
+(154,240,ls),
+(355,240,o),
+(468,362,o),
+(468,596,cs),
+(468,714,l),
+(320,714,l),
+(320,607,ls),
+(320,433,o),
+(252,372,o),
+(122,372,cs),
+(86,372,l),
+(86,165,l),
+(25,165,l),
+(25,85,l),
+(86,85,l),
+(86,0,l)
+);
+}
+);
+width = 521;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB1;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB0;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (308,0);
+ref = dot_top;
+}
+);
+width = 521;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB2;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (126,714);
+},
+{
+name = top_right_can;
+pos = (362,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,0,l),
+(200,107,ls),
+(200,281,o),
+(269,342,o),
+(399,342,cs),
+(435,342,l),
+(435,549,l),
+(496,549,l),
+(496,629,l),
+(435,629,l),
+(435,714,l),
+(288,714,l),
+(288,629,l),
+(106,629,l),
+(106,549,l),
+(288,549,l),
+(288,428,l),
+(400,474,l),
+(367,474,ls),
+(166,474,o),
+(53,352,o),
+(53,118,cs),
+(53,0,l)
+);
+}
+);
+width = 521;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "theThCree-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB3;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB2;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (275,0);
+ref = dot_top;
+}
+);
+width = 521;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB4;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (160,714);
+},
+{
+name = top_right_can;
+pos = (395,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(468,0,l),
+(468,118,ls),
+(468,352,o),
+(355,474,o),
+(154,474,cs),
+(121,474,l),
+(233,428,l),
+(233,549,l),
+(415,549,l),
+(415,629,l),
+(233,629,l),
+(233,714,l),
+(86,714,l),
+(86,629,l),
+(25,629,l),
+(25,549,l),
+(86,549,l),
+(86,342,l),
+(122,342,ls),
+(252,342,o),
+(320,281,o),
+(320,107,cs),
+(320,0,l)
+);
+}
+);
+width = 521;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB5;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB4;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (73,0);
+ref = dot_top;
+}
+);
+width = 521;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB6;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (127,714);
+},
+{
+name = top_right_can;
+pos = (362,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(201,0,l),
+(201,289,l),
+(89,240,l),
+(122,240,ls),
+(323,240,o),
+(436,362,o),
+(436,596,cs),
+(436,666,l),
+(337,626,l),
+(549,420,l),
+(632,508,l),
+(420,714,l),
+(288,714,l),
+(288,607,ls),
+(288,433,o),
+(220,372,o),
+(90,372,cs),
+(54,372,l),
+(54,0,l)
+);
+}
+);
+width = 648;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB7;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB6;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (276,0);
+ref = dot_top;
+}
+);
+width = 648;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB8;
+kernRight = soright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (286,714);
+},
+{
+name = top_right_can;
+pos = (521,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(359,0,l),
+(359,107,ls),
+(359,281,o),
+(428,342,o),
+(558,342,cs),
+(594,342,l),
+(594,714,l),
+(447,714,l),
+(447,425,l),
+(559,474,l),
+(526,474,ls),
+(325,474,o),
+(212,352,o),
+(212,118,cs),
+(212,48,l),
+(311,88,l),
+(99,294,l),
+(16,206,l),
+(228,0,l)
+);
+}
+);
+width = 648;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB9;
+kernRight = soright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB8;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (434,0);
+ref = dot_top;
+}
+);
+width = 648;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABA;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (128,714);
+},
+{
+name = top_right_can;
+pos = (363,714);
+}
+);
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(420,0,l),
+(632,206,l),
+(549,294,l),
+(337,88,l),
+(436,48,l),
+(436,118,ls),
+(436,352,o),
+(323,474,o),
+(122,474,cs),
+(89,474,l),
+(201,425,l),
+(201,714,l),
+(54,714,l),
+(54,342,l),
+(90,342,ls),
+(220,342,o),
+(288,281,o),
+(288,107,cs),
+(288,0,l)
+);
+}
+);
+width = 648;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABB;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+alignment = -1;
+ref = uni11ABA;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (41,0);
+ref = dot_top;
+}
+);
+width = 648;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABC;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(481,0,l),
+(481,134,l),
+(183,134,l),
+(183,84,l),
+(489,613,l),
+(489,714,l),
+(36,714,l),
+(36,580,l),
+(334,580,l),
+(334,630,l),
+(29,101,l),
+(29,0,l)
+);
+}
+);
+width = 518;
+}
+);
+metricRight = "=|";
+},
+{
+color = 8;
+glyphname = uni11ABD;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(489,0,l),
+(489,101,l),
+(184,630,l),
+(184,580,l),
+(482,580,l),
+(482,714,l),
+(29,714,l),
+(29,613,l),
+(334,84,l),
+(334,134,l),
+(37,134,l),
+(37,0,l)
+);
+}
+);
+width = 518;
+}
+);
+metricLeft = "=|uni11ABC";
+metricRight = "=|uni11ABC";
+},
+{
+color = 8;
+glyphname = uni11ABE;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(198,0,l),
+(198,588,l),
+(113,588,l),
+(414,0,l),
+(544,0,l),
+(544,714,l),
+(400,714,l),
+(400,126,l),
+(485,126,l),
+(183,714,l),
+(53,714,l),
+(53,0,l)
+);
+}
+);
+width = 597;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABF;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(183,0,l),
+(484,589,l),
+(399,589,l),
+(399,0,l),
+(544,0,l),
+(544,714,l),
+(414,714,l),
+(112,125,l),
+(198,125,l),
+(198,714,l),
+(53,714,l),
+(53,0,l)
+);
+}
+);
+width = 597;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = "raiseddoubledotFinal-canadian.cree";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "86DE26EB-3058-4E6D-9480-BC9D8886A6AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(145,589,o),
+(176,620,o),
+(176,659,cs),
+(176,697,o),
+(145,728,o),
+(106,728,cs),
+(68,728,o),
+(37,698,o),
+(37,659,cs),
+(37,619,o),
+(68,589,o),
+(106,589,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(145,398,o),
+(176,430,o),
+(176,468,cs),
+(176,507,o),
+(145,538,o),
+(106,538,cs),
+(68,538,o),
+(37,507,o),
+(37,468,cs),
+(37,429,o),
+(68,398,o),
+(106,398,cs)
+);
+}
+);
+width = 213;
+}
+);
+note = g725;
+}
+);
+instances = (
+{
+axesValues = (
+154,
+75,
+0
+);
+instanceInterpolations = {
+"86DE26EB-3058-4E6D-9480-BC9D8886A6AA" = 1;
+};
+name = "RC CB roman";
+}
+);
+kerningLTR = {
+"86DE26EB-3058-4E6D-9480-BC9D8886A6AA" = {
+"@MMK_L_caright" = {
+"@MMK_R_ecanleft" = -66;
+"@MMK_R_mwestleft" = -26;
+"@MMK_R_neleft" = -39;
+};
+"@MMK_L_ciright" = {
+"@MMK_R_icanleft" = -66;
+"@MMK_R_noleft" = -73;
+};
+"@MMK_L_ecanright" = {
+"@MMK_R_coleft" = -66;
+"@MMK_R_moleft" = -67;
+"@MMK_R_sileft" = -36;
+};
+"@MMK_L_icanright" = {
+"@MMK_R_celeft" = -66;
+"@MMK_R_meleft" = -67;
+"@MMK_R_mwestleft" = -53;
+"@MMK_R_saleft" = -30;
+"she-canadian" = -67;
+};
+"@MMK_L_maright" = {
+"@MMK_R_acanleft" = -58;
+"@MMK_R_ecanleft" = -67;
+"@MMK_R_mwestleft" = -44;
+"@MMK_R_neleft" = -39;
+};
+"@MMK_L_miright" = {
+"@MMK_R_acanleft" = -58;
+"@MMK_R_icanleft" = -67;
+"@MMK_R_moleft" = -92;
+"@MMK_R_noleft" = -73;
+"@MMK_R_yeleft" = -95;
+};
+"@MMK_L_mwestright" = {
+"@MMK_R_coleft" = -26;
+"@MMK_R_icanleft" = -53;
+"@MMK_R_moleft" = -44;
+"@MMK_R_noleft" = -70;
+"@MMK_R_sileft" = -13;
+"@MMK_R_yeleft" = -27;
+};
+"@MMK_L_naright" = {
+"@MMK_R_acanleft" = -67;
+"@MMK_R_celeft" = -73;
+"@MMK_R_meleft" = -73;
+"@MMK_R_mwestleft" = -70;
+"@MMK_R_neleft" = -78;
+"@MMK_R_saleft" = -42;
+};
+"@MMK_L_niright" = {
+"@MMK_R_coleft" = -39;
+"@MMK_R_moleft" = -39;
+"@MMK_R_noleft" = -78;
+"@MMK_R_sileft" = -1;
+};
+"@MMK_L_ocanright" = {
+"@MMK_R_meleft" = -58;
+"@MMK_R_moleft" = -58;
+"@MMK_R_noleft" = -67;
+};
+"@MMK_L_seright" = {
+"@MMK_R_ecanleft" = -36;
+"@MMK_R_mwestleft" = -13;
+"@MMK_R_neleft" = -1;
+};
+"@MMK_L_soright" = {
+"@MMK_R_icanleft" = -30;
+"@MMK_R_noleft" = -42;
+};
+"@MMK_L_yiright" = {
+"@MMK_R_meleft" = -95;
+"@MMK_R_mwestleft" = -27;
+};
+"shi-canadian" = {
+"@MMK_R_icanleft" = -67;
+};
+};
+};
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "italic angle";
+}
+);
+properties = (
+{
+key = copyrights;
+values = (
+{
+language = ENG;
+value = "Copyright 2018 Google Inc. All Rights Reserved.";
+}
+);
+},
+{
+key = manufacturers;
+values = (
+{
+language = ENG;
+value = "Monotype Imaging Inc.";
+}
+);
+},
+{
+key = designers;
+values = (
+{
+language = ENG;
+value = "Monotype Design Team";
+}
+);
+},
+{
+key = description;
+value = "Designed by Monotype design team.";
+},
+{
+key = trademarks;
+values = (
+{
+language = ENG;
+value = "Noto is a trademark of Google Inc.";
+}
+);
+},
+{
+key = licenseURL;
+value = "http://scripts.sil.org/OFL";
+},
+{
+key = licenses;
+values = (
+{
+language = ENG;
+value = "This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.";
+}
+);
+},
+{
+key = manufacturerURL;
+value = "http://www.google.com/get/noto/";
+},
+{
+key = designerURL;
+value = "http://www.monotype.com/studio";
+}
+);
+settings = {
+disablesNiceNames = 1;
+};
+stems = (
+{
+name = "New Stem";
+}
+);
+unitsPerEm = 1000;
+userData = {
+GSDontShowVersionAlert = 1;
+};
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/sources/Exported instances UCAS SansCanadianAboriginal/Sans Canadian Aboriginal-RC CL Italic.glyphs
+++ b/sources/Exported instances UCAS SansCanadianAboriginal/Sans Canadian Aboriginal-RC CL Italic.glyphs
@@ -1,0 +1,37311 @@
+{
+.appVersion = "3151";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+},
+{
+name = Width;
+tag = wdth;
+},
+{
+name = Slant;
+tag = slnt;
+}
+);
+classes = (
+{
+code = "zero one two three four five six seven eight nine ";
+name = Num;
+},
+{
+code = "zero.canadian one.canadian two.canadian three.canadian four.canadian five.canadian six.canadian seven.canadian eight.canadian nine.canadian 
+";
+name = Num_can;
+},
+{
+code = "ke-canadian.square ki-canadian.square kii-canadian.square ko-canadian.square koo-canadian.square ka-canadian.square kaa-canadian.square kweWestCree-canadian.square kwiiWestCree-canadian.square kwoWestCree-canadian.square kwooWestCree-canadian.square kwaWestCree-canadian.square kwaaWestCree-canadian.square ce-canadian.square ci-canadian.square cii-canadian.square co-canadian.square coo-canadian.square ca-canadian.square caa-canadian.square me-canadian.square mi-canadian.square mii-canadian.square mo-canadian.square moo-canadian.square ma-canadian.square maa-canadian.square ne-canadian.square ni-canadian.square nii-canadian.square no-canadian.square noo-canadian.square na-canadian.square naa-canadian.square nweWestCree-canadian.square nwaWestCree-canadian.square nwaaWestCree-canadian.square se-canadian.square si-canadian.square sii-canadian.square so-canadian.square soo-canadian.square sa-canadian.square saa-canadian.square sho-canadian.square shoo-canadian.square sha-canadian.square shaa-canadian.square ye-canadian.square yi-canadian.square yii-canadian.square yo-canadian.square yoo-canadian.square ya-canadian.square yaa-canadian.square re-canadian.square reRCree-canadian.square leWestCree-canadian.square ri-canadian.square rii-canadian.square ro-canadian.square loWestCree-canadian.square ra-canadian.square raa-canadian.square laWestCree-canadian.square reWestCree-canadian.square riWestCree-canadian.square roWestCree-canadian.square raWestCree-canadian.square theThCree-canadian.square thiThCree-canadian.square thiiThCree-canadian.square thoThCree-canadian.square thooThCree-canadian.square thaThCree-canadian.square thaaThCree-canadian.square thweeWoodScree-canadian.square thwiWoodScree-canadian.square thwiiWoodScree-canadian.square thwoWoodScree-canadian.square thwooWoodScree-canadian.square thwaWoodScree-canadian.square thwaaWoodScree-canadian.square nwiOjibway-canadian.square nwiiOjibway-canadian.square nwoOjibway-canadian.square nwooOjibway-canadian.square looWestCree-canadian.square laaWestCree-canadian.square ";
+name = Dene_square;
+},
+{
+code = "ke-canadian ki-canadian kii-canadian ko-canadian koo-canadian ka-canadian kaa-canadian kweWestCree-canadian kwiiWestCree-canadian kwoWestCree-canadian kwooWestCree-canadian kwaWestCree-canadian kwaaWestCree-canadian ce-canadian ci-canadian cii-canadian co-canadian coo-canadian ca-canadian caa-canadian me-canadian mi-canadian mii-canadian mo-canadian moo-canadian ma-canadian maa-canadian ne-canadian ni-canadian nii-canadian no-canadian noo-canadian na-canadian naa-canadian nweWestCree-canadian nwaWestCree-canadian nwaaWestCree-canadian se-canadian si-canadian sii-canadian so-canadian soo-canadian sa-canadian saa-canadian sho-canadian shoo-canadian sha-canadian shaa-canadian ye-canadian yi-canadian yii-canadian yo-canadian yoo-canadian ya-canadian yaa-canadian re-canadian reRCree-canadian leWestCree-canadian ri-canadian rii-canadian ro-canadian loWestCree-canadian ra-canadian raa-canadian laWestCree-canadian reWestCree-canadian riWestCree-canadian roWestCree-canadian raWestCree-canadian theThCree-canadian thiThCree-canadian thiiThCree-canadian thoThCree-canadian thooThCree-canadian thaThCree-canadian thaaThCree-canadian thweeWoodScree-canadian thwiWoodScree-canadian thwiiWoodScree-canadian thwoWoodScree-canadian thwooWoodScree-canadian thwaWoodScree-canadian thwaaWoodScree-canadian nwiOjibway-canadian nwiiOjibway-canadian nwoOjibway-canadian nwooOjibway-canadian looWestCree-canadian laaWestCree-canadian 
+";
+name = Dene_round;
+},
+{
+code = "acuteFinal-canadian.mid graveFinal-canadian.mid ringTophalfFinal-canadian.mid ringRighthalfFinal-canadian.mid ringFinal-canadian.mid doubleacuteFinal-canadian.mid doubleshortverticalstrokesFinal-canadian.mid shorthorizontalstrokeFinal-canadian.mid downtackFinal-canadian.mid pWestCree-canadian.mid c-canadian.mid mWestCree-canadian.mid ";
+name = Final_mid;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian ringFinal-canadian doubleacuteFinal-canadian doubleshortverticalstrokesFinal-canadian shorthorizontalstrokeFinal-canadian downtackFinal-canadian pWestCree-canadian c-canadian mWestCree-canadian ";
+name = Final_mid_ori;
+},
+{
+code = "acuteFinal-canadian.base graveFinal-canadian.base ringBottomhalfFinal-canadian.base ringTophalfFinal-canadian.base ringRighthalfFinal-canadian.base plusFinal-canadian.base pWestCree-canadian.base c-canadian.base thSayisi-canadian.base mWestCree-canadian.base ";
+name = Final_base;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringBottomhalfFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian plusFinal-canadian pWestCree-canadian c-canadian thSayisi-canadian mWestCree-canadian ";
+name = Final_base_ori;
+},
+{
+code = "ng-canadian ngai-canadian ngaai-canadian ngi-canadian ngii-canadian ngo-canadian ngoo-canadian nga-canadian ngaa-canadian ";
+name = Nunavik;
+},
+{
+code = "ng-canadian.nunavik ngai-canadian.nunavik ngaai-canadian.nunavik ngi-canadian.nunavik ngii-canadian.nunavik ngo-canadian.nunavik ngoo-canadian.nunavik nga-canadian.nunavik ngaa-canadian.nunavik ";
+name = Nunavik_alt;
+}
+);
+customParameters = (
+{
+name = vendorID;
+value = GOOG;
+},
+{
+name = panose;
+value = (
+2,
+11,
+5,
+2,
+4,
+5,
+4,
+2,
+2,
+4
+);
+},
+{
+name = unicodeRanges;
+value = (
+0,
+1,
+2,
+5,
+6,
+45,
+77
+);
+},
+{
+name = codePageRanges;
+value = (
+"1252"
+);
+},
+{
+name = fsType;
+value = (
+);
+}
+);
+date = "2022-06-21 10:06:40 +0000";
+familyName = "Sans Canadian Aboriginal";
+featurePrefixes = (
+{
+automatic = 1;
+code = "languagesystem DFLT dflt;
+
+languagesystem cans dflt;
+";
+name = Languagesystems;
+}
+);
+features = (
+{
+automatic = 1;
+code = "feature ss01;
+feature ss02;
+feature ss03;
+feature ss04;
+";
+tag = aalt;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+tag = salt;
+},
+{
+code = "lookup space_can {
+sub space by space.canadian;
+} space_can;
+
+lookup num_can {
+sub @Num by @Num_can;
+} num_can;
+";
+labels = (
+{
+language = dflt;
+value = "CAN Space and numerals";
+}
+);
+tag = ss01;
+},
+{
+code = "lookup dene_square {
+sub @Dene_round by @Dene_square;
+} dene_square;
+
+";
+labels = (
+{
+language = dflt;
+value = "Dene Square";
+}
+);
+tag = ss02;
+},
+{
+code = "lookup nunavik_alt {
+sub @Nunavik by @Nunavik_alt;
+} nunavik_alt;
+
+";
+labels = (
+{
+language = dflt;
+value = "Nunanvik Alt";
+}
+);
+tag = ss03;
+},
+{
+code = "lookup final_mid {
+sub @Final_mid_ori by @Final_mid;
+} final_mid;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final mid";
+}
+);
+tag = ss04;
+},
+{
+code = "lookup final_base {
+sub @Final_base_ori by @Final_base;
+} final_base;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final base";
+}
+);
+tag = ss05;
+},
+{
+code = "lookup plaincree_first {
+sub wiWestCree-canadian' plusFinal-canadian by i-canadian;
+} plaincree_first;
+
+lookup plaincree_second {
+sub i-canadian plusFinal-canadian' by raiseddoubledotFinal-canadian.cree;
+} plaincree_second;
+
+lookup plaincree_third {
+sub middledotFinal-canadian plusFinal-canadian by raiseddoubledotFinal-canadian.cree;
+} plaincree_third;
+";
+labels = (
+{
+language = dflt;
+value = Plaincree;
+}
+);
+tag = ss06;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+labels = (
+{
+language = dflt;
+value = "";
+}
+);
+tag = ss07;
+}
+);
+fontMaster = (
+{
+axesValues = (
+0,
+0,
+0
+);
+customParameters = (
+{
+name = typoAscender;
+value = 1069;
+},
+{
+name = typoDescender;
+value = -293;
+},
+{
+name = typoLineGap;
+value = 0;
+},
+{
+name = winAscent;
+value = 1069;
+},
+{
+name = winDescent;
+value = 293;
+},
+{
+name = hheaAscender;
+value = 1069;
+},
+{
+name = hheaDescender;
+value = -293;
+},
+{
+name = strikeoutPosition;
+value = 293.66467;
+},
+{
+name = strikeoutSize;
+value = 50;
+},
+{
+name = "Master Icon Glyph Name";
+value = s;
+}
+);
+guides = (
+{
+lockAngle = 1;
+locked = 1;
+pos = (230,357);
+},
+{
+locked = 1;
+pos = (-54,-12);
+},
+{
+locked = 1;
+pos = (103,726);
+}
+);
+id = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+metricValues = (
+{
+over = 17;
+pos = 1069;
+},
+{
+over = 17;
+pos = 714;
+},
+{
+over = 17;
+pos = 489;
+},
+{
+over = -17;
+},
+{
+over = -17;
+pos = -293;
+},
+{
+pos = 12;
+}
+);
+name = "RC CL Italic";
+stemValues = (
+63
+);
+}
+);
+glyphs = (
+{
+glyphname = idotless;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(69,0,l),
+(182,534,l),
+(119,534,l),
+(5,0,l)
+);
+}
+);
+width = 178;
+}
+);
+note = dotlessi;
+unicode = 305;
+},
+{
+glyphname = "acuteFinal-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(108,357,l),
+(304,714,l),
+(249,714,l),
+(54,357,l)
+);
+}
+);
+width = 234;
+}
+);
+metricRight = "=|";
+note = uni141F;
+unicode = 5151;
+},
+{
+glyphname = "graveFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(228,357,l),
+(179,714,l),
+(130,714,l),
+(178,357,l)
+);
+}
+);
+width = 234;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+unicode = 5152;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(271,351,o),
+(308,392,o),
+(324,465,cs),
+(377,714,l),
+(332,714,l),
+(280,470,ls),
+(268,413,o),
+(245,393,o),
+(202,393,cs),
+(151,393,o),
+(136,426,o),
+(147,474,cs),
+(197,714,l),
+(152,714,l),
+(102,477,ls),
+(86,400,o),
+(123,351,o),
+(199,351,cs)
+);
+}
+);
+width = 329;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1421;
+unicode = 5153;
+},
+{
+glyphname = "ringTophalfFinal-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,357,l),
+(173,601,ls),
+(185,658,o),
+(208,678,o),
+(252,678,cs),
+(302,678,o),
+(317,645,o),
+(307,597,cs),
+(256,357,l),
+(301,357,l),
+(351,594,ls),
+(368,671,o),
+(330,720,o),
+(254,720,cs),
+(182,720,o),
+(145,679,o),
+(129,606,cs),
+(76,357,l)
+);
+}
+);
+width = 329;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+unicode = 5154;
+},
+{
+glyphname = "ringRighthalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(109,357,ls),
+(259,357,o),
+(301,490,o),
+(301,582,cs),
+(301,668,o),
+(252,714,o),
+(171,714,cs),
+(148,714,l),
+(139,670,l),
+(168,670,ls),
+(224,670,o),
+(254,639,o),
+(254,579,cs),
+(254,518,o),
+(234,401,o),
+(114,401,cs),
+(82,401,l),
+(72,357,l)
+);
+}
+);
+width = 286;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+unicode = 5155;
+},
+{
+glyphname = "ringFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(367,411,o),
+(430,477,o),
+(430,566,cs),
+(430,653,o),
+(367,720,o),
+(275,720,cs),
+(183,720,o),
+(119,654,o),
+(119,566,cs),
+(119,477,o),
+(183,411,o),
+(275,411,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(207,451,o),
+(162,497,o),
+(162,566,cs),
+(162,634,o),
+(207,680,o),
+(275,680,cs),
+(342,680,o),
+(388,633,o),
+(388,566,cs),
+(388,497,o),
+(342,451,o),
+(275,451,cs)
+);
+}
+);
+width = 413;
+}
+);
+note = uni1424;
+unicode = 5156;
+},
+{
+glyphname = "doubleacuteFinal-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(107,357,l),
+(303,714,l),
+(251,714,l),
+(54,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(217,357,l),
+(414,714,l),
+(361,714,l),
+(164,357,l)
+);
+}
+);
+width = 344;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricRight = "=|";
+note = uni1425;
+unicode = 5157;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,357,l),
+(197,714,l),
+(152,714,l),
+(76,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(220,357,l),
+(296,714,l),
+(251,714,l),
+(175,357,l)
+);
+}
+);
+width = 248;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "pWestCree-canadian";
+note = uni1426;
+unicode = 5158;
+},
+{
+glyphname = "middledotFinal-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(137,325,o),
+(156,344,o),
+(156,367,cs),
+(156,390,o),
+(137,409,o),
+(114,409,cs),
+(91,409,o),
+(72,390,o),
+(72,367,cs),
+(72,344,o),
+(91,325,o),
+(114,325,cs)
+);
+}
+);
+width = 176;
+}
+);
+note = uni1427;
+unicode = 5159;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(361,522,l),
+(371,568,l),
+(122,568,l),
+(112,522,l)
+);
+}
+);
+width = 355;
+}
+);
+metricRight = "=|";
+note = uni1428;
+unicode = 5160;
+},
+{
+glyphname = "plusFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(238,421,l),
+(264,547,l),
+(368,547,l),
+(378,591,l),
+(274,591,l),
+(300,714,l),
+(257,714,l),
+(231,591,l),
+(127,591,l),
+(118,547,l),
+(222,547,l),
+(195,421,l)
+);
+}
+);
+width = 357;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+unicode = 5161;
+},
+{
+glyphname = "downtackFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(226,357,l),
+(293,670,l),
+(394,670,l),
+(404,714,l),
+(153,714,l),
+(144,670,l),
+(247,670,l),
+(181,357,l)
+);
+}
+);
+width = 357;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni142A;
+unicode = 5162;
+},
+{
+glyphname = "thFinalWoodScree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(224,357,l),
+(243,445,l),
+(345,445,l),
+(354,486,l),
+(252,486,l),
+(273,585,l),
+(375,585,l),
+(384,626,l),
+(282,626,l),
+(300,714,l),
+(255,714,l),
+(237,626,l),
+(134,626,l),
+(125,585,l),
+(228,585,l),
+(207,486,l),
+(104,486,l),
+(95,445,l),
+(198,445,l),
+(179,357,l)
+);
+}
+);
+width = 355;
+}
+);
+metricLeft = "hyphen-canadian";
+metricRight = "hyphen-canadian";
+note = uni167E;
+unicode = 5758;
+},
+{
+glyphname = "ringSmallFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(271,554,o),
+(309,591,o),
+(309,641,cs),
+(309,690,o),
+(271,727,o),
+(223,727,cs),
+(174,727,o),
+(136,690,o),
+(136,641,cs),
+(136,591,o),
+(174,554,o),
+(223,554,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(191,586,o),
+(170,609,o),
+(170,641,cs),
+(170,672,o),
+(191,695,o),
+(223,695,cs),
+(254,695,o),
+(276,672,o),
+(276,641,cs),
+(276,609,o),
+(254,586,o),
+(223,586,cs)
+);
+}
+);
+width = 277;
+}
+);
+note = g725;
+unicode = 6366;
+},
+{
+glyphname = "raiseddotFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(209,643,o),
+(228,661,o),
+(228,685,cs),
+(228,708,o),
+(209,727,o),
+(186,727,cs),
+(162,727,o),
+(144,708,o),
+(144,685,cs),
+(144,661,o),
+(162,643,o),
+(186,643,cs)
+);
+}
+);
+width = 184;
+}
+);
+note = g725;
+unicode = 6367;
+},
+{
+glyphname = "acuteFinal-canadian.base";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "acuteFinal-canadian";
+}
+);
+width = 234;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.base";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "graveFinal-canadian";
+}
+);
+width = 234;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian.base";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 329;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1421;
+},
+{
+glyphname = "ringTophalfFinal-canadian.base";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 329;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.base";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 286;
+}
+);
+metricLeft = "==|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "plusFinal-canadian.base";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(148,0,l),
+(174,126,l),
+(278,126,l),
+(288,170,l),
+(184,170,l),
+(210,293,l),
+(168,293,l),
+(142,170,l),
+(37,170,l),
+(28,126,l),
+(132,126,l),
+(106,0,l)
+);
+}
+);
+width = 357;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+},
+{
+glyphname = "acuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "acuteFinal-canadian";
+}
+);
+width = 234;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.mid";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "graveFinal-canadian";
+}
+);
+width = 234;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringTophalfFinal-canadian.mid";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-38,-178);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 329;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.mid";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 286;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "ringFinal-canadian.mid";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-44,-210);
+ref = "ringFinal-canadian";
+}
+);
+width = 413;
+}
+);
+metricLeft = "ringFinal-canadian";
+metricWidth = "ringFinal-canadian";
+note = uni1424;
+},
+{
+glyphname = "doubleacuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "doubleacuteFinal-canadian";
+}
+);
+width = 344;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "doubleacuteFinal-canadian";
+note = uni1425;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian.mid";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "doubleshortverticalstrokesFinal-canadian";
+}
+);
+width = 248;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricWidth = "doubleshortverticalstrokesFinal-canadian";
+note = uni1426;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian.mid";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-38,-178);
+ref = "shorthorizontalstrokeFinal-canadian";
+}
+);
+width = 355;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "shorthorizontalstrokeFinal-canadian";
+note = uni1428;
+},
+{
+glyphname = "downtackFinal-canadian.mid";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "downtackFinal-canadian";
+}
+);
+width = 357;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "downtackFinal-canadian";
+note = uni142A;
+},
+{
+glyphname = "e-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (322,470);
+},
+{
+name = top_center_can;
+pos = (376,714);
+},
+{
+name = top_left_can;
+pos = (201,714);
+},
+{
+name = top_right_can;
+pos = (553,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(239,0,l),
+(624,694,l),
+(629,714,l),
+(128,714,l),
+(124,694,l),
+(214,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(257,68,l),
+(185,677,l),
+(169,661,l),
+(561,661,l),
+(550,677,l),
+(221,68,l)
+);
+}
+);
+width = 557;
+}
+);
+metricRight = "=|";
+note = uni1401;
+unicode = 5121;
+},
+{
+glyphname = "aai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (161,0);
+ref = ring_top.canadian;
+}
+);
+width = 557;
+}
+);
+note = uni1402;
+unicode = 5122;
+},
+{
+glyphname = "i-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (316,417);
+},
+{
+name = top_center_can;
+pos = (378,714);
+},
+{
+name = top_left_can;
+pos = (200,714);
+},
+{
+name = top_right_can;
+pos = (552,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(365,714,l),
+(-20,20,l),
+(-24,0,l),
+(476,0,l),
+(481,20,l),
+(390,714,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(347,646,l),
+(420,37,l),
+(435,53,l),
+(44,53,l),
+(54,37,l),
+(383,646,l)
+);
+}
+);
+width = 557;
+}
+);
+metricLeft = "e-canadian";
+metricWidth = "e-canadian";
+note = uni1403;
+unicode = 5123;
+},
+{
+glyphname = "ii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (218,0);
+ref = dot_top;
+}
+);
+width = 557;
+}
+);
+note = uni1404;
+unicode = 5124;
+},
+{
+glyphname = "o-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (249,364);
+},
+{
+name = top_center_can;
+pos = (383,714);
+},
+{
+name = top_double;
+pos = (462,714);
+},
+{
+name = top_left_can;
+pos = (190,714);
+},
+{
+name = top_right_can;
+pos = (573,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(31,0,l),
+(528,344,l),
+(534,370,l),
+(183,714,l),
+(165,714,l),
+(13,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(202,640,l),
+(178,650,l),
+(480,352,l),
+(480,372,l),
+(60,79,l),
+(81,73,l)
+);
+}
+);
+width = 539;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1405;
+unicode = 5125;
+},
+{
+glyphname = "oo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (29,0);
+ref = dot_top;
+}
+);
+width = 539;
+}
+);
+note = uni1406;
+unicode = 5126;
+},
+{
+glyphname = "yCreeoo-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (166,0);
+ref = doubledot_top;
+}
+);
+width = 539;
+}
+);
+note = uni1407;
+unicode = 5127;
+},
+{
+glyphname = "eeCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(31,0,l),
+(528,344,l),
+(534,370,l),
+(183,714,l),
+(165,714,l),
+(13,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(198,640,l),
+(187,645,l),
+(483,352,l),
+(488,375,l),
+(69,82,l),
+(77,73,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(239,265,l),
+(279,456,l),
+(250,456,l),
+(209,265,l)
+);
+}
+);
+width = 539;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "o-canadian";
+note = uni1408;
+unicode = 5128;
+},
+{
+glyphname = "iCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (175,7);
+ref = dot_middle_optic_small;
+}
+);
+width = 539;
+}
+);
+note = uni1409;
+unicode = 5129;
+},
+{
+glyphname = "a-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (337,357);
+},
+{
+name = top_center_can;
+pos = (342,714);
+},
+{
+name = top_left_can;
+pos = (162,714);
+},
+{
+name = top_right_can;
+pos = (546,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(556,714,l),
+(58,370,l),
+(53,344,l),
+(404,0,l),
+(422,0,l),
+(574,714,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(385,74,l),
+(409,64,l),
+(107,362,l),
+(107,342,l),
+(527,635,l),
+(506,641,l)
+);
+}
+);
+width = 539;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni140A;
+unicode = 5130;
+},
+{
+glyphname = "aa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (385,0);
+ref = dot_top;
+}
+);
+width = 539;
+}
+);
+note = uni140B;
+unicode = 5131;
+},
+{
+glyphname = "we-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "e-canadian";
+}
+);
+width = 733;
+}
+);
+note = uni140C;
+unicode = 5132;
+},
+{
+glyphname = "weWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (557,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 733;
+}
+);
+note = uni140D;
+unicode = 5133;
+},
+{
+glyphname = "wi-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "i-canadian";
+}
+);
+width = 733;
+}
+);
+note = uni140E;
+unicode = 5134;
+},
+{
+glyphname = "wiWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (557,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 733;
+}
+);
+note = uni140F;
+unicode = 5135;
+},
+{
+glyphname = "wii-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (394,0);
+ref = dot_top;
+}
+);
+width = 733;
+}
+);
+note = uni1410;
+unicode = 5136;
+},
+{
+glyphname = "wiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (218,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (557,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 733;
+}
+);
+note = uni1411;
+unicode = 5137;
+},
+{
+glyphname = "wo-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "o-canadian";
+}
+);
+width = 714;
+}
+);
+note = uni1412;
+unicode = 5138;
+},
+{
+glyphname = "woWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (539,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 714;
+}
+);
+note = uni1413;
+unicode = 5139;
+},
+{
+glyphname = "woo-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (398,0);
+ref = dot_top;
+}
+);
+width = 714;
+}
+);
+note = uni1414;
+unicode = 5140;
+},
+{
+glyphname = "wooWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (29,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (539,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 714;
+}
+);
+note = uni1415;
+unicode = 5141;
+},
+{
+glyphname = "wooNaskapi-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (144,-98);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (259,-209);
+ref = dot_top;
+}
+);
+width = 539;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricWidth = "o-canadian";
+note = uni1416;
+unicode = 5142;
+},
+{
+glyphname = "wa-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "a-canadian";
+}
+);
+width = 714;
+}
+);
+note = uni1417;
+unicode = 5143;
+},
+{
+glyphname = "waWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (539,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 714;
+}
+);
+note = uni1418;
+unicode = 5144;
+},
+{
+glyphname = "waa-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (561,0);
+ref = dot_top;
+}
+);
+width = 714;
+}
+);
+note = uni1419;
+unicode = 5145;
+},
+{
+glyphname = "waaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (385,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (539,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 714;
+}
+);
+note = uni141A;
+unicode = 5146;
+},
+{
+glyphname = "waaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (88,-207);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (248,-98);
+ref = dot_top;
+}
+);
+width = 539;
+}
+);
+metricWidth = "a-canadian";
+note = uni141B;
+unicode = 5147;
+},
+{
+glyphname = "ai-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(238,351,o),
+(279,384,o),
+(295,438,c),
+(281,438,l),
+(281,382,o),
+(312,351,o),
+(368,351,cs),
+(434,351,o),
+(473,391,o),
+(491,479,cs),
+(541,714,l),
+(498,714,l),
+(448,479,ls),
+(435,420,o),
+(412,393,o),
+(369,393,cs),
+(322,393,o),
+(305,421,o),
+(317,478,cs),
+(368,714,l),
+(325,714,l),
+(276,483,ls),
+(263,422,o),
+(236,393,o),
+(194,393,cs),
+(152,393,o),
+(133,423,o),
+(144,474,cs),
+(195,714,l),
+(152,714,l),
+(101,470,ls),
+(86,402,o),
+(119,351,o),
+(187,351,cs)
+);
+}
+);
+width = 493;
+}
+);
+metricRight = "=|";
+note = uni141C;
+unicode = 5148;
+},
+{
+glyphname = "ycreew-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(354,528,o),
+(381,564,o),
+(381,624,cs),
+(381,685,o),
+(354,720,o),
+(313,720,cs),
+(273,720,o),
+(246,685,o),
+(246,624,cs),
+(246,564,o),
+(273,528,o),
+(314,528,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(207,351,o),
+(234,387,o),
+(234,447,cs),
+(234,508,o),
+(207,543,o),
+(167,543,cs),
+(126,543,o),
+(99,508,o),
+(99,447,cs),
+(99,387,o),
+(126,351,o),
+(167,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(142,379,o),
+(129,401,o),
+(129,447,cs),
+(129,493,o),
+(142,515,o),
+(167,515,cs),
+(191,515,o),
+(205,493,o),
+(205,447,cs),
+(205,401,o),
+(191,379,o),
+(167,379,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(289,556,o),
+(276,578,o),
+(276,624,cs),
+(276,670,o),
+(289,692,o),
+(314,692,cs),
+(338,692,o),
+(352,670,o),
+(352,624,cs),
+(352,578,o),
+(338,556,o),
+(314,556,cs)
+);
+}
+);
+width = 356;
+}
+);
+metricRight = "=|";
+note = uni141D;
+unicode = 5149;
+},
+{
+glyphname = "glottalstop-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(323,357,l),
+(326,369,l),
+(281,714,l),
+(267,714,l),
+(75,369,l),
+(73,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(277,663,l),
+(253,667,l),
+(287,376,l),
+(299,394,l),
+(114,394,l),
+(121,376,l)
+);
+}
+);
+width = 349;
+}
+);
+metricRight = "=|";
+note = uni141E;
+unicode = 5150;
+},
+{
+glyphname = "en-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+pos = (557,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 791;
+}
+);
+note = uni142B;
+unicode = 5163;
+},
+{
+glyphname = "in-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+pos = (385,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 619;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142C;
+unicode = 5164;
+},
+{
+glyphname = "on-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (422,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 656;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142D;
+unicode = 5165;
+},
+{
+glyphname = "an-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (512,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 746;
+}
+);
+metricRight = "graveFinal-canadian";
+note = uni142E;
+unicode = 5166;
+},
+{
+glyphname = "pe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (323,470);
+},
+{
+name = top_center_can;
+pos = (379,714);
+},
+{
+name = top_left_can;
+pos = (201,714);
+},
+{
+name = top_right_can;
+pos = (553,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(239,0,l),
+(624,694,l),
+(629,714,l),
+(567,714,l),
+(218,75,l),
+(261,75,l),
+(182,714,l),
+(128,714,l),
+(124,694,l),
+(214,0,l)
+);
+}
+);
+width = 557;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni142F;
+unicode = 5167;
+},
+{
+glyphname = "paai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (161,0);
+ref = ring_top.canadian;
+}
+);
+width = 557;
+}
+);
+note = uni1430;
+unicode = 5168;
+},
+{
+glyphname = "pi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (318,417);
+},
+{
+name = top_center_can;
+pos = (378,714);
+},
+{
+name = top_left_can;
+pos = (200,714);
+},
+{
+name = top_right_can;
+pos = (552,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(365,714,l),
+(-20,20,l),
+(-24,0,l),
+(37,0,l),
+(387,639,l),
+(343,639,l),
+(422,0,l),
+(476,0,l),
+(480,20,l),
+(390,714,l)
+);
+}
+);
+width = 556;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni1431;
+unicode = 5169;
+},
+{
+glyphname = "pii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (218,0);
+ref = dot_top;
+}
+);
+width = 557;
+}
+);
+note = uni1432;
+unicode = 5170;
+},
+{
+glyphname = "po-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (196,365);
+},
+{
+name = top_center_can;
+pos = (360,714);
+},
+{
+name = top_double;
+pos = (446,714);
+},
+{
+name = top_left_can;
+pos = (171,714);
+},
+{
+name = top_right_can;
+pos = (546,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+name = "Thin Slanted";
+shapes = (
+{
+closed = 1;
+nodes = (
+(9,0,l),
+(501,344,l),
+(507,370,l),
+(161,714,l),
+(143,714,l),
+(132,662,l),
+(447,348,l),
+(453,380,l),
+(5,66,l),
+(-9,0,l)
+);
+}
+);
+width = 512;
+}
+);
+metricRight = "o-canadian";
+note = uni1433;
+unicode = 5171;
+},
+{
+glyphname = "poo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (10,0);
+ref = dot_top;
+}
+);
+width = 512;
+}
+);
+note = uni1434;
+unicode = 5172;
+},
+{
+glyphname = "ycreepoo-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (150,0);
+ref = doubledot_top;
+}
+);
+width = 512;
+}
+);
+note = uni1435;
+unicode = 5173;
+},
+{
+glyphname = "heeCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (136,8);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 512;
+}
+);
+note = uni1436;
+unicode = 5174;
+},
+{
+glyphname = "hiCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (117,9);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 512;
+}
+);
+note = uni1437;
+unicode = 5175;
+},
+{
+glyphname = "pa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (273,357);
+},
+{
+name = top_center_can;
+pos = (354,714);
+},
+{
+name = top_left_can;
+pos = (163,714);
+},
+{
+name = top_right_can;
+pos = (541,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(550,714,l),
+(59,370,l),
+(53,344,l),
+(398,0,l),
+(416,0,l),
+(427,52,l),
+(113,366,l),
+(107,334,l),
+(554,648,l),
+(568,714,l)
+);
+}
+);
+width = 511;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1438;
+unicode = 5176;
+},
+{
+glyphname = "paa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (380,0);
+ref = dot_top;
+}
+);
+width = 512;
+}
+);
+note = uni1439;
+unicode = 5177;
+},
+{
+glyphname = "pwe-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "pe-canadian";
+}
+);
+width = 733;
+}
+);
+note = uni143A;
+unicode = 5178;
+},
+{
+glyphname = "pweWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "pe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (557,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 733;
+}
+);
+note = uni143B;
+unicode = 5179;
+},
+{
+glyphname = "pwi-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "pi-canadian";
+}
+);
+width = 733;
+}
+);
+note = uni143C;
+unicode = 5180;
+},
+{
+glyphname = "pwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (557,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 733;
+}
+);
+note = uni143D;
+unicode = 5181;
+},
+{
+glyphname = "pwii-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (394,0);
+ref = dot_top;
+}
+);
+width = 733;
+}
+);
+note = uni143E;
+unicode = 5182;
+},
+{
+glyphname = "pwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (218,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (557,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 733;
+}
+);
+note = uni143F;
+unicode = 5183;
+},
+{
+glyphname = "pwo-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "po-canadian";
+}
+);
+width = 687;
+}
+);
+note = uni1440;
+unicode = 5184;
+},
+{
+glyphname = "pwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (512,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 687;
+}
+);
+note = uni1441;
+unicode = 5185;
+},
+{
+glyphname = "pwoo-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (374,0);
+ref = dot_top;
+}
+);
+width = 687;
+}
+);
+note = uni1442;
+unicode = 5186;
+},
+{
+glyphname = "pwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (10,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (512,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 687;
+}
+);
+note = uni1443;
+unicode = 5187;
+},
+{
+glyphname = "pwa-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "pa-canadian";
+}
+);
+width = 687;
+}
+);
+note = uni1444;
+unicode = 5188;
+},
+{
+glyphname = "pwaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (512,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 687;
+}
+);
+note = uni1445;
+unicode = 5189;
+},
+{
+glyphname = "pwaa-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (555,0);
+ref = dot_top;
+}
+);
+width = 687;
+}
+);
+note = uni1446;
+unicode = 5190;
+},
+{
+glyphname = "pwaaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (380,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (512,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 687;
+}
+);
+note = uni1447;
+unicode = 5191;
+},
+{
+glyphname = "ycreepwaa-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+pos = (85,-207);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (245,-98);
+ref = dot_top;
+}
+);
+width = 511;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1448;
+unicode = 5192;
+},
+{
+glyphname = "p-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(292,357,l),
+(301,396,l),
+(150,548,l),
+(144,516,l),
+(358,666,l),
+(368,714,l),
+(358,714,l),
+(116,545,l),
+(112,527,l),
+(282,357,l)
+);
+}
+);
+width = 320;
+}
+);
+note = uni1449;
+unicode = 5193;
+},
+{
+glyphname = "pWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,357,l),
+(197,714,l),
+(152,714,l),
+(76,357,l)
+);
+}
+);
+width = 149;
+}
+);
+metricRight = "=|";
+note = uni144A;
+unicode = 5194;
+},
+{
+color = 6;
+glyphname = "hCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(86,189,l),
+(119,346,ls),
+(127,388,o),
+(150,408,o),
+(179,408,cs),
+(214,408,o),
+(227,384,o),
+(218,343,cs),
+(185,189,l),
+(231,189,l),
+(264,346,ls),
+(277,407,o),
+(249,449,o),
+(194,449,cs),
+(156,449,o),
+(125,424,o),
+(116,385,c),
+(126,380,l),
+(162,546,l),
+(116,546,l),
+(40,189,l)
+);
+}
+);
+width = 278;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144B;
+unicode = 5195;
+},
+{
+glyphname = "te-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (306,357);
+},
+{
+name = top_center_can;
+pos = (382,714);
+},
+{
+name = top_left_can;
+pos = (194,714);
+},
+{
+name = top_right_can;
+pos = (570,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(385,-13,o),
+(464,62,o),
+(497,220,cs),
+(602,714,l),
+(539,714,l),
+(436,227,ls),
+(409,102,o),
+(354,47,o),
+(259,47,cs),
+(139,47,o),
+(97,114,o),
+(126,250,cs),
+(225,714,l),
+(161,714,l),
+(63,253,ls),
+(28,85,o),
+(99,-13,o),
+(256,-13,cs)
+);
+}
+);
+width = 563;
+}
+);
+metricRight = "=|";
+note = uni144C;
+unicode = 5196;
+},
+{
+glyphname = "taai-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (163,0);
+ref = ring_top.canadian;
+}
+);
+width = 564;
+}
+);
+note = uni144D;
+unicode = 5197;
+},
+{
+glyphname = "ti-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (305,357);
+},
+{
+name = middle_right_can;
+pos = (619,357);
+},
+{
+name = top_center_can;
+pos = (381,714);
+},
+{
+name = top_left_can;
+pos = (194,714);
+},
+{
+name = top_right_can;
+pos = (570,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(73,0,l),
+(176,487,ls),
+(203,612,o),
+(259,667,o),
+(353,667,cs),
+(473,667,o),
+(515,600,o),
+(486,464,cs),
+(387,0,l),
+(450,0,l),
+(548,461,ls),
+(584,629,o),
+(513,727,o),
+(356,727,cs),
+(227,727,o),
+(148,652,o),
+(114,494,cs),
+(9,0,l)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni144E;
+unicode = 5198;
+},
+{
+glyphname = "tii-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (221,0);
+ref = dot_top;
+}
+);
+width = 564;
+}
+);
+note = uni144F;
+unicode = 5199;
+},
+{
+glyphname = "to-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (223,357);
+},
+{
+name = middle_right_can;
+pos = (534,357);
+},
+{
+name = top_center_can;
+pos = (310,714);
+},
+{
+name = top_double;
+pos = (356,714);
+},
+{
+name = top_left_can;
+pos = (171,714);
+},
+{
+name = top_right_can;
+pos = (489,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(91,0,ls),
+(381,0,o),
+(454,305,o),
+(454,474,cs),
+(454,633,o),
+(371,714,o),
+(215,714,cs),
+(143,714,l),
+(131,655,l),
+(203,655,ls),
+(329,655,o),
+(390,597,o),
+(390,473,cs),
+(390,336,o),
+(332,59,o),
+(94,59,cs),
+(4,59,l),
+(-9,0,l)
+);
+}
+);
+width = 469;
+}
+);
+note = uni1450;
+unicode = 5200;
+},
+{
+glyphname = "too-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (149,0);
+ref = dot_top;
+}
+);
+width = 469;
+}
+);
+note = uni1451;
+unicode = 5201;
+},
+{
+glyphname = "ycreetoo-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (61,0);
+ref = doubledot_top;
+}
+);
+width = 469;
+}
+);
+note = uni1452;
+unicode = 5202;
+},
+{
+glyphname = "deeCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (160,0);
+ref = stroke_middle;
+}
+);
+width = 469;
+}
+);
+note = uni1453;
+unicode = 5203;
+},
+{
+glyphname = "diCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (139,0);
+ref = dot_middle;
+}
+);
+width = 469;
+}
+);
+note = uni1454;
+unicode = 5204;
+},
+{
+glyphname = "ta-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (292,357);
+},
+{
+name = top_center_can;
+pos = (358,714);
+},
+{
+name = top_left_can;
+pos = (177,714);
+},
+{
+name = top_right_can;
+pos = (498,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(374,0,l),
+(386,59,l),
+(311,59,ls),
+(185,59,o),
+(127,117,o),
+(127,241,cs),
+(127,382,o),
+(185,655,o),
+(420,655,cs),
+(513,655,l),
+(526,714,l),
+(423,714,ls),
+(137,714,o),
+(63,413,o),
+(63,239,cs),
+(63,81,o),
+(143,0,o),
+(299,0,cs)
+);
+}
+);
+width = 469;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|to-canadian";
+note = uni1455;
+unicode = 5205;
+},
+{
+glyphname = "taa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (197,0);
+ref = dot_top;
+}
+);
+width = 469;
+}
+);
+note = uni1456;
+unicode = 5206;
+},
+{
+glyphname = "twe-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "te-canadian";
+}
+);
+width = 739;
+}
+);
+note = uni1457;
+unicode = 5207;
+},
+{
+glyphname = "tweWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (564,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 739;
+}
+);
+note = uni1458;
+unicode = 5208;
+},
+{
+glyphname = "twi-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ti-canadian";
+}
+);
+width = 739;
+}
+);
+note = uni1459;
+unicode = 5209;
+},
+{
+glyphname = "twiWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (564,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 739;
+}
+);
+note = uni145A;
+unicode = 5210;
+},
+{
+glyphname = "twii-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (396,0);
+ref = dot_top;
+}
+);
+width = 739;
+}
+);
+note = uni145B;
+unicode = 5211;
+},
+{
+glyphname = "twiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (221,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (564,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 739;
+}
+);
+note = uni145C;
+unicode = 5212;
+},
+{
+glyphname = "two-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "to-canadian";
+}
+);
+width = 644;
+}
+);
+note = uni145D;
+unicode = 5213;
+},
+{
+glyphname = "twoWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (469,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 644;
+}
+);
+note = uni145E;
+unicode = 5214;
+},
+{
+glyphname = "twoo-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (325,0);
+ref = dot_top;
+}
+);
+width = 644;
+}
+);
+note = uni145F;
+unicode = 5215;
+},
+{
+glyphname = "twooWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (149,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (469,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 644;
+}
+);
+note = uni1460;
+unicode = 5216;
+},
+{
+glyphname = "twa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ta-canadian";
+}
+);
+width = 644;
+}
+);
+note = uni1461;
+unicode = 5217;
+},
+{
+glyphname = "twaWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (469,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 644;
+}
+);
+note = uni1462;
+unicode = 5218;
+},
+{
+glyphname = "twaa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (373,0);
+ref = dot_top;
+}
+);
+width = 644;
+}
+);
+note = uni1463;
+unicode = 5219;
+},
+{
+glyphname = "twaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (197,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (469,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 644;
+}
+);
+note = uni1464;
+unicode = 5220;
+},
+{
+glyphname = "twaaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (192,0);
+ref = "ta-canadian";
+}
+);
+width = 661;
+}
+);
+note = uni1465;
+unicode = 5221;
+},
+{
+glyphname = "t-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(261,357,l),
+(271,401,l),
+(241,401,ls),
+(183,401,o),
+(154,432,o),
+(154,491,cs),
+(154,566,o),
+(184,670,o),
+(296,670,cs),
+(327,670,l),
+(337,714,l),
+(303,714,ls),
+(156,714,o),
+(109,590,o),
+(109,489,cs),
+(109,403,o),
+(155,357,o),
+(238,357,cs)
+);
+}
+);
+width = 286;
+}
+);
+note = uni1466;
+unicode = 5222;
+},
+{
+glyphname = "tte-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+pos = (564,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 713;
+}
+);
+note = uni1467;
+unicode = 5223;
+},
+{
+glyphname = "tti-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+pos = (564,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 713;
+}
+);
+note = uni1468;
+unicode = 5224;
+},
+{
+glyphname = "tto-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+pos = (469,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 619;
+}
+);
+note = uni1469;
+unicode = 5225;
+},
+{
+glyphname = "tta-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+pos = (469,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 619;
+}
+);
+note = uni146A;
+unicode = 5226;
+},
+{
+glyphname = "ke-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (291,457);
+},
+{
+name = top_center_can;
+pos = (329,714);
+},
+{
+name = top_left_can;
+pos = (186,714);
+},
+{
+name = top_right_can;
+pos = (474,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(353,0,l),
+(449,454,ls),
+(477,585,o),
+(461,727,o),
+(316,727,cs),
+(144,727,o),
+(95,501,o),
+(95,381,cs),
+(95,273,o),
+(141,212,o),
+(229,212,cs),
+(294,212,o),
+(341,249,o),
+(373,331,c),
+(360,331,l),
+(289,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(186,268,o),
+(156,307,o),
+(156,383,cs),
+(156,464,o),
+(191,671,o),
+(311,671,cs),
+(370,671,o),
+(400,632,o),
+(400,557,cs),
+(400,476,o),
+(365,268,o),
+(244,268,cs)
+);
+}
+);
+width = 466;
+}
+);
+metricRight = "te-canadian";
+note = uni146B;
+unicode = 5227;
+},
+{
+glyphname = "kaai-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (118,0);
+ref = ring_top.canadian;
+}
+);
+width = 466;
+}
+);
+note = uni146C;
+unicode = 5228;
+},
+{
+glyphname = "ki-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (297,457);
+},
+{
+name = top_center_can;
+pos = (336,714);
+},
+{
+name = top_left_can;
+pos = (193,714);
+},
+{
+name = top_right_can;
+pos = (480,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(73,0,l),
+(151,365,l),
+(136,334,l),
+(136,262,o),
+(179,212,o),
+(252,212,cs),
+(417,212,o),
+(466,441,o),
+(466,555,cs),
+(466,666,o),
+(417,727,o),
+(323,727,cs),
+(217,727,o),
+(147,647,o),
+(113,488,cs),
+(9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(192,268,o),
+(163,307,o),
+(163,382,cs),
+(163,464,o),
+(200,671,o),
+(318,671,cs),
+(377,671,o),
+(406,633,o),
+(406,557,cs),
+(406,472,o),
+(369,268,o),
+(251,268,cs)
+);
+}
+);
+width = 466;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni146D;
+unicode = 5229;
+},
+{
+glyphname = "kii-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (175,0);
+ref = dot_top;
+}
+);
+width = 466;
+}
+);
+note = uni146E;
+unicode = 5230;
+},
+{
+glyphname = "ko-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (280,411);
+},
+{
+name = top_center_can;
+pos = (330,714);
+},
+{
+name = top_double;
+pos = (473,714);
+},
+{
+name = top_left_can;
+pos = (187,714);
+},
+{
+name = top_right_can;
+pos = (473,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(298,-13,o),
+(367,67,o),
+(401,226,cs),
+(505,714,l),
+(441,714,l),
+(363,349,l),
+(378,380,l),
+(378,452,o),
+(335,502,o),
+(262,502,cs),
+(97,502,o),
+(47,274,o),
+(47,159,cs),
+(47,49,o),
+(97,-13,o),
+(191,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(137,43,o),
+(108,82,o),
+(108,157,cs),
+(108,239,o),
+(145,446,o),
+(263,446,cs),
+(322,446,o),
+(351,407,o),
+(351,332,cs),
+(351,244,o),
+(316,43,o),
+(196,43,cs)
+);
+}
+);
+width = 466;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni146F;
+unicode = 5231;
+},
+{
+glyphname = "koo-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (312,0);
+ref = dot_top;
+}
+);
+width = 466;
+}
+);
+note = uni1470;
+unicode = 5232;
+},
+{
+glyphname = "ycreekoo-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (178,0);
+ref = doubledot_top;
+}
+);
+width = 466;
+}
+);
+note = uni1471;
+unicode = 5233;
+},
+{
+glyphname = "ka-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (286,412);
+},
+{
+name = top_center_can;
+pos = (335,714);
+},
+{
+name = top_left_can;
+pos = (193,714);
+},
+{
+name = top_right_can;
+pos = (479,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(370,-13,o),
+(419,213,o),
+(419,333,cs),
+(419,441,o),
+(372,502,o),
+(284,502,cs),
+(224,502,o),
+(177,465,o),
+(141,383,c),
+(154,383,l),
+(225,714,l),
+(161,714,l),
+(65,260,ls),
+(28,85,o),
+(79,-13,o),
+(197,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(144,43,o),
+(115,82,o),
+(115,157,cs),
+(115,238,o),
+(149,446,o),
+(269,446,cs),
+(328,446,o),
+(357,407,o),
+(357,331,cs),
+(357,249,o),
+(323,43,o),
+(203,43,cs)
+);
+}
+);
+width = 466;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "==|ke-canadian";
+note = uni1472;
+unicode = 5234;
+},
+{
+glyphname = "kaa-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (32,0);
+ref = dot_top;
+}
+);
+width = 466;
+}
+);
+note = uni1473;
+unicode = 5235;
+},
+{
+glyphname = "kwe-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ke-canadian";
+}
+);
+width = 641;
+}
+);
+note = uni1474;
+unicode = 5236;
+},
+{
+glyphname = "kweWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (466,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 641;
+}
+);
+note = uni1475;
+unicode = 5237;
+},
+{
+glyphname = "kwi-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ki-canadian";
+}
+);
+width = 641;
+}
+);
+note = uni1476;
+unicode = 5238;
+},
+{
+glyphname = "kwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (466,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 641;
+}
+);
+note = uni1477;
+unicode = 5239;
+},
+{
+glyphname = "kwii-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (351,0);
+ref = dot_top;
+}
+);
+width = 641;
+}
+);
+note = uni1478;
+unicode = 5240;
+},
+{
+glyphname = "kwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (175,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (466,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 641;
+}
+);
+note = uni1479;
+unicode = 5241;
+},
+{
+glyphname = "kwo-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ko-canadian";
+}
+);
+width = 641;
+}
+);
+note = uni147A;
+unicode = 5242;
+},
+{
+glyphname = "kwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (466,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 641;
+}
+);
+note = uni147B;
+unicode = 5243;
+},
+{
+glyphname = "kwoo-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (487,0);
+ref = dot_top;
+}
+);
+width = 641;
+}
+);
+note = uni147C;
+unicode = 5244;
+},
+{
+glyphname = "kwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (312,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (466,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 641;
+}
+);
+note = uni147D;
+unicode = 5245;
+},
+{
+glyphname = "kwa-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ka-canadian";
+}
+);
+width = 641;
+}
+);
+note = uni147E;
+unicode = 5246;
+},
+{
+glyphname = "kwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (466,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 641;
+}
+);
+note = uni147F;
+unicode = 5247;
+},
+{
+glyphname = "kwaa-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (207,0);
+ref = dot_top;
+}
+);
+width = 641;
+}
+);
+note = uni1480;
+unicode = 5248;
+},
+{
+glyphname = "kwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (32,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (466,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 641;
+}
+);
+note = uni1481;
+unicode = 5249;
+},
+{
+glyphname = "kwaaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (192,0);
+ref = "ka-canadian";
+}
+);
+width = 658;
+}
+);
+note = uni1482;
+unicode = 5250;
+},
+{
+glyphname = "k-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(273,351,o),
+(302,472,o),
+(302,531,cs),
+(302,587,o),
+(276,622,o),
+(231,622,cs),
+(191,622,o),
+(160,590,o),
+(148,546,c),
+(162,546,l),
+(197,714,l),
+(152,714,l),
+(105,494,ls),
+(92,434,o),
+(98,351,o),
+(180,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(156,388,o),
+(143,408,o),
+(143,444,cs),
+(143,484,o),
+(161,585,o),
+(220,585,cs),
+(246,585,o),
+(259,565,o),
+(259,530,cs),
+(259,488,o),
+(241,388,o),
+(182,388,cs)
+);
+}
+);
+width = 288;
+}
+);
+note = uni1483;
+unicode = 5251;
+},
+{
+glyphname = "kw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(229,350,o),
+(268,393,o),
+(286,481,cs),
+(335,714,l),
+(290,714,l),
+(253,538,l),
+(268,546,l),
+(269,592,o),
+(243,621,o),
+(203,621,cs),
+(119,621,o),
+(90,502,o),
+(90,446,cs),
+(90,386,o),
+(119,350,o),
+(171,350,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(145,388,o),
+(131,408,o),
+(131,443,cs),
+(131,483,o),
+(150,584,o),
+(208,584,cs),
+(234,584,o),
+(248,563,o),
+(248,528,cs),
+(248,493,o),
+(232,388,o),
+(171,388,cs)
+);
+}
+);
+width = 288;
+}
+);
+metricLeft = "=|k-canadian";
+metricRight = "=|k-canadian";
+note = uni1484;
+unicode = 5252;
+},
+{
+glyphname = "southslaveykeh-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+pos = (466,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 615;
+}
+);
+note = uni1485;
+unicode = 5253;
+},
+{
+glyphname = "southslaveykih-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+pos = (466,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 615;
+}
+);
+note = uni1486;
+unicode = 5254;
+},
+{
+glyphname = "southslaveykoh-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+pos = (466,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 615;
+}
+);
+note = uni1487;
+unicode = 5255;
+},
+{
+glyphname = "southslaveykah-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+pos = (466,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 615;
+}
+);
+note = uni1488;
+unicode = 5256;
+},
+{
+glyphname = "ce-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (283,435);
+},
+{
+name = top_center_can;
+pos = (328,714);
+},
+{
+name = top_left_can;
+pos = (186,714);
+},
+{
+name = top_right_can;
+pos = (469,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(348,0,l),
+(453,491,ls),
+(484,641,o),
+(425,727,o),
+(311,727,cs),
+(203,727,o),
+(142,658,o),
+(109,504,cs),
+(88,405,l),
+(151,405,l),
+(174,513,ls),
+(198,623,o),
+(238,670,o),
+(304,670,cs),
+(380,670,o),
+(416,615,o),
+(392,502,cs),
+(285,0,l)
+);
+}
+);
+width = 462;
+}
+);
+metricRight = "te-canadian";
+note = uni1489;
+unicode = 5257;
+},
+{
+glyphname = "caai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (118,0);
+ref = ring_top.canadian;
+}
+);
+width = 462;
+}
+);
+note = uni148A;
+unicode = 5258;
+},
+{
+glyphname = "ci-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (291,435);
+},
+{
+name = top_center_can;
+pos = (336,714);
+},
+{
+name = top_left_can;
+pos = (194,714);
+},
+{
+name = top_right_can;
+pos = (478,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(73,0,l),
+(182,513,ls),
+(205,623,o),
+(245,670,o),
+(312,670,cs),
+(388,670,o),
+(424,615,o),
+(400,502,cs),
+(379,405,l),
+(442,405,l),
+(460,491,ls),
+(493,641,o),
+(433,727,o),
+(319,727,cs),
+(210,727,o),
+(149,658,o),
+(117,504,cs),
+(9,0,l)
+);
+}
+);
+width = 462;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+unicode = 5259;
+},
+{
+glyphname = "cii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (175,0);
+ref = dot_top;
+}
+);
+width = 462;
+}
+);
+note = uni148C;
+unicode = 5260;
+},
+{
+glyphname = "co-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (284,435);
+},
+{
+name = top_center_can;
+pos = (327,714);
+},
+{
+name = top_double;
+pos = (469,714);
+},
+{
+name = top_left_can;
+pos = (186,714);
+},
+{
+name = top_right_can;
+pos = (469,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(299,-13,o),
+(360,56,o),
+(393,210,cs),
+(500,714,l),
+(437,714,l),
+(328,201,ls),
+(304,91,o),
+(265,44,o),
+(198,44,cs),
+(121,44,o),
+(86,99,o),
+(110,212,cs),
+(131,309,l),
+(68,309,l),
+(49,223,ls),
+(17,73,o),
+(77,-13,o),
+(191,-13,cs)
+);
+}
+);
+width = 461;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+unicode = 5261;
+},
+{
+glyphname = "coo-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (308,0);
+ref = dot_top;
+}
+);
+width = 462;
+}
+);
+note = uni148E;
+unicode = 5262;
+},
+{
+glyphname = "ycreecoo-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (173,0);
+ref = doubledot_top;
+}
+);
+width = 462;
+}
+);
+note = uni148F;
+unicode = 5263;
+},
+{
+glyphname = "ca-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (292,435);
+},
+{
+name = top_center_can;
+pos = (336,714);
+},
+{
+name = top_left_can;
+pos = (194,714);
+},
+{
+name = top_right_can;
+pos = (476,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(307,-13,o),
+(367,56,o),
+(400,210,cs),
+(421,309,l),
+(358,309,l),
+(335,201,ls),
+(311,91,o),
+(272,44,o),
+(206,44,cs),
+(129,44,o),
+(94,99,o),
+(118,212,cs),
+(225,714,l),
+(161,714,l),
+(57,223,ls),
+(25,73,o),
+(85,-13,o),
+(199,-13,cs)
+);
+}
+);
+width = 461;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+unicode = 5264;
+},
+{
+glyphname = "caa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (33,0);
+ref = dot_top;
+}
+);
+width = 462;
+}
+);
+note = uni1491;
+unicode = 5265;
+},
+{
+glyphname = "cwe-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ce-canadian";
+}
+);
+width = 637;
+}
+);
+note = uni1492;
+unicode = 5266;
+},
+{
+glyphname = "cweWestCree-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (462,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 637;
+}
+);
+note = uni1493;
+unicode = 5267;
+},
+{
+glyphname = "cwi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+pos = (176,0);
+ref = "ci-canadian";
+}
+);
+width = 638;
+}
+);
+note = uni1494;
+unicode = 5268;
+},
+{
+glyphname = "cwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "ci-canadian";
+},
+{
+anchor = middle_right_can;
+pos = (462,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 638;
+}
+);
+note = uni1495;
+unicode = 5269;
+},
+{
+glyphname = "cwii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+pos = (176,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (351,0);
+ref = dot_top;
+}
+);
+width = 638;
+}
+);
+note = uni1496;
+unicode = 5270;
+},
+{
+glyphname = "cwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (175,0);
+ref = dot_top;
+},
+{
+anchor = middle_right_can;
+pos = (462,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 638;
+}
+);
+note = uni1497;
+unicode = 5271;
+},
+{
+glyphname = "cwo-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "co-canadian";
+}
+);
+width = 637;
+}
+);
+note = uni1498;
+unicode = 5272;
+},
+{
+glyphname = "cwoWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (462,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 637;
+}
+);
+note = uni1499;
+unicode = 5273;
+},
+{
+glyphname = "cwoo-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (484,0);
+ref = dot_top;
+}
+);
+width = 637;
+}
+);
+note = uni149A;
+unicode = 5274;
+},
+{
+glyphname = "cwooWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (308,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (462,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 637;
+}
+);
+note = uni149B;
+unicode = 5275;
+},
+{
+glyphname = "cwa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ca-canadian";
+}
+);
+width = 637;
+}
+);
+note = uni149C;
+unicode = 5276;
+},
+{
+glyphname = "cwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (462,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 637;
+}
+);
+note = uni149D;
+unicode = 5277;
+},
+{
+glyphname = "cwaa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (208,0);
+ref = dot_top;
+}
+);
+width = 637;
+}
+);
+note = uni149E;
+unicode = 5278;
+},
+{
+glyphname = "cwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (33,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (462,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 637;
+}
+);
+note = uni149F;
+unicode = 5279;
+},
+{
+glyphname = "cwaaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (192,0);
+ref = "ca-canadian";
+}
+);
+width = 654;
+}
+);
+note = uni14A0;
+unicode = 5280;
+},
+{
+glyphname = "c-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(241,351,o),
+(279,394,o),
+(293,465,cs),
+(301,502,l),
+(259,502,l),
+(250,459,ls),
+(240,416,o),
+(218,390,o),
+(185,390,cs),
+(147,390,o),
+(136,424,o),
+(145,468,cs),
+(197,714,l),
+(152,714,l),
+(102,476,ls),
+(87,408,o),
+(113,351,o),
+(183,351,cs)
+);
+}
+);
+width = 279;
+}
+);
+note = uni14A1;
+unicode = 5281;
+},
+{
+glyphname = "thSayisi-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(224,351,o),
+(259,394,o),
+(275,467,cs),
+(328,714,l),
+(282,714,l),
+(229,465,ls),
+(218,411,o),
+(196,390,o),
+(162,390,cs),
+(125,390,o),
+(113,424,o),
+(123,469,cs),
+(130,502,l),
+(88,502,l),
+(82,474,ls),
+(69,405,o),
+(95,351,o),
+(165,351,cs)
+);
+}
+);
+width = 280;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "=|c-canadian";
+note = uni14A2;
+unicode = 5282;
+},
+{
+glyphname = "me-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (183,357);
+},
+{
+name = top_center_can;
+pos = (292,714);
+},
+{
+name = top_left_can;
+pos = (166,714);
+},
+{
+name = top_right_can;
+pos = (415,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(295,0,l),
+(447,714,l),
+(135,714,l),
+(122,655,l),
+(371,655,l),
+(232,0,l)
+);
+}
+);
+width = 412;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+unicode = 5283;
+},
+{
+glyphname = "maai-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (103,0);
+ref = ring_top.canadian;
+}
+);
+width = 412;
+}
+);
+note = uni14A4;
+unicode = 5284;
+},
+{
+glyphname = "mi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (278,357);
+},
+{
+name = top_center_can;
+pos = (321,714);
+},
+{
+name = top_left_can;
+pos = (197,714);
+},
+{
+name = top_right_can;
+pos = (446,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(76,0,l),
+(216,655,l),
+(464.99,655.008,l),
+(478,714,l),
+(165,714,l),
+(13,0,l)
+);
+}
+);
+width = 413;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+unicode = 5285;
+},
+{
+glyphname = "mii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (160,0);
+ref = dot_top;
+}
+);
+width = 412;
+}
+);
+note = uni14A6;
+unicode = 5286;
+},
+{
+glyphname = "mo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (184,357);
+},
+{
+name = top_center_can;
+pos = (293,714);
+},
+{
+name = top_double;
+pos = (417,714);
+},
+{
+name = top_left_can;
+pos = (167,714);
+},
+{
+name = top_right_can;
+pos = (416,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(296,0,l),
+(448,714,l),
+(385,714,l),
+(245,59,l),
+(-4,59,l),
+(-16,0,l)
+);
+}
+);
+width = 413;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+unicode = 5287;
+},
+{
+glyphname = "moo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (254,0);
+ref = dot_top;
+}
+);
+width = 412;
+}
+);
+note = uni14A8;
+unicode = 5288;
+},
+{
+glyphname = "ycreemoo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (120,0);
+ref = doubledot_top;
+}
+);
+width = 412;
+}
+);
+note = uni14A9;
+unicode = 5289;
+},
+{
+glyphname = "ma-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (278,357);
+},
+{
+name = top_center_can;
+pos = (321,714);
+},
+{
+name = top_left_can;
+pos = (197,714);
+},
+{
+name = top_right_can;
+pos = (445,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(326,0,l),
+(338,59,l),
+(89,59,l),
+(228,714,l),
+(165,714,l),
+(13,0,l)
+);
+}
+);
+width = 413;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+unicode = 5290;
+},
+{
+glyphname = "maa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+}
+);
+width = 412;
+}
+);
+note = uni14AB;
+unicode = 5291;
+},
+{
+glyphname = "mwe-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "me-canadian";
+}
+);
+width = 588;
+}
+);
+note = uni14AC;
+unicode = 5292;
+},
+{
+glyphname = "mweWestCree-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "me-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (412,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 588;
+}
+);
+note = uni14AD;
+unicode = 5293;
+},
+{
+glyphname = "mwi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "mi-canadian";
+}
+);
+width = 588;
+}
+);
+note = uni14AE;
+unicode = 5294;
+},
+{
+glyphname = "mwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (412,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 588;
+}
+);
+note = uni14AF;
+unicode = 5295;
+},
+{
+glyphname = "mwii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (336,0);
+ref = dot_top;
+}
+);
+width = 588;
+}
+);
+note = uni14B0;
+unicode = 5296;
+},
+{
+glyphname = "mwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (160,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (412,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 588;
+}
+);
+note = uni14B1;
+unicode = 5297;
+},
+{
+glyphname = "mwo-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "mo-canadian";
+}
+);
+width = 588;
+}
+);
+note = uni14B2;
+unicode = 5298;
+},
+{
+glyphname = "mwoWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (412,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 588;
+}
+);
+note = uni14B3;
+unicode = 5299;
+},
+{
+glyphname = "mwoo-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (430,0);
+ref = dot_top;
+}
+);
+width = 588;
+}
+);
+note = uni14B4;
+unicode = 5300;
+},
+{
+glyphname = "mwooWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (254,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (412,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 588;
+}
+);
+note = uni14B5;
+unicode = 5301;
+},
+{
+glyphname = "mwa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ma-canadian";
+}
+);
+width = 588;
+}
+);
+note = uni14B6;
+unicode = 5302;
+},
+{
+glyphname = "mwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (412,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 588;
+}
+);
+note = uni14B7;
+unicode = 5303;
+},
+{
+glyphname = "mwaa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (212,0);
+ref = dot_top;
+}
+);
+width = 588;
+}
+);
+note = uni14B8;
+unicode = 5304;
+},
+{
+glyphname = "mwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (412,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 588;
+}
+);
+note = uni14B9;
+unicode = 5305;
+},
+{
+glyphname = "mwaaNaskapi-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (192,0);
+ref = "ma-canadian";
+}
+);
+width = 604;
+}
+);
+note = uni14BA;
+unicode = 5306;
+},
+{
+glyphname = "m-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(248,357,l),
+(258,401,l),
+(131,401,l),
+(197,714,l),
+(152,714,l),
+(76,357,l)
+);
+}
+);
+width = 254;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni14BB;
+unicode = 5307;
+},
+{
+glyphname = "mWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "t-canadian";
+}
+);
+width = 286;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "t-canadian";
+note = uni14BC;
+unicode = 5308;
+},
+{
+glyphname = "mh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(226,357,l),
+(302,714,l),
+(258,714,l),
+(191,401,l),
+(63,401,l),
+(53,357,l)
+);
+}
+);
+width = 254;
+}
+);
+metricLeft = "=|m-canadian";
+metricRight = "=|m-canadian";
+note = uni14BD;
+unicode = 5309;
+},
+{
+glyphname = "mAthapascan-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(261,357,l),
+(270,398,l),
+(135,398,l),
+(133,374,l),
+(244,504,ls),
+(280,546,o),
+(306,587,o),
+(306,636,cs),
+(306,689,o),
+(277,720,o),
+(226,720,cs),
+(175,720,o),
+(136,686,o),
+(122,598,c),
+(164,598,l),
+(173,661,o),
+(196,684,o),
+(224,684,cs),
+(251,684,o),
+(264,669,o),
+(264,638,cs),
+(264,598,o),
+(245,564,o),
+(210,524,cs),
+(87,380,l),
+(82,357,l)
+);
+}
+);
+width = 278;
+}
+);
+note = uni14BE;
+unicode = 5310;
+},
+{
+glyphname = "mSayisi-canadian";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = two.canadian;
+}
+);
+width = 450;
+}
+);
+note = uni14BF;
+unicode = 5311;
+},
+{
+glyphname = "ne-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (405,254);
+},
+{
+name = top_center_can;
+pos = (451,508);
+},
+{
+name = top_left_can;
+pos = (139,508);
+},
+{
+name = top_right_can;
+pos = (607,508);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(538,-13,o),
+(587,204,o),
+(587,312,cs),
+(587,425,o),
+(531,489,o),
+(426,489,cs),
+(103,489,l),
+(91,431,l),
+(353,431,l),
+(352,454,l),
+(243,415,o),
+(214,252,o),
+(214,164,cs),
+(214,52,o),
+(270,-13,o),
+(369,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(308,43,o),
+(276,84,o),
+(276,163,cs),
+(276,241,o),
+(306,433,o),
+(431,433,cs),
+(493,433,o),
+(525,392,o),
+(525,314,cs),
+(525,236,o),
+(496,43,o),
+(370,43,cs)
+);
+}
+);
+width = 637;
+}
+);
+metricRight = "=|ke-canadian";
+note = uni14C0;
+unicode = 5312;
+},
+{
+glyphname = "naai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (78,-206);
+ref = ring_top.canadian;
+}
+);
+width = 637;
+}
+);
+note = uni14C1;
+unicode = 5313;
+},
+{
+glyphname = "ni-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (235,254);
+},
+{
+name = top_center_can;
+pos = (298,508);
+},
+{
+name = top_left_can;
+pos = (141,508);
+},
+{
+name = top_right_can;
+pos = (610,508);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(372,-13,o),
+(420,204,o),
+(420,312,cs),
+(420,373,o),
+(402,417,o),
+(367,440,c),
+(362,431,l),
+(626,431,l),
+(639,489,l),
+(272,489,ls),
+(94,489,o),
+(48,273,o),
+(48,164,cs),
+(48,52,o),
+(103,-13,o),
+(202,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(141,43,o),
+(110,84,o),
+(110,163,cs),
+(110,241,o),
+(139,433,o),
+(264,433,cs),
+(327,433,o),
+(358,392,o),
+(358,314,cs),
+(358,236,o),
+(329,43,o),
+(204,43,cs)
+);
+}
+);
+width = 638;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+unicode = 5314;
+},
+{
+glyphname = "nii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (136,-206);
+ref = dot_top;
+}
+);
+width = 637;
+}
+);
+note = uni14C3;
+unicode = 5315;
+},
+{
+glyphname = "no-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (405,254);
+},
+{
+name = top_center_can;
+pos = (457,508);
+},
+{
+name = top_double;
+pos = (460,508);
+},
+{
+name = top_left_can;
+pos = (138,508);
+},
+{
+name = top_right_can;
+pos = (608,508);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(365,0,ls),
+(544,0,o),
+(590,217,o),
+(590,325,cs),
+(590,437,o),
+(535,502,o),
+(436,502,cs),
+(266,502,o),
+(218,286,o),
+(218,177,cs),
+(218,116,o),
+(236,72,o),
+(271,49,c),
+(276,59,l),
+(12,59,l),
+(-1,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(311,56,o),
+(279,97,o),
+(279,175,cs),
+(279,254,o),
+(309,446,o),
+(434,446,cs),
+(496,446,o),
+(528,405,o),
+(528,326,cs),
+(528,248,o),
+(499,56,o),
+(373,56,cs)
+);
+}
+);
+width = 637;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14C4;
+unicode = 5316;
+},
+{
+glyphname = "noo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (296,-206);
+ref = dot_top;
+}
+);
+width = 637;
+}
+);
+note = uni14C5;
+unicode = 5317;
+},
+{
+glyphname = "ycreenoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (165,-206);
+ref = doubledot_top;
+}
+);
+width = 637;
+}
+);
+note = uni14C6;
+unicode = 5318;
+},
+{
+glyphname = "na-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (236,254);
+},
+{
+name = top_center_can;
+pos = (291,508);
+},
+{
+name = top_double;
+pos = (404,508);
+},
+{
+name = top_left_can;
+pos = (141,508);
+},
+{
+name = top_right_can;
+pos = (610,508);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(534,0,l),
+(546,59,l),
+(284,59,l),
+(284,35,l),
+(393,74,o),
+(422,237,o),
+(422,325,cs),
+(422,437,o),
+(367,502,o),
+(268,502,cs),
+(99,502,o),
+(50,286,o),
+(50,177,cs),
+(50,64,o),
+(106,0,o),
+(211,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(143,56,o),
+(112,97,o),
+(112,175,cs),
+(112,254,o),
+(141,446,o),
+(267,446,cs),
+(329,446,o),
+(361,405,o),
+(361,326,cs),
+(361,248,o),
+(331,56,o),
+(206,56,cs)
+);
+}
+);
+width = 637;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+unicode = 5319;
+},
+{
+glyphname = "naa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (130,-206);
+ref = dot_top;
+}
+);
+width = 637;
+}
+);
+note = uni14C8;
+unicode = 5320;
+},
+{
+glyphname = "nwe-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ne-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni14C9;
+unicode = 5321;
+},
+{
+glyphname = "nweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni14CA;
+unicode = 5322;
+},
+{
+glyphname = "nwa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "na-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni14CB;
+unicode = 5323;
+},
+{
+glyphname = "nwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni14CC;
+unicode = 5324;
+},
+{
+glyphname = "nwaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (306,-206);
+ref = dot_top;
+}
+);
+width = 812;
+}
+);
+note = uni14CD;
+unicode = 5325;
+},
+{
+glyphname = "nwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (130,-206);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni14CE;
+unicode = 5326;
+},
+{
+glyphname = "nwaaNaskapi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (108,-206);
+ref = doubledot_top;
+}
+);
+width = 637;
+}
+);
+note = uni14CF;
+unicode = 5327;
+},
+{
+glyphname = "n-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(375,449,l),
+(385,493,l),
+(238,493,l),
+(235,468,l),
+(289,488,o),
+(311,574,o),
+(311,620,cs),
+(311,682,o),
+(281,720,o),
+(229,720,cs),
+(142,720,o),
+(111,611,o),
+(111,546,cs),
+(111,484,o),
+(142,449,o),
+(196,449,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(166,485,o),
+(151,506,o),
+(151,545,cs),
+(151,587,o),
+(169,683,o),
+(227,683,cs),
+(255,683,o),
+(270,663,o),
+(270,624,cs),
+(270,582,o),
+(253,485,o),
+(193,485,cs)
+);
+}
+);
+width = 361;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni14D0;
+unicode = 5328;
+},
+{
+color = 6;
+glyphname = "ngCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-167);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 329;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "=|";
+note = uni14D1;
+unicode = 5329;
+},
+{
+glyphname = "nh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(274,449,ls),
+(364,449,o),
+(395,557,o),
+(395,623,cs),
+(395,685,o),
+(364,720,o),
+(313,720,cs),
+(227,720,o),
+(195,611,o),
+(195,546,cs),
+(195,524,o),
+(200,494,o),
+(224,477,c),
+(228,493,l),
+(82,493,l),
+(73,449,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(251,485,o),
+(236,506,o),
+(236,545,cs),
+(236,587,o),
+(253,683,o),
+(311,683,cs),
+(340,683,o),
+(355,663,o),
+(355,624,cs),
+(355,582,o),
+(337,485,o),
+(279,485,cs)
+);
+}
+);
+width = 362;
+}
+);
+metricLeft = "=|n-canadian";
+metricRight = "=|n-canadian";
+note = uni14D2;
+unicode = 5330;
+},
+{
+glyphname = "le-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (405,254);
+},
+{
+name = top_center_can;
+pos = (452,508);
+},
+{
+name = top_left_can;
+pos = (139,508);
+},
+{
+name = top_right_can;
+pos = (607,508);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(315,0,ls),
+(512,0,o),
+(585,161,o),
+(585,297,cs),
+(585,416,o),
+(515,489,o),
+(393,489,cs),
+(103,489,l),
+(91,431,l),
+(381,431,ls),
+(473,431,o),
+(522,382,o),
+(522,294,cs),
+(522,201,o),
+(482,57,o),
+(320,57,cs),
+(312,57,l),
+(300,0,l)
+);
+}
+);
+width = 636;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D3;
+unicode = 5331;
+},
+{
+glyphname = "laai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (81,-206);
+ref = ring_top.canadian;
+}
+);
+width = 637;
+}
+);
+note = uni14D4;
+unicode = 5332;
+},
+{
+glyphname = "li-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (237,254);
+},
+{
+name = top_center_can;
+pos = (299,508);
+},
+{
+name = top_left_can;
+pos = (143,508);
+},
+{
+name = top_right_can;
+pos = (610,508);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(233,0,l),
+(245,57,l),
+(237,57,ls),
+(159,57,o),
+(114,110,o),
+(114,195,cs),
+(114,293,o),
+(167,431,o),
+(321,431,cs),
+(625,431,l),
+(638,489,l),
+(325,489,ls),
+(135,489,o),
+(51,337,o),
+(51,194,cs),
+(51,78,o),
+(118,0,o),
+(223,0,cs)
+);
+}
+);
+width = 637;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14D5;
+unicode = 5333;
+},
+{
+glyphname = "lii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (138,-206);
+ref = dot_top;
+}
+);
+width = 637;
+}
+);
+note = uni14D6;
+unicode = 5334;
+},
+{
+glyphname = "lo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (404,254);
+},
+{
+name = top_center_can;
+pos = (456,508);
+},
+{
+name = top_double;
+pos = (421,508);
+},
+{
+name = top_left_can;
+pos = (138,508);
+},
+{
+name = top_right_can;
+pos = (607,508);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(311,0,ls),
+(502,0,o),
+(586,152,o),
+(586,295,cs),
+(586,411,o),
+(519,489,o),
+(414,489,cs),
+(404,489,l),
+(392,432,l),
+(400,432,ls),
+(477,432,o),
+(523,380,o),
+(523,294,cs),
+(523,196,o),
+(470,58,o),
+(316,58,cs),
+(12,58,l),
+(-1,0,l)
+);
+}
+);
+width = 637;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D7;
+unicode = 5335;
+},
+{
+glyphname = "loo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (295,-206);
+ref = dot_top;
+}
+);
+width = 637;
+}
+);
+note = uni14D8;
+unicode = 5336;
+},
+{
+glyphname = "ycreeloo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (125,-206);
+ref = doubledot_top;
+}
+);
+width = 637;
+}
+);
+note = uni14D9;
+unicode = 5337;
+},
+{
+glyphname = "la-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (237,254);
+},
+{
+name = top_center_can;
+pos = (292,508);
+},
+{
+name = top_left_can;
+pos = (143,508);
+},
+{
+name = top_right_can;
+pos = (610,508);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(534,0,l),
+(546,58,l),
+(256,58,ls),
+(164,58,o),
+(114,107,o),
+(114,195,cs),
+(114,288,o),
+(155,432,o),
+(316,432,cs),
+(325,432,l),
+(337,489,l),
+(322,489,ls),
+(124,489,o),
+(52,328,o),
+(52,193,cs),
+(52,73,o),
+(122,0,o),
+(244,0,cs)
+);
+}
+);
+width = 637;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14DA;
+unicode = 5338;
+},
+{
+glyphname = "laa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (131,-206);
+ref = dot_top;
+}
+);
+width = 637;
+}
+);
+note = uni14DB;
+unicode = 5339;
+},
+{
+glyphname = "lwe-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "le-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni14DC;
+unicode = 5340;
+},
+{
+glyphname = "lweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "le-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni14DD;
+unicode = 5341;
+},
+{
+glyphname = "lwi-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "li-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni14DE;
+unicode = 5342;
+},
+{
+glyphname = "lwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni14DF;
+unicode = 5343;
+},
+{
+glyphname = "lwii-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (314,-206);
+ref = dot_top;
+}
+);
+width = 812;
+}
+);
+note = uni14E0;
+unicode = 5344;
+},
+{
+glyphname = "lwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (138,-206);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni14E1;
+unicode = 5345;
+},
+{
+glyphname = "lwo-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "lo-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni14E2;
+unicode = 5346;
+},
+{
+glyphname = "lwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni14E3;
+unicode = 5347;
+},
+{
+glyphname = "lwoo-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (470,-206);
+ref = dot_top;
+}
+);
+width = 812;
+}
+);
+note = uni14E4;
+unicode = 5348;
+},
+{
+glyphname = "lwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (295,-206);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni14E5;
+unicode = 5349;
+},
+{
+glyphname = "lwa-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "la-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni14E6;
+unicode = 5350;
+},
+{
+glyphname = "lwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni14E7;
+unicode = 5351;
+},
+{
+glyphname = "lwaa-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (307,-206);
+ref = dot_top;
+}
+);
+width = 812;
+}
+);
+note = uni14E8;
+unicode = 5352;
+},
+{
+glyphname = "lwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (131,-206);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni14E9;
+unicode = 5353;
+},
+{
+glyphname = "l-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(356,357,l),
+(365,401,l),
+(240,401,ls),
+(183,401,o),
+(154,432,o),
+(154,491,cs),
+(154,566,o),
+(185,670,o),
+(295,670,cs),
+(298,670,l),
+(308,714,l),
+(303,714,ls),
+(156,714,o),
+(109,590,o),
+(109,489,cs),
+(109,404,o),
+(155,357,o),
+(240,357,cs)
+);
+}
+);
+width = 361;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "m-canadian";
+note = uni14EA;
+unicode = 5354;
+},
+{
+glyphname = "lWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(262,357,l),
+(268,386,l),
+(131,466,l),
+(126,442,l),
+(297,522,l),
+(302,545,l),
+(163,620,l),
+(159,598,l),
+(331,679,l),
+(338,714,l),
+(329,714,l),
+(133,623,l),
+(129,603,l),
+(268,527,l),
+(272,546,l),
+(100,468,l),
+(96,448,l),
+(253,357,l)
+);
+}
+);
+width = 291;
+}
+);
+metricRight = "=|";
+note = uni14EB;
+unicode = 5355;
+},
+{
+glyphname = "mediall-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(392,-13,l),
+(402,30,l),
+(106,199,l),
+(99,171,l),
+(467,337,l),
+(473,370,l),
+(175,528,l),
+(169,504,l),
+(538,674,l),
+(549,727,l),
+(531,727,l),
+(123,539,l),
+(116,508,l),
+(415,347,l),
+(420,369,l),
+(52,206,l),
+(46,175,l),
+(375,-13,l)
+);
+}
+);
+width = 508;
+}
+);
+metricRight = "=|";
+note = uni14EC;
+unicode = 5356;
+},
+{
+glyphname = "se-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (194,714);
+},
+{
+name = top_right_can;
+pos = (426,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(306,0,l),
+(376,326,l),
+(351,326,ls),
+(213,326,o),
+(156,388,o),
+(193,558,cs),
+(226,714,l),
+(163,714,l),
+(130,560,ls),
+(87,361,o),
+(169,268,o),
+(338,268,cs),
+(351,268,l),
+(305,292,l),
+(243,0,l)
+);
+}
+);
+width = 423;
+}
+);
+note = uni14ED;
+unicode = 5357;
+},
+{
+glyphname = "saai-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (210,0);
+ref = ring_top.canadian;
+}
+);
+width = 423;
+}
+);
+note = uni14EE;
+unicode = 5358;
+},
+{
+glyphname = "si-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (196,714);
+},
+{
+name = top_right_can;
+pos = (428,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(76,0,l),
+(138,292,l),
+(86,268,l),
+(122,268,ls),
+(285,268,o),
+(382,351,o),
+(424,547,cs),
+(459,714,l),
+(396,714,l),
+(361,550,ls),
+(327,396,o),
+(253,326,o),
+(127,326,cs),
+(82,326,l),
+(12,0,l)
+);
+}
+);
+width = 423;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+unicode = 5359;
+},
+{
+glyphname = "sii-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (268,0);
+ref = dot_top;
+}
+);
+width = 423;
+}
+);
+note = uni14F0;
+unicode = 5360;
+},
+{
+glyphname = "so-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (427,714);
+},
+{
+name = top_left_can;
+pos = (195,714);
+},
+{
+name = top_right_can;
+pos = (426,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(75,0,l),
+(110,164,ls),
+(143,318,o),
+(217,388,o),
+(343,388,cs),
+(389,388,l),
+(458,714,l),
+(395,714,l),
+(332,422,l),
+(384,446,l),
+(349,446,ls),
+(185,446,o),
+(88,363,o),
+(47,167,cs),
+(11,0,l)
+);
+}
+);
+width = 422;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+unicode = 5361;
+},
+{
+glyphname = "soo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (265,0);
+ref = dot_top;
+}
+);
+width = 423;
+}
+);
+note = uni14F2;
+unicode = 5362;
+},
+{
+glyphname = "ycreesoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (131,0);
+ref = doubledot_top;
+}
+);
+width = 423;
+}
+);
+note = uni14F3;
+unicode = 5363;
+},
+{
+glyphname = "sa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (196,714);
+},
+{
+name = top_right_can;
+pos = (428,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(307,0,l),
+(340,154,ls),
+(383,353,o),
+(301,446,o),
+(132,446,cs),
+(119,446,l),
+(165,422,l),
+(228,714,l),
+(164,714,l),
+(95,388,l),
+(119,388,ls),
+(257,388,o),
+(314,326,o),
+(277,156,cs),
+(244,0,l)
+);
+}
+);
+width = 422;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+unicode = 5364;
+},
+{
+glyphname = "saa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+}
+);
+width = 423;
+}
+);
+note = uni14F5;
+unicode = 5365;
+},
+{
+glyphname = "swe-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "se-canadian";
+}
+);
+width = 599;
+}
+);
+note = uni14F6;
+unicode = 5366;
+},
+{
+glyphname = "sweWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "se-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (423,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 599;
+}
+);
+note = uni14F7;
+unicode = 5367;
+},
+{
+glyphname = "swi-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "si-canadian";
+}
+);
+width = 599;
+}
+);
+note = uni14F8;
+unicode = 5368;
+},
+{
+glyphname = "swiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (423,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 599;
+}
+);
+note = uni14F9;
+unicode = 5369;
+},
+{
+glyphname = "swii-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (444,0);
+ref = dot_top;
+}
+);
+width = 599;
+}
+);
+note = uni14FA;
+unicode = 5370;
+},
+{
+glyphname = "swiiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (268,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (423,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 599;
+}
+);
+note = uni14FB;
+unicode = 5371;
+},
+{
+glyphname = "swo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "so-canadian";
+}
+);
+width = 599;
+}
+);
+note = uni14FC;
+unicode = 5372;
+},
+{
+glyphname = "swoWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (423,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 599;
+}
+);
+note = uni14FD;
+unicode = 5373;
+},
+{
+glyphname = "swoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (441,0);
+ref = dot_top;
+}
+);
+width = 599;
+}
+);
+note = uni14FE;
+unicode = 5374;
+},
+{
+glyphname = "swooWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (265,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (423,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 599;
+}
+);
+note = uni14FF;
+unicode = 5375;
+},
+{
+glyphname = "swa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "sa-canadian";
+}
+);
+width = 599;
+}
+);
+note = uni1500;
+unicode = 5376;
+},
+{
+glyphname = "swaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (423,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 599;
+}
+);
+note = uni1501;
+unicode = 5377;
+},
+{
+glyphname = "swaa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (212,0);
+ref = dot_top;
+}
+);
+width = 599;
+}
+);
+note = uni1502;
+unicode = 5378;
+},
+{
+glyphname = "swaaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (423,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 599;
+}
+);
+note = uni1503;
+unicode = 5379;
+},
+{
+glyphname = "swaaNaskapi-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (192,0);
+ref = "sa-canadian";
+}
+);
+width = 615;
+}
+);
+note = uni1504;
+unicode = 5380;
+},
+{
+glyphname = "s-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(248,357,l),
+(266,444,ls),
+(285,532,o),
+(249,589,o),
+(159,589,cs),
+(145,589,l),
+(166,566,l),
+(197,714,l),
+(152,714,l),
+(118,551,l),
+(147,551,ls),
+(216,551,o),
+(236,514,o),
+(221,442,cs),
+(203,357,l)
+);
+}
+);
+width = 276;
+}
+);
+metricRight = "=|";
+note = uni1505;
+unicode = 5381;
+},
+{
+color = 6;
+glyphname = "sAthapascan-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(219,183,o),
+(258,227,o),
+(258,290,cs),
+(258,331,o),
+(241,358,o),
+(200,378,cs),
+(180,389,ls),
+(154,401,o),
+(141,421,o),
+(141,445,cs),
+(141,486,o),
+(164,515,o),
+(207,515,cs),
+(243,515,o),
+(261,497,o),
+(250,444,c),
+(292,444,l),
+(305,507,o),
+(272,552,o),
+(209,552,cs),
+(137,552,o),
+(99,505,o),
+(99,442,cs),
+(99,406,o),
+(118,374,o),
+(155,356,cs),
+(175,346,ls),
+(206,330,o),
+(216,313,o),
+(216,287,cs),
+(216,245,o),
+(193,220,o),
+(153,220,cs),
+(114,220,o),
+(91,237,o),
+(104,294,c),
+(62,294,l),
+(47,223,o),
+(85,183,o),
+(152,183,cs)
+);
+}
+);
+width = 302;
+}
+);
+metricRight = "=|";
+note = uni1506;
+unicode = 5382;
+},
+{
+glyphname = "sw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(122,357,l),
+(140,442,ls),
+(156,518,o),
+(191,551,o),
+(256,551,cs),
+(289,551,l),
+(324,714,l),
+(278,714,l),
+(248,570,l),
+(280,589,l),
+(254,589,ls),
+(165,589,o),
+(116,544,o),
+(96,447,cs),
+(76,357,l)
+);
+}
+);
+width = 276;
+}
+);
+metricLeft = "=|s-canadian";
+metricRight = "=|s-canadian";
+note = uni1507;
+unicode = 5383;
+},
+{
+glyphname = "sBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(254,357,l),
+(264,401,l),
+(203,401,ls),
+(154,401,o),
+(135,426,o),
+(148,483,cs),
+(197,714,l),
+(152,714,l),
+(104,488,ls),
+(86,404,o),
+(121,357,o),
+(201,357,cs)
+);
+}
+);
+width = 260;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "m-canadian";
+note = uni1508;
+unicode = 5384;
+},
+{
+glyphname = "moosecreesk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(256,225,o),
+(281,371,o),
+(281,456,cs),
+(281,546,o),
+(241,590,o),
+(158,590,cs),
+(150,590,l),
+(166,568,l),
+(197,714,l),
+(152,714,l),
+(118,552,l),
+(145,552,ls),
+(235,552,o),
+(244,505,o),
+(239,428,c),
+(244,415,l),
+(249,448,o),
+(242,495,o),
+(186,495,cs),
+(101,495,o),
+(75,376,o),
+(75,322,cs),
+(75,263,o),
+(104,225,o),
+(156,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(130,261,o),
+(116,282,o),
+(116,319,cs),
+(116,360,o),
+(134,460,o),
+(192,460,cs),
+(220,460,o),
+(235,441,o),
+(235,404,cs),
+(235,363,o),
+(216,261,o),
+(158,261,cs)
+);
+}
+);
+width = 299;
+}
+);
+metricRight = "=|";
+note = uni1509;
+unicode = 5385;
+},
+{
+glyphname = "skwNaskapi-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(244,225,o),
+(275,342,o),
+(275,403,cs),
+(275,460,o),
+(249,495,o),
+(204,495,cs),
+(167,495,o),
+(135,467,o),
+(125,421,c),
+(136,423,l),
+(167,509,o),
+(205,552,o),
+(287,552,cs),
+(312,552,l),
+(346,714,l),
+(301,714,l),
+(270,567,l),
+(297,590,l),
+(282,590,ls),
+(130,590,o),
+(76,419,o),
+(76,324,cs),
+(76,265,o),
+(103,225,o),
+(155,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(130,261,o),
+(116,282,o),
+(116,319,cs),
+(116,360,o),
+(134,460,o),
+(192,460,cs),
+(220,460,o),
+(234,441,o),
+(234,404,cs),
+(234,363,o),
+(216,261,o),
+(158,261,cs)
+);
+}
+);
+width = 299;
+}
+);
+metricLeft = "=|moosecreesk-canadian";
+metricRight = "=|moosecreesk-canadian";
+note = uni150A;
+unicode = 5386;
+},
+{
+glyphname = "swNaskapi-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(230,184,l),
+(246,259,ls),
+(267,357,o),
+(226,411,o),
+(142,411,cs),
+(125,411,l),
+(143,387,l),
+(173,531,l),
+(129,531,l),
+(96,373,l),
+(128,373,ls),
+(192,373,o),
+(218,341,o),
+(201,260,cs),
+(185,184,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(215,65,o),
+(234,84,o),
+(234,107,cs),
+(234,131,o),
+(215,150,o),
+(192,150,cs),
+(169,150,o),
+(149,131,o),
+(149,107,cs),
+(149,84,o),
+(169,65,o),
+(192,65,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(192,564,o),
+(210,583,o),
+(210,607,cs),
+(210,631,o),
+(192,649,o),
+(168,649,cs),
+(145,649,o),
+(126,631,o),
+(126,607,cs),
+(126,583,o),
+(145,564,o),
+(168,564,cs)
+);
+}
+);
+width = 312;
+}
+);
+metricRight = "=|";
+note = uni150B;
+unicode = 5387;
+},
+{
+glyphname = "spwaNaskapi-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(416,0,l),
+(427,52,l),
+(113,366,l),
+(107,334,l),
+(554,648,l),
+(568,714,l),
+(550,714,l),
+(59,370,l),
+(53,344,l),
+(398,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,511,o),
+(218,530,o),
+(218,553,cs),
+(218,577,o),
+(200,596,o),
+(176,596,cs),
+(154,596,o),
+(134,577,o),
+(134,553,cs),
+(134,530,o),
+(154,511,o),
+(176,511,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(353,619,l),
+(366,681,ls),
+(380,745,o),
+(354,783,o),
+(294,783,cs),
+(272,783,l),
+(299,764,l),
+(321,865,l),
+(279,865,l),
+(254,747,l),
+(277,747,ls),
+(320,747,o),
+(332,728,o),
+(322,676,cs),
+(310,619,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(511,724,o),
+(529,744,o),
+(529,767,cs),
+(529,791,o),
+(511,810,o),
+(487,810,cs),
+(465,810,o),
+(445,791,o),
+(445,767,cs),
+(445,744,o),
+(465,724,o),
+(487,724,cs)
+);
+}
+);
+width = 511;
+}
+);
+metricRight = "pa-canadian";
+metricWidth = "pa-canadian";
+note = uni150C;
+unicode = 5388;
+},
+{
+glyphname = "stwaNaskapi-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (312,0);
+ref = "ta-canadian";
+}
+);
+width = 781;
+}
+);
+note = uni150D;
+unicode = 5389;
+},
+{
+glyphname = "skwaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (312,0);
+ref = "ka-canadian";
+}
+);
+width = 778;
+}
+);
+note = uni150E;
+unicode = 5390;
+},
+{
+glyphname = "scwaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (312,0);
+ref = "ca-canadian";
+}
+);
+width = 774;
+}
+);
+note = uni150F;
+unicode = 5391;
+},
+{
+glyphname = "she-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (327,714);
+},
+{
+name = top_right_can;
+pos = (637,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(568,-13,o),
+(627,58,o),
+(659,210,cs),
+(680,309,l),
+(617,309,l),
+(594,205,ls),
+(570,91,o),
+(534,44,o),
+(469,44,cs),
+(397,44,o),
+(373,104,o),
+(393,218,cs),
+(439,479,ls),
+(467,638,o),
+(417,727,o),
+(306,727,cs),
+(204,727,o),
+(145,656,o),
+(112,504,cs),
+(92,405,l),
+(155,405,l),
+(177,509,ls),
+(202,623,o),
+(238,670,o),
+(302,670,cs),
+(375,670,o),
+(399,610,o),
+(379,496,cs),
+(332,234,ls),
+(305,76,o),
+(354,-13,o),
+(466,-13,cs)
+);
+}
+);
+width = 723;
+}
+);
+metricRight = "=|";
+note = uni1510;
+unicode = 5392;
+},
+{
+glyphname = "shi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (287,714);
+},
+{
+name = top_right_can;
+pos = (597,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(282,-13,o),
+(337,45,o),
+(382,220,cs),
+(451,495,ls),
+(486,632,o),
+(519,670,o),
+(585,670,cs),
+(656,670,o),
+(680,609,o),
+(653,487,cs),
+(636,405,l),
+(699,405,l),
+(714,473,ls),
+(748,628,o),
+(701,727,o),
+(588,727,cs),
+(487,727,o),
+(434,669,o),
+(390,494,cs),
+(318,218,ls),
+(283,83,o),
+(251,44,o),
+(184,44,cs),
+(114,44,o),
+(90,104,o),
+(116,226,cs),
+(134,309,l),
+(71,309,l),
+(56,241,ls),
+(21,83,o),
+(68,-13,o),
+(181,-13,cs)
+);
+}
+);
+width = 722;
+}
+);
+metricLeft = "she-canadian";
+metricRight = "she-canadian";
+note = uni1511;
+unicode = 5393;
+},
+{
+glyphname = "shii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (438,0);
+ref = dot_top;
+}
+);
+width = 724;
+}
+);
+note = uni1512;
+unicode = 5394;
+},
+{
+glyphname = "sho-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (423,508);
+},
+{
+name = top_left_can;
+pos = (278,508);
+},
+{
+name = top_right_can;
+pos = (567,508);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(238,44,l),
+(155,45,o),
+(101,85,o),
+(101,154,cs),
+(101,226,o),
+(143,297,o),
+(224,297,cs),
+(336,297,o),
+(377,134,o),
+(517,134,cs),
+(632,134,o),
+(697,231,o),
+(697,335,cs),
+(697,437,o),
+(622,500,o),
+(510,502,c),
+(497,445,l),
+(582,444,o),
+(636,405,o),
+(636,335,cs),
+(636,263,o),
+(594,192,o),
+(514,192,cs),
+(401,192,o),
+(360,355,o),
+(220,355,cs),
+(103,355,o),
+(40,256,o),
+(40,154,cs),
+(40,52,o),
+(115,-11,o),
+(225,-13,c)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1513;
+unicode = 5395;
+},
+{
+glyphname = "shoo-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (262,-206);
+ref = dot_top;
+}
+);
+width = 737;
+}
+);
+note = uni1514;
+unicode = 5396;
+},
+{
+glyphname = "sha-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (426,508);
+},
+{
+name = top_left_can;
+pos = (280,508);
+},
+{
+name = top_right_can;
+pos = (571,508);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(569,-14,o),
+(671,70,o),
+(671,212,cs),
+(671,297,o),
+(618,355,o),
+(537,355,cs),
+(411,355,o),
+(309,192,o),
+(210,192,cs),
+(160,192,o),
+(130,227,o),
+(130,281,cs),
+(130,389,o),
+(208,445,o),
+(312,445,c),
+(325,502,l),
+(169,503,o),
+(67,419,o),
+(67,277,cs),
+(67,192,o),
+(119,134,o),
+(200,134,cs),
+(326,134,o),
+(428,297,o),
+(527,297,cs),
+(577,297,o),
+(608,262,o),
+(608,208,cs),
+(608,100,o),
+(532,44,o),
+(426,44,c),
+(414,-13,l)
+);
+}
+);
+width = 738;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1515;
+unicode = 5397;
+},
+{
+glyphname = "shaa-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (265,-206);
+ref = dot_top;
+}
+);
+width = 737;
+}
+);
+note = uni1516;
+unicode = 5398;
+},
+{
+glyphname = "shwe-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "she-canadian";
+}
+);
+width = 900;
+}
+);
+note = uni1517;
+unicode = 5399;
+},
+{
+glyphname = "shweWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "she-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (724,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 900;
+}
+);
+note = uni1518;
+unicode = 5400;
+},
+{
+glyphname = "shwi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "shi-canadian";
+}
+);
+width = 900;
+}
+);
+note = uni1519;
+unicode = 5401;
+},
+{
+glyphname = "shwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (724,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 900;
+}
+);
+note = uni151A;
+unicode = 5402;
+},
+{
+glyphname = "shwii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (613,0);
+ref = dot_top;
+}
+);
+width = 900;
+}
+);
+note = uni151B;
+unicode = 5403;
+},
+{
+glyphname = "shwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (438,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (724,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 900;
+}
+);
+note = uni151C;
+unicode = 5404;
+},
+{
+glyphname = "shwo-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "sho-canadian";
+}
+);
+width = 913;
+}
+);
+note = uni151D;
+unicode = 5405;
+},
+{
+glyphname = "shwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (737,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 913;
+}
+);
+note = uni151E;
+unicode = 5406;
+},
+{
+glyphname = "shwoo-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (437,-206);
+ref = dot_top;
+}
+);
+width = 913;
+}
+);
+note = uni151F;
+unicode = 5407;
+},
+{
+glyphname = "shwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (262,-206);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (737,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 913;
+}
+);
+note = uni1520;
+unicode = 5408;
+},
+{
+glyphname = "shwa-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "sha-canadian";
+}
+);
+width = 913;
+}
+);
+note = uni1521;
+unicode = 5409;
+},
+{
+glyphname = "shwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (737,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 913;
+}
+);
+note = uni1522;
+unicode = 5410;
+},
+{
+glyphname = "shwaa-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (441,-206);
+ref = dot_top;
+}
+);
+width = 913;
+}
+);
+note = uni1523;
+unicode = 5411;
+},
+{
+glyphname = "shwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (265,-206);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (737,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 913;
+}
+);
+note = uni1524;
+unicode = 5412;
+},
+{
+glyphname = "sh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(474,299,o),
+(556,365,o),
+(556,473,cs),
+(556,537,o),
+(515,582,o),
+(446,582,cs),
+(358,582,o),
+(303,485,o),
+(232,485,cs),
+(188,485,o),
+(164,511,o),
+(164,552,cs),
+(164,631,o),
+(227,680,o),
+(317,679,c),
+(326,722,l),
+(202,723,o),
+(119,658,o),
+(119,550,cs),
+(119,485,o),
+(160,440,o),
+(229,440,cs),
+(317,440,o),
+(373,537,o),
+(443,537,cs),
+(487,537,o),
+(511,511,o),
+(511,471,cs),
+(511,396,o),
+(452,342,o),
+(361,343,c),
+(352,301,l)
+);
+}
+);
+width = 562;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni1525;
+unicode = 5413;
+},
+{
+glyphname = "ye-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (493,357);
+},
+{
+name = top_left_can;
+pos = (175,714);
+},
+{
+name = top_right_can;
+pos = (455,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(335,0,l),
+(403,321,l),
+(133,321,l),
+(136,300,l),
+(491,688,l),
+(446,726,l),
+(51,290,l),
+(46,264,l),
+(328,264,l),
+(271,0,l)
+);
+}
+);
+width = 448;
+}
+);
+note = uni1526;
+unicode = 5414;
+},
+{
+glyphname = "yaai-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-25,0);
+ref = ring_top.canadian;
+}
+);
+width = 448;
+}
+);
+note = uni1527;
+unicode = 5415;
+},
+{
+glyphname = "yi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (194,714);
+},
+{
+name = top_right_can;
+pos = (476,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(73,0,l),
+(129,264,l),
+(411,264,l),
+(416,290,l),
+(195,726,l),
+(143,698,l),
+(345,302,l),
+(348,321,l),
+(78,321,l),
+(9,0,l)
+);
+}
+);
+width = 448;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni1528;
+unicode = 5416;
+},
+{
+glyphname = "yii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (33,0);
+ref = dot_top;
+}
+);
+width = 448;
+}
+);
+note = uni1529;
+unicode = 5417;
+},
+{
+glyphname = "yo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (493,357);
+},
+{
+name = top_double;
+pos = (456,714);
+},
+{
+name = top_left_can;
+pos = (173,714);
+},
+{
+name = top_right_can;
+pos = (456,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(353,16,l),
+(150,412,l),
+(148,393,l),
+(418,393,l),
+(487,714,l),
+(423,714,l),
+(367,450,l),
+(85,450,l),
+(80,424,l),
+(300,-12,l)
+);
+}
+);
+width = 448;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152A;
+unicode = 5418;
+},
+{
+glyphname = "yoo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (295,0);
+ref = dot_top;
+}
+);
+width = 448;
+}
+);
+note = uni152B;
+unicode = 5419;
+},
+{
+glyphname = "ycreeyoo-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (160,0);
+ref = doubledot_top;
+}
+);
+width = 448;
+}
+);
+note = uni152C;
+unicode = 5420;
+},
+{
+glyphname = "ya-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (194,714);
+},
+{
+name = top_right_can;
+pos = (476,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(445,424,l),
+(451,450,l),
+(169,450,l),
+(225,714,l),
+(162,714,l),
+(93,393,l),
+(364,393,l),
+(360,414,l),
+(6,26,l),
+(50,-12,l)
+);
+}
+);
+width = 448;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152D;
+unicode = 5421;
+},
+{
+glyphname = "yaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (32,0);
+ref = dot_top;
+}
+);
+width = 448;
+}
+);
+note = uni152E;
+unicode = 5422;
+},
+{
+glyphname = "ywe-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ye-canadian";
+}
+);
+width = 623;
+}
+);
+note = uni152F;
+unicode = 5423;
+},
+{
+glyphname = "yweWestCree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ye-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (448,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 623;
+}
+);
+note = uni1530;
+unicode = 5424;
+},
+{
+glyphname = "ywi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "yi-canadian";
+}
+);
+width = 623;
+}
+);
+note = uni1531;
+unicode = 5425;
+},
+{
+glyphname = "ywiWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (448,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 623;
+}
+);
+note = uni1532;
+unicode = 5426;
+},
+{
+glyphname = "ywii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (208,0);
+ref = dot_top;
+}
+);
+width = 623;
+}
+);
+note = uni1533;
+unicode = 5427;
+},
+{
+glyphname = "ywiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (33,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (448,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 623;
+}
+);
+note = uni1534;
+unicode = 5428;
+},
+{
+glyphname = "ywo-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "yo-canadian";
+}
+);
+width = 623;
+}
+);
+note = uni1535;
+unicode = 5429;
+},
+{
+glyphname = "ywoWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (448,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 623;
+}
+);
+note = uni1536;
+unicode = 5430;
+},
+{
+glyphname = "ywoo-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (470,0);
+ref = dot_top;
+}
+);
+width = 623;
+}
+);
+note = uni1537;
+unicode = 5431;
+},
+{
+glyphname = "ywooWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (295,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (448,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 623;
+}
+);
+note = uni1538;
+unicode = 5432;
+},
+{
+glyphname = "ywa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ya-canadian";
+}
+);
+width = 623;
+}
+);
+note = uni1539;
+unicode = 5433;
+},
+{
+glyphname = "ywaWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (448,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 623;
+}
+);
+note = uni153A;
+unicode = 5434;
+},
+{
+glyphname = "ywaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (207,0);
+ref = dot_top;
+}
+);
+width = 623;
+}
+);
+note = uni153B;
+unicode = 5435;
+},
+{
+glyphname = "ywaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (32,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (448,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 623;
+}
+);
+note = uni153C;
+unicode = 5436;
+},
+{
+glyphname = "ywaaNaskapi-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (192,0);
+ref = "ya-canadian";
+}
+);
+width = 640;
+}
+);
+note = uni153D;
+unicode = 5437;
+},
+{
+glyphname = "y-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(307,565,l),
+(311,582,l),
+(173,582,l),
+(201,714,l),
+(156,714,l),
+(120,542,l),
+(257,542,l),
+(255,569,l),
+(80,375,l),
+(112,348,l)
+);
+}
+);
+width = 268;
+}
+);
+note = uni153E;
+unicode = 5438;
+},
+{
+glyphname = "biblecreey-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(109,357,l),
+(227,661,l),
+(201,662,l),
+(213,357,l),
+(239,357,l),
+(379,661,l),
+(354,661,l),
+(342,357,l),
+(382,357,l),
+(385,370,l),
+(397,714,l),
+(363,714,l),
+(220,406,l),
+(249,406,l),
+(237,714,l),
+(204,714,l),
+(69,370,l),
+(66,357,l)
+);
+}
+);
+width = 400;
+}
+);
+metricRight = "=|";
+note = uni153F;
+unicode = 5439;
+},
+{
+glyphname = "yWestCree-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(195,220,l),
+(221,346,l),
+(325,346,l),
+(335,390,l),
+(231,390,l),
+(257,513,l),
+(215,513,l),
+(189,390,l),
+(85,390,l),
+(75,346,l),
+(179,346,l),
+(153,220,l)
+);
+}
+);
+width = 357;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1540;
+unicode = 5440;
+},
+{
+glyphname = "yiSayisi-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (40,189);
+ref = "fullstop-canadian";
+}
+);
+width = 291;
+}
+);
+metricLeft = "fullstop-canadian";
+metricWidth = "fullstop-canadian";
+note = uni1541;
+unicode = 5441;
+},
+{
+glyphname = "re-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (293,508);
+},
+{
+name = top_left_can;
+pos = (151,508);
+},
+{
+name = top_right_can;
+pos = (645,508);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(306,-13,o),
+(370,51,o),
+(401,199,cs),
+(451,431,l),
+(660,431,l),
+(672,489,l),
+(401,489,l),
+(338,195,ls),
+(315,88,o),
+(274,44,o),
+(205,44,cs),
+(128,44,o),
+(97,101,o),
+(118,203,cs),
+(179,489,l),
+(116,489,l),
+(57,214,ls),
+(27,75,o),
+(82,-13,o),
+(202,-13,cs)
+);
+}
+);
+width = 671;
+}
+);
+metricRight = "=|ne-canadian";
+note = uni1542;
+unicode = 5442;
+},
+{
+glyphname = "reRCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (489,508);
+},
+{
+name = top_left_can;
+pos = (139,508);
+},
+{
+name = top_right_can;
+pos = (631,508);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(502,-13,o),
+(566,51,o),
+(597,199,cs),
+(660,489,l),
+(596,489,l),
+(533,195,ls),
+(510,88,o),
+(469,44,o),
+(400,44,cs),
+(323,44,o),
+(292,101,o),
+(313,203,cs),
+(374,489,l),
+(103,489,l),
+(91,431,l),
+(300,431,l),
+(253,214,ls),
+(224,76,o),
+(278,-13,o),
+(398,-13,cs)
+);
+}
+);
+width = 671;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1543;
+unicode = 5443;
+},
+{
+glyphname = "leWestCree-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (489,508);
+},
+{
+name = top_left_can;
+pos = (138,508);
+},
+{
+name = top_right_can;
+pos = (632,508);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(271,0,l),
+(333,294,ls),
+(356,401,o),
+(398,445,o),
+(467,445,cs),
+(544,445,o),
+(575,388,o),
+(553,286,cs),
+(492,0,l),
+(556,0,l),
+(614,275,ls),
+(644,414,o),
+(589,502,o),
+(469,502,cs),
+(366,502,o),
+(302,438,o),
+(270,290,cs),
+(221,59,l),
+(12,59,l),
+(-1,0,l)
+);
+}
+);
+width = 671;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+unicode = 5444;
+},
+{
+glyphname = "raai-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (75,-206);
+ref = ring_top.canadian;
+}
+);
+width = 671;
+}
+);
+note = uni1545;
+unicode = 5445;
+},
+{
+glyphname = "ri-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (292,508);
+},
+{
+name = top_left_can;
+pos = (150,508);
+},
+{
+name = top_right_can;
+pos = (643,508);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(75,0,l),
+(137,294,ls),
+(160,401,o),
+(202,445,o),
+(272,445,cs),
+(348,445,o),
+(379,388,o),
+(357,286,cs),
+(296,0,l),
+(567,0,l),
+(580,59,l),
+(371,59,l),
+(417,275,ls),
+(447,414,o),
+(392,502,o),
+(276,502,cs),
+(168,502,o),
+(104,438,o),
+(73,290,cs),
+(11,0,l)
+);
+}
+);
+width = 670;
+}
+);
+metricLeft = "re-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+unicode = 5446;
+},
+{
+glyphname = "rii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (132,-206);
+ref = dot_top;
+}
+);
+width = 671;
+}
+);
+note = uni1547;
+unicode = 5447;
+},
+{
+glyphname = "ro-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (286,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(77,0,l),
+(139,292,l),
+(109,265,l),
+(179,265,ls),
+(371,265,o),
+(430,422,o),
+(430,540,cs),
+(430,648,o),
+(368,714,o),
+(258,714,cs),
+(167,714,l),
+(155,656,l),
+(247,656,ls),
+(326,656,o),
+(367,615,o),
+(367,537,cs),
+(367,441,o),
+(321,322,o),
+(176,322,cs),
+(81,322,l),
+(13,0,l)
+);
+}
+);
+width = 424;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1548;
+unicode = 5448;
+},
+{
+glyphname = "roo-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (125,0);
+ref = dot_top;
+}
+);
+width = 424;
+}
+);
+note = uni1549;
+unicode = 5449;
+},
+{
+glyphname = "loWestCree-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (304,714);
+},
+{
+name = top_left_can;
+pos = (198,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(124,0,ls),
+(317,0,o),
+(376,157,o),
+(376,275,cs),
+(376,383,o),
+(313,449,o),
+(204,449,cs),
+(145,449,l),
+(167,421,l),
+(229,714,l),
+(166,714,l),
+(97,393,l),
+(192,393,ls),
+(271,393,o),
+(313,351,o),
+(313,274,cs),
+(313,178,o),
+(267,58,o),
+(121,58,cs),
+(26,58,l),
+(14,0,l)
+);
+}
+);
+width = 427;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+unicode = 5450;
+},
+{
+glyphname = "ra-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (338,714);
+},
+{
+name = top_right_can;
+pos = (428,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(308,0,l),
+(376,321,l),
+(281,321,ls),
+(202,321,o),
+(161,363,o),
+(161,440,cs),
+(161,536,o),
+(207,656,o),
+(353,656,cs),
+(448,656,l),
+(460,714,l),
+(350,714,ls),
+(157,714,o),
+(98,557,o),
+(98,439,cs),
+(98,331,o),
+(161,265,o),
+(270,265,cs),
+(329,265,l),
+(307,293,l),
+(244,0,l)
+);
+}
+);
+width = 426;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+unicode = 5451;
+},
+{
+glyphname = "raa-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (177,0);
+ref = dot_top;
+}
+);
+width = 424;
+}
+);
+note = uni154C;
+unicode = 5452;
+},
+{
+glyphname = "laWestCree-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (429,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(306,0,l),
+(319,58,l),
+(226,58,ls),
+(147,58,o),
+(105,99,o),
+(105,177,cs),
+(105,273,o),
+(151,392,o),
+(297,392,cs),
+(392,392,l),
+(461,714,l),
+(397,714,l),
+(335,422,l),
+(365,449,l),
+(294,449,ls),
+(101,449,o),
+(42,292,o),
+(42,174,cs),
+(42,66,o),
+(105,0,o),
+(214,0,cs)
+);
+}
+);
+width = 426;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+unicode = 5453;
+},
+{
+glyphname = "rwaa-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (353,0);
+ref = dot_top;
+}
+);
+width = 600;
+}
+);
+note = uni154E;
+unicode = 5454;
+},
+{
+glyphname = "rwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (177,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (424,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 600;
+}
+);
+note = uni154F;
+unicode = 5455;
+},
+{
+glyphname = "r-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(223,357,l),
+(258,525,l),
+(220,525,ls),
+(180,525,o),
+(160,546,o),
+(160,582,cs),
+(160,622,o),
+(177,675,o),
+(252,675,cs),
+(290,675,l),
+(298,714,l),
+(260,714,ls),
+(161,714,o),
+(117,656,o),
+(117,581,cs),
+(117,525,o),
+(152,487,o),
+(213,487,cs),
+(234,487,l),
+(208,502,l),
+(177,357,l)
+);
+}
+);
+width = 251;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni1550;
+unicode = 5456;
+},
+{
+glyphname = "rWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(152,714,l),
+(146,685,l),
+(283,605,l),
+(288,629,l),
+(117,549,l),
+(112,526,l),
+(251,451,l),
+(256,473,l),
+(84,392,l),
+(76,357,l),
+(86,357,l),
+(282,448,l),
+(286,468,l),
+(146,544,l),
+(143,525,l),
+(315,603,l),
+(319,623,l),
+(162,714,l)
+);
+}
+);
+width = 291;
+}
+);
+metricLeft = "=|lWestCree-canadian";
+metricRight = "=|lWestCree-canadian";
+note = uni1551;
+unicode = 5457;
+},
+{
+glyphname = "rMedial-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(24,-13,l),
+(432,175,l),
+(439,206,l),
+(140,367,l),
+(135,345,l),
+(503,508,l),
+(509,539,l),
+(180,727,l),
+(163,727,l),
+(153,684,l),
+(449,515,l),
+(456,543,l),
+(88,377,l),
+(82,344,l),
+(380,186,l),
+(386,210,l),
+(17,40,l),
+(6,-13,l)
+);
+}
+);
+width = 507;
+}
+);
+metricLeft = "mediall-canadian";
+metricRight = "mediall-canadian";
+note = uni1552;
+unicode = 5458;
+},
+{
+glyphname = "fe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(253,0,l),
+(665,694,l),
+(669,714,l),
+(616,714,l),
+(244,72,l),
+(260,72,l),
+(207,377,l),
+(181,371,l),
+(195,348,o),
+(218,336,o),
+(252,336,cs),
+(370,336,o),
+(413,510,o),
+(413,591,cs),
+(413,673,o),
+(377,727,o),
+(308,727,cs),
+(190,727,o),
+(145,567,o),
+(145,461,cs),
+(145,432,o),
+(148,404,o),
+(154,374,cs),
+(228,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(214,379,o),
+(194,410,o),
+(194,465,cs),
+(194,531,o),
+(224,679,o),
+(305,679,cs),
+(344,679,o),
+(364,648,o),
+(364,592,cs),
+(364,526,o),
+(335,379,o),
+(253,379,cs)
+);
+}
+);
+width = 597;
+}
+);
+metricRight = "e-canadian";
+note = uni1553;
+unicode = 5459;
+},
+{
+glyphname = "faai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (172,0);
+ref = ring_top.canadian;
+}
+);
+width = 597;
+}
+);
+note = uni1554;
+unicode = 5460;
+},
+{
+glyphname = "fi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (391,714);
+},
+{
+name = top_left_can;
+pos = (213,714);
+},
+{
+name = top_right_can;
+pos = (594,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(299,-13,o),
+(339,152,o),
+(339,240,cs),
+(339,326,o),
+(302,379,o),
+(239,379,cs),
+(216,379,o),
+(189,368,o),
+(166,344,c),
+(200,346,l),
+(386,642,l),
+(370,642,l),
+(473,0,l),
+(517,0,l),
+(521,20,l),
+(403,714,l),
+(378,714,l),
+(142,347,ls),
+(100,282,o),
+(71,203,o),
+(71,120,cs),
+(71,38,o),
+(109,-13,o),
+(176,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(141,35,o),
+(121,66,o),
+(121,122,cs),
+(121,188,o),
+(151,335,o),
+(232,335,cs),
+(273,335,o),
+(289,302,o),
+(289,243,cs),
+(289,175,o),
+(259,35,o),
+(180,35,cs)
+);
+}
+);
+width = 597;
+}
+);
+metricLeft = "fe-canadian";
+metricRight = "e-canadian";
+note = uni1555;
+unicode = 5461;
+},
+{
+glyphname = "fii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (230,0);
+ref = dot_top;
+}
+);
+width = 597;
+}
+);
+note = uni1556;
+unicode = 5462;
+},
+{
+glyphname = "fo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (274,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(40,0,l),
+(527,344,l),
+(533,370,l),
+(358,670,ls),
+(339,702,o),
+(314,727,o),
+(267,727,cs),
+(158,727,o),
+(110,579,o),
+(104,486,cs),
+(97,392,o),
+(136,332,o),
+(205,332,cs),
+(308,332,o),
+(359,473,o),
+(365,565,cs),
+(367,598,o),
+(363,627,o),
+(359,647,c),
+(336,609,l),
+(487,352,l),
+(493,381,l),
+(35,58,l),
+(22,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(170,380,o),
+(151,415,o),
+(154,480,cs),
+(157,552,o),
+(186,680,o),
+(263,680,cs),
+(304,680,o),
+(323,645,o),
+(320,579,cs),
+(317,508,o),
+(289,380,o),
+(211,380,cs)
+);
+}
+);
+width = 538;
+}
+);
+metricRight = "o-canadian";
+note = uni1557;
+unicode = 5463;
+},
+{
+glyphname = "foo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "fo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (113,0);
+ref = dot_top;
+}
+);
+width = 538;
+}
+);
+note = uni1558;
+unicode = 5464;
+},
+{
+glyphname = "fa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (464,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(412,0,l),
+(422,48,l),
+(106,367,l),
+(102,346,l),
+(358,609,l),
+(343,654,l),
+(303,589,o),
+(289,516,o),
+(289,466,cs),
+(289,382,o),
+(328,331,o),
+(396,331,cs),
+(510,331,o),
+(557,499,o),
+(557,589,cs),
+(557,678,o),
+(516,727,o),
+(454,727,cs),
+(417,727,o),
+(385,711,o),
+(353,677,cs),
+(58,370,l),
+(53,344,l),
+(394,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(357,379,o),
+(337,409,o),
+(337,465,cs),
+(337,531,o),
+(366,679,o),
+(448,679,cs),
+(487,679,o),
+(507,648,o),
+(507,593,cs),
+(507,527,o),
+(478,379,o),
+(396,379,cs)
+);
+}
+);
+width = 540;
+}
+);
+metricRight = "=|fo-canadian";
+note = uni1559;
+unicode = 5465;
+},
+{
+glyphname = "faa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (303,0);
+ref = dot_top;
+}
+);
+width = 538;
+}
+);
+note = uni155A;
+unicode = 5466;
+},
+{
+glyphname = "fwaa-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (479,0);
+ref = dot_top;
+}
+);
+width = 713;
+}
+);
+note = uni155B;
+unicode = 5467;
+},
+{
+glyphname = "fwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (303,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (538,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 713;
+}
+);
+note = uni155C;
+unicode = 5468;
+},
+{
+glyphname = "f-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(281,357,l),
+(287,389,l),
+(137,542,l),
+(137,533,l),
+(254,653,l),
+(252,686,l),
+(235,660,o),
+(222,617,o),
+(222,587,cs),
+(222,548,o),
+(242,522,o),
+(274,522,cs),
+(331,522,o),
+(353,605,o),
+(353,653,cs),
+(353,695,o),
+(336,720,o),
+(303,720,cs),
+(285,720,o),
+(270,713,o),
+(252,695,cs),
+(105,544,l),
+(101,527,l),
+(271,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(258,550,o),
+(250,564,o),
+(250,588,cs),
+(250,614,o),
+(261,692,o),
+(299,692,cs),
+(315,692,o),
+(324,679,o),
+(324,655,cs),
+(324,629,o),
+(312,550,o),
+(275,550,cs)
+);
+}
+);
+width = 319;
+}
+);
+note = uni155D;
+unicode = 5469;
+},
+{
+glyphname = "the-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (626,357);
+},
+{
+name = top_center_can;
+pos = (385,714);
+},
+{
+name = top_left_can;
+pos = (192,714);
+},
+{
+name = top_right_can;
+pos = (577,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(392,-13,o),
+(470,60,o),
+(504,220,cs),
+(610,714,l),
+(546,714,l),
+(443,227,ls),
+(416,103,o),
+(359,47,o),
+(262,47,cs),
+(118,47,o),
+(102,142,o),
+(126,257,cs),
+(169,454,l),
+(137,441,l),
+(135,387,o),
+(162,331,o),
+(222,331,cs),
+(335,331,o),
+(379,484,o),
+(387,573,cs),
+(394,667,o),
+(357,727,o),
+(282,727,cs),
+(203,727,o),
+(149,659,o),
+(123,536,cs),
+(65,259,ls),
+(33,106,o),
+(81,-13,o),
+(259,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(188,380,o),
+(168,410,o),
+(168,466,cs),
+(168,532,o),
+(197,679,o),
+(279,679,cs),
+(317,679,o),
+(337,648,o),
+(337,593,cs),
+(337,527,o),
+(308,380,o),
+(227,380,cs)
+);
+}
+);
+width = 571;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155E;
+unicode = 5470;
+},
+{
+glyphname = "theNCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(393,-13,o),
+(470,62,o),
+(506,227,cs),
+(567,514,ls),
+(597,653,o),
+(549,727,o),
+(473,727,cs),
+(355,727,o),
+(310,567,o),
+(310,466,cs),
+(310,386,o),
+(349,331,o),
+(414,331,cs),
+(459,331,o),
+(502,366,o),
+(523,421,c),
+(488,438,l),
+(445,234,ls),
+(417,102,o),
+(362,46,o),
+(261,46,cs),
+(140,46,o),
+(97,114,o),
+(126,250,cs),
+(225,714,l),
+(161,714,l),
+(63,253,ls),
+(28,85,o),
+(99,-13,o),
+(258,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(380,380,o),
+(360,410,o),
+(360,466,cs),
+(360,532,o),
+(389,679,o),
+(469,679,cs),
+(506,679,o),
+(526,648,o),
+(526,593,cs),
+(526,527,o),
+(497,380,o),
+(417,380,cs)
+);
+}
+);
+width = 571;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155F;
+unicode = 5471;
+},
+{
+glyphname = "thi-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (383,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(263,-13,o),
+(308,147,o),
+(308,248,cs),
+(308,328,o),
+(270,383,o),
+(205,383,cs),
+(160,383,o),
+(117,348,o),
+(96,293,c),
+(130,276,l),
+(174,480,ls),
+(202,612,o),
+(257,668,o),
+(358,668,cs),
+(479,668,o),
+(522,600,o),
+(493,464,cs),
+(394,0,l),
+(458,0,l),
+(555,461,ls),
+(591,629,o),
+(520,727,o),
+(361,727,cs),
+(226,727,o),
+(149,652,o),
+(113,487,cs),
+(52,200,ls),
+(22,61,o),
+(70,-13,o),
+(146,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(112,35,o),
+(93,66,o),
+(93,121,cs),
+(93,187,o),
+(121,334,o),
+(201,334,cs),
+(239,334,o),
+(259,304,o),
+(259,248,cs),
+(259,182,o),
+(230,35,o),
+(149,35,cs)
+);
+}
+);
+width = 571;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1560;
+unicode = 5472;
+},
+{
+glyphname = "thiNCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (383,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(415,-13,o),
+(470,55,o),
+(496,178,cs),
+(554,455,ls),
+(586,608,o),
+(538,727,o),
+(360,727,cs),
+(227,727,o),
+(148,654,o),
+(114,494,cs),
+(9,0,l),
+(73,0,l),
+(176,487,ls),
+(203,611,o),
+(260,667,o),
+(357,667,cs),
+(501,667,o),
+(517,572,o),
+(493,457,cs),
+(450,260,l),
+(481,273,l),
+(483,327,o),
+(457,383,o),
+(397,383,cs),
+(283,383,o),
+(240,230,o),
+(232,141,cs),
+(225,47,o),
+(262,-13,o),
+(337,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(301,35,o),
+(282,66,o),
+(282,121,cs),
+(282,187,o),
+(311,334,o),
+(392,334,cs),
+(431,334,o),
+(451,304,o),
+(451,248,cs),
+(451,182,o),
+(422,35,o),
+(340,35,cs)
+);
+}
+);
+width = 571;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1561;
+unicode = 5473;
+},
+{
+glyphname = "thii-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "thi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (222,0);
+ref = dot_top;
+}
+);
+width = 571;
+}
+);
+note = uni1562;
+unicode = 5474;
+},
+{
+glyphname = "thiiNCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "thiNCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (222,0);
+ref = dot_top;
+}
+);
+width = 571;
+}
+);
+note = uni1563;
+unicode = 5475;
+},
+{
+glyphname = "tho-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (343,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(158,0,ls),
+(438,0,o),
+(510,312,o),
+(510,477,cs),
+(510,631,o),
+(445,727,o),
+(327,727,cs),
+(168,727,o),
+(110,559,o),
+(110,444,cs),
+(110,359,o),
+(147,306,o),
+(212,306,cs),
+(329,306,o),
+(369,471,o),
+(369,560,cs),
+(369,634,o),
+(341,682,o),
+(287,689,c),
+(274,671,l),
+(276,678,o),
+(292,683,o),
+(317,683,cs),
+(405,683,o),
+(450,613,o),
+(450,490,cs),
+(450,361,o),
+(400,59,o),
+(161,59,cs),
+(48,59,l),
+(35,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(181,353,o),
+(161,384,o),
+(161,440,cs),
+(161,499,o),
+(189,659,o),
+(269,659,cs),
+(307,659,o),
+(327,627,o),
+(327,572,cs),
+(327,515,o),
+(300,353,o),
+(219,353,cs)
+);
+}
+);
+width = 525;
+}
+);
+metricRight = "to-canadian";
+note = uni1564;
+unicode = 5476;
+},
+{
+glyphname = "thoo-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "tho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (183,0);
+ref = dot_top;
+}
+);
+width = 525;
+}
+);
+note = uni1565;
+unicode = 5477;
+},
+{
+glyphname = "tha-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (385,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(387,0,l),
+(399,59,l),
+(296,59,ls),
+(184,59,o),
+(125,122,o),
+(125,246,cs),
+(125,383,o),
+(197,684,o),
+(371,684,cs),
+(399,684,o),
+(425,675,o),
+(442,658,c),
+(418,687,l),
+(304,697,o),
+(263,527,o),
+(263,441,cs),
+(263,358,o),
+(299,306,o),
+(363,306,cs),
+(472,306,o),
+(524,457,o),
+(524,557,cs),
+(524,664,o),
+(466,726,o),
+(369,726,cs),
+(152,726,o),
+(63,413,o),
+(63,246,cs),
+(63,90,o),
+(144,0,o),
+(284,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(328,353,o),
+(308,384,o),
+(308,440,cs),
+(308,499,o),
+(336,659,o),
+(417,659,cs),
+(454,659,o),
+(474,627,o),
+(474,572,cs),
+(474,515,o),
+(447,353,o),
+(366,353,cs)
+);
+}
+);
+width = 524;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tho-canadian";
+note = uni1566;
+unicode = 5478;
+},
+{
+glyphname = "thaa-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (225,0);
+ref = dot_top;
+}
+);
+width = 525;
+}
+);
+note = uni1567;
+unicode = 5479;
+},
+{
+glyphname = "thwaa-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (400,0);
+ref = dot_top;
+}
+);
+width = 700;
+}
+);
+note = uni1568;
+unicode = 5480;
+},
+{
+glyphname = "thwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (225,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (525,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 700;
+}
+);
+note = uni1569;
+unicode = 5481;
+},
+{
+glyphname = "th-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(271,357,l),
+(279,397,l),
+(229,397,ls),
+(175,397,o),
+(147,426,o),
+(147,485,cs),
+(147,548,o),
+(182,689,o),
+(265,689,cs),
+(277,689,o),
+(288,686,o),
+(299,679,c),
+(283,696,l),
+(225,698,o),
+(206,611,o),
+(206,573,cs),
+(206,534,o),
+(225,509,o),
+(257,509,cs),
+(319,509,o),
+(339,599,o),
+(339,640,cs),
+(339,691,o),
+(313,720,o),
+(263,720,cs),
+(150,720,o),
+(107,562,o),
+(107,485,cs),
+(107,405,o),
+(149,357,o),
+(221,357,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(241,536,o),
+(232,548,o),
+(232,572,cs),
+(232,601,o),
+(244,678,o),
+(284,678,cs),
+(301,678,o),
+(310,666,o),
+(310,642,cs),
+(310,613,o),
+(297,536,o),
+(257,536,cs)
+);
+}
+);
+width = 306;
+}
+);
+metricLeft = "t-canadian";
+note = uni156A;
+unicode = 5482;
+},
+{
+glyphname = "tthe-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (619,357);
+},
+{
+name = top_center_can;
+pos = (381,714);
+},
+{
+name = top_left_can;
+pos = (194,714);
+},
+{
+name = top_right_can;
+pos = (570,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(385,-13,o),
+(464,62,o),
+(497,219,cs),
+(602,714,l),
+(543,714,l),
+(440,227,ls),
+(413,102,o),
+(357,47,o),
+(259,47,cs),
+(137,47,o),
+(93,114,o),
+(122,250,cs),
+(221,714,l),
+(161,714,l),
+(63,253,ls),
+(28,85,o),
+(99,-13,o),
+(256,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(340,405,l),
+(406,714,l),
+(357,714,l),
+(291,405,l)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156B;
+unicode = 5483;
+},
+{
+glyphname = "tthi-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(69,0,l),
+(172,487,ls),
+(199,612,o),
+(255,667,o),
+(352,667,cs),
+(475,667,o),
+(519,600,o),
+(490,464,cs),
+(391,0,l),
+(450,0,l),
+(548,461,ls),
+(584,629,o),
+(513,727,o),
+(356,727,cs),
+(227,727,o),
+(148,652,o),
+(115,495,cs),
+(9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(255,0,l),
+(320,309,l),
+(272,309,l),
+(206,0,l)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156C;
+unicode = 5484;
+},
+{
+glyphname = "ttho-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (329,714);
+},
+{
+name = top_left_can;
+pos = (192,714);
+},
+{
+name = top_right_can;
+pos = (509,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(112,0,ls),
+(402,0,o),
+(475,305,o),
+(475,474,cs),
+(475,633,o),
+(392,714,o),
+(236,714,cs),
+(164,714,l),
+(152,655,l),
+(224,655,ls),
+(350,655,o),
+(411,597,o),
+(411,473,cs),
+(411,336,o),
+(353,59,o),
+(115,59,cs),
+(25,59,l),
+(13,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(260,330,l),
+(271,384,l),
+(94,384,l),
+(83,330,l)
+);
+}
+);
+width = 490;
+}
+);
+metricRight = "to-canadian";
+note = uni156D;
+unicode = 5485;
+},
+{
+glyphname = "ttha-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (347,714);
+},
+{
+name = top_left_can;
+pos = (180,714);
+},
+{
+name = top_right_can;
+pos = (491,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(374,0,l),
+(386,59,l),
+(311,59,ls),
+(185,59,o),
+(127,117,o),
+(127,241,cs),
+(127,382,o),
+(185,655,o),
+(420,655,cs),
+(513,655,l),
+(526,714,l),
+(423,714,ls),
+(137,714,o),
+(63,413,o),
+(63,239,cs),
+(63,81,o),
+(143.004,0,o),
+(299,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(440,330,l),
+(452,384,l),
+(276,384,l),
+(264,330,l)
+);
+}
+);
+width = 490;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|ttho-canadian";
+note = uni156E;
+unicode = 5486;
+},
+{
+glyphname = "tth-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(242,523,l),
+(227,523,l),
+(286,402,l),
+(322,419,l),
+(260,545,l),
+(253,530,l),
+(381,584,l),
+(368,619,l),
+(246,567,l),
+(260,561,l),
+(293,714,l),
+(253,714,l),
+(219,560,l),
+(237,566,l),
+(131,619,l),
+(115,584,l),
+(217,533,l),
+(215,548,l),
+(105,427,l),
+(134,402,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(559,523,l),
+(544,523,l),
+(603,402,l),
+(638,419,l),
+(577,545,l),
+(570,530,l),
+(698,584,l),
+(684,618,l),
+(562,567,l),
+(577,561,l),
+(610,714,l),
+(570,714,l),
+(536,560,l),
+(554,566,l),
+(448,620,l),
+(431,585,l),
+(534,533,l),
+(531,548,l),
+(422,427,l),
+(450,402,l)
+);
+}
+);
+width = 669;
+}
+);
+metricRight = "=|";
+note = uni156F;
+unicode = 5487;
+},
+{
+glyphname = "tye-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(385,-13,o),
+(464,62,o),
+(497,219,cs),
+(602,714,l),
+(543,714,l),
+(439,227,ls),
+(413,102,o),
+(357,47,o),
+(259,47,cs),
+(137,47,o),
+(93,114,o),
+(122,250,cs),
+(221,714,l),
+(161,714,l),
+(63,253,ls),
+(28,85,o),
+(99,-13,o),
+(256,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(386,426,o),
+(417,459,o),
+(434,536,cs),
+(472,714,l),
+(438,714,l),
+(402,542,ls),
+(390,484,o),
+(369,461,o),
+(329,461,cs),
+(290,461,o),
+(277,483,o),
+(288,536,cs),
+(325,714,l),
+(292,714,l),
+(254,533,ls),
+(239,465,o),
+(267,426,o),
+(329,426,cs)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1570;
+unicode = 5488;
+},
+{
+glyphname = "tyi-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(69,0,l),
+(172,487,ls),
+(199,612,o),
+(255,667,o),
+(352,667,cs),
+(475,667,o),
+(519,600,o),
+(490,464,cs),
+(391,0,l),
+(450,0,l),
+(548,461,ls),
+(584,629,o),
+(513,727,o),
+(356,727,cs),
+(227,727,o),
+(148,652,o),
+(114,495,cs),
+(9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(173,0,l),
+(210,172,ls),
+(222,230,o),
+(243,253,o),
+(283,253,cs),
+(322,253,o),
+(335,231,o),
+(324,178,cs),
+(286,0,l),
+(320,0,l),
+(358,181,ls),
+(372,249,o),
+(345,288,o),
+(283,288,cs),
+(226,288,o),
+(195,255,o),
+(178,178,cs),
+(140,0,l)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1571;
+unicode = 5489;
+},
+{
+glyphname = "tyo-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(110,0,ls),
+(402,0,o),
+(476,305,o),
+(476,474,cs),
+(476,633,o),
+(391,714,o),
+(234,714,cs),
+(166,714,l),
+(154,656,l),
+(222,656,ls),
+(349,656,o),
+(413,597,o),
+(413,473,cs),
+(413,315,o),
+(333,58,o),
+(112,58,cs),
+(26,58,l),
+(14,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(105,217,ls),
+(228,217,o),
+(262,304,o),
+(266,379,cs),
+(271,455,o),
+(231,497,o),
+(162,497,cs),
+(119,497,l),
+(111,459,l),
+(154,459,ls),
+(204,459,o),
+(229,432,o),
+(228,382,cs),
+(226,328,o),
+(205,255,o),
+(110,255,cs),
+(68,255,l),
+(60,217,l)
+);
+}
+);
+width = 491;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1572;
+unicode = 5490;
+},
+{
+glyphname = "tya-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(374,0,l),
+(386,58,l),
+(317,58,ls),
+(190,58,o),
+(127,117,o),
+(127,241,cs),
+(127,399,o),
+(207,656,o),
+(427,656,cs),
+(513,656,l),
+(525,714,l),
+(430,714,ls),
+(138,714,o),
+(63,409,o),
+(63,240,cs),
+(63,81,o),
+(149,0,o),
+(306,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(420,217,l),
+(429,255,l),
+(386,255,ls),
+(336,255,o),
+(310,282,o),
+(312,332,cs),
+(313,386,o),
+(334,459,o),
+(429,459,cs),
+(472,459,l),
+(480,497,l),
+(435,497,ls),
+(311,497,o),
+(278,410,o),
+(274,335,cs),
+(269,259,o),
+(309,217,o),
+(378,217,cs)
+);
+}
+);
+width = 492;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1573;
+unicode = 5491;
+},
+{
+glyphname = "heNunavik-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(345,0,l),
+(570,197,l),
+(535,241,l),
+(347,76,l),
+(366,62,l),
+(449,454,ls),
+(477,585,o),
+(461,727,o),
+(316,727,cs),
+(144,727,o),
+(95,500,o),
+(95,381,cs),
+(95,273,o),
+(141,212,o),
+(229,212,cs),
+(294,212,o),
+(340,249,o),
+(372,330,c),
+(360,334,l),
+(289,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(186,268,o),
+(156,307,o),
+(156,383,cs),
+(156,465,o),
+(191,671,o),
+(311,671,cs),
+(370,671,o),
+(400,632,o),
+(400,557,cs),
+(400,476,o),
+(365,268,o),
+(244,268,cs)
+);
+}
+);
+width = 604;
+}
+);
+metricLeft = "ke-canadian";
+note = uni1574;
+unicode = 5492;
+},
+{
+glyphname = "hiNunavik-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (473,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(212,0,l),
+(291,373,l),
+(275,334,l),
+(275,262,o),
+(317,212,o),
+(391,212,cs),
+(556,212,o),
+(605,441,o),
+(605,555,cs),
+(605,666,o),
+(556,727,o),
+(461,727,cs),
+(356,727,o),
+(286,647,o),
+(252,488,cs),
+(161,59,l),
+(181,63,l),
+(60,233,l),
+(14,197,l),
+(156,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(331,268,o),
+(301,307,o),
+(301,382,cs),
+(301,464,o),
+(339,671,o),
+(457,671,cs),
+(516,671,o),
+(544,633,o),
+(544,557,cs),
+(544,472,o),
+(508,268,o),
+(390,268,cs)
+);
+}
+);
+width = 605;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1575;
+unicode = 5493;
+},
+{
+glyphname = "hiiNunavik-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "hiNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (311,0);
+ref = dot_top;
+}
+);
+width = 604;
+}
+);
+note = uni1576;
+unicode = 5494;
+},
+{
+glyphname = "hoNunavik-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (327,714);
+},
+{
+name = top_right_can;
+pos = (471,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(296,-13,o),
+(367,67,o),
+(400,226,cs),
+(491,655,l),
+(471,651,l),
+(592,481,l),
+(639,517,l),
+(496,714,l),
+(441,714,l),
+(361,341,l),
+(378,380,l),
+(378,452,o),
+(335,502,o),
+(262,502,cs),
+(96,502,o),
+(47,273,o),
+(47,159,cs),
+(47,48,o),
+(96,-13,o),
+(191,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(137,43,o),
+(108,81,o),
+(108,157,cs),
+(108,242,o),
+(144,446,o),
+(262,446,cs),
+(321,446,o),
+(351,407,o),
+(351,332,cs),
+(351,250,o),
+(314,43,o),
+(195,43,cs)
+);
+}
+);
+width = 605;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "heNunavik-canadian";
+note = uni1577;
+unicode = 5495;
+},
+{
+glyphname = "hooNunavik-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "hoNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (310,0);
+ref = dot_top;
+}
+);
+width = 604;
+}
+);
+note = uni1578;
+unicode = 5496;
+},
+{
+glyphname = "haNunavik-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (475,714);
+},
+{
+name = top_left_can;
+pos = (331,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(509,-13,o),
+(558,214,o),
+(558,333,cs),
+(558,441,o),
+(512,502,o),
+(423,502,cs),
+(359,502,o),
+(312,465,o),
+(280,384,c),
+(292,380,l),
+(364,714,l),
+(307,714,l),
+(82,517,l),
+(118,473,l),
+(306,638,l),
+(287,652,l),
+(204,260,ls),
+(176,129,o),
+(191,-13,o),
+(336,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(283,43,o),
+(253,82,o),
+(253,157,cs),
+(253,238,o),
+(288,446,o),
+(408,446,cs),
+(467,446,o),
+(497,407,o),
+(497,331,cs),
+(497,249,o),
+(461,43,o),
+(341,43,cs)
+);
+}
+);
+width = 605;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1579;
+unicode = 5497;
+},
+{
+glyphname = "haaNunavik-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "haNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (169,0);
+ref = dot_top;
+}
+);
+width = 604;
+}
+);
+note = uni157A;
+unicode = 5498;
+},
+{
+glyphname = "hNunavik-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(338,351,o),
+(370,475,o),
+(370,532,cs),
+(370,588,o),
+(345,622,o),
+(301,622,cs),
+(268,622,o),
+(244,605,o),
+(225,572,c),
+(232,560,l),
+(264,714,l),
+(224,714,l),
+(111,616,l),
+(135,589,l),
+(232,674,l),
+(217,697,l),
+(174,495,ls),
+(160,430,o),
+(172,351,o),
+(246,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(223,388,o),
+(209,407,o),
+(209,445,cs),
+(209,503,o),
+(234,585,o),
+(287,585,cs),
+(315,585,o),
+(329,566,o),
+(329,529,cs),
+(329,471,o),
+(304,388,o),
+(250,388,cs)
+);
+}
+);
+width = 356;
+}
+);
+metricRight = "k-canadian";
+note = uni157B;
+unicode = 5499;
+},
+{
+color = 4;
+glyphname = "nunavuth-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(76,0,l),
+(149,342,l),
+(430,342,l),
+(357,0,l),
+(420,0,l),
+(572,714,l),
+(509,714,l),
+(442,400,l),
+(162,400,l),
+(228,714,l),
+(165,714,l),
+(13,0,l)
+);
+}
+);
+width = 537;
+}
+);
+metricRight = "=|";
+note = uni157C;
+unicode = 5500;
+},
+{
+glyphname = "hk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (76,357);
+ref = "fullstop-canadian";
+}
+);
+width = 291;
+}
+);
+metricLeft = "fullstop-canadian";
+note = uni157D;
+unicode = 5501;
+},
+{
+glyphname = "qaai-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (252,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (370,0);
+ref = ring_top.canadian;
+}
+);
+width = 718;
+}
+);
+note = uni157E;
+unicode = 5502;
+},
+{
+glyphname = "qi-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (252,0);
+ref = "ki-canadian";
+}
+);
+width = 718;
+}
+);
+note = uni157F;
+unicode = 5503;
+},
+{
+glyphname = "qii-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (252,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (427,0);
+ref = dot_top;
+}
+);
+width = 718;
+}
+);
+note = uni1580;
+unicode = 5504;
+},
+{
+glyphname = "qo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (252,0);
+ref = "ko-canadian";
+}
+);
+width = 718;
+}
+);
+note = uni1581;
+unicode = 5505;
+},
+{
+glyphname = "qoo-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (252,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (564,0);
+ref = dot_top;
+}
+);
+width = 718;
+}
+);
+note = uni1582;
+unicode = 5506;
+},
+{
+glyphname = "qa-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (252,0);
+ref = "ka-canadian";
+}
+);
+width = 718;
+}
+);
+note = uni1583;
+unicode = 5507;
+},
+{
+glyphname = "qaa-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (252,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (283,0);
+ref = dot_top;
+}
+);
+width = 718;
+}
+);
+note = uni1584;
+unicode = 5508;
+},
+{
+glyphname = "q-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (252,0);
+ref = "k-canadian";
+}
+);
+width = 540;
+}
+);
+note = uni1585;
+unicode = 5509;
+},
+{
+glyphname = "tlhe-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (334,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(94,0,l),
+(256,276,l),
+(209,251,l),
+(217,249,o),
+(226,249,o),
+(234,249,cs),
+(293,249,o),
+(338,278,o),
+(375,341,c),
+(369,357,l),
+(293,0,l),
+(356,0,l),
+(457,474,ls),
+(482,591,o),
+(467,727,o),
+(323,727,cs),
+(160,727,o),
+(105,537,o),
+(105,417,cs),
+(105,340,o),
+(134,287,o),
+(187,268,c),
+(27,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(194,305,o),
+(165,343,o),
+(165,419,cs),
+(165,494,o),
+(198,671,o),
+(317,671,cs),
+(377,671,o),
+(404,631,o),
+(404,561,cs),
+(404,484,o),
+(371,305,o),
+(254,305,cs)
+);
+}
+);
+width = 469;
+}
+);
+metricRight = "te-canadian";
+note = uni1586;
+unicode = 5510;
+},
+{
+glyphname = "tlhi-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(72,0,l),
+(151,370,l),
+(131,361,l),
+(144,296,o),
+(185,255,o),
+(248,250,c),
+(228,265,l),
+(272,0,l),
+(338,0,l),
+(294,260,l),
+(425,278,o),
+(470,452,o),
+(470,553,cs),
+(470,661,o),
+(415,727,o),
+(320,727,cs),
+(226,727,o),
+(149,656,o),
+(116,502,cs),
+(9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,305,o),
+(169,346,o),
+(169,420,cs),
+(169,497,o),
+(205,671,o),
+(319,671,cs),
+(378,671,o),
+(408,630,o),
+(408,555,cs),
+(408,476,o),
+(375,305,o),
+(259,305,cs)
+);
+}
+);
+width = 472;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|tlhe-canadian";
+note = uni1587;
+unicode = 5511;
+},
+{
+glyphname = "tlho-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (348,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(293,-13,o),
+(370,58,o),
+(403,212,cs),
+(510,714,l),
+(447,714,l),
+(368,344,l),
+(388,353,l),
+(375,418,o),
+(334,459,o),
+(271,464,c),
+(291,449,l),
+(247,714,l),
+(181,714,l),
+(225,454,l),
+(94,436,o),
+(50,262,o),
+(50,161,cs),
+(50,53,o),
+(104,-13,o),
+(199,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(141,43,o),
+(112,84,o),
+(112,159,cs),
+(112,238,o),
+(144,409,o),
+(260,409,cs),
+(319,409,o),
+(350,368,o),
+(350,294,cs),
+(350,217,o),
+(314,43,o),
+(200,43,cs)
+);
+}
+);
+width = 471;
+}
+);
+metricLeft = "tlhe-canadian";
+metricRight = "te-canadian";
+note = uni1588;
+unicode = 5512;
+},
+{
+glyphname = "tlha-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(358,-13,o),
+(413,177,o),
+(413,297,cs),
+(413,374,o),
+(384,427,o),
+(331,446,c),
+(490,714,l),
+(424,714,l),
+(262,438,l),
+(309,463,l),
+(300,465,o),
+(292,465,o),
+(284,465,cs),
+(225,465,o),
+(179,436,o),
+(143,373,c),
+(149,357,l),
+(224,714,l),
+(161,714,l),
+(61,240,ls),
+(36,123,o),
+(51,-13,o),
+(195,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(141,43,o),
+(114,83,o),
+(114,153,cs),
+(114,230,o),
+(147,409,o),
+(264,409,cs),
+(324,409,o),
+(353,371,o),
+(353,295,cs),
+(353,220,o),
+(319,43,o),
+(201,43,cs)
+);
+}
+);
+width = 470;
+}
+);
+metricLeft = "te-canadian";
+note = uni1589;
+unicode = 5513;
+},
+{
+glyphname = "reWestCree-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(341,0,l),
+(566,198,l),
+(529,241,l),
+(343,74,l),
+(361,61,l),
+(452,491,ls),
+(484,641,o),
+(425,727,o),
+(311,727,cs),
+(203,727,o),
+(142,658,o),
+(109,504,cs),
+(88,405,l),
+(151,405,l),
+(174,513,ls),
+(198,623,o),
+(237,670,o),
+(304,670,cs),
+(381,670,o),
+(416,615,o),
+(392,502,cs),
+(285,0,l)
+);
+}
+);
+width = 600;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+unicode = 5514;
+},
+{
+glyphname = "riWestCree-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(211,0,l),
+(320,513,ls),
+(344,623,o),
+(383,670,o),
+(450,670,cs),
+(527,670,o),
+(562,615,o),
+(538,502,cs),
+(517,405,l),
+(580,405,l),
+(599,491,ls),
+(631,641,o),
+(571,727,o),
+(457,727,cs),
+(349,727,o),
+(288,658,o),
+(255,504,cs),
+(161,62,l),
+(181,65,l),
+(63,234,l),
+(14,198,l),
+(155,0,l)
+);
+}
+);
+width = 601;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+unicode = 5515;
+},
+{
+glyphname = "roWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(299,-13,o),
+(360,56,o),
+(393,210,cs),
+(487,652,l),
+(467,649,l),
+(586,480,l),
+(634,516,l),
+(493,714,l),
+(437,714,l),
+(328,201,ls),
+(304,91,o),
+(265,44,o),
+(198,44,cs),
+(121,44,o),
+(86,99,o),
+(110,212,cs),
+(131,309,l),
+(68,309,l),
+(49,223,ls),
+(17,73,o),
+(77,-13,o),
+(191,-13,cs)
+);
+}
+);
+width = 600;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+unicode = 5516;
+},
+{
+glyphname = "raWestCree-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(445,-13,o),
+(505,56,o),
+(538,210,cs),
+(560,309,l),
+(497,309,l),
+(474,201,ls),
+(450,91,o),
+(411,44,o),
+(344,44,cs),
+(267,44,o),
+(232,99,o),
+(256,212,cs),
+(363,714,l),
+(306,714,l),
+(82,516,l),
+(118,473,l),
+(305,640,l),
+(286,653,l),
+(195,223,ls),
+(164,73,o),
+(223,-13,o),
+(337,-13,cs)
+);
+}
+);
+width = 600;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+unicode = 5517;
+},
+{
+glyphname = "ngaai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:30:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (493,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (610,0);
+ref = ring_top.canadian;
+}
+);
+width = 955;
+}
+);
+note = uni158E;
+unicode = 5518;
+},
+{
+glyphname = "ngi-canadian";
+kernLeft = mwestleft;
+kernRight = ciright;
+lastChange = "2023-01-13 15:30:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (493,0);
+ref = "ci-canadian";
+}
+);
+width = 955;
+}
+);
+note = uni158F;
+unicode = 5519;
+},
+{
+glyphname = "ngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:30:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (493,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (668,0);
+ref = dot_top;
+}
+);
+width = 955;
+}
+);
+note = uni1590;
+unicode = 5520;
+},
+{
+glyphname = "ngo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:30:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (468,0);
+ref = "co-canadian";
+}
+);
+width = 929;
+}
+);
+note = uni1591;
+unicode = 5521;
+},
+{
+glyphname = "ngoo-canadian";
+lastChange = "2023-01-13 15:30:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "ngo-canadian";
+},
+{
+anchor = top_right_can;
+pos = (776,0);
+ref = dot_top;
+}
+);
+width = 929;
+}
+);
+note = uni1592;
+unicode = 5522;
+},
+{
+glyphname = "nga-canadian";
+kernLeft = mwestleft;
+kernRight = caright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (494,0);
+ref = "ca-canadian";
+}
+);
+width = 955;
+}
+);
+note = uni1593;
+unicode = 5523;
+},
+{
+glyphname = "ngaa-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (494,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (526,0);
+ref = dot_top;
+}
+);
+width = 955;
+}
+);
+note = uni1594;
+unicode = 5524;
+},
+{
+glyphname = "ng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(426,225,o),
+(465,266,o),
+(481,345,cs),
+(487,376,l),
+(445,376,l),
+(437,341,ls),
+(425,288,o),
+(405,264,o),
+(370,264,cs),
+(333,264,o),
+(319,290,o),
+(330,341,cs),
+(363,493,l),
+(245,493,l),
+(253,476,l),
+(289,501,o),
+(307,569,o),
+(309,612,cs),
+(313,678,o),
+(283,720,o),
+(228,720,cs),
+(148,720,o),
+(115,620,o),
+(111,557,cs),
+(106,488,o),
+(138,449,o),
+(195,449,cs),
+(329,449,l),
+(314,478,l),
+(287,350,ls),
+(271,274,o),
+(302,225,o),
+(366,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(164,485,o),
+(149,508,o),
+(151,552,cs),
+(153,596,o),
+(170,683,o),
+(226,683,cs),
+(255,683,o),
+(270,660,o),
+(268,617,cs),
+(266,573,o),
+(249,485,o),
+(192,485,cs)
+);
+}
+);
+width = 493;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1595;
+unicode = 5525;
+},
+{
+glyphname = "nng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(655,225,o),
+(694,266,o),
+(710,345,cs),
+(717,376,l),
+(675,376,l),
+(667,341,ls),
+(655,288,o),
+(634,264,o),
+(600,264,cs),
+(562,264,o),
+(548,290,o),
+(560,341,cs),
+(592,493,l),
+(479,493,l),
+(481,476,l),
+(519,504,o),
+(538,577,o),
+(538,621,cs),
+(538,682,o),
+(508,720,o),
+(456,720,cs),
+(370,720,o),
+(338,611,o),
+(338,546,cs),
+(338,517,o),
+(346,494,o),
+(360,478,c),
+(368,493,l),
+(252,493,l),
+(253,476,l),
+(293,504,o),
+(311,582,o),
+(311,620,cs),
+(311,681,o),
+(281,720,o),
+(229,720,cs),
+(142,720,o),
+(111,611,o),
+(111,546,cs),
+(111,484,o),
+(142,449,o),
+(196,449,cs),
+(537,449,l),
+(516,350,ls),
+(500,274,o),
+(531,225,o),
+(595,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(166,485,o),
+(151,506,o),
+(151,545,cs),
+(151,587,o),
+(169,683,o),
+(227,683,cs),
+(255,683,o),
+(270,663,o),
+(270,624,cs),
+(270,582,o),
+(253,485,o),
+(193,485,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(393,485,o),
+(379,506,o),
+(379,545,cs),
+(379,587,o),
+(396,683,o),
+(454,683,cs),
+(483,683,o),
+(497,663,o),
+(497,624,cs),
+(497,582,o),
+(480,485,o),
+(421,485,cs)
+);
+}
+);
+width = 722;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1596;
+unicode = 5526;
+},
+{
+glyphname = "sheSayisi-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (526,357);
+},
+{
+name = top_center_can;
+pos = (334,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(358,0,l),
+(456,462,ls),
+(491,630,o),
+(440,727,o),
+(324,727,cs),
+(145,727,o),
+(91,488,o),
+(91,362,cs),
+(91,268,o),
+(123,214,o),
+(192,214,cs),
+(263,214,o),
+(304,276,o),
+(331,425,c),
+(300,425,l),
+(279,314,o),
+(252,268,o),
+(207,268,cs),
+(169,268,o),
+(150,300,o),
+(150,360,cs),
+(150,450,o),
+(192,671,o),
+(318,671,cs),
+(394,671,o),
+(422,599,o),
+(393,461,cs),
+(294,0,l)
+);
+}
+);
+width = 471;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1597;
+unicode = 5527;
+},
+{
+glyphname = "shiSayisi-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(73,0,l),
+(175,479,ls),
+(203,609,o),
+(247,671,o),
+(317,671,cs),
+(380,671,o),
+(411,631,o),
+(411,551,cs),
+(411,479,o),
+(372,268,o),
+(289,268,cs),
+(238,268,o),
+(223,317,o),
+(248,425,c),
+(216,425,l),
+(185,286,o),
+(215,214,o),
+(296,214,cs),
+(421,214,o),
+(471,445,o),
+(471,548,cs),
+(471,662,o),
+(419,727,o),
+(321,727,cs),
+(216,727,o),
+(147,648,o),
+(114,492,cs),
+(9,0,l)
+);
+}
+);
+width = 471;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni1598;
+unicode = 5528;
+},
+{
+glyphname = "shoSayisi-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (332,714);
+},
+{
+name = top_left_can;
+pos = (185,714);
+},
+{
+name = top_right_can;
+pos = (479,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(304,-13,o),
+(372,66,o),
+(405,222,cs),
+(510,714,l),
+(447,714,l),
+(345,235,ls),
+(317,105,o),
+(272,43,o),
+(202,43,cs),
+(140,43,o),
+(108,83,o),
+(108,163,cs),
+(108,235,o),
+(148,446,o),
+(230,446,cs),
+(282,446,o),
+(297,397,o),
+(272,289,c),
+(303,289,l),
+(335,428,o),
+(305,500,o),
+(224,500,cs),
+(99,500,o),
+(48,269,o),
+(48,166,cs),
+(48,52,o),
+(101,-13,o),
+(199,-13,cs)
+);
+}
+);
+width = 471;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1599;
+unicode = 5529;
+},
+{
+glyphname = "shaSayisi-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(373,-13,o),
+(428,226,o),
+(428,352,cs),
+(428,446,o),
+(396,500,o),
+(327,500,cs),
+(256,500,o),
+(215,438,o),
+(187,289,c),
+(218,289,l),
+(239,400,o),
+(267,446,o),
+(312,446,cs),
+(350,446,o),
+(369,414,o),
+(369,354,cs),
+(369,264,o),
+(326,43,o),
+(201,43,cs),
+(125,43,o),
+(97,115,o),
+(126,253,cs),
+(224,714,l),
+(161,714,l),
+(63,252,ls),
+(27,84,o),
+(78,-13,o),
+(195,-13,cs)
+);
+}
+);
+width = 471;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni159A;
+unicode = 5530;
+},
+{
+glyphname = "theWoodScree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(542,-13,o),
+(594,196,o),
+(594,311,cs),
+(594,425,o),
+(537,489,o),
+(433,489,cs),
+(111,489,l),
+(99,434,l),
+(361,434,l),
+(361,456,l),
+(255,417,o),
+(223,252,o),
+(223,166,cs),
+(223,54,o),
+(279,-13,o),
+(378,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(316,43,o),
+(284,84,o),
+(284,162,cs),
+(284,240,o),
+(314,434,o),
+(439,434,cs),
+(502,434,o),
+(533,393,o),
+(533,315,cs),
+(533,236,o),
+(504,43,o),
+(379,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(670,659,l),
+(682,714,l),
+(159,714,l),
+(147,659,l)
+);
+}
+);
+width = 648;
+}
+);
+note = uni159B;
+unicode = 5531;
+},
+{
+glyphname = "thiWoodScree-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(372,-13,o),
+(424,199,o),
+(424,311,cs),
+(424,371,o),
+(407,414,o),
+(373,440,c),
+(369,434,l),
+(631,434,l),
+(642,489,l),
+(288,489,ls),
+(96,489,o),
+(53,278,o),
+(53,166,cs),
+(53,54,o),
+(107,-13,o),
+(207,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(145,43,o),
+(114,84,o),
+(114,162,cs),
+(114,240,o),
+(143,434,o),
+(269,434,cs),
+(331,434,o),
+(363,393,o),
+(363,315,cs),
+(363,236,o),
+(333,43,o),
+(209,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(679,659,l),
+(691,714,l),
+(169,714,l),
+(157,659,l)
+);
+}
+);
+width = 649;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159C;
+unicode = 5532;
+},
+{
+glyphname = "thoWoodScree-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(361,0,ls),
+(554,0,o),
+(597,211,o),
+(597,323,cs),
+(597,435,o),
+(542,502,o),
+(442,502,cs),
+(277,502,o),
+(226,290,o),
+(226,178,cs),
+(226,118,o),
+(242,75,o),
+(277,49,c),
+(280,55,l),
+(19,55,l),
+(7,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(318,55,o),
+(287,96,o),
+(287,174,cs),
+(287,254,o),
+(316,446,o),
+(441,446,cs),
+(504,446,o),
+(536,405,o),
+(536,327,cs),
+(536,249,o),
+(507,55,o),
+(381,55,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(670,659,l),
+(682,714,l),
+(159,714,l),
+(147,659,l)
+);
+}
+);
+width = 649;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159D;
+unicode = 5533;
+},
+{
+glyphname = "thaWoodScree-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(539,0,l),
+(550,55,l),
+(289,55,l),
+(289,33,l),
+(394,73,o),
+(426,237,o),
+(426,323,cs),
+(426,435,o),
+(371,502,o),
+(272,502,cs),
+(108,502,o),
+(55,293,o),
+(55,178,cs),
+(55,64,o),
+(113,0,o),
+(216,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(147,55,o),
+(116,96,o),
+(116,174,cs),
+(116,254,o),
+(146,446,o),
+(270,446,cs),
+(334,446,o),
+(365,405,o),
+(365,327,cs),
+(365,249,o),
+(336,55,o),
+(210,55,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(678,659,l),
+(690,714,l),
+(166.99,714,l),
+(155,659,l)
+);
+}
+);
+width = 649;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159E;
+unicode = 5534;
+},
+{
+glyphname = "thWoodScree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(367,357,l),
+(376,398,l),
+(230,398,l),
+(227,375,l),
+(281,396,o),
+(302,481,o),
+(302,528,cs),
+(302,590,o),
+(272,628,o),
+(220,628,cs),
+(134,628,o),
+(103,518,o),
+(103,454,cs),
+(103,392,o),
+(134,357,o),
+(188,357,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(158,393,o),
+(143,414,o),
+(143,453,cs),
+(143,495,o),
+(160,591,o),
+(218,591,cs),
+(247,591,o),
+(262,570,o),
+(262,531,cs),
+(262,490,o),
+(245,393,o),
+(185,393,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(436,700,l),
+(445,742,l),
+(162,742,l),
+(153,700,l)
+);
+}
+);
+width = 396;
+}
+);
+metricRight = "=|";
+note = uni159F;
+unicode = 5535;
+},
+{
+glyphname = "lhi-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (466,714);
+},
+{
+name = top_right_can;
+pos = (538,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(233,0,l),
+(245,57,l),
+(237,57,ls),
+(159,57,o),
+(114,110,o),
+(114,195,cs),
+(114,293,o),
+(167,431,o),
+(321,431,cs),
+(625,431,l),
+(637,483,l),
+(556,747,l),
+(497,728,l),
+(579,460,l),
+(601,489,l),
+(325,489,ls),
+(135,489,o),
+(51,337,o),
+(51,194,cs),
+(51,78,o),
+(118,0,o),
+(223,0,cs)
+);
+}
+);
+width = 637;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A0;
+unicode = 5536;
+},
+{
+glyphname = "lhii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "lhi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (305,0);
+ref = dot_top;
+}
+);
+width = 637;
+}
+);
+note = uni15A1;
+unicode = 5537;
+},
+{
+glyphname = "lho-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (367,507);
+},
+{
+name = top_right_can;
+pos = (454,507);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(140,-239,l),
+(58,28,l),
+(36,-1,l),
+(311,-1,ls),
+(502,-1,o),
+(586,152,o),
+(586,294,cs),
+(586,410,o),
+(519,488,o),
+(414,488,cs),
+(404,488,l),
+(392,431,l),
+(400,431,ls),
+(477,431,o),
+(523,379,o),
+(523,294,cs),
+(523,195,o),
+(470,58,o),
+(316,58,cs),
+(12,58,l),
+(0,5,l),
+(81,-258,l)
+);
+}
+);
+width = 638;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni15A2;
+unicode = 5538;
+},
+{
+glyphname = "lhoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "lho-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (293,-207);
+ref = dot_top;
+}
+);
+width = 637;
+}
+);
+note = uni15A3;
+unicode = 5539;
+},
+{
+glyphname = "lha-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (384,507);
+},
+{
+name = top_left_can;
+pos = (295,507);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(535,6,l),
+(546,58,l),
+(256,58,ls),
+(164,58,o),
+(114,107,o),
+(114,195,cs),
+(114,287,o),
+(155,432,o),
+(316,432,cs),
+(325,432,l),
+(337,489,l),
+(322,489,ls),
+(124,489,o),
+(52,328,o),
+(52,193,cs),
+(52,73,o),
+(122,0,o),
+(244,0,cs),
+(493,0,l),
+(477,26,l),
+(294,-223,l),
+(341,-258,l)
+);
+}
+);
+width = 637;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A4;
+unicode = 5540;
+},
+{
+glyphname = "lhaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "lha-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (134,-207);
+ref = dot_top;
+}
+);
+width = 637;
+}
+);
+note = uni15A5;
+unicode = 5541;
+},
+{
+glyphname = "lh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(371,361,l),
+(380,401,l),
+(240,401,ls),
+(183,401,o),
+(154,432,o),
+(154,491,cs),
+(154,566,o),
+(185,670,o),
+(295,670,cs),
+(298,670,l),
+(308,714,l),
+(303,714,ls),
+(156,714,o),
+(109,590,o),
+(109,489,cs),
+(109,404,o),
+(155,357,o),
+(240,357,cs),
+(347,357,l),
+(333,383,l),
+(230,241,l),
+(265,215,l)
+);
+}
+);
+width = 397;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni15A6;
+unicode = 5542;
+},
+{
+glyphname = "theThCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (173,714);
+},
+{
+name = top_right_can;
+pos = (456,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(298,121,l),
+(271,0,l),
+(335,0,l),
+(361,121,l),
+(423,121,l),
+(432,163,l),
+(370,163,l),
+(403,321,l),
+(126,321,l),
+(136,299,l),
+(491,688,l),
+(446,726,l),
+(51,290,l),
+(46,264,l),
+(328,264,l),
+(306,163,l),
+(118,163,l),
+(109,121,l)
+);
+}
+);
+width = 485;
+}
+);
+metricLeft = "ye-canadian";
+note = uni15A7;
+unicode = 5543;
+},
+{
+glyphname = "thiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (231,714);
+},
+{
+name = top_right_can;
+pos = (513,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(110,0,l),
+(136,121,l),
+(325,121,l),
+(334,163,l),
+(145,163,l),
+(166,264,l),
+(448,264,l),
+(453,290,l),
+(233,726,l),
+(181,698,l),
+(385,295,l),
+(401,321,l),
+(115,321,l),
+(81,163,l),
+(19,163,l),
+(11,121,l),
+(73,121,l),
+(46,0,l)
+);
+}
+);
+width = 485;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+unicode = 5544;
+},
+{
+glyphname = "thiiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (69,0);
+ref = dot_top;
+}
+);
+width = 485;
+}
+);
+note = uni15A9;
+unicode = 5545;
+},
+{
+glyphname = "thoThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (173,714);
+},
+{
+name = top_right_can;
+pos = (456,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(353,16,l),
+(148,419,l),
+(132,393,l),
+(418,393,l),
+(452,551,l),
+(515,551,l),
+(523,593,l),
+(460,593,l),
+(487,714,l),
+(423,714,l),
+(397,593,l),
+(208,593,l),
+(199,551,l),
+(388,551,l),
+(367,450,l),
+(85,450,l),
+(80,424,l),
+(300,-12,l)
+);
+}
+);
+width = 486;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+unicode = 5546;
+},
+{
+glyphname = "thooThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (295,0);
+ref = dot_top;
+}
+);
+width = 485;
+}
+);
+note = uni15AB;
+unicode = 5547;
+},
+{
+glyphname = "thaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (230,714);
+},
+{
+name = top_right_can;
+pos = (513,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(483,424,l),
+(488,450,l),
+(205,450,l),
+(227,551,l),
+(415,551,l),
+(424,593,l),
+(235,593,l),
+(262,714,l),
+(198,714,l),
+(172,593,l),
+(110,593,l),
+(101,551,l),
+(163,551,l),
+(130,393,l),
+(407,393,l),
+(398,415,l),
+(42,26,l),
+(87,-12,l)
+);
+}
+);
+width = 486;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+unicode = 5548;
+},
+{
+glyphname = "thaaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:30:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (69,0);
+ref = dot_top;
+}
+);
+width = 486;
+}
+);
+note = uni15AD;
+unicode = 5549;
+},
+{
+glyphname = "thThCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(153,634,l),
+(134,542,l),
+(274,542,l),
+(265,564,l),
+(94,375,l),
+(126,348,l),
+(321,565,l),
+(325,582,l),
+(186,582,l),
+(198,634,l),
+(290,634,l),
+(295,661,l),
+(203,661,l),
+(215,714,l),
+(170,714,l),
+(159,661,l),
+(127,661,l),
+(122,634,l)
+);
+}
+);
+width = 282;
+}
+);
+metricRight = "y-canadian";
+note = uni15AE;
+unicode = 5550;
+},
+{
+glyphname = "bAivilik-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(373,-13,o),
+(423,213,o),
+(423,333,cs),
+(423,441,o),
+(375,502,o),
+(288,502,cs),
+(227,502,o),
+(180,465,o),
+(145,382,c),
+(157,381,l),
+(228,714,l),
+(165,714,l),
+(13,0,l),
+(71,0,l),
+(99,131,l),
+(89,114,l),
+(92,28,o),
+(136,-13,o),
+(208,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(148,43,o),
+(119,82,o),
+(119,157,cs),
+(119,238,o),
+(153,446,o),
+(273,446,cs),
+(332,446,o),
+(361,407,o),
+(361,331,cs),
+(361,249,o),
+(326,43,o),
+(206,43,cs)
+);
+}
+);
+width = 470;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|ke-canadian";
+note = uni15AF;
+unicode = 5551;
+},
+{
+glyphname = "eBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(76,0,l),
+(169,435,l),
+(184,391,o),
+(224,365,o),
+(276,365,cs),
+(397,365,o),
+(451,500,o),
+(451,585,cs),
+(451,670,o),
+(403,727,o),
+(325,727,cs),
+(284,727,o),
+(246,710,o),
+(218,678,c),
+(225,714,l),
+(165,714,l),
+(13,0,l)
+);
+}
+);
+width = 425;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B0;
+unicode = 5552;
+},
+{
+glyphname = "iBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(190,-13,o),
+(227,4,o),
+(256,36,c),
+(248,0,l),
+(309,0,l),
+(461,714,l),
+(397,714,l),
+(304,279,l),
+(289,323,o),
+(249,349,o),
+(197,349,cs),
+(76,349,o),
+(22,214,o),
+(22,129,cs),
+(22,44,o),
+(71,-13,o),
+(149,-13,cs)
+);
+}
+);
+width = 426;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B1;
+unicode = 5553;
+},
+{
+glyphname = "oBlackfoot-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(319,-13,o),
+(370,122,o),
+(370,207,cs),
+(370,291,o),
+(323,349,o),
+(248,349,cs),
+(207,349,o),
+(171,333,o),
+(140,303,c),
+(228,714,l),
+(165,714,l),
+(13,0,l),
+(73,0,l),
+(87,62,l),
+(101,16,o),
+(141,-13,o),
+(195,-13,cs)
+);
+}
+);
+width = 424;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "eBlackfoot-canadian";
+note = uni15B2;
+unicode = 5554;
+},
+{
+glyphname = "aBlackfoot-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(308,0,l),
+(460,714,l),
+(399,714,l),
+(385,652,l),
+(371,698,o),
+(331,727,o),
+(277,727,cs),
+(153,727,o),
+(102,592,o),
+(102,507,cs),
+(102,423,o),
+(149,365,o),
+(225,365,cs),
+(265,365,o),
+(302,381,o),
+(332,411,c),
+(244,0,l)
+);
+}
+);
+width = 425;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B3;
+unicode = 5555;
+},
+{
+glyphname = "weBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(76,0,l),
+(146,330,l),
+(420,330,l),
+(432,386,l),
+(158,386,l),
+(216,658,l),
+(490,658,l),
+(501,714,l),
+(165,714,l),
+(13,0,l)
+);
+}
+);
+width = 448;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B4;
+unicode = 5556;
+},
+{
+glyphname = "wiBlackfoot-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(331,0,l),
+(483,714,l),
+(419,714,l),
+(350,384,l),
+(76,384,l),
+(64,328,l),
+(337,328,l),
+(280,56,l),
+(6,56,l),
+(-6,0,l)
+);
+}
+);
+width = 448;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B5;
+unicode = 5557;
+},
+{
+glyphname = "woBlackfoot-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(349,0,l),
+(361,56,l),
+(88,56,l),
+(146,328,l),
+(419,328,l),
+(431,384,l),
+(158,384,l),
+(228,714,l),
+(165,714,l),
+(13,0,l)
+);
+}
+);
+width = 447;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "weBlackfoot-canadian";
+note = uni15B6;
+unicode = 5558;
+},
+{
+glyphname = "waBlackfoot-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(331,0,l),
+(483,714,l),
+(146,714,l),
+(134,658,l),
+(407,658,l),
+(349,386,l),
+(76,386,l),
+(64,330,l),
+(338,330,l),
+(267,0,l)
+);
+}
+);
+width = 448;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B7;
+unicode = 5559;
+},
+{
+glyphname = "neBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(76,0,l),
+(218,664,l),
+(259,664,l),
+(242,697,l),
+(228,632,ls),
+(201,505,o),
+(253,421,o),
+(373,421,cs),
+(475,421,o),
+(546,485,o),
+(574,618,cs),
+(594,714,l),
+(532,714,l),
+(511,614,ls),
+(492,520,o),
+(445,479,o),
+(376,479,cs),
+(298,479,o),
+(270,534,o),
+(288,620,cs),
+(308,714,l),
+(165,714,l),
+(13,0,l)
+);
+}
+);
+width = 532;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B8;
+unicode = 5560;
+},
+{
+glyphname = "niBlackfoot-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(48,0,l),
+(68,100,ls),
+(88,194,o),
+(135,235,o),
+(204,235,cs),
+(283,235,o),
+(311,180,o),
+(293,94,cs),
+(272,0,l),
+(416,0,l),
+(568,714,l),
+(504,714,l),
+(363,50,l),
+(321,50,l),
+(338,17,l),
+(352,82,ls),
+(379,209,o),
+(327,293,o),
+(207,293,cs),
+(105,293,o),
+(34,229,o),
+(6,96,cs),
+(-15,0,l)
+);
+}
+);
+width = 533;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B9;
+unicode = 5561;
+},
+{
+glyphname = "noBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(156,0,l),
+(174,81,ls),
+(198,187,o),
+(235,236,o),
+(306,236,cs),
+(383,236,o),
+(417,177,o),
+(395,73,cs),
+(381,0,l),
+(443,0,l),
+(456,60,ls),
+(486,203,o),
+(430,293,o),
+(312,293,cs),
+(207,293,o),
+(140,218,o),
+(112,81,cs),
+(99,17,l),
+(129,50,l),
+(87,50,l),
+(228,714,l),
+(165,714,l),
+(13,0,l)
+);
+}
+);
+width = 532;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "neBlackfoot-canadian";
+note = uni15BA;
+unicode = 5562;
+},
+{
+glyphname = "naBlackfoot-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(416,0,l),
+(568,714,l),
+(424,714,l),
+(406,633,ls),
+(383,527,o),
+(345,478,o),
+(274,478,cs),
+(197,478,o),
+(164,537,o),
+(185,641,cs),
+(200,714,l),
+(137,714,l),
+(124,654,ls),
+(94,511,o),
+(150,421,o),
+(268,421,cs),
+(374,421,o),
+(440,496,o),
+(469,633,cs),
+(482,697,l),
+(452,664,l),
+(493,664,l),
+(352,0,l)
+);
+}
+);
+width = 533;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BB;
+unicode = 5563;
+},
+{
+glyphname = "keBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(76,0,l),
+(213,640,l),
+(187,640,l),
+(257,267,l),
+(289,267,l),
+(564,714,l),
+(495,714,l),
+(265,340,l),
+(294,337,l),
+(223,714,l),
+(165,714,l),
+(13,0,l)
+);
+}
+);
+width = 491;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15BC;
+unicode = 5564;
+},
+{
+glyphname = "kiBlackfoot-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(45,1,l),
+(274,375,l),
+(246,378,l),
+(317,1,l),
+(375,1,l),
+(527,715,l),
+(463,715,l),
+(327,75,l),
+(352,75,l),
+(282,447,l),
+(251,447,l),
+(-25,1,l)
+);
+}
+);
+width = 492;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BD;
+unicode = 5565;
+},
+{
+glyphname = "koBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(71,0,l),
+(307,373,l),
+(279,377,l),
+(349,0,l),
+(412,0,l),
+(326,447,l),
+(295,447,l),
+(65,74,l),
+(92,74,l),
+(228,714,l),
+(165,714,l),
+(13,0,l)
+);
+}
+);
+width = 491;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "keBlackfoot-canadian";
+note = uni15BE;
+unicode = 5566;
+},
+{
+glyphname = "kaBlackfoot-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(375,1,l),
+(527,715,l),
+(469,715,l),
+(232,342,l),
+(261,338,l),
+(191,715,l),
+(127,715,l),
+(213,268,l),
+(245,268,l),
+(474,641,l),
+(448,641,l),
+(311,1,l)
+);
+}
+);
+width = 492;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BF;
+unicode = 5567;
+},
+{
+color = 9;
+glyphname = "heSayisi-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_right_can;
+pos = (524,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(403,0,l),
+(555,714,l),
+(492,714,l),
+(399,276,l),
+(414,275,l),
+(468,565,o),
+(425,727,o),
+(291,727,cs),
+(198,727,o),
+(134,649,o),
+(100,499,cs),
+(88,441,o),
+(82,392,o),
+(81,352,c),
+(141,352,l),
+(142,390,o),
+(148,438,o),
+(160,490,cs),
+(184,605,o),
+(233,670,o),
+(298,670,cs),
+(423,670,o),
+(439,445,o),
+(339,0,c)
+);
+}
+);
+width = 520;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni15C0;
+unicode = 5568;
+},
+{
+color = 9;
+glyphname = "hiSayisi-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(76,0,l),
+(173,451,o),
+(274,670,o),
+(389,670,cs),
+(460,670,o),
+(485,588,o),
+(456,448,cs),
+(447,409,o),
+(437,380,o),
+(424,352,c),
+(485,352,l),
+(499,385,o),
+(510,420,o),
+(518,452,cs),
+(552,622,o),
+(511,727,o),
+(409,727,cs),
+(290,727,o),
+(194,580,o),
+(127,298,c),
+(139,297,l),
+(228,714,l),
+(165,714,l),
+(13,0,l)
+);
+}
+);
+width = 520;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C1;
+unicode = 5569;
+},
+{
+color = 9;
+glyphname = "hoSayisi-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (355,714);
+},
+{
+name = top_left_can;
+pos = (186,714);
+},
+{
+name = top_right_can;
+pos = (524,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(277,-13,o),
+(374,134,o),
+(440,416,c),
+(428,417,l),
+(340,0,l),
+(403,0,l),
+(555,714,l),
+(491,714,l),
+(395,263,o),
+(293,44,o),
+(179,44,cs),
+(108,44,o),
+(83,126,o),
+(112,266,cs),
+(121,305,o),
+(130,334,o),
+(143,362,c),
+(82,362,l),
+(68,329,o),
+(57,294,o),
+(50,262,cs),
+(16,92,o),
+(57,-13,o),
+(159,-13,cs)
+);
+}
+);
+width = 520;
+}
+);
+metricLeft = "heSayisi-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15C2;
+unicode = 5570;
+},
+{
+color = 9;
+glyphname = "haSayisi-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(369,-13,o),
+(434,65,o),
+(467,215,cs),
+(479,273,o),
+(486,322,o),
+(487,362,c),
+(426,362,l),
+(425,324,o),
+(420,276,o),
+(408,224,cs),
+(384,109,o),
+(335,44,o),
+(269,44,cs),
+(145,44,o),
+(129,269,o),
+(228,714,c),
+(165,714,l),
+(13,0,l),
+(76,0,l),
+(169,438,l),
+(154,439,l),
+(100,149,o),
+(142,-13,o),
+(276,-13,cs)
+);
+}
+);
+width = 519;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C3;
+unicode = 5571;
+},
+{
+color = 9;
+glyphname = "ghuCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(239,0,l),
+(624,694,l),
+(629,714,l),
+(573,714,l),
+(438,463,l),
+(466,477,l),
+(186,477,l),
+(208,462,l),
+(179,714,l),
+(128,714,l),
+(124,694,l),
+(214,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(440,428,l),
+(427,442,l),
+(235,87,l),
+(253,84,l),
+(211,440,l),
+(191,428,l)
+);
+}
+);
+width = 557;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C4;
+unicode = 5572;
+},
+{
+color = 9;
+glyphname = "ghoCarrier-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(31,0,l),
+(167,251,l),
+(138,237,l),
+(419,237,l),
+(396,252,l),
+(425,0,l),
+(476,0,l),
+(481,20,l),
+(390,714,l),
+(365,714,l),
+(-20,20,l),
+(-24,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(405,335,l),
+(192,338,l),
+(206,274,l),
+(377,578,l),
+(324,579,l),
+(365,271,l)
+);
+}
+);
+width = 557;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C5;
+unicode = 5573;
+},
+{
+color = 9;
+glyphname = "gheCarrier-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (85,363);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(10,0,l),
+(502,344,l),
+(508,370,l),
+(162,714,l),
+(144,714,l),
+(134,669,l),
+(248,556,l),
+(241,598,l),
+(141,133,l),
+(163,170,l),
+(4,59,l),
+(-8,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(280,567,l),
+(260,550,l),
+(466,344,l),
+(468,379,l),
+(185,181,l),
+(194,164,l)
+);
+}
+);
+width = 513;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15C6;
+unicode = 5574;
+},
+{
+color = 9;
+glyphname = "gheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (25,6);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 512;
+}
+);
+note = uni15C7;
+unicode = 5575;
+},
+{
+color = 9;
+glyphname = "ghiCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (5,6);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 512;
+}
+);
+note = uni15C8;
+unicode = 5576;
+},
+{
+color = 9;
+glyphname = "ghaCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(417,0,l),
+(427,45,l),
+(313,158,l),
+(320,116,l),
+(420,581,l),
+(398,544,l),
+(557,655,l),
+(569,714,l),
+(551,714,l),
+(59,370,l),
+(53,344,l),
+(399,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(301,164,l),
+(104,362,l),
+(103,341,l),
+(376,533,l),
+(364,538,l),
+(285,164,l)
+);
+}
+);
+width = 513;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15C9;
+unicode = 5577;
+},
+{
+color = 9;
+glyphname = "ruCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(239,0,l),
+(624,694,l),
+(629,714,l),
+(571,714,l),
+(517,613,l),
+(541,629,l),
+(171,629,l),
+(191,613,l),
+(179,714,l),
+(128,714,l),
+(124,694,l),
+(214,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(517,579,l),
+(510,595,l),
+(235,88,l),
+(253,85,l),
+(192,593,l),
+(176,579,l)
+);
+}
+);
+width = 557;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CA;
+unicode = 5578;
+},
+{
+color = 9;
+glyphname = "roCarrier-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(365,714,l),
+(-20,20,l),
+(-24,0,l),
+(34,0,l),
+(87,101,l),
+(64,85,l),
+(434,85,l),
+(414,101,l),
+(425,0,l),
+(476,0,l),
+(480,20,l),
+(390,714,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(88,135,l),
+(95,119,l),
+(370,626,l),
+(351,629,l),
+(412,121,l),
+(429,135,l)
+);
+}
+);
+width = 556;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CB;
+unicode = 5579;
+},
+{
+color = 9;
+glyphname = "reCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(10,0,l),
+(501,344,l),
+(507,370,l),
+(162,714,l),
+(143,714,l),
+(133,670,l),
+(190,614,l),
+(184,655,l),
+(60,73,l),
+(78,109,l),
+(3,57,l),
+(-9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(223,617,l),
+(204,601,l),
+(458,345,l),
+(461,379,l),
+(107,128,l),
+(115,111,l)
+);
+}
+);
+width = 512;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CC;
+unicode = 5580;
+},
+{
+color = 9;
+glyphname = "reeCarrier-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(10,0,l),
+(502,344,l),
+(508,370,l),
+(162,714,l),
+(144,714,l),
+(135,675,l),
+(188,622,l),
+(186,659,l),
+(60,70,l),
+(78,106,l),
+(3,54,l),
+(-8,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(221,629,l),
+(204,611,l),
+(470,345,l),
+(473,380,l),
+(99,116,l),
+(109,99,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(229,268,l),
+(269,456,l),
+(241,456,l),
+(201,268,l)
+);
+}
+);
+width = 513;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CD;
+unicode = 5581;
+},
+{
+color = 9;
+glyphname = "riCarrier-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(10,0,l),
+(502,344,l),
+(508,370,l),
+(162,714,l),
+(144,714,l),
+(135,675,l),
+(189,621,l),
+(186,659,l),
+(60,70,l),
+(80,107,l),
+(3,54,l),
+(-8,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(293,328,o),
+(309,343,o),
+(309,363,cs),
+(309,382,o),
+(293,397,o),
+(274,397,cs),
+(255,397,o),
+(240,382,o),
+(240,363,cs),
+(240,343,o),
+(255,328,o),
+(274,328,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(221,629,l),
+(203,613,l),
+(470,345,l),
+(473,380,l),
+(100,117,l),
+(109,99,l)
+);
+}
+);
+width = 513;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CE;
+unicode = 5582;
+},
+{
+color = 9;
+glyphname = "raCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(417,0,l),
+(427,44,l),
+(370,100,l),
+(376,59,l),
+(500,641,l),
+(482,605,l),
+(557,657,l),
+(569,714,l),
+(550,714,l),
+(59,370,l),
+(53,344,l),
+(398,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(356,113,l),
+(102,369,l),
+(99,335,l),
+(453,586,l),
+(445,603,l),
+(337,97,l)
+);
+}
+);
+width = 513;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15CF;
+unicode = 5583;
+},
+{
+color = 9;
+glyphname = "wuCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(241,0,l),
+(629,694,l),
+(634,714,l),
+(578,714,l),
+(273,147,l),
+(284,146,l),
+(405,714,l),
+(354,714,l),
+(232,143,l),
+(243,143,l),
+(177,714,l),
+(128,714,l),
+(124,694,l),
+(217,0,l)
+);
+}
+);
+width = 562;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D0;
+unicode = 5584;
+},
+{
+color = 9;
+glyphname = "woCarrier-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(32,0,l),
+(336,567,l),
+(326,568,l),
+(205,0,l),
+(256,0,l),
+(377,571,l),
+(366,571,l),
+(433,0,l),
+(481,0,l),
+(485,20,l),
+(393,714,l),
+(368,714,l),
+(-20,20,l),
+(-24,0,l)
+);
+}
+);
+width = 561;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D1;
+unicode = 5585;
+},
+{
+color = 9;
+glyphname = "weCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(29,0,l),
+(521,344,l),
+(527,370,l),
+(181,714,l),
+(163,714,l),
+(153,669,l),
+(444,378,l),
+(448,390,l),
+(94,390,l),
+(83,339,l),
+(437,339,l),
+(439,349,l),
+(23,58,l),
+(11,0,l)
+);
+}
+);
+width = 532;
+}
+);
+metricRight = "o-canadian";
+note = uni15D2;
+unicode = 5586;
+},
+{
+color = 9;
+glyphname = "weeCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(29,0,l),
+(521,344,l),
+(527,370,l),
+(181,714,l),
+(163,714,l),
+(154,671,l),
+(463,366,l),
+(470,386,l),
+(202,386,l),
+(219,464,l),
+(182,464,l),
+(165,386,l),
+(93,386,l),
+(84,343,l),
+(155,343,l),
+(139,265,l),
+(177,265,l),
+(193,343,l),
+(461,343,l),
+(453,356,l),
+(23,55,l),
+(11,0,l)
+);
+}
+);
+width = 532;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D3;
+unicode = 5587;
+},
+{
+color = 9;
+glyphname = "wiCarrier-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(30,0,l),
+(522,344,l),
+(528,370,l),
+(182,714,l),
+(164,714,l),
+(155,671,l),
+(453,375,l),
+(458,388,l),
+(252,388,l),
+(245,408,o),
+(225,422,o),
+(202,422,cs),
+(179,422,o),
+(159,408,o),
+(151,388,c),
+(94,388,l),
+(85,344,l),
+(150,344,l),
+(159,324,o),
+(179,309,o),
+(202,309,cs),
+(224,309,o),
+(245,324,o),
+(253,344,c),
+(450,344,l),
+(446,351,l),
+(24,56,l),
+(12,0,l)
+);
+}
+);
+width = 533;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D4;
+unicode = 5588;
+},
+{
+color = 9;
+glyphname = "waCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(416,0,l),
+(426,45,l),
+(136,336,l),
+(132,324,l),
+(485,324,l),
+(496,375,l),
+(143,375,l),
+(141,365,l),
+(556,656,l),
+(568,714,l),
+(550,714,l),
+(59,370,l),
+(53,344,l),
+(398,0,l)
+);
+}
+);
+width = 532;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15D5;
+unicode = 5589;
+},
+{
+color = 9;
+glyphname = "hwuCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(241,0,l),
+(629,694,l),
+(634,714,l),
+(581,714,l),
+(449,471,l),
+(470,483,l),
+(349,483,l),
+(399,714,l),
+(357,714,l),
+(307,483,l),
+(186,483,l),
+(204,470,l),
+(174,714,l),
+(128,714,l),
+(124,694,l),
+(217,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(243,123,l),
+(204,459,l),
+(188,444,l),
+(301,444,l),
+(233,123,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(339,444,l),
+(450,444,l),
+(442,458,l),
+(262,124,l),
+(270,120,l)
+);
+}
+);
+width = 562;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D6;
+unicode = 5590;
+},
+{
+color = 9;
+glyphname = "hwoCarrier-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(29,0,l),
+(161,243,l),
+(140,231,l),
+(260,231,l),
+(211,0,l),
+(253,0,l),
+(302,231,l),
+(424,231,l),
+(406,244,l),
+(435,0,l),
+(481,0,l),
+(485,20,l),
+(393,714,l),
+(368,714,l),
+(-20,20,l),
+(-24,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(347,590,l),
+(339,594,l),
+(271,270,l),
+(159,270,l),
+(167,256,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(421,270,l),
+(308,270,l),
+(376,591,l),
+(367,591,l),
+(406,255,l)
+);
+}
+);
+width = 561;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D7;
+unicode = 5591;
+},
+{
+color = 9;
+glyphname = "hweCarrier-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(30,0,l),
+(522,344,l),
+(528,370,l),
+(182,714,l),
+(164,714,l),
+(155,671,l),
+(252,575,l),
+(212,385,l),
+(94,385,l),
+(84,341,l),
+(202,341,l),
+(162,152,l),
+(23,55,l),
+(12,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(240,344,l),
+(445,344,l),
+(205,177,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(284,550,l),
+(452,382,l),
+(248,382,l)
+);
+}
+);
+width = 533;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D8;
+unicode = 5592;
+},
+{
+color = 9;
+glyphname = "hweeCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(29,0,l),
+(521,344,l),
+(527,370,l),
+(181,714,l),
+(163,714,l),
+(154,674,l),
+(263,567,l),
+(224,383,l),
+(180,383,l),
+(197,463,l),
+(164,463,l),
+(147,383,l),
+(92,383,l),
+(84,344,l),
+(138,344,l),
+(122,265,l),
+(155,265,l),
+(171,344,l),
+(216,344,l),
+(176,160,l),
+(22,53,l),
+(11,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(251,346,l),
+(446,346,l),
+(217,183,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(293,543,l),
+(452,381,l),
+(258,381,l)
+);
+}
+);
+width = 532;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D9;
+unicode = 5593;
+},
+{
+color = 9;
+glyphname = "hwiCarrier-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(30,0,l),
+(522,344,l),
+(528,370,l),
+(182,714,l),
+(164,714,l),
+(155,674,l),
+(264,567,l),
+(225,381,l),
+(203,381,l),
+(197,400,o),
+(180,413,o),
+(160,413,cs),
+(139,413,o),
+(122,400,o),
+(116,381,c),
+(93,381,l),
+(85,346,l),
+(115,346,l),
+(121,327,o),
+(139,312,o),
+(159,312,cs),
+(179,312,o),
+(197,327,o),
+(204,346,c),
+(217,346,l),
+(177,160,l),
+(23,53,l),
+(12,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(252,346,l),
+(447,346,l),
+(217,183,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(294,543,l),
+(453,381,l),
+(259,381,l)
+);
+}
+);
+width = 533;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15DA;
+unicode = 5594;
+},
+{
+color = 9;
+glyphname = "hwaCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(551,714,l),
+(59,370,l),
+(53,344,l),
+(399,0,l),
+(417,0,l),
+(426,43,l),
+(329,139,l),
+(369,329,l),
+(486,329,l),
+(496,373,l),
+(379,373,l),
+(419,562,l),
+(557,659,l),
+(569,714,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(340,370,l),
+(136,370,l),
+(376,537,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(297,164,l),
+(129,332,l),
+(332,332,l)
+);
+}
+);
+width = 532;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15DB;
+unicode = 5595;
+},
+{
+color = 9;
+glyphname = "thuCarrier-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(385,-13,o),
+(464,62,o),
+(497,220,cs),
+(602,714,l),
+(161,714,l),
+(63,253,ls),
+(28,85,o),
+(99,-13,o),
+(256,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(213,656,l),
+(527,656,l),
+(436,227,ls),
+(409,102,o),
+(354,47,o),
+(259,47,cs),
+(139,47,o),
+(97,114,o),
+(126,250,cs)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DC;
+unicode = 5596;
+},
+{
+color = 9;
+glyphname = "thoCarrier-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(450,0,l),
+(548,461,ls),
+(584,629,o),
+(513,727,o),
+(356,727,cs),
+(227,727,o),
+(148,652,o),
+(114,494,cs),
+(9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(176,487,ls),
+(203,612,o),
+(258,667,o),
+(353,667,cs),
+(473,667,o),
+(515,600,o),
+(486,464,cs),
+(399,58,l),
+(85,58,l)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DD;
+unicode = 5597;
+},
+{
+color = 9;
+glyphname = "theCarrier-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (297,357);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(153,0,ls),
+(445,0,o),
+(530,301,o),
+(530,476,cs),
+(530,632,o),
+(448,714,o),
+(291,714,cs),
+(165,714,l),
+(13,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(222,686,l),
+(197,657,l),
+(280,657,ls),
+(405,657,o),
+(468,597,o),
+(468,475,cs),
+(468,338,o),
+(401,57,o),
+(159,57,cs),
+(74,57,l),
+(83,31,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "to-canadian";
+note = uni15DE;
+unicode = 5598;
+},
+{
+color = 9;
+glyphname = "theeCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (234,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 543;
+}
+);
+note = uni15DF;
+unicode = 5599;
+},
+{
+color = 9;
+glyphname = "thiCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (214,0);
+ref = dot_middle;
+}
+);
+width = 543;
+}
+);
+note = uni15E0;
+unicode = 5600;
+},
+{
+color = 9;
+glyphname = "thaCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(427,0,l),
+(579,714,l),
+(439,714,ls),
+(147.006,714,o),
+(61,413,o),
+(61,238,cs),
+(61,82,o),
+(144,0,o),
+(301,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(123,376,o),
+(190,657,o),
+(432,657,cs),
+(518,657,l),
+(509,683,l),
+(370,28,l),
+(395,57,l),
+(311,57,ls),
+(187,57,o),
+(123,117,o),
+(123,239,cs)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15E1;
+unicode = 5601;
+},
+{
+color = 9;
+glyphname = "ttuCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(383,-13,o),
+(463,62,o),
+(496,211,cs),
+(602,714,l),
+(579,714,l),
+(316,514,l),
+(356,509,l),
+(186,714,l),
+(161,714,l),
+(62,245,ls),
+(27,81,o),
+(96,-13,o),
+(250,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(140,47,o),
+(97,113,o),
+(124,242,cs),
+(210,645,l),
+(186,637,l),
+(322,468,l),
+(338,468,l),
+(545,631,l),
+(524,645,l),
+(434,219,ls),
+(409,101,o),
+(352,47,o),
+(253,47,cs)
+);
+}
+);
+width = 564;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E2;
+unicode = 5602;
+},
+{
+color = 9;
+glyphname = "ttoCarrier-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(33,0,l),
+(296,200,l),
+(256,205,l),
+(425,0,l),
+(450,0,l),
+(550,469,ls),
+(585,633,o),
+(515,727,o),
+(361,727,cs),
+(229,727,o),
+(148,652,o),
+(116,503,cs),
+(9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(472,667,o),
+(515,601,o),
+(487,472,cs),
+(402,69,l),
+(425,77,l),
+(290,246,l),
+(274,246,l),
+(67,83,l),
+(88,69,l),
+(178,495,ls),
+(203,613,o),
+(260,667,o),
+(359,667,cs)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E3;
+unicode = 5603;
+},
+{
+color = 9;
+glyphname = "tteCarrier-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (339,357);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(162,0,ls),
+(456,0,o),
+(540,303,o),
+(540,476,cs),
+(540,632,o),
+(457,714,o),
+(303,714,cs),
+(161,714,l),
+(156,694,l),
+(181,336,l),
+(190,390,l),
+(14,20,l),
+(9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(237,348,l),
+(240,363,l),
+(216,685,l),
+(194,657,l),
+(290,657,ls),
+(415,657,o),
+(479,597,o),
+(479,475,cs),
+(479,338,o),
+(411,57,o),
+(169,57,cs),
+(71,57,l),
+(85,31,l)
+);
+}
+);
+width = 554;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15E4;
+unicode = 5604;
+},
+{
+color = 9;
+glyphname = "tteeCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (280,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 553;
+}
+);
+note = uni15E5;
+unicode = 5605;
+},
+{
+color = 9;
+glyphname = "ttiCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (265,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 553;
+}
+);
+note = uni15E6;
+unicode = 5606;
+},
+{
+color = 9;
+glyphname = "ttaCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,0,l),
+(445,20,l),
+(420,378,l),
+(411,324,l),
+(587,694,l),
+(592,714,l),
+(439,714,ls),
+(145,714,o),
+(61,411,o),
+(61,238,cs),
+(61,82,o),
+(144,0,o),
+(297.998,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(407,57,l),
+(311,57,ls),
+(186,57,o),
+(123,117,o),
+(123,239,cs),
+(123,376,o),
+(190,657,o),
+(432,657,cs),
+(530,657,l),
+(516,683,l),
+(364,366,l),
+(361,351,l),
+(385,29,l)
+);
+}
+);
+width = 553;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tteCarrier-canadian";
+note = uni15E7;
+unicode = 5607;
+},
+{
+color = 9;
+glyphname = "puCarrier-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(385,-13,o),
+(464,62,o),
+(497,220,cs),
+(602,714,l),
+(539,714,l),
+(501,535,l),
+(187,535,l),
+(225,714,l),
+(161,714,l),
+(63,253,ls),
+(28,85,o),
+(99,-13,o),
+(256,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(139,47,o),
+(97,114,o),
+(126,250,cs),
+(175,478,l),
+(489,478,l),
+(436,227,ls),
+(409,102,o),
+(354,47,o),
+(259,47,cs)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E8;
+unicode = 5608;
+},
+{
+color = 9;
+glyphname = "poCarrier-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(73,0,l),
+(111,179,l),
+(425,179,l),
+(387,0,l),
+(450,0,l),
+(548,461,ls),
+(584,629,o),
+(513,727,o),
+(356,727,cs),
+(227,727,o),
+(148,652,o),
+(114,494,cs),
+(9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(176,487,ls),
+(203,612,o),
+(258,667,o),
+(353,667,cs),
+(473,667,o),
+(515,600,o),
+(486,464,cs),
+(437,236,l),
+(123,236,l)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E9;
+unicode = 5609;
+},
+{
+color = 9;
+glyphname = "peCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (329,357);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(159,0,ls),
+(451,0,o),
+(537,302,o),
+(537,476,cs),
+(537,632,o),
+(454,714,o),
+(300,714,cs),
+(158,714,l),
+(146,657,l),
+(215,657,l),
+(88,57,l),
+(18,57,l),
+(6,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(284,685,l),
+(224,657,l),
+(287,657,ls),
+(412,657,o),
+(475,597,o),
+(475,475,cs),
+(475,339,o),
+(409,57,o),
+(166,57,cs),
+(97,57,l),
+(145,29,l)
+);
+}
+);
+width = 550;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15EA;
+unicode = 5610;
+},
+{
+color = 9;
+glyphname = "peeCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (270,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 550;
+}
+);
+note = uni15EB;
+unicode = 5611;
+},
+{
+color = 9;
+glyphname = "piCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (256,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 550;
+}
+);
+note = uni15EC;
+unicode = 5612;
+},
+{
+color = 9;
+glyphname = "paCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,0,l),
+(452,57,l),
+(383,57,l),
+(510,657,l),
+(580,657,l),
+(592,714,l),
+(439,714,ls),
+(147,714,o),
+(61,412,o),
+(61,238,cs),
+(61,82,o),
+(144,0,o),
+(298,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(374,57,l),
+(311,57,ls),
+(186,57,o),
+(123,117,o),
+(123,239,cs),
+(123,375,o),
+(190,657,o),
+(432,657,cs),
+(502,657,l),
+(453,685,l),
+(314,29,l)
+);
+}
+);
+width = 550;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|peCarrier-canadian";
+note = uni15ED;
+unicode = 5613;
+},
+{
+color = 6;
+glyphname = "pCarrier-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(292,189,l),
+(302,233,l),
+(199,233,l),
+(265,546,l),
+(220,546,l),
+(154,233,l),
+(51,233,l),
+(42,189,l)
+);
+}
+);
+width = 357;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni15EE;
+unicode = 5614;
+},
+{
+color = 9;
+glyphname = "guCarrier-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (434,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(233,-13,o),
+(288,32,o),
+(321,117,c),
+(298,117,l),
+(300,34,o),
+(345,-13,o),
+(421,-13,cs),
+(512,-13,o),
+(568,50,o),
+(595,176,cs),
+(709,714,l),
+(648,714,l),
+(534,177,ls),
+(516,89,o),
+(479,46,o),
+(419,46,cs),
+(358,46,o),
+(332,92,o),
+(350,177,cs),
+(464,714,l),
+(405,714,l),
+(291,176,ls),
+(272,91,o),
+(233,46,o),
+(172,46,cs),
+(112,46,o),
+(87,90,o),
+(105,176,cs),
+(219,714,l),
+(158,714,l),
+(45,179,ls),
+(20,60,o),
+(63,-13,o),
+(159,-13,cs)
+);
+}
+);
+width = 668;
+}
+);
+metricRight = "=|";
+note = uni15EF;
+unicode = 5615;
+},
+{
+color = 9;
+glyphname = "goCarrier-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(67,0,l),
+(181,537,ls),
+(199,625,o),
+(236,668,o),
+(295,668,cs),
+(357,668,o),
+(383,622,o),
+(365,537,cs),
+(251,0,l),
+(310,0,l),
+(424,538,ls),
+(442,623,o),
+(481,668,o),
+(542,668,cs),
+(603,668,o),
+(627,624,o),
+(609,538,cs),
+(495,0,l),
+(556,0,l),
+(669,535,ls),
+(694,654,o),
+(651,727,o),
+(555,727,cs),
+(481,727,o),
+(427,682,o),
+(394,597,c),
+(416,597,l),
+(415,680,o),
+(370,727,o),
+(294,727,cs),
+(202,727,o),
+(146,664,o),
+(120,538,cs),
+(6,0,l)
+);
+}
+);
+width = 666;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F0;
+unicode = 5616;
+},
+{
+color = 9;
+glyphname = "geCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (379,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(251,0,ls),
+(432,0,o),
+(481,125,o),
+(481,225,cs),
+(481,299,o),
+(446,351,o),
+(383,365,c),
+(382,343,l),
+(510,367,o),
+(552,469,o),
+(552,555,cs),
+(552,649,o),
+(489,714,o),
+(389,714,cs),
+(165,714,l),
+(153,660,l),
+(380,660,ls),
+(448,660,o),
+(488,617,o),
+(488,550,cs),
+(488,465,o),
+(444,384,o),
+(322,384,cs),
+(95,384,l),
+(83,330,l),
+(311,330,ls),
+(382,330,o),
+(420,296,o),
+(420,230,cs),
+(420,178,o),
+(407,54,o),
+(255,54,cs),
+(25,54,l),
+(14,0,l)
+);
+}
+);
+width = 553;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15F1;
+unicode = 5617;
+},
+{
+color = 9;
+glyphname = "geeCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(251,0,ls),
+(432,0,o),
+(481,125,o),
+(481,225,cs),
+(481,299,o),
+(446,351,o),
+(383,365,c),
+(382,343,l),
+(510,367,o),
+(552,469,o),
+(552,555,cs),
+(552,649,o),
+(489,714,o),
+(389,714,cs),
+(165,714,l),
+(153,660,l),
+(380,660,ls),
+(448,660,o),
+(488,617,o),
+(488,550,cs),
+(488,465,o),
+(444,384,o),
+(322,384,cs),
+(299,384,l),
+(317,468,l),
+(276,468,l),
+(258,384,l),
+(95,384,l),
+(83,330,l),
+(247,330,l),
+(229,248,l),
+(270,248,l),
+(288,330,l),
+(311,330,ls),
+(382,330,o),
+(420,296,o),
+(420,230,cs),
+(420,178,o),
+(407,54,o),
+(255,54,cs),
+(25,54,l),
+(14,0,l)
+);
+}
+);
+width = 553;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F2;
+unicode = 5618;
+},
+{
+color = 9;
+glyphname = "giCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(251,0,ls),
+(432,0,o),
+(481,125,o),
+(481,225,cs),
+(481,298,o),
+(446,351,o),
+(383,365,c),
+(382,343,l),
+(510,367,o),
+(552,470,o),
+(552,555,cs),
+(552,649,o),
+(489,714,o),
+(389,714,cs),
+(165,714,l),
+(153,660,l),
+(380,660,ls),
+(448,660,o),
+(488,617,o),
+(488,550,cs),
+(488,465,o),
+(444,384,o),
+(322,384,cs),
+(313,384,l),
+(332,366,l),
+(329,395,o),
+(304,418,o),
+(273,418,cs),
+(250,418,o),
+(230,404,o),
+(221,384,c),
+(95,384,l),
+(83,330,l),
+(221,330,l),
+(230,310,o),
+(250,296,o),
+(273,296,cs),
+(304,296,o),
+(329,319,o),
+(331,348,c),
+(304,330,l),
+(311,330,ls),
+(382,330,o),
+(420,296,o),
+(420,230,cs),
+(420,178,o),
+(407,54,o),
+(255,54,cs),
+(25,54,l),
+(14,0,l)
+);
+}
+);
+width = 553;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F3;
+unicode = 5619;
+},
+{
+color = 9;
+glyphname = "gaCarrier-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (389,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(436,0,l),
+(447,54,l),
+(220,54,ls),
+(152,54,o),
+(112,97,o),
+(112,164,cs),
+(112,249,o),
+(156,330,o),
+(278,330,cs),
+(507,330,l),
+(518,384,l),
+(289,384,ls),
+(219,384,o),
+(181,418,o),
+(181,484,cs),
+(181,536,o),
+(193,660,o),
+(346,660,cs),
+(575,660,l),
+(587,714,l),
+(350,714,ls),
+(169,714,o),
+(119,589,o),
+(119,489,cs),
+(119,415,o),
+(155,363,o),
+(218,349,c),
+(219,371,l),
+(90,347,o),
+(49,245,o),
+(49,159,cs),
+(49,65,o),
+(111,0,o),
+(211,0,cs)
+);
+}
+);
+width = 554;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|geCarrier-canadian";
+note = uni15F4;
+unicode = 5620;
+},
+{
+color = 9;
+glyphname = "khuCarrier-canadian";
+lastChange = "2023-01-13 15:30:11 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(230,-13,o),
+(283,28,o),
+(315,106,c),
+(299,107,l),
+(303,31,o),
+(347,-13,o),
+(421,-13,cs),
+(512,-13,o),
+(568,50,o),
+(595,176,cs),
+(709,714,l),
+(158,714,l),
+(45,179,ls),
+(20,60,o),
+(63,-13,o),
+(159,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(112,46,o),
+(87,90,o),
+(105,176,cs),
+(207,657,l),
+(393,657,l),
+(291,176,ls),
+(272,91,o),
+(233,46,o),
+(172,46,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(358,46,o),
+(332,92,o),
+(350,177,cs),
+(452,657,l),
+(636,657,l),
+(534,177,ls),
+(516,89,o),
+(479,46,o),
+(419,46,cs)
+);
+}
+);
+width = 668;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F5;
+unicode = 5621;
+},
+{
+color = 9;
+glyphname = "khoCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(556,0,l),
+(669,535,ls),
+(694,654,o),
+(651,727,o),
+(555,727,cs),
+(484,727,o),
+(431,686,o),
+(399,608,c),
+(416,607,l),
+(411,683,o),
+(367,727,o),
+(294,727,cs),
+(202,727,o),
+(146,664,o),
+(120,538,cs),
+(6,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(180,537,ls),
+(199,625,o),
+(235,668,o),
+(295,668,cs),
+(357,668,o),
+(383,622,o),
+(365,537,cs),
+(262,57,l),
+(79,57,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(424,538,ls),
+(442,623,o),
+(481,668,o),
+(542,668,cs),
+(603,668,o),
+(627,624,o),
+(609,538,cs),
+(507,57,l),
+(322,57,l)
+);
+}
+);
+width = 666;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F6;
+unicode = 5622;
+},
+{
+color = 9;
+glyphname = "kheCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(253,0,ls),
+(434,0,o),
+(483,124,o),
+(483,225,cs),
+(483,298,o),
+(448,350,o),
+(386,364,c),
+(386,343,l),
+(519,370,o),
+(554,476,o),
+(554,555,cs),
+(554,649,o),
+(491,714,o),
+(389,714,cs),
+(165,714,l),
+(13,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(146,330,l),
+(313,330,ls),
+(383,330,o),
+(421,296,o),
+(421,230,cs),
+(421,177,o),
+(409,54,o),
+(257,54,cs),
+(87,54,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(216,660,l),
+(382,660,ls),
+(450,660,o),
+(490,617,o),
+(490,550,cs),
+(490,469,o),
+(449,384,o),
+(324,384,cs),
+(158,384,l)
+);
+}
+);
+width = 555;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F7;
+unicode = 5623;
+},
+{
+color = 9;
+glyphname = "kheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(253,0,ls),
+(434,0,o),
+(483,124,o),
+(483,225,cs),
+(483,298,o),
+(448,350,o),
+(386,364,c),
+(386,343,l),
+(519,370,o),
+(554,476,o),
+(554,555,cs),
+(554,649,o),
+(491,714,o),
+(389,714,cs),
+(165,714,l),
+(13,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(146,330,l),
+(262,330,l),
+(243,239,l),
+(281,239,l),
+(303,346,l),
+(281,330,l),
+(313,330,ls),
+(383,330,o),
+(421,296,o),
+(421,230,cs),
+(421,177,o),
+(409,54,o),
+(257,54,cs),
+(87,54,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(331,477,l),
+(293,477,l),
+(273,384,l),
+(158,384,l),
+(216,660,l),
+(382,660,ls),
+(450,660,o),
+(490,617,o),
+(490,550,cs),
+(490,469,o),
+(449,384,o),
+(324,384,cs),
+(293,384,l),
+(308,369,l)
+);
+}
+);
+width = 555;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F8;
+unicode = 5624;
+},
+{
+color = 9;
+glyphname = "khiCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(253,0,ls),
+(434,0,o),
+(483,124,o),
+(483,225,cs),
+(483,294,o),
+(452,344,o),
+(396,362,c),
+(388,343,l),
+(519,371,o),
+(554,476,o),
+(554,555,cs),
+(554,649,o),
+(491,714,o),
+(389,714,cs),
+(165,714,l),
+(13,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(146,333,l),
+(233,333,l),
+(241,311,o),
+(262,296,o),
+(286,296,cs),
+(317,296,o),
+(342,321,o),
+(344,352,c),
+(298,333,l),
+(316,333,ls),
+(386,333,o),
+(421,298,o),
+(421,232,cs),
+(421,178,o),
+(409,54,o),
+(257,54,cs),
+(87,54,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(382,660,ls),
+(450,660,o),
+(490,616,o),
+(490,549,cs),
+(490,467,o),
+(452,381,o),
+(327,381,cs),
+(309,381,l),
+(344,362,l),
+(342,393,o),
+(317,418,o),
+(286,418,cs),
+(255,418,o),
+(229,393,o),
+(229,362,c),
+(246,381,l),
+(157,381,l),
+(216,660,l)
+);
+}
+);
+width = 555;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F9;
+unicode = 5625;
+},
+{
+color = 9;
+glyphname = "khaCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,0,l),
+(592,714,l),
+(352,714,ls),
+(170,714,o),
+(121,590,o),
+(121,489,cs),
+(121,416,o),
+(156,364,o),
+(218,350,c),
+(216,371,l),
+(84,344,o),
+(49,238,o),
+(49,159,cs),
+(49,65,o),
+(111,0,o),
+(214,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(153,54,o),
+(112,97,o),
+(112,164,cs),
+(112,245,o),
+(155,330,o),
+(280,330,cs),
+(447,330,l),
+(388,54,l),
+(220,54,ls)
+);
+},
+{
+closed = 1;
+nodes = (
+(221,384,o),
+(183,418,o),
+(183,484,cs),
+(183,537,o),
+(195,660,o),
+(347,660,cs),
+(517,660,l),
+(458,384,l),
+(291,384,ls)
+);
+}
+);
+width = 557;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15FA;
+unicode = 5626;
+},
+{
+color = 9;
+glyphname = "kkuCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(230,-13,o),
+(283,28,o),
+(315,106,c),
+(299,106,l),
+(303,31,o),
+(348,-13,o),
+(421,-13,cs),
+(512,-13,o),
+(568,50,o),
+(595,176,cs),
+(709,714,l),
+(684,714,l),
+(413,541,l),
+(401,474,l),
+(654,637,l),
+(636,657,l),
+(534,177,ls),
+(516,89,o),
+(479,46,o),
+(419,46,cs),
+(358,46,o),
+(331,92,o),
+(349,177,cs),
+(463,714,l),
+(405,714,l),
+(291,176,ls),
+(273,91,o),
+(233,46,o),
+(172,46,cs),
+(112,46,o),
+(87,91,o),
+(105,176,cs),
+(207,657,l),
+(179,650,l),
+(364,484,l),
+(376,543,l),
+(183.997,714,l),
+(158,714,l),
+(45,179,ls),
+(20,60,o),
+(63,-13,o),
+(159,-13,cs)
+);
+}
+);
+width = 668;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FB;
+unicode = 5627;
+},
+{
+color = 9;
+glyphname = "kkoCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(30,0,l),
+(301,173,l),
+(314,240,l),
+(60,77,l),
+(79,57,l),
+(181,537,ls),
+(199,625,o),
+(235,668,o),
+(295,668,cs),
+(356,668,o),
+(383,622,o),
+(365,537,cs),
+(251,0,l),
+(309,0,l),
+(423,538,ls),
+(441,623,o),
+(481,668,o),
+(542,668,cs),
+(603,668,o),
+(627,623,o),
+(609,538,cs),
+(508,57,l),
+(535,64,l),
+(350,230,l),
+(338,171,l),
+(530,0,l),
+(556,0,l),
+(669,535,ls),
+(694,654,o),
+(651,727,o),
+(555,727,cs),
+(484,727,o),
+(431,686,o),
+(399,608,c),
+(416,608,l),
+(411,683,o),
+(367,727,o),
+(294,727,cs),
+(202,727,o),
+(146,664,o),
+(120,538,cs),
+(6,0,l)
+);
+}
+);
+width = 666;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FC;
+unicode = 5628;
+},
+{
+color = 9;
+glyphname = "kkeCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(266,0,ls),
+(447,0,o),
+(497,125,o),
+(497,225,cs),
+(497,299,o),
+(462,350,o),
+(400,363,c),
+(400,343,l),
+(533,370,o),
+(567,476,o),
+(567,555,cs),
+(567,649,o),
+(505,714,o),
+(405,714,cs),
+(164,714,l),
+(160,694,l),
+(181,384,l),
+(97,384,l),
+(85,330,l),
+(167,330,l),
+(17,20,l),
+(12,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(231,330,l),
+(327,330,ls),
+(397,330,o),
+(435,296,o),
+(435,230,cs),
+(435,180,o),
+(423,54,o),
+(270,54,cs),
+(70,54,l),
+(84,29,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(219,688,l),
+(194,660,l),
+(396,660,ls),
+(464,660,o),
+(504,617,o),
+(504,550,cs),
+(504,465,o),
+(460,384,o),
+(338,384,cs),
+(240,384,l)
+);
+}
+);
+width = 569;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni15FD;
+unicode = 5629;
+},
+{
+color = 9;
+glyphname = "kkeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(266,0,ls),
+(447,0,o),
+(497,125,o),
+(497,225,cs),
+(497,299,o),
+(462,350,o),
+(400,363,c),
+(400,343,l),
+(533,370,o),
+(567,476,o),
+(567,555,cs),
+(567,649,o),
+(505,714,o),
+(405,714,cs),
+(164,714,l),
+(160,694,l),
+(181,384,l),
+(97,384,l),
+(85,330,l),
+(167,330,l),
+(17,20,l),
+(12,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(232,332,l),
+(295,332,l),
+(276,239,l),
+(314,239,l),
+(336,348,l),
+(313,332,l),
+(332,332,ls),
+(400,332,o),
+(435,296,o),
+(435,230,cs),
+(435,180,o),
+(423,54,o),
+(270,54,cs),
+(70,54,l),
+(84,29,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(364,477,l),
+(326,477,l),
+(306,383,l),
+(240,383,l),
+(219,688,l),
+(194,660,l),
+(396,660,ls),
+(464,660,o),
+(504,617,o),
+(504,550,cs),
+(504,465,o),
+(460,383,o),
+(340,383,cs),
+(323,383,l),
+(341,370,l)
+);
+}
+);
+width = 569;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FE;
+unicode = 5630;
+},
+{
+color = 9;
+glyphname = "kkiCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(266,0,ls),
+(447,0,o),
+(497,125,o),
+(497,225,cs),
+(497,299,o),
+(462,350,o),
+(400,363,c),
+(400,343,l),
+(533,370,o),
+(567,476,o),
+(567,555,cs),
+(567,649,o),
+(505,714,o),
+(405,714,cs),
+(164,714,l),
+(160,694,l),
+(181,384,l),
+(97,384,l),
+(85,330,l),
+(167,330,l),
+(17,20,l),
+(12,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(233,334,l),
+(256,334,l),
+(264,312,o),
+(285,296,o),
+(309,296,cs),
+(335,296,o),
+(358,315,o),
+(362,340,c),
+(311,334,l),
+(332,334,ls),
+(403,334,o),
+(435,296,o),
+(435,230,cs),
+(435,180,o),
+(423,54,o),
+(270,54,cs),
+(70,54,l),
+(84,29,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(360,398,o),
+(337,418,o),
+(309,418,cs),
+(285,418,o),
+(264,402,o),
+(256,380,c),
+(241,380,l),
+(219,688,l),
+(194,660,l),
+(396,660,ls),
+(464,660,o),
+(504,617,o),
+(504,550,cs),
+(504,465,o),
+(463,380,o),
+(340,380,cs),
+(311,380,l),
+(364,371,l)
+);
+}
+);
+width = 569;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FF;
+unicode = 5631;
+},
+{
+color = 9;
+glyphname = "kkaCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(452,0,l),
+(456,20,l),
+(435,330,l),
+(520,330,l),
+(532,384,l),
+(449,384,l),
+(599,694,l),
+(604,714,l),
+(350,714,ls),
+(169,714,o),
+(119,589,o),
+(119,489,cs),
+(119,415,o),
+(154,364,o),
+(216,351,c),
+(216,371,l),
+(84,344,o),
+(49,238,o),
+(49,159,cs),
+(49,65,o),
+(111,0,o),
+(211,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(422,54,l),
+(220,54,ls),
+(152,54,o),
+(112,97,o),
+(112,164,cs),
+(112,249,o),
+(156,330,o),
+(278,330,cs),
+(376,330,l),
+(398,26,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(219,384,o),
+(181,418,o),
+(181,484,cs),
+(181,534,o),
+(193,660,o),
+(346,660,cs),
+(546,660,l),
+(532,685,l),
+(385,384,l),
+(289,384,ls)
+);
+}
+);
+width = 568;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|kkeCarrier-canadian";
+note = uni1600;
+unicode = 5632;
+},
+{
+color = 6;
+glyphname = "kkCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(302,546,l),
+(139,240,l),
+(167,240,l),
+(136,546,l),
+(96,546,l),
+(93,534,l),
+(138,189,l),
+(151,189,l),
+(343,534,l),
+(346,546,l)
+);
+}
+);
+width = 314;
+}
+);
+note = uni1601;
+unicode = 5633;
+},
+{
+color = 9;
+glyphname = "nuCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(379,-13,o),
+(466,75,o),
+(501,240,cs),
+(516,309,l),
+(453,309,l),
+(439,242,ls),
+(412,113,o),
+(348,48,o),
+(249,47,cs),
+(143,47,o),
+(98,119,o),
+(125,247,cs),
+(225,714,l),
+(161,714,l),
+(63,251,ls),
+(29,90,o),
+(99,-13,o),
+(245,-13,cs)
+);
+}
+);
+width = 560;
+}
+);
+metricLeft = "te-canadian";
+note = uni1602;
+unicode = 5634;
+},
+{
+color = 9;
+glyphname = "noCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(447,0,l),
+(546,463,ls),
+(579,624,o),
+(510,727,o),
+(364,727,cs),
+(229,727,o),
+(142,639,o),
+(107,474,cs),
+(93,405,l),
+(156,405,l),
+(170,472,ls),
+(196,601,o),
+(260,666,o),
+(359,667,cs),
+(465,667,o),
+(510,595,o),
+(483,467,cs),
+(383,0,l)
+);
+}
+);
+width = 561;
+}
+);
+metricLeft = "=|nuCarrier-canadian";
+metricRight = "te-canadian";
+note = uni1603;
+unicode = 5635;
+},
+{
+color = 9;
+glyphname = "neCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (253,357);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(170,0,ls),
+(434,0,o),
+(527,283,o),
+(527,474,cs),
+(527,633,o),
+(444,714,o),
+(288,714,cs),
+(143,714,l),
+(130,655,l),
+(276,655,ls),
+(402,655,o),
+(464,597,o),
+(464,473,cs),
+(464,332,o),
+(401,59,o),
+(175,59,cs),
+(168,59,l),
+(155,0,l)
+);
+}
+);
+width = 542;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1604;
+unicode = 5636;
+},
+{
+color = 9;
+glyphname = "neeCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "neCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (190,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 542;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1605;
+unicode = 5637;
+},
+{
+color = 9;
+glyphname = "niCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "neCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (169,0);
+ref = dot_middle;
+}
+);
+width = 542;
+}
+);
+note = uni1606;
+unicode = 5638;
+},
+{
+color = 9;
+glyphname = "naCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(446,0,l),
+(459,59,l),
+(312,59,ls),
+(187,59,o),
+(125,117,o),
+(125,241,cs),
+(125,382,o),
+(188,655,o),
+(413,655,cs),
+(421,655,l),
+(433,714,l),
+(419,714,ls),
+(155,714,o),
+(62,431,o),
+(62,240,cs),
+(62,81,o),
+(145,0,o),
+(301,0,cs)
+);
+}
+);
+width = 541;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni1607;
+unicode = 5639;
+},
+{
+color = 9;
+glyphname = "muCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(234,-13,o),
+(288,32,o),
+(321,117,c),
+(298,117,l),
+(300,34,o),
+(345,-13,o),
+(421,-13,cs),
+(512,-13,o),
+(568,50,o),
+(595,176,cs),
+(643,402,l),
+(582,402,l),
+(534,177,ls),
+(516,89,o),
+(479,46,o),
+(419,46,cs),
+(358,46,o),
+(331,91,o),
+(350,177,cs),
+(397,402,l),
+(339,402,l),
+(291,176,ls),
+(273,91,o),
+(233,46,o),
+(172,46,cs),
+(112,46,o),
+(87,91,o),
+(105,176,cs),
+(219,714,l),
+(158,714,l),
+(45,179,ls),
+(20,60,o),
+(63,-13,o),
+(159,-13,cs)
+);
+}
+);
+width = 668;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "=|";
+note = uni1608;
+unicode = 5640;
+},
+{
+color = 9;
+glyphname = "moCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(556,0,l),
+(669,535,ls),
+(694,654,o),
+(651,727,o),
+(555,727,cs),
+(481,727,o),
+(427,682,o),
+(394,597,c),
+(416,597,l),
+(414,680,o),
+(369,727,o),
+(294,727,cs),
+(202,727,o),
+(146,664,o),
+(120,538,cs),
+(72,312,l),
+(133,312,l),
+(180,537,ls),
+(199,625,o),
+(235,668,o),
+(295,668,cs),
+(356,668,o),
+(383,623,o),
+(365,537,cs),
+(317,312,l),
+(376,312,l),
+(424,538,ls),
+(442,623,o),
+(481,668,o),
+(542,668,cs),
+(603,668,o),
+(627,623,o),
+(609,538,cs),
+(495,0,l)
+);
+}
+);
+width = 666;
+}
+);
+metricLeft = "=|muCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni1609;
+unicode = 5641;
+},
+{
+color = 9;
+glyphname = "meCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(249,0,ls),
+(430,0,o),
+(480,125,o),
+(480,225,cs),
+(480,299,o),
+(444,351,o),
+(381,365,c),
+(380,343,l),
+(508,367,o),
+(550,469,o),
+(550,555,cs),
+(550,649,o),
+(488,714,o),
+(388,714,cs),
+(143,714,l),
+(131,660,l),
+(379,660,ls),
+(446,660,o),
+(487,617,o),
+(487,550,cs),
+(487,465,o),
+(442,384,o),
+(320,384,cs),
+(253,384,l),
+(242,330,l),
+(309,330,ls),
+(380,330,o),
+(418,296,o),
+(418,230,cs),
+(418,178,o),
+(406,54,o),
+(253,54,cs),
+(183,54,l),
+(172,0,l)
+);
+}
+);
+width = 552;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160A;
+unicode = 5642;
+},
+{
+color = 9;
+glyphname = "meeCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(249,0,ls),
+(430,0,o),
+(480,125,o),
+(480,225,cs),
+(480,299,o),
+(444,351,o),
+(381,365,c),
+(380,343,l),
+(508,367,o),
+(550,469,o),
+(550,555,cs),
+(550,649,o),
+(488,714,o),
+(388,714,cs),
+(143,714,l),
+(131,660,l),
+(379,660,ls),
+(446,660,o),
+(487,617,o),
+(487,550,cs),
+(487,465,o),
+(442,383,o),
+(321,383,cs),
+(293,383,l),
+(313,474,l),
+(272,474,l),
+(223,241,l),
+(264,241,l),
+(282,331,l),
+(311,331,ls),
+(380,331,o),
+(418,296,o),
+(418,230,cs),
+(418,178,o),
+(406,54,o),
+(253,54,cs),
+(183,54,l),
+(172,0,l)
+);
+}
+);
+width = 552;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160B;
+unicode = 5643;
+},
+{
+color = 9;
+glyphname = "miCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(248.996,0,ls),
+(427,0,o),
+(472,120,o),
+(478,213,cs),
+(483,292,o),
+(448,349,o),
+(381,365,c),
+(380,343,l),
+(504,366,o),
+(544,462,o),
+(549,543,cs),
+(556,643,o),
+(493,714,o),
+(388,714,cs),
+(143,714,l),
+(131,660,l),
+(379,660,ls),
+(448,660,o),
+(488,615,o),
+(486,545,cs),
+(484,462,o),
+(440,383,o),
+(320,383,cs),
+(299,383,l),
+(332,364,l),
+(330,395,o),
+(304,418,o),
+(274,418,cs),
+(240,418,o),
+(214,389,o),
+(214,357,cs),
+(214,324,o),
+(240,296,o),
+(274,296,cs),
+(304,296,o),
+(329,319,o),
+(332,349,c),
+(298,331,l),
+(310,331,ls),
+(382,331,o),
+(420,295,o),
+(418,226,cs),
+(415,171,o),
+(400,54,o),
+(253,54,cs),
+(183,54,l),
+(172,0,l)
+);
+}
+);
+width = 550;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160C;
+unicode = 5644;
+},
+{
+color = 9;
+glyphname = "maCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(457,0,l),
+(469,54,l),
+(220,54,ls),
+(152,54,o),
+(112,97,o),
+(112,164,cs),
+(112,249,o),
+(156,330,o),
+(278,330,cs),
+(346,330,l),
+(357,384,l),
+(289,384,ls),
+(219,384,o),
+(181,418,o),
+(181,484,cs),
+(181,536,o),
+(193,660,o),
+(346,660,cs),
+(416,660,l),
+(427.003,714,l),
+(350,714,ls),
+(169,714,o),
+(119,589,o),
+(119,489,cs),
+(119,415,o),
+(155,363,o),
+(218,349,c),
+(219,371,l),
+(90,347,o),
+(49,245,o),
+(49,159,cs),
+(49,65,o),
+(111,0,o),
+(211,0,cs)
+);
+}
+);
+width = 552;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni160D;
+unicode = 5645;
+},
+{
+color = 9;
+glyphname = "yuCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(408,-13,o),
+(508,107,o),
+(565,376,cs),
+(615,612,o),
+(583,727,o),
+(477,727,cs),
+(349,727,o),
+(304,547,o),
+(304,458,cs),
+(304,378,o),
+(343,326,o),
+(406,326,cs),
+(421,326,o),
+(433,329,o),
+(441,334,c),
+(452,384,l),
+(441,380,o),
+(432,378,o),
+(422,378,cs),
+(381,378,o),
+(359,409,o),
+(359,463,cs),
+(359,518,o),
+(388,674,o),
+(469,674,cs),
+(535,674,o),
+(550,591,o),
+(508,391,cs),
+(457,148,o),
+(382,47,o),
+(247,47,cs),
+(140,47,o),
+(97,112,o),
+(124,241,cs),
+(225,714,l),
+(161,714,l),
+(62,244,ls),
+(28,83,o),
+(98,-13,o),
+(244,-13,cs)
+);
+}
+);
+width = 598;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160E;
+unicode = 5646;
+},
+{
+color = 9;
+glyphname = "yoCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(297,-13,o),
+(341,167,o),
+(341,256,cs),
+(341,336,o),
+(303,388,o),
+(239,388,cs),
+(225,388,o),
+(212,385,o),
+(205,380,c),
+(194,330,l),
+(204,334,o),
+(213,336,o),
+(223,336,cs),
+(264,336,o),
+(286,305,o),
+(286,251,cs),
+(286,196,o),
+(257,40,o),
+(176,40,cs),
+(110,40,o),
+(95,123,o),
+(137,323,cs),
+(189,566,o),
+(264,667,o),
+(398,667,cs),
+(506,667,o),
+(549,602,o),
+(521,473,cs),
+(421,0,l),
+(484,0,l),
+(584,470,ls),
+(617,631,o),
+(548,727,o),
+(401,727,cs),
+(237,727,o),
+(138,607,o),
+(81,338,cs),
+(31,102,o),
+(63,-13,o),
+(168,-13,cs)
+);
+}
+);
+width = 597;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160F;
+unicode = 5647;
+},
+{
+color = 9;
+glyphname = "yeCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(439,-13,o),
+(519,297,o),
+(519,457,cs),
+(519,628,o),
+(439,714,o),
+(287,714,cs),
+(159,714,l),
+(146,655,l),
+(279,655,ls),
+(396,655,o),
+(455,591,o),
+(455,452,cs),
+(455,326,o),
+(399,43,o),
+(213,43,cs),
+(134,43,o),
+(91,89,o),
+(91,172,cs),
+(91,231,o),
+(116,362,o),
+(200,362,cs),
+(238,362,o),
+(258,333,o),
+(258,279,cs),
+(258,236,o),
+(247,192,o),
+(232,150,c),
+(281,150,l),
+(296,195,o),
+(308,242,o),
+(308,287,cs),
+(308,367,o),
+(270,415,o),
+(202,415,cs),
+(81,415,o),
+(36,259,o),
+(36,168,cs),
+(36,57,o),
+(101,-13,o),
+(210,-13,cs)
+);
+}
+);
+width = 537;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1610;
+unicode = 5648;
+},
+{
+color = 9;
+glyphname = "yeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(441,-13,o),
+(520,304,o),
+(520,465,cs),
+(520,628,o),
+(438,714,o),
+(290,714,cs),
+(159,714,l),
+(146,655,l),
+(279,655,ls),
+(396,655,o),
+(456,591,o),
+(456,460,cs),
+(456,329,o),
+(398,43,o),
+(213,43,cs),
+(134,43,o),
+(91,88,o),
+(91,174,cs),
+(91,229,o),
+(116,362,o),
+(197,362,cs),
+(241,362,o),
+(260,319,o),
+(244,242,cs),
+(231,180,l),
+(272,180,l),
+(345,521,l),
+(303,521,l),
+(257,304,l),
+(268,304,l),
+(276,371,o),
+(245,415,o),
+(189,415,cs),
+(80,415,o),
+(37,260,o),
+(37,171,cs),
+(37,58,o),
+(100,-13,o),
+(213,-13,cs)
+);
+}
+);
+width = 537;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1611;
+unicode = 5649;
+},
+{
+color = 9;
+glyphname = "yiCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(444,-13,o),
+(520,307,o),
+(520,465,cs),
+(520,628,o),
+(439,714,o),
+(290,714,cs),
+(159,714,l),
+(146,655,l),
+(279,655,ls),
+(396,655,o),
+(456,591,o),
+(456,460,cs),
+(456,333,o),
+(402,43,o),
+(213,43,cs),
+(133,43,o),
+(90,90,o),
+(90,171,cs),
+(90,238,o),
+(112,342,o),
+(202,338,c),
+(186,356,l),
+(187,323,o),
+(215,299,o),
+(246,299,cs),
+(279,299,o),
+(306,325,o),
+(306,357,cs),
+(306,389,o),
+(279,415,o),
+(246,415,cs),
+(222,415,o),
+(201,401,o),
+(192,381,c),
+(81,379,o),
+(35,257,o),
+(35,165,cs),
+(35,56,o),
+(102,-13,o),
+(210,-13,cs)
+);
+}
+);
+width = 537;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1612;
+unicode = 5650;
+},
+{
+color = 9;
+glyphname = "yaCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(427,0,l),
+(440,59,l),
+(307,59,ls),
+(190,59,o),
+(131,123,o),
+(131,262,cs),
+(131,388,o),
+(187,671,o),
+(373,671,cs),
+(452,671,o),
+(495,625,o),
+(495,542,cs),
+(495,483,o),
+(470,352,o),
+(386,352,cs),
+(348,352,o),
+(328,381,o),
+(328,435,cs),
+(328,479,o),
+(339,522,o),
+(354,564,c),
+(305,564,l),
+(290,519,o),
+(278,472,o),
+(278,427,cs),
+(278,347,o),
+(316,299,o),
+(384,299,cs),
+(505,299,o),
+(550,455,o),
+(550,546,cs),
+(550,657,o),
+(485,727,o),
+(376,727,cs),
+(146,727,o),
+(66,417,o),
+(66,257,cs),
+(66,86,o),
+(147,0,o),
+(299,0,cs)
+);
+}
+);
+width = 538;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|yeCarrier-canadian";
+note = uni1613;
+unicode = 5651;
+},
+{
+color = 9;
+glyphname = "juCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(438,-13,o),
+(502,150,o),
+(502,268,cs),
+(502,357,o),
+(459,415,o),
+(388,415,cs),
+(309,415,o),
+(262,348,o),
+(243,240,cs),
+(236,206,o),
+(234,171,o),
+(235,150,c),
+(283,150,l),
+(284,169,o),
+(284,199,o),
+(292,240,cs),
+(311,322,o),
+(344,362,o),
+(386,362,cs),
+(425,362,o),
+(448,327,o),
+(448,267,cs),
+(448,177,o),
+(406,43,o),
+(270,43,cs),
+(175,43,o),
+(126,105,o),
+(126,217,cs),
+(126,336,o),
+(180,655,o),
+(504,655,cs),
+(579,655,l),
+(591,714,l),
+(151,714,l),
+(139,657,l),
+(397,657,l),
+(419,677,l),
+(171,671,o),
+(64,410,o),
+(64,220,cs),
+(64,74,o),
+(137,-13,o),
+(267,-13,cs)
+);
+}
+);
+width = 550;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni1614;
+unicode = 5652;
+},
+{
+color = 9;
+glyphname = "juSayisi-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (399,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(418,-13,o),
+(503,226,o),
+(513,391,cs),
+(523,565,o),
+(440,675,o),
+(283,683,c),
+(324,657,l),
+(585,657,l),
+(597,714,l),
+(156,714,l),
+(144,655,l),
+(207,655,ls),
+(380,655,o),
+(460,568,o),
+(451,400,cs),
+(445,272,o),
+(392,43,o),
+(221,43,cs),
+(134,43,o),
+(86,94,o),
+(90,184,cs),
+(92,242,o),
+(119,362,o),
+(195,362,cs),
+(235,362,o),
+(253,331,o),
+(251,273,cs),
+(251,239,o),
+(240,182,o),
+(227,150,c),
+(275,150,l),
+(290,191,o),
+(301,235,o),
+(302,278,cs),
+(307,363,o),
+(270,415,o),
+(198,415,cs),
+(87,415,o),
+(43,275,o),
+(36,189,cs),
+(27,68,o),
+(98,-13,o),
+(220,-13,cs)
+);
+}
+);
+width = 548;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1615;
+unicode = 5653;
+},
+{
+color = 9;
+glyphname = "joCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(447,0,l),
+(459,57,l),
+(200,57,l),
+(178,37,l),
+(427,43,o),
+(534,304,o),
+(534,494,cs),
+(534,640,o),
+(460,727,o),
+(331,727,cs),
+(160,727,o),
+(96,564,o),
+(96,446,cs),
+(96,357,o),
+(138,299,o),
+(209,299,cs),
+(288,299,o),
+(336,366,o),
+(355,474,cs),
+(361,508,o),
+(363,543,o),
+(363,564,c),
+(314,564,l),
+(314,545,o),
+(314,515,o),
+(305,474,cs),
+(286,392,o),
+(254,352,o),
+(212,352,cs),
+(172,352,o),
+(150,387,o),
+(150,447,cs),
+(150,537,o),
+(191,671,o),
+(328,671,cs),
+(422,671,o),
+(471,609,o),
+(471,497,cs),
+(471,378,o),
+(417,59,o),
+(94,59,cs),
+(19,59,l),
+(6,0,l)
+);
+}
+);
+width = 550;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1616;
+unicode = 5654;
+},
+{
+color = 9;
+glyphname = "jeCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(520,-13,o),
+(570,345,o),
+(570,487,cs),
+(570,640,o),
+(514,727,o),
+(401,727,cs),
+(290,727,o),
+(212,644,o),
+(161,469,c),
+(176,471,l),
+(228,714,l),
+(165,714,l),
+(13,0,l),
+(76,0,l),
+(141,304,ls),
+(193,554,o),
+(270,667,o),
+(387,667,cs),
+(472,667,o),
+(510,608,o),
+(510,486,cs),
+(510,388,o),
+(471,40,o),
+(349,40,cs),
+(309,40,o),
+(289,68,o),
+(289,123,cs),
+(289,193,o),
+(319,336,o),
+(413,336,cs),
+(426,336,o),
+(438,333,o),
+(444,330,c),
+(453,380,l),
+(441,385,o),
+(426,388,o),
+(410,388,cs),
+(281,388,o),
+(235,216,o),
+(235,122,cs),
+(235,37,o),
+(274,-13,o),
+(345,-13,cs)
+);
+}
+);
+width = 601;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "te-canadian";
+note = uni1617;
+unicode = 5655;
+},
+{
+color = 9;
+glyphname = "jeeCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(520,-13,o),
+(570,347,o),
+(570,486,cs),
+(570,640,o),
+(514,727,o),
+(401,727,cs),
+(289,727,o),
+(212,643,o),
+(161,469,c),
+(176,471,l),
+(228,714,l),
+(165,714,l),
+(13,0,l),
+(76,0,l),
+(140,299,ls),
+(194,555,o),
+(268,667,o),
+(386,667,cs),
+(472,667,o),
+(510,608,o),
+(510,485,cs),
+(510,369,o),
+(470,40,o),
+(341,40,cs),
+(295,40,o),
+(271,71,o),
+(271,132,cs),
+(271,196,o),
+(298,320,o),
+(375,340,c),
+(356,246,l),
+(391,246,l),
+(437,465,l),
+(402,465,l),
+(384,379,l),
+(273,359,o),
+(235,204,o),
+(235,121,cs),
+(235,37,o),
+(274,-13,o),
+(345,-13,cs)
+);
+}
+);
+width = 601;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1618;
+unicode = 5656;
+},
+{
+color = 9;
+glyphname = "jiCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(520,-13,o),
+(570,347,o),
+(570,486,cs),
+(570,640,o),
+(514,727,o),
+(401,727,cs),
+(289,727,o),
+(212,643,o),
+(161,469,c),
+(176,471,l),
+(228,714,l),
+(165,714,l),
+(13,0,l),
+(76,0,l),
+(140,299,ls),
+(194,555,o),
+(268,667,o),
+(386,667,cs),
+(472,667,o),
+(510,608,o),
+(510,485,cs),
+(510,369,o),
+(470,40,o),
+(341,40,cs),
+(295,40,o),
+(271,71,o),
+(271,132,cs),
+(271,188,o),
+(292,290,o),
+(351,324,c),
+(359,308,o),
+(375,297,o),
+(394,297,cs),
+(424,297,o),
+(450,323,o),
+(450,355,cs),
+(450,387,o),
+(425,412,o),
+(394,412,cs),
+(363,412,o),
+(340,385,o),
+(341,357,c),
+(263,314,o),
+(235,192,o),
+(235,121,cs),
+(235,37,o),
+(274,-13,o),
+(345,-13,cs)
+);
+}
+);
+width = 601;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1619;
+unicode = 5657;
+},
+{
+color = 9;
+glyphname = "jiSayisi-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(501,-13,o),
+(588,378,o),
+(588,549,cs),
+(588,671,o),
+(551,727,o),
+(476,727,cs),
+(345,727,o),
+(308,543,o),
+(308,459,cs),
+(308,368,o),
+(353,326,o),
+(407,326,cs),
+(423,326,o),
+(434,328,o),
+(443,334,c),
+(455,384,l),
+(447,380,o),
+(438,378,o),
+(424,378,cs),
+(388,378,o),
+(361,402,o),
+(361,465,cs),
+(361,508,o),
+(385,674,o),
+(472,674,cs),
+(513,674,o),
+(532,642,o),
+(532,559,cs),
+(532,424,o),
+(462,47,o),
+(269,47,cs),
+(110,47,o),
+(131,262,o),
+(162,405,cs),
+(228,714,l),
+(165,714,l),
+(13,0,l),
+(76,0,l),
+(143,319,l),
+(127,327,l),
+(93,169,o),
+(110,-13,o),
+(274,-13,cs)
+);
+}
+);
+width = 601;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161A;
+unicode = 5658;
+},
+{
+color = 9;
+glyphname = "jaCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (393,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(359,-12,o),
+(436,71,o),
+(488,245,c),
+(472,243,l),
+(421,0,l),
+(484,0,l),
+(636,714,l),
+(573,714,l),
+(508,410,ls),
+(455,161,o),
+(379,47,o),
+(262,47,cs),
+(177,47,o),
+(139,106,o),
+(139,229,cs),
+(139,326,o),
+(178,675,o),
+(300,675,cs),
+(339,675,o),
+(360,646,o),
+(360,592,cs),
+(360,521,o),
+(330,378,o),
+(236,378,cs),
+(223,378,o),
+(211,381,o),
+(205,384,c),
+(196,334,l),
+(208,329,o),
+(223,326,o),
+(239,326,cs),
+(367,326,o),
+(413,498,o),
+(413,592,cs),
+(413,677,o),
+(375,727,o),
+(304,727,cs),
+(129,727,o),
+(79,369,o),
+(79,227,cs),
+(79,75,o),
+(135,-12,o),
+(248,-12,cs)
+);
+}
+);
+width = 601;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni161B;
+unicode = 5659;
+},
+{
+color = 9;
+glyphname = "jjuCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(427,-13,o),
+(497,149,o),
+(497,271,cs),
+(497,359,o),
+(455,415,o),
+(385,415,cs),
+(312,415,o),
+(266,359,o),
+(239,245,cs),
+(231,214,o),
+(227,176,o),
+(227,150,c),
+(276,150,l),
+(277,165,o),
+(278,195,o),
+(286,233,cs),
+(305,318,o),
+(337,362,o),
+(381,362,cs),
+(420,362,o),
+(442,327,o),
+(442,269,cs),
+(442,180,o),
+(401,42,o),
+(264,42,cs),
+(176,42,o),
+(130,104,o),
+(130,219,cs),
+(130,391,o),
+(212,655,o),
+(477,655,cs),
+(573,655,l),
+(585,714,l),
+(488,714,ls),
+(390,714,o),
+(311,685,o),
+(249,638,c),
+(179,727,l),
+(128,687,l),
+(200,595,l),
+(101,493,o),
+(68,336,o),
+(68,223,cs),
+(68,78,o),
+(138,-13,o),
+(261,-13,cs)
+);
+}
+);
+width = 544;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni161C;
+unicode = 5660;
+},
+{
+color = 9;
+glyphname = "jjoCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(464,27,l),
+(392,119,l),
+(491,221,o),
+(524,378,o),
+(524,491,cs),
+(524,636,o),
+(454,727,o),
+(331,727,cs),
+(164,727,o),
+(95,565,o),
+(95,443,cs),
+(95,355,o),
+(137,299,o),
+(207,299,cs),
+(279,299,o),
+(326,355,o),
+(353,469,cs),
+(360,500,o),
+(365,538,o),
+(365,564,c),
+(316,564,l),
+(315,549,o),
+(313,519,o),
+(306,481,cs),
+(287,396,o),
+(255,352,o),
+(211,352,cs),
+(171,352,o),
+(149,387,o),
+(149,445,cs),
+(149,534,o),
+(191,672,o),
+(328,672,cs),
+(416,672,o),
+(462,610,o),
+(462,495,cs),
+(462,323,o),
+(380,59,o),
+(114,59,cs),
+(19,59,l),
+(6,0,l),
+(104,0,ls),
+(202,0,o),
+(281,29,o),
+(343,76,c),
+(412,-13,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|jjuCarrier-canadian";
+note = uni161D;
+unicode = 5661;
+},
+{
+color = 9;
+glyphname = "jjeCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(523,-13,o),
+(572,345,o),
+(572,486,cs),
+(572,649,o),
+(503,727,o),
+(379,727,cs),
+(325,727,o),
+(267,709,o),
+(218,662,c),
+(165,726,l),
+(118,682,l),
+(177,612,l),
+(149,572,o),
+(126,520,o),
+(111,451,cs),
+(15,0,l),
+(78,0,l),
+(173,449,ls),
+(204,593,o),
+(273,667,o),
+(376,667,cs),
+(469,667,o),
+(512,611,o),
+(512,486,cs),
+(512,389,o),
+(473,40,o),
+(351,40,cs),
+(311,40,o),
+(291,68,o),
+(291,123,cs),
+(291,193,o),
+(321,336,o),
+(415,336,cs),
+(428,336,o),
+(439,333,o),
+(446,330,c),
+(455,380,l),
+(443,385,o),
+(428,388,o),
+(411,388,cs),
+(284,388,o),
+(238,216,o),
+(238,122,cs),
+(238,37,o),
+(276,-13,o),
+(347,-13,cs)
+);
+}
+);
+width = 604;
+}
+);
+metricRight = "jeCarrier-canadian";
+note = uni161E;
+unicode = 5662;
+},
+{
+color = 9;
+glyphname = "jjeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(523,-13,o),
+(572,345,o),
+(572,486,cs),
+(572,649,o),
+(503,727,o),
+(379,727,cs),
+(325,727,o),
+(267,709,o),
+(218,662,c),
+(165,726,l),
+(118,682,l),
+(177,612,l),
+(149,572,o),
+(126,520,o),
+(111,451,cs),
+(15,0,l),
+(78,0,l),
+(173,449,ls),
+(204,593,o),
+(273,667,o),
+(376,667,cs),
+(469,667,o),
+(512,611,o),
+(512,486,cs),
+(512,382,o),
+(475,40,o),
+(345,40,cs),
+(299,40,o),
+(274,70,o),
+(274,132,cs),
+(274,205,o),
+(301,325,o),
+(379,341,c),
+(359,246,l),
+(394,246,l),
+(441,465,l),
+(405,465,l),
+(387,379,l),
+(278,361,o),
+(238,210,o),
+(238,122,cs),
+(238,37,o),
+(276,-13,o),
+(347,-13,cs)
+);
+}
+);
+width = 604;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161F;
+unicode = 5663;
+},
+{
+color = 9;
+glyphname = "jjiCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,-13,o),
+(505,69,o),
+(552,285,cs),
+(614,566,o),
+(550,727,o),
+(379,727,cs),
+(315,727,o),
+(261,705,o),
+(217,663,c),
+(165,726,l),
+(118,682,l),
+(176,614,l),
+(147,572,o),
+(125,517,o),
+(111,451,cs),
+(15,0,l),
+(78,0,l),
+(173,449,ls),
+(204,593,o),
+(273,667,o),
+(376,667,cs),
+(508,667,o),
+(548,539,o),
+(492,289,cs),
+(451,99,o),
+(407,40,o),
+(344,40,cs),
+(280,40,o),
+(260,100,o),
+(284,208,cs),
+(298,271,o),
+(321,308,o),
+(352,324,c),
+(359,308,o),
+(376,297,o),
+(395,297,cs),
+(425,297,o),
+(450,323,o),
+(450,355,cs),
+(450,386,o),
+(426,412,o),
+(395,412,cs),
+(361,412,o),
+(342,381,o),
+(342,355,c),
+(299,333,o),
+(266,282,o),
+(248,204,cs),
+(219,69,o),
+(257,-13,o),
+(347,-13,cs)
+);
+}
+);
+width = 604;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1620;
+unicode = 5664;
+},
+{
+color = 9;
+glyphname = "jjaCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(326,-13,o),
+(385,5,o),
+(434,52,c),
+(487,-12,l),
+(534,32,l),
+(475,102,l),
+(503,142,o),
+(525,194,o),
+(540,263,cs),
+(637,714,l),
+(574,714,l),
+(478,265,ls),
+(447,121,o),
+(378,47,o),
+(276,47,cs),
+(183,47,o),
+(139,103,o),
+(139,228,cs),
+(139,325,o),
+(178,674,o),
+(300,674,cs),
+(340,674,o),
+(360,646,o),
+(360,591,cs),
+(360,521,o),
+(330,378,o),
+(237,378,cs),
+(224,378,o),
+(212,381,o),
+(206,384,c),
+(197,334,l),
+(208,329,o),
+(224,326,o),
+(240,326,cs),
+(368,326,o),
+(414,498,o),
+(414,592,cs),
+(414,677,o),
+(376,727,o),
+(305,727,cs),
+(129,727,o),
+(79,369,o),
+(79,228,cs),
+(79,65,o),
+(148,-13,o),
+(273,-13,cs)
+);
+}
+);
+width = 604;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "=|jjeCarrier-canadian";
+note = uni1621;
+unicode = 5665;
+},
+{
+color = 9;
+glyphname = "luCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(383,-13,o),
+(458,62,o),
+(492,224,cs),
+(596,714,l),
+(533,714,l),
+(429,229,ls),
+(403,104,o),
+(349,46,o),
+(259,46,cs),
+(170,46,o),
+(126,105,o),
+(126,215,cs),
+(126,336,o),
+(180,642,o),
+(388,662,c),
+(400,714,l),
+(148.998,714,l),
+(137,661,l),
+(310,661,l),
+(354,678,l),
+(148,671,o),
+(62,378,o),
+(62,213,cs),
+(62,69,o),
+(129,-13,o),
+(257,-13,cs)
+);
+}
+);
+width = 557;
+}
+);
+metricRight = "te-canadian";
+note = uni1622;
+unicode = 5666;
+},
+{
+color = 9;
+glyphname = "loCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(73,0,l),
+(176,485,ls),
+(203,610,o),
+(257,668,o),
+(347,668,cs),
+(435,668,o),
+(479,609,o),
+(479,499,cs),
+(479,378,o),
+(426,72,o),
+(217,52,c),
+(206,0,l),
+(456,0,l),
+(468,53,l),
+(295,53,l),
+(251,36,l),
+(457,43,o),
+(544,336,o),
+(544,501,cs),
+(544,645,o),
+(476,727,o),
+(348,727,cs),
+(223,727,o),
+(148,652,o),
+(114,490,cs),
+(9,0,l)
+);
+}
+);
+width = 557;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|luCarrier-canadian";
+note = uni1623;
+unicode = 5667;
+},
+{
+color = 9;
+glyphname = "leCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (293,357);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(164,0,ls),
+(454,0,o),
+(527,306,o),
+(527,482,cs),
+(527,638,o),
+(471,727,o),
+(372,727,cs),
+(288,727,o),
+(216,658,o),
+(171,534,c),
+(181,534,l),
+(218,714,l),
+(162,714,l),
+(95,399,l),
+(149,399,l),
+(185,566,o),
+(263,667,o),
+(352,667,cs),
+(426,667,o),
+(463,602,o),
+(463,477,cs),
+(463,338,o),
+(406,59,o),
+(165,59,cs),
+(22,59,l),
+(10,0,l)
+);
+}
+);
+width = 541;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1624;
+unicode = 5668;
+},
+{
+color = 9;
+glyphname = "leeCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "leCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (230,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 541;
+}
+);
+metricLeft = "leCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1625;
+unicode = 5669;
+},
+{
+color = 9;
+glyphname = "liCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "leCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (209,0);
+ref = dot_middle;
+}
+);
+width = 541;
+}
+);
+note = uni1626;
+unicode = 5670;
+},
+{
+color = 9;
+glyphname = "laCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(427,0,l),
+(440,59,l),
+(313,59,ls),
+(187,59,o),
+(125,115,o),
+(125,240,cs),
+(125,370,o),
+(194,667,o),
+(354,667,cs),
+(447,667,o),
+(486,563,o),
+(459,399,c),
+(512,399,l),
+(579,714,l),
+(522,714,l),
+(479,513,l),
+(487,511,l),
+(496,647,o),
+(444,727,o),
+(351,727,cs),
+(149,727,o),
+(61,399,o),
+(61,239,cs),
+(61,81,o),
+(143,0,o),
+(301,0,cs)
+);
+}
+);
+width = 540;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|leCarrier-canadian";
+note = uni1627;
+unicode = 5671;
+},
+{
+color = 1;
+glyphname = "dluCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(482,-13,o),
+(531,350,o),
+(531,457,cs),
+(531,583,o),
+(482,657,o),
+(384,677,c),
+(392,664,l),
+(587,664,l),
+(569,578,l),
+(617,578,l),
+(665,800,l),
+(616,800,l),
+(598,714,l),
+(357,714,l),
+(346,662,l),
+(439,641,o),
+(473,581,o),
+(473,471,cs),
+(473,390,o),
+(434,46,o),
+(231,46,cs),
+(131,46,o),
+(98,117,o),
+(129,261,cs),
+(225,714,l),
+(161,714,l),
+(67,269,ls),
+(28,85,o),
+(84,-13,o),
+(225,-13,cs)
+);
+}
+);
+width = 581;
+}
+);
+metricLeft = "te-canadian";
+note = uni1628;
+unicode = 5672;
+},
+{
+color = 9;
+glyphname = "dloCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(477,-86,l),
+(524,136,l),
+(475,136,l),
+(457,50,l),
+(290,50,l),
+(248,38,l),
+(441,43,o),
+(544,316,o),
+(544,501,cs),
+(544,645,o),
+(476,727,o),
+(348,727,cs),
+(223,727,o),
+(148,652,o),
+(114,490,cs),
+(9,0,l),
+(73,0,l),
+(176,485,ls),
+(203,610,o),
+(257,668,o),
+(347,668,cs),
+(435,668,o),
+(479,609,o),
+(479,499,cs),
+(479,378,o),
+(426,72,o),
+(217,52,c),
+(206,0,l),
+(447,0,l),
+(429,-86,l)
+);
+}
+);
+width = 581;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "dluCarrier-canadian";
+note = uni1629;
+unicode = 5673;
+},
+{
+color = 9;
+glyphname = "dleCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (305,357);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(175,0,ls),
+(465,0,o),
+(538,306,o),
+(538,482,cs),
+(538,638,o),
+(481,727,o),
+(383,727,cs),
+(298,727,o),
+(220,656,o),
+(176,527,c),
+(182,527,l),
+(224,729,l),
+(287,729,l),
+(297,776,l),
+(124,776,l),
+(114,729,l),
+(176,729,l),
+(106,399,l),
+(159,399,l),
+(196,566,o),
+(273,667,o),
+(363,667,cs),
+(437,667,o),
+(474,602,o),
+(474,477,cs),
+(474,338,o),
+(417,59,o),
+(176,59,cs),
+(33,59,l),
+(21,0,l)
+);
+}
+);
+width = 552;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni162A;
+unicode = 5674;
+},
+{
+color = 9;
+glyphname = "dleeCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (241,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 552;
+}
+);
+note = uni162B;
+unicode = 5675;
+},
+{
+color = 9;
+glyphname = "dliCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (221,0);
+ref = dot_middle;
+}
+);
+width = 552;
+}
+);
+note = uni162C;
+unicode = 5676;
+},
+{
+color = 9;
+glyphname = "dlaCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(427,0,l),
+(440,59,l),
+(313,59,ls),
+(187,59,o),
+(125,115,o),
+(125,240,cs),
+(125,370,o),
+(194,667,o),
+(354,667,cs),
+(447,667,o),
+(486,563,o),
+(459,399,c),
+(512,399,l),
+(582,729,l),
+(643,729,l),
+(654,776,l),
+(482,776,l),
+(471,729,l),
+(534,729,l),
+(487,508,l),
+(495,506,l),
+(504,647,o),
+(444,727,o),
+(351,727,cs),
+(149,727,o),
+(61,399,o),
+(61,239,cs),
+(61,81,o),
+(143,0,o),
+(301,0,cs)
+);
+}
+);
+width = 552;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni162D;
+unicode = 5677;
+},
+{
+color = 9;
+glyphname = "lhuCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(487,-13,o),
+(553,290,o),
+(553,455,cs),
+(553,568,o),
+(518,650,o),
+(451,681,c),
+(467,661,l),
+(619,661,l),
+(631,714,l),
+(435,714,l),
+(424,662,l),
+(471,642,o),
+(495,579,o),
+(495,489,cs),
+(495,351,o),
+(446,46,o),
+(257,46,cs),
+(169,46,o),
+(127,103,o),
+(127,214,cs),
+(127,336,o),
+(182,613,o),
+(333,662,c),
+(345,714,l),
+(148.998,714,l),
+(137,661,l),
+(289,661,l),
+(313,686,l),
+(133,632,o),
+(62,360,o),
+(62,212,cs),
+(62,68,o),
+(127,-13,o),
+(254,-13,cs)
+);
+}
+);
+width = 579;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162E;
+unicode = 5678;
+},
+{
+color = 9;
+glyphname = "lhoCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(192,0,l),
+(203,52,l),
+(155,72,o),
+(131,135,o),
+(131,225,cs),
+(131,363,o),
+(181,668,o),
+(370,668,cs),
+(457,668,o),
+(500,611,o),
+(500,500,cs),
+(500,378,o),
+(445,101,o),
+(293,52,c),
+(282,0,l),
+(478,0,l),
+(489,53,l),
+(338,53,l),
+(314,28,l),
+(494,82,o),
+(565,354,o),
+(565,502,cs),
+(565,646,o),
+(499,727,o),
+(373,727,cs),
+(140,727,o),
+(74,424,o),
+(74,259,cs),
+(74,146,o),
+(109,64,o),
+(176,33,c),
+(160,53,l),
+(8,53,l),
+(-4,0,l)
+);
+}
+);
+width = 578;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162F;
+unicode = 5679;
+},
+{
+color = 9;
+glyphname = "lheCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (309,357);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(470,-13,o),
+(550,309,o),
+(550,486,cs),
+(550,637,o),
+(488,727,o),
+(377,727,cs),
+(291,727,o),
+(227,673,o),
+(187,568,c),
+(191,566,l),
+(223,714,l),
+(166,714,l),
+(106,434,l),
+(160,434,l),
+(199,593,o),
+(264,667,o),
+(356,667,cs),
+(442,667,o),
+(488,603,o),
+(488,487,cs),
+(488,351,o),
+(429,47,o),
+(246,47,cs),
+(146,47,o),
+(99,137,o),
+(127,280,c),
+(73,280,l),
+(14,0,l),
+(71,0,l),
+(109,185,l),
+(100,185,l),
+(92,64,o),
+(152,-13,o),
+(257,-13,cs)
+);
+}
+);
+width = 564;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1630;
+unicode = 5680;
+},
+{
+color = 9;
+glyphname = "lheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (244,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 563;
+}
+);
+note = uni1631;
+unicode = 5681;
+},
+{
+color = 9;
+glyphname = "lhiCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (224,0);
+ref = dot_middle;
+}
+);
+width = 563;
+}
+);
+note = uni1632;
+unicode = 5682;
+},
+{
+color = 9;
+glyphname = "lhaCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(321,-13,o),
+(385,41,o),
+(424,146,c),
+(421,148,l),
+(389,0,l),
+(446,0,l),
+(506,280,l),
+(452,280,l),
+(413,121,o),
+(348,47,o),
+(255,47,cs),
+(169,47,o),
+(125,111,o),
+(125,227,cs),
+(125,363,o),
+(183,667,o),
+(366,667,cs),
+(466,667,o),
+(513,577,o),
+(485,434,c),
+(539,434,l),
+(598,714,l),
+(541,714,l),
+(502,529,l),
+(511,529,l),
+(520,650,o),
+(460,727,o),
+(357,727,cs),
+(142,727,o),
+(62,405,o),
+(62,228,cs),
+(62,77,o),
+(124,-13,o),
+(235,-13,cs)
+);
+}
+);
+width = 564;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1633;
+unicode = 5683;
+},
+{
+color = 9;
+glyphname = "tlhuCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(487,-13,o),
+(553,290,o),
+(553,455,cs),
+(553,563,o),
+(526,646,o),
+(458,681,c),
+(454,664,l),
+(610,664,l),
+(592,578,l),
+(640,578,l),
+(687,800,l),
+(639,800,l),
+(620,714,l),
+(435,714,l),
+(424,662,l),
+(471,642,o),
+(495,579,o),
+(495,489,cs),
+(495,351,o),
+(446,46,o),
+(257,46,cs),
+(169,46,o),
+(127,103,o),
+(127,214,cs),
+(127,336,o),
+(182,613,o),
+(333,662,c),
+(345,714,l),
+(148.998,714,l),
+(137,661,l),
+(299,661,l),
+(291,678,l),
+(126,614,o),
+(62,354,o),
+(62,212,cs),
+(62,68,o),
+(127,-13,o),
+(254,-13,cs)
+);
+}
+);
+width = 602;
+}
+);
+metricLeft = "lhuCarrier-canadian";
+note = uni1634;
+unicode = 5684;
+},
+{
+color = 9;
+glyphname = "tlhoCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(11,-86,l),
+(30,0,l),
+(215,0,l),
+(227,52,l),
+(179,72,o),
+(155,135,o),
+(155,225,cs),
+(155,363,o),
+(204,668,o),
+(393,668,cs),
+(481,668,o),
+(524,611,o),
+(524,500,cs),
+(524,378,o),
+(468,101,o),
+(316.994,52,c),
+(306,0,l),
+(501,0,l),
+(513,53,l),
+(352,53,l),
+(360,36,l),
+(524,100,o),
+(588,360,o),
+(588,502,cs),
+(588,646,o),
+(523,727,o),
+(396,727,cs),
+(163,727,o),
+(97,424,o),
+(97,259,cs),
+(97,151,o),
+(124,68,o),
+(192,33,c),
+(196,50,l),
+(39,50,l),
+(58,136,l),
+(10,136,l),
+(-37,-86,l)
+);
+}
+);
+width = 602;
+}
+);
+metricLeft = "=|tlhuCarrier-canadian";
+metricRight = "lhuCarrier-canadian";
+note = uni1635;
+unicode = 5685;
+},
+{
+color = 9;
+glyphname = "tlheCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (314,357);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(476,-13,o),
+(558,309,o),
+(558,486,cs),
+(558,637,o),
+(495,727,o),
+(384,727,cs),
+(287,727,o),
+(219,663,o),
+(178,547,c),
+(190,567,l),
+(224,729,l),
+(286,729,l),
+(296,776,l),
+(124,776,l),
+(114,729,l),
+(176,729,l),
+(113,434,l),
+(166,434,l),
+(205,593,o),
+(271,667,o),
+(363,667,cs),
+(449,667,o),
+(495,603,o),
+(495,487,cs),
+(495,351,o),
+(436,47,o),
+(253,47,cs),
+(152,47,o),
+(106,137,o),
+(133,280,c),
+(80,280,l),
+(21,0,l),
+(77,0,l),
+(116,185,l),
+(107,185,l),
+(99,64,o),
+(158,-13,o),
+(264,-13,cs)
+);
+}
+);
+width = 572;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1636;
+unicode = 5686;
+},
+{
+color = 9;
+glyphname = "tlheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (251,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 572;
+}
+);
+note = uni1637;
+unicode = 5687;
+},
+{
+color = 9;
+glyphname = "tlhiCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (230,0);
+ref = dot_middle;
+}
+);
+width = 572;
+}
+);
+note = uni1638;
+unicode = 5688;
+},
+{
+color = 9;
+glyphname = "tlhaCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(321,-13,o),
+(385,41,o),
+(425,146,c),
+(421,148,l),
+(390,0,l),
+(446,0,l),
+(506,280,l),
+(453,280,l),
+(414,121,o),
+(348,47,o),
+(255,47,cs),
+(169,47,o),
+(125,111,o),
+(125,227,cs),
+(125,363,o),
+(183,667,o),
+(366,667,cs),
+(467,667,o),
+(513,577,o),
+(486,434,c),
+(539,434,l),
+(602,729,l),
+(663,729,l),
+(674,776,l),
+(502,776,l),
+(492,729,l),
+(554,729,l),
+(510,524,l),
+(519,523,l),
+(527,653,o),
+(461,727,o),
+(357,727,cs),
+(142,727,o),
+(62,405,o),
+(62,228,cs),
+(62,77,o),
+(124,-13,o),
+(235,-13,cs)
+);
+}
+);
+width = 572;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni1639;
+unicode = 5689;
+},
+{
+color = 9;
+glyphname = "tluCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(236,-13,o),
+(281,25,o),
+(318,112,c),
+(300,113,l),
+(304,32,o),
+(342,-13,o),
+(411,-13,cs),
+(589,-13,o),
+(647,341,o),
+(647,481,cs),
+(647,584,o),
+(616,645,o),
+(556,673,c),
+(541,664,l),
+(700,664,l),
+(682,578,l),
+(730,578,l),
+(777,800,l),
+(728,800,l),
+(710,714,l),
+(481,714,l),
+(470,662,l),
+(550,658,o),
+(588,610,o),
+(588,498,cs),
+(588,381,o),
+(535,46,o),
+(411,46,cs),
+(352,46,o),
+(333,96,o),
+(354,193,cs),
+(379,309,l),
+(319,309,l),
+(294,192,ls),
+(273,93,o),
+(237,46,o),
+(183,46,cs),
+(136,46,o),
+(115,76,o),
+(115,161,cs),
+(115,229,o),
+(160,667,o),
+(378,662,c),
+(389,714,l),
+(150,714,l),
+(138,661,l),
+(293,661,l),
+(282,670,l),
+(112,609,o),
+(52,296,o),
+(52,154,cs),
+(52,43,o),
+(93,-13,o),
+(172,-13,cs)
+);
+}
+);
+width = 692;
+}
+);
+metricRight = "tlhuCarrier-canadian";
+note = uni163A;
+unicode = 5690;
+},
+{
+color = 1;
+glyphname = "tloCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(588,-86,l),
+(635,136,l),
+(587,136,l),
+(568,50,l),
+(421,50,l),
+(430,41,l),
+(606,101,o),
+(665,417,o),
+(665,560,cs),
+(665,671,o),
+(625,727,o),
+(546,727,cs),
+(482,727,o),
+(437,689,o),
+(400,602,c),
+(418,602,l),
+(414,682,o),
+(376,727,o),
+(307,727,cs),
+(129,727,o),
+(71,373,o),
+(71,233,cs),
+(71,134,o),
+(101,73,o),
+(158,44,c),
+(173,53,l),
+(8,53,l),
+(-3,0,l),
+(237,0,l),
+(248,52,l),
+(168,56,o),
+(130,104,o),
+(130,216,cs),
+(130,333,o),
+(183,668,o),
+(306,668,cs),
+(366,668,o),
+(384,618,o),
+(364,521,cs),
+(339,405,l),
+(399,405,l),
+(424,522,ls),
+(445,621,o),
+(481,668,o),
+(535,668,cs),
+(582,668,o),
+(603,638,o),
+(603,553,cs),
+(603,485,o),
+(558,47,o),
+(340,52,c),
+(329,0,l),
+(558,0,l),
+(540,-86,l)
+);
+}
+);
+width = 691;
+}
+);
+metricLeft = "tluCarrier-canadian";
+metricRight = "tlhuCarrier-canadian";
+note = uni163B;
+unicode = 5691;
+},
+{
+color = 9;
+glyphname = "tleCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (253,357);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(418,-13,o),
+(504,92,o),
+(504,225,cs),
+(504,302,o),
+(464,357,o),
+(398,364,c),
+(395,348,l),
+(507,354,o),
+(577,460,o),
+(577,560,cs),
+(577,658,o),
+(510,727,o),
+(404,727,cs),
+(301,727,o),
+(217,661,o),
+(179,547,c),
+(186,547,l),
+(224,729,l),
+(287,729,l),
+(297,776,l),
+(124,776,l),
+(114,729,l),
+(176,729,l),
+(113,434,l),
+(165,434,l),
+(202,591,o),
+(275,669,o),
+(383,669,cs),
+(464,669,o),
+(512,621,o),
+(512,548,cs),
+(512,461,o),
+(458,384,o),
+(367,384,cs),
+(335,384,l),
+(323,330,l),
+(354,330,ls),
+(410,330,o),
+(444,293,o),
+(444,230,cs),
+(444,127,o),
+(385,45,o),
+(271,45,cs),
+(152,45,o),
+(103,129,o),
+(132,280,c),
+(80,280,l),
+(21,0,l),
+(78,0,l),
+(113,167,l),
+(102,168,l),
+(96,59,o),
+(168,-13,o),
+(281,-13,cs)
+);
+}
+);
+width = 576;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni163C;
+unicode = 5692;
+},
+{
+color = 9;
+glyphname = "tleeCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (189,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 575;
+}
+);
+note = uni163D;
+unicode = 5693;
+},
+{
+color = 9;
+glyphname = "tliCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (174,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 575;
+}
+);
+note = uni163E;
+unicode = 5694;
+},
+{
+color = 9;
+glyphname = "tlaCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(313,-13,o),
+(391,42,o),
+(432,136,c),
+(426,147,l),
+(395,0,l),
+(452,0,l),
+(512,280,l),
+(459,280,l),
+(423,123,o),
+(350,45,o),
+(241,45,cs),
+(160,45,o),
+(112,93,o),
+(112,166,cs),
+(112,253,o),
+(166,330,o),
+(257,330,cs),
+(290,330,l),
+(301,384,l),
+(270,384,ls),
+(214,384,o),
+(180,421,o),
+(180,484,cs),
+(180,587,o),
+(239,669,o),
+(354,669,cs),
+(471,669,o),
+(521,585,o),
+(491,434,c),
+(544,434,l),
+(606,729,l),
+(668,729,l),
+(678,776,l),
+(505,776,l),
+(495,729,l),
+(558,729,l),
+(518,543,l),
+(523,550,l),
+(530,657,o),
+(458,727,o),
+(344,727,cs),
+(206,727,o),
+(120,622,o),
+(120,489,cs),
+(120,419,o),
+(153,368,o),
+(207,353,c),
+(211,363,l),
+(110,348,o),
+(48,248,o),
+(48,154,cs),
+(48,56,o),
+(114,-13,o),
+(220,-13,cs)
+);
+}
+);
+width = 576;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni163F;
+unicode = 5695;
+},
+{
+color = 9;
+glyphname = "zuCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(454,-13,o),
+(527,147,o),
+(527,327,cs),
+(527,397,o),
+(516,484,o),
+(516,551,cs),
+(516,620,o),
+(539,659,o),
+(599,659,cs),
+(618,659,l),
+(630,714,l),
+(593,714,ls),
+(497,714,o),
+(456,658,o),
+(456,547,cs),
+(456,482,o),
+(466,403,o),
+(466,326,cs),
+(466,183,o),
+(416,47,o),
+(258,47,cs),
+(163,47,o),
+(110,98,o),
+(110,183,cs),
+(110,331,o),
+(272,524,o),
+(272,631,cs),
+(272,683,o),
+(239,714,o),
+(182,714,cs),
+(147,714,l),
+(135,659,l),
+(163,659,ls),
+(195,659,o),
+(210,645,o),
+(210,619,cs),
+(210,533,o),
+(45,342,o),
+(45,177,cs),
+(45,63,o),
+(123,-13,o),
+(250,-13,cs)
+);
+}
+);
+width = 577;
+}
+);
+metricRight = "=|";
+note = uni1640;
+unicode = 5696;
+},
+{
+color = 9;
+glyphname = "zoCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(32,0,ls),
+(128,0,o),
+(169,56,o),
+(169,167,cs),
+(169,232,o),
+(159,311,o),
+(159,388,cs),
+(159,531,o),
+(210,667,o),
+(368,667,cs),
+(462,667,o),
+(516,616,o),
+(516,531,cs),
+(516,383,o),
+(353,190,o),
+(353,83,cs),
+(353,31,o),
+(386,0,o),
+(444,0,cs),
+(479,0,l),
+(490,55,l),
+(462,55,ls),
+(430,55,o),
+(415,69,o),
+(415,95,cs),
+(415,181,o),
+(581,372,o),
+(581,537,cs),
+(581,651,o),
+(502,727,o),
+(375,727,cs),
+(172,727,o),
+(99,567,o),
+(99,387,cs),
+(99,317,o),
+(110,230,o),
+(110,163,cs),
+(110,94,o),
+(87,55,o),
+(26,55,cs),
+(7,55,l),
+(-5,0,l)
+);
+}
+);
+width = 578;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1641;
+unicode = 5697;
+},
+{
+color = 9;
+glyphname = "zeCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (310,357);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(465,-13,o),
+(545,391,o),
+(545,548,cs),
+(545,663,o),
+(506,727,o),
+(438,727,cs),
+(349,727,o),
+(259,620,o),
+(222,620,cs),
+(197,620,o),
+(190,637,o),
+(199,679,cs),
+(207,714,l),
+(149,714,l),
+(138,661,ls),
+(125,603,o),
+(147,563,o),
+(193,563,cs),
+(265,563,o),
+(348,667,o),
+(415,667,cs),
+(459,667,o),
+(481,623,o),
+(481,539,cs),
+(481,413,o),
+(410,47,o),
+(279,47,cs),
+(212,47,o),
+(170,151,o),
+(98,151,cs),
+(54,151,o),
+(22,115,o),
+(9,53,cs),
+(-3,0,l),
+(55,0,l),
+(62,35,ls),
+(70,72,o),
+(88,94,o),
+(108,94,cs),
+(151,94,o),
+(198,-13,o),
+(288,-13,cs)
+);
+}
+);
+width = 548;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1642;
+unicode = 5698;
+},
+{
+color = 9;
+glyphname = "zeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (247,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 548;
+}
+);
+note = uni1643;
+unicode = 5699;
+},
+{
+color = 9;
+glyphname = "ziCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (227,0);
+ref = dot_middle;
+}
+);
+width = 548;
+}
+);
+note = uni1644;
+unicode = 5700;
+},
+{
+color = 9;
+glyphname = "zaCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(248,-13,o),
+(338,94,o),
+(375,94,cs),
+(400,94,o),
+(407,77,o),
+(398,35,cs),
+(390,0,l),
+(448,0,l),
+(459,53,ls),
+(472,111,o),
+(450,151,o),
+(404,151,cs),
+(332,151,o),
+(249,47,o),
+(182,47,cs),
+(138,47,o),
+(115,91,o),
+(115,175,cs),
+(115,301,o),
+(187,667,o),
+(318,667,cs),
+(385,667,o),
+(427,563,o),
+(498,563,cs),
+(542,563,o),
+(575,599,o),
+(588,661,cs),
+(600,714,l),
+(542,714,l),
+(535,679,ls),
+(527,642,o),
+(509,620,o),
+(489,620,cs),
+(446,620,o),
+(399,727,o),
+(309,727,cs),
+(132,727,o),
+(51,323,o),
+(51,166,cs),
+(51,51,o),
+(91,-13,o),
+(159,-13,cs)
+);
+}
+);
+width = 549;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|zeCarrier-canadian";
+note = uni1645;
+unicode = 5701;
+},
+{
+color = 6;
+glyphname = "zCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(271,189,l),
+(280,233,l),
+(96,233,l),
+(92,205,l),
+(339,521,l),
+(345,546,l),
+(116,546,l),
+(107,502,l),
+(288,502,l),
+(293,530,l),
+(46,214,l),
+(40,189,l)
+);
+}
+);
+width = 335;
+}
+);
+metricRight = "=|";
+note = uni1646;
+unicode = 5702;
+},
+{
+color = 6;
+glyphname = "initialzCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(158,99,l),
+(177,189,l),
+(271,189,l),
+(280,233,l),
+(86,233,l),
+(97,210,l),
+(339,521,l),
+(345,546,l),
+(253,546,l),
+(272,636,l),
+(227,636,l),
+(208,546,l),
+(116,546,l),
+(107,502,l),
+(299,502,l),
+(288,525,l),
+(46,214,l),
+(40,189,l),
+(132,189,l),
+(113,99,l)
+);
+}
+);
+width = 335;
+}
+);
+metricLeft = "zCarrier-canadian";
+metricRight = "zCarrier-canadian";
+note = uni1647;
+unicode = 5703;
+},
+{
+color = 9;
+glyphname = "dzuCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(454,-13,o),
+(527,147,o),
+(527,327,cs),
+(527,397,o),
+(516,484,o),
+(516,551,cs),
+(516,620,o),
+(539,659,o),
+(599,659,cs),
+(618,659,l),
+(630,714,l),
+(593,714,ls),
+(505,714,o),
+(463,658,o),
+(459,547,cs),
+(458,482,o),
+(468,398,o),
+(467,326,cs),
+(465,183,o),
+(416,47,o),
+(258,47,cs),
+(163,47,o),
+(110,98,o),
+(110,183,cs),
+(110,331,o),
+(269,524,o),
+(269,631,cs),
+(269,683,o),
+(239,714,o),
+(182,714,cs),
+(147,714,l),
+(135,659,l),
+(163,659,ls),
+(195,659,o),
+(210,645,o),
+(210,619,cs),
+(210,533,o),
+(45,342,o),
+(45,177,cs),
+(45,63,o),
+(123,-13,o),
+(250,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(361,507,l),
+(398,683,l),
+(450,683,l),
+(457,714,l),
+(321,714,l),
+(315,683,l),
+(367,683,l),
+(329,507,l)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1648;
+unicode = 5704;
+},
+{
+color = 9;
+glyphname = "dzoCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(32,0,ls),
+(121,0,o),
+(163,56,o),
+(167,167,cs),
+(168,232,o),
+(158,316,o),
+(159,388,cs),
+(160,531,o),
+(210,667,o),
+(368,667,cs),
+(462,667,o),
+(516,616,o),
+(516,531,cs),
+(516,383,o),
+(357,190,o),
+(357,83,cs),
+(357,31,o),
+(386,0,o),
+(444,0,cs),
+(478,0,l),
+(490,55,l),
+(462,55,ls),
+(430,55,o),
+(415,69,o),
+(415,95,cs),
+(415,181,o),
+(581,372,o),
+(581,537,cs),
+(581,651,o),
+(502,727,o),
+(375,727,cs),
+(172,727,o),
+(99,567,o),
+(99,387,cs),
+(99,317,o),
+(110,230,o),
+(110,163,cs),
+(110,94,o),
+(87,55,o),
+(26,55,cs),
+(7,55,l),
+(-5,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(304,0,l),
+(311,31,l),
+(259,31,l),
+(296,207,l),
+(265,207,l),
+(227,31,l),
+(175,31,l),
+(168,0,l)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1649;
+unicode = 5705;
+},
+{
+color = 9;
+glyphname = "dzeCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (324,357);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(481,-13,o),
+(562,391,o),
+(562,548,cs),
+(562,663,o),
+(523,727,o),
+(454,727,cs),
+(365,727,o),
+(276,620,o),
+(238,620,cs),
+(214,620,o),
+(207,637,o),
+(216,679,cs),
+(223,714,l),
+(166,714,l),
+(154,661,ls),
+(141,603,o),
+(164,563,o),
+(210,563,cs),
+(282,563,o),
+(365,667,o),
+(432,667,cs),
+(475,667,o),
+(498,623,o),
+(498,539,cs),
+(498,413,o),
+(426,47,o),
+(296,47,cs),
+(228,47,o),
+(186,151,o),
+(115,151,cs),
+(71,151,o),
+(38,115,o),
+(25,53,cs),
+(14,0,l),
+(71,0,l),
+(78,35,ls),
+(87,72,o),
+(104,94,o),
+(125,94,cs),
+(167,94,o),
+(215,-13,o),
+(305,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(106,249,l),
+(124,337,l),
+(230,337,l),
+(239,377,l),
+(132,377,l),
+(151,465,l),
+(113,465,l),
+(67,249,l)
+);
+}
+);
+width = 565;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164A;
+unicode = 5706;
+},
+{
+color = 9;
+glyphname = "dzeeCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "dzeCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (261,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 565;
+}
+);
+metricLeft = "dzeCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164B;
+unicode = 5707;
+},
+{
+color = 9;
+glyphname = "dziCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "dzeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (239,0);
+ref = dot_middle;
+}
+);
+width = 563;
+}
+);
+note = uni164C;
+unicode = 5708;
+},
+{
+color = 9;
+glyphname = "dzaCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(248,-13,o),
+(338,94,o),
+(375,94,cs),
+(400,94,o),
+(407,77,o),
+(398,35,cs),
+(390,0,l),
+(448,0,l),
+(459,53,ls),
+(472,111,o),
+(450,151,o),
+(404,151,cs),
+(332,151,o),
+(249,47,o),
+(182,47,cs),
+(138,47,o),
+(115,91,o),
+(115,175,cs),
+(115,301,o),
+(187,667,o),
+(318,667,cs),
+(385,667,o),
+(427,563,o),
+(499,563,cs),
+(543,563,o),
+(575,599,o),
+(588,661,cs),
+(600,714,l),
+(542,714,l),
+(535,679,ls),
+(527,642,o),
+(509,620,o),
+(489,620,cs),
+(446,620,o),
+(399,727,o),
+(309,727,cs),
+(132,727,o),
+(51,323,o),
+(51,166,cs),
+(51,51,o),
+(91,-13,o),
+(159,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(501,249,l),
+(547,465,l),
+(508,465,l),
+(489,377,l),
+(384,377,l),
+(375,337,l),
+(481,337,l),
+(462,249,l)
+);
+}
+);
+width = 565;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dzeCarrier-canadian";
+note = uni164D;
+unicode = 5709;
+},
+{
+color = 9;
+glyphname = "suCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(229,-13,o),
+(287,39,o),
+(323,142,c),
+(304,142,l),
+(298,41,o),
+(339,-13,o),
+(422,-13,cs),
+(558,-13,o),
+(600,142,o),
+(608,271,cs),
+(612,348,o),
+(603,460,o),
+(607,536,cs),
+(610,597,o),
+(622,659,o),
+(688,659,cs),
+(706,659,l),
+(718,714,l),
+(686,714,ls),
+(587,714,o),
+(557,641,o),
+(550,547,cs),
+(545,475,o),
+(550,359,o),
+(547,281,cs),
+(545,181,o),
+(519,46,o),
+(417,46,cs),
+(334,46,o),
+(339,141,o),
+(354,212,cs),
+(461,714,l),
+(405,714,l),
+(298,210,ls),
+(275,100,o),
+(232,46,o),
+(169,46,cs),
+(121,46,o),
+(96,75,o),
+(96,130,cs),
+(96,270,o),
+(268,524,o),
+(268,635,cs),
+(268,687,o),
+(238.003,714,o),
+(180,714,cs),
+(147,714,l),
+(136,659,l),
+(154,659,ls),
+(189,659,o),
+(205,645,o),
+(205,613,cs),
+(205,510,o),
+(32,282,o),
+(32,120,cs),
+(32,38,o),
+(78,-13,o),
+(153,-13,cs)
+);
+}
+);
+width = 665;
+}
+);
+metricRight = "=|";
+note = uni164E;
+unicode = 5710;
+},
+{
+color = 9;
+glyphname = "soCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(28,0,ls),
+(127,0,o),
+(157,73,o),
+(163,167,cs),
+(168,239,o),
+(163,355,o),
+(166,433,cs),
+(168,533,o),
+(195,668,o),
+(296,668,cs),
+(379,668,o),
+(375,573,o),
+(359,502,cs),
+(253,0,l),
+(308,0,l),
+(415,504,ls),
+(439,614,o),
+(481,668,o),
+(545,668,cs),
+(592,668,o),
+(617,639,o),
+(617,584,cs),
+(617,444,o),
+(446,190,o),
+(446,79,cs),
+(446,27,o),
+(475,0,o),
+(533,0,cs),
+(566,0,l),
+(578,55,l),
+(560,55,ls),
+(525,55,o),
+(508,69,o),
+(508,101,cs),
+(508,204,o),
+(681,432,o),
+(681,594,cs),
+(681,676,o),
+(636,727,o),
+(561,727,cs),
+(485,727,o),
+(427,675,o),
+(390,572,c),
+(410,572,l),
+(415,673,o),
+(375,727,o),
+(292,727,cs),
+(156,727,o),
+(113,572,o),
+(106,443,cs),
+(101,366,o),
+(110,254,o),
+(106,178,cs),
+(104,117,o),
+(91,55,o),
+(25,55,cs),
+(7,55,l),
+(-4,0,l)
+);
+}
+);
+width = 665;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5711;
+},
+{
+color = 9;
+glyphname = "seCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(435,-13,o),
+(495,136,o),
+(495,229,cs),
+(495,308,o),
+(457,358,o),
+(391,365,c),
+(388,349,l),
+(528,361,o),
+(572,498,o),
+(572,587,cs),
+(572,671,o),
+(530,727,o),
+(458,727,cs),
+(362,727,o),
+(279,620,o),
+(231,620,cs),
+(211,620,o),
+(205,638,o),
+(213,674,cs),
+(221,714,l),
+(164,714,l),
+(152,661,ls),
+(139,601,o),
+(161,563,o),
+(209,563,cs),
+(286,563,o),
+(363,669,o),
+(439,669,cs),
+(485,669,o),
+(508,634,o),
+(508,578,cs),
+(508,501,o),
+(469,384,o),
+(353,384,cs),
+(93,384,l),
+(81,330,l),
+(341,330,ls),
+(401,330,o),
+(434,293,o),
+(434,232,cs),
+(434,170,o),
+(399,45,o),
+(306,45,cs),
+(227,45,o),
+(187,151,o),
+(114,151,cs),
+(71,151,o),
+(37,117,o),
+(23,53,cs),
+(12,0,l),
+(69,0,l),
+(76,35,ls),
+(84,73,o),
+(102,94,o),
+(123,94,cs),
+(169,94,o),
+(215,-13,o),
+(315,-13,cs)
+);
+}
+);
+width = 567;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni1650;
+unicode = 5712;
+},
+{
+color = 9;
+glyphname = "seeCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(435,-13,o),
+(495,136,o),
+(495,229,cs),
+(495,301,o),
+(463,349,o),
+(407,362,c),
+(401,351,l),
+(531,370,o),
+(572,501,o),
+(572,587,cs),
+(572,671,o),
+(530,727,o),
+(458,727,cs),
+(362,727,o),
+(279,620,o),
+(231,620,cs),
+(211,620,o),
+(205,638,o),
+(213,674,cs),
+(221,714,l),
+(164,714,l),
+(152,661,ls),
+(139,601,o),
+(161,563,o),
+(209,563,cs),
+(286,563,o),
+(363,669,o),
+(439,669,cs),
+(485,669,o),
+(508,634,o),
+(508,578,cs),
+(508,501,o),
+(469,383,o),
+(353,383,cs),
+(292,383,l),
+(305,355,l),
+(328,468,l),
+(290,468,l),
+(272,383,l),
+(92,383,l),
+(82,331,l),
+(261,331,l),
+(241,236,l),
+(279,236,l),
+(305,359,l),
+(281,331,l),
+(340,331,ls),
+(402,331,o),
+(434,293,o),
+(434,232,cs),
+(434,170,o),
+(399,45,o),
+(306,45,cs),
+(227,45,o),
+(187,151,o),
+(114,151,cs),
+(71,151,o),
+(37,117,o),
+(23,53,cs),
+(12,0,l),
+(69,0,l),
+(76,35,ls),
+(84,73,o),
+(102,94,o),
+(123,94,cs),
+(169,94,o),
+(215,-13,o),
+(315,-13,cs)
+);
+}
+);
+width = 567;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1651;
+unicode = 5713;
+},
+{
+color = 9;
+glyphname = "siCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(435,-13,o),
+(495,136,o),
+(495,229,cs),
+(495,301,o),
+(463,349,o),
+(407,362,c),
+(401,351,l),
+(531,370,o),
+(572,501,o),
+(572,587,cs),
+(572,671,o),
+(530,727,o),
+(458,727,cs),
+(362,727,o),
+(279,620,o),
+(231,620,cs),
+(211,620,o),
+(205,638,o),
+(213,674,cs),
+(221,714,l),
+(164,714,l),
+(152,661,ls),
+(139,601,o),
+(161,563,o),
+(209,563,cs),
+(286,563,o),
+(363,669,o),
+(439,669,cs),
+(485,669,o),
+(509,634,o),
+(509,578,cs),
+(509,501,o),
+(471,381,o),
+(356,381,cs),
+(304,381,l),
+(332,362,l),
+(331,394,o),
+(305,418,o),
+(274,418,cs),
+(250,418,o),
+(229,403,o),
+(220,383,c),
+(92,383,l),
+(82,331,l),
+(220,331,l),
+(229,311,o),
+(250,296,o),
+(274,296,cs),
+(305,296,o),
+(331,320,o),
+(332,352,c),
+(304,333,l),
+(346,333,ls),
+(407,333,o),
+(435,293,o),
+(435,232,cs),
+(435,170,o),
+(399,45,o),
+(306,45,cs),
+(227,45,o),
+(187,151,o),
+(114,151,cs),
+(71,151,o),
+(37,117,o),
+(23,53,cs),
+(12,0,l),
+(69,0,l),
+(76,35,ls),
+(84,73,o),
+(102,94,o),
+(123,94,cs),
+(169,94,o),
+(215,-13,o),
+(315,-13,cs)
+);
+}
+);
+width = 567;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1652;
+unicode = 5714;
+},
+{
+color = 9;
+glyphname = "saCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(252,-13,o),
+(335,94,o),
+(383,94,cs),
+(403,94,o),
+(410,76,o),
+(402,40,cs),
+(393,0,l),
+(451,0,l),
+(462,53,ls),
+(476,113,o),
+(454,151,o),
+(406,151,cs),
+(329,151,o),
+(251,45,o),
+(175,45,cs),
+(129,45,o),
+(106,80,o),
+(106,136,cs),
+(106,213,o),
+(145,330,o),
+(261,330,cs),
+(522,330,l),
+(533,384,l),
+(274,384,ls),
+(213,384,o),
+(181,421,o),
+(181,482,cs),
+(181,544,o),
+(215,669,o),
+(308,669,cs),
+(387,669,o),
+(428,563,o),
+(501,563,cs),
+(544,563,o),
+(577,597,o),
+(591,661,cs),
+(603,714,l),
+(546,714,l),
+(538,679,ls),
+(530,641,o),
+(513,620,o),
+(492,620,cs),
+(445,620,o),
+(400,727,o),
+(300,727,cs),
+(180,727,o),
+(119,578,o),
+(119,485,cs),
+(119,406,o),
+(158,356,o),
+(223,349,c),
+(227,365,l),
+(86,353,o),
+(43,216,o),
+(43,127,cs),
+(43,43,o),
+(85,-13,o),
+(156,-13,cs)
+);
+}
+);
+width = 567;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1653;
+unicode = 5715;
+},
+{
+color = 9;
+glyphname = "shuCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(223,-13,o),
+(279,33,o),
+(317,126,c),
+(303,127,l),
+(302,36,o),
+(343,-13,o),
+(422,-13,cs),
+(558,-13,o),
+(600,142,o),
+(608,271,cs),
+(612,348,o),
+(603,460,o),
+(607,536,cs),
+(610,597,o),
+(622,659,o),
+(688,659,cs),
+(706,659,l),
+(718,714,l),
+(686,714,ls),
+(608,714,o),
+(571,671,o),
+(555,602,cs),
+(551,585,o),
+(549,566,o),
+(548,546,c),
+(566,574,l),
+(431,574,l),
+(461,714,l),
+(405,714,l),
+(376,574,l),
+(242,574,l),
+(250,555,l),
+(261,586,o),
+(268,613,o),
+(268,635,cs),
+(268,687,o),
+(238.003,714,o),
+(180,714,cs),
+(147,714,l),
+(136,659,l),
+(154,659,ls),
+(189,659,o),
+(205,645,o),
+(205,613,cs),
+(205,510,o),
+(32,282,o),
+(32,120,cs),
+(32,38,o),
+(78,-13,o),
+(153,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(121,46,o),
+(96,75,o),
+(96,130,cs),
+(96,236,o),
+(193,400,o),
+(241,524,c),
+(365,524,l),
+(298,210,ls),
+(275,100,o),
+(232,46,o),
+(169,46,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(334,46,o),
+(339,141,o),
+(354,212,cs),
+(421,524,l),
+(546,524,l),
+(543,448,o),
+(549,355,o),
+(547,281,cs),
+(545,181,o),
+(519,46,o),
+(417,46,cs)
+);
+}
+);
+width = 665;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1654;
+unicode = 5716;
+},
+{
+color = 9;
+glyphname = "shoCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(28,0,ls),
+(105,0,o),
+(142,43,o),
+(159,112,cs),
+(163,129,o),
+(165,148,o),
+(165,168,c),
+(148,140,l),
+(282,140,l),
+(253,0,l),
+(308,0,l),
+(338,140,l),
+(472,140,l),
+(463,159,l),
+(452,128,o),
+(446,101,o),
+(446,79,cs),
+(446,27,o),
+(475,0,o),
+(533,0,cs),
+(566,0,l),
+(578,55,l),
+(560,55,ls),
+(525,55,o),
+(508,69,o),
+(508,101,cs),
+(508,204,o),
+(681,432,o),
+(681,594,cs),
+(681,676,o),
+(636,727,o),
+(561,727,cs),
+(490,727,o),
+(435,681,o),
+(397,588,c),
+(410,587,l),
+(411,678,o),
+(371,727,o),
+(292,727,cs),
+(156,727,o),
+(113,572,o),
+(106,443,cs),
+(101,366,o),
+(110,254,o),
+(106,178,cs),
+(104,117,o),
+(91,55,o),
+(25,55,cs),
+(7,55,l),
+(-4,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(171,266,o),
+(164,359,o),
+(166,433,cs),
+(168,533,o),
+(195,668,o),
+(296,668,cs),
+(379,668,o),
+(375,573,o),
+(359,502,cs),
+(293,190,l),
+(167,190,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(415,504,ls),
+(439,614,o),
+(481,668,o),
+(545,668,cs),
+(592,668,o),
+(617,639,o),
+(617,584,cs),
+(617,478,o),
+(521,314,o),
+(473,190,c),
+(349,190,l)
+);
+}
+);
+width = 665;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1655;
+unicode = 5717;
+},
+{
+color = 9;
+glyphname = "sheCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(435,-13,o),
+(495,136,o),
+(495,229,cs),
+(495,301,o),
+(463,349,o),
+(407,362,c),
+(401,351,l),
+(531,370,o),
+(572,501,o),
+(572,587,cs),
+(572,671,o),
+(530,727,o),
+(458,727,cs),
+(362,727,o),
+(279,620,o),
+(231,620,cs),
+(211,620,o),
+(205,638,o),
+(213,674,cs),
+(221,714,l),
+(164,714,l),
+(152,661,ls),
+(139,601,o),
+(161,565,o),
+(209,565,cs),
+(222,565,o),
+(235,567,o),
+(248,574,c),
+(227,600,l),
+(182,384,l),
+(93,384,l),
+(81,330,l),
+(170,330,l),
+(124,111,l),
+(158,136,l),
+(145,144,o),
+(129,149,o),
+(114,149,cs),
+(71,149,o),
+(37,117,o),
+(23,53,cs),
+(12,0,l),
+(69,0,l),
+(76,35,ls),
+(84,73,o),
+(102,94,o),
+(123,94,cs),
+(169,94,o),
+(215,-13,o),
+(315,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(221,330,l),
+(341,330,ls),
+(401,330,o),
+(434,293,o),
+(434,232,cs),
+(434,170,o),
+(399,45,o),
+(306,45,cs),
+(252,45,o),
+(217,93,o),
+(177,124,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(275,585,l),
+(328,614,o),
+(384,669,o),
+(439,669,cs),
+(485,669,o),
+(508,634,o),
+(508,578,cs),
+(508,501,o),
+(469,384,o),
+(353,384,cs),
+(232,384,l)
+);
+}
+);
+width = 567;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1656;
+unicode = 5718;
+},
+{
+color = 9;
+glyphname = "sheeCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(435,-13,o),
+(495,136,o),
+(495,229,cs),
+(495,301,o),
+(463,349,o),
+(407,362,c),
+(401,351,l),
+(531,370,o),
+(572,501,o),
+(572,587,cs),
+(572,671,o),
+(530,727,o),
+(458,727,cs),
+(362,727,o),
+(279,620,o),
+(231,620,cs),
+(211,620,o),
+(205,638,o),
+(213,674,cs),
+(221,714,l),
+(164,714,l),
+(152,661,ls),
+(139,601,o),
+(161,565,o),
+(209,565,cs),
+(220,565,o),
+(233,567,o),
+(244,573,c),
+(227,598,l),
+(181,380,l),
+(92,380,l),
+(82,334,l),
+(171,334,l),
+(125,113,l),
+(152,137,l),
+(140,144,o),
+(127,149,o),
+(114,149,cs),
+(71,149,o),
+(37,117,o),
+(23,53,cs),
+(12,0,l),
+(69,0,l),
+(76,35,ls),
+(84,73,o),
+(102,94,o),
+(123,94,cs),
+(169,94,o),
+(215,-13,o),
+(315,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(250,44,o),
+(214,98,o),
+(169,128,c),
+(213,334,l),
+(304,334,l),
+(284,236,l),
+(317,236,l),
+(340,345,l),
+(324,334,l),
+(343,334,ls),
+(404,334,o),
+(435,293,o),
+(435,232,cs),
+(435,170,o),
+(399,44,o),
+(306,44,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(366,468,l),
+(333,468,l),
+(314,380,l),
+(223,380,l),
+(266,580,l),
+(324,610,o),
+(382,670,o),
+(439,670,cs),
+(485,670,o),
+(510,634,o),
+(510,578,cs),
+(510,501,o),
+(470,380,o),
+(354,380,cs),
+(334,380,l),
+(346,371,l)
+);
+}
+);
+width = 567;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1657;
+unicode = 5719;
+},
+{
+color = 9;
+glyphname = "shiCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(152,661,ls),
+(139,601,o),
+(161,565,o),
+(209,565,cs),
+(220,565,o),
+(233,567,o),
+(244,574,c),
+(227,598,l),
+(181,380,l),
+(92,380,l),
+(82,334,l),
+(171,334,l),
+(125,113,l),
+(152,137,l),
+(140,144,o),
+(127,149,o),
+(114,149,cs),
+(71,149,o),
+(37,117,o),
+(23,53,cs),
+(12,0,l),
+(69,0,l),
+(76,35,ls),
+(84,73,o),
+(102,94,o),
+(123,94,cs),
+(169,94,o),
+(215,-13,o),
+(315,-13,cs),
+(435,-13,o),
+(495,136,o),
+(495,229,cs),
+(495,301,o),
+(463,349,o),
+(407,362,c),
+(401,351,l),
+(531,370,o),
+(572,501,o),
+(572,587,cs),
+(572,671,o),
+(530,727,o),
+(458,727,cs),
+(362,727,o),
+(279,620,o),
+(231,620,cs),
+(211,620,o),
+(205,638,o),
+(213,674,cs),
+(221,714,l),
+(164,714,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(213,334,l),
+(273,334,l),
+(280,311,o),
+(301,296,o),
+(325,296,cs),
+(353,296,o),
+(376,317,o),
+(381,346,c),
+(330,334,l),
+(350,334,ls),
+(407,334,o),
+(436,292,o),
+(436,232,cs),
+(436,170,o),
+(399,44,o),
+(306,44,cs),
+(250,44,o),
+(214,98,o),
+(169,128,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(265,580,l),
+(324,610,o),
+(382,670,o),
+(439,670,cs),
+(485,670,o),
+(510,634,o),
+(510,578,cs),
+(510,501,o),
+(474,380,o),
+(361,380,cs),
+(330,380,l),
+(380,369,l),
+(376,398,o),
+(353,418,o),
+(326,418,cs),
+(302,418,o),
+(280,402,o),
+(273,380,c),
+(223,380,l)
+);
+}
+);
+width = 567;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1658;
+unicode = 5720;
+},
+{
+color = 9;
+glyphname = "shaCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(253,-13,o),
+(335,94,o),
+(383,94,cs),
+(403,94,o),
+(410,76,o),
+(402,40,cs),
+(393,0,l),
+(451,0,l),
+(462,53,ls),
+(476,113,o),
+(454,149,o),
+(406,149,cs),
+(393,149,o),
+(379,147,o),
+(366,140,c),
+(388,114,l),
+(433,330,l),
+(522,330,l),
+(533,384,l),
+(444,384,l),
+(490,603,l),
+(456,578,l),
+(470,570,o),
+(485,565,o),
+(501,565,cs),
+(544,565,o),
+(577,597,o),
+(591,661,cs),
+(603,714,l),
+(546,714,l),
+(538,679,ls),
+(530,641,o),
+(513,620,o),
+(492,620,cs),
+(445,620,o),
+(400,727,o),
+(300,727,cs),
+(180,727,o),
+(119,578,o),
+(119,485,cs),
+(119,413,o),
+(152,365,o),
+(207,352,c),
+(213,363,l),
+(84,344,o),
+(43,213,o),
+(43,127,cs),
+(43,43,o),
+(85,-13,o),
+(156,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(130,45,o),
+(106,80,o),
+(106,136,cs),
+(106,213,o),
+(146,330,o),
+(261,330,cs),
+(382,330,l),
+(339,129,l),
+(286,100,o),
+(231,45,o),
+(175,45,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(213,384,o),
+(181,421,o),
+(181,482,cs),
+(181,544,o),
+(215,669,o),
+(309,669,cs),
+(363,669,o),
+(398,621,o),
+(437,590,c),
+(393,384,l),
+(274,384,ls)
+);
+}
+);
+width = 567;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1659;
+unicode = 5721;
+},
+{
+color = 6;
+glyphname = "shCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(150,99,l),
+(171,203,l),
+(141,190,l),
+(153,190,ls),
+(240,190,o),
+(275,242,o),
+(275,310,cs),
+(275,358,o),
+(249,388,o),
+(201,388,cs),
+(184,388,ls),
+(154,388,o),
+(138,403,o),
+(138,431,cs),
+(138,463,o),
+(150,507,o),
+(206,507,cs),
+(316,507,l),
+(325,546,l),
+(245,546,l),
+(264,636,l),
+(221,636,l),
+(198,530,l),
+(229,546,l),
+(217,546,ls),
+(130,546,o),
+(94,494,o),
+(94,426,cs),
+(94,378,o),
+(121,348,o),
+(169,348,cs),
+(186,348,ls),
+(216,348,o),
+(232,333,o),
+(232,305,cs),
+(232,273,o),
+(220,229,o),
+(164,229,cs),
+(54,229,l),
+(45,190,l),
+(126,190,l),
+(107,99,l)
+);
+}
+);
+width = 317;
+}
+);
+metricRight = "=|";
+note = uni18F5;
+unicode = 5722;
+},
+{
+color = 9;
+glyphname = "tsuCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(223,-13,o),
+(278,33,o),
+(317,126,c),
+(303,127,l),
+(302,36,o),
+(343,-13,o),
+(422,-13,cs),
+(558,-13,o),
+(600,142,o),
+(608,271,cs),
+(612,348,o),
+(603,460,o),
+(607,536,cs),
+(610,597,o),
+(622,659,o),
+(688,659,cs),
+(706,659,l),
+(718,714,l),
+(686,714,ls),
+(587,714,o),
+(557,641,o),
+(551,547,cs),
+(549,500,o),
+(553,443,o),
+(553,382,c),
+(390,382,l),
+(451,668,l),
+(514,668,l),
+(524,714,l),
+(341,714,l),
+(331,668,l),
+(395,668,l),
+(335,382,l),
+(174,382,l),
+(219,482,o),
+(267,576,o),
+(267,635,cs),
+(267,687,o),
+(238.003,714,o),
+(180,714,cs),
+(147,714,l),
+(136,659,l),
+(154,659,ls),
+(189,659,o),
+(205,645,o),
+(205,613,cs),
+(205,510,o),
+(32,282,o),
+(32,120,cs),
+(32,38,o),
+(78,-13,o),
+(153,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(121,46,o),
+(96,75,o),
+(96,130,cs),
+(96,187,o),
+(123,258,o),
+(156,332,c),
+(323,332,l),
+(298,210,ls),
+(275,100,o),
+(232,46,o),
+(169,46,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(334,46,o),
+(339,141,o),
+(354,212,cs),
+(379,332,l),
+(550,332,l),
+(549,312,o),
+(548,295,o),
+(547,281,cs),
+(545,181,o),
+(519,46,o),
+(417,46,cs)
+);
+}
+);
+width = 665;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165B;
+unicode = 5723;
+},
+{
+color = 9;
+glyphname = "tsoCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(28,0,ls),
+(127,0,o),
+(156,73,o),
+(163,167,cs),
+(164,214,o),
+(161,271,o),
+(160,332,c),
+(323,332,l),
+(262,46,l),
+(200,46,l),
+(190,0,l),
+(372,0,l),
+(382,46,l),
+(318,46,l),
+(379,332,l),
+(540,332,l),
+(495,232,o),
+(446,138,o),
+(446,79,cs),
+(446,27,o),
+(475,0,o),
+(533,0,cs),
+(566,0,l),
+(578,55,l),
+(560,55,ls),
+(525,55,o),
+(508,69,o),
+(508,101,cs),
+(508,204,o),
+(681,432,o),
+(681,594,cs),
+(681,676,o),
+(636,727,o),
+(561,727,cs),
+(490,727,o),
+(435,681,o),
+(397,588,c),
+(410,587,l),
+(411,678,o),
+(371,727,o),
+(292,727,cs),
+(156,727,o),
+(113,572,o),
+(106,443,cs),
+(101,366,o),
+(110,254,o),
+(106,178,cs),
+(104,117,o),
+(91,55,o),
+(25,55,cs),
+(7,55,l),
+(-4,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(164,402,o),
+(165,419,o),
+(166,433,cs),
+(168,533,o),
+(195,668,o),
+(296,668,cs),
+(379,668,o),
+(375,573,o),
+(359,502,cs),
+(334,382,l),
+(164,382,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(415,504,ls),
+(439,614,o),
+(481,668,o),
+(545,668,cs),
+(592,668,o),
+(617,639,o),
+(617,584,cs),
+(617,527,o),
+(591,456,o),
+(557,382,c),
+(390,382,l)
+);
+}
+);
+width = 665;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165C;
+unicode = 5724;
+},
+{
+color = 9;
+glyphname = "tseCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(437,-13,o),
+(497,136,o),
+(497,229,cs),
+(497,301,o),
+(465,349,o),
+(409,362,c),
+(404,351,l),
+(533,370,o),
+(574,501,o),
+(574,587,cs),
+(574,671,o),
+(532,727,o),
+(460,727,cs),
+(364,727,o),
+(285,620,o),
+(237,620,cs),
+(217,620,o),
+(210,638,o),
+(218,674,cs),
+(226,714,l),
+(169,714,l),
+(157,661,ls),
+(144,601,o),
+(166,566,o),
+(214,566,cs),
+(237,566,o),
+(261,575,o),
+(281,590,c),
+(273,610,l),
+(224,380,l),
+(135,380,l),
+(157,481,l),
+(119,481,l),
+(66,233,l),
+(104,233,l),
+(126,334,l),
+(214,334,l),
+(165,100,l),
+(181,120,l),
+(163,135,o),
+(144,148,o),
+(119,148,cs),
+(76,148,o),
+(42,117,o),
+(28,53,cs),
+(17,0,l),
+(74,0,l),
+(82,35,ls),
+(90,73,o),
+(107,94,o),
+(128,94,cs),
+(175,94,o),
+(217,-13,o),
+(317,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(267,45,o),
+(237,75,o),
+(207,102,c),
+(255,334,l),
+(344,334,ls),
+(404,334,o),
+(437,297,o),
+(437,232,cs),
+(437,170,o),
+(402,45,o),
+(309,45,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(314,607,l),
+(356,635,o),
+(398,669,o),
+(442,669,cs),
+(488,669,o),
+(511,634,o),
+(511,578,cs),
+(511,501,o),
+(472,380,o),
+(356,380,cs),
+(266,380,l)
+);
+}
+);
+width = 569;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni165D;
+unicode = 5725;
+},
+{
+color = 9;
+glyphname = "tseeCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(437,-13,o),
+(497,136,o),
+(497,229,cs),
+(497,301,o),
+(465,349,o),
+(409,362,c),
+(404,351,l),
+(533,370,o),
+(574,501,o),
+(574,587,cs),
+(574,671,o),
+(532,727,o),
+(460,727,cs),
+(364,727,o),
+(285,620,o),
+(237,620,cs),
+(217,620,o),
+(210,638,o),
+(218,674,cs),
+(226,714,l),
+(169,714,l),
+(157,661,ls),
+(144,601,o),
+(166,566,o),
+(214,566,cs),
+(237,566,o),
+(261,575,o),
+(281,590,c),
+(267,610,l),
+(219,379,l),
+(133,379,l),
+(154,481,l),
+(119,481,l),
+(66,233,l),
+(102,233,l),
+(123,335,l),
+(209,335,l),
+(159,100,l),
+(181,120,l),
+(163,135,o),
+(144,148,o),
+(119,148,cs),
+(76,148,o),
+(42,117,o),
+(28,53,cs),
+(17,0,l),
+(74,0,l),
+(82,35,ls),
+(90,73,o),
+(107,94,o),
+(128,94,cs),
+(175,94,o),
+(217,-13,o),
+(317,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(265,45,o),
+(229,81,o),
+(199,108,c),
+(247,335,l),
+(325,335,l),
+(303,232,l),
+(336,232,l),
+(361,348,l),
+(337,335,l),
+(344,335,ls),
+(404,335,o),
+(437,297,o),
+(437,232,cs),
+(437,166,o),
+(401,45,o),
+(309,45,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(388,471,l),
+(354,471,l),
+(335,379,l),
+(257,379,l),
+(304,602,l),
+(346,629,o),
+(395,669,o),
+(442,669,cs),
+(488,669,o),
+(512,634,o),
+(512,578,cs),
+(512,501,o),
+(473,379,o),
+(357,379,cs),
+(349,379,l),
+(366,371,l)
+);
+}
+);
+width = 569;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165E;
+unicode = 5726;
+},
+{
+color = 9;
+glyphname = "tsiCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(437,-13,o),
+(497,136,o),
+(497,229,cs),
+(497,301,o),
+(465,349,o),
+(409,362,c),
+(403,351,l),
+(533,370,o),
+(574,501,o),
+(574,587,cs),
+(574,671,o),
+(532,727,o),
+(460,727,cs),
+(364,727,o),
+(285,620,o),
+(237,620,cs),
+(217,620,o),
+(210,638,o),
+(218,674,cs),
+(226,714,l),
+(169,714,l),
+(157,661,ls),
+(144,601,o),
+(166,566,o),
+(214,566,cs),
+(237,566,o),
+(261,575,o),
+(282,590,c),
+(268,610,l),
+(219,379,l),
+(133,379,l),
+(154,481,l),
+(119,481,l),
+(66,233,l),
+(102,233,l),
+(123,335,l),
+(209,335,l),
+(160,100,l),
+(182,119,l),
+(163,135,o),
+(144,148,o),
+(119,148,cs),
+(76,148,o),
+(42,117,o),
+(28,53,cs),
+(17,0,l),
+(74,0,l),
+(82,35,ls),
+(90,73,o),
+(107,94,o),
+(128,94,cs),
+(175,94,o),
+(217,-13,o),
+(317,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(265,45,o),
+(229,80,o),
+(200,108,c),
+(247,335,l),
+(293,335,l),
+(299,313,o),
+(318,296,o),
+(342,296,cs),
+(366,296,o),
+(387,313,o),
+(392,340,c),
+(333,335,l),
+(344,335,ls),
+(404,335,o),
+(437,297,o),
+(437,232,cs),
+(437,166,o),
+(401,45,o),
+(309,45,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(394,397,o),
+(371,418,o),
+(345,418,cs),
+(322,418,o),
+(301,401,o),
+(296,379,c),
+(258,379,l),
+(304,602,l),
+(346,629,o),
+(395,669,o),
+(442,669,cs),
+(488,669,o),
+(512,633,o),
+(512,578,cs),
+(512,501,o),
+(473,379,o),
+(357,379,cs),
+(341,379,l),
+(396,370,l)
+);
+}
+);
+width = 569;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165F;
+unicode = 5727;
+},
+{
+color = 9;
+glyphname = "tsaCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(252,-13,o),
+(332,94,o),
+(380,94,cs),
+(400,94,o),
+(406,76,o),
+(398,40,cs),
+(390,0,l),
+(447,0,l),
+(459,53,ls),
+(472,113,o),
+(450,148,o),
+(402,148,cs),
+(379,148,o),
+(356,138,o),
+(335,124,c),
+(344,104,l),
+(392,334,l),
+(481,334,l),
+(459,233,l),
+(498,233,l),
+(550,480,l),
+(512,480,l),
+(491,380,l),
+(403,380,l),
+(452,614,l),
+(435,594,l),
+(454,579,o),
+(472,566,o),
+(497,566,cs),
+(540,566,o),
+(574,597,o),
+(588,661,cs),
+(599,714,l),
+(542,714,l),
+(535,679,ls),
+(527,641,o),
+(509,620,o),
+(488,620,cs),
+(442,620,o),
+(400,727,o),
+(300,727,cs),
+(180,727,o),
+(119,577,o),
+(119,484,cs),
+(119,413,o),
+(152,365,o),
+(207,352,c),
+(213,363,l),
+(83,344,o),
+(43,213,o),
+(43,127,cs),
+(43,43,o),
+(85,-13,o),
+(156,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(129,45,o),
+(106,80,o),
+(106,136,cs),
+(106,213,o),
+(145,334,o),
+(260,334,cs),
+(350,334,l),
+(303,107,l),
+(261,79,o),
+(218,45,o),
+(174,45,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(212,380,o),
+(180,417,o),
+(180,482,cs),
+(180,544,o),
+(214,669,o),
+(307,669,cs),
+(349,669,o),
+(380,639,o),
+(409,612,c),
+(361,380,l),
+(273,380,ls)
+);
+}
+);
+width = 568;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1660;
+unicode = 5728;
+},
+{
+color = 9;
+glyphname = "chuCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(223,-13,o),
+(279,33,o),
+(317,126,c),
+(303,127,l),
+(302,36,o),
+(343,-13,o),
+(422,-13,cs),
+(558,-13,o),
+(600,142,o),
+(608,271,cs),
+(612,348,o),
+(603,460,o),
+(607,536,cs),
+(610,597,o),
+(622,659,o),
+(688,659,cs),
+(706,659,l),
+(718,714,l),
+(686,714,ls),
+(587,714,o),
+(557,641,o),
+(551,547,cs),
+(546,475,o),
+(550,359,o),
+(547,281,cs),
+(545,181,o),
+(519,46,o),
+(417,46,cs),
+(334,46,o),
+(339,141,o),
+(354,212,cs),
+(451,668,l),
+(514,668,l),
+(524,714,l),
+(341,714,l),
+(331,668,l),
+(395,668,l),
+(298,210,ls),
+(275,100,o),
+(232,46,o),
+(169,46,cs),
+(121,46,o),
+(96,75,o),
+(96,130,cs),
+(96,270,o),
+(267,524,o),
+(267,635,cs),
+(267,687,o),
+(238.003,714,o),
+(180,714,cs),
+(147,714,l),
+(136,659,l),
+(154,659,ls),
+(189,659,o),
+(205,645,o),
+(205,613,cs),
+(205,510,o),
+(32,282,o),
+(32,120,cs),
+(32,38,o),
+(78,-13,o),
+(153,-13,cs)
+);
+}
+);
+width = 665;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164E;
+unicode = 5729;
+},
+{
+color = 9;
+glyphname = "choCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(28,0,ls),
+(127,0,o),
+(156,73,o),
+(163,167,cs),
+(167,239,o),
+(163,355,o),
+(166,433,cs),
+(168,533,o),
+(195,668,o),
+(296,668,cs),
+(379,668,o),
+(375,573,o),
+(359,502,cs),
+(262,46,l),
+(200,46,l),
+(190,0,l),
+(372,0,l),
+(382,46,l),
+(318,46,l),
+(415,504,ls),
+(439,614,o),
+(481,668,o),
+(545,668,cs),
+(592,668,o),
+(617,639,o),
+(617,584,cs),
+(617,444,o),
+(446,190,o),
+(446,79,cs),
+(446,27,o),
+(475,0,o),
+(533,0,cs),
+(566,0,l),
+(578,55,l),
+(560,55,ls),
+(525,55,o),
+(508,69,o),
+(508,101,cs),
+(508,204,o),
+(681,432,o),
+(681,594,cs),
+(681,676,o),
+(636,727,o),
+(561,727,cs),
+(490,727,o),
+(435,681,o),
+(397,588,c),
+(410,587,l),
+(411,678,o),
+(371,727,o),
+(292,727,cs),
+(156,727,o),
+(113,572,o),
+(106,443,cs),
+(101,366,o),
+(110,254,o),
+(106,178,cs),
+(104,117,o),
+(91,55,o),
+(25,55,cs),
+(7,55,l),
+(-4,0,l)
+);
+}
+);
+width = 665;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5730;
+},
+{
+color = 9;
+glyphname = "cheCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(437,-13,o),
+(497,136,o),
+(497,229,cs),
+(497,301,o),
+(465,349,o),
+(409,362,c),
+(404,351,l),
+(533,370,o),
+(574,501,o),
+(574,587,cs),
+(574,671,o),
+(532,727,o),
+(460,727,cs),
+(364,727,o),
+(285,620,o),
+(237,620,cs),
+(217,620,o),
+(210,638,o),
+(218,674,cs),
+(226,714,l),
+(169,714,l),
+(157,661,ls),
+(144,601,o),
+(166,565,o),
+(214,565,cs),
+(291,565,o),
+(365,669,o),
+(441,669,cs),
+(487,669,o),
+(510,634,o),
+(510,578,cs),
+(510,501,o),
+(471,384,o),
+(355,384,cs),
+(136,384,l),
+(157,481,l),
+(119,481,l),
+(66,233,l),
+(104,233,l),
+(125,330,l),
+(343,330,ls),
+(403,330,o),
+(436,293,o),
+(436,232,cs),
+(436,170,o),
+(401,45,o),
+(308,45,cs),
+(229,45,o),
+(192.006,148.992,o),
+(119,149,cs),
+(76,149,o),
+(43,118,o),
+(28,53,cs),
+(17,0,l),
+(74,0,l),
+(82,35,ls),
+(90,73,o),
+(107,94,o),
+(128,94,cs),
+(175,94,o),
+(217,-13,o),
+(317,-13,cs)
+);
+}
+);
+width = 569;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni1663;
+unicode = 5731;
+},
+{
+color = 9;
+glyphname = "cheeCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(437,-13,o),
+(497,136,o),
+(497,229,cs),
+(497,301,o),
+(465,349,o),
+(409,362,c),
+(404,351,l),
+(533,370,o),
+(574,501,o),
+(574,587,cs),
+(574,671,o),
+(532,727,o),
+(460,727,cs),
+(364,727,o),
+(285,620,o),
+(237,620,cs),
+(217,620,o),
+(210,638,o),
+(218,674,cs),
+(226,714,l),
+(169,714,l),
+(157,661,ls),
+(144,601,o),
+(166,565,o),
+(214,565,cs),
+(291,565,o),
+(365,670,o),
+(441,670,cs),
+(487,670,o),
+(511,634,o),
+(511,578,cs),
+(511,501,o),
+(473,380,o),
+(357,380,cs),
+(305,380,l),
+(319,365,l),
+(340,468,l),
+(302,468,l),
+(283,380,l),
+(135,380,l),
+(157,481,l),
+(119,481,l),
+(66,233,l),
+(104,233,l),
+(126,334,l),
+(274,334,l),
+(253,236,l),
+(292,236,l),
+(315,351,l),
+(297,334,l),
+(347,334,ls),
+(407,334,o),
+(437,293,o),
+(437,232,cs),
+(437,170,o),
+(402,44,o),
+(308,44,cs),
+(229,44,o),
+(192,149,o),
+(119,149,cs),
+(76,149,o),
+(43,118,o),
+(28,53,cs),
+(17,0,l),
+(74,0,l),
+(82,35,ls),
+(90,73,o),
+(107,94,o),
+(128,94,cs),
+(175,94,o),
+(217,-13,o),
+(317,-13,cs)
+);
+}
+);
+width = 569;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1664;
+unicode = 5732;
+},
+{
+color = 9;
+glyphname = "chiCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(437,-13,o),
+(497,136,o),
+(497,229,cs),
+(497,301,o),
+(465,349,o),
+(409,362,c),
+(404,351,l),
+(533,370,o),
+(574,501,o),
+(574,587,cs),
+(574,671,o),
+(532,727,o),
+(460,727,cs),
+(364,727,o),
+(285,620,o),
+(237,620,cs),
+(217,620,o),
+(210,638,o),
+(218,674,cs),
+(226,714,l),
+(169,714,l),
+(157,661,ls),
+(144,601,o),
+(166,565,o),
+(214,565,cs),
+(291,565,o),
+(365,670,o),
+(441,670,cs),
+(487,670,o),
+(511,634,o),
+(511,578,cs),
+(511,501,o),
+(473,380,o),
+(360,380,cs),
+(318,380,l),
+(340,368,l),
+(337,397,o),
+(312,418,o),
+(282,418,cs),
+(257,418,o),
+(236,402,o),
+(227,380,c),
+(135,380,l),
+(157,481,l),
+(119,481,l),
+(66,233,l),
+(104,233,l),
+(126,334,l),
+(227,334,l),
+(235,313,o),
+(255,296,o),
+(282,296,cs),
+(312,296,o),
+(337,318,o),
+(341,348,c),
+(314,334,l),
+(349,334,ls),
+(406,334,o),
+(437,296,o),
+(437,232,cs),
+(437,170,o),
+(402,44,o),
+(308,44,cs),
+(229,44,o),
+(192,149,o),
+(119,149,cs),
+(76,149,o),
+(43,118,o),
+(28,53,cs),
+(17,0,l),
+(74,0,l),
+(82,35,ls),
+(90,73,o),
+(107,94,o),
+(128,94,cs),
+(175,94,o),
+(217,-13,o),
+(317,-13,cs)
+);
+}
+);
+width = 569;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1665;
+unicode = 5733;
+},
+{
+color = 9;
+glyphname = "chaCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(252,-11,o),
+(332,96,o),
+(380,96,cs),
+(400,96,o),
+(406,78,o),
+(398,42,cs),
+(390,2,l),
+(447,2,l),
+(459,55,ls),
+(472,115,o),
+(450,151,o),
+(402,151,cs),
+(325,151,o),
+(251,47,o),
+(175,47,cs),
+(129,47,o),
+(106,83,o),
+(106,138,cs),
+(106,215,o),
+(145,332,o),
+(261,332,cs),
+(480,332,l),
+(460,235,l),
+(498,235,l),
+(550,483,l),
+(512,483,l),
+(492,386,l),
+(274,386,ls),
+(213,386,o),
+(181,423,o),
+(181,484,cs),
+(181,547,o),
+(215,671,o),
+(308,671,cs),
+(387,671,o),
+(424,567,o),
+(497,567,cs),
+(540,567,o),
+(574,598,o),
+(588,663,cs),
+(600,716,l),
+(542,716,l),
+(535,681,ls),
+(527,643,o),
+(509,622,o),
+(489,622,cs),
+(442,622,o),
+(400,729,o),
+(300,729,cs),
+(180,729,o),
+(119,580,o),
+(119,487,cs),
+(119,415,o),
+(152,367,o),
+(207,354,c),
+(213,365,l),
+(83,346,o),
+(43,215,o),
+(43,129,cs),
+(43,45,o),
+(85,-11,o),
+(156,-11,cs)
+);
+}
+);
+width = 568;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1666;
+unicode = 5734;
+},
+{
+color = 9;
+glyphname = "ttsuCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(223,-13,o),
+(278,33,o),
+(317,126,c),
+(303,127,l),
+(302,36,o),
+(343,-13,o),
+(422,-13,cs),
+(558,-13,o),
+(600,142,o),
+(608,271,cs),
+(612,348,o),
+(603,460,o),
+(607,536,cs),
+(610,597,o),
+(622,659,o),
+(688,659,cs),
+(706,659,l),
+(718,714,l),
+(686,714,ls),
+(587,714,o),
+(557,641,o),
+(551,547,cs),
+(549,529,o),
+(547,513,o),
+(547,495,c),
+(572,537,l),
+(394,402,l),
+(451,668,l),
+(514,668,l),
+(524,714,l),
+(341,714,l),
+(331,668,l),
+(395,668,l),
+(339,402,l),
+(214,534,l),
+(226,490,l),
+(250,548,o),
+(267,599,o),
+(267,635,cs),
+(267,687,o),
+(238.003,714,o),
+(180,714,cs),
+(147,714,l),
+(136,659,l),
+(154,659,ls),
+(189,659,o),
+(205,645,o),
+(205,613,cs),
+(205,510,o),
+(32,282,o),
+(32,120,cs),
+(32,38,o),
+(78,-13,o),
+(153,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(121,46,o),
+(96,75,o),
+(96,130,cs),
+(96,222,o),
+(166,349,o),
+(215,460,c),
+(326,343,l),
+(298,210,ls),
+(275,100,o),
+(232,46,o),
+(169,46,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(334,46,o),
+(339,141,o),
+(354,212,cs),
+(380,334,l),
+(545,458,l),
+(545,399,o),
+(548,337,o),
+(547,281,cs),
+(545,181,o),
+(519,46,o),
+(417,46,cs)
+);
+}
+);
+width = 665;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1667;
+unicode = 5735;
+},
+{
+color = 9;
+glyphname = "ttsoCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(28,0,ls),
+(127,0,o),
+(156,73,o),
+(163,167,cs),
+(164,185,o),
+(166,201,o),
+(167,219,c),
+(141,177,l),
+(319,312,l),
+(262,46,l),
+(200,46,l),
+(190,0,l),
+(372,0,l),
+(382,46,l),
+(318,46,l),
+(375,312,l),
+(500,180,l),
+(488,224,l),
+(464,166,o),
+(446,115,o),
+(446,79,cs),
+(446,27,o),
+(475,0,o),
+(533,0,cs),
+(566,0,l),
+(578,55,l),
+(560,55,ls),
+(525,55,o),
+(508,69,o),
+(508,101,cs),
+(508,204,o),
+(681,432,o),
+(681,594,cs),
+(681,676,o),
+(636,727,o),
+(561,727,cs),
+(490,727,o),
+(435,681,o),
+(397,588,c),
+(410,587,l),
+(411,678,o),
+(371,727,o),
+(292,727,cs),
+(156,727,o),
+(113,572,o),
+(106,443,cs),
+(101,366,o),
+(110,254,o),
+(106,178,cs),
+(104,117,o),
+(91,55,o),
+(25,55,cs),
+(7,55,l),
+(-4,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(169,315,o),
+(165,377,o),
+(166,433,cs),
+(168,533,o),
+(195,668,o),
+(296,668,cs),
+(379,668,o),
+(375,573,o),
+(359,502,cs),
+(333,380,l),
+(169,256,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(387,371,l),
+(415,504,ls),
+(439,614,o),
+(481,668,o),
+(545,668,cs),
+(592,668,o),
+(617,639,o),
+(617,584,cs),
+(617,492,o),
+(547,365,o),
+(498,254,c)
+);
+}
+);
+width = 665;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1668;
+unicode = 5736;
+},
+{
+color = 9;
+glyphname = "ttseCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(436,-13,o),
+(497,136,o),
+(497,229,cs),
+(497,301,o),
+(465,349,o),
+(409,362,c),
+(403,351,l),
+(533,370,o),
+(574,501,o),
+(574,587,cs),
+(574,670,o),
+(532,727,o),
+(460,727,cs),
+(364,727,o),
+(284,620,o),
+(236,620,cs),
+(216,620,o),
+(210,638,o),
+(218,674,cs),
+(226,714,l),
+(169,714,l),
+(157,661,ls),
+(144,601,o),
+(166,565,o),
+(214,565,cs),
+(220,565,o),
+(226,565,o),
+(233,567,c),
+(204,596,l),
+(228,380,l),
+(135,380,l),
+(157,481,l),
+(119,481,l),
+(66,233,l),
+(104,233,l),
+(126,334,l),
+(220,334,l),
+(103,120,l),
+(147,144,l),
+(139,147,o),
+(130,149,o),
+(119,149,cs),
+(75,149,o),
+(42,117,o),
+(28,53,cs),
+(17,0,l),
+(74,0,l),
+(81,35,ls),
+(89,73,o),
+(107,94,o),
+(128,94,cs),
+(174,94,o),
+(216,-13,o),
+(316,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(243,44,o),
+(208,115,o),
+(162,136,c),
+(268,334,l),
+(349,334,ls),
+(407,334,o),
+(438,296,o),
+(438,236,cs),
+(438,172,o),
+(402,44,o),
+(308,44,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(252,574,l),
+(312,590,o),
+(375,670,o),
+(441,670,cs),
+(488,670,o),
+(511,633,o),
+(511,577,cs),
+(511,502,o),
+(473,380,o),
+(358,380,cs),
+(273,380,l)
+);
+}
+);
+width = 569;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1669;
+unicode = 5737;
+},
+{
+color = 9;
+glyphname = "ttseeCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(436,-13,o),
+(497,136,o),
+(497,229,cs),
+(497,301,o),
+(465,349,o),
+(409,362,c),
+(403,351,l),
+(533,370,o),
+(574,501,o),
+(574,587,cs),
+(574,670,o),
+(532,727,o),
+(460,727,cs),
+(364,727,o),
+(284,620,o),
+(236,620,cs),
+(216,620,o),
+(210,638,o),
+(218,674,cs),
+(226,714,l),
+(169,714,l),
+(157,661,ls),
+(144,601,o),
+(166,565,o),
+(214,565,cs),
+(220,565,o),
+(226,565,o),
+(233,567,c),
+(202,596,l),
+(225,380,l),
+(135,380,l),
+(157,481,l),
+(119,481,l),
+(66,233,l),
+(104,233,l),
+(126,334,l),
+(217,334,l),
+(101,120,l),
+(147,144,l),
+(139,147,o),
+(130,149,o),
+(119,149,cs),
+(75,149,o),
+(42,117,o),
+(28,53,cs),
+(17,0,l),
+(74,0,l),
+(81,35,ls),
+(89,73,o),
+(107,94,o),
+(128,94,cs),
+(174,94,o),
+(216,-13,o),
+(316,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(242,44,o),
+(203,120,o),
+(157,140,c),
+(262,334,l),
+(318,334,l),
+(297,232,l),
+(333,232,l),
+(356,342,l),
+(341,334,l),
+(349,334,ls),
+(407,334,o),
+(438,296,o),
+(438,236,cs),
+(438,172,o),
+(402,44,o),
+(308,44,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(383,471,l),
+(347,471,l),
+(328,380,l),
+(266,380,l),
+(245,571,l),
+(305,585,o),
+(374,670,o),
+(441,670,cs),
+(488,670,o),
+(511,633,o),
+(511,577,cs),
+(511,502,o),
+(473,380,o),
+(358,380,cs),
+(351,380,l),
+(362,371,l)
+);
+}
+);
+width = 569;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166A;
+unicode = 5738;
+},
+{
+color = 9;
+glyphname = "ttsiCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(436,-13,o),
+(497,136,o),
+(497,229,cs),
+(497,301,o),
+(465,349,o),
+(409,362,c),
+(403,351,l),
+(533,370,o),
+(574,501,o),
+(574,587,cs),
+(574,670,o),
+(532,727,o),
+(460,727,cs),
+(364,727,o),
+(284,620,o),
+(236,620,cs),
+(216,620,o),
+(210,638,o),
+(218,674,cs),
+(226,714,l),
+(169,714,l),
+(157,661,ls),
+(144,601,o),
+(166,565,o),
+(214,565,cs),
+(220,565,o),
+(226,565,o),
+(233,567,c),
+(202,596,l),
+(225,380,l),
+(135,380,l),
+(157,481,l),
+(119,481,l),
+(66,233,l),
+(104,233,l),
+(126,334,l),
+(217,334,l),
+(101,120,l),
+(147,144,l),
+(139,147,o),
+(130,149,o),
+(119,149,cs),
+(75,149,o),
+(42,117,o),
+(28,53,cs),
+(17,0,l),
+(74,0,l),
+(81,35,ls),
+(89,73,o),
+(107,94,o),
+(128,94,cs),
+(174,94,o),
+(216,-13,o),
+(316,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(242,44,o),
+(204,119,o),
+(157,140,c),
+(262,334,l),
+(279,334,l),
+(283,319,o),
+(302,296,o),
+(330,296,cs),
+(358,296,o),
+(378,318,o),
+(384,342,c),
+(341,334,l),
+(348,334,ls),
+(406,334,o),
+(438,296,o),
+(438,236,cs),
+(438,172,o),
+(402,44,o),
+(308,44,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(377,403,o),
+(353,418,o),
+(330,418,cs),
+(306,418,o),
+(284,400,o),
+(279,380,c),
+(267,380,l),
+(246,571,l),
+(306,586,o),
+(374,670,o),
+(441,670,cs),
+(488,670,o),
+(511,633,o),
+(511,577,cs),
+(511,502,o),
+(473,380,o),
+(358,380,cs),
+(351,380,l),
+(384,371,l)
+);
+}
+);
+width = 569;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166B;
+unicode = 5739;
+},
+{
+color = 9;
+glyphname = "ttsaCarrier-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(253,-13,o),
+(332,94,o),
+(380,94,cs),
+(400,94,o),
+(407,76,o),
+(399,40,cs),
+(390,0,l),
+(448,0,l),
+(459,53,ls),
+(473,113,o),
+(451,149,o),
+(403,149,cs),
+(396,149,o),
+(390,149,o),
+(383,147,c),
+(412,118,l),
+(389,334,l),
+(481,334,l),
+(459,233,l),
+(498,233,l),
+(550,481,l),
+(512,481,l),
+(491,380,l),
+(397,380,l),
+(513,594,l),
+(469,570,l),
+(478,567,o),
+(487,565,o),
+(497,565,cs),
+(541,565,o),
+(574,597,o),
+(588,661,cs),
+(600,714,l),
+(542,714,l),
+(535,679,ls),
+(527,641,o),
+(510,620,o),
+(489,620,cs),
+(442,620,o),
+(400,727,o),
+(300,727,cs),
+(180,727,o),
+(119,578,o),
+(119,485,cs),
+(119,413,o),
+(152,365,o),
+(207,352,c),
+(213,363,l),
+(83,344,o),
+(43,213,o),
+(43,127,cs),
+(43,44,o),
+(85,-13,o),
+(156,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(129,44,o),
+(105,81,o),
+(105,137,cs),
+(105,212,o),
+(143,334,o),
+(258,334,cs),
+(344,334,l),
+(364,140,l),
+(305,124,o),
+(242,44,o),
+(175,44,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(210,380,o),
+(179,418,o),
+(179,478,cs),
+(179,542,o),
+(214,670,o),
+(308,670,cs),
+(374,670,o),
+(408,599,o),
+(454,578,c),
+(348,380,l),
+(267,380,ls)
+);
+}
+);
+width = 568;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni166C;
+unicode = 5740;
+},
+{
+glyphname = "qai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (252,0);
+ref = "ke-canadian";
+}
+);
+width = 718;
+}
+);
+note = uni166F;
+unicode = 5743;
+},
+{
+glyphname = "ngai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (488,0);
+ref = "ce-canadian";
+}
+);
+width = 948;
+}
+);
+note = uni1670;
+unicode = 5744;
+},
+{
+glyphname = "nngi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (711,0);
+ref = "ci-canadian";
+}
+);
+width = 1171;
+}
+);
+note = uni1671;
+unicode = 5745;
+},
+{
+glyphname = "nngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (711,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (886,0);
+ref = dot_top;
+}
+);
+width = 1171;
+}
+);
+note = uni1672;
+unicode = 5746;
+},
+{
+glyphname = "nngo-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (711,0);
+ref = "ce-canadian";
+}
+);
+width = 1171;
+}
+);
+note = uni1673;
+unicode = 5747;
+},
+{
+glyphname = "nngoo-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (711,0);
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (878,0);
+ref = dot_top;
+}
+);
+width = 1171;
+}
+);
+note = uni1674;
+unicode = 5748;
+},
+{
+glyphname = "nnga-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (711,0);
+ref = "ca-canadian";
+}
+);
+width = 1171;
+}
+);
+note = uni1675;
+unicode = 5749;
+},
+{
+glyphname = "nngaa-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (711,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (743,0);
+ref = dot_top;
+}
+);
+width = 1171;
+}
+);
+note = uni1676;
+unicode = 5750;
+},
+{
+glyphname = "thweeWoodScree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (485,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 660;
+}
+);
+note = uni1677;
+unicode = 5751;
+},
+{
+glyphname = "thwiWoodScree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (485,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 660;
+}
+);
+note = uni1678;
+unicode = 5752;
+},
+{
+glyphname = "thwiiWoodScree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (69,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (485,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 660;
+}
+);
+note = uni1679;
+unicode = 5753;
+},
+{
+glyphname = "thwoWoodScree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (485,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 660;
+}
+);
+note = uni167A;
+unicode = 5754;
+},
+{
+glyphname = "thwooWoodScree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (295,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (485,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 660;
+}
+);
+note = uni167B;
+unicode = 5755;
+},
+{
+glyphname = "thwaWoodScree-canadian";
+lastChange = "2023-01-13 15:30:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = middle_right_can;
+pos = (486,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 662;
+}
+);
+note = uni167C;
+unicode = 5756;
+},
+{
+glyphname = "thwaaWoodScree-canadian";
+lastChange = "2023-01-13 15:30:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (69,0);
+ref = dot_top;
+},
+{
+anchor = middle_right_can;
+pos = (486,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 662;
+}
+);
+note = uni167D;
+unicode = 5757;
+},
+{
+glyphname = "wBlackfoot-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(371,584,l),
+(380,625,l),
+(134,625,l),
+(125,584,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(341,446,l),
+(350,487,l),
+(104,487,l),
+(95,446,l)
+);
+}
+);
+width = 351;
+}
+);
+metricRight = "=|";
+note = uni167F;
+unicode = 5759;
+},
+{
+glyphname = "oy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-28,0);
+ref = ring_top.canadian;
+}
+);
+width = 539;
+}
+);
+note = uni18B0;
+unicode = 6320;
+},
+{
+glyphname = "ay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (327,0);
+ref = ring_top.canadian;
+}
+);
+width = 539;
+}
+);
+note = uni18B1;
+unicode = 6321;
+},
+{
+glyphname = "aay-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (124,0);
+ref = ring_top.canadian;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (385,0);
+ref = dot_top;
+}
+);
+width = 539;
+}
+);
+note = uni18B2;
+unicode = 6322;
+},
+{
+glyphname = "way-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (503,0);
+ref = ring_top.canadian;
+}
+);
+width = 714;
+}
+);
+note = uni18B3;
+unicode = 6323;
+},
+{
+glyphname = "poy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-47,0);
+ref = ring_top.canadian;
+}
+);
+width = 512;
+}
+);
+note = uni18B4;
+unicode = 6324;
+},
+{
+glyphname = "pay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (322,0);
+ref = ring_top.canadian;
+}
+);
+width = 512;
+}
+);
+note = uni18B5;
+unicode = 6325;
+},
+{
+glyphname = "pwoy-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (128,0);
+ref = ring_top.canadian;
+}
+);
+width = 687;
+}
+);
+note = uni18B6;
+unicode = 6326;
+},
+{
+glyphname = "tay-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (140,0);
+ref = ring_top.canadian;
+}
+);
+width = 469;
+}
+);
+note = uni18B7;
+unicode = 6327;
+},
+{
+glyphname = "kay-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-26,0);
+ref = ring_top.canadian;
+}
+);
+width = 466;
+}
+);
+note = uni18B8;
+unicode = 6328;
+},
+{
+glyphname = "kway-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (150,0);
+ref = ring_top.canadian;
+}
+);
+width = 641;
+}
+);
+note = uni18B9;
+unicode = 6329;
+},
+{
+glyphname = "may-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-22,0);
+ref = ring_top.canadian;
+}
+);
+width = 412;
+}
+);
+note = uni18BA;
+unicode = 6330;
+},
+{
+glyphname = "noy-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (238,-206);
+ref = ring_top.canadian;
+}
+);
+width = 637;
+}
+);
+note = uni18BB;
+unicode = 6331;
+},
+{
+glyphname = "nay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (73,-206);
+ref = ring_top.canadian;
+}
+);
+width = 637;
+}
+);
+note = uni18BC;
+unicode = 6332;
+},
+{
+glyphname = "lay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (74,-206);
+ref = ring_top.canadian;
+}
+);
+width = 637;
+}
+);
+note = uni18BD;
+unicode = 6333;
+},
+{
+glyphname = "soy-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (208,0);
+ref = ring_top.canadian;
+}
+);
+width = 423;
+}
+);
+note = uni18BE;
+unicode = 6334;
+},
+{
+glyphname = "say-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-21,0);
+ref = ring_top.canadian;
+}
+);
+width = 423;
+}
+);
+note = uni18BF;
+unicode = 6335;
+},
+{
+glyphname = "shoy-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (204,-206);
+ref = ring_top.canadian;
+}
+);
+width = 737;
+}
+);
+note = uni18C0;
+unicode = 6336;
+},
+{
+glyphname = "shay-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (207,-206);
+ref = ring_top.canadian;
+}
+);
+width = 737;
+}
+);
+note = uni18C1;
+unicode = 6337;
+},
+{
+glyphname = "shwoy-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (380,-206);
+ref = ring_top.canadian;
+}
+);
+width = 913;
+}
+);
+note = uni18C2;
+unicode = 6338;
+},
+{
+glyphname = "yoy-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (237,0);
+ref = ring_top.canadian;
+}
+);
+width = 448;
+}
+);
+note = uni18C3;
+unicode = 6339;
+},
+{
+glyphname = "yay-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-26,0);
+ref = ring_top.canadian;
+}
+);
+width = 448;
+}
+);
+note = uni18C4;
+unicode = 6340;
+},
+{
+glyphname = "ray-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (120,0);
+ref = ring_top.canadian;
+}
+);
+width = 424;
+}
+);
+note = uni18C5;
+unicode = 6341;
+},
+{
+glyphname = "nwi-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ni-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni18C6;
+unicode = 6342;
+},
+{
+glyphname = "nwiOjibway-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni18C7;
+unicode = 6343;
+},
+{
+glyphname = "nwii-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (311,-206);
+ref = dot_top;
+}
+);
+width = 812;
+}
+);
+note = uni18C8;
+unicode = 6344;
+},
+{
+glyphname = "nwiiOjibway-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (136,-206);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni18C9;
+unicode = 6345;
+},
+{
+glyphname = "nwo-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "no-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni18CA;
+unicode = 6346;
+},
+{
+glyphname = "nwoOjibway-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni18CB;
+unicode = 6347;
+},
+{
+glyphname = "nwoo-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (471,-206);
+ref = dot_top;
+}
+);
+width = 812;
+}
+);
+note = uni18CC;
+unicode = 6348;
+},
+{
+glyphname = "nwooOjibway-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (296,-206);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni18CD;
+unicode = 6349;
+},
+{
+glyphname = "rwee-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "reRCree-canadian";
+}
+);
+width = 847;
+}
+);
+note = uni18CE;
+unicode = 6350;
+},
+{
+glyphname = "rwi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ri-canadian";
+}
+);
+width = 847;
+}
+);
+note = uni18CF;
+unicode = 6351;
+},
+{
+glyphname = "rwii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (308,-206);
+ref = dot_top;
+}
+);
+width = 847;
+}
+);
+note = uni18D0;
+unicode = 6352;
+},
+{
+glyphname = "rwo-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ro-canadian";
+}
+);
+width = 600;
+}
+);
+note = uni18D1;
+unicode = 6353;
+},
+{
+glyphname = "rwoo-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (300,0);
+ref = dot_top;
+}
+);
+width = 600;
+}
+);
+note = uni18D2;
+unicode = 6354;
+},
+{
+glyphname = "rwa-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ra-canadian";
+}
+);
+width = 600;
+}
+);
+note = uni18D3;
+unicode = 6355;
+},
+{
+glyphname = "pOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,357,l),
+(261,663,l),
+(233,663,l),
+(265,357,l),
+(305,357,l),
+(308,369,l),
+(263,714,l),
+(250,714,l),
+(57,369,l),
+(55,357,l)
+);
+}
+);
+width = 313;
+}
+);
+metricLeft = "kkCarrier-canadian";
+note = uni18D4;
+unicode = 6356;
+},
+{
+glyphname = "tOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 329;
+}
+);
+metricRight = "=|";
+note = uni1422;
+unicode = 6357;
+},
+{
+glyphname = "kOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(122,357,l),
+(159,533,l),
+(144,525,l),
+(143,479,o),
+(169,450,o),
+(209,450,cs),
+(293,450,o),
+(322,569,o),
+(322,625,cs),
+(322,685,o),
+(293,721,o),
+(241,721,cs),
+(183,721,o),
+(144,678,o),
+(126,590,cs),
+(76,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(177,487,o),
+(164,508,o),
+(164,543,cs),
+(164,578,o),
+(180,683,o),
+(241,683,cs),
+(267,683,o),
+(280,663,o),
+(280,628,cs),
+(280,588,o),
+(262,487,o),
+(204,487,cs)
+);
+}
+);
+width = 288;
+}
+);
+metricLeft = "k-canadian";
+metricRight = "k-canadian";
+note = uni18D6;
+unicode = 6358;
+},
+{
+glyphname = "cOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,357,l),
+(175,606,ls),
+(186,660,o),
+(208,681,o),
+(241,681,cs),
+(279,681,o),
+(290,647,o),
+(280,602,cs),
+(273,569,l),
+(315,569,l),
+(321,597,ls),
+(335,666,o),
+(309,720,o),
+(239,720,cs),
+(180,720,o),
+(144,677,o),
+(129,604,cs),
+(76,357,l)
+);
+}
+);
+width = 279;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni18D7;
+unicode = 6359;
+},
+{
+glyphname = "mOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,357,l),
+(188,670,l),
+(315,670,l),
+(325,714,l),
+(152,714,l),
+(76,357,l)
+);
+}
+);
+width = 254;
+}
+);
+metricLeft = "m-canadian";
+metricRight = "m-canadian";
+note = uni18D8;
+unicode = 6360;
+},
+{
+glyphname = "nOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(278,443,o),
+(309,552,o),
+(309,616,cs),
+(309,639,o),
+(305,669,o),
+(281,686,c),
+(277,670,l),
+(422,670,l),
+(432,714,l),
+(231,714,ls),
+(140,714,o),
+(110,606,o),
+(110,540,cs),
+(110,478,o),
+(141,443,o),
+(191,443,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(165,480,o),
+(150,500,o),
+(150,539,cs),
+(150,581,o),
+(167,677,o),
+(225,677,cs),
+(254,677,o),
+(269,657,o),
+(269,618,cs),
+(269,576,o),
+(251,480,o),
+(194,480,cs)
+);
+}
+);
+width = 361;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "n-canadian";
+note = uni18D9;
+unicode = 6361;
+},
+{
+glyphname = "sOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,357,l),
+(152,501,l),
+(121,482,l),
+(147,482,ls),
+(235,482,o),
+(285,527,o),
+(305,624,cs),
+(324,714,l),
+(279,714,l),
+(261,629,ls),
+(245,553,o),
+(210,520,o),
+(144,520,cs),
+(111,520,l),
+(76,357,l)
+);
+}
+);
+width = 276;
+}
+);
+metricLeft = "s-canadian";
+metricRight = "s-canadian";
+note = uni18DA;
+unicode = 6362;
+},
+{
+color = 1;
+glyphname = "shOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(216,352,o),
+(251,392,o),
+(273,468,cs),
+(313,607,ls),
+(327,655,o),
+(346,682,o),
+(381,682,cs),
+(416,682,o),
+(430,659,o),
+(418,610,cs),
+(410,570,l),
+(452,570,l),
+(459,602,ls),
+(476,675,o),
+(447,721,o),
+(383,721,cs),
+(325,721,o),
+(290,681,o),
+(268,606,cs),
+(227,466,ls),
+(214,418,o),
+(194,391,o),
+(160,391,cs),
+(124,391,o),
+(111,415,o),
+(122,464,cs),
+(131,503,l),
+(88,503,l),
+(81,471,ls),
+(65,398,o),
+(94,352,o),
+(157,352,cs)
+);
+}
+);
+width = 416;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "c-canadian";
+note = uni18DB;
+unicode = 6363;
+},
+{
+color = 9;
+glyphname = "easternw-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (-37,-318);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (103,0);
+ref = "glottalstop-canadian";
+}
+);
+width = 450;
+}
+);
+note = uni18DC;
+unicode = 6364;
+},
+{
+color = 9;
+glyphname = "westernw-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (624,-318);
+ref = dot_top;
+scale = (-1,1);
+},
+{
+alignment = -1;
+ref = "glottalstop-canadian";
+}
+);
+width = 460;
+}
+);
+metricLeft = "glottalstop-canadian";
+note = uni18DD;
+unicode = 6365;
+},
+{
+glyphname = "rweRCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "reRCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (671,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 847;
+}
+);
+note = uni18E0;
+unicode = 6368;
+},
+{
+glyphname = "looWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+}
+);
+width = 424;
+}
+);
+note = uni18E1;
+unicode = 6369;
+},
+{
+glyphname = "laaWestCree-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (267,0);
+ref = dot_top;
+}
+);
+width = 425;
+}
+);
+note = uni18E2;
+unicode = 6370;
+},
+{
+glyphname = "thwe-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "the-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (571,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 746;
+}
+);
+note = uni18E3;
+unicode = 6371;
+},
+{
+glyphname = "thwa-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (525,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 700;
+}
+);
+note = uni18E4;
+unicode = 6372;
+},
+{
+glyphname = "tthwe-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "tthe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (564,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 739;
+}
+);
+note = uni18E5;
+unicode = 6373;
+},
+{
+glyphname = "tthoo-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ttho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (168,0);
+ref = dot_top;
+}
+);
+width = 490;
+}
+);
+note = uni18E6;
+unicode = 6374;
+},
+{
+glyphname = "tthaa-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ttha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (186,0);
+ref = dot_top;
+}
+);
+width = 490;
+}
+);
+note = uni18E7;
+unicode = 6375;
+},
+{
+glyphname = "tlhwe-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "tlhe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (470,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 645;
+}
+);
+note = uni18E8;
+unicode = 6376;
+},
+{
+glyphname = "tlhoo-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "tlho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (185,0);
+ref = dot_top;
+}
+);
+width = 470;
+}
+);
+note = uni18E9;
+unicode = 6377;
+},
+{
+glyphname = "shweSayisi-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "sheSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (471,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 647;
+}
+);
+note = uni18EA;
+unicode = 6378;
+},
+{
+glyphname = "shooSayisi-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "shoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (318,0);
+ref = dot_top;
+}
+);
+width = 471;
+}
+);
+note = uni18EB;
+unicode = 6379;
+},
+{
+color = 9;
+glyphname = "hooSayisi-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "hoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (363,0);
+ref = dot_top;
+}
+);
+width = 520;
+}
+);
+note = uni18EC;
+unicode = 6380;
+},
+{
+color = 9;
+glyphname = "gwuCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "guCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (667,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 843;
+}
+);
+note = uni18ED;
+unicode = 6381;
+},
+{
+color = 9;
+glyphname = "deneGeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "geCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (219,0);
+ref = dot_top;
+}
+);
+width = 553;
+}
+);
+note = uni18EE;
+unicode = 6382;
+},
+{
+color = 9;
+glyphname = "gaaCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (228,0);
+ref = dot_top;
+}
+);
+width = 553;
+}
+);
+note = uni18EF;
+unicode = 6383;
+},
+{
+color = 9;
+glyphname = "gwaCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (553,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 729;
+}
+);
+note = uni18F0;
+unicode = 6384;
+},
+{
+color = 9;
+glyphname = "juuSayisi-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "juSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (240,0);
+ref = dot_top;
+}
+);
+width = 549;
+}
+);
+note = uni18F1;
+unicode = 6385;
+},
+{
+color = 9;
+glyphname = "jwaCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "jaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (602,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 777;
+}
+);
+note = uni18F2;
+unicode = 6386;
+},
+{
+glyphname = "lBeaverDene-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "pWestCree-canadian";
+}
+);
+width = 149;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+unicode = 6387;
+},
+{
+glyphname = "rBeaverDene-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,357,l),
+(169,581,ls),
+(182,641,o),
+(207,673,o),
+(246,673,cs),
+(252,673,l),
+(262,720,l),
+(259,720,ls),
+(215,720,o),
+(183,689,o),
+(172,637,c),
+(176,636,l),
+(193,714,l),
+(152,714,l),
+(76,357,l)
+);
+}
+);
+width = 189;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni18F4;
+unicode = 6388;
+},
+{
+color = 6;
+glyphname = "sDentalCarrier-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(153,190,ls),
+(240,190,o),
+(275,242,o),
+(275,310,cs),
+(275,358,o),
+(248,388,o),
+(201,388,cs),
+(183,388,ls),
+(153,388,o),
+(137,403,o),
+(137,431,cs),
+(137,463,o),
+(149,507,o),
+(205,507,cs),
+(316,507,l),
+(325,546,l),
+(217,546,ls),
+(130,546,o),
+(94,493,o),
+(94,426,cs),
+(94,378,o),
+(121,348,o),
+(168,348,cs),
+(186,348,ls),
+(216,348,o),
+(232,333,o),
+(232,305,cs),
+(232,273,o),
+(220,229,o),
+(164,229,cs),
+(53,229,l),
+(45,190,l)
+);
+}
+);
+width = 317;
+}
+);
+metricLeft = "shCarrier-canadian";
+metricRight = "=|";
+note = uni18F5;
+unicode = 6389;
+},
+{
+glyphname = "pWestCree-canadian.base";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "pWestCree-canadian";
+}
+);
+width = 149;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.base";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "c-canadian";
+}
+);
+width = 279;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "thSayisi-canadian.base";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "thSayisi-canadian";
+}
+);
+width = 279;
+}
+);
+metricLeft = "=|c-canadian";
+note = uni14A2;
+},
+{
+glyphname = "mWestCree-canadian.base";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "mWestCree-canadian";
+}
+);
+width = 286;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+glyphname = "pWestCree-canadian.mid";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "pWestCree-canadian";
+}
+);
+width = 150;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.mid";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "c-canadian";
+}
+);
+width = 279;
+}
+);
+metricLeft = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "mWestCree-canadian.mid";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "mWestCree-canadian";
+}
+);
+width = 286;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+color = 11;
+glyphname = "ngaai-canadian.nunavik";
+lastChange = "2023-01-13 15:30:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (498,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (615,0);
+ref = ring_top.canadian;
+}
+);
+width = 960;
+}
+);
+note = uni158E;
+},
+{
+color = 11;
+glyphname = "ngi-canadian.nunavik";
+lastChange = "2023-01-13 15:30:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (498,0);
+ref = "ci-canadian";
+}
+);
+width = 960;
+}
+);
+note = uni158F;
+},
+{
+color = 11;
+glyphname = "ngii-canadian.nunavik";
+lastChange = "2023-01-13 15:30:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (498,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (673,0);
+ref = dot_top;
+}
+);
+width = 960;
+}
+);
+note = uni1590;
+},
+{
+color = 11;
+glyphname = "ngo-canadian.nunavik";
+lastChange = "2023-01-13 15:30:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (498,0);
+ref = "co-canadian";
+}
+);
+width = 959;
+}
+);
+note = uni1591;
+},
+{
+color = 11;
+glyphname = "ngoo-canadian.nunavik";
+lastChange = "2023-01-13 15:30:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "ngo-canadian.nunavik";
+},
+{
+anchor = top_right_can;
+pos = (806,0);
+ref = dot_top;
+}
+);
+width = 959;
+}
+);
+note = uni1592;
+},
+{
+color = 11;
+glyphname = "nga-canadian.nunavik";
+lastChange = "2023-01-13 15:30:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (498,0);
+ref = "ca-canadian";
+}
+);
+width = 959;
+}
+);
+note = uni1593;
+},
+{
+color = 11;
+glyphname = "ngaa-canadian.nunavik";
+lastChange = "2023-01-13 15:30:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (498,0);
+ref = "ca-canadian";
+},
+{
+anchor = top_left_can;
+pos = (531,0);
+ref = dot_top;
+}
+);
+width = 959;
+}
+);
+note = uni1594;
+},
+{
+color = 11;
+glyphname = "ng-canadian.nunavik";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(441,157,o),
+(469,272,o),
+(469,334,cs),
+(469,391,o),
+(444,428,o),
+(395,428,cs),
+(366,428,o),
+(341,410,o),
+(325,379,c),
+(334,377,l),
+(359,493,l),
+(250,493,l),
+(255,479,l),
+(294,508,o),
+(310,579,o),
+(310,620,cs),
+(310,682,o),
+(279,720,o),
+(228,720,cs),
+(143,720,o),
+(111,612,o),
+(111,546,cs),
+(111,484,o),
+(142,449,o),
+(196,449,cs),
+(322,449,l),
+(308,469,l),
+(272,303,ls),
+(260,246,o),
+(267,157,o),
+(350,157,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(325,194,o),
+(309,215,o),
+(309,255,cs),
+(309,292,o),
+(325,392,o),
+(385,392,cs),
+(413,392,o),
+(427,371,o),
+(427,333,cs),
+(427,293,o),
+(411,194,o),
+(353,194,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(165,485,o),
+(151,506,o),
+(151,545,cs),
+(151,585,o),
+(167,683,o),
+(225,683,cs),
+(254,683,o),
+(269,662,o),
+(269,621,cs),
+(269,585,o),
+(252,485,o),
+(193,485,cs)
+);
+}
+);
+width = 498;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+color = 11;
+glyphname = "ngai-canadian.nunavik";
+lastChange = "2023-01-13 15:30:17 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (498,0);
+ref = "ce-canadian";
+}
+);
+width = 960;
+}
+);
+note = uni1670;
+},
+{
+color = 11;
+glyphname = "ke-canadian.square";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (362,714);
+},
+{
+name = top_left_can;
+pos = (183,714);
+},
+{
+name = top_right_can;
+pos = (540,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(419,0,l),
+(571,714,l),
+(437,714,ls),
+(139,714,o),
+(84,489,o),
+(84,362,cs),
+(84,223,o),
+(169,141,o),
+(316,141,cs),
+(385,141,l),
+(355,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(207,198,o),
+(146,255,o),
+(146,363,cs),
+(146,455,o),
+(176,657,o),
+(421,657,cs),
+(494,657,l),
+(397,198,l),
+(328,198,ls)
+);
+}
+);
+width = 536;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146B;
+},
+{
+color = 11;
+glyphname = "ki-canadian.square";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (375,714);
+},
+{
+name = top_left_can;
+pos = (197,714);
+},
+{
+name = top_right_can;
+pos = (553,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(76,0,l),
+(106,141,l),
+(183,141,ls),
+(475,141,o),
+(529,367,o),
+(529,493,cs),
+(529,631,o),
+(443,714,o),
+(298,714,cs),
+(165,714,l),
+(13,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(216,657,l),
+(289,657,ls),
+(405,657,o),
+(467,600,o),
+(467,493,cs),
+(467,400,o),
+(441,198,o),
+(195,198,cs),
+(119,198,l)
+);
+}
+);
+width = 535;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni146D;
+},
+{
+color = 11;
+glyphname = "kii-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (214,0);
+ref = dot_top;
+}
+);
+width = 537;
+}
+);
+note = uni146E;
+},
+{
+color = 11;
+glyphname = "ko-canadian.square";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (362,714);
+},
+{
+name = top_left_can;
+pos = (183,714);
+},
+{
+name = top_right_can;
+pos = (540,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(419,0,l),
+(571,714,l),
+(507,714,l),
+(478,573,l),
+(400,573,ls),
+(108,573,o),
+(54,347,o),
+(54,221,cs),
+(54,83,o),
+(140,0,o),
+(285,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(178,57,o),
+(116,114,o),
+(116,221,cs),
+(116,314,o),
+(142,516,o),
+(388,516,cs),
+(465,516,l),
+(367,57,l),
+(294,57,ls)
+);
+}
+);
+width = 536;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146F;
+},
+{
+color = 11;
+glyphname = "koo-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (380,0);
+ref = dot_top;
+}
+);
+width = 537;
+}
+);
+note = uni1470;
+},
+{
+color = 11;
+glyphname = "ka-canadian.square";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (375,714);
+},
+{
+name = top_left_can;
+pos = (197,714);
+},
+{
+name = top_right_can;
+pos = (553,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(147,0,ls),
+(443,0,o),
+(500,225,o),
+(500,352,cs),
+(500,491,o),
+(413,573,o),
+(267,573,cs),
+(199,573,l),
+(228,714,l),
+(165,714,l),
+(13,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(187,516,l),
+(255,516,ls),
+(376,516,o),
+(437,459,o),
+(437,351,cs),
+(437,259,o),
+(406,57,o),
+(162,57,cs),
+(89,57,l)
+);
+}
+);
+width = 536;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1472;
+},
+{
+color = 11;
+glyphname = "kaa-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+}
+);
+width = 537;
+}
+);
+note = uni1473;
+},
+{
+color = 11;
+glyphname = "kweWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (537,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 712;
+}
+);
+note = uni1475;
+},
+{
+color = 11;
+glyphname = "kwiiWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (214,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (537,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 712;
+}
+);
+note = uni1479;
+},
+{
+color = 11;
+glyphname = "kwoWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (537,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 712;
+}
+);
+note = uni147B;
+},
+{
+color = 11;
+glyphname = "kwooWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (380,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (537,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 712;
+}
+);
+note = uni147D;
+},
+{
+color = 11;
+glyphname = "kwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (537,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 712;
+}
+);
+note = uni147F;
+},
+{
+color = 11;
+glyphname = "kwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (537,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 712;
+}
+);
+note = uni1481;
+},
+{
+color = 11;
+glyphname = "ce-canadian.square";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (375,714);
+},
+{
+name = top_left_can;
+pos = (187,714);
+},
+{
+name = top_right_can;
+pos = (564,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(443,0,l),
+(542,463,ls),
+(575,624,o),
+(506,727,o),
+(360,727,cs),
+(225,727,o),
+(138,639,o),
+(103,474,cs),
+(89,405,l),
+(152,405,l),
+(166,472,ls),
+(192,601,o),
+(256,666,o),
+(356,667,cs),
+(462,667,o),
+(506,595,o),
+(479,467,cs),
+(379,0,l)
+);
+}
+);
+width = 557;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni1489;
+},
+{
+color = 11;
+glyphname = "ci-canadian.square";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (381,714);
+},
+{
+name = top_left_can;
+pos = (194,714);
+},
+{
+name = top_right_can;
+pos = (571,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(73,0,l),
+(177,491,ls),
+(202,608,o),
+(262,667,o),
+(357,667,cs),
+(466,667,o),
+(514,594,o),
+(486,469,cs),
+(473,405,l),
+(536,405,l),
+(547,460,ls),
+(582,622,o),
+(509,727,o),
+(363,727,cs),
+(232,727,o),
+(147,646,o),
+(114,491,cs),
+(9,0,l)
+);
+}
+);
+width = 556;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+},
+{
+color = 11;
+glyphname = "cii-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (221,0);
+ref = dot_top;
+}
+);
+width = 555;
+}
+);
+note = uni148C;
+},
+{
+color = 11;
+glyphname = "co-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (374,714);
+},
+{
+name = top_left_can;
+pos = (186,714);
+},
+{
+name = top_right_can;
+pos = (563,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(371,-13,o),
+(456,68,o),
+(489,223,cs),
+(594,714,l),
+(530,714,l),
+(426,223,ls),
+(402,106,o),
+(341,47,o),
+(246,47,cs),
+(137,47,o),
+(90,120,o),
+(117,245,cs),
+(131,309,l),
+(68,309,l),
+(56,254,ls),
+(21,92,o),
+(95,-13,o),
+(240,-13,cs)
+);
+}
+);
+width = 555;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+},
+{
+color = 11;
+glyphname = "coo-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (402,0);
+ref = dot_top;
+}
+);
+width = 555;
+}
+);
+note = uni148E;
+},
+{
+color = 11;
+glyphname = "ca-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (381,714);
+},
+{
+name = top_left_can;
+pos = (194,714);
+},
+{
+name = top_right_can;
+pos = (571,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(379,-13,o),
+(465,75,o),
+(500,240,cs),
+(515,309,l),
+(452,309,l),
+(438,242,ls),
+(411,113,o),
+(348,48,o),
+(249,47,cs),
+(143,47,o),
+(98,119,o),
+(125,247,cs),
+(225,714,l),
+(161,714,l),
+(63,251,ls),
+(29,90,o),
+(99,-13,o),
+(245,-13,cs)
+);
+}
+);
+width = 555;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+},
+{
+color = 11;
+glyphname = "caa-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (33,0);
+ref = dot_top;
+}
+);
+width = 555;
+}
+);
+note = uni1491;
+},
+{
+color = 11;
+glyphname = "me-canadian.square";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (324,714);
+},
+{
+name = top_double;
+pos = (479,714);
+},
+{
+name = top_left_can;
+pos = (166,714);
+},
+{
+name = top_right_can;
+pos = (478,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(359,0,l),
+(511,714,l),
+(135,714,l),
+(122,655,l),
+(434,655,l),
+(295,0,l)
+);
+}
+);
+width = 476;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+},
+{
+color = 11;
+glyphname = "mi-canadian.square";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (353,714);
+},
+{
+name = top_left_can;
+pos = (197,714);
+},
+{
+name = top_right_can;
+pos = (509,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(76,0,l),
+(216,655,l),
+(528,655,l),
+(541,714,l),
+(165,714,l),
+(13,0,l)
+);
+}
+);
+width = 476;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+},
+{
+color = 11;
+glyphname = "mii-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (192,0);
+ref = dot_top;
+}
+);
+width = 475;
+}
+);
+note = uni14A6;
+},
+{
+color = 11;
+glyphname = "mo-canadian.square";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (325,714);
+},
+{
+name = top_double;
+pos = (480,714);
+},
+{
+name = top_left_can;
+pos = (167,714);
+},
+{
+name = top_right_can;
+pos = (480,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(360,0,l),
+(512,714,l),
+(448,714,l),
+(309,59,l),
+(-4,59,l),
+(-16,0,l)
+);
+}
+);
+width = 477;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+},
+{
+color = 11;
+glyphname = "moo-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (318,0);
+ref = dot_top;
+}
+);
+width = 475;
+}
+);
+note = uni14A8;
+},
+{
+color = 11;
+glyphname = "ma-canadian.square";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (353,714);
+},
+{
+name = top_left_can;
+pos = (197,714);
+},
+{
+name = top_right_can;
+pos = (508,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(389,0,l),
+(401,59,l),
+(89,59,l),
+(228,714,l),
+(165,714,l),
+(13,0,l)
+);
+}
+);
+width = 476;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+},
+{
+color = 11;
+glyphname = "maa-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+}
+);
+width = 475;
+}
+);
+note = uni14AB;
+},
+{
+color = 11;
+glyphname = "ne-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (456,714);
+},
+{
+name = top_left_can;
+pos = (298,714);
+},
+{
+name = top_right_can;
+pos = (615,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(437,-13,o),
+(505,54,o),
+(536,200,cs),
+(646,714,l),
+(151,714,l),
+(139,655,l),
+(253,655,l),
+(159,209,ls),
+(130,70,o),
+(190,-13,o),
+(319,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(237,47,o),
+(198,101,o),
+(220,200,cs),
+(316,655,l),
+(570,655,l),
+(474,200,ls),
+(452,98,o),
+(404,47,o),
+(326,47,cs)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C0;
+},
+{
+color = 11;
+glyphname = "ni-canadian.square";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (352,714);
+},
+{
+name = top_left_can;
+pos = (194,714);
+},
+{
+name = top_right_can;
+pos = (511,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(333,-13,o),
+(401,54,o),
+(432,200,cs),
+(529,655,l),
+(644,655,l),
+(656,714,l),
+(161,714,l),
+(55,209,ls),
+(26,70,o),
+(86,-13,o),
+(215,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(133,47,o),
+(94,101,o),
+(116,200,cs),
+(212,655,l),
+(466,655,l),
+(369,200,ls),
+(347,98,o),
+(301,47,o),
+(222,47,cs)
+);
+}
+);
+width = 608;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+},
+{
+color = 11;
+glyphname = "nii-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (191,0);
+ref = dot_top;
+}
+);
+width = 607;
+}
+);
+note = uni14C3;
+},
+{
+color = 11;
+glyphname = "no-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (456,714);
+},
+{
+name = top_double;
+pos = (466,714);
+},
+{
+name = top_left_can;
+pos = (298,714);
+},
+{
+name = top_right_can;
+pos = (605,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(494,0,l),
+(600,505,ls),
+(629,644,o),
+(569,727,o),
+(440,727,cs),
+(322,727,o),
+(255,660,o),
+(223,514,cs),
+(126,59,l),
+(12,59,l),
+(-1,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(286,514,ls),
+(308,616,o),
+(354,667,o),
+(433,667,cs),
+(522,667,o),
+(561,613,o),
+(540,514,cs),
+(443,59,l),
+(189,59,l)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C4;
+},
+{
+color = 11;
+glyphname = "noo-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (295,0);
+ref = dot_top;
+}
+);
+width = 607;
+}
+);
+note = uni14C5;
+},
+{
+color = 11;
+glyphname = "na-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (351,714);
+},
+{
+name = top_double;
+pos = (361,714);
+},
+{
+name = top_left_can;
+pos = (193,714);
+},
+{
+name = top_right_can;
+pos = (510,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(504,0,l),
+(516,59,l),
+(402,59,l),
+(496,505,ls),
+(525,644,o),
+(465,727,o),
+(336,727,cs),
+(218,727,o),
+(150,660,o),
+(119,514,cs),
+(9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(181,514,ls),
+(203,616,o),
+(251,667,o),
+(329,667,cs),
+(418,667,o),
+(457,613,o),
+(435,514,cs),
+(339,59,l),
+(85,59,l)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+},
+{
+color = 11;
+glyphname = "naa-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (190,0);
+ref = dot_top;
+}
+);
+width = 607;
+}
+);
+note = uni14C8;
+},
+{
+color = 11;
+glyphname = "nweWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 783;
+}
+);
+note = uni14CA;
+},
+{
+color = 11;
+glyphname = "nwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 783;
+}
+);
+note = uni14CC;
+},
+{
+color = 11;
+glyphname = "nwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (190,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 783;
+}
+);
+note = uni14CE;
+},
+{
+color = 11;
+glyphname = "se-canadian.square";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (195,714);
+},
+{
+name = top_right_can;
+pos = (559,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(435,0,l),
+(486,238,l),
+(368,238,ls),
+(204,238,o),
+(143,321,o),
+(179,494,cs),
+(226,714,l),
+(163,714,l),
+(116,494,ls),
+(74,298,o),
+(165,181,o),
+(357,181,cs),
+(434,181,l),
+(414,198,l),
+(372,0,l)
+);
+}
+);
+width = 551;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14ED;
+},
+{
+color = 11;
+glyphname = "si-canadian.square";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (196,714);
+},
+{
+name = top_right_can;
+pos = (561,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(75,0,l),
+(118,199,l),
+(90,181,l),
+(167,181,ls),
+(375,181,o),
+(496,281,o),
+(540,487,cs),
+(588,714,l),
+(525,714,l),
+(476,487,ls),
+(441,323,o),
+(339,238,o),
+(180,238,cs),
+(63,238,l),
+(12,0,l)
+);
+}
+);
+width = 551;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+},
+{
+color = 11;
+glyphname = "sii-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (401,0);
+ref = dot_top;
+}
+);
+width = 552;
+}
+);
+note = uni14F0;
+},
+{
+color = 11;
+glyphname = "so-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (556,714);
+},
+{
+name = top_left_can;
+pos = (195,714);
+},
+{
+name = top_right_can;
+pos = (556,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(74,0,l),
+(123,227,ls),
+(158,391,o),
+(260,476,o),
+(419,476,cs),
+(537,476,l),
+(587,714,l),
+(524,714,l),
+(481,515,l),
+(509,533,l),
+(432,533,ls),
+(225,533,o),
+(103,433,o),
+(59,227,cs),
+(11,0,l)
+);
+}
+);
+width = 552;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+},
+{
+color = 11;
+glyphname = "soo-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (395,0);
+ref = dot_top;
+}
+);
+width = 552;
+}
+);
+note = uni14F2;
+},
+{
+color = 11;
+glyphname = "sa-canadian.square";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (199,714);
+},
+{
+name = top_right_can;
+pos = (557,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(436,0,l),
+(483,220,ls),
+(525,416,o),
+(435,533,o),
+(242,533,cs),
+(165,533,l),
+(185,516,l),
+(228,714,l),
+(164,714,l),
+(113,476,l),
+(231,476,ls),
+(395,476,o),
+(457,393,o),
+(420,220,cs),
+(373,0,l)
+);
+}
+);
+width = 551;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+},
+{
+color = 11;
+glyphname = "saa-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (39,0);
+ref = dot_top;
+}
+);
+width = 552;
+}
+);
+note = uni14F5;
+},
+{
+color = 11;
+glyphname = "sho-canadian.square";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (366,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(417,0,l),
+(429,54,l),
+(210,54,ls),
+(140,54,o),
+(105,87,o),
+(105,153,cs),
+(105,212,o),
+(120,330,o),
+(260,330,cs),
+(324,330,ls),
+(499,330,o),
+(544,466,o),
+(544,564,cs),
+(544,658,o),
+(489,714,o),
+(397,714,cs),
+(162,714,l),
+(150,660,l),
+(376,660,ls),
+(445,660,o),
+(481,626,o),
+(481,560,cs),
+(481,498,o),
+(463,385,o),
+(325,385,cs),
+(262,385,ls),
+(85,385,o),
+(42,246,o),
+(42,149,cs),
+(42,56,o),
+(96,0,o),
+(189,0,cs)
+);
+}
+);
+width = 538;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+color = 11;
+glyphname = "shoo-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (205,0);
+ref = dot_top;
+}
+);
+width = 539;
+}
+);
+note = g728;
+},
+{
+color = 11;
+glyphname = "sha-canadian.square";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (367,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(246,0,ls),
+(430,0,o),
+(475,135,o),
+(475,242,cs),
+(475,333,o),
+(420,385,o),
+(330,385,cs),
+(279,385,ls),
+(211,385,o),
+(175,413,o),
+(175,475,cs),
+(175,547,o),
+(194,660,o),
+(339,660,cs),
+(560,660,l),
+(572,714,l),
+(339,714,ls),
+(155,714,o),
+(111,578,o),
+(111,472,cs),
+(111,381,o),
+(165,330,o),
+(255,330,cs),
+(306,330,ls),
+(374,330,o),
+(411,301,o),
+(411,238,cs),
+(411,168,o),
+(387,54,o),
+(246,54,cs),
+(25,54,l),
+(13,0,l)
+);
+}
+);
+width = 539;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+color = 11;
+glyphname = "shaa-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (206,0);
+ref = dot_top;
+}
+);
+width = 538;
+}
+);
+note = g730;
+},
+{
+color = 11;
+glyphname = "ye-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (175,714);
+},
+{
+name = top_right_can;
+pos = (571,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(450,0,l),
+(501,238,l),
+(125,238,l),
+(128,210,l),
+(608,680,l),
+(565,726,l),
+(33,206,l),
+(28,181,l),
+(425,181,l),
+(387,0,l)
+);
+}
+);
+width = 564;
+}
+);
+metricLeft = "ye-canadian";
+note = uni1526;
+},
+{
+color = 11;
+glyphname = "yi-canadian.square";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (193,714);
+},
+{
+name = top_right_can;
+pos = (588,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(74,0,l),
+(112,181,l),
+(510,181,l),
+(515,206,l),
+(192,726,l),
+(139,687,l),
+(432,210,l),
+(436,238,l),
+(61,238,l),
+(10,0,l)
+);
+}
+);
+width = 564;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni1528;
+},
+{
+color = 11;
+glyphname = "yii-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (31,0);
+ref = dot_top;
+}
+);
+width = 564;
+}
+);
+note = uni1529;
+},
+{
+color = 11;
+glyphname = "yo-canadian.square";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (570,714);
+},
+{
+name = top_left_can;
+pos = (174,714);
+},
+{
+name = top_right_can;
+pos = (570,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(472,27,l),
+(179,504,l),
+(175,476,l),
+(551,476,l),
+(602,714,l),
+(538,714,l),
+(499,533,l),
+(102,533,l),
+(97,508,l),
+(419,-12,l)
+);
+}
+);
+width = 564;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152A;
+},
+{
+color = 11;
+glyphname = "yoo-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (410,0);
+ref = dot_top;
+}
+);
+width = 564;
+}
+);
+note = uni152B;
+},
+{
+color = 11;
+glyphname = "ya-canadian.square";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (194,714);
+},
+{
+name = top_right_can;
+pos = (589,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(579,508,l),
+(584,533,l),
+(187,533,l),
+(225,714,l),
+(162,714,l),
+(111,476,l),
+(487,476,l),
+(484,504,l),
+(4,34,l),
+(47,-12,l)
+);
+}
+);
+width = 564;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152D;
+},
+{
+color = 11;
+glyphname = "yaa-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (32,0);
+ref = dot_top;
+}
+);
+width = 564;
+}
+);
+note = uni152E;
+},
+{
+color = 11;
+glyphname = "re-canadian.square";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (352,714);
+},
+{
+name = top_left_can;
+pos = (194,714);
+},
+{
+name = top_right_can;
+pos = (511,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(333,-13,o),
+(401,54,o),
+(432,200,cs),
+(529,655,l),
+(644,655,l),
+(656,714,l),
+(478,714,l),
+(369,200,ls),
+(347,98,o),
+(301,47,o),
+(222,47,cs),
+(133,47,o),
+(94,101,o),
+(116,200,cs),
+(224,714,l),
+(161,714,l),
+(55,209,ls),
+(26,70,o),
+(86,-13,o),
+(215,-13,cs)
+);
+}
+);
+width = 608;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1542;
+},
+{
+color = 11;
+glyphname = "reRCree-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (456,714);
+},
+{
+name = top_left_can;
+pos = (298,714);
+},
+{
+name = top_right_can;
+pos = (615,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(437,-13,o),
+(505,54,o),
+(536,200,cs),
+(646,714,l),
+(583,714,l),
+(474,200,ls),
+(452,98,o),
+(404,47,o),
+(326,47,cs),
+(237,47,o),
+(198,101,o),
+(220,200,cs),
+(329,714,l),
+(151,714,l),
+(139,655,l),
+(253,655,l),
+(159,209,ls),
+(130,70,o),
+(190,-13,o),
+(319,-13,cs)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni1543;
+},
+{
+color = 11;
+glyphname = "leWestCree-canadian.square";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (455,714);
+},
+{
+name = top_left_can;
+pos = (297,714);
+},
+{
+name = top_right_can;
+pos = (614,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(176,0,l),
+(285,514,ls),
+(307,616,o),
+(353,667,o),
+(432,667,cs),
+(521,667,o),
+(560,613,o),
+(539,514,cs),
+(430,0,l),
+(493,0,l),
+(599,505,ls),
+(629,644,o),
+(568,727,o),
+(439,727,cs),
+(321,727,o),
+(254,660,o),
+(222,514,cs),
+(125,58,l),
+(12,58,l),
+(-1,0,l)
+);
+}
+);
+width = 608;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+},
+{
+color = 11;
+glyphname = "ri-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (351,714);
+},
+{
+name = top_left_can;
+pos = (195,714);
+},
+{
+name = top_right_can;
+pos = (510,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(72,0,l),
+(181,514,ls),
+(203,616,o),
+(251,667,o),
+(329,667,cs),
+(418,667,o),
+(457,613,o),
+(435,514,cs),
+(326,0,l),
+(504,0,l),
+(516,59,l),
+(402,59,l),
+(496,505,ls),
+(525,644,o),
+(465,727,o),
+(336,727,cs),
+(218,727,o),
+(150,660,o),
+(119,514,cs),
+(9,0,l)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+},
+{
+color = 11;
+glyphname = "rii-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (190,0);
+ref = dot_top;
+}
+);
+width = 607;
+}
+);
+note = uni1547;
+},
+{
+color = 11;
+glyphname = "ro-canadian.square";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (370,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(76,0,l),
+(112,168,l),
+(79,141,l),
+(172,141,ls),
+(461,141,o),
+(515,367,o),
+(515,493,cs),
+(515,631,o),
+(431,714,o),
+(285,714,cs),
+(165,714,l),
+(153,657,l),
+(275,657,ls),
+(392,657,o),
+(452,600,o),
+(452,493,cs),
+(452,400,o),
+(427,198,o),
+(179,198,cs),
+(55,198,l),
+(13,0,l)
+);
+}
+);
+width = 521;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1548;
+},
+{
+color = 11;
+glyphname = "loWestCree-canadian.square";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (368,714);
+},
+{
+name = top_left_can;
+pos = (198,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(143,0,ls),
+(430,0,o),
+(483,227,o),
+(483,352,cs),
+(483,491,o),
+(399,573,o),
+(253,573,cs),
+(171,573,l),
+(194,546,l),
+(229,714,l),
+(166,714,l),
+(123,516,l),
+(243,516,ls),
+(361,516,o),
+(420,459,o),
+(420,352,cs),
+(420,259,o),
+(393,57,o),
+(156,57,cs),
+(26,57,l),
+(14,0,l)
+);
+}
+);
+width = 519;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+},
+{
+color = 11;
+glyphname = "ra-canadian.square";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (350,714);
+},
+{
+name = top_right_can;
+pos = (522,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(401,0,l),
+(444,198,l),
+(323,198,ls),
+(206,198,o),
+(147,255,o),
+(147,362,cs),
+(147,455,o),
+(174,657,o),
+(411,657,cs),
+(541,657,l),
+(553,714,l),
+(424,714,ls),
+(137,714,o),
+(84,487,o),
+(84,362,cs),
+(84,223,o),
+(167,141,o),
+(314,141,cs),
+(396,141,l),
+(373,168,l),
+(337,0,l)
+);
+}
+);
+width = 519;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+},
+{
+color = 11;
+glyphname = "raa-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (191,0);
+ref = dot_top;
+}
+);
+width = 519;
+}
+);
+note = uni154C;
+},
+{
+color = 11;
+glyphname = "laWestCree-canadian.square";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (523,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(402,0,l),
+(414,57,l),
+(294,57,ls),
+(178,57,o),
+(117,114,o),
+(117,221,cs),
+(117,314,o),
+(143,516,o),
+(390,516,cs),
+(511,516,l),
+(554,714,l),
+(490,714,l),
+(454,546,l),
+(488,573,l),
+(397,573,ls),
+(108,573,o),
+(54,347,o),
+(54,221,cs),
+(54,83,o),
+(138,0,o),
+(285,0,cs)
+);
+}
+);
+width = 519;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+},
+{
+color = 11;
+glyphname = "reWestCree-canadian.square";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(436,0,l),
+(661,198,l),
+(624,241,l),
+(438,75,l),
+(457,63,l),
+(542,463,ls),
+(576,624,o),
+(507,727,o),
+(361,727,cs),
+(226,727,o),
+(138,642,o),
+(103,474,cs),
+(89,405,l),
+(152,405,l),
+(166,472,ls),
+(192,601,o),
+(256,666,o),
+(356,667,cs),
+(462,667,o),
+(506,595,o),
+(479,467,cs),
+(380,0,l)
+);
+}
+);
+width = 695;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+},
+{
+color = 11;
+glyphname = "riWestCree-canadian.square";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(212,0,l),
+(316,491,ls),
+(340,608,o),
+(400,667,o),
+(495,667,cs),
+(604,667,o),
+(650,595,o),
+(624,469,cs),
+(611,405,l),
+(674,405,l),
+(685,460,ls),
+(717,622,o),
+(646,727,o),
+(501,727,cs),
+(370,727,o),
+(285,649,o),
+(252,491,cs),
+(161,62,l),
+(181,64,l),
+(62,234,l),
+(14,198,l),
+(155,0,l)
+);
+}
+);
+width = 694;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+},
+{
+color = 11;
+glyphname = "roWestCree-canadian.square";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(372,-13,o),
+(457,65,o),
+(490,223,cs),
+(581,652,l),
+(561,650,l),
+(681,480,l),
+(728,516,l),
+(587,714,l),
+(530,714,l),
+(426,223,ls),
+(402,106,o),
+(342,47,o),
+(247,47,cs),
+(138,47,o),
+(92,119,o),
+(118,245,cs),
+(131,309,l),
+(68,309,l),
+(57,254,ls),
+(25,92,o),
+(96,-13,o),
+(241,-13,cs)
+);
+}
+);
+width = 694;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+},
+{
+color = 11;
+glyphname = "raWestCree-canadian.square";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(516,-13,o),
+(604,72,o),
+(639,240,cs),
+(653,309,l),
+(590,309,l),
+(576,242,ls),
+(550,113,o),
+(486,48,o),
+(386,47,cs),
+(280,47,o),
+(236,119,o),
+(263,247,cs),
+(362,714,l),
+(306,714,l),
+(82,516,l),
+(118,473,l),
+(304,639,l),
+(285,651,l),
+(200,251,ls),
+(166,90,o),
+(235,-13,o),
+(381,-13,cs)
+);
+}
+);
+width = 694;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+},
+{
+color = 11;
+glyphname = "theThCree-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (175,714);
+},
+{
+name = top_right_can;
+pos = (571,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(450,0,l),
+(466,73,l),
+(536,73,l),
+(544,111,l),
+(474,111,l),
+(501,238,l),
+(128,238,l),
+(136,218,l),
+(608,680,l),
+(565,726,l),
+(33,206,l),
+(28,181,l),
+(425,181,l),
+(411,111,l),
+(222,111,l),
+(214,73,l),
+(402,73,l),
+(387,0,l)
+);
+}
+);
+width = 608;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15A7;
+},
+{
+color = 11;
+glyphname = "thiThCree-canadian.square";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (234,714);
+},
+{
+name = top_right_can;
+pos = (629,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(119,0,l),
+(134,73,l),
+(323,73,l),
+(331,111,l),
+(143,111,l),
+(158,181,l),
+(555,181,l),
+(560,206,l),
+(238,726,l),
+(185,687,l),
+(476,214,l),
+(488,238,l),
+(106,238,l),
+(80,111,l),
+(8,111,l),
+(1,73,l),
+(71,73,l),
+(56,0,l)
+);
+}
+);
+width = 609;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+},
+{
+color = 11;
+glyphname = "thiiThCree-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (71,0);
+ref = dot_top;
+}
+);
+width = 608;
+}
+);
+note = uni15A9;
+},
+{
+color = 11;
+glyphname = "thoThCree-canadian.square";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (173,714);
+},
+{
+name = top_right_can;
+pos = (570,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(472,27,l),
+(182,500,l),
+(169,476,l),
+(550,476,l),
+(577,603,l),
+(648,603,l),
+(656,641,l),
+(585,641,l),
+(601,714,l),
+(537,714,l),
+(522,641,l),
+(333,641,l),
+(325,603,l),
+(513,603,l),
+(499,533,l),
+(102,533,l),
+(97,508,l),
+(418,-12,l)
+);
+}
+);
+width = 608;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+},
+{
+color = 11;
+glyphname = "thooThCree-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (410,0);
+ref = dot_top;
+}
+);
+width = 608;
+}
+);
+note = uni15AB;
+},
+{
+color = 11;
+glyphname = "thaThCree-canadian.square";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (238,714);
+},
+{
+name = top_right_can;
+pos = (634,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(623,508,l),
+(628,533,l),
+(231,533,l),
+(246,603,l),
+(435,603,l),
+(443,641,l),
+(254,641,l),
+(270,714,l),
+(206,714,l),
+(191,641,l),
+(120,641,l),
+(112,603,l),
+(182,603,l),
+(156,476,l),
+(528,476,l),
+(521,496,l),
+(49,34,l),
+(92,-12,l)
+);
+}
+);
+width = 608;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+},
+{
+color = 11;
+glyphname = "thaaThCree-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (77,0);
+ref = dot_top;
+}
+);
+width = 608;
+}
+);
+note = uni15AD;
+},
+{
+color = 11;
+glyphname = "thweeWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (608,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni1677;
+},
+{
+color = 11;
+glyphname = "thwiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (608,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni1678;
+},
+{
+color = 11;
+glyphname = "thwiiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (71,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (608,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni1679;
+},
+{
+color = 11;
+glyphname = "thwoWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (608,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni167A;
+},
+{
+color = 11;
+glyphname = "thwooWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (410,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (608,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni167B;
+},
+{
+color = 11;
+glyphname = "thwaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (608,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni167C;
+},
+{
+color = 11;
+glyphname = "thwaaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (77,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (608,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni167D;
+},
+{
+color = 11;
+glyphname = "nwiOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 783;
+}
+);
+note = uni18C7;
+},
+{
+color = 11;
+glyphname = "nwiiOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (191,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 783;
+}
+);
+note = uni18C9;
+},
+{
+color = 11;
+glyphname = "nwoOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 783;
+}
+);
+note = uni18CB;
+},
+{
+color = 11;
+glyphname = "nwooOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (295,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 783;
+}
+);
+note = uni18CD;
+},
+{
+color = 11;
+glyphname = "looWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+}
+);
+width = 519;
+}
+);
+note = uni18E1;
+},
+{
+color = 11;
+glyphname = "laaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (363,0);
+ref = dot_top;
+}
+);
+width = 519;
+}
+);
+note = uni18E2;
+},
+{
+color = 0;
+glyphname = zero;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(568,561,o),
+(519,725,o),
+(338,725,cs),
+(155,725,o),
+(106,545,o),
+(106,359,cs),
+(106,110,o),
+(189,-10,o),
+(337,-10,cs),
+(492,-10,o),
+(568,112,o),
+(568,359,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(173,505,o),
+(198,668,o),
+(338,668,cs),
+(487,668,o),
+(501,495,o),
+(501,359,cs),
+(501,167,o),
+(458,47,o),
+(337,47,cs),
+(223,47,o),
+(173,165,o),
+(173,359,cs)
+);
+}
+);
+width = 630;
+}
+);
+unicode = 48;
+},
+{
+color = 0;
+glyphname = one;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(293,714,l),
+(86,558,l),
+(123,512,l),
+(235,597,ls),
+(258,614,o),
+(271,626,o),
+(287,641,c),
+(286,617,o),
+(286,593,o),
+(286,567,cs),
+(286,0,l),
+(353,0,l),
+(353,714,l)
+);
+}
+);
+width = 476;
+}
+);
+unicode = 49;
+},
+{
+color = 0;
+glyphname = two;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(563,0,l),
+(563,58,l),
+(198,58,l),
+(198,60,l),
+(367,237,ls),
+(439,309,o),
+(489,365,o),
+(516,429,cs),
+(528,460,o),
+(534,496,o),
+(534,537,cs),
+(534,650,o),
+(452,724,o),
+(333,724,cs),
+(257,724,o),
+(187,698,o),
+(124,644,c),
+(161,598,l),
+(215,643,o),
+(273,665,o),
+(327,665,cs),
+(414,665,o),
+(467,616,o),
+(467,530,cs),
+(467,466,o),
+(446,417,o),
+(404,364,cs),
+(382,336,o),
+(355,306,o),
+(321,271,cs),
+(110,49,l),
+(110,0,l)
+);
+}
+);
+width = 615;
+}
+);
+unicode = 50;
+},
+{
+color = 0;
+glyphname = three;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(546,662,o),
+(463,724,o),
+(339,724,cs),
+(242,724,o),
+(172,694,o),
+(113,650,c),
+(143,603,l),
+(198,643,o),
+(260,667,o),
+(332,667,cs),
+(421,667,o),
+(480,627,o),
+(480,542,cs),
+(480,442,o),
+(392,397,o),
+(290,397,cs),
+(216,397,l),
+(216,343,l),
+(289,343,ls),
+(412,343,o),
+(497,308,o),
+(497,199,cs),
+(497,106,o),
+(435,46,o),
+(303,46,cs),
+(235,46,o),
+(160,65,o),
+(106,92,c),
+(106,31,l),
+(160,7,o),
+(227,-10,o),
+(310,-10,cs),
+(471,-10,o),
+(568,71,o),
+(568,196,cs),
+(568,302,o),
+(504,358,o),
+(392,373,c),
+(392,375,l),
+(480,393,o),
+(546,458,o),
+(546,553,cs)
+);
+}
+);
+width = 619;
+}
+);
+unicode = 51;
+},
+{
+color = 0;
+glyphname = four;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(456,234,l),
+(456,717,l),
+(391,717,l),
+(37,229,l),
+(37,180,l),
+(389,180,l),
+(389,0,l),
+(456,0,l),
+(456,180,l),
+(576,180,l),
+(576,234,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(104,234,l),
+(331,545,ls),
+(358,582,o),
+(368,599,o),
+(388,633,c),
+(391,633,l),
+(391,611,o),
+(389,576,o),
+(389,538,cs),
+(389,234,l)
+);
+}
+);
+width = 602;
+}
+);
+unicode = 52;
+},
+{
+color = 0;
+glyphname = five;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(254,436,o),
+(215,426,o),
+(185,419,c),
+(206,656,l),
+(500,656,l),
+(500,714,l),
+(148,714,l),
+(119,379,l),
+(151,359,l),
+(194,373,o),
+(238,381,o),
+(293,381,cs),
+(415,381,o),
+(476,321,o),
+(476,221,cs),
+(476,110,o),
+(399,46,o),
+(279,46,cs),
+(210,46,o),
+(144,67,o),
+(98,93,c),
+(98,31,l),
+(143,7,o),
+(205,-10,o),
+(283,-10,cs),
+(449,-10,o),
+(544,80,o),
+(544,222,cs),
+(544,359,o),
+(455,436,o),
+(317,436,cs)
+);
+}
+);
+width = 590;
+}
+);
+unicode = 53;
+},
+{
+color = 0;
+glyphname = six;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(91,139,o),
+(162,-10,o),
+(332,-10,cs),
+(470,-10,o),
+(555,82,o),
+(555,230,cs),
+(555,365,o),
+(478,448,o),
+(348,448,cs),
+(253,448,o),
+(185,402,o),
+(156,339,c),
+(153,339,l),
+(158,531,o),
+(227,670,o),
+(408,670,cs),
+(450,670,o),
+(483,664,o),
+(508,656,c),
+(508,714,l),
+(481,721,o),
+(446,726,o),
+(409,726,cs),
+(174,726,o),
+(91,541,o),
+(91,303,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,46,o),
+(163,172,o),
+(163,256,cs),
+(163,332,o),
+(248,393,o),
+(335,393,cs),
+(439,393,o),
+(489,330,o),
+(489,229,cs),
+(489,115,o),
+(432,46,o),
+(331,46,cs)
+);
+}
+);
+width = 602;
+}
+);
+unicode = 54;
+},
+{
+color = 0;
+glyphname = seven;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(584,673,l),
+(584,714,l),
+(117,714,l),
+(117,656,l),
+(511,656,l),
+(227,0,l),
+(298,0,l)
+);
+}
+);
+width = 609;
+}
+);
+unicode = 55;
+},
+{
+color = 0;
+glyphname = eight;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(474,-10,o),
+(571,61,o),
+(571,183,cs),
+(571,284,o),
+(499,341,o),
+(393,381,c),
+(486,419,o),
+(547,471,o),
+(547,558,cs),
+(547,665,o),
+(466,724,o),
+(341,724,cs),
+(218,724,o),
+(134,660,o),
+(134,557,cs),
+(134,457,o),
+(212,411,o),
+(284,379,c),
+(181,342,o),
+(111,285,o),
+(111,178,cs),
+(111,66,o),
+(198,-10,o),
+(337,-10,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(240,43,o),
+(175,96,o),
+(175,180,cs),
+(175,276,o),
+(256,321,o),
+(338,349,c),
+(452,306,o),
+(507,260,o),
+(507,184,cs),
+(507,92,o),
+(438,43,o),
+(337,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(256,442,o),
+(199,481,o),
+(199,553,cs),
+(199,629,o),
+(260,671,o),
+(341,671,cs),
+(429,671,o),
+(482,631,o),
+(482,554,cs),
+(482,485,o),
+(433,448,o),
+(342,410,c)
+);
+}
+);
+width = 632;
+}
+);
+unicode = 56;
+},
+{
+color = 0;
+glyphname = nine;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(568,583,o),
+(499,724,o),
+(328,724,cs),
+(189,724,o),
+(104,633,o),
+(104,486,cs),
+(104,351,o),
+(180,266,o),
+(309,266,cs),
+(403,266,o),
+(473,311,o),
+(503,376,c),
+(506,376,l),
+(500,179,o),
+(427,44,o),
+(248,44,cs),
+(208,44,o),
+(170,50,o),
+(145,58,c),
+(145,0,l),
+(172,-7,o),
+(214,-12,o),
+(251,-12,cs),
+(487,-12,o),
+(568,178,o),
+(568,410,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(460,667,o),
+(496,540,o),
+(496,459,cs),
+(496,383,o),
+(409,321,o),
+(325,321,cs),
+(222,321,o),
+(170,385,o),
+(170,487,cs),
+(170,601,o),
+(227,667,o),
+(329,667,cs)
+);
+}
+);
+width = 628;
+}
+);
+unicode = 57;
+},
+{
+glyphname = zero.canadian;
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(385,-12,o),
+(454,382,o),
+(454,531,cs),
+(454,660,o),
+(407,727,o),
+(314,727,cs),
+(117,727,o),
+(51,332,o),
+(51,183,cs),
+(51,55,o),
+(98,-12,o),
+(192,-12,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(139,46,o),
+(112,88,o),
+(112,176,cs),
+(112,286,o),
+(168,669,o),
+(312,669,cs),
+(366,669,o),
+(393,627,o),
+(393,538,cs),
+(393,428,o),
+(336,46,o),
+(193,46,cs)
+);
+}
+);
+width = 456;
+}
+);
+metricRight = "=|";
+},
+{
+glyphname = one.canadian;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(182,0,l),
+(334,714,l),
+(277,714,l),
+(91,550,l),
+(127,508,l),
+(307,666,l),
+(261,671,l),
+(119,0,l)
+);
+}
+);
+width = 299;
+}
+);
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = two.canadian;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(363,59,l),
+(91.993,58.992,l),
+(91,34,l),
+(336,309,ls),
+(414,396,o),
+(458,487,o),
+(458,576,cs),
+(458,670,o),
+(403,727,o),
+(310,727,cs),
+(198,727,o),
+(124,646,o),
+(93,470,c),
+(156,470,l),
+(181,612,o),
+(229,670,o),
+(306,670,cs),
+(364,670,o),
+(396,636,o),
+(396,575,cs),
+(396,498,o),
+(353,417,o),
+(284,339,cs),
+(20,43,l),
+(10,0,l),
+(350,0,l)
+);
+}
+);
+width = 450;
+}
+);
+note = uni14BF;
+},
+{
+glyphname = three.canadian;
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(369,-13,o),
+(412,129,o),
+(412,226,cs),
+(412,299,o),
+(381,347,o),
+(322,367,c),
+(317,344,l),
+(445,355,o),
+(480,497,o),
+(480,574,cs),
+(480,671,o),
+(425,727,o),
+(329,727,cs),
+(221,727,o),
+(149,647,o),
+(115,487,c),
+(178,487,l),
+(208,616,o),
+(253,670,o),
+(325,670,cs),
+(384,670,o),
+(415,635,o),
+(415,568,cs),
+(415,509,o),
+(400,385,o),
+(282,385,cs),
+(254,385,l),
+(242,330,l),
+(271,330,ls),
+(321,330,o),
+(349,292,o),
+(349,229,cs),
+(349,165,o),
+(327,44,o),
+(214,44,cs),
+(106,44,o),
+(98,137,o),
+(118,227,c),
+(55,227,l),
+(28,110,o),
+(57,-13,o),
+(214,-13,cs)
+);
+}
+);
+width = 485;
+}
+);
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = four.canadian;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(297,0,l),
+(335,180,l),
+(417,180,l),
+(428,235,l),
+(347,235,l),
+(449,717,l),
+(398,717,l),
+(30,224,l),
+(20,180,l),
+(274,180,l),
+(236,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(397,649,l),
+(376,649,l),
+(288,235,l),
+(78,235,l),
+(80,220,l)
+);
+}
+);
+width = 456;
+}
+);
+},
+{
+glyphname = five.canadian;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(384,-13,o),
+(420,162,o),
+(420,255,cs),
+(420,356,o),
+(365,411,o),
+(255,411,cs),
+(162,411,l),
+(184,388,l),
+(262,672,l),
+(230,655,l),
+(494,655,l),
+(506,714,l),
+(211,714,l),
+(118,369,l),
+(126,354,l),
+(237,354,ls),
+(318,354,o),
+(356,322,o),
+(356,249,cs),
+(356,190,o),
+(340,44,o),
+(217,44,cs),
+(114,44,o),
+(100,126,o),
+(116,199,c),
+(53,199,l),
+(32,94,o),
+(73,-13,o),
+(215,-13,cs)
+);
+}
+);
+width = 478;
+}
+);
+},
+{
+glyphname = six.canadian;
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(347,-13,o),
+(406,152,o),
+(406,262,cs),
+(406,361,o),
+(355,427,o),
+(269,427,cs),
+(194,427,o),
+(132,371,o),
+(99,275,c),
+(116,270,l),
+(123,314,o),
+(127,336,o),
+(138,388,cs),
+(183,593,o),
+(245,670,o),
+(320,670,cs),
+(412,670,o),
+(410,580,o),
+(402,519,c),
+(464,519,l),
+(474,613,o),
+(449,727,o),
+(322,727,cs),
+(89,727,o),
+(46,230,o),
+(46,177,cs),
+(46,131,o),
+(53,94,o),
+(67,65,cs),
+(91,15,o),
+(138,-13,o),
+(199,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(140,43,o),
+(107,88,o),
+(107,160,cs),
+(107,234,o),
+(145,372,o),
+(255,372,cs),
+(313,372,o),
+(343,331,o),
+(343,260,cs),
+(343,189,o),
+(311,43,o),
+(201,43,cs)
+);
+}
+);
+width = 456;
+}
+);
+metricLeft = zero.canadian;
+},
+{
+glyphname = seven.canadian;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(106,0,l),
+(437,673,l),
+(446,714,l),
+(121,714,l),
+(108,655,l),
+(371,655,l),
+(374,676,l),
+(49,20,l),
+(46,0,l)
+);
+}
+);
+width = 378;
+}
+);
+},
+{
+glyphname = eight.canadian;
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(358,-13,o),
+(411,114,o),
+(417,210,cs),
+(423,286,o),
+(384,342,o),
+(327,363,c),
+(319,345,l),
+(426,358,o),
+(475,473,o),
+(481,555,cs),
+(488,658,o),
+(426,727,o),
+(325,727,cs),
+(191,727,o),
+(137,600,o),
+(130,506,cs),
+(124,429,o),
+(157,372,o),
+(215,352,c),
+(215,373,l),
+(95,357,o),
+(52,244,o),
+(47,162,cs),
+(39,59,o),
+(107,-13,o),
+(215,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(144,43,o),
+(106,85,o),
+(109,159,cs),
+(111,231,o),
+(143,331,o),
+(249,331,cs),
+(321,331,o),
+(359,288,o),
+(356,215,cs),
+(354,146,o),
+(325,43,o),
+(216,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(222,384,o),
+(189,425,o),
+(191,496,cs),
+(193,564,o),
+(221,671,o),
+(323,671,cs),
+(387,671,o),
+(421,630,o),
+(419,560,cs),
+(417,492,o),
+(384,384,o),
+(285,384,cs)
+);
+}
+);
+width = 489;
+}
+);
+metricLeft = "=|";
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = nine.canadian;
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(416,-13,o),
+(458,484,o),
+(458,537,cs),
+(458,583,o),
+(452,620,o),
+(438,649,cs),
+(414,699,o),
+(366,727,o),
+(305,727,cs),
+(157,727,o),
+(98,562,o),
+(98,452,cs),
+(98,353,o),
+(149,287,o),
+(235,287,cs),
+(310,287,o),
+(372,343,o),
+(405,439,c),
+(388,444,l),
+(381,400,o),
+(377,378,o),
+(366,326,cs),
+(322,121,o),
+(259,44,o),
+(184,44,cs),
+(92,44,o),
+(94,134,o),
+(102,195,c),
+(40,195,l),
+(30,101,o),
+(55,-13,o),
+(182,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(192,342,o),
+(161,383,o),
+(161,454,cs),
+(161,525,o),
+(193,671,o),
+(304,671,cs),
+(364,671,o),
+(397,626,o),
+(397,554,cs),
+(397,480,o),
+(359,342,o),
+(250,342,cs)
+);
+}
+);
+width = 456;
+}
+);
+metricLeft = "=|six.canadian";
+metricRight = "=|six.canadian";
+},
+{
+glyphname = CR;
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+width = 201;
+}
+);
+note = CR;
+unicode = 13;
+},
+{
+color = 0;
+glyphname = .notdef;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(605,714,l),
+(194,714,l),
+(194,0,l),
+(605,0,l),
+(605,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(554,663,l),
+(554,51,l),
+(245,51,l),
+(245,663,l),
+(245,663,l)
+);
+}
+);
+width = 700;
+}
+);
+note = ".notdef";
+},
+{
+glyphname = .null;
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+width = 0;
+}
+);
+note = NULL;
+},
+{
+glyphname = space;
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+width = 206;
+}
+);
+note = space;
+unicode = 32;
+},
+{
+glyphname = nbspace;
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+width = 201;
+}
+);
+note = uni00A0;
+unicode = 160;
+},
+{
+glyphname = space.canadian;
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+width = 400;
+}
+);
+note = space;
+},
+{
+glyphname = "hyphen-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(336,416,l),
+(345,457,l),
+(98,457,l),
+(89,416,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(306,278,l),
+(315,319,l),
+(68,319,l),
+(59,278,l)
+);
+}
+);
+width = 352;
+}
+);
+metricRight = "=|";
+note = uni1400;
+unicode = 5120;
+},
+{
+glyphname = "chi-canadian";
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(51,0,l),
+(243,319,l),
+(223,323,l),
+(281,0,l),
+(337,0,l),
+(342,20,l),
+(269,388,l),
+(259,336,l),
+(482,694,l),
+(487,714,l),
+(426,714,l),
+(238,400,l),
+(257,397,l),
+(202,714,l),
+(146,714,l),
+(141,694,l),
+(214,336,l),
+(223,388,l),
+(-5,20,l),
+(-10,0,l)
+);
+}
+);
+width = 432;
+}
+);
+metricRight = "=|";
+note = uni166D;
+unicode = 5741;
+},
+{
+glyphname = "fullstop-canadian";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(44,0,l),
+(132,147,l),
+(120,151,l),
+(148,0,l),
+(187,0,l),
+(189,10,l),
+(152,193,l),
+(148,167,l),
+(259,346,l),
+(262,357,l),
+(218,357,l),
+(129,208,l),
+(145,204,l),
+(117,357,l),
+(78,357,l),
+(75,346,l),
+(112,171,l),
+(117,196,l),
+(2,10,l),
+(0,0,l)
+);
+}
+);
+width = 291;
+}
+);
+note = uni1541;
+unicode = 5742;
+},
+{
+glyphname = period;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(25,8,o),
+(38,-9,o),
+(70,-9,cs),
+(97,-9,o),
+(114,11,o),
+(117,43,cs),
+(121,67,o),
+(108,84,o),
+(75,84,cs),
+(45,84,o),
+(31,61,o),
+(28,32,cs)
+);
+}
+);
+width = 215;
+}
+);
+note = period;
+unicode = 46;
+},
+{
+glyphname = comma;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(-8,-131,l),
+(38,-60,o),
+(82,37,o),
+(114,112,c),
+(112,123,l),
+(53,123,l),
+(26,47,o),
+(-8,-34,o),
+(-55,-131,c)
+);
+}
+);
+width = 190;
+}
+);
+note = comma;
+unicode = 44;
+},
+{
+glyphname = hyphen;
+kernLeft = hyphen;
+kernRight = hyphen;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(217,243,l),
+(228,299,l),
+(55,299,l),
+(43,243,l)
+);
+}
+);
+width = 261;
+}
+);
+unicode = 45;
+},
+{
+glyphname = quotesinglbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-14,-591);
+ref = quoteright;
+}
+);
+width = 206;
+}
+);
+unicode = 8218;
+},
+{
+glyphname = quotedblbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+pos = (-93,-591);
+ref = quotedblright;
+}
+);
+width = 417;
+}
+);
+unicode = 8222;
+},
+{
+glyphname = quotedblleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(328,459,l),
+(350,532,o),
+(392,630,o),
+(441,714,c),
+(397,714,l),
+(350,643,o),
+(303,553,o),
+(270,468,c),
+(274,459,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(164,459,l),
+(188,535,o),
+(226,627,o),
+(278,714,c),
+(234,714,l),
+(187,643,o),
+(139,553,o),
+(107,468,c),
+(111,459,l)
+);
+}
+);
+width = 398;
+}
+);
+unicode = 8220;
+},
+{
+glyphname = quotedblright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(309,459,l),
+(358,531,o),
+(406,624,o),
+(436,704,c),
+(432,714,l),
+(379,714,l),
+(356,639,o),
+(316,544,o),
+(265,459,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(146,459,l),
+(195,531,o),
+(243,624,o),
+(274,704,c),
+(269,714,l),
+(216,714,l),
+(194,642,o),
+(151,541,o),
+(103,459,c)
+);
+}
+);
+width = 398;
+}
+);
+unicode = 8221;
+},
+{
+glyphname = quoteleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(167,459,l),
+(190,532,o),
+(232,630,o),
+(281,714,c),
+(235,714,l),
+(187,643,o),
+(139,553,o),
+(107,468,c),
+(111,459,l)
+);
+}
+);
+width = 238;
+}
+);
+unicode = 8216;
+},
+{
+glyphname = quoteright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(150,459,l),
+(198,531,o),
+(246,624,o),
+(277,704,c),
+(273,714,l),
+(217,714,l),
+(195,642,o),
+(152,541,o),
+(103,459,c)
+);
+}
+);
+width = 238;
+}
+);
+unicode = 8217;
+},
+{
+glyphname = dottedCircle;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(210,522,o),
+(197,511,o),
+(197,496,cs),
+(197,483,o),
+(210,470,o),
+(223,470,cs),
+(238,470,o),
+(249,483,o),
+(249,496,cs),
+(249,511,o),
+(238,522,o),
+(223,522,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(378,522,o),
+(365,511,o),
+(365,496,cs),
+(365,483,o),
+(378,470,o),
+(391,470,cs),
+(406,470,o),
+(417,483,o),
+(417,496,cs),
+(417,511,o),
+(406,522,o),
+(391,522,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(210,112,o),
+(197,101,o),
+(197,86,cs),
+(197,73,o),
+(210,60,o),
+(223,60,cs),
+(238,60,o),
+(249,73,o),
+(249,86,cs),
+(249,101,o),
+(238,112,o),
+(223,112,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(378,112,o),
+(365,101,o),
+(365,86,cs),
+(365,73,o),
+(378,60,o),
+(391,60,cs),
+(406,60,o),
+(417,73,o),
+(417,86,cs),
+(417,101,o),
+(406,112,o),
+(391,112,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(294,540,o),
+(281,529,o),
+(281,514,cs),
+(281,501,o),
+(294,488,o),
+(307,488,cs),
+(322,488,o),
+(333,501,o),
+(333,514,cs),
+(333,529,o),
+(322,540,o),
+(307,540,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(294,94,o),
+(281,83,o),
+(281,68,cs),
+(281,55,o),
+(294,42,o),
+(307,42,cs),
+(322,42,o),
+(333,55,o),
+(333,68,cs),
+(333,83,o),
+(322,94,o),
+(307,94,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(58,278,o),
+(71,265,o),
+(84,265,cs),
+(99,265,o),
+(110,278,o),
+(110,291,cs),
+(110,306,o),
+(99,317,o),
+(84,317,cs),
+(71,317,o),
+(58,306,o),
+(58,291,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(504,278,o),
+(517,265,o),
+(530,265,cs),
+(545,265,o),
+(556,278,o),
+(556,291,cs),
+(556,306,o),
+(545,317,o),
+(530,317,cs),
+(517,317,o),
+(504,306,o),
+(504,291,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(123,120,o),
+(136,107,o),
+(149,107,cs),
+(164,107,o),
+(175,120,o),
+(175,133,cs),
+(175,148,o),
+(164,159,o),
+(149,159,cs),
+(136,159,o),
+(123,148,o),
+(123,133,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(123,436,o),
+(136,423,o),
+(149,423,cs),
+(164,423,o),
+(175,436,o),
+(175,449,cs),
+(175,464,o),
+(164,475,o),
+(149,475,cs),
+(136,475,o),
+(123,464,o),
+(123,449,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(439,120,o),
+(452,107,o),
+(465,107,cs),
+(480,107,o),
+(491,120,o),
+(491,133,cs),
+(491,148,o),
+(480,159,o),
+(465,159,cs),
+(452,159,o),
+(439,148,o),
+(439,133,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(439,436,o),
+(452,423,o),
+(465,423,cs),
+(480,423,o),
+(491,436,o),
+(491,449,cs),
+(491,464,o),
+(480,475,o),
+(465,475,cs),
+(452,475,o),
+(439,464,o),
+(439,449,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(76,194,o),
+(89,181,o),
+(102,181,cs),
+(117,181,o),
+(128,194,o),
+(128,207,cs),
+(128,222,o),
+(117,233,o),
+(102,233,cs),
+(89,233,o),
+(76,222,o),
+(76,207,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(76,362,o),
+(89,349,o),
+(102,349,cs),
+(117,349,o),
+(128,362,o),
+(128,375,cs),
+(128,390,o),
+(117,401,o),
+(102,401,cs),
+(89,401,o),
+(76,390,o),
+(76,375,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(486,194,o),
+(499,181,o),
+(512,181,cs),
+(527,181,o),
+(538,194,o),
+(538,207,cs),
+(538,222,o),
+(527,233,o),
+(512,233,cs),
+(499,233,o),
+(486,222,o),
+(486,207,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(486,362,o),
+(499,349,o),
+(512,349,cs),
+(527,349,o),
+(538,362,o),
+(538,375,cs),
+(538,390,o),
+(527,401,o),
+(512,401,cs),
+(499,401,o),
+(486,390,o),
+(486,375,cs)
+);
+}
+);
+width = 604;
+}
+);
+note = uni25CC;
+unicode = 9676;
+},
+{
+glyphname = dotaccentcomb;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(140,734,o),
+(123,713,o),
+(121,682,cs),
+(118,661,o),
+(130,647,o),
+(153,647,cs),
+(180,647,o),
+(196,667,o),
+(198,695,cs),
+(201,720,o),
+(189,734,o),
+(166,734,cs)
+);
+}
+);
+width = 130;
+}
+);
+note = uni0307;
+unicode = 775;
+},
+{
+glyphname = dotaccent;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(179,647,o),
+(193,658,o),
+(199,684,cs),
+(206,716,o),
+(193,734,o),
+(165,734,cs),
+(143,734,o),
+(129,722,o),
+(123,696,cs),
+(116,664,o),
+(128,647,o),
+(156,647,cs)
+);
+}
+);
+width = 132;
+}
+);
+note = dotaccent;
+unicode = 729;
+},
+{
+glyphname = caron;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(272,644,o),
+(313,700,o),
+(360,756,c),
+(363,764,l),
+(317,764,l),
+(287,733,o),
+(260,697,o),
+(223,651,c),
+(209,693,o),
+(195,731,o),
+(179,764,c),
+(138,764,l),
+(136,756,l),
+(157,708,o),
+(176,658,o),
+(186,606,c),
+(248,606,l),
+(248,606,l)
+);
+}
+);
+width = 280;
+}
+);
+note = caron;
+unicode = 711;
+},
+{
+glyphname = breve;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(281,606,o),
+(322,648,o),
+(340,734,c),
+(300,734,l),
+(285,679,o),
+(259,650,o),
+(222,650,cs),
+(182,650,o),
+(162,682,o),
+(169,734,c),
+(131,734,l),
+(117,655,o),
+(152,606,o),
+(219,606,cs)
+);
+}
+);
+width = 264;
+}
+);
+note = breve;
+unicode = 728;
+},
+{
+glyphname = ring;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(247,609,o),
+(282,653,o),
+(282,715,cs),
+(282,774,o),
+(247,820,o),
+(204,820,cs),
+(161,820,o),
+(127,776,o),
+(127,715,cs),
+(127,651,o),
+(161,609,o),
+(204,609,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(178,647,o),
+(161,678,o),
+(161,715,cs),
+(161,753,o),
+(180,783,o),
+(204,783,cs),
+(228,783,o),
+(247,752,o),
+(247,715,cs),
+(247,678,o),
+(229,647,o),
+(204,647,cs)
+);
+}
+);
+width = 209;
+}
+);
+note = ring;
+unicode = 730;
+},
+{
+glyphname = ogonek;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(16,-222,o),
+(33,-219,o),
+(44,-213,c),
+(54,-170,l),
+(45,-174,o),
+(29,-178,o),
+(18,-178,cs),
+(-6,-178,o),
+(-14,-158,o),
+(-7,-121,cs),
+(2,-83,o),
+(31,-42,o),
+(75,0,c),
+(51,14,l),
+(-9,-37,o),
+(-42,-84,o),
+(-53,-132,cs),
+(-64,-187,o),
+(-43,-222,o),
+(1,-222,cs)
+);
+}
+);
+width = 170;
+}
+);
+note = ogonek;
+unicode = 731;
+},
+{
+glyphname = ring_top.canadian;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (219,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(300,784,o),
+(338,821,o),
+(338,870,cs),
+(338,920,o),
+(300,956,o),
+(252,956,cs),
+(203,956,o),
+(165,920,o),
+(165,870,cs),
+(165,821,o),
+(203,784,o),
+(252,784,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(220,816,o),
+(199,838,o),
+(199,870,cs),
+(199,901,o),
+(220,924,o),
+(252,924,cs),
+(283,924,o),
+(305,901,o),
+(305,870,cs),
+(305,838,o),
+(283,816,o),
+(252,816,cs)
+);
+}
+);
+width = 237;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (84,357);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(108,316,o),
+(126,334,o),
+(126,357,cs),
+(126,380,o),
+(108,398,o),
+(85,398,cs),
+(61,398,o),
+(43,380,o),
+(43,357,cs),
+(43,334,o),
+(61,316,o),
+(84,316,cs)
+);
+}
+);
+width = 121;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (79,357);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,320,o),
+(116.005,336.009,o),
+(116.005,357,cs),
+(116.005,377.991,o),
+(100,394,o),
+(79,394,cs),
+(58,394,o),
+(42,378,o),
+(42,357,cs),
+(42,336,o),
+(58,320,o),
+(79,320,cs)
+);
+}
+);
+width = 111;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_small;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (74,357);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(92,325,o),
+(106,339,o),
+(106,357,cs),
+(106,375,o),
+(92,389,o),
+(74,389,cs),
+(56,389,o),
+(42,375,o),
+(42,357,cs),
+(42,339,o),
+(56,325,o),
+(74,325,cs)
+);
+}
+);
+width = 102;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_top;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (161,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(215,817,o),
+(233,836,o),
+(233,859,cs),
+(233,883,o),
+(215,901,o),
+(191,901,cs),
+(168,901,o),
+(149,883,o),
+(149,859,cs),
+(149,836,o),
+(168,817,o),
+(191,817,cs)
+);
+}
+);
+width = 121;
+}
+);
+note = g725;
+},
+{
+glyphname = doubledot_middle;
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(162,403,o),
+(181,421,o),
+(181,444,cs),
+(181,468,o),
+(162,486,o),
+(139,486,cs),
+(115,486,o),
+(97,468,o),
+(97,444,cs),
+(97,421,o),
+(115,403,o),
+(139,403,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(125,228,o),
+(144,246,o),
+(144,270,cs),
+(144,293,o),
+(125,311,o),
+(102,311,cs),
+(78,311,o),
+(60,293,o),
+(60,270,cs),
+(60,246,o),
+(78,228,o),
+(102,228,cs)
+);
+}
+);
+width = 194;
+}
+);
+metricRight = "=|";
+note = g725;
+},
+{
+glyphname = doubledot_top;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top_double;
+pos = (296,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(349,817,o),
+(367,836,o),
+(367,859,cs),
+(367,883,o),
+(349,901,o),
+(325,901,cs),
+(302,901,o),
+(283,882,o),
+(283,859,cs),
+(283,836,o),
+(302,817,o),
+(325,817,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(215,817,o),
+(234,836,o),
+(234,859,cs),
+(234,883,o),
+(215,901,o),
+(192,901,cs),
+(168,901,o),
+(150,883,o),
+(150,859,cs),
+(150,836,o),
+(168,817,o),
+(192,817,cs)
+);
+}
+);
+width = 256;
+}
+);
+note = g725;
+},
+{
+glyphname = g727;
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (366,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(417,0,l),
+(429,54,l),
+(210,54,ls),
+(140,54,o),
+(105,87,o),
+(105,153,cs),
+(105,212,o),
+(120,330,o),
+(260,330,cs),
+(324,330,ls),
+(499,330,o),
+(544,466,o),
+(544,564,cs),
+(544,658,o),
+(489,714,o),
+(397,714,cs),
+(162,714,l),
+(150,660,l),
+(376,660,ls),
+(445,660,o),
+(481,626,o),
+(481,560,cs),
+(481,498,o),
+(463,385,o),
+(325,385,cs),
+(262,385,ls),
+(85,385,o),
+(42,246,o),
+(42,149,cs),
+(42,56,o),
+(96,0,o),
+(189,0,cs)
+);
+}
+);
+width = 538;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+glyphname = g728;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (205,0);
+ref = dot_top;
+}
+);
+width = 539;
+}
+);
+note = g728;
+},
+{
+glyphname = g729;
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (367,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(246,0,ls),
+(430,0,o),
+(475,135,o),
+(475,242,cs),
+(475,333,o),
+(420,385,o),
+(330,385,cs),
+(279,385,ls),
+(211,385,o),
+(175,413,o),
+(175,475,cs),
+(175,547,o),
+(194,660,o),
+(339,660,cs),
+(560,660,l),
+(572,714,l),
+(339,714,ls),
+(155,714,o),
+(111,578,o),
+(111,472,cs),
+(111,381,o),
+(165,330,o),
+(255,330,cs),
+(306,330,ls),
+(374,330,o),
+(411,301,o),
+(411,238,cs),
+(411,168,o),
+(387,54,o),
+(246,54,cs),
+(25,54,l),
+(13,0,l)
+);
+}
+);
+width = 539;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+glyphname = g730;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (206,0);
+ref = dot_top;
+}
+);
+width = 538;
+}
+);
+note = g730;
+},
+{
+glyphname = g731;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = g727;
+}
+);
+width = 714;
+}
+);
+note = g731;
+},
+{
+glyphname = g732;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (539,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 714;
+}
+);
+note = g732;
+},
+{
+glyphname = g733;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (381,0);
+ref = dot_top;
+}
+);
+width = 714;
+}
+);
+note = g733;
+},
+{
+glyphname = g734;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (205,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (539,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 714;
+}
+);
+note = g734;
+},
+{
+glyphname = g735;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = g729;
+}
+);
+width = 713;
+}
+);
+note = g735;
+},
+{
+glyphname = g736;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (538,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 713;
+}
+);
+note = g736;
+},
+{
+glyphname = g737;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (382,0);
+ref = dot_top;
+}
+);
+width = 713;
+}
+);
+note = g737;
+},
+{
+glyphname = g738;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (206,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (538,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 713;
+}
+);
+note = g738;
+},
+{
+glyphname = g739;
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(446,222,o),
+(478,329,o),
+(478,395,cs),
+(478,458,o),
+(447,493,o),
+(393,493,cs),
+(250,493,l),
+(254,478,l),
+(296,509,o),
+(310,582,o),
+(310,621,cs),
+(310,682,o),
+(279,720,o),
+(228,720,cs),
+(143,720,o),
+(111,612,o),
+(111,546,cs),
+(111,484,o),
+(142,449,o),
+(196,449,cs),
+(339,449,l),
+(335,464,l),
+(292,432,o),
+(279,360,o),
+(279,322,cs),
+(279,260,o),
+(310,222,o),
+(361,222,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(165,485,o),
+(151,506,o),
+(151,545,cs),
+(151,585,o),
+(167,683,o),
+(225,683,cs),
+(254,683,o),
+(269,662,o),
+(269,621,cs),
+(269,585,o),
+(252,485,o),
+(193,485,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(335,258,o),
+(320,280,o),
+(320,321,cs),
+(320,357,o),
+(335,456,o),
+(396,456,cs),
+(424,456,o),
+(438,436,o),
+(438,397,cs),
+(438,357,o),
+(422,258,o),
+(364,258,cs)
+);
+}
+);
+width = 493;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+glyphname = g740;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (148,0);
+ref = ring_top.canadian;
+}
+);
+width = 539;
+}
+);
+note = g740;
+},
+{
+glyphname = g741;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (149,0);
+ref = ring_top.canadian;
+}
+);
+width = 538;
+}
+);
+note = g741;
+},
+{
+glyphname = g742;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (323,0);
+ref = ring_top.canadian;
+}
+);
+width = 714;
+}
+);
+note = g742;
+},
+{
+glyphname = stroke_middle;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (63,357);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(60,244,l),
+(108,470,l),
+(66,470,l),
+(19,244,l)
+);
+}
+);
+width = 78;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (59,357);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(56,258,l),
+(98,456,l),
+(63,456,l),
+(22,258,l)
+);
+}
+);
+width = 71;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_small;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (57,357);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(52,261,l),
+(92,453,l),
+(63,453,l),
+(22,261,l)
+);
+}
+);
+width = 66;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_threequart;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (63,357);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(59,245,l),
+(106,469,l),
+(68,469,l),
+(21,245,l)
+);
+}
+);
+width = 78;
+}
+);
+note = g723;
+},
+{
+color = 8;
+glyphname = uni11AB0;
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (231,714);
+},
+{
+name = top_right_can;
+pos = (463,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(111,0,l),
+(136,121,l),
+(326,121,l),
+(335,163,l),
+(146,163,l),
+(172,289,l),
+(125,268,l),
+(157,268,ls),
+(320,268,o),
+(417,351,o),
+(459,547,cs),
+(494,714,l),
+(431,714,l),
+(396,550,ls),
+(363,396,o),
+(289,326,o),
+(162,326,cs),
+(117,326,l),
+(82,163,l),
+(19,163,l),
+(11,121,l),
+(73,121,l),
+(47,0,l)
+);
+}
+);
+width = 458;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB1;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB0;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (301,0);
+ref = dot_top;
+}
+);
+width = 456;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB2;
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (195,714);
+},
+{
+name = top_right_can;
+pos = (427,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(75,0,l),
+(110,164,ls),
+(143,318,o),
+(217,388,o),
+(344,388,cs),
+(389,388,l),
+(424,551,l),
+(487,551,l),
+(495,593,l),
+(433,593,l),
+(459,714,l),
+(395,714,l),
+(370,593,l),
+(180,593,l),
+(171,551,l),
+(360,551,l),
+(334,425,l),
+(381,446,l),
+(349,446,ls),
+(186,446,o),
+(88,363,o),
+(47,167,cs),
+(11,0,l)
+);
+}
+);
+width = 458;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "theThCree-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB3;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB2;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (266,0);
+ref = dot_top;
+}
+);
+width = 457;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB4;
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (231,714);
+},
+{
+name = top_right_can;
+pos = (463,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(342,0,l),
+(375,154,ls),
+(418,353,o),
+(336,446,o),
+(167,446,cs),
+(154,446,l),
+(200,422,l),
+(228,551,l),
+(417,551,l),
+(425,593,l),
+(237,593,l),
+(263,714,l),
+(199,714,l),
+(173,593,l),
+(110,593,l),
+(101,551,l),
+(164,551,l),
+(130,388,l),
+(155,388,ls),
+(292,388,o),
+(349,326,o),
+(312,156,cs),
+(279,0,l)
+);
+}
+);
+width = 457;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB5;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB4;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (69,0);
+ref = dot_top;
+}
+);
+width = 456;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB6;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (197,714);
+},
+{
+name = top_right_can;
+pos = (429,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(76,1,l),
+(138,293,l),
+(86,269,l),
+(116,269,ls),
+(287,269,o),
+(382,354,o),
+(425,553,cs),
+(454,687,l),
+(406,677,l),
+(545,481,l),
+(594,517,l),
+(453,715,l),
+(396,715,l),
+(362,557,ls),
+(327,396,o),
+(251,327,o),
+(118,327,cs),
+(82,327,l),
+(12,1,l)
+);
+}
+);
+width = 560;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB7;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB6;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (269,0);
+ref = dot_top;
+}
+);
+width = 560;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB8;
+kernRight = soright;
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (333,714);
+},
+{
+name = top_right_can;
+pos = (564,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(213,0,l),
+(247,158,ls),
+(281,319,o),
+(357,388,o),
+(490,388,cs),
+(527,388,l),
+(596,714,l),
+(533,714,l),
+(470,422,l),
+(522,446,l),
+(493,446,ls),
+(321,446,o),
+(226,361,o),
+(184,162,cs),
+(155,28,l),
+(202,38,l),
+(63,234,l),
+(14,198,l),
+(155,0,l)
+);
+}
+);
+width = 560;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB9;
+kernRight = soright;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB8;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (402,0);
+ref = dot_top;
+}
+);
+width = 560;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABA;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:30:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (195,714);
+},
+{
+name = top_right_can;
+pos = (428,714);
+}
+);
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(302,0,l),
+(526,198,l),
+(489,241,l),
+(287,61,l),
+(318,54,l),
+(331,112,ls),
+(372,304,o),
+(304,445,o),
+(148,445,cs),
+(127,445,l),
+(163,410,l),
+(228,714,l),
+(164,714,l),
+(95,388,l),
+(122,388,ls),
+(257,388,o),
+(306,286,o),
+(266,99,cs),
+(245,0,l)
+);
+}
+);
+width = 560;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABB;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+alignment = -1;
+ref = uni11ABA;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+}
+);
+width = 560;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABC;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(355,0,l),
+(368,59,l),
+(66,59,l),
+(64,30,l),
+(504,668,l),
+(513,714,l),
+(149.005,714,l),
+(136,655,l),
+(438,655,l),
+(440,684,l),
+(0,46,l),
+(-10,0,l)
+);
+}
+);
+width = 456;
+}
+);
+metricRight = "=|";
+},
+{
+color = 8;
+glyphname = uni11ABD;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(362,0,l),
+(372,46,l),
+(194,684,l),
+(193,655,l),
+(495,655,l),
+(508,714,l),
+(142,714,l),
+(133,668,l),
+(311,30,l),
+(311,59,l),
+(10,59,l),
+(-3,0,l)
+);
+}
+);
+width = 456;
+}
+);
+metricLeft = "=|uni11ABC";
+metricRight = "=|uni11ABC";
+},
+{
+color = 8;
+glyphname = uni11ABE;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(75,0,l),
+(214,651,l),
+(178,651,l),
+(351,0,l),
+(408,0,l),
+(560,714,l),
+(497,714,l),
+(358,63,l),
+(395,63,l),
+(221,714,l),
+(165,714,l),
+(13,0,l)
+);
+}
+);
+width = 525;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABF;
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(69,0,l),
+(529,655,l),
+(485,655,l),
+(345,0,l),
+(408,0,l),
+(560,714,l),
+(503,714,l),
+(43,59,l),
+(88,59,l),
+(227,714,l),
+(165,714,l),
+(13,0,l)
+);
+}
+);
+width = 525;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = "raiseddoubledotFinal-canadian.cree";
+lastChange = "2023-01-13 15:28:16 +0000";
+layers = (
+{
+layerId = "A0BEBE03-9AB7-4E04-894D-4F686A7231C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(209,643,o),
+(227,661,o),
+(227,685,cs),
+(227,708,o),
+(209,727,o),
+(185,727,cs),
+(162,727,o),
+(143,708,o),
+(143,685,cs),
+(143,661,o),
+(162,643,o),
+(185,643,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(172,468,o),
+(191,486,o),
+(191,510,cs),
+(191,533,o),
+(172,552,o),
+(149,552,cs),
+(125,552,o),
+(107,534,o),
+(107,510,cs),
+(107,486,o),
+(125,468,o),
+(149,468,cs)
+);
+}
+);
+width = 184;
+}
+);
+note = g725;
+}
+);
+instances = (
+{
+axesValues = (
+67,
+68,
+12
+);
+instanceInterpolations = {
+"A0BEBE03-9AB7-4E04-894D-4F686A7231C4" = 1;
+};
+name = "RC CL Italic";
+}
+);
+kerningLTR = {
+"A0BEBE03-9AB7-4E04-894D-4F686A7231C4" = {
+"@MMK_L_caright" = {
+"@MMK_R_ecanleft" = -66;
+"@MMK_R_mwestleft" = -25;
+"@MMK_R_neleft" = -51;
+};
+"@MMK_L_ciright" = {
+"@MMK_R_icanleft" = -66;
+"@MMK_R_noleft" = -88;
+};
+"@MMK_L_ecanright" = {
+"@MMK_R_coleft" = -66;
+"@MMK_R_moleft" = -66;
+"@MMK_R_sileft" = -36;
+};
+"@MMK_L_icanright" = {
+"@MMK_R_celeft" = -66;
+"@MMK_R_meleft" = -66;
+"@MMK_R_mwestleft" = -39;
+"@MMK_R_saleft" = -31;
+"she-canadian" = -66;
+};
+"@MMK_L_maright" = {
+"@MMK_R_acanleft" = -63;
+"@MMK_R_ecanleft" = -66;
+"@MMK_R_mwestleft" = -47;
+"@MMK_R_neleft" = -51;
+};
+"@MMK_L_miright" = {
+"@MMK_R_acanleft" = -63;
+"@MMK_R_icanleft" = -66;
+"@MMK_R_moleft" = -88;
+"@MMK_R_noleft" = -88;
+"@MMK_R_yeleft" = -88;
+};
+"@MMK_L_mwestright" = {
+"@MMK_R_coleft" = -25;
+"@MMK_R_icanleft" = -39;
+"@MMK_R_moleft" = -47;
+"@MMK_R_noleft" = -75;
+"@MMK_R_sileft" = -13;
+"@MMK_R_yeleft" = -20;
+};
+"@MMK_L_naright" = {
+"@MMK_R_acanleft" = -83;
+"@MMK_R_celeft" = -88;
+"@MMK_R_meleft" = -88;
+"@MMK_R_mwestleft" = -75;
+"@MMK_R_neleft" = -103;
+"@MMK_R_saleft" = -58;
+};
+"@MMK_L_niright" = {
+"@MMK_R_coleft" = -51;
+"@MMK_R_moleft" = -51;
+"@MMK_R_noleft" = -103;
+"@MMK_R_sileft" = -4;
+};
+"@MMK_L_ocanright" = {
+"@MMK_R_meleft" = -63;
+"@MMK_R_moleft" = -63;
+"@MMK_R_noleft" = -83;
+};
+"@MMK_L_seright" = {
+"@MMK_R_ecanleft" = -36;
+"@MMK_R_mwestleft" = -13;
+"@MMK_R_neleft" = -4;
+};
+"@MMK_L_soright" = {
+"@MMK_R_icanleft" = -31;
+"@MMK_R_noleft" = -58;
+};
+"@MMK_L_yiright" = {
+"@MMK_R_meleft" = -88;
+"@MMK_R_mwestleft" = -20;
+};
+"shi-canadian" = {
+"@MMK_R_icanleft" = -66;
+};
+};
+};
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "italic angle";
+}
+);
+properties = (
+{
+key = copyrights;
+values = (
+{
+language = ENG;
+value = "Copyright 2018 Google Inc. All Rights Reserved.";
+}
+);
+},
+{
+key = manufacturers;
+values = (
+{
+language = ENG;
+value = "Monotype Imaging Inc.";
+}
+);
+},
+{
+key = designers;
+values = (
+{
+language = ENG;
+value = "Monotype Design Team";
+}
+);
+},
+{
+key = description;
+value = "Designed by Monotype design team.";
+},
+{
+key = trademarks;
+values = (
+{
+language = ENG;
+value = "Noto is a trademark of Google Inc.";
+}
+);
+},
+{
+key = licenseURL;
+value = "http://scripts.sil.org/OFL";
+},
+{
+key = licenses;
+values = (
+{
+language = ENG;
+value = "This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.";
+}
+);
+},
+{
+key = manufacturerURL;
+value = "http://www.google.com/get/noto/";
+},
+{
+key = designerURL;
+value = "http://www.monotype.com/studio";
+}
+);
+settings = {
+disablesNiceNames = 1;
+};
+stems = (
+{
+name = "New Stem";
+}
+);
+unitsPerEm = 1000;
+userData = {
+GSDontShowVersionAlert = 1;
+};
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/sources/Exported instances UCAS SansCanadianAboriginal/Sans Canadian Aboriginal-RC CL roman.glyphs
+++ b/sources/Exported instances UCAS SansCanadianAboriginal/Sans Canadian Aboriginal-RC CL roman.glyphs
@@ -1,0 +1,37309 @@
+{
+.appVersion = "3151";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+},
+{
+name = Width;
+tag = wdth;
+},
+{
+name = Slant;
+tag = slnt;
+}
+);
+classes = (
+{
+code = "zero one two three four five six seven eight nine ";
+name = Num;
+},
+{
+code = "zero.canadian one.canadian two.canadian three.canadian four.canadian five.canadian six.canadian seven.canadian eight.canadian nine.canadian 
+";
+name = Num_can;
+},
+{
+code = "ke-canadian.square ki-canadian.square kii-canadian.square ko-canadian.square koo-canadian.square ka-canadian.square kaa-canadian.square kweWestCree-canadian.square kwiiWestCree-canadian.square kwoWestCree-canadian.square kwooWestCree-canadian.square kwaWestCree-canadian.square kwaaWestCree-canadian.square ce-canadian.square ci-canadian.square cii-canadian.square co-canadian.square coo-canadian.square ca-canadian.square caa-canadian.square me-canadian.square mi-canadian.square mii-canadian.square mo-canadian.square moo-canadian.square ma-canadian.square maa-canadian.square ne-canadian.square ni-canadian.square nii-canadian.square no-canadian.square noo-canadian.square na-canadian.square naa-canadian.square nweWestCree-canadian.square nwaWestCree-canadian.square nwaaWestCree-canadian.square se-canadian.square si-canadian.square sii-canadian.square so-canadian.square soo-canadian.square sa-canadian.square saa-canadian.square sho-canadian.square shoo-canadian.square sha-canadian.square shaa-canadian.square ye-canadian.square yi-canadian.square yii-canadian.square yo-canadian.square yoo-canadian.square ya-canadian.square yaa-canadian.square re-canadian.square reRCree-canadian.square leWestCree-canadian.square ri-canadian.square rii-canadian.square ro-canadian.square loWestCree-canadian.square ra-canadian.square raa-canadian.square laWestCree-canadian.square reWestCree-canadian.square riWestCree-canadian.square roWestCree-canadian.square raWestCree-canadian.square theThCree-canadian.square thiThCree-canadian.square thiiThCree-canadian.square thoThCree-canadian.square thooThCree-canadian.square thaThCree-canadian.square thaaThCree-canadian.square thweeWoodScree-canadian.square thwiWoodScree-canadian.square thwiiWoodScree-canadian.square thwoWoodScree-canadian.square thwooWoodScree-canadian.square thwaWoodScree-canadian.square thwaaWoodScree-canadian.square nwiOjibway-canadian.square nwiiOjibway-canadian.square nwoOjibway-canadian.square nwooOjibway-canadian.square looWestCree-canadian.square laaWestCree-canadian.square ";
+name = Dene_square;
+},
+{
+code = "ke-canadian ki-canadian kii-canadian ko-canadian koo-canadian ka-canadian kaa-canadian kweWestCree-canadian kwiiWestCree-canadian kwoWestCree-canadian kwooWestCree-canadian kwaWestCree-canadian kwaaWestCree-canadian ce-canadian ci-canadian cii-canadian co-canadian coo-canadian ca-canadian caa-canadian me-canadian mi-canadian mii-canadian mo-canadian moo-canadian ma-canadian maa-canadian ne-canadian ni-canadian nii-canadian no-canadian noo-canadian na-canadian naa-canadian nweWestCree-canadian nwaWestCree-canadian nwaaWestCree-canadian se-canadian si-canadian sii-canadian so-canadian soo-canadian sa-canadian saa-canadian sho-canadian shoo-canadian sha-canadian shaa-canadian ye-canadian yi-canadian yii-canadian yo-canadian yoo-canadian ya-canadian yaa-canadian re-canadian reRCree-canadian leWestCree-canadian ri-canadian rii-canadian ro-canadian loWestCree-canadian ra-canadian raa-canadian laWestCree-canadian reWestCree-canadian riWestCree-canadian roWestCree-canadian raWestCree-canadian theThCree-canadian thiThCree-canadian thiiThCree-canadian thoThCree-canadian thooThCree-canadian thaThCree-canadian thaaThCree-canadian thweeWoodScree-canadian thwiWoodScree-canadian thwiiWoodScree-canadian thwoWoodScree-canadian thwooWoodScree-canadian thwaWoodScree-canadian thwaaWoodScree-canadian nwiOjibway-canadian nwiiOjibway-canadian nwoOjibway-canadian nwooOjibway-canadian looWestCree-canadian laaWestCree-canadian 
+";
+name = Dene_round;
+},
+{
+code = "acuteFinal-canadian.mid graveFinal-canadian.mid ringTophalfFinal-canadian.mid ringRighthalfFinal-canadian.mid ringFinal-canadian.mid doubleacuteFinal-canadian.mid doubleshortverticalstrokesFinal-canadian.mid shorthorizontalstrokeFinal-canadian.mid downtackFinal-canadian.mid pWestCree-canadian.mid c-canadian.mid mWestCree-canadian.mid ";
+name = Final_mid;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian ringFinal-canadian doubleacuteFinal-canadian doubleshortverticalstrokesFinal-canadian shorthorizontalstrokeFinal-canadian downtackFinal-canadian pWestCree-canadian c-canadian mWestCree-canadian ";
+name = Final_mid_ori;
+},
+{
+code = "acuteFinal-canadian.base graveFinal-canadian.base ringBottomhalfFinal-canadian.base ringTophalfFinal-canadian.base ringRighthalfFinal-canadian.base plusFinal-canadian.base pWestCree-canadian.base c-canadian.base thSayisi-canadian.base mWestCree-canadian.base ";
+name = Final_base;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringBottomhalfFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian plusFinal-canadian pWestCree-canadian c-canadian thSayisi-canadian mWestCree-canadian ";
+name = Final_base_ori;
+},
+{
+code = "ng-canadian ngai-canadian ngaai-canadian ngi-canadian ngii-canadian ngo-canadian ngoo-canadian nga-canadian ngaa-canadian ";
+name = Nunavik;
+},
+{
+code = "ng-canadian.nunavik ngai-canadian.nunavik ngaai-canadian.nunavik ngi-canadian.nunavik ngii-canadian.nunavik ngo-canadian.nunavik ngoo-canadian.nunavik nga-canadian.nunavik ngaa-canadian.nunavik ";
+name = Nunavik_alt;
+}
+);
+customParameters = (
+{
+name = vendorID;
+value = GOOG;
+},
+{
+name = panose;
+value = (
+2,
+11,
+5,
+2,
+4,
+5,
+4,
+2,
+2,
+4
+);
+},
+{
+name = unicodeRanges;
+value = (
+0,
+1,
+2,
+5,
+6,
+45,
+77
+);
+},
+{
+name = codePageRanges;
+value = (
+"1252"
+);
+},
+{
+name = fsType;
+value = (
+);
+}
+);
+date = "2022-06-21 10:06:40 +0000";
+familyName = "Sans Canadian Aboriginal";
+featurePrefixes = (
+{
+automatic = 1;
+code = "languagesystem DFLT dflt;
+
+languagesystem cans dflt;
+";
+name = Languagesystems;
+}
+);
+features = (
+{
+automatic = 1;
+code = "feature ss01;
+feature ss02;
+feature ss03;
+feature ss04;
+";
+tag = aalt;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+tag = salt;
+},
+{
+code = "lookup space_can {
+sub space by space.canadian;
+} space_can;
+
+lookup num_can {
+sub @Num by @Num_can;
+} num_can;
+";
+labels = (
+{
+language = dflt;
+value = "CAN Space and numerals";
+}
+);
+tag = ss01;
+},
+{
+code = "lookup dene_square {
+sub @Dene_round by @Dene_square;
+} dene_square;
+
+";
+labels = (
+{
+language = dflt;
+value = "Dene Square";
+}
+);
+tag = ss02;
+},
+{
+code = "lookup nunavik_alt {
+sub @Nunavik by @Nunavik_alt;
+} nunavik_alt;
+
+";
+labels = (
+{
+language = dflt;
+value = "Nunanvik Alt";
+}
+);
+tag = ss03;
+},
+{
+code = "lookup final_mid {
+sub @Final_mid_ori by @Final_mid;
+} final_mid;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final mid";
+}
+);
+tag = ss04;
+},
+{
+code = "lookup final_base {
+sub @Final_base_ori by @Final_base;
+} final_base;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final base";
+}
+);
+tag = ss05;
+},
+{
+code = "lookup plaincree_first {
+sub wiWestCree-canadian' plusFinal-canadian by i-canadian;
+} plaincree_first;
+
+lookup plaincree_second {
+sub i-canadian plusFinal-canadian' by raiseddoubledotFinal-canadian.cree;
+} plaincree_second;
+
+lookup plaincree_third {
+sub middledotFinal-canadian plusFinal-canadian by raiseddoubledotFinal-canadian.cree;
+} plaincree_third;
+";
+labels = (
+{
+language = dflt;
+value = Plaincree;
+}
+);
+tag = ss06;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+labels = (
+{
+language = dflt;
+value = "";
+}
+);
+tag = ss07;
+}
+);
+fontMaster = (
+{
+axesValues = (
+0,
+0,
+0
+);
+customParameters = (
+{
+name = typoAscender;
+value = 1069;
+},
+{
+name = typoDescender;
+value = -293;
+},
+{
+name = typoLineGap;
+value = 0;
+},
+{
+name = winAscent;
+value = 1069;
+},
+{
+name = winDescent;
+value = 293;
+},
+{
+name = hheaAscender;
+value = 1069;
+},
+{
+name = hheaDescender;
+value = -293;
+},
+{
+name = strikeoutPosition;
+value = 293.66467;
+},
+{
+name = strikeoutSize;
+value = 50;
+}
+);
+guides = (
+{
+lockAngle = 1;
+locked = 1;
+pos = (230,357);
+}
+);
+id = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+metricValues = (
+{
+over = 17;
+pos = 1069;
+},
+{
+over = 17;
+pos = 714;
+},
+{
+over = 17;
+pos = 489;
+},
+{
+over = -17;
+},
+{
+over = -17;
+pos = -293;
+},
+{
+}
+);
+name = "RC CL roman";
+stemValues = (
+63
+);
+}
+);
+glyphs = (
+{
+glyphname = idotless;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(120,534,l),
+(57,534,l),
+(57,0,l),
+(120,0,l)
+);
+}
+);
+width = 177;
+}
+);
+note = dotlessi;
+unicode = 305;
+},
+{
+glyphname = "acuteFinal-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(80,357,l),
+(204,714,l),
+(154,714,l),
+(30,357,l)
+);
+}
+);
+width = 234;
+}
+);
+metricRight = "=|";
+note = uni141F;
+unicode = 5151;
+},
+{
+glyphname = "graveFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(204,357,l),
+(80,714,l),
+(30,714,l),
+(154,357,l)
+);
+}
+);
+width = 234;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+unicode = 5152;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(236,351,o),
+(277,398,o),
+(277,490,cs),
+(277,714,l),
+(232,714,l),
+(232,487,ls),
+(232,421,o),
+(211,393,o),
+(165,393,cs),
+(119,393,o),
+(97,422,o),
+(97,486,cs),
+(97,714,l),
+(52,714,l),
+(52,487,ls),
+(52,399,o),
+(94,351,o),
+(165,351,cs)
+);
+}
+);
+width = 329;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1421;
+unicode = 5153;
+},
+{
+glyphname = "ringTophalfFinal-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,357,l),
+(97,585,ls),
+(97,649,o),
+(119,678,o),
+(165,678,cs),
+(211,678,o),
+(232,650,o),
+(232,585,cs),
+(232,357,l),
+(277,357,l),
+(277,581,ls),
+(277,673,o),
+(236,720,o),
+(165,720,cs),
+(94,720,o),
+(52,672,o),
+(52,584,cs),
+(52,357,l)
+);
+}
+);
+width = 329;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+unicode = 5154;
+},
+{
+glyphname = "ringRighthalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(74,357,ls),
+(181,357,o),
+(235,422,o),
+(235,535,cs),
+(235,647,o),
+(181,714,o),
+(76,714,cs),
+(48,714,l),
+(48,670,l),
+(71,670,ls),
+(152,670,o),
+(189,622,o),
+(189,535,cs),
+(189,446,o),
+(152,401,o),
+(71,401,cs),
+(48,401,l),
+(48,357,l)
+);
+}
+);
+width = 286;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+unicode = 5155;
+},
+{
+glyphname = "ringFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(299,411,o),
+(362,477,o),
+(362,566,cs),
+(362,653,o),
+(298,720,o),
+(207,720,cs),
+(115,720,o),
+(51,654,o),
+(51,566,cs),
+(51,477,o),
+(115,411,o),
+(207,411,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(139,451,o),
+(94,497,o),
+(94,566,cs),
+(94,634,o),
+(139,680,o),
+(207,680,cs),
+(274,680,o),
+(319,633,o),
+(319,566,cs),
+(319,497,o),
+(274,451,o),
+(207,451,cs)
+);
+}
+);
+width = 413;
+}
+);
+note = uni1424;
+unicode = 5156;
+},
+{
+glyphname = "doubleacuteFinal-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(204,714,l),
+(154,714,l),
+(30,357,l),
+(80,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(314,714,l),
+(264,714,l),
+(140,357,l),
+(191,357,l)
+);
+}
+);
+width = 344;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricRight = "=|";
+note = uni1425;
+unicode = 5157;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,714,l),
+(52,714,l),
+(52,357,l),
+(97,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(196,714,l),
+(151,714,l),
+(151,357,l),
+(196,357,l)
+);
+}
+);
+width = 248;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "pWestCree-canadian";
+note = uni1426;
+unicode = 5158;
+},
+{
+glyphname = "middledotFinal-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(111,325,o),
+(130,344,o),
+(130,367,cs),
+(130,390,o),
+(111,409,o),
+(88,409,cs),
+(64,409,o),
+(46,390,o),
+(46,367,cs),
+(46,344,o),
+(64,325,o),
+(88,325,cs)
+);
+}
+);
+width = 176;
+}
+);
+note = uni1427;
+unicode = 5159;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(303,522,l),
+(303,568,l),
+(52,568,l),
+(52,522,l)
+);
+}
+);
+width = 355;
+}
+);
+metricRight = "=|";
+note = uni1428;
+unicode = 5160;
+},
+{
+glyphname = "plusFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,421,l),
+(200,547,l),
+(303,547,l),
+(303,591,l),
+(200,591,l),
+(200,714,l),
+(157,714,l),
+(157,591,l),
+(52,591,l),
+(52,547,l),
+(157,547,l),
+(157,421,l)
+);
+}
+);
+width = 355;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+unicode = 5161;
+},
+{
+glyphname = "downtackFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(201,357,l),
+(201,670,l),
+(303,670,l),
+(303,714,l),
+(52,714,l),
+(52,670,l),
+(156,670,l),
+(156,357,l)
+);
+}
+);
+width = 355;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni142A;
+unicode = 5162;
+},
+{
+glyphname = "thFinalWoodScree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,357,l),
+(200,445,l),
+(303,445,l),
+(303,486,l),
+(200,486,l),
+(200,585,l),
+(303,585,l),
+(303,626,l),
+(200,626,l),
+(200,714,l),
+(155,714,l),
+(155,626,l),
+(52,626,l),
+(52,585,l),
+(155,585,l),
+(155,486,l),
+(52,486,l),
+(52,445,l),
+(155,445,l),
+(155,357,l)
+);
+}
+);
+width = 355;
+}
+);
+metricLeft = "hyphen-canadian";
+metricRight = "hyphen-canadian";
+note = uni167E;
+unicode = 5758;
+},
+{
+glyphname = "ringSmallFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(187,554,o),
+(225,591,o),
+(225,641,cs),
+(225,690,o),
+(187,727,o),
+(139,727,cs),
+(90,727,o),
+(52,690,o),
+(52,641,cs),
+(52,591,o),
+(90,554,o),
+(139,554,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(107,586,o),
+(86,609,o),
+(86,641,cs),
+(86,672,o),
+(107,695,o),
+(139,695,cs),
+(170,695,o),
+(192,672,o),
+(192,641,cs),
+(192,609,o),
+(170,586,o),
+(139,586,cs)
+);
+}
+);
+width = 277;
+}
+);
+note = g725;
+unicode = 6366;
+},
+{
+glyphname = "raiseddotFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(115,643,o),
+(134,661,o),
+(134,685,cs),
+(134,708,o),
+(115,727,o),
+(92,727,cs),
+(68,727,o),
+(50,708,o),
+(50,685,cs),
+(50,661,o),
+(68,643,o),
+(92,643,cs)
+);
+}
+);
+width = 184;
+}
+);
+note = g725;
+unicode = 6367;
+},
+{
+glyphname = "acuteFinal-canadian.base";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "acuteFinal-canadian";
+}
+);
+width = 234;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.base";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "graveFinal-canadian";
+}
+);
+width = 234;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian.base";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 329;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1421;
+},
+{
+glyphname = "ringTophalfFinal-canadian.base";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 329;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.base";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 286;
+}
+);
+metricLeft = "==|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "plusFinal-canadian.base";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,0,l),
+(200,126,l),
+(303,126,l),
+(303,170,l),
+(200,170,l),
+(200,293,l),
+(157,293,l),
+(157,170,l),
+(52,170,l),
+(52,126,l),
+(157,126,l),
+(157,0,l)
+);
+}
+);
+width = 355;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+},
+{
+glyphname = "acuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "acuteFinal-canadian";
+}
+);
+width = 234;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.mid";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "graveFinal-canadian";
+}
+);
+width = 234;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringTophalfFinal-canadian.mid";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-178);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 329;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.mid";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 286;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "ringFinal-canadian.mid";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-210);
+ref = "ringFinal-canadian";
+}
+);
+width = 413;
+}
+);
+metricLeft = "ringFinal-canadian";
+metricWidth = "ringFinal-canadian";
+note = uni1424;
+},
+{
+glyphname = "doubleacuteFinal-canadian.mid";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "doubleacuteFinal-canadian";
+}
+);
+width = 344;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "doubleacuteFinal-canadian";
+note = uni1425;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian.mid";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "doubleshortverticalstrokesFinal-canadian";
+}
+);
+width = 248;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricWidth = "doubleshortverticalstrokesFinal-canadian";
+note = uni1426;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian.mid";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-178);
+ref = "shorthorizontalstrokeFinal-canadian";
+}
+);
+width = 355;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "shorthorizontalstrokeFinal-canadian";
+note = uni1428;
+},
+{
+glyphname = "downtackFinal-canadian.mid";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "downtackFinal-canadian";
+}
+);
+width = 355;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "downtackFinal-canadian";
+note = uni142A;
+},
+{
+glyphname = "e-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (276,470);
+},
+{
+name = top_center_can;
+pos = (276,714);
+},
+{
+name = top_left_can;
+pos = (101,714);
+},
+{
+name = top_right_can;
+pos = (453,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(291,0,l),
+(529,694,l),
+(529,714,l),
+(28,714,l),
+(28,694,l),
+(266,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(294,74,l),
+(93,677,l),
+(83,661,l),
+(473,661,l),
+(465,677,l),
+(264,74,l)
+);
+}
+);
+width = 557;
+}
+);
+metricRight = "=|";
+note = uni1401;
+unicode = 5121;
+},
+{
+glyphname = "aai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (160,0);
+ref = ring_top.canadian;
+}
+);
+width = 557;
+}
+);
+note = uni1402;
+unicode = 5122;
+},
+{
+glyphname = "i-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (275,417);
+},
+{
+name = top_center_can;
+pos = (279,714);
+},
+{
+name = top_left_can;
+pos = (103,714);
+},
+{
+name = top_right_can;
+pos = (455,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(529,0,l),
+(529,20,l),
+(291,714,l),
+(266,714,l),
+(28,20,l),
+(28,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(294,640,l),
+(263,640,l),
+(465,37,l),
+(472,53,l),
+(83,53,l),
+(92,37,l)
+);
+}
+);
+width = 557;
+}
+);
+metricLeft = "e-canadian";
+metricWidth = "e-canadian";
+note = uni1403;
+unicode = 5123;
+},
+{
+glyphname = "ii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (218,0);
+ref = dot_top;
+}
+);
+width = 557;
+}
+);
+note = uni1404;
+unicode = 5124;
+},
+{
+glyphname = "o-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (222,357);
+},
+{
+name = top_center_can;
+pos = (283,714);
+},
+{
+name = top_double;
+pos = (362,714);
+},
+{
+name = top_left_can;
+pos = (90,714);
+},
+{
+name = top_right_can;
+pos = (473,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(83,0,l),
+(507,344,l),
+(507,370,l),
+(83,714,l),
+(65,714,l),
+(65,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(118,641,l),
+(103,634,l),
+(460,341,l),
+(460,373,l),
+(103,80,l),
+(118,73,l)
+);
+}
+);
+width = 539;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1405;
+unicode = 5125;
+},
+{
+glyphname = "oo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (30,0);
+ref = dot_top;
+}
+);
+width = 539;
+}
+);
+note = uni1406;
+unicode = 5126;
+},
+{
+glyphname = "yCreeoo-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (167,0);
+ref = doubledot_top;
+}
+);
+width = 539;
+}
+);
+note = uni1407;
+unicode = 5127;
+},
+{
+glyphname = "eeCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(83,0,l),
+(507,344,l),
+(507,370,l),
+(83,714,l),
+(65,714,l),
+(65,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(114,641,l),
+(103,638,l),
+(460,345,l),
+(460,369,l),
+(103,77,l),
+(114,73,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(234,453,l),
+(205,453,l),
+(205,261,l),
+(234,261,l)
+);
+}
+);
+width = 539;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "o-canadian";
+note = uni1408;
+unicode = 5128;
+},
+{
+glyphname = "iCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (171,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 539;
+}
+);
+note = uni1409;
+unicode = 5129;
+},
+{
+glyphname = "a-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (313,357);
+},
+{
+name = top_center_can;
+pos = (242,714);
+},
+{
+name = top_left_can;
+pos = (62,714);
+},
+{
+name = top_right_can;
+pos = (446,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(474,0,l),
+(474,714,l),
+(456,714,l),
+(31,370,l),
+(31,344,l),
+(456,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(436,80,l),
+(78,372,l),
+(78,341,l),
+(436,634,l),
+(421,641,l),
+(421,73,l)
+);
+}
+);
+width = 539;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni140A;
+unicode = 5130;
+},
+{
+glyphname = "aa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (385,0);
+ref = dot_top;
+}
+);
+width = 539;
+}
+);
+note = uni140B;
+unicode = 5131;
+},
+{
+glyphname = "we-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "e-canadian";
+}
+);
+width = 733;
+}
+);
+note = uni140C;
+unicode = 5132;
+},
+{
+glyphname = "weWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (557,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 733;
+}
+);
+note = uni140D;
+unicode = 5133;
+},
+{
+glyphname = "wi-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "i-canadian";
+}
+);
+width = 733;
+}
+);
+note = uni140E;
+unicode = 5134;
+},
+{
+glyphname = "wiWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (557,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 733;
+}
+);
+note = uni140F;
+unicode = 5135;
+},
+{
+glyphname = "wii-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (393,0);
+ref = dot_top;
+}
+);
+width = 733;
+}
+);
+note = uni1410;
+unicode = 5136;
+},
+{
+glyphname = "wiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (218,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (557,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 733;
+}
+);
+note = uni1411;
+unicode = 5137;
+},
+{
+glyphname = "wo-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "o-canadian";
+}
+);
+width = 714;
+}
+);
+note = uni1412;
+unicode = 5138;
+},
+{
+glyphname = "woWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (539,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 714;
+}
+);
+note = uni1413;
+unicode = 5139;
+},
+{
+glyphname = "woo-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (398,0);
+ref = dot_top;
+}
+);
+width = 714;
+}
+);
+note = uni1414;
+unicode = 5140;
+},
+{
+glyphname = "wooWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (30,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (539,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 714;
+}
+);
+note = uni1415;
+unicode = 5141;
+},
+{
+glyphname = "wooNaskapi-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (171,-98);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (305,-207);
+ref = dot_top;
+}
+);
+width = 539;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricWidth = "o-canadian";
+note = uni1416;
+unicode = 5142;
+},
+{
+glyphname = "wa-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "a-canadian";
+}
+);
+width = 714;
+}
+);
+note = uni1417;
+unicode = 5143;
+},
+{
+glyphname = "waWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (539,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 714;
+}
+);
+note = uni1418;
+unicode = 5144;
+},
+{
+glyphname = "waa-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (561,0);
+ref = dot_top;
+}
+);
+width = 714;
+}
+);
+note = uni1419;
+unicode = 5145;
+},
+{
+glyphname = "waaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (385,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (539,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 714;
+}
+);
+note = uni141A;
+unicode = 5146;
+},
+{
+glyphname = "waaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (111,-207);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (245,-98);
+ref = dot_top;
+}
+);
+width = 539;
+}
+);
+metricWidth = "a-canadian";
+note = uni141B;
+unicode = 5147;
+},
+{
+glyphname = "ai-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(208,351,o),
+(239,383,o),
+(253,438,c),
+(239,438,l),
+(254,380,o),
+(288,351,o),
+(336,351,cs),
+(395,351,o),
+(441,390,o),
+(441,493,cs),
+(441,714,l),
+(398,714,l),
+(398,493,ls),
+(398,412,o),
+(368,393,o),
+(332,393,cs),
+(297,393,o),
+(267,414,o),
+(267,492,cs),
+(267,714,l),
+(225,714,l),
+(225,493,ls),
+(225,412,o),
+(195,393,o),
+(159,393,cs),
+(123,393,o),
+(95,414,o),
+(95,492,cs),
+(95,714,l),
+(52,714,l),
+(52,491,ls),
+(52,390,o),
+(98,351,o),
+(157,351,cs)
+);
+}
+);
+width = 493;
+}
+);
+metricRight = "=|";
+note = uni141C;
+unicode = 5148;
+},
+{
+glyphname = "ycreew-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(277,528,o),
+(304,564,o),
+(304,624,cs),
+(304,685,o),
+(277,720,o),
+(237,720,cs),
+(196,720,o),
+(169,685,o),
+(169,624,cs),
+(169,564,o),
+(196,528,o),
+(237,528,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(160,351,o),
+(187,387,o),
+(187,447,cs),
+(187,508,o),
+(160,543,o),
+(119,543,cs),
+(79,543,o),
+(52,508,o),
+(52,447,cs),
+(52,387,o),
+(79,351,o),
+(119,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(95,379,o),
+(81,401,o),
+(81,447,cs),
+(81,493,o),
+(95,515,o),
+(119,515,cs),
+(144,515,o),
+(157,493,o),
+(157,447,cs),
+(157,401,o),
+(144,379,o),
+(119,379,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(212,556,o),
+(199,578,o),
+(199,624,cs),
+(199,670,o),
+(212,692,o),
+(237,692,cs),
+(261,692,o),
+(275,670,o),
+(275,624,cs),
+(275,578,o),
+(261,556,o),
+(237,556,cs)
+);
+}
+);
+width = 356;
+}
+);
+metricRight = "=|";
+note = uni141D;
+unicode = 5149;
+},
+{
+glyphname = "glottalstop-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(299,357,l),
+(299,369,l),
+(181,714,l),
+(167,714,l),
+(49,369,l),
+(49,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(186,667,l),
+(163,667,l),
+(258,376,l),
+(266,394,l),
+(82,394,l),
+(89,376,l)
+);
+}
+);
+width = 348;
+}
+);
+metricRight = "=|";
+note = uni141E;
+unicode = 5150;
+},
+{
+glyphname = "en-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+pos = (557,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 791;
+}
+);
+note = uni142B;
+unicode = 5163;
+},
+{
+glyphname = "in-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+pos = (385,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 619;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142C;
+unicode = 5164;
+},
+{
+glyphname = "on-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (422,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 656;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142D;
+unicode = 5165;
+},
+{
+glyphname = "an-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (512,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 746;
+}
+);
+metricRight = "graveFinal-canadian";
+note = uni142E;
+unicode = 5166;
+},
+{
+glyphname = "pe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (276,470);
+},
+{
+name = top_center_can;
+pos = (276,714);
+},
+{
+name = top_left_can;
+pos = (101,714);
+},
+{
+name = top_right_can;
+pos = (453,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(291,0,l),
+(529,694,l),
+(529,714,l),
+(473,714,l),
+(260,77,l),
+(299,77,l),
+(85,714,l),
+(28,714,l),
+(28,694,l),
+(266,0,l)
+);
+}
+);
+width = 557;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni142F;
+unicode = 5167;
+},
+{
+glyphname = "paai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (160,0);
+ref = ring_top.canadian;
+}
+);
+width = 557;
+}
+);
+note = uni1430;
+unicode = 5168;
+},
+{
+glyphname = "pi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (279,417);
+},
+{
+name = top_center_can;
+pos = (279,714);
+},
+{
+name = top_left_can;
+pos = (102,714);
+},
+{
+name = top_right_can;
+pos = (455,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(84,0,l),
+(298,637,l),
+(259,637,l),
+(473,0,l),
+(529,0,l),
+(529,20,l),
+(291,714,l),
+(266,714,l),
+(28,20,l),
+(28,0,l)
+);
+}
+);
+width = 557;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni1431;
+unicode = 5169;
+},
+{
+glyphname = "pii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (218,0);
+ref = dot_top;
+}
+);
+width = 557;
+}
+);
+note = uni1432;
+unicode = 5170;
+},
+{
+glyphname = "po-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (171,357);
+},
+{
+name = top_center_can;
+pos = (259,714);
+},
+{
+name = top_double;
+pos = (345,714);
+},
+{
+name = top_left_can;
+pos = (71,714);
+},
+{
+name = top_right_can;
+pos = (446,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(61,0,l),
+(480,344,l),
+(480,370,l),
+(61,714,l),
+(43,714,l),
+(43,656,l),
+(426,341,l),
+(426,373,l),
+(43,58,l),
+(43,0,l)
+);
+}
+);
+width = 512;
+}
+);
+metricRight = "o-canadian";
+note = uni1433;
+unicode = 5171;
+},
+{
+glyphname = "poo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (10,0);
+ref = dot_top;
+}
+);
+width = 512;
+}
+);
+note = uni1434;
+unicode = 5172;
+},
+{
+glyphname = "ycreepoo-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (151,0);
+ref = doubledot_top;
+}
+);
+width = 512;
+}
+);
+note = uni1435;
+unicode = 5173;
+},
+{
+glyphname = "heeCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (135,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 512;
+}
+);
+note = uni1436;
+unicode = 5174;
+},
+{
+glyphname = "hiCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (115,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 512;
+}
+);
+note = uni1437;
+unicode = 5175;
+},
+{
+glyphname = "pa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (248,357);
+},
+{
+name = top_center_can;
+pos = (254,714);
+},
+{
+name = top_left_can;
+pos = (62,714);
+},
+{
+name = top_right_can;
+pos = (441,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(469,0,l),
+(469,58,l),
+(86,373,l),
+(86,341,l),
+(469,656,l),
+(469,714,l),
+(451,714,l),
+(31,370,l),
+(31,344,l),
+(451,0,l)
+);
+}
+);
+width = 512;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1438;
+unicode = 5176;
+},
+{
+glyphname = "paa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (380,0);
+ref = dot_top;
+}
+);
+width = 512;
+}
+);
+note = uni1439;
+unicode = 5177;
+},
+{
+glyphname = "pwe-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "pe-canadian";
+}
+);
+width = 733;
+}
+);
+note = uni143A;
+unicode = 5178;
+},
+{
+glyphname = "pweWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "pe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (557,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 733;
+}
+);
+note = uni143B;
+unicode = 5179;
+},
+{
+glyphname = "pwi-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "pi-canadian";
+}
+);
+width = 733;
+}
+);
+note = uni143C;
+unicode = 5180;
+},
+{
+glyphname = "pwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (557,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 733;
+}
+);
+note = uni143D;
+unicode = 5181;
+},
+{
+glyphname = "pwii-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (393,0);
+ref = dot_top;
+}
+);
+width = 733;
+}
+);
+note = uni143E;
+unicode = 5182;
+},
+{
+glyphname = "pwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (218,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (557,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 733;
+}
+);
+note = uni143F;
+unicode = 5183;
+},
+{
+glyphname = "pwo-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "po-canadian";
+}
+);
+width = 687;
+}
+);
+note = uni1440;
+unicode = 5184;
+},
+{
+glyphname = "pwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (512,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 687;
+}
+);
+note = uni1441;
+unicode = 5185;
+},
+{
+glyphname = "pwoo-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (374,0);
+ref = dot_top;
+}
+);
+width = 687;
+}
+);
+note = uni1442;
+unicode = 5186;
+},
+{
+glyphname = "pwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (10,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (512,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 687;
+}
+);
+note = uni1443;
+unicode = 5187;
+},
+{
+glyphname = "pwa-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "pa-canadian";
+}
+);
+width = 687;
+}
+);
+note = uni1444;
+unicode = 5188;
+},
+{
+glyphname = "pwaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (512,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 687;
+}
+);
+note = uni1445;
+unicode = 5189;
+},
+{
+glyphname = "pwaa-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (556,0);
+ref = dot_top;
+}
+);
+width = 687;
+}
+);
+note = uni1446;
+unicode = 5190;
+},
+{
+glyphname = "pwaaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (380,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (512,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 687;
+}
+);
+note = uni1447;
+unicode = 5191;
+},
+{
+glyphname = "ycreepwaa-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+pos = (109,-207);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (243,-98);
+ref = dot_top;
+}
+);
+width = 512;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1448;
+unicode = 5192;
+},
+{
+glyphname = "p-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(268,357,l),
+(268,399,l),
+(86,551,l),
+(86,520,l),
+(268,671,l),
+(268,714,l),
+(258,714,l),
+(52,545,l),
+(52,527,l),
+(258,357,l)
+);
+}
+);
+width = 320;
+}
+);
+note = uni1449;
+unicode = 5193;
+},
+{
+glyphname = "pWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,357,l),
+(97,714,l),
+(52,714,l),
+(52,357,l)
+);
+}
+);
+width = 149;
+}
+);
+metricRight = "=|";
+note = uni144A;
+unicode = 5194;
+},
+{
+color = 6;
+glyphname = "hCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,189,l),
+(97,345,ls),
+(97,385,o),
+(116,408,o),
+(151,408,cs),
+(182,408,o),
+(197,387,o),
+(197,344,cs),
+(197,189,l),
+(242,189,l),
+(242,352,ls),
+(242,418,o),
+(206,449,o),
+(160,449,cs),
+(118,449,o),
+(89,420,o),
+(86,380,c),
+(97,374,l),
+(97,546,l),
+(52,546,l),
+(52,189,l)
+);
+}
+);
+width = 278;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144B;
+unicode = 5195;
+},
+{
+glyphname = "te-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (281,357);
+},
+{
+name = top_center_can;
+pos = (281,714);
+},
+{
+name = top_left_can;
+pos = (94,714);
+},
+{
+name = top_right_can;
+pos = (470,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(421,-13,o),
+(502,73,o),
+(502,245,cs),
+(502,714,l),
+(439,714,l),
+(439,244,ls),
+(439,107,o),
+(382,47,o),
+(281,47,cs),
+(184,47,o),
+(125,109,o),
+(125,244,cs),
+(125,714,l),
+(61,714,l),
+(61,242,ls),
+(61,74,o),
+(146,-13,o),
+(282,-13,cs)
+);
+}
+);
+width = 563;
+}
+);
+metricRight = "=|";
+note = uni144C;
+unicode = 5196;
+},
+{
+glyphname = "taai-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (163,0);
+ref = ring_top.canadian;
+}
+);
+width = 564;
+}
+);
+note = uni144D;
+unicode = 5197;
+},
+{
+glyphname = "ti-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (281,357);
+},
+{
+name = middle_right_can;
+pos = (595,357);
+},
+{
+name = top_center_can;
+pos = (281,714);
+},
+{
+name = top_left_can;
+pos = (94,714);
+},
+{
+name = top_right_can;
+pos = (470,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(125,0,l),
+(125,470,ls),
+(125,607,o),
+(181,667,o),
+(282,667,cs),
+(380,667,o),
+(439,605,o),
+(439,470,cs),
+(439,0,l),
+(502,0,l),
+(502,472,ls),
+(502,640,o),
+(418,727,o),
+(282,727,cs),
+(145,727,o),
+(61,641,o),
+(61,469,cs),
+(61,0,l)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni144E;
+unicode = 5198;
+},
+{
+glyphname = "tii-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (221,0);
+ref = dot_top;
+}
+);
+width = 564;
+}
+);
+note = uni144F;
+unicode = 5199;
+},
+{
+glyphname = "to-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (199,357);
+},
+{
+name = middle_right_can;
+pos = (510,357);
+},
+{
+name = top_center_can;
+pos = (210,714);
+},
+{
+name = top_double;
+pos = (256,714);
+},
+{
+name = top_left_can;
+pos = (71,714);
+},
+{
+name = top_right_can;
+pos = (389,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(127,0,ls),
+(325,0,o),
+(417,125,o),
+(417,358,cs),
+(417,591,o),
+(325,714,o),
+(123,714,cs),
+(43,714,l),
+(43,655,l),
+(123,655,ls),
+(287,655,o),
+(353,557,o),
+(353,358,cs),
+(353,161,o),
+(287,59,o),
+(128,59,cs),
+(43,59,l),
+(43,0,l)
+);
+}
+);
+width = 469;
+}
+);
+note = uni1450;
+unicode = 5200;
+},
+{
+glyphname = "too-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (149,0);
+ref = dot_top;
+}
+);
+width = 469;
+}
+);
+note = uni1451;
+unicode = 5201;
+},
+{
+glyphname = "ycreetoo-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (61,0);
+ref = doubledot_top;
+}
+);
+width = 469;
+}
+);
+note = uni1452;
+unicode = 5202;
+},
+{
+glyphname = "deeCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (160,0);
+ref = stroke_middle;
+}
+);
+width = 469;
+}
+);
+note = uni1453;
+unicode = 5203;
+},
+{
+glyphname = "diCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (138,0);
+ref = dot_middle;
+}
+);
+width = 469;
+}
+);
+note = uni1454;
+unicode = 5204;
+},
+{
+glyphname = "ta-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (271,357);
+},
+{
+name = top_center_can;
+pos = (260,714);
+},
+{
+name = top_left_can;
+pos = (80,714);
+},
+{
+name = top_right_can;
+pos = (398,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(426,0,l),
+(426,59,l),
+(346,59,ls),
+(182,59,o),
+(116,157,o),
+(116,356,cs),
+(116,553,o),
+(182,655,o),
+(341,655,cs),
+(426,655,l),
+(426,714,l),
+(341,714,ls),
+(144,714,o),
+(52,589,o),
+(52,356,cs),
+(52,123,o),
+(144,0,o),
+(347,0,cs)
+);
+}
+);
+width = 469;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|to-canadian";
+note = uni1455;
+unicode = 5205;
+},
+{
+glyphname = "taa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (199,0);
+ref = dot_top;
+}
+);
+width = 469;
+}
+);
+note = uni1456;
+unicode = 5206;
+},
+{
+glyphname = "twe-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "te-canadian";
+}
+);
+width = 739;
+}
+);
+note = uni1457;
+unicode = 5207;
+},
+{
+glyphname = "tweWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (564,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 739;
+}
+);
+note = uni1458;
+unicode = 5208;
+},
+{
+glyphname = "twi-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ti-canadian";
+}
+);
+width = 739;
+}
+);
+note = uni1459;
+unicode = 5209;
+},
+{
+glyphname = "twiWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (564,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 739;
+}
+);
+note = uni145A;
+unicode = 5210;
+},
+{
+glyphname = "twii-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (396,0);
+ref = dot_top;
+}
+);
+width = 739;
+}
+);
+note = uni145B;
+unicode = 5211;
+},
+{
+glyphname = "twiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (221,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (564,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 739;
+}
+);
+note = uni145C;
+unicode = 5212;
+},
+{
+glyphname = "two-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "to-canadian";
+}
+);
+width = 644;
+}
+);
+note = uni145D;
+unicode = 5213;
+},
+{
+glyphname = "twoWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (469,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 644;
+}
+);
+note = uni145E;
+unicode = 5214;
+},
+{
+glyphname = "twoo-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (325,0);
+ref = dot_top;
+}
+);
+width = 644;
+}
+);
+note = uni145F;
+unicode = 5215;
+},
+{
+glyphname = "twooWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (149,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (469,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 644;
+}
+);
+note = uni1460;
+unicode = 5216;
+},
+{
+glyphname = "twa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ta-canadian";
+}
+);
+width = 644;
+}
+);
+note = uni1461;
+unicode = 5217;
+},
+{
+glyphname = "twaWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (469,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 644;
+}
+);
+note = uni1462;
+unicode = 5218;
+},
+{
+glyphname = "twaa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (375,0);
+ref = dot_top;
+}
+);
+width = 644;
+}
+);
+note = uni1463;
+unicode = 5219;
+},
+{
+glyphname = "twaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (199,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (469,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 644;
+}
+);
+note = uni1464;
+unicode = 5220;
+},
+{
+glyphname = "twaaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (192,0);
+ref = "ta-canadian";
+}
+);
+width = 661;
+}
+);
+note = uni1465;
+unicode = 5221;
+},
+{
+glyphname = "t-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(238,357,l),
+(238,401,l),
+(216,401,ls),
+(134,401,o),
+(97,446,o),
+(97,535,cs),
+(97,623,o),
+(134,670,o),
+(216,670,cs),
+(238,670,l),
+(238,714,l),
+(210,714,ls),
+(106,714,o),
+(51,647,o),
+(51,535,cs),
+(51,423,o),
+(106,357,o),
+(212,357,cs)
+);
+}
+);
+width = 286;
+}
+);
+note = uni1466;
+unicode = 5222;
+},
+{
+glyphname = "tte-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+pos = (564,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 713;
+}
+);
+note = uni1467;
+unicode = 5223;
+},
+{
+glyphname = "tti-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+pos = (564,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 713;
+}
+);
+note = uni1468;
+unicode = 5224;
+},
+{
+glyphname = "tto-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+pos = (469,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 619;
+}
+);
+note = uni1469;
+unicode = 5225;
+},
+{
+glyphname = "tta-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+pos = (469,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 619;
+}
+);
+note = uni146A;
+unicode = 5226;
+},
+{
+glyphname = "ke-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (245,457);
+},
+{
+name = top_center_can;
+pos = (230,714);
+},
+{
+name = top_left_can;
+pos = (87,714);
+},
+{
+name = top_right_can;
+pos = (373,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(405,0,l),
+(405,465,ls),
+(405,637,o),
+(345,727,o),
+(232,727,cs),
+(119,727,o),
+(55,635,o),
+(55,467,cs),
+(55,305,o),
+(118,212,o),
+(223,212,cs),
+(289,212,o),
+(336,258,o),
+(348,324,c),
+(341,353,l),
+(341.005,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(156,268,o),
+(117,333,o),
+(117,470,cs),
+(117,607,o),
+(156,671,o),
+(230,671,cs),
+(304,671,o),
+(342,608,o),
+(342,470,cs),
+(342,333,o),
+(303,268,o),
+(230,268,cs)
+);
+}
+);
+width = 466;
+}
+);
+metricRight = "te-canadian";
+note = uni146B;
+unicode = 5227;
+},
+{
+glyphname = "kaai-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (117,0);
+ref = ring_top.canadian;
+}
+);
+width = 466;
+}
+);
+note = uni146C;
+unicode = 5228;
+},
+{
+glyphname = "ki-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (252,457);
+},
+{
+name = top_center_can;
+pos = (236,714);
+},
+{
+name = top_left_can;
+pos = (93,714);
+},
+{
+name = top_right_can;
+pos = (380,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(125,0,l),
+(125,353,l),
+(118,324,l),
+(129,258,o),
+(177,212,o),
+(242,212,cs),
+(348,212,o),
+(411,305,o),
+(411,467,cs),
+(411,635,o),
+(347,727,o),
+(236,727,cs),
+(121,727,o),
+(61,634,o),
+(61,465,cs),
+(61,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(163,268,o),
+(124,333,o),
+(124,470,cs),
+(124,608,o),
+(162,671,o),
+(236,671,cs),
+(310,671,o),
+(349,607,o),
+(349,470,cs),
+(349,333,o),
+(309,268,o),
+(236,268,cs)
+);
+}
+);
+width = 466;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni146D;
+unicode = 5229;
+},
+{
+glyphname = "kii-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (175,0);
+ref = dot_top;
+}
+);
+width = 466;
+}
+);
+note = uni146E;
+unicode = 5230;
+},
+{
+glyphname = "ko-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (245,411);
+},
+{
+name = top_center_can;
+pos = (230,714);
+},
+{
+name = top_double;
+pos = (373,714);
+},
+{
+name = top_left_can;
+pos = (87,714);
+},
+{
+name = top_right_can;
+pos = (373,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(344,-13,o),
+(405,77,o),
+(405,249,cs),
+(405,714,l),
+(341.005,714,l),
+(341,361,l),
+(348,390,l),
+(336,456,o),
+(289,502,o),
+(223,502,cs),
+(118,502,o),
+(55,409,o),
+(55,245,cs),
+(55,79,o),
+(118,-13,o),
+(231,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(156,43,o),
+(117,107,o),
+(117,244,cs),
+(117,381,o),
+(156,446,o),
+(230,446,cs),
+(303,446,o),
+(342,381,o),
+(342,244,cs),
+(342,106,o),
+(304,43,o),
+(230,43,cs)
+);
+}
+);
+width = 466;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni146F;
+unicode = 5231;
+},
+{
+glyphname = "koo-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (312,0);
+ref = dot_top;
+}
+);
+width = 466;
+}
+);
+note = uni1470;
+unicode = 5232;
+},
+{
+glyphname = "ycreekoo-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (179,0);
+ref = doubledot_top;
+}
+);
+width = 466;
+}
+);
+note = uni1471;
+unicode = 5233;
+},
+{
+glyphname = "ka-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (252,412);
+},
+{
+name = top_center_can;
+pos = (236,714);
+},
+{
+name = top_left_can;
+pos = (93,714);
+},
+{
+name = top_right_can;
+pos = (380,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(347,-13,o),
+(411,79,o),
+(411,247,cs),
+(411,409,o),
+(348,502,o),
+(242,502,cs),
+(177,502,o),
+(129,456,o),
+(118,390,c),
+(125,361,l),
+(125,714,l),
+(61,714,l),
+(61,249,ls),
+(61,77,o),
+(121,-13,o),
+(234,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(162,43,o),
+(124,106,o),
+(124,244,cs),
+(124,381,o),
+(163,446,o),
+(236,446,cs),
+(309,446,o),
+(349,381,o),
+(349,244,cs),
+(349,107,o),
+(310,43,o),
+(236,43,cs)
+);
+}
+);
+width = 466;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "==|ke-canadian";
+note = uni1472;
+unicode = 5234;
+},
+{
+glyphname = "kaa-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (33,0);
+ref = dot_top;
+}
+);
+width = 466;
+}
+);
+note = uni1473;
+unicode = 5235;
+},
+{
+glyphname = "kwe-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ke-canadian";
+}
+);
+width = 641;
+}
+);
+note = uni1474;
+unicode = 5236;
+},
+{
+glyphname = "kweWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (466,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 641;
+}
+);
+note = uni1475;
+unicode = 5237;
+},
+{
+glyphname = "kwi-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ki-canadian";
+}
+);
+width = 641;
+}
+);
+note = uni1476;
+unicode = 5238;
+},
+{
+glyphname = "kwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (466,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 641;
+}
+);
+note = uni1477;
+unicode = 5239;
+},
+{
+glyphname = "kwii-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (351,0);
+ref = dot_top;
+}
+);
+width = 641;
+}
+);
+note = uni1478;
+unicode = 5240;
+},
+{
+glyphname = "kwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (175,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (466,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 641;
+}
+);
+note = uni1479;
+unicode = 5241;
+},
+{
+glyphname = "kwo-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ko-canadian";
+}
+);
+width = 641;
+}
+);
+note = uni147A;
+unicode = 5242;
+},
+{
+glyphname = "kwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (466,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 641;
+}
+);
+note = uni147B;
+unicode = 5243;
+},
+{
+glyphname = "kwoo-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (488,0);
+ref = dot_top;
+}
+);
+width = 641;
+}
+);
+note = uni147C;
+unicode = 5244;
+},
+{
+glyphname = "kwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (312,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (466,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 641;
+}
+);
+note = uni147D;
+unicode = 5245;
+},
+{
+glyphname = "kwa-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ka-canadian";
+}
+);
+width = 641;
+}
+);
+note = uni147E;
+unicode = 5246;
+},
+{
+glyphname = "kwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (466,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 641;
+}
+);
+note = uni147F;
+unicode = 5247;
+},
+{
+glyphname = "kwaa-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (208,0);
+ref = dot_top;
+}
+);
+width = 641;
+}
+);
+note = uni1480;
+unicode = 5248;
+},
+{
+glyphname = "kwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (33,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (466,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 641;
+}
+);
+note = uni1481;
+unicode = 5249;
+},
+{
+glyphname = "kwaaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (192,0);
+ref = "ka-canadian";
+}
+);
+width = 658;
+}
+);
+note = uni1482;
+unicode = 5250;
+},
+{
+glyphname = "k-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(203,351,o),
+(246,395,o),
+(246,490,cs),
+(246,577,o),
+(207,622,o),
+(158,622,cs),
+(118,622,o),
+(88,591,o),
+(85,539,c),
+(97,540,l),
+(97,714,l),
+(52,714,l),
+(52,486,ls),
+(52,398,o),
+(91,351,o),
+(149,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(115,388,o),
+(95,415,o),
+(95,487,cs),
+(95,556,o),
+(117,585,o),
+(150,585,cs),
+(182,585,o),
+(204,557,o),
+(204,488,cs),
+(204,418,o),
+(183,388,o),
+(150,388,cs)
+);
+}
+);
+width = 288;
+}
+);
+note = uni1483;
+unicode = 5251;
+},
+{
+glyphname = "kw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(198,351,o),
+(236,398,o),
+(236,486,cs),
+(236,714,l),
+(191,714,l),
+(191,540,l),
+(204,539,l),
+(200,591,o),
+(170,622,o),
+(131,622,cs),
+(81,622,o),
+(42,577,o),
+(42,490,cs),
+(42,395,o),
+(85,351,o),
+(139,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(105,388,o),
+(84,418,o),
+(84,488,cs),
+(84,557,o),
+(106,585,o),
+(138,585,cs),
+(171,585,o),
+(193,556,o),
+(193,487,cs),
+(193,415,o),
+(173,388,o),
+(138,388,cs)
+);
+}
+);
+width = 288;
+}
+);
+metricLeft = "=|k-canadian";
+metricRight = "=|k-canadian";
+note = uni1484;
+unicode = 5252;
+},
+{
+glyphname = "southslaveykeh-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+pos = (466,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 615;
+}
+);
+note = uni1485;
+unicode = 5253;
+},
+{
+glyphname = "southslaveykih-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+pos = (466,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 615;
+}
+);
+note = uni1486;
+unicode = 5254;
+},
+{
+glyphname = "southslaveykoh-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+pos = (466,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 615;
+}
+);
+note = uni1487;
+unicode = 5255;
+},
+{
+glyphname = "southslaveykah-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+pos = (466,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 615;
+}
+);
+note = uni1488;
+unicode = 5256;
+},
+{
+glyphname = "ce-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (243,435);
+},
+{
+name = top_center_can;
+pos = (228,714);
+},
+{
+name = top_left_can;
+pos = (86,714);
+},
+{
+name = top_right_can;
+pos = (369,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(400,0,l),
+(400,488,ls),
+(400,636,o),
+(340,727,o),
+(229,727,cs),
+(116,727,o),
+(54,640,o),
+(54,496,cs),
+(54,405,l),
+(117,405,l),
+(117,506,ls),
+(117,609,o),
+(153,670,o),
+(228,670,cs),
+(300,670,o),
+(337,609,o),
+(337,500,cs),
+(337,0,l)
+);
+}
+);
+width = 461;
+}
+);
+metricRight = "te-canadian";
+note = uni1489;
+unicode = 5257;
+},
+{
+glyphname = "caai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (118,0);
+ref = ring_top.canadian;
+}
+);
+width = 462;
+}
+);
+note = uni148A;
+unicode = 5258;
+},
+{
+glyphname = "ci-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (251,435);
+},
+{
+name = top_center_can;
+pos = (236,714);
+},
+{
+name = top_left_can;
+pos = (94,714);
+},
+{
+name = top_right_can;
+pos = (378,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(125,0,l),
+(125,500,ls),
+(125,609,o),
+(162,670,o),
+(233,670,cs),
+(309,670,o),
+(345,609,o),
+(345,506,cs),
+(345,405,l),
+(408,405,l),
+(408,496,ls),
+(408,640,o),
+(345,727,o),
+(234,727,cs),
+(121,727,o),
+(61,636,o),
+(61,488,cs),
+(61,0,l)
+);
+}
+);
+width = 462;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+unicode = 5259;
+},
+{
+glyphname = "cii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (175,0);
+ref = dot_top;
+}
+);
+width = 462;
+}
+);
+note = uni148C;
+unicode = 5260;
+},
+{
+glyphname = "co-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (243,435);
+},
+{
+name = top_center_can;
+pos = (227,714);
+},
+{
+name = top_double;
+pos = (369,714);
+},
+{
+name = top_left_can;
+pos = (86,714);
+},
+{
+name = top_right_can;
+pos = (369,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(340,-13,o),
+(400,78,o),
+(400,226,cs),
+(400,714,l),
+(337,714,l),
+(337,214,ls),
+(337,106,o),
+(300,44,o),
+(228,44,cs),
+(153,44,o),
+(117,106,o),
+(117,208,cs),
+(117,309,l),
+(54,309,l),
+(54,218,ls),
+(54,74,o),
+(116,-13,o),
+(229,-13,cs)
+);
+}
+);
+width = 461;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+unicode = 5261;
+},
+{
+glyphname = "coo-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (308,0);
+ref = dot_top;
+}
+);
+width = 462;
+}
+);
+note = uni148E;
+unicode = 5262;
+},
+{
+glyphname = "ycreecoo-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (174,0);
+ref = doubledot_top;
+}
+);
+width = 462;
+}
+);
+note = uni148F;
+unicode = 5263;
+},
+{
+glyphname = "ca-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (251,435);
+},
+{
+name = top_center_can;
+pos = (236,714);
+},
+{
+name = top_left_can;
+pos = (94,714);
+},
+{
+name = top_right_can;
+pos = (377,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(345,-13,o),
+(408,75,o),
+(408,218,cs),
+(408,309,l),
+(345,309,l),
+(345,208,ls),
+(345,106,o),
+(309,44,o),
+(233,44,cs),
+(162,44,o),
+(125,106,o),
+(125,214,cs),
+(125,714,l),
+(61,714,l),
+(61,226,ls),
+(61,78,o),
+(121,-13,o),
+(233,-13,cs)
+);
+}
+);
+width = 462;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+unicode = 5264;
+},
+{
+glyphname = "caa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (33,0);
+ref = dot_top;
+}
+);
+width = 462;
+}
+);
+note = uni1491;
+unicode = 5265;
+},
+{
+glyphname = "cwe-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ce-canadian";
+}
+);
+width = 637;
+}
+);
+note = uni1492;
+unicode = 5266;
+},
+{
+glyphname = "cweWestCree-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (462,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 637;
+}
+);
+note = uni1493;
+unicode = 5267;
+},
+{
+glyphname = "cwi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ci-canadian";
+}
+);
+width = 637;
+}
+);
+note = uni1494;
+unicode = 5268;
+},
+{
+glyphname = "cwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (462,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 637;
+}
+);
+note = uni1495;
+unicode = 5269;
+},
+{
+glyphname = "cwii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (351,0);
+ref = dot_top;
+}
+);
+width = 637;
+}
+);
+note = uni1496;
+unicode = 5270;
+},
+{
+glyphname = "cwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (175,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (462,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 637;
+}
+);
+note = uni1497;
+unicode = 5271;
+},
+{
+glyphname = "cwo-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "co-canadian";
+}
+);
+width = 637;
+}
+);
+note = uni1498;
+unicode = 5272;
+},
+{
+glyphname = "cwoWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (462,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 637;
+}
+);
+note = uni1499;
+unicode = 5273;
+},
+{
+glyphname = "cwoo-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (484,0);
+ref = dot_top;
+}
+);
+width = 637;
+}
+);
+note = uni149A;
+unicode = 5274;
+},
+{
+glyphname = "cwooWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (308,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (462,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 637;
+}
+);
+note = uni149B;
+unicode = 5275;
+},
+{
+glyphname = "cwa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ca-canadian";
+}
+);
+width = 637;
+}
+);
+note = uni149C;
+unicode = 5276;
+},
+{
+glyphname = "cwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (462,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 637;
+}
+);
+note = uni149D;
+unicode = 5277;
+},
+{
+glyphname = "cwaa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (208,0);
+ref = dot_top;
+}
+);
+width = 637;
+}
+);
+note = uni149E;
+unicode = 5278;
+},
+{
+glyphname = "cwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (33,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (462,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 637;
+}
+);
+note = uni149F;
+unicode = 5279;
+},
+{
+glyphname = "cwaaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (192,0);
+ref = "ca-canadian";
+}
+);
+width = 654;
+}
+);
+note = uni14A0;
+unicode = 5280;
+},
+{
+glyphname = "c-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(207,351,o),
+(246,395,o),
+(246,474,cs),
+(246,502,l),
+(205,502,l),
+(205,467,ls),
+(205,417,o),
+(184,390,o),
+(151,390,cs),
+(115,390,o),
+(97,416,o),
+(97,473,cs),
+(97,714,l),
+(52,714,l),
+(52,479,ls),
+(52,394,o),
+(89,351,o),
+(150,351,cs)
+);
+}
+);
+width = 279;
+}
+);
+note = uni14A1;
+unicode = 5281;
+},
+{
+glyphname = "thSayisi-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(191,351,o),
+(228,394,o),
+(228,479,cs),
+(228,714,l),
+(182,714,l),
+(182,473,ls),
+(182,416,o),
+(165,390,o),
+(128,390,cs),
+(95,390,o),
+(75,417,o),
+(75,467,cs),
+(75,502,l),
+(33,502,l),
+(33,474,ls),
+(33,395,o),
+(72,351,o),
+(132,351,cs)
+);
+}
+);
+width = 280;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "=|c-canadian";
+note = uni14A2;
+unicode = 5282;
+},
+{
+glyphname = "me-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (159,357);
+},
+{
+name = top_center_can;
+pos = (192,714);
+},
+{
+name = top_left_can;
+pos = (66,714);
+},
+{
+name = top_right_can;
+pos = (315,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(347,0,l),
+(347,714,l),
+(34,714,l),
+(34,655,l),
+(284,655,l),
+(284,0,l)
+);
+}
+);
+width = 412;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+unicode = 5283;
+},
+{
+glyphname = "maai-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (103,0);
+ref = ring_top.canadian;
+}
+);
+width = 412;
+}
+);
+note = uni14A4;
+unicode = 5284;
+},
+{
+glyphname = "mi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (254,357);
+},
+{
+name = top_center_can;
+pos = (221,714);
+},
+{
+name = top_left_can;
+pos = (97,714);
+},
+{
+name = top_right_can;
+pos = (345,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(128,0,l),
+(128,655,l),
+(378,655,l),
+(378,714,l),
+(65,714,l),
+(65,0,l)
+);
+}
+);
+width = 412;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+unicode = 5285;
+},
+{
+glyphname = "mii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (161,0);
+ref = dot_top;
+}
+);
+width = 412;
+}
+);
+note = uni14A6;
+unicode = 5286;
+},
+{
+glyphname = "mo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (159,357);
+},
+{
+name = top_center_can;
+pos = (192,714);
+},
+{
+name = top_double;
+pos = (316,714);
+},
+{
+name = top_left_can;
+pos = (66,714);
+},
+{
+name = top_right_can;
+pos = (315,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(347,0,l),
+(347,714,l),
+(284,714,l),
+(284,59,l),
+(34,59,l),
+(34,0,l)
+);
+}
+);
+width = 412;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+unicode = 5287;
+},
+{
+glyphname = "moo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (255,0);
+ref = dot_top;
+}
+);
+width = 412;
+}
+);
+note = uni14A8;
+unicode = 5288;
+},
+{
+glyphname = "ycreemoo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (121,0);
+ref = doubledot_top;
+}
+);
+width = 412;
+}
+);
+note = uni14A9;
+unicode = 5289;
+},
+{
+glyphname = "ma-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (254,357);
+},
+{
+name = top_center_can;
+pos = (221,714);
+},
+{
+name = top_left_can;
+pos = (97,714);
+},
+{
+name = top_right_can;
+pos = (345,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(378,0,l),
+(378,59,l),
+(128,59,l),
+(128,714,l),
+(65,714,l),
+(65,0,l)
+);
+}
+);
+width = 412;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+unicode = 5290;
+},
+{
+glyphname = "maa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+}
+);
+width = 412;
+}
+);
+note = uni14AB;
+unicode = 5291;
+},
+{
+glyphname = "mwe-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "me-canadian";
+}
+);
+width = 588;
+}
+);
+note = uni14AC;
+unicode = 5292;
+},
+{
+glyphname = "mweWestCree-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "me-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (412,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 588;
+}
+);
+note = uni14AD;
+unicode = 5293;
+},
+{
+glyphname = "mwi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "mi-canadian";
+}
+);
+width = 588;
+}
+);
+note = uni14AE;
+unicode = 5294;
+},
+{
+glyphname = "mwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (412,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 588;
+}
+);
+note = uni14AF;
+unicode = 5295;
+},
+{
+glyphname = "mwii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (336,0);
+ref = dot_top;
+}
+);
+width = 588;
+}
+);
+note = uni14B0;
+unicode = 5296;
+},
+{
+glyphname = "mwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (161,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (412,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 588;
+}
+);
+note = uni14B1;
+unicode = 5297;
+},
+{
+glyphname = "mwo-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "mo-canadian";
+}
+);
+width = 588;
+}
+);
+note = uni14B2;
+unicode = 5298;
+},
+{
+glyphname = "mwoWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (412,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 588;
+}
+);
+note = uni14B3;
+unicode = 5299;
+},
+{
+glyphname = "mwoo-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (430,0);
+ref = dot_top;
+}
+);
+width = 588;
+}
+);
+note = uni14B4;
+unicode = 5300;
+},
+{
+glyphname = "mwooWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (255,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (412,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 588;
+}
+);
+note = uni14B5;
+unicode = 5301;
+},
+{
+glyphname = "mwa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ma-canadian";
+}
+);
+width = 588;
+}
+);
+note = uni14B6;
+unicode = 5302;
+},
+{
+glyphname = "mwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (412,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 588;
+}
+);
+note = uni14B7;
+unicode = 5303;
+},
+{
+glyphname = "mwaa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (212,0);
+ref = dot_top;
+}
+);
+width = 588;
+}
+);
+note = uni14B8;
+unicode = 5304;
+},
+{
+glyphname = "mwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (412,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 588;
+}
+);
+note = uni14B9;
+unicode = 5305;
+},
+{
+glyphname = "mwaaNaskapi-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (192,0);
+ref = "ma-canadian";
+}
+);
+width = 604;
+}
+);
+note = uni14BA;
+unicode = 5306;
+},
+{
+glyphname = "m-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(225,401,l),
+(97,401,l),
+(97,714,l),
+(52,714,l),
+(52,357,l),
+(225,357,l)
+);
+}
+);
+width = 254;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni14BB;
+unicode = 5307;
+},
+{
+glyphname = "mWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+ref = "t-canadian";
+}
+);
+width = 286;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "t-canadian";
+note = uni14BC;
+unicode = 5308;
+},
+{
+glyphname = "mh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(202,357,l),
+(202,714,l),
+(158,714,l),
+(158,401,l),
+(29,401,l),
+(29,357,l)
+);
+}
+);
+width = 254;
+}
+);
+metricLeft = "=|m-canadian";
+metricRight = "=|m-canadian";
+note = uni14BD;
+unicode = 5309;
+},
+{
+glyphname = "mAthapascan-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(238,357,l),
+(238,398,l),
+(103,398,l),
+(104,375,l),
+(186,497,ls),
+(219,546,o),
+(226,582,o),
+(226,617,cs),
+(226,678,o),
+(195,720,o),
+(139,720,cs),
+(79,720,o),
+(46,676,o),
+(46,598,c),
+(88,598,l),
+(88,661,o),
+(104,684,o),
+(138,684,cs),
+(169,684,o),
+(184,660,o),
+(184,617,cs),
+(184,587,o),
+(182,563,o),
+(148,511,cs),
+(58,379,l),
+(58,357,l)
+);
+}
+);
+width = 278;
+}
+);
+note = uni14BE;
+unicode = 5310;
+},
+{
+glyphname = "mSayisi-canadian";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = two.canadian;
+}
+);
+width = 450;
+}
+);
+note = uni14BF;
+unicode = 5311;
+},
+{
+glyphname = "ne-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (403,254);
+},
+{
+name = top_center_can;
+pos = (395,508);
+},
+{
+name = top_left_can;
+pos = (83,508);
+},
+{
+name = top_right_can;
+pos = (551,508);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(514,-13,o),
+(582,73,o),
+(582,239,cs),
+(582,404,o),
+(515,489,o),
+(395,489,cs),
+(51,489,l),
+(51,431,l),
+(312,431,l),
+(309,448,l),
+(253,415,o),
+(225,330,o),
+(225,236,cs),
+(225,73,o),
+(292,-13,o),
+(404,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(326,43,o),
+(288,106,o),
+(288,239,cs),
+(288,362,o),
+(327,433,o),
+(404,433,cs),
+(479,433,o),
+(520,371,o),
+(520,239,cs),
+(520,106,o),
+(481,43,o),
+(404,43,cs)
+);
+}
+);
+width = 637;
+}
+);
+metricRight = "=|ke-canadian";
+note = uni14C0;
+unicode = 5312;
+},
+{
+glyphname = "naai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (125,-206);
+ref = ring_top.canadian;
+}
+);
+width = 637;
+}
+);
+note = uni14C1;
+unicode = 5313;
+},
+{
+glyphname = "ni-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (235,254);
+},
+{
+name = top_center_can;
+pos = (243,508);
+},
+{
+name = top_left_can;
+pos = (87,508);
+},
+{
+name = top_right_can;
+pos = (554,508);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(345,-13,o),
+(412,73,o),
+(412,236,cs),
+(412,330,o),
+(384,415,o),
+(328,448,c),
+(325,431,l),
+(586,431,l),
+(586,489,l),
+(242,489,ls),
+(123,489,o),
+(55,403,o),
+(55,238,cs),
+(55,73,o),
+(123,-13,o),
+(233,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(156,43,o),
+(117,106,o),
+(117,239,cs),
+(117,372,o),
+(158,434,o),
+(233,434,cs),
+(310,434,o),
+(349,363,o),
+(349,239,cs),
+(349,106,o),
+(310,43,o),
+(233,43,cs)
+);
+}
+);
+width = 637;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+unicode = 5314;
+},
+{
+glyphname = "nii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (183,-206);
+ref = dot_top;
+}
+);
+width = 637;
+}
+);
+note = uni14C3;
+unicode = 5315;
+},
+{
+glyphname = "no-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (402,254);
+},
+{
+name = top_center_can;
+pos = (400,508);
+},
+{
+name = top_double;
+pos = (404,508);
+},
+{
+name = top_left_can;
+pos = (82,508);
+},
+{
+name = top_right_can;
+pos = (551,508);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(395,0,ls),
+(514,0,o),
+(582,85,o),
+(582,250,cs),
+(582,416,o),
+(514,502,o),
+(404,502,cs),
+(292,502,o),
+(225,416,o),
+(225,253,cs),
+(225,159,o),
+(253,74,o),
+(310,41,c),
+(312,59,l),
+(51,59,l),
+(51,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(327,55,o),
+(288,126,o),
+(288,250,cs),
+(288,383,o),
+(326,446,o),
+(404,446,cs),
+(481,446,o),
+(520,383,o),
+(520,250,cs),
+(520,117,o),
+(479,55,o),
+(404,55,cs)
+);
+}
+);
+width = 637;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14C4;
+unicode = 5316;
+},
+{
+glyphname = "noo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (339,-206);
+ref = dot_top;
+}
+);
+width = 637;
+}
+);
+note = uni14C5;
+unicode = 5317;
+},
+{
+glyphname = "ycreenoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (209,-206);
+ref = doubledot_top;
+}
+);
+width = 637;
+}
+);
+note = uni14C6;
+unicode = 5318;
+},
+{
+glyphname = "na-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (235,254);
+},
+{
+name = top_center_can;
+pos = (237,508);
+},
+{
+name = top_double;
+pos = (349,508);
+},
+{
+name = top_left_can;
+pos = (87,508);
+},
+{
+name = top_right_can;
+pos = (554,508);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(586,0,l),
+(586,58,l),
+(325,58,l),
+(327,41,l),
+(384,74,o),
+(412,159,o),
+(412,253,cs),
+(412,416,o),
+(345,502,o),
+(233,502,cs),
+(123,502,o),
+(55,416,o),
+(55,250,cs),
+(55,85,o),
+(123,0,o),
+(242,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(158,55,o),
+(117,117,o),
+(117,250,cs),
+(117,383,o),
+(156,446,o),
+(233,446,cs),
+(310,446,o),
+(349,383,o),
+(349,250,cs),
+(349,126,o),
+(310,55,o),
+(233,55,cs)
+);
+}
+);
+width = 637;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+unicode = 5319;
+},
+{
+glyphname = "naa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (176,-206);
+ref = dot_top;
+}
+);
+width = 637;
+}
+);
+note = uni14C8;
+unicode = 5320;
+},
+{
+glyphname = "nwe-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ne-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni14C9;
+unicode = 5321;
+},
+{
+glyphname = "nweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni14CA;
+unicode = 5322;
+},
+{
+glyphname = "nwa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "na-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni14CB;
+unicode = 5323;
+},
+{
+glyphname = "nwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni14CC;
+unicode = 5324;
+},
+{
+glyphname = "nwaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (351,-206);
+ref = dot_top;
+}
+);
+width = 812;
+}
+);
+note = uni14CD;
+unicode = 5325;
+},
+{
+glyphname = "nwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (176,-206);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni14CE;
+unicode = 5326;
+},
+{
+glyphname = "nwaaNaskapi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (154,-206);
+ref = doubledot_top;
+}
+);
+width = 637;
+}
+);
+note = uni14CF;
+unicode = 5327;
+},
+{
+glyphname = "n-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(333,449,l),
+(333,493,l),
+(188,493,l),
+(189,473,l),
+(220,488,o),
+(234,535,o),
+(234,587,cs),
+(234,674,o),
+(196,720,o),
+(138,720,cs),
+(80,720,o),
+(42,673,o),
+(42,585,cs),
+(42,498,o),
+(79,449,o),
+(144,449,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(104,485,o),
+(83,517,o),
+(83,585,cs),
+(83,654,o),
+(104,683,o),
+(139,683,cs),
+(173,683,o),
+(193,653,o),
+(193,585,cs),
+(193,516,o),
+(172,485,o),
+(138,485,cs)
+);
+}
+);
+width = 362;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni14D0;
+unicode = 5328;
+},
+{
+color = 6;
+glyphname = "ngCarrier-canadian";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-167);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 329;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "=|";
+note = uni14D1;
+unicode = 5329;
+},
+{
+glyphname = "nh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(219,449,ls),
+(283,449,o),
+(320,498,o),
+(320,585,cs),
+(320,673,o),
+(282,720,o),
+(224,720,cs),
+(166,720,o),
+(129,674,o),
+(129,587,cs),
+(129,535,o),
+(142,488,o),
+(173,473,c),
+(175,493,l),
+(29,493,l),
+(29,449,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(191,485,o),
+(170,516,o),
+(170,585,cs),
+(170,653,o),
+(189,683,o),
+(224,683,cs),
+(258,683,o),
+(279,654,o),
+(279,585,cs),
+(279,517,o),
+(258,485,o),
+(224,485,cs)
+);
+}
+);
+width = 362;
+}
+);
+metricLeft = "=|n-canadian";
+metricRight = "=|n-canadian";
+note = uni14D2;
+unicode = 5330;
+},
+{
+glyphname = "le-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (402,254);
+},
+{
+name = top_center_can;
+pos = (396,508);
+},
+{
+name = top_left_can;
+pos = (83,508);
+},
+{
+name = top_right_can;
+pos = (551,508);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(365,0,ls),
+(502.006,0,o),
+(582,84,o),
+(582,244,cs),
+(582,404,o),
+(503,489,o),
+(363,489,cs),
+(51,489,l),
+(51,431,l),
+(362,431,ls),
+(464,431,o),
+(519,368,o),
+(519,243,cs),
+(519,120,o),
+(465,57,o),
+(360,57,cs),
+(352,57,l),
+(352,0,l)
+);
+}
+);
+width = 637;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D3;
+unicode = 5331;
+},
+{
+glyphname = "laai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (125,-206);
+ref = ring_top.canadian;
+}
+);
+width = 637;
+}
+);
+note = uni14D4;
+unicode = 5332;
+},
+{
+glyphname = "li-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (235,254);
+},
+{
+name = top_center_can;
+pos = (243,508);
+},
+{
+name = top_left_can;
+pos = (87,508);
+},
+{
+name = top_right_can;
+pos = (554,508);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(285,0,l),
+(285,57,l),
+(277,57,ls),
+(172,57,o),
+(118,120,o),
+(118,244,cs),
+(118,369,o),
+(173,431,o),
+(275,431,cs),
+(586,431,l),
+(586,489,l),
+(273,489,ls),
+(137,489,o),
+(55,404,o),
+(55,244,cs),
+(55,84,o),
+(135,0,o),
+(272,0,cs)
+);
+}
+);
+width = 637;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14D5;
+unicode = 5333;
+},
+{
+glyphname = "lii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (183,-206);
+ref = dot_top;
+}
+);
+width = 637;
+}
+);
+note = uni14D6;
+unicode = 5334;
+},
+{
+glyphname = "lo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (402,254);
+},
+{
+name = top_center_can;
+pos = (400,508);
+},
+{
+name = top_double;
+pos = (365,508);
+},
+{
+name = top_left_can;
+pos = (82,508);
+},
+{
+name = top_right_can;
+pos = (551,508);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(364,0,ls),
+(500,0,o),
+(582,85,o),
+(582,245,cs),
+(582,405,o),
+(502,489,o),
+(365,489,cs),
+(352,489,l),
+(352,432,l),
+(360,432,ls),
+(465,432,o),
+(519,369,o),
+(519,246,cs),
+(519,121,o),
+(464,58,o),
+(362,58,cs),
+(51,58,l),
+(51,0,l)
+);
+}
+);
+width = 637;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D7;
+unicode = 5335;
+},
+{
+glyphname = "loo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (339,-206);
+ref = dot_top;
+}
+);
+width = 637;
+}
+);
+note = uni14D8;
+unicode = 5336;
+},
+{
+glyphname = "ycreeloo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (170,-206);
+ref = doubledot_top;
+}
+);
+width = 637;
+}
+);
+note = uni14D9;
+unicode = 5337;
+},
+{
+glyphname = "la-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (235,254);
+},
+{
+name = top_center_can;
+pos = (237,508);
+},
+{
+name = top_left_can;
+pos = (87,508);
+},
+{
+name = top_right_can;
+pos = (554,508);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(586,0,l),
+(586,58,l),
+(275,58,ls),
+(172,58,o),
+(118,121,o),
+(118,246,cs),
+(118,369,o),
+(172,432,o),
+(277,432,cs),
+(285,432,l),
+(285,489,l),
+(272,489,ls),
+(135,489,o),
+(55,404,o),
+(55,245,cs),
+(55,85,o),
+(136,0,o),
+(273,0,cs)
+);
+}
+);
+width = 637;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14DA;
+unicode = 5338;
+},
+{
+glyphname = "laa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (176,-206);
+ref = dot_top;
+}
+);
+width = 637;
+}
+);
+note = uni14DB;
+unicode = 5339;
+},
+{
+glyphname = "lwe-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "le-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni14DC;
+unicode = 5340;
+},
+{
+glyphname = "lweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "le-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni14DD;
+unicode = 5341;
+},
+{
+glyphname = "lwi-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "li-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni14DE;
+unicode = 5342;
+},
+{
+glyphname = "lwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni14DF;
+unicode = 5343;
+},
+{
+glyphname = "lwii-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (358,-206);
+ref = dot_top;
+}
+);
+width = 812;
+}
+);
+note = uni14E0;
+unicode = 5344;
+},
+{
+glyphname = "lwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (183,-206);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni14E1;
+unicode = 5345;
+},
+{
+glyphname = "lwo-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "lo-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni14E2;
+unicode = 5346;
+},
+{
+glyphname = "lwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni14E3;
+unicode = 5347;
+},
+{
+glyphname = "lwoo-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (514,-206);
+ref = dot_top;
+}
+);
+width = 812;
+}
+);
+note = uni14E4;
+unicode = 5348;
+},
+{
+glyphname = "lwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (339,-206);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni14E5;
+unicode = 5349;
+},
+{
+glyphname = "lwa-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "la-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni14E6;
+unicode = 5350;
+},
+{
+glyphname = "lwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni14E7;
+unicode = 5351;
+},
+{
+glyphname = "lwaa-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (351,-206);
+ref = dot_top;
+}
+);
+width = 812;
+}
+);
+note = uni14E8;
+unicode = 5352;
+},
+{
+glyphname = "lwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (176,-206);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni14E9;
+unicode = 5353;
+},
+{
+glyphname = "l-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(332,357,l),
+(332,401,l),
+(215,401,ls),
+(134,401,o),
+(97,445,o),
+(97,535,cs),
+(97,622,o),
+(134,670,o),
+(204,670,cs),
+(208,670,l),
+(208,714,l),
+(202,714,ls),
+(105,714,o),
+(51,647,o),
+(51,535,cs),
+(51,422,o),
+(105,357,o),
+(211,357,cs)
+);
+}
+);
+width = 361;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "m-canadian";
+note = uni14EA;
+unicode = 5354;
+},
+{
+glyphname = "lWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(238,357,l),
+(238,389,l),
+(83,469,l),
+(83,447,l),
+(238,523,l),
+(238,547,l),
+(83,624,l),
+(83,601,l),
+(238,681,l),
+(238,714,l),
+(229,714,l),
+(52,623,l),
+(52,603,l),
+(208,526,l),
+(208,544,l),
+(52,468,l),
+(52,448,l),
+(229,357,l)
+);
+}
+);
+width = 290;
+}
+);
+metricRight = "=|";
+note = uni14EB;
+unicode = 5355;
+},
+{
+glyphname = "mediall-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(447,-13,l),
+(447,35,l),
+(114,206,l),
+(114,179,l),
+(447,341,l),
+(447,373,l),
+(114,535,l),
+(114,508,l),
+(447,679,l),
+(447,727,l),
+(430,727,l),
+(60,539,l),
+(60,508,l),
+(395,346,l),
+(395,368,l),
+(60,206,l),
+(60,175,l),
+(430,-13,l)
+);
+}
+);
+width = 507;
+}
+);
+metricRight = "=|";
+note = uni14EC;
+unicode = 5356;
+},
+{
+glyphname = "se-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (94,714);
+},
+{
+name = top_right_can;
+pos = (326,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(358,0,l),
+(358,326,l),
+(322,326,ls),
+(188,326,o),
+(126,388,o),
+(126,556,cs),
+(126,714,l),
+(63,714,l),
+(63,552,ls),
+(63,357,o),
+(149,268,o),
+(312,268,cs),
+(341,268,l),
+(295,292,l),
+(295,0,l)
+);
+}
+);
+width = 423;
+}
+);
+note = uni14ED;
+unicode = 5357;
+},
+{
+glyphname = "saai-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (211,0);
+ref = ring_top.canadian;
+}
+);
+width = 423;
+}
+);
+note = uni14EE;
+unicode = 5358;
+},
+{
+glyphname = "si-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (97,714);
+},
+{
+name = top_right_can;
+pos = (329,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(128,0,l),
+(128,292,l),
+(82,268,l),
+(111,268,ls),
+(274,268,o),
+(360,357,o),
+(360,552,cs),
+(360,714,l),
+(297,714,l),
+(297,556,ls),
+(297,388,o),
+(235,326,o),
+(101,326,cs),
+(65,326,l),
+(65,0,l)
+);
+}
+);
+width = 423;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+unicode = 5359;
+},
+{
+glyphname = "sii-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (268,0);
+ref = dot_top;
+}
+);
+width = 423;
+}
+);
+note = uni14F0;
+unicode = 5360;
+},
+{
+glyphname = "so-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (327,714);
+},
+{
+name = top_left_can;
+pos = (95,714);
+},
+{
+name = top_right_can;
+pos = (326,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(126,0,l),
+(126,158,ls),
+(126,326,o),
+(188,388,o),
+(322,388,cs),
+(358,388,l),
+(358,714,l),
+(295,714,l),
+(295,422,l),
+(341,446,l),
+(312,446,ls),
+(149,446,o),
+(63,357,o),
+(63,162,cs),
+(63,0,l)
+);
+}
+);
+width = 423;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+unicode = 5361;
+},
+{
+glyphname = "soo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (265,0);
+ref = dot_top;
+}
+);
+width = 423;
+}
+);
+note = uni14F2;
+unicode = 5362;
+},
+{
+glyphname = "ycreesoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (132,0);
+ref = doubledot_top;
+}
+);
+width = 423;
+}
+);
+note = uni14F3;
+unicode = 5363;
+},
+{
+glyphname = "sa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (97,714);
+},
+{
+name = top_right_can;
+pos = (329,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(360,0,l),
+(360,162,ls),
+(360,357,o),
+(274,446,o),
+(111,446,cs),
+(82,446,l),
+(128,422,l),
+(128,714,l),
+(65,714,l),
+(65,388,l),
+(101,388,ls),
+(235,388,o),
+(297,326,o),
+(297,158,cs),
+(297,0,l)
+);
+}
+);
+width = 423;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+unicode = 5364;
+},
+{
+glyphname = "saa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (37,0);
+ref = dot_top;
+}
+);
+width = 423;
+}
+);
+note = uni14F5;
+unicode = 5365;
+},
+{
+glyphname = "swe-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "se-canadian";
+}
+);
+width = 599;
+}
+);
+note = uni14F6;
+unicode = 5366;
+},
+{
+glyphname = "sweWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "se-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (423,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 599;
+}
+);
+note = uni14F7;
+unicode = 5367;
+},
+{
+glyphname = "swi-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "si-canadian";
+}
+);
+width = 599;
+}
+);
+note = uni14F8;
+unicode = 5368;
+},
+{
+glyphname = "swiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (423,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 599;
+}
+);
+note = uni14F9;
+unicode = 5369;
+},
+{
+glyphname = "swii-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (444,0);
+ref = dot_top;
+}
+);
+width = 599;
+}
+);
+note = uni14FA;
+unicode = 5370;
+},
+{
+glyphname = "swiiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (268,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (423,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 599;
+}
+);
+note = uni14FB;
+unicode = 5371;
+},
+{
+glyphname = "swo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "so-canadian";
+}
+);
+width = 599;
+}
+);
+note = uni14FC;
+unicode = 5372;
+},
+{
+glyphname = "swoWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (423,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 599;
+}
+);
+note = uni14FD;
+unicode = 5373;
+},
+{
+glyphname = "swoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (441,0);
+ref = dot_top;
+}
+);
+width = 599;
+}
+);
+note = uni14FE;
+unicode = 5374;
+},
+{
+glyphname = "swooWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (265,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (423,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 599;
+}
+);
+note = uni14FF;
+unicode = 5375;
+},
+{
+glyphname = "swa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "sa-canadian";
+}
+);
+width = 599;
+}
+);
+note = uni1500;
+unicode = 5376;
+},
+{
+glyphname = "swaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (423,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 599;
+}
+);
+note = uni1501;
+unicode = 5377;
+},
+{
+glyphname = "swaa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (212,0);
+ref = dot_top;
+}
+);
+width = 599;
+}
+);
+note = uni1502;
+unicode = 5378;
+},
+{
+glyphname = "swaaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (37,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (423,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 599;
+}
+);
+note = uni1503;
+unicode = 5379;
+},
+{
+glyphname = "swaaNaskapi-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (192,0);
+ref = "sa-canadian";
+}
+);
+width = 615;
+}
+);
+note = uni1504;
+unicode = 5380;
+},
+{
+glyphname = "s-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(224,357,l),
+(224,442,ls),
+(224,540,o),
+(178,589,o),
+(96,589,cs),
+(71,589,l),
+(97,567,l),
+(97,714,l),
+(52,714,l),
+(52,551,l),
+(86,551,ls),
+(150,551,o),
+(179,517,o),
+(179,439,cs),
+(179,357,l)
+);
+}
+);
+width = 276;
+}
+);
+metricRight = "=|";
+note = uni1505;
+unicode = 5381;
+},
+{
+color = 6;
+glyphname = "sAthapascan-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(213,183,o),
+(249,224,o),
+(249,277,cs),
+(249,323,o),
+(230,352,o),
+(184,374,cs),
+(141,395,ls),
+(107,412,o),
+(99,430,o),
+(99,458,cs),
+(99,492,o),
+(117,515,o),
+(153,515,cs),
+(188,515,o),
+(210,497,o),
+(208,444,c),
+(250,444,l),
+(252,510,o),
+(218,552,o),
+(152,552,cs),
+(92,552,o),
+(57,512,o),
+(57,458,cs),
+(57,412,o),
+(77,381,o),
+(119,361,cs),
+(163,340,ls),
+(195,324,o),
+(207,308,o),
+(207,276,cs),
+(207,240,o),
+(187,220,o),
+(152,220,cs),
+(115,220,o),
+(93,238,o),
+(94,294,c),
+(52,294,l),
+(50,222,o),
+(86,183,o),
+(151,183,cs)
+);
+}
+);
+width = 302;
+}
+);
+metricRight = "=|";
+note = uni1506;
+unicode = 5382;
+},
+{
+glyphname = "sw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,357,l),
+(97,439,ls),
+(97,517,o),
+(127,551,o),
+(191,551,cs),
+(224,551,l),
+(224,714,l),
+(179,714,l),
+(179,567,l),
+(205,589,l),
+(180,589,ls),
+(99,589,o),
+(52,540,o),
+(52,442,cs),
+(52,357,l)
+);
+}
+);
+width = 276;
+}
+);
+metricLeft = "=|s-canadian";
+metricRight = "=|s-canadian";
+note = uni1507;
+unicode = 5383;
+},
+{
+glyphname = "sBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(231,357,l),
+(231,401,l),
+(172,401,ls),
+(116,401,o),
+(97,425,o),
+(97,485,cs),
+(97,714,l),
+(52,714,l),
+(52,480,ls),
+(52,399,o),
+(87,357,o),
+(168,357,c)
+);
+}
+);
+width = 260;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "m-canadian";
+note = uni1508;
+unicode = 5384;
+},
+{
+glyphname = "moosecreesk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(205,225,o),
+(246,268,o),
+(246,378,cs),
+(246,522,o),
+(197,590,o),
+(86,590,cs),
+(77,590,l),
+(97,567,l),
+(97,714,l),
+(52,714,l),
+(52,552,l),
+(78,552,ls),
+(167,552,o),
+(194,508,o),
+(200,424,c),
+(213,414,l),
+(207,460,o),
+(179,495,o),
+(143,495,cs),
+(91,495,o),
+(53,448,o),
+(53,362,cs),
+(53,269,o),
+(97,225,o),
+(149,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(117,261,o),
+(94,292,o),
+(94,362,cs),
+(94,430,o),
+(117,460,o),
+(149,460,cs),
+(181,460,o),
+(204,429,o),
+(204,361,cs),
+(204,289,o),
+(183,261,o),
+(149,261,cs)
+);
+}
+);
+width = 298;
+}
+);
+metricRight = "=|";
+note = uni1509;
+unicode = 5385;
+},
+{
+glyphname = "skwNaskapi-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(202,225,o),
+(246,269,o),
+(246,362,cs),
+(246,448,o),
+(207,495,o),
+(155,495,cs),
+(120,495,o),
+(91,460,o),
+(85,414,c),
+(98,424,l),
+(105,508,o),
+(131,552,o),
+(220,552,cs),
+(246,552,l),
+(246,714,l),
+(201,714,l),
+(201,567,l),
+(222,590,l),
+(212,590,ls),
+(102,590,o),
+(52,522,o),
+(52,378,cs),
+(52,268,o),
+(93,225,o),
+(149,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(115,261,o),
+(94,289,o),
+(94,361,cs),
+(94,429,o),
+(117,460,o),
+(149,460,cs),
+(181,460,o),
+(204,430,o),
+(204,362,cs),
+(204,292,o),
+(182,261,o),
+(149,261,cs)
+);
+}
+);
+width = 298;
+}
+);
+metricLeft = "=|moosecreesk-canadian";
+metricRight = "=|moosecreesk-canadian";
+note = uni150A;
+unicode = 5386;
+},
+{
+glyphname = "swNaskapi-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(243,184,l),
+(243,263,ls),
+(243,359,o),
+(197,411,o),
+(116,411,cs),
+(90,411,l),
+(113,389,l),
+(113,531,l),
+(69,531,l),
+(69,373,l),
+(108,373,ls),
+(169,373,o),
+(199,338,o),
+(199,260,cs),
+(199,184,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(245,65,o),
+(264,84,o),
+(264,107,cs),
+(264,131,o),
+(244,150,o),
+(222,150,cs),
+(199,150,o),
+(180,131,o),
+(180,107,cs),
+(180,84,o),
+(199,65,o),
+(222,65,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(114,564,o),
+(133,583,o),
+(133,606,cs),
+(133,630,o),
+(114,649,o),
+(91,649,cs),
+(68,649,o),
+(49,630,o),
+(49,606,cs),
+(49,583,o),
+(68,564,o),
+(91,564,cs)
+);
+}
+);
+width = 313;
+}
+);
+metricRight = "=|";
+note = uni150B;
+unicode = 5387;
+},
+{
+glyphname = "spwaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(469,0,l),
+(469,58,l),
+(86,373,l),
+(86,341,l),
+(469,656,l),
+(469,714,l),
+(451,714,l),
+(31,370,l),
+(31,344,l),
+(451,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(132,511,o),
+(152,529,o),
+(152,553,cs),
+(152,577,o),
+(132,596,o),
+(109,596,cs),
+(87,596,o),
+(67,577,o),
+(67,553,cs),
+(67,529,o),
+(87,511,o),
+(109,511,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(272,619,l),
+(272,681,ls),
+(272,747,o),
+(242,783,o),
+(178,783,cs),
+(157,783,l),
+(188,764,l),
+(188,865,l),
+(146,865,l),
+(146,747,l),
+(169,747,ls),
+(210,747,o),
+(230,727,o),
+(230,676,cs),
+(230,619,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(398,724,o),
+(418,743,o),
+(418,767,cs),
+(418,791,o),
+(398,810,o),
+(375,810,cs),
+(353,810,o),
+(333,791,o),
+(333,767,cs),
+(333,743,o),
+(353,724,o),
+(375,724,cs)
+);
+}
+);
+width = 512;
+}
+);
+metricRight = "pa-canadian";
+metricWidth = "pa-canadian";
+note = uni150C;
+unicode = 5388;
+},
+{
+glyphname = "stwaNaskapi-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (312,0);
+ref = "ta-canadian";
+}
+);
+width = 781;
+}
+);
+note = uni150D;
+unicode = 5389;
+},
+{
+glyphname = "skwaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (312,0);
+ref = "ka-canadian";
+}
+);
+width = 778;
+}
+);
+note = uni150E;
+unicode = 5390;
+},
+{
+glyphname = "scwaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (312,0);
+ref = "ca-canadian";
+}
+);
+width = 774;
+}
+);
+note = uni150F;
+unicode = 5391;
+},
+{
+glyphname = "she-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (227,714);
+},
+{
+name = top_right_can;
+pos = (537,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(604,-13,o),
+(667,67,o),
+(667,226,cs),
+(667,309,l),
+(603,309,l),
+(603,216,ls),
+(603,98,o),
+(567,44,o),
+(504,44,cs),
+(435,44,o),
+(406,97,o),
+(399,226,cs),
+(387,487,ls),
+(380,647,o),
+(333,727,o),
+(223,727,cs),
+(120,727,o),
+(58,648,o),
+(58,488,cs),
+(58,405,l),
+(121,405,l),
+(121,498,ls),
+(121,617,o),
+(157,670,o),
+(220,670,cs),
+(289,670,o),
+(318,617,o),
+(325,488,cs),
+(337,227,ls),
+(344,67,o),
+(392,-13,o),
+(501,-13,cs)
+);
+}
+);
+width = 725;
+}
+);
+metricRight = "=|";
+note = uni1510;
+unicode = 5392;
+},
+{
+glyphname = "shi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (190,714);
+},
+{
+name = top_right_can;
+pos = (500,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(333,-13,o),
+(380,67,o),
+(387,227,cs),
+(399,488,ls),
+(406,617,o),
+(435,670,o),
+(504,670,cs),
+(567,670,o),
+(603,617,o),
+(603,498,cs),
+(603,405,l),
+(667,405,l),
+(667,488,ls),
+(667,648,o),
+(604,727,o),
+(501,727,cs),
+(391,727,o),
+(344,647,o),
+(337,487,cs),
+(325,226,ls),
+(319,97,o),
+(289,44,o),
+(220,44,cs),
+(157,44,o),
+(121,98,o),
+(121,216,cs),
+(121,309,l),
+(58,309,l),
+(58,226,ls),
+(58,67,o),
+(121,-13,o),
+(223,-13,cs)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "she-canadian";
+metricRight = "she-canadian";
+note = uni1511;
+unicode = 5393;
+},
+{
+glyphname = "shii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (439,0);
+ref = dot_top;
+}
+);
+width = 724;
+}
+);
+note = uni1512;
+unicode = 5394;
+},
+{
+glyphname = "sho-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (368,508);
+},
+{
+name = top_left_can;
+pos = (224,508);
+},
+{
+name = top_right_can;
+pos = (513,508);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(283,44,l),
+(171,43,o),
+(118,92,o),
+(118,180,cs),
+(118,250,o),
+(151,297,o),
+(215,297,cs),
+(315,297,o),
+(403,134,o),
+(531,134,cs),
+(626,134,o),
+(682,204,o),
+(682,307,cs),
+(682,431,o),
+(600,503,o),
+(456,502,c),
+(454,445,l),
+(567,446,o),
+(620,398,o),
+(620,309,cs),
+(620,239,o),
+(586,192,o),
+(522,192,cs),
+(422,192,o),
+(334,355,o),
+(207,355,cs),
+(112,355,o),
+(55,286,o),
+(55,182,cs),
+(55,59,o),
+(137,-14,o),
+(281,-13,c)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1513;
+unicode = 5395;
+},
+{
+glyphname = "shoo-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (308,-206);
+ref = dot_top;
+}
+);
+width = 737;
+}
+);
+note = uni1514;
+unicode = 5396;
+},
+{
+glyphname = "sha-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (369,508);
+},
+{
+name = top_left_can;
+pos = (223,508);
+},
+{
+name = top_right_can;
+pos = (514,508);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(600,-14,o),
+(682,59,o),
+(682,182,cs),
+(682,286,o),
+(626,355,o),
+(531,355,cs),
+(403,355,o),
+(315,192,o),
+(215,192,cs),
+(151,192,o),
+(118,239,o),
+(118,309,cs),
+(118,398,o),
+(171,446,o),
+(283,445,c),
+(281,502,l),
+(137,503,o),
+(55,431,o),
+(55,307,cs),
+(55,204,o),
+(112,134,o),
+(207,134,cs),
+(334,134,o),
+(422,297,o),
+(522,297,cs),
+(586,297,o),
+(620,250,o),
+(620,180,cs),
+(620,92,o),
+(567,43,o),
+(454,44,c),
+(456,-13,l)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1515;
+unicode = 5397;
+},
+{
+glyphname = "shaa-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (308,-206);
+ref = dot_top;
+}
+);
+width = 737;
+}
+);
+note = uni1516;
+unicode = 5398;
+},
+{
+glyphname = "shwe-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "she-canadian";
+}
+);
+width = 900;
+}
+);
+note = uni1517;
+unicode = 5399;
+},
+{
+glyphname = "shweWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "she-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (724,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 900;
+}
+);
+note = uni1518;
+unicode = 5400;
+},
+{
+glyphname = "shwi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "shi-canadian";
+}
+);
+width = 900;
+}
+);
+note = uni1519;
+unicode = 5401;
+},
+{
+glyphname = "shwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (724,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 900;
+}
+);
+note = uni151A;
+unicode = 5402;
+},
+{
+glyphname = "shwii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (614,0);
+ref = dot_top;
+}
+);
+width = 900;
+}
+);
+note = uni151B;
+unicode = 5403;
+},
+{
+glyphname = "shwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (439,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (724,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 900;
+}
+);
+note = uni151C;
+unicode = 5404;
+},
+{
+glyphname = "shwo-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "sho-canadian";
+}
+);
+width = 913;
+}
+);
+note = uni151D;
+unicode = 5405;
+},
+{
+glyphname = "shwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (737,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 913;
+}
+);
+note = uni151E;
+unicode = 5406;
+},
+{
+glyphname = "shwoo-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (483,-206);
+ref = dot_top;
+}
+);
+width = 913;
+}
+);
+note = uni151F;
+unicode = 5407;
+},
+{
+glyphname = "shwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (308,-206);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (737,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 913;
+}
+);
+note = uni1520;
+unicode = 5408;
+},
+{
+glyphname = "shwa-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "sha-canadian";
+}
+);
+width = 913;
+}
+);
+note = uni1521;
+unicode = 5409;
+},
+{
+glyphname = "shwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (737,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 913;
+}
+);
+note = uni1522;
+unicode = 5410;
+},
+{
+glyphname = "shwaa-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (484,-206);
+ref = dot_top;
+}
+);
+width = 913;
+}
+);
+note = uni1523;
+unicode = 5411;
+},
+{
+glyphname = "shwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (308,-206);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (737,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 913;
+}
+);
+note = uni1524;
+unicode = 5412;
+},
+{
+glyphname = "sh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(443,301,o),
+(510,356,o),
+(510,449,cs),
+(510,533,o),
+(462,582,o),
+(392,582,cs),
+(302,582,o),
+(245,485,o),
+(174,485,cs),
+(126,485,o),
+(97,514,o),
+(97,574,cs),
+(97,638,o),
+(143,679,o),
+(232,679,c),
+(231,722,l),
+(118,722,o),
+(51,666,o),
+(51,574,cs),
+(51,489,o),
+(100,440,o),
+(169,440,cs),
+(259,440,o),
+(316,537,o),
+(387,537,cs),
+(435,537,o),
+(465,508,o),
+(465,448,cs),
+(465,384,o),
+(418,343,o),
+(329,343,c),
+(331,301,l)
+);
+}
+);
+width = 561;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni1525;
+unicode = 5413;
+},
+{
+glyphname = "ye-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (469,357);
+},
+{
+name = top_left_can;
+pos = (73,714);
+},
+{
+name = top_right_can;
+pos = (356,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(387,0,l),
+(387,321,l),
+(116,321,l),
+(120,300,l),
+(402,691,l),
+(355,726,l),
+(41,290,l),
+(41,264,l),
+(323,264,l),
+(323,0,l)
+);
+}
+);
+width = 448;
+}
+);
+note = uni1526;
+unicode = 5414;
+},
+{
+glyphname = "yaai-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-25,0);
+ref = ring_top.canadian;
+}
+);
+width = 448;
+}
+);
+note = uni1527;
+unicode = 5415;
+},
+{
+glyphname = "yi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (94,714);
+},
+{
+name = top_right_can;
+pos = (376,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(125,0,l),
+(125,264,l),
+(407,264,l),
+(407,290,l),
+(93,726,l),
+(46,691,l),
+(329,300,l),
+(333,321,l),
+(62,321,l),
+(62,0,l)
+);
+}
+);
+width = 448;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni1528;
+unicode = 5416;
+},
+{
+glyphname = "yii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (33,0);
+ref = dot_top;
+}
+);
+width = 448;
+}
+);
+note = uni1529;
+unicode = 5417;
+},
+{
+glyphname = "yo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (469,357);
+},
+{
+name = top_double;
+pos = (356,714);
+},
+{
+name = top_left_can;
+pos = (73,714);
+},
+{
+name = top_right_can;
+pos = (356,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(402,23,l),
+(120,414,l),
+(116,393,l),
+(387,393,l),
+(387,714,l),
+(323,714,l),
+(323,450,l),
+(41,450,l),
+(41,424,l),
+(355,-12,l)
+);
+}
+);
+width = 448;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152A;
+unicode = 5418;
+},
+{
+glyphname = "yoo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (295,0);
+ref = dot_top;
+}
+);
+width = 448;
+}
+);
+note = uni152B;
+unicode = 5419;
+},
+{
+glyphname = "ycreeyoo-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (161,0);
+ref = doubledot_top;
+}
+);
+width = 448;
+}
+);
+note = uni152C;
+unicode = 5420;
+},
+{
+glyphname = "ya-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (94,714);
+},
+{
+name = top_right_can;
+pos = (376,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(407,424,l),
+(407,450,l),
+(125,450,l),
+(125,714,l),
+(62,714,l),
+(62,393,l),
+(333,393,l),
+(329,414,l),
+(47,23,l),
+(93,-12,l)
+);
+}
+);
+width = 448;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152D;
+unicode = 5421;
+},
+{
+glyphname = "yaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (33,0);
+ref = dot_top;
+}
+);
+width = 448;
+}
+);
+note = uni152E;
+unicode = 5422;
+},
+{
+glyphname = "ywe-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ye-canadian";
+}
+);
+width = 623;
+}
+);
+note = uni152F;
+unicode = 5423;
+},
+{
+glyphname = "yweWestCree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ye-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (448,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 623;
+}
+);
+note = uni1530;
+unicode = 5424;
+},
+{
+glyphname = "ywi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "yi-canadian";
+}
+);
+width = 623;
+}
+);
+note = uni1531;
+unicode = 5425;
+},
+{
+glyphname = "ywiWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (448,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 623;
+}
+);
+note = uni1532;
+unicode = 5426;
+},
+{
+glyphname = "ywii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (208,0);
+ref = dot_top;
+}
+);
+width = 623;
+}
+);
+note = uni1533;
+unicode = 5427;
+},
+{
+glyphname = "ywiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (33,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (448,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 623;
+}
+);
+note = uni1534;
+unicode = 5428;
+},
+{
+glyphname = "ywo-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "yo-canadian";
+}
+);
+width = 623;
+}
+);
+note = uni1535;
+unicode = 5429;
+},
+{
+glyphname = "ywoWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (448,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 623;
+}
+);
+note = uni1536;
+unicode = 5430;
+},
+{
+glyphname = "ywoo-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (470,0);
+ref = dot_top;
+}
+);
+width = 623;
+}
+);
+note = uni1537;
+unicode = 5431;
+},
+{
+glyphname = "ywooWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (295,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (448,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 623;
+}
+);
+note = uni1538;
+unicode = 5432;
+},
+{
+glyphname = "ywa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ya-canadian";
+}
+);
+width = 623;
+}
+);
+note = uni1539;
+unicode = 5433;
+},
+{
+glyphname = "ywaWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (448,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 623;
+}
+);
+note = uni153A;
+unicode = 5434;
+},
+{
+glyphname = "ywaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (208,0);
+ref = dot_top;
+}
+);
+width = 623;
+}
+);
+note = uni153B;
+unicode = 5435;
+},
+{
+glyphname = "ywaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (33,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (448,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 623;
+}
+);
+note = uni153C;
+unicode = 5436;
+},
+{
+glyphname = "ywaaNaskapi-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (192,0);
+ref = "ya-canadian";
+}
+);
+width = 640;
+}
+);
+note = uni153D;
+unicode = 5437;
+},
+{
+glyphname = "y-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(240,565,l),
+(240,582,l),
+(101,582,l),
+(101,714,l),
+(56,714,l),
+(56,542,l),
+(194,542,l),
+(193,569,l),
+(52,372,l),
+(86,349,l)
+);
+}
+);
+width = 268;
+}
+);
+note = uni153E;
+unicode = 5438;
+},
+{
+glyphname = "biblecreey-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(136,661,l),
+(113,661,l),
+(188,357,l),
+(214,357,l),
+(289,661,l),
+(266,661,l),
+(320,357,l),
+(360,357,l),
+(360,370,l),
+(298,714,l),
+(264,714,l),
+(187,406,l),
+(215,406,l),
+(137,714,l),
+(104,714,l),
+(42,370,l),
+(42,357,l),
+(82,357,l)
+);
+}
+);
+width = 402;
+}
+);
+metricRight = "=|";
+note = uni153F;
+unicode = 5439;
+},
+{
+glyphname = "yWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,208,l),
+(200,334,l),
+(303,334,l),
+(303,378,l),
+(200,378,l),
+(200,501,l),
+(157,501,l),
+(157,378,l),
+(52,378,l),
+(52,334,l),
+(157,334,l),
+(157,208,l)
+);
+}
+);
+width = 355;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1540;
+unicode = 5440;
+},
+{
+glyphname = "yiSayisi-canadian";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,189);
+ref = "fullstop-canadian";
+}
+);
+width = 291;
+}
+);
+metricLeft = "fullstop-canadian";
+metricWidth = "fullstop-canadian";
+note = uni1541;
+unicode = 5441;
+},
+{
+glyphname = "re-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (237,508);
+},
+{
+name = top_left_can;
+pos = (95,508);
+},
+{
+name = top_right_can;
+pos = (588,508);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(350,-13,o),
+(410,71,o),
+(410,214,cs),
+(410,431,l),
+(620,431,l),
+(620,489,l),
+(348,489,l),
+(348,205,ls),
+(348,98,o),
+(311,44,o),
+(237,44,cs),
+(163,44,o),
+(126,99,o),
+(126,205,cs),
+(126,489,l),
+(63,489,l),
+(63,214,ls),
+(63,68,o),
+(126,-13,o),
+(237,-13,cs)
+);
+}
+);
+width = 671;
+}
+);
+metricRight = "=|ne-canadian";
+note = uni1542;
+unicode = 5442;
+},
+{
+glyphname = "reRCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (434,508);
+},
+{
+name = top_left_can;
+pos = (83,508);
+},
+{
+name = top_right_can;
+pos = (577,508);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(546,-13,o),
+(609,68,o),
+(609,214,cs),
+(609,489,l),
+(545,489,l),
+(545,205,ls),
+(545,99,o),
+(508,44,o),
+(434,44,cs),
+(360,44,o),
+(323,98,o),
+(323,205,cs),
+(323,489,l),
+(51,489,l),
+(51,431,l),
+(261,431,l),
+(261,214,ls),
+(261,71,o),
+(321,-13,o),
+(434,-13,cs)
+);
+}
+);
+width = 672;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1543;
+unicode = 5443;
+},
+{
+glyphname = "leWestCree-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (434,508);
+},
+{
+name = top_left_can;
+pos = (83,508);
+},
+{
+name = top_right_can;
+pos = (577,508);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(323,0,l),
+(323,284,ls),
+(323,391,o),
+(360,445,o),
+(434,445,cs),
+(508,445,o),
+(545,390,o),
+(545,284,cs),
+(545,0,l),
+(609,0,l),
+(609,275,ls),
+(609,421,o),
+(546,502,o),
+(434,502,cs),
+(321,502,o),
+(261,418,o),
+(261,275,cs),
+(261,59,l),
+(51,59,l),
+(51,0,l)
+);
+}
+);
+width = 672;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+unicode = 5444;
+},
+{
+glyphname = "raai-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (119,-206);
+ref = ring_top.canadian;
+}
+);
+width = 671;
+}
+);
+note = uni1545;
+unicode = 5445;
+},
+{
+glyphname = "ri-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (237,508);
+},
+{
+name = top_left_can;
+pos = (95,508);
+},
+{
+name = top_right_can;
+pos = (588,508);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(126,0,l),
+(126,284,ls),
+(126,390,o),
+(163,445,o),
+(238,445,cs),
+(311,445,o),
+(348,391,o),
+(348,284,cs),
+(348,0,l),
+(620,0,l),
+(620,59,l),
+(410,59,l),
+(410,275,ls),
+(410,418,o),
+(350,502,o),
+(237,502,cs),
+(126,502,o),
+(63,421,o),
+(63,275,cs),
+(63,0,l)
+);
+}
+);
+width = 671;
+}
+);
+metricLeft = "re-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+unicode = 5446;
+},
+{
+glyphname = "rii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (176,-206);
+ref = dot_top;
+}
+);
+width = 671;
+}
+);
+note = uni1547;
+unicode = 5447;
+},
+{
+glyphname = "ro-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (185,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(128,0,l),
+(128,286,l),
+(113,265,l),
+(173,265,ls),
+(297,265,o),
+(375,354,o),
+(375,488,cs),
+(375,625,o),
+(302,714,o),
+(164,714,cs),
+(65,714,l),
+(65,656,l),
+(157,656,ls),
+(260,656,o),
+(311,591,o),
+(311,488,cs),
+(311,387,o),
+(259,322,o),
+(157,322,cs),
+(65,322,l),
+(65,0,l)
+);
+}
+);
+width = 424;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1548;
+unicode = 5448;
+},
+{
+glyphname = "roo-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (125,0);
+ref = dot_top;
+}
+);
+width = 424;
+}
+);
+note = uni1549;
+unicode = 5449;
+},
+{
+glyphname = "loWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (203,714);
+},
+{
+name = top_left_can;
+pos = (97,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(164,0,ls),
+(302,0,o),
+(375,89,o),
+(375,226,cs),
+(375,360,o),
+(297,450,o),
+(173,450,cs),
+(113,450,l),
+(128,428,l),
+(128,714,l),
+(65,714,l),
+(65,393,l),
+(157,393,ls),
+(259,393,o),
+(311,327,o),
+(311,226,cs),
+(311,124,o),
+(260,58,o),
+(157,58,cs),
+(65,58,l),
+(65,0,l)
+);
+}
+);
+width = 424;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+unicode = 5450;
+},
+{
+glyphname = "ra-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (237,714);
+},
+{
+name = top_right_can;
+pos = (327,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(359,0,l),
+(359,322,l),
+(266,322,ls),
+(164,322,o),
+(112,387,o),
+(112,488,cs),
+(112,591,o),
+(163,656,o),
+(267,656,cs),
+(359,656,l),
+(359,714,l),
+(260,714,ls),
+(121,714,o),
+(49,625,o),
+(49,488,cs),
+(49,354,o),
+(126,265,o),
+(250,265,cs),
+(310,265,l),
+(295,286,l),
+(295,0,l)
+);
+}
+);
+width = 424;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+unicode = 5451;
+},
+{
+glyphname = "raa-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (178,0);
+ref = dot_top;
+}
+);
+width = 424;
+}
+);
+note = uni154C;
+unicode = 5452;
+},
+{
+glyphname = "laWestCree-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (327,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(359,0,l),
+(359,58,l),
+(267,58,ls),
+(163,58,o),
+(112,124,o),
+(112,226,cs),
+(112,327,o),
+(164,393,o),
+(266,393,cs),
+(359,393,l),
+(359,714,l),
+(295,714,l),
+(295,428,l),
+(310,450,l),
+(250,450,ls),
+(126,450,o),
+(49,360,o),
+(49,226,cs),
+(49,89,o),
+(121,0,o),
+(260,0,cs)
+);
+}
+);
+width = 424;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+unicode = 5453;
+},
+{
+glyphname = "rwaa-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (353,0);
+ref = dot_top;
+}
+);
+width = 600;
+}
+);
+note = uni154E;
+unicode = 5454;
+},
+{
+glyphname = "rwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (178,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (424,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 600;
+}
+);
+note = uni154F;
+unicode = 5455;
+},
+{
+glyphname = "r-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,357,l),
+(200,525,l),
+(160,525,ls),
+(113,525,o),
+(86,549,o),
+(86,600,cs),
+(86,651,o),
+(115,675,o),
+(162,675,cs),
+(200,675,l),
+(200,714,l),
+(161,714,ls),
+(86.995,714,o),
+(42,674,o),
+(42,600,cs),
+(42,529,o),
+(85,487,o),
+(155,487,cs),
+(182,487,l),
+(154,503,l),
+(154,357,l)
+);
+}
+);
+width = 252;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni1550;
+unicode = 5456;
+},
+{
+glyphname = "rWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(62,357,l),
+(238,448,l),
+(238,468,l),
+(83,544,l),
+(83,526,l),
+(238,603,l),
+(238,623,l),
+(62,714,l),
+(52,714,l),
+(52,681,l),
+(208,601,l),
+(208,624,l),
+(52,547,l),
+(52,523,l),
+(208,447,l),
+(208,469,l),
+(52,389,l),
+(52,357,l)
+);
+}
+);
+width = 290;
+}
+);
+metricLeft = "=|lWestCree-canadian";
+metricRight = "=|lWestCree-canadian";
+note = uni1551;
+unicode = 5457;
+},
+{
+glyphname = "rMedial-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(78,-13,l),
+(462,175,l),
+(462,204,l),
+(119,366,l),
+(119,348,l),
+(462,510,l),
+(462,539,l),
+(78,727,l),
+(60,727,l),
+(60,680,l),
+(408,509,l),
+(408,537,l),
+(60,375,l),
+(60,339,l),
+(408,177,l),
+(408,205,l),
+(60,34,l),
+(60,-13,l)
+);
+}
+);
+width = 522;
+}
+);
+metricLeft = "mediall-canadian";
+metricRight = "mediall-canadian";
+note = uni1552;
+unicode = 5458;
+},
+{
+glyphname = "fe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(305,0,l),
+(569,694,l),
+(569,714,l),
+(519,714,l),
+(282,72,l),
+(299,72,l),
+(181,373,l),
+(155,365,l),
+(175,342,o),
+(197,333,o),
+(224,333,cs),
+(297,333,o),
+(348,408,o),
+(348,530,cs),
+(348,654,o),
+(302,727,o),
+(219,727,cs),
+(136,727,o),
+(90,654,o),
+(90,541,cs),
+(90,482,o),
+(102,427,o),
+(125,371,cs),
+(280,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(167,379,o),
+(141,440,o),
+(141,540,cs),
+(141,633,o),
+(169,679,o),
+(219,679,cs),
+(269,679,o),
+(297,633,o),
+(297,529,cs),
+(297,426,o),
+(269,379,o),
+(221,379,cs)
+);
+}
+);
+width = 597;
+}
+);
+metricRight = "e-canadian";
+note = uni1553;
+unicode = 5459;
+},
+{
+glyphname = "faai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (176,0);
+ref = ring_top.canadian;
+}
+);
+width = 597;
+}
+);
+note = uni1554;
+unicode = 5460;
+},
+{
+glyphname = "fi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (295,714);
+},
+{
+name = top_left_can;
+pos = (115,714);
+},
+{
+name = top_right_can;
+pos = (497,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(302,-13,o),
+(348,60,o),
+(348,184,cs),
+(348,306,o),
+(297,381,o),
+(224,381,cs),
+(197,381,o),
+(175,372,o),
+(155,349,c),
+(181,341,l),
+(299,642,l),
+(282,642,l),
+(519,0,l),
+(569,0,l),
+(569,20,l),
+(305,714,l),
+(280,714,l),
+(125,343,ls),
+(102,287,o),
+(90,232,o),
+(90,173,cs),
+(90,60,o),
+(136,-13,o),
+(219,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(169,35,o),
+(141,81,o),
+(141,174,cs),
+(141,274,o),
+(167,335,o),
+(221,335,cs),
+(269,335,o),
+(297,288,o),
+(297,185,cs),
+(297,81,o),
+(269,35,o),
+(219,35,cs)
+);
+}
+);
+width = 597;
+}
+);
+metricLeft = "fe-canadian";
+metricRight = "e-canadian";
+note = uni1555;
+unicode = 5461;
+},
+{
+glyphname = "fii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (234,0);
+ref = dot_top;
+}
+);
+width = 597;
+}
+);
+note = uni1556;
+unicode = 5462;
+},
+{
+glyphname = "fo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (174,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(92,0,l),
+(506,344,l),
+(506,370,l),
+(267,678,ls),
+(241,712,o),
+(208,727,o),
+(172,727,cs),
+(91,727,o),
+(47,654,o),
+(47,528,cs),
+(47,408,o),
+(95,331,o),
+(174,331,cs),
+(251,331,o),
+(298,408,o),
+(298,528,cs),
+(298,581,o),
+(286,623,o),
+(274,650,c),
+(255,612,l),
+(458,352,l),
+(458,373,l),
+(74,54,l),
+(74,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(125,379,o),
+(98,425,o),
+(98,529,cs),
+(98,633,o),
+(125,679,o),
+(174,679,cs),
+(224,679,o),
+(250,633,o),
+(250,529,cs),
+(250,426,o),
+(224,379,o),
+(174,379,cs)
+);
+}
+);
+width = 538;
+}
+);
+metricRight = "o-canadian";
+note = uni1557;
+unicode = 5463;
+},
+{
+glyphname = "foo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "fo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (114,0);
+ref = dot_top;
+}
+);
+width = 538;
+}
+);
+note = uni1558;
+unicode = 5464;
+},
+{
+glyphname = "fa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (364,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(464,0,l),
+(464,54,l),
+(80,373,l),
+(80,352,l),
+(283,612,l),
+(263,650,l),
+(251,623,o),
+(239,581,o),
+(239,528,cs),
+(239,408,o),
+(286,331,o),
+(364,331,cs),
+(443,331,o),
+(491,408,o),
+(491,528,cs),
+(491,654,o),
+(447,727,o),
+(365,727,cs),
+(330,727,o),
+(297,712,o),
+(270,678,cs),
+(31,370,l),
+(31,344,l),
+(445,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(314,379,o),
+(287,426,o),
+(287,529,cs),
+(287,633,o),
+(314.009,679.007,o),
+(363,679,cs),
+(413,679,o),
+(440,633,o),
+(440,529,cs),
+(440,425,o),
+(413,379,o),
+(363,379,cs)
+);
+}
+);
+width = 538;
+}
+);
+metricRight = "=|fo-canadian";
+note = uni1559;
+unicode = 5465;
+},
+{
+glyphname = "faa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (303,0);
+ref = dot_top;
+}
+);
+width = 538;
+}
+);
+note = uni155A;
+unicode = 5466;
+},
+{
+glyphname = "fwaa-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (479,0);
+ref = dot_top;
+}
+);
+width = 713;
+}
+);
+note = uni155B;
+unicode = 5467;
+},
+{
+glyphname = "fwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (303,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (538,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 713;
+}
+);
+note = uni155C;
+unicode = 5468;
+},
+{
+glyphname = "f-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(258,357,l),
+(258,389,l),
+(74,544,l),
+(74,536,l),
+(165,651,l),
+(158,681,l),
+(152,666,o),
+(147,646,o),
+(147,618,cs),
+(147,552,o),
+(173,522,o),
+(209,522,cs),
+(247,522,o),
+(271,554,o),
+(271,621,cs),
+(271,691,o),
+(245,720,o),
+(208,720,cs),
+(192,720,o),
+(175,712,o),
+(159,692,cs),
+(42,544,l),
+(42,527,l),
+(247,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(187,550,o),
+(175,571,o),
+(175,620,cs),
+(175,667,o),
+(187,692,o),
+(208,692,cs),
+(230,692,o),
+(242,672,o),
+(242,620,cs),
+(242,570,o),
+(231,550,o),
+(209,550,cs)
+);
+}
+);
+width = 319;
+}
+);
+note = uni155D;
+unicode = 5469;
+},
+{
+glyphname = "the-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (602,357);
+},
+{
+name = top_center_can;
+pos = (285,714);
+},
+{
+name = top_left_can;
+pos = (93,714);
+},
+{
+name = top_right_can;
+pos = (477,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(426,-13,o),
+(510,73,o),
+(510,245,cs),
+(510,714,l),
+(446,714,l),
+(446,243,ls),
+(446,107,o),
+(389,47,o),
+(285,47,cs),
+(184,47,o),
+(124,111,o),
+(124,246,cs),
+(124,445,l),
+(94,431,l),
+(104,372,o),
+(143,331,o),
+(191,331,cs),
+(268,331,o),
+(317,406,o),
+(317,529,cs),
+(317,652,o),
+(272,727,o),
+(190,727,cs),
+(106,727,o),
+(61,653,o),
+(61,514,cs),
+(61,257,ls),
+(61,77,o),
+(145,-13,o),
+(285,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(142,379,o),
+(113,426,o),
+(113,529,cs),
+(113,632,o),
+(140,679,o),
+(189,679,cs),
+(238,679,o),
+(265,632,o),
+(265,530,cs),
+(265,427,o),
+(239,379,o),
+(191,379,cs)
+);
+}
+);
+width = 571;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155E;
+unicode = 5470;
+},
+{
+glyphname = "theNCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(428,-13,o),
+(510,73,o),
+(510,255,cs),
+(510,514,ls),
+(510,653,o),
+(465,727,o),
+(381,727,cs),
+(298,727,o),
+(254,652,o),
+(254,529,cs),
+(254,406,o),
+(303,331,o),
+(379,331,cs),
+(428,331,o),
+(467,372,o),
+(477,431,c),
+(447,445,l),
+(447,245,ls),
+(447,108,o),
+(389,46,o),
+(286,46,cs),
+(183,46,o),
+(125,108,o),
+(125,241,cs),
+(125,714,l),
+(61,714,l),
+(61,242,ls),
+(61,74,o),
+(146,-13,o),
+(286,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(332,379,o),
+(306,427,o),
+(306,530,cs),
+(306,632,o),
+(332,679,o),
+(382,679,cs),
+(431,679,o),
+(458,632,o),
+(458,529,cs),
+(458,426,o),
+(429,379,o),
+(380,379,cs)
+);
+}
+);
+width = 571;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155F;
+unicode = 5471;
+},
+{
+glyphname = "thi-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (283,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(272,-13,o),
+(317,62,o),
+(317,185,cs),
+(317,308,o),
+(268,383,o),
+(191,383,cs),
+(143,383,o),
+(104,342,o),
+(94,283,c),
+(124,269,l),
+(124,469,ls),
+(124,606,o),
+(182,668,o),
+(285,668,cs),
+(388,668,o),
+(446,606,o),
+(446,473,cs),
+(446,0,l),
+(510,0,l),
+(510,472,ls),
+(510,640,o),
+(425,727,o),
+(285,727,cs),
+(143,727,o),
+(61,641,o),
+(61,459,cs),
+(61,200,ls),
+(61,61,o),
+(106,-13,o),
+(190,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(140,35,o),
+(113,82,o),
+(113,185,cs),
+(113,288,o),
+(142,335,o),
+(191,335,cs),
+(239,335,o),
+(265,287,o),
+(265,184,cs),
+(265,82,o),
+(238,35,o),
+(189,35,cs)
+);
+}
+);
+width = 571;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1560;
+unicode = 5472;
+},
+{
+glyphname = "thiNCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (283,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(465,-13,o),
+(510,61,o),
+(510,200,cs),
+(510,459,ls),
+(510,641,o),
+(428,727,o),
+(286,727,cs),
+(146,727,o),
+(61,640,o),
+(61,472,cs),
+(61,0,l),
+(125,0,l),
+(125,473,ls),
+(125,606,o),
+(183,668,o),
+(286,668,cs),
+(389,668,o),
+(447,606,o),
+(447,469,cs),
+(447,269,l),
+(477,283,l),
+(467,342,o),
+(428,383,o),
+(379,383,cs),
+(303,383,o),
+(254,308,o),
+(254,185,cs),
+(254,62,o),
+(298,-13,o),
+(381,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(332,35,o),
+(306,82,o),
+(306,184,cs),
+(306,287,o),
+(332,335,o),
+(380,335,cs),
+(429,335,o),
+(458,288,o),
+(458,185,cs),
+(458,82,o),
+(431,35,o),
+(382,35,cs)
+);
+}
+);
+width = 571;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1561;
+unicode = 5473;
+},
+{
+glyphname = "thii-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "thi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (223,0);
+ref = dot_top;
+}
+);
+width = 571;
+}
+);
+note = uni1562;
+unicode = 5474;
+},
+{
+glyphname = "thiiNCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "thiNCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (223,0);
+ref = dot_top;
+}
+);
+width = 571;
+}
+);
+note = uni1563;
+unicode = 5475;
+},
+{
+glyphname = "tho-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (239,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(189,0,ls),
+(384,0,o),
+(473,125,o),
+(473,365,cs),
+(473,589,o),
+(388,727,o),
+(243,727,cs),
+(140,727,o),
+(57,652,o),
+(57,505,cs),
+(57,376,o),
+(104,306,o),
+(183,306,cs),
+(263,306,o),
+(307,376,o),
+(307,497,cs),
+(307,616,o),
+(266,689,o),
+(193,691,c),
+(165,662,l),
+(184,675,o),
+(209,684,o),
+(234,684,cs),
+(353,684,o),
+(410,563,o),
+(410,369,cs),
+(410,161,o),
+(348,59,o),
+(188,59,cs),
+(83,59,l),
+(83,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(136,353,o),
+(109,400,o),
+(109,506,cs),
+(109,607,o),
+(141,659,o),
+(188,659,cs),
+(235,659,o),
+(261,612,o),
+(261,507,cs),
+(261,401,o),
+(234,353,o),
+(185,353,cs)
+);
+}
+);
+width = 525;
+}
+);
+metricRight = "to-canadian";
+note = uni1564;
+unicode = 5476;
+},
+{
+glyphname = "thoo-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "tho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (178,0);
+ref = dot_top;
+}
+);
+width = 525;
+}
+);
+note = uni1565;
+unicode = 5477;
+},
+{
+glyphname = "tha-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (288,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(442,0,l),
+(442,59,l),
+(337,59,ls),
+(177,59,o),
+(114,161,o),
+(114,369,cs),
+(114,563,o),
+(172,684,o),
+(291,684,cs),
+(316,684,o),
+(341,675,o),
+(359,662,c),
+(332,691,l),
+(259,689,o),
+(217,616,o),
+(217,497,cs),
+(217,376,o),
+(262,306,o),
+(342,306,cs),
+(420,306,o),
+(468,376,o),
+(468,505,cs),
+(468,652,o),
+(385,727,o),
+(281,727,cs),
+(137,727,o),
+(52,589,o),
+(52,365,cs),
+(52,128,o),
+(138,0,o),
+(336,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(290,353,o),
+(264,401,o),
+(264,507,cs),
+(264,612,o),
+(290,659,o),
+(337,659,cs),
+(383,659,o),
+(416,607,o),
+(416,506,cs),
+(416,400,o),
+(389,353,o),
+(340,353,cs)
+);
+}
+);
+width = 525;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tho-canadian";
+note = uni1566;
+unicode = 5478;
+},
+{
+glyphname = "thaa-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (227,0);
+ref = dot_top;
+}
+);
+width = 525;
+}
+);
+note = uni1567;
+unicode = 5479;
+},
+{
+glyphname = "thwaa-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (402,0);
+ref = dot_top;
+}
+);
+width = 700;
+}
+);
+note = uni1568;
+unicode = 5480;
+},
+{
+glyphname = "thwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (227,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (525,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 700;
+}
+);
+note = uni1569;
+unicode = 5481;
+},
+{
+glyphname = "th-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(245,357,l),
+(245,397,l),
+(199,397,ls),
+(122,397,o),
+(91,447,o),
+(91,540,cs),
+(91,633,o),
+(122,689,o),
+(176,689,cs),
+(189,689,o),
+(200,685,o),
+(208,680,c),
+(190,700,l),
+(154,697,o),
+(134,663,o),
+(134,607,cs),
+(134,539,o),
+(159,509,o),
+(196,509,cs),
+(234,509,o),
+(258,541,o),
+(258,607,cs),
+(258,688,o),
+(222,720,o),
+(172,720,cs),
+(98,720,o),
+(51,654,o),
+(51,537,cs),
+(51,426,o),
+(96,357,o),
+(197,357,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(174,536,o),
+(162,557,o),
+(162,606,cs),
+(162,653,o),
+(174,678,o),
+(195,678,cs),
+(217,678,o),
+(229,658,o),
+(229,606,cs),
+(229,556,o),
+(218,536,o),
+(196,536,cs)
+);
+}
+);
+width = 306;
+}
+);
+metricLeft = "t-canadian";
+note = uni156A;
+unicode = 5482;
+},
+{
+glyphname = "tthe-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (595,357);
+},
+{
+name = top_center_can;
+pos = (281,714);
+},
+{
+name = top_left_can;
+pos = (94,714);
+},
+{
+name = top_right_can;
+pos = (470,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(421,-13,o),
+(502,73,o),
+(502,245,cs),
+(502,714,l),
+(443,714,l),
+(443,243,ls),
+(443,107,o),
+(382,47,o),
+(281,47,cs),
+(184,47,o),
+(121,109,o),
+(121,242,cs),
+(121,714,l),
+(61,714,l),
+(61,242,ls),
+(61,74,o),
+(146,-13,o),
+(282,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(306,405,l),
+(306,714,l),
+(257,714,l),
+(257,405,l)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156B;
+unicode = 5483;
+},
+{
+glyphname = "tthi-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,0,l),
+(121,471,ls),
+(121,607,o),
+(181,667,o),
+(282,667,cs),
+(380,667,o),
+(443,605,o),
+(443,472,cs),
+(443,0,l),
+(502,0,l),
+(502,472,ls),
+(502,640,o),
+(418,727,o),
+(282,727,cs),
+(143,727,o),
+(61,641,o),
+(61,469,cs),
+(61,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(306,0,l),
+(306,309,l),
+(257,309,l),
+(257,0,l)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156C;
+unicode = 5484;
+},
+{
+glyphname = "ttho-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (251,714);
+},
+{
+name = top_left_can;
+pos = (96,714);
+},
+{
+name = top_right_can;
+pos = (407,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(148,0,ls),
+(346,0,o),
+(438,125,o),
+(438,358,cs),
+(438,591,o),
+(346,714,o),
+(144,714,cs),
+(64,714,l),
+(64,655,l),
+(145,655,ls),
+(308,655,o),
+(374,557,o),
+(374,358,cs),
+(374,161,o),
+(308,59,o),
+(149,59,cs),
+(64,59,l),
+(64,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(241,330,l),
+(241,384,l),
+(64,384,l),
+(64,330,l)
+);
+}
+);
+width = 490;
+}
+);
+metricRight = "to-canadian";
+note = uni156D;
+unicode = 5485;
+},
+{
+glyphname = "ttha-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (251,714);
+},
+{
+name = top_left_can;
+pos = (84,714);
+},
+{
+name = top_right_can;
+pos = (395,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(426,0,l),
+(426,59,l),
+(346,59,ls),
+(182,59,o),
+(116,158,o),
+(116,356,cs),
+(116,554,o),
+(182,655,o),
+(341,655,cs),
+(426,655,l),
+(426,714,l),
+(341,714,ls),
+(144,714,o),
+(52,589,o),
+(52,356,cs),
+(52,123,o),
+(144,0,o),
+(347,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(426,330,l),
+(426,384,l),
+(249,384,l),
+(249,330,l)
+);
+}
+);
+width = 490;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|ttho-canadian";
+note = uni156E;
+unicode = 5486;
+},
+{
+glyphname = "tth-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(499,523,l),
+(483,523,l),
+(564,402,l),
+(596,425,l),
+(514,547,l),
+(509,532,l),
+(625,584,l),
+(610,620,l),
+(496,566,l),
+(511,560,l),
+(511,714,l),
+(472,714,l),
+(472,560,l),
+(487,566,l),
+(372,620,l),
+(357,584,l),
+(474,532,l),
+(469,547,l),
+(387,425,l),
+(419,402,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(184,523,l),
+(169,523,l),
+(254,402,l),
+(285,425,l),
+(199,547,l),
+(195,532,l),
+(311,584,l),
+(296,620,l),
+(181,566,l),
+(196,560,l),
+(196,714,l),
+(157,714,l),
+(157,560,l),
+(173,566,l),
+(57,620,l),
+(43,584,l),
+(159,532,l),
+(154,547,l),
+(68,425,l),
+(100,402,l)
+);
+}
+);
+width = 668;
+}
+);
+metricRight = "=|";
+note = uni156F;
+unicode = 5487;
+},
+{
+glyphname = "tye-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(421,-13,o),
+(502,73,o),
+(502,245,cs),
+(502,714,l),
+(443,714,l),
+(443,247,ls),
+(443,107,o),
+(382,47,o),
+(281,47,cs),
+(184,47,o),
+(121,109,o),
+(121,246,cs),
+(121,714,l),
+(61,714,l),
+(61,242,ls),
+(61,74,o),
+(146,-13,o),
+(282,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(338,426,o),
+(372,463,o),
+(372,538,cs),
+(372,714,l),
+(338,714,l),
+(338,540,ls),
+(338,483,o),
+(319,461,o),
+(281,461,cs),
+(245,461,o),
+(225,484,o),
+(225,540,cs),
+(225,714,l),
+(192,714,l),
+(192,538,ls),
+(192,462,o),
+(227,426,o),
+(282,426,cs)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1570;
+unicode = 5488;
+},
+{
+glyphname = "tyi-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,0,l),
+(121,467,ls),
+(121,607,o),
+(181,667,o),
+(282,667,cs),
+(380,667,o),
+(443,605,o),
+(443,468,cs),
+(443,0,l),
+(502,0,l),
+(502,472,ls),
+(502,640,o),
+(418,727,o),
+(282,727,cs),
+(143,727,o),
+(61,641,o),
+(61,469,cs),
+(61,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(225,0,l),
+(225,174,ls),
+(225,231,o),
+(246,253,o),
+(282,253,cs),
+(319,253,o),
+(338,230,o),
+(338,174,cs),
+(338,0,l),
+(372,0,l),
+(372,176,ls),
+(372,252,o),
+(337,288,o),
+(282,288,cs),
+(225,288,o),
+(192,251,o),
+(192,176,cs),
+(192,0,l)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1571;
+unicode = 5489;
+},
+{
+glyphname = "tyo-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(149,0,ls),
+(344,0,o),
+(438,125,o),
+(438,358,cs),
+(438,591,o),
+(344,714,o),
+(144,714,cs),
+(65,714,l),
+(65,656,l),
+(140,656,ls),
+(308,656,o),
+(375,558,o),
+(375,358,cs),
+(375,160,o),
+(308,58,o),
+(144,58,cs),
+(65,58,l),
+(65,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(113,217,ls),
+(195,217,o),
+(240,263,o),
+(240,357,cs),
+(240,451,o),
+(194,497,o),
+(113,497,cs),
+(65,497,l),
+(65,459,l),
+(108,459,ls),
+(171,459,o),
+(200,428,o),
+(200,357,cs),
+(200,286,o),
+(171,255,o),
+(109,255,cs),
+(65,255,l),
+(65,217,l)
+);
+}
+);
+width = 490;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1572;
+unicode = 5490;
+},
+{
+glyphname = "tya-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(426,0,l),
+(426,58,l),
+(351,58,ls),
+(183,58,o),
+(116,156,o),
+(116,356,cs),
+(116,555,o),
+(183,656,o),
+(346,656,cs),
+(426,656,l),
+(426,714,l),
+(341,714,ls),
+(146,714,o),
+(52,589,o),
+(52,356,cs),
+(52,123,o),
+(146,0,o),
+(347,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(426,217,l),
+(426,255,l),
+(383,255,ls),
+(320,255,o),
+(290,286,o),
+(290,357,cs),
+(290,428,o),
+(320,459,o),
+(382,459,cs),
+(426,459,l),
+(426,497,l),
+(377,497,ls),
+(295,497,o),
+(251,451,o),
+(251,357,cs),
+(251,263,o),
+(296,217,o),
+(377,217,cs)
+);
+}
+);
+width = 491;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1573;
+unicode = 5491;
+},
+{
+glyphname = "heNunavik-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(397,0,l),
+(581,198,l),
+(541,239,l),
+(362,44,l),
+(405,43,l),
+(405,465,ls),
+(405,637,o),
+(345,727,o),
+(232,727,cs),
+(119,727,o),
+(55,635,o),
+(55,467,cs),
+(55,305,o),
+(118,212,o),
+(223,212,cs),
+(289,212,o),
+(336,258,o),
+(348,324,c),
+(341,353,l),
+(341,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(156,268,o),
+(117,333,o),
+(117,470,cs),
+(117,607,o),
+(156,671,o),
+(230,671,cs),
+(304,671,o),
+(342,608,o),
+(342,470,cs),
+(342,333,o),
+(303,268,o),
+(230,268,cs)
+);
+}
+);
+width = 604;
+}
+);
+metricLeft = "ke-canadian";
+note = uni1574;
+unicode = 5492;
+},
+{
+glyphname = "hiNunavik-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (373,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(262,0,l),
+(262,353,l),
+(256,324,l),
+(267,258,o),
+(315,212,o),
+(380,212,cs),
+(486,212,o),
+(549,305,o),
+(549,467,cs),
+(549,635,o),
+(485,727,o),
+(372,727,cs),
+(259,727,o),
+(199,637,o),
+(199,465,cs),
+(199,43,l),
+(242,44,l),
+(63,239,l),
+(23,198,l),
+(206,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(301,268,o),
+(262,333,o),
+(262,470,cs),
+(262,608,o),
+(300,671,o),
+(374,671,cs),
+(448.001,671.002,o),
+(486,607,o),
+(486,470,cs),
+(486,333,o),
+(447,268,o),
+(374,268,cs)
+);
+}
+);
+width = 604;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1575;
+unicode = 5493;
+},
+{
+glyphname = "hiiNunavik-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "hiNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (312,0);
+ref = dot_top;
+}
+);
+width = 604;
+}
+);
+note = uni1576;
+unicode = 5494;
+},
+{
+glyphname = "hoNunavik-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (229,714);
+},
+{
+name = top_right_can;
+pos = (373,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(345,-13,o),
+(405,77,o),
+(405,249,cs),
+(405,671,l),
+(362,670,l),
+(541,475,l),
+(581,516,l),
+(397,714,l),
+(341,714,l),
+(341,361,l),
+(348,390,l),
+(336,456,o),
+(289,502,o),
+(223,502,cs),
+(118,502,o),
+(55,409,o),
+(55,247,cs),
+(55,79,o),
+(119,-13,o),
+(232,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(156,43,o),
+(117,107,o),
+(117,244,cs),
+(117,381,o),
+(156,446,o),
+(230,446,cs),
+(303,446,o),
+(342,381,o),
+(342,244,cs),
+(342,106,o),
+(304,43,o),
+(230,43,cs)
+);
+}
+);
+width = 604;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "heNunavik-canadian";
+note = uni1577;
+unicode = 5495;
+},
+{
+glyphname = "hooNunavik-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "hoNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (312,0);
+ref = dot_top;
+}
+);
+width = 604;
+}
+);
+note = uni1578;
+unicode = 5496;
+},
+{
+glyphname = "haNunavik-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (375,714);
+},
+{
+name = top_left_can;
+pos = (231,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(485,-13,o),
+(549,79,o),
+(549,247,cs),
+(549,409,o),
+(486,502,o),
+(380,502,cs),
+(315,502,o),
+(267,456,o),
+(256,390,c),
+(262,361,l),
+(262,714,l),
+(206,714,l),
+(23,516,l),
+(63,475,l),
+(242,670,l),
+(199,671,l),
+(199,249,ls),
+(199,77,o),
+(259,-13,o),
+(372,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(300,43,o),
+(262,106,o),
+(262,244,cs),
+(262,381,o),
+(301,446,o),
+(374,446,cs),
+(447,446,o),
+(486,381,o),
+(486,244,cs),
+(486,107,o),
+(448.001,42.998,o),
+(374,43,cs)
+);
+}
+);
+width = 604;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1579;
+unicode = 5497;
+},
+{
+glyphname = "haaNunavik-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "haNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (171,0);
+ref = dot_top;
+}
+);
+width = 604;
+}
+);
+note = uni157A;
+unicode = 5498;
+},
+{
+glyphname = "hNunavik-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(271,351,o),
+(314,395,o),
+(314,490,cs),
+(314,577,o),
+(276,622,o),
+(226,622,cs),
+(186,622,o),
+(156,591,o),
+(153,539,c),
+(165,539,l),
+(165,714,l),
+(123,714,l),
+(32,615,l),
+(58,591,l),
+(150,690,l),
+(120,688,l),
+(120,486,ls),
+(120,398,o),
+(159,351,o),
+(217,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(183,388,o),
+(162,415,o),
+(162,487,cs),
+(162,556,o),
+(185,585,o),
+(218,585,cs),
+(250,585,o),
+(273,557,o),
+(273,488,cs),
+(273,418,o),
+(251,388,o),
+(218,388,cs)
+);
+}
+);
+width = 356;
+}
+);
+metricRight = "k-canadian";
+note = uni157B;
+unicode = 5499;
+},
+{
+color = 4;
+glyphname = "nunavuth-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(128,342,l),
+(409,342,l),
+(409,0,l),
+(472,0,l),
+(472,714,l),
+(409,714,l),
+(409,400,l),
+(128,400,l),
+(128,714,l),
+(65,714,l),
+(65,0,l),
+(128,0,l)
+);
+}
+);
+width = 537;
+}
+);
+metricRight = "=|";
+note = uni157C;
+unicode = 5500;
+},
+{
+glyphname = "hk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,357);
+ref = "fullstop-canadian";
+}
+);
+width = 291;
+}
+);
+metricLeft = "fullstop-canadian";
+note = uni157D;
+unicode = 5501;
+},
+{
+glyphname = "qaai-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (252,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (369,0);
+ref = ring_top.canadian;
+}
+);
+width = 718;
+}
+);
+note = uni157E;
+unicode = 5502;
+},
+{
+glyphname = "qi-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (252,0);
+ref = "ki-canadian";
+}
+);
+width = 718;
+}
+);
+note = uni157F;
+unicode = 5503;
+},
+{
+glyphname = "qii-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (252,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (427,0);
+ref = dot_top;
+}
+);
+width = 718;
+}
+);
+note = uni1580;
+unicode = 5504;
+},
+{
+glyphname = "qo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (252,0);
+ref = "ko-canadian";
+}
+);
+width = 718;
+}
+);
+note = uni1581;
+unicode = 5505;
+},
+{
+glyphname = "qoo-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (252,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (564,0);
+ref = dot_top;
+}
+);
+width = 718;
+}
+);
+note = uni1582;
+unicode = 5506;
+},
+{
+glyphname = "qa-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (252,0);
+ref = "ka-canadian";
+}
+);
+width = 718;
+}
+);
+note = uni1583;
+unicode = 5507;
+},
+{
+glyphname = "qaa-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (252,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (284,0);
+ref = dot_top;
+}
+);
+width = 718;
+}
+);
+note = uni1584;
+unicode = 5508;
+},
+{
+glyphname = "q-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (252,0);
+ref = "k-canadian";
+}
+);
+width = 540;
+}
+);
+note = uni1585;
+unicode = 5509;
+},
+{
+glyphname = "tlhe-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (234,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(146,0,l),
+(250,274,l),
+(198,253,l),
+(206,251,o),
+(215,250,o),
+(225,250,cs),
+(294,250,o),
+(336,293,o),
+(351,351,c),
+(345,365,l),
+(345,0,l),
+(408,0,l),
+(408,493,ls),
+(408,637,o),
+(347,727,o),
+(234,727,cs),
+(122,727,o),
+(57,637,o),
+(57,487,cs),
+(57,362,o),
+(106,282,o),
+(180,262,c),
+(79,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(159,305,o),
+(119,367,o),
+(119,488,cs),
+(119,609,o),
+(158,671,o),
+(232,671,cs),
+(307,671,o),
+(346,610,o),
+(346,488,cs),
+(346,366,o),
+(305,305,o),
+(232,305,cs)
+);
+}
+);
+width = 469;
+}
+);
+metricRight = "te-canadian";
+note = uni1586;
+unicode = 5510;
+},
+{
+glyphname = "tlhi-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(124,0,l),
+(124,365,l),
+(119,351,l),
+(134,293,o),
+(175,250,o),
+(245,250,c),
+(220,274,l),
+(324,0,l),
+(390,0,l),
+(290,262,l),
+(364,282,o),
+(413,362,o),
+(413,487,cs),
+(413,637,o),
+(348,727,o),
+(235,727,cs),
+(123,727,o),
+(61,637,o),
+(61,493,cs),
+(61,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(165,305,o),
+(124,366,o),
+(124,488,cs),
+(124,610,o),
+(162,671,o),
+(238,671,cs),
+(312,671,o),
+(350,609,o),
+(350,488,cs),
+(350,367,o),
+(311,305,o),
+(238,305,cs)
+);
+}
+);
+width = 470;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|tlhe-canadian";
+note = uni1587;
+unicode = 5511;
+},
+{
+glyphname = "tlho-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (247,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(347,-13,o),
+(408,77,o),
+(408,221,cs),
+(408,714,l),
+(345,714,l),
+(345,349,l),
+(351,363,l),
+(336,421,o),
+(294,464,o),
+(225,464,c),
+(250,440,l),
+(146,714,l),
+(79,714,l),
+(180,452,l),
+(106,432,o),
+(57,352,o),
+(57,227,cs),
+(57,77,o),
+(122,-13,o),
+(234,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(158,43,o),
+(119,105,o),
+(119,226,cs),
+(119,347,o),
+(159,409,o),
+(232,409,cs),
+(305,409,o),
+(346,348,o),
+(346,226,cs),
+(346,104,o),
+(307,43,o),
+(232,43,cs)
+);
+}
+);
+width = 469;
+}
+);
+metricLeft = "tlhe-canadian";
+metricRight = "te-canadian";
+note = uni1588;
+unicode = 5512;
+},
+{
+glyphname = "tlha-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(348,-13,o),
+(413,77,o),
+(413,227,cs),
+(413,352,o),
+(364,432,o),
+(290,452,c),
+(390,714,l),
+(324,714,l),
+(220,440,l),
+(271,461,l),
+(263,463,o),
+(255,464,o),
+(245,464,cs),
+(175,464,o),
+(134,421,o),
+(119,363,c),
+(124,349,l),
+(124,714,l),
+(61,714,l),
+(61,221,ls),
+(61,77,o),
+(123,-13,o),
+(235,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(162,43,o),
+(124,104,o),
+(124,226,cs),
+(124,348,o),
+(165,409,o),
+(238,409,cs),
+(311,409,o),
+(350,347,o),
+(350,226,cs),
+(350,105,o),
+(312,43,o),
+(238,43,cs)
+);
+}
+);
+width = 470;
+}
+);
+metricLeft = "te-canadian";
+note = uni1589;
+unicode = 5513;
+},
+{
+glyphname = "reWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(393,0,l),
+(576,198,l),
+(536,239,l),
+(357,44,l),
+(400,43,l),
+(400,488,ls),
+(400,636,o),
+(340,727,o),
+(229,727,cs),
+(116,727,o),
+(54,640,o),
+(54,496,cs),
+(54,405,l),
+(117,405,l),
+(117,506,ls),
+(117,609,o),
+(153,670,o),
+(228,670,cs),
+(300,670,o),
+(337,609,o),
+(337,500,cs),
+(337,0,l)
+);
+}
+);
+width = 599;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+unicode = 5514;
+},
+{
+glyphname = "riWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(262,0,l),
+(262,500,ls),
+(262,609,o),
+(299,670,o),
+(371,670,cs),
+(446,670,o),
+(482,609,o),
+(482,506,cs),
+(482,405,l),
+(545,405,l),
+(545,496,ls),
+(545,640,o),
+(483,727,o),
+(370,727,cs),
+(258,727,o),
+(199,636,o),
+(199,488,cs),
+(199,43,l),
+(242,44,l),
+(63,239,l),
+(23,198,l),
+(206,0,l)
+);
+}
+);
+width = 599;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+unicode = 5515;
+},
+{
+glyphname = "roWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(340,-13,o),
+(400,78,o),
+(400,226,cs),
+(400,671,l),
+(357,670,l),
+(536,475,l),
+(576,516,l),
+(393,714,l),
+(337,714,l),
+(337,214,ls),
+(337,106,o),
+(300,44,o),
+(228,44,cs),
+(153,44,o),
+(117,106,o),
+(117,208,cs),
+(117,309,l),
+(54,309,l),
+(54,218,ls),
+(54,74,o),
+(116,-13,o),
+(229,-13,cs)
+);
+}
+);
+width = 599;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+unicode = 5516;
+},
+{
+glyphname = "raWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(483,-13,o),
+(545,75,o),
+(545,218,cs),
+(545,309,l),
+(482,309,l),
+(482,208,ls),
+(482,106,o),
+(446,44,o),
+(371,44,cs),
+(300,44,o),
+(262,106,o),
+(262,214,cs),
+(262,714,l),
+(206,714,l),
+(23,516,l),
+(63,475,l),
+(242,670,l),
+(199,671,l),
+(199,226,ls),
+(199,78,o),
+(259,-13,o),
+(370,-13,cs)
+);
+}
+);
+width = 599;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+unicode = 5517;
+},
+{
+glyphname = "ngaai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (494,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (611,0);
+ref = ring_top.canadian;
+}
+);
+width = 955;
+}
+);
+note = uni158E;
+unicode = 5518;
+},
+{
+glyphname = "ngi-canadian";
+kernLeft = mwestleft;
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (494,0);
+ref = "ci-canadian";
+}
+);
+width = 955;
+}
+);
+note = uni158F;
+unicode = 5519;
+},
+{
+glyphname = "ngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (494,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (669,0);
+ref = dot_top;
+}
+);
+width = 955;
+}
+);
+note = uni1590;
+unicode = 5520;
+},
+{
+glyphname = "ngo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:31:47 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (470,0);
+ref = "co-canadian";
+}
+);
+width = 931;
+}
+);
+note = uni1591;
+unicode = 5521;
+},
+{
+glyphname = "ngoo-canadian";
+lastChange = "2023-01-13 15:31:47 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+ref = "ngo-canadian";
+},
+{
+anchor = top_right_can;
+pos = (778,0);
+ref = dot_top;
+}
+);
+width = 931;
+}
+);
+note = uni1592;
+unicode = 5522;
+},
+{
+glyphname = "nga-canadian";
+kernLeft = mwestleft;
+kernRight = caright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (494,0);
+ref = "ca-canadian";
+}
+);
+width = 955;
+}
+);
+note = uni1593;
+unicode = 5523;
+},
+{
+glyphname = "ngaa-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (494,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (527,0);
+ref = dot_top;
+}
+);
+width = 955;
+}
+);
+note = uni1594;
+unicode = 5524;
+},
+{
+glyphname = "ng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(424,225,o),
+(462,263,o),
+(462,341,cs),
+(462,376,l),
+(419,376,l),
+(419,335,ls),
+(419,285,o),
+(399,263,o),
+(365,263,cs),
+(330,263,o),
+(311,286,o),
+(311,342,cs),
+(311,493,l),
+(189,493,l),
+(189,473,l),
+(220,488,o),
+(234,535,o),
+(234,587,cs),
+(234,674,o),
+(196,720,o),
+(138,720,cs),
+(80,720,o),
+(42,673,o),
+(42,585,cs),
+(42,498,o),
+(79,449,o),
+(144,449,cs),
+(280,449,l),
+(266,464,l),
+(266,347,ls),
+(266,266,o),
+(303,225,o),
+(364,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(104,485,o),
+(83,517,o),
+(83,585,cs),
+(83,654,o),
+(104,683,o),
+(139,683,cs),
+(173,683,o),
+(193,653,o),
+(193,585,cs),
+(193,516,o),
+(172,485,o),
+(138,485,cs)
+);
+}
+);
+width = 495;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1595;
+unicode = 5525;
+},
+{
+glyphname = "nng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(652,225,o),
+(690,263,o),
+(690,341,cs),
+(690,376,l),
+(647,376,l),
+(647,335,ls),
+(647,285,o),
+(628,263,o),
+(593,263,cs),
+(558,263,o),
+(539,286,o),
+(539,342,cs),
+(539,493,l),
+(418,493,l),
+(417,473,l),
+(449,488,o),
+(462,535,o),
+(462,587,cs),
+(462,675,o),
+(425,720,o),
+(365,720,cs),
+(308,720,o),
+(270,673,o),
+(270,585,cs),
+(270,535,o),
+(284,487,o),
+(315,472,c),
+(314,493,l),
+(190,493,l),
+(189,473,l),
+(220,488,o),
+(234,535,o),
+(234,587,cs),
+(234,674,o),
+(196,720,o),
+(138,720,cs),
+(80,720,o),
+(42,673,o),
+(42,585,cs),
+(42,498,o),
+(79,449,o),
+(144,449,cs),
+(494,449,l),
+(494,347,ls),
+(494,266,o),
+(532,225,o),
+(593,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(104,485,o),
+(83,517,o),
+(83,585,cs),
+(83,654,o),
+(104,683,o),
+(139,683,cs),
+(173,683,o),
+(193,653,o),
+(193,585,cs),
+(193,516,o),
+(172,485,o),
+(138,485,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(333,485,o),
+(311,517,o),
+(311,585,cs),
+(311,654,o),
+(332,683,o),
+(367,683,cs),
+(402,683,o),
+(421,653,o),
+(421,585,cs),
+(421,516,o),
+(400,485,o),
+(366,485,cs)
+);
+}
+);
+width = 723;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1596;
+unicode = 5526;
+},
+{
+glyphname = "sheSayisi-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (502,357);
+},
+{
+name = top_center_can;
+pos = (234,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(410,0,l),
+(410,468,ls),
+(410,636,o),
+(350,727,o),
+(234,727,cs),
+(120,727,o),
+(55,635,o),
+(55,459,cs),
+(55,291,o),
+(107,214,o),
+(185,214,cs),
+(251,214,o),
+(297,261,o),
+(293,425,c),
+(262,425,l),
+(265,293,o),
+(233,268,o),
+(196,268,cs),
+(145,268,o),
+(116,322,o),
+(116,460,cs),
+(116,608,o),
+(156,671,o),
+(233,671,cs),
+(309,671,o),
+(346,608,o),
+(346,467,cs),
+(346,0,l)
+);
+}
+);
+width = 471;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1597;
+unicode = 5527;
+},
+{
+glyphname = "shiSayisi-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(125,0,l),
+(125,467,ls),
+(125,608,o),
+(162,671,o),
+(238,671,cs),
+(315,671,o),
+(355,607,o),
+(355,460,cs),
+(355,321,o),
+(326,268,o),
+(276,268,cs),
+(238,268,o),
+(206,293,o),
+(209,425,c),
+(178,425,l),
+(174,261,o),
+(221,214,o),
+(287,214,cs),
+(364,214,o),
+(417,291,o),
+(417,458,cs),
+(417,635,o),
+(351,727,o),
+(237,727,cs),
+(121,727,o),
+(61,636,o),
+(61,468,cs),
+(61,0,l)
+);
+}
+);
+width = 472;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni1598;
+unicode = 5528;
+},
+{
+glyphname = "shoSayisi-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (232,714);
+},
+{
+name = top_left_can;
+pos = (85,714);
+},
+{
+name = top_right_can;
+pos = (379,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(351,-13,o),
+(410,78,o),
+(410,246,cs),
+(410,714,l),
+(346,714,l),
+(346,247,ls),
+(346,106,o),
+(309,43,o),
+(233,43,cs),
+(156,43,o),
+(116,107,o),
+(116,254,cs),
+(116,393,o),
+(145,446,o),
+(196,446,cs),
+(233,446,o),
+(265,421,o),
+(262,289,c),
+(293,289,l),
+(297,453,o),
+(251,500,o),
+(185,500,cs),
+(107,500,o),
+(55,423,o),
+(55,256,cs),
+(55,79,o),
+(120,-13,o),
+(235,-13,cs)
+);
+}
+);
+width = 471;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1599;
+unicode = 5529;
+},
+{
+glyphname = "shaSayisi-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(352,-13,o),
+(417,79,o),
+(417,255,cs),
+(417,423,o),
+(364,500,o),
+(287,500,cs),
+(220,500,o),
+(174,453,o),
+(178,289,c),
+(209,289,l),
+(206,421,o),
+(238,446,o),
+(276,446,cs),
+(326,446,o),
+(355,392,o),
+(355,254,cs),
+(355,106,o),
+(315,43,o),
+(238,43,cs),
+(162,43,o),
+(125,106,o),
+(125,247,cs),
+(125,714,l),
+(61,714,l),
+(61,246,ls),
+(61,78,o),
+(121,-13,o),
+(237,-13,cs)
+);
+}
+);
+width = 472;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni159A;
+unicode = 5530;
+},
+{
+glyphname = "theWoodScree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(521,-13,o),
+(590,73,o),
+(590,239,cs),
+(590,404,o),
+(522,489,o),
+(403,489,cs),
+(59,489,l),
+(59,434,l),
+(319,434,l),
+(317,448,l),
+(261,415,o),
+(233,330,o),
+(233,236,cs),
+(233,73,o),
+(299,-13,o),
+(411,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(334,43,o),
+(295,106,o),
+(295,239,cs),
+(295,363,o),
+(335,434,o),
+(411,434,cs),
+(487,434,o),
+(527,372,o),
+(527,239,cs),
+(527,106,o),
+(488,43,o),
+(411,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(581,659,l),
+(581,714,l),
+(59,714,l),
+(59,659,l)
+);
+}
+);
+width = 648;
+}
+);
+note = uni159B;
+unicode = 5531;
+},
+{
+glyphname = "thiWoodScree-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(349,-13,o),
+(416,73,o),
+(416,236,cs),
+(416,330,o),
+(388,415,o),
+(332,448,c),
+(329,434,l),
+(590,434,l),
+(590,489,l),
+(246,489,ls),
+(127,489,o),
+(59,405,o),
+(59,239,cs),
+(59,73,o),
+(127,-13,o),
+(237,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(160,43,o),
+(121,106,o),
+(121,239,cs),
+(121,372,o),
+(162,434,o),
+(237,434,cs),
+(314,434,o),
+(353,363,o),
+(353,239,cs),
+(353,106,o),
+(314,43,o),
+(237,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(590,659,l),
+(590,714,l),
+(67,714,l),
+(67,659,l)
+);
+}
+);
+width = 648;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159C;
+unicode = 5532;
+},
+{
+glyphname = "thoWoodScree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(403,0,ls),
+(522,0,o),
+(590,85,o),
+(590,250,cs),
+(590,416,o),
+(521,502,o),
+(411,502,cs),
+(299,502,o),
+(233,416,o),
+(233,253,cs),
+(233,159,o),
+(261,74,o),
+(317,41,c),
+(319,55,l),
+(59,55,l),
+(59,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(335,55,o),
+(295,126,o),
+(295,250,cs),
+(295,383,o),
+(334,446,o),
+(411,446,cs),
+(488,446,o),
+(527,383,o),
+(527,250,cs),
+(527,117,o),
+(487,55,o),
+(411,55,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(581,659,l),
+(581,714,l),
+(59,714,l),
+(59,659,l)
+);
+}
+);
+width = 648;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159D;
+unicode = 5533;
+},
+{
+glyphname = "thaWoodScree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(590,0,l),
+(590,55,l),
+(329,55,l),
+(331,41,l),
+(388,74,o),
+(416,159,o),
+(416,253,cs),
+(416,416,o),
+(349,502,o),
+(237,502,cs),
+(127,502,o),
+(59,416,o),
+(59,250,cs),
+(59,85,o),
+(127,0,o),
+(246,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(162,55,o),
+(121,117,o),
+(121,250,cs),
+(121,383,o),
+(160,446,o),
+(237,446,cs),
+(314,446,o),
+(353,383,o),
+(353,250,cs),
+(353,126,o),
+(314,55,o),
+(237,55,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(590,659,l),
+(590,714,l),
+(67,714,l),
+(67,659,l)
+);
+}
+);
+width = 648;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159E;
+unicode = 5534;
+},
+{
+glyphname = "thWoodScree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(343,357,l),
+(343,398,l),
+(198,398,l),
+(199,381,l),
+(230,396,o),
+(244,443,o),
+(244,495,cs),
+(244,581,o),
+(206,628,o),
+(148,628,cs),
+(90,628,o),
+(52,581,o),
+(52,493,cs),
+(52,406,o),
+(89,357,o),
+(154,357,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(114,393,o),
+(93,425,o),
+(93,493,cs),
+(93,562,o),
+(114,591,o),
+(149,591,cs),
+(183,591,o),
+(203,561,o),
+(203,493,cs),
+(203,424,o),
+(182,393,o),
+(148,393,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(339,700,l),
+(339,742,l),
+(56,742,l),
+(56,700,l)
+);
+}
+);
+width = 395;
+}
+);
+metricRight = "=|";
+note = uni159F;
+unicode = 5535;
+},
+{
+glyphname = "lhi-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (366,714);
+},
+{
+name = top_right_can;
+pos = (438,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(285,0,l),
+(285,57,l),
+(277,57,ls),
+(172,57,o),
+(118,120,o),
+(118,242,cs),
+(118,369,o),
+(173,431,o),
+(275,431,cs),
+(586,431,l),
+(586,483,l),
+(448,747,l),
+(398,718,l),
+(535,454,l),
+(537,489,l),
+(273,489,ls),
+(137,489,o),
+(55,404,o),
+(55,243,cs),
+(55,84,o),
+(135,0,o),
+(272,0,cs)
+);
+}
+);
+width = 637;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A0;
+unicode = 5536;
+},
+{
+glyphname = "lhii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "lhi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (305,0);
+ref = dot_top;
+}
+);
+width = 637;
+}
+);
+note = uni15A1;
+unicode = 5537;
+},
+{
+glyphname = "lho-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (311,507);
+},
+{
+name = top_right_can;
+pos = (398,507);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(239,-230,l),
+(102,34,l),
+(100,-1,l),
+(364,-1,ls),
+(500,-1,o),
+(582,84,o),
+(582,246,cs),
+(582,404,o),
+(502,488,o),
+(365,488,cs),
+(352,488,l),
+(352,431,l),
+(360,431,ls),
+(465,431,o),
+(519,368,o),
+(519,246,cs),
+(519,121,o),
+(464,58,o),
+(362,58,cs),
+(51,58,l),
+(51,5,l),
+(189,-259,l)
+);
+}
+);
+width = 637;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni15A2;
+unicode = 5538;
+},
+{
+glyphname = "lhoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "lho-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (337,-207);
+ref = dot_top;
+}
+);
+width = 637;
+}
+);
+note = uni15A3;
+unicode = 5539;
+},
+{
+glyphname = "lha-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (328,507);
+},
+{
+name = top_left_can;
+pos = (239,507);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(586,6,l),
+(586,58,l),
+(275,58,ls),
+(172,58,o),
+(118,121,o),
+(118,247,cs),
+(118,369,o),
+(172,432,o),
+(277,432,cs),
+(285,432,l),
+(285,489,l),
+(272,489,ls),
+(135,489,o),
+(55,405,o),
+(55,247,cs),
+(55,85,o),
+(136,0,o),
+(273,0,cs),
+(537,0,l),
+(535,35,l),
+(398,-229,l),
+(448,-258,l)
+);
+}
+);
+width = 637;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A4;
+unicode = 5540;
+},
+{
+glyphname = "lhaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "lha-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (179,-207);
+ref = dot_top;
+}
+);
+width = 637;
+}
+);
+note = uni15A5;
+unicode = 5541;
+},
+{
+glyphname = "lh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(345,361,l),
+(345,401,l),
+(209,401,ls),
+(128,401,o),
+(96,451,o),
+(96,536,cs),
+(96,621,o),
+(128,670,o),
+(198,670,cs),
+(203,670,l),
+(203,714,l),
+(197,714,ls),
+(97,714,o),
+(51,641,o),
+(51,536,cs),
+(51,428,o),
+(98,357,o),
+(209,357,cs),
+(314,357,l),
+(309,382,l),
+(233,236,l),
+(270,215,l)
+);
+}
+);
+width = 396;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni15A6;
+unicode = 5542;
+},
+{
+glyphname = "theThCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (73,714);
+},
+{
+name = top_right_can;
+pos = (356,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(387,0,l),
+(387,121,l),
+(450,121,l),
+(450,163,l),
+(387,163,l),
+(387,321,l),
+(106,321,l),
+(120,300,l),
+(402,691,l),
+(355,726,l),
+(41,290,l),
+(41,264,l),
+(323,264,l),
+(323,163,l),
+(135,163,l),
+(135,121,l),
+(323,121,l),
+(323,0,l)
+);
+}
+);
+width = 485;
+}
+);
+metricLeft = "ye-canadian";
+note = uni15A7;
+unicode = 5543;
+},
+{
+glyphname = "thiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (130,714);
+},
+{
+name = top_right_can;
+pos = (413,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(162,0,l),
+(162,121,l),
+(351,121,l),
+(351,163,l),
+(162,163,l),
+(162,264,l),
+(443,264,l),
+(443,290,l),
+(130,726,l),
+(83,691,l),
+(369,295,l),
+(379,321,l),
+(98,321,l),
+(98,163,l),
+(35,163,l),
+(35,121,l),
+(98,121,l),
+(98,0,l)
+);
+}
+);
+width = 484;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+unicode = 5544;
+},
+{
+glyphname = "thiiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (70,0);
+ref = dot_top;
+}
+);
+width = 485;
+}
+);
+note = uni15A9;
+unicode = 5545;
+},
+{
+glyphname = "thoThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (73,714);
+},
+{
+name = top_right_can;
+pos = (356,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(402,23,l),
+(120,414,l),
+(106,393,l),
+(387,393,l),
+(387,551,l),
+(450,551,l),
+(450,593,l),
+(387,593,l),
+(387,714,l),
+(323,714,l),
+(323,593,l),
+(135,593,l),
+(135,551,l),
+(323,551,l),
+(323,450,l),
+(41,450,l),
+(41,424,l),
+(355,-12,l)
+);
+}
+);
+width = 485;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+unicode = 5546;
+},
+{
+glyphname = "thooThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (295,0);
+ref = dot_top;
+}
+);
+width = 485;
+}
+);
+note = uni15AB;
+unicode = 5547;
+},
+{
+glyphname = "thaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (130,714);
+},
+{
+name = top_right_can;
+pos = (413,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(443,424,l),
+(443,450,l),
+(162,450,l),
+(162,551,l),
+(351,551,l),
+(351,593,l),
+(162,593,l),
+(162,714,l),
+(98,714,l),
+(98,593,l),
+(35,593,l),
+(35,551,l),
+(98,551,l),
+(98,393,l),
+(379,393,l),
+(365,414,l),
+(83,23,l),
+(130,-12,l)
+);
+}
+);
+width = 484;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+unicode = 5548;
+},
+{
+glyphname = "thaaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:31:47 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (69,0);
+ref = dot_top;
+}
+);
+width = 484;
+}
+);
+note = uni15AD;
+unicode = 5549;
+},
+{
+glyphname = "thThCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(253,565,l),
+(253,582,l),
+(116,582,l),
+(116,634,l),
+(206,634,l),
+(206,661,l),
+(116,661,l),
+(116,714,l),
+(70,714,l),
+(70,661,l),
+(38,661,l),
+(38,634,l),
+(70,634,l),
+(70,541,l),
+(215,541,l),
+(206,570,l),
+(65,372,l),
+(100,349,l)
+);
+}
+);
+width = 281;
+}
+);
+metricRight = "y-canadian";
+note = uni15AE;
+unicode = 5550;
+},
+{
+glyphname = "bAivilik-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(352,-13,o),
+(415,80,o),
+(415,246,cs),
+(415,409,o),
+(352,502,o),
+(249,502,cs),
+(180,502,o),
+(133,456,o),
+(122,390,c),
+(128,368,l),
+(128,714,l),
+(65,714,l),
+(65,0,l),
+(123,0,l),
+(123,118,l),
+(119,102,l),
+(133,33,o),
+(179,-13,o),
+(250,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(166,43,o),
+(128,108,o),
+(128,244,cs),
+(128,381,o),
+(167,446,o),
+(240,446,cs),
+(313,446,o),
+(352,381,o),
+(352,244,cs),
+(352,107,o),
+(314,43,o),
+(240,43,cs)
+);
+}
+);
+width = 470;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|ke-canadian";
+note = uni15AF;
+unicode = 5551;
+},
+{
+glyphname = "eBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(128,0,l),
+(128,425,l),
+(154,386,o),
+(192,365,o),
+(238,365,cs),
+(325,365,o),
+(383,443,o),
+(383,546,cs),
+(383,650,o),
+(325,727,o),
+(238,727,cs),
+(189,727,o),
+(150,704,o),
+(125,664,c),
+(125,714,l),
+(65,714,l),
+(65,0,l)
+);
+}
+);
+width = 425;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B0;
+unicode = 5552;
+},
+{
+glyphname = "iBlackfoot-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(236,-13,o),
+(275,10,o),
+(300,50,c),
+(300,0,l),
+(361,0,l),
+(361,714,l),
+(297,714,l),
+(297,289,l),
+(272,328,o),
+(233,349,o),
+(187,349,cs),
+(100,349,o),
+(42,271,o),
+(42,168,cs),
+(42,64,o),
+(100,-13,o),
+(187,-13,cs)
+);
+}
+);
+width = 426;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B1;
+unicode = 5553;
+},
+{
+glyphname = "oBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(325,-13,o),
+(383,64,o),
+(383,168,cs),
+(383,271,o),
+(325,349,o),
+(238,349,cs),
+(192,349,o),
+(154,328,o),
+(128,289,c),
+(128,714,l),
+(65,714,l),
+(65,0,l),
+(125,0,l),
+(125,50,l),
+(150,10,o),
+(189,-13,o),
+(238,-13,cs)
+);
+}
+);
+width = 425;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "eBlackfoot-canadian";
+note = uni15B2;
+unicode = 5554;
+},
+{
+glyphname = "aBlackfoot-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(361,0,l),
+(361,714,l),
+(300,714,l),
+(300,664,l),
+(275,704,o),
+(236,727,o),
+(187,727,cs),
+(100,727,o),
+(42,650,o),
+(42,546,cs),
+(42,443,o),
+(100,365,o),
+(187,365,cs),
+(233,365,o),
+(272,386,o),
+(297,425,c),
+(297,0,l)
+);
+}
+);
+width = 426;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B3;
+unicode = 5555;
+},
+{
+glyphname = "weBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(128,330,l),
+(401,330,l),
+(401,386,l),
+(128,386,l),
+(128,658,l),
+(401,658,l),
+(401,714,l),
+(65,714,l),
+(65,0,l),
+(128,0,l)
+);
+}
+);
+width = 448;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B4;
+unicode = 5556;
+},
+{
+glyphname = "wiBlackfoot-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(384,0,l),
+(384,714,l),
+(320,714,l),
+(320,384,l),
+(47,384,l),
+(47,328,l),
+(320,328,l),
+(320,56,l),
+(47,56,l),
+(47,0,l)
+);
+}
+);
+width = 449;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B5;
+unicode = 5557;
+},
+{
+glyphname = "woBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(401,0,l),
+(401,56,l),
+(128,56,l),
+(128,328,l),
+(401,328,l),
+(401,384,l),
+(128,384,l),
+(128,714,l),
+(65,714,l),
+(65,0,l)
+);
+}
+);
+width = 448;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "weBlackfoot-canadian";
+note = uni15B6;
+unicode = 5558;
+},
+{
+glyphname = "waBlackfoot-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(384,0,l),
+(384,714,l),
+(47,714,l),
+(47,658,l),
+(320,658,l),
+(320,386,l),
+(47,386,l),
+(47,330,l),
+(320,330,l),
+(320,0,l)
+);
+}
+);
+width = 449;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B7;
+unicode = 5559;
+},
+{
+glyphname = "neBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(128,0,l),
+(128,664,l),
+(170,664,l),
+(146,697,l),
+(146,666,ls),
+(146,507,o),
+(205,421,o),
+(318,421,cs),
+(431,421,o),
+(495,509,o),
+(495,664,cs),
+(495,714,l),
+(433,714,l),
+(433,657,ls),
+(433,540,o),
+(395,478,o),
+(320,478,cs),
+(245,478,o),
+(208,539,o),
+(208,656,cs),
+(208,714,l),
+(65,714,l),
+(65,0,l)
+);
+}
+);
+width = 532;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B8;
+unicode = 5560;
+},
+{
+glyphname = "niBlackfoot-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,0,l),
+(100,57,ls),
+(100,174,o),
+(137,236,o),
+(212,236,cs),
+(287,236,o),
+(324,175,o),
+(324,58,cs),
+(324,0,l),
+(468,0,l),
+(468,714,l),
+(404,714,l),
+(404,50,l),
+(362,50,l),
+(386,17,l),
+(386,48,ls),
+(386,207,o),
+(327,293,o),
+(214,293,cs),
+(101,293,o),
+(37,205,o),
+(37,50,cs),
+(37,0,l)
+);
+}
+);
+width = 533;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B9;
+unicode = 5561;
+},
+{
+glyphname = "noBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(208,0,l),
+(208,58,ls),
+(208,175,o),
+(245,236,o),
+(320,236,cs),
+(395,236,o),
+(433,174,o),
+(433,57,cs),
+(433,0,l),
+(495,0,l),
+(495,50,ls),
+(495,205,o),
+(431,293,o),
+(318,293,cs),
+(205,293,o),
+(146,207,o),
+(146,48,cs),
+(146,17,l),
+(170,50,l),
+(128,50,l),
+(128,714,l),
+(65,714,l),
+(65,0,l)
+);
+}
+);
+width = 532;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "neBlackfoot-canadian";
+note = uni15BA;
+unicode = 5562;
+},
+{
+glyphname = "naBlackfoot-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(468,0,l),
+(468,714,l),
+(324,714,l),
+(324,656,ls),
+(324,539,o),
+(287,478,o),
+(212,478,cs),
+(137,478,o),
+(100,540,o),
+(100,657,cs),
+(100,714,l),
+(37,714,l),
+(37,664,ls),
+(37,509,o),
+(101,421,o),
+(214,421,cs),
+(327,421,o),
+(386,507,o),
+(386,666,cs),
+(386,697,l),
+(362,664,l),
+(404,664,l),
+(404,0,l)
+);
+}
+);
+width = 533;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BB;
+unicode = 5563;
+},
+{
+glyphname = "keBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(128,0,l),
+(128,640,l),
+(104,640,l),
+(252,267,l),
+(284,267,l),
+(464,714,l),
+(401,714,l),
+(252,339,l),
+(273,339,l),
+(124,714,l),
+(65,714,l),
+(65,0,l)
+);
+}
+);
+width = 491;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15BC;
+unicode = 5564;
+},
+{
+glyphname = "kiBlackfoot-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(90,0,l),
+(239,375,l),
+(218,375,l),
+(367,0,l),
+(427,0,l),
+(427,714,l),
+(363,714,l),
+(363,74,l),
+(388,74,l),
+(239,447,l),
+(208,447,l),
+(27,0,l)
+);
+}
+);
+width = 492;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BD;
+unicode = 5565;
+},
+{
+glyphname = "koBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(124,0,l),
+(273,375,l),
+(252,375,l),
+(401,0,l),
+(464,0,l),
+(284,447,l),
+(252,447,l),
+(104,74,l),
+(128,74,l),
+(128,714,l),
+(65,714,l),
+(65,0,l)
+);
+}
+);
+width = 491;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "keBlackfoot-canadian";
+note = uni15BE;
+unicode = 5566;
+},
+{
+glyphname = "kaBlackfoot-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(427,0,l),
+(427,714,l),
+(367,714,l),
+(218,339,l),
+(239,339,l),
+(90,714,l),
+(27,714,l),
+(208,267,l),
+(239,267,l),
+(388,640,l),
+(363,640,l),
+(363,0,l)
+);
+}
+);
+width = 492;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BF;
+unicode = 5567;
+},
+{
+color = 9;
+glyphname = "heSayisi-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_right_can;
+pos = (424,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(455,0,l),
+(455,714,l),
+(392,714,l),
+(392,291,l),
+(403,291,l),
+(398,559,o),
+(332,727,o),
+(204,727,cs),
+(102,727,o),
+(46,642,o),
+(46,473,cs),
+(46,438,o),
+(49,388,o),
+(57,352,c),
+(118,352,l),
+(110,386,o),
+(107,438,o),
+(107,466,cs),
+(107,612,o),
+(147,670,o),
+(217,670,cs),
+(331,670,o),
+(390,470,o),
+(391,0,c)
+);
+}
+);
+width = 520;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni15C0;
+unicode = 5568;
+},
+{
+color = 9;
+glyphname = "hiSayisi-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(128,0,l),
+(129,470,o),
+(189,670,o),
+(303,670,cs),
+(373,670,o),
+(412,612,o),
+(412,466,cs),
+(412,438,o),
+(409,386,o),
+(402,352,c),
+(462,352,l),
+(471,388,o),
+(473,438,o),
+(473,473,cs),
+(473,642,o),
+(417,727,o),
+(316,727,cs),
+(187,727,o),
+(122,559,o),
+(117,291,c),
+(128,291,l),
+(128,714,l),
+(65,714,l),
+(65,0,l)
+);
+}
+);
+width = 519;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C1;
+unicode = 5569;
+},
+{
+color = 9;
+glyphname = "hoSayisi-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (255,714);
+},
+{
+name = top_left_can;
+pos = (86,714);
+},
+{
+name = top_right_can;
+pos = (424,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(332,-13,o),
+(398,155,o),
+(403,423,c),
+(392,423,l),
+(392,0,l),
+(455,0,l),
+(455,714,l),
+(391,714,l),
+(390,244,o),
+(331,44,o),
+(217,44,cs),
+(147,44,o),
+(107,102,o),
+(107,248,cs),
+(107,276,o),
+(110,328,o),
+(118,362,c),
+(57,362,l),
+(49,326,o),
+(46,276,o),
+(46,241,cs),
+(46,72,o),
+(102,-13,o),
+(204,-13,cs)
+);
+}
+);
+width = 520;
+}
+);
+metricLeft = "heSayisi-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15C2;
+unicode = 5570;
+},
+{
+color = 9;
+glyphname = "haSayisi-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(417,-13,o),
+(473,72,o),
+(473,241,cs),
+(473,276,o),
+(471,326,o),
+(462,362,c),
+(402,362,l),
+(409,328,o),
+(412,276,o),
+(412,248,cs),
+(412,102,o),
+(373,44,o),
+(303,44,cs),
+(189,44,o),
+(129,244,o),
+(128,714,c),
+(65,714,l),
+(65,0,l),
+(128,0,l),
+(128,423,l),
+(117,423,l),
+(122,155,o),
+(187,-13,o),
+(316,-13,cs)
+);
+}
+);
+width = 519;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C3;
+unicode = 5571;
+},
+{
+color = 9;
+glyphname = "ghuCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(291,0,l),
+(529,694,l),
+(529,714,l),
+(477,714,l),
+(393,463,l),
+(426,477,l),
+(132,477,l),
+(166,462,l),
+(81,714,l),
+(28,714,l),
+(28,694,l),
+(266,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(412,428,l),
+(388,439,l),
+(269,82,l),
+(289,82,l),
+(170,440,l),
+(147,428,l)
+);
+}
+);
+width = 557;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C4;
+unicode = 5572;
+},
+{
+color = 9;
+glyphname = "ghoCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(81,0,l),
+(166,252,l),
+(132,237,l),
+(426,237,l),
+(393,251,l),
+(477,0,l),
+(529,0,l),
+(529,20,l),
+(291,714,l),
+(266,714,l),
+(28,20,l),
+(28,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(289,632,l),
+(269,632,l),
+(388,275,l),
+(412,286,l),
+(147,286,l),
+(170,274,l)
+);
+}
+);
+width = 557;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C5;
+unicode = 5573;
+},
+{
+color = 9;
+glyphname = "gheCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (60,357);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(61,0,l),
+(480,344,l),
+(480,370,l),
+(61,714,l),
+(43,714,l),
+(43,662,l),
+(173,555,l),
+(165,590,l),
+(165,124,l),
+(173,158,l),
+(43,51,l),
+(43,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(211,559,l),
+(198,541,l),
+(441,340,l),
+(441,374,l),
+(198,174,l),
+(211,156,l)
+);
+}
+);
+width = 512;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15C6;
+unicode = 5574;
+},
+{
+color = 9;
+glyphname = "gheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (24,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 512;
+}
+);
+note = uni15C7;
+unicode = 5575;
+},
+{
+color = 9;
+glyphname = "ghiCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (4,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 512;
+}
+);
+note = uni15C8;
+unicode = 5576;
+},
+{
+color = 9;
+glyphname = "ghaCarrier-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(470,0,l),
+(470,51,l),
+(340,159,l),
+(348,129,l),
+(348,585,l),
+(340,555,l),
+(470,662,l),
+(470,714,l),
+(452,714,l),
+(32,370,l),
+(32,344,l),
+(452,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(315,173,l),
+(71,374,l),
+(71,339,l),
+(315,540,l),
+(302,548,l),
+(302,169,l)
+);
+}
+);
+width = 513;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15C9;
+unicode = 5577;
+},
+{
+color = 9;
+glyphname = "ruCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(291,0,l),
+(529,694,l),
+(529,714,l),
+(477,714,l),
+(444,615,l),
+(464,629,l),
+(94,629,l),
+(116,615,l),
+(82,714,l),
+(28,714,l),
+(28,694,l),
+(266,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(450,579,l),
+(439,594,l),
+(270,82,l),
+(290,82,l),
+(120,594,l),
+(107,579,l)
+);
+}
+);
+width = 557;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CA;
+unicode = 5578;
+},
+{
+color = 9;
+glyphname = "roCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(82,0,l),
+(115,99,l),
+(94,85,l),
+(465,85,l),
+(443,99,l),
+(477,0,l),
+(529,0,l),
+(529,20,l),
+(291,714,l),
+(266,714,l),
+(28,20,l),
+(28,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(288,632,l),
+(268,632,l),
+(438,120,l),
+(451,135,l),
+(109,135,l),
+(119,120,l)
+);
+}
+);
+width = 557;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CB;
+unicode = 5579;
+},
+{
+color = 9;
+glyphname = "reCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(61,0,l),
+(480,344,l),
+(480,370,l),
+(61,714,l),
+(43,714,l),
+(43,661,l),
+(107,608,l),
+(96,632,l),
+(96,82,l),
+(107,105,l),
+(43,53,l),
+(43,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(143,611,l),
+(133,592,l),
+(437,339,l),
+(437,374,l),
+(133,122,l),
+(143,102,l)
+);
+}
+);
+width = 512;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CC;
+unicode = 5580;
+},
+{
+color = 9;
+glyphname = "reeCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(61,0,l),
+(480,344,l),
+(480,370,l),
+(61,714,l),
+(43,714,l),
+(43,667,l),
+(107,614,l),
+(96,632,l),
+(96,82,l),
+(107,99,l),
+(43,47,l),
+(43,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(138,611,l),
+(129,600,l),
+(446,339,l),
+(446,374,l),
+(128,113,l),
+(138,102,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(223,264,l),
+(223,452,l),
+(195,452,l),
+(195,264,l)
+);
+}
+);
+width = 512;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CD;
+unicode = 5581;
+},
+{
+color = 9;
+glyphname = "riCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(61,0,l),
+(480,344,l),
+(480,370,l),
+(61,714,l),
+(43,714,l),
+(43,667,l),
+(107,614,l),
+(96,632,l),
+(96,82,l),
+(107,99,l),
+(43,47,l),
+(43,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(242,323,o),
+(258,338,o),
+(258,357,cs),
+(258,376,o),
+(242,391,o),
+(223,391,cs),
+(204,391,o),
+(189,376,o),
+(189,357,cs),
+(189,338,o),
+(204,323,o),
+(223,323,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(138,611,l),
+(129,600,l),
+(446,339,l),
+(446,374,l),
+(128,112,l),
+(138,102,l)
+);
+}
+);
+width = 512;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CE;
+unicode = 5582;
+},
+{
+color = 9;
+glyphname = "raCarrier-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(470,0,l),
+(470,53,l),
+(406,106,l),
+(417,69,l),
+(417,646,l),
+(406,609,l),
+(470,661,l),
+(470,714,l),
+(451,714,l),
+(32,370,l),
+(32,344,l),
+(451,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(380,592,l),
+(370,612,l),
+(370,102,l),
+(380,122,l),
+(75,374,l),
+(75,340,l)
+);
+}
+);
+width = 513;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15CF;
+unicode = 5583;
+},
+{
+color = 9;
+glyphname = "wuCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(293,0,l),
+(534,694,l),
+(534,714,l),
+(484,714,l),
+(292,124,l),
+(308,124,l),
+(308,714,l),
+(259,714,l),
+(259,124,l),
+(274,124,l),
+(80,714,l),
+(28,714,l),
+(28,694,l),
+(269,0,l)
+);
+}
+);
+width = 562;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D0;
+unicode = 5584;
+},
+{
+color = 9;
+glyphname = "woCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(79,0,l),
+(273,590,l),
+(256,590,l),
+(256,0,l),
+(306,0,l),
+(306,590,l),
+(291,590,l),
+(484,0,l),
+(534,0,l),
+(534,20,l),
+(293,714,l),
+(269,714,l),
+(28,20,l),
+(28,0,l)
+);
+}
+);
+width = 562;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D1;
+unicode = 5585;
+},
+{
+color = 9;
+glyphname = "weCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(80,0,l),
+(500,344,l),
+(500,370,l),
+(81,714,l),
+(63,714,l),
+(63,662,l),
+(419,369,l),
+(419,383,l),
+(66,383,l),
+(66,332,l),
+(419,332,l),
+(419,345,l),
+(63,51,l),
+(63,0,l)
+);
+}
+);
+width = 532;
+}
+);
+metricRight = "o-canadian";
+note = uni15D2;
+unicode = 5586;
+},
+{
+color = 9;
+glyphname = "weeCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(80,0,l),
+(500,344,l),
+(500,370,l),
+(81,714,l),
+(63,714,l),
+(63,665,l),
+(435,362,l),
+(440,379,l),
+(173,379,l),
+(173,457,l),
+(135,457,l),
+(135,379,l),
+(63,379,l),
+(63,336,l),
+(135,336,l),
+(135,258,l),
+(173,258,l),
+(173,336,l),
+(441,336,l),
+(436,352,l),
+(63,49,l),
+(63,0,l)
+);
+}
+);
+width = 532;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D3;
+unicode = 5587;
+},
+{
+color = 9;
+glyphname = "wiCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(80,0,l),
+(500,344,l),
+(500,370,l),
+(81,714,l),
+(63,714,l),
+(63,665,l),
+(435,362,l),
+(440,379,l),
+(226,379,l),
+(218,399,o),
+(198,414,o),
+(175,414,cs),
+(152,414,o),
+(132,399,o),
+(124,379,c),
+(63,379,l),
+(63,336,l),
+(123,336,l),
+(132,316,o),
+(152,300,o),
+(175,300,cs),
+(198,300,o),
+(218,316,o),
+(226,336,c),
+(441,336,l),
+(436,352,l),
+(63,49,l),
+(63,0,l)
+);
+}
+);
+width = 532;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D4;
+unicode = 5588;
+},
+{
+color = 9;
+glyphname = "waCarrier-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(470,0,l),
+(470,52,l),
+(113,345,l),
+(113,331,l),
+(467,331,l),
+(467,382,l),
+(113,382,l),
+(113,369,l),
+(470,662,l),
+(470,714,l),
+(453,714,l),
+(32,370,l),
+(32,344,l),
+(452,0,l)
+);
+}
+);
+width = 533;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15D5;
+unicode = 5589;
+},
+{
+color = 9;
+glyphname = "hwuCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(293,0,l),
+(534,694,l),
+(534,714,l),
+(487,714,l),
+(407,474,l),
+(426,483,l),
+(303,483,l),
+(303,714,l),
+(261,714,l),
+(261,483,l),
+(134,483,l),
+(156,475,l),
+(77,714,l),
+(28,714,l),
+(28,694,l),
+(269,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(263,445,l),
+(263,112,l),
+(273,113,l),
+(162,453,l),
+(139,445,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(301,445,l),
+(422,445,l),
+(402,453,l),
+(291,116,l),
+(301,115,l)
+);
+}
+);
+width = 562;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D6;
+unicode = 5590;
+},
+{
+color = 9;
+glyphname = "hwoCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(77,0,l),
+(157,240,l),
+(138,228,l),
+(260,228,l),
+(260,0,l),
+(302,0,l),
+(302,228,l),
+(431,228,l),
+(407,239,l),
+(487,0,l),
+(534,0,l),
+(534,20,l),
+(293,714,l),
+(269,714,l),
+(28,20,l),
+(28,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(272,598,l),
+(262,600,l),
+(262,272,l),
+(151,272,l),
+(161,261,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(417,272,l),
+(299,272,l),
+(299,602,l),
+(289,601,l),
+(401,261,l)
+);
+}
+);
+width = 562;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D7;
+unicode = 5591;
+},
+{
+color = 9;
+glyphname = "hweCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(80,0,l),
+(500,344,l),
+(500,370,l),
+(81,714,l),
+(63,714,l),
+(63,665,l),
+(181,568,l),
+(181,380,l),
+(63,380,l),
+(63,335,l),
+(181,335,l),
+(181,145,l),
+(63,48,l),
+(63,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(218,338,l),
+(424,338,l),
+(218,169,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(218,545,l),
+(423,376,l),
+(218,376,l)
+);
+}
+);
+width = 532;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D8;
+unicode = 5592;
+},
+{
+color = 9;
+glyphname = "hweeCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(80,0,l),
+(500,344,l),
+(500,370,l),
+(81,714,l),
+(63,714,l),
+(63,667,l),
+(195,561,l),
+(195,377,l),
+(151,377,l),
+(151,457,l),
+(118,457,l),
+(118,377,l),
+(63,377,l),
+(63,337,l),
+(118,337,l),
+(118,258,l),
+(151,258,l),
+(151,337,l),
+(195,337,l),
+(195,153,l),
+(63,45,l),
+(63,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(230,340,l),
+(425,340,l),
+(230,176,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(230,538,l),
+(424,375,l),
+(230,375,l)
+);
+}
+);
+width = 532;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D9;
+unicode = 5593;
+},
+{
+color = 9;
+glyphname = "hwiCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(80,0,l),
+(500,344,l),
+(500,370,l),
+(81,714,l),
+(63,714,l),
+(63,667,l),
+(195,561,l),
+(195,375,l),
+(177,375,l),
+(171,394,o),
+(154,408,o),
+(134,408,cs),
+(113,408,o),
+(96,394,o),
+(90,375,c),
+(63,375,l),
+(63,340,l),
+(89,340,l),
+(95,321,o),
+(113,306,o),
+(133,306,cs),
+(153,306,o),
+(171,321,o),
+(178,340,c),
+(195,340,l),
+(195,153,l),
+(63,45,l),
+(63,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(230,340,l),
+(425,340,l),
+(230,176,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(230,538,l),
+(424,375,l),
+(230,375,l)
+);
+}
+);
+width = 532;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15DA;
+unicode = 5594;
+},
+{
+color = 9;
+glyphname = "hwaCarrier-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(470,0,l),
+(470,49,l),
+(352,145,l),
+(352,334,l),
+(470,334,l),
+(470,379,l),
+(352,379,l),
+(352,568,l),
+(470,666,l),
+(470,714,l),
+(453,714,l),
+(32,370,l),
+(32,344,l),
+(452,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(110,338,l),
+(314,338,l),
+(314,169,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(314,545,l),
+(314,376,l),
+(109,376,l)
+);
+}
+);
+width = 533;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15DB;
+unicode = 5595;
+},
+{
+color = 9;
+glyphname = "thuCarrier-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(421,-13,o),
+(502,73,o),
+(502,245,cs),
+(502,714,l),
+(61,714,l),
+(61,242,ls),
+(61,74,o),
+(146,-13,o),
+(282,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(124,656,l),
+(439,656,l),
+(439,244,ls),
+(439,107,o),
+(382,47,o),
+(281,47,cs),
+(184,47,o),
+(124,109,o),
+(124,244,cs)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DC;
+unicode = 5596;
+},
+{
+color = 9;
+glyphname = "thoCarrier-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(502,0,l),
+(502,472,ls),
+(502,640,o),
+(418,727,o),
+(282,727,cs),
+(143,727,o),
+(61,641,o),
+(61,469,cs),
+(61,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(124,470,ls),
+(124,607,o),
+(181,667,o),
+(282,667,cs),
+(380,667,o),
+(439,605,o),
+(439,470,cs),
+(439,58,l),
+(124,58,l)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DD;
+unicode = 5597;
+},
+{
+color = 9;
+glyphname = "theCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (272,357);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(202,0,ls),
+(400,0,o),
+(491,125,o),
+(491,358,cs),
+(491,591,o),
+(400,714,o),
+(197,714,cs),
+(65,714,l),
+(65,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(128,679,l),
+(106,657,l),
+(197,657,ls),
+(363,657,o),
+(428,558,o),
+(428,358,cs),
+(428,159,o),
+(363,57,o),
+(202,57,cs),
+(106,57,l),
+(128,35,l)
+);
+}
+);
+width = 543;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "to-canadian";
+note = uni15DE;
+unicode = 5598;
+},
+{
+color = 9;
+glyphname = "theeCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (233,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 543;
+}
+);
+note = uni15DF;
+unicode = 5599;
+},
+{
+color = 9;
+glyphname = "thiCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (212,0);
+ref = dot_middle;
+}
+);
+width = 543;
+}
+);
+note = uni15E0;
+unicode = 5600;
+},
+{
+color = 9;
+glyphname = "thaCarrier-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(479,0,l),
+(479,714,l),
+(341,714,ls),
+(144,714,o),
+(52,589,o),
+(52,356,cs),
+(52,123,o),
+(144,0,o),
+(347,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(116,555,o),
+(180,657,o),
+(341,657,cs),
+(438,657,l),
+(415,679,l),
+(415,35,l),
+(438,57,l),
+(346,57,ls),
+(180,57,o),
+(116,156,o),
+(116,356,cs)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15E1;
+unicode = 5601;
+},
+{
+color = 9;
+glyphname = "ttuCarrier-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(421,-13,o),
+(502,73,o),
+(502,245,cs),
+(502,714,l),
+(479,714,l),
+(274,520,l),
+(291,520,l),
+(86,714,l),
+(61,714,l),
+(61,242,ls),
+(61,74,o),
+(146,-13,o),
+(282,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(184,47,o),
+(124,109,o),
+(124,244,cs),
+(124,665,l),
+(70,662,l),
+(274,468,l),
+(290,468,l),
+(494,662,l),
+(439,665,l),
+(439,244,ls),
+(439,107,o),
+(382,47,o),
+(281,47,cs)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E2;
+unicode = 5602;
+},
+{
+color = 9;
+glyphname = "ttoCarrier-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(85,0,l),
+(290,194,l),
+(273,194,l),
+(477,0,l),
+(502,0,l),
+(502,472,ls),
+(502,640,o),
+(418,727,o),
+(282,727,cs),
+(143,727,o),
+(61,641,o),
+(61,469,cs),
+(61,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(380,667,o),
+(439,605,o),
+(439,470,cs),
+(439,49,l),
+(494,52,l),
+(290,246,l),
+(274,246,l),
+(69,52,l),
+(124,49,l),
+(124,470,ls),
+(124,607,o),
+(181,667,o),
+(282,667,cs)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E3;
+unicode = 5603;
+},
+{
+color = 9;
+glyphname = "tteCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (315,357);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(211,0,ls),
+(409,0,o),
+(501,125,o),
+(501,358,cs),
+(501,591,o),
+(409,714,o),
+(207,714,cs),
+(61,714,l),
+(61,694,l),
+(158,345,l),
+(158,369,l),
+(61,20,l),
+(61,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(215,348,l),
+(215,363,l),
+(118,707,l),
+(118,657,l),
+(207,657,ls),
+(373,657,o),
+(437,558,o),
+(437,358,cs),
+(437,159,o),
+(373,57,o),
+(212,57,cs),
+(118,57,l),
+(118,4,l)
+);
+}
+);
+width = 553;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15E4;
+unicode = 5604;
+},
+{
+color = 9;
+glyphname = "tteeCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (280,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 553;
+}
+);
+note = uni15E5;
+unicode = 5605;
+},
+{
+color = 9;
+glyphname = "ttiCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (265,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 553;
+}
+);
+note = uni15E6;
+unicode = 5606;
+},
+{
+color = 9;
+glyphname = "ttaCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(492,0,l),
+(492,20,l),
+(395,369,l),
+(395,345,l),
+(492,694,l),
+(492,714,l),
+(341,714,ls),
+(144,714,o),
+(52,589,o),
+(52,356,cs),
+(52,123,o),
+(144,0,o),
+(347,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(435,57,l),
+(346,57,ls),
+(180,57,o),
+(116,156,o),
+(116,356,cs),
+(116,555,o),
+(180,657,o),
+(341,657,cs),
+(435,657,l),
+(435,710,l),
+(338,366,l),
+(338,351,l),
+(435,7,l)
+);
+}
+);
+width = 553;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tteCarrier-canadian";
+note = uni15E7;
+unicode = 5607;
+},
+{
+color = 9;
+glyphname = "puCarrier-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(421,-13,o),
+(502,73,o),
+(502,245,cs),
+(502,714,l),
+(439,714,l),
+(439,535,l),
+(125,535,l),
+(125,714,l),
+(61,714,l),
+(61,242,ls),
+(61,74,o),
+(146,-13,o),
+(282,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(184,47,o),
+(125,109,o),
+(125,244,cs),
+(125,478,l),
+(439,478,l),
+(439,244,ls),
+(439,107,o),
+(382,47,o),
+(281,47,cs)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E8;
+unicode = 5608;
+},
+{
+color = 9;
+glyphname = "poCarrier-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(125,0,l),
+(125,179,l),
+(439,179,l),
+(439,0,l),
+(502,0,l),
+(502,472,ls),
+(502,640,o),
+(418,727,o),
+(282,727,cs),
+(145,727,o),
+(61,641,o),
+(61,469,cs),
+(61,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(125,470,ls),
+(125,607,o),
+(181,667,o),
+(282,667,cs),
+(380,667,o),
+(439,605,o),
+(439,470,cs),
+(439,236,l),
+(125,236,l)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E9;
+unicode = 5609;
+},
+{
+color = 9;
+glyphname = "peCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (305,357);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(208,0,ls),
+(407,0,o),
+(498,125,o),
+(498,358,cs),
+(498,591,o),
+(407,714,o),
+(204,714,cs),
+(58,714,l),
+(58,657,l),
+(127,657,l),
+(127,57,l),
+(58,57,l),
+(58,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(190,679,l),
+(160,657,l),
+(205,657,ls),
+(371,657,o),
+(434,558,o),
+(434,358,cs),
+(434,159,o),
+(371,57,o),
+(209,57,cs),
+(160,57,l),
+(190,35,l)
+);
+}
+);
+width = 550;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15EA;
+unicode = 5610;
+},
+{
+color = 9;
+glyphname = "peeCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (270,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 550;
+}
+);
+note = uni15EB;
+unicode = 5611;
+},
+{
+color = 9;
+glyphname = "piCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (255,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 550;
+}
+);
+note = uni15EC;
+unicode = 5612;
+},
+{
+color = 9;
+glyphname = "paCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(492,0,l),
+(492,57,l),
+(423,57,l),
+(423,657,l),
+(492,657,l),
+(492,714,l),
+(346,714,ls),
+(144,714,o),
+(52,591,o),
+(52,358,cs),
+(52,125,o),
+(144,0,o),
+(342,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(390,57,l),
+(341,57,ls),
+(180,57,o),
+(116,159,o),
+(116,358,cs),
+(116,558,o),
+(180,657,o),
+(346,657,cs),
+(390,657,l),
+(360,679,l),
+(360,35,l)
+);
+}
+);
+width = 550;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|peCarrier-canadian";
+note = uni15ED;
+unicode = 5613;
+},
+{
+color = 6;
+glyphname = "pCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(303,189,l),
+(303,233,l),
+(200,233,l),
+(200,546,l),
+(155,546,l),
+(155,233,l),
+(52,233,l),
+(52,189,l)
+);
+}
+);
+width = 355;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni15EE;
+unicode = 5614;
+},
+{
+color = 9;
+glyphname = "guCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (334,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(279,-13,o),
+(328,30,o),
+(347,117,c),
+(321,117,l),
+(343,29,o),
+(392,-13,o),
+(460,-13,cs),
+(551,-13,o),
+(609,54,o),
+(609,182,cs),
+(609,714,l),
+(548,714,l),
+(548,185,ls),
+(548,89,o),
+(516,46,o),
+(457,46,cs),
+(398,46,o),
+(364,91,o),
+(364,185,cs),
+(364,714,l),
+(305,714,l),
+(305,185,ls),
+(305,89,o),
+(271,46,o),
+(212,46,cs),
+(152,46,o),
+(119,89,o),
+(119,185,cs),
+(119,714,l),
+(58,714,l),
+(58,184,ls),
+(58,53,o),
+(118,-13,o),
+(209,-13,cs)
+);
+}
+);
+width = 667;
+}
+);
+metricRight = "=|";
+note = uni15EF;
+unicode = 5615;
+},
+{
+color = 9;
+glyphname = "goCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(119,0,l),
+(119,529,ls),
+(119,624,o),
+(152,668,o),
+(211,668,cs),
+(269,668,o),
+(303,623,o),
+(303,529,cs),
+(303,0,l),
+(362,0,l),
+(362,529,ls),
+(362,625,o),
+(396,668,o),
+(455,668,cs),
+(516,668,o),
+(548,625,o),
+(548,529,cs),
+(548,0,l),
+(609,0,l),
+(609,530,ls),
+(609,661,o),
+(549,727,o),
+(458,727,cs),
+(388,727,o),
+(339,684,o),
+(320,597,c),
+(346,597,l),
+(324,685,o),
+(275,727,o),
+(207,727,cs),
+(117,727,o),
+(58,660,o),
+(58,532,cs),
+(58,0,l)
+);
+}
+);
+width = 667;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F0;
+unicode = 5616;
+},
+{
+color = 9;
+glyphname = "geCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (278,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(298,0,ls),
+(416,0,o),
+(491,65,o),
+(491,187,cs),
+(491,274,o),
+(446,341,o),
+(373,366,c),
+(373,348,l),
+(447,371,o),
+(491,435,o),
+(491,525,cs),
+(491,648,o),
+(415,714,o),
+(298,714,cs),
+(65,714,l),
+(65,660,l),
+(288,660,ls),
+(374,660,o),
+(428,617,o),
+(428,523,cs),
+(428,431,o),
+(374,384,o),
+(289,384,cs),
+(65,384,l),
+(65,330,l),
+(290,330,ls),
+(373,330,o),
+(428,283,o),
+(428,190,cs),
+(428,96,o),
+(373,54,o),
+(288,54,cs),
+(65,54,l),
+(65,0,l)
+);
+}
+);
+width = 553;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15F1;
+unicode = 5617;
+},
+{
+color = 9;
+glyphname = "geeCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(298,0,ls),
+(416,0,o),
+(491,65,o),
+(491,187,cs),
+(491,274,o),
+(446,341,o),
+(373,366,c),
+(373,348,l),
+(447,371,o),
+(491,435,o),
+(491,525,cs),
+(491,648,o),
+(415,714,o),
+(298,714,cs),
+(65,714,l),
+(65,660,l),
+(288,660,ls),
+(374,660,o),
+(428,617,o),
+(428,523,cs),
+(428,431,o),
+(374,384,o),
+(289,384,cs),
+(266,384,l),
+(266,468,l),
+(228,468,l),
+(228,384,l),
+(65,384,l),
+(65,331,l),
+(228,331,l),
+(228,248,l),
+(266,248,l),
+(266,331,l),
+(290,331,ls),
+(373,331,o),
+(428,283,o),
+(428,190,cs),
+(428,96,o),
+(373,54,o),
+(288,54,cs),
+(65,54,l),
+(65,0,l)
+);
+}
+);
+width = 553;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F2;
+unicode = 5618;
+},
+{
+color = 9;
+glyphname = "giCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(298,0,ls),
+(416,0,o),
+(491,65,o),
+(491,187,cs),
+(491,274,o),
+(446,341,o),
+(373,366,c),
+(373,348,l),
+(447,371,o),
+(491,435,o),
+(491,525,cs),
+(491,648,o),
+(415,714,o),
+(298,714,cs),
+(65,714,l),
+(65,660,l),
+(288,660,ls),
+(374,660,o),
+(428,617,o),
+(428,523,cs),
+(428,431,o),
+(374,384,o),
+(295,384,cs),
+(281,384,l),
+(305,376,l),
+(296,401,o),
+(274,418,o),
+(248,418,cs),
+(225,418,o),
+(205,404,o),
+(196,384,c),
+(65,384,l),
+(65,331,l),
+(196,331,l),
+(204,310,o),
+(225,296,o),
+(248,296,cs),
+(274,296,o),
+(296,313,o),
+(305,338,c),
+(281,331,l),
+(295,331,ls),
+(373,331,o),
+(428,283,o),
+(428,190,cs),
+(428,96,o),
+(373,54,o),
+(288,54,cs),
+(65,54,l),
+(65,0,l)
+);
+}
+);
+width = 553;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F3;
+unicode = 5619;
+},
+{
+color = 9;
+glyphname = "gaCarrier-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (289,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(489,0,l),
+(489,54,l),
+(265,54,ls),
+(180,54,o),
+(126,96,o),
+(126,190,cs),
+(126,283,o),
+(181,330,o),
+(263,330,cs),
+(489,330,l),
+(489,384,l),
+(264,384,ls),
+(179,384,o),
+(126,431,o),
+(126,523,cs),
+(126,617,o),
+(180,660,o),
+(265,660,cs),
+(489,660,l),
+(489,714,l),
+(255,714,ls),
+(138,714,o),
+(62,648,o),
+(62,525,cs),
+(62,435,o),
+(106,371,o),
+(181,348,c),
+(181,366,l),
+(107,341,o),
+(62,274,o),
+(62,187,cs),
+(62,65,o),
+(137,0,o),
+(255,0,cs)
+);
+}
+);
+width = 554;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|geCarrier-canadian";
+note = uni15F4;
+unicode = 5620;
+},
+{
+color = 9;
+glyphname = "khuCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(280,-13,o),
+(329,30,o),
+(348,117,c),
+(322,117,l),
+(344,29,o),
+(393,-13,o),
+(461,-13,cs),
+(551,-13,o),
+(609,54,o),
+(609,182,cs),
+(609,714,l),
+(58,714,l),
+(58,184,ls),
+(58,53,o),
+(118,-13,o),
+(209,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(152,46,o),
+(120,89,o),
+(120,185,cs),
+(120,657,l),
+(306,657,l),
+(306,185,ls),
+(306,89,o),
+(272,46,o),
+(213,46,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(398,46,o),
+(364,91,o),
+(364,185,cs),
+(364,657,l),
+(548,657,l),
+(548,185,ls),
+(548,89,o),
+(516,46,o),
+(457,46,cs)
+);
+}
+);
+width = 667;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F5;
+unicode = 5621;
+},
+{
+color = 9;
+glyphname = "khoCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(609,0,l),
+(609,530,ls),
+(609,661,o),
+(549,727,o),
+(458,727,cs),
+(387,727,o),
+(338,684,o),
+(319,597,c),
+(345,597,l),
+(323,685,o),
+(274,727,o),
+(207,727,cs),
+(116,727,o),
+(58,660,o),
+(58,532,cs),
+(58,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(119,529,ls),
+(119,624,o),
+(151,668,o),
+(210,668,cs),
+(269,668,o),
+(303,623,o),
+(303,529,cs),
+(303,57,l),
+(119,57,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(361,529,ls),
+(361,625,o),
+(395,668,o),
+(454,668,cs),
+(515,668,o),
+(547,625,o),
+(547,529,cs),
+(547,57,l),
+(361,57,l)
+);
+}
+);
+width = 667;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F6;
+unicode = 5622;
+},
+{
+color = 9;
+glyphname = "kheCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(300,0,ls),
+(418,0,o),
+(493,65,o),
+(493,187,cs),
+(493,274,o),
+(448,341,o),
+(375,366,c),
+(375,348,l),
+(449,371,o),
+(493,435,o),
+(493,525,cs),
+(493,648,o),
+(417,714,o),
+(300,714,cs),
+(65,714,l),
+(65,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(128,331,l),
+(292,331,ls),
+(374,331,o),
+(430,283,o),
+(430,190,cs),
+(430,96,o),
+(375,54,o),
+(290,54,cs),
+(128,54,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(128,660,l),
+(290,660,ls),
+(376,660,o),
+(430,617,o),
+(430,523,cs),
+(430,431,o),
+(376,384,o),
+(291,384,cs),
+(128,384,l)
+);
+}
+);
+width = 555;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F7;
+unicode = 5623;
+},
+{
+color = 9;
+glyphname = "kheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(300,0,ls),
+(418,0,o),
+(493,65,o),
+(493,187,cs),
+(493,278,o),
+(443,347,o),
+(361,366,c),
+(361,347,l),
+(444,364,o),
+(493,430,o),
+(493,525,cs),
+(493,648,o),
+(417,714,o),
+(300,714,cs),
+(65,714,l),
+(65,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(128,331,l),
+(244,331,l),
+(244,239,l),
+(282,239,l),
+(282,345,l),
+(259,331,l),
+(297,331,ls),
+(377,331,o),
+(430,283,o),
+(430,190,cs),
+(430,96,o),
+(375,54,o),
+(290,54,cs),
+(128,54,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(282,477,l),
+(244,477,l),
+(244,384,l),
+(128,384,l),
+(128,660,l),
+(290,660,ls),
+(376,660,o),
+(430,617,o),
+(430,523,cs),
+(430,431,o),
+(379,384,o),
+(297,384,cs),
+(259,384,l),
+(282,369,l)
+);
+}
+);
+width = 555;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F8;
+unicode = 5624;
+},
+{
+color = 9;
+glyphname = "khiCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(300,0,ls),
+(418,0,o),
+(493,65,o),
+(493,187,cs),
+(493,274,o),
+(448,341,o),
+(375,365,c),
+(375,348,l),
+(449,370,o),
+(493,435,o),
+(493,525,cs),
+(493,648,o),
+(417,714,o),
+(300,714,cs),
+(65,714,l),
+(65,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(128,333,l),
+(206,333,l),
+(215,311,o),
+(236,296,o),
+(260,296,cs),
+(291,296,o),
+(315,321,o),
+(318,352,c),
+(284,333,l),
+(300,333,ls),
+(377,333,o),
+(430,285,o),
+(430,191,cs),
+(430,95,o),
+(375,54,o),
+(290,54,cs),
+(128,54,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(290,660,ls),
+(376,660,o),
+(430,618,o),
+(430,521,cs),
+(430,429,o),
+(379,381,o),
+(299,381,cs),
+(284,381,l),
+(317,362,l),
+(315,393,o),
+(291,418,o),
+(260,418,cs),
+(229,418,o),
+(204,393,o),
+(201,362,c),
+(219,381,l),
+(128,381,l),
+(128,660,l)
+);
+}
+);
+width = 555;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F9;
+unicode = 5625;
+},
+{
+color = 9;
+glyphname = "khaCarrier-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(491,0,l),
+(491,714,l),
+(255,714,ls),
+(138,714,o),
+(62,648,o),
+(62,525,cs),
+(62,435,o),
+(106,370,o),
+(181,348,c),
+(180,365,l),
+(107,341,o),
+(62,274,o),
+(62,187,cs),
+(62,65,o),
+(137,0,o),
+(255,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(180,54,o),
+(126,96,o),
+(126,190,cs),
+(126,283,o),
+(181,331,o),
+(263,331,cs),
+(427,331,l),
+(427,54,l),
+(265,54,ls)
+);
+},
+{
+closed = 1;
+nodes = (
+(179,384,o),
+(126,431,o),
+(126,523,cs),
+(126,617,o),
+(180,660,o),
+(265,660,cs),
+(427,660,l),
+(427,384,l),
+(264,384,ls)
+);
+}
+);
+width = 556;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15FA;
+unicode = 5626;
+},
+{
+color = 9;
+glyphname = "kkuCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(279,-13,o),
+(327,29,o),
+(347,115,c),
+(322,115,l),
+(344,29,o),
+(392,-13,o),
+(460,-13,cs),
+(551,-13,o),
+(609,54,o),
+(609,182,cs),
+(609,714,l),
+(584,714,l),
+(351,537,l),
+(351,476,l),
+(563,640,l),
+(548,649,l),
+(548,185,ls),
+(548,89,o),
+(515,46,o),
+(456,46,cs),
+(398,46,o),
+(363,91,o),
+(363,185,cs),
+(363,714,l),
+(305,714,l),
+(305,185,ls),
+(305,89,o),
+(271,46,o),
+(213,46,cs),
+(152,46,o),
+(119,89,o),
+(119,185,cs),
+(119,649,l),
+(105,640,l),
+(314,477,l),
+(314,539,l),
+(84,714,l),
+(58,714,l),
+(58,184,ls),
+(58,53,o),
+(118,-13,o),
+(209,-13,cs)
+);
+}
+);
+width = 667;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FB;
+unicode = 5627;
+},
+{
+color = 9;
+glyphname = "kkoCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(83,0,l),
+(316,177,l),
+(316,238,l),
+(104,74,l),
+(119,65,l),
+(119,529,ls),
+(119,625,o),
+(152,668,o),
+(211,668,cs),
+(269,668,o),
+(304,623,o),
+(304,529,cs),
+(304,0,l),
+(362,0,l),
+(362,529,ls),
+(362,625,o),
+(396,668,o),
+(455,668,cs),
+(516,668,o),
+(548,625,o),
+(548,529,cs),
+(548,65,l),
+(563,74,l),
+(353,237,l),
+(353,175,l),
+(583,0,l),
+(609,0,l),
+(609,530,ls),
+(609,661,o),
+(550,727,o),
+(459,727,cs),
+(389,727,o),
+(340,685,o),
+(320,599,c),
+(346,599,l),
+(323,685,o),
+(275,727,o),
+(208,727,cs),
+(117,727,o),
+(58,660,o),
+(58,532,cs),
+(58,0,l)
+);
+}
+);
+width = 667;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FC;
+unicode = 5628;
+},
+{
+color = 9;
+glyphname = "kkeCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(314,0,ls),
+(432,0,o),
+(507,65,o),
+(507,187,cs),
+(507,274,o),
+(462,341,o),
+(389,365,c),
+(388,348,l),
+(463,370,o),
+(507,435,o),
+(507,525,cs),
+(507,648,o),
+(431,714,o),
+(314,714,cs),
+(64,714,l),
+(64,694,l),
+(151,384,l),
+(67,384,l),
+(67,330,l),
+(151,330,l),
+(64,20,l),
+(64,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(214,330,l),
+(305,330,ls),
+(388,330,o),
+(443,283,o),
+(443,190,cs),
+(443,96,o),
+(389,54,o),
+(304,54,cs),
+(109,54,l),
+(129,27,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(128,687,l),
+(108,660,l),
+(304,660,ls),
+(389,660,o),
+(443,617,o),
+(443,523,cs),
+(443,431,o),
+(390,384,o),
+(305,384,cs),
+(213,384,l)
+);
+}
+);
+width = 569;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni15FD;
+unicode = 5629;
+},
+{
+color = 9;
+glyphname = "kkeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(314,0,ls),
+(432,0,o),
+(507,65,o),
+(507,187,cs),
+(507,274,o),
+(462,341,o),
+(389,365,c),
+(388,348,l),
+(463,370,o),
+(507,435,o),
+(507,525,cs),
+(507,648,o),
+(431,714,o),
+(314,714,cs),
+(64,714,l),
+(64,694,l),
+(151,384,l),
+(67,384,l),
+(67,330,l),
+(151,330,l),
+(64,20,l),
+(64,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(213,332,l),
+(277,332,l),
+(277,247,l),
+(315,247,l),
+(315,348,l),
+(288,332,l),
+(310,332,ls),
+(391,332,o),
+(443,285,o),
+(443,191,cs),
+(443,97,o),
+(389,54,o),
+(304,54,cs),
+(107,54,l),
+(128,27,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(315,468,l),
+(277,468,l),
+(277,383,l),
+(212,383,l),
+(126,687,l),
+(106,660,l),
+(304,660,ls),
+(389,660,o),
+(443,617,o),
+(443,522,cs),
+(443,429,o),
+(392,383,o),
+(310,383,cs),
+(288,383,l),
+(315,369,l)
+);
+}
+);
+width = 569;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FE;
+unicode = 5630;
+},
+{
+color = 9;
+glyphname = "kkiCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(314,0,ls),
+(432,0,o),
+(507,65,o),
+(507,187,cs),
+(507,274,o),
+(462,341,o),
+(389,365,c),
+(388,348,l),
+(463,370,o),
+(507,435,o),
+(507,525,cs),
+(507,648,o),
+(431,714,o),
+(314,714,cs),
+(64,714,l),
+(64,694,l),
+(151,384,l),
+(67,384,l),
+(67,330,l),
+(151,330,l),
+(64,20,l),
+(64,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(214,334,l),
+(232,334,l),
+(239,312,o),
+(260,296,o),
+(285,296,cs),
+(316,296,o),
+(339,322,o),
+(340,349,c),
+(293,334,l),
+(310,334,ls),
+(391,334,o),
+(443,285,o),
+(443,189,cs),
+(443,97,o),
+(389,54,o),
+(304,54,cs),
+(107,54,l),
+(128,27,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(339,392,o),
+(317,418,o),
+(285,418,cs),
+(260,418,o),
+(239,402,o),
+(232,380,c),
+(213,380,l),
+(126,687,l),
+(106,660,l),
+(304,660,ls),
+(389,660,o),
+(443,617,o),
+(443,520,cs),
+(443,429,o),
+(392,380,o),
+(310,380,cs),
+(293,380,l),
+(341,365,l)
+);
+}
+);
+width = 569;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FF;
+unicode = 5631;
+},
+{
+color = 9;
+glyphname = "kkaCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(505,0,l),
+(505,20,l),
+(418,330,l),
+(503,330,l),
+(503,384,l),
+(418,384,l),
+(505,694,l),
+(505,714,l),
+(255,714,ls),
+(138,714,o),
+(62,648,o),
+(62,525,cs),
+(62,435,o),
+(106,370,o),
+(181,348,c),
+(180,365,l),
+(107,341,o),
+(62,274,o),
+(62,187,cs),
+(62,65,o),
+(137,0,o),
+(255,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(460,54,l),
+(265,54,ls),
+(180,54,o),
+(126,96,o),
+(126,190,cs),
+(126,283,o),
+(181,330,o),
+(263,330,cs),
+(354,330,l),
+(440,27,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(179,384,o),
+(126,431,o),
+(126,523,cs),
+(126,617,o),
+(180,660,o),
+(265,660,cs),
+(461,660,l),
+(441,687,l),
+(356,384,l),
+(264,384,ls)
+);
+}
+);
+width = 569;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|kkeCarrier-canadian";
+note = uni1600;
+unicode = 5632;
+},
+{
+color = 6;
+glyphname = "kkCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(164,189,l),
+(283,534,l),
+(283,546,l),
+(239,546,l),
+(142,242,l),
+(173,242,l),
+(75,546,l),
+(32,546,l),
+(32,534,l),
+(151,189,l)
+);
+}
+);
+width = 314;
+}
+);
+note = uni1601;
+unicode = 5633;
+},
+{
+color = 9;
+glyphname = "nuCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(420,-13,o),
+(502,74,o),
+(502,248,cs),
+(502,309,l),
+(439,309,l),
+(439,244,ls),
+(439,108,o),
+(382,47,o),
+(281,47,cs),
+(184,47,o),
+(125,110,o),
+(125,239,cs),
+(125,714,l),
+(61,714,l),
+(61,243,ls),
+(61,75,o),
+(147,-13,o),
+(281,-13,cs)
+);
+}
+);
+width = 559;
+}
+);
+metricLeft = "te-canadian";
+note = uni1602;
+unicode = 5634;
+},
+{
+color = 9;
+glyphname = "noCarrier-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(497,0,l),
+(497,471,ls),
+(497,639,o),
+(411,727,o),
+(277,727,cs),
+(138,727,o),
+(57,640,o),
+(57,466,cs),
+(57,405,l),
+(120,405,l),
+(120,470,ls),
+(120,606,o),
+(176,667,o),
+(277,667,cs),
+(374,667,o),
+(433,604,o),
+(433,475,cs),
+(433,0,l)
+);
+}
+);
+width = 558;
+}
+);
+metricLeft = "=|nuCarrier-canadian";
+metricRight = "te-canadian";
+note = uni1603;
+unicode = 5635;
+},
+{
+color = 9;
+glyphname = "neCarrier-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (228,357);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(210,0,ls),
+(395,0,o),
+(489,125,o),
+(489,358,cs),
+(489,591,o),
+(398,714,o),
+(195,714,cs),
+(43,714,l),
+(43,655,l),
+(196,655,ls),
+(359,655,o),
+(426,557,o),
+(426,358,cs),
+(426,161,o),
+(356,59,o),
+(211,59,cs),
+(207,59,l),
+(207,0,l)
+);
+}
+);
+width = 541;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1604;
+unicode = 5636;
+},
+{
+color = 9;
+glyphname = "neeCarrier-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+ref = "neCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (189,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 541;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1605;
+unicode = 5637;
+},
+{
+color = 9;
+glyphname = "niCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "neCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (168,0);
+ref = dot_middle;
+}
+);
+width = 542;
+}
+);
+note = uni1606;
+unicode = 5638;
+},
+{
+color = 9;
+glyphname = "naCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(499,0,l),
+(499,59,l),
+(346,59,ls),
+(182,59,o),
+(116,157,o),
+(116,356,cs),
+(116,553,o),
+(186,655,o),
+(331,655,cs),
+(335,655,l),
+(335,714,l),
+(331,714,ls),
+(147,714,o),
+(52,589,o),
+(52,356,cs),
+(52,123,o),
+(144,0,o),
+(347,0,cs)
+);
+}
+);
+width = 542;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni1607;
+unicode = 5639;
+},
+{
+color = 9;
+glyphname = "muCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(279,-13,o),
+(328,30,o),
+(347,117,c),
+(321,117,l),
+(343,29,o),
+(392,-13,o),
+(460,-13,cs),
+(551,-13,o),
+(609,54,o),
+(609,182,cs),
+(609,402,l),
+(548,402,l),
+(548,185,ls),
+(548,89,o),
+(516,46,o),
+(457,46,cs),
+(398,46,o),
+(364,91,o),
+(364,185,cs),
+(364,402,l),
+(305,402,l),
+(305,185,ls),
+(305,89,o),
+(271,46,o),
+(212,46,cs),
+(152,46,o),
+(119,89,o),
+(119,185,cs),
+(119,714,l),
+(58,714,l),
+(58,184,ls),
+(58,53,o),
+(118,-13,o),
+(209,-13,cs)
+);
+}
+);
+width = 667;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "=|";
+note = uni1608;
+unicode = 5640;
+},
+{
+color = 9;
+glyphname = "moCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(609,0,l),
+(609,530,ls),
+(609,661,o),
+(549,727,o),
+(458,727,cs),
+(388,727,o),
+(339,684,o),
+(320,597,c),
+(346,597,l),
+(324,685,o),
+(275,727,o),
+(207,727,cs),
+(117,727,o),
+(58,660,o),
+(58,532,cs),
+(58,312,l),
+(119,312,l),
+(119,529,ls),
+(119,624,o),
+(152,668,o),
+(211,668,cs),
+(269,668,o),
+(303,623,o),
+(303,529,cs),
+(303,312,l),
+(362,312,l),
+(362,529,ls),
+(362,625,o),
+(396,668,o),
+(455,668,cs),
+(516,668,o),
+(548,625,o),
+(548,529,cs),
+(548,0,l)
+);
+}
+);
+width = 667;
+}
+);
+metricLeft = "=|muCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni1609;
+unicode = 5641;
+},
+{
+color = 9;
+glyphname = "meCarrier-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(296,0,ls),
+(415,0,o),
+(489,65,o),
+(489,187,cs),
+(489,274,o),
+(444,341,o),
+(371,366,c),
+(371,348,l),
+(445,371,o),
+(489,435,o),
+(489,525,cs),
+(489,648,o),
+(414,714,o),
+(296,714,cs),
+(43,714,l),
+(43,660,l),
+(286,660,ls),
+(372,660,o),
+(426,617,o),
+(426,523,cs),
+(426,431,o),
+(372,384,o),
+(288,384,cs),
+(223,384,l),
+(223,330,l),
+(288,330,ls),
+(371,330,o),
+(426,283,o),
+(426,190,cs),
+(426,96,o),
+(372,54,o),
+(286,54,cs),
+(223,54,l),
+(223,0,l)
+);
+}
+);
+width = 551;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160A;
+unicode = 5642;
+},
+{
+color = 9;
+glyphname = "meeCarrier-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(296,0,ls),
+(415,0,o),
+(489,65,o),
+(489,187,cs),
+(489,274,o),
+(444,341,o),
+(371,365,c),
+(371,348,l),
+(445,370,o),
+(489,435,o),
+(489,525,cs),
+(489,648,o),
+(414,714,o),
+(296,714,cs),
+(43,714,l),
+(43,660,l),
+(286,660,ls),
+(372,660,o),
+(426,617,o),
+(426,522,cs),
+(426,430,o),
+(374,383,o),
+(292,383,cs),
+(263,383,l),
+(263,474,l),
+(223,474,l),
+(223,241,l),
+(263,241,l),
+(263,331,l),
+(292,331,ls),
+(373,331,o),
+(426,284,o),
+(426,191,cs),
+(426,97,o),
+(372,54,o),
+(286,54,cs),
+(223,54,l),
+(223,0,l)
+);
+}
+);
+width = 551;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160B;
+unicode = 5643;
+},
+{
+color = 9;
+glyphname = "miCarrier-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(296,0,ls),
+(415,0,o),
+(489,65,o),
+(489,187,cs),
+(489,274,o),
+(444,341,o),
+(371,365,c),
+(371,348,l),
+(445,370,o),
+(489,435,o),
+(489,525,cs),
+(489,648,o),
+(414,714,o),
+(296,714,cs),
+(43,714,l),
+(43,660,l),
+(286,660,ls),
+(372,660,o),
+(426,617,o),
+(426,522,cs),
+(426,430,o),
+(374,383,o),
+(295,383,cs),
+(273,383,l),
+(307,365,l),
+(304,395,o),
+(280,418,o),
+(249,418,cs),
+(215,418,o),
+(189,390,o),
+(189,357,cs),
+(189,324,o),
+(215,296,o),
+(249,296,cs),
+(279,296,o),
+(304,320,o),
+(307,349,c),
+(273,331,l),
+(294,331,ls),
+(373,331,o),
+(426,284,o),
+(426,191,cs),
+(426,97,o),
+(372,54,o),
+(286,54,cs),
+(223,54,l),
+(223,0,l)
+);
+}
+);
+width = 551;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160C;
+unicode = 5644;
+},
+{
+color = 9;
+glyphname = "maCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(509,0,l),
+(509,54,l),
+(265,54,ls),
+(180,54,o),
+(126,96,o),
+(126,190,cs),
+(126,283,o),
+(180,330,o),
+(263,330,cs),
+(329,330,l),
+(329,384,l),
+(264,384,ls),
+(180,384,o),
+(126,430,o),
+(126,522,cs),
+(126,617,o),
+(180,660,o),
+(265,660,cs),
+(329,660,l),
+(329,714,l),
+(255,714,ls),
+(137,714,o),
+(62,649,o),
+(62,525,cs),
+(62,438,o),
+(107,372,o),
+(181,349,c),
+(181,366,l),
+(106,343,o),
+(62,277,o),
+(62,188,cs),
+(62,66,o),
+(138,0,o),
+(255,0,cs)
+);
+}
+);
+width = 552;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni160D;
+unicode = 5645;
+},
+{
+color = 9;
+glyphname = "yuCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(453,-13,o),
+(537,112,o),
+(537,402,cs),
+(537,627,o),
+(482,727,o),
+(384,727,cs),
+(301,727,o),
+(253,651,o),
+(253,524,cs),
+(253,399,o),
+(301,326,o),
+(382,326,cs),
+(397,326,o),
+(412,329,o),
+(422,334,c),
+(422,384,l),
+(415,381,o),
+(405,378,o),
+(388,378,cs),
+(333,378,o),
+(307,426,o),
+(307,526,cs),
+(307,626,o),
+(333,674,o),
+(384,674,cs),
+(445,674,o),
+(477,601,o),
+(477,403,cs),
+(477,137,o),
+(414,47,o),
+(288,47,cs),
+(185,47,o),
+(125,110,o),
+(125,242,cs),
+(125,714,l),
+(61,714,l),
+(61,244,ls),
+(61,74,o),
+(149,-13,o),
+(286,-13,cs)
+);
+}
+);
+width = 598;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160E;
+unicode = 5646;
+},
+{
+color = 9;
+glyphname = "yoCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(298,-13,o),
+(345,63,o),
+(345,190,cs),
+(345,315,o),
+(298,388,o),
+(216,388,cs),
+(202,388,o),
+(186,385,o),
+(176,380,c),
+(176,330,l),
+(184,333,o),
+(193,336,o),
+(210,336,cs),
+(265,336,o),
+(291,288,o),
+(291,188,cs),
+(291,88,o),
+(265,40,o),
+(215,40,cs),
+(153,40,o),
+(122,113,o),
+(122,311,cs),
+(122,577,o),
+(184,667,o),
+(311,667,cs),
+(413,667,o),
+(473,604,o),
+(473,472,cs),
+(473,0,l),
+(537,0,l),
+(537,470,ls),
+(537,640,o),
+(449,727,o),
+(313,727,cs),
+(145,727,o),
+(61,602,o),
+(61,312,cs),
+(61,87,o),
+(117,-13,o),
+(214,-13,cs)
+);
+}
+);
+width = 598;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160F;
+unicode = 5647;
+},
+{
+color = 9;
+glyphname = "yeCarrier-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(403,-13,o),
+(484,128,o),
+(484,354,cs),
+(484,591,o),
+(393,714,o),
+(189,714,cs),
+(58,714,l),
+(58,655,l),
+(189,655,ls),
+(354,655,o),
+(421,557,o),
+(421,353,cs),
+(421,156,o),
+(371,43,o),
+(250,43,cs),
+(142,43,o),
+(100,115,o),
+(100,215,cs),
+(100,313,o),
+(130,362,o),
+(179,362,cs),
+(228,362,o),
+(255,313,o),
+(255,223,cs),
+(255,190,o),
+(252,171,o),
+(249,150,c),
+(298,150,l),
+(303,177,o),
+(305,193,o),
+(305,228,cs),
+(305,343,o),
+(260,415,o),
+(178,415,cs),
+(96,415,o),
+(45,342,o),
+(45,215,cs),
+(45,89,o),
+(109,-13,o),
+(249,-13,cs)
+);
+}
+);
+width = 536;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1610;
+unicode = 5648;
+},
+{
+color = 9;
+glyphname = "yeeCarrier-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(403,-13,o),
+(484,128,o),
+(484,354,cs),
+(484,591,o),
+(393,714,o),
+(189,714,cs),
+(58,714,l),
+(58,655,l),
+(189,655,ls),
+(354,655,o),
+(421,557,o),
+(421,353,cs),
+(421,156,o),
+(371,43,o),
+(248,43,cs),
+(142,43,o),
+(100,116,o),
+(100,219,cs),
+(100,312,o),
+(128,362,o),
+(172,362,cs),
+(218,362,o),
+(245,314,o),
+(245,240,cs),
+(245,180,l),
+(280,180,l),
+(280,521,l),
+(245,521,l),
+(245,303,l),
+(255,303,l),
+(248,374,o),
+(213,415,o),
+(161,415,cs),
+(94,415,o),
+(45,345,o),
+(45,219,cs),
+(45,89,o),
+(109,-13,o),
+(247,-13,cs)
+);
+}
+);
+width = 536;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1611;
+unicode = 5649;
+},
+{
+color = 9;
+glyphname = "yiCarrier-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(403,-13,o),
+(484,128,o),
+(484,354,cs),
+(484,591,o),
+(393,714,o),
+(189,714,cs),
+(58,714,l),
+(58,655,l),
+(189,655,ls),
+(354,655,o),
+(421,557,o),
+(421,353,cs),
+(421,156,o),
+(371,43,o),
+(252,43,cs),
+(144,43,o),
+(100,117,o),
+(100,203,cs),
+(100,288,o),
+(131,335,o),
+(175,337,c),
+(160,348,l),
+(163,322,o),
+(189,299,o),
+(219,299,cs),
+(252,299,o),
+(278,326,o),
+(278,357,cs),
+(278,389,o),
+(252,415,o),
+(219,415,cs),
+(194,415,o),
+(174,401,o),
+(165,381,c),
+(93,373,o),
+(45,305,o),
+(45,198,cs),
+(45,89,o),
+(109,-13,o),
+(249,-13,cs)
+);
+}
+);
+width = 536;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1612;
+unicode = 5650;
+},
+{
+color = 9;
+glyphname = "yaCarrier-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(479,0,l),
+(479,59,l),
+(347,59,ls),
+(182,59,o),
+(116,157,o),
+(116,361,cs),
+(116,558,o),
+(166,671,o),
+(295,671,cs),
+(394,671,o),
+(436,599,o),
+(436,499,cs),
+(436,401,o),
+(407,352,o),
+(358,352,cs),
+(308,352,o),
+(282,401,o),
+(282,491,cs),
+(282,524,o),
+(284,543,o),
+(287,564,c),
+(239,564,l),
+(234,537,o),
+(232,521,o),
+(232,486,cs),
+(232,371,o),
+(277,299,o),
+(359,299,cs),
+(440,299,o),
+(491,372,o),
+(491,499,cs),
+(491,625,o),
+(427,727,o),
+(296,727,cs),
+(134,727,o),
+(52,586,o),
+(52,360,cs),
+(52,123,o),
+(143,0,o),
+(348,0,cs)
+);
+}
+);
+width = 536;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|yeCarrier-canadian";
+note = uni1613;
+unicode = 5651;
+},
+{
+color = 9;
+glyphname = "juCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(441,-13,o),
+(504,90,o),
+(504,213,cs),
+(504,342,o),
+(453,415,o),
+(371,415,cs),
+(289,415,o),
+(245,343,o),
+(245,228,cs),
+(245,193,o),
+(247,175,o),
+(252,150,c),
+(300,150,l),
+(297,170,o),
+(295,191,o),
+(295,223,cs),
+(295,312,o),
+(321,362,o),
+(370,362,cs),
+(420,362,o),
+(449,312,o),
+(449,213,cs),
+(449,116,o),
+(408,43,o),
+(300,43,cs),
+(184,43,o),
+(121,135,o),
+(121,312,cs),
+(121,558,o),
+(237,655,o),
+(427,655,cs),
+(492,655,l),
+(492,714,l),
+(51,714,l),
+(51,657,l),
+(310,657,l),
+(358,682,l),
+(182,682,o),
+(58,557,o),
+(58,310,cs),
+(58,108,o),
+(149,-13,o),
+(296,-13,cs)
+);
+}
+);
+width = 549;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni1614;
+unicode = 5652;
+},
+{
+color = 9;
+glyphname = "juSayisi-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (278,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(400,-13,o),
+(492,108,o),
+(492,310,cs),
+(492,557,o),
+(368,682,o),
+(191,682,c),
+(240,657,l),
+(498,657,l),
+(498,714,l),
+(58,714,l),
+(58,655,l),
+(123,655,ls),
+(312,655,o),
+(428,558,o),
+(428,312,cs),
+(428,135,o),
+(365,43,o),
+(250,43,cs),
+(141,43,o),
+(100,116,o),
+(100,213,cs),
+(100,312,o),
+(130,362,o),
+(179,362,cs),
+(228,362,o),
+(255,312,o),
+(255,223,cs),
+(255,191,o),
+(252,170,o),
+(249,150,c),
+(298,150,l),
+(303,175,o),
+(305,193,o),
+(305,228,cs),
+(305,343,o),
+(260,415,o),
+(178,415,cs),
+(96,415,o),
+(45,342,o),
+(45,213,cs),
+(45,90,o),
+(108,-13,o),
+(253,-13,cs)
+);
+}
+);
+width = 549;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1615;
+unicode = 5653;
+},
+{
+color = 9;
+glyphname = "joCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(498,0,l),
+(498,57,l),
+(240,57,l),
+(191,32,l),
+(368,32,o),
+(492,157,o),
+(492,404,cs),
+(492,606,o),
+(400,727,o),
+(253,727,cs),
+(108,727,o),
+(45,624,o),
+(45,501,cs),
+(45,372,o),
+(96,299,o),
+(178,299,cs),
+(260,299,o),
+(305,371,o),
+(305,486,cs),
+(305,521,o),
+(303,539,o),
+(298,564,c),
+(249,564,l),
+(252,544,o),
+(255,523,o),
+(255,491,cs),
+(255,402,o),
+(228,352,o),
+(179,352,cs),
+(130,352,o),
+(100,402,o),
+(100,501,cs),
+(100,598,o),
+(141,671,o),
+(250,671,cs),
+(365,671,o),
+(428,579,o),
+(428,402,cs),
+(428,156,o),
+(312,59,o),
+(123,59,cs),
+(58,59,l),
+(58,0,l)
+);
+}
+);
+width = 549;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1616;
+unicode = 5654;
+},
+{
+color = 9;
+glyphname = "jeCarrier-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(485,-13,o),
+(540,87,o),
+(540,312,cs),
+(540,587,o),
+(452,727,o),
+(317,727,cs),
+(181,727,o),
+(113,604,o),
+(109,386,c),
+(128,391,l),
+(128,714,l),
+(65,714,l),
+(65,0,l),
+(128,0,l),
+(128,294,ls),
+(128,558,o),
+(193,667,o),
+(307,667,cs),
+(412,667,o),
+(480,559,o),
+(480,312,cs),
+(480,113,o),
+(449,40,o),
+(387,40,cs),
+(338,40,o),
+(311,88,o),
+(311,188,cs),
+(311,288,o),
+(336,336,o),
+(395,336,cs),
+(409,336,o),
+(418,333,o),
+(425,330,c),
+(425,380,l),
+(416,385,o),
+(400,388,o),
+(388,388,cs),
+(304,388,o),
+(257,315,o),
+(257,190,cs),
+(257,63,o),
+(304,-13,o),
+(388,-13,cs)
+);
+}
+);
+width = 601;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "te-canadian";
+note = uni1617;
+unicode = 5655;
+},
+{
+color = 9;
+glyphname = "jeeCarrier-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(485,-13,o),
+(540,89,o),
+(540,312,cs),
+(540,587,o),
+(452,727,o),
+(317,727,cs),
+(210,727,o),
+(145,651,o),
+(120,513,c),
+(128,507,l),
+(128,714,l),
+(65,714,l),
+(65,0,l),
+(128,0,l),
+(128,294,ls),
+(128,558,o),
+(193,667,o),
+(307,667,cs),
+(412,667,o),
+(480,559,o),
+(480,312,cs),
+(480,117,o),
+(446,40,o),
+(378,40,cs),
+(324,40,o),
+(292,92,o),
+(292,191,cs),
+(292,279,o),
+(314,329,o),
+(355,341,c),
+(355,246,l),
+(391,246,l),
+(391,465,l),
+(355,465,l),
+(355,379,l),
+(297,365,o),
+(257,302,o),
+(257,188,cs),
+(257,62,o),
+(304,-13,o),
+(388,-13,cs)
+);
+}
+);
+width = 601;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1618;
+unicode = 5656;
+},
+{
+color = 9;
+glyphname = "jiCarrier-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(485,-13,o),
+(540,89,o),
+(540,312,cs),
+(540,587,o),
+(452,727,o),
+(317,727,cs),
+(210,727,o),
+(145,651,o),
+(120,514,c),
+(128,508,l),
+(128,714,l),
+(65,714,l),
+(65,0,l),
+(128,0,l),
+(128,294,ls),
+(128,558,o),
+(193,667,o),
+(307,667,cs),
+(412,667,o),
+(480,559,o),
+(480,312,cs),
+(480,117,o),
+(446,40,o),
+(378,40,cs),
+(324,40,o),
+(292,92,o),
+(292,191,cs),
+(292,260,o),
+(306,301,o),
+(332,321,c),
+(339,307,o),
+(353,297,o),
+(371,297,cs),
+(401,297,o),
+(426,323,o),
+(426,355,cs),
+(426,386,o),
+(401,412,o),
+(371,412,cs),
+(336,412,o),
+(315,380,o),
+(318,353,c),
+(280,329,o),
+(257,274,o),
+(257,188,cs),
+(257,62,o),
+(304,-13,o),
+(388,-13,cs)
+);
+}
+);
+width = 601;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1619;
+unicode = 5657;
+},
+{
+color = 9;
+glyphname = "jiSayisi-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(452,-13,o),
+(540,127,o),
+(540,402,cs),
+(540,627,o),
+(485,727,o),
+(388,727,cs),
+(304,727,o),
+(257,651,o),
+(257,524,cs),
+(257,399,o),
+(304,326,o),
+(388,326,cs),
+(400,326,o),
+(416,329,o),
+(425,334,c),
+(425,384,l),
+(418,381,o),
+(409,378,o),
+(395,378,cs),
+(336,378,o),
+(311,426,o),
+(311,526,cs),
+(311,626,o),
+(338,674,o),
+(387,674,cs),
+(449,674,o),
+(480,601,o),
+(480,402,cs),
+(480,155,o),
+(412,47,o),
+(307,47,cs),
+(193,47,o),
+(128,156,o),
+(128,420,cs),
+(128,714,l),
+(65,714,l),
+(65,0,l),
+(128,0,l),
+(128,323,l),
+(109,328,l),
+(113,110,o),
+(181,-13,o),
+(317,-13,cs)
+);
+}
+);
+width = 601;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161A;
+unicode = 5658;
+},
+{
+color = 9;
+glyphname = "jaCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (294,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(420,-13,o),
+(489,110,o),
+(492,328,c),
+(474,323,l),
+(474,0,l),
+(537,0,l),
+(537,714,l),
+(473,714,l),
+(473,420,ls),
+(473,156,o),
+(409,47,o),
+(294,47,cs),
+(189,47,o),
+(122,155,o),
+(122,402,cs),
+(122,601,o),
+(153,674,o),
+(215,674,cs),
+(263,674,o),
+(291,626,o),
+(291,526,cs),
+(291,426,o),
+(265,378,o),
+(207,378,cs),
+(193,378,o),
+(184,381,o),
+(176,384,c),
+(176,334,l),
+(186,329,o),
+(202,326,o),
+(214,326,cs),
+(298,326,o),
+(345,399,o),
+(345,524,cs),
+(345,651,o),
+(298,727,o),
+(214,727,cs),
+(117,727,o),
+(61,627,o),
+(61,402,cs),
+(61,127,o),
+(150,-13,o),
+(285,-13,cs)
+);
+}
+);
+width = 602;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni161B;
+unicode = 5659;
+},
+{
+color = 9;
+glyphname = "jjuCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(434,-13,o),
+(498,89,o),
+(498,215,cs),
+(498,342,o),
+(447,415,o),
+(366,415,cs),
+(284,415,o),
+(239,343,o),
+(239,228,cs),
+(239,196,o),
+(241,175,o),
+(246,150,c),
+(294,150,l),
+(291,170,o),
+(289,192,o),
+(289,223,cs),
+(289,312,o),
+(315,362,o),
+(365,362,cs),
+(412,362,o),
+(443,309,o),
+(443,215,cs),
+(443,114,o),
+(402,42,o),
+(297,42,cs),
+(187,42,o),
+(123,132,o),
+(123,322,cs),
+(123,548,o),
+(223,655,o),
+(397,655,cs),
+(486,655,l),
+(486,714,l),
+(396,714,ls),
+(300,714,o),
+(224,686,o),
+(169,633,c),
+(76,727,l),
+(34,686,l),
+(130,589,l),
+(83,526,o),
+(60,436,o),
+(60,324,cs),
+(60,106,o),
+(154,-13,o),
+(294,-13,cs)
+);
+}
+);
+width = 543;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni161C;
+unicode = 5660;
+},
+{
+color = 9;
+glyphname = "jjoCarrier-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(510,28,l),
+(413,125,l),
+(460,188,o),
+(483,278,o),
+(483,390,cs),
+(483,608,o),
+(390,727,o),
+(250,727,cs),
+(109,727,o),
+(45,625,o),
+(45,499,cs),
+(45,372,o),
+(96,299,o),
+(178,299,cs),
+(260,299,o),
+(304,371,o),
+(304,486,cs),
+(304,518,o),
+(302,539,o),
+(298,564,c),
+(249,564,l),
+(252,544,o),
+(255,522,o),
+(255,491,cs),
+(255,402,o),
+(228,352,o),
+(179,352,cs),
+(132,352,o),
+(100,405,o),
+(100,499,cs),
+(100,600,o),
+(142,672,o),
+(246,672,cs),
+(357,672,o),
+(420,582,o),
+(420,392,cs),
+(420,166,o),
+(320,59,o),
+(146,59,cs),
+(58,59,l),
+(58,0,l),
+(147,0,ls),
+(243,0,o),
+(319,28,o),
+(375,81,c),
+(468,-13,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|jjuCarrier-canadian";
+note = uni161D;
+unicode = 5661;
+},
+{
+color = 9;
+glyphname = "jjeCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(487,-13,o),
+(543,87,o),
+(543,312,cs),
+(543,602,o),
+(461,727,o),
+(296,727,cs),
+(232,727,o),
+(178,702,o),
+(138,655,c),
+(64,727,l),
+(25,683,l),
+(106,606,l),
+(81,558,o),
+(67,495,o),
+(67,417,cs),
+(67,0,l),
+(130,0,l),
+(130,420,ls),
+(130,584,o),
+(191,667,o),
+(296,667,cs),
+(420,667,o),
+(482,577,o),
+(482,311,cs),
+(482,113,o),
+(451,40,o),
+(389,40,cs),
+(339,40,o),
+(313,88,o),
+(313,188,cs),
+(313,288,o),
+(338,336,o),
+(394,336,cs),
+(411,336,o),
+(420,333,o),
+(428,330,c),
+(428,380,l),
+(418,385,o),
+(402,388,o),
+(387,388,cs),
+(306,388,o),
+(259,315,o),
+(259,190,cs),
+(259,63,o),
+(306,-13,o),
+(390,-13,cs)
+);
+}
+);
+width = 604;
+}
+);
+metricRight = "jeCarrier-canadian";
+note = uni161E;
+unicode = 5662;
+},
+{
+color = 9;
+glyphname = "jjeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(487,-13,o),
+(543,89,o),
+(543,312,cs),
+(543,602,o),
+(461,727,o),
+(296,727,cs),
+(232,727,o),
+(178,702,o),
+(138,655,c),
+(64,727,l),
+(25,683,l),
+(106,606,l),
+(81,558,o),
+(67,495,o),
+(67,417,cs),
+(67,0,l),
+(130,0,l),
+(130,420,ls),
+(130,584,o),
+(191,667,o),
+(295,667,cs),
+(420,667,o),
+(482,577,o),
+(482,311,cs),
+(482,116,o),
+(448,40,o),
+(381,40,cs),
+(325,40,o),
+(294,92,o),
+(294,191,cs),
+(294,285,o),
+(317,329,o),
+(358,341,c),
+(358,246,l),
+(394,246,l),
+(394,465,l),
+(358,465,l),
+(358,379,l),
+(301,368,o),
+(259,303,o),
+(259,188,cs),
+(259,62,o),
+(306,-13,o),
+(390,-13,cs)
+);
+}
+);
+width = 604;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161F;
+unicode = 5663;
+},
+{
+color = 9;
+glyphname = "jjiCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(487,-13,o),
+(543,89,o),
+(543,312,cs),
+(543,602,o),
+(461,727,o),
+(296,727,cs),
+(232,727,o),
+(178,702,o),
+(138,655,c),
+(64,727,l),
+(25,683,l),
+(106,606,l),
+(81,558,o),
+(67,495,o),
+(67,417,cs),
+(67,0,l),
+(130,0,l),
+(130,420,ls),
+(130,584,o),
+(191,667,o),
+(295,667,cs),
+(420,667,o),
+(482,577,o),
+(482,311,cs),
+(482,116,o),
+(448,40,o),
+(381,40,cs),
+(325,40,o),
+(294,92,o),
+(294,191,cs),
+(294,263,o),
+(308,302,o),
+(334,320,c),
+(340,307,o),
+(356,297,o),
+(372,297,cs),
+(403,297,o),
+(428,323,o),
+(428,355,cs),
+(428,386,o),
+(403,412,o),
+(372,412,cs),
+(339,412,o),
+(317,381,o),
+(320,353,c),
+(283,330,o),
+(259,275,o),
+(259,188,cs),
+(259,62,o),
+(306,-13,o),
+(390,-13,cs)
+);
+}
+);
+width = 604;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1620;
+unicode = 5664;
+},
+{
+color = 9;
+glyphname = "jjaCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(372,-13,o),
+(426,12,o),
+(466,59,c),
+(540,-13,l),
+(579,31,l),
+(498,108,l),
+(523,156,o),
+(537,219,o),
+(537,297,cs),
+(537,714,l),
+(473,714,l),
+(473,294,ls),
+(473,130,o),
+(413,47,o),
+(308,47,cs),
+(184,47,o),
+(122,137,o),
+(122,403,cs),
+(122,601,o),
+(153,674,o),
+(215,674,cs),
+(265,674,o),
+(291,626,o),
+(291,526,cs),
+(291,426,o),
+(265,378,o),
+(210,378,cs),
+(193,378,o),
+(184,381,o),
+(176,384,c),
+(176,334,l),
+(186,329,o),
+(202,326,o),
+(216,326,cs),
+(298,326,o),
+(345,399,o),
+(345,524,cs),
+(345,651,o),
+(298,727,o),
+(214,727,cs),
+(117,727,o),
+(61,627,o),
+(61,402,cs),
+(61,112,o),
+(143,-13,o),
+(308,-13,cs)
+);
+}
+);
+width = 604;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "=|jjeCarrier-canadian";
+note = uni1621;
+unicode = 5665;
+},
+{
+color = 9;
+glyphname = "luCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(410,-13,o),
+(496,64,o),
+(496,251,cs),
+(496,714,l),
+(433,714,l),
+(433,251,ls),
+(433,99,o),
+(370,46,o),
+(285,46,cs),
+(162,46,o),
+(119,156,o),
+(119,335,cs),
+(119,544,o),
+(171,644,o),
+(299,662,c),
+(299,714,l),
+(49,714,l),
+(49,661,l),
+(219,661,l),
+(256,678,l),
+(133,662,o),
+(56,560,o),
+(56,328,cs),
+(56,117,o),
+(124,-13,o),
+(284,-13,cs)
+);
+}
+);
+width = 557;
+}
+);
+metricRight = "te-canadian";
+note = uni1622;
+unicode = 5666;
+},
+{
+color = 9;
+glyphname = "loCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(125,0,l),
+(125,463,ls),
+(125,615,o),
+(187,668,o),
+(273,668,cs),
+(396,668,o),
+(438,558,o),
+(438,379,cs),
+(438,170,o),
+(386,70,o),
+(258,52,c),
+(258,0,l),
+(508,0,l),
+(508,53,l),
+(338,53,l),
+(302,36,l),
+(425,52,o),
+(502,154,o),
+(502,386,cs),
+(502,597,o),
+(434,727,o),
+(273,727,cs),
+(147,727,o),
+(61,650,o),
+(61,463,cs),
+(61,0,l)
+);
+}
+);
+width = 557;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|luCarrier-canadian";
+note = uni1623;
+unicode = 5667;
+},
+{
+color = 9;
+glyphname = "leCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (269,357);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,0,ls),
+(397,0,o),
+(489,125,o),
+(489,369,cs),
+(489,611,o),
+(398,727,o),
+(284,727,cs),
+(179,727,o),
+(127,640,o),
+(111,529,c),
+(119,531,l),
+(119,714,l),
+(62,714,l),
+(62,399,l),
+(116,399,l),
+(117,556,o),
+(168,667,o),
+(270,667,cs),
+(363,667,o),
+(425,576,o),
+(425,369,cs),
+(425,161,o),
+(361,59,o),
+(201,59,cs),
+(62,59,l),
+(62,0,l)
+);
+}
+);
+width = 541;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1624;
+unicode = 5668;
+},
+{
+color = 9;
+glyphname = "leeCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+ref = "leCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (230,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 541;
+}
+);
+metricLeft = "leCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1625;
+unicode = 5669;
+},
+{
+color = 9;
+glyphname = "liCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "leCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (209,0);
+ref = dot_middle;
+}
+);
+width = 541;
+}
+);
+note = uni1626;
+unicode = 5670;
+},
+{
+color = 9;
+glyphname = "laCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(479,0,l),
+(479,59,l),
+(340,59,ls),
+(180,59,o),
+(116,161,o),
+(116,369,cs),
+(116,576,o),
+(178,667,o),
+(271,667,cs),
+(373,667,o),
+(424,556,o),
+(425,399,c),
+(479,399,l),
+(479,714,l),
+(422,714,l),
+(422,531,l),
+(430,529,l),
+(413,640,o),
+(362,727,o),
+(257,727,cs),
+(143,727,o),
+(52,611,o),
+(52,369,cs),
+(52,125,o),
+(144,0,o),
+(341,0,cs)
+);
+}
+);
+width = 541;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|leCarrier-canadian";
+note = uni1627;
+unicode = 5671;
+},
+{
+color = 1;
+glyphname = "dluCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(434,-13,o),
+(502,117,o),
+(502,328,cs),
+(502,540,o),
+(438,643,o),
+(336,670,c),
+(323,664,l),
+(499,664,l),
+(499,578,l),
+(547,578,l),
+(547,800,l),
+(499,800,l),
+(499,714,l),
+(258,714,l),
+(258,662,l),
+(386,644,o),
+(438,544,o),
+(438,335,cs),
+(438,156,o),
+(396,46,o),
+(273,46,cs),
+(187,46,o),
+(125,99,o),
+(125,250,cs),
+(125,714,l),
+(61,714,l),
+(61,251,ls),
+(61,64,o),
+(147,-13,o),
+(273,-13,cs)
+);
+}
+);
+width = 581;
+}
+);
+metricLeft = "te-canadian";
+note = uni1628;
+unicode = 5672;
+},
+{
+color = 9;
+glyphname = "dloCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(547,-86,l),
+(547,136,l),
+(499,136,l),
+(499,50,l),
+(323,50,l),
+(336,44,l),
+(438,71,o),
+(502,174,o),
+(502,386,cs),
+(502,597,o),
+(434,727,o),
+(273,727,cs),
+(147,727,o),
+(61,650,o),
+(61,463,cs),
+(61,0,l),
+(125,0,l),
+(125,464,ls),
+(125,615,o),
+(187,668,o),
+(273,668,cs),
+(396,668,o),
+(438,558,o),
+(438,379,cs),
+(438,170,o),
+(386,70,o),
+(258,52,c),
+(258,0,l),
+(499,0,l),
+(499,-86,l)
+);
+}
+);
+width = 581;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "dluCarrier-canadian";
+note = uni1629;
+unicode = 5673;
+},
+{
+color = 9;
+glyphname = "dleCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (281,357);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(211,0,ls),
+(408,0,o),
+(500,125,o),
+(500,369,cs),
+(500,611,o),
+(409,727,o),
+(295,727,cs),
+(196,727,o),
+(136,649,o),
+(115,528,c),
+(121,525,l),
+(121,729,l),
+(184,729,l),
+(184,776,l),
+(11,776,l),
+(11,729,l),
+(73,729,l),
+(73,399,l),
+(127,399,l),
+(128,556,o),
+(179,667,o),
+(281,667,cs),
+(373,667,o),
+(436,576,o),
+(436,369,cs),
+(436,161,o),
+(372,59,o),
+(212,59,cs),
+(72.998,58.992,l),
+(72.998,0,l)
+);
+}
+);
+width = 552;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni162A;
+unicode = 5674;
+},
+{
+color = 9;
+glyphname = "dleeCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (242,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 552;
+}
+);
+note = uni162B;
+unicode = 5675;
+},
+{
+color = 9;
+glyphname = "dliCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (220,0);
+ref = dot_middle;
+}
+);
+width = 552;
+}
+);
+note = uni162C;
+unicode = 5676;
+},
+{
+color = 9;
+glyphname = "dlaCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(479,0,l),
+(479,59,l),
+(340,59,ls),
+(180,59,o),
+(116,161,o),
+(116,369,cs),
+(116,576,o),
+(179,667,o),
+(271,667,cs),
+(373,667,o),
+(424,556,o),
+(425,399,c),
+(479,399,l),
+(479,729,l),
+(541,729,l),
+(541,776,l),
+(368,776,l),
+(368,729,l),
+(431,729,l),
+(431,525,l),
+(437,528,l),
+(416,649,o),
+(356,727,o),
+(257,727,cs),
+(143,727,o),
+(52,611,o),
+(52,369,cs),
+(52,125,o),
+(144,0,o),
+(341,0,cs)
+);
+}
+);
+width = 552;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni162D;
+unicode = 5677;
+},
+{
+color = 9;
+glyphname = "lhuCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(448,-13,o),
+(524,108,o),
+(524,327,cs),
+(524,523,o),
+(465,643,o),
+(357,682,c),
+(379,661,l),
+(531,661,l),
+(531,714,l),
+(336,714,l),
+(336,662,l),
+(421,623,o),
+(461,510,o),
+(461,338,cs),
+(461,138,o),
+(410,46,o),
+(290,46,cs),
+(170,46,o),
+(120,138,o),
+(120,338,cs),
+(120,511,o),
+(160,624,o),
+(245,662,c),
+(245,714,l),
+(49,714,l),
+(49,661,l),
+(201,661,l),
+(223,682,l),
+(115,643,o),
+(56,525,o),
+(56,327,cs),
+(56,108,o),
+(132,-13,o),
+(290,-13,cs)
+);
+}
+);
+width = 580;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162E;
+unicode = 5678;
+},
+{
+color = 9;
+glyphname = "lhoCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(244,0,l),
+(244,52,l),
+(159,91,o),
+(119,204,o),
+(119,376,cs),
+(119,576,o),
+(170,668,o),
+(290,668,cs),
+(410,668,o),
+(460,576,o),
+(460,376,cs),
+(460,203,o),
+(420,90,o),
+(335,52,c),
+(335,0,l),
+(531,0,l),
+(531,53,l),
+(379,53,l),
+(356,32,l),
+(465,71,o),
+(524,189,o),
+(524,387,cs),
+(524,606,o),
+(448,727,o),
+(290,727,cs),
+(132,727,o),
+(56,606,o),
+(56,387,cs),
+(56,191,o),
+(115,71,o),
+(223,32,c),
+(201,53,l),
+(49,53,l),
+(49,0,l)
+);
+}
+);
+width = 580;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162F;
+unicode = 5679;
+},
+{
+color = 9;
+glyphname = "lheCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (283,357);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(417,-13,o),
+(511,103,o),
+(511,357,cs),
+(511,611,o),
+(417,727,o),
+(297,727,cs),
+(187,727,o),
+(131,645,o),
+(116,548,c),
+(121,547,l),
+(121,714,l),
+(65,714,l),
+(65,434,l),
+(118,434,l),
+(124,564,o),
+(169,667,o),
+(283,667,cs),
+(381,667,o),
+(447,576,o),
+(447,357,cs),
+(447,138,o),
+(381,47,o),
+(283,47,cs),
+(169,47,o),
+(124,150,o),
+(118,280,c),
+(65,280,l),
+(65,0,l),
+(121,0,l),
+(121,167,l),
+(116,166,l),
+(131,69,o),
+(187,-13,o),
+(297,-13,cs)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1630;
+unicode = 5680;
+},
+{
+color = 9;
+glyphname = "lheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (244,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 563;
+}
+);
+note = uni1631;
+unicode = 5681;
+},
+{
+color = 9;
+glyphname = "lhiCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (223,0);
+ref = dot_middle;
+}
+);
+width = 563;
+}
+);
+note = uni1632;
+unicode = 5682;
+},
+{
+color = 9;
+glyphname = "lhaCarrier-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(376,-13,o),
+(432,69,o),
+(447,166,c),
+(442,167,l),
+(442,0,l),
+(499,0,l),
+(499,280,l),
+(445,280,l),
+(439,150,o),
+(394,47,o),
+(280,47,cs),
+(182,47,o),
+(116,138,o),
+(116,357,cs),
+(116,576,o),
+(182,667,o),
+(280,667,cs),
+(394,667,o),
+(439,564,o),
+(445,434,c),
+(499,434,l),
+(499,714,l),
+(442,714,l),
+(442,547,l),
+(447,548,l),
+(432,645,o),
+(376,727,o),
+(266,727,cs),
+(146,727,o),
+(52,611,o),
+(52,357,cs),
+(52,103,o),
+(146,-13,o),
+(266,-13,cs)
+);
+}
+);
+width = 564;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1633;
+unicode = 5683;
+},
+{
+color = 9;
+glyphname = "tlhuCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(448,-13,o),
+(524,108,o),
+(524,327,cs),
+(524,505,o),
+(477,623,o),
+(386,672,c),
+(371,664,l),
+(521,664,l),
+(521,578,l),
+(569,578,l),
+(569,800,l),
+(521,800,l),
+(521.003,714,l),
+(336,714,l),
+(336,662,l),
+(421,623,o),
+(462,510,o),
+(462,338,cs),
+(462,138,o),
+(410,46,o),
+(290,46,cs),
+(170,46,o),
+(119,138,o),
+(119,338,cs),
+(119,511,o),
+(159,624,o),
+(245,662,c),
+(245,714,l),
+(49,714,l),
+(49,661,l),
+(207,661,l),
+(190,669,l),
+(101,619,o),
+(56,504,o),
+(56,327,cs),
+(56,108,o),
+(132,-13,o),
+(290,-13,cs)
+);
+}
+);
+width = 602;
+}
+);
+metricLeft = "lhuCarrier-canadian";
+note = uni1634;
+unicode = 5684;
+},
+{
+color = 9;
+glyphname = "tlhoCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(81,-86,l),
+(81,0,l),
+(267,0,l),
+(267,52,l),
+(181,91,o),
+(141,204,o),
+(141,376,cs),
+(141,576,o),
+(192,668,o),
+(313,668,cs),
+(433,668,o),
+(483,576,o),
+(483,376,cs),
+(483,203,o),
+(443,90,o),
+(358,52,c),
+(358,0,l),
+(553,0,l),
+(553,53,l),
+(396,53,l),
+(412,45,l),
+(501,95,o),
+(546,210,o),
+(546,387,cs),
+(546,606,o),
+(470,727,o),
+(313,727,cs),
+(155,727,o),
+(79,606,o),
+(79,387,cs),
+(79,209,o),
+(126,91,o),
+(216,42,c),
+(232,50,l),
+(81,50,l),
+(81,136,l),
+(33,136,l),
+(33,-86,l)
+);
+}
+);
+width = 602;
+}
+);
+metricLeft = "=|tlhuCarrier-canadian";
+metricRight = "lhuCarrier-canadian";
+note = uni1635;
+unicode = 5685;
+},
+{
+color = 9;
+glyphname = "tlheCarrier-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (292,357);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(425,-13,o),
+(519,103,o),
+(519,357,cs),
+(519,611,o),
+(425,727,o),
+(305,727,cs),
+(199,727,o),
+(136,654,o),
+(115,544,c),
+(121,540,l),
+(121,729,l),
+(183,729,l),
+(183,776,l),
+(11,776,l),
+(11,729,l),
+(73,729,l),
+(73,434,l),
+(127,434,l),
+(133,564,o),
+(178,667,o),
+(291,667,cs),
+(390,667,o),
+(456,579,o),
+(456,357,cs),
+(456,138,o),
+(390,47,o),
+(291,47,cs),
+(178,47,o),
+(133,150,o),
+(127,280,c),
+(73,280,l),
+(72.998,0,l),
+(130,0,l),
+(130,168,l),
+(125,160,l),
+(143,64,o),
+(198,-13,o),
+(305,-13,cs)
+);
+}
+);
+width = 571;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1636;
+unicode = 5686;
+},
+{
+color = 9;
+glyphname = "tlheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (253,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 572;
+}
+);
+note = uni1637;
+unicode = 5687;
+},
+{
+color = 9;
+glyphname = "tlhiCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (231,0);
+ref = dot_middle;
+}
+);
+width = 572;
+}
+);
+note = uni1638;
+unicode = 5688;
+},
+{
+color = 9;
+glyphname = "tlhaCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(374,-13,o),
+(429,64,o),
+(447,160,c),
+(442,168,l),
+(442,0,l),
+(499,0,l),
+(499,280,l),
+(445,280,l),
+(439,150,o),
+(394,47,o),
+(280,47,cs),
+(182,47,o),
+(116,138,o),
+(116,357,cs),
+(116,579,o),
+(182,667,o),
+(280,667,cs),
+(394,667,o),
+(439,564,o),
+(445,434,c),
+(499,434,l),
+(499,729,l),
+(561,729,l),
+(561,776,l),
+(388,776,l),
+(388,729,l),
+(450,729,l),
+(450,541,l),
+(457,544,l),
+(435,654,o),
+(372,727,o),
+(266,727,cs),
+(146,727,o),
+(52,611,o),
+(52,357,cs),
+(52,103,o),
+(146,-13,o),
+(266,-13,cs)
+);
+}
+);
+width = 572;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni1639;
+unicode = 5689;
+},
+{
+color = 9;
+glyphname = "tluCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(277,-13,o),
+(325,26,o),
+(343,113,c),
+(327,113,l),
+(344,26,o),
+(392,-13,o),
+(451,-13,cs),
+(549,-13,o),
+(614,61,o),
+(614,294,cs),
+(614,528,o),
+(563,633,o),
+(469,671,c),
+(454,664,l),
+(611,664,l),
+(611,578,l),
+(659,578,l),
+(659,800,l),
+(611,800,l),
+(611,714,l),
+(381,714,l),
+(381,662,l),
+(500,657,o),
+(550,548,o),
+(550,296,cs),
+(550,89,o),
+(507,46,o),
+(449,46,cs),
+(399,46,o),
+(365,91,o),
+(365,196,cs),
+(365,309,l),
+(305,309,l),
+(305,196,ls),
+(305,91,o),
+(270,46,o),
+(220,46,cs),
+(162,46,o),
+(120,89,o),
+(120,296,cs),
+(120,548,o),
+(170,657,o),
+(289,662,c),
+(289,714,l),
+(50,714,l),
+(50,661,l),
+(213,661,l),
+(197,669,l),
+(106,629,o),
+(56,526,o),
+(56,294,cs),
+(56,61,o),
+(120,-13,o),
+(218,-13,cs)
+);
+}
+);
+width = 692;
+}
+);
+metricRight = "tlhuCarrier-canadian";
+note = uni163A;
+unicode = 5690;
+},
+{
+color = 1;
+glyphname = "tloCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(659,-86,l),
+(659,136,l),
+(611,136,l),
+(611,50,l),
+(454,50,l),
+(469,43,l),
+(563,81,o),
+(614,186,o),
+(614,420,cs),
+(614,653,o),
+(549,727,o),
+(451,727,cs),
+(392,727,o),
+(344,688,o),
+(327,601,c),
+(343,601,l),
+(325,688,o),
+(277,727,o),
+(218,727,cs),
+(120,727,o),
+(56,653,o),
+(56,420,cs),
+(56,188,o),
+(106,85,o),
+(197,45,c),
+(213,53,l),
+(50,53,l),
+(50,0,l),
+(289,0,l),
+(289,52,l),
+(170,57,o),
+(120,166,o),
+(120,418,cs),
+(120,625,o),
+(162,668,o),
+(220,668,cs),
+(270,668,o),
+(305,623,o),
+(305,518,cs),
+(305,405,l),
+(365,405,l),
+(365,518,ls),
+(365,623,o),
+(399,668,o),
+(449,668,cs),
+(507,668,o),
+(550,625,o),
+(550,418,cs),
+(550,166,o),
+(500,57,o),
+(381,52,c),
+(381,0,l),
+(611,0,l),
+(611,-86,l)
+);
+}
+);
+width = 692;
+}
+);
+metricLeft = "tluCarrier-canadian";
+metricRight = "tlhuCarrier-canadian";
+note = uni163B;
+unicode = 5691;
+},
+{
+color = 9;
+glyphname = "tleCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (228,357);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(436,-13,o),
+(513,59,o),
+(513,185,cs),
+(513,279,o),
+(469,346,o),
+(391,362,c),
+(391,352,l),
+(469,368,o),
+(513,435,o),
+(513,529,cs),
+(513,655,o),
+(436,727,o),
+(321,727,cs),
+(205,727,o),
+(134,655,o),
+(115,550,c),
+(121,544,l),
+(121,729,l),
+(184,729,l),
+(184,776,l),
+(11,776,l),
+(11,729,l),
+(73,729,l),
+(73,434,l),
+(125,434,l),
+(127,569,o),
+(173,669,o),
+(306,669,cs),
+(397,669,o),
+(451,620,o),
+(451,521,cs),
+(451,434,o),
+(409,384,o),
+(339,384,cs),
+(305,384,l),
+(305,330,l),
+(339,330,ls),
+(408,330,o),
+(451,280,o),
+(451,194,cs),
+(451,95,o),
+(397,45,o),
+(305,45,cs),
+(173,45,o),
+(127,145,o),
+(125,280,c),
+(73,280,l),
+(72.998,0,l),
+(130,0,l),
+(130,159,l),
+(121,151,l),
+(143,55,o),
+(209,-13,o),
+(321,-13,cs)
+);
+}
+);
+width = 575;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni163C;
+unicode = 5692;
+},
+{
+color = 9;
+glyphname = "tleeCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (189,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 575;
+}
+);
+note = uni163D;
+unicode = 5693;
+},
+{
+color = 9;
+glyphname = "tliCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (172,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 575;
+}
+);
+note = uni163E;
+unicode = 5694;
+},
+{
+color = 9;
+glyphname = "tlaCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(366,-13,o),
+(432,55,o),
+(454,151,c),
+(446,159,l),
+(446,0,l),
+(502,0,l),
+(502,280,l),
+(450,280,l),
+(449,145,o),
+(402,45,o),
+(270,45,cs),
+(178,45,o),
+(124,95,o),
+(124,194,cs),
+(124,280,o),
+(167,330,o),
+(237,330,cs),
+(268,330,l),
+(268,384,l),
+(237,384,ls),
+(166,384,o),
+(124,434,o),
+(124,521,cs),
+(124,620,o),
+(179,669,o),
+(269,669,cs),
+(402,669,o),
+(449,569,o),
+(450,434,c),
+(502,434,l),
+(502,729,l),
+(564,729,l),
+(564,776,l),
+(392,776,l),
+(392,729,l),
+(454,729,l),
+(454,544,l),
+(460,550,l),
+(441,655,o),
+(370,727,o),
+(254,727,cs),
+(139,727,o),
+(62,655,o),
+(62,529,cs),
+(62,435,o),
+(106,368,o),
+(184,352,c),
+(184,362,l),
+(106,346,o),
+(62,279,o),
+(62,185,cs),
+(62,59,o),
+(139,-13,o),
+(254,-13,cs)
+);
+}
+);
+width = 575;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni163F;
+unicode = 5695;
+},
+{
+color = 9;
+glyphname = "zuCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(432,-13,o),
+(522,79,o),
+(522,236,cs),
+(522,357,o),
+(446,514,o),
+(446,596,cs),
+(446,626,o),
+(458,659,o),
+(508,659,cs),
+(530,659,l),
+(530,714,l),
+(493,714,ls),
+(416,714,o),
+(385,668,o),
+(385,603,cs),
+(385,512,o),
+(459,361,o),
+(459,245,cs),
+(459,117,o),
+(398,47,o),
+(288,47,cs),
+(178,47,o),
+(117,117,o),
+(117,245,cs),
+(117,361,o),
+(192,512,o),
+(192,603,cs),
+(192,668,o),
+(161,714,o),
+(84,714,cs),
+(47,714,l),
+(47,659,l),
+(68,659,ls),
+(119,659,o),
+(131,625,o),
+(131,596,cs),
+(131,514,o),
+(54,357,o),
+(54,236,cs),
+(54,79,o),
+(144,-13,o),
+(288,-13,cs)
+);
+}
+);
+width = 577;
+}
+);
+metricRight = "=|";
+note = uni1640;
+unicode = 5696;
+},
+{
+color = 9;
+glyphname = "zoCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(84,0,ls),
+(161,0,o),
+(192,46,o),
+(192,111,cs),
+(192,202,o),
+(118,353,o),
+(118,469,cs),
+(118,597,o),
+(179,667,o),
+(289,667,cs),
+(399,667,o),
+(460,597,o),
+(460,469,cs),
+(460,353,o),
+(385,202,o),
+(385,111,cs),
+(385,46,o),
+(416,0,o),
+(493,0,cs),
+(530,0,l),
+(530,55,l),
+(509,55,ls),
+(458,55,o),
+(446,89,o),
+(446,118,cs),
+(446,200,o),
+(523,357,o),
+(523,478,cs),
+(523,635,o),
+(433,727,o),
+(289,727,cs),
+(145,727,o),
+(55,635,o),
+(55,478,cs),
+(55,357,o),
+(131,200,o),
+(131,118,cs),
+(131,88,o),
+(119,55,o),
+(69,55,cs),
+(47,55,l),
+(47,0,l)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1641;
+unicode = 5697;
+},
+{
+color = 9;
+glyphname = "zeCarrier-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (284,357);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(424,-13,o),
+(495,94,o),
+(495,357,cs),
+(495,620,o),
+(424,727,o),
+(330,727,cs),
+(252,727,o),
+(179,620,o),
+(142,620,cs),
+(123,620,o),
+(107,633,o),
+(107,679,cs),
+(107,714,l),
+(49,714,l),
+(49,661,ls),
+(49,596,o),
+(81,563,o),
+(127,563,cs),
+(189,563,o),
+(254,667,o),
+(317,667,cs),
+(380,667,o),
+(432,589,o),
+(432,357,cs),
+(432,125,o),
+(380,47,o),
+(317,47,cs),
+(254,47,o),
+(189,151,o),
+(127,151,cs),
+(81,151,o),
+(49,118,o),
+(49,53,cs),
+(49,0,l),
+(107,0,l),
+(107,35,ls),
+(107,81,o),
+(123,94,o),
+(142,94,cs),
+(179,94,o),
+(252,-13,o),
+(330,-13,cs)
+);
+}
+);
+width = 547;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1642;
+unicode = 5698;
+},
+{
+color = 9;
+glyphname = "zeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (245,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 548;
+}
+);
+note = uni1643;
+unicode = 5699;
+},
+{
+color = 9;
+glyphname = "ziCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (224,0);
+ref = dot_middle;
+}
+);
+width = 548;
+}
+);
+note = uni1644;
+unicode = 5700;
+},
+{
+color = 9;
+glyphname = "zaCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(296,-13,o),
+(369,94,o),
+(406,94,cs),
+(425,94,o),
+(441,81,o),
+(441,35,cs),
+(441,0,l),
+(499,0,l),
+(499,53,ls),
+(499,118,o),
+(466,151,o),
+(421,151,cs),
+(358,151,o),
+(294,47,o),
+(231,47,cs),
+(168,47,o),
+(116,125,o),
+(116,357,cs),
+(116,589,o),
+(168,667,o),
+(231,667,cs),
+(294,667,o),
+(358,563,o),
+(421,563,cs),
+(466,563,o),
+(499,596,o),
+(499,661,cs),
+(499,714,l),
+(441,714,l),
+(441,679,ls),
+(441,633,o),
+(425,620,o),
+(406,620,cs),
+(369,620,o),
+(296,727,o),
+(217,727,cs),
+(124,727,o),
+(52,620,o),
+(52,357,cs),
+(52,94,o),
+(124,-13,o),
+(217,-13,cs)
+);
+}
+);
+width = 548;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|zeCarrier-canadian";
+note = uni1645;
+unicode = 5701;
+},
+{
+color = 6;
+glyphname = "zCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(283,189,l),
+(283,233,l),
+(99,233,l),
+(99,205,l),
+(280,521,l),
+(280,546,l),
+(52,546,l),
+(52,502,l),
+(234,502,l),
+(234,530,l),
+(52,214,l),
+(52,189,l)
+);
+}
+);
+width = 335;
+}
+);
+metricRight = "=|";
+note = uni1646;
+unicode = 5702;
+},
+{
+color = 6;
+glyphname = "initialzCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(144,189,l),
+(144,99,l),
+(189,99,l),
+(189,189,l),
+(283,189,l),
+(283,233,l),
+(86,233,l),
+(101,208,l),
+(280,521,l),
+(280,546,l),
+(189,546,l),
+(189,636,l),
+(144,636,l),
+(144,546,l),
+(52,546,l),
+(52,502,l),
+(246,502,l),
+(232,527,l),
+(52,214,l),
+(52,189,l)
+);
+}
+);
+width = 335;
+}
+);
+metricLeft = "zCarrier-canadian";
+metricRight = "zCarrier-canadian";
+note = uni1647;
+unicode = 5703;
+},
+{
+color = 9;
+glyphname = "dzuCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(432,-13,o),
+(522,79,o),
+(522,236,cs),
+(522,357,o),
+(446,514,o),
+(446,596,cs),
+(446,626,o),
+(458,659,o),
+(508,659,cs),
+(530,659,l),
+(530,714,l),
+(496,714,ls),
+(421,714,o),
+(388,668,o),
+(388,603,cs),
+(388,512,o),
+(459,364,o),
+(459,245,cs),
+(459,117,o),
+(398,47,o),
+(288,47,cs),
+(178,47,o),
+(117,117,o),
+(117,245,cs),
+(117,364,o),
+(189,512,o),
+(189,603,cs),
+(189,668,o),
+(156,714,o),
+(81,714,cs),
+(47,714,l),
+(47,659,l),
+(68,659,ls),
+(119,659,o),
+(131,625,o),
+(131,596,cs),
+(131,514,o),
+(54,357,o),
+(54,236,cs),
+(54,79,o),
+(144,-13,o),
+(288,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(304,507,l),
+(304,683,l),
+(356,683,l),
+(356.004,714,l),
+(221,714,l),
+(221,683,l),
+(273,683,l),
+(273,507,l)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1648;
+unicode = 5704;
+},
+{
+color = 9;
+glyphname = "dzoCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(81,0,ls),
+(156,0,o),
+(189,46,o),
+(189,111,cs),
+(189,202,o),
+(118,350,o),
+(118,469,cs),
+(118,597,o),
+(179,667,o),
+(289,667,cs),
+(399,667,o),
+(460,597,o),
+(460,469,cs),
+(460,350,o),
+(388,202,o),
+(388,111,cs),
+(388,46,o),
+(421,0,o),
+(496,0,cs),
+(530,0,l),
+(530,55,l),
+(509,55,ls),
+(458,55,o),
+(446,89,o),
+(446,118,cs),
+(446,200,o),
+(523,357,o),
+(523,478,cs),
+(523,635,o),
+(433,727,o),
+(289,727,cs),
+(145,727,o),
+(55,635,o),
+(55,478,cs),
+(55,357,o),
+(131,200,o),
+(131,118,cs),
+(131,88,o),
+(119,55,o),
+(69,55,cs),
+(47,55,l),
+(47,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(357,0,l),
+(357,31,l),
+(304,31,l),
+(304,207,l),
+(273,207,l),
+(273,31,l),
+(221,31,l),
+(221,0,l)
+);
+}
+);
+width = 577;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1649;
+unicode = 5705;
+},
+{
+color = 9;
+glyphname = "dzeCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (298,357);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(439,-13,o),
+(511,94,o),
+(511,357,cs),
+(511,620,o),
+(440,727,o),
+(346,727,cs),
+(267,727,o),
+(195,620,o),
+(157,620,cs),
+(138,620,o),
+(122,633,o),
+(122,679,cs),
+(122,714,l),
+(65,714,l),
+(65,661,ls),
+(65,596,o),
+(97,563,o),
+(142,563,cs),
+(205,563,o),
+(269,667,o),
+(333,667,cs),
+(395,667,o),
+(447,589,o),
+(447,357,cs),
+(447,125,o),
+(395,47,o),
+(333,47,cs),
+(269,47,o),
+(205,151,o),
+(142,151,cs),
+(97,151,o),
+(65,118,o),
+(65,53,cs),
+(65,0,l),
+(122,0,l),
+(122,35,ls),
+(122,79,o),
+(138,92,o),
+(157,92,cs),
+(195,92,o),
+(267,-13,o),
+(346,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(103,249,l),
+(103,337,l),
+(209,337,l),
+(209,377,l),
+(103,377,l),
+(103,465,l),
+(65,465,l),
+(65,249,l)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164A;
+unicode = 5706;
+},
+{
+color = 9;
+glyphname = "dzeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+ref = "dzeCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (259,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 563;
+}
+);
+metricLeft = "dzeCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164B;
+unicode = 5707;
+},
+{
+color = 9;
+glyphname = "dziCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "dzeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (238,0);
+ref = dot_middle;
+}
+);
+width = 563;
+}
+);
+note = uni164C;
+unicode = 5708;
+},
+{
+color = 9;
+glyphname = "dzaCarrier-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(296,-13,o),
+(369,92,o),
+(406,92,cs),
+(425,92,o),
+(441,79,o),
+(441,35,cs),
+(441,0,l),
+(499,0,l),
+(499,53,ls),
+(499,118,o),
+(466,151,o),
+(421,151,cs),
+(358,151,o),
+(294,47,o),
+(231,47,cs),
+(168,47,o),
+(116,125,o),
+(116,357,cs),
+(116,589,o),
+(168,667,o),
+(231,667,cs),
+(294,667,o),
+(358,563,o),
+(421,563,cs),
+(466,563,o),
+(499,596,o),
+(499,661,cs),
+(499,714,l),
+(441,714,l),
+(441,679,ls),
+(441,633,o),
+(425,620,o),
+(406,620,cs),
+(369,620,o),
+(296,727,o),
+(217,727,cs),
+(124,727,o),
+(52,620,o),
+(52,357,cs),
+(52,94,o),
+(124,-13,o),
+(217,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(499,249,l),
+(499,465,l),
+(460,465,l),
+(460,377,l),
+(355,377,l),
+(355,337,l),
+(460,337,l),
+(460,249,l)
+);
+}
+);
+width = 564;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dzeCarrier-canadian";
+note = uni164D;
+unicode = 5709;
+},
+{
+color = 9;
+glyphname = "suCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(278,-13,o),
+(326,40,o),
+(342,142,c),
+(324,142,l),
+(340,40,o),
+(388,-13,o),
+(464,-13,cs),
+(556,-13,o),
+(613,60,o),
+(613,181,cs),
+(613,319,o),
+(539,491,o),
+(539,595,cs),
+(539,625,o),
+(550,659,o),
+(600,659,cs),
+(618,659,l),
+(618,714,l),
+(585,714,ls),
+(507,714,o),
+(479,668,o),
+(479,602,cs),
+(479,494,o),
+(551,311,o),
+(551,185,cs),
+(551,93,o),
+(517,46,o),
+(459,46,cs),
+(395,46,o),
+(361,102,o),
+(361,211,cs),
+(361,714,l),
+(305,714,l),
+(305,211,ls),
+(305,103,o),
+(271,46,o),
+(208,46,cs),
+(149,46,o),
+(115,93,o),
+(115,185,cs),
+(115,311,o),
+(187,494,o),
+(187,602,cs),
+(187,668,o),
+(158,714,o),
+(80,714,cs),
+(47,714,l),
+(47,659,l),
+(65,659,ls),
+(115,659,o),
+(127,625,o),
+(127,595,cs),
+(127,491,o),
+(53,319,o),
+(53,181,cs),
+(53,60,o),
+(110,-13,o),
+(202,-13,cs)
+);
+}
+);
+width = 665;
+}
+);
+metricRight = "=|";
+note = uni164E;
+unicode = 5710;
+},
+{
+color = 9;
+glyphname = "soCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(80,0,ls),
+(158,0,o),
+(186,46,o),
+(186,112,cs),
+(186,220,o),
+(115,403,o),
+(115,529,cs),
+(115,621,o),
+(148,668,o),
+(206,668,cs),
+(270,668,o),
+(304,612,o),
+(304,503,cs),
+(304,0,l),
+(360,0,l),
+(360,503,ls),
+(360,611,o),
+(394,668,o),
+(457,668,cs),
+(516,668,o),
+(550,621,o),
+(550,529,cs),
+(550,403,o),
+(478,220,o),
+(478,112,cs),
+(478,46,o),
+(507,0,o),
+(585,0,cs),
+(618,0,l),
+(618,55,l),
+(600,55,ls),
+(550,55,o),
+(538,89,o),
+(538,119,cs),
+(538,223,o),
+(612,395,o),
+(612,533,cs),
+(612,654,o),
+(555,727,o),
+(463,727,cs),
+(387,727,o),
+(340,674,o),
+(323,572,c),
+(341,572,l),
+(325,674,o),
+(277,727,o),
+(201,727,cs),
+(109,727,o),
+(53,654,o),
+(53,533,cs),
+(53,395,o),
+(126,223,o),
+(126,119,cs),
+(126,89,o),
+(115,55,o),
+(65,55,cs),
+(47,55,l),
+(47,0,l)
+);
+}
+);
+width = 665;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5711;
+},
+{
+color = 9;
+glyphname = "seCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(444,-13,o),
+(504,61,o),
+(504,178,cs),
+(504,286,o),
+(454,356,o),
+(367,365,c),
+(367,349,l),
+(454,358,o),
+(504,428,o),
+(504,536,cs),
+(504,653,o),
+(444,727,o),
+(359,727,cs),
+(275,727,o),
+(199,620,o),
+(155,620,cs),
+(137,620,o),
+(121,633,o),
+(121,679,cs),
+(121,714,l),
+(63,714,l),
+(63,661,ls),
+(63,596,o),
+(96,563,o),
+(141,563,cs),
+(206,563,o),
+(280,669,o),
+(344,669,cs),
+(404,669,o),
+(442,616,o),
+(442,530,cs),
+(442,434,o),
+(395,384,o),
+(325,384,cs),
+(63,384,l),
+(63,330,l),
+(325,330,ls),
+(397,330,o),
+(442,280,o),
+(442,184,cs),
+(442,98,o),
+(404,45,o),
+(345,45,cs),
+(280,45,o),
+(206,151,o),
+(141,151,cs),
+(96,151,o),
+(63,118,o),
+(63,53,cs),
+(63,0,l),
+(121,0,l),
+(121,35,ls),
+(121,81,o),
+(137,94,o),
+(155,94,cs),
+(199,94,o),
+(275,-13,o),
+(360,-13,cs)
+);
+}
+);
+width = 566;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni1650;
+unicode = 5712;
+},
+{
+color = 9;
+glyphname = "seeCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(444,-13,o),
+(504,61,o),
+(504,178,cs),
+(504,279,o),
+(460,346,o),
+(384,362,c),
+(384,352,l),
+(460,368,o),
+(504,436,o),
+(504,536,cs),
+(504,653,o),
+(444,727,o),
+(359,727,cs),
+(275,727,o),
+(199,620,o),
+(155,620,cs),
+(137,620,o),
+(121,633,o),
+(121,679,cs),
+(121,714,l),
+(63,714,l),
+(63,661,ls),
+(63,596,o),
+(96,563,o),
+(141,563,cs),
+(206,563,o),
+(280,669,o),
+(344,669,cs),
+(404,669,o),
+(442,616,o),
+(442,530,cs),
+(442,434,o),
+(395,383,o),
+(324,383,cs),
+(263,383,l),
+(281,362,l),
+(281,468,l),
+(243,468,l),
+(243,383,l),
+(63,383,l),
+(63,331,l),
+(243,331,l),
+(243,236,l),
+(281,236,l),
+(281,349,l),
+(263,331,l),
+(324,331,ls),
+(397,331,o),
+(442,280,o),
+(442,184,cs),
+(442,98,o),
+(404,45,o),
+(345,45,cs),
+(280,45,o),
+(206,151,o),
+(141,151,cs),
+(96,151,o),
+(63,118,o),
+(63,53,cs),
+(63,0,l),
+(121,0,l),
+(121,35,ls),
+(121,81,o),
+(137,94,o),
+(155,94,cs),
+(199,94,o),
+(275,-13,o),
+(360,-13,cs)
+);
+}
+);
+width = 566;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1651;
+unicode = 5713;
+},
+{
+color = 9;
+glyphname = "siCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(444,-13,o),
+(504,61,o),
+(504,178,cs),
+(504,279,o),
+(460,346,o),
+(384,362,c),
+(384,352,l),
+(460,368,o),
+(504,436,o),
+(504,536,cs),
+(504,653,o),
+(444,727,o),
+(359,727,cs),
+(275,727,o),
+(199,620,o),
+(155,620,cs),
+(137,620,o),
+(121,633,o),
+(121,679,cs),
+(121,714,l),
+(63,714,l),
+(63,661,ls),
+(63,596,o),
+(96,563,o),
+(141,563,cs),
+(206,563,o),
+(280,669,o),
+(344,669,cs),
+(404,669,o),
+(442,615,o),
+(442,528,cs),
+(442,432,o),
+(397,382,o),
+(329,382,cs),
+(283,382,l),
+(309,363,l),
+(307,394,o),
+(282,418,o),
+(250,418,cs),
+(226,418,o),
+(205,403,o),
+(196,383,c),
+(63,383,l),
+(63,331,l),
+(197,331,l),
+(205,311,o),
+(226,296,o),
+(250,296,cs),
+(281,296,o),
+(306,320,o),
+(309,351,c),
+(283,332,l),
+(329,332,ls),
+(400,332,o),
+(442,282,o),
+(442,186,cs),
+(442,99,o),
+(404,45,o),
+(345,45,cs),
+(280,45,o),
+(206,151,o),
+(141,151,cs),
+(96,151,o),
+(63,118,o),
+(63,53,cs),
+(63,0,l),
+(121,0,l),
+(121,35,ls),
+(121,81,o),
+(137,94,o),
+(155,94,cs),
+(199,94,o),
+(275,-13,o),
+(360,-13,cs)
+);
+}
+);
+width = 566;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1652;
+unicode = 5714;
+},
+{
+color = 9;
+glyphname = "saCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(291,-13,o),
+(367,94,o),
+(411,94,cs),
+(429,94,o),
+(445,81,o),
+(445,35,cs),
+(445,0,l),
+(503,0,l),
+(503,53,ls),
+(503,118,o),
+(470,151,o),
+(425,151,cs),
+(360,151,o),
+(286,45,o),
+(221,45,cs),
+(162,45,o),
+(124,98,o),
+(124,184,cs),
+(124,280,o),
+(169,330,o),
+(241,330,cs),
+(503,330,l),
+(503,384,l),
+(241,384,ls),
+(171,384,o),
+(124,434,o),
+(124,530,cs),
+(124,616,o),
+(162,669,o),
+(222,669,cs),
+(286,669,o),
+(360,563,o),
+(425,563,cs),
+(470,563,o),
+(503,596,o),
+(503,661,cs),
+(503,714,l),
+(445,714,l),
+(445,679,ls),
+(445,633,o),
+(429,620,o),
+(411,620,cs),
+(367,620,o),
+(291,727,o),
+(207,727,cs),
+(122,727,o),
+(62,653,o),
+(62,536,cs),
+(62,428,o),
+(112,358,o),
+(199,349,c),
+(199,365,l),
+(112,356,o),
+(62,286,o),
+(62,178,cs),
+(62,61,o),
+(122,-13,o),
+(206,-13,cs)
+);
+}
+);
+width = 566;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1653;
+unicode = 5715;
+},
+{
+color = 9;
+glyphname = "shuCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(275,-13,o),
+(322,36,o),
+(340,131,c),
+(326,131,l),
+(344,36,o),
+(391,-13,o),
+(464,-13,cs),
+(556,-13,o),
+(613,60,o),
+(613,181,cs),
+(613,319,o),
+(539,491,o),
+(539,595,cs),
+(539,625,o),
+(550,659,o),
+(600,659,cs),
+(618,659,l),
+(618,714,l),
+(585,714,ls),
+(507,714,o),
+(479,668,o),
+(479,602,cs),
+(479,584,o),
+(482,565,o),
+(484,544,c),
+(496,574,l),
+(361,574,l),
+(361,714,l),
+(305,714,l),
+(305,574,l),
+(170,574,l),
+(182,544,l),
+(184,565,o),
+(187,584,o),
+(187,602,cs),
+(187,668,o),
+(158,714,o),
+(80,714,cs),
+(47,714,l),
+(47,659,l),
+(65,659,ls),
+(115,659,o),
+(127,625,o),
+(127,595,cs),
+(127,491,o),
+(53,319,o),
+(53,181,cs),
+(53,60,o),
+(110,-13,o),
+(202,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(149,46,o),
+(115,93,o),
+(115,185,cs),
+(115,285,o),
+(160,419,o),
+(179,524,c),
+(305,524,l),
+(305,211,ls),
+(305,103,o),
+(271,46,o),
+(208,46,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(395,46,o),
+(361,102,o),
+(361,211,cs),
+(361,524,l),
+(487,524,l),
+(506,419,o),
+(551,285,o),
+(551,185,cs),
+(551,93,o),
+(517,46,o),
+(459,46,cs)
+);
+}
+);
+width = 665;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1654;
+unicode = 5716;
+},
+{
+color = 9;
+glyphname = "shoCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(80,0,ls),
+(158,0,o),
+(186,46,o),
+(186,112,cs),
+(186,130,o),
+(183,149,o),
+(181,170,c),
+(169,140,l),
+(304,140,l),
+(304,0,l),
+(360,0,l),
+(360,140,l),
+(496,140,l),
+(483,170,l),
+(481,149,o),
+(479,130,o),
+(479,112,cs),
+(479,46,o),
+(507,0,o),
+(585,0,cs),
+(618,0,l),
+(618,55,l),
+(600,55,ls),
+(550,55,o),
+(538,89,o),
+(538,119,cs),
+(538,223,o),
+(612,395,o),
+(612,533,cs),
+(612,654,o),
+(555,727,o),
+(463,727,cs),
+(390,727,o),
+(343,678,o),
+(325,583,c),
+(339,583,l),
+(321,678,o),
+(274,727,o),
+(201,727,cs),
+(109,727,o),
+(53,654,o),
+(53,533,cs),
+(53,395,o),
+(126,223,o),
+(126,119,cs),
+(126,89,o),
+(115,55,o),
+(65,55,cs),
+(47,55,l),
+(47,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(160,295,o),
+(115,429,o),
+(115,529,cs),
+(115,621,o),
+(148,668,o),
+(206,668,cs),
+(270,668,o),
+(304,612,o),
+(304,503,cs),
+(304,190,l),
+(178,190,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(360,503,ls),
+(360,611,o),
+(394,668,o),
+(457,668,cs),
+(516,668,o),
+(550,621,o),
+(550,529,cs),
+(550,429,o),
+(505,295,o),
+(486,190,c),
+(360,190,l)
+);
+}
+);
+width = 665;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1655;
+unicode = 5717;
+},
+{
+color = 9;
+glyphname = "sheCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(444,-13,o),
+(504,61,o),
+(504,178,cs),
+(504,279,o),
+(460,346,o),
+(384,362,c),
+(384,352,l),
+(460,368,o),
+(504,436,o),
+(504,536,cs),
+(504,653,o),
+(444,727,o),
+(359,727,cs),
+(275,727,o),
+(199,620,o),
+(155,620,cs),
+(137,620,o),
+(121,633,o),
+(121,679,cs),
+(121,714,l),
+(63,714,l),
+(63,661,ls),
+(63,596,o),
+(96,565,o),
+(141,565,cs),
+(156,565,o),
+(171,570,o),
+(186,578,c),
+(153,589,l),
+(153,384,l),
+(63,384,l),
+(63,330,l),
+(153,330,l),
+(153,125,l),
+(186,136,l),
+(171,144,o),
+(156,149,o),
+(141,149,cs),
+(96,149,o),
+(63,118,o),
+(63,53,cs),
+(63,0,l),
+(121,0,l),
+(121,35,ls),
+(121,81,o),
+(137,94,o),
+(155,94,cs),
+(199,94,o),
+(275,-13,o),
+(360,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(203,330,l),
+(325,330,ls),
+(397,330,o),
+(442,280,o),
+(442,184,cs),
+(442,98,o),
+(404,45,o),
+(345,45,cs),
+(299,45,o),
+(249,96,o),
+(203,126,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(203,588,l),
+(249,618,o),
+(299,669,o),
+(344,669,cs),
+(404,669,o),
+(442,616,o),
+(442,530,cs),
+(442,434,o),
+(395,384,o),
+(325,384,cs),
+(203,384,l)
+);
+}
+);
+width = 566;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1656;
+unicode = 5718;
+},
+{
+color = 9;
+glyphname = "sheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(444,-13,o),
+(504,61,o),
+(504,178,cs),
+(504,279,o),
+(460,346,o),
+(384,362,c),
+(384,352,l),
+(460,368,o),
+(504,436,o),
+(504,536,cs),
+(504,653,o),
+(444,727,o),
+(359,727,cs),
+(275,727,o),
+(199,620,o),
+(155,620,cs),
+(137,620,o),
+(121,633,o),
+(121,679,cs),
+(121,714,l),
+(63,714,l),
+(63,661,ls),
+(63,596,o),
+(96,565,o),
+(141,565,cs),
+(153,565,o),
+(167,569,o),
+(180,576,c),
+(153,587,l),
+(153,380,l),
+(63,380,l),
+(63,334,l),
+(153,334,l),
+(153,127,l),
+(180,138,l),
+(167,145,o),
+(154,149,o),
+(141,149,cs),
+(96,149,o),
+(63,118,o),
+(63,53,cs),
+(63,0,l),
+(121,0,l),
+(121,35,ls),
+(121,81,o),
+(137,94,o),
+(155,94,cs),
+(199,94,o),
+(275,-13,o),
+(360,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(298,44,o),
+(245,101,o),
+(194,130,c),
+(194,334,l),
+(286,334,l),
+(286,236,l),
+(319,236,l),
+(319,347,l),
+(303,334,l),
+(331,334,ls),
+(401,334,o),
+(443,280,o),
+(443,186,cs),
+(443,98,o),
+(405,44,o),
+(346,44,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(319,468,l),
+(286,468,l),
+(286,380,l),
+(194,380,l),
+(194,584,l),
+(245,613,o),
+(298,670,o),
+(345,670,cs),
+(405,670,o),
+(443,616,o),
+(443,528,cs),
+(443,434,o),
+(399,380,o),
+(331,380,cs),
+(303,380,l),
+(319,367,l)
+);
+}
+);
+width = 566;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1657;
+unicode = 5719;
+},
+{
+color = 9;
+glyphname = "shiCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(63,661,ls),
+(63,596,o),
+(96,565,o),
+(141,565,cs),
+(152,565,o),
+(165,569,o),
+(176,574,c),
+(153,587,l),
+(153,380,l),
+(63,380,l),
+(63,334,l),
+(153,334,l),
+(153,127,l),
+(177,140,l),
+(165,145,o),
+(153,149,o),
+(141,149,cs),
+(96,149,o),
+(63,118,o),
+(63,53,cs),
+(63,0,l),
+(121,0,l),
+(121,35,ls),
+(121,81,o),
+(137,94,o),
+(155,94,cs),
+(199,94,o),
+(275,-13,o),
+(360,-13,cs),
+(444,-13,o),
+(504,61,o),
+(504,178,cs),
+(504,279,o),
+(460,346,o),
+(384,362,c),
+(384,352,l),
+(460,368,o),
+(504,436,o),
+(504,536,cs),
+(504,653,o),
+(444,727,o),
+(359,727,cs),
+(275,727,o),
+(199,620,o),
+(155,620,cs),
+(137,620,o),
+(121,633,o),
+(121,679,cs),
+(121,714,l),
+(63,714,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(194,334,l),
+(250,334,l),
+(258,311,o),
+(279,296,o),
+(302,296,cs),
+(332,296,o),
+(357,322,o),
+(357,351,c),
+(313,333,l),
+(334,333,ls),
+(402,333,o),
+(443,280,o),
+(443,186,cs),
+(443,98,o),
+(405,44,o),
+(346,44,cs),
+(298,44,o),
+(245,100,o),
+(194,130,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(194,584,l),
+(245,614,o),
+(298,670,o),
+(345,670,cs),
+(405,670,o),
+(443,616,o),
+(443,528,cs),
+(443,434,o),
+(400,381,o),
+(334,381,cs),
+(314,381,l),
+(358,363,l),
+(357,393,o),
+(332,418,o),
+(302,418,cs),
+(279,418,o),
+(258,403,o),
+(250,380,c),
+(194,380,l)
+);
+}
+);
+width = 566;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1658;
+unicode = 5720;
+},
+{
+color = 9;
+glyphname = "shaCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(291,-13,o),
+(367,94,o),
+(411,94,cs),
+(429,94,o),
+(445,81,o),
+(445,35,cs),
+(445,0,l),
+(503,0,l),
+(503,53,ls),
+(503,118,o),
+(470,149,o),
+(425,149,cs),
+(410,149,o),
+(395,144,o),
+(380,136,c),
+(413,125,l),
+(413,330,l),
+(503,330,l),
+(503,384,l),
+(413,384,l),
+(413,589,l),
+(380,578,l),
+(395,570,o),
+(410,565,o),
+(425,565,cs),
+(470,565,o),
+(503,596,o),
+(503,661,cs),
+(503,714,l),
+(445,714,l),
+(445,679,ls),
+(445,633,o),
+(429,620,o),
+(411,620,cs),
+(367,620,o),
+(291,727,o),
+(207,727,cs),
+(122,727,o),
+(62,653,o),
+(62,536,cs),
+(62,436,o),
+(106,368,o),
+(182,352,c),
+(182,362,l),
+(106,346,o),
+(62,279,o),
+(62,178,cs),
+(62,61,o),
+(122,-13,o),
+(206,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(162,45,o),
+(124,98,o),
+(124,184,cs),
+(124,280,o),
+(169,330,o),
+(241,330,cs),
+(363,330,l),
+(363,126,l),
+(317,96,o),
+(267,45,o),
+(221,45,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(171,384,o),
+(124,434,o),
+(124,530,cs),
+(124,616,o),
+(162,669,o),
+(222,669,cs),
+(267,669,o),
+(317,618,o),
+(363,588,c),
+(363,384,l),
+(241,384,ls)
+);
+}
+);
+width = 566;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1659;
+unicode = 5721;
+},
+{
+color = 6;
+glyphname = "shCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(180,99,l),
+(180,201,l),
+(148,190,l),
+(164,190,ls),
+(231,190,o),
+(265,226,o),
+(265,289,cs),
+(265,350,o),
+(234,388,o),
+(172,388,cs),
+(152,388,ls),
+(118,388,o),
+(95,402,o),
+(95,447,cs),
+(95,491,o),
+(119,507,o),
+(152,507,cs),
+(261,507,l),
+(261,546,l),
+(180,546,l),
+(180,636,l),
+(137,636,l),
+(137,531,l),
+(168,546,l),
+(153,546,ls),
+(87,546,o),
+(52,509,o),
+(52,446,cs),
+(52,386,o),
+(84,348,o),
+(145,348,cs),
+(166,348,ls),
+(199,348,o),
+(222,332,o),
+(222,288,cs),
+(222,245,o),
+(199,229,o),
+(166,229,cs),
+(57,229,l),
+(57,190,l),
+(137,190,l),
+(137,99,l)
+);
+}
+);
+width = 317;
+}
+);
+metricRight = "=|";
+note = uni18F5;
+unicode = 5722;
+},
+{
+color = 9;
+glyphname = "tsuCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(275,-13,o),
+(322,36,o),
+(340,131,c),
+(326,131,l),
+(344,36,o),
+(391,-13,o),
+(464,-13,cs),
+(556,-13,o),
+(613,60,o),
+(613,181,cs),
+(613,319,o),
+(539,491,o),
+(539,595,cs),
+(539,625,o),
+(550,659,o),
+(600,659,cs),
+(618,659,l),
+(618,714,l),
+(585,714,ls),
+(509,714,o),
+(481,671,o),
+(481,604,cs),
+(481,545,o),
+(505,465,o),
+(524,382,c),
+(360,382,l),
+(360,668,l),
+(424,668,l),
+(424,714,l),
+(241,714,l),
+(241,668,l),
+(306,668,l),
+(306,382,l),
+(142,382,l),
+(161,465,o),
+(185,545,o),
+(185,604,cs),
+(185,671,o),
+(156,714,o),
+(80,714,cs),
+(47,714,l),
+(47,659,l),
+(65,659,ls),
+(115,659,o),
+(127,625,o),
+(127,595,cs),
+(127,491,o),
+(53,319,o),
+(53,181,cs),
+(53,60,o),
+(110,-13,o),
+(202,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(150,46,o),
+(115,93,o),
+(115,185,cs),
+(115,230,o),
+(124,280,o),
+(135,332,c),
+(306,332,l),
+(306,211,ls),
+(306,103,o),
+(272,46,o),
+(209,46,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(394,46,o),
+(360,102,o),
+(360,211,cs),
+(360,332,l),
+(531,332,l),
+(542,280,o),
+(551,230,o),
+(551,185,cs),
+(551,93,o),
+(517,46,o),
+(458,46,cs)
+);
+}
+);
+width = 665;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165B;
+unicode = 5723;
+},
+{
+color = 9;
+glyphname = "tsoCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(80,0,ls),
+(156,0,o),
+(184,43,o),
+(184,110,cs),
+(184,169,o),
+(161,249,o),
+(142,332,c),
+(305,332,l),
+(305,46,l),
+(242,46,l),
+(242,0,l),
+(424,0,l),
+(424,46,l),
+(359,46,l),
+(359,332,l),
+(523,332,l),
+(504,249,o),
+(480,169,o),
+(480,110,cs),
+(480,43,o),
+(509,0,o),
+(585,0,cs),
+(618,0,l),
+(618,55,l),
+(600,55,ls),
+(550,55,o),
+(538,89,o),
+(538,119,cs),
+(538,223,o),
+(612,395,o),
+(612,533,cs),
+(612,654,o),
+(555,727,o),
+(463,727,cs),
+(390,727,o),
+(343,678,o),
+(325,583,c),
+(340,583,l),
+(321,678,o),
+(274,727,o),
+(201,727,cs),
+(109,727,o),
+(53,654,o),
+(53,533,cs),
+(53,395,o),
+(126,223,o),
+(126,119,cs),
+(126,89,o),
+(115,55,o),
+(65,55,cs),
+(47,55,l),
+(47,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(124,434,o),
+(115,484,o),
+(115,529,cs),
+(115,621,o),
+(148,668,o),
+(207,668,cs),
+(271,668,o),
+(305,612,o),
+(305,503,cs),
+(305,382,l),
+(134,382,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(359,503,ls),
+(359,611,o),
+(394,668,o),
+(457,668,cs),
+(515,668,o),
+(550,621,o),
+(550,529,cs),
+(550,484,o),
+(541,434,o),
+(530,382,c),
+(359,382,l)
+);
+}
+);
+width = 665;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165C;
+unicode = 5724;
+},
+{
+color = 9;
+glyphname = "tseCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(446,-13,o),
+(506,61,o),
+(506,178,cs),
+(506,279,o),
+(463,346,o),
+(386,362,c),
+(386,352,l),
+(462,368,o),
+(506,436,o),
+(506,536,cs),
+(506,653,o),
+(446,727,o),
+(362,727,cs),
+(277,727,o),
+(201,620,o),
+(157,620,cs),
+(139,620,o),
+(123,633,o),
+(123,679,cs),
+(123,714,l),
+(65,714,l),
+(65,662,ls),
+(65,597,o),
+(98,566,o),
+(143,566,cs),
+(165,566,o),
+(190,580,o),
+(214,596,c),
+(196,604,l),
+(196,380,l),
+(104,380,l),
+(104,481,l),
+(65,481,l),
+(65,233,l),
+(104,233,l),
+(104,334,l),
+(196,334,l),
+(196,110,l),
+(214,118,l),
+(190,134,o),
+(165,148,o),
+(143,148,cs),
+(98,148,o),
+(65,117,o),
+(65,52,cs),
+(65,0,l),
+(123,0,l),
+(123,35,ls),
+(123,81,o),
+(139,94,o),
+(157,94,cs),
+(201,94,o),
+(277,-13,o),
+(362,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(312,45,o),
+(274,76,o),
+(238,103,c),
+(238,334,l),
+(327,334,ls),
+(400,334,o),
+(445,281,o),
+(445,185,cs),
+(445,99,o),
+(407,45,o),
+(348,45,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(238,611,l),
+(274,638,o),
+(312,669,o),
+(347,669,cs),
+(407,669,o),
+(445,615,o),
+(445,529,cs),
+(445,433,o),
+(398,380,o),
+(327,380,cs),
+(238,380,l)
+);
+}
+);
+width = 568;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni165D;
+unicode = 5725;
+},
+{
+color = 9;
+glyphname = "tseeCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(446,-13,o),
+(506,61,o),
+(506,178,cs),
+(506,279,o),
+(463,346,o),
+(386,362,c),
+(386,352,l),
+(462,368,o),
+(506,436,o),
+(506,536,cs),
+(506,653,o),
+(446,727,o),
+(362,727,cs),
+(277,727,o),
+(201,620,o),
+(157,620,cs),
+(139,620,o),
+(123,633,o),
+(123,679,cs),
+(123,714,l),
+(65,714,l),
+(65,662,ls),
+(65,597,o),
+(98,566,o),
+(143,566,cs),
+(163,566,o),
+(185,579,o),
+(207,593,c),
+(191,608,l),
+(191,379,l),
+(101,379,l),
+(101,481,l),
+(65,481,l),
+(65,233,l),
+(101,233,l),
+(101,335,l),
+(191,335,l),
+(191,106,l),
+(205,121,l),
+(184,135,o),
+(162,148,o),
+(143,148,cs),
+(98,148,o),
+(65,117,o),
+(65,52,cs),
+(65,0,l),
+(123,0,l),
+(123,35,ls),
+(123,81,o),
+(139,94,o),
+(157,94,cs),
+(201,94,o),
+(277,-13,o),
+(362,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(310,45,o),
+(270,79,o),
+(229,108,c),
+(229,335,l),
+(307,335,l),
+(307,232,l),
+(340,232,l),
+(340,346,l),
+(325,335,l),
+(335,335,ls),
+(406,335,o),
+(446,281,o),
+(446,187,cs),
+(446,99,o),
+(408,45,o),
+(348,45,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(340,471,l),
+(307,471,l),
+(307,379,l),
+(229,379,l),
+(229,606,l),
+(270,635,o),
+(310,669,o),
+(347,669,cs),
+(408,669,o),
+(446,615,o),
+(446,527,cs),
+(446,433,o),
+(403,379,o),
+(335,379,cs),
+(325,379,l),
+(340,368,l)
+);
+}
+);
+width = 568;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165E;
+unicode = 5726;
+},
+{
+color = 9;
+glyphname = "tsiCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(446,-13,o),
+(506,61,o),
+(506,178,cs),
+(506,279,o),
+(463,346,o),
+(386,362,c),
+(386,352,l),
+(463,368,o),
+(506,436,o),
+(506,536,cs),
+(506,653,o),
+(446,727,o),
+(362,727,cs),
+(277,727,o),
+(201,620,o),
+(157,620,cs),
+(139,620,o),
+(123,633,o),
+(123,679,cs),
+(123,714,l),
+(65,714,l),
+(65,662,ls),
+(65,597,o),
+(98,566,o),
+(143,566,cs),
+(165,566,o),
+(189,580,o),
+(213,595,c),
+(191,599,l),
+(191,379,l),
+(101,379,l),
+(101,481,l),
+(65,481,l),
+(65,233,l),
+(101,233,l),
+(101,335,l),
+(191,335,l),
+(191,115,l),
+(213,119,l),
+(189,134,o),
+(165,148,o),
+(143,148,cs),
+(98,148,o),
+(65,117,o),
+(65,52,cs),
+(65,0,l),
+(123,0,l),
+(123,35,ls),
+(123,81,o),
+(139,94,o),
+(157,94,cs),
+(201,94,o),
+(277,-13,o),
+(362,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(310,45,o),
+(270,79,o),
+(229,108,c),
+(229,335,l),
+(275,335,l),
+(281,311,o),
+(301,296,o),
+(324,296,cs),
+(354,296,o),
+(374,323,o),
+(376,350,c),
+(315,335,l),
+(334,335,ls),
+(405,335,o),
+(446,281,o),
+(446,187,cs),
+(446,99,o),
+(408,45,o),
+(348,45,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(375,391,o),
+(354,418,o),
+(324,418,cs),
+(301,418,o),
+(282,403,o),
+(275,379,c),
+(229,379,l),
+(229,606,l),
+(270,635,o),
+(310,669,o),
+(347,669,cs),
+(408,669,o),
+(446,615,o),
+(446,527,cs),
+(446,433,o),
+(403,379,o),
+(334,379,cs),
+(315,379,l),
+(376,362,l)
+);
+}
+);
+width = 568;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165F;
+unicode = 5727;
+},
+{
+color = 9;
+glyphname = "tsaCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(291,-13,o),
+(367,94,o),
+(411,94,cs),
+(429,94,o),
+(445,81,o),
+(445,35,cs),
+(445,0,l),
+(503,0,l),
+(503,52,ls),
+(503,117,o),
+(470,148,o),
+(425,148,cs),
+(403,148,o),
+(378,134,o),
+(354,118,c),
+(372,110,l),
+(372,334,l),
+(464,334,l),
+(464,233,l),
+(503,233,l),
+(503,481,l),
+(464,481,l),
+(464,380,l),
+(372,380,l),
+(372,604,l),
+(355,596,l),
+(378,580,o),
+(403,566,o),
+(425,566,cs),
+(470,566,o),
+(503,597,o),
+(503,662,cs),
+(503,714,l),
+(445,714,l),
+(445,679,ls),
+(445,633,o),
+(429,620,o),
+(411,620,cs),
+(367,620,o),
+(291,727,o),
+(207,727,cs),
+(122,727,o),
+(62,653,o),
+(62,536,cs),
+(62,436,o),
+(106,368,o),
+(182,352,c),
+(182,362,l),
+(106,346,o),
+(62,279,o),
+(62,178,cs),
+(62,61,o),
+(122,-13,o),
+(206,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(161,45,o),
+(123,99,o),
+(123,185,cs),
+(123,281,o),
+(168,334,o),
+(241,334,cs),
+(330,334,l),
+(330,103,l),
+(294,76,o),
+(256,45,o),
+(220,45,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(170,380,o),
+(123,433,o),
+(123,529,cs),
+(123,615,o),
+(161,669,o),
+(221,669,cs),
+(256,669,o),
+(294,638,o),
+(330,611,c),
+(330,380,l),
+(241,380,ls)
+);
+}
+);
+width = 568;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1660;
+unicode = 5728;
+},
+{
+color = 9;
+glyphname = "chuCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(275,-13,o),
+(322,36,o),
+(340,131,c),
+(326,131,l),
+(344,36,o),
+(391,-13,o),
+(464,-13,cs),
+(556,-13,o),
+(613,60,o),
+(613,181,cs),
+(613,319,o),
+(539,491,o),
+(539,595,cs),
+(539,625,o),
+(550,659,o),
+(600,659,cs),
+(618,659,l),
+(618,714,l),
+(585,714,ls),
+(509,714,o),
+(481,671,o),
+(481,604,cs),
+(481,491,o),
+(551,311,o),
+(551,185,cs),
+(551,93,o),
+(517,46,o),
+(458,46,cs),
+(394,46,o),
+(360,102,o),
+(360,211,cs),
+(360,668,l),
+(424,668,l),
+(424,714,l),
+(241,714,l),
+(241,668,l),
+(306,668,l),
+(306,211,ls),
+(306,103,o),
+(272,46,o),
+(209,46,cs),
+(150,46,o),
+(115,93,o),
+(115,185,cs),
+(115,311,o),
+(185,491,o),
+(185,604,cs),
+(185,671,o),
+(156,714,o),
+(80,714,cs),
+(47,714,l),
+(47,659,l),
+(65,659,ls),
+(115,659,o),
+(127,625,o),
+(127,595,cs),
+(127,491,o),
+(53,319,o),
+(53,181,cs),
+(53,60,o),
+(110,-13,o),
+(202,-13,cs)
+);
+}
+);
+width = 665;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164E;
+unicode = 5729;
+},
+{
+color = 9;
+glyphname = "choCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(80,0,ls),
+(156,0,o),
+(184,43,o),
+(184,110,cs),
+(184,223,o),
+(115,403,o),
+(115,529,cs),
+(115,621,o),
+(148,668,o),
+(207,668,cs),
+(271,668,o),
+(305,612,o),
+(305,503,cs),
+(305,46,l),
+(242,46,l),
+(242,0,l),
+(424,0,l),
+(424,46,l),
+(359,46,l),
+(359,503,ls),
+(359,611,o),
+(394,668,o),
+(457,668,cs),
+(515,668,o),
+(550,621,o),
+(550,529,cs),
+(550,403,o),
+(480,223,o),
+(480,110,cs),
+(480,43,o),
+(509,0,o),
+(585,0,cs),
+(618,0,l),
+(618,55,l),
+(600,55,ls),
+(550,55,o),
+(538,89,o),
+(538,119,cs),
+(538,223,o),
+(612,395,o),
+(612,533,cs),
+(612,654,o),
+(555,727,o),
+(463,727,cs),
+(390,727,o),
+(343,678,o),
+(325,583,c),
+(340,583,l),
+(321,678,o),
+(274,727,o),
+(201,727,cs),
+(109,727,o),
+(53,654,o),
+(53,533,cs),
+(53,395,o),
+(126,223,o),
+(126,119,cs),
+(126,89,o),
+(115,55,o),
+(65,55,cs),
+(47,55,l),
+(47,0,l)
+);
+}
+);
+width = 665;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5730;
+},
+{
+color = 9;
+glyphname = "cheCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(446,-13,o),
+(506,61,o),
+(506,178,cs),
+(506,279,o),
+(463,346,o),
+(386,362,c),
+(386,352,l),
+(462,368,o),
+(506,436,o),
+(506,536,cs),
+(506,653,o),
+(446,727,o),
+(362,727,cs),
+(277,727,o),
+(201,620,o),
+(157,620,cs),
+(139,620,o),
+(123,633,o),
+(123,679,cs),
+(123,714,l),
+(65,714,l),
+(65,661,ls),
+(65,596,o),
+(98,565,o),
+(143,565,cs),
+(208,565,o),
+(282,669,o),
+(346,669,cs),
+(406,669,o),
+(444,616,o),
+(444,530,cs),
+(444,434,o),
+(397,384,o),
+(327,384,cs),
+(104,384,l),
+(104,481,l),
+(65,481,l),
+(65,233,l),
+(104,233,l),
+(104,330,l),
+(327,330,ls),
+(399,330,o),
+(444,280,o),
+(444,184,cs),
+(444,98,o),
+(406,45,o),
+(347,45,cs),
+(282,45,o),
+(208,149,o),
+(143,149,cs),
+(98,149,o),
+(65,118,o),
+(65,53,cs),
+(65,0,l),
+(123,0,l),
+(123,35,ls),
+(123,81,o),
+(139,94,o),
+(157,94,cs),
+(201,94,o),
+(277,-13,o),
+(362,-13,cs)
+);
+}
+);
+width = 568;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni1663;
+unicode = 5731;
+},
+{
+color = 9;
+glyphname = "cheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(446,-13,o),
+(506,61,o),
+(506,178,cs),
+(506,279,o),
+(463,346,o),
+(386,362,c),
+(386,352,l),
+(462,368,o),
+(506,436,o),
+(506,536,cs),
+(506,653,o),
+(446,727,o),
+(362,727,cs),
+(277,727,o),
+(201,620,o),
+(157,620,cs),
+(139,620,o),
+(123,633,o),
+(123,679,cs),
+(123,714,l),
+(65,714,l),
+(65,661,ls),
+(65,596,o),
+(98,565,o),
+(143,565,cs),
+(208,565,o),
+(283,670,o),
+(347,670,cs),
+(407,670,o),
+(445,616,o),
+(445,530,cs),
+(445,434,o),
+(401,380,o),
+(333,380,cs),
+(275,380,l),
+(293,367,l),
+(293,468,l),
+(255,468,l),
+(255,380,l),
+(104,380,l),
+(104,481,l),
+(65,481,l),
+(65,233,l),
+(104,233,l),
+(104,334,l),
+(255,334,l),
+(255,236,l),
+(293,236,l),
+(293,347,l),
+(275,334,l),
+(333,334,ls),
+(404,334,o),
+(445,280,o),
+(445,184,cs),
+(445,98,o),
+(407,44,o),
+(348,44,cs),
+(283,44,o),
+(208,149,o),
+(143,149,cs),
+(98,149,o),
+(65,118,o),
+(65,53,cs),
+(65,0,l),
+(123,0,l),
+(123,35,ls),
+(123,81,o),
+(139,94,o),
+(157,94,cs),
+(201,94,o),
+(277,-13,o),
+(362,-13,cs)
+);
+}
+);
+width = 568;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1664;
+unicode = 5732;
+},
+{
+color = 9;
+glyphname = "chiCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(446,-13,o),
+(506,61,o),
+(506,178,cs),
+(506,279,o),
+(463,346,o),
+(386,362,c),
+(386,352,l),
+(463,368,o),
+(506,436,o),
+(506,536,cs),
+(506,653,o),
+(446,727,o),
+(362,727,cs),
+(277,727,o),
+(201,620,o),
+(157,620,cs),
+(139,620,o),
+(123,633,o),
+(123,679,cs),
+(123,714,l),
+(65,714,l),
+(65,661,ls),
+(65,596,o),
+(98,565,o),
+(143,565,cs),
+(208,565,o),
+(283,670,o),
+(347,670,cs),
+(407,670,o),
+(445,616,o),
+(445,530,cs),
+(445,434,o),
+(401,380,o),
+(332,380,cs),
+(284,380,l),
+(318,361,l),
+(316,393,o),
+(291,418,o),
+(259,418,cs),
+(234,418,o),
+(212,402,o),
+(204,380,c),
+(104,380,l),
+(104,481,l),
+(65,481,l),
+(65,233,l),
+(104,233,l),
+(104,334,l),
+(204,334,l),
+(212,312,o),
+(234,296,o),
+(259,296,cs),
+(291,296,o),
+(316,321,o),
+(318,353,c),
+(284,334,l),
+(332,334,ls),
+(404,334,o),
+(445,280,o),
+(445,184,cs),
+(445,98,o),
+(407,44,o),
+(348,44,cs),
+(283,44,o),
+(208,149,o),
+(143,149,cs),
+(98,149,o),
+(65,118,o),
+(65,53,cs),
+(65,0,l),
+(123,0,l),
+(123,35,ls),
+(123,81,o),
+(139,94,o),
+(157,94,cs),
+(201,94,o),
+(277,-13,o),
+(362,-13,cs)
+);
+}
+);
+width = 568;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1665;
+unicode = 5733;
+},
+{
+color = 9;
+glyphname = "chaCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(291,-13,o),
+(367,94,o),
+(411,94,cs),
+(429,94,o),
+(445,81,o),
+(445,35,cs),
+(445,0,l),
+(503,0,l),
+(503,53,ls),
+(503,118,o),
+(470,149,o),
+(425,149,cs),
+(360,149,o),
+(286,45,o),
+(222,45,cs),
+(162,45,o),
+(124,98,o),
+(124,184,cs),
+(124,280,o),
+(171,330,o),
+(241,330,cs),
+(464,330,l),
+(464,233,l),
+(503,233,l),
+(503,481,l),
+(464,481,l),
+(464,384,l),
+(241,384,ls),
+(169,384,o),
+(124,434,o),
+(124,530,cs),
+(124,616,o),
+(162,669,o),
+(221,669,cs),
+(286,669,o),
+(360,565,o),
+(425,565,cs),
+(470,565,o),
+(503,596,o),
+(503,661,cs),
+(503,714,l),
+(445,714,l),
+(445,679,ls),
+(445,633,o),
+(429,620,o),
+(411,620,cs),
+(367,620,o),
+(291,727,o),
+(206,727,cs),
+(122,727,o),
+(62,653,o),
+(62,536,cs),
+(62,436,o),
+(106,368,o),
+(182,352,c),
+(182,362,l),
+(106,346,o),
+(62,279,o),
+(62,178,cs),
+(62,61,o),
+(122,-13,o),
+(207,-13,cs)
+);
+}
+);
+width = 568;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1666;
+unicode = 5734;
+},
+{
+color = 9;
+glyphname = "ttsuCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(275,-13,o),
+(322,36,o),
+(340,131,c),
+(326,131,l),
+(344,36,o),
+(391,-13,o),
+(464,-13,cs),
+(556,-13,o),
+(613,60,o),
+(613,181,cs),
+(613,319,o),
+(539,491,o),
+(539,595,cs),
+(539,625,o),
+(550,659,o),
+(600,659,cs),
+(618,659,l),
+(618,714,l),
+(585,714,ls),
+(509,714,o),
+(481,671,o),
+(481,604,cs),
+(481,571,o),
+(487,533,o),
+(493,493,c),
+(513,539,l),
+(360,403,l),
+(360,668,l),
+(424,668,l),
+(424,714,l),
+(241,714,l),
+(241,668,l),
+(306,668,l),
+(306,403,l),
+(153,538,l),
+(173,492,l),
+(179,533,o),
+(185,571,o),
+(185,604,cs),
+(185,671,o),
+(156,714,o),
+(80,714,cs),
+(47,714,l),
+(47,659,l),
+(65,659,ls),
+(115,659,o),
+(127,625,o),
+(127,595,cs),
+(127,491,o),
+(53,319,o),
+(53,181,cs),
+(53,60,o),
+(110,-13,o),
+(202,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(150,46,o),
+(115,93,o),
+(115,185,cs),
+(115,269,o),
+(147,372,o),
+(167,463,c),
+(306,341,l),
+(306,211,ls),
+(306,103,o),
+(272,46,o),
+(209,46,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(394,46,o),
+(360,102,o),
+(360,211,cs),
+(360,341,l),
+(498,463,l),
+(519,373,o),
+(551,269,o),
+(551,185,cs),
+(551,93,o),
+(517,46,o),
+(458,46,cs)
+);
+}
+);
+width = 665;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1667;
+unicode = 5735;
+},
+{
+color = 9;
+glyphname = "ttsoCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(80,0,ls),
+(156,0,o),
+(185,43,o),
+(185,110,cs),
+(185,143,o),
+(179,181,o),
+(173,222,c),
+(153,176,l),
+(306,311,l),
+(306,46,l),
+(241,46,l),
+(241,0,l),
+(424,0,l),
+(424,46,l),
+(360,46,l),
+(360,311,l),
+(513,175,l),
+(493,221,l),
+(487,181,o),
+(481,143,o),
+(481,110,cs),
+(481,43,o),
+(509,0,o),
+(585,0,cs),
+(618,0,l),
+(618,55,l),
+(600,55,ls),
+(550,55,o),
+(539,89,o),
+(539,119,cs),
+(539,223,o),
+(613,395,o),
+(613,533,cs),
+(613,654,o),
+(556,727,o),
+(464,727,cs),
+(391,727,o),
+(344,678,o),
+(326,583,c),
+(340,583,l),
+(322,678,o),
+(275,727,o),
+(202,727,cs),
+(110,727,o),
+(53,654,o),
+(53,533,cs),
+(53,395,o),
+(127,223,o),
+(127,119,cs),
+(127,89,o),
+(115,55,o),
+(65,55,cs),
+(47,55,l),
+(47,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(147,342,o),
+(115,445,o),
+(115,529,cs),
+(115,621,o),
+(150,668,o),
+(209,668,cs),
+(272,668,o),
+(306,611,o),
+(306,503,cs),
+(306,373,l),
+(167,251,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(360,373,l),
+(360,503,ls),
+(360,612,o),
+(394,668,o),
+(458,668,cs),
+(517,668,o),
+(551,621,o),
+(551,529,cs),
+(551,445,o),
+(519,341,o),
+(498,251,c)
+);
+}
+);
+width = 665;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1668;
+unicode = 5736;
+},
+{
+color = 9;
+glyphname = "ttseCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(446,-13,o),
+(506,61,o),
+(506,178,cs),
+(506,279,o),
+(463,346,o),
+(386,362,c),
+(386,352,l),
+(463,368,o),
+(506,436,o),
+(506,536,cs),
+(506,653,o),
+(446,727,o),
+(362,727,cs),
+(277,727,o),
+(201,620,o),
+(157,620,cs),
+(139,620,o),
+(123,633,o),
+(123,679,cs),
+(123,714,l),
+(65,714,l),
+(65,661,ls),
+(65,596,o),
+(98,565,o),
+(143,565,cs),
+(152,565,o),
+(163,566,o),
+(164,575,c),
+(128,595,l),
+(199,380,l),
+(104,380,l),
+(104,481,l),
+(65,481,l),
+(65,233,l),
+(104,233,l),
+(104,334,l),
+(199,334,l),
+(128,119,l),
+(164,139,l),
+(162,148,o),
+(152,149,o),
+(143,149,cs),
+(98,149,o),
+(65,118,o),
+(65,53,cs),
+(65,0,l),
+(123,0,l),
+(123,35,ls),
+(123,81,o),
+(139,94,o),
+(157,94,cs),
+(201,94,o),
+(277,-13,o),
+(362,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(292,44,o),
+(232,120,o),
+(180,139,c),
+(243,334,l),
+(332,334,ls),
+(404,334,o),
+(445,280,o),
+(445,184,cs),
+(445,98,o),
+(407,44,o),
+(348,44,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(180,575,l),
+(232,594,o),
+(292,670,o),
+(347,670,cs),
+(407,670,o),
+(445,616,o),
+(445,530,cs),
+(445,434,o),
+(401,380,o),
+(332,380,cs),
+(243,380,l)
+);
+}
+);
+width = 568;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1669;
+unicode = 5737;
+},
+{
+color = 9;
+glyphname = "ttseeCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(446,-13,o),
+(506,61,o),
+(506,178,cs),
+(506,279,o),
+(463,346,o),
+(386,362,c),
+(386,352,l),
+(463,368,o),
+(506,436,o),
+(506,536,cs),
+(506,653,o),
+(446,727,o),
+(362,727,cs),
+(277,727,o),
+(201,620,o),
+(157,620,cs),
+(139,620,o),
+(123,633,o),
+(123,679,cs),
+(123,714,l),
+(65,714,l),
+(65,661,ls),
+(65,596,o),
+(98,565,o),
+(143,565,cs),
+(149,565,o),
+(159,565,o),
+(158,573,c),
+(126,593,l),
+(196,380,l),
+(104,380,l),
+(104,481,l),
+(65,481,l),
+(65,233,l),
+(104,233,l),
+(104,334,l),
+(196,334,l),
+(126,121,l),
+(158,141,l),
+(159,149,o),
+(149,149,o),
+(143,149,cs),
+(98,149,o),
+(65,118,o),
+(65,53,cs),
+(65,0,l),
+(123,0,l),
+(123,35,ls),
+(123,81,o),
+(139,94,o),
+(157,94,cs),
+(201,94,o),
+(277,-13,o),
+(362,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(291,44,o),
+(229,122,o),
+(176,141,c),
+(238,334,l),
+(299,334,l),
+(299,232,l),
+(335,232,l),
+(335,347,l),
+(319,334,l),
+(332,334,ls),
+(404,334,o),
+(445,280,o),
+(445,184,cs),
+(445,98,o),
+(407,44,o),
+(348,44,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(335,471,l),
+(299,471,l),
+(299,380,l),
+(238,380,l),
+(176,573,l),
+(229,592,o),
+(291,670,o),
+(347,670,cs),
+(407,670,o),
+(445,616,o),
+(445,530,cs),
+(445,434,o),
+(401,380,o),
+(332,380,cs),
+(319,380,l),
+(335,367,l)
+);
+}
+);
+width = 568;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166A;
+unicode = 5738;
+},
+{
+color = 9;
+glyphname = "ttsiCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(446,-13,o),
+(506,61,o),
+(506,178,cs),
+(506,279,o),
+(463,346,o),
+(386,362,c),
+(386,352,l),
+(463,368,o),
+(506,436,o),
+(506,536,cs),
+(506,653,o),
+(446,727,o),
+(362,727,cs),
+(277,727,o),
+(201,620,o),
+(157,620,cs),
+(139,620,o),
+(123,633,o),
+(123,679,cs),
+(123,714,l),
+(65,714,l),
+(65,661,ls),
+(65,596,o),
+(98,565,o),
+(143,565,cs),
+(150,565,o),
+(158,565,o),
+(161,574,c),
+(131,580,l),
+(196,380,l),
+(104,380,l),
+(104,481,l),
+(65,481,l),
+(65,233,l),
+(104,233,l),
+(104,334,l),
+(196,334,l),
+(128,128,l),
+(160,140,l),
+(158,149,o),
+(149,149,o),
+(143,149,cs),
+(98,149,o),
+(65,118,o),
+(65,53,cs),
+(65,0,l),
+(123,0,l),
+(123,35,ls),
+(123,81,o),
+(139,94,o),
+(157,94,cs),
+(201,94,o),
+(277,-13,o),
+(362,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(291,44,o),
+(225,125,o),
+(172,143,c),
+(234,334,l),
+(255,334,l),
+(262,312,o),
+(282,296,o),
+(306,296,cs),
+(332,296,o),
+(355,316,o),
+(359,343,c),
+(315,334,l),
+(335,334,ls),
+(406,334,o),
+(445,280,o),
+(445,184,cs),
+(445,98,o),
+(407,44,o),
+(348,44,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(355,398,o),
+(333,418,o),
+(306,418,cs),
+(283,418,o),
+(262,402,o),
+(255,380,c),
+(234,380,l),
+(172,571,l),
+(225,589,o),
+(291,670,o),
+(347,670,cs),
+(407,670,o),
+(445,616,o),
+(445,530,cs),
+(445,434,o),
+(404,380,o),
+(335,380,cs),
+(315,380,l),
+(359,371,l)
+);
+}
+);
+width = 568;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166B;
+unicode = 5739;
+},
+{
+color = 9;
+glyphname = "ttsaCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(291,-13,o),
+(367,94,o),
+(411,94,cs),
+(429,94,o),
+(445,81,o),
+(445,35,cs),
+(445,0,l),
+(503,0,l),
+(503,53,ls),
+(503,118,o),
+(470,149,o),
+(425,149,cs),
+(416,149,o),
+(406,148,o),
+(404,139,c),
+(440,119,l),
+(369,334,l),
+(464,334,l),
+(464,233,l),
+(503,233,l),
+(503,481,l),
+(464,481,l),
+(464,380,l),
+(369,380,l),
+(440,595,l),
+(404,575,l),
+(405,566,o),
+(416,565,o),
+(425,565,cs),
+(470,565,o),
+(503,596,o),
+(503,661,cs),
+(503,714,l),
+(445,714,l),
+(445,679,ls),
+(445,633,o),
+(429,620,o),
+(411,620,cs),
+(367,620,o),
+(291,727,o),
+(207,727,cs),
+(122,727,o),
+(62,653,o),
+(62,536,cs),
+(62,436,o),
+(106,368,o),
+(182,352,c),
+(182,362,l),
+(106,346,o),
+(62,279,o),
+(62,178,cs),
+(62,61,o),
+(122,-13,o),
+(206,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(161,44,o),
+(123,98,o),
+(123,184,cs),
+(123,280,o),
+(165,334,o),
+(236,334,cs),
+(325,334,l),
+(388,139,l),
+(336,120,o),
+(276,44,o),
+(220,44,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(167,380,o),
+(123,434,o),
+(123,530,cs),
+(123,616,o),
+(161,670,o),
+(221,670,cs),
+(276,670,o),
+(336,594,o),
+(388,575,c),
+(325,380,l),
+(236,380,ls)
+);
+}
+);
+width = 568;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni166C;
+unicode = 5740;
+},
+{
+glyphname = "qai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (252,0);
+ref = "ke-canadian";
+}
+);
+width = 718;
+}
+);
+note = uni166F;
+unicode = 5743;
+},
+{
+glyphname = "ngai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (488,0);
+ref = "ce-canadian";
+}
+);
+width = 948;
+}
+);
+note = uni1670;
+unicode = 5744;
+},
+{
+glyphname = "nngi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (735,0);
+ref = "ci-canadian";
+}
+);
+width = 1195;
+}
+);
+note = uni1671;
+unicode = 5745;
+},
+{
+glyphname = "nngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (735,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (910,0);
+ref = dot_top;
+}
+);
+width = 1195;
+}
+);
+note = uni1672;
+unicode = 5746;
+},
+{
+glyphname = "nngo-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (735,0);
+ref = "ce-canadian";
+}
+);
+width = 1195;
+}
+);
+note = uni1673;
+unicode = 5747;
+},
+{
+glyphname = "nngoo-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (735,0);
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (902,0);
+ref = dot_top;
+}
+);
+width = 1195;
+}
+);
+note = uni1674;
+unicode = 5748;
+},
+{
+glyphname = "nnga-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (735,0);
+ref = "ca-canadian";
+}
+);
+width = 1195;
+}
+);
+note = uni1675;
+unicode = 5749;
+},
+{
+glyphname = "nngaa-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (735,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (768,0);
+ref = dot_top;
+}
+);
+width = 1195;
+}
+);
+note = uni1676;
+unicode = 5750;
+},
+{
+glyphname = "thweeWoodScree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (485,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 660;
+}
+);
+note = uni1677;
+unicode = 5751;
+},
+{
+glyphname = "thwiWoodScree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (485,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 660;
+}
+);
+note = uni1678;
+unicode = 5752;
+},
+{
+glyphname = "thwiiWoodScree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (70,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (485,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 660;
+}
+);
+note = uni1679;
+unicode = 5753;
+},
+{
+glyphname = "thwoWoodScree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (485,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 660;
+}
+);
+note = uni167A;
+unicode = 5754;
+},
+{
+glyphname = "thwooWoodScree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (295,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (485,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 660;
+}
+);
+note = uni167B;
+unicode = 5755;
+},
+{
+glyphname = "thwaWoodScree-canadian";
+lastChange = "2023-01-13 15:31:47 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = middle_right_can;
+pos = (484,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 660;
+}
+);
+note = uni167C;
+unicode = 5756;
+},
+{
+glyphname = "thwaaWoodScree-canadian";
+lastChange = "2023-01-13 15:31:47 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (69,0);
+ref = dot_top;
+},
+{
+anchor = middle_right_can;
+pos = (484,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 660;
+}
+);
+note = uni167D;
+unicode = 5757;
+},
+{
+glyphname = "wBlackfoot-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(300,584,l),
+(300,625,l),
+(52,625,l),
+(52,584,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(300,446,l),
+(300,487,l),
+(52,487,l),
+(52,446,l)
+);
+}
+);
+width = 352;
+}
+);
+metricRight = "=|";
+note = uni167F;
+unicode = 5759;
+},
+{
+glyphname = "oy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-28,0);
+ref = ring_top.canadian;
+}
+);
+width = 539;
+}
+);
+note = uni18B0;
+unicode = 6320;
+},
+{
+glyphname = "ay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (327,0);
+ref = ring_top.canadian;
+}
+);
+width = 539;
+}
+);
+note = uni18B1;
+unicode = 6321;
+},
+{
+glyphname = "aay-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (124,0);
+ref = ring_top.canadian;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (385,0);
+ref = dot_top;
+}
+);
+width = 539;
+}
+);
+note = uni18B2;
+unicode = 6322;
+},
+{
+glyphname = "way-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (503,0);
+ref = ring_top.canadian;
+}
+);
+width = 714;
+}
+);
+note = uni18B3;
+unicode = 6323;
+},
+{
+glyphname = "poy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-48,0);
+ref = ring_top.canadian;
+}
+);
+width = 512;
+}
+);
+note = uni18B4;
+unicode = 6324;
+},
+{
+glyphname = "pay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (323,0);
+ref = ring_top.canadian;
+}
+);
+width = 512;
+}
+);
+note = uni18B5;
+unicode = 6325;
+},
+{
+glyphname = "pwoy-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (128,0);
+ref = ring_top.canadian;
+}
+);
+width = 687;
+}
+);
+note = uni18B6;
+unicode = 6326;
+},
+{
+glyphname = "tay-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (141,0);
+ref = ring_top.canadian;
+}
+);
+width = 469;
+}
+);
+note = uni18B7;
+unicode = 6327;
+},
+{
+glyphname = "kay-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-25,0);
+ref = ring_top.canadian;
+}
+);
+width = 466;
+}
+);
+note = uni18B8;
+unicode = 6328;
+},
+{
+glyphname = "kway-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (150,0);
+ref = ring_top.canadian;
+}
+);
+width = 641;
+}
+);
+note = uni18B9;
+unicode = 6329;
+},
+{
+glyphname = "may-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-21,0);
+ref = ring_top.canadian;
+}
+);
+width = 412;
+}
+);
+note = uni18BA;
+unicode = 6330;
+},
+{
+glyphname = "noy-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (281,-206);
+ref = ring_top.canadian;
+}
+);
+width = 637;
+}
+);
+note = uni18BB;
+unicode = 6331;
+},
+{
+glyphname = "nay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (118,-206);
+ref = ring_top.canadian;
+}
+);
+width = 637;
+}
+);
+note = uni18BC;
+unicode = 6332;
+},
+{
+glyphname = "lay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (118,-206);
+ref = ring_top.canadian;
+}
+);
+width = 637;
+}
+);
+note = uni18BD;
+unicode = 6333;
+},
+{
+glyphname = "soy-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (208,0);
+ref = ring_top.canadian;
+}
+);
+width = 423;
+}
+);
+note = uni18BE;
+unicode = 6334;
+},
+{
+glyphname = "say-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-21,0);
+ref = ring_top.canadian;
+}
+);
+width = 423;
+}
+);
+note = uni18BF;
+unicode = 6335;
+},
+{
+glyphname = "shoy-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (250,-206);
+ref = ring_top.canadian;
+}
+);
+width = 737;
+}
+);
+note = uni18C0;
+unicode = 6336;
+},
+{
+glyphname = "shay-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (251,-206);
+ref = ring_top.canadian;
+}
+);
+width = 737;
+}
+);
+note = uni18C1;
+unicode = 6337;
+},
+{
+glyphname = "shwoy-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (425,-206);
+ref = ring_top.canadian;
+}
+);
+width = 913;
+}
+);
+note = uni18C2;
+unicode = 6338;
+},
+{
+glyphname = "yoy-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (237,0);
+ref = ring_top.canadian;
+}
+);
+width = 448;
+}
+);
+note = uni18C3;
+unicode = 6339;
+},
+{
+glyphname = "yay-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-25,0);
+ref = ring_top.canadian;
+}
+);
+width = 448;
+}
+);
+note = uni18C4;
+unicode = 6340;
+},
+{
+glyphname = "ray-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (120,0);
+ref = ring_top.canadian;
+}
+);
+width = 424;
+}
+);
+note = uni18C5;
+unicode = 6341;
+},
+{
+glyphname = "nwi-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ni-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni18C6;
+unicode = 6342;
+},
+{
+glyphname = "nwiOjibway-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni18C7;
+unicode = 6343;
+},
+{
+glyphname = "nwii-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (358,-206);
+ref = dot_top;
+}
+);
+width = 812;
+}
+);
+note = uni18C8;
+unicode = 6344;
+},
+{
+glyphname = "nwiiOjibway-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (183,-206);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni18C9;
+unicode = 6345;
+},
+{
+glyphname = "nwo-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "no-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni18CA;
+unicode = 6346;
+},
+{
+glyphname = "nwoOjibway-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni18CB;
+unicode = 6347;
+},
+{
+glyphname = "nwoo-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (514,-206);
+ref = dot_top;
+}
+);
+width = 812;
+}
+);
+note = uni18CC;
+unicode = 6348;
+},
+{
+glyphname = "nwooOjibway-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (339,-206);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (637,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 812;
+}
+);
+note = uni18CD;
+unicode = 6349;
+},
+{
+glyphname = "rwee-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "reRCree-canadian";
+}
+);
+width = 847;
+}
+);
+note = uni18CE;
+unicode = 6350;
+},
+{
+glyphname = "rwi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ri-canadian";
+}
+);
+width = 847;
+}
+);
+note = uni18CF;
+unicode = 6351;
+},
+{
+glyphname = "rwii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (352,-206);
+ref = dot_top;
+}
+);
+width = 847;
+}
+);
+note = uni18D0;
+unicode = 6352;
+},
+{
+glyphname = "rwo-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ro-canadian";
+}
+);
+width = 600;
+}
+);
+note = uni18D1;
+unicode = 6353;
+},
+{
+glyphname = "rwoo-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (300,0);
+ref = dot_top;
+}
+);
+width = 600;
+}
+);
+note = uni18D2;
+unicode = 6354;
+},
+{
+glyphname = "rwa-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = "ra-canadian";
+}
+);
+width = 600;
+}
+);
+note = uni18D3;
+unicode = 6355;
+},
+{
+glyphname = "pOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(73,357,l),
+(171,663,l),
+(144,663,l),
+(241,357,l),
+(282,357,l),
+(282,369,l),
+(164,714,l),
+(151,714,l),
+(32,369,l),
+(32,357,l)
+);
+}
+);
+width = 314;
+}
+);
+metricLeft = "kkCarrier-canadian";
+note = uni18D4;
+unicode = 6356;
+},
+{
+glyphname = "tOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 329;
+}
+);
+metricRight = "=|";
+note = uni1422;
+unicode = 6357;
+},
+{
+glyphname = "kOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,356,l),
+(97,531,l),
+(85,531,l),
+(88,479,o),
+(118,448,o),
+(158,448,cs),
+(207,448,o),
+(246,493,o),
+(246,580,cs),
+(246,675,o),
+(203,719,o),
+(149,719,cs),
+(91,719,o),
+(52,672,o),
+(52,584,cs),
+(52,356,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(117,485,o),
+(94,514,o),
+(94,583,cs),
+(94,656,o),
+(115,683,o),
+(150,683,cs),
+(183,683,o),
+(205,653,o),
+(205,583,cs),
+(205,513,o),
+(182,485,o),
+(150,485,cs)
+);
+}
+);
+width = 288;
+}
+);
+metricLeft = "k-canadian";
+metricRight = "k-canadian";
+note = uni18D6;
+unicode = 6358;
+},
+{
+glyphname = "cOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,357,l),
+(97,598,ls),
+(97,655,o),
+(115,681,o),
+(151,681,cs),
+(184,681,o),
+(205,654,o),
+(205,604,cs),
+(205,569,l),
+(246,569,l),
+(246,597,ls),
+(246,676,o),
+(207,720,o),
+(150,720,cs),
+(89,720,o),
+(52,677,o),
+(52,592,cs),
+(52,357,l)
+);
+}
+);
+width = 279;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni18D7;
+unicode = 6359;
+},
+{
+glyphname = "mOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,357,l),
+(97,670,l),
+(225,670,l),
+(225,714,l),
+(52,714,l),
+(52,357,l)
+);
+}
+);
+width = 254;
+}
+);
+metricLeft = "m-canadian";
+metricRight = "m-canadian";
+note = uni18D8;
+unicode = 6360;
+},
+{
+glyphname = "nOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(196,443,o),
+(234,489,o),
+(234,576,cs),
+(234,628,o),
+(220,675,o),
+(189,690,c),
+(188,670,l),
+(333,670,l),
+(333,714,l),
+(144,714,ls),
+(79,714,o),
+(42,665,o),
+(42,577,cs),
+(42,490,o),
+(80,443,o),
+(138,443,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(104,480,o),
+(83,509,o),
+(83,577,cs),
+(83,646,o),
+(104,677,o),
+(138,677,cs),
+(172,677,o),
+(193,647,o),
+(193,578,cs),
+(193,510,o),
+(173,480,o),
+(139,480,cs)
+);
+}
+);
+width = 362;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "n-canadian";
+note = uni18D9;
+unicode = 6361;
+},
+{
+glyphname = "sOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,357,l),
+(97,504,l),
+(71,482,l),
+(96,482,ls),
+(178,482,o),
+(224,531,o),
+(224,629,cs),
+(224,714,l),
+(179,714,l),
+(179,632,ls),
+(179,554,o),
+(150,520,o),
+(86,520,cs),
+(52,520,l),
+(52,357,l)
+);
+}
+);
+width = 276;
+}
+);
+metricLeft = "s-canadian";
+metricRight = "s-canadian";
+note = uni18DA;
+unicode = 6362;
+},
+{
+color = 1;
+glyphname = "shOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(190,351,o),
+(221,392,o),
+(226,473,cs),
+(235,602,ls),
+(239,655,o),
+(254,681,o),
+(287,681,cs),
+(321,681,o),
+(341,656,o),
+(341,605,cs),
+(341,569,l),
+(383,569,l),
+(383,601,ls),
+(383,679,o),
+(345,720,o),
+(289,720,cs),
+(227,720,o),
+(196,679,o),
+(191,598,cs),
+(181,469,ls),
+(178,416,o),
+(163,390,o),
+(130,390,cs),
+(96,390,o),
+(76,415,o),
+(76,466,cs),
+(76,502,l),
+(33,502,l),
+(33,470,ls),
+(33,392,o),
+(71,351,o),
+(128,351,cs)
+);
+}
+);
+width = 416;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "c-canadian";
+note = uni18DB;
+unicode = 6363;
+},
+{
+color = 9;
+glyphname = "easternw-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (30,-318);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (102,0);
+ref = "glottalstop-canadian";
+}
+);
+width = 450;
+}
+);
+note = uni18DC;
+unicode = 6364;
+},
+{
+color = 9;
+glyphname = "westernw-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (431,-318);
+ref = dot_top;
+scale = (-1,1);
+},
+{
+alignment = -1;
+pos = (348,0);
+ref = "glottalstop-canadian";
+scale = (-1,1);
+}
+);
+width = 461;
+}
+);
+metricLeft = "glottalstop-canadian";
+note = uni18DD;
+unicode = 6365;
+},
+{
+glyphname = "rweRCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "reRCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (671,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 847;
+}
+);
+note = uni18E0;
+unicode = 6368;
+},
+{
+glyphname = "looWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+}
+);
+width = 424;
+}
+);
+note = uni18E1;
+unicode = 6369;
+},
+{
+glyphname = "laaWestCree-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (267,0);
+ref = dot_top;
+}
+);
+width = 424;
+}
+);
+note = uni18E2;
+unicode = 6370;
+},
+{
+glyphname = "thwe-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "the-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (571,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 746;
+}
+);
+note = uni18E3;
+unicode = 6371;
+},
+{
+glyphname = "thwa-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (525,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 700;
+}
+);
+note = uni18E4;
+unicode = 6372;
+},
+{
+glyphname = "tthwe-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "tthe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (564,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 739;
+}
+);
+note = uni18E5;
+unicode = 6373;
+},
+{
+glyphname = "tthoo-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ttho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (190,0);
+ref = dot_top;
+}
+);
+width = 490;
+}
+);
+note = uni18E6;
+unicode = 6374;
+},
+{
+glyphname = "tthaa-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ttha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (190,0);
+ref = dot_top;
+}
+);
+width = 490;
+}
+);
+note = uni18E7;
+unicode = 6375;
+},
+{
+glyphname = "tlhwe-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "tlhe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (470,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 645;
+}
+);
+note = uni18E8;
+unicode = 6376;
+},
+{
+glyphname = "tlhoo-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "tlho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (186,0);
+ref = dot_top;
+}
+);
+width = 470;
+}
+);
+note = uni18E9;
+unicode = 6377;
+},
+{
+glyphname = "shweSayisi-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "sheSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (471,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 647;
+}
+);
+note = uni18EA;
+unicode = 6378;
+},
+{
+glyphname = "shooSayisi-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "shoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (318,0);
+ref = dot_top;
+}
+);
+width = 471;
+}
+);
+note = uni18EB;
+unicode = 6379;
+},
+{
+color = 9;
+glyphname = "hooSayisi-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "hoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (363,0);
+ref = dot_top;
+}
+);
+width = 520;
+}
+);
+note = uni18EC;
+unicode = 6380;
+},
+{
+color = 9;
+glyphname = "gwuCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "guCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (667,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 843;
+}
+);
+note = uni18ED;
+unicode = 6381;
+},
+{
+color = 9;
+glyphname = "deneGeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "geCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (218,0);
+ref = dot_top;
+}
+);
+width = 553;
+}
+);
+note = uni18EE;
+unicode = 6382;
+},
+{
+color = 9;
+glyphname = "gaaCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (229,0);
+ref = dot_top;
+}
+);
+width = 553;
+}
+);
+note = uni18EF;
+unicode = 6383;
+},
+{
+color = 9;
+glyphname = "gwaCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (553,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 729;
+}
+);
+note = uni18F0;
+unicode = 6384;
+},
+{
+color = 9;
+glyphname = "juuSayisi-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "juSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (217,0);
+ref = dot_top;
+}
+);
+width = 549;
+}
+);
+note = uni18F1;
+unicode = 6385;
+},
+{
+color = 9;
+glyphname = "jwaCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "jaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (602,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 777;
+}
+);
+note = uni18F2;
+unicode = 6386;
+},
+{
+glyphname = "lBeaverDene-canadian";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+ref = "pWestCree-canadian";
+}
+);
+width = 149;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+unicode = 6387;
+},
+{
+glyphname = "rBeaverDene-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,357,l),
+(97,580,ls),
+(97,640,o),
+(115,673,o),
+(153,673,cs),
+(161,673,l),
+(161,720,l),
+(153,720,ls),
+(115,720,o),
+(89,681,o),
+(88,636,c),
+(93,636,l),
+(93,714,l),
+(52,714,l),
+(52,357,l)
+);
+}
+);
+width = 189;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni18F4;
+unicode = 6388;
+},
+{
+color = 6;
+glyphname = "sDentalCarrier-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(164,190,ls),
+(231,190,o),
+(265,226,o),
+(265,289,cs),
+(265,350,o),
+(234,388,o),
+(172,388,cs),
+(152,388,ls),
+(118,388,o),
+(95,402,o),
+(95,447,cs),
+(95,491,o),
+(119,507,o),
+(152,507,cs),
+(261,507,l),
+(261,546,l),
+(153,546,ls),
+(87,546,o),
+(52,509,o),
+(52,446,cs),
+(52,386,o),
+(84,348,o),
+(145,348,cs),
+(166,348,ls),
+(199,348,o),
+(222,332,o),
+(222,288,cs),
+(222,245,o),
+(199,229,o),
+(166,229,cs),
+(57,229,l),
+(57,190,l)
+);
+}
+);
+width = 317;
+}
+);
+metricLeft = "shCarrier-canadian";
+metricRight = "=|";
+note = uni18F5;
+unicode = 6389;
+},
+{
+glyphname = "pWestCree-canadian.base";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "pWestCree-canadian";
+}
+);
+width = 149;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.base";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "c-canadian";
+}
+);
+width = 279;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "thSayisi-canadian.base";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "thSayisi-canadian";
+}
+);
+width = 279;
+}
+);
+metricLeft = "=|c-canadian";
+note = uni14A2;
+},
+{
+glyphname = "mWestCree-canadian.base";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "mWestCree-canadian";
+}
+);
+width = 286;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+glyphname = "pWestCree-canadian.mid";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "pWestCree-canadian";
+}
+);
+width = 150;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.mid";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "c-canadian";
+}
+);
+width = 279;
+}
+);
+metricLeft = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "mWestCree-canadian.mid";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "mWestCree-canadian";
+}
+);
+width = 286;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+color = 11;
+glyphname = "ngaai-canadian.nunavik";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (499,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (617,0);
+ref = ring_top.canadian;
+}
+);
+width = 961;
+}
+);
+note = uni158E;
+},
+{
+color = 11;
+glyphname = "ngi-canadian.nunavik";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (499,0);
+ref = "ci-canadian";
+}
+);
+width = 961;
+}
+);
+note = uni158F;
+},
+{
+color = 11;
+glyphname = "ngii-canadian.nunavik";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (499,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (674,0);
+ref = dot_top;
+}
+);
+width = 961;
+}
+);
+note = uni1590;
+},
+{
+color = 11;
+glyphname = "ngo-canadian.nunavik";
+lastChange = "2023-01-13 15:31:47 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (499,0);
+ref = "co-canadian";
+}
+);
+width = 960;
+}
+);
+note = uni1591;
+},
+{
+color = 11;
+glyphname = "ngoo-canadian.nunavik";
+lastChange = "2023-01-13 15:31:47 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+ref = "ngo-canadian.nunavik";
+},
+{
+anchor = top_right_can;
+pos = (807,0);
+ref = dot_top;
+}
+);
+width = 960;
+}
+);
+note = uni1592;
+},
+{
+color = 11;
+glyphname = "nga-canadian.nunavik";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (499,0);
+ref = "ca-canadian";
+}
+);
+width = 961;
+}
+);
+note = uni1593;
+},
+{
+color = 11;
+glyphname = "ngaa-canadian.nunavik";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (499,0);
+ref = "ca-canadian";
+},
+{
+anchor = top_left_can;
+pos = (532,0);
+ref = dot_top;
+}
+);
+width = 961;
+}
+);
+note = uni1594;
+},
+{
+color = 11;
+glyphname = "ng-canadian.nunavik";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(414,157,o),
+(457,202,o),
+(457,296,cs),
+(457,384,o),
+(418,428,o),
+(368,428,cs),
+(328,428,o),
+(298,397,o),
+(295,345,c),
+(308,345,l),
+(308,493,l),
+(187,493,l),
+(189,472,l),
+(220,487,o),
+(234,535,o),
+(234,587,cs),
+(234,674,o),
+(196,720,o),
+(138,720,cs),
+(80,720,o),
+(42,673,o),
+(42,585,cs),
+(42,498,o),
+(79,449,o),
+(144,449,cs),
+(291,449,l),
+(263,477,l),
+(263,293,ls),
+(263,204,o),
+(301,157,o),
+(360,157,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(325,195,o),
+(306,221,o),
+(306,293,cs),
+(306,362,o),
+(328,391,o),
+(361,391,cs),
+(393,391,o),
+(415,363,o),
+(415,294,cs),
+(415,224,o),
+(393,195,o),
+(361,195,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(104,485,o),
+(83,517,o),
+(83,585,cs),
+(83,654,o),
+(104,683,o),
+(139,683,cs),
+(173,683,o),
+(193,653,o),
+(193,585,cs),
+(193,516,o),
+(172,485,o),
+(138,485,cs)
+);
+}
+);
+width = 499;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+color = 11;
+glyphname = "ngai-canadian.nunavik";
+lastChange = "2023-01-13 15:31:47 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (499,0);
+ref = "ce-canadian";
+}
+);
+width = 960;
+}
+);
+note = uni1670;
+},
+{
+color = 11;
+glyphname = "ke-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (263,714);
+},
+{
+name = top_left_can;
+pos = (84,714);
+},
+{
+name = top_right_can;
+pos = (441,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(472,0,l),
+(472,714,l),
+(338,714,ls),
+(147,714,o),
+(52,610,o),
+(52,427,cs),
+(52,243,o),
+(147,141,o),
+(338,141,cs),
+(408,141,l),
+(408,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(183,198,o),
+(116,277,o),
+(116,427,cs),
+(116,577,o),
+(183,657,o),
+(335,657,cs),
+(408,657,l),
+(408,198,l),
+(335,198,ls)
+);
+}
+);
+width = 537;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146B;
+},
+{
+color = 11;
+glyphname = "ki-canadian.square";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (275,714);
+},
+{
+name = top_left_can;
+pos = (97,714);
+},
+{
+name = top_right_can;
+pos = (453,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(128,0,l),
+(128,141,l),
+(198,141,ls),
+(390,141,o),
+(484,243,o),
+(484,427,cs),
+(484,610,o),
+(390,714,o),
+(198,714,cs),
+(65,714,l),
+(65,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(128,657,l),
+(202,657,ls),
+(353,657,o),
+(421,577,o),
+(421,427,cs),
+(421,277,o),
+(353,198,o),
+(202,198,cs),
+(128,198,l)
+);
+}
+);
+width = 536;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni146D;
+},
+{
+color = 11;
+glyphname = "kii-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (214,0);
+ref = dot_top;
+}
+);
+width = 537;
+}
+);
+note = uni146E;
+},
+{
+color = 11;
+glyphname = "ko-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (263,714);
+},
+{
+name = top_left_can;
+pos = (84,714);
+},
+{
+name = top_right_can;
+pos = (441,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(472,0,l),
+(472,714,l),
+(408,714,l),
+(408,573,l),
+(338,573,ls),
+(147,573,o),
+(52,471,o),
+(52,287,cs),
+(52,104,o),
+(147,0,o),
+(338,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(183,57,o),
+(116,137,o),
+(116,287,cs),
+(116,437,o),
+(183,516,o),
+(335,516,cs),
+(408,516,l),
+(408,57,l),
+(335,57,ls)
+);
+}
+);
+width = 537;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146F;
+},
+{
+color = 11;
+glyphname = "koo-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (380,0);
+ref = dot_top;
+}
+);
+width = 537;
+}
+);
+note = uni1470;
+},
+{
+color = 11;
+glyphname = "ka-canadian.square";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (275,714);
+},
+{
+name = top_left_can;
+pos = (97,714);
+},
+{
+name = top_right_can;
+pos = (453,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(198,0,ls),
+(390,0,o),
+(484,104,o),
+(484,287,cs),
+(484,471,o),
+(390,573,o),
+(198,573,cs),
+(128,573,l),
+(128,714,l),
+(65,714,l),
+(65,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(128,516,l),
+(202,516,ls),
+(353,516,o),
+(421,437,o),
+(421,287,cs),
+(421,137,o),
+(353,57,o),
+(202,57,cs),
+(128,57,l)
+);
+}
+);
+width = 536;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1472;
+},
+{
+color = 11;
+glyphname = "kaa-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+}
+);
+width = 537;
+}
+);
+note = uni1473;
+},
+{
+color = 11;
+glyphname = "kweWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (537,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 712;
+}
+);
+note = uni1475;
+},
+{
+color = 11;
+glyphname = "kwiiWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (214,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (537,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 712;
+}
+);
+note = uni1479;
+},
+{
+color = 11;
+glyphname = "kwoWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (537,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 712;
+}
+);
+note = uni147B;
+},
+{
+color = 11;
+glyphname = "kwooWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (380,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (537,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 712;
+}
+);
+note = uni147D;
+},
+{
+color = 11;
+glyphname = "kwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (537,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 712;
+}
+);
+note = uni147F;
+},
+{
+color = 11;
+glyphname = "kwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (537,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 712;
+}
+);
+note = uni1481;
+},
+{
+color = 11;
+glyphname = "ce-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (274,714);
+},
+{
+name = top_left_can;
+pos = (86,714);
+},
+{
+name = top_right_can;
+pos = (463,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(494,0,l),
+(494,471,ls),
+(494,639,o),
+(409,727,o),
+(274,727,cs),
+(135,727,o),
+(54,640,o),
+(54,466,cs),
+(54,405,l),
+(117,405,l),
+(117,470,ls),
+(117,606,o),
+(173,667,o),
+(275,667,cs),
+(371,667,o),
+(430,604,o),
+(430,475,cs),
+(430,0,l)
+);
+}
+);
+width = 555;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni1489;
+},
+{
+color = 11;
+glyphname = "ci-canadian.square";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (281,714);
+},
+{
+name = top_left_can;
+pos = (94,714);
+},
+{
+name = top_right_can;
+pos = (471,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(125,0,l),
+(125,475,ls),
+(125,604,o),
+(184,667,o),
+(281,667,cs),
+(382,667,o),
+(439,606,o),
+(439,470,cs),
+(439,405,l),
+(502,405,l),
+(502,466,ls),
+(502,640,o),
+(420,727,o),
+(281,727,cs),
+(147,727,o),
+(61,639,o),
+(61,471,cs),
+(61,0,l)
+);
+}
+);
+width = 556;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+},
+{
+color = 11;
+glyphname = "cii-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (221,0);
+ref = dot_top;
+}
+);
+width = 555;
+}
+);
+note = uni148C;
+},
+{
+color = 11;
+glyphname = "co-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (274,714);
+},
+{
+name = top_left_can;
+pos = (86,714);
+},
+{
+name = top_right_can;
+pos = (463,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(409,-13,o),
+(494,75,o),
+(494,243,cs),
+(494,714,l),
+(430,714,l),
+(430,239,ls),
+(430,110,o),
+(371,47,o),
+(275,47,cs),
+(173,47,o),
+(117,108,o),
+(117,244,cs),
+(117,309,l),
+(54,309,l),
+(54,248,ls),
+(54,74,o),
+(135,-13,o),
+(274,-13,cs)
+);
+}
+);
+width = 555;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+},
+{
+color = 11;
+glyphname = "coo-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (402,0);
+ref = dot_top;
+}
+);
+width = 555;
+}
+);
+note = uni148E;
+},
+{
+color = 11;
+glyphname = "ca-canadian.square";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (281,714);
+},
+{
+name = top_left_can;
+pos = (94,714);
+},
+{
+name = top_right_can;
+pos = (471,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(420,-13,o),
+(502,74,o),
+(502,248,cs),
+(502,309,l),
+(439,309,l),
+(439,244,ls),
+(439,108,o),
+(382,47,o),
+(281,47,cs),
+(184,47,o),
+(125,110,o),
+(125,239,cs),
+(125,714,l),
+(61,714,l),
+(61,243,ls),
+(61,75,o),
+(147,-13,o),
+(281,-13,cs)
+);
+}
+);
+width = 556;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+},
+{
+color = 11;
+glyphname = "caa-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (33,0);
+ref = dot_top;
+}
+);
+width = 555;
+}
+);
+note = uni1491;
+},
+{
+color = 11;
+glyphname = "me-canadian.square";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (224,714);
+},
+{
+name = top_double;
+pos = (379,714);
+},
+{
+name = top_left_can;
+pos = (66,714);
+},
+{
+name = top_right_can;
+pos = (379,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(411,0,l),
+(411,714,l),
+(34,714,l),
+(34,655,l),
+(347,655,l),
+(347,0,l)
+);
+}
+);
+width = 476;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+},
+{
+color = 11;
+glyphname = "mi-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (253,714);
+},
+{
+name = top_left_can;
+pos = (97,714);
+},
+{
+name = top_right_can;
+pos = (408,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(128,0,l),
+(128,655,l),
+(441,655,l),
+(441,714,l),
+(65,714,l),
+(65,0,l)
+);
+}
+);
+width = 475;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+},
+{
+color = 11;
+glyphname = "mii-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (192,0);
+ref = dot_top;
+}
+);
+width = 475;
+}
+);
+note = uni14A6;
+},
+{
+color = 11;
+glyphname = "mo-canadian.square";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (224,714);
+},
+{
+name = top_double;
+pos = (379,714);
+},
+{
+name = top_left_can;
+pos = (66,714);
+},
+{
+name = top_right_can;
+pos = (379,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(411,0,l),
+(411,714,l),
+(347,714,l),
+(347,59,l),
+(34,59,l),
+(34,0,l)
+);
+}
+);
+width = 476;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+},
+{
+color = 11;
+glyphname = "moo-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (318,0);
+ref = dot_top;
+}
+);
+width = 475;
+}
+);
+note = uni14A8;
+},
+{
+color = 11;
+glyphname = "ma-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (253,714);
+},
+{
+name = top_left_can;
+pos = (97,714);
+},
+{
+name = top_right_can;
+pos = (408,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(441,0,l),
+(441,59,l),
+(128,59,l),
+(128,714,l),
+(65,714,l),
+(65,0,l)
+);
+}
+);
+width = 475;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+},
+{
+color = 11;
+glyphname = "maa-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+}
+);
+width = 475;
+}
+);
+note = uni14AB;
+},
+{
+color = 11;
+glyphname = "ne-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (356,714);
+},
+{
+name = top_left_can;
+pos = (198,714);
+},
+{
+name = top_right_can;
+pos = (515,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(478,-13,o),
+(546,62,o),
+(546,210,cs),
+(546,714,l),
+(51,714,l),
+(51,655,l),
+(166,655,l),
+(166,214,ls),
+(166,62,o),
+(233,-13,o),
+(356,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(270,47,o),
+(229,98,o),
+(229,209,cs),
+(229,655,l),
+(483,655,l),
+(483,209,ls),
+(483,99,o),
+(442,47,o),
+(356,47,cs)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C0;
+},
+{
+color = 11;
+glyphname = "ni-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (251,714);
+},
+{
+name = top_left_can;
+pos = (93,714);
+},
+{
+name = top_right_can;
+pos = (410,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(374,-13,o),
+(441,62,o),
+(441,214,cs),
+(441,655,l),
+(556,655,l),
+(556,714,l),
+(61,714,l),
+(61,210,ls),
+(61,62,o),
+(129,-13,o),
+(251,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(166,47,o),
+(124,99,o),
+(124,209,cs),
+(124,655,l),
+(378,655,l),
+(378,209,ls),
+(378,98,o),
+(337,47,o),
+(251,47,cs)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+},
+{
+color = 11;
+glyphname = "nii-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (191,0);
+ref = dot_top;
+}
+);
+width = 607;
+}
+);
+note = uni14C3;
+},
+{
+color = 11;
+glyphname = "no-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (356,714);
+},
+{
+name = top_double;
+pos = (366,714);
+},
+{
+name = top_left_can;
+pos = (198,714);
+},
+{
+name = top_right_can;
+pos = (505,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(546,0,l),
+(546,504,ls),
+(546,652,o),
+(478,727,o),
+(356,727,cs),
+(233,727,o),
+(166,652,o),
+(166,500,cs),
+(166,59,l),
+(51,59,l),
+(51,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(229,505,ls),
+(229,616,o),
+(270,667,o),
+(356,667,cs),
+(442,667,o),
+(483,615,o),
+(483,505,cs),
+(483,59,l),
+(229,59,l)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C4;
+},
+{
+color = 11;
+glyphname = "noo-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (295,0);
+ref = dot_top;
+}
+);
+width = 607;
+}
+);
+note = uni14C5;
+},
+{
+color = 11;
+glyphname = "na-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (251,714);
+},
+{
+name = top_double;
+pos = (261,714);
+},
+{
+name = top_left_can;
+pos = (93,714);
+},
+{
+name = top_right_can;
+pos = (410,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(556,0,l),
+(556,59,l),
+(441,59,l),
+(441,500,ls),
+(441,652,o),
+(374,727,o),
+(251,727,cs),
+(129,727,o),
+(61,652,o),
+(61,504,cs),
+(61,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(124,505,ls),
+(124,615,o),
+(166,667,o),
+(251,667,cs),
+(337,667,o),
+(378,616,o),
+(378,505,cs),
+(378,59,l),
+(124,59,l)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+},
+{
+color = 11;
+glyphname = "naa-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (191,0);
+ref = dot_top;
+}
+);
+width = 607;
+}
+);
+note = uni14C8;
+},
+{
+color = 11;
+glyphname = "nweWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 783;
+}
+);
+note = uni14CA;
+},
+{
+color = 11;
+glyphname = "nwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 783;
+}
+);
+note = uni14CC;
+},
+{
+color = 11;
+glyphname = "nwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (191,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 783;
+}
+);
+note = uni14CE;
+},
+{
+color = 11;
+glyphname = "se-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (95,714);
+},
+{
+name = top_right_can;
+pos = (459,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(487,0,l),
+(487,238,l),
+(369,238,ls),
+(208,238,o),
+(126,328,o),
+(126,494,cs),
+(126,714,l),
+(63,714,l),
+(63,494,ls),
+(63,294,o),
+(172,181,o),
+(370,181,cs),
+(448,181,l),
+(424,198,l),
+(424,0,l)
+);
+}
+);
+width = 552;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14ED;
+},
+{
+color = 11;
+glyphname = "si-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (97,714);
+},
+{
+name = top_right_can;
+pos = (462,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(128,0,l),
+(128,198,l),
+(104,181,l),
+(182,181,ls),
+(380,181,o),
+(489,294,o),
+(489,487,cs),
+(489,714,l),
+(426,714,l),
+(426,487,ls),
+(426,328,o),
+(344,238,o),
+(185,238,cs),
+(65,238,l),
+(65,0,l)
+);
+}
+);
+width = 552;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+},
+{
+color = 11;
+glyphname = "sii-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (401,0);
+ref = dot_top;
+}
+);
+width = 552;
+}
+);
+note = uni14F0;
+},
+{
+color = 11;
+glyphname = "so-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (456,714);
+},
+{
+name = top_left_can;
+pos = (95,714);
+},
+{
+name = top_right_can;
+pos = (456,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(126,0,l),
+(126,220,ls),
+(126,386,o),
+(208,476,o),
+(369,476,cs),
+(487,476,l),
+(487,714,l),
+(424,714,l),
+(424,516,l),
+(448,533,l),
+(370,533,ls),
+(172,533,o),
+(63,420,o),
+(63,220,cs),
+(63,0,l)
+);
+}
+);
+width = 552;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+},
+{
+color = 11;
+glyphname = "soo-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (395,0);
+ref = dot_top;
+}
+);
+width = 552;
+}
+);
+note = uni14F2;
+},
+{
+color = 11;
+glyphname = "sa-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (100,714);
+},
+{
+name = top_right_can;
+pos = (458,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(489,0,l),
+(489,220,ls),
+(489,420,o),
+(380,533,o),
+(182,533,cs),
+(104,533,l),
+(128,516,l),
+(128,714,l),
+(65,714,l),
+(65,476,l),
+(183,476,ls),
+(344,476,o),
+(426,386,o),
+(426,220,cs),
+(426,0,l)
+);
+}
+);
+width = 552;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+},
+{
+color = 11;
+glyphname = "saa-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (39,0);
+ref = dot_top;
+}
+);
+width = 552;
+}
+);
+note = uni14F5;
+},
+{
+color = 11;
+glyphname = "sho-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (270,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(473,0,l),
+(473,54,l),
+(243,54,ls),
+(155,54,o),
+(120,103,o),
+(120,192,cs),
+(120,282,o),
+(155,330,o),
+(243,330,cs),
+(309,330,ls),
+(424,330,o),
+(483,402,o),
+(483,523,cs),
+(483,642,o),
+(424,714,o),
+(309,714,cs),
+(66,714,l),
+(66,660,l),
+(297,660,ls),
+(384,660,o),
+(419,611,o),
+(419,523,cs),
+(419,432,o),
+(384,385,o),
+(297,385,cs),
+(230,385,ls),
+(115,385,o),
+(56,312,o),
+(56,192,cs),
+(56,72,o),
+(115,0,o),
+(230,0,cs)
+);
+}
+);
+width = 539;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+color = 11;
+glyphname = "shoo-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (209,0);
+ref = dot_top;
+}
+);
+width = 539;
+}
+);
+note = g728;
+},
+{
+color = 11;
+glyphname = "sha-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (270,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(309,0,ls),
+(424,0,o),
+(482,72,o),
+(482,191,cs),
+(482,312,o),
+(424,384,o),
+(309,384,cs),
+(242,384,ls),
+(155,384,o),
+(119,432,o),
+(119,522,cs),
+(119,611,o),
+(154,660,o),
+(242,660,cs),
+(473,660,l),
+(473,714,l),
+(229,714,ls),
+(113,714,o),
+(56,641,o),
+(56,522,cs),
+(56,402,o),
+(113,330,o),
+(229,330,cs),
+(296,330,ls),
+(383,330,o),
+(418,282,o),
+(418,191,cs),
+(418,102,o),
+(383,54,o),
+(296,54,cs),
+(65,54,l),
+(65,0,l)
+);
+}
+);
+width = 538;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+color = 11;
+glyphname = "shaa-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (209,0);
+ref = dot_top;
+}
+);
+width = 538;
+}
+);
+note = g730;
+},
+{
+color = 11;
+glyphname = "ye-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (75,714);
+},
+{
+name = top_right_can;
+pos = (471,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(503,0,l),
+(503,238,l),
+(127,238,l),
+(126,210,l),
+(518,687,l),
+(471,726,l),
+(41,206,l),
+(41,181,l),
+(439,181,l),
+(439,0,l)
+);
+}
+);
+width = 564;
+}
+);
+metricLeft = "ye-canadian";
+note = uni1526;
+},
+{
+color = 11;
+glyphname = "yi-canadian.square";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (94,714);
+},
+{
+name = top_right_can;
+pos = (490,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(126,0,l),
+(126,181,l),
+(523,181,l),
+(523,206,l),
+(94,726,l),
+(47,687,l),
+(438,210,l),
+(438,238,l),
+(62,238,l),
+(62,0,l)
+);
+}
+);
+width = 564;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni1528;
+},
+{
+color = 11;
+glyphname = "yii-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (33,0);
+ref = dot_top;
+}
+);
+width = 564;
+}
+);
+note = uni1529;
+},
+{
+color = 11;
+glyphname = "yo-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (471,714);
+},
+{
+name = top_left_can;
+pos = (75,714);
+},
+{
+name = top_right_can;
+pos = (471,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(518,27,l),
+(126,504,l),
+(127,476,l),
+(503,476,l),
+(503,714,l),
+(439,714,l),
+(439,533,l),
+(41,533,l),
+(41,508,l),
+(471,-12,l)
+);
+}
+);
+width = 564;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152A;
+},
+{
+color = 11;
+glyphname = "yoo-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (411,0);
+ref = dot_top;
+}
+);
+width = 564;
+}
+);
+note = uni152B;
+},
+{
+color = 11;
+glyphname = "ya-canadian.square";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (94,714);
+},
+{
+name = top_right_can;
+pos = (490,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(523,508,l),
+(523,533,l),
+(126,533,l),
+(126,714,l),
+(62,714,l),
+(62,476,l),
+(438,476,l),
+(438,504,l),
+(47,27,l),
+(94,-12,l)
+);
+}
+);
+width = 564;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152D;
+},
+{
+color = 11;
+glyphname = "yaa-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (33,0);
+ref = dot_top;
+}
+);
+width = 564;
+}
+);
+note = uni152E;
+},
+{
+color = 11;
+glyphname = "re-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (251,714);
+},
+{
+name = top_left_can;
+pos = (93,714);
+},
+{
+name = top_right_can;
+pos = (410,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(375,-13,o),
+(441,62,o),
+(441,214,cs),
+(441,655,l),
+(556,655,l),
+(556,714,l),
+(378,714,l),
+(378,209,ls),
+(378,98,o),
+(337,47,o),
+(251,47,cs),
+(166,47,o),
+(124,99,o),
+(124,209,cs),
+(124,714,l),
+(61,714,l),
+(61,210,ls),
+(61,62,o),
+(129,-13,o),
+(251,-13,cs)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1542;
+},
+{
+color = 11;
+glyphname = "reRCree-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (356,714);
+},
+{
+name = top_left_can;
+pos = (198,714);
+},
+{
+name = top_right_can;
+pos = (515,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(478,-13,o),
+(546,62,o),
+(546,210,cs),
+(546,714,l),
+(483,714,l),
+(483,209,ls),
+(483,99,o),
+(442,47,o),
+(356,47,cs),
+(270,47,o),
+(229,98,o),
+(229,209,cs),
+(229,714,l),
+(51,714,l),
+(51,655,l),
+(166,655,l),
+(166,214,ls),
+(166,62,o),
+(232,-13,o),
+(356,-13,cs)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni1543;
+},
+{
+color = 11;
+glyphname = "leWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (356,714);
+},
+{
+name = top_left_can;
+pos = (198,714);
+},
+{
+name = top_right_can;
+pos = (515,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(229,0,l),
+(229,505,ls),
+(229,615,o),
+(270,666,o),
+(356,666,cs),
+(442,666,o),
+(483,615,o),
+(483,505,cs),
+(483,0,l),
+(546,0,l),
+(546,503,ls),
+(546,652,o),
+(478,726,o),
+(356,726,cs),
+(232,726,o),
+(166,652,o),
+(166,500,cs),
+(166,58,l),
+(51,58,l),
+(51,0,l)
+);
+}
+);
+width = 609;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+},
+{
+color = 11;
+glyphname = "ri-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (251,714);
+},
+{
+name = top_left_can;
+pos = (95,714);
+},
+{
+name = top_right_can;
+pos = (410,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(124,0,l),
+(124,505,ls),
+(124,615,o),
+(166,667,o),
+(251,667,cs),
+(337,667,o),
+(378,616,o),
+(378,505,cs),
+(378,0,l),
+(556,0,l),
+(556,59,l),
+(441,59,l),
+(441,500,ls),
+(441,652,o),
+(375,727,o),
+(251,727,cs),
+(129,727,o),
+(61,652,o),
+(61,504,cs),
+(61,0,l)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+},
+{
+color = 11;
+glyphname = "rii-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (191,0);
+ref = dot_top;
+}
+);
+width = 607;
+}
+);
+note = uni1547;
+},
+{
+color = 11;
+glyphname = "ro-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (270,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(128,0,l),
+(128,162,l),
+(100,141,l),
+(184,141,ls),
+(375,141,o),
+(470,243,o),
+(470,427,cs),
+(470,610,o),
+(375,714,o),
+(184,714,cs),
+(65,714,l),
+(65,657,l),
+(187,657,ls),
+(339,657,o),
+(406,577,o),
+(406,427,cs),
+(406,277,o),
+(339,198,o),
+(187,198,cs),
+(65,198,l),
+(65,0,l)
+);
+}
+);
+width = 522;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1548;
+},
+{
+color = 11;
+glyphname = "loWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (267,714);
+},
+{
+name = top_left_can;
+pos = (97,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(184,0,ls),
+(375,0,o),
+(470,104,o),
+(470,287,cs),
+(470,471,o),
+(375,573,o),
+(184,573,cs),
+(100,573,l),
+(128,552,l),
+(128,714,l),
+(65,714,l),
+(65,516,l),
+(187,516,ls),
+(339,516,o),
+(406,437,o),
+(406,287,cs),
+(406,137,o),
+(339,57,o),
+(187,57,cs),
+(65,57,l),
+(65,0,l)
+);
+}
+);
+width = 519;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+},
+{
+color = 11;
+glyphname = "ra-canadian.square";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (251,714);
+},
+{
+name = top_right_can;
+pos = (422,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(454,0,l),
+(454,198,l),
+(331,198,ls),
+(180,198,o),
+(112,277,o),
+(112,427,cs),
+(112,577,o),
+(180,657,o),
+(331,657,cs),
+(454,657,l),
+(454,714,l),
+(335,714,ls),
+(144,714,o),
+(49,610,o),
+(49,427,cs),
+(49,243,o),
+(144,141,o),
+(335,141,cs),
+(419,141,l),
+(390,162,l),
+(390,0,l)
+);
+}
+);
+width = 519;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+},
+{
+color = 11;
+glyphname = "raa-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (192,0);
+ref = dot_top;
+}
+);
+width = 519;
+}
+);
+note = uni154C;
+},
+{
+color = 11;
+glyphname = "laWestCree-canadian.square";
+lastChange = "2023-01-13 15:31:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (422,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(454,0,l),
+(454,57,l),
+(331,57,ls),
+(180,57,o),
+(112,137,o),
+(112,287,cs),
+(112,437,o),
+(180,516,o),
+(331,516,cs),
+(454,516,l),
+(454,714,l),
+(390,714,l),
+(390,552,l),
+(419,573,l),
+(335,573,ls),
+(144,573,o),
+(49,471,o),
+(49,287,cs),
+(49,104,o),
+(144,0,o),
+(335,0,cs)
+);
+}
+);
+width = 519;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+},
+{
+color = 11;
+glyphname = "reWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(487,0,l),
+(670,198,l),
+(630,239,l),
+(451,44,l),
+(494,43,l),
+(494,471,ls),
+(494,639,o),
+(409,727,o),
+(274,727,cs),
+(135,727,o),
+(54,640,o),
+(54,466,cs),
+(54,405,l),
+(117,405,l),
+(117,470,ls),
+(117,606,o),
+(173,667,o),
+(275,667,cs),
+(371,667,o),
+(430,604,o),
+(430,475,cs),
+(430,0,l)
+);
+}
+);
+width = 693;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+},
+{
+color = 11;
+glyphname = "riWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(262,0,l),
+(262,475,ls),
+(262,604,o),
+(322,667,o),
+(418,667,cs),
+(520,667,o),
+(576,606,o),
+(576,470,cs),
+(576,405,l),
+(639,405,l),
+(639,466,ls),
+(639,640,o),
+(558,727,o),
+(419,727,cs),
+(284,727,o),
+(199,639,o),
+(199,471,cs),
+(199,43,l),
+(242,44,l),
+(63,239,l),
+(23,198,l),
+(206,0,l)
+);
+}
+);
+width = 693;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+},
+{
+color = 11;
+glyphname = "roWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(409,-13,o),
+(494,75,o),
+(494,243,cs),
+(494,671,l),
+(451,670,l),
+(630,475,l),
+(670,516,l),
+(487,714,l),
+(430,714,l),
+(430,239,ls),
+(430,110,o),
+(371,47,o),
+(275,47,cs),
+(173,47,o),
+(117,108,o),
+(117,244,cs),
+(117,309,l),
+(54,309,l),
+(54,248,ls),
+(54,74,o),
+(135,-13,o),
+(274,-13,cs)
+);
+}
+);
+width = 693;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+},
+{
+color = 11;
+glyphname = "raWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(558,-13,o),
+(639,74,o),
+(639,248,cs),
+(639,309,l),
+(576,309,l),
+(576,244,ls),
+(576,108,o),
+(520,47,o),
+(418,47,cs),
+(322,47,o),
+(262,110,o),
+(262,239,cs),
+(262,714,l),
+(206,714,l),
+(23,516,l),
+(63,475,l),
+(242,670,l),
+(199,671,l),
+(199,243,ls),
+(199,75,o),
+(284,-13,o),
+(419,-13,cs)
+);
+}
+);
+width = 693;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+},
+{
+color = 11;
+glyphname = "theThCree-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (75,714);
+},
+{
+name = top_right_can;
+pos = (471,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(439,73,l),
+(439,0,l),
+(503,0,l),
+(503,73,l),
+(573,73,l),
+(573,111,l),
+(503,111,l),
+(503,238,l),
+(127,238,l),
+(126,210,l),
+(518,687,l),
+(471,726,l),
+(41,206,l),
+(41,181,l),
+(439,181,l),
+(439,111,l),
+(250,111,l),
+(250,73,l)
+);
+}
+);
+width = 608;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15A7;
+},
+{
+color = 11;
+glyphname = "thiThCree-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (132,714);
+},
+{
+name = top_right_can;
+pos = (527,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(169,0,l),
+(169,73,l),
+(358,73,l),
+(358,111,l),
+(169,111,l),
+(169,181,l),
+(567,181,l),
+(567,206,l),
+(137,726,l),
+(90,687,l),
+(482,210,l),
+(482,238,l),
+(106,238,l),
+(106,111,l),
+(35,111,l),
+(35,73,l),
+(106,73,l),
+(106,0,l)
+);
+}
+);
+width = 608;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+},
+{
+color = 11;
+glyphname = "thiiThCree-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (71,0);
+ref = dot_top;
+}
+);
+width = 608;
+}
+);
+note = uni15A9;
+},
+{
+color = 11;
+glyphname = "thoThCree-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (75,714);
+},
+{
+name = top_right_can;
+pos = (471,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(518,27,l),
+(126,504,l),
+(127,476,l),
+(503,476,l),
+(503,603,l),
+(573,603,l),
+(573,641,l),
+(503,641,l),
+(503,714,l),
+(439,714,l),
+(439,641,l),
+(250,641,l),
+(250,603,l),
+(439,603,l),
+(439,533,l),
+(41,533,l),
+(41,508,l),
+(471,-12,l)
+);
+}
+);
+width = 608;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+},
+{
+color = 11;
+glyphname = "thooThCree-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (411,0);
+ref = dot_top;
+}
+);
+width = 608;
+}
+);
+note = uni15AB;
+},
+{
+color = 11;
+glyphname = "thaThCree-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (138,714);
+},
+{
+name = top_right_can;
+pos = (533,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(567,508,l),
+(567,533,l),
+(169,533,l),
+(169,603,l),
+(358,603,l),
+(358,641,l),
+(169,641,l),
+(169,714,l),
+(106,714,l),
+(106,641,l),
+(35,641,l),
+(35,603,l),
+(106,603,l),
+(106,476,l),
+(482,476,l),
+(482,504,l),
+(90,27,l),
+(137,-12,l)
+);
+}
+);
+width = 608;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+},
+{
+color = 11;
+glyphname = "thaaThCree-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (77,0);
+ref = dot_top;
+}
+);
+width = 608;
+}
+);
+note = uni15AD;
+},
+{
+color = 11;
+glyphname = "thweeWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (608,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni1677;
+},
+{
+color = 11;
+glyphname = "thwiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (608,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni1678;
+},
+{
+color = 11;
+glyphname = "thwiiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (71,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (608,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni1679;
+},
+{
+color = 11;
+glyphname = "thwoWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (608,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni167A;
+},
+{
+color = 11;
+glyphname = "thwooWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (411,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (608,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni167B;
+},
+{
+color = 11;
+glyphname = "thwaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (608,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni167C;
+},
+{
+color = 11;
+glyphname = "thwaaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (77,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (608,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 784;
+}
+);
+note = uni167D;
+},
+{
+color = 11;
+glyphname = "nwiOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 783;
+}
+);
+note = uni18C7;
+},
+{
+color = 11;
+glyphname = "nwiiOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (191,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 783;
+}
+);
+note = uni18C9;
+},
+{
+color = 11;
+glyphname = "nwoOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 783;
+}
+);
+note = uni18CB;
+},
+{
+color = 11;
+glyphname = "nwooOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (295,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 783;
+}
+);
+note = uni18CD;
+},
+{
+color = 11;
+glyphname = "looWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+}
+);
+width = 519;
+}
+);
+note = uni18E1;
+},
+{
+color = 11;
+glyphname = "laaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (363,0);
+ref = dot_top;
+}
+);
+width = 519;
+}
+);
+note = uni18E2;
+},
+{
+color = 0;
+glyphname = zero;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(525,561,o),
+(475,725,o),
+(294,725,cs),
+(112,725,o),
+(62,545,o),
+(62,359,cs),
+(62,110,o),
+(146,-10,o),
+(294,-10,cs),
+(449,-10,o),
+(525,112,o),
+(525,359,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(130,505,o),
+(154,668,o),
+(294,668,cs),
+(443,668,o),
+(457,495,o),
+(457,359,cs),
+(457,167,o),
+(414,47,o),
+(294,47,cs),
+(179,47,o),
+(130,165,o),
+(130,359,cs)
+);
+}
+);
+width = 586;
+}
+);
+unicode = 48;
+},
+{
+color = 0;
+glyphname = one;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(227,714,l),
+(20,558,l),
+(56,512,l),
+(169,597,ls),
+(192,614,o),
+(205,626,o),
+(221,641,c),
+(220,617,o),
+(219,593,o),
+(219,567,cs),
+(219,0,l),
+(287,0,l),
+(287,714,l)
+);
+}
+);
+width = 410;
+}
+);
+unicode = 49;
+},
+{
+color = 0;
+glyphname = two;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(494,0,l),
+(494,58,l),
+(129,58,l),
+(129,60,l),
+(299,237,ls),
+(370,309,o),
+(420,365,o),
+(447,429,cs),
+(459,460,o),
+(466,496,o),
+(466,537,cs),
+(466,650,o),
+(383,724,o),
+(264,724,cs),
+(188,724,o),
+(118,698,o),
+(55,644,c),
+(92,598,l),
+(146,643,o),
+(204,665,o),
+(258,665,cs),
+(345,665,o),
+(398,616,o),
+(398,530,cs),
+(398,466,o),
+(377,417,o),
+(335,364,cs),
+(313,336,o),
+(286,306,o),
+(252,271,cs),
+(41,49,l),
+(41,0,l)
+);
+}
+);
+width = 546;
+}
+);
+unicode = 50;
+},
+{
+color = 0;
+glyphname = three;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(466,662,o),
+(383,724,o),
+(259,724,cs),
+(162,724,o),
+(92,694,o),
+(33,650,c),
+(63,603,l),
+(118,643,o),
+(180,667,o),
+(252,667,cs),
+(341,667,o),
+(400,627,o),
+(400,542,cs),
+(400,442,o),
+(312,397,o),
+(210,397,cs),
+(136,397,l),
+(136,343,l),
+(209,343,ls),
+(332,343,o),
+(417,308,o),
+(417,199,cs),
+(417,106,o),
+(355,46,o),
+(223,46,cs),
+(155,46,o),
+(80,65,o),
+(26,92,c),
+(26,31,l),
+(80,7,o),
+(147,-10,o),
+(230,-10,cs),
+(391,-10,o),
+(488,71,o),
+(488,196,cs),
+(488,302,o),
+(424,358,o),
+(312,373,c),
+(312,375,l),
+(400,393,o),
+(466,459,o),
+(466,553,cs)
+);
+}
+);
+width = 539;
+}
+);
+unicode = 51;
+},
+{
+color = 0;
+glyphname = four;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(459,234,l),
+(459,717,l),
+(394,717,l),
+(40,229,l),
+(40,180,l),
+(393,180,l),
+(393,0,l),
+(459,0,l),
+(459,180,l),
+(580,180,l),
+(580,234,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(107,234,l),
+(334,545,ls),
+(362,582,o),
+(371,599,o),
+(392,633,c),
+(394,633,l),
+(394,611,o),
+(393,576,o),
+(393,538,cs),
+(393,234,l)
+);
+}
+);
+width = 605;
+}
+);
+unicode = 52;
+},
+{
+color = 0;
+glyphname = five;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(205,436,o),
+(165,426,o),
+(135,419,c),
+(156,656,l),
+(451,656,l),
+(451,714,l),
+(99,714,l),
+(69,379,l),
+(101,359,l),
+(145,373,o),
+(189,381,o),
+(244,381,cs),
+(365,381,o),
+(426,321,o),
+(426,221,cs),
+(426,110,o),
+(349,46,o),
+(229,46,cs),
+(160,46,o),
+(95,67,o),
+(48,93,c),
+(48,31,l),
+(94,7,o),
+(156,-10,o),
+(233,-10,cs),
+(399,-10,o),
+(495,80,o),
+(495,222,cs),
+(495,359,o),
+(406,436,o),
+(267,436,cs)
+);
+}
+);
+width = 541;
+}
+);
+unicode = 53;
+},
+{
+color = 0;
+glyphname = six;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(60,139,o),
+(130,-10,o),
+(300,-10,cs),
+(439,-10,o),
+(523,82,o),
+(523,230,cs),
+(523,365,o),
+(447,448,o),
+(316,448,cs),
+(221,448,o),
+(154,402,o),
+(124,339,c),
+(121,339,l),
+(126,531,o),
+(195,670,o),
+(376,670,cs),
+(418,670,o),
+(451,664,o),
+(476,656,c),
+(476,714,l),
+(449,721,o),
+(414,726,o),
+(377,726,cs),
+(142,726,o),
+(60,541,o),
+(60,303,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(168,46,o),
+(131,172,o),
+(131,256,cs),
+(131,332,o),
+(216,393,o),
+(303,393,cs),
+(407,393,o),
+(457,330,o),
+(457,229,cs),
+(457,115,o),
+(400,46,o),
+(299,46,cs)
+);
+}
+);
+width = 571;
+}
+);
+unicode = 54;
+},
+{
+color = 0;
+glyphname = seven;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(484,673,l),
+(484,714,l),
+(17,714,l),
+(17,656,l),
+(411,656,l),
+(127,0,l),
+(198,0,l)
+);
+}
+);
+width = 509;
+}
+);
+unicode = 55;
+},
+{
+color = 0;
+glyphname = eight;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(426,-10,o),
+(522,61,o),
+(522,183,cs),
+(522,284,o),
+(451,341,o),
+(344,381,c),
+(438,419,o),
+(499,471,o),
+(499,558,cs),
+(499,665,o),
+(418,724,o),
+(293,724,cs),
+(170,724,o),
+(86,660,o),
+(86,557,cs),
+(86,457,o),
+(163,411,o),
+(236,379,c),
+(132,342,o),
+(63,285,o),
+(63,178,cs),
+(63,66,o),
+(150,-10,o),
+(289,-10,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(192,43,o),
+(127,96,o),
+(127,180,cs),
+(127,276,o),
+(208,321,o),
+(290,349,c),
+(404,306,o),
+(458,260,o),
+(458,184,cs),
+(458,92,o),
+(390,43,o),
+(289,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(208,442,o),
+(150,481,o),
+(150,553,cs),
+(150,629,o),
+(211,671,o),
+(292,671,cs),
+(381,671,o),
+(434,631,o),
+(434,554,cs),
+(434,485,o),
+(385,448,o),
+(294,410,c)
+);
+}
+);
+width = 584;
+}
+);
+unicode = 56;
+},
+{
+color = 0;
+glyphname = nine;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(509,583,o),
+(440,724,o),
+(269,724,cs),
+(130,724,o),
+(45,633,o),
+(45,486,cs),
+(45,351,o),
+(121,266,o),
+(250,266,cs),
+(344,266,o),
+(414,311,o),
+(444,376,c),
+(447,376,l),
+(441,179,o),
+(368,44,o),
+(189,44,cs),
+(149,44,o),
+(110,50,o),
+(86,58,c),
+(86,0,l),
+(113,-7,o),
+(155,-12,o),
+(192,-12,cs),
+(428,-12,o),
+(509,178,o),
+(509,410,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(401,667,o),
+(437,540,o),
+(437,459,cs),
+(437,383,o),
+(350,321,o),
+(266,321,cs),
+(163,321,o),
+(111,385,o),
+(111,487,cs),
+(111,601,o),
+(168,667,o),
+(270,667,cs)
+);
+}
+);
+width = 569;
+}
+);
+unicode = 57;
+},
+{
+glyphname = zero.canadian;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(410,617,o),
+(346,727,o),
+(228,727,cs),
+(110,727,o),
+(47,617,o),
+(47,357,cs),
+(47,97,o),
+(110,-12,o),
+(228,-12,cs),
+(346,-12,o),
+(410,97,o),
+(410,357,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(111,583,o),
+(149,669,o),
+(229,669,cs),
+(310,669,o),
+(346,585,o),
+(346,357,cs),
+(346,129,o),
+(310,46,o),
+(229,46,cs),
+(148,46,o),
+(111,131,o),
+(111,357,cs)
+);
+}
+);
+width = 457;
+}
+);
+metricRight = "=|";
+},
+{
+glyphname = one.canadian;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(234,0,l),
+(234,714,l),
+(177,714,l),
+(26,550,l),
+(67,511,l),
+(213,670,l),
+(171,671,l),
+(171,0,l)
+);
+}
+);
+width = 299;
+}
+);
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = two.canadian;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(403,59,l),
+(132,59,l),
+(133,36,l),
+(322,307,ls),
+(379,389,o),
+(396,465,o),
+(396,534,cs),
+(396,659,o),
+(329,727,o),
+(227,727,cs),
+(108,727,o),
+(46,638,o),
+(46,470,c),
+(110,470,l),
+(110,608,o),
+(147,670,o),
+(225,670,cs),
+(293,670,o),
+(333,625,o),
+(333,535,cs),
+(333,473,o),
+(315,405,o),
+(264,331,cs),
+(63,43,l),
+(63,0,l),
+(403,0,l)
+);
+}
+);
+width = 450;
+}
+);
+note = uni14BF;
+},
+{
+glyphname = three.canadian;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(356,-13,o),
+(422,53,o),
+(422,187,cs),
+(422,285,o),
+(380,353,o),
+(296,370,c),
+(296,347,l),
+(374,361,o),
+(415,431,o),
+(415,525,cs),
+(415,662,o),
+(352,727,o),
+(246,727,cs),
+(130,727,o),
+(64,642,o),
+(63,487,c),
+(126,487,l),
+(127,613,o),
+(167,670,o),
+(244,670,cs),
+(315,670,o),
+(351,629,o),
+(351,523,cs),
+(351,429,o),
+(317,385,o),
+(253,385,cs),
+(223,385,l),
+(223,330,l),
+(254,330,ls),
+(322,330,o),
+(357,285,o),
+(357,191,cs),
+(357,86,o),
+(319,44,o),
+(245,44,cs),
+(164,44,o),
+(121,102,o),
+(121,227,c),
+(58,227,l),
+(58,68,o),
+(126,-13,o),
+(247,-13,cs)
+);
+}
+);
+width = 484;
+}
+);
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = four.canadian;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(349,0,l),
+(349,180,l),
+(430,180,l),
+(430,235,l),
+(349,235,l),
+(349,717,l),
+(298,717,l),
+(34,224,l),
+(34,180,l),
+(288,180,l),
+(288,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(311,649,l),
+(290,649,l),
+(290,235,l),
+(80,235,l),
+(85,220,l)
+);
+}
+);
+width = 456;
+}
+);
+},
+{
+glyphname = five.canadian;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(354,-13,o),
+(425,63,o),
+(425,202,cs),
+(425,341,o),
+(359,411,o),
+(234,411,cs),
+(126,411,l),
+(153,390,l),
+(170,673,l),
+(143,655,l),
+(405,655,l),
+(405,714,l),
+(111,714,l),
+(90,369,l),
+(102,354,l),
+(221,354,ls),
+(322,354,o),
+(361,306,o),
+(361,199,cs),
+(361,93,o),
+(319,44,o),
+(245,44,cs),
+(169,44,o),
+(125,92,o),
+(125,199,c),
+(62,199,l),
+(62,58,o),
+(135,-13,o),
+(245,-13,cs)
+);
+}
+);
+width = 478;
+}
+);
+},
+{
+glyphname = six.canadian;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(343,-13,o),
+(413,76,o),
+(413,208,cs),
+(413,341,o),
+(347,427,o),
+(249,427,cs),
+(168,427,o),
+(109,372,o),
+(96,261,c),
+(114,257,l),
+(111,295,o),
+(111,319,o),
+(111,371,cs),
+(111,589,o),
+(151,671,o),
+(239,671,cs),
+(310,671,o),
+(341,614,o),
+(345,519,c),
+(408,519,l),
+(401,645,o),
+(346,727,o),
+(241,727,cs),
+(116,727,o),
+(47,619,o),
+(47,359,cs),
+(47,199,o),
+(66,112,o),
+(105,55,cs),
+(140,6,o),
+(185,-13,o),
+(242,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(163,43,o),
+(122,109,o),
+(122,212,cs),
+(122,309,o),
+(167,372,o),
+(240,372,cs),
+(313,372,o),
+(350,309,o),
+(350,208,cs),
+(350,107,o),
+(308,43,o),
+(239,43,cs)
+);
+}
+);
+width = 457;
+}
+);
+metricLeft = zero.canadian;
+},
+{
+glyphname = seven.canadian;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(346,673,l),
+(346,714,l),
+(21,714,l),
+(21,655,l),
+(285,655,l),
+(284,676,l),
+(98,20,l),
+(98,0,l),
+(158,0,l)
+);
+}
+);
+width = 378;
+}
+);
+},
+{
+glyphname = eight.canadian;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(359,-13,o),
+(429,62,o),
+(429,185,cs),
+(429,290,o),
+(377,351,o),
+(303,368,c),
+(299,349,l),
+(364,360,o),
+(417,422,o),
+(417,529,cs),
+(417,652,o),
+(351,727,o),
+(246,727,cs),
+(140,727,o),
+(74,652,o),
+(74,529,cs),
+(74,422,o),
+(127,360,o),
+(193,349,c),
+(188,368,l),
+(115,351,o),
+(62,290,o),
+(62,185,cs),
+(62,62,o),
+(132,-13,o),
+(246,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(170,43,o),
+(125,89,o),
+(125,187,cs),
+(125,286,o),
+(172,330,o),
+(246,330,cs),
+(320,330,o),
+(366,286,o),
+(366,187,cs),
+(366,89,o),
+(321,43,o),
+(246,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(179,384,o),
+(137,429,o),
+(137,527,cs),
+(137,624,o),
+(176,671,o),
+(246,671,cs),
+(316,671,o),
+(355,624,o),
+(355,527,cs),
+(355,429,o),
+(313,384,o),
+(246,384,cs)
+);
+}
+);
+width = 491;
+}
+);
+metricLeft = "=|";
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = nine.canadian;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(341,-13,o),
+(410,95,o),
+(410,355,cs),
+(410,515,o),
+(391,602,o),
+(352,659,cs),
+(317,708,o),
+(272,727,o),
+(215,727,cs),
+(114,727,o),
+(44,638,o),
+(44,506,cs),
+(44,373,o),
+(109,287,o),
+(208,287,cs),
+(288,287,o),
+(348,342,o),
+(361,453,c),
+(343,457,l),
+(345,419,o),
+(346,395,o),
+(346,343,cs),
+(346,125,o),
+(306,43,o),
+(218,43,cs),
+(147,43,o),
+(116,100,o),
+(111,195,c),
+(48,195,l),
+(56,69,o),
+(111,-13,o),
+(215,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(144,342,o),
+(106,405,o),
+(106,506,cs),
+(106,607,o),
+(148,671,o),
+(218,671,cs),
+(294,671,o),
+(335,605,o),
+(335,502,cs),
+(335,405,o),
+(290,342,o),
+(217,342,cs)
+);
+}
+);
+width = 457;
+}
+);
+metricLeft = "=|six.canadian";
+metricRight = "=|six.canadian";
+},
+{
+glyphname = CR;
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+width = 201;
+}
+);
+note = CR;
+unicode = 13;
+},
+{
+color = 0;
+glyphname = .notdef;
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(505,714,l),
+(94,714,l),
+(94,0,l),
+(505,0,l),
+(505,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(454,663,l),
+(454,51,l),
+(145,51,l),
+(145,663,l),
+(145,663,l)
+);
+}
+);
+width = 600;
+}
+);
+note = ".notdef";
+},
+{
+glyphname = .null;
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+width = 0;
+}
+);
+note = NULL;
+},
+{
+glyphname = space;
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+width = 206;
+}
+);
+note = space;
+unicode = 32;
+},
+{
+glyphname = nbspace;
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+width = 201;
+}
+);
+note = uni00A0;
+unicode = 160;
+},
+{
+glyphname = space.canadian;
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+width = 400;
+}
+);
+note = space;
+},
+{
+glyphname = "hyphen-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(300,416,l),
+(300,457,l),
+(52,457,l),
+(52,416,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(300,278,l),
+(300,319,l),
+(52,319,l),
+(52,278,l)
+);
+}
+);
+width = 352;
+}
+);
+metricRight = "=|";
+note = uni1400;
+unicode = 5120;
+},
+{
+glyphname = "chi-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,0,l),
+(226,319,l),
+(206,319,l),
+(331,0,l),
+(389,0,l),
+(389,20,l),
+(238,387,l),
+(238,336,l),
+(387,694,l),
+(387,714,l),
+(328,714,l),
+(206,400,l),
+(226,400,l),
+(104,714,l),
+(45,714,l),
+(45,694,l),
+(194,337,l),
+(194,388,l),
+(42,20,l),
+(42,0,l)
+);
+}
+);
+width = 431;
+}
+);
+metricRight = "=|";
+note = uni166D;
+unicode = 5741;
+},
+{
+glyphname = "fullstop-canadian";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(239,0,l),
+(239,10,l),
+(162,193,l),
+(164,167,l),
+(238,346,l),
+(238,357,l),
+(196,357,l),
+(137,200,l),
+(155,202,l),
+(95,357,l),
+(53,357,l),
+(53,346,l),
+(128,169,l),
+(128,195,l),
+(52,10,l),
+(52,0,l),
+(93,0,l),
+(157,163,l),
+(136,161,l),
+(198,0,l)
+);
+}
+);
+width = 291;
+}
+);
+note = uni1541;
+unicode = 5742;
+},
+{
+glyphname = period;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(72,8,o),
+(87,-9,o),
+(116,-9,cs),
+(148,-9,o),
+(161,8,o),
+(161,37,cs),
+(161,66,o),
+(148,84,o),
+(116,84,cs),
+(87,84,o),
+(72,66,o),
+(72,37,cs)
+);
+}
+);
+width = 215;
+}
+);
+note = period;
+unicode = 46;
+},
+{
+glyphname = comma;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(72,-131,l),
+(102,-60,o),
+(126,37,o),
+(142,112,c),
+(138,123,l),
+(79,123,l),
+(69,47,o),
+(52,-34,o),
+(25,-131,c)
+);
+}
+);
+width = 190;
+}
+);
+note = comma;
+unicode = 44;
+},
+{
+glyphname = hyphen;
+kernLeft = hyphen;
+kernRight = hyphen;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(217,299,l),
+(43,299,l),
+(43,243,l),
+(217,243,l)
+);
+}
+);
+width = 261;
+}
+);
+unicode = 45;
+},
+{
+glyphname = quotesinglbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (34,-591);
+ref = quoteright;
+}
+);
+width = 245;
+}
+);
+unicode = 8218;
+},
+{
+glyphname = quotedblbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+pos = (34,-591);
+ref = quotedblright;
+}
+);
+width = 418;
+}
+);
+unicode = 8222;
+},
+{
+glyphname = quotedblleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(282,459,l),
+(290,532,o),
+(311,629,o),
+(341,714,c),
+(297,714,l),
+(265,643,o),
+(237,554,o),
+(222,468,c),
+(228,459,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(119,459,l),
+(128,532,o),
+(148,629,o),
+(178,714,c),
+(135,714,l),
+(102,643,o),
+(74,554,o),
+(59,468,c),
+(66,459,l)
+);
+}
+);
+width = 398;
+}
+);
+unicode = 8220;
+},
+{
+glyphname = quotedblright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(263,459,l),
+(296,531,o),
+(324,624,o),
+(338,704,c),
+(332,714,l),
+(279,714,l),
+(272,639,o),
+(252,544,o),
+(219,459,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(100,459,l),
+(134,531,o),
+(162,624,o),
+(176,704,c),
+(170,714,l),
+(116,714,l),
+(110,642,o),
+(88,541,o),
+(57,459,c)
+);
+}
+);
+width = 398;
+}
+);
+unicode = 8221;
+},
+{
+glyphname = quoteleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(122,459,l),
+(130,532,o),
+(151,629,o),
+(181,714,c),
+(135,714,l),
+(102,643,o),
+(74,554,o),
+(59,468,c),
+(66,459,l)
+);
+}
+);
+width = 238;
+}
+);
+unicode = 8216;
+},
+{
+glyphname = quoteright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(103,459,l),
+(136,531,o),
+(164,624,o),
+(178,704,c),
+(172,714,l),
+(116,714,l),
+(110,642,o),
+(88,541,o),
+(57,459,c)
+);
+}
+);
+width = 238;
+}
+);
+unicode = 8217;
+},
+{
+glyphname = dottedCircle;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,522,o),
+(187,511,o),
+(187,496,cs),
+(187,483,o),
+(200,470,o),
+(213,470,cs),
+(228,470,o),
+(239,483,o),
+(239,496,cs),
+(239,511,o),
+(228,522,o),
+(213,522,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(368,522,o),
+(355,511,o),
+(355,496,cs),
+(355,483,o),
+(368,470,o),
+(381,470,cs),
+(396,470,o),
+(407,483,o),
+(407,496,cs),
+(407,511,o),
+(396,522,o),
+(381,522,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,112,o),
+(187,101,o),
+(187,86,cs),
+(187,73,o),
+(200,60,o),
+(213,60,cs),
+(228,60,o),
+(239,73,o),
+(239,86,cs),
+(239,101,o),
+(228,112,o),
+(213,112,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(368,112,o),
+(355,101,o),
+(355,86,cs),
+(355,73,o),
+(368,60,o),
+(381,60,cs),
+(396,60,o),
+(407,73,o),
+(407,86,cs),
+(407,101,o),
+(396,112,o),
+(381,112,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(284,540,o),
+(271,529,o),
+(271,514,cs),
+(271,501,o),
+(284,488,o),
+(297,488,cs),
+(312,488,o),
+(323,501,o),
+(323,514,cs),
+(323,529,o),
+(312,540,o),
+(297,540,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(284,94,o),
+(271,83,o),
+(271,68,cs),
+(271,55,o),
+(284,42,o),
+(297,42,cs),
+(312,42,o),
+(323,55,o),
+(323,68,cs),
+(323,83,o),
+(312,94,o),
+(297,94,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(48,278,o),
+(61,265,o),
+(74,265,cs),
+(89,265,o),
+(100,278,o),
+(100,291,cs),
+(100,306,o),
+(89,317,o),
+(74,317,cs),
+(61,317,o),
+(48,306,o),
+(48,291,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(494,278,o),
+(507,265,o),
+(520,265,cs),
+(535,265,o),
+(546,278,o),
+(546,291,cs),
+(546,306,o),
+(535,317,o),
+(520,317,cs),
+(507,317,o),
+(494,306,o),
+(494,291,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(113,120,o),
+(126,107,o),
+(139,107,cs),
+(154,107,o),
+(165,120,o),
+(165,133,cs),
+(165,148,o),
+(154,159,o),
+(139,159,cs),
+(126,159,o),
+(113,148,o),
+(113,133,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(113,436,o),
+(126,423,o),
+(139,423,cs),
+(154,423,o),
+(165,436,o),
+(165,449,cs),
+(165,464,o),
+(154,475,o),
+(139,475,cs),
+(126,475,o),
+(113,464,o),
+(113,449,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(429,120,o),
+(442,107,o),
+(455,107,cs),
+(470,107,o),
+(481,120,o),
+(481,133,cs),
+(481,148,o),
+(470,159,o),
+(455,159,cs),
+(442,159,o),
+(429,148,o),
+(429,133,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(429,436,o),
+(442,423,o),
+(455,423,cs),
+(470,423,o),
+(481,436,o),
+(481,449,cs),
+(481,464,o),
+(470,475,o),
+(455,475,cs),
+(442,475,o),
+(429,464,o),
+(429,449,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(66,194,o),
+(79,181,o),
+(92,181,cs),
+(107,181,o),
+(118,194,o),
+(118,207,cs),
+(118,222,o),
+(107,233,o),
+(92,233,cs),
+(79,233,o),
+(66,222,o),
+(66,207,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(66,362,o),
+(79,349,o),
+(92,349,cs),
+(107,349,o),
+(118,362,o),
+(118,375,cs),
+(118,390,o),
+(107,401,o),
+(92,401,cs),
+(79,401,o),
+(66,390,o),
+(66,375,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(476,194,o),
+(489,181,o),
+(502,181,cs),
+(517,181,o),
+(528,194,o),
+(528,207,cs),
+(528,222,o),
+(517,233,o),
+(502,233,cs),
+(489,233,o),
+(476,222,o),
+(476,207,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(476,362,o),
+(489,349,o),
+(502,349,cs),
+(517,349,o),
+(528,362,o),
+(528,375,cs),
+(528,390,o),
+(517,401,o),
+(502,401,cs),
+(489,401,o),
+(476,390,o),
+(476,375,cs)
+);
+}
+);
+width = 594;
+}
+);
+note = uni25CC;
+unicode = 9676;
+},
+{
+glyphname = dotaccentcomb;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(41,734,o),
+(26,717,o),
+(26,690,cs),
+(26,663,o),
+(41,647,o),
+(65,647,cs),
+(89,647,o),
+(104,662,o),
+(104,690,cs),
+(104,718,o),
+(89,734,o),
+(65,734,cs)
+);
+}
+);
+width = 130;
+}
+);
+note = uni0307;
+unicode = 775;
+},
+{
+glyphname = dotaccent;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(90,647,o),
+(105,663,o),
+(105,690,cs),
+(105,718,o),
+(90,734,o),
+(66,734,cs),
+(42,734,o),
+(27,717,o),
+(27,690,cs),
+(27,663,o),
+(42,647,o),
+(66,647,cs)
+);
+}
+);
+width = 132;
+}
+);
+note = dotaccent;
+unicode = 729;
+},
+{
+glyphname = caron;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(187,644,o),
+(217,700,o),
+(252,756,c),
+(252,764,l),
+(210,764,l),
+(187,733,o),
+(166,697,o),
+(139,651,c),
+(116,693,o),
+(94,731,o),
+(71,764,c),
+(27,764,l),
+(27,756,l),
+(58,708,o),
+(88,658,o),
+(109,606,c),
+(171,606,l),
+(171,606,l)
+);
+}
+);
+width = 280;
+}
+);
+note = caron;
+unicode = 711;
+},
+{
+glyphname = breve;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(193,606,o),
+(231,650,o),
+(237,734,c),
+(197,734,l),
+(191,680,o),
+(169,650,o),
+(131,650,cs),
+(91,650,o),
+(72,679,o),
+(66,734,c),
+(27,734,l),
+(32,647,o),
+(71,606,o),
+(131,606,cs)
+);
+}
+);
+width = 264;
+}
+);
+note = breve;
+unicode = 728;
+},
+{
+glyphname = ring;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(147,609,o),
+(182,653,o),
+(182,715,cs),
+(182,774,o),
+(147,820,o),
+(104,820,cs),
+(61,820,o),
+(27,776,o),
+(27,715,cs),
+(27,651,o),
+(62,609,o),
+(104,609,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(79,647,o),
+(61,678,o),
+(61,715,cs),
+(61,753,o),
+(80,783,o),
+(104,783,cs),
+(128,783,o),
+(147,752,o),
+(147,715,cs),
+(147,678,o),
+(130,647,o),
+(104,647,cs)
+);
+}
+);
+width = 209;
+}
+);
+note = ring;
+unicode = 730;
+},
+{
+glyphname = ogonek;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(114,-222,o),
+(130,-218,o),
+(142,-213,c),
+(142,-170,l),
+(134,-174,o),
+(120,-178,o),
+(106,-178,cs),
+(85,-178,o),
+(72,-159,o),
+(72,-123,cs),
+(72,-77,o),
+(97,-37,o),
+(127,0,c),
+(100,14,l),
+(49,-38,o),
+(27,-85,o),
+(27,-133,cs),
+(27,-191,o),
+(59,-222,o),
+(98,-222,cs)
+);
+}
+);
+width = 170;
+}
+);
+note = ogonek;
+unicode = 731;
+},
+{
+glyphname = ring_top.canadian;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (118,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(167,784,o),
+(205,821,o),
+(205,870,cs),
+(205,920,o),
+(167,956,o),
+(118,956,cs),
+(70,956,o),
+(32,920,o),
+(32,870,cs),
+(32,821,o),
+(70,784,o),
+(118,784,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(87,816,o),
+(65,838,o),
+(65,870,cs),
+(65,901,o),
+(87,924,o),
+(118,924,cs),
+(150,924,o),
+(172,901,o),
+(172,870,cs),
+(172,838,o),
+(150,816,o),
+(118,816,cs)
+);
+}
+);
+width = 237;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (61,357);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(84,316,o),
+(102,334,o),
+(102,357,cs),
+(102,380,o),
+(84,398,o),
+(61,398,cs),
+(38,398,o),
+(19,380,o),
+(19,357,cs),
+(19,334,o),
+(38,316,o),
+(61,316,cs)
+);
+}
+);
+width = 121;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (56,357);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(76,320,o),
+(93,336,o),
+(93,357,cs),
+(93,378,o),
+(76,394,o),
+(56,394,cs),
+(35,394,o),
+(19,378,o),
+(19,357,cs),
+(19,336,o),
+(35,320,o),
+(56,320,cs)
+);
+}
+);
+width = 111;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_small;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (51,357);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(69,325,o),
+(83,339,o),
+(83,357,cs),
+(83,375,o),
+(69,389,o),
+(51,389,cs),
+(33,389,o),
+(19,375,o),
+(19,357,cs),
+(19,339,o),
+(33,325,o),
+(51,325,cs)
+);
+}
+);
+width = 102;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_top;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (61,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(84,817,o),
+(103,836,o),
+(103,859,cs),
+(103,883,o),
+(84,901,o),
+(61,901,cs),
+(37,901,o),
+(19,883,o),
+(19,859,cs),
+(19,836,o),
+(37,817,o),
+(61,817,cs)
+);
+}
+);
+width = 121;
+}
+);
+note = g725;
+},
+{
+glyphname = doubledot_middle;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(119,403,o),
+(138,421,o),
+(138,444,cs),
+(138,468,o),
+(119,486,o),
+(96,486,cs),
+(73,486,o),
+(54,468,o),
+(54,444,cs),
+(54,421,o),
+(73,403,o),
+(96,403,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(119,228,o),
+(138,246,o),
+(138,270,cs),
+(138,293,o),
+(119,311,o),
+(96,311,cs),
+(73,311,o),
+(54,293,o),
+(54,270,cs),
+(54,246,o),
+(73,228,o),
+(96,228,cs)
+);
+}
+);
+width = 192;
+}
+);
+metricRight = "=|";
+note = g725;
+},
+{
+glyphname = doubledot_top;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top_double;
+pos = (195,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(218,817,o),
+(237,836,o),
+(237,859,cs),
+(237,883,o),
+(218,901,o),
+(195,901,cs),
+(171,901,o),
+(153,882,o),
+(153,859,cs),
+(153,836,o),
+(171,817,o),
+(195,817,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(84,817,o),
+(103,836,o),
+(103,859,cs),
+(103,883,o),
+(84,901,o),
+(61,901,cs),
+(38,901,o),
+(19,883,o),
+(19,859,cs),
+(19,836,o),
+(38,817,o),
+(61,817,cs)
+);
+}
+);
+width = 256;
+}
+);
+note = g725;
+},
+{
+glyphname = g727;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (270,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(473,0,l),
+(473,54,l),
+(243,54,ls),
+(155,54,o),
+(120,103,o),
+(120,192,cs),
+(120,282,o),
+(155,330,o),
+(243,330,cs),
+(309,330,ls),
+(424,330,o),
+(483,402,o),
+(483,523,cs),
+(483,642,o),
+(424,714,o),
+(309,714,cs),
+(66,714,l),
+(66,660,l),
+(297,660,ls),
+(384,660,o),
+(419,611,o),
+(419,523,cs),
+(419,432,o),
+(384,385,o),
+(297,385,cs),
+(230,385,ls),
+(114,385,o),
+(56,312,o),
+(56,192,cs),
+(56,72,o),
+(114,0,o),
+(230,0,cs)
+);
+}
+);
+width = 539;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+glyphname = g728;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (209,0);
+ref = dot_top;
+}
+);
+width = 539;
+}
+);
+note = g728;
+},
+{
+glyphname = g729;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (270,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(309,0,ls),
+(424,0,o),
+(482,72,o),
+(482,191,cs),
+(482,312,o),
+(424,384,o),
+(309,384,cs),
+(242,384,ls),
+(155,384,o),
+(119,432,o),
+(119,522,cs),
+(119,611,o),
+(154,660,o),
+(242,660,cs),
+(473,660,l),
+(473,714,l),
+(229,714,ls),
+(113,714,o),
+(56,641,o),
+(56,522,cs),
+(56,402,o),
+(113,330,o),
+(229,330,cs),
+(296,330,ls),
+(383,330,o),
+(418,282,o),
+(418,191,cs),
+(418,102,o),
+(383,54,o),
+(296,54,cs),
+(65,54,l),
+(65,0,l)
+);
+}
+);
+width = 538;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+glyphname = g730;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (209,0);
+ref = dot_top;
+}
+);
+width = 538;
+}
+);
+note = g730;
+},
+{
+glyphname = g731;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = g727;
+}
+);
+width = 714;
+}
+);
+note = g731;
+},
+{
+glyphname = g732;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (539,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 714;
+}
+);
+note = g732;
+},
+{
+glyphname = g733;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (385,0);
+ref = dot_top;
+}
+);
+width = 714;
+}
+);
+note = g733;
+},
+{
+glyphname = g734;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (209,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (539,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 714;
+}
+);
+note = g734;
+},
+{
+glyphname = g735;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = g729;
+}
+);
+width = 713;
+}
+);
+note = g735;
+},
+{
+glyphname = g736;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (538,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 713;
+}
+);
+note = g736;
+},
+{
+glyphname = g737;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (385,0);
+ref = dot_top;
+}
+);
+width = 713;
+}
+);
+note = g737;
+},
+{
+glyphname = g738;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (209,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (538,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 713;
+}
+);
+note = g738;
+},
+{
+glyphname = g739;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(414,222,o),
+(453,276,o),
+(453,356,cs),
+(453,436,o),
+(414,493,o),
+(353,493,cs),
+(188,493,l),
+(189,473,l),
+(216,486,o),
+(234,535,o),
+(234,587,cs),
+(234,666,o),
+(196,720,o),
+(138,720,cs),
+(80,720,o),
+(42,666,o),
+(42,585,cs),
+(42,505,o),
+(81,449,o),
+(142,449,cs),
+(307,449,l),
+(306,469,l),
+(278,455,o),
+(261,405,o),
+(261,355,cs),
+(261,275,o),
+(298,222,o),
+(357,222,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(104,486,o),
+(82,524,o),
+(82,585,cs),
+(82,647,o),
+(105,683,o),
+(139,683,cs),
+(171,683,o),
+(194,645,o),
+(194,585,cs),
+(194,525,o),
+(173,486,o),
+(138,486,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(324,258,o),
+(300,296,o),
+(300,357,cs),
+(300,418,o),
+(323,456,o),
+(357,456,cs),
+(390,456,o),
+(413,417,o),
+(413,356,cs),
+(413,295,o),
+(390,258,o),
+(356,258,cs)
+);
+}
+);
+width = 495;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+glyphname = g740;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (151,0);
+ref = ring_top.canadian;
+}
+);
+width = 539;
+}
+);
+note = g740;
+},
+{
+glyphname = g741;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (151,0);
+ref = ring_top.canadian;
+}
+);
+width = 538;
+}
+);
+note = g741;
+},
+{
+glyphname = g742;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (176,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (327,0);
+ref = ring_top.canadian;
+}
+);
+width = 714;
+}
+);
+note = g742;
+},
+{
+glyphname = stroke_middle;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (39,357);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(60,470,l),
+(18,470,l),
+(18,244,l),
+(60,244,l)
+);
+}
+);
+width = 78;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (35,357);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(52,456,l),
+(18,456,l),
+(18,258,l),
+(52,258,l)
+);
+}
+);
+width = 71;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_small;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (33,357);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(48,453,l),
+(18,453,l),
+(18,261,l),
+(48,261,l)
+);
+}
+);
+width = 66;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_threequart;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (39,357);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(58,469,l),
+(20,469,l),
+(20,245,l),
+(58,245,l)
+);
+}
+);
+width = 78;
+}
+);
+note = g723;
+},
+{
+color = 8;
+glyphname = uni11AB0;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (130,714);
+},
+{
+name = top_right_can;
+pos = (362,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(162,0,l),
+(162,121,l),
+(351,121,l),
+(351,163,l),
+(162,163,l),
+(162,292,l),
+(115,268,l),
+(139,268,ls),
+(299,268,o),
+(393,398,o),
+(393,614,cs),
+(393,714,l),
+(331,714,l),
+(331,620,ls),
+(331,427,o),
+(256,326,o),
+(126,326,cs),
+(98,326,l),
+(98,163,l),
+(35,163,l),
+(35,121,l),
+(98,121,l),
+(98,0,l)
+);
+}
+);
+width = 456;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB1;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB0;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (301,0);
+ref = dot_top;
+}
+);
+width = 456;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB2;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (95,714);
+},
+{
+name = top_right_can;
+pos = (327,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(126,0,l),
+(126,94,ls),
+(126,287,o),
+(200,388,o),
+(331,388,cs),
+(359,388,l),
+(359,551,l),
+(422,551,l),
+(422,593,l),
+(359,593,l),
+(359,714,l),
+(295,714,l),
+(295,593,l),
+(106,593,l),
+(106,551,l),
+(295,551,l),
+(295,422,l),
+(341,446,l),
+(318,446,ls),
+(158,446,o),
+(63,317,o),
+(63,100,cs),
+(63,0,l)
+);
+}
+);
+width = 457;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "theThCree-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB3;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB2;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (266,0);
+ref = dot_top;
+}
+);
+width = 457;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB4;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (130,714);
+},
+{
+name = top_right_can;
+pos = (362,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(393,0,l),
+(393,100,ls),
+(393,316,o),
+(299,446,o),
+(139,446,cs),
+(115,446,l),
+(162,422,l),
+(162,551,l),
+(351,551,l),
+(351,593,l),
+(162,593,l),
+(162,714,l),
+(98,714,l),
+(98,593,l),
+(35,593,l),
+(35,551,l),
+(98,551,l),
+(98,388,l),
+(126,388,ls),
+(256,388,o),
+(331,287,o),
+(331,94,cs),
+(331,0,l)
+);
+}
+);
+width = 456;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB5;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB4;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (70,0);
+ref = dot_top;
+}
+);
+width = 456;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB6;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (96,714);
+},
+{
+name = top_right_can;
+pos = (329,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(128,0,l),
+(128,293,l),
+(82,268,l),
+(106,268,ls),
+(266,268,o),
+(360,398,o),
+(360,614,cs),
+(360,686,l),
+(316,676,l),
+(499,478,l),
+(537,516,l),
+(355,714,l),
+(297,714,l),
+(297,620,ls),
+(297,427,o),
+(223,326,o),
+(93,326,cs),
+(65,326,l),
+(65,0,l)
+);
+}
+);
+width = 560;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB7;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB6;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (268,0);
+ref = dot_top;
+}
+);
+width = 560;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB8;
+kernRight = soright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (232,714);
+},
+{
+name = top_right_can;
+pos = (463,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(263,0,l),
+(263,94,ls),
+(263,287,o),
+(337,388,o),
+(467,388,cs),
+(495,388,l),
+(495,714,l),
+(432,714,l),
+(432,421,l),
+(478,446,l),
+(454,446,ls),
+(294,446,o),
+(200,316,o),
+(200,100,cs),
+(200,28,l),
+(244,38,l),
+(61,236,l),
+(23,198,l),
+(206,0,l)
+);
+}
+);
+width = 560;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB9;
+kernRight = soright;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB8;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (403,0);
+ref = dot_top;
+}
+);
+width = 560;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABA;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (96,714);
+},
+{
+name = top_right_can;
+pos = (329,714);
+}
+);
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(355,0,l),
+(537,198,l),
+(499,236,l),
+(316,38,l),
+(360,28,l),
+(360,100,ls),
+(360,316,o),
+(266,446,o),
+(106,446,cs),
+(82,446,l),
+(128,421,l),
+(128,714,l),
+(65,714,l),
+(65,388,l),
+(93,388,ls),
+(223,388,o),
+(297,287,o),
+(297,94,cs),
+(297,0,l)
+);
+}
+);
+width = 560;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABB;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+alignment = -1;
+ref = uni11ABA;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+}
+);
+width = 560;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABC;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(407,0,l),
+(407,59,l),
+(105.008,58.992,l),
+(105,30,l),
+(414,668,l),
+(414,714,l),
+(49,714,l),
+(49,655,l),
+(351,655,l),
+(351,684,l),
+(42,46,l),
+(42,0,l)
+);
+}
+);
+width = 456;
+}
+);
+metricRight = "=|";
+},
+{
+color = 8;
+glyphname = uni11ABD;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(414,0,l),
+(414,46,l),
+(106,684,l),
+(106,655,l),
+(407,655,l),
+(407,714,l),
+(42,714,l),
+(42,668,l),
+(351,30,l),
+(351,59,l),
+(49,59,l),
+(49,0,l)
+);
+}
+);
+width = 456;
+}
+);
+metricLeft = "=|uni11ABC";
+metricRight = "=|uni11ABC";
+},
+{
+color = 8;
+glyphname = uni11ABE;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(127,0,l),
+(127,651,l),
+(93,651,l),
+(403,0,l),
+(460,0,l),
+(460,714,l),
+(397,714,l),
+(397,63,l),
+(432,63,l),
+(121,714,l),
+(65,714,l),
+(65,0,l)
+);
+}
+);
+width = 525;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABF;
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,0,l),
+(432,655,l),
+(397,655,l),
+(397,0,l),
+(460,0,l),
+(460,714,l),
+(403,714,l),
+(93,59,l),
+(127,59,l),
+(127,714,l),
+(65,714,l),
+(65,0,l)
+);
+}
+);
+width = 525;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = "raiseddoubledotFinal-canadian.cree";
+lastChange = "2023-01-13 15:28:10 +0000";
+layers = (
+{
+layerId = "2974A4AB-0281-4EAC-B7D6-9B88228DB59B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(115,643,o),
+(134,661,o),
+(134,685,cs),
+(134,708,o),
+(115,727,o),
+(92,727,cs),
+(68,727,o),
+(50,708,o),
+(50,685,cs),
+(50,661,o),
+(68,643,o),
+(92,643,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(115,468,o),
+(134,486,o),
+(134,510,cs),
+(134,533,o),
+(115,552,o),
+(92,552,cs),
+(68,552,o),
+(50,534,o),
+(50,510,cs),
+(50,486,o),
+(68,468,o),
+(92,468,cs)
+);
+}
+);
+width = 184;
+}
+);
+note = g725;
+}
+);
+instances = (
+{
+axesValues = (
+67,
+68,
+0
+);
+instanceInterpolations = {
+"2974A4AB-0281-4EAC-B7D6-9B88228DB59B" = 1;
+};
+name = "RC CL roman";
+}
+);
+kerningLTR = {
+"2974A4AB-0281-4EAC-B7D6-9B88228DB59B" = {
+"@MMK_L_caright" = {
+"@MMK_R_ecanleft" = -66;
+"@MMK_R_mwestleft" = -25;
+"@MMK_R_neleft" = -51;
+};
+"@MMK_L_ciright" = {
+"@MMK_R_icanleft" = -66;
+"@MMK_R_noleft" = -88;
+};
+"@MMK_L_ecanright" = {
+"@MMK_R_coleft" = -66;
+"@MMK_R_moleft" = -66;
+"@MMK_R_sileft" = -36;
+};
+"@MMK_L_icanright" = {
+"@MMK_R_celeft" = -66;
+"@MMK_R_meleft" = -66;
+"@MMK_R_mwestleft" = -39;
+"@MMK_R_saleft" = -31;
+"she-canadian" = -66;
+};
+"@MMK_L_maright" = {
+"@MMK_R_acanleft" = -63;
+"@MMK_R_ecanleft" = -66;
+"@MMK_R_mwestleft" = -47;
+"@MMK_R_neleft" = -51;
+};
+"@MMK_L_miright" = {
+"@MMK_R_acanleft" = -63;
+"@MMK_R_icanleft" = -66;
+"@MMK_R_moleft" = -88;
+"@MMK_R_noleft" = -88;
+"@MMK_R_yeleft" = -88;
+};
+"@MMK_L_mwestright" = {
+"@MMK_R_coleft" = -25;
+"@MMK_R_icanleft" = -39;
+"@MMK_R_moleft" = -47;
+"@MMK_R_noleft" = -75;
+"@MMK_R_sileft" = -13;
+"@MMK_R_yeleft" = -20;
+};
+"@MMK_L_naright" = {
+"@MMK_R_acanleft" = -83;
+"@MMK_R_celeft" = -88;
+"@MMK_R_meleft" = -88;
+"@MMK_R_mwestleft" = -75;
+"@MMK_R_neleft" = -103;
+"@MMK_R_saleft" = -58;
+};
+"@MMK_L_niright" = {
+"@MMK_R_coleft" = -51;
+"@MMK_R_moleft" = -51;
+"@MMK_R_noleft" = -103;
+"@MMK_R_sileft" = -4;
+};
+"@MMK_L_ocanright" = {
+"@MMK_R_meleft" = -63;
+"@MMK_R_moleft" = -63;
+"@MMK_R_noleft" = -83;
+};
+"@MMK_L_seright" = {
+"@MMK_R_ecanleft" = -36;
+"@MMK_R_mwestleft" = -13;
+"@MMK_R_neleft" = -4;
+};
+"@MMK_L_soright" = {
+"@MMK_R_icanleft" = -31;
+"@MMK_R_noleft" = -58;
+};
+"@MMK_L_yiright" = {
+"@MMK_R_meleft" = -88;
+"@MMK_R_mwestleft" = -20;
+};
+"shi-canadian" = {
+"@MMK_R_icanleft" = -66;
+};
+};
+};
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "italic angle";
+}
+);
+properties = (
+{
+key = copyrights;
+values = (
+{
+language = ENG;
+value = "Copyright 2018 Google Inc. All Rights Reserved.";
+}
+);
+},
+{
+key = manufacturers;
+values = (
+{
+language = ENG;
+value = "Monotype Imaging Inc.";
+}
+);
+},
+{
+key = designers;
+values = (
+{
+language = ENG;
+value = "Monotype Design Team";
+}
+);
+},
+{
+key = description;
+value = "Designed by Monotype design team.";
+},
+{
+key = trademarks;
+values = (
+{
+language = ENG;
+value = "Noto is a trademark of Google Inc.";
+}
+);
+},
+{
+key = licenseURL;
+value = "http://scripts.sil.org/OFL";
+},
+{
+key = licenses;
+values = (
+{
+language = ENG;
+value = "This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.";
+}
+);
+},
+{
+key = manufacturerURL;
+value = "http://www.google.com/get/noto/";
+},
+{
+key = designerURL;
+value = "http://www.monotype.com/studio";
+}
+);
+settings = {
+disablesNiceNames = 1;
+};
+stems = (
+{
+name = "New Stem";
+}
+);
+unitsPerEm = 1000;
+userData = {
+GSDontShowVersionAlert = 1;
+};
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/sources/Exported instances UCAS SansCanadianAboriginal/Sans Canadian Aboriginal-RC CR Italic.glyphs
+++ b/sources/Exported instances UCAS SansCanadianAboriginal/Sans Canadian Aboriginal-RC CR Italic.glyphs
@@ -1,0 +1,37316 @@
+{
+.appVersion = "3151";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+},
+{
+name = Width;
+tag = wdth;
+},
+{
+name = Slant;
+tag = slnt;
+}
+);
+classes = (
+{
+code = "zero one two three four five six seven eight nine ";
+name = Num;
+},
+{
+code = "zero.canadian one.canadian two.canadian three.canadian four.canadian five.canadian six.canadian seven.canadian eight.canadian nine.canadian 
+";
+name = Num_can;
+},
+{
+code = "ke-canadian.square ki-canadian.square kii-canadian.square ko-canadian.square koo-canadian.square ka-canadian.square kaa-canadian.square kweWestCree-canadian.square kwiiWestCree-canadian.square kwoWestCree-canadian.square kwooWestCree-canadian.square kwaWestCree-canadian.square kwaaWestCree-canadian.square ce-canadian.square ci-canadian.square cii-canadian.square co-canadian.square coo-canadian.square ca-canadian.square caa-canadian.square me-canadian.square mi-canadian.square mii-canadian.square mo-canadian.square moo-canadian.square ma-canadian.square maa-canadian.square ne-canadian.square ni-canadian.square nii-canadian.square no-canadian.square noo-canadian.square na-canadian.square naa-canadian.square nweWestCree-canadian.square nwaWestCree-canadian.square nwaaWestCree-canadian.square se-canadian.square si-canadian.square sii-canadian.square so-canadian.square soo-canadian.square sa-canadian.square saa-canadian.square sho-canadian.square shoo-canadian.square sha-canadian.square shaa-canadian.square ye-canadian.square yi-canadian.square yii-canadian.square yo-canadian.square yoo-canadian.square ya-canadian.square yaa-canadian.square re-canadian.square reRCree-canadian.square leWestCree-canadian.square ri-canadian.square rii-canadian.square ro-canadian.square loWestCree-canadian.square ra-canadian.square raa-canadian.square laWestCree-canadian.square reWestCree-canadian.square riWestCree-canadian.square roWestCree-canadian.square raWestCree-canadian.square theThCree-canadian.square thiThCree-canadian.square thiiThCree-canadian.square thoThCree-canadian.square thooThCree-canadian.square thaThCree-canadian.square thaaThCree-canadian.square thweeWoodScree-canadian.square thwiWoodScree-canadian.square thwiiWoodScree-canadian.square thwoWoodScree-canadian.square thwooWoodScree-canadian.square thwaWoodScree-canadian.square thwaaWoodScree-canadian.square nwiOjibway-canadian.square nwiiOjibway-canadian.square nwoOjibway-canadian.square nwooOjibway-canadian.square looWestCree-canadian.square laaWestCree-canadian.square ";
+name = Dene_square;
+},
+{
+code = "ke-canadian ki-canadian kii-canadian ko-canadian koo-canadian ka-canadian kaa-canadian kweWestCree-canadian kwiiWestCree-canadian kwoWestCree-canadian kwooWestCree-canadian kwaWestCree-canadian kwaaWestCree-canadian ce-canadian ci-canadian cii-canadian co-canadian coo-canadian ca-canadian caa-canadian me-canadian mi-canadian mii-canadian mo-canadian moo-canadian ma-canadian maa-canadian ne-canadian ni-canadian nii-canadian no-canadian noo-canadian na-canadian naa-canadian nweWestCree-canadian nwaWestCree-canadian nwaaWestCree-canadian se-canadian si-canadian sii-canadian so-canadian soo-canadian sa-canadian saa-canadian sho-canadian shoo-canadian sha-canadian shaa-canadian ye-canadian yi-canadian yii-canadian yo-canadian yoo-canadian ya-canadian yaa-canadian re-canadian reRCree-canadian leWestCree-canadian ri-canadian rii-canadian ro-canadian loWestCree-canadian ra-canadian raa-canadian laWestCree-canadian reWestCree-canadian riWestCree-canadian roWestCree-canadian raWestCree-canadian theThCree-canadian thiThCree-canadian thiiThCree-canadian thoThCree-canadian thooThCree-canadian thaThCree-canadian thaaThCree-canadian thweeWoodScree-canadian thwiWoodScree-canadian thwiiWoodScree-canadian thwoWoodScree-canadian thwooWoodScree-canadian thwaWoodScree-canadian thwaaWoodScree-canadian nwiOjibway-canadian nwiiOjibway-canadian nwoOjibway-canadian nwooOjibway-canadian looWestCree-canadian laaWestCree-canadian 
+";
+name = Dene_round;
+},
+{
+code = "acuteFinal-canadian.mid graveFinal-canadian.mid ringTophalfFinal-canadian.mid ringRighthalfFinal-canadian.mid ringFinal-canadian.mid doubleacuteFinal-canadian.mid doubleshortverticalstrokesFinal-canadian.mid shorthorizontalstrokeFinal-canadian.mid downtackFinal-canadian.mid pWestCree-canadian.mid c-canadian.mid mWestCree-canadian.mid ";
+name = Final_mid;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian ringFinal-canadian doubleacuteFinal-canadian doubleshortverticalstrokesFinal-canadian shorthorizontalstrokeFinal-canadian downtackFinal-canadian pWestCree-canadian c-canadian mWestCree-canadian ";
+name = Final_mid_ori;
+},
+{
+code = "acuteFinal-canadian.base graveFinal-canadian.base ringBottomhalfFinal-canadian.base ringTophalfFinal-canadian.base ringRighthalfFinal-canadian.base plusFinal-canadian.base pWestCree-canadian.base c-canadian.base thSayisi-canadian.base mWestCree-canadian.base ";
+name = Final_base;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringBottomhalfFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian plusFinal-canadian pWestCree-canadian c-canadian thSayisi-canadian mWestCree-canadian ";
+name = Final_base_ori;
+},
+{
+code = "ng-canadian ngai-canadian ngaai-canadian ngi-canadian ngii-canadian ngo-canadian ngoo-canadian nga-canadian ngaa-canadian ";
+name = Nunavik;
+},
+{
+code = "ng-canadian.nunavik ngai-canadian.nunavik ngaai-canadian.nunavik ngi-canadian.nunavik ngii-canadian.nunavik ngo-canadian.nunavik ngoo-canadian.nunavik nga-canadian.nunavik ngaa-canadian.nunavik ";
+name = Nunavik_alt;
+}
+);
+customParameters = (
+{
+name = vendorID;
+value = GOOG;
+},
+{
+name = panose;
+value = (
+2,
+11,
+5,
+2,
+4,
+5,
+4,
+2,
+2,
+4
+);
+},
+{
+name = unicodeRanges;
+value = (
+0,
+1,
+2,
+5,
+6,
+45,
+77
+);
+},
+{
+name = codePageRanges;
+value = (
+"1252"
+);
+},
+{
+name = fsType;
+value = (
+);
+}
+);
+date = "2022-06-21 10:06:40 +0000";
+familyName = "Sans Canadian Aboriginal";
+featurePrefixes = (
+{
+automatic = 1;
+code = "languagesystem DFLT dflt;
+
+languagesystem cans dflt;
+";
+name = Languagesystems;
+}
+);
+features = (
+{
+automatic = 1;
+code = "feature ss01;
+feature ss02;
+feature ss03;
+feature ss04;
+";
+tag = aalt;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+tag = salt;
+},
+{
+code = "lookup space_can {
+sub space by space.canadian;
+} space_can;
+
+lookup num_can {
+sub @Num by @Num_can;
+} num_can;
+";
+labels = (
+{
+language = dflt;
+value = "CAN Space and numerals";
+}
+);
+tag = ss01;
+},
+{
+code = "lookup dene_square {
+sub @Dene_round by @Dene_square;
+} dene_square;
+
+";
+labels = (
+{
+language = dflt;
+value = "Dene Square";
+}
+);
+tag = ss02;
+},
+{
+code = "lookup nunavik_alt {
+sub @Nunavik by @Nunavik_alt;
+} nunavik_alt;
+
+";
+labels = (
+{
+language = dflt;
+value = "Nunanvik Alt";
+}
+);
+tag = ss03;
+},
+{
+code = "lookup final_mid {
+sub @Final_mid_ori by @Final_mid;
+} final_mid;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final mid";
+}
+);
+tag = ss04;
+},
+{
+code = "lookup final_base {
+sub @Final_base_ori by @Final_base;
+} final_base;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final base";
+}
+);
+tag = ss05;
+},
+{
+code = "lookup plaincree_first {
+sub wiWestCree-canadian' plusFinal-canadian by i-canadian;
+} plaincree_first;
+
+lookup plaincree_second {
+sub i-canadian plusFinal-canadian' by raiseddoubledotFinal-canadian.cree;
+} plaincree_second;
+
+lookup plaincree_third {
+sub middledotFinal-canadian plusFinal-canadian by raiseddoubledotFinal-canadian.cree;
+} plaincree_third;
+";
+labels = (
+{
+language = dflt;
+value = Plaincree;
+}
+);
+tag = ss06;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+labels = (
+{
+language = dflt;
+value = "";
+}
+);
+tag = ss07;
+}
+);
+fontMaster = (
+{
+axesValues = (
+0,
+0,
+0
+);
+customParameters = (
+{
+name = typoAscender;
+value = 1069;
+},
+{
+name = typoDescender;
+value = -293;
+},
+{
+name = typoLineGap;
+value = 0;
+},
+{
+name = winAscent;
+value = 1069;
+},
+{
+name = winDescent;
+value = 293;
+},
+{
+name = hheaAscender;
+value = 1069;
+},
+{
+name = hheaDescender;
+value = -293;
+},
+{
+name = strikeoutPosition;
+value = 297.19162;
+},
+{
+name = strikeoutSize;
+value = 50;
+},
+{
+name = "Master Icon Glyph Name";
+value = s;
+}
+);
+guides = (
+{
+lockAngle = 1;
+locked = 1;
+pos = (230,357);
+},
+{
+locked = 1;
+pos = (-54,-12);
+},
+{
+locked = 1;
+pos = (103,726);
+}
+);
+id = "9563F490-07F6-43DA-A81C-32B2684714C2";
+metricValues = (
+{
+over = 19;
+pos = 1069;
+},
+{
+over = 19;
+pos = 714;
+},
+{
+over = 19;
+pos = 495;
+},
+{
+over = -19;
+},
+{
+over = -19;
+pos = -293;
+},
+{
+pos = 12;
+}
+);
+name = "RC CR Italic";
+stemValues = (
+93
+);
+}
+);
+glyphs = (
+{
+glyphname = idotless;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,0,l),
+(211,538,l),
+(118,538,l),
+(4,0,l)
+);
+}
+);
+width = 206;
+}
+);
+note = dotlessi;
+unicode = 305;
+},
+{
+glyphname = "acuteFinal-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(128,357,l),
+(333,714,l),
+(255,714,l),
+(50,357,l)
+);
+}
+);
+width = 261;
+}
+);
+metricRight = "=|";
+note = uni141F;
+unicode = 5151;
+},
+{
+glyphname = "graveFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(257,357,l),
+(196,714,l),
+(126,714,l),
+(186,357,l)
+);
+}
+);
+width = 261;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+unicode = 5152;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(291,351,o),
+(333,395,o),
+(350,474,cs),
+(401,714,l),
+(337,714,l),
+(287,478,ls),
+(276,428,o),
+(255,409,o),
+(215,409,cs),
+(170,409,o),
+(155,437,o),
+(165,482,cs),
+(214,714,l),
+(150,714,l),
+(102,489,ls),
+(85,404,o),
+(126,351,o),
+(210,351,cs)
+);
+}
+);
+width = 353;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1421;
+unicode = 5153;
+},
+{
+glyphname = "ringTophalfFinal-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(138,357,l),
+(188,593,ls),
+(199,643,o),
+(220,662,o),
+(260,662,cs),
+(305,662,o),
+(319,634,o),
+(310,589,cs),
+(261,357,l),
+(325,357,l),
+(372,582,ls),
+(390,667,o),
+(349,720,o),
+(264,720,cs),
+(184,720,o),
+(142,676,o),
+(125,597,cs),
+(74,357,l)
+);
+}
+);
+width = 353;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+unicode = 5154;
+},
+{
+glyphname = "ringRighthalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(118,357,ls),
+(267,357,o),
+(319,477,o),
+(319,578,cs),
+(319,666,o),
+(267,714,o),
+(181,714,cs),
+(148,714,l),
+(135,653,l),
+(174,653,ls),
+(226,653,o),
+(254,625,o),
+(254,572,cs),
+(254,512,o),
+(231,418,o),
+(126,418,cs),
+(86,418,l),
+(72,357,l)
+);
+}
+);
+width = 303;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+unicode = 5155;
+},
+{
+glyphname = "ringFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(371,403,o),
+(437,471,o),
+(437,562,cs),
+(437,652,o),
+(370,720,o),
+(276,720,cs),
+(182,720,o),
+(115,652,o),
+(115,562,cs),
+(115,471,o),
+(182,403,o),
+(276,403,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(215,458,o),
+(175,500,o),
+(175,562,cs),
+(175,622,o),
+(215,665,o),
+(276,665,cs),
+(336,665,o),
+(377,621,o),
+(377,562,cs),
+(377,500,o),
+(336,458,o),
+(276,458,cs)
+);
+}
+);
+width = 418;
+}
+);
+note = uni1424;
+unicode = 5156;
+},
+{
+glyphname = "doubleacuteFinal-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(125,357,l),
+(332,714,l),
+(257,714,l),
+(50,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(255,357,l),
+(463,714,l),
+(387,714,l),
+(180,357,l)
+);
+}
+);
+width = 391;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricRight = "=|";
+note = uni1425;
+unicode = 5157;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(138,357,l),
+(214,714,l),
+(150,714,l),
+(74,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(253,357,l),
+(329,714,l),
+(265,714,l),
+(189,357,l)
+);
+}
+);
+width = 281;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "pWestCree-canadian";
+note = uni1426;
+unicode = 5158;
+},
+{
+glyphname = "middledotFinal-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(150,315,o),
+(173,338,o),
+(173,367,cs),
+(173,396,o),
+(150,419,o),
+(121,419,cs),
+(93,419,o),
+(69,396,o),
+(69,367,cs),
+(69,338,o),
+(93,315,o),
+(121,315,cs)
+);
+}
+);
+width = 191;
+}
+);
+note = uni1427;
+unicode = 5159;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(377,517,l),
+(391,581,l),
+(122,581,l),
+(108,517,l)
+);
+}
+);
+width = 371;
+}
+);
+metricRight = "=|";
+note = uni1428;
+unicode = 5160;
+},
+{
+glyphname = "plusFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(251,413,l),
+(277,534,l),
+(381,534,l),
+(394,596,l),
+(290,596,l),
+(315,714,l),
+(255,714,l),
+(230,596,l),
+(125,596,l),
+(112,534,l),
+(216,534,l),
+(191,413,l)
+);
+}
+);
+width = 371;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+unicode = 5161;
+},
+{
+glyphname = "downtackFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(241,357,l),
+(304,653,l),
+(406,653,l),
+(419,714,l),
+(150,714,l),
+(137,653,l),
+(240,653,l),
+(177,357,l)
+);
+}
+);
+width = 371;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni142A;
+unicode = 5162;
+},
+{
+glyphname = "thFinalWoodScree-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(240,357,l),
+(257,435,l),
+(359,435,l),
+(371,491,l),
+(269,491,l),
+(288,580,l),
+(389,580,l),
+(401,636,l),
+(300,636,l),
+(316,714,l),
+(252,714,l),
+(236,636,l),
+(133,636,l),
+(121,580,l),
+(224,580,l),
+(205,491,l),
+(102,491,l),
+(90,435,l),
+(193,435,l),
+(176,357,l)
+);
+}
+);
+width = 369;
+}
+);
+metricLeft = "hyphen-canadian";
+metricRight = "hyphen-canadian";
+note = uni167E;
+unicode = 5758;
+},
+{
+glyphname = "ringSmallFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(280,539,o),
+(323,579,o),
+(323,633,cs),
+(323,688,o),
+(280,727,o),
+(228,727,cs),
+(176,727,o),
+(133,688,o),
+(133,633,cs),
+(133,579,o),
+(175,539,o),
+(228,539,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(197,581,o),
+(177,603,o),
+(177,633,cs),
+(177,663,o),
+(198,685,o),
+(228,685,cs),
+(258,685,o),
+(279,663,o),
+(279,633,cs),
+(279,603,o),
+(258,581,o),
+(228,581,cs)
+);
+}
+);
+width = 292;
+}
+);
+note = g725;
+unicode = 6366;
+},
+{
+glyphname = "raiseddotFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(219,623,o),
+(242,646,o),
+(242,675,cs),
+(242,704,o),
+(219,727,o),
+(190,727,cs),
+(161,727,o),
+(138,704,o),
+(138,675,cs),
+(138,646,o),
+(161,623,o),
+(190,623,cs)
+);
+}
+);
+width = 197;
+}
+);
+note = g725;
+unicode = 6367;
+},
+{
+glyphname = "acuteFinal-canadian.base";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "acuteFinal-canadian";
+}
+);
+width = 261;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.base";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "graveFinal-canadian";
+}
+);
+width = 261;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian.base";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 353;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1421;
+},
+{
+glyphname = "ringTophalfFinal-canadian.base";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 353;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.base";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 303;
+}
+);
+metricLeft = "==|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "plusFinal-canadian.base";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(163,0,l),
+(189,121,l),
+(293,121,l),
+(306,183,l),
+(202,183,l),
+(227,301,l),
+(167,301,l),
+(142,183,l),
+(37,183,l),
+(24,121,l),
+(129,121,l),
+(103,0,l)
+);
+}
+);
+width = 371;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+},
+{
+glyphname = "acuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-168);
+ref = "acuteFinal-canadian";
+}
+);
+width = 261;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.mid";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "graveFinal-canadian";
+}
+);
+width = 261;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringTophalfFinal-canadian.mid";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-38,-178);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 353;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.mid";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-168);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 303;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "ringFinal-canadian.mid";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-44,-206);
+ref = "ringFinal-canadian";
+}
+);
+width = 418;
+}
+);
+metricLeft = "ringFinal-canadian";
+metricWidth = "ringFinal-canadian";
+note = uni1424;
+},
+{
+glyphname = "doubleacuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-168);
+ref = "doubleacuteFinal-canadian";
+}
+);
+width = 391;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "doubleacuteFinal-canadian";
+note = uni1425;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian.mid";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-168);
+ref = "doubleshortverticalstrokesFinal-canadian";
+}
+);
+width = 281;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricWidth = "doubleshortverticalstrokesFinal-canadian";
+note = uni1426;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian.mid";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-38,-182);
+ref = "shorthorizontalstrokeFinal-canadian";
+}
+);
+width = 371;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "shorthorizontalstrokeFinal-canadian";
+note = uni1428;
+},
+{
+glyphname = "downtackFinal-canadian.mid";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "downtackFinal-canadian";
+}
+);
+width = 371;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "downtackFinal-canadian";
+note = uni142A;
+},
+{
+glyphname = "e-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (341,470);
+},
+{
+name = top_center_can;
+pos = (396,714);
+},
+{
+name = top_left_can;
+pos = (210,714);
+},
+{
+name = top_right_can;
+pos = (584,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(261,0,l),
+(665,688,l),
+(670,714,l),
+(125,714,l),
+(119,688,l),
+(230,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(289,101,l),
+(209,659,l),
+(188,638,l),
+(570,638,l),
+(554,659,l),
+(240,101,l)
+);
+}
+);
+width = 596;
+}
+);
+metricRight = "=|";
+note = uni1401;
+unicode = 5121;
+},
+{
+glyphname = "aai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (180,0);
+ref = ring_top.canadian;
+}
+);
+width = 597;
+}
+);
+note = uni1402;
+unicode = 5122;
+},
+{
+glyphname = "i-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (328,376);
+},
+{
+name = top_center_can;
+pos = (397,714);
+},
+{
+name = top_left_can;
+pos = (209,714);
+},
+{
+name = top_right_can;
+pos = (583,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(381,714,l),
+(-22,26,l),
+(-28,0,l),
+(518,0,l),
+(523,26,l),
+(413,714,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(354,613,l),
+(434,55,l),
+(455,76,l),
+(72,76,l),
+(89,55,l),
+(403,613,l)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "e-canadian";
+metricWidth = "e-canadian";
+note = uni1403;
+unicode = 5123;
+},
+{
+glyphname = "ii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (229,0);
+ref = dot_top;
+}
+);
+width = 597;
+}
+);
+note = uni1404;
+unicode = 5124;
+},
+{
+glyphname = "o-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (262,366);
+},
+{
+name = top_center_can;
+pos = (396,714);
+},
+{
+name = top_double;
+pos = (483,714);
+},
+{
+name = top_left_can;
+pos = (198,714);
+},
+{
+name = top_right_can;
+pos = (595,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(33,0,l),
+(558,340,l),
+(566,374,l),
+(185,714,l),
+(160.996,714,l),
+(8.996,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(216,609,l),
+(181,622,l),
+(479,352,l),
+(477,375,l),
+(78,112,l),
+(108,105,l)
+);
+}
+);
+width = 569;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1405;
+unicode = 5125;
+},
+{
+glyphname = "oo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (28,0);
+ref = dot_top;
+}
+);
+width = 569;
+}
+);
+note = uni1406;
+unicode = 5126;
+},
+{
+glyphname = "yCreeoo-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (160,0);
+ref = doubledot_top;
+}
+);
+width = 569;
+}
+);
+note = uni1407;
+unicode = 5127;
+},
+{
+glyphname = "eeCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(33,0,l),
+(558,340,l),
+(566,374,l),
+(185,714,l),
+(160.996,714,l),
+(8.996,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(210,609,l),
+(195,613,l),
+(483,352,l),
+(489,380,l),
+(91,118,l),
+(102,105,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(255,278,l),
+(291,449,l),
+(256,449,l),
+(220,278,l)
+);
+}
+);
+width = 569;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "o-canadian";
+note = uni1408;
+unicode = 5128;
+},
+{
+glyphname = "iCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (187,9);
+ref = dot_middle_optic_small;
+}
+);
+width = 569;
+}
+);
+note = uni1409;
+unicode = 5129;
+},
+{
+glyphname = "a-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (353,357);
+},
+{
+name = top_center_can;
+pos = (352,714);
+},
+{
+name = top_left_can;
+pos = (174,714);
+},
+{
+name = top_right_can;
+pos = (566,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(582,714,l),
+(57,374,l),
+(50,340,l),
+(430,0,l),
+(455,0,l),
+(607,714,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(400,105,l),
+(434,92,l),
+(136,362,l),
+(138,339,l),
+(538,602,l),
+(508,609,l)
+);
+}
+);
+width = 570;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni140A;
+unicode = 5130;
+},
+{
+glyphname = "aa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (396,0);
+ref = dot_top;
+}
+);
+width = 569;
+}
+);
+note = uni140B;
+unicode = 5131;
+},
+{
+glyphname = "we-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "e-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni140C;
+unicode = 5132;
+},
+{
+glyphname = "weWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (597,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni140D;
+unicode = 5133;
+},
+{
+glyphname = "wi-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "i-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni140E;
+unicode = 5134;
+},
+{
+glyphname = "wiWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (597,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni140F;
+unicode = 5135;
+},
+{
+glyphname = "wii-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (420,0);
+ref = dot_top;
+}
+);
+width = 788;
+}
+);
+note = uni1410;
+unicode = 5136;
+},
+{
+glyphname = "wiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (229,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (597,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni1411;
+unicode = 5137;
+},
+{
+glyphname = "wo-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "o-canadian";
+}
+);
+width = 761;
+}
+);
+note = uni1412;
+unicode = 5138;
+},
+{
+glyphname = "woWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (569,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 761;
+}
+);
+note = uni1413;
+unicode = 5139;
+},
+{
+glyphname = "woo-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (418,0);
+ref = dot_top;
+}
+);
+width = 761;
+}
+);
+note = uni1414;
+unicode = 5140;
+},
+{
+glyphname = "wooWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (28,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (569,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 761;
+}
+);
+note = uni1415;
+unicode = 5141;
+},
+{
+glyphname = "wooNaskapi-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (146,-97);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (274,-211);
+ref = dot_top;
+}
+);
+width = 569;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricWidth = "o-canadian";
+note = uni1416;
+unicode = 5142;
+},
+{
+glyphname = "wa-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "a-canadian";
+}
+);
+width = 761;
+}
+);
+note = uni1417;
+unicode = 5143;
+},
+{
+glyphname = "waWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (569,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 761;
+}
+);
+note = uni1418;
+unicode = 5144;
+},
+{
+glyphname = "waa-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (588,0);
+ref = dot_top;
+}
+);
+width = 761;
+}
+);
+note = uni1419;
+unicode = 5145;
+},
+{
+glyphname = "waaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (396,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (569,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 761;
+}
+);
+note = uni141A;
+unicode = 5146;
+},
+{
+glyphname = "waaNaskapi-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (82,-207);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (254,-97);
+ref = dot_top;
+}
+);
+width = 570;
+}
+);
+metricWidth = "a-canadian";
+note = uni141B;
+unicode = 5147;
+},
+{
+glyphname = "ai-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(248,351,o),
+(289,381,o),
+(309,434,c),
+(291,434,l),
+(294,380,o),
+(327,351,o),
+(384,351,cs),
+(457,351,o),
+(498,393,o),
+(517,484,cs),
+(566,714,l),
+(506,714,l),
+(457,484,ls),
+(446,432,o),
+(424,409,o),
+(386,409,cs),
+(344,409,o),
+(328,433,o),
+(339,484,cs),
+(388,714,l),
+(328,714,l),
+(280,487,ls),
+(269,434,o),
+(245,409,o),
+(207,409,cs),
+(168,409,o),
+(151,435,o),
+(161,481,cs),
+(211,714,l),
+(150,714,l),
+(100,477,ls),
+(84,404,o),
+(121.998,351,o),
+(195,351,cs)
+);
+}
+);
+width = 518;
+}
+);
+metricRight = "=|";
+note = uni141C;
+unicode = 5148;
+},
+{
+glyphname = "ycreew-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(368,528,o),
+(396,564,o),
+(396,624,cs),
+(396,684,o),
+(367,720,o),
+(325,720,cs),
+(283,720,o),
+(253,684,o),
+(253,624,cs),
+(253,564,o),
+(282,528,o),
+(325,528,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(211,351,o),
+(240,387,o),
+(240,447,cs),
+(240,507,o),
+(210,543,o),
+(168,543,cs),
+(126,543,o),
+(97,507,o),
+(97,447,cs),
+(97,387,o),
+(126,351,o),
+(168,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(146,386,o),
+(133,406,o),
+(133,447,cs),
+(133,489,o),
+(146,508,o),
+(168,508,cs),
+(190,508,o),
+(204,489,o),
+(204,447,cs),
+(204,406,o),
+(190,386,o),
+(168,386,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(303,563,o),
+(289,583,o),
+(289,624,cs),
+(289,666,o),
+(303,685,o),
+(325,685,cs),
+(347,685,o),
+(360,666,o),
+(360,624,cs),
+(360,583,o),
+(347,563,o),
+(325,563,cs)
+);
+}
+);
+width = 371;
+}
+);
+metricRight = "=|";
+note = uni141D;
+unicode = 5149;
+},
+{
+glyphname = "glottalstop-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(342,357,l),
+(345,372,l),
+(290,714,l),
+(274,714,l),
+(72,372,l),
+(69,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(285,647,l),
+(255,650,l),
+(292,385,l),
+(306,406,l),
+(129,406,l),
+(136,385,l)
+);
+}
+);
+width = 365;
+}
+);
+metricRight = "=|";
+note = uni141E;
+unicode = 5150;
+},
+{
+glyphname = "en-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+pos = (597,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 857;
+}
+);
+note = uni142B;
+unicode = 5163;
+},
+{
+glyphname = "in-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+pos = (410,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 671;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142C;
+unicode = 5164;
+},
+{
+glyphname = "on-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (443,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 704;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142D;
+unicode = 5165;
+},
+{
+glyphname = "an-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (540,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 801;
+}
+);
+metricRight = "graveFinal-canadian";
+note = uni142E;
+unicode = 5166;
+},
+{
+glyphname = "pe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (341,470);
+},
+{
+name = top_center_can;
+pos = (398,714);
+},
+{
+name = top_left_can;
+pos = (209,714);
+},
+{
+name = top_right_can;
+pos = (584,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(261,0,l),
+(665,688,l),
+(670,714,l),
+(580,714,l),
+(232,109,l),
+(296,109,l),
+(204,714,l),
+(125,714,l),
+(119,688,l),
+(230,0,l)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni142F;
+unicode = 5167;
+},
+{
+glyphname = "paai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (180,0);
+ref = ring_top.canadian;
+}
+);
+width = 597;
+}
+);
+note = uni1430;
+unicode = 5168;
+},
+{
+glyphname = "pi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (330,376);
+},
+{
+name = top_center_can;
+pos = (397,714);
+},
+{
+name = top_left_can;
+pos = (209,714);
+},
+{
+name = top_right_can;
+pos = (583,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(381,714,l),
+(-22,26,l),
+(-28,0,l),
+(63,0,l),
+(410,605,l),
+(347,605,l),
+(438,0,l),
+(517,0,l),
+(523,26,l),
+(413,714,l)
+);
+}
+);
+width = 595;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni1431;
+unicode = 5169;
+},
+{
+glyphname = "pii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (229,0);
+ref = dot_top;
+}
+);
+width = 597;
+}
+);
+note = uni1432;
+unicode = 5170;
+},
+{
+glyphname = "po-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (193,368);
+},
+{
+name = top_center_can;
+pos = (374,714);
+},
+{
+name = top_double;
+pos = (471,714);
+},
+{
+name = top_left_can;
+pos = (182,714);
+},
+{
+name = top_right_can;
+pos = (571,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+name = "Thin Slanted";
+shapes = (
+{
+closed = 1;
+nodes = (
+(13,0,l),
+(534,340,l),
+(541,374,l),
+(165,714,l),
+(141,714,l),
+(124,636,l),
+(444,345,l),
+(453,388,l),
+(10,97,l),
+(-11,0,l)
+);
+}
+);
+width = 544;
+}
+);
+metricRight = "o-canadian";
+note = uni1433;
+unicode = 5171;
+},
+{
+glyphname = "poo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (12,0);
+ref = dot_top;
+}
+);
+width = 545;
+}
+);
+note = uni1434;
+unicode = 5172;
+},
+{
+glyphname = "ycreepoo-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (148,0);
+ref = doubledot_top;
+}
+);
+width = 545;
+}
+);
+note = uni1435;
+unicode = 5173;
+},
+{
+glyphname = "heeCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (130,11);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 545;
+}
+);
+note = uni1436;
+unicode = 5174;
+},
+{
+glyphname = "hiCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (109,13);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 545;
+}
+);
+note = uni1437;
+unicode = 5175;
+},
+{
+glyphname = "pa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (319,357);
+},
+{
+name = top_center_can;
+pos = (372,714);
+},
+{
+name = top_left_can;
+pos = (175,714);
+},
+{
+name = top_right_can;
+pos = (562,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(577,714,l),
+(58,374,l),
+(50,340,l),
+(425,0,l),
+(450,0,l),
+(467,78,l),
+(147,369,l),
+(139,326,l),
+(581,617,l),
+(602,714,l)
+);
+}
+);
+width = 544;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1438;
+unicode = 5176;
+},
+{
+glyphname = "paa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (393,0);
+ref = dot_top;
+}
+);
+width = 545;
+}
+);
+note = uni1439;
+unicode = 5177;
+},
+{
+glyphname = "pwe-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "pe-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni143A;
+unicode = 5178;
+},
+{
+glyphname = "pweWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "pe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (597,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni143B;
+unicode = 5179;
+},
+{
+glyphname = "pwi-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "pi-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni143C;
+unicode = 5180;
+},
+{
+glyphname = "pwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (597,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni143D;
+unicode = 5181;
+},
+{
+glyphname = "pwii-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (420,0);
+ref = dot_top;
+}
+);
+width = 788;
+}
+);
+note = uni143E;
+unicode = 5182;
+},
+{
+glyphname = "pwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (229,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (597,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni143F;
+unicode = 5183;
+},
+{
+glyphname = "pwo-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "po-canadian";
+}
+);
+width = 736;
+}
+);
+note = uni1440;
+unicode = 5184;
+},
+{
+glyphname = "pwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (545,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 736;
+}
+);
+note = uni1441;
+unicode = 5185;
+},
+{
+glyphname = "pwoo-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (396,0);
+ref = dot_top;
+}
+);
+width = 736;
+}
+);
+note = uni1442;
+unicode = 5186;
+},
+{
+glyphname = "pwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (12,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (545,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 736;
+}
+);
+note = uni1443;
+unicode = 5187;
+},
+{
+glyphname = "pwa-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "pa-canadian";
+}
+);
+width = 736;
+}
+);
+note = uni1444;
+unicode = 5188;
+},
+{
+glyphname = "pwaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (545,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 736;
+}
+);
+note = uni1445;
+unicode = 5189;
+},
+{
+glyphname = "pwaa-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (584,0);
+ref = dot_top;
+}
+);
+width = 736;
+}
+);
+note = uni1446;
+unicode = 5190;
+},
+{
+glyphname = "pwaaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (393,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (545,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 736;
+}
+);
+note = uni1447;
+unicode = 5191;
+},
+{
+glyphname = "ycreepwaa-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+pos = (77,-207);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (249,-97);
+ref = dot_top;
+}
+);
+width = 544;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1448;
+unicode = 5192;
+},
+{
+glyphname = "p-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(307,357,l),
+(319,412,l),
+(165,554,l),
+(155,507,l),
+(369,648,l),
+(383,714,l),
+(370,714,l),
+(114,546,l),
+(110,526,l),
+(294,357,l)
+);
+}
+);
+width = 335;
+}
+);
+note = uni1449;
+unicode = 5193;
+},
+{
+glyphname = "pWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(138,357,l),
+(214,714,l),
+(150,714,l),
+(74,357,l)
+);
+}
+);
+width = 166;
+}
+);
+metricRight = "=|";
+note = uni144A;
+unicode = 5194;
+},
+{
+color = 6;
+glyphname = "hCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(102,189,l),
+(133,335,ls),
+(141,374,o),
+(162,393,o),
+(189,393,cs),
+(222,393,o),
+(234,371,o),
+(226,333,cs),
+(195,189,l),
+(259.005,189,l),
+(291,341,ls),
+(305,405,o),
+(273,450,o),
+(213,450,cs),
+(174,450,o),
+(140,425,o),
+(130,388,c),
+(143,379,l),
+(178,546,l),
+(115,546,l),
+(39,189,l)
+);
+}
+);
+width = 306;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144B;
+unicode = 5195;
+},
+{
+glyphname = "te-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (324,357);
+},
+{
+name = top_center_can;
+pos = (400,714);
+},
+{
+name = top_left_can;
+pos = (205,714);
+},
+{
+name = top_right_can;
+pos = (596,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(419,-13,o),
+(505,68,o),
+(541,234,cs),
+(643,714,l),
+(549,714,l),
+(449,244,ls),
+(424,125,o),
+(372,74,o),
+(281,74,cs),
+(169,74,o),
+(128,137,o),
+(155,264,cs),
+(251,714,l),
+(158,714,l),
+(64,271,ls),
+(26,92,o),
+(106,-13,o),
+(275,-13,cs)
+);
+}
+);
+width = 603;
+}
+);
+metricRight = "=|";
+note = uni144C;
+unicode = 5196;
+},
+{
+glyphname = "taai-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (182,0);
+ref = ring_top.canadian;
+}
+);
+width = 602;
+}
+);
+note = uni144D;
+unicode = 5197;
+},
+{
+glyphname = "ti-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (324,357);
+},
+{
+name = middle_right_can;
+pos = (678,357);
+},
+{
+name = top_center_can;
+pos = (400,714);
+},
+{
+name = top_left_can;
+pos = (205,714);
+},
+{
+name = top_right_can;
+pos = (596,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,0,l),
+(199,470,ls),
+(224,589,o),
+(278,640,o),
+(368,640,cs),
+(479,640,o),
+(520,577,o),
+(493,450,cs),
+(397,0,l),
+(491,0,l),
+(585,443,ls),
+(623,622,o),
+(542,727,o),
+(374,727,cs),
+(229,727,o),
+(143,646,o),
+(108,480,cs),
+(6,0,l)
+);
+}
+);
+width = 603;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni144E;
+unicode = 5198;
+},
+{
+glyphname = "tii-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (230,0);
+ref = dot_top;
+}
+);
+width = 602;
+}
+);
+note = uni144F;
+unicode = 5199;
+},
+{
+glyphname = "to-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (226,357);
+},
+{
+name = middle_right_can;
+pos = (588,357);
+},
+{
+name = top_center_can;
+pos = (326,714);
+},
+{
+name = top_double;
+pos = (383,714);
+},
+{
+name = top_left_can;
+pos = (183,714);
+},
+{
+name = top_right_can;
+pos = (512,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(107,0,ls),
+(414,0,o),
+(487,291,o),
+(487,457,cs),
+(487,623,o),
+(394,714,o),
+(226,714,cs),
+(142,714,l),
+(124,628,l),
+(209,628,ls),
+(332,628,o),
+(393,570,o),
+(393,452,cs),
+(393,328,o),
+(340,86,o),
+(111,86,cs),
+(8,86,l),
+(-10,0,l)
+);
+}
+);
+width = 504;
+}
+);
+note = uni1450;
+unicode = 5200;
+},
+{
+glyphname = "too-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (157,0);
+ref = dot_top;
+}
+);
+width = 504;
+}
+);
+note = uni1451;
+unicode = 5201;
+},
+{
+glyphname = "ycreetoo-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (61,0);
+ref = doubledot_top;
+}
+);
+width = 504;
+}
+);
+note = uni1452;
+unicode = 5202;
+},
+{
+glyphname = "deeCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (156,0);
+ref = stroke_middle;
+}
+);
+width = 504;
+}
+);
+note = uni1453;
+unicode = 5203;
+},
+{
+glyphname = "diCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (133,0);
+ref = dot_middle;
+}
+);
+width = 504;
+}
+);
+note = uni1454;
+unicode = 5204;
+},
+{
+glyphname = "ta-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (324,357);
+},
+{
+name = top_center_can;
+pos = (376,714);
+},
+{
+name = top_left_can;
+pos = (188,714);
+},
+{
+name = top_right_can;
+pos = (520,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(409,0,l),
+(427,86,l),
+(339,86,ls),
+(217,86,o),
+(158,144,o),
+(158,261,cs),
+(158,394,o),
+(215,628,o),
+(438,628,cs),
+(542,628,l),
+(560,714,l),
+(442,714,ls),
+(141,714,o),
+(64,430,o),
+(64,256,cs),
+(64,91,o),
+(154,0,o),
+(322,0,cs)
+);
+}
+);
+width = 504;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|to-canadian";
+note = uni1455;
+unicode = 5205;
+},
+{
+glyphname = "taa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (207,0);
+ref = dot_top;
+}
+);
+width = 504;
+}
+);
+note = uni1456;
+unicode = 5206;
+},
+{
+glyphname = "twe-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "te-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni1457;
+unicode = 5207;
+},
+{
+glyphname = "tweWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (602,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni1458;
+unicode = 5208;
+},
+{
+glyphname = "twi-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ti-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni1459;
+unicode = 5209;
+},
+{
+glyphname = "twiWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (602,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni145A;
+unicode = 5210;
+},
+{
+glyphname = "twii-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (422,0);
+ref = dot_top;
+}
+);
+width = 794;
+}
+);
+note = uni145B;
+unicode = 5211;
+},
+{
+glyphname = "twiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (230,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (602,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni145C;
+unicode = 5212;
+},
+{
+glyphname = "two-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "to-canadian";
+}
+);
+width = 696;
+}
+);
+note = uni145D;
+unicode = 5213;
+},
+{
+glyphname = "twoWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (504,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 696;
+}
+);
+note = uni145E;
+unicode = 5214;
+},
+{
+glyphname = "twoo-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (348,0);
+ref = dot_top;
+}
+);
+width = 696;
+}
+);
+note = uni145F;
+unicode = 5215;
+},
+{
+glyphname = "twooWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (157,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (504,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 696;
+}
+);
+note = uni1460;
+unicode = 5216;
+},
+{
+glyphname = "twa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ta-canadian";
+}
+);
+width = 696;
+}
+);
+note = uni1461;
+unicode = 5217;
+},
+{
+glyphname = "twaWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (504,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 696;
+}
+);
+note = uni1462;
+unicode = 5218;
+},
+{
+glyphname = "twaa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (398,0);
+ref = dot_top;
+}
+);
+width = 696;
+}
+);
+note = uni1463;
+unicode = 5219;
+},
+{
+glyphname = "twaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (207,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (504,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 696;
+}
+);
+note = uni1464;
+unicode = 5220;
+},
+{
+glyphname = "twaaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (202,0);
+ref = "ta-canadian";
+}
+);
+width = 706;
+}
+);
+note = uni1465;
+unicode = 5221;
+},
+{
+glyphname = "t-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(277,357,l),
+(290,418,l),
+(251,418,ls),
+(198,418,o),
+(171,447,o),
+(171,499,cs),
+(171,565,o),
+(199,653,o),
+(301,653,cs),
+(340,653,l),
+(353,714,l),
+(309,714,ls),
+(162,714,o),
+(106,599,o),
+(106,493,cs),
+(106,405,o),
+(157,357,o),
+(244,357,cs)
+);
+}
+);
+width = 303;
+}
+);
+note = uni1466;
+unicode = 5222;
+},
+{
+glyphname = "tte-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+pos = (602,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 768;
+}
+);
+note = uni1467;
+unicode = 5223;
+},
+{
+glyphname = "tti-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+pos = (602,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 768;
+}
+);
+note = uni1468;
+unicode = 5224;
+},
+{
+glyphname = "tto-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+pos = (504,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 670;
+}
+);
+note = uni1469;
+unicode = 5225;
+},
+{
+glyphname = "tta-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+pos = (504,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 670;
+}
+);
+note = uni146A;
+unicode = 5226;
+},
+{
+glyphname = "ke-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (302,457);
+},
+{
+name = top_center_can;
+pos = (344,714);
+},
+{
+name = top_left_can;
+pos = (196,714);
+},
+{
+name = top_right_can;
+pos = (492,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(387,0,l),
+(481,446,ls),
+(510,583,o),
+(484,727,o),
+(329,727,cs),
+(149,727,o),
+(91,515,o),
+(91,386,cs),
+(91,272,o),
+(143,205,o),
+(238,205,cs),
+(298,205,o),
+(344,239,o),
+(375,309,c),
+(360,314,l),
+(293,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(209,286,o),
+(181,321,o),
+(181,390,cs),
+(181,462,o),
+(214,647,o),
+(321,647,cs),
+(374,647,o),
+(402,612,o),
+(402,543,cs),
+(402,471,o),
+(369,286,o),
+(263,286,cs)
+);
+}
+);
+width = 499;
+}
+);
+metricRight = "te-canadian";
+note = uni146B;
+unicode = 5227;
+},
+{
+glyphname = "kaai-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (133,0);
+ref = ring_top.canadian;
+}
+);
+width = 498;
+}
+);
+note = uni146C;
+unicode = 5228;
+},
+{
+glyphname = "ki-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (310,457);
+},
+{
+name = top_center_can;
+pos = (351,714);
+},
+{
+name = top_left_can;
+pos = (204,714);
+},
+{
+name = top_right_can;
+pos = (500,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,0,l),
+(172,341,l),
+(156,314,l),
+(155,252,o),
+(200,205,o),
+(273,205,cs),
+(441,205,o),
+(500,421,o),
+(500,542,cs),
+(500,660,o),
+(441,727,o),
+(336,727,cs),
+(220,727,o),
+(143,645,o),
+(110,487,cs),
+(6,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(217,286,o),
+(189,321,o),
+(189,390,cs),
+(189,462,o),
+(224,647,o),
+(329,647,cs),
+(382,647,o),
+(410,612,o),
+(410,544,cs),
+(410,469,o),
+(376,286,o),
+(271,286,cs)
+);
+}
+);
+width = 499;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni146D;
+unicode = 5229;
+},
+{
+glyphname = "kii-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (182,0);
+ref = dot_top;
+}
+);
+width = 498;
+}
+);
+note = uni146E;
+unicode = 5230;
+},
+{
+glyphname = "ko-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (285,375);
+},
+{
+name = top_center_can;
+pos = (345,714);
+},
+{
+name = top_double;
+pos = (493,714);
+},
+{
+name = top_left_can;
+pos = (197,714);
+},
+{
+name = top_right_can;
+pos = (493,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(326,-13,o),
+(402,69,o),
+(436,227,cs),
+(539,714,l),
+(446,714,l),
+(373,373,l),
+(389,400,l),
+(390,462,o),
+(345,509,o),
+(272,509,cs),
+(104,509,o),
+(45,293,o),
+(45,172,cs),
+(45,55,o),
+(104,-13,o),
+(210,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(163,67,o),
+(135,102,o),
+(135,170,cs),
+(135,243,o),
+(170,428,o),
+(275,428,cs),
+(328,428,o),
+(356,392,o),
+(356,324,cs),
+(356,248,o),
+(323,67,o),
+(217,67,cs)
+);
+}
+);
+width = 499;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni146F;
+unicode = 5231;
+},
+{
+glyphname = "koo-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (322,0);
+ref = dot_top;
+}
+);
+width = 498;
+}
+);
+note = uni1470;
+unicode = 5232;
+},
+{
+glyphname = "ycreekoo-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (170,0);
+ref = doubledot_top;
+}
+);
+width = 498;
+}
+);
+note = uni1471;
+unicode = 5233;
+},
+{
+glyphname = "ka-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (292,377);
+},
+{
+name = top_center_can;
+pos = (352,714);
+},
+{
+name = top_left_can;
+pos = (204,714);
+},
+{
+name = top_right_can;
+pos = (500,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(396,-13,o),
+(454,199,o),
+(454,328,cs),
+(454,442,o),
+(400,509,o),
+(306,509,cs),
+(248,509,o),
+(202,475,o),
+(170,405,c),
+(184,400,l),
+(251,714,l),
+(158,714,l),
+(63,268,ls),
+(25,91,o),
+(86,-13,o),
+(216,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(170,67,o),
+(142,102,o),
+(142,171,cs),
+(142,243,o),
+(175,428,o),
+(281,428,cs),
+(335,428,o),
+(363,393,o),
+(363,324,cs),
+(363,252,o),
+(330,67,o),
+(224,67,cs)
+);
+}
+);
+width = 499;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "==|ke-canadian";
+note = uni1472;
+unicode = 5234;
+},
+{
+glyphname = "kaa-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (34,0);
+ref = dot_top;
+}
+);
+width = 498;
+}
+);
+note = uni1473;
+unicode = 5235;
+},
+{
+glyphname = "kwe-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ke-canadian";
+}
+);
+width = 689;
+}
+);
+note = uni1474;
+unicode = 5236;
+},
+{
+glyphname = "kweWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (498,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 689;
+}
+);
+note = uni1475;
+unicode = 5237;
+},
+{
+glyphname = "kwi-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ki-canadian";
+}
+);
+width = 689;
+}
+);
+note = uni1476;
+unicode = 5238;
+},
+{
+glyphname = "kwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (498,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 689;
+}
+);
+note = uni1477;
+unicode = 5239;
+},
+{
+glyphname = "kwii-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (373,0);
+ref = dot_top;
+}
+);
+width = 689;
+}
+);
+note = uni1478;
+unicode = 5240;
+},
+{
+glyphname = "kwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (182,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (498,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 689;
+}
+);
+note = uni1479;
+unicode = 5241;
+},
+{
+glyphname = "kwo-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ko-canadian";
+}
+);
+width = 689;
+}
+);
+note = uni147A;
+unicode = 5242;
+},
+{
+glyphname = "kwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (498,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 689;
+}
+);
+note = uni147B;
+unicode = 5243;
+},
+{
+glyphname = "kwoo-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (514,0);
+ref = dot_top;
+}
+);
+width = 689;
+}
+);
+note = uni147C;
+unicode = 5244;
+},
+{
+glyphname = "kwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (322,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (498,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 689;
+}
+);
+note = uni147D;
+unicode = 5245;
+},
+{
+glyphname = "kwa-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ka-canadian";
+}
+);
+width = 689;
+}
+);
+note = uni147E;
+unicode = 5246;
+},
+{
+glyphname = "kwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (498,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 689;
+}
+);
+note = uni147F;
+unicode = 5247;
+},
+{
+glyphname = "kwaa-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (226,0);
+ref = dot_top;
+}
+);
+width = 689;
+}
+);
+note = uni1480;
+unicode = 5248;
+},
+{
+glyphname = "kwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (34,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (498,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 689;
+}
+);
+note = uni1481;
+unicode = 5249;
+},
+{
+glyphname = "kwaaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (202,0);
+ref = "ka-canadian";
+}
+);
+width = 699;
+}
+);
+note = uni1482;
+unicode = 5250;
+},
+{
+glyphname = "k-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(289,351,o),
+(322,465,o),
+(322,527,cs),
+(322,586,o),
+(293,622,o),
+(245,622,cs),
+(205,622,o),
+(175,594,o),
+(162,553,c),
+(180,553,l),
+(214,714,l),
+(150,714,l),
+(104,497,ls),
+(90,432,o),
+(102,351,o),
+(191,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(171,400,o),
+(158,418,o),
+(158,450,cs),
+(158,487,o),
+(177,573,o),
+(226,573,cs),
+(250,573,o),
+(263,555,o),
+(263,524,cs),
+(263,486,o),
+(244,400,o),
+(195,400,cs)
+);
+}
+);
+width = 309;
+}
+);
+note = uni1483;
+unicode = 5251;
+},
+{
+glyphname = "kw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(247,350,o),
+(290,394,o),
+(309,483,cs),
+(357,714,l),
+(294,714,l),
+(258,546,l),
+(274,551,l),
+(277,593,o),
+(249,621,o),
+(208,621,cs),
+(124,621,o),
+(90,512,o),
+(90,452,cs),
+(90,389,o),
+(124,350,o),
+(183,350,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(160,400,o),
+(147,418,o),
+(147,449,cs),
+(147,486,o),
+(166,572,o),
+(216,572,cs),
+(239,572,o),
+(253,554,o),
+(253,522,cs),
+(253,489,o),
+(236,400,o),
+(184,400,cs)
+);
+}
+);
+width = 310;
+}
+);
+metricLeft = "=|k-canadian";
+metricRight = "=|k-canadian";
+note = uni1484;
+unicode = 5252;
+},
+{
+glyphname = "southslaveykeh-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+pos = (498,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 663;
+}
+);
+note = uni1485;
+unicode = 5253;
+},
+{
+glyphname = "southslaveykih-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+pos = (498,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 663;
+}
+);
+note = uni1486;
+unicode = 5254;
+},
+{
+glyphname = "southslaveykoh-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+pos = (498,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 663;
+}
+);
+note = uni1487;
+unicode = 5255;
+},
+{
+glyphname = "southslaveykah-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+pos = (498,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 663;
+}
+);
+note = uni1488;
+unicode = 5256;
+},
+{
+glyphname = "ce-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (289,417);
+},
+{
+name = top_center_can;
+pos = (342,714);
+},
+{
+name = top_left_can;
+pos = (195,714);
+},
+{
+name = top_right_can;
+pos = (487,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(381,0,l),
+(483,480,ls),
+(515,635,o),
+(450,727,o),
+(324,727,cs),
+(204,727,o),
+(136,655,o),
+(102,497,cs),
+(82,401,l),
+(174,401,l),
+(197,508,ls),
+(218,604,o),
+(254,645,o),
+(313,645,cs),
+(383,645,o),
+(414,595,o),
+(393,498,cs),
+(287,0,l)
+);
+}
+);
+width = 493;
+}
+);
+metricRight = "te-canadian";
+note = uni1489;
+unicode = 5257;
+},
+{
+glyphname = "caai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (133,0);
+ref = ring_top.canadian;
+}
+);
+width = 492;
+}
+);
+note = uni148A;
+unicode = 5258;
+},
+{
+glyphname = "ci-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (299,417);
+},
+{
+name = top_center_can;
+pos = (351,714);
+},
+{
+name = top_left_can;
+pos = (205,714);
+},
+{
+name = top_right_can;
+pos = (498,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,0,l),
+(207,508,ls),
+(227,604,o),
+(263,645,o),
+(324,645,cs),
+(393,645,o),
+(424,595,o),
+(403,498,cs),
+(383,401,l),
+(475,401,l),
+(492,480,ls),
+(525,635,o),
+(460,727,o),
+(333,727,cs),
+(213,727,o),
+(145,655,o),
+(112,497,cs),
+(6,0,l)
+);
+}
+);
+width = 492;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+unicode = 5259;
+},
+{
+glyphname = "cii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (181,0);
+ref = dot_top;
+}
+);
+width = 492;
+}
+);
+note = uni148C;
+unicode = 5260;
+},
+{
+glyphname = "co-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (290,417);
+},
+{
+name = top_center_can;
+pos = (341,714);
+},
+{
+name = top_double;
+pos = (487,714);
+},
+{
+name = top_left_can;
+pos = (195,714);
+},
+{
+name = top_right_can;
+pos = (487,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(325,-13,o),
+(393,59,o),
+(427,217,cs),
+(533,714,l),
+(439,714,l),
+(332,206,ls),
+(311,110,o),
+(275,69,o),
+(215,69,cs),
+(145,69,o),
+(114,119,o),
+(135,216,cs),
+(156,313,l),
+(63,313,l),
+(46,234,ls),
+(13,79,o),
+(79,-13,o),
+(205,-13,cs)
+);
+}
+);
+width = 493;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+unicode = 5261;
+},
+{
+glyphname = "coo-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (317,0);
+ref = dot_top;
+}
+);
+width = 492;
+}
+);
+note = uni148E;
+unicode = 5262;
+},
+{
+glyphname = "ycreecoo-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (164,0);
+ref = doubledot_top;
+}
+);
+width = 492;
+}
+);
+note = uni148F;
+unicode = 5263;
+},
+{
+glyphname = "ca-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (299,417);
+},
+{
+name = top_center_can;
+pos = (352,714);
+},
+{
+name = top_left_can;
+pos = (205,714);
+},
+{
+name = top_right_can;
+pos = (496,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(334,-13,o),
+(402,59,o),
+(436,217,cs),
+(456,313,l),
+(364,313,l),
+(341,206,ls),
+(320,110,o),
+(284,69,o),
+(225,69,cs),
+(155,69,o),
+(124,119,o),
+(145,216,cs),
+(251,714,l),
+(158,714,l),
+(56,234,ls),
+(23,79,o),
+(88,-13,o),
+(214,-13,cs)
+);
+}
+);
+width = 491;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+unicode = 5264;
+},
+{
+glyphname = "caa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (35,0);
+ref = dot_top;
+}
+);
+width = 492;
+}
+);
+note = uni1491;
+unicode = 5265;
+},
+{
+glyphname = "cwe-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ce-canadian";
+}
+);
+width = 683;
+}
+);
+note = uni1492;
+unicode = 5266;
+},
+{
+glyphname = "cweWestCree-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (492,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 683;
+}
+);
+note = uni1493;
+unicode = 5267;
+},
+{
+glyphname = "cwi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+pos = (191,0);
+ref = "ci-canadian";
+}
+);
+width = 683;
+}
+);
+note = uni1494;
+unicode = 5268;
+},
+{
+glyphname = "cwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "ci-canadian";
+},
+{
+anchor = middle_right_can;
+pos = (492,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 683;
+}
+);
+note = uni1495;
+unicode = 5269;
+},
+{
+glyphname = "cwii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+pos = (191,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (372,0);
+ref = dot_top;
+}
+);
+width = 683;
+}
+);
+note = uni1496;
+unicode = 5270;
+},
+{
+glyphname = "cwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (181,0);
+ref = dot_top;
+},
+{
+anchor = middle_right_can;
+pos = (492,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 683;
+}
+);
+note = uni1497;
+unicode = 5271;
+},
+{
+glyphname = "cwo-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "co-canadian";
+}
+);
+width = 683;
+}
+);
+note = uni1498;
+unicode = 5272;
+},
+{
+glyphname = "cwoWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (492,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 683;
+}
+);
+note = uni1499;
+unicode = 5273;
+},
+{
+glyphname = "cwoo-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (508,0);
+ref = dot_top;
+}
+);
+width = 683;
+}
+);
+note = uni149A;
+unicode = 5274;
+},
+{
+glyphname = "cwooWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (317,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (492,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 683;
+}
+);
+note = uni149B;
+unicode = 5275;
+},
+{
+glyphname = "cwa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ca-canadian";
+}
+);
+width = 683;
+}
+);
+note = uni149C;
+unicode = 5276;
+},
+{
+glyphname = "cwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (492,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 683;
+}
+);
+note = uni149D;
+unicode = 5277;
+},
+{
+glyphname = "cwaa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (227,0);
+ref = dot_top;
+}
+);
+width = 683;
+}
+);
+note = uni149E;
+unicode = 5278;
+},
+{
+glyphname = "cwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (35,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (492,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 683;
+}
+);
+note = uni149F;
+unicode = 5279;
+},
+{
+glyphname = "cwaaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (202,0);
+ref = "ca-canadian";
+}
+);
+width = 694;
+}
+);
+note = uni14A0;
+unicode = 5280;
+},
+{
+glyphname = "c-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(258.001,351,o),
+(300,394,o),
+(315,468,cs),
+(323,504,l),
+(264,504,l),
+(254,462,ls),
+(246,424,o),
+(227,403,o),
+(198,403,cs),
+(165,403,o),
+(154,431,o),
+(162,469,cs),
+(214,714,l),
+(150,714,l),
+(101,484,ls),
+(85,408,o),
+(117,351,o),
+(194,351,cs)
+);
+}
+);
+width = 299;
+}
+);
+note = uni14A1;
+unicode = 5281;
+},
+{
+glyphname = "thSayisi-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(240,351,o),
+(280,394,o),
+(297,470,cs),
+(349,714,l),
+(285,714,l),
+(232,466,ls),
+(223,421,o),
+(203,403,o),
+(174,403,cs),
+(141,403,o),
+(130,431,o),
+(138,469,cs),
+(145,504,l),
+(86,504,l),
+(81,479,ls),
+(66,406,o),
+(98,351,o),
+(175,351,cs)
+);
+}
+);
+width = 301;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "=|c-canadian";
+note = uni14A2;
+unicode = 5282;
+},
+{
+glyphname = "me-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (186,357);
+},
+{
+name = top_center_can;
+pos = (311,714);
+},
+{
+name = top_left_can;
+pos = (180,714);
+},
+{
+name = top_right_can;
+pos = (436,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(332,0,l),
+(484,714,l),
+(133,714,l),
+(115,628,l),
+(372,628,l),
+(238,0,l)
+);
+}
+);
+width = 447;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+unicode = 5283;
+},
+{
+glyphname = "maai-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (118,0);
+ref = ring_top.canadian;
+}
+);
+width = 446;
+}
+);
+note = uni14A4;
+unicode = 5284;
+},
+{
+glyphname = "mi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (308,357);
+},
+{
+name = top_center_can;
+pos = (336,714);
+},
+{
+name = top_left_can;
+pos = (208,714);
+},
+{
+name = top_right_can;
+pos = (464,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(102,0,l),
+(236,628,l),
+(493,628,l),
+(511,714,l),
+(160.996,714,l),
+(8.996,0,l)
+);
+}
+);
+width = 446;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+unicode = 5285;
+},
+{
+glyphname = "mii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (167,0);
+ref = dot_top;
+}
+);
+width = 446;
+}
+);
+note = uni14A6;
+unicode = 5286;
+},
+{
+glyphname = "mo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (186,357);
+},
+{
+name = top_center_can;
+pos = (311,714);
+},
+{
+name = top_double;
+pos = (437,714);
+},
+{
+name = top_left_can;
+pos = (180,714);
+},
+{
+name = top_right_can;
+pos = (437,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(332,0,l),
+(484,714,l),
+(390,714,l),
+(257,86,l),
+(0,86,l),
+(-18,0,l)
+);
+}
+);
+width = 447;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+unicode = 5287;
+},
+{
+glyphname = "moo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (267,0);
+ref = dot_top;
+}
+);
+width = 446;
+}
+);
+note = uni14A8;
+unicode = 5288;
+},
+{
+glyphname = "ycreemoo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (115,0);
+ref = doubledot_top;
+}
+);
+width = 446;
+}
+);
+note = uni14A9;
+unicode = 5289;
+},
+{
+glyphname = "ma-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (308,357);
+},
+{
+name = top_center_can;
+pos = (336,714);
+},
+{
+name = top_left_can;
+pos = (208,714);
+},
+{
+name = top_right_can;
+pos = (464,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(359,0,l),
+(377,86,l),
+(121,86,l),
+(254,714,l),
+(160.996,714,l),
+(8.996,0,l)
+);
+}
+);
+width = 446;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+unicode = 5290;
+},
+{
+glyphname = "maa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (39,0);
+ref = dot_top;
+}
+);
+width = 446;
+}
+);
+note = uni14AB;
+unicode = 5291;
+},
+{
+glyphname = "mwe-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "me-canadian";
+}
+);
+width = 638;
+}
+);
+note = uni14AC;
+unicode = 5292;
+},
+{
+glyphname = "mweWestCree-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "me-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (446,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 638;
+}
+);
+note = uni14AD;
+unicode = 5293;
+},
+{
+glyphname = "mwi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "mi-canadian";
+}
+);
+width = 638;
+}
+);
+note = uni14AE;
+unicode = 5294;
+},
+{
+glyphname = "mwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (446,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 638;
+}
+);
+note = uni14AF;
+unicode = 5295;
+},
+{
+glyphname = "mwii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (358,0);
+ref = dot_top;
+}
+);
+width = 638;
+}
+);
+note = uni14B0;
+unicode = 5296;
+},
+{
+glyphname = "mwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (167,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (446,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 638;
+}
+);
+note = uni14B1;
+unicode = 5297;
+},
+{
+glyphname = "mwo-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "mo-canadian";
+}
+);
+width = 638;
+}
+);
+note = uni14B2;
+unicode = 5298;
+},
+{
+glyphname = "mwoWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (446,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 638;
+}
+);
+note = uni14B3;
+unicode = 5299;
+},
+{
+glyphname = "mwoo-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (459,0);
+ref = dot_top;
+}
+);
+width = 638;
+}
+);
+note = uni14B4;
+unicode = 5300;
+},
+{
+glyphname = "mwooWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (267,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (446,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 638;
+}
+);
+note = uni14B5;
+unicode = 5301;
+},
+{
+glyphname = "mwa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ma-canadian";
+}
+);
+width = 638;
+}
+);
+note = uni14B6;
+unicode = 5302;
+},
+{
+glyphname = "mwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (446,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 638;
+}
+);
+note = uni14B7;
+unicode = 5303;
+},
+{
+glyphname = "mwaa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (230,0);
+ref = dot_top;
+}
+);
+width = 638;
+}
+);
+note = uni14B8;
+unicode = 5304;
+},
+{
+glyphname = "mwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (39,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (446,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 638;
+}
+);
+note = uni14B9;
+unicode = 5305;
+},
+{
+glyphname = "mwaaNaskapi-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (202,0);
+ref = "ma-canadian";
+}
+);
+width = 648;
+}
+);
+note = uni14BA;
+unicode = 5306;
+},
+{
+glyphname = "m-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(267,357,l),
+(280,418,l),
+(151,418,l),
+(214,714,l),
+(150,714,l),
+(74,357,l)
+);
+}
+);
+width = 275;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni14BB;
+unicode = 5307;
+},
+{
+glyphname = "mWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "t-canadian";
+}
+);
+width = 303;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "t-canadian";
+note = uni14BC;
+unicode = 5308;
+},
+{
+glyphname = "mh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(247,357,l),
+(323,714,l),
+(260,714,l),
+(197,418,l),
+(67,418,l),
+(54,357,l)
+);
+}
+);
+width = 275;
+}
+);
+metricLeft = "=|m-canadian";
+metricRight = "=|m-canadian";
+note = uni14BD;
+unicode = 5309;
+},
+{
+glyphname = "mAthapascan-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(278,357,l),
+(290,413,l),
+(152,413,l),
+(150,383,l),
+(260,502,ls),
+(297,542,o),
+(324,583,o),
+(324,632,cs),
+(324,686,o),
+(291,720,o),
+(235,720,cs),
+(175,720,o),
+(133,683,o),
+(117,595,c),
+(175,595,l),
+(184,651,o),
+(204,672,o),
+(231,672,cs),
+(254,672,o),
+(267,658,o),
+(267,632,cs),
+(267,595,o),
+(244,561,o),
+(210,524,cs),
+(86,390,l),
+(79,357,l)
+);
+}
+);
+width = 295;
+}
+);
+note = uni14BE;
+unicode = 5310;
+},
+{
+glyphname = "mSayisi-canadian";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = two.canadian;
+}
+);
+width = 486;
+}
+);
+note = uni14BF;
+unicode = 5311;
+},
+{
+glyphname = "ne-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (428,254);
+},
+{
+name = top_center_can;
+pos = (472,514);
+},
+{
+name = top_left_can;
+pos = (151,514);
+},
+{
+name = top_right_can;
+pos = (636,514);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(568,-13,o),
+(629,190,o),
+(629,306,cs),
+(629,424,o),
+(564,495,o),
+(448,495,cs),
+(100,495,l),
+(82,410,l),
+(346,410,l),
+(346,444,l),
+(250,400,o),
+(221,258,o),
+(221,175,cs),
+(221,57,o),
+(285,-13,o),
+(395,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(341,67,o),
+(311,105,o),
+(311,174,cs),
+(311,246,o),
+(342,415,o),
+(451,415,cs),
+(508,415,o),
+(538,377,o),
+(538,307,cs),
+(538,236,o),
+(508,67,o),
+(398,67,cs)
+);
+}
+);
+width = 676;
+}
+);
+metricRight = "=|ke-canadian";
+note = uni14C0;
+unicode = 5312;
+},
+{
+glyphname = "naai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (98,-200);
+ref = ring_top.canadian;
+}
+);
+width = 676;
+}
+);
+note = uni14C1;
+unicode = 5313;
+},
+{
+glyphname = "ni-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (250,254);
+},
+{
+name = top_center_can;
+pos = (318,514);
+},
+{
+name = top_left_can;
+pos = (153,514);
+},
+{
+name = top_right_can;
+pos = (638,514);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(392,-13,o),
+(453,190,o),
+(453,307,cs),
+(453,361,o),
+(436,401,o),
+(406,424,c),
+(398,410,l),
+(664,410,l),
+(682,495,l),
+(287,495,ls),
+(104,495,o),
+(45,293,o),
+(45,176,cs),
+(45,57,o),
+(109,-13,o),
+(219,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(165,67,o),
+(135,105,o),
+(135,174,cs),
+(135,246,o),
+(166,415,o),
+(275,415,cs),
+(333,415,o),
+(362,377,o),
+(362,307,cs),
+(362,236,o),
+(332,67,o),
+(223,67,cs)
+);
+}
+);
+width = 676;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+unicode = 5314;
+},
+{
+glyphname = "nii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (147,-200);
+ref = dot_top;
+}
+);
+width = 676;
+}
+);
+note = uni14C3;
+unicode = 5315;
+},
+{
+glyphname = "no-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (427,254);
+},
+{
+name = top_center_can;
+pos = (480,514);
+},
+{
+name = top_double;
+pos = (484,514);
+},
+{
+name = top_left_can;
+pos = (150,514);
+},
+{
+name = top_right_can;
+pos = (636,514);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(389,0,ls),
+(572,0,o),
+(631,203,o),
+(631,319,cs),
+(631,438,o),
+(566,509,o),
+(457,509,cs),
+(283,509,o),
+(223,306,o),
+(223,188,cs),
+(223,135,o),
+(239,94,o),
+(270,71,c),
+(278,85,l),
+(12,85,l),
+(-6,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(343,80,o),
+(313,119,o),
+(313,188,cs),
+(313,259,o),
+(344,428,o),
+(453,428,cs),
+(510,428,o),
+(540,390,o),
+(540,321,cs),
+(540,250,o),
+(509,80,o),
+(400,80,cs)
+);
+}
+);
+width = 676;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14C4;
+unicode = 5316;
+},
+{
+glyphname = "noo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (312,-200);
+ref = dot_top;
+}
+);
+width = 676;
+}
+);
+note = uni14C5;
+unicode = 5317;
+},
+{
+glyphname = "ycreenoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (162,-200);
+ref = doubledot_top;
+}
+);
+width = 676;
+}
+);
+note = uni14C6;
+unicode = 5318;
+},
+{
+glyphname = "na-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (252,254);
+},
+{
+name = top_center_can;
+pos = (308,514);
+},
+{
+name = top_double;
+pos = (440,514);
+},
+{
+name = top_left_can;
+pos = (153,514);
+},
+{
+name = top_right_can;
+pos = (639,514);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(576,0,l),
+(594,85,l),
+(330,85,l),
+(330,52,l),
+(427,95,o),
+(456,237,o),
+(456,320,cs),
+(456,438,o),
+(391,509,o),
+(282,509,cs),
+(108,509,o),
+(48,306,o),
+(48,189,cs),
+(48,72,o),
+(112,0,o),
+(228,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(168,80,o),
+(138,119,o),
+(138,188,cs),
+(138,259,o),
+(169,428,o),
+(278,428,cs),
+(336,428,o),
+(365,390,o),
+(365,321,cs),
+(365,250,o),
+(335,80,o),
+(226,80,cs)
+);
+}
+);
+width = 676;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+unicode = 5319;
+},
+{
+glyphname = "naa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (137,-200);
+ref = dot_top;
+}
+);
+width = 676;
+}
+);
+note = uni14C8;
+unicode = 5320;
+},
+{
+glyphname = "nwe-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ne-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni14C9;
+unicode = 5321;
+},
+{
+glyphname = "nweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (676,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni14CA;
+unicode = 5322;
+},
+{
+glyphname = "nwa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "na-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni14CB;
+unicode = 5323;
+},
+{
+glyphname = "nwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (676,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni14CC;
+unicode = 5324;
+},
+{
+glyphname = "nwaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (329,-200);
+ref = dot_top;
+}
+);
+width = 867;
+}
+);
+note = uni14CD;
+unicode = 5325;
+},
+{
+glyphname = "nwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (137,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (676,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni14CE;
+unicode = 5326;
+},
+{
+glyphname = "nwaaNaskapi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (117,-200);
+ref = doubledot_top;
+}
+);
+width = 676;
+}
+);
+note = uni14CF;
+unicode = 5327;
+},
+{
+glyphname = "n-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(399,449,l),
+(412,510,l),
+(266,510,l),
+(263,475,l),
+(310,497,o),
+(331,572,o),
+(331,616,cs),
+(331,680,o),
+(296,720,o),
+(238,720,cs),
+(149,720,o),
+(111,622,o),
+(111,552,cs),
+(111,488,o),
+(147,449,o),
+(207,449,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(181,498,o),
+(167,517,o),
+(167,551,cs),
+(167,589,o),
+(184,671,o),
+(234,671,cs),
+(261,671,o),
+(274,652,o),
+(274,618,cs),
+(274,580,o),
+(258,498,o),
+(206,498,cs)
+);
+}
+);
+width = 387;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni14D0;
+unicode = 5328;
+},
+{
+color = 6;
+glyphname = "ngCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-167);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 353;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "=|";
+note = uni14D1;
+unicode = 5329;
+},
+{
+glyphname = "nh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(290,449,ls),
+(383,449,o),
+(421,546,o),
+(421,618,cs),
+(421,682,o),
+(384,720,o),
+(327,720,cs),
+(239,720,o),
+(200,622,o),
+(200,552,cs),
+(200,529,o),
+(207,502,o),
+(226,486,c),
+(233,510,l),
+(87,510,l),
+(74,449,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(271,498,o),
+(257,517,o),
+(257,551,cs),
+(257,589,o),
+(274,671,o),
+(324,671,cs),
+(350,671,o),
+(364,652,o),
+(364,618,cs),
+(364,580,o),
+(348,498,o),
+(297,498,cs)
+);
+}
+);
+width = 389;
+}
+);
+metricLeft = "=|n-canadian";
+metricRight = "=|n-canadian";
+note = uni14D2;
+unicode = 5330;
+},
+{
+glyphname = "le-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (427,254);
+},
+{
+name = top_center_can;
+pos = (473,514);
+},
+{
+name = top_left_can;
+pos = (151,514);
+},
+{
+name = top_right_can;
+pos = (636,514);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(338,0,ls),
+(539,0,o),
+(627,145,o),
+(627,295,cs),
+(627,418,o),
+(551,495,o),
+(422,495,cs),
+(100,495,l),
+(82,410,l),
+(404,410,ls),
+(489,410,o),
+(535,367,o),
+(535,289,cs),
+(535,203,o),
+(494,83,o),
+(350,83,cs),
+(334,83,l),
+(316,0,l)
+);
+}
+);
+width = 676;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D3;
+unicode = 5331;
+},
+{
+glyphname = "laai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (100,-200);
+ref = ring_top.canadian;
+}
+);
+width = 676;
+}
+);
+note = uni14D4;
+unicode = 5332;
+},
+{
+glyphname = "li-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (254,254);
+},
+{
+name = top_center_can;
+pos = (321,514);
+},
+{
+name = top_left_can;
+pos = (156,514);
+},
+{
+name = top_right_can;
+pos = (640,514);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(257,0,l),
+(274,83,l),
+(259,83,ls),
+(186,83,o),
+(143,130,o),
+(143,206,cs),
+(143,293,o),
+(190,410,o),
+(331,410,cs),
+(665,410,l),
+(683,495,l),
+(338,495,ls),
+(144,495,o),
+(50,355,o),
+(50,204,cs),
+(50,84,o),
+(124,0,o),
+(239,0,cs)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14D5;
+unicode = 5333;
+},
+{
+glyphname = "lii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (149,-200);
+ref = dot_top;
+}
+);
+width = 676;
+}
+);
+note = uni14D6;
+unicode = 5334;
+},
+{
+glyphname = "lo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (426,254);
+},
+{
+name = top_center_can;
+pos = (479,514);
+},
+{
+name = top_double;
+pos = (448,514);
+},
+{
+name = top_left_can;
+pos = (150,514);
+},
+{
+name = top_right_can;
+pos = (635,514);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(338,0,ls),
+(533,0,o),
+(626,140,o),
+(626,291,cs),
+(626,412,o),
+(553,495,o),
+(438,495,cs),
+(420,495,l),
+(402,412,l),
+(418,412,ls),
+(491,412,o),
+(534,366,o),
+(534,289,cs),
+(534,202,o),
+(486,85,o),
+(346,85,cs),
+(12,85,l),
+(-6,0,l)
+);
+}
+);
+width = 676;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D7;
+unicode = 5335;
+},
+{
+glyphname = "loo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (311,-200);
+ref = dot_top;
+}
+);
+width = 676;
+}
+);
+note = uni14D8;
+unicode = 5336;
+},
+{
+glyphname = "ycreeloo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (126,-200);
+ref = doubledot_top;
+}
+);
+width = 676;
+}
+);
+note = uni14D9;
+unicode = 5337;
+},
+{
+glyphname = "la-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (253,254);
+},
+{
+name = top_center_can;
+pos = (309,514);
+},
+{
+name = top_left_can;
+pos = (155,514);
+},
+{
+name = top_right_can;
+pos = (639,514);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(576,0,l),
+(594,85,l),
+(273,85,ls),
+(188,85,o),
+(142,129,o),
+(142,207,cs),
+(142,292,o),
+(183,412,o),
+(327,412,cs),
+(343,412,l),
+(361,495,l),
+(338,495,ls),
+(137,495,o),
+(49,350,o),
+(49,200,cs),
+(49,77,o),
+(126,0,o),
+(255,0,cs)
+);
+}
+);
+width = 676;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14DA;
+unicode = 5338;
+},
+{
+glyphname = "laa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (138,-200);
+ref = dot_top;
+}
+);
+width = 676;
+}
+);
+note = uni14DB;
+unicode = 5339;
+},
+{
+glyphname = "lwe-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "le-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni14DC;
+unicode = 5340;
+},
+{
+glyphname = "lweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "le-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (676,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni14DD;
+unicode = 5341;
+},
+{
+glyphname = "lwi-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "li-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni14DE;
+unicode = 5342;
+},
+{
+glyphname = "lwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (676,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni14DF;
+unicode = 5343;
+},
+{
+glyphname = "lwii-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (341,-200);
+ref = dot_top;
+}
+);
+width = 867;
+}
+);
+note = uni14E0;
+unicode = 5344;
+},
+{
+glyphname = "lwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (149,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (676,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni14E1;
+unicode = 5345;
+},
+{
+glyphname = "lwo-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "lo-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni14E2;
+unicode = 5346;
+},
+{
+glyphname = "lwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (676,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni14E3;
+unicode = 5347;
+},
+{
+glyphname = "lwoo-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (502,-200);
+ref = dot_top;
+}
+);
+width = 867;
+}
+);
+note = uni14E4;
+unicode = 5348;
+},
+{
+glyphname = "lwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (311,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (676,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni14E5;
+unicode = 5349;
+},
+{
+glyphname = "lwa-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "la-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni14E6;
+unicode = 5350;
+},
+{
+glyphname = "lwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (676,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni14E7;
+unicode = 5351;
+},
+{
+glyphname = "lwaa-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (330,-200);
+ref = dot_top;
+}
+);
+width = 867;
+}
+);
+note = uni14E8;
+unicode = 5352;
+},
+{
+glyphname = "lwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (138,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (676,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni14E9;
+unicode = 5353;
+},
+{
+glyphname = "l-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(373,357,l),
+(387,418,l),
+(251,418,ls),
+(198,418,o),
+(171,446,o),
+(171,499,cs),
+(171,564,o),
+(199,653,o),
+(298,653,cs),
+(305,653,l),
+(318,714,l),
+(309,714,ls),
+(161,714,o),
+(106,598,o),
+(106,493,cs),
+(106,405,o),
+(157,357,o),
+(248,357,cs)
+);
+}
+);
+width = 382;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "m-canadian";
+note = uni14EA;
+unicode = 5354;
+},
+{
+glyphname = "lWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(273,357,l),
+(281,397,l),
+(145,473,l),
+(138,439,l),
+(307,517,l),
+(313,548,l),
+(175,619,l),
+(169,589,l),
+(338,665,l),
+(349,714,l),
+(337,714,l),
+(131,622,l),
+(126,597,l),
+(265,523,l),
+(270,548,l),
+(99,474,l),
+(94,449,l),
+(261,357,l)
+);
+}
+);
+width = 301;
+}
+);
+metricRight = "=|";
+note = uni14EB;
+unicode = 5355;
+},
+{
+glyphname = "mediall-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(415,-13,l),
+(429,50,l),
+(132,212,l),
+(123,168,l),
+(488,330,l),
+(497,373,l),
+(199,525,l),
+(189,487,l),
+(556,650,l),
+(572,727,l),
+(548,727,l),
+(119,536,l),
+(111,497,l),
+(409,340,l),
+(416,374,l),
+(51,217,l),
+(43,178,l),
+(391,-13,l)
+);
+}
+);
+width = 528;
+}
+);
+metricRight = "=|";
+note = uni14EC;
+unicode = 5356;
+},
+{
+glyphname = "se-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (206,714);
+},
+{
+name = top_right_can;
+pos = (445,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(339,0,l),
+(412,343,l),
+(385,343,ls),
+(246,343,o),
+(187,405,o),
+(222,570,cs),
+(253,714,l),
+(160,714,l),
+(129,572,ls),
+(85,365,o),
+(176,258,o),
+(364,258,cs),
+(378,258,l),
+(308,289,l),
+(246,0,l)
+);
+}
+);
+width = 454;
+}
+);
+note = uni14ED;
+unicode = 5357;
+},
+{
+glyphname = "saai-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (228,0);
+ref = ring_top.canadian;
+}
+);
+width = 454;
+}
+);
+note = uni14EE;
+unicode = 5358;
+},
+{
+glyphname = "si-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (208,714);
+},
+{
+name = top_right_can;
+pos = (446,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(102,0,l),
+(164,290,l),
+(87,258,l),
+(123,258,ls),
+(308,258,o),
+(414,347,o),
+(459,558,cs),
+(492,714,l),
+(399,714,l),
+(367,564,ls),
+(334,415,o),
+(258,343,o),
+(129,343,cs),
+(82,343,l),
+(9,0,l)
+);
+}
+);
+width = 453;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+unicode = 5359;
+},
+{
+glyphname = "sii-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (277,0);
+ref = dot_top;
+}
+);
+width = 454;
+}
+);
+note = uni14F0;
+unicode = 5360;
+},
+{
+glyphname = "so-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (445,714);
+},
+{
+name = top_left_can;
+pos = (207,714);
+},
+{
+name = top_right_can;
+pos = (445,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(101,0,l),
+(134,150,ls),
+(166,299,o),
+(242,371,o),
+(372,371,cs),
+(419,371,l),
+(491,714,l),
+(398,714,l),
+(336,424,l),
+(413,456,l),
+(377,456,ls),
+(192,456,o),
+(86,367,o),
+(41,156,cs),
+(8,0,l)
+);
+}
+);
+width = 455;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+unicode = 5361;
+},
+{
+glyphname = "soo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (275,0);
+ref = dot_top;
+}
+);
+width = 454;
+}
+);
+note = uni14F2;
+unicode = 5362;
+},
+{
+glyphname = "ycreesoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (123,0);
+ref = doubledot_top;
+}
+);
+width = 454;
+}
+);
+note = uni14F3;
+unicode = 5363;
+},
+{
+glyphname = "sa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (209,714);
+},
+{
+name = top_right_can;
+pos = (447,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(341,0,l),
+(372,142,ls),
+(416,349,o),
+(325,456,o),
+(137,456,cs),
+(123,456,l),
+(193,425,l),
+(255,714,l),
+(161,714,l),
+(89,371,l),
+(116,371,ls),
+(255,371,o),
+(314,309,o),
+(278,144,cs),
+(248,0,l)
+);
+}
+);
+width = 454;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+unicode = 5364;
+},
+{
+glyphname = "saa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (39,0);
+ref = dot_top;
+}
+);
+width = 454;
+}
+);
+note = uni14F5;
+unicode = 5365;
+},
+{
+glyphname = "swe-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "se-canadian";
+}
+);
+width = 646;
+}
+);
+note = uni14F6;
+unicode = 5366;
+},
+{
+glyphname = "sweWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "se-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (454,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 646;
+}
+);
+note = uni14F7;
+unicode = 5367;
+},
+{
+glyphname = "swi-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "si-canadian";
+}
+);
+width = 646;
+}
+);
+note = uni14F8;
+unicode = 5368;
+},
+{
+glyphname = "swiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (454,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 646;
+}
+);
+note = uni14F9;
+unicode = 5369;
+},
+{
+glyphname = "swii-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (469,0);
+ref = dot_top;
+}
+);
+width = 646;
+}
+);
+note = uni14FA;
+unicode = 5370;
+},
+{
+glyphname = "swiiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (277,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (454,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 646;
+}
+);
+note = uni14FB;
+unicode = 5371;
+},
+{
+glyphname = "swo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "so-canadian";
+}
+);
+width = 646;
+}
+);
+note = uni14FC;
+unicode = 5372;
+},
+{
+glyphname = "swoWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (454,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 646;
+}
+);
+note = uni14FD;
+unicode = 5373;
+},
+{
+glyphname = "swoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (467,0);
+ref = dot_top;
+}
+);
+width = 646;
+}
+);
+note = uni14FE;
+unicode = 5374;
+},
+{
+glyphname = "swooWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (275,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (454,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 646;
+}
+);
+note = uni14FF;
+unicode = 5375;
+},
+{
+glyphname = "swa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "sa-canadian";
+}
+);
+width = 646;
+}
+);
+note = uni1500;
+unicode = 5376;
+},
+{
+glyphname = "swaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (454,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 646;
+}
+);
+note = uni1501;
+unicode = 5377;
+},
+{
+glyphname = "swaa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (230,0);
+ref = dot_top;
+}
+);
+width = 646;
+}
+);
+note = uni1502;
+unicode = 5378;
+},
+{
+glyphname = "swaaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (39,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (454,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 646;
+}
+);
+note = uni1503;
+unicode = 5379;
+},
+{
+glyphname = "swaaNaskapi-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (202,0);
+ref = "sa-canadian";
+}
+);
+width = 656;
+}
+);
+note = uni1504;
+unicode = 5380;
+},
+{
+glyphname = "s-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(268,357,l),
+(284,436,ls),
+(304,533,o),
+(262,595,o),
+(167,595,cs),
+(149,595,l),
+(183,566,l),
+(214,714,l),
+(150,714,l),
+(114,543,l),
+(146,543,ls),
+(213,543,o),
+(235,507,o),
+(220,435,cs),
+(204,357,l)
+);
+}
+);
+width = 296;
+}
+);
+metricRight = "=|";
+note = uni1505;
+unicode = 5381;
+},
+{
+color = 6;
+glyphname = "sAthapascan-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(237,183,o),
+(281,229,o),
+(281,293,cs),
+(281,335,o),
+(261,364,o),
+(220,382,cs),
+(190,395,ls),
+(167,406,o),
+(155,423,o),
+(155,444,cs),
+(155,479,o),
+(176,503,o),
+(213,503,cs),
+(247,503,o),
+(263,485,o),
+(254,440,c),
+(313,440,l),
+(326,509,o),
+(285,552,o),
+(217,552,cs),
+(138,552,o),
+(96,505,o),
+(96,439,cs),
+(96,401,o),
+(117,369,o),
+(155,352,cs),
+(185,339,ls),
+(212,326,o),
+(222,311,o),
+(222,289,cs),
+(222,254,o),
+(201,232,o),
+(165,232,cs),
+(128,232,o),
+(109,249,o),
+(120,297,c),
+(61,297,l),
+(47,225,o),
+(89,183,o),
+(163,183,cs)
+);
+}
+);
+width = 324;
+}
+);
+metricRight = "=|";
+note = uni1506;
+unicode = 5382;
+},
+{
+glyphname = "sw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(138,357,l),
+(155,434,ls),
+(171,511,o),
+(207,543,o),
+(275,543,cs),
+(307,543,l),
+(343,714,l),
+(279,714,l),
+(249,570,l),
+(295,595,l),
+(264,595,ls),
+(169,595,o),
+(114,545,o),
+(92,440,cs),
+(75,357,l)
+);
+}
+);
+width = 295;
+}
+);
+metricLeft = "=|s-canadian";
+metricRight = "=|s-canadian";
+note = uni1507;
+unicode = 5383;
+},
+{
+glyphname = "sBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(274,357,l),
+(287,418,l),
+(220,418,ls),
+(174,418,o),
+(156,442,o),
+(167,493,cs),
+(214,714,l),
+(150,714,l),
+(105,499,ls),
+(85,410,o),
+(126,357,o),
+(213,357,cs)
+);
+}
+);
+width = 282;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "m-canadian";
+note = uni1508;
+unicode = 5384;
+},
+{
+glyphname = "moosecreesk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(272,225,o),
+(302,363,o),
+(302,452,cs),
+(302,546,o),
+(258,596,o),
+(170,596,cs),
+(158,596,l),
+(183,568,l),
+(214,714,l),
+(150,714,l),
+(114,544,l),
+(147,544,ls),
+(233,544,o),
+(246,507,o),
+(243,433,c),
+(253,425,l),
+(254,455,o),
+(241,494,o),
+(190,494,cs),
+(104,494,o),
+(73,385,o),
+(73,328,cs),
+(73,265,o),
+(107,225,o),
+(167,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(144,273,o),
+(130,292,o),
+(130,325,cs),
+(130,362,o),
+(149,448,o),
+(199,448,cs),
+(225,448,o),
+(238,430,o),
+(238,398,cs),
+(238,360,o),
+(219,273,o),
+(170,273,cs)
+);
+}
+);
+width = 319;
+}
+);
+metricRight = "=|";
+note = uni1509;
+unicode = 5385;
+},
+{
+glyphname = "skwNaskapi-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(258,225,o),
+(295,331,o),
+(295,398,cs),
+(295,457,o),
+(267,494,o),
+(219,494,cs),
+(181,494,o),
+(150,469,o),
+(139,429,c),
+(155,432,l),
+(183,509,o),
+(219,544,o),
+(299,544,cs),
+(331,544,l),
+(367,714,l),
+(303,714,l),
+(272,567,l),
+(312,596,l),
+(294,596,ls),
+(130,596,o),
+(76,428,o),
+(76,331,cs),
+(76,268,o),
+(107,225,o),
+(168,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(144,273,o),
+(132,292,o),
+(132,325,cs),
+(132,362,o),
+(150,448,o),
+(199,448,cs),
+(225,448,o),
+(238,430,o),
+(238,398,cs),
+(238,360,o),
+(219,273,o),
+(171,273,cs)
+);
+}
+);
+width = 319;
+}
+);
+metricLeft = "=|moosecreesk-canadian";
+metricRight = "=|moosecreesk-canadian";
+note = uni150A;
+unicode = 5386;
+},
+{
+glyphname = "swNaskapi-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(250,188,l),
+(263,253,ls),
+(285,356,o),
+(239,416,o),
+(148,416,cs),
+(129,416,l),
+(157,388,l),
+(187,527,l),
+(123,527,l),
+(89,365,l),
+(124,365,ls),
+(189,365,o),
+(216,333,o),
+(200,254,cs),
+(186,188,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(228,47,o),
+(251,70,o),
+(251,99,cs),
+(251,129,o),
+(228,152,o),
+(199,152,cs),
+(171,152,o),
+(147,129,o),
+(147,99,cs),
+(147,70,o),
+(171,47,o),
+(199,47,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(203,562,o),
+(226,586,o),
+(226,615,cs),
+(226,644,o),
+(203,668,o),
+(174,668,cs),
+(146,668,o),
+(123,644,o),
+(123,615,cs),
+(123,586,o),
+(146,562,o),
+(174,562,cs)
+);
+}
+);
+width = 328;
+}
+);
+metricRight = "=|";
+note = uni150B;
+unicode = 5387;
+},
+{
+glyphname = "spwaNaskapi-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(450,0,l),
+(467,78,l),
+(147,369,l),
+(139,326,l),
+(581,617,l),
+(602,714,l),
+(577,714,l),
+(58,374,l),
+(50,340,l),
+(425,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(210,515,o),
+(233,539,o),
+(233,567,cs),
+(233,597,o),
+(210,620,o),
+(181,620,cs),
+(153,620,o),
+(129,597,o),
+(129,567,cs),
+(129,539,o),
+(153,515,o),
+(181,515,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(377,625,l),
+(390,683,ls),
+(405,754,o),
+(375,797,o),
+(308,797,cs),
+(283,797,l),
+(323,773,l),
+(345,876,l),
+(284,876,l),
+(257,748,l),
+(280,748,ls),
+(324,748,o),
+(338,727,o),
+(327,677,cs),
+(317,625,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(543,729,o),
+(567,753,o),
+(567,782,cs),
+(567,811,o),
+(543,834,o),
+(515,834,cs),
+(487,834,o),
+(463,811,o),
+(463,782,cs),
+(463,753,o),
+(487,729,o),
+(515,729,cs)
+);
+}
+);
+width = 544;
+}
+);
+metricRight = "pa-canadian";
+metricWidth = "pa-canadian";
+note = uni150C;
+unicode = 5388;
+},
+{
+glyphname = "stwaNaskapi-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (327,0);
+ref = "ta-canadian";
+}
+);
+width = 831;
+}
+);
+note = uni150D;
+unicode = 5389;
+},
+{
+glyphname = "skwaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (327,0);
+ref = "ka-canadian";
+}
+);
+width = 825;
+}
+);
+note = uni150E;
+unicode = 5390;
+},
+{
+glyphname = "scwaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (327,0);
+ref = "ca-canadian";
+}
+);
+width = 819;
+}
+);
+note = uni150F;
+unicode = 5391;
+},
+{
+glyphname = "she-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (340,714);
+},
+{
+name = top_right_can;
+pos = (680,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(600,-13,o),
+(667,63,o),
+(699,218,cs),
+(719,313,l),
+(627,313,l),
+(604,208,ls),
+(584,110,o),
+(551,69,o),
+(493,69,cs),
+(429,69,o),
+(407,120,o),
+(424,218,cs),
+(469,474,ls),
+(497,638,o),
+(439,727,o),
+(317,727,cs),
+(203,727,o),
+(137,651,o),
+(104,496,cs),
+(84,401,l),
+(177,401,l),
+(199,506,ls),
+(220,604,o),
+(253,645,o),
+(310,645,cs),
+(375,645,o),
+(397,594,o),
+(380,496,cs),
+(335,240,ls),
+(307,76,o),
+(364,-13,o),
+(486,-13,cs)
+);
+}
+);
+width = 756;
+}
+);
+metricRight = "=|";
+note = uni1510;
+unicode = 5392;
+},
+{
+glyphname = "shi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (278,714);
+},
+{
+name = top_right_can;
+pos = (617,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(309,-13,o),
+(371,51,o),
+(415,225,cs),
+(482,495,ls),
+(512,609,o),
+(541,645,o),
+(600,645,cs),
+(663,645,o),
+(687,593,o),
+(664,490,cs),
+(645,401,l),
+(738,401,l),
+(752,467,ls),
+(787,625,o),
+(731,727,o),
+(605,727,cs),
+(495,727,o),
+(434,663,o),
+(390,489,cs),
+(321,218,ls),
+(292,105,o),
+(263,69,o),
+(203,69,cs),
+(141,69,o),
+(117,120,o),
+(139,223,cs),
+(158,313,l),
+(66,313,l),
+(51,247,ls),
+(17,88,o),
+(73,-13,o),
+(198,-13,cs)
+);
+}
+);
+width = 756;
+}
+);
+metricLeft = "she-canadian";
+metricRight = "she-canadian";
+note = uni1511;
+unicode = 5393;
+},
+{
+glyphname = "shii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (447,0);
+ref = dot_top;
+}
+);
+width = 758;
+}
+);
+note = uni1512;
+unicode = 5394;
+},
+{
+glyphname = "sho-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (444,514);
+},
+{
+name = top_left_can;
+pos = (296,514);
+},
+{
+name = top_right_can;
+pos = (591,514);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(264,69,l),
+(181,70,o),
+(129,107,o),
+(129,168,cs),
+(129,230,o),
+(165,285,o),
+(235,285,cs),
+(345,285,o),
+(397,126,o),
+(548,126,cs),
+(669,126,o),
+(738,220,o),
+(738,329,cs),
+(738,436,o),
+(655,506,o),
+(529,509,c),
+(511,427,l),
+(595,425,o),
+(648,388,o),
+(648,327,cs),
+(648,266,o),
+(611,210,o),
+(542,210,cs),
+(432,210,o),
+(379,370,o),
+(229,370,cs),
+(104,370,o),
+(39,271,o),
+(39,167,cs),
+(39,59,o),
+(122,-11,o),
+(246,-13,c)
+);
+}
+);
+width = 777;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1513;
+unicode = 5395;
+},
+{
+glyphname = "shoo-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (273,-200);
+ref = dot_top;
+}
+);
+width = 775;
+}
+);
+note = uni1514;
+unicode = 5396;
+},
+{
+glyphname = "sha-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (446,514);
+},
+{
+name = top_left_can;
+pos = (298,514);
+},
+{
+name = top_right_can;
+pos = (593,514);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(596,-16,o),
+(714,68,o),
+(714,217,cs),
+(714,307,o),
+(656,370,o),
+(564,370,cs),
+(428,370,o),
+(324,210,o),
+(229,210,cs),
+(184,210,o),
+(156,239,o),
+(156,286,cs),
+(156,381,o),
+(232,427,o),
+(329,427,c),
+(346,509,l),
+(181,511,o),
+(63,427,o),
+(63,278,cs),
+(63,188,o),
+(121,126,o),
+(213,126,cs),
+(348,126,o),
+(453,285,o),
+(547,285,cs),
+(593,285,o),
+(621,256,o),
+(621,209,cs),
+(621,114,o),
+(546,68,o),
+(448,69,c),
+(431,-13,l)
+);
+}
+);
+width = 777;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1515;
+unicode = 5397;
+},
+{
+glyphname = "shaa-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (275,-200);
+ref = dot_top;
+}
+);
+width = 775;
+}
+);
+note = uni1516;
+unicode = 5398;
+},
+{
+glyphname = "shwe-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "she-canadian";
+}
+);
+width = 949;
+}
+);
+note = uni1517;
+unicode = 5399;
+},
+{
+glyphname = "shweWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "she-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (758,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 949;
+}
+);
+note = uni1518;
+unicode = 5400;
+},
+{
+glyphname = "shwi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "shi-canadian";
+}
+);
+width = 949;
+}
+);
+note = uni1519;
+unicode = 5401;
+},
+{
+glyphname = "shwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (758,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 949;
+}
+);
+note = uni151A;
+unicode = 5402;
+},
+{
+glyphname = "shwii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (639,0);
+ref = dot_top;
+}
+);
+width = 949;
+}
+);
+note = uni151B;
+unicode = 5403;
+},
+{
+glyphname = "shwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (447,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (758,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 949;
+}
+);
+note = uni151C;
+unicode = 5404;
+},
+{
+glyphname = "shwo-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "sho-canadian";
+}
+);
+width = 966;
+}
+);
+note = uni151D;
+unicode = 5405;
+},
+{
+glyphname = "shwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (775,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 966;
+}
+);
+note = uni151E;
+unicode = 5406;
+},
+{
+glyphname = "shwoo-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (465,-200);
+ref = dot_top;
+}
+);
+width = 966;
+}
+);
+note = uni151F;
+unicode = 5407;
+},
+{
+glyphname = "shwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (273,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (775,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 966;
+}
+);
+note = uni1520;
+unicode = 5408;
+},
+{
+glyphname = "shwa-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "sha-canadian";
+}
+);
+width = 966;
+}
+);
+note = uni1521;
+unicode = 5409;
+},
+{
+glyphname = "shwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (775,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 966;
+}
+);
+note = uni1522;
+unicode = 5410;
+},
+{
+glyphname = "shwaa-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (467,-200);
+ref = dot_top;
+}
+);
+width = 966;
+}
+);
+note = uni1523;
+unicode = 5411;
+},
+{
+glyphname = "shwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (275,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (775,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 966;
+}
+);
+note = uni1524;
+unicode = 5412;
+},
+{
+glyphname = "sh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(496,296,o),
+(588,360,o),
+(588,475,cs),
+(588,543,o),
+(543,592,o),
+(468,592,cs),
+(375,592,o),
+(311,493,o),
+(241,493,cs),
+(202,493,o),
+(180,515,o),
+(180,551,cs),
+(180,621,o),
+(239,665,o),
+(327,662,c),
+(339,722,l),
+(209,725,o),
+(115,662,o),
+(115,546,cs),
+(115,477,o),
+(161,429,o),
+(236,429,cs),
+(329,429,o),
+(393,528,o),
+(463,528,cs),
+(502,528,o),
+(523,506,o),
+(523,470,cs),
+(523,403,o),
+(467,356,o),
+(379,359,c),
+(367,299,l)
+);
+}
+);
+width = 591;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni1525;
+unicode = 5413;
+},
+{
+glyphname = "ye-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (544,357);
+},
+{
+name = top_left_can;
+pos = (184,714);
+},
+{
+name = top_right_can;
+pos = (472,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(367,0,l),
+(438,334,l),
+(171,334,l),
+(176,304,l),
+(519,670,l),
+(455,726,l),
+(44,282,l),
+(38,251,l),
+(327,251,l),
+(273,0,l)
+);
+}
+);
+width = 479;
+}
+);
+note = uni1526;
+unicode = 5414;
+},
+{
+glyphname = "yaai-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-12,0);
+ref = ring_top.canadian;
+}
+);
+width = 479;
+}
+);
+note = uni1527;
+unicode = 5415;
+},
+{
+glyphname = "yi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (207,714);
+},
+{
+name = top_right_can;
+pos = (496,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,0,l),
+(153,251,l),
+(442,251,l),
+(449,282,l),
+(209.995,726,l),
+(135,684,l),
+(341,307,l),
+(345,334,l),
+(77,334,l),
+(6,0,l)
+);
+}
+);
+width = 479;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni1528;
+unicode = 5416;
+},
+{
+glyphname = "yii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (37,0);
+ref = dot_top;
+}
+);
+width = 479;
+}
+);
+note = uni1529;
+unicode = 5417;
+},
+{
+glyphname = "yo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (544,357);
+},
+{
+name = top_double;
+pos = (472,714);
+},
+{
+name = top_left_can;
+pos = (183,714);
+},
+{
+name = top_right_can;
+pos = (472,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(390,30,l),
+(184,407,l),
+(180,380,l),
+(447,380,l),
+(519,714,l),
+(425,714,l),
+(372,463,l),
+(83,463,l),
+(76,432,l),
+(315,-12,l)
+);
+}
+);
+width = 479;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152A;
+unicode = 5418;
+},
+{
+glyphname = "yoo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (303,0);
+ref = dot_top;
+}
+);
+width = 479;
+}
+);
+note = uni152B;
+unicode = 5419;
+},
+{
+glyphname = "ycreeyoo-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (150,0);
+ref = doubledot_top;
+}
+);
+width = 479;
+}
+);
+note = uni152C;
+unicode = 5420;
+},
+{
+glyphname = "ya-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (205,714);
+},
+{
+name = top_right_can;
+pos = (494,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(481,432,l),
+(487,463,l),
+(198,463,l),
+(252,714,l),
+(158,714,l),
+(87,380,l),
+(355,380,l),
+(349,410,l),
+(6,44,l),
+(70,-12,l)
+);
+}
+);
+width = 479;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152D;
+unicode = 5421;
+},
+{
+glyphname = "yaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+}
+);
+width = 479;
+}
+);
+note = uni152E;
+unicode = 5422;
+},
+{
+glyphname = "ywe-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ye-canadian";
+}
+);
+width = 670;
+}
+);
+note = uni152F;
+unicode = 5423;
+},
+{
+glyphname = "yweWestCree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ye-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (479,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 670;
+}
+);
+note = uni1530;
+unicode = 5424;
+},
+{
+glyphname = "ywi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "yi-canadian";
+}
+);
+width = 670;
+}
+);
+note = uni1531;
+unicode = 5425;
+},
+{
+glyphname = "ywiWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (479,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 670;
+}
+);
+note = uni1532;
+unicode = 5426;
+},
+{
+glyphname = "ywii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (229,0);
+ref = dot_top;
+}
+);
+width = 670;
+}
+);
+note = uni1533;
+unicode = 5427;
+},
+{
+glyphname = "ywiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (37,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (479,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 670;
+}
+);
+note = uni1534;
+unicode = 5428;
+},
+{
+glyphname = "ywo-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "yo-canadian";
+}
+);
+width = 670;
+}
+);
+note = uni1535;
+unicode = 5429;
+},
+{
+glyphname = "ywoWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (479,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 670;
+}
+);
+note = uni1536;
+unicode = 5430;
+},
+{
+glyphname = "ywoo-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (494,0);
+ref = dot_top;
+}
+);
+width = 670;
+}
+);
+note = uni1537;
+unicode = 5431;
+},
+{
+glyphname = "ywooWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (303,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (479,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 670;
+}
+);
+note = uni1538;
+unicode = 5432;
+},
+{
+glyphname = "ywa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ya-canadian";
+}
+);
+width = 670;
+}
+);
+note = uni1539;
+unicode = 5433;
+},
+{
+glyphname = "ywaWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (479,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 670;
+}
+);
+note = uni153A;
+unicode = 5434;
+},
+{
+glyphname = "ywaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (227,0);
+ref = dot_top;
+}
+);
+width = 670;
+}
+);
+note = uni153B;
+unicode = 5435;
+},
+{
+glyphname = "ywaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (479,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 670;
+}
+);
+note = uni153C;
+unicode = 5436;
+},
+{
+glyphname = "ywaaNaskapi-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (202,0);
+ref = "ya-canadian";
+}
+);
+width = 680;
+}
+);
+note = uni153D;
+unicode = 5437;
+},
+{
+glyphname = "y-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(326,568,l),
+(331,588,l),
+(191,588,l),
+(218,714,l),
+(155,714,l),
+(116,534,l),
+(254,534,l),
+(252,572,l),
+(80,386,l),
+(125,348,l)
+);
+}
+);
+width = 286;
+}
+);
+note = uni153E;
+unicode = 5438;
+},
+{
+glyphname = "biblecreey-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(125,357,l),
+(239,644,l),
+(204,645,l),
+(223,357,l),
+(260,357,l),
+(401,644,l),
+(365,644,l),
+(358,357,l),
+(415,357,l),
+(418,374,l),
+(425,714,l),
+(378,714,l),
+(231,418,l),
+(272,418,l),
+(253,714,l),
+(207,714,l),
+(68,374,l),
+(64,357,l)
+);
+}
+);
+width = 433;
+}
+);
+metricRight = "=|";
+note = uni153F;
+unicode = 5439;
+},
+{
+glyphname = "yWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(209,216,l),
+(235,338,l),
+(339,338,l),
+(352,399,l),
+(248,399,l),
+(273,517,l),
+(213,517,l),
+(188,399,l),
+(83,399,l),
+(70,338,l),
+(174,338,l),
+(149,216,l)
+);
+}
+);
+width = 371;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1540;
+unicode = 5440;
+},
+{
+glyphname = "yiSayisi-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (40,189);
+ref = "fullstop-canadian";
+}
+);
+width = 311;
+}
+);
+metricLeft = "fullstop-canadian";
+metricWidth = "fullstop-canadian";
+note = uni1541;
+unicode = 5441;
+},
+{
+glyphname = "re-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (310,514);
+},
+{
+name = top_left_can;
+pos = (163,514);
+},
+{
+name = top_right_can;
+pos = (674,514);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(335,-13,o),
+(406,55,o),
+(438,207,cs),
+(482,410,l),
+(698,410,l),
+(716,495,l),
+(408,495,l),
+(346,203,ls),
+(326,109,o),
+(289,69,o),
+(226,69,cs),
+(156,69,o),
+(126,119,o),
+(146,211,cs),
+(206,495,l),
+(113,495,l),
+(56,227,ls),
+(24,80,o),
+(88,-13,o),
+(222,-13,cs)
+);
+}
+);
+width = 710;
+}
+);
+metricRight = "=|ne-canadian";
+note = uni1542;
+unicode = 5442;
+},
+{
+glyphname = "reRCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (513,514);
+},
+{
+name = top_left_can;
+pos = (151,514);
+},
+{
+name = top_right_can;
+pos = (661,514);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(539,-13,o),
+(610,55,o),
+(642,207,cs),
+(704,495,l),
+(610,495,l),
+(548,203,ls),
+(527,109,o),
+(490,69,o),
+(428,69,cs),
+(357,69,o),
+(328,119,o),
+(348,211,cs),
+(408,495,l),
+(100,495,l),
+(82,410,l),
+(299,410,l),
+(260,227,ls),
+(228,81,o),
+(292,-13,o),
+(426,-13,cs)
+);
+}
+);
+width = 711;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1543;
+unicode = 5443;
+},
+{
+glyphname = "leWestCree-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (513,514);
+},
+{
+name = top_left_can;
+pos = (149,514);
+},
+{
+name = top_right_can;
+pos = (660,514);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(302,0,l),
+(364,293,ls),
+(385,387,o),
+(422,426,o),
+(484,426,cs),
+(555,426,o),
+(584,377,o),
+(564,284,cs),
+(504,0,l),
+(597,0,l),
+(654,268,ls),
+(686,415,o),
+(622,509,o),
+(489,509,cs),
+(375,509,o),
+(305,440,o),
+(272,288,cs),
+(229,85,l),
+(12,85,l),
+(-6,0,l)
+);
+}
+);
+width = 710;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+unicode = 5444;
+},
+{
+glyphname = "raai-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (92,-200);
+ref = ring_top.canadian;
+}
+);
+width = 711;
+}
+);
+note = uni1545;
+unicode = 5445;
+},
+{
+glyphname = "ri-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (311,514);
+},
+{
+name = top_left_can;
+pos = (163,514);
+},
+{
+name = top_right_can;
+pos = (674,514);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(101,0,l),
+(164,293,ls),
+(184,387,o),
+(221,426,o),
+(285,426,cs),
+(354,426,o),
+(383,376,o),
+(364,284,cs),
+(303,0,l),
+(611,0,l),
+(629,85,l),
+(413,85,l),
+(452,268,ls),
+(483,415,o),
+(419,509,o),
+(291,509,cs),
+(172,509,o),
+(102,440,o),
+(69,288,cs),
+(8,0,l)
+);
+}
+);
+width = 711;
+}
+);
+metricLeft = "re-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+unicode = 5446;
+},
+{
+glyphname = "rii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (141,-200);
+ref = dot_top;
+}
+);
+width = 711;
+}
+);
+note = uni1547;
+unicode = 5447;
+},
+{
+glyphname = "ro-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (299,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(103,0,l),
+(165,293,l),
+(121,252,l),
+(197,252,ls),
+(397,252,o),
+(462,403,o),
+(462,529,cs),
+(462,643,o),
+(392,714,o),
+(272,714,cs),
+(163,714,l),
+(145,630,l),
+(255,630,ls),
+(330,630,o),
+(370,592,o),
+(370,522,cs),
+(370,429,o),
+(322,334,o),
+(193,334,cs),
+(80,334,l),
+(9,0,l)
+);
+}
+);
+width = 456;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1548;
+unicode = 5448;
+},
+{
+glyphname = "roo-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (130,0);
+ref = dot_top;
+}
+);
+width = 456;
+}
+);
+note = uni1549;
+unicode = 5449;
+},
+{
+glyphname = "loWestCree-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (311,714);
+},
+{
+name = top_left_can;
+pos = (208,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(144,0,ls),
+(344,0,o),
+(409,151,o),
+(409,277,cs),
+(409,391,o),
+(339,462,o),
+(219,462,cs),
+(160,462,l),
+(192,420,l),
+(254,714,l),
+(160.996,714,l),
+(90,380,l),
+(202,380,ls),
+(277,380,o),
+(317,342,o),
+(317,272,cs),
+(317,179,o),
+(269,85,o),
+(140,85,cs),
+(27,85,l),
+(9,0,l)
+);
+}
+);
+width = 457;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+unicode = 5450;
+},
+{
+glyphname = "ra-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (355,714);
+},
+{
+name = top_right_can;
+pos = (446,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(342,0,l),
+(413,334,l),
+(301,334,ls),
+(226,334,o),
+(186,372,o),
+(186,442,cs),
+(186,535,o),
+(234,629,o),
+(363,629,cs),
+(476,629,l),
+(494,714,l),
+(359,714,ls),
+(159,714,o),
+(94,563,o),
+(94,437,cs),
+(94,323,o),
+(164,252,o),
+(284,252,cs),
+(343,252,l),
+(311,294,l),
+(248,0,l)
+);
+}
+);
+width = 457;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+unicode = 5451;
+},
+{
+glyphname = "raa-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (185,0);
+ref = dot_top;
+}
+);
+width = 456;
+}
+);
+note = uni154C;
+unicode = 5452;
+},
+{
+glyphname = "laWestCree-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (447,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(341,0,l),
+(359,84,l),
+(248,84,ls),
+(173,84,o),
+(133,122,o),
+(133,192,cs),
+(133,285,o),
+(181,380,o),
+(310,380,cs),
+(423,380,l),
+(494,714,l),
+(401,714,l),
+(339,421,l),
+(383,462,l),
+(306,462,ls),
+(106,462,o),
+(41,311,o),
+(41,185,cs),
+(41,71,o),
+(111,0,o),
+(231,0,cs)
+);
+}
+);
+width = 457;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+unicode = 5453;
+},
+{
+glyphname = "rwaa-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (376,0);
+ref = dot_top;
+}
+);
+width = 647;
+}
+);
+note = uni154E;
+unicode = 5454;
+},
+{
+glyphname = "rwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (185,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (456,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 647;
+}
+);
+note = uni154F;
+unicode = 5455;
+},
+{
+glyphname = "r-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(243,357,l),
+(280,532,l),
+(232,532,ls),
+(196,532,o),
+(177,550,o),
+(177,581,cs),
+(177,621,o),
+(196,661,o),
+(259,661,cs),
+(307,661,l),
+(319,714,l),
+(269,714,ls),
+(170,714,o),
+(116,661,o),
+(116,579,cs),
+(116,521,o),
+(155,480,o),
+(220,480,cs),
+(244,480,l),
+(209,498,l),
+(179,357,l)
+);
+}
+);
+width = 271;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni1550;
+unicode = 5456;
+},
+{
+glyphname = "rWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(150,714,l),
+(142,674,l),
+(278,598,l),
+(285,632,l),
+(116,554,l),
+(110,523,l),
+(247,452,l),
+(254,482,l),
+(85,406,l),
+(74,357,l),
+(86,357,l),
+(292,449,l),
+(297,474,l),
+(158,548,l),
+(153,523,l),
+(324,597,l),
+(329,622,l),
+(162,714,l)
+);
+}
+);
+width = 301;
+}
+);
+metricLeft = "=|lWestCree-canadian";
+metricRight = "=|lWestCree-canadian";
+note = uni1551;
+unicode = 5457;
+},
+{
+glyphname = "rMedial-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(26,-13,l),
+(456,178,l),
+(464,217,l),
+(165,374,l),
+(158,340,l),
+(523,497,l),
+(531,536,l),
+(183,727,l),
+(159,727,l),
+(146,664,l),
+(442,502,l),
+(452,546,l),
+(86,384,l),
+(77,341,l),
+(376,189,l),
+(385,227,l),
+(19,64,l),
+(3,-13,l)
+);
+}
+);
+width = 528;
+}
+);
+metricLeft = "mediall-canadian";
+metricRight = "mediall-canadian";
+note = uni1552;
+unicode = 5458;
+},
+{
+glyphname = "fe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(276,0,l),
+(711,688,l),
+(717,714,l),
+(639,714,l),
+(266,106,l),
+(286,106,l),
+(230,373,l),
+(184,368,l),
+(200,347,o),
+(225,334,o),
+(260,334,cs),
+(382,334,o),
+(434,496,o),
+(434,585,cs),
+(434,671,o),
+(391,727,o),
+(313,727,cs),
+(188,727,o),
+(138,576,o),
+(138,470,cs),
+(138,438,o),
+(143,407,o),
+(153,371,cs),
+(244,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(228,395,o),
+(210,423,o),
+(210,472,cs),
+(210,529,o),
+(236,659,o),
+(309,659,cs),
+(343,659,o),
+(362,632,o),
+(362,583,cs),
+(362,526,o),
+(336,395,o),
+(264,395,cs)
+);
+}
+);
+width = 643;
+}
+);
+metricRight = "e-canadian";
+note = uni1553;
+unicode = 5459;
+},
+{
+glyphname = "faai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (190,0);
+ref = ring_top.canadian;
+}
+);
+width = 643;
+}
+);
+note = uni1554;
+unicode = 5460;
+},
+{
+glyphname = "fi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (407,714);
+},
+{
+name = top_left_can;
+pos = (216,714);
+},
+{
+name = top_right_can;
+pos = (621,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(314,-13,o),
+(358,142,o),
+(358,233,cs),
+(358,324,o),
+(315,381,o),
+(248,381,cs),
+(224,381,o),
+(196,370,o),
+(171,348,c),
+(227,349,l),
+(400,608,l),
+(377,608,l),
+(499,0,l),
+(564,0,l),
+(569,26,l),
+(423,714,l),
+(391,714,l),
+(141,353,ls),
+(94,285,o),
+(64,211,o),
+(64,128,cs),
+(64,42,o),
+(108,-13,o),
+(185,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(154,55,o),
+(136,82,o),
+(136,131,cs),
+(136,188,o),
+(162,319,o),
+(235,319,cs),
+(270,319,o),
+(287,290,o),
+(287,239,cs),
+(287,180,o),
+(260,55,o),
+(190,55,cs)
+);
+}
+);
+width = 642;
+}
+);
+metricLeft = "fe-canadian";
+metricRight = "e-canadian";
+note = uni1555;
+unicode = 5461;
+},
+{
+glyphname = "fii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (239,0);
+ref = dot_top;
+}
+);
+width = 643;
+}
+);
+note = uni1556;
+unicode = 5462;
+},
+{
+glyphname = "fo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (287,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(44.996,0,l),
+(558,340,l),
+(565,374,l),
+(381,664,ls),
+(356,703,o),
+(325,727,o),
+(276,727,cs),
+(167,727,o),
+(112,598,o),
+(102,501,cs),
+(92,397,o),
+(137,329,o),
+(217,329,cs),
+(318,329,o),
+(377,451,o),
+(386,548,cs),
+(388,581,o),
+(387,611,o),
+(383,633,c),
+(347,581,l),
+(492,355,l),
+(500,390,l),
+(39,84,l),
+(21,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(188,396,o),
+(170,431,o),
+(175,495,cs),
+(180,561,o),
+(205,661,o),
+(271,661,cs),
+(309,661,o),
+(326,627,o),
+(322,563,cs),
+(317,497,o),
+(292,396,o),
+(226,396,cs)
+);
+}
+);
+width = 568;
+}
+);
+metricRight = "o-canadian";
+note = uni1557;
+unicode = 5463;
+},
+{
+glyphname = "foo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "fo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (117,0);
+ref = dot_top;
+}
+);
+width = 569;
+}
+);
+note = uni1558;
+unicode = 5464;
+},
+{
+glyphname = "fa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (482,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(443,0,l),
+(458,70,l),
+(134,369,l),
+(129,346,l),
+(366,578,l),
+(346,647,l),
+(311,589,o),
+(295,520,o),
+(295,470,cs),
+(295,383,o),
+(341,327,o),
+(418,327,cs),
+(536,327,o),
+(588,487,o),
+(588,581,cs),
+(588,672,o),
+(542,727,o),
+(470,727,cs),
+(429,727,o),
+(393,710,o),
+(356,673,cs),
+(57,374,l),
+(50,340,l),
+(419,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(383,394,o),
+(365,422,o),
+(365,471,cs),
+(365,528,o),
+(391,659,o),
+(463,659,cs),
+(498,659,o),
+(517,632,o),
+(517,583,cs),
+(517,526,o),
+(491,394,o),
+(418,394,cs)
+);
+}
+);
+width = 570;
+}
+);
+metricRight = "=|fo-canadian";
+note = uni1559;
+unicode = 5465;
+},
+{
+glyphname = "faa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (312,0);
+ref = dot_top;
+}
+);
+width = 569;
+}
+);
+note = uni155A;
+unicode = 5466;
+},
+{
+glyphname = "fwaa-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (504,0);
+ref = dot_top;
+}
+);
+width = 760;
+}
+);
+note = uni155B;
+unicode = 5467;
+},
+{
+glyphname = "fwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (312,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (569,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 760;
+}
+);
+note = uni155C;
+unicode = 5468;
+},
+{
+glyphname = "f-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(297,357,l),
+(305,400,l),
+(149,545,l),
+(148,531,l),
+(258,641,l),
+(254,682,l),
+(238,658,o),
+(225,616,o),
+(225,588,cs),
+(225,547,o),
+(248,519,o),
+(284,519,cs),
+(342,519,o),
+(369,595,o),
+(369,649,cs),
+(369,694,o),
+(349,720,o),
+(312,720,cs),
+(291,720,o),
+(273,711,o),
+(253,691,cs),
+(104,544,l),
+(100,525,l),
+(284,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(269,556,o),
+(261,568,o),
+(261,590,cs),
+(261,616,o),
+(274,683,o),
+(307,683,cs),
+(322,683,o),
+(331,672,o),
+(331,650,cs),
+(331,624,o),
+(318,556,o),
+(285,556,cs)
+);
+}
+);
+width = 334;
+}
+);
+note = uni155D;
+unicode = 5469;
+},
+{
+glyphname = "the-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (687,357);
+},
+{
+name = top_center_can;
+pos = (406,714);
+},
+{
+name = top_left_can;
+pos = (205,714);
+},
+{
+name = top_right_can;
+pos = (605,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(427,-13,o),
+(513,65,o),
+(549,234,cs),
+(652,714,l),
+(558,714,l),
+(458,243,ls),
+(433,126,o),
+(379,73,o),
+(284,73,cs),
+(152,73,o),
+(132,159,o),
+(157,273,cs),
+(194,441,l),
+(148,418,l),
+(152,371,o),
+(181,326,o),
+(233,326,cs),
+(349,326,o),
+(400,456,o),
+(411,557,cs),
+(423,661,o),
+(379,727,o),
+(291,727,cs),
+(204,727,o),
+(147,658,o),
+(119,529,cs),
+(67,282,ls),
+(31,110,o),
+(91,-13,o),
+(280,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(206,394,o),
+(188,422,o),
+(188,471,cs),
+(188,528,o),
+(215,659,o),
+(287,659,cs),
+(322,659,o),
+(340,632,o),
+(340,583,cs),
+(340,525,o),
+(314,394,o),
+(242,394,cs)
+);
+}
+);
+width = 612;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155E;
+unicode = 5470;
+},
+{
+glyphname = "theNCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(428,-13,o),
+(512,68,o),
+(551,247,cs),
+(606,507,ls),
+(637,651,o),
+(582,727,o),
+(497,727,cs),
+(373,727,o),
+(323,576,o),
+(323,472,cs),
+(323,389,o),
+(363,326,o),
+(439,326,cs),
+(481,326,o),
+(522,354,o),
+(543,398,c),
+(498,428,l),
+(460,251,ls),
+(433,124,o),
+(381,71,o),
+(283,71,cs),
+(169,71,o),
+(129,137,o),
+(155,264,cs),
+(251,714,l),
+(158,714,l),
+(64,271,ls),
+(26,92,o),
+(106,-13,o),
+(277,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(413,394,o),
+(394,422,o),
+(394,471,cs),
+(394,528,o),
+(421,659,o),
+(492,659,cs),
+(526,659,o),
+(544,632,o),
+(544,583,cs),
+(544,525,o),
+(518,394,o),
+(447,394,cs)
+);
+}
+);
+width = 610;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155F;
+unicode = 5471;
+},
+{
+glyphname = "thi-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (402,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(284,-13,o),
+(334,138,o),
+(334,242,cs),
+(334,325,o),
+(294,388,o),
+(218,388,cs),
+(176,388,o),
+(135,360,o),
+(114,316,c),
+(159,286,l),
+(197,463,ls),
+(224,590,o),
+(277,643,o),
+(374,643,cs),
+(488,643,o),
+(529,577,o),
+(502,450,cs),
+(406,0,l),
+(500,0,l),
+(594,443,ls),
+(631,622,o),
+(551,727,o),
+(380,727,cs),
+(229,727,o),
+(145,646,o),
+(106,467,cs),
+(51,207,ls),
+(20,63,o),
+(75,-13,o),
+(160,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(131,55,o),
+(113,82,o),
+(113,131,cs),
+(113,189,o),
+(139,320,o),
+(210,320,cs),
+(244,320,o),
+(263,292,o),
+(263,243,cs),
+(263,186,o),
+(236,55,o),
+(165,55,cs)
+);
+}
+);
+width = 612;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1560;
+unicode = 5472;
+},
+{
+glyphname = "thiNCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (401,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(453,-13,o),
+(511,56,o),
+(538,185,cs),
+(590,432,ls),
+(626,604,o),
+(566,727,o),
+(377,727,cs),
+(230,727,o),
+(144,649,o),
+(108,480,cs),
+(6,0,l),
+(99,0,l),
+(199,471,ls),
+(224,588,o),
+(278,641,o),
+(373,641,cs),
+(505,641,o),
+(526,555,o),
+(500,441,cs),
+(463,273,l),
+(510,296,l),
+(506,343,o),
+(476,388,o),
+(424,388,cs),
+(309,388,o),
+(258,258,o),
+(246,157,cs),
+(235,53,o),
+(279,-13,o),
+(366,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(336,55,o),
+(317,82,o),
+(317,131,cs),
+(317,189,o),
+(343,320,o),
+(416,320,cs),
+(451,320,o),
+(469,292,o),
+(469,243,cs),
+(469,186,o),
+(443,55,o),
+(370,55,cs)
+);
+}
+);
+width = 610;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1561;
+unicode = 5473;
+},
+{
+glyphname = "thii-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "thi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (232,0);
+ref = dot_top;
+}
+);
+width = 610;
+}
+);
+note = uni1562;
+unicode = 5474;
+},
+{
+glyphname = "thiiNCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "thiNCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (232,0);
+ref = dot_top;
+}
+);
+width = 610;
+}
+);
+note = uni1563;
+unicode = 5475;
+},
+{
+glyphname = "tho-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (356,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(177,0,ls),
+(464,0,o),
+(543,289,o),
+(543,463,cs),
+(543,624,o),
+(467,727,o),
+(337,727,cs),
+(175,727,o),
+(104,572,o),
+(104,446,cs),
+(104,357,o),
+(146,300,o),
+(220,300,cs),
+(342,300,o),
+(388,455,o),
+(388,548,cs),
+(388,624,o),
+(356,674,o),
+(298,681,c),
+(279,655,l),
+(286,662,o),
+(302,667,o),
+(324,667,cs),
+(408,667,o),
+(455,595,o),
+(455,476,cs),
+(455,351,o),
+(409,86,o),
+(181,86,cs),
+(49,86,l),
+(31,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(195,367,o),
+(177,394,o),
+(177,443,cs),
+(177,495,o),
+(204,642,o),
+(277,642,cs),
+(311,642,o),
+(329,614,o),
+(329,566,cs),
+(329,515,o),
+(303,367,o),
+(230,367,cs)
+);
+}
+);
+width = 559;
+}
+);
+metricRight = "to-canadian";
+note = uni1564;
+unicode = 5476;
+},
+{
+glyphname = "thoo-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "tho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (186,0);
+ref = dot_top;
+}
+);
+width = 560;
+}
+);
+note = uni1565;
+unicode = 5477;
+},
+{
+glyphname = "tha-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (408,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(425,0,l),
+(443,86,l),
+(324,86,ls),
+(213,86,o),
+(154,146,o),
+(154,264,cs),
+(154,390,o),
+(225,667,o),
+(391,667,cs),
+(418,667,o),
+(443,659,o),
+(461,644,c),
+(437,679,l),
+(321,687,o),
+(275,529,o),
+(275,439,cs),
+(275,353,o),
+(316,300,o),
+(388,300,cs),
+(501,300,o),
+(562,437,o),
+(562,548,cs),
+(562,660,o),
+(497,727,o),
+(389,727,cs),
+(162,727,o),
+(63,431,o),
+(63,258,cs),
+(63,97,o),
+(153,0,o),
+(305.995,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(357,367,o),
+(339,394,o),
+(339,443,cs),
+(339,495,o),
+(366,642,o),
+(439,642,cs),
+(473,642,o),
+(491,614,o),
+(491,566,cs),
+(491,515,o),
+(465,367,o),
+(391,367,cs)
+);
+}
+);
+width = 559;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tho-canadian";
+note = uni1566;
+unicode = 5478;
+},
+{
+glyphname = "thaa-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (238,0);
+ref = dot_top;
+}
+);
+width = 560;
+}
+);
+note = uni1567;
+unicode = 5479;
+},
+{
+glyphname = "thwaa-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (430,0);
+ref = dot_top;
+}
+);
+width = 752;
+}
+);
+note = uni1568;
+unicode = 5480;
+},
+{
+glyphname = "thwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (238,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (560,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 752;
+}
+);
+note = uni1569;
+unicode = 5481;
+},
+{
+glyphname = "th-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(285,357,l),
+(297,411,l),
+(240,411,ls),
+(187,411,o),
+(160,440,o),
+(160,494,cs),
+(160,554,o),
+(194,679,o),
+(274,679,cs),
+(285,679,o),
+(296,677,o),
+(305,672,c),
+(288,691,l),
+(232,692,o),
+(210,612,o),
+(210,573,cs),
+(210,532,o),
+(231,504,o),
+(267,504,cs),
+(331,504,o),
+(354,590,o),
+(354,634,cs),
+(354,687,o),
+(324,720,o),
+(268,720,cs),
+(152,720,o),
+(105,573,o),
+(105,491,cs),
+(105,408,o),
+(151,357,o),
+(230,357,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(252,541,o),
+(243,552,o),
+(243,573,cs),
+(243,600,o),
+(255,668,o),
+(291,668,cs),
+(307,668,o),
+(315,657,o),
+(315,635,cs),
+(315,609,o),
+(303,541,o),
+(268,541,cs)
+);
+}
+);
+width = 321;
+}
+);
+metricLeft = "t-canadian";
+note = uni156A;
+unicode = 5482;
+},
+{
+glyphname = "tthe-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (678,357);
+},
+{
+name = top_center_can;
+pos = (400,714);
+},
+{
+name = top_left_can;
+pos = (205,714);
+},
+{
+name = top_right_can;
+pos = (596,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(419,-13,o),
+(505,67,o),
+(541,234,cs),
+(643,714,l),
+(556,714,l),
+(456,244,ls),
+(430,125,o),
+(377,74,o),
+(281,74,cs),
+(165,74,o),
+(122,136,o),
+(149,264,cs),
+(245,714,l),
+(158,714,l),
+(64,271,ls),
+(26,92,o),
+(106,-13,o),
+(275,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(368,401,l),
+(435,714,l),
+(365,714,l),
+(298,401,l)
+);
+}
+);
+width = 603;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156B;
+unicode = 5483;
+},
+{
+glyphname = "tthi-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(93,0,l),
+(193,470,ls),
+(218,589,o),
+(272,640,o),
+(367,640,cs),
+(483,640,o),
+(527,578,o),
+(500,450,cs),
+(404,0,l),
+(491,0,l),
+(585,443,ls),
+(623,622,o),
+(542,727,o),
+(374,727,cs),
+(229,727,o),
+(143,647,o),
+(108,480,cs),
+(6,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(284,0,l),
+(350,313,l),
+(280,313,l),
+(213,0,l)
+);
+}
+);
+width = 603;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156C;
+unicode = 5484;
+},
+{
+glyphname = "ttho-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (344,714);
+},
+{
+name = top_left_can;
+pos = (200,714);
+},
+{
+name = top_right_can;
+pos = (529,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(125,0,ls),
+(432,0,o),
+(505,291,o),
+(505,457,cs),
+(505,623,o),
+(412,714,o),
+(244,714,cs),
+(160,714,l),
+(142,628,l),
+(227,628,ls),
+(350,628,o),
+(411,570,o),
+(411,452,cs),
+(411,328,o),
+(358,86,o),
+(129,86,cs),
+(26,86,l),
+(8,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(264,318,l),
+(281,397,l),
+(93,397,l),
+(76,318,l)
+);
+}
+);
+width = 522;
+}
+);
+metricRight = "to-canadian";
+note = uni156D;
+unicode = 5485;
+},
+{
+glyphname = "ttha-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (361,714);
+},
+{
+name = top_left_can;
+pos = (193,714);
+},
+{
+name = top_right_can;
+pos = (512,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(409,0,l),
+(427,86,l),
+(339,86,ls),
+(217,86,o),
+(158,144,o),
+(158,261,cs),
+(158,394,o),
+(215,628,o),
+(438,628,cs),
+(543,628,l),
+(561,714,l),
+(442,714,ls),
+(141,714,o),
+(64,430,o),
+(64,256,cs),
+(64,91,o),
+(154,0,o),
+(323,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(474,318,l),
+(490,397,l),
+(303,397,l),
+(286,318,l)
+);
+}
+);
+width = 522;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|ttho-canadian";
+note = uni156E;
+unicode = 5486;
+},
+{
+glyphname = "tth-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(254,512,l),
+(231,512,l),
+(291,390,l),
+(341,414,l),
+(278,542,l),
+(266,519,l),
+(402,574,l),
+(384,622,l),
+(257,571,l),
+(277,559,l),
+(310,714,l),
+(254,714,l),
+(221,559,l),
+(244,570,l),
+(131,622,l),
+(109,573,l),
+(217,524,l),
+(214,546,l),
+(105,425,l),
+(144,390,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(595,512,l),
+(572,512,l),
+(632,390,l),
+(682,414,l),
+(619,542,l),
+(608,519,l),
+(743,573,l),
+(725,621,l),
+(598,571,l),
+(618,559,l),
+(651,714,l),
+(595,714,l),
+(562,559,l),
+(586,570,l),
+(472,622,l),
+(450,573,l),
+(559,524,l),
+(556,546,l),
+(446,425,l),
+(485,390,l)
+);
+}
+);
+width = 714;
+}
+);
+metricRight = "=|";
+note = uni156F;
+unicode = 5487;
+},
+{
+glyphname = "tye-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(419,-13,o),
+(505,68,o),
+(541,234,cs),
+(643,714,l),
+(556,714,l),
+(456,244,ls),
+(430,125,o),
+(377,74,o),
+(281,74,cs),
+(165,74,o),
+(122,136,o),
+(149,264,cs),
+(245,714,l),
+(158,714,l),
+(64,271,ls),
+(26,92,o),
+(106,-13,o),
+(275,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(405,426,o),
+(438,459,o),
+(454,532,cs),
+(493,714,l),
+(450,714,l),
+(413,539,ls),
+(402,491,o),
+(384,471,o),
+(350,471,cs),
+(315,471,o),
+(304,490,o),
+(314,536,cs),
+(351,714,l),
+(308,714,l),
+(269,533,ls),
+(255,466,o),
+(285,426,o),
+(348,426,cs)
+);
+}
+);
+width = 603;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1570;
+unicode = 5488;
+},
+{
+glyphname = "tyi-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(93,0,l),
+(193,470,ls),
+(218,589,o),
+(272,640,o),
+(368,640,cs),
+(483,640,o),
+(527,578,o),
+(500,450,cs),
+(404,0,l),
+(491,0,l),
+(585,443,ls),
+(623,622,o),
+(542,727,o),
+(374,727,cs),
+(229,727,o),
+(143,646,o),
+(108,480,cs),
+(6,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,0,l),
+(236,175,ls),
+(246,223,o),
+(265,243,o),
+(299,243,cs),
+(333,243,o),
+(345,224,o),
+(335,178,cs),
+(298,0,l),
+(341,0,l),
+(379,181,ls),
+(394,248,o),
+(364,288,o),
+(301,288,cs),
+(244,288,o),
+(210,255,o),
+(194,182,cs),
+(156,0,l)
+);
+}
+);
+width = 603;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1571;
+unicode = 5489;
+},
+{
+glyphname = "tyo-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(124,0,ls),
+(432,0,o),
+(507,291,o),
+(507,457,cs),
+(507,623,o),
+(413,714,o),
+(243,714,cs),
+(162,714,l),
+(144,630,l),
+(228,630,ls),
+(350,630,o),
+(413,570,o),
+(413,452,cs),
+(413,295,o),
+(328,84,o),
+(128,84,cs),
+(28,84,l),
+(11,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(110,219,ls),
+(226,219,o),
+(267,293,o),
+(273,370,cs),
+(280,448,o),
+(238,495,o),
+(165,495,cs),
+(116,495,l),
+(104,444,l),
+(154,444,ls),
+(200,444,o),
+(223,420,o),
+(221,375,cs),
+(218,326,o),
+(197,270,o),
+(116,270,cs),
+(68,270,l),
+(57,219,l)
+);
+}
+);
+width = 524;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1572;
+unicode = 5490;
+},
+{
+glyphname = "tya-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(408,0,l),
+(426,84,l),
+(342,84,ls),
+(220,84,o),
+(157,144,o),
+(157,262,cs),
+(157,419,o),
+(242,630,o),
+(443,630,cs),
+(542,630,l),
+(559,714,l),
+(447,714,ls),
+(138,714,o),
+(64,423,o),
+(64,257,cs),
+(64,91,o),
+(158,0,o),
+(327,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(455,219,l),
+(466,270,l),
+(417,270,ls),
+(370,270,o),
+(347,294,o),
+(350,339,cs),
+(352,388,o),
+(374,444,o),
+(454,444,cs),
+(502,444,l),
+(513,495,l),
+(460,495,ls),
+(345,495,o),
+(304,421,o),
+(297,344,cs),
+(290,266,o),
+(332,219,o),
+(406,219,cs)
+);
+}
+);
+width = 523;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1573;
+unicode = 5491;
+},
+{
+glyphname = "heNunavik-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(376,0,l),
+(616,199,l),
+(565,264,l),
+(377,107,l),
+(405,86,l),
+(481,446,ls),
+(510,582,o),
+(484,727,o),
+(329,727,cs),
+(149,727,o),
+(91,515,o),
+(91,386,cs),
+(91,272,o),
+(143,205,o),
+(238,205,cs),
+(298,205,o),
+(344,239,o),
+(375,309,c),
+(360,312,l),
+(293,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(209,286,o),
+(181,321,o),
+(181,390,cs),
+(181,462,o),
+(214,647,o),
+(321,647,cs),
+(374,647,o),
+(402,612,o),
+(402,543,cs),
+(402,471,o),
+(369,286,o),
+(263,286,cs)
+);
+}
+);
+width = 647;
+}
+);
+metricLeft = "ke-canadian";
+note = uni1574;
+unicode = 5492;
+},
+{
+glyphname = "hiNunavik-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (500,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(250,0,l),
+(325,352,l),
+(306,314,l),
+(305,252,o),
+(351,205,o),
+(424,205,cs),
+(592,205,o),
+(650,421,o),
+(650,542,cs),
+(650,660,o),
+(591,727,o),
+(486,727,cs),
+(371,727,o),
+(293,645,o),
+(260,487,cs),
+(174,82,l),
+(204,90,l),
+(77,253,l),
+(11,199,l),
+(167,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(367,286,o),
+(339,321,o),
+(339,390,cs),
+(339,462,o),
+(375,647,o),
+(479,647,cs),
+(533,647,o),
+(561,612,o),
+(561,544,cs),
+(561,469,o),
+(527,286,o),
+(421,286,cs)
+);
+}
+);
+width = 649;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1575;
+unicode = 5493;
+},
+{
+glyphname = "hiiNunavik-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "hiNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (330,0);
+ref = dot_top;
+}
+);
+width = 647;
+}
+);
+note = uni1576;
+unicode = 5494;
+},
+{
+glyphname = "hoNunavik-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (343,714);
+},
+{
+name = top_right_can;
+pos = (492,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(325,-13,o),
+(402,69,o),
+(436,227,cs),
+(521,632,l),
+(491,624,l),
+(619,461,l),
+(684,515,l),
+(528,714,l),
+(446,714,l),
+(371,362,l),
+(389,400,l),
+(390,462,o),
+(345,509,o),
+(272,509,cs),
+(104,509,o),
+(45,293,o),
+(45,172,cs),
+(45,54,o),
+(104,-13,o),
+(209,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(163,67,o),
+(135,102,o),
+(135,170,cs),
+(135,245,o),
+(169,428,o),
+(274,428,cs),
+(328,428,o),
+(356,393,o),
+(356,324,cs),
+(356,252,o),
+(321,67,o),
+(216,67,cs)
+);
+}
+);
+width = 648;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "heNunavik-canadian";
+note = uni1577;
+unicode = 5495;
+},
+{
+glyphname = "hooNunavik-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "hoNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (321,0);
+ref = dot_top;
+}
+);
+width = 647;
+}
+);
+note = uni1578;
+unicode = 5496;
+},
+{
+glyphname = "haNunavik-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (502,714);
+},
+{
+name = top_left_can;
+pos = (353,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(545,-13,o),
+(603,199,o),
+(603,328,cs),
+(603,442,o),
+(550,509,o),
+(456,509,cs),
+(396,509,o),
+(349,475,o),
+(319,405,c),
+(334,402,l),
+(401,714,l),
+(318,714,l),
+(78,515,l),
+(129,450,l),
+(317,607,l),
+(289,628,l),
+(212,268,ls),
+(183,132,o),
+(210,-13,o),
+(365,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(320,67,o),
+(291,102,o),
+(291,171,cs),
+(291,243,o),
+(324,428,o),
+(431,428,cs),
+(485,428,o),
+(513,393,o),
+(513,324,cs),
+(513,252,o),
+(480,67,o),
+(373,67,cs)
+);
+}
+);
+width = 648;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1579;
+unicode = 5497;
+},
+{
+glyphname = "haaNunavik-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "haNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (184,0);
+ref = dot_top;
+}
+);
+width = 647;
+}
+);
+note = uni157A;
+unicode = 5498;
+},
+{
+glyphname = "hNunavik-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(358.007,351,o),
+(395,467,o),
+(395,529,cs),
+(395,586,o),
+(366,622,o),
+(318,622,cs),
+(285,622,o),
+(261,606,o),
+(241,571,c),
+(251,554,l),
+(285,714,l),
+(228,714,l),
+(108,615,l),
+(140,578,l),
+(243,663,l),
+(220,696,l),
+(177,495,ls),
+(162,423,o),
+(184,351,o),
+(261,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(242,400,o),
+(228,417,o),
+(228,451,cs),
+(228,504,o),
+(252,573,o),
+(299,573,cs),
+(324,573,o),
+(338,556,o),
+(338,523,cs),
+(338,470,o),
+(313,400,o),
+(267,400,cs)
+);
+}
+);
+width = 382;
+}
+);
+metricRight = "k-canadian";
+note = uni157B;
+unicode = 5499;
+},
+{
+color = 4;
+glyphname = "nunavuth-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(102,0,l),
+(172,328,l),
+(439,328,l),
+(369,0,l),
+(463,0,l),
+(615,714,l),
+(521,714,l),
+(457,412,l),
+(190,412,l),
+(254,714,l),
+(160.996,714,l),
+(8.996,0,l)
+);
+}
+);
+width = 578;
+}
+);
+metricRight = "=|";
+note = uni157C;
+unicode = 5500;
+},
+{
+glyphname = "hk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (76,357);
+ref = "fullstop-canadian";
+}
+);
+width = 311;
+}
+);
+metricLeft = "fullstop-canadian";
+note = uni157D;
+unicode = 5501;
+},
+{
+glyphname = "qaai-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (270,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (403,0);
+ref = ring_top.canadian;
+}
+);
+width = 767;
+}
+);
+note = uni157E;
+unicode = 5502;
+},
+{
+glyphname = "qi-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (270,0);
+ref = "ki-canadian";
+}
+);
+width = 767;
+}
+);
+note = uni157F;
+unicode = 5503;
+},
+{
+glyphname = "qii-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (270,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (451,0);
+ref = dot_top;
+}
+);
+width = 767;
+}
+);
+note = uni1580;
+unicode = 5504;
+},
+{
+glyphname = "qo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (270,0);
+ref = "ko-canadian";
+}
+);
+width = 767;
+}
+);
+note = uni1581;
+unicode = 5505;
+},
+{
+glyphname = "qoo-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (270,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (592,0);
+ref = dot_top;
+}
+);
+width = 767;
+}
+);
+note = uni1582;
+unicode = 5506;
+},
+{
+glyphname = "qa-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (270,0);
+ref = "ka-canadian";
+}
+);
+width = 767;
+}
+);
+note = uni1583;
+unicode = 5507;
+},
+{
+glyphname = "qaa-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (270,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (304,0);
+ref = dot_top;
+}
+);
+width = 767;
+}
+);
+note = uni1584;
+unicode = 5508;
+},
+{
+glyphname = "q-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (270,0);
+ref = "k-canadian";
+}
+);
+width = 578;
+}
+);
+note = uni1585;
+unicode = 5509;
+},
+{
+glyphname = "tlhe-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (352,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(116,0,l),
+(283,280,l),
+(214,242,l),
+(223,241,o),
+(233,240,o),
+(241,240,cs),
+(299,240,o),
+(345,265,o),
+(383,321,c),
+(375,347,l),
+(301,0,l),
+(394,0,l),
+(493,469,ls),
+(519,592,o),
+(492,727,o),
+(339,727,cs),
+(168,727,o),
+(103,549,o),
+(103,420,cs),
+(103,348,o),
+(130,294,o),
+(181,269,c),
+(18,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(218,321,o),
+(191,358,o),
+(191,423,cs),
+(191.008,494.007,o),
+(225,647,o),
+(329,647,cs),
+(385,647,o),
+(410,609,o),
+(410,548,cs),
+(410,476,o),
+(376,321,o),
+(273,321,cs)
+);
+}
+);
+width = 506;
+}
+);
+metricRight = "te-canadian";
+note = uni1586;
+unicode = 5510;
+},
+{
+glyphname = "tlhi-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,0,l),
+(175,360,l),
+(142,345,l),
+(162,283,o),
+(204,246,o),
+(270,243,c),
+(238,263,l),
+(285,0,l),
+(382,0,l),
+(336,258,l),
+(458,285,o),
+(506,441,o),
+(506,542,cs),
+(506,655,o),
+(443,727,o),
+(335,727,cs),
+(227,727,o),
+(146,653,o),
+(112,496,cs),
+(7,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(224,321,o),
+(195,358,o),
+(195,424,cs),
+(195,494,o),
+(230,647,o),
+(332,647,cs),
+(387,647,o),
+(415,610,o),
+(415,544,cs),
+(415,473,o),
+(382,321,o),
+(279,321,cs)
+);
+}
+);
+width = 509;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|tlhe-canadian";
+note = uni1587;
+unicode = 5511;
+},
+{
+glyphname = "tlho-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (364,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(327,-13,o),
+(408,61,o),
+(442,218,cs),
+(547,714,l),
+(455,714,l),
+(378,354,l),
+(411,369,l),
+(392,431,o),
+(350,468,o),
+(284,471,c),
+(316,451,l),
+(269,714,l),
+(172,714,l),
+(218,456,l),
+(96,429,o),
+(49,273,o),
+(49,172,cs),
+(49,59,o),
+(111,-13,o),
+(219,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(167,67,o),
+(139,104,o),
+(139,170,cs),
+(139,241,o),
+(172,393,o),
+(275,393,cs),
+(329,393,o),
+(358,356,o),
+(358,290,cs),
+(358,220,o),
+(323,67,o),
+(222,67,cs)
+);
+}
+);
+width = 507;
+}
+);
+metricLeft = "tlhe-canadian";
+metricRight = "te-canadian";
+note = uni1588;
+unicode = 5512;
+},
+{
+glyphname = "tlha-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(383,-13,o),
+(448,165,o),
+(448,294,cs),
+(448,366,o),
+(421,420,o),
+(370,445,c),
+(533,714,l),
+(436,714,l),
+(269,434,l),
+(338,472,l),
+(328,473,o),
+(319,474,o),
+(310,474,cs),
+(253,474,o),
+(206,449,o),
+(169,393,c),
+(177,367,l),
+(250,714,l),
+(158,714,l),
+(58,245,ls),
+(32,122,o),
+(59,-13,o),
+(212,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(166,67,o),
+(141,105,o),
+(141,166,cs),
+(141,238,o),
+(175,393,o),
+(278,393,cs),
+(333,393,o),
+(360,356,o),
+(360,291,cs),
+(360,220,o),
+(326,67,o),
+(223,67,cs)
+);
+}
+);
+width = 505;
+}
+);
+metricLeft = "te-canadian";
+note = uni1589;
+unicode = 5513;
+},
+{
+glyphname = "reWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(370,0,l),
+(610,201,l),
+(558,264,l),
+(371,107,l),
+(399,86,l),
+(482,480,ls),
+(515,635,o),
+(450,727,o),
+(324,727,cs),
+(204,727,o),
+(136,655,o),
+(102,497,cs),
+(82,401,l),
+(174,401,l),
+(197,508,ls),
+(218,604,o),
+(253,645,o),
+(313,645,cs),
+(384,645,o),
+(414,595,o),
+(393,498,cs),
+(287,0,l)
+);
+}
+);
+width = 641;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+unicode = 5514;
+},
+{
+glyphname = "riWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(248,0,l),
+(356,508,ls),
+(376,604,o),
+(412,645,o),
+(472,645,cs),
+(542,645,o),
+(573,595,o),
+(552,498,cs),
+(531,401,l),
+(624,401,l),
+(641,480,ls),
+(674,635,o),
+(608,727,o),
+(482,727,cs),
+(362,727,o),
+(294,655,o),
+(261,497,cs),
+(174,86,l),
+(204,93,l),
+(80,255,l),
+(11,201,l),
+(165,0,l)
+);
+}
+);
+width = 641;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+unicode = 5515;
+},
+{
+glyphname = "roWestCree-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(325,-13,o),
+(393,59,o),
+(426,217,cs),
+(514,628,l),
+(483,621,l),
+(607,459,l),
+(677,513,l),
+(522,714,l),
+(439,714,l),
+(332,206,ls),
+(311,110,o),
+(275,69,o),
+(215,69,cs),
+(145,69,o),
+(114,119,o),
+(135,216,cs),
+(156,313,l),
+(63,313,l),
+(46,234,ls),
+(13,79,o),
+(79,-13,o),
+(205,-13,cs)
+);
+}
+);
+width = 642;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+unicode = 5516;
+},
+{
+glyphname = "raWestCree-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(483,-13,o),
+(551,59,o),
+(585,217,cs),
+(605,313,l),
+(513,313,l),
+(490,206,ls),
+(469,110,o),
+(434,69,o),
+(374,69,cs),
+(303,69,o),
+(273,119,o),
+(294,216,cs),
+(400,714,l),
+(317,714,l),
+(77,513,l),
+(129,450,l),
+(316,607,l),
+(288,628,l),
+(205,234,ls),
+(172,79,o),
+(237,-13,o),
+(363,-13,cs)
+);
+}
+);
+width = 640;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+unicode = 5517;
+},
+{
+glyphname = "ngaai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:30:02 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (526,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (658,0);
+ref = ring_top.canadian;
+}
+);
+width = 1018;
+}
+);
+note = uni158E;
+unicode = 5518;
+},
+{
+glyphname = "ngi-canadian";
+kernLeft = mwestleft;
+kernRight = ciright;
+lastChange = "2023-01-13 15:30:02 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (526,0);
+ref = "ci-canadian";
+}
+);
+width = 1018;
+}
+);
+note = uni158F;
+unicode = 5519;
+},
+{
+glyphname = "ngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:30:02 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (526,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (707,0);
+ref = dot_top;
+}
+);
+width = 1018;
+}
+);
+note = uni1590;
+unicode = 5520;
+},
+{
+glyphname = "ngo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:30:02 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (501,0);
+ref = "co-canadian";
+}
+);
+width = 994;
+}
+);
+note = uni1591;
+unicode = 5521;
+},
+{
+glyphname = "ngoo-canadian";
+lastChange = "2023-01-13 15:30:02 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "ngo-canadian";
+},
+{
+anchor = top_right_can;
+pos = (818,0);
+ref = dot_top;
+}
+);
+width = 994;
+}
+);
+note = uni1592;
+unicode = 5522;
+},
+{
+glyphname = "nga-canadian";
+kernLeft = mwestleft;
+kernRight = caright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (525,0);
+ref = "ca-canadian";
+}
+);
+width = 1017;
+}
+);
+note = uni1593;
+unicode = 5523;
+},
+{
+glyphname = "ngaa-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (525,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (561,0);
+ref = dot_top;
+}
+);
+width = 1017;
+}
+);
+note = uni1594;
+unicode = 5524;
+},
+{
+glyphname = "ng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(456,225,o),
+(499,267,o),
+(516,347,cs),
+(522,378,l),
+(463,378,l),
+(455,341,ls),
+(445,298,o),
+(426,277,o),
+(396,277,cs),
+(364,277,o),
+(351,300,o),
+(360,342,cs),
+(396,510,l),
+(269,510,l),
+(277,482,l),
+(308,504,o),
+(327,563,o),
+(330,604,cs),
+(336,673,o),
+(301,720,o),
+(238,720,cs),
+(158,720,o),
+(119,636,o),
+(112,568,cs),
+(105,494,o),
+(142,449,o),
+(207,449,cs),
+(346,449,l),
+(327,488,l),
+(300,358,ls),
+(283,277,o),
+(318,225,o),
+(390,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(179,498,o),
+(165,520,o),
+(168,561,cs),
+(171,603,o),
+(188,671,o),
+(234,671,cs),
+(262,671,o),
+(276,649,o),
+(273,608,cs),
+(270,566,o),
+(253,498,o),
+(206,498,cs)
+);
+}
+);
+width = 526;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1595;
+unicode = 5525;
+},
+{
+glyphname = "nng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(705,225,o),
+(748,267,o),
+(764,347,cs),
+(771,378,l),
+(711,378,l),
+(703,341,ls),
+(693,298,o),
+(675,277,o),
+(645,277,cs),
+(612,277,o),
+(599,300,o),
+(609,342,cs),
+(645,510,l),
+(526,510,l),
+(524,482,l),
+(560,509,o),
+(579,574,o),
+(579,616,cs),
+(579,680,o),
+(544,720,o),
+(486,720,cs),
+(397,720,o),
+(359,622,o),
+(359,552,cs),
+(359,525,o),
+(366,503,o),
+(380,486,c),
+(389,510,l),
+(279,510,l),
+(276,482,l),
+(313,509,o),
+(331,577,o),
+(331,616,cs),
+(331,679,o),
+(296,720,o),
+(238,720,cs),
+(149,720,o),
+(111,622,o),
+(111,552,cs),
+(111,488,o),
+(147,449,o),
+(207,449,cs),
+(567,449,l),
+(548,358,ls),
+(531,277,o),
+(567,225,o),
+(639,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(181,498,o),
+(167,517,o),
+(167,551,cs),
+(167,589,o),
+(184,671,o),
+(234,671,cs),
+(261,671,o),
+(274,652,o),
+(274,618,cs),
+(274,580,o),
+(258,498,o),
+(206,498,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(429,498,o),
+(415,517,o),
+(415,551,cs),
+(415,589,o),
+(432,671,o),
+(483,671,cs),
+(509,671,o),
+(523,652,o),
+(523,618,cs),
+(523,580,o),
+(506,498,o),
+(454,498,cs)
+);
+}
+);
+width = 774;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1596;
+unicode = 5526;
+},
+{
+glyphname = "sheSayisi-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (580,357);
+},
+{
+name = top_center_can;
+pos = (352,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(395,0,l),
+(491,454,ls),
+(527,623,o),
+(471,727,o),
+(339,727,cs),
+(150,727,o),
+(87,497,o),
+(87,362,cs),
+(87,264,o),
+(124,207,o),
+(198,207,cs),
+(274,207,o),
+(316,270,o),
+(345,426,c),
+(304,426,l),
+(285,324,o),
+(261,284,o),
+(223,284,cs),
+(190,284,o),
+(174,311,o),
+(174,362,cs),
+(174,439,o),
+(214,647,o),
+(328,647,cs),
+(401,647,o),
+(424,579,o),
+(398,454,cs),
+(301,0,l)
+);
+}
+);
+width = 507;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1597;
+unicode = 5527;
+},
+{
+glyphname = "shiSayisi-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,0,l),
+(201,473,ls),
+(226,592,o),
+(267,647,o),
+(332,647,cs),
+(389,647,o),
+(419,610,o),
+(419,538,cs),
+(419,475,o),
+(383,284,o),
+(312,284,cs),
+(268,284,o),
+(255,326,o),
+(278,426,c),
+(238,426,l),
+(203,282,o),
+(235,207,o),
+(324,207,cs),
+(455,207,o),
+(507,431,o),
+(507,535,cs),
+(507,656,o),
+(445,727,o),
+(335,727,cs),
+(220,727,o),
+(145,647,o),
+(111,491,cs),
+(7,0,l)
+);
+}
+);
+width = 507;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni1598;
+unicode = 5528;
+},
+{
+glyphname = "shoSayisi-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (349,714);
+},
+{
+name = top_left_can;
+pos = (196,714);
+},
+{
+name = top_right_can;
+pos = (500,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(333,-13,o),
+(409,67,o),
+(442,223,cs),
+(547,714,l),
+(453,714,l),
+(353,241,ls),
+(327,122,o),
+(286,67,o),
+(222,67,cs),
+(164,67,o),
+(135,104,o),
+(135,176,cs),
+(135,239,o),
+(170,430,o),
+(241,430,cs),
+(286,430,o),
+(299,388,o),
+(275,288,c),
+(316,288,l),
+(350,432,o),
+(318,507,o),
+(230,507,cs),
+(99,507,o),
+(46,283,o),
+(46,179,cs),
+(46,58,o),
+(108,-13,o),
+(218,-13,cs)
+);
+}
+);
+width = 507;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1599;
+unicode = 5529;
+},
+{
+glyphname = "shaSayisi-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(404,-13,o),
+(467,217,o),
+(467,352,cs),
+(467,450,o),
+(430,507,o),
+(356,507,cs),
+(279,507,o),
+(237,444,o),
+(209,288,c),
+(250,288,l),
+(269,390,o),
+(292,430,o),
+(331,430,cs),
+(364,430,o),
+(380,403,o),
+(380,352,cs),
+(380,275,o),
+(340,67,o),
+(225,67,cs),
+(152,67,o),
+(129,135,o),
+(156,260,cs),
+(253,714,l),
+(159,714,l),
+(62,260,ls),
+(27,91,o),
+(83,-13,o),
+(214,-13,cs)
+);
+}
+);
+width = 507;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni159A;
+unicode = 5530;
+},
+{
+glyphname = "theWoodScree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(572,-13,o),
+(635,184,o),
+(635,305,cs),
+(635,424,o),
+(569,495,o),
+(455,495,cs),
+(107,495,l),
+(90,417,l),
+(354,417,l),
+(353,445,l),
+(259,402,o),
+(228,259,o),
+(228,178,cs),
+(228,61,o),
+(292,-13,o),
+(401,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(348,67,o),
+(318,105,o),
+(318,175,cs),
+(318,247,o),
+(349,416,o),
+(458,416,cs),
+(515,416,o),
+(545,378,o),
+(545,308,cs),
+(545,236,o),
+(513,67,o),
+(405,67,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(705,636,l),
+(722,714,l),
+(154,714,l),
+(137,636,l)
+);
+}
+);
+width = 686;
+}
+);
+note = uni159B;
+unicode = 5531;
+},
+{
+glyphname = "thiWoodScree-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(394,-13,o),
+(456,185,o),
+(456,305,cs),
+(456,359,o),
+(441,399,o),
+(411,424,c),
+(404,417,l),
+(668,417,l),
+(685,495,l),
+(301,495,ls),
+(104,495,o),
+(49,297,o),
+(49,178,cs),
+(49,61,o),
+(113,-13,o),
+(222,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(170,67,o),
+(139,105,o),
+(139,175,cs),
+(139,247,o),
+(171,416,o),
+(279,416,cs),
+(337,416,o),
+(366,378,o),
+(366,308,cs),
+(366,236,o),
+(335,67,o),
+(226,67,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(715,636,l),
+(732,714,l),
+(164,714,l),
+(147,636,l)
+);
+}
+);
+width = 687;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159C;
+unicode = 5532;
+},
+{
+glyphname = "thoWoodScree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(386,0,ls),
+(583,0,o),
+(637,198,o),
+(637,318,cs),
+(637,435,o),
+(574,509,o),
+(464,509,cs),
+(292,509,o),
+(230,310,o),
+(230,191,cs),
+(230,137,o),
+(245,96,o),
+(275,71,c),
+(282,78,l),
+(19,78,l),
+(2,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(350,79,o),
+(320,117,o),
+(320,187,cs),
+(320,260,o),
+(352,428,o),
+(460,428,cs),
+(517,428,o),
+(547,390,o),
+(547,320,cs),
+(547,249,o),
+(516,79,o),
+(407,79,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(705,636,l),
+(722,714,l),
+(154,714,l),
+(137,636,l)
+);
+}
+);
+width = 686;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159D;
+unicode = 5533;
+},
+{
+glyphname = "thaWoodScree-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(579,0,l),
+(595,78,l),
+(331,78,l),
+(333,50,l),
+(427,93,o),
+(458,236,o),
+(458,317,cs),
+(458,435,o),
+(393,509,o),
+(285,509,cs),
+(113,509,o),
+(51,311,o),
+(51,191,cs),
+(51,71,o),
+(117,0,o),
+(231,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(170,79,o),
+(141,117,o),
+(141,187,cs),
+(141,260,o),
+(172,428,o),
+(281,428,cs),
+(338,428,o),
+(368,390,o),
+(368,320,cs),
+(368,249,o),
+(336,79,o),
+(228,79,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(713,636,l),
+(730,714,l),
+(162,714,l),
+(145,636,l)
+);
+}
+);
+width = 686;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159E;
+unicode = 5534;
+},
+{
+glyphname = "thWoodScree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(390,357,l),
+(402,413,l),
+(257,413,l),
+(253,383,l),
+(301,405,o),
+(321,479,o),
+(321,524,cs),
+(321,588,o),
+(286,628,o),
+(228,628,cs),
+(140,628,o),
+(101,529,o),
+(101,460,cs),
+(101,395,o),
+(137,357,o),
+(198,357,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(171,405,o),
+(158,424,o),
+(158,458,cs),
+(158,496,o),
+(174,579,o),
+(225,579,cs),
+(251,579,o),
+(265,560,o),
+(265,526,cs),
+(265,488,o),
+(248,405,o),
+(196,405,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(453,690,l),
+(466,746,l),
+(161,746,l),
+(148,690,l)
+);
+}
+);
+width = 418;
+}
+);
+metricRight = "=|";
+note = uni159F;
+unicode = 5535;
+},
+{
+glyphname = "lhi-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (479,714);
+},
+{
+name = top_right_can;
+pos = (564,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(257,0,l),
+(274,83,l),
+(259,83,ls),
+(186,83,o),
+(143,130,o),
+(143,206,cs),
+(143,293,o),
+(190,410,o),
+(331,410,cs),
+(665,410,l),
+(681,486,l),
+(590,752,l),
+(504,722,l),
+(595,453,l),
+(629,495,l),
+(338,495,ls),
+(144,495,o),
+(50,355,o),
+(50,204,cs),
+(50,84,o),
+(124,0,o),
+(239,0,cs)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A0;
+unicode = 5536;
+},
+{
+glyphname = "lhii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "lhi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (308,0);
+ref = dot_top;
+}
+);
+width = 676;
+}
+);
+note = uni15A1;
+unicode = 5537;
+},
+{
+glyphname = "lho-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (387,513);
+},
+{
+name = top_right_can;
+pos = (478,513);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(173,-227,l),
+(81,42,l),
+(48,-1,l),
+(338,-1,ls),
+(533,-1,o),
+(626,140,o),
+(626,291,cs),
+(626,411,o),
+(553,495,o),
+(438,495,cs),
+(420,495,l),
+(402,412,l),
+(418,412,ls),
+(491,412,o),
+(534,365,o),
+(534,289,cs),
+(534,201,o),
+(486,84,o),
+(346,84,cs),
+(12,84,l),
+(-4,9,l),
+(87,-258,l)
+);
+}
+);
+width = 676;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni15A2;
+unicode = 5538;
+},
+{
+glyphname = "lhoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "lho-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (309,-201);
+ref = dot_top;
+}
+);
+width = 676;
+}
+);
+note = uni15A3;
+unicode = 5539;
+},
+{
+glyphname = "lha-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (403,513);
+},
+{
+name = top_left_can;
+pos = (311,513);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(578,9,l),
+(594,85,l),
+(273,85,ls),
+(188,85,o),
+(142,129,o),
+(142,207,cs),
+(142,292,o),
+(183,412,o),
+(327,412,cs),
+(343,412,l),
+(361,495,l),
+(338,495,ls),
+(137,495,o),
+(49,350,o),
+(49,200,cs),
+(49,77,o),
+(126,0,o),
+(255,0,cs),
+(516,0,l),
+(492,39,l),
+(305,-206,l),
+(373,-258,l)
+);
+}
+);
+width = 676;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A4;
+unicode = 5540;
+},
+{
+glyphname = "lhaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "lha-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (140,-201);
+ref = dot_top;
+}
+);
+width = 676;
+}
+);
+note = uni15A5;
+unicode = 5541;
+},
+{
+glyphname = "lh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(389,363,l),
+(400,418,l),
+(251,418,ls),
+(198,418,o),
+(171,446,o),
+(171,499,cs),
+(171,564,o),
+(199,653,o),
+(298,653,cs),
+(305,653,l),
+(318,714,l),
+(309,714,ls),
+(161,714,o),
+(106,598,o),
+(106,493,cs),
+(106,405,o),
+(157,357,o),
+(248,357,cs),
+(357,357,l),
+(336,395,l),
+(227,253,l),
+(275,215,l)
+);
+}
+);
+width = 411;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni15A6;
+unicode = 5542;
+},
+{
+glyphname = "theThCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (183,714);
+},
+{
+name = top_right_can;
+pos = (472,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(297,108,l),
+(273,0,l),
+(367,0,l),
+(390,108,l),
+(453,108,l),
+(465,164,l),
+(402,164,l),
+(438,334,l),
+(162,334,l),
+(176,303,l),
+(519,670,l),
+(455,726,l),
+(44,282,l),
+(38,251,l),
+(327,251,l),
+(308,164,l),
+(118,164,l),
+(106,108,l)
+);
+}
+);
+width = 514;
+}
+);
+metricLeft = "ye-canadian";
+note = uni15A7;
+unicode = 5543;
+},
+{
+glyphname = "thiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (240,714);
+},
+{
+name = top_right_can;
+pos = (530,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(134,0,l),
+(158,108,l),
+(349,108,l),
+(360,164,l),
+(169,164,l),
+(188,251,l),
+(477,251,l),
+(483,282,l),
+(245,726,l),
+(170,684,l),
+(379,297,l),
+(402,334,l),
+(112,334,l),
+(76,164,l),
+(13,164,l),
+(1,108,l),
+(64,108,l),
+(41,0,l)
+);
+}
+);
+width = 513;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+unicode = 5544;
+},
+{
+glyphname = "thiiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (71,0);
+ref = dot_top;
+}
+);
+width = 514;
+}
+);
+note = uni15A9;
+unicode = 5545;
+},
+{
+glyphname = "thoThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (183,714);
+},
+{
+name = top_right_can;
+pos = (472,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(390,30,l),
+(180,417,l),
+(158,380,l),
+(447,380,l),
+(483,550,l),
+(547,550,l),
+(559,606,l),
+(495,606,l),
+(518,714,l),
+(425,714,l),
+(402,606,l),
+(211,606,l),
+(199,550,l),
+(390,550,l),
+(372,463,l),
+(83,463,l),
+(76,432,l),
+(315,-12,l)
+);
+}
+);
+width = 514;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+unicode = 5546;
+},
+{
+glyphname = "thooThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (303,0);
+ref = dot_top;
+}
+);
+width = 514;
+}
+);
+note = uni15AB;
+unicode = 5547;
+},
+{
+glyphname = "thaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (241,714);
+},
+{
+name = top_right_can;
+pos = (530,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(517,432,l),
+(523,463,l),
+(233,463,l),
+(252,550,l),
+(443,550,l),
+(454,606,l),
+(263,606,l),
+(287,714,l),
+(193,714,l),
+(170,606,l),
+(107,606,l),
+(96,550,l),
+(158,550,l),
+(122,380,l),
+(399,380,l),
+(385,411,l),
+(41,44,l),
+(105,-12,l)
+);
+}
+);
+width = 515;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+unicode = 5548;
+},
+{
+glyphname = "thaaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:30:02 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (71,0);
+ref = dot_top;
+}
+);
+width = 515;
+}
+);
+note = uni15AD;
+unicode = 5549;
+},
+{
+glyphname = "thThCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(153,635,l),
+(132,534,l),
+(276,534,l),
+(262,565,l),
+(96,386,l),
+(140,348,l),
+(342,568,l),
+(346,588,l),
+(206,588,l),
+(216,635,l),
+(307,635,l),
+(314,667,l),
+(223,667,l),
+(233,714,l),
+(170,714,l),
+(160,667,l),
+(127,667,l),
+(121,635,l)
+);
+}
+);
+width = 301;
+}
+);
+metricRight = "y-canadian";
+note = uni15AE;
+unicode = 5550;
+},
+{
+glyphname = "bAivilik-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(398,-13,o),
+(458,199,o),
+(458,328,cs),
+(458,442,o),
+(404,509,o),
+(310,509,cs),
+(252,509,o),
+(207,475,o),
+(174,406,c),
+(188,401,l),
+(254,714,l),
+(160.996,714,l),
+(9,0,l),
+(95,0,l),
+(119,115,l),
+(109,100,l),
+(115,25,o),
+(160,-13,o),
+(231,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(174,67,o),
+(147,102,o),
+(147,171,cs),
+(147,243,o),
+(179,428,o),
+(286,428,cs),
+(339,428,o),
+(367,393,o),
+(367,324,cs),
+(367,252,o),
+(335,67,o),
+(228,67,cs)
+);
+}
+);
+width = 503;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|ke-canadian";
+note = uni15AF;
+unicode = 5551;
+},
+{
+glyphname = "eBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(102,0,l),
+(194,431,l),
+(212,388,o),
+(253,362,o),
+(306,362,cs),
+(430,362,o),
+(486,494,o),
+(486,583,cs),
+(486,669,o),
+(436,727,o),
+(355,727,cs),
+(311,727,o),
+(271,709,o),
+(242,677,c),
+(250,714,l),
+(160.996,714,l),
+(8.996,0,l)
+);
+}
+);
+width = 458;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B0;
+unicode = 5552;
+},
+{
+glyphname = "iBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(194,-13,o),
+(234,5,o),
+(263,37,c),
+(255,0,l),
+(344,0,l),
+(496,714,l),
+(403,714,l),
+(311,283,l),
+(294,326,o),
+(253,352,o),
+(199,352,cs),
+(75,352,o),
+(19,220,o),
+(19,131,cs),
+(19,45,o),
+(69,-13,o),
+(150,-13,cs)
+);
+}
+);
+width = 459;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B1;
+unicode = 5553;
+},
+{
+glyphname = "oBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(351,-13,o),
+(406,118,o),
+(406,207,cs),
+(406,294,o),
+(357,352,o),
+(278,352,cs),
+(236,352,o),
+(198,336,o),
+(168,307,c),
+(254,714,l),
+(160.996,714,l),
+(8.996,0,l),
+(98,0,l),
+(112,64,l),
+(126,17,o),
+(169,-13,o),
+(226,-13,cs)
+);
+}
+);
+width = 458;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "eBlackfoot-canadian";
+note = uni15B2;
+unicode = 5554;
+},
+{
+glyphname = "aBlackfoot-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(344,0,l),
+(496,714,l),
+(407.002,714,l),
+(393,650,l),
+(378,697,o),
+(336,727,o),
+(279,727,cs),
+(154,727,o),
+(99,596,o),
+(99,507,cs),
+(99,420,o),
+(148,362,o),
+(227,362,cs),
+(269,362,o),
+(307,378,o),
+(337,407,c),
+(250,0,l)
+);
+}
+);
+width = 459;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B3;
+unicode = 5555;
+},
+{
+glyphname = "weBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(102,0,l),
+(169,316,l),
+(452,316,l),
+(469,397,l),
+(187,397,l),
+(237,633,l),
+(519,633,l),
+(536,714,l),
+(160.996,714,l),
+(8.996,0,l)
+);
+}
+);
+width = 484;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B4;
+unicode = 5556;
+},
+{
+glyphname = "wiBlackfoot-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(370,0,l),
+(522,714,l),
+(428,714,l),
+(361,398,l),
+(79,398,l),
+(62,317,l),
+(344,317,l),
+(294,81,l),
+(12,81,l),
+(-5,0,l)
+);
+}
+);
+width = 485;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B5;
+unicode = 5557;
+},
+{
+glyphname = "woBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(384,0,l),
+(401,81,l),
+(120,81,l),
+(170,317,l),
+(452,317,l),
+(469,398,l),
+(187,398,l),
+(254,714,l),
+(160.996,714,l),
+(8.996,0,l)
+);
+}
+);
+width = 484;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "weBlackfoot-canadian";
+note = uni15B6;
+unicode = 5558;
+},
+{
+glyphname = "waBlackfoot-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(370,0,l),
+(522,714,l),
+(147,714,l),
+(130,633,l),
+(411,633,l),
+(361,397,l),
+(79,397,l),
+(62,316,l),
+(344,316,l),
+(276,0,l)
+);
+}
+);
+width = 485;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B7;
+unicode = 5559;
+},
+{
+glyphname = "neBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(102,0,l),
+(239,644,l),
+(285,644,l),
+(266,695,l),
+(256,643,ls),
+(226,504,o),
+(288,414,o),
+(419,414,cs),
+(533,414,o),
+(609,483,o),
+(639,625,cs),
+(658,714,l),
+(567,714,l),
+(547,617,ls),
+(530,535,o),
+(488,497,o),
+(425,497,cs),
+(354,497,o),
+(326,546,o),
+(343,625,cs),
+(362,714,l),
+(160.996,714,l),
+(8.996,0,l)
+);
+}
+);
+width = 593;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B8;
+unicode = 5560;
+},
+{
+glyphname = "niBlackfoot-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(72,0,l),
+(92,97,ls),
+(109,179,o),
+(151,217,o),
+(214,217,cs),
+(285,217,o),
+(313,168,o),
+(297,89,cs),
+(277,0,l),
+(479,0,l),
+(631,714,l),
+(537,714,l),
+(400,70,l),
+(354,70,l),
+(373,19,l),
+(384,71,ls),
+(413,210,o),
+(352,300,o),
+(220,300,cs),
+(106,300,o),
+(30,231,o),
+(0,89,cs),
+(-19,0,l)
+);
+}
+);
+width = 594;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B9;
+unicode = 5561;
+},
+{
+glyphname = "noBlackfoot-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(210,0,l),
+(229,84,ls),
+(249,176,o),
+(284,218,o),
+(348,218,cs),
+(418,218,o),
+(449,166,o),
+(431,76,cs),
+(415,0,l),
+(506.998,0,l),
+(519,56,ls),
+(550,205,o),
+(486,300,o),
+(355,300,cs),
+(240,300,o),
+(167,225,o),
+(137,80,cs),
+(124,19,l),
+(163,70,l),
+(117,70,l),
+(254,714,l),
+(160.996,714,l),
+(8.996,0,l)
+);
+}
+);
+width = 594;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "neBlackfoot-canadian";
+note = uni15BA;
+unicode = 5562;
+},
+{
+glyphname = "naBlackfoot-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(479,0,l),
+(631,714,l),
+(429,714,l),
+(411,630,ls),
+(391,538,o),
+(355,496,o),
+(292,496,cs),
+(221,496,o),
+(190,548,o),
+(209,638,cs),
+(224,714,l),
+(133,714,l),
+(121,658,ls),
+(89,509,o),
+(154,414,o),
+(284,414,cs),
+(399,414,o),
+(472,489,o),
+(503,634,cs),
+(516,695,l),
+(476,644,l),
+(522,644,l),
+(385,0,l)
+);
+}
+);
+width = 594;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BB;
+unicode = 5563;
+},
+{
+glyphname = "keBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(102,0,l),
+(232,606,l),
+(197,606,l),
+(272,265,l),
+(314,265,l),
+(605,714,l),
+(501,714,l),
+(282,371,l),
+(322,366,l),
+(247,714,l),
+(160.996,714,l),
+(8.996,0,l)
+);
+}
+);
+width = 526;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15BC;
+unicode = 5564;
+},
+{
+glyphname = "kiBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(71,1,l),
+(290,343,l),
+(250,348,l),
+(325,1,l),
+(411,1,l),
+(563,715,l),
+(470,715,l),
+(341,108,l),
+(375,108,l),
+(300,450,l),
+(258,450,l),
+(-32,1,l)
+);
+}
+);
+width = 526;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BD;
+unicode = 5565;
+},
+{
+glyphname = "koBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(95,0,l),
+(328,344,l),
+(283,350,l),
+(358,0,l),
+(453,0,l),
+(353,449,l),
+(311,449,l),
+(91,108,l),
+(125,108,l),
+(254,714,l),
+(160.996,714,l),
+(8.996,0,l)
+);
+}
+);
+width = 526;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "keBlackfoot-canadian";
+note = uni15BE;
+unicode = 5566;
+},
+{
+glyphname = "kaBlackfoot-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(410,1,l),
+(562,715,l),
+(476,715,l),
+(243,371,l),
+(288,365,l),
+(213,715,l),
+(119,715,l),
+(218,265,l),
+(260,265,l),
+(480,607,l),
+(446,607,l),
+(317,1,l)
+);
+}
+);
+width = 525;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BF;
+unicode = 5567;
+},
+{
+color = 9;
+glyphname = "heSayisi-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_right_can;
+pos = (555,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(450,0,l),
+(602,714,l),
+(509,714,l),
+(421,299,l),
+(439,298,l),
+(490,572,o),
+(441,727,o),
+(301,727,cs),
+(200,727,o),
+(130,646,o),
+(96,492,cs),
+(85,440,o),
+(79,394,o),
+(78,348,c),
+(167,348,l),
+(168,390,o),
+(173,433,o),
+(184,481,cs),
+(206,586,o),
+(251,645,o),
+(313,645,cs),
+(432,645,o),
+(450,433,o),
+(356,0,c)
+);
+}
+);
+width = 565;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni15C0;
+unicode = 5568;
+},
+{
+color = 9;
+glyphname = "hiSayisi-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(102,0,l),
+(194,426,o),
+(297,645,o),
+(408,645,cs),
+(475,645,o),
+(498,569,o),
+(471,438,cs),
+(463,401,o),
+(454,374,o),
+(442,348,c),
+(531,348,l),
+(545,381,o),
+(555,413,o),
+(562,444,cs),
+(598,618,o),
+(551,727,o),
+(441,727,cs),
+(317,727,o),
+(215,584,o),
+(154,322,c),
+(170,321,l),
+(254,714,l),
+(160.996,714,l),
+(8.996,0,l)
+);
+}
+);
+width = 564;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C1;
+unicode = 5569;
+},
+{
+color = 9;
+glyphname = "hoSayisi-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (377,714);
+},
+{
+name = top_left_can;
+pos = (199,714);
+},
+{
+name = top_right_can;
+pos = (557,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(294,-13,o),
+(396,130,o),
+(457,392,c),
+(442,393,l),
+(358,0,l),
+(451,0,l),
+(603,714,l),
+(509,714,l),
+(418,288,o),
+(315,69,o),
+(204,69,cs),
+(137,69,o),
+(113,145,o),
+(141,276,cs),
+(149,313,o),
+(158,340,o),
+(169,366,c),
+(80,366,l),
+(67,333,o),
+(56,301,o),
+(49,270,cs),
+(14,96,o),
+(61,-13,o),
+(171,-13,cs)
+);
+}
+);
+width = 566;
+}
+);
+metricLeft = "heSayisi-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15C2;
+unicode = 5570;
+},
+{
+color = 9;
+glyphname = "haSayisi-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(410,-13,o),
+(480,68,o),
+(515,222,cs),
+(526,274,o),
+(532,320,o),
+(533,366,c),
+(444,366,l),
+(443,324,o),
+(438,281,o),
+(427,233,cs),
+(405,128,o),
+(360,69,o),
+(298,69,cs),
+(178,69,o),
+(160,281,o),
+(254,714,c),
+(160.996,714,l),
+(8.996,0,l),
+(102,0,l),
+(189,415,l),
+(172,416,l),
+(120,142,o),
+(169,-13,o),
+(309,-13,cs)
+);
+}
+);
+width = 564;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C3;
+unicode = 5571;
+},
+{
+color = 9;
+glyphname = "ghuCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(261,0,l),
+(665,688,l),
+(670,714,l),
+(589,714,l),
+(458,481,l),
+(495,498,l),
+(202,498,l),
+(232,480,l),
+(199,714,l),
+(125,714,l),
+(119,688,l),
+(230,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(457,428,l),
+(439,445,l),
+(256,123,l),
+(284,118,l),
+(237,442,l),
+(212,428,l)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C4;
+unicode = 5572;
+},
+{
+color = 9;
+glyphname = "ghoCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(54,0,l),
+(186,233,l),
+(148,216,l),
+(441,216,l),
+(411,234,l),
+(443,0,l),
+(518,0,l),
+(523,26,l),
+(413,714,l),
+(381,714,l),
+(-22,26,l),
+(-28,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(419,361,l),
+(229,365,l),
+(247,272,l),
+(398,516,l),
+(316,517,l),
+(362,268,l)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C5;
+unicode = 5573;
+},
+{
+color = 9;
+glyphname = "gheCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (88,366);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(13,0,l),
+(534,340,l),
+(541,374,l),
+(165,714,l),
+(141,714,l),
+(126,647,l),
+(248,537,l),
+(240,596,l),
+(143,141,l),
+(171,193,l),
+(7,85,l),
+(-11,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(297,555,l),
+(270,528,l),
+(476,339,l),
+(479,388,l),
+(206,208,l),
+(217,182,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15C6;
+unicode = 5574;
+},
+{
+color = 9;
+glyphname = "gheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (25,9);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 545;
+}
+);
+note = uni15C7;
+unicode = 5575;
+},
+{
+color = 9;
+glyphname = "ghiCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (4,9);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 545;
+}
+);
+note = uni15C8;
+unicode = 5576;
+},
+{
+color = 9;
+glyphname = "ghaCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(451,0,l),
+(465,67,l),
+(344,177,l),
+(352,118,l),
+(449,573,l),
+(421,521,l),
+(585,629,l),
+(603,714,l),
+(579,714,l),
+(58,374,l),
+(50,340,l),
+(427,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(321,186,l),
+(130,363,l),
+(128,335,l),
+(386,506,l),
+(370,514,l),
+(301,185,l)
+);
+}
+);
+width = 545;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15C9;
+unicode = 5577;
+},
+{
+color = 9;
+glyphname = "ruCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(261,0,l),
+(665,688,l),
+(670,714,l),
+(586,714,l),
+(531,616,l),
+(562,634,l),
+(186,634,l),
+(213,615,l),
+(199,714,l),
+(125,714,l),
+(119,688,l),
+(230,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(525,564,l),
+(516,583,l),
+(256,125,l),
+(284,120,l),
+(217,580,l),
+(195,564,l)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CA;
+unicode = 5578;
+},
+{
+color = 9;
+glyphname = "roCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(381,714,l),
+(-22,26,l),
+(-28,0,l),
+(57,0,l),
+(112,98,l),
+(81,80,l),
+(457,80,l),
+(430,99,l),
+(444,0,l),
+(517,0,l),
+(523,26,l),
+(413,714,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(117,150,l),
+(127,131,l),
+(387,589,l),
+(358,594,l),
+(426,134,l),
+(448,150,l)
+);
+}
+);
+width = 595;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CB;
+unicode = 5579;
+},
+{
+color = 9;
+glyphname = "reCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(13,0,l),
+(533,340,l),
+(540,374,l),
+(165,714,l),
+(140,714,l),
+(126,649,l),
+(189,591,l),
+(181,649,l),
+(61,85,l),
+(85,135,l),
+(6,82,l),
+(-12,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(238,598,l),
+(213,570,l),
+(464,339,l),
+(468,387,l),
+(130,162,l),
+(140,135,l)
+);
+}
+);
+width = 543;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CC;
+unicode = 5580;
+},
+{
+color = 9;
+glyphname = "reeCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(13,0,l),
+(534,340,l),
+(541,374,l),
+(165,714,l),
+(141,714,l),
+(129,657,l),
+(185,605,l),
+(183,656,l),
+(61,78,l),
+(83,128,l),
+(5,77,l),
+(-11,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(234,618,l),
+(211,589,l),
+(485,339,l),
+(489,388,l),
+(115,142,l),
+(128,115,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(247,279,l),
+(284,450,l),
+(249,450,l),
+(212,279,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CD;
+unicode = 5581;
+},
+{
+color = 9;
+glyphname = "riCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(13,0,l),
+(534,340,l),
+(541,374,l),
+(165,714,l),
+(141,714,l),
+(129,657,l),
+(187,603,l),
+(183,656,l),
+(61,78,l),
+(87,130,l),
+(5,77,l),
+(-11,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(304,328,o),
+(323,345,o),
+(323,367,cs),
+(323,389,o),
+(304,405,o),
+(283,405,cs),
+(263,405,o),
+(245,389,o),
+(245,367,cs),
+(245,345,o),
+(263,328,o),
+(283,328,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(234,618,l),
+(209,591,l),
+(485,339,l),
+(489,388,l),
+(117,144,l),
+(128,115,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CE;
+unicode = 5582;
+},
+{
+color = 9;
+glyphname = "raCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(451,0,l),
+(465,65,l),
+(402,123,l),
+(410,65,l),
+(529,629,l),
+(505,579,l),
+(585,632,l),
+(602,714,l),
+(578,714,l),
+(58,374,l),
+(50,340,l),
+(426,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(378,144,l),
+(126,375,l),
+(123,327,l),
+(461,552,l),
+(451,579,l),
+(353,116,l)
+);
+}
+);
+width = 545;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15CF;
+unicode = 5583;
+},
+{
+color = 9;
+glyphname = "wuCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(266,0,l),
+(673,688,l),
+(679,714,l),
+(598,714,l),
+(307,195,l),
+(324,194,l),
+(434.992,714,l),
+(362,714,l),
+(251,192,l),
+(270,192,l),
+(194,714,l),
+(125,714,l),
+(119,688,l),
+(234,0,l)
+);
+}
+);
+width = 605;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D0;
+unicode = 5584;
+},
+{
+color = 9;
+glyphname = "woCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(53,0,l),
+(345,519,l),
+(327,520,l),
+(216,0,l),
+(289,0,l),
+(400,522,l),
+(381,522,l),
+(457,0,l),
+(526,0,l),
+(532,26,l),
+(417,714,l),
+(386,714,l),
+(-22,26,l),
+(-28,0,l)
+);
+}
+);
+width = 604;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D1;
+unicode = 5585;
+},
+{
+color = 9;
+glyphname = "weCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(32,0,l),
+(553,340,l),
+(560,374,l),
+(184,714,l),
+(160,714,l),
+(146,647,l),
+(430,388,l),
+(435,403,l),
+(94,403,l),
+(78,331,l),
+(420,331,l),
+(424,344,l),
+(26,84,l),
+(8,0,l)
+);
+}
+);
+width = 563;
+}
+);
+metricRight = "o-canadian";
+note = uni15D2;
+unicode = 5586;
+},
+{
+color = 9;
+glyphname = "weeCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(32,0,l),
+(553,340,l),
+(560,374,l),
+(184,714,l),
+(160,714,l),
+(147,652,l),
+(461,370,l),
+(471,397,l),
+(213,397,l),
+(229,470,l),
+(178,470,l),
+(162,397,l),
+(92,397,l),
+(80,338,l),
+(149,338,l),
+(134,265,l),
+(185,265,l),
+(200,338,l),
+(459,338,l),
+(449,355,l),
+(25,79,l),
+(8,0,l)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D3;
+unicode = 5587;
+},
+{
+color = 9;
+glyphname = "wiCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(32,0,l),
+(553,340,l),
+(560,374,l),
+(184,714,l),
+(160,714,l),
+(147,652,l),
+(444,384,l),
+(453,399,l),
+(264,399,l),
+(254,421,o),
+(231,437,o),
+(205,437,cs),
+(179,437,o),
+(156,421,o),
+(146,399,c),
+(93,399,l),
+(80,340,l),
+(146,340,l),
+(156,318,o),
+(179,302,o),
+(205,302,cs),
+(231,302,o),
+(253,318,o),
+(263,340,c),
+(441,340,l),
+(436,347,l),
+(25,80,l),
+(8,0,l)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D4;
+unicode = 5588;
+},
+{
+color = 9;
+glyphname = "waCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(450,0,l),
+(464,67,l),
+(180,326,l),
+(175,311,l),
+(516,311,l),
+(531,383,l),
+(190,383,l),
+(187,370,l),
+(584,630,l),
+(602,714,l),
+(577,714,l),
+(58,374,l),
+(50,340,l),
+(425,0,l)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15D5;
+unicode = 5589;
+},
+{
+color = 9;
+glyphname = "hwuCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(266,0,l),
+(673,688,l),
+(679,714,l),
+(604,714,l),
+(478,495,l),
+(504,508,l),
+(382,508,l),
+(426,714,l),
+(369,714,l),
+(325,508,l),
+(201,508,l),
+(223,495,l),
+(190,714,l),
+(125,714,l),
+(119,688,l),
+(234,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(269,156,l),
+(223,473,l),
+(206,456,l),
+(318,456,l),
+(254,156,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(367,456,l),
+(477,456,l),
+(468,473,l),
+(290,158,l),
+(303,153,l)
+);
+}
+);
+width = 605;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D6;
+unicode = 5590;
+},
+{
+color = 9;
+glyphname = "hwoCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(47,0,l),
+(173,219,l),
+(148,206,l),
+(269,206,l),
+(225,0,l),
+(283,0,l),
+(327,206,l),
+(450,206,l),
+(428,219,l),
+(462,0,l),
+(526,0,l),
+(532,26,l),
+(417,714,l),
+(386,714,l),
+(-22,26,l),
+(-28,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(361,556,l),
+(348,561,l),
+(284,258,l),
+(175,258,l),
+(183,241,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(446,258,l),
+(334,258,l),
+(397,558,l),
+(382,558,l),
+(428,241,l)
+);
+}
+);
+width = 604;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D7;
+unicode = 5591;
+},
+{
+color = 9;
+glyphname = "hweCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(32,0,l),
+(553,340,l),
+(560,374,l),
+(184,714,l),
+(160,714,l),
+(147,652,l),
+(246,563,l),
+(210,396,l),
+(92,396,l),
+(79,334,l),
+(197,334,l),
+(162,169,l),
+(24,79,l),
+(8,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(248,340,l),
+(440,340,l),
+(217,196,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(289,534,l),
+(447,390,l),
+(258,390,l)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D8;
+unicode = 5592;
+},
+{
+color = 9;
+glyphname = "hweeCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(32,0,l),
+(553,340,l),
+(560,374,l),
+(184,714,l),
+(160,714,l),
+(147,656,l),
+(267,550,l),
+(233,392,l),
+(188,392,l),
+(204,468,l),
+(161,468,l),
+(145,392,l),
+(91,392,l),
+(80,339,l),
+(133,339,l),
+(118,265,l),
+(161,265,l),
+(176,339,l),
+(222,339,l),
+(188,181,l),
+(24,75,l),
+(8,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(267,343,l),
+(444,343,l),
+(239,208,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(305,522,l),
+(450,389,l),
+(277,389,l)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D9;
+unicode = 5593;
+},
+{
+color = 9;
+glyphname = "hwiCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(31,0,l),
+(552,340,l),
+(559,374,l),
+(183,714,l),
+(159,714,l),
+(147,656,l),
+(266,550,l),
+(231,388,l),
+(208,388,l),
+(200,408,o),
+(182,422,o),
+(160,422,cs),
+(138,422,o),
+(120,408,o),
+(112,388,c),
+(90,388,l),
+(80,343,l),
+(111,343,l),
+(119,323,o),
+(138,309,o),
+(160,309,cs),
+(181,309,o),
+(200,323,o),
+(208,343,c),
+(221,343,l),
+(187,181,l),
+(23,75,l),
+(7,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(266,343,l),
+(442,343,l),
+(238,208,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(304,523,l),
+(449,388,l),
+(276,388,l)
+);
+}
+);
+width = 562;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15DA;
+unicode = 5594;
+},
+{
+color = 9;
+glyphname = "hwaCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(578,714,l),
+(58,374,l),
+(50,340,l),
+(426,0,l),
+(451,0,l),
+(464,62,l),
+(365,151,l),
+(400,318,l),
+(518,318,l),
+(531,380,l),
+(413,380,l),
+(448,545,l),
+(586,635,l),
+(603,714,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(362,374,l),
+(171,374,l),
+(393,518,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(321,180,l),
+(163,324,l),
+(352,324,l)
+);
+}
+);
+width = 564;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15DB;
+unicode = 5595;
+},
+{
+color = 9;
+glyphname = "thuCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(419,-13,o),
+(505,68,o),
+(541,234,cs),
+(643,714,l),
+(158,714,l),
+(64,271,ls),
+(26,92,o),
+(106,-13,o),
+(275,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(233,630,l),
+(532,630,l),
+(449,244,ls),
+(424,125,o),
+(372,74,o),
+(281,74,cs),
+(169,74,o),
+(128,137,o),
+(155,264,cs)
+);
+}
+);
+width = 603;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DC;
+unicode = 5596;
+},
+{
+color = 9;
+glyphname = "thoCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(491,0,l),
+(585,443,ls),
+(623,622,o),
+(542,727,o),
+(374,727,cs),
+(229,727,o),
+(143,646,o),
+(108,480,cs),
+(6,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,470,ls),
+(224,589,o),
+(277,640,o),
+(368,640,cs),
+(479,640,o),
+(520,577,o),
+(493,450,cs),
+(415,84,l),
+(117,84,l)
+);
+}
+);
+width = 603;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DD;
+unicode = 5597;
+},
+{
+color = 9;
+glyphname = "theCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (319,357);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(180,0,ls),
+(479,0,o),
+(572,277,o),
+(572,460,cs),
+(572,623,o),
+(481,714,o),
+(312,714,cs),
+(160.996,714,l),
+(8.996,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(245,671,l),
+(210,631,l),
+(297,631,ls),
+(417,631,o),
+(480,571,o),
+(480,454,cs),
+(480,322,o),
+(414,83,o),
+(187,83,cs),
+(100,83,l),
+(112,46,l)
+);
+}
+);
+width = 588;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "to-canadian";
+note = uni15DE;
+unicode = 5598;
+},
+{
+color = 9;
+glyphname = "theeCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (249,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 588;
+}
+);
+note = uni15DF;
+unicode = 5599;
+},
+{
+color = 9;
+glyphname = "thiCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (226,0);
+ref = dot_middle;
+}
+);
+width = 588;
+}
+);
+note = uni15E0;
+unicode = 5600;
+},
+{
+color = 9;
+glyphname = "thaCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(474,0,l),
+(626,714,l),
+(455,714,ls),
+(155,714,o),
+(63,437,o),
+(63,254,cs),
+(63,91,o),
+(153,0,o),
+(323,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(154,392,o),
+(221,631,o),
+(447,631,cs),
+(535,631,l),
+(522,668,l),
+(389,43,l),
+(425,83,l),
+(338,83,ls),
+(217,83,o),
+(154,143,o),
+(154,260,cs)
+);
+}
+);
+width = 589;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15E1;
+unicode = 5601;
+},
+{
+color = 9;
+glyphname = "ttuCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(418,-13,o),
+(505,66,o),
+(540,229,cs),
+(643,714,l),
+(612,714,l),
+(322,515,l),
+(386,507,l),
+(190,714,l),
+(158,714,l),
+(63,265,ls),
+(25,89,o),
+(104,-13,o),
+(271,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(170,74,o),
+(128,136,o),
+(154,258,cs),
+(230,617,l),
+(192,603,l),
+(335,448,l),
+(354,448,l),
+(560,595,l),
+(529,615,l),
+(449,239,ls),
+(424,125,o),
+(371,74,o),
+(276,74,cs)
+);
+}
+);
+width = 603;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E2;
+unicode = 5602;
+},
+{
+color = 9;
+glyphname = "ttoCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(36,0,l),
+(327,199,l),
+(263,207,l),
+(459,0,l),
+(491,0,l),
+(586,449,ls),
+(623,625,o),
+(545,727,o),
+(377,727,cs),
+(230,727,o),
+(144,648,o),
+(109,485,cs),
+(6,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(479,640,o),
+(520,578,o),
+(494,456,cs),
+(418,97,l),
+(457,111,l),
+(314,266,l),
+(295,266,l),
+(88,119,l),
+(120,99,l),
+(200,475,ls),
+(224,589,o),
+(278,640,o),
+(372,640,cs)
+);
+}
+);
+width = 603;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E3;
+unicode = 5603;
+},
+{
+color = 9;
+glyphname = "tteCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (362,357);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(190,0,ls),
+(487,0,o),
+(583,275,o),
+(583,460,cs),
+(583,623,o),
+(491,714,o),
+(326,714,cs),
+(157,714,l),
+(151,688,l),
+(184,327,l),
+(197,406,l),
+(11,26,l),
+(5,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(266,347,l),
+(269,364,l),
+(240,672,l),
+(208,631,l),
+(307,631,ls),
+(428,631,o),
+(491,571,o),
+(491,454,cs),
+(491,322,o),
+(424,83,o),
+(198,83,cs),
+(98,83,l),
+(117,45,l)
+);
+}
+);
+width = 599;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15E4;
+unicode = 5604;
+},
+{
+color = 9;
+glyphname = "tteeCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (300,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 598;
+}
+);
+note = uni15E5;
+unicode = 5605;
+},
+{
+color = 9;
+glyphname = "ttiCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (287,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 598;
+}
+);
+note = uni15E6;
+unicode = 5606;
+},
+{
+color = 9;
+glyphname = "ttaCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(488,0,l),
+(493,26,l),
+(461,387,l),
+(448,308,l),
+(634,688,l),
+(639,714,l),
+(455,714,ls),
+(157,714,o),
+(63,439,o),
+(63,254,cs),
+(63,91,o),
+(153,0,o),
+(318,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(437,83,l),
+(338,83,ls),
+(217,83,o),
+(154,143,o),
+(154,260,cs),
+(154,392,o),
+(220,631,o),
+(447,631,cs),
+(547,631,l),
+(527,669,l),
+(379,367,l),
+(375,350,l),
+(404,42,l)
+);
+}
+);
+width = 598;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tteCarrier-canadian";
+note = uni15E7;
+unicode = 5607;
+},
+{
+color = 9;
+glyphname = "puCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(419,-13,o),
+(505,68,o),
+(541,234,cs),
+(643,714,l),
+(549,714,l),
+(514,546,l),
+(216,546,l),
+(251,714,l),
+(158,714,l),
+(64,271,ls),
+(26,92,o),
+(106,-13,o),
+(275,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(169,74,o),
+(128,137,o),
+(155,264,cs),
+(198,463,l),
+(496,463,l),
+(449,244,ls),
+(424,125,o),
+(372,74,o),
+(281,74,cs)
+);
+}
+);
+width = 603;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E8;
+unicode = 5608;
+},
+{
+color = 9;
+glyphname = "poCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,0,l),
+(135,168,l),
+(433,168,l),
+(397,0,l),
+(491,0,l),
+(585,443,ls),
+(623,622,o),
+(542,727,o),
+(374,727,cs),
+(229,727,o),
+(143,646,o),
+(108,480,cs),
+(6,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,470,ls),
+(224,589,o),
+(277,640,o),
+(368,640,cs),
+(479,640,o),
+(520,577,o),
+(493,450,cs),
+(451,251,l),
+(152,251,l)
+);
+}
+);
+width = 603;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E9;
+unicode = 5609;
+},
+{
+color = 9;
+glyphname = "peCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (350,357);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(187.006,0,ls),
+(486,0,o),
+(579,277,o),
+(579,460,cs),
+(579,623,o),
+(489,714,o),
+(323,714,cs),
+(154,714,l),
+(137,631,l),
+(207,631,l),
+(91,83,l),
+(20,83,l),
+(2,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(308,672,l),
+(218,631,l),
+(304,631,ls),
+(425,631,o),
+(488,571,o),
+(488,454,cs),
+(488,323,o),
+(422,83,o),
+(195,83,cs),
+(102,83,l),
+(175,42,l)
+);
+}
+);
+width = 595;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15EA;
+unicode = 5610;
+},
+{
+color = 9;
+glyphname = "peeCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (288,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 595;
+}
+);
+note = uni15EB;
+unicode = 5611;
+},
+{
+color = 9;
+glyphname = "piCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (275,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 595;
+}
+);
+note = uni15EC;
+unicode = 5612;
+},
+{
+color = 9;
+glyphname = "paCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(487,0,l),
+(504,83,l),
+(434,83,l),
+(550,631,l),
+(621,631,l),
+(639,714,l),
+(454,714,ls),
+(155,714,o),
+(62,437,o),
+(62,254,cs),
+(62,91,o),
+(152,0,o),
+(318,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(423,83,l),
+(337,83,ls),
+(216,83,o),
+(153,143,o),
+(153,260,cs),
+(153,391,o),
+(219,631,o),
+(446,631,cs),
+(539,631,l),
+(466,672,l),
+(333,42,l)
+);
+}
+);
+width = 595;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|peCarrier-canadian";
+note = uni15ED;
+unicode = 5613;
+},
+{
+color = 6;
+glyphname = "pCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(308,189,l),
+(322,250,l),
+(219,250,l),
+(282,546,l),
+(218,546,l),
+(155,250,l),
+(53,250,l),
+(39,189,l)
+);
+}
+);
+width = 372;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni15EE;
+unicode = 5614;
+},
+{
+color = 9;
+glyphname = "guCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (454,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(253,-13,o),
+(311,32,o),
+(349,120,c),
+(314,120,l),
+(320,35,o),
+(368,-13,o),
+(450,-13,cs),
+(552,-13,o),
+(612,52,o),
+(639,181,cs),
+(752,714,l),
+(663,714,l),
+(550,183,ls),
+(535,109,o),
+(502,72,o),
+(449,72,cs),
+(394,72,o),
+(370,112,o),
+(386,185,cs),
+(498,714,l),
+(411,714,l),
+(299,184,ls),
+(283,110,o),
+(248,72,o),
+(194,72,cs),
+(139,72,o),
+(117,111,o),
+(133,186,cs),
+(245,714,l),
+(156,714,l),
+(45,189,ls),
+(18,64,o),
+(66,-13,o),
+(174,-13,cs)
+);
+}
+);
+width = 710;
+}
+);
+metricRight = "=|";
+note = uni15EF;
+unicode = 5615;
+},
+{
+color = 9;
+glyphname = "goCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(94,0,l),
+(206,531,ls),
+(222,605,o),
+(255,642,o),
+(307,642,cs),
+(362,642,o),
+(386,602,o),
+(371,529,cs),
+(258,0,l),
+(345,0,l),
+(457,530,ls),
+(473,604,o),
+(508,642,o),
+(562,642,cs),
+(616,642,o),
+(639,603,o),
+(623,528,cs),
+(511,0,l),
+(600,0,l),
+(711,525,ls),
+(738,650,o),
+(690,727,o),
+(582,727,cs),
+(503,727,o),
+(445,682,o),
+(407,594,c),
+(442,594,l),
+(436,679,o),
+(388,727,o),
+(306,727,cs),
+(204,727,o),
+(145,662,o),
+(118,533,cs),
+(4,0,l)
+);
+}
+);
+width = 710;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F0;
+unicode = 5616;
+},
+{
+color = 9;
+glyphname = "geCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (400,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(282,0,ls),
+(457,0,o),
+(526,108,o),
+(526,224,cs),
+(526,295,o),
+(491,349,o),
+(428,368,c),
+(423,336,l),
+(548,362,o),
+(596,457,o),
+(596,549,cs),
+(596,648,o),
+(527,714,o),
+(420,714,cs),
+(161,714,l),
+(145,636,l),
+(403,636,ls),
+(466,636,o),
+(503,599,o),
+(503,540,cs),
+(503,462,o),
+(459,395,o),
+(353,395,cs),
+(94,395,l),
+(77,319,l),
+(337,319,ls),
+(401,319,o),
+(436,287,o),
+(436,229,cs),
+(436,175,o),
+(416,78,o),
+(287,78,cs),
+(26,78,l),
+(10,0,l)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15F1;
+unicode = 5617;
+},
+{
+color = 9;
+glyphname = "geeCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(282,0,ls),
+(457,0,o),
+(526,108,o),
+(526,224,cs),
+(526,295,o),
+(491,349,o),
+(428,368,c),
+(423,336,l),
+(548,362,o),
+(596,457,o),
+(596,549,cs),
+(596,648,o),
+(527,714,o),
+(420,714,cs),
+(161,714,l),
+(145,636,l),
+(403,636,ls),
+(466,636,o),
+(503,599,o),
+(503,540,cs),
+(503,462,o),
+(459,395,o),
+(353,395,cs),
+(322,395,l),
+(340,479,l),
+(284,479,l),
+(266,395,l),
+(94,395,l),
+(77,319,l),
+(250,319,l),
+(232,237,l),
+(288,237,l),
+(306,319,l),
+(337,319,ls),
+(401,319,o),
+(436,287,o),
+(436,229,cs),
+(436,175,o),
+(416,78,o),
+(287,78,cs),
+(26,78,l),
+(10,0,l)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F2;
+unicode = 5618;
+},
+{
+color = 9;
+glyphname = "giCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(282,0,ls),
+(457,0,o),
+(526,108,o),
+(526,224,cs),
+(526,295,o),
+(492,348,o),
+(428,368,c),
+(424,336,l),
+(548,362,o),
+(596,458,o),
+(596,549,cs),
+(596,648,o),
+(527,714,o),
+(420,714,cs),
+(161,714,l),
+(145,636,l),
+(403,636,ls),
+(466,636,o),
+(503,599,o),
+(503,540,cs),
+(503,462,o),
+(459,395,o),
+(353,395,cs),
+(335,395,l),
+(361,370,l),
+(357,405,o),
+(327,432,o),
+(289,432,cs),
+(262,432,o),
+(239,417,o),
+(228,395,c),
+(94,395,l),
+(77,319,l),
+(228,319,l),
+(239,297,o),
+(262,282,o),
+(289,282,cs),
+(326,282,o),
+(356,309,o),
+(360,344,c),
+(322,319,l),
+(337,319,ls),
+(401,319,o),
+(436,287,o),
+(436,229,cs),
+(436,175,o),
+(416,78,o),
+(287,78,cs),
+(26,78,l),
+(10,0,l)
+);
+}
+);
+width = 595;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F3;
+unicode = 5619;
+},
+{
+color = 9;
+glyphname = "gaCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (410,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(481,0,l),
+(498,78,l),
+(239,78,ls),
+(176,78,o),
+(139,115,o),
+(139,174,cs),
+(139,252,o),
+(184,319,o),
+(289,319,cs),
+(550,319,l),
+(566,395,l),
+(306,395,ls),
+(241,395,o),
+(206,427,o),
+(206,485,cs),
+(206,539,o),
+(226,636,o),
+(355,636,cs),
+(616,636,l),
+(632,714,l),
+(361,714,ls),
+(186,714,o),
+(116,606,o),
+(116,490,cs),
+(116,419,o),
+(151,365,o),
+(214,346,c),
+(219,378,l),
+(95,352,o),
+(46,257,o),
+(46,165,cs),
+(46,66,o),
+(115,0,o),
+(222,0,cs)
+);
+}
+);
+width = 597;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|geCarrier-canadian";
+note = uni15F4;
+unicode = 5620;
+},
+{
+color = 9;
+glyphname = "khuCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(249,-13,o),
+(306,27,o),
+(343,108,c),
+(315,110,l),
+(324,31,o),
+(372,-13,o),
+(450,-13,cs),
+(552,-13,o),
+(612,52,o),
+(639,181,cs),
+(752,714,l),
+(156,714,l),
+(45,189,ls),
+(18,64,o),
+(66,-13,o),
+(174,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(139,72,o),
+(117,111,o),
+(133,186,cs),
+(228,632,l),
+(394,632,l),
+(299,184,ls),
+(283,110,o),
+(248,72,o),
+(194,72,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(394,72,o),
+(370,112,o),
+(386,185,cs),
+(481,632,l),
+(645,632,l),
+(550,183,ls),
+(535,109,o),
+(502,72,o),
+(449,72,cs)
+);
+}
+);
+width = 710;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F5;
+unicode = 5621;
+},
+{
+color = 9;
+glyphname = "khoCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(600,0,l),
+(711,525,ls),
+(738,650,o),
+(690,727,o),
+(582,727,cs),
+(507,727,o),
+(450,687,o),
+(413,606,c),
+(441,604,l),
+(432,683,o),
+(384,727,o),
+(306,727,cs),
+(204,727,o),
+(145,662,o),
+(118,533,cs),
+(4,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(206,531,ls),
+(221,605,o),
+(254,642,o),
+(307,642,cs),
+(362,642,o),
+(386,602,o),
+(370,529,cs),
+(275,82,l),
+(111,82,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(457,530,ls),
+(473,604,o),
+(508,642,o),
+(562,642,cs),
+(616,642,o),
+(639,603,o),
+(623,528,cs),
+(528,82,l),
+(362,82,l)
+);
+}
+);
+width = 710;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F6;
+unicode = 5622;
+},
+{
+color = 9;
+glyphname = "kheCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(285,0,ls),
+(460,0,o),
+(530,107,o),
+(530,223,cs),
+(530,294,o),
+(496,346,o),
+(433,367,c),
+(431,337,l),
+(562,366,o),
+(599,468,o),
+(599,549,cs),
+(599,648,o),
+(530,714,o),
+(422,714,cs),
+(160.996,714,l),
+(8.996,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(169,319,l),
+(340,319,ls),
+(405,319,o),
+(440,287,o),
+(440,229,cs),
+(440,173,o),
+(418,77,o),
+(290,77,cs),
+(118,77,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(237,637,l),
+(407,637,ls),
+(470,637,o),
+(506,599,o),
+(506,540,cs),
+(506,467,o),
+(466.994,394.992,o),
+(356,395,cs),
+(186,395,l)
+);
+}
+);
+width = 599;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F7;
+unicode = 5623;
+},
+{
+color = 9;
+glyphname = "kheeCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(285,0,ls),
+(460,0,o),
+(530,107,o),
+(530,223,cs),
+(530,294,o),
+(496,346,o),
+(433,367,c),
+(431,337,l),
+(562,366,o),
+(599,468,o),
+(599,549,cs),
+(599,648,o),
+(530,714,o),
+(422,714,cs),
+(160.996,714,l),
+(8.996,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(169,319,l),
+(277,319,l),
+(258,232,l),
+(311,232,l),
+(333,337,l),
+(305,319,l),
+(340,319,ls),
+(405,319,o),
+(440,287,o),
+(440,229,cs),
+(440,173,o),
+(418,77,o),
+(290,77,cs),
+(118,77,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(364,484,l),
+(312,484,l),
+(293,395,l),
+(186,395,l),
+(237,637,l),
+(407,637,ls),
+(470,637,o),
+(506,599,o),
+(506,540,cs),
+(506,467,o),
+(467,395,o),
+(356,395,cs),
+(322,395,l),
+(342,377,l)
+);
+}
+);
+width = 599;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F8;
+unicode = 5624;
+},
+{
+color = 9;
+glyphname = "khiCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(285,0,ls),
+(460,0,o),
+(530,107,o),
+(530,223,cs),
+(530,292,o),
+(498,343,o),
+(439,366,c),
+(428,336,l),
+(561,365,o),
+(599,468,o),
+(599,549,cs),
+(599,648,o),
+(530,714,o),
+(422,714,cs),
+(160.996,714,l),
+(8.996,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(170,323,l),
+(250,323,l),
+(260,299,o),
+(285,282,o),
+(313,282,cs),
+(350,282,o),
+(380,313,o),
+(383,351,c),
+(321,323,l),
+(344,323,ls),
+(409,323,o),
+(440,290,o),
+(440,231,cs),
+(440,174,o),
+(418,77,o),
+(290,77,cs),
+(118,77,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(407,637,ls),
+(470,637,o),
+(506,598,o),
+(506,538,cs),
+(506,465,o),
+(471,391,o),
+(360,391,cs),
+(331,391,l),
+(384,363,l),
+(381,402,o),
+(351,432,o),
+(313,432,cs),
+(275,432,o),
+(244,402,o),
+(242,363,c),
+(267,391,l),
+(185,391,l),
+(237,637,l)
+);
+}
+);
+width = 599;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F9;
+unicode = 5625;
+},
+{
+color = 9;
+glyphname = "khaCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(485,0,l),
+(637,714,l),
+(361,714,ls),
+(186,714,o),
+(116,607,o),
+(116,491,cs),
+(116,420,o),
+(151,368,o),
+(213,347,c),
+(215,377,l),
+(84,348,o),
+(46,246,o),
+(46,165,cs),
+(46,66,o),
+(115,0,o),
+(223,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(175,77,o),
+(139,115,o),
+(139,174,cs),
+(139,247,o),
+(179,319,o),
+(290,319,cs),
+(461,319,l),
+(409,77,l),
+(238,77,ls)
+);
+},
+{
+closed = 1;
+nodes = (
+(242,395,o),
+(207,427,o),
+(207,485,cs),
+(207,541,o),
+(229,637,o),
+(356,637,cs),
+(528,637,l),
+(477,395,l),
+(306,395,ls)
+);
+}
+);
+width = 600;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15FA;
+unicode = 5626;
+},
+{
+color = 9;
+glyphname = "kkuCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(249,-13,o),
+(305,27,o),
+(343,108,c),
+(315,108,l),
+(324,31,o),
+(372,-13,o),
+(450,-13,cs),
+(552,-13,o),
+(611,52,o),
+(639,181,cs),
+(752,714,l),
+(721,714,l),
+(445,555,l),
+(427,459,l),
+(673,602,l),
+(645,631,l),
+(550,183,ls),
+(535,109,o),
+(502,72,o),
+(449,72,cs),
+(394,72,o),
+(370,114,o),
+(385,185,cs),
+(497,714,l),
+(412,714,l),
+(299,184,ls),
+(284,110,o),
+(248,72,o),
+(194,72,cs),
+(139,72,o),
+(117,111,o),
+(133,186,cs),
+(227,631,l),
+(185,618,l),
+(371,472,l),
+(389,557,l),
+(188,714,l),
+(156,714,l),
+(45,189,ls),
+(18,63,o),
+(66,-13,o),
+(174,-13,cs)
+);
+}
+);
+width = 710;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FB;
+unicode = 5627;
+},
+{
+color = 9;
+glyphname = "kkoCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(36,0,l),
+(310,159,l),
+(329,255,l),
+(83,112,l),
+(111,83,l),
+(206,531,ls),
+(222,605,o),
+(254,642,o),
+(307,642,cs),
+(362,642,o),
+(386,600,o),
+(371,529,cs),
+(259,0,l),
+(344,0,l),
+(456,530,ls),
+(472,604,o),
+(508,642,o),
+(562,642,cs),
+(616,642,o),
+(639,603,o),
+(623,528,cs),
+(528,83,l),
+(570,96,l),
+(385,242,l),
+(367,157,l),
+(568,0,l),
+(600,0,l),
+(711,525,ls),
+(738,651,o),
+(690,727,o),
+(582,727,cs),
+(507,727,o),
+(450,687,o),
+(413,606,c),
+(441,606,l),
+(432,683,o),
+(384,727,o),
+(306,727,cs),
+(204,727,o),
+(145,662,o),
+(118,533,cs),
+(4,0,l)
+);
+}
+);
+width = 710;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FC;
+unicode = 5628;
+},
+{
+color = 9;
+glyphname = "kkeCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(299,0,ls),
+(474,0,o),
+(544,108,o),
+(544,224,cs),
+(544,295,o),
+(510,346,o),
+(447,367,c),
+(444,337,l),
+(575,366,o),
+(613,468,o),
+(613,549,cs),
+(613,648,o),
+(544,714,o),
+(437,714,cs),
+(160,714,l),
+(154,688,l),
+(180,395,l),
+(97,395,l),
+(81,319,l),
+(159,319,l),
+(14,26,l),
+(8,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(253,319,l),
+(354,319,ls),
+(418,319,o),
+(453,287,o),
+(453,229,cs),
+(453,176,o),
+(433,78,o),
+(304,78,cs),
+(94,78,l),
+(115,40,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(241,678,l),
+(206,636,l),
+(421,636,ls),
+(484,636,o),
+(520,599,o),
+(520,540,cs),
+(520,462,o),
+(476,395,o),
+(370,395,cs),
+(268,395,l)
+);
+}
+);
+width = 613;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni15FD;
+unicode = 5629;
+},
+{
+color = 9;
+glyphname = "kkeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(299,0,ls),
+(474,0,o),
+(544,108,o),
+(544,224,cs),
+(544,295,o),
+(510,346,o),
+(447,367,c),
+(444,337,l),
+(575,366,o),
+(613,468,o),
+(613,549,cs),
+(613,648,o),
+(544,714,o),
+(437,714,cs),
+(160,714,l),
+(154,688,l),
+(180,395,l),
+(97,395,l),
+(81,319,l),
+(159,319,l),
+(14,26,l),
+(8,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(254,322,l),
+(310,322,l),
+(292,232,l),
+(344,232,l),
+(367,341,l),
+(338,322,l),
+(362,322,ls),
+(422,322,o),
+(453,287,o),
+(453,229,cs),
+(453,176,o),
+(433,78,o),
+(304,78,cs),
+(94,78,l),
+(115,40,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(398,484,l),
+(345,484,l),
+(326,393,l),
+(268,393,l),
+(241,678,l),
+(206,636,l),
+(421,636,ls),
+(484,636,o),
+(520,599,o),
+(520,540,cs),
+(520,462,o),
+(476,393,o),
+(374,393,cs),
+(352,393,l),
+(376,378,l)
+);
+}
+);
+width = 613;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FE;
+unicode = 5630;
+},
+{
+color = 9;
+glyphname = "kkiCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(299,0,ls),
+(474,0,o),
+(544,108,o),
+(544,224,cs),
+(544,295,o),
+(510,346,o),
+(447,367,c),
+(444,337,l),
+(575,366,o),
+(613,468,o),
+(613,549,cs),
+(613,648,o),
+(544,714,o),
+(437,714,cs),
+(160,714,l),
+(154,688,l),
+(180,395,l),
+(97,395,l),
+(81,319,l),
+(159,319,l),
+(14,26,l),
+(8,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(256,325,l),
+(274,325,l),
+(284,299,o),
+(308,282,o),
+(337,282,cs),
+(368,282,o),
+(393,303,o),
+(401,332,c),
+(337,325,l),
+(362,325,ls),
+(427,325,o),
+(453,287,o),
+(453,229,cs),
+(453,176,o),
+(433,78,o),
+(304,78,cs),
+(94,78,l),
+(115,40,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(397,410,o),
+(370,432,o),
+(337,432,cs),
+(308,432,o),
+(284,415,o),
+(274,389,c),
+(269,389,l),
+(241,678,l),
+(206,636,l),
+(421,636,ls),
+(484,636,o),
+(520,599,o),
+(520,540,cs),
+(520,462,o),
+(480,389,o),
+(374,389,cs),
+(338,389,l),
+(403,377,l)
+);
+}
+);
+width = 613;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FF;
+unicode = 5631;
+},
+{
+color = 9;
+glyphname = "kkaCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(500,0,l),
+(505,26,l),
+(479,319,l),
+(563,319,l),
+(579,395,l),
+(500,395,l),
+(646,688,l),
+(652,714,l),
+(361,714,ls),
+(186,714,o),
+(116,606,o),
+(116,490,cs),
+(116,419,o),
+(150,368,o),
+(213,347,c),
+(215,377,l),
+(84,348,o),
+(46,246,o),
+(46,165,cs),
+(46,66,o),
+(115,0,o),
+(222,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(454,78,l),
+(239,78,ls),
+(176,78,o),
+(139,115,o),
+(139,174,cs),
+(139,252,o),
+(184,319,o),
+(290,319,cs),
+(391,319,l),
+(418,36,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(241,395,o),
+(206,427,o),
+(206,485,cs),
+(206,538,o),
+(226,636,o),
+(355,636,cs),
+(565,636,l),
+(545,674,l),
+(406,395,l),
+(306,395,ls)
+);
+}
+);
+width = 613;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|kkeCarrier-canadian";
+note = uni1600;
+unicode = 5632;
+},
+{
+color = 6;
+glyphname = "kkCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(304,546,l),
+(147,260,l),
+(188,260,l),
+(152,546,l),
+(95,546,l),
+(92,532,l),
+(147,189,l),
+(163,189,l),
+(365,532,l),
+(367,546,l)
+);
+}
+);
+width = 336;
+}
+);
+note = uni1601;
+unicode = 5633;
+},
+{
+color = 9;
+glyphname = "nuCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(414,-13,o),
+(508,78,o),
+(544,245,cs),
+(558,312,l),
+(466,312,l),
+(452,249,ls),
+(428,132,o),
+(369,74,o),
+(276,73,cs),
+(174,73,o),
+(130,141,o),
+(156,261,cs),
+(252,714,l),
+(159,714,l),
+(63,267,ls),
+(28,97,o),
+(107,-13,o),
+(269,-13,cs)
+);
+}
+);
+width = 597;
+}
+);
+metricLeft = "te-canadian";
+note = uni1602;
+unicode = 5634;
+},
+{
+color = 9;
+glyphname = "noCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(484,0,l),
+(579,447,ls),
+(615,617,o),
+(536,727,o),
+(374,727,cs),
+(229,727,o),
+(135,636,o),
+(99,469,cs),
+(85,402,l),
+(177,402,l),
+(191,465,ls),
+(215,582,o),
+(274,640,o),
+(367,641,cs),
+(469,641,o),
+(513,573,o),
+(487,453,cs),
+(391,0,l)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "=|nuCarrier-canadian";
+metricRight = "te-canadian";
+note = uni1603;
+unicode = 5635;
+},
+{
+color = 9;
+glyphname = "neCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (276,357);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(192,0,ls),
+(468,0,o),
+(571,257,o),
+(571,457,cs),
+(571.006,623,o),
+(479,714,o),
+(311,714,cs),
+(140,714,l),
+(122,628,l),
+(295,628,ls),
+(417,628,o),
+(478,570,o),
+(478,452,cs),
+(478,321,o),
+(418,86,o),
+(201,86,cs),
+(191,86,l),
+(173,0,l)
+);
+}
+);
+width = 588;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1604;
+unicode = 5636;
+},
+{
+color = 9;
+glyphname = "neeCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "neCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (206,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 588;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1605;
+unicode = 5637;
+},
+{
+color = 9;
+glyphname = "niCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "neCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (184,0);
+ref = dot_middle;
+}
+);
+width = 588;
+}
+);
+note = uni1606;
+unicode = 5638;
+},
+{
+color = 9;
+glyphname = "naCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(495,0,l),
+(513,86,l),
+(340,86,ls),
+(218,86,o),
+(157,144,o),
+(157,262,cs),
+(157,393,o),
+(217,628,o),
+(434,628,cs),
+(444,628,l),
+(462,714,l),
+(443,714,ls),
+(167,714,o),
+(64,457,o),
+(64,257,cs),
+(64,91,o),
+(156,0,o),
+(324,0,cs)
+);
+}
+);
+width = 589;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni1607;
+unicode = 5639;
+},
+{
+color = 9;
+glyphname = "muCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(253,-13,o),
+(311,31,o),
+(349,120,c),
+(314,120,l),
+(320,35,o),
+(368,-13,o),
+(450,-13,cs),
+(552,-13,o),
+(611,52,o),
+(639,181,cs),
+(686,404,l),
+(597,404,l),
+(550,183,ls),
+(534,109,o),
+(501,72,o),
+(449,72,cs),
+(394,72,o),
+(370,113,o),
+(386,185,cs),
+(432,404,l),
+(345,404,l),
+(299,184,ls),
+(283,110,o),
+(248,72,o),
+(194,72,cs),
+(140,72,o),
+(117,111,o),
+(133,186,cs),
+(245,714,l),
+(156,714,l),
+(45,189,ls),
+(18,63,o),
+(66,-13,o),
+(174,-13,cs)
+);
+}
+);
+width = 710;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "=|";
+note = uni1608;
+unicode = 5640;
+},
+{
+color = 9;
+glyphname = "moCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(600,0,l),
+(711,525,ls),
+(738,651,o),
+(690,727,o),
+(582,727,cs),
+(503,727,o),
+(445,683,o),
+(407,594,c),
+(442,594,l),
+(436,679,o),
+(388,727,o),
+(306,727,cs),
+(204,727,o),
+(145,662,o),
+(118,533,cs),
+(70,310,l),
+(160,310,l),
+(207,531,ls),
+(222,605,o),
+(255,642,o),
+(307,642,cs),
+(362,642,o),
+(386,601,o),
+(370,529,cs),
+(324,310,l),
+(411,310,l),
+(457,530,ls),
+(473,604,o),
+(508,642,o),
+(562,642,cs),
+(616,642,o),
+(639,603,o),
+(623,528,cs),
+(511,0,l)
+);
+}
+);
+width = 710;
+}
+);
+metricLeft = "=|muCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni1609;
+unicode = 5641;
+},
+{
+color = 9;
+glyphname = "meCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(282,0,ls),
+(457,0,o),
+(527,108,o),
+(527,224,cs),
+(527,295,o),
+(492,349,o),
+(428,368,c),
+(424,336,l),
+(548,362,o),
+(596,457,o),
+(596,549,cs),
+(596,648,o),
+(527,714,o),
+(421,714,cs),
+(140,714,l),
+(124,636,l),
+(404,636,ls),
+(467,636,o),
+(503,599,o),
+(503,540,cs),
+(503,462,o),
+(459,395,o),
+(353,395,cs),
+(269,395,l),
+(253,319,l),
+(337,319,ls),
+(401,319,o),
+(436,287,o),
+(436,229,cs),
+(436,175,o),
+(417,78,o),
+(287,78,cs),
+(202,78,l),
+(186,0,l)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160A;
+unicode = 5642;
+},
+{
+color = 9;
+glyphname = "meeCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(282,0,ls),
+(457,0,o),
+(527,108,o),
+(527,224,cs),
+(527,295,o),
+(492,349,o),
+(428,368,c),
+(424,336,l),
+(548,362,o),
+(596,457,o),
+(596,549,cs),
+(596,648,o),
+(527,714,o),
+(421,714,cs),
+(140,714,l),
+(124,636,l),
+(404,636,ls),
+(467,636,o),
+(503,599,o),
+(503,540,cs),
+(503,462,o),
+(459,394,o),
+(355,394,cs),
+(325,394,l),
+(344,480,l),
+(287,480,l),
+(235,236,l),
+(292,236,l),
+(310,320,l),
+(340,320,ls),
+(402,320,o),
+(436,287,o),
+(436,229,cs),
+(436,175,o),
+(417,78,o),
+(287,78,cs),
+(202,78,l),
+(186,0,l)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160B;
+unicode = 5643;
+},
+{
+color = 9;
+glyphname = "miCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(282,0,ls),
+(452,0,o),
+(514,99,o),
+(525,203,cs),
+(533,284,o),
+(498,345,o),
+(428,368,c),
+(424,336,l),
+(541,360,o),
+(586,445,o),
+(594,528,cs),
+(606,637,o),
+(537,714,o),
+(421,714,cs),
+(140,714,l),
+(124,636,l),
+(404,636,ls),
+(469,636,o),
+(506,596,o),
+(502,532,cs),
+(499,456,o),
+(455,394,o),
+(353,394,cs),
+(317,394,l),
+(367,367,l),
+(363,404,o),
+(333,432,o),
+(295,432,cs),
+(254,432,o),
+(222,398,o),
+(222,357,cs),
+(222,316,o),
+(254,282,o),
+(295,282,cs),
+(333,282,o),
+(362,311,o),
+(367,347,c),
+(316,320,l),
+(338,320,ls),
+(405,320,o),
+(440,285,o),
+(436,221,cs),
+(432,163,o),
+(407,78,o),
+(287,78,cs),
+(202,78,l),
+(186,0,l)
+);
+}
+);
+width = 594;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160C;
+unicode = 5644;
+},
+{
+color = 9;
+glyphname = "maCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(503,0,l),
+(520,78,l),
+(239,78,ls),
+(176,78,o),
+(139,115,o),
+(139,174,cs),
+(139,252,o),
+(184,319,o),
+(289,319,cs),
+(373,319,l),
+(390,395,l),
+(306,395,ls),
+(241,395,o),
+(206,427,o),
+(206,485,cs),
+(206,539,o),
+(226,636,o),
+(355,636,cs),
+(441,636,l),
+(457,714,l),
+(361,714,ls),
+(186,714,o),
+(116,606,o),
+(116,490,cs),
+(116,419,o),
+(151,365,o),
+(214,346,c),
+(219,378,l),
+(95,352,o),
+(46,257,o),
+(46,165,cs),
+(46,66,o),
+(115,0,o),
+(222,0,cs)
+);
+}
+);
+width = 597;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni160D;
+unicode = 5645;
+},
+{
+color = 9;
+glyphname = "yuCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(445,-13,o),
+(555,110,o),
+(611,374,cs),
+(659,603,o),
+(624,727,o),
+(502,727,cs),
+(363,727,o),
+(314,556,o),
+(314,460,cs),
+(314,374,o),
+(357,318,o),
+(427,318,cs),
+(441,318,o),
+(453,320,o),
+(462,325,c),
+(477,398,l),
+(469,395,o),
+(461,393,o),
+(452,393,cs),
+(414,393,o),
+(394,420,o),
+(394,468,cs),
+(394,519,o),
+(419,652,o),
+(491,652,cs),
+(555,652,o),
+(564,571,o),
+(529,400,cs),
+(480,169,o),
+(408,74,o),
+(278,74,cs),
+(170,74,o),
+(129,138,o),
+(155,260,cs),
+(251,714,l),
+(158,714,l),
+(63,267,ls),
+(27,96,o),
+(105,-13,o),
+(270,-13,cs)
+);
+}
+);
+width = 643;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160E;
+unicode = 5646;
+},
+{
+color = 9;
+glyphname = "yoCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(327,-13,o),
+(376,158,o),
+(376,254,cs),
+(376,340,o),
+(334,396,o),
+(264,396,cs),
+(250,396,o),
+(237,394,o),
+(228,389,c),
+(213,316,l),
+(222,319,o),
+(230,321,o),
+(239,321,cs),
+(276,321,o),
+(296,294,o),
+(296,246,cs),
+(296,195,o),
+(271,62,o),
+(199,62,cs),
+(136,62,o),
+(126,143,o),
+(162,314,cs),
+(210,545,o),
+(282,640,o),
+(413,640,cs),
+(521,640,o),
+(562,576,o),
+(536,454,cs),
+(439,0,l),
+(533,0,l),
+(628,447,ls),
+(663,618,o),
+(585,727,o),
+(420,727,cs),
+(245,727,o),
+(135,604,o),
+(79,340,cs),
+(31,111,o),
+(66,-13,o),
+(188,-13,cs)
+);
+}
+);
+width = 645;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160F;
+unicode = 5647;
+},
+{
+color = 9;
+glyphname = "yeCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(472,-13,o),
+(564,276,o),
+(564,445,cs),
+(564,622,o),
+(474,714,o),
+(307,714,cs),
+(157,714,l),
+(139,628,l),
+(293,628,ls),
+(410,628,o),
+(470,566,o),
+(470,438,cs),
+(470,316,o),
+(416,67,o),
+(239,67,cs),
+(160,67,o),
+(116,110,o),
+(116,187,cs),
+(116,240,o),
+(139,346,o),
+(211,346,cs),
+(247,346,o),
+(265,321,o),
+(265,273,cs),
+(265,237,o),
+(255,198,o),
+(243,162,c),
+(313,162,l),
+(328,202,o),
+(339,247,o),
+(339,287,cs),
+(339,370,o),
+(293,422,o),
+(216,422,cs),
+(87,422,o),
+(36,275,o),
+(36,177,cs),
+(36,61,o),
+(111,-13,o),
+(235,-13,cs)
+);
+}
+);
+width = 583;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1610;
+unicode = 5648;
+},
+{
+color = 9;
+glyphname = "yeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(473,-13,o),
+(565,281,o),
+(565,451,cs),
+(565,622,o),
+(473,714,o),
+(309,714,cs),
+(157,714,l),
+(139,628,l),
+(293,628,ls),
+(410,628,o),
+(470,566,o),
+(470,443,cs),
+(470,321,o),
+(416,67,o),
+(239,67,cs),
+(160,67,o),
+(116,109,o),
+(116,187,cs),
+(116,238,o),
+(140,346,o),
+(209,346,cs),
+(251,346,o),
+(267,306,o),
+(253,240,cs),
+(241,185,l),
+(298,185,l),
+(368,515,l),
+(312,515,l),
+(269,314,l),
+(281,314,l),
+(289,379,o),
+(255,422,o),
+(197,422,cs),
+(84,422,o),
+(37,274,o),
+(37,182,cs),
+(37,63,o),
+(110,-13,o),
+(239,-13,cs)
+);
+}
+);
+width = 583;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1611;
+unicode = 5649;
+},
+{
+color = 9;
+glyphname = "yiCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(474,-13,o),
+(565,279,o),
+(565,451,cs),
+(565,622,o),
+(474,714,o),
+(309,714,cs),
+(157,714,l),
+(139,628,l),
+(293,628,ls),
+(410,628,o),
+(470,566,o),
+(470,443,cs),
+(470,318,o),
+(416,67,o),
+(239,67,cs),
+(158,67,o),
+(115,111,o),
+(115,185,cs),
+(115,251,o),
+(141,333,o),
+(220,330,c),
+(198,356,l),
+(199,317,o),
+(232,288,o),
+(270,288,cs),
+(310,288,o),
+(341,319,o),
+(341,358,cs),
+(341,396,o),
+(310,427,o),
+(270,427,cs),
+(242,427,o),
+(219,412,o),
+(207,390,c),
+(91,385,o),
+(35,274,o),
+(35,174,cs),
+(35,61,o),
+(112,-13,o),
+(234,-13,cs)
+);
+}
+);
+width = 583;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1612;
+unicode = 5650;
+},
+{
+color = 9;
+glyphname = "yaCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(473,0,l),
+(491,86,l),
+(337,86,ls),
+(220,86,o),
+(160,148,o),
+(160,276,cs),
+(160,398,o),
+(214,647,o),
+(391,647,cs),
+(470,647,o),
+(514,604,o),
+(514,527,cs),
+(514,474,o),
+(491,368,o),
+(418,368,cs),
+(383,368,o),
+(365,393,o),
+(365,441,cs),
+(365,479,o),
+(374,516,o),
+(387,552,c),
+(316,552,l),
+(302,512,o),
+(291,467,o),
+(291,427,cs),
+(291,344,o),
+(336,292,o),
+(414,292,cs),
+(542,292,o),
+(594,439,o),
+(594,537,cs),
+(594,653,o),
+(519,727,o),
+(395,727,cs),
+(158,727,o),
+(65,438,o),
+(65,269,cs),
+(65,92,o),
+(155,0,o),
+(323,0,cs)
+);
+}
+);
+width = 583;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|yeCarrier-canadian";
+note = uni1613;
+unicode = 5651;
+},
+{
+color = 9;
+glyphname = "juCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(469,-13,o),
+(547,137,o),
+(547,266,cs),
+(547,360,o),
+(498,422,o),
+(417,422,cs),
+(321,422,o),
+(271,340,o),
+(257,236,cs),
+(253,208,o),
+(252,180,o),
+(253,162,c),
+(323,162,l),
+(323,179,o),
+(323,205,o),
+(330,239,cs),
+(344,305,o),
+(371,346,o),
+(413,346,cs),
+(449,346,o),
+(469,316,o),
+(469,265,cs),
+(469,181,o),
+(427,67,o),
+(301,67,cs),
+(205,67,o),
+(155,125,o),
+(155,230,cs),
+(155,380,o),
+(246,628,o),
+(537,628,cs),
+(619,628,l),
+(638,714,l),
+(149,714,l),
+(131,631,l),
+(388,631,l),
+(449,663,l),
+(196,655,o),
+(63,441,o),
+(63,231,cs),
+(63,81,o),
+(149,-13,o),
+(293,-13,cs)
+);
+}
+);
+width = 594;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni1614;
+unicode = 5652;
+},
+{
+color = 9;
+glyphname = "juSayisi-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (414,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,-13,o),
+(538,189,o),
+(554,362,cs),
+(570,544,o),
+(479,659,o),
+(300,669,c),
+(366,631,l),
+(625,631,l),
+(642,714,l),
+(153,714,l),
+(135,628,l),
+(212,628,ls),
+(397,628,o),
+(478,542,o),
+(463,373,cs),
+(454,249,o),
+(402,67,o),
+(245,67,cs),
+(156,67,o),
+(109,116,o),
+(115,201,cs),
+(118,256,o),
+(144,346,o),
+(206,346,cs),
+(244,346,o),
+(260,317,o),
+(257,263,cs),
+(257,233,o),
+(248,191,o),
+(237,162,c),
+(307,162,l),
+(320,198,o),
+(329,235,o),
+(331,272,cs),
+(339,364,o),
+(295,422,o),
+(212,422,cs),
+(102,422,o),
+(47,304,o),
+(37,207,cs),
+(24,76,o),
+(104,-13,o),
+(243,-13,cs)
+);
+}
+);
+width = 592;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1615;
+unicode = 5653;
+},
+{
+color = 9;
+glyphname = "joCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(492,0,l),
+(510,83,l),
+(253,83,l),
+(192,51,l),
+(445,59,o),
+(578,273,o),
+(578,483,cs),
+(578,633,o),
+(492,727,o),
+(348,727,cs),
+(172,727,o),
+(94,577,o),
+(94,448,cs),
+(94,354,o),
+(143,292,o),
+(224,292,cs),
+(320,292,o),
+(370,374,o),
+(384,478,cs),
+(388,506,o),
+(389,534,o),
+(388,552,c),
+(318,552,l),
+(318,535,o),
+(318,509,o),
+(311,475,cs),
+(297,409,o),
+(270,368,o),
+(228,368,cs),
+(192,368,o),
+(172,398,o),
+(172,449,cs),
+(172,533,o),
+(214,647,o),
+(340,647,cs),
+(436,647,o),
+(486,589,o),
+(486,484,cs),
+(486,334,o),
+(395,86,o),
+(104,86,cs),
+(22,86,l),
+(3,0,l)
+);
+}
+);
+width = 594;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1616;
+unicode = 5654;
+},
+{
+color = 9;
+glyphname = "jeCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(562,-13,o),
+(614,325,o),
+(614,470,cs),
+(614,631,o),
+(551,727,o),
+(430,727,cs),
+(316,727,o),
+(234,644,o),
+(184,477,c),
+(203,476,l),
+(254,714,l),
+(160.996,714,l),
+(8.996,0,l),
+(102,0,l),
+(169,313,ls),
+(215,533,o),
+(293,641,o),
+(405,641,cs),
+(488,641,o),
+(526,584,o),
+(526,467,cs),
+(526,378,o),
+(490,62,o),
+(382,62,cs),
+(345,62,o),
+(326,88,o),
+(326,136,cs),
+(326,197,o),
+(354,321,o),
+(437,321,cs),
+(448,321,o),
+(458,319,o),
+(464,316,c),
+(477,389,l),
+(465,394,o),
+(449,396,o),
+(432,396,cs),
+(297,396,o),
+(248,231,o),
+(248,133,cs),
+(248,42,o),
+(294,-13,o),
+(375,-13,cs)
+);
+}
+);
+width = 646;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "te-canadian";
+note = uni1617;
+unicode = 5655;
+},
+{
+color = 9;
+glyphname = "jeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(562,-13,o),
+(614,327,o),
+(614,469,cs),
+(614,631,o),
+(551,727,o),
+(430,727,cs),
+(316,727,o),
+(234,644,o),
+(184,477,c),
+(203,476,l),
+(254,714,l),
+(160.996,714,l),
+(8.996,0,l),
+(102,0,l),
+(167,305,ls),
+(216,535,o),
+(291,641,o),
+(404,641,cs),
+(488,641,o),
+(526,583,o),
+(526,466,cs),
+(526,349,o),
+(488,62,o),
+(368,62,cs),
+(321,62,o),
+(296,94,o),
+(296,150,cs),
+(296,207,o),
+(320,309,o),
+(387,330,c),
+(369,244,l),
+(417,244,l),
+(463,464,l),
+(416,464,l),
+(398,382,l),
+(287,360,o),
+(247,215,o),
+(247,131,cs),
+(247,41,o),
+(294,-13,o),
+(375,-13,cs)
+);
+}
+);
+width = 646;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1618;
+unicode = 5656;
+},
+{
+color = 9;
+glyphname = "jiCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(562,-13,o),
+(614,327,o),
+(614,469,cs),
+(614,631,o),
+(551,727,o),
+(430,727,cs),
+(316,727,o),
+(234,644,o),
+(184,477,c),
+(203,476,l),
+(254,714,l),
+(160.996,714,l),
+(8.996,0,l),
+(102,0,l),
+(167,305,ls),
+(216,535,o),
+(291,641,o),
+(404,641,cs),
+(488,641,o),
+(526,583,o),
+(526,466,cs),
+(526,349,o),
+(488,62,o),
+(368,62,cs),
+(321,62,o),
+(296,94,o),
+(296,150,cs),
+(296,198,o),
+(313,278,o),
+(361,309,c),
+(370,295,o),
+(386,285,o),
+(405,285,cs),
+(442,285,o),
+(470,315,o),
+(470,354,cs),
+(470,392,o),
+(442,422,o),
+(405,422,cs),
+(366,422,o),
+(338,386,o),
+(342,349,c),
+(272,305,o),
+(247,198,o),
+(247,131,cs),
+(247,41,o),
+(294,-13,o),
+(375,-13,cs)
+);
+}
+);
+width = 646;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1619;
+unicode = 5657;
+},
+{
+color = 9;
+glyphname = "jiSayisi-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(540,-13,o),
+(634,362,o),
+(634,539,cs),
+(634,665,o),
+(589,727,o),
+(502,727,cs),
+(362,727,o),
+(318,552,o),
+(318,460,cs),
+(318,367,o),
+(365,318,o),
+(427,318,cs),
+(444,318,o),
+(455,320,o),
+(464,325,c),
+(481,398,l),
+(473,395,o),
+(465,393,o),
+(454,393,cs),
+(419,394,o),
+(396,416,o),
+(396,470,cs),
+(396,511,o),
+(419,652,o),
+(495,652,cs),
+(533,652,o),
+(550,622,o),
+(550,551,cs),
+(550,434,o),
+(486,73,o),
+(299,73,cs),
+(147,73,o),
+(159,266,o),
+(188,404,cs),
+(254,714,l),
+(160.996,714,l),
+(8.996,0,l),
+(102,0,l),
+(165,300,l),
+(144,306,l),
+(112,153,o),
+(145,-13,o),
+(306,-13,cs)
+);
+}
+);
+width = 647;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161A;
+unicode = 5658;
+},
+{
+color = 9;
+glyphname = "jaCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (415,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(377,-13,o),
+(459,70,o),
+(508,237,c),
+(489,238,l),
+(439,0,l),
+(532,0,l),
+(684,714,l),
+(590,714,l),
+(524,402,ls),
+(478,182,o),
+(400,73,o),
+(287,73,cs),
+(204,73,o),
+(166,131,o),
+(166,247,cs),
+(166,336,o),
+(203,652,o),
+(311,652,cs),
+(347,652,o),
+(366,627,o),
+(366,579,cs),
+(366,518,o),
+(339,394,o),
+(256,394,cs),
+(245,394,o),
+(235,395,o),
+(229,398,c),
+(216,325,l),
+(228,321,o),
+(243,318,o),
+(260,318,cs),
+(396,318,o),
+(445,483,o),
+(445,581,cs),
+(445,673,o),
+(399,728,o),
+(318,728,cs),
+(131,728,o),
+(78,390,o),
+(78,244,cs),
+(78,83,o),
+(142,-13,o),
+(263,-13,cs)
+);
+}
+);
+width = 647;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni161B;
+unicode = 5659;
+},
+{
+color = 9;
+glyphname = "jjuCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(456,-13,o),
+(542,135,o),
+(542,270,cs),
+(542,362,o),
+(494,422,o),
+(414,422,cs),
+(333,422,o),
+(280,362,o),
+(254,251,cs),
+(247,221,o),
+(244,186,o),
+(244,162,c),
+(314,162,l),
+(315,177,o),
+(317,204,o),
+(324,237,cs),
+(340,308,o),
+(368,346,o),
+(408,346,cs),
+(444,346,o),
+(464,316,o),
+(464,267,cs),
+(464,184,o),
+(421,65,o),
+(295,65,cs),
+(205,65,o),
+(157,124,o),
+(157,233,cs),
+(157,412,o),
+(251,628,o),
+(500,628,cs),
+(612,628,l),
+(630,714,l),
+(516,714,ls),
+(411,714,o),
+(325,685,o),
+(257,638,c),
+(188,727,l),
+(113,669,l),
+(185,577,l),
+(99,484,o),
+(66,348,o),
+(66,238,cs),
+(66,85,o),
+(148,-13,o),
+(287,-13,cs)
+);
+}
+);
+width = 588;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni161C;
+unicode = 5660;
+},
+{
+color = 9;
+glyphname = "jjoCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(522,45,l),
+(450,137,l),
+(537,230,o),
+(570,366,o),
+(570,476,cs),
+(570,629,o),
+(487,727,o),
+(348,727,cs),
+(179,727,o),
+(93,579,o),
+(93,444,cs),
+(93,352,o),
+(142,292,o),
+(222,292,cs),
+(303,292,o),
+(356,352,o),
+(381,463,cs),
+(388,493,o),
+(392,528,o),
+(392,552,c),
+(322,552,l),
+(321,537,o),
+(318,510,o),
+(312,477,cs),
+(296,406,o),
+(268,368,o),
+(228,368,cs),
+(191,368,o),
+(172,398,o),
+(172,447,cs),
+(172,530,o),
+(215,649,o),
+(341,649,cs),
+(431,649,o),
+(479,590,o),
+(479,481,cs),
+(479,302,o),
+(384,86,o),
+(135,86,cs),
+(23,86,l),
+(5,0,l),
+(120,0,ls),
+(224,0,o),
+(310,29,o),
+(378,76,c),
+(447,-13,l)
+);
+}
+);
+width = 588;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|jjuCarrier-canadian";
+note = uni161D;
+unicode = 5661;
+},
+{
+color = 9;
+glyphname = "jjeCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(568,-13,o),
+(619,325,o),
+(619,469,cs),
+(619,640,o),
+(543,727,o),
+(404,727,cs),
+(342,727,o),
+(280,707,o),
+(229,661,c),
+(173,727,l),
+(104,663,l),
+(168,588,l),
+(141,546,o),
+(119,492,o),
+(104,424,cs),
+(14,0,l),
+(107,0,l),
+(197,422,ls),
+(228,567,o),
+(296,641,o),
+(398,641,cs),
+(488,641,o),
+(531,587,o),
+(531,467,cs),
+(531,380,o),
+(495,62,o),
+(386,62,cs),
+(350,62,o),
+(331,88,o),
+(331,136,cs),
+(331,197,o),
+(358,321,o),
+(441,321,cs),
+(452,321,o),
+(462,319,o),
+(468,316,c),
+(482,389,l),
+(470,394,o),
+(454,396,o),
+(437,396,cs),
+(302,396,o),
+(253,231,o),
+(253,133,cs),
+(253,42,o),
+(298,-13,o),
+(380,-13,cs)
+);
+}
+);
+width = 651;
+}
+);
+metricRight = "jeCarrier-canadian";
+note = uni161E;
+unicode = 5662;
+},
+{
+color = 9;
+glyphname = "jjeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(568,-13,o),
+(619,325,o),
+(619,469,cs),
+(619,640,o),
+(543,727,o),
+(404,727,cs),
+(342,727,o),
+(280,707,o),
+(229,661,c),
+(173,727,l),
+(104,663,l),
+(168,588,l),
+(141,546,o),
+(119,492,o),
+(104,424,cs),
+(14,0,l),
+(107,0,l),
+(197,422,ls),
+(228,567,o),
+(296,641,o),
+(398,641,cs),
+(488,641,o),
+(531,587,o),
+(531,467,cs),
+(531,370,o),
+(497,62,o),
+(375,62,cs),
+(329,62,o),
+(301,92,o),
+(301,152,cs),
+(301,218,o),
+(326,314,o),
+(392,331,c),
+(374,244,l),
+(421,244,l),
+(468,464,l),
+(420,464,l),
+(403,382,l),
+(294,360,o),
+(253,222,o),
+(253,133,cs),
+(253,42,o),
+(298,-13,o),
+(380,-13,cs)
+);
+}
+);
+width = 651;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161F;
+unicode = 5663;
+},
+{
+color = 9;
+glyphname = "jjiCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(490,-13,o),
+(559,92,o),
+(601,294,cs),
+(658,568,o),
+(585,727,o),
+(404,727,cs),
+(335,727,o),
+(276,705,o),
+(229,662,c),
+(173,727,l),
+(104,663,l),
+(168,590,l),
+(140,546,o),
+(118,490,o),
+(104,424,cs),
+(14,0,l),
+(107,0,l),
+(197,422,ls),
+(228,567,o),
+(295,641,o),
+(398,641,cs),
+(522,641,o),
+(561,528,o),
+(514,300,cs),
+(479,137,o),
+(442,62,o),
+(372,62,cs),
+(312,62,o),
+(289,117,o),
+(309,211,cs),
+(319,261,o),
+(337,294,o),
+(365,309,c),
+(374,295,o),
+(391,285,o),
+(410,285,cs),
+(447,285,o),
+(475,316,o),
+(475,354,cs),
+(475,392,o),
+(447,422,o),
+(410,422,cs),
+(365,422,o),
+(344,380,o),
+(347,348,c),
+(304,322,o),
+(275,271,o),
+(261,202,cs),
+(233,69,o),
+(281,-13,o),
+(380,-13,cs)
+);
+}
+);
+width = 650;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1620;
+unicode = 5664;
+},
+{
+color = 9;
+glyphname = "jjaCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(356,-13,o),
+(418,7,o),
+(469,53,c),
+(525,-13,l),
+(594,51,l),
+(530,126,l),
+(557,168,o),
+(579,222,o),
+(594,290,cs),
+(684,714,l),
+(591,714,l),
+(501,292,ls),
+(470,147,o),
+(402,73,o),
+(300,73,cs),
+(210,73,o),
+(167,127,o),
+(167,247,cs),
+(167,334,o),
+(204,652,o),
+(312,652,cs),
+(348,652,o),
+(367,626,o),
+(367,578,cs),
+(367,517,o),
+(340,393,o),
+(257,393,cs),
+(246,393,o),
+(236,395,o),
+(230,398,c),
+(216,325,l),
+(228,320,o),
+(244,318,o),
+(261,318,cs),
+(396,318,o),
+(445,483,o),
+(445,581,cs),
+(445,672,o),
+(400,727,o),
+(318,727,cs),
+(130,727,o),
+(78,389,o),
+(78,245,cs),
+(78,74,o),
+(155,-13,o),
+(294,-13,cs)
+);
+}
+);
+width = 652;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "=|jjeCarrier-canadian";
+note = uni1621;
+unicode = 5665;
+},
+{
+color = 9;
+glyphname = "luCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(418,-13,o),
+(502,67,o),
+(538,236,cs),
+(640,714,l),
+(547,714,l),
+(447,245,ls),
+(421,127,o),
+(370,73,o),
+(284,73,cs),
+(199,73,o),
+(156,127,o),
+(156,228,cs),
+(156,350,o),
+(216,616,o),
+(404,639,c),
+(420,714,l),
+(148,714,l),
+(131,636,l),
+(300,636,l),
+(368,664,l),
+(159,654,o),
+(61,395,o),
+(61,223,cs),
+(61,76,o),
+(139,-13,o),
+(281,-13,cs)
+);
+}
+);
+width = 600;
+}
+);
+metricRight = "te-canadian";
+note = uni1622;
+unicode = 5666;
+},
+{
+color = 9;
+glyphname = "loCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,0,l),
+(200,469,ls),
+(225,587,o),
+(277,641,o),
+(363,641,cs),
+(448,641,o),
+(491,587,o),
+(491,486,cs),
+(491,364,o),
+(431,98,o),
+(243,75,c),
+(227,0,l),
+(499,0,l),
+(515,78,l),
+(346,78,l),
+(279,50,l),
+(488,60,o),
+(586,319,o),
+(586,491,cs),
+(586,638,o),
+(508,727,o),
+(366,727,cs),
+(228,727,o),
+(144,647,o),
+(108,478,cs),
+(7,0,l)
+);
+}
+);
+width = 600;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|luCarrier-canadian";
+note = uni1623;
+unicode = 5667;
+},
+{
+color = 9;
+glyphname = "leCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (311,357);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(188,0,ls),
+(496,0,o),
+(569,291,o),
+(569,471,cs),
+(569,629,o),
+(505,727,o),
+(397,727,cs),
+(311,727,o),
+(238,663,o),
+(195,547,c),
+(206,547,l),
+(241,714,l),
+(158,714,l),
+(90,396,l),
+(169,396,l),
+(204,549,o),
+(277,641,o),
+(364,641,cs),
+(437,641,o),
+(475,577,o),
+(475,462,cs),
+(475,327,o),
+(421,86,o),
+(190,86,cs),
+(24,86,l),
+(6,0,l)
+);
+}
+);
+width = 585;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1624;
+unicode = 5668;
+},
+{
+color = 9;
+glyphname = "leeCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "leCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (241,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 585;
+}
+);
+metricLeft = "leCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1625;
+unicode = 5669;
+},
+{
+color = 9;
+glyphname = "liCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "leCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (219,0);
+ref = dot_middle;
+}
+);
+width = 585;
+}
+);
+note = uni1626;
+unicode = 5670;
+},
+{
+color = 9;
+glyphname = "laCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(474,0,l),
+(493,86,l),
+(342,86,ls),
+(218,86,o),
+(156,143,o),
+(156,261,cs),
+(156,380,o),
+(218,641,o),
+(372,641,cs),
+(464,641,o),
+(505,545,o),
+(480,396,c),
+(559,396,l),
+(626,714,l),
+(542,714,l),
+(503,529,l),
+(512,525,l),
+(518,652,o),
+(462,727,o),
+(366,727,cs),
+(155,727,o),
+(63,422,o),
+(63,257,cs),
+(63,91,o),
+(154,0,o),
+(326,0,cs)
+);
+}
+);
+width = 585;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|leCarrier-canadian";
+note = uni1627;
+unicode = 5671;
+},
+{
+color = 1;
+glyphname = "dluCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(509,-13,o),
+(570,308,o),
+(570,433,cs),
+(570,562,o),
+(514,640,o),
+(405,664,c),
+(421,642,l),
+(621,642,l),
+(603,558,l),
+(671,558,l),
+(723,798,l),
+(654,798,l),
+(636,714,l),
+(378,714,l),
+(362,638,l),
+(447,619,o),
+(483,560,o),
+(483,456,cs),
+(483,368,o),
+(442,73,o),
+(261,73,cs),
+(166,73,o),
+(131,142,o),
+(159,275,cs),
+(252,714,l),
+(159,714,l),
+(67,284,ls),
+(27,93,o),
+(96,-13,o),
+(253,-13,cs)
+);
+}
+);
+width = 640;
+}
+);
+metricLeft = "te-canadian";
+note = uni1628;
+unicode = 5672;
+},
+{
+color = 9;
+glyphname = "dloCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(536,-84,l),
+(587,156,l),
+(518,156,l),
+(499,72,l),
+(338,72,l),
+(285,55,l),
+(468,65,o),
+(586,292,o),
+(586,491,cs),
+(586,638,o),
+(508,727,o),
+(366,727,cs),
+(228,727,o),
+(144,647,o),
+(108,478,cs),
+(7,0,l),
+(100,0,l),
+(200,469,ls),
+(225,587,o),
+(277,641,o),
+(363,641,cs),
+(448,641,o),
+(491,587,o),
+(491,486,cs),
+(491,364,o),
+(431,98,o),
+(243,75,c),
+(227,0,l),
+(485,0,l),
+(467,-84,l)
+);
+}
+);
+width = 640;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "dluCarrier-canadian";
+note = uni1629;
+unicode = 5673;
+},
+{
+color = 9;
+glyphname = "dleCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (325,357);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(201,0,ls),
+(509,0,o),
+(582,291,o),
+(582,471,cs),
+(582,629,o),
+(518,727,o),
+(410,727,cs),
+(322,727,o),
+(238,658,o),
+(194,533,c),
+(201,533,l),
+(241,726,l),
+(308,726,l),
+(322,793,l),
+(122,793,l),
+(108,726,l),
+(174,726,l),
+(103,396,l),
+(182,396,l),
+(217,549,o),
+(290,641,o),
+(377,641,cs),
+(450,641,o),
+(488,577,o),
+(488,462,cs),
+(488,327,o),
+(434,86,o),
+(203,86,cs),
+(37,86,l),
+(19,0,l)
+);
+}
+);
+width = 598;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni162A;
+unicode = 5674;
+},
+{
+color = 9;
+glyphname = "dleeCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (255,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 598;
+}
+);
+note = uni162B;
+unicode = 5675;
+},
+{
+color = 9;
+glyphname = "dliCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (232,0);
+ref = dot_middle;
+}
+);
+width = 598;
+}
+);
+note = uni162C;
+unicode = 5676;
+},
+{
+color = 9;
+glyphname = "dlaCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(474,0,l),
+(493,86,l),
+(342,86,ls),
+(218,86,o),
+(156,143,o),
+(156,261,cs),
+(156,380,o),
+(218,641,o),
+(372,641,cs),
+(464,641,o),
+(505,545,o),
+(480,396,c),
+(559,396,l),
+(629,726,l),
+(694,726,l),
+(708,793,l),
+(509,793,l),
+(494,726,l),
+(560,726,l),
+(516,521,l),
+(527,517,l),
+(533,652,o),
+(462,727,o),
+(366,727,cs),
+(155,727,o),
+(63,422,o),
+(63,257,cs),
+(63,91,o),
+(154,0,o),
+(326,0,cs)
+);
+}
+);
+width = 598;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni162D;
+unicode = 5677;
+},
+{
+color = 9;
+glyphname = "lhuCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(513,-13,o),
+(588,259,o),
+(588,428,cs),
+(588,547,o),
+(545,635,o),
+(467,666,c),
+(496,636,l),
+(653,636,l),
+(669,714,l),
+(456,714,l),
+(439,639,l),
+(482,617,o),
+(504,560,o),
+(504,480,cs),
+(504,353,o),
+(457,73,o),
+(285,73,cs),
+(201,73,o),
+(159,127,o),
+(159,230,cs),
+(159,342,o),
+(211,585,o),
+(346,639,c),
+(362,714,l),
+(148,714,l),
+(131,636,l),
+(289,636,l),
+(330,671,l),
+(145,624,o),
+(64,377,o),
+(64,223,cs),
+(64,76,o),
+(140,-13,o),
+(281,-13,cs)
+);
+}
+);
+width = 618;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162E;
+unicode = 5678;
+},
+{
+color = 9;
+glyphname = "lhoCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(209,0,l),
+(225,75,l),
+(182,97,o),
+(161,154,o),
+(161,234,cs),
+(161,361,o),
+(208,641,o),
+(380,641,cs),
+(463,641,o),
+(506,587,o),
+(506,484,cs),
+(506,372,o),
+(454,129,o),
+(319,75,c),
+(303,0,l),
+(516,0,l),
+(533,78,l),
+(375,78,l),
+(334,43,l),
+(520,90,o),
+(601,337,o),
+(601,491,cs),
+(601,638,o),
+(525,727,o),
+(383,727,cs),
+(151,727,o),
+(76,455,o),
+(76,286,cs),
+(76,167,o),
+(119,79,o),
+(197,48,c),
+(169,78,l),
+(12,78,l),
+(-5,0,l)
+);
+}
+);
+width = 617;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162F;
+unicode = 5679;
+},
+{
+color = 9;
+glyphname = "lheCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (326,357);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(503,-13,o),
+(592,292,o),
+(592,474,cs),
+(592,631,o),
+(523,727,o),
+(406,727,cs),
+(318,727,o),
+(250,674,o),
+(210,573,c),
+(215,571,l),
+(245,714,l),
+(161,714,l),
+(101,431,l),
+(180,431,l),
+(219,574,o),
+(285,641,o),
+(371,641,cs),
+(455,641,o),
+(499,580,o),
+(499,471,cs),
+(499,344,o),
+(441,73,o),
+(271,73,cs),
+(178,73,o),
+(130,154,o),
+(148,283,c),
+(70,283,l),
+(9,0,l),
+(92.992,0,l),
+(130,176,l),
+(120,176,l),
+(117,60,o),
+(181,-13,o),
+(289,-13,cs)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1630;
+unicode = 5680;
+},
+{
+color = 9;
+glyphname = "lheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (256,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 607;
+}
+);
+note = uni1631;
+unicode = 5681;
+},
+{
+color = 9;
+glyphname = "lhiCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (233,0);
+ref = dot_middle;
+}
+);
+width = 607;
+}
+);
+note = uni1632;
+unicode = 5682;
+},
+{
+color = 9;
+glyphname = "lhaCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(335,-13,o),
+(403,40,o),
+(443,141,c),
+(438,143,l),
+(408,0,l),
+(492,0,l),
+(552,283,l),
+(473,283,l),
+(434,140,o),
+(368,73,o),
+(282,73,cs),
+(198,73,o),
+(154,134,o),
+(154,243,cs),
+(154,370,o),
+(213,641,o),
+(382,641,cs),
+(475,641,o),
+(523,560,o),
+(505,431,c),
+(584,431,l),
+(644,714,l),
+(560,714,l),
+(523,538,l),
+(533,538,l),
+(536,654,o),
+(472,727,o),
+(368,727,cs),
+(150,727,o),
+(62,422,o),
+(62,240,cs),
+(62,83,o),
+(130,-13,o),
+(247,-13,cs)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1633;
+unicode = 5683;
+},
+{
+color = 9;
+glyphname = "tlhuCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(513,-13,o),
+(588,259,o),
+(588,428,cs),
+(588,540,o),
+(560,628,o),
+(480,666,c),
+(474,642,l),
+(640,642,l),
+(622,558,l),
+(690,558,l),
+(741,798,l),
+(672,798,l),
+(654,714,l),
+(456,714,l),
+(439,639,l),
+(482,617,o),
+(504,560,o),
+(504,480,cs),
+(504,353,o),
+(457,73,o),
+(285,73,cs),
+(201,73,o),
+(159,127,o),
+(159,230,cs),
+(159,342,o),
+(211,585,o),
+(346,639,c),
+(362,714,l),
+(148,714,l),
+(131,636,l),
+(304,636,l),
+(295,658,l),
+(131,596,o),
+(64,365,o),
+(64,223,cs),
+(64,76,o),
+(140,-13,o),
+(281,-13,cs)
+);
+}
+);
+width = 655;
+}
+);
+metricLeft = "lhuCarrier-canadian";
+note = uni1634;
+unicode = 5684;
+},
+{
+color = 9;
+glyphname = "tlhoCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(30,-84,l),
+(48,0,l),
+(247,0,l),
+(263,75,l),
+(221,97,o),
+(199,154,o),
+(199,234,cs),
+(199,361,o),
+(246,641,o),
+(418,641,cs),
+(501,641,o),
+(544,587,o),
+(544,484,cs),
+(544,372,o),
+(492,129,o),
+(357,75,c),
+(341,0,l),
+(555,0,l),
+(571,78,l),
+(399,78,l),
+(408,56,l),
+(571,118,o),
+(639,349,o),
+(639,491,cs),
+(639,638,o),
+(563,727,o),
+(422,727,cs),
+(189,727,o),
+(114,455,o),
+(114,286,cs),
+(114,174,o),
+(143,86,o),
+(222,48,c),
+(228,72,l),
+(63,72,l),
+(81,156,l),
+(12,156,l),
+(-39,-84,l)
+);
+}
+);
+width = 656;
+}
+);
+metricLeft = "=|tlhuCarrier-canadian";
+metricRight = "lhuCarrier-canadian";
+note = uni1635;
+unicode = 5685;
+},
+{
+color = 9;
+glyphname = "tlheCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (334,357);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(512,-13,o),
+(602,292,o),
+(602,474,cs),
+(602,631,o),
+(533,727,o),
+(415,727,cs),
+(309,727,o),
+(234,658,o),
+(192,537,c),
+(209,569,l),
+(243,726,l),
+(307,726,l),
+(322,793,l),
+(122,793,l),
+(108,726,l),
+(174,726,l),
+(110,431,l),
+(189,431,l),
+(229,574,o),
+(294,641,o),
+(381,641,cs),
+(464,641,o),
+(510,580,o),
+(510,471,cs),
+(510,344,o),
+(450,73,o),
+(281,73,cs),
+(187,73,o),
+(140,154,o),
+(158,283,c),
+(79,283,l),
+(19,0,l),
+(103,0,l),
+(139,176,l),
+(130,176,l),
+(127,60,o),
+(191,-13,o),
+(299,-13,cs)
+);
+}
+);
+width = 617;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1636;
+unicode = 5686;
+},
+{
+color = 9;
+glyphname = "tlheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (264,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 617;
+}
+);
+note = uni1637;
+unicode = 5687;
+},
+{
+color = 9;
+glyphname = "tlhiCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (241,0);
+ref = dot_middle;
+}
+);
+width = 617;
+}
+);
+note = uni1638;
+unicode = 5688;
+},
+{
+color = 9;
+glyphname = "tlhaCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(335,-13,o),
+(404,40,o),
+(444,141,c),
+(439,143,l),
+(408.995,0,l),
+(493,0,l),
+(553,283,l),
+(474,283,l),
+(435,140,o),
+(369,73,o),
+(282,73,cs),
+(198,73,o),
+(154,134,o),
+(154,243,cs),
+(154,370,o),
+(213,641,o),
+(382,641,cs),
+(476,641,o),
+(524,560,o),
+(506,431,c),
+(584,431,l),
+(647,726,l),
+(712,726,l),
+(727,793,l),
+(528,793,l),
+(513,726,l),
+(579,726,l),
+(537,530,l),
+(546,529,l),
+(547,658,o),
+(473,727,o),
+(368,727,cs),
+(150,727,o),
+(62,422,o),
+(62,240,cs),
+(62,83,o),
+(130,-13,o),
+(247,-13,cs)
+);
+}
+);
+width = 617;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni1639;
+unicode = 5689;
+},
+{
+color = 9;
+glyphname = "tluCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(259,-13,o),
+(309,25,o),
+(348,112,c),
+(320,112,l),
+(328,31,o),
+(373,-13,o),
+(447,-13,cs),
+(631,-13,o),
+(689,308,o),
+(689,450,cs),
+(689,558,o),
+(654,625,o),
+(588,656,c),
+(566,642,l),
+(739,642,l),
+(720,558,l),
+(789,558,l),
+(840,798,l),
+(771,798,l),
+(753.008,714,l),
+(506,714,l),
+(490,638,l),
+(566,632,o),
+(602,583,o),
+(602,477,cs),
+(602,376,o),
+(557,72,o),
+(446,72,cs),
+(393,72,o),
+(376,115,o),
+(393,196,cs),
+(417,313,l),
+(329,313,l),
+(305,196,ls),
+(287,112,o),
+(256,72,o),
+(208,72,cs),
+(165,72,o),
+(145,100,o),
+(145,172,cs),
+(145,246,o),
+(196,640,o),
+(395,638,c),
+(411,714,l),
+(149,714,l),
+(132,636,l),
+(300,636,l),
+(285,651,l),
+(111,585,o),
+(54,305,o),
+(54,165,cs),
+(54,48,o),
+(101,-13,o),
+(190,-13,cs)
+);
+}
+);
+width = 754;
+}
+);
+metricRight = "tlhuCarrier-canadian";
+note = uni163A;
+unicode = 5690;
+},
+{
+color = 1;
+glyphname = "tloCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(652,-84,l),
+(703,156,l),
+(634,156,l),
+(616,72,l),
+(456,72,l),
+(469,58,l),
+(652,122,o),
+(711,406,o),
+(711,549,cs),
+(711,666,o),
+(663,727,o),
+(574,727,cs),
+(505,727,o),
+(455,689,o),
+(416,602,c),
+(444,601,l),
+(436,683,o),
+(392,727,o),
+(318,727,cs),
+(133,727,o),
+(75,406,o),
+(75,264,cs),
+(75,161,o),
+(109,95,o),
+(169,63,c),
+(192,78,l),
+(13,78,l),
+(-4,0,l),
+(259,0,l),
+(275,76,l),
+(199,82,o),
+(162,131,o),
+(162,237,cs),
+(162,338,o),
+(208,642,o),
+(318,642,cs),
+(371,642,o),
+(389,599,o),
+(372,518,cs),
+(347,401,l),
+(435,401,l),
+(460,518,ls),
+(478,602,o),
+(509,642,o),
+(556,642,cs),
+(599,642,o),
+(619,614,o),
+(619,542,cs),
+(619,468,o),
+(568,74,o),
+(370,76,c),
+(353,0,l),
+(601,0,l),
+(583,-84,l)
+);
+}
+);
+width = 753;
+}
+);
+metricLeft = "tluCarrier-canadian";
+metricRight = "tlhuCarrier-canadian";
+note = uni163B;
+unicode = 5691;
+},
+{
+color = 9;
+glyphname = "tleCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (274,357);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(452,-13,o),
+(546,87,o),
+(546,224,cs),
+(546,302,o),
+(506,359,o),
+(441,367,c),
+(437,346,l),
+(546,354,o),
+(618,456,o),
+(618,557,cs),
+(618,656,o),
+(547,727,o),
+(434,727,cs),
+(329,727,o),
+(241,665,o),
+(199,555,c),
+(206,553,l),
+(242,726,l),
+(308,726,l),
+(322,793,l),
+(122,793,l),
+(108,726,l),
+(174,726,l),
+(111,431,l),
+(188,431,l),
+(221,572,o),
+(293,643,o),
+(399,643,cs),
+(477,643,o),
+(523,601,o),
+(523,536,cs),
+(523,460,o),
+(473,396,o),
+(391,396,cs),
+(361,396,l),
+(345,319,l),
+(373,319,ls),
+(425,319,o),
+(457,286,o),
+(457,230,cs),
+(457,140,o),
+(403,71,o),
+(300,71,cs),
+(185,71,o),
+(132,147,o),
+(156,283,c),
+(79,283,l),
+(19,0,l),
+(103,0,l),
+(138,165,l),
+(122,164,l),
+(119,56,o),
+(197,-13,o),
+(314,-13,cs)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni163C;
+unicode = 5692;
+},
+{
+color = 9;
+glyphname = "tleeCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (204,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 615;
+}
+);
+note = uni163D;
+unicode = 5693;
+},
+{
+color = 9;
+glyphname = "tliCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (190,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 615;
+}
+);
+note = uni163E;
+unicode = 5694;
+},
+{
+color = 9;
+glyphname = "tlaCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(322,-13,o),
+(402,37,o),
+(448,127,c),
+(439,144,l),
+(408,0,l),
+(491,0,l),
+(552,283,l),
+(475,283,l),
+(442,142,o),
+(370,71,o),
+(263,71,cs),
+(185,71,o),
+(139,113,o),
+(139,178,cs),
+(139,254,o),
+(189,318,o),
+(271,318,cs),
+(301,318,l),
+(317,395,l),
+(289,395,ls),
+(237,395,o),
+(205,428,o),
+(205,484,cs),
+(205,574,o),
+(259,643,o),
+(363,643,cs),
+(477,643,o),
+(530,567,o),
+(506,431,c),
+(583,431,l),
+(646,726,l),
+(711,726,l),
+(725,793,l),
+(525,793,l),
+(510,726,l),
+(577,726,l),
+(536,532,l),
+(544,544,l),
+(551,655,o),
+(473,727,o),
+(348,727,cs),
+(210,727,o),
+(116,627,o),
+(116,490,cs),
+(116,418,o),
+(151,363,o),
+(207,349,c),
+(213,366,l),
+(110,352,o),
+(44,254,o),
+(44,157,cs),
+(44,58,o),
+(115,-13,o),
+(228,-13,cs)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni163F;
+unicode = 5695;
+},
+{
+color = 9;
+glyphname = "zuCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(478,-13,o),
+(564,135,o),
+(564,321,cs),
+(564,388,o),
+(552,466,o),
+(552,536,cs),
+(552,598,o),
+(575,633,o),
+(632,633,cs),
+(652,633,l),
+(669,714,l),
+(623,714,ls),
+(513,714,o),
+(465,654,o),
+(465,531,cs),
+(465,467,o),
+(476,398,o),
+(476,318,cs),
+(476,186,o),
+(421,73,o),
+(283,73,cs),
+(193,73,o),
+(142,120,o),
+(142,197,cs),
+(142,328,o),
+(296,507,o),
+(296,618,cs),
+(296,678,o),
+(256,714,o),
+(187,714,cs),
+(146,714,l),
+(129,633,l),
+(158,633,ls),
+(191,633,o),
+(205,620,o),
+(205,595,cs),
+(205,516,o),
+(47,344,o),
+(47,183,cs),
+(47,66,o),
+(134,-13,o),
+(273,-13,cs)
+);
+}
+);
+width = 617;
+}
+);
+metricRight = "=|";
+note = uni1640;
+unicode = 5696;
+},
+{
+color = 9;
+glyphname = "zoCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(41,0,ls),
+(151,0,o),
+(200,60,o),
+(200,183,cs),
+(200,247,o),
+(188,316,o),
+(188,396,cs),
+(188,528,o),
+(244,641,o),
+(381,641,cs),
+(471,641,o),
+(522,594,o),
+(522,517,cs),
+(522,386,o),
+(368,207,o),
+(368,96,cs),
+(368,36,o),
+(408,0,o),
+(477,0,cs),
+(518,0,l),
+(535,81,l),
+(506,81,ls),
+(473,81,o),
+(459,94,o),
+(459,119,cs),
+(459,198,o),
+(617,370,o),
+(617,531,cs),
+(617,648,o),
+(530,727,o),
+(391,727,cs),
+(186,727,o),
+(100,579,o),
+(100,393,cs),
+(100,326,o),
+(112,248,o),
+(112,178,cs),
+(112,116,o),
+(90,81,o),
+(32,81,cs),
+(12,81,l),
+(-5,0,l)
+);
+}
+);
+width = 618;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1641;
+unicode = 5697;
+},
+{
+color = 9;
+glyphname = "zeCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (323,357);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(501,-13,o),
+(584,370,o),
+(584,535,cs),
+(584,658,o),
+(540,727,o),
+(461,727,cs),
+(366,727,o),
+(279,625,o),
+(241,625,cs),
+(218,625,o),
+(212,642,o),
+(221,683,cs),
+(227,714,l),
+(143,714,l),
+(131,656,ls),
+(115,586,o),
+(141,543,o),
+(197,543,cs),
+(277,543,o),
+(359,641,o),
+(424,641,cs),
+(468,641,o),
+(490,599,o),
+(490,520,cs),
+(490,403,o),
+(424,73,o),
+(298,73,cs),
+(231,73,o),
+(191,171,o),
+(112,171,cs),
+(58,171,o),
+(19,131,o),
+(4,58,cs),
+(-9,0,l),
+(75,0,l),
+(82,31,ls),
+(90,70,o),
+(106,89,o),
+(126,89,cs),
+(168,89,o),
+(217,-13,o),
+(312,-13,cs)
+);
+}
+);
+width = 588;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1642;
+unicode = 5698;
+},
+{
+color = 9;
+glyphname = "zeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (253,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 589;
+}
+);
+note = uni1643;
+unicode = 5699;
+},
+{
+color = 9;
+glyphname = "ziCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (230,0);
+ref = dot_middle;
+}
+);
+width = 589;
+}
+);
+note = uni1644;
+unicode = 5700;
+},
+{
+color = 9;
+glyphname = "zaCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(270,-13,o),
+(357,89,o),
+(395,89,cs),
+(418,89,o),
+(424,72,o),
+(415,31,cs),
+(408,0,l),
+(492,0,l),
+(505,58,ls),
+(520,128,o),
+(494,171,o),
+(438,171,cs),
+(358,171,o),
+(277,73,o),
+(212,73,cs),
+(168,73,o),
+(145,115,o),
+(145,194,cs),
+(145,311,o),
+(212,641,o),
+(337,641,cs),
+(404,641,o),
+(445,543,o),
+(524,543,cs),
+(578,543,o),
+(616,583,o),
+(632,656,cs),
+(644,714,l),
+(560,714,l),
+(554,683,ls),
+(545,644,o),
+(530,625,o),
+(509,625,cs),
+(467,625,o),
+(418,727,o),
+(323,727,cs),
+(135,727,o),
+(51,344,o),
+(51,179,cs),
+(51,56,o),
+(96,-13,o),
+(175,-13,cs)
+);
+}
+);
+width = 589;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|zeCarrier-canadian";
+note = uni1645;
+unicode = 5701;
+},
+{
+color = 6;
+glyphname = "zCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(287,189,l),
+(300,250,l),
+(119,250,l),
+(113,212,l),
+(353,512,l),
+(361,546,l),
+(115,546,l),
+(101,485,l),
+(281,485,l),
+(287,523,l),
+(46,223,l),
+(39,189,l)
+);
+}
+);
+width = 350;
+}
+);
+metricRight = "=|";
+note = uni1646;
+unicode = 5702;
+},
+{
+color = 6;
+glyphname = "initialzCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(174,99,l),
+(193,189,l),
+(287,189,l),
+(300,250,l),
+(100,250,l),
+(117,216,l),
+(353,512,l),
+(361,546,l),
+(269,546,l),
+(288,636,l),
+(225,636,l),
+(206,546,l),
+(115,546,l),
+(101,485,l),
+(299,485,l),
+(283,519,l),
+(46,223,l),
+(39,189,l),
+(130,189,l),
+(111,99,l)
+);
+}
+);
+width = 350;
+}
+);
+metricLeft = "zCarrier-canadian";
+metricRight = "zCarrier-canadian";
+note = uni1647;
+unicode = 5703;
+},
+{
+color = 9;
+glyphname = "dzuCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(478,-13,o),
+(564,135,o),
+(564,321,cs),
+(564,388,o),
+(552,466,o),
+(552,536,cs),
+(552,598,o),
+(575,633,o),
+(632,633,cs),
+(652,633,l),
+(669,714,l),
+(623,714,ls),
+(525,714,o),
+(475,653,o),
+(469,531,cs),
+(467,467,o),
+(479,390,o),
+(477,318,cs),
+(475,186,o),
+(421,73,o),
+(283,73,cs),
+(193,73,o),
+(142,120,o),
+(142,197,cs),
+(142,328,o),
+(291,507,o),
+(291,618,cs),
+(291,678,o),
+(255,714,o),
+(187,714,cs),
+(146,714,l),
+(129,633,l),
+(158,633,ls),
+(191,633,o),
+(205,620,o),
+(205,595,cs),
+(205,516,o),
+(47,344,o),
+(47,183,cs),
+(47,66,o),
+(134,-13,o),
+(273,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(383,499,l),
+(420,675,l),
+(471,675,l),
+(480,714,l),
+(338,714,l),
+(329,675,l),
+(380,675,l),
+(343,499,l)
+);
+}
+);
+width = 617;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1648;
+unicode = 5704;
+},
+{
+color = 9;
+glyphname = "dzoCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(41,0,ls),
+(139,0,o),
+(189,61,o),
+(195,183,cs),
+(197,247,o),
+(185,324,o),
+(187,396,cs),
+(189,528,o),
+(244,641,o),
+(381,641,cs),
+(471,641,o),
+(522,594,o),
+(522,517,cs),
+(522,386,o),
+(374,207,o),
+(374,96,cs),
+(374,36,o),
+(409,0,o),
+(477,0,cs),
+(517,0,l),
+(535,81,l),
+(506,81,ls),
+(473,81,o),
+(459,94,o),
+(459,119,cs),
+(459,198,o),
+(617,370,o),
+(617,531,cs),
+(617,648,o),
+(530,727,o),
+(391,727,cs),
+(186,727,o),
+(100,579,o),
+(100,393,cs),
+(100,326,o),
+(112,248,o),
+(112,178,cs),
+(112,116,o),
+(90,81,o),
+(32,81,cs),
+(12,81,l),
+(-5,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(327,0,l),
+(335,39,l),
+(284,39,l),
+(321,215,l),
+(281,215,l),
+(244,39,l),
+(193,39,l),
+(184,0,l)
+);
+}
+);
+width = 617;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1649;
+unicode = 5705;
+},
+{
+color = 9;
+glyphname = "dzeCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (342,357);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(520,-13,o),
+(603,370,o),
+(603,535,cs),
+(603,658,o),
+(559,727,o),
+(480,727,cs),
+(384,727,o),
+(298,625,o),
+(259,625,cs),
+(237,625,o),
+(230,642,o),
+(239,683,cs),
+(246,714,l),
+(162,714,l),
+(149,656,ls),
+(134,586,o),
+(160,543,o),
+(216,543,cs),
+(296,543,o),
+(378,641,o),
+(443,641,cs),
+(487,641,o),
+(509,599,o),
+(509,520,cs),
+(509,403,o),
+(442,73,o),
+(317,73,cs),
+(250,73,o),
+(209,171,o),
+(131,171,cs),
+(77,171,o),
+(38,131,o),
+(23,58,cs),
+(10,0,l),
+(94,0,l),
+(101,31,ls),
+(109,70,o),
+(125,89,o),
+(145,89,cs),
+(187,89,o),
+(236,-13,o),
+(331,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(115,250,l),
+(133,331,l),
+(238,331,l),
+(250,383,l),
+(143,383,l),
+(161,464,l),
+(109,464,l),
+(63,250,l)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164A;
+unicode = 5706;
+},
+{
+color = 9;
+glyphname = "dzeeCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "dzeCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (272,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 607;
+}
+);
+metricLeft = "dzeCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164B;
+unicode = 5707;
+},
+{
+color = 9;
+glyphname = "dziCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "dzeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (248,0);
+ref = dot_middle;
+}
+);
+width = 607;
+}
+);
+note = uni164C;
+unicode = 5708;
+},
+{
+color = 9;
+glyphname = "dzaCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(270,-13,o),
+(357,89,o),
+(395,89,cs),
+(418,89,o),
+(424,72,o),
+(415,31,cs),
+(409,0,l),
+(493,0,l),
+(505,58,ls),
+(520,128,o),
+(495,171,o),
+(439,171,cs),
+(358,171,o),
+(277,73,o),
+(212,73,cs),
+(168,73,o),
+(145,115,o),
+(145,194,cs),
+(145,311,o),
+(212,641,o),
+(338,641,cs),
+(405,641,o),
+(445,543,o),
+(524,543,cs),
+(578,543,o),
+(617,583,o),
+(632,656,cs),
+(645,714,l),
+(561,714,l),
+(554,683,ls),
+(546,644,o),
+(530,625,o),
+(509,625,cs),
+(467,625,o),
+(419,727,o),
+(324,727,cs),
+(135,727,o),
+(51,344,o),
+(51,179,cs),
+(51,56,o),
+(96,-13,o),
+(175,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(546,250,l),
+(591,464,l),
+(539,464,l),
+(522,383,l),
+(416,383,l),
+(405,331,l),
+(511,331,l),
+(494,250,l)
+);
+}
+);
+width = 608;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dzeCarrier-canadian";
+note = uni164D;
+unicode = 5709;
+},
+{
+color = 9;
+glyphname = "suCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(254,-13,o),
+(317,40,o),
+(353,142,c),
+(322,142,l),
+(320,40,o),
+(366,-13,o),
+(457,-13,cs),
+(592,-13,o),
+(643,118,o),
+(654,249,cs),
+(661,330,o),
+(650,455,o),
+(656,530,cs),
+(659,585,o),
+(675,633,o),
+(730,633,cs),
+(749,633,l),
+(766,714,l),
+(725,714,ls),
+(622,714,o),
+(582,646,o),
+(572,547,cs),
+(565,472,o),
+(570,336,o),
+(565,261,cs),
+(563,177,o),
+(537,72,o),
+(451,72,cs),
+(377,72,o),
+(378,152,o),
+(391,212,cs),
+(498,714,l),
+(416,714,l),
+(309,210,ls),
+(289,117,o),
+(252,72,o),
+(195,72,cs),
+(152,72,o),
+(128,98,o),
+(128,147,cs),
+(128,267,o),
+(289,516,o),
+(289,625,cs),
+(289,683,o),
+(254,714,o),
+(188,714,cs),
+(147,714,l),
+(130,633,l),
+(148,633,ls),
+(181,633,o),
+(196,620,o),
+(196,591,cs),
+(196,494,o),
+(34,282,o),
+(34,131,cs),
+(34,43,o),
+(86,-13,o),
+(171,-13,cs)
+);
+}
+);
+width = 715;
+}
+);
+metricRight = "=|";
+note = uni164E;
+unicode = 5710;
+},
+{
+color = 9;
+glyphname = "soCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(37,0,ls),
+(140,0,o),
+(180,68,o),
+(190,167,cs),
+(197,242,o),
+(192,378,o),
+(196,453,cs),
+(199,537,o),
+(224,642,o),
+(310,642,cs),
+(385,642,o),
+(384,562,o),
+(371,502,cs),
+(264,0,l),
+(345,0,l),
+(452,504,ls),
+(472,597,o),
+(509,642,o),
+(566,642,cs),
+(610,642,o),
+(634,616,o),
+(634,567,cs),
+(634,447,o),
+(473,198,o),
+(473,89,cs),
+(473,31,o),
+(507,0,o),
+(573,0,cs),
+(614,0,l),
+(631,81,l),
+(613,81,ls),
+(581,81,o),
+(566,94,o),
+(566,123,cs),
+(566,220,o),
+(727,432,o),
+(727,583,cs),
+(727,671,o),
+(676,727,o),
+(591,727,cs),
+(508,727,o),
+(444,674,o),
+(409,572,c),
+(439,572,l),
+(441,674,o),
+(395,727,o),
+(305,727,cs),
+(169,727,o),
+(119,596,o),
+(108,465,cs),
+(101,384,o),
+(112,259,o),
+(105,184,cs),
+(102,129,o),
+(87,81,o),
+(31,81,cs),
+(13,81,l),
+(-5,0,l)
+);
+}
+);
+width = 715;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5711;
+},
+{
+color = 9;
+glyphname = "seCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(469,-13,o),
+(536,128,o),
+(536,229,cs),
+(536,306,o),
+(498,358,o),
+(432,367,c),
+(428,346,l),
+(563,360,o),
+(611,487,o),
+(611,578,cs),
+(611,667,o),
+(562,727,o),
+(482,727,cs),
+(381,727,o),
+(298,625,o),
+(254,625,cs),
+(235,625,o),
+(229,641,o),
+(237,676,cs),
+(245,714,l),
+(161,714,l),
+(148,656,ls),
+(133,586,o),
+(159,543,o),
+(216,543,cs),
+(301,543,o),
+(378,643,o),
+(451,643,cs),
+(494,643,o),
+(517,611,o),
+(517,561,cs),
+(517,489,o),
+(477,395,o),
+(375,395,cs),
+(92,395,l),
+(76,319,l),
+(358,319,ls),
+(416,319,o),
+(446,286,o),
+(446,230,cs),
+(446,174,o),
+(414,71,o),
+(333,71,cs),
+(259,71,o),
+(213,171,o),
+(130,171,cs),
+(76,171,o),
+(37,133,o),
+(21,58,cs),
+(9,0,l),
+(93,0,l),
+(99,31,ls),
+(108,70,o),
+(123,89,o),
+(144,89,cs),
+(193,89,o),
+(242,-13,o),
+(346,-13,cs)
+);
+}
+);
+width = 605;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni1650;
+unicode = 5712;
+},
+{
+color = 9;
+glyphname = "seeCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(469,-13,o),
+(536,128,o),
+(536,229,cs),
+(536,301,o),
+(502,352,o),
+(444,365,c),
+(436,347,l),
+(565,366,o),
+(611,489,o),
+(611,578,cs),
+(611,667,o),
+(562,727,o),
+(482,727,cs),
+(381,727,o),
+(298,625,o),
+(254,625,cs),
+(235,625,o),
+(229,641,o),
+(237,676,cs),
+(245,714,l),
+(161,714,l),
+(148,656,ls),
+(133,586,o),
+(159,543,o),
+(216,543,cs),
+(301,543,o),
+(378,643,o),
+(451,643,cs),
+(494,643,o),
+(517,611,o),
+(517,561,cs),
+(517,489,o),
+(476,393,o),
+(375,393,cs),
+(320,393,l),
+(335,353,l),
+(360,475,l),
+(308,475,l),
+(292,393,l),
+(92,393,l),
+(77,321,l),
+(276,321,l),
+(257,231,l),
+(309,231,l),
+(336,362,l),
+(304,321,l),
+(359,321,ls),
+(416,321,o),
+(446,286,o),
+(446,230,cs),
+(446,174,o),
+(414,71,o),
+(333,71,cs),
+(259,71,o),
+(213,171,o),
+(130,171,cs),
+(76,171,o),
+(37,133,o),
+(21,58,cs),
+(9,0,l),
+(93,0,l),
+(99,31,ls),
+(108,70,o),
+(123,89,o),
+(144,89,cs),
+(193,89,o),
+(242,-13,o),
+(346,-13,cs)
+);
+}
+);
+width = 605;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1651;
+unicode = 5713;
+},
+{
+color = 9;
+glyphname = "siCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(469,-13,o),
+(536,128,o),
+(536,229,cs),
+(536,301,o),
+(502,352,o),
+(444,365,c),
+(436,347,l),
+(565,366,o),
+(611,489,o),
+(611,578,cs),
+(611,667,o),
+(562,727,o),
+(482,727,cs),
+(381,727,o),
+(298,625,o),
+(254,625,cs),
+(235,625,o),
+(229,641,o),
+(237,676,cs),
+(245,714,l),
+(161,714,l),
+(148,656,ls),
+(133,586,o),
+(159,543,o),
+(216,543,cs),
+(301,543,o),
+(378,643,o),
+(451,643,cs),
+(494,643,o),
+(519,611,o),
+(519,561,cs),
+(519,489,o),
+(481,391,o),
+(379,391,cs),
+(321,391,l),
+(360,363,l),
+(359,403,o),
+(328,432,o),
+(289,432,cs),
+(262,432,o),
+(237,416,o),
+(226,393,c),
+(92,393,l),
+(77,321,l),
+(226,321,l),
+(238,298,o),
+(262,282,o),
+(289,282,cs),
+(326,282,o),
+(358,312,o),
+(360,351,c),
+(320,323,l),
+(367,323,ls),
+(424,323,o),
+(448,286,o),
+(448,230,cs),
+(448,174,o),
+(414,71,o),
+(333,71,cs),
+(259,71,o),
+(213,171,o),
+(130,171,cs),
+(76,171,o),
+(37,133,o),
+(21,58,cs),
+(9,0,l),
+(93,0,l),
+(99,31,ls),
+(108,70,o),
+(123,89,o),
+(144,89,cs),
+(193,89,o),
+(242,-13,o),
+(346,-13,cs)
+);
+}
+);
+width = 605;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1652;
+unicode = 5714;
+},
+{
+color = 9;
+glyphname = "saCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(270,-13,o),
+(353,89,o),
+(398,89,cs),
+(416,89,o),
+(422,73,o),
+(415,38,cs),
+(407,0,l),
+(491,0,l),
+(503,58,ls),
+(519,128,o),
+(493,171,o),
+(435,171,cs),
+(350,171,o),
+(273,71,o),
+(200,71,cs),
+(157,71,o),
+(134,103,o),
+(134,153,cs),
+(134,225,o),
+(174,319,o),
+(276,319,cs),
+(559,319,l),
+(575,395,l),
+(293,395,ls),
+(236,395,o),
+(205,428,o),
+(205,484,cs),
+(205,540,o),
+(237,643,o),
+(318,643,cs),
+(392,643,o),
+(438,543,o),
+(521,543,cs),
+(575,543,o),
+(614,581,o),
+(630,656,cs),
+(643,714,l),
+(559,714,l),
+(552,683,ls),
+(544,644,o),
+(528,625,o),
+(507,625,cs),
+(458,625,o),
+(409,727,o),
+(305,727,cs),
+(182,727,o),
+(115,586,o),
+(115,485,cs),
+(115,408,o),
+(153,356,o),
+(219,347,c),
+(223,368,l),
+(88,354,o),
+(40,227,o),
+(40,136,cs),
+(40,47,o),
+(89,-13,o),
+(169,-13,cs)
+);
+}
+);
+width = 605;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1653;
+unicode = 5715;
+},
+{
+color = 9;
+glyphname = "shuCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(247,-13,o),
+(307,32,o),
+(345,122,c),
+(323,124,l),
+(326,34,o),
+(372,-13,o),
+(457,-13,cs),
+(592,-13,o),
+(643,118,o),
+(654,249,cs),
+(661,330,o),
+(650,455,o),
+(656,530,cs),
+(659,585,o),
+(675,633,o),
+(730,633,cs),
+(749,633,l),
+(766,714,l),
+(725,714,ls),
+(636,714,o),
+(591,666,o),
+(575,583,cs),
+(572,568,o),
+(570,551,o),
+(569,533,c),
+(592,580,l),
+(469,580,l),
+(498,714,l),
+(416,714,l),
+(388,580,l),
+(264,580,l),
+(274,549,l),
+(283,578,o),
+(289,604,o),
+(289,625,cs),
+(289,683,o),
+(254,714,o),
+(188,714,cs),
+(147,714,l),
+(130,633,l),
+(148,633,ls),
+(181,633,o),
+(196,620,o),
+(196,591,cs),
+(196,494,o),
+(34,282,o),
+(34,131,cs),
+(34,43,o),
+(86,-13,o),
+(171,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(152,72,o),
+(128,98,o),
+(128,147,cs),
+(128,237,o),
+(215,387,o),
+(261,506,c),
+(372,506,l),
+(309,210,ls),
+(289,117,o),
+(252,72,o),
+(195,72,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(377,72,o),
+(378,152,o),
+(391,212,cs),
+(454,506,l),
+(567,506,l),
+(563,427,o),
+(569,328,o),
+(565,261,cs),
+(563,177,o),
+(537,72,o),
+(451,72,cs)
+);
+}
+);
+width = 715;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1654;
+unicode = 5716;
+},
+{
+color = 9;
+glyphname = "shoCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(37,0,ls),
+(126,0,o),
+(170,48,o),
+(187,131,cs),
+(190,146,o),
+(192,163,o),
+(192,181,c),
+(169,134,l),
+(292,134,l),
+(264,0,l),
+(345,0,l),
+(374,134,l),
+(498,134,l),
+(488,165,l),
+(478,136,o),
+(473,110,o),
+(473,89,cs),
+(473,31,o),
+(507,0,o),
+(573,0,cs),
+(614,0,l),
+(632,81,l),
+(613,81,ls),
+(581,81,o),
+(566,94,o),
+(566,123,cs),
+(566,220,o),
+(727,432,o),
+(727,583,cs),
+(727,671,o),
+(676,727,o),
+(591,727,cs),
+(515,727,o),
+(455,682,o),
+(417,592,c),
+(438,590,l),
+(436,680,o),
+(390,727,o),
+(305,727,cs),
+(169,727,o),
+(119,596,o),
+(108,465,cs),
+(101,384,o),
+(112,259,o),
+(105,184,cs),
+(102,129,o),
+(87,81,o),
+(31,81,cs),
+(13,81,l),
+(-5,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,287,o),
+(193,386,o),
+(196,453,cs),
+(199,537,o),
+(224,642,o),
+(310,642,cs),
+(385,642,o),
+(384,562,o),
+(371,502,cs),
+(308,208,l),
+(195,208,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(452,504,ls),
+(472,597,o),
+(509,642,o),
+(566,642,cs),
+(610,642,o),
+(634,616,o),
+(634,567,cs),
+(634,477,o),
+(546,327,o),
+(501,208,c),
+(389,208,l)
+);
+}
+);
+width = 715;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1655;
+unicode = 5717;
+},
+{
+color = 9;
+glyphname = "sheCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(469,-13,o),
+(536,128,o),
+(536,229,cs),
+(536,301,o),
+(502,352,o),
+(444,365,c),
+(436,347,l),
+(565,366,o),
+(611,489,o),
+(611,578,cs),
+(611,667,o),
+(562,727,o),
+(482,727,cs),
+(381,727,o),
+(298,625,o),
+(254,625,cs),
+(235,625,o),
+(229,641,o),
+(237,676,cs),
+(245,714,l),
+(161,714,l),
+(148,656,ls),
+(133,586,o),
+(159,545,o),
+(216,545,cs),
+(232,545,o),
+(247,548,o),
+(262,555,c),
+(225,594,l),
+(183,395,l),
+(92,395,l),
+(76,319,l),
+(167,319,l),
+(125,118,l),
+(179,157,l),
+(164,164,o),
+(147,169,o),
+(130,169,cs),
+(76,169,o),
+(37,133,o),
+(21,58,cs),
+(9,0,l),
+(93,0,l),
+(99,31,ls),
+(108,70,o),
+(123,89,o),
+(144,89,cs),
+(193,89,o),
+(242,-13,o),
+(346,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(240,319,l),
+(358,319,ls),
+(416,319,o),
+(446,286,o),
+(446,230,cs),
+(446,174,o),
+(414,71,o),
+(333,71,cs),
+(283,71,o),
+(246,115,o),
+(203,144,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(293,567,l),
+(346,595,o),
+(399,643,o),
+(451,643,cs),
+(494,643,o),
+(517,611,o),
+(517,561,cs),
+(517,489,o),
+(477,395,o),
+(375,395,cs),
+(256,395,l)
+);
+}
+);
+width = 605;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1656;
+unicode = 5718;
+},
+{
+color = 9;
+glyphname = "sheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(469,-13,o),
+(536,128,o),
+(536,229,cs),
+(536,301,o),
+(502,352,o),
+(444,365,c),
+(436,347,l),
+(565,366,o),
+(611,489,o),
+(611,578,cs),
+(611,667,o),
+(562,727,o),
+(482,727,cs),
+(381,727,o),
+(298,625,o),
+(254,625,cs),
+(235,625,o),
+(229,641,o),
+(237,676,cs),
+(245,714,l),
+(161,714,l),
+(148,656,ls),
+(133,586,o),
+(159,545,o),
+(216,545,cs),
+(228,545,o),
+(241,548,o),
+(253,553,c),
+(225,591,l),
+(182,389,l),
+(91,389,l),
+(77,325,l),
+(169,325,l),
+(125,120,l),
+(169,159,l),
+(157,165,o),
+(144,169,o),
+(130,169,cs),
+(76,169,o),
+(37,133,o),
+(21,58,cs),
+(9,0,l),
+(93,0,l),
+(99,31,ls),
+(108,70,o),
+(123,89,o),
+(144,89,cs),
+(193,89,o),
+(242,-13,o),
+(346,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(280,69,o),
+(241,122,o),
+(190,150,c),
+(228,325,l),
+(315,325,l),
+(295,231,l),
+(338,231,l),
+(361,340,l),
+(343,325,l),
+(363,325,ls),
+(420,325,o),
+(449,286,o),
+(449,230,cs),
+(449,174,o),
+(414,69,o),
+(333,69,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(390,475,l),
+(346,475,l),
+(328,389,l),
+(241,389,l),
+(278,560,l),
+(339,588,o),
+(396,645,o),
+(451,645,cs),
+(494,645,o),
+(519,611,o),
+(519,561,cs),
+(519,489,o),
+(478,389,o),
+(376,389,cs),
+(357,389,l),
+(369,376,l)
+);
+}
+);
+width = 605;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1657;
+unicode = 5719;
+},
+{
+color = 9;
+glyphname = "shiCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(148,656,ls),
+(133,586,o),
+(159,545,o),
+(216,545,cs),
+(229,545,o),
+(241,548,o),
+(254,553,c),
+(225,591,l),
+(182,389,l),
+(91,389,l),
+(77,325,l),
+(168,325,l),
+(125,120,l),
+(168,159,l),
+(156,165,o),
+(143,169,o),
+(130,169,cs),
+(76,169,o),
+(37,133,o),
+(21,58,cs),
+(9,0,l),
+(93,0,l),
+(99,31,ls),
+(108,70,o),
+(123,89,o),
+(144,89,cs),
+(193,89,o),
+(242,-13,o),
+(346,-13,cs),
+(469,-13,o),
+(536,128,o),
+(536,229,cs),
+(536,301,o),
+(502,352,o),
+(444,365,c),
+(436,347,l),
+(565,366,o),
+(611,489,o),
+(611,578,cs),
+(611,667,o),
+(562,727,o),
+(482,727,cs),
+(381,727,o),
+(298,625,o),
+(254,625,cs),
+(235,625,o),
+(229,641,o),
+(237,676,cs),
+(245,714,l),
+(161,714,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(227,325,l),
+(282,325,l),
+(291,299,o),
+(314,282,o),
+(343,282,cs),
+(376,282,o),
+(402,308,o),
+(409,342,c),
+(352,325,l),
+(373,325,ls),
+(425,325,o),
+(450,284,o),
+(450,230,cs),
+(450,174,o),
+(414,69,o),
+(333,69,cs),
+(280,69,o),
+(241,122,o),
+(190,150,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(277,560,l),
+(339,588,o),
+(396,645,o),
+(451,645,cs),
+(494,645,o),
+(520,611,o),
+(520,561,cs),
+(520,489,o),
+(484,389,o),
+(387,389,cs),
+(351,389,l),
+(408,374,l),
+(402,408,o),
+(375,432,o),
+(343,432,cs),
+(316,432,o),
+(291,414,o),
+(281,389,c),
+(241,389,l)
+);
+}
+);
+width = 605;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1658;
+unicode = 5720;
+},
+{
+color = 9;
+glyphname = "shaCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(271,-13,o),
+(353,89,o),
+(398,89,cs),
+(416,89,o),
+(422,73,o),
+(415,38,cs),
+(407,0,l),
+(491,0,l),
+(503,58,ls),
+(519,128,o),
+(493,169,o),
+(435,169,cs),
+(420,169,o),
+(404,166,o),
+(390,159,c),
+(427,120,l),
+(468,319,l),
+(559,319,l),
+(575,395,l),
+(485,395,l),
+(527,596,l),
+(472,557,l),
+(487,550,o),
+(504,545,o),
+(521,545,cs),
+(575,545,o),
+(614,581,o),
+(630,656,cs),
+(643,714,l),
+(559,714,l),
+(552,683,ls),
+(544,644,o),
+(528,625,o),
+(507,625,cs),
+(458,625,o),
+(409,727,o),
+(306,727,cs),
+(183,727,o),
+(115,586,o),
+(115,485,cs),
+(115,413,o),
+(149,362,o),
+(207,349,c),
+(215,367,l),
+(87,348,o),
+(40,225,o),
+(40,136,cs),
+(40,47,o),
+(90,-13,o),
+(169,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(158,71,o),
+(134,103,o),
+(134,153,cs),
+(134,225,o),
+(175,319,o),
+(276,319,cs),
+(395,319,l),
+(359,147,l),
+(305,119,o),
+(252,71,o),
+(200,71,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(236,395,o),
+(205,428,o),
+(205,484,cs),
+(205,540,o),
+(238,643,o),
+(319,643,cs),
+(369,643,o),
+(406,599,o),
+(449,570,c),
+(411,395,l),
+(293,395,ls)
+);
+}
+);
+width = 605;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1659;
+unicode = 5721;
+},
+{
+color = 6;
+glyphname = "shCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(169,99,l),
+(191,205,l),
+(145,190,l),
+(167,190,ls),
+(256,190,o),
+(299,240,o),
+(299,312,cs),
+(299,362,o),
+(270,394,o),
+(218,394,cs),
+(195,394,ls),
+(166,394,o),
+(152,408,o),
+(152,432,cs),
+(152,462,o),
+(165,493,o),
+(212,493,cs),
+(336,493,l),
+(347,546,l),
+(264,546,l),
+(283,636,l),
+(222,636,l),
+(199,526,l),
+(246,546,l),
+(224,546,ls),
+(135,546,o),
+(92,496,o),
+(92,423,cs),
+(92,374,o),
+(121,342,o),
+(173,342,cs),
+(196,342,ls),
+(225,342,o),
+(239,328,o),
+(239,304,cs),
+(239,275,o),
+(226,242,o),
+(179,242,cs),
+(55,242,l),
+(44,190,l),
+(127,190,l),
+(108,99,l)
+);
+}
+);
+width = 340;
+}
+);
+metricRight = "=|";
+note = uni18F5;
+unicode = 5722;
+},
+{
+color = 9;
+glyphname = "tsuCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(247,-13,o),
+(306,32,o),
+(345,122,c),
+(323,124,l),
+(326,34,o),
+(372,-13,o),
+(457,-13,cs),
+(592,-13,o),
+(643,118,o),
+(654,249,cs),
+(661,330,o),
+(650,455,o),
+(656,530,cs),
+(659,585,o),
+(675,633,o),
+(730,633,cs),
+(749,633,l),
+(766,714,l),
+(725,714,ls),
+(622,714,o),
+(583,646,o),
+(573,547,cs),
+(571,504,o),
+(574,451,o),
+(574,394,c),
+(430,394,l),
+(484,649,l),
+(543,649,l),
+(557,714,l),
+(356,714,l),
+(342,649,l),
+(402,649,l),
+(348,394,l),
+(205,394,l),
+(245,484,o),
+(288,570,o),
+(288,625,cs),
+(288,683,o),
+(254,714,o),
+(188,714,cs),
+(147,714,l),
+(130,633,l),
+(148,633,ls),
+(181,633,o),
+(196,620,o),
+(196,591,cs),
+(196,494,o),
+(34,282,o),
+(34,131,cs),
+(34,43,o),
+(86,-13,o),
+(171,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(152,72,o),
+(128,98,o),
+(128,147,cs),
+(128,193,o),
+(150,255,o),
+(179,320,c),
+(332,320,l),
+(309,210,ls),
+(290,117,o),
+(252,72,o),
+(195,72,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(377,72,o),
+(378,152,o),
+(391,212,cs),
+(414,320,l),
+(569,320,l),
+(568,296,o),
+(567,275,o),
+(565,260,cs),
+(563,177,o),
+(537,72,o),
+(451,72,cs)
+);
+}
+);
+width = 715;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165B;
+unicode = 5723;
+},
+{
+color = 9;
+glyphname = "tsoCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(37,0,ls),
+(140,0,o),
+(178,68,o),
+(189,167,cs),
+(191,210,o),
+(188,263,o),
+(188,320,c),
+(332,320,l),
+(278,65,l),
+(218,65,l),
+(205,0,l),
+(406,0,l),
+(419,65,l),
+(359,65,l),
+(413,320,l),
+(556,320,l),
+(517,230,o),
+(474,144,o),
+(474,89,cs),
+(474,31,o),
+(507,0,o),
+(573,0,cs),
+(614,0,l),
+(632,81,l),
+(613,81,ls),
+(581,81,o),
+(566,94,o),
+(566,123,cs),
+(566,220,o),
+(727,432,o),
+(727,583,cs),
+(727,671,o),
+(676,727,o),
+(591,727,cs),
+(515,727,o),
+(455,682,o),
+(417,592,c),
+(438,590,l),
+(436,680,o),
+(390,727,o),
+(305,727,cs),
+(169,727,o),
+(119,596,o),
+(108,465,cs),
+(101,384,o),
+(112,259,o),
+(105,184,cs),
+(102,129,o),
+(87,81,o),
+(31,81,cs),
+(13,81,l),
+(-5,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(193,418,o),
+(195,439,o),
+(196,454,cs),
+(199,537,o),
+(224,642,o),
+(310,642,cs),
+(385,642,o),
+(384,562,o),
+(371,502,cs),
+(348,394,l),
+(192,394,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(452,504,ls),
+(472,597,o),
+(509,642,o),
+(566,642,cs),
+(610,642,o),
+(634,616,o),
+(634,567,cs),
+(634,521,o),
+(611,459,o),
+(583,394,c),
+(429,394,l)
+);
+}
+);
+width = 715;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165C;
+unicode = 5724;
+},
+{
+color = 9;
+glyphname = "tseCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(471,-13,o),
+(538,128,o),
+(538,229,cs),
+(538,301,o),
+(504,352,o),
+(446,365,c),
+(438,347,l),
+(566,366,o),
+(613,489,o),
+(613,578,cs),
+(613,667,o),
+(564,727,o),
+(484,727,cs),
+(383,727,o),
+(302,625,o),
+(258,625,cs),
+(239,625,o),
+(233,641,o),
+(241,676,cs),
+(249,714,l),
+(165,714,l),
+(152,656,ls),
+(137,586,o),
+(163,548,o),
+(220,548,cs),
+(245,548,o),
+(270,556,o),
+(290,569,c),
+(276,600,l),
+(232,389,l),
+(147,389,l),
+(166,477,l),
+(114,477,l),
+(62,237,l),
+(114,237,l),
+(133,325,l),
+(218,325,l),
+(173,113,l),
+(199,143,l),
+(180,156,o),
+(160,166,o),
+(134,166,cs),
+(80,166,o),
+(41,133,o),
+(25,58,cs),
+(13,0,l),
+(97,0,l),
+(104,31,ls),
+(112,70,o),
+(127,89,o),
+(148,89,cs),
+(197,89,o),
+(244,-13,o),
+(348,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(297,71,o),
+(266,98,o),
+(234,123,c),
+(277,325,l),
+(361,325,ls),
+(419,325,o),
+(450,292,o),
+(450,230,cs),
+(450,174,o),
+(417,71,o),
+(336,71,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(333,589,l),
+(374,614,o),
+(414,643,o),
+(454,643,cs),
+(497,643,o),
+(520,611,o),
+(520,561,cs),
+(520,489,o),
+(479,389,o),
+(378,389,cs),
+(291,389,l)
+);
+}
+);
+width = 607;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni165D;
+unicode = 5725;
+},
+{
+color = 9;
+glyphname = "tseeCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(471,-13,o),
+(538,128,o),
+(538,229,cs),
+(538,301,o),
+(504,352,o),
+(446,365,c),
+(438,347,l),
+(566,366,o),
+(613,489,o),
+(613,578,cs),
+(613,667,o),
+(564,727,o),
+(484,727,cs),
+(383,727,o),
+(302,625,o),
+(258,625,cs),
+(239,625,o),
+(233,641,o),
+(241,676,cs),
+(249,714,l),
+(165,714,l),
+(152,656,ls),
+(137,586,o),
+(163,548,o),
+(220,548,cs),
+(245,548,o),
+(270,556,o),
+(290,569,c),
+(268,600,l),
+(224,388,l),
+(143,388,l),
+(162,477,l),
+(114,477,l),
+(62,237,l),
+(110,237,l),
+(129,326,l),
+(210,326,l),
+(165,113,l),
+(199,143,l),
+(180,156,o),
+(160,166,o),
+(134,166,cs),
+(80,166,o),
+(41,133,o),
+(25,58,cs),
+(13,0,l),
+(97,0,l),
+(104,31,ls),
+(112,70,o),
+(127,89,o),
+(148,89,cs),
+(197,89,o),
+(244,-13,o),
+(348,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(294,71,o),
+(254,107,o),
+(222,132,c),
+(262,326,l),
+(334,326,l),
+(313,226,l),
+(357,226,l),
+(381,342,l),
+(353,326,l),
+(362,326,ls),
+(419,326,o),
+(450,292,o),
+(450,230,cs),
+(450,168,o),
+(415,71,o),
+(336,71,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(411,480,l),
+(368,480,l),
+(348,388,l),
+(276,388,l),
+(317,581,l),
+(357,604,o),
+(408,643,o),
+(454,643,cs),
+(497,643,o),
+(521,611,o),
+(521,561,cs),
+(521,489,o),
+(481,388,o),
+(380,388,cs),
+(368,388,l),
+(389,378,l)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165E;
+unicode = 5726;
+},
+{
+color = 9;
+glyphname = "tsiCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(471,-13,o),
+(538,128,o),
+(538,229,cs),
+(538,301,o),
+(504,352,o),
+(446,365,c),
+(438,347,l),
+(566,366,o),
+(613,489,o),
+(613,578,cs),
+(613,667,o),
+(564,727,o),
+(484,727,cs),
+(383,727,o),
+(302,625,o),
+(258,625,cs),
+(239,625,o),
+(233,641,o),
+(241,676,cs),
+(249,714,l),
+(165,714,l),
+(152,656,ls),
+(137,586,o),
+(163,548,o),
+(220,548,cs),
+(245,548,o),
+(269,556,o),
+(289,569,c),
+(267,600,l),
+(222,388,l),
+(143,388,l),
+(162,477,l),
+(114,477,l),
+(62,237,l),
+(110,237,l),
+(129,326,l),
+(209,326,l),
+(164,113,l),
+(198,143,l),
+(179,156,o),
+(160,166,o),
+(134,166,cs),
+(80,166,o),
+(41,133,o),
+(25,58,cs),
+(13,0,l),
+(97,0,l),
+(104,31,ls),
+(112,70,o),
+(127,89,o),
+(148,89,cs),
+(197,89,o),
+(244,-13,o),
+(348,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(294,71,o),
+(253,107,o),
+(221,132,c),
+(261,326,l),
+(301,326,l),
+(309,301,o),
+(331,282,o),
+(358,282,cs),
+(385,282,o),
+(407,300,o),
+(416,331,c),
+(350,326,l),
+(362,326,ls),
+(419,326,o),
+(450,292,o),
+(450,231,cs),
+(450,168,o),
+(415,71,o),
+(336,71,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(417,409,o),
+(392,432,o),
+(363,432,cs),
+(336,432,o),
+(312,413,o),
+(306,388,c),
+(275,388,l),
+(315,581,l),
+(356,603,o),
+(408,643,o),
+(454,643,cs),
+(497,643,o),
+(521,611,o),
+(521,562,cs),
+(521,489,o),
+(481,388,o),
+(380,388,cs),
+(362,388,l),
+(422,377,l)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165F;
+unicode = 5727;
+},
+{
+color = 9;
+glyphname = "tsaCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(270,-13,o),
+(351,89,o),
+(395,89,cs),
+(414,89,o),
+(420,73,o),
+(413,38,cs),
+(404,0,l),
+(488,0,l),
+(501,58,ls),
+(516,128,o),
+(490,166,o),
+(433,166,cs),
+(408,166,o),
+(383,158,o),
+(363,145,c),
+(377,114,l),
+(421,325,l),
+(506,325,l),
+(487,237,l),
+(539,237,l),
+(591,477,l),
+(539,477,l),
+(520,389,l),
+(435,389,l),
+(480,601,l),
+(454,571,l),
+(473,558,o),
+(493,548,o),
+(519,548,cs),
+(573,548,o),
+(612,581,o),
+(628,656,cs),
+(640,714,l),
+(556,714,l),
+(550,683,ls),
+(541,644,o),
+(526,625,o),
+(505,625,cs),
+(456,625,o),
+(409,727,o),
+(305,727,cs),
+(182,727,o),
+(115,586,o),
+(115,485,cs),
+(115,413,o),
+(149,362,o),
+(207,349,c),
+(215,367,l),
+(87,348,o),
+(40,225,o),
+(40,136,cs),
+(40,48,o),
+(89,-13,o),
+(169,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(157,71,o),
+(133,103,o),
+(133,153,cs),
+(133,225,o),
+(174,325,o),
+(275,325,cs),
+(362,325,l),
+(320,125,l),
+(280,100,o),
+(239,71,o),
+(199,71,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(234,389,o),
+(203,422,o),
+(203,484,cs),
+(203,540,o),
+(236,643,o),
+(317,643,cs),
+(356,643,o),
+(387,616,o),
+(419,591,c),
+(376,389,l),
+(292,389,ls)
+);
+}
+);
+width = 606;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1660;
+unicode = 5728;
+},
+{
+color = 9;
+glyphname = "chuCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(247,-13,o),
+(307,32,o),
+(345,122,c),
+(323,124,l),
+(326,34,o),
+(372,-13,o),
+(457,-13,cs),
+(592,-13,o),
+(643,118,o),
+(654,249,cs),
+(661,330,o),
+(650,455,o),
+(656,530,cs),
+(659,585,o),
+(675,633,o),
+(730,633,cs),
+(749,633,l),
+(766,714,l),
+(725,714,ls),
+(622,714,o),
+(583,646,o),
+(573,547,cs),
+(566,472,o),
+(570,336,o),
+(565,261,cs),
+(563,177,o),
+(537,72,o),
+(451,72,cs),
+(377,72,o),
+(378,152,o),
+(391,212,cs),
+(484,649,l),
+(543,649,l),
+(557,714,l),
+(356,714,l),
+(342,649,l),
+(402,649,l),
+(309,210,ls),
+(289,117,o),
+(252,72,o),
+(195,72,cs),
+(152,72,o),
+(128,98,o),
+(128,147,cs),
+(128,267,o),
+(288,516,o),
+(288,625,cs),
+(288,683,o),
+(254,714,o),
+(188,714,cs),
+(147,714,l),
+(130,633,l),
+(148,633,ls),
+(181,633,o),
+(196,620,o),
+(196,591,cs),
+(196,494,o),
+(34,282,o),
+(34,131,cs),
+(34,43,o),
+(86,-13,o),
+(171,-13,cs)
+);
+}
+);
+width = 715;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164E;
+unicode = 5729;
+},
+{
+color = 9;
+glyphname = "choCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(37,0,ls),
+(140,0,o),
+(178,68,o),
+(189,167,cs),
+(196,242,o),
+(192,378,o),
+(196,453,cs),
+(199,537,o),
+(224,642,o),
+(310,642,cs),
+(385,642,o),
+(384,562,o),
+(371,502,cs),
+(278,65,l),
+(218,65,l),
+(205,0,l),
+(406,0,l),
+(419,65,l),
+(359,65,l),
+(452,504,ls),
+(472,597,o),
+(509,642,o),
+(566,642,cs),
+(610,642,o),
+(634,616,o),
+(634,567,cs),
+(634,447,o),
+(474,198,o),
+(474,89,cs),
+(474,31,o),
+(507,0,o),
+(573,0,cs),
+(614,0,l),
+(631,81,l),
+(613,81,ls),
+(581,81,o),
+(566,94,o),
+(566,123,cs),
+(566,220,o),
+(727,432,o),
+(727,583,cs),
+(727,671,o),
+(676,727,o),
+(591,727,cs),
+(515,727,o),
+(455,682,o),
+(417,592,c),
+(438,590,l),
+(436,680,o),
+(390,727,o),
+(305,727,cs),
+(169,727,o),
+(119,596,o),
+(108,465,cs),
+(101,384,o),
+(112,259,o),
+(105,184,cs),
+(102,129,o),
+(87,81,o),
+(31,81,cs),
+(13,81,l),
+(-5,0,l)
+);
+}
+);
+width = 715;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5730;
+},
+{
+color = 9;
+glyphname = "cheCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(471,-13,o),
+(538,128,o),
+(538,229,cs),
+(538,301,o),
+(504,352,o),
+(446,365,c),
+(438,347,l),
+(566,366,o),
+(613,489,o),
+(613,578,cs),
+(613,667,o),
+(564,727,o),
+(484,727,cs),
+(383,727,o),
+(302,625,o),
+(258,625,cs),
+(239,625,o),
+(233,641,o),
+(241,676,cs),
+(249,714,l),
+(165,714,l),
+(152,656,ls),
+(137,586,o),
+(163,546,o),
+(221,546,cs),
+(306,546,o),
+(380,643,o),
+(453,643,cs),
+(496,643,o),
+(519,611,o),
+(519,561,cs),
+(519,489,o),
+(479,395,o),
+(377,395,cs),
+(148,395,l),
+(166,477,l),
+(114,477,l),
+(62,237,l),
+(114,237,l),
+(132,319,l),
+(360,319,ls),
+(418,319,o),
+(448,286,o),
+(448,230,cs),
+(448,174,o),
+(416,71,o),
+(335,71,cs),
+(261,71,o),
+(217,168,o),
+(134,168,cs),
+(80,168,o),
+(41,132,o),
+(25,58,cs),
+(13,0,l),
+(97,0,l),
+(104,31,ls),
+(112,70,o),
+(127,89,o),
+(148,89,cs),
+(197,89,o),
+(244,-13,o),
+(348,-13,cs)
+);
+}
+);
+width = 607;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni1663;
+unicode = 5731;
+},
+{
+color = 9;
+glyphname = "cheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(471,-13,o),
+(538,128,o),
+(538,229,cs),
+(538,301,o),
+(504,352,o),
+(446,365,c),
+(438,347,l),
+(566,366,o),
+(613,489,o),
+(613,578,cs),
+(613,667,o),
+(564,727,o),
+(484,727,cs),
+(383,727,o),
+(302,625,o),
+(258,625,cs),
+(239,625,o),
+(233,641,o),
+(241,676,cs),
+(249,714,l),
+(165,714,l),
+(152,656,ls),
+(137,586,o),
+(163,546,o),
+(220,546,cs),
+(305,546,o),
+(379,645,o),
+(453,645,cs),
+(495,645,o),
+(520,611,o),
+(520,561,cs),
+(520,489,o),
+(481,389,o),
+(379,389,cs),
+(330,389,l),
+(348,372,l),
+(369,475,l),
+(318,475,l),
+(299,389,l),
+(147,389,l),
+(166,477,l),
+(114,477,l),
+(62,237,l),
+(114,237,l),
+(133,325,l),
+(286,325,l),
+(267,231,l),
+(319,231,l),
+(343,346,l),
+(319,325,l),
+(366,325,ls),
+(424,325,o),
+(450,286,o),
+(450,230,cs),
+(450,174,o),
+(416,69,o),
+(335,69,cs),
+(261,69,o),
+(217,168,o),
+(134,168,cs),
+(80,168,o),
+(41,132,o),
+(25,58,cs),
+(13,0,l),
+(97,0,l),
+(104,31,ls),
+(112,70,o),
+(127,89,o),
+(148,89,cs),
+(197,89,o),
+(244,-13,o),
+(348,-13,cs)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1664;
+unicode = 5732;
+},
+{
+color = 9;
+glyphname = "chiCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(471,-13,o),
+(538,128,o),
+(538,229,cs),
+(538,301,o),
+(504,352,o),
+(446,365,c),
+(438,347,l),
+(566,366,o),
+(613,489,o),
+(613,578,cs),
+(613,667,o),
+(564,727,o),
+(484,727,cs),
+(383,727,o),
+(302,625,o),
+(258,625,cs),
+(239,625,o),
+(233,641,o),
+(241,676,cs),
+(249,714,l),
+(165,714,l),
+(152,656,ls),
+(137,586,o),
+(163,546,o),
+(220,546,cs),
+(305,546,o),
+(379,645,o),
+(453,645,cs),
+(495,645,o),
+(520,611,o),
+(520,561,cs),
+(520,489,o),
+(481,389,o),
+(383,389,cs),
+(340,389,l),
+(370,373,l),
+(364,407,o),
+(335,432,o),
+(300,432,cs),
+(269,432,o),
+(245,414,o),
+(234,389,c),
+(147,389,l),
+(166,477,l),
+(114,477,l),
+(62,237,l),
+(114,237,l),
+(133,325,l),
+(234,325,l),
+(245,302,o),
+(267,282,o),
+(300,282,cs),
+(336,282,o),
+(364,308,o),
+(371,344,c),
+(332,325,l),
+(370,325,ls),
+(422,325,o),
+(450,289,o),
+(450,230,cs),
+(450,174,o),
+(416,69,o),
+(335,69,cs),
+(261,69,o),
+(217,168,o),
+(134,168,cs),
+(80,168,o),
+(41,132,o),
+(25,58,cs),
+(13,0,l),
+(97,0,l),
+(104,31,ls),
+(112,70,o),
+(127,89,o),
+(148,89,cs),
+(197,89,o),
+(244,-13,o),
+(348,-13,cs)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1665;
+unicode = 5733;
+},
+{
+color = 9;
+glyphname = "chaCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(271,-11,o),
+(352,91,o),
+(396,91,cs),
+(415,91,o),
+(421,75,o),
+(413,40,cs),
+(405,2,l),
+(489,2,l),
+(502,60,ls),
+(517,130,o),
+(491,170,o),
+(433,170,cs),
+(348,170,o),
+(274,73,o),
+(201,73,cs),
+(158,73,o),
+(135,105,o),
+(135,154,cs),
+(135,227,o),
+(175,321,o),
+(277,321,cs),
+(506,321,l),
+(488,239,l),
+(540,239,l),
+(592,479,l),
+(540,479,l),
+(522,397,l),
+(294,397,ls),
+(236,397,o),
+(206,430,o),
+(206,485,cs),
+(206,542,o),
+(238,645,o),
+(319,645,cs),
+(393,645,o),
+(437,548,o),
+(520,548,cs),
+(574,548,o),
+(613,584,o),
+(629,658,cs),
+(641,716,l),
+(557,716,l),
+(550,685,ls),
+(542,646,o),
+(527,627,o),
+(506,627,cs),
+(457,627,o),
+(410,729,o),
+(306,729,cs),
+(183,729,o),
+(116,588,o),
+(116,487,cs),
+(116,415,o),
+(150,364,o),
+(208,351,c),
+(216,369,l),
+(88,350,o),
+(41,227,o),
+(41,138,cs),
+(41,49,o),
+(90,-11,o),
+(170,-11,cs)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1666;
+unicode = 5734;
+},
+{
+color = 9;
+glyphname = "ttsuCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(247,-13,o),
+(306,32,o),
+(345,122,c),
+(323,124,l),
+(326,34,o),
+(372,-13,o),
+(457,-13,cs),
+(592,-13,o),
+(643,118,o),
+(654,249,cs),
+(661,330,o),
+(650,455,o),
+(656,530,cs),
+(659,585,o),
+(675,633,o),
+(730,633,cs),
+(749,633,l),
+(766,714,l),
+(725,714,ls),
+(622,714,o),
+(583,646,o),
+(573,547,cs),
+(570,523,o),
+(568,500,o),
+(566,477,c),
+(605,544,l),
+(435,420,l),
+(484,649,l),
+(543,649,l),
+(557,714,l),
+(356,714,l),
+(342,649,l),
+(402,649,l),
+(354,421,l),
+(229,545,l),
+(248,478,l),
+(271,536,o),
+(288,588,o),
+(288,625,cs),
+(288,683,o),
+(254,714,o),
+(188,714,cs),
+(147,714,l),
+(130,633,l),
+(148,633,ls),
+(181,633,o),
+(196,620,o),
+(196,591,cs),
+(196,494,o),
+(34,282,o),
+(34,131,cs),
+(34,43,o),
+(86,-13,o),
+(171,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(152,72,o),
+(128,98,o),
+(128,147,cs),
+(128,224,o),
+(189,334,o),
+(233,435,c),
+(336,334,l),
+(309,210,ls),
+(289,117,o),
+(252,72,o),
+(195,72,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(377,72,o),
+(378,152,o),
+(391,212,cs),
+(415,324,l),
+(564,430,l),
+(564,371,o),
+(567,310,o),
+(565,261,cs),
+(563,177,o),
+(537,72,o),
+(451,72,cs)
+);
+}
+);
+width = 715;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1667;
+unicode = 5735;
+},
+{
+color = 9;
+glyphname = "ttsoCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(37,0,ls),
+(140,0,o),
+(178,68,o),
+(189,167,cs),
+(191,191,o),
+(193,214,o),
+(195,237,c),
+(157,170,l),
+(326,294,l),
+(278,65,l),
+(218,65,l),
+(205,0,l),
+(406,0,l),
+(419,65,l),
+(359,65,l),
+(408,293,l),
+(532,169,l),
+(514,236,l),
+(491,178,o),
+(474,126,o),
+(474,89,cs),
+(474,31,o),
+(507,0,o),
+(573,0,cs),
+(614,0,l),
+(632,81,l),
+(613,81,ls),
+(581,81,o),
+(566,94,o),
+(566,123,cs),
+(566,220,o),
+(727,432,o),
+(727,583,cs),
+(727,671,o),
+(676,727,o),
+(591,727,cs),
+(515,727,o),
+(455,682,o),
+(417,592,c),
+(438,590,l),
+(436,680,o),
+(390,727,o),
+(305,727,cs),
+(169,727,o),
+(119,596,o),
+(108,465,cs),
+(101,384,o),
+(112,259,o),
+(105,184,cs),
+(102,129,o),
+(87,81,o),
+(31,81,cs),
+(13,81,l),
+(-5,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(197,343,o),
+(194,404,o),
+(196,453,cs),
+(199,537,o),
+(224,642,o),
+(310,642,cs),
+(385,642,o),
+(384,562,o),
+(371,502,cs),
+(347,390,l),
+(197,284,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(426,380,l),
+(452,504,ls),
+(472,597,o),
+(509,642,o),
+(566,642,cs),
+(610,642,o),
+(634,616,o),
+(634,567,cs),
+(634,490,o),
+(573,380,o),
+(528,279,c)
+);
+}
+);
+width = 715;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1668;
+unicode = 5736;
+},
+{
+color = 9;
+glyphname = "ttseCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(470,-13,o),
+(538,127,o),
+(538,228,cs),
+(538,301,o),
+(504,352,o),
+(445,365,c),
+(437,347,l),
+(566,366,o),
+(613,488,o),
+(613,578,cs),
+(613,666,o),
+(564,727,o),
+(484,727,cs),
+(382,727,o),
+(302,625,o),
+(257,625,cs),
+(239,625,o),
+(233,641,o),
+(240,676,cs),
+(248,714,l),
+(164,714,l),
+(152,656,ls),
+(136,586,o),
+(162,546,o),
+(220,546,cs),
+(230,546,o),
+(238,547,o),
+(247,549,c),
+(207,591,l),
+(234,389,l),
+(147,389,l),
+(166,477,l),
+(114,477,l),
+(62,237,l),
+(114,237,l),
+(133,325,l),
+(222,325,l),
+(110,127,l),
+(171,163,l),
+(160,166,o),
+(148,168,o),
+(134,168,cs),
+(79,168,o),
+(41,132,o),
+(25,58,cs),
+(12,0,l),
+(96,0,l),
+(103,31,ls),
+(111,70,o),
+(127,89,o),
+(148,89,cs),
+(197,89,o),
+(244,-13,o),
+(347,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(277,69,o),
+(240,129,o),
+(194,151,c),
+(290,325,l),
+(370,325,ls),
+(423,325,o),
+(451,291,o),
+(451,236,cs),
+(451,178,o),
+(417,69,o),
+(335,69,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(276,560,l),
+(334,578,o),
+(393,645,o),
+(453,645,cs),
+(497,645,o),
+(521,611,o),
+(521,559,cs),
+(521,490,o),
+(481,389,o),
+(381,389,cs),
+(297,389,l)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1669;
+unicode = 5737;
+},
+{
+color = 9;
+glyphname = "ttseeCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(470,-13,o),
+(538,127,o),
+(538,228,cs),
+(538,301,o),
+(504,352,o),
+(445,365,c),
+(437,347,l),
+(566,366,o),
+(613,488,o),
+(613,578,cs),
+(613,666,o),
+(564,727,o),
+(484,727,cs),
+(382,727,o),
+(302,625,o),
+(257,625,cs),
+(239,625,o),
+(233,641,o),
+(240,676,cs),
+(248,714,l),
+(164,714,l),
+(152,656,ls),
+(136,586,o),
+(162,546,o),
+(220,546,cs),
+(230,546,o),
+(238,547,o),
+(247,549,c),
+(203,591,l),
+(230,389,l),
+(147,389,l),
+(166,477,l),
+(114,477,l),
+(62,237,l),
+(114,237,l),
+(133,325,l),
+(218,325,l),
+(106,127,l),
+(171,163,l),
+(160,166,o),
+(148,168,o),
+(134,168,cs),
+(79,168,o),
+(41,132,o),
+(25,58,cs),
+(12,0,l),
+(96,0,l),
+(103,31,ls),
+(111,70,o),
+(127,89,o),
+(148,89,cs),
+(197,89,o),
+(244,-13,o),
+(347,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(276,69,o),
+(233,136,o),
+(186,156,c),
+(280,325,l),
+(330,325,l),
+(308,226,l),
+(356,226,l),
+(379,337,l),
+(359,325,l),
+(370,325,ls),
+(423,325,o),
+(451,291,o),
+(451,236,cs),
+(451,178,o),
+(417,69,o),
+(335,69,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(410,480,l),
+(362,480,l),
+(343,389,l),
+(287,389,l),
+(266,554,l),
+(323,571,o),
+(391,645,o),
+(453,645,cs),
+(497,645,o),
+(521,611,o),
+(521,559,cs),
+(521,490,o),
+(481,389,o),
+(381,389,cs),
+(371,389,l),
+(387,376,l)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166A;
+unicode = 5738;
+},
+{
+color = 9;
+glyphname = "ttsiCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(470,-13,o),
+(538,127,o),
+(538,228,cs),
+(538,301,o),
+(504,352,o),
+(445,365,c),
+(437,347,l),
+(566,366,o),
+(613,488,o),
+(613,578,cs),
+(613,666,o),
+(564,727,o),
+(484,727,cs),
+(382,727,o),
+(302,625,o),
+(257,625,cs),
+(239,625,o),
+(233,641,o),
+(240,676,cs),
+(248,714,l),
+(164,714,l),
+(152,656,ls),
+(136,586,o),
+(162,546,o),
+(220,546,cs),
+(230,546,o),
+(238,547,o),
+(247,549,c),
+(203,591,l),
+(230,389,l),
+(147,389,l),
+(166,477,l),
+(114,477,l),
+(62,237,l),
+(114,237,l),
+(133,325,l),
+(218,325,l),
+(106,127,l),
+(171,163,l),
+(160,166,o),
+(148,168,o),
+(134,168,cs),
+(79,168,o),
+(41,132,o),
+(25,58,cs),
+(12,0,l),
+(96,0,l),
+(103,31,ls),
+(111,70,o),
+(127,89,o),
+(148,89,cs),
+(197,89,o),
+(244,-13,o),
+(347,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(276,69,o),
+(232,136,o),
+(185,156,c),
+(280,325,l),
+(291,325,l),
+(298,304,o),
+(322,282,o),
+(350,282,cs),
+(383,282,o),
+(405,308,o),
+(413,337,c),
+(359,325,l),
+(371,325,ls),
+(423,325,o),
+(451,291,o),
+(451,236,cs),
+(451,178,o),
+(417,69,o),
+(335,69,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(405,412,o),
+(379,432,o),
+(350,432,cs),
+(324,432,o),
+(298,413,o),
+(291,389,c),
+(286,389,l),
+(265,554,l),
+(323,570,o),
+(391,645,o),
+(453,645,cs),
+(497,645,o),
+(521,611,o),
+(521,559,cs),
+(521,490,o),
+(482,389,o),
+(382,389,cs),
+(371,389,l),
+(413,376,l)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166B;
+unicode = 5739;
+},
+{
+color = 9;
+glyphname = "ttsaCarrier-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(271,-13,o),
+(351,89,o),
+(396,89,cs),
+(414,89,o),
+(420,73,o),
+(413,38,cs),
+(405,0,l),
+(489,0,l),
+(501,58,ls),
+(517,128,o),
+(491,168,o),
+(433,168,cs),
+(423,168,o),
+(415,167,o),
+(406,165,c),
+(446,123,l),
+(419,325,l),
+(506,325,l),
+(487,237,l),
+(539,237,l),
+(591,477,l),
+(539,477,l),
+(520,389,l),
+(431,389,l),
+(543,587,l),
+(482,551,l),
+(493,548,o),
+(506,546,o),
+(519,546,cs),
+(574,546,o),
+(612,582,o),
+(628,656,cs),
+(641,714,l),
+(557,714,l),
+(550,683,ls),
+(542,644,o),
+(526,625,o),
+(505,625,cs),
+(456,625,o),
+(409,727,o),
+(306,727,cs),
+(183,727,o),
+(115,587,o),
+(115,486,cs),
+(115,413,o),
+(149,362,o),
+(208,349,c),
+(216,367,l),
+(87,348,o),
+(40,226,o),
+(40,136,cs),
+(40,48,o),
+(89,-13,o),
+(169,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(157,69,o),
+(133,103,o),
+(133,155,cs),
+(133,224,o),
+(172,325,o),
+(272,325,cs),
+(356,325,l),
+(377,154,l),
+(320,136,o),
+(261,69,o),
+(200,69,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(230,389,o),
+(202,423,o),
+(202,478,cs),
+(202,536,o),
+(236,645,o),
+(318,645,cs),
+(376,645,o),
+(413,585,o),
+(459,563,c),
+(363,389,l),
+(283,389,ls)
+);
+}
+);
+width = 606;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni166C;
+unicode = 5740;
+},
+{
+glyphname = "qai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (270,0);
+ref = "ke-canadian";
+}
+);
+width = 767;
+}
+);
+note = uni166F;
+unicode = 5743;
+},
+{
+glyphname = "ngai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (516,0);
+ref = "ce-canadian";
+}
+);
+width = 1006;
+}
+);
+note = uni1670;
+unicode = 5744;
+},
+{
+glyphname = "nngi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (756,0);
+ref = "ci-canadian";
+}
+);
+width = 1245;
+}
+);
+note = uni1671;
+unicode = 5745;
+},
+{
+glyphname = "nngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (756,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (937,0);
+ref = dot_top;
+}
+);
+width = 1245;
+}
+);
+note = uni1672;
+unicode = 5746;
+},
+{
+glyphname = "nngo-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (756,0);
+ref = "ce-canadian";
+}
+);
+width = 1245;
+}
+);
+note = uni1673;
+unicode = 5747;
+},
+{
+glyphname = "nngoo-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (756,0);
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (928,0);
+ref = dot_top;
+}
+);
+width = 1245;
+}
+);
+note = uni1674;
+unicode = 5748;
+},
+{
+glyphname = "nnga-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (756,0);
+ref = "ca-canadian";
+}
+);
+width = 1245;
+}
+);
+note = uni1675;
+unicode = 5749;
+},
+{
+glyphname = "nngaa-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (756,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (791,0);
+ref = dot_top;
+}
+);
+width = 1245;
+}
+);
+note = uni1676;
+unicode = 5750;
+},
+{
+glyphname = "thweeWoodScree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (514,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 706;
+}
+);
+note = uni1677;
+unicode = 5751;
+},
+{
+glyphname = "thwiWoodScree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (514,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 706;
+}
+);
+note = uni1678;
+unicode = 5752;
+},
+{
+glyphname = "thwiiWoodScree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (71,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (514,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 706;
+}
+);
+note = uni1679;
+unicode = 5753;
+},
+{
+glyphname = "thwoWoodScree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (514,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 706;
+}
+);
+note = uni167A;
+unicode = 5754;
+},
+{
+glyphname = "thwooWoodScree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (303,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (514,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 706;
+}
+);
+note = uni167B;
+unicode = 5755;
+},
+{
+glyphname = "thwaWoodScree-canadian";
+lastChange = "2023-01-13 15:30:02 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = middle_right_can;
+pos = (515,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 706;
+}
+);
+note = uni167C;
+unicode = 5756;
+},
+{
+glyphname = "thwaaWoodScree-canadian";
+lastChange = "2023-01-13 15:30:02 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (71,0);
+ref = dot_top;
+},
+{
+anchor = middle_right_can;
+pos = (515,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 706;
+}
+);
+note = uni167D;
+unicode = 5757;
+},
+{
+glyphname = "wBlackfoot-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(385,578,l),
+(397,634,l),
+(134,634,l),
+(122,578,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(355,437,l),
+(367,493,l),
+(103,493,l),
+(91,437,l)
+);
+}
+);
+width = 366;
+}
+);
+metricRight = "=|";
+note = uni167F;
+unicode = 5759;
+},
+{
+glyphname = "oy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-20,0);
+ref = ring_top.canadian;
+}
+);
+width = 569;
+}
+);
+note = uni18B0;
+unicode = 6320;
+},
+{
+glyphname = "ay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (347,0);
+ref = ring_top.canadian;
+}
+);
+width = 569;
+}
+);
+note = uni18B1;
+unicode = 6321;
+},
+{
+glyphname = "aay-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (134,0);
+ref = ring_top.canadian;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (396,0);
+ref = dot_top;
+}
+);
+width = 569;
+}
+);
+note = uni18B2;
+unicode = 6322;
+},
+{
+glyphname = "way-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (539,0);
+ref = ring_top.canadian;
+}
+);
+width = 761;
+}
+);
+note = uni18B3;
+unicode = 6323;
+},
+{
+glyphname = "poy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-37,0);
+ref = ring_top.canadian;
+}
+);
+width = 545;
+}
+);
+note = uni18B4;
+unicode = 6324;
+},
+{
+glyphname = "pay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (344,0);
+ref = ring_top.canadian;
+}
+);
+width = 545;
+}
+);
+note = uni18B5;
+unicode = 6325;
+},
+{
+glyphname = "pwoy-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (155,0);
+ref = ring_top.canadian;
+}
+);
+width = 736;
+}
+);
+note = uni18B6;
+unicode = 6326;
+},
+{
+glyphname = "tay-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (158,0);
+ref = ring_top.canadian;
+}
+);
+width = 504;
+}
+);
+note = uni18B7;
+unicode = 6327;
+},
+{
+glyphname = "kay-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-15,0);
+ref = ring_top.canadian;
+}
+);
+width = 498;
+}
+);
+note = uni18B8;
+unicode = 6328;
+},
+{
+glyphname = "kway-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (177,0);
+ref = ring_top.canadian;
+}
+);
+width = 689;
+}
+);
+note = uni18B9;
+unicode = 6329;
+},
+{
+glyphname = "may-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-10,0);
+ref = ring_top.canadian;
+}
+);
+width = 446;
+}
+);
+note = uni18BA;
+unicode = 6330;
+},
+{
+glyphname = "noy-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (263,-200);
+ref = ring_top.canadian;
+}
+);
+width = 676;
+}
+);
+note = uni18BB;
+unicode = 6331;
+},
+{
+glyphname = "nay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (88,-200);
+ref = ring_top.canadian;
+}
+);
+width = 676;
+}
+);
+note = uni18BC;
+unicode = 6332;
+},
+{
+glyphname = "lay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (89,-200);
+ref = ring_top.canadian;
+}
+);
+width = 676;
+}
+);
+note = uni18BD;
+unicode = 6333;
+},
+{
+glyphname = "soy-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (226,0);
+ref = ring_top.canadian;
+}
+);
+width = 454;
+}
+);
+note = uni18BE;
+unicode = 6334;
+},
+{
+glyphname = "say-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-10,0);
+ref = ring_top.canadian;
+}
+);
+width = 454;
+}
+);
+note = uni18BF;
+unicode = 6335;
+},
+{
+glyphname = "shoy-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (224,-200);
+ref = ring_top.canadian;
+}
+);
+width = 775;
+}
+);
+note = uni18C0;
+unicode = 6336;
+},
+{
+glyphname = "shay-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (226,-200);
+ref = ring_top.canadian;
+}
+);
+width = 775;
+}
+);
+note = uni18C1;
+unicode = 6337;
+},
+{
+glyphname = "shwoy-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (416,-200);
+ref = ring_top.canadian;
+}
+);
+width = 966;
+}
+);
+note = uni18C2;
+unicode = 6338;
+},
+{
+glyphname = "yoy-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (254,0);
+ref = ring_top.canadian;
+}
+);
+width = 479;
+}
+);
+note = uni18C3;
+unicode = 6339;
+},
+{
+glyphname = "yay-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-13,0);
+ref = ring_top.canadian;
+}
+);
+width = 479;
+}
+);
+note = uni18C4;
+unicode = 6340;
+},
+{
+glyphname = "ray-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (136,0);
+ref = ring_top.canadian;
+}
+);
+width = 456;
+}
+);
+note = uni18C5;
+unicode = 6341;
+},
+{
+glyphname = "nwi-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ni-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni18C6;
+unicode = 6342;
+},
+{
+glyphname = "nwiOjibway-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (676,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni18C7;
+unicode = 6343;
+},
+{
+glyphname = "nwii-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (339,-200);
+ref = dot_top;
+}
+);
+width = 867;
+}
+);
+note = uni18C8;
+unicode = 6344;
+},
+{
+glyphname = "nwiiOjibway-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (147,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (676,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni18C9;
+unicode = 6345;
+},
+{
+glyphname = "nwo-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "no-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni18CA;
+unicode = 6346;
+},
+{
+glyphname = "nwoOjibway-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (676,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni18CB;
+unicode = 6347;
+},
+{
+glyphname = "nwoo-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (503,-200);
+ref = dot_top;
+}
+);
+width = 867;
+}
+);
+note = uni18CC;
+unicode = 6348;
+},
+{
+glyphname = "nwooOjibway-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (312,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (676,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni18CD;
+unicode = 6349;
+},
+{
+glyphname = "rwee-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "reRCree-canadian";
+}
+);
+width = 903;
+}
+);
+note = uni18CE;
+unicode = 6350;
+},
+{
+glyphname = "rwi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ri-canadian";
+}
+);
+width = 903;
+}
+);
+note = uni18CF;
+unicode = 6351;
+},
+{
+glyphname = "rwii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (332,-200);
+ref = dot_top;
+}
+);
+width = 903;
+}
+);
+note = uni18D0;
+unicode = 6352;
+},
+{
+glyphname = "rwo-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ro-canadian";
+}
+);
+width = 647;
+}
+);
+note = uni18D1;
+unicode = 6353;
+},
+{
+glyphname = "rwoo-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (321,0);
+ref = dot_top;
+}
+);
+width = 647;
+}
+);
+note = uni18D2;
+unicode = 6354;
+},
+{
+glyphname = "rwa-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ra-canadian";
+}
+);
+width = 647;
+}
+);
+note = uni18D3;
+unicode = 6355;
+},
+{
+glyphname = "pOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(118,357,l),
+(275,643,l),
+(235,643,l),
+(270,357,l),
+(328,357,l),
+(331,371,l),
+(276,714,l),
+(259,714,l),
+(58,371,l),
+(55,357,l)
+);
+}
+);
+width = 335;
+}
+);
+metricLeft = "kkCarrier-canadian";
+note = uni18D4;
+unicode = 6356;
+},
+{
+glyphname = "tOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 353;
+}
+);
+metricRight = "=|";
+note = uni1422;
+unicode = 6357;
+},
+{
+glyphname = "kOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(138,357,l),
+(174,525,l),
+(158,520,l),
+(155,478,o),
+(183,450,o),
+(224,450,cs),
+(308,450,o),
+(342,559,o),
+(342,619,cs),
+(342,682,o),
+(308,721,o),
+(249,721,cs),
+(185,721,o),
+(142,677,o),
+(123,588,cs),
+(75,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(193,499,o),
+(179,517,o),
+(179,549,cs),
+(179,582,o),
+(197,671,o),
+(248,671,cs),
+(272,671,o),
+(285,653,o),
+(285,622,cs),
+(285,585,o),
+(266,499,o),
+(217,499,cs)
+);
+}
+);
+width = 310;
+}
+);
+metricLeft = "k-canadian";
+metricRight = "k-canadian";
+note = uni18D6;
+unicode = 6358;
+},
+{
+glyphname = "cOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(138,357,l),
+(191,605,ls),
+(200,650,o),
+(220,668,o),
+(249,668,cs),
+(282,668,o),
+(293,640,o),
+(285,602,cs),
+(277,567,l),
+(336,567,l),
+(341,592,ls),
+(356,665,o),
+(325,720,o),
+(248,720,cs),
+(183,720,o),
+(143,677,o),
+(126,601,cs),
+(74,357,l)
+);
+}
+);
+width = 299;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni18D7;
+unicode = 6359;
+},
+{
+glyphname = "mOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(138,357,l),
+(201,653,l),
+(330,653,l),
+(343,714,l),
+(150,714,l),
+(74,357,l)
+);
+}
+);
+width = 275;
+}
+);
+metricLeft = "m-canadian";
+metricRight = "m-canadian";
+note = uni18D8;
+unicode = 6360;
+},
+{
+glyphname = "nOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(292,443,o),
+(330,541,o),
+(330,611,cs),
+(330,634,o),
+(324,661,o),
+(305,677,c),
+(298,653,l),
+(443,653,l),
+(457,714,l),
+(241,714,ls),
+(148,714,o),
+(110,617,o),
+(110,545,cs),
+(110,482,o),
+(146,443,o),
+(203,443,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(180,492,o),
+(167,511,o),
+(167,545,cs),
+(167,583,o),
+(183,665,o),
+(234,665,cs),
+(260,665,o),
+(274,646,o),
+(274,612,cs),
+(274,574,o),
+(257,492,o),
+(207,492,cs)
+);
+}
+);
+width = 389;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "n-canadian";
+note = uni18D9;
+unicode = 6361;
+},
+{
+glyphname = "sOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(139,357,l),
+(170,501,l),
+(124,476,l),
+(155,476,ls),
+(250,476,o),
+(305,526,o),
+(327,631,cs),
+(345,714,l),
+(281,714,l),
+(264,637,ls),
+(248,560,o),
+(212,528,o),
+(144,528,cs),
+(111,528,l),
+(75,357,l)
+);
+}
+);
+width = 297;
+}
+);
+metricLeft = "s-canadian";
+metricRight = "s-canadian";
+note = uni18DA;
+unicode = 6362;
+},
+{
+color = 1;
+glyphname = "shOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(233,353,o),
+(272,394,o),
+(295,474,cs),
+(333,604,ls),
+(345,648,o),
+(362,670,o),
+(392,670,cs),
+(423,670,o),
+(436,649,o),
+(426,608,cs),
+(418,569,l),
+(477,569,l),
+(484,598,ls),
+(500,673,o),
+(466,722,o),
+(395,722,cs),
+(331,722,o),
+(292,681,o),
+(269,600,cs),
+(231,471,ls),
+(219,427,o),
+(202,404,o),
+(171,404,cs),
+(140,404,o),
+(128,425,o),
+(137,467,cs),
+(146,506,l),
+(86,506,l),
+(80,476,ls),
+(64,402,o),
+(98,353,o),
+(169,353,cs)
+);
+}
+);
+width = 440;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "c-canadian";
+note = uni18DB;
+unicode = 6363;
+},
+{
+color = 9;
+glyphname = "easternw-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (-40,-318);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (123,0);
+ref = "glottalstop-canadian";
+}
+);
+width = 486;
+}
+);
+note = uni18DC;
+unicode = 6364;
+},
+{
+color = 9;
+glyphname = "westernw-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (656,-318);
+ref = dot_top;
+scale = (-1,1);
+},
+{
+alignment = -1;
+ref = "glottalstop-canadian";
+}
+);
+width = 491;
+}
+);
+metricLeft = "glottalstop-canadian";
+note = uni18DD;
+unicode = 6365;
+},
+{
+glyphname = "rweRCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "reRCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (711,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 903;
+}
+);
+note = uni18E0;
+unicode = 6368;
+},
+{
+glyphname = "looWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (39,0);
+ref = dot_top;
+}
+);
+width = 456;
+}
+);
+note = uni18E1;
+unicode = 6369;
+},
+{
+glyphname = "laaWestCree-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (277,0);
+ref = dot_top;
+}
+);
+width = 456;
+}
+);
+note = uni18E2;
+unicode = 6370;
+},
+{
+glyphname = "thwe-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "the-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (610,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 801;
+}
+);
+note = uni18E3;
+unicode = 6371;
+},
+{
+glyphname = "thwa-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (560,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 752;
+}
+);
+note = uni18E4;
+unicode = 6372;
+},
+{
+glyphname = "tthwe-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "tthe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (602,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni18E5;
+unicode = 6373;
+},
+{
+glyphname = "tthoo-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ttho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (175,0);
+ref = dot_top;
+}
+);
+width = 522;
+}
+);
+note = uni18E6;
+unicode = 6374;
+},
+{
+glyphname = "tthaa-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ttha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (191,0);
+ref = dot_top;
+}
+);
+width = 522;
+}
+);
+note = uni18E7;
+unicode = 6375;
+},
+{
+glyphname = "tlhwe-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "tlhe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (505,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 696;
+}
+);
+note = uni18E8;
+unicode = 6376;
+},
+{
+glyphname = "tlhoo-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "tlho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (192,0);
+ref = dot_top;
+}
+);
+width = 505;
+}
+);
+note = uni18E9;
+unicode = 6377;
+},
+{
+glyphname = "shweSayisi-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "sheSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (505,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 696;
+}
+);
+note = uni18EA;
+unicode = 6378;
+},
+{
+glyphname = "shooSayisi-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "shoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (330,0);
+ref = dot_top;
+}
+);
+width = 505;
+}
+);
+note = uni18EB;
+unicode = 6379;
+},
+{
+color = 9;
+glyphname = "hooSayisi-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "hoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (386,0);
+ref = dot_top;
+}
+);
+width = 564;
+}
+);
+note = uni18EC;
+unicode = 6380;
+},
+{
+color = 9;
+glyphname = "gwuCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "guCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (709,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 901;
+}
+);
+note = uni18ED;
+unicode = 6381;
+},
+{
+color = 9;
+glyphname = "deneGeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "geCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (231,0);
+ref = dot_top;
+}
+);
+width = 596;
+}
+);
+note = uni18EE;
+unicode = 6382;
+},
+{
+color = 9;
+glyphname = "gaaCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (241,0);
+ref = dot_top;
+}
+);
+width = 596;
+}
+);
+note = uni18EF;
+unicode = 6383;
+},
+{
+color = 9;
+glyphname = "gwaCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (596,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni18F0;
+unicode = 6384;
+},
+{
+color = 9;
+glyphname = "juuSayisi-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "juSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (246,0);
+ref = dot_top;
+}
+);
+width = 594;
+}
+);
+note = uni18F1;
+unicode = 6385;
+},
+{
+color = 9;
+glyphname = "jwaCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "jaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (646,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni18F2;
+unicode = 6386;
+},
+{
+glyphname = "lBeaverDene-canadian";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "pWestCree-canadian";
+}
+);
+width = 166;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+unicode = 6387;
+},
+{
+glyphname = "rBeaverDene-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(138,357,l),
+(183,569,ls),
+(195,625,o),
+(221,654,o),
+(261,654,cs),
+(268,654,l),
+(282,720,l),
+(278,720,ls),
+(232,720,o),
+(199,689,o),
+(186,633,c),
+(191,633,l),
+(208,714,l),
+(150,714,l),
+(74,357,l)
+);
+}
+);
+width = 210;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni18F4;
+unicode = 6388;
+},
+{
+color = 6;
+glyphname = "sDentalCarrier-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(167,190,ls),
+(255,190,o),
+(299,239,o),
+(299,312,cs),
+(299,362,o),
+(269,394,o),
+(217,394,cs),
+(195,394,ls),
+(166,394,o),
+(151,408,o),
+(151,432,cs),
+(151,461,o),
+(165,494,o),
+(212,494,cs),
+(335,494,l),
+(347,546,l),
+(223,546,ls),
+(135,546,o),
+(92,496,o),
+(92,423,cs),
+(92,373,o),
+(121,342,o),
+(173,342,cs),
+(195,342,ls),
+(224,342,o),
+(239,328,o),
+(239,304,cs),
+(239,275,o),
+(225,242,o),
+(178,242,cs),
+(55,242,l),
+(43,190,l)
+);
+}
+);
+width = 340;
+}
+);
+metricLeft = "shCarrier-canadian";
+metricRight = "=|";
+note = uni18F5;
+unicode = 6389;
+},
+{
+glyphname = "pWestCree-canadian.base";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "pWestCree-canadian";
+}
+);
+width = 166;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.base";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "c-canadian";
+}
+);
+width = 299;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "thSayisi-canadian.base";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "thSayisi-canadian";
+}
+);
+width = 300;
+}
+);
+metricLeft = "=|c-canadian";
+note = uni14A2;
+},
+{
+glyphname = "mWestCree-canadian.base";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "mWestCree-canadian";
+}
+);
+width = 303;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+glyphname = "pWestCree-canadian.mid";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-168);
+ref = "pWestCree-canadian";
+}
+);
+width = 167;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.mid";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-168);
+ref = "c-canadian";
+}
+);
+width = 300;
+}
+);
+metricLeft = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "mWestCree-canadian.mid";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "mWestCree-canadian";
+}
+);
+width = 303;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+color = 11;
+glyphname = "ngaai-canadian.nunavik";
+lastChange = "2023-01-13 15:30:02 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (538,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (670,0);
+ref = ring_top.canadian;
+}
+);
+width = 1030;
+}
+);
+note = uni158E;
+},
+{
+color = 11;
+glyphname = "ngi-canadian.nunavik";
+lastChange = "2023-01-13 15:30:02 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (538,0);
+ref = "ci-canadian";
+}
+);
+width = 1030;
+}
+);
+note = uni158F;
+},
+{
+color = 11;
+glyphname = "ngii-canadian.nunavik";
+lastChange = "2023-01-13 15:30:02 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (538,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (719,0);
+ref = dot_top;
+}
+);
+width = 1030;
+}
+);
+note = uni1590;
+},
+{
+color = 11;
+glyphname = "ngo-canadian.nunavik";
+lastChange = "2023-01-13 15:30:02 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (538,0);
+ref = "co-canadian";
+}
+);
+width = 1031;
+}
+);
+note = uni1591;
+},
+{
+color = 11;
+glyphname = "ngoo-canadian.nunavik";
+lastChange = "2023-01-13 15:30:02 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "ngo-canadian.nunavik";
+},
+{
+anchor = top_right_can;
+pos = (855,0);
+ref = dot_top;
+}
+);
+width = 1031;
+}
+);
+note = uni1592;
+},
+{
+color = 11;
+glyphname = "nga-canadian.nunavik";
+lastChange = "2023-01-13 15:30:02 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (538,0);
+ref = "ca-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni1593;
+},
+{
+color = 11;
+glyphname = "ngaa-canadian.nunavik";
+lastChange = "2023-01-13 15:30:02 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (538,0);
+ref = "ca-canadian";
+},
+{
+anchor = top_left_can;
+pos = (573,0);
+ref = dot_top;
+}
+);
+width = 1029;
+}
+);
+note = uni1594;
+},
+{
+color = 11;
+glyphname = "ng-canadian.nunavik";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(477,163,o),
+(510,272,o),
+(510,337,cs),
+(510,396,o),
+(481,434,o),
+(431,434,cs),
+(399,434,o),
+(373,416,o),
+(357,385,c),
+(371,381,l),
+(399,510,l),
+(276,510,l),
+(280,486,l),
+(316,514,o),
+(331,577,o),
+(331,617,cs),
+(331,679,o),
+(297,720,o),
+(238,720,cs),
+(150,720,o),
+(112,623,o),
+(112,552,cs),
+(112,488,o),
+(148,449,o),
+(208,449,cs),
+(348,449,l),
+(327,478,l),
+(291,311,ls),
+(278,248,o),
+(293,163,o),
+(381,163,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(360,212,o),
+(345,231,o),
+(345,265,cs),
+(345,300,o),
+(362,385,o),
+(413,385,cs),
+(438,385,o),
+(452,367,o),
+(452,333,cs),
+(452,297,o),
+(434,212,o),
+(385,212,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(181,498,o),
+(167,517,o),
+(167,551,cs),
+(167,588,o),
+(185,671,o),
+(234,671,cs),
+(260,671,o),
+(275,652,o),
+(275,617,cs),
+(275,582,o),
+(257,498,o),
+(207,498,cs)
+);
+}
+);
+width = 538;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+color = 11;
+glyphname = "ngai-canadian.nunavik";
+lastChange = "2023-01-13 15:30:02 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (538,0);
+ref = "ce-canadian";
+}
+);
+width = 1031;
+}
+);
+note = uni1670;
+},
+{
+color = 11;
+glyphname = "ke-canadian.square";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (384,714);
+},
+{
+name = top_left_can;
+pos = (197,714);
+},
+{
+name = top_right_can;
+pos = (572,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(466,0,l),
+(618,714,l),
+(447,714,ls),
+(172,714,o),
+(83,525,o),
+(83,368,cs),
+(83,226,o),
+(174,139,o),
+(328,139,cs),
+(402,139,l),
+(373,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(232,222,o),
+(175,274,o),
+(175,371,cs),
+(175,471,o),
+(219,631,o),
+(425,631,cs),
+(507,631,l),
+(419,222,l),
+(345,222,ls)
+);
+}
+);
+width = 581;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146B;
+},
+{
+color = 11;
+glyphname = "ki-canadian.square";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (396,714);
+},
+{
+name = top_left_can;
+pos = (208,714);
+},
+{
+name = top_right_can;
+pos = (584,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(102,0,l),
+(132,139,l),
+(215,139,ls),
+(485,139,o),
+(573,329,o),
+(573,484,cs),
+(573,626,o),
+(482,714,o),
+(330,714,cs),
+(160.996,714,l),
+(8.996,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(237,631,l),
+(317,631,ls),
+(424,631,o),
+(481,579,o),
+(481,482,cs),
+(481,382,o),
+(441,222,o),
+(234,222,cs),
+(150,222,l)
+);
+}
+);
+width = 580;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni146D;
+},
+{
+color = 11;
+glyphname = "kii-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (226,0);
+ref = dot_top;
+}
+);
+width = 582;
+}
+);
+note = uni146E;
+},
+{
+color = 11;
+glyphname = "ko-canadian.square";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (384,714);
+},
+{
+name = top_left_can;
+pos = (197,714);
+},
+{
+name = top_right_can;
+pos = (572,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(466,0,l),
+(618,714,l),
+(525,714,l),
+(496,575,l),
+(412,575,ls),
+(141,575,o),
+(53,385,o),
+(53,230,cs),
+(53,88,o),
+(145,0,o),
+(297,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(203,83,o),
+(145,135,o),
+(145,232,cs),
+(145,332,o),
+(186,492,o),
+(393,492,cs),
+(477,492,l),
+(390,83,l),
+(310,83,ls)
+);
+}
+);
+width = 581;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146F;
+},
+{
+color = 11;
+glyphname = "koo-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (403,0);
+ref = dot_top;
+}
+);
+width = 582;
+}
+);
+note = uni1470;
+},
+{
+color = 11;
+glyphname = "ka-canadian.square";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (396,714);
+},
+{
+name = top_left_can;
+pos = (208,714);
+},
+{
+name = top_right_can;
+pos = (584,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(181,0,ls),
+(455,0,o),
+(544,189,o),
+(544,346,cs),
+(544,488,o),
+(452,575,o),
+(299,575,cs),
+(225,575,l),
+(254,714,l),
+(160.996,714,l),
+(8.996,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(208,492,l),
+(282,492,ls),
+(395,492,o),
+(452,440,o),
+(452,343,cs),
+(452,243,o),
+(407,83,o),
+(202,83,cs),
+(121,83,l)
+);
+}
+);
+width = 580;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1472;
+},
+{
+color = 11;
+glyphname = "kaa-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (39,0);
+ref = dot_top;
+}
+);
+width = 582;
+}
+);
+note = uni1473;
+},
+{
+color = 11;
+glyphname = "kweWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (582,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 773;
+}
+);
+note = uni1475;
+},
+{
+color = 11;
+glyphname = "kwiiWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (226,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (582,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 773;
+}
+);
+note = uni1479;
+},
+{
+color = 11;
+glyphname = "kwoWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (582,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 773;
+}
+);
+note = uni147B;
+},
+{
+color = 11;
+glyphname = "kwooWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (403,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (582,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 773;
+}
+);
+note = uni147D;
+},
+{
+color = 11;
+glyphname = "kwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (582,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 773;
+}
+);
+note = uni147F;
+},
+{
+color = 11;
+glyphname = "kwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (39,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (582,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 773;
+}
+);
+note = uni1481;
+},
+{
+color = 11;
+glyphname = "ce-canadian.square";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (391,714);
+},
+{
+name = top_left_can;
+pos = (195,714);
+},
+{
+name = top_right_can;
+pos = (587,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(481,0,l),
+(576,447,ls),
+(612,617,o),
+(533,727,o),
+(371,727,cs),
+(226,727,o),
+(132,636,o),
+(96,469,cs),
+(82,402,l),
+(174,402,l),
+(188,465,ls),
+(212,582,o),
+(271,640,o),
+(364,641,cs),
+(466,641,o),
+(510,573,o),
+(484,453,cs),
+(388,0,l)
+);
+}
+);
+width = 593;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni1489;
+},
+{
+color = 11;
+glyphname = "ci-canadian.square";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (401,714);
+},
+{
+name = top_left_can;
+pos = (206,714);
+},
+{
+name = top_right_can;
+pos = (598,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,0,l),
+(201,475,ls),
+(224,585,o),
+(283,641,o),
+(373,641,cs),
+(476,641,o),
+(521,573,o),
+(496,458,cs),
+(484,402,l),
+(577,402,l),
+(586,446,ls),
+(622,615,o),
+(539,728,o),
+(380,728,cs),
+(237,728,o),
+(143,641,o),
+(108,476,cs),
+(7,0,l)
+);
+}
+);
+width = 593;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+},
+{
+color = 11;
+glyphname = "cii-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (230,0);
+ref = dot_top;
+}
+);
+width = 592;
+}
+);
+note = uni148C;
+},
+{
+color = 11;
+glyphname = "co-canadian.square";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (391,714);
+},
+{
+name = top_left_can;
+pos = (195,714);
+},
+{
+name = top_right_can;
+pos = (587,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(403,-14,o),
+(497,73,o),
+(532,238,cs),
+(633,714,l),
+(540,714,l),
+(439,239,ls),
+(415,129,o),
+(357,73,o),
+(267,73,cs),
+(164,73,o),
+(118,141,o),
+(144,256,cs),
+(156,312,l),
+(63,312,l),
+(54,268,ls),
+(18,99,o),
+(101,-14,o),
+(260,-14,cs)
+);
+}
+);
+width = 593;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+},
+{
+color = 11;
+glyphname = "coo-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (417,0);
+ref = dot_top;
+}
+);
+width = 592;
+}
+);
+note = uni148E;
+},
+{
+color = 11;
+glyphname = "ca-canadian.square";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (401,714);
+},
+{
+name = top_left_can;
+pos = (206,714);
+},
+{
+name = top_right_can;
+pos = (598,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(414,-13,o),
+(508,78,o),
+(543,245,cs),
+(558,312,l),
+(465,312,l),
+(452,249,ls),
+(427,132,o),
+(369,74,o),
+(276,73,cs),
+(174,73,o),
+(130,141,o),
+(156,261,cs),
+(252,714,l),
+(159,714,l),
+(63,267,ls),
+(28,97,o),
+(107,-13,o),
+(269,-13,cs)
+);
+}
+);
+width = 593;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+},
+{
+color = 11;
+glyphname = "caa-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (35,0);
+ref = dot_top;
+}
+);
+width = 592;
+}
+);
+note = uni1491;
+},
+{
+color = 11;
+glyphname = "me-canadian.square";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (342,714);
+},
+{
+name = top_double;
+pos = (500,714);
+},
+{
+name = top_left_can;
+pos = (179,714);
+},
+{
+name = top_right_can;
+pos = (500,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(395,0,l),
+(547,714,l),
+(133,714,l),
+(115,628,l),
+(435,628,l),
+(301,0,l)
+);
+}
+);
+width = 510;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+},
+{
+color = 11;
+glyphname = "mi-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (368,714);
+},
+{
+name = top_left_can;
+pos = (208,714);
+},
+{
+name = top_right_can;
+pos = (527,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(102,0,l),
+(236,628,l),
+(556,628,l),
+(574,714,l),
+(160.996,714,l),
+(8.996,0,l)
+);
+}
+);
+width = 509;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+},
+{
+color = 11;
+glyphname = "mii-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (198,0);
+ref = dot_top;
+}
+);
+width = 509;
+}
+);
+note = uni14A6;
+},
+{
+color = 11;
+glyphname = "mo-canadian.square";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (342,714);
+},
+{
+name = top_double;
+pos = (500,714);
+},
+{
+name = top_left_can;
+pos = (180,714);
+},
+{
+name = top_right_can;
+pos = (500,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(395,0,l),
+(547,714,l),
+(453,714,l),
+(320,86,l),
+(0,86,l),
+(-19,0,l)
+);
+}
+);
+width = 510;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+},
+{
+color = 11;
+glyphname = "moo-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (330,0);
+ref = dot_top;
+}
+);
+width = 509;
+}
+);
+note = uni14A8;
+},
+{
+color = 11;
+glyphname = "ma-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (368,714);
+},
+{
+name = top_left_can;
+pos = (208,714);
+},
+{
+name = top_right_can;
+pos = (527,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(422,0,l),
+(441,86,l),
+(121,86,l),
+(254,714,l),
+(160.996,714,l),
+(8.996,0,l)
+);
+}
+);
+width = 509;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+},
+{
+color = 11;
+glyphname = "maa-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (39,0);
+ref = dot_top;
+}
+);
+width = 509;
+}
+);
+note = uni14AB;
+},
+{
+color = 11;
+glyphname = "ne-canadian.square";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (474,714);
+},
+{
+name = top_left_can;
+pos = (312,714);
+},
+{
+name = top_right_can;
+pos = (638,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(468,-14,o),
+(544,59,o),
+(577,211,cs),
+(684,714,l),
+(146,714,l),
+(128,629,l),
+(247,629,l),
+(162,228,ls),
+(130,78,o),
+(198,-14,o),
+(341,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(267,74,o),
+(232,123,o),
+(251,215,cs),
+(339,629,l),
+(573,629,l),
+(485,211,ls),
+(465,118,o),
+(422,74,o),
+(349,74,cs)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C0;
+},
+{
+color = 11;
+glyphname = "ni-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (368,714);
+},
+{
+name = top_left_can;
+pos = (205,714);
+},
+{
+name = top_right_can;
+pos = (532,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(362,-14,o),
+(437,59,o),
+(470,211,cs),
+(559,629,l),
+(678,629,l),
+(696,714,l),
+(158,714,l),
+(55,228,ls),
+(23,78,o),
+(91,-14,o),
+(234,-14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(160,74,o),
+(125,124,o),
+(144,215,cs),
+(232,629,l),
+(466,629,l),
+(377,211,ls),
+(358,119,o),
+(315,74,o),
+(243,74,cs)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+},
+{
+color = 11;
+glyphname = "nii-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (198,0);
+ref = dot_top;
+}
+);
+width = 644;
+}
+);
+note = uni14C3;
+},
+{
+color = 11;
+glyphname = "no-canadian.square";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (474,714);
+},
+{
+name = top_double;
+pos = (484,714);
+},
+{
+name = top_left_can;
+pos = (312,714);
+},
+{
+name = top_right_can;
+pos = (624,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(532,0,l),
+(635,486,ls),
+(666,636,o),
+(598,728,o),
+(456,728,cs),
+(328,728,o),
+(252,655,o),
+(220,503,cs),
+(131,85,l),
+(12,85,l),
+(-6,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(312,503,ls),
+(332,595,o),
+(374,640,o),
+(447,640,cs),
+(529,640,o),
+(564,590,o),
+(545,499,cs),
+(457,85,l),
+(223,85,l)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C4;
+},
+{
+color = 11;
+glyphname = "noo-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (306,0);
+ref = dot_top;
+}
+);
+width = 644;
+}
+);
+note = uni14C5;
+},
+{
+color = 11;
+glyphname = "na-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (367,714);
+},
+{
+name = top_double;
+pos = (377,714);
+},
+{
+name = top_left_can;
+pos = (205,714);
+},
+{
+name = top_right_can;
+pos = (531,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(544,0,l),
+(562,85,l),
+(443,85,l),
+(528,486,ls),
+(559,636,o),
+(492,728,o),
+(349,728,cs),
+(222,728,o),
+(146,655,o),
+(113,503,cs),
+(6,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(205,503,ls),
+(225,596,o),
+(268,640,o),
+(341,640,cs),
+(423,640,o),
+(458,591,o),
+(438,499,cs),
+(350,85,l),
+(116,85,l)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+},
+{
+color = 11;
+glyphname = "naa-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (198,0);
+ref = dot_top;
+}
+);
+width = 644;
+}
+);
+note = uni14C8;
+},
+{
+color = 11;
+glyphname = "nweWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (644,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 836;
+}
+);
+note = uni14CA;
+},
+{
+color = 11;
+glyphname = "nwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (644,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 836;
+}
+);
+note = uni14CC;
+},
+{
+color = 11;
+glyphname = "nwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (198,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (644,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 836;
+}
+);
+note = uni14CE;
+},
+{
+color = 11;
+glyphname = "se-canadian.square";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (207,714);
+},
+{
+name = top_right_can;
+pos = (588,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(477,0,l),
+(532,262,l),
+(383,262,ls),
+(228,262,o),
+(172,335,o),
+(207,496,cs),
+(253,714,l),
+(160,714,l),
+(113,496,ls),
+(71,300,o),
+(169,179,o),
+(366,179,cs),
+(450,179,l),
+(426,204,l),
+(383,0,l)
+);
+}
+);
+width = 592;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14ED;
+},
+{
+color = 11;
+glyphname = "si-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (209,714);
+},
+{
+name = top_right_can;
+pos = (589,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(103,0,l),
+(147,204,l),
+(113,179,l),
+(196,179,ls),
+(416,179,o),
+(537,276,o),
+(581,485,cs),
+(630,714,l),
+(537,714,l),
+(488,486,ls),
+(456,338,o),
+(363,262,o),
+(214,262,cs),
+(65,262,l),
+(9,0,l)
+);
+}
+);
+width = 591;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+},
+{
+color = 11;
+glyphname = "sii-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (420,0);
+ref = dot_top;
+}
+);
+width = 591;
+}
+);
+note = uni14F0;
+},
+{
+color = 11;
+glyphname = "so-canadian.square";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (581,714);
+},
+{
+name = top_left_can;
+pos = (206,714);
+},
+{
+name = top_right_can;
+pos = (581,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,0,l),
+(149,228,ls),
+(181,376,o),
+(274,452,o),
+(423,452,cs),
+(572,452,l),
+(628,714,l),
+(534,714,l),
+(491,510,l),
+(525,535,l),
+(441,535,ls),
+(221,535,o),
+(100,438,o),
+(56,229,cs),
+(7,0,l)
+);
+}
+);
+width = 591;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+},
+{
+color = 11;
+glyphname = "soo-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (413,0);
+ref = dot_top;
+}
+);
+width = 591;
+}
+);
+note = uni14F2;
+},
+{
+color = 11;
+glyphname = "sa-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (210,714);
+},
+{
+name = top_right_can;
+pos = (584,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(478,0,l),
+(525,218,ls),
+(567,414,o),
+(469,535,o),
+(272,535,cs),
+(188,535,l),
+(212,510,l),
+(255,714,l),
+(161,714,l),
+(106,452,l),
+(256,452,ls),
+(410,452,o),
+(466,379,o),
+(431,218,cs),
+(385,0,l)
+);
+}
+);
+width = 591;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+},
+{
+color = 11;
+glyphname = "saa-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (41,0);
+ref = dot_top;
+}
+);
+width = 591;
+}
+);
+note = uni14F5;
+},
+{
+color = 11;
+glyphname = "sho-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (388,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(463,0,l),
+(480,78,l),
+(233,78,ls),
+(168,78,o),
+(134,108,o),
+(134,167,cs),
+(134,230,o),
+(159,318,o),
+(279,318,cs),
+(350,318,ls),
+(524,318,o),
+(588,437,o),
+(588,554,cs),
+(588,653,o),
+(527,714,o),
+(426,714,cs),
+(161,714,l),
+(144,636,l),
+(395,636,ls),
+(461,636,o),
+(495,605,o),
+(495,547,cs),
+(495,482,o),
+(468,396,o),
+(350,396,cs),
+(279,396,ls),
+(104,396,o),
+(41,275,o),
+(41,160,cs),
+(41,61,o),
+(102,0,o),
+(203,0,cs)
+);
+}
+);
+width = 583;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+color = 11;
+glyphname = "shoo-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (219,0);
+ref = dot_top;
+}
+);
+width = 583;
+}
+);
+note = g728;
+},
+{
+color = 11;
+glyphname = "sha-canadian.square";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (393,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(278,0,ls),
+(459,0,o),
+(522,118,o),
+(522,242,cs),
+(522,338,o),
+(462,396,o),
+(363,396,cs),
+(301,396,ls),
+(237,396,o),
+(202,423,o),
+(202,480,cs),
+(202,551,o),
+(230,636,o),
+(353,636,cs),
+(602,636,l),
+(618,714,l),
+(352,714,ls),
+(172,714,o),
+(108,596,o),
+(108,472,cs),
+(108,376,o),
+(168,318,o),
+(267,318,cs),
+(329,318,ls),
+(393,318,o),
+(428,291,o),
+(428,234,cs),
+(428,164,o),
+(398,78,o),
+(277,78,cs),
+(28,78,l),
+(12,0,l)
+);
+}
+);
+width = 584;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+color = 11;
+glyphname = "shaa-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (223,0);
+ref = dot_top;
+}
+);
+width = 582;
+}
+);
+note = g730;
+},
+{
+color = 11;
+glyphname = "ye-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (185,714);
+},
+{
+name = top_right_can;
+pos = (599,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(493,0,l),
+(549,261,l),
+(172,261,l),
+(176,221,l),
+(647,658,l),
+(586,726,l),
+(29,209,l),
+(22,179,l),
+(438,179,l),
+(400,0,l)
+);
+}
+);
+width = 606;
+}
+);
+metricLeft = "ye-canadian";
+note = uni1526;
+},
+{
+color = 11;
+glyphname = "yi-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (205,714);
+},
+{
+name = top_right_can;
+pos = (618,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,0,l),
+(138,179,l),
+(554,179,l),
+(560,209,l),
+(204,726,l),
+(128,668,l),
+(432,221,l),
+(438,261,l),
+(62,261,l),
+(6,0,l)
+);
+}
+);
+width = 606;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni1528;
+},
+{
+color = 11;
+glyphname = "yii-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (35,0);
+ref = dot_top;
+}
+);
+width = 606;
+}
+);
+note = uni1529;
+},
+{
+color = 11;
+glyphname = "yo-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (599,714);
+},
+{
+name = top_left_can;
+pos = (185,714);
+},
+{
+name = top_right_can;
+pos = (599,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(524,46,l),
+(221,493,l),
+(214,453,l),
+(590,453,l),
+(646,714,l),
+(552,714,l),
+(514,535,l),
+(98,535,l),
+(92,505,l),
+(448,-12,l)
+);
+}
+);
+width = 606;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152A;
+},
+{
+color = 11;
+glyphname = "yoo-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (430,0);
+ref = dot_top;
+}
+);
+width = 606;
+}
+);
+note = uni152B;
+},
+{
+color = 11;
+glyphname = "ya-canadian.square";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (206,714);
+},
+{
+name = top_right_can;
+pos = (619,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(624,505,l),
+(630,535,l),
+(215,535,l),
+(253,714,l),
+(159,714,l),
+(104,453,l),
+(480,453,l),
+(476,493,l),
+(5,56,l),
+(66,-12,l)
+);
+}
+);
+width = 606;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152D;
+},
+{
+color = 11;
+glyphname = "yaa-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (35,0);
+ref = dot_top;
+}
+);
+width = 606;
+}
+);
+note = uni152E;
+},
+{
+color = 11;
+glyphname = "re-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (368,714);
+},
+{
+name = top_left_can;
+pos = (205,714);
+},
+{
+name = top_right_can;
+pos = (532,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(362,-14,o),
+(437,59,o),
+(470,211,cs),
+(559,629,l),
+(678,629,l),
+(696,714,l),
+(484,714,l),
+(377,211,ls),
+(358,119,o),
+(315,74,o),
+(243,74,cs),
+(160,74,o),
+(125,124,o),
+(144,215,cs),
+(250,714,l),
+(158,714,l),
+(55,228,ls),
+(23,78,o),
+(91,-14,o),
+(234,-14,cs)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1542;
+},
+{
+color = 11;
+glyphname = "reRCree-canadian.square";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (474,714);
+},
+{
+name = top_left_can;
+pos = (312,714);
+},
+{
+name = top_right_can;
+pos = (638,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(468,-14,o),
+(544,59,o),
+(577,211,cs),
+(684,714,l),
+(591,714,l),
+(485,211,ls),
+(465,118,o),
+(422,74,o),
+(349,74,cs),
+(267,74,o),
+(232,123,o),
+(251,215,cs),
+(357,714,l),
+(146,714,l),
+(128,629,l),
+(247,629,l),
+(162,228,ls),
+(130,78,o),
+(198,-14,o),
+(341,-14,cs)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni1543;
+},
+{
+color = 11;
+glyphname = "leWestCree-canadian.square";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (474,714);
+},
+{
+name = top_left_can;
+pos = (311,714);
+},
+{
+name = top_right_can;
+pos = (638,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(205,0,l),
+(312,502,ls),
+(332,595,o),
+(374,640,o),
+(446,640,cs),
+(529,640,o),
+(564,590,o),
+(545,499,cs),
+(439,0,l),
+(531,0,l),
+(634,486,ls),
+(666,636,o),
+(598,728,o),
+(455,728,cs),
+(327,728,o),
+(252,655,o),
+(219,502,cs),
+(130,84,l),
+(12,84,l),
+(-6,0,l)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+},
+{
+color = 11;
+glyphname = "ri-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (367,714);
+},
+{
+name = top_left_can;
+pos = (206,714);
+},
+{
+name = top_right_can;
+pos = (531,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(98,0,l),
+(205,503,ls),
+(225,596,o),
+(268,640,o),
+(341,640,cs),
+(423,640,o),
+(458,591,o),
+(438,499,cs),
+(332,0,l),
+(544,0,l),
+(562,85,l),
+(443,85,l),
+(528,486,ls),
+(559,636,o),
+(492,728,o),
+(349,728,cs),
+(222,728,o),
+(146,655,o),
+(113,503,cs),
+(6,0,l)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+},
+{
+color = 11;
+glyphname = "rii-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (198,0);
+ref = dot_top;
+}
+);
+width = 644;
+}
+);
+note = uni1547;
+},
+{
+color = 11;
+glyphname = "ro-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (391,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(103,0,l),
+(141,180,l),
+(91,139,l),
+(207,139,ls),
+(471,139,o),
+(559,329,o),
+(559,484,cs),
+(559,626,o),
+(468,714,o),
+(315,714,cs),
+(161,714,l),
+(144,631,l),
+(302,631,ls),
+(410,631,o),
+(466,579,o),
+(466,482,cs),
+(466,382,o),
+(426,222,o),
+(217,222,cs),
+(57,222,l),
+(9,0,l)
+);
+}
+);
+width = 566;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1548;
+},
+{
+color = 11;
+glyphname = "loWestCree-canadian.square";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (388,714);
+},
+{
+name = top_left_can;
+pos = (209,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(176,0,ls),
+(440,0,o),
+(527,190,o),
+(527,346,cs),
+(527,488,o),
+(437,575,o),
+(284,575,cs),
+(184,575,l),
+(217,534,l),
+(255,714,l),
+(161,714,l),
+(114,492,l),
+(271,492,ls),
+(379,492,o),
+(435,440,o),
+(435,343,cs),
+(435,243,o),
+(394,83,o),
+(191,83,cs),
+(27,83,l),
+(9,0,l)
+);
+}
+);
+width = 561;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+},
+{
+color = 11;
+glyphname = "ra-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (372,714);
+},
+{
+name = top_right_can;
+pos = (553,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(447,0,l),
+(495,222,l),
+(337,222,ls),
+(229,222,o),
+(174,274,o),
+(174,371,cs),
+(174,471,o),
+(215,631,o),
+(417,631,cs),
+(581,631,l),
+(598.99,714,l),
+(433,714,ls),
+(168,714,o),
+(81,524,o),
+(81,368,cs),
+(81,226,o),
+(171,139,o),
+(325,139,cs),
+(425,139,l),
+(392,180,l),
+(354,0,l)
+);
+}
+);
+width = 562;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+},
+{
+color = 11;
+glyphname = "raa-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (202,0);
+ref = dot_top;
+}
+);
+width = 562;
+}
+);
+note = uni154C;
+},
+{
+color = 11;
+glyphname = "laWestCree-canadian.square";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (552,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(447,0,l),
+(464,83,l),
+(307,83,ls),
+(200,83,o),
+(143,135,o),
+(143,232,cs),
+(143,332,o),
+(184,492,o),
+(392,492,cs),
+(551,492,l),
+(599,714,l),
+(505,714,l),
+(467,534,l),
+(517,575,l),
+(402,575,ls),
+(139,575,o),
+(51,385,o),
+(51,230,cs),
+(51,88,o),
+(141,0,o),
+(294,0,cs)
+);
+}
+);
+width = 562;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+},
+{
+color = 11;
+glyphname = "reWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(471,0,l),
+(710,201,l),
+(658,264,l),
+(472,107,l),
+(500,87,l),
+(577,447,ls),
+(612,617,o),
+(534,727,o),
+(373,727,cs),
+(228,727,o),
+(132,640,o),
+(96,469,cs),
+(82,402,l),
+(174,402,l),
+(188,465,ls),
+(212,582,o),
+(271,640,o),
+(364,641,cs),
+(466,641,o),
+(510,573,o),
+(484,453,cs),
+(388,0,l)
+);
+}
+);
+width = 741;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+},
+{
+color = 11;
+glyphname = "riWestCree-canadian.square";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(248,0,l),
+(349,475,ls),
+(372,585,o),
+(430,641,o),
+(520,641,cs),
+(623,641,o),
+(668,574,o),
+(643,458,cs),
+(632,402,l),
+(724,402,l),
+(733,446,ls),
+(768,615,o),
+(686,728,o),
+(527,728,cs),
+(384,728,o),
+(291,643,o),
+(256,476,cs),
+(173,87,l),
+(205,92,l),
+(80,255,l),
+(11,201,l),
+(165,0,l)
+);
+}
+);
+width = 740;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+},
+{
+color = 11;
+glyphname = "roWestCree-canadian.square";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(403,-14,o),
+(496,71,o),
+(531,238,cs),
+(614,627,l),
+(582,622,l),
+(708,459,l),
+(777,513,l),
+(621,714,l),
+(539,714,l),
+(438,239,ls),
+(415,129,o),
+(357,73,o),
+(266,73,cs),
+(164,73,o),
+(119,140,o),
+(144,256,cs),
+(155,312,l),
+(63,312,l),
+(54,268,ls),
+(19,99,o),
+(101,-14,o),
+(260,-14,cs)
+);
+}
+);
+width = 742;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+},
+{
+color = 11;
+glyphname = "raWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(559,-13,o),
+(655,74,o),
+(691,245,cs),
+(705,312,l),
+(613,312,l),
+(599,249,ls),
+(575,132,o),
+(516,74,o),
+(423,73,cs),
+(321,73,o),
+(277,141,o),
+(303,261,cs),
+(399,714,l),
+(316,714,l),
+(77,513,l),
+(129,450,l),
+(315,607,l),
+(287,627,l),
+(210,267,ls),
+(175,97,o),
+(253,-13,o),
+(414,-13,cs)
+);
+}
+);
+width = 741;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+},
+{
+color = 11;
+glyphname = "theThCree-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (185,714);
+},
+{
+name = top_right_can;
+pos = (599,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(493,0,l),
+(507,66,l),
+(583,66,l),
+(593,115,l),
+(518,115,l),
+(549,261,l),
+(180,261,l),
+(190,233,l),
+(647,658,l),
+(586,726,l),
+(29,209,l),
+(22,179,l),
+(438,179,l),
+(425,115,l),
+(233,115,l),
+(223,66,l),
+(414,66,l),
+(400,0,l)
+);
+}
+);
+width = 653;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15A7;
+},
+{
+color = 11;
+glyphname = "thiThCree-canadian.square";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (248,714);
+},
+{
+name = top_right_can;
+pos = (661,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(147,0,l),
+(161,66,l),
+(353,66,l),
+(363,115,l),
+(172,115,l),
+(186,179,l),
+(602,179,l),
+(608,209,l),
+(252,726,l),
+(175,668,l),
+(474,228,l),
+(491,261,l),
+(110,261,l),
+(79,115,l),
+(3,115,l),
+(-7,66,l),
+(68,66,l),
+(54,0,l)
+);
+}
+);
+width = 654;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+},
+{
+color = 11;
+glyphname = "thiiThCree-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (78,0);
+ref = dot_top;
+}
+);
+width = 653;
+}
+);
+note = uni15A9;
+},
+{
+color = 11;
+glyphname = "thoThCree-canadian.square";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (184,714);
+},
+{
+name = top_right_can;
+pos = (599,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(524,46,l),
+(226,486,l),
+(209,453,l),
+(589,453,l),
+(620,599,l),
+(696,599,l),
+(706,648,l),
+(631,648,l),
+(645,714,l),
+(552,714,l),
+(538,648,l),
+(346,648,l),
+(336,599,l),
+(527,599,l),
+(514,535,l),
+(98,535,l),
+(92,505,l),
+(447,-12,l)
+);
+}
+);
+width = 652;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+},
+{
+color = 11;
+glyphname = "thooThCree-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (429,0);
+ref = dot_top;
+}
+);
+width = 653;
+}
+);
+note = uni15AB;
+},
+{
+color = 11;
+glyphname = "thaThCree-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (253,714);
+},
+{
+name = top_right_can;
+pos = (667,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(671,505,l),
+(677,535,l),
+(261,535,l),
+(275,599,l),
+(466,599,l),
+(476,648,l),
+(285,648,l),
+(299,714,l),
+(206,714,l),
+(192,648,l),
+(116,648,l),
+(106,599,l),
+(181,599,l),
+(150,453,l),
+(519,453,l),
+(509,481,l),
+(52,56,l),
+(113,-12,l)
+);
+}
+);
+width = 653;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+},
+{
+color = 11;
+glyphname = "thaaThCree-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (83,0);
+ref = dot_top;
+}
+);
+width = 653;
+}
+);
+note = uni15AD;
+},
+{
+color = 11;
+glyphname = "thweeWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni1677;
+},
+{
+color = 11;
+glyphname = "thwiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni1678;
+},
+{
+color = 11;
+glyphname = "thwiiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (78,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni1679;
+},
+{
+color = 11;
+glyphname = "thwoWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni167A;
+},
+{
+color = 11;
+glyphname = "thwooWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (429,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni167B;
+},
+{
+color = 11;
+glyphname = "thwaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni167C;
+},
+{
+color = 11;
+glyphname = "thwaaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (83,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni167D;
+},
+{
+color = 11;
+glyphname = "nwiOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (644,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 836;
+}
+);
+note = uni18C7;
+},
+{
+color = 11;
+glyphname = "nwiiOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (198,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (644,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 836;
+}
+);
+note = uni18C9;
+},
+{
+color = 11;
+glyphname = "nwoOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (644,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 836;
+}
+);
+note = uni18CB;
+},
+{
+color = 11;
+glyphname = "nwooOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (306,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (644,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 836;
+}
+);
+note = uni18CD;
+},
+{
+color = 11;
+glyphname = "looWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (39,0);
+ref = dot_top;
+}
+);
+width = 562;
+}
+);
+note = uni18E1;
+},
+{
+color = 11;
+glyphname = "laaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (384,0);
+ref = dot_top;
+}
+);
+width = 562;
+}
+);
+note = uni18E2;
+},
+{
+color = 0;
+glyphname = zero;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(578,570,o),
+(519,725,o),
+(341,725,cs),
+(160,725,o),
+(102,559,o),
+(102,358,cs),
+(102,112,o),
+(187,-10,o),
+(340,-10,cs),
+(500,-10,o),
+(578,110,o),
+(578,358,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,485,o),
+(218,644,o),
+(341,644,cs),
+(470,644,o),
+(479,477,o),
+(479,358,cs),
+(479,196,o),
+(448,71,o),
+(340,71,cs),
+(236,71,o),
+(200,195,o),
+(200,358,cs)
+);
+}
+);
+width = 636;
+}
+);
+unicode = 48;
+},
+{
+color = 0;
+glyphname = one;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(297,714,l),
+(81,547,l),
+(133,482,l),
+(238,563,ls),
+(259,579,o),
+(272,591,o),
+(288,607,c),
+(287,575,o),
+(286,546,o),
+(286,514,cs),
+(286,0,l),
+(386,0,l),
+(386,714,l)
+);
+}
+);
+width = 509;
+}
+);
+unicode = 49;
+},
+{
+color = 0;
+glyphname = two;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(580,0,l),
+(580,83,l),
+(238,83,l),
+(238,85,l),
+(379,231,ls),
+(455,305,o),
+(508,363,o),
+(536,426,cs),
+(549,458,o),
+(555,494,o),
+(555,535,cs),
+(555,648,o),
+(470,724,o),
+(345,724,cs),
+(254,724,o),
+(185,693,o),
+(120,636,c),
+(174,571,l),
+(229,617,o),
+(283,640,o),
+(335,640,cs),
+(410,640,o),
+(458,598,o),
+(458,523,cs),
+(458,466,o),
+(438,423,o),
+(397,371,cs),
+(375,345,o),
+(348,314,o),
+(313,279,cs),
+(111,68,l),
+(111,0,l)
+);
+}
+);
+width = 631;
+}
+);
+unicode = 50;
+},
+{
+color = 0;
+glyphname = three;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(561,662,o),
+(477,724,o),
+(347,724,cs),
+(243,724,o),
+(173,694,o),
+(114,651,c),
+(156,583,l),
+(205,617,o),
+(265,643,o),
+(334,643,cs),
+(413,643,o),
+(465,608,o),
+(465,535,cs),
+(465,444,o),
+(379,407,o),
+(286,407,cs),
+(219,407,l),
+(219,331,l),
+(285,331,ls),
+(405,331,o),
+(479,298,o),
+(479,203,cs),
+(479,122,o),
+(425,70,o),
+(303,70,cs),
+(238,70,o),
+(165,88,o),
+(109,116,c),
+(109,31,l),
+(164,7,o),
+(230,-10,o),
+(315,-10,cs),
+(476,-10,o),
+(582,68,o),
+(582,198,cs),
+(582,303,o),
+(519,359,o),
+(406,373,c),
+(406,375,l),
+(495,395,o),
+(561,459,o),
+(561,554,cs)
+);
+}
+);
+width = 632;
+}
+);
+unicode = 51;
+},
+{
+color = 0;
+glyphname = four;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(468,246,l),
+(468,716,l),
+(375,716,l),
+(35,241,l),
+(35,170,l),
+(371,170,l),
+(371,0,l),
+(468,0,l),
+(468,170,l),
+(578,170,l),
+(578,246,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(127,246,l),
+(317,509,ls),
+(342,544,o),
+(351,560,o),
+(370,593,c),
+(373,593,l),
+(373,576,o),
+(371,541,o),
+(371,495,cs),
+(371,246,l)
+);
+}
+);
+width = 605;
+}
+);
+unicode = 52;
+},
+{
+color = 0;
+glyphname = five;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(274,444,o),
+(240,435,o),
+(213,429,c),
+(231,630,l),
+(512,630,l),
+(512,714,l),
+(147,714,l),
+(118,369,l),
+(160,345,l),
+(199,357,o),
+(241,366,o),
+(291,366,cs),
+(402,366,o),
+(458,313,o),
+(458,223,cs),
+(458,126,o),
+(390,70,o),
+(282,70,cs),
+(215,70,o),
+(147,91,o),
+(99,116,c),
+(99,31,l),
+(147,6,o),
+(210,-10,o),
+(289,-10,cs),
+(462,-10,o),
+(558,79,o),
+(558,226,cs),
+(558,365,o),
+(468,444,o),
+(333,444,cs)
+);
+}
+);
+width = 605;
+}
+);
+unicode = 53;
+},
+{
+color = 0;
+glyphname = six;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(89,133,o),
+(165,-10,o),
+(336,-10,cs),
+(479,-10,o),
+(566,83,o),
+(566,233,cs),
+(566,372,o),
+(490,455,o),
+(361,455,cs),
+(270,455,o),
+(210,411,o),
+(181,353,c),
+(178,353,l),
+(183,526,o),
+(247,646,o),
+(418,646,cs),
+(462,646,o),
+(494,641,o),
+(520,634,c),
+(520,714,l),
+(493,721,o),
+(455,725,o),
+(420,725,cs),
+(176,725,o),
+(89,547,o),
+(89,303,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(224,70,o),
+(190,176,o),
+(190,255,cs),
+(190,321,o),
+(260,376,o),
+(338,376,cs),
+(428,376,o),
+(470,322,o),
+(470,231,cs),
+(470,129,o),
+(421,70,o),
+(334,70,cs)
+);
+}
+);
+width = 611;
+}
+);
+unicode = 54;
+},
+{
+color = 0;
+glyphname = seven;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(598,655,l),
+(598,714,l),
+(119,714,l),
+(119,631,l),
+(492,631,l),
+(217,0,l),
+(320,0,l)
+);
+}
+);
+width = 622;
+}
+);
+unicode = 55;
+},
+{
+color = 0;
+glyphname = eight;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(480,-10,o),
+(579,59,o),
+(579,185,cs),
+(579,284,o),
+(506,341,o),
+(410,379,c),
+(498,417,o),
+(557,470,o),
+(557,556,cs),
+(557,665,o),
+(472,724,o),
+(342,724,cs),
+(214,724,o),
+(127,661,o),
+(127,556,cs),
+(127,460,o),
+(198,411,o),
+(267,378,c),
+(171,341,o),
+(105,285,o),
+(105,181,cs),
+(105,68,o),
+(190,-10,o),
+(339,-10,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(253,64,o),
+(197,110,o),
+(197,184,cs),
+(197,267,o),
+(267,308,o),
+(340,335,c),
+(436,297,o),
+(488,254,o),
+(488,186,cs),
+(488,107,o),
+(429,64,o),
+(338,64,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(270,451,o),
+(220,486,o),
+(220,548,cs),
+(220,613,o),
+(273,650,o),
+(342,650,cs),
+(416,650,o),
+(463,615,o),
+(463,549,cs),
+(463,488,o),
+(418,455,o),
+(343,422,c)
+);
+}
+);
+width = 635;
+}
+);
+unicode = 56;
+},
+{
+color = 0;
+glyphname = nine;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(578,586,o),
+(503,724,o),
+(331,724,cs),
+(188,724,o),
+(100,632,o),
+(100,482,cs),
+(100,344,o),
+(176,259,o),
+(303,259,cs),
+(394,259,o),
+(456,302,o),
+(485,363,c),
+(489,363,l),
+(483,181,o),
+(411,68,o),
+(243,68,cs),
+(204,68,o),
+(168,73,o),
+(143,80,c),
+(143,-2,l),
+(170,-8,o),
+(213,-11,o),
+(247,-11,cs),
+(492,-11,o),
+(578,171,o),
+(578,408,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(443,643,o),
+(477,535,o),
+(477,461,cs),
+(477,394,o),
+(404,337,o),
+(330,337,cs),
+(241,337,o),
+(196,394,o),
+(196,483,cs),
+(196,586,o),
+(245,643,o),
+(333,643,cs)
+);
+}
+);
+width = 636;
+}
+);
+unicode = 57;
+},
+{
+glyphname = zero.canadian;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(421,-12,o),
+(492,358,o),
+(492,514,cs),
+(492,653,o),
+(437,727,o),
+(331,727,cs),
+(121,727,o),
+(52,357,o),
+(52,200,cs),
+(52,62,o),
+(106,-12,o),
+(214,-12,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(167,72,o),
+(141,111,o),
+(141,193,cs),
+(141,294,o),
+(194,643,o),
+(326,643,cs),
+(377,643,o),
+(403,603,o),
+(403,522,cs),
+(403,421,o),
+(349,72,o),
+(218,72,cs)
+);
+}
+);
+width = 497;
+}
+);
+metricRight = "=|";
+},
+{
+glyphname = one.canadian;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(221,0,l),
+(373,714,l),
+(289,714,l),
+(82,541,l),
+(134,478,l),
+(331,642,l),
+(266,652,l),
+(128,0,l)
+);
+}
+);
+width = 336;
+}
+);
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = two.canadian;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(406,86,l),
+(133,86,l),
+(131,51,l),
+(365,300,ls),
+(446,385,o),
+(493,471,o),
+(493,564,cs),
+(493,664,o),
+(430,727,o),
+(327,727,cs),
+(206,727,o),
+(124,645,o),
+(91,468,c),
+(184,468,l),
+(206,593,o),
+(250,645,o),
+(319,645,cs),
+(372,645,o),
+(401,614,o),
+(401,561,cs),
+(401,488,o),
+(356,415,o),
+(292,347,cs),
+(23,62,l),
+(10,0,l),
+(388,0,l)
+);
+}
+);
+width = 486;
+}
+);
+note = uni14BF;
+},
+{
+glyphname = three.canadian;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(390,-13,o),
+(444,117,o),
+(444,224,cs),
+(444,300,o),
+(409,351,o),
+(345,370,c),
+(338,338,l),
+(468,349,o),
+(510,483,o),
+(510,567,cs),
+(510,666,o),
+(448,727,o),
+(342,727,cs),
+(221,727,o),
+(139,644,o),
+(108,483,c),
+(201,483,l),
+(226,595,o),
+(267,645,o),
+(332,645,cs),
+(386,645,o),
+(415,613,o),
+(415,555,cs),
+(415,497,o),
+(396,397,o),
+(295,397,cs),
+(265,397,l),
+(248,318,l),
+(279,318,ls),
+(326,318,o),
+(352,286,o),
+(352,230,cs),
+(352,170,o),
+(327,69,o),
+(230,69,cs),
+(137,69,o),
+(126,151,o),
+(142,231,c),
+(50,231,l),
+(24,106,o),
+(67,-13,o),
+(230,-13,cs)
+);
+}
+);
+width = 514;
+}
+);
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = four.canadian;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(329,0,l),
+(365,170,l),
+(447,170,l),
+(463,248,l),
+(382,248,l),
+(481,716,l),
+(406,716,l),
+(30,233,l),
+(16,170,l),
+(275,170,l),
+(239,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(404,621,l),
+(374,621,l),
+(295,248,l),
+(98,248,l),
+(102,226,l)
+);
+}
+);
+width = 487;
+}
+);
+},
+{
+glyphname = five.canadian;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(406,-13,o),
+(455,152,o),
+(455,256,cs),
+(455,362,o),
+(393,423,o),
+(277,423,cs),
+(183,423,l),
+(214,395,l),
+(286,655,l),
+(242,628,l),
+(518,628,l),
+(536,714,l),
+(212,714,l),
+(114,362,l),
+(127,341,l),
+(249,341,ls),
+(324,341,o),
+(361,311,o),
+(361,244,cs),
+(361,188,o),
+(339,69,o),
+(236,69,cs),
+(147,69,o),
+(130,139,o),
+(143,205,c),
+(50,205,l),
+(32,91,o),
+(86,-13,o),
+(232,-13,cs)
+);
+}
+);
+width = 509;
+}
+);
+},
+{
+glyphname = six.canadian;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(381,-13,o),
+(451,137,o),
+(451,259,cs),
+(451,364,o),
+(393,434,o),
+(297,434,cs),
+(224,434,o),
+(164,388,o),
+(129,304,c),
+(149,283,l),
+(154,320,o),
+(157,341,o),
+(168,389,cs),
+(206,570,o),
+(262,646,o),
+(336,646,cs),
+(419,646,o),
+(423,570,o),
+(416,512,c),
+(508,512,l),
+(518,621,o),
+(472,727,o),
+(342,727,cs),
+(103,727,o),
+(49,292,o),
+(49,196,cs),
+(49,145,o),
+(56,104,o),
+(74,71,cs),
+(102,18,o),
+(156,-13,o),
+(227,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(171,66,o),
+(139,107,o),
+(139,173,cs),
+(139,241,o),
+(175,356,o),
+(273,356,cs),
+(329,356,o),
+(359,318,o),
+(359,253,cs),
+(359,187,o),
+(327,66,o),
+(229,66,cs)
+);
+}
+);
+width = 498;
+}
+);
+metricLeft = zero.canadian;
+},
+{
+glyphname = seven.canadian;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(133,0,l),
+(464,655,l),
+(477,714,l),
+(122,714,l),
+(104,628,l),
+(366,628,l),
+(370,657,l),
+(48,26,l),
+(43,0,l)
+);
+}
+);
+width = 407;
+}
+);
+},
+{
+glyphname = eight.canadian;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(373,-13,o),
+(442,96,o),
+(452,201,cs),
+(461,284,o),
+(420,345,o),
+(352,368,c),
+(341,339,l),
+(446,350,o),
+(503,448,o),
+(512,538,cs),
+(523,650,o),
+(453,727,o),
+(337,727,cs),
+(206,727,o),
+(137,618,o),
+(127,514,cs),
+(119,432,o),
+(155,368,o),
+(221,347,c),
+(223,378,l),
+(107,364,o),
+(53,267,o),
+(45,179,cs),
+(34,68,o),
+(112,-13,o),
+(234,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(167,66,o),
+(131,106,o),
+(136,174,cs),
+(139,242,o),
+(175,319,o),
+(263,319,cs),
+(331,319,o),
+(367,279,o),
+(362,211,cs),
+(359,145,o),
+(326,66,o),
+(235,66,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(244,396,o),
+(213,435,o),
+(216,501,cs),
+(219,566,o),
+(249,648,o),
+(334,648,cs),
+(392,648,o),
+(424,609,o),
+(421,543,cs),
+(418,478,o),
+(385,396,o),
+(303,396,cs)
+);
+}
+);
+width = 522;
+}
+);
+metricLeft = "=|";
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = nine.canadian;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(442,-13,o),
+(497,422,o),
+(497,518,cs),
+(497,569,o),
+(489,610,o),
+(472,643,cs),
+(444,696,o),
+(390,727,o),
+(319,727,cs),
+(164,727,o),
+(94,577,o),
+(94,455,cs),
+(94,350,o),
+(152,280,o),
+(248,280,cs),
+(322,280,o),
+(381,326,o),
+(416,410,c),
+(396,431,l),
+(392,394,o),
+(388,373,o),
+(378,325,cs),
+(339,144,o),
+(284,68,o),
+(209,68,cs),
+(126,68,o),
+(122,144,o),
+(129,202,c),
+(37,202,l),
+(28,93,o),
+(73,-13,o),
+(203,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(217,358,o),
+(186,396,o),
+(186,461,cs),
+(186,527,o),
+(219,648,o),
+(316,648,cs),
+(374,648,o),
+(407,607,o),
+(407,541,cs),
+(407,473,o),
+(370,358,o),
+(273,358,cs)
+);
+}
+);
+width = 499;
+}
+);
+metricLeft = "=|six.canadian";
+metricRight = "=|six.canadian";
+},
+{
+glyphname = CR;
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+width = 213;
+}
+);
+note = CR;
+unicode = 13;
+},
+{
+color = 0;
+glyphname = .notdef;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(604,714,l),
+(193,714,l),
+(193,0,l),
+(604,0,l),
+(604,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(553,663,l),
+(553,51,l),
+(244,51,l),
+(244,663,l),
+(244,663,l)
+);
+}
+);
+width = 699;
+}
+);
+note = ".notdef";
+},
+{
+glyphname = .null;
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+width = 0;
+}
+);
+note = NULL;
+},
+{
+glyphname = space;
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+width = 216;
+}
+);
+note = space;
+unicode = 32;
+},
+{
+glyphname = nbspace;
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+width = 213;
+}
+);
+note = uni00A0;
+unicode = 160;
+},
+{
+glyphname = space.canadian;
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+width = 427;
+}
+);
+note = space;
+},
+{
+glyphname = "hyphen-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(350,410,l),
+(362,466,l),
+(98,466,l),
+(86,410,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(320,269,l),
+(332,325,l),
+(67,325,l),
+(55,269,l)
+);
+}
+);
+width = 366;
+}
+);
+metricRight = "=|";
+note = uni1400;
+unicode = 5120;
+},
+{
+glyphname = "chi-canadian";
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(78,0,l),
+(267,301,l),
+(236,307,l),
+(299,0,l),
+(383,0,l),
+(388,26,l),
+(302,400,l),
+(288,326,l),
+(527,688,l),
+(532,714,l),
+(441,714,l),
+(256,417,l),
+(286,412,l),
+(225,714,l),
+(141.992,714,l),
+(136,688,l),
+(223,323,l),
+(236,398,l),
+(-8,26,l),
+(-13,0,l)
+);
+}
+);
+width = 475;
+}
+);
+metricRight = "=|";
+note = uni166D;
+unicode = 5741;
+},
+{
+glyphname = "fullstop-canadian";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(57,0,l),
+(140,133,l),
+(125,139,l),
+(154,0,l),
+(210,0,l),
+(213,12,l),
+(168,194,l),
+(165,164,l),
+(282,344,l),
+(285,357,l),
+(224,357,l),
+(137,218,l),
+(159,211,l),
+(129,357,l),
+(73,357,l),
+(70,344,l),
+(113,169,l),
+(119,199,l),
+(-2,12,l),
+(-4,0,l)
+);
+}
+);
+width = 311;
+}
+);
+note = uni1541;
+unicode = 5742;
+},
+{
+glyphname = period;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(15,13,o),
+(34,-10,o),
+(76,-10,cs),
+(110,-10,o),
+(132,12,o),
+(137,50,cs),
+(143,84,o),
+(125,106,o),
+(82,106,cs),
+(45,106,o),
+(26,82,o),
+(21,47,cs)
+);
+}
+);
+width = 231;
+}
+);
+note = period;
+unicode = 46;
+},
+{
+glyphname = comma;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(10,-133,l),
+(58,-60,o),
+(105,41,o),
+(138,117,c),
+(135,129,l),
+(51,129,l),
+(25,52,o),
+(-11,-36,o),
+(-57,-133,c)
+);
+}
+);
+width = 215;
+}
+);
+note = comma;
+unicode = 44;
+},
+{
+glyphname = hyphen;
+kernLeft = hyphen;
+kernRight = hyphen;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(223,230,l),
+(240,310,l),
+(50,310,l),
+(33,230,l)
+);
+}
+);
+width = 264;
+}
+);
+unicode = 45;
+},
+{
+glyphname = quotesinglbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-585);
+ref = quoteright;
+}
+);
+width = 238;
+}
+);
+unicode = 8218;
+},
+{
+glyphname = quotedblbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+pos = (-92,-585);
+ref = quotedblright;
+}
+);
+width = 456;
+}
+);
+unicode = 8222;
+},
+{
+glyphname = quotedblleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(355,451,l),
+(379,528,o),
+(419,625,o),
+(467,714,c),
+(402,714,l),
+(354,641,o),
+(306,548,o),
+(271,461,c),
+(275,451,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(172,451,l),
+(197,530,o),
+(235,623,o),
+(284,714,c),
+(220,714,l),
+(172,641,o),
+(124,548,o),
+(89,461,c),
+(93,451,l)
+);
+}
+);
+width = 411;
+}
+);
+unicode = 8220;
+},
+{
+glyphname = quotedblright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(333,451,l),
+(383,525,o),
+(432,623,o),
+(465,704,c),
+(460,714,l),
+(381,714,l),
+(358,637,o),
+(317,539,o),
+(269,451,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(151,451,l),
+(201,525,o),
+(250,623,o),
+(283,704,c),
+(278,714,l),
+(199,714,l),
+(176,639,o),
+(133,537,o),
+(87,451,c)
+);
+}
+);
+width = 411;
+}
+);
+unicode = 8221;
+},
+{
+glyphname = quoteleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(176,451,l),
+(200,528,o),
+(241,625,o),
+(289,714,c),
+(221,714,l),
+(173,641,o),
+(124,548,o),
+(89,461,c),
+(93,451,l)
+);
+}
+);
+width = 233;
+}
+);
+unicode = 8216;
+},
+{
+glyphname = quoteright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(156,451,l),
+(206,525,o),
+(255,623,o),
+(288,704,c),
+(283,714,l),
+(199,714,l),
+(176,639,o),
+(134,537,o),
+(87,451,c)
+);
+}
+);
+width = 233;
+}
+);
+unicode = 8217;
+},
+{
+glyphname = dottedCircle;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(210,522,o),
+(197,511,o),
+(197,496,cs),
+(197,483,o),
+(210,470,o),
+(223,470,cs),
+(238,470,o),
+(249,483,o),
+(249,496,cs),
+(249,511,o),
+(238,522,o),
+(223,522,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(378,522,o),
+(365,511,o),
+(365,496,cs),
+(365,483,o),
+(378,470,o),
+(391,470,cs),
+(406,470,o),
+(417,483,o),
+(417,496,cs),
+(417,511,o),
+(406,522,o),
+(391,522,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(210,112,o),
+(197,101,o),
+(197,86,cs),
+(197,73,o),
+(210,60,o),
+(223,60,cs),
+(238,60,o),
+(249,73,o),
+(249,86,cs),
+(249,101,o),
+(238,112,o),
+(223,112,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(378,112,o),
+(365,101,o),
+(365,86,cs),
+(365,73,o),
+(378,60,o),
+(391,60,cs),
+(406,60,o),
+(417,73,o),
+(417,86,cs),
+(417,101,o),
+(406,112,o),
+(391,112,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(294,540,o),
+(281,529,o),
+(281,514,cs),
+(281,501,o),
+(294,488,o),
+(307,488,cs),
+(322,488,o),
+(333,501,o),
+(333,514,cs),
+(333,529,o),
+(322,540,o),
+(307,540,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(294,94,o),
+(281,83,o),
+(281,68,cs),
+(281,55,o),
+(294,42,o),
+(307,42,cs),
+(322,42,o),
+(333,55,o),
+(333,68,cs),
+(333,83,o),
+(322,94,o),
+(307,94,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(58,278,o),
+(71,265,o),
+(84,265,cs),
+(99,265,o),
+(110,278,o),
+(110,291,cs),
+(110,306,o),
+(99,317,o),
+(84,317,cs),
+(71,317,o),
+(58,306,o),
+(58,291,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(504,278,o),
+(517,265,o),
+(530,265,cs),
+(545,265,o),
+(556,278,o),
+(556,291,cs),
+(556,306,o),
+(545,317,o),
+(530,317,cs),
+(517,317,o),
+(504,306,o),
+(504,291,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(123,120,o),
+(136,107,o),
+(149,107,cs),
+(164,107,o),
+(175,120,o),
+(175,133,cs),
+(175,148,o),
+(164,159,o),
+(149,159,cs),
+(136,159,o),
+(123,148,o),
+(123,133,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(123,436,o),
+(136,423,o),
+(149,423,cs),
+(164,423,o),
+(175,436,o),
+(175,449,cs),
+(175,464,o),
+(164,475,o),
+(149,475,cs),
+(136,475,o),
+(123,464,o),
+(123,449,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(439,120,o),
+(452,107,o),
+(465,107,cs),
+(480,107,o),
+(491,120,o),
+(491,133,cs),
+(491,148,o),
+(480,159,o),
+(465,159,cs),
+(452,159,o),
+(439,148,o),
+(439,133,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(439,436,o),
+(452,423,o),
+(465,423,cs),
+(480,423,o),
+(491,436,o),
+(491,449,cs),
+(491,464,o),
+(480,475,o),
+(465,475,cs),
+(452,475,o),
+(439,464,o),
+(439,449,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(76,194,o),
+(89,181,o),
+(102,181,cs),
+(117,181,o),
+(128,194,o),
+(128,207,cs),
+(128,222,o),
+(117,233,o),
+(102,233,cs),
+(89,233,o),
+(76,222,o),
+(76,207,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(76,362,o),
+(89,349,o),
+(102,349,cs),
+(117,349,o),
+(128,362,o),
+(128,375,cs),
+(128,390,o),
+(117,401,o),
+(102,401,cs),
+(89,401,o),
+(76,390,o),
+(76,375,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(486,194,o),
+(499,181,o),
+(512,181,cs),
+(527,181,o),
+(538,194,o),
+(538,207,cs),
+(538,222,o),
+(527,233,o),
+(512,233,cs),
+(499,233,o),
+(486,222,o),
+(486,207,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(486,362,o),
+(499,349,o),
+(512,349,cs),
+(527,349,o),
+(538,362,o),
+(538,375,cs),
+(538,390,o),
+(527,401,o),
+(512,401,cs),
+(499,401,o),
+(486,390,o),
+(486,375,cs)
+);
+}
+);
+width = 604;
+}
+);
+note = uni25CC;
+unicode = 9676;
+},
+{
+glyphname = dotaccentcomb;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(147,744,o),
+(127,723,o),
+(123,688,cs),
+(117,656,o),
+(134,638,o),
+(169,638,cs),
+(203,638,o),
+(223,658,o),
+(227,691,cs),
+(233,725,o),
+(216,744,o),
+(181,744,cs)
+);
+}
+);
+width = 162;
+}
+);
+note = uni0307;
+unicode = 775;
+},
+{
+glyphname = dotaccent;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(204,638,o),
+(222,653,o),
+(228,684,cs),
+(236,722,o),
+(218,744,o),
+(181,744,cs),
+(149,744,o),
+(131,728,o),
+(125,696,cs),
+(116,659,o),
+(133,638,o),
+(171,638,cs)
+);
+}
+);
+width = 164;
+}
+);
+note = dotaccent;
+unicode = 729;
+},
+{
+glyphname = caron;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(312,645,o),
+(355,698,o),
+(405,755,c),
+(407,764,l),
+(342,764,l),
+(310,735,o),
+(282,702,o),
+(246,661,c),
+(230,699,o),
+(216,735,o),
+(197,764,c),
+(139,764,l),
+(137,755,l),
+(160,708,o),
+(182,657,o),
+(194,606,c),
+(286,606,l),
+(286,606,l)
+);
+}
+);
+width = 327;
+}
+);
+note = caron;
+unicode = 711;
+},
+{
+glyphname = breve;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(310,606,o),
+(359,653,o),
+(381,746,c),
+(324,746,l),
+(308,694,o),
+(281,667,o),
+(242,667,cs),
+(201,667,o),
+(182,695,o),
+(187,746,c),
+(135,746,l),
+(120,660,o),
+(160,606,o),
+(238,606,cs)
+);
+}
+);
+width = 304;
+}
+);
+note = breve;
+unicode = 728;
+},
+{
+glyphname = ring;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(264,608,o),
+(303,652,o),
+(303,718,cs),
+(303,781,o),
+(264,827,o),
+(215,827,cs),
+(166,827,o),
+(129,783,o),
+(129,717,cs),
+(129,651,o),
+(166,608,o),
+(215,608,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(191,656,o),
+(175,683,o),
+(175,717,cs),
+(174.997,753.009,o),
+(193,779,o),
+(215,779,cs),
+(237,779,o),
+(255,752,o),
+(255,717,cs),
+(255,684,o),
+(239,656,o),
+(215,656,cs)
+);
+}
+);
+width = 232;
+}
+);
+note = ring;
+unicode = 730;
+},
+{
+glyphname = ogonek;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(32,-227,o),
+(51,-223,o),
+(66,-216,c),
+(79,-158,l),
+(67,-163,o),
+(50,-167,o),
+(39,-167,cs),
+(16,-167,o),
+(7,-148,o),
+(14,-116,cs),
+(21,-79,o),
+(48,-40,o),
+(94,0,c),
+(59,17,l),
+(-7,-35,o),
+(-41,-81,o),
+(-51,-131,cs),
+(-63,-189,o),
+(-37,-227,o),
+(15,-227,cs)
+);
+}
+);
+width = 194;
+}
+);
+note = ogonek;
+unicode = 731;
+},
+{
+glyphname = ring_top.canadian;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (219,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(306,784,o),
+(348,824,o),
+(348,878,cs),
+(348,933,o),
+(306,972,o),
+(253,972,cs),
+(201,972,o),
+(158,933,o),
+(158,878,cs),
+(158,824,o),
+(201,784,o),
+(253,784,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(223,826,o),
+(202,848,o),
+(202,878,cs),
+(202,907,o),
+(223,930,o),
+(253,930,cs),
+(284,930,o),
+(304,907,o),
+(304,878,cs),
+(304,848,o),
+(284,826,o),
+(253,826,cs)
+);
+}
+);
+width = 239;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (93,357);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,306,o),
+(144,329,o),
+(144,357,cs),
+(144,385,o),
+(121,408,o),
+(93,408,cs),
+(65,408,o),
+(42,385,o),
+(42,357,cs),
+(42,329,o),
+(65,306,o),
+(93,306,cs)
+);
+}
+);
+width = 140;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (84,357);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(108,314,o),
+(127,332,o),
+(127,357,cs),
+(127,382,o),
+(108,400,o),
+(84,400,cs),
+(60,400,o),
+(41,382,o),
+(41,357,cs),
+(41,332,o),
+(60,314,o),
+(84,314,cs)
+);
+}
+);
+width = 122;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_small;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (75,357);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(95,322,o),
+(110,338,o),
+(110,357,cs),
+(110,376,o),
+(95,392,o),
+(75,392,cs),
+(56,392,o),
+(41,376,o),
+(41,357,cs),
+(41,338,o),
+(56,322,o),
+(75,322,cs)
+);
+}
+);
+width = 105;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_top;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (170,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(229,809,o),
+(253,832,o),
+(253,861,cs),
+(253,890,o),
+(229,913,o),
+(201,913,cs),
+(172,913,o),
+(149,890,o),
+(149,861,cs),
+(149,832,o),
+(172,809,o),
+(201,809,cs)
+);
+}
+);
+width = 140;
+}
+);
+note = g725;
+},
+{
+glyphname = doubledot_middle;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(172,395,o),
+(195,418,o),
+(195,447,cs),
+(195,476,o),
+(172,499,o),
+(144,499,cs),
+(115,499,o),
+(92,476,o),
+(92,447,cs),
+(92,418,o),
+(115,395,o),
+(144,395,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(134,215,o),
+(157,238,o),
+(157,267,cs),
+(157,296,o),
+(134,319,o),
+(105,319,cs),
+(76,319,o),
+(53,296,o),
+(53,267,cs),
+(53,238,o),
+(76,215,o),
+(105,215,cs)
+);
+}
+);
+width = 202;
+}
+);
+metricRight = "=|";
+note = g725;
+},
+{
+glyphname = doubledot_top;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top_double;
+pos = (322,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(381,809,o),
+(405,832,o),
+(405,861,cs),
+(405,890,o),
+(381,913,o),
+(352,913,cs),
+(323,913,o),
+(301,890,o),
+(301,861,cs),
+(301,832,o),
+(323,809,o),
+(352,809,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(229,809,o),
+(252,832,o),
+(252,861,cs),
+(252,890,o),
+(229,913,o),
+(200,913,cs),
+(171,913,o),
+(148,890,o),
+(148,861,cs),
+(148,832,o),
+(171,809,o),
+(200,809,cs)
+);
+}
+);
+width = 292;
+}
+);
+note = g725;
+},
+{
+glyphname = g727;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (389,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(463,0,l),
+(480,78,l),
+(233,78,ls),
+(168,78,o),
+(134,108,o),
+(134,167,cs),
+(134,230,o),
+(159,318,o),
+(279,318,cs),
+(350,318,ls),
+(524,318,o),
+(588,437,o),
+(588,554,cs),
+(588,653,o),
+(527,714,o),
+(426,714,cs),
+(161,714,l),
+(144,636,l),
+(395,636,ls),
+(461,636,o),
+(495,605,o),
+(495,547,cs),
+(495,482,o),
+(468,396,o),
+(350,396,cs),
+(279,396,ls),
+(104,396,o),
+(41,275,o),
+(41,160,cs),
+(41,61,o),
+(102,0,o),
+(203,0,cs)
+);
+}
+);
+width = 583;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+glyphname = g728;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (219,0);
+ref = dot_top;
+}
+);
+width = 583;
+}
+);
+note = g728;
+},
+{
+glyphname = g729;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (393,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(278,0,ls),
+(459,0,o),
+(522,118,o),
+(522,242,cs),
+(522,338,o),
+(462,396,o),
+(363,396,cs),
+(301,396,ls),
+(237,396,o),
+(202,423,o),
+(202,480,cs),
+(202,551,o),
+(230,636,o),
+(353,636,cs),
+(602,636,l),
+(618,714,l),
+(352,714,ls),
+(172,714,o),
+(108,596,o),
+(108,472,cs),
+(108,376,o),
+(168,318,o),
+(267,318,cs),
+(329,318,ls),
+(393,318,o),
+(428,291,o),
+(428,234,cs),
+(428,164,o),
+(398,78,o),
+(277,78,cs),
+(28,78,l),
+(12,0,l)
+);
+}
+);
+width = 584;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+glyphname = g730;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (223,0);
+ref = dot_top;
+}
+);
+width = 582;
+}
+);
+note = g730;
+},
+{
+glyphname = g731;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = g727;
+}
+);
+width = 774;
+}
+);
+note = g731;
+},
+{
+glyphname = g732;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (583,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 774;
+}
+);
+note = g732;
+},
+{
+glyphname = g733;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (411,0);
+ref = dot_top;
+}
+);
+width = 774;
+}
+);
+note = g733;
+},
+{
+glyphname = g734;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (219,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (583,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 774;
+}
+);
+note = g734;
+},
+{
+glyphname = g735;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = g729;
+}
+);
+width = 774;
+}
+);
+note = g735;
+},
+{
+glyphname = g736;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (582,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 774;
+}
+);
+note = g736;
+},
+{
+glyphname = g737;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (414,0);
+ref = dot_top;
+}
+);
+width = 774;
+}
+);
+note = g737;
+},
+{
+glyphname = g738;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (223,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (582,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 774;
+}
+);
+note = g738;
+},
+{
+glyphname = g739;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(479,239,o),
+(518,337,o),
+(518,407,cs),
+(518,472,o),
+(482,510,o),
+(421,510,cs),
+(274,510,l),
+(279,486,l),
+(318,518,o),
+(331,581,o),
+(331,617,cs),
+(331,680,o),
+(296,720,o),
+(238,720,cs),
+(150,720,o),
+(112,623,o),
+(112,552,cs),
+(112,488,o),
+(148,449,o),
+(208,449,cs),
+(355,449,l),
+(350,473,l),
+(309,440,o),
+(298,378,o),
+(298,343,cs),
+(298,279,o),
+(333,239,o),
+(391,239,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(181,498,o),
+(167,517,o),
+(167,551,cs),
+(167,588,o),
+(185,671,o),
+(234,671,cs),
+(260,671,o),
+(275,652,o),
+(275,617,cs),
+(275,582,o),
+(257,498,o),
+(207,498,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(369,288,o),
+(354,307,o),
+(354,343,cs),
+(354,377,o),
+(371,461,o),
+(422,461,cs),
+(448,461,o),
+(462,442,o),
+(462,408,cs),
+(462,372,o),
+(445,288,o),
+(395,288,cs)
+);
+}
+);
+width = 531;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+glyphname = g740;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (170,0);
+ref = ring_top.canadian;
+}
+);
+width = 583;
+}
+);
+note = g740;
+},
+{
+glyphname = g741;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (174,0);
+ref = ring_top.canadian;
+}
+);
+width = 582;
+}
+);
+note = g741;
+},
+{
+glyphname = g742;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (362,0);
+ref = ring_top.canadian;
+}
+);
+width = 774;
+}
+);
+note = g742;
+},
+{
+glyphname = stroke_middle;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (70,357);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(73,241,l),
+(122,473,l),
+(66,473,l),
+(17,241,l)
+);
+}
+);
+width = 92;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (63,357);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(66,265,l),
+(104,449,l),
+(60,449,l),
+(22,265,l)
+);
+}
+);
+width = 79;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_small;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (59,357);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(59,271,l),
+(95,443,l),
+(59,443,l),
+(23,271,l)
+);
+}
+);
+width = 71;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_threequart;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (70,357);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(71,243,l),
+(120,471,l),
+(68,471,l),
+(19,243,l)
+);
+}
+);
+width = 92;
+}
+);
+note = g723;
+},
+{
+color = 8;
+glyphname = uni11AB0;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (240,714);
+},
+{
+name = top_right_can;
+pos = (479,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(135,0,l),
+(158,108,l),
+(349,108,l),
+(361,164,l),
+(170,164,l),
+(196,288,l),
+(123,258,l),
+(156,258,ls),
+(341,258,o),
+(447,347,o),
+(492,558,cs),
+(525,714,l),
+(432,714,l),
+(400,564,ls),
+(367,415,o),
+(291,343,o),
+(162,343,cs),
+(115,343,l),
+(77,164,l),
+(13,164,l),
+(1,108,l),
+(65,108,l),
+(42,0,l)
+);
+}
+);
+width = 486;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB1;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB0;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (310,0);
+ref = dot_top;
+}
+);
+width = 487;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB2;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (206,714);
+},
+{
+name = top_right_can;
+pos = (445,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(101,0,l),
+(134,150,ls),
+(166,299,o),
+(242,371,o),
+(372,371,cs),
+(419,371,l),
+(457,550,l),
+(521,550,l),
+(532,606,l),
+(469,606,l),
+(492,714,l),
+(398,714,l),
+(375,606,l),
+(184,606,l),
+(172,550,l),
+(363,550,l),
+(337,426,l),
+(411,456,l),
+(377,456,ls),
+(193,456,o),
+(86,367,o),
+(41,156,cs),
+(8,0,l)
+);
+}
+);
+width = 488;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "theThCree-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB3;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB2;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (275,0);
+ref = dot_top;
+}
+);
+width = 488;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB4;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (242,714);
+},
+{
+name = top_right_can;
+pos = (480,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(374,0,l),
+(405,142,ls),
+(449,349,o),
+(357,456,o),
+(170,456,cs),
+(156,456,l),
+(226,425,l),
+(253,550,l),
+(444,550,l),
+(455,606,l),
+(265,606,l),
+(288,714,l),
+(194,714,l),
+(171,606,l),
+(107,606,l),
+(96,550,l),
+(159,550,l),
+(122,371,l),
+(149,371,ls),
+(288,371,o),
+(347,309,o),
+(311,144,cs),
+(281,0,l)
+);
+}
+);
+width = 487;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB5;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB4;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (72,0);
+ref = dot_top;
+}
+);
+width = 487;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB6;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (209,714);
+},
+{
+name = top_right_can;
+pos = (448,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(103,1,l),
+(165,291,l),
+(89,259,l),
+(119,259,ls),
+(313,259,o),
+(416,352,o),
+(462,568,cs),
+(486,680,l),
+(416,657,l),
+(568,459,l),
+(638,514,l),
+(484,715,l),
+(400,715,l),
+(370,573,ls),
+(336,416,o),
+(255,344,o),
+(120,344,cs),
+(83,344,l),
+(10,1,l)
+);
+}
+);
+width = 602;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB7;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB6;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (278,0);
+ref = dot_top;
+}
+);
+width = 602;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB8;
+kernRight = soright;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (354,714);
+},
+{
+name = top_right_can;
+pos = (593,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(249,0,l),
+(280,142,ls),
+(314,299,o),
+(395,371,o),
+(530,371,cs),
+(567,371,l),
+(640,714,l),
+(546,714,l),
+(484,424,l),
+(561,456,l),
+(531,456,ls),
+(337,456,o),
+(234,363,o),
+(187,147,cs),
+(163,35,l),
+(234,58,l),
+(81,256,l),
+(11,201,l),
+(166,0,l)
+);
+}
+);
+width = 603;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB9;
+kernRight = soright;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB8;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (423,0);
+ref = dot_top;
+}
+);
+width = 602;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABA;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (208,714);
+},
+{
+name = top_right_can;
+pos = (447,714);
+}
+);
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(332,0,l),
+(572,201,l),
+(519,264,l),
+(314,92,l),
+(356,76,l),
+(367,125,ls),
+(405,309,o),
+(331,454,o),
+(162,454,cs),
+(136,454,l),
+(189,406,l),
+(255,714,l),
+(161,714,l),
+(89,371,l),
+(120,371,ls),
+(260,371,o),
+(309,283,o),
+(271,107,cs),
+(249,0,l)
+);
+}
+);
+width = 603;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABB;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+alignment = -1;
+ref = uni11ABA;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (38,0);
+ref = dot_top;
+}
+);
+width = 602;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABC;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(388,0,l),
+(407,86,l),
+(98,86,l),
+(97,49,l),
+(533,648,l),
+(547,714,l),
+(144,714,l),
+(126,628,l),
+(433,628,l),
+(435,665,l),
+(-1,66,l),
+(-15,0,l)
+);
+}
+);
+width = 486;
+}
+);
+metricRight = "=|";
+},
+{
+color = 8;
+glyphname = uni11ABD;
+lastChange = "2023-01-13 15:29:45 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(396,0,l),
+(410,66,l),
+(215,665,l),
+(215,628,l),
+(522,628,l),
+(541,714,l),
+(137,714,l),
+(123,648,l),
+(318,49,l),
+(318,86,l),
+(11,86,l),
+(-8,0,l)
+);
+}
+);
+width = 487;
+}
+);
+metricLeft = "=|uni11ABC";
+metricRight = "=|uni11ABC";
+},
+{
+color = 8;
+glyphname = uni11ABE;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(101,0,l),
+(235,629,l),
+(179,629,l),
+(363,0,l),
+(446,0,l),
+(598,714,l),
+(506,714,l),
+(372,85,l),
+(428,85,l),
+(244,714,l),
+(160.996,714,l),
+(8.996,0,l)
+);
+}
+);
+width = 561;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABF;
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(92,0,l),
+(555,632,l),
+(489,632,l),
+(354,0,l),
+(446,0,l),
+(598,714,l),
+(515,714,l),
+(51,82,l),
+(118,82,l),
+(253,714,l),
+(160.996,714,l),
+(8.996,0,l)
+);
+}
+);
+width = 561;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = "raiseddoubledotFinal-canadian.cree";
+lastChange = "2023-01-13 15:28:18 +0000";
+layers = (
+{
+layerId = "9563F490-07F6-43DA-A81C-32B2684714C2";
+shapes = (
+{
+closed = 1;
+nodes = (
+(218,623,o),
+(241,646,o),
+(241,675,cs),
+(241,704,o),
+(218,727,o),
+(189,727,cs),
+(160,727,o),
+(137,705,o),
+(137,675,cs),
+(137,646,o),
+(160,623,o),
+(189,623,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(181,443,o),
+(204,466,o),
+(204,495,cs),
+(204,524,o),
+(181,547,o),
+(152,547,cs),
+(123,547,o),
+(100,524,o),
+(100,495,cs),
+(100,466,o),
+(123,443,o),
+(152,443,cs)
+);
+}
+);
+width = 197;
+}
+);
+note = g725;
+}
+);
+instances = (
+{
+axesValues = (
+98,
+72,
+12
+);
+instanceInterpolations = {
+"9563F490-07F6-43DA-A81C-32B2684714C2" = 1;
+};
+name = "RC CR Italic";
+}
+);
+kerningLTR = {
+"9563F490-07F6-43DA-A81C-32B2684714C2" = {
+"@MMK_L_caright" = {
+"@MMK_R_ecanleft" = -67;
+"@MMK_R_mwestleft" = -25;
+"@MMK_R_neleft" = -48;
+};
+"@MMK_L_ciright" = {
+"@MMK_R_icanleft" = -67;
+"@MMK_R_noleft" = -84;
+};
+"@MMK_L_ecanright" = {
+"@MMK_R_coleft" = -67;
+"@MMK_R_moleft" = -67;
+"@MMK_R_sileft" = -37;
+};
+"@MMK_L_icanright" = {
+"@MMK_R_celeft" = -67;
+"@MMK_R_meleft" = -67;
+"@MMK_R_mwestleft" = -45;
+"@MMK_R_saleft" = -32;
+"she-canadian" = -67;
+};
+"@MMK_L_maright" = {
+"@MMK_R_acanleft" = -63;
+"@MMK_R_ecanleft" = -67;
+"@MMK_R_mwestleft" = -46;
+"@MMK_R_neleft" = -48;
+};
+"@MMK_L_miright" = {
+"@MMK_R_acanleft" = -63;
+"@MMK_R_icanleft" = -67;
+"@MMK_R_moleft" = -91;
+"@MMK_R_noleft" = -84;
+"@MMK_R_yeleft" = -92;
+};
+"@MMK_L_mwestright" = {
+"@MMK_R_coleft" = -25;
+"@MMK_R_icanleft" = -45;
+"@MMK_R_moleft" = -46;
+"@MMK_R_noleft" = -74;
+"@MMK_R_sileft" = -13;
+"@MMK_R_yeleft" = -23;
+};
+"@MMK_L_naright" = {
+"@MMK_R_acanleft" = -79;
+"@MMK_R_celeft" = -84;
+"@MMK_R_meleft" = -84;
+"@MMK_R_mwestleft" = -74;
+"@MMK_R_neleft" = -96;
+"@MMK_R_saleft" = -55;
+};
+"@MMK_L_niright" = {
+"@MMK_R_coleft" = -48;
+"@MMK_R_moleft" = -48;
+"@MMK_R_noleft" = -96;
+"@MMK_R_sileft" = -3;
+};
+"@MMK_L_ocanright" = {
+"@MMK_R_meleft" = -63;
+"@MMK_R_moleft" = -63;
+"@MMK_R_noleft" = -79;
+};
+"@MMK_L_seright" = {
+"@MMK_R_ecanleft" = -37;
+"@MMK_R_mwestleft" = -13;
+"@MMK_R_neleft" = -3;
+};
+"@MMK_L_soright" = {
+"@MMK_R_icanleft" = -32;
+"@MMK_R_noleft" = -55;
+};
+"@MMK_L_yiright" = {
+"@MMK_R_meleft" = -92;
+"@MMK_R_mwestleft" = -23;
+};
+"shi-canadian" = {
+"@MMK_R_icanleft" = -67;
+};
+};
+};
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "italic angle";
+}
+);
+properties = (
+{
+key = copyrights;
+values = (
+{
+language = ENG;
+value = "Copyright 2018 Google Inc. All Rights Reserved.";
+}
+);
+},
+{
+key = manufacturers;
+values = (
+{
+language = ENG;
+value = "Monotype Imaging Inc.";
+}
+);
+},
+{
+key = designers;
+values = (
+{
+language = ENG;
+value = "Monotype Design Team";
+}
+);
+},
+{
+key = description;
+value = "Designed by Monotype design team.";
+},
+{
+key = trademarks;
+values = (
+{
+language = ENG;
+value = "Noto is a trademark of Google Inc.";
+}
+);
+},
+{
+key = licenseURL;
+value = "http://scripts.sil.org/OFL";
+},
+{
+key = licenses;
+values = (
+{
+language = ENG;
+value = "This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.";
+}
+);
+},
+{
+key = manufacturerURL;
+value = "http://www.google.com/get/noto/";
+},
+{
+key = designerURL;
+value = "http://www.monotype.com/studio";
+}
+);
+settings = {
+disablesNiceNames = 1;
+};
+stems = (
+{
+name = "New Stem";
+}
+);
+unitsPerEm = 1000;
+userData = {
+GSDontShowVersionAlert = 1;
+};
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/sources/Exported instances UCAS SansCanadianAboriginal/Sans Canadian Aboriginal-RC CR roman.glyphs
+++ b/sources/Exported instances UCAS SansCanadianAboriginal/Sans Canadian Aboriginal-RC CR roman.glyphs
@@ -1,0 +1,37306 @@
+{
+.appVersion = "3151";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+},
+{
+name = Width;
+tag = wdth;
+},
+{
+name = Slant;
+tag = slnt;
+}
+);
+classes = (
+{
+code = "zero one two three four five six seven eight nine ";
+name = Num;
+},
+{
+code = "zero.canadian one.canadian two.canadian three.canadian four.canadian five.canadian six.canadian seven.canadian eight.canadian nine.canadian 
+";
+name = Num_can;
+},
+{
+code = "ke-canadian.square ki-canadian.square kii-canadian.square ko-canadian.square koo-canadian.square ka-canadian.square kaa-canadian.square kweWestCree-canadian.square kwiiWestCree-canadian.square kwoWestCree-canadian.square kwooWestCree-canadian.square kwaWestCree-canadian.square kwaaWestCree-canadian.square ce-canadian.square ci-canadian.square cii-canadian.square co-canadian.square coo-canadian.square ca-canadian.square caa-canadian.square me-canadian.square mi-canadian.square mii-canadian.square mo-canadian.square moo-canadian.square ma-canadian.square maa-canadian.square ne-canadian.square ni-canadian.square nii-canadian.square no-canadian.square noo-canadian.square na-canadian.square naa-canadian.square nweWestCree-canadian.square nwaWestCree-canadian.square nwaaWestCree-canadian.square se-canadian.square si-canadian.square sii-canadian.square so-canadian.square soo-canadian.square sa-canadian.square saa-canadian.square sho-canadian.square shoo-canadian.square sha-canadian.square shaa-canadian.square ye-canadian.square yi-canadian.square yii-canadian.square yo-canadian.square yoo-canadian.square ya-canadian.square yaa-canadian.square re-canadian.square reRCree-canadian.square leWestCree-canadian.square ri-canadian.square rii-canadian.square ro-canadian.square loWestCree-canadian.square ra-canadian.square raa-canadian.square laWestCree-canadian.square reWestCree-canadian.square riWestCree-canadian.square roWestCree-canadian.square raWestCree-canadian.square theThCree-canadian.square thiThCree-canadian.square thiiThCree-canadian.square thoThCree-canadian.square thooThCree-canadian.square thaThCree-canadian.square thaaThCree-canadian.square thweeWoodScree-canadian.square thwiWoodScree-canadian.square thwiiWoodScree-canadian.square thwoWoodScree-canadian.square thwooWoodScree-canadian.square thwaWoodScree-canadian.square thwaaWoodScree-canadian.square nwiOjibway-canadian.square nwiiOjibway-canadian.square nwoOjibway-canadian.square nwooOjibway-canadian.square looWestCree-canadian.square laaWestCree-canadian.square ";
+name = Dene_square;
+},
+{
+code = "ke-canadian ki-canadian kii-canadian ko-canadian koo-canadian ka-canadian kaa-canadian kweWestCree-canadian kwiiWestCree-canadian kwoWestCree-canadian kwooWestCree-canadian kwaWestCree-canadian kwaaWestCree-canadian ce-canadian ci-canadian cii-canadian co-canadian coo-canadian ca-canadian caa-canadian me-canadian mi-canadian mii-canadian mo-canadian moo-canadian ma-canadian maa-canadian ne-canadian ni-canadian nii-canadian no-canadian noo-canadian na-canadian naa-canadian nweWestCree-canadian nwaWestCree-canadian nwaaWestCree-canadian se-canadian si-canadian sii-canadian so-canadian soo-canadian sa-canadian saa-canadian sho-canadian shoo-canadian sha-canadian shaa-canadian ye-canadian yi-canadian yii-canadian yo-canadian yoo-canadian ya-canadian yaa-canadian re-canadian reRCree-canadian leWestCree-canadian ri-canadian rii-canadian ro-canadian loWestCree-canadian ra-canadian raa-canadian laWestCree-canadian reWestCree-canadian riWestCree-canadian roWestCree-canadian raWestCree-canadian theThCree-canadian thiThCree-canadian thiiThCree-canadian thoThCree-canadian thooThCree-canadian thaThCree-canadian thaaThCree-canadian thweeWoodScree-canadian thwiWoodScree-canadian thwiiWoodScree-canadian thwoWoodScree-canadian thwooWoodScree-canadian thwaWoodScree-canadian thwaaWoodScree-canadian nwiOjibway-canadian nwiiOjibway-canadian nwoOjibway-canadian nwooOjibway-canadian looWestCree-canadian laaWestCree-canadian 
+";
+name = Dene_round;
+},
+{
+code = "acuteFinal-canadian.mid graveFinal-canadian.mid ringTophalfFinal-canadian.mid ringRighthalfFinal-canadian.mid ringFinal-canadian.mid doubleacuteFinal-canadian.mid doubleshortverticalstrokesFinal-canadian.mid shorthorizontalstrokeFinal-canadian.mid downtackFinal-canadian.mid pWestCree-canadian.mid c-canadian.mid mWestCree-canadian.mid ";
+name = Final_mid;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian ringFinal-canadian doubleacuteFinal-canadian doubleshortverticalstrokesFinal-canadian shorthorizontalstrokeFinal-canadian downtackFinal-canadian pWestCree-canadian c-canadian mWestCree-canadian ";
+name = Final_mid_ori;
+},
+{
+code = "acuteFinal-canadian.base graveFinal-canadian.base ringBottomhalfFinal-canadian.base ringTophalfFinal-canadian.base ringRighthalfFinal-canadian.base plusFinal-canadian.base pWestCree-canadian.base c-canadian.base thSayisi-canadian.base mWestCree-canadian.base ";
+name = Final_base;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringBottomhalfFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian plusFinal-canadian pWestCree-canadian c-canadian thSayisi-canadian mWestCree-canadian ";
+name = Final_base_ori;
+},
+{
+code = "ng-canadian ngai-canadian ngaai-canadian ngi-canadian ngii-canadian ngo-canadian ngoo-canadian nga-canadian ngaa-canadian ";
+name = Nunavik;
+},
+{
+code = "ng-canadian.nunavik ngai-canadian.nunavik ngaai-canadian.nunavik ngi-canadian.nunavik ngii-canadian.nunavik ngo-canadian.nunavik ngoo-canadian.nunavik nga-canadian.nunavik ngaa-canadian.nunavik ";
+name = Nunavik_alt;
+}
+);
+customParameters = (
+{
+name = vendorID;
+value = GOOG;
+},
+{
+name = panose;
+value = (
+2,
+11,
+5,
+2,
+4,
+5,
+4,
+2,
+2,
+4
+);
+},
+{
+name = unicodeRanges;
+value = (
+0,
+1,
+2,
+5,
+6,
+45,
+77
+);
+},
+{
+name = codePageRanges;
+value = (
+"1252"
+);
+},
+{
+name = fsType;
+value = (
+);
+}
+);
+date = "2022-06-21 10:06:40 +0000";
+familyName = "Sans Canadian Aboriginal";
+featurePrefixes = (
+{
+automatic = 1;
+code = "languagesystem DFLT dflt;
+
+languagesystem cans dflt;
+";
+name = Languagesystems;
+}
+);
+features = (
+{
+automatic = 1;
+code = "feature ss01;
+feature ss02;
+feature ss03;
+feature ss04;
+";
+tag = aalt;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+tag = salt;
+},
+{
+code = "lookup space_can {
+sub space by space.canadian;
+} space_can;
+
+lookup num_can {
+sub @Num by @Num_can;
+} num_can;
+";
+labels = (
+{
+language = dflt;
+value = "CAN Space and numerals";
+}
+);
+tag = ss01;
+},
+{
+code = "lookup dene_square {
+sub @Dene_round by @Dene_square;
+} dene_square;
+
+";
+labels = (
+{
+language = dflt;
+value = "Dene Square";
+}
+);
+tag = ss02;
+},
+{
+code = "lookup nunavik_alt {
+sub @Nunavik by @Nunavik_alt;
+} nunavik_alt;
+
+";
+labels = (
+{
+language = dflt;
+value = "Nunanvik Alt";
+}
+);
+tag = ss03;
+},
+{
+code = "lookup final_mid {
+sub @Final_mid_ori by @Final_mid;
+} final_mid;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final mid";
+}
+);
+tag = ss04;
+},
+{
+code = "lookup final_base {
+sub @Final_base_ori by @Final_base;
+} final_base;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final base";
+}
+);
+tag = ss05;
+},
+{
+code = "lookup plaincree_first {
+sub wiWestCree-canadian' plusFinal-canadian by i-canadian;
+} plaincree_first;
+
+lookup plaincree_second {
+sub i-canadian plusFinal-canadian' by raiseddoubledotFinal-canadian.cree;
+} plaincree_second;
+
+lookup plaincree_third {
+sub middledotFinal-canadian plusFinal-canadian by raiseddoubledotFinal-canadian.cree;
+} plaincree_third;
+";
+labels = (
+{
+language = dflt;
+value = Plaincree;
+}
+);
+tag = ss06;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+labels = (
+{
+language = dflt;
+value = "";
+}
+);
+tag = ss07;
+}
+);
+fontMaster = (
+{
+axesValues = (
+0,
+0,
+0
+);
+customParameters = (
+{
+name = typoAscender;
+value = 1069;
+},
+{
+name = typoDescender;
+value = -293;
+},
+{
+name = typoLineGap;
+value = 0;
+},
+{
+name = winAscent;
+value = 1069;
+},
+{
+name = winDescent;
+value = 293;
+},
+{
+name = hheaAscender;
+value = 1069;
+},
+{
+name = hheaDescender;
+value = -293;
+},
+{
+name = strikeoutPosition;
+value = 297.19162;
+},
+{
+name = strikeoutSize;
+value = 50;
+}
+);
+guides = (
+{
+lockAngle = 1;
+locked = 1;
+pos = (230,357);
+}
+);
+id = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+metricValues = (
+{
+over = 19;
+pos = 1069;
+},
+{
+over = 19;
+pos = 714;
+},
+{
+over = 19;
+pos = 495;
+},
+{
+over = -19;
+},
+{
+over = -19;
+pos = -293;
+},
+{
+}
+);
+name = "RC CR roman";
+stemValues = (
+93
+);
+}
+);
+glyphs = (
+{
+glyphname = idotless;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(149,538,l),
+(57,538,l),
+(57,0,l),
+(149,0,l)
+);
+}
+);
+width = 206;
+}
+);
+note = dotlessi;
+unicode = 305;
+},
+{
+glyphname = "acuteFinal-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(98,357,l),
+(233,714,l),
+(162,714,l),
+(27,357,l)
+);
+}
+);
+width = 260;
+}
+);
+metricRight = "=|";
+note = uni141F;
+unicode = 5151;
+},
+{
+glyphname = "graveFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(233,357,l),
+(98,714,l),
+(27,714,l),
+(162,357,l)
+);
+}
+);
+width = 260;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+unicode = 5152;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(254,351,o),
+(301,401,o),
+(301,496,cs),
+(301,714,l),
+(238,714,l),
+(238,492,ls),
+(238,435,o),
+(218,409,o),
+(176,409,cs),
+(135,409,o),
+(115,436,o),
+(115,492,cs),
+(115,714,l),
+(51,714,l),
+(51,494,ls),
+(51,401,o),
+(99,351,o),
+(176,351,cs)
+);
+}
+);
+width = 352;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1421;
+unicode = 5153;
+},
+{
+glyphname = "ringTophalfFinal-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(115,357,l),
+(115,580,ls),
+(115,635,o),
+(135,662,o),
+(176,662,cs),
+(218,662,o),
+(238,636,o),
+(238,579,cs),
+(238,357,l),
+(301,357,l),
+(301,575,ls),
+(301,670,o),
+(254,720,o),
+(176,720,cs),
+(99,720,o),
+(51,670,o),
+(51,577,cs),
+(51,357,l)
+);
+}
+);
+width = 352;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+unicode = 5154;
+},
+{
+glyphname = "ringRighthalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(89,357,ls),
+(197,357,o),
+(255,424,o),
+(255,535,cs),
+(255,646,o),
+(197,714,o),
+(90,714,cs),
+(49,714,l),
+(49,653,l),
+(83,653,ls),
+(155,653,o),
+(190,611,o),
+(190,535,cs),
+(190,458,o),
+(155,418,o),
+(83,418,cs),
+(49,418,l),
+(49,357,l)
+);
+}
+);
+width = 303;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+unicode = 5155;
+},
+{
+glyphname = "ringFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(304,403,o),
+(370,471,o),
+(370,562,cs),
+(370,652,o),
+(303,720,o),
+(210,720,cs),
+(115,720,o),
+(49,652,o),
+(49,562,cs),
+(49,471,o),
+(115,403,o),
+(210,403,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(148,458,o),
+(108,500,o),
+(108,562,cs),
+(108,622,o),
+(148,665,o),
+(210,665,cs),
+(269,665,o),
+(310,621,o),
+(310,562,cs),
+(310,500,o),
+(269,458,o),
+(210,458,cs)
+);
+}
+);
+width = 418;
+}
+);
+note = uni1424;
+unicode = 5156;
+},
+{
+glyphname = "doubleacuteFinal-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(233,714,l),
+(162,714,l),
+(27,357,l),
+(98,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(363,714,l),
+(291,714,l),
+(157,357,l),
+(229,357,l)
+);
+}
+);
+width = 390;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricRight = "=|";
+note = uni1425;
+unicode = 5157;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(115,714,l),
+(51,714,l),
+(51,357,l),
+(115,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(230,714,l),
+(166,714,l),
+(166,357,l),
+(230,357,l)
+);
+}
+);
+width = 281;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "pWestCree-canadian";
+note = uni1426;
+unicode = 5158;
+},
+{
+glyphname = "middledotFinal-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(125,315,o),
+(148,338,o),
+(148,367,cs),
+(148,396,o),
+(125,419,o),
+(96,419,cs),
+(67,419,o),
+(44,396,o),
+(44,367,cs),
+(44,338,o),
+(67,315,o),
+(96,315,cs)
+);
+}
+);
+width = 191;
+}
+);
+note = uni1427;
+unicode = 5159;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(320,517,l),
+(320,581,l),
+(51,581,l),
+(51,517,l)
+);
+}
+);
+width = 371;
+}
+);
+metricRight = "=|";
+note = uni1428;
+unicode = 5160;
+},
+{
+glyphname = "plusFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(216,413,l),
+(216,534,l),
+(320,534,l),
+(320,596,l),
+(216,596,l),
+(216,714,l),
+(156,714,l),
+(156,596,l),
+(51,596,l),
+(51,534,l),
+(156,534,l),
+(156,413,l)
+);
+}
+);
+width = 371;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+unicode = 5161;
+},
+{
+glyphname = "downtackFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(218,357,l),
+(218,653,l),
+(320,653,l),
+(320,714,l),
+(51,714,l),
+(51,653,l),
+(154,653,l),
+(154,357,l)
+);
+}
+);
+width = 371;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni142A;
+unicode = 5162;
+},
+{
+glyphname = "thFinalWoodScree-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(218,357,l),
+(218,435,l),
+(320,435,l),
+(320,491,l),
+(218,491,l),
+(218,580,l),
+(320,580,l),
+(320,636,l),
+(218,636,l),
+(218,714,l),
+(154,714,l),
+(154,636,l),
+(51,636,l),
+(51,580,l),
+(154,580,l),
+(154,491,l),
+(51,491,l),
+(51,435,l),
+(154,435,l),
+(154,357,l)
+);
+}
+);
+width = 371;
+}
+);
+metricLeft = "hyphen-canadian";
+metricRight = "hyphen-canadian";
+note = uni167E;
+unicode = 5758;
+},
+{
+glyphname = "ringSmallFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(198,539,o),
+(241,579,o),
+(241,633,cs),
+(241,688,o),
+(198,727,o),
+(146,727,cs),
+(94,727,o),
+(51,688,o),
+(51,633,cs),
+(51,579,o),
+(93,539,o),
+(146,539,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(116,581,o),
+(95,603,o),
+(95,633,cs),
+(95,663,o),
+(116,685,o),
+(146,685,cs),
+(176,685,o),
+(197,663,o),
+(197,633,cs),
+(197,603,o),
+(176,581,o),
+(146,581,cs)
+);
+}
+);
+width = 292;
+}
+);
+note = g725;
+unicode = 6366;
+},
+{
+glyphname = "raiseddotFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(127,623,o),
+(150,646,o),
+(150,675,cs),
+(150,704,o),
+(127,727,o),
+(98,727,cs),
+(70,727,o),
+(46,704,o),
+(46,675,cs),
+(46,646,o),
+(70,623,o),
+(98,623,cs)
+);
+}
+);
+width = 197;
+}
+);
+note = g725;
+unicode = 6367;
+},
+{
+glyphname = "acuteFinal-canadian.base";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "acuteFinal-canadian";
+}
+);
+width = 260;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.base";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "graveFinal-canadian";
+}
+);
+width = 260;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian.base";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 352;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1421;
+},
+{
+glyphname = "ringTophalfFinal-canadian.base";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 352;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.base";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 303;
+}
+);
+metricLeft = "==|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "plusFinal-canadian.base";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(216,0,l),
+(216,121,l),
+(320,121,l),
+(320,183,l),
+(216,183,l),
+(216,301,l),
+(156,301,l),
+(156,183,l),
+(51,183,l),
+(51,121,l),
+(156,121,l),
+(156,0,l)
+);
+}
+);
+width = 371;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+},
+{
+glyphname = "acuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "acuteFinal-canadian";
+}
+);
+width = 260;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.mid";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "graveFinal-canadian";
+}
+);
+width = 260;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringTophalfFinal-canadian.mid";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-178);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 352;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.mid";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 303;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "ringFinal-canadian.mid";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-206);
+ref = "ringFinal-canadian";
+}
+);
+width = 418;
+}
+);
+metricLeft = "ringFinal-canadian";
+metricWidth = "ringFinal-canadian";
+note = uni1424;
+},
+{
+glyphname = "doubleacuteFinal-canadian.mid";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "doubleacuteFinal-canadian";
+}
+);
+width = 390;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "doubleacuteFinal-canadian";
+note = uni1425;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian.mid";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "doubleshortverticalstrokesFinal-canadian";
+}
+);
+width = 281;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricWidth = "doubleshortverticalstrokesFinal-canadian";
+note = uni1426;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian.mid";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-182);
+ref = "shorthorizontalstrokeFinal-canadian";
+}
+);
+width = 371;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "shorthorizontalstrokeFinal-canadian";
+note = uni1428;
+},
+{
+glyphname = "downtackFinal-canadian.mid";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "downtackFinal-canadian";
+}
+);
+width = 371;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "downtackFinal-canadian";
+note = uni142A;
+},
+{
+glyphname = "e-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (297,470);
+},
+{
+name = top_center_can;
+pos = (297,714);
+},
+{
+name = top_left_can;
+pos = (110,714);
+},
+{
+name = top_right_can;
+pos = (485,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(314,0,l),
+(571,688,l),
+(571,714,l),
+(26,714,l),
+(26,688,l),
+(283,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(320,110,l),
+(123,659,l),
+(107,638,l),
+(487,638,l),
+(475,659,l),
+(277,110,l)
+);
+}
+);
+width = 597;
+}
+);
+metricRight = "=|";
+note = uni1401;
+unicode = 5121;
+},
+{
+glyphname = "aai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (179,0);
+ref = ring_top.canadian;
+}
+);
+width = 597;
+}
+);
+note = uni1402;
+unicode = 5122;
+},
+{
+glyphname = "i-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (296,376);
+},
+{
+name = top_center_can;
+pos = (298,714);
+},
+{
+name = top_left_can;
+pos = (111,714);
+},
+{
+name = top_right_can;
+pos = (485,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(571,0,l),
+(571,26,l),
+(314,714,l),
+(283,714,l),
+(26,26,l),
+(26,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(319,604,l),
+(276,604,l),
+(474,55,l),
+(486,76,l),
+(107,76,l),
+(122,55,l)
+);
+}
+);
+width = 597;
+}
+);
+metricLeft = "e-canadian";
+metricWidth = "e-canadian";
+note = uni1403;
+unicode = 5123;
+},
+{
+glyphname = "ii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (228,0);
+ref = dot_top;
+}
+);
+width = 597;
+}
+);
+note = uni1404;
+unicode = 5124;
+},
+{
+glyphname = "o-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (235,357);
+},
+{
+name = top_center_can;
+pos = (296,714);
+},
+{
+name = top_double;
+pos = (383,714);
+},
+{
+name = top_left_can;
+pos = (99,714);
+},
+{
+name = top_right_can;
+pos = (495,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(86,0,l),
+(539,340,l),
+(539,374,l),
+(86,714,l),
+(62,714,l),
+(62,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(139,609,l),
+(118,599,l),
+(462,337,l),
+(462,378,l),
+(118,116,l),
+(139,105,l)
+);
+}
+);
+width = 569;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1405;
+unicode = 5125;
+},
+{
+glyphname = "oo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (29,0);
+ref = dot_top;
+}
+);
+width = 569;
+}
+);
+note = uni1406;
+unicode = 5126;
+},
+{
+glyphname = "yCreeoo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (161,0);
+ref = doubledot_top;
+}
+);
+width = 569;
+}
+);
+note = uni1407;
+unicode = 5127;
+},
+{
+glyphname = "eeCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(86,0,l),
+(539,340,l),
+(539,374,l),
+(86,714,l),
+(62,714,l),
+(62,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(133,609,l),
+(118,605,l),
+(462,343,l),
+(462,372,l),
+(118,110,l),
+(133,105,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(249,443,l),
+(213,443,l),
+(213,271,l),
+(249,271,l)
+);
+}
+);
+width = 569;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "o-canadian";
+note = uni1408;
+unicode = 5128;
+},
+{
+glyphname = "iCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (182,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 569;
+}
+);
+note = uni1409;
+unicode = 5129;
+},
+{
+glyphname = "a-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (331,357);
+},
+{
+name = top_center_can;
+pos = (253,714);
+},
+{
+name = top_left_can;
+pos = (75,714);
+},
+{
+name = top_right_can;
+pos = (467,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(507,0,l),
+(507,714,l),
+(483,714,l),
+(30,374,l),
+(30,340,l),
+(483,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(451,115,l),
+(107,377,l),
+(107,336,l),
+(451,598,l),
+(430,609,l),
+(430,105,l)
+);
+}
+);
+width = 569;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni140A;
+unicode = 5130;
+},
+{
+glyphname = "aa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (397,0);
+ref = dot_top;
+}
+);
+width = 569;
+}
+);
+note = uni140B;
+unicode = 5131;
+},
+{
+glyphname = "we-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "e-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni140C;
+unicode = 5132;
+},
+{
+glyphname = "weWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (597,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni140D;
+unicode = 5133;
+},
+{
+glyphname = "wi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "i-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni140E;
+unicode = 5134;
+},
+{
+glyphname = "wiWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (597,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni140F;
+unicode = 5135;
+},
+{
+glyphname = "wii-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (420,0);
+ref = dot_top;
+}
+);
+width = 788;
+}
+);
+note = uni1410;
+unicode = 5136;
+},
+{
+glyphname = "wiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (228,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (597,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni1411;
+unicode = 5137;
+},
+{
+glyphname = "wo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "o-canadian";
+}
+);
+width = 761;
+}
+);
+note = uni1412;
+unicode = 5138;
+},
+{
+glyphname = "woWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (569,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 761;
+}
+);
+note = uni1413;
+unicode = 5139;
+},
+{
+glyphname = "woo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (418,0);
+ref = dot_top;
+}
+);
+width = 761;
+}
+);
+note = uni1414;
+unicode = 5140;
+},
+{
+glyphname = "wooWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (29,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (569,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 761;
+}
+);
+note = uni1415;
+unicode = 5141;
+},
+{
+glyphname = "wooNaskapi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (179,-97);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (324,-207);
+ref = dot_top;
+}
+);
+width = 569;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricWidth = "o-canadian";
+note = uni1416;
+unicode = 5142;
+},
+{
+glyphname = "wa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "a-canadian";
+}
+);
+width = 761;
+}
+);
+note = uni1417;
+unicode = 5143;
+},
+{
+glyphname = "waWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (569,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 761;
+}
+);
+note = uni1418;
+unicode = 5144;
+},
+{
+glyphname = "waa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (588,0);
+ref = dot_top;
+}
+);
+width = 761;
+}
+);
+note = uni1419;
+unicode = 5145;
+},
+{
+glyphname = "waaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (397,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (569,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 761;
+}
+);
+note = uni141A;
+unicode = 5146;
+},
+{
+glyphname = "waaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (104,-207);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (249,-97);
+ref = dot_top;
+}
+);
+width = 569;
+}
+);
+metricWidth = "a-canadian";
+note = uni141B;
+unicode = 5147;
+},
+{
+glyphname = "ai-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(218,351,o),
+(250,380,o),
+(268,435,c),
+(249,435,l),
+(267,378,o),
+(302,351,o),
+(351,351,cs),
+(419,351,o),
+(467,394,o),
+(467,495,cs),
+(467,714,l),
+(407,714,l),
+(407,496,ls),
+(407,428,o),
+(381,409,o),
+(347,409,cs),
+(313,409,o),
+(288,429,o),
+(288,496,cs),
+(288,714,l),
+(229,714,l),
+(229,496,ls),
+(229,428,o),
+(203,409,o),
+(169,409,cs),
+(135,409,o),
+(111,430,o),
+(111,496,cs),
+(111,714,l),
+(51,714,l),
+(51,494,ls),
+(51,394,o),
+(99,351,o),
+(166,351,cs)
+);
+}
+);
+width = 518;
+}
+);
+metricRight = "=|";
+note = uni141C;
+unicode = 5148;
+},
+{
+glyphname = "ycreew-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(291,528,o),
+(320,564,o),
+(320,624,cs),
+(320,684,o),
+(290,720,o),
+(249,720,cs),
+(206,720,o),
+(177,684,o),
+(177,624,cs),
+(177,564,o),
+(206,528,o),
+(248,528,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(165,351,o),
+(194,387,o),
+(194,447,cs),
+(194,507,o),
+(164,543,o),
+(122,543,cs),
+(80,543,o),
+(51,507,o),
+(51,447,cs),
+(51,387,o),
+(79,351,o),
+(122,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(100,386,o),
+(87,406,o),
+(87,447,cs),
+(87,489,o),
+(100,508,o),
+(122,508,cs),
+(144,508,o),
+(158,489,o),
+(158,447,cs),
+(158,406,o),
+(144,386,o),
+(122,386,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(226,563,o),
+(213,583,o),
+(213,624,cs),
+(213,666,o),
+(226,685,o),
+(248,685,cs),
+(271,685,o),
+(284,666,o),
+(284,624,cs),
+(284,583,o),
+(271,563,o),
+(248,563,cs)
+);
+}
+);
+width = 371;
+}
+);
+metricRight = "=|";
+note = uni141D;
+unicode = 5149;
+},
+{
+glyphname = "glottalstop-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(319,357,l),
+(319,372,l),
+(191,714,l),
+(174,714,l),
+(46,372,l),
+(46,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(198,650,l),
+(167,650,l),
+(261,385,l),
+(271,406,l),
+(94,406,l),
+(103,385,l)
+);
+}
+);
+width = 365;
+}
+);
+metricRight = "=|";
+note = uni141E;
+unicode = 5150;
+},
+{
+glyphname = "en-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+pos = (597,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 857;
+}
+);
+note = uni142B;
+unicode = 5163;
+},
+{
+glyphname = "in-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+pos = (410,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 670;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142C;
+unicode = 5164;
+},
+{
+glyphname = "on-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (443,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 703;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142D;
+unicode = 5165;
+},
+{
+glyphname = "an-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (540,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 800;
+}
+);
+metricRight = "graveFinal-canadian";
+note = uni142E;
+unicode = 5166;
+},
+{
+glyphname = "pe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (297,470);
+},
+{
+name = top_center_can;
+pos = (297,714);
+},
+{
+name = top_left_can;
+pos = (110,714);
+},
+{
+name = top_right_can;
+pos = (485,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(314,0,l),
+(571,688,l),
+(571,714,l),
+(489,714,l),
+(270,111,l),
+(329,111,l),
+(110,714,l),
+(26,714,l),
+(26,688,l),
+(283,0,l)
+);
+}
+);
+width = 597;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni142F;
+unicode = 5167;
+},
+{
+glyphname = "paai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (179,0);
+ref = ring_top.canadian;
+}
+);
+width = 597;
+}
+);
+note = uni1430;
+unicode = 5168;
+},
+{
+glyphname = "pi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (298,376);
+},
+{
+name = top_center_can;
+pos = (298,714);
+},
+{
+name = top_left_can;
+pos = (111,714);
+},
+{
+name = top_right_can;
+pos = (486,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(109,0,l),
+(327,603,l),
+(268,603,l),
+(488,0,l),
+(571,0,l),
+(571,26,l),
+(314,714,l),
+(283,714,l),
+(26,26,l),
+(26,0,l)
+);
+}
+);
+width = 597;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni1431;
+unicode = 5169;
+},
+{
+glyphname = "pii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (228,0);
+ref = dot_top;
+}
+);
+width = 597;
+}
+);
+note = uni1432;
+unicode = 5170;
+},
+{
+glyphname = "po-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (169,357);
+},
+{
+name = top_center_can;
+pos = (274,714);
+},
+{
+name = top_double;
+pos = (371,714);
+},
+{
+name = top_left_can;
+pos = (82,714);
+},
+{
+name = top_right_can;
+pos = (471,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(66,0,l),
+(514,340,l),
+(514,374,l),
+(66,714,l),
+(42,714,l),
+(42,628,l),
+(425,336,l),
+(425,379,l),
+(42,87,l),
+(42,0,l)
+);
+}
+);
+width = 544;
+}
+);
+metricRight = "o-canadian";
+note = uni1433;
+unicode = 5171;
+},
+{
+glyphname = "poo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (12,0);
+ref = dot_top;
+}
+);
+width = 545;
+}
+);
+note = uni1434;
+unicode = 5172;
+},
+{
+glyphname = "ycreepoo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (149,0);
+ref = doubledot_top;
+}
+);
+width = 545;
+}
+);
+note = uni1435;
+unicode = 5173;
+},
+{
+glyphname = "heeCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (129,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 545;
+}
+);
+note = uni1436;
+unicode = 5174;
+},
+{
+glyphname = "hiCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (108,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 545;
+}
+);
+note = uni1437;
+unicode = 5175;
+},
+{
+glyphname = "pa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (294,357);
+},
+{
+name = top_center_can;
+pos = (272,714);
+},
+{
+name = top_left_can;
+pos = (75,714);
+},
+{
+name = top_right_can;
+pos = (463,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(503,0,l),
+(503,86,l),
+(120,378,l),
+(120,335,l),
+(503,627,l),
+(503,714,l),
+(479,714,l),
+(30,374,l),
+(30,340,l),
+(479,0,l)
+);
+}
+);
+width = 545;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1438;
+unicode = 5176;
+},
+{
+glyphname = "paa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (393,0);
+ref = dot_top;
+}
+);
+width = 545;
+}
+);
+note = uni1439;
+unicode = 5177;
+},
+{
+glyphname = "pwe-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "pe-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni143A;
+unicode = 5178;
+},
+{
+glyphname = "pweWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "pe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (597,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni143B;
+unicode = 5179;
+},
+{
+glyphname = "pwi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "pi-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni143C;
+unicode = 5180;
+},
+{
+glyphname = "pwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (597,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni143D;
+unicode = 5181;
+},
+{
+glyphname = "pwii-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (420,0);
+ref = dot_top;
+}
+);
+width = 788;
+}
+);
+note = uni143E;
+unicode = 5182;
+},
+{
+glyphname = "pwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (228,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (597,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni143F;
+unicode = 5183;
+},
+{
+glyphname = "pwo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "po-canadian";
+}
+);
+width = 736;
+}
+);
+note = uni1440;
+unicode = 5184;
+},
+{
+glyphname = "pwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (545,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 736;
+}
+);
+note = uni1441;
+unicode = 5185;
+},
+{
+glyphname = "pwoo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (396,0);
+ref = dot_top;
+}
+);
+width = 736;
+}
+);
+note = uni1442;
+unicode = 5186;
+},
+{
+glyphname = "pwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (12,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (545,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 736;
+}
+);
+note = uni1443;
+unicode = 5187;
+},
+{
+glyphname = "pwa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "pa-canadian";
+}
+);
+width = 736;
+}
+);
+note = uni1444;
+unicode = 5188;
+},
+{
+glyphname = "pwaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (545,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 736;
+}
+);
+note = uni1445;
+unicode = 5189;
+},
+{
+glyphname = "pwaa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (585,0);
+ref = dot_top;
+}
+);
+width = 736;
+}
+);
+note = uni1446;
+unicode = 5190;
+},
+{
+glyphname = "pwaaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (393,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (545,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 736;
+}
+);
+note = uni1447;
+unicode = 5191;
+},
+{
+glyphname = "ycreepwaa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+pos = (102,-207);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (247,-97);
+ref = dot_top;
+}
+);
+width = 545;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1448;
+unicode = 5192;
+},
+{
+glyphname = "p-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(284,357,l),
+(284,417,l),
+(100,559,l),
+(100,513,l),
+(284,654,l),
+(284,714,l),
+(271,714,l),
+(51,546,l),
+(51,526,l),
+(271,357,l)
+);
+}
+);
+width = 335;
+}
+);
+note = uni1449;
+unicode = 5193;
+},
+{
+glyphname = "pWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(115,357,l),
+(115,714,l),
+(51,714,l),
+(51,357,l)
+);
+}
+);
+width = 166;
+}
+);
+metricRight = "=|";
+note = uni144A;
+unicode = 5194;
+},
+{
+color = 6;
+glyphname = "hCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(115,189,l),
+(115,334,ls),
+(115,371,o),
+(132,393,o),
+(164,393,cs),
+(194,393,o),
+(207,373,o),
+(207,334,cs),
+(207,189,l),
+(271,189,l),
+(271,345,ls),
+(271,419,o),
+(227,450,o),
+(180,450,cs),
+(136,450,o),
+(105,422,o),
+(100,384,c),
+(115,374,l),
+(115,546,l),
+(51,546,l),
+(51,189,l)
+);
+}
+);
+width = 306;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144B;
+unicode = 5195;
+},
+{
+glyphname = "te-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (301,357);
+},
+{
+name = top_center_can;
+pos = (301,714);
+},
+{
+name = top_left_can;
+pos = (106,714);
+},
+{
+name = top_right_can;
+pos = (497,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(455,-13,o),
+(544,81,o),
+(544,262,cs),
+(544,714,l),
+(450,714,l),
+(450,262,ls),
+(450,131,o),
+(397,74,o),
+(301,74,cs),
+(207,74,o),
+(152,134,o),
+(152,262,cs),
+(152,714,l),
+(58,714,l),
+(58,260,ls),
+(58,81,o),
+(150,-13,o),
+(301,-13,cs)
+);
+}
+);
+width = 602;
+}
+);
+metricRight = "=|";
+note = uni144C;
+unicode = 5196;
+},
+{
+glyphname = "taai-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (181,0);
+ref = ring_top.canadian;
+}
+);
+width = 602;
+}
+);
+note = uni144D;
+unicode = 5197;
+},
+{
+glyphname = "ti-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (301,357);
+},
+{
+name = middle_right_can;
+pos = (655,357);
+},
+{
+name = top_center_can;
+pos = (301,714);
+},
+{
+name = top_left_can;
+pos = (106,714);
+},
+{
+name = top_right_can;
+pos = (497,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(152,0,l),
+(152,452,ls),
+(152,582,o),
+(205,640,o),
+(301,640,cs),
+(395,640,o),
+(450,580,o),
+(450,452,cs),
+(450,0,l),
+(544,0,l),
+(544,454,ls),
+(544,633,o),
+(453,727,o),
+(301,727,cs),
+(151,727,o),
+(58,633,o),
+(58,452,cs),
+(58,0,l)
+);
+}
+);
+width = 602;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni144E;
+unicode = 5198;
+},
+{
+glyphname = "tii-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (231,0);
+ref = dot_top;
+}
+);
+width = 602;
+}
+);
+note = uni144F;
+unicode = 5199;
+},
+{
+glyphname = "to-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (202,357);
+},
+{
+name = middle_right_can;
+pos = (564,357);
+},
+{
+name = top_center_can;
+pos = (227,714);
+},
+{
+name = top_double;
+pos = (284,714);
+},
+{
+name = top_left_can;
+pos = (83,714);
+},
+{
+name = top_right_can;
+pos = (413,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(141,0,ls),
+(347,0,o),
+(453,124,o),
+(453,358,cs),
+(453,592,o),
+(347,714,o),
+(138,714,cs),
+(43,714,l),
+(43,628,l),
+(139,628,ls),
+(289,628,o),
+(360,542,o),
+(360,358,cs),
+(360,175,o),
+(289,86,o),
+(142,86,cs),
+(43,86,l),
+(43,0,l)
+);
+}
+);
+width = 504;
+}
+);
+note = uni1450;
+unicode = 5200;
+},
+{
+glyphname = "too-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (157,0);
+ref = dot_top;
+}
+);
+width = 504;
+}
+);
+note = uni1451;
+unicode = 5201;
+},
+{
+glyphname = "ycreetoo-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (61,0);
+ref = doubledot_top;
+}
+);
+width = 504;
+}
+);
+note = uni1452;
+unicode = 5202;
+},
+{
+glyphname = "deeCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (156,0);
+ref = stroke_middle;
+}
+);
+width = 504;
+}
+);
+note = uni1453;
+unicode = 5203;
+},
+{
+glyphname = "diCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (132,0);
+ref = dot_middle;
+}
+);
+width = 504;
+}
+);
+note = uni1454;
+unicode = 5204;
+},
+{
+glyphname = "ta-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (303,357);
+},
+{
+name = top_center_can;
+pos = (278,714);
+},
+{
+name = top_left_can;
+pos = (91,714);
+},
+{
+name = top_right_can;
+pos = (421,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(461,0,l),
+(461,86,l),
+(365,86,ls),
+(215,86,o),
+(145,173,o),
+(145,356,cs),
+(145,539,o),
+(215,628,o),
+(362,628,cs),
+(461,628,l),
+(461,714,l),
+(363,714,ls),
+(157,714,o),
+(51,590,o),
+(51,356,cs),
+(51,122,o),
+(157,0,o),
+(366,0,cs)
+);
+}
+);
+width = 504;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|to-canadian";
+note = uni1455;
+unicode = 5205;
+},
+{
+glyphname = "taa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (208,0);
+ref = dot_top;
+}
+);
+width = 504;
+}
+);
+note = uni1456;
+unicode = 5206;
+},
+{
+glyphname = "twe-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "te-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni1457;
+unicode = 5207;
+},
+{
+glyphname = "tweWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (602,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni1458;
+unicode = 5208;
+},
+{
+glyphname = "twi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ti-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni1459;
+unicode = 5209;
+},
+{
+glyphname = "twiWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (602,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni145A;
+unicode = 5210;
+},
+{
+glyphname = "twii-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (422,0);
+ref = dot_top;
+}
+);
+width = 794;
+}
+);
+note = uni145B;
+unicode = 5211;
+},
+{
+glyphname = "twiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (231,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (602,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni145C;
+unicode = 5212;
+},
+{
+glyphname = "two-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "to-canadian";
+}
+);
+width = 696;
+}
+);
+note = uni145D;
+unicode = 5213;
+},
+{
+glyphname = "twoWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (504,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 696;
+}
+);
+note = uni145E;
+unicode = 5214;
+},
+{
+glyphname = "twoo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (348,0);
+ref = dot_top;
+}
+);
+width = 696;
+}
+);
+note = uni145F;
+unicode = 5215;
+},
+{
+glyphname = "twooWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (157,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (504,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 696;
+}
+);
+note = uni1460;
+unicode = 5216;
+},
+{
+glyphname = "twa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ta-canadian";
+}
+);
+width = 696;
+}
+);
+note = uni1461;
+unicode = 5217;
+},
+{
+glyphname = "twaWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (504,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 696;
+}
+);
+note = uni1462;
+unicode = 5218;
+},
+{
+glyphname = "twaa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (400,0);
+ref = dot_top;
+}
+);
+width = 696;
+}
+);
+note = uni1463;
+unicode = 5219;
+},
+{
+glyphname = "twaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (208,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (504,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 696;
+}
+);
+note = uni1464;
+unicode = 5220;
+},
+{
+glyphname = "twaaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (202,0);
+ref = "ta-canadian";
+}
+);
+width = 706;
+}
+);
+note = uni1465;
+unicode = 5221;
+},
+{
+glyphname = "t-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(254,357,l),
+(254,418,l),
+(220,418,ls),
+(148,418,o),
+(113,458,o),
+(113,535,cs),
+(113,611,o),
+(148,653,o),
+(220,653,cs),
+(254,653,l),
+(254,714,l),
+(214,714,ls),
+(107,714,o),
+(49,646,o),
+(49,535,cs),
+(49,424,o),
+(107,357,o),
+(215,357,cs)
+);
+}
+);
+width = 303;
+}
+);
+note = uni1466;
+unicode = 5222;
+},
+{
+glyphname = "tte-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+pos = (602,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 768;
+}
+);
+note = uni1467;
+unicode = 5223;
+},
+{
+glyphname = "tti-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+pos = (602,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 768;
+}
+);
+note = uni1468;
+unicode = 5224;
+},
+{
+glyphname = "tto-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+pos = (504,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 670;
+}
+);
+note = uni1469;
+unicode = 5225;
+},
+{
+glyphname = "tta-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+pos = (504,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 670;
+}
+);
+note = uni146A;
+unicode = 5226;
+},
+{
+glyphname = "ke-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (258,457);
+},
+{
+name = top_center_can;
+pos = (245,714);
+},
+{
+name = top_left_can;
+pos = (97,714);
+},
+{
+name = top_right_can;
+pos = (393,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(439,0,l),
+(439,462,ls),
+(439,633,o),
+(372,727,o),
+(248,727,cs),
+(124,727,o),
+(51,631,o),
+(51,463,cs),
+(51,303,o),
+(122,205,o),
+(234,205,cs),
+(297,205,o),
+(344,247,o),
+(355,303,c),
+(346,328,l),
+(346,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(180,286,o),
+(142,343,o),
+(142,467,cs),
+(142,590,o),
+(179,647,o),
+(245,647,cs),
+(311,647,o),
+(348,591,o),
+(348,467,cs),
+(348,343,o),
+(309,286,o),
+(245,286,cs)
+);
+}
+);
+width = 497;
+}
+);
+metricRight = "te-canadian";
+note = uni146B;
+unicode = 5227;
+},
+{
+glyphname = "kaai-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (133,0);
+ref = ring_top.canadian;
+}
+);
+width = 498;
+}
+);
+note = uni146C;
+unicode = 5228;
+},
+{
+glyphname = "ki-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (265,457);
+},
+{
+name = top_center_can;
+pos = (252,714);
+},
+{
+name = top_left_can;
+pos = (105,714);
+},
+{
+name = top_right_can;
+pos = (401,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(152,0,l),
+(152,328,l),
+(143,303,l),
+(154,247,o),
+(200,205,o),
+(264,205,cs),
+(376,205,o),
+(447,303,o),
+(447,464,cs),
+(447,631,o),
+(374,727,o),
+(252,727,cs),
+(126,727,o),
+(58,629,o),
+(58,462,cs),
+(58,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(188,286,o),
+(150,343,o),
+(150,467,cs),
+(150,591,o),
+(186,647,o),
+(252,647,cs),
+(319,647,o),
+(355,590,o),
+(355,467,cs),
+(355,343,o),
+(317,286,o),
+(252,286,cs)
+);
+}
+);
+width = 498;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni146D;
+unicode = 5229;
+},
+{
+glyphname = "kii-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (182,0);
+ref = dot_top;
+}
+);
+width = 498;
+}
+);
+note = uni146E;
+unicode = 5230;
+},
+{
+glyphname = "ko-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (258,375);
+},
+{
+name = top_center_can;
+pos = (245,714);
+},
+{
+name = top_double;
+pos = (393,714);
+},
+{
+name = top_left_can;
+pos = (97,714);
+},
+{
+name = top_right_can;
+pos = (393,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(371,-13,o),
+(439,81,o),
+(439,252,cs),
+(439,714,l),
+(346,714,l),
+(346,386,l),
+(355,411,l),
+(344,467,o),
+(297,509,o),
+(234,509,cs),
+(122,509,o),
+(51,411,o),
+(51,246,cs),
+(51,83,o),
+(122,-13,o),
+(247,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(179,67,o),
+(142,124,o),
+(142,247,cs),
+(142,371,o),
+(180,428,o),
+(245,428,cs),
+(309,428,o),
+(348,371,o),
+(348,247,cs),
+(348,123,o),
+(311,67,o),
+(245,67,cs)
+);
+}
+);
+width = 497;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni146F;
+unicode = 5231;
+},
+{
+glyphname = "koo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (323,0);
+ref = dot_top;
+}
+);
+width = 498;
+}
+);
+note = uni1470;
+unicode = 5232;
+},
+{
+glyphname = "ycreekoo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (171,0);
+ref = doubledot_top;
+}
+);
+width = 498;
+}
+);
+note = uni1471;
+unicode = 5233;
+},
+{
+glyphname = "ka-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (265,377);
+},
+{
+name = top_center_can;
+pos = (253,714);
+},
+{
+name = top_left_can;
+pos = (105,714);
+},
+{
+name = top_right_can;
+pos = (401,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(374,-13,o),
+(447,83,o),
+(447,250,cs),
+(447,411,o),
+(376,509,o),
+(264,509,cs),
+(200,509,o),
+(154,467,o),
+(143,411,c),
+(152,386,l),
+(152,714,l),
+(58,714,l),
+(58,252,ls),
+(58,81,o),
+(125,-13,o),
+(250,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(186,67,o),
+(150,123,o),
+(150,247,cs),
+(150,371,o),
+(188,428,o),
+(252,428,cs),
+(317,428,o),
+(355,371,o),
+(355,247,cs),
+(355,124,o),
+(319,67,o),
+(252,67,cs)
+);
+}
+);
+width = 498;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "==|ke-canadian";
+note = uni1472;
+unicode = 5234;
+},
+{
+glyphname = "kaa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (35,0);
+ref = dot_top;
+}
+);
+width = 498;
+}
+);
+note = uni1473;
+unicode = 5235;
+},
+{
+glyphname = "kwe-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ke-canadian";
+}
+);
+width = 689;
+}
+);
+note = uni1474;
+unicode = 5236;
+},
+{
+glyphname = "kweWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (498,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 689;
+}
+);
+note = uni1475;
+unicode = 5237;
+},
+{
+glyphname = "kwi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ki-canadian";
+}
+);
+width = 689;
+}
+);
+note = uni1476;
+unicode = 5238;
+},
+{
+glyphname = "kwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (498,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 689;
+}
+);
+note = uni1477;
+unicode = 5239;
+},
+{
+glyphname = "kwii-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (374,0);
+ref = dot_top;
+}
+);
+width = 689;
+}
+);
+note = uni1478;
+unicode = 5240;
+},
+{
+glyphname = "kwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (182,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (498,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 689;
+}
+);
+note = uni1479;
+unicode = 5241;
+},
+{
+glyphname = "kwo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ko-canadian";
+}
+);
+width = 689;
+}
+);
+note = uni147A;
+unicode = 5242;
+},
+{
+glyphname = "kwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (498,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 689;
+}
+);
+note = uni147B;
+unicode = 5243;
+},
+{
+glyphname = "kwoo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (514,0);
+ref = dot_top;
+}
+);
+width = 689;
+}
+);
+note = uni147C;
+unicode = 5244;
+},
+{
+glyphname = "kwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (323,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (498,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 689;
+}
+);
+note = uni147D;
+unicode = 5245;
+},
+{
+glyphname = "kwa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ka-canadian";
+}
+);
+width = 689;
+}
+);
+note = uni147E;
+unicode = 5246;
+},
+{
+glyphname = "kwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (498,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 689;
+}
+);
+note = uni147F;
+unicode = 5247;
+},
+{
+glyphname = "kwaa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (227,0);
+ref = dot_top;
+}
+);
+width = 689;
+}
+);
+note = uni1480;
+unicode = 5248;
+},
+{
+glyphname = "kwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (35,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (498,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 689;
+}
+);
+note = uni1481;
+unicode = 5249;
+},
+{
+glyphname = "kwaaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (202,0);
+ref = "ka-canadian";
+}
+);
+width = 699;
+}
+);
+note = uni1482;
+unicode = 5250;
+},
+{
+glyphname = "k-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(220,351,o),
+(268,396,o),
+(268,491,cs),
+(268,576,o),
+(226,622,o),
+(173,622,cs),
+(133,622,o),
+(104,594,o),
+(99,548,c),
+(115,548,l),
+(115,714,l),
+(51,714,l),
+(51,486,ls),
+(51,401,o),
+(93,351,o),
+(160,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(129,400,o),
+(110,423,o),
+(110,487,cs),
+(110,548,o),
+(131,573,o),
+(160,573,cs),
+(189,573,o),
+(210,549,o),
+(210,487,cs),
+(210,425,o),
+(190,400,o),
+(160,400,cs)
+);
+}
+);
+width = 309;
+}
+);
+note = uni1483;
+unicode = 5251;
+},
+{
+glyphname = "kw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(216,351,o),
+(258,401,o),
+(258,486,cs),
+(258,714,l),
+(194,714,l),
+(194,548,l),
+(210,548,l),
+(205,594,o),
+(175,622,o),
+(136,622,cs),
+(82,622,o),
+(41,576,o),
+(41,491,cs),
+(41,396,o),
+(89,351,o),
+(148,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(119,400,o),
+(99,425,o),
+(99,487,cs),
+(99,549,o),
+(120,573,o),
+(148,573,cs),
+(178,573,o),
+(198,548,o),
+(198,487,cs),
+(198,423,o),
+(179,400,o),
+(148,400,cs)
+);
+}
+);
+width = 309;
+}
+);
+metricLeft = "=|k-canadian";
+metricRight = "=|k-canadian";
+note = uni1484;
+unicode = 5252;
+},
+{
+glyphname = "southslaveykeh-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+pos = (498,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 663;
+}
+);
+note = uni1485;
+unicode = 5253;
+},
+{
+glyphname = "southslaveykih-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+pos = (498,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 663;
+}
+);
+note = uni1486;
+unicode = 5254;
+},
+{
+glyphname = "southslaveykoh-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+pos = (498,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 663;
+}
+);
+note = uni1487;
+unicode = 5255;
+},
+{
+glyphname = "southslaveykah-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+pos = (498,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 663;
+}
+);
+note = uni1488;
+unicode = 5256;
+},
+{
+glyphname = "ce-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (254,417);
+},
+{
+name = top_center_can;
+pos = (243,714);
+},
+{
+name = top_left_can;
+pos = (96,714);
+},
+{
+name = top_right_can;
+pos = (387,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(433,0,l),
+(433,480,ls),
+(433,634,o),
+(367,727,o),
+(243,727,cs),
+(120,727,o),
+(49,638,o),
+(49,484,cs),
+(49,401,l),
+(142,401,l),
+(142,500,ls),
+(142,592,o),
+(175,645,o),
+(242,645,cs),
+(306,645,o),
+(340,593,o),
+(340,496,cs),
+(340,0,l)
+);
+}
+);
+width = 491;
+}
+);
+metricRight = "te-canadian";
+note = uni1489;
+unicode = 5257;
+},
+{
+glyphname = "caai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (133,0);
+ref = ring_top.canadian;
+}
+);
+width = 492;
+}
+);
+note = uni148A;
+unicode = 5258;
+},
+{
+glyphname = "ci-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (263,417);
+},
+{
+name = top_center_can;
+pos = (252,714);
+},
+{
+name = top_left_can;
+pos = (106,714);
+},
+{
+name = top_right_can;
+pos = (398,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(152,0,l),
+(152,496,ls),
+(152,593,o),
+(186,645,o),
+(250,645,cs),
+(317,645,o),
+(350,592,o),
+(350,500,cs),
+(350,401,l),
+(443,401,l),
+(443,484,ls),
+(443,638,o),
+(372,727,o),
+(251,727,cs),
+(125,727,o),
+(58,634,o),
+(58,479,cs),
+(58,0,l)
+);
+}
+);
+width = 492;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+unicode = 5259;
+},
+{
+glyphname = "cii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (182,0);
+ref = dot_top;
+}
+);
+width = 492;
+}
+);
+note = uni148C;
+unicode = 5260;
+},
+{
+glyphname = "co-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (254,417);
+},
+{
+name = top_center_can;
+pos = (242,714);
+},
+{
+name = top_double;
+pos = (387,714);
+},
+{
+name = top_left_can;
+pos = (96,714);
+},
+{
+name = top_right_can;
+pos = (387,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(366,-13,o),
+(433,80,o),
+(433,235,cs),
+(433,714,l),
+(340,714,l),
+(340,218,ls),
+(340,121,o),
+(306,69,o),
+(242,69,cs),
+(175,69,o),
+(142,122,o),
+(142,214,cs),
+(142,313,l),
+(49,313,l),
+(49,230,ls),
+(49,76,o),
+(120,-13,o),
+(245,-13,cs)
+);
+}
+);
+width = 491;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+unicode = 5261;
+},
+{
+glyphname = "coo-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (317,0);
+ref = dot_top;
+}
+);
+width = 492;
+}
+);
+note = uni148E;
+unicode = 5262;
+},
+{
+glyphname = "ycreecoo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (165,0);
+ref = doubledot_top;
+}
+);
+width = 492;
+}
+);
+note = uni148F;
+unicode = 5263;
+},
+{
+glyphname = "ca-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (263,417);
+},
+{
+name = top_center_can;
+pos = (252,714);
+},
+{
+name = top_left_can;
+pos = (106,714);
+},
+{
+name = top_right_can;
+pos = (397,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(372,-13,o),
+(443,76,o),
+(443,230,cs),
+(443,313,l),
+(350,313,l),
+(350,214,ls),
+(350,122,o),
+(317,69,o),
+(250,69,cs),
+(186,69,o),
+(152,121,o),
+(152,218,cs),
+(152,714,l),
+(58,714,l),
+(58,234,ls),
+(58,80,o),
+(125,-13,o),
+(249,-13,cs)
+);
+}
+);
+width = 492;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+unicode = 5264;
+},
+{
+glyphname = "caa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+}
+);
+width = 492;
+}
+);
+note = uni1491;
+unicode = 5265;
+},
+{
+glyphname = "cwe-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ce-canadian";
+}
+);
+width = 683;
+}
+);
+note = uni1492;
+unicode = 5266;
+},
+{
+glyphname = "cweWestCree-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (492,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 683;
+}
+);
+note = uni1493;
+unicode = 5267;
+},
+{
+glyphname = "cwi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ci-canadian";
+}
+);
+width = 683;
+}
+);
+note = uni1494;
+unicode = 5268;
+},
+{
+glyphname = "cwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (492,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 683;
+}
+);
+note = uni1495;
+unicode = 5269;
+},
+{
+glyphname = "cwii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (374,0);
+ref = dot_top;
+}
+);
+width = 683;
+}
+);
+note = uni1496;
+unicode = 5270;
+},
+{
+glyphname = "cwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (182,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (492,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 683;
+}
+);
+note = uni1497;
+unicode = 5271;
+},
+{
+glyphname = "cwo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "co-canadian";
+}
+);
+width = 683;
+}
+);
+note = uni1498;
+unicode = 5272;
+},
+{
+glyphname = "cwoWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (492,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 683;
+}
+);
+note = uni1499;
+unicode = 5273;
+},
+{
+glyphname = "cwoo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (509,0);
+ref = dot_top;
+}
+);
+width = 683;
+}
+);
+note = uni149A;
+unicode = 5274;
+},
+{
+glyphname = "cwooWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (317,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (492,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 683;
+}
+);
+note = uni149B;
+unicode = 5275;
+},
+{
+glyphname = "cwa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ca-canadian";
+}
+);
+width = 683;
+}
+);
+note = uni149C;
+unicode = 5276;
+},
+{
+glyphname = "cwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (492,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 683;
+}
+);
+note = uni149D;
+unicode = 5277;
+},
+{
+glyphname = "cwaa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (227,0);
+ref = dot_top;
+}
+);
+width = 683;
+}
+);
+note = uni149E;
+unicode = 5278;
+},
+{
+glyphname = "cwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (492,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 683;
+}
+);
+note = uni149F;
+unicode = 5279;
+},
+{
+glyphname = "cwaaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (202,0);
+ref = "ca-canadian";
+}
+);
+width = 694;
+}
+);
+note = uni14A0;
+unicode = 5280;
+},
+{
+glyphname = "c-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(226,351,o),
+(269,396,o),
+(269,478,cs),
+(269,504,l),
+(210,504,l),
+(210,468,ls),
+(210,426,o),
+(191,403,o),
+(162,403,cs),
+(130,403,o),
+(115,425,o),
+(115,473,cs),
+(115,714,l),
+(51,714,l),
+(51,482,ls),
+(51,396,o),
+(91,351,o),
+(161,351,cs)
+);
+}
+);
+width = 299;
+}
+);
+note = uni14A1;
+unicode = 5281;
+},
+{
+glyphname = "thSayisi-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(207,351,o),
+(247,396,o),
+(247,482,cs),
+(247,714,l),
+(184,714,l),
+(184,473,ls),
+(184,425,o),
+(168,403,o),
+(136,403,cs),
+(107,403,o),
+(89,426,o),
+(89,468,cs),
+(89,504,l),
+(30,504,l),
+(30,478,ls),
+(30,396,o),
+(73,351,o),
+(140,351,cs)
+);
+}
+);
+width = 298;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "=|c-canadian";
+note = uni14A2;
+unicode = 5282;
+},
+{
+glyphname = "me-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (163,357);
+},
+{
+name = top_center_can;
+pos = (212,714);
+},
+{
+name = top_left_can;
+pos = (80,714);
+},
+{
+name = top_right_can;
+pos = (338,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(384,0,l),
+(384,714,l),
+(34,714,l),
+(34,628,l),
+(291,628,l),
+(291,0,l)
+);
+}
+);
+width = 446;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+unicode = 5283;
+},
+{
+glyphname = "maai-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (118,0);
+ref = ring_top.canadian;
+}
+);
+width = 446;
+}
+);
+note = uni14A4;
+unicode = 5284;
+},
+{
+glyphname = "mi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (284,357);
+},
+{
+name = top_center_can;
+pos = (237,714);
+},
+{
+name = top_left_can;
+pos = (109,714);
+},
+{
+name = top_right_can;
+pos = (365,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(155,0,l),
+(155,628,l),
+(412,628,l),
+(412.002,714,l),
+(62,714,l),
+(62,0,l)
+);
+}
+);
+width = 446;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+unicode = 5285;
+},
+{
+glyphname = "mii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (167,0);
+ref = dot_top;
+}
+);
+width = 446;
+}
+);
+note = uni14A6;
+unicode = 5286;
+},
+{
+glyphname = "mo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (163,357);
+},
+{
+name = top_center_can;
+pos = (212,714);
+},
+{
+name = top_double;
+pos = (338,714);
+},
+{
+name = top_left_can;
+pos = (80,714);
+},
+{
+name = top_right_can;
+pos = (338,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(384,0,l),
+(384,714,l),
+(291,714,l),
+(291,86,l),
+(34,86,l),
+(34,0,l)
+);
+}
+);
+width = 446;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+unicode = 5287;
+},
+{
+glyphname = "moo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (268,0);
+ref = dot_top;
+}
+);
+width = 446;
+}
+);
+note = uni14A8;
+unicode = 5288;
+},
+{
+glyphname = "ycreemoo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (116,0);
+ref = doubledot_top;
+}
+);
+width = 446;
+}
+);
+note = uni14A9;
+unicode = 5289;
+},
+{
+glyphname = "ma-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (284,357);
+},
+{
+name = top_center_can;
+pos = (237,714);
+},
+{
+name = top_left_can;
+pos = (109,714);
+},
+{
+name = top_right_can;
+pos = (365,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(412.002,0,l),
+(412,86,l),
+(155,86,l),
+(155,714,l),
+(62,714,l),
+(62,0,l)
+);
+}
+);
+width = 446;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+unicode = 5290;
+},
+{
+glyphname = "maa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (39,0);
+ref = dot_top;
+}
+);
+width = 446;
+}
+);
+note = uni14AB;
+unicode = 5291;
+},
+{
+glyphname = "mwe-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "me-canadian";
+}
+);
+width = 638;
+}
+);
+note = uni14AC;
+unicode = 5292;
+},
+{
+glyphname = "mweWestCree-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "me-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (446,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 638;
+}
+);
+note = uni14AD;
+unicode = 5293;
+},
+{
+glyphname = "mwi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "mi-canadian";
+}
+);
+width = 638;
+}
+);
+note = uni14AE;
+unicode = 5294;
+},
+{
+glyphname = "mwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (446,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 638;
+}
+);
+note = uni14AF;
+unicode = 5295;
+},
+{
+glyphname = "mwii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (359,0);
+ref = dot_top;
+}
+);
+width = 638;
+}
+);
+note = uni14B0;
+unicode = 5296;
+},
+{
+glyphname = "mwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (167,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (446,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 638;
+}
+);
+note = uni14B1;
+unicode = 5297;
+},
+{
+glyphname = "mwo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "mo-canadian";
+}
+);
+width = 638;
+}
+);
+note = uni14B2;
+unicode = 5298;
+},
+{
+glyphname = "mwoWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (446,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 638;
+}
+);
+note = uni14B3;
+unicode = 5299;
+},
+{
+glyphname = "mwoo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (459,0);
+ref = dot_top;
+}
+);
+width = 638;
+}
+);
+note = uni14B4;
+unicode = 5300;
+},
+{
+glyphname = "mwooWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (268,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (446,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 638;
+}
+);
+note = uni14B5;
+unicode = 5301;
+},
+{
+glyphname = "mwa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ma-canadian";
+}
+);
+width = 638;
+}
+);
+note = uni14B6;
+unicode = 5302;
+},
+{
+glyphname = "mwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (446,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 638;
+}
+);
+note = uni14B7;
+unicode = 5303;
+},
+{
+glyphname = "mwaa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (230,0);
+ref = dot_top;
+}
+);
+width = 638;
+}
+);
+note = uni14B8;
+unicode = 5304;
+},
+{
+glyphname = "mwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (39,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (446,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 638;
+}
+);
+note = uni14B9;
+unicode = 5305;
+},
+{
+glyphname = "mwaaNaskapi-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (202,0);
+ref = "ma-canadian";
+}
+);
+width = 648;
+}
+);
+note = uni14BA;
+unicode = 5306;
+},
+{
+glyphname = "m-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(244,418,l),
+(115,418,l),
+(115,714,l),
+(51,714,l),
+(51,357,l),
+(244,357,l)
+);
+}
+);
+width = 275;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni14BB;
+unicode = 5307;
+},
+{
+glyphname = "mWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+ref = "t-canadian";
+}
+);
+width = 303;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "t-canadian";
+note = uni14BC;
+unicode = 5308;
+},
+{
+glyphname = "mh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(224,357,l),
+(224,714,l),
+(160,714,l),
+(160,418,l),
+(31,418,l),
+(31,357,l)
+);
+}
+);
+width = 275;
+}
+);
+metricLeft = "=|m-canadian";
+metricRight = "=|m-canadian";
+note = uni14BD;
+unicode = 5309;
+},
+{
+glyphname = "mAthapascan-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(255,357,l),
+(255,413,l),
+(118,413,l),
+(120,384,l),
+(202,495,ls),
+(235,540,o),
+(245,578,o),
+(245,615,cs),
+(245,675,o),
+(213,720,o),
+(148,720,cs),
+(80,720,o),
+(44,672,o),
+(43,595,c),
+(101,595,l),
+(101,651,o),
+(116,672,o),
+(146,672,cs),
+(174,672,o),
+(187,652,o),
+(187,614,cs),
+(187,585,o),
+(184,561,o),
+(149,514,cs),
+(56,390,l),
+(56,357,l)
+);
+}
+);
+width = 295;
+}
+);
+note = uni14BE;
+unicode = 5310;
+},
+{
+glyphname = "mSayisi-canadian";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = two.canadian;
+}
+);
+width = 486;
+}
+);
+note = uni14BF;
+unicode = 5311;
+},
+{
+glyphname = "ne-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (426,254);
+},
+{
+name = top_center_can;
+pos = (415,514);
+},
+{
+name = top_left_can;
+pos = (94,514);
+},
+{
+name = top_right_can;
+pos = (580,514);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(547,-13,o),
+(625,74,o),
+(625,241,cs),
+(625,409,o),
+(548,495,o),
+(414,495,cs),
+(48,495,l),
+(48,410,l),
+(309,410,l),
+(304,433,l),
+(255,399,o),
+(229,321,o),
+(229,237,cs),
+(229,74,o),
+(304,-13,o),
+(427,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(358,67,o),
+(321,123,o),
+(321,241,cs),
+(321,354,o),
+(359,415,o),
+(427,415,cs),
+(495,415,o),
+(533,360,o),
+(533,241,cs),
+(533,123,o),
+(496,67,o),
+(427,67,cs)
+);
+}
+);
+width = 676;
+}
+);
+metricRight = "=|ke-canadian";
+note = uni14C0;
+unicode = 5312;
+},
+{
+glyphname = "naai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (143,-200);
+ref = ring_top.canadian;
+}
+);
+width = 676;
+}
+);
+note = uni14C1;
+unicode = 5313;
+},
+{
+glyphname = "ni-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (250,254);
+},
+{
+name = top_center_can;
+pos = (262,514);
+},
+{
+name = top_left_can;
+pos = (97,514);
+},
+{
+name = top_right_can;
+pos = (582,514);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(371,-13,o),
+(447,74,o),
+(447,237,cs),
+(447,321,o),
+(421,399,o),
+(372,434,c),
+(367,410,l),
+(628,410,l),
+(628,495,l),
+(262,495,ls),
+(127,495,o),
+(51,406,o),
+(51,240,cs),
+(51,74,o),
+(129,-13,o),
+(249,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(180,67,o),
+(142,123,o),
+(142,242,cs),
+(142,361,o),
+(181,416,o),
+(249,416,cs),
+(317,416,o),
+(355,355,o),
+(355,242,cs),
+(355,123,o),
+(318,67,o),
+(249,67,cs)
+);
+}
+);
+width = 676;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+unicode = 5314;
+},
+{
+glyphname = "nii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (192,-200);
+ref = dot_top;
+}
+);
+width = 676;
+}
+);
+note = uni14C3;
+unicode = 5315;
+},
+{
+glyphname = "no-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (425,254);
+},
+{
+name = top_center_can;
+pos = (424,514);
+},
+{
+name = top_double;
+pos = (427,514);
+},
+{
+name = top_left_can;
+pos = (94,514);
+},
+{
+name = top_right_can;
+pos = (580,514);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(414,0,ls),
+(548,0,o),
+(625,87,o),
+(625,254,cs),
+(625,421,o),
+(547,509,o),
+(427,509,cs),
+(304,509,o),
+(229,421,o),
+(229,258,cs),
+(229,174,o),
+(255,96,o),
+(304,62,c),
+(309,85,l),
+(48,85,l),
+(48,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(359,79,o),
+(321,140,o),
+(321,253,cs),
+(321,372,o),
+(358,428,o),
+(427,428,cs),
+(496,428,o),
+(533,373,o),
+(533,253,cs),
+(533,134,o),
+(495,79,o),
+(427,79,cs)
+);
+}
+);
+width = 676;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14C4;
+unicode = 5316;
+},
+{
+glyphname = "noo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (354,-200);
+ref = dot_top;
+}
+);
+width = 676;
+}
+);
+note = uni14C5;
+unicode = 5317;
+},
+{
+glyphname = "ycreenoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (205,-200);
+ref = doubledot_top;
+}
+);
+width = 676;
+}
+);
+note = uni14C6;
+unicode = 5318;
+},
+{
+glyphname = "na-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (250,254);
+},
+{
+name = top_center_can;
+pos = (251,514);
+},
+{
+name = top_double;
+pos = (384,514);
+},
+{
+name = top_left_can;
+pos = (97,514);
+},
+{
+name = top_right_can;
+pos = (582,514);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(628,0,l),
+(628,85,l),
+(367,85,l),
+(372,62,l),
+(421,96,o),
+(447,174,o),
+(447,258,cs),
+(447,421,o),
+(371,509,o),
+(249,509,cs),
+(129,509,o),
+(51,421,o),
+(51,254,cs),
+(51,87,o),
+(127,0,o),
+(262,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(181,79,o),
+(142,134,o),
+(142,253,cs),
+(142,373,o),
+(180,428,o),
+(249,428,cs),
+(318,428,o),
+(355,372,o),
+(355,253,cs),
+(355,140,o),
+(317,79,o),
+(249,79,cs)
+);
+}
+);
+width = 676;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+unicode = 5319;
+},
+{
+glyphname = "naa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (181,-200);
+ref = dot_top;
+}
+);
+width = 676;
+}
+);
+note = uni14C8;
+unicode = 5320;
+},
+{
+glyphname = "nwe-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ne-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni14C9;
+unicode = 5321;
+},
+{
+glyphname = "nweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (676,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni14CA;
+unicode = 5322;
+},
+{
+glyphname = "nwa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "na-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni14CB;
+unicode = 5323;
+},
+{
+glyphname = "nwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (676,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni14CC;
+unicode = 5324;
+},
+{
+glyphname = "nwaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (373,-200);
+ref = dot_top;
+}
+);
+width = 867;
+}
+);
+note = uni14CD;
+unicode = 5325;
+},
+{
+glyphname = "nwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (181,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (676,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni14CE;
+unicode = 5326;
+},
+{
+glyphname = "nwaaNaskapi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (162,-200);
+ref = doubledot_top;
+}
+);
+width = 676;
+}
+);
+note = uni14CF;
+unicode = 5327;
+},
+{
+glyphname = "n-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(356,449,l),
+(356,510,l),
+(211,510,l),
+(214,482,l),
+(240,496,o),
+(255,540,o),
+(255,588,cs),
+(255,672,o),
+(215,720,o),
+(148,720,cs),
+(82,720,o),
+(41,671,o),
+(41,585,cs),
+(41,500,o),
+(82,449,o),
+(153,449,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(117,498,o),
+(98,525,o),
+(98,585,cs),
+(98,645,o),
+(117,671,o),
+(149,671,cs),
+(180,671,o),
+(197,644,o),
+(197,585,cs),
+(197,525,o),
+(179,498,o),
+(148,498,cs)
+);
+}
+);
+width = 387;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni14D0;
+unicode = 5328;
+},
+{
+color = 6;
+glyphname = "ngCarrier-canadian";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-167);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 352;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "=|";
+note = uni14D1;
+unicode = 5329;
+},
+{
+glyphname = "nh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(234,449,ls),
+(305,449,o),
+(346,500,o),
+(346,585,cs),
+(346,671,o),
+(305,720,o),
+(239,720,cs),
+(172,720,o),
+(132,672,o),
+(132,588,cs),
+(132,540,o),
+(147,496,o),
+(173,482,c),
+(176,510,l),
+(31,510,l),
+(31,449,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(208,498,o),
+(189,525,o),
+(189,585,cs),
+(189,644,o),
+(207,671,o),
+(238,671,cs),
+(269,671,o),
+(289,645,o),
+(289,585,cs),
+(289,525,o),
+(269,498,o),
+(239,498,cs)
+);
+}
+);
+width = 387;
+}
+);
+metricLeft = "=|n-canadian";
+metricRight = "=|n-canadian";
+note = uni14D2;
+unicode = 5330;
+},
+{
+glyphname = "le-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (426,254);
+},
+{
+name = top_center_can;
+pos = (417,514);
+},
+{
+name = top_left_can;
+pos = (94,514);
+},
+{
+name = top_right_can;
+pos = (579,514);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(392,0,ls),
+(537,0,o),
+(625,86,o),
+(625,247,cs),
+(625,408,o),
+(540,495,o),
+(391,495,cs),
+(48,495,l),
+(48,410,l),
+(387,410,ls),
+(481,410,o),
+(532,355,o),
+(532,246,cs),
+(532,138,o),
+(482,83,o),
+(384,83,cs),
+(368,83,l),
+(368,0,l)
+);
+}
+);
+width = 676;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D3;
+unicode = 5331;
+},
+{
+glyphname = "laai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (143,-200);
+ref = ring_top.canadian;
+}
+);
+width = 676;
+}
+);
+note = uni14D4;
+unicode = 5332;
+},
+{
+glyphname = "li-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (250,254);
+},
+{
+name = top_center_can;
+pos = (262,514);
+},
+{
+name = top_left_can;
+pos = (97,514);
+},
+{
+name = top_right_can;
+pos = (582,514);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(307,0,l),
+(307,83,l),
+(291,83,ls),
+(194,83,o),
+(143,138,o),
+(143,246,cs),
+(143,354,o),
+(194,410,o),
+(289,410,cs),
+(628,410,l),
+(628,495,l),
+(285,495,ls),
+(140,495,o),
+(51,408,o),
+(51,247,cs),
+(51,86,o),
+(138,0,o),
+(284,0,cs)
+);
+}
+);
+width = 676;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14D5;
+unicode = 5333;
+},
+{
+glyphname = "lii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (192,-200);
+ref = dot_top;
+}
+);
+width = 676;
+}
+);
+note = uni14D6;
+unicode = 5334;
+},
+{
+glyphname = "lo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (425,254);
+},
+{
+name = top_center_can;
+pos = (424,514);
+},
+{
+name = top_double;
+pos = (392,514);
+},
+{
+name = top_left_can;
+pos = (94,514);
+},
+{
+name = top_right_can;
+pos = (579,514);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(391,0,ls),
+(536,0,o),
+(625,87,o),
+(625,248,cs),
+(625,409,o),
+(537,495,o),
+(392,495,cs),
+(368,495,l),
+(368,412,l),
+(384,412,ls),
+(482,412,o),
+(532,357,o),
+(532,249,cs),
+(532,140,o),
+(481,85,o),
+(387,85,cs),
+(48,85,l),
+(48,0,l)
+);
+}
+);
+width = 676;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D7;
+unicode = 5335;
+},
+{
+glyphname = "loo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (354,-200);
+ref = dot_top;
+}
+);
+width = 676;
+}
+);
+note = uni14D8;
+unicode = 5336;
+},
+{
+glyphname = "ycreeloo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (170,-200);
+ref = doubledot_top;
+}
+);
+width = 676;
+}
+);
+note = uni14D9;
+unicode = 5337;
+},
+{
+glyphname = "la-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (250,254);
+},
+{
+name = top_center_can;
+pos = (251,514);
+},
+{
+name = top_left_can;
+pos = (97,514);
+},
+{
+name = top_right_can;
+pos = (582,514);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(628,0,l),
+(628,85,l),
+(289,85,ls),
+(194,85,o),
+(143,140,o),
+(143,249,cs),
+(143,357,o),
+(194,412,o),
+(291,412,cs),
+(307,412,l),
+(307,495,l),
+(284,495,ls),
+(138,495,o),
+(51,408,o),
+(51,248,cs),
+(51,87,o),
+(139.992,0,o),
+(285,0,cs)
+);
+}
+);
+width = 676;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14DA;
+unicode = 5338;
+},
+{
+glyphname = "laa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (181,-200);
+ref = dot_top;
+}
+);
+width = 676;
+}
+);
+note = uni14DB;
+unicode = 5339;
+},
+{
+glyphname = "lwe-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "le-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni14DC;
+unicode = 5340;
+},
+{
+glyphname = "lweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "le-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (676,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni14DD;
+unicode = 5341;
+},
+{
+glyphname = "lwi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "li-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni14DE;
+unicode = 5342;
+},
+{
+glyphname = "lwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (676,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni14DF;
+unicode = 5343;
+},
+{
+glyphname = "lwii-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (384,-200);
+ref = dot_top;
+}
+);
+width = 867;
+}
+);
+note = uni14E0;
+unicode = 5344;
+},
+{
+glyphname = "lwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (192,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (676,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni14E1;
+unicode = 5345;
+},
+{
+glyphname = "lwo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "lo-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni14E2;
+unicode = 5346;
+},
+{
+glyphname = "lwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (676,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni14E3;
+unicode = 5347;
+},
+{
+glyphname = "lwoo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (545,-200);
+ref = dot_top;
+}
+);
+width = 867;
+}
+);
+note = uni14E4;
+unicode = 5348;
+},
+{
+glyphname = "lwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (354,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (676,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni14E5;
+unicode = 5349;
+},
+{
+glyphname = "lwa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "la-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni14E6;
+unicode = 5350;
+},
+{
+glyphname = "lwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (676,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni14E7;
+unicode = 5351;
+},
+{
+glyphname = "lwaa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (373,-200);
+ref = dot_top;
+}
+);
+width = 867;
+}
+);
+note = uni14E8;
+unicode = 5352;
+},
+{
+glyphname = "lwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (181,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (676,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni14E9;
+unicode = 5353;
+},
+{
+glyphname = "l-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(351,357,l),
+(351,418,l),
+(221,418,ls),
+(148,418,o),
+(113,458,o),
+(113,535,cs),
+(113,611,o),
+(148,653,o),
+(213,653,cs),
+(219,653,l),
+(219,714,l),
+(209,714,ls),
+(107,714,o),
+(49,646,o),
+(49,535,cs),
+(49,424,o),
+(107,357,o),
+(215,357,cs)
+);
+}
+);
+width = 382;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "m-canadian";
+note = uni14EA;
+unicode = 5354;
+},
+{
+glyphname = "lWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(249,357,l),
+(249,401,l),
+(95,478,l),
+(95,446,l),
+(249,520,l),
+(249,551,l),
+(95,626,l),
+(95,593,l),
+(249,669,l),
+(249,714,l),
+(238,714,l),
+(51,622,l),
+(51,597,l),
+(206,523,l),
+(206,547,l),
+(51,474,l),
+(51,449,l),
+(238,357,l)
+);
+}
+);
+width = 300;
+}
+);
+metricRight = "=|";
+note = uni14EB;
+unicode = 5355;
+},
+{
+glyphname = "mediall-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(471,-13,l),
+(471,57,l),
+(138,220,l),
+(138,179,l),
+(471,336,l),
+(471,378,l),
+(138,535,l),
+(138,494,l),
+(471,657,l),
+(471,727,l),
+(447,727,l),
+(57,536,l),
+(57,497,l),
+(391,340,l),
+(391,374,l),
+(57,217,l),
+(57,178,l),
+(447,-13,l)
+);
+}
+);
+width = 528;
+}
+);
+metricRight = "=|";
+note = uni14EC;
+unicode = 5356;
+},
+{
+glyphname = "se-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (107,714);
+},
+{
+name = top_right_can;
+pos = (345,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(392,0,l),
+(392,343,l),
+(355,343,ls),
+(220,343,o),
+(154,403,o),
+(154,572,cs),
+(154,714,l),
+(60,714,l),
+(60,566,ls),
+(60,358,o),
+(158,258,o),
+(338,258,cs),
+(369,258,l),
+(299,290,l),
+(299,0,l)
+);
+}
+);
+width = 454;
+}
+);
+note = uni14ED;
+unicode = 5357;
+},
+{
+glyphname = "saai-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (228,0);
+ref = ring_top.canadian;
+}
+);
+width = 454;
+}
+);
+note = uni14EE;
+unicode = 5358;
+},
+{
+glyphname = "si-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (109,714);
+},
+{
+name = top_right_can;
+pos = (348,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(156,0,l),
+(156,290,l),
+(86,258,l),
+(116,258,ls),
+(297,258,o),
+(394,358,o),
+(394,566,cs),
+(394,714,l),
+(300,714,l),
+(300,572,ls),
+(300,403,o),
+(234,343,o),
+(99,343,cs),
+(62,343,l),
+(62,0,l)
+);
+}
+);
+width = 454;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+unicode = 5359;
+},
+{
+glyphname = "sii-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (278,0);
+ref = dot_top;
+}
+);
+width = 454;
+}
+);
+note = uni14F0;
+unicode = 5360;
+},
+{
+glyphname = "so-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (346,714);
+},
+{
+name = top_left_can;
+pos = (108,714);
+},
+{
+name = top_right_can;
+pos = (345,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(154,0,l),
+(154,142,ls),
+(154,311,o),
+(220,371,o),
+(355,371,cs),
+(392,371,l),
+(392,714,l),
+(299,714,l),
+(299,424,l),
+(369,456,l),
+(338,456,ls),
+(158,456,o),
+(60,356,o),
+(60,148,cs),
+(60,0,l)
+);
+}
+);
+width = 454;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+unicode = 5361;
+},
+{
+glyphname = "soo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (275,0);
+ref = dot_top;
+}
+);
+width = 454;
+}
+);
+note = uni14F2;
+unicode = 5362;
+},
+{
+glyphname = "ycreesoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (124,0);
+ref = doubledot_top;
+}
+);
+width = 454;
+}
+);
+note = uni14F3;
+unicode = 5363;
+},
+{
+glyphname = "sa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (109,714);
+},
+{
+name = top_right_can;
+pos = (348,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(394,0,l),
+(394,148,ls),
+(394,356,o),
+(297,456,o),
+(116,456,cs),
+(86,456,l),
+(156,424,l),
+(156,714,l),
+(62,714,l),
+(62,371,l),
+(99,371,ls),
+(234,371,o),
+(300,311,o),
+(300,142,cs),
+(300,0,l)
+);
+}
+);
+width = 454;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+unicode = 5364;
+},
+{
+glyphname = "saa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (39,0);
+ref = dot_top;
+}
+);
+width = 454;
+}
+);
+note = uni14F5;
+unicode = 5365;
+},
+{
+glyphname = "swe-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "se-canadian";
+}
+);
+width = 646;
+}
+);
+note = uni14F6;
+unicode = 5366;
+},
+{
+glyphname = "sweWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "se-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (454,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 646;
+}
+);
+note = uni14F7;
+unicode = 5367;
+},
+{
+glyphname = "swi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "si-canadian";
+}
+);
+width = 646;
+}
+);
+note = uni14F8;
+unicode = 5368;
+},
+{
+glyphname = "swiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (454,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 646;
+}
+);
+note = uni14F9;
+unicode = 5369;
+},
+{
+glyphname = "swii-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (469,0);
+ref = dot_top;
+}
+);
+width = 646;
+}
+);
+note = uni14FA;
+unicode = 5370;
+},
+{
+glyphname = "swiiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (278,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (454,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 646;
+}
+);
+note = uni14FB;
+unicode = 5371;
+},
+{
+glyphname = "swo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "so-canadian";
+}
+);
+width = 646;
+}
+);
+note = uni14FC;
+unicode = 5372;
+},
+{
+glyphname = "swoWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (454,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 646;
+}
+);
+note = uni14FD;
+unicode = 5373;
+},
+{
+glyphname = "swoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (467,0);
+ref = dot_top;
+}
+);
+width = 646;
+}
+);
+note = uni14FE;
+unicode = 5374;
+},
+{
+glyphname = "swooWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (275,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (454,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 646;
+}
+);
+note = uni14FF;
+unicode = 5375;
+},
+{
+glyphname = "swa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "sa-canadian";
+}
+);
+width = 646;
+}
+);
+note = uni1500;
+unicode = 5376;
+},
+{
+glyphname = "swaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (454,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 646;
+}
+);
+note = uni1501;
+unicode = 5377;
+},
+{
+glyphname = "swaa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (231,0);
+ref = dot_top;
+}
+);
+width = 646;
+}
+);
+note = uni1502;
+unicode = 5378;
+},
+{
+glyphname = "swaaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (39,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (454,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 646;
+}
+);
+note = uni1503;
+unicode = 5379;
+},
+{
+glyphname = "swaaNaskapi-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (202,0);
+ref = "sa-canadian";
+}
+);
+width = 656;
+}
+);
+note = uni1504;
+unicode = 5380;
+},
+{
+glyphname = "s-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(244,357,l),
+(244,436,ls),
+(244,540,o),
+(192,595,o),
+(105,595,cs),
+(75,595,l),
+(115,568,l),
+(115,714,l),
+(51,714,l),
+(51,543,l),
+(83,543,ls),
+(150,543,o),
+(180,509,o),
+(180,433,cs),
+(180,357,l)
+);
+}
+);
+width = 295;
+}
+);
+metricRight = "=|";
+note = uni1505;
+unicode = 5381;
+},
+{
+color = 6;
+glyphname = "sAthapascan-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(232,183,o),
+(272,226,o),
+(272,282,cs),
+(272,327,o),
+(251,358,o),
+(203,379,cs),
+(153,400,ls),
+(123,414,o),
+(114,429,o),
+(114,454,cs),
+(114,484,o),
+(131,503,o),
+(163,503,cs),
+(195,503,o),
+(215,488,o),
+(214,440,c),
+(272,440,l),
+(273,510,o),
+(234,552,o),
+(163.003,552,cs),
+(97,552,o),
+(56,510,o),
+(56,453,cs),
+(56,407,o),
+(77,375,o),
+(122,356,cs),
+(172,334,ls),
+(201,321,o),
+(213,306,o),
+(213,279,cs),
+(213,248,o),
+(194,232,o),
+(163,232,cs),
+(129,232,o),
+(109,248,o),
+(110,297,c),
+(51,297,l),
+(50,223,o),
+(91,183,o),
+(162,183,cs)
+);
+}
+);
+width = 323;
+}
+);
+metricRight = "=|";
+note = uni1506;
+unicode = 5382;
+},
+{
+glyphname = "sw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(115,357,l),
+(115,433,ls),
+(115,509,o),
+(145,543,o),
+(212,543,cs),
+(244,543,l),
+(244,714,l),
+(180,714,l),
+(180,568,l),
+(220,595,l),
+(190,595,ls),
+(103,595,o),
+(51,540,o),
+(51,436,cs),
+(51,357,l)
+);
+}
+);
+width = 295;
+}
+);
+metricLeft = "=|s-canadian";
+metricRight = "=|s-canadian";
+note = uni1507;
+unicode = 5383;
+},
+{
+glyphname = "sBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(251,357,l),
+(251,418,l),
+(186,418,ls),
+(133,418,o),
+(115,440,o),
+(115,496,cs),
+(115,714,l),
+(51,714,l),
+(51,487,ls),
+(51,402,o),
+(92,357,o),
+(177,357,c)
+);
+}
+);
+width = 282;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "m-canadian";
+note = uni1508;
+unicode = 5384;
+},
+{
+glyphname = "moosecreesk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(222,225,o),
+(268,271,o),
+(268,380,cs),
+(268,525,o),
+(213,596,o),
+(100,596,cs),
+(84,596,l),
+(115,568,l),
+(115,714,l),
+(51,714,l),
+(51,544,l),
+(83,544,ls),
+(171,544,o),
+(196,506,o),
+(203,431,c),
+(220,424,l),
+(214,463,o),
+(187,494,o),
+(151,494,cs),
+(92,494,o),
+(52,445,o),
+(52,362,cs),
+(52,270,o),
+(101,225,o),
+(159,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(130,273,o),
+(109,300,o),
+(109,361,cs),
+(109,422,o),
+(130,448,o),
+(159,448,cs),
+(188,448,o),
+(209,421,o),
+(209,361,cs),
+(209,298,o),
+(190,273,o),
+(159,273,cs)
+);
+}
+);
+width = 319;
+}
+);
+metricRight = "=|";
+note = uni1509;
+unicode = 5385;
+},
+{
+glyphname = "skwNaskapi-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(218,225,o),
+(267,270,o),
+(267,362,cs),
+(267,445,o),
+(226,494,o),
+(168,494,cs),
+(132,494,o),
+(105,463,o),
+(98,424,c),
+(116,431,l),
+(122,506,o),
+(147,544,o),
+(236,544,cs),
+(268,544,l),
+(268,714,l),
+(204,714,l),
+(204,568,l),
+(234,596,l),
+(218,596,ls),
+(106,596,o),
+(51,525,o),
+(51,380,cs),
+(51,271,o),
+(96,225,o),
+(159,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(128,273,o),
+(109,298,o),
+(109,361,cs),
+(109,421,o),
+(130,448,o),
+(159,448,cs),
+(188,448,o),
+(210,422,o),
+(210,361,cs),
+(210,300,o),
+(189,273,o),
+(159,273,cs)
+);
+}
+);
+width = 319;
+}
+);
+metricLeft = "=|moosecreesk-canadian";
+metricRight = "=|moosecreesk-canadian";
+note = uni150A;
+unicode = 5386;
+},
+{
+glyphname = "swNaskapi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(263,188,l),
+(263,257,ls),
+(263,358,o),
+(211,416,o),
+(124,416,cs),
+(94,416,l),
+(128,389,l),
+(128,527,l),
+(65,527,l),
+(65,365,l),
+(106,365,ls),
+(169,365,o),
+(199,330,o),
+(199,254,cs),
+(199,188,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(260,47,o),
+(283,70,o),
+(283,99,cs),
+(283,129,o),
+(259,152,o),
+(231,152,cs),
+(203,152,o),
+(179,129,o),
+(179,99,cs),
+(179,70,o),
+(202,47,o),
+(231,47,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(124,562,o),
+(148,585,o),
+(148,615,cs),
+(148,644,o),
+(125,668,o),
+(96,668,cs),
+(68,668,o),
+(44,644,o),
+(44,615,cs),
+(44,585,o),
+(68,562,o),
+(96,562,cs)
+);
+}
+);
+width = 327;
+}
+);
+metricRight = "=|";
+note = uni150B;
+unicode = 5387;
+},
+{
+glyphname = "spwaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(503,0,l),
+(503,86,l),
+(120,378,l),
+(120,335,l),
+(503,627,l),
+(503,714,l),
+(479,714,l),
+(30,374,l),
+(30,340,l),
+(479,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(141,515,o),
+(165,538,o),
+(165,567,cs),
+(165,597,o),
+(141,620,o),
+(113,620,cs),
+(85,620,o),
+(61,597,o),
+(61,567,cs),
+(61,538,o),
+(85,515,o),
+(113,515,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(297,625,l),
+(297,683,ls),
+(297,755,o),
+(262,797,o),
+(191,797,cs),
+(166,797,l),
+(211,773,l),
+(211,876,l),
+(150,876,l),
+(150,748,l),
+(174,748,ls),
+(214,748,o),
+(236,728,o),
+(236,677,cs),
+(236,625,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(429,729,o),
+(453,753,o),
+(453,782,cs),
+(453,811,o),
+(429,834,o),
+(401,834,cs),
+(373,834,o),
+(350,811,o),
+(350,782,cs),
+(350,753,o),
+(373,729,o),
+(401,729,cs)
+);
+}
+);
+width = 545;
+}
+);
+metricRight = "pa-canadian";
+metricWidth = "pa-canadian";
+note = uni150C;
+unicode = 5388;
+},
+{
+glyphname = "stwaNaskapi-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (327,0);
+ref = "ta-canadian";
+}
+);
+width = 831;
+}
+);
+note = uni150D;
+unicode = 5389;
+},
+{
+glyphname = "skwaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (327,0);
+ref = "ka-canadian";
+}
+);
+width = 825;
+}
+);
+note = uni150E;
+unicode = 5390;
+},
+{
+glyphname = "scwaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (327,0);
+ref = "ca-canadian";
+}
+);
+width = 819;
+}
+);
+note = uni150F;
+unicode = 5391;
+},
+{
+glyphname = "she-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (241,714);
+},
+{
+name = top_right_can;
+pos = (581,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(635,-13,o),
+(706,70,o),
+(706,235,cs),
+(706,313,l),
+(613,313,l),
+(613,220,ls),
+(613,117,o),
+(581,69,o),
+(524,69,cs),
+(463,69,o),
+(436,116,o),
+(430,226,cs),
+(419,488,ls),
+(412,643,o),
+(360,727,o),
+(238,727,cs),
+(123,727,o),
+(52,644,o),
+(52,479,cs),
+(52,401,l),
+(144,401,l),
+(144,495,ls),
+(144,597,o),
+(177,645,o),
+(234,645,cs),
+(295,645,o),
+(322,598,o),
+(327,488,cs),
+(339,226,ls),
+(346,71,o),
+(398,-13,o),
+(520,-13,cs)
+);
+}
+);
+width = 758;
+}
+);
+metricRight = "=|";
+note = uni1510;
+unicode = 5392;
+},
+{
+glyphname = "shi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (179,714);
+},
+{
+name = top_right_can;
+pos = (518,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(360,-13,o),
+(412,71,o),
+(419,226,cs),
+(430,488,ls),
+(436,598,o),
+(463,645,o),
+(524,645,cs),
+(581,645,o),
+(613,597,o),
+(613,495,cs),
+(613,401,l),
+(706,401,l),
+(706,479,ls),
+(706,644,o),
+(635,727,o),
+(519,727,cs),
+(398,727,o),
+(346,643,o),
+(339,488,cs),
+(327,226,ls),
+(322,116,o),
+(295,69,o),
+(234,69,cs),
+(177,69,o),
+(144,117,o),
+(144,220,cs),
+(144,313,l),
+(52,313,l),
+(52,235,ls),
+(52,70,o),
+(122,-13,o),
+(238,-13,cs)
+);
+}
+);
+width = 758;
+}
+);
+metricLeft = "she-canadian";
+metricRight = "she-canadian";
+note = uni1511;
+unicode = 5393;
+},
+{
+glyphname = "shii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (448,0);
+ref = dot_top;
+}
+);
+width = 758;
+}
+);
+note = uni1512;
+unicode = 5394;
+},
+{
+glyphname = "sho-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (387,514);
+},
+{
+name = top_left_can;
+pos = (240,514);
+},
+{
+name = top_right_can;
+pos = (535,514);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(305,69,l),
+(198,67,o),
+(143,109,o),
+(143,187,cs),
+(143,247,o),
+(173,285,o),
+(230,285,cs),
+(329,285,o),
+(420,126,o),
+(558,126,cs),
+(661,126,o),
+(724,199,o),
+(724,305,cs),
+(724,434,o),
+(630,511,o),
+(473,509,c),
+(470,427,l),
+(577,428,o),
+(632,386,o),
+(632,308,cs),
+(632,248,o),
+(601,210,o),
+(544,210,cs),
+(446,210,o),
+(355,370,o),
+(217,370,cs),
+(114,370,o),
+(51,297,o),
+(51,190,cs),
+(51,62,o),
+(144,-15,o),
+(302,-13,c)
+);
+}
+);
+width = 775;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1513;
+unicode = 5395;
+},
+{
+glyphname = "shoo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (317,-200);
+ref = dot_top;
+}
+);
+width = 775;
+}
+);
+note = uni1514;
+unicode = 5396;
+},
+{
+glyphname = "sha-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (388,514);
+},
+{
+name = top_left_can;
+pos = (239,514);
+},
+{
+name = top_right_can;
+pos = (535,514);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(630,-15,o),
+(724,62,o),
+(724,190,cs),
+(724,297,o),
+(661,370,o),
+(558,370,cs),
+(420,370,o),
+(329,210,o),
+(230,210,cs),
+(173,210,o),
+(143,248,o),
+(143,308,cs),
+(143,386,o),
+(198,428,o),
+(305,427,c),
+(302,509,l),
+(144,511,o),
+(51,434,o),
+(51,305,cs),
+(51,199,o),
+(113,126,o),
+(217,126,cs),
+(355,126,o),
+(446,285,o),
+(544,285,cs),
+(601,285,o),
+(632,247,o),
+(632,187,cs),
+(632,109,o),
+(577,67,o),
+(470,69,c),
+(473,-13,l)
+);
+}
+);
+width = 775;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1515;
+unicode = 5397;
+},
+{
+glyphname = "shaa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (318,-200);
+ref = dot_top;
+}
+);
+width = 775;
+}
+);
+note = uni1516;
+unicode = 5398;
+},
+{
+glyphname = "shwe-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "she-canadian";
+}
+);
+width = 949;
+}
+);
+note = uni1517;
+unicode = 5399;
+},
+{
+glyphname = "shweWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "she-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (758,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 949;
+}
+);
+note = uni1518;
+unicode = 5400;
+},
+{
+glyphname = "shwi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "shi-canadian";
+}
+);
+width = 949;
+}
+);
+note = uni1519;
+unicode = 5401;
+},
+{
+glyphname = "shwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (758,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 949;
+}
+);
+note = uni151A;
+unicode = 5402;
+},
+{
+glyphname = "shwii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (640,0);
+ref = dot_top;
+}
+);
+width = 949;
+}
+);
+note = uni151B;
+unicode = 5403;
+},
+{
+glyphname = "shwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (448,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (758,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 949;
+}
+);
+note = uni151C;
+unicode = 5404;
+},
+{
+glyphname = "shwo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "sho-canadian";
+}
+);
+width = 966;
+}
+);
+note = uni151D;
+unicode = 5405;
+},
+{
+glyphname = "shwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (775,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 966;
+}
+);
+note = uni151E;
+unicode = 5406;
+},
+{
+glyphname = "shwoo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (509,-200);
+ref = dot_top;
+}
+);
+width = 966;
+}
+);
+note = uni151F;
+unicode = 5407;
+},
+{
+glyphname = "shwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (317,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (775,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 966;
+}
+);
+note = uni1520;
+unicode = 5408;
+},
+{
+glyphname = "shwa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "sha-canadian";
+}
+);
+width = 966;
+}
+);
+note = uni1521;
+unicode = 5409;
+},
+{
+glyphname = "shwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (775,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 966;
+}
+);
+note = uni1522;
+unicode = 5410;
+},
+{
+glyphname = "shwaa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (509,-200);
+ref = dot_top;
+}
+);
+width = 966;
+}
+);
+note = uni1523;
+unicode = 5411;
+},
+{
+glyphname = "shwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (318,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (775,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 966;
+}
+);
+note = uni1524;
+unicode = 5412;
+},
+{
+glyphname = "sh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(469,299,o),
+(543,356,o),
+(543,453,cs),
+(543,538,o),
+(491,592,o),
+(414,592,cs),
+(317,592,o),
+(255,493,o),
+(184,493,cs),
+(139,493,o),
+(114,519,o),
+(114,569,cs),
+(114,626,o),
+(159,662,o),
+(244,662,c),
+(242,722,l),
+(123,722,o),
+(49,665,o),
+(49,568,cs),
+(49,483,o),
+(101,429,o),
+(178,429,cs),
+(275,429,o),
+(336,528,o),
+(408,528,cs),
+(452,528,o),
+(478,502,o),
+(478,452,cs),
+(478,395,o),
+(432,359,o),
+(348,359,c),
+(350,299,l)
+);
+}
+);
+width = 592;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni1525;
+unicode = 5413;
+},
+{
+glyphname = "ye-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (521,357);
+},
+{
+name = top_left_can;
+pos = (83,714);
+},
+{
+name = top_right_can;
+pos = (373,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(419,0,l),
+(419,334,l),
+(152,334,l),
+(158,304,l),
+(438,674,l),
+(371,726,l),
+(37,282,l),
+(37,251,l),
+(326,251,l),
+(326,0,l)
+);
+}
+);
+width = 479;
+}
+);
+note = uni1526;
+unicode = 5414;
+},
+{
+glyphname = "yaai-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-13,0);
+ref = ring_top.canadian;
+}
+);
+width = 479;
+}
+);
+note = uni1527;
+unicode = 5415;
+},
+{
+glyphname = "yi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (107,714);
+},
+{
+name = top_right_can;
+pos = (396,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(153,0,l),
+(153,251,l),
+(442,251,l),
+(442,282,l),
+(108,726,l),
+(41,674,l),
+(321,305,l),
+(327,334,l),
+(59,334,l),
+(59,0,l)
+);
+}
+);
+width = 479;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni1528;
+unicode = 5416;
+},
+{
+glyphname = "yii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (37,0);
+ref = dot_top;
+}
+);
+width = 479;
+}
+);
+note = uni1529;
+unicode = 5417;
+},
+{
+glyphname = "yo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (521,357);
+},
+{
+name = top_double;
+pos = (373,714);
+},
+{
+name = top_left_can;
+pos = (83,714);
+},
+{
+name = top_right_can;
+pos = (373,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(438,40,l),
+(157,409,l),
+(152,380,l),
+(419,380,l),
+(419,714,l),
+(326,714,l),
+(326,463,l),
+(37,463,l),
+(37,432,l),
+(371,-12,l)
+);
+}
+);
+width = 479;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152A;
+unicode = 5418;
+},
+{
+glyphname = "yoo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (303,0);
+ref = dot_top;
+}
+);
+width = 479;
+}
+);
+note = uni152B;
+unicode = 5419;
+},
+{
+glyphname = "ycreeyoo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (151,0);
+ref = doubledot_top;
+}
+);
+width = 479;
+}
+);
+note = uni152C;
+unicode = 5420;
+},
+{
+glyphname = "ya-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (107,714);
+},
+{
+name = top_right_can;
+pos = (396,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(442,432,l),
+(442,463,l),
+(153,463,l),
+(153,714,l),
+(59,714,l),
+(59,380,l),
+(327,380,l),
+(321,410,l),
+(41,40,l),
+(108,-12,l)
+);
+}
+);
+width = 479;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152D;
+unicode = 5421;
+},
+{
+glyphname = "yaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (37,0);
+ref = dot_top;
+}
+);
+width = 479;
+}
+);
+note = uni152E;
+unicode = 5422;
+},
+{
+glyphname = "ywe-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ye-canadian";
+}
+);
+width = 670;
+}
+);
+note = uni152F;
+unicode = 5423;
+},
+{
+glyphname = "yweWestCree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ye-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (479,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 670;
+}
+);
+note = uni1530;
+unicode = 5424;
+},
+{
+glyphname = "ywi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "yi-canadian";
+}
+);
+width = 670;
+}
+);
+note = uni1531;
+unicode = 5425;
+},
+{
+glyphname = "ywiWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (479,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 670;
+}
+);
+note = uni1532;
+unicode = 5426;
+},
+{
+glyphname = "ywii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (228,0);
+ref = dot_top;
+}
+);
+width = 670;
+}
+);
+note = uni1533;
+unicode = 5427;
+},
+{
+glyphname = "ywiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (37,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (479,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 670;
+}
+);
+note = uni1534;
+unicode = 5428;
+},
+{
+glyphname = "ywo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "yo-canadian";
+}
+);
+width = 670;
+}
+);
+note = uni1535;
+unicode = 5429;
+},
+{
+glyphname = "ywoWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (479,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 670;
+}
+);
+note = uni1536;
+unicode = 5430;
+},
+{
+glyphname = "ywoo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (495,0);
+ref = dot_top;
+}
+);
+width = 670;
+}
+);
+note = uni1537;
+unicode = 5431;
+},
+{
+glyphname = "ywooWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (303,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (479,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 670;
+}
+);
+note = uni1538;
+unicode = 5432;
+},
+{
+glyphname = "ywa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ya-canadian";
+}
+);
+width = 670;
+}
+);
+note = uni1539;
+unicode = 5433;
+},
+{
+glyphname = "ywaWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (479,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 670;
+}
+);
+note = uni153A;
+unicode = 5434;
+},
+{
+glyphname = "ywaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (228,0);
+ref = dot_top;
+}
+);
+width = 670;
+}
+);
+note = uni153B;
+unicode = 5435;
+},
+{
+glyphname = "ywaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (37,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (479,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 670;
+}
+);
+note = uni153C;
+unicode = 5436;
+},
+{
+glyphname = "ywaaNaskapi-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (202,0);
+ref = "ya-canadian";
+}
+);
+width = 680;
+}
+);
+note = uni153D;
+unicode = 5437;
+},
+{
+glyphname = "y-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(259,568,l),
+(259,588,l),
+(119,588,l),
+(119,714,l),
+(55,714,l),
+(55,534,l),
+(193,534,l),
+(192,572,l),
+(51,381,l),
+(98,349,l)
+);
+}
+);
+width = 286;
+}
+);
+note = uni153E;
+unicode = 5438;
+},
+{
+glyphname = "biblecreey-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(153,644,l),
+(120,644,l),
+(198,357,l),
+(235,357,l),
+(314,644,l),
+(281,644,l),
+(335,357,l),
+(392,357,l),
+(392,374,l),
+(326,714,l),
+(279,714,l),
+(197,419,l),
+(236,419,l),
+(154,714,l),
+(107,714,l),
+(41,374,l),
+(41,357,l),
+(98,357,l)
+);
+}
+);
+width = 433;
+}
+);
+metricRight = "=|";
+note = uni153F;
+unicode = 5439;
+},
+{
+glyphname = "yWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(216,209,l),
+(216,330,l),
+(320,330,l),
+(320,391,l),
+(216,391,l),
+(216,510,l),
+(156,510,l),
+(156,391,l),
+(51,391,l),
+(51,330,l),
+(156,330,l),
+(156,209,l)
+);
+}
+);
+width = 371;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1540;
+unicode = 5440;
+},
+{
+glyphname = "yiSayisi-canadian";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,189);
+ref = "fullstop-canadian";
+}
+);
+width = 311;
+}
+);
+metricLeft = "fullstop-canadian";
+metricWidth = "fullstop-canadian";
+note = uni1541;
+unicode = 5441;
+},
+{
+glyphname = "re-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (254,514);
+},
+{
+name = top_left_can;
+pos = (107,514);
+},
+{
+name = top_right_can;
+pos = (617,514);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(379,-13,o),
+(446,76,o),
+(446,226,cs),
+(446,410,l),
+(664,410,l),
+(664,495,l),
+(355,495,l),
+(355,213,ls),
+(355,117,o),
+(320,69,o),
+(254,69,cs),
+(187,69,o),
+(153,118,o),
+(153,212,cs),
+(153,495,l),
+(60,495,l),
+(60,227,ls),
+(60,71,o),
+(131,-13,o),
+(254,-13,cs)
+);
+}
+);
+width = 712;
+}
+);
+metricRight = "=|ne-canadian";
+note = uni1542;
+unicode = 5442;
+},
+{
+glyphname = "reRCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (457,514);
+},
+{
+name = top_left_can;
+pos = (94,514);
+},
+{
+name = top_right_can;
+pos = (605,514);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(580,-13,o),
+(652,71,o),
+(652,227,cs),
+(652,495,l),
+(558,495,l),
+(558,212,ls),
+(558,118,o),
+(524,69,o),
+(457,69,cs),
+(391,69,o),
+(356,117,o),
+(356,212,cs),
+(356,495,l),
+(48,495,l),
+(48,410,l),
+(265,410,l),
+(265,226,ls),
+(265,76,o),
+(332,-13,o),
+(457,-13,cs)
+);
+}
+);
+width = 712;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1543;
+unicode = 5443;
+},
+{
+glyphname = "leWestCree-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (457,514);
+},
+{
+name = top_left_can;
+pos = (94,514);
+},
+{
+name = top_right_can;
+pos = (605,514);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(356,0,l),
+(356,282,ls),
+(356,378,o),
+(391,426,o),
+(457,426,cs),
+(524,426,o),
+(558,377,o),
+(558,283,cs),
+(558,0,l),
+(652,0,l),
+(652,269,ls),
+(652,424,o),
+(581,509,o),
+(457,509,cs),
+(332,509,o),
+(265,419,o),
+(265,269,cs),
+(265,85,l),
+(48,85,l),
+(48,0,l)
+);
+}
+);
+width = 712;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+unicode = 5444;
+},
+{
+glyphname = "raai-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (135,-200);
+ref = ring_top.canadian;
+}
+);
+width = 711;
+}
+);
+note = uni1545;
+unicode = 5445;
+},
+{
+glyphname = "ri-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (254,514);
+},
+{
+name = top_left_can;
+pos = (107,514);
+},
+{
+name = top_right_can;
+pos = (617,514);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(153,0,l),
+(153,283,ls),
+(153,377,o),
+(187,426,o),
+(254,426,cs),
+(320,426,o),
+(355,379,o),
+(355,283,cs),
+(355,0,l),
+(664,0,l),
+(664,85,l),
+(446,85,l),
+(446,269,ls),
+(446,419,o),
+(379,509,o),
+(254,509,cs),
+(131,509,o),
+(60,424,o),
+(60,269,cs),
+(60,0,l)
+);
+}
+);
+width = 712;
+}
+);
+metricLeft = "re-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+unicode = 5446;
+},
+{
+glyphname = "rii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (184,-200);
+ref = dot_top;
+}
+);
+width = 711;
+}
+);
+note = uni1547;
+unicode = 5447;
+},
+{
+glyphname = "ro-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (200,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(155,0,l),
+(155,279,l),
+(132,252,l),
+(194,252,ls),
+(326,252,o),
+(410,344,o),
+(410,481,cs),
+(410,624,o),
+(331,714,o),
+(181,714,cs),
+(62,714,l),
+(62,630,l),
+(171,630,ls),
+(269,630,o),
+(316,573,o),
+(316,482,cs),
+(316,391,o),
+(268,334,o),
+(172,334,cs),
+(62,334,l),
+(62,0,l)
+);
+}
+);
+width = 456;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1548;
+unicode = 5448;
+},
+{
+glyphname = "roo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (130,0);
+ref = dot_top;
+}
+);
+width = 456;
+}
+);
+note = uni1549;
+unicode = 5449;
+},
+{
+glyphname = "loWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (212,714);
+},
+{
+name = top_left_can;
+pos = (109,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(181,0,ls),
+(331,0,o),
+(410,90,o),
+(410,233,cs),
+(410,371,o),
+(326,462,o),
+(194,462,cs),
+(132,462,l),
+(155,435,l),
+(155,714,l),
+(62,714,l),
+(62,380,l),
+(172,380,ls),
+(268,380,o),
+(316,323,o),
+(316,232,cs),
+(316,141,o),
+(269,85,o),
+(171,85,cs),
+(62,85,l),
+(62,0,l)
+);
+}
+);
+width = 456;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+unicode = 5450;
+},
+{
+glyphname = "ra-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (256,714);
+},
+{
+name = top_right_can;
+pos = (348,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(394,0,l),
+(394,334,l),
+(284,334,ls),
+(188,334,o),
+(140,391,o),
+(140,482,cs),
+(140,573,o),
+(187,630,o),
+(285,630,cs),
+(394,630,l),
+(394,714,l),
+(275,714,ls),
+(125,714,o),
+(46,624,o),
+(46,481,cs),
+(46,344,o),
+(130,252,o),
+(262,252,cs),
+(324,252,l),
+(301,279,l),
+(301,0,l)
+);
+}
+);
+width = 456;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+unicode = 5451;
+},
+{
+glyphname = "raa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (186,0);
+ref = dot_top;
+}
+);
+width = 456;
+}
+);
+note = uni154C;
+unicode = 5452;
+},
+{
+glyphname = "laWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (348,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(394,0,l),
+(394,85,l),
+(285,85,ls),
+(187,85,o),
+(140,141,o),
+(140,232,cs),
+(140,323,o),
+(188,380,o),
+(284,380,cs),
+(394,380,l),
+(394,714,l),
+(301,714,l),
+(301,435,l),
+(324,462,l),
+(262,462,ls),
+(130,462,o),
+(46,371,o),
+(46,233,cs),
+(46,90,o),
+(125,0,o),
+(275,0,cs)
+);
+}
+);
+width = 456;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+unicode = 5453;
+},
+{
+glyphname = "rwaa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (377,0);
+ref = dot_top;
+}
+);
+width = 647;
+}
+);
+note = uni154E;
+unicode = 5454;
+},
+{
+glyphname = "rwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (186,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (456,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 647;
+}
+);
+note = uni154F;
+unicode = 5455;
+},
+{
+glyphname = "r-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(219,357,l),
+(219,532,l),
+(169,532,ls),
+(126,532,o),
+(102,553,o),
+(102,596,cs),
+(102,639,o),
+(127,661,o),
+(170,661,cs),
+(219,661,l),
+(219,714,l),
+(168,714,ls),
+(88,714,o),
+(41,671,o),
+(41,596,cs),
+(41,525,o),
+(86,480,o),
+(161,480,cs),
+(190,480,l),
+(155,499,l),
+(155,357,l)
+);
+}
+);
+width = 270;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni1550;
+unicode = 5456;
+},
+{
+glyphname = "rWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(63,357,l),
+(249,449,l),
+(249,474,l),
+(94,547,l),
+(94,523,l),
+(249,597,l),
+(249,622,l),
+(63,714,l),
+(51,714,l),
+(51,669,l),
+(206,593,l),
+(206,626,l),
+(51,551,l),
+(51,520,l),
+(206,446,l),
+(206,478,l),
+(51,401,l),
+(51,357,l)
+);
+}
+);
+width = 300;
+}
+);
+metricLeft = "=|lWestCree-canadian";
+metricRight = "=|lWestCree-canadian";
+note = uni1551;
+unicode = 5457;
+},
+{
+glyphname = "rMedial-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(81,-13,l),
+(486,178,l),
+(486,213,l),
+(147,370,l),
+(147,344,l),
+(486,501,l),
+(486,536,l),
+(81,727,l),
+(57,727,l),
+(57,659,l),
+(405,495,l),
+(405,538,l),
+(57,381,l),
+(57,333,l),
+(405,176,l),
+(405,219,l),
+(57,55,l),
+(57,-13,l)
+);
+}
+);
+width = 543;
+}
+);
+metricLeft = "mediall-canadian";
+metricRight = "mediall-canadian";
+note = uni1552;
+unicode = 5458;
+},
+{
+glyphname = "fe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(328,0,l),
+(618,688,l),
+(618,714,l),
+(544,714,l),
+(297,106,l),
+(320,106,l),
+(207,369,l),
+(160,363,l),
+(180,340,o),
+(204,329,o),
+(234,329,cs),
+(310,329,o),
+(370,407,o),
+(370,529,cs),
+(370,649,o),
+(319,727,o),
+(227,727,cs),
+(134,727,o),
+(83,649,o),
+(83,539,cs),
+(83,480,o),
+(96,427,o),
+(124,368,cs),
+(297,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(181,394,o),
+(157,446,o),
+(157,536,cs),
+(157,621,o),
+(183,660,o),
+(227,660,cs),
+(271,660,o),
+(296,621,o),
+(296,528,cs),
+(296,435,o),
+(271,394,o),
+(228,394,cs)
+);
+}
+);
+width = 644;
+}
+);
+metricRight = "e-canadian";
+note = uni1553;
+unicode = 5459;
+},
+{
+glyphname = "faai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (195,0);
+ref = ring_top.canadian;
+}
+);
+width = 643;
+}
+);
+note = uni1554;
+unicode = 5460;
+},
+{
+glyphname = "fi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (314,714);
+},
+{
+name = top_left_can;
+pos = (121,714);
+},
+{
+name = top_right_can;
+pos = (527,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(319,-13,o),
+(370,65,o),
+(370,185,cs),
+(370,307,o),
+(310,385,o),
+(234,385,cs),
+(204,385,o),
+(180,374,o),
+(160,351,c),
+(207,345,l),
+(320,608,l),
+(297,608,l),
+(544,0,l),
+(618,0,l),
+(618,26,l),
+(328,714,l),
+(297,714,l),
+(124,346,ls),
+(96,287,o),
+(83,234,o),
+(83,175,cs),
+(83,65,o),
+(134,-13,o),
+(227,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(183,54,o),
+(157,93,o),
+(157,178,cs),
+(157,268,o),
+(181,320,o),
+(228,320,cs),
+(271,320,o),
+(296,279,o),
+(296,186,cs),
+(296,93,o),
+(271,54,o),
+(227,54,cs)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "fe-canadian";
+metricRight = "e-canadian";
+note = uni1555;
+unicode = 5461;
+},
+{
+glyphname = "fii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (244,0);
+ref = dot_top;
+}
+);
+width = 643;
+}
+);
+note = uni1556;
+unicode = 5462;
+},
+{
+glyphname = "fo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (187,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(98,0,l),
+(538,340,l),
+(538,374,l),
+(292,674,ls),
+(261,713,o),
+(224,727,o),
+(184,727,cs),
+(95,727,o),
+(44,650,o),
+(44,526,cs),
+(44,406,o),
+(99,327,o),
+(186,327,cs),
+(271,327,o),
+(323,407,o),
+(323,526,cs),
+(323,571,o),
+(313,613,o),
+(301,641,c),
+(272,585,l),
+(461,355,l),
+(461,378,l),
+(74,79,l),
+(74,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(144,394,o),
+(118,433,o),
+(118,527,cs),
+(118,621,o),
+(144,660,o),
+(188,660,cs),
+(231,660,o),
+(256,621,o),
+(256,528,cs),
+(256,435,o),
+(231,394,o),
+(188,394,cs)
+);
+}
+);
+width = 568;
+}
+);
+metricRight = "o-canadian";
+note = uni1557;
+unicode = 5463;
+},
+{
+glyphname = "foo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "fo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (117,0);
+ref = dot_top;
+}
+);
+width = 569;
+}
+);
+note = uni1558;
+unicode = 5464;
+},
+{
+glyphname = "fa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (382,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(495,0,l),
+(495,79,l),
+(108,378,l),
+(108,356,l),
+(297,585,l),
+(267,641,l),
+(255,613,o),
+(245,571,o),
+(245,526,cs),
+(245,407,o),
+(298,327,o),
+(383,327,cs),
+(470,327,o),
+(524,406,o),
+(524,526,cs),
+(524,650,o),
+(474,727,o),
+(384,727,cs),
+(345,727,o),
+(308,713,o),
+(276,674,cs),
+(30,374,l),
+(30,340,l),
+(471,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(338,394,o),
+(313,435,o),
+(313,528,cs),
+(313,621,o),
+(338,660,o),
+(381,660,cs),
+(425,660,o),
+(450,621,o),
+(450,527,cs),
+(450,433,o),
+(425,394,o),
+(381,394,cs)
+);
+}
+);
+width = 568;
+}
+);
+metricRight = "=|fo-canadian";
+note = uni1559;
+unicode = 5465;
+},
+{
+glyphname = "faa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (312,0);
+ref = dot_top;
+}
+);
+width = 569;
+}
+);
+note = uni155A;
+unicode = 5466;
+},
+{
+glyphname = "fwaa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (504,0);
+ref = dot_top;
+}
+);
+width = 760;
+}
+);
+note = uni155B;
+unicode = 5467;
+},
+{
+glyphname = "fwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (312,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (569,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 760;
+}
+);
+note = uni155C;
+unicode = 5468;
+},
+{
+glyphname = "f-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(274,357,l),
+(274,399,l),
+(86,546,l),
+(86,536,l),
+(172,640,l),
+(162,676,l),
+(155,661,o),
+(151,640,o),
+(151,615,cs),
+(151,551,o),
+(180,519,o),
+(220,519,cs),
+(260,519,o),
+(288,553,o),
+(288,620,cs),
+(288,691,o),
+(256,720,o),
+(218,720,cs),
+(200,720,o),
+(180,711,o),
+(163,690,cs),
+(41,545,l),
+(41,525,l),
+(261,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(198,556,o),
+(187,575,o),
+(187,618,cs),
+(187,662,o),
+(198,683,o),
+(218,683,cs),
+(238,683,o),
+(249,666,o),
+(249,618,cs),
+(249,574,o),
+(239,556,o),
+(218,556,cs)
+);
+}
+);
+width = 334;
+}
+);
+note = uni155D;
+unicode = 5469;
+},
+{
+glyphname = "the-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (662,357);
+},
+{
+name = top_center_can;
+pos = (305,714);
+},
+{
+name = top_left_can;
+pos = (104,714);
+},
+{
+name = top_right_can;
+pos = (504,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(460,-13,o),
+(551,81,o),
+(551,262,cs),
+(551,714,l),
+(458,714,l),
+(458,260,ls),
+(458,132,o),
+(404,73,o),
+(304,73,cs),
+(207,73,o),
+(150,135,o),
+(150,263,cs),
+(150,435,l),
+(109,409,l),
+(121,360,o),
+(160,326,o),
+(204,326,cs),
+(289,326,o),
+(344,404,o),
+(344,527,cs),
+(344,649,o),
+(295,727,o),
+(203,727,cs),
+(108,727,o),
+(58,650,o),
+(58,501,cs),
+(58,284,ls),
+(58,85,o),
+(148,-13,o),
+(304,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(159,394,o),
+(132,433,o),
+(132,527,cs),
+(132,620,o),
+(158,660,o),
+(202,660,cs),
+(245,660,o),
+(270,620,o),
+(270,528,cs),
+(270,435,o),
+(246,394,o),
+(203,394,cs)
+);
+}
+);
+width = 609;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155E;
+unicode = 5470;
+},
+{
+glyphname = "theNCree-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(463,-13,o),
+(551,81,o),
+(551,279,cs),
+(551,501,ls),
+(551,650,o),
+(501,727,o),
+(407,727,cs),
+(315,727,o),
+(266,649,o),
+(266,527,cs),
+(266,404,o),
+(321,326,o),
+(405,326,cs),
+(450,326,o),
+(488,360,o),
+(501,409,c),
+(459,435,l),
+(459,261,ls),
+(459,132,o),
+(403,71,o),
+(305,71,cs),
+(206,71,o),
+(152,131,o),
+(152,258,cs),
+(152,714,l),
+(58,714,l),
+(58,260,ls),
+(58,81,o),
+(150,-13,o),
+(305,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(364,394,o),
+(340,435,o),
+(340,528,cs),
+(340,620,o),
+(365,660,o),
+(408,660,cs),
+(452,660,o),
+(477,620,o),
+(477,527,cs),
+(477,433,o),
+(450,394,o),
+(407,394,cs)
+);
+}
+);
+width = 609;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155F;
+unicode = 5471;
+},
+{
+glyphname = "thi-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (302,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(295,-13,o),
+(344,65,o),
+(344,187,cs),
+(344,310,o),
+(289,388,o),
+(204,388,cs),
+(160,388,o),
+(121,354,o),
+(109,305,c),
+(150,279,l),
+(150,453,ls),
+(150,582,o),
+(206,643,o),
+(304,643,cs),
+(403,643,o),
+(458,583,o),
+(458,456,cs),
+(458,0,l),
+(551,0,l),
+(551,454,ls),
+(551,633,o),
+(459,727,o),
+(304,727,cs),
+(147,727,o),
+(58,633,o),
+(58,435,cs),
+(58,213,ls),
+(58,64,o),
+(108,-13,o),
+(203,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(158,54,o),
+(132,94,o),
+(132,187,cs),
+(132,281,o),
+(159,320,o),
+(203,320,cs),
+(246,320,o),
+(270,279,o),
+(270,186,cs),
+(270,94,o),
+(245,54,o),
+(202,54,cs)
+);
+}
+);
+width = 609;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1560;
+unicode = 5472;
+},
+{
+glyphname = "thiNCree-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (302,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(501,-13,o),
+(551,64,o),
+(551,213,cs),
+(551,435,ls),
+(551,633,o),
+(463,727,o),
+(305,727,cs),
+(150,727,o),
+(58,633,o),
+(58,454,cs),
+(58,0,l),
+(152,0,l),
+(152,456,ls),
+(152,583,o),
+(206,643,o),
+(305,643,cs),
+(403,643,o),
+(459,582,o),
+(459,453,cs),
+(459,279,l),
+(501,305,l),
+(488,354,o),
+(450,388,o),
+(405,388,cs),
+(321,388,o),
+(266,310,o),
+(266,187,cs),
+(266,65,o),
+(315,-13,o),
+(407,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(365,54,o),
+(340,94,o),
+(340,186,cs),
+(340,279,o),
+(364,320,o),
+(407,320,cs),
+(450,320,o),
+(477,281,o),
+(477,187,cs),
+(477,94,o),
+(452,54,o),
+(408,54,cs)
+);
+}
+);
+width = 609;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1561;
+unicode = 5473;
+},
+{
+glyphname = "thii-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "thi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (232,0);
+ref = dot_top;
+}
+);
+width = 610;
+}
+);
+note = uni1562;
+unicode = 5474;
+},
+{
+glyphname = "thiiNCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "thiNCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (232,0);
+ref = dot_top;
+}
+);
+width = 610;
+}
+);
+note = uni1563;
+unicode = 5475;
+},
+{
+glyphname = "tho-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (252,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(205,0,ls),
+(407,0,o),
+(509,123,o),
+(509,365,cs),
+(509,589,o),
+(413,727,o),
+(257,727,cs),
+(137,727,o),
+(52,644,o),
+(52,502,cs),
+(52,373,o),
+(106,300,o),
+(193,300,cs),
+(281,300,o),
+(330,373,o),
+(330,489,cs),
+(330,602,o),
+(289,679,o),
+(210,683,c),
+(180,649,l),
+(197,660,o),
+(220,667,o),
+(242,667,cs),
+(359,667,o),
+(418,551,o),
+(418,371,cs),
+(418,176,o),
+(353,86,o),
+(201,86,cs),
+(80,86,l),
+(80,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(152,367,o),
+(126,407,o),
+(126,504,cs),
+(126,599,o),
+(156,642,o),
+(197,642,cs),
+(239,642,o),
+(264,602,o),
+(264,505,cs),
+(264,409,o),
+(239,367,o),
+(196,367,cs)
+);
+}
+);
+width = 560;
+}
+);
+metricRight = "to-canadian";
+note = uni1564;
+unicode = 5476;
+},
+{
+glyphname = "thoo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "tho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (182,0);
+ref = dot_top;
+}
+);
+width = 560;
+}
+);
+note = uni1565;
+unicode = 5477;
+},
+{
+glyphname = "tha-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (310,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(480,0,l),
+(480,86,l),
+(359,86,ls),
+(207,86,o),
+(142,176,o),
+(142,371,cs),
+(142,551,o),
+(202,667,o),
+(318,667,cs),
+(340,667,o),
+(364,660,o),
+(380,649,c),
+(350,683,l),
+(271,679,o),
+(230,602,o),
+(230,489,cs),
+(230,373,o),
+(279,300,o),
+(368,300,cs),
+(454,300,o),
+(508,373,o),
+(508,502,cs),
+(508,644,o),
+(423,727,o),
+(303,727,cs),
+(147,727,o),
+(51,589,o),
+(51,365,cs),
+(51,127,o),
+(149,0,o),
+(356,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(321,367,o),
+(296,409,o),
+(296,505,cs),
+(296,602,o),
+(322,642,o),
+(363,642,cs),
+(404,642,o),
+(434,599,o),
+(434,504,cs),
+(434,407,o),
+(408,367,o),
+(365,367,cs)
+);
+}
+);
+width = 560;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tho-canadian";
+note = uni1566;
+unicode = 5478;
+},
+{
+glyphname = "thaa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (240,0);
+ref = dot_top;
+}
+);
+width = 560;
+}
+);
+note = uni1567;
+unicode = 5479;
+},
+{
+glyphname = "thwaa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (432,0);
+ref = dot_top;
+}
+);
+width = 752;
+}
+);
+note = uni1568;
+unicode = 5480;
+},
+{
+glyphname = "thwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (240,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (560,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 752;
+}
+);
+note = uni1569;
+unicode = 5481;
+},
+{
+glyphname = "th-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(263,357,l),
+(263,411,l),
+(210,411,ls),
+(136,411,o),
+(103,455,o),
+(103,541,cs),
+(103,626,o),
+(135,679,o),
+(190,679,cs),
+(201,679,o),
+(210,676,o),
+(218,672,c),
+(197,694,l),
+(161,691,o),
+(139,656,o),
+(139,605,cs),
+(139,537,o),
+(167,504,o),
+(208,504,cs),
+(249,504,o),
+(276,538,o),
+(276,605,cs),
+(276,685,o),
+(236,720,o),
+(180,720,cs),
+(101,720,o),
+(49,654,o),
+(49,537,cs),
+(49,425,o),
+(99,357,o),
+(206,357,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(186,541,o),
+(175,559,o),
+(175,603,cs),
+(175,647,o),
+(186,668,o),
+(206,668,cs),
+(226,668,o),
+(237,651,o),
+(237,603,cs),
+(237,559,o),
+(227,541,o),
+(207,541,cs)
+);
+}
+);
+width = 322;
+}
+);
+metricLeft = "t-canadian";
+note = uni156A;
+unicode = 5482;
+},
+{
+glyphname = "tthe-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (655,357);
+},
+{
+name = top_center_can;
+pos = (301,714);
+},
+{
+name = top_left_can;
+pos = (106,714);
+},
+{
+name = top_right_can;
+pos = (497,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(455,-13,o),
+(544,81,o),
+(544,262,cs),
+(544,714,l),
+(456,714,l),
+(456,260,ls),
+(456,131,o),
+(397,74,o),
+(301,74,cs),
+(207,74,o),
+(146,134,o),
+(146,260,cs),
+(146,714,l),
+(58,714,l),
+(58,260,ls),
+(58,81,o),
+(150,-13,o),
+(301,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(336,401,l),
+(336,714,l),
+(266,714,l),
+(266,401,l)
+);
+}
+);
+width = 602;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156B;
+unicode = 5483;
+},
+{
+glyphname = "tthi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(146,0,l),
+(146,454,ls),
+(146,582,o),
+(205,640,o),
+(301,640,cs),
+(395,640,o),
+(456,580,o),
+(456,454,cs),
+(456,0,l),
+(544,0,l),
+(544,454,ls),
+(544,633,o),
+(452,727,o),
+(301,727,cs),
+(147,727,o),
+(58,633,o),
+(58,452,cs),
+(58,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(336,0,l),
+(336,313,l),
+(266,313,l),
+(266,0,l)
+);
+}
+);
+width = 602;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156C;
+unicode = 5484;
+},
+{
+glyphname = "ttho-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (266,714);
+},
+{
+name = top_left_can;
+pos = (107,714);
+},
+{
+name = top_right_can;
+pos = (426,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(159,0,ls),
+(365,0,o),
+(471,124,o),
+(471,358,cs),
+(471,592,o),
+(365,714,o),
+(156,714,cs),
+(61,714,l),
+(61,628,l),
+(157,628,ls),
+(307,628,o),
+(378,542,o),
+(378,358,cs),
+(378,175,o),
+(307,86,o),
+(160,86,cs),
+(61,86,l),
+(61,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(249,318,l),
+(249,397,l),
+(61,397,l),
+(61,318,l)
+);
+}
+);
+width = 522;
+}
+);
+metricRight = "to-canadian";
+note = uni156D;
+unicode = 5485;
+},
+{
+glyphname = "ttha-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (264,714);
+},
+{
+name = top_left_can;
+pos = (97,714);
+},
+{
+name = top_right_can;
+pos = (416,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(461,0,l),
+(461,86,l),
+(365,86,ls),
+(215,86,o),
+(145,173,o),
+(145,357,cs),
+(145,539,o),
+(215,628,o),
+(362,628,cs),
+(461,628,l),
+(461,714,l),
+(363,714,ls),
+(157,714,o),
+(51,591,o),
+(51,357,cs),
+(51,123,o),
+(157,0,o),
+(366,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(461,318,l),
+(461,397,l),
+(273,397,l),
+(273,318,l)
+);
+}
+);
+width = 522;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|ttho-canadian";
+note = uni156E;
+unicode = 5486;
+},
+{
+glyphname = "tth-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(538,512,l),
+(515,512,l),
+(598,390,l),
+(642,422,l),
+(558,544,l),
+(551,522,l),
+(674,574,l),
+(654,623,l),
+(533,570,l),
+(554,559,l),
+(554,714,l),
+(499,714,l),
+(499,559,l),
+(521,570,l),
+(399,623,l),
+(379,574,l),
+(503,522,l),
+(496,544,l),
+(411,422,l),
+(456,390,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(198,512,l),
+(175,512,l),
+(261,390,l),
+(305,422,l),
+(218,544,l),
+(211,522,l),
+(334,574,l),
+(314,623,l),
+(193,570,l),
+(214,559,l),
+(214,714,l),
+(159,714,l),
+(159,559,l),
+(181,570,l),
+(59,623,l),
+(40,574,l),
+(163,522,l),
+(156,544,l),
+(69,422,l),
+(113,390,l)
+);
+}
+);
+width = 714;
+}
+);
+metricRight = "=|";
+note = uni156F;
+unicode = 5487;
+},
+{
+glyphname = "tye-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(455,-13,o),
+(544,81,o),
+(544,262,cs),
+(544,714,l),
+(456,714,l),
+(456,266,ls),
+(456,131,o),
+(397,74,o),
+(301,74,cs),
+(207,74,o),
+(146,134,o),
+(146,266,cs),
+(146,714,l),
+(58,714,l),
+(58,260,ls),
+(58,81,o),
+(150,-13,o),
+(301,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(360,426,o),
+(394,464,o),
+(394,536,cs),
+(394,714,l),
+(350,714,l),
+(350,538,ls),
+(350,491,o),
+(333,471,o),
+(301,471,cs),
+(269,471,o),
+(252,492,o),
+(252,538,cs),
+(252,714,l),
+(208,714,l),
+(208,536,ls),
+(208,464,o),
+(243,426,o),
+(301,426,cs)
+);
+}
+);
+width = 602;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1570;
+unicode = 5488;
+},
+{
+glyphname = "tyi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(146,0,l),
+(146,448,ls),
+(146,582,o),
+(205,640,o),
+(301,640,cs),
+(395,640,o),
+(456,580,o),
+(456,448,cs),
+(456,0,l),
+(544,0,l),
+(544,454,ls),
+(544,633,o),
+(452,727,o),
+(301,727,cs),
+(147,727,o),
+(58,633,o),
+(58,452,cs),
+(58,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(252,0,l),
+(252,176,ls),
+(252,223,o),
+(269,243,o),
+(301,243,cs),
+(333,243,o),
+(350,222,o),
+(350,176,cs),
+(350,0,l),
+(394,0,l),
+(394,178,ls),
+(394,250,o),
+(359,288,o),
+(301,288,cs),
+(242,288,o),
+(208,250,o),
+(208,178,cs),
+(208,0,l)
+);
+}
+);
+width = 602;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1571;
+unicode = 5489;
+},
+{
+glyphname = "tyo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(160,0,ls),
+(362,0,o),
+(472,124,o),
+(472,358,cs),
+(472,592,o),
+(362,714,o),
+(157,714,cs),
+(62,714,l),
+(62,630,l),
+(150,630,ls),
+(307,630,o),
+(379,543,o),
+(379,358,cs),
+(379,174,o),
+(307,84,o),
+(153,84,cs),
+(62,84,l),
+(62,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(118,219,ls),
+(201,219,o),
+(248,266,o),
+(248,357,cs),
+(248,448,o),
+(201,495,o),
+(118,495,cs),
+(62,495,l),
+(62,444,l),
+(111,444,ls),
+(169,444,o),
+(194,416,o),
+(194,357,cs),
+(194,298,o),
+(169,270,o),
+(111,270,cs),
+(62,270,l),
+(62,219,l)
+);
+}
+);
+width = 523;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1572;
+unicode = 5490;
+},
+{
+glyphname = "tya-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(461,0,l),
+(461,84,l),
+(373,84,ls),
+(216,84,o),
+(144,172,o),
+(144,357,cs),
+(144,541,o),
+(216,630,o),
+(370,630,cs),
+(461,630,l),
+(461,714,l),
+(363,714,ls),
+(161,714,o),
+(51,591,o),
+(51,357,cs),
+(51,123,o),
+(161,0,o),
+(366,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(461,219,l),
+(461,270,l),
+(412,270,ls),
+(355,270,o),
+(329,298,o),
+(329,357,cs),
+(329,416,o),
+(355,444,o),
+(411,444,cs),
+(461,444,l),
+(461,495,l),
+(405,495,ls),
+(322,495,o),
+(275,448,o),
+(275,357,cs),
+(275,266,o),
+(322,219,o),
+(405,219,cs)
+);
+}
+);
+width = 523;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1573;
+unicode = 5491;
+},
+{
+glyphname = "heNunavik-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(429,0,l),
+(626,201,l),
+(570,260,l),
+(379,66,l),
+(439,62,l),
+(439,462,ls),
+(439,633,o),
+(372,727,o),
+(248,727,cs),
+(124,727,o),
+(51,631,o),
+(51,463,cs),
+(51,303,o),
+(122,205,o),
+(234,205,cs),
+(297,205,o),
+(344,247,o),
+(355,303,c),
+(347,328,l),
+(347,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(180,286,o),
+(142,343,o),
+(142,467,cs),
+(142,590,o),
+(179,647,o),
+(245,647,cs),
+(311,647,o),
+(348,591,o),
+(348,467,cs),
+(348,343,o),
+(309,286,o),
+(245,286,cs)
+);
+}
+);
+width = 647;
+}
+);
+metricLeft = "ke-canadian";
+note = uni1574;
+unicode = 5492;
+},
+{
+glyphname = "hiNunavik-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (400,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(301,0,l),
+(301,328,l),
+(292,303,l),
+(303,247,o),
+(350,205,o),
+(414,205,cs),
+(526,205,o),
+(596,303,o),
+(596,464,cs),
+(596,631,o),
+(523,727,o),
+(400,727,cs),
+(275,727,o),
+(208,633,o),
+(208,462,cs),
+(208,63,l),
+(268,66,l),
+(77,260,l),
+(21,201,l),
+(218,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(338,286,o),
+(300,343,o),
+(300,467,cs),
+(300,591,o),
+(336,647,o),
+(402,647,cs),
+(468,647,o),
+(505,590,o),
+(505,467,cs),
+(505,343,o),
+(467,286,o),
+(402,286,cs)
+);
+}
+);
+width = 647;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1575;
+unicode = 5493;
+},
+{
+glyphname = "hiiNunavik-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "hiNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (330,0);
+ref = dot_top;
+}
+);
+width = 647;
+}
+);
+note = uni1576;
+unicode = 5494;
+},
+{
+glyphname = "hoNunavik-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (244,714);
+},
+{
+name = top_right_can;
+pos = (393,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(372,-13,o),
+(439,81,o),
+(439,252,cs),
+(439,652,l),
+(379,648,l),
+(570,454,l),
+(626,513,l),
+(429,714,l),
+(347,714,l),
+(347,386,l),
+(355,411,l),
+(344,467,o),
+(297,509,o),
+(234,509,cs),
+(122,509,o),
+(51,411,o),
+(51,250,cs),
+(51,83,o),
+(124,-13,o),
+(248,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(179,67,o),
+(142,124,o),
+(142,247,cs),
+(142,371,o),
+(180,428,o),
+(245,428,cs),
+(309,428,o),
+(348,371,o),
+(348,247,cs),
+(348,123,o),
+(311,67,o),
+(245,67,cs)
+);
+}
+);
+width = 647;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "heNunavik-canadian";
+note = uni1577;
+unicode = 5495;
+},
+{
+glyphname = "hooNunavik-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "hoNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (323,0);
+ref = dot_top;
+}
+);
+width = 647;
+}
+);
+note = uni1578;
+unicode = 5496;
+},
+{
+glyphname = "haNunavik-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (403,714);
+},
+{
+name = top_left_can;
+pos = (255,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(523,-13,o),
+(596,83,o),
+(596,250,cs),
+(596,411,o),
+(526,509,o),
+(414,509,cs),
+(350,509,o),
+(304,467,o),
+(292,411,c),
+(301,386,l),
+(301,714,l),
+(218,714,l),
+(21,513,l),
+(77,454,l),
+(268,648,l),
+(208,651,l),
+(208,252,ls),
+(208,81,o),
+(275,-13,o),
+(400,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(336,67,o),
+(300,123,o),
+(300,247,cs),
+(300,371,o),
+(338,428,o),
+(402,428,cs),
+(467,428,o),
+(505,371,o),
+(505,247,cs),
+(505,124,o),
+(468,67,o),
+(402,67,cs)
+);
+}
+);
+width = 647;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1579;
+unicode = 5497;
+},
+{
+glyphname = "haaNunavik-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "haNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (185,0);
+ref = dot_top;
+}
+);
+width = 647;
+}
+);
+note = uni157A;
+unicode = 5498;
+},
+{
+glyphname = "hNunavik-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(293,351,o),
+(341,396,o),
+(341,491,cs),
+(341,576,o),
+(300,622,o),
+(246,622,cs),
+(206,622,o),
+(177,594,o),
+(172,548,c),
+(187,548,l),
+(187,714,l),
+(129,714,l),
+(31,614,l),
+(64,581,l),
+(162,682,l),
+(124,680,l),
+(124,486,ls),
+(124,401,o),
+(166,351,o),
+(233,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(202,400,o),
+(183,423,o),
+(183,487,cs),
+(183,548,o),
+(204,573,o),
+(233,573,cs),
+(262,573,o),
+(284,549,o),
+(284,487,cs),
+(284,425,o),
+(263,400,o),
+(233,400,cs)
+);
+}
+);
+width = 382;
+}
+);
+metricRight = "k-canadian";
+note = uni157B;
+unicode = 5499;
+},
+{
+color = 4;
+glyphname = "nunavuth-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(155,328,l),
+(422,328,l),
+(422,0,l),
+(515,0,l),
+(515,714,l),
+(422,714,l),
+(422,412,l),
+(155,412,l),
+(155,714,l),
+(62,714,l),
+(62,0,l),
+(155,0,l)
+);
+}
+);
+width = 577;
+}
+);
+metricRight = "=|";
+note = uni157C;
+unicode = 5500;
+},
+{
+glyphname = "hk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,357);
+ref = "fullstop-canadian";
+}
+);
+width = 311;
+}
+);
+metricLeft = "fullstop-canadian";
+note = uni157D;
+unicode = 5501;
+},
+{
+glyphname = "qaai-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (270,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (403,0);
+ref = ring_top.canadian;
+}
+);
+width = 767;
+}
+);
+note = uni157E;
+unicode = 5502;
+},
+{
+glyphname = "qi-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (270,0);
+ref = "ki-canadian";
+}
+);
+width = 767;
+}
+);
+note = uni157F;
+unicode = 5503;
+},
+{
+glyphname = "qii-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (270,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (452,0);
+ref = dot_top;
+}
+);
+width = 767;
+}
+);
+note = uni1580;
+unicode = 5504;
+},
+{
+glyphname = "qo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (270,0);
+ref = "ko-canadian";
+}
+);
+width = 767;
+}
+);
+note = uni1581;
+unicode = 5505;
+},
+{
+glyphname = "qoo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (270,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (593,0);
+ref = dot_top;
+}
+);
+width = 767;
+}
+);
+note = uni1582;
+unicode = 5506;
+},
+{
+glyphname = "qa-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (270,0);
+ref = "ka-canadian";
+}
+);
+width = 767;
+}
+);
+note = uni1583;
+unicode = 5507;
+},
+{
+glyphname = "qaa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (270,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (305,0);
+ref = dot_top;
+}
+);
+width = 767;
+}
+);
+note = uni1584;
+unicode = 5508;
+},
+{
+glyphname = "q-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (270,0);
+ref = "k-canadian";
+}
+);
+width = 578;
+}
+);
+note = uni1585;
+unicode = 5509;
+},
+{
+glyphname = "tlhe-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (253,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(169,0,l),
+(275,274,l),
+(203,246,l),
+(213,243,o),
+(225,241,o),
+(238,241,cs),
+(306,241,o),
+(350,283,o),
+(362,332,c),
+(354,357,l),
+(354,0,l),
+(446,0,l),
+(446,485,ls),
+(446,635,o),
+(378,727,o),
+(253,727,cs),
+(128,727,o),
+(54,634,o),
+(54,482,cs),
+(54,366,o),
+(101,287,o),
+(173,261,c),
+(71,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(185,321,o),
+(146,375,o),
+(146,484,cs),
+(146,593,o),
+(183,647,o),
+(250,647,cs),
+(318,647,o),
+(355,594,o),
+(355,484,cs),
+(355,374,o),
+(315,321,o),
+(250,321,cs)
+);
+}
+);
+width = 504;
+}
+);
+metricRight = "te-canadian";
+note = uni1586;
+unicode = 5510;
+},
+{
+glyphname = "tlhi-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(151,0,l),
+(151,357,l),
+(143,333,l),
+(154,283,o),
+(198,241,o),
+(267,241,c),
+(230,274,l),
+(336,0,l),
+(434,0,l),
+(332,261,l),
+(404,287,o),
+(450,366,o),
+(450,482,cs),
+(450,634,o),
+(377,727,o),
+(252,727,cs),
+(127,727,o),
+(58,635,o),
+(58,485,cs),
+(58,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(190,321,o),
+(150,374,o),
+(150,484,cs),
+(150,594,o),
+(187,647,o),
+(255,647,cs),
+(321,647,o),
+(359,593,o),
+(359,484,cs),
+(359,375,o),
+(320,321,o),
+(255,321,cs)
+);
+}
+);
+width = 504;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|tlhe-canadian";
+note = uni1587;
+unicode = 5511;
+},
+{
+glyphname = "tlho-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (263,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(378,-13,o),
+(446,79,o),
+(446,229,cs),
+(446,714,l),
+(354,714,l),
+(354,357,l),
+(362,381,l),
+(350,431,o),
+(307,473,o),
+(238,473,c),
+(275,440,l),
+(169,714,l),
+(71,714,l),
+(173,453,l),
+(101,427,o),
+(54,348,o),
+(54,232,cs),
+(54,80,o),
+(128,-13,o),
+(253,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(183,67,o),
+(146,121,o),
+(146,230,cs),
+(146,339,o),
+(185,393,o),
+(250,393,cs),
+(315,393,o),
+(355,340,o),
+(355,230,cs),
+(355,120,o),
+(318,67,o),
+(250,67,cs)
+);
+}
+);
+width = 504;
+}
+);
+metricLeft = "tlhe-canadian";
+metricRight = "te-canadian";
+note = uni1588;
+unicode = 5512;
+},
+{
+glyphname = "tlha-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(377,-13,o),
+(450,80,o),
+(450,232,cs),
+(450,348,o),
+(404,427,o),
+(332,453,c),
+(434,714,l),
+(336,714,l),
+(230,440,l),
+(302,468,l),
+(291,471,o),
+(279,473,o),
+(267,473,cs),
+(198,473,o),
+(154,431,o),
+(143,381,c),
+(151,357,l),
+(151,714,l),
+(58,714,l),
+(58,229,ls),
+(58,79,o),
+(127,-13,o),
+(252,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(187,67,o),
+(150,120,o),
+(150,230,cs),
+(150,340,o),
+(190,393,o),
+(255,393,cs),
+(320,393,o),
+(359,339,o),
+(359,230,cs),
+(359,121,o),
+(321,67,o),
+(255,67,cs)
+);
+}
+);
+width = 505;
+}
+);
+metricLeft = "te-canadian";
+note = uni1589;
+unicode = 5513;
+},
+{
+glyphname = "reWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(423,0,l),
+(620,201,l),
+(563,260,l),
+(372,66,l),
+(433,62,l),
+(433,480,ls),
+(433,634,o),
+(367,727,o),
+(243,727,cs),
+(120,727,o),
+(49,638,o),
+(49,484,cs),
+(49,401,l),
+(142,401,l),
+(142,500,ls),
+(142,592,o),
+(175,645,o),
+(242,645,cs),
+(306,645,o),
+(340,593,o),
+(340,496,cs),
+(340,0,l)
+);
+}
+);
+width = 641;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+unicode = 5514;
+},
+{
+glyphname = "riWestCree-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(301,0,l),
+(301,496,ls),
+(301,593,o),
+(335,645,o),
+(399,645,cs),
+(466,645,o),
+(499,592,o),
+(499,500,cs),
+(499,401,l),
+(591,401,l),
+(591,484,ls),
+(591,638,o),
+(521,727,o),
+(398,727,cs),
+(274,727,o),
+(208,634,o),
+(208,479,cs),
+(208,62,l),
+(268,66,l),
+(77,260,l),
+(21,201,l),
+(218,0,l)
+);
+}
+);
+width = 640;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+unicode = 5515;
+},
+{
+glyphname = "roWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(366,-13,o),
+(433,80,o),
+(433,235,cs),
+(433,652,l),
+(372,648,l),
+(563,454,l),
+(620,513,l),
+(423,714,l),
+(340,714,l),
+(340,218,ls),
+(340,121,o),
+(306,69,o),
+(242,69,cs),
+(175,69,o),
+(142,122,o),
+(142,214,cs),
+(142,313,l),
+(49,313,l),
+(49,230,ls),
+(49,76,o),
+(120,-13,o),
+(243,-13,cs)
+);
+}
+);
+width = 641;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+unicode = 5516;
+},
+{
+glyphname = "raWestCree-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(521,-13,o),
+(591,76,o),
+(591,230,cs),
+(591,313,l),
+(499,313,l),
+(499,214,ls),
+(499,122,o),
+(466,69,o),
+(399,69,cs),
+(335,69,o),
+(301,121,o),
+(301,218,cs),
+(301,714,l),
+(218,714,l),
+(21,513,l),
+(77,454,l),
+(268,648,l),
+(208,652,l),
+(208,234,ls),
+(208,80,o),
+(274,-13,o),
+(398,-13,cs)
+);
+}
+);
+width = 640;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+unicode = 5517;
+},
+{
+glyphname = "ngaai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (525,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (658,0);
+ref = ring_top.canadian;
+}
+);
+width = 1017;
+}
+);
+note = uni158E;
+unicode = 5518;
+},
+{
+glyphname = "ngi-canadian";
+kernLeft = mwestleft;
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (525,0);
+ref = "ci-canadian";
+}
+);
+width = 1017;
+}
+);
+note = uni158F;
+unicode = 5519;
+},
+{
+glyphname = "ngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (525,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (708,0);
+ref = dot_top;
+}
+);
+width = 1017;
+}
+);
+note = uni1590;
+unicode = 5520;
+},
+{
+glyphname = "ngo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:31:32 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (500,0);
+ref = "co-canadian";
+}
+);
+width = 991;
+}
+);
+note = uni1591;
+unicode = 5521;
+},
+{
+glyphname = "ngoo-canadian";
+lastChange = "2023-01-13 15:31:32 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+ref = "ngo-canadian";
+},
+{
+anchor = top_right_can;
+pos = (817,0);
+ref = dot_top;
+}
+);
+width = 991;
+}
+);
+note = uni1592;
+unicode = 5522;
+},
+{
+glyphname = "nga-canadian";
+kernLeft = mwestleft;
+kernRight = caright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (525,0);
+ref = "ca-canadian";
+}
+);
+width = 1017;
+}
+);
+note = uni1593;
+unicode = 5523;
+},
+{
+glyphname = "ngaa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (525,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (561,0);
+ref = dot_top;
+}
+);
+width = 1017;
+}
+);
+note = uni1594;
+unicode = 5524;
+},
+{
+glyphname = "ng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(453,225,o),
+(495,267,o),
+(495,347,cs),
+(495,378,l),
+(435,378,l),
+(435,340,ls),
+(435,296,o),
+(417,277,o),
+(387,277,cs),
+(356,277,o),
+(340,297,o),
+(340,345,cs),
+(340,510,l),
+(213,510,l),
+(214,482,l),
+(240,496,o),
+(255,540,o),
+(255,588,cs),
+(255,672,o),
+(215,720,o),
+(148,720,cs),
+(82,720,o),
+(41,671,o),
+(41,585,cs),
+(41,500,o),
+(82,449,o),
+(153,449,cs),
+(292,449,l),
+(276,467,l),
+(276,352,ls),
+(276,268,o),
+(317,225,o),
+(386,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(117,498,o),
+(98,525,o),
+(98,585,cs),
+(98,645,o),
+(117,671,o),
+(149,671,cs),
+(180,671,o),
+(197,644,o),
+(197,585,cs),
+(197,525,o),
+(179,498,o),
+(148,498,cs)
+);
+}
+);
+width = 525;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1595;
+unicode = 5525;
+},
+{
+glyphname = "nng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(701,225,o),
+(743,267,o),
+(743,347,cs),
+(743,378,l),
+(683,378,l),
+(683,340,ls),
+(683,296,o),
+(666,277,o),
+(635,277,cs),
+(604,277,o),
+(588,297,o),
+(588,345,cs),
+(588,510,l),
+(463,510,l),
+(463,482,l),
+(489,496,o),
+(503,540,o),
+(503,588,cs),
+(503,674,o),
+(463,720,o),
+(396,720,cs),
+(331,720,o),
+(290,671,o),
+(290,585,cs),
+(290,539,o),
+(304,495,o),
+(330,481,c),
+(331,510,l),
+(214,510,l),
+(214,482,l),
+(240,496,o),
+(255,540,o),
+(255,588,cs),
+(255,672,o),
+(215,720,o),
+(148,720,cs),
+(82,720,o),
+(41,671,o),
+(41,585,cs),
+(41,500,o),
+(82,449,o),
+(153,449,cs),
+(524,449,l),
+(524,352,ls),
+(524,268,o),
+(565,225,o),
+(635,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(117,498,o),
+(98,525,o),
+(98,585,cs),
+(98,645,o),
+(117,671,o),
+(149,671,cs),
+(180,671,o),
+(197,644,o),
+(197,585,cs),
+(197,525,o),
+(179,498,o),
+(148,498,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(366,498,o),
+(347,525,o),
+(347,585,cs),
+(347,645,o),
+(366,671,o),
+(397,671,cs),
+(428,671,o),
+(446,644,o),
+(446,585,cs),
+(446,525,o),
+(427,498,o),
+(397,498,cs)
+);
+}
+);
+width = 773;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1596;
+unicode = 5526;
+},
+{
+glyphname = "sheSayisi-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (557,357);
+},
+{
+name = top_center_can;
+pos = (252,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(446,0,l),
+(446,466,ls),
+(446,633,o),
+(380,727,o),
+(252,727,cs),
+(125,727,o),
+(51,631,o),
+(51,454,cs),
+(51,286,o),
+(109,207,o),
+(191,207,cs),
+(266,207,o),
+(311,261,o),
+(306,426,c),
+(265,426,l),
+(268,308,o),
+(242,284,o),
+(209,284,cs),
+(166,284,o),
+(140,329,o),
+(140,457,cs),
+(140,591,o),
+(179,647,o),
+(249,647,cs),
+(318,647,o),
+(353,591,o),
+(353,462,cs),
+(353.002,0,l)
+);
+}
+);
+width = 504;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1597;
+unicode = 5527;
+},
+{
+glyphname = "shiSayisi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(152,0,l),
+(152,462,ls),
+(152,591,o),
+(187,647,o),
+(256,647,cs),
+(326,647,o),
+(364,591,o),
+(364,457,cs),
+(364,329,o),
+(339,284,o),
+(295,284,cs),
+(263,284,o),
+(236,308,o),
+(240,426,c),
+(199,426,l),
+(194,261,o),
+(239,207,o),
+(314,207,cs),
+(396,207,o),
+(454,286,o),
+(454,455,cs),
+(454,631,o),
+(380,727,o),
+(254,727,cs),
+(125,727,o),
+(58,633,o),
+(58,466,cs),
+(58,0,l)
+);
+}
+);
+width = 505;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni1598;
+unicode = 5528;
+},
+{
+glyphname = "shoSayisi-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (248,714);
+},
+{
+name = top_left_can;
+pos = (95,714);
+},
+{
+name = top_right_can;
+pos = (400,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(380,-13,o),
+(446,81,o),
+(446,248,cs),
+(446,714,l),
+(353.002,714,l),
+(353,252,ls),
+(353,123,o),
+(318,67,o),
+(249,67,cs),
+(179,67,o),
+(140,123,o),
+(140,257,cs),
+(140,385,o),
+(166,430,o),
+(209,430,cs),
+(242,430,o),
+(268,406,o),
+(265,288,c),
+(306,288,l),
+(311,453,o),
+(266,507,o),
+(191,507,cs),
+(109,507,o),
+(51,428,o),
+(51,259,cs),
+(51,83,o),
+(125,-13,o),
+(251,-13,cs)
+);
+}
+);
+width = 504;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1599;
+unicode = 5529;
+},
+{
+glyphname = "shaSayisi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(380,-13,o),
+(454,83,o),
+(454,260,cs),
+(454,428,o),
+(396,507,o),
+(314,507,cs),
+(239,507,o),
+(194,453,o),
+(199,288,c),
+(240,288,l),
+(236,406,o),
+(263,430,o),
+(295,430,cs),
+(339,430,o),
+(364,385,o),
+(364,257,cs),
+(364,123,o),
+(326,67,o),
+(256,67,cs),
+(187,67,o),
+(152,123,o),
+(152,252,cs),
+(152,714,l),
+(58,714,l),
+(58,248,ls),
+(58,81,o),
+(125,-13,o),
+(253,-13,cs)
+);
+}
+);
+width = 505;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni159A;
+unicode = 5530;
+},
+{
+glyphname = "theWoodScree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(553,-13,o),
+(631,74,o),
+(631,241,cs),
+(631,409,o),
+(555,495,o),
+(420,495,cs),
+(54,495,l),
+(54,417,l),
+(316,417,l),
+(311,433,l),
+(261,399,o),
+(236,321,o),
+(236,237,cs),
+(236,74,o),
+(311,-13,o),
+(433,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(365,67,o),
+(327,123,o),
+(327,242,cs),
+(327,355,o),
+(365,416,o),
+(433,416,cs),
+(501,416,o),
+(540,361,o),
+(540,242,cs),
+(540,123,o),
+(502,67,o),
+(433,67,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(622,636,l),
+(622,714,l),
+(54,714,l),
+(54,636,l)
+);
+}
+);
+width = 686;
+}
+);
+note = uni159B;
+unicode = 5531;
+},
+{
+glyphname = "thiWoodScree-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(375,-13,o),
+(450,74,o),
+(450,237,cs),
+(450,321,o),
+(425,399,o),
+(375,434,c),
+(370,417,l),
+(631,417,l),
+(631,495,l),
+(265,495,ls),
+(131,495,o),
+(54,408,o),
+(54,241,cs),
+(54,74,o),
+(132,-13,o),
+(252,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(183,67,o),
+(146,123,o),
+(146,242,cs),
+(146,361,o),
+(184,416,o),
+(252,416,cs),
+(321,416,o),
+(358,355,o),
+(358,242,cs),
+(358,123,o),
+(321,67,o),
+(252,67,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(631,636,l),
+(631,714,l),
+(63,714,l),
+(63,636,l)
+);
+}
+);
+width = 686;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159C;
+unicode = 5532;
+},
+{
+glyphname = "thoWoodScree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(421,0,ls),
+(555,0,o),
+(631,87,o),
+(631,254,cs),
+(631,421,o),
+(554,509,o),
+(433,509,cs),
+(311,509,o),
+(236,421,o),
+(236,258,cs),
+(236,174,o),
+(261,96,o),
+(311,62,c),
+(316,78,l),
+(54,78,l),
+(54,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(365,79,o),
+(327,140,o),
+(327,253,cs),
+(327,372,o),
+(365,428,o),
+(433,428,cs),
+(502,428,o),
+(540,373,o),
+(540,253,cs),
+(540,134,o),
+(501,79,o),
+(433,79,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(622,636,l),
+(622,714,l),
+(54,714,l),
+(54,636,l)
+);
+}
+);
+width = 686;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159D;
+unicode = 5533;
+},
+{
+glyphname = "thaWoodScree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(631,0,l),
+(631,78,l),
+(370,78,l),
+(375,62,l),
+(425,96,o),
+(450,174,o),
+(450,258,cs),
+(450,421,o),
+(375,509,o),
+(252,509,cs),
+(132,509,o),
+(54,421,o),
+(54,254,cs),
+(54,87,o),
+(131,0,o),
+(265.005,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(184,79,o),
+(146,134,o),
+(146,253,cs),
+(146,373,o),
+(183,428,o),
+(252,428,cs),
+(321,428,o),
+(358,372,o),
+(358,253,cs),
+(358,140,o),
+(321,79,o),
+(252,79,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(631,636,l),
+(631,714,l),
+(63,714,l),
+(63,636,l)
+);
+}
+);
+width = 686;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159E;
+unicode = 5534;
+},
+{
+glyphname = "thWoodScree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(366,357,l),
+(366,413,l),
+(221,413,l),
+(224,390,l),
+(250,404,o),
+(265,447,o),
+(265,496,cs),
+(265,579,o),
+(225,628,o),
+(158,628,cs),
+(92,628,o),
+(51,578,o),
+(51,493,cs),
+(51,408,o),
+(92,357,o),
+(163,357,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(127,405,o),
+(108,433,o),
+(108,493,cs),
+(108,553,o),
+(127,579,o),
+(159,579,cs),
+(190,579,o),
+(207,552,o),
+(207,492,cs),
+(207,433,o),
+(189,405,o),
+(158,405,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(360,690,l),
+(360,746,l),
+(55,746,l),
+(55,690,l)
+);
+}
+);
+width = 417;
+}
+);
+metricRight = "=|";
+note = uni159F;
+unicode = 5535;
+},
+{
+glyphname = "lhi-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (377,714);
+},
+{
+name = top_right_can;
+pos = (462,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(307,0,l),
+(307,83,l),
+(291,83,ls),
+(194,83,o),
+(143,138,o),
+(143,245,cs),
+(143,354,o),
+(194,410,o),
+(289,410,cs),
+(628,410,l),
+(628,486,l),
+(479,752,l),
+(407,710,l),
+(556,444,l),
+(556,495,l),
+(285,495,ls),
+(140,495,o),
+(51,408,o),
+(51,246,cs),
+(51,86,o),
+(138,0,o),
+(284,0,cs)
+);
+}
+);
+width = 676;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A0;
+unicode = 5536;
+},
+{
+glyphname = "lhii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "lhi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (307,0);
+ref = dot_top;
+}
+);
+width = 676;
+}
+);
+note = uni15A1;
+unicode = 5537;
+},
+{
+glyphname = "lho-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (332,513);
+},
+{
+name = top_right_can;
+pos = (422,513);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(268,-216,l),
+(120,51,l),
+(119,-1,l),
+(391,-1,ls),
+(536,-1,o),
+(625,86,o),
+(625,248,cs),
+(625,409,o),
+(537,495,o),
+(392,495,cs),
+(368,495,l),
+(368,412,l),
+(384,412,ls),
+(482,412,o),
+(532,356,o),
+(532,250,cs),
+(532,140,o),
+(481,84,o),
+(387,84,cs),
+(48,84,l),
+(48,9,l),
+(196,-259,l)
+);
+}
+);
+width = 676;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni15A2;
+unicode = 5538;
+},
+{
+glyphname = "lhoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "lho-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (353,-201);
+ref = dot_top;
+}
+);
+width = 676;
+}
+);
+note = uni15A3;
+unicode = 5539;
+},
+{
+glyphname = "lha-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (346,513);
+},
+{
+name = top_left_can;
+pos = (254,513);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(628,9,l),
+(628,85,l),
+(289,85,ls),
+(194,85,o),
+(143,140,o),
+(143,250,cs),
+(143,357,o),
+(194,412,o),
+(291,412,cs),
+(307,412,l),
+(307,495,l),
+(284,495,ls),
+(138,495,o),
+(51,409,o),
+(51,249,cs),
+(51,87,o),
+(139.992,0,o),
+(285,0,cs),
+(556,0,l),
+(556,51,l),
+(407,-216,l),
+(479,-258,l)
+);
+}
+);
+width = 676;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A4;
+unicode = 5540;
+},
+{
+glyphname = "lhaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "lha-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (184,-201);
+ref = dot_top;
+}
+);
+width = 676;
+}
+);
+note = uni15A5;
+unicode = 5541;
+},
+{
+glyphname = "lh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(363,363,l),
+(363,418,l),
+(217,418,ls),
+(144,418,o),
+(112,461,o),
+(112,536,cs),
+(112,610,o),
+(144,653,o),
+(207,653,cs),
+(214,653,l),
+(214,714,l),
+(204,714,ls),
+(101,714,o),
+(49,641,o),
+(49,536,cs),
+(49,427,o),
+(101,357,o),
+(216,357,cs),
+(321,357,l),
+(314,393,l),
+(231,244,l),
+(281,215,l)
+);
+}
+);
+width = 412;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni15A6;
+unicode = 5542;
+},
+{
+glyphname = "theThCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (83,714);
+},
+{
+name = top_right_can;
+pos = (373,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(419,0,l),
+(419,108,l),
+(483,108,l),
+(483,164,l),
+(419,164,l),
+(419,334,l),
+(139,334,l),
+(158,304,l),
+(438,674,l),
+(371,726,l),
+(37,282,l),
+(37,251,l),
+(326,251,l),
+(326,164,l),
+(135,164,l),
+(135,108,l),
+(326,108,l),
+(326,0,l)
+);
+}
+);
+width = 514;
+}
+);
+metricLeft = "ye-canadian";
+note = uni15A7;
+unicode = 5543;
+},
+{
+glyphname = "thiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (142,714);
+},
+{
+name = top_right_can;
+pos = (432,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(188,0,l),
+(188,108,l),
+(380,108,l),
+(380,164,l),
+(188,164,l),
+(188,251,l),
+(477,251,l),
+(477,282,l),
+(144,726,l),
+(76,674,l),
+(363,296,l),
+(376,334,l),
+(95,334,l),
+(95,164,l),
+(31,164,l),
+(31,108,l),
+(95,108,l),
+(95,0,l)
+);
+}
+);
+width = 514;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+unicode = 5544;
+},
+{
+glyphname = "thiiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (72,0);
+ref = dot_top;
+}
+);
+width = 514;
+}
+);
+note = uni15A9;
+unicode = 5545;
+},
+{
+glyphname = "thoThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (83,714);
+},
+{
+name = top_right_can;
+pos = (373,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(438,40,l),
+(157,409,l),
+(139,380,l),
+(419,380,l),
+(419,550,l),
+(483,550,l),
+(483,606,l),
+(419,606,l),
+(419,714,l),
+(326,714,l),
+(326,606,l),
+(135,606,l),
+(135,550,l),
+(326,550,l),
+(326,463,l),
+(37,463,l),
+(37,432,l),
+(371,-12,l)
+);
+}
+);
+width = 514;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+unicode = 5546;
+},
+{
+glyphname = "thooThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (303,0);
+ref = dot_top;
+}
+);
+width = 514;
+}
+);
+note = uni15AB;
+unicode = 5547;
+},
+{
+glyphname = "thaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (142,714);
+},
+{
+name = top_right_can;
+pos = (432,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(477,432,l),
+(477,463,l),
+(188,463,l),
+(188,550,l),
+(380,550,l),
+(380,606,l),
+(188,606,l),
+(188,714,l),
+(95,714,l),
+(95,606,l),
+(31,606,l),
+(31,550,l),
+(95,550,l),
+(95,380,l),
+(376,380,l),
+(357,409,l),
+(76,40,l),
+(144,-12,l)
+);
+}
+);
+width = 514;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+unicode = 5548;
+},
+{
+glyphname = "thaaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (72,0);
+ref = dot_top;
+}
+);
+width = 514;
+}
+);
+note = uni15AD;
+unicode = 5549;
+},
+{
+glyphname = "thThCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(274,568,l),
+(274,588,l),
+(135,588,l),
+(135,635,l),
+(224,635,l),
+(224,667,l),
+(135,667,l),
+(135,714,l),
+(71,714,l),
+(71,667,l),
+(38,667,l),
+(38,635,l),
+(71,635,l),
+(71,533,l),
+(220,533,l),
+(206,572,l),
+(66,381,l),
+(114,349,l)
+);
+}
+);
+width = 301;
+}
+);
+metricRight = "y-canadian";
+note = uni15AE;
+unicode = 5550;
+},
+{
+glyphname = "bAivilik-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(380,-13,o),
+(451,84,o),
+(451,250,cs),
+(451,411,o),
+(381,509,o),
+(272,509,cs),
+(205,509,o),
+(158,467,o),
+(147,411,c),
+(155,385,l),
+(155,714,l),
+(62,714,l),
+(62,0,l),
+(147,0,l),
+(147,104,l),
+(143,88,l),
+(158,29,o),
+(202,-13,o),
+(274,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(191,67,o),
+(154,124,o),
+(154,247,cs),
+(154,371,o),
+(192,428,o),
+(257,428,cs),
+(322,428,o),
+(359,371,o),
+(359,247,cs),
+(359,124,o),
+(323,67,o),
+(257,67,cs)
+);
+}
+);
+width = 502;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|ke-canadian";
+note = uni15AF;
+unicode = 5551;
+},
+{
+glyphname = "eBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(155,0,l),
+(155,420,l),
+(181,383,o),
+(221,362,o),
+(268,362,cs),
+(360,362,o),
+(420,440,o),
+(420,545,cs),
+(420,650,o),
+(360,727,o),
+(268,727,cs),
+(217,727,o),
+(175,703,o),
+(151,662,c),
+(151,714,l),
+(62,714,l),
+(62,0,l)
+);
+}
+);
+width = 458;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B0;
+unicode = 5552;
+},
+{
+glyphname = "iBlackfoot-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(240,-13,o),
+(282,11,o),
+(307,52,c),
+(307,0,l),
+(396,0,l),
+(396,714,l),
+(302,714,l),
+(302,294,l),
+(276,331,o),
+(236,352,o),
+(189,352,cs),
+(97,352,o),
+(38,274,o),
+(38,169,cs),
+(38,64,o),
+(97,-13,o),
+(189,-13,cs)
+);
+}
+);
+width = 458;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B1;
+unicode = 5553;
+},
+{
+glyphname = "oBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(360,-13,o),
+(420,64,o),
+(420,169,cs),
+(420,274,o),
+(360,352,o),
+(268,352,cs),
+(221,352,o),
+(181,331,o),
+(155,294,c),
+(155,714,l),
+(62,714,l),
+(62,0,l),
+(151,0,l),
+(151,52,l),
+(175,11,o),
+(217,-13,o),
+(268,-13,cs)
+);
+}
+);
+width = 458;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "eBlackfoot-canadian";
+note = uni15B2;
+unicode = 5554;
+},
+{
+glyphname = "aBlackfoot-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(396,0,l),
+(396,714,l),
+(307,714,l),
+(307,662,l),
+(282,703,o),
+(240,727,o),
+(189,727,cs),
+(97,727,o),
+(38,650,o),
+(38,545,cs),
+(38,440,o),
+(97,362,o),
+(189,362,cs),
+(236,362,o),
+(276,383,o),
+(302,420,c),
+(302,0,l)
+);
+}
+);
+width = 458;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B3;
+unicode = 5555;
+},
+{
+glyphname = "weBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(155,316,l),
+(437,316,l),
+(437,397,l),
+(155,397,l),
+(155,633,l),
+(437,633,l),
+(437,714,l),
+(62,714,l),
+(62,0,l),
+(155,0,l)
+);
+}
+);
+width = 484;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B4;
+unicode = 5556;
+},
+{
+glyphname = "wiBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(422,0,l),
+(422,714,l),
+(329.003,714,l),
+(329,398,l),
+(47,398,l),
+(47,317,l),
+(329,317,l),
+(329,81,l),
+(47,81,l),
+(47,0,l)
+);
+}
+);
+width = 484;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B5;
+unicode = 5557;
+},
+{
+glyphname = "woBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(437,0,l),
+(437,81,l),
+(155,81,l),
+(155,317,l),
+(437,317,l),
+(437,398,l),
+(155,398,l),
+(155,714,l),
+(62,714,l),
+(62,0,l)
+);
+}
+);
+width = 484;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "weBlackfoot-canadian";
+note = uni15B6;
+unicode = 5558;
+},
+{
+glyphname = "waBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(422,0,l),
+(422,714,l),
+(47,714,l),
+(47,633,l),
+(329,633,l),
+(329,397,l),
+(47,397,l),
+(47,316,l),
+(329,316,l),
+(329.003,0,l)
+);
+}
+);
+width = 484;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B7;
+unicode = 5559;
+},
+{
+glyphname = "neBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(155,0,l),
+(155,644,l),
+(201,644,l),
+(172,695,l),
+(172,668,ls),
+(172,505,o),
+(238,414,o),
+(363,414,cs),
+(486,414,o),
+(560,507,o),
+(560,666,cs),
+(560,714,l),
+(468.002,714,l),
+(468,656,ls),
+(468,552,o),
+(433,496,o),
+(365,496,cs),
+(298,496,o),
+(263,551,o),
+(263,655,cs),
+(263,714,l),
+(62,714,l),
+(62,0,l)
+);
+}
+);
+width = 593;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B8;
+unicode = 5560;
+},
+{
+glyphname = "niBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(125,0,l),
+(125,58,ls),
+(125,162,o),
+(160,218,o),
+(228,218,cs),
+(295,218,o),
+(330,163,o),
+(330,59,cs),
+(330,0,l),
+(531,0,l),
+(531,714,l),
+(438,714,l),
+(438,70,l),
+(392,70,l),
+(421,19,l),
+(421,46,ls),
+(421,209,o),
+(355,300,o),
+(230,300,cs),
+(107,300,o),
+(33,207,o),
+(33,48,cs),
+(33,0,l)
+);
+}
+);
+width = 593;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B9;
+unicode = 5561;
+},
+{
+glyphname = "noBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(263,0,l),
+(263,59,ls),
+(263,163,o),
+(298,218,o),
+(365,218,cs),
+(433,218,o),
+(468,162,o),
+(468,58,cs),
+(468.002,0,l),
+(560,0,l),
+(560,48,ls),
+(560,207,o),
+(486,300,o),
+(363,300,cs),
+(238,300,o),
+(172,209,o),
+(172,46,cs),
+(172,19,l),
+(201,70,l),
+(155,70,l),
+(155,714,l),
+(62,714,l),
+(62,0,l)
+);
+}
+);
+width = 593;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "neBlackfoot-canadian";
+note = uni15BA;
+unicode = 5562;
+},
+{
+glyphname = "naBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(531,0,l),
+(531,714,l),
+(330,714,l),
+(330,655,ls),
+(330,551,o),
+(295,496,o),
+(228,496,cs),
+(160,496,o),
+(125,552,o),
+(125,656,cs),
+(125,714,l),
+(33,714,l),
+(33,666,ls),
+(33,507,o),
+(107,414,o),
+(230,414,cs),
+(355,414,o),
+(421,505,o),
+(421,668,cs),
+(421,695,l),
+(392,644,l),
+(438,644,l),
+(438,0,l)
+);
+}
+);
+width = 593;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BB;
+unicode = 5563;
+},
+{
+glyphname = "keBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(155,0,l),
+(155,606,l),
+(122,606,l),
+(268,265,l),
+(311,265,l),
+(505,714,l),
+(412,714,l),
+(264,367,l),
+(297,367,l),
+(149,714,l),
+(62,714,l),
+(62,0,l)
+);
+}
+);
+width = 526;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15BC;
+unicode = 5564;
+},
+{
+glyphname = "kiBlackfoot-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(114,0,l),
+(263,347,l),
+(229,347,l),
+(377,0,l),
+(465,0,l),
+(465,714,l),
+(371,714,l),
+(371,108,l),
+(404,108,l),
+(258,449,l),
+(216,449,l),
+(21,0,l)
+);
+}
+);
+width = 527;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BD;
+unicode = 5565;
+},
+{
+glyphname = "koBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(149,0,l),
+(297,347,l),
+(264,347,l),
+(412,0,l),
+(505,0,l),
+(311,449,l),
+(268,449,l),
+(122,108,l),
+(155,108,l),
+(155,714,l),
+(62,714,l),
+(62,0,l)
+);
+}
+);
+width = 526;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "keBlackfoot-canadian";
+note = uni15BE;
+unicode = 5566;
+},
+{
+glyphname = "kaBlackfoot-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(465,0,l),
+(465,714,l),
+(377,714,l),
+(229,367,l),
+(263,367,l),
+(114,714,l),
+(21,714,l),
+(216,265,l),
+(258,265,l),
+(404,606,l),
+(371,606,l),
+(371,0,l)
+);
+}
+);
+width = 527;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BF;
+unicode = 5567;
+},
+{
+color = 9;
+glyphname = "heSayisi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_right_can;
+pos = (456,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(502,0,l),
+(502,714,l),
+(410,714,l),
+(410,313,l),
+(425,313,l),
+(421,573,o),
+(343,727,o),
+(216,727,cs),
+(107,727,o),
+(44,640,o),
+(44,467,cs),
+(44,431,o),
+(47,386,o),
+(55,348,c),
+(143,348,l),
+(137,382,o),
+(134,428,o),
+(134,455,cs),
+(134,592,o),
+(173,645,o),
+(237,645,cs),
+(342,645,o),
+(407,469,o),
+(409,0,c)
+);
+}
+);
+width = 564;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni15C0;
+unicode = 5568;
+},
+{
+color = 9;
+glyphname = "hiSayisi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(155,0,l),
+(157,469,o),
+(222,645,o),
+(327,645,cs),
+(391,645,o),
+(430,592,o),
+(430,455,cs),
+(430,428,o),
+(427,382,o),
+(421,348,c),
+(509,348,l),
+(517,386,o),
+(520,431,o),
+(520,467,cs),
+(520,640,o),
+(457,727,o),
+(348,727,cs),
+(221,727,o),
+(144,573,o),
+(139,313,c),
+(154,313,l),
+(154,714,l),
+(62,714,l),
+(62,0,l)
+);
+}
+);
+width = 564;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C1;
+unicode = 5569;
+},
+{
+color = 9;
+glyphname = "hoSayisi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (277,714);
+},
+{
+name = top_left_can;
+pos = (98,714);
+},
+{
+name = top_right_can;
+pos = (457,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(343,-13,o),
+(421,141,o),
+(425,401,c),
+(410,401,l),
+(410,0,l),
+(502,0,l),
+(502,714,l),
+(409,714,l),
+(407,245,o),
+(342,69,o),
+(237,69,cs),
+(173,69,o),
+(134,122,o),
+(134,259,cs),
+(134,286,o),
+(137,332,o),
+(143,366,c),
+(55,366,l),
+(47,328,o),
+(44,283,o),
+(44,247,cs),
+(44,74,o),
+(107,-13,o),
+(216,-13,cs)
+);
+}
+);
+width = 564;
+}
+);
+metricLeft = "heSayisi-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15C2;
+unicode = 5570;
+},
+{
+color = 9;
+glyphname = "haSayisi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(457,-13,o),
+(520,74,o),
+(520,247,cs),
+(520,283,o),
+(517,328,o),
+(509,366,c),
+(421,366,l),
+(427,332,o),
+(430,286,o),
+(430,259,cs),
+(430,122,o),
+(391,69,o),
+(327,69,cs),
+(222,69,o),
+(157,245,o),
+(155,714,c),
+(62,714,l),
+(62,0,l),
+(154,0,l),
+(154,401,l),
+(139,401,l),
+(144,141,o),
+(221,-13,o),
+(348,-13,cs)
+);
+}
+);
+width = 564;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C3;
+unicode = 5571;
+},
+{
+color = 9;
+glyphname = "ghuCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(314,0,l),
+(571,688,l),
+(571,714,l),
+(495,714,l),
+(411,482,l),
+(459,498,l),
+(139,498,l),
+(188,480,l),
+(103,714,l),
+(26,714,l),
+(26,688,l),
+(283,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(437,428,l),
+(400,440,l),
+(284,117,l),
+(314,117,l),
+(198,442,l),
+(162,428,l)
+);
+}
+);
+width = 597;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C4;
+unicode = 5572;
+},
+{
+color = 9;
+glyphname = "ghoCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(103,0,l),
+(188,234,l),
+(139,216,l),
+(459,216,l),
+(411,232,l),
+(495,0,l),
+(571,0,l),
+(571,26,l),
+(314,714,l),
+(283,714,l),
+(26,26,l),
+(26,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(314,597,l),
+(284,597,l),
+(400,274,l),
+(437,286,l),
+(162,286,l),
+(198,272,l)
+);
+}
+);
+width = 597;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C5;
+unicode = 5573;
+},
+{
+color = 9;
+glyphname = "gheCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (63,357);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(66,0,l),
+(514,340,l),
+(514,374,l),
+(66,714,l),
+(42,714,l),
+(42,638,l),
+(174,537,l),
+(166,582,l),
+(166,129,l),
+(174,176,l),
+(42,75,l),
+(42,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(232,545,l),
+(215,516,l),
+(453,333,l),
+(453,381,l),
+(215,200,l),
+(232,170,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15C6;
+unicode = 5574;
+},
+{
+color = 9;
+glyphname = "gheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (24,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 545;
+}
+);
+note = uni15C7;
+unicode = 5575;
+},
+{
+color = 9;
+glyphname = "ghiCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (2,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 545;
+}
+);
+note = uni15C8;
+unicode = 5576;
+},
+{
+color = 9;
+glyphname = "ghaCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(503,0,l),
+(503,75,l),
+(372,176,l),
+(380,137,l),
+(380,577,l),
+(372,537,l),
+(503,638,l),
+(503,714,l),
+(479,714,l),
+(30,374,l),
+(30,340,l),
+(479,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(330,198,l),
+(92,381,l),
+(92,332,l),
+(330,515,l),
+(314,529,l),
+(314,190,l)
+);
+}
+);
+width = 545;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15C9;
+unicode = 5577;
+},
+{
+color = 9;
+glyphname = "ruCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(314,0,l),
+(571,688,l),
+(571,714,l),
+(496,714,l),
+(461,619,l),
+(485,634,l),
+(112,634,l),
+(139,619,l),
+(104,714,l),
+(26,714,l),
+(26,688,l),
+(283,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(465,564,l),
+(452,582,l),
+(286,118,l),
+(316,118,l),
+(150,582,l),
+(132,564,l)
+);
+}
+);
+width = 597;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CA;
+unicode = 5578;
+},
+{
+color = 9;
+glyphname = "roCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(104,0,l),
+(138,95,l),
+(113,80,l),
+(486,80,l),
+(460,95,l),
+(495,0,l),
+(571,0,l),
+(571,26,l),
+(314,714,l),
+(283,714,l),
+(26,26,l),
+(26,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(314,597,l),
+(283,597,l),
+(450,132,l),
+(467,150,l),
+(134,150,l),
+(148,132,l)
+);
+}
+);
+width = 597;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CB;
+unicode = 5579;
+},
+{
+color = 9;
+glyphname = "reCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(66,0,l),
+(514,340,l),
+(514,374,l),
+(66,714,l),
+(42,714,l),
+(42,636,l),
+(108,585,l),
+(97,612,l),
+(97,101,l),
+(108,129,l),
+(42,77,l),
+(42,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(164,590,l),
+(152,559,l),
+(447,332,l),
+(447,381,l),
+(152,155,l),
+(164,122,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CC;
+unicode = 5580;
+},
+{
+color = 9;
+glyphname = "reeCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(66,0,l),
+(514,340,l),
+(514,374,l),
+(66,714,l),
+(42,714,l),
+(42,647,l),
+(108,595,l),
+(97,613,l),
+(97,100,l),
+(108,118,l),
+(42,67,l),
+(42,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(156,590,l),
+(146,574,l),
+(462,332,l),
+(462,381,l),
+(145,138,l),
+(156,124,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(241,272,l),
+(241,443,l),
+(206,443,l),
+(206,272,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CD;
+unicode = 5581;
+},
+{
+color = 9;
+glyphname = "riCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(66,0,l),
+(514,340,l),
+(514,374,l),
+(66,714,l),
+(42,714,l),
+(42,647,l),
+(108,595,l),
+(97,613,l),
+(97,100,l),
+(108,118,l),
+(42,67,l),
+(42,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(260,318,o),
+(278,335,o),
+(278,357,cs),
+(278,379,o),
+(260,396,o),
+(238,396,cs),
+(218,396,o),
+(200,379,o),
+(200,357,cs),
+(200,335,o),
+(218,318,o),
+(238,318,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(156,590,l),
+(146,574,l),
+(462,332,l),
+(462,381,l),
+(145,138,l),
+(156,124,l)
+);
+}
+);
+width = 544;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CE;
+unicode = 5582;
+},
+{
+color = 9;
+glyphname = "raCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(503,0,l),
+(503,78,l),
+(437,129,l),
+(448,81,l),
+(448,634,l),
+(437,585,l),
+(503,637,l),
+(503,714,l),
+(479,714,l),
+(30,374,l),
+(30,340,l),
+(479,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(393,560,l),
+(381,592,l),
+(381,123,l),
+(393,155,l),
+(98,382,l),
+(98,333,l)
+);
+}
+);
+width = 545;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15CF;
+unicode = 5583;
+},
+{
+color = 9;
+glyphname = "wuCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(318,0,l),
+(580,688,l),
+(580,714,l),
+(509,714,l),
+(321,178,l),
+(341,178,l),
+(341,714,l),
+(271,714,l),
+(271,178,l),
+(291,178,l),
+(101,714,l),
+(26,714,l),
+(26,688,l),
+(287,0,l)
+);
+}
+);
+width = 606;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D0;
+unicode = 5584;
+},
+{
+color = 9;
+glyphname = "woCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,0,l),
+(289,536,l),
+(268,536,l),
+(268,0,l),
+(339,0,l),
+(339,536,l),
+(318,536,l),
+(508,0,l),
+(580,0,l),
+(580,26,l),
+(318,714,l),
+(287,714,l),
+(26,26,l),
+(26,0,l)
+);
+}
+);
+width = 606;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D1;
+unicode = 5585;
+},
+{
+color = 9;
+glyphname = "weCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(84,0,l),
+(533,340,l),
+(533,374,l),
+(84,714,l),
+(60,714,l),
+(60,638,l),
+(404,377,l),
+(404,393,l),
+(65,393,l),
+(65,321,l),
+(405,321,l),
+(405,336,l),
+(60,75,l),
+(60,0,l)
+);
+}
+);
+width = 563;
+}
+);
+metricRight = "o-canadian";
+note = uni15D2;
+unicode = 5586;
+},
+{
+color = 9;
+glyphname = "weeCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(84,0,l),
+(533,340,l),
+(533,374,l),
+(84,714,l),
+(60,714,l),
+(60,643,l),
+(434,363,l),
+(441,387,l),
+(182,387,l),
+(182,460,l),
+(131,460,l),
+(131,387,l),
+(60,387,l),
+(60,328,l),
+(131,328,l),
+(131,255,l),
+(182,255,l),
+(182,328,l),
+(442,328,l),
+(435,351,l),
+(60,70,l),
+(60,0,l)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D3;
+unicode = 5587;
+},
+{
+color = 9;
+glyphname = "wiCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(84,0,l),
+(533,340,l),
+(533,374,l),
+(84,714,l),
+(60,714,l),
+(60,643,l),
+(434,363,l),
+(441,387,l),
+(237,387,l),
+(227,409,o),
+(205,424,o),
+(179,424,cs),
+(153,424,o),
+(130,409,o),
+(120,387,c),
+(60,387,l),
+(60,328,l),
+(120,328,l),
+(130,306,o),
+(153,290,o),
+(179,290,cs),
+(204,290,o),
+(227,306,o),
+(237,328,c),
+(442,328,l),
+(435,351,l),
+(60,70,l),
+(60,0,l)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D4;
+unicode = 5588;
+},
+{
+color = 9;
+glyphname = "waCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(503,0,l),
+(503,76,l),
+(159,336,l),
+(159,321,l),
+(499,321,l),
+(499,393,l),
+(159,393,l),
+(159,377,l),
+(503,638,l),
+(503,714,l),
+(480,714,l),
+(30,374,l),
+(30,340,l),
+(479,0,l)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15D5;
+unicode = 5589;
+},
+{
+color = 9;
+glyphname = "hwuCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(318,0,l),
+(580,688,l),
+(580,714,l),
+(513,714,l),
+(435,500,l),
+(460,509,l),
+(332,509,l),
+(332,714,l),
+(275,714,l),
+(275,509,l),
+(143,509,l),
+(172,501,l),
+(95,714,l),
+(26,714,l),
+(26,688,l),
+(287,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(279,457,l),
+(279,146,l),
+(294,148,l),
+(182,465,l),
+(150,457,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(328,457,l),
+(454,457,l),
+(426,465,l),
+(314,150,l),
+(328,147,l)
+);
+}
+);
+width = 606;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D6;
+unicode = 5590;
+},
+{
+color = 9;
+glyphname = "hwoCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(95,0,l),
+(173,214,l),
+(149,201,l),
+(274,201,l),
+(274,0,l),
+(331,0,l),
+(331,201,l),
+(467,201,l),
+(435,213,l),
+(512,0,l),
+(580,0,l),
+(580,26,l),
+(318,714,l),
+(287,714,l),
+(26,26,l),
+(26,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(292,562,l),
+(278,565,l),
+(278,261,l),
+(168,261,l),
+(181,249,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(447,261,l),
+(327,261,l),
+(327,566,l),
+(313,564,l),
+(425,249,l)
+);
+}
+);
+width = 606;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D7;
+unicode = 5591;
+},
+{
+color = 9;
+glyphname = "hweCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(84,0,l),
+(533,340,l),
+(533,374,l),
+(84,714,l),
+(60,714,l),
+(60,643,l),
+(179,554,l),
+(179,388,l),
+(60,388,l),
+(60,326,l),
+(179,326,l),
+(179,159,l),
+(60,69,l),
+(60,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(228,332,l),
+(420,332,l),
+(228,187,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(228,526,l),
+(419,383,l),
+(228,383,l)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D8;
+unicode = 5592;
+},
+{
+color = 9;
+glyphname = "hweeCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(84,0,l),
+(533,340,l),
+(533,374,l),
+(84,714,l),
+(60,714,l),
+(60,647,l),
+(202,542,l),
+(202,384,l),
+(158,384,l),
+(158,459,l),
+(115,459,l),
+(115,384,l),
+(60,384,l),
+(60,331,l),
+(115,331,l),
+(115,256,l),
+(158,256,l),
+(158,331,l),
+(202,331,l),
+(202,172,l),
+(60,65,l),
+(60,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(247,335,l),
+(423,335,l),
+(247,198,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(247,515,l),
+(422,380,l),
+(247,380,l)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D9;
+unicode = 5593;
+},
+{
+color = 9;
+glyphname = "hwiCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(84,0,l),
+(533,340,l),
+(533,374,l),
+(84,714,l),
+(60,714,l),
+(60,647,l),
+(202,542,l),
+(202,380,l),
+(184,380,l),
+(176,400,o),
+(158,414,o),
+(136,414,cs),
+(114,414,o),
+(96,400,o),
+(88,380,c),
+(60,380,l),
+(60,335,l),
+(87,335,l),
+(95,315,o),
+(114,301,o),
+(136,301,cs),
+(157,301,o),
+(176,315,o),
+(184,335,c),
+(202,335,l),
+(202,172,l),
+(60,65,l),
+(60,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(247,335,l),
+(423,335,l),
+(247,198,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(247,515,l),
+(422,380,l),
+(247,380,l)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15DA;
+unicode = 5594;
+},
+{
+color = 9;
+glyphname = "hwaCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(503,0,l),
+(503,70,l),
+(385,159,l),
+(385,326,l),
+(503,326,l),
+(503,388,l),
+(385,388,l),
+(385,554,l),
+(503,644,l),
+(503,714,l),
+(480,714,l),
+(30,374,l),
+(30,340,l),
+(479,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(144,331,l),
+(335,331,l),
+(335,187,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(335,526,l),
+(335,382,l),
+(144,382,l)
+);
+}
+);
+width = 563;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15DB;
+unicode = 5595;
+},
+{
+color = 9;
+glyphname = "thuCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(455,-13,o),
+(544,81,o),
+(544,262,cs),
+(544,714,l),
+(58,714,l),
+(58,260,ls),
+(58,81,o),
+(150,-13,o),
+(301,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(151,630,l),
+(451,630,l),
+(451,262,ls),
+(451,131,o),
+(397,74,o),
+(301,74,cs),
+(207,74,o),
+(151,134,o),
+(151,262,cs)
+);
+}
+);
+width = 602;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DC;
+unicode = 5596;
+},
+{
+color = 9;
+glyphname = "thoCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(544,0,l),
+(544,454,ls),
+(544,633,o),
+(452,727,o),
+(301,727,cs),
+(147,727,o),
+(58,633,o),
+(58,452,cs),
+(58,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(151,452,ls),
+(151,582,o),
+(205,640,o),
+(301,640,cs),
+(395,640,o),
+(451,580,o),
+(451,452,cs),
+(451,84,l),
+(151,84,l)
+);
+}
+);
+width = 602;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DD;
+unicode = 5597;
+},
+{
+color = 9;
+glyphname = "theCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (294,357);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(225,0,ls),
+(431,0,o),
+(537,124,o),
+(537,358,cs),
+(537,592,o),
+(431,714,o),
+(222,714,cs),
+(62,714,l),
+(62,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(155,659,l),
+(127,631,l),
+(222,631,ls),
+(376,631,o),
+(444,544,o),
+(444,358,cs),
+(444,173,o),
+(376,83,o),
+(225,83,cs),
+(127,83,l),
+(155,55,l)
+);
+}
+);
+width = 588;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "to-canadian";
+note = uni15DE;
+unicode = 5598;
+},
+{
+color = 9;
+glyphname = "theeCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (248,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 588;
+}
+);
+note = uni15DF;
+unicode = 5599;
+},
+{
+color = 9;
+glyphname = "thiCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (224,0);
+ref = dot_middle;
+}
+);
+width = 588;
+}
+);
+note = uni15E0;
+unicode = 5600;
+},
+{
+color = 9;
+glyphname = "thaCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(526,0,l),
+(526,714,l),
+(363,714,ls),
+(157,714,o),
+(51,590,o),
+(51,356,cs),
+(51,122,o),
+(157,0,o),
+(366,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(144,541,o),
+(211,631,o),
+(362,631,cs),
+(461,631,l),
+(433,659,l),
+(433,55,l),
+(461,83,l),
+(365,83,ls),
+(211,83,o),
+(144,170,o),
+(144,356,cs)
+);
+}
+);
+width = 588;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15E1;
+unicode = 5601;
+},
+{
+color = 9;
+glyphname = "ttuCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(455,-13,o),
+(544,81,o),
+(544,262,cs),
+(544,714,l),
+(513,714,l),
+(289,524,l),
+(314,524,l),
+(90,714,l),
+(58,714,l),
+(58,260,ls),
+(58,81,o),
+(150,-13,o),
+(301,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(207,74,o),
+(151,134,o),
+(151,262,cs),
+(151,641,l),
+(69,637,l),
+(292,448,l),
+(311,448,l),
+(534,637,l),
+(451,641,l),
+(451,262,ls),
+(451,131,o),
+(397,74,o),
+(301,74,cs)
+);
+}
+);
+width = 602;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E2;
+unicode = 5602;
+},
+{
+color = 9;
+glyphname = "ttoCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(89,0,l),
+(313,190,l),
+(288,190,l),
+(512,0,l),
+(544,0,l),
+(544,454,ls),
+(544,633,o),
+(452,727,o),
+(301,727,cs),
+(147,727,o),
+(58,633,o),
+(58,452,cs),
+(58,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(395,640,o),
+(451,580,o),
+(451,452,cs),
+(451,73,l),
+(533,77,l),
+(310,266,l),
+(291,266,l),
+(68,77,l),
+(151,73,l),
+(151,452,ls),
+(151,583,o),
+(205,640,o),
+(301,640,cs)
+);
+}
+);
+width = 602;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E3;
+unicode = 5603;
+},
+{
+color = 9;
+glyphname = "tteCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (339,357);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(235,0,ls),
+(441,0,o),
+(547,124,o),
+(547,358,cs),
+(547,592,o),
+(441,714,o),
+(232,714,cs),
+(57,714,l),
+(57,688,l),
+(160,343,l),
+(160,371,l),
+(57,26,l),
+(57,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(245,347,l),
+(245,364,l),
+(142,706,l),
+(142,631,l),
+(233,631,ls),
+(387,631,o),
+(454,544,o),
+(454,358,cs),
+(454,173,o),
+(387,83,o),
+(236,83,cs),
+(142,83,l),
+(142,5,l)
+);
+}
+);
+width = 598;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15E4;
+unicode = 5604;
+},
+{
+color = 9;
+glyphname = "tteeCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (300,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 598;
+}
+);
+note = uni15E5;
+unicode = 5605;
+},
+{
+color = 9;
+glyphname = "ttiCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (287,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 598;
+}
+);
+note = uni15E6;
+unicode = 5606;
+},
+{
+color = 9;
+glyphname = "ttaCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(541,0,l),
+(541,26,l),
+(438,371,l),
+(438,343,l),
+(541,688,l),
+(541,714,l),
+(363,714,ls),
+(157,714,o),
+(51,590,o),
+(51,356,cs),
+(51,122,o),
+(157,0,o),
+(366,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(456,83,l),
+(365,83,ls),
+(211,83,o),
+(144,170,o),
+(144,356,cs),
+(144,541,o),
+(211,631,o),
+(362,631,cs),
+(456,631,l),
+(456,709,l),
+(353,367,l),
+(353,350,l),
+(456,8,l)
+);
+}
+);
+width = 598;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tteCarrier-canadian";
+note = uni15E7;
+unicode = 5607;
+},
+{
+color = 9;
+glyphname = "puCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(455,-13,o),
+(544,81,o),
+(544,262,cs),
+(544,714,l),
+(450,714,l),
+(450,546,l),
+(152,546,l),
+(152,714,l),
+(58,714,l),
+(58,260,ls),
+(58,81,o),
+(150,-13,o),
+(301,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(207,74,o),
+(152,134,o),
+(152,262,cs),
+(152,463,l),
+(450,463,l),
+(450,262,ls),
+(450,131,o),
+(397,74,o),
+(301,74,cs)
+);
+}
+);
+width = 602;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E8;
+unicode = 5608;
+},
+{
+color = 9;
+glyphname = "poCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(152,0,l),
+(152,168,l),
+(450,168,l),
+(450,0,l),
+(544,0,l),
+(544,454,ls),
+(544,633,o),
+(453,727,o),
+(301,727,cs),
+(151,727,o),
+(58,633,o),
+(58,452,cs),
+(58,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(152,452,ls),
+(152,582,o),
+(205,640,o),
+(301,640,cs),
+(395,640,o),
+(450,580,o),
+(450,452,cs),
+(450,251,l),
+(152,251,l)
+);
+}
+);
+width = 602;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E9;
+unicode = 5609;
+},
+{
+color = 9;
+glyphname = "peCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (327,357);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(233,0,ls),
+(439,0,o),
+(545,124,o),
+(545,358,cs),
+(545,592,o),
+(439,714,o),
+(229,714,cs),
+(55,714,l),
+(55,631,l),
+(126,631,l),
+(126,83,l),
+(55,83,l),
+(55,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(218,659,l),
+(178,631,l),
+(230,631,ls),
+(384,631,o),
+(451,544,o),
+(451,358,cs),
+(451,173,o),
+(384,83,o),
+(233,83,cs),
+(178,83,l),
+(218,55,l)
+);
+}
+);
+width = 596;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15EA;
+unicode = 5610;
+},
+{
+color = 9;
+glyphname = "peeCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (288,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 595;
+}
+);
+note = uni15EB;
+unicode = 5611;
+},
+{
+color = 9;
+glyphname = "piCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (275,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 595;
+}
+);
+note = uni15EC;
+unicode = 5612;
+},
+{
+color = 9;
+glyphname = "paCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(541,0,l),
+(541,83,l),
+(470,83,l),
+(470,631,l),
+(541,631,l),
+(541,714,l),
+(366,714,ls),
+(157,714,o),
+(51,592,o),
+(51,358,cs),
+(51,124,o),
+(157,0,o),
+(363,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(417,83,l),
+(362,83,ls),
+(211,83,o),
+(144,173,o),
+(144,358,cs),
+(144,544,o),
+(211,631,o),
+(365,631,cs),
+(417,631,l),
+(377,659,l),
+(377,55,l)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|peCarrier-canadian";
+note = uni15ED;
+unicode = 5613;
+},
+{
+color = 6;
+glyphname = "pCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(320,189,l),
+(320,250,l),
+(217,250,l),
+(217,546,l),
+(154,546,l),
+(154,250,l),
+(51,250,l),
+(51,189,l)
+);
+}
+);
+width = 371;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni15EE;
+unicode = 5614;
+},
+{
+color = 9;
+glyphname = "guCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (355,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(300,-13,o),
+(353,31,o),
+(375,120,c),
+(335,120,l),
+(361,30,o),
+(413,-13,o),
+(487,-13,cs),
+(588,-13,o),
+(653,57,o),
+(653,187,cs),
+(653,714,l),
+(563,714,l),
+(563,192,ls),
+(563,110,o),
+(534,72,o),
+(482,72,cs),
+(430,72,o),
+(399,111,o),
+(399,192,cs),
+(399,714,l),
+(312,714,l),
+(312,192,ls),
+(312,110,o),
+(281,72,o),
+(229,72,cs),
+(175,72,o),
+(146,110,o),
+(146,192,cs),
+(146,714,l),
+(57,714,l),
+(57,189,ls),
+(57,57,o),
+(123,-13,o),
+(223,-13,cs)
+);
+}
+);
+width = 710;
+}
+);
+metricRight = "=|";
+note = uni15EF;
+unicode = 5615;
+},
+{
+color = 9;
+glyphname = "goCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(146,0,l),
+(146,522,ls),
+(146,604,o),
+(175,642,o),
+(228,642,cs),
+(279,642,o),
+(311,603,o),
+(311,522,cs),
+(311,0,l),
+(398,0,l),
+(398,522,ls),
+(398,604,o),
+(428,642,o),
+(480,642,cs),
+(534,642,o),
+(563,604,o),
+(563,522,cs),
+(563,0,l),
+(653,0,l),
+(653,525,ls),
+(653,657,o),
+(586,727,o),
+(486,727,cs),
+(410,727,o),
+(357,683,o),
+(334,594,c),
+(375,594,l),
+(349,684,o),
+(296,727,o),
+(222,727,cs),
+(122,727,o),
+(57,657,o),
+(57,526,cs),
+(57,0,l)
+);
+}
+);
+width = 710;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F0;
+unicode = 5616;
+},
+{
+color = 9;
+glyphname = "geCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (300,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(333,0,ls),
+(461,0,o),
+(537,68,o),
+(537,192,cs),
+(537,277,o),
+(490,345,o),
+(417,372,c),
+(417,343,l),
+(492,366,o),
+(537,431,o),
+(537,520,cs),
+(537,645,o),
+(460,714,o),
+(333,714,cs),
+(62,714,l),
+(62,636,l),
+(316,636,ls),
+(396,636,o),
+(444,599,o),
+(444,517,cs),
+(444,436,o),
+(396,396,o),
+(317,396,cs),
+(62,396,l),
+(62,319,l),
+(318,319,ls),
+(395,319,o),
+(444,278,o),
+(444,196,cs),
+(444,115,o),
+(396,78,o),
+(316,78,cs),
+(62,78,l),
+(62,0,l)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15F1;
+unicode = 5617;
+},
+{
+color = 9;
+glyphname = "geeCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(333,0,ls),
+(461,0,o),
+(537,68,o),
+(537,192,cs),
+(537,277,o),
+(490,345,o),
+(417,372,c),
+(417,343,l),
+(492,366,o),
+(537,431,o),
+(537,520,cs),
+(537,645,o),
+(460,714,o),
+(333,714,cs),
+(62,714,l),
+(62,636,l),
+(316,636,ls),
+(396,636,o),
+(444,599,o),
+(444,517,cs),
+(444,436,o),
+(396,395,o),
+(317,395,cs),
+(286,395,l),
+(286,479,l),
+(234,479,l),
+(234,395,l),
+(62,395,l),
+(62,320,l),
+(234,320,l),
+(234,237,l),
+(286,237,l),
+(286,320,l),
+(318,320,ls),
+(395,320,o),
+(444,278,o),
+(444,196,cs),
+(444,115,o),
+(396,78,o),
+(316,78,cs),
+(62,78,l),
+(62,0,l)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F2;
+unicode = 5618;
+},
+{
+color = 9;
+glyphname = "giCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(333,0,ls),
+(461,0,o),
+(537,68,o),
+(537,192,cs),
+(537,277,o),
+(490,345,o),
+(417,371,c),
+(417,343,l),
+(492,367,o),
+(537,431,o),
+(537,520,cs),
+(537,645,o),
+(460,714,o),
+(333,714,cs),
+(62,714,l),
+(62,636,l),
+(316,636,ls),
+(396,636,o),
+(444,599,o),
+(444,517,cs),
+(444,436,o),
+(396,395,o),
+(325,395,cs),
+(301,395,l),
+(333,383,l),
+(323,412,o),
+(297,432,o),
+(265,432,cs),
+(238,432,o),
+(215,417,o),
+(203,395,c),
+(62,395,l),
+(62,320,l),
+(203,320,l),
+(214,297,o),
+(238,282,o),
+(265,282,cs),
+(297,282,o),
+(323,303,o),
+(333,332,c),
+(301,320,l),
+(326,320,ls),
+(395,320,o),
+(444,278,o),
+(444,196,cs),
+(444,115,o),
+(396,78,o),
+(316,78,cs),
+(62,78,l),
+(62,0,l)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F3;
+unicode = 5619;
+},
+{
+color = 9;
+glyphname = "gaCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (312,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(535,0,l),
+(535,78,l),
+(280,78,ls),
+(201,78,o),
+(152,115,o),
+(152,196,cs),
+(152,278,o),
+(202,319,o),
+(279,319,cs),
+(535,319,l),
+(535,396,l),
+(279,396,ls),
+(200,396,o),
+(152,436,o),
+(152,517,cs),
+(152,599,o),
+(200,636,o),
+(280,636,cs),
+(535,636,l),
+(535,714,l),
+(263,714,ls),
+(137,714,o),
+(59,645,o),
+(59,520,cs),
+(59,431,o),
+(104,367,o),
+(180,343,c),
+(180,372,l),
+(106,345,o),
+(59,277,o),
+(59,192,cs),
+(59,68,o),
+(135,0,o),
+(263,0,cs)
+);
+}
+);
+width = 597;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|geCarrier-canadian";
+note = uni15F4;
+unicode = 5620;
+},
+{
+color = 9;
+glyphname = "khuCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(301,-13,o),
+(353,31,o),
+(376,120,c),
+(335,120,l),
+(362,30,o),
+(414,-13,o),
+(488,-13,cs),
+(588,-13,o),
+(653,57,o),
+(653,187,cs),
+(653,714,l),
+(57,714,l),
+(57,189,ls),
+(57,57,o),
+(123,-13,o),
+(223,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(176,72,o),
+(147,110,o),
+(147,192,cs),
+(147,632,l),
+(313,632,l),
+(313,192,ls),
+(313,110,o),
+(283,72,o),
+(230,72,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(430,72,o),
+(399,111,o),
+(399,192,cs),
+(399,632,l),
+(563,632,l),
+(563,192,ls),
+(563,110,o),
+(534,72,o),
+(482,72,cs)
+);
+}
+);
+width = 710;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F5;
+unicode = 5621;
+},
+{
+color = 9;
+glyphname = "khoCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(653,0,l),
+(653,525,ls),
+(653,657,o),
+(586,727,o),
+(486,727,cs),
+(409,727,o),
+(356,683,o),
+(334,594,c),
+(374,594,l),
+(348,684,o),
+(296,727,o),
+(222,727,cs),
+(121,727,o),
+(57,657,o),
+(57,526,cs),
+(57,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(146,522,ls),
+(146,604,o),
+(176,642,o),
+(228,642,cs),
+(280,642,o),
+(311,603,o),
+(311,522,cs),
+(311,82,l),
+(146,82,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(396,522,ls),
+(396,604,o),
+(427,642,o),
+(480,642,cs),
+(533,642,o),
+(563,604,o),
+(563,522,cs),
+(563,82,l),
+(396,82,l)
+);
+}
+);
+width = 710;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F6;
+unicode = 5622;
+},
+{
+color = 9;
+glyphname = "kheCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(337,0,ls),
+(465,0,o),
+(541,68,o),
+(541,192,cs),
+(541,277,o),
+(494,345,o),
+(420,372,c),
+(420,343,l),
+(496,366,o),
+(541,431,o),
+(541,520,cs),
+(541,645,o),
+(463,714,o),
+(337,714,cs),
+(62,714,l),
+(62,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(154,319,l),
+(321,319,ls),
+(398,319,o),
+(447,278,o),
+(447,196,cs),
+(447,115,o),
+(399,77,o),
+(320,77,cs),
+(154,77,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(154,637,l),
+(320,637,ls),
+(400,637,o),
+(447,599,o),
+(447,517,cs),
+(447,436,o),
+(399,395,o),
+(321,395,cs),
+(154,395,l)
+);
+}
+);
+width = 600;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F7;
+unicode = 5623;
+},
+{
+color = 9;
+glyphname = "kheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(337,0,ls),
+(465,0,o),
+(541,68,o),
+(541,192,cs),
+(541,278,o),
+(494,344,o),
+(418,368,c),
+(418,345,l),
+(495,365,o),
+(541,430,o),
+(541,520,cs),
+(541,645,o),
+(463,714,o),
+(337,714,cs),
+(62,714,l),
+(62,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(154,320,l),
+(262,320,l),
+(262,232,l),
+(314,232,l),
+(314,342,l),
+(282,320,l),
+(329,320,ls),
+(402,320,o),
+(447,278,o),
+(447,196,cs),
+(447,115,o),
+(399,77,o),
+(320,77,cs),
+(154,77,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(314,484,l),
+(262,484,l),
+(262,395,l),
+(154,395,l),
+(154,637,l),
+(320,637,ls),
+(400,637,o),
+(447,599,o),
+(447,517,cs),
+(447,436,o),
+(403,395,o),
+(329,395,cs),
+(282,395,l),
+(314,373,l)
+);
+}
+);
+width = 600;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F8;
+unicode = 5624;
+},
+{
+color = 9;
+glyphname = "khiCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(337,0,ls),
+(465,0,o),
+(541,68,o),
+(541,192,cs),
+(541,277,o),
+(495,343,o),
+(422,370,c),
+(422,343,l),
+(496,367,o),
+(541,431,o),
+(541,520,cs),
+(541,645,o),
+(463,714,o),
+(337,714,cs),
+(62,714,l),
+(62,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(154,324,l),
+(222,324,l),
+(233,299,o),
+(258,282,o),
+(286,282,cs),
+(324,282,o),
+(353,313,o),
+(357,351,c),
+(307,324,l),
+(333,324,ls),
+(402,324,o),
+(447,281,o),
+(447,198,cs),
+(447,114,o),
+(399,77,o),
+(320,77,cs),
+(154,77,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(320,637,ls),
+(400,637,o),
+(447,600,o),
+(447,515,cs),
+(447,433,o),
+(403,391,o),
+(333,391,cs),
+(307,391,l),
+(357,363,l),
+(353,402,o),
+(324,432,o),
+(286,432,cs),
+(248,432,o),
+(218,402,o),
+(214,364,c),
+(239,391,l),
+(154,391,l),
+(154,637,l)
+);
+}
+);
+width = 600;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F9;
+unicode = 5625;
+},
+{
+color = 9;
+glyphname = "khaCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(538,0,l),
+(538,714,l),
+(263,714,ls),
+(137,714,o),
+(59,645,o),
+(59,520,cs),
+(59,431,o),
+(103,367,o),
+(178,343,c),
+(177,370,l),
+(105,343,o),
+(59,277,o),
+(59,192,cs),
+(59,68,o),
+(135,0,o),
+(263,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(201,77,o),
+(152,115,o),
+(152,196,cs),
+(152,278,o),
+(202,319,o),
+(279,319,cs),
+(445,319,l),
+(445,77,l),
+(280,77,ls)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,395,o),
+(152,436,o),
+(152,517,cs),
+(152,599,o),
+(200,637,o),
+(280,637,cs),
+(445,637,l),
+(445,395,l),
+(279,395,ls)
+);
+}
+);
+width = 600;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15FA;
+unicode = 5626;
+},
+{
+color = 9;
+glyphname = "kkuCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(300,-13,o),
+(353,31,o),
+(376,121,c),
+(335,121,l),
+(361,30,o),
+(413,-13,o),
+(487,-13,cs),
+(588,-13,o),
+(653,57,o),
+(653,187,cs),
+(653,714,l),
+(622,714,l),
+(382,548,l),
+(382,461,l),
+(585,604,l),
+(563,616,l),
+(563,192,ls),
+(563,110,o),
+(534,72,o),
+(481,72,cs),
+(430,72,o),
+(398,111,o),
+(398,192,cs),
+(398,714,l),
+(313,714,l),
+(313,192,ls),
+(313,110,o),
+(282,72,o),
+(230,72,cs),
+(176,72,o),
+(146,110,o),
+(146,192,cs),
+(146,616,l),
+(125,603,l),
+(325,462,l),
+(325,551,l),
+(89,714,l),
+(57,714,l),
+(57,189,ls),
+(57,57,o),
+(123,-13,o),
+(223,-13,cs)
+);
+}
+);
+width = 710;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FB;
+unicode = 5627;
+},
+{
+color = 9;
+glyphname = "kkoCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(88,0,l),
+(327,166,l),
+(327,253,l),
+(124,110,l),
+(146,98,l),
+(146,522,ls),
+(146,604,o),
+(176,642,o),
+(228,642,cs),
+(280,642,o),
+(311,603,o),
+(311,522,cs),
+(311,0,l),
+(397,0,l),
+(397,522,ls),
+(397,604,o),
+(428,642,o),
+(480,642,cs),
+(534,642,o),
+(563,604,o),
+(563,522,cs),
+(563,98,l),
+(584,111,l),
+(385,252,l),
+(385,163,l),
+(621,0,l),
+(653,0,l),
+(653,525,ls),
+(653,657,o),
+(586,727,o),
+(486,727,cs),
+(409,727,o),
+(356,683,o),
+(334,593,c),
+(375,593,l),
+(349,684,o),
+(296,727,o),
+(222,727,cs),
+(122,727,o),
+(57,657,o),
+(57,527,cs),
+(57,0,l)
+);
+}
+);
+width = 710;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FC;
+unicode = 5628;
+},
+{
+color = 9;
+glyphname = "kkeCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(351,0,ls),
+(479,0,o),
+(554,68,o),
+(554,192,cs),
+(554,277,o),
+(508,343,o),
+(436,370,c),
+(435,343,l),
+(510,367,o),
+(554,431,o),
+(554,520,cs),
+(554,645,o),
+(477,714,o),
+(351,714,cs),
+(60,714,l),
+(60,688,l),
+(147,396,l),
+(66,396,l),
+(66,319,l),
+(148,319,l),
+(60,26,l),
+(60,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(241,319,l),
+(335,319,ls),
+(412,319,o),
+(461,278,o),
+(461,196,cs),
+(461,115,o),
+(413,78,o),
+(333,78,cs),
+(127,78,l),
+(156,38,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(155,676,l),
+(126,636,l),
+(333,636,ls),
+(413,636,o),
+(461,599,o),
+(461,517,cs),
+(461,436,o),
+(413,396,o),
+(335,396,cs),
+(239,396,l)
+);
+}
+);
+width = 613;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni15FD;
+unicode = 5629;
+},
+{
+color = 9;
+glyphname = "kkeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(351,0,ls),
+(479,0,o),
+(554,68,o),
+(554,192,cs),
+(554,277,o),
+(508,343,o),
+(436,370,c),
+(435,343,l),
+(510,367,o),
+(554,431,o),
+(554,520,cs),
+(554,645,o),
+(477,714,o),
+(351,714,cs),
+(60,714,l),
+(60,688,l),
+(147,396,l),
+(66,396,l),
+(66,319,l),
+(148,319,l),
+(60,26,l),
+(60,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(239,322,l),
+(295,322,l),
+(295,237,l),
+(347,237,l),
+(347,341,l),
+(312,322,l),
+(343,322,ls),
+(416,322,o),
+(461,280,o),
+(461,198,cs),
+(461,116,o),
+(413,78,o),
+(333,78,cs),
+(125,78,l),
+(155,38,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(347,479,l),
+(295,479,l),
+(295,393,l),
+(237,393,l),
+(153,676,l),
+(124,636,l),
+(333,636,ls),
+(413,636,o),
+(461,598,o),
+(461,516,cs),
+(461,434,o),
+(417,393,o),
+(343,393,cs),
+(312,393,l),
+(347,378,l)
+);
+}
+);
+width = 613;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FE;
+unicode = 5630;
+},
+{
+color = 9;
+glyphname = "kkiCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(351,0,ls),
+(479,0,o),
+(554,68,o),
+(554,192,cs),
+(554,277,o),
+(508,343,o),
+(436,370,c),
+(435,343,l),
+(510,367,o),
+(554,431,o),
+(554,520,cs),
+(554,645,o),
+(477,714,o),
+(351,714,cs),
+(60,714,l),
+(60,688,l),
+(147,396,l),
+(66,396,l),
+(66,319,l),
+(148,319,l),
+(60,26,l),
+(60,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(240,326,l),
+(251,326,l),
+(260,300,o),
+(284,282,o),
+(314,282,cs),
+(353,282,o),
+(379,315,o),
+(381,346,c),
+(324,326,l),
+(343,326,ls),
+(416,326,o),
+(461,280,o),
+(461,195,cs),
+(461,116,o),
+(413,78,o),
+(333,78,cs),
+(125,78,l),
+(155,38,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(379,400,o),
+(354,432,o),
+(314,432,cs),
+(284,432,o),
+(261,415,o),
+(251,389,c),
+(238,389,l),
+(153,676,l),
+(124,636,l),
+(333,636,ls),
+(413,636,o),
+(461,598,o),
+(461,513,cs),
+(461,434,o),
+(417,389,o),
+(343,389,cs),
+(325,389,l),
+(382,368,l)
+);
+}
+);
+width = 613;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FF;
+unicode = 5631;
+},
+{
+color = 9;
+glyphname = "kkaCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(553,0,l),
+(553,26,l),
+(466,319,l),
+(547,319,l),
+(547,396,l),
+(466,396,l),
+(553,688,l),
+(553,714,l),
+(263,714,ls),
+(137,714,o),
+(59,645,o),
+(59,520,cs),
+(59,431,o),
+(103,367,o),
+(178,343,c),
+(177,370,l),
+(105,343,o),
+(59,277,o),
+(59,192,cs),
+(59,68,o),
+(135,0,o),
+(263,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(486,78,l),
+(280,78,ls),
+(201,78,o),
+(152,115,o),
+(152,196,cs),
+(152,278,o),
+(202,319,o),
+(279,319,cs),
+(373,319,l),
+(457,38,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,396,o),
+(152,436,o),
+(152,517,cs),
+(152,599,o),
+(200,636,o),
+(280,636,cs),
+(487,636,l),
+(458,676,l),
+(374,396,l),
+(279,396,ls)
+);
+}
+);
+width = 613;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|kkeCarrier-canadian";
+note = uni1600;
+unicode = 5632;
+},
+{
+color = 6;
+glyphname = "kkCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(176,189,l),
+(305,532,l),
+(305,546,l),
+(243,546,l),
+(146,262,l),
+(191,262,l),
+(93,546,l),
+(31,546,l),
+(31,532,l),
+(160,189,l)
+);
+}
+);
+width = 336;
+}
+);
+note = uni1601;
+unicode = 5633;
+},
+{
+color = 9;
+glyphname = "nuCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(456,-13,o),
+(543,80,o),
+(543,259,cs),
+(543,312,l),
+(451,312,l),
+(451,252,ls),
+(451,130,o),
+(397,73,o),
+(301,73,cs),
+(207,73,o),
+(152,133,o),
+(152,255,cs),
+(152,714,l),
+(58,714,l),
+(58,259,ls),
+(58,81,o),
+(150,-13,o),
+(302,-13,cs)
+);
+}
+);
+width = 595;
+}
+);
+metricLeft = "te-canadian";
+note = uni1602;
+unicode = 5634;
+},
+{
+color = 9;
+glyphname = "noCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(537,0,l),
+(537,455,ls),
+(537,633,o),
+(445,727,o),
+(294,727,cs),
+(140,727,o),
+(52,634,o),
+(52,455,cs),
+(52,402,l),
+(145,402,l),
+(145,462,ls),
+(145,584,o),
+(198,641,o),
+(294,641,cs),
+(389,641,o),
+(443,581,o),
+(443,459,cs),
+(443,0,l)
+);
+}
+);
+width = 595;
+}
+);
+metricLeft = "=|nuCarrier-canadian";
+metricRight = "te-canadian";
+note = uni1603;
+unicode = 5635;
+},
+{
+color = 9;
+glyphname = "neCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (253,357);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(233,0,ls),
+(430,0,o),
+(538,124,o),
+(538,358,cs),
+(538,592,o),
+(432,714,o),
+(222,714,cs),
+(41,714,l),
+(41,628,l),
+(223,628,ls),
+(373,628,o),
+(444,541,o),
+(444,358,cs),
+(444,175,o),
+(371,86,o),
+(233,86,cs),
+(225,86,l),
+(225,0,l)
+);
+}
+);
+width = 589;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1604;
+unicode = 5636;
+},
+{
+color = 9;
+glyphname = "neeCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+ref = "neCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (207,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 589;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1605;
+unicode = 5637;
+},
+{
+color = 9;
+glyphname = "niCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "neCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (183,0);
+ref = dot_middle;
+}
+);
+width = 588;
+}
+);
+note = uni1606;
+unicode = 5638;
+},
+{
+color = 9;
+glyphname = "naCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(548,0,l),
+(548,86,l),
+(365,86,ls),
+(215,86,o),
+(144,173,o),
+(144,356,cs),
+(144,539,o),
+(218,628,o),
+(356,628,cs),
+(363,628,l),
+(363,714,l),
+(356,714,ls),
+(159,714,o),
+(51,590,o),
+(51,356,cs),
+(51,122,o),
+(157,0,o),
+(366,0,cs)
+);
+}
+);
+width = 589;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni1607;
+unicode = 5639;
+},
+{
+color = 9;
+glyphname = "muCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(300,-13,o),
+(353,31,o),
+(375,120,c),
+(335,120,l),
+(361,30,o),
+(413,-13,o),
+(487,-13,cs),
+(588,-13,o),
+(653,57,o),
+(653,187,cs),
+(653,404,l),
+(563,404,l),
+(563,192,ls),
+(563,110,o),
+(534,72,o),
+(482,72,cs),
+(430,72,o),
+(399,111,o),
+(399,192,cs),
+(399,404,l),
+(312,404,l),
+(312,192,ls),
+(312,110,o),
+(281,72,o),
+(229,72,cs),
+(175,72,o),
+(146,110,o),
+(146,192,cs),
+(146,714,l),
+(57,714,l),
+(57,189,ls),
+(57,57,o),
+(123,-13,o),
+(223,-13,cs)
+);
+}
+);
+width = 710;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "=|";
+note = uni1608;
+unicode = 5640;
+},
+{
+color = 9;
+glyphname = "moCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(653,0,l),
+(653,525,ls),
+(653,657,o),
+(586,727,o),
+(486,727,cs),
+(410,727,o),
+(357,683,o),
+(334,594,c),
+(375,594,l),
+(349,684,o),
+(296,727,o),
+(222,727,cs),
+(122,727,o),
+(57,657,o),
+(57,527,cs),
+(57,310,l),
+(146,310,l),
+(146,522,ls),
+(146,604,o),
+(175,642,o),
+(228,642,cs),
+(279,642,o),
+(311,603,o),
+(311,522,cs),
+(311,310,l),
+(398,310,l),
+(398,522,ls),
+(398,604,o),
+(428,642,o),
+(480,642,cs),
+(534,642,o),
+(563,604,o),
+(563,522,cs),
+(563,0,l)
+);
+}
+);
+width = 710;
+}
+);
+metricLeft = "=|muCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni1609;
+unicode = 5641;
+},
+{
+color = 9;
+glyphname = "meCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(334,0,ls),
+(462,0,o),
+(538,68,o),
+(538,192,cs),
+(538,277,o),
+(491,345,o),
+(417,372,c),
+(417,343,l),
+(493,366,o),
+(538,431,o),
+(538,520,cs),
+(538,645,o),
+(460,714,o),
+(334,714,cs),
+(41,714,l),
+(41,636,l),
+(317,636,ls),
+(397,636,o),
+(444,599,o),
+(444,517,cs),
+(444,436,o),
+(396,396,o),
+(318,396,cs),
+(237,396,l),
+(237,319,l),
+(318,319,ls),
+(395,319,o),
+(444,278,o),
+(444,196,cs),
+(444,115,o),
+(396,78,o),
+(317,78,cs),
+(237,78,l),
+(237,0,l)
+);
+}
+);
+width = 597;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160A;
+unicode = 5642;
+},
+{
+color = 9;
+glyphname = "meeCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(334,0,ls),
+(462,0,o),
+(538,68,o),
+(538,192,cs),
+(538,277,o),
+(492,343,o),
+(419,370,c),
+(419,343,l),
+(493,367,o),
+(538,431,o),
+(538,520,cs),
+(538,645,o),
+(460,714,o),
+(334,714,cs),
+(41,714,l),
+(41,636,l),
+(317,636,ls),
+(397,636,o),
+(444,598,o),
+(444,516,cs),
+(444,435,o),
+(399,394,o),
+(325,394,cs),
+(294,394,l),
+(294,480,l),
+(237,480,l),
+(237,236,l),
+(294,236,l),
+(294,321,l),
+(324,321,ls),
+(399,321,o),
+(444,279,o),
+(444,197,cs),
+(444,116,o),
+(396,78,o),
+(317,78,cs),
+(237,78,l),
+(237,0,l)
+);
+}
+);
+width = 597;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160B;
+unicode = 5643;
+},
+{
+color = 9;
+glyphname = "miCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(334,0,ls),
+(462,0,o),
+(538,68,o),
+(538,192,cs),
+(538,277,o),
+(492,343,o),
+(419,370,c),
+(419,343,l),
+(493,367,o),
+(538,431,o),
+(538,520,cs),
+(538,645,o),
+(460,714,o),
+(334,714,cs),
+(41,714,l),
+(41,636,l),
+(317,636,ls),
+(397,636,o),
+(444,598,o),
+(444,516,cs),
+(444,435,o),
+(399,394,o),
+(329,394,cs),
+(292,394,l),
+(343,368,l),
+(338,404,o),
+(309,432,o),
+(271,432,cs),
+(229,432,o),
+(197,398,o),
+(197,358,cs),
+(197,316,o),
+(229,282,o),
+(271,282,cs),
+(309,282,o),
+(338,311,o),
+(342,346,c),
+(292,321,l),
+(328,321,ls),
+(399,321,o),
+(444,279,o),
+(444,197,cs),
+(444,116,o),
+(396,78,o),
+(317,78,cs),
+(237,78,l),
+(237,0,l)
+);
+}
+);
+width = 597;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160C;
+unicode = 5644;
+},
+{
+color = 9;
+glyphname = "maCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(556,0,l),
+(556,78,l),
+(280,78,ls),
+(200,78,o),
+(152,115,o),
+(152,196,cs),
+(152,277,o),
+(201,318,o),
+(278,318,cs),
+(359,318,l),
+(359,395,l),
+(279,395,ls),
+(201,395,o),
+(152,436,o),
+(152,517,cs),
+(152,598,o),
+(201,636,o),
+(280,636,cs),
+(359,636,l),
+(359,714,l),
+(263,714,ls),
+(135,714,o),
+(59,646,o),
+(59,521,cs),
+(59,435,o),
+(106,369,o),
+(180,343,c),
+(180,372,l),
+(104,347,o),
+(59,281,o),
+(59,192,cs),
+(59,69,o),
+(137,0,o),
+(263,0,cs)
+);
+}
+);
+width = 597;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni160D;
+unicode = 5645;
+},
+{
+color = 9;
+glyphname = "yuCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(489,-13,o),
+(584,120,o),
+(584,400,cs),
+(584,628,o),
+(520,727,o),
+(413,727,cs),
+(319,727,o),
+(264,649,o),
+(264,519,cs),
+(264,392,o),
+(320,318,o),
+(407,318,cs),
+(421,318,o),
+(435,320,o),
+(446,325,c),
+(446,398,l),
+(439,396,o),
+(431,393,o),
+(417,393,cs),
+(368,393,o),
+(342,434,o),
+(342,523,cs),
+(342,610,o),
+(367,652,o),
+(411,652,cs),
+(466,652,o),
+(496,590,o),
+(496,403,cs),
+(496,158,o),
+(431,73,o),
+(311,73,cs),
+(211,73,o),
+(152,134,o),
+(152,261,cs),
+(152,714,l),
+(58,714,l),
+(58,264,ls),
+(58,81,o),
+(156,-13,o),
+(308,-13,cs)
+);
+}
+);
+width = 642;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160E;
+unicode = 5646;
+},
+{
+color = 9;
+glyphname = "yoCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(323,-13,o),
+(379,65,o),
+(379,195,cs),
+(379,322,o),
+(323,396,o),
+(236,396,cs),
+(222,396,o),
+(207,394,o),
+(197,389,c),
+(197,316,l),
+(204,318,o),
+(212,321,o),
+(226,321,cs),
+(275,321,o),
+(300,280,o),
+(300,191,cs),
+(300,104,o),
+(276,62,o),
+(232,62,cs),
+(176,62,o),
+(147,124,o),
+(147,311,cs),
+(147,556,o),
+(211,641,o),
+(332,641,cs),
+(432,641,o),
+(491,580,o),
+(491,453,cs),
+(491,0,l),
+(584,0,l),
+(584,450,ls),
+(584,633,o),
+(487,727,o),
+(335,727,cs),
+(154,727,o),
+(58,594,o),
+(58,314,cs),
+(58,86,o),
+(123,-13,o),
+(230,-13,cs)
+);
+}
+);
+width = 642;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160F;
+unicode = 5647;
+},
+{
+color = 9;
+glyphname = "yeCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(436,-13,o),
+(532,128,o),
+(532,351,cs),
+(532,593,o),
+(426,714,o),
+(211,714,cs),
+(56,714,l),
+(56,628,l),
+(213,628,ls),
+(368,628,o),
+(439,542,o),
+(439,349,cs),
+(439,170,o),
+(388,67,o),
+(268,67,cs),
+(165,67,o),
+(124,131,o),
+(124,220,cs),
+(124,304,o),
+(150,346,o),
+(194,346,cs),
+(239,346,o),
+(263,304,o),
+(263,226,cs),
+(263,197,o),
+(261,181,o),
+(259,162,c),
+(329,162,l),
+(333,186,o),
+(335,203,o),
+(335,233,cs),
+(335,345,o),
+(286,422,o),
+(194,422,cs),
+(101,422,o),
+(44,344,o),
+(44,219,cs),
+(44,90,o),
+(117,-13,o),
+(267,-13,cs)
+);
+}
+);
+width = 583;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1610;
+unicode = 5648;
+},
+{
+color = 9;
+glyphname = "yeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(436,-13,o),
+(532,128,o),
+(532,351,cs),
+(532,593,o),
+(426,714,o),
+(211,714,cs),
+(56,714,l),
+(56,628,l),
+(213,628,ls),
+(368,628,o),
+(439,542,o),
+(439,349,cs),
+(439,170,o),
+(389,67,o),
+(267,67,cs),
+(165,67,o),
+(124,131,o),
+(124,223,cs),
+(124,303,o),
+(149,346,o),
+(189,346,cs),
+(230,346,o),
+(255,305,o),
+(255,237,cs),
+(255,185,l),
+(303,185,l),
+(303,515,l),
+(255,515,l),
+(255,311,l),
+(267,311,l),
+(261,381,o),
+(226,422,o),
+(170,422,cs),
+(98,422,o),
+(44,348,o),
+(44,222,cs),
+(44,90,o),
+(117,-13,o),
+(266,-13,cs)
+);
+}
+);
+width = 583;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1611;
+unicode = 5649;
+},
+{
+color = 9;
+glyphname = "yiCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(436,-13,o),
+(532,128,o),
+(532,351,cs),
+(532,593,o),
+(426,714,o),
+(211,714,cs),
+(56,714,l),
+(56,628,l),
+(213,628,ls),
+(368,628,o),
+(439,542,o),
+(439,349,cs),
+(439,170,o),
+(388,67,o),
+(271,67,cs),
+(167,67,o),
+(124,132,o),
+(124,212,cs),
+(124,288,o),
+(152,328,o),
+(195,330,c),
+(170,345,l),
+(175,314,o),
+(204,288,o),
+(241,288,cs),
+(281,288,o),
+(312,319,o),
+(312,358,cs),
+(312,396,o),
+(281,427,o),
+(241,427,cs),
+(213,427,o),
+(189,411,o),
+(178,390,c),
+(98,381,o),
+(44,313,o),
+(44,204,cs),
+(44,90,o),
+(117,-13,o),
+(267,-13,cs)
+);
+}
+);
+width = 583;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1612;
+unicode = 5650;
+},
+{
+color = 9;
+glyphname = "yaCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(526,0,l),
+(526,86,l),
+(370,86,ls),
+(215,86,o),
+(144,172,o),
+(144,365,cs),
+(144,544,o),
+(194,647,o),
+(320,647,cs),
+(418,647,o),
+(459,583,o),
+(459,494,cs),
+(459,410,o),
+(432,368,o),
+(388,368,cs),
+(344,368,o),
+(320,410,o),
+(320,488,cs),
+(320,517,o),
+(322,533,o),
+(324,552,c),
+(254,552,l),
+(249,528,o),
+(247,511,o),
+(247,481,cs),
+(247,369,o),
+(297,292,o),
+(389,292,cs),
+(482,292,o),
+(539,370,o),
+(539,495,cs),
+(539,624,o),
+(465,727,o),
+(321,727,cs),
+(146,727,o),
+(51,586,o),
+(51,363,cs),
+(51,121,o),
+(156.996,0,o),
+(372,0,cs)
+);
+}
+);
+width = 583;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|yeCarrier-canadian";
+note = uni1613;
+unicode = 5651;
+},
+{
+color = 9;
+glyphname = "juCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(476,-13,o),
+(550,89,o),
+(550,220,cs),
+(550,344,o),
+(494,422,o),
+(401,422,cs),
+(309,422,o),
+(259,345,o),
+(259,233,cs),
+(259,203,o),
+(261,185,o),
+(266,162,c),
+(336,162,l),
+(334,179,o),
+(331,198,o),
+(331,226,cs),
+(331,303,o),
+(356,346,o),
+(400,346,cs),
+(444,346,o),
+(471,303,o),
+(471,221,cs),
+(471,130,o),
+(428,67,o),
+(326,67,cs),
+(209,67,o),
+(149,152,o),
+(149,309,cs),
+(149,541,o),
+(269,628,o),
+(459,628,cs),
+(538,628,l),
+(538,714,l),
+(49,714,l),
+(49,631,l),
+(306,631,l),
+(379,667,l),
+(185,667,o),
+(56,543,o),
+(56,307,cs),
+(56,110,o),
+(157,-13,o),
+(320,-13,cs)
+);
+}
+);
+width = 594;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni1614;
+unicode = 5652;
+},
+{
+color = 9;
+glyphname = "juSayisi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (301,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(437,-13,o),
+(538,110,o),
+(538,307,cs),
+(538,543,o),
+(409,667,o),
+(215,667,c),
+(289,631,l),
+(545,631,l),
+(545,714,l),
+(56,714,l),
+(56,628,l),
+(135,628,ls),
+(326,628,o),
+(445,541,o),
+(445,309,cs),
+(445,152,o),
+(386,67,o),
+(269,67,cs),
+(166,67,o),
+(124,130,o),
+(124,221,cs),
+(124,303,o),
+(150,346,o),
+(194,346,cs),
+(238,346,o),
+(263,303,o),
+(263,226,cs),
+(263,198,o),
+(261,179,o),
+(259,162,c),
+(329,162,l),
+(333,185,o),
+(335,203,o),
+(335,233,cs),
+(335,345,o),
+(286,422,o),
+(193,422,cs),
+(101,422,o),
+(44,344,o),
+(44,220,cs),
+(44,89,o),
+(118,-13,o),
+(274,-13,cs)
+);
+}
+);
+width = 594;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1615;
+unicode = 5653;
+},
+{
+color = 9;
+glyphname = "joCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(545,0,l),
+(545,83,l),
+(289,83,l),
+(215,47,l),
+(409,47,o),
+(538,171,o),
+(538,407,cs),
+(538,604,o),
+(437,727,o),
+(274,727,cs),
+(118,727,o),
+(44,625,o),
+(44,494,cs),
+(44,370,o),
+(101,292,o),
+(193,292,cs),
+(286,292,o),
+(335,369,o),
+(335,481,cs),
+(335,511,o),
+(333,529,o),
+(329,552,c),
+(259,552,l),
+(261,535,o),
+(263,516,o),
+(263,488,cs),
+(263,411,o),
+(238,368,o),
+(194,368,cs),
+(150,368,o),
+(124,411,o),
+(124,493,cs),
+(124,584,o),
+(166,647,o),
+(269,647,cs),
+(386,647,o),
+(445,562,o),
+(445,405,cs),
+(445,173,o),
+(326,86,o),
+(135,86,cs),
+(56,86,l),
+(56,0,l)
+);
+}
+);
+width = 594;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1616;
+unicode = 5654;
+},
+{
+color = 9;
+glyphname = "jeCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(523,-13,o),
+(588,86,o),
+(588,314,cs),
+(588,586,o),
+(490,727,o),
+(346,727,cs),
+(211,727,o),
+(138,616,o),
+(132,413,c),
+(154,419,l),
+(154,714,l),
+(62,714,l),
+(62,0,l),
+(155,0,l),
+(155,295,ls),
+(155,545,o),
+(221,641,o),
+(330,641,cs),
+(432,641,o),
+(499,543,o),
+(499,312,cs),
+(499,124,o),
+(470,62,o),
+(415,62,cs),
+(371,62,o),
+(346,104,o),
+(346,191,cs),
+(346,280,o),
+(371,321,o),
+(422,321,cs),
+(434,321,o),
+(442,318,o),
+(449,316,c),
+(449,389,l),
+(439,394,o),
+(424,396,o),
+(411,396,cs),
+(323,396,o),
+(267,322,o),
+(267,195,cs),
+(267,65,o),
+(323,-13,o),
+(416,-13,cs)
+);
+}
+);
+width = 646;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "te-canadian";
+note = uni1617;
+unicode = 5655;
+},
+{
+color = 9;
+glyphname = "jeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(522,-13,o),
+(588,87,o),
+(588,314,cs),
+(588,586,o),
+(490,727,o),
+(346,727,cs),
+(237,727,o),
+(169,657,o),
+(143,526,c),
+(154,516,l),
+(154,714,l),
+(62,714,l),
+(62,0,l),
+(155,0,l),
+(155,295,ls),
+(155,545,o),
+(221,641,o),
+(330,641,cs),
+(432,641,o),
+(499,543,o),
+(499,312,cs),
+(499,130,o),
+(466,62,o),
+(400,62,cs),
+(346,62,o),
+(313,111,o),
+(313,198,cs),
+(313,273,o),
+(333,317,o),
+(370,331,c),
+(370,244,l),
+(418,244,l),
+(418,464,l),
+(370,464,l),
+(370,382,l),
+(310,365,o),
+(267,301,o),
+(267,191,cs),
+(267,64,o),
+(322,-13,o),
+(416,-13,cs)
+);
+}
+);
+width = 646;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1618;
+unicode = 5656;
+},
+{
+color = 9;
+glyphname = "jiCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(522,-13,o),
+(588,87,o),
+(588,314,cs),
+(588,586,o),
+(490,727,o),
+(346,727,cs),
+(237,727,o),
+(169,657,o),
+(143,526,c),
+(154,516,l),
+(154,714,l),
+(62,714,l),
+(62,0,l),
+(155,0,l),
+(155,295,ls),
+(155,545,o),
+(221,641,o),
+(330,641,cs),
+(432,641,o),
+(499,543,o),
+(499,312,cs),
+(499,130,o),
+(466,62,o),
+(400,62,cs),
+(346,62,o),
+(313,111,o),
+(313,198,cs),
+(313,253,o),
+(325,286,o),
+(346,304,c),
+(354,293,o),
+(367,285,o),
+(382,285,cs),
+(419,285,o),
+(447,316,o),
+(447,354,cs),
+(447,392,o),
+(419,422,o),
+(382,422,cs),
+(336,422,o),
+(312,378,o),
+(320,342,c),
+(287,316,o),
+(267,266,o),
+(267,191,cs),
+(267,64,o),
+(322,-13,o),
+(416,-13,cs)
+);
+}
+);
+width = 646;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1619;
+unicode = 5657;
+},
+{
+color = 9;
+glyphname = "jiSayisi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(490,-13,o),
+(588,128,o),
+(588,400,cs),
+(588,628,o),
+(523,727,o),
+(416,727,cs),
+(323,727,o),
+(267,649,o),
+(267,519,cs),
+(267,392,o),
+(323,318,o),
+(411,318,cs),
+(424,318,o),
+(439,320,o),
+(449,325,c),
+(449,398,l),
+(442,396,o),
+(434,393,o),
+(422,393,cs),
+(371,393,o),
+(346,434,o),
+(346,523,cs),
+(346,610,o),
+(371,652,o),
+(414,652,cs),
+(470,652,o),
+(499,590,o),
+(499,402,cs),
+(499,171,o),
+(432,73,o),
+(330,73,cs),
+(221,73,o),
+(155,169,o),
+(155,419,cs),
+(155,714,l),
+(62,714,l),
+(62,0,l),
+(154,0,l),
+(154,295,l),
+(132,301,l),
+(138,98,o),
+(211,-13,o),
+(346,-13,cs)
+);
+}
+);
+width = 646;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161A;
+unicode = 5658;
+},
+{
+color = 9;
+glyphname = "jaCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (316,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(435,-13,o),
+(508,98,o),
+(514,301,c),
+(492,295,l),
+(492,0,l),
+(584,0,l),
+(584,714,l),
+(491,714,l),
+(491,419,ls),
+(491,169,o),
+(425,73,o),
+(316,73,cs),
+(214,73,o),
+(147,171,o),
+(147,402,cs),
+(147,590,o),
+(176,652,o),
+(232,652,cs),
+(275,652,o),
+(300,610,o),
+(300,523,cs),
+(300,434,o),
+(275,393,o),
+(224,393,cs),
+(212,393,o),
+(204,396,o),
+(197,398,c),
+(197,325,l),
+(207,320,o),
+(222,318,o),
+(235,318,cs),
+(323,318,o),
+(379,392,o),
+(379,519,cs),
+(379,649,o),
+(323,727,o),
+(230,727,cs),
+(123,727,o),
+(58,628,o),
+(58,400,cs),
+(58,128,o),
+(156,-13,o),
+(300,-13,cs)
+);
+}
+);
+width = 646;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni161B;
+unicode = 5659;
+},
+{
+color = 9;
+glyphname = "jjuCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(471,-13,o),
+(544,90,o),
+(544,219,cs),
+(544,344,o),
+(488,422,o),
+(395,422,cs),
+(303,422,o),
+(253,345,o),
+(253,233,cs),
+(253,204,o),
+(255,185,o),
+(260,162,c),
+(330,162,l),
+(328,179,o),
+(325,200,o),
+(325,226,cs),
+(325,303,o),
+(350,346,o),
+(394,346,cs),
+(436,346,o),
+(465,301,o),
+(465,220,cs),
+(465,129,o),
+(423,65,o),
+(323,65,cs),
+(209,65,o),
+(150,151,o),
+(150,318,cs),
+(150,532,o),
+(255,628,o),
+(431,628,cs),
+(532,628,l),
+(532,714,l),
+(426,714,ls),
+(323,714,o),
+(240,685,o),
+(179,632,c),
+(85,727,l),
+(23,668,l),
+(122,569,l),
+(79,507,o),
+(57,423,o),
+(57,322,cs),
+(57,111,o),
+(160,-13,o),
+(319,-13,cs)
+);
+}
+);
+width = 588;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni161C;
+unicode = 5660;
+},
+{
+color = 9;
+glyphname = "jjoCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(565,46,l),
+(467,145,l),
+(510,207,o),
+(532,291,o),
+(532,392,cs),
+(532,603,o),
+(429,727,o),
+(270,727,cs),
+(118,727,o),
+(44,624,o),
+(44,495,cs),
+(44,370,o),
+(101,292,o),
+(194,292,cs),
+(286,292,o),
+(336,369,o),
+(336,481,cs),
+(336,510,o),
+(334,529,o),
+(329,552,c),
+(259,552,l),
+(261,535,o),
+(263,514,o),
+(263,488,cs),
+(263,411,o),
+(239,368,o),
+(195,368,cs),
+(152,368,o),
+(124,413,o),
+(124,494,cs),
+(124,585,o),
+(166,649,o),
+(266,649,cs),
+(380,649,o),
+(439,563,o),
+(439,396,cs),
+(439,182,o),
+(334,86,o),
+(158,86,cs),
+(56,86,l),
+(56,0,l),
+(162,0,ls),
+(266,0,o),
+(349,29,o),
+(409,82,c),
+(504,-13,l)
+);
+}
+);
+width = 588;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|jjuCarrier-canadian";
+note = uni161D;
+unicode = 5661;
+},
+{
+color = 9;
+glyphname = "jjeCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(528,-13,o),
+(592,86,o),
+(592,314,cs),
+(592,594,o),
+(501,727,o),
+(324,727,cs),
+(255,727,o),
+(195,702,o),
+(151,654,c),
+(73,727,l),
+(16,664,l),
+(103,582,l),
+(80,533,o),
+(66,471,o),
+(66,395,cs),
+(66,0,l),
+(160,0,l),
+(160,399,ls),
+(160,560,o),
+(219,641,o),
+(323,641,cs),
+(439,641,o),
+(504,556,o),
+(504,311,cs),
+(504,124,o),
+(474,62,o),
+(419,62,cs),
+(374,62,o),
+(350,104,o),
+(350,191,cs),
+(350,280,o),
+(376,321,o),
+(425,321,cs),
+(439,321,o),
+(447,318,o),
+(454,316,c),
+(454,389,l),
+(443,394,o),
+(428,396,o),
+(414,396,cs),
+(328,396,o),
+(271,322,o),
+(271,195,cs),
+(271,65,o),
+(327,-13,o),
+(421,-13,cs)
+);
+}
+);
+width = 650;
+}
+);
+metricRight = "jeCarrier-canadian";
+note = uni161E;
+unicode = 5662;
+},
+{
+color = 9;
+glyphname = "jjeeCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(527,-13,o),
+(592,87,o),
+(592,314,cs),
+(592,594,o),
+(501,727,o),
+(324,727,cs),
+(255,727,o),
+(195,702,o),
+(151,654,c),
+(73,727,l),
+(16,664,l),
+(103,582,l),
+(80,533,o),
+(66,471,o),
+(66,395,cs),
+(66,0,l),
+(160,0,l),
+(160,399,ls),
+(160,560,o),
+(219,641,o),
+(323,641,cs),
+(439,641,o),
+(504,556,o),
+(504,311,cs),
+(504,129,o),
+(470,62,o),
+(404,62,cs),
+(349,62,o),
+(318,111,o),
+(318,198,cs),
+(318,276,o),
+(338,317,o),
+(374,331,c),
+(374,244,l),
+(422,244,l),
+(422,464,l),
+(374,464,l),
+(374,382,l),
+(315,367,o),
+(271,301,o),
+(271,191,cs),
+(271,64,o),
+(327,-13,o),
+(421,-13,cs)
+);
+}
+);
+width = 650;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161F;
+unicode = 5663;
+},
+{
+color = 9;
+glyphname = "jjiCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(527,-13,o),
+(592,87,o),
+(592,314,cs),
+(592,594,o),
+(501,727,o),
+(324,727,cs),
+(255,727,o),
+(195,702,o),
+(151,654,c),
+(73,727,l),
+(16,664,l),
+(103,582,l),
+(80,533,o),
+(66,471,o),
+(66,395,cs),
+(66,0,l),
+(160,0,l),
+(160,399,ls),
+(160,560,o),
+(219,641,o),
+(323,641,cs),
+(439,641,o),
+(504,556,o),
+(504,311,cs),
+(504,129,o),
+(470,62,o),
+(404,62,cs),
+(349,62,o),
+(318,111,o),
+(318,198,cs),
+(318,255,o),
+(330,288,o),
+(351,304,c),
+(358,293,o),
+(373,285,o),
+(388,285,cs),
+(425,285,o),
+(453,316,o),
+(453,354,cs),
+(453,392,o),
+(425,422,o),
+(388,422,cs),
+(344,422,o),
+(319,380,o),
+(326,344,c),
+(293,318,o),
+(271,267,o),
+(271,191,cs),
+(271,64,o),
+(327,-13,o),
+(421,-13,cs)
+);
+}
+);
+width = 650;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1620;
+unicode = 5664;
+},
+{
+color = 9;
+glyphname = "jjaCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(396,-13,o),
+(456,12,o),
+(500,60,c),
+(578,-13,l),
+(634,50,l),
+(547,132,l),
+(571,181,o),
+(584,243,o),
+(584,319,cs),
+(584,714,l),
+(491,714,l),
+(491,315,ls),
+(491,154,o),
+(432,73,o),
+(328,73,cs),
+(211,73,o),
+(147,158,o),
+(147,403,cs),
+(147,590,o),
+(176,652,o),
+(232,652,cs),
+(276,652,o),
+(300,610,o),
+(300,523,cs),
+(300,434,o),
+(275,393,o),
+(226,393,cs),
+(212,393,o),
+(204,396,o),
+(197,398,c),
+(197,325,l),
+(207,320,o),
+(222,318,o),
+(236,318,cs),
+(323,318,o),
+(379,392,o),
+(379,519,cs),
+(379,649,o),
+(323,727,o),
+(230,727,cs),
+(123,727,o),
+(58,628,o),
+(58,400,cs),
+(58,120,o),
+(150,-13,o),
+(326,-13,cs)
+);
+}
+);
+width = 650;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "=|jjeCarrier-canadian";
+note = uni1621;
+unicode = 5665;
+},
+{
+color = 9;
+glyphname = "luCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(450,-13,o),
+(541,74,o),
+(541,264,cs),
+(541,714,l),
+(447,714,l),
+(447,265,ls),
+(447,126,o),
+(390,73,o),
+(307,73,cs),
+(194,73,o),
+(149,167,o),
+(149,333,cs),
+(149,520,o),
+(200,620,o),
+(321,639,c),
+(321,714,l),
+(49,714,l),
+(49,636,l),
+(219,636,l),
+(278,664,l),
+(139,647,o),
+(56,544,o),
+(56,321,cs),
+(56,113,o),
+(137,-13,o),
+(305,-13,cs)
+);
+}
+);
+width = 599;
+}
+);
+metricRight = "te-canadian";
+note = uni1622;
+unicode = 5666;
+},
+{
+color = 9;
+glyphname = "loCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(152,0,l),
+(152,449,ls),
+(152,588,o),
+(209,641,o),
+(293,641,cs),
+(405,641,o),
+(450,547,o),
+(450,381,cs),
+(450,194,o),
+(399,94,o),
+(278,75,c),
+(278,0,l),
+(550,0,l),
+(550,78,l),
+(380,78,l),
+(321,50,l),
+(460,67,o),
+(543,170,o),
+(543,393,cs),
+(543,601,o),
+(462,727,o),
+(294,727,cs),
+(150,727,o),
+(58,640,o),
+(58,450,cs),
+(58,0,l)
+);
+}
+);
+width = 599;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|luCarrier-canadian";
+note = uni1623;
+unicode = 5667;
+},
+{
+color = 9;
+glyphname = "leCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (288,357);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(222,0,ls),
+(429,0,o),
+(535,124,o),
+(535,369,cs),
+(535,614,o),
+(431,727,o),
+(313,727,cs),
+(207,727,o),
+(151,647,o),
+(132,541,c),
+(143,545,l),
+(143,714,l),
+(59,714,l),
+(59,396,l),
+(138,396,l),
+(140,547,o),
+(196,641,o),
+(289,641,cs),
+(377,641,o),
+(441,561,o),
+(441,368,cs),
+(441,175,o),
+(374,86,o),
+(223,86,cs),
+(59,86,l),
+(59,0,l)
+);
+}
+);
+width = 586;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1624;
+unicode = 5668;
+},
+{
+color = 9;
+glyphname = "leeCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+ref = "leCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (242,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 586;
+}
+);
+metricLeft = "leCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1625;
+unicode = 5669;
+},
+{
+color = 9;
+glyphname = "liCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "leCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (218,0);
+ref = dot_middle;
+}
+);
+width = 585;
+}
+);
+note = uni1626;
+unicode = 5670;
+},
+{
+color = 9;
+glyphname = "laCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(526,0,l),
+(526,86,l),
+(362,86,ls),
+(211,86,o),
+(144,175,o),
+(144,368,cs),
+(144,561,o),
+(208,641,o),
+(296,641,cs),
+(390,641,o),
+(445,547,o),
+(447,396,c),
+(526,396,l),
+(526,714,l),
+(443,714,l),
+(443,545,l),
+(453,541,l),
+(435,647,o),
+(378,727,o),
+(272,727,cs),
+(154,727,o),
+(51,614,o),
+(51,369,cs),
+(51,124,o),
+(157,0,o),
+(363,0,cs)
+);
+}
+);
+width = 585;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|leCarrier-canadian";
+note = uni1627;
+unicode = 5671;
+},
+{
+color = 1;
+glyphname = "dluCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(462,-13,o),
+(543,113,o),
+(543,321,cs),
+(543,519,o),
+(479,621,o),
+(372,652,c),
+(354,642,l),
+(536,642,l),
+(536,558,l),
+(605,558,l),
+(605,798,l),
+(536,798,l),
+(536,714,l),
+(278,714,l),
+(278,638,l),
+(399,620,o),
+(450,520,o),
+(450,333,cs),
+(450,167,o),
+(405,73,o),
+(294,73,cs),
+(209,73,o),
+(152,127,o),
+(152,265,cs),
+(152,714,l),
+(58,714,l),
+(58,264,ls),
+(58,74,o),
+(150,-13,o),
+(295,-13,cs)
+);
+}
+);
+width = 639;
+}
+);
+metricLeft = "te-canadian";
+note = uni1628;
+unicode = 5672;
+},
+{
+color = 9;
+glyphname = "dloCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(605,-84,l),
+(605,156,l),
+(536,156,l),
+(536,72,l),
+(354,72,l),
+(372,62,l),
+(479,93,o),
+(543,195,o),
+(543,393,cs),
+(543,601,o),
+(462,727,o),
+(295,727,cs),
+(149,727,o),
+(58,640,o),
+(58,450,cs),
+(58,0,l),
+(152,0,l),
+(152,449,ls),
+(152,587,o),
+(209,641,o),
+(294,641,cs),
+(405,641,o),
+(450,547,o),
+(450,381,cs),
+(450,194,o),
+(399,94,o),
+(278,76,c),
+(278,0,l),
+(536,0,l),
+(536,-84,l)
+);
+}
+);
+width = 639;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "dluCarrier-canadian";
+note = uni1629;
+unicode = 5673;
+},
+{
+color = 9;
+glyphname = "dleCarrier-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (302,357);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(235,0,ls),
+(442,0,o),
+(548,124,o),
+(548,369,cs),
+(548,614,o),
+(445,727,o),
+(326,727,cs),
+(226,727,o),
+(155,655,o),
+(131.002,525,c),
+(141,520,l),
+(141,726,l),
+(207,726,l),
+(207,793,l),
+(6,793,l),
+(6,726,l),
+(72,726,l),
+(72,396,l),
+(151,396,l),
+(153,547,o),
+(209,641,o),
+(302,641,cs),
+(390,641,o),
+(454,561,o),
+(454,368,cs),
+(454,175,o),
+(387,86,o),
+(236,86,cs),
+(72,86,l),
+(72,0,l)
+);
+}
+);
+width = 599;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni162A;
+unicode = 5674;
+},
+{
+color = 9;
+glyphname = "dleeCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (256,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 598;
+}
+);
+note = uni162B;
+unicode = 5675;
+},
+{
+color = 9;
+glyphname = "dliCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (232,0);
+ref = dot_middle;
+}
+);
+width = 598;
+}
+);
+note = uni162C;
+unicode = 5676;
+},
+{
+color = 9;
+glyphname = "dlaCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(526,0,l),
+(526,86,l),
+(362,86,ls),
+(211,86,o),
+(144,175,o),
+(144,368,cs),
+(144,561,o),
+(209,641,o),
+(296,641,cs),
+(390,641,o),
+(445,547,o),
+(447,396,c),
+(526,396,l),
+(526,726,l),
+(592,726,l),
+(592,793,l),
+(392,793,l),
+(392,726,l),
+(457,726,l),
+(457,520,l),
+(467,525,l),
+(443,655,o),
+(372,727,o),
+(272,727,cs),
+(154,727,o),
+(51,614,o),
+(51,369,cs),
+(51,123,o),
+(157,0,o),
+(363,0,cs)
+);
+}
+);
+width = 598;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni162D;
+unicode = 5677;
+},
+{
+color = 9;
+glyphname = "lhuCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(477,-13,o),
+(563,110,o),
+(563,319,cs),
+(563,520,o),
+(491,634,o),
+(375,667,c),
+(412,636,l),
+(570,636,l),
+(570,714,l),
+(357,714,l),
+(357,639,l),
+(430,597,o),
+(470,494,o),
+(470,337,cs),
+(470,155,o),
+(420,73,o),
+(309,73,cs),
+(200,73,o),
+(150,155,o),
+(150,337,cs),
+(150,494,o),
+(189,598,o),
+(263,639,c),
+(263,714,l),
+(49,714,l),
+(49,636,l),
+(206,636,l),
+(244,667,l),
+(128,634,o),
+(56,521,o),
+(56,319,cs),
+(56,110,o),
+(142,-13,o),
+(309,-13,cs)
+);
+}
+);
+width = 619;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162E;
+unicode = 5678;
+},
+{
+color = 9;
+glyphname = "lhoCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(262,0,l),
+(262,75,l),
+(189,117,o),
+(149,220,o),
+(149,377,cs),
+(149,559,o),
+(199,641,o),
+(309,641,cs),
+(420,641,o),
+(469,559,o),
+(469,377,cs),
+(469,220,o),
+(430,116,o),
+(356,75,c),
+(356,0,l),
+(570,0,l),
+(570,78,l),
+(413,78,l),
+(375,47,l),
+(491,80,o),
+(563,193,o),
+(563,395,cs),
+(563,604,o),
+(477,727,o),
+(309,727,cs),
+(142,727,o),
+(56,604,o),
+(56,395,cs),
+(56,194,o),
+(128,80,o),
+(244,47,c),
+(207,78,l),
+(49,78,l),
+(49,0,l)
+);
+}
+);
+width = 619;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162F;
+unicode = 5679;
+},
+{
+color = 9;
+glyphname = "lheCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (302,357);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(450,-13,o),
+(556,100,o),
+(556,357,cs),
+(556,614,o),
+(450,727,o),
+(326,727,cs),
+(217,727,o),
+(157,651,o),
+(139,555,c),
+(145,555,l),
+(145,714,l),
+(62,714,l),
+(62,431,l),
+(141,431,l),
+(151,548,o),
+(197,641,o),
+(303,641,cs),
+(394,641,o),
+(463,561,o),
+(463,357,cs),
+(463,153,o),
+(395,73,o),
+(303,73,cs),
+(197,73,o),
+(151,166,o),
+(141,283,c),
+(62,283,l),
+(62,0,l),
+(145,0,l),
+(145,159,l),
+(139,159,l),
+(157,63,o),
+(217,-13,o),
+(326,-13,cs)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1630;
+unicode = 5680;
+},
+{
+color = 9;
+glyphname = "lheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (256,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 607;
+}
+);
+note = uni1631;
+unicode = 5681;
+},
+{
+color = 9;
+glyphname = "lhiCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (232,0);
+ref = dot_middle;
+}
+);
+width = 607;
+}
+);
+note = uni1632;
+unicode = 5682;
+},
+{
+color = 9;
+glyphname = "lhaCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(390,-13,o),
+(450,63,o),
+(467,159,c),
+(461,159,l),
+(461,0,l),
+(545,0,l),
+(545,283,l),
+(466,283,l),
+(456,166,o),
+(410,73,o),
+(304,73,cs),
+(212,73,o),
+(144,153,o),
+(144,357,cs),
+(144,561,o),
+(212,641,o),
+(304,641,cs),
+(410,641,o),
+(456,548,o),
+(466,431,c),
+(545,431,l),
+(545,714,l),
+(461,714,l),
+(461,555,l),
+(467,555,l),
+(450,651,o),
+(390,727,o),
+(280,727,cs),
+(157,727,o),
+(51,614,o),
+(51,357,cs),
+(51,100,o),
+(157,-13,o),
+(280,-13,cs)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1633;
+unicode = 5683;
+},
+{
+color = 9;
+glyphname = "tlhuCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(477,-13,o),
+(563,110,o),
+(563,319,cs),
+(563,496,o),
+(509,607,o),
+(417,653,c),
+(394,642,l),
+(556,642,l),
+(556,558,l),
+(625,558,l),
+(625,798,l),
+(556,798,l),
+(556,714,l),
+(357,714,l),
+(357,639,l),
+(431,597,o),
+(470,494,o),
+(470,337,cs),
+(470,155,o),
+(420,73,o),
+(309,73,cs),
+(199,73,o),
+(149,155,o),
+(149,337,cs),
+(149,494,o),
+(188,598,o),
+(263,639,c),
+(263,714,l),
+(49,714,l),
+(49,636,l),
+(218,636,l),
+(194,649,l),
+(107,600,o),
+(56,492,o),
+(56,319,cs),
+(56,110,o),
+(142,-13,o),
+(309,-13,cs)
+);
+}
+);
+width = 655;
+}
+);
+metricLeft = "lhuCarrier-canadian";
+note = uni1634;
+unicode = 5684;
+},
+{
+color = 9;
+glyphname = "tlhoCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,-84,l),
+(99,0,l),
+(298,0,l),
+(298,75,l),
+(224,117,o),
+(185,220,o),
+(185,377,cs),
+(185,559,o),
+(235,641,o),
+(346,641,cs),
+(456,641,o),
+(506,559,o),
+(506,377,cs),
+(506,220,o),
+(467,116,o),
+(392,75,c),
+(392,0,l),
+(606,0,l),
+(606,78,l),
+(438,78,l),
+(461,65,l),
+(549,114,o),
+(599,222,o),
+(599,395,cs),
+(599,604,o),
+(513,727,o),
+(346,727,cs),
+(178,727,o),
+(93,604,o),
+(93,395,cs),
+(93,218,o),
+(147,107,o),
+(238,61,c),
+(261,72,l),
+(99,72,l),
+(99,156,l),
+(30,156,l),
+(30,-84,l)
+);
+}
+);
+width = 655;
+}
+);
+metricLeft = "=|tlhuCarrier-canadian";
+metricRight = "lhuCarrier-canadian";
+note = uni1635;
+unicode = 5685;
+},
+{
+color = 9;
+glyphname = "tlheCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (313,357);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(460,-13,o),
+(566,100,o),
+(566,357,cs),
+(566,614,o),
+(460,727,o),
+(337,727,cs),
+(229,727,o),
+(156,658,o),
+(131,535,c),
+(141,530,l),
+(141,726,l),
+(207,726,l),
+(207,793,l),
+(6,793,l),
+(6,726,l),
+(72,726,l),
+(72,431,l),
+(151,431,l),
+(161,548,o),
+(207,641,o),
+(313,641,cs),
+(405,641,o),
+(473,566,o),
+(473,357,cs),
+(473,153,o),
+(405,73,o),
+(313,73,cs),
+(207,73,o),
+(161,166,o),
+(151,283,c),
+(72,283,l),
+(72,0,l),
+(156,0,l),
+(156,175,l),
+(149,162,l),
+(166,64,o),
+(226,-13,o),
+(337,-13,cs)
+);
+}
+);
+width = 617;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1636;
+unicode = 5686;
+},
+{
+color = 9;
+glyphname = "tlheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (267,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 617;
+}
+);
+note = uni1637;
+unicode = 5687;
+},
+{
+color = 9;
+glyphname = "tlhiCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (243,0);
+ref = dot_middle;
+}
+);
+width = 617;
+}
+);
+note = uni1638;
+unicode = 5688;
+},
+{
+color = 9;
+glyphname = "tlhaCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(391,-13,o),
+(451,64,o),
+(468,162,c),
+(461,175,l),
+(461,0,l),
+(545,0,l),
+(545,283,l),
+(466,283,l),
+(456,166,o),
+(410,73,o),
+(304,73,cs),
+(212,73,o),
+(144,153,o),
+(144,357,cs),
+(144,566,o),
+(212,641,o),
+(304,641,cs),
+(410,641,o),
+(456,548,o),
+(466,431,c),
+(545,431,l),
+(545,726,l),
+(611,726,l),
+(611,793,l),
+(410,793,l),
+(410,726,l),
+(476,726,l),
+(476,530,l),
+(486,535,l),
+(461,658,o),
+(389,727,o),
+(280,727,cs),
+(157,727,o),
+(51,614,o),
+(51,357,cs),
+(51,100,o),
+(157,-13,o),
+(280,-13,cs)
+);
+}
+);
+width = 617;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni1639;
+unicode = 5689;
+},
+{
+color = 9;
+glyphname = "tluCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(301,-13,o),
+(351,25,o),
+(372,111,c),
+(346,111,l),
+(366,25,o),
+(417,-13,o),
+(482,-13,cs),
+(594,-13,o),
+(662,71,o),
+(662,285,cs),
+(662,506,o),
+(608,612,o),
+(509,653,c),
+(488,642,l),
+(655,642,l),
+(655,558,l),
+(724,558,l),
+(724,798,l),
+(655,798,l),
+(655,714,l),
+(407,714,l),
+(407,638,l),
+(518,634,o),
+(568,527,o),
+(568,290,cs),
+(568,113,o),
+(532,72,o),
+(479,72,cs),
+(433,72,o),
+(403,113,o),
+(403,203,cs),
+(403,313,l),
+(315,313,l),
+(315,203,ls),
+(315,113,o),
+(285,72,o),
+(239,72,cs),
+(186,72,o),
+(150,113,o),
+(150,290,cs),
+(150,527,o),
+(200,634,o),
+(312,638,c),
+(312,714,l),
+(50,714,l),
+(50,636,l),
+(224,636,l),
+(201,649,l),
+(107,606,o),
+(57,501,o),
+(57,285,cs),
+(57,71,o),
+(124,-13,o),
+(235,-13,cs)
+);
+}
+);
+width = 754;
+}
+);
+metricRight = "tlhuCarrier-canadian";
+note = uni163A;
+unicode = 5690;
+},
+{
+color = 1;
+glyphname = "tloCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(724,-84,l),
+(724,156,l),
+(655,156,l),
+(655,72,l),
+(488,72,l),
+(509,61,l),
+(608,102,o),
+(662,208,o),
+(662,429,cs),
+(662,643,o),
+(594,727,o),
+(482,727,cs),
+(417,727,o),
+(366,689,o),
+(346,603,c),
+(372,603,l),
+(351,689,o),
+(301,727,o),
+(235,727,cs),
+(124,727,o),
+(57,643,o),
+(57,429,cs),
+(57,213,o),
+(107,108,o),
+(201,65,c),
+(224,78,l),
+(50,78,l),
+(50,0,l),
+(312,0,l),
+(312,76,l),
+(200,80,o),
+(150,187,o),
+(150,424,cs),
+(150,601,o),
+(186,642,o),
+(239,642,cs),
+(285,642,o),
+(315,601,o),
+(315,511,cs),
+(315,401,l),
+(403,401,l),
+(403,511,ls),
+(403,601,o),
+(433,642,o),
+(479,642,cs),
+(532,642,o),
+(568,601,o),
+(568,424,cs),
+(568,187,o),
+(518,80,o),
+(407,76,c),
+(407,0,l),
+(655,0,l),
+(655,-84,l)
+);
+}
+);
+width = 754;
+}
+);
+metricLeft = "tluCarrier-canadian";
+metricRight = "tlhuCarrier-canadian";
+note = uni163B;
+unicode = 5691;
+},
+{
+color = 9;
+glyphname = "tleCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (250,357);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(478,-13,o),
+(556,63,o),
+(556,186,cs),
+(556,282,o),
+(510,349,o),
+(430,365,c),
+(430,349,l),
+(510,365,o),
+(556,432,o),
+(556,528,cs),
+(556,651,o),
+(478,727,o),
+(353,727,cs),
+(237,727,o),
+(153,660,o),
+(132,546,c),
+(141,537,l),
+(141,726,l),
+(207,726,l),
+(207,793,l),
+(6,793,l),
+(6,726,l),
+(72,726,l),
+(72,431,l),
+(149,431,l),
+(151,557,o),
+(202,643,o),
+(327,643,cs),
+(416,643,o),
+(464,598,o),
+(464,514,cs),
+(464,439,o),
+(426,396,o),
+(360,396,cs),
+(330,396,l),
+(330,319,l),
+(360,319,ls),
+(427,319,o),
+(464,276,o),
+(464,201,cs),
+(464,116,o),
+(416,71,o),
+(327,71,cs),
+(202,71,o),
+(151,157,o),
+(149,283,c),
+(72,283,l),
+(72,0,l),
+(156,0,l),
+(156,158,l),
+(142,146,l),
+(169,48,o),
+(243,-13,o),
+(353,-13,cs)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni163C;
+unicode = 5692;
+},
+{
+color = 9;
+glyphname = "tleeCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (204,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 615;
+}
+);
+note = uni163D;
+unicode = 5693;
+},
+{
+color = 9;
+glyphname = "tliCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (188,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 615;
+}
+);
+note = uni163E;
+unicode = 5694;
+},
+{
+color = 9;
+glyphname = "tlaCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(373,-13,o),
+(447,48,o),
+(473,146,c),
+(460,158,l),
+(460,0,l),
+(543,0,l),
+(543,283,l),
+(466,283,l),
+(465,157,o),
+(414,71,o),
+(289,71,cs),
+(200,71,o),
+(151,116,o),
+(151,201,cs),
+(151,276,o),
+(189,319,o),
+(255,319,cs),
+(287,319,l),
+(287,396,l),
+(255,396,ls),
+(189,396,o),
+(151,439,o),
+(151,514,cs),
+(151,598,o),
+(199,643,o),
+(288,643,cs),
+(414,643,o),
+(465,557,o),
+(466,431,c),
+(543,431,l),
+(543,726,l),
+(609,726,l),
+(609,793,l),
+(409,793,l),
+(409,726,l),
+(474,726,l),
+(474,537,l),
+(483,546,l),
+(463,660,o),
+(379,727,o),
+(262,727,cs),
+(137,727,o),
+(59,651,o),
+(59,528,cs),
+(59,432,o),
+(106,365,o),
+(185,349,c),
+(185,365,l),
+(106,349,o),
+(59,282,o),
+(59,186,cs),
+(59,63,o),
+(137,-13,o),
+(262,-13,cs)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni163F;
+unicode = 5695;
+},
+{
+color = 9;
+glyphname = "zuCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(465,-13,o),
+(562,80,o),
+(562,234,cs),
+(562,351,o),
+(487,499,o),
+(487,575,cs),
+(487,605,o),
+(500,633,o),
+(546,633,cs),
+(570,633,l),
+(570,714,l),
+(523,714,ls),
+(435,714,o),
+(397,664,o),
+(397,589,cs),
+(397,498,o),
+(469,357,o),
+(469,248,cs),
+(469,138,o),
+(411,73,o),
+(308,73,cs),
+(205,73,o),
+(148,137,o),
+(148,248,cs),
+(148,357,o),
+(220,498,o),
+(220,589,cs),
+(220,664,o),
+(182,714,o),
+(94,714,cs),
+(47.009,714,l),
+(47,633,l),
+(71,633,ls),
+(116,633,o),
+(130,605,o),
+(130,575,cs),
+(130,499,o),
+(55,351,o),
+(55,234,cs),
+(55,80,o),
+(151,-13,o),
+(308,-13,cs)
+);
+}
+);
+width = 617;
+}
+);
+metricRight = "=|";
+note = uni1640;
+unicode = 5696;
+},
+{
+color = 9;
+glyphname = "zoCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(94,0,ls),
+(182,0,o),
+(220,50,o),
+(220,125,cs),
+(220,216,o),
+(148,357,o),
+(148,466,cs),
+(148,576,o),
+(206,641,o),
+(309,641,cs),
+(412,641,o),
+(469,577,o),
+(469,466,cs),
+(469,357,o),
+(397,216,o),
+(397,125,cs),
+(397,50,o),
+(436,0,o),
+(523,0,cs),
+(570,0,l),
+(570,81,l),
+(546,81,ls),
+(501,81,o),
+(487,109,o),
+(487,139,cs),
+(487,215,o),
+(563,363,o),
+(563,480,cs),
+(563,634,o),
+(466,727,o),
+(309,727,cs),
+(152,727,o),
+(56,634,o),
+(56,480,cs),
+(56,363,o),
+(130,215,o),
+(130,139,cs),
+(130,109,o),
+(117,81,o),
+(71,81,cs),
+(47,81,l),
+(47.009,0,l)
+);
+}
+);
+width = 617;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1641;
+unicode = 5697;
+},
+{
+color = 9;
+glyphname = "zeCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (298,357);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(460,-13,o),
+(538,99,o),
+(538,357,cs),
+(538,615,o),
+(460,727,o),
+(354,727,cs),
+(270,727,o),
+(199,625,o),
+(162,625,cs),
+(142,625,o),
+(128,638,o),
+(128,683,cs),
+(128,714,l),
+(44,714,l),
+(44,656,ls),
+(44,579,o),
+(83,543,o),
+(136,543,cs),
+(206,543,o),
+(269,641,o),
+(332,641,cs),
+(394,641,o),
+(445,571,o),
+(445,357,cs),
+(445,143,o),
+(394,73,o),
+(332,73,cs),
+(269,73,o),
+(206,171,o),
+(136,171,cs),
+(83,171,o),
+(44,135,o),
+(44,58,cs),
+(44,0,l),
+(128,0,l),
+(128,31,ls),
+(128,76,o),
+(142,89,o),
+(162,89,cs),
+(199,89,o),
+(270,-13,o),
+(354,-13,cs)
+);
+}
+);
+width = 589;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1642;
+unicode = 5698;
+},
+{
+color = 9;
+glyphname = "zeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (252,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 589;
+}
+);
+note = uni1643;
+unicode = 5699;
+},
+{
+color = 9;
+glyphname = "ziCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (228,0);
+ref = dot_middle;
+}
+);
+width = 589;
+}
+);
+note = uni1644;
+unicode = 5700;
+},
+{
+color = 9;
+glyphname = "zaCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(319,-13,o),
+(390,89,o),
+(427,89,cs),
+(447,89,o),
+(461,76,o),
+(461,31,cs),
+(461,0,l),
+(545,0,l),
+(545,58,ls),
+(545,135,o),
+(506,171,o),
+(453,171,cs),
+(383,171,o),
+(320,73,o),
+(257,73,cs),
+(195,73,o),
+(144,143,o),
+(144,357,cs),
+(144,571,o),
+(195,641,o),
+(257,641,cs),
+(320,641,o),
+(383,543,o),
+(453,543,cs),
+(506,543,o),
+(545,579,o),
+(545,656,cs),
+(545,714,l),
+(461,714,l),
+(461,683,ls),
+(461,638,o),
+(447,625,o),
+(427,625,cs),
+(390,625,o),
+(319,727,o),
+(235,727,cs),
+(129,727,o),
+(51,615,o),
+(51,357,cs),
+(51,99,o),
+(129,-13,o),
+(235,-13,cs)
+);
+}
+);
+width = 589;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|zeCarrier-canadian";
+note = uni1645;
+unicode = 5701;
+},
+{
+color = 6;
+glyphname = "zCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(300.008,189,l),
+(300,250,l),
+(118,250,l),
+(118,212,l),
+(297,512,l),
+(297,546,l),
+(51,546,l),
+(51,485,l),
+(230,485,l),
+(230,523,l),
+(51,223,l),
+(51,189,l)
+);
+}
+);
+width = 351;
+}
+);
+metricRight = "=|";
+note = uni1646;
+unicode = 5702;
+},
+{
+color = 6;
+glyphname = "initialzCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(143,189,l),
+(143,99,l),
+(206,99,l),
+(206,189,l),
+(300.008,189,l),
+(300,250,l),
+(98,250,l),
+(119,213,l),
+(297,512,l),
+(297,546,l),
+(206,546,l),
+(206,636,l),
+(143,636,l),
+(143,546,l),
+(51,546,l),
+(51,485,l),
+(250,485,l),
+(229,522,l),
+(51,223,l),
+(51,189,l)
+);
+}
+);
+width = 351;
+}
+);
+metricLeft = "zCarrier-canadian";
+metricRight = "zCarrier-canadian";
+note = uni1647;
+unicode = 5703;
+},
+{
+color = 9;
+glyphname = "dzuCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(465,-13,o),
+(562,80,o),
+(562,234,cs),
+(562,351,o),
+(487,499,o),
+(487,575,cs),
+(487,605,o),
+(500,633,o),
+(546,633,cs),
+(570,633,l),
+(570,714,l),
+(527,714,ls),
+(443,714,o),
+(402,664,o),
+(402,589,cs),
+(402,498,o),
+(469,361,o),
+(469,248,cs),
+(469,138,o),
+(412,73,o),
+(308,73,cs),
+(204,73,o),
+(148,137,o),
+(148,248,cs),
+(148,361,o),
+(215,498,o),
+(215,589,cs),
+(215,664,o),
+(174,714,o),
+(90,714,cs),
+(47.009,714,l),
+(47,633,l),
+(71,633,ls),
+(116,633,o),
+(130,605,o),
+(130,575,cs),
+(130,499,o),
+(55,351,o),
+(55,234,cs),
+(55,80,o),
+(151,-13,o),
+(308,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(329,499,l),
+(329,675,l),
+(379,675,l),
+(379,714,l),
+(238,714,l),
+(238,675,l),
+(288,675,l),
+(288,499,l)
+);
+}
+);
+width = 617;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1648;
+unicode = 5704;
+},
+{
+color = 9;
+glyphname = "dzoCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(90,0,ls),
+(174,0,o),
+(216,50,o),
+(216,125,cs),
+(216,216,o),
+(148,353,o),
+(148,466,cs),
+(148,576,o),
+(205,641,o),
+(309,641,cs),
+(413,641,o),
+(469,577,o),
+(469,466,cs),
+(469,353,o),
+(402,216,o),
+(402,125,cs),
+(402,50,o),
+(444,0,o),
+(527,0,cs),
+(570,0,l),
+(570,81,l),
+(546,81,ls),
+(501,81,o),
+(487,109,o),
+(487,139,cs),
+(487,215,o),
+(563,363,o),
+(563,480,cs),
+(563,634,o),
+(466,727,o),
+(309,727,cs),
+(152,727,o),
+(56,634,o),
+(56,480,cs),
+(56,363,o),
+(130,215,o),
+(130,139,cs),
+(130,109,o),
+(117,81,o),
+(71,81,cs),
+(47,81,l),
+(47.009,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(380,0,l),
+(380,39,l),
+(329,39,l),
+(329,215,l),
+(289,215,l),
+(289,39,l),
+(238,39,l),
+(238,0,l)
+);
+}
+);
+width = 617;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1649;
+unicode = 5705;
+},
+{
+color = 9;
+glyphname = "dzeCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (317,357);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(478,-13,o),
+(556,99,o),
+(556,357,cs),
+(556,615,o),
+(478,727,o),
+(371,727,cs),
+(288,727,o),
+(217,625,o),
+(180,625,cs),
+(160,625,o),
+(146,638,o),
+(146,683,cs),
+(146,714,l),
+(62,714,l),
+(62,656,ls),
+(62,579,o),
+(100,543,o),
+(154,543,cs),
+(224,543,o),
+(287,641,o),
+(350,641,cs),
+(411,641,o),
+(463,571,o),
+(463,357,cs),
+(463,143,o),
+(411,73,o),
+(350,73,cs),
+(287,73,o),
+(224,171,o),
+(154,171,cs),
+(100,171,o),
+(62,135,o),
+(62,58,cs),
+(62,0,l),
+(146,0,l),
+(146,31,ls),
+(146,73,o),
+(160,86,o),
+(180,86,cs),
+(217,86,o),
+(288,-13,o),
+(371,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(113,250,l),
+(113,331,l),
+(219,331,l),
+(219,383,l),
+(113,383,l),
+(113,464,l),
+(62,464,l),
+(62,250,l)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164A;
+unicode = 5706;
+},
+{
+color = 9;
+glyphname = "dzeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+ref = "dzeCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (271,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 607;
+}
+);
+metricLeft = "dzeCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164B;
+unicode = 5707;
+},
+{
+color = 9;
+glyphname = "dziCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "dzeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (247,0);
+ref = dot_middle;
+}
+);
+width = 607;
+}
+);
+note = uni164C;
+unicode = 5708;
+},
+{
+color = 9;
+glyphname = "dzaCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(319,-13,o),
+(390,86,o),
+(427,86,cs),
+(447,86,o),
+(461,73,o),
+(461,31,cs),
+(461,0,l),
+(545,0,l),
+(545,58,ls),
+(545,135,o),
+(506,171,o),
+(453,171,cs),
+(383,171,o),
+(320,73,o),
+(257,73,cs),
+(195,73,o),
+(144,143,o),
+(144,357,cs),
+(144,571,o),
+(195,641,o),
+(257,641,cs),
+(320,641,o),
+(383,543,o),
+(453,543,cs),
+(506,543,o),
+(545,579,o),
+(545,656,cs),
+(545,714,l),
+(461,714,l),
+(461,683,ls),
+(461,638,o),
+(447,625,o),
+(427,625,cs),
+(390,625,o),
+(319,727,o),
+(235,727,cs),
+(129,727,o),
+(51,615,o),
+(51,357,cs),
+(51,99,o),
+(129,-13,o),
+(235,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(545,250,l),
+(545,464,l),
+(493,464,l),
+(493,383,l),
+(388,383,l),
+(388,331,l),
+(493,331,l),
+(493,250,l)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dzeCarrier-canadian";
+note = uni164D;
+unicode = 5709;
+},
+{
+color = 9;
+glyphname = "suCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(301,-13,o),
+(353,40,o),
+(372,142,c),
+(343,142,l),
+(362,40,o),
+(415,-13,o),
+(497,-13,cs),
+(599,-13,o),
+(661,64,o),
+(661,184,cs),
+(661,314,o),
+(592,476,o),
+(592,575,cs),
+(592,605,o),
+(604,633,o),
+(648,633,cs),
+(667,633,l),
+(667,714,l),
+(626,714,ls),
+(538,714,o),
+(503,665,o),
+(503,588,cs),
+(503,481,o),
+(570,302,o),
+(570,192,cs),
+(570,113,o),
+(541,72,o),
+(487,72,cs),
+(430,72,o),
+(398,119,o),
+(398,213,cs),
+(398,714,l),
+(317,714,l),
+(317,213,ls),
+(317,120,o),
+(285,72,o),
+(228,72,cs),
+(175,72,o),
+(145,113,o),
+(145,192,cs),
+(145,302,o),
+(212,481,o),
+(212,588,cs),
+(212,665,o),
+(176,714,o),
+(89,714,cs),
+(48,714,l),
+(48,633,l),
+(66,633,ls),
+(111,633,o),
+(124,604,o),
+(124,575,cs),
+(124,476,o),
+(54,314,o),
+(54,184,cs),
+(54,63,o),
+(116,-13,o),
+(219,-13,cs)
+);
+}
+);
+width = 715;
+}
+);
+metricRight = "=|";
+note = uni164E;
+unicode = 5710;
+},
+{
+color = 9;
+glyphname = "soCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(89,0,ls),
+(176,0,o),
+(211,49,o),
+(211,126,cs),
+(211,233,o),
+(144,412,o),
+(144,522,cs),
+(144,601,o),
+(173,642,o),
+(227,642,cs),
+(284,642,o),
+(316,595,o),
+(316,501,cs),
+(316,0,l),
+(398,0,l),
+(398,501,ls),
+(398,594,o),
+(430,642,o),
+(486,642,cs),
+(540,642,o),
+(570,601,o),
+(570,522,cs),
+(570,412,o),
+(503,233,o),
+(503,126,cs),
+(503,49,o),
+(538,0,o),
+(626,0,cs),
+(667,0,l),
+(667,81,l),
+(648,81,ls),
+(604,81,o),
+(591,110,o),
+(591,139,cs),
+(591,238,o),
+(661,400,o),
+(661,530,cs),
+(661,651,o),
+(598,727,o),
+(496,727,cs),
+(414,727,o),
+(361,674,o),
+(343,572,c),
+(371,572,l),
+(353,674,o),
+(300,727,o),
+(218,727,cs),
+(116,727,o),
+(53,650,o),
+(53,530,cs),
+(53,400,o),
+(123,238,o),
+(123,139,cs),
+(123,109,o),
+(111,81,o),
+(66,81,cs),
+(48,81,l),
+(48,0,l)
+);
+}
+);
+width = 715;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5711;
+},
+{
+color = 9;
+glyphname = "seCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(482,-13,o),
+(546,64,o),
+(546,180,cs),
+(546,288,o),
+(493,358,o),
+(406,367,c),
+(406,347,l),
+(493,356,o),
+(546,426,o),
+(546,534,cs),
+(546,650,o),
+(482,727,o),
+(391,727,cs),
+(302,727,o),
+(220,625,o),
+(178,625,cs),
+(159,625,o),
+(145,638,o),
+(145,683,cs),
+(145,714,l),
+(61,714,l),
+(61,656,ls),
+(61,579,o),
+(100,543,o),
+(153,543,cs),
+(225,543,o),
+(302,643,o),
+(365,643,cs),
+(420,643,o),
+(454,597,o),
+(454,522,cs),
+(454,439,o),
+(411,395,o),
+(342,395,cs),
+(61,395,l),
+(61,319,l),
+(342,319,ls),
+(412,319,o),
+(454,275,o),
+(454,192,cs),
+(454,117,o),
+(420,71,o),
+(365,71,cs),
+(302,71,o),
+(225,171,o),
+(153,171,cs),
+(100,171,o),
+(61,135,o),
+(61,58,cs),
+(61,0,l),
+(145,0,l),
+(145,31,ls),
+(145,76,o),
+(159,89,o),
+(178,89,cs),
+(220,89,o),
+(302,-13,o),
+(391,-13,cs)
+);
+}
+);
+width = 605;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni1650;
+unicode = 5712;
+},
+{
+color = 9;
+glyphname = "seeCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(482,-13,o),
+(546,64,o),
+(546,180,cs),
+(546,281,o),
+(499,349,o),
+(422,365,c),
+(422,349,l),
+(499,365,o),
+(546,432,o),
+(546,534,cs),
+(546,650,o),
+(482,727,o),
+(391,727,cs),
+(302,727,o),
+(220,625,o),
+(178,625,cs),
+(159,625,o),
+(145,638,o),
+(145,683,cs),
+(145,714,l),
+(61,714,l),
+(61,656,ls),
+(61,579,o),
+(100,543,o),
+(153,543,cs),
+(225,543,o),
+(302,643,o),
+(365,643,cs),
+(420,643,o),
+(454,597,o),
+(454,522,cs),
+(454,439,o),
+(411,393,o),
+(343,393,cs),
+(289,393,l),
+(312,365,l),
+(312,475,l),
+(261,475,l),
+(261,393,l),
+(61,393,l),
+(61,321,l),
+(261,321,l),
+(261,231,l),
+(312,231,l),
+(312,345,l),
+(289,321,l),
+(343,321,ls),
+(412,321,o),
+(454,275,o),
+(454,192,cs),
+(454,117,o),
+(420,71,o),
+(365,71,cs),
+(302,71,o),
+(225,171,o),
+(153,171,cs),
+(100,171,o),
+(61,135,o),
+(61,58,cs),
+(61,0,l),
+(145,0,l),
+(145,31,ls),
+(145,76,o),
+(159,89,o),
+(178,89,cs),
+(220,89,o),
+(302,-13,o),
+(391,-13,cs)
+);
+}
+);
+width = 605;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1651;
+unicode = 5713;
+},
+{
+color = 9;
+glyphname = "siCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(482,-13,o),
+(546,64,o),
+(546,180,cs),
+(546,281,o),
+(499,349,o),
+(422,365,c),
+(422,349,l),
+(499,365,o),
+(546,432,o),
+(546,534,cs),
+(546,650,o),
+(482,727,o),
+(391,727,cs),
+(302,727,o),
+(220,625,o),
+(178,625,cs),
+(159,625,o),
+(145,638,o),
+(145,683,cs),
+(145,714,l),
+(61,714,l),
+(61,656,ls),
+(61,579,o),
+(100,543,o),
+(153,543,cs),
+(225,543,o),
+(302,643,o),
+(365,643,cs),
+(420,643,o),
+(454,596,o),
+(454,519,cs),
+(454,435,o),
+(415,392,o),
+(351,392,cs),
+(301,392,l),
+(338,364,l),
+(334,403,o),
+(304,432,o),
+(265,432,cs),
+(238,432,o),
+(214,416,o),
+(202,393,c),
+(61,393,l),
+(61,321,l),
+(203,321,l),
+(214,298,o),
+(238,282,o),
+(265,282,cs),
+(304,282,o),
+(333,312,o),
+(337,349,c),
+(300,322,l),
+(351,322,ls),
+(417,322,o),
+(454,279,o),
+(454,195,cs),
+(454,118,o),
+(420,71,o),
+(365,71,cs),
+(302,71,o),
+(225,171,o),
+(153,171,cs),
+(100,171,o),
+(61,135,o),
+(61,58,cs),
+(61,0,l),
+(145,0,l),
+(145,31,ls),
+(145,76,o),
+(159,89,o),
+(178,89,cs),
+(220,89,o),
+(302,-13,o),
+(391,-13,cs)
+);
+}
+);
+width = 605;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1652;
+unicode = 5714;
+},
+{
+color = 9;
+glyphname = "saCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(304,-13,o),
+(385,89,o),
+(427,89,cs),
+(446,89,o),
+(460,76,o),
+(460,31,cs),
+(460,0,l),
+(544,0,l),
+(544,58,ls),
+(544,135,o),
+(505,171,o),
+(452,171,cs),
+(380,171,o),
+(303,71,o),
+(240,71,cs),
+(185,71,o),
+(151,117,o),
+(151,192,cs),
+(151,275,o),
+(193,319,o),
+(263,319,cs),
+(544,319,l),
+(544,395,l),
+(263,395,ls),
+(194,395,o),
+(151,439,o),
+(151,522,cs),
+(151,597,o),
+(185,643,o),
+(241,643,cs),
+(303,643,o),
+(380,543,o),
+(452,543,cs),
+(505,543,o),
+(544,579,o),
+(544,656,cs),
+(544,714,l),
+(460,714,l),
+(460,683,ls),
+(460,638,o),
+(446,625,o),
+(427,625,cs),
+(385,625,o),
+(304,727,o),
+(214,727,cs),
+(124,727,o),
+(59,650,o),
+(59,534,cs),
+(59,426,o),
+(112,356,o),
+(199,347,c),
+(199,367,l),
+(112,358,o),
+(59,288,o),
+(59,180,cs),
+(59,64,o),
+(124,-13,o),
+(214,-13,cs)
+);
+}
+);
+width = 605;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1653;
+unicode = 5715;
+},
+{
+color = 9;
+glyphname = "shuCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(297,-13,o),
+(348,35,o),
+(369,128,c),
+(346,128,l),
+(367,35,o),
+(418,-13,o),
+(497,-13,cs),
+(599,-13,o),
+(661,64,o),
+(661,184,cs),
+(661,314,o),
+(592,476,o),
+(592,575,cs),
+(592,605,o),
+(604,633,o),
+(648,633,cs),
+(667,633,l),
+(667,714,l),
+(626,714,ls),
+(538,714,o),
+(504,665,o),
+(504,588,cs),
+(504,570,o),
+(506,550,o),
+(509,531,c),
+(523,580,l),
+(398,580,l),
+(398,714,l),
+(317,714,l),
+(317,580,l),
+(192,580,l),
+(207,531,l),
+(209,550,o),
+(211,570,o),
+(211,588,cs),
+(211,665,o),
+(176,714,o),
+(89,714,cs),
+(48,714,l),
+(48,633,l),
+(66,633,ls),
+(111,633,o),
+(124,604,o),
+(124,575,cs),
+(124,476,o),
+(54,314,o),
+(54,184,cs),
+(54,63,o),
+(116,-13,o),
+(219,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(175,72,o),
+(145,113,o),
+(145,192,cs),
+(145,278,o),
+(186,404,o),
+(203,506,c),
+(317,506,l),
+(317,213,ls),
+(317,120,o),
+(285,72,o),
+(228,72,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(430,72,o),
+(398,119,o),
+(398,213,cs),
+(398,506,l),
+(512,506,l),
+(529,404,o),
+(570,278,o),
+(570,192,cs),
+(570,113,o),
+(541,72,o),
+(487,72,cs)
+);
+}
+);
+width = 715;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1654;
+unicode = 5716;
+},
+{
+color = 9;
+glyphname = "shoCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(89,0,ls),
+(176,0,o),
+(211,49,o),
+(211,126,cs),
+(211,144,o),
+(208,164,o),
+(206,183,c),
+(192,134,l),
+(316,134,l),
+(316,0,l),
+(398,0,l),
+(398,134,l),
+(522,134,l),
+(508,183,l),
+(506,164,o),
+(504,144,o),
+(504,126,cs),
+(504,49,o),
+(538,0,o),
+(626,0,cs),
+(667,0,l),
+(667,81,l),
+(648,81,ls),
+(604,81,o),
+(591,110,o),
+(591,139,cs),
+(591,238,o),
+(661,400,o),
+(661,530,cs),
+(661,651,o),
+(598,727,o),
+(496,727,cs),
+(418,727,o),
+(367,679,o),
+(345,586,c),
+(368,586,l),
+(348,679,o),
+(296,727,o),
+(218,727,cs),
+(116,727,o),
+(53,650,o),
+(53,530,cs),
+(53,400,o),
+(123,238,o),
+(123,139,cs),
+(123,109,o),
+(111,81,o),
+(66,81,cs),
+(48,81,l),
+(48,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(185,310,o),
+(144,436,o),
+(144,522,cs),
+(144,601,o),
+(173,642,o),
+(227,642,cs),
+(284,642,o),
+(316,595,o),
+(316,501,cs),
+(316,208,l),
+(203,208,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(398,501,ls),
+(398,594,o),
+(430,642,o),
+(486,642,cs),
+(540,642,o),
+(570,601,o),
+(570,522,cs),
+(570,436,o),
+(529,310,o),
+(511,208,c),
+(398,208,l)
+);
+}
+);
+width = 715;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1655;
+unicode = 5717;
+},
+{
+color = 9;
+glyphname = "sheCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(482,-13,o),
+(546,64,o),
+(546,180,cs),
+(546,281,o),
+(499,349,o),
+(422,365,c),
+(422,349,l),
+(499,365,o),
+(546,432,o),
+(546,534,cs),
+(546,650,o),
+(482,727,o),
+(391,727,cs),
+(302,727,o),
+(220,625,o),
+(178,625,cs),
+(159,625,o),
+(145,638,o),
+(145,683,cs),
+(145,714,l),
+(61,714,l),
+(61,656,ls),
+(61,579,o),
+(100,545,o),
+(153,545,cs),
+(171,545,o),
+(189,551,o),
+(206,559,c),
+(152,574,l),
+(152,395,l),
+(61,395,l),
+(61,319,l),
+(152,319,l),
+(152,140,l),
+(205,155,l),
+(188,163,o),
+(171,169,o),
+(153,169,cs),
+(100,169,o),
+(61,135,o),
+(61,58,cs),
+(61,0,l),
+(145,0,l),
+(145,31,ls),
+(145,76,o),
+(159,89,o),
+(178,89,cs),
+(220,89,o),
+(302,-13,o),
+(391,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(225,319,l),
+(342,319,ls),
+(412,319,o),
+(454,275,o),
+(454,192,cs),
+(454,117,o),
+(420,71,o),
+(365,71,cs),
+(322,71,o),
+(273,116,o),
+(225,144,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(225,570,l),
+(273,598,o),
+(322,643,o),
+(365,643,cs),
+(420,643,o),
+(454,597,o),
+(454,522,cs),
+(454,439,o),
+(411,395,o),
+(342,395,cs),
+(225,395,l)
+);
+}
+);
+width = 605;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1656;
+unicode = 5718;
+},
+{
+color = 9;
+glyphname = "sheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(482,-13,o),
+(546,64,o),
+(546,180,cs),
+(546,281,o),
+(499,349,o),
+(422,365,c),
+(422,349,l),
+(499,365,o),
+(546,432,o),
+(546,534,cs),
+(546,650,o),
+(482,727,o),
+(391,727,cs),
+(302,727,o),
+(220,625,o),
+(178,625,cs),
+(159,625,o),
+(145,638,o),
+(145,683,cs),
+(145,714,l),
+(61,714,l),
+(61,656,ls),
+(61,579,o),
+(100,545,o),
+(153,545,cs),
+(167,545,o),
+(182,549,o),
+(197,556,c),
+(152,572,l),
+(152,389,l),
+(61,389,l),
+(61,325,l),
+(152,325,l),
+(152,142,l),
+(198,158,l),
+(183,165,o),
+(168,169,o),
+(153,169,cs),
+(100,169,o),
+(61,135,o),
+(61,58,cs),
+(61,0,l),
+(145,0,l),
+(145,31,ls),
+(145,76,o),
+(159,89,o),
+(178,89,cs),
+(220,89,o),
+(302,-13,o),
+(391,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(321,69,o),
+(266,123,o),
+(211,151,c),
+(211,325,l),
+(298,325,l),
+(298,231,l),
+(342,231,l),
+(342,341,l),
+(322,325,l),
+(353,325,ls),
+(419,325,o),
+(457,275,o),
+(457,196,cs),
+(457,116,o),
+(423,69,o),
+(367,69,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(342,475,l),
+(298,475,l),
+(298,389,l),
+(211,389,l),
+(211,563,l),
+(266,591,o),
+(321,645,o),
+(367,645,cs),
+(423,645,o),
+(457,598,o),
+(457,518,cs),
+(457,439,o),
+(417,389,o),
+(353,389,cs),
+(322,389,l),
+(342,373,l)
+);
+}
+);
+width = 605;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1657;
+unicode = 5719;
+},
+{
+color = 9;
+glyphname = "shiCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(61,656,ls),
+(61,579,o),
+(100,545,o),
+(153,545,cs),
+(166,545,o),
+(179,549,o),
+(191,554,c),
+(152,571,l),
+(152,389,l),
+(61,389,l),
+(61,325,l),
+(152,325,l),
+(152,143,l),
+(191,160,l),
+(179,165,o),
+(166,169,o),
+(153,169,cs),
+(100,169,o),
+(61,135,o),
+(61,58,cs),
+(61,0,l),
+(145,0,l),
+(145,31,ls),
+(145,76,o),
+(159,89,o),
+(178,89,cs),
+(220,89,o),
+(302,-13,o),
+(391,-13,cs),
+(482,-13,o),
+(546,64,o),
+(546,180,cs),
+(546,281,o),
+(499,349,o),
+(422,365,c),
+(422,349,l),
+(499,365,o),
+(546,432,o),
+(546,534,cs),
+(546,650,o),
+(482,727,o),
+(391,727,cs),
+(302,727,o),
+(220,625,o),
+(178,625,cs),
+(159,625,o),
+(145,638,o),
+(145,683,cs),
+(145,714,l),
+(61,714,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(211,325,l),
+(258,325,l),
+(269,298,o),
+(293,282,o),
+(319,282,cs),
+(356,282,o),
+(385,315,o),
+(386,349,c),
+(330,324,l),
+(359,324,ls),
+(421,324,o),
+(457,276,o),
+(457,196,cs),
+(457,116,o),
+(423,69,o),
+(367,69,cs),
+(321,69,o),
+(265,123,o),
+(211,151,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(211,563,l),
+(265,591,o),
+(321,645,o),
+(367,645,cs),
+(423,645,o),
+(457,598,o),
+(457,518,cs),
+(457,438,o),
+(419,390,o),
+(359,390,cs),
+(331,390,l),
+(386,364,l),
+(386,400,o),
+(357,432,o),
+(319,432,cs),
+(293,432,o),
+(269,416,o),
+(258,389,c),
+(211,389,l)
+);
+}
+);
+width = 605;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1658;
+unicode = 5720;
+},
+{
+color = 9;
+glyphname = "shaCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(304,-13,o),
+(385,89,o),
+(427,89,cs),
+(446,89,o),
+(460,76,o),
+(460,31,cs),
+(460,0,l),
+(544,0,l),
+(544,58,ls),
+(544,135,o),
+(505,169,o),
+(452,169,cs),
+(434,169,o),
+(417,163,o),
+(399,155,c),
+(453,140,l),
+(453,319,l),
+(544,319,l),
+(544,395,l),
+(453,395,l),
+(453,574,l),
+(400,559,l),
+(417,551,o),
+(434,545,o),
+(452,545,cs),
+(505,545,o),
+(544,579,o),
+(544,656,cs),
+(544,714,l),
+(460,714,l),
+(460,683,ls),
+(460,638,o),
+(446,625,o),
+(427,625,cs),
+(385,625,o),
+(304,727,o),
+(214,727,cs),
+(124,727,o),
+(59,650,o),
+(59,534,cs),
+(59,432,o),
+(106,365,o),
+(184,349,c),
+(184,365,l),
+(106,349,o),
+(59,281,o),
+(59,180,cs),
+(59,64,o),
+(124,-13,o),
+(214,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(185,71,o),
+(151,117,o),
+(151,192,cs),
+(151,275,o),
+(193,319,o),
+(263,319,cs),
+(380,319,l),
+(380,144,l),
+(333,116,o),
+(283,71,o),
+(240,71,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(194,395,o),
+(151,439,o),
+(151,522,cs),
+(151,597,o),
+(185,643,o),
+(241,643,cs),
+(283,643,o),
+(333,598,o),
+(380,570,c),
+(380,395,l),
+(263,395,ls)
+);
+}
+);
+width = 605;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1659;
+unicode = 5721;
+},
+{
+color = 6;
+glyphname = "shCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,99,l),
+(200,202,l),
+(155,190,l),
+(179,190,ls),
+(251,190,o),
+(289,227,o),
+(289,292,cs),
+(289,355,o),
+(254,394,o),
+(188,394,cs),
+(164,394,ls),
+(131,394,o),
+(111,407,o),
+(111,443,cs),
+(111,480,o),
+(131,493,o),
+(164,493,cs),
+(284,493,l),
+(284,546,l),
+(200,546,l),
+(200,636,l),
+(140,636,l),
+(140,528,l),
+(183,546,l),
+(161,546,ls),
+(88,546,o),
+(51,508,o),
+(51,443,cs),
+(51,381,o),
+(86,342,o),
+(151,342,cs),
+(177,342,ls),
+(209,342,o),
+(229,328,o),
+(229,292,cs),
+(229,256,o),
+(209,242,o),
+(177,242,cs),
+(56,242,l),
+(56,190,l),
+(140,190,l),
+(140,99,l)
+);
+}
+);
+width = 340;
+}
+);
+metricRight = "=|";
+note = uni18F5;
+unicode = 5722;
+},
+{
+color = 9;
+glyphname = "tsuCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(297,-13,o),
+(348,35,o),
+(369,128,c),
+(346,128,l),
+(367,35,o),
+(418,-13,o),
+(497,-13,cs),
+(599,-13,o),
+(661,64,o),
+(661,184,cs),
+(661,314,o),
+(592,476,o),
+(592,575,cs),
+(592,605,o),
+(604,633,o),
+(648,633,cs),
+(667,633,l),
+(667,714,l),
+(626,714,ls),
+(540,714,o),
+(506,668,o),
+(506,591,cs),
+(506,537,o),
+(527,467,o),
+(543,394,c),
+(397,394,l),
+(397,649,l),
+(458,649,l),
+(458,714,l),
+(257,714,l),
+(257,649,l),
+(318,649,l),
+(318,394,l),
+(172,394,l),
+(189,467,o),
+(209,537,o),
+(209,591,cs),
+(209,668,o),
+(174,714,o),
+(89,714,cs),
+(48,714,l),
+(48,633,l),
+(66,633,ls),
+(111,633,o),
+(124,604,o),
+(124,575,cs),
+(124,476,o),
+(54,314,o),
+(54,184,cs),
+(54,63,o),
+(116,-13,o),
+(219,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(175,72,o),
+(145,113,o),
+(145,192,cs),
+(145,229,o),
+(152,274,o),
+(162,320,c),
+(318,320,l),
+(318,213,ls),
+(318,120,o),
+(286,72,o),
+(229,72,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(429,72,o),
+(397,119,o),
+(397,213,cs),
+(397,320,l),
+(554,320,l),
+(563,274,o),
+(570,229,o),
+(570,192,cs),
+(570,113,o),
+(540,72,o),
+(486,72,cs)
+);
+}
+);
+width = 715;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165B;
+unicode = 5723;
+},
+{
+color = 9;
+glyphname = "tsoCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(89,0,ls),
+(174,0,o),
+(208,46,o),
+(208,123,cs),
+(208,177,o),
+(188,247,o),
+(172,320,c),
+(318,320,l),
+(318,65,l),
+(257,65,l),
+(257,0,l),
+(458,0,l),
+(458,65,l),
+(396,65,l),
+(396,320,l),
+(543,320,l),
+(526,247,o),
+(506,177,o),
+(506,123,cs),
+(506,46,o),
+(540,0,o),
+(626,0,cs),
+(667,0,l),
+(667,81,l),
+(648,81,ls),
+(604,81,o),
+(591,110,o),
+(591,139,cs),
+(591,238,o),
+(661,400,o),
+(661,530,cs),
+(661,651,o),
+(598,727,o),
+(496,727,cs),
+(418,727,o),
+(366,679,o),
+(346,586,c),
+(369,586,l),
+(347,679,o),
+(296,727,o),
+(218,727,cs),
+(116,727,o),
+(53,650,o),
+(53,530,cs),
+(53,400,o),
+(123,238,o),
+(123,139,cs),
+(123,109,o),
+(111,81,o),
+(66,81,cs),
+(48,81,l),
+(48,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(152,440,o),
+(144,485,o),
+(144,522,cs),
+(144,601,o),
+(174,642,o),
+(228,642,cs),
+(285,642,o),
+(318,595,o),
+(318,501,cs),
+(318,394,l),
+(161,394,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(396,501,ls),
+(396,594,o),
+(429,642,o),
+(485,642,cs),
+(539,642,o),
+(570,601,o),
+(570,522,cs),
+(570,485,o),
+(562,440,o),
+(553,394,c),
+(396,394,l)
+);
+}
+);
+width = 715;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165C;
+unicode = 5724;
+},
+{
+color = 9;
+glyphname = "tseCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(484,-13,o),
+(548,64,o),
+(548,180,cs),
+(548,281,o),
+(501,349,o),
+(423,365,c),
+(423,349,l),
+(501,365,o),
+(548,432,o),
+(548,534,cs),
+(548,650,o),
+(484,727,o),
+(393,727,cs),
+(303,727,o),
+(222,625,o),
+(180,625,cs),
+(161,625,o),
+(147,638,o),
+(147,683,cs),
+(147,714,l),
+(63,714,l),
+(63,658,ls),
+(63,581,o),
+(102,548,o),
+(155,548,cs),
+(179,548,o),
+(205,559,o),
+(230,575,c),
+(202,584,l),
+(202,389,l),
+(115,389,l),
+(115,477,l),
+(63,477,l),
+(63,237,l),
+(115,237,l),
+(115,325,l),
+(202,325,l),
+(202,130,l),
+(231,140,l),
+(205,155,o),
+(179,166,o),
+(155,166,cs),
+(102,166,o),
+(63,133,o),
+(63,56,cs),
+(63,0,l),
+(147,0,l),
+(147,31,ls),
+(147,76,o),
+(161,89,o),
+(180,89,cs),
+(222,89,o),
+(303,-13,o),
+(393,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(335,71,o),
+(298,97,o),
+(261,122,c),
+(261,325,l),
+(345,325,ls),
+(416,325,o),
+(458,277,o),
+(458,193,cs),
+(458,118,o),
+(424,71,o),
+(368,71,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(261,592,l),
+(298,617,o),
+(335,643,o),
+(368,643,cs),
+(424,643,o),
+(458,596,o),
+(458,521,cs),
+(458,437,o),
+(414,389,o),
+(345,389,cs),
+(261,389,l)
+);
+}
+);
+width = 607;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni165D;
+unicode = 5725;
+},
+{
+color = 9;
+glyphname = "tseeCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(484,-13,o),
+(548,64,o),
+(548,180,cs),
+(548,281,o),
+(501,349,o),
+(423,365,c),
+(423,349,l),
+(501,365,o),
+(548,432,o),
+(548,534,cs),
+(548,650,o),
+(484,727,o),
+(393,727,cs),
+(303,727,o),
+(222,625,o),
+(180,625,cs),
+(161,625,o),
+(147,638,o),
+(147,683,cs),
+(147,714,l),
+(63,714,l),
+(63,658,ls),
+(63,581,o),
+(102,548,o),
+(155,548,cs),
+(175,548,o),
+(197,558,o),
+(219,570,c),
+(194,590,l),
+(194,388,l),
+(111,388,l),
+(111,477,l),
+(63,477,l),
+(63,237,l),
+(111,237,l),
+(111,326,l),
+(194,326,l),
+(194,124,l),
+(216,145,l),
+(195,156,o),
+(174,166,o),
+(155,166,cs),
+(102,166,o),
+(63,133,o),
+(63,56,cs),
+(63,0,l),
+(147,0,l),
+(147,31,ls),
+(147,76,o),
+(161,89,o),
+(180,89,cs),
+(222,89,o),
+(303,-13,o),
+(393,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(331,71,o),
+(290,103,o),
+(247,130,c),
+(247,326,l),
+(319,326,l),
+(319,226,l),
+(362,226,l),
+(362,342,l),
+(342,326,l),
+(358,326,ls),
+(424,326,o),
+(459,277,o),
+(459,197,cs),
+(459,118,o),
+(425,71,o),
+(368,71,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(362,480,l),
+(319,480,l),
+(319,388,l),
+(247,388,l),
+(247,584,l),
+(290,611,o),
+(331,643,o),
+(368,643,cs),
+(425,643,o),
+(459,596,o),
+(459,517,cs),
+(459,437,o),
+(423,388,o),
+(358,388,cs),
+(342,388,l),
+(362,373,l)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165E;
+unicode = 5726;
+},
+{
+color = 9;
+glyphname = "tsiCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(484,-13,o),
+(548,64,o),
+(548,180,cs),
+(548,281,o),
+(501,349,o),
+(424,365,c),
+(424,349,l),
+(501,365,o),
+(548,432,o),
+(548,534,cs),
+(548,650,o),
+(484,727,o),
+(393,727,cs),
+(303,727,o),
+(222,625,o),
+(180,625,cs),
+(161,625,o),
+(147,638,o),
+(147,683,cs),
+(147,714,l),
+(63,714,l),
+(63,658,ls),
+(63,581,o),
+(102,548,o),
+(155,548,cs),
+(178,548,o),
+(202,559,o),
+(226,572,c),
+(193,580,l),
+(193,388,l),
+(111,388,l),
+(111,477,l),
+(63,477,l),
+(63,237,l),
+(111,237,l),
+(111,326,l),
+(193,326,l),
+(193,134,l),
+(225,142,l),
+(202,155,o),
+(178,166,o),
+(155,166,cs),
+(102,166,o),
+(63,133,o),
+(63,56,cs),
+(63,0,l),
+(147,0,l),
+(147,31,ls),
+(147,76,o),
+(161,89,o),
+(180,89,cs),
+(222,89,o),
+(303,-13,o),
+(393,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(331,71,o),
+(289,104,o),
+(245,131,c),
+(245,326,l),
+(285,326,l),
+(294,299,o),
+(316,282,o),
+(342,282,cs),
+(379,282,o),
+(401,317,o),
+(403,348,c),
+(341,326,l),
+(359,326,ls),
+(424,326,o),
+(459,277,o),
+(459,197,cs),
+(459,118,o),
+(425,71,o),
+(368,71,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(401,398,o),
+(379,432,o),
+(342,432,cs),
+(316,432,o),
+(294,416,o),
+(285,388,c),
+(245,388,l),
+(245,583,l),
+(289,610,o),
+(331,643,o),
+(368,643,cs),
+(425,643,o),
+(459,596,o),
+(459,517,cs),
+(459,437,o),
+(423,388,o),
+(359,388,cs),
+(341,388,l),
+(403,362,l)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165F;
+unicode = 5727;
+},
+{
+color = 9;
+glyphname = "tsaCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(304,-13,o),
+(385,89,o),
+(427,89,cs),
+(446,89,o),
+(460,76,o),
+(460,31,cs),
+(460,0,l),
+(544,0,l),
+(544,56,ls),
+(544,133,o),
+(505,166,o),
+(452,166,cs),
+(428,166,o),
+(402,155,o),
+(376,140,c),
+(405,130,l),
+(405,325,l),
+(492,325,l),
+(492,237,l),
+(544,237,l),
+(544,477,l),
+(492,477,l),
+(492,389,l),
+(405,389,l),
+(405,584,l),
+(377,575,l),
+(402,559,o),
+(428,548,o),
+(452,548,cs),
+(505,548,o),
+(544,581,o),
+(544,658,cs),
+(544,714,l),
+(460,714,l),
+(460,683,ls),
+(460,638,o),
+(446,625,o),
+(427,625,cs),
+(385,625,o),
+(304,727,o),
+(214,727,cs),
+(124,727,o),
+(59,650,o),
+(59,534,cs),
+(59,432,o),
+(106,365,o),
+(184,349,c),
+(184,365,l),
+(106,349,o),
+(59,281,o),
+(59,180,cs),
+(59,64,o),
+(124,-13,o),
+(214,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(183,71,o),
+(149,118,o),
+(149,193,cs),
+(149,277,o),
+(191,325,o),
+(262,325,cs),
+(346,325,l),
+(346,122,l),
+(309,97,o),
+(272,71,o),
+(239,71,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(193,389,o),
+(149,437,o),
+(149,521,cs),
+(149,596,o),
+(183,643,o),
+(239,643,cs),
+(272,643,o),
+(309,617,o),
+(346,592,c),
+(346,389,l),
+(262,389,ls)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1660;
+unicode = 5728;
+},
+{
+color = 9;
+glyphname = "chuCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(297,-13,o),
+(348,35,o),
+(369,128,c),
+(346,128,l),
+(367,35,o),
+(418,-13,o),
+(497,-13,cs),
+(599,-13,o),
+(661,64,o),
+(661,184,cs),
+(661,314,o),
+(592,476,o),
+(592,575,cs),
+(592,605,o),
+(604,633,o),
+(648,633,cs),
+(667,633,l),
+(667,714,l),
+(626,714,ls),
+(540,714,o),
+(506,668,o),
+(506,591,cs),
+(506,476,o),
+(570,302,o),
+(570,192,cs),
+(570,113,o),
+(540,72,o),
+(486,72,cs),
+(429,72,o),
+(397,119,o),
+(397,213,cs),
+(397,649,l),
+(458,649,l),
+(458,714,l),
+(257,714,l),
+(257,649,l),
+(318,649,l),
+(318,213,ls),
+(318,120,o),
+(286,72,o),
+(229,72,cs),
+(175,72,o),
+(145,113,o),
+(145,192,cs),
+(145,302,o),
+(209,476,o),
+(209,591,cs),
+(209,668,o),
+(174,714,o),
+(89,714,cs),
+(48,714,l),
+(48,633,l),
+(66,633,ls),
+(111,633,o),
+(124,604,o),
+(124,575,cs),
+(124,476,o),
+(54,314,o),
+(54,184,cs),
+(54,63,o),
+(116,-13,o),
+(219,-13,cs)
+);
+}
+);
+width = 715;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164E;
+unicode = 5729;
+},
+{
+color = 9;
+glyphname = "choCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(89,0,ls),
+(174,0,o),
+(208,46,o),
+(208,123,cs),
+(208,238,o),
+(144,412,o),
+(144,522,cs),
+(144,601,o),
+(174,642,o),
+(228,642,cs),
+(285,642,o),
+(318,595,o),
+(318,501,cs),
+(318,65,l),
+(257,65,l),
+(257,0,l),
+(458,0,l),
+(458,65,l),
+(397,65,l),
+(397,501,ls),
+(397,594,o),
+(429,642,o),
+(485,642,cs),
+(539,642,o),
+(570,601,o),
+(570,522,cs),
+(570,412,o),
+(506,238,o),
+(506,123,cs),
+(506,46,o),
+(540,0,o),
+(626,0,cs),
+(667,0,l),
+(667,81,l),
+(648,81,ls),
+(604,81,o),
+(591,110,o),
+(591,139,cs),
+(591,238,o),
+(661,400,o),
+(661,530,cs),
+(661,651,o),
+(598,727,o),
+(496,727,cs),
+(418,727,o),
+(366,679,o),
+(346,586,c),
+(369,586,l),
+(347,679,o),
+(296,727,o),
+(218,727,cs),
+(116,727,o),
+(53,650,o),
+(53,530,cs),
+(53,400,o),
+(123,238,o),
+(123,139,cs),
+(123,109,o),
+(111,81,o),
+(66,81,cs),
+(48,81,l),
+(48,0,l)
+);
+}
+);
+width = 715;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5730;
+},
+{
+color = 9;
+glyphname = "cheCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(484,-13,o),
+(548,64,o),
+(548,180,cs),
+(548,281,o),
+(501,349,o),
+(423,365,c),
+(423,349,l),
+(501,365,o),
+(548,432,o),
+(548,534,cs),
+(548,650,o),
+(484,727,o),
+(393,727,cs),
+(303,727,o),
+(222,625,o),
+(180,625,cs),
+(161,625,o),
+(147,638,o),
+(147,683,cs),
+(147,714,l),
+(63,714,l),
+(63,656,ls),
+(63,579,o),
+(102,546,o),
+(155,546,cs),
+(227,546,o),
+(304,643,o),
+(366,643,cs),
+(422,643,o),
+(456,597,o),
+(456,522,cs),
+(456,439,o),
+(413,395,o),
+(344,395,cs),
+(115,395,l),
+(115,477,l),
+(63,477,l),
+(63,237,l),
+(115,237,l),
+(115,319,l),
+(344,319,ls),
+(414,319,o),
+(456,275,o),
+(456,192,cs),
+(456,117,o),
+(422,71,o),
+(367,71,cs),
+(304,71,o),
+(227,168,o),
+(155,168,cs),
+(102,168,o),
+(63,135,o),
+(63,58,cs),
+(63,0,l),
+(147,0,l),
+(147,31,ls),
+(147,76,o),
+(161,89,o),
+(180,89,cs),
+(222,89,o),
+(303,-13,o),
+(393,-13,cs)
+);
+}
+);
+width = 607;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni1663;
+unicode = 5731;
+},
+{
+color = 9;
+glyphname = "cheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(484,-13,o),
+(548,64,o),
+(548,180,cs),
+(548,281,o),
+(501,349,o),
+(423,365,c),
+(423,349,l),
+(501,365,o),
+(548,432,o),
+(548,534,cs),
+(548,650,o),
+(484,727,o),
+(393,727,cs),
+(303,727,o),
+(222,625,o),
+(180,625,cs),
+(161,625,o),
+(147,638,o),
+(147,683,cs),
+(147,714,l),
+(63,714,l),
+(63,656,ls),
+(63,579,o),
+(102,546,o),
+(155,546,cs),
+(228,546,o),
+(305,645,o),
+(369,645,cs),
+(425,645,o),
+(458,598,o),
+(458,522,cs),
+(458,439,o),
+(419,389,o),
+(355,389,cs),
+(298,389,l),
+(322,374,l),
+(322,475,l),
+(270,475,l),
+(270,389,l),
+(115,389,l),
+(115,477,l),
+(63,477,l),
+(63,237,l),
+(115,237,l),
+(115,325,l),
+(270,325,l),
+(270,231,l),
+(322,231,l),
+(322,340,l),
+(298,325,l),
+(355,325,ls),
+(421,325,o),
+(458,275,o),
+(458,192,cs),
+(458,116,o),
+(425,69,o),
+(369,69,cs),
+(305,69,o),
+(228,168,o),
+(155,168,cs),
+(102,168,o),
+(63,135,o),
+(63,58,cs),
+(63,0,l),
+(147,0,l),
+(147,31,ls),
+(147,76,o),
+(161,89,o),
+(180,89,cs),
+(222,89,o),
+(303,-13,o),
+(393,-13,cs)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1664;
+unicode = 5732;
+},
+{
+color = 9;
+glyphname = "chiCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(484,-13,o),
+(548,64,o),
+(548,180,cs),
+(548,281,o),
+(501,349,o),
+(424,365,c),
+(424,349,l),
+(501,365,o),
+(548,432,o),
+(548,534,cs),
+(548,650,o),
+(484,727,o),
+(393,727,cs),
+(303,727,o),
+(222,625,o),
+(180,625,cs),
+(161,625,o),
+(147,638,o),
+(147,683,cs),
+(147,714,l),
+(63,714,l),
+(63,656,ls),
+(63,579,o),
+(102,546,o),
+(155,546,cs),
+(228,546,o),
+(305,645,o),
+(369,645,cs),
+(425,645,o),
+(458,598,o),
+(458,522,cs),
+(458,439,o),
+(419,389,o),
+(355,389,cs),
+(302,389,l),
+(349,361,l),
+(347,401,o),
+(317,432,o),
+(277,432,cs),
+(247,432,o),
+(222,414,o),
+(211,389,c),
+(115,389,l),
+(115,477,l),
+(63,477,l),
+(63,237,l),
+(115,237,l),
+(115,325,l),
+(211,325,l),
+(222,300,o),
+(247,282,o),
+(277,282,cs),
+(316,282,o),
+(346,314,o),
+(350,352,c),
+(302,325,l),
+(355,325,ls),
+(421,325,o),
+(458,275,o),
+(458,192,cs),
+(458,116,o),
+(425,69,o),
+(369,69,cs),
+(305,69,o),
+(228,168,o),
+(155,168,cs),
+(102,168,o),
+(63,135,o),
+(63,58,cs),
+(63,0,l),
+(147,0,l),
+(147,31,ls),
+(147,76,o),
+(161,89,o),
+(180,89,cs),
+(222,89,o),
+(303,-13,o),
+(393,-13,cs)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1665;
+unicode = 5733;
+},
+{
+color = 9;
+glyphname = "chaCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(304,-13,o),
+(385,89,o),
+(427,89,cs),
+(446,89,o),
+(460,76,o),
+(460,31,cs),
+(460,0,l),
+(544,0,l),
+(544,58,ls),
+(544,135,o),
+(505,168,o),
+(452,168,cs),
+(380,168,o),
+(303,71,o),
+(241,71,cs),
+(185,71,o),
+(151,117,o),
+(151,192,cs),
+(151,275,o),
+(194,319,o),
+(263,319,cs),
+(492,319,l),
+(492,237,l),
+(544,237,l),
+(544,477,l),
+(492,477,l),
+(492,395,l),
+(263,395,ls),
+(193,395,o),
+(151,439,o),
+(151,522,cs),
+(151,597,o),
+(185,643,o),
+(240,643,cs),
+(303,643,o),
+(380,546,o),
+(452,546,cs),
+(505,546,o),
+(544,579,o),
+(544,656,cs),
+(544,714,l),
+(460,714,l),
+(460,683,ls),
+(460,638,o),
+(446,625,o),
+(427,625,cs),
+(385,625,o),
+(304,727,o),
+(214,727,cs),
+(124,727,o),
+(59,650,o),
+(59,534,cs),
+(59,432,o),
+(106,365,o),
+(184,349,c),
+(184,365,l),
+(106,349,o),
+(59,281,o),
+(59,180,cs),
+(59,64,o),
+(124,-13,o),
+(214,-13,cs)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1666;
+unicode = 5734;
+},
+{
+color = 9;
+glyphname = "ttsuCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(297,-13,o),
+(348,35,o),
+(369,128,c),
+(346,128,l),
+(367,35,o),
+(418,-13,o),
+(497,-13,cs),
+(599,-13,o),
+(661,64,o),
+(661,184,cs),
+(661,314,o),
+(592,476,o),
+(592,575,cs),
+(592,605,o),
+(604,633,o),
+(648,633,cs),
+(667,633,l),
+(667,714,l),
+(626,714,ls),
+(540,714,o),
+(506,668,o),
+(506,591,cs),
+(506,557,o),
+(512,519,o),
+(517,478,c),
+(548,547,l),
+(397,421,l),
+(397,649,l),
+(458,649,l),
+(458,714,l),
+(257,714,l),
+(257,649,l),
+(318,649,l),
+(318,421,l),
+(168,547,l),
+(198,477,l),
+(204,519,o),
+(209,557,o),
+(209,591,cs),
+(209,668,o),
+(174,714,o),
+(89,714,cs),
+(48,714,l),
+(48,633,l),
+(66,633,ls),
+(111,633,o),
+(124,604,o),
+(124,575,cs),
+(124,476,o),
+(54,314,o),
+(54,184,cs),
+(54,63,o),
+(116,-13,o),
+(219,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(175,72,o),
+(145,113,o),
+(145,192,cs),
+(145,263,o),
+(173,354,o),
+(191,439,c),
+(318,333,l),
+(318,213,ls),
+(318,120,o),
+(286,72,o),
+(229,72,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(429,72,o),
+(397,119,o),
+(397,213,cs),
+(397,333,l),
+(524,439,l),
+(542,355,o),
+(570,263,o),
+(570,192,cs),
+(570,113,o),
+(540,72,o),
+(486,72,cs)
+);
+}
+);
+width = 715;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1667;
+unicode = 5735;
+},
+{
+color = 9;
+glyphname = "ttsoCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(89,0,ls),
+(174,0,o),
+(209,46,o),
+(209,123,cs),
+(209,157,o),
+(204,195,o),
+(198,237,c),
+(168,167,l),
+(318,293,l),
+(318,65,l),
+(257,65,l),
+(257,0,l),
+(458,0,l),
+(458,65,l),
+(397,65,l),
+(397,293,l),
+(548,167,l),
+(517,236,l),
+(512,195,o),
+(506,157,o),
+(506,123,cs),
+(506,46,o),
+(540,0,o),
+(626,0,cs),
+(667,0,l),
+(667,81,l),
+(648,81,ls),
+(604,81,o),
+(592,109,o),
+(592,139,cs),
+(592,238,o),
+(661,400,o),
+(661,530,cs),
+(661,650,o),
+(599,727,o),
+(497,727,cs),
+(418,727,o),
+(367,679,o),
+(346,586,c),
+(369,586,l),
+(348,679,o),
+(297,727,o),
+(219,727,cs),
+(116,727,o),
+(54,651,o),
+(54,530,cs),
+(54,400,o),
+(124,238,o),
+(124,139,cs),
+(124,110,o),
+(111,81,o),
+(66,81,cs),
+(48,81,l),
+(48,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(173,360,o),
+(145,451,o),
+(145,522,cs),
+(145,601,o),
+(175,642,o),
+(229,642,cs),
+(286,642,o),
+(318,594,o),
+(318,501,cs),
+(318,381,l),
+(191,275,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(397,381,l),
+(397,501,ls),
+(397,595,o),
+(429,642,o),
+(486,642,cs),
+(540,642,o),
+(570,601,o),
+(570,522,cs),
+(570,451,o),
+(542,359,o),
+(524,275,c)
+);
+}
+);
+width = 715;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1668;
+unicode = 5736;
+},
+{
+color = 9;
+glyphname = "ttseCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(484,-13,o),
+(548,64,o),
+(548,180,cs),
+(548,281,o),
+(501,349,o),
+(424,365,c),
+(424,349,l),
+(501,365,o),
+(548,432,o),
+(548,534,cs),
+(548,650,o),
+(484,727,o),
+(393,727,cs),
+(303,727,o),
+(222,625,o),
+(180,625,cs),
+(161,625,o),
+(147,638,o),
+(147,683,cs),
+(147,714,l),
+(63,714,l),
+(63,656,ls),
+(63,579,o),
+(102,546,o),
+(155,546,cs),
+(168,546,o),
+(181,548,o),
+(188,557,c),
+(133,589,l),
+(204,389,l),
+(115,389,l),
+(115,477,l),
+(63,477,l),
+(63,237,l),
+(115,237,l),
+(115,325,l),
+(204,325,l),
+(133,125,l),
+(188,157,l),
+(181,166,o),
+(168,168,o),
+(155,168,cs),
+(102,168,o),
+(63,135,o),
+(63,58,cs),
+(63,0,l),
+(147,0,l),
+(147,31,ls),
+(147,76,o),
+(161,89,o),
+(180,89,cs),
+(222,89,o),
+(303,-13,o),
+(393,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(318,69,o),
+(260,133,o),
+(208,153,c),
+(267,325,l),
+(355,325,ls),
+(421,325,o),
+(458,275,o),
+(458,192,cs),
+(458,116,o),
+(425,69,o),
+(369,69,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(208,561,l),
+(260,581,o),
+(318,645,o),
+(369,645,cs),
+(425,645,o),
+(458,598,o),
+(458,522,cs),
+(458,439,o),
+(419,389,o),
+(355,389,cs),
+(267,389,l)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1669;
+unicode = 5737;
+},
+{
+color = 9;
+glyphname = "ttseeCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(484,-13,o),
+(548,64,o),
+(548,180,cs),
+(548,281,o),
+(501,349,o),
+(424,365,c),
+(424,349,l),
+(501,365,o),
+(548,432,o),
+(548,534,cs),
+(548,650,o),
+(484,727,o),
+(393,727,cs),
+(303,727,o),
+(222,625,o),
+(180,625,cs),
+(161,625,o),
+(147,638,o),
+(147,683,cs),
+(147,714,l),
+(63,714,l),
+(63,656,ls),
+(63,579,o),
+(102,546,o),
+(155,546,cs),
+(165,546,o),
+(176,547,o),
+(179,554,c),
+(130,587,l),
+(200,389,l),
+(115,389,l),
+(115,477,l),
+(63,477,l),
+(63,237,l),
+(115,237,l),
+(115,325,l),
+(200,325,l),
+(130,127,l),
+(179,160,l),
+(176,167,o),
+(165,168,o),
+(155,168,cs),
+(102,168,o),
+(63,135,o),
+(63,58,cs),
+(63,0,l),
+(147,0,l),
+(147,31,ls),
+(147,76,o),
+(161,89,o),
+(180,89,cs),
+(222,89,o),
+(303,-13,o),
+(393,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(316,69,o),
+(256,136,o),
+(201,157,c),
+(259,325,l),
+(313,325,l),
+(313,226,l),
+(360,226,l),
+(360,341,l),
+(340,325,l),
+(355,325,ls),
+(421,325,o),
+(458,275,o),
+(458,192,cs),
+(458,116,o),
+(425,69,o),
+(369,69,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(360,480,l),
+(313,480,l),
+(313,389,l),
+(259,389,l),
+(201,557,l),
+(256,578,o),
+(316,645,o),
+(369,645,cs),
+(425,645,o),
+(458,598,o),
+(458,522,cs),
+(458,439,o),
+(419,389,o),
+(355,389,cs),
+(340,389,l),
+(360,373,l)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166A;
+unicode = 5738;
+},
+{
+color = 9;
+glyphname = "ttsiCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(484,-13,o),
+(548,64,o),
+(548,180,cs),
+(548,281,o),
+(501,349,o),
+(424,365,c),
+(424,349,l),
+(501,365,o),
+(548,432,o),
+(548,534,cs),
+(548,650,o),
+(484,727,o),
+(393,727,cs),
+(303,727,o),
+(222,625,o),
+(180,625,cs),
+(161,625,o),
+(147,638,o),
+(147,683,cs),
+(147,714,l),
+(63,714,l),
+(63,656,ls),
+(63,579,o),
+(102,546,o),
+(155,546,cs),
+(164,546,o),
+(173,546,o),
+(182,555,c),
+(138,565,l),
+(200,389,l),
+(115,389,l),
+(115,477,l),
+(63,477,l),
+(63,237,l),
+(115,237,l),
+(115,325,l),
+(200,325,l),
+(135,140,l),
+(181,160,l),
+(173,168,o),
+(164,168,o),
+(155,168,cs),
+(102,168,o),
+(63,135,o),
+(63,58,cs),
+(63,0,l),
+(147,0,l),
+(147,31,ls),
+(147,76,o),
+(161,89,o),
+(180,89,cs),
+(222,89,o),
+(303,-13,o),
+(393,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(316,69,o),
+(249,141,o),
+(195,160,c),
+(252,325,l),
+(267,325,l),
+(278,300,o),
+(300,282,o),
+(327,282,cs),
+(358,282,o),
+(383,306,o),
+(389,337,c),
+(337,325,l),
+(360,325,ls),
+(425,325,o),
+(458,275,o),
+(458,192,cs),
+(458,116,o),
+(425,69,o),
+(369,69,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(384,408,o),
+(358,432,o),
+(327,432,cs),
+(300,432,o),
+(277,414,o),
+(267,389,c),
+(252,389,l),
+(195,554,l),
+(249,573,o),
+(316,645,o),
+(369,645,cs),
+(425,645,o),
+(458,598,o),
+(458,522,cs),
+(458,439,o),
+(424,389,o),
+(360,389,cs),
+(338,389,l),
+(390,376,l)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166B;
+unicode = 5739;
+},
+{
+color = 9;
+glyphname = "ttsaCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(304,-13,o),
+(385,89,o),
+(427,89,cs),
+(446,89,o),
+(460,76,o),
+(460,31,cs),
+(460,0,l),
+(544,0,l),
+(544,58,ls),
+(544,135,o),
+(505,168,o),
+(452,168,cs),
+(439,168,o),
+(426,166,o),
+(419,157,c),
+(474,125,l),
+(403,325,l),
+(492,325,l),
+(492,237,l),
+(544,237,l),
+(544,477,l),
+(492,477,l),
+(492,389,l),
+(403,389,l),
+(474,589,l),
+(419,557,l),
+(426,548,o),
+(439,546,o),
+(452,546,cs),
+(505,546,o),
+(544,579,o),
+(544,656,cs),
+(544,714,l),
+(460,714,l),
+(460,683,ls),
+(460,638,o),
+(446,625,o),
+(427,625,cs),
+(385,625,o),
+(304,727,o),
+(214,727,cs),
+(124,727,o),
+(59,650,o),
+(59,534,cs),
+(59,432,o),
+(106,365,o),
+(183,349,c),
+(183,365,l),
+(106,349,o),
+(59,281,o),
+(59,180,cs),
+(59,64,o),
+(124,-13,o),
+(214,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(182,69,o),
+(149,116,o),
+(149,192,cs),
+(149,275,o),
+(186,325,o),
+(252,325,cs),
+(340,325,l),
+(399,153,l),
+(348,133,o),
+(289,69,o),
+(238,69,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(188,389,o),
+(149,439,o),
+(149,522,cs),
+(149,598,o),
+(182,645,o),
+(239,645,cs),
+(289,645,o),
+(348,581,o),
+(399,561,c),
+(340,389,l),
+(252,389,ls)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni166C;
+unicode = 5740;
+},
+{
+glyphname = "qai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (270,0);
+ref = "ke-canadian";
+}
+);
+width = 767;
+}
+);
+note = uni166F;
+unicode = 5743;
+},
+{
+glyphname = "ngai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (516,0);
+ref = "ce-canadian";
+}
+);
+width = 1006;
+}
+);
+note = uni1670;
+unicode = 5744;
+},
+{
+glyphname = "nngi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (772,0);
+ref = "ci-canadian";
+}
+);
+width = 1261;
+}
+);
+note = uni1671;
+unicode = 5745;
+},
+{
+glyphname = "nngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (772,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (953,0);
+ref = dot_top;
+}
+);
+width = 1261;
+}
+);
+note = uni1672;
+unicode = 5746;
+},
+{
+glyphname = "nngo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (772,0);
+ref = "ce-canadian";
+}
+);
+width = 1261;
+}
+);
+note = uni1673;
+unicode = 5747;
+},
+{
+glyphname = "nngoo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (772,0);
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (943,0);
+ref = dot_top;
+}
+);
+width = 1261;
+}
+);
+note = uni1674;
+unicode = 5748;
+},
+{
+glyphname = "nnga-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (772,0);
+ref = "ca-canadian";
+}
+);
+width = 1261;
+}
+);
+note = uni1675;
+unicode = 5749;
+},
+{
+glyphname = "nngaa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (772,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (806,0);
+ref = dot_top;
+}
+);
+width = 1261;
+}
+);
+note = uni1676;
+unicode = 5750;
+},
+{
+glyphname = "thweeWoodScree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (514,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 706;
+}
+);
+note = uni1677;
+unicode = 5751;
+},
+{
+glyphname = "thwiWoodScree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (514,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 706;
+}
+);
+note = uni1678;
+unicode = 5752;
+},
+{
+glyphname = "thwiiWoodScree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (72,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (514,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 706;
+}
+);
+note = uni1679;
+unicode = 5753;
+},
+{
+glyphname = "thwoWoodScree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (514,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 706;
+}
+);
+note = uni167A;
+unicode = 5754;
+},
+{
+glyphname = "thwooWoodScree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (303,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (514,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 706;
+}
+);
+note = uni167B;
+unicode = 5755;
+},
+{
+glyphname = "thwaWoodScree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = middle_right_can;
+pos = (514,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 705;
+}
+);
+note = uni167C;
+unicode = 5756;
+},
+{
+glyphname = "thwaaWoodScree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (72,0);
+ref = dot_top;
+},
+{
+anchor = middle_right_can;
+pos = (514,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 705;
+}
+);
+note = uni167D;
+unicode = 5757;
+},
+{
+glyphname = "wBlackfoot-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(316,578,l),
+(316,634,l),
+(51,634,l),
+(51,578,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(316,437,l),
+(316,493,l),
+(51,493,l),
+(51,437,l)
+);
+}
+);
+width = 367;
+}
+);
+metricRight = "=|";
+note = uni167F;
+unicode = 5759;
+},
+{
+glyphname = "oy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-21,0);
+ref = ring_top.canadian;
+}
+);
+width = 569;
+}
+);
+note = uni18B0;
+unicode = 6320;
+},
+{
+glyphname = "ay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (347,0);
+ref = ring_top.canadian;
+}
+);
+width = 569;
+}
+);
+note = uni18B1;
+unicode = 6321;
+},
+{
+glyphname = "aay-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (134,0);
+ref = ring_top.canadian;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (397,0);
+ref = dot_top;
+}
+);
+width = 569;
+}
+);
+note = uni18B2;
+unicode = 6322;
+},
+{
+glyphname = "way-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (539,0);
+ref = ring_top.canadian;
+}
+);
+width = 761;
+}
+);
+note = uni18B3;
+unicode = 6323;
+},
+{
+glyphname = "poy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-37,0);
+ref = ring_top.canadian;
+}
+);
+width = 545;
+}
+);
+note = uni18B4;
+unicode = 6324;
+},
+{
+glyphname = "pay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (344,0);
+ref = ring_top.canadian;
+}
+);
+width = 545;
+}
+);
+note = uni18B5;
+unicode = 6325;
+},
+{
+glyphname = "pwoy-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (154,0);
+ref = ring_top.canadian;
+}
+);
+width = 736;
+}
+);
+note = uni18B6;
+unicode = 6326;
+},
+{
+glyphname = "tay-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (159,0);
+ref = ring_top.canadian;
+}
+);
+width = 504;
+}
+);
+note = uni18B7;
+unicode = 6327;
+},
+{
+glyphname = "kay-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-14,0);
+ref = ring_top.canadian;
+}
+);
+width = 498;
+}
+);
+note = uni18B8;
+unicode = 6328;
+},
+{
+glyphname = "kway-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (177,0);
+ref = ring_top.canadian;
+}
+);
+width = 689;
+}
+);
+note = uni18B9;
+unicode = 6329;
+},
+{
+glyphname = "may-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-10,0);
+ref = ring_top.canadian;
+}
+);
+width = 446;
+}
+);
+note = uni18BA;
+unicode = 6330;
+},
+{
+glyphname = "noy-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (304,-200);
+ref = ring_top.canadian;
+}
+);
+width = 676;
+}
+);
+note = uni18BB;
+unicode = 6331;
+},
+{
+glyphname = "nay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (132,-200);
+ref = ring_top.canadian;
+}
+);
+width = 676;
+}
+);
+note = uni18BC;
+unicode = 6332;
+},
+{
+glyphname = "lay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (132,-200);
+ref = ring_top.canadian;
+}
+);
+width = 676;
+}
+);
+note = uni18BD;
+unicode = 6333;
+},
+{
+glyphname = "soy-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (226,0);
+ref = ring_top.canadian;
+}
+);
+width = 454;
+}
+);
+note = uni18BE;
+unicode = 6334;
+},
+{
+glyphname = "say-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-10,0);
+ref = ring_top.canadian;
+}
+);
+width = 454;
+}
+);
+note = uni18BF;
+unicode = 6335;
+},
+{
+glyphname = "shoy-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (268,-200);
+ref = ring_top.canadian;
+}
+);
+width = 775;
+}
+);
+note = uni18C0;
+unicode = 6336;
+},
+{
+glyphname = "shay-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (268,-200);
+ref = ring_top.canadian;
+}
+);
+width = 775;
+}
+);
+note = uni18C1;
+unicode = 6337;
+},
+{
+glyphname = "shwoy-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (459,-200);
+ref = ring_top.canadian;
+}
+);
+width = 966;
+}
+);
+note = uni18C2;
+unicode = 6338;
+},
+{
+glyphname = "yoy-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (254,0);
+ref = ring_top.canadian;
+}
+);
+width = 479;
+}
+);
+note = uni18C3;
+unicode = 6339;
+},
+{
+glyphname = "yay-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-13,0);
+ref = ring_top.canadian;
+}
+);
+width = 479;
+}
+);
+note = uni18C4;
+unicode = 6340;
+},
+{
+glyphname = "ray-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (136,0);
+ref = ring_top.canadian;
+}
+);
+width = 456;
+}
+);
+note = uni18C5;
+unicode = 6341;
+},
+{
+glyphname = "nwi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ni-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni18C6;
+unicode = 6342;
+},
+{
+glyphname = "nwiOjibway-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (676,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni18C7;
+unicode = 6343;
+},
+{
+glyphname = "nwii-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (384,-200);
+ref = dot_top;
+}
+);
+width = 867;
+}
+);
+note = uni18C8;
+unicode = 6344;
+},
+{
+glyphname = "nwiiOjibway-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (192,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (676,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni18C9;
+unicode = 6345;
+},
+{
+glyphname = "nwo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "no-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni18CA;
+unicode = 6346;
+},
+{
+glyphname = "nwoOjibway-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (676,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni18CB;
+unicode = 6347;
+},
+{
+glyphname = "nwoo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (545,-200);
+ref = dot_top;
+}
+);
+width = 867;
+}
+);
+note = uni18CC;
+unicode = 6348;
+},
+{
+glyphname = "nwooOjibway-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (354,-200);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (676,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 867;
+}
+);
+note = uni18CD;
+unicode = 6349;
+},
+{
+glyphname = "rwee-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "reRCree-canadian";
+}
+);
+width = 903;
+}
+);
+note = uni18CE;
+unicode = 6350;
+},
+{
+glyphname = "rwi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ri-canadian";
+}
+);
+width = 903;
+}
+);
+note = uni18CF;
+unicode = 6351;
+},
+{
+glyphname = "rwii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (375,-200);
+ref = dot_top;
+}
+);
+width = 903;
+}
+);
+note = uni18D0;
+unicode = 6352;
+},
+{
+glyphname = "rwo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ro-canadian";
+}
+);
+width = 647;
+}
+);
+note = uni18D1;
+unicode = 6353;
+},
+{
+glyphname = "rwoo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (321,0);
+ref = dot_top;
+}
+);
+width = 647;
+}
+);
+note = uni18D2;
+unicode = 6354;
+},
+{
+glyphname = "rwa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = "ra-canadian";
+}
+);
+width = 647;
+}
+);
+note = uni18D3;
+unicode = 6355;
+},
+{
+glyphname = "pOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(90,357,l),
+(188,643,l),
+(148,643,l),
+(245,357,l),
+(304,357,l),
+(304,371,l),
+(176,714,l),
+(160,714,l),
+(31,371,l),
+(31,357,l)
+);
+}
+);
+width = 335;
+}
+);
+metricLeft = "kkCarrier-canadian";
+note = uni18D4;
+unicode = 6356;
+},
+{
+glyphname = "tOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 352;
+}
+);
+metricRight = "=|";
+note = uni1422;
+unicode = 6357;
+},
+{
+glyphname = "kOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(115,356,l),
+(115,523,l),
+(99,522,l),
+(104,477,o),
+(133,448,o),
+(173,448,cs),
+(226,448,o),
+(268,494,o),
+(268,580,cs),
+(268,675,o),
+(220,719,o),
+(160,719,cs),
+(93,719,o),
+(51,670,o),
+(51,584,cs),
+(51,356,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(131,497,o),
+(110,523,o),
+(110,584,cs),
+(110,647,o),
+(129,671,o),
+(160,671,cs),
+(190,671,o),
+(210,645,o),
+(210,583,cs),
+(210,522,o),
+(189,497,o),
+(160,497,cs)
+);
+}
+);
+width = 309;
+}
+);
+metricLeft = "k-canadian";
+metricRight = "k-canadian";
+note = uni18D6;
+unicode = 6358;
+},
+{
+glyphname = "cOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(115,357,l),
+(115,598,ls),
+(115,646,o),
+(130,668,o),
+(162,668,cs),
+(191,668,o),
+(210,645,o),
+(210,603,cs),
+(210,567,l),
+(269,567,l),
+(269,593,ls),
+(269,675,o),
+(226,720,o),
+(161,720,cs),
+(91,720,o),
+(51,675,o),
+(51,589,cs),
+(51,357,l)
+);
+}
+);
+width = 299;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni18D7;
+unicode = 6359;
+},
+{
+glyphname = "mOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(115,357,l),
+(115,653,l),
+(244,653,l),
+(244,714,l),
+(51,714,l),
+(51,357,l)
+);
+}
+);
+width = 275;
+}
+);
+metricLeft = "m-canadian";
+metricRight = "m-canadian";
+note = uni18D8;
+unicode = 6360;
+},
+{
+glyphname = "nOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(215,443,o),
+(255,491,o),
+(255,575,cs),
+(255,624,o),
+(240,667,o),
+(214,681,c),
+(211,653,l),
+(356,653,l),
+(356,714,l),
+(153,714,ls),
+(82,714,o),
+(41,663,o),
+(41,578,cs),
+(41,492,o),
+(82,443,o),
+(148,443,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(117,492,o),
+(98,518,o),
+(98,578,cs),
+(98,638,o),
+(117,665,o),
+(148,665,cs),
+(179,665,o),
+(197,638,o),
+(197,578,cs),
+(197,519,o),
+(180,492,o),
+(149,492,cs)
+);
+}
+);
+width = 387;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "n-canadian";
+note = uni18D9;
+unicode = 6361;
+},
+{
+glyphname = "sOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(115,357,l),
+(115,503,l),
+(75,476,l),
+(105,476,ls),
+(192,476,o),
+(244,531,o),
+(244,635,cs),
+(244,714,l),
+(180,714,l),
+(180,638,ls),
+(180,562,o),
+(150,528,o),
+(83,528,cs),
+(51,528,l),
+(51,357,l)
+);
+}
+);
+width = 295;
+}
+);
+metricLeft = "s-canadian";
+metricRight = "s-canadian";
+note = uni18DA;
+unicode = 6362;
+},
+{
+color = 1;
+glyphname = "shOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(205,351,o),
+(240,394,o),
+(246,478,cs),
+(254,599,ls),
+(258,645,o),
+(270,668,o),
+(300,668,cs),
+(330,668,o),
+(348,646,o),
+(348,601,cs),
+(348,567,l),
+(407,567,l),
+(407,597,ls),
+(407,678,o),
+(367,720,o),
+(302,720,cs),
+(232,720,o),
+(197,677,o),
+(191,593,cs),
+(183,472,ls),
+(179,426,o),
+(166,403,o),
+(136,403,cs),
+(106,403,o),
+(89,425,o),
+(89,470,cs),
+(89,504,l),
+(30,504,l),
+(30,474,ls),
+(30,393,o),
+(70,351,o),
+(135,351,cs)
+);
+}
+);
+width = 437;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "c-canadian";
+note = uni18DB;
+unicode = 6363;
+},
+{
+color = 9;
+glyphname = "easternw-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (26,-318);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (123,0);
+ref = "glottalstop-canadian";
+}
+);
+width = 486;
+}
+);
+note = uni18DC;
+unicode = 6364;
+},
+{
+color = 9;
+glyphname = "westernw-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (464,-318);
+ref = dot_top;
+scale = (-1,1);
+},
+{
+alignment = -1;
+pos = (365,0);
+ref = "glottalstop-canadian";
+scale = (-1,1);
+}
+);
+width = 492;
+}
+);
+metricLeft = "glottalstop-canadian";
+note = uni18DD;
+unicode = 6365;
+},
+{
+glyphname = "rweRCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "reRCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (711,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 903;
+}
+);
+note = uni18E0;
+unicode = 6368;
+},
+{
+glyphname = "looWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (39,0);
+ref = dot_top;
+}
+);
+width = 456;
+}
+);
+note = uni18E1;
+unicode = 6369;
+},
+{
+glyphname = "laaWestCree-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (278,0);
+ref = dot_top;
+}
+);
+width = 456;
+}
+);
+note = uni18E2;
+unicode = 6370;
+},
+{
+glyphname = "thwe-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "the-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (610,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 801;
+}
+);
+note = uni18E3;
+unicode = 6371;
+},
+{
+glyphname = "thwa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (560,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 752;
+}
+);
+note = uni18E4;
+unicode = 6372;
+},
+{
+glyphname = "tthwe-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "tthe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (602,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni18E5;
+unicode = 6373;
+},
+{
+glyphname = "tthoo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ttho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (196,0);
+ref = dot_top;
+}
+);
+width = 522;
+}
+);
+note = uni18E6;
+unicode = 6374;
+},
+{
+glyphname = "tthaa-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ttha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (194,0);
+ref = dot_top;
+}
+);
+width = 522;
+}
+);
+note = uni18E7;
+unicode = 6375;
+},
+{
+glyphname = "tlhwe-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "tlhe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (505,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 696;
+}
+);
+note = uni18E8;
+unicode = 6376;
+},
+{
+glyphname = "tlhoo-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "tlho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (193,0);
+ref = dot_top;
+}
+);
+width = 505;
+}
+);
+note = uni18E9;
+unicode = 6377;
+},
+{
+glyphname = "shweSayisi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "sheSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (505,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 696;
+}
+);
+note = uni18EA;
+unicode = 6378;
+},
+{
+glyphname = "shooSayisi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "shoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (330,0);
+ref = dot_top;
+}
+);
+width = 505;
+}
+);
+note = uni18EB;
+unicode = 6379;
+},
+{
+color = 9;
+glyphname = "hooSayisi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "hoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (387,0);
+ref = dot_top;
+}
+);
+width = 564;
+}
+);
+note = uni18EC;
+unicode = 6380;
+},
+{
+color = 9;
+glyphname = "gwuCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "guCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (709,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 901;
+}
+);
+note = uni18ED;
+unicode = 6381;
+},
+{
+color = 9;
+glyphname = "deneGeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "geCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (230,0);
+ref = dot_top;
+}
+);
+width = 596;
+}
+);
+note = uni18EE;
+unicode = 6382;
+},
+{
+color = 9;
+glyphname = "gaaCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (242,0);
+ref = dot_top;
+}
+);
+width = 596;
+}
+);
+note = uni18EF;
+unicode = 6383;
+},
+{
+color = 9;
+glyphname = "gwaCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (596,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 788;
+}
+);
+note = uni18F0;
+unicode = 6384;
+},
+{
+color = 9;
+glyphname = "juuSayisi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "juSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (231,0);
+ref = dot_top;
+}
+);
+width = 594;
+}
+);
+note = uni18F1;
+unicode = 6385;
+},
+{
+color = 9;
+glyphname = "jwaCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "jaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (646,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni18F2;
+unicode = 6386;
+},
+{
+glyphname = "lBeaverDene-canadian";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+ref = "pWestCree-canadian";
+}
+);
+width = 166;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+unicode = 6387;
+},
+{
+glyphname = "rBeaverDene-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(115,357,l),
+(115,567,ls),
+(115,623,o),
+(134,654,o),
+(172,654,cs),
+(182,654,l),
+(182,720,l),
+(173,720,ls),
+(132,720,o),
+(105,681,o),
+(104,634,c),
+(109,634,l),
+(109,714,l),
+(51,714,l),
+(51,357,l)
+);
+}
+);
+width = 210;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni18F4;
+unicode = 6388;
+},
+{
+color = 6;
+glyphname = "sDentalCarrier-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(178,190,ls),
+(251,190,o),
+(289,227,o),
+(289,292,cs),
+(289,355,o),
+(254,394,o),
+(188,394,cs),
+(164,394,ls),
+(131,394,o),
+(111,407,o),
+(111,443,cs),
+(111,480,o),
+(131,493,o),
+(164,493,cs),
+(284,493,l),
+(284,546,l),
+(161,546,ls),
+(88,546,o),
+(51,508,o),
+(51,443,cs),
+(51,381,o),
+(86,342,o),
+(151,342,cs),
+(177,342,ls),
+(209,342,o),
+(229,328,o),
+(229,292,cs),
+(229,256,o),
+(209,242,o),
+(177,242,cs),
+(56,242,l),
+(56,190,l)
+);
+}
+);
+width = 340;
+}
+);
+metricLeft = "shCarrier-canadian";
+metricRight = "=|";
+note = uni18F5;
+unicode = 6389;
+},
+{
+glyphname = "pWestCree-canadian.base";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "pWestCree-canadian";
+}
+);
+width = 166;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.base";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "c-canadian";
+}
+);
+width = 299;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "thSayisi-canadian.base";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "thSayisi-canadian";
+}
+);
+width = 300;
+}
+);
+metricLeft = "=|c-canadian";
+note = uni14A2;
+},
+{
+glyphname = "mWestCree-canadian.base";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "mWestCree-canadian";
+}
+);
+width = 303;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+glyphname = "pWestCree-canadian.mid";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "pWestCree-canadian";
+}
+);
+width = 166;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.mid";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "c-canadian";
+}
+);
+width = 299;
+}
+);
+metricLeft = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "mWestCree-canadian.mid";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "mWestCree-canadian";
+}
+);
+width = 303;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+color = 11;
+glyphname = "ngaai-canadian.nunavik";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (537,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (670,0);
+ref = ring_top.canadian;
+}
+);
+width = 1029;
+}
+);
+note = uni158E;
+},
+{
+color = 11;
+glyphname = "ngi-canadian.nunavik";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (537,0);
+ref = "ci-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni158F;
+},
+{
+color = 11;
+glyphname = "ngii-canadian.nunavik";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (537,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (719,0);
+ref = dot_top;
+}
+);
+width = 1029;
+}
+);
+note = uni1590;
+},
+{
+color = 11;
+glyphname = "ngo-canadian.nunavik";
+lastChange = "2023-01-13 15:31:32 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (537,0);
+ref = "co-canadian";
+}
+);
+width = 1028;
+}
+);
+note = uni1591;
+},
+{
+color = 11;
+glyphname = "ngoo-canadian.nunavik";
+lastChange = "2023-01-13 15:31:32 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+ref = "ngo-canadian.nunavik";
+},
+{
+anchor = top_right_can;
+pos = (854,0);
+ref = dot_top;
+}
+);
+width = 1028;
+}
+);
+note = uni1592;
+},
+{
+color = 11;
+glyphname = "nga-canadian.nunavik";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (537,0);
+ref = "ca-canadian";
+}
+);
+width = 1029;
+}
+);
+note = uni1593;
+},
+{
+color = 11;
+glyphname = "ngaa-canadian.nunavik";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (537,0);
+ref = "ca-canadian";
+},
+{
+anchor = top_left_can;
+pos = (573,0);
+ref = dot_top;
+}
+);
+width = 1029;
+}
+);
+note = uni1594;
+},
+{
+color = 11;
+glyphname = "ng-canadian.nunavik";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(448,163,o),
+(496,208,o),
+(496,303,cs),
+(496,388,o),
+(454,434,o),
+(401,434,cs),
+(362,434,o),
+(332,406,o),
+(327,361,c),
+(343,361,l),
+(343,510,l),
+(211,510,l),
+(214,483,l),
+(241,497,o),
+(255,540,o),
+(255,588,cs),
+(255,672,o),
+(215,720,o),
+(148,720,cs),
+(82,720,o),
+(41,671,o),
+(41,585,cs),
+(41,500,o),
+(82,449,o),
+(153,449,cs),
+(320,449,l),
+(279,490,l),
+(279,298,ls),
+(279,213,o),
+(320,163,o),
+(388,163,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(357,212,o),
+(338,235,o),
+(338,299,cs),
+(338,360,o),
+(359,385,o),
+(388,385,cs),
+(417,385,o),
+(438,361,o),
+(438,299,cs),
+(438,237,o),
+(418,212,o),
+(388,212,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(117,498,o),
+(98,525,o),
+(98,585,cs),
+(98,645,o),
+(117,671,o),
+(149,671,cs),
+(180,671,o),
+(197,644,o),
+(197,585,cs),
+(197,525,o),
+(179,498,o),
+(148,498,cs)
+);
+}
+);
+width = 537;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+color = 11;
+glyphname = "ngai-canadian.nunavik";
+lastChange = "2023-01-13 15:31:32 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (537,0);
+ref = "ce-canadian";
+}
+);
+width = 1028;
+}
+);
+note = uni1670;
+},
+{
+color = 11;
+glyphname = "ke-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (286,714);
+},
+{
+name = top_left_can;
+pos = (99,714);
+},
+{
+name = top_right_can;
+pos = (474,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(520,0,l),
+(520,714,l),
+(351,714,ls),
+(154,714,o),
+(51,608,o),
+(51,426,cs),
+(51,243,o),
+(154,139,o),
+(351,139,cs),
+(426,139,l),
+(426,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(208,222,o),
+(144,293,o),
+(144,426,cs),
+(144,559,o),
+(208,631,o),
+(345,631,cs),
+(426,631,l),
+(426,222,l),
+(345,222,ls)
+);
+}
+);
+width = 582;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146B;
+},
+{
+color = 11;
+glyphname = "ki-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (297,714);
+},
+{
+name = top_left_can;
+pos = (109,714);
+},
+{
+name = top_right_can;
+pos = (485,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(155,0,l),
+(155,139,l),
+(231,139,ls),
+(427,139,o),
+(531,243,o),
+(531,426,cs),
+(531,608,o),
+(427,714,o),
+(231,714,cs),
+(62,714,l),
+(62,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(155,631,l),
+(236,631,ls),
+(373,631,o),
+(437,559,o),
+(437,426,cs),
+(437,293,o),
+(373,222,o),
+(236,222,cs),
+(155,222,l)
+);
+}
+);
+width = 582;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni146D;
+},
+{
+color = 11;
+glyphname = "kii-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (227,0);
+ref = dot_top;
+}
+);
+width = 582;
+}
+);
+note = uni146E;
+},
+{
+color = 11;
+glyphname = "ko-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (286,714);
+},
+{
+name = top_left_can;
+pos = (99,714);
+},
+{
+name = top_right_can;
+pos = (474,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(520,0,l),
+(520,714,l),
+(426,714,l),
+(426,575,l),
+(351,575,ls),
+(154,575,o),
+(51,471,o),
+(51,288,cs),
+(51,106,o),
+(154,0,o),
+(351,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(208,83,o),
+(144,155,o),
+(144,288,cs),
+(144,421,o),
+(208,492,o),
+(345,492,cs),
+(426,492,l),
+(426,83,l),
+(345,83,ls)
+);
+}
+);
+width = 582;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146F;
+},
+{
+color = 11;
+glyphname = "koo-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (404,0);
+ref = dot_top;
+}
+);
+width = 582;
+}
+);
+note = uni1470;
+},
+{
+color = 11;
+glyphname = "ka-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (297,714);
+},
+{
+name = top_left_can;
+pos = (109,714);
+},
+{
+name = top_right_can;
+pos = (485,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(231,0,ls),
+(427,0,o),
+(531,106,o),
+(531,288,cs),
+(531,471,o),
+(427,575,o),
+(231,575,cs),
+(155,575,l),
+(155,714,l),
+(62,714,l),
+(62,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(155,492,l),
+(236,492,ls),
+(373,492,o),
+(437,421,o),
+(437,288,cs),
+(437,155,o),
+(373,83,o),
+(236,83,cs),
+(155,83,l)
+);
+}
+);
+width = 582;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1472;
+},
+{
+color = 11;
+glyphname = "kaa-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (39,0);
+ref = dot_top;
+}
+);
+width = 582;
+}
+);
+note = uni1473;
+},
+{
+color = 11;
+glyphname = "kweWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (582,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 773;
+}
+);
+note = uni1475;
+},
+{
+color = 11;
+glyphname = "kwiiWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (227,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (582,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 773;
+}
+);
+note = uni1479;
+},
+{
+color = 11;
+glyphname = "kwoWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (582,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 773;
+}
+);
+note = uni147B;
+},
+{
+color = 11;
+glyphname = "kwooWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (404,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (582,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 773;
+}
+);
+note = uni147D;
+},
+{
+color = 11;
+glyphname = "kwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (582,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 773;
+}
+);
+note = uni147F;
+},
+{
+color = 11;
+glyphname = "kwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (39,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (582,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 773;
+}
+);
+note = uni1481;
+},
+{
+color = 11;
+glyphname = "ce-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (291,714);
+},
+{
+name = top_left_can;
+pos = (96,714);
+},
+{
+name = top_right_can;
+pos = (488,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(534,0,l),
+(534,455,ls),
+(534,633,o),
+(442,727,o),
+(291,727,cs),
+(137,727,o),
+(49,634,o),
+(49,455,cs),
+(49,402,l),
+(142,402,l),
+(142,462,ls),
+(142,584,o),
+(195,641,o),
+(291,641,cs),
+(386,641,o),
+(440,581,o),
+(440,459,cs),
+(440,0,l)
+);
+}
+);
+width = 592;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni1489;
+},
+{
+color = 11;
+glyphname = "ci-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (301,714);
+},
+{
+name = top_left_can;
+pos = (106,714);
+},
+{
+name = top_right_can;
+pos = (497,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(152,0,l),
+(152,459,ls),
+(152,581,o),
+(207,641,o),
+(301,641,cs),
+(397,641,o),
+(451,584,o),
+(451,462,cs),
+(451,402,l),
+(543,402,l),
+(543,455,ls),
+(543,634,o),
+(456,727,o),
+(302,727,cs),
+(150,727,o),
+(58,633,o),
+(58,455,cs),
+(58,0,l)
+);
+}
+);
+width = 592;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+},
+{
+color = 11;
+glyphname = "cii-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (231,0);
+ref = dot_top;
+}
+);
+width = 592;
+}
+);
+note = uni148C;
+},
+{
+color = 11;
+glyphname = "co-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (291,714);
+},
+{
+name = top_left_can;
+pos = (96,714);
+},
+{
+name = top_right_can;
+pos = (488,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(442,-13,o),
+(534,81,o),
+(534,259,cs),
+(534,714,l),
+(440,714,l),
+(440,255,ls),
+(440,133,o),
+(386,73,o),
+(291,73,cs),
+(195,73,o),
+(142,130,o),
+(142,252,cs),
+(142,312,l),
+(49,312,l),
+(49,259,ls),
+(49,80,o),
+(137,-13,o),
+(291,-13,cs)
+);
+}
+);
+width = 592;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+},
+{
+color = 11;
+glyphname = "coo-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (418,0);
+ref = dot_top;
+}
+);
+width = 592;
+}
+);
+note = uni148E;
+},
+{
+color = 11;
+glyphname = "ca-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (301,714);
+},
+{
+name = top_left_can;
+pos = (106,714);
+},
+{
+name = top_right_can;
+pos = (497,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(456,-13,o),
+(543,80,o),
+(543,259,cs),
+(543,312,l),
+(451,312,l),
+(451,252,ls),
+(451,130,o),
+(397,73,o),
+(301,73,cs),
+(207,73,o),
+(152,133,o),
+(152,255,cs),
+(152,714,l),
+(58,714,l),
+(58,259,ls),
+(58,81,o),
+(150,-13,o),
+(302,-13,cs)
+);
+}
+);
+width = 592;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+},
+{
+color = 11;
+glyphname = "caa-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+}
+);
+width = 592;
+}
+);
+note = uni1491;
+},
+{
+color = 11;
+glyphname = "me-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (243,714);
+},
+{
+name = top_double;
+pos = (401,714);
+},
+{
+name = top_left_can;
+pos = (80,714);
+},
+{
+name = top_right_can;
+pos = (401,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(447,0,l),
+(447,714,l),
+(34,714,l),
+(34,628,l),
+(354,628,l),
+(354,0,l)
+);
+}
+);
+width = 509;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+},
+{
+color = 11;
+glyphname = "mi-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (269,714);
+},
+{
+name = top_left_can;
+pos = (109,714);
+},
+{
+name = top_right_can;
+pos = (428,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(155,0,l),
+(155,628,l),
+(475,628,l),
+(475,714,l),
+(62,714,l),
+(62,0,l)
+);
+}
+);
+width = 509;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+},
+{
+color = 11;
+glyphname = "mii-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (199,0);
+ref = dot_top;
+}
+);
+width = 509;
+}
+);
+note = uni14A6;
+},
+{
+color = 11;
+glyphname = "mo-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (243,714);
+},
+{
+name = top_double;
+pos = (401,714);
+},
+{
+name = top_left_can;
+pos = (80,714);
+},
+{
+name = top_right_can;
+pos = (401,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(447,0,l),
+(447,714,l),
+(354,714,l),
+(354,86,l),
+(34,86,l),
+(34,0,l)
+);
+}
+);
+width = 509;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+},
+{
+color = 11;
+glyphname = "moo-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (331,0);
+ref = dot_top;
+}
+);
+width = 509;
+}
+);
+note = uni14A8;
+},
+{
+color = 11;
+glyphname = "ma-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (269,714);
+},
+{
+name = top_left_can;
+pos = (109,714);
+},
+{
+name = top_right_can;
+pos = (428,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(475,0,l),
+(475,86,l),
+(155,86,l),
+(155,714,l),
+(62,714,l),
+(62,0,l)
+);
+}
+);
+width = 509;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+},
+{
+color = 11;
+glyphname = "maa-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (39,0);
+ref = dot_top;
+}
+);
+width = 509;
+}
+);
+note = uni14AB;
+},
+{
+color = 11;
+glyphname = "ne-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (376,714);
+},
+{
+name = top_left_can;
+pos = (213,714);
+},
+{
+name = top_right_can;
+pos = (540,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(511,-13,o),
+(586,69,o),
+(586,224,cs),
+(586,714,l),
+(48,714,l),
+(48,629,l),
+(166,629,l),
+(166,227,ls),
+(166,69,o),
+(241,-13,o),
+(376,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(297,74,o),
+(259,121,o),
+(259,220,cs),
+(259,629,l),
+(493,629,l),
+(493,220,ls),
+(493,122,o),
+(455,74,o),
+(376,74,cs)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C0;
+},
+{
+color = 11;
+glyphname = "ni-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (268,714);
+},
+{
+name = top_left_can;
+pos = (105,714);
+},
+{
+name = top_right_can;
+pos = (432,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(403,-13,o),
+(478,69,o),
+(478,227,cs),
+(478,629,l),
+(596,629,l),
+(596,714,l),
+(58,714,l),
+(58,224,ls),
+(58,69,o),
+(133,-13,o),
+(268,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(189,74,o),
+(151,122,o),
+(151,220,cs),
+(151,629,l),
+(385,629,l),
+(385,220,ls),
+(385,121,o),
+(347,74,o),
+(268,74,cs)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+},
+{
+color = 11;
+glyphname = "nii-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (198,0);
+ref = dot_top;
+}
+);
+width = 644;
+}
+);
+note = uni14C3;
+},
+{
+color = 11;
+glyphname = "no-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (376,714);
+},
+{
+name = top_double;
+pos = (386,714);
+},
+{
+name = top_left_can;
+pos = (213,714);
+},
+{
+name = top_right_can;
+pos = (525,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(586,0,l),
+(586,490,ls),
+(586,645,o),
+(511,727,o),
+(376,727,cs),
+(241,727,o),
+(166,645,o),
+(166,487,cs),
+(166,85,l),
+(48,85,l),
+(48,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(259,494,ls),
+(259,593,o),
+(297,640,o),
+(376,640,cs),
+(455,640,o),
+(493,592,o),
+(493,494,cs),
+(493,85,l),
+(259,85,l)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C4;
+},
+{
+color = 11;
+glyphname = "noo-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (306,0);
+ref = dot_top;
+}
+);
+width = 644;
+}
+);
+note = uni14C5;
+},
+{
+color = 11;
+glyphname = "na-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (268,714);
+},
+{
+name = top_double;
+pos = (278,714);
+},
+{
+name = top_left_can;
+pos = (105,714);
+},
+{
+name = top_right_can;
+pos = (432,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(596,0,l),
+(596,85,l),
+(478,85,l),
+(478,487,ls),
+(478,645,o),
+(403,727,o),
+(268,727,cs),
+(133,727,o),
+(58,645,o),
+(58,490,cs),
+(58,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(151,494,ls),
+(151,592,o),
+(189,640,o),
+(268,640,cs),
+(347,640,o),
+(385,593,o),
+(385,494,cs),
+(385,85,l),
+(151,85,l)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+},
+{
+color = 11;
+glyphname = "naa-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (198,0);
+ref = dot_top;
+}
+);
+width = 644;
+}
+);
+note = uni14C8;
+},
+{
+color = 11;
+glyphname = "nweWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (644,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 836;
+}
+);
+note = uni14CA;
+},
+{
+color = 11;
+glyphname = "nwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (644,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 836;
+}
+);
+note = uni14CC;
+},
+{
+color = 11;
+glyphname = "nwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (198,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (644,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 836;
+}
+);
+note = uni14CE;
+},
+{
+color = 11;
+glyphname = "se-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (108,714);
+},
+{
+name = top_right_can;
+pos = (488,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(529,0,l),
+(529,262,l),
+(380,262,ls),
+(230,262,o),
+(154,342,o),
+(154,496,cs),
+(154,714,l),
+(60,714,l),
+(60,495,ls),
+(60,292,o),
+(176,179,o),
+(381,179,cs),
+(465,179,l),
+(436,204,l),
+(436,0,l)
+);
+}
+);
+width = 591;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14ED;
+},
+{
+color = 11;
+glyphname = "si-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (109,714);
+},
+{
+name = top_right_can;
+pos = (490,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(156,0,l),
+(156,204,l),
+(127,179,l),
+(210,179,ls),
+(416,179,o),
+(531,292,o),
+(531,485,cs),
+(531,714,l),
+(438,714,l),
+(438,486,ls),
+(438,342,o),
+(362,262,o),
+(216,262,cs),
+(62,262,l),
+(62,0,l)
+);
+}
+);
+width = 591;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+},
+{
+color = 11;
+glyphname = "sii-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (420,0);
+ref = dot_top;
+}
+);
+width = 591;
+}
+);
+note = uni14F0;
+},
+{
+color = 11;
+glyphname = "so-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (483,714);
+},
+{
+name = top_left_can;
+pos = (108,714);
+},
+{
+name = top_right_can;
+pos = (483,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(154,0,l),
+(154,218,ls),
+(154,372,o),
+(230,452,o),
+(380,452,cs),
+(529,452,l),
+(529,714,l),
+(436,714,l),
+(436,510,l),
+(465,535,l),
+(381,535,ls),
+(176,535,o),
+(60,422,o),
+(60,219,cs),
+(60,0,l)
+);
+}
+);
+width = 591;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+},
+{
+color = 11;
+glyphname = "soo-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (413,0);
+ref = dot_top;
+}
+);
+width = 591;
+}
+);
+note = uni14F2;
+},
+{
+color = 11;
+glyphname = "sa-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (111,714);
+},
+{
+name = top_right_can;
+pos = (485,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(531,0,l),
+(531,219,ls),
+(531,422,o),
+(416,535,o),
+(210,535,cs),
+(127,535,l),
+(156,510,l),
+(156,714,l),
+(62,714,l),
+(62,452,l),
+(212,452,ls),
+(362,452,o),
+(438,372,o),
+(438,218,cs),
+(438,0,l)
+);
+}
+);
+width = 591;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+},
+{
+color = 11;
+glyphname = "saa-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (41,0);
+ref = dot_top;
+}
+);
+width = 591;
+}
+);
+note = uni14F5;
+},
+{
+color = 11;
+glyphname = "sho-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (292,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(519,0,l),
+(519,78,l),
+(265,78,ls),
+(183,78,o),
+(147,120,o),
+(147,198,cs),
+(147,277,o),
+(182,319,o),
+(265,319,cs),
+(337,319,ls),
+(464,319,o),
+(529,392,o),
+(529,517,cs),
+(529,641,o),
+(464,714,o),
+(337,714,cs),
+(64,714,l),
+(64,636,l),
+(319,636,ls),
+(400,636,o),
+(436,594,o),
+(436,517,cs),
+(436,438,o),
+(401,396,o),
+(319,396,cs),
+(246,396,ls),
+(119,396,o),
+(54,322,o),
+(54,198,cs),
+(54,73,o),
+(119,0,o),
+(246,0,cs)
+);
+}
+);
+width = 583;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+color = 11;
+glyphname = "shoo-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (222,0);
+ref = dot_top;
+}
+);
+width = 583;
+}
+);
+note = g728;
+},
+{
+color = 11;
+glyphname = "sha-canadian.square";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (292,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(337,0,ls),
+(463,0,o),
+(529,73,o),
+(529,197,cs),
+(529,322,o),
+(463,396,o),
+(337,396,cs),
+(264,396,ls),
+(182,396,o),
+(146,438,o),
+(146,516,cs),
+(146,594,o),
+(182,636,o),
+(264,636,cs),
+(519,636,l),
+(519,714,l),
+(245,714,ls),
+(119,714,o),
+(54,641,o),
+(54,516,cs),
+(54,392,o),
+(119,318,o),
+(245,318,cs),
+(318,318,ls),
+(400,318,o),
+(435,277,o),
+(435,197,cs),
+(435,119,o),
+(400,78,o),
+(318,78,cs),
+(64,78,l),
+(64,0,l)
+);
+}
+);
+width = 583;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+color = 11;
+glyphname = "shaa-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (222,0);
+ref = dot_top;
+}
+);
+width = 582;
+}
+);
+note = g730;
+},
+{
+color = 11;
+glyphname = "ye-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (86,714);
+},
+{
+name = top_right_can;
+pos = (500,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(546,0,l),
+(546,261,l),
+(170,261,l),
+(170,221,l),
+(565,668,l),
+(498,726,l),
+(37,209,l),
+(37,179,l),
+(453,179,l),
+(453,0,l)
+);
+}
+);
+width = 606;
+}
+);
+metricLeft = "ye-canadian";
+note = uni1526;
+},
+{
+color = 11;
+glyphname = "yi-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (106,714);
+},
+{
+name = top_right_can;
+pos = (520,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(153,0,l),
+(153,179,l),
+(569,179,l),
+(569,209,l),
+(108,726,l),
+(41,668,l),
+(436,221,l),
+(436,261,l),
+(59,261,l),
+(59,0,l)
+);
+}
+);
+width = 606;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni1528;
+},
+{
+color = 11;
+glyphname = "yii-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+}
+);
+width = 606;
+}
+);
+note = uni1529;
+},
+{
+color = 11;
+glyphname = "yo-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (500,714);
+},
+{
+name = top_left_can;
+pos = (86,714);
+},
+{
+name = top_right_can;
+pos = (500,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(565,46,l),
+(170,493,l),
+(170,453,l),
+(546,453,l),
+(546,714,l),
+(453,714,l),
+(453,535,l),
+(37,535,l),
+(37,505,l),
+(498,-12,l)
+);
+}
+);
+width = 606;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152A;
+},
+{
+color = 11;
+glyphname = "yoo-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (430,0);
+ref = dot_top;
+}
+);
+width = 606;
+}
+);
+note = uni152B;
+},
+{
+color = 11;
+glyphname = "ya-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (106,714);
+},
+{
+name = top_right_can;
+pos = (520,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(569,505,l),
+(569,535,l),
+(153,535,l),
+(153,714,l),
+(59,714,l),
+(59,453,l),
+(436,453,l),
+(436,493,l),
+(41,46,l),
+(108,-12,l)
+);
+}
+);
+width = 606;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152D;
+},
+{
+color = 11;
+glyphname = "yaa-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (36,0);
+ref = dot_top;
+}
+);
+width = 606;
+}
+);
+note = uni152E;
+},
+{
+color = 11;
+glyphname = "re-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (268,714);
+},
+{
+name = top_left_can;
+pos = (105,714);
+},
+{
+name = top_right_can;
+pos = (432,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(404,-13,o),
+(478,69,o),
+(478,227,cs),
+(478,629,l),
+(596,629,l),
+(596,714,l),
+(385,714,l),
+(385,220,ls),
+(385,121,o),
+(347,74,o),
+(268,74,cs),
+(189,74,o),
+(151,122,o),
+(151,220,cs),
+(151,714,l),
+(58,714,l),
+(58,224,ls),
+(58,69,o),
+(133,-13,o),
+(268,-13,cs)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1542;
+},
+{
+color = 11;
+glyphname = "reRCree-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (376,714);
+},
+{
+name = top_left_can;
+pos = (213,714);
+},
+{
+name = top_right_can;
+pos = (540,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(511,-13,o),
+(586,69,o),
+(586,224,cs),
+(586,714,l),
+(493,714,l),
+(493,220,ls),
+(493,122,o),
+(455,74,o),
+(376,74,cs),
+(297,74,o),
+(259,121,o),
+(259,220,cs),
+(259,714,l),
+(48,714,l),
+(48,629,l),
+(166,629,l),
+(166,227,ls),
+(166,69,o),
+(240,-13,o),
+(376,-13,cs)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni1543;
+},
+{
+color = 11;
+glyphname = "leWestCree-canadian.square";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (376,714);
+},
+{
+name = top_left_can;
+pos = (213,714);
+},
+{
+name = top_right_can;
+pos = (540,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(259,0,l),
+(259,494,ls),
+(259,592,o),
+(297,640,o),
+(376,640,cs),
+(455,640,o),
+(493,592,o),
+(493,494,cs),
+(493,0,l),
+(586,0,l),
+(586,489,ls),
+(586,645,o),
+(511,727,o),
+(376,727,cs),
+(240,727,o),
+(166,645,o),
+(166,487,cs),
+(166,84,l),
+(48,84,l),
+(48,0,l)
+);
+}
+);
+width = 646;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+},
+{
+color = 11;
+glyphname = "ri-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (268,714);
+},
+{
+name = top_left_can;
+pos = (107,714);
+},
+{
+name = top_right_can;
+pos = (432,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(151,0,l),
+(151,494,ls),
+(151,592,o),
+(189,640,o),
+(268,640,cs),
+(347,640,o),
+(385,593,o),
+(385,494,cs),
+(385,0,l),
+(596,0,l),
+(596,85,l),
+(478,85,l),
+(478,487,ls),
+(478,645,o),
+(404,727,o),
+(268,727,cs),
+(133,727,o),
+(58,645,o),
+(58,490,cs),
+(58,0,l)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+},
+{
+color = 11;
+glyphname = "rii-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (198,0);
+ref = dot_top;
+}
+);
+width = 644;
+}
+);
+note = uni1547;
+},
+{
+color = 11;
+glyphname = "ro-canadian.square";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (291,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(155,0,l),
+(155,166,l),
+(119,139,l),
+(216,139,ls),
+(412,139,o),
+(516,243,o),
+(516,426,cs),
+(516,608,o),
+(412,714,o),
+(216,714,cs),
+(62,714,l),
+(62,631,l),
+(221,631,ls),
+(358,631,o),
+(422,559,o),
+(422,426,cs),
+(422,293,o),
+(358,222,o),
+(221,222,cs),
+(62,222,l),
+(62,0,l)
+);
+}
+);
+width = 567;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1548;
+},
+{
+color = 11;
+glyphname = "loWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (289,714);
+},
+{
+name = top_left_can;
+pos = (109,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(216,0,ls),
+(412,0,o),
+(516,106,o),
+(516,288,cs),
+(516,471,o),
+(412,575,o),
+(216,575,cs),
+(119,575,l),
+(155,548,l),
+(155,714,l),
+(62,714,l),
+(62,492,l),
+(221,492,ls),
+(358,492,o),
+(422,421,o),
+(422,288,cs),
+(422,155,o),
+(358,83,o),
+(221,83,cs),
+(62,83,l),
+(62,0,l)
+);
+}
+);
+width = 562;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+},
+{
+color = 11;
+glyphname = "ra-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (273,714);
+},
+{
+name = top_right_can;
+pos = (454,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(500,0,l),
+(500,222,l),
+(341,222,ls),
+(204,222,o),
+(140,293,o),
+(140,426,cs),
+(140,559,o),
+(204,631,o),
+(341,631,cs),
+(500,631,l),
+(500,714,l),
+(346,714,ls),
+(150,714,o),
+(46,608,o),
+(46,426,cs),
+(46,243,o),
+(150,139,o),
+(346,139,cs),
+(443,139,l),
+(407,166,l),
+(407,0,l)
+);
+}
+);
+width = 562;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+},
+{
+color = 11;
+glyphname = "raa-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (203,0);
+ref = dot_top;
+}
+);
+width = 562;
+}
+);
+note = uni154C;
+},
+{
+color = 11;
+glyphname = "laWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (454,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(500,0,l),
+(500,83,l),
+(341,83,ls),
+(204,83,o),
+(140,155,o),
+(140,288,cs),
+(140,421,o),
+(204,492,o),
+(341,492,cs),
+(500,492,l),
+(500,714,l),
+(407,714,l),
+(407,548,l),
+(443,575,l),
+(346,575,ls),
+(150,575,o),
+(46,471,o),
+(46,288,cs),
+(46,106,o),
+(150,0,o),
+(346,0,cs)
+);
+}
+);
+width = 562;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+},
+{
+color = 11;
+glyphname = "reWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(523,0,l),
+(720,201,l),
+(664,260,l),
+(473,66,l),
+(534,62,l),
+(534,455,ls),
+(534,633,o),
+(442,727,o),
+(291,727,cs),
+(137,727,o),
+(49,634,o),
+(49,455,cs),
+(49,402,l),
+(142,402,l),
+(142,462,ls),
+(142,584,o),
+(195,641,o),
+(291,641,cs),
+(386,641,o),
+(440,581,o),
+(440,459,cs),
+(440,0,l)
+);
+}
+);
+width = 741;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+},
+{
+color = 11;
+glyphname = "riWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(301,0,l),
+(301,459,ls),
+(301,581,o),
+(355,641,o),
+(450,641,cs),
+(546,641,o),
+(599,584,o),
+(599,462,cs),
+(599,402,l),
+(692,402,l),
+(692,455,ls),
+(692,634,o),
+(604,727,o),
+(450,727,cs),
+(299,727,o),
+(207,633,o),
+(207,455,cs),
+(207,62,l),
+(268,66,l),
+(77,260,l),
+(21,201,l),
+(218,0,l)
+);
+}
+);
+width = 741;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+},
+{
+color = 11;
+glyphname = "roWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(442,-13,o),
+(534,81,o),
+(534,259,cs),
+(534,652,l),
+(473,648,l),
+(664,454,l),
+(720,513,l),
+(523,714,l),
+(440,714,l),
+(440,255,ls),
+(440,133,o),
+(386,73,o),
+(291,73,cs),
+(195,73,o),
+(142,130,o),
+(142,252,cs),
+(142,312,l),
+(49,312,l),
+(49,259,ls),
+(49,80,o),
+(137,-13,o),
+(291,-13,cs)
+);
+}
+);
+width = 741;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+},
+{
+color = 11;
+glyphname = "raWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(604,-13,o),
+(692,80,o),
+(692,259,cs),
+(692,312,l),
+(599,312,l),
+(599,252,ls),
+(599,130,o),
+(546,73,o),
+(450,73,cs),
+(355,73,o),
+(301,133,o),
+(301,255,cs),
+(301,714,l),
+(218,714,l),
+(21,513,l),
+(77,454,l),
+(268,648,l),
+(207,652,l),
+(207,259,ls),
+(207,81,o),
+(299,-13,o),
+(450,-13,cs)
+);
+}
+);
+width = 741;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+},
+{
+color = 11;
+glyphname = "theThCree-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (86,714);
+},
+{
+name = top_right_can;
+pos = (500,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(453,66,l),
+(453,0,l),
+(546,0,l),
+(546,66,l),
+(622,66,l),
+(622,115,l),
+(546,115,l),
+(546,261,l),
+(170,261,l),
+(170,221,l),
+(565,668,l),
+(498,726,l),
+(37,209,l),
+(37,179,l),
+(453,179,l),
+(453,115,l),
+(262,115,l),
+(262,66,l)
+);
+}
+);
+width = 653;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15A7;
+},
+{
+color = 11;
+glyphname = "thiThCree-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (148,714);
+},
+{
+name = top_right_can;
+pos = (562,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,0,l),
+(200,66,l),
+(391,66,l),
+(391,115,l),
+(200,115,l),
+(200,179,l),
+(616,179,l),
+(616,209,l),
+(155,726,l),
+(88,668,l),
+(483,221,l),
+(483,261,l),
+(107,261,l),
+(107,115,l),
+(31,115,l),
+(31,66,l),
+(107,66,l),
+(107,0,l)
+);
+}
+);
+width = 653;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+},
+{
+color = 11;
+glyphname = "thiiThCree-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (78,0);
+ref = dot_top;
+}
+);
+width = 653;
+}
+);
+note = uni15A9;
+},
+{
+color = 11;
+glyphname = "thoThCree-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (86,714);
+},
+{
+name = top_right_can;
+pos = (500,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(565,46,l),
+(170,493,l),
+(170,453,l),
+(546,453,l),
+(546,599,l),
+(622,599,l),
+(622,648,l),
+(546,648,l),
+(546,714,l),
+(453,714,l),
+(453,648,l),
+(262,648,l),
+(262,599,l),
+(453,599,l),
+(453,535,l),
+(37,535,l),
+(37,505,l),
+(498,-12,l)
+);
+}
+);
+width = 653;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+},
+{
+color = 11;
+glyphname = "thooThCree-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (430,0);
+ref = dot_top;
+}
+);
+width = 653;
+}
+);
+note = uni15AB;
+},
+{
+color = 11;
+glyphname = "thaThCree-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (154,714);
+},
+{
+name = top_right_can;
+pos = (567,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(616,505,l),
+(616,535,l),
+(200,535,l),
+(200,599,l),
+(391,599,l),
+(391,648,l),
+(200,648,l),
+(200,714,l),
+(107,714,l),
+(107,648,l),
+(31,648,l),
+(31,599,l),
+(107,599,l),
+(107,453,l),
+(483,453,l),
+(483,493,l),
+(88,46,l),
+(155,-12,l)
+);
+}
+);
+width = 653;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+},
+{
+color = 11;
+glyphname = "thaaThCree-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (84,0);
+ref = dot_top;
+}
+);
+width = 653;
+}
+);
+note = uni15AD;
+},
+{
+color = 11;
+glyphname = "thweeWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni1677;
+},
+{
+color = 11;
+glyphname = "thwiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni1678;
+},
+{
+color = 11;
+glyphname = "thwiiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (78,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni1679;
+},
+{
+color = 11;
+glyphname = "thwoWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni167A;
+},
+{
+color = 11;
+glyphname = "thwooWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (430,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni167B;
+},
+{
+color = 11;
+glyphname = "thwaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni167C;
+},
+{
+color = 11;
+glyphname = "thwaaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (84,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (653,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni167D;
+},
+{
+color = 11;
+glyphname = "nwiOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (644,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 836;
+}
+);
+note = uni18C7;
+},
+{
+color = 11;
+glyphname = "nwiiOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (198,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (644,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 836;
+}
+);
+note = uni18C9;
+},
+{
+color = 11;
+glyphname = "nwoOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (644,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 836;
+}
+);
+note = uni18CB;
+},
+{
+color = 11;
+glyphname = "nwooOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (306,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (644,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 836;
+}
+);
+note = uni18CD;
+},
+{
+color = 11;
+glyphname = "looWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (39,0);
+ref = dot_top;
+}
+);
+width = 562;
+}
+);
+note = uni18E1;
+},
+{
+color = 11;
+glyphname = "laaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (384,0);
+ref = dot_top;
+}
+);
+width = 562;
+}
+);
+note = uni18E2;
+},
+{
+color = 0;
+glyphname = zero;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(535,570,o),
+(476,725,o),
+(298,725,cs),
+(117,725,o),
+(59,559,o),
+(59,358,cs),
+(59,112,o),
+(144,-10,o),
+(297,-10,cs),
+(457,-10,o),
+(535,110,o),
+(535,358,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(157,485,o),
+(175,644,o),
+(298,644,cs),
+(427,644,o),
+(437,477,o),
+(437,358,cs),
+(437,196,o),
+(405,71,o),
+(297,71,cs),
+(194,71,o),
+(157,195,o),
+(157,358,cs)
+);
+}
+);
+width = 593;
+}
+);
+unicode = 48;
+},
+{
+color = 0;
+glyphname = one;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(234,714,l),
+(17,547,l),
+(70,482,l),
+(175,563,ls),
+(195,579,o),
+(208,591,o),
+(225,607,c),
+(223,575,o),
+(223,546,o),
+(223,514,cs),
+(223,0,l),
+(322,0,l),
+(322,714,l)
+);
+}
+);
+width = 445;
+}
+);
+unicode = 49;
+},
+{
+color = 0;
+glyphname = two;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(510,0,l),
+(510,83,l),
+(168,83,l),
+(168,85,l),
+(309,231,ls),
+(385,305,o),
+(438,363,o),
+(465,426,cs),
+(478,458,o),
+(485,494,o),
+(485,535,cs),
+(485,648,o),
+(400,724,o),
+(274,724,cs),
+(184,724,o),
+(114,693,o),
+(49,636,c),
+(103,571,l),
+(159,617,o),
+(213,640,o),
+(265,640,cs),
+(339,640,o),
+(387,598,o),
+(387,523,cs),
+(387,466,o),
+(368,423,o),
+(326,371,cs),
+(305,345,o),
+(277,314,o),
+(243,279,cs),
+(41,68,l),
+(41,0,l)
+);
+}
+);
+width = 560;
+}
+);
+unicode = 50;
+},
+{
+color = 0;
+glyphname = three;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(480,662,o),
+(396,724,o),
+(266,724,cs),
+(162,724,o),
+(92,694,o),
+(33,651,c),
+(76,583,l),
+(124,617,o),
+(184,643,o),
+(253,643,cs),
+(332,643,o),
+(384,608,o),
+(384,535,cs),
+(384,444,o),
+(298,407,o),
+(205,407,cs),
+(138,407,l),
+(138,331,l),
+(204,331,ls),
+(325,331,o),
+(398,298,o),
+(398,203,cs),
+(398,122,o),
+(345,70,o),
+(222,70,cs),
+(157,70,o),
+(84,88,o),
+(28,116,c),
+(28,31,l),
+(84,7,o),
+(149,-10,o),
+(234,-10,cs),
+(396,-10,o),
+(502,68,o),
+(502,198,cs),
+(502,303,o),
+(438,359,o),
+(326,373,c),
+(326,375,l),
+(414,395,o),
+(480,459,o),
+(480,554,cs)
+);
+}
+);
+width = 551;
+}
+);
+unicode = 51;
+},
+{
+color = 0;
+glyphname = four;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(469,246,l),
+(469,716,l),
+(376,716,l),
+(36,241,l),
+(36,170,l),
+(372,170,l),
+(372,0,l),
+(469,0,l),
+(469,170,l),
+(579,170,l),
+(579,246,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(128,246,l),
+(318,509,ls),
+(343,544,o),
+(352,560,o),
+(371,593,c),
+(374,593,l),
+(374,576,o),
+(372,541,o),
+(372,495,cs),
+(372,246,l)
+);
+}
+);
+width = 607;
+}
+);
+unicode = 52;
+},
+{
+color = 0;
+glyphname = five;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(223,444,o),
+(189,435,o),
+(161,429,c),
+(179,630,l),
+(461,630,l),
+(461,714,l),
+(95,714,l),
+(67,369,l),
+(108,345,l),
+(147,357,o),
+(189,366,o),
+(240,366,cs),
+(350,366,o),
+(406,312,o),
+(406,223,cs),
+(406,126,o),
+(338,70,o),
+(231,70,cs),
+(164,70,o),
+(95,91,o),
+(48,116,c),
+(48,31,l),
+(95,6,o),
+(159,-10,o),
+(237,-10,cs),
+(410,-10,o),
+(506,79,o),
+(506,226,cs),
+(506,365,o),
+(416,444,o),
+(281,444,cs)
+);
+}
+);
+width = 553;
+}
+);
+unicode = 53;
+},
+{
+color = 0;
+glyphname = six;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(58,133,o),
+(134,-10,o),
+(305,-10,cs),
+(448,-10,o),
+(535,83,o),
+(535,233,cs),
+(535,372,o),
+(459,455,o),
+(330,455,cs),
+(240,455,o),
+(179,411,o),
+(151,353,c),
+(147,353,l),
+(152,526,o),
+(217,646,o),
+(387,646,cs),
+(431,646,o),
+(463,641,o),
+(489,634,c),
+(489,714,l),
+(462,721,o),
+(424,725,o),
+(389,725,cs),
+(145,725,o),
+(58,547,o),
+(58,303,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(194,70,o),
+(159,176,o),
+(159,255,cs),
+(159,321,o),
+(229,376,o),
+(307,376,cs),
+(397,376,o),
+(439,322,o),
+(439,231,cs),
+(439,129,o),
+(390,70,o),
+(303,70,cs)
+);
+}
+);
+width = 580;
+}
+);
+unicode = 54;
+},
+{
+color = 0;
+glyphname = seven;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(499,655,l),
+(499,714,l),
+(19,714,l),
+(19,631,l),
+(393,631,l),
+(118,0,l),
+(221,0,l)
+);
+}
+);
+width = 523;
+}
+);
+unicode = 55;
+},
+{
+color = 0;
+glyphname = eight;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(432,-10,o),
+(532,59,o),
+(532,185,cs),
+(532,284,o),
+(459,341,o),
+(362,379,c),
+(450,417,o),
+(509,470,o),
+(509,556,cs),
+(509,665,o),
+(424,724,o),
+(295,724,cs),
+(166,724,o),
+(79,661,o),
+(79,556,cs),
+(79,460,o),
+(150,411,o),
+(220,378,c),
+(123,341,o),
+(57,285,o),
+(57,181,cs),
+(57,68,o),
+(142,-10,o),
+(292,-10,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(205,64,o),
+(149,110,o),
+(149,184,cs),
+(149,267,o),
+(219,308,o),
+(292,335,c),
+(388,297,o),
+(440,254,o),
+(440,186,cs),
+(440,107,o),
+(382,64,o),
+(291,64,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(222,451,o),
+(173,486,o),
+(173,548,cs),
+(173,613,o),
+(225,650,o),
+(294,650,cs),
+(369,650,o),
+(415,615,o),
+(415,549,cs),
+(415,488,o),
+(370,455,o),
+(295,422,c)
+);
+}
+);
+width = 588;
+}
+);
+unicode = 56;
+},
+{
+color = 0;
+glyphname = nine;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(521,586,o),
+(445,724,o),
+(274,724,cs),
+(130,724,o),
+(43,632,o),
+(43,482,cs),
+(43,344,o),
+(119,259,o),
+(246,259,cs),
+(337,259,o),
+(399,302,o),
+(428,363,c),
+(431,363,l),
+(425,181,o),
+(353,68,o),
+(186,68,cs),
+(147,68,o),
+(111,73,o),
+(85,80,c),
+(85,-2,l),
+(112,-8,o),
+(155,-11,o),
+(190,-11,cs),
+(434,-11,o),
+(521,171,o),
+(521,408,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(386,643,o),
+(420,535,o),
+(420,461,cs),
+(420,394,o),
+(346,337,o),
+(272,337,cs),
+(184,337,o),
+(139,394,o),
+(139,483,cs),
+(139,586,o),
+(188,643,o),
+(276,643,cs)
+);
+}
+);
+width = 579;
+}
+);
+unicode = 57;
+},
+{
+glyphname = zero.canadian;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(452,612,o),
+(380,727,o),
+(248,727,cs),
+(117,727,o),
+(45,612,o),
+(45,357,cs),
+(45,102,o),
+(117,-12,o),
+(248,-12,cs),
+(380,-12,o),
+(452,102,o),
+(452,357,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(139,563,o),
+(174,643,o),
+(249,643,cs),
+(324,643,o),
+(358,564,o),
+(358,357,cs),
+(358,150,o),
+(324,72,o),
+(249,72,cs),
+(174,72,o),
+(139,151,o),
+(139,357,cs)
+);
+}
+);
+width = 497;
+}
+);
+metricRight = "=|";
+},
+{
+glyphname = one.canadian;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(274,0,l),
+(274,714,l),
+(190,714,l),
+(20,541,l),
+(77,482,l),
+(241,648,l),
+(180,652,l),
+(180,0,l)
+);
+}
+);
+width = 336;
+}
+);
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = two.canadian;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(441,86,l),
+(168,86,l),
+(169,54,l),
+(351,298,ls),
+(415,384,o),
+(434,458,o),
+(434,527,cs),
+(434,653,o),
+(359,727,o),
+(246,727,cs),
+(116,727,o),
+(45,634,o),
+(45,468,c),
+(138,468,l),
+(138,589,o),
+(173,645,o),
+(244,645,cs),
+(306,645,o),
+(340,603,o),
+(340,527,cs),
+(340,470,o),
+(322,408,o),
+(268,335,cs),
+(64,62,l),
+(64,0,l),
+(441,0,l)
+);
+}
+);
+width = 486;
+}
+);
+note = uni14BF;
+},
+{
+glyphname = three.canadian;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(381,-13,o),
+(455,58,o),
+(455,190,cs),
+(455,288,o),
+(410,358,o),
+(320,374,c),
+(320,342,l),
+(404,357,o),
+(448,429,o),
+(448,522,cs),
+(448,657,o),
+(377,727,o),
+(261,727,cs),
+(133,727,o),
+(60,636,o),
+(58,483,c),
+(151,483,l),
+(151,593,o),
+(188,645,o),
+(259,645,cs),
+(322,645,o),
+(354,607,o),
+(354,517,cs),
+(354,434,o),
+(323,397,o),
+(264,397,cs),
+(233,397,l),
+(233,318,l),
+(265,318,ls),
+(328,318,o),
+(361,279,o),
+(361,197,cs),
+(361,107,o),
+(326,69,o),
+(258,69,cs),
+(184,69,o),
+(146,121,o),
+(146,231,c),
+(53,231,l),
+(53,71,o),
+(127,-13,o),
+(261,-13,cs)
+);
+}
+);
+width = 514;
+}
+);
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = four.canadian;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(381,0,l),
+(381,170,l),
+(463,170,l),
+(463,248,l),
+(381,248,l),
+(381,716,l),
+(307,716,l),
+(33,233,l),
+(33,170,l),
+(291,170,l),
+(291,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(323,621,l),
+(295,621,l),
+(295,248,l),
+(98,248,l),
+(105,226,l)
+);
+}
+);
+width = 487;
+}
+);
+},
+{
+glyphname = five.canadian;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(380,-13,o),
+(460,66,o),
+(460,209,cs),
+(460,350,o),
+(387,423,o),
+(253,423,cs),
+(146,423,l),
+(182,396,l),
+(199,655,l),
+(162,628,l),
+(436,628,l),
+(436,714,l),
+(112,714,l),
+(89,362,l),
+(107,341,l),
+(233,341,ls),
+(328,341,o),
+(367,300,o),
+(367,205,cs),
+(367,112,o),
+(328,69,o),
+(261,69,cs),
+(191,69,o),
+(152,112,o),
+(152,205,c),
+(59,205,l),
+(60,61,o),
+(139,-13,o),
+(262,-13,cs)
+);
+}
+);
+width = 509;
+}
+);
+},
+{
+glyphname = six.canadian;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(379,-13,o),
+(457,78,o),
+(457,211,cs),
+(457,347,o),
+(384,434,o),
+(276,434,cs),
+(196,434,o),
+(137,387,o),
+(118,291,c),
+(142,272,l),
+(139,306,o),
+(139,327,o),
+(139,381,cs),
+(139,571,o),
+(177,646,o),
+(260,646,cs),
+(326,646,o),
+(357,595,o),
+(361,512,c),
+(454,512,l),
+(444,643,o),
+(380,727,o),
+(264,727,cs),
+(125,727,o),
+(45,614,o),
+(45,361,cs),
+(45,205,o),
+(66,117,o),
+(111,57,cs),
+(148,7,o),
+(199,-13,o),
+(265,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(189,66,o),
+(150,124,o),
+(150,215,cs),
+(150,301,o),
+(193,356,o),
+(261,356,cs),
+(329,356,o),
+(366,301,o),
+(366,211,cs),
+(366,122,o),
+(326,66,o),
+(260,66,cs)
+);
+}
+);
+width = 498;
+}
+);
+metricLeft = zero.canadian;
+},
+{
+glyphname = seven.canadian;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(378,655,l),
+(378,714,l),
+(23,714,l),
+(23,628,l),
+(287,628,l),
+(286,657,l),
+(96,26,l),
+(96,0,l),
+(186,0,l)
+);
+}
+);
+width = 407;
+}
+);
+},
+{
+glyphname = eight.canadian;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(387,-13,o),
+(466,65,o),
+(466,188,cs),
+(466,293,o),
+(410,356,o),
+(329,373,c),
+(324,344,l),
+(399,356,o),
+(453,420,o),
+(453,526,cs),
+(453,649,o),
+(379,727,o),
+(263,727,cs),
+(146,727,o),
+(72,649,o),
+(72,526,cs),
+(72,420,o),
+(127,356,o),
+(201,344,c),
+(197,373,l),
+(115,356,o),
+(59,293,o),
+(59,188,cs),
+(59,65,o),
+(138,-13,o),
+(263,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(193,66,o),
+(151,108,o),
+(151,193,cs),
+(151,278,o),
+(194,318,o),
+(263,318,cs),
+(331,318,o),
+(374,277.996,o),
+(374,193,cs),
+(374,108,o),
+(332,66,o),
+(263,66,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(201,396,o),
+(163,436,o),
+(163,521,cs),
+(163,606,o),
+(199,648,o),
+(263,648,cs),
+(327,648,o),
+(362,606,o),
+(362,521,cs),
+(362,436,o),
+(324,396,o),
+(263,396,cs)
+);
+}
+);
+width = 525;
+}
+);
+metricLeft = "=|";
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = nine.canadian;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(372,-13,o),
+(453,100,o),
+(453,353,cs),
+(453,509,o),
+(432,597,o),
+(387,657,cs),
+(349,707,o),
+(298,727,o),
+(233,727,cs),
+(119,727,o),
+(41,636,o),
+(41,503,cs),
+(41,367,o),
+(114,280,o),
+(222,280,cs),
+(302,280,o),
+(361,327,o),
+(380,423,c),
+(356,442,l),
+(358,408,o),
+(359,387,o),
+(359,333,cs),
+(359,143,o),
+(321,68,o),
+(237,68,cs),
+(172,68,o),
+(141,119,o),
+(137,202,c),
+(44,202,l),
+(54,71,o),
+(118,-13,o),
+(234,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(168,358,o),
+(132,413,o),
+(132,503,cs),
+(132,592,o),
+(172,648,o),
+(238,648,cs),
+(309,648,o),
+(348,590,o),
+(348,499,cs),
+(348,413,o),
+(305,358,o),
+(237,358,cs)
+);
+}
+);
+width = 498;
+}
+);
+metricLeft = "=|six.canadian";
+metricRight = "=|six.canadian";
+},
+{
+glyphname = CR;
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+width = 213;
+}
+);
+note = CR;
+unicode = 13;
+},
+{
+color = 0;
+glyphname = .notdef;
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(505,714,l),
+(94,714,l),
+(94,0,l),
+(505,0,l),
+(505,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(454,663,l),
+(454,51,l),
+(145,51,l),
+(145,663,l),
+(145,663,l)
+);
+}
+);
+width = 600;
+}
+);
+note = ".notdef";
+},
+{
+glyphname = .null;
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+width = 0;
+}
+);
+note = NULL;
+},
+{
+glyphname = space;
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+width = 216;
+}
+);
+note = space;
+unicode = 32;
+},
+{
+glyphname = nbspace;
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+width = 213;
+}
+);
+note = uni00A0;
+unicode = 160;
+},
+{
+glyphname = space.canadian;
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+width = 427;
+}
+);
+note = space;
+},
+{
+glyphname = "hyphen-canadian";
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(316,410,l),
+(316,466,l),
+(51,466,l),
+(51,410,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(316,269,l),
+(316,325,l),
+(51,325,l),
+(51,269,l)
+);
+}
+);
+width = 367;
+}
+);
+metricRight = "=|";
+note = uni1400;
+unicode = 5120;
+},
+{
+glyphname = "chi-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(126,0,l),
+(254,303,l),
+(222,303,l),
+(348,0,l),
+(435,0,l),
+(435,26,l),
+(269,399,l),
+(269,324,l),
+(433,688,l),
+(433,714,l),
+(345,714,l),
+(221,415,l),
+(253,415,l),
+(129,714,l),
+(42,714,l),
+(42,688,l),
+(205,325,l),
+(205,400,l),
+(39.005,25.992,l),
+(39.005,0,l)
+);
+}
+);
+width = 474;
+}
+);
+metricRight = "=|";
+note = uni166D;
+unicode = 5741;
+},
+{
+glyphname = "fullstop-canadian";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(263,0,l),
+(263,12,l),
+(181,194,l),
+(183,165,l),
+(262,344,l),
+(262,357,l),
+(203,357,l),
+(143,206,l),
+(169,210,l),
+(108,357,l),
+(49,357,l),
+(49,344,l),
+(128,169,l),
+(129,198,l),
+(48,12,l),
+(48,0,l),
+(107,0,l),
+(171,159,l),
+(141,155,l),
+(205,0,l)
+);
+}
+);
+width = 311;
+}
+);
+note = uni1541;
+unicode = 5742;
+},
+{
+glyphname = period;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(62,10,o),
+(86,-10,o),
+(121,-10,cs),
+(159,-10,o),
+(180,10,o),
+(180,48,cs),
+(180,87,o),
+(159,106,o),
+(121,106,cs),
+(86,106,o),
+(62,87,o),
+(62,48,cs)
+);
+}
+);
+width = 231;
+}
+);
+note = period;
+unicode = 46;
+},
+{
+glyphname = comma;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(91,-133,l),
+(123,-60,o),
+(148,41,o),
+(166,117,c),
+(161,129,l),
+(77,129,l),
+(67,52,o),
+(50,-36,o),
+(24,-133,c)
+);
+}
+);
+width = 215;
+}
+);
+note = comma;
+unicode = 44;
+},
+{
+glyphname = hyphen;
+kernLeft = hyphen;
+kernRight = hyphen;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(227,310,l),
+(37,310,l),
+(37,230,l),
+(227,230,l)
+);
+}
+);
+width = 264;
+}
+);
+unicode = 45;
+},
+{
+glyphname = quotesinglbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (32,-585);
+ref = quoteright;
+}
+);
+width = 265;
+}
+);
+unicode = 8218;
+},
+{
+glyphname = quotedblbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+pos = (32,-585);
+ref = quotedblright;
+}
+);
+width = 457;
+}
+);
+unicode = 8222;
+},
+{
+glyphname = quotedblleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(311,451,l),
+(320,527,o),
+(340,624,o),
+(368,714,c),
+(303,714,l),
+(271,642,o),
+(242,549,o),
+(225,461,c),
+(232,451,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(129,451,l),
+(138,527,o),
+(158,624,o),
+(186,714,c),
+(121,714,l),
+(89,641,o),
+(60,549,o),
+(43,461,c),
+(50,451,l)
+);
+}
+);
+width = 411;
+}
+);
+unicode = 8220;
+},
+{
+glyphname = quotedblright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(290,451,l),
+(324,525,o),
+(352,623,o),
+(368,704,c),
+(361,714,l),
+(282,714,l),
+(275,637,o),
+(255,539,o),
+(225,451,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(108,451,l),
+(142,525,o),
+(170,623,o),
+(186,704,c),
+(179,714,l),
+(100,714,l),
+(93,640,o),
+(72,537,o),
+(43,451,c)
+);
+}
+);
+width = 411;
+}
+);
+unicode = 8221;
+},
+{
+glyphname = quoteleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(133,451,l),
+(142,527,o),
+(162,625,o),
+(190,714,c),
+(121,714,l),
+(89,641,o),
+(60,549,o),
+(43,461,c),
+(50,451,l)
+);
+}
+);
+width = 233;
+}
+);
+unicode = 8216;
+},
+{
+glyphname = quoteright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(112,451,l),
+(146,525,o),
+(174,623,o),
+(190,704,c),
+(183,714,l),
+(100,714,l),
+(93,640,o),
+(72,537,o),
+(43,451,c)
+);
+}
+);
+width = 233;
+}
+);
+unicode = 8217;
+},
+{
+glyphname = dottedCircle;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,522,o),
+(187,511,o),
+(187,496,cs),
+(187,483,o),
+(200,470,o),
+(213,470,cs),
+(228,470,o),
+(239,483,o),
+(239,496,cs),
+(239,511,o),
+(228,522,o),
+(213,522,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(368,522,o),
+(355,511,o),
+(355,496,cs),
+(355,483,o),
+(368,470,o),
+(381,470,cs),
+(396,470,o),
+(407,483,o),
+(407,496,cs),
+(407,511,o),
+(396,522,o),
+(381,522,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,112,o),
+(187,101,o),
+(187,86,cs),
+(187,73,o),
+(200,60,o),
+(213,60,cs),
+(228,60,o),
+(239,73,o),
+(239,86,cs),
+(239,101,o),
+(228,112,o),
+(213,112,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(368,112,o),
+(355,101,o),
+(355,86,cs),
+(355,73,o),
+(368,60,o),
+(381,60,cs),
+(396,60,o),
+(407,73,o),
+(407,86,cs),
+(407,101,o),
+(396,112,o),
+(381,112,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(284,540,o),
+(271,529,o),
+(271,514,cs),
+(271,501,o),
+(284,488,o),
+(297,488,cs),
+(312,488,o),
+(323,501,o),
+(323,514,cs),
+(323,529,o),
+(312,540,o),
+(297,540,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(284,94,o),
+(271,83,o),
+(271,68,cs),
+(271,55,o),
+(284,42,o),
+(297,42,cs),
+(312,42,o),
+(323,55,o),
+(323,68,cs),
+(323,83,o),
+(312,94,o),
+(297,94,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(48,278,o),
+(61,265,o),
+(74,265,cs),
+(89,265,o),
+(100,278,o),
+(100,291,cs),
+(100,306,o),
+(89,317,o),
+(74,317,cs),
+(61,317,o),
+(48,306,o),
+(48,291,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(494,278,o),
+(507,265,o),
+(520,265,cs),
+(535,265,o),
+(546,278,o),
+(546,291,cs),
+(546,306,o),
+(535,317,o),
+(520,317,cs),
+(507,317,o),
+(494,306,o),
+(494,291,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(113,120,o),
+(126,107,o),
+(139,107,cs),
+(154,107,o),
+(165,120,o),
+(165,133,cs),
+(165,148,o),
+(154,159,o),
+(139,159,cs),
+(126,159,o),
+(113,148,o),
+(113,133,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(113,436,o),
+(126,423,o),
+(139,423,cs),
+(154,423,o),
+(165,436,o),
+(165,449,cs),
+(165,464,o),
+(154,475,o),
+(139,475,cs),
+(126,475,o),
+(113,464,o),
+(113,449,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(429,120,o),
+(442,107,o),
+(455,107,cs),
+(470,107,o),
+(481,120,o),
+(481,133,cs),
+(481,148,o),
+(470,159,o),
+(455,159,cs),
+(442,159,o),
+(429,148,o),
+(429,133,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(429,436,o),
+(442,423,o),
+(455,423,cs),
+(470,423,o),
+(481,436,o),
+(481,449,cs),
+(481,464,o),
+(470,475,o),
+(455,475,cs),
+(442,475,o),
+(429,464,o),
+(429,449,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(66,194,o),
+(79,181,o),
+(92,181,cs),
+(107,181,o),
+(118,194,o),
+(118,207,cs),
+(118,222,o),
+(107,233,o),
+(92,233,cs),
+(79,233,o),
+(66,222,o),
+(66,207,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(66,362,o),
+(79,349,o),
+(92,349,cs),
+(107,349,o),
+(118,362,o),
+(118,375,cs),
+(118,390,o),
+(107,401,o),
+(92,401,cs),
+(79,401,o),
+(66,390,o),
+(66,375,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(476,194,o),
+(489,181,o),
+(502,181,cs),
+(517,181,o),
+(528,194,o),
+(528,207,cs),
+(528,222,o),
+(517,233,o),
+(502,233,cs),
+(489,233,o),
+(476,222,o),
+(476,207,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(476,362,o),
+(489,349,o),
+(502,349,cs),
+(517,349,o),
+(528,362,o),
+(528,375,cs),
+(528,390,o),
+(517,401,o),
+(502,401,cs),
+(489,401,o),
+(476,390,o),
+(476,375,cs)
+);
+}
+);
+width = 594;
+}
+);
+note = uni25CC;
+unicode = 9676;
+},
+{
+glyphname = dotaccentcomb;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(50,744,o),
+(28,727,o),
+(28,690,cs),
+(28,654,o),
+(50,638,o),
+(81,638,cs),
+(111,638,o),
+(134,654,o),
+(134,690,cs),
+(134,728,o),
+(111,744,o),
+(81,744,cs)
+);
+}
+);
+width = 162;
+}
+);
+note = uni0307;
+unicode = 775;
+},
+{
+glyphname = dotaccent;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(112,638,o),
+(135,654,o),
+(135,690,cs),
+(135,728,o),
+(112,744,o),
+(82,744,cs),
+(51,744,o),
+(29,727,o),
+(29,690,cs),
+(29,654,o),
+(51,638,o),
+(82,638,cs)
+);
+}
+);
+width = 164;
+}
+);
+note = dotaccent;
+unicode = 729;
+},
+{
+glyphname = caron;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(228,645,o),
+(259,698,o),
+(298,755,c),
+(298,764,l),
+(237,764,l),
+(211,735,o),
+(190,702,o),
+(163,661,c),
+(138,699,o),
+(116,735,o),
+(91,764,c),
+(29,764,l),
+(29,755,l),
+(62,708,o),
+(95,657,o),
+(117,606,c),
+(210,606,l),
+(210,606,l)
+);
+}
+);
+width = 327;
+}
+);
+note = caron;
+unicode = 711;
+},
+{
+glyphname = breve;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(225,606,o),
+(269,657,o),
+(275,746,c),
+(220,746,l),
+(212,692,o),
+(187,667,o),
+(151,667,cs),
+(109,667,o),
+(90,691,o),
+(82,746,c),
+(29,746,l),
+(34,652,o),
+(78,606,o),
+(151,606,cs)
+);
+}
+);
+width = 304;
+}
+);
+note = breve;
+unicode = 728;
+},
+{
+glyphname = ring;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(164,608,o),
+(203,652,o),
+(203,718,cs),
+(203,781,o),
+(163,827,o),
+(115,827,cs),
+(66,827,o),
+(29,783,o),
+(29,717,cs),
+(29,651,o),
+(66,608,o),
+(115,608,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(91,656,o),
+(75,683,o),
+(75,717,cs),
+(75,753,o),
+(93,779,o),
+(115,779,cs),
+(137,779,o),
+(155,752,o),
+(155,717,cs),
+(155,684,o),
+(138,656,o),
+(115,656,cs)
+);
+}
+);
+width = 232;
+}
+);
+note = ring;
+unicode = 730;
+},
+{
+glyphname = ogonek;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(131,-227,o),
+(149,-222,o),
+(165,-216,c),
+(165,-158,l),
+(156,-163,o),
+(139,-167,o),
+(125,-167,cs),
+(104,-167,o),
+(92,-150,o),
+(92,-117,cs),
+(92,-75,o),
+(114,-39,o),
+(147,0,c),
+(109,17,l),
+(52,-36,o),
+(29,-83,o),
+(29,-132,cs),
+(29,-193,o),
+(66,-227,o),
+(113,-227,cs)
+);
+}
+);
+width = 194;
+}
+);
+note = ogonek;
+unicode = 731;
+},
+{
+glyphname = ring_top.canadian;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (119,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(171,784,o),
+(214,824,o),
+(214,878,cs),
+(214,933,o),
+(171,972,o),
+(119,972,cs),
+(67,972,o),
+(24,933,o),
+(24,878,cs),
+(24,824,o),
+(67,784,o),
+(119,784,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(89,826,o),
+(68,848,o),
+(68,878,cs),
+(68,907,o),
+(89,930,o),
+(119,930,cs),
+(150,930,o),
+(170,907,o),
+(170,878,cs),
+(170,848,o),
+(150,826,o),
+(119,826,cs)
+);
+}
+);
+width = 239;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (70,357);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(98,306,o),
+(121,329,o),
+(121,357,cs),
+(121,385,o),
+(98,408,o),
+(70,408,cs),
+(42,408,o),
+(19,385,o),
+(19,357,cs),
+(19,329,o),
+(42,306,o),
+(70,306,cs)
+);
+}
+);
+width = 140;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (61,357);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(85,314,o),
+(105,332,o),
+(105,357,cs),
+(105,382,o),
+(85,400,o),
+(61,400,cs),
+(37,400,o),
+(18,382,o),
+(18,357,cs),
+(18,332,o),
+(37,314,o),
+(61,314,cs)
+);
+}
+);
+width = 123;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_small;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (52,357);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(72,322,o),
+(87,338,o),
+(87,357,cs),
+(87,376,o),
+(72,392,o),
+(52,392,cs),
+(33,392,o),
+(18,376,o),
+(18,357,cs),
+(18,338,o),
+(33,322,o),
+(52,322,cs)
+);
+}
+);
+width = 105;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_top;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (70,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,809,o),
+(122,832,o),
+(122,861,cs),
+(122,890,o),
+(99,913,o),
+(70,913,cs),
+(41,913,o),
+(18,890,o),
+(18,861,cs),
+(18,832,o),
+(41,809,o),
+(70,809,cs)
+);
+}
+);
+width = 140;
+}
+);
+note = g725;
+},
+{
+glyphname = doubledot_middle;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(130,395,o),
+(153,418,o),
+(153,447,cs),
+(153,476,o),
+(130,499,o),
+(101,499,cs),
+(72,499,o),
+(49,476,o),
+(49,447,cs),
+(49,418,o),
+(72,395,o),
+(101,395,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(130,215,o),
+(153,238,o),
+(153,267,cs),
+(153,296,o),
+(130,319,o),
+(101,319,cs),
+(72,319,o),
+(49,296,o),
+(49,267,cs),
+(49,238,o),
+(72,215,o),
+(101,215,cs)
+);
+}
+);
+width = 202;
+}
+);
+metricRight = "=|";
+note = g725;
+},
+{
+glyphname = doubledot_top;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top_double;
+pos = (222,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(251,809,o),
+(275,832,o),
+(275,861,cs),
+(275,890,o),
+(251,913,o),
+(222,913,cs),
+(193,913,o),
+(171,890,o),
+(171,861,cs),
+(171,832,o),
+(193,809,o),
+(222,809,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(98,809,o),
+(121,832,o),
+(121,861,cs),
+(121,890,o),
+(98,913,o),
+(69,913,cs),
+(40,913,o),
+(17,890,o),
+(17,861,cs),
+(17,832,o),
+(40,809,o),
+(69,809,cs)
+);
+}
+);
+width = 292;
+}
+);
+note = g725;
+},
+{
+glyphname = g727;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (292,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(519,0,l),
+(519,78,l),
+(265,78,ls),
+(183,78,o),
+(147,120,o),
+(147,198,cs),
+(147,277,o),
+(182,319,o),
+(265,319,cs),
+(337,319,ls),
+(463,319,o),
+(529,392,o),
+(529,517,cs),
+(529,641,o),
+(463,714,o),
+(337,714,cs),
+(64,714,l),
+(64,636,l),
+(319,636,ls),
+(400,636,o),
+(436,594,o),
+(436,517,cs),
+(436,438,o),
+(401,396,o),
+(319,396,cs),
+(246,396,ls),
+(119,396,o),
+(54,322,o),
+(54,198,cs),
+(54,73,o),
+(119,0,o),
+(246,0,cs)
+);
+}
+);
+width = 583;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+glyphname = g728;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (222,0);
+ref = dot_top;
+}
+);
+width = 583;
+}
+);
+note = g728;
+},
+{
+glyphname = g729;
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (292,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(337,0,ls),
+(463,0,o),
+(529,73,o),
+(529,197,cs),
+(529,322,o),
+(463,396,o),
+(337,396,cs),
+(264,396,ls),
+(182,396,o),
+(146,438,o),
+(146,516,cs),
+(146,594,o),
+(182,636,o),
+(264,636,cs),
+(519,636,l),
+(519,714,l),
+(245,714,ls),
+(119,714,o),
+(54,641,o),
+(54,516,cs),
+(54,392,o),
+(119,318,o),
+(245,318,cs),
+(318,318,ls),
+(400,318,o),
+(435,277,o),
+(435,197,cs),
+(435,119,o),
+(400,78,o),
+(318,78,cs),
+(64,78,l),
+(64,0,l)
+);
+}
+);
+width = 583;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+glyphname = g730;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (222,0);
+ref = dot_top;
+}
+);
+width = 582;
+}
+);
+note = g730;
+},
+{
+glyphname = g731;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = g727;
+}
+);
+width = 774;
+}
+);
+note = g731;
+},
+{
+glyphname = g732;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (583,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 774;
+}
+);
+note = g732;
+},
+{
+glyphname = g733;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (413,0);
+ref = dot_top;
+}
+);
+width = 774;
+}
+);
+note = g733;
+},
+{
+glyphname = g734;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (222,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (583,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 774;
+}
+);
+note = g734;
+},
+{
+glyphname = g735;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = g729;
+}
+);
+width = 774;
+}
+);
+note = g735;
+},
+{
+glyphname = g736;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (582,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 774;
+}
+);
+note = g736;
+},
+{
+glyphname = g737;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (413,0);
+ref = dot_top;
+}
+);
+width = 774;
+}
+);
+note = g737;
+},
+{
+glyphname = g738;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (222,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (582,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 774;
+}
+);
+note = g738;
+},
+{
+glyphname = g739;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(446,239,o),
+(488,293,o),
+(488,374,cs),
+(488,454,o),
+(446,510,o),
+(377,510,cs),
+(211,510,l),
+(214,482,l),
+(237,495,o),
+(255,540,o),
+(255,588,cs),
+(255,667,o),
+(215,720,o),
+(148,720,cs),
+(82,720,o),
+(41,666,o),
+(41,585,cs),
+(41,505,o),
+(83,449,o),
+(152,449,cs),
+(318,449,l),
+(315,477,l),
+(291,464,o),
+(274,419,o),
+(274,371,cs),
+(274,292,o),
+(314,239,o),
+(381,239,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(117,498,o),
+(97,530,o),
+(97,585,cs),
+(97,640,o),
+(118,671,o),
+(149,671,cs),
+(178,671,o),
+(198,639,o),
+(198,585,cs),
+(198,531,o),
+(179,498,o),
+(148,498,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(351,288,o),
+(330,320,o),
+(330,375,cs),
+(330,429,o),
+(350,461,o),
+(381,461,cs),
+(411,461,o),
+(432,429,o),
+(432,374,cs),
+(432,319,o),
+(411,288,o),
+(380,288,cs)
+);
+}
+);
+width = 529;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+glyphname = g740;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (173,0);
+ref = ring_top.canadian;
+}
+);
+width = 583;
+}
+);
+note = g740;
+},
+{
+glyphname = g741;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (173,0);
+ref = ring_top.canadian;
+}
+);
+width = 582;
+}
+);
+note = g741;
+},
+{
+glyphname = g742;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (364,0);
+ref = ring_top.canadian;
+}
+);
+width = 774;
+}
+);
+note = g742;
+},
+{
+glyphname = stroke_middle;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (46,357);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(74,473,l),
+(18,473,l),
+(18,241,l),
+(74,241,l)
+);
+}
+);
+width = 92;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (40,357);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(61,449,l),
+(18,449,l),
+(18,265,l),
+(61,265,l)
+);
+}
+);
+width = 79;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_small;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (35,357);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(53,443,l),
+(18,443,l),
+(18,271,l),
+(53,271,l)
+);
+}
+);
+width = 71;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_threequart;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (46,357);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(72,471,l),
+(20,471,l),
+(20,243,l),
+(72,243,l)
+);
+}
+);
+width = 92;
+}
+);
+note = g723;
+},
+{
+color = 8;
+glyphname = uni11AB0;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (142,714);
+},
+{
+name = top_right_can;
+pos = (381,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(188,0,l),
+(188,108,l),
+(380,108,l),
+(380,164,l),
+(188,164,l),
+(188,290,l),
+(118,258,l),
+(146,258,ls),
+(324,258,o),
+(427,385,o),
+(427,607,cs),
+(427,714,l),
+(334,714,l),
+(334,615,ls),
+(334,429,o),
+(260,343,o),
+(126,343,cs),
+(95,343,l),
+(95,164,l),
+(31,164,l),
+(31,108,l),
+(95,108,l),
+(95,0,l)
+);
+}
+);
+width = 487;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB1;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB0;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (311,0);
+ref = dot_top;
+}
+);
+width = 487;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB2;
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (107,714);
+},
+{
+name = top_right_can;
+pos = (346,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(154,0,l),
+(154,99,ls),
+(154,285,o),
+(227,371,o),
+(361,371,cs),
+(393,371,l),
+(393,550,l),
+(456,550,l),
+(456,606,l),
+(393,606,l),
+(393,714,l),
+(299,714,l),
+(299,606,l),
+(108,606,l),
+(108,550,l),
+(299,550,l),
+(299,424,l),
+(369,456,l),
+(342,456,ls),
+(164,456,o),
+(60,330,o),
+(60,107,cs),
+(60,0,l)
+);
+}
+);
+width = 487;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "theThCree-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB3;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB2;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (276,0);
+ref = dot_top;
+}
+);
+width = 488;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB4;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (142,714);
+},
+{
+name = top_right_can;
+pos = (381,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(427,0,l),
+(427,107,ls),
+(427,329,o),
+(324,456,o),
+(146,456,cs),
+(118,456,l),
+(188,424,l),
+(188,550,l),
+(380,550,l),
+(380,606,l),
+(188,606,l),
+(188,714,l),
+(95,714,l),
+(95,606,l),
+(31,606,l),
+(31,550,l),
+(95,550,l),
+(95,371,l),
+(126,371,ls),
+(260,371,o),
+(334,285,o),
+(334,99,cs),
+(334,0,l)
+);
+}
+);
+width = 487;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB5;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB4;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (72,0);
+ref = dot_top;
+}
+);
+width = 487;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB6;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (109,714);
+},
+{
+name = top_right_can;
+pos = (348,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(156,0,l),
+(156,292,l),
+(86,258,l),
+(113,258,ls),
+(291,258,o),
+(394,385,o),
+(394,607,cs),
+(394,679,l),
+(330,658,l),
+(528,457,l),
+(582,513,l),
+(385,714,l),
+(301,714,l),
+(301,615,ls),
+(301,429,o),
+(227,343,o),
+(94,343,cs),
+(62,343,l),
+(62,0,l)
+);
+}
+);
+width = 603;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB7;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB6;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (278,0);
+ref = dot_top;
+}
+);
+width = 602;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB8;
+kernRight = soright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (255,714);
+},
+{
+name = top_right_can;
+pos = (494,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(301,0,l),
+(301,99,ls),
+(301,285,o),
+(376,371,o),
+(509,371,cs),
+(540,371,l),
+(540,714,l),
+(447,714,l),
+(447,422,l),
+(517,456,l),
+(489,456,ls),
+(311,456,o),
+(209,329,o),
+(209,107,cs),
+(209,35,l),
+(272,56,l),
+(75,257,l),
+(21,201,l),
+(218,0,l)
+);
+}
+);
+width = 602;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB9;
+kernRight = soright;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB8;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (424,0);
+ref = dot_top;
+}
+);
+width = 602;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABA;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (109,714);
+},
+{
+name = top_right_can;
+pos = (348,714);
+}
+);
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(385,0,l),
+(582,201,l),
+(528,257,l),
+(330,56,l),
+(394,35,l),
+(394,107,ls),
+(394,329,o),
+(291,456,o),
+(113,456,cs),
+(86,456,l),
+(156,422,l),
+(156,714,l),
+(62,714,l),
+(62,371,l),
+(94,371,ls),
+(227,371,o),
+(301,285,o),
+(301,99,cs),
+(301,0,l)
+);
+}
+);
+width = 603;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABB;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+alignment = -1;
+ref = uni11ABA;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (39,0);
+ref = dot_top;
+}
+);
+width = 602;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABC;
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(441,0,l),
+(441,86,l),
+(133,86,l),
+(133,49,l),
+(449,648,l),
+(449,714,l),
+(45,714,l),
+(45,628,l),
+(353,628,l),
+(353,665,l),
+(38,66,l),
+(38,0,l)
+);
+}
+);
+width = 487;
+}
+);
+metricRight = "=|";
+},
+{
+color = 8;
+glyphname = uni11ABD;
+lastChange = "2023-01-13 15:31:28 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(449,0,l),
+(449,66,l),
+(134,665,l),
+(134,628,l),
+(441,628,l),
+(441,714,l),
+(38,714,l),
+(38,648,l),
+(353,49,l),
+(353,86,l),
+(45,86,l),
+(45,0,l)
+);
+}
+);
+width = 487;
+}
+);
+metricLeft = "=|uni11ABC";
+metricRight = "=|uni11ABC";
+},
+{
+color = 8;
+glyphname = uni11ABE;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(153,0,l),
+(153,629,l),
+(101,629,l),
+(416,0,l),
+(499,0,l),
+(499,714,l),
+(407,714,l),
+(407,85,l),
+(460,85,l),
+(145,714,l),
+(62,714,l),
+(62,0,l)
+);
+}
+);
+width = 561;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABF;
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(145,0,l),
+(459,632,l),
+(407,632,l),
+(407,0,l),
+(499,0,l),
+(499,714,l),
+(416,714,l),
+(101,82,l),
+(154,82,l),
+(154,714,l),
+(62,714,l),
+(62,0,l)
+);
+}
+);
+width = 561;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = "raiseddoubledotFinal-canadian.cree";
+lastChange = "2023-01-13 15:28:11 +0000";
+layers = (
+{
+layerId = "7D3FB2DB-72C7-4646-AA25-FB3BBECA0225";
+shapes = (
+{
+closed = 1;
+nodes = (
+(127,623,o),
+(150,646,o),
+(150,675,cs),
+(150,704,o),
+(127,727,o),
+(98,727,cs),
+(70,727,o),
+(46,705,o),
+(46,675,cs),
+(46,646,o),
+(70,623,o),
+(98,623,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(127,443,o),
+(150,466,o),
+(150,495,cs),
+(150,524,o),
+(127,547,o),
+(98,547,cs),
+(70,547,o),
+(46,524,o),
+(46,495,cs),
+(46,466,o),
+(70,443,o),
+(98,443,cs)
+);
+}
+);
+width = 197;
+}
+);
+note = g725;
+}
+);
+instances = (
+{
+axesValues = (
+98,
+72,
+0
+);
+instanceInterpolations = {
+"7D3FB2DB-72C7-4646-AA25-FB3BBECA0225" = 1;
+};
+name = "RC CR roman";
+}
+);
+kerningLTR = {
+"7D3FB2DB-72C7-4646-AA25-FB3BBECA0225" = {
+"@MMK_L_caright" = {
+"@MMK_R_ecanleft" = -67;
+"@MMK_R_mwestleft" = -25;
+"@MMK_R_neleft" = -48;
+};
+"@MMK_L_ciright" = {
+"@MMK_R_icanleft" = -67;
+"@MMK_R_noleft" = -84;
+};
+"@MMK_L_ecanright" = {
+"@MMK_R_coleft" = -67;
+"@MMK_R_moleft" = -67;
+"@MMK_R_sileft" = -37;
+};
+"@MMK_L_icanright" = {
+"@MMK_R_celeft" = -67;
+"@MMK_R_meleft" = -67;
+"@MMK_R_mwestleft" = -45;
+"@MMK_R_saleft" = -32;
+"she-canadian" = -67;
+};
+"@MMK_L_maright" = {
+"@MMK_R_acanleft" = -63;
+"@MMK_R_ecanleft" = -67;
+"@MMK_R_mwestleft" = -46;
+"@MMK_R_neleft" = -48;
+};
+"@MMK_L_miright" = {
+"@MMK_R_acanleft" = -63;
+"@MMK_R_icanleft" = -67;
+"@MMK_R_moleft" = -91;
+"@MMK_R_noleft" = -84;
+"@MMK_R_yeleft" = -92;
+};
+"@MMK_L_mwestright" = {
+"@MMK_R_coleft" = -25;
+"@MMK_R_icanleft" = -45;
+"@MMK_R_moleft" = -46;
+"@MMK_R_noleft" = -74;
+"@MMK_R_sileft" = -13;
+"@MMK_R_yeleft" = -23;
+};
+"@MMK_L_naright" = {
+"@MMK_R_acanleft" = -79;
+"@MMK_R_celeft" = -84;
+"@MMK_R_meleft" = -84;
+"@MMK_R_mwestleft" = -74;
+"@MMK_R_neleft" = -96;
+"@MMK_R_saleft" = -55;
+};
+"@MMK_L_niright" = {
+"@MMK_R_coleft" = -48;
+"@MMK_R_moleft" = -48;
+"@MMK_R_noleft" = -96;
+"@MMK_R_sileft" = -3;
+};
+"@MMK_L_ocanright" = {
+"@MMK_R_meleft" = -63;
+"@MMK_R_moleft" = -63;
+"@MMK_R_noleft" = -79;
+};
+"@MMK_L_seright" = {
+"@MMK_R_ecanleft" = -37;
+"@MMK_R_mwestleft" = -13;
+"@MMK_R_neleft" = -3;
+};
+"@MMK_L_soright" = {
+"@MMK_R_icanleft" = -32;
+"@MMK_R_noleft" = -55;
+};
+"@MMK_L_yiright" = {
+"@MMK_R_meleft" = -92;
+"@MMK_R_mwestleft" = -23;
+};
+"shi-canadian" = {
+"@MMK_R_icanleft" = -67;
+};
+};
+};
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "italic angle";
+}
+);
+properties = (
+{
+key = copyrights;
+values = (
+{
+language = ENG;
+value = "Copyright 2018 Google Inc. All Rights Reserved.";
+}
+);
+},
+{
+key = manufacturers;
+values = (
+{
+language = ENG;
+value = "Monotype Imaging Inc.";
+}
+);
+},
+{
+key = designers;
+values = (
+{
+language = ENG;
+value = "Monotype Design Team";
+}
+);
+},
+{
+key = description;
+value = "Designed by Monotype design team.";
+},
+{
+key = trademarks;
+values = (
+{
+language = ENG;
+value = "Noto is a trademark of Google Inc.";
+}
+);
+},
+{
+key = licenseURL;
+value = "http://scripts.sil.org/OFL";
+},
+{
+key = licenses;
+values = (
+{
+language = ENG;
+value = "This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.";
+}
+);
+},
+{
+key = manufacturerURL;
+value = "http://www.google.com/get/noto/";
+},
+{
+key = designerURL;
+value = "http://www.monotype.com/studio";
+}
+);
+settings = {
+disablesNiceNames = 1;
+};
+stems = (
+{
+name = "New Stem";
+}
+);
+unitsPerEm = 1000;
+userData = {
+GSDontShowVersionAlert = 1;
+};
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/sources/Exported instances UCAS SansCanadianAboriginal/Sans Canadian Aboriginal-RC L Italic.glyphs
+++ b/sources/Exported instances UCAS SansCanadianAboriginal/Sans Canadian Aboriginal-RC L Italic.glyphs
@@ -1,0 +1,37318 @@
+{
+.appVersion = "3151";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+},
+{
+name = Width;
+tag = wdth;
+},
+{
+name = Slant;
+tag = slnt;
+}
+);
+classes = (
+{
+code = "zero one two three four five six seven eight nine ";
+name = Num;
+},
+{
+code = "zero.canadian one.canadian two.canadian three.canadian four.canadian five.canadian six.canadian seven.canadian eight.canadian nine.canadian 
+";
+name = Num_can;
+},
+{
+code = "ke-canadian.square ki-canadian.square kii-canadian.square ko-canadian.square koo-canadian.square ka-canadian.square kaa-canadian.square kweWestCree-canadian.square kwiiWestCree-canadian.square kwoWestCree-canadian.square kwooWestCree-canadian.square kwaWestCree-canadian.square kwaaWestCree-canadian.square ce-canadian.square ci-canadian.square cii-canadian.square co-canadian.square coo-canadian.square ca-canadian.square caa-canadian.square me-canadian.square mi-canadian.square mii-canadian.square mo-canadian.square moo-canadian.square ma-canadian.square maa-canadian.square ne-canadian.square ni-canadian.square nii-canadian.square no-canadian.square noo-canadian.square na-canadian.square naa-canadian.square nweWestCree-canadian.square nwaWestCree-canadian.square nwaaWestCree-canadian.square se-canadian.square si-canadian.square sii-canadian.square so-canadian.square soo-canadian.square sa-canadian.square saa-canadian.square sho-canadian.square shoo-canadian.square sha-canadian.square shaa-canadian.square ye-canadian.square yi-canadian.square yii-canadian.square yo-canadian.square yoo-canadian.square ya-canadian.square yaa-canadian.square re-canadian.square reRCree-canadian.square leWestCree-canadian.square ri-canadian.square rii-canadian.square ro-canadian.square loWestCree-canadian.square ra-canadian.square raa-canadian.square laWestCree-canadian.square reWestCree-canadian.square riWestCree-canadian.square roWestCree-canadian.square raWestCree-canadian.square theThCree-canadian.square thiThCree-canadian.square thiiThCree-canadian.square thoThCree-canadian.square thooThCree-canadian.square thaThCree-canadian.square thaaThCree-canadian.square thweeWoodScree-canadian.square thwiWoodScree-canadian.square thwiiWoodScree-canadian.square thwoWoodScree-canadian.square thwooWoodScree-canadian.square thwaWoodScree-canadian.square thwaaWoodScree-canadian.square nwiOjibway-canadian.square nwiiOjibway-canadian.square nwoOjibway-canadian.square nwooOjibway-canadian.square looWestCree-canadian.square laaWestCree-canadian.square ";
+name = Dene_square;
+},
+{
+code = "ke-canadian ki-canadian kii-canadian ko-canadian koo-canadian ka-canadian kaa-canadian kweWestCree-canadian kwiiWestCree-canadian kwoWestCree-canadian kwooWestCree-canadian kwaWestCree-canadian kwaaWestCree-canadian ce-canadian ci-canadian cii-canadian co-canadian coo-canadian ca-canadian caa-canadian me-canadian mi-canadian mii-canadian mo-canadian moo-canadian ma-canadian maa-canadian ne-canadian ni-canadian nii-canadian no-canadian noo-canadian na-canadian naa-canadian nweWestCree-canadian nwaWestCree-canadian nwaaWestCree-canadian se-canadian si-canadian sii-canadian so-canadian soo-canadian sa-canadian saa-canadian sho-canadian shoo-canadian sha-canadian shaa-canadian ye-canadian yi-canadian yii-canadian yo-canadian yoo-canadian ya-canadian yaa-canadian re-canadian reRCree-canadian leWestCree-canadian ri-canadian rii-canadian ro-canadian loWestCree-canadian ra-canadian raa-canadian laWestCree-canadian reWestCree-canadian riWestCree-canadian roWestCree-canadian raWestCree-canadian theThCree-canadian thiThCree-canadian thiiThCree-canadian thoThCree-canadian thooThCree-canadian thaThCree-canadian thaaThCree-canadian thweeWoodScree-canadian thwiWoodScree-canadian thwiiWoodScree-canadian thwoWoodScree-canadian thwooWoodScree-canadian thwaWoodScree-canadian thwaaWoodScree-canadian nwiOjibway-canadian nwiiOjibway-canadian nwoOjibway-canadian nwooOjibway-canadian looWestCree-canadian laaWestCree-canadian 
+";
+name = Dene_round;
+},
+{
+code = "acuteFinal-canadian.mid graveFinal-canadian.mid ringTophalfFinal-canadian.mid ringRighthalfFinal-canadian.mid ringFinal-canadian.mid doubleacuteFinal-canadian.mid doubleshortverticalstrokesFinal-canadian.mid shorthorizontalstrokeFinal-canadian.mid downtackFinal-canadian.mid pWestCree-canadian.mid c-canadian.mid mWestCree-canadian.mid ";
+name = Final_mid;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian ringFinal-canadian doubleacuteFinal-canadian doubleshortverticalstrokesFinal-canadian shorthorizontalstrokeFinal-canadian downtackFinal-canadian pWestCree-canadian c-canadian mWestCree-canadian ";
+name = Final_mid_ori;
+},
+{
+code = "acuteFinal-canadian.base graveFinal-canadian.base ringBottomhalfFinal-canadian.base ringTophalfFinal-canadian.base ringRighthalfFinal-canadian.base plusFinal-canadian.base pWestCree-canadian.base c-canadian.base thSayisi-canadian.base mWestCree-canadian.base ";
+name = Final_base;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringBottomhalfFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian plusFinal-canadian pWestCree-canadian c-canadian thSayisi-canadian mWestCree-canadian ";
+name = Final_base_ori;
+},
+{
+code = "ng-canadian ngai-canadian ngaai-canadian ngi-canadian ngii-canadian ngo-canadian ngoo-canadian nga-canadian ngaa-canadian ";
+name = Nunavik;
+},
+{
+code = "ng-canadian.nunavik ngai-canadian.nunavik ngaai-canadian.nunavik ngi-canadian.nunavik ngii-canadian.nunavik ngo-canadian.nunavik ngoo-canadian.nunavik nga-canadian.nunavik ngaa-canadian.nunavik ";
+name = Nunavik_alt;
+}
+);
+customParameters = (
+{
+name = vendorID;
+value = GOOG;
+},
+{
+name = panose;
+value = (
+2,
+11,
+5,
+2,
+4,
+5,
+4,
+2,
+2,
+4
+);
+},
+{
+name = unicodeRanges;
+value = (
+0,
+1,
+2,
+5,
+6,
+45,
+77
+);
+},
+{
+name = codePageRanges;
+value = (
+"1252"
+);
+},
+{
+name = fsType;
+value = (
+);
+}
+);
+date = "2022-06-21 10:06:40 +0000";
+familyName = "Sans Canadian Aboriginal";
+featurePrefixes = (
+{
+automatic = 1;
+code = "languagesystem DFLT dflt;
+
+languagesystem cans dflt;
+";
+name = Languagesystems;
+}
+);
+features = (
+{
+automatic = 1;
+code = "feature ss01;
+feature ss02;
+feature ss03;
+feature ss04;
+";
+tag = aalt;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+tag = salt;
+},
+{
+code = "lookup space_can {
+sub space by space.canadian;
+} space_can;
+
+lookup num_can {
+sub @Num by @Num_can;
+} num_can;
+";
+labels = (
+{
+language = dflt;
+value = "CAN Space and numerals";
+}
+);
+tag = ss01;
+},
+{
+code = "lookup dene_square {
+sub @Dene_round by @Dene_square;
+} dene_square;
+
+";
+labels = (
+{
+language = dflt;
+value = "Dene Square";
+}
+);
+tag = ss02;
+},
+{
+code = "lookup nunavik_alt {
+sub @Nunavik by @Nunavik_alt;
+} nunavik_alt;
+
+";
+labels = (
+{
+language = dflt;
+value = "Nunanvik Alt";
+}
+);
+tag = ss03;
+},
+{
+code = "lookup final_mid {
+sub @Final_mid_ori by @Final_mid;
+} final_mid;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final mid";
+}
+);
+tag = ss04;
+},
+{
+code = "lookup final_base {
+sub @Final_base_ori by @Final_base;
+} final_base;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final base";
+}
+);
+tag = ss05;
+},
+{
+code = "lookup plaincree_first {
+sub wiWestCree-canadian' plusFinal-canadian by i-canadian;
+} plaincree_first;
+
+lookup plaincree_second {
+sub i-canadian plusFinal-canadian' by raiseddoubledotFinal-canadian.cree;
+} plaincree_second;
+
+lookup plaincree_third {
+sub middledotFinal-canadian plusFinal-canadian by raiseddoubledotFinal-canadian.cree;
+} plaincree_third;
+";
+labels = (
+{
+language = dflt;
+value = Plaincree;
+}
+);
+tag = ss06;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+labels = (
+{
+language = dflt;
+value = "";
+}
+);
+tag = ss07;
+}
+);
+fontMaster = (
+{
+axesValues = (
+0,
+0,
+0
+);
+customParameters = (
+{
+name = typoAscender;
+value = 1069;
+},
+{
+name = typoDescender;
+value = -293;
+},
+{
+name = typoLineGap;
+value = 0;
+},
+{
+name = winAscent;
+value = 1069;
+},
+{
+name = winDescent;
+value = 293;
+},
+{
+name = hheaAscender;
+value = 1069;
+},
+{
+name = hheaDescender;
+value = -293;
+},
+{
+name = strikeoutPosition;
+value = 293.43713;
+},
+{
+name = strikeoutSize;
+value = 50;
+},
+{
+name = "Master Icon Glyph Name";
+value = s;
+}
+);
+guides = (
+{
+lockAngle = 1;
+locked = 1;
+pos = (773,357);
+},
+{
+locked = 1;
+pos = (-54,-12);
+},
+{
+locked = 1;
+pos = (113,726);
+},
+{
+locked = 1;
+pos = (776,370);
+},
+{
+locked = 1;
+pos = (772,344);
+}
+);
+id = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+metricValues = (
+{
+over = 17;
+pos = 1069;
+},
+{
+over = 17;
+pos = 714;
+},
+{
+over = 17;
+pos = 489;
+},
+{
+over = -17;
+},
+{
+over = -17;
+pos = -293;
+},
+{
+pos = 12;
+}
+);
+name = "RC L Italic";
+stemValues = (
+64
+);
+}
+);
+glyphs = (
+{
+glyphname = idotless;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(89,0,l),
+(203,534,l),
+(139,534,l),
+(26,0,l)
+);
+}
+);
+width = 219;
+}
+);
+note = dotlessi;
+unicode = 305;
+},
+{
+glyphname = "acuteFinal-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(128,357,l),
+(359,714,l),
+(303,714,l),
+(72,357,l)
+);
+}
+);
+width = 307;
+}
+);
+metricRight = "=|";
+note = uni141F;
+unicode = 5151;
+},
+{
+glyphname = "graveFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(283,357,l),
+(198,714,l),
+(148,714,l),
+(232,357,l)
+);
+}
+);
+width = 307;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+unicode = 5152;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(338,351,o),
+(388,401,o),
+(407,487,cs),
+(455,714,l),
+(407,714,l),
+(362,498,ls),
+(346,425,o),
+(313,395,o),
+(250,395,cs),
+(182,395,o),
+(158,434,o),
+(173,505,cs),
+(218,714,l),
+(170,714,l),
+(126,507,ls),
+(106,409,o),
+(151,351,o),
+(248,351,cs)
+);
+}
+);
+width = 425;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1421;
+unicode = 5153;
+},
+{
+glyphname = "ringTophalfFinal-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,357,l),
+(187,573,ls),
+(203,646,o),
+(236,676,o),
+(299,676,cs),
+(367,676,o),
+(391,637,o),
+(376,566,cs),
+(331,357,l),
+(379,357,l),
+(423,564,ls),
+(443,662,o),
+(398,720,o),
+(301,720,cs),
+(211,720,o),
+(161,670,o),
+(142,584,cs),
+(94,357,l)
+);
+}
+);
+width = 425;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+unicode = 5154;
+},
+{
+glyphname = "ringRighthalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(162,357,ls),
+(306,357,o),
+(371,465,o),
+(371,577,cs),
+(371,662,o),
+(319,714,o),
+(229,714,cs),
+(166,714,l),
+(156,670,l),
+(224,670,ls),
+(290,670,o),
+(323,635,o),
+(323,575,cs),
+(323,505,o),
+(291,401,o),
+(167,401,cs),
+(100,401,l),
+(90,357,l)
+);
+}
+);
+width = 374;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+unicode = 5155;
+},
+{
+glyphname = "ringFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(411,372,o),
+(486,446,o),
+(486,546,cs),
+(486,646,o),
+(409,720,o),
+(309,720,cs),
+(208,720,o),
+(133,646,o),
+(133,546,cs),
+(133,446,o),
+(207,372,o),
+(309,372,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(231,413,o),
+(178,469,o),
+(178,546,cs),
+(178,623,o),
+(232,678,o),
+(309,678,cs),
+(385,678,o),
+(441,623,o),
+(441,546,cs),
+(441,469,o),
+(386,413,o),
+(309,413,cs)
+);
+}
+);
+width = 489;
+}
+);
+note = uni1424;
+unicode = 5156;
+},
+{
+glyphname = "doubleacuteFinal-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(127,357,l),
+(359,714,l),
+(303,714,l),
+(72,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(263,357,l),
+(494,714,l),
+(439,714,l),
+(208,357,l)
+);
+}
+);
+width = 442;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricRight = "=|";
+note = uni1425;
+unicode = 5157;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,357,l),
+(218,714,l),
+(170,714,l),
+(94,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(264,357,l),
+(340,714,l),
+(292,714,l),
+(216,357,l)
+);
+}
+);
+width = 310;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "pWestCree-canadian";
+note = uni1426;
+unicode = 5158;
+},
+{
+glyphname = "middledotFinal-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(161,322,o),
+(181,342,o),
+(181,367,cs),
+(181,392,o),
+(161,412,o),
+(136,412,cs),
+(111,412,o),
+(92,392,o),
+(92,367,cs),
+(92,342,o),
+(111,322,o),
+(136,322,cs)
+);
+}
+);
+width = 220;
+}
+);
+note = uni1427;
+unicode = 5159;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(446,516,l),
+(456,563,l),
+(136,563,l),
+(126,516,l)
+);
+}
+);
+width = 456;
+}
+);
+metricRight = "=|";
+note = uni1428;
+unicode = 5160;
+},
+{
+glyphname = "plusFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(282,379,l),
+(313,525,l),
+(450,525,l),
+(459,571,l),
+(323,571,l),
+(353,714,l),
+(307,714,l),
+(276,571,l),
+(138,571,l),
+(128,525,l),
+(266,525,l),
+(235,379,l)
+);
+}
+);
+width = 458;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+unicode = 5161;
+},
+{
+glyphname = "downtackFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(277,357,l),
+(343,669,l),
+(479,669,l),
+(489,714,l),
+(168,714,l),
+(158,669,l),
+(296,669,l),
+(229,357,l)
+);
+}
+);
+width = 457;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni142A;
+unicode = 5162;
+},
+{
+glyphname = "thFinalWoodScree-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(280,357,l),
+(298,445,l),
+(433,445,l),
+(442,486,l),
+(307,486,l),
+(328,585,l),
+(463,585,l),
+(472,626,l),
+(337,626,l),
+(356,714,l),
+(308,714,l),
+(289,626,l),
+(152,626,l),
+(143,585,l),
+(280,585,l),
+(259,486,l),
+(122,486,l),
+(113,445,l),
+(251,445,l),
+(232,357,l)
+);
+}
+);
+width = 461;
+}
+);
+metricLeft = "hyphen-canadian";
+metricRight = "hyphen-canadian";
+note = uni167E;
+unicode = 5758;
+},
+{
+glyphname = "ringSmallFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(306,529,o),
+(352,570,o),
+(352,628,cs),
+(352,686,o),
+(306,727,o),
+(251,727,cs),
+(196,727,o),
+(152,686,o),
+(152,628,cs),
+(152,570,o),
+(196,529,o),
+(251,529,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(212,564,o),
+(188,591,o),
+(188,628,cs),
+(188,665,o),
+(213,693,o),
+(252,693,cs),
+(290,693,o),
+(315,665,o),
+(315,628,cs),
+(315,591,o),
+(290,564,o),
+(252,564,cs)
+);
+}
+);
+width = 340;
+}
+);
+note = g725;
+unicode = 6366;
+},
+{
+glyphname = "raiseddotFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(230,637,o),
+(249,657,o),
+(249,682,cs),
+(249,707,o),
+(230,727,o),
+(205,727,cs),
+(179,727,o),
+(160,707,o),
+(160,682,cs),
+(160,657,o),
+(179,637,o),
+(205,637,cs)
+);
+}
+);
+width = 223;
+}
+);
+note = g725;
+unicode = 6367;
+},
+{
+glyphname = "acuteFinal-canadian.base";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "acuteFinal-canadian";
+}
+);
+width = 307;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.base";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "graveFinal-canadian";
+}
+);
+width = 307;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian.base";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 425;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1421;
+},
+{
+glyphname = "ringTophalfFinal-canadian.base";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 425;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.base";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-75,-357);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 374;
+}
+);
+metricLeft = "==|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "plusFinal-canadian.base";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,0,l),
+(231,146,l),
+(368,146,l),
+(378,192,l),
+(241,192,l),
+(272,335,l),
+(225,335,l),
+(195,192,l),
+(57,192,l),
+(47,146,l),
+(185,146,l),
+(154,0,l)
+);
+}
+);
+width = 457;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+},
+{
+glyphname = "acuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "acuteFinal-canadian";
+}
+);
+width = 307;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.mid";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "graveFinal-canadian";
+}
+);
+width = 307;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringTophalfFinal-canadian.mid";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-38,-178);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 425;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.mid";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-168);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 374;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "ringFinal-canadian.mid";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-40,-189);
+ref = "ringFinal-canadian";
+}
+);
+width = 489;
+}
+);
+metricLeft = "ringFinal-canadian";
+metricWidth = "ringFinal-canadian";
+note = uni1424;
+},
+{
+glyphname = "doubleacuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "doubleacuteFinal-canadian";
+}
+);
+width = 442;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "doubleacuteFinal-canadian";
+note = uni1425;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian.mid";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "doubleshortverticalstrokesFinal-canadian";
+}
+);
+width = 310;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricWidth = "doubleshortverticalstrokesFinal-canadian";
+note = uni1426;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian.mid";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-37,-173);
+ref = "shorthorizontalstrokeFinal-canadian";
+}
+);
+width = 456;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "shorthorizontalstrokeFinal-canadian";
+note = uni1428;
+},
+{
+glyphname = "downtackFinal-canadian.mid";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-168);
+ref = "downtackFinal-canadian";
+}
+);
+width = 457;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "downtackFinal-canadian";
+note = uni142A;
+},
+{
+glyphname = "e-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (401,470);
+},
+{
+name = top_center_can;
+pos = (454,714);
+},
+{
+name = top_left_can;
+pos = (225,714);
+},
+{
+name = top_right_can;
+pos = (684,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(320,0,l),
+(774,694,l),
+(778,714,l),
+(137,714,l),
+(132,694,l),
+(291,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(329,71,l),
+(198,677,l),
+(185,660,l),
+(706,660,l),
+(692,677,l),
+(305,71,l)
+);
+}
+);
+width = 714;
+}
+);
+metricRight = "=|";
+note = uni1401;
+unicode = 5121;
+},
+{
+glyphname = "aai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (234,0);
+ref = ring_top.canadian;
+}
+);
+width = 715;
+}
+);
+note = uni1402;
+unicode = 5122;
+},
+{
+glyphname = "i-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (397,417);
+},
+{
+name = top_center_can;
+pos = (457,714);
+},
+{
+name = top_left_can;
+pos = (226,714);
+},
+{
+name = top_right_can;
+pos = (685,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(442,714,l),
+(-12,20,l),
+(-16,0,l),
+(625,0,l),
+(630,20,l),
+(471,714,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(433,643,l),
+(564,37,l),
+(577,54,l),
+(56,54,l),
+(70,37,l),
+(457,643,l)
+);
+}
+);
+width = 714;
+}
+);
+metricLeft = "e-canadian";
+metricWidth = "e-canadian";
+note = uni1403;
+unicode = 5123;
+},
+{
+glyphname = "ii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (293,0);
+ref = dot_top;
+}
+);
+width = 715;
+}
+);
+note = uni1404;
+unicode = 5124;
+},
+{
+glyphname = "o-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (304,362);
+},
+{
+name = top_center_can;
+pos = (467,714);
+},
+{
+name = top_double;
+pos = (555,714);
+},
+{
+name = top_left_can;
+pos = (212,714);
+},
+{
+name = top_right_can;
+pos = (714,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(51,0,l),
+(672,343,l),
+(678,371,l),
+(203,714,l),
+(183,714,l),
+(31,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(225,648,l),
+(204,648,l),
+(610,354,l),
+(613,371,l),
+(83,77,l),
+(102,70,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1405;
+unicode = 5125;
+},
+{
+glyphname = "oo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (48,0);
+ref = dot_top;
+}
+);
+width = 688;
+}
+);
+note = uni1406;
+unicode = 5126;
+},
+{
+glyphname = "yCreeoo-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (229,0);
+ref = doubledot_top;
+}
+);
+width = 688;
+}
+);
+note = uni1407;
+unicode = 5127;
+},
+{
+glyphname = "eeCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(51,0,l),
+(671,342,l),
+(678,371,l),
+(203,714,l),
+(183,714,l),
+(31,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(224,648,l),
+(207,646,l),
+(611,354,l),
+(615,372,l),
+(86,79,l),
+(100,70,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(297,264,l),
+(338,457,l),
+(307,457,l),
+(266,264,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "o-canadian";
+note = uni1408;
+unicode = 5128;
+},
+{
+glyphname = "iCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (225,5);
+ref = dot_middle_optic_small;
+}
+);
+width = 688;
+}
+);
+note = uni1409;
+unicode = 5129;
+},
+{
+glyphname = "a-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (423,355);
+},
+{
+name = top_center_can;
+pos = (418,714);
+},
+{
+name = top_left_can;
+pos = (167,714);
+},
+{
+name = top_right_can;
+pos = (677,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(685,714,l),
+(65,371,l),
+(59,343,l),
+(533,0,l),
+(552.999,0,l),
+(704.999,714,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(512,66,l),
+(533,66,l),
+(127,360,l),
+(123,343,l),
+(654,637,l),
+(634,644,l)
+);
+}
+);
+width = 688;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni140A;
+unicode = 5130;
+},
+{
+glyphname = "aa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (513,0);
+ref = dot_top;
+}
+);
+width = 688;
+}
+);
+note = uni140B;
+unicode = 5131;
+},
+{
+glyphname = "we-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "e-canadian";
+}
+);
+width = 935;
+}
+);
+note = uni140C;
+unicode = 5132;
+},
+{
+glyphname = "weWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (715,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 935;
+}
+);
+note = uni140D;
+unicode = 5133;
+},
+{
+glyphname = "wi-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "i-canadian";
+}
+);
+width = 935;
+}
+);
+note = uni140E;
+unicode = 5134;
+},
+{
+glyphname = "wiWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (715,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 935;
+}
+);
+note = uni140F;
+unicode = 5135;
+},
+{
+glyphname = "wii-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (514,0);
+ref = dot_top;
+}
+);
+width = 935;
+}
+);
+note = uni1410;
+unicode = 5136;
+},
+{
+glyphname = "wiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (293,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (715,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 935;
+}
+);
+note = uni1411;
+unicode = 5137;
+},
+{
+glyphname = "wo-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "o-canadian";
+}
+);
+width = 909;
+}
+);
+note = uni1412;
+unicode = 5138;
+},
+{
+glyphname = "woWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (688,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 909;
+}
+);
+note = uni1413;
+unicode = 5139;
+},
+{
+glyphname = "woo-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (523,0);
+ref = dot_top;
+}
+);
+width = 909;
+}
+);
+note = uni1414;
+unicode = 5140;
+},
+{
+glyphname = "wooWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (48,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (688,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 909;
+}
+);
+note = uni1415;
+unicode = 5141;
+},
+{
+glyphname = "wooNaskapi-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (196,-99);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (350,-209);
+ref = dot_top;
+}
+);
+width = 688;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricWidth = "o-canadian";
+note = uni1416;
+unicode = 5142;
+},
+{
+glyphname = "wa-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "a-canadian";
+}
+);
+width = 909;
+}
+);
+note = uni1417;
+unicode = 5143;
+},
+{
+glyphname = "waWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (688,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 909;
+}
+);
+note = uni1418;
+unicode = 5144;
+},
+{
+glyphname = "waa-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (733,0);
+ref = dot_top;
+}
+);
+width = 909;
+}
+);
+note = uni1419;
+unicode = 5145;
+},
+{
+glyphname = "waaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (513,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (688,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 909;
+}
+);
+note = uni141A;
+unicode = 5146;
+},
+{
+glyphname = "waaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (144,-208);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (339,-99);
+ref = dot_top;
+}
+);
+width = 688;
+}
+);
+metricWidth = "a-canadian";
+note = uni141B;
+unicode = 5147;
+},
+{
+glyphname = "ai-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(303,351,o),
+(347,384,o),
+(373,451,c),
+(358,454,l),
+(359,387,o),
+(396,351,o),
+(468,351,cs),
+(555,351,o),
+(603,399,o),
+(625,504,cs),
+(670,714,l),
+(624,714,l),
+(580,504,ls),
+(564,427,o),
+(531,393,o),
+(469,393,cs),
+(405,393,o),
+(382,429,o),
+(398,503,cs),
+(443,714,l),
+(397,714,l),
+(353,506,ls),
+(337,428,o),
+(302,393,o),
+(242,393,cs),
+(181,393,o),
+(155,431,o),
+(170,501,cs),
+(216,714,l),
+(170,714,l),
+(125,503,ls),
+(106,410,o),
+(149,351,o),
+(238,351,cs)
+);
+}
+);
+width = 640;
+}
+);
+metricRight = "=|";
+note = uni141C;
+unicode = 5148;
+},
+{
+glyphname = "ycreew-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(434,528,o),
+(471,568,o),
+(471,624,cs),
+(471,681,o),
+(435,720,o),
+(385,720,cs),
+(336,720,o),
+(298,681,o),
+(298,624,cs),
+(298,568,o),
+(335,528,o),
+(385,528,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(250,351,o),
+(288,391,o),
+(288,447,cs),
+(288,504,o),
+(251,543,o),
+(201,543,cs),
+(152,543,o),
+(114,504,o),
+(114,447,cs),
+(114,391,o),
+(151,351,o),
+(201,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(168,380,o),
+(145,407,o),
+(145,447,cs),
+(145,487,o),
+(168,514,o),
+(201,514,cs),
+(234,514,o),
+(257,487,o),
+(257,447,cs),
+(257,407,o),
+(234,380,o),
+(201,380,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(351,557,o),
+(329,584,o),
+(329,624,cs),
+(329,664,o),
+(352,691,o),
+(385,691,cs),
+(418,691,o),
+(440,664,o),
+(440,624,cs),
+(440,584,o),
+(418,557,o),
+(385,557,cs)
+);
+}
+);
+width = 461;
+}
+);
+metricRight = "=|";
+note = uni141D;
+unicode = 5149;
+},
+{
+glyphname = "glottalstop-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(408,357,l),
+(411,369,l),
+(332,714,l),
+(316,714,l),
+(90,369,l),
+(87,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(331,671,l),
+(304,672,l),
+(369,376,l),
+(382,394,l),
+(130,394,l),
+(140,376,l)
+);
+}
+);
+width = 448;
+}
+);
+metricRight = "=|";
+note = uni141E;
+unicode = 5150;
+},
+{
+glyphname = "en-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+pos = (715,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 1021;
+}
+);
+note = uni142B;
+unicode = 5163;
+},
+{
+glyphname = "in-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+pos = (498,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 805;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142C;
+unicode = 5164;
+},
+{
+glyphname = "on-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (547,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 854;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142D;
+unicode = 5165;
+},
+{
+glyphname = "an-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (641,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 948;
+}
+);
+metricRight = "graveFinal-canadian";
+note = uni142E;
+unicode = 5166;
+},
+{
+glyphname = "pe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (401,470);
+},
+{
+name = top_center_can;
+pos = (457,714);
+},
+{
+name = top_left_can;
+pos = (225,714);
+},
+{
+name = top_right_can;
+pos = (684,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(320,0,l),
+(774,694,l),
+(778,714,l),
+(712,714,l),
+(299,73,l),
+(334,73,l),
+(193,714,l),
+(137,714,l),
+(132,694,l),
+(291,0,l)
+);
+}
+);
+width = 714;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni142F;
+unicode = 5167;
+},
+{
+glyphname = "paai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (234,0);
+ref = ring_top.canadian;
+}
+);
+width = 715;
+}
+);
+note = uni1430;
+unicode = 5168;
+},
+{
+glyphname = "pi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (398,417);
+},
+{
+name = top_center_can;
+pos = (457,714);
+},
+{
+name = top_left_can;
+pos = (224,714);
+},
+{
+name = top_right_can;
+pos = (683,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(442,714,l),
+(-12,20,l),
+(-16,0,l),
+(50,0,l),
+(463,641,l),
+(428,641,l),
+(569,0,l),
+(625,0,l),
+(630,20,l),
+(471,714,l)
+);
+}
+);
+width = 714;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni1431;
+unicode = 5169;
+},
+{
+glyphname = "pii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (294,0);
+ref = dot_top;
+}
+);
+width = 715;
+}
+);
+note = uni1432;
+unicode = 5170;
+},
+{
+glyphname = "po-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (254,364);
+},
+{
+name = top_center_can;
+pos = (439,714);
+},
+{
+name = top_double;
+pos = (533,714);
+},
+{
+name = top_left_can;
+pos = (188,714);
+},
+{
+name = top_right_can;
+pos = (683,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+name = "Thin Slanted";
+shapes = (
+{
+closed = 1;
+nodes = (
+(27,0,l),
+(641,343,l),
+(647,371,l),
+(179,714,l),
+(159,714,l),
+(148,662,l),
+(575,349,l),
+(582,378,l),
+(21,65,l),
+(8,0,l)
+);
+}
+);
+width = 657;
+}
+);
+metricRight = "o-canadian";
+note = uni1433;
+unicode = 5171;
+},
+{
+glyphname = "poo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (24,0);
+ref = dot_top;
+}
+);
+width = 658;
+}
+);
+note = uni1434;
+unicode = 5172;
+},
+{
+glyphname = "ycreepoo-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (207,0);
+ref = doubledot_top;
+}
+);
+width = 658;
+}
+);
+note = uni1435;
+unicode = 5173;
+},
+{
+glyphname = "heeCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (192,7);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 658;
+}
+);
+note = uni1436;
+unicode = 5174;
+},
+{
+glyphname = "hiCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (171,9);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 658;
+}
+);
+note = uni1437;
+unicode = 5175;
+},
+{
+glyphname = "pa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (315,357);
+},
+{
+name = top_center_can;
+pos = (419,714);
+},
+{
+name = top_left_can;
+pos = (168,714);
+},
+{
+name = top_right_can;
+pos = (669,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(678,714,l),
+(65,371,l),
+(59,343,l),
+(526,0,l),
+(546,0,l),
+(557,52,l),
+(130,365,l),
+(124,336,l),
+(684,649,l),
+(698,714,l)
+);
+}
+);
+width = 657;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1438;
+unicode = 5176;
+},
+{
+glyphname = "paa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (505,0);
+ref = dot_top;
+}
+);
+width = 658;
+}
+);
+note = uni1439;
+unicode = 5177;
+},
+{
+glyphname = "pwe-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "pe-canadian";
+}
+);
+width = 935;
+}
+);
+note = uni143A;
+unicode = 5178;
+},
+{
+glyphname = "pweWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "pe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (715,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 935;
+}
+);
+note = uni143B;
+unicode = 5179;
+},
+{
+glyphname = "pwi-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "pi-canadian";
+}
+);
+width = 935;
+}
+);
+note = uni143C;
+unicode = 5180;
+},
+{
+glyphname = "pwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (715,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 935;
+}
+);
+note = uni143D;
+unicode = 5181;
+},
+{
+glyphname = "pwii-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (514,0);
+ref = dot_top;
+}
+);
+width = 935;
+}
+);
+note = uni143E;
+unicode = 5182;
+},
+{
+glyphname = "pwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (294,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (715,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 935;
+}
+);
+note = uni143F;
+unicode = 5183;
+},
+{
+glyphname = "pwo-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "po-canadian";
+}
+);
+width = 878;
+}
+);
+note = uni1440;
+unicode = 5184;
+},
+{
+glyphname = "pwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (658,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 878;
+}
+);
+note = uni1441;
+unicode = 5185;
+},
+{
+glyphname = "pwoo-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (495,0);
+ref = dot_top;
+}
+);
+width = 878;
+}
+);
+note = uni1442;
+unicode = 5186;
+},
+{
+glyphname = "pwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (24,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (658,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 878;
+}
+);
+note = uni1443;
+unicode = 5187;
+},
+{
+glyphname = "pwa-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "pa-canadian";
+}
+);
+width = 878;
+}
+);
+note = uni1444;
+unicode = 5188;
+},
+{
+glyphname = "pwaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (658,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 878;
+}
+);
+note = uni1445;
+unicode = 5189;
+},
+{
+glyphname = "pwaa-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (725,0);
+ref = dot_top;
+}
+);
+width = 878;
+}
+);
+note = uni1446;
+unicode = 5190;
+},
+{
+glyphname = "pwaaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (505,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (658,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 878;
+}
+);
+note = uni1447;
+unicode = 5191;
+},
+{
+glyphname = "ycreepwaa-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+pos = (141,-208);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (336,-99);
+ref = dot_top;
+}
+);
+width = 657;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1448;
+unicode = 5192;
+},
+{
+glyphname = "p-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(373,357,l),
+(381,395,l),
+(175,548,l),
+(168,515,l),
+(439,667,l),
+(449,714,l),
+(436,714,l),
+(134,545,l),
+(130,527,l),
+(360,357,l)
+);
+}
+);
+width = 419;
+}
+);
+note = uni1449;
+unicode = 5193;
+},
+{
+glyphname = "pWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,357,l),
+(218,714,l),
+(170,714,l),
+(94,357,l)
+);
+}
+);
+width = 188;
+}
+);
+metricRight = "=|";
+note = uni144A;
+unicode = 5194;
+},
+{
+color = 6;
+glyphname = "hCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(106,189,l),
+(136,331,ls),
+(146,379,o),
+(177,406,o),
+(218,406,cs),
+(264,406,o),
+(283,377,o),
+(272,326,cs),
+(243,189,l),
+(290,189,l),
+(321,332,ls),
+(336,404,o),
+(299,449,o),
+(233,449,cs),
+(185,449,o),
+(143,420,o),
+(131,379,c),
+(145,374,l),
+(182,546,l),
+(134,546,l),
+(58,189,l)
+);
+}
+);
+width = 350;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144B;
+unicode = 5195;
+},
+{
+glyphname = "te-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (380,357);
+},
+{
+name = top_center_can;
+pos = (456,714);
+},
+{
+name = top_left_can;
+pos = (208,714);
+},
+{
+name = top_right_can;
+pos = (705,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(502,-13,o),
+(602,82,o),
+(644,275,cs),
+(737,714,l),
+(673,714,l),
+(581,279,ls),
+(547,119,o),
+(469,47,o),
+(333,47,cs),
+(177,47,o),
+(115,130,o),
+(152,301,cs),
+(240,714,l),
+(176,714,l),
+(89,304,ls),
+(45,100,o),
+(137,-13,o),
+(329,-13,cs)
+);
+}
+);
+width = 714;
+}
+);
+metricRight = "=|";
+note = uni144C;
+unicode = 5196;
+},
+{
+glyphname = "taai-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (233,0);
+ref = ring_top.canadian;
+}
+);
+width = 713;
+}
+);
+note = uni144D;
+unicode = 5197;
+},
+{
+glyphname = "ti-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (380,357);
+},
+{
+name = middle_right_can;
+pos = (825,357);
+},
+{
+name = top_center_can;
+pos = (456,714);
+},
+{
+name = top_left_can;
+pos = (208,714);
+},
+{
+name = top_right_can;
+pos = (705,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(88,0,l),
+(180,435,ls),
+(214,595,o),
+(293,667,o),
+(428,667,cs),
+(584,667,o),
+(646,584,o),
+(609,413,cs),
+(521,0,l),
+(585,0,l),
+(672,410,ls),
+(716,614,o),
+(624,727,o),
+(432,727,cs),
+(259,727,o),
+(159,632,o),
+(117,439,cs),
+(24,0,l)
+);
+}
+);
+width = 713;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni144E;
+unicode = 5198;
+},
+{
+glyphname = "tii-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (292,0);
+ref = dot_top;
+}
+);
+width = 713;
+}
+);
+note = uni144F;
+unicode = 5199;
+},
+{
+glyphname = "to-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (292,357);
+},
+{
+name = middle_right_can;
+pos = (725,357);
+},
+{
+name = top_center_can;
+pos = (373,714);
+},
+{
+name = top_double;
+pos = (430,714);
+},
+{
+name = top_left_can;
+pos = (190,714);
+},
+{
+name = top_right_can;
+pos = (609,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(163,0,ls),
+(483,0,o),
+(569,272,o),
+(569,449,cs),
+(569,617,o),
+(472,714,o),
+(298,714,cs),
+(161,714,l),
+(149,656,l),
+(289,656,ls),
+(431,656,o),
+(505,583,o),
+(505,447,cs),
+(505,299,o),
+(437,58,o),
+(170,58,cs),
+(22,58,l),
+(9,0,l)
+);
+}
+);
+width = 606;
+}
+);
+note = uni1450;
+unicode = 5200;
+},
+{
+glyphname = "too-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (209,0);
+ref = dot_top;
+}
+);
+width = 606;
+}
+);
+note = uni1451;
+unicode = 5201;
+},
+{
+glyphname = "ycreetoo-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (103,0);
+ref = doubledot_top;
+}
+);
+width = 606;
+}
+);
+note = uni1452;
+unicode = 5202;
+},
+{
+glyphname = "deeCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (227,0);
+ref = stroke_middle;
+}
+);
+width = 606;
+}
+);
+note = uni1453;
+unicode = 5203;
+},
+{
+glyphname = "diCarrier-canadian";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (204,0);
+ref = dot_middle;
+}
+);
+width = 606;
+}
+);
+note = uni1454;
+unicode = 5204;
+},
+{
+glyphname = "ta-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (362,357);
+},
+{
+name = top_center_can;
+pos = (433,714);
+},
+{
+name = top_left_can;
+pos = (196,714);
+},
+{
+name = top_right_can;
+pos = (615,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(493,0,l),
+(505,58,l),
+(364,58,ls),
+(222,58,o),
+(149,131,o),
+(149,267,cs),
+(149,417,o),
+(217,656,o),
+(483,656,cs),
+(632,656,l),
+(645,714,l),
+(489,714,ls),
+(171,714,o),
+(85,443,o),
+(85,265,cs),
+(85,97,o),
+(181,0,o),
+(355,0,cs)
+);
+}
+);
+width = 606;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|to-canadian";
+note = uni1455;
+unicode = 5205;
+},
+{
+glyphname = "taa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (269,0);
+ref = dot_top;
+}
+);
+width = 606;
+}
+);
+note = uni1456;
+unicode = 5206;
+},
+{
+glyphname = "twe-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "te-canadian";
+}
+);
+width = 933;
+}
+);
+note = uni1457;
+unicode = 5207;
+},
+{
+glyphname = "tweWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (713,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 933;
+}
+);
+note = uni1458;
+unicode = 5208;
+},
+{
+glyphname = "twi-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ti-canadian";
+}
+);
+width = 933;
+}
+);
+note = uni1459;
+unicode = 5209;
+},
+{
+glyphname = "twiWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (713,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 933;
+}
+);
+note = uni145A;
+unicode = 5210;
+},
+{
+glyphname = "twii-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (512,0);
+ref = dot_top;
+}
+);
+width = 933;
+}
+);
+note = uni145B;
+unicode = 5211;
+},
+{
+glyphname = "twiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (292,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (713,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 933;
+}
+);
+note = uni145C;
+unicode = 5212;
+},
+{
+glyphname = "two-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "to-canadian";
+}
+);
+width = 826;
+}
+);
+note = uni145D;
+unicode = 5213;
+},
+{
+glyphname = "twoWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (606,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 826;
+}
+);
+note = uni145E;
+unicode = 5214;
+},
+{
+glyphname = "twoo-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (429,0);
+ref = dot_top;
+}
+);
+width = 826;
+}
+);
+note = uni145F;
+unicode = 5215;
+},
+{
+glyphname = "twooWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (209,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (606,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 826;
+}
+);
+note = uni1460;
+unicode = 5216;
+},
+{
+glyphname = "twa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ta-canadian";
+}
+);
+width = 826;
+}
+);
+note = uni1461;
+unicode = 5217;
+},
+{
+glyphname = "twaWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (606,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 826;
+}
+);
+note = uni1462;
+unicode = 5218;
+},
+{
+glyphname = "twaa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (489,0);
+ref = dot_top;
+}
+);
+width = 826;
+}
+);
+note = uni1463;
+unicode = 5219;
+},
+{
+glyphname = "twaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (269,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (606,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 826;
+}
+);
+note = uni1464;
+unicode = 5220;
+},
+{
+glyphname = "twaaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (221,0);
+ref = "ta-canadian";
+}
+);
+width = 827;
+}
+);
+note = uni1465;
+unicode = 5221;
+},
+{
+glyphname = "t-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(331,357,l),
+(341,401,l),
+(273,401,ls),
+(207,401,o),
+(174,436,o),
+(174,496,cs),
+(174,571,o),
+(208,670,o),
+(330,670,cs),
+(397,670,l),
+(407,714,l),
+(336,714,ls),
+(193,714,o),
+(126,609,o),
+(126,494,cs),
+(126,409,o),
+(178,357,o),
+(268,357,cs)
+);
+}
+);
+width = 374;
+}
+);
+note = uni1466;
+unicode = 5222;
+},
+{
+glyphname = "tte-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+pos = (713,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 900;
+}
+);
+note = uni1467;
+unicode = 5223;
+},
+{
+glyphname = "tti-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+pos = (713,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 900;
+}
+);
+note = uni1468;
+unicode = 5224;
+},
+{
+glyphname = "tto-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+pos = (606,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni1469;
+unicode = 5225;
+},
+{
+glyphname = "tta-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+pos = (606,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni146A;
+unicode = 5226;
+},
+{
+glyphname = "ke-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (356,457);
+},
+{
+name = top_center_can;
+pos = (389,714);
+},
+{
+name = top_left_can;
+pos = (199,714);
+},
+{
+name = top_right_can;
+pos = (573,716);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(460,0,l),
+(553,436,ls),
+(583,579,o),
+(538,727,o),
+(369,727,cs),
+(186,727,o),
+(115,546,o),
+(115,415,cs),
+(115,291,o),
+(188,213,o),
+(302,213,cs),
+(386,213,o),
+(450,258,o),
+(483,338,c),
+(471,353,l),
+(396,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(228,268,o),
+(177,324,o),
+(177,416,cs),
+(177,510,o),
+(225,671,o),
+(364,671,cs),
+(450,671,o),
+(500,615,o),
+(500,522,cs),
+(500,426,o),
+(452,268,o),
+(314,268,cs)
+);
+}
+);
+width = 588;
+}
+);
+metricRight = "te-canadian";
+note = uni146B;
+unicode = 5227;
+},
+{
+glyphname = "kaai-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (168,0);
+ref = ring_top.canadian;
+}
+);
+width = 588;
+}
+);
+note = uni146C;
+unicode = 5228;
+},
+{
+glyphname = "ki-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (363,457);
+},
+{
+name = top_center_can;
+pos = (392,714);
+},
+{
+name = top_left_can;
+pos = (208,714);
+},
+{
+name = top_right_can;
+pos = (586,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(88,0,l),
+(167,374,l),
+(156,369,l),
+(151,287,o),
+(217,213,o),
+(321,213,cs),
+(500,213,o),
+(568,396,o),
+(568,522,cs),
+(568,649,o),
+(494,727,o),
+(373,727,cs),
+(249,727,o),
+(161,645,o),
+(130,499,cs),
+(24,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(233,268,o),
+(183,324,o),
+(183,417,cs),
+(183,509,o),
+(230,671,o),
+(369,671,cs),
+(455,671,o),
+(506,616,o),
+(506,523,cs),
+(506,430,o),
+(458,268,o),
+(320,268,cs)
+);
+}
+);
+width = 588;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni146D;
+unicode = 5229;
+},
+{
+glyphname = "kii-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (227,0);
+ref = dot_top;
+}
+);
+width = 588;
+}
+);
+note = uni146E;
+unicode = 5230;
+},
+{
+glyphname = "ko-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (348,411);
+},
+{
+name = top_center_can;
+pos = (390,714);
+},
+{
+name = top_double;
+pos = (579,714);
+},
+{
+name = top_left_can;
+pos = (201,714);
+},
+{
+name = top_right_can;
+pos = (579,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(388,-13,o),
+(475,69,o),
+(506,215,cs),
+(612,714,l),
+(548,714,l),
+(468,340,l),
+(479,345,l),
+(484,427,o),
+(419,501,o),
+(314,501,cs),
+(134,501,o),
+(67,316,o),
+(67,192,cs),
+(67,65,o),
+(141,-13,o),
+(264,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(180,43,o),
+(129,98,o),
+(129,191,cs),
+(129,284,o),
+(178,445,o),
+(316,445,cs),
+(402,445,o),
+(452,390,o),
+(452,297,cs),
+(452,203,o),
+(406,43,o),
+(266,43,cs)
+);
+}
+);
+width = 588;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni146F;
+unicode = 5231;
+},
+{
+glyphname = "koo-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (415,0);
+ref = dot_top;
+}
+);
+width = 588;
+}
+);
+note = uni1470;
+unicode = 5232;
+},
+{
+glyphname = "ycreekoo-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (253,0);
+ref = doubledot_top;
+}
+);
+width = 588;
+}
+);
+note = uni1471;
+unicode = 5233;
+},
+{
+glyphname = "ka-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (353,412);
+},
+{
+name = top_center_can;
+pos = (396,714);
+},
+{
+name = top_left_can;
+pos = (208,714);
+},
+{
+name = top_right_can;
+pos = (586,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(449,-13,o),
+(521,168,o),
+(521,299,cs),
+(521,423,o),
+(448,501,o),
+(334,501,cs),
+(251,501,o),
+(187,456,o),
+(153,376,c),
+(165,361,l),
+(240,714,l),
+(176,714,l),
+(83,278,ls),
+(46,101,o),
+(123,-13,o),
+(269,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(186,43,o),
+(136,99,o),
+(136,192,cs),
+(136,288,o),
+(184,446,o),
+(322,446,cs),
+(408,446,o),
+(458,390,o),
+(458,298,cs),
+(458,204,o),
+(411,43,o),
+(272,43,cs)
+);
+}
+);
+width = 588;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "==|ke-canadian";
+note = uni1472;
+unicode = 5234;
+},
+{
+glyphname = "kaa-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (43,0);
+ref = dot_top;
+}
+);
+width = 588;
+}
+);
+note = uni1473;
+unicode = 5235;
+},
+{
+glyphname = "kwe-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ke-canadian";
+}
+);
+width = 808;
+}
+);
+note = uni1474;
+unicode = 5236;
+},
+{
+glyphname = "kweWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (588,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 808;
+}
+);
+note = uni1475;
+unicode = 5237;
+},
+{
+glyphname = "kwi-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ki-canadian";
+}
+);
+width = 808;
+}
+);
+note = uni1476;
+unicode = 5238;
+},
+{
+glyphname = "kwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (588,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 808;
+}
+);
+note = uni1477;
+unicode = 5239;
+},
+{
+glyphname = "kwii-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (448,0);
+ref = dot_top;
+}
+);
+width = 808;
+}
+);
+note = uni1478;
+unicode = 5240;
+},
+{
+glyphname = "kwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (227,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (588,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 808;
+}
+);
+note = uni1479;
+unicode = 5241;
+},
+{
+glyphname = "kwo-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ko-canadian";
+}
+);
+width = 808;
+}
+);
+note = uni147A;
+unicode = 5242;
+},
+{
+glyphname = "kwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (588,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 808;
+}
+);
+note = uni147B;
+unicode = 5243;
+},
+{
+glyphname = "kwoo-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (635,0);
+ref = dot_top;
+}
+);
+width = 808;
+}
+);
+note = uni147C;
+unicode = 5244;
+},
+{
+glyphname = "kwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (415,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (588,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 808;
+}
+);
+note = uni147D;
+unicode = 5245;
+},
+{
+glyphname = "kwa-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ka-canadian";
+}
+);
+width = 808;
+}
+);
+note = uni147E;
+unicode = 5246;
+},
+{
+glyphname = "kwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (588,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 808;
+}
+);
+note = uni147F;
+unicode = 5247;
+},
+{
+glyphname = "kwaa-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (263,0);
+ref = dot_top;
+}
+);
+width = 808;
+}
+);
+note = uni1480;
+unicode = 5248;
+},
+{
+glyphname = "kwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (43,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (588,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 808;
+}
+);
+note = uni1481;
+unicode = 5249;
+},
+{
+glyphname = "kwaaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (221,0);
+ref = "ka-canadian";
+}
+);
+width = 809;
+}
+);
+note = uni1482;
+unicode = 5250;
+},
+{
+glyphname = "k-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(319,351,o),
+(367,442,o),
+(367,517,cs),
+(367,580,o),
+(329,622,o),
+(270,622,cs),
+(221,622,o),
+(183,591,o),
+(165,544,c),
+(181,542,l),
+(218,714,l),
+(170,714,l),
+(125.005,502.995,ls),
+(109,430,o),
+(133,351,o),
+(227,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(189,389,o),
+(164,416,o),
+(164,460,cs),
+(164,512,o),
+(196,584,o),
+(258,584,cs),
+(299,584,o),
+(324,558,o),
+(324,514,cs),
+(324,461,o),
+(292,389,o),
+(229,389,cs)
+);
+}
+);
+width = 374;
+}
+);
+note = uni1483;
+unicode = 5251;
+},
+{
+glyphname = "kw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(288,351,o),
+(337,395,o),
+(354,479,cs),
+(405,714,l),
+(357,714,l),
+(319,538,l),
+(333,538,l),
+(333,586,o),
+(297,622,o),
+(244,622,cs),
+(157,622,o),
+(111,531,o),
+(111,459,cs),
+(111,394,o),
+(152,351,o),
+(219,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(179,389,o),
+(154,415,o),
+(154,459,cs),
+(154,511,o),
+(185,584,o),
+(248,584,cs),
+(288,584,o),
+(314,557,o),
+(314,513,cs),
+(314,463,o),
+(284,389,o),
+(219,389,cs)
+);
+}
+);
+width = 375;
+}
+);
+metricLeft = "=|k-canadian";
+metricRight = "=|k-canadian";
+note = uni1484;
+unicode = 5252;
+},
+{
+glyphname = "southslaveykeh-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+pos = (588,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 775;
+}
+);
+note = uni1485;
+unicode = 5253;
+},
+{
+glyphname = "southslaveykih-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+pos = (588,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 775;
+}
+);
+note = uni1486;
+unicode = 5254;
+},
+{
+glyphname = "southslaveykoh-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+pos = (588,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 775;
+}
+);
+note = uni1487;
+unicode = 5255;
+},
+{
+glyphname = "southslaveykah-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+pos = (588,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 775;
+}
+);
+note = uni1488;
+unicode = 5256;
+},
+{
+glyphname = "ce-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (351,434);
+},
+{
+name = top_center_can;
+pos = (391,714);
+},
+{
+name = top_left_can;
+pos = (202,714);
+},
+{
+name = top_right_can;
+pos = (577,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(457,0,l),
+(554,456,ls),
+(588,617,o),
+(515,727,o),
+(368,727,cs),
+(235,727,o),
+(157,648,o),
+(122,486,cs),
+(104,405,l),
+(168,405,l),
+(184,483,ls),
+(211,612,o),
+(269,670,o),
+(363,670,cs),
+(474,670,o),
+(518,591,o),
+(491,464,cs),
+(393,0,l)
+);
+}
+);
+width = 585;
+}
+);
+metricRight = "te-canadian";
+note = uni1489;
+unicode = 5257;
+},
+{
+glyphname = "caai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (173,0);
+ref = ring_top.canadian;
+}
+);
+width = 584;
+}
+);
+note = uni148A;
+unicode = 5258;
+},
+{
+glyphname = "ci-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (354,434);
+},
+{
+name = top_center_can;
+pos = (397,714);
+},
+{
+name = top_left_can;
+pos = (208,714);
+},
+{
+name = top_right_can;
+pos = (584,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(88,0,l),
+(190,483,ls),
+(217,612,o),
+(274,670,o),
+(369,670,cs),
+(481,670,o),
+(524,591,o),
+(497,464,cs),
+(485,405,l),
+(548,405,l),
+(559,456,ls),
+(595,617,o),
+(521,727,o),
+(374,727,cs),
+(241,727,o),
+(162,648,o),
+(127,486,cs),
+(24,0,l)
+);
+}
+);
+width = 584;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+unicode = 5259;
+},
+{
+glyphname = "cii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (233,0);
+ref = dot_top;
+}
+);
+width = 584;
+}
+);
+note = uni148C;
+unicode = 5260;
+},
+{
+glyphname = "co-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (352,434);
+},
+{
+name = top_center_can;
+pos = (390,714);
+},
+{
+name = top_double;
+pos = (577,714);
+},
+{
+name = top_left_can;
+pos = (202,714);
+},
+{
+name = top_right_can;
+pos = (577,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(391,-13,o),
+(470,66,o),
+(505,228,cs),
+(609,714,l),
+(545,714,l),
+(442,231,ls),
+(415,102,o),
+(358,44,o),
+(263,44,cs),
+(151,44,o),
+(109,123,o),
+(135,250,cs),
+(147,309,l),
+(84,309,l),
+(73,258,ls),
+(38,97,o),
+(111,-13,o),
+(258,-13,cs)
+);
+}
+);
+width = 585;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+unicode = 5261;
+},
+{
+glyphname = "coo-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (413,0);
+ref = dot_top;
+}
+);
+width = 584;
+}
+);
+note = uni148E;
+unicode = 5262;
+},
+{
+glyphname = "ycreecoo-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (250,0);
+ref = doubledot_top;
+}
+);
+width = 584;
+}
+);
+note = uni148F;
+unicode = 5263;
+},
+{
+glyphname = "ca-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (355,434);
+},
+{
+name = top_center_can;
+pos = (398,714);
+},
+{
+name = top_left_can;
+pos = (208,714);
+},
+{
+name = top_right_can;
+pos = (582,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(397,-13,o),
+(475,66,o),
+(510,228,cs),
+(527,309,l),
+(464,309,l),
+(448,231,ls),
+(420,102,o),
+(364,44,o),
+(269,44,cs),
+(158,44,o),
+(114,123,o),
+(141,250,cs),
+(240,714,l),
+(176,714,l),
+(79,258,ls),
+(44,97,o),
+(117,-13,o),
+(264,-13,cs)
+);
+}
+);
+width = 584;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+unicode = 5264;
+},
+{
+glyphname = "caa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (44,0);
+ref = dot_top;
+}
+);
+width = 584;
+}
+);
+note = uni1491;
+unicode = 5265;
+},
+{
+glyphname = "cwe-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ce-canadian";
+}
+);
+width = 804;
+}
+);
+note = uni1492;
+unicode = 5266;
+},
+{
+glyphname = "cweWestCree-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (584,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 804;
+}
+);
+note = uni1493;
+unicode = 5267;
+},
+{
+glyphname = "cwi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+pos = (220,0);
+ref = "ci-canadian";
+}
+);
+width = 804;
+}
+);
+note = uni1494;
+unicode = 5268;
+},
+{
+glyphname = "cwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "ci-canadian";
+},
+{
+anchor = middle_right_can;
+pos = (584,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 804;
+}
+);
+note = uni1495;
+unicode = 5269;
+},
+{
+glyphname = "cwii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+pos = (220,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (453,0);
+ref = dot_top;
+}
+);
+width = 804;
+}
+);
+note = uni1496;
+unicode = 5270;
+},
+{
+glyphname = "cwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (233,0);
+ref = dot_top;
+},
+{
+anchor = middle_right_can;
+pos = (584,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 804;
+}
+);
+note = uni1497;
+unicode = 5271;
+},
+{
+glyphname = "cwo-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "co-canadian";
+}
+);
+width = 804;
+}
+);
+note = uni1498;
+unicode = 5272;
+},
+{
+glyphname = "cwoWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (584,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 804;
+}
+);
+note = uni1499;
+unicode = 5273;
+},
+{
+glyphname = "cwoo-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (633,0);
+ref = dot_top;
+}
+);
+width = 804;
+}
+);
+note = uni149A;
+unicode = 5274;
+},
+{
+glyphname = "cwooWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (413,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (584,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 804;
+}
+);
+note = uni149B;
+unicode = 5275;
+},
+{
+glyphname = "cwa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ca-canadian";
+}
+);
+width = 804;
+}
+);
+note = uni149C;
+unicode = 5276;
+},
+{
+glyphname = "cwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (584,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 804;
+}
+);
+note = uni149D;
+unicode = 5277;
+},
+{
+glyphname = "cwaa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (264,0);
+ref = dot_top;
+}
+);
+width = 804;
+}
+);
+note = uni149E;
+unicode = 5278;
+},
+{
+glyphname = "cwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (44,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (584,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 804;
+}
+);
+note = uni149F;
+unicode = 5279;
+},
+{
+glyphname = "cwaaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (221,0);
+ref = "ca-canadian";
+}
+);
+width = 805;
+}
+);
+note = uni14A0;
+unicode = 5280;
+},
+{
+glyphname = "c-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(297,351,o),
+(346,393,o),
+(362,470,cs),
+(369,502,l),
+(324,502,l),
+(317,468,ls),
+(305,417,o),
+(275,391,o),
+(229,391,cs),
+(177,391,o),
+(156,423,o),
+(169,484,cs),
+(218,714,l),
+(170,714,l),
+(123,489,ls),
+(105,405,o),
+(144,351,o),
+(227,351,cs)
+);
+}
+);
+width = 364;
+}
+);
+note = uni14A1;
+unicode = 5281;
+},
+{
+glyphname = "thSayisi-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(280,351,o),
+(326,393,o),
+(343,471,cs),
+(395,714,l),
+(347,714,l),
+(295,470,ls),
+(284,415,o),
+(252,391,o),
+(208,391,cs),
+(154,391,o),
+(134,426,o),
+(145,478,cs),
+(150,502,l),
+(105,502,l),
+(101,484,ls),
+(84,407,o),
+(125,351,o),
+(206,351,cs)
+);
+}
+);
+width = 365;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "=|c-canadian";
+note = uni14A2;
+unicode = 5282;
+},
+{
+glyphname = "me-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (232,357);
+},
+{
+name = top_center_can;
+pos = (341,714);
+},
+{
+name = top_left_can;
+pos = (175,714);
+},
+{
+name = top_right_can;
+pos = (505,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(385.006,0,l),
+(537.006,714,l),
+(143,714,l),
+(131,656,l),
+(461,656,l),
+(321,0,l)
+);
+}
+);
+width = 520;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+unicode = 5283;
+},
+{
+glyphname = "maai-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (157,0);
+ref = ring_top.canadian;
+}
+);
+width = 520;
+}
+);
+note = uni14A4;
+unicode = 5284;
+},
+{
+glyphname = "mi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (337,357);
+},
+{
+name = top_center_can;
+pos = (380,714);
+},
+{
+name = top_left_can;
+pos = (216,714);
+},
+{
+name = top_right_can;
+pos = (545,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(95,0,l),
+(235,656,l),
+(565,656,l),
+(577,714,l),
+(183,714,l),
+(31,0,l)
+);
+}
+);
+width = 521;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+unicode = 5285;
+},
+{
+glyphname = "mii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (216,0);
+ref = dot_top;
+}
+);
+width = 520;
+}
+);
+note = uni14A6;
+unicode = 5286;
+},
+{
+glyphname = "mo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (232,357);
+},
+{
+name = top_center_can;
+pos = (341,714);
+},
+{
+name = top_double;
+pos = (505,714);
+},
+{
+name = top_left_can;
+pos = (175,714);
+},
+{
+name = top_right_can;
+pos = (505,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(385.006,0,l),
+(537.006,714,l),
+(473,714,l),
+(334,58,l),
+(3,58,l),
+(-9,0,l)
+);
+}
+);
+width = 520;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+unicode = 5287;
+},
+{
+glyphname = "moo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (341,0);
+ref = dot_top;
+}
+);
+width = 520;
+}
+);
+note = uni14A8;
+unicode = 5288;
+},
+{
+glyphname = "ycreemoo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (179,0);
+ref = doubledot_top;
+}
+);
+width = 520;
+}
+);
+note = uni14A9;
+unicode = 5289;
+},
+{
+glyphname = "ma-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (337,357);
+},
+{
+name = top_center_can;
+pos = (380,714);
+},
+{
+name = top_left_can;
+pos = (216,714);
+},
+{
+name = top_right_can;
+pos = (545,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(425,0,l),
+(438,58,l),
+(108,58,l),
+(247,714,l),
+(183,714,l),
+(31,0,l)
+);
+}
+);
+width = 521;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+unicode = 5290;
+},
+{
+glyphname = "maa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+}
+);
+width = 520;
+}
+);
+note = uni14AB;
+unicode = 5291;
+},
+{
+glyphname = "mwe-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "me-canadian";
+}
+);
+width = 741;
+}
+);
+note = uni14AC;
+unicode = 5292;
+},
+{
+glyphname = "mweWestCree-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "me-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (520,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 741;
+}
+);
+note = uni14AD;
+unicode = 5293;
+},
+{
+glyphname = "mwi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "mi-canadian";
+}
+);
+width = 741;
+}
+);
+note = uni14AE;
+unicode = 5294;
+},
+{
+glyphname = "mwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (520,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 741;
+}
+);
+note = uni14AF;
+unicode = 5295;
+},
+{
+glyphname = "mwii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (436,0);
+ref = dot_top;
+}
+);
+width = 741;
+}
+);
+note = uni14B0;
+unicode = 5296;
+},
+{
+glyphname = "mwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (216,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (520,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 741;
+}
+);
+note = uni14B1;
+unicode = 5297;
+},
+{
+glyphname = "mwo-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "mo-canadian";
+}
+);
+width = 741;
+}
+);
+note = uni14B2;
+unicode = 5298;
+},
+{
+glyphname = "mwoWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (520,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 741;
+}
+);
+note = uni14B3;
+unicode = 5299;
+},
+{
+glyphname = "mwoo-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (561,0);
+ref = dot_top;
+}
+);
+width = 741;
+}
+);
+note = uni14B4;
+unicode = 5300;
+},
+{
+glyphname = "mwooWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (341,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (520,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 741;
+}
+);
+note = uni14B5;
+unicode = 5301;
+},
+{
+glyphname = "mwa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ma-canadian";
+}
+);
+width = 741;
+}
+);
+note = uni14B6;
+unicode = 5302;
+},
+{
+glyphname = "mwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (520,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 741;
+}
+);
+note = uni14B7;
+unicode = 5303;
+},
+{
+glyphname = "mwaa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (272,0);
+ref = dot_top;
+}
+);
+width = 741;
+}
+);
+note = uni14B8;
+unicode = 5304;
+},
+{
+glyphname = "mwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (520,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 741;
+}
+);
+note = uni14B9;
+unicode = 5305;
+},
+{
+glyphname = "mwaaNaskapi-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (221,0);
+ref = "ma-canadian";
+}
+);
+width = 741;
+}
+);
+note = uni14BA;
+unicode = 5306;
+},
+{
+glyphname = "m-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(310,357,l),
+(320,401,l),
+(151,401,l),
+(218,714,l),
+(170,714,l),
+(94,357,l)
+);
+}
+);
+width = 337;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni14BB;
+unicode = 5307;
+},
+{
+glyphname = "mWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "t-canadian";
+}
+);
+width = 374;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "t-canadian";
+note = uni14BC;
+unicode = 5308;
+},
+{
+glyphname = "mh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(290,357,l),
+(366,714,l),
+(319,714,l),
+(252,401,l),
+(83,401,l),
+(74,357,l)
+);
+}
+);
+width = 336;
+}
+);
+metricLeft = "=|m-canadian";
+metricRight = "=|m-canadian";
+note = uni14BD;
+unicode = 5309;
+},
+{
+glyphname = "mAthapascan-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(327,357,l),
+(336,397,l),
+(157,397,l),
+(155,373,l),
+(298,500,ls),
+(341,539,o),
+(365,576,o),
+(365,626,cs),
+(365,682,o),
+(326,720,o),
+(265,720,cs),
+(198,720,o),
+(150,682,o),
+(135,594,c),
+(179,594,l),
+(190,656,o),
+(219,682,o),
+(262,682,cs),
+(299,682,o),
+(322,661,o),
+(322,625,cs),
+(322,584,o),
+(303,556,o),
+(258,516,cs),
+(104,380,l),
+(99,357,l)
+);
+}
+);
+width = 357;
+}
+);
+note = uni14BE;
+unicode = 5310;
+},
+{
+glyphname = "mSayisi-canadian";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = two.canadian;
+}
+);
+width = 581;
+}
+);
+note = uni14BF;
+unicode = 5311;
+},
+{
+glyphname = "ne-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (520,254);
+},
+{
+name = top_center_can;
+pos = (565,507);
+},
+{
+name = top_left_can;
+pos = (152,507);
+},
+{
+name = top_right_can;
+pos = (770,507);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(663,-13,o),
+(747,151,o),
+(747,287,cs),
+(747,409,o),
+(670,489,o),
+(535,489,cs),
+(116,489,l),
+(104,431,l),
+(455,431,l),
+(455,458,l),
+(326,423,o),
+(285,282,o),
+(285,189,cs),
+(285,68,o),
+(363,-13,o),
+(493,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(400,43,o),
+(347,101,o),
+(347,190,cs),
+(347,292,o),
+(403,433,o),
+(537,433,cs),
+(632,433,o),
+(684,375,o),
+(684,286,cs),
+(684,184,o),
+(628,43,o),
+(494,43,cs)
+);
+}
+);
+width = 816;
+}
+);
+metricRight = "=|ke-canadian";
+note = uni14C0;
+unicode = 5312;
+},
+{
+glyphname = "naai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (137,-207);
+ref = ring_top.canadian;
+}
+);
+width = 815;
+}
+);
+note = uni14C1;
+unicode = 5313;
+},
+{
+glyphname = "ni-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (298,254);
+},
+{
+name = top_center_can;
+pos = (361,507);
+},
+{
+name = top_left_can;
+pos = (156,507);
+},
+{
+name = top_right_can;
+pos = (775,507);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(444,-13,o),
+(528,151,o),
+(528,287,cs),
+(528,357,o),
+(496,412,o),
+(447,438,c),
+(438,431,l),
+(791,431,l),
+(803,489,l),
+(326,489,ls),
+(148,489,o),
+(66,327,o),
+(66,190,cs),
+(66,68,o),
+(144,-13,o),
+(274,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(181,43,o),
+(129,101,o),
+(129,190,cs),
+(129,292,o),
+(185,433,o),
+(319,433,cs),
+(413,433,o),
+(465,375,o),
+(465,286,cs),
+(465,184,o),
+(409,43,o),
+(275,43,cs)
+);
+}
+);
+width = 815;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+unicode = 5314;
+},
+{
+glyphname = "nii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (197,-207);
+ref = dot_top;
+}
+);
+width = 815;
+}
+);
+note = uni14C3;
+unicode = 5315;
+},
+{
+glyphname = "no-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (521,254);
+},
+{
+name = top_center_can;
+pos = (571,507);
+},
+{
+name = top_double;
+pos = (575,507);
+},
+{
+name = top_left_can;
+pos = (152,507);
+},
+{
+name = top_right_can;
+pos = (771,507);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(489,0,ls),
+(667,0,o),
+(749,162,o),
+(749,299,cs),
+(749,421,o),
+(671,501,o),
+(541,501,cs),
+(371,501,o),
+(287,337,o),
+(287,202,cs),
+(287,131,o),
+(320,77,o),
+(369,51,c),
+(377,58,l),
+(24,58,l),
+(12,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(402,56,o),
+(350,113,o),
+(350,203,cs),
+(350,304,o),
+(406,445,o),
+(540,445,cs),
+(635,445,o),
+(687,388,o),
+(687,299,cs),
+(687,197,o),
+(631,56,o),
+(497,56,cs)
+);
+}
+);
+width = 815;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14C4;
+unicode = 5316;
+},
+{
+glyphname = "noo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (407,-207);
+ref = dot_top;
+}
+);
+width = 815;
+}
+);
+note = uni14C5;
+unicode = 5317;
+},
+{
+glyphname = "ycreenoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (249,-207);
+ref = doubledot_top;
+}
+);
+width = 815;
+}
+);
+note = uni14C6;
+unicode = 5318;
+},
+{
+glyphname = "na-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (299,254);
+},
+{
+name = top_center_can;
+pos = (356,507);
+},
+{
+name = top_double;
+pos = (501,507);
+},
+{
+name = top_left_can;
+pos = (157,507);
+},
+{
+name = top_right_can;
+pos = (775,507);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(699,0,l),
+(712,58,l),
+(361,58,l),
+(360,31,l),
+(489,66,o),
+(530,207,o),
+(530,300,cs),
+(530,421,o),
+(452,501,o),
+(322,501,cs),
+(152,501,o),
+(69,337,o),
+(69,202,cs),
+(69,80,o),
+(146,0,o),
+(280,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(183,56,o),
+(131,113,o),
+(131,203,cs),
+(131,304,o),
+(187,445,o),
+(321,445,cs),
+(416,445,o),
+(468,388,o),
+(468,299,cs),
+(468,197,o),
+(412,56,o),
+(278,56,cs)
+);
+}
+);
+width = 816;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+unicode = 5319;
+},
+{
+glyphname = "naa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (191,-207);
+ref = dot_top;
+}
+);
+width = 815;
+}
+);
+note = uni14C8;
+unicode = 5320;
+},
+{
+glyphname = "nwe-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ne-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni14C9;
+unicode = 5321;
+},
+{
+glyphname = "nweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (815,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni14CA;
+unicode = 5322;
+},
+{
+glyphname = "nwa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "na-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni14CB;
+unicode = 5323;
+},
+{
+glyphname = "nwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (815,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni14CC;
+unicode = 5324;
+},
+{
+glyphname = "nwaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (412,-207);
+ref = dot_top;
+}
+);
+width = 1036;
+}
+);
+note = uni14CD;
+unicode = 5325;
+},
+{
+glyphname = "nwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (191,-207);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (815,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni14CE;
+unicode = 5326;
+},
+{
+glyphname = "nwaaNaskapi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (175,-207);
+ref = doubledot_top;
+}
+);
+width = 815;
+}
+);
+note = uni14CF;
+unicode = 5327;
+},
+{
+glyphname = "n-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(477,449,l),
+(486,494,l),
+(298,494,l),
+(295,468,l),
+(354,487,o),
+(377,562,o),
+(377,609,cs),
+(377,676,o),
+(335,720,o),
+(268,720,cs),
+(179,720,o),
+(132,637,o),
+(132,561,cs),
+(132,493,o),
+(174,449,o),
+(242,449,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,487,o),
+(174,516,o),
+(174,560,cs),
+(174,605,o),
+(198,683,o),
+(267,683,cs),
+(310,683,o),
+(335,654,o),
+(335,610,cs),
+(335,565,o),
+(311,487,o),
+(242,487,cs)
+);
+}
+);
+width = 484;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni14D0;
+unicode = 5328;
+},
+{
+color = 6;
+glyphname = "ngCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-167);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 425;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "=|";
+note = uni14D1;
+unicode = 5329;
+},
+{
+glyphname = "nh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(356,449,ls),
+(449,449,o),
+(496,533,o),
+(496,610,cs),
+(496,677,o),
+(453,720,o),
+(386,720,cs),
+(297,720,o),
+(250,637,o),
+(250,561,cs),
+(250,519,o),
+(272,489,o),
+(292,477,c),
+(298,494,l),
+(103,494,l),
+(93,449,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(318,487,o),
+(293,516,o),
+(293,560,cs),
+(293,605,o),
+(316,683,o),
+(385,683,cs),
+(428,683,o),
+(453,654,o),
+(453,610,cs),
+(453,565,o),
+(430,487,o),
+(361,487,cs)
+);
+}
+);
+width = 484;
+}
+);
+metricLeft = "=|n-canadian";
+metricRight = "=|n-canadian";
+note = uni14D2;
+unicode = 5330;
+},
+{
+glyphname = "le-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (520,254);
+},
+{
+name = top_center_can;
+pos = (565,507);
+},
+{
+name = top_left_can;
+pos = (152,507);
+},
+{
+name = top_right_can;
+pos = (770,507);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(450.008,0,ls),
+(672,0,o),
+(748,156,o),
+(748,291,cs),
+(748,412,o),
+(670,489,o),
+(539,489,cs),
+(116,489,l),
+(104,430,l),
+(526,430,ls),
+(629,430,o),
+(684,379,o),
+(684,288,cs),
+(684,186,o),
+(633,57,o),
+(456,57,cs),
+(414,57,l),
+(402,0,l)
+);
+}
+);
+width = 816;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D3;
+unicode = 5331;
+},
+{
+glyphname = "laai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (139,-207);
+ref = ring_top.canadian;
+}
+);
+width = 815;
+}
+);
+note = uni14D4;
+unicode = 5332;
+},
+{
+glyphname = "li-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (300,254);
+},
+{
+name = top_center_can;
+pos = (363,507);
+},
+{
+name = top_left_can;
+pos = (158,507);
+},
+{
+name = top_right_can;
+pos = (776,507);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(310,0,l),
+(322,57,l),
+(285,57,ls),
+(186,57,o),
+(131,111,o),
+(131,201,cs),
+(131,303,o),
+(184,430,o),
+(362,430,cs),
+(791,430,l),
+(803,489,l),
+(367,489,ls),
+(149,489,o),
+(68,339,o),
+(68,200,cs),
+(68,80,o),
+(145,0,o),
+(271,0,cs)
+);
+}
+);
+width = 816;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14D5;
+unicode = 5333;
+},
+{
+glyphname = "lii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (199,-207);
+ref = dot_top;
+}
+);
+width = 815;
+}
+);
+note = uni14D6;
+unicode = 5334;
+},
+{
+glyphname = "lo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (519,254);
+},
+{
+name = top_center_can;
+pos = (569,507);
+},
+{
+name = top_double;
+pos = (556,507);
+},
+{
+name = top_left_can;
+pos = (152,507);
+},
+{
+name = top_right_can;
+pos = (770,507);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(448,0,ls),
+(667,0,o),
+(748,150,o),
+(748,288,cs),
+(748,409,o),
+(670,489,o),
+(544,489,cs),
+(505,489,l),
+(494,431,l),
+(530,431,ls),
+(629,431,o),
+(685,378,o),
+(685,288,cs),
+(685,186,o),
+(631,58,o),
+(454,58,cs),
+(24,58,l),
+(12,0,l)
+);
+}
+);
+width = 816;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D7;
+unicode = 5335;
+},
+{
+glyphname = "loo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (405,-207);
+ref = dot_top;
+}
+);
+width = 815;
+}
+);
+note = uni14D8;
+unicode = 5336;
+},
+{
+glyphname = "ycreeloo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (229,-207);
+ref = doubledot_top;
+}
+);
+width = 815;
+}
+);
+note = uni14D9;
+unicode = 5337;
+},
+{
+glyphname = "la-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (300,254);
+},
+{
+name = top_center_can;
+pos = (357,507);
+},
+{
+name = top_left_can;
+pos = (158,507);
+},
+{
+name = top_right_can;
+pos = (775,507);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(699,0,l),
+(712,58,l),
+(289,58,ls),
+(187,58,o),
+(132,110,o),
+(132,201,cs),
+(132,303,o),
+(182,431,o),
+(359,431,cs),
+(401,431,l),
+(413,489,l),
+(365,489,ls),
+(143,489,o),
+(68,333,o),
+(68,198,cs),
+(68,77,o),
+(146,0,o),
+(276,0,cs)
+);
+}
+);
+width = 816;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14DA;
+unicode = 5338;
+},
+{
+glyphname = "laa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (192,-207);
+ref = dot_top;
+}
+);
+width = 815;
+}
+);
+note = uni14DB;
+unicode = 5339;
+},
+{
+glyphname = "lwe-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "le-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni14DC;
+unicode = 5340;
+},
+{
+glyphname = "lweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "le-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (815,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni14DD;
+unicode = 5341;
+},
+{
+glyphname = "lwi-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "li-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni14DE;
+unicode = 5342;
+},
+{
+glyphname = "lwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (815,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni14DF;
+unicode = 5343;
+},
+{
+glyphname = "lwii-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (419,-207);
+ref = dot_top;
+}
+);
+width = 1036;
+}
+);
+note = uni14E0;
+unicode = 5344;
+},
+{
+glyphname = "lwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (199,-207);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (815,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni14E1;
+unicode = 5345;
+},
+{
+glyphname = "lwo-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "lo-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni14E2;
+unicode = 5346;
+},
+{
+glyphname = "lwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (815,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni14E3;
+unicode = 5347;
+},
+{
+glyphname = "lwoo-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (625,-207);
+ref = dot_top;
+}
+);
+width = 1036;
+}
+);
+note = uni14E4;
+unicode = 5348;
+},
+{
+glyphname = "lwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (405,-207);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (815,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni14E5;
+unicode = 5349;
+},
+{
+glyphname = "lwa-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "la-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni14E6;
+unicode = 5350;
+},
+{
+glyphname = "lwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (815,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni14E7;
+unicode = 5351;
+},
+{
+glyphname = "lwaa-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (413,-207);
+ref = dot_top;
+}
+);
+width = 1036;
+}
+);
+note = uni14E8;
+unicode = 5352;
+},
+{
+glyphname = "lwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (192,-207);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (815,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni14E9;
+unicode = 5353;
+},
+{
+glyphname = "l-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(457,357,l),
+(466,401,l),
+(274,401,ls),
+(208,401,o),
+(174,435,o),
+(174,496,cs),
+(174,569,o),
+(206,670,o),
+(328,670,cs),
+(349,670,l),
+(358,714,l),
+(333,714,ls),
+(190,714,o),
+(127,608,o),
+(127,494,cs),
+(127,407,o),
+(179,357,o),
+(272,357,cs)
+);
+}
+);
+width = 483;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "m-canadian";
+note = uni14EA;
+unicode = 5354;
+},
+{
+glyphname = "lWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(336,357,l),
+(342,387,l),
+(158,466,l),
+(152,444,l),
+(371,521,l),
+(376,545,l),
+(190,621,l),
+(185,598,l),
+(404,679,l),
+(412,714,l),
+(401,714,l),
+(151,623,l),
+(147,603,l),
+(336,526,l),
+(340,545,l),
+(118,468,l),
+(114,448,l),
+(325,357,l)
+);
+}
+);
+width = 382;
+}
+);
+metricRight = "=|";
+note = uni14EB;
+unicode = 5355;
+},
+{
+glyphname = "mediall-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(525,-13,l),
+(534,30,l),
+(129,202,l),
+(123,171,l),
+(599,337,l),
+(606,370,l),
+(200,532,l),
+(194,504,l),
+(671,675,l),
+(682,727,l),
+(662,727,l),
+(140,539,l),
+(134,508,l),
+(541,345,l),
+(546,370,l),
+(70,205,l),
+(64,175,l),
+(506,-13,l)
+);
+}
+);
+width = 657;
+}
+);
+metricRight = "=|";
+note = uni14EC;
+unicode = 5356;
+},
+{
+glyphname = "se-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (212,714);
+},
+{
+name = top_right_can;
+pos = (519,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(400,0,l),
+(469,325,l),
+(433,325,ls),
+(258,325,o),
+(180,419,o),
+(221,608,cs),
+(244,714,l),
+(180,714,l),
+(157,604,ls),
+(113,395,o),
+(215,267,o),
+(419,267,cs),
+(441,267,l),
+(398,292,l),
+(336,0,l)
+);
+}
+);
+width = 535;
+}
+);
+note = uni14ED;
+unicode = 5357;
+},
+{
+glyphname = "saai-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (300,0);
+ref = ring_top.canadian;
+}
+);
+width = 535;
+}
+);
+note = uni14EE;
+unicode = 5358;
+},
+{
+glyphname = "si-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (215,714);
+},
+{
+name = top_right_can;
+pos = (523,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(95,0,l),
+(157,293,l),
+(106,267,l),
+(149,267,ls),
+(347,267,o),
+(481,373,o),
+(529,599,cs),
+(554,714,l),
+(490,714,l),
+(467,606,ls),
+(426,418,o),
+(316,325,o),
+(153,325,cs),
+(100,325,l),
+(31,0,l)
+);
+}
+);
+width = 534;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+unicode = 5359;
+},
+{
+glyphname = "sii-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (359,0);
+ref = dot_top;
+}
+);
+width = 535;
+}
+);
+note = uni14F0;
+unicode = 5360;
+},
+{
+glyphname = "so-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (520,714);
+},
+{
+name = top_left_can;
+pos = (212,714);
+},
+{
+name = top_right_can;
+pos = (520,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(92,0,l),
+(116,108,ls),
+(156,296,o),
+(266,389,o),
+(430,389,cs),
+(483,389,l),
+(552,714,l),
+(488,714,l),
+(425,421,l),
+(476,447,l),
+(433,447,ls),
+(236,447,o),
+(102,341,o),
+(53,115,cs),
+(28,0,l)
+);
+}
+);
+width = 535;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+unicode = 5361;
+},
+{
+glyphname = "soo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (355,0);
+ref = dot_top;
+}
+);
+width = 535;
+}
+);
+note = uni14F2;
+unicode = 5362;
+},
+{
+glyphname = "ycreesoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (194,0);
+ref = doubledot_top;
+}
+);
+width = 535;
+}
+);
+note = uni14F3;
+unicode = 5363;
+},
+{
+glyphname = "sa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (216,714);
+},
+{
+name = top_right_can;
+pos = (523,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(403,0,l),
+(426,110,ls),
+(471,319,o),
+(368,447,o),
+(164,447,cs),
+(142,447,l),
+(185,422,l),
+(247,714,l),
+(184,714,l),
+(114,389,l),
+(151,389,ls),
+(325,389,o),
+(403,295,o),
+(362,106,cs),
+(339,0,l)
+);
+}
+);
+width = 535;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+unicode = 5364;
+},
+{
+glyphname = "saa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+}
+);
+width = 535;
+}
+);
+note = uni14F5;
+unicode = 5365;
+},
+{
+glyphname = "swe-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "se-canadian";
+}
+);
+width = 755;
+}
+);
+note = uni14F6;
+unicode = 5366;
+},
+{
+glyphname = "sweWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "se-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (535,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 755;
+}
+);
+note = uni14F7;
+unicode = 5367;
+},
+{
+glyphname = "swi-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "si-canadian";
+}
+);
+width = 755;
+}
+);
+note = uni14F8;
+unicode = 5368;
+},
+{
+glyphname = "swiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (535,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 755;
+}
+);
+note = uni14F9;
+unicode = 5369;
+},
+{
+glyphname = "swii-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (579,0);
+ref = dot_top;
+}
+);
+width = 755;
+}
+);
+note = uni14FA;
+unicode = 5370;
+},
+{
+glyphname = "swiiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (359,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (535,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 755;
+}
+);
+note = uni14FB;
+unicode = 5371;
+},
+{
+glyphname = "swo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "so-canadian";
+}
+);
+width = 755;
+}
+);
+note = uni14FC;
+unicode = 5372;
+},
+{
+glyphname = "swoWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (535,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 755;
+}
+);
+note = uni14FD;
+unicode = 5373;
+},
+{
+glyphname = "swoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (576,0);
+ref = dot_top;
+}
+);
+width = 755;
+}
+);
+note = uni14FE;
+unicode = 5374;
+},
+{
+glyphname = "swooWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (355,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (535,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 755;
+}
+);
+note = uni14FF;
+unicode = 5375;
+},
+{
+glyphname = "swa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "sa-canadian";
+}
+);
+width = 755;
+}
+);
+note = uni1500;
+unicode = 5376;
+},
+{
+glyphname = "swaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (535,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 755;
+}
+);
+note = uni1501;
+unicode = 5377;
+},
+{
+glyphname = "swaa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (272,0);
+ref = dot_top;
+}
+);
+width = 755;
+}
+);
+note = uni1502;
+unicode = 5378;
+},
+{
+glyphname = "swaaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (535,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 755;
+}
+);
+note = uni1503;
+unicode = 5379;
+},
+{
+glyphname = "swaaNaskapi-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (221,0);
+ref = "sa-canadian";
+}
+);
+width = 756;
+}
+);
+note = uni1504;
+unicode = 5380;
+},
+{
+glyphname = "s-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(311,357,l),
+(323,413,ls),
+(347,524,o),
+(291,593,o),
+(181,593,cs),
+(166,593,l),
+(186,566,l),
+(218,714,l),
+(170,714,l),
+(136,552,l),
+(167,552,ls),
+(256,552,o),
+(295,506,o),
+(276,415,cs),
+(263,357,l)
+);
+}
+);
+width = 357;
+}
+);
+metricRight = "=|";
+note = uni1505;
+unicode = 5381;
+},
+{
+color = 6;
+glyphname = "sAthapascan-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(278.993,183,o),
+(321,230,o),
+(321,290,cs),
+(321,329,o),
+(301,356,o),
+(261,372,cs),
+(200,394,ls),
+(171,405,o),
+(160,423,o),
+(160,447,cs),
+(160,487,o),
+(188,515,o),
+(244,515,cs),
+(295,515,o),
+(320,491,o),
+(311,444,c),
+(354,444,l),
+(365,507,o),
+(323,552,o),
+(246,552,cs),
+(159,552,o),
+(117,503,o),
+(117,444,cs),
+(117,403,o),
+(143,374,o),
+(176,361,cs),
+(237,339,ls),
+(268,327,o),
+(278,311,o),
+(278,287,cs),
+(278,247,o),
+(250,220,o),
+(194,220,cs),
+(136,220,o),
+(114,245,o),
+(123,294,c),
+(80,294,l),
+(68,229,o),
+(106,183,o),
+(193,183,cs)
+);
+}
+);
+width = 383;
+}
+);
+metricRight = "=|";
+note = uni1506;
+unicode = 5382;
+},
+{
+glyphname = "sw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,357,l),
+(153,412,ls),
+(174,510,o),
+(223,552,o),
+(316,552,cs),
+(352,552,l),
+(387,714,l),
+(339,714,l),
+(308,569,l),
+(340,593,l),
+(309,593,ls),
+(197,593,o),
+(131,535,o),
+(107,417,cs),
+(94,357,l)
+);
+}
+);
+width = 357;
+}
+);
+metricLeft = "=|s-canadian";
+metricRight = "=|s-canadian";
+note = uni1507;
+unicode = 5383;
+},
+{
+glyphname = "sBlackfoot-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(318,357,l),
+(328,401,l),
+(243,401,ls),
+(182,401,o),
+(158,432,o),
+(172,499,cs),
+(218,714,l),
+(170,714,l),
+(125,499,ls),
+(105,409,o),
+(146,357,o),
+(237,357,cs)
+);
+}
+);
+width = 345;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "m-canadian";
+note = uni1508;
+unicode = 5384;
+},
+{
+glyphname = "moosecreesk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(302,225,o),
+(346,331,o),
+(346,435,cs),
+(346,538,o),
+(300,592,o),
+(191,592,cs),
+(172,592,l),
+(187,569,l),
+(218,714,l),
+(171,714,l),
+(136,552,l),
+(183,552,ls),
+(279,552,o),
+(306,512,o),
+(302,419,c),
+(312,424,l),
+(307,463,o),
+(279,495,o),
+(227,495,cs),
+(137,495,o),
+(94,406,o),
+(94,335,cs),
+(94,269,o),
+(135,225,o),
+(204,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(161,262,o),
+(137,291,o),
+(137,335,cs),
+(137,387,o),
+(168,459,o),
+(231,459,cs),
+(273,459,o),
+(297,432,o),
+(297,388,cs),
+(297,332,o),
+(263,262,o),
+(205,262,cs)
+);
+}
+);
+width = 384;
+}
+);
+metricRight = "=|";
+note = uni1509;
+unicode = 5385;
+},
+{
+glyphname = "skwNaskapi-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(295,225,o),
+(341,314,o),
+(341,389,cs),
+(341,453,o),
+(304,495,o),
+(245,495,cs),
+(199,495,o),
+(159,466,o),
+(142,417,c),
+(158,429,l),
+(188,511,o),
+(239,552,o),
+(325,552,cs),
+(379,552,l),
+(413,714,l),
+(365,714,l),
+(334,568,l),
+(361,592,l),
+(327,592,ls),
+(156,592,o),
+(97,437,o),
+(97,340,cs),
+(97,270,o),
+(136,225,o),
+(204,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(163,262,o),
+(140,291,o),
+(140,335,cs),
+(140,387,o),
+(170,459,o),
+(232,459,cs),
+(274,459,o),
+(298,432,o),
+(298,388,cs),
+(298,332,o),
+(265,262,o),
+(207,262,cs)
+);
+}
+);
+width = 386;
+}
+);
+metricLeft = "=|moosecreesk-canadian";
+metricRight = "=|moosecreesk-canadian";
+note = uni150A;
+unicode = 5386;
+},
+{
+glyphname = "swNaskapi-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(292,184,l),
+(303,236,ls),
+(327,347,o),
+(277,413,o),
+(167,413,cs),
+(146,413,l),
+(162,388,l),
+(193,531,l),
+(146,531,l),
+(112,373,l),
+(152,373,ls),
+(241,373,o),
+(275,332,o),
+(256,237,cs),
+(244,184,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(276,65,o),
+(294,84,o),
+(294,108,cs),
+(294,131,o),
+(276,150,o),
+(252,150,cs),
+(229,150,o),
+(209,131,o),
+(209,108,cs),
+(209,84,o),
+(229,65,o),
+(252,65,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(210,564,o),
+(228,583,o),
+(228,606,cs),
+(228,631,o),
+(210,649,o),
+(186,649,cs),
+(162,649,o),
+(143,631,o),
+(143,606,cs),
+(143,583,o),
+(162,564,o),
+(186,564,cs)
+);
+}
+);
+width = 389;
+}
+);
+metricRight = "=|";
+note = uni150B;
+unicode = 5387;
+},
+{
+glyphname = "spwaNaskapi-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(546,0,l),
+(557,52,l),
+(130,365,l),
+(124,336,l),
+(684,649,l),
+(698,714,l),
+(678,714,l),
+(65,371,l),
+(59,343,l),
+(526,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(224,506,o),
+(242,526,o),
+(242,549,cs),
+(242,574,o),
+(224,593,o),
+(199,593,cs),
+(176,593,o),
+(156,574,o),
+(156,549,cs),
+(156,526,o),
+(176,506,o),
+(199,506,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(419,618,l),
+(428,661,ls),
+(444,738,o),
+(410,786,o),
+(336,786,cs),
+(314,786,l),
+(337,766,l),
+(358,866,l),
+(312,866,l),
+(287,748,l),
+(317,748,ls),
+(375,748,o),
+(395,720,o),
+(382,659,cs),
+(373,618,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(616,724,o),
+(635,743,o),
+(635,767,cs),
+(635,791,o),
+(616,810,o),
+(592,810,cs),
+(568,810,o),
+(549,791,o),
+(549,767,cs),
+(549,743,o),
+(568,724,o),
+(592,724,cs)
+);
+}
+);
+width = 657;
+}
+);
+metricRight = "pa-canadian";
+metricWidth = "pa-canadian";
+note = uni150C;
+unicode = 5388;
+},
+{
+glyphname = "stwaNaskapi-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (390,0);
+ref = "ta-canadian";
+}
+);
+width = 996;
+}
+);
+note = uni150D;
+unicode = 5389;
+},
+{
+glyphname = "skwaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (390,0);
+ref = "ka-canadian";
+}
+);
+width = 978;
+}
+);
+note = uni150E;
+unicode = 5390;
+},
+{
+glyphname = "scwaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (390,0);
+ref = "ca-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni150F;
+unicode = 5391;
+},
+{
+glyphname = "she-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (384,714);
+},
+{
+name = top_right_can;
+pos = (788,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(743,-13,o),
+(822,74,o),
+(854,233,cs),
+(870,309,l),
+(807,309,l),
+(791,234,ls),
+(764,107,o),
+(711,44,o),
+(619,44,cs),
+(521,44,o),
+(481,111,o),
+(502,249,cs),
+(535,457,ls),
+(562,632,o),
+(497,727,o),
+(360,727,cs),
+(233,727,o),
+(154,640,o),
+(122,481,cs),
+(106,405,l),
+(170,405,l),
+(185,480,ls),
+(212,607,o),
+(265,670,o),
+(357,670,cs),
+(455,670,o),
+(495,602,o),
+(474,465,cs),
+(441,258,ls),
+(413,82,o),
+(479,-13,o),
+(617,-13,cs)
+);
+}
+);
+width = 928;
+}
+);
+metricRight = "=|";
+note = uni1510;
+unicode = 5392;
+},
+{
+glyphname = "shi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (344,714);
+},
+{
+name = top_right_can;
+pos = (748,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(375,-13,o),
+(443,67,o),
+(490,239,cs),
+(550,466,ls),
+(588,609,o),
+(635,670,o),
+(728,670,cs),
+(825,670,o),
+(870,602,o),
+(840,462,cs),
+(828,405,l),
+(892,405,l),
+(902,454,ls),
+(938,623,o),
+(867,727,o),
+(729,727,cs),
+(603,727,o),
+(535,647,o),
+(489,475,cs),
+(428,247,ls),
+(390,105,o),
+(343,44,o),
+(250,44,cs),
+(153,44,o),
+(108,111,o),
+(138,252,cs),
+(150,309,l),
+(86,309,l),
+(76,260,ls),
+(39,90,o),
+(110,-13,o),
+(249,-13,cs)
+);
+}
+);
+width = 930;
+}
+);
+metricLeft = "she-canadian";
+metricRight = "she-canadian";
+note = uni1511;
+unicode = 5393;
+},
+{
+glyphname = "shii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (582,0);
+ref = dot_top;
+}
+);
+width = 928;
+}
+);
+note = uni1512;
+unicode = 5394;
+},
+{
+glyphname = "sho-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (531,507);
+},
+{
+name = top_left_can;
+pos = (336,507);
+},
+{
+name = top_right_can;
+pos = (725,507);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(298,43,l),
+(183,43,o),
+(119,87,o),
+(119,161,cs),
+(119,234,o),
+(164,297,o),
+(259,297,cs),
+(408,297,o),
+(523,134,o),
+(696,134,cs),
+(822,134,o),
+(895,220,o),
+(895,329,cs),
+(895,434,o),
+(808,501,o),
+(665,501,c),
+(654,446,l),
+(769,445,o),
+(833,401,o),
+(833,328,cs),
+(833,255,o),
+(788,192,o),
+(692,192,cs),
+(543,192,o),
+(429,354,o),
+(255,354,cs),
+(129,354,o),
+(57,268,o),
+(57,160,cs),
+(57,55,o),
+(144,-12,o),
+(286,-13,c)
+);
+}
+);
+width = 952;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1513;
+unicode = 5395;
+},
+{
+glyphname = "shoo-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (367,-207);
+ref = dot_top;
+}
+);
+width = 951;
+}
+);
+note = uni1514;
+unicode = 5396;
+},
+{
+glyphname = "sha-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (533,507);
+},
+{
+name = top_left_can;
+pos = (337,507);
+},
+{
+name = top_right_can;
+pos = (727,507);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(738,-15,o),
+(869,55,o),
+(869,203,cs),
+(869,293,o),
+(806,354,o),
+(700,354,cs),
+(545,354,o),
+(392,192,o),
+(260,192,cs),
+(188,192,o),
+(146,229,o),
+(146,289,cs),
+(146,398,o),
+(241,446,o),
+(363,446,c),
+(374,501,l),
+(216,504,o),
+(84,434,o),
+(84,286,cs),
+(84,196,o),
+(148,134,o),
+(253,134,cs),
+(409,134,o),
+(561,297,o),
+(693,297,cs),
+(766,297,o),
+(807,260,o),
+(807,200,cs),
+(807,91,o),
+(713,42,o),
+(590,43,c),
+(578,-13,l)
+);
+}
+);
+width = 953;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1515;
+unicode = 5397;
+},
+{
+glyphname = "shaa-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (367,-207);
+ref = dot_top;
+}
+);
+width = 951;
+}
+);
+note = uni1516;
+unicode = 5398;
+},
+{
+glyphname = "shwe-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "she-canadian";
+}
+);
+width = 1148;
+}
+);
+note = uni1517;
+unicode = 5399;
+},
+{
+glyphname = "shweWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "she-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (928,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1148;
+}
+);
+note = uni1518;
+unicode = 5400;
+},
+{
+glyphname = "shwi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "shi-canadian";
+}
+);
+width = 1148;
+}
+);
+note = uni1519;
+unicode = 5401;
+},
+{
+glyphname = "shwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (928,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1148;
+}
+);
+note = uni151A;
+unicode = 5402;
+},
+{
+glyphname = "shwii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (802,0);
+ref = dot_top;
+}
+);
+width = 1148;
+}
+);
+note = uni151B;
+unicode = 5403;
+},
+{
+glyphname = "shwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (582,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (928,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1148;
+}
+);
+note = uni151C;
+unicode = 5404;
+},
+{
+glyphname = "shwo-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "sho-canadian";
+}
+);
+width = 1172;
+}
+);
+note = uni151D;
+unicode = 5405;
+},
+{
+glyphname = "shwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (951,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1172;
+}
+);
+note = uni151E;
+unicode = 5406;
+},
+{
+glyphname = "shwoo-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (587,-207);
+ref = dot_top;
+}
+);
+width = 1172;
+}
+);
+note = uni151F;
+unicode = 5407;
+},
+{
+glyphname = "shwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (367,-207);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (951,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1172;
+}
+);
+note = uni1520;
+unicode = 5408;
+},
+{
+glyphname = "shwa-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "sha-canadian";
+}
+);
+width = 1172;
+}
+);
+note = uni1521;
+unicode = 5409;
+},
+{
+glyphname = "shwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (951,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1172;
+}
+);
+note = uni1522;
+unicode = 5410;
+},
+{
+glyphname = "shwaa-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (587,-207);
+ref = dot_top;
+}
+);
+width = 1172;
+}
+);
+note = uni1523;
+unicode = 5411;
+},
+{
+glyphname = "shwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (367,-207);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (951,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1172;
+}
+);
+note = uni1524;
+unicode = 5412;
+},
+{
+glyphname = "sh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(610,296,o),
+(710,356,o),
+(710,472,cs),
+(710,541,o),
+(661,589,o),
+(580,589,cs),
+(466,589,o),
+(367,479,o),
+(268,479,cs),
+(215,479,o),
+(184,507,o),
+(184,553,cs),
+(184,637,o),
+(256,681,o),
+(356,678,c),
+(365,722,l),
+(237,727,o),
+(136,667,o),
+(136,550,cs),
+(136,481,o),
+(185,433,o),
+(266,433,cs),
+(381,433,o),
+(480,544,o),
+(578,544,cs),
+(631,544,o),
+(662,515,o),
+(662,470,cs),
+(662,387,o),
+(592,341,o),
+(491,344,c),
+(483,301,l)
+);
+}
+);
+width = 733;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni1525;
+unicode = 5413;
+},
+{
+glyphname = "ye-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (656,357);
+},
+{
+name = top_left_can;
+pos = (182,714);
+},
+{
+name = top_right_can;
+pos = (556,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(435,0,l),
+(504,321,l),
+(139,321,l),
+(141,289,l),
+(592,684,l),
+(553,726,l),
+(59,290,l),
+(54,264,l),
+(428,264,l),
+(372,0,l)
+);
+}
+);
+width = 569;
+}
+);
+note = uni1526;
+unicode = 5414;
+},
+{
+glyphname = "yaai-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-4,0);
+ref = ring_top.canadian;
+}
+);
+width = 569;
+}
+);
+note = uni1527;
+unicode = 5415;
+},
+{
+glyphname = "yi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (220,714);
+},
+{
+name = top_right_can;
+pos = (595,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(93,0,l),
+(150,264,l),
+(524,264,l),
+(529,290,l),
+(212,726,l),
+(165,692,l),
+(461,290,l),
+(463,321,l),
+(98,321,l),
+(30,0,l)
+);
+}
+);
+width = 569;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni1528;
+unicode = 5416;
+},
+{
+glyphname = "yii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (56,0);
+ref = dot_top;
+}
+);
+width = 569;
+}
+);
+note = uni1529;
+unicode = 5417;
+},
+{
+glyphname = "yo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (656,357);
+},
+{
+name = top_double;
+pos = (556,714);
+},
+{
+name = top_left_can;
+pos = (181,714);
+},
+{
+name = top_right_can;
+pos = (556,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(452,22,l),
+(156,424,l),
+(154,393,l),
+(519,393,l),
+(587,714,l),
+(523,714,l),
+(467,450,l),
+(93,450,l),
+(87,424,l),
+(405,-12,l)
+);
+}
+);
+width = 569;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152A;
+unicode = 5418;
+},
+{
+glyphname = "yoo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (391,0);
+ref = dot_top;
+}
+);
+width = 569;
+}
+);
+note = uni152B;
+unicode = 5419;
+},
+{
+glyphname = "ycreeyoo-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (229,0);
+ref = doubledot_top;
+}
+);
+width = 569;
+}
+);
+note = uni152C;
+unicode = 5420;
+},
+{
+glyphname = "ya-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (213,714);
+},
+{
+name = top_right_can;
+pos = (587,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(558,424,l),
+(563,450,l),
+(189,450,l),
+(245,714,l),
+(181,714,l),
+(113,393,l),
+(478,393,l),
+(475,425,l),
+(24,30,l),
+(64,-12,l)
+);
+}
+);
+width = 569;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152D;
+unicode = 5421;
+},
+{
+glyphname = "yaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+}
+);
+width = 569;
+}
+);
+note = uni152E;
+unicode = 5422;
+},
+{
+glyphname = "ywe-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ye-canadian";
+}
+);
+width = 790;
+}
+);
+note = uni152F;
+unicode = 5423;
+},
+{
+glyphname = "yweWestCree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ye-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (569,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 790;
+}
+);
+note = uni1530;
+unicode = 5424;
+},
+{
+glyphname = "ywi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "yi-canadian";
+}
+);
+width = 790;
+}
+);
+note = uni1531;
+unicode = 5425;
+},
+{
+glyphname = "ywiWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (569,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 790;
+}
+);
+note = uni1532;
+unicode = 5426;
+},
+{
+glyphname = "ywii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (276,0);
+ref = dot_top;
+}
+);
+width = 790;
+}
+);
+note = uni1533;
+unicode = 5427;
+},
+{
+glyphname = "ywiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (56,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (569,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 790;
+}
+);
+note = uni1534;
+unicode = 5428;
+},
+{
+glyphname = "ywo-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "yo-canadian";
+}
+);
+width = 790;
+}
+);
+note = uni1535;
+unicode = 5429;
+},
+{
+glyphname = "ywoWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (569,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 790;
+}
+);
+note = uni1536;
+unicode = 5430;
+},
+{
+glyphname = "ywoo-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (612,0);
+ref = dot_top;
+}
+);
+width = 790;
+}
+);
+note = uni1537;
+unicode = 5431;
+},
+{
+glyphname = "ywooWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (391,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (569,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 790;
+}
+);
+note = uni1538;
+unicode = 5432;
+},
+{
+glyphname = "ywa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ya-canadian";
+}
+);
+width = 790;
+}
+);
+note = uni1539;
+unicode = 5433;
+},
+{
+glyphname = "ywaWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (569,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 790;
+}
+);
+note = uni153A;
+unicode = 5434;
+},
+{
+glyphname = "ywaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (270,0);
+ref = dot_top;
+}
+);
+width = 790;
+}
+);
+note = uni153B;
+unicode = 5435;
+},
+{
+glyphname = "ywaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (569,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 790;
+}
+);
+note = uni153C;
+unicode = 5436;
+},
+{
+glyphname = "ywaaNaskapi-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (221,0);
+ref = "ya-canadian";
+}
+);
+width = 790;
+}
+);
+note = uni153D;
+unicode = 5437;
+},
+{
+glyphname = "y-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(371,565,l),
+(374,582,l),
+(191,582,l),
+(219,714,l),
+(172,714,l),
+(135,542,l),
+(319,542,l),
+(313,569,l),
+(99,379,l),
+(128,348,l)
+);
+}
+);
+width = 346;
+}
+);
+note = uni153E;
+unicode = 5438;
+},
+{
+glyphname = "biblecreey-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(131,357,l),
+(266,661,l),
+(239,661,l),
+(273,357,l),
+(300,357,l),
+(464,661,l),
+(435,661,l),
+(443,357,l),
+(484,357,l),
+(487,370,l),
+(479,714,l),
+(448,714,l),
+(282,407,l),
+(309,407,l),
+(275,714,l),
+(244,714,l),
+(89,370,l),
+(86,357,l)
+);
+}
+);
+width = 522;
+}
+);
+metricRight = "=|";
+note = uni153F;
+unicode = 5439;
+},
+{
+glyphname = "yWestCree-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(244,200,l),
+(275,346,l),
+(412,346,l),
+(421,391,l),
+(285,391,l),
+(315,535,l),
+(268,535,l),
+(238,391,l),
+(100,391,l),
+(90,346,l),
+(228,346,l),
+(197,200,l)
+);
+}
+);
+width = 458;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1540;
+unicode = 5440;
+},
+{
+glyphname = "yiSayisi-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (40,189);
+ref = "fullstop-canadian";
+}
+);
+width = 347;
+}
+);
+metricLeft = "fullstop-canadian";
+metricWidth = "fullstop-canadian";
+note = uni1541;
+unicode = 5441;
+},
+{
+glyphname = "re-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (355,507);
+},
+{
+name = top_left_can;
+pos = (167,507);
+},
+{
+name = top_right_can;
+pos = (819,507);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(399,-13,o),
+(480,65,o),
+(515,225,cs),
+(559,431,l),
+(836,431,l),
+(848,489,l),
+(508,489,l),
+(453,228,ls),
+(425,102,o),
+(368,44,o),
+(275,44,cs),
+(164,44,o),
+(115,113,o),
+(142,239,cs),
+(196,489,l),
+(132,489,l),
+(80,246,ls),
+(46,87,o),
+(121,-13,o),
+(271,-13,cs)
+);
+}
+);
+width = 860;
+}
+);
+metricRight = "=|ne-canadian";
+note = uni1542;
+unicode = 5442;
+},
+{
+glyphname = "reRCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (616,507);
+},
+{
+name = top_left_can;
+pos = (152,507);
+},
+{
+name = top_right_can;
+pos = (804,507);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(660,-13,o),
+(742,65,o),
+(776,225,cs),
+(832,489,l),
+(768,489,l),
+(713,228,ls),
+(685,102,o),
+(628,44,o),
+(535,44,cs),
+(424,44,o),
+(375,113,o),
+(402,239,cs),
+(456,489,l),
+(116,489,l),
+(104,431,l),
+(381,431,l),
+(341,246,ls),
+(307,87,o),
+(383,-13,o),
+(532,-13,cs)
+);
+}
+);
+width = 860;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1543;
+unicode = 5443;
+},
+{
+glyphname = "leWestCree-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (616,507);
+},
+{
+name = top_left_can;
+pos = (151,507);
+},
+{
+name = top_right_can;
+pos = (804,507);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(352,0,l),
+(407,260,ls),
+(434,386,o),
+(492,445,o),
+(585,445,cs),
+(696,445,o),
+(744,376,o),
+(718,250,cs),
+(664,0,l),
+(728,0,l),
+(780,243,ls),
+(814,402,o),
+(738,501,o),
+(589,501,cs),
+(461,501,o),
+(379,424,o),
+(345,264,cs),
+(301,58,l),
+(24,58,l),
+(12,0,l)
+);
+}
+);
+width = 860;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+unicode = 5444;
+},
+{
+glyphname = "raai-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (132,-207);
+ref = ring_top.canadian;
+}
+);
+width = 860;
+}
+);
+note = uni1545;
+unicode = 5445;
+},
+{
+glyphname = "ri-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (356,507);
+},
+{
+name = top_left_can;
+pos = (168,507);
+},
+{
+name = top_right_can;
+pos = (820,507);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(92,0,l),
+(147,260,ls),
+(174,386,o),
+(232,445,o),
+(331,445,cs),
+(436,445,o),
+(484,375,o),
+(458,250,cs),
+(404,0,l),
+(744,0,l),
+(756,58,l),
+(479,58,l),
+(519,243,ls),
+(553,402,o),
+(477,501,o),
+(334,501,cs),
+(200,501,o),
+(118,424,o),
+(84,264,cs),
+(28,0,l)
+);
+}
+);
+width = 860;
+}
+);
+metricLeft = "re-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+unicode = 5446;
+},
+{
+glyphname = "rii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (191,-207);
+ref = dot_top;
+}
+);
+width = 860;
+}
+);
+note = uni1547;
+unicode = 5447;
+},
+{
+glyphname = "ro-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (332,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(94,0,l),
+(156,293,l),
+(122,264,l),
+(241,264,ls),
+(426,264,o),
+(526,379,o),
+(526,528,cs),
+(526,641,o),
+(450,714,o),
+(326,714,cs),
+(183,714,l),
+(171,656,l),
+(316,656,ls),
+(410,656,o),
+(464,607,o),
+(464,526,cs),
+(464,410,o),
+(386,322,o),
+(248,322,cs),
+(99,322,l),
+(31,0,l)
+);
+}
+);
+width = 539;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1548;
+unicode = 5448;
+},
+{
+glyphname = "roo-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (169,0);
+ref = dot_top;
+}
+);
+width = 540;
+}
+);
+note = uni1549;
+unicode = 5449;
+},
+{
+glyphname = "loWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (361,714);
+},
+{
+name = top_left_can;
+pos = (216,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(186,0,ls),
+(371,0,o),
+(471,115,o),
+(471,264,cs),
+(471,376,o),
+(395,450,o),
+(271,450,cs),
+(161,450,l),
+(185,419,l),
+(247,714,l),
+(183,714,l),
+(115,392,l),
+(261,392,ls),
+(355,392,o),
+(409,343,o),
+(409,262,cs),
+(409,146,o),
+(331,58,o),
+(193,58,cs),
+(44,58,l),
+(32,0,l)
+);
+}
+);
+width = 540;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+unicode = 5450;
+},
+{
+glyphname = "ra-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (406,714);
+},
+{
+name = top_right_can;
+pos = (524,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(404,0,l),
+(472,322,l),
+(327,322,ls),
+(233,322,o),
+(179,371,o),
+(179,452,cs),
+(179,568,o),
+(257,656,o),
+(395,656,cs),
+(544,656,l),
+(556,714,l),
+(402,714,ls),
+(217,714,o),
+(117,599,o),
+(117,450,cs),
+(117,338,o),
+(193,264,o),
+(317,264,cs),
+(427,264,l),
+(403,295,l),
+(340,0,l)
+);
+}
+);
+width = 540;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+unicode = 5451;
+},
+{
+glyphname = "raa-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (241,0);
+ref = dot_top;
+}
+);
+width = 540;
+}
+);
+note = uni154C;
+unicode = 5452;
+},
+{
+glyphname = "laWestCree-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (525,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(404,0,l),
+(416,58,l),
+(272,58,ls),
+(178,58,o),
+(124,107,o),
+(124,188,cs),
+(124,304,o),
+(202,392,o),
+(339,392,cs),
+(488,392,l),
+(557,714,l),
+(493,714,l),
+(431,421,l),
+(466,450,l),
+(347,450,ls),
+(161,450,o),
+(61,335,o),
+(61,186,cs),
+(61,73,o),
+(138,0,o),
+(262,0,cs)
+);
+}
+);
+width = 540;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+unicode = 5453;
+},
+{
+glyphname = "rwaa-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (462,0);
+ref = dot_top;
+}
+);
+width = 760;
+}
+);
+note = uni154E;
+unicode = 5454;
+},
+{
+glyphname = "rwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (241,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (540,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 760;
+}
+);
+note = uni154F;
+unicode = 5455;
+},
+{
+glyphname = "r-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(284,357,l),
+(320,527,l),
+(251,527,ls),
+(203,527,o),
+(181,546,o),
+(181,583,cs),
+(181,637,o),
+(210,674,o),
+(281,674,cs),
+(351,674,l),
+(360,714,l),
+(289,714,ls),
+(193,714,o),
+(137,667,o),
+(137,582,cs),
+(137,525,o),
+(175,487,o),
+(243,487,cs),
+(291,487,l),
+(268,507,l),
+(237,357,l)
+);
+}
+);
+width = 330;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni1550;
+unicode = 5456;
+},
+{
+glyphname = "rWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(170,714,l),
+(164,684,l),
+(349,605,l),
+(354,627,l),
+(135,550,l),
+(131,526,l),
+(316,450,l),
+(321,473,l),
+(102,392,l),
+(94,357,l),
+(105,357,l),
+(355,448,l),
+(360,468,l),
+(171,545,l),
+(167,526,l),
+(388,603,l),
+(393,623,l),
+(181,714,l)
+);
+}
+);
+width = 383;
+}
+);
+metricLeft = "=|lWestCree-canadian";
+metricRight = "=|lWestCree-canadian";
+note = uni1551;
+unicode = 5457;
+},
+{
+glyphname = "rMedial-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(43,-13,l),
+(565,175,l),
+(571,206,l),
+(164,369,l),
+(159,344,l),
+(635,509,l),
+(641,539,l),
+(199,727,l),
+(180,727,l),
+(171,684,l),
+(576,512,l),
+(582,543,l),
+(106,377,l),
+(99,344,l),
+(505,182,l),
+(511,210,l),
+(34,39,l),
+(23,-13,l)
+);
+}
+);
+width = 657;
+}
+);
+metricLeft = "mediall-canadian";
+metricRight = "mediall-canadian";
+note = uni1552;
+unicode = 5458;
+},
+{
+glyphname = "fe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(331,0,l),
+(817,694,l),
+(821,714,l),
+(764,714,l),
+(319,68,l),
+(332,68,l),
+(236,380,l),
+(204,376,l),
+(227,348,o),
+(259,333,o),
+(300,333,cs),
+(431,333,o),
+(488,477,o),
+(488,573,cs),
+(488,664,o),
+(436,727,o),
+(346,727,cs),
+(214,727,o),
+(157,589,o),
+(157,484,cs),
+(157,447,o),
+(164,411,o),
+(178,371,cs),
+(302,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(244,380,o),
+(211,420,o),
+(211,489,cs),
+(211,555,o),
+(244,677,o),
+(343,677,cs),
+(401,677,o),
+(435,636,o),
+(435,571,cs),
+(435,502,o),
+(402,380,o),
+(301,380,cs)
+);
+}
+);
+width = 757;
+}
+);
+metricRight = "e-canadian";
+note = uni1553;
+unicode = 5459;
+},
+{
+glyphname = "faai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (242,0);
+ref = ring_top.canadian;
+}
+);
+width = 759;
+}
+);
+note = uni1554;
+unicode = 5460;
+},
+{
+glyphname = "fi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (465,714);
+},
+{
+name = top_left_can;
+pos = (228,714);
+},
+{
+name = top_right_can;
+pos = (733,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(362,-13,o),
+(414,131,o),
+(414,225,cs),
+(414,318,o),
+(362,382,o),
+(279,382,cs),
+(251,382,o),
+(222,372,o),
+(196,351,c),
+(231,347,l),
+(462,646,l),
+(444,647,l),
+(621,0,l),
+(670,0,l),
+(674,20,l),
+(480,714,l),
+(451,714,l),
+(160,347,ls),
+(113,287,o),
+(84,218,o),
+(84,142,cs),
+(84,49,o),
+(138,-13,o),
+(226,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(170,37,o),
+(138,77,o),
+(138,145,cs),
+(138,212,o),
+(171,334,o),
+(270,334,cs),
+(329,334,o),
+(361,292,o),
+(361,225,cs),
+(361,156,o),
+(328,37,o),
+(228,37,cs)
+);
+}
+);
+width = 758;
+}
+);
+metricLeft = "fe-canadian";
+metricRight = "e-canadian";
+note = uni1555;
+unicode = 5461;
+},
+{
+glyphname = "fii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (301,0);
+ref = dot_top;
+}
+);
+width = 759;
+}
+);
+note = uni1556;
+unicode = 5462;
+},
+{
+glyphname = "fo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (324,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(67,0,l),
+(679,343,l),
+(685,371,l),
+(429,667,ls),
+(396,705,o),
+(357,727,o),
+(307,727,cs),
+(176,727,o),
+(122,585,o),
+(120,491,cs),
+(118,395,o),
+(172,331,o),
+(258,331,cs),
+(378,331,o),
+(443,451,o),
+(444,557,cs),
+(445,588,o),
+(440,615,o),
+(431,637,c),
+(410,608,l),
+(623,360,l),
+(627,374,l),
+(59,57,l),
+(47,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(205,380,o),
+(173,422,o),
+(174,493,cs),
+(175,562,o),
+(208,677,o),
+(306,677,cs),
+(364,677,o),
+(397,635,o),
+(396,566,cs),
+(395,495,o),
+(363,380,o),
+(264,380,cs)
+);
+}
+);
+width = 695;
+}
+);
+metricRight = "o-canadian";
+note = uni1557;
+unicode = 5463;
+},
+{
+glyphname = "foo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "fo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (160,0);
+ref = dot_top;
+}
+);
+width = 695;
+}
+);
+note = uni1558;
+unicode = 5464;
+},
+{
+glyphname = "fa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (571,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(544,0,l),
+(554,48,l),
+(121,366,l),
+(119,349,l),
+(438,611,l),
+(422,645,l),
+(386,598,o),
+(369,533,o),
+(369,484,cs),
+(369,393,o),
+(424,330,o),
+(513,330,cs),
+(640,330,o),
+(696,473,o),
+(696,569,cs),
+(696,665,o),
+(642,727,o),
+(556,727,cs),
+(514,727,o),
+(475,711,o),
+(436,678,cs),
+(65,371,l),
+(59,343,l),
+(524,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(453,380,o),
+(420,420,o),
+(420,488,cs),
+(420,555,o),
+(454,677,o),
+(553,677,cs),
+(611,677,o),
+(644,636,o),
+(644,570,cs),
+(644,502,o),
+(611,380,o),
+(511,380,cs)
+);
+}
+);
+width = 695;
+}
+);
+metricRight = "=|fo-canadian";
+note = uni1559;
+unicode = 5465;
+},
+{
+glyphname = "faa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (407,0);
+ref = dot_top;
+}
+);
+width = 695;
+}
+);
+note = uni155A;
+unicode = 5466;
+},
+{
+glyphname = "fwaa-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (627,0);
+ref = dot_top;
+}
+);
+width = 916;
+}
+);
+note = uni155B;
+unicode = 5467;
+},
+{
+glyphname = "fwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (407,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (695,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 916;
+}
+);
+note = uni155C;
+unicode = 5468;
+},
+{
+glyphname = "f-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(368,357,l),
+(375,390,l),
+(165,544,l),
+(163,529,l),
+(313,655,l),
+(313,687,l),
+(294,667,o),
+(281,627,o),
+(281,598,cs),
+(281,553,o),
+(309,522,o),
+(351,522,cs),
+(414,522,o),
+(443,591,o),
+(443,643,cs),
+(443,691,o),
+(417,720,o),
+(375,720,cs),
+(352,720,o),
+(330,712,o),
+(306,692,cs),
+(128,544,l),
+(125,527,l),
+(355,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(327,552,o),
+(312,570,o),
+(312,600,cs),
+(312,641,o),
+(334,690,o),
+(373,690,cs),
+(397,690,o),
+(411,673,o),
+(411,643,cs),
+(411,602,o),
+(390,552,o),
+(352,552,cs)
+);
+}
+);
+width = 424;
+}
+);
+note = uni155D;
+unicode = 5469;
+},
+{
+glyphname = "the-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (839,357);
+},
+{
+name = top_center_can;
+pos = (466,714);
+},
+{
+name = top_left_can;
+pos = (212,714);
+},
+{
+name = top_right_can;
+pos = (720,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(511,-13,o),
+(611,82,o),
+(653,275,cs),
+(746,714,l),
+(682,714,l),
+(590,278,ls),
+(555,119,o),
+(477,46,o),
+(337,46,cs),
+(153,46,o),
+(119,154,o),
+(151,301,cs),
+(182,448,l),
+(158,435,l),
+(165,379,o),
+(206,327,o),
+(277,327,cs),
+(408,327,o),
+(462,469,o),
+(465,566,cs),
+(467,662,o),
+(415,727,o),
+(325,727,cs),
+(226,727,o),
+(164,656,o),
+(138,537,cs),
+(90,309,ls),
+(51,126,o),
+(113,-13,o),
+(336,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(220,377,o),
+(188,418,o),
+(188,486,cs),
+(188,553,o),
+(221,677,o),
+(321,677,cs),
+(378,677,o),
+(411,636,o),
+(411,570,cs),
+(411,501,o),
+(379,377,o),
+(278,377,cs)
+);
+}
+);
+width = 723;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155E;
+unicode = 5470;
+},
+{
+glyphname = "theNCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(511,-13,o),
+(612,83,o),
+(654,280,cs),
+(700,500,ls),
+(729,636,o),
+(675,727,o),
+(569,727,cs),
+(437,727,o),
+(380,587,o),
+(380,483,cs),
+(380,399,o),
+(424,327,o),
+(516,327,cs),
+(570,327,o),
+(617,357,o),
+(642,407,c),
+(622,426,l),
+(591,278,ls),
+(557,118,o),
+(478,46,o),
+(335,46,cs),
+(174,46,o),
+(116,133,o),
+(152,302,cs),
+(240,714,l),
+(176,714,l),
+(89,304,ls),
+(45,101,o),
+(137,-13,o),
+(333,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(466,377,o),
+(434,418,o),
+(434,486,cs),
+(434,553,o),
+(467,677,o),
+(566,677,cs),
+(623,677,o),
+(656,636,o),
+(656,570,cs),
+(656,501,o),
+(623,377,o),
+(523,377,cs)
+);
+}
+);
+width = 722;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155F;
+unicode = 5471;
+},
+{
+glyphname = "thi-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (460,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(333,-13,o),
+(390,127,o),
+(390,231,cs),
+(390,315,o),
+(346,387,o),
+(254,387,cs),
+(200,387,o),
+(153,357,o),
+(128,307,c),
+(148,288,l),
+(179,436,ls),
+(213,596,o),
+(292,668,o),
+(435,668,cs),
+(596,668,o),
+(654,581,o),
+(618,412,cs),
+(530,0,l),
+(594,0,l),
+(681,410,ls),
+(724,613,o),
+(633,727,o),
+(437,727,cs),
+(259,727,o),
+(158,631,o),
+(116,434,cs),
+(70,214,ls),
+(41,78,o),
+(95,-13,o),
+(201,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(147,37,o),
+(114,78,o),
+(114,144,cs),
+(114,213,o),
+(147,337,o),
+(247,337,cs),
+(304,337,o),
+(336,296,o),
+(336,228,cs),
+(336,161,o),
+(303,37,o),
+(204,37,cs)
+);
+}
+);
+width = 722;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1560;
+unicode = 5472;
+},
+{
+glyphname = "thiNCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (460,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(544,-13,o),
+(606,58,o),
+(632,177,cs),
+(680,405,ls),
+(719,588,o),
+(657,727,o),
+(434,727,cs),
+(259,727,o),
+(159,632,o),
+(117,439,cs),
+(24,0,l),
+(88,0,l),
+(180,436,ls),
+(214,595,o),
+(293,668,o),
+(433,668,cs),
+(617,668,o),
+(651,560,o),
+(619,413,cs),
+(588,266,l),
+(612,279,l),
+(605,335,o),
+(564,387,o),
+(493,387,cs),
+(362,387,o),
+(308,245,o),
+(305,148,cs),
+(303,52,o),
+(355,-13,o),
+(445,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(392,37,o),
+(359,78,o),
+(359,144,cs),
+(359,213,o),
+(392,337,o),
+(492,337,cs),
+(550,337,o),
+(582,296,o),
+(582,228,cs),
+(582,161,o),
+(549,37,o),
+(449,37,cs)
+);
+}
+);
+width = 722;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1561;
+unicode = 5473;
+},
+{
+glyphname = "thii-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "thi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (295,0);
+ref = dot_top;
+}
+);
+width = 722;
+}
+);
+note = uni1562;
+unicode = 5474;
+},
+{
+glyphname = "thiiNCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "thiNCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (295,0);
+ref = dot_top;
+}
+);
+width = 722;
+}
+);
+note = uni1563;
+unicode = 5475;
+},
+{
+glyphname = "tho-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (410,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(231,0,ls),
+(533,0,o),
+(636,250,o),
+(636,445,cs),
+(636,617,o),
+(539,727,o),
+(387,727,cs),
+(214,727,o),
+(129,593,o),
+(129,458,cs),
+(129,366,o),
+(181,304,o),
+(267,304,cs),
+(390,304,o),
+(451,438,o),
+(451,542,cs),
+(451,633,o),
+(398,690,o),
+(313,686,c),
+(310,664,l),
+(326,674,o),
+(352,679,o),
+(383,679,cs),
+(500,679,o),
+(574,594,o),
+(574,451,cs),
+(574,306,o),
+(513,58,o),
+(236,58,cs),
+(72,58,l),
+(60,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(214,353,o),
+(182,393,o),
+(182,459,cs),
+(182,525,o),
+(216,655,o),
+(315,655,cs),
+(371,655,o),
+(402,615,o),
+(402,550,cs),
+(402,483,o),
+(369,353,o),
+(270,353,cs)
+);
+}
+);
+width = 674;
+}
+);
+metricRight = "to-canadian";
+note = uni1564;
+unicode = 5476;
+},
+{
+glyphname = "thoo-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "tho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (245,0);
+ref = dot_top;
+}
+);
+width = 675;
+}
+);
+note = uni1565;
+unicode = 5477;
+},
+{
+glyphname = "tha-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (468,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(514,0,l),
+(526,58,l),
+(374,58,ls),
+(228,58,o),
+(149,135,o),
+(149,276,cs),
+(149,422,o),
+(227,678,o),
+(442,678,cs),
+(482,678,o),
+(522,669,o),
+(551,652,c),
+(530,683,l),
+(402,701,o),
+(331,569,o),
+(331,455,cs),
+(331,364,o),
+(382,304,o),
+(468,304,cs),
+(590,304,o),
+(656,434,o),
+(656,544,cs),
+(656,658,o),
+(577,726,o),
+(445,726,cs),
+(188,726,o),
+(86,454,o),
+(86,271,cs),
+(86,102,o),
+(186,0,o),
+(360,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(415,353,o),
+(382,393,o),
+(382,459,cs),
+(382,525,o),
+(416,655,o),
+(515,655,cs),
+(571,655,o),
+(603,615,o),
+(603,550,cs),
+(603,483,o),
+(569,353,o),
+(470,353,cs)
+);
+}
+);
+width = 676;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tho-canadian";
+note = uni1566;
+unicode = 5478;
+},
+{
+glyphname = "thaa-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (303,0);
+ref = dot_top;
+}
+);
+width = 675;
+}
+);
+note = uni1567;
+unicode = 5479;
+},
+{
+glyphname = "thwaa-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (524,0);
+ref = dot_top;
+}
+);
+width = 895;
+}
+);
+note = uni1568;
+unicode = 5480;
+},
+{
+glyphname = "thwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (303,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (675,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 895;
+}
+);
+note = uni1569;
+unicode = 5481;
+},
+{
+glyphname = "th-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(341,357,l),
+(350,397,l),
+(274,397,ls),
+(204,397,o),
+(169,433,o),
+(169,497,cs),
+(169,566,o),
+(207,688,o),
+(308,688,cs),
+(326,688,o),
+(346,683,o),
+(361,675,c),
+(343,696,l),
+(276,701,o),
+(249,632,o),
+(249,585,cs),
+(249,539,o),
+(276,509,o),
+(318,509,cs),
+(384,509,o),
+(411,584,o),
+(411,629,cs),
+(411,685,o),
+(373,720,o),
+(306,720,cs),
+(178,720,o),
+(126,585,o),
+(126,494,cs),
+(126,408,o),
+(178,357,o),
+(265,357,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(293,539,o),
+(279,556,o),
+(279,585,cs),
+(279,617,o),
+(294,676,o),
+(339,676,cs),
+(365,676,o),
+(380,659,o),
+(380,630,cs),
+(380,599,o),
+(365,539,o),
+(319,539,cs)
+);
+}
+);
+width = 395;
+}
+);
+metricLeft = "t-canadian";
+note = uni156A;
+unicode = 5482;
+},
+{
+glyphname = "tthe-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (825,357);
+},
+{
+name = top_center_can;
+pos = (456,714);
+},
+{
+name = top_left_can;
+pos = (208,714);
+},
+{
+name = top_right_can;
+pos = (705,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(501,-13,o),
+(602,79,o),
+(644,278,cs),
+(737,714,l),
+(675,714,l),
+(582,279,ls),
+(548,119,o),
+(470,47,o),
+(332,47,cs),
+(176,47,o),
+(114,130,o),
+(151,301,cs),
+(238,714,l),
+(176,714,l),
+(89,304,ls),
+(45,100,o),
+(137,-13,o),
+(329,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(417,405,l),
+(483,714,l),
+(430,714,l),
+(364,405,l)
+);
+}
+);
+width = 713;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156B;
+unicode = 5483;
+},
+{
+glyphname = "tthi-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(86,0,l),
+(179,435,ls),
+(213,595,o),
+(291,667,o),
+(429,667,cs),
+(584,667,o),
+(647,584,o),
+(610,413,cs),
+(523,0,l),
+(585,0,l),
+(672,410,ls),
+(716,614,o),
+(624,727,o),
+(432,727,cs),
+(260,727,o),
+(159,635,o),
+(117,436,cs),
+(24,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(331,0,l),
+(397,309,l),
+(344,309,l),
+(278,0,l)
+);
+}
+);
+width = 713;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156C;
+unicode = 5484;
+},
+{
+glyphname = "ttho-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (408,714);
+},
+{
+name = top_left_can;
+pos = (210,714);
+},
+{
+name = top_right_can;
+pos = (629,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(184.009,0,ls),
+(504,0,o),
+(590,272,o),
+(590,449,cs),
+(590,617,o),
+(493,714,o),
+(318,714,cs),
+(182,714,l),
+(170,656,l),
+(310,656,ls),
+(452,656,o),
+(526,583,o),
+(526,447,cs),
+(526,299,o),
+(458,58,o),
+(191,58,cs),
+(42,58,l),
+(30,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(336,331,l),
+(347,384,l),
+(112,384,l),
+(101,331,l)
+);
+}
+);
+width = 627;
+}
+);
+metricRight = "to-canadian";
+note = uni156D;
+unicode = 5485;
+},
+{
+glyphname = "ttha-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (424,714);
+},
+{
+name = top_left_can;
+pos = (199,714);
+},
+{
+name = top_right_can;
+pos = (611,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(493,0,l),
+(505,58,l),
+(364,58,ls),
+(222,58,o),
+(149,131,o),
+(149,267,cs),
+(149,417,o),
+(217,656,o),
+(483,656,cs),
+(632,656,l),
+(645,714,l),
+(490,714,ls),
+(171,714,o),
+(85,443,o),
+(85,265,cs),
+(85,97,o),
+(181,0,o),
+(356,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(561,331,l),
+(573,384,l),
+(338,384,l),
+(326,331,l)
+);
+}
+);
+width = 627;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|ttho-canadian";
+note = uni156E;
+unicode = 5486;
+},
+{
+glyphname = "tth-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(288,506,l),
+(271,506,l),
+(339,371,l),
+(378,391,l),
+(306,530,l),
+(298,513,l),
+(462,569,l),
+(449,607,l),
+(293,554,l),
+(306,546,l),
+(342,714,l),
+(299,714,l),
+(263,545,l),
+(279,553,l),
+(139,607,l),
+(124,569,l),
+(259,517,l),
+(257,534,l),
+(133,400,l),
+(163,371,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(692,506,l),
+(675,506,l),
+(743,371,l),
+(782,391,l),
+(710,530,l),
+(702,513,l),
+(866,568,l),
+(853,607,l),
+(697,554,l),
+(710,546,l),
+(746,714,l),
+(702,714,l),
+(667,545,l),
+(683,553,l),
+(542,607,l),
+(528,569,l),
+(663,517,l),
+(661,534,l),
+(536,400,l),
+(567,371,l)
+);
+}
+);
+width = 852;
+}
+);
+metricRight = "=|";
+note = uni156F;
+unicode = 5487;
+},
+{
+glyphname = "tye-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(502,-13,o),
+(602,82,o),
+(644,277,cs),
+(737,714,l),
+(675,714,l),
+(583,284,ls),
+(549,120,o),
+(470,47,o),
+(332,47,cs),
+(176,47,o),
+(114,130,o),
+(150,301,cs),
+(238.009,714,l),
+(176,714,l),
+(89,304,ls),
+(45,101,o),
+(137,-13,o),
+(330,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(477,426,o),
+(522,469,o),
+(541,558,cs),
+(574,714,l),
+(537,714,l),
+(505,564,ls),
+(490,495,o),
+(459,464,o),
+(405,464,cs),
+(349,464,o),
+(330,495,o),
+(345,566,cs),
+(376,714,l),
+(338,714,l),
+(307,565,ls),
+(289,477,o),
+(325,426,o),
+(404,426,cs)
+);
+}
+);
+width = 713;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1570;
+unicode = 5488;
+},
+{
+glyphname = "tyi-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(86.009,0,l),
+(178,430,ls),
+(212,594,o),
+(291,667,o),
+(429,667,cs),
+(585,667,o),
+(647,584,o),
+(611,413,cs),
+(523,0,l),
+(585,0,l),
+(672,410,ls),
+(716,613,o),
+(624,727,o),
+(431,727,cs),
+(259,727,o),
+(159,632,o),
+(117,437,cs),
+(24,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(224,0,l),
+(256,150,ls),
+(271,219,o),
+(302,250,o),
+(356,250,cs),
+(412,250,o),
+(431,219,o),
+(416,148,cs),
+(385,0,l),
+(422,0,l),
+(454,149,ls),
+(472,237,o),
+(436,288,o),
+(356,288,cs),
+(283,288,o),
+(239,245,o),
+(220,156,cs),
+(187,0,l)
+);
+}
+);
+width = 713;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1571;
+unicode = 5489;
+},
+{
+glyphname = "tyo-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(184,0,ls),
+(505,0,o),
+(591,272,o),
+(591,449,cs),
+(591,617,o),
+(493,714,o),
+(318,714,cs),
+(183,714,l),
+(171,656,l),
+(310,656,ls),
+(452,656,o),
+(527,583,o),
+(527,447,cs),
+(527,292,o),
+(452,58,o),
+(190,58,cs),
+(44,58,l),
+(32,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(166,217,ls),
+(284,217,o),
+(335,296,o),
+(337,381,cs),
+(338,453,o),
+(294,497,o),
+(217,497,cs),
+(137,497,l),
+(129,458,l),
+(208,458,ls),
+(266,458,o),
+(297,430,o),
+(296,380,cs),
+(296,320,o),
+(262,256,o),
+(171,256,cs),
+(86,256,l),
+(77,217,l)
+);
+}
+);
+width = 628;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1572;
+unicode = 5490;
+},
+{
+glyphname = "tya-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(492,0,l),
+(504,58,l),
+(366,58,ls),
+(224,58,o),
+(149,131,o),
+(149,267,cs),
+(149,422,o),
+(225,656,o),
+(486,656,cs),
+(632,656,l),
+(644,714,l),
+(493,714,ls),
+(172,714,o),
+(85,442,o),
+(85,265,cs),
+(85,97,o),
+(183,0,o),
+(358,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(539,217,l),
+(547,256,l),
+(469,256,ls),
+(411,256,o),
+(380,284,o),
+(380,334,cs),
+(381,394,o),
+(415,458,o),
+(506,458,cs),
+(590,458,l),
+(598,497,l),
+(510,497,ls),
+(392,497,o),
+(341,418,o),
+(340,333,cs),
+(338,261,o),
+(383,217,o),
+(460,217,cs)
+);
+}
+);
+width = 628;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1573;
+unicode = 5491;
+},
+{
+glyphname = "heNunavik-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(453,0,l),
+(731,198,l),
+(698,246,l),
+(451,70,l),
+(472,54,l),
+(553,436,ls),
+(583,576,o),
+(538,727,o),
+(369,727,cs),
+(186,727,o),
+(115,545,o),
+(115,415,cs),
+(115,291,o),
+(188,213,o),
+(302,213,cs),
+(386,213,o),
+(451,259,o),
+(484,338,c),
+(466,327,l),
+(396,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(228,268,o),
+(177,324,o),
+(177,416,cs),
+(177,509,o),
+(225,671,o),
+(364,671,cs),
+(450,671,o),
+(500,615,o),
+(500,522,cs),
+(500,426,o),
+(452,268,o),
+(314,268,cs)
+);
+}
+);
+width = 771;
+}
+);
+metricLeft = "ke-canadian";
+note = uni1574;
+unicode = 5492;
+},
+{
+glyphname = "hiNunavik-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (581,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(272,0,l),
+(352,376,l),
+(340,369,l),
+(336,287,o),
+(402,213,o),
+(505,213,cs),
+(684,213,o),
+(752,398,o),
+(752,522,cs),
+(752,649,o),
+(678,727,o),
+(557,727,cs),
+(433,727,o),
+(345,645,o),
+(314,499,cs),
+(219,51,l),
+(243,57,l),
+(62,239,l),
+(20,198,l),
+(215,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(417,268,o),
+(368,324,o),
+(368,417,cs),
+(368,509,o),
+(414,671,o),
+(553,671,cs),
+(640,671,o),
+(690,616,o),
+(690,523,cs),
+(690,430,o),
+(643,268,o),
+(504,268,cs)
+);
+}
+);
+width = 771;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1575;
+unicode = 5493;
+},
+{
+glyphname = "hiiNunavik-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "hiNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (415,0);
+ref = dot_top;
+}
+);
+width = 771;
+}
+);
+note = uni1576;
+unicode = 5494;
+},
+{
+glyphname = "hoNunavik-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (391,714);
+},
+{
+name = top_right_can;
+pos = (580,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(387,-13,o),
+(475,69,o),
+(506,215,cs),
+(601,663,l),
+(577,657,l),
+(757,475,l),
+(799,516,l),
+(605,714,l),
+(548,714,l),
+(468,338,l),
+(479,345,l),
+(484,427,o),
+(418,501,o),
+(314,501,cs),
+(135,501,o),
+(67,316,o),
+(67,192,cs),
+(67,65,o),
+(141,-13,o),
+(263,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(180,43,o),
+(129,98,o),
+(129,191,cs),
+(129,284,o),
+(177,446,o),
+(316,446,cs),
+(402,446,o),
+(452,390,o),
+(452,297,cs),
+(452,205,o),
+(405,43,o),
+(266,43,cs)
+);
+}
+);
+width = 771;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "heNunavik-canadian";
+note = uni1577;
+unicode = 5495;
+},
+{
+glyphname = "hooNunavik-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "hoNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (416,0);
+ref = dot_top;
+}
+);
+width = 771;
+}
+);
+note = uni1578;
+unicode = 5496;
+},
+{
+glyphname = "haNunavik-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (580,714);
+},
+{
+name = top_left_can;
+pos = (391,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(633,-13,o),
+(705,169,o),
+(705,299,cs),
+(705,423,o),
+(632,501,o),
+(517,501,cs),
+(433,501,o),
+(369,455,o),
+(336,376,c),
+(354,387,l),
+(423,714,l),
+(367,714,l),
+(88,516,l),
+(121,468,l),
+(369,644,l),
+(348,660,l),
+(267,278,ls),
+(237,138,o),
+(282,-13,o),
+(451,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(370,43,o),
+(319,99,o),
+(319,192,cs),
+(319,288,o),
+(368,446,o),
+(506,446,cs),
+(592,446,o),
+(642,390,o),
+(642,298,cs),
+(642,205,o),
+(595,43,o),
+(456,43,cs)
+);
+}
+);
+width = 772;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1579;
+unicode = 5497;
+},
+{
+glyphname = "haaNunavik-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "haNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (226,0);
+ref = dot_top;
+}
+);
+width = 771;
+}
+);
+note = uni157A;
+unicode = 5498;
+},
+{
+glyphname = "hNunavik-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(410,351,o),
+(459,443,o),
+(459,517,cs),
+(459,580,o),
+(421,622,o),
+(363,622,cs),
+(323,622,o),
+(290,603,o),
+(270,569,c),
+(277,560,l),
+(310,714,l),
+(266,714,l),
+(126,615,l),
+(149,583,l),
+(277,674,l),
+(258,693,l),
+(217,501,ls),
+(199,420,o),
+(235,351,o),
+(318,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(281,389,o),
+(255,414,o),
+(255,460,cs),
+(255,518,o),
+(288,584,o),
+(350,584,cs),
+(391,584,o),
+(417,558,o),
+(417,514,cs),
+(417,455,o),
+(383,389,o),
+(321,389,cs)
+);
+}
+);
+width = 466;
+}
+);
+metricRight = "k-canadian";
+note = uni157B;
+unicode = 5499;
+},
+{
+color = 4;
+glyphname = "nunavuth-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(95,0,l),
+(168,342,l),
+(556,342,l),
+(483,0,l),
+(547,0,l),
+(699,714,l),
+(635,714,l),
+(568,399,l),
+(181,399,l),
+(247,714,l),
+(183,714,l),
+(31,0,l)
+);
+}
+);
+width = 682;
+}
+);
+metricRight = "=|";
+note = uni157C;
+unicode = 5500;
+},
+{
+glyphname = "hk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (76,357);
+ref = "fullstop-canadian";
+}
+);
+width = 347;
+}
+);
+metricLeft = "fullstop-canadian";
+note = uni157D;
+unicode = 5501;
+},
+{
+glyphname = "qaai-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (329,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (497,0);
+ref = ring_top.canadian;
+}
+);
+width = 917;
+}
+);
+note = uni157E;
+unicode = 5502;
+},
+{
+glyphname = "qi-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (329,0);
+ref = "ki-canadian";
+}
+);
+width = 917;
+}
+);
+note = uni157F;
+unicode = 5503;
+},
+{
+glyphname = "qii-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (329,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (556,0);
+ref = dot_top;
+}
+);
+width = 917;
+}
+);
+note = uni1580;
+unicode = 5504;
+},
+{
+glyphname = "qo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (329,0);
+ref = "ko-canadian";
+}
+);
+width = 917;
+}
+);
+note = uni1581;
+unicode = 5505;
+},
+{
+glyphname = "qoo-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (329,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (744,0);
+ref = dot_top;
+}
+);
+width = 917;
+}
+);
+note = uni1582;
+unicode = 5506;
+},
+{
+glyphname = "qa-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (329,0);
+ref = "ka-canadian";
+}
+);
+width = 917;
+}
+);
+note = uni1583;
+unicode = 5507;
+},
+{
+glyphname = "qaa-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (329,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (372,0);
+ref = dot_top;
+}
+);
+width = 917;
+}
+);
+note = uni1584;
+unicode = 5508;
+},
+{
+glyphname = "q-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (329,0);
+ref = "k-canadian";
+}
+);
+width = 703;
+}
+);
+note = uni1585;
+unicode = 5509;
+},
+{
+glyphname = "tlhe-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (396,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(125,0,l),
+(324,275,l),
+(279,251,l),
+(289,250,o),
+(300,250,o),
+(310,250,cs),
+(384,250,o),
+(446,284,o),
+(483,347,c),
+(479,362,l),
+(402,0,l),
+(465,0,l),
+(564,465,ls),
+(594,607,o),
+(531,727,o),
+(375,727,cs),
+(213,727,o),
+(124,586,o),
+(124,444,cs),
+(124,354,o),
+(172,286,o),
+(249,264,c),
+(57,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(237,306,o),
+(186,362,o),
+(186,450,cs),
+(186,548,o),
+(246,671,o),
+(371,671,cs),
+(461,671,o),
+(509,618,o),
+(509,533,cs),
+(509,431,o),
+(447,306,o),
+(320,306,cs)
+);
+}
+);
+width = 593;
+}
+);
+metricRight = "te-canadian";
+note = uni1586;
+unicode = 5510;
+},
+{
+glyphname = "tlhi-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(88,0,l),
+(171,390,l),
+(150,381,l),
+(167,308,o),
+(229,257,o),
+(313,252,c),
+(282,277,l),
+(365,0,l),
+(433,0,l),
+(356,256,l),
+(494,266,o),
+(575,405,o),
+(575,530,cs),
+(575,648,o),
+(498,727,o),
+(374,727,cs),
+(251,727,o),
+(163,649,o),
+(131,502,cs),
+(25,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(240,306,o),
+(188,359,o),
+(188,446,cs),
+(188,546,o),
+(248,671,o),
+(374,671,cs),
+(462,671,o),
+(512,617,o),
+(512,532,cs),
+(512,432,o),
+(452,306,o),
+(327,306,cs)
+);
+}
+);
+width = 595;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|tlhe-canadian";
+note = uni1587;
+unicode = 5511;
+},
+{
+glyphname = "tlho-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (416,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(392,-13,o),
+(479,65,o),
+(511,212,cs),
+(618,714,l),
+(554,714,l),
+(472,324,l),
+(492,333,l),
+(475,406,o),
+(413,457,o),
+(329,462,c),
+(360,437,l),
+(277,714,l),
+(209,714,l),
+(286,458,l),
+(149,448,o),
+(68,309,o),
+(68,184,cs),
+(68,66,o),
+(144,-13,o),
+(268,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(181,43,o),
+(130,97,o),
+(130,182,cs),
+(130,282,o),
+(190,408,o),
+(315,408,cs),
+(402,408,o),
+(454,355,o),
+(454,268,cs),
+(454,168,o),
+(394,43,o),
+(269,43,cs)
+);
+}
+);
+width = 594;
+}
+);
+metricLeft = "tlhe-canadian";
+metricRight = "te-canadian";
+note = uni1588;
+unicode = 5512;
+},
+{
+glyphname = "tlha-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(428,-13,o),
+(517,128,o),
+(517,270,cs),
+(517,360,o),
+(469,428,o),
+(392,450,c),
+(584,714,l),
+(516,714,l),
+(317,439,l),
+(362,463,l),
+(352,464,o),
+(341,464,o),
+(331,464,cs),
+(257,464,o),
+(195,430,o),
+(158,367,c),
+(162,352,l),
+(239,714,l),
+(176,714,l),
+(77,249,ls),
+(47,107,o),
+(110,-13,o),
+(266,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(181,43,o),
+(132,96,o),
+(132,181,cs),
+(132,283,o),
+(195,408,o),
+(321,408,cs),
+(404,408,o),
+(455,352,o),
+(455,264,cs),
+(455,166,o),
+(395,43,o),
+(271,43,cs)
+);
+}
+);
+width = 593;
+}
+);
+metricLeft = "te-canadian";
+note = uni1589;
+unicode = 5513;
+},
+{
+glyphname = "reWestCree-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(450,0,l),
+(727,198,l),
+(694,245,l),
+(447,69,l),
+(468,55,l),
+(553,456,ls),
+(587,617,o),
+(515,727,o),
+(368,727,cs),
+(235,727,o),
+(157,648,o),
+(122,486,cs),
+(104,405,l),
+(168,405,l),
+(184,483,ls),
+(211,612,o),
+(268,670,o),
+(363,670,cs),
+(474,670,o),
+(518,591,o),
+(491,464,cs),
+(393,0,l)
+);
+}
+);
+width = 767;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+unicode = 5514;
+},
+{
+glyphname = "riWestCree-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(271,0,l),
+(373,483,ls),
+(400,612,o),
+(457,670,o),
+(553,670,cs),
+(664,670,o),
+(709,590,o),
+(680,464,cs),
+(668,405,l),
+(732,405,l),
+(743,456,ls),
+(778,617,o),
+(704,727,o),
+(557,727,cs),
+(424,727,o),
+(346,648,o),
+(311,486,cs),
+(219,52,l),
+(243,59,l),
+(64,241,l),
+(20,198,l),
+(214,0,l)
+);
+}
+);
+width = 768;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+unicode = 5515;
+},
+{
+glyphname = "roWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(391,-13,o),
+(470,66,o),
+(505,228,cs),
+(597,662,l),
+(573,655,l),
+(751,473,l),
+(795,516,l),
+(602,714,l),
+(545,714,l),
+(442,231,ls),
+(415,102,o),
+(358,44,o),
+(263,44,cs),
+(151,44,o),
+(107,124,o),
+(135,250,cs),
+(148,309,l),
+(84,309,l),
+(73,258,ls),
+(38,97,o),
+(111,-13,o),
+(258,-13,cs)
+);
+}
+);
+width = 767;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+unicode = 5516;
+},
+{
+glyphname = "raWestCree-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(580,-13,o),
+(658,66,o),
+(693,228,cs),
+(711,309,l),
+(647,309,l),
+(631,231,ls),
+(604,102,o),
+(547,44,o),
+(452,44,cs),
+(341,44,o),
+(297,123,o),
+(324,250,cs),
+(422,714,l),
+(365,714,l),
+(88,516,l),
+(121,469,l),
+(368,645,l),
+(347,659,l),
+(262,258,ls),
+(228,97,o),
+(300,-13,o),
+(447,-13,cs)
+);
+}
+);
+width = 767;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+unicode = 5517;
+},
+{
+glyphname = "ngaai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:29:29 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (649,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (822,0);
+ref = ring_top.canadian;
+}
+);
+width = 1233;
+}
+);
+note = uni158E;
+unicode = 5518;
+},
+{
+glyphname = "ngi-canadian";
+kernLeft = mwestleft;
+kernRight = ciright;
+lastChange = "2023-01-13 15:29:29 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (649,0);
+ref = "ci-canadian";
+}
+);
+width = 1233;
+}
+);
+note = uni158F;
+unicode = 5519;
+},
+{
+glyphname = "ngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:29:29 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (649,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (882,0);
+ref = dot_top;
+}
+);
+width = 1233;
+}
+);
+note = uni1590;
+unicode = 5520;
+},
+{
+glyphname = "ngo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:29:29 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (621,0);
+ref = "co-canadian";
+}
+);
+width = 1206;
+}
+);
+note = uni1591;
+unicode = 5521;
+},
+{
+glyphname = "ngoo-canadian";
+lastChange = "2023-01-13 15:29:29 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "ngo-canadian";
+},
+{
+anchor = top_right_can;
+pos = (1034,0);
+ref = dot_top;
+}
+);
+width = 1206;
+}
+);
+note = uni1592;
+unicode = 5522;
+},
+{
+glyphname = "nga-canadian";
+kernLeft = mwestleft;
+kernRight = caright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (647,0);
+ref = "ca-canadian";
+}
+);
+width = 1231;
+}
+);
+note = uni1593;
+unicode = 5523;
+},
+{
+glyphname = "ngaa-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (647,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (691,0);
+ref = dot_top;
+}
+);
+width = 1231;
+}
+);
+note = uni1594;
+unicode = 5524;
+},
+{
+glyphname = "ng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(553,225,o),
+(603,270,o),
+(622,353,cs),
+(627,376,l),
+(582,376,l),
+(576,350,ls),
+(563,293,o),
+(532,265,o),
+(484,265,cs),
+(433,265,o),
+(412,297,o),
+(425,356,cs),
+(454,494,l),
+(308,494,l),
+(312,474,l),
+(357,498,o),
+(378,562,o),
+(378,606,cs),
+(379,674,o),
+(337,720,o),
+(268,720,cs),
+(180,720,o),
+(134,638,o),
+(133,565,cs),
+(131,495,o),
+(174,449,o),
+(244,449,cs),
+(414,449,l),
+(401,468,l),
+(379,363,ls),
+(361,280,o),
+(402,225,o),
+(481,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,487,o),
+(175,516,o),
+(176,562,cs),
+(176,608,o),
+(200,683,o),
+(268,683,cs),
+(311,683,o),
+(336,653,o),
+(335,607,cs),
+(335,562,o),
+(311,487,o),
+(243,487,cs)
+);
+}
+);
+width = 649;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1595;
+unicode = 5525;
+},
+{
+glyphname = "nng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(841,225,o),
+(890,270,o),
+(908,353,cs),
+(913,376,l),
+(868,376,l),
+(862,350,ls),
+(849,293,o),
+(818,265,o),
+(771,265,cs),
+(719,265,o),
+(698,297,o),
+(711,356,cs),
+(741,494,l),
+(597,494,l),
+(599,474,l),
+(645,498,o),
+(666,565,o),
+(666,609,cs),
+(666,676,o),
+(624,720,o),
+(556,720,cs),
+(467,720,o),
+(420,637,o),
+(420,561,cs),
+(420,525,o),
+(433,496,o),
+(457,477,c),
+(466,494,l),
+(309,494,l),
+(310,474,l),
+(357,499,o),
+(377,566,o),
+(377,608,cs),
+(377,676,o),
+(335,720,o),
+(268,720,cs),
+(179,720,o),
+(132,637,o),
+(132,561,cs),
+(132,493,o),
+(174,449,o),
+(242,449,cs),
+(684,449,l),
+(665,363,ls),
+(647,280,o),
+(689,225,o),
+(768,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,487,o),
+(174,516,o),
+(174,560,cs),
+(174,605,o),
+(198,683,o),
+(267,683,cs),
+(310,683,o),
+(335,654,o),
+(335,610,cs),
+(335,565,o),
+(311,487,o),
+(242,487,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(488,487,o),
+(463,516,o),
+(463,560,cs),
+(463,605,o),
+(487,683,o),
+(556,683,cs),
+(598,683,o),
+(623,654,o),
+(623,610,cs),
+(623,565,o),
+(600,487,o),
+(530,487,cs)
+);
+}
+);
+width = 935;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1596;
+unicode = 5526;
+},
+{
+glyphname = "sheSayisi-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (704,357);
+},
+{
+name = top_center_can;
+pos = (397,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(466,0,l),
+(561,447,ls),
+(593,600,o),
+(542,727,o),
+(380,727,cs),
+(184,727,o),
+(109,523,o),
+(109,384,cs),
+(109,279,o),
+(158,214,o),
+(246,214,cs),
+(335,214,o),
+(391,283,o),
+(417,425,c),
+(377,425,l),
+(356,318,o),
+(318,269,o),
+(256,269,cs),
+(200,269,o),
+(170,310,o),
+(170,383,cs),
+(170,486,o),
+(222,671,o),
+(375,671,cs),
+(493,671,o),
+(524,575,o),
+(497,449,cs),
+(402,0,l)
+);
+}
+);
+width = 594;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1597;
+unicode = 5527;
+},
+{
+glyphname = "shiSayisi-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(88,0,l),
+(190,483,ls),
+(216,607,o),
+(279,671,o),
+(373,671,cs),
+(463,671,o),
+(513,617,o),
+(513,523,cs),
+(513,443,o),
+(470,269,o),
+(366,269,cs),
+(298,269,o),
+(269,326,o),
+(293,425,c),
+(253,425,l),
+(220,300,o),
+(269,214,o),
+(369,214,cs),
+(516,214,o),
+(574,413,o),
+(574,523,cs),
+(574,649,o),
+(500,727,o),
+(375,727,cs),
+(247,727,o),
+(160,644,o),
+(129,493,cs),
+(24,0,l)
+);
+}
+);
+width = 594;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni1598;
+unicode = 5528;
+},
+{
+glyphname = "shoSayisi-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (394,714);
+},
+{
+name = top_left_can;
+pos = (201,714);
+},
+{
+name = top_right_can;
+pos = (586,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(395,-13,o),
+(480,70,o),
+(512,221,cs),
+(617,714,l),
+(553,714,l),
+(450,231,ls),
+(424,107,o),
+(362,43,o),
+(268,43,cs),
+(178,43,o),
+(129,97,o),
+(129,191,cs),
+(129,271,o),
+(171,445,o),
+(275,445,cs),
+(343,445,o),
+(372,388,o),
+(348,289,c),
+(389,289,l),
+(421,414,o),
+(372,500,o),
+(272,500,cs),
+(125,500,o),
+(67,301,o),
+(67,191,cs),
+(67,65,o),
+(141,-13,o),
+(266,-13,cs)
+);
+}
+);
+width = 593;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1599;
+unicode = 5529;
+},
+{
+glyphname = "shaSayisi-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(457,-13,o),
+(532,191,o),
+(532,330,cs),
+(532,435,o),
+(483,500,o),
+(396,500,cs),
+(307,500,o),
+(251,431,o),
+(224,289,c),
+(264,289,l),
+(286,396,o),
+(324,445,o),
+(385,445,cs),
+(441,445,o),
+(471,404,o),
+(471,331,cs),
+(471,228,o),
+(419,43,o),
+(267,43,cs),
+(148,43,o),
+(117,139,o),
+(144,265,cs),
+(240,714,l),
+(176,714,l),
+(81,267,ls),
+(48,114,o),
+(99,-13,o),
+(262,-13,cs)
+);
+}
+);
+width = 593;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni159A;
+unicode = 5530;
+},
+{
+glyphname = "theWoodScree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(672,-13,o),
+(756,151,o),
+(756,284,cs),
+(756,407,o),
+(676,489,o),
+(548,489,cs),
+(126,489,l),
+(115,434,l),
+(465,434,l),
+(466,459,l),
+(337,424,o),
+(295,285,o),
+(295,194,cs),
+(295,71,o),
+(374,-13,o),
+(499,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(412,43,o),
+(357,104,o),
+(357,196,cs),
+(357,299,o),
+(418,433,o),
+(548,433,cs),
+(639,433,o),
+(694,374,o),
+(694,283,cs),
+(694,182,o),
+(635,43,o),
+(501,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(833,659,l),
+(844,714,l),
+(174,714,l),
+(163,659,l)
+);
+}
+);
+width = 829;
+}
+);
+note = uni159B;
+unicode = 5531;
+},
+{
+glyphname = "thiWoodScree-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(448,-13,o),
+(532,151,o),
+(532,284,cs),
+(532,355,o),
+(501,411,o),
+(452,439,c),
+(442,434,l),
+(795,434,l),
+(806,489,l),
+(334,489,ls),
+(157,489,o),
+(71,334,o),
+(71,194,cs),
+(71,71,o),
+(150,-13,o),
+(275,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(188,43,o),
+(133,104,o),
+(133,196,cs),
+(133,299,o),
+(194,433,o),
+(324,433,cs),
+(415,433,o),
+(470,374,o),
+(470,283,cs),
+(470,182,o),
+(411,43,o),
+(277,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(843,659,l),
+(854,714,l),
+(185,714,l),
+(173,659,l)
+);
+}
+);
+width = 829;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159C;
+unicode = 5532;
+},
+{
+glyphname = "thoWoodScree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(495,0,ls),
+(672,0,o),
+(758,155,o),
+(758,295,cs),
+(758,418,o),
+(679,501,o),
+(553,501,cs),
+(381,501,o),
+(297,338,o),
+(297,205,cs),
+(297,134,o),
+(327,78,o),
+(377,49,c),
+(387,55,l),
+(34,55,l),
+(22,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(413,56,o),
+(359,115,o),
+(359,206,cs),
+(359,307,o),
+(417,445,o),
+(552,445,cs),
+(641,445,o),
+(695,385,o),
+(695,293,cs),
+(695,190,o),
+(634,56,o),
+(505,56,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(832,659,l),
+(844,714,l),
+(174,714,l),
+(163,659,l)
+);
+}
+);
+width = 829;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159D;
+unicode = 5533;
+},
+{
+glyphname = "thaWoodScree-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(703,0,l),
+(714,55,l),
+(364,55,l),
+(362,30,l),
+(492,65,o),
+(534,203,o),
+(534,295,cs),
+(534,418,o),
+(454,501,o),
+(330,501,cs),
+(156,501,o),
+(73,338,o),
+(73,205,cs),
+(73,82,o),
+(152,0,o),
+(281,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(189,56,o),
+(135,115,o),
+(135,206,cs),
+(135,307,o),
+(193,445,o),
+(328,445,cs),
+(417,445,o),
+(471,385,o),
+(471,293,cs),
+(471,190,o),
+(411,56,o),
+(281,56,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(842,659,l),
+(854,714,l),
+(184,714,l),
+(172,659,l)
+);
+}
+);
+width = 829;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159E;
+unicode = 5534;
+},
+{
+glyphname = "thWoodScree-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(467,357,l),
+(476,399,l),
+(288,399,l),
+(285,375,l),
+(345,394,o),
+(368,470,o),
+(368,516,cs),
+(368,583,o),
+(325,628,o),
+(258,628,cs),
+(169,628,o),
+(122,544,o),
+(122,469,cs),
+(122,400,o),
+(165,357,o),
+(233,357,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(190,394,o),
+(165,423,o),
+(165,467,cs),
+(165,512,o),
+(189,590,o),
+(258,590,cs),
+(300,590,o),
+(325,561,o),
+(325,517,cs),
+(325,473,o),
+(302,394,o),
+(232,394,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(538,700,l),
+(547,742,l),
+(181,742,l),
+(171,700,l)
+);
+}
+);
+width = 513;
+}
+);
+metricRight = "=|";
+note = uni159F;
+unicode = 5535;
+},
+{
+glyphname = "lhi-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (578,714);
+},
+{
+name = top_right_can;
+pos = (666,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(310,0,l),
+(322,57,l),
+(285,57,ls),
+(186,57,o),
+(131,111,o),
+(131,201,cs),
+(131,303,o),
+(184,430,o),
+(362,430,cs),
+(791,430,l),
+(802,483,l),
+(681,747,l),
+(625,721,l),
+(743,463,l),
+(759,489,l),
+(367,489,ls),
+(149,489,o),
+(68,339,o),
+(68,200,cs),
+(68,80,o),
+(145,0,o),
+(271,0,cs)
+);
+}
+);
+width = 816;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A0;
+unicode = 5536;
+},
+{
+glyphname = "lhii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "lhi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (414,0);
+ref = dot_top;
+}
+);
+width = 815;
+}
+);
+note = uni15A1;
+unicode = 5537;
+},
+{
+glyphname = "lho-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (452,507);
+},
+{
+name = top_right_can;
+pos = (567,507);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(191,-232,l),
+(73,25,l),
+(56,0,l),
+(448,0,ls),
+(667,0,o),
+(748,149,o),
+(748,288,cs),
+(748,408,o),
+(670,488,o),
+(544,488,cs),
+(505,488,l),
+(494,431,l),
+(530,431,ls),
+(629,431,o),
+(685,377,o),
+(685,288,cs),
+(685,186,o),
+(632,58,o),
+(454,58,cs),
+(24,58,l),
+(13,6,l),
+(134,-258,l)
+);
+}
+);
+width = 817;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni15A2;
+unicode = 5538;
+},
+{
+glyphname = "lhoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "lho-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (403,-207);
+ref = dot_top;
+}
+);
+width = 815;
+}
+);
+note = uni15A3;
+unicode = 5539;
+},
+{
+glyphname = "lha-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (478,507);
+},
+{
+name = top_left_can;
+pos = (362,507);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(700,6,l),
+(712,58,l),
+(289,58,ls),
+(187,58,o),
+(132,110,o),
+(132,201,cs),
+(132,303,o),
+(182,431,o),
+(359,431,cs),
+(401,431,l),
+(413,489,l),
+(365,489,ls),
+(143,489,o),
+(68,333,o),
+(68,198,cs),
+(68,77,o),
+(146,0,o),
+(276,0,cs),
+(654,0,l),
+(640,25,l),
+(423,-220,l),
+(467,-258,l)
+);
+}
+);
+width = 816;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A4;
+unicode = 5540;
+},
+{
+glyphname = "lhaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "lha-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (197,-207);
+ref = dot_top;
+}
+);
+width = 815;
+}
+);
+note = uni15A5;
+unicode = 5541;
+},
+{
+glyphname = "lh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(475,362,l),
+(484,401,l),
+(274,401,ls),
+(208,401,o),
+(174,435,o),
+(174,496,cs),
+(174,569,o),
+(206,670,o),
+(328,670,cs),
+(349,670,l),
+(358,714,l),
+(333,714,ls),
+(190,714,o),
+(127,608,o),
+(127,494,cs),
+(127,407,o),
+(179,357,o),
+(272,357,cs),
+(446,357,l),
+(432,384,l),
+(313,246,l),
+(348,215,l)
+);
+}
+);
+width = 518;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni15A6;
+unicode = 5542;
+},
+{
+glyphname = "theThCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (181,714);
+},
+{
+name = top_right_can;
+pos = (556,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(398,121,l),
+(372,0,l),
+(435,0,l),
+(461,121,l),
+(545,121,l),
+(554,163,l),
+(470,163,l),
+(504,321,l),
+(149,321,l),
+(157,302,l),
+(592,684,l),
+(553,726,l),
+(59,290,l),
+(54,264,l),
+(428,264,l),
+(407,163,l),
+(154,163,l),
+(146,121,l)
+);
+}
+);
+width = 608;
+}
+);
+metricLeft = "ye-canadian";
+note = uni15A7;
+unicode = 5543;
+},
+{
+glyphname = "thiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (253,714);
+},
+{
+name = top_right_can;
+pos = (627,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(132,0,l),
+(159,121,l),
+(411,121,l),
+(420,163,l),
+(167,163,l),
+(189,264,l),
+(563,264,l),
+(568,290,l),
+(251,726,l),
+(204,692,l),
+(492,298,l),
+(505,321,l),
+(137,321,l),
+(104,163,l),
+(20,163,l),
+(11,121,l),
+(94,121,l),
+(69,0,l)
+);
+}
+);
+width = 608;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+unicode = 5544;
+},
+{
+glyphname = "thiiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (88,0);
+ref = dot_top;
+}
+);
+width = 608;
+}
+);
+note = uni15A9;
+unicode = 5545;
+},
+{
+glyphname = "thoThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (181,714);
+},
+{
+name = top_right_can;
+pos = (556,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(451,22,l),
+(164,416,l),
+(151,393,l),
+(519,393,l),
+(552,551,l),
+(637,551,l),
+(645,593,l),
+(561,593,l),
+(587,714,l),
+(523,714,l),
+(497,593,l),
+(244,593,l),
+(236,551,l),
+(488,551,l),
+(467,450,l),
+(93,450,l),
+(87,424,l),
+(405,-12,l)
+);
+}
+);
+width = 609;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+unicode = 5546;
+},
+{
+glyphname = "thooThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (391,0);
+ref = dot_top;
+}
+);
+width = 608;
+}
+);
+note = uni15AB;
+unicode = 5547;
+},
+{
+glyphname = "thaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (253,714);
+},
+{
+name = top_right_can;
+pos = (627,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(598,424,l),
+(603,450,l),
+(228,450,l),
+(249,551,l),
+(502,551,l),
+(510,593,l),
+(258,593,l),
+(284,714,l),
+(220,714,l),
+(194,593,l),
+(111,593,l),
+(102,551,l),
+(185,551,l),
+(152,393,l),
+(508,393,l),
+(500,412,l),
+(63,30,l),
+(103,-12,l)
+);
+}
+);
+width = 609;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+unicode = 5548;
+},
+{
+glyphname = "thaaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:29:29 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (89,0);
+ref = dot_top;
+}
+);
+width = 609;
+}
+);
+note = uni15AD;
+unicode = 5549;
+},
+{
+glyphname = "thThCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(184,634,l),
+(164,542,l),
+(341,542,l),
+(333,561,l),
+(128,379,l),
+(157,348,l),
+(399,565,l),
+(403,582,l),
+(220,582,l),
+(231,634,l),
+(354,634,l),
+(360,661,l),
+(236,661,l),
+(248,714,l),
+(200,714,l),
+(189,661,l),
+(147,661,l),
+(141,634,l)
+);
+}
+);
+width = 374;
+}
+);
+metricRight = "y-canadian";
+note = uni15AE;
+unicode = 5550;
+},
+{
+glyphname = "bAivilik-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(456,-13,o),
+(529,168,o),
+(529,299,cs),
+(529,423,o),
+(456,501,o),
+(342,501,cs),
+(259,501,o),
+(198,456,o),
+(166,386,c),
+(175,376,l),
+(247,714,l),
+(183,714,l),
+(32,0,l),
+(93,0,l),
+(123,143,l),
+(115,131,l),
+(125,42,o),
+(186,-13,o),
+(281,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(194,43,o),
+(144,99,o),
+(144,192,cs),
+(144,288,o),
+(192,446,o),
+(330,446,cs),
+(417,446,o),
+(467,390,o),
+(467,298,cs),
+(467,204,o),
+(420,43,o),
+(281,43,cs)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|ke-canadian";
+note = uni15AF;
+unicode = 5551;
+},
+{
+glyphname = "eBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(95,0,l),
+(187,433,l),
+(212,390,o),
+(258,365,o),
+(316,365,cs),
+(438,365,o),
+(507,476,o),
+(507,574,cs),
+(507,663,o),
+(449,727,o),
+(358,727,cs),
+(313,727,o),
+(270,710,o),
+(238,681,c),
+(245,714,l),
+(183,714,l),
+(31,0,l)
+);
+}
+);
+width = 489;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B0;
+unicode = 5552;
+},
+{
+glyphname = "iBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(225,-13,o),
+(268,4,o),
+(299,33,c),
+(292,0,l),
+(354,0,l),
+(506,714,l),
+(442,714,l),
+(350,281,l),
+(326,324,o),
+(280,349,o),
+(222,349,cs),
+(100,349,o),
+(30,238,o),
+(30,140,cs),
+(30,51,o),
+(89,-13,o),
+(179,-13,cs)
+);
+}
+);
+width = 489;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B1;
+unicode = 5553;
+},
+{
+glyphname = "oBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(356,-13,o),
+(427,95,o),
+(427,196,cs),
+(427,285,o),
+(369,349,o),
+(280,349,cs),
+(235,349,o),
+(191,332,o),
+(160,302,c),
+(247,714,l),
+(183,714,l),
+(31,0,l),
+(93,0,l),
+(106,62,l),
+(129,15,o),
+(176,-13,o),
+(236,-13,cs)
+);
+}
+);
+width = 489;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "eBlackfoot-canadian";
+note = uni15B2;
+unicode = 5554;
+},
+{
+glyphname = "aBlackfoot-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(353,0,l),
+(505,714,l),
+(443,714,l),
+(430,652,l),
+(407,699,o),
+(361,727,o),
+(300,727,cs),
+(180,727,o),
+(110,619,o),
+(110,518,cs),
+(110,429,o),
+(168,365,o),
+(256,365,cs),
+(302,365,o),
+(345,382,o),
+(377,412,c),
+(289,0,l)
+);
+}
+);
+width = 488;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B3;
+unicode = 5555;
+},
+{
+glyphname = "weBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(95,0,l),
+(165,330,l),
+(527,330,l),
+(538,385,l),
+(177,385,l),
+(235,659,l),
+(597,659,l),
+(608,714,l),
+(183,714,l),
+(31,0,l)
+);
+}
+);
+width = 571;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B4;
+unicode = 5556;
+},
+{
+glyphname = "wiBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(436,0,l),
+(588,714,l),
+(524,714,l),
+(454,384,l),
+(92,384,l),
+(81,329,l),
+(442,329,l),
+(384,55,l),
+(22,55,l),
+(11,0,l)
+);
+}
+);
+width = 571;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B5;
+unicode = 5557;
+},
+{
+glyphname = "woBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(457,0,l),
+(468,55,l),
+(107,55,l),
+(165,329,l),
+(527,329,l),
+(538,384,l),
+(177,384,l),
+(247,714,l),
+(183,714,l),
+(31,0,l)
+);
+}
+);
+width = 571;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "weBlackfoot-canadian";
+note = uni15B6;
+unicode = 5558;
+},
+{
+glyphname = "waBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(436,0,l),
+(588,714,l),
+(162,714,l),
+(151,659,l),
+(512,659,l),
+(454,385,l),
+(93,385,l),
+(81,330,l),
+(442,330,l),
+(372,0,l)
+);
+}
+);
+width = 571;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B7;
+unicode = 5559;
+},
+{
+glyphname = "neBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(95,0,l),
+(237,664,l),
+(283,664,l),
+(267,702,l),
+(261,673,ls),
+(229,524,o),
+(304,422,o),
+(450,422,cs),
+(579,422,o),
+(667,500,o),
+(697,650,cs),
+(711,714,l),
+(648,714,l),
+(635,653,ls),
+(612,536,o),
+(550,478,o),
+(453,478,cs),
+(347,478,o),
+(298,550,o),
+(322,662,cs),
+(333,714,l),
+(183,714,l),
+(31,0,l)
+);
+}
+);
+width = 657;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B8;
+unicode = 5560;
+},
+{
+glyphname = "niBlackfoot-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(57,0,l),
+(70,61,ls),
+(93,178,o),
+(156,236,o),
+(252,236,cs),
+(359,236,o),
+(408,164,o),
+(384,52,cs),
+(373,0,l),
+(522,0,l),
+(674,714,l),
+(610,714,l),
+(469,50,l),
+(422,50,l),
+(439,12,l),
+(445,41,ls),
+(477,190,o),
+(402,292,o),
+(255,292,cs),
+(126,292,o),
+(39,214,o),
+(8,64,cs),
+(-6,0,l)
+);
+}
+);
+width = 657;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B9;
+unicode = 5561;
+},
+{
+glyphname = "noBlackfoot-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(181,0,l),
+(192,55,ls),
+(218,177,o),
+(275,236,o),
+(372,236,cs),
+(479,236,o),
+(531,163,o),
+(506,45,cs),
+(497,0,l),
+(560,0,l),
+(567,37,ls),
+(598,191,o),
+(522,293,o),
+(377,293,cs),
+(247,293,o),
+(163,212,o),
+(129,54,cs),
+(120,13,l),
+(153,50,l),
+(106,50,l),
+(247,714,l),
+(183,714,l),
+(31,0,l)
+);
+}
+);
+width = 658;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "neBlackfoot-canadian";
+note = uni15BA;
+unicode = 5562;
+},
+{
+glyphname = "naBlackfoot-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(522,0,l),
+(674,714,l),
+(525,714,l),
+(513,659,ls),
+(488,537,o),
+(431,478,o),
+(334,478,cs),
+(226,478,o),
+(175,551,o),
+(200,669,cs),
+(209,714,l),
+(146,714,l),
+(139,677,ls),
+(108,523,o),
+(184,421,o),
+(329,421,cs),
+(458,421,o),
+(543,502,o),
+(577,660,cs),
+(585,701,l),
+(553,664,l),
+(600,664,l),
+(458,0,l)
+);
+}
+);
+width = 657;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BB;
+unicode = 5563;
+},
+{
+glyphname = "keBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(95,0,l),
+(233,645,l),
+(207,645,l),
+(323,267,l),
+(354,267,l),
+(685,714,l),
+(611,714,l),
+(336,339,l),
+(357,337,l),
+(242,714,l),
+(183,714,l),
+(31,0,l)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15BC;
+unicode = 5564;
+},
+{
+glyphname = "kiBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(53,0,l),
+(328,375,l),
+(307,377,l),
+(421,0,l),
+(480,0,l),
+(632,714,l),
+(568,714,l),
+(431,69,l),
+(456,69,l),
+(340,447,l),
+(309,447,l),
+(-22,0,l)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BD;
+unicode = 5565;
+},
+{
+glyphname = "koBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(92,0,l),
+(380,382,l),
+(347,387,l),
+(468,0,l),
+(533,0,l),
+(392,447,l),
+(360,447,l),
+(82,69,l),
+(110,69,l),
+(247,714,l),
+(183,714,l),
+(31,0,l)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "keBlackfoot-canadian";
+note = uni15BE;
+unicode = 5566;
+},
+{
+glyphname = "kaBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(480,1,l),
+(632,715,l),
+(572,715,l),
+(284,332,l),
+(317,328,l),
+(196,715,l),
+(130,715,l),
+(271,268,l),
+(303,268,l),
+(581,646,l),
+(554,646,l),
+(416,1,l)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BF;
+unicode = 5567;
+},
+{
+color = 9;
+glyphname = "heSayisi-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_right_can;
+pos = (646,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(526,0,l),
+(678,714,l),
+(614,714,l),
+(512,234,l),
+(526,233,l),
+(581,542,o),
+(513,727,o),
+(340,727,cs),
+(227,727,o),
+(152,649,o),
+(118,499,cs),
+(107,451,o),
+(101,406,o),
+(100,352,c),
+(161,352,l),
+(163,400,o),
+(168,443,o),
+(177,483,cs),
+(204,606,o),
+(261,670,o),
+(346,670,cs),
+(513,670,o),
+(554,435,o),
+(462,0,c)
+);
+}
+);
+width = 661;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni15C0;
+unicode = 5568;
+},
+{
+color = 9;
+glyphname = "hiSayisi-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(95,0,l),
+(189,441,o),
+(319,670,o),
+(474,670,cs),
+(569,670,o),
+(609,587,o),
+(579,449,cs),
+(572,412,o),
+(561,383,o),
+(548,352,c),
+(609,352,l),
+(624,388,o),
+(635,420,o),
+(642,450,cs),
+(676,619,o),
+(616,727,o),
+(489,727,cs),
+(339,727,o),
+(211,562,o),
+(140,272,c),
+(152,271,l),
+(247,714,l),
+(183,714,l),
+(31,0,l)
+);
+}
+);
+width = 662;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C1;
+unicode = 5569;
+},
+{
+color = 9;
+glyphname = "hoSayisi-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (427,714);
+},
+{
+name = top_left_can;
+pos = (207,714);
+},
+{
+name = top_right_can;
+pos = (647,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(371,-13,o),
+(499,152,o),
+(570,442,c),
+(558,443,l),
+(463,0,l),
+(527,0,l),
+(679,714,l),
+(615,714,l),
+(521,273,o),
+(391,44,o),
+(236,44,cs),
+(141,44,o),
+(101,127,o),
+(131,265,cs),
+(138,302,o),
+(149,331,o),
+(162,362,c),
+(101,362,l),
+(86,326,o),
+(75,294,o),
+(68,264,cs),
+(34,95,o),
+(94,-13,o),
+(221,-13,cs)
+);
+}
+);
+width = 662;
+}
+);
+metricLeft = "heSayisi-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15C2;
+unicode = 5570;
+},
+{
+color = 9;
+glyphname = "haSayisi-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(482,-13,o),
+(557,65,o),
+(591,215,cs),
+(602,263,o),
+(608,308,o),
+(609,362,c),
+(548,362,l),
+(546,314,o),
+(541,271,o),
+(532,231,cs),
+(505,108,o),
+(448,44,o),
+(363,44,cs),
+(196,44,o),
+(155,279,o),
+(247,714,c),
+(183,714,l),
+(31,0,l),
+(95,0,l),
+(197,480,l),
+(183,481,l),
+(128,172,o),
+(196,-13,o),
+(369,-13,cs)
+);
+}
+);
+width = 661;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C3;
+unicode = 5571;
+},
+{
+color = 9;
+glyphname = "ghuCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(320,0,l),
+(774,694,l),
+(778,714,l),
+(718,714,l),
+(556,462,l),
+(584,477,l),
+(221,477,l),
+(243,462,l),
+(189,714,l),
+(137,714,l),
+(132,694,l),
+(291,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(553,427,l),
+(543,440,l),
+(306,70,l),
+(330,66,l),
+(248,441,l),
+(232,427,l)
+);
+}
+);
+width = 714;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C4;
+unicode = 5572;
+},
+{
+color = 9;
+glyphname = "ghoCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(44,0,l),
+(206,252,l),
+(178,237,l),
+(541,237,l),
+(519,252,l),
+(573,0,l),
+(625,0,l),
+(630,20,l),
+(471,714,l),
+(442,714,l),
+(-12,20,l),
+(-16,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(527,303,l),
+(218,304,l),
+(228,275,l),
+(459,628,l),
+(423,631,l),
+(505,272,l)
+);
+}
+);
+width = 714;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C5;
+unicode = 5573;
+},
+{
+color = 9;
+glyphname = "gheCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (104,363);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(27,0,l),
+(640,342,l),
+(647,371,l),
+(179,714,l),
+(160,714,l),
+(150,667,l),
+(299,558,l),
+(293,596,l),
+(194,132,l),
+(214,168,l),
+(20,60,l),
+(8,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(337,568,l),
+(318,550,l),
+(594,346,l),
+(596,377,l),
+(240,179,l),
+(250,159,l)
+);
+}
+);
+width = 657;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15C6;
+unicode = 5574;
+},
+{
+color = 9;
+glyphname = "gheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (43,6);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 658;
+}
+);
+note = uni15C7;
+unicode = 5575;
+},
+{
+color = 9;
+glyphname = "ghiCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (21,6);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 658;
+}
+);
+note = uni15C8;
+unicode = 5576;
+},
+{
+color = 9;
+glyphname = "ghaCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(545,0,l),
+(555,47,l),
+(405,156,l),
+(411,118,l),
+(510,582,l),
+(490,546,l),
+(684,654,l),
+(697,714,l),
+(677,714,l),
+(64,372,l),
+(58,343,l),
+(525,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(387,164,l),
+(113,366,l),
+(112,339,l),
+(464,535,l),
+(453,551,l),
+(368,151,l)
+);
+}
+);
+width = 656;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15C9;
+unicode = 5577;
+},
+{
+color = 9;
+glyphname = "ruCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(320,0,l),
+(774,694,l),
+(778,714,l),
+(718,714,l),
+(653,615,l),
+(683,629,l),
+(188,629,l),
+(210,614,l),
+(188,714,l),
+(137,714,l),
+(132,694,l),
+(291,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(651,577,l),
+(639,591,l),
+(306,71,l),
+(330,68,l),
+(215,592,l),
+(199,577,l)
+);
+}
+);
+width = 714;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CA;
+unicode = 5578;
+},
+{
+color = 9;
+glyphname = "roCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(442,714,l),
+(-12,20,l),
+(-16,0,l),
+(45,0,l),
+(109,99,l),
+(80,85,l),
+(574,85,l),
+(552,100,l),
+(574,0,l),
+(625,0,l),
+(630,20,l),
+(471,714,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(112,137,l),
+(123,123,l),
+(456,643,l),
+(432,646,l),
+(548,122,l),
+(563,137,l)
+);
+}
+);
+width = 714;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CB;
+unicode = 5579;
+},
+{
+color = 9;
+glyphname = "reCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(26,0,l),
+(640,343,l),
+(646,371,l),
+(178,714,l),
+(159,714,l),
+(149,668,l),
+(222,615,l),
+(214,654,l),
+(91,74,l),
+(112,109,l),
+(19,57,l),
+(7,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(259,622,l),
+(240,603,l),
+(590,346,l),
+(591,376,l),
+(139,123,l),
+(148,104,l)
+);
+}
+);
+width = 656;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CC;
+unicode = 5580;
+},
+{
+color = 9;
+glyphname = "reeCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(26,0,l),
+(640,343,l),
+(646,371,l),
+(178,714,l),
+(159,714,l),
+(150,674,l),
+(220,622,l),
+(214,658,l),
+(90,69,l),
+(108,104,l),
+(18,53,l),
+(7,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(256,632,l),
+(235,614,l),
+(601,347,l),
+(603,376,l),
+(132,114,l),
+(142,94,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(281,266,l),
+(322,456,l),
+(288,456,l),
+(247,266,l)
+);
+}
+);
+width = 656;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CD;
+unicode = 5581;
+},
+{
+color = 9;
+glyphname = "riCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(26,0,l),
+(640,343,l),
+(646,371,l),
+(178,714,l),
+(159,714,l),
+(150,674,l),
+(221,622,l),
+(214,658,l),
+(90,69,l),
+(110,105,l),
+(18,53,l),
+(7,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(357,324,o),
+(374,340,o),
+(374,362,cs),
+(374,384,o),
+(357,399,o),
+(336,399,cs),
+(315,399,o),
+(298,384,o),
+(298,362,cs),
+(298,340,o),
+(315,324,o),
+(336,324,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(256,632,l),
+(235,614,l),
+(601,347,l),
+(603,376,l),
+(133,114,l),
+(142,94,l)
+);
+}
+);
+width = 656;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CE;
+unicode = 5582;
+},
+{
+color = 9;
+glyphname = "raCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(545,0,l),
+(555,46,l),
+(482,99,l),
+(490,60,l),
+(613,640,l),
+(592,605,l),
+(685,657,l),
+(697,714,l),
+(677,714,l),
+(64,371,l),
+(58,343,l),
+(526,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(464,111,l),
+(114,368,l),
+(113,338,l),
+(565,591,l),
+(555,610,l),
+(445,92,l)
+);
+}
+);
+width = 656;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15CF;
+unicode = 5583;
+},
+{
+color = 9;
+glyphname = "wuCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(323,0,l),
+(778,694,l),
+(783,714,l),
+(724,714,l),
+(344,121,l),
+(357,120,l),
+(483,714,l),
+(429,714,l),
+(303,119,l),
+(317,119,l),
+(186,714,l),
+(137,714,l),
+(132,694,l),
+(293,0,l)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D0;
+unicode = 5584;
+},
+{
+color = 9;
+glyphname = "woCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(43,0,l),
+(423,593,l),
+(410,594,l),
+(284,0,l),
+(338,0,l),
+(464,595,l),
+(450,595,l),
+(581,0,l),
+(630,0,l),
+(634,20,l),
+(474,714,l),
+(444,714,l),
+(-12,20,l),
+(-16,0,l)
+);
+}
+);
+width = 718;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D1;
+unicode = 5585;
+},
+{
+color = 9;
+glyphname = "weCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(48,0,l),
+(662,343,l),
+(668,371,l),
+(200,714,l),
+(180,714,l),
+(170,667,l),
+(567,377,l),
+(571,389,l),
+(112,389,l),
+(101,338,l),
+(565,338,l),
+(565,349,l),
+(41,58,l),
+(29,0,l)
+);
+}
+);
+width = 678;
+}
+);
+metricRight = "o-canadian";
+note = uni15D2;
+unicode = 5586;
+},
+{
+color = 9;
+glyphname = "weeCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(48,0,l),
+(662,343,l),
+(668,371,l),
+(200,714,l),
+(181,714,l),
+(171,671,l),
+(580,373,l),
+(585,386,l),
+(236,386,l),
+(254,472,l),
+(214,472,l),
+(196,386,l),
+(111,386,l),
+(102,342,l),
+(186,342,l),
+(168,256,l),
+(208,256,l),
+(226,342,l),
+(580,342,l),
+(578,353,l),
+(40,54,l),
+(29,0,l)
+);
+}
+);
+width = 678;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D3;
+unicode = 5587;
+},
+{
+color = 9;
+glyphname = "wiCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(48,0,l),
+(662,343,l),
+(668,371,l),
+(200,714,l),
+(181,714,l),
+(171,671,l),
+(576,376,l),
+(584,386,l),
+(301,386,l),
+(293,410,o),
+(270,427,o),
+(243,427,cs),
+(216,427,o),
+(194,410,o),
+(186,386,c),
+(111,386,l),
+(102,344,l),
+(186,344,l),
+(195,321,o),
+(217,303,o),
+(243,303,cs),
+(270,303,o),
+(292,321,o),
+(300,344,c),
+(579,344,l),
+(575,351,l),
+(40,54,l),
+(29,0,l)
+);
+}
+);
+width = 678;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D4;
+unicode = 5588;
+},
+{
+color = 9;
+glyphname = "waCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(545,0,l),
+(555,47,l),
+(158,337,l),
+(154,325,l),
+(614,325,l),
+(625,376,l),
+(161,376,l),
+(161,365,l),
+(684,656,l),
+(697,714,l),
+(677,714,l),
+(64,371,l),
+(58,343,l),
+(525,0,l)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15D5;
+unicode = 5589;
+},
+{
+color = 9;
+glyphname = "hwuCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(323,0,l),
+(778,694,l),
+(783,714,l),
+(727,714,l),
+(570,471,l),
+(592,483,l),
+(429,483,l),
+(478,714,l),
+(433,714,l),
+(384,483,l),
+(220,483,l),
+(237,472,l),
+(183,714,l),
+(137,714,l),
+(132,694,l),
+(293,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(318,100,l),
+(239,457,l),
+(228,443,l),
+(378,443,l),
+(305,99,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(417,443,l),
+(568,443,l),
+(563,456,l),
+(334,101,l),
+(344,97,l)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D6;
+unicode = 5590;
+},
+{
+color = 9;
+glyphname = "hwoCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(40,0,l),
+(197,243,l),
+(175,231,l),
+(338,231,l),
+(289,0,l),
+(334,0,l),
+(383,231,l),
+(547,231,l),
+(530,242,l),
+(584,0,l),
+(630,0,l),
+(634,20,l),
+(474,714,l),
+(444,714,l),
+(-12,20,l),
+(-16,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(433,613,l),
+(423,617,l),
+(350,271,l),
+(199,271,l),
+(204,258,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(539,271,l),
+(389,271,l),
+(461,615,l),
+(449,614,l),
+(528,257,l)
+);
+}
+);
+width = 718;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D7;
+unicode = 5591;
+},
+{
+color = 9;
+glyphname = "hweCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(48,0,l),
+(662,343,l),
+(668,371,l),
+(200,714,l),
+(180,714,l),
+(171,672,l),
+(308,573,l),
+(268,387,l),
+(111,387,l),
+(101,341,l),
+(259,341,l),
+(219,154,l),
+(40,54,l),
+(28,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(297,344,l),
+(569,344,l),
+(261,174,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(341,552,l),
+(571,384,l),
+(306,384,l)
+);
+}
+);
+width = 678;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D8;
+unicode = 5592;
+},
+{
+color = 9;
+glyphname = "hweeCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(48,0,l),
+(662,343,l),
+(668,371,l),
+(200,714,l),
+(180,714,l),
+(172,673,l),
+(318,567,l),
+(280,384,l),
+(219,384,l),
+(237,471,l),
+(201,471,l),
+(183,384,l),
+(110,384,l),
+(102,344,l),
+(174,344,l),
+(156,258,l),
+(192,258,l),
+(210,344,l),
+(271,344,l),
+(232,159,l),
+(40,53,l),
+(28,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(307,346,l),
+(572,346,l),
+(271,178,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(349,547,l),
+(574,382,l),
+(314,382,l)
+);
+}
+);
+width = 678;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D9;
+unicode = 5593;
+},
+{
+color = 9;
+glyphname = "hwiCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(48,0,l),
+(662,343,l),
+(668,371,l),
+(200,714,l),
+(180,714,l),
+(172,673,l),
+(319,567,l),
+(279,382,l),
+(244,382,l),
+(238,404,o),
+(217,420,o),
+(193,420,cs),
+(169,420,o),
+(149,404,o),
+(143,382,c),
+(110,382,l),
+(102,346,l),
+(142,346,l),
+(149,324,o),
+(170,308,o),
+(193,308,cs),
+(217,308,o),
+(237,324,o),
+(244,346,c),
+(272,346,l),
+(232,159,l),
+(40,53,l),
+(28,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(307,346,l),
+(572,346,l),
+(271,178,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(349,547,l),
+(574,382,l),
+(315,382,l)
+);
+}
+);
+width = 678;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15DA;
+unicode = 5594;
+},
+{
+color = 9;
+glyphname = "hwaCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(678,714,l),
+(64,371,l),
+(58,343,l),
+(526,0,l),
+(545,0,l),
+(554,42,l),
+(418,141,l),
+(457,327,l),
+(614,327,l),
+(624,373,l),
+(467,373,l),
+(507,560,l),
+(686,660,l),
+(697,714,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(428,370,l),
+(156,370,l),
+(464,540,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(384,162,l),
+(154,330,l),
+(420,330,l)
+);
+}
+);
+width = 678;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15DB;
+unicode = 5595;
+},
+{
+color = 9;
+glyphname = "thuCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(502,-13,o),
+(602,82,o),
+(644,275,cs),
+(737,714,l),
+(176,714,l),
+(89,304,ls),
+(45,100,o),
+(137,-13,o),
+(329,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(228,656,l),
+(661,656,l),
+(581,279,ls),
+(547,119,o),
+(469,47,o),
+(333,47,cs),
+(177,47,o),
+(115,130,o),
+(152,301,cs)
+);
+}
+);
+width = 714;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DC;
+unicode = 5596;
+},
+{
+color = 9;
+glyphname = "thoCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(585,0,l),
+(672,410,ls),
+(716,614,o),
+(624,727,o),
+(432,727,cs),
+(259,727,o),
+(159,632,o),
+(117,439,cs),
+(24,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(180,435,ls),
+(214,595,o),
+(292,667,o),
+(428,667,cs),
+(584,667,o),
+(646,584,o),
+(609,413,cs),
+(533,58,l),
+(100,58,l)
+);
+}
+);
+width = 713;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DD;
+unicode = 5597;
+},
+{
+color = 9;
+glyphname = "theCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (369,357);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(244,0,ls),
+(564,0,o),
+(654,271,o),
+(654,449,cs),
+(654,617,o),
+(557,714,o),
+(383,714,cs),
+(183,714,l),
+(31,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(240,679,l),
+(216,657,l),
+(372,657,ls),
+(515,657,o),
+(593,583,o),
+(593,447,cs),
+(593,292,o),
+(513,57,o),
+(249,57,cs),
+(92,57,l),
+(103,37,l)
+);
+}
+);
+width = 691;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "to-canadian";
+note = uni15DE;
+unicode = 5598;
+},
+{
+color = 9;
+glyphname = "theeCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (303,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 691;
+}
+);
+note = uni15DF;
+unicode = 5599;
+},
+{
+color = 9;
+glyphname = "thiCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (281,0);
+ref = dot_middle;
+}
+);
+width = 691;
+}
+);
+note = uni15E0;
+unicode = 5600;
+},
+{
+color = 9;
+glyphname = "thaCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(555,0,l),
+(707,714,l),
+(495,714,ls),
+(175,714,o),
+(85,443,o),
+(85,265,cs),
+(85,97,o),
+(181,0,o),
+(356,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(146,422,o),
+(226,657,o),
+(490,657,cs),
+(646,657,l),
+(636,677,l),
+(499,35,l),
+(523,57,l),
+(367,57,ls),
+(223,57,o),
+(146,131,o),
+(146,267,cs)
+);
+}
+);
+width = 690;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15E1;
+unicode = 5601;
+},
+{
+color = 9;
+glyphname = "ttuCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(501,-13,o),
+(602,79,o),
+(644,277,cs),
+(737,714,l),
+(709,714,l),
+(392,514,l),
+(440,506,l),
+(206,714,l),
+(176,714,l),
+(88,301,ls),
+(45,99,o),
+(136,-13,o),
+(329,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(178,47,o),
+(116,130,o),
+(151,299,cs),
+(227,657,l),
+(198,649,l),
+(397,469,l),
+(416,469,l),
+(680,638,l),
+(660,654,l),
+(581,281,ls),
+(547,119,o),
+(468,47,o),
+(329,47,cs)
+);
+}
+);
+width = 713;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E2;
+unicode = 5602;
+},
+{
+color = 9;
+glyphname = "ttoCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(52,0,l),
+(369,200,l),
+(321,208,l),
+(555,0,l),
+(585,0,l),
+(673,413,ls),
+(716,615,o),
+(625,727,o),
+(432,727,cs),
+(260,727,o),
+(159,635,o),
+(117,437,cs),
+(24,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(583,667,o),
+(645,584,o),
+(610,415,cs),
+(534,57,l),
+(563,65,l),
+(364,245,l),
+(345,245,l),
+(81,76,l),
+(101,60,l),
+(180,433,ls),
+(214,595,o),
+(293,667,o),
+(432,667,cs)
+);
+}
+);
+width = 713;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E3;
+unicode = 5603;
+},
+{
+color = 9;
+glyphname = "tteCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (421,357);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(253,0,ls),
+(561,0,o),
+(664,257,o),
+(664,449,cs),
+(664,616,o),
+(567,714,o),
+(394,714,cs),
+(176,714,l),
+(171,694,l),
+(228,333,l),
+(234,386,l),
+(28,20,l),
+(24,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(280,347,l),
+(284,364,l),
+(233,685,l),
+(211,657,l),
+(381,657,ls),
+(526,657,o),
+(603,583,o),
+(603,447,cs),
+(603,293,o),
+(524,57,o),
+(259,57,cs),
+(87,57,l),
+(103,32,l)
+);
+}
+);
+width = 701;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15E4;
+unicode = 5604;
+},
+{
+color = 9;
+glyphname = "tteeCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (360,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 701;
+}
+);
+note = uni15E5;
+unicode = 5605;
+},
+{
+color = 9;
+glyphname = "ttiCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (343,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 701;
+}
+);
+note = uni15E6;
+unicode = 5606;
+},
+{
+color = 9;
+glyphname = "ttaCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(574,0,l),
+(578,20,l),
+(522,381,l),
+(515,328,l),
+(721,694,l),
+(725,714,l),
+(496,714,ls),
+(188,714,o),
+(85,457,o),
+(85,265,cs),
+(85,98,o),
+(182,0,o),
+(356,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(538,57,l),
+(368,57,ls),
+(224,57,o),
+(147,131,o),
+(147,267,cs),
+(147,421,o),
+(225,657,o),
+(490,657,cs),
+(662,657,l),
+(646,682,l),
+(469,367,l),
+(465,350,l),
+(516,29,l)
+);
+}
+);
+width = 701;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tteCarrier-canadian";
+note = uni15E7;
+unicode = 5607;
+},
+{
+color = 9;
+glyphname = "puCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(502,-13,o),
+(602,82,o),
+(644,275,cs),
+(737,714,l),
+(673,714,l),
+(635,535,l),
+(202,535,l),
+(240,714,l),
+(176,714,l),
+(89,304,ls),
+(45,100,o),
+(137,-13,o),
+(329,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(177,47,o),
+(115,130,o),
+(152,301,cs),
+(190,479,l),
+(623,479,l),
+(581,279,ls),
+(547,119,o),
+(469,47,o),
+(333,47,cs)
+);
+}
+);
+width = 714;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E8;
+unicode = 5608;
+},
+{
+color = 9;
+glyphname = "poCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(88,0,l),
+(126,179,l),
+(559,179,l),
+(521,0,l),
+(585,0,l),
+(672,410,ls),
+(716,614,o),
+(624,727,o),
+(432,727,cs),
+(259,727,o),
+(159,632,o),
+(117,439,cs),
+(24,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(180,435,ls),
+(214,595,o),
+(292,667,o),
+(428,667,cs),
+(584,667,o),
+(646,584,o),
+(609,413,cs),
+(571,235,l),
+(138,235,l)
+);
+}
+);
+width = 713;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E9;
+unicode = 5609;
+},
+{
+color = 9;
+glyphname = "peCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (407,357);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(248,0,ls),
+(567,0,o),
+(658,270,o),
+(658,449,cs),
+(658,617,o),
+(561,714,o),
+(388,714,cs),
+(170,714,l),
+(158,657,l),
+(251,657,l),
+(123,57,l),
+(30,57,l),
+(18,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(320,685,l),
+(277,657,l),
+(376,657,ls),
+(519,657,o),
+(596,583,o),
+(596,447,cs),
+(596,292,o),
+(517,57,o),
+(253,57,cs),
+(150,57,l),
+(181,29,l)
+);
+}
+);
+width = 695;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15EA;
+unicode = 5610;
+},
+{
+color = 9;
+glyphname = "peeCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (346,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 695;
+}
+);
+note = uni15EB;
+unicode = 5611;
+},
+{
+color = 9;
+glyphname = "piCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (329,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 695;
+}
+);
+note = uni15EC;
+unicode = 5612;
+},
+{
+color = 9;
+glyphname = "paCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(573,0,l),
+(585,57,l),
+(492,57,l),
+(620,657,l),
+(713,657,l),
+(725,714,l),
+(496,714,ls),
+(177,714,o),
+(85,444,o),
+(85,265,cs),
+(85,97,o),
+(182,0,o),
+(355,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(466,57,l),
+(368,57,ls),
+(224,57,o),
+(147,131,o),
+(147,267,cs),
+(147,422,o),
+(226,657,o),
+(490,657,cs),
+(594,657,l),
+(562,685,l),
+(423,29,l)
+);
+}
+);
+width = 695;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|peCarrier-canadian";
+note = uni15ED;
+unicode = 5613;
+},
+{
+color = 6;
+glyphname = "pCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(377,189,l),
+(387,234,l),
+(251,234,l),
+(317,546,l),
+(269,546,l),
+(203,234,l),
+(66,234,l),
+(56,189,l)
+);
+}
+);
+width = 457;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni15EE;
+unicode = 5614;
+},
+{
+color = 9;
+glyphname = "guCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (534,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(318,-13,o),
+(386,39,o),
+(425,139,c),
+(402,139,l),
+(409,44,o),
+(469,-13,o),
+(563,-13,cs),
+(674,-13,o),
+(747,59,o),
+(776,192,cs),
+(887,714,l),
+(825,714,l),
+(715,195,ls),
+(694,97,o),
+(641,45,o),
+(561,45,cs),
+(475,45,o),
+(435,107,o),
+(457,210,cs),
+(564,714,l),
+(504,714,l),
+(397,211,ls),
+(373,102,o),
+(318,45,o),
+(235,45,cs),
+(145,45,o),
+(110,104,o),
+(134,217,cs),
+(240,714,l),
+(178,714,l),
+(73,222,ls),
+(42,74,o),
+(98,-13,o),
+(226,-13,cs)
+);
+}
+);
+width = 865;
+}
+);
+metricRight = "=|";
+note = uni15EF;
+unicode = 5615;
+},
+{
+color = 9;
+glyphname = "goCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(88,0,l),
+(198,519,ls),
+(219,617,o),
+(272,669,o),
+(351,669,cs),
+(438,669,o),
+(478,607,o),
+(456,504,cs),
+(349,0,l),
+(409,0,l),
+(516,503,ls),
+(539,612,o),
+(594,669,o),
+(678,669,cs),
+(768,669,o),
+(802,610,o),
+(778,497,cs),
+(672,0,l),
+(734,0,l),
+(839,492,ls),
+(870,640,o),
+(815,727,o),
+(687,727,cs),
+(594,727,o),
+(527,675,o),
+(488,575,c),
+(511,575,l),
+(504,670,o),
+(444,727,o),
+(350,727,cs),
+(239,727,o),
+(165,655,o),
+(137,522,cs),
+(26,0,l)
+);
+}
+);
+width = 864;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F0;
+unicode = 5616;
+},
+{
+color = 9;
+glyphname = "geCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (453,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(357,0,ls),
+(522,0,o),
+(609,84,o),
+(609,215,cs),
+(609,288,o),
+(572,344,o),
+(506,362,c),
+(503,344,l),
+(629,365,o),
+(681,459,o),
+(681,553,cs),
+(681,650,o),
+(612,714,o),
+(502,714,cs),
+(183,714,l),
+(171,660,l),
+(487,660,ls),
+(571,660,o),
+(617,619,o),
+(617,549,cs),
+(617,446,o),
+(552,384,o),
+(430,384,cs),
+(113,384,l),
+(101,330,l),
+(420,330,ls),
+(502,330,o),
+(547,290,o),
+(547,220,cs),
+(547,126,o),
+(495,54,o),
+(359,54,cs),
+(43,54,l),
+(31,0,l)
+);
+}
+);
+width = 700;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15F1;
+unicode = 5617;
+},
+{
+color = 9;
+glyphname = "geeCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(357,0,ls),
+(522,0,o),
+(609,84,o),
+(609,215,cs),
+(609,288,o),
+(572,344,o),
+(506,362,c),
+(503,344,l),
+(629,365,o),
+(681,459,o),
+(681,553,cs),
+(681,650,o),
+(612,714,o),
+(502,714,cs),
+(183,714,l),
+(171,660,l),
+(487,660,ls),
+(571,660,o),
+(617,619,o),
+(617,549,cs),
+(617,446,o),
+(552,384,o),
+(430,384,cs),
+(370,384,l),
+(389,474,l),
+(347,474,l),
+(328,384,l),
+(113,384,l),
+(101,330,l),
+(316,330,l),
+(298,242,l),
+(340,242,l),
+(359,330,l),
+(420,330,ls),
+(502,330,o),
+(547,290,o),
+(547,220,cs),
+(547,126,o),
+(495,54,o),
+(359,54,cs),
+(43,54,l),
+(31,0,l)
+);
+}
+);
+width = 700;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F2;
+unicode = 5618;
+},
+{
+color = 9;
+glyphname = "giCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(357,0,ls),
+(522,0,o),
+(609,84,o),
+(609,215,cs),
+(609,288,o),
+(572,344,o),
+(506,363,c),
+(504,344,l),
+(630,365,o),
+(681,459,o),
+(681,553,cs),
+(681,650,o),
+(612,714,o),
+(502,714,cs),
+(183,714,l),
+(171,660,l),
+(487,660,ls),
+(571,660,o),
+(617,619,o),
+(617,549,cs),
+(617,446,o),
+(552,384,o),
+(430,384,cs),
+(386,384,l),
+(410,366,l),
+(407,399,o),
+(378,425,o),
+(344,425,cs),
+(316,425,o),
+(293,408,o),
+(284,384,c),
+(113,384,l),
+(101,330,l),
+(285,330,l),
+(294,307,o),
+(317,290,o),
+(344,290,cs),
+(378,290,o),
+(405,316,o),
+(409,348,c),
+(383,330,l),
+(420,330,ls),
+(502,330,o),
+(547,290,o),
+(547,220,cs),
+(547,126,o),
+(495,54,o),
+(359,54,cs),
+(43,54,l),
+(31,0,l)
+);
+}
+);
+width = 700;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F3;
+unicode = 5619;
+},
+{
+color = 9;
+glyphname = "gaCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (466,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(566,0,l),
+(577,54,l),
+(261,54,ls),
+(177,54,o),
+(131,95,o),
+(131,165,cs),
+(131,268,o),
+(197,330,o),
+(318,330,cs),
+(637,330,l),
+(648,384,l),
+(329,384,ls),
+(246,384,o),
+(202,424,o),
+(202,494,cs),
+(202,588,o),
+(253,660,o),
+(389,660,cs),
+(706,660,l),
+(717,714,l),
+(391,714,ls),
+(227,714,o),
+(139,630,o),
+(139,499,cs),
+(139,426,o),
+(177,370,o),
+(242,352,c),
+(245,370,l),
+(119,349,o),
+(67,255,o),
+(67,161,cs),
+(67,64,o),
+(136,0,o),
+(247,0,cs)
+);
+}
+);
+width = 702;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|geCarrier-canadian";
+note = uni15F4;
+unicode = 5620;
+},
+{
+color = 9;
+glyphname = "khuCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(316,-13,o),
+(383,36,o),
+(421,131,c),
+(404,132,l),
+(411,43,o),
+(471,-13,o),
+(563,-13,cs),
+(674,-13,o),
+(747,59,o),
+(776,192,cs),
+(887,714,l),
+(178,714,l),
+(73,222,ls),
+(42,74,o),
+(98,-13,o),
+(226,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(145,45,o),
+(110,104,o),
+(134,217,cs),
+(228,658,l),
+(492,658,l),
+(397,211,ls),
+(373,102,o),
+(318,45,o),
+(235,45,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(475,45,o),
+(435,107,o),
+(457,210,cs),
+(552,658,l),
+(813,658,l),
+(715,195,ls),
+(694,97,o),
+(641,45,o),
+(561,45,cs)
+);
+}
+);
+width = 865;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F5;
+unicode = 5621;
+},
+{
+color = 9;
+glyphname = "khoCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(734,0,l),
+(839,492,ls),
+(870,640,o),
+(815,727,o),
+(687,727,cs),
+(597,727,o),
+(530,678,o),
+(492,583,c),
+(509,582,l),
+(501,671,o),
+(442,727,o),
+(350,727,cs),
+(239,727,o),
+(165,655,o),
+(137,522,cs),
+(26,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(198,519,ls),
+(219,617,o),
+(272,669,o),
+(351,669,cs),
+(438,669,o),
+(477,607,o),
+(456,504,cs),
+(360,56,l),
+(100,56,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(516,503,ls),
+(539,612,o),
+(594,669,o),
+(678,669,cs),
+(768,669,o),
+(802,610,o),
+(778,497,cs),
+(684,56,l),
+(421,56,l)
+);
+}
+);
+width = 864;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F6;
+unicode = 5622;
+},
+{
+color = 9;
+glyphname = "kheCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(360,0,ls),
+(525,0,o),
+(613,84,o),
+(613,216,cs),
+(613,289,o),
+(575,344,o),
+(508,362,c),
+(506,344,l),
+(635,365,o),
+(684,462,o),
+(684,553,cs),
+(684,650,o),
+(615,714,o),
+(504,714,cs),
+(183,714,l),
+(31,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(165,331,l),
+(423,331,ls),
+(505,331,o),
+(550,291,o),
+(550,220,cs),
+(550,126,o),
+(498,54,o),
+(362,54,cs),
+(106,54,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(236,660,l),
+(490,660,ls),
+(574,660,o),
+(620,619,o),
+(620,549,cs),
+(620,447,o),
+(556,384,o),
+(433,384,cs),
+(177,384,l)
+);
+}
+);
+width = 704;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F7;
+unicode = 5623;
+},
+{
+color = 9;
+glyphname = "kheeCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(360,0,ls),
+(525,0,o),
+(613,84,o),
+(613,216,cs),
+(613,289,o),
+(575,344,o),
+(508,362,c),
+(506,344,l),
+(635,365,o),
+(684,462,o),
+(684,553,cs),
+(684,650,o),
+(615,714,o),
+(504,714,cs),
+(183,714,l),
+(31,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(165,331,l),
+(331,331,l),
+(312,239,l),
+(357,239,l),
+(379,345,l),
+(358,331,l),
+(423,331,ls),
+(505,331,o),
+(550,291,o),
+(550,220,cs),
+(550,126,o),
+(498,54,o),
+(362,54,cs),
+(106,54,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(407,476,l),
+(362,476,l),
+(343,384,l),
+(177,384,l),
+(236,660,l),
+(490,660,ls),
+(574,660,o),
+(620,619,o),
+(620,549,cs),
+(620,447,o),
+(556,384,o),
+(433,384,cs),
+(369,384,l),
+(385,370,l)
+);
+}
+);
+width = 704;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F8;
+unicode = 5624;
+},
+{
+color = 9;
+glyphname = "khiCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(360,0,ls),
+(525,0,o),
+(613,84,o),
+(613,216,cs),
+(613,287,o),
+(576,342,o),
+(511,362,c),
+(506,344,l),
+(635,365,o),
+(684,462,o),
+(684,553,cs),
+(684,650,o),
+(615,714,o),
+(504,714,cs),
+(183,714,l),
+(31,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(166,332,l),
+(298,332,l),
+(308,308,o),
+(331,290,o),
+(358,290,cs),
+(393,290,o),
+(420,317,o),
+(424,351,c),
+(385.002,331.992,l),
+(424,332,ls),
+(506,332,o),
+(550,291,o),
+(550,221,cs),
+(550,126,o),
+(498,54,o),
+(362,54,cs),
+(106,54,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(490,660,ls),
+(574,660,o),
+(620,619,o),
+(620,549,cs),
+(620,446,o),
+(557,383,o),
+(434,383,cs),
+(389,383,l),
+(424,364,l),
+(421,399,o),
+(393,425,o),
+(358,425,cs),
+(323,425,o),
+(295,398,o),
+(293,364,c),
+(317,383,l),
+(177,383,l),
+(236,660,l)
+);
+}
+);
+width = 704;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F9;
+unicode = 5625;
+},
+{
+color = 9;
+glyphname = "khaCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(568,0,l),
+(720,714,l),
+(391,714,ls),
+(226,714,o),
+(139,630,o),
+(139,498,cs),
+(139,425,o),
+(177,370,o),
+(243,352,c),
+(244,370,l),
+(116,349,o),
+(67,252,o),
+(67,161,cs),
+(67,64,o),
+(136,0,o),
+(247,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(176,54,o),
+(130,95,o),
+(130,165,cs),
+(130,267,o),
+(195,330,o),
+(318,330,cs),
+(574,330,l),
+(515,54,l),
+(260,54,ls)
+);
+},
+{
+closed = 1;
+nodes = (
+(246,383,o),
+(201,423,o),
+(201,494,cs),
+(201,588,o),
+(254,660,o),
+(389,660,cs),
+(645,660,l),
+(586,383,l),
+(328,383,ls)
+);
+}
+);
+width = 703;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15FA;
+unicode = 5626;
+},
+{
+color = 9;
+glyphname = "kkuCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(314,-13,o),
+(382,35,o),
+(421,131,c),
+(404,132,l),
+(411,44,o),
+(469,-13,o),
+(563,-13,cs),
+(674,-13,o),
+(747,58,o),
+(776,192,cs),
+(887,714,l),
+(857,714,l),
+(514,537,l),
+(501,471,l),
+(834,641,l),
+(813,662,l),
+(715,195,ls),
+(694,97,o),
+(641,45,o),
+(561,45,cs),
+(470,45,o),
+(436,113,o),
+(457,210,cs),
+(564,714,l),
+(504,714,l),
+(397,211,ls),
+(373,100,o),
+(316,45,o),
+(235,45,cs),
+(145,45,o),
+(110,103,o),
+(134,217,cs),
+(229,665,l),
+(199,653,l),
+(464,478,l),
+(476,537,l),
+(208,714,l),
+(178,714,l),
+(73,222,ls),
+(42,73,o),
+(99,-13,o),
+(226,-13,cs)
+);
+}
+);
+width = 865;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FB;
+unicode = 5627;
+},
+{
+color = 9;
+glyphname = "kkoCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(55,0,l),
+(398,177,l),
+(411,243,l),
+(79,73,l),
+(99,52,l),
+(198,519,ls),
+(219,617,o),
+(271,669,o),
+(351,669,cs),
+(442,669,o),
+(476,601,o),
+(456,504,cs),
+(348,0,l),
+(408,0,l),
+(515,503,ls),
+(539,614,o),
+(596,669,o),
+(678,669,cs),
+(767,669,o),
+(802,611,o),
+(778,497,cs),
+(683,49,l),
+(713,61,l),
+(448,236,l),
+(436,177,l),
+(704,0,l),
+(734,0,l),
+(839,492,ls),
+(871,641,o),
+(813,727,o),
+(687,727,cs),
+(598,727,o),
+(530,679,o),
+(491,583,c),
+(509,582,l),
+(501,670,o),
+(443,727,o),
+(349,727,cs),
+(239,727,o),
+(166,656,o),
+(137,522,cs),
+(26,0,l)
+);
+}
+);
+width = 864;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FC;
+unicode = 5628;
+},
+{
+color = 9;
+glyphname = "kkeCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(375,0,ls),
+(539,0,o),
+(627,84,o),
+(627,215,cs),
+(627,288,o),
+(590,344,o),
+(521,363,c),
+(520,344,l),
+(649,365,o),
+(699,461,o),
+(699,553,cs),
+(699,651,o),
+(630,714,o),
+(518,714,cs),
+(181,714,l),
+(176,694,l),
+(224,384,l),
+(116,384,l),
+(104,330,l),
+(210,330,l),
+(33,20,l),
+(29,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(276,330,l),
+(438,330,ls),
+(520,330,o),
+(564,290,o),
+(564,220,cs),
+(564,127,o),
+(513,54,o),
+(377,54,cs),
+(89,54,l),
+(106,30,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(239,688,l),
+(216,660,l),
+(504,660,ls),
+(589,660,o),
+(635,619,o),
+(635,549,cs),
+(635,445,o),
+(569,384,o),
+(447,384,cs),
+(286,384,l)
+);
+}
+);
+width = 718;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni15FD;
+unicode = 5629;
+},
+{
+color = 9;
+glyphname = "kkeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(375,0,ls),
+(539,0,o),
+(627,84,o),
+(627,215,cs),
+(627,288,o),
+(590,344,o),
+(521,363,c),
+(520,344,l),
+(649,365,o),
+(699,461,o),
+(699,553,cs),
+(699,651,o),
+(630,714,o),
+(518,714,cs),
+(181,714,l),
+(176,694,l),
+(224,384,l),
+(116,384,l),
+(104,330,l),
+(210,330,l),
+(33,20,l),
+(29,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(277,332,l),
+(366,332,l),
+(347,239,l),
+(392,239,l),
+(415,348,l),
+(395,332,l),
+(439,332,ls),
+(521,332,o),
+(564,290,o),
+(564,220,cs),
+(564,127,o),
+(513,54,o),
+(377,54,cs),
+(89,54,l),
+(106,30,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(443,476,l),
+(397,476,l),
+(378,383,l),
+(286,383,l),
+(239,688,l),
+(216,660,l),
+(504,660,ls),
+(589,660,o),
+(635,619,o),
+(635,549,cs),
+(635,445,o),
+(569,383,o),
+(448,383,cs),
+(406,383,l),
+(420,369,l)
+);
+}
+);
+width = 718;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FE;
+unicode = 5630;
+},
+{
+color = 9;
+glyphname = "kkiCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(375,0,ls),
+(539,0,o),
+(627,84,o),
+(627,215,cs),
+(627,288,o),
+(590,344,o),
+(521,363,c),
+(520,344,l),
+(649,365,o),
+(699,461,o),
+(699,553,cs),
+(699,651,o),
+(630,714,o),
+(518,714,cs),
+(181,714,l),
+(176,694,l),
+(224,384,l),
+(116,384,l),
+(104,330,l),
+(210,330,l),
+(33,20,l),
+(29,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(277,332,l),
+(330,332,l),
+(339,308,o),
+(362,290,o),
+(390,290,cs),
+(423,290,o),
+(449,315,o),
+(453,347,c),
+(413,332,l),
+(439,332,ls),
+(521,332,o),
+(564,290,o),
+(564,220,cs),
+(564,127,o),
+(513,54,o),
+(377,54,cs),
+(89,54,l),
+(106,30,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(451,400,o),
+(423,425,o),
+(389,425,cs),
+(361,425,o),
+(338,407,o),
+(329,382,c),
+(286,382,l),
+(239,688,l),
+(216,660,l),
+(504,660,ls),
+(589,660,o),
+(635,619,o),
+(635,549,cs),
+(635,445,o),
+(569,382,o),
+(448,382,cs),
+(414,382,l),
+(454,367,l)
+);
+}
+);
+width = 718;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FF;
+unicode = 5631;
+},
+{
+color = 9;
+glyphname = "kkaCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(585,0,l),
+(590,20,l),
+(542,330,l),
+(651,330,l),
+(662,384,l),
+(556,384,l),
+(733,694,l),
+(737,714,l),
+(391,714,ls),
+(227,714,o),
+(139,630,o),
+(139,499,cs),
+(139,426,o),
+(176,370,o),
+(245,351,c),
+(246,370,l),
+(117,349,o),
+(67,253,o),
+(67,161,cs),
+(67,63,o),
+(136,0,o),
+(248,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(550,54,l),
+(262,54,ls),
+(177,54,o),
+(131,95,o),
+(131,165,cs),
+(131,269,o),
+(197,330,o),
+(319,330,cs),
+(480,330,l),
+(528,26,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(246,384,o),
+(202,424,o),
+(202,494,cs),
+(202,587,o),
+(253,660,o),
+(389,660,cs),
+(677,660,l),
+(660,684,l),
+(490,384,l),
+(329,384,ls)
+);
+}
+);
+width = 718;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|kkeCarrier-canadian";
+note = uni1600;
+unicode = 5632;
+},
+{
+color = 6;
+glyphname = "kkCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(392,546,l),
+(193,234,l),
+(228,234,l),
+(161,546,l),
+(119,546,l),
+(116,534,l),
+(195,189,l),
+(211,189,l),
+(437,534,l),
+(440,546,l)
+);
+}
+);
+width = 431;
+}
+);
+note = uni1601;
+unicode = 5633;
+},
+{
+color = 9;
+glyphname = "nuCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(495,-13,o),
+(604,84,o),
+(641,262,cs),
+(651,309,l),
+(587,309,l),
+(578,266,ls),
+(548,121,o),
+(464,46,o),
+(335,46,cs),
+(185,46,o),
+(118,141,o),
+(152,305,cs),
+(240,714,l),
+(176,714,l),
+(89,305,ls),
+(48,112,o),
+(143,-13,o),
+(331,-13,cs)
+);
+}
+);
+width = 710;
+}
+);
+metricLeft = "te-canadian";
+note = uni1602;
+unicode = 5634;
+},
+{
+color = 9;
+glyphname = "noCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(582,0,l),
+(669,409,ls),
+(710,602,o),
+(615,727,o),
+(427,727,cs),
+(263,727,o),
+(154,630,o),
+(117,452,cs),
+(107,405,l),
+(171,405,l),
+(180,448,ls),
+(210,593,o),
+(294,668,o),
+(423,668,cs),
+(573,668,o),
+(640,573,o),
+(605,409,cs),
+(518,0,l)
+);
+}
+);
+width = 710;
+}
+);
+metricLeft = "=|nuCarrier-canadian";
+metricRight = "te-canadian";
+note = uni1603;
+unicode = 5635;
+},
+{
+color = 9;
+glyphname = "neCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (322,357);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(250,0,ls),
+(560,0,o),
+(654,263,o),
+(654,448,cs),
+(654,617,o),
+(556,714,o),
+(382,714,cs),
+(157,714,l),
+(145,656,l),
+(374,656,ls),
+(515,656,o),
+(591,582,o),
+(591,446,cs),
+(591,297,o),
+(520,58,o),
+(257,58,cs),
+(236,58,l),
+(224,0,l)
+);
+}
+);
+width = 691;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1604;
+unicode = 5636;
+},
+{
+color = 9;
+glyphname = "neeCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "neCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (257,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 691;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1605;
+unicode = 5637;
+},
+{
+color = 9;
+glyphname = "niCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "neCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (234,0);
+ref = dot_middle;
+}
+);
+width = 691;
+}
+);
+note = uni1606;
+unicode = 5638;
+},
+{
+color = 9;
+glyphname = "naCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(582,0,l),
+(595,58,l),
+(366,58,ls),
+(224,58,o),
+(148,132,o),
+(148,268,cs),
+(148,417,o),
+(219,656,o),
+(482,656,cs),
+(503,656,l),
+(515,714,l),
+(489,714,ls),
+(180,714,o),
+(85,451,o),
+(85,266,cs),
+(85,97,o),
+(183,0,o),
+(357,0,cs)
+);
+}
+);
+width = 692;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni1607;
+unicode = 5639;
+},
+{
+color = 9;
+glyphname = "muCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(316,-13,o),
+(386,37,o),
+(425,139,c),
+(402,139,l),
+(409,46,o),
+(467,-13,o),
+(563,-13,cs),
+(674,-13,o),
+(747,59,o),
+(776,192,cs),
+(820,402,l),
+(757,402,l),
+(713,195,ls),
+(693,97,o),
+(640,45,o),
+(562,45,cs),
+(471,45,o),
+(437,113,o),
+(458,209,cs),
+(498,402,l),
+(437,402,l),
+(396,211,ls),
+(372,100,o),
+(316,45,o),
+(235,45,cs),
+(146,45,o),
+(111,102,o),
+(136,217,cs),
+(241,714,l),
+(178,714,l),
+(73,222,ls),
+(42,73,o),
+(99,-13,o),
+(226,-13,cs)
+);
+}
+);
+width = 865;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "=|";
+note = uni1608;
+unicode = 5640;
+},
+{
+color = 9;
+glyphname = "moCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(735,0,l),
+(839,492,ls),
+(871,641,o),
+(814,727,o),
+(687,727,cs),
+(596,727,o),
+(527,677,o),
+(488,575,c),
+(511,575,l),
+(504,668,o),
+(446,727,o),
+(350,727,cs),
+(239,727,o),
+(166,655,o),
+(137,522,cs),
+(92,312,l),
+(156,312,l),
+(200,519,ls),
+(220,617,o),
+(273,669,o),
+(351,669,cs),
+(442,669,o),
+(476,601,o),
+(455,505,cs),
+(414,312,l),
+(476,312,l),
+(517,503,ls),
+(541,614,o),
+(597,669,o),
+(678,669,cs),
+(767,669,o),
+(802,612,o),
+(777,497,cs),
+(672,0,l)
+);
+}
+);
+width = 865;
+}
+);
+metricLeft = "=|muCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni1609;
+unicode = 5641;
+},
+{
+color = 9;
+glyphname = "meCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(358,0,ls),
+(523,0,o),
+(610,84,o),
+(610,215,cs),
+(610,288,o),
+(573,344,o),
+(507,362,c),
+(504,344,l),
+(631,365,o),
+(682,459,o),
+(682,553,cs),
+(682,650,o),
+(613,714,o),
+(503,714,cs),
+(157,714,l),
+(146,660,l),
+(488,660,ls),
+(572,660,o),
+(618,619,o),
+(618,549,cs),
+(618,446,o),
+(553,384,o),
+(431,384,cs),
+(318,384,l),
+(307,330,l),
+(421,330,ls),
+(503,330,o),
+(548,290,o),
+(548,220,cs),
+(548,126,o),
+(496,54,o),
+(360,54,cs),
+(248,54,l),
+(237,0,l)
+);
+}
+);
+width = 701;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160A;
+unicode = 5642;
+},
+{
+color = 9;
+glyphname = "meeCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(358,0,ls),
+(523,0,o),
+(610,84,o),
+(610,215,cs),
+(610,288,o),
+(573,344,o),
+(507,362,c),
+(504,344,l),
+(631,365,o),
+(682,459,o),
+(682,553,cs),
+(682,650,o),
+(613,714,o),
+(503,714,cs),
+(157,714,l),
+(146,660,l),
+(488,660,ls),
+(572,660,o),
+(618,619,o),
+(618,549,cs),
+(618,446,o),
+(553,383,o),
+(431,383,cs),
+(363,383,l),
+(382,474,l),
+(336,474,l),
+(287,241,l),
+(333,241,l),
+(352,331,l),
+(422,331,ls),
+(503,331,o),
+(548,290,o),
+(548,220,cs),
+(548,126,o),
+(496,54,o),
+(360,54,cs),
+(248,54,l),
+(237,0,l)
+);
+}
+);
+width = 701;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160B;
+unicode = 5643;
+},
+{
+color = 9;
+glyphname = "miCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(358,0,ls),
+(521,0,o),
+(603,80,o),
+(609,204,cs),
+(613,282,o),
+(576,342,o),
+(507,362,c),
+(504,344,l),
+(626,364,o),
+(677,452,o),
+(681,541,cs),
+(687,644,o),
+(617,714,o),
+(503,714,cs),
+(157,714,l),
+(146,660,l),
+(488,660,ls),
+(574,660,o),
+(620,617,o),
+(618,545,cs),
+(616,442,o),
+(551,383,o),
+(431,383,cs),
+(367,383,l),
+(401,364,l),
+(399,400,o),
+(370,426,o),
+(335,426,cs),
+(298,426,o),
+(269,396,o),
+(269,359,cs),
+(269,323,o),
+(298,292,o),
+(335,292,cs),
+(369,292,o),
+(396,317,o),
+(401,350,c),
+(366,331,l),
+(421,331,ls),
+(505,331,o),
+(550,290,o),
+(547,216,cs),
+(545,122,o),
+(493,54,o),
+(360,54,cs),
+(248,54,l),
+(237,0,l)
+);
+}
+);
+width = 700;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160C;
+unicode = 5644;
+},
+{
+color = 9;
+glyphname = "maCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(593,0,l),
+(605,54,l),
+(261,54,ls),
+(177,54,o),
+(131,95,o),
+(131,165,cs),
+(131,268,o),
+(197,330,o),
+(318,330,cs),
+(431,330,l),
+(443,384,l),
+(329,384,ls),
+(246,384,o),
+(202,424,o),
+(202,494,cs),
+(202,588,o),
+(253,660,o),
+(389,660,cs),
+(501,660,l),
+(513,714,l),
+(391,714,ls),
+(227,714,o),
+(139,630,o),
+(139,499,cs),
+(139,426,o),
+(177,370,o),
+(242,352,c),
+(245,370,l),
+(119,349,o),
+(67,255,o),
+(67,161,cs),
+(67,64,o),
+(136,0,o),
+(247,0,cs)
+);
+}
+);
+width = 702;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni160D;
+unicode = 5645;
+},
+{
+color = 9;
+glyphname = "yuCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(533,-13,o),
+(648,107,o),
+(705,376,cs),
+(744,564,o),
+(724,727,o),
+(573,727,cs),
+(432,727,o),
+(381,574,o),
+(381,474,cs),
+(381,382,o),
+(430,326,o),
+(514,326,cs),
+(529,326,o),
+(542,328,o),
+(560,334,c),
+(571,385,l),
+(558,381,o),
+(543,379,o),
+(529,379,cs),
+(469,379,o),
+(438,414,o),
+(438,478,cs),
+(438,544,o),
+(468,673,o),
+(569,673,cs),
+(678,673,o),
+(677,544,o),
+(646,387,cs),
+(598,147,o),
+(509,47,o),
+(339,47,cs),
+(171,47,o),
+(119,149,o),
+(154,309,cs),
+(240,714,l),
+(176,714,l),
+(90,309,ls),
+(51,122,o),
+(127,-13,o),
+(336,-13,cs)
+);
+}
+);
+width = 753;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160E;
+unicode = 5646;
+},
+{
+color = 9;
+glyphname = "yoCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(368,-13,o),
+(420,140,o),
+(420,240,cs),
+(420,332,o),
+(371,388,o),
+(286,388,cs),
+(272,388,o),
+(259,386,o),
+(241,380,c),
+(230,329,l),
+(242,333,o),
+(257,335,o),
+(272,335,cs),
+(332,335,o),
+(363,300,o),
+(363,236,cs),
+(363,170,o),
+(333,41,o),
+(232,41,cs),
+(123,41,o),
+(123,170,o),
+(155,327,cs),
+(202,567,o),
+(292,667,o),
+(461,667,cs),
+(630,667,o),
+(681,565,o),
+(647,405,cs),
+(561,0,l),
+(625,0,l),
+(711,405,ls),
+(750,592,o),
+(674,727,o),
+(465,727,cs),
+(268,727,o),
+(152,607,o),
+(96,338,cs),
+(56,150,o),
+(77,-13,o),
+(227,-13,cs)
+);
+}
+);
+width = 753;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160F;
+unicode = 5647;
+},
+{
+color = 9;
+glyphname = "yeCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(541,-13,o),
+(654,239,o),
+(654,432,cs),
+(654,610,o),
+(551,714,o),
+(367,714,cs),
+(184,714,l),
+(172,656,l),
+(357,656,ls),
+(509,656,o),
+(590,575,o),
+(590,430,cs),
+(590,278,o),
+(514,43,o),
+(299,43,cs),
+(185,43,o),
+(120,98,o),
+(120,188,cs),
+(120,264,o),
+(161,362,o),
+(248,362,cs),
+(305,362,o),
+(337,325,o),
+(337,263,cs),
+(337,224,o),
+(327,185,o),
+(312,149,c),
+(364,149,l),
+(381,190,o),
+(392,230,o),
+(392,271,cs),
+(392,359,o),
+(338,414,o),
+(250,414,cs),
+(130,414,o),
+(62,298,o),
+(62,184,cs),
+(62,65,o),
+(151,-13,o),
+(296,-13,cs)
+);
+}
+);
+width = 694;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1610;
+unicode = 5648;
+},
+{
+color = 9;
+glyphname = "yeeCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(541,-13,o),
+(655,241,o),
+(655,435,cs),
+(655,610,o),
+(551,714,o),
+(369,714,cs),
+(185,714,l),
+(173,656,l),
+(358,656,ls),
+(510,656,o),
+(591,575,o),
+(591,431,cs),
+(591,289,o),
+(520,43,o),
+(300,43,cs),
+(186,43,o),
+(121,96,o),
+(121,187,cs),
+(121,259,o),
+(161,362,o),
+(252,362,cs),
+(325,362,o),
+(339,299,o),
+(324,229,cs),
+(313,180,l),
+(357,180,l),
+(429,520,l),
+(386,520,l),
+(341,311,l),
+(349,310,l),
+(350,376,o),
+(312,414,o),
+(246,414,cs),
+(125,414,o),
+(63,289,o),
+(63,184,cs),
+(63,65,o),
+(151,-13,o),
+(298,-13,cs)
+);
+}
+);
+width = 694;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1611;
+unicode = 5649;
+},
+{
+color = 9;
+glyphname = "yiCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(525,-13,o),
+(653,212,o),
+(653,435,cs),
+(653,610,o),
+(549,714,o),
+(367,714,cs),
+(184,714,l),
+(172,656,l),
+(357,656,ls),
+(509,656,o),
+(589,575,o),
+(589,431,cs),
+(589,249,o),
+(496,43,o),
+(299,43,cs),
+(184,43,o),
+(119,97,o),
+(119,184,cs),
+(119,266,o),
+(164,339,o),
+(265,336,c),
+(246,355,l),
+(247,321,o),
+(275,295,o),
+(309,295,cs),
+(344,295,o),
+(371,323,o),
+(371,358,cs),
+(371,393,o),
+(344,419,o),
+(308,419,cs),
+(283,419,o),
+(261,404,o),
+(253,383,c),
+(129,379,o),
+(61,291,o),
+(61,179,cs),
+(61,64,o),
+(150,-13,o),
+(296,-13,cs)
+);
+}
+);
+width = 694;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1612;
+unicode = 5650;
+},
+{
+color = 9;
+glyphname = "yaCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(558,0,l),
+(570,58,l),
+(384,58,ls),
+(233,58,o),
+(152,139,o),
+(152,284,cs),
+(152,436,o),
+(228,671,o),
+(443,671,cs),
+(556,671,o),
+(622,616,o),
+(622,526,cs),
+(622,450,o),
+(581,352,o),
+(493,352,cs),
+(437,352,o),
+(404,389,o),
+(404,451,cs),
+(404,490,o),
+(415,529,o),
+(429,565,c),
+(377,565,l),
+(360,524,o),
+(350,484,o),
+(350,443,cs),
+(350,355,o),
+(403,300,o),
+(492,300,cs),
+(611,300,o),
+(680,416,o),
+(680,530,cs),
+(680,649,o),
+(591,727,o),
+(446,727,cs),
+(201,727,o),
+(88,475,o),
+(88,282,cs),
+(88,104,o),
+(191,0,o),
+(374,0,cs)
+);
+}
+);
+width = 694;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|yeCarrier-canadian";
+note = uni1613;
+unicode = 5651;
+},
+{
+color = 9;
+glyphname = "juCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(535,-13,o),
+(642,112,o),
+(642,257,cs),
+(642,351,o),
+(587,414,o),
+(498,414,cs),
+(381,414,o),
+(325,311,o),
+(315,203,cs),
+(312,184,o),
+(311,165,o),
+(311,149,c),
+(364,149,l),
+(363,161,o),
+(364,177,o),
+(367,197,cs),
+(375,281,o),
+(412,362,o),
+(495,362,cs),
+(552,362,o),
+(585,321,o),
+(585,256,cs),
+(585,142,o),
+(508,43,o),
+(367,43,cs),
+(228,43,o),
+(148,118,o),
+(148,247,cs),
+(148,468,o),
+(326,656,o),
+(631,656,cs),
+(721,656,l),
+(733,714,l),
+(175,714,l),
+(163,657,l),
+(508,657,l),
+(573,682,l),
+(284,680,o),
+(84,496,o),
+(84,249,cs),
+(84,91,o),
+(191,-13,o),
+(361,-13,cs)
+);
+}
+);
+width = 714;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni1614;
+unicode = 5652;
+},
+{
+color = 9;
+glyphname = "juSayisi-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (474,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(546,-13,o),
+(654,195,o),
+(657,377,cs),
+(661,568,o),
+(538,681,o),
+(310,685,c),
+(388,657,l),
+(726,657,l),
+(738,714,l),
+(179,714,l),
+(167,656,l),
+(257,656,ls),
+(485,656,o),
+(598,561,o),
+(595,383,cs),
+(593,241,o),
+(525,43,o),
+(305,43,cs),
+(182,43,o),
+(117,99,o),
+(118,191,cs),
+(118,274,o),
+(167,362,o),
+(248,362,cs),
+(304,362,o),
+(335,325,o),
+(334,261,cs),
+(334,225,o),
+(323,181,o),
+(309,149,c),
+(361,149,l),
+(381,192,o),
+(387,236,o),
+(388,268,cs),
+(390,358,o),
+(338,414,o),
+(250,414,cs),
+(136,414,o),
+(63,304,o),
+(61,189,cs),
+(58,67,o),
+(146,-13,o),
+(303,-13,cs)
+);
+}
+);
+width = 711;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1615;
+unicode = 5653;
+},
+{
+color = 9;
+glyphname = "joCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(587,0,l),
+(599,57,l),
+(253,57,l),
+(189,32,l),
+(478,34,o),
+(677,218,o),
+(677,465,cs),
+(677,623,o),
+(570,727,o),
+(401,727,cs),
+(227,727,o),
+(120,602,o),
+(120,457,cs),
+(120,363,o),
+(175,300,o),
+(264,300,cs),
+(380,300,o),
+(437,403,o),
+(447,511,cs),
+(450,530,o),
+(451,549,o),
+(450,565,c),
+(398,565,l),
+(398,553,o),
+(398,537,o),
+(395,517,cs),
+(387,433,o),
+(349,352,o),
+(267,352,cs),
+(209,352,o),
+(177,393,o),
+(177,458,cs),
+(177,572,o),
+(254,671,o),
+(395,671,cs),
+(533,671,o),
+(613,596,o),
+(613,467,cs),
+(613,246,o),
+(436,58,o),
+(131,58,cs),
+(41,58,l),
+(29,0,l)
+);
+}
+);
+width = 713;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1616;
+unicode = 5654;
+},
+{
+color = 9;
+glyphname = "jeCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(662,-13,o),
+(709,319,o),
+(709,453,cs),
+(709,629,o),
+(630,727,o),
+(478,727,cs),
+(338,727,o),
+(237,639,o),
+(178,465,c),
+(190,448,l),
+(247,714,l),
+(183,714,l),
+(31,0,l),
+(95,0,l),
+(158,297,ls),
+(210,544,o),
+(313,668,o),
+(467,668,cs),
+(590,668,o),
+(648,595,o),
+(648,451,cs),
+(648,363,o),
+(619,41,o),
+(464,41,cs),
+(406,41,o),
+(373,79,o),
+(373,145,cs),
+(373,223,o),
+(408,335,o),
+(522,335,cs),
+(539,335,o),
+(553,333,o),
+(566,329,c),
+(577,380,l),
+(560,386,o),
+(541,388,o),
+(519,388,cs),
+(369,388,o),
+(316,246,o),
+(316,142,cs),
+(316,47,o),
+(370,-13,o),
+(459,-13,cs)
+);
+}
+);
+width = 759;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "te-canadian";
+note = uni1617;
+unicode = 5655;
+},
+{
+color = 9;
+glyphname = "jeeCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(661,-13,o),
+(709,319,o),
+(709,452,cs),
+(709,629,o),
+(630,727,o),
+(478,727,cs),
+(337,727,o),
+(237,639,o),
+(178,464,c),
+(190,448,l),
+(247,714,l),
+(183,714,l),
+(31,0,l),
+(95,0,l),
+(158,295,ls),
+(210,544,o),
+(313,668,o),
+(467,668,cs),
+(590,668,o),
+(648,594,o),
+(648,451,cs),
+(648,355,o),
+(617,41,o),
+(457,41,cs),
+(394,41,o),
+(359,81,o),
+(359,150,cs),
+(359,221,o),
+(388,326,o),
+(485,340,c),
+(465,245,l),
+(505,245,l),
+(552,470,l),
+(512,470,l),
+(494,383,l),
+(360,366,o),
+(316,235,o),
+(316,141,cs),
+(316,47,o),
+(370,-13,o),
+(460,-13,cs)
+);
+}
+);
+width = 759;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1618;
+unicode = 5656;
+},
+{
+color = 9;
+glyphname = "jiCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(661,-13,o),
+(709,319,o),
+(709,452,cs),
+(709,629,o),
+(630,727,o),
+(478,727,cs),
+(337,727,o),
+(237,639,o),
+(178,464,c),
+(190,448,l),
+(247,714,l),
+(183,714,l),
+(31,0,l),
+(95,0,l),
+(158,295,ls),
+(210,544,o),
+(313,668,o),
+(467,668,cs),
+(590,668,o),
+(648,594,o),
+(648,451,cs),
+(648,355,o),
+(617,41,o),
+(457,41,cs),
+(394,41,o),
+(359,81,o),
+(359,150,cs),
+(359,210,o),
+(380,295,o),
+(448,325,c),
+(456,308,o),
+(474,295,o),
+(496,295,cs),
+(531,295,o),
+(556,323,o),
+(556,358,cs),
+(556,393,o),
+(530,419,o),
+(495,419,cs),
+(462,419,o),
+(437,394,o),
+(435,361,c),
+(345,324,o),
+(316,219,o),
+(316,141,cs),
+(316,47,o),
+(370,-13,o),
+(460,-13,cs)
+);
+}
+);
+width = 759;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1619;
+unicode = 5657;
+},
+{
+color = 9;
+glyphname = "jiSayisi-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(634,-13,o),
+(731,349,o),
+(731,532,cs),
+(731,659,o),
+(681,727,o),
+(584,727,cs),
+(440,727,o),
+(387,569,o),
+(387,471,cs),
+(387,379,o),
+(438,326,o),
+(515,326,cs),
+(535,326,o),
+(555,329,o),
+(566,334,c),
+(578,386,l),
+(566,381,o),
+(551,379,o),
+(535,379,cs),
+(476,379,o),
+(443,410,o),
+(443,476,cs),
+(443,533,o),
+(473,673,o),
+(580,673,cs),
+(642,673,o),
+(671,629,o),
+(671,537,cs),
+(671,390,o),
+(597,46,o),
+(359,46,cs),
+(159,46,o),
+(148,250,o),
+(186,428,cs),
+(247,714,l),
+(183,714,l),
+(31,0,l),
+(95,0,l),
+(166,340,l),
+(152,352,l),
+(113,170,o),
+(159,-13,o),
+(361,-13,cs)
+);
+}
+);
+width = 761;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161A;
+unicode = 5658;
+},
+{
+color = 9;
+glyphname = "jaCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (472,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(471,-12,o),
+(571,75,o),
+(630,250,c),
+(618,267,l),
+(562,0,l),
+(625,0,l),
+(777,714,l),
+(713,714,l),
+(650,417,ls),
+(598,171,o),
+(495,46,o),
+(341,46,cs),
+(219,46,o),
+(160,119,o),
+(160,264,cs),
+(160,351,o),
+(190,673,o),
+(344,673,cs),
+(403,673,o),
+(436,635,o),
+(436,570,cs),
+(436,491,o),
+(400,379,o),
+(286,379,cs),
+(270,379,o),
+(256,381,o),
+(242,386,c),
+(232,334,l),
+(249,328,o),
+(267,326,o),
+(289,326,cs),
+(440,326,o),
+(492,469,o),
+(492,573,cs),
+(492,668,o),
+(439,727,o),
+(349,727,cs),
+(147,727,o),
+(98,395,o),
+(98,261,cs),
+(98,86,o),
+(179,-12,o),
+(330,-12,cs)
+);
+}
+);
+width = 760;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni161B;
+unicode = 5659;
+},
+{
+color = 9;
+glyphname = "jjuCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(519,-13,o),
+(627,110,o),
+(627,257,cs),
+(627,351,o),
+(571,414,o),
+(481,414,cs),
+(390,414,o),
+(328,354,o),
+(304,240,cs),
+(296,208,o),
+(293,176,o),
+(293,149,c),
+(346,149,l),
+(346,173,o),
+(348,200,o),
+(355,231,cs),
+(374,316,o),
+(415,362,o),
+(477,362,cs),
+(536,362,o),
+(570,320,o),
+(570,255,cs),
+(570,140,o),
+(489,43,o),
+(352,43,cs),
+(220,43,o),
+(147,118,o),
+(147,252,cs),
+(147,445,o),
+(258,656,o),
+(562,656,cs),
+(699,656,l),
+(711,714,l),
+(574,714,ls),
+(434,714,o),
+(330,678,o),
+(254,622,c),
+(172,727,l),
+(120,686,l),
+(205,579,l),
+(115,489,o),
+(84,361,o),
+(84,256,cs),
+(84,91,o),
+(183,-13,o),
+(348,-13,cs)
+);
+}
+);
+width = 699;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni161C;
+unicode = 5660;
+},
+{
+color = 9;
+glyphname = "jjoCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(627,28,l),
+(542,135,l),
+(632,225,o),
+(663,353,o),
+(663,458,cs),
+(663,623,o),
+(564,727,o),
+(399,727,cs),
+(228,727,o),
+(120,604,o),
+(120,457,cs),
+(120,363,o),
+(176,300,o),
+(266,300,cs),
+(357,300,o),
+(419,360,o),
+(443,474,cs),
+(451,506,o),
+(454,538,o),
+(454,565,c),
+(402,565,l),
+(401,541,o),
+(399,514,o),
+(392,483,cs),
+(373,398,o),
+(332,352,o),
+(270,352,cs),
+(211,352,o),
+(177,394,o),
+(177,459,cs),
+(177,574,o),
+(258,671,o),
+(395,671,cs),
+(527,671,o),
+(600,596,o),
+(600,462,cs),
+(600,269,o),
+(489,58,o),
+(185,58,cs),
+(48,58,l),
+(36,0,l),
+(173,0,ls),
+(313,0,o),
+(417,36,o),
+(493,92,c),
+(575,-13,l)
+);
+}
+);
+width = 699;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|jjuCarrier-canadian";
+note = uni161D;
+unicode = 5661;
+},
+{
+color = 9;
+glyphname = "jjeCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(666,-13,o),
+(714,320,o),
+(714,453,cs),
+(714,633,o),
+(630,727,o),
+(468,727,cs),
+(382,727,o),
+(307,699,o),
+(247,639,c),
+(176,726,l),
+(127,685,l),
+(204,590,l),
+(164,536,o),
+(135,464,o),
+(115,373,cs),
+(36,0,l),
+(100,0,l),
+(178,368,ls),
+(220,567,o),
+(317,668,o),
+(464,668,cs),
+(592,668,o),
+(653,598,o),
+(653,451,cs),
+(653,364,o),
+(623,41,o),
+(469,41,cs),
+(410,41,o),
+(377,79,o),
+(377,145,cs),
+(377,224,o),
+(413,335,o),
+(527,335,cs),
+(547,335,o),
+(560,333,o),
+(571,329,c),
+(581,380,l),
+(567,386,o),
+(548,388,o),
+(527,388,cs),
+(375,388,o),
+(321,246,o),
+(321,142,cs),
+(321,47,o),
+(374,-13,o),
+(464,-13,cs)
+);
+}
+);
+width = 764;
+}
+);
+metricRight = "jeCarrier-canadian";
+note = uni161E;
+unicode = 5662;
+},
+{
+color = 9;
+glyphname = "jjeeCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(666,-13,o),
+(714,320,o),
+(714,453,cs),
+(714,633,o),
+(630,727,o),
+(468,727,cs),
+(382,727,o),
+(307,699,o),
+(247,639,c),
+(176,726,l),
+(127,685,l),
+(204,590,l),
+(164,536,o),
+(135,464,o),
+(115,373,cs),
+(36,0,l),
+(100,0,l),
+(178,368,ls),
+(220,567,o),
+(317,668,o),
+(464,668,cs),
+(592,668,o),
+(653,598,o),
+(653,451,cs),
+(653,362,o),
+(624,41,o),
+(462,41,cs),
+(400,41,o),
+(363,81,o),
+(363,151,cs),
+(363,225,o),
+(392,324,o),
+(484,340,c),
+(464,245,l),
+(504,245,l),
+(551,469,l),
+(511,469,l),
+(493,381,l),
+(365,364,o),
+(321,237,o),
+(321,142,cs),
+(321,47,o),
+(374,-13,o),
+(464,-13,cs)
+);
+}
+);
+width = 764;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161F;
+unicode = 5663;
+},
+{
+color = 9;
+glyphname = "jjiCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(626,-13,o),
+(682,202,o),
+(705,363,cs),
+(735,595,o),
+(652,727,o),
+(467,727,cs),
+(378,727,o),
+(304,697,o),
+(246,640,c),
+(176,726,l),
+(127,685,l),
+(204,591,l),
+(164,536,o),
+(134,463,o),
+(115,373,cs),
+(36,0,l),
+(100,0,l),
+(178,368,ls),
+(220,567,o),
+(317,668,o),
+(464,667.995,cs),
+(609,668,o),
+(669,567,o),
+(644,368,cs),
+(626,242,o),
+(593,41,o),
+(462,41,cs),
+(391,41,o),
+(357,93,o),
+(367,182,cs),
+(373,244,o),
+(395,305,o),
+(454,326,c),
+(462,308,o),
+(481,295,o),
+(503,295,cs),
+(539,295,o),
+(564,324,o),
+(564,358,cs),
+(564,393,o),
+(538,419,o),
+(503,419,cs),
+(469,419,o),
+(446,393,o),
+(443,363,c),
+(367,335,o),
+(333,258,o),
+(325,179,cs),
+(311,62,o),
+(365,-13,o),
+(464,-13,cs)
+);
+}
+);
+width = 759;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1620;
+unicode = 5664;
+},
+{
+color = 9;
+glyphname = "jjaCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(430,-13,o),
+(506,15,o),
+(566,75,c),
+(636,-12,l),
+(686,29,l),
+(608,124,l),
+(648,178,o),
+(678,250,o),
+(697,341,cs),
+(776,714,l),
+(713,714,l),
+(635,346,ls),
+(592,147,o),
+(495,46,o),
+(348,46,cs),
+(221,46,o),
+(160,116,o),
+(160,263,cs),
+(160,350,o),
+(189,673,o),
+(344,673,cs),
+(402,673,o),
+(435,635,o),
+(435,569,cs),
+(435,490,o),
+(399,379,o),
+(286,379,cs),
+(266,379,o),
+(252,381,o),
+(242,385,c),
+(231,334,l),
+(245,328,o),
+(264,326,o),
+(285,326,cs),
+(438,326,o),
+(492,468,o),
+(492,572,cs),
+(492,667,o),
+(438,727,o),
+(348,727,cs),
+(146,727,o),
+(98,394,o),
+(98,261,cs),
+(98,81,o),
+(183,-13,o),
+(345,-13,cs)
+);
+}
+);
+width = 765;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "=|jjeCarrier-canadian";
+note = uni1621;
+unicode = 5665;
+},
+{
+color = 9;
+glyphname = "luCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(500,-13,o),
+(602,82,o),
+(643,275,cs),
+(736,714,l),
+(672,714,l),
+(580,281,ls),
+(546,122,o),
+(468,46,o),
+(339,46,cs),
+(212,46,o),
+(145,120,o),
+(145,245,cs),
+(145,420,o),
+(255,652,o),
+(476,661,c),
+(488,714,l),
+(166,714,l),
+(155,660,l),
+(366,660,l),
+(406,676,l),
+(199,653,o),
+(81,425,o),
+(81,242,cs),
+(81,86,o),
+(175,-13,o),
+(336,-13,cs)
+);
+}
+);
+width = 713;
+}
+);
+metricRight = "te-canadian";
+note = uni1622;
+unicode = 5666;
+},
+{
+color = 9;
+glyphname = "loCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(88,0,l),
+(180,433,ls),
+(214,592,o),
+(291,668,o),
+(421,668,cs),
+(548,668,o),
+(615,594,o),
+(615,469,cs),
+(615,294,o),
+(505,62,o),
+(284,53,c),
+(272,0,l),
+(594,0,l),
+(605,54,l),
+(394,54,l),
+(354,38,l),
+(561,61,o),
+(679,289,o),
+(679,472,cs),
+(679,628,o),
+(585,727,o),
+(423,727,cs),
+(260,727,o),
+(158,632,o),
+(117,439,cs),
+(24,0,l)
+);
+}
+);
+width = 712;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|luCarrier-canadian";
+note = uni1623;
+unicode = 5667;
+},
+{
+color = 9;
+glyphname = "leCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (368,358);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(240,0,ls),
+(556,0,o),
+(651,262,o),
+(651,459,cs),
+(651,623,o),
+(571,727,o),
+(435,727,cs),
+(323,727,o),
+(234,654,o),
+(186,523,c),
+(196,523,l),
+(237,714,l),
+(179,714,l),
+(112,399,l),
+(166,399,l),
+(208,571,o),
+(299,668,o),
+(419,668,cs),
+(527,668,o),
+(587,589,o),
+(587,456,cs),
+(587,287,o),
+(504,58,o),
+(248,58,cs),
+(40,58,l),
+(27,0,l)
+);
+}
+);
+width = 687;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1624;
+unicode = 5668;
+},
+{
+color = 9;
+glyphname = "leeCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "leCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (303,1);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 687;
+}
+);
+metricLeft = "leCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1625;
+unicode = 5669;
+},
+{
+color = 9;
+glyphname = "liCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "leCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (280,1);
+ref = dot_middle;
+}
+);
+width = 687;
+}
+);
+note = uni1626;
+unicode = 5670;
+},
+{
+color = 9;
+glyphname = "laCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(557,0,l),
+(569,58,l),
+(379,58,ls),
+(224,58,o),
+(150,130,o),
+(150,271,cs),
+(150,416,o),
+(226,668,o),
+(429,668,cs),
+(557,668,o),
+(618,563,o),
+(588,399,c),
+(642,399,l),
+(709,714,l),
+(651,714,l),
+(607,508,l),
+(617,507,l),
+(621,643,o),
+(548,727,o),
+(423,727,cs),
+(186,727,o),
+(86,445,o),
+(86,270,cs),
+(86,97,o),
+(182,0,o),
+(370,0,cs)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|leCarrier-canadian";
+note = uni1627;
+unicode = 5671;
+},
+{
+color = 1;
+glyphname = "dluCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(581,-13,o),
+(664,265,o),
+(664,421,cs),
+(664,563,o),
+(594,659,o),
+(474,680,c),
+(490,664,l),
+(724,664,l),
+(706,577,l),
+(756,577,l),
+(803,800,l),
+(754,800,l),
+(735,714,l),
+(424,714,l),
+(412,661,l),
+(539,648,o),
+(604,567,o),
+(604,433,cs),
+(604,308,o),
+(544,46,o),
+(320,46,cs),
+(179,46,o),
+(117,137,o),
+(151,298,cs),
+(240,714,l),
+(176,714,l),
+(88,302,ls),
+(47,107,o),
+(135,-13,o),
+(317,-13,cs)
+);
+}
+);
+width = 745;
+}
+);
+metricLeft = "te-canadian";
+note = uni1628;
+unicode = 5672;
+},
+{
+color = 9;
+glyphname = "dloCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(615,-86,l),
+(663,137,l),
+(613,137,l),
+(595,51,l),
+(393,51,l),
+(385,44,l),
+(570,74,o),
+(679,293,o),
+(679,472,cs),
+(679,628,o),
+(585,727,o),
+(423,727,cs),
+(260,727,o),
+(158,632,o),
+(117,439,cs),
+(24,0,l),
+(88,0,l),
+(180,433,ls),
+(214,592,o),
+(291,668,o),
+(421,668,cs),
+(548,668,o),
+(615,594,o),
+(615,469,cs),
+(615,294,o),
+(505,62,o),
+(284,53,c),
+(272,0,l),
+(584,0,l),
+(566,-86,l)
+);
+}
+);
+width = 746;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "dluCarrier-canadian";
+note = uni1629;
+unicode = 5673;
+},
+{
+color = 9;
+glyphname = "dleCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (378,358);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(251,0,ls),
+(567,0,o),
+(662,262,o),
+(662,459,cs),
+(662,623,o),
+(581,727,o),
+(446,727,cs),
+(332,727,o),
+(234,648,o),
+(184,510,c),
+(194,510,l),
+(239,728,l),
+(323,728,l),
+(333,776,l),
+(123,776,l),
+(112,728,l),
+(193,728,l),
+(123,399,l),
+(177,399,l),
+(219,571,o),
+(310,668,o),
+(430,668,cs),
+(538,668,o),
+(598,589,o),
+(598,456,cs),
+(598,287,o),
+(514,58,o),
+(259,58,cs),
+(50,58,l),
+(38,0,l)
+);
+}
+);
+width = 698;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni162A;
+unicode = 5674;
+},
+{
+color = 9;
+glyphname = "dleeCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (313,1);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 698;
+}
+);
+note = uni162B;
+unicode = 5675;
+},
+{
+color = 9;
+glyphname = "dliCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (290,1);
+ref = dot_middle;
+}
+);
+width = 698;
+}
+);
+note = uni162C;
+unicode = 5676;
+},
+{
+color = 9;
+glyphname = "dlaCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(557,0,l),
+(569,58,l),
+(379,58,ls),
+(224,58,o),
+(150,130,o),
+(150,271,cs),
+(150,416,o),
+(226,668,o),
+(429,668,cs),
+(557,668,o),
+(618,563,o),
+(588,399,c),
+(642,399,l),
+(712,728,l),
+(791,728,l),
+(801,776,l),
+(591,776,l),
+(582,728,l),
+(662,728,l),
+(615,506,l),
+(624,505,l),
+(628,643,o),
+(548,727,o),
+(423,727,cs),
+(186,727,o),
+(86,445,o),
+(86,270,cs),
+(86,97,o),
+(182,0,o),
+(370,0,cs)
+);
+}
+);
+width = 697;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni162D;
+unicode = 5677;
+},
+{
+color = 9;
+glyphname = "lhuCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(615,-13,o),
+(708,238,o),
+(708,424,cs),
+(708,552,o),
+(655,644,o),
+(558,679,c),
+(575,659,l),
+(775,659,l),
+(787,714,l),
+(537,714,l),
+(525,661,l),
+(605,631,o),
+(647,552,o),
+(647,441,cs),
+(647,288,o),
+(581,46,o),
+(366,46,cs),
+(232,46,o),
+(156,127,o),
+(156,265,cs),
+(156,402,o),
+(225,621,o),
+(405,661,c),
+(416,714,l),
+(166,714,l),
+(154,659,l),
+(360,659,l),
+(385,685,l),
+(177,644,o),
+(92,422,o),
+(92,261,cs),
+(92,93,o),
+(194,-13,o),
+(365,-13,cs)
+);
+}
+);
+width = 753;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162E;
+unicode = 5678;
+},
+{
+color = 9;
+glyphname = "lhoCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(264,0,l),
+(276,53,l),
+(196,83,o),
+(154,162,o),
+(154,273,cs),
+(154,426,o),
+(220,668,o),
+(435,668,cs),
+(569,668,o),
+(645,587,o),
+(645,449,cs),
+(645,312,o),
+(576,93,o),
+(396,53,c),
+(385,0,l),
+(635,0,l),
+(647,55,l),
+(441,55,l),
+(416,29,l),
+(624,70,o),
+(709,292,o),
+(709,453,cs),
+(709,621,o),
+(607,727,o),
+(436,727,cs),
+(186,727,o),
+(93,476,o),
+(93,290,cs),
+(93,162,o),
+(146,70,o),
+(243,35,c),
+(226,55,l),
+(26,55,l),
+(14,0,l)
+);
+}
+);
+width = 753;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162F;
+unicode = 5679;
+},
+{
+color = 9;
+glyphname = "lheCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (387,357);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(584,-13,o),
+(682,265,o),
+(682,451,cs),
+(682,619,o),
+(594,727,o),
+(448,727,cs),
+(338,727,o),
+(248,663,o),
+(200,550,c),
+(206,549,l),
+(241,714,l),
+(184,714,l),
+(124,434,l),
+(178,434,l),
+(222,585,o),
+(313,668,o),
+(430,668,cs),
+(551,668,o),
+(618,587,o),
+(618,449,cs),
+(618,294,o),
+(541,46,o),
+(339.009,46.005,cs),
+(210,46,o),
+(129,143,o),
+(145,280,c),
+(91,280,l),
+(32,0,l),
+(89,0,l),
+(130,194,l),
+(120,192,l),
+(128,68,o),
+(218,-13,o),
+(346,-13,cs)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1630;
+unicode = 5680;
+},
+{
+color = 9;
+glyphname = "lheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (321,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 719;
+}
+);
+note = uni1631;
+unicode = 5681;
+},
+{
+color = 9;
+glyphname = "lhiCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (299,0);
+ref = dot_middle;
+}
+);
+width = 719;
+}
+);
+note = uni1632;
+unicode = 5682;
+},
+{
+color = 9;
+glyphname = "lhaCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(428,-13,o),
+(519,51,o),
+(567,164,c),
+(561,165,l),
+(525,0,l),
+(583,0,l),
+(642,280,l),
+(588,280,l),
+(545,129,o),
+(453,46,o),
+(336,46,cs),
+(216,46,o),
+(149,127,o),
+(149,265,cs),
+(149,420,o),
+(225,668,o),
+(427,668,cs),
+(556,668,o),
+(637,571,o),
+(621,434,c),
+(675,434,l),
+(734,714,l),
+(676.993,714,l),
+(636,520,l),
+(647,522,l),
+(638,646,o),
+(549,727,o),
+(421,727,cs),
+(182,727,o),
+(85,449,o),
+(85,263,cs),
+(85,95,o),
+(173,-13,o),
+(318,-13,cs)
+);
+}
+);
+width = 718;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1633;
+unicode = 5683;
+},
+{
+color = 9;
+glyphname = "tlhuCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(615,-13,o),
+(708,238,o),
+(708,424,cs),
+(708,549,o),
+(662,643,o),
+(565,679,c),
+(566,663,l),
+(766,663,l),
+(748,577,l),
+(797,577,l),
+(844,800,l),
+(795,800,l),
+(777,714,l),
+(537,714,l),
+(525,661,l),
+(605,631,o),
+(647,552,o),
+(647,441,cs),
+(647,288,o),
+(581,46,o),
+(366,46,cs),
+(232,46,o),
+(156,127,o),
+(156,265,cs),
+(156,402,o),
+(225,621,o),
+(405,661,c),
+(416,714,l),
+(166,714,l),
+(154,659,l),
+(361,659,l),
+(377,682,l),
+(166,637,o),
+(92,411,o),
+(92,261,cs),
+(92,93,o),
+(194,-13,o),
+(365,-13,cs)
+);
+}
+);
+width = 775;
+}
+);
+metricLeft = "lhuCarrier-canadian";
+note = uni1634;
+unicode = 5684;
+},
+{
+color = 9;
+glyphname = "tlhoCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(29,-86,l),
+(47,0,l),
+(287,0,l),
+(298,53,l),
+(218,83,o),
+(177,162,o),
+(177,273,cs),
+(177,426,o),
+(243,668,o),
+(458,668,cs),
+(591,668,o),
+(667,587,o),
+(667,449,cs),
+(667,312,o),
+(599,93,o),
+(419,53,c),
+(407,0,l),
+(657,0,l),
+(669,55,l),
+(462,55,l),
+(446,32,l),
+(658,77,o),
+(731,303,o),
+(731,453,cs),
+(731,621,o),
+(629,727,o),
+(459,727,cs),
+(209,727,o),
+(115,476,o),
+(115,290,cs),
+(115,165,o),
+(161,71,o),
+(258,35,c),
+(258,51,l),
+(58,51,l),
+(76,137,l),
+(26,137,l),
+(-21,-86,l)
+);
+}
+);
+width = 775;
+}
+);
+metricLeft = "=|tlhuCarrier-canadian";
+metricRight = "lhuCarrier-canadian";
+note = uni1635;
+unicode = 5685;
+},
+{
+color = 9;
+glyphname = "tlheCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (393,357);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(591,-13,o),
+(688,265,o),
+(688,451,cs),
+(688,619,o),
+(600,727,o),
+(455,727,cs),
+(337,727,o),
+(242,656,o),
+(191,532,c),
+(203,540,l),
+(243,728,l),
+(323,728,l),
+(334,776,l),
+(123,776,l),
+(112,728,l),
+(193,728,l),
+(131,434,l),
+(185,434,l),
+(228,585,o),
+(320,668,o),
+(437,668,cs),
+(557,668,o),
+(625,587,o),
+(625,449,cs),
+(625,294,o),
+(548,46,o),
+(346,46,cs),
+(217,46,o),
+(136,143,o),
+(152,280,c),
+(98,280,l),
+(39,0,l),
+(96,0,l),
+(137,194,l),
+(126,192,l),
+(135,68,o),
+(224,-13,o),
+(353,-13,cs)
+);
+}
+);
+width = 726;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1636;
+unicode = 5686;
+},
+{
+color = 9;
+glyphname = "tlheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (328,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 726;
+}
+);
+note = uni1637;
+unicode = 5687;
+},
+{
+color = 9;
+glyphname = "tlhiCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (305,0);
+ref = dot_middle;
+}
+);
+width = 726;
+}
+);
+note = uni1638;
+unicode = 5688;
+},
+{
+color = 9;
+glyphname = "tlhaCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(428,-13,o),
+(519,51,o),
+(567,164,c),
+(561,165,l),
+(526,0,l),
+(583,0,l),
+(643,280,l),
+(589,280,l),
+(545,129,o),
+(454,46,o),
+(336,46,cs),
+(216,46,o),
+(149,127,o),
+(149,265,cs),
+(149,420,o),
+(225,668,o),
+(427,668,cs),
+(556,668,o),
+(637,571,o),
+(621,434,c),
+(675,434,l),
+(738,728,l),
+(818,728,l),
+(829,776,l),
+(618,776,l),
+(608,728,l),
+(688,728,l),
+(643,518,l),
+(651,519,l),
+(641,647,o),
+(550,727,o),
+(421,727,cs),
+(182,727,o),
+(85,449,o),
+(85,263,cs),
+(85,95,o),
+(173,-13,o),
+(318,-13,cs)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni1639;
+unicode = 5689;
+},
+{
+color = 9;
+glyphname = "tluCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(326,-13,o),
+(384,32,o),
+(422,126,c),
+(405,126,l),
+(413,39,o),
+(470,-13,o),
+(559,-13,cs),
+(762,-13,o),
+(819,279,o),
+(819,427,cs),
+(819,554,o),
+(770,639,o),
+(679,672,c),
+(666,664,l),
+(879,664,l),
+(860,577,l),
+(910,577,l),
+(957,800,l),
+(908,800,l),
+(889,714,l),
+(594,714,l),
+(582,661,l),
+(700,648,o),
+(758,576,o),
+(758,440,cs),
+(758,320,o),
+(714,45,o),
+(558,45,cs),
+(473,45,o),
+(437,107,o),
+(460,215,cs),
+(480,309,l),
+(419,309,l),
+(400,217,ls),
+(375,101,o),
+(329,45,o),
+(251,45,cs),
+(178,45,o),
+(141,93,o),
+(141,192,cs),
+(141,312,o),
+(201,657,o),
+(461,661,c),
+(472,714,l),
+(166,714,l),
+(155,659,l),
+(349,659,l),
+(338,668,l),
+(147,607,o),
+(78,342,o),
+(78,189,cs),
+(78,60,o),
+(136,-13,o),
+(242,-13,cs)
+);
+}
+);
+width = 888;
+}
+);
+metricRight = "tlhuCarrier-canadian";
+note = uni163A;
+unicode = 5690;
+},
+{
+color = 1;
+glyphname = "tloCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(769,-86,l),
+(817,137,l),
+(767,137,l),
+(749,51,l),
+(559,51,l),
+(570,43,l),
+(765,101,o),
+(837,369,o),
+(837,525,cs),
+(837,654,o),
+(778,727,o),
+(672,727,cs),
+(588,727,o),
+(530,681,o),
+(492,586,c),
+(509,585,l),
+(502,674,o),
+(445,727,o),
+(355,727,cs),
+(153,727,o),
+(95,435,o),
+(95,287,cs),
+(95,163,o),
+(143,79,o),
+(230,45,c),
+(245,54,l),
+(26,54,l),
+(14,0,l),
+(321,0,l),
+(332,53,l),
+(215,66,o),
+(156,138,o),
+(156,274,cs),
+(156,394,o),
+(200,669,o),
+(357,669,cs),
+(441,669,o),
+(477,607,o),
+(454,499,cs),
+(435,405,l),
+(496,405,l),
+(515,497,ls),
+(539,613,o),
+(586,669,o),
+(663,669,cs),
+(736,669,o),
+(773,621,o),
+(773,522,cs),
+(773,402,o),
+(714,57,o),
+(453,53,c),
+(442,0,l),
+(738,0,l),
+(720,-86,l)
+);
+}
+);
+width = 889;
+}
+);
+metricLeft = "tluCarrier-canadian";
+metricRight = "tlhuCarrier-canadian";
+note = uni163B;
+unicode = 5691;
+},
+{
+color = 9;
+glyphname = "tleCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (304,357);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(532,-13,o),
+(641,75,o),
+(641,215,cs),
+(641,293,o),
+(596,352,o),
+(525,363,c),
+(521,349,l),
+(635,359,o),
+(712,444,o),
+(712,550,cs),
+(712,655,o),
+(621,727,o),
+(478,727,cs),
+(346,727,o),
+(247,664,o),
+(196,548,c),
+(202,537,l),
+(242,728,l),
+(323,728,l),
+(333,776,l),
+(123,776,l),
+(112,728,l),
+(193,728,l),
+(130,434,l),
+(184,434,l),
+(222,593,o),
+(313,669,o),
+(462,669,cs),
+(579,669,o),
+(648,620,o),
+(648,541,cs),
+(648,438,o),
+(566,385,o),
+(455,385,cs),
+(412,385,l),
+(400,330,l),
+(442,330,ls),
+(529,330,o),
+(579,289,o),
+(579,219,cs),
+(579,109,o),
+(496,45,o),
+(375,45,cs),
+(217,45,o),
+(130,135,o),
+(151,280,c),
+(97,280,l),
+(38,0,l),
+(96,0,l),
+(138,198,l),
+(124,186,l),
+(130,65,o),
+(231,-13,o),
+(381,-13,cs)
+);
+}
+);
+width = 732;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni163C;
+unicode = 5692;
+},
+{
+color = 9;
+glyphname = "tleeCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (239,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 731;
+}
+);
+note = uni163D;
+unicode = 5693;
+},
+{
+color = 9;
+glyphname = "tliCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (221,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 731;
+}
+);
+note = uni163E;
+unicode = 5694;
+},
+{
+color = 9;
+glyphname = "tlaCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(423,-13,o),
+(516,40,o),
+(571,138,c),
+(565,151,l),
+(532,0,l),
+(590,0,l),
+(650,280,l),
+(596,280,l),
+(558,121,o),
+(467,45,o),
+(318,45,cs),
+(201,45,o),
+(132,94,o),
+(132,173,cs),
+(132,276,o),
+(213,329,o),
+(325,329,cs),
+(368,329,l),
+(380,384,l),
+(338,384,ls),
+(251,384,o),
+(201,425,o),
+(201,495,cs),
+(201,605,o),
+(284,669,o),
+(406,669,cs),
+(563,669,o),
+(650,579,o),
+(629,434,c),
+(683,434,l),
+(744,728,l),
+(824,728,l),
+(835,776,l),
+(624,776,l),
+(614,728,l),
+(695,728,l),
+(651,522,l),
+(659,531,l),
+(648,651,o),
+(547,727,o),
+(399,727,cs),
+(248,727,o),
+(139,639,o),
+(139,499,cs),
+(139,423,o),
+(182,366,o),
+(249,353,c),
+(252,364,l),
+(143,351,o),
+(68,268,o),
+(68,164,cs),
+(68,59,o),
+(158,-13,o),
+(302,-13,cs)
+);
+}
+);
+width = 731;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni163F;
+unicode = 5695;
+},
+{
+color = 9;
+glyphname = "zuCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(551,-13,o),
+(681,117,o),
+(681,309,cs),
+(681,404,o),
+(643,490,o),
+(643,558,cs),
+(643,620,o),
+(677,658,o),
+(741,658,cs),
+(773,658,l),
+(784,714,l),
+(742,714,ls),
+(640,714,o),
+(582,661,o),
+(582,560,cs),
+(582,483,o),
+(619,403,o),
+(619,312,cs),
+(619,155,o),
+(520,46,o),
+(351,46,cs),
+(216,46,o),
+(134,109,o),
+(134,208,cs),
+(134,363,o),
+(314,497,o),
+(314,621,cs),
+(314,678,o),
+(273,714,o),
+(205,714,cs),
+(163,714,l),
+(151,658,l),
+(186,658,ls),
+(231,658,o),
+(252,643,o),
+(252,612,cs),
+(252,514,o),
+(71,377,o),
+(71,202,cs),
+(71,74,o),
+(176,-13,o),
+(343,-13,cs)
+);
+}
+);
+width = 748;
+}
+);
+metricRight = "=|";
+note = uni1640;
+unicode = 5696;
+},
+{
+color = 9;
+glyphname = "zoCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(53,0,ls),
+(156,0,o),
+(213,53,o),
+(213,154,cs),
+(213,231,o),
+(176,311,o),
+(176,402,cs),
+(176,559,o),
+(275,668,o),
+(445,668,cs),
+(579,668,o),
+(661,605,o),
+(661,506,cs),
+(661,351,o),
+(482,217,o),
+(482,93,cs),
+(482,36,o),
+(522,0,o),
+(591,0,cs),
+(633,0,l),
+(644,56,l),
+(609,56,ls),
+(564,56,o),
+(544,71,o),
+(544,102,cs),
+(544,200,o),
+(725,337,o),
+(725,512,cs),
+(725,640,o),
+(619,727,o),
+(452,727,cs),
+(244,727,o),
+(114,597,o),
+(114,405,cs),
+(114,310,o),
+(153,224,o),
+(153,156,cs),
+(153,94,o),
+(118,56,o),
+(54,56,cs),
+(23,56,l),
+(11,0,l)
+);
+}
+);
+width = 748;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1641;
+unicode = 5697;
+},
+{
+color = 9;
+glyphname = "zeCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (396,357);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(574,-13,o),
+(671,337,o),
+(671,513,cs),
+(671,648,o),
+(616,727,o),
+(517,727,cs),
+(404,727,o),
+(296,620,o),
+(242,620,cs),
+(213,620,o),
+(203,642,o),
+(212,685,cs),
+(219,714,l),
+(161,714,l),
+(152,673,ls),
+(138,606,o),
+(164,563,o),
+(220,563,cs),
+(305,563,o),
+(405,668,o),
+(498,668,cs),
+(569,668,o),
+(606,611,o),
+(606,506,cs),
+(606,362,o),
+(527,46,o),
+(361,46,cs),
+(266,46,o),
+(212,151,o),
+(128,151,cs),
+(74,151,o),
+(32,111,o),
+(18,41,cs),
+(9,0,l),
+(67,0,l),
+(73,29,ls),
+(82,70,o),
+(105,94,o),
+(133,94,cs),
+(189,94,o),
+(254,-13,o),
+(367,-13,cs)
+);
+}
+);
+width = 697;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1642;
+unicode = 5698;
+},
+{
+color = 9;
+glyphname = "zeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (331,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 696;
+}
+);
+note = uni1643;
+unicode = 5699;
+},
+{
+color = 9;
+glyphname = "ziCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (308,0);
+ref = dot_middle;
+}
+);
+width = 696;
+}
+);
+note = uni1644;
+unicode = 5700;
+},
+{
+color = 9;
+glyphname = "zaCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(340,-13,o),
+(448,94,o),
+(502,94,cs),
+(531,94,o),
+(541,72,o),
+(532,29,cs),
+(525,0,l),
+(583,0,l),
+(592,41,ls),
+(606,108,o),
+(580,151,o),
+(524,151,cs),
+(439,151,o),
+(339,46,o),
+(246,46,cs),
+(175,46,o),
+(138,103,o),
+(138,208,cs),
+(138,352,o),
+(217,668,o),
+(383,668,cs),
+(478,668,o),
+(532,563,o),
+(616,563,cs),
+(670,563,o),
+(712,603,o),
+(726,673,cs),
+(735,714,l),
+(677,714,l),
+(671,685,ls),
+(662,644,o),
+(639,620,o),
+(611,620,cs),
+(555,620,o),
+(490,727,o),
+(377,727,cs),
+(170,727,o),
+(74,377,o),
+(74,201,cs),
+(74,66,o),
+(129,-13,o),
+(227,-13,cs)
+);
+}
+);
+width = 696;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|zeCarrier-canadian";
+note = uni1645;
+unicode = 5701;
+},
+{
+color = 6;
+glyphname = "zCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(355,189,l),
+(365,232,l),
+(117,232,l),
+(115,205,l),
+(423,521,l),
+(428,546,l),
+(134,546,l),
+(125,503,l),
+(370,503,l),
+(372,530,l),
+(64,214,l),
+(58,189,l)
+);
+}
+);
+width = 438;
+}
+);
+metricRight = "=|";
+note = uni1646;
+unicode = 5702;
+},
+{
+color = 6;
+glyphname = "initialzCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(209,99,l),
+(228,189,l),
+(355,189,l),
+(365,232,l),
+(111,232,l),
+(120,210,l),
+(423,521,l),
+(428,546,l),
+(304,546,l),
+(323,636,l),
+(277,636,l),
+(258,546,l),
+(134,546,l),
+(125,503,l),
+(375,503,l),
+(366,524,l),
+(64,214,l),
+(58,189,l),
+(182,189,l),
+(163,99,l)
+);
+}
+);
+width = 438;
+}
+);
+metricLeft = "zCarrier-canadian";
+metricRight = "zCarrier-canadian";
+note = uni1647;
+unicode = 5703;
+},
+{
+color = 9;
+glyphname = "dzuCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(551,-13,o),
+(681,117,o),
+(681,309,cs),
+(681,404,o),
+(643,490,o),
+(643,558,cs),
+(643,620,o),
+(677,658,o),
+(741,658,cs),
+(773,658,l),
+(784,714,l),
+(742,714,ls),
+(642,714,o),
+(584,661,o),
+(583,560,cs),
+(583,483,o),
+(620,401,o),
+(619,312,cs),
+(619,155,o),
+(520,46,o),
+(351,46,cs),
+(216,46,o),
+(134,109,o),
+(134,208,cs),
+(134,363,o),
+(313,497,o),
+(313,621,cs),
+(313,678,o),
+(273,714,o),
+(205,714,cs),
+(163,714,l),
+(151,658,l),
+(186,658,ls),
+(231,658,o),
+(252,643,o),
+(252,612,cs),
+(252,514,o),
+(71,377,o),
+(71,202,cs),
+(71,74,o),
+(176,-13,o),
+(343,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(447,507,l),
+(484,679,l),
+(554,679,l),
+(562,714,l),
+(384,714,l),
+(376,679,l),
+(446,679,l),
+(410,507,l)
+);
+}
+);
+width = 748;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1648;
+unicode = 5704;
+},
+{
+color = 9;
+glyphname = "dzoCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(53,0,ls),
+(153,0,o),
+(211,53,o),
+(212,154,cs),
+(213,231,o),
+(176,313,o),
+(176,402,cs),
+(177,559,o),
+(275,668,o),
+(445,668,cs),
+(579,668,o),
+(661,605,o),
+(661,506,cs),
+(661,351,o),
+(483,217,o),
+(483,93,cs),
+(483,36,o),
+(522,0,o),
+(591,0,cs),
+(632,0,l),
+(644,56,l),
+(609,56,ls),
+(564,56,o),
+(544,71,o),
+(544,102,cs),
+(544,200,o),
+(725,337,o),
+(725,512,cs),
+(725,640,o),
+(619,727,o),
+(452,727,cs),
+(244,727,o),
+(114,597,o),
+(114,405,cs),
+(114,310,o),
+(153,224,o),
+(153,156,cs),
+(153,94,o),
+(118,56,o),
+(54,56,cs),
+(23,56,l),
+(11,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(412,0,l),
+(420,35,l),
+(349,35,l),
+(385,207,l),
+(348,207,l),
+(312,35,l),
+(241,35,l),
+(233,0,l)
+);
+}
+);
+width = 747;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1649;
+unicode = 5705;
+},
+{
+color = 9;
+glyphname = "dzeCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (406,357);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(597,-13,o),
+(693,337,o),
+(693,513,cs),
+(693,648,o),
+(638,727,o),
+(539,727,cs),
+(427,727,o),
+(318,620,o),
+(264,620,cs),
+(236,620,o),
+(225,642,o),
+(235,685,cs),
+(241,714,l),
+(183,714,l),
+(175,673,ls),
+(160,606,o),
+(187,563,o),
+(243,563,cs),
+(328,563,o),
+(428,668,o),
+(521,668,cs),
+(592,668,o),
+(629,611,o),
+(629,506,cs),
+(629,362,o),
+(549,46,o),
+(384,46,cs),
+(289,46,o),
+(234,151,o),
+(151,151,cs),
+(96,151,o),
+(55,111,o),
+(40,41,cs),
+(31,0,l),
+(89,0,l),
+(96,29,ls),
+(105,70,o),
+(127,94,o),
+(155,94,cs),
+(212,94,o),
+(277,-13,o),
+(390,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(125,249,l),
+(143,338,l),
+(278,338,l),
+(286,376,l),
+(152,376,l),
+(170,465,l),
+(130,465,l),
+(85,249,l)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164A;
+unicode = 5706;
+},
+{
+color = 9;
+glyphname = "dzeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "dzeCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (341,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 719;
+}
+);
+metricLeft = "dzeCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164B;
+unicode = 5707;
+},
+{
+color = 9;
+glyphname = "dziCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "dzeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (318,0);
+ref = dot_middle;
+}
+);
+width = 719;
+}
+);
+note = uni164C;
+unicode = 5708;
+},
+{
+color = 9;
+glyphname = "dzaCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(341,-13,o),
+(449,94,o),
+(503,94,cs),
+(532,94,o),
+(542,72,o),
+(532,29,cs),
+(526,0,l),
+(584,0,l),
+(593,41,ls),
+(607,108,o),
+(580,151,o),
+(524,151,cs),
+(439,151,o),
+(339,46,o),
+(246,46,cs),
+(176,46,o),
+(138,103,o),
+(138,208,cs),
+(138,352,o),
+(218,668,o),
+(383,668,cs),
+(478,668,o),
+(533,563,o),
+(617,563,cs),
+(671,563,o),
+(712,603,o),
+(727,673,cs),
+(736,714,l),
+(678,714,l),
+(672,685,ls),
+(662,644,o),
+(640,620,o),
+(612,620,cs),
+(555,620,o),
+(490,727,o),
+(378,727,cs),
+(170,727,o),
+(74,377,o),
+(74,201,cs),
+(74,66,o),
+(129,-13,o),
+(228,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(637,249,l),
+(683,465,l),
+(642,465,l),
+(624,376,l),
+(489,376,l),
+(481,338,l),
+(616,338,l),
+(597,249,l)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dzeCarrier-canadian";
+note = uni164D;
+unicode = 5709;
+},
+{
+color = 9;
+glyphname = "suCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(313,-13,o),
+(381,40,o),
+(423,149,c),
+(400,149,l),
+(404,46,o),
+(459,-13,o),
+(558,-13,cs),
+(723,-13,o),
+(785,139,o),
+(787,277,cs),
+(788,377,o),
+(755,480,o),
+(756,555,cs),
+(757,616,o),
+(785,658,o),
+(850,658,cs),
+(884,658,l),
+(896,714,l),
+(847,714,ls),
+(745,714,o),
+(698,653,o),
+(696,556,cs),
+(694,477,o),
+(726,373,o),
+(725,276,cs),
+(724,173,o),
+(683,45,o),
+(558,45,cs),
+(446,45,o),
+(439,148,o),
+(456,229,cs),
+(559,714,l),
+(500,714,l),
+(396,229,ls),
+(371,107,o),
+(314,45,o),
+(229,45,cs),
+(159,45,o),
+(120,86,o),
+(120,157,cs),
+(120,326,o),
+(313,493,o),
+(313,622,cs),
+(313,680,o),
+(274,714,o),
+(207,714,cs),
+(163.005,714,l),
+(151,658,l),
+(182,658,ls),
+(227,658,o),
+(249,642,o),
+(249,608,cs),
+(249,497,o),
+(56,341,o),
+(56,151,cs),
+(56,51,o),
+(116,-13,o),
+(219,-13,cs)
+);
+}
+);
+width = 859;
+}
+);
+metricRight = "=|";
+note = uni164E;
+unicode = 5710;
+},
+{
+color = 9;
+glyphname = "soCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(60,0,ls),
+(163,0,o),
+(209,61,o),
+(212,158,cs),
+(213,237,o),
+(182,341,o),
+(183,438,cs),
+(183,541,o),
+(225,669,o),
+(349,669,cs),
+(461,669,o),
+(468,566,o),
+(451,485,cs),
+(348,0,l),
+(408,0,l),
+(511,485,ls),
+(536,607,o),
+(593,669,o),
+(679,669,cs),
+(748,669,o),
+(788,628,o),
+(788,557,cs),
+(788,388,o),
+(595,221,o),
+(595,92,cs),
+(595,34,o),
+(633.002,0,o),
+(701,0,cs),
+(744,0,l),
+(756,56,l),
+(726,56,ls),
+(680,56,o),
+(658,72,o),
+(658,106,cs),
+(658,217,o),
+(852,373,o),
+(852,563,cs),
+(852,663,o),
+(791,727,o),
+(688,727,cs),
+(595,727,o),
+(527,674,o),
+(484,565,c),
+(507,565,l),
+(503,668,o),
+(448,727,o),
+(350,727,cs),
+(185,727,o),
+(123,575,o),
+(120,437,cs),
+(119,337,o),
+(152,234,o),
+(151,159,cs),
+(150,98,o),
+(122,56,o),
+(58,56,cs),
+(23,56,l),
+(11,0,l)
+);
+}
+);
+width = 859;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5711;
+},
+{
+color = 9;
+glyphname = "seCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(558,-13,o),
+(629,106,o),
+(629,211,cs),
+(629,286,o),
+(589,344,o),
+(520,365,c),
+(516,345,l),
+(639,365,o),
+(705,464,o),
+(705.009,569,cs),
+(705,662,o),
+(643,727,o),
+(550,727,cs),
+(432,727,o),
+(323,620,o),
+(263,620,cs),
+(233,620,o),
+(221,641,o),
+(231,684,cs),
+(238,714,l),
+(180,714,l),
+(171,674,ls),
+(158,608,o),
+(187,564,o),
+(245,564,cs),
+(331,564,o),
+(432,669,o),
+(534,669,cs),
+(600,669,o),
+(641,627,o),
+(641,562,cs),
+(641,466,o),
+(575,384,o),
+(456,384,cs),
+(110,384,l),
+(99,330,l),
+(447,330,ls),
+(525,330,o),
+(567,286,o),
+(567,218,cs),
+(567,139,o),
+(520,45,o),
+(423,45,cs),
+(321,45,o),
+(243,150,o),
+(149,150,cs),
+(91,150,o),
+(52,113,o),
+(37,40,cs),
+(28,0,l),
+(86,0,l),
+(92,29,ls),
+(102,73,o),
+(122,94,o),
+(154,94,cs),
+(225,94,o),
+(311,-13,o),
+(429,-13,cs)
+);
+}
+);
+width = 721;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni1650;
+unicode = 5712;
+},
+{
+color = 9;
+glyphname = "seeCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(558,-13,o),
+(629,106,o),
+(629,211,cs),
+(629,284,o),
+(591,342,o),
+(525,363,c),
+(522,347,l),
+(641,369,o),
+(705,465,o),
+(705.009,569,cs),
+(705,662,o),
+(643,727,o),
+(550,727,cs),
+(432,727,o),
+(323,620,o),
+(263,620,cs),
+(233,620,o),
+(221,641,o),
+(231,684,cs),
+(238,714,l),
+(180,714,l),
+(171,674,ls),
+(158,608,o),
+(187,564,o),
+(245,564,cs),
+(331,564,o),
+(432,669,o),
+(534,669,cs),
+(600,669,o),
+(641,627,o),
+(641,562,cs),
+(641,466,o),
+(575,384,o),
+(456,384,cs),
+(382,384,l),
+(395,356,l),
+(418,469,l),
+(376,469,l),
+(358,384,l),
+(110,384,l),
+(99,331,l),
+(346,331,l),
+(326,234,l),
+(368,234,l),
+(394,359,l),
+(371,331,l),
+(453,331,ls),
+(523,333,o),
+(567,287,o),
+(567,218,cs),
+(567,139,o),
+(520,45,o),
+(423,45,cs),
+(321,45,o),
+(243,150,o),
+(149,150,cs),
+(91,150,o),
+(52,113,o),
+(37,40,cs),
+(28,0,l),
+(86,0,l),
+(92,29,ls),
+(102,73,o),
+(122,94,o),
+(154,94,cs),
+(225,94,o),
+(311,-13,o),
+(429,-13,cs)
+);
+}
+);
+width = 721;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1651;
+unicode = 5713;
+},
+{
+color = 9;
+glyphname = "siCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(558,-13,o),
+(629,106,o),
+(629,211,cs),
+(629,284,o),
+(591,342,o),
+(525,363,c),
+(522,347,l),
+(641,369,o),
+(705,465,o),
+(705.009,569,cs),
+(705,662,o),
+(643,727,o),
+(550,727,cs),
+(432,727,o),
+(323,620,o),
+(263,620,cs),
+(233,620,o),
+(221,641,o),
+(231,684,cs),
+(238,714,l),
+(180,714,l),
+(171,674,ls),
+(158,608,o),
+(187,564,o),
+(245,564,cs),
+(331,564,o),
+(432,669,o),
+(534,669,cs),
+(600,669,o),
+(642,627,o),
+(642,562,cs),
+(642,466,o),
+(577,383,o),
+(458,383,cs),
+(398,383,l),
+(424,363,l),
+(422,398,o),
+(394,423,o),
+(360,423,cs),
+(334,423,o),
+(311,407,o),
+(302,384,c),
+(110,384,l),
+(99,331,l),
+(303,331,l),
+(312,308,o),
+(335,292,o),
+(361,292,cs),
+(394,292,o),
+(421,317,o),
+(424,351,c),
+(397,332,l),
+(450,332,ls),
+(528,332,o),
+(568,286,o),
+(568,218,cs),
+(568,139,o),
+(520,45,o),
+(423,45,cs),
+(321,45,o),
+(243,150,o),
+(149,150,cs),
+(91,150,o),
+(52,113,o),
+(37,40,cs),
+(28,0,l),
+(86,0,l),
+(92,29,ls),
+(102,73,o),
+(122,94,o),
+(154,94,cs),
+(225,94,o),
+(311,-13,o),
+(429,-13,cs)
+);
+}
+);
+width = 721;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1652;
+unicode = 5714;
+},
+{
+color = 9;
+glyphname = "saCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(336,-13,o),
+(445,94,o),
+(505,94,cs),
+(534,94,o),
+(547,73,o),
+(537,30,cs),
+(530,0,l),
+(588,0,l),
+(596,40,ls),
+(610,106,o),
+(581,150,o),
+(523,150,cs),
+(437,150,o),
+(336,45,o),
+(234,45,cs),
+(168,45,o),
+(127,87,o),
+(127,152,cs),
+(127,248,o),
+(192,330,o),
+(312,330,cs),
+(658,330,l),
+(669,384,l),
+(321,384,ls),
+(243,384,o),
+(201,428,o),
+(201,496,cs),
+(201,575,o),
+(248,669,o),
+(345,669,cs),
+(447,669,o),
+(525,564,o),
+(619,564,cs),
+(677,564,o),
+(716,601,o),
+(731,674,cs),
+(740,714,l),
+(682,714,l),
+(676,685,ls),
+(666,641,o),
+(645,620,o),
+(614,620,cs),
+(543,620,o),
+(457,727,o),
+(339,727,cs),
+(210,727,o),
+(139,608,o),
+(139,503,cs),
+(139,428,o),
+(179,370,o),
+(248,349,c),
+(252,369,l),
+(129,349,o),
+(63,250,o),
+(63,145,cs),
+(63,52,o),
+(125,-13,o),
+(218,-13,cs)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1653;
+unicode = 5715;
+},
+{
+color = 9;
+glyphname = "shuCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(309,-13,o),
+(375,36,o),
+(418,137,c),
+(402,139,l),
+(408,42,o),
+(463,-13,o),
+(558,-13,cs),
+(723,-13,o),
+(785,139,o),
+(787,277,cs),
+(788,377,o),
+(755,480,o),
+(756,555,cs),
+(757,616,o),
+(785,658,o),
+(850,658,cs),
+(884,658,l),
+(896,714,l),
+(847,714,ls),
+(752,714,o),
+(703,663,o),
+(697,575,cs),
+(696,564,o),
+(695,551,o),
+(697,539,c),
+(715,574,l),
+(530,574,l),
+(559,714,l),
+(500,714,l),
+(470,574,l),
+(285,574,l),
+(296,548,l),
+(307,574,o),
+(313,599,o),
+(313,622,cs),
+(313,680,o),
+(274,714,o),
+(207,714,cs),
+(163.005,714,l),
+(151,658,l),
+(182,658,ls),
+(227,658,o),
+(249,642,o),
+(249,608,cs),
+(249,497,o),
+(56,341,o),
+(56,151,cs),
+(56,51,o),
+(116,-13,o),
+(219,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(159,45,o),
+(120,86,o),
+(120,157,cs),
+(120,287,o),
+(233,411,o),
+(285,521,c),
+(459,521,l),
+(396,229,ls),
+(371,107,o),
+(314,45,o),
+(229,45,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(446,45,o),
+(439,148,o),
+(456,229,cs),
+(518,521,l),
+(697,521,l),
+(702,447,o),
+(725,360,o),
+(725,276,cs),
+(724,173,o),
+(683,45,o),
+(558,45,cs)
+);
+}
+);
+width = 859;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1654;
+unicode = 5716;
+},
+{
+color = 9;
+glyphname = "shoCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(60,0,ls),
+(155,0,o),
+(204,51,o),
+(210,139,cs),
+(211,150,o),
+(212,163,o),
+(211,175,c),
+(192,140,l),
+(378,140,l),
+(348,0,l),
+(408,0,l),
+(437,140,l),
+(622,140,l),
+(611,166,l),
+(601,140,o),
+(595,115,o),
+(595,92,cs),
+(595,34,o),
+(633.002,0,o),
+(701,0,cs),
+(744,0,l),
+(756,56,l),
+(726,56,ls),
+(680,56,o),
+(658,72,o),
+(658,106,cs),
+(658,217,o),
+(852,373,o),
+(852,563,cs),
+(852,663,o),
+(791,727,o),
+(688,727,cs),
+(599,727,o),
+(533,678,o),
+(489,577,c),
+(506,575,l),
+(500,672,o),
+(444,727,o),
+(350,727,cs),
+(185,727,o),
+(123,575,o),
+(120,437,cs),
+(119,337,o),
+(152,234,o),
+(151,159,cs),
+(150,98,o),
+(122,56,o),
+(58,56,cs),
+(23,56,l),
+(11,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(205,267,o),
+(182,354,o),
+(183,438,cs),
+(183,541,o),
+(225,669,o),
+(349,669,cs),
+(461,669,o),
+(468,566,o),
+(451,485,cs),
+(389,193,l),
+(211,193,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(511,485,ls),
+(536,607,o),
+(593,669,o),
+(679,669,cs),
+(748,669,o),
+(788,628,o),
+(788,557,cs),
+(788,427,o),
+(674,303,o),
+(622,193,c),
+(449,193,l)
+);
+}
+);
+width = 859;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1655;
+unicode = 5717;
+},
+{
+color = 9;
+glyphname = "sheCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(558,-13,o),
+(629,106,o),
+(629,211,cs),
+(629,284,o),
+(591,342,o),
+(525,363,c),
+(522,347,l),
+(641,369,o),
+(705,465,o),
+(705.009,569,cs),
+(705,662,o),
+(643,727,o),
+(550,727,cs),
+(432,727,o),
+(323,620,o),
+(263,620,cs),
+(233,620,o),
+(221,641,o),
+(231,684,cs),
+(238,714,l),
+(180,714,l),
+(171,674,ls),
+(158,608,o),
+(187,565,o),
+(245,565,cs),
+(264,565,o),
+(286,570,o),
+(304,578,c),
+(275,602,l),
+(229,384,l),
+(110,384,l),
+(99,330,l),
+(217,330,l),
+(171,112,l),
+(209,136,l),
+(189,145,o),
+(169,149,o),
+(149,149,cs),
+(91,149,o),
+(52,113,o),
+(37,40,cs),
+(28,0,l),
+(86,0,l),
+(92,29,ls),
+(102,73,o),
+(122,94,o),
+(154,94,cs),
+(225,94,o),
+(311,-13,o),
+(429,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(270,330,l),
+(447,330,ls),
+(525,330,o),
+(567,286,o),
+(567,218,cs),
+(567,139,o),
+(520,45,o),
+(423,45,cs),
+(350,45,o),
+(289,98,o),
+(227,128,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(324,586,l),
+(389,616,o),
+(461,669,o),
+(534,669,cs),
+(600,669,o),
+(641,627,o),
+(641,562,cs),
+(641,466,o),
+(575,384,o),
+(456,384,cs),
+(281,384,l)
+);
+}
+);
+width = 721;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1656;
+unicode = 5718;
+},
+{
+color = 9;
+glyphname = "sheeCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(558,-13,o),
+(629,106,o),
+(629,211,cs),
+(629,284,o),
+(591,342,o),
+(525,363,c),
+(522,347,l),
+(641,369,o),
+(705,465,o),
+(705.009,569,cs),
+(705,662,o),
+(643,727,o),
+(550,727,cs),
+(432,727,o),
+(323,620,o),
+(263,620,cs),
+(233,620,o),
+(221,641,o),
+(231,684,cs),
+(238,714,l),
+(180,714,l),
+(171,674,ls),
+(158,608,o),
+(187,565,o),
+(245,565,cs),
+(262,565,o),
+(279,569,o),
+(297,576,c),
+(275,602,l),
+(228,381,l),
+(109,381,l),
+(99,334,l),
+(218,334,l),
+(172,112,l),
+(205,137,l),
+(186,145,o),
+(168,149,o),
+(149,149,cs),
+(91,149,o),
+(52,113,o),
+(37,40,cs),
+(28,0,l),
+(86,0,l),
+(92,29,ls),
+(102,73,o),
+(122,94,o),
+(154,94,cs),
+(225,94,o),
+(311,-13,o),
+(429,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(349,44,o),
+(288,100,o),
+(223,130,c),
+(266,334,l),
+(392,334,l),
+(371,235,l),
+(408,235,l),
+(433,356,l),
+(417,334,l),
+(449,334,ls),
+(527,334,o),
+(568,286,o),
+(568,218,cs),
+(568,139,o),
+(520,44,o),
+(423,44,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(458,469,l),
+(420,469,l),
+(402,381,l),
+(276,381,l),
+(319,585,l),
+(387,615,o),
+(460,670,o),
+(534,670,cs),
+(600,670,o),
+(642,627,o),
+(642,562,cs),
+(642,466,o),
+(576,381,o),
+(457,381,cs),
+(427,381,l),
+(434,359,l)
+);
+}
+);
+width = 721;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1657;
+unicode = 5719;
+},
+{
+color = 9;
+glyphname = "shiCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(171,674,ls),
+(158,608,o),
+(187,565,o),
+(245,565,cs),
+(262,565,o),
+(279,569,o),
+(298,577,c),
+(275,602,l),
+(228,381,l),
+(109,381,l),
+(99,334,l),
+(218,334,l),
+(171,112,l),
+(204,137,l),
+(186,145,o),
+(167,149,o),
+(149,149,cs),
+(91,149,o),
+(52,113,o),
+(37,40,cs),
+(28,0,l),
+(86,0,l),
+(92,29,ls),
+(102,73,o),
+(122,94,o),
+(154,94,cs),
+(225,94,o),
+(311,-13,o),
+(429,-13,cs),
+(558,-13,o),
+(629,106,o),
+(629,211,cs),
+(629,284,o),
+(591,342,o),
+(525,363,c),
+(522,347,l),
+(641,369,o),
+(705,465,o),
+(705.009,569,cs),
+(705,662,o),
+(643,727,o),
+(550,727,cs),
+(432,727,o),
+(323,620,o),
+(263,620,cs),
+(233,620,o),
+(221,641,o),
+(231,684,cs),
+(238,714,l),
+(180,714,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(266,334,l),
+(357,334,l),
+(365,309,o),
+(388,292,o),
+(415,292,cs),
+(449,292,o),
+(473,319,o),
+(478,350,c),
+(431,334,l),
+(451,334,ls),
+(528,334,o),
+(569,286,o),
+(569,218,cs),
+(569,139,o),
+(520,44,o),
+(423,44,cs),
+(349,44,o),
+(288,99,o),
+(223,130,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(319,585,l),
+(387,615,o),
+(460,670,o),
+(534,670,cs),
+(600,670,o),
+(643,627,o),
+(643,562,cs),
+(643,466,o),
+(577,381,o),
+(459,381,cs),
+(431,381,l),
+(477,365,l),
+(476,397,o),
+(449,423,o),
+(415,423,cs),
+(387,423,o),
+(364,405,o),
+(356,381,c),
+(276,381,l)
+);
+}
+);
+width = 721;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1658;
+unicode = 5720;
+},
+{
+color = 9;
+glyphname = "shaCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(336,-13,o),
+(445,94,o),
+(505,94,cs),
+(534,94,o),
+(547,73,o),
+(537,30,cs),
+(530,0,l),
+(588,0,l),
+(596,40,ls),
+(610,106,o),
+(581,149,o),
+(523,149,cs),
+(503,149,o),
+(482,144,o),
+(464,136,c),
+(493,112,l),
+(539,330,l),
+(658,330,l),
+(669,384,l),
+(550,384,l),
+(597,602,l),
+(559,578,l),
+(579,569,o),
+(599,565,o),
+(619,565,cs),
+(677,565,o),
+(716,601,o),
+(731,674,cs),
+(740,714,l),
+(682,714,l),
+(676,685,ls),
+(666,641,o),
+(645,620,o),
+(614,620,cs),
+(543,620,o),
+(457,727,o),
+(339,727,cs),
+(210,727,o),
+(139,608,o),
+(139,503,cs),
+(139,430,o),
+(177,372,o),
+(243,351,c),
+(246,367,l),
+(127,345,o),
+(63,249,o),
+(63,145,cs),
+(63,52,o),
+(125,-13,o),
+(218,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(168,45,o),
+(127,87,o),
+(127,152,cs),
+(127,248,o),
+(192,330,o),
+(312,330,cs),
+(487,330,l),
+(444,128,l),
+(378,98,o),
+(307,45,o),
+(234,45,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(243,384,o),
+(201,428,o),
+(201,496,cs),
+(201,575,o),
+(248,669,o),
+(345,669,cs),
+(418,669,o),
+(479,616,o),
+(541,586,c),
+(498,384,l),
+(321,384,ls)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1659;
+unicode = 5721;
+},
+{
+color = 6;
+glyphname = "shCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(196,99,l),
+(218,203,l),
+(181,189,l),
+(215,189,ls),
+(303,189,o),
+(349,233,o),
+(349,306,cs),
+(349,355,o),
+(317,387,o),
+(256,387,cs),
+(216,387,ls),
+(174,387,o),
+(155,404,o),
+(155,433,cs),
+(155,478,o),
+(183,507,o),
+(241,507,cs),
+(389,507,l),
+(398,546,l),
+(291,546,l),
+(310,636,l),
+(265,636,l),
+(243,531,l),
+(279,546,l),
+(246,546,ls),
+(158,546,o),
+(113,503,o),
+(113,429,cs),
+(113,380,o),
+(144,348,o),
+(205,348,cs),
+(246,348,ls),
+(288,348,o),
+(306,331,o),
+(306,303,cs),
+(306,257,o),
+(279,228,o),
+(221,228,cs),
+(72,228,l),
+(64,189,l),
+(170,189,l),
+(151,99,l)
+);
+}
+);
+width = 409;
+}
+);
+metricRight = "=|";
+note = uni18F5;
+unicode = 5722;
+},
+{
+color = 9;
+glyphname = "tsuCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(309,-13,o),
+(374,36,o),
+(418,137,c),
+(402,139,l),
+(408,42,o),
+(463,-13,o),
+(558,-13,cs),
+(723,-13,o),
+(785,139,o),
+(787,277,cs),
+(788,377,o),
+(755,480,o),
+(756,555,cs),
+(757,616,o),
+(785,658,o),
+(850,658,cs),
+(884,658,l),
+(896,714,l),
+(847,714,ls),
+(745,714,o),
+(698,653,o),
+(696,556,cs),
+(695,506,o),
+(711,448,o),
+(719,384,c),
+(488,384,l),
+(548,666,l),
+(635,666,l),
+(646,714,l),
+(414,714,l),
+(403,666,l),
+(490,666,l),
+(430,384,l),
+(200,384,l),
+(251,473,o),
+(312,552,o),
+(312,622,cs),
+(312,680,o),
+(274,714,o),
+(207,714,cs),
+(163.005,714,l),
+(151,658,l),
+(182,658,ls),
+(227,658,o),
+(249,642,o),
+(249,608,cs),
+(249,497,o),
+(56,341,o),
+(56,151,cs),
+(56,51,o),
+(116,-13,o),
+(219,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(159,45,o),
+(120,86,o),
+(120,157,cs),
+(120,215,o),
+(142,274,o),
+(173,330,c),
+(419,330,l),
+(397,229,ls),
+(371,107,o),
+(314,45,o),
+(229,45,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(446,45,o),
+(438,148,o),
+(455,229,cs),
+(477,330,l),
+(723,330,l),
+(724,311,o),
+(725,291,o),
+(725,272,cs),
+(724,173,o),
+(683,45,o),
+(558,45,cs)
+);
+}
+);
+width = 859;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165B;
+unicode = 5723;
+},
+{
+color = 9;
+glyphname = "tsoCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(60,0,ls),
+(163,0,o),
+(209,61,o),
+(211,158,cs),
+(212,208,o),
+(196,266,o),
+(188,330,c),
+(419,330,l),
+(359,48,l),
+(272,48,l),
+(262,0,l),
+(494,0,l),
+(504,48,l),
+(417,48,l),
+(477,330,l),
+(707,330,l),
+(656,241,o),
+(595,162,o),
+(595,92,cs),
+(595,34,o),
+(633.002,0,o),
+(701,0,cs),
+(744,0,l),
+(756,56,l),
+(726,56,ls),
+(680,56,o),
+(658,72,o),
+(658,106,cs),
+(658,217,o),
+(852,373,o),
+(852,563,cs),
+(852,663,o),
+(791,727,o),
+(688,727,cs),
+(599,727,o),
+(533,678,o),
+(489,577,c),
+(506,575,l),
+(500,672,o),
+(444,727,o),
+(350,727,cs),
+(185,727,o),
+(123,575,o),
+(120,437,cs),
+(119,337,o),
+(152,234,o),
+(151,159,cs),
+(150,98,o),
+(122,56,o),
+(58,56,cs),
+(23,56,l),
+(11,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(183,403,o),
+(182,423,o),
+(183,442,cs),
+(183,541,o),
+(225,669,o),
+(349,669,cs),
+(461,669,o),
+(469,566,o),
+(452,485,cs),
+(430,384,l),
+(185,384,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(510,485,ls),
+(536,607,o),
+(593,669,o),
+(679,669,cs),
+(748,669,o),
+(788,628,o),
+(788,557,cs),
+(788,499,o),
+(765,440,o),
+(735,384,c),
+(489,384,l)
+);
+}
+);
+width = 859;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165C;
+unicode = 5724;
+},
+{
+color = 9;
+glyphname = "tseCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(562,-13,o),
+(633,106,o),
+(633,211,cs),
+(633,284,o),
+(595,342,o),
+(529,363,c),
+(526,347,l),
+(644,369,o),
+(709,465,o),
+(709,569,cs),
+(709,662,o),
+(647,727,o),
+(554,727,cs),
+(436,727,o),
+(328,620,o),
+(268,620,cs),
+(238,620,o),
+(226,641,o),
+(236,684,cs),
+(243,714,l),
+(185,714,l),
+(176,674,ls),
+(163,608,o),
+(192,566,o),
+(249,566,cs),
+(280,566,o),
+(314,579,o),
+(348,598,c),
+(331,619,l),
+(282,381,l),
+(155,381,l),
+(177,483,l),
+(135,483,l),
+(82,230,l),
+(123,230,l),
+(145,333,l),
+(271,333,l),
+(221,98,l),
+(247,119,l),
+(217,135,o),
+(184,148,o),
+(154,148,cs),
+(96,148,o),
+(57,113,o),
+(42,40,cs),
+(33,0,l),
+(91,0,l),
+(97,29,ls),
+(107,73,o),
+(127,94,o),
+(159,94,cs),
+(230,94,o),
+(315,-13,o),
+(433,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(370,45,o),
+(320,78,o),
+(271,106,c),
+(319,333,l),
+(451,333,ls),
+(529,333,o),
+(571,287,o),
+(571,218,cs),
+(571,139,o),
+(524,45,o),
+(427,45,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(378,611,l),
+(429,639,o),
+(483,669,o),
+(538,669,cs),
+(604,669,o),
+(645,627,o),
+(645,562,cs),
+(645,466,o),
+(580,381,o),
+(460,381,cs),
+(330,381,l)
+);
+}
+);
+width = 725;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni165D;
+unicode = 5725;
+},
+{
+color = 9;
+glyphname = "tseeCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(562,-13,o),
+(633,106,o),
+(633,211,cs),
+(633,284,o),
+(595,342,o),
+(529,363,c),
+(526,347,l),
+(644,369,o),
+(709,465,o),
+(709,569,cs),
+(709,662,o),
+(647,727,o),
+(554,727,cs),
+(436,727,o),
+(328,620,o),
+(268,620,cs),
+(238,620,o),
+(226,641,o),
+(236,684,cs),
+(243,714,l),
+(185,714,l),
+(176,674,ls),
+(163,608,o),
+(192,566,o),
+(249,566,cs),
+(280,566,o),
+(314,579,o),
+(348,598,c),
+(330,619,l),
+(280,381,l),
+(154,381,l),
+(176,483,l),
+(135,483,l),
+(82,230,l),
+(123,230,l),
+(144,333,l),
+(269,333,l),
+(220,98,l),
+(247,119,l),
+(217,135,o),
+(184,148,o),
+(154,148,cs),
+(96,148,o),
+(57,113,o),
+(42,40,cs),
+(33,0,l),
+(91,0,l),
+(97,29,ls),
+(107,73,o),
+(127,94,o),
+(159,94,cs),
+(230,94,o),
+(315,-13,o),
+(433,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(369,45,o),
+(317,80,o),
+(266,109,c),
+(313,333,l),
+(418,333,l),
+(397,233,l),
+(434,233,l),
+(458,345,l),
+(442,333,l),
+(451,333,ls),
+(529,333,o),
+(571,287,o),
+(571,218,cs),
+(571,138,o),
+(524,45,o),
+(427,45,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(485,470,l),
+(448,470,l),
+(429,381,l),
+(324,381,l),
+(372,609,l),
+(423,636,o),
+(482,669,o),
+(538,669,cs),
+(604,669,o),
+(646,627,o),
+(646,562,cs),
+(646,466,o),
+(580,381,o),
+(461,381,cs),
+(449,381,l),
+(464,371,l)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165E;
+unicode = 5726;
+},
+{
+color = 9;
+glyphname = "tsiCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(562,-12,o),
+(633,107,o),
+(633,211,cs),
+(633,285,o),
+(596,342,o),
+(529,364,c),
+(526,348,l),
+(645,369,o),
+(709,465,o),
+(709,569,cs),
+(709,663,o),
+(647,727,o),
+(555,727,cs),
+(436,727,o),
+(328,620,o),
+(268,620,cs),
+(238,620,o),
+(226,641,o),
+(236,684,cs),
+(243,714,l),
+(185,714,l),
+(176,674,ls),
+(163,608,o),
+(192,567,o),
+(249,567,cs),
+(278,567,o),
+(310,580,o),
+(342,597,c),
+(324,619,l),
+(275,381,l),
+(154,381,l),
+(176,483,l),
+(135,483,l),
+(82,231,l),
+(123,231,l),
+(144,334,l),
+(264,334,l),
+(214,99,l),
+(240,121,l),
+(211,136,o),
+(182,148,o),
+(154,148,cs),
+(96,148,o),
+(57,114,o),
+(42,41,cs),
+(33,0,l),
+(91,0,l),
+(97,29,ls),
+(107,73,o),
+(127,95,o),
+(159,95,cs),
+(230,95,o),
+(315,-12,o),
+(433,-12,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(368,46,o),
+(312,83,o),
+(261,111,c),
+(307,334,l),
+(388,334,l),
+(396,309,o),
+(419,292,o),
+(445,292,cs),
+(477,292,o),
+(499,315,o),
+(505,343,c),
+(433,334,l),
+(452,334,ls),
+(529,334,o),
+(572,288,o),
+(572,218,cs),
+(572,138,o),
+(524,46,o),
+(428,46,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(501,402,o),
+(475,423,o),
+(446,423,cs),
+(419,423,o),
+(396,405,o),
+(389,381,c),
+(318,381,l),
+(366,607,l),
+(418,633,o),
+(481,669,o),
+(539,669,cs),
+(604,669,o),
+(646,627,o),
+(646,562,cs),
+(646,466,o),
+(580,381,o),
+(461,381,cs),
+(439,381,l),
+(507,372,l)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165F;
+unicode = 5727;
+},
+{
+color = 9;
+glyphname = "tsaCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(336,-12,o),
+(444,95,o),
+(505,95,cs),
+(534,95,o),
+(546,74,o),
+(536,31,cs),
+(530,0,l),
+(587,0,l),
+(596,41,ls),
+(610,107,o),
+(580,148,o),
+(523,148,cs),
+(492,148,o),
+(458,135,o),
+(424,117,c),
+(440,96,l),
+(490,333,l),
+(617,333,l),
+(595,232,l),
+(637,232,l),
+(691,484,l),
+(649,484,l),
+(627,381,l),
+(501,381,l),
+(550,616,l),
+(525,596,l),
+(555,580,o),
+(588,567,o),
+(618,567,cs),
+(676,567,o),
+(715,601,o),
+(731,674,cs),
+(739,714,l),
+(681,714,l),
+(675,686,ls),
+(665,642,o),
+(645,620,o),
+(614,620,cs),
+(543,620,o),
+(457,727,o),
+(339,727,cs),
+(210,727,o),
+(139,608,o),
+(139,504,cs),
+(139,430,o),
+(177,373,o),
+(243,351,c),
+(246,367,l),
+(127,346,o),
+(63,250,o),
+(63,145,cs),
+(63,52,o),
+(125,-12,o),
+(218,-12,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(168,46,o),
+(127,88,o),
+(127,153,cs),
+(127,249,o),
+(192,333,o),
+(312,333,cs),
+(442,333,l),
+(394,103,l),
+(343,76,o),
+(288,46,o),
+(234,46,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(243,381,o),
+(201,427,o),
+(201,497,cs),
+(201,575,o),
+(248,669,o),
+(344,669,cs),
+(402,669,o),
+(452,636,o),
+(501,608,c),
+(453,381,l),
+(321,381,ls)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1660;
+unicode = 5728;
+},
+{
+color = 9;
+glyphname = "chuCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(309,-13,o),
+(375,36,o),
+(418,137,c),
+(402,139,l),
+(408,42,o),
+(463,-13,o),
+(558,-13,cs),
+(723,-13,o),
+(785,139,o),
+(787,277,cs),
+(788,377,o),
+(755,480,o),
+(756,555,cs),
+(757,616,o),
+(785,658,o),
+(850,658,cs),
+(884,658,l),
+(896,714,l),
+(847,714,ls),
+(745,714,o),
+(698,653,o),
+(696,556,cs),
+(694,477,o),
+(726,373,o),
+(725,276,cs),
+(724,173,o),
+(683,45,o),
+(558,45,cs),
+(446,45,o),
+(439,148,o),
+(456,229,cs),
+(549,666,l),
+(635,666,l),
+(646,714,l),
+(414,714,l),
+(403,666,l),
+(489,666,l),
+(396,229,ls),
+(371,107,o),
+(314,45,o),
+(229,45,cs),
+(159,45,o),
+(120,86,o),
+(120,157,cs),
+(120,326,o),
+(312,493,o),
+(312,622,cs),
+(312,680,o),
+(274,714,o),
+(207,714,cs),
+(163.005,714,l),
+(151,658,l),
+(182,658,ls),
+(227,658,o),
+(249,642,o),
+(249,608,cs),
+(249,497,o),
+(56,341,o),
+(56,151,cs),
+(56,51,o),
+(116,-13,o),
+(219,-13,cs)
+);
+}
+);
+width = 859;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164E;
+unicode = 5729;
+},
+{
+color = 9;
+glyphname = "choCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(60,0,ls),
+(163,0,o),
+(209,61,o),
+(211,158,cs),
+(213,237,o),
+(182,341,o),
+(183,438,cs),
+(183,541,o),
+(225,669,o),
+(349,669,cs),
+(461,669,o),
+(468,566,o),
+(451,485,cs),
+(359,48,l),
+(272,48,l),
+(262,0,l),
+(494,0,l),
+(504,48,l),
+(418,48,l),
+(511,485,ls),
+(536,607,o),
+(593,669,o),
+(679,669,cs),
+(748,669,o),
+(788,628,o),
+(788,557,cs),
+(788,388,o),
+(595,221,o),
+(595,92,cs),
+(595,34,o),
+(633.002,0,o),
+(701,0,cs),
+(744,0,l),
+(756,56,l),
+(726,56,ls),
+(680,56,o),
+(658,72,o),
+(658,106,cs),
+(658,217,o),
+(852,373,o),
+(852,563,cs),
+(852,663,o),
+(791,727,o),
+(688,727,cs),
+(599,727,o),
+(533,678,o),
+(489,577,c),
+(506,575,l),
+(500,672,o),
+(444,727,o),
+(350,727,cs),
+(185,727,o),
+(123,575,o),
+(120,437,cs),
+(119,337,o),
+(152,234,o),
+(151,159,cs),
+(150,98,o),
+(122,56,o),
+(58,56,cs),
+(23,56,l),
+(11,0,l)
+);
+}
+);
+width = 859;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5730;
+},
+{
+color = 9;
+glyphname = "cheCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(562,-13,o),
+(633,106,o),
+(633,211,cs),
+(633,284,o),
+(595,342,o),
+(529,363,c),
+(526,347,l),
+(644,369,o),
+(709,465,o),
+(709,569,cs),
+(709,662,o),
+(647,727,o),
+(554,727,cs),
+(436,727,o),
+(328,620,o),
+(268,620,cs),
+(238,620,o),
+(226,641,o),
+(236,684,cs),
+(243,714,l),
+(185,714,l),
+(176,674,ls),
+(163,608,o),
+(192,566,o),
+(250,566,cs),
+(336,566,o),
+(435,669,o),
+(538,669,cs),
+(604,669,o),
+(645,627,o),
+(645,562,cs),
+(645,466,o),
+(579,384,o),
+(460,384,cs),
+(156,384,l),
+(177,483,l),
+(135,483,l),
+(82,230,l),
+(123,230,l),
+(145,330,l),
+(451,330,ls),
+(529,330,o),
+(571,286,o),
+(571,218,cs),
+(571,139,o),
+(524,45,o),
+(427,45,cs),
+(325,45,o),
+(248,148,o),
+(154,148,cs),
+(96,148,o),
+(56,111,o),
+(42,40,cs),
+(33,0,l),
+(91,0,l),
+(97,29,ls),
+(107,73,o),
+(127,94,o),
+(159,94,cs),
+(230,94,o),
+(315,-13,o),
+(433,-13,cs)
+);
+}
+);
+width = 725;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni1663;
+unicode = 5731;
+},
+{
+color = 9;
+glyphname = "cheeCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(562,-13,o),
+(633,106,o),
+(633,211,cs),
+(633,284,o),
+(595,342,o),
+(529,363,c),
+(526,347,l),
+(644,369,o),
+(709,465,o),
+(709,569,cs),
+(709,662,o),
+(647,727,o),
+(554,727,cs),
+(436,727,o),
+(328,620,o),
+(268,620,cs),
+(238,620,o),
+(226,641,o),
+(236,684,cs),
+(243,714,l),
+(185,714,l),
+(176,674,ls),
+(163,608,o),
+(192,566,o),
+(250,566,cs),
+(336,566,o),
+(435,669,o),
+(538,669,cs),
+(604,669,o),
+(645,627,o),
+(645,562,cs),
+(645,466,o),
+(579,381,o),
+(460,381,cs),
+(393,381,l),
+(408,369,l),
+(429,468,l),
+(388,468,l),
+(369,381,l),
+(155,381,l),
+(177,483,l),
+(135,483,l),
+(82,230,l),
+(123,230,l),
+(145,334,l),
+(359,334,l),
+(338,234,l),
+(379,234,l),
+(404,348,l),
+(383,334,l),
+(453,334,ls),
+(530,334,o),
+(571,286,o),
+(571,218,cs),
+(571,139,o),
+(524,45,o),
+(427,45,cs),
+(325,45,o),
+(248,148,o),
+(154,148,cs),
+(96,148,o),
+(56,111,o),
+(42,40,cs),
+(33,0,l),
+(91,0,l),
+(97,29,ls),
+(107,73,o),
+(127,94,o),
+(159,94,cs),
+(230,94,o),
+(315,-13,o),
+(433,-13,cs)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1664;
+unicode = 5732;
+},
+{
+color = 9;
+glyphname = "chiCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(561,-13,o),
+(632,106,o),
+(632,211,cs),
+(632,284,o),
+(594,342,o),
+(528,363,c),
+(525,347,l),
+(643,369,o),
+(708,465,o),
+(708,569,cs),
+(708,662,o),
+(646,727,o),
+(553,727,cs),
+(435,727,o),
+(327,620,o),
+(267,620,cs),
+(237,620,o),
+(225,641,o),
+(235,684,cs),
+(242,714,l),
+(184,714,l),
+(175,674,ls),
+(162,608,o),
+(191,566,o),
+(249,566,cs),
+(335,566,o),
+(434,669,o),
+(537,669,cs),
+(603,669,o),
+(644,627,o),
+(644,562,cs),
+(644,466,o),
+(578,381,o),
+(460,381,cs),
+(408,381,l),
+(429,367,l),
+(427,399,o),
+(399,423,o),
+(366,423,cs),
+(337,423,o),
+(316,405,o),
+(307,381,c),
+(155,381,l),
+(177,483,l),
+(135,483,l),
+(81,231,l),
+(123,231,l),
+(145,334,l),
+(307,334,l),
+(317,309,o),
+(339,292,o),
+(366,292,cs),
+(399,292,o),
+(424,316,o),
+(429,347,c),
+(402,334,l),
+(453,334,ls),
+(529,334,o),
+(570,287,o),
+(570,218,cs),
+(570,139,o),
+(523,45,o),
+(426,45,cs),
+(325,45,o),
+(247,148,o),
+(153,148,cs),
+(95,148,o),
+(55,111,o),
+(41,40,cs),
+(32,0,l),
+(90,0,l),
+(96,29,ls),
+(106,73,o),
+(126,94,o),
+(158,94,cs),
+(229,94,o),
+(314,-13,o),
+(432,-13,cs)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1665;
+unicode = 5733;
+},
+{
+color = 9;
+glyphname = "chaCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(337,-12,o),
+(445,95,o),
+(506,95,cs),
+(535,95,o),
+(547,74,o),
+(537,31,cs),
+(531,1,l),
+(588,1,l),
+(597,41,ls),
+(611,107,o),
+(581,149,o),
+(523,149,cs),
+(437,149,o),
+(338,46,o),
+(235,46,cs),
+(170,46,o),
+(128,88,o),
+(128,154,cs),
+(128,249,o),
+(194,331,o),
+(313,331,cs),
+(617,331,l),
+(596,232,l),
+(638,232,l),
+(692,485,l),
+(650,485,l),
+(629,385,l),
+(322,385,ls),
+(244,385,o),
+(202,429,o),
+(202,498,cs),
+(202,576,o),
+(249,670,o),
+(346,670,cs),
+(448,670,o),
+(526,567,o),
+(619,567,cs),
+(677,567,o),
+(717,604,o),
+(731,675,cs),
+(740,715,l),
+(682,715,l),
+(676,686,ls),
+(666,642,o),
+(646,621,o),
+(614,621,cs),
+(544,621,o),
+(458,728,o),
+(340,728,cs),
+(212,728,o),
+(140,609,o),
+(140,504,cs),
+(140,431,o),
+(178,373,o),
+(244,352,c),
+(247,368,l),
+(129,346,o),
+(64,250,o),
+(64,146,cs),
+(64,53,o),
+(126,-12,o),
+(219,-12,cs)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1666;
+unicode = 5734;
+},
+{
+color = 9;
+glyphname = "ttsuCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(309,-13,o),
+(374,36,o),
+(418,137,c),
+(402,139,l),
+(408,42,o),
+(463,-13,o),
+(558,-13,cs),
+(723,-13,o),
+(785,139,o),
+(787,277,cs),
+(788,377,o),
+(755,480,o),
+(756,555,cs),
+(757,616,o),
+(785,658,o),
+(850,658,cs),
+(884,658,l),
+(896,714,l),
+(847,714,ls),
+(745,714,o),
+(698,653,o),
+(696,556,cs),
+(695,534,o),
+(698,512,o),
+(699,492,c),
+(723,542,l),
+(493,402,l),
+(549,666,l),
+(635,666,l),
+(646,714,l),
+(414,714,l),
+(403,666,l),
+(489,666,l),
+(433,402,l),
+(256,543,l),
+(269,490,l),
+(294,537,o),
+(312,582,o),
+(312,622,cs),
+(312,680,o),
+(274,714,o),
+(207,714,cs),
+(163.005,714,l),
+(151,658,l),
+(182,658,ls),
+(227,658,o),
+(249,642,o),
+(249,608,cs),
+(249,497,o),
+(56,341,o),
+(56,151,cs),
+(56,51,o),
+(116,-13,o),
+(219,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(159,45,o),
+(120,86,o),
+(120,157,cs),
+(120,270,o),
+(204,374,o),
+(259,470,c),
+(421,342,l),
+(396,229,ls),
+(371,107,o),
+(314,45,o),
+(229,45,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(446,45,o),
+(439,148,o),
+(456,229,cs),
+(478,335,l),
+(701,467,l),
+(710,408,o),
+(725,342,o),
+(725,276,cs),
+(724,173,o),
+(683,45,o),
+(558,45,cs)
+);
+}
+);
+width = 859;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1667;
+unicode = 5735;
+},
+{
+color = 9;
+glyphname = "ttsoCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(60,0,ls),
+(163,0,o),
+(209,61,o),
+(211,158,cs),
+(212,180,o),
+(210,202,o),
+(209,222,c),
+(184,172,l),
+(415,312,l),
+(359,48,l),
+(272,48,l),
+(262,0,l),
+(494,0,l),
+(504,48,l),
+(418,48,l),
+(474,312,l),
+(651,171,l),
+(638,224,l),
+(613,177,o),
+(595,132,o),
+(595,92,cs),
+(595,34,o),
+(633.002,0,o),
+(701,0,cs),
+(744,0,l),
+(756,56,l),
+(726,56,ls),
+(680,56,o),
+(658,72,o),
+(658,106,cs),
+(658,217,o),
+(852,373,o),
+(852,563,cs),
+(852,663,o),
+(791,727,o),
+(688,727,cs),
+(599,727,o),
+(533,678,o),
+(489,577,c),
+(506,575,l),
+(500,672,o),
+(444,727,o),
+(350,727,cs),
+(185,727,o),
+(123,575,o),
+(120,437,cs),
+(119,337,o),
+(152,234,o),
+(151,159,cs),
+(150,98,o),
+(122,56,o),
+(58,56,cs),
+(23,56,l),
+(11,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(198,306,o),
+(182,372,o),
+(183,438,cs),
+(183,541,o),
+(225,669,o),
+(349,669,cs),
+(461,669,o),
+(468,566,o),
+(451,485,cs),
+(429,379,l),
+(206,247,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(487,372,l),
+(511,485,ls),
+(536,607,o),
+(593,669,o),
+(679,669,cs),
+(748,669,o),
+(788,628,o),
+(788,557,cs),
+(788,444,o),
+(703,340,o),
+(648,244,c)
+);
+}
+);
+width = 859;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1668;
+unicode = 5736;
+},
+{
+color = 9;
+glyphname = "ttseCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(560,-13,o),
+(632,106,o),
+(632,210,cs),
+(632,284,o),
+(594,342,o),
+(528,363,c),
+(525,347,l),
+(643,369,o),
+(708,464,o),
+(708,569,cs),
+(708,662,o),
+(646,727,o),
+(553,727,cs),
+(435,727,o),
+(327,620,o),
+(266,620,cs),
+(237,620,o),
+(225,641,o),
+(235,684,cs),
+(242,714,l),
+(184,714,l),
+(175,674,ls),
+(162,608,o),
+(191,566,o),
+(249,566,cs),
+(257,566,o),
+(265,566,o),
+(273,568,c),
+(237,596,l),
+(283,381,l),
+(154,381,l),
+(176,483,l),
+(135,483,l),
+(81,230,l),
+(123,230,l),
+(145,334,l),
+(274,334,l),
+(138,121,l),
+(184,145,l),
+(175,147,o),
+(164,148,o),
+(153,148,cs),
+(94,148,o),
+(56,113,o),
+(41,40,cs),
+(32,0,l),
+(90,0,l),
+(96,29,ls),
+(106,73,o),
+(126,94,o),
+(158,94,cs),
+(228,94,o),
+(314,-13,o),
+(432,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(340,44,o),
+(273,117,o),
+(203,139,c),
+(327,334,l),
+(451,334,ls),
+(528,334,o),
+(571,287,o),
+(571,218,cs),
+(571,139,o),
+(523,44,o),
+(426,44,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(290,573,l),
+(363,591,o),
+(448,670,o),
+(537,670,cs),
+(603,670,o),
+(645,627,o),
+(645,561,cs),
+(645,466,o),
+(578,381,o),
+(459,381,cs),
+(331,381,l)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1669;
+unicode = 5737;
+},
+{
+color = 9;
+glyphname = "ttseeCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(560,-13,o),
+(632,106,o),
+(632,210,cs),
+(632,284,o),
+(594,342,o),
+(528,363,c),
+(525,347,l),
+(643,369,o),
+(708,464,o),
+(708,569,cs),
+(708,662,o),
+(646,727,o),
+(553,727,cs),
+(435,727,o),
+(327,620,o),
+(266,620,cs),
+(237,620,o),
+(225,641,o),
+(235,684,cs),
+(242,714,l),
+(184,714,l),
+(175,674,ls),
+(162,608,o),
+(191,566,o),
+(249,566,cs),
+(257,566,o),
+(265,566,o),
+(273,568,c),
+(237,596,l),
+(283,381,l),
+(154,381,l),
+(176,483,l),
+(135,483,l),
+(81,230,l),
+(123,230,l),
+(145,334,l),
+(274,334,l),
+(137,121,l),
+(184,145,l),
+(175,147,o),
+(164,148,o),
+(153,148,cs),
+(94,148,o),
+(56,113,o),
+(41,40,cs),
+(32,0,l),
+(90,0,l),
+(96,29,ls),
+(106,73,o),
+(126,94,o),
+(158,94,cs),
+(228,94,o),
+(314,-13,o),
+(432,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(340,44,o),
+(271,119,o),
+(201,140,c),
+(325,334,l),
+(409,334,l),
+(387,233,l),
+(425,233,l),
+(449,345,l),
+(435,334,l),
+(451,334,ls),
+(528,334,o),
+(571,287,o),
+(571,218,cs),
+(571,139,o),
+(523,44,o),
+(426,44,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(475,470,l),
+(437,470,l),
+(418,381,l),
+(329,381,l),
+(288,572,l),
+(361,589,o),
+(447,670,o),
+(537,670,cs),
+(603,670,o),
+(645,627,o),
+(645,561,cs),
+(645,466,o),
+(578,381,o),
+(459,381,cs),
+(443,381,l),
+(454,372,l)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166A;
+unicode = 5738;
+},
+{
+color = 9;
+glyphname = "ttsiCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(560,-13,o),
+(632,106,o),
+(632,210,cs),
+(632,284,o),
+(594,342,o),
+(528,363,c),
+(525,347,l),
+(643,369,o),
+(708,464,o),
+(708,569,cs),
+(708,662,o),
+(646,727,o),
+(553,727,cs),
+(435,727,o),
+(327,620,o),
+(266,620,cs),
+(237,620,o),
+(225,641,o),
+(235,684,cs),
+(242,714,l),
+(184,714,l),
+(175,674,ls),
+(162,608,o),
+(191,566,o),
+(249,566,cs),
+(257,566,o),
+(265,566,o),
+(273,568,c),
+(237,596,l),
+(283,381,l),
+(154,381,l),
+(176,483,l),
+(135,483,l),
+(81,230,l),
+(123,230,l),
+(145,334,l),
+(274,334,l),
+(138,121,l),
+(184,145,l),
+(175,147,o),
+(164,148,o),
+(153,148,cs),
+(94,148,o),
+(56,113,o),
+(41,40,cs),
+(32,0,l),
+(90,0,l),
+(96,29,ls),
+(106,73,o),
+(126,94,o),
+(158,94,cs),
+(228,94,o),
+(314,-13,o),
+(432,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(340,44,o),
+(268,120,o),
+(199,141,c),
+(322,334,l),
+(362,334,l),
+(371,309,o),
+(395,292,o),
+(419,292,cs),
+(450,292,o),
+(475,315,o),
+(480,345,c),
+(435,334,l),
+(457,334,ls),
+(531,334,o),
+(571,287,o),
+(571,218,cs),
+(571,139,o),
+(523,44,o),
+(426,44,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(473,404,o),
+(448,423,o),
+(419,423,cs),
+(394,423,o),
+(369,407,o),
+(362,381,c),
+(324,381,l),
+(284,570,l),
+(357,587,o),
+(447,670,o),
+(537,670,cs),
+(603,670,o),
+(645,627,o),
+(645,561,cs),
+(645,466,o),
+(581,381,o),
+(462,381,cs),
+(443,381,l),
+(480,372,l)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166B;
+unicode = 5739;
+},
+{
+color = 9;
+glyphname = "ttsaCarrier-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(336,-13,o),
+(443,94,o),
+(504,94,cs),
+(533,94,o),
+(546,73,o),
+(536,30,cs),
+(529,0,l),
+(587,0,l),
+(595,40,ls),
+(609,106,o),
+(580,148,o),
+(522,148,cs),
+(514,148,o),
+(506,148,o),
+(498,146,c),
+(534,118,l),
+(487,333,l),
+(616,333,l),
+(594,231,l),
+(636,231,l),
+(690,484,l),
+(648,484,l),
+(626,380,l),
+(496,380,l),
+(633,593,l),
+(586,569,l),
+(596,567,o),
+(607,566,o),
+(618,566,cs),
+(676,566,o),
+(715,601,o),
+(730,674,cs),
+(739,714,l),
+(681,714,l),
+(674,685,ls),
+(665,641,o),
+(644,620,o),
+(613,620,cs),
+(542,620,o),
+(457,727,o),
+(339,727,cs),
+(210,727,o),
+(139,608,o),
+(139,504,cs),
+(139,430,o),
+(177,372,o),
+(243,351,c),
+(246,367,l),
+(127,345,o),
+(63,250,o),
+(63,145,cs),
+(63,52,o),
+(125,-13,o),
+(218,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(168,44,o),
+(126,87,o),
+(126,153,cs),
+(126,248,o),
+(193,333,o),
+(312,333,cs),
+(440,333,l),
+(480,141,l),
+(408,123,o),
+(323,44,o),
+(234,44,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(243,380,o),
+(200,427,o),
+(200,496,cs),
+(200,575,o),
+(248,670,o),
+(345,670,cs),
+(430,670,o),
+(498,597,o),
+(568,575,c),
+(444,380,l),
+(320,380,ls)
+);
+}
+);
+width = 723;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni166C;
+unicode = 5740;
+},
+{
+glyphname = "qai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (329,0);
+ref = "ke-canadian";
+}
+);
+width = 917;
+}
+);
+note = uni166F;
+unicode = 5743;
+},
+{
+glyphname = "ngai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (645,0);
+ref = "ce-canadian";
+}
+);
+width = 1229;
+}
+);
+note = uni1670;
+unicode = 5744;
+},
+{
+glyphname = "nngi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (931,0);
+ref = "ci-canadian";
+}
+);
+width = 1514;
+}
+);
+note = uni1671;
+unicode = 5745;
+},
+{
+glyphname = "nngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (931,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (1163,0);
+ref = dot_top;
+}
+);
+width = 1514;
+}
+);
+note = uni1672;
+unicode = 5746;
+},
+{
+glyphname = "nngo-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (931,0);
+ref = "ce-canadian";
+}
+);
+width = 1514;
+}
+);
+note = uni1673;
+unicode = 5747;
+},
+{
+glyphname = "nngoo-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (931,0);
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (1157,0);
+ref = dot_top;
+}
+);
+width = 1514;
+}
+);
+note = uni1674;
+unicode = 5748;
+},
+{
+glyphname = "nnga-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (931,0);
+ref = "ca-canadian";
+}
+);
+width = 1514;
+}
+);
+note = uni1675;
+unicode = 5749;
+},
+{
+glyphname = "nngaa-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (931,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (975,0);
+ref = dot_top;
+}
+);
+width = 1514;
+}
+);
+note = uni1676;
+unicode = 5750;
+},
+{
+glyphname = "thweeWoodScree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (608,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 829;
+}
+);
+note = uni1677;
+unicode = 5751;
+},
+{
+glyphname = "thwiWoodScree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (608,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 829;
+}
+);
+note = uni1678;
+unicode = 5752;
+},
+{
+glyphname = "thwiiWoodScree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (88,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (608,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 829;
+}
+);
+note = uni1679;
+unicode = 5753;
+},
+{
+glyphname = "thwoWoodScree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (608,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 829;
+}
+);
+note = uni167A;
+unicode = 5754;
+},
+{
+glyphname = "thwooWoodScree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (391,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (608,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 829;
+}
+);
+note = uni167B;
+unicode = 5755;
+},
+{
+glyphname = "thwaWoodScree-canadian";
+lastChange = "2023-01-13 15:29:29 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = middle_right_can;
+pos = (609,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 829;
+}
+);
+note = uni167C;
+unicode = 5756;
+},
+{
+glyphname = "thwaaWoodScree-canadian";
+lastChange = "2023-01-13 15:29:29 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (89,0);
+ref = dot_top;
+},
+{
+anchor = middle_right_can;
+pos = (609,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 829;
+}
+);
+note = uni167D;
+unicode = 5757;
+},
+{
+glyphname = "wBlackfoot-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(462,584,l),
+(471,625,l),
+(152,625,l),
+(143,584,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(432,446,l),
+(441,487,l),
+(122,487,l),
+(113,446,l)
+);
+}
+);
+width = 460;
+}
+);
+metricRight = "=|";
+note = uni167F;
+unicode = 5759;
+},
+{
+glyphname = "oy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-12,0);
+ref = ring_top.canadian;
+}
+);
+width = 688;
+}
+);
+note = uni18B0;
+unicode = 6320;
+},
+{
+glyphname = "ay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (453,0);
+ref = ring_top.canadian;
+}
+);
+width = 688;
+}
+);
+note = uni18B1;
+unicode = 6321;
+},
+{
+glyphname = "aay-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (194,0);
+ref = ring_top.canadian;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (513,0);
+ref = dot_top;
+}
+);
+width = 688;
+}
+);
+note = uni18B2;
+unicode = 6322;
+},
+{
+glyphname = "way-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (673,0);
+ref = ring_top.canadian;
+}
+);
+width = 909;
+}
+);
+note = uni18B3;
+unicode = 6323;
+},
+{
+glyphname = "poy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-36,0);
+ref = ring_top.canadian;
+}
+);
+width = 658;
+}
+);
+note = uni18B4;
+unicode = 6324;
+},
+{
+glyphname = "pay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (446,0);
+ref = ring_top.canadian;
+}
+);
+width = 658;
+}
+);
+note = uni18B5;
+unicode = 6325;
+},
+{
+glyphname = "pwoy-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (185,0);
+ref = ring_top.canadian;
+}
+);
+width = 878;
+}
+);
+note = uni18B6;
+unicode = 6326;
+},
+{
+glyphname = "tay-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (209,0);
+ref = ring_top.canadian;
+}
+);
+width = 606;
+}
+);
+note = uni18B7;
+unicode = 6327;
+},
+{
+glyphname = "kay-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-16,0);
+ref = ring_top.canadian;
+}
+);
+width = 588;
+}
+);
+note = uni18B8;
+unicode = 6328;
+},
+{
+glyphname = "kway-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (204,0);
+ref = ring_top.canadian;
+}
+);
+width = 808;
+}
+);
+note = uni18B9;
+unicode = 6329;
+},
+{
+glyphname = "may-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-8,0);
+ref = ring_top.canadian;
+}
+);
+width = 520;
+}
+);
+note = uni18BA;
+unicode = 6330;
+},
+{
+glyphname = "noy-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (347,-207);
+ref = ring_top.canadian;
+}
+);
+width = 815;
+}
+);
+note = uni18BB;
+unicode = 6331;
+},
+{
+glyphname = "nay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (132,-207);
+ref = ring_top.canadian;
+}
+);
+width = 815;
+}
+);
+note = uni18BC;
+unicode = 6332;
+},
+{
+glyphname = "lay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (133,-207);
+ref = ring_top.canadian;
+}
+);
+width = 815;
+}
+);
+note = uni18BD;
+unicode = 6333;
+},
+{
+glyphname = "soy-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (296,0);
+ref = ring_top.canadian;
+}
+);
+width = 535;
+}
+);
+note = uni18BE;
+unicode = 6334;
+},
+{
+glyphname = "say-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-8,0);
+ref = ring_top.canadian;
+}
+);
+width = 535;
+}
+);
+note = uni18BF;
+unicode = 6335;
+},
+{
+glyphname = "shoy-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (307,-207);
+ref = ring_top.canadian;
+}
+);
+width = 951;
+}
+);
+note = uni18C0;
+unicode = 6336;
+},
+{
+glyphname = "shay-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (308,-207);
+ref = ring_top.canadian;
+}
+);
+width = 951;
+}
+);
+note = uni18C1;
+unicode = 6337;
+},
+{
+glyphname = "shwoy-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (527,-207);
+ref = ring_top.canadian;
+}
+);
+width = 1172;
+}
+);
+note = uni18C2;
+unicode = 6338;
+},
+{
+glyphname = "yoy-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (332,0);
+ref = ring_top.canadian;
+}
+);
+width = 569;
+}
+);
+note = uni18C3;
+unicode = 6339;
+},
+{
+glyphname = "yay-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-10,0);
+ref = ring_top.canadian;
+}
+);
+width = 569;
+}
+);
+note = uni18C4;
+unicode = 6340;
+},
+{
+glyphname = "ray-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (182,0);
+ref = ring_top.canadian;
+}
+);
+width = 540;
+}
+);
+note = uni18C5;
+unicode = 6341;
+},
+{
+glyphname = "nwi-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ni-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni18C6;
+unicode = 6342;
+},
+{
+glyphname = "nwiOjibway-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (815,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni18C7;
+unicode = 6343;
+},
+{
+glyphname = "nwii-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (417,-207);
+ref = dot_top;
+}
+);
+width = 1036;
+}
+);
+note = uni18C8;
+unicode = 6344;
+},
+{
+glyphname = "nwiiOjibway-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (197,-207);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (815,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni18C9;
+unicode = 6345;
+},
+{
+glyphname = "nwo-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "no-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni18CA;
+unicode = 6346;
+},
+{
+glyphname = "nwoOjibway-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (815,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni18CB;
+unicode = 6347;
+},
+{
+glyphname = "nwoo-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (627,-207);
+ref = dot_top;
+}
+);
+width = 1036;
+}
+);
+note = uni18CC;
+unicode = 6348;
+},
+{
+glyphname = "nwooOjibway-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (407,-207);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (815,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni18CD;
+unicode = 6349;
+},
+{
+glyphname = "rwee-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "reRCree-canadian";
+}
+);
+width = 1080;
+}
+);
+note = uni18CE;
+unicode = 6350;
+},
+{
+glyphname = "rwi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ri-canadian";
+}
+);
+width = 1080;
+}
+);
+note = uni18CF;
+unicode = 6351;
+},
+{
+glyphname = "rwii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (412,-207);
+ref = dot_top;
+}
+);
+width = 1080;
+}
+);
+note = uni18D0;
+unicode = 6352;
+},
+{
+glyphname = "rwo-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ro-canadian";
+}
+);
+width = 760;
+}
+);
+note = uni18D1;
+unicode = 6353;
+},
+{
+glyphname = "rwoo-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (389,0);
+ref = dot_top;
+}
+);
+width = 760;
+}
+);
+note = uni18D2;
+unicode = 6354;
+},
+{
+glyphname = "rwa-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ra-canadian";
+}
+);
+width = 760;
+}
+);
+note = uni18D3;
+unicode = 6355;
+},
+{
+glyphname = "pOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(126,357,l),
+(325,669,l),
+(290,669,l),
+(357,357,l),
+(399,357,l),
+(402,369,l),
+(323,714,l),
+(307,714,l),
+(81,369,l),
+(78,357,l)
+);
+}
+);
+width = 430;
+}
+);
+metricLeft = "kkCarrier-canadian";
+note = uni18D4;
+unicode = 6356;
+},
+{
+glyphname = "tOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 425;
+}
+);
+metricRight = "=|";
+note = uni1422;
+unicode = 6357;
+},
+{
+glyphname = "kOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,357,l),
+(179,533,l),
+(166,533,l),
+(165,485,o),
+(202,449,o),
+(255,449,cs),
+(341,449,o),
+(387,540,o),
+(387,612,cs),
+(387,677,o),
+(347,720,o),
+(280,720,cs),
+(211,720,o),
+(162,676,o),
+(144,592,cs),
+(94,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(210,487,o),
+(185,514,o),
+(185,558,cs),
+(185,608,o),
+(215,682,o),
+(280,682,cs),
+(320,682,o),
+(344,656,o),
+(344,612,cs),
+(344,560,o),
+(313,487,o),
+(251,487,cs)
+);
+}
+);
+width = 374;
+}
+);
+metricLeft = "k-canadian";
+metricRight = "k-canadian";
+note = uni18D6;
+unicode = 6358;
+},
+{
+glyphname = "cOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,357,l),
+(193,601,ls),
+(205,656,o),
+(237,680,o),
+(281,680,cs),
+(335,680,o),
+(354,645,o),
+(344,593,cs),
+(339,569,l),
+(383,569,l),
+(387,587,ls),
+(404,664,o),
+(364,720,o),
+(282,720,cs),
+(209,720,o),
+(162,678,o),
+(146,600,cs),
+(94,357,l)
+);
+}
+);
+width = 364;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni18D7;
+unicode = 6359;
+},
+{
+glyphname = "mOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,357,l),
+(208,670,l),
+(377,670,l),
+(387,714,l),
+(170,714,l),
+(94,357,l)
+);
+}
+);
+width = 337;
+}
+);
+metricLeft = "m-canadian";
+metricRight = "m-canadian";
+note = uni18D8;
+unicode = 6360;
+},
+{
+glyphname = "nOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(330,443,o),
+(377,527,o),
+(377,602,cs),
+(377,644,o),
+(356,674,o),
+(335,687,c),
+(329,670,l),
+(525,670,l),
+(534,714,l),
+(271,714,ls),
+(178,714,o),
+(131,630,o),
+(131,554,cs),
+(131,487,o),
+(174,443,o),
+(241,443,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,480,o),
+(174,509,o),
+(174,554,cs),
+(174,598,o),
+(198,676,o),
+(267,676,cs),
+(309,676,o),
+(334,648,o),
+(334,603,cs),
+(334,559,o),
+(311,480,o),
+(242,480,cs)
+);
+}
+);
+width = 485;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "n-canadian";
+note = uni18D9;
+unicode = 6361;
+},
+{
+glyphname = "sOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,357,l),
+(172,502,l),
+(141,478,l),
+(172,478,ls),
+(285,478,o),
+(350,536,o),
+(374,654,cs),
+(387,714,l),
+(339,714,l),
+(328,659,ls),
+(307,561,o),
+(258,519,o),
+(165,519,cs),
+(128,519,l),
+(94,357,l)
+);
+}
+);
+width = 357;
+}
+);
+metricLeft = "s-canadian";
+metricRight = "s-canadian";
+note = uni18DA;
+unicode = 6362;
+},
+{
+color = 1;
+glyphname = "shOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(276,351,o),
+(317,394,o),
+(342,476,cs),
+(378,597,ls),
+(395,653,o),
+(420,682,o),
+(468,682,cs),
+(518,682,o),
+(540,650,o),
+(529,596,cs),
+(524,569,l),
+(568,569,l),
+(572,592,ls),
+(587,668,o),
+(548,720,o),
+(469,720,cs),
+(397,720,o),
+(355,678,o),
+(331,596,cs),
+(295,475,ls),
+(278,419,o),
+(252,390,o),
+(205,390,cs),
+(155,390,o),
+(133,422,o),
+(144,475,cs),
+(149,503,l),
+(105,503,l),
+(100,480,ls),
+(86,404,o),
+(125,351,o),
+(204,351,cs)
+);
+}
+);
+width = 549;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "c-canadian";
+note = uni18DB;
+unicode = 6363;
+},
+{
+color = 9;
+glyphname = "easternw-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (-23,-318);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (115,0);
+ref = "glottalstop-canadian";
+}
+);
+width = 561;
+}
+);
+note = uni18DC;
+unicode = 6364;
+},
+{
+color = 9;
+glyphname = "westernw-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (716,-318);
+ref = dot_top;
+scale = (-1,1);
+},
+{
+alignment = -1;
+ref = "glottalstop-canadian";
+}
+);
+width = 565;
+}
+);
+metricLeft = "glottalstop-canadian";
+note = uni18DD;
+unicode = 6365;
+},
+{
+glyphname = "rweRCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "reRCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (860,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1080;
+}
+);
+note = uni18E0;
+unicode = 6368;
+},
+{
+glyphname = "looWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+}
+);
+width = 540;
+}
+);
+note = uni18E1;
+unicode = 6369;
+},
+{
+glyphname = "laaWestCree-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (360,0);
+ref = dot_top;
+}
+);
+width = 539;
+}
+);
+note = uni18E2;
+unicode = 6370;
+},
+{
+glyphname = "thwe-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "the-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (722,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 942;
+}
+);
+note = uni18E3;
+unicode = 6371;
+},
+{
+glyphname = "thwa-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (675,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 895;
+}
+);
+note = uni18E4;
+unicode = 6372;
+},
+{
+glyphname = "tthwe-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "tthe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (713,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 933;
+}
+);
+note = uni18E5;
+unicode = 6373;
+},
+{
+glyphname = "tthoo-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ttho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (244,0);
+ref = dot_top;
+}
+);
+width = 627;
+}
+);
+note = uni18E6;
+unicode = 6374;
+},
+{
+glyphname = "tthaa-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ttha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (260,0);
+ref = dot_top;
+}
+);
+width = 627;
+}
+);
+note = uni18E7;
+unicode = 6375;
+},
+{
+glyphname = "tlhwe-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "tlhe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (593,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 813;
+}
+);
+note = uni18E8;
+unicode = 6376;
+},
+{
+glyphname = "tlhoo-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "tlho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (251,0);
+ref = dot_top;
+}
+);
+width = 593;
+}
+);
+note = uni18E9;
+unicode = 6377;
+},
+{
+glyphname = "shweSayisi-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "sheSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (593,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 813;
+}
+);
+note = uni18EA;
+unicode = 6378;
+},
+{
+glyphname = "shooSayisi-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "shoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (422,0);
+ref = dot_top;
+}
+);
+width = 593;
+}
+);
+note = uni18EB;
+unicode = 6379;
+},
+{
+color = 9;
+glyphname = "hooSayisi-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "hoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (482,0);
+ref = dot_top;
+}
+);
+width = 661;
+}
+);
+note = uni18EC;
+unicode = 6380;
+},
+{
+color = 9;
+glyphname = "gwuCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "guCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (865,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1085;
+}
+);
+note = uni18ED;
+unicode = 6381;
+},
+{
+color = 9;
+glyphname = "deneGeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "geCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (289,0);
+ref = dot_top;
+}
+);
+width = 701;
+}
+);
+note = uni18EE;
+unicode = 6382;
+},
+{
+color = 9;
+glyphname = "gaaCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (301,0);
+ref = dot_top;
+}
+);
+width = 701;
+}
+);
+note = uni18EF;
+unicode = 6383;
+},
+{
+color = 9;
+glyphname = "gwaCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (701,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 921;
+}
+);
+note = uni18F0;
+unicode = 6384;
+},
+{
+color = 9;
+glyphname = "juuSayisi-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "juSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (311,0);
+ref = dot_top;
+}
+);
+width = 714;
+}
+);
+note = uni18F1;
+unicode = 6385;
+},
+{
+color = 9;
+glyphname = "jwaCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "jaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (760,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 981;
+}
+);
+note = uni18F2;
+unicode = 6386;
+},
+{
+glyphname = "lBeaverDene-canadian";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "pWestCree-canadian";
+}
+);
+width = 188;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+unicode = 6387;
+},
+{
+glyphname = "rBeaverDene-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,357,l),
+(188,576,ls),
+(202,640,o),
+(234,672,o),
+(281,672,cs),
+(291,672,l),
+(301,720,l),
+(294,720,ls),
+(242,720,o),
+(203,687,o),
+(192,632,c),
+(197,635,l),
+(214.006,714,l),
+(170,714,l),
+(94,357,l)
+);
+}
+);
+width = 232;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni18F4;
+unicode = 6388;
+},
+{
+color = 6;
+glyphname = "sDentalCarrier-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(215,189,ls),
+(303,189,o),
+(349,232,o),
+(349,306,cs),
+(349,355,o),
+(317,387,o),
+(256,387,cs),
+(216,387,ls),
+(174,387,o),
+(155,404,o),
+(155,433,cs),
+(155,478,o),
+(183,508,o),
+(241,508,cs),
+(389,508,l),
+(397,546,l),
+(247,546,ls),
+(158,546,o),
+(113,503,o),
+(113,429,cs),
+(113,380,o),
+(144,348,o),
+(205,348,cs),
+(246,348,ls),
+(288,348,o),
+(306,331,o),
+(306,303,cs),
+(306,257,o),
+(278,228,o),
+(220,228,cs),
+(72,228,l),
+(64,189,l)
+);
+}
+);
+width = 409;
+}
+);
+metricLeft = "shCarrier-canadian";
+metricRight = "=|";
+note = uni18F5;
+unicode = 6389;
+},
+{
+glyphname = "pWestCree-canadian.base";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "pWestCree-canadian";
+}
+);
+width = 188;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.base";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "c-canadian";
+}
+);
+width = 364;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "thSayisi-canadian.base";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "thSayisi-canadian";
+}
+);
+width = 364;
+}
+);
+metricLeft = "=|c-canadian";
+note = uni14A2;
+},
+{
+glyphname = "mWestCree-canadian.base";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "mWestCree-canadian";
+}
+);
+width = 374;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+glyphname = "pWestCree-canadian.mid";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "pWestCree-canadian";
+}
+);
+width = 188;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.mid";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "c-canadian";
+}
+);
+width = 364;
+}
+);
+metricLeft = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "mWestCree-canadian.mid";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-168);
+ref = "mWestCree-canadian";
+}
+);
+width = 375;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+color = 11;
+glyphname = "ngaai-canadian.nunavik";
+lastChange = "2023-01-13 15:29:29 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (652,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (825,0);
+ref = ring_top.canadian;
+}
+);
+width = 1236;
+}
+);
+note = uni158E;
+},
+{
+color = 11;
+glyphname = "ngi-canadian.nunavik";
+lastChange = "2023-01-13 15:29:29 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (652,0);
+ref = "ci-canadian";
+}
+);
+width = 1236;
+}
+);
+note = uni158F;
+},
+{
+color = 11;
+glyphname = "ngii-canadian.nunavik";
+lastChange = "2023-01-13 15:29:29 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (652,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (885,0);
+ref = dot_top;
+}
+);
+width = 1236;
+}
+);
+note = uni1590;
+},
+{
+color = 11;
+glyphname = "ngo-canadian.nunavik";
+lastChange = "2023-01-13 15:29:29 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (652,0);
+ref = "co-canadian";
+}
+);
+width = 1237;
+}
+);
+note = uni1591;
+},
+{
+color = 11;
+glyphname = "ngoo-canadian.nunavik";
+lastChange = "2023-01-13 15:29:29 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "ngo-canadian.nunavik";
+},
+{
+anchor = top_right_can;
+pos = (1065,0);
+ref = dot_top;
+}
+);
+width = 1237;
+}
+);
+note = uni1592;
+},
+{
+color = 11;
+glyphname = "nga-canadian.nunavik";
+lastChange = "2023-01-13 15:29:29 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (652,0);
+ref = "ca-canadian";
+}
+);
+width = 1236;
+}
+);
+note = uni1593;
+},
+{
+color = 11;
+glyphname = "ngaa-canadian.nunavik";
+lastChange = "2023-01-13 15:29:29 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (652,0);
+ref = "ca-canadian";
+},
+{
+anchor = top_left_can;
+pos = (696,0);
+ref = dot_top;
+}
+);
+width = 1236;
+}
+);
+note = uni1594;
+},
+{
+color = 11;
+glyphname = "ng-canadian.nunavik";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(555,158,o),
+(603,247,o),
+(603,323,cs),
+(603,386,o),
+(564,429,o),
+(504,429,cs),
+(466,429,o),
+(432,410,o),
+(413,376,c),
+(419,365,l),
+(447,494,l),
+(309,494,l),
+(312,475,l),
+(358,500,o),
+(378,565,o),
+(378,609,cs),
+(378,676,o),
+(335,720,o),
+(268,720,cs),
+(178,720,o),
+(133,636,o),
+(133,561,cs),
+(133,493,o),
+(175,449,o),
+(243,449,cs),
+(415,449,l),
+(395,475,l),
+(359,308,ls),
+(343,231,o),
+(378,158,o),
+(463,158,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(425,196,o),
+(398,223,o),
+(398,268,cs),
+(398,319,o),
+(429,392,o),
+(493,392,cs),
+(534,392,o),
+(560,365,o),
+(560,320,cs),
+(560,268,o),
+(529,196,o),
+(466,196,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,487,o),
+(175,516,o),
+(175,560,cs),
+(175,614,o),
+(205,683,o),
+(267,683,cs),
+(310,683,o),
+(336,654,o),
+(336,609,cs),
+(336,556,o),
+(304,487,o),
+(243,487,cs)
+);
+}
+);
+width = 652;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+color = 11;
+glyphname = "ngai-canadian.nunavik";
+lastChange = "2023-01-13 15:29:29 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (652,0);
+ref = "ce-canadian";
+}
+);
+width = 1237;
+}
+);
+note = uni1670;
+},
+{
+color = 11;
+glyphname = "ke-canadian.square";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (438,714);
+},
+{
+name = top_left_can;
+pos = (206,714);
+},
+{
+name = top_right_can;
+pos = (674,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(553,0,l),
+(705,714,l),
+(474,714,ls),
+(223,714,o),
+(104,558,o),
+(104,370,cs),
+(104,227,o),
+(198,141,o),
+(360,141,cs),
+(519,141,l),
+(489,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(238,198,o),
+(167,261,o),
+(167,374,cs),
+(167,521,o),
+(256,657,o),
+(462,657,cs),
+(629,657,l),
+(532,198,l),
+(371,198,ls)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146B;
+},
+{
+color = 11;
+glyphname = "ki-canadian.square";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (452,714);
+},
+{
+name = top_left_can;
+pos = (216,714);
+},
+{
+name = top_right_can;
+pos = (687,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(95,0,l),
+(125,141,l),
+(295,141,ls),
+(544,141,o),
+(662,299,o),
+(662,483,cs),
+(662,628,o),
+(567,714,o),
+(406,714,cs),
+(183,714,l),
+(31,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(235,657,l),
+(396,657,ls),
+(528,657,o),
+(599,593,o),
+(599,481,cs),
+(599,334,o),
+(511,198,o),
+(307,198,cs),
+(138,198,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni146D;
+},
+{
+color = 11;
+glyphname = "kii-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (287,0);
+ref = dot_top;
+}
+);
+width = 689;
+}
+);
+note = uni146E;
+},
+{
+color = 11;
+glyphname = "ko-canadian.square";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (437,714);
+},
+{
+name = top_left_can;
+pos = (205,714);
+},
+{
+name = top_right_can;
+pos = (673,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(552,0,l),
+(704,714,l),
+(640,714,l),
+(611,573,l),
+(440,573,ls),
+(191,573,o),
+(74,415,o),
+(74,231,cs),
+(74,86,o),
+(168,0,o),
+(329,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(208,57,o),
+(137,121,o),
+(137,233,cs),
+(137,380,o),
+(224,516,o),
+(429,516,cs),
+(598,516,l),
+(501,57,l),
+(339,57,ls)
+);
+}
+);
+width = 687;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146F;
+},
+{
+color = 11;
+glyphname = "koo-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (509,0);
+ref = dot_top;
+}
+);
+width = 689;
+}
+);
+note = uni1470;
+},
+{
+color = 11;
+glyphname = "ka-canadian.square";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (452,714);
+},
+{
+name = top_left_can;
+pos = (216,714);
+},
+{
+name = top_right_can;
+pos = (688,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(263,0,ls),
+(513,0,o),
+(632,156,o),
+(632,344,cs),
+(632,487,o),
+(538,573,o),
+(376,573,cs),
+(218,573,l),
+(247,714,l),
+(183,714,l),
+(31,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(205,516,l),
+(365,516,ls),
+(498,516,o),
+(569,453,o),
+(569,340,cs),
+(569,193,o),
+(480,57,o),
+(275,57,cs),
+(108,57,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1472;
+},
+{
+color = 11;
+glyphname = "kaa-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+}
+);
+width = 689;
+}
+);
+note = uni1473;
+},
+{
+color = 11;
+glyphname = "kweWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (689,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 909;
+}
+);
+note = uni1475;
+},
+{
+color = 11;
+glyphname = "kwiiWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (287,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (689,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 909;
+}
+);
+note = uni1479;
+},
+{
+color = 11;
+glyphname = "kwoWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (689,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 909;
+}
+);
+note = uni147B;
+},
+{
+color = 11;
+glyphname = "kwooWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (509,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (689,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 909;
+}
+);
+note = uni147D;
+},
+{
+color = 11;
+glyphname = "kwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (689,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 909;
+}
+);
+note = uni147F;
+},
+{
+color = 11;
+glyphname = "kwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (689,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 909;
+}
+);
+note = uni1481;
+},
+{
+color = 11;
+glyphname = "ce-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (451,714);
+},
+{
+name = top_left_can;
+pos = (202,714);
+},
+{
+name = top_right_can;
+pos = (700,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(579,0,l),
+(666,409,ls),
+(707,602,o),
+(612,727,o),
+(424,727,cs),
+(260,727,o),
+(151,630,o),
+(114,452,cs),
+(104,405,l),
+(168,405,l),
+(177,448,ls),
+(207,593,o),
+(291,668,o),
+(420,668,cs),
+(570,668,o),
+(638,573,o),
+(603,409,cs),
+(515,0,l)
+);
+}
+);
+width = 707;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni1489;
+},
+{
+color = 11;
+glyphname = "ci-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (456,714);
+},
+{
+name = top_left_can;
+pos = (208,714);
+},
+{
+name = top_right_can;
+pos = (706,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(88,0,l),
+(182,442,ls),
+(213,591,o),
+(298,668,o),
+(429,668,cs),
+(570,668,o),
+(645,580,o),
+(616,442,cs),
+(607,405,l),
+(671,405,l),
+(678,438,ls),
+(714,609,o),
+(612,727,o),
+(432,727,cs),
+(268,727,o),
+(158,630,o),
+(120,453,cs),
+(24,0,l)
+);
+}
+);
+width = 707;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+},
+{
+color = 11;
+glyphname = "cii-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (292,0);
+ref = dot_top;
+}
+);
+width = 707;
+}
+);
+note = uni148C;
+},
+{
+color = 11;
+glyphname = "co-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (451,714);
+},
+{
+name = top_left_can;
+pos = (202,714);
+},
+{
+name = top_right_can;
+pos = (700,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(487,-13,o),
+(597,84,o),
+(635,261,cs),
+(731,714,l),
+(667,714,l),
+(574,272,ls),
+(542,123,o),
+(457,46,o),
+(326,46,cs),
+(185,46,o),
+(109,134,o),
+(139,272,cs),
+(147,309,l),
+(84,309,l),
+(77,276,ls),
+(41,105,o),
+(143,-13,o),
+(323,-13,cs)
+);
+}
+);
+width = 707;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+},
+{
+color = 11;
+glyphname = "coo-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (535,0);
+ref = dot_top;
+}
+);
+width = 707;
+}
+);
+note = uni148E;
+},
+{
+color = 11;
+glyphname = "ca-canadian.square";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (456,714);
+},
+{
+name = top_left_can;
+pos = (208,714);
+},
+{
+name = top_right_can;
+pos = (705,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(495,-13,o),
+(604,84,o),
+(640,262,cs),
+(650,309,l),
+(587,309,l),
+(578,266,ls),
+(547,121,o),
+(464,46,o),
+(335,46,cs),
+(185,46,o),
+(118,141,o),
+(152,305,cs),
+(240,714,l),
+(176,714,l),
+(89,305,ls),
+(48,112,o),
+(143,-13,o),
+(331,-13,cs)
+);
+}
+);
+width = 706;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+},
+{
+color = 11;
+glyphname = "caa-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (44,0);
+ref = dot_top;
+}
+);
+width = 707;
+}
+);
+note = uni1491;
+},
+{
+color = 11;
+glyphname = "me-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (383,714);
+},
+{
+name = top_double;
+pos = (588,714);
+},
+{
+name = top_left_can;
+pos = (175,714);
+},
+{
+name = top_right_can;
+pos = (588,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(468,0,l),
+(620,714,l),
+(143,714,l),
+(131,656,l),
+(544,656,l),
+(403.993,0,l)
+);
+}
+);
+width = 603;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+},
+{
+color = 11;
+glyphname = "mi-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (422,714);
+},
+{
+name = top_left_can;
+pos = (216,714);
+},
+{
+name = top_right_can;
+pos = (628,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(95,0,l),
+(235,656,l),
+(647,656,l),
+(660,714,l),
+(183,714,l),
+(31,0,l)
+);
+}
+);
+width = 603;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+},
+{
+color = 11;
+glyphname = "mii-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (258,0);
+ref = dot_top;
+}
+);
+width = 603;
+}
+);
+note = uni14A6;
+},
+{
+color = 11;
+glyphname = "mo-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (383,714);
+},
+{
+name = top_double;
+pos = (588,714);
+},
+{
+name = top_left_can;
+pos = (175,714);
+},
+{
+name = top_right_can;
+pos = (588,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(468,0,l),
+(620,714,l),
+(555.993,714,l),
+(416,58,l),
+(3,58,l),
+(-9,0,l)
+);
+}
+);
+width = 603;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+},
+{
+color = 11;
+glyphname = "moo-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (424,0);
+ref = dot_top;
+}
+);
+width = 603;
+}
+);
+note = uni14A8;
+},
+{
+color = 11;
+glyphname = "ma-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (422,714);
+},
+{
+name = top_left_can;
+pos = (216,714);
+},
+{
+name = top_right_can;
+pos = (628,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(508,0,l),
+(520,58,l),
+(108,58,l),
+(247,714,l),
+(183,714,l),
+(31,0,l)
+);
+}
+);
+width = 603;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+},
+{
+color = 11;
+glyphname = "maa-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+}
+);
+width = 603;
+}
+);
+note = uni14AB;
+},
+{
+color = 11;
+glyphname = "ne-canadian.square";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (545,714);
+},
+{
+name = top_left_can;
+pos = (344,714);
+},
+{
+name = top_right_can;
+pos = (752,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(560,-13,o),
+(646,68,o),
+(682,238,cs),
+(784,714,l),
+(164,714,l),
+(152,656,l),
+(299,656,l),
+(215,261,ls),
+(179,90,o),
+(254,-13,o),
+(417,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(300,47,o),
+(249,120,o),
+(277,252,cs),
+(363,656,l),
+(708,656,l),
+(619,240,ls),
+(591,109,o),
+(528,47,o),
+(420,47,cs)
+);
+}
+);
+width = 760;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C0;
+},
+{
+color = 11;
+glyphname = "ni-canadian.square";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (411,714);
+},
+{
+name = top_left_can;
+pos = (208,714);
+},
+{
+name = top_right_can;
+pos = (615,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(424,-13,o),
+(510,68,o),
+(546,238,cs),
+(635,656,l),
+(783,656,l),
+(795,714,l),
+(176,714,l),
+(80,261,ls),
+(43,90,o),
+(119,-13,o),
+(282,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(165,47,o),
+(113,120,o),
+(141,252,cs),
+(227,656,l),
+(572,656,l),
+(483,240,ls),
+(455,109,o),
+(392,47,o),
+(285,47,cs)
+);
+}
+);
+width = 760;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+},
+{
+color = 11;
+glyphname = "nii-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (247,0);
+ref = dot_top;
+}
+);
+width = 759;
+}
+);
+note = uni14C3;
+},
+{
+color = 11;
+glyphname = "no-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (548,714);
+},
+{
+name = top_double;
+pos = (558,714);
+},
+{
+name = top_left_can;
+pos = (344,714);
+},
+{
+name = top_right_can;
+pos = (749,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(631,0,l),
+(727,453,ls),
+(763,624,o),
+(688,727,o),
+(525,727,cs),
+(382,727,o),
+(297,646,o),
+(261,476,cs),
+(172,58,l),
+(24,58,l),
+(12,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(324,474,ls),
+(352,605,o),
+(414,667,o),
+(522,667,cs),
+(642,667,o),
+(693,594,o),
+(665,462,cs),
+(579,58,l),
+(235,58,l)
+);
+}
+);
+width = 759;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C4;
+},
+{
+color = 11;
+glyphname = "noo-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (383,0);
+ref = dot_top;
+}
+);
+width = 759;
+}
+);
+note = uni14C5;
+},
+{
+color = 11;
+glyphname = "na-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (412,714);
+},
+{
+name = top_double;
+pos = (422,714);
+},
+{
+name = top_left_can;
+pos = (208,714);
+},
+{
+name = top_right_can;
+pos = (616,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(643,0,l),
+(655,58,l),
+(508,58,l),
+(592,453,ls),
+(628,624,o),
+(553,727,o),
+(390,727,cs),
+(248,727,o),
+(162,646,o),
+(125,476,cs),
+(24,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(188,474,ls),
+(216,605,o),
+(280,667,o),
+(387,667,cs),
+(507,667,o),
+(558,594,o),
+(530,462,cs),
+(444,58,l),
+(100,58,l)
+);
+}
+);
+width = 759;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+},
+{
+color = 11;
+glyphname = "naa-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (247,0);
+ref = dot_top;
+}
+);
+width = 759;
+}
+);
+note = uni14C8;
+},
+{
+color = 11;
+glyphname = "nweWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (759,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 979;
+}
+);
+note = uni14CA;
+},
+{
+color = 11;
+glyphname = "nwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (759,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 979;
+}
+);
+note = uni14CC;
+},
+{
+color = 11;
+glyphname = "nwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (247,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (759,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 979;
+}
+);
+note = uni14CE;
+},
+{
+color = 11;
+glyphname = "se-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (212,714);
+},
+{
+name = top_right_can;
+pos = (674,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(553,0,l),
+(603,238,l),
+(405,238,ls),
+(230,238,o),
+(162,329,o),
+(202,514,cs),
+(244,714,l),
+(180,714,l),
+(138,514,ls),
+(93,304,o),
+(190,181,o),
+(394,181,cs),
+(549,181,l),
+(532,202,l),
+(488.99,0,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14ED;
+},
+{
+color = 11;
+glyphname = "si-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (215,714);
+},
+{
+name = top_right_can;
+pos = (677,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(96,0,l),
+(139,202,l),
+(113,181,l),
+(266,181,ls),
+(488,181,o),
+(618,290,o),
+(664,511,cs),
+(708,714,l),
+(644,714,l),
+(601,512,ls),
+(563,333,o),
+(450,238,o),
+(278,238,cs),
+(82,238,l),
+(32,0,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+},
+{
+color = 11;
+glyphname = "sii-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (513,0);
+ref = dot_top;
+}
+);
+width = 688;
+}
+);
+note = uni14F0;
+},
+{
+color = 11;
+glyphname = "so-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (673,714);
+},
+{
+name = top_left_can;
+pos = (212,714);
+},
+{
+name = top_right_can;
+pos = (673,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(92,0,l),
+(135,202,ls),
+(173,381,o),
+(286,476,o),
+(458,476,cs),
+(654,476,l),
+(704,714,l),
+(641,714,l),
+(597,512,l),
+(623,533,l),
+(470,533,ls),
+(248,533,o),
+(118,424,o),
+(71,203,cs),
+(28,0,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+},
+{
+color = 11;
+glyphname = "soo-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (508,0);
+ref = dot_top;
+}
+);
+width = 688;
+}
+);
+note = uni14F2;
+},
+{
+color = 11;
+glyphname = "sa-canadian.square";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (216,714);
+},
+{
+name = top_right_can;
+pos = (675,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(555,0,l),
+(597,200,ls),
+(642,410,o),
+(546,533,o),
+(341,533,cs),
+(187,533,l),
+(203,512,l),
+(246,714,l),
+(183,714,l),
+(132,476,l),
+(330,476,ls),
+(506,476,o),
+(573,385,o),
+(534,200,cs),
+(491,0,l)
+);
+}
+);
+width = 687;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+},
+{
+color = 11;
+glyphname = "saa-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (52,0);
+ref = dot_top;
+}
+);
+width = 688;
+}
+);
+note = uni14F5;
+},
+{
+color = 11;
+glyphname = "sho-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (440,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(546,0,l),
+(557,55,l),
+(259,55,ls),
+(170,55,o),
+(124,91,o),
+(124,161,cs),
+(124,258,o),
+(184,330,o),
+(315,330,cs),
+(415,330,ls),
+(589,330,o),
+(672,422,o),
+(672,555,cs),
+(672,653,o),
+(606,714,o),
+(492,714,cs),
+(182,714,l),
+(171,659,l),
+(473,659,ls),
+(563,659,o),
+(609,622,o),
+(609,553,cs),
+(609,454,o),
+(549,385,o),
+(417,385,cs),
+(317,385,ls),
+(143,385,o),
+(60,292,o),
+(60,159,cs),
+(60,61,o),
+(127,0,o),
+(240,0,cs)
+);
+}
+);
+width = 684;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+color = 11;
+glyphname = "shoo-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (276,0);
+ref = dot_top;
+}
+);
+width = 684;
+}
+);
+note = g728;
+},
+{
+color = 11;
+glyphname = "sha-canadian.square";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (454,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(343,0,ls),
+(521,0,o),
+(604,92,o),
+(604,230,cs),
+(604,328,o),
+(538,384,o),
+(424,384,cs),
+(330,384,ls),
+(240,384,o),
+(194,417,o),
+(194,486,cs),
+(194,587,o),
+(253,659,o),
+(387,659,cs),
+(688,659,l),
+(700,714,l),
+(388,714,ls),
+(216,714,o),
+(130,623,o),
+(130,484,cs),
+(130,386,o),
+(196,329,o),
+(309,329,cs),
+(404,329,ls),
+(494,329,o),
+(540,297,o),
+(540,229,cs),
+(540,126,o),
+(479,55,o),
+(345,55,cs),
+(43,55,l),
+(31,0,l)
+);
+}
+);
+width = 686;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+color = 11;
+glyphname = "shaa-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (289,0);
+ref = dot_top;
+}
+);
+width = 684;
+}
+);
+note = g730;
+},
+{
+color = 11;
+glyphname = "ye-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (182,714);
+},
+{
+name = top_right_can;
+pos = (704,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(584,0,l),
+(634,238,l),
+(132,238,l),
+(133,201,l),
+(737,678,l),
+(699,726,l),
+(41,206,l),
+(36,181,l),
+(558,181,l),
+(520,0,l)
+);
+}
+);
+width = 716;
+}
+);
+metricLeft = "ye-canadian";
+note = uni1526;
+},
+{
+color = 11;
+glyphname = "yi-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (212,714);
+},
+{
+name = top_right_can;
+pos = (734,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(93,0,l),
+(131,181,l),
+(654,181,l),
+(659,206,l),
+(210,726,l),
+(162,684,l),
+(574,204,l),
+(581,238,l),
+(79,238,l),
+(29,0,l)
+);
+}
+);
+width = 716;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni1528;
+},
+{
+color = 11;
+glyphname = "yii-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (48,0);
+ref = dot_top;
+}
+);
+width = 716;
+}
+);
+note = uni1529;
+},
+{
+color = 11;
+glyphname = "yo-canadian.square";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (703,714);
+},
+{
+name = top_left_can;
+pos = (181,714);
+},
+{
+name = top_right_can;
+pos = (703,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(602,30,l),
+(189,510,l),
+(183,476,l),
+(685,476,l),
+(735,714,l),
+(671,714,l),
+(633,533,l),
+(110,533,l),
+(105,508,l),
+(554,-12,l)
+);
+}
+);
+width = 716;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152A;
+},
+{
+color = 11;
+glyphname = "yoo-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (540,0);
+ref = dot_top;
+}
+);
+width = 716;
+}
+);
+note = uni152B;
+},
+{
+color = 11;
+glyphname = "ya-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (210,714);
+},
+{
+name = top_right_can;
+pos = (732,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(723,508,l),
+(728,533,l),
+(205,533,l),
+(244,714,l),
+(180,714,l),
+(130,476,l),
+(631,476,l),
+(630,513,l),
+(26,36,l),
+(64,-12,l)
+);
+}
+);
+width = 716;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152D;
+},
+{
+color = 11;
+glyphname = "yaa-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (46,0);
+ref = dot_top;
+}
+);
+width = 716;
+}
+);
+note = uni152E;
+},
+{
+color = 11;
+glyphname = "re-canadian.square";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (412,714);
+},
+{
+name = top_left_can;
+pos = (208,714);
+},
+{
+name = top_right_can;
+pos = (616,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(424,-13,o),
+(510,68,o),
+(546,238,cs),
+(635,656,l),
+(783,656,l),
+(795,714,l),
+(584,714,l),
+(483,240,ls),
+(455,109,o),
+(392,47,o),
+(285,47,cs),
+(165,47,o),
+(113,120,o),
+(141,252,cs),
+(239,714,l),
+(176,714,l),
+(80,261,ls),
+(43,90,o),
+(119,-13,o),
+(282,-13,cs)
+);
+}
+);
+width = 760;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1542;
+},
+{
+color = 11;
+glyphname = "reRCree-canadian.square";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (548,714);
+},
+{
+name = top_left_can;
+pos = (344,714);
+},
+{
+name = top_right_can;
+pos = (752,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(560,-13,o),
+(646,68,o),
+(682,238,cs),
+(784,714,l),
+(720,714,l),
+(619,240,ls),
+(591,109,o),
+(528,47,o),
+(420,47,cs),
+(300,47,o),
+(249,120,o),
+(277,252,cs),
+(375,714,l),
+(164,714,l),
+(152,656,l),
+(299,656,l),
+(215,261,ls),
+(179,90,o),
+(254,-13,o),
+(417,-13,cs)
+);
+}
+);
+width = 760;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni1543;
+},
+{
+color = 11;
+glyphname = "leWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (548,714);
+},
+{
+name = top_left_can;
+pos = (344,714);
+},
+{
+name = top_right_can;
+pos = (752,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(223,0,l),
+(324,474,ls),
+(352,605,o),
+(415,667,o),
+(522,667,cs),
+(642,667,o),
+(694,594,o),
+(666,462,cs),
+(568,0,l),
+(631,0,l),
+(727,453,ls),
+(764,624,o),
+(688,727,o),
+(525,727,cs),
+(383,727,o),
+(297,645,o),
+(261,476,cs),
+(172,58,l),
+(24,58,l),
+(12,0,l)
+);
+}
+);
+width = 763;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+},
+{
+color = 11;
+glyphname = "ri-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (412,714);
+},
+{
+name = top_left_can;
+pos = (212,714);
+},
+{
+name = top_right_can;
+pos = (616,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(88,0,l),
+(188,474,ls),
+(216,605,o),
+(280,667,o),
+(387,667,cs),
+(507,667,o),
+(558,594,o),
+(530,462,cs),
+(432,0,l),
+(643,0,l),
+(655,58,l),
+(508,58,l),
+(592,453,ls),
+(628,624,o),
+(553,727,o),
+(390,727,cs),
+(248,727,o),
+(162,646,o),
+(125,476,cs),
+(24,0,l)
+);
+}
+);
+width = 759;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+},
+{
+color = 11;
+glyphname = "rii-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (247,0);
+ref = dot_top;
+}
+);
+width = 759;
+}
+);
+note = uni1547;
+},
+{
+color = 11;
+glyphname = "ro-canadian.square";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (443,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(95,0,l),
+(131,169,l),
+(96,141,l),
+(279,141,ls),
+(525,141,o),
+(643,298,o),
+(643,485,cs),
+(643,628,o),
+(548,714,o),
+(387,714,cs),
+(183,714,l),
+(171,657,l),
+(377,657,ls),
+(509,657,o),
+(579,593,o),
+(579,480,cs),
+(579,333,o),
+(492,198,o),
+(284,198,cs),
+(73,198,l),
+(31,0,l)
+);
+}
+);
+width = 669;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1548;
+},
+{
+color = 11;
+glyphname = "loWestCree-canadian.square";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (443,714);
+},
+{
+name = top_left_can;
+pos = (216,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(252,0,ls),
+(495,0,o),
+(613,157,o),
+(613,344,cs),
+(613,487,o),
+(520,573,o),
+(357,573,cs),
+(188,573,l),
+(211,545,l),
+(248,714,l),
+(184,714,l),
+(141,516,l),
+(347,516,ls),
+(481,516,o),
+(550,453,o),
+(550,340,cs),
+(550,193,o),
+(462,57,o),
+(257,57,cs),
+(44,57,l),
+(32,0,l)
+);
+}
+);
+width = 667;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+},
+{
+color = 11;
+glyphname = "ra-canadian.square";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (426,714);
+},
+{
+name = top_right_can;
+pos = (653,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(532,0,l),
+(574,198,l),
+(368,198,ls),
+(235,198,o),
+(166,261,o),
+(166,374,cs),
+(166,521,o),
+(254,657,o),
+(459,657,cs),
+(672,657,l),
+(684,714,l),
+(463,714,ls),
+(220,714,o),
+(102,557,o),
+(102,370,cs),
+(102,227,o),
+(196,141,o),
+(358,141,cs),
+(528,141,l),
+(504,169,l),
+(468,0,l)
+);
+}
+);
+width = 667;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+},
+{
+color = 11;
+glyphname = "raa-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (261,0);
+ref = dot_top;
+}
+);
+width = 668;
+}
+);
+note = uni154C;
+},
+{
+color = 11;
+glyphname = "laWestCree-canadian.square";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (652,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(532,0,l),
+(544,57,l),
+(337,57,ls),
+(205,57,o),
+(135,121,o),
+(135,234,cs),
+(135,381,o),
+(223,516,o),
+(430,516,cs),
+(641,516,l),
+(684,714,l),
+(620,714,l),
+(584,545,l),
+(619,573,l),
+(436,573,ls),
+(189,573,o),
+(72,416,o),
+(72,229,cs),
+(72,86,o),
+(166,0,o),
+(327,0,cs)
+);
+}
+);
+width = 667;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+},
+{
+color = 11;
+glyphname = "reWestCree-canadian.square";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(573,0,l),
+(850,198,l),
+(816,246,l),
+(569,70,l),
+(591,53,l),
+(666,409,ls),
+(707,602,o),
+(613,727,o),
+(424,727,cs),
+(262,727,o),
+(151,631,o),
+(114,452,cs),
+(104,405,l),
+(168,405,l),
+(177,448,ls),
+(207,593,o),
+(291,668,o),
+(420,668,cs),
+(570,668,o),
+(638,573,o),
+(603,409,cs),
+(516,0,l)
+);
+}
+);
+width = 890;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+},
+{
+color = 11;
+glyphname = "riWestCree-canadian.square";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(271,0,l),
+(365,442,ls),
+(397,591,o),
+(481,668,o),
+(612,668,cs),
+(753,668,o),
+(828,580,o),
+(799,442,cs),
+(791,405,l),
+(854,405,l),
+(861,438,ls),
+(896,609,o),
+(795,727,o),
+(615,727,cs),
+(451,727,o),
+(341,631,o),
+(303,453,cs),
+(218,53,l),
+(243,59,l),
+(64,241,l),
+(20,198,l),
+(214,0,l)
+);
+}
+);
+width = 890;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+},
+{
+color = 11;
+glyphname = "roWestCree-canadian.square";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(488,-13,o),
+(597,83,o),
+(635,261,cs),
+(720,661,l),
+(695,655,l),
+(875,473,l),
+(919,516,l),
+(725,714,l),
+(668,714,l),
+(574,272,ls),
+(542,123,o),
+(457,46,o),
+(327,46,cs),
+(186,46,o),
+(110,134,o),
+(140,272,cs),
+(148,309,l),
+(84,309,l),
+(78,276,ls),
+(42,105,o),
+(143,-13,o),
+(324,-13,cs)
+);
+}
+);
+width = 891;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+},
+{
+color = 11;
+glyphname = "raWestCree-canadian.square";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(676,-13,o),
+(787,83,o),
+(824,262,cs),
+(833,309,l),
+(770,309,l),
+(761,266,ls),
+(731,121,o),
+(647,46,o),
+(518,46,cs),
+(368,46,o),
+(300,141,o),
+(335,305,cs),
+(422,714,l),
+(365,714,l),
+(88,516,l),
+(122,468,l),
+(369,644,l),
+(347,661,l),
+(272,305,ls),
+(231,112,o),
+(325,-13,o),
+(514,-13,cs)
+);
+}
+);
+width = 890;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+},
+{
+color = 11;
+glyphname = "theThCree-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (182,714);
+},
+{
+name = top_right_can;
+pos = (704,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(584,0,l),
+(599,73,l),
+(686,73,l),
+(694,111,l),
+(607,111,l),
+(634,238,l),
+(153,238,l),
+(159,220,l),
+(737,678,l),
+(699,726,l),
+(41,206,l),
+(36,181,l),
+(558,181,l),
+(544,111,l),
+(290,111,l),
+(282,73,l),
+(535,73,l),
+(520,0,l)
+);
+}
+);
+width = 759;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15A7;
+},
+{
+color = 11;
+glyphname = "thiThCree-canadian.square";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (245,714);
+},
+{
+name = top_right_can;
+pos = (767,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(137,0,l),
+(152,73,l),
+(404,73,l),
+(412,111,l),
+(160,111,l),
+(175,181,l),
+(698,181,l),
+(703,206,l),
+(254,726,l),
+(206,684,l),
+(605,217,l),
+(615,238,l),
+(123,238,l),
+(96,111,l),
+(9,111,l),
+(1,73,l),
+(88,73,l),
+(73,0,l)
+);
+}
+);
+width = 760;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+},
+{
+color = 11;
+glyphname = "thiiThCree-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (79,0);
+ref = dot_top;
+}
+);
+width = 759;
+}
+);
+note = uni15A9;
+},
+{
+color = 11;
+glyphname = "thoThCree-canadian.square";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (180,714);
+},
+{
+name = top_right_can;
+pos = (702,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(601,30,l),
+(203,497,l),
+(193,476,l),
+(684,476,l),
+(711,603,l),
+(798,603,l),
+(805,641,l),
+(719,641,l),
+(734,714,l),
+(670,714,l),
+(655,641,l),
+(402,641,l),
+(395,603,l),
+(646,603,l),
+(632,533,l),
+(110,533,l),
+(105,508,l),
+(553,-12,l)
+);
+}
+);
+width = 759;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+},
+{
+color = 11;
+glyphname = "thooThCree-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (539,0);
+ref = dot_top;
+}
+);
+width = 759;
+}
+);
+note = uni15AB;
+},
+{
+color = 11;
+glyphname = "thaThCree-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (255,714);
+},
+{
+name = top_right_can;
+pos = (777,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(766,508,l),
+(771,533,l),
+(248,533,l),
+(263,603,l),
+(517,603,l),
+(524,641,l),
+(272,641,l),
+(287,714,l),
+(223.006,714,l),
+(208,641,l),
+(121,641,l),
+(113,603,l),
+(200,603,l),
+(173,476,l),
+(654,476,l),
+(648,494,l),
+(69,36,l),
+(107,-12,l)
+);
+}
+);
+width = 759;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+},
+{
+color = 11;
+glyphname = "thaaThCree-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (91,0);
+ref = dot_top;
+}
+);
+width = 759;
+}
+);
+note = uni15AD;
+},
+{
+color = 11;
+glyphname = "thweeWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (759,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 980;
+}
+);
+note = uni1677;
+},
+{
+color = 11;
+glyphname = "thwiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (759,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 980;
+}
+);
+note = uni1678;
+},
+{
+color = 11;
+glyphname = "thwiiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (79,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (759,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 980;
+}
+);
+note = uni1679;
+},
+{
+color = 11;
+glyphname = "thwoWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (759,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 980;
+}
+);
+note = uni167A;
+},
+{
+color = 11;
+glyphname = "thwooWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (539,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (759,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 980;
+}
+);
+note = uni167B;
+},
+{
+color = 11;
+glyphname = "thwaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (759,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 980;
+}
+);
+note = uni167C;
+},
+{
+color = 11;
+glyphname = "thwaaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (91,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (759,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 980;
+}
+);
+note = uni167D;
+},
+{
+color = 11;
+glyphname = "nwiOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (759,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 979;
+}
+);
+note = uni18C7;
+},
+{
+color = 11;
+glyphname = "nwiiOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (247,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (759,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 979;
+}
+);
+note = uni18C9;
+},
+{
+color = 11;
+glyphname = "nwoOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (759,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 979;
+}
+);
+note = uni18CB;
+},
+{
+color = 11;
+glyphname = "nwooOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (383,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (759,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 979;
+}
+);
+note = uni18CD;
+},
+{
+color = 11;
+glyphname = "looWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (52,0);
+ref = dot_top;
+}
+);
+width = 668;
+}
+);
+note = uni18E1;
+},
+{
+color = 11;
+glyphname = "laaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (489,0);
+ref = dot_top;
+}
+);
+width = 668;
+}
+);
+note = uni18E2;
+},
+{
+color = 0;
+glyphname = zero;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(568,560,o),
+(519,725,o),
+(338,725,cs),
+(155,725,o),
+(106,544,o),
+(106,359,cs),
+(106,110,o),
+(189,-10,o),
+(337,-10,cs),
+(492,-10,o),
+(568,112,o),
+(568,359,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(172,506,o),
+(197,670,o),
+(338,670,cs),
+(488,670,o),
+(502,496,o),
+(502,359,cs),
+(502,165,o),
+(459,45,o),
+(337,45,cs),
+(222,45,o),
+(172,163,o),
+(172,359,cs)
+);
+}
+);
+width = 629;
+}
+);
+unicode = 48;
+},
+{
+color = 0;
+glyphname = one;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(293,714,l),
+(86,558,l),
+(122,514,l),
+(235,599,ls),
+(258,616,o),
+(271,628,o),
+(287,643,c),
+(286,620,o),
+(286,596,o),
+(286,570,cs),
+(286,0,l),
+(351,0,l),
+(351,714,l)
+);
+}
+);
+width = 474;
+}
+);
+unicode = 49;
+},
+{
+color = 0;
+glyphname = two;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(562,0,l),
+(562,56,l),
+(195,56,l),
+(195,58,l),
+(367,238,ls),
+(438,309,o),
+(488,365,o),
+(514,429,cs),
+(527,460,o),
+(533,496,o),
+(533,537,cs),
+(533,650,o),
+(451,724,o),
+(332,724,cs),
+(257,724,o),
+(187,699,o),
+(124,644,c),
+(160,600,l),
+(215,645,o),
+(273,667,o),
+(327,667,cs),
+(414,667,o),
+(468,617,o),
+(468,530,cs),
+(468,466,o),
+(447,417,o),
+(405,363,cs),
+(383,336,o),
+(356,305,o),
+(322,270,cs),
+(110,47,l),
+(110,0,l)
+);
+}
+);
+width = 614;
+}
+);
+unicode = 50;
+},
+{
+color = 0;
+glyphname = three;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(545,662,o),
+(463,724,o),
+(339,724,cs),
+(242,724,o),
+(172,694,o),
+(113,650,c),
+(142,604,l),
+(198,644,o),
+(260,669,o),
+(332,669,cs),
+(422,669,o),
+(481,628,o),
+(481,542,cs),
+(481,442,o),
+(393,397,o),
+(290,397,cs),
+(216,397,l),
+(216,344,l),
+(290,344,ls),
+(413,344,o),
+(498,308,o),
+(498,199,cs),
+(498,105,o),
+(435,45,o),
+(303,45,cs),
+(234,45,o),
+(160,63,o),
+(106,90,c),
+(106,31,l),
+(160,7,o),
+(227,-10,o),
+(309,-10,cs),
+(470,-10,o),
+(567,71,o),
+(567,196,cs),
+(567,302,o),
+(503,358,o),
+(392,373,c),
+(392,375,l),
+(479,393,o),
+(545,458,o),
+(545,553,cs)
+);
+}
+);
+width = 619;
+}
+);
+unicode = 51;
+},
+{
+color = 0;
+glyphname = four;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(455,234,l),
+(455,717,l),
+(392,717,l),
+(37,228,l),
+(37,181,l),
+(391,181,l),
+(391,0,l),
+(455,0,l),
+(455,181,l),
+(576,181,l),
+(576,234,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(102,234,l),
+(332,547,ls),
+(359,585,o),
+(369,601,o),
+(390,636,c),
+(392,636,l),
+(392,614,o),
+(391,579,o),
+(391,541,cs),
+(391,234,l)
+);
+}
+);
+width = 602;
+}
+);
+unicode = 52;
+},
+{
+color = 0;
+glyphname = five;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(253,436,o),
+(213,425,o),
+(183,418,c),
+(204,657,l),
+(499,657,l),
+(499,714,l),
+(148,714,l),
+(119,380,l),
+(150,360,l),
+(194,374,o),
+(238,382,o),
+(293,382,cs),
+(415,382,o),
+(477,321,o),
+(477,221,cs),
+(477,109,o),
+(400,45,o),
+(279,45,cs),
+(209,45,o),
+(144,65,o),
+(98,91,c),
+(98,31,l),
+(143,7,o),
+(205,-10,o),
+(283,-10,cs),
+(448,-10,o),
+(544,80,o),
+(544,222,cs),
+(544,359,o),
+(455,436,o),
+(316,436,cs)
+);
+}
+);
+width = 589;
+}
+);
+unicode = 53;
+},
+{
+color = 0;
+glyphname = six;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(91,139,o),
+(162,-10,o),
+(331,-10,cs),
+(470,-10,o),
+(554,82,o),
+(554,229,cs),
+(554,364,o),
+(478,448,o),
+(347,448,cs),
+(251,448,o),
+(184,401,o),
+(154,339,c),
+(151,339,l),
+(157,532,o),
+(226,671,o),
+(407,671,cs),
+(449,671,o),
+(482,666,o),
+(507,658,c),
+(507,714,l),
+(480,721,o),
+(445,726,o),
+(408,726,cs),
+(174,726,o),
+(91,541,o),
+(91,303,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,45,o),
+(161,172,o),
+(161,256,cs),
+(161,333,o),
+(247,394,o),
+(335,394,cs),
+(440,394,o),
+(490,331,o),
+(490,229,cs),
+(490,114,o),
+(433,45,o),
+(330,45,cs)
+);
+}
+);
+width = 602;
+}
+);
+unicode = 54;
+},
+{
+color = 0;
+glyphname = seven;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(583,674,l),
+(583,714,l),
+(117,714,l),
+(117,657,l),
+(512,657,l),
+(227,0,l),
+(296,0,l)
+);
+}
+);
+width = 608;
+}
+);
+unicode = 55;
+},
+{
+color = 0;
+glyphname = eight;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(474,-10,o),
+(570,61,o),
+(570,183,cs),
+(570,284,o),
+(498,341,o),
+(391,381,c),
+(486,419,o),
+(547,471,o),
+(547,558,cs),
+(547,665,o),
+(466,724,o),
+(341,724,cs),
+(219,724,o),
+(134,660,o),
+(134,557,cs),
+(134,457,o),
+(212,411,o),
+(286,379,c),
+(181,342,o),
+(112,285,o),
+(112,178,cs),
+(112,66,o),
+(198,-10,o),
+(337,-10,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(239,42,o),
+(174,95,o),
+(174,180,cs),
+(174,277,o),
+(255,322,o),
+(338,350,c),
+(453,307,o),
+(508,260,o),
+(508,184,cs),
+(508,91,o),
+(439,42,o),
+(337,42,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(255,441,o),
+(197,481,o),
+(197,553,cs),
+(197,630,o),
+(259,672,o),
+(341,672,cs),
+(430,672,o),
+(484,632,o),
+(484,554,cs),
+(484,485,o),
+(434,447,o),
+(342,409,c)
+);
+}
+);
+width = 632;
+}
+);
+unicode = 56;
+},
+{
+color = 0;
+glyphname = nine;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(567,582,o),
+(498,724,o),
+(327,724,cs),
+(189,724,o),
+(104,633,o),
+(104,486,cs),
+(104,351,o),
+(180,266,o),
+(309,266,cs),
+(404,266,o),
+(474,312,o),
+(504,377,c),
+(507,377,l),
+(502,179,o),
+(428,43,o),
+(249,43,cs),
+(209,43,o),
+(170,49,o),
+(145,57,c),
+(145,0,l),
+(172,-7,o),
+(214,-12,o),
+(251,-12,cs),
+(487,-12,o),
+(567,178,o),
+(567,410,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(461,669,o),
+(498,541,o),
+(498,459,cs),
+(498,383,o),
+(409,320,o),
+(324,320,cs),
+(221,320,o),
+(169,385,o),
+(169,487,cs),
+(169,602,o),
+(225,669,o),
+(329,669,cs)
+);
+}
+);
+width = 628;
+}
+);
+unicode = 57;
+},
+{
+glyphname = zero.canadian;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(489,-12,o),
+(566,328,o),
+(566,493,cs),
+(566,642,o),
+(500,727,o),
+(378,727,cs),
+(150,727,o),
+(74,387,o),
+(74,221,cs),
+(74,72,o),
+(140,-12,o),
+(261,-12,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(180,47,o),
+(136,107,o),
+(136,220,cs),
+(136,348,o),
+(194,668,o),
+(375,668,cs),
+(460,668,o),
+(504,608,o),
+(504,495,cs),
+(504,367,o),
+(445,47,o),
+(265,47,cs)
+);
+}
+);
+width = 592;
+}
+);
+metricRight = "=|";
+},
+{
+glyphname = one.canadian;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(221,0,l),
+(373,714,l),
+(315,714,l),
+(96,557,l),
+(129,511,l),
+(343,664,l),
+(299,671,l),
+(156,0,l)
+);
+}
+);
+width = 356;
+}
+);
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = two.canadian;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(479,58,l),
+(120,58,l),
+(118,31,l),
+(408,279,ls),
+(504,361,o),
+(569,443,o),
+(569,551,cs),
+(569,657,o),
+(496,727,o),
+(377,727,cs),
+(241,727,o),
+(149,640,o),
+(115,470,c),
+(178,470,l),
+(205,604,o),
+(271,670,o),
+(372,670,cs),
+(457,670,o),
+(506,623,o),
+(506,548,cs),
+(506,455,o),
+(443,383,o),
+(361,313,cs),
+(45,45,l),
+(36,0,l),
+(467,0,l)
+);
+}
+);
+width = 581;
+}
+);
+note = uni14BF;
+},
+{
+glyphname = three.canadian;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(433,-13,o),
+(519,89,o),
+(519,216,cs),
+(519,294,o),
+(478,349,o),
+(407,363,c),
+(402,344,l),
+(523,354,o),
+(582,457,o),
+(582,555,cs),
+(582,657,o),
+(507,727,o),
+(384,727,cs),
+(248,727,o),
+(159,647,o),
+(130,487,c),
+(193,487,l),
+(217,611,o),
+(279,670,o),
+(379,670,cs),
+(467,670,o),
+(518,624,o),
+(518,548,cs),
+(518,460,o),
+(467,385,o),
+(354,385,cs),
+(315,385,l),
+(304,330,l),
+(345,330,ls),
+(417,330,o),
+(456,290,o),
+(456,222,cs),
+(456,128,o),
+(399,44,o),
+(281,44,cs),
+(159,44,o),
+(117,119,o),
+(132,227,c),
+(68,227,l),
+(50,90,o),
+(118,-13,o),
+(281,-13,cs)
+);
+}
+);
+width = 610;
+}
+);
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = four.canadian;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(392,0,l),
+(431,181,l),
+(540,181,l),
+(552,236,l),
+(442,236,l),
+(544,717,l),
+(491,717,l),
+(43,223,l),
+(34,181,l),
+(368,181,l),
+(330,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(497,655,l),
+(470,655,l),
+(380,236,l),
+(101,236,l),
+(104,220,l)
+);
+}
+);
+width = 589;
+}
+);
+},
+{
+glyphname = five.canadian;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(448,-13,o),
+(530,109,o),
+(530,237,cs),
+(530,346,o),
+(460,411,o),
+(338,411,cs),
+(195,411,l),
+(211,390,l),
+(297,678,l),
+(271,657,l),
+(600,657,l),
+(612,714,l),
+(245,714,l),
+(144,370,l),
+(155,354,l),
+(323,354,ls),
+(416,354,o),
+(467,313,o),
+(467,233,cs),
+(467,137,o),
+(410,44,o),
+(288,44,cs),
+(179,44,o),
+(121,106,o),
+(135,199,c),
+(72,199,l),
+(55,76,o),
+(139,-13,o),
+(286,-13,cs)
+);
+}
+);
+width = 605;
+}
+);
+},
+{
+glyphname = six.canadian;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(432,-13,o),
+(523,105,o),
+(523,238,cs),
+(523,351,o),
+(450,427,o),
+(333,427,cs),
+(235,427,o),
+(162,376,o),
+(125,279,c),
+(140,262,l),
+(143,300,o),
+(148,332,o),
+(156,377,cs),
+(192,549,o),
+(260,670,o),
+(387,670,cs),
+(488,670,o),
+(521,604,o),
+(518,520,c),
+(581,520,l),
+(589,635,o),
+(524,727,o),
+(389,727,cs),
+(142,727,o),
+(73,364,o),
+(73,216,cs),
+(73,156,o),
+(85,107,o),
+(109,71,cs),
+(143,18,o),
+(206,-13,o),
+(283,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(194,43,o),
+(139,96,o),
+(139,181,cs),
+(139,279,o),
+(205,372,o),
+(319,372,cs),
+(407,372,o),
+(461,320,o),
+(461,235,cs),
+(461,138,o),
+(399,43,o),
+(283,43,cs)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = zero.canadian;
+},
+{
+glyphname = seven.canadian;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(143,0,l),
+(538,674,l),
+(547,714,l),
+(129,714,l),
+(117,656,l),
+(474,656,l),
+(474,680,l),
+(84,20,l),
+(81,0,l)
+);
+}
+);
+width = 482;
+}
+);
+},
+{
+glyphname = eight.canadian;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(435,-13,o),
+(529,82,o),
+(531,202,cs),
+(533,280,o),
+(486,341,o),
+(411,360,c),
+(403,343,l),
+(513,353,o),
+(586,441,o),
+(587,548,cs),
+(590,654,o),
+(512,727,o),
+(384,727,cs),
+(242,727,o),
+(157,633,o),
+(155,512,cs),
+(153,437,o),
+(194,376,o),
+(266,353,c),
+(263,373,l),
+(137,362,o),
+(69,267,o),
+(67,167,cs),
+(65,59,o),
+(151,-13,o),
+(288,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(186,42,o),
+(129,89,o),
+(130,167,cs),
+(131,262,o),
+(198,331,o),
+(308,331,cs),
+(413,331,o),
+(470,284,o),
+(469,206,cs),
+(468,113,o),
+(403,42,o),
+(291,42,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(269,384,o),
+(217,431,o),
+(217,509,cs),
+(218,598,o),
+(274,672,o),
+(381,672,cs),
+(472,672,o),
+(525,625,o),
+(524,548,cs),
+(524,459,o),
+(467,384,o),
+(360,384,cs)
+);
+}
+);
+width = 623;
+}
+);
+metricLeft = "=|";
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = nine.canadian;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(492,-13,o),
+(561,350,o),
+(561,498,cs),
+(561,558,o),
+(549,607,o),
+(526,643,cs),
+(491,696,o),
+(428,727,o),
+(351,727,cs),
+(203,727,o),
+(111,609,o),
+(111,476,cs),
+(111,363,o),
+(184,287,o),
+(301,287,cs),
+(399,287,o),
+(472,338,o),
+(509,435,c),
+(495,452,l),
+(491,414,o),
+(487,382,o),
+(478,337,cs),
+(442,165,o),
+(374,44,o),
+(247,44,cs),
+(146,44,o),
+(113,110,o),
+(116,194,c),
+(53,194,l),
+(45,79,o),
+(110,-13,o),
+(245,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(227,342,o),
+(173,394,o),
+(173,479,cs),
+(173,576,o),
+(235,671,o),
+(351,671,cs),
+(440,671,o),
+(495,618,o),
+(495,533,cs),
+(495,435,o),
+(430,342,o),
+(315,342,cs)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "=|six.canadian";
+metricRight = "=|six.canadian";
+},
+{
+glyphname = CR;
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+width = 261;
+}
+);
+note = CR;
+unicode = 13;
+},
+{
+color = 0;
+glyphname = .notdef;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(605,714,l),
+(194,714,l),
+(194,0,l),
+(605,0,l),
+(605,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(554,663,l),
+(554,51,l),
+(245,51,l),
+(245,663,l),
+(245,663,l)
+);
+}
+);
+width = 700;
+}
+);
+note = ".notdef";
+},
+{
+glyphname = .null;
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+width = 0;
+}
+);
+note = NULL;
+},
+{
+glyphname = space;
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+width = 263;
+}
+);
+note = space;
+unicode = 32;
+},
+{
+glyphname = nbspace;
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+width = 261;
+}
+);
+note = uni00A0;
+unicode = 160;
+},
+{
+glyphname = space.canadian;
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+width = 504;
+}
+);
+note = space;
+},
+{
+glyphname = "hyphen-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(427,416,l),
+(436,457,l),
+(116,457,l),
+(107,416,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(397,278,l),
+(406,319,l),
+(86,319,l),
+(77,278,l)
+);
+}
+);
+width = 461;
+}
+);
+metricRight = "=|";
+note = uni1400;
+unicode = 5120;
+},
+{
+glyphname = "chi-canadian";
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(69,0,l),
+(307,324,l),
+(281,329,l),
+(383,0,l),
+(439,0,l),
+(443,20,l),
+(325,386,l),
+(318,336,l),
+(583,694,l),
+(588,714,l),
+(525,714,l),
+(294,398,l),
+(319,394,l),
+(218,714,l),
+(163,714,l),
+(159,694,l),
+(275,338,l),
+(283,388,l),
+(10,20,l),
+(6,0,l)
+);
+}
+);
+width = 549;
+}
+);
+metricRight = "=|";
+note = uni166D;
+unicode = 5741;
+},
+{
+glyphname = "fullstop-canadian";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(52,0,l),
+(162,151,l),
+(149,154,l),
+(197,0,l),
+(236,0,l),
+(238,10,l),
+(178,193,l),
+(174,165,l),
+(308,346,l),
+(311,357,l),
+(266,357,l),
+(157,208,l),
+(172,205,l),
+(125,357,l),
+(86,357,l),
+(83,346,l),
+(142,170,l),
+(146,196,l),
+(9,10,l),
+(7,0,l)
+);
+}
+);
+width = 347;
+}
+);
+note = uni1541;
+unicode = 5742;
+},
+{
+glyphname = period;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(27,7,o),
+(40,-9,o),
+(71,-9,cs),
+(98,-9,o),
+(115,11,o),
+(118,42,cs),
+(121,66,o),
+(108,82,o),
+(76,82,cs),
+(46,82,o),
+(33,59,o),
+(30,31,cs)
+);
+}
+);
+width = 229;
+}
+);
+note = period;
+unicode = 46;
+},
+{
+glyphname = comma;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(0,-131,l),
+(45,-60,o),
+(90,37,o),
+(121,111,c),
+(119,123,l),
+(60,123,l),
+(33,46,o),
+(0,-34,o),
+(-48,-131,c)
+);
+}
+);
+width = 204;
+}
+);
+note = comma;
+unicode = 44;
+},
+{
+glyphname = hyphen;
+kernLeft = hyphen;
+kernRight = hyphen;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(262,243,l),
+(273,298,l),
+(49,298,l),
+(38,243,l)
+);
+}
+);
+width = 300;
+}
+);
+unicode = 45;
+},
+{
+glyphname = quotesinglbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-49,-591);
+ref = quoteright;
+}
+);
+width = 222;
+}
+);
+unicode = 8218;
+},
+{
+glyphname = quotedblbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+pos = (-93,-591);
+ref = quotedblright;
+}
+);
+width = 415;
+}
+);
+unicode = 8222;
+},
+{
+glyphname = quotedblleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(302,459,l),
+(325,537,o),
+(366,631,o),
+(415,714,c),
+(371,714,l),
+(322,643,o),
+(277,553,o),
+(244,469,c),
+(248,459,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(138,459,l),
+(162,538,o),
+(202,630,o),
+(252,714,c),
+(208,714,l),
+(158,643,o),
+(114,553,o),
+(81,469,c),
+(85,459,l)
+);
+}
+);
+width = 346;
+}
+);
+unicode = 8220;
+},
+{
+glyphname = quotedblright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(284,459,l),
+(334,531,o),
+(379,622,o),
+(411,704,c),
+(407,714,l),
+(353,714,l),
+(329,635,o),
+(289,542,o),
+(240,459,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(120,459,l),
+(171,531,o),
+(215,622,o),
+(248,704,c),
+(243,714,l),
+(190,714,l),
+(166,636,o),
+(125,541,o),
+(76,459,c)
+);
+}
+);
+width = 346;
+}
+);
+unicode = 8221;
+},
+{
+glyphname = quoteleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(139,459,l),
+(163,537,o),
+(205,631,o),
+(253,714,c),
+(209,714,l),
+(159,643,o),
+(114,553,o),
+(81,469,c),
+(85,459,l)
+);
+}
+);
+width = 184;
+}
+);
+unicode = 8216;
+},
+{
+glyphname = quoteright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(122,459,l),
+(171,531,o),
+(217,622,o),
+(249,704,c),
+(245,714,l),
+(190,714,l),
+(166,636,o),
+(126,541,o),
+(77,459,c)
+);
+}
+);
+width = 184;
+}
+);
+unicode = 8217;
+},
+{
+glyphname = dottedCircle;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(210,522,o),
+(197,511,o),
+(197,496,cs),
+(197,483,o),
+(210,470,o),
+(223,470,cs),
+(238,470,o),
+(249,483,o),
+(249,496,cs),
+(249,511,o),
+(238,522,o),
+(223,522,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(378,522,o),
+(365,511,o),
+(365,496,cs),
+(365,483,o),
+(378,470,o),
+(391,470,cs),
+(406,470,o),
+(417,483,o),
+(417,496,cs),
+(417,511,o),
+(406,522,o),
+(391,522,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(210,112,o),
+(197,101,o),
+(197,86,cs),
+(197,73,o),
+(210,60,o),
+(223,60,cs),
+(238,60,o),
+(249,73,o),
+(249,86,cs),
+(249,101,o),
+(238,112,o),
+(223,112,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(378,112,o),
+(365,101,o),
+(365,86,cs),
+(365,73,o),
+(378,60,o),
+(391,60,cs),
+(406,60,o),
+(417,73,o),
+(417,86,cs),
+(417,101,o),
+(406,112,o),
+(391,112,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(294,540,o),
+(281,529,o),
+(281,514,cs),
+(281,501,o),
+(294,488,o),
+(307,488,cs),
+(322,488,o),
+(333,501,o),
+(333,514,cs),
+(333,529,o),
+(322,540,o),
+(307,540,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(294,94,o),
+(281,83,o),
+(281,68,cs),
+(281,55,o),
+(294,42,o),
+(307,42,cs),
+(322,42,o),
+(333,55,o),
+(333,68,cs),
+(333,83,o),
+(322,94,o),
+(307,94,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(58,278,o),
+(71,265,o),
+(84,265,cs),
+(99,265,o),
+(110,278,o),
+(110,291,cs),
+(110,306,o),
+(99,317,o),
+(84,317,cs),
+(71,317,o),
+(58,306,o),
+(58,291,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(504,278,o),
+(517,265,o),
+(530,265,cs),
+(545,265,o),
+(556,278,o),
+(556,291,cs),
+(556,306,o),
+(545,317,o),
+(530,317,cs),
+(517,317,o),
+(504,306,o),
+(504,291,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(123,120,o),
+(136,107,o),
+(149,107,cs),
+(164,107,o),
+(175,120,o),
+(175,133,cs),
+(175,148,o),
+(164,159,o),
+(149,159,cs),
+(136,159,o),
+(123,148,o),
+(123,133,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(123,436,o),
+(136,423,o),
+(149,423,cs),
+(164,423,o),
+(175,436,o),
+(175,449,cs),
+(175,464,o),
+(164,475,o),
+(149,475,cs),
+(136,475,o),
+(123,464,o),
+(123,449,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(439,120,o),
+(452,107,o),
+(465,107,cs),
+(480,107,o),
+(491,120,o),
+(491,133,cs),
+(491,148,o),
+(480,159,o),
+(465,159,cs),
+(452,159,o),
+(439,148,o),
+(439,133,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(439,436,o),
+(452,423,o),
+(465,423,cs),
+(480,423,o),
+(491,436,o),
+(491,449,cs),
+(491,464,o),
+(480,475,o),
+(465,475,cs),
+(452,475,o),
+(439,464,o),
+(439,449,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(76,194,o),
+(89,181,o),
+(102,181,cs),
+(117,181,o),
+(128,194,o),
+(128,207,cs),
+(128,222,o),
+(117,233,o),
+(102,233,cs),
+(89,233,o),
+(76,222,o),
+(76,207,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(76,362,o),
+(89,349,o),
+(102,349,cs),
+(117,349,o),
+(128,362,o),
+(128,375,cs),
+(128,390,o),
+(117,401,o),
+(102,401,cs),
+(89,401,o),
+(76,390,o),
+(76,375,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(486,194,o),
+(499,181,o),
+(512,181,cs),
+(527,181,o),
+(538,194,o),
+(538,207,cs),
+(538,222,o),
+(527,233,o),
+(512,233,cs),
+(499,233,o),
+(486,222,o),
+(486,207,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(486,362,o),
+(499,349,o),
+(512,349,cs),
+(527,349,o),
+(538,362,o),
+(538,375,cs),
+(538,390,o),
+(527,401,o),
+(512,401,cs),
+(499,401,o),
+(486,390,o),
+(486,375,cs)
+);
+}
+);
+width = 604;
+}
+);
+note = uni25CC;
+unicode = 9676;
+},
+{
+glyphname = dotaccentcomb;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(149,734,o),
+(135,719,o),
+(130,690,cs),
+(125,661,o),
+(138,647,o),
+(167,647,cs),
+(193,647,o),
+(207,661,o),
+(212,689,cs),
+(217,718,o),
+(204,734,o),
+(175,734,cs)
+);
+}
+);
+width = 153;
+}
+);
+note = uni0307;
+unicode = 775;
+},
+{
+glyphname = dotaccent;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(198,647,o),
+(210,667,o),
+(213,692,cs),
+(218,718,o),
+(205,734,o),
+(175,734,cs),
+(147,734,o),
+(134,716,o),
+(131,689,cs),
+(127,662,o),
+(138,647,o),
+(168,647,cs)
+);
+}
+);
+width = 155;
+}
+);
+note = dotaccent;
+unicode = 729;
+},
+{
+glyphname = caron;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(308,645,o),
+(360,701,o),
+(415,756,c),
+(417,764,l),
+(370,764,l),
+(331,731,o),
+(290,691,o),
+(254,651,c),
+(234,689,o),
+(213,731,o),
+(187,764,c),
+(147,764,l),
+(145,756,l),
+(174,711,o),
+(200,659,o),
+(217,606,c),
+(278,606,l),
+(278,606,l)
+);
+}
+);
+width = 343;
+}
+);
+note = caron;
+unicode = 711;
+},
+{
+glyphname = breve;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(323,606,o),
+(371,647,o),
+(395,734,c),
+(352,734,l),
+(335,679,o),
+(303,651,o),
+(253,651,cs),
+(201,651,o),
+(177,680,o),
+(180,734,c),
+(139,734,l),
+(130,656,o),
+(171,606,o),
+(251,606,cs)
+);
+}
+);
+width = 326;
+}
+);
+note = breve;
+unicode = 728;
+},
+{
+glyphname = ring;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(287,609,o),
+(331,652,o),
+(331,715,cs),
+(331,774,o),
+(287,820,o),
+(234,820,cs),
+(179,820,o),
+(137,776,o),
+(137,715,cs),
+(137,651,o),
+(180,609,o),
+(234,609,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(198,647,o),
+(174,678,o),
+(174,715,cs),
+(174,753,o),
+(200,783,o),
+(234,783,cs),
+(266,783,o),
+(293,753,o),
+(293,715,cs),
+(293,678,o),
+(268,647,o),
+(234,647,cs)
+);
+}
+);
+width = 267;
+}
+);
+note = ring;
+unicode = 730;
+},
+{
+glyphname = ogonek;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(42,-222,o),
+(60,-219,o),
+(77,-213,c),
+(86,-170,l),
+(74,-174,o),
+(56,-178,o),
+(44,-178,cs),
+(14,-178,o),
+(1,-161,o),
+(4,-128,cs),
+(8,-87,o),
+(38,-49,o),
+(106,0,c),
+(78,14,l),
+(2,-34,o),
+(-39,-84,o),
+(-44,-137,cs),
+(-50,-188,o),
+(-22,-222,o),
+(25,-222,cs)
+);
+}
+);
+width = 211;
+}
+);
+note = ogonek;
+unicode = 731;
+},
+{
+glyphname = ring_top.canadian;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (224,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(314,784,o),
+(360,824,o),
+(360,883,cs),
+(360,941,o),
+(314,981,o),
+(259,981,cs),
+(204,981,o),
+(160,941,o),
+(160,883,cs),
+(160,824,o),
+(204,784,o),
+(259,784,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(220,818,o),
+(196,845,o),
+(196,883,cs),
+(196,920,o),
+(221,947,o),
+(260,947,cs),
+(298,947,o),
+(323,920,o),
+(323,883,cs),
+(323,845,o),
+(298,818,o),
+(260,818,cs)
+);
+}
+);
+width = 248;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (88,357);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(113,313,o),
+(133,332,o),
+(133,357,cs),
+(133,382,o),
+(113,401,o),
+(88,401,cs),
+(63,401,o),
+(44,382,o),
+(44,357,cs),
+(44,332,o),
+(63,313,o),
+(88,313,cs)
+);
+}
+);
+width = 128;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (83,357);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(106,317,o),
+(123,334,o),
+(123,357,cs),
+(123,380,o),
+(106,397,o),
+(83,397,cs),
+(61,397,o),
+(43,380,o),
+(43,357,cs),
+(43,334,o),
+(61,317,o),
+(83,317,cs)
+);
+}
+);
+width = 119;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_small;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (79,357);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,322,o),
+(114,337,o),
+(114,357,cs),
+(114,377,o),
+(99,392,o),
+(79,392,cs),
+(59,392,o),
+(43,377,o),
+(43,357,cs),
+(43,337,o),
+(59,322,o),
+(79,322,cs)
+);
+}
+);
+width = 110;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_top;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (164,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(220,816,o),
+(240,835,o),
+(240,860,cs),
+(240,885,o),
+(220,905,o),
+(195,905,cs),
+(170,905,o),
+(150,885,o),
+(150,860,cs),
+(150,835,o),
+(170,816,o),
+(195,816,cs)
+);
+}
+);
+width = 128;
+}
+);
+note = g725;
+},
+{
+glyphname = doubledot_middle;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(179,402,o),
+(198,421,o),
+(198,447,cs),
+(198,472,o),
+(179,491,o),
+(154,491,cs),
+(129,491,o),
+(109,472,o),
+(109,447,cs),
+(109,421,o),
+(129,402,o),
+(154,402,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(141,223,o),
+(160,242,o),
+(160,267,cs),
+(160,293,o),
+(141,312,o),
+(116,312,cs),
+(91,312,o),
+(71,293,o),
+(71,267,cs),
+(71,242,o),
+(91,223,o),
+(116,223,cs)
+);
+}
+);
+width = 221;
+}
+);
+metricRight = "=|";
+note = g725;
+},
+{
+glyphname = doubledot_top;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top_double;
+pos = (327,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(382,816,o),
+(402,835,o),
+(402,860,cs),
+(402,885,o),
+(382,905,o),
+(357,905,cs),
+(332,905,o),
+(312,885,o),
+(312,860,cs),
+(312,835,o),
+(332,816,o),
+(357,816,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(217,816,o),
+(237,835,o),
+(237,860,cs),
+(237,885,o),
+(217,905,o),
+(192,905,cs),
+(167,905,o),
+(148,885,o),
+(148,860,cs),
+(148,835,o),
+(167,816,o),
+(192,816,cs)
+);
+}
+);
+width = 287;
+}
+);
+note = g725;
+},
+{
+glyphname = g727;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (440,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(546,0,l),
+(557,55,l),
+(259,55,ls),
+(170,55,o),
+(124,91,o),
+(124,161,cs),
+(124,258,o),
+(184,330,o),
+(315,330,cs),
+(415,330,ls),
+(589,330,o),
+(672,422,o),
+(672,555,cs),
+(672,653,o),
+(606,714,o),
+(492,714,cs),
+(182,714,l),
+(171,659,l),
+(473,659,ls),
+(563,659,o),
+(609,622,o),
+(609,553,cs),
+(609,454,o),
+(549,385,o),
+(417,385,cs),
+(317,385,ls),
+(143,385,o),
+(60,292,o),
+(60,159,cs),
+(60,61,o),
+(127,0,o),
+(240,0,cs)
+);
+}
+);
+width = 684;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+glyphname = g728;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (276,0);
+ref = dot_top;
+}
+);
+width = 684;
+}
+);
+note = g728;
+},
+{
+glyphname = g729;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (454,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(343,0,ls),
+(521,0,o),
+(604,92,o),
+(604,230,cs),
+(604,328,o),
+(538,384,o),
+(424,384,cs),
+(330,384,ls),
+(240,384,o),
+(194,417,o),
+(194,486,cs),
+(194,587,o),
+(253,659,o),
+(387,659,cs),
+(688,659,l),
+(700,714,l),
+(388,714,ls),
+(216,714,o),
+(130,623,o),
+(130,484,cs),
+(130,386,o),
+(196,329,o),
+(309,329,cs),
+(404,329,ls),
+(494,329,o),
+(540,297,o),
+(540,229,cs),
+(540,126,o),
+(479,55,o),
+(345,55,cs),
+(43,55,l),
+(31,0,l)
+);
+}
+);
+width = 686;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+glyphname = g730;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (289,0);
+ref = dot_top;
+}
+);
+width = 684;
+}
+);
+note = g730;
+},
+{
+glyphname = g731;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = g727;
+}
+);
+width = 904;
+}
+);
+note = g731;
+},
+{
+glyphname = g732;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (684,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 904;
+}
+);
+note = g732;
+},
+{
+glyphname = g733;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (496,0);
+ref = dot_top;
+}
+);
+width = 904;
+}
+);
+note = g733;
+},
+{
+glyphname = g734;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (276,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (684,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 904;
+}
+);
+note = g734;
+},
+{
+glyphname = g735;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = g729;
+}
+);
+width = 904;
+}
+);
+note = g735;
+},
+{
+glyphname = g736;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (684,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 904;
+}
+);
+note = g736;
+},
+{
+glyphname = g737;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (509,0);
+ref = dot_top;
+}
+);
+width = 904;
+}
+);
+note = g737;
+},
+{
+glyphname = g738;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (289,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (684,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 904;
+}
+);
+note = g738;
+},
+{
+glyphname = g739;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(565,223,o),
+(611,308,o),
+(611,382,cs),
+(611,450,o),
+(568,494,o),
+(500,494,cs),
+(303,494,l),
+(317,478,l),
+(360,504,o),
+(378,567,o),
+(378,609,cs),
+(378,676,o),
+(335,720,o),
+(268,720,cs),
+(178,720,o),
+(133,635,o),
+(133,561,cs),
+(133,493,o),
+(176,449,o),
+(244,449,cs),
+(440,449,l),
+(426,465,l),
+(383,438,o),
+(365,375,o),
+(365,334,cs),
+(365,267,o),
+(408,223,o),
+(476,223,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,487,o),
+(175,516,o),
+(175,560,cs),
+(175,614,o),
+(206,683,o),
+(267,683,cs),
+(310,683,o),
+(336,654,o),
+(336,609,cs),
+(336,556,o),
+(305,487,o),
+(243,487,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(434,260,o),
+(408,289,o),
+(408,334,cs),
+(408,387,o),
+(438,456,o),
+(501,456,cs),
+(543,456,o),
+(569,427,o),
+(569,383,cs),
+(569,329,o),
+(538,260,o),
+(476,260,cs)
+);
+}
+);
+width = 647;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+glyphname = g740;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (217,0);
+ref = ring_top.canadian;
+}
+);
+width = 684;
+}
+);
+note = g740;
+},
+{
+glyphname = g741;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (229,0);
+ref = ring_top.canadian;
+}
+);
+width = 684;
+}
+);
+note = g741;
+},
+{
+glyphname = g742;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (437,0);
+ref = ring_top.canadian;
+}
+);
+width = 904;
+}
+);
+note = g742;
+},
+{
+glyphname = stroke_middle;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (65,357);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(63,244,l),
+(110,470,l),
+(67,470,l),
+(20,244,l)
+);
+}
+);
+width = 82;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (61,357);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(58,258,l),
+(100,456,l),
+(65,456,l),
+(23,258,l)
+);
+}
+);
+width = 75;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_small;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (59,357);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(54,260,l),
+(95,454,l),
+(64,454,l),
+(23,260,l)
+);
+}
+);
+width = 70;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_threequart;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (65,357);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(62,245,l),
+(110,469,l),
+(68,469,l),
+(21,245,l)
+);
+}
+);
+width = 82;
+}
+);
+note = g723;
+},
+{
+color = 8;
+glyphname = uni11AB0;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (253,714);
+},
+{
+name = top_right_can;
+pos = (561,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(133,0,l),
+(159,121,l),
+(412,121,l),
+(421,163,l),
+(168,163,l),
+(195,290,l),
+(148,267,l),
+(188,267,ls),
+(385,267,o),
+(519,373,o),
+(568,599,cs),
+(593,714,l),
+(529,714,l),
+(505,606,ls),
+(465,418,o),
+(355,325,o),
+(191,325,cs),
+(139,325,l),
+(104,163,l),
+(20,163,l),
+(11,121,l),
+(95,121,l),
+(69,0,l)
+);
+}
+);
+width = 573;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB1;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB0;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (397,0);
+ref = dot_top;
+}
+);
+width = 573;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB2;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (212,714);
+},
+{
+name = top_right_can;
+pos = (520,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(92,0,l),
+(116,108,ls),
+(156,296,o),
+(266,389,o),
+(430,389,cs),
+(483,389,l),
+(517,551,l),
+(601,551,l),
+(610,593,l),
+(526,593,l),
+(552,714,l),
+(488,714,l),
+(462,593,l),
+(209,593,l),
+(201,551,l),
+(453,551,l),
+(426,424,l),
+(474,447,l),
+(434,447,ls),
+(236,447,o),
+(102,341,o),
+(53,115,cs),
+(28,0,l)
+);
+}
+);
+width = 573;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "theThCree-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB3;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB2;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (356,0);
+ref = dot_top;
+}
+);
+width = 573;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB4;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (253,714);
+},
+{
+name = top_right_can;
+pos = (561,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(441,0,l),
+(464,110,ls),
+(508,319,o),
+(406,447,o),
+(202,447,cs),
+(181,447,l),
+(223,424,l),
+(250,551,l),
+(503,551,l),
+(511,593,l),
+(259,593,l),
+(285,714,l),
+(221,714,l),
+(196,593,l),
+(111,593,l),
+(102,551,l),
+(186,551,l),
+(152,389,l),
+(188,389,ls),
+(363,389,o),
+(441,295,o),
+(400,106,cs),
+(377,0,l)
+);
+}
+);
+width = 573;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB5;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB4;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (89,0);
+ref = dot_top;
+}
+);
+width = 573;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB6;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (215,714);
+},
+{
+name = top_right_can;
+pos = (523,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(95,1,l),
+(157,292,l),
+(108,268,l),
+(137,268,ls),
+(350,268,o),
+(481,380,o),
+(530,603,cs),
+(549,689,l),
+(503,671,l),
+(696,473,l),
+(741,517,l),
+(548,715,l),
+(490,715,l),
+(467,608,ls),
+(427,424,o),
+(314,326,o),
+(138,326,cs),
+(100,326,l),
+(31,1,l)
+);
+}
+);
+width = 713;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB7;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB6;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (360,0);
+ref = dot_top;
+}
+);
+width = 714;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB8;
+kernRight = soright;
+lastChange = "2023-01-13 15:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (391,714);
+},
+{
+name = top_right_can;
+pos = (699,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(272,0,l),
+(295,107,ls),
+(335,291,o),
+(448,389,o),
+(624,389,cs),
+(662,389,l),
+(731,714,l),
+(667,714,l),
+(605,423,l),
+(654,447,l),
+(625,447,ls),
+(411,447,o),
+(282,340,o),
+(232,112,cs),
+(213,26,l),
+(259,44,l),
+(65,242,l),
+(20,198,l),
+(214,0,l)
+);
+}
+);
+width = 714;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB9;
+kernRight = soright;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB8;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (533,0);
+ref = dot_top;
+}
+);
+width = 714;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABA;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (215,714);
+},
+{
+name = top_right_can;
+pos = (524,714);
+}
+);
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(397,0,l),
+(674,198,l),
+(641,245,l),
+(378,58,l),
+(411,39,l),
+(423,95,ls),
+(466,303,o),
+(365,447,o),
+(174,447,cs),
+(148,447,l),
+(185,420,l),
+(247,714,l),
+(184,714,l),
+(114,389,l),
+(149,389,ls),
+(328,389,o),
+(401,282,o),
+(358,86,cs),
+(340,0,l)
+);
+}
+);
+width = 714;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABB;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+alignment = -1;
+ref = uni11ABA;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+}
+);
+width = 714;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABC;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(459,0,l),
+(471,58,l),
+(73,58,l),
+(74,30,l),
+(610,668,l),
+(620,714,l),
+(156,714,l),
+(144,656,l),
+(542,656,l),
+(542,684,l),
+(5,46,l),
+(-5,0,l)
+);
+}
+);
+width = 567;
+}
+);
+metricRight = "=|";
+},
+{
+color = 8;
+glyphname = uni11ABD;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(468,0,l),
+(478,46,l),
+(202,684,l),
+(201,656,l),
+(599,656,l),
+(611,714,l),
+(147,714,l),
+(137,668,l),
+(414,30,l),
+(414,58,l),
+(16,58,l),
+(4,0,l)
+);
+}
+);
+width = 567;
+}
+);
+metricLeft = "=|uni11ABC";
+metricRight = "=|uni11ABC";
+},
+{
+color = 8;
+glyphname = uni11ABE;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(95,0,l),
+(233,650,l),
+(201,650,l),
+(476,0,l),
+(533,0,l),
+(685,714,l),
+(622,714,l),
+(484,64,l),
+(515,64,l),
+(241,714,l),
+(183,714,l),
+(31,0,l)
+);
+}
+);
+width = 668;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABF;
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(89,0,l),
+(652,654,l),
+(609,654,l),
+(470,0,l),
+(533,0,l),
+(685,714,l),
+(628,714,l),
+(64,60,l),
+(108,60,l),
+(247,714,l),
+(183,714,l),
+(31,0,l)
+);
+}
+);
+width = 668;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = "raiseddoubledotFinal-canadian.cree";
+lastChange = "2023-01-13 15:28:21 +0000";
+layers = (
+{
+layerId = "DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(230,637,o),
+(249,657,o),
+(249,682,cs),
+(249,707,o),
+(230,727,o),
+(204,727,cs),
+(179,727,o),
+(160,707,o),
+(160,682,cs),
+(160,657,o),
+(179,637,o),
+(204,637,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(192,458,o),
+(211,478,o),
+(211,503,cs),
+(211,528,o),
+(192,547,o),
+(167,547,cs),
+(141,547,o),
+(122,528,o),
+(122,503,cs),
+(122,478,o),
+(141,458,o),
+(167,458,cs)
+);
+}
+);
+width = 223;
+}
+);
+note = g725;
+}
+);
+instances = (
+{
+axesValues = (
+65,
+89,
+12
+);
+instanceInterpolations = {
+"DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4" = 1;
+};
+name = "RC L Italic";
+}
+);
+kerningLTR = {
+"DE93BBBF-E17B-48DE-A6AB-0C4E62D4ADD4" = {
+"@MMK_L_caright" = {
+"@MMK_R_ecanleft" = -80;
+"@MMK_R_mwestleft" = -28;
+"@MMK_R_neleft" = -64;
+};
+"@MMK_L_ciright" = {
+"@MMK_R_icanleft" = -80;
+"@MMK_R_noleft" = -108;
+};
+"@MMK_L_ecanright" = {
+"@MMK_R_coleft" = -80;
+"@MMK_R_moleft" = -82;
+"@MMK_R_sileft" = -49;
+};
+"@MMK_L_icanright" = {
+"@MMK_R_celeft" = -80;
+"@MMK_R_meleft" = -82;
+"@MMK_R_mwestleft" = -65;
+"@MMK_R_saleft" = -43;
+"she-canadian" = -82;
+};
+"@MMK_L_maright" = {
+"@MMK_R_acanleft" = -83;
+"@MMK_R_ecanleft" = -82;
+"@MMK_R_mwestleft" = -54;
+"@MMK_R_neleft" = -64;
+};
+"@MMK_L_miright" = {
+"@MMK_R_acanleft" = -83;
+"@MMK_R_icanleft" = -82;
+"@MMK_R_moleft" = -106;
+"@MMK_R_noleft" = -108;
+"@MMK_R_yeleft" = -109;
+};
+"@MMK_L_mwestright" = {
+"@MMK_R_coleft" = -28;
+"@MMK_R_icanleft" = -65;
+"@MMK_R_moleft" = -54;
+"@MMK_R_noleft" = -85;
+"@MMK_R_sileft" = -18;
+"@MMK_R_yeleft" = -30;
+};
+"@MMK_L_naright" = {
+"@MMK_R_acanleft" = -102;
+"@MMK_R_celeft" = -108;
+"@MMK_R_meleft" = -108;
+"@MMK_R_mwestleft" = -85;
+"@MMK_R_neleft" = -128;
+"@MMK_R_saleft" = -82;
+};
+"@MMK_L_niright" = {
+"@MMK_R_coleft" = -64;
+"@MMK_R_moleft" = -64;
+"@MMK_R_noleft" = -128;
+"@MMK_R_sileft" = -6;
+};
+"@MMK_L_ocanright" = {
+"@MMK_R_meleft" = -83;
+"@MMK_R_moleft" = -83;
+"@MMK_R_noleft" = -102;
+};
+"@MMK_L_seright" = {
+"@MMK_R_ecanleft" = -49;
+"@MMK_R_mwestleft" = -18;
+"@MMK_R_neleft" = -4;
+};
+"@MMK_L_soright" = {
+"@MMK_R_icanleft" = -43;
+"@MMK_R_noleft" = -82;
+};
+"@MMK_L_yiright" = {
+"@MMK_R_meleft" = -109;
+"@MMK_R_mwestleft" = -30;
+};
+"shi-canadian" = {
+"@MMK_R_icanleft" = -82;
+};
+};
+};
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "italic angle";
+}
+);
+properties = (
+{
+key = copyrights;
+values = (
+{
+language = ENG;
+value = "Copyright 2018 Google Inc. All Rights Reserved.";
+}
+);
+},
+{
+key = manufacturers;
+values = (
+{
+language = ENG;
+value = "Monotype Imaging Inc.";
+}
+);
+},
+{
+key = designers;
+values = (
+{
+language = ENG;
+value = "Monotype Design Team";
+}
+);
+},
+{
+key = description;
+value = "Designed by Monotype design team.";
+},
+{
+key = trademarks;
+values = (
+{
+language = ENG;
+value = "Noto is a trademark of Google Inc.";
+}
+);
+},
+{
+key = licenseURL;
+value = "http://scripts.sil.org/OFL";
+},
+{
+key = licenses;
+values = (
+{
+language = ENG;
+value = "This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.";
+}
+);
+},
+{
+key = manufacturerURL;
+value = "http://www.google.com/get/noto/";
+},
+{
+key = designerURL;
+value = "http://www.monotype.com/studio";
+}
+);
+settings = {
+disablesNiceNames = 1;
+};
+stems = (
+{
+name = "New Stem";
+}
+);
+unitsPerEm = 1000;
+userData = {
+GSDontShowVersionAlert = 1;
+};
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/sources/Exported instances UCAS SansCanadianAboriginal/Sans Canadian Aboriginal-RC L roman.glyphs
+++ b/sources/Exported instances UCAS SansCanadianAboriginal/Sans Canadian Aboriginal-RC L roman.glyphs
@@ -1,0 +1,37305 @@
+{
+.appVersion = "3151";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+},
+{
+name = Width;
+tag = wdth;
+},
+{
+name = Slant;
+tag = slnt;
+}
+);
+classes = (
+{
+code = "zero one two three four five six seven eight nine ";
+name = Num;
+},
+{
+code = "zero.canadian one.canadian two.canadian three.canadian four.canadian five.canadian six.canadian seven.canadian eight.canadian nine.canadian 
+";
+name = Num_can;
+},
+{
+code = "ke-canadian.square ki-canadian.square kii-canadian.square ko-canadian.square koo-canadian.square ka-canadian.square kaa-canadian.square kweWestCree-canadian.square kwiiWestCree-canadian.square kwoWestCree-canadian.square kwooWestCree-canadian.square kwaWestCree-canadian.square kwaaWestCree-canadian.square ce-canadian.square ci-canadian.square cii-canadian.square co-canadian.square coo-canadian.square ca-canadian.square caa-canadian.square me-canadian.square mi-canadian.square mii-canadian.square mo-canadian.square moo-canadian.square ma-canadian.square maa-canadian.square ne-canadian.square ni-canadian.square nii-canadian.square no-canadian.square noo-canadian.square na-canadian.square naa-canadian.square nweWestCree-canadian.square nwaWestCree-canadian.square nwaaWestCree-canadian.square se-canadian.square si-canadian.square sii-canadian.square so-canadian.square soo-canadian.square sa-canadian.square saa-canadian.square sho-canadian.square shoo-canadian.square sha-canadian.square shaa-canadian.square ye-canadian.square yi-canadian.square yii-canadian.square yo-canadian.square yoo-canadian.square ya-canadian.square yaa-canadian.square re-canadian.square reRCree-canadian.square leWestCree-canadian.square ri-canadian.square rii-canadian.square ro-canadian.square loWestCree-canadian.square ra-canadian.square raa-canadian.square laWestCree-canadian.square reWestCree-canadian.square riWestCree-canadian.square roWestCree-canadian.square raWestCree-canadian.square theThCree-canadian.square thiThCree-canadian.square thiiThCree-canadian.square thoThCree-canadian.square thooThCree-canadian.square thaThCree-canadian.square thaaThCree-canadian.square thweeWoodScree-canadian.square thwiWoodScree-canadian.square thwiiWoodScree-canadian.square thwoWoodScree-canadian.square thwooWoodScree-canadian.square thwaWoodScree-canadian.square thwaaWoodScree-canadian.square nwiOjibway-canadian.square nwiiOjibway-canadian.square nwoOjibway-canadian.square nwooOjibway-canadian.square looWestCree-canadian.square laaWestCree-canadian.square ";
+name = Dene_square;
+},
+{
+code = "ke-canadian ki-canadian kii-canadian ko-canadian koo-canadian ka-canadian kaa-canadian kweWestCree-canadian kwiiWestCree-canadian kwoWestCree-canadian kwooWestCree-canadian kwaWestCree-canadian kwaaWestCree-canadian ce-canadian ci-canadian cii-canadian co-canadian coo-canadian ca-canadian caa-canadian me-canadian mi-canadian mii-canadian mo-canadian moo-canadian ma-canadian maa-canadian ne-canadian ni-canadian nii-canadian no-canadian noo-canadian na-canadian naa-canadian nweWestCree-canadian nwaWestCree-canadian nwaaWestCree-canadian se-canadian si-canadian sii-canadian so-canadian soo-canadian sa-canadian saa-canadian sho-canadian shoo-canadian sha-canadian shaa-canadian ye-canadian yi-canadian yii-canadian yo-canadian yoo-canadian ya-canadian yaa-canadian re-canadian reRCree-canadian leWestCree-canadian ri-canadian rii-canadian ro-canadian loWestCree-canadian ra-canadian raa-canadian laWestCree-canadian reWestCree-canadian riWestCree-canadian roWestCree-canadian raWestCree-canadian theThCree-canadian thiThCree-canadian thiiThCree-canadian thoThCree-canadian thooThCree-canadian thaThCree-canadian thaaThCree-canadian thweeWoodScree-canadian thwiWoodScree-canadian thwiiWoodScree-canadian thwoWoodScree-canadian thwooWoodScree-canadian thwaWoodScree-canadian thwaaWoodScree-canadian nwiOjibway-canadian nwiiOjibway-canadian nwoOjibway-canadian nwooOjibway-canadian looWestCree-canadian laaWestCree-canadian 
+";
+name = Dene_round;
+},
+{
+code = "acuteFinal-canadian.mid graveFinal-canadian.mid ringTophalfFinal-canadian.mid ringRighthalfFinal-canadian.mid ringFinal-canadian.mid doubleacuteFinal-canadian.mid doubleshortverticalstrokesFinal-canadian.mid shorthorizontalstrokeFinal-canadian.mid downtackFinal-canadian.mid pWestCree-canadian.mid c-canadian.mid mWestCree-canadian.mid ";
+name = Final_mid;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian ringFinal-canadian doubleacuteFinal-canadian doubleshortverticalstrokesFinal-canadian shorthorizontalstrokeFinal-canadian downtackFinal-canadian pWestCree-canadian c-canadian mWestCree-canadian ";
+name = Final_mid_ori;
+},
+{
+code = "acuteFinal-canadian.base graveFinal-canadian.base ringBottomhalfFinal-canadian.base ringTophalfFinal-canadian.base ringRighthalfFinal-canadian.base plusFinal-canadian.base pWestCree-canadian.base c-canadian.base thSayisi-canadian.base mWestCree-canadian.base ";
+name = Final_base;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringBottomhalfFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian plusFinal-canadian pWestCree-canadian c-canadian thSayisi-canadian mWestCree-canadian ";
+name = Final_base_ori;
+},
+{
+code = "ng-canadian ngai-canadian ngaai-canadian ngi-canadian ngii-canadian ngo-canadian ngoo-canadian nga-canadian ngaa-canadian ";
+name = Nunavik;
+},
+{
+code = "ng-canadian.nunavik ngai-canadian.nunavik ngaai-canadian.nunavik ngi-canadian.nunavik ngii-canadian.nunavik ngo-canadian.nunavik ngoo-canadian.nunavik nga-canadian.nunavik ngaa-canadian.nunavik ";
+name = Nunavik_alt;
+}
+);
+customParameters = (
+{
+name = vendorID;
+value = GOOG;
+},
+{
+name = panose;
+value = (
+2,
+11,
+5,
+2,
+4,
+5,
+4,
+2,
+2,
+4
+);
+},
+{
+name = unicodeRanges;
+value = (
+0,
+1,
+2,
+5,
+6,
+45,
+77
+);
+},
+{
+name = codePageRanges;
+value = (
+"1252"
+);
+},
+{
+name = fsType;
+value = (
+);
+}
+);
+date = "2022-06-21 10:06:40 +0000";
+familyName = "Sans Canadian Aboriginal";
+featurePrefixes = (
+{
+automatic = 1;
+code = "languagesystem DFLT dflt;
+
+languagesystem cans dflt;
+";
+name = Languagesystems;
+}
+);
+features = (
+{
+automatic = 1;
+code = "feature ss01;
+feature ss02;
+feature ss03;
+feature ss04;
+";
+tag = aalt;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+tag = salt;
+},
+{
+code = "lookup space_can {
+sub space by space.canadian;
+} space_can;
+
+lookup num_can {
+sub @Num by @Num_can;
+} num_can;
+";
+labels = (
+{
+language = dflt;
+value = "CAN Space and numerals";
+}
+);
+tag = ss01;
+},
+{
+code = "lookup dene_square {
+sub @Dene_round by @Dene_square;
+} dene_square;
+
+";
+labels = (
+{
+language = dflt;
+value = "Dene Square";
+}
+);
+tag = ss02;
+},
+{
+code = "lookup nunavik_alt {
+sub @Nunavik by @Nunavik_alt;
+} nunavik_alt;
+
+";
+labels = (
+{
+language = dflt;
+value = "Nunanvik Alt";
+}
+);
+tag = ss03;
+},
+{
+code = "lookup final_mid {
+sub @Final_mid_ori by @Final_mid;
+} final_mid;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final mid";
+}
+);
+tag = ss04;
+},
+{
+code = "lookup final_base {
+sub @Final_base_ori by @Final_base;
+} final_base;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final base";
+}
+);
+tag = ss05;
+},
+{
+code = "lookup plaincree_first {
+sub wiWestCree-canadian' plusFinal-canadian by i-canadian;
+} plaincree_first;
+
+lookup plaincree_second {
+sub i-canadian plusFinal-canadian' by raiseddoubledotFinal-canadian.cree;
+} plaincree_second;
+
+lookup plaincree_third {
+sub middledotFinal-canadian plusFinal-canadian by raiseddoubledotFinal-canadian.cree;
+} plaincree_third;
+";
+labels = (
+{
+language = dflt;
+value = Plaincree;
+}
+);
+tag = ss06;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+labels = (
+{
+language = dflt;
+value = "";
+}
+);
+tag = ss07;
+}
+);
+fontMaster = (
+{
+axesValues = (
+0,
+0,
+0
+);
+customParameters = (
+{
+name = typoAscender;
+value = 1069;
+},
+{
+name = typoDescender;
+value = -293;
+},
+{
+name = typoLineGap;
+value = 0;
+},
+{
+name = winAscent;
+value = 1069;
+},
+{
+name = winDescent;
+value = 293;
+},
+{
+name = hheaAscender;
+value = 1069;
+},
+{
+name = hheaDescender;
+value = -293;
+},
+{
+name = strikeoutPosition;
+value = 293.43713;
+},
+{
+name = strikeoutSize;
+value = 50;
+}
+);
+guides = (
+{
+lockAngle = 1;
+locked = 1;
+pos = (230,357);
+}
+);
+id = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+metricValues = (
+{
+over = 17;
+pos = 1069;
+},
+{
+over = 17;
+pos = 714;
+},
+{
+over = 17;
+pos = 489;
+},
+{
+over = -17;
+},
+{
+over = -17;
+pos = -293;
+},
+{
+}
+);
+name = "RC L roman";
+stemValues = (
+64
+);
+}
+);
+glyphs = (
+{
+glyphname = idotless;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(141,534,l),
+(78,534,l),
+(78,0,l),
+(141,0,l)
+);
+}
+);
+width = 219;
+}
+);
+note = dotlessi;
+unicode = 305;
+},
+{
+glyphname = "acuteFinal-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,357,l),
+(259,714,l),
+(206,714,l),
+(48,357,l)
+);
+}
+);
+width = 307;
+}
+);
+metricRight = "=|";
+note = uni141F;
+unicode = 5151;
+},
+{
+glyphname = "graveFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(259,357,l),
+(100,714,l),
+(48,714,l),
+(206,357,l)
+);
+}
+);
+width = 307;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+unicode = 5152;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(301,351,o),
+(355,408,o),
+(355,512,cs),
+(355,714,l),
+(307,714,l),
+(307,511,ls),
+(307,431,o),
+(274,395,o),
+(213,395,cs),
+(152,395,o),
+(118,433,o),
+(118,511,cs),
+(118,714,l),
+(69.995,714,l),
+(70,510,ls),
+(70,409,o),
+(125,351,o),
+(212,351,cs)
+);
+}
+);
+width = 425;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1421;
+unicode = 5153;
+},
+{
+glyphname = "ringTophalfFinal-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(118,357,l),
+(118,560,ls),
+(118,638,o),
+(152,676,o),
+(213,676,cs),
+(274,676,o),
+(307,640,o),
+(307,560,cs),
+(307,357,l),
+(355,357,l),
+(355,559,ls),
+(355,663,o),
+(301,720,o),
+(212,720,cs),
+(125,720,o),
+(70,662,o),
+(70,561,cs),
+(69.995,357,l)
+);
+}
+);
+width = 425;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+unicode = 5154;
+},
+{
+glyphname = "ringRighthalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(134,357,ls),
+(244,357,o),
+(306,425,o),
+(306,535,cs),
+(306,646,o),
+(244,714,o),
+(133,714,cs),
+(66,714,l),
+(66,670,l),
+(131,670,ls),
+(215,670,o),
+(258,621,o),
+(258,535,cs),
+(258,449,o),
+(215,401,o),
+(131,401,cs),
+(66,401,l),
+(66,357,l)
+);
+}
+);
+width = 374;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+unicode = 5155;
+},
+{
+glyphname = "ringFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(346,372,o),
+(421,446,o),
+(421,546,cs),
+(421,646,o),
+(345,720,o),
+(244,720,cs),
+(144,720,o),
+(68,646,o),
+(68,546,cs),
+(68,446,o),
+(142,372,o),
+(244,372,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(167,413,o),
+(113,469,o),
+(113,546,cs),
+(113,623,o),
+(168,678,o),
+(244,678,cs),
+(320,678,o),
+(376,623,o),
+(376,546,cs),
+(376,469,o),
+(321,413,o),
+(244,413,cs)
+);
+}
+);
+width = 489;
+}
+);
+note = uni1424;
+unicode = 5156;
+},
+{
+glyphname = "doubleacuteFinal-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(259,714,l),
+(206,714,l),
+(48,357,l),
+(100,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(394,714,l),
+(342,714,l),
+(184,357,l),
+(236,357,l)
+);
+}
+);
+width = 442;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricRight = "=|";
+note = uni1425;
+unicode = 5157;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(118,714,l),
+(69.995,714,l),
+(69.995,357,l),
+(118,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(240,714,l),
+(192,714,l),
+(192,357,l),
+(240,357,l)
+);
+}
+);
+width = 310;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "pWestCree-canadian";
+note = uni1426;
+unicode = 5158;
+},
+{
+glyphname = "middledotFinal-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(135,322,o),
+(155,342,o),
+(155,367,cs),
+(155,392,o),
+(135,412,o),
+(110,412,cs),
+(85,412,o),
+(66,392,o),
+(66,367,cs),
+(66,342,o),
+(85,322,o),
+(110,322,cs)
+);
+}
+);
+width = 220;
+}
+);
+note = uni1427;
+unicode = 5159;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(389,516,l),
+(389,563,l),
+(68,563,l),
+(68,516,l)
+);
+}
+);
+width = 457;
+}
+);
+metricRight = "=|";
+note = uni1428;
+unicode = 5160;
+},
+{
+glyphname = "plusFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(252,379,l),
+(252,525,l),
+(389,525,l),
+(389,571,l),
+(252,571,l),
+(252,714,l),
+(206,714,l),
+(206,571,l),
+(68,571,l),
+(68,525,l),
+(206,525,l),
+(206,379,l)
+);
+}
+);
+width = 457;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+unicode = 5161;
+},
+{
+glyphname = "downtackFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(253,357,l),
+(253,669,l),
+(389,669,l),
+(389,714,l),
+(68,714,l),
+(68,669,l),
+(205,669,l),
+(205,357,l)
+);
+}
+);
+width = 457;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni142A;
+unicode = 5162;
+},
+{
+glyphname = "thFinalWoodScree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(255,357,l),
+(255,445,l),
+(391,445,l),
+(391,486,l),
+(255,486,l),
+(255,585,l),
+(391,585,l),
+(391,626,l),
+(255,626,l),
+(255,714,l),
+(208,714,l),
+(208,626,l),
+(70,626,l),
+(70,585,l),
+(208,585,l),
+(208,486,l),
+(70,486,l),
+(70,445,l),
+(208,445,l),
+(208,357,l)
+);
+}
+);
+width = 461;
+}
+);
+metricLeft = "hyphen-canadian";
+metricRight = "hyphen-canadian";
+note = uni167E;
+unicode = 5758;
+},
+{
+glyphname = "ringSmallFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(225,529,o),
+(270,570,o),
+(270,628,cs),
+(270,686,o),
+(225,727,o),
+(170,727,cs),
+(115,727,o),
+(70,686,o),
+(70,628,cs),
+(70,570,o),
+(115,529,o),
+(170,529,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(131,564,o),
+(106,591,o),
+(106,628,cs),
+(106,665,o),
+(132,693,o),
+(170,693,cs),
+(208,693,o),
+(233,665,o),
+(233,628,cs),
+(233,591,o),
+(209,564,o),
+(170,564,cs)
+);
+}
+);
+width = 340;
+}
+);
+note = g725;
+unicode = 6366;
+},
+{
+glyphname = "raiseddotFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(137,637,o),
+(156,657,o),
+(156,682,cs),
+(156,707,o),
+(137,727,o),
+(112,727,cs),
+(86,727,o),
+(67,707,o),
+(67,682,cs),
+(67,657,o),
+(86,637,o),
+(112,637,cs)
+);
+}
+);
+width = 223;
+}
+);
+note = g725;
+unicode = 6367;
+},
+{
+glyphname = "acuteFinal-canadian.base";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "acuteFinal-canadian";
+}
+);
+width = 307;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.base";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "graveFinal-canadian";
+}
+);
+width = 307;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian.base";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 425;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1421;
+},
+{
+glyphname = "ringTophalfFinal-canadian.base";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 425;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.base";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 374;
+}
+);
+metricLeft = "==|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "plusFinal-canadian.base";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(252,0,l),
+(252,146,l),
+(389,146,l),
+(389,192,l),
+(252,192,l),
+(252,335,l),
+(206,335,l),
+(206,192,l),
+(68,192,l),
+(68,146,l),
+(206,146,l),
+(206,0,l)
+);
+}
+);
+width = 457;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+},
+{
+glyphname = "acuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "acuteFinal-canadian";
+}
+);
+width = 307;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.mid";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "graveFinal-canadian";
+}
+);
+width = 307;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringTophalfFinal-canadian.mid";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-178);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 425;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.mid";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 374;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "ringFinal-canadian.mid";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-189);
+ref = "ringFinal-canadian";
+}
+);
+width = 489;
+}
+);
+metricLeft = "ringFinal-canadian";
+metricWidth = "ringFinal-canadian";
+note = uni1424;
+},
+{
+glyphname = "doubleacuteFinal-canadian.mid";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "doubleacuteFinal-canadian";
+}
+);
+width = 442;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "doubleacuteFinal-canadian";
+note = uni1425;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian.mid";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "doubleshortverticalstrokesFinal-canadian";
+}
+);
+width = 310;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricWidth = "doubleshortverticalstrokesFinal-canadian";
+note = uni1426;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian.mid";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-173);
+ref = "shorthorizontalstrokeFinal-canadian";
+}
+);
+width = 457;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "shorthorizontalstrokeFinal-canadian";
+note = uni1428;
+},
+{
+glyphname = "downtackFinal-canadian.mid";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "downtackFinal-canadian";
+}
+);
+width = 457;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "downtackFinal-canadian";
+note = uni142A;
+},
+{
+glyphname = "e-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (354,470);
+},
+{
+name = top_center_can;
+pos = (354,714);
+},
+{
+name = top_left_can;
+pos = (125,714);
+},
+{
+name = top_right_can;
+pos = (584,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(372,0,l),
+(678,694,l),
+(678,714,l),
+(37,714,l),
+(37,694,l),
+(343,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(369,73,l),
+(109,677,l),
+(102,660,l),
+(613,660,l),
+(608,677,l),
+(348,73,l)
+);
+}
+);
+width = 715;
+}
+);
+metricRight = "=|";
+note = uni1401;
+unicode = 5121;
+},
+{
+glyphname = "aai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (233,0);
+ref = ring_top.canadian;
+}
+);
+width = 715;
+}
+);
+note = uni1402;
+unicode = 5122;
+},
+{
+glyphname = "i-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (357,417);
+},
+{
+name = top_center_can;
+pos = (358,714);
+},
+{
+name = top_left_can;
+pos = (126,714);
+},
+{
+name = top_right_can;
+pos = (584,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(678,0,l),
+(678,20,l),
+(372,714,l),
+(343,714,l),
+(37,20,l),
+(37,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(368,641,l),
+(346,641,l),
+(607,37,l),
+(613,54,l),
+(102,54,l),
+(107,37,l)
+);
+}
+);
+width = 715;
+}
+);
+metricLeft = "e-canadian";
+metricWidth = "e-canadian";
+note = uni1403;
+unicode = 5123;
+},
+{
+glyphname = "ii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (294,0);
+ref = dot_top;
+}
+);
+width = 715;
+}
+);
+note = uni1404;
+unicode = 5124;
+},
+{
+glyphname = "o-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (278,357);
+},
+{
+name = top_center_can;
+pos = (366,714);
+},
+{
+name = top_double;
+pos = (454,714);
+},
+{
+name = top_left_can;
+pos = (111,714);
+},
+{
+name = top_right_can;
+pos = (613,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(103,0,l),
+(651,343,l),
+(651,371,l),
+(103,714,l),
+(83,714,l),
+(83,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(139,642,l),
+(121,640,l),
+(589,346,l),
+(589,369,l),
+(121,75,l),
+(139,72,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1405;
+unicode = 5125;
+},
+{
+glyphname = "oo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (47,0);
+ref = dot_top;
+}
+);
+width = 688;
+}
+);
+note = uni1406;
+unicode = 5126;
+},
+{
+glyphname = "yCreeoo-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (228,0);
+ref = doubledot_top;
+}
+);
+width = 688;
+}
+);
+note = uni1407;
+unicode = 5127;
+},
+{
+glyphname = "eeCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(103,0,l),
+(651,343,l),
+(651,371,l),
+(103,714,l),
+(83,714,l),
+(83,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(138,642,l),
+(121,641,l),
+(589,348,l),
+(589,367,l),
+(121,74,l),
+(138,72,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(293,454,l),
+(262,454,l),
+(262,260,l),
+(293,260,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "o-canadian";
+note = uni1408;
+unicode = 5128;
+},
+{
+glyphname = "iCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (223,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 688;
+}
+);
+note = uni1409;
+unicode = 5129;
+},
+{
+glyphname = "a-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (404,357);
+},
+{
+name = top_center_can;
+pos = (318,714);
+},
+{
+name = top_left_can;
+pos = (67,714);
+},
+{
+name = top_right_can;
+pos = (577,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(605,0,l),
+(605,714,l),
+(585,714,l),
+(38,371,l),
+(38,343,l),
+(585,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(567,74,l),
+(99,368,l),
+(99,346,l),
+(566,640,l),
+(549,643,l),
+(549,71,l)
+);
+}
+);
+width = 688;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni140A;
+unicode = 5130;
+},
+{
+glyphname = "aa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (513,0);
+ref = dot_top;
+}
+);
+width = 688;
+}
+);
+note = uni140B;
+unicode = 5131;
+},
+{
+glyphname = "we-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "e-canadian";
+}
+);
+width = 935;
+}
+);
+note = uni140C;
+unicode = 5132;
+},
+{
+glyphname = "weWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (715,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 935;
+}
+);
+note = uni140D;
+unicode = 5133;
+},
+{
+glyphname = "wi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "i-canadian";
+}
+);
+width = 935;
+}
+);
+note = uni140E;
+unicode = 5134;
+},
+{
+glyphname = "wiWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (715,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 935;
+}
+);
+note = uni140F;
+unicode = 5135;
+},
+{
+glyphname = "wii-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (514,0);
+ref = dot_top;
+}
+);
+width = 935;
+}
+);
+note = uni1410;
+unicode = 5136;
+},
+{
+glyphname = "wiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (294,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (715,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 935;
+}
+);
+note = uni1411;
+unicode = 5137;
+},
+{
+glyphname = "wo-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "o-canadian";
+}
+);
+width = 909;
+}
+);
+note = uni1412;
+unicode = 5138;
+},
+{
+glyphname = "woWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (688,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 909;
+}
+);
+note = uni1413;
+unicode = 5139;
+},
+{
+glyphname = "woo-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (522,0);
+ref = dot_top;
+}
+);
+width = 909;
+}
+);
+note = uni1414;
+unicode = 5140;
+},
+{
+glyphname = "wooWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (47,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (688,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 909;
+}
+);
+note = uni1415;
+unicode = 5141;
+},
+{
+glyphname = "wooNaskapi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (222,-99);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (399,-208);
+ref = dot_top;
+}
+);
+width = 688;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricWidth = "o-canadian";
+note = uni1416;
+unicode = 5142;
+},
+{
+glyphname = "wa-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "a-canadian";
+}
+);
+width = 909;
+}
+);
+note = uni1417;
+unicode = 5143;
+},
+{
+glyphname = "waWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (688,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 909;
+}
+);
+note = uni1418;
+unicode = 5144;
+},
+{
+glyphname = "waa-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (733,0);
+ref = dot_top;
+}
+);
+width = 909;
+}
+);
+note = uni1419;
+unicode = 5145;
+},
+{
+glyphname = "waaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (513,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (688,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 909;
+}
+);
+note = uni141A;
+unicode = 5146;
+},
+{
+glyphname = "waaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (161,-208);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (338,-99);
+ref = dot_top;
+}
+);
+width = 688;
+}
+);
+metricWidth = "a-canadian";
+note = uni141B;
+unicode = 5147;
+},
+{
+glyphname = "ai-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(270,351,o),
+(312,387,o),
+(328,454,c),
+(311,454,l),
+(328,386,o),
+(372,351,o),
+(435,351,cs),
+(517,351,o),
+(570,404,o),
+(570,510,cs),
+(570,714,l),
+(524,714,l),
+(524,510,ls),
+(524,425,o),
+(489,393,o),
+(434,393,cs),
+(379,393,o),
+(343,427,o),
+(343,509,cs),
+(343,714,l),
+(297,714,l),
+(297,510,ls),
+(297,425,o),
+(261,393,o),
+(206,393,cs),
+(151,393,o),
+(116,427,o),
+(116,509,cs),
+(116,714,l),
+(69.995,714,l),
+(70,508,ls),
+(70,404,o),
+(125,351,o),
+(205,351,cs)
+);
+}
+);
+width = 640;
+}
+);
+metricRight = "=|";
+note = uni141C;
+unicode = 5148;
+},
+{
+glyphname = "ycreew-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(357,528,o),
+(394,568,o),
+(394,624,cs),
+(394,681,o),
+(357,720,o),
+(307,720,cs),
+(258,720,o),
+(220,681,o),
+(220,624,cs),
+(220,568,o),
+(258,528,o),
+(307,528,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(205,351,o),
+(242,391,o),
+(242,447,cs),
+(242,504,o),
+(205,543,o),
+(156,543,cs),
+(106,543,o),
+(69,504,o),
+(69,447,cs),
+(69,391,o),
+(106,351,o),
+(155,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(122,380,o),
+(99,407,o),
+(99,447,cs),
+(99,487,o),
+(122,514,o),
+(155,514,cs),
+(188,514,o),
+(211,487,o),
+(211,447,cs),
+(211,407,o),
+(188,380,o),
+(155,380,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(274,557,o),
+(251,584,o),
+(251,624,cs),
+(251,664,o),
+(274,691,o),
+(307,691,cs),
+(340,691,o),
+(363,664,o),
+(363,624,cs),
+(363,584,o),
+(340,557,o),
+(307,557,cs)
+);
+}
+);
+width = 463;
+}
+);
+metricRight = "=|";
+note = uni141D;
+unicode = 5149;
+},
+{
+glyphname = "glottalstop-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(384,357,l),
+(384,369,l),
+(232,714,l),
+(216,714,l),
+(63,369,l),
+(63,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(237,672,l),
+(211,672,l),
+(339,376,l),
+(350,395,l),
+(98,395,l),
+(108,376,l)
+);
+}
+);
+width = 447;
+}
+);
+metricRight = "=|";
+note = uni141E;
+unicode = 5150;
+},
+{
+glyphname = "en-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+pos = (715,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 1021;
+}
+);
+note = uni142B;
+unicode = 5163;
+},
+{
+glyphname = "in-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+pos = (498,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 805;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142C;
+unicode = 5164;
+},
+{
+glyphname = "on-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (547,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 854;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142D;
+unicode = 5165;
+},
+{
+glyphname = "an-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (641,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 948;
+}
+);
+metricRight = "graveFinal-canadian";
+note = uni142E;
+unicode = 5166;
+},
+{
+glyphname = "pe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (354,470);
+},
+{
+name = top_center_can;
+pos = (354,714);
+},
+{
+name = top_left_can;
+pos = (125,714);
+},
+{
+name = top_right_can;
+pos = (584,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(372,0,l),
+(678,694,l),
+(678,714,l),
+(620,714,l),
+(343,75,l),
+(374,75,l),
+(97,714,l),
+(37,714,l),
+(37,694,l),
+(343,0,l)
+);
+}
+);
+width = 715;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni142F;
+unicode = 5167;
+},
+{
+glyphname = "paai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (233,0);
+ref = ring_top.canadian;
+}
+);
+width = 715;
+}
+);
+note = uni1430;
+unicode = 5168;
+},
+{
+glyphname = "pi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (355,417);
+},
+{
+name = top_center_can;
+pos = (358,714);
+},
+{
+name = top_left_can;
+pos = (128,714);
+},
+{
+name = top_right_can;
+pos = (587,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(95,0,l),
+(373,639,l),
+(342,639,l),
+(618,0,l),
+(678,0,l),
+(678,20,l),
+(372,714,l),
+(343,714,l),
+(37,20,l),
+(37,0,l)
+);
+}
+);
+width = 715;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni1431;
+unicode = 5169;
+},
+{
+glyphname = "pii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (294,0);
+ref = dot_top;
+}
+);
+width = 715;
+}
+);
+note = uni1432;
+unicode = 5170;
+},
+{
+glyphname = "po-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (228,357);
+},
+{
+name = top_center_can;
+pos = (339,714);
+},
+{
+name = top_double;
+pos = (433,714);
+},
+{
+name = top_left_can;
+pos = (88,714);
+},
+{
+name = top_right_can;
+pos = (583,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(78.995,0,l),
+(620,343,l),
+(620,371,l),
+(78.995,714,l),
+(59,714,l),
+(59,657,l),
+(555,342,l),
+(555,372,l),
+(59,58,l),
+(59,0,l)
+);
+}
+);
+width = 657;
+}
+);
+metricRight = "o-canadian";
+note = uni1433;
+unicode = 5171;
+},
+{
+glyphname = "poo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (24,0);
+ref = dot_top;
+}
+);
+width = 658;
+}
+);
+note = uni1434;
+unicode = 5172;
+},
+{
+glyphname = "ycreepoo-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (207,0);
+ref = doubledot_top;
+}
+);
+width = 658;
+}
+);
+note = uni1435;
+unicode = 5173;
+},
+{
+glyphname = "heeCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (191,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 658;
+}
+);
+note = uni1436;
+unicode = 5174;
+},
+{
+glyphname = "hiCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (168,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 658;
+}
+);
+note = uni1437;
+unicode = 5175;
+},
+{
+glyphname = "pa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (291,357);
+},
+{
+name = top_center_can;
+pos = (319,714);
+},
+{
+name = top_left_can;
+pos = (67,714);
+},
+{
+name = top_right_can;
+pos = (570,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(598,0,l),
+(598,57,l),
+(103,372,l),
+(103,342,l),
+(598,656,l),
+(598,714,l),
+(579,714,l),
+(38,371,l),
+(38,343,l),
+(579,0,l)
+);
+}
+);
+width = 657;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1438;
+unicode = 5176;
+},
+{
+glyphname = "paa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (505,0);
+ref = dot_top;
+}
+);
+width = 658;
+}
+);
+note = uni1439;
+unicode = 5177;
+},
+{
+glyphname = "pwe-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "pe-canadian";
+}
+);
+width = 935;
+}
+);
+note = uni143A;
+unicode = 5178;
+},
+{
+glyphname = "pweWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "pe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (715,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 935;
+}
+);
+note = uni143B;
+unicode = 5179;
+},
+{
+glyphname = "pwi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "pi-canadian";
+}
+);
+width = 935;
+}
+);
+note = uni143C;
+unicode = 5180;
+},
+{
+glyphname = "pwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (715,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 935;
+}
+);
+note = uni143D;
+unicode = 5181;
+},
+{
+glyphname = "pwii-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (514,0);
+ref = dot_top;
+}
+);
+width = 935;
+}
+);
+note = uni143E;
+unicode = 5182;
+},
+{
+glyphname = "pwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (294,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (715,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 935;
+}
+);
+note = uni143F;
+unicode = 5183;
+},
+{
+glyphname = "pwo-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "po-canadian";
+}
+);
+width = 878;
+}
+);
+note = uni1440;
+unicode = 5184;
+},
+{
+glyphname = "pwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (658,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 878;
+}
+);
+note = uni1441;
+unicode = 5185;
+},
+{
+glyphname = "pwoo-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (495,0);
+ref = dot_top;
+}
+);
+width = 878;
+}
+);
+note = uni1442;
+unicode = 5186;
+},
+{
+glyphname = "pwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (24,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (658,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 878;
+}
+);
+note = uni1443;
+unicode = 5187;
+},
+{
+glyphname = "pwa-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "pa-canadian";
+}
+);
+width = 878;
+}
+);
+note = uni1444;
+unicode = 5188;
+},
+{
+glyphname = "pwaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (658,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 878;
+}
+);
+note = uni1445;
+unicode = 5189;
+},
+{
+glyphname = "pwaa-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (726,0);
+ref = dot_top;
+}
+);
+width = 878;
+}
+);
+note = uni1446;
+unicode = 5190;
+},
+{
+glyphname = "pwaaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (505,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (658,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 878;
+}
+);
+note = uni1447;
+unicode = 5191;
+},
+{
+glyphname = "ycreepwaa-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+pos = (158,-208);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (335,-99);
+ref = dot_top;
+}
+);
+width = 657;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1448;
+unicode = 5192;
+},
+{
+glyphname = "p-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(349,357,l),
+(349,399,l),
+(110,552,l),
+(110,520,l),
+(349,671,l),
+(349,714,l),
+(336,714,l),
+(70,545,l),
+(70,527,l),
+(336,357,l)
+);
+}
+);
+width = 419;
+}
+);
+note = uni1449;
+unicode = 5193;
+},
+{
+glyphname = "pWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(118,357,l),
+(118,714,l),
+(69.995,714,l),
+(69.995,357,l)
+);
+}
+);
+width = 188;
+}
+);
+metricRight = "=|";
+note = uni144A;
+unicode = 5194;
+},
+{
+color = 6;
+glyphname = "hCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(118,189,l),
+(118,330,ls),
+(118,378,o),
+(146,406,o),
+(191,406,cs),
+(232,406,o),
+(254,380,o),
+(254,327,cs),
+(254,189,l),
+(302,189,l),
+(302,336,ls),
+(302,410,o),
+(258,449,o),
+(198,449,cs),
+(147,449,o),
+(108,418,o),
+(103,373,c),
+(118,367,l),
+(118,546,l),
+(69.995,546,l),
+(69.995,189,l)
+);
+}
+);
+width = 350;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144B;
+unicode = 5195;
+},
+{
+glyphname = "te-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (356,357);
+},
+{
+name = top_center_can;
+pos = (356,714);
+},
+{
+name = top_left_can;
+pos = (108,714);
+},
+{
+name = top_right_can;
+pos = (605,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(530,-13,o),
+(637,102,o),
+(637,303,cs),
+(637,714,l),
+(573,714,l),
+(573,300,ls),
+(573,134,o),
+(494,47,o),
+(356,47,cs),
+(222,47,o),
+(140,135,o),
+(140,300,cs),
+(140,714,l),
+(76,714,l),
+(76,299,ls),
+(76,101,o),
+(185,-13,o),
+(356,-13,cs)
+);
+}
+);
+width = 713;
+}
+);
+metricRight = "=|";
+note = uni144C;
+unicode = 5196;
+},
+{
+glyphname = "taai-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (232,0);
+ref = ring_top.canadian;
+}
+);
+width = 713;
+}
+);
+note = uni144D;
+unicode = 5197;
+},
+{
+glyphname = "ti-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (356,357);
+},
+{
+name = middle_right_can;
+pos = (801,357);
+},
+{
+name = top_center_can;
+pos = (356,714);
+},
+{
+name = top_left_can;
+pos = (108,714);
+},
+{
+name = top_right_can;
+pos = (605,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(140,0,l),
+(140,414,ls),
+(140,580,o),
+(221,667,o),
+(357,667,cs),
+(491,667,o),
+(573,579,o),
+(573,414,cs),
+(573,0,l),
+(637,0,l),
+(637,415,ls),
+(637,612,o),
+(529,727,o),
+(358,727,cs),
+(184,727,o),
+(76,613,o),
+(76,411,cs),
+(76,0,l)
+);
+}
+);
+width = 713;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni144E;
+unicode = 5198;
+},
+{
+glyphname = "tii-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (292,0);
+ref = dot_top;
+}
+);
+width = 713;
+}
+);
+note = uni144F;
+unicode = 5199;
+},
+{
+glyphname = "to-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (268,357);
+},
+{
+name = middle_right_can;
+pos = (700,357);
+},
+{
+name = top_center_can;
+pos = (273,714);
+},
+{
+name = top_double;
+pos = (329,714);
+},
+{
+name = top_left_can;
+pos = (90,714);
+},
+{
+name = top_right_can;
+pos = (508,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(210,0,ls),
+(420,0,o),
+(537,134,o),
+(537,358,cs),
+(537,582,o),
+(420,714,o),
+(206,714,cs),
+(61,714,l),
+(61,656,l),
+(206,656,ls),
+(382,656,o),
+(473,549,o),
+(473,358,cs),
+(473,167,o),
+(382,58,o),
+(208,58,cs),
+(61,58,l),
+(61,0,l)
+);
+}
+);
+width = 606;
+}
+);
+note = uni1450;
+unicode = 5200;
+},
+{
+glyphname = "too-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (209,0);
+ref = dot_top;
+}
+);
+width = 606;
+}
+);
+note = uni1451;
+unicode = 5201;
+},
+{
+glyphname = "ycreetoo-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (103,0);
+ref = doubledot_top;
+}
+);
+width = 606;
+}
+);
+note = uni1452;
+unicode = 5202;
+},
+{
+glyphname = "deeCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (227,0);
+ref = stroke_middle;
+}
+);
+width = 606;
+}
+);
+note = uni1453;
+unicode = 5203;
+},
+{
+glyphname = "diCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (203,0);
+ref = dot_middle;
+}
+);
+width = 606;
+}
+);
+note = uni1454;
+unicode = 5204;
+},
+{
+glyphname = "ta-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (339,357);
+},
+{
+name = top_center_can;
+pos = (334,714);
+},
+{
+name = top_left_can;
+pos = (98,714);
+},
+{
+name = top_right_can;
+pos = (516,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(545,0,l),
+(545,58,l),
+(400,58,ls),
+(224,58,o),
+(133,166,o),
+(133,357,cs),
+(133,548,o),
+(224,656,o),
+(399,656,cs),
+(545,656,l),
+(545,714,l),
+(399,714,ls),
+(186,714,o),
+(69,581,o),
+(69,357,cs),
+(69,133,o),
+(186,0,o),
+(398,0,cs)
+);
+}
+);
+width = 606;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|to-canadian";
+note = uni1455;
+unicode = 5205;
+},
+{
+glyphname = "taa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (270,0);
+ref = dot_top;
+}
+);
+width = 606;
+}
+);
+note = uni1456;
+unicode = 5206;
+},
+{
+glyphname = "twe-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "te-canadian";
+}
+);
+width = 933;
+}
+);
+note = uni1457;
+unicode = 5207;
+},
+{
+glyphname = "tweWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (713,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 933;
+}
+);
+note = uni1458;
+unicode = 5208;
+},
+{
+glyphname = "twi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ti-canadian";
+}
+);
+width = 933;
+}
+);
+note = uni1459;
+unicode = 5209;
+},
+{
+glyphname = "twiWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (713,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 933;
+}
+);
+note = uni145A;
+unicode = 5210;
+},
+{
+glyphname = "twii-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (512,0);
+ref = dot_top;
+}
+);
+width = 933;
+}
+);
+note = uni145B;
+unicode = 5211;
+},
+{
+glyphname = "twiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (292,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (713,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 933;
+}
+);
+note = uni145C;
+unicode = 5212;
+},
+{
+glyphname = "two-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "to-canadian";
+}
+);
+width = 826;
+}
+);
+note = uni145D;
+unicode = 5213;
+},
+{
+glyphname = "twoWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (606,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 826;
+}
+);
+note = uni145E;
+unicode = 5214;
+},
+{
+glyphname = "twoo-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (429,0);
+ref = dot_top;
+}
+);
+width = 826;
+}
+);
+note = uni145F;
+unicode = 5215;
+},
+{
+glyphname = "twooWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (209,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (606,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 826;
+}
+);
+note = uni1460;
+unicode = 5216;
+},
+{
+glyphname = "twa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ta-canadian";
+}
+);
+width = 826;
+}
+);
+note = uni1461;
+unicode = 5217;
+},
+{
+glyphname = "twaWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (606,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 826;
+}
+);
+note = uni1462;
+unicode = 5218;
+},
+{
+glyphname = "twaa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (490,0);
+ref = dot_top;
+}
+);
+width = 826;
+}
+);
+note = uni1463;
+unicode = 5219;
+},
+{
+glyphname = "twaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (270,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (606,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 826;
+}
+);
+note = uni1464;
+unicode = 5220;
+},
+{
+glyphname = "twaaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (221,0);
+ref = "ta-canadian";
+}
+);
+width = 827;
+}
+);
+note = uni1465;
+unicode = 5221;
+},
+{
+glyphname = "t-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(308,357,l),
+(308,401,l),
+(243,401,ls),
+(159,401,o),
+(116,448,o),
+(116,535,cs),
+(116,621,o),
+(159,670,o),
+(243,670,cs),
+(308,670,l),
+(308,714,l),
+(239,714,ls),
+(130,714,o),
+(68,646,o),
+(68,535,cs),
+(68,424,o),
+(130,357,o),
+(241,357,cs)
+);
+}
+);
+width = 374;
+}
+);
+note = uni1466;
+unicode = 5222;
+},
+{
+glyphname = "tte-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+pos = (713,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 900;
+}
+);
+note = uni1467;
+unicode = 5223;
+},
+{
+glyphname = "tti-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+pos = (713,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 900;
+}
+);
+note = uni1468;
+unicode = 5224;
+},
+{
+glyphname = "tto-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+pos = (606,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni1469;
+unicode = 5225;
+},
+{
+glyphname = "tta-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+pos = (606,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni146A;
+unicode = 5226;
+},
+{
+glyphname = "ke-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (313,457);
+},
+{
+name = top_center_can;
+pos = (291,714);
+},
+{
+name = top_left_can;
+pos = (102,714);
+},
+{
+name = top_right_can;
+pos = (480,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(512,0,l),
+(512,464,ls),
+(512,628,o),
+(429,727,o),
+(293,727,cs),
+(157,727,o),
+(70,628,o),
+(70,467,cs),
+(70,311,o),
+(156,213,o),
+(285,213,cs),
+(374,213,o),
+(440,266,o),
+(456,338,c),
+(448,353,l),
+(448,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(194,269,o),
+(133,342,o),
+(133,470,cs),
+(133,598,o),
+(193,671,o),
+(291,671,cs),
+(391,671,o),
+(449,599,o),
+(449,470,cs),
+(449,342,o),
+(389,269,o),
+(291,269,cs)
+);
+}
+);
+width = 588;
+}
+);
+metricRight = "te-canadian";
+note = uni146B;
+unicode = 5227;
+},
+{
+glyphname = "kaai-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (172,0);
+ref = ring_top.canadian;
+}
+);
+width = 588;
+}
+);
+note = uni146C;
+unicode = 5228;
+},
+{
+glyphname = "ki-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (318,457);
+},
+{
+name = top_center_can;
+pos = (296,714);
+},
+{
+name = top_left_can;
+pos = (108,714);
+},
+{
+name = top_right_can;
+pos = (486,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(140,0,l),
+(140,353,l),
+(132,338,l),
+(148,266,o),
+(214,213,o),
+(303,213,cs),
+(432,213,o),
+(518,312,o),
+(518,469,cs),
+(518,628,o),
+(431,727,o),
+(297,727,cs),
+(160,727,o),
+(76,628,o),
+(76,464,cs),
+(76,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,269,o),
+(139,342,o),
+(139,470,cs),
+(139,599,o),
+(197,671,o),
+(296,671,cs),
+(395,671,o),
+(455,598,o),
+(455,470,cs),
+(455,342,o),
+(394,269,o),
+(296,269,cs)
+);
+}
+);
+width = 588;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni146D;
+unicode = 5229;
+},
+{
+glyphname = "kii-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (232,0);
+ref = dot_top;
+}
+);
+width = 588;
+}
+);
+note = uni146E;
+unicode = 5230;
+},
+{
+glyphname = "ko-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (313,411);
+},
+{
+name = top_center_can;
+pos = (291,714);
+},
+{
+name = top_double;
+pos = (481,714);
+},
+{
+name = top_left_can;
+pos = (102,714);
+},
+{
+name = top_right_can;
+pos = (480,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(429,-13,o),
+(512,86,o),
+(512,250,cs),
+(512,714,l),
+(448,714,l),
+(448,361,l),
+(456,376,l),
+(440,448,o),
+(374,501,o),
+(285,501,cs),
+(156,501,o),
+(70,401,o),
+(70,244,cs),
+(70,85,o),
+(155,-13,o),
+(291,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(193,43,o),
+(133,116,o),
+(133,244,cs),
+(133,372,o),
+(194,445,o),
+(291,445,cs),
+(389,445,o),
+(449,372,o),
+(449,244,cs),
+(449,115,o),
+(391,43,o),
+(291,43,cs)
+);
+}
+);
+width = 588;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni146F;
+unicode = 5231;
+},
+{
+glyphname = "koo-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (416,0);
+ref = dot_top;
+}
+);
+width = 588;
+}
+);
+note = uni1470;
+unicode = 5232;
+},
+{
+glyphname = "ycreekoo-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (254,0);
+ref = doubledot_top;
+}
+);
+width = 588;
+}
+);
+note = uni1471;
+unicode = 5233;
+},
+{
+glyphname = "ka-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (318,412);
+},
+{
+name = top_center_can;
+pos = (297,714);
+},
+{
+name = top_left_can;
+pos = (108,714);
+},
+{
+name = top_right_can;
+pos = (486,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(431,-13,o),
+(518,86,o),
+(518,246,cs),
+(518,402,o),
+(432,501,o),
+(304,501,cs),
+(215,501,o),
+(148,448,o),
+(132,376,c),
+(140,361,l),
+(140,714,l),
+(76,714,l),
+(76,250,ls),
+(76,86,o),
+(158,-13,o),
+(295,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(197,43,o),
+(139,115,o),
+(139,244,cs),
+(139,372,o),
+(199,445,o),
+(296,445,cs),
+(394,445,o),
+(455,372,o),
+(455,244,cs),
+(455,116,o),
+(395,43,o),
+(296,43,cs)
+);
+}
+);
+width = 588;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "==|ke-canadian";
+note = uni1472;
+unicode = 5234;
+},
+{
+glyphname = "kaa-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (44,0);
+ref = dot_top;
+}
+);
+width = 588;
+}
+);
+note = uni1473;
+unicode = 5235;
+},
+{
+glyphname = "kwe-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ke-canadian";
+}
+);
+width = 808;
+}
+);
+note = uni1474;
+unicode = 5236;
+},
+{
+glyphname = "kweWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (588,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 808;
+}
+);
+note = uni1475;
+unicode = 5237;
+},
+{
+glyphname = "kwi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ki-canadian";
+}
+);
+width = 808;
+}
+);
+note = uni1476;
+unicode = 5238;
+},
+{
+glyphname = "kwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (588,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 808;
+}
+);
+note = uni1477;
+unicode = 5239;
+},
+{
+glyphname = "kwii-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (453,0);
+ref = dot_top;
+}
+);
+width = 808;
+}
+);
+note = uni1478;
+unicode = 5240;
+},
+{
+glyphname = "kwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (232,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (588,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 808;
+}
+);
+note = uni1479;
+unicode = 5241;
+},
+{
+glyphname = "kwo-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ko-canadian";
+}
+);
+width = 808;
+}
+);
+note = uni147A;
+unicode = 5242;
+},
+{
+glyphname = "kwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (588,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 808;
+}
+);
+note = uni147B;
+unicode = 5243;
+},
+{
+glyphname = "kwoo-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (636,0);
+ref = dot_top;
+}
+);
+width = 808;
+}
+);
+note = uni147C;
+unicode = 5244;
+},
+{
+glyphname = "kwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (416,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (588,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 808;
+}
+);
+note = uni147D;
+unicode = 5245;
+},
+{
+glyphname = "kwa-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ka-canadian";
+}
+);
+width = 808;
+}
+);
+note = uni147E;
+unicode = 5246;
+},
+{
+glyphname = "kwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (588,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 808;
+}
+);
+note = uni147F;
+unicode = 5247;
+},
+{
+glyphname = "kwaa-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (264,0);
+ref = dot_top;
+}
+);
+width = 808;
+}
+);
+note = uni1480;
+unicode = 5248;
+},
+{
+glyphname = "kwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (44,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (588,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 808;
+}
+);
+note = uni1481;
+unicode = 5249;
+},
+{
+glyphname = "kwaaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (221,0);
+ref = "ka-canadian";
+}
+);
+width = 809;
+}
+);
+note = uni1482;
+unicode = 5250;
+},
+{
+glyphname = "k-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(261,351,o),
+(314,402,o),
+(314,488,cs),
+(314,571,o),
+(264,622,o),
+(199.002,622,cs),
+(150,622,o),
+(112,588,o),
+(105,541,c),
+(118,535,l),
+(118,714,l),
+(69.995,714,l),
+(70,488,ls),
+(70,402,o),
+(119,351,o),
+(193,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(144,389,o),
+(114,422,o),
+(114,487,cs),
+(114,549,o),
+(147,584,o),
+(192,584,cs),
+(238,584,o),
+(270,549,o),
+(270,488,cs),
+(270,425,o),
+(239,389,o),
+(193,389,cs)
+);
+}
+);
+width = 374;
+}
+);
+note = uni1483;
+unicode = 5251;
+},
+{
+glyphname = "kw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(254,351,o),
+(304,402,o),
+(304,488,cs),
+(304,714,l),
+(256,714,l),
+(256,535,l),
+(269,541,l),
+(262,588,o),
+(224,622,o),
+(175,622,cs),
+(109,622,o),
+(60,571,o),
+(60,488,cs),
+(60,402,o),
+(112,351,o),
+(181,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(135,389,o),
+(104,425,o),
+(104,488,cs),
+(104,549,o),
+(136,584,o),
+(182,584,cs),
+(227,584,o),
+(259,549,o),
+(259,487,cs),
+(259,422,o),
+(230,389,o),
+(181,389,cs)
+);
+}
+);
+width = 374;
+}
+);
+metricLeft = "=|k-canadian";
+metricRight = "=|k-canadian";
+note = uni1484;
+unicode = 5252;
+},
+{
+glyphname = "southslaveykeh-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+pos = (588,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 775;
+}
+);
+note = uni1485;
+unicode = 5253;
+},
+{
+glyphname = "southslaveykih-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+pos = (588,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 775;
+}
+);
+note = uni1486;
+unicode = 5254;
+},
+{
+glyphname = "southslaveykoh-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+pos = (588,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 775;
+}
+);
+note = uni1487;
+unicode = 5255;
+},
+{
+glyphname = "southslaveykah-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+pos = (588,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 775;
+}
+);
+note = uni1488;
+unicode = 5256;
+},
+{
+glyphname = "ce-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (311,434);
+},
+{
+name = top_center_can;
+pos = (291,714);
+},
+{
+name = top_left_can;
+pos = (102,714);
+},
+{
+name = top_right_can;
+pos = (477,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(509,0,l),
+(509,472,ls),
+(509,631,o),
+(427,727,o),
+(292,727,cs),
+(153,727,o),
+(70,631,o),
+(70,474,cs),
+(70,405,l),
+(133,405,l),
+(133,479,ls),
+(133,599,o),
+(190,670,o),
+(291,670,cs),
+(388,670,o),
+(445,599,o),
+(445,478,cs),
+(445,0,l)
+);
+}
+);
+width = 585;
+}
+);
+metricRight = "te-canadian";
+note = uni1489;
+unicode = 5257;
+},
+{
+glyphname = "caai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (173,0);
+ref = ring_top.canadian;
+}
+);
+width = 584;
+}
+);
+note = uni148A;
+unicode = 5258;
+},
+{
+glyphname = "ci-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (314,434);
+},
+{
+name = top_center_can;
+pos = (297,714);
+},
+{
+name = top_left_can;
+pos = (108,714);
+},
+{
+name = top_right_can;
+pos = (484,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(140,0,l),
+(140,478,ls),
+(140,599,o),
+(196,670,o),
+(296,670,cs),
+(396,670,o),
+(451,600,o),
+(451,479,cs),
+(451,405,l),
+(514,405,l),
+(514,474,ls),
+(514,630,o),
+(434,727,o),
+(297,727,cs),
+(157,727,o),
+(76,630,o),
+(76,471,cs),
+(76,0,l)
+);
+}
+);
+width = 584;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+unicode = 5259;
+},
+{
+glyphname = "cii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (233,0);
+ref = dot_top;
+}
+);
+width = 584;
+}
+);
+note = uni148C;
+unicode = 5260;
+},
+{
+glyphname = "co-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (311,434);
+},
+{
+name = top_center_can;
+pos = (290,714);
+},
+{
+name = top_double;
+pos = (477,714);
+},
+{
+name = top_left_can;
+pos = (102,714);
+},
+{
+name = top_right_can;
+pos = (477,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(427,-13,o),
+(509,81,o),
+(509,243,cs),
+(509,714,l),
+(445,714,l),
+(445,236,ls),
+(445,112,o),
+(388,44,o),
+(291,44,cs),
+(188,44,o),
+(133,114,o),
+(133,238,cs),
+(133,309,l),
+(70,309,l),
+(70,239,ls),
+(70,83,o),
+(150,-13,o),
+(292,-13,cs)
+);
+}
+);
+width = 585;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+unicode = 5261;
+},
+{
+glyphname = "coo-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (413,0);
+ref = dot_top;
+}
+);
+width = 584;
+}
+);
+note = uni148E;
+unicode = 5262;
+},
+{
+glyphname = "ycreecoo-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (251,0);
+ref = doubledot_top;
+}
+);
+width = 584;
+}
+);
+note = uni148F;
+unicode = 5263;
+},
+{
+glyphname = "ca-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (314,434);
+},
+{
+name = top_center_can;
+pos = (297,714);
+},
+{
+name = top_left_can;
+pos = (108,714);
+},
+{
+name = top_right_can;
+pos = (484,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(434,-13,o),
+(514,82,o),
+(514,240,cs),
+(514,309,l),
+(451,309,l),
+(451,237,ls),
+(451,112,o),
+(397,44,o),
+(296,44,cs),
+(195,44,o),
+(140,114,o),
+(140,237,cs),
+(140,714,l),
+(76,714,l),
+(76,242,ls),
+(76,81,o),
+(156,-13,o),
+(296,-13,cs)
+);
+}
+);
+width = 584;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+unicode = 5264;
+},
+{
+glyphname = "caa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (44,0);
+ref = dot_top;
+}
+);
+width = 584;
+}
+);
+note = uni1491;
+unicode = 5265;
+},
+{
+glyphname = "cwe-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ce-canadian";
+}
+);
+width = 804;
+}
+);
+note = uni1492;
+unicode = 5266;
+},
+{
+glyphname = "cweWestCree-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (584,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 804;
+}
+);
+note = uni1493;
+unicode = 5267;
+},
+{
+glyphname = "cwi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ci-canadian";
+}
+);
+width = 804;
+}
+);
+note = uni1494;
+unicode = 5268;
+},
+{
+glyphname = "cwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (584,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 804;
+}
+);
+note = uni1495;
+unicode = 5269;
+},
+{
+glyphname = "cwii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (453,0);
+ref = dot_top;
+}
+);
+width = 804;
+}
+);
+note = uni1496;
+unicode = 5270;
+},
+{
+glyphname = "cwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (233,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (584,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 804;
+}
+);
+note = uni1497;
+unicode = 5271;
+},
+{
+glyphname = "cwo-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "co-canadian";
+}
+);
+width = 804;
+}
+);
+note = uni1498;
+unicode = 5272;
+},
+{
+glyphname = "cwoWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (584,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 804;
+}
+);
+note = uni1499;
+unicode = 5273;
+},
+{
+glyphname = "cwoo-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (633,0);
+ref = dot_top;
+}
+);
+width = 804;
+}
+);
+note = uni149A;
+unicode = 5274;
+},
+{
+glyphname = "cwooWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (413,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (584,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 804;
+}
+);
+note = uni149B;
+unicode = 5275;
+},
+{
+glyphname = "cwa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ca-canadian";
+}
+);
+width = 804;
+}
+);
+note = uni149C;
+unicode = 5276;
+},
+{
+glyphname = "cwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (584,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 804;
+}
+);
+note = uni149D;
+unicode = 5277;
+},
+{
+glyphname = "cwaa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (264,0);
+ref = dot_top;
+}
+);
+width = 804;
+}
+);
+note = uni149E;
+unicode = 5278;
+},
+{
+glyphname = "cwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (44,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (584,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 804;
+}
+);
+note = uni149F;
+unicode = 5279;
+},
+{
+glyphname = "cwaaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (221,0);
+ref = "ca-canadian";
+}
+);
+width = 805;
+}
+);
+note = uni14A0;
+unicode = 5280;
+},
+{
+glyphname = "c-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(264,351,o),
+(315,398,o),
+(315,481,cs),
+(315,502,l),
+(270,502,l),
+(270,476,ls),
+(270,420,o),
+(240,391,o),
+(193,391,cs),
+(145,391,o),
+(118,420,o),
+(118,484,cs),
+(118,714,l),
+(69.995,714,l),
+(70,489,ls),
+(70,398,o),
+(117,351,o),
+(193,351,cs)
+);
+}
+);
+width = 364;
+}
+);
+note = uni14A1;
+unicode = 5281;
+},
+{
+glyphname = "thSayisi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(247,351,o),
+(294,398,o),
+(294,489,cs),
+(294,714,l),
+(246,714,l),
+(246,484,ls),
+(246,420,o),
+(219,391,o),
+(171,391,cs),
+(124,391,o),
+(94,420,o),
+(94,476,cs),
+(94,502,l),
+(49,502,l),
+(49,481,ls),
+(49,398,o),
+(100,351,o),
+(171,351,cs)
+);
+}
+);
+width = 364;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "=|c-canadian";
+note = uni14A2;
+unicode = 5282;
+},
+{
+glyphname = "me-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (208,357);
+},
+{
+name = top_center_can;
+pos = (241,714);
+},
+{
+name = top_left_can;
+pos = (75,714);
+},
+{
+name = top_right_can;
+pos = (405,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(437,0,l),
+(437,714,l),
+(43,714,l),
+(43,656,l),
+(373,656,l),
+(373,0,l)
+);
+}
+);
+width = 520;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+unicode = 5283;
+},
+{
+glyphname = "maai-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (156,0);
+ref = ring_top.canadian;
+}
+);
+width = 520;
+}
+);
+note = uni14A4;
+unicode = 5284;
+},
+{
+glyphname = "mi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (313,357);
+},
+{
+name = top_center_can;
+pos = (280,714);
+},
+{
+name = top_left_can;
+pos = (116,714);
+},
+{
+name = top_right_can;
+pos = (445,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(147,0,l),
+(147,656,l),
+(477,656,l),
+(477,714,l),
+(83,714,l),
+(83,0,l)
+);
+}
+);
+width = 520;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+unicode = 5285;
+},
+{
+glyphname = "mii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (216,0);
+ref = dot_top;
+}
+);
+width = 520;
+}
+);
+note = uni14A6;
+unicode = 5286;
+},
+{
+glyphname = "mo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (208,357);
+},
+{
+name = top_center_can;
+pos = (241,714);
+},
+{
+name = top_double;
+pos = (405,714);
+},
+{
+name = top_left_can;
+pos = (75,714);
+},
+{
+name = top_right_can;
+pos = (405,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(437,0,l),
+(437,714,l),
+(373,714,l),
+(373,58,l),
+(43,58,l),
+(43,0,l)
+);
+}
+);
+width = 520;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+unicode = 5287;
+},
+{
+glyphname = "moo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (341,0);
+ref = dot_top;
+}
+);
+width = 520;
+}
+);
+note = uni14A8;
+unicode = 5288;
+},
+{
+glyphname = "ycreemoo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (179,0);
+ref = doubledot_top;
+}
+);
+width = 520;
+}
+);
+note = uni14A9;
+unicode = 5289;
+},
+{
+glyphname = "ma-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (313,357);
+},
+{
+name = top_center_can;
+pos = (280,714);
+},
+{
+name = top_left_can;
+pos = (116,714);
+},
+{
+name = top_right_can;
+pos = (445,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(477,0,l),
+(477,58,l),
+(147,58,l),
+(147,714,l),
+(83,714,l),
+(83,0,l)
+);
+}
+);
+width = 520;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+unicode = 5290;
+},
+{
+glyphname = "maa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+}
+);
+width = 520;
+}
+);
+note = uni14AB;
+unicode = 5291;
+},
+{
+glyphname = "mwe-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "me-canadian";
+}
+);
+width = 741;
+}
+);
+note = uni14AC;
+unicode = 5292;
+},
+{
+glyphname = "mweWestCree-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "me-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (520,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 741;
+}
+);
+note = uni14AD;
+unicode = 5293;
+},
+{
+glyphname = "mwi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "mi-canadian";
+}
+);
+width = 741;
+}
+);
+note = uni14AE;
+unicode = 5294;
+},
+{
+glyphname = "mwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (520,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 741;
+}
+);
+note = uni14AF;
+unicode = 5295;
+},
+{
+glyphname = "mwii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (436,0);
+ref = dot_top;
+}
+);
+width = 741;
+}
+);
+note = uni14B0;
+unicode = 5296;
+},
+{
+glyphname = "mwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (216,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (520,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 741;
+}
+);
+note = uni14B1;
+unicode = 5297;
+},
+{
+glyphname = "mwo-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "mo-canadian";
+}
+);
+width = 741;
+}
+);
+note = uni14B2;
+unicode = 5298;
+},
+{
+glyphname = "mwoWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (520,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 741;
+}
+);
+note = uni14B3;
+unicode = 5299;
+},
+{
+glyphname = "mwoo-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (561,0);
+ref = dot_top;
+}
+);
+width = 741;
+}
+);
+note = uni14B4;
+unicode = 5300;
+},
+{
+glyphname = "mwooWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (341,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (520,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 741;
+}
+);
+note = uni14B5;
+unicode = 5301;
+},
+{
+glyphname = "mwa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ma-canadian";
+}
+);
+width = 741;
+}
+);
+note = uni14B6;
+unicode = 5302;
+},
+{
+glyphname = "mwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (520,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 741;
+}
+);
+note = uni14B7;
+unicode = 5303;
+},
+{
+glyphname = "mwaa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (272,0);
+ref = dot_top;
+}
+);
+width = 741;
+}
+);
+note = uni14B8;
+unicode = 5304;
+},
+{
+glyphname = "mwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (520,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 741;
+}
+);
+note = uni14B9;
+unicode = 5305;
+},
+{
+glyphname = "mwaaNaskapi-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (221,0);
+ref = "ma-canadian";
+}
+);
+width = 741;
+}
+);
+note = uni14BA;
+unicode = 5306;
+},
+{
+glyphname = "m-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(286,401,l),
+(118,401,l),
+(118,714,l),
+(69.995,714,l),
+(69.995,357,l),
+(286,357,l)
+);
+}
+);
+width = 337;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni14BB;
+unicode = 5307;
+},
+{
+glyphname = "mWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+ref = "t-canadian";
+}
+);
+width = 374;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "t-canadian";
+note = uni14BC;
+unicode = 5308;
+},
+{
+glyphname = "mh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(268,357,l),
+(268,714,l),
+(221,714,l),
+(221,401,l),
+(51,401,l),
+(51,357,l)
+);
+}
+);
+width = 338;
+}
+);
+metricLeft = "=|m-canadian";
+metricRight = "=|m-canadian";
+note = uni14BD;
+unicode = 5309;
+},
+{
+glyphname = "mAthapascan-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(304,357,l),
+(304,397,l),
+(125,397,l),
+(125,375,l),
+(238,499,ls),
+(274,540,o),
+(285,575,o),
+(285,616,cs),
+(285,678,o),
+(243,720,o),
+(176,720,cs),
+(104,720,o),
+(61,672,o),
+(61,594,c),
+(104,594,l),
+(104,654,o),
+(129,682,o),
+(176,682,cs),
+(219,682,o),
+(242,658,o),
+(242,615,cs),
+(242,579,o),
+(233,554,o),
+(198,514,cs),
+(75,379,l),
+(75,357,l)
+);
+}
+);
+width = 357;
+}
+);
+note = uni14BE;
+unicode = 5310;
+},
+{
+glyphname = "mSayisi-canadian";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = two.canadian;
+}
+);
+width = 581;
+}
+);
+note = uni14BF;
+unicode = 5311;
+},
+{
+glyphname = "ne-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (518,254);
+},
+{
+name = top_center_can;
+pos = (509,507);
+},
+{
+name = top_left_can;
+pos = (96,507);
+},
+{
+name = top_right_can;
+pos = (714,507);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(655,-13,o),
+(745,83,o),
+(745,239,cs),
+(745,394,o),
+(657,489,o),
+(509,489,cs),
+(64,489,l),
+(64,431,l),
+(413,431,l),
+(407,447,l),
+(330,415,o),
+(291,331,o),
+(291,236,cs),
+(291,82,o),
+(380,-13,o),
+(518,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(414,43,o),
+(354,116,o),
+(354,238,cs),
+(354,357,o),
+(414,433,o),
+(516,433,cs),
+(621,433,o),
+(682,360,o),
+(682,238,cs),
+(682,117,o),
+(622,43,o),
+(518,43,cs)
+);
+}
+);
+width = 815;
+}
+);
+metricRight = "=|ke-canadian";
+note = uni14C0;
+unicode = 5312;
+},
+{
+glyphname = "naai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (183,-207);
+ref = ring_top.canadian;
+}
+);
+width = 815;
+}
+);
+note = uni14C1;
+unicode = 5313;
+},
+{
+glyphname = "ni-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (298,254);
+},
+{
+name = top_center_can;
+pos = (307,507);
+},
+{
+name = top_left_can;
+pos = (102,507);
+},
+{
+name = top_right_can;
+pos = (720,507);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(436,-13,o),
+(524,82,o),
+(524,237,cs),
+(524,332,o),
+(485,416,o),
+(407,448,c),
+(403,431,l),
+(751,431,l),
+(751,489,l),
+(306,489,ls),
+(157,489,o),
+(70,391,o),
+(70,237,cs),
+(70,83,o),
+(160,-13,o),
+(297,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(193,43,o),
+(133,117,o),
+(133,238,cs),
+(133,360,o),
+(194,433,o),
+(299,433,cs),
+(401,433,o),
+(461,358,o),
+(461,238,cs),
+(461,116,o),
+(402,43,o),
+(297,43,cs)
+);
+}
+);
+width = 815;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+unicode = 5314;
+},
+{
+glyphname = "nii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (243,-207);
+ref = dot_top;
+}
+);
+width = 815;
+}
+);
+note = uni14C3;
+unicode = 5315;
+},
+{
+glyphname = "no-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (517,254);
+},
+{
+name = top_center_can;
+pos = (514,507);
+},
+{
+name = top_double;
+pos = (518,507);
+},
+{
+name = top_left_can;
+pos = (96,507);
+},
+{
+name = top_right_can;
+pos = (714,507);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(512,0,ls),
+(658,0,o),
+(745,95,o),
+(745,250,cs),
+(745,406,o),
+(656,501,o),
+(518,501,cs),
+(380,501,o),
+(291,406,o),
+(291,252,cs),
+(291,158,o),
+(330,74,o),
+(406,41,c),
+(413,58,l),
+(64,58,l),
+(64,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(414,56,o),
+(354,131,o),
+(354,250,cs),
+(354,373,o),
+(414,445,o),
+(518,445,cs),
+(622,445,o),
+(682,372,o),
+(682,250,cs),
+(682,128,o),
+(621,56,o),
+(516,56,cs)
+);
+}
+);
+width = 815;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14C4;
+unicode = 5316;
+},
+{
+glyphname = "noo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (449,-207);
+ref = dot_top;
+}
+);
+width = 815;
+}
+);
+note = uni14C5;
+unicode = 5317;
+},
+{
+glyphname = "ycreenoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (292,-207);
+ref = doubledot_top;
+}
+);
+width = 815;
+}
+);
+note = uni14C6;
+unicode = 5318;
+},
+{
+glyphname = "na-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (298,254);
+},
+{
+name = top_center_can;
+pos = (301,507);
+},
+{
+name = top_double;
+pos = (447,507);
+},
+{
+name = top_left_can;
+pos = (102,507);
+},
+{
+name = top_right_can;
+pos = (720,507);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(751,0,l),
+(751,58,l),
+(403,58,l),
+(408,41,l),
+(485,73,o),
+(524,157,o),
+(524,252,cs),
+(524,407,o),
+(436,501,o),
+(297,501,cs),
+(160,501,o),
+(70,406,o),
+(70,250,cs),
+(70,96,o),
+(157,0,o),
+(304,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(194,56,o),
+(133,128,o),
+(133,250,cs),
+(133,372,o),
+(193,445,o),
+(297,445,cs),
+(402,445,o),
+(461,373,o),
+(461,250,cs),
+(461,131,o),
+(401,56,o),
+(299,56,cs)
+);
+}
+);
+width = 815;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+unicode = 5319;
+},
+{
+glyphname = "naa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (237,-207);
+ref = dot_top;
+}
+);
+width = 815;
+}
+);
+note = uni14C8;
+unicode = 5320;
+},
+{
+glyphname = "nwe-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ne-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni14C9;
+unicode = 5321;
+},
+{
+glyphname = "nweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (815,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni14CA;
+unicode = 5322;
+},
+{
+glyphname = "nwa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "na-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni14CB;
+unicode = 5323;
+},
+{
+glyphname = "nwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (815,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni14CC;
+unicode = 5324;
+},
+{
+glyphname = "nwaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (457,-207);
+ref = dot_top;
+}
+);
+width = 1036;
+}
+);
+note = uni14CD;
+unicode = 5325;
+},
+{
+glyphname = "nwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (237,-207);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (815,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni14CE;
+unicode = 5326;
+},
+{
+glyphname = "nwaaNaskapi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (221,-207);
+ref = doubledot_top;
+}
+);
+width = 815;
+}
+);
+note = uni14CF;
+unicode = 5327;
+},
+{
+glyphname = "n-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(433,449,l),
+(433,494,l),
+(238,494,l),
+(240,473,l),
+(279,487,o),
+(302,535,o),
+(302,587,cs),
+(302,669,o),
+(253,720,o),
+(181,720,cs),
+(110,720,o),
+(60,669,o),
+(60,586,cs),
+(60,503,o),
+(109,449,o),
+(187,449,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(135,487,o),
+(103,524,o),
+(103,586,cs),
+(103,647,o),
+(135,683,o),
+(182,683,cs),
+(228,683,o),
+(259,647,o),
+(259,585,cs),
+(259,523,o),
+(228,487,o),
+(181,487,cs)
+);
+}
+);
+width = 484;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni14D0;
+unicode = 5328;
+},
+{
+color = 6;
+glyphname = "ngCarrier-canadian";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-167);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 425;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "=|";
+note = uni14D1;
+unicode = 5329;
+},
+{
+glyphname = "nh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(298,449,ls),
+(376,449,o),
+(425,503,o),
+(425,586,cs),
+(425,669,o),
+(375,720,o),
+(304,720,cs),
+(232,720,o),
+(182,669,o),
+(182,587,cs),
+(182,535,o),
+(206,487,o),
+(245,473,c),
+(247,494,l),
+(51,494,l),
+(51,449,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(257,487,o),
+(226,523,o),
+(226,585,cs),
+(226,647,o),
+(257,683,o),
+(303,683,cs),
+(350,683,o),
+(382,647,o),
+(382,586,cs),
+(382,524,o),
+(350,487,o),
+(304,487,cs)
+);
+}
+);
+width = 485;
+}
+);
+metricLeft = "=|n-canadian";
+metricRight = "=|n-canadian";
+note = uni14D2;
+unicode = 5330;
+},
+{
+glyphname = "le-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (517,254);
+},
+{
+name = top_center_can;
+pos = (509,507);
+},
+{
+name = top_left_can;
+pos = (96,507);
+},
+{
+name = top_right_can;
+pos = (714,507);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(500,0,ls),
+(652,0,o),
+(745,93,o),
+(745,244,cs),
+(745,396,o),
+(657,489,o),
+(497,489,cs),
+(64,489,l),
+(64,430,l),
+(498,430,ls),
+(617,430,o),
+(682,362,o),
+(682,243,cs),
+(682,126,o),
+(615,57,o),
+(497,57,cs),
+(454,57,l),
+(454,0,l)
+);
+}
+);
+width = 815;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D3;
+unicode = 5331;
+},
+{
+glyphname = "laai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (183,-207);
+ref = ring_top.canadian;
+}
+);
+width = 815;
+}
+);
+note = uni14D4;
+unicode = 5332;
+},
+{
+glyphname = "li-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (298,254);
+},
+{
+name = top_center_can;
+pos = (307,507);
+},
+{
+name = top_left_can;
+pos = (102,507);
+},
+{
+name = top_right_can;
+pos = (720,507);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(362,0,l),
+(362,57,l),
+(320,57,ls),
+(198,57,o),
+(134,126,o),
+(134,242,cs),
+(134,356,o),
+(192,430,o),
+(319,430,cs),
+(751,430,l),
+(751,489,l),
+(318,489,ls),
+(156,489,o),
+(70,390,o),
+(70,243,cs),
+(70,93,o),
+(162,0,o),
+(315,0,cs)
+);
+}
+);
+width = 815;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14D5;
+unicode = 5333;
+},
+{
+glyphname = "lii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (243,-207);
+ref = dot_top;
+}
+);
+width = 815;
+}
+);
+note = uni14D6;
+unicode = 5334;
+},
+{
+glyphname = "lo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (517,254);
+},
+{
+name = top_center_can;
+pos = (514,507);
+},
+{
+name = top_double;
+pos = (500,507);
+},
+{
+name = top_left_can;
+pos = (96,507);
+},
+{
+name = top_right_can;
+pos = (714,507);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(495,0,ls),
+(655,0,o),
+(745,93,o),
+(745,245,cs),
+(745,396,o),
+(653,489,o),
+(500,489,cs),
+(454,489,l),
+(454,431,l),
+(496,431,ls),
+(617,431,o),
+(682,363,o),
+(682,245,cs),
+(682,127,o),
+(617,58,o),
+(496,58,cs),
+(64,58,l),
+(64,0,l)
+);
+}
+);
+width = 815;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D7;
+unicode = 5335;
+},
+{
+glyphname = "loo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (449,-207);
+ref = dot_top;
+}
+);
+width = 815;
+}
+);
+note = uni14D8;
+unicode = 5336;
+},
+{
+glyphname = "ycreeloo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (274,-207);
+ref = doubledot_top;
+}
+);
+width = 815;
+}
+);
+note = uni14D9;
+unicode = 5337;
+},
+{
+glyphname = "la-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (298,254);
+},
+{
+name = top_center_can;
+pos = (301,507);
+},
+{
+name = top_left_can;
+pos = (102,507);
+},
+{
+name = top_right_can;
+pos = (720,507);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(751,0,l),
+(751,58,l),
+(322,58,ls),
+(200,58,o),
+(134,126,o),
+(134,246,cs),
+(134,363,o),
+(197,431,o),
+(317,431,cs),
+(362,431,l),
+(362,489,l),
+(317,489,ls),
+(159,489,o),
+(70,395,o),
+(70,245,cs),
+(70,91,o),
+(162,0,o),
+(321,0,cs)
+);
+}
+);
+width = 815;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14DA;
+unicode = 5338;
+},
+{
+glyphname = "laa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (237,-207);
+ref = dot_top;
+}
+);
+width = 815;
+}
+);
+note = uni14DB;
+unicode = 5339;
+},
+{
+glyphname = "lwe-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "le-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni14DC;
+unicode = 5340;
+},
+{
+glyphname = "lweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "le-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (815,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni14DD;
+unicode = 5341;
+},
+{
+glyphname = "lwi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "li-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni14DE;
+unicode = 5342;
+},
+{
+glyphname = "lwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (815,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni14DF;
+unicode = 5343;
+},
+{
+glyphname = "lwii-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (463,-207);
+ref = dot_top;
+}
+);
+width = 1036;
+}
+);
+note = uni14E0;
+unicode = 5344;
+},
+{
+glyphname = "lwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (243,-207);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (815,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni14E1;
+unicode = 5345;
+},
+{
+glyphname = "lwo-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "lo-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni14E2;
+unicode = 5346;
+},
+{
+glyphname = "lwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (815,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni14E3;
+unicode = 5347;
+},
+{
+glyphname = "lwoo-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (670,-207);
+ref = dot_top;
+}
+);
+width = 1036;
+}
+);
+note = uni14E4;
+unicode = 5348;
+},
+{
+glyphname = "lwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (449,-207);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (815,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni14E5;
+unicode = 5349;
+},
+{
+glyphname = "lwa-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "la-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni14E6;
+unicode = 5350;
+},
+{
+glyphname = "lwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (815,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni14E7;
+unicode = 5351;
+},
+{
+glyphname = "lwaa-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (457,-207);
+ref = dot_top;
+}
+);
+width = 1036;
+}
+);
+note = uni14E8;
+unicode = 5352;
+},
+{
+glyphname = "lwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (237,-207);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (815,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni14E9;
+unicode = 5353;
+},
+{
+glyphname = "l-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(433,357,l),
+(433,401,l),
+(248,401,ls),
+(159,401,o),
+(115,449,o),
+(115,536,cs),
+(115,622,o),
+(159,670,o),
+(245,670,cs),
+(259,670,l),
+(259,714,l),
+(242,714,ls),
+(130,714,o),
+(68,646,o),
+(68,535,cs),
+(68,425,o),
+(130,357,o),
+(244,357,cs)
+);
+}
+);
+width = 484;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "m-canadian";
+note = uni14EA;
+unicode = 5354;
+},
+{
+glyphname = "lWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(312,357,l),
+(312,389,l),
+(108,470,l),
+(108,447,l),
+(312,523,l),
+(312,547,l),
+(108,624,l),
+(108,601,l),
+(312,682,l),
+(312,714,l),
+(301,714,l),
+(70,623,l),
+(70,603,l),
+(275,526,l),
+(275,544,l),
+(70,468,l),
+(70,448,l),
+(301,357,l)
+);
+}
+);
+width = 382;
+}
+);
+metricRight = "=|";
+note = uni14EB;
+unicode = 5355;
+},
+{
+glyphname = "mediall-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(580,-13,l),
+(580,35,l),
+(137,207,l),
+(137,177,l),
+(580,340,l),
+(580,373,l),
+(137,537,l),
+(137,508,l),
+(580,680,l),
+(580,727,l),
+(561,727,l),
+(78,539,l),
+(78,508,l),
+(521,344,l),
+(521,369,l),
+(78,206,l),
+(78,175,l),
+(561,-13,l)
+);
+}
+);
+width = 658;
+}
+);
+metricRight = "=|";
+note = uni14EC;
+unicode = 5356;
+},
+{
+glyphname = "se-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (112,714);
+},
+{
+name = top_right_can;
+pos = (420,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(452,0,l),
+(452,325,l),
+(414,325,ls),
+(237,325,o),
+(144,418,o),
+(144,607,cs),
+(144,714,l),
+(80,714,l),
+(80,601,ls),
+(80,387,o),
+(200,267,o),
+(403,267,cs),
+(433,267,l),
+(388,293,l),
+(388,0,l)
+);
+}
+);
+width = 535;
+}
+);
+note = uni14ED;
+unicode = 5357;
+},
+{
+glyphname = "saai-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (299,0);
+ref = ring_top.canadian;
+}
+);
+width = 535;
+}
+);
+note = uni14EE;
+unicode = 5358;
+},
+{
+glyphname = "si-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (116,714);
+},
+{
+name = top_right_can;
+pos = (423,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(147,0,l),
+(147,293,l),
+(102,267,l),
+(132,267,ls),
+(335,267,o),
+(455,387,o),
+(455,601,cs),
+(455,714,l),
+(391,714,l),
+(391,607,ls),
+(391,418,o),
+(298,325,o),
+(121,325,cs),
+(83,325,l),
+(83,0,l)
+);
+}
+);
+width = 535;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+unicode = 5359;
+},
+{
+glyphname = "sii-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (359,0);
+ref = dot_top;
+}
+);
+width = 535;
+}
+);
+note = uni14F0;
+unicode = 5360;
+},
+{
+glyphname = "so-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (420,714);
+},
+{
+name = top_left_can;
+pos = (112,714);
+},
+{
+name = top_right_can;
+pos = (420,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(144,0,l),
+(144,107,ls),
+(144,296,o),
+(237,389,o),
+(414,389,cs),
+(452,389,l),
+(452,714,l),
+(388,714,l),
+(388,421,l),
+(433,447,l),
+(403,447,ls),
+(200,447,o),
+(80,327,o),
+(80,113,cs),
+(80,0,l)
+);
+}
+);
+width = 535;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+unicode = 5361;
+},
+{
+glyphname = "soo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (356,0);
+ref = dot_top;
+}
+);
+width = 535;
+}
+);
+note = uni14F2;
+unicode = 5362;
+},
+{
+glyphname = "ycreesoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (194,0);
+ref = doubledot_top;
+}
+);
+width = 535;
+}
+);
+note = uni14F3;
+unicode = 5363;
+},
+{
+glyphname = "sa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (116,714);
+},
+{
+name = top_right_can;
+pos = (423,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(455,0,l),
+(455,113,ls),
+(455,327,o),
+(335,447,o),
+(132,447,cs),
+(102,447,l),
+(147,421,l),
+(147,714,l),
+(83,714,l),
+(83,389,l),
+(121,389,ls),
+(298,389,o),
+(391,296,o),
+(391,107,cs),
+(391,0,l)
+);
+}
+);
+width = 535;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+unicode = 5364;
+},
+{
+glyphname = "saa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+}
+);
+width = 535;
+}
+);
+note = uni14F5;
+unicode = 5365;
+},
+{
+glyphname = "swe-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "se-canadian";
+}
+);
+width = 755;
+}
+);
+note = uni14F6;
+unicode = 5366;
+},
+{
+glyphname = "sweWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "se-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (535,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 755;
+}
+);
+note = uni14F7;
+unicode = 5367;
+},
+{
+glyphname = "swi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "si-canadian";
+}
+);
+width = 755;
+}
+);
+note = uni14F8;
+unicode = 5368;
+},
+{
+glyphname = "swiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (535,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 755;
+}
+);
+note = uni14F9;
+unicode = 5369;
+},
+{
+glyphname = "swii-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (579,0);
+ref = dot_top;
+}
+);
+width = 755;
+}
+);
+note = uni14FA;
+unicode = 5370;
+},
+{
+glyphname = "swiiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (359,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (535,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 755;
+}
+);
+note = uni14FB;
+unicode = 5371;
+},
+{
+glyphname = "swo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "so-canadian";
+}
+);
+width = 755;
+}
+);
+note = uni14FC;
+unicode = 5372;
+},
+{
+glyphname = "swoWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (535,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 755;
+}
+);
+note = uni14FD;
+unicode = 5373;
+},
+{
+glyphname = "swoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (576,0);
+ref = dot_top;
+}
+);
+width = 755;
+}
+);
+note = uni14FE;
+unicode = 5374;
+},
+{
+glyphname = "swooWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (356,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (535,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 755;
+}
+);
+note = uni14FF;
+unicode = 5375;
+},
+{
+glyphname = "swa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "sa-canadian";
+}
+);
+width = 755;
+}
+);
+note = uni1500;
+unicode = 5376;
+},
+{
+glyphname = "swaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (535,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 755;
+}
+);
+note = uni1501;
+unicode = 5377;
+},
+{
+glyphname = "swaa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (272,0);
+ref = dot_top;
+}
+);
+width = 755;
+}
+);
+note = uni1502;
+unicode = 5378;
+},
+{
+glyphname = "swaaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (535,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 755;
+}
+);
+note = uni1503;
+unicode = 5379;
+},
+{
+glyphname = "swaaNaskapi-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (221,0);
+ref = "sa-canadian";
+}
+);
+width = 756;
+}
+);
+note = uni1504;
+unicode = 5380;
+},
+{
+glyphname = "s-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(287,357,l),
+(287,416,ls),
+(287,523,o),
+(230,593,o),
+(123,593,cs),
+(92,593,l),
+(118,568,l),
+(118,714,l),
+(69.995,714,l),
+(70,552,l),
+(108,552,ls),
+(199,552,o),
+(240,504,o),
+(240,413,cs),
+(240,357,l)
+);
+}
+);
+width = 357;
+}
+);
+metricRight = "=|";
+note = uni1505;
+unicode = 5381;
+},
+{
+color = 6;
+glyphname = "sAthapascan-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(267,183,o),
+(312,224,o),
+(312,279,cs),
+(312,323,o),
+(290,352,o),
+(240,371,cs),
+(166,397,ls),
+(130,412,o),
+(119,429,o),
+(119,455,cs),
+(119,491,o),
+(145,515,o),
+(193,515,cs),
+(242,515,o),
+(269,493,o),
+(270,444,c),
+(313,444,l),
+(312,510,o),
+(269,552,o),
+(193,552,cs),
+(120,552,o),
+(76,512,o),
+(76,456,cs),
+(76,412,o),
+(100,381,o),
+(147,363,cs),
+(220,336,ls),
+(256,322,o),
+(269,307,o),
+(269,278,cs),
+(269,241,o),
+(241,220,o),
+(193,220,cs),
+(142,220,o),
+(114,241,o),
+(113,294,c),
+(70,294,l),
+(71,223,o),
+(113,183,o),
+(192,183,cs)
+);
+}
+);
+width = 383;
+}
+);
+metricRight = "=|";
+note = uni1506;
+unicode = 5382;
+},
+{
+glyphname = "sw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(118,357,l),
+(118,413,ls),
+(118,504,o),
+(159,552,o),
+(250,552,cs),
+(287,552,l),
+(287,714,l),
+(240,714,l),
+(240,568,l),
+(266,593,l),
+(234,593,ls),
+(127,593,o),
+(70,523,o),
+(70,416,cs),
+(69.995,357,l)
+);
+}
+);
+width = 357;
+}
+);
+metricLeft = "=|s-canadian";
+metricRight = "=|s-canadian";
+note = uni1507;
+unicode = 5383;
+},
+{
+glyphname = "sBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(295,357,l),
+(295,401,l),
+(210,401,ls),
+(147,401,o),
+(118,431,o),
+(118,499,cs),
+(118,714,l),
+(69.995,714,l),
+(70,495,ls),
+(70,405,o),
+(116,357,o),
+(206,357,c)
+);
+}
+);
+width = 346;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "m-canadian";
+note = uni1508;
+unicode = 5384;
+},
+{
+glyphname = "moosecreesk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(262,225,o),
+(314,278,o),
+(314,374,cs),
+(314,516,o),
+(255,592,o),
+(129,592,cs),
+(98,592,l),
+(118,567,l),
+(118,714,l),
+(71,714,l),
+(71,552,l),
+(122,552,ls),
+(225,552,o),
+(258,502,o),
+(265,423,c),
+(282,414,l),
+(274,460,o),
+(236,495,o),
+(188,495,cs),
+(120,495,o),
+(70,444,o),
+(70,362,cs),
+(70,276,o),
+(123,225,o),
+(191,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(145,262,o),
+(113,299,o),
+(113,362,cs),
+(113,423,o),
+(145,459,o),
+(192,459,cs),
+(237,459,o),
+(270,423,o),
+(270,361,cs),
+(270,300,o),
+(241,262,o),
+(191,262,cs)
+);
+}
+);
+width = 384;
+}
+);
+metricRight = "=|";
+note = uni1509;
+unicode = 5385;
+},
+{
+glyphname = "skwNaskapi-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(261,225,o),
+(314,276,o),
+(314,362,cs),
+(314,444,o),
+(264,495,o),
+(196,495,cs),
+(147,495,o),
+(110,460,o),
+(102,414,c),
+(119,423,l),
+(126,502,o),
+(159,552,o),
+(262,552,cs),
+(313,552,l),
+(313,714,l),
+(265,714,l),
+(265,567,l),
+(286,592,l),
+(255,592,ls),
+(129,592,o),
+(70,516,o),
+(70,374,cs),
+(70,278,o),
+(122,225,o),
+(192,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(144,262,o),
+(114,300,o),
+(114,361,cs),
+(114,423,o),
+(147,459,o),
+(192,459,cs),
+(238,459,o),
+(270,423,o),
+(270,362,cs),
+(270,299,o),
+(239,262,o),
+(192,262,cs)
+);
+}
+);
+width = 384;
+}
+);
+metricLeft = "=|moosecreesk-canadian";
+metricRight = "=|moosecreesk-canadian";
+note = uni150A;
+unicode = 5386;
+},
+{
+glyphname = "swNaskapi-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(305,184,l),
+(305,240,ls),
+(305,344,o),
+(248,413,o),
+(141,413,cs),
+(111.999,412.992,l),
+(132,389,l),
+(132,531,l),
+(85,531,l),
+(85,373,l),
+(126,373,ls),
+(216,373,o),
+(258,327,o),
+(258,237,cs),
+(258,184,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(305,64,o),
+(324,83,o),
+(324,108,cs),
+(324,132,o),
+(305,151,o),
+(281,151,cs),
+(258,151,o),
+(238,132,o),
+(238,108,cs),
+(238,83,o),
+(258,64,o),
+(281,64,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(132,564,o),
+(152,583,o),
+(152,607,cs),
+(152,631,o),
+(132,650,o),
+(108,650,cs),
+(85,650,o),
+(65,631,o),
+(65,607,cs),
+(65,583,o),
+(85,564,o),
+(108,564,cs)
+);
+}
+);
+width = 389;
+}
+);
+metricRight = "=|";
+note = uni150B;
+unicode = 5387;
+},
+{
+glyphname = "spwaNaskapi-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(598,0,l),
+(598,58,l),
+(103,372,l),
+(103,342,l),
+(598,656,l),
+(598,714,l),
+(579,714,l),
+(38,371,l),
+(38,343,l),
+(579,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(159,506,o),
+(178,525,o),
+(178,549,cs),
+(178,574,o),
+(159,593,o),
+(135,593,cs),
+(112,593,o),
+(92,574,o),
+(92,549,cs),
+(92,525,o),
+(112,506,o),
+(135,506,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(341,618,l),
+(341,661,ls),
+(341,737,o),
+(301,786,o),
+(223,786,cs),
+(200,786,l),
+(227,766,l),
+(227,866,l),
+(181,866,l),
+(181,748,l),
+(210,748,ls),
+(269,748,o),
+(294,716,o),
+(294,659,cs),
+(294,618,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(505,724,o),
+(525,742,o),
+(525,767,cs),
+(525,791,o),
+(505,810,o),
+(481,810,cs),
+(458,810,o),
+(438,791,o),
+(438,767,cs),
+(438,742,o),
+(458,724,o),
+(481,724,cs)
+);
+}
+);
+width = 657;
+}
+);
+metricRight = "pa-canadian";
+metricWidth = "pa-canadian";
+note = uni150C;
+unicode = 5388;
+},
+{
+glyphname = "stwaNaskapi-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (390,0);
+ref = "ta-canadian";
+}
+);
+width = 996;
+}
+);
+note = uni150D;
+unicode = 5389;
+},
+{
+glyphname = "skwaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (390,0);
+ref = "ka-canadian";
+}
+);
+width = 978;
+}
+);
+note = uni150E;
+unicode = 5390;
+},
+{
+glyphname = "scwaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (390,0);
+ref = "ca-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni150F;
+unicode = 5391;
+},
+{
+glyphname = "she-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (284,714);
+},
+{
+name = top_right_can;
+pos = (688,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(779,-13,o),
+(857,79,o),
+(857,243,cs),
+(857,309,l),
+(793,309,l),
+(793,240,ls),
+(793,110,o),
+(742,44,o),
+(650,44,cs),
+(554,44,o),
+(510,111,o),
+(502,241,cs),
+(489,471,ls),
+(479,635,o),
+(413,727,o),
+(283,727,cs),
+(151,727,o),
+(71,634,o),
+(71,471,cs),
+(71,405,l),
+(135,405,l),
+(135,476,ls),
+(135,602,o),
+(188,670,o),
+(281,670,cs),
+(372,670,o),
+(419,602,o),
+(426,474,cs),
+(439,243,ls),
+(449,77,o),
+(515,-13,o),
+(649,-13,cs)
+);
+}
+);
+width = 928;
+}
+);
+metricRight = "=|";
+note = uni1510;
+unicode = 5392;
+},
+{
+glyphname = "shi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (243,714);
+},
+{
+name = top_right_can;
+pos = (647,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(414,-13,o),
+(479,77,o),
+(489,243,cs),
+(502,474,ls),
+(510,602,o),
+(556,670,o),
+(648,670,cs),
+(740,670,o),
+(793,602,o),
+(793,476,cs),
+(793,405,l),
+(857,405,l),
+(857,471,ls),
+(857,634,o),
+(777,727,o),
+(645,727,cs),
+(515,727,o),
+(449,635,o),
+(439,471,cs),
+(426,241,ls),
+(418,111,o),
+(374,44,o),
+(278,44,cs),
+(186,44,o),
+(135,110,o),
+(135,240,cs),
+(135,309,l),
+(71,309,l),
+(71,243,ls),
+(71,79,o),
+(149,-13,o),
+(280,-13,cs)
+);
+}
+);
+width = 928;
+}
+);
+metricLeft = "she-canadian";
+metricRight = "she-canadian";
+note = uni1511;
+unicode = 5393;
+},
+{
+glyphname = "shii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (583,0);
+ref = dot_top;
+}
+);
+width = 928;
+}
+);
+note = uni1512;
+unicode = 5394;
+},
+{
+glyphname = "sho-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (476,507);
+},
+{
+name = top_left_can;
+pos = (281,507);
+},
+{
+name = top_right_can;
+pos = (670,507);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(342,43,l),
+(205,43,o),
+(133,90,o),
+(133,180,cs),
+(133,251,o),
+(173,297,o),
+(260,297,cs),
+(396,297,o),
+(537,134,o),
+(696,134,cs),
+(813,134,o),
+(881,204,o),
+(881,307,cs),
+(881,431,o),
+(781,502,o),
+(612,501,c),
+(610,446,l),
+(747,446,o),
+(818,398,o),
+(818,309,cs),
+(818,238,o),
+(778,192,o),
+(691,192,cs),
+(556,192,o),
+(414,354,o),
+(255,354,cs),
+(138,354,o),
+(70,284,o),
+(70,182,cs),
+(70,57,o),
+(171,-13,o),
+(340,-13,c)
+);
+}
+);
+width = 951;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1513;
+unicode = 5395;
+},
+{
+glyphname = "shoo-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (411,-207);
+ref = dot_top;
+}
+);
+width = 951;
+}
+);
+note = uni1514;
+unicode = 5396;
+},
+{
+glyphname = "sha-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (476,507);
+},
+{
+name = top_left_can;
+pos = (281,507);
+},
+{
+name = top_right_can;
+pos = (671,507);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(781,-14,o),
+(881,57,o),
+(881,182,cs),
+(881,284,o),
+(814,354,o),
+(696,354,cs),
+(537,354,o),
+(396,192,o),
+(260,192,cs),
+(173,192,o),
+(133,238,o),
+(133,309,cs),
+(133,398,o),
+(205,447,o),
+(342,446,c),
+(340,501,l),
+(171,502,o),
+(70,431,o),
+(70,307,cs),
+(70,204,o),
+(137,134,o),
+(255,134,cs),
+(414,134,o),
+(556,297,o),
+(691,297,cs),
+(778,297,o),
+(818,251,o),
+(818,180,cs),
+(818,90,o),
+(747,42,o),
+(610,43,c),
+(612,-13,l)
+);
+}
+);
+width = 951;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1515;
+unicode = 5397;
+},
+{
+glyphname = "shaa-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (412,-207);
+ref = dot_top;
+}
+);
+width = 951;
+}
+);
+note = uni1516;
+unicode = 5398;
+},
+{
+glyphname = "shwe-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "she-canadian";
+}
+);
+width = 1148;
+}
+);
+note = uni1517;
+unicode = 5399;
+},
+{
+glyphname = "shweWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "she-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (928,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1148;
+}
+);
+note = uni1518;
+unicode = 5400;
+},
+{
+glyphname = "shwi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "shi-canadian";
+}
+);
+width = 1148;
+}
+);
+note = uni1519;
+unicode = 5401;
+},
+{
+glyphname = "shwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (928,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1148;
+}
+);
+note = uni151A;
+unicode = 5402;
+},
+{
+glyphname = "shwii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (803,0);
+ref = dot_top;
+}
+);
+width = 1148;
+}
+);
+note = uni151B;
+unicode = 5403;
+},
+{
+glyphname = "shwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (583,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (928,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1148;
+}
+);
+note = uni151C;
+unicode = 5404;
+},
+{
+glyphname = "shwo-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "sho-canadian";
+}
+);
+width = 1172;
+}
+);
+note = uni151D;
+unicode = 5405;
+},
+{
+glyphname = "shwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (951,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1172;
+}
+);
+note = uni151E;
+unicode = 5406;
+},
+{
+glyphname = "shwoo-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (632,-207);
+ref = dot_top;
+}
+);
+width = 1172;
+}
+);
+note = uni151F;
+unicode = 5407;
+},
+{
+glyphname = "shwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (411,-207);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (951,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1172;
+}
+);
+note = uni1520;
+unicode = 5408;
+},
+{
+glyphname = "shwa-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "sha-canadian";
+}
+);
+width = 1172;
+}
+);
+note = uni1521;
+unicode = 5409;
+},
+{
+glyphname = "shwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (951,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1172;
+}
+);
+note = uni1522;
+unicode = 5410;
+},
+{
+glyphname = "shwaa-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (632,-207);
+ref = dot_top;
+}
+);
+width = 1172;
+}
+);
+note = uni1523;
+unicode = 5411;
+},
+{
+glyphname = "shwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (412,-207);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (951,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1172;
+}
+);
+note = uni1524;
+unicode = 5412;
+},
+{
+glyphname = "sh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(587,301,o),
+(664,357,o),
+(664,455,cs),
+(664,533,o),
+(610,589,o),
+(522,589,cs),
+(402,589,o),
+(316,479,o),
+(213,479,cs),
+(151,479,o),
+(116,513,o),
+(116,568,cs),
+(116,638,o),
+(172,678,o),
+(273,678,c),
+(271,722,l),
+(146,722,o),
+(68,665,o),
+(68,567,cs),
+(68,489,o),
+(123,433,o),
+(210,433,cs),
+(330,433,o),
+(417,544,o),
+(519,544,cs),
+(582,544,o),
+(616,509,o),
+(616,454,cs),
+(616,384,o),
+(560,344,o),
+(459,344,c),
+(461,301,l)
+);
+}
+);
+width = 732;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni1525;
+unicode = 5413;
+},
+{
+glyphname = "ye-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (632,357);
+},
+{
+name = top_left_can;
+pos = (81,714);
+},
+{
+name = top_right_can;
+pos = (456,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(487,0,l),
+(487,321,l),
+(122,321,l),
+(125,288,l),
+(501,687,l),
+(457,726,l),
+(49,290,l),
+(49,264,l),
+(423,264,l),
+(423,0,l)
+);
+}
+);
+width = 569;
+}
+);
+note = uni1526;
+unicode = 5414;
+},
+{
+glyphname = "yaai-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-10,0);
+ref = ring_top.canadian;
+}
+);
+width = 569;
+}
+);
+note = uni1527;
+unicode = 5415;
+},
+{
+glyphname = "yi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (114,714);
+},
+{
+name = top_right_can;
+pos = (489,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(146,0,l),
+(146,264,l),
+(520,264,l),
+(520,290,l),
+(113,726,l),
+(70,687,l),
+(446,289,l),
+(447,321,l),
+(82,321,l),
+(82,0,l)
+);
+}
+);
+width = 569;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni1528;
+unicode = 5416;
+},
+{
+glyphname = "yii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+}
+);
+width = 569;
+}
+);
+note = uni1529;
+unicode = 5417;
+},
+{
+glyphname = "yo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (632,357);
+},
+{
+name = top_double;
+pos = (456,714);
+},
+{
+name = top_left_can;
+pos = (81,714);
+},
+{
+name = top_right_can;
+pos = (456,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(500,27,l),
+(124,425,l),
+(122,393,l),
+(487,393,l),
+(487,714,l),
+(423,714,l),
+(423,450,l),
+(49,450,l),
+(49,424,l),
+(457,-12,l)
+);
+}
+);
+width = 569;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152A;
+unicode = 5418;
+},
+{
+glyphname = "yoo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (391,0);
+ref = dot_top;
+}
+);
+width = 569;
+}
+);
+note = uni152B;
+unicode = 5419;
+},
+{
+glyphname = "ycreeyoo-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (230,0);
+ref = doubledot_top;
+}
+);
+width = 569;
+}
+);
+note = uni152C;
+unicode = 5420;
+},
+{
+glyphname = "ya-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (114,714);
+},
+{
+name = top_right_can;
+pos = (489,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(520,424,l),
+(520,450,l),
+(146,450,l),
+(146,714,l),
+(82,714,l),
+(82,393,l),
+(447,393,l),
+(445,426,l),
+(69,27,l),
+(113,-12,l)
+);
+}
+);
+width = 569;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152D;
+unicode = 5421;
+},
+{
+glyphname = "yaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+}
+);
+width = 569;
+}
+);
+note = uni152E;
+unicode = 5422;
+},
+{
+glyphname = "ywe-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ye-canadian";
+}
+);
+width = 790;
+}
+);
+note = uni152F;
+unicode = 5423;
+},
+{
+glyphname = "yweWestCree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ye-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (569,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 790;
+}
+);
+note = uni1530;
+unicode = 5424;
+},
+{
+glyphname = "ywi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "yi-canadian";
+}
+);
+width = 790;
+}
+);
+note = uni1531;
+unicode = 5425;
+},
+{
+glyphname = "ywiWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (569,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 790;
+}
+);
+note = uni1532;
+unicode = 5426;
+},
+{
+glyphname = "ywii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (270,0);
+ref = dot_top;
+}
+);
+width = 790;
+}
+);
+note = uni1533;
+unicode = 5427;
+},
+{
+glyphname = "ywiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (569,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 790;
+}
+);
+note = uni1534;
+unicode = 5428;
+},
+{
+glyphname = "ywo-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "yo-canadian";
+}
+);
+width = 790;
+}
+);
+note = uni1535;
+unicode = 5429;
+},
+{
+glyphname = "ywoWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (569,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 790;
+}
+);
+note = uni1536;
+unicode = 5430;
+},
+{
+glyphname = "ywoo-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (612,0);
+ref = dot_top;
+}
+);
+width = 790;
+}
+);
+note = uni1537;
+unicode = 5431;
+},
+{
+glyphname = "ywooWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (391,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (569,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 790;
+}
+);
+note = uni1538;
+unicode = 5432;
+},
+{
+glyphname = "ywa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ya-canadian";
+}
+);
+width = 790;
+}
+);
+note = uni1539;
+unicode = 5433;
+},
+{
+glyphname = "ywaWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (569,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 790;
+}
+);
+note = uni153A;
+unicode = 5434;
+},
+{
+glyphname = "ywaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (270,0);
+ref = dot_top;
+}
+);
+width = 790;
+}
+);
+note = uni153B;
+unicode = 5435;
+},
+{
+glyphname = "ywaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (50,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (569,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 790;
+}
+);
+note = uni153C;
+unicode = 5436;
+},
+{
+glyphname = "ywaaNaskapi-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (221,0);
+ref = "ya-canadian";
+}
+);
+width = 790;
+}
+);
+note = uni153D;
+unicode = 5437;
+},
+{
+glyphname = "y-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(303,565,l),
+(303,582,l),
+(119,582,l),
+(119,714,l),
+(71,714,l),
+(71,542,l),
+(255,542,l),
+(254,572,l),
+(70,375,l),
+(102,348,l)
+);
+}
+);
+width = 346;
+}
+);
+note = uni153E;
+unicode = 5438;
+},
+{
+glyphname = "biblecreey-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(176,661,l),
+(150,661,l),
+(248,357,l),
+(275,357,l),
+(373,661,l),
+(347,661,l),
+(419,357,l),
+(461,357,l),
+(461,370,l),
+(380,714,l),
+(348,714,l),
+(249,408,l),
+(274,408,l),
+(175,714,l),
+(143,714,l),
+(62,370,l),
+(62,357,l),
+(104,357,l)
+);
+}
+);
+width = 523;
+}
+);
+metricRight = "=|";
+note = uni153F;
+unicode = 5439;
+},
+{
+glyphname = "yWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(252,196,l),
+(252,342,l),
+(389,342,l),
+(389,387,l),
+(252,387,l),
+(252,531,l),
+(206,531,l),
+(206,387,l),
+(68,387,l),
+(68,342,l),
+(206,342,l),
+(206,196,l)
+);
+}
+);
+width = 457;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1540;
+unicode = 5440;
+},
+{
+glyphname = "yiSayisi-canadian";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,189);
+ref = "fullstop-canadian";
+}
+);
+width = 347;
+}
+);
+metricLeft = "fullstop-canadian";
+metricWidth = "fullstop-canadian";
+note = uni1541;
+unicode = 5441;
+},
+{
+glyphname = "re-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (300,507);
+},
+{
+name = top_left_can;
+pos = (112,507);
+},
+{
+name = top_right_can;
+pos = (764,507);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(439,-13,o),
+(519,82,o),
+(519,237,cs),
+(519,431,l),
+(796,431,l),
+(796,489,l),
+(456,489,l),
+(456,237,ls),
+(456,113,o),
+(402,44,o),
+(300,44,cs),
+(198,44,o),
+(143,114,o),
+(143,237,cs),
+(143,489,l),
+(79,489,l),
+(79,237,ls),
+(79,81,o),
+(161,-13,o),
+(300,-13,cs)
+);
+}
+);
+width = 860;
+}
+);
+metricRight = "=|ne-canadian";
+note = uni1542;
+unicode = 5442;
+},
+{
+glyphname = "reRCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (560,507);
+},
+{
+name = top_left_can;
+pos = (96,507);
+},
+{
+name = top_right_can;
+pos = (748,507);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(700,-13,o),
+(780,81,o),
+(780,237,cs),
+(780,489,l),
+(716,489,l),
+(716,237,ls),
+(716,114,o),
+(663,44,o),
+(561,44,cs),
+(459,44,o),
+(404,111,o),
+(404,234,cs),
+(404,489,l),
+(64,489,l),
+(64,431,l),
+(341,431,l),
+(341,235,ls),
+(341,80,o),
+(422,-13,o),
+(561,-13,cs)
+);
+}
+);
+width = 859;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1543;
+unicode = 5443;
+},
+{
+glyphname = "leWestCree-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (560,507);
+},
+{
+name = top_left_can;
+pos = (96,507);
+},
+{
+name = top_right_can;
+pos = (748,507);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(404,0,l),
+(404,251,ls),
+(404,375,o),
+(458,445,o),
+(560,445,cs),
+(662,445,o),
+(716,375,o),
+(716,252,cs),
+(716,0,l),
+(780,0,l),
+(780,252,ls),
+(780,407,o),
+(700,501,o),
+(561,501,cs),
+(422,501,o),
+(341,406,o),
+(341,250,cs),
+(341,58,l),
+(64,58,l),
+(64,0,l)
+);
+}
+);
+width = 859;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+unicode = 5444;
+},
+{
+glyphname = "raai-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (176,-207);
+ref = ring_top.canadian;
+}
+);
+width = 860;
+}
+);
+note = uni1545;
+unicode = 5445;
+},
+{
+glyphname = "ri-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (300,507);
+},
+{
+name = top_left_can;
+pos = (112,507);
+},
+{
+name = top_right_can;
+pos = (764,507);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(143,0,l),
+(143,252,ls),
+(143,375,o),
+(197,445,o),
+(299,445,cs),
+(401,445,o),
+(456,378,o),
+(456,254,cs),
+(456,0,l),
+(796,0,l),
+(796,58,l),
+(519,58,l),
+(519,254,ls),
+(519,409,o),
+(439,501,o),
+(299,501,cs),
+(161,501,o),
+(79,407,o),
+(79,251,cs),
+(79,0,l)
+);
+}
+);
+width = 860;
+}
+);
+metricLeft = "re-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+unicode = 5446;
+},
+{
+glyphname = "rii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (236,-207);
+ref = dot_top;
+}
+);
+width = 860;
+}
+);
+note = uni1547;
+unicode = 5447;
+},
+{
+glyphname = "ro-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (233,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(147,0,l),
+(147,286,l),
+(128,264,l),
+(235,264,ls),
+(382,264,o),
+(473,354,o),
+(473,488,cs),
+(473,625,o),
+(387,714,o),
+(226,714,cs),
+(83,714,l),
+(83,656,l),
+(227,656,ls),
+(346,656,o),
+(409,591,o),
+(409,489,cs),
+(409,387,o),
+(344,322,o),
+(228,322,cs),
+(83,322,l),
+(83,0,l)
+);
+}
+);
+width = 540;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1548;
+unicode = 5448;
+},
+{
+glyphname = "roo-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (169,0);
+ref = dot_top;
+}
+);
+width = 540;
+}
+);
+note = uni1549;
+unicode = 5449;
+},
+{
+glyphname = "loWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (261,714);
+},
+{
+name = top_left_can;
+pos = (116,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(226,0,ls),
+(387,0,o),
+(473,89,o),
+(473,226,cs),
+(473,360,o),
+(382,450,o),
+(235,450,cs),
+(128,450,l),
+(147,428,l),
+(147,714,l),
+(83,714,l),
+(83,392,l),
+(228,392,ls),
+(344,392,o),
+(409,327,o),
+(409,225,cs),
+(409,123,o),
+(346,58,o),
+(227,58,cs),
+(83,58,l),
+(83,0,l)
+);
+}
+);
+width = 540;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+unicode = 5450;
+},
+{
+glyphname = "ra-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (306,714);
+},
+{
+name = top_right_can;
+pos = (425,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(456,0,l),
+(456,322,l),
+(312,322,ls),
+(195,322,o),
+(130,387,o),
+(130,489,cs),
+(130,591,o),
+(194,656,o),
+(312,656,cs),
+(456,656,l),
+(456,714,l),
+(314,714,ls),
+(153,714,o),
+(67,625,o),
+(67,488,cs),
+(67,354,o),
+(158,264,o),
+(305,264,cs),
+(412,264,l),
+(393,286,l),
+(393,0,l)
+);
+}
+);
+width = 539;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+unicode = 5451;
+},
+{
+glyphname = "raa-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (242,0);
+ref = dot_top;
+}
+);
+width = 540;
+}
+);
+note = uni154C;
+unicode = 5452;
+},
+{
+glyphname = "laWestCree-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (425,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(456,0,l),
+(456,58,l),
+(312,58,ls),
+(194,58,o),
+(130,123,o),
+(130,225,cs),
+(130,327,o),
+(195,392,o),
+(312,392,cs),
+(456,392,l),
+(456,714,l),
+(393,714,l),
+(393,428,l),
+(412,450,l),
+(305,450,ls),
+(158,450,o),
+(67,360,o),
+(67,226,cs),
+(67,89,o),
+(153,0,o),
+(314,0,cs)
+);
+}
+);
+width = 539;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+unicode = 5453;
+},
+{
+glyphname = "rwaa-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (462,0);
+ref = dot_top;
+}
+);
+width = 760;
+}
+);
+note = uni154E;
+unicode = 5454;
+},
+{
+glyphname = "rwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (242,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (540,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 760;
+}
+);
+note = uni154F;
+unicode = 5455;
+},
+{
+glyphname = "r-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(259,357,l),
+(259,527,l),
+(188,527,ls),
+(132,527,o),
+(105,553,o),
+(105,600,cs),
+(105,647,o),
+(131,674,o),
+(188,674,cs),
+(259,674,l),
+(259,714,l),
+(189,714,ls),
+(106,714,o),
+(60,671,o),
+(60,600,cs),
+(60,531,o),
+(107,487,o),
+(184,487,cs),
+(238,487,l),
+(211,507,l),
+(211,357,l)
+);
+}
+);
+width = 329;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni1550;
+unicode = 5456;
+},
+{
+glyphname = "rWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(81,357,l),
+(312,448,l),
+(312,468,l),
+(106,544,l),
+(106,526,l),
+(312,603,l),
+(312,623,l),
+(81,714,l),
+(69.995,714,l),
+(70,682,l),
+(273,601,l),
+(273,624,l),
+(70,547,l),
+(70,523,l),
+(273,447,l),
+(273,470,l),
+(70,389,l),
+(69.995,357,l)
+);
+}
+);
+width = 382;
+}
+);
+metricLeft = "=|lWestCree-canadian";
+metricRight = "=|lWestCree-canadian";
+note = uni1551;
+unicode = 5457;
+},
+{
+glyphname = "rMedial-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,-13,l),
+(585,175,l),
+(585,205,l),
+(139,368,l),
+(139,345,l),
+(585,509,l),
+(585,539,l),
+(97,727,l),
+(78,727,l),
+(78,680,l),
+(525,508,l),
+(525,537,l),
+(78,373,l),
+(78,340,l),
+(525,177,l),
+(525,207,l),
+(78,35,l),
+(78,-13,l)
+);
+}
+);
+width = 663;
+}
+);
+metricLeft = "mediall-canadian";
+metricRight = "mediall-canadian";
+note = uni1552;
+unicode = 5458;
+},
+{
+glyphname = "fe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(383,0,l),
+(722,694,l),
+(722,714,l),
+(668,714,l),
+(357,68,l),
+(373,68,l),
+(209,373,l),
+(178,365,l),
+(204,341,o),
+(233,331,o),
+(265,331,cs),
+(356,331,o),
+(421,411,o),
+(421,529,cs),
+(421,649,o),
+(359,727,o),
+(260,727,cs),
+(161,727,o),
+(99,649,o),
+(99,533,cs),
+(99,483,o),
+(111,432,o),
+(146,371,cs),
+(353,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(193,380,o),
+(153,440,o),
+(153,532,cs),
+(153,623,o),
+(192,677,o),
+(260,677,cs),
+(329,677,o),
+(367,624,o),
+(367,529,cs),
+(367,434,o),
+(328,380,o),
+(261,380,cs)
+);
+}
+);
+width = 759;
+}
+);
+metricRight = "e-canadian";
+note = uni1553;
+unicode = 5459;
+},
+{
+glyphname = "faai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (245,0);
+ref = ring_top.canadian;
+}
+);
+width = 759;
+}
+);
+note = uni1554;
+unicode = 5460;
+},
+{
+glyphname = "fi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (369,714);
+},
+{
+name = top_left_can;
+pos = (131,714);
+},
+{
+name = top_right_can;
+pos = (636,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(359,-13,o),
+(421,65,o),
+(421,185,cs),
+(421,303,o),
+(356,383,o),
+(265,383,cs),
+(233,383,o),
+(204,373,o),
+(178,349,c),
+(209,341,l),
+(373,646,l),
+(357,646,l),
+(668,0,l),
+(722,0,l),
+(722,20,l),
+(383,714,l),
+(353,714,l),
+(146,343,ls),
+(111,282,o),
+(99,231,o),
+(99,181,cs),
+(99,65,o),
+(161,-13,o),
+(260,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(192,37,o),
+(153,91,o),
+(153,182,cs),
+(153,274,o),
+(193,334,o),
+(261,334,cs),
+(328,334,o),
+(367,280,o),
+(367,185,cs),
+(367,90,o),
+(329,37,o),
+(260,37,cs)
+);
+}
+);
+width = 759;
+}
+);
+metricLeft = "fe-canadian";
+metricRight = "e-canadian";
+note = uni1555;
+unicode = 5461;
+},
+{
+glyphname = "fii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (305,0);
+ref = dot_top;
+}
+);
+width = 759;
+}
+);
+note = uni1556;
+unicode = 5462;
+},
+{
+glyphname = "fo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (224,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(119,0,l),
+(658,343,l),
+(658,371,l),
+(339,679,ls),
+(307,711,o),
+(266,727,o),
+(223,727,cs),
+(128,727,o),
+(63,653,o),
+(63,528,cs),
+(63,409,o),
+(125,331,o),
+(222,331,cs),
+(319,331,o),
+(379,410,o),
+(379,528,cs),
+(379,578,o),
+(367,620,o),
+(349,649,c),
+(332,611,l),
+(598,354,l),
+(598,370,l),
+(99,53,l),
+(99,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(156,380,o),
+(117,434,o),
+(117,529,cs),
+(117,625,o),
+(156,677,o),
+(224,677,cs),
+(292,677,o),
+(330,626,o),
+(330,529,cs),
+(330,434,o),
+(291,380,o),
+(224,380,cs)
+);
+}
+);
+width = 695;
+}
+);
+metricRight = "o-canadian";
+note = uni1557;
+unicode = 5463;
+},
+{
+glyphname = "foo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "fo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (160,0);
+ref = dot_top;
+}
+);
+width = 695;
+}
+);
+note = uni1558;
+unicode = 5464;
+},
+{
+glyphname = "fa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (472,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(596,0,l),
+(596,53,l),
+(95,371,l),
+(97,355,l),
+(363,613,l),
+(346,649,l),
+(328,620,o),
+(316,578,o),
+(316,528,cs),
+(316,410,o),
+(377,331,o),
+(473,331,cs),
+(570,331,o),
+(632,409,o),
+(632,528,cs),
+(632,653,o),
+(567,727,o),
+(472,727,cs),
+(429,727,o),
+(388,711,o),
+(357,679,cs),
+(38,371,l),
+(38,343,l),
+(577,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(404,380,o),
+(366,434,o),
+(366,529,cs),
+(366,625,o),
+(404,677,o),
+(472,677,cs),
+(540,677,o),
+(578,625,o),
+(578,529,cs),
+(578,433,o),
+(540,380,o),
+(472,380,cs)
+);
+}
+);
+width = 695;
+}
+);
+metricRight = "=|fo-canadian";
+note = uni1559;
+unicode = 5465;
+},
+{
+glyphname = "faa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (407,0);
+ref = dot_top;
+}
+);
+width = 695;
+}
+);
+note = uni155A;
+unicode = 5466;
+},
+{
+glyphname = "fwaa-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (628,0);
+ref = dot_top;
+}
+);
+width = 916;
+}
+);
+note = uni155B;
+unicode = 5467;
+},
+{
+glyphname = "fwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (407,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (695,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 916;
+}
+);
+note = uni155C;
+unicode = 5468;
+},
+{
+glyphname = "f-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(344,357,l),
+(344,389,l),
+(101,544,l),
+(101,534,l),
+(225,653,l),
+(220,681,l),
+(210,666,o),
+(204,645,o),
+(204,620,cs),
+(204,558,o),
+(236,522,o),
+(283,522,cs),
+(330,522,o),
+(361,559,o),
+(361,621,cs),
+(361,685,o),
+(328,720,o),
+(282,720,cs),
+(261,720,o),
+(240,711,o),
+(219,692,cs),
+(65,544,l),
+(65,527,l),
+(331,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(252,552,o),
+(235,576,o),
+(235,621,cs),
+(235,665,o),
+(252,690,o),
+(282,690,cs),
+(312,690,o),
+(329,667,o),
+(329,621,cs),
+(329,575,o),
+(312,552,o),
+(282,552,cs)
+);
+}
+);
+width = 424;
+}
+);
+note = uni155D;
+unicode = 5469;
+},
+{
+glyphname = "the-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (810,357);
+},
+{
+name = top_center_can;
+pos = (361,714);
+},
+{
+name = top_left_can;
+pos = (107,714);
+},
+{
+name = top_right_can;
+pos = (614,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(539,-13,o),
+(646,102,o),
+(646,303,cs),
+(646,714,l),
+(582,714,l),
+(582,299,ls),
+(582,133,o),
+(502,46,o),
+(361,46,cs),
+(222,46,o),
+(138,132,o),
+(138,295,cs),
+(138,445,l),
+(115,430,l),
+(127,368,o),
+(179,327,o),
+(241,327,cs),
+(335,327,o),
+(396,405,o),
+(396,527,cs),
+(396,649,o),
+(336,727,o),
+(237,727,cs),
+(136,727,o),
+(76,649,o),
+(76,517,cs),
+(76,307,ls),
+(76,102,o),
+(185,-13,o),
+(361,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(168,377,o),
+(129,429,o),
+(129,527,cs),
+(129,623,o),
+(168,677,o),
+(236,677,cs),
+(304,677,o),
+(342,623,o),
+(342,527,cs),
+(342,430,o),
+(304,377,o),
+(236,377,cs)
+);
+}
+);
+width = 722;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155E;
+unicode = 5470;
+},
+{
+glyphname = "theNCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(540,-13,o),
+(646,102,o),
+(646,309,cs),
+(646,517,ls),
+(646,649,o),
+(586,727,o),
+(485,727,cs),
+(386,727,o),
+(326,649,o),
+(326,527,cs),
+(326,406,o),
+(387,327,o),
+(481,327,cs),
+(543,327,o),
+(595,368,o),
+(607,430,c),
+(584,445,l),
+(584,295,ls),
+(584,131,o),
+(502,46,o),
+(361,46,cs),
+(222,46,o),
+(140,134,o),
+(140,298,cs),
+(140,714,l),
+(76,714,l),
+(76,299,ls),
+(76,101,o),
+(185,-13,o),
+(361,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(418,377,o),
+(380,432,o),
+(380,527,cs),
+(380,623,o),
+(418,677,o),
+(486,677,cs),
+(554,677,o),
+(592,623,o),
+(592,527,cs),
+(592,430,o),
+(553,377,o),
+(486,377,cs)
+);
+}
+);
+width = 722;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155F;
+unicode = 5471;
+},
+{
+glyphname = "thi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (359,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(336,-13,o),
+(396,65,o),
+(396,187,cs),
+(396,308,o),
+(335,387,o),
+(241,387,cs),
+(179,387,o),
+(127,346,o),
+(115,284,c),
+(138,269,l),
+(138,419,ls),
+(138,583,o),
+(220,668,o),
+(361,668,cs),
+(500,668,o),
+(582,580,o),
+(582,416,cs),
+(582,0,l),
+(646,0,l),
+(646,415,ls),
+(646,613,o),
+(537,727,o),
+(361,727,cs),
+(182,727,o),
+(76,612,o),
+(76,405,cs),
+(76,197,ls),
+(76,65,o),
+(136,-13,o),
+(237,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(168,37,o),
+(129,91,o),
+(129,187,cs),
+(129,284,o),
+(168,337,o),
+(236,337,cs),
+(304,337,o),
+(342,282,o),
+(342,187,cs),
+(342,91,o),
+(304,37,o),
+(236,37,cs)
+);
+}
+);
+width = 722;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1560;
+unicode = 5472;
+},
+{
+glyphname = "thiNCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (359,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(586,-13,o),
+(646,65,o),
+(646,197,cs),
+(646,405,ls),
+(646,612,o),
+(540,727,o),
+(361,727,cs),
+(185,727,o),
+(76,613,o),
+(76,415,cs),
+(76,0,l),
+(140,0,l),
+(140,416,ls),
+(140,580,o),
+(222,668,o),
+(361,668,cs),
+(502,668,o),
+(584,583,o),
+(584,419,cs),
+(584,269,l),
+(607,284,l),
+(595,346,o),
+(543,387,o),
+(481,387,cs),
+(387,387,o),
+(326,308,o),
+(326,187,cs),
+(326,65,o),
+(386,-13,o),
+(485,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(418,37,o),
+(380,91,o),
+(380,187,cs),
+(380,282,o),
+(418,337,o),
+(486,337,cs),
+(553,337,o),
+(592,284,o),
+(592,187,cs),
+(592,91,o),
+(554,37,o),
+(486,37,cs)
+);
+}
+);
+width = 722;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1561;
+unicode = 5473;
+},
+{
+glyphname = "thii-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "thi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (295,0);
+ref = dot_top;
+}
+);
+width = 722;
+}
+);
+note = uni1562;
+unicode = 5474;
+},
+{
+glyphname = "thiiNCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "thiNCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (295,0);
+ref = dot_top;
+}
+);
+width = 722;
+}
+);
+note = uni1563;
+unicode = 5475;
+},
+{
+glyphname = "tho-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (307,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(271,0,ls),
+(490,0,o),
+(605,129,o),
+(605,363,cs),
+(605,583,o),
+(498,727,o),
+(309,727,cs),
+(170,727,o),
+(76,644,o),
+(76,501,cs),
+(76,379,o),
+(139,304,o),
+(236,304,cs),
+(333,304,o),
+(394,377,o),
+(394,498,cs),
+(394,598,o),
+(345,683,o),
+(244,688,c),
+(209,657,l),
+(233,670,o),
+(267,678,o),
+(300,678,cs),
+(465,678,o),
+(542,556,o),
+(542,366,cs),
+(542,163,o),
+(452,58,o),
+(268,58,cs),
+(109,58,l),
+(109,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(168,353,o),
+(130,405,o),
+(130,504,cs),
+(130,602,o),
+(177,655,o),
+(237,655,cs),
+(298,655,o),
+(343,603,o),
+(343,504,cs),
+(343,405,o),
+(305,353,o),
+(236,353,cs)
+);
+}
+);
+width = 674;
+}
+);
+metricRight = "to-canadian";
+note = uni1564;
+unicode = 5476;
+},
+{
+glyphname = "thoo-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "tho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (243,0);
+ref = dot_top;
+}
+);
+width = 675;
+}
+);
+note = uni1565;
+unicode = 5477;
+},
+{
+glyphname = "tha-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (368,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(565,0,l),
+(565,58,l),
+(407,58,ls),
+(222,58,o),
+(132,163,o),
+(132,366,cs),
+(132,556,o),
+(210,678,o),
+(374,678,cs),
+(408,678,o),
+(441,670,o),
+(466,657,c),
+(431,688,l),
+(330,683,o),
+(281,598,o),
+(281,498,cs),
+(281,377,o),
+(342,304,o),
+(438,304,cs),
+(536,304,o),
+(598,379,o),
+(598,501,cs),
+(598,644,o),
+(504,727,o),
+(366,727,cs),
+(177,727,o),
+(69,583,o),
+(69,363,cs),
+(69,130,o),
+(184,0,o),
+(404,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(370,353,o),
+(332,405,o),
+(332,504,cs),
+(332,603,o),
+(377,655,o),
+(438,655,cs),
+(497,655,o),
+(545,602,o),
+(545,504,cs),
+(545,405,o),
+(506,353,o),
+(438,353,cs)
+);
+}
+);
+width = 674;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tho-canadian";
+note = uni1566;
+unicode = 5478;
+},
+{
+glyphname = "thaa-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (304,0);
+ref = dot_top;
+}
+);
+width = 675;
+}
+);
+note = uni1567;
+unicode = 5479;
+},
+{
+glyphname = "thwaa-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (524,0);
+ref = dot_top;
+}
+);
+width = 895;
+}
+);
+note = uni1568;
+unicode = 5480;
+},
+{
+glyphname = "thwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (304,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (675,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 895;
+}
+);
+note = uni1569;
+unicode = 5481;
+},
+{
+glyphname = "th-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(316,357,l),
+(316,397,l),
+(243,397,ls),
+(152,397,o),
+(110,447,o),
+(110,538,cs),
+(110,628,o),
+(148,688,o),
+(225,688,cs),
+(243,688,o),
+(259,684,o),
+(271,679,c),
+(248,700,l),
+(198,697,o),
+(175,658,o),
+(175,607,cs),
+(175,544,o),
+(206,509,o),
+(254,509,cs),
+(301,509,o),
+(332,545,o),
+(332,607,cs),
+(332,681,o),
+(287,720,o),
+(219,720,cs),
+(124,720,o),
+(68,647,o),
+(68,536,cs),
+(68,425,o),
+(126,357,o),
+(241,357,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(223,539,o),
+(206,562,o),
+(206,607,cs),
+(206,652,o),
+(223,676,o),
+(253,676,cs),
+(283,676,o),
+(300,654,o),
+(300,607,cs),
+(300,561,o),
+(283,539,o),
+(254,539,cs)
+);
+}
+);
+width = 395;
+}
+);
+metricLeft = "t-canadian";
+note = uni156A;
+unicode = 5482;
+},
+{
+glyphname = "tthe-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (801,357);
+},
+{
+name = top_center_can;
+pos = (356,714);
+},
+{
+name = top_left_can;
+pos = (108,714);
+},
+{
+name = top_right_can;
+pos = (605,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(530,-13,o),
+(637,102,o),
+(637,303,cs),
+(637,714,l),
+(575,714,l),
+(575,300,ls),
+(575,134,o),
+(494,47,o),
+(356,47,cs),
+(222,47,o),
+(138,135,o),
+(138,299,cs),
+(138,714,l),
+(76,714,l),
+(76,299,ls),
+(76,101,o),
+(185,-13,o),
+(356,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(383,405,l),
+(383,714,l),
+(330,714,l),
+(330,405,l)
+);
+}
+);
+width = 713;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156B;
+unicode = 5483;
+},
+{
+glyphname = "tthi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(138,0,l),
+(138,414,ls),
+(138,580,o),
+(221,667,o),
+(357,667,cs),
+(491,667,o),
+(575,579,o),
+(575,415,cs),
+(575,0,l),
+(637,0,l),
+(637,415,ls),
+(637,612,o),
+(528,727,o),
+(358,727,cs),
+(183,727,o),
+(76,613,o),
+(76,411,cs),
+(76,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(383,0,l),
+(383,309,l),
+(330,309,l),
+(330,0,l)
+);
+}
+);
+width = 713;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156C;
+unicode = 5484;
+},
+{
+glyphname = "ttho-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (320,714);
+},
+{
+name = top_left_can;
+pos = (113,714);
+},
+{
+name = top_right_can;
+pos = (526,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(231,0,ls),
+(441,0,o),
+(558,134,o),
+(558,358,cs),
+(558,582,o),
+(441,714,o),
+(226,714,cs),
+(82,714,l),
+(82,656,l),
+(226,656,ls),
+(403,656,o),
+(494,549,o),
+(494,358,cs),
+(494,167,o),
+(403,58,o),
+(228,58,cs),
+(82,58,l),
+(82,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(317,331,l),
+(317,384,l),
+(82,384,l),
+(82,331,l)
+);
+}
+);
+width = 627;
+}
+);
+metricRight = "to-canadian";
+note = uni156D;
+unicode = 5485;
+},
+{
+glyphname = "ttha-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (326,714);
+},
+{
+name = top_left_can;
+pos = (101,714);
+},
+{
+name = top_right_can;
+pos = (514,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(545,0,l),
+(545,58,l),
+(400,58,ls),
+(224,58,o),
+(133,166,o),
+(133,357,cs),
+(133,548,o),
+(224,656,o),
+(399,656,cs),
+(545,656,l),
+(545,714,l),
+(399,714,ls),
+(186,714,o),
+(69,581,o),
+(69,357,cs),
+(69,133,o),
+(186,0,o),
+(398,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(545,331,l),
+(545,384,l),
+(310,384,l),
+(310,331,l)
+);
+}
+);
+width = 627;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|ttho-canadian";
+note = uni156E;
+unicode = 5486;
+},
+{
+glyphname = "tth-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(636,505,l),
+(620,505,l),
+(715,371,l),
+(749,396,l),
+(652,532,l),
+(648,515,l),
+(798,569,l),
+(784,609,l),
+(634,554,l),
+(649,545,l),
+(649,714,l),
+(607,714,l),
+(607,545,l),
+(622,554,l),
+(472,609,l),
+(458,569,l),
+(608,515,l),
+(603,532,l),
+(506,396,l),
+(541,371,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(232,505,l),
+(216,505,l),
+(313,371,l),
+(347,396,l),
+(249,532,l),
+(244,515,l),
+(394,569,l),
+(380,609,l),
+(231,554,l),
+(245,545,l),
+(245,714,l),
+(203,714,l),
+(203,545,l),
+(218,554,l),
+(68,609,l),
+(55,569,l),
+(205,515,l),
+(200,532,l),
+(101,396,l),
+(136,371,l)
+);
+}
+);
+width = 853;
+}
+);
+metricRight = "=|";
+note = uni156F;
+unicode = 5487;
+},
+{
+glyphname = "tye-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(530,-13,o),
+(637,102,o),
+(637,303,cs),
+(637,714,l),
+(575,714,l),
+(575,301,ls),
+(575,134,o),
+(494,47,o),
+(356,47,cs),
+(222,47,o),
+(138,135,o),
+(138,300,cs),
+(138,714,l),
+(76,714,l),
+(76,299,ls),
+(76,101,o),
+(185,-13,o),
+(356,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(430,426,o),
+(474,473,o),
+(474,563,cs),
+(474,714,l),
+(437,714,l),
+(437,565,ls),
+(437,497,o),
+(410,464,o),
+(356,464,cs),
+(303,464,o),
+(276,498,o),
+(276,565,cs),
+(276,714,l),
+(239,714,l),
+(239,563,ls),
+(239,473,o),
+(284,426,o),
+(356,426,cs)
+);
+}
+);
+width = 713;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1570;
+unicode = 5488;
+},
+{
+glyphname = "tyi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(138,0,l),
+(138,413,ls),
+(138,580,o),
+(221,667,o),
+(357,667,cs),
+(491,667,o),
+(575,579,o),
+(575,414,cs),
+(575,0,l),
+(637,0,l),
+(637,415,ls),
+(637,612,o),
+(528,727,o),
+(358,727,cs),
+(183,727,o),
+(76,613,o),
+(76,411,cs),
+(76,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(276,0,l),
+(276,149,ls),
+(276,216,o),
+(303,250,o),
+(357,250,cs),
+(409,250,o),
+(437,216,o),
+(437,149,cs),
+(437,0,l),
+(474,0,l),
+(474,151,ls),
+(474,241,o),
+(428,288,o),
+(356,288,cs),
+(283,288,o),
+(239,241,o),
+(239,151,cs),
+(239,0,l)
+);
+}
+);
+width = 713;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1571;
+unicode = 5489;
+},
+{
+glyphname = "tyo-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(233,0,ls),
+(442,0,o),
+(559,134,o),
+(559,358,cs),
+(559,582,o),
+(442,714,o),
+(228,714,cs),
+(83,714,l),
+(83,656,l),
+(226,656,ls),
+(404,656,o),
+(495,549,o),
+(495,358,cs),
+(495,167,o),
+(404,58,o),
+(228,58,cs),
+(83,58,l),
+(83,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(169,217,ls),
+(261,217,o),
+(310,269,o),
+(310,357,cs),
+(310,445,o),
+(260,497,o),
+(169,497,cs),
+(83,497,l),
+(83,458,l),
+(164,458,ls),
+(237,458,o),
+(269,423,o),
+(269,357,cs),
+(269,291,o),
+(237,256,o),
+(165,256,cs),
+(83,256,l),
+(83,217,l)
+);
+}
+);
+width = 628;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1572;
+unicode = 5490;
+},
+{
+glyphname = "tya-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(545,0,l),
+(545,58,l),
+(402,58,ls),
+(224,58,o),
+(133,166,o),
+(133,357,cs),
+(133,548,o),
+(224,656,o),
+(401,656,cs),
+(545,656,l),
+(545,714,l),
+(399,714,ls),
+(187,714,o),
+(69,581,o),
+(69,357,cs),
+(69,133,o),
+(187,0,o),
+(398,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(545,217,l),
+(545,256,l),
+(464,256,ls),
+(392,256,o),
+(360,291,o),
+(360,357,cs),
+(360,423,o),
+(392,458,o),
+(464,458,cs),
+(545,458,l),
+(545,497,l),
+(459,497,ls),
+(367,497,o),
+(318,445,o),
+(318,357,cs),
+(318,269,o),
+(368,217,o),
+(459,217,cs)
+);
+}
+);
+width = 628;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1573;
+unicode = 5491;
+},
+{
+glyphname = "heNunavik-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(506,0,l),
+(742,198,l),
+(706,242,l),
+(471,45,l),
+(512,43,l),
+(512,464,ls),
+(512,628,o),
+(429,727,o),
+(293,727,cs),
+(157,727,o),
+(70,628,o),
+(70,467,cs),
+(70,311,o),
+(156,213,o),
+(285,213,cs),
+(374,213,o),
+(440,266,o),
+(456,338,c),
+(449,353,l),
+(449,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(194,269,o),
+(133,342,o),
+(133,470,cs),
+(133,598,o),
+(193,671,o),
+(291,671,cs),
+(391,671,o),
+(449,599,o),
+(449,470,cs),
+(449,342,o),
+(389,269,o),
+(291,269,cs)
+);
+}
+);
+width = 771;
+}
+);
+metricLeft = "ke-canadian";
+note = uni1574;
+unicode = 5492;
+},
+{
+glyphname = "hiNunavik-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (479,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(322,0,l),
+(322,353,l),
+(315,338,l),
+(331,266,o),
+(397,213,o),
+(486,213,cs),
+(615,213,o),
+(700,312,o),
+(700,469,cs),
+(700,628,o),
+(615,727,o),
+(479,727,cs),
+(342,727,o),
+(258,628,o),
+(258,464,cs),
+(258,46,l),
+(299,45,l),
+(64,242,l),
+(29,198,l),
+(265,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(381,269,o),
+(321,342,o),
+(321,470,cs),
+(321,599,o),
+(380,671,o),
+(479,671,cs),
+(578,671,o),
+(637,598,o),
+(637,470,cs),
+(637,342,o),
+(576,269,o),
+(479,269,cs)
+);
+}
+);
+width = 770;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1575;
+unicode = 5493;
+},
+{
+glyphname = "hiiNunavik-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "hiNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (415,0);
+ref = dot_top;
+}
+);
+width = 771;
+}
+);
+note = uni1576;
+unicode = 5494;
+},
+{
+glyphname = "hoNunavik-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (291,714);
+},
+{
+name = top_right_can;
+pos = (480,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(429,-13,o),
+(512,86,o),
+(512,250,cs),
+(512,671,l),
+(471,669,l),
+(706,472,l),
+(742,516,l),
+(506,714,l),
+(449,714,l),
+(449,361,l),
+(456,376,l),
+(440,448,o),
+(374,501,o),
+(285,501,cs),
+(156,501,o),
+(70,401,o),
+(70,245,cs),
+(70,85,o),
+(156,-13,o),
+(292,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(193,43,o),
+(133,116,o),
+(133,244,cs),
+(133,372,o),
+(194,445,o),
+(291,445,cs),
+(389,445,o),
+(449,372,o),
+(449,244,cs),
+(449,115,o),
+(391,43,o),
+(291,43,cs)
+);
+}
+);
+width = 771;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "heNunavik-canadian";
+note = uni1577;
+unicode = 5495;
+},
+{
+glyphname = "hooNunavik-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "hoNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (416,0);
+ref = dot_top;
+}
+);
+width = 771;
+}
+);
+note = uni1578;
+unicode = 5496;
+},
+{
+glyphname = "haNunavik-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (480,714);
+},
+{
+name = top_left_can;
+pos = (290,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(614,-13,o),
+(700,86,o),
+(700,246,cs),
+(700,402,o),
+(615,501,o),
+(487,501,cs),
+(397,501,o),
+(331,448,o),
+(315,376,c),
+(322,361,l),
+(322,714,l),
+(265,714,l),
+(29,516,l),
+(64,472,l),
+(299,669,l),
+(258,668,l),
+(258,250,ls),
+(258,86,o),
+(341,-13,o),
+(478,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(380,43,o),
+(321,115,o),
+(321,244,cs),
+(321,372,o),
+(381,445,o),
+(479,445,cs),
+(576,445,o),
+(637,372,o),
+(637,244,cs),
+(637,116,o),
+(578,43,o),
+(479,43,cs)
+);
+}
+);
+width = 770;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1579;
+unicode = 5497;
+},
+{
+glyphname = "haaNunavik-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "haNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (226,0);
+ref = dot_top;
+}
+);
+width = 771;
+}
+);
+note = uni157A;
+unicode = 5498;
+},
+{
+glyphname = "hNunavik-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(354,351,o),
+(406,402,o),
+(406,488,cs),
+(406,571,o),
+(357,622,o),
+(291,622,cs),
+(242,622,o),
+(204,588,o),
+(197,541,c),
+(210,541,l),
+(210,714,l),
+(165,714,l),
+(48,615,l),
+(71,587,l),
+(189,686,l),
+(162,686,l),
+(162,488,ls),
+(162,402,o),
+(212,351,o),
+(285,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(236,389,o),
+(207,422,o),
+(207,487,cs),
+(207,549,o),
+(239,584,o),
+(284,584,cs),
+(330,584,o),
+(363,549,o),
+(363,488,cs),
+(363,425,o),
+(331,389,o),
+(285,389,cs)
+);
+}
+);
+width = 466;
+}
+);
+metricRight = "k-canadian";
+note = uni157B;
+unicode = 5499;
+},
+{
+color = 4;
+glyphname = "nunavuth-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(147,342,l),
+(535,342,l),
+(535,0,l),
+(599,0,l),
+(599,714,l),
+(535,714,l),
+(535,399,l),
+(147,399,l),
+(147,714,l),
+(83,714,l),
+(83,0,l),
+(147,0,l)
+);
+}
+);
+width = 682;
+}
+);
+metricRight = "=|";
+note = uni157C;
+unicode = 5500;
+},
+{
+glyphname = "hk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,357);
+ref = "fullstop-canadian";
+}
+);
+width = 347;
+}
+);
+metricLeft = "fullstop-canadian";
+note = uni157D;
+unicode = 5501;
+},
+{
+glyphname = "qaai-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (329,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (501,0);
+ref = ring_top.canadian;
+}
+);
+width = 917;
+}
+);
+note = uni157E;
+unicode = 5502;
+},
+{
+glyphname = "qi-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (329,0);
+ref = "ki-canadian";
+}
+);
+width = 917;
+}
+);
+note = uni157F;
+unicode = 5503;
+},
+{
+glyphname = "qii-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (329,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (561,0);
+ref = dot_top;
+}
+);
+width = 917;
+}
+);
+note = uni1580;
+unicode = 5504;
+},
+{
+glyphname = "qo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (329,0);
+ref = "ko-canadian";
+}
+);
+width = 917;
+}
+);
+note = uni1581;
+unicode = 5505;
+},
+{
+glyphname = "qoo-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (329,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (745,0);
+ref = dot_top;
+}
+);
+width = 917;
+}
+);
+note = uni1582;
+unicode = 5506;
+},
+{
+glyphname = "qa-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (329,0);
+ref = "ka-canadian";
+}
+);
+width = 917;
+}
+);
+note = uni1583;
+unicode = 5507;
+},
+{
+glyphname = "qaa-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (329,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (373,0);
+ref = dot_top;
+}
+);
+width = 917;
+}
+);
+note = uni1584;
+unicode = 5508;
+},
+{
+glyphname = "q-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (329,0);
+ref = "k-canadian";
+}
+);
+width = 703;
+}
+);
+note = uni1585;
+unicode = 5509;
+},
+{
+glyphname = "tlhe-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (296,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(177,0,l),
+(318,276,l),
+(264,252,l),
+(272,251,o),
+(280,250,o),
+(288,250,cs),
+(375,250,o),
+(439,296,o),
+(458,357,c),
+(454,376,l),
+(454,0,l),
+(517,0,l),
+(517,484,ls),
+(517,633,o),
+(434,727,o),
+(297,727,cs),
+(157,727,o),
+(73,630,o),
+(73,487,cs),
+(73,362,o),
+(140,277,o),
+(241,259,c),
+(109,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(196,306,o),
+(136,374,o),
+(136,488,cs),
+(136,603,o),
+(196,671,o),
+(295,671,cs),
+(395,671,o),
+(454,604,o),
+(454,489,cs),
+(454,374,o),
+(394,306,o),
+(295,306,cs)
+);
+}
+);
+width = 593;
+}
+);
+metricRight = "te-canadian";
+note = uni1586;
+unicode = 5510;
+},
+{
+glyphname = "tlhi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(139,0,l),
+(139,376,l),
+(134,359,l),
+(151,297,o),
+(216,250,o),
+(305,250,c),
+(275,276,l),
+(416,0,l),
+(484,0,l),
+(352,259,l),
+(453,277,o),
+(520,362,o),
+(520,487,cs),
+(520,630,o),
+(436,727,o),
+(296,727,cs),
+(159,727,o),
+(76,633,o),
+(76,484,cs),
+(76,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,306,o),
+(139,374,o),
+(139,489,cs),
+(139,604,o),
+(197,671,o),
+(298,671,cs),
+(397,671,o),
+(457,603,o),
+(457,488,cs),
+(457,374,o),
+(397,306,o),
+(298,306,cs)
+);
+}
+);
+width = 593;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|tlhe-canadian";
+note = uni1587;
+unicode = 5511;
+},
+{
+glyphname = "tlho-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (316,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(434,-13,o),
+(517,81,o),
+(517,230,cs),
+(517,714,l),
+(454,714,l),
+(454,338,l),
+(459,355,l),
+(442,417,o),
+(377,464,o),
+(288,464,c),
+(318,438,l),
+(177,714,l),
+(109,714,l),
+(241,455,l),
+(140,437,o),
+(73,352,o),
+(73,227,cs),
+(73,84,o),
+(157,-13,o),
+(297,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(196,43,o),
+(136,111,o),
+(136,226,cs),
+(136,340,o),
+(196,408,o),
+(295,408,cs),
+(394,408,o),
+(454,340,o),
+(454,225,cs),
+(454,110,o),
+(395,43,o),
+(295,43,cs)
+);
+}
+);
+width = 593;
+}
+);
+metricLeft = "tlhe-canadian";
+metricRight = "te-canadian";
+note = uni1588;
+unicode = 5512;
+},
+{
+glyphname = "tlha-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(436,-13,o),
+(520,84,o),
+(520,227,cs),
+(520,352,o),
+(453,437,o),
+(352,455,c),
+(484,714,l),
+(416,714,l),
+(275,438,l),
+(329,462,l),
+(321,463,o),
+(313,464,o),
+(305,464,cs),
+(216,464,o),
+(151,417,o),
+(134,355,c),
+(139,338,l),
+(139,714,l),
+(76,714,l),
+(76,230,ls),
+(76,81,o),
+(159,-13,o),
+(296,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(197,43,o),
+(139,110,o),
+(139,225,cs),
+(139,340,o),
+(199,408,o),
+(298,408,cs),
+(397,408,o),
+(457,340,o),
+(457,226,cs),
+(457,111,o),
+(397,43,o),
+(298,43,cs)
+);
+}
+);
+width = 593;
+}
+);
+metricLeft = "te-canadian";
+note = uni1589;
+unicode = 5513;
+},
+{
+glyphname = "reWestCree-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(502,0,l),
+(738,198,l),
+(702,242,l),
+(467,45,l),
+(508,43,l),
+(508,472,ls),
+(508,631,o),
+(427,727,o),
+(292,727,cs),
+(153,727,o),
+(70,631,o),
+(70,474,cs),
+(70,405,l),
+(133,405,l),
+(133,479,ls),
+(133,599,o),
+(190,670,o),
+(291,670,cs),
+(388,670,o),
+(445,599,o),
+(445,478,cs),
+(445,0,l)
+);
+}
+);
+width = 767;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+unicode = 5514;
+},
+{
+glyphname = "riWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(322,0,l),
+(322,478,ls),
+(322,599,o),
+(379,670,o),
+(478,670,cs),
+(579,670,o),
+(633,600,o),
+(633,479,cs),
+(633,405,l),
+(696,405,l),
+(696,474,ls),
+(696,630,o),
+(616,727,o),
+(479,727,cs),
+(340,727,o),
+(258,630,o),
+(258,471,cs),
+(258,43,l),
+(299,45,l),
+(64,242,l),
+(29,198,l),
+(265,0,l)
+);
+}
+);
+width = 766;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+unicode = 5515;
+},
+{
+glyphname = "roWestCree-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(427,-13,o),
+(508,81,o),
+(508,243,cs),
+(508,671,l),
+(467,669,l),
+(702,472,l),
+(738,516,l),
+(502,714,l),
+(445,714,l),
+(445,236,ls),
+(445,112,o),
+(388,44,o),
+(291,44,cs),
+(188,44,o),
+(133,114,o),
+(133,238,cs),
+(133,309,l),
+(70,309,l),
+(70,239,ls),
+(70,83,o),
+(150,-13,o),
+(291,-13,cs)
+);
+}
+);
+width = 767;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+unicode = 5516;
+},
+{
+glyphname = "raWestCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(616,-13,o),
+(696,82,o),
+(696,240,cs),
+(696,309,l),
+(633,309,l),
+(633,237,ls),
+(633,112,o),
+(579,44,o),
+(478,44,cs),
+(377,44,o),
+(322,113,o),
+(322,235,cs),
+(322,714,l),
+(265,714,l),
+(29,516,l),
+(64,472,l),
+(299,669,l),
+(258,671,l),
+(258,242,ls),
+(258,81,o),
+(339,-13,o),
+(478,-13,cs)
+);
+}
+);
+width = 766;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+unicode = 5517;
+},
+{
+glyphname = "ngaai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (647,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (820,0);
+ref = ring_top.canadian;
+}
+);
+width = 1231;
+}
+);
+note = uni158E;
+unicode = 5518;
+},
+{
+glyphname = "ngi-canadian";
+kernLeft = mwestleft;
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (647,0);
+ref = "ci-canadian";
+}
+);
+width = 1231;
+}
+);
+note = uni158F;
+unicode = 5519;
+},
+{
+glyphname = "ngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (647,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (880,0);
+ref = dot_top;
+}
+);
+width = 1231;
+}
+);
+note = uni1590;
+unicode = 5520;
+},
+{
+glyphname = "ngo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:30:54 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (619,0);
+ref = "co-canadian";
+}
+);
+width = 1204;
+}
+);
+note = uni1591;
+unicode = 5521;
+},
+{
+glyphname = "ngoo-canadian";
+lastChange = "2023-01-13 15:30:54 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+ref = "ngo-canadian";
+},
+{
+anchor = top_right_can;
+pos = (1032,0);
+ref = dot_top;
+}
+);
+width = 1204;
+}
+);
+note = uni1592;
+unicode = 5522;
+},
+{
+glyphname = "nga-canadian";
+kernLeft = mwestleft;
+kernRight = caright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (647,0);
+ref = "ca-canadian";
+}
+);
+width = 1231;
+}
+);
+note = uni1593;
+unicode = 5523;
+},
+{
+glyphname = "ngaa-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (647,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (691,0);
+ref = dot_top;
+}
+);
+width = 1231;
+}
+);
+note = uni1594;
+unicode = 5524;
+},
+{
+glyphname = "ng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(548,225,o),
+(598,270,o),
+(598,353,cs),
+(598,376,l),
+(553,376,l),
+(553,348,ls),
+(553,292,o),
+(523,264,o),
+(476,264,cs),
+(428,264,o),
+(400,293,o),
+(400,356,cs),
+(400,494,l),
+(239,494,l),
+(241,474,l),
+(279,488,o),
+(302,536,o),
+(302,587,cs),
+(302,669,o),
+(253,720,o),
+(181,720,cs),
+(110,720,o),
+(60,669,o),
+(60,586,cs),
+(60,503,o),
+(109,449,o),
+(187,449,cs),
+(367,449,l),
+(353,465,l),
+(353,361,ls),
+(353,271,o),
+(400,225,o),
+(476,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(135,487,o),
+(103,524,o),
+(103,586,cs),
+(103,647,o),
+(135,683,o),
+(182,683,cs),
+(228,683,o),
+(259,647,o),
+(259,585,cs),
+(259,523,o),
+(228,487,o),
+(181,487,cs)
+);
+}
+);
+width = 647;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1595;
+unicode = 5525;
+},
+{
+glyphname = "nng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(835,225,o),
+(885,270,o),
+(885,353,cs),
+(885,376,l),
+(840,376,l),
+(840,348,ls),
+(840,292,o),
+(810,264,o),
+(763,264,cs),
+(716,264,o),
+(688,293,o),
+(688,356,cs),
+(688,494,l),
+(529,494,l),
+(531,474,l),
+(569,488,o),
+(592,536,o),
+(592,587,cs),
+(592,670,o),
+(543,720,o),
+(470,720,cs),
+(399,720,o),
+(350,669,o),
+(350,587,cs),
+(350,535,o),
+(373,488,o),
+(411,473,c),
+(413,494,l),
+(239,494,l),
+(241,474,l),
+(279,488,o),
+(302,536,o),
+(302,587,cs),
+(302,669,o),
+(253,720,o),
+(181,720,cs),
+(110,720,o),
+(60,669,o),
+(60,586,cs),
+(60,503,o),
+(109,449,o),
+(187,449,cs),
+(640,449,l),
+(640,361,ls),
+(640,271,o),
+(687,225,o),
+(764,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(135,487,o),
+(103,524,o),
+(103,586,cs),
+(103,647,o),
+(135,683,o),
+(182,683,cs),
+(228,683,o),
+(259,647,o),
+(259,585,cs),
+(259,523,o),
+(228,487,o),
+(181,487,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(424,487,o),
+(393,524,o),
+(393,586,cs),
+(393,647,o),
+(425,683,o),
+(472,683,cs),
+(517,683,o),
+(549,647,o),
+(549,585,cs),
+(549,523,o),
+(518,487,o),
+(471,487,cs)
+);
+}
+);
+width = 934;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1596;
+unicode = 5526;
+},
+{
+glyphname = "sheSayisi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (680,357);
+},
+{
+name = top_center_can;
+pos = (297,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(517,0,l),
+(517,465,ls),
+(517,629,o),
+(437,727,o),
+(297,727,cs),
+(157,727,o),
+(70,627,o),
+(70,457,cs),
+(70,298,o),
+(137,214,o),
+(237,214,cs),
+(324,214,o),
+(383,280,o),
+(379,425,c),
+(339,425,l),
+(340,305,o),
+(298,269,o),
+(244,269,cs),
+(174,269,o),
+(132,329,o),
+(132,458,cs),
+(132,599,o),
+(193,671,o),
+(295,671,cs),
+(398,671,o),
+(454,599,o),
+(454,467,cs),
+(454,0,l)
+);
+}
+);
+width = 593;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1597;
+unicode = 5527;
+},
+{
+glyphname = "shiSayisi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(140,0,l),
+(140,467,ls),
+(140,599,o),
+(196,671,o),
+(299,671,cs),
+(401,671,o),
+(461,601,o),
+(461,460,cs),
+(461,332,o),
+(419,269,o),
+(349,269,cs),
+(296,269,o),
+(253,305,o),
+(254,425,c),
+(214,425,l),
+(211,280,o),
+(270,214,o),
+(356,214,cs),
+(456,214,o),
+(523,300,o),
+(523,459,cs),
+(523,629,o),
+(438,727,o),
+(299,727,cs),
+(158,727,o),
+(76,629,o),
+(76,465,cs),
+(76,0,l)
+);
+}
+);
+width = 593;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni1598;
+unicode = 5528;
+},
+{
+glyphname = "shoSayisi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (294,714);
+},
+{
+name = top_left_can;
+pos = (101,714);
+},
+{
+name = top_right_can;
+pos = (486,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(435,-13,o),
+(517,85,o),
+(517,249,cs),
+(517,714,l),
+(454,714,l),
+(454,247,ls),
+(454,115,o),
+(397,43,o),
+(294,43,cs),
+(193,43,o),
+(132,113,o),
+(132,254,cs),
+(132,382,o),
+(174,445,o),
+(244,445,cs),
+(298,445,o),
+(340,409,o),
+(339,289,c),
+(379,289,l),
+(383,434,o),
+(324,500,o),
+(237,500,cs),
+(137,500,o),
+(70,414,o),
+(70,253,cs),
+(70,84,o),
+(155,-13,o),
+(294,-13,cs)
+);
+}
+);
+width = 593;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1599;
+unicode = 5529;
+},
+{
+glyphname = "shaSayisi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(436,-13,o),
+(523,87,o),
+(523,257,cs),
+(523,416,o),
+(457,500,o),
+(357,500,cs),
+(271,500,o),
+(211,434,o),
+(214,289,c),
+(254,289,l),
+(253,409,o),
+(296,445,o),
+(349,445,cs),
+(419,445,o),
+(461,385,o),
+(461,256,cs),
+(461,115,o),
+(400,43,o),
+(298,43,cs),
+(195,43,o),
+(140,115,o),
+(140,247,cs),
+(140,714,l),
+(76,714,l),
+(76,249,ls),
+(76,85,o),
+(157,-13,o),
+(296,-13,cs)
+);
+}
+);
+width = 593;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni159A;
+unicode = 5530;
+},
+{
+glyphname = "theWoodScree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(665,-13,o),
+(755,83,o),
+(755,239,cs),
+(755,394,o),
+(667,489,o),
+(519,489,cs),
+(74,489,l),
+(74,434,l),
+(423,434,l),
+(417,447,l),
+(340,415,o),
+(301,331,o),
+(301,236,cs),
+(301,82,o),
+(390,-13,o),
+(528,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(424,43,o),
+(364,116,o),
+(364,238,cs),
+(364,358,o),
+(424,433,o),
+(526,433,cs),
+(631,433,o),
+(692,360,o),
+(692,238,cs),
+(692,117,o),
+(632,43,o),
+(528,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(744,659,l),
+(744,714,l),
+(74,714,l),
+(74,659,l)
+);
+}
+);
+width = 829;
+}
+);
+note = uni159B;
+unicode = 5531;
+},
+{
+glyphname = "thiWoodScree-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,-13,o),
+(528,82,o),
+(528,237,cs),
+(528,332,o),
+(488,416,o),
+(411,448,c),
+(406,434,l),
+(755,434,l),
+(755,489,l),
+(310,489,ls),
+(161,489,o),
+(74,392,o),
+(74,238,cs),
+(74,83,o),
+(163,-13,o),
+(301,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(197,43,o),
+(137,117,o),
+(137,238,cs),
+(137,360,o),
+(198,433,o),
+(303,433,cs),
+(405,433,o),
+(465,358,o),
+(465,238,cs),
+(465,116,o),
+(405,43,o),
+(301,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(755,659,l),
+(755,714,l),
+(85,714,l),
+(85,659,l)
+);
+}
+);
+width = 829;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159C;
+unicode = 5532;
+},
+{
+glyphname = "thoWoodScree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(522,0,ls),
+(668,0,o),
+(755,95,o),
+(755,250,cs),
+(755,406,o),
+(666,501,o),
+(528,501,cs),
+(390,501,o),
+(301,406,o),
+(301,252,cs),
+(301,158,o),
+(340,74,o),
+(416,41,c),
+(423,55,l),
+(74,55,l),
+(74,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(424,56,o),
+(364,131,o),
+(364,250,cs),
+(364,373,o),
+(424,445,o),
+(528,445,cs),
+(632,445,o),
+(692,372,o),
+(692,250,cs),
+(692,128,o),
+(631,56,o),
+(526,56,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(744,659,l),
+(744,714,l),
+(74,714,l),
+(74,659,l)
+);
+}
+);
+width = 829;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159D;
+unicode = 5533;
+},
+{
+glyphname = "thaWoodScree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(755,0,l),
+(755,55,l),
+(406,55,l),
+(412,41,l),
+(488,73,o),
+(528,157,o),
+(528,252,cs),
+(528,407,o),
+(440,501,o),
+(301,501,cs),
+(163,501,o),
+(74,406,o),
+(74,250,cs),
+(74,96,o),
+(161,0,o),
+(308,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(198,56,o),
+(137,128,o),
+(137,250,cs),
+(137,372,o),
+(197,445,o),
+(301,445,cs),
+(405,445,o),
+(465,373,o),
+(465,250,cs),
+(465,131,o),
+(405,56,o),
+(303,56,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(755,659,l),
+(755,714,l),
+(85,714,l),
+(85,659,l)
+);
+}
+);
+width = 829;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159E;
+unicode = 5534;
+},
+{
+glyphname = "thWoodScree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(443,357,l),
+(443,399,l),
+(248,399,l),
+(250,381,l),
+(289,395,o),
+(312,442,o),
+(312,495,cs),
+(312,577,o),
+(263,628,o),
+(191,628,cs),
+(120,628,o),
+(70,576,o),
+(70,493,cs),
+(70,410,o),
+(119,357,o),
+(197,357,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(145,394,o),
+(113,431,o),
+(113,493,cs),
+(113,555,o),
+(145,590,o),
+(192,590,cs),
+(238,590,o),
+(269,555,o),
+(269,493,cs),
+(269,431,o),
+(238,394,o),
+(191,394,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(442,700,l),
+(442,742,l),
+(75,742,l),
+(75,700,l)
+);
+}
+);
+width = 513;
+}
+);
+metricRight = "=|";
+note = uni159F;
+unicode = 5535;
+},
+{
+glyphname = "lhi-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (478,714);
+},
+{
+name = top_right_can;
+pos = (566,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(362,0,l),
+(362,57,l),
+(320,57,ls),
+(198,57,o),
+(134,126,o),
+(134,242,cs),
+(134,356,o),
+(192,430,o),
+(319,430,cs),
+(751,430,l),
+(751,483,l),
+(574,747,l),
+(526,714,l),
+(704,450,l),
+(702,489,l),
+(318,489,ls),
+(156,489,o),
+(70,390,o),
+(70,242,cs),
+(70,93,o),
+(162,0,o),
+(315,0,cs)
+);
+}
+);
+width = 815;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A0;
+unicode = 5536;
+},
+{
+glyphname = "lhii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "lhi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (414,0);
+ref = dot_top;
+}
+);
+width = 815;
+}
+);
+note = uni15A1;
+unicode = 5537;
+},
+{
+glyphname = "lho-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (396,507);
+},
+{
+name = top_right_can;
+pos = (511,507);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(289,-226,l),
+(112,38,l),
+(113,0,l),
+(495,0,ls),
+(655,0,o),
+(745,93,o),
+(745,245,cs),
+(745,396,o),
+(653,488,o),
+(500,488,cs),
+(454,488,l),
+(454,431,l),
+(496,431,ls),
+(617,431,o),
+(682,362,o),
+(682,246,cs),
+(682,127,o),
+(617,58,o),
+(496,58,cs),
+(64,58,l),
+(64,6,l),
+(242,-258,l)
+);
+}
+);
+width = 815;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni15A2;
+unicode = 5538;
+},
+{
+glyphname = "lhoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "lho-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (447,-207);
+ref = dot_top;
+}
+);
+width = 815;
+}
+);
+note = uni15A3;
+unicode = 5539;
+},
+{
+glyphname = "lha-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (422,507);
+},
+{
+name = top_left_can;
+pos = (306,507);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(751,6,l),
+(751,58,l),
+(322,58,ls),
+(200,58,o),
+(134,126,o),
+(134,246,cs),
+(134,363,o),
+(197,431,o),
+(317,431,cs),
+(362,431,l),
+(362,489,l),
+(317,489,ls),
+(159,489,o),
+(70,395,o),
+(70,245,cs),
+(70,91,o),
+(162,0,o),
+(321,0,cs),
+(702,0,l),
+(704,39,l),
+(526,-226,l),
+(574,-258,l)
+);
+}
+);
+width = 815;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A4;
+unicode = 5540;
+},
+{
+glyphname = "lhaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "lha-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (242,-207);
+ref = dot_top;
+}
+);
+width = 815;
+}
+);
+note = uni15A5;
+unicode = 5541;
+},
+{
+glyphname = "lh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(449,362,l),
+(449,401,l),
+(247,401,ls),
+(156,401,o),
+(115,451,o),
+(115,536,cs),
+(115,621,o),
+(156,670,o),
+(243,670,cs),
+(257,670,l),
+(257,714,l),
+(241,714,ls),
+(128,714,o),
+(68,644,o),
+(68,536,cs),
+(68,427,o),
+(128,357,o),
+(243,357,cs),
+(419,357,l),
+(415,385,l),
+(319,238,l),
+(353,215,l)
+);
+}
+);
+width = 517;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni15A6;
+unicode = 5542;
+},
+{
+glyphname = "theThCree-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (81,714);
+},
+{
+name = top_right_can;
+pos = (456,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(487,0,l),
+(487,121,l),
+(571,121,l),
+(571,163,l),
+(487,163,l),
+(487,321,l),
+(127,321,l),
+(125,288,l),
+(501,687,l),
+(457,726,l),
+(49,290,l),
+(49,264,l),
+(423,264,l),
+(423,163,l),
+(171,163,l),
+(171,121,l),
+(423,121,l),
+(423,0,l)
+);
+}
+);
+width = 608;
+}
+);
+metricLeft = "ye-canadian";
+note = uni15A7;
+unicode = 5543;
+},
+{
+glyphname = "thiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (153,714);
+},
+{
+name = top_right_can;
+pos = (528,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(185,0,l),
+(185,121,l),
+(438,121,l),
+(438,163,l),
+(185,163,l),
+(185,263.995,l),
+(559,264,l),
+(559,290,l),
+(152,726,l),
+(109,687,l),
+(486,287,l),
+(483,321,l),
+(121,321,l),
+(121,163,l),
+(37,163,l),
+(37,121,l),
+(121,121,l),
+(121,0,l)
+);
+}
+);
+width = 608;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+unicode = 5544;
+},
+{
+glyphname = "thiiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (89,0);
+ref = dot_top;
+}
+);
+width = 608;
+}
+);
+note = uni15A9;
+unicode = 5545;
+},
+{
+glyphname = "thoThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (81,714);
+},
+{
+name = top_right_can;
+pos = (456,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(500,27,l),
+(124,425,l),
+(126,393,l),
+(487,393,l),
+(487,551,l),
+(571,551,l),
+(571,593,l),
+(487,593,l),
+(487,714,l),
+(423,714,l),
+(423,593,l),
+(171,593,l),
+(171,551,l),
+(423,551,l),
+(423,450,l),
+(49,450,l),
+(49,424,l),
+(457,-12,l)
+);
+}
+);
+width = 608;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+unicode = 5546;
+},
+{
+glyphname = "thooThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (391,0);
+ref = dot_top;
+}
+);
+width = 608;
+}
+);
+note = uni15AB;
+unicode = 5547;
+},
+{
+glyphname = "thaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (153,714);
+},
+{
+name = top_right_can;
+pos = (528,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(559,424,l),
+(559,450,l),
+(185,450.005,l),
+(185,551,l),
+(438,551,l),
+(438,593,l),
+(185,593,l),
+(185,714,l),
+(121,714,l),
+(121,593,l),
+(37,593,l),
+(37,551,l),
+(121,551,l),
+(121,393,l),
+(483,393,l),
+(485,425,l),
+(109,27,l),
+(152,-12,l)
+);
+}
+);
+width = 608;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+unicode = 5548;
+},
+{
+glyphname = "thaaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (89,0);
+ref = dot_top;
+}
+);
+width = 608;
+}
+);
+note = uni15AD;
+unicode = 5549;
+},
+{
+glyphname = "thThCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(332,565,l),
+(332,582,l),
+(148,582,l),
+(148,634,l),
+(271,634,l),
+(271,661,l),
+(148,661,l),
+(148,714,l),
+(100,714,l),
+(100,661,l),
+(58,661,l),
+(58,634,l),
+(100,634,l),
+(100,542,l),
+(284,542,l),
+(278,568,l),
+(99,375,l),
+(131,348,l)
+);
+}
+);
+width = 375;
+}
+);
+metricRight = "y-canadian";
+note = uni15AE;
+unicode = 5550;
+},
+{
+glyphname = "bAivilik-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,-13,o),
+(526,87,o),
+(526,245,cs),
+(526,401,o),
+(439,501,o),
+(313,501,cs),
+(223,501,o),
+(157,448,o),
+(140,376,c),
+(147,361,l),
+(147,714,l),
+(83,714,l),
+(83,0,l),
+(145,0,l),
+(145,128,l),
+(140,114,l),
+(157,41,o),
+(223,-13,o),
+(314,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(206,43,o),
+(147,116,o),
+(147,244,cs),
+(147,372,o),
+(207,445,o),
+(305,445,cs),
+(402,445,o),
+(463,372,o),
+(463,244,cs),
+(463,116,o),
+(403,43,o),
+(305,43,cs)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|ke-canadian";
+note = uni15AF;
+unicode = 5551;
+},
+{
+glyphname = "eBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(147,0,l),
+(147,423,l),
+(177,386,o),
+(221,365,o),
+(273,365,cs),
+(372,365,o),
+(442,442,o),
+(442,546,cs),
+(442,650,o),
+(372,727,o),
+(273,727,cs),
+(220,727,o),
+(174,704,o),
+(145,667,c),
+(145,714,l),
+(83,714,l),
+(83,0,l)
+);
+}
+);
+width = 489;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B0;
+unicode = 5552;
+},
+{
+glyphname = "iBlackfoot-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(269,-13,o),
+(314,10,o),
+(343,47,c),
+(343,0,l),
+(405,0,l),
+(405,714,l),
+(341,714,l),
+(341,291,l),
+(312,328,o),
+(267,349,o),
+(215,349,cs),
+(116,349,o),
+(47,272,o),
+(47,168,cs),
+(47,64,o),
+(116,-13,o),
+(215,-13,cs)
+);
+}
+);
+width = 488;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B1;
+unicode = 5553;
+},
+{
+glyphname = "oBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(372,-13,o),
+(442,64,o),
+(442,168,cs),
+(442,272,o),
+(372,349,o),
+(273,349,cs),
+(221,349,o),
+(177,328,o),
+(147,291,c),
+(147,714,l),
+(83,714,l),
+(83,0,l),
+(145,0,l),
+(145,47,l),
+(174,10,o),
+(220,-13,o),
+(273,-13,cs)
+);
+}
+);
+width = 489;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "eBlackfoot-canadian";
+note = uni15B2;
+unicode = 5554;
+},
+{
+glyphname = "aBlackfoot-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(405,0,l),
+(405,714,l),
+(343,714,l),
+(343,667,l),
+(314,704,o),
+(269,727,o),
+(215,727,cs),
+(116,727,o),
+(47,650,o),
+(47,546,cs),
+(47,442,o),
+(116,365,o),
+(215,365,cs),
+(267,365,o),
+(312,386,o),
+(341,423,c),
+(341,0,l)
+);
+}
+);
+width = 488;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B3;
+unicode = 5555;
+},
+{
+glyphname = "weBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(147,330,l),
+(509,330,l),
+(509,385,l),
+(147,385,l),
+(147,659,l),
+(509,659,l),
+(509,714,l),
+(83,714,l),
+(83,0,l),
+(147,0,l)
+);
+}
+);
+width = 571;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B4;
+unicode = 5556;
+},
+{
+glyphname = "wiBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(488,0,l),
+(488,714,l),
+(424,714,l),
+(424,384,l),
+(62,384,l),
+(62,329,l),
+(424,329,l),
+(424,55,l),
+(62,55,l),
+(62,0,l)
+);
+}
+);
+width = 571;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B5;
+unicode = 5557;
+},
+{
+glyphname = "woBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(509,0,l),
+(509,55,l),
+(147,55,l),
+(147,329,l),
+(509,329,l),
+(509,384,l),
+(147,384,l),
+(147,714,l),
+(83,714,l),
+(83,0,l)
+);
+}
+);
+width = 571;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "weBlackfoot-canadian";
+note = uni15B6;
+unicode = 5558;
+},
+{
+glyphname = "waBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(488,0,l),
+(488,714,l),
+(62,714,l),
+(62,659,l),
+(424,659,l),
+(424,385,l),
+(62,385,l),
+(62,330,l),
+(424,330,l),
+(424,0,l)
+);
+}
+);
+width = 571;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B7;
+unicode = 5559;
+},
+{
+glyphname = "neBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(147,0,l),
+(147,664,l),
+(194,664,l),
+(170,702,l),
+(170,679,ls),
+(170,519,o),
+(252,422,o),
+(389,422,cs),
+(525,422,o),
+(611,519,o),
+(611,674,cs),
+(611,714,l),
+(549,714,l),
+(549,672,ls),
+(549,550,o),
+(490,478,o),
+(390,478,cs),
+(291,478,o),
+(233,549,o),
+(233,671,cs),
+(233,714,l),
+(83,714,l),
+(83,0,l)
+);
+}
+);
+width = 657;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B8;
+unicode = 5560;
+},
+{
+glyphname = "niBlackfoot-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(109,0,l),
+(109,42,ls),
+(109,164,o),
+(168,236,o),
+(267,236,cs),
+(367,236,o),
+(425,165,o),
+(425,43,cs),
+(425,0,l),
+(574,0,l),
+(574,714,l),
+(510,714,l),
+(510,50,l),
+(464,50,l),
+(488,12,l),
+(488,35,ls),
+(488,195,o),
+(406,292,o),
+(268,292,cs),
+(133,292,o),
+(46,195,o),
+(46,40,cs),
+(46,0,l)
+);
+}
+);
+width = 657;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B9;
+unicode = 5561;
+},
+{
+glyphname = "noBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(233,0,l),
+(233,43,ls),
+(233,165,o),
+(291,236,o),
+(390,236,cs),
+(490,236,o),
+(549,164,o),
+(549,42,cs),
+(549,0,l),
+(611,0,l),
+(611,40,ls),
+(611,195,o),
+(525,292,o),
+(389,292,cs),
+(252,292,o),
+(170,195,o),
+(170,35,cs),
+(170,12,l),
+(194,50,l),
+(147,50,l),
+(147,714,l),
+(83,714,l),
+(83,0,l)
+);
+}
+);
+width = 657;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "neBlackfoot-canadian";
+note = uni15BA;
+unicode = 5562;
+},
+{
+glyphname = "naBlackfoot-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(574,0,l),
+(574,714,l),
+(425,714,l),
+(425,671,ls),
+(425,549,o),
+(367,478,o),
+(267,478,cs),
+(168,478,o),
+(109,550,o),
+(109,672,cs),
+(109,714,l),
+(46,714,l),
+(46,674,ls),
+(46,519,o),
+(133,422,o),
+(268,422,cs),
+(406,422,o),
+(488,519,o),
+(488,679,cs),
+(488,702,l),
+(464,664,l),
+(510,664,l),
+(510,0,l)
+);
+}
+);
+width = 657;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BB;
+unicode = 5563;
+},
+{
+glyphname = "keBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(147,0,l),
+(147,645,l),
+(120,645,l),
+(318,267,l),
+(349,267,l),
+(585,714,l),
+(518,714,l),
+(317,329,l),
+(344,329,l),
+(143,714,l),
+(83,714,l),
+(83,0,l)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15BC;
+unicode = 5564;
+},
+{
+glyphname = "kiBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,0,l),
+(298,385,l),
+(271,385,l),
+(473,0,l),
+(532,0,l),
+(532,714,l),
+(468,714,l),
+(468,69,l),
+(496,69,l),
+(298,447,l),
+(266,447,l),
+(29.993,0,l)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BD;
+unicode = 5565;
+},
+{
+glyphname = "koBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(143,0,l),
+(344,385,l),
+(317,385,l),
+(518,0,l),
+(585,0,l),
+(349,447,l),
+(318,447,l),
+(120,69,l),
+(147,69,l),
+(147,714,l),
+(83,714,l),
+(83,0,l)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "keBlackfoot-canadian";
+note = uni15BE;
+unicode = 5566;
+},
+{
+glyphname = "kaBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(532,0,l),
+(532,714,l),
+(473,714,l),
+(271,329,l),
+(298,329,l),
+(97,714,l),
+(29.993,714,l),
+(266,267,l),
+(298,267,l),
+(496,645,l),
+(468,645,l),
+(468,0,l)
+);
+}
+);
+width = 615;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BF;
+unicode = 5567;
+},
+{
+color = 9;
+glyphname = "heSayisi-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_right_can;
+pos = (546,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(577,0,l),
+(577,714,l),
+(514,714,l),
+(514,254,l),
+(527,254,l),
+(519,528,o),
+(431,727,o),
+(261,727,cs),
+(134,727,o),
+(63,640,o),
+(63,473,cs),
+(63,437,o),
+(67,394,o),
+(76,352,c),
+(137,352,l),
+(128,393,o),
+(125,436,o),
+(125,469,cs),
+(125,608,o),
+(178,670,o),
+(272,670,cs),
+(426,670,o),
+(513,459,o),
+(514,0,c)
+);
+}
+);
+width = 660;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni15C0;
+unicode = 5568;
+},
+{
+color = 9;
+glyphname = "hiSayisi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(147,0,l),
+(148,459,o),
+(235,670,o),
+(389,670,cs),
+(483,670,o),
+(536,608,o),
+(536,469,cs),
+(536,436,o),
+(533,393,o),
+(524,352,c),
+(585,352,l),
+(594,394,o),
+(598,437,o),
+(598,473,cs),
+(598,640,o),
+(527,727,o),
+(400,727,cs),
+(230,727,o),
+(142,528,o),
+(134,254,c),
+(147,254,l),
+(147,714,l),
+(83,714,l),
+(83,0,l)
+);
+}
+);
+width = 661;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C1;
+unicode = 5569;
+},
+{
+color = 9;
+glyphname = "hoSayisi-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (326,714);
+},
+{
+name = top_left_can;
+pos = (106,714);
+},
+{
+name = top_right_can;
+pos = (546,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(431,-13,o),
+(519,186,o),
+(527,460,c),
+(514,460,l),
+(514,0,l),
+(577,0,l),
+(577,714,l),
+(514,714,l),
+(513,255,o),
+(426,44,o),
+(272,44,cs),
+(178,44,o),
+(125,106,o),
+(125,245,cs),
+(125,278,o),
+(128,321,o),
+(137,362,c),
+(76,362,l),
+(67,320,o),
+(63,277,o),
+(63,241,cs),
+(63,74,o),
+(134,-13,o),
+(261,-13,cs)
+);
+}
+);
+width = 660;
+}
+);
+metricLeft = "heSayisi-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15C2;
+unicode = 5570;
+},
+{
+color = 9;
+glyphname = "haSayisi-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(527,-13,o),
+(598,74,o),
+(598,241,cs),
+(598,277,o),
+(594,320,o),
+(585,362,c),
+(524,362,l),
+(533,321,o),
+(536,278,o),
+(536,245,cs),
+(536,106,o),
+(483,44,o),
+(389,44,cs),
+(235,44,o),
+(148,255,o),
+(147,714,c),
+(83,714,l),
+(83,0,l),
+(147,0,l),
+(147,460,l),
+(134,460,l),
+(142,186,o),
+(230,-13,o),
+(400,-13,cs)
+);
+}
+);
+width = 661;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C3;
+unicode = 5571;
+},
+{
+color = 9;
+glyphname = "ghuCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(372,0,l),
+(678,694,l),
+(678,714,l),
+(624,714,l),
+(516,463,l),
+(550,477,l),
+(166,477,l),
+(201,463,l),
+(93,714,l),
+(37,714,l),
+(37,694,l),
+(343,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(531,427,l),
+(508,439,l),
+(346,66,l),
+(371,66,l),
+(209,440,l),
+(187,427,l)
+);
+}
+);
+width = 715;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C4;
+unicode = 5572;
+},
+{
+color = 9;
+glyphname = "ghoCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(93,0,l),
+(201,251,l),
+(166,237,l),
+(550,237,l),
+(516,251,l),
+(624,0,l),
+(678,0,l),
+(678,20,l),
+(372,714,l),
+(343,714,l),
+(37,20,l),
+(37,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(371,648,l),
+(346,648,l),
+(508,275,l),
+(531,287,l),
+(187,287,l),
+(209,274,l)
+);
+}
+);
+width = 715;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C5;
+unicode = 5573;
+},
+{
+color = 9;
+glyphname = "gheCarrier-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (78,357);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(78.995,0,l),
+(620,343,l),
+(620,371,l),
+(78.995,714,l),
+(59,714,l),
+(59,662,l),
+(227,555,l),
+(219,582,l),
+(219,127,l),
+(227,160,l),
+(59,53,l),
+(59,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(269,563,l),
+(255,543,l),
+(569,342,l),
+(569,372,l),
+(255,172,l),
+(269,152,l)
+);
+}
+);
+width = 657;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15C6;
+unicode = 5574;
+},
+{
+color = 9;
+glyphname = "gheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (40,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 658;
+}
+);
+note = uni15C7;
+unicode = 5575;
+},
+{
+color = 9;
+glyphname = "ghiCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (18,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 658;
+}
+);
+note = uni15C8;
+unicode = 5576;
+},
+{
+color = 9;
+glyphname = "ghaCarrier-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(597,0,l),
+(597,52,l),
+(432,158,l),
+(441,128,l),
+(441,586,l),
+(432,556,l),
+(597,662,l),
+(597,714,l),
+(578,714,l),
+(37,371,l),
+(37,343,l),
+(578,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(405,170,l),
+(88,372,l),
+(88,342,l),
+(405,544,l),
+(391,560,l),
+(391,155,l)
+);
+}
+);
+width = 656;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15C9;
+unicode = 5577;
+},
+{
+color = 9;
+glyphname = "ruCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(372,0,l),
+(678,694,l),
+(678,714,l),
+(624,714,l),
+(582,617,l),
+(601,629,l),
+(114,629,l),
+(135,616,l),
+(93,714,l),
+(37,714,l),
+(37,694,l),
+(343,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(585,577,l),
+(574,594,l),
+(347,67,l),
+(371,67,l),
+(144,593,l),
+(130,577,l)
+);
+}
+);
+width = 715;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CA;
+unicode = 5578;
+},
+{
+color = 9;
+glyphname = "roCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(92,0,l),
+(134,97,l),
+(114,85,l),
+(601,85,l),
+(582,98,l),
+(624,0,l),
+(678,0,l),
+(678,20,l),
+(372,714,l),
+(343,714,l),
+(37,20,l),
+(37,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(370,649,l),
+(346,649,l),
+(572,121,l),
+(585,137,l),
+(131,137,l),
+(142,120,l)
+);
+}
+);
+width = 715;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CB;
+unicode = 5579;
+},
+{
+color = 9;
+glyphname = "reCarrier-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(79,0,l),
+(620,343,l),
+(620,371,l),
+(79,714,l),
+(59,714,l),
+(59,662,l),
+(139,611,l),
+(128,633,l),
+(128,80,l),
+(139,103,l),
+(59,52,l),
+(59,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(179,615,l),
+(167,597,l),
+(567,342,l),
+(567,372,l),
+(167,118,l),
+(179,99,l)
+);
+}
+);
+width = 657;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CC;
+unicode = 5580;
+},
+{
+color = 9;
+glyphname = "reeCarrier-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(79,0,l),
+(620,343,l),
+(620,371,l),
+(79,714,l),
+(59,714,l),
+(59,667,l),
+(139,616,l),
+(128,636,l),
+(128,76,l),
+(139,98,l),
+(59,47,l),
+(59,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(174,618,l),
+(163,605,l),
+(577,342,l),
+(577,372,l),
+(163,109,l),
+(174,99,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(277,263,l),
+(277,453,l),
+(243,453,l),
+(243,263,l)
+);
+}
+);
+width = 657;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CD;
+unicode = 5581;
+},
+{
+color = 9;
+glyphname = "riCarrier-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(79,0,l),
+(620,343,l),
+(620,371,l),
+(79,714,l),
+(59,714,l),
+(59,667,l),
+(139,616,l),
+(128,636,l),
+(128,76,l),
+(139,98,l),
+(59,47,l),
+(59,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(302,319,o),
+(319,335,o),
+(319,357,cs),
+(319,379,o),
+(302,395,o),
+(281,395,cs),
+(260,395,o),
+(243,379,o),
+(243,357,cs),
+(243,335,o),
+(260,319,o),
+(281,319,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(174,617,l),
+(163,604,l),
+(577,342,l),
+(577,372,l),
+(163,110,l),
+(174,100,l)
+);
+}
+);
+width = 657;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CE;
+unicode = 5582;
+},
+{
+color = 9;
+glyphname = "raCarrier-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(597,0,l),
+(597,53,l),
+(519,103,l),
+(529,77,l),
+(529,637,l),
+(519,611,l),
+(597,661,l),
+(597,714,l),
+(577,714,l),
+(37,371,l),
+(37,343,l),
+(577,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(491,598,l),
+(478,615,l),
+(478,100,l),
+(491,117,l),
+(90,372,l),
+(90,342,l)
+);
+}
+);
+width = 656;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15CF;
+unicode = 5583;
+},
+{
+color = 9;
+glyphname = "wuCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(375,0,l),
+(683,694,l),
+(683,714,l),
+(632,714,l),
+(371,105,l),
+(388,105,l),
+(388,714,l),
+(335,714,l),
+(335,105,l),
+(352,105,l),
+(90,714,l),
+(37,714,l),
+(37,694,l),
+(345,0,l)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D0;
+unicode = 5584;
+},
+{
+color = 9;
+glyphname = "woCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(89,0,l),
+(350,609,l),
+(334,609,l),
+(334,0,l),
+(386,0,l),
+(386,609,l),
+(369,609,l),
+(631,0,l),
+(683,0,l),
+(683,20,l),
+(375,714,l),
+(345,714,l),
+(37,20,l),
+(37,0,l)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D1;
+unicode = 5585;
+},
+{
+color = 9;
+glyphname = "weCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,0,l),
+(641,343,l),
+(641,371,l),
+(100,714,l),
+(80,714,l),
+(80,662,l),
+(548,367,l),
+(548,383,l),
+(81,383,l),
+(81,332,l),
+(548,332,l),
+(548,347,l),
+(80,52,l),
+(80,0,l)
+);
+}
+);
+width = 678;
+}
+);
+metricRight = "o-canadian";
+note = uni15D2;
+unicode = 5586;
+},
+{
+color = 9;
+glyphname = "weeCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,0,l),
+(641,343,l),
+(641,371,l),
+(100,714,l),
+(80,714,l),
+(80,666,l),
+(559,365,l),
+(563,379,l),
+(206,379,l),
+(206,466,l),
+(166,466,l),
+(166,379,l),
+(80,379,l),
+(80,336,l),
+(166,336,l),
+(166,249,l),
+(206,249,l),
+(206,336,l),
+(565,336,l),
+(561,350,l),
+(80,48,l),
+(80,0,l)
+);
+}
+);
+width = 678;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D3;
+unicode = 5587;
+},
+{
+color = 9;
+glyphname = "wiCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,0,l),
+(641,343,l),
+(641,371,l),
+(100,714,l),
+(80,714,l),
+(80,666,l),
+(559,365,l),
+(564,379,l),
+(275,379,l),
+(267,403,o),
+(244,420,o),
+(218,420,cs),
+(191,420,o),
+(169,403,o),
+(161,379,c),
+(80,379,l),
+(80,336,l),
+(161,336,l),
+(170,313,o),
+(192,295,o),
+(218,295,cs),
+(244,295,o),
+(266,313,o),
+(274,336,c),
+(566,336,l),
+(561,350,l),
+(80,48,l),
+(80,0,l)
+);
+}
+);
+width = 678;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D4;
+unicode = 5588;
+},
+{
+color = 9;
+glyphname = "waCarrier-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(597,0,l),
+(597,52,l),
+(130,347,l),
+(130,331,l),
+(596,331,l),
+(596,382,l),
+(130,382,l),
+(130,367,l),
+(597,662,l),
+(597,714,l),
+(578,714,l),
+(37,371,l),
+(37,343,l),
+(578,0,l)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15D5;
+unicode = 5589;
+},
+{
+color = 9;
+glyphname = "hwuCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(375,0,l),
+(683,694,l),
+(683,714,l),
+(634,714,l),
+(529,470,l),
+(554,483,l),
+(383,483,l),
+(383.004,714,l),
+(338,714,l),
+(338,483,l),
+(166,483,l),
+(192,471,l),
+(87,714,l),
+(37,714,l),
+(37,694,l),
+(345,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(341,443,l),
+(341,92,l),
+(353,94,l),
+(197,456,l),
+(182,443,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(380,443,l),
+(539,443,l),
+(525,456,l),
+(368,94,l),
+(380,91,l)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D6;
+unicode = 5590;
+},
+{
+color = 9;
+glyphname = "hwoCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(87,0,l),
+(193,244,l),
+(167,230,l),
+(338,230,l),
+(338,0,l),
+(383,0,l),
+(383,230,l),
+(556,230,l),
+(529,244,l),
+(634,0,l),
+(683,0,l),
+(683,20,l),
+(375,714,l),
+(345,714,l),
+(37,20,l),
+(37,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(348,611,l),
+(340,613,l),
+(340,272,l),
+(186,272,l),
+(196,258,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(537,272,l),
+(380,272,l),
+(380,614,l),
+(372,612,l),
+(524,258,l)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D7;
+unicode = 5591;
+},
+{
+color = 9;
+glyphname = "hweCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,0,l),
+(641,343,l),
+(641,371,l),
+(100,714,l),
+(80,714,l),
+(80,666,l),
+(238,567,l),
+(238,380,l),
+(80,380,l),
+(80,335,l),
+(238,335,l),
+(238,147,l),
+(80,47,l),
+(80,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(276,338,l),
+(548,338,l),
+(276,167,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(276,547,l),
+(545,377,l),
+(276,377,l)
+);
+}
+);
+width = 678;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D8;
+unicode = 5592;
+},
+{
+color = 9;
+glyphname = "hweeCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,0,l),
+(641,343,l),
+(641,371,l),
+(100,714,l),
+(80,714,l),
+(80,667,l),
+(250,562,l),
+(250,378,l),
+(189,378,l),
+(189,464,l),
+(153,464,l),
+(153,378,l),
+(80,378,l),
+(80,337,l),
+(153,337,l),
+(153,251,l),
+(189,251,l),
+(189,337,l),
+(250,337,l),
+(250,152,l),
+(80,47,l),
+(80,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(285,339,l),
+(550,339,l),
+(285,171,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(285,542,l),
+(548,376,l),
+(285,376,l)
+);
+}
+);
+width = 678;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D9;
+unicode = 5593;
+},
+{
+color = 9;
+glyphname = "hwiCarrier-canadian";
+lastChange = "2023-01-13 15:28:12 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,0,l),
+(641,343,l),
+(641,371,l),
+(100,714,l),
+(80,714,l),
+(80,667,l),
+(250,562,l),
+(250,376,l),
+(219,376,l),
+(212,398,o),
+(192,414,o),
+(167,414,cs),
+(143,414,o),
+(124,398,o),
+(117,376,c),
+(80,376,l),
+(80,339,l),
+(117,339,l),
+(124,318,o),
+(144,301,o),
+(168,301,cs),
+(191,301,o),
+(211,318,o),
+(218,339,c),
+(250,339,l),
+(250,152,l),
+(80,47,l),
+(80,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(285,339,l),
+(550,339,l),
+(285,171,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(285,542,l),
+(548,376,l),
+(285,376,l)
+);
+}
+);
+width = 678;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15DA;
+unicode = 5594;
+},
+{
+color = 9;
+glyphname = "hwaCarrier-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(597,0,l),
+(597,48,l),
+(439,147,l),
+(439,334,l),
+(597,334,l),
+(597,379,l),
+(439,379,l),
+(439,567,l),
+(597,666,l),
+(597,714,l),
+(578,714,l),
+(37,371,l),
+(37,343,l),
+(578,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(132,337,l),
+(401,337,l),
+(401,167,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(401,547,l),
+(401,376,l),
+(130,376,l)
+);
+}
+);
+width = 677;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15DB;
+unicode = 5595;
+},
+{
+color = 9;
+glyphname = "thuCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(530,-13,o),
+(637,102,o),
+(637,303,cs),
+(637,714,l),
+(76,714,l),
+(76,299,ls),
+(76,101,o),
+(185,-13,o),
+(356,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(139,656,l),
+(573,656,l),
+(573,300,ls),
+(573,134,o),
+(494,47,o),
+(356,47,cs),
+(222,47,o),
+(139,135,o),
+(139,300,cs)
+);
+}
+);
+width = 713;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DC;
+unicode = 5596;
+},
+{
+color = 9;
+glyphname = "thoCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(637,0,l),
+(637,415,ls),
+(637,612,o),
+(528,727,o),
+(358,727,cs),
+(183,727,o),
+(76,613,o),
+(76,411,cs),
+(76,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(139,414,ls),
+(139,580,o),
+(221,667,o),
+(357,667,cs),
+(491,667,o),
+(573,579,o),
+(573,414,cs),
+(573,58,l),
+(139,58,l)
+);
+}
+);
+width = 713;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DD;
+unicode = 5597;
+},
+{
+color = 9;
+glyphname = "theCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (344,357);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(295,0,ls),
+(505,0,o),
+(622,134,o),
+(622,358,cs),
+(622,582,o),
+(505,714,o),
+(291,714,cs),
+(83,714,l),
+(83,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(147,679,l),
+(125,657,l),
+(291,657,ls),
+(468,657,o),
+(558,550,o),
+(558,358,cs),
+(558,167,o),
+(468,57,o),
+(293,57,cs),
+(125,57,l),
+(147,35,l)
+);
+}
+);
+width = 691;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "to-canadian";
+note = uni15DE;
+unicode = 5598;
+},
+{
+color = 9;
+glyphname = "theeCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (303,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 691;
+}
+);
+note = uni15DF;
+unicode = 5599;
+},
+{
+color = 9;
+glyphname = "thiCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (280,0);
+ref = dot_middle;
+}
+);
+width = 691;
+}
+);
+note = uni15E0;
+unicode = 5600;
+},
+{
+color = 9;
+glyphname = "thaCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(608,0,l),
+(608,714,l),
+(399,714,ls),
+(186,714,o),
+(69,581,o),
+(69,357,cs),
+(69,133,o),
+(186,0,o),
+(398,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(133,548,o),
+(223,657,o),
+(399,657,cs),
+(566,657,l),
+(544,679,l),
+(544,35,l),
+(566,57,l),
+(400,57,ls),
+(223,57,o),
+(133,165,o),
+(133,357,cs)
+);
+}
+);
+width = 691;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15E1;
+unicode = 5601;
+},
+{
+color = 9;
+glyphname = "ttuCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(530,-13,o),
+(637,102,o),
+(637,303,cs),
+(637,714,l),
+(609,714,l),
+(348,520,l),
+(366,520,l),
+(105,714,l),
+(76,714,l),
+(76,299,ls),
+(76,101,o),
+(185,-13,o),
+(356,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(222,47,o),
+(139,135,o),
+(139,300,cs),
+(139,664,l),
+(86,663,l),
+(347,469,l),
+(366,469,l),
+(627,663,l),
+(573,664,l),
+(573,300,ls),
+(573,134,o),
+(494,47,o),
+(356,47,cs)
+);
+}
+);
+width = 713;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E2;
+unicode = 5602;
+},
+{
+color = 9;
+glyphname = "ttoCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(104,0,l),
+(365,194,l),
+(347,194,l),
+(607,0,l),
+(637,0,l),
+(637,415,ls),
+(637,613,o),
+(528,727,o),
+(356,727,cs),
+(182,727,o),
+(76,612,o),
+(76,411,cs),
+(76,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(491,667,o),
+(573,579,o),
+(573,414,cs),
+(573,50,l),
+(627,51,l),
+(365,245,l),
+(347,245,l),
+(86,51,l),
+(139,50,l),
+(139,414,ls),
+(139,580,o),
+(219,667,o),
+(357,667,cs)
+);
+}
+);
+width = 713;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E3;
+unicode = 5603;
+},
+{
+color = 9;
+glyphname = "tteCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (397,357);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(305,0,ls),
+(515,0,o),
+(632,134,o),
+(632,358,cs),
+(632,582,o),
+(515,714,o),
+(300,714,cs),
+(75,714,l),
+(75,694,l),
+(203,345,l),
+(203,369,l),
+(75,20,l),
+(75,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(259,347,l),
+(259,364,l),
+(133,708,l),
+(133,657,l),
+(301,657,ls),
+(478,657,o),
+(568,550,o),
+(568,358,cs),
+(568,167,o),
+(478,57,o),
+(303,57,cs),
+(133,57,l),
+(133,4,l)
+);
+}
+);
+width = 701;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15E4;
+unicode = 5604;
+},
+{
+color = 9;
+glyphname = "tteeCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (359,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 701;
+}
+);
+note = uni15E5;
+unicode = 5605;
+},
+{
+color = 9;
+glyphname = "ttiCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (342,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 701;
+}
+);
+note = uni15E6;
+unicode = 5606;
+},
+{
+color = 9;
+glyphname = "ttaCarrier-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(625,0,l),
+(625,20,l),
+(498,369,l),
+(498,345,l),
+(625,694,l),
+(625,714,l),
+(399,714,ls),
+(186,714,o),
+(69,581,o),
+(69,357,cs),
+(69,133,o),
+(186,0,o),
+(398,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(568,57,l),
+(400,57,ls),
+(223,57,o),
+(133,165,o),
+(133,357,cs),
+(133,548,o),
+(223,657,o),
+(399,657,cs),
+(568,657,l),
+(568,710,l),
+(442,367,l),
+(442,350,l),
+(568,7,l)
+);
+}
+);
+width = 700;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tteCarrier-canadian";
+note = uni15E7;
+unicode = 5607;
+},
+{
+color = 9;
+glyphname = "puCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(530,-13,o),
+(637,102,o),
+(637,303,cs),
+(637,714,l),
+(573,714,l),
+(573,535,l),
+(140,535,l),
+(140,714,l),
+(76,714,l),
+(76,299,ls),
+(76,101,o),
+(185,-13,o),
+(356,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(222,47,o),
+(140,135,o),
+(140,300,cs),
+(140,479,l),
+(573,479,l),
+(573,300,ls),
+(573,134,o),
+(494,47,o),
+(356,47,cs)
+);
+}
+);
+width = 713;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E8;
+unicode = 5608;
+},
+{
+color = 9;
+glyphname = "poCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(140,0,l),
+(140,179,l),
+(573,179,l),
+(573,0,l),
+(637,0,l),
+(637,415,ls),
+(637,612,o),
+(529,727,o),
+(358,727,cs),
+(184,727,o),
+(76,613,o),
+(76,411,cs),
+(76,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(140,414,ls),
+(140,580,o),
+(221,667,o),
+(357,667,cs),
+(491,667,o),
+(573,579,o),
+(573,414,cs),
+(573,235,l),
+(140,235,l)
+);
+}
+);
+width = 713;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E9;
+unicode = 5609;
+},
+{
+color = 9;
+glyphname = "peCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (385,357);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(299,0,ls),
+(509,0,o),
+(626,134,o),
+(626,358,cs),
+(626,582,o),
+(509,714,o),
+(294,714,cs),
+(69,714,l),
+(69,657,l),
+(163,657,l),
+(163,57,l),
+(69,57,l),
+(69,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(226,679,l),
+(201,657,l),
+(295,657,ls),
+(472,657,o),
+(562,550,o),
+(562,358,cs),
+(562,167,o),
+(472,57,o),
+(297,57,cs),
+(201,57,l),
+(226,35,l)
+);
+}
+);
+width = 695;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15EA;
+unicode = 5610;
+},
+{
+color = 9;
+glyphname = "peeCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (347,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 695;
+}
+);
+note = uni15EB;
+unicode = 5611;
+},
+{
+color = 9;
+glyphname = "piCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (330,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 695;
+}
+);
+note = uni15EC;
+unicode = 5612;
+},
+{
+color = 9;
+glyphname = "paCarrier-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(625,0,l),
+(625,57,l),
+(532,57,l),
+(532,657,l),
+(625,657,l),
+(625,714,l),
+(400,714,ls),
+(186,714,o),
+(69,582,o),
+(69,358,cs),
+(69,134,o),
+(186,0,o),
+(396,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(493,57,l),
+(398,57,ls),
+(223,57,o),
+(133,167,o),
+(133,358,cs),
+(133,550,o),
+(223,657,o),
+(400,657,cs),
+(493,657,l),
+(469,679,l),
+(469,35,l)
+);
+}
+);
+width = 694;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|peCarrier-canadian";
+note = uni15ED;
+unicode = 5613;
+},
+{
+color = 6;
+glyphname = "pCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(389,189,l),
+(389,234,l),
+(253,234,l),
+(253,546,l),
+(205,546,l),
+(205,234,l),
+(68,234,l),
+(68,189,l)
+);
+}
+);
+width = 457;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni15EE;
+unicode = 5614;
+},
+{
+color = 9;
+glyphname = "guCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (434,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(359,-13,o),
+(423,41,o),
+(446,139,c),
+(422,139,l),
+(448,40,o),
+(511,-13,o),
+(598,-13,cs),
+(715,-13,o),
+(787,71,o),
+(787,214,cs),
+(787,714,l),
+(725,714,l),
+(725,216,ls),
+(725,105,o),
+(678,45,o),
+(595,45,cs),
+(514,45,o),
+(464,107,o),
+(464,215,cs),
+(464,714,l),
+(404,714,l),
+(404,215,ls),
+(404,104,o),
+(354,45,o),
+(272,45,cs),
+(188,45,o),
+(140,104,o),
+(140,216,cs),
+(140,714,l),
+(78,714,l),
+(78,216,ls),
+(78,70,o),
+(151,-13,o),
+(269,-13,cs)
+);
+}
+);
+width = 865;
+}
+);
+metricRight = "=|";
+note = uni15EF;
+unicode = 5615;
+},
+{
+color = 9;
+glyphname = "goCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(140,0,l),
+(140,498,ls),
+(140,609,o),
+(187,669,o),
+(271,669,cs),
+(353,669,o),
+(403,609,o),
+(403,499,cs),
+(403,0,l),
+(463,0,l),
+(463,499,ls),
+(463,608,o),
+(513,669,o),
+(594,669,cs),
+(678,669,o),
+(725,609,o),
+(725,498,cs),
+(725,0,l),
+(787,0,l),
+(787,499,ls),
+(787,643,o),
+(714,727,o),
+(597,727,cs),
+(509,727,o),
+(445,673,o),
+(421,575,c),
+(445,575,l),
+(420,674,o),
+(357,727,o),
+(268,727,cs),
+(150,727,o),
+(78,643,o),
+(78,499,cs),
+(78,0,l)
+);
+}
+);
+width = 865;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F0;
+unicode = 5616;
+},
+{
+color = 9;
+glyphname = "geCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (353,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(407,0,ls),
+(548,0,o),
+(622,69,o),
+(622,188,cs),
+(622,275,o),
+(570,341,o),
+(488,366,c),
+(488,348,l),
+(572,371,o),
+(622,434,o),
+(622,524,cs),
+(622,644,o),
+(547,714,o),
+(407,714,cs),
+(83,714,l),
+(83,660,l),
+(397,660,ls),
+(507,660,o),
+(558,613,o),
+(558,523,cs),
+(558,433,o),
+(501,384,o),
+(399,384,cs),
+(83,384,l),
+(83,331,l),
+(400,331,ls),
+(502,331,o),
+(558,279,o),
+(558,190,cs),
+(558,101,o),
+(507,54,o),
+(397,54,cs),
+(83,54,l),
+(83,0,l)
+);
+}
+);
+width = 701;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15F1;
+unicode = 5617;
+},
+{
+color = 9;
+glyphname = "geeCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(407,0,ls),
+(548,0,o),
+(622,69,o),
+(622,188,cs),
+(622,275,o),
+(570,341,o),
+(488,366,c),
+(488,348,l),
+(572,371,o),
+(622,434,o),
+(622,524,cs),
+(622,644,o),
+(547,714,o),
+(407,714,cs),
+(83,714,l),
+(83,660,l),
+(397,660,ls),
+(507,660,o),
+(558,613,o),
+(558,523,cs),
+(558,433,o),
+(501,384,o),
+(399,384,cs),
+(340,384,l),
+(340,474,l),
+(298,474,l),
+(298,384,l),
+(83,384,l),
+(83,331,l),
+(298,331,l),
+(298,242,l),
+(340,242,l),
+(340,331,l),
+(400,331,ls),
+(502,331,o),
+(558,279,o),
+(558,190,cs),
+(558,101,o),
+(507,54,o),
+(397,54,cs),
+(83,54,l),
+(83,0,l)
+);
+}
+);
+width = 701;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F2;
+unicode = 5618;
+},
+{
+color = 9;
+glyphname = "giCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(407,0,ls),
+(548,0,o),
+(622,69,o),
+(622,188,cs),
+(622,277,o),
+(567,345,o),
+(480,366,c),
+(479,348,l),
+(568,368,o),
+(622,432,o),
+(622,524,cs),
+(622,644,o),
+(547,714,o),
+(407,714,cs),
+(83,714,l),
+(83,660,l),
+(397,660,ls),
+(507,660,o),
+(558,613,o),
+(558,523,cs),
+(558,433,o),
+(501,384,o),
+(401,384,cs),
+(361,384,l),
+(384,376,l),
+(376,405,o),
+(350,425,o),
+(320,425,cs),
+(293,425,o),
+(270,408,o),
+(260,384,c),
+(83,384,l),
+(83,331,l),
+(261,331,l),
+(270,307,o),
+(294,290,o),
+(321,290,cs),
+(350,290,o),
+(375,310,o),
+(384,339,c),
+(361,331,l),
+(402,331,ls),
+(502,331,o),
+(558,279,o),
+(558,190,cs),
+(558,101,o),
+(507,54,o),
+(397,54,cs),
+(83,54,l),
+(83,0,l)
+);
+}
+);
+width = 701;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F3;
+unicode = 5619;
+},
+{
+color = 9;
+glyphname = "gaCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (366,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(618,0,l),
+(618,54,l),
+(304,54,ls),
+(194,54,o),
+(143,101,o),
+(143,190,cs),
+(143,279,o),
+(199,331,o),
+(301,331,cs),
+(618,331,l),
+(618,384,l),
+(302,384,ls),
+(200,384,o),
+(143,433,o),
+(143,523,cs),
+(143,613,o),
+(194,660,o),
+(304,660,cs),
+(618,660,l),
+(618,714,l),
+(294,714,ls),
+(154,714,o),
+(79,644,o),
+(79,524,cs),
+(79,434,o),
+(129,371,o),
+(213,349,c),
+(213,367,l),
+(131,342,o),
+(79,275,o),
+(79,188,cs),
+(79,69,o),
+(153,0,o),
+(294,0,cs)
+);
+}
+);
+width = 701;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|geCarrier-canadian";
+note = uni15F4;
+unicode = 5620;
+},
+{
+color = 9;
+glyphname = "khuCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(359,-13,o),
+(423,41,o),
+(446,139,c),
+(422,139,l),
+(449,40,o),
+(512,-13,o),
+(599,-13,cs),
+(716,-13,o),
+(787,71,o),
+(787,214,cs),
+(787,714,l),
+(78,714,l),
+(78,216,ls),
+(78,70,o),
+(151,-13,o),
+(269,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(188,45,o),
+(140,104,o),
+(140,216,cs),
+(140,658,l),
+(404,658,l),
+(404,215,ls),
+(404,104,o),
+(355,45,o),
+(272,45,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(514,45,o),
+(464,107,o),
+(464,215,cs),
+(464,658,l),
+(725,658,l),
+(725,216,ls),
+(725,105,o),
+(678,45,o),
+(595,45,cs)
+);
+}
+);
+width = 865;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F5;
+unicode = 5621;
+},
+{
+color = 9;
+glyphname = "khoCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(787,0,l),
+(787,499,ls),
+(787,643,o),
+(715,727,o),
+(598,727,cs),
+(510,727,o),
+(447,674,o),
+(421,575,c),
+(445,575,l),
+(421,673,o),
+(357,727,o),
+(268,727,cs),
+(151,727,o),
+(78,644,o),
+(78,499,cs),
+(78,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(140,498,ls),
+(140,609,o),
+(187,669,o),
+(271,669,cs),
+(353,669,o),
+(403,609,o),
+(403,499,cs),
+(403,56,l),
+(140,56,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(463,499,ls),
+(463,608,o),
+(513,669,o),
+(595,669,cs),
+(678,669,o),
+(725,609,o),
+(725,498,cs),
+(725,56,l),
+(463,56,l)
+);
+}
+);
+width = 865;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F6;
+unicode = 5622;
+},
+{
+color = 9;
+glyphname = "kheCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(409,0,ls),
+(550,0,o),
+(624,69,o),
+(624,188,cs),
+(624,275,o),
+(573,341,o),
+(490,366,c),
+(490,348,l),
+(574,371,o),
+(624,434,o),
+(624,524,cs),
+(624,644,o),
+(549,714,o),
+(409,714,cs),
+(83,714,l),
+(83,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(147,331,l),
+(402,331,ls),
+(504,331,o),
+(560,279,o),
+(560,190,cs),
+(560,101,o),
+(509,54,o),
+(399,54,cs),
+(147,54,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(147,660,l),
+(399,660,ls),
+(509,660,o),
+(560,613,o),
+(560,523,cs),
+(560,433,o),
+(503,384,o),
+(401,384,cs),
+(147,384,l)
+);
+}
+);
+width = 703;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F7;
+unicode = 5623;
+},
+{
+color = 9;
+glyphname = "kheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(409,0,ls),
+(550,0,o),
+(624,69,o),
+(624,188,cs),
+(624,276,o),
+(571,344,o),
+(485,366,c),
+(485,348,l),
+(572,368,o),
+(624,433,o),
+(624,524,cs),
+(624,644,o),
+(549,714,o),
+(409,714,cs),
+(83,714,l),
+(83,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(147,331,l),
+(313,331,l),
+(313,239,l),
+(358,239,l),
+(358,346,l),
+(341,331,l),
+(404,331,ls),
+(505,331,o),
+(560,280,o),
+(560,190,cs),
+(560,101,o),
+(509,54,o),
+(399,54,cs),
+(147,54,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(358,476,l),
+(313,476,l),
+(313,384,l),
+(147,384,l),
+(147,660,l),
+(399,660,ls),
+(509,660,o),
+(560,613,o),
+(560,523,cs),
+(560,432,o),
+(504,384,o),
+(403,384,cs),
+(341,384,l),
+(358,369,l)
+);
+}
+);
+width = 703;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F8;
+unicode = 5624;
+},
+{
+color = 9;
+glyphname = "khiCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(409,0,ls),
+(550,0,o),
+(624,69,o),
+(624,188,cs),
+(624,275,o),
+(573,340,o),
+(491,365,c),
+(490,348,l),
+(574,371,o),
+(624,434,o),
+(624,524,cs),
+(624,644,o),
+(549,714,o),
+(409,714,cs),
+(83,714,l),
+(83,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(147,332,l),
+(274,332,l),
+(283,308,o),
+(306,290,o),
+(334,290,cs),
+(368,290,o),
+(395,317,o),
+(399,351,c),
+(365,332,l),
+(405,332,ls),
+(505,332,o),
+(560,280,o),
+(560,191,cs),
+(560,101,o),
+(509,54,o),
+(399,54,cs),
+(147,54,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(399,660,ls),
+(509,660,o),
+(560,613,o),
+(560,522,cs),
+(560,432,o),
+(504,383,o),
+(404,383,cs),
+(366,383,l),
+(400,364,l),
+(397,399,o),
+(368,425,o),
+(333,425,cs),
+(299,425,o),
+(271,398,o),
+(268,364,c),
+(291,383,l),
+(147,383,l),
+(147,660,l)
+);
+}
+);
+width = 703;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F9;
+unicode = 5625;
+},
+{
+color = 9;
+glyphname = "khaCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(620,0,l),
+(620,714,l),
+(294,714,ls),
+(154,714,o),
+(79,644,o),
+(79,524,cs),
+(79,434,o),
+(129,371,o),
+(214,349,c),
+(213,366,l),
+(131,342,o),
+(79,275,o),
+(79,188,cs),
+(79,69,o),
+(153,0,o),
+(294,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(194,54,o),
+(143,101,o),
+(143,190,cs),
+(143,279,o),
+(199,331,o),
+(301,331,cs),
+(556,331,l),
+(556,54,l),
+(304,54,ls)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,384,o),
+(143,433,o),
+(143,523,cs),
+(143,613,o),
+(194,660,o),
+(304,660,cs),
+(556,660,l),
+(556,384,l),
+(302,384,ls)
+);
+}
+);
+width = 703;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15FA;
+unicode = 5626;
+},
+{
+color = 9;
+glyphname = "kkuCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(363,-13,o),
+(428,46,o),
+(448,152,c),
+(420,152,l),
+(443,45,o),
+(508,-13,o),
+(598,-13,cs),
+(715,-13,o),
+(787,71,o),
+(787,214,cs),
+(787,714,l),
+(758,714,l),
+(452,535,l),
+(452,474,l),
+(764,656,l),
+(725,659,l),
+(725,216,ls),
+(725,105,o),
+(678,45,o),
+(595,45,cs),
+(514,45,o),
+(464,107,o),
+(464,215,cs),
+(464,714,l),
+(404,714,l),
+(404,215,ls),
+(404,104,o),
+(354,45,o),
+(272,45,cs),
+(188,45,o),
+(140,104,o),
+(140,216,cs),
+(140,659,l),
+(101,655,l),
+(413,475,l),
+(413,536,l),
+(108,714,l),
+(78,714,l),
+(78,216,ls),
+(78,70,o),
+(151,-13,o),
+(269,-13,cs)
+);
+}
+);
+width = 865;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FB;
+unicode = 5627;
+},
+{
+color = 9;
+glyphname = "kkoCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(107,0,l),
+(413,179,l),
+(413,240,l),
+(100,58,l),
+(140,55,l),
+(140,498,ls),
+(140,609,o),
+(186,669,o),
+(269,669,cs),
+(350,669,o),
+(400,607,o),
+(400,499,cs),
+(400,0,l),
+(461,0,l),
+(461,499,ls),
+(461,610,o),
+(510,669,o),
+(592,669,cs),
+(677,669,o),
+(725,610,o),
+(725,498,cs),
+(725,55,l),
+(764,59,l),
+(452,239,l),
+(452,178,l),
+(757,0,l),
+(787,0,l),
+(787,498,ls),
+(787,644,o),
+(713,727,o),
+(596,727,cs),
+(502,727,o),
+(436,668,o),
+(417,562,c),
+(445,562,l),
+(422,669,o),
+(357,727,o),
+(266,727,cs),
+(149,727,o),
+(78,643,o),
+(78,500,cs),
+(78,0,l)
+);
+}
+);
+width = 865;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FC;
+unicode = 5628;
+},
+{
+color = 9;
+glyphname = "kkeCarrier-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(424,0,ls),
+(564,0,o),
+(638,69,o),
+(638,188,cs),
+(638,274,o),
+(587,341,o),
+(505,365,c),
+(504,348,l),
+(589,371,o),
+(638,434,o),
+(638,524,cs),
+(638,644,o),
+(563,714,o),
+(424,714,cs),
+(80,714,l),
+(80,694,l),
+(193,384,l),
+(86,384,l),
+(86,331,l),
+(193,331,l),
+(80,20,l),
+(80,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(258,331,l),
+(417,331,ls),
+(519,331,o),
+(575,279,o),
+(575,190,cs),
+(575,101,o),
+(524,54,o),
+(413,54,cs),
+(128,54,l),
+(147,27,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(146,687,l),
+(127,660,l),
+(413,660,ls),
+(523,660,o),
+(575,613,o),
+(575,523,cs),
+(575,433,o),
+(518,384,o),
+(416,384,cs),
+(256,384,l)
+);
+}
+);
+width = 717;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni15FD;
+unicode = 5629;
+},
+{
+color = 9;
+glyphname = "kkeeCarrier-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(424,0,ls),
+(564,0,o),
+(638,69,o),
+(638,188,cs),
+(638,274,o),
+(587,341,o),
+(505,365,c),
+(504,348,l),
+(589,371,o),
+(638,434,o),
+(638,524,cs),
+(638,644,o),
+(563,714,o),
+(424,714,cs),
+(80,714,l),
+(80,694,l),
+(193,384,l),
+(86,384,l),
+(86,331,l),
+(193,331,l),
+(80,20,l),
+(80,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(257,332,l),
+(348,332,l),
+(348,242,l),
+(393,242,l),
+(393,347,l),
+(374,332,l),
+(420,332,ls),
+(519,332,o),
+(575,280,o),
+(575,191,cs),
+(575,101,o),
+(524,54,o),
+(413,54,cs),
+(128,54,l),
+(147,27,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(393,474,l),
+(348,474,l),
+(348,383,l),
+(256,383,l),
+(146,687,l),
+(127,660,l),
+(413,660,ls),
+(523,660,o),
+(575,612,o),
+(575,522,cs),
+(575,432,o),
+(519,383,o),
+(419,383,cs),
+(374,383,l),
+(393,369,l)
+);
+}
+);
+width = 717;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FE;
+unicode = 5630;
+},
+{
+color = 9;
+glyphname = "kkiCarrier-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(424,0,ls),
+(564,0,o),
+(638,69,o),
+(638,188,cs),
+(638,274,o),
+(587,341,o),
+(505,365,c),
+(504,348,l),
+(589,371,o),
+(638,434,o),
+(638,524,cs),
+(638,644,o),
+(563,714,o),
+(424,714,cs),
+(80,714,l),
+(80,694,l),
+(193,384,l),
+(86,384,l),
+(86,331,l),
+(193,331,l),
+(80,20,l),
+(80,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(258,333,l),
+(306,333,l),
+(315,308,o),
+(339,290,o),
+(366,290,cs),
+(401,290,o),
+(427,317,o),
+(431,350,c),
+(395,333,l),
+(420,333,ls),
+(519,333,o),
+(575,280,o),
+(575,190,cs),
+(575,101,o),
+(524,54,o),
+(413,54,cs),
+(128,54,l),
+(147,27,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(429,398,o),
+(401,425,o),
+(366,425,cs),
+(338,425,o),
+(315,407,o),
+(306,382,c),
+(256,382,l),
+(146,687,l),
+(127,660,l),
+(413,660,ls),
+(523,660,o),
+(575,612,o),
+(575,522,cs),
+(575,432,o),
+(519,382,o),
+(419,382,cs),
+(395,382,l),
+(431,365,l)
+);
+}
+);
+width = 717;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FF;
+unicode = 5631;
+},
+{
+color = 9;
+glyphname = "kkaCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(638,0,l),
+(638,20,l),
+(525,331,l),
+(622,331,l),
+(622,384,l),
+(525,384,l),
+(638,694,l),
+(638,714,l),
+(294,714,ls),
+(154,714,o),
+(79,644,o),
+(79,524,cs),
+(79,434,o),
+(129,371,o),
+(214,349,c),
+(213,366,l),
+(131,342,o),
+(79,274,o),
+(79,188,cs),
+(79,69,o),
+(153,0,o),
+(294,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(590,54,l),
+(304,54,ls),
+(194,54,o),
+(143,101,o),
+(143,190,cs),
+(143,279,o),
+(199,331,o),
+(301,331,cs),
+(460,331,l),
+(571,27,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,384,o),
+(143,433,o),
+(143,523,cs),
+(143,613,o),
+(194,660,o),
+(304,660,cs),
+(590,660,l),
+(571,687,l),
+(461,384,l),
+(302,384,ls)
+);
+}
+);
+width = 718;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|kkeCarrier-canadian";
+note = uni1600;
+unicode = 5632;
+},
+{
+color = 6;
+glyphname = "kkCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(223,189,l),
+(376,534,l),
+(376,546,l),
+(332,546,l),
+(198,235,l),
+(234,235,l),
+(100,546,l),
+(55,546,l),
+(55,534,l),
+(208,189,l)
+);
+}
+);
+width = 431;
+}
+);
+note = uni1601;
+unicode = 5633;
+},
+{
+color = 9;
+glyphname = "nuCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(535,-13,o),
+(637,91,o),
+(637,269,cs),
+(637,309,l),
+(573,309,l),
+(573,266,ls),
+(573,120,o),
+(493,46,o),
+(363,46,cs),
+(216,46,o),
+(140,129,o),
+(140,296,cs),
+(140,714,l),
+(76,714,l),
+(76,292,ls),
+(76,94,o),
+(180,-13,o),
+(362,-13,cs)
+);
+}
+);
+width = 710;
+}
+);
+metricLeft = "te-canadian";
+note = uni1602;
+unicode = 5634;
+},
+{
+color = 9;
+glyphname = "noCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(634,0,l),
+(634,422,ls),
+(634,620,o),
+(531,727,o),
+(348,727,cs),
+(175,727,o),
+(73,623,o),
+(73,445,cs),
+(73,405,l),
+(136,405,l),
+(136,448,ls),
+(136,594,o),
+(217,668,o),
+(347,668,cs),
+(494,668,o),
+(570,585,o),
+(570,418,cs),
+(570,0,l)
+);
+}
+);
+width = 710;
+}
+);
+metricLeft = "=|nuCarrier-canadian";
+metricRight = "te-canadian";
+note = uni1603;
+unicode = 5635;
+},
+{
+color = 9;
+glyphname = "neCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (299,357);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(299,0,ls),
+(504,0,o),
+(622,134,o),
+(622,358,cs),
+(622,582,o),
+(505,714,o),
+(291,714,cs),
+(57,714,l),
+(57,656,l),
+(291,656,ls),
+(467,656,o),
+(558,549,o),
+(558,358,cs),
+(558,167,o),
+(466,58,o),
+(296,58,cs),
+(276,58,l),
+(276,0,l)
+);
+}
+);
+width = 691;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1604;
+unicode = 5636;
+},
+{
+color = 9;
+glyphname = "neeCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+ref = "neCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (258,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 691;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1605;
+unicode = 5637;
+},
+{
+color = 9;
+glyphname = "niCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "neCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (234,0);
+ref = dot_middle;
+}
+);
+width = 691;
+}
+);
+note = uni1606;
+unicode = 5638;
+},
+{
+color = 9;
+glyphname = "naCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(634,0,l),
+(634,58,l),
+(400,58,ls),
+(224,58,o),
+(133,166,o),
+(133,357,cs),
+(133,548,o),
+(225,656,o),
+(395,656,cs),
+(415,656,l),
+(415,714,l),
+(392,714,ls),
+(187,714,o),
+(69,581,o),
+(69,357,cs),
+(69,133,o),
+(186,0,o),
+(398,0,cs)
+);
+}
+);
+width = 691;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni1607;
+unicode = 5639;
+},
+{
+color = 9;
+glyphname = "muCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(359,-13,o),
+(423,41,o),
+(446,139,c),
+(422,139,l),
+(448,40,o),
+(511,-13,o),
+(598,-13,cs),
+(715,-13,o),
+(787,71,o),
+(787,214,cs),
+(787,402,l),
+(725,402,l),
+(725,216,ls),
+(725,105,o),
+(678,45,o),
+(595,45,cs),
+(514,45,o),
+(464,107,o),
+(464,215,cs),
+(464,402,l),
+(404,402,l),
+(404,215,ls),
+(404,104,o),
+(354,45,o),
+(272,45,cs),
+(188,45,o),
+(140,104,o),
+(140,216,cs),
+(140,714,l),
+(78,714,l),
+(78,216,ls),
+(78,70,o),
+(151,-13,o),
+(269,-13,cs)
+);
+}
+);
+width = 865;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "=|";
+note = uni1608;
+unicode = 5640;
+},
+{
+color = 9;
+glyphname = "moCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(787,0,l),
+(787,499,ls),
+(787,643,o),
+(714,727,o),
+(597,727,cs),
+(509,727,o),
+(445,673,o),
+(421,575,c),
+(445,575,l),
+(420,674,o),
+(357,727,o),
+(268,727,cs),
+(150,727,o),
+(78,643,o),
+(78,500,cs),
+(78,312,l),
+(140,312,l),
+(140,498,ls),
+(140,609,o),
+(187,669,o),
+(271,669,cs),
+(353,669,o),
+(403,607,o),
+(403,499,cs),
+(403,312,l),
+(463,312,l),
+(463,499,ls),
+(463,608,o),
+(513,669,o),
+(594,669,cs),
+(678,669,o),
+(725,609,o),
+(725,498,cs),
+(725,0,l)
+);
+}
+);
+width = 865;
+}
+);
+metricLeft = "=|muCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni1609;
+unicode = 5641;
+},
+{
+color = 9;
+glyphname = "meCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(406.996,0,ls),
+(548,0,o),
+(622,69,o),
+(622,188,cs),
+(622,275,o),
+(571,341,o),
+(488,366,c),
+(488,348,l),
+(572,371,o),
+(622,434,o),
+(622,524,cs),
+(622,644,o),
+(547,714,o),
+(406.996,714,cs),
+(57,714,l),
+(57,660,l),
+(397,660,ls),
+(507,660,o),
+(558,613,o),
+(558,523,cs),
+(558,433,o),
+(501,384,o),
+(399,384,cs),
+(287,384,l),
+(287,331,l),
+(400,331,ls),
+(502,331,o),
+(558,279,o),
+(558,190,cs),
+(558,101,o),
+(507,54,o),
+(397,54,cs),
+(287,54,l),
+(287,0,l)
+);
+}
+);
+width = 701;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160A;
+unicode = 5642;
+},
+{
+color = 9;
+glyphname = "meeCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(406.996,0,ls),
+(548,0,o),
+(622,69,o),
+(622,188,cs),
+(622,275,o),
+(570,341,o),
+(488,365,c),
+(488,348,l),
+(572,371,o),
+(622,434,o),
+(622,524,cs),
+(622,644,o),
+(547,714,o),
+(406.996,714,cs),
+(57,714,l),
+(57,660,l),
+(397,660,ls),
+(507,660,o),
+(558,612,o),
+(558,522,cs),
+(558,432,o),
+(502,383,o),
+(400,383,cs),
+(333,383,l),
+(333,474,l),
+(287,474,l),
+(287,241,l),
+(333,241,l),
+(333,331,l),
+(401,331,ls),
+(503,331,o),
+(558,280,o),
+(558,190,cs),
+(558,101,o),
+(507,54,o),
+(397,54,cs),
+(287,54,l),
+(287,0,l)
+);
+}
+);
+width = 701;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160B;
+unicode = 5643;
+},
+{
+color = 9;
+glyphname = "miCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(406.996,0,ls),
+(548,0,o),
+(622,69,o),
+(622,188,cs),
+(622,275,o),
+(570,341,o),
+(488,365,c),
+(488,348,l),
+(572,371,o),
+(622,434,o),
+(622,524,cs),
+(622,644,o),
+(547,714,o),
+(406.996,714,cs),
+(57,714,l),
+(57,660,l),
+(397,660,ls),
+(507,660,o),
+(558,612,o),
+(558,522,cs),
+(558,432,o),
+(502,383,o),
+(403,383,cs),
+(342,383,l),
+(376,365,l),
+(373,399,o),
+(345,425,o),
+(310,425,cs),
+(273,425,o),
+(244,395,o),
+(244,358,cs),
+(244,321,o),
+(273,290,o),
+(310,290,cs),
+(345,290,o),
+(372,317,o),
+(376,350,c),
+(341,331,l),
+(404,331,ls),
+(503,331,o),
+(558,280,o),
+(558,190,cs),
+(558,101,o),
+(507,54,o),
+(397,54,cs),
+(287,54,l),
+(287,0,l)
+);
+}
+);
+width = 701;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160C;
+unicode = 5644;
+},
+{
+color = 9;
+glyphname = "maCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(644,0,l),
+(644,54,l),
+(304,54,ls),
+(195,54,o),
+(143,100,o),
+(143,190,cs),
+(143,279,o),
+(199,330,o),
+(301,330,cs),
+(414,330,l),
+(414,384,l),
+(302,384,ls),
+(200,384,o),
+(143,433,o),
+(143,523,cs),
+(143,612,o),
+(194,660,o),
+(304,660,cs),
+(414,660,l),
+(414,714,l),
+(294,714,ls),
+(154,714,o),
+(79,644,o),
+(79,524,cs),
+(79,435,o),
+(130,372,o),
+(213,349,c),
+(213,367,l),
+(130,343,o),
+(79,275,o),
+(79,188,cs),
+(79,69,o),
+(154,0,o),
+(294,0,cs)
+);
+}
+);
+width = 701;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni160D;
+unicode = 5645;
+},
+{
+color = 9;
+glyphname = "yuCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(566,-13,o),
+(677,125,o),
+(677,407,cs),
+(677,623,o),
+(609,727,o),
+(490,727,cs),
+(391,727,o),
+(326,650,o),
+(326,525,cs),
+(326,402,o),
+(389,325,o),
+(492,326,cs),
+(509,326,o),
+(528,328,o),
+(540,334,c),
+(540,385,l),
+(531,382,o),
+(518,379,o),
+(498,379,cs),
+(420,379,o),
+(383,432,o),
+(383,527,cs),
+(383,619,o),
+(421,673,o),
+(489,673,cs),
+(573,673,o),
+(615,597,o),
+(615,408,cs),
+(615,149,o),
+(527,46,o),
+(371,46,cs),
+(225,46,o),
+(140,131,o),
+(140,307,cs),
+(140,714,l),
+(76,714,l),
+(76,305,ls),
+(76,97,o),
+(190,-13,o),
+(368,-13,cs)
+);
+}
+);
+width = 753;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160E;
+unicode = 5646;
+},
+{
+color = 9;
+glyphname = "yoCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(362,-13,o),
+(427,64,o),
+(427,189,cs),
+(427,312,o),
+(363,388,o),
+(260,388,cs),
+(244,388,o),
+(224,386,o),
+(212,380,c),
+(212,329,l),
+(222,332,o),
+(234,335,o),
+(254,335,cs),
+(332,335,o),
+(370,282,o),
+(370,187,cs),
+(370,95,o),
+(332,41,o),
+(264,41,cs),
+(180,41,o),
+(137,117,o),
+(137,306,cs),
+(137,565,o),
+(225,668,o),
+(382,668,cs),
+(527,668,o),
+(613,583,o),
+(613,407,cs),
+(613,0,l),
+(677,0,l),
+(677,409,ls),
+(677,617,o),
+(563,727,o),
+(384,727,cs),
+(186,727,o),
+(76,589,o),
+(76,307,cs),
+(76,91,o),
+(143,-13,o),
+(263,-13,cs)
+);
+}
+);
+width = 753;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160F;
+unicode = 5647;
+},
+{
+color = 9;
+glyphname = "yeCarrier-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(516,-13,o),
+(624,133,o),
+(624,356,cs),
+(624,583,o),
+(507,714,o),
+(282,714,cs),
+(86,714,l),
+(86,656,l),
+(285,656,ls),
+(470,656,o),
+(561,549,o),
+(561,354,cs),
+(561,161,o),
+(484,43,o),
+(318,43,cs),
+(182,43,o),
+(127,121,o),
+(127,214,cs),
+(127,309,o),
+(169,362,o),
+(235,362,cs),
+(304,362,o),
+(341,308,o),
+(341,222,cs),
+(341,189,o),
+(338,171,o),
+(334,149,c),
+(386,149,l),
+(392,177,o),
+(394,193,o),
+(394,227,cs),
+(394,339,o),
+(335,414,o),
+(235,414,cs),
+(134,414,o),
+(69,337,o),
+(69,214,cs),
+(69,92,o),
+(150,-13,o),
+(317,-13,cs)
+);
+}
+);
+width = 693;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1610;
+unicode = 5648;
+},
+{
+color = 9;
+glyphname = "yeeCarrier-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(516,-13,o),
+(624,133,o),
+(624,356,cs),
+(624,583,o),
+(507,714,o),
+(282,714,cs),
+(86,714,l),
+(86,656,l),
+(285,656,ls),
+(470,656,o),
+(561,549,o),
+(561,354,cs),
+(561,161,o),
+(484,43,o),
+(317,43,cs),
+(182,43,o),
+(127,119,o),
+(127,221,cs),
+(127,308,o),
+(167,362,o),
+(227,362,cs),
+(290,362,o),
+(327,312,o),
+(327,229,cs),
+(327,180,l),
+(368,180,l),
+(368,520,l),
+(327,520,l),
+(327,300,l),
+(337,300,l),
+(326,374,o),
+(282,414,o),
+(216,414,cs),
+(130,414,o),
+(69,338,o),
+(69,221,cs),
+(69,90,o),
+(149,-13,o),
+(317,-13,cs)
+);
+}
+);
+width = 693;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1611;
+unicode = 5649;
+},
+{
+color = 9;
+glyphname = "yiCarrier-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(516,-13,o),
+(624,133,o),
+(624,356,cs),
+(624,583,o),
+(507,714,o),
+(282,714,cs),
+(86,714,l),
+(86,656,l),
+(285,656,ls),
+(470,656,o),
+(561,549,o),
+(561,354,cs),
+(561,161,o),
+(484,43,o),
+(320,43,cs),
+(182,43,o),
+(127,116,o),
+(127,201,cs),
+(127,289,o),
+(171,337,o),
+(245,336,c),
+(219,352,l),
+(222,321,o),
+(249,295,o),
+(282,295,cs),
+(318,295,o),
+(344,324,o),
+(344,358,cs),
+(344,393,o),
+(318,419,o),
+(282,419,cs),
+(256,419,o),
+(235,404,o),
+(226,384,c),
+(129,378,o),
+(69,307,o),
+(69,198,cs),
+(69,88,o),
+(150,-13,o),
+(317,-13,cs)
+);
+}
+);
+width = 693;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1612;
+unicode = 5650;
+},
+{
+color = 9;
+glyphname = "yaCarrier-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(608,0,l),
+(608,58,l),
+(409,58,ls),
+(223,58,o),
+(133,165,o),
+(133,360,cs),
+(133,553,o),
+(210,671,o),
+(379,671,cs),
+(512,671,o),
+(567,593,o),
+(567,500,cs),
+(567,405,o),
+(525,352,o),
+(458,352,cs),
+(390,352,o),
+(353,406,o),
+(353,492,cs),
+(353,525,o),
+(356,543,o),
+(360,565,c),
+(308,565,l),
+(302,537,o),
+(299,521,o),
+(299,487,cs),
+(299,375,o),
+(359,300,o),
+(458,300,cs),
+(559,300,o),
+(624,377,o),
+(624,500,cs),
+(624,622,o),
+(544,727,o),
+(379,727,cs),
+(178,727,o),
+(69,581,o),
+(69,358,cs),
+(69,131,o),
+(187,0,o),
+(412,0,cs)
+);
+}
+);
+width = 693;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|yeCarrier-canadian";
+note = uni1613;
+unicode = 5651;
+},
+{
+color = 9;
+glyphname = "juCarrier-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(550,-13,o),
+(644,82,o),
+(644,226,cs),
+(644,337,o),
+(580,414,o),
+(480,414,cs),
+(381,414,o),
+(319,339,o),
+(319,227,cs),
+(319,193,o),
+(322,176,o),
+(328,149,c),
+(380,149,l),
+(376,170,o),
+(373,190,o),
+(373,222,cs),
+(373,308,o),
+(413,362,o),
+(480,362,cs),
+(547,362,o),
+(587,308,o),
+(587,225,cs),
+(587,112,o),
+(520,43,o),
+(386,43,cs),
+(228,43,o),
+(142,138,o),
+(142,317,cs),
+(142,547,o),
+(287,656,o),
+(541,656,cs),
+(627,656,l),
+(627,714,l),
+(70,714,l),
+(70,657,l),
+(414,657,l),
+(484,684,l),
+(230,684,o),
+(79,549,o),
+(79,315,cs),
+(79,112,o),
+(196,-13,o),
+(384,-13,cs)
+);
+}
+);
+width = 713;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni1614;
+unicode = 5652;
+},
+{
+color = 9;
+glyphname = "juSayisi-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (364,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(517,-13,o),
+(635,112,o),
+(635,315,cs),
+(635,549,o),
+(484,684,o),
+(229,684,c),
+(300,657,l),
+(644,657,l),
+(644,714,l),
+(86,714,l),
+(86,656,l),
+(172,656,ls),
+(426,656,o),
+(572,547,o),
+(572,317,cs),
+(572,138,o),
+(485,43,o),
+(327,43,cs),
+(194,43,o),
+(127,112,o),
+(127,225,cs),
+(127,308,o),
+(167,362,o),
+(234,362,cs),
+(301,362,o),
+(341,308,o),
+(341,222,cs),
+(341,190,o),
+(338,170,o),
+(334,149,c),
+(386,149,l),
+(392,176,o),
+(394,193,o),
+(394,227,cs),
+(394,339,o),
+(332,414,o),
+(234,414,cs),
+(133,414,o),
+(69,337,o),
+(69,226,cs),
+(69,82,o),
+(163,-13,o),
+(330,-13,cs)
+);
+}
+);
+width = 714;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1615;
+unicode = 5653;
+},
+{
+color = 9;
+glyphname = "joCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(644,0,l),
+(644,57,l),
+(300,57,l),
+(229,30,l),
+(484,30,o),
+(635,165,o),
+(635,399,cs),
+(635,602,o),
+(517,727,o),
+(330,727,cs),
+(163,727,o),
+(69,632,o),
+(69,488,cs),
+(69,377,o),
+(133,300,o),
+(234,300,cs),
+(332,300,o),
+(394,375,o),
+(394,487,cs),
+(394,521,o),
+(392,538,o),
+(386,565,c),
+(334,565,l),
+(338,544,o),
+(341,524,o),
+(341,492,cs),
+(341,406,o),
+(301,352,o),
+(234,352,cs),
+(167,352,o),
+(127,406,o),
+(127,489,cs),
+(127,602,o),
+(194,671,o),
+(327,671,cs),
+(485,671,o),
+(572,576,o),
+(572,397,cs),
+(572,167,o),
+(426,58,o),
+(172,58,cs),
+(86,58,l),
+(86,0,l)
+);
+}
+);
+width = 714;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1616;
+unicode = 5654;
+},
+{
+color = 9;
+glyphname = "jeCarrier-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(617,-13,o),
+(685,91,o),
+(685,307,cs),
+(685,586,o),
+(572,727,o),
+(398,727,cs),
+(226,727,o),
+(131,603,o),
+(127,366,c),
+(147,392,l),
+(147,714,l),
+(83,714,l),
+(83,0,l),
+(147,0,l),
+(147,284,ls),
+(147,550,o),
+(231,668,o),
+(391,668,cs),
+(534,668,o),
+(623,559,o),
+(623,306,cs),
+(623,117,o),
+(581,41,o),
+(497,41,cs),
+(429,41,o),
+(390,95,o),
+(390,187,cs),
+(390,282,o),
+(428,335,o),
+(507,335,cs),
+(526,335,o),
+(538,332,o),
+(548,329,c),
+(548,380,l),
+(536,386,o),
+(516,388,o),
+(501,388,cs),
+(397,388,o),
+(333,312,o),
+(333,189,cs),
+(333,64,o),
+(399,-13,o),
+(498,-13,cs)
+);
+}
+);
+width = 761;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "te-canadian";
+note = uni1617;
+unicode = 5655;
+},
+{
+color = 9;
+glyphname = "jeeCarrier-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(617,-13,o),
+(685,91,o),
+(685,307,cs),
+(685,586,o),
+(572,727,o),
+(398,727,cs),
+(260,727,o),
+(171,649,o),
+(139,497,c),
+(147,489,l),
+(147,714,l),
+(83,714,l),
+(83,0,l),
+(147,0,l),
+(147,284,ls),
+(147,550,o),
+(231,668,o),
+(391,668,cs),
+(534,668,o),
+(623,559,o),
+(623,306,cs),
+(623,122,o),
+(580,41,o),
+(489,41,cs),
+(416,41,o),
+(375,98,o),
+(375,192,cs),
+(375,282,o),
+(409,328,o),
+(465,341,c),
+(465,245,l),
+(504,245,l),
+(504,470,l),
+(465,470,l),
+(465,381,l),
+(388,368,o),
+(333,303,o),
+(333,187,cs),
+(333,63,o),
+(397,-13,o),
+(496,-13,cs)
+);
+}
+);
+width = 761;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1618;
+unicode = 5656;
+},
+{
+color = 9;
+glyphname = "jiCarrier-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(617,-13,o),
+(685,91,o),
+(685,307,cs),
+(685,586,o),
+(572,727,o),
+(398,727,cs),
+(260,727,o),
+(171,649,o),
+(139,497,c),
+(147,490,l),
+(147,714,l),
+(83,714,l),
+(83,0,l),
+(147,0,l),
+(147,284,ls),
+(147,550,o),
+(231,668,o),
+(391,668,cs),
+(534,668,o),
+(623,559,o),
+(623,306,cs),
+(623,122,o),
+(580,41,o),
+(489,41,cs),
+(416,41,o),
+(375,98,o),
+(375,192,cs),
+(375,259,o),
+(394,298,o),
+(427,319,c),
+(435,305,o),
+(450,295,o),
+(468,295,cs),
+(503,295,o),
+(529,324,o),
+(529,358,cs),
+(529,393,o),
+(503,419,o),
+(467,419,cs),
+(430,419,o),
+(405,388,o),
+(407,354,c),
+(362,326,o),
+(333,271,o),
+(333,187,cs),
+(333,63,o),
+(397,-13,o),
+(496,-13,cs)
+);
+}
+);
+width = 761;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1619;
+unicode = 5657;
+},
+{
+color = 9;
+glyphname = "jiSayisi-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(572,-13,o),
+(685,128,o),
+(685,407,cs),
+(685,623,o),
+(617,727,o),
+(498,727,cs),
+(399,727,o),
+(333,650,o),
+(333,525,cs),
+(333,402,o),
+(397,326,o),
+(501,326,cs),
+(516,326,o),
+(536,328,o),
+(548,334,c),
+(548,385,l),
+(538,382,o),
+(526,379,o),
+(507,379,cs),
+(428,379,o),
+(390,432,o),
+(390,527,cs),
+(390,619,o),
+(429,673,o),
+(496,673,cs),
+(580,673,o),
+(623,597,o),
+(623,408,cs),
+(623,155,o),
+(534,46,o),
+(391,46,cs),
+(231,46,o),
+(147,164,o),
+(147,430,cs),
+(147,714,l),
+(83,714,l),
+(83,0,l),
+(147,0,l),
+(147,322,l),
+(127,348,l),
+(131,111,o),
+(226,-13,o),
+(398,-13,cs)
+);
+}
+);
+width = 761;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161A;
+unicode = 5658;
+},
+{
+color = 9;
+glyphname = "jaCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (372,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(534,-13,o),
+(629,111,o),
+(633,348,c),
+(614,322,l),
+(614,0,l),
+(677,0,l),
+(677,714,l),
+(613,714,l),
+(613,430,ls),
+(613,164,o),
+(530,46,o),
+(370,46,cs),
+(227,46,o),
+(137,155,o),
+(137,408,cs),
+(137,597,o),
+(180,673,o),
+(264,673,cs),
+(331,673,o),
+(370,619,o),
+(370,527,cs),
+(370,432,o),
+(332,379,o),
+(253,379,cs),
+(234,379,o),
+(222,382,o),
+(212,385,c),
+(212,334,l),
+(224,328,o),
+(244,326,o),
+(260,326,cs),
+(363,326,o),
+(427,402,o),
+(427,525,cs),
+(427,650,o),
+(362,727,o),
+(263,727,cs),
+(143,727,o),
+(76,623,o),
+(76,407,cs),
+(76,128,o),
+(188,-13,o),
+(362,-13,cs)
+);
+}
+);
+width = 760;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni161B;
+unicode = 5659;
+},
+{
+color = 9;
+glyphname = "jjuCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(549,-13,o),
+(630,92,o),
+(630,214,cs),
+(630,337,o),
+(565,414,o),
+(464,414,cs),
+(364,414,o),
+(304,339,o),
+(304,227,cs),
+(304,194,o),
+(307,176,o),
+(313,149,c),
+(365,149,l),
+(361,170,o),
+(358,190,o),
+(358,222,cs),
+(358,308,o),
+(395,362,o),
+(463,362,cs),
+(529,362,o),
+(572,307,o),
+(572,215,cs),
+(572,120,o),
+(514,43,o),
+(382,43,cs),
+(219,43,o),
+(139,153,o),
+(139,326,cs),
+(139,541,o),
+(257,656,o),
+(483,656,cs),
+(613,656,l),
+(613,714,l),
+(483,714,ls),
+(352,714,o),
+(251,678,o),
+(183,612,c),
+(68,727,l),
+(26,685,l),
+(144,568,l),
+(98,507,o),
+(75,425,o),
+(75,327,cs),
+(75,126,o),
+(187,-13,o),
+(381,-13,cs)
+);
+}
+);
+width = 699;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni161C;
+unicode = 5660;
+},
+{
+color = 9;
+glyphname = "jjoCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(673,29,l),
+(556,146,l),
+(601,207,o),
+(624,289,o),
+(624,387,cs),
+(624,588,o),
+(513,727,o),
+(319,727,cs),
+(152,727,o),
+(69,622,o),
+(69,499,cs),
+(69,377,o),
+(134,300,o),
+(235,300,cs),
+(336,300,o),
+(395,375,o),
+(395,487,cs),
+(395,520,o),
+(393,538,o),
+(387,565,c),
+(334,565,l),
+(339,544,o),
+(341,524,o),
+(341,492,cs),
+(341,406,o),
+(304,352,o),
+(236,352,cs),
+(171,352,o),
+(127,407,o),
+(127,499,cs),
+(127,594,o),
+(183,671,o),
+(319,671,cs),
+(480,671,o),
+(561,561,o),
+(561,388,cs),
+(561,173,o),
+(442,58,o),
+(216,58,cs),
+(86,58,l),
+(86,0,l),
+(217,0,ls),
+(347,0,o),
+(449,36,o),
+(516,102,c),
+(631,-13,l)
+);
+}
+);
+width = 699;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|jjuCarrier-canadian";
+note = uni161D;
+unicode = 5661;
+},
+{
+color = 9;
+glyphname = "jjeCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(622,-13,o),
+(689,91,o),
+(689,307,cs),
+(689,589,o),
+(581,727,o),
+(385,727,cs),
+(295,727,o),
+(222,693,o),
+(170,631,c),
+(73,727,l),
+(32,684,l),
+(137,581,l),
+(105,524,o),
+(88,450,o),
+(88,360,cs),
+(88,0,l),
+(152,0,l),
+(152,360,ls),
+(152,564,o),
+(237,668,o),
+(385,668,cs),
+(539,668,o),
+(627,565,o),
+(627,306,cs),
+(627,117,o),
+(585,41,o),
+(501,41,cs),
+(433,41,o),
+(395,95,o),
+(395,187,cs),
+(395,282,o),
+(432,335,o),
+(510,335,cs),
+(530,335,o),
+(543,332,o),
+(553,329,c),
+(553,380,l),
+(541,386,o),
+(521,388,o),
+(504,388,cs),
+(401,388,o),
+(338,312,o),
+(338,189,cs),
+(338,64,o),
+(403,-13,o),
+(502,-13,cs)
+);
+}
+);
+width = 765;
+}
+);
+metricRight = "jeCarrier-canadian";
+note = uni161E;
+unicode = 5662;
+},
+{
+color = 9;
+glyphname = "jjeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(622,-13,o),
+(689,91,o),
+(689,307,cs),
+(689,589,o),
+(581,727,o),
+(385,727,cs),
+(295,727,o),
+(222,693,o),
+(170,631,c),
+(73,727,l),
+(32,684,l),
+(137,581,l),
+(105,524,o),
+(88,450,o),
+(88,360,cs),
+(88,0,l),
+(152,0,l),
+(152,360,ls),
+(152,564,o),
+(237,668,o),
+(385,668,cs),
+(539,668,o),
+(627,565,o),
+(627,306,cs),
+(627,122,o),
+(584,41,o),
+(493,41,cs),
+(420,41,o),
+(379,98,o),
+(379,192,cs),
+(379,280,o),
+(412,326,o),
+(464,339,c),
+(464,245,l),
+(504,245,l),
+(504,469,l),
+(464,469,l),
+(464,381,l),
+(390,367,o),
+(338,300,o),
+(338,187,cs),
+(338,63,o),
+(402,-13,o),
+(501,-13,cs)
+);
+}
+);
+width = 765;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161F;
+unicode = 5663;
+},
+{
+color = 9;
+glyphname = "jjiCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(622,-13,o),
+(689,91,o),
+(689,307,cs),
+(689,589,o),
+(581,727,o),
+(385,727,cs),
+(295,727,o),
+(222,693,o),
+(170,631,c),
+(73,727,l),
+(32,684,l),
+(137,581,l),
+(105,524,o),
+(88,450,o),
+(88,360,cs),
+(88,0,l),
+(152,0,l),
+(152,360,ls),
+(152,564,o),
+(237,668,o),
+(385,668,cs),
+(539,668,o),
+(627,565,o),
+(627,306,cs),
+(627,122,o),
+(584,41,o),
+(493,41,cs),
+(420,41,o),
+(379,98,o),
+(379,192,cs),
+(379,262,o),
+(401,303,o),
+(435,322,c),
+(444,307,o),
+(461,295,o),
+(480,295,cs),
+(515,295,o),
+(541,324,o),
+(541,358,cs),
+(541,393,o),
+(515,419,o),
+(480,419,cs),
+(445,419,o),
+(420,391,o),
+(420,360,c),
+(370,334,o),
+(338,276,o),
+(338,187,cs),
+(338,63,o),
+(402,-13,o),
+(501,-13,cs)
+);
+}
+);
+width = 765;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1620;
+unicode = 5664;
+},
+{
+color = 9;
+glyphname = "jjaCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(469,-13,o),
+(543,21,o),
+(595,83,c),
+(692,-13,l),
+(733,30,l),
+(628,133,l),
+(660,190,o),
+(677,264,o),
+(677,354,cs),
+(677,714,l),
+(613,714,l),
+(613,354,ls),
+(613,150,o),
+(527,46,o),
+(380,46,cs),
+(225,46,o),
+(137,149,o),
+(137,408,cs),
+(137,597,o),
+(180,673,o),
+(264,673,cs),
+(332,673,o),
+(370,619,o),
+(370,527,cs),
+(370,432,o),
+(332,379,o),
+(254,379,cs),
+(234,379,o),
+(222,382,o),
+(212,385,c),
+(212,334,l),
+(224,328,o),
+(244,326,o),
+(260,326,cs),
+(363,326,o),
+(427,402,o),
+(427,525,cs),
+(427,650,o),
+(362,727,o),
+(263,727,cs),
+(143,727,o),
+(76,623,o),
+(76,407,cs),
+(76,125,o),
+(184,-13,o),
+(379,-13,cs)
+);
+}
+);
+width = 765;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "=|jjeCarrier-canadian";
+note = uni1621;
+unicode = 5665;
+},
+{
+color = 9;
+glyphname = "luCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(529,-13,o),
+(636,91,o),
+(636,292,cs),
+(636,714,l),
+(572,714,l),
+(572,290,ls),
+(572,124,o),
+(491,46,o),
+(364,46,cs),
+(215,46,o),
+(139,152,o),
+(139,337,cs),
+(139,543,o),
+(223,654,o),
+(387,661,c),
+(387,714,l),
+(66,714,l),
+(66,660,l),
+(295,660,l),
+(331,682,l),
+(180,666,o),
+(75,558,o),
+(75,329,cs),
+(75,116,o),
+(178,-13,o),
+(362,-13,cs)
+);
+}
+);
+width = 712;
+}
+);
+metricRight = "te-canadian";
+note = uni1622;
+unicode = 5666;
+},
+{
+color = 9;
+glyphname = "loCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(140,0,l),
+(140,424,ls),
+(140,590,o),
+(221,668,o),
+(349,668,cs),
+(497,668,o),
+(573,562,o),
+(573,377,cs),
+(573,171,o),
+(489,60,o),
+(324,53,c),
+(324,0,l),
+(646,0,l),
+(646,54,l),
+(417,54,l),
+(381,32,l),
+(532,48,o),
+(637,156,o),
+(637,385,cs),
+(637,598,o),
+(534,727,o),
+(349,727,cs),
+(183,727,o),
+(76,623,o),
+(76,422,cs),
+(76,0,l)
+);
+}
+);
+width = 712;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|luCarrier-canadian";
+note = uni1623;
+unicode = 5667;
+},
+{
+color = 9;
+glyphname = "leCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (343,358);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(283,0,ls),
+(503,0,o),
+(618,133,o),
+(618,370,cs),
+(618,599,o),
+(511,727,o),
+(354,727,cs),
+(228,727,o),
+(149,640,o),
+(128,521,c),
+(137,521,l),
+(137,714,l),
+(79,714,l),
+(79,399,l),
+(133,399,l),
+(137,560,o),
+(212,668,o),
+(342,668,cs),
+(472,668,o),
+(554,567,o),
+(554,369,cs),
+(554,167,o),
+(465,58,o),
+(283,58,cs),
+(79,58,l),
+(79,0,l)
+);
+}
+);
+width = 687;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1624;
+unicode = 5668;
+},
+{
+color = 9;
+glyphname = "leeCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+ref = "leCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (302,1);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 687;
+}
+);
+metricLeft = "leCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1625;
+unicode = 5669;
+},
+{
+color = 9;
+glyphname = "liCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "leCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (279,1);
+ref = dot_middle;
+}
+);
+width = 687;
+}
+);
+note = uni1626;
+unicode = 5670;
+},
+{
+color = 9;
+glyphname = "laCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(608,0,l),
+(608,58,l),
+(403,58,ls),
+(222,58,o),
+(133,167,o),
+(133,369,cs),
+(133,567,o),
+(216,668,o),
+(346,668,cs),
+(476,668,o),
+(550,560,o),
+(554,399,c),
+(608,399,l),
+(608,714,l),
+(550,714,l),
+(550,521,l),
+(559,521,l),
+(538,640,o),
+(459,727,o),
+(334,727,cs),
+(177,727,o),
+(69,599,o),
+(69,370,cs),
+(69,133,o),
+(184,0,o),
+(404,0,cs)
+);
+}
+);
+width = 687;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|leCarrier-canadian";
+note = uni1627;
+unicode = 5671;
+},
+{
+color = 1;
+glyphname = "dluCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(534,-13,o),
+(637,116,o),
+(637,329,cs),
+(637,530,o),
+(557,638,o),
+(440,670,c),
+(428,664,l),
+(636,664,l),
+(636,577,l),
+(686,577,l),
+(686,800,l),
+(636,800,l),
+(636,714,l),
+(324,714,l),
+(324,661,l),
+(489,654,o),
+(573,543,o),
+(573,337,cs),
+(573,152,o),
+(497,46,o),
+(354,46,cs),
+(221,46,o),
+(140,126,o),
+(140,292,cs),
+(140,714,l),
+(76,714,l),
+(76,295,ls),
+(76,93,o),
+(183,-13,o),
+(353,-13,cs)
+);
+}
+);
+width = 745;
+}
+);
+metricLeft = "te-canadian";
+note = uni1628;
+unicode = 5672;
+},
+{
+color = 9;
+glyphname = "dloCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(686,-86,l),
+(686,137,l),
+(636,137,l),
+(636,50,l),
+(428,50,l),
+(440,44,l),
+(557,76,o),
+(637,184,o),
+(637,385,cs),
+(637,598,o),
+(534,727,o),
+(355,727,cs),
+(181,727,o),
+(76,621,o),
+(76,419,cs),
+(76,0,l),
+(140,0,l),
+(140,422,ls),
+(140,588,o),
+(221,668,o),
+(354,668,cs),
+(497,668,o),
+(573,562,o),
+(573,377,cs),
+(573,171,o),
+(489,60,o),
+(324,53,c),
+(324,0,l),
+(636,0,l),
+(636,-86,l)
+);
+}
+);
+width = 745;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "dluCarrier-canadian";
+note = uni1629;
+unicode = 5673;
+},
+{
+color = 9;
+glyphname = "dleCarrier-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (354,358);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(294,0,ls),
+(513,0,o),
+(628,133,o),
+(628,370,cs),
+(628,599,o),
+(521,727,o),
+(365,727,cs),
+(246,727,o),
+(163,651,o),
+(132,527,c),
+(140,520,l),
+(140,728,l),
+(220,728,l),
+(220,776,l),
+(10,776,l),
+(10,728,l),
+(90,728,l),
+(90,399,l),
+(144,399,l),
+(148,560,o),
+(223,668,o),
+(353,668,cs),
+(483,668,o),
+(565,567,o),
+(565,369,cs),
+(565,167,o),
+(476,58,o),
+(294,58,cs),
+(90,58,l),
+(90,0,l)
+);
+}
+);
+width = 697;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni162A;
+unicode = 5674;
+},
+{
+color = 9;
+glyphname = "dleeCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (314,1);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 698;
+}
+);
+note = uni162B;
+unicode = 5675;
+},
+{
+color = 9;
+glyphname = "dliCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (290,1);
+ref = dot_middle;
+}
+);
+width = 698;
+}
+);
+note = uni162C;
+unicode = 5676;
+},
+{
+color = 9;
+glyphname = "dlaCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(608,0,l),
+(608,58,l),
+(403,58,ls),
+(223,58,o),
+(133,164,o),
+(133,369,cs),
+(133,567,o),
+(215,668,o),
+(344,668,cs),
+(475,668,o),
+(550,560,o),
+(554,399,c),
+(608,399,l),
+(608,728,l),
+(688,728,l),
+(688,776,l),
+(478,776,l),
+(478,728,l),
+(558,728,l),
+(558,520,l),
+(565,527,l),
+(535,651,o),
+(452,727,o),
+(333,727,cs),
+(176,727,o),
+(69,599,o),
+(69,370,cs),
+(69,131,o),
+(186,0,o),
+(404,0,cs)
+);
+}
+);
+width = 698;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni162D;
+unicode = 5677;
+},
+{
+color = 9;
+glyphname = "lhuCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(573,-13,o),
+(678,115,o),
+(678,334,cs),
+(678,543,o),
+(586,647,o),
+(466,682,c),
+(486,659,l),
+(687,659,l),
+(687,714,l),
+(437,714,l),
+(437,661,l),
+(537,630,o),
+(614,531,o),
+(614,342,cs),
+(614,147,o),
+(536,46,o),
+(376,46,cs),
+(217,46,o),
+(139,147,o),
+(139,342,cs),
+(139,531,o),
+(217,630,o),
+(316,661,c),
+(316,714,l),
+(66,714,l),
+(66,659,l),
+(267,659,l),
+(287,682,l),
+(167,647,o),
+(75,544,o),
+(75,334,cs),
+(75,115,o),
+(180,-13,o),
+(376,-13,cs)
+);
+}
+);
+width = 753;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162E;
+unicode = 5678;
+},
+{
+color = 9;
+glyphname = "lhoCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(316,0,l),
+(316,53,l),
+(216,84,o),
+(139,183,o),
+(139,372,cs),
+(139,567,o),
+(217,668,o),
+(376,668,cs),
+(536,668,o),
+(614,567,o),
+(614,372,cs),
+(613.991,182.993,o),
+(536,84,o),
+(437,53,c),
+(437,0,l),
+(687,0,l),
+(687,55,l),
+(486,55,l),
+(465,32,l),
+(586,67,o),
+(678,170,o),
+(678,380,cs),
+(678,599,o),
+(573,727,o),
+(376,727,cs),
+(179,727,o),
+(75,599,o),
+(75,380,cs),
+(75,171,o),
+(167,67,o),
+(287,32,c),
+(267,55,l),
+(66,55,l),
+(66,0,l)
+);
+}
+);
+width = 753;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162F;
+unicode = 5679;
+},
+{
+color = 9;
+glyphname = "lheCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (362,357);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(537,-13,o),
+(650,115,o),
+(650,357,cs),
+(650,599,o),
+(537,727,o),
+(371,727,cs),
+(239,727,o),
+(158,643,o),
+(135,539,c),
+(141,539,l),
+(141,714,l),
+(83,714,l),
+(83,434,l),
+(137,434,l),
+(148,563,o),
+(221,668,o),
+(361,668,cs),
+(493,668,o),
+(586,567,o),
+(586,357,cs),
+(586,147,o),
+(498,46,o),
+(361,46,cs),
+(221,46,o),
+(148,151,o),
+(137,280,c),
+(83,280,l),
+(83,0,l),
+(141,0,l),
+(141,175,l),
+(135,175,l),
+(158,71,o),
+(239,-13,o),
+(371,-13,cs)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1630;
+unicode = 5680;
+},
+{
+color = 9;
+glyphname = "lheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (321,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 719;
+}
+);
+note = uni1631;
+unicode = 5681;
+},
+{
+color = 9;
+glyphname = "lhiCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (298,0);
+ref = dot_middle;
+}
+);
+width = 719;
+}
+);
+note = uni1632;
+unicode = 5682;
+},
+{
+color = 9;
+glyphname = "lhaCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(480,-13,o),
+(561,71,o),
+(584,175,c),
+(578,175,l),
+(578,0,l),
+(636,0,l),
+(636,280,l),
+(582,280,l),
+(571,151,o),
+(498,46,o),
+(358,46,cs),
+(226,46,o),
+(133,147,o),
+(133,357,cs),
+(133,567,o),
+(221,668,o),
+(358,668,cs),
+(498,668,o),
+(571,563,o),
+(582,434,c),
+(636,434,l),
+(636,714,l),
+(578,714,l),
+(578,539,l),
+(584,539,l),
+(561,643,o),
+(480,727,o),
+(348,727,cs),
+(182,727,o),
+(69,599,o),
+(69,357,cs),
+(69,115,o),
+(182,-13,o),
+(348,-13,cs)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1633;
+unicode = 5683;
+},
+{
+color = 9;
+glyphname = "tlhuCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(573,-13,o),
+(678,115,o),
+(678,334,cs),
+(678,524,o),
+(603,627,o),
+(502,671,c),
+(488,664,l),
+(677,664,l),
+(677,577,l),
+(727,577,l),
+(727,800,l),
+(677,800,l),
+(677,714,l),
+(437,714,l),
+(437,661,l),
+(537,630,o),
+(614,531,o),
+(614,342,cs),
+(614,147,o),
+(536,46,o),
+(376,46,cs),
+(217,46,o),
+(139,147,o),
+(139,342,cs),
+(139,531,o),
+(216,630,o),
+(316,661,c),
+(316,714,l),
+(66,714,l),
+(66,659,l),
+(258,659,l),
+(243,667,l),
+(146,622,o),
+(75,520,o),
+(75,334,cs),
+(75,115,o),
+(180,-13,o),
+(376,-13,cs)
+);
+}
+);
+width = 775;
+}
+);
+metricLeft = "lhuCarrier-canadian";
+note = uni1634;
+unicode = 5684;
+},
+{
+color = 9;
+glyphname = "tlhoCarrier-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(97,-86,l),
+(97,0,l),
+(337,0,l),
+(337,53,l),
+(238,84,o),
+(160,183,o),
+(160,372,cs),
+(160,567,o),
+(238,668,o),
+(398,668,cs),
+(557,668,o),
+(636,567,o),
+(636,372,cs),
+(636,183,o),
+(558,84,o),
+(458,53,c),
+(458,0,l),
+(708,0,l),
+(708,55,l),
+(516,55,l),
+(531,47,l),
+(628,92,o),
+(699,194,o),
+(699,380,cs),
+(699,599,o),
+(595,727,o),
+(398,727,cs),
+(201,727,o),
+(96,599,o),
+(96,380,cs),
+(96,190,o),
+(172,87,o),
+(273,43,c),
+(287,50,l),
+(97,50,l),
+(97,137,l),
+(48,137,l),
+(48,-86,l)
+);
+}
+);
+width = 774;
+}
+);
+metricLeft = "=|tlhuCarrier-canadian";
+metricRight = "lhuCarrier-canadian";
+note = uni1635;
+unicode = 5685;
+},
+{
+color = 9;
+glyphname = "tlheCarrier-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (369,357);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(544,-13,o),
+(656,115,o),
+(656,357,cs),
+(656,599,o),
+(544,727,o),
+(378,727,cs),
+(250,727,o),
+(164,647,o),
+(133,536,c),
+(140,528,l),
+(140,728,l),
+(221,728,l),
+(221,776,l),
+(10,776,l),
+(10,728,l),
+(90,728,l),
+(90,434,l),
+(144,434,l),
+(155,563,o),
+(227,668,o),
+(367,668,cs),
+(499,668,o),
+(593,568,o),
+(593,357,cs),
+(593,147,o),
+(499,46,o),
+(367,46,cs),
+(227,46,o),
+(155,151,o),
+(144,280,c),
+(90,280,l),
+(90,0,l),
+(148,0,l),
+(148,182,l),
+(143,170,l),
+(167,72,o),
+(248,-13,o),
+(378,-13,cs)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1636;
+unicode = 5686;
+},
+{
+color = 9;
+glyphname = "tlheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (328,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 726;
+}
+);
+note = uni1637;
+unicode = 5687;
+},
+{
+color = 9;
+glyphname = "tlhiCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (305,0);
+ref = dot_middle;
+}
+);
+width = 726;
+}
+);
+note = uni1638;
+unicode = 5688;
+},
+{
+color = 9;
+glyphname = "tlhaCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(478,-13,o),
+(560,68,o),
+(583,171,c),
+(578,183,l),
+(578,0,l),
+(636,0,l),
+(636,280,l),
+(582,280,l),
+(571,151,o),
+(498,46,o),
+(358,46,cs),
+(226,46,o),
+(133,147,o),
+(133,357,cs),
+(133,568,o),
+(221,668,o),
+(358,668,cs),
+(498,668,o),
+(571,563,o),
+(582,434,c),
+(636,434,l),
+(636,728,l),
+(716,728,l),
+(716,776,l),
+(505,776,l),
+(505,728,l),
+(585,728,l),
+(585,527,l),
+(593,535,l),
+(562,650,o),
+(476,727,o),
+(348,727,cs),
+(182,727,o),
+(69,599,o),
+(69,357,cs),
+(69,115,o),
+(182,-13,o),
+(348,-13,cs)
+);
+}
+);
+width = 726;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni1639;
+unicode = 5689;
+},
+{
+color = 9;
+glyphname = "tluCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(357,-13,o),
+(418,38,o),
+(441,134,c),
+(424,134,l),
+(448,38,o),
+(508,-13,o),
+(590,-13,cs),
+(716,-13,o),
+(791,81,o),
+(791,298,cs),
+(791,524,o),
+(718,633,o),
+(608,671,c),
+(594,664,l),
+(790,664,l),
+(790,577,l),
+(840,577,l),
+(840,800,l),
+(790,800,l),
+(790,714,l),
+(493,714,l),
+(493,661,l),
+(648,657,o),
+(727,543,o),
+(727,301,cs),
+(727,113,o),
+(676,45,o),
+(586,45,cs),
+(513,45,o),
+(463,105,o),
+(463,225,cs),
+(463,309,l),
+(402,309,l),
+(402,225,ls),
+(402,105,o),
+(352,45,o),
+(279,45,cs),
+(190,45,o),
+(139,113,o),
+(139,301,cs),
+(139,543,o),
+(218,657,o),
+(372,661,c),
+(372,714,l),
+(66,714,l),
+(66,659,l),
+(264,659,l),
+(250,667,l),
+(145,628,o),
+(75,519,o),
+(75,298,cs),
+(75,81,o),
+(149,-13,o),
+(276,-13,cs)
+);
+}
+);
+width = 888;
+}
+);
+metricRight = "tlhuCarrier-canadian";
+note = uni163A;
+unicode = 5690;
+},
+{
+color = 1;
+glyphname = "tloCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(840,-86,l),
+(840,137,l),
+(790,137,l),
+(790,50,l),
+(594,50,l),
+(608,43,l),
+(718,81,o),
+(791,190,o),
+(791,416,cs),
+(791,633,o),
+(716,727,o),
+(590,727,cs),
+(508,727,o),
+(448,676,o),
+(424,580,c),
+(441,580,l),
+(418,676,o),
+(357,727,o),
+(276,727,cs),
+(149,727,o),
+(75,633,o),
+(75,416,cs),
+(75,195,o),
+(145,86,o),
+(250,47,c),
+(264,55,l),
+(66,55,l),
+(66,0,l),
+(372,0,l),
+(372,53,l),
+(218,57,o),
+(139,171,o),
+(139,413,cs),
+(139,601,o),
+(190,669,o),
+(279,669,cs),
+(352,669,o),
+(402,609,o),
+(402,489,cs),
+(402,405,l),
+(463,405,l),
+(463,489,ls),
+(463,609,o),
+(513,669,o),
+(586,669,cs),
+(676,669,o),
+(727,601,o),
+(727,413,cs),
+(727,171,o),
+(648,57,o),
+(493,53,c),
+(493,0,l),
+(790,0,l),
+(790,-86,l)
+);
+}
+);
+width = 888;
+}
+);
+metricLeft = "tluCarrier-canadian";
+metricRight = "tlhuCarrier-canadian";
+note = uni163B;
+unicode = 5691;
+},
+{
+color = 9;
+glyphname = "tleCarrier-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (279,357);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(574,-13,o),
+(651,70,o),
+(651,188,cs),
+(651,277,o),
+(600,344,o),
+(508,364,c),
+(508,350,l),
+(600,369,o),
+(651,436,o),
+(651,526,cs),
+(651,644,o),
+(574,727,o),
+(410,727,cs),
+(252,727,o),
+(164,653,o),
+(133,548,c),
+(140,537,l),
+(140,728,l),
+(220,728,l),
+(220,776,l),
+(10,776,l),
+(10,728,l),
+(90,728,l),
+(90,434,l),
+(144,434,l),
+(148,571,o),
+(221,669,o),
+(399,669,cs),
+(532,669,o),
+(588,612,o),
+(588,521,cs),
+(588,434,o),
+(529,385,o),
+(425,385,cs),
+(382,385,l),
+(382,330,l),
+(425,330,ls),
+(533,330,o),
+(588,280,o),
+(588,193,cs),
+(588,102,o),
+(527,45,o),
+(399,45,cs),
+(221,45,o),
+(148,143,o),
+(144,280,c),
+(90,280,l),
+(90,0,l),
+(148,0,l),
+(148,168,l),
+(140,157,l),
+(172,57,o),
+(255,-13,o),
+(410,-13,cs)
+);
+}
+);
+width = 730;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni163C;
+unicode = 5692;
+},
+{
+color = 9;
+glyphname = "tleeCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (238,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 731;
+}
+);
+note = uni163D;
+unicode = 5693;
+},
+{
+color = 9;
+glyphname = "tliCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (220,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 731;
+}
+);
+note = uni163E;
+unicode = 5694;
+},
+{
+color = 9;
+glyphname = "tlaCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(476,-13,o),
+(558,57,o),
+(591,157,c),
+(583,168,l),
+(583,0,l),
+(640,0,l),
+(640,280,l),
+(587,280,l),
+(582,143,o),
+(510,45,o),
+(332,45,cs),
+(204,45,o),
+(143,102,o),
+(143,193,cs),
+(143,280,o),
+(198,330,o),
+(305,330,cs),
+(368,330,l),
+(368,385,l),
+(305,385,ls),
+(202,385,o),
+(143,434,o),
+(143,521,cs),
+(143,612,o),
+(199,669,o),
+(331,669,cs),
+(510,669,o),
+(582,571,o),
+(587,434,c),
+(640,434,l),
+(640,728,l),
+(721,728,l),
+(721,776,l),
+(510,776,l),
+(510,728,l),
+(591,728,l),
+(591,537,l),
+(597,548,l),
+(566,653,o),
+(479,727,o),
+(320,727,cs),
+(156,727,o),
+(79,644,o),
+(79,526,cs),
+(79,436,o),
+(130,369,o),
+(222,350,c),
+(222,364,l),
+(131,344,o),
+(79,277,o),
+(79,188,cs),
+(79,70,o),
+(156,-13,o),
+(320,-13,cs)
+);
+}
+);
+width = 731;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni163F;
+unicode = 5695;
+},
+{
+color = 9;
+glyphname = "zuCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(560,-13,o),
+(675,90,o),
+(675,249,cs),
+(675,378,o),
+(573,507,o),
+(573,589,cs),
+(573,625,o),
+(590,658,o),
+(652,658,cs),
+(684,658,l),
+(684,714,l),
+(640,714,ls),
+(549,714,o),
+(511,664,o),
+(511,595,cs),
+(511,499,o),
+(611,380,o),
+(611,257,cs),
+(611,125,o),
+(524,46,o),
+(373,46,cs),
+(223,46,o),
+(136,125,o),
+(136,257,cs),
+(136,380,o),
+(236,499,o),
+(236,595,cs),
+(236,664,o),
+(198,714,o),
+(107,714,cs),
+(63,714,l),
+(63,658,l),
+(95,658,ls),
+(157,658,o),
+(174,625,o),
+(174,589,cs),
+(174,507,o),
+(72,378,o),
+(72,249,cs),
+(72,90,o),
+(187,-13,o),
+(373,-13,cs)
+);
+}
+);
+width = 747;
+}
+);
+metricRight = "=|";
+note = uni1640;
+unicode = 5696;
+},
+{
+color = 9;
+glyphname = "zoCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(107,0,ls),
+(198,0,o),
+(236,50,o),
+(236,119,cs),
+(236,215,o),
+(136,334,o),
+(136,457,cs),
+(136,589,o),
+(223,668,o),
+(374,668,cs),
+(525,668,o),
+(611,589,o),
+(611,457,cs),
+(611,334,o),
+(511,215,o),
+(511,119,cs),
+(511,50,o),
+(549,0,o),
+(640,0,cs),
+(684,0,l),
+(684,56,l),
+(653,56,ls),
+(590,56,o),
+(573,89,o),
+(573,125,cs),
+(573,207,o),
+(675,336,o),
+(675,465,cs),
+(675,624,o),
+(561,727,o),
+(374,727,cs),
+(187,727,o),
+(72,624,o),
+(72,465,cs),
+(72,336,o),
+(174,207,o),
+(174,125,cs),
+(174,89,o),
+(157,56,o),
+(95,56,cs),
+(63,56,l),
+(63,0,l)
+);
+}
+);
+width = 747;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1641;
+unicode = 5697;
+},
+{
+color = 9;
+glyphname = "zeCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (367,357);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(537,-13,o),
+(627,109,o),
+(627,357,cs),
+(627,605,o),
+(537,727,o),
+(409,727,cs),
+(306,727,o),
+(218,620,o),
+(168,620,cs),
+(142,620,o),
+(118,635,o),
+(118,685,cs),
+(118,714,l),
+(61,714,l),
+(61,673,ls),
+(61,601,o),
+(99,563,o),
+(156,563,cs),
+(230,563,o),
+(309,668,o),
+(398,668,cs),
+(495,668,o),
+(563,575,o),
+(563,357,cs),
+(563,139,o),
+(495,46,o),
+(398,46,cs),
+(309,46,o),
+(230,151,o),
+(156,151,cs),
+(99,151,o),
+(61,113,o),
+(61,41,cs),
+(61,0,l),
+(118,0,l),
+(118,29,ls),
+(118,79,o),
+(142,94,o),
+(168,94,cs),
+(218,94,o),
+(306,-13,o),
+(409,-13,cs)
+);
+}
+);
+width = 696;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1642;
+unicode = 5698;
+},
+{
+color = 9;
+glyphname = "zeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (326,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 696;
+}
+);
+note = uni1643;
+unicode = 5699;
+},
+{
+color = 9;
+glyphname = "ziCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (303,0);
+ref = dot_middle;
+}
+);
+width = 696;
+}
+);
+note = uni1644;
+unicode = 5700;
+},
+{
+color = 9;
+glyphname = "zaCarrier-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(390,-13,o),
+(478,94,o),
+(529,94,cs),
+(555,94,o),
+(578,79,o),
+(578,29,cs),
+(578,0,l),
+(636,0,l),
+(636,41,ls),
+(636,113,o),
+(597,151,o),
+(541,151,cs),
+(466,151,o),
+(387,46,o),
+(298,46,cs),
+(202,46,o),
+(133,139,o),
+(133,357,cs),
+(133,575,o),
+(202,668,o),
+(298,668,cs),
+(387,668,o),
+(466,563,o),
+(541,563,cs),
+(597,563,o),
+(636,601,o),
+(636,673,cs),
+(636,714,l),
+(578,714,l),
+(578,685,ls),
+(578,635,o),
+(555,620,o),
+(529,620,cs),
+(478,620,o),
+(390,727,o),
+(288,727,cs),
+(160,727,o),
+(69,605,o),
+(69,357,cs),
+(69,109,o),
+(159,-13,o),
+(288,-13,cs)
+);
+}
+);
+width = 697;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|zeCarrier-canadian";
+note = uni1645;
+unicode = 5701;
+},
+{
+color = 6;
+glyphname = "zCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(367,189,l),
+(367,232,l),
+(119,232,l),
+(119,205,l),
+(364,521,l),
+(364,546,l),
+(69.995,546,l),
+(70,503,l),
+(315,503,l),
+(315,530,l),
+(70,214,l),
+(69.995,189,l)
+);
+}
+);
+width = 437;
+}
+);
+metricRight = "=|";
+note = uni1646;
+unicode = 5702;
+},
+{
+color = 6;
+glyphname = "initialzCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(194,189,l),
+(194,99,l),
+(240,99,l),
+(240,189,l),
+(367,189,l),
+(367,232,l),
+(111,232,l),
+(122,208,l),
+(364,521,l),
+(364,546,l),
+(240,546,l),
+(240,636,l),
+(194,636,l),
+(194,546,l),
+(69.995,546,l),
+(70,503,l),
+(323,503,l),
+(311,526,l),
+(70,214,l),
+(69.995,189,l)
+);
+}
+);
+width = 437;
+}
+);
+metricLeft = "zCarrier-canadian";
+metricRight = "zCarrier-canadian";
+note = uni1647;
+unicode = 5703;
+},
+{
+color = 9;
+glyphname = "dzuCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(560,-13,o),
+(675,90,o),
+(675,249,cs),
+(675,378,o),
+(573,507,o),
+(573,589,cs),
+(573,625,o),
+(590,658,o),
+(652,658,cs),
+(684,658,l),
+(684,714,l),
+(641,714,ls),
+(551,714,o),
+(512,664,o),
+(512,595,cs),
+(512,499,o),
+(611,381,o),
+(611,257,cs),
+(611,125,o),
+(524,46,o),
+(373,46,cs),
+(222,46,o),
+(136,125,o),
+(136,257,cs),
+(136,381,o),
+(235,499,o),
+(235,595,cs),
+(235,664,o),
+(196,714,o),
+(106,714,cs),
+(63,714,l),
+(63,658,l),
+(95,658,ls),
+(157,658,o),
+(174,625,o),
+(174,589,cs),
+(174,507,o),
+(72,378,o),
+(72,249,cs),
+(72,90,o),
+(187,-13,o),
+(373,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(392,507,l),
+(392,679,l),
+(463,679,l),
+(463,714,l),
+(284,714,l),
+(284,679,l),
+(355,679,l),
+(355,507,l)
+);
+}
+);
+width = 747;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1648;
+unicode = 5704;
+},
+{
+color = 9;
+glyphname = "dzoCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(106,0,ls),
+(196,0,o),
+(235,50,o),
+(235,119,cs),
+(235,215,o),
+(136,333,o),
+(136,457,cs),
+(136,589,o),
+(223,668,o),
+(374,668,cs),
+(525,668,o),
+(611,589,o),
+(611,457,cs),
+(611,333,o),
+(512,215,o),
+(512,119,cs),
+(512,50,o),
+(551,0,o),
+(641,0,cs),
+(684,0,l),
+(684,56,l),
+(653,56,ls),
+(590,56,o),
+(573,89,o),
+(573,125,cs),
+(573,207,o),
+(675,336,o),
+(675,465,cs),
+(675,624,o),
+(561,727,o),
+(374,727,cs),
+(187,727,o),
+(72,624,o),
+(72,465,cs),
+(72,336,o),
+(174,207,o),
+(174,125,cs),
+(174,89,o),
+(157,56,o),
+(95,56,cs),
+(63,56,l),
+(63,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(463,0,l),
+(463,35,l),
+(392,35,l),
+(392,207,l),
+(355,207,l),
+(355,35,l),
+(285,35,l),
+(285,0,l)
+);
+}
+);
+width = 747;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1649;
+unicode = 5705;
+},
+{
+color = 9;
+glyphname = "dzeCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (382,357);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(559,-13,o),
+(650,109,o),
+(650,357,cs),
+(650,605,o),
+(560,727,o),
+(431,727,cs),
+(329,727,o),
+(241,620,o),
+(190,620,cs),
+(164,620,o),
+(141,635,o),
+(141,685,cs),
+(141,714,l),
+(83,714,l),
+(83,673,ls),
+(83,601,o),
+(122,563,o),
+(179,563,cs),
+(253,563,o),
+(332,668,o),
+(421,668,cs),
+(517,668,o),
+(586,575,o),
+(586,357,cs),
+(586,139,o),
+(517,46,o),
+(421,46,cs),
+(332,46,o),
+(253,151,o),
+(179,151,cs),
+(122,151,o),
+(83,113,o),
+(83,41,cs),
+(83,0,l),
+(141,0,l),
+(141,29,ls),
+(141,78,o),
+(164,93,o),
+(190,93,cs),
+(241,93,o),
+(329,-13,o),
+(431,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(123,249,l),
+(123,338,l),
+(258,338,l),
+(258,376,l),
+(123,376,l),
+(123,465,l),
+(83,465,l),
+(83,249,l)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164A;
+unicode = 5706;
+},
+{
+color = 9;
+glyphname = "dzeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+ref = "dzeCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (341,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 719;
+}
+);
+metricLeft = "dzeCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164B;
+unicode = 5707;
+},
+{
+color = 9;
+glyphname = "dziCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "dzeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (318,0);
+ref = dot_middle;
+}
+);
+width = 719;
+}
+);
+note = uni164C;
+unicode = 5708;
+},
+{
+color = 9;
+glyphname = "dzaCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(390,-13,o),
+(478,93,o),
+(529,93,cs),
+(555,93,o),
+(578,78,o),
+(578,29,cs),
+(578,0,l),
+(636,0,l),
+(636,41,ls),
+(636,113,o),
+(597,151,o),
+(541,151,cs),
+(466,151,o),
+(387,46,o),
+(298,46,cs),
+(202,46,o),
+(133,139,o),
+(133,357,cs),
+(133,575,o),
+(202,668,o),
+(298,668,cs),
+(387,668,o),
+(466,563,o),
+(541,563,cs),
+(597,563,o),
+(636,601,o),
+(636,673,cs),
+(636,714,l),
+(578,714,l),
+(578,685,ls),
+(578,635,o),
+(555,620,o),
+(529,620,cs),
+(478,620,o),
+(390,727,o),
+(288,727,cs),
+(160,727,o),
+(69,605,o),
+(69,357,cs),
+(69,109,o),
+(160,-13,o),
+(288,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(636,249,l),
+(636,465,l),
+(596,465,l),
+(596,376,l),
+(461,376,l),
+(461,338,l),
+(596,338,l),
+(596,249,l)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dzeCarrier-canadian";
+note = uni164D;
+unicode = 5709;
+},
+{
+color = 9;
+glyphname = "suCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(355,-13,o),
+(418,45,o),
+(440,148,c),
+(419,148,l),
+(441,45,o),
+(505,-13,o),
+(599,-13,cs),
+(722,-13,o),
+(788,76,o),
+(788,202,cs),
+(788,345,o),
+(686,496,o),
+(686,589,cs),
+(686,625,o),
+(704,658,o),
+(765,658,cs),
+(796,658,l),
+(796,714,l),
+(753,714,ls),
+(662,714,o),
+(625,664,o),
+(625,595,cs),
+(625,489,o),
+(724,340,o),
+(724,208,cs),
+(724,108,o),
+(681,45,o),
+(595,45,cs),
+(509,45,o),
+(459,109,o),
+(459,231,cs),
+(459,714,l),
+(400,714,l),
+(400,231,ls),
+(400,109,o),
+(350,45,o),
+(265,45,cs),
+(179,45,o),
+(135,108,o),
+(135,208,cs),
+(135,340,o),
+(235,489,o),
+(235,595,cs),
+(235,664,o),
+(197,714,o),
+(106,714,cs),
+(63,714,l),
+(63,658,l),
+(94,658,ls),
+(156,658,o),
+(173,625,o),
+(173,589,cs),
+(173,496,o),
+(72,345,o),
+(72,202,cs),
+(72,76,o),
+(138,-13,o),
+(261,-13,cs)
+);
+}
+);
+width = 859;
+}
+);
+metricRight = "=|";
+note = uni164E;
+unicode = 5710;
+},
+{
+color = 9;
+glyphname = "soCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(106,0,ls),
+(197,0,o),
+(234,50,o),
+(234,119,cs),
+(234,225,o),
+(135,374,o),
+(135,506,cs),
+(135,606,o),
+(179,669,o),
+(264,669,cs),
+(350,669,o),
+(400,605,o),
+(400,483,cs),
+(400,0,l),
+(459,0,l),
+(459,483,ls),
+(459,605,o),
+(509,669,o),
+(595,669,cs),
+(680,669,o),
+(724,606,o),
+(724,506,cs),
+(724,374,o),
+(625,225,o),
+(625,119,cs),
+(625,50,o),
+(662,0,o),
+(753,0,cs),
+(796,0,l),
+(796,56,l),
+(765,56,ls),
+(704,56,o),
+(686,89,o),
+(686,125,cs),
+(686,218,o),
+(787,369,o),
+(787,512,cs),
+(787,638,o),
+(721,727,o),
+(599,727,cs),
+(505,727,o),
+(441,669,o),
+(419,566,c),
+(440,566,l),
+(418,669,o),
+(354,727,o),
+(260,727,cs),
+(137,727,o),
+(71,638,o),
+(71,512,cs),
+(71,369,o),
+(173,218,o),
+(173,125,cs),
+(173,89,o),
+(156,56,o),
+(94,56,cs),
+(63,56,l),
+(63,0,l)
+);
+}
+);
+width = 859;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5711;
+},
+{
+color = 9;
+glyphname = "seCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(573,-13,o),
+(641,64,o),
+(641,179,cs),
+(641,283,o),
+(581,353,o),
+(478,366,c),
+(478,348,l),
+(581,360,o),
+(641,430,o),
+(641,535,cs),
+(641,650,o),
+(573,727,o),
+(467,727,cs),
+(363,727,o),
+(244,620,o),
+(185,620,cs),
+(161,620,o),
+(138,635,o),
+(138,685,cs),
+(138,714,l),
+(80,714,l),
+(80,674,ls),
+(80,602,o),
+(118,564,o),
+(174,564,cs),
+(254,564,o),
+(365,669,o),
+(455,669,cs),
+(532,669,o),
+(578,617,o),
+(578,530,cs),
+(578,434,o),
+(516,384,o),
+(413,384,cs),
+(80,384,l),
+(80,330,l),
+(413,330,ls),
+(517,330,o),
+(578,280,o),
+(578,184,cs),
+(578,97,o),
+(532,45,o),
+(455,45,cs),
+(365,45,o),
+(254,150,o),
+(174,150,cs),
+(118,150,o),
+(80,112,o),
+(80,40,cs),
+(80,0,l),
+(138,0,l),
+(138,29,ls),
+(138,79,o),
+(161,94,o),
+(185,94,cs),
+(244,94,o),
+(363,-13,o),
+(467,-13,cs)
+);
+}
+);
+width = 720;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni1650;
+unicode = 5712;
+},
+{
+color = 9;
+glyphname = "seeCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(573,-13,o),
+(641,64,o),
+(641,179,cs),
+(641,277,o),
+(588,344,o),
+(496,364,c),
+(496,350,l),
+(588,369,o),
+(641,436,o),
+(641,535,cs),
+(641,650,o),
+(573,727,o),
+(467,727,cs),
+(363,727,o),
+(244,620,o),
+(185,620,cs),
+(161,620,o),
+(138,635,o),
+(138,685,cs),
+(138,714,l),
+(80,714,l),
+(80,674,ls),
+(80,602,o),
+(118,564,o),
+(174,564,cs),
+(254,564,o),
+(365,669,o),
+(455,669,cs),
+(532,669,o),
+(578,617,o),
+(578,530,cs),
+(578,434,o),
+(516,384,o),
+(416,384,cs),
+(353,384,l),
+(369,361,l),
+(369,469,l),
+(328,469,l),
+(328,384,l),
+(80,384,l),
+(80,331,l),
+(328,331,l),
+(328,234,l),
+(369,234,l),
+(369,353,l),
+(353,331,l),
+(416,331,ls),
+(517,331,o),
+(578,280,o),
+(578,184,cs),
+(578,97,o),
+(532,45,o),
+(455,45,cs),
+(365,45,o),
+(254,150,o),
+(174,150,cs),
+(118,150,o),
+(80,112,o),
+(80,40,cs),
+(80,0,l),
+(138,0,l),
+(138,29,ls),
+(138,79,o),
+(161,94,o),
+(185,94,cs),
+(244,94,o),
+(363,-13,o),
+(467,-13,cs)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1651;
+unicode = 5713;
+},
+{
+color = 9;
+glyphname = "siCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(573,-13,o),
+(641,64,o),
+(641,179,cs),
+(641,277,o),
+(587,344,o),
+(498,364,c),
+(498,350,l),
+(588,369,o),
+(641,436,o),
+(641,535,cs),
+(641,650,o),
+(573,727,o),
+(467,727,cs),
+(363,727,o),
+(244,620,o),
+(185,620,cs),
+(161,620,o),
+(138,635,o),
+(138,685,cs),
+(138,714,l),
+(80,714,l),
+(80,674,ls),
+(80,602,o),
+(118,564,o),
+(174,564,cs),
+(254,564,o),
+(365,669,o),
+(455,669,cs),
+(533,669,o),
+(579,617,o),
+(579,530,cs),
+(579,433,o),
+(518,383,o),
+(425,383,cs),
+(377,383,l),
+(400,364,l),
+(398,398,o),
+(371,423,o),
+(336,423,cs),
+(310,423,o),
+(287,407,o),
+(278,384,c),
+(80,384,l),
+(80,331,l),
+(279,331,l),
+(288,308,o),
+(311,292,o),
+(337,292,cs),
+(370,292,o),
+(396,317,o),
+(400,350,c),
+(376,332,l),
+(425,332,ls),
+(519,332,o),
+(579,281,o),
+(579,184,cs),
+(579,97,o),
+(533,45,o),
+(456,45,cs),
+(365,45,o),
+(254,150,o),
+(174,150,cs),
+(118,150,o),
+(80,112,o),
+(80,40,cs),
+(80,0,l),
+(138,0,l),
+(138,29,ls),
+(138,79,o),
+(161,94,o),
+(185,94,cs),
+(244,94,o),
+(363,-13,o),
+(467,-13,cs)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1652;
+unicode = 5714;
+},
+{
+color = 9;
+glyphname = "saCarrier-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(357,-13,o),
+(477,94,o),
+(535,94,cs),
+(560,94,o),
+(583,79,o),
+(583,29,cs),
+(583,0,l),
+(641,0,l),
+(641,40,ls),
+(641,112,o),
+(602,150,o),
+(546,150,cs),
+(466,150,o),
+(356,45,o),
+(266,45,cs),
+(189,45,o),
+(143,97,o),
+(143,184,cs),
+(143,280,o),
+(203,330,o),
+(307,330,cs),
+(641,330,l),
+(641,384,l),
+(307,384,ls),
+(204,384,o),
+(143,434,o),
+(143,530,cs),
+(143,617,o),
+(189,669,o),
+(266,669,cs),
+(356,669,o),
+(466,564,o),
+(546,564,cs),
+(602,564,o),
+(641,602,o),
+(641,674,cs),
+(641,714,l),
+(583,714,l),
+(583,685,ls),
+(583,635,o),
+(560,620,o),
+(535,620,cs),
+(477,620,o),
+(357,727,o),
+(254,727,cs),
+(147,727,o),
+(79,650,o),
+(79,535,cs),
+(79,430,o),
+(139,360,o),
+(243,348,c),
+(243,366,l),
+(140,353,o),
+(79,283,o),
+(79,179,cs),
+(79,64,o),
+(147,-13,o),
+(253,-13,cs)
+);
+}
+);
+width = 721;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1653;
+unicode = 5715;
+},
+{
+color = 9;
+glyphname = "shuCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(352,-13,o),
+(414,41,o),
+(438,139,c),
+(422,139,l),
+(445,41,o),
+(508,-13,o),
+(599,-13,cs),
+(722,-13,o),
+(788,76,o),
+(788,202,cs),
+(788,345,o),
+(686,496,o),
+(686,589,cs),
+(686,625,o),
+(704,658,o),
+(765,658,cs),
+(796,658,l),
+(796,714,l),
+(753,714,ls),
+(662,714,o),
+(625,664,o),
+(625,595,cs),
+(625,577,o),
+(629,557,o),
+(632,538,c),
+(646,574,l),
+(459,574,l),
+(459,714,l),
+(400,714,l),
+(400,574,l),
+(214,574,l),
+(227,538,l),
+(231,557,o),
+(234,577,o),
+(234,595,cs),
+(234,664,o),
+(197,714,o),
+(106,714,cs),
+(63,714,l),
+(63,658,l),
+(94,658,ls),
+(156,658,o),
+(173,625,o),
+(173,589,cs),
+(173,496,o),
+(72,345,o),
+(72,202,cs),
+(72,76,o),
+(138,-13,o),
+(261,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(179,45,o),
+(135,108,o),
+(135,208,cs),
+(135,312,o),
+(197,426,o),
+(223,521,c),
+(400,521,l),
+(400,231,ls),
+(400,109,o),
+(350,45,o),
+(265,45,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(509,45,o),
+(459,109,o),
+(459,231,cs),
+(459,521,l),
+(637,521,l),
+(662,426,o),
+(724,312,o),
+(724,208,cs),
+(724,108,o),
+(681,45,o),
+(595,45,cs)
+);
+}
+);
+width = 859;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1654;
+unicode = 5716;
+},
+{
+color = 9;
+glyphname = "shoCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(106,0,ls),
+(197,0,o),
+(234,50,o),
+(234,119,cs),
+(234,137,o),
+(231,157,o),
+(227,176,c),
+(214,140,l),
+(400,140,l),
+(400,0,l),
+(459,0,l),
+(459,140,l),
+(645,140,l),
+(632,176,l),
+(628,157,o),
+(625,137,o),
+(625,119,cs),
+(625,50,o),
+(662,0,o),
+(753,0,cs),
+(796,0,l),
+(796,56,l),
+(765,56,ls),
+(704,56,o),
+(686,89,o),
+(686,125,cs),
+(686,218,o),
+(787,369,o),
+(787,512,cs),
+(787,638,o),
+(721,727,o),
+(599,727,cs),
+(507,727,o),
+(445,673,o),
+(421,575,c),
+(438,575,l),
+(414,673,o),
+(352,727,o),
+(260,727,cs),
+(137,727,o),
+(71,638,o),
+(71,512,cs),
+(71,369,o),
+(173,218,o),
+(173,125,cs),
+(173,89,o),
+(156,56,o),
+(94,56,cs),
+(63,56,l),
+(63,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(197,288,o),
+(135,402,o),
+(135,506,cs),
+(135,606,o),
+(179,669,o),
+(264,669,cs),
+(350,669,o),
+(400,605,o),
+(400,483,cs),
+(400,193,l),
+(222,193,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(459,483,ls),
+(459,605,o),
+(509,669,o),
+(595,669,cs),
+(680,669,o),
+(724,606,o),
+(724,506,cs),
+(724,402,o),
+(662,288,o),
+(636,193,c),
+(459,193,l)
+);
+}
+);
+width = 859;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1655;
+unicode = 5717;
+},
+{
+color = 9;
+glyphname = "sheCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(573,-13,o),
+(641,64,o),
+(641,179,cs),
+(641,277,o),
+(588,344,o),
+(496,364,c),
+(496,350,l),
+(588,369,o),
+(641,436,o),
+(641,535,cs),
+(641,650,o),
+(573,727,o),
+(467,727,cs),
+(363,727,o),
+(244,620,o),
+(185,620,cs),
+(161,620,o),
+(138,635,o),
+(138,685,cs),
+(138,714,l),
+(80,714,l),
+(80,674,ls),
+(80,602,o),
+(118,565,o),
+(174,565,cs),
+(193,565,o),
+(212,570,o),
+(232,578,c),
+(199,590,l),
+(199,384,l),
+(80,384,l),
+(80,330,l),
+(199,330,l),
+(199,124,l),
+(232,136,l),
+(212,144,o),
+(193,149,o),
+(174,149,cs),
+(118,149,o),
+(80,112,o),
+(80,40,cs),
+(80,0,l),
+(138,0,l),
+(138,29,ls),
+(138,79,o),
+(161,94,o),
+(185,94,cs),
+(244,94,o),
+(363,-13,o),
+(467,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(251,330,l),
+(413,330,ls),
+(517,330,o),
+(578,280,o),
+(578,184,cs),
+(578,97,o),
+(532,45,o),
+(455,45,cs),
+(390,45,o),
+(316,98,o),
+(251,128,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(251,586,l),
+(316,616,o),
+(390,669,o),
+(455,669,cs),
+(532,669,o),
+(578,617,o),
+(578,530,cs),
+(578,434,o),
+(516,384,o),
+(413,384,cs),
+(251,384,l)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1656;
+unicode = 5718;
+},
+{
+color = 9;
+glyphname = "sheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(573,-13,o),
+(641,64,o),
+(641,179,cs),
+(641,277,o),
+(588,344,o),
+(496,364,c),
+(496,350,l),
+(588,369,o),
+(641,436,o),
+(641,535,cs),
+(641,650,o),
+(573,727,o),
+(467,727,cs),
+(363,727,o),
+(244,620,o),
+(185,620,cs),
+(161,620,o),
+(138,635,o),
+(138,685,cs),
+(138,714,l),
+(80,714,l),
+(80,674,ls),
+(80,602,o),
+(118,565,o),
+(174,565,cs),
+(192,565,o),
+(212,570,o),
+(231,577,c),
+(199,591,l),
+(199,381,l),
+(80,381,l),
+(80,334,l),
+(199,334,l),
+(199,123,l),
+(231,137,l),
+(212,144,o),
+(192,149,o),
+(174,149,cs),
+(118,149,o),
+(80,112,o),
+(80,40,cs),
+(80,0,l),
+(138,0,l),
+(138,29,ls),
+(138,79,o),
+(161,94,o),
+(185,94,cs),
+(244,94,o),
+(363,-13,o),
+(467,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(390,44,o),
+(313,99,o),
+(247,130,c),
+(247,334,l),
+(372,334,l),
+(372,235,l),
+(409,235,l),
+(409,348,l),
+(395,334,l),
+(419,334,ls),
+(519,334,o),
+(579,281,o),
+(579,186,cs),
+(579,97,o),
+(533,44,o),
+(456,44,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(409,469,l),
+(372,469,l),
+(372,381,l),
+(247,381,l),
+(247,584,l),
+(313,615,o),
+(390,670,o),
+(455,670,cs),
+(533,670,o),
+(579,617,o),
+(579,528,cs),
+(579,433,o),
+(518,381,o),
+(419,381,cs),
+(395,381,l),
+(409,366,l)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1657;
+unicode = 5719;
+},
+{
+color = 9;
+glyphname = "shiCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(80,674,ls),
+(80,602,o),
+(118,565,o),
+(174,565,cs),
+(191,565,o),
+(210,569,o),
+(229,577,c),
+(199,592,l),
+(199,381,l),
+(80,381,l),
+(80,334,l),
+(199,334,l),
+(199,122,l),
+(229,137,l),
+(210,145,o),
+(191,149,o),
+(174,149,cs),
+(118,149,o),
+(80,112,o),
+(80,40,cs),
+(80,0,l),
+(138,0,l),
+(138,29,ls),
+(138,79,o),
+(161,94,o),
+(185,94,cs),
+(244,94,o),
+(363,-13,o),
+(467,-13,cs),
+(573,-13,o),
+(641,64,o),
+(641,179,cs),
+(641,277,o),
+(587,344,o),
+(498,364,c),
+(498,350,l),
+(588,369,o),
+(641,436,o),
+(641,535,cs),
+(641,650,o),
+(573,727,o),
+(467,727,cs),
+(363,727,o),
+(244,620,o),
+(185,620,cs),
+(161,620,o),
+(138,635,o),
+(138,685,cs),
+(138,714,l),
+(80,714,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(247,334,l),
+(332,334,l),
+(342,308,o),
+(365,292,o),
+(391,292,cs),
+(425,292,o),
+(451,319,o),
+(453,352,c),
+(401,333,l),
+(426,333,ls),
+(520,333,o),
+(579,280,o),
+(579,186,cs),
+(579,97,o),
+(533,44,o),
+(456,44,cs),
+(390,44,o),
+(313,99,o),
+(247,130,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(247,584,l),
+(313,615,o),
+(390,670,o),
+(455,670,cs),
+(533,670,o),
+(579,617,o),
+(579,528,cs),
+(579,434,o),
+(519,381,o),
+(426,381,cs),
+(402,381,l),
+(454,362,l),
+(453,396,o),
+(425,423,o),
+(390,423,cs),
+(364,423,o),
+(341,407,o),
+(332,381,c),
+(247,381,l)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1658;
+unicode = 5720;
+},
+{
+color = 9;
+glyphname = "shaCarrier-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(357,-13,o),
+(477,94,o),
+(535,94,cs),
+(560,94,o),
+(583,79,o),
+(583,29,cs),
+(583,0,l),
+(641,0,l),
+(641,40,ls),
+(641,112,o),
+(602,149,o),
+(546,149,cs),
+(528,149,o),
+(508,144,o),
+(489,136,c),
+(522,124,l),
+(522,330,l),
+(641,330,l),
+(641,384,l),
+(522,384,l),
+(522,590,l),
+(489,578,l),
+(508,570,o),
+(528,565,o),
+(546,565,cs),
+(602,565,o),
+(641,602,o),
+(641,674,cs),
+(641,714,l),
+(583,714,l),
+(583,685,ls),
+(583,635,o),
+(560,620,o),
+(535,620,cs),
+(477,620,o),
+(357,727,o),
+(254,727,cs),
+(147,727,o),
+(79,650,o),
+(79,535,cs),
+(79,436,o),
+(132,369,o),
+(224,350,c),
+(224,364,l),
+(132,344,o),
+(79,277,o),
+(79,179,cs),
+(79,64,o),
+(147,-13,o),
+(253,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(189,45,o),
+(143,97,o),
+(143,184,cs),
+(143,280,o),
+(203,330,o),
+(307,330,cs),
+(469,330,l),
+(469,128,l),
+(404,98,o),
+(330,45,o),
+(266,45,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(204,384,o),
+(143,434,o),
+(143,530,cs),
+(143,617,o),
+(189,669,o),
+(266,669,cs),
+(330,669,o),
+(404,616,o),
+(469,586,c),
+(469,384,l),
+(307,384,ls)
+);
+}
+);
+width = 721;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1659;
+unicode = 5721;
+},
+{
+color = 6;
+glyphname = "shCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(228,99,l),
+(228,203,l),
+(203,189,l),
+(226,189,ls),
+(301,189,o),
+(339,225,o),
+(339,287,cs),
+(339,349,o),
+(302,387,o),
+(228,387,cs),
+(186,387,ls),
+(139,387,o),
+(113,404,o),
+(113,447,cs),
+(113,490,o),
+(140,507,o),
+(186,507,cs),
+(333,507,l),
+(333,546,l),
+(228,546,l),
+(228,636,l),
+(182,636,l),
+(182,530,l),
+(206,546,l),
+(183,546,ls),
+(108,546,o),
+(70,510,o),
+(70,448,cs),
+(70,386,o),
+(107,348,o),
+(181,348,cs),
+(223,348,ls),
+(270,348,o),
+(296,330,o),
+(296,288,cs),
+(296,246,o),
+(269,228,o),
+(223,228,cs),
+(76,228,l),
+(76,189,l),
+(182,189,l),
+(182,99,l)
+);
+}
+);
+width = 409;
+}
+);
+metricRight = "=|";
+note = uni18F5;
+unicode = 5722;
+},
+{
+color = 9;
+glyphname = "tsuCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(352,-13,o),
+(414,41,o),
+(438,139,c),
+(422,139,l),
+(445,41,o),
+(508,-13,o),
+(599,-13,cs),
+(722,-13,o),
+(788,76,o),
+(788,202,cs),
+(788,345,o),
+(686,496,o),
+(686,589,cs),
+(686,625,o),
+(704,658,o),
+(765,658,cs),
+(796,658,l),
+(796,714,l),
+(753,714,ls),
+(663,714,o),
+(626,665,o),
+(626,595,cs),
+(626,537,o),
+(662,463,o),
+(689,384,c),
+(459,384,l),
+(459,666,l),
+(546,666,l),
+(546,714,l),
+(313,714,l),
+(313,666,l),
+(401,666,l),
+(401,384,l),
+(171,384,l),
+(198,463,o),
+(234,537,o),
+(234,595,cs),
+(234,665,o),
+(196,714,o),
+(106,714,cs),
+(63,714,l),
+(63,658,l),
+(94,658,ls),
+(156,658,o),
+(173,625,o),
+(173,589,cs),
+(173,496,o),
+(72,345,o),
+(72,202,cs),
+(72,76,o),
+(138,-13,o),
+(261,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(179,45,o),
+(135,108,o),
+(135,208,cs),
+(135,248,o),
+(144,289,o),
+(156,330,c),
+(401,330,l),
+(401,231,ls),
+(401,109,o),
+(350,45,o),
+(265,45,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(509,45,o),
+(459,109,o),
+(459,231,cs),
+(459,330,l),
+(703,330,l),
+(715,289,o),
+(724,248,o),
+(724,208,cs),
+(724,108,o),
+(680,45,o),
+(595,45,cs)
+);
+}
+);
+width = 859;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165B;
+unicode = 5723;
+},
+{
+color = 9;
+glyphname = "tsoCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(106,0,ls),
+(196,0,o),
+(233,49,o),
+(233,119,cs),
+(233,177,o),
+(197,251,o),
+(170,330,c),
+(401,330,l),
+(401,48,l),
+(314,48,l),
+(314,0,l),
+(546,0,l),
+(546,48,l),
+(458,48,l),
+(458,330,l),
+(689,330,l),
+(661,251,o),
+(626,177,o),
+(626,119,cs),
+(626,49,o),
+(663,0,o),
+(753,0,cs),
+(796,0,l),
+(796,56,l),
+(765,56,ls),
+(704,56,o),
+(686,89,o),
+(686,125,cs),
+(686,218,o),
+(787,369,o),
+(787,512,cs),
+(787,638,o),
+(721,727,o),
+(599,727,cs),
+(507,727,o),
+(445,673,o),
+(421,575,c),
+(438,575,l),
+(414,673,o),
+(352,727,o),
+(260,727,cs),
+(137,727,o),
+(71,638,o),
+(71,512,cs),
+(71,369,o),
+(173,218,o),
+(173,125,cs),
+(173,89,o),
+(156,56,o),
+(94,56,cs),
+(63,56,l),
+(63,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(144,425,o),
+(135,466,o),
+(135,506,cs),
+(135,606,o),
+(179,669,o),
+(264,669,cs),
+(350,669,o),
+(401,605,o),
+(401,483,cs),
+(401,384,l),
+(156,384,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(458,483,ls),
+(458,605,o),
+(509,669,o),
+(594,669,cs),
+(680,669,o),
+(724,606,o),
+(724,506,cs),
+(724,466,o),
+(715,425,o),
+(703,384,c),
+(458,384,l)
+);
+}
+);
+width = 859;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165C;
+unicode = 5724;
+},
+{
+color = 9;
+glyphname = "tseCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(577,-13,o),
+(645,64,o),
+(645,179,cs),
+(645,277,o),
+(592,344,o),
+(500,364,c),
+(500,350,l),
+(592,369,o),
+(645,436,o),
+(645,535,cs),
+(645,650,o),
+(577,727,o),
+(471,727,cs),
+(367,727,o),
+(247,620,o),
+(189,620,cs),
+(165,620,o),
+(141,635,o),
+(141,685,cs),
+(141,714,l),
+(84,714,l),
+(84,676,ls),
+(84,603,o),
+(122,566,o),
+(178,566,cs),
+(208,566,o),
+(242,580,o),
+(277,598,c),
+(253,606,l),
+(253,381,l),
+(125,381,l),
+(125,483,l),
+(84,483,l),
+(84,231,l),
+(125,231,l),
+(125,333,l),
+(253,333,l),
+(253,108,l),
+(277,116,l),
+(242,134,o),
+(208,148,o),
+(178,148,cs),
+(122,148,o),
+(84,111,o),
+(84,38,cs),
+(84,0,l),
+(141,0,l),
+(141,29,ls),
+(141,79,o),
+(165,94,o),
+(189,94,cs),
+(247,94,o),
+(367,-13,o),
+(471,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(409,45,o),
+(353,77,o),
+(300,104,c),
+(300,333,l),
+(417,333,ls),
+(521,333,o),
+(582,280,o),
+(582,184,cs),
+(582,97,o),
+(536,45,o),
+(459,45,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(300,610,l),
+(353,637,o),
+(409,669,o),
+(459,669,cs),
+(536,669,o),
+(582,617,o),
+(582,530,cs),
+(582,434,o),
+(520,381,o),
+(417,381,cs),
+(300,381,l)
+);
+}
+);
+width = 724;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni165D;
+unicode = 5725;
+},
+{
+color = 9;
+glyphname = "tseeCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(577,-13,o),
+(645,64,o),
+(645,179,cs),
+(645,277,o),
+(592,344,o),
+(500,364,c),
+(500,350,l),
+(592,369,o),
+(645,436,o),
+(645,535,cs),
+(645,650,o),
+(577,727,o),
+(471,727,cs),
+(367,727,o),
+(247,620,o),
+(189,620,cs),
+(165,620,o),
+(141,635,o),
+(141,685,cs),
+(141,714,l),
+(84,714,l),
+(84,676,ls),
+(84,603,o),
+(122,566,o),
+(178,566,cs),
+(205,566,o),
+(237,579,o),
+(270,596,c),
+(251,606,l),
+(251,381,l),
+(125,381,l),
+(125,483,l),
+(84,483,l),
+(84,231,l),
+(125,231,l),
+(125,333,l),
+(251,333,l),
+(251,106,l),
+(270,118,l),
+(237,135,o),
+(205,148,o),
+(178,148,cs),
+(122,148,o),
+(84,111,o),
+(84,38,cs),
+(84,0,l),
+(141,0,l),
+(141,29,ls),
+(141,79,o),
+(165,94,o),
+(189,94,cs),
+(247,94,o),
+(367,-13,o),
+(471,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(408,45,o),
+(349,79,o),
+(294,107,c),
+(294,333,l),
+(400,333,l),
+(400,233,l),
+(437,233,l),
+(437,355,l),
+(403,333,l),
+(424,333,ls),
+(524,333,o),
+(582,280,o),
+(582,186,cs),
+(582,97,o),
+(536,45,o),
+(459,45,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(437,470,l),
+(400,470,l),
+(400,381,l),
+(294,381,l),
+(294,607,l),
+(349,635,o),
+(408,669,o),
+(459,669,cs),
+(536,669,o),
+(582,617,o),
+(582,528,cs),
+(582,434,o),
+(524,381,o),
+(424,381,cs),
+(403,381,l),
+(437,359,l)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165E;
+unicode = 5726;
+},
+{
+color = 9;
+glyphname = "tsiCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(577,-13,o),
+(645,64,o),
+(645,179,cs),
+(645,277,o),
+(591,344,o),
+(502,364,c),
+(502,350,l),
+(592,369,o),
+(645,436,o),
+(645,535,cs),
+(645,650,o),
+(577,727,o),
+(471,727,cs),
+(367,727,o),
+(247,620,o),
+(189,620,cs),
+(165,620,o),
+(141,635,o),
+(141,685,cs),
+(141,714,l),
+(84,714,l),
+(84,676,ls),
+(84,603,o),
+(122,566,o),
+(178,566,cs),
+(204,566,o),
+(235,579,o),
+(266,595,c),
+(245,613,l),
+(245,381,l),
+(125,381,l),
+(125,483,l),
+(84,483,l),
+(84,231,l),
+(125,231,l),
+(125,334,l),
+(245,334,l),
+(245,101,l),
+(266,119,l),
+(234,135,o),
+(204,148,o),
+(178,148,cs),
+(122,148,o),
+(84,111,o),
+(84,38,cs),
+(84,0,l),
+(141,0,l),
+(141,29,ls),
+(141,79,o),
+(165,94,o),
+(189,94,cs),
+(247,94,o),
+(367,-13,o),
+(471,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(406,45,o),
+(345,81,o),
+(289,110,c),
+(289,334,l),
+(365,334,l),
+(373,309,o),
+(396,292,o),
+(422,292,cs),
+(456,292,o),
+(481,319,o),
+(483,352,c),
+(417,334,l),
+(433,334,ls),
+(526,334,o),
+(582,281,o),
+(582,186,cs),
+(582,97,o),
+(536,45,o),
+(459,45,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(482,396,o),
+(456,423,o),
+(422,423,cs),
+(395,423,o),
+(372,406,o),
+(364,381,c),
+(289,381,l),
+(289,604,l),
+(345,633,o),
+(406,669,o),
+(459,669,cs),
+(536,669,o),
+(582,617,o),
+(582,528,cs),
+(582,433,o),
+(525,381,o),
+(433,381,cs),
+(418,381,l),
+(484,362,l)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165F;
+unicode = 5727;
+},
+{
+color = 9;
+glyphname = "tsaCarrier-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(357,-13,o),
+(477,94,o),
+(535,94,cs),
+(560,94,o),
+(583,79,o),
+(583,29,cs),
+(583,0,l),
+(641,0,l),
+(641,38,ls),
+(641,111,o),
+(602,148,o),
+(546,148,cs),
+(517,148,o),
+(483,134,o),
+(448,116,c),
+(472,108,l),
+(472,333,l),
+(599,333,l),
+(599,231,l),
+(641,231,l),
+(641,483,l),
+(599,483,l),
+(599,381,l),
+(472,381,l),
+(472,606,l),
+(447,598,l),
+(483,580,o),
+(516,566,o),
+(546,566,cs),
+(602,566,o),
+(641,603,o),
+(641,676,cs),
+(641,714,l),
+(583,714,l),
+(583,685,ls),
+(583,635,o),
+(560,620,o),
+(535,620,cs),
+(477,620,o),
+(357,727,o),
+(254,727,cs),
+(147,727,o),
+(79,650,o),
+(79,535,cs),
+(79,436,o),
+(132,369,o),
+(224,350,c),
+(224,364,l),
+(132,344,o),
+(79,277,o),
+(79,179,cs),
+(79,64,o),
+(147,-13,o),
+(253,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(189,45,o),
+(142,97,o),
+(142,184,cs),
+(142,280,o),
+(203,333,o),
+(307,333,cs),
+(424,333,l),
+(424,104,l),
+(372,77,o),
+(315,45,o),
+(265,45,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(204,381,o),
+(142,434,o),
+(142,530,cs),
+(142,617,o),
+(189,669,o),
+(266,669,cs),
+(315,669,o),
+(372,637,o),
+(424,610,c),
+(424,381,l),
+(307,381,ls)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1660;
+unicode = 5728;
+},
+{
+color = 9;
+glyphname = "chuCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(352,-13,o),
+(414,41,o),
+(438,139,c),
+(422,139,l),
+(445,41,o),
+(508,-13,o),
+(599,-13,cs),
+(722,-13,o),
+(788,76,o),
+(788,202,cs),
+(788,345,o),
+(686,496,o),
+(686,589,cs),
+(686,625,o),
+(704,658,o),
+(765,658,cs),
+(796,658,l),
+(796,714,l),
+(753,714,ls),
+(663,714,o),
+(626,665,o),
+(626,595,cs),
+(626,488,o),
+(724,340,o),
+(724,208,cs),
+(724,108,o),
+(680,45,o),
+(595,45,cs),
+(509,45,o),
+(459,109,o),
+(459,231,cs),
+(459,666,l),
+(546,666,l),
+(546,714,l),
+(313,714,l),
+(313,666,l),
+(400,666,l),
+(400,231,ls),
+(400,109,o),
+(350,45,o),
+(265,45,cs),
+(179,45,o),
+(135,108,o),
+(135,208,cs),
+(135,340,o),
+(234,488,o),
+(234,595,cs),
+(234,665,o),
+(196,714,o),
+(106,714,cs),
+(63,714,l),
+(63,658,l),
+(94,658,ls),
+(156,658,o),
+(173,625,o),
+(173,589,cs),
+(173,496,o),
+(72,345,o),
+(72,202,cs),
+(72,76,o),
+(138,-13,o),
+(261,-13,cs)
+);
+}
+);
+width = 859;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164E;
+unicode = 5729;
+},
+{
+color = 9;
+glyphname = "choCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(106,0,ls),
+(196,0,o),
+(233,49,o),
+(233,119,cs),
+(233,226,o),
+(135,374,o),
+(135,506,cs),
+(135,606,o),
+(179,669,o),
+(264,669,cs),
+(350,669,o),
+(400,605,o),
+(400,483,cs),
+(400,48,l),
+(314,48,l),
+(314,0,l),
+(546,0,l),
+(546,48,l),
+(459,48,l),
+(459,483,ls),
+(459,605,o),
+(509,669,o),
+(594,669,cs),
+(680,669,o),
+(724,606,o),
+(724,506,cs),
+(724,374,o),
+(626,226,o),
+(626,119,cs),
+(626,49,o),
+(663,0,o),
+(753,0,cs),
+(796,0,l),
+(796,56,l),
+(765,56,ls),
+(704,56,o),
+(686,89,o),
+(686,125,cs),
+(686,218,o),
+(787,369,o),
+(787,512,cs),
+(787,638,o),
+(721,727,o),
+(599,727,cs),
+(507,727,o),
+(445,673,o),
+(421,575,c),
+(438,575,l),
+(414,673,o),
+(352,727,o),
+(260,727,cs),
+(137,727,o),
+(71,638,o),
+(71,512,cs),
+(71,369,o),
+(173,218,o),
+(173,125,cs),
+(173,89,o),
+(156,56,o),
+(94,56,cs),
+(63,56,l),
+(63,0,l)
+);
+}
+);
+width = 859;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5730;
+},
+{
+color = 9;
+glyphname = "cheCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(577,-13,o),
+(645,64,o),
+(645,179,cs),
+(645,277,o),
+(592,344,o),
+(500,364,c),
+(500,350,l),
+(592,369,o),
+(645,436,o),
+(645,535,cs),
+(645,650,o),
+(577,727,o),
+(471,727,cs),
+(367,727,o),
+(247,620,o),
+(189,620,cs),
+(165,620,o),
+(141,635,o),
+(141,685,cs),
+(141,714,l),
+(84,714,l),
+(84,675,ls),
+(84,603,o),
+(122,566,o),
+(178,566,cs),
+(258,566,o),
+(368,669,o),
+(458,669,cs),
+(535,669,o),
+(582,617,o),
+(582,530,cs),
+(582,434,o),
+(520,384,o),
+(417,384,cs),
+(125,384,l),
+(125,483,l),
+(84,483,l),
+(84,231,l),
+(125,231,l),
+(125,330,l),
+(417,330,ls),
+(521,330,o),
+(582,280,o),
+(582,184,cs),
+(582,97,o),
+(535,45,o),
+(459,45,cs),
+(368,45,o),
+(258,148,o),
+(178,148,cs),
+(122,148,o),
+(84,111,o),
+(84,39,cs),
+(84,0,l),
+(141,0,l),
+(141,29,ls),
+(141,79,o),
+(165,94,o),
+(189,94,cs),
+(247,94,o),
+(367,-13,o),
+(471,-13,cs)
+);
+}
+);
+width = 724;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni1663;
+unicode = 5731;
+},
+{
+color = 9;
+glyphname = "cheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(577,-13,o),
+(645,64,o),
+(645,179,cs),
+(645,277,o),
+(592,344,o),
+(500,364,c),
+(500,350,l),
+(592,369,o),
+(645,436,o),
+(645,535,cs),
+(645,650,o),
+(577,727,o),
+(471,727,cs),
+(367,727,o),
+(247,620,o),
+(189,620,cs),
+(165,620,o),
+(141,635,o),
+(141,685,cs),
+(141,714,l),
+(84,714,l),
+(84,675,ls),
+(84,603,o),
+(122,566,o),
+(178,566,cs),
+(259,566,o),
+(369,670,o),
+(459,670,cs),
+(537,670,o),
+(583,617,o),
+(583,529,cs),
+(583,433,o),
+(522,381,o),
+(422,381,cs),
+(364,381,l),
+(382,368,l),
+(382,469,l),
+(340,469,l),
+(340,381,l),
+(125,381,l),
+(125,483,l),
+(84,483,l),
+(84,231,l),
+(125,231,l),
+(125,334,l),
+(340,334,l),
+(340,234,l),
+(382,234,l),
+(382,347,l),
+(364,334,l),
+(422,334,ls),
+(523,334,o),
+(583,281,o),
+(583,185,cs),
+(583,97,o),
+(537,44,o),
+(460,44,cs),
+(369,44,o),
+(259,148,o),
+(178,148,cs),
+(122,148,o),
+(84,111,o),
+(84,39,cs),
+(84,0,l),
+(141,0,l),
+(141,29,ls),
+(141,79,o),
+(165,94,o),
+(189,94,cs),
+(247,94,o),
+(367,-13,o),
+(471,-13,cs)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1664;
+unicode = 5732;
+},
+{
+color = 9;
+glyphname = "chiCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(577,-13,o),
+(645,64,o),
+(645,179,cs),
+(645,277,o),
+(591,344,o),
+(502,364,c),
+(502,350,l),
+(592,369,o),
+(645,436,o),
+(645,535,cs),
+(645,650,o),
+(577,727,o),
+(471,727,cs),
+(367,727,o),
+(247,620,o),
+(189,620,cs),
+(165,620,o),
+(141,635,o),
+(141,685,cs),
+(141,714,l),
+(84,714,l),
+(84,675,ls),
+(84,603,o),
+(122,566,o),
+(178,566,cs),
+(259,566,o),
+(369,670,o),
+(459,670,cs),
+(537,670,o),
+(583,617,o),
+(583,529,cs),
+(583,433,o),
+(522,381,o),
+(428,381,cs),
+(386,381,l),
+(410,361,l),
+(409,397,o),
+(381,423,o),
+(346,423,cs),
+(318,423,o),
+(295,405,o),
+(286,381,c),
+(125,381,l),
+(125,483,l),
+(84,483,l),
+(84,231,l),
+(125,231,l),
+(125,334,l),
+(287,334,l),
+(296,309,o),
+(319,292,o),
+(346,292,cs),
+(381,292,o),
+(407,319,o),
+(411,353,c),
+(385,334,l),
+(428,334,ls),
+(523,334,o),
+(583,281,o),
+(583,185,cs),
+(583,97,o),
+(537,44,o),
+(460,44,cs),
+(369,44,o),
+(259,148,o),
+(178,148,cs),
+(122,148,o),
+(84,111,o),
+(84,39,cs),
+(84,0,l),
+(141,0,l),
+(141,29,ls),
+(141,79,o),
+(165,94,o),
+(189,94,cs),
+(247,94,o),
+(367,-13,o),
+(471,-13,cs)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1665;
+unicode = 5733;
+},
+{
+color = 9;
+glyphname = "chaCarrier-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(357,-13,o),
+(477,94,o),
+(535,94,cs),
+(560,94,o),
+(583,79,o),
+(583,29,cs),
+(583,0,l),
+(641,0,l),
+(641,39,ls),
+(641,111,o),
+(602,148,o),
+(546,148,cs),
+(466,148,o),
+(356,45,o),
+(266,45,cs),
+(189,45,o),
+(143,97,o),
+(143,184,cs),
+(143,280,o),
+(204,330,o),
+(307,330,cs),
+(599,330,l),
+(599,231,l),
+(641,231,l),
+(641,483,l),
+(599,483,l),
+(599,384,l),
+(307,384,ls),
+(203,384,o),
+(143,434,o),
+(143,530,cs),
+(143,617,o),
+(189,669,o),
+(266,669,cs),
+(356,669,o),
+(466,566,o),
+(546,566,cs),
+(602,566,o),
+(641,603,o),
+(641,675,cs),
+(641,714,l),
+(583,714,l),
+(583,685,ls),
+(583,635,o),
+(560,620,o),
+(535,620,cs),
+(477,620,o),
+(357,727,o),
+(253,727,cs),
+(147,727,o),
+(79,650,o),
+(79,535,cs),
+(79,436,o),
+(132,369,o),
+(224,350,c),
+(224,364,l),
+(132,344,o),
+(79,277,o),
+(79,179,cs),
+(79,64,o),
+(147,-13,o),
+(254,-13,cs)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1666;
+unicode = 5734;
+},
+{
+color = 9;
+glyphname = "ttsuCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(352,-13,o),
+(414,41,o),
+(438,139,c),
+(422,139,l),
+(445,41,o),
+(508,-13,o),
+(599,-13,cs),
+(722,-13,o),
+(788,76,o),
+(788,202,cs),
+(788,345,o),
+(686,496,o),
+(686,589,cs),
+(686,625,o),
+(704,658,o),
+(765,658,cs),
+(796,658,l),
+(796,714,l),
+(753,714,ls),
+(663,714,o),
+(626,665,o),
+(626,595,cs),
+(626,566,o),
+(634,532,o),
+(643,497,c),
+(664,543,l),
+(459,401,l),
+(459,666,l),
+(546,666,l),
+(546,714,l),
+(313,714,l),
+(313,666,l),
+(401,666,l),
+(401,401,l),
+(195,543,l),
+(216,497,l),
+(226,532,o),
+(234,566,o),
+(234,595,cs),
+(234,665,o),
+(196,714,o),
+(106,714,cs),
+(63,714,l),
+(63,658,l),
+(94,658,ls),
+(156,658,o),
+(173,625,o),
+(173,589,cs),
+(173,496,o),
+(72,345,o),
+(72,202,cs),
+(72,76,o),
+(138,-13,o),
+(261,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(179,45,o),
+(135,108,o),
+(135,208,cs),
+(135,296,o),
+(180,389,o),
+(208,472,c),
+(401,340,l),
+(401,231,ls),
+(401,109,o),
+(350,45,o),
+(265,45,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(509,45,o),
+(459,109,o),
+(459,231,cs),
+(459,340,l),
+(651,472,l),
+(679,389,o),
+(724,296,o),
+(724,208,cs),
+(724,108,o),
+(680,45,o),
+(595,45,cs)
+);
+}
+);
+width = 859;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1667;
+unicode = 5735;
+},
+{
+color = 9;
+glyphname = "ttsoCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(106,0,ls),
+(196,0,o),
+(234,49,o),
+(234,119,cs),
+(234,148,o),
+(226,182,o),
+(216,217,c),
+(195,171,l),
+(401,313,l),
+(401,48,l),
+(313,48,l),
+(313,0,l),
+(546,0,l),
+(546,48,l),
+(459,48,l),
+(459,313,l),
+(664,171,l),
+(643,217,l),
+(634,182,o),
+(626,148,o),
+(626,119,cs),
+(626,49,o),
+(663,0,o),
+(753,0,cs),
+(796,0,l),
+(796,56,l),
+(765,56,ls),
+(704,56,o),
+(686,89,o),
+(686,125,cs),
+(686,218,o),
+(788,369,o),
+(788,512,cs),
+(788,638,o),
+(722,727,o),
+(599,727,cs),
+(508,727,o),
+(445,673,o),
+(422,575,c),
+(438,575,l),
+(414,673,o),
+(352,727,o),
+(261,727,cs),
+(138,727,o),
+(72,638,o),
+(72,512,cs),
+(72,369,o),
+(173,218,o),
+(173,125,cs),
+(173,89,o),
+(156,56,o),
+(94,56,cs),
+(63,56,l),
+(63,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(180,325,o),
+(135,418,o),
+(135,506,cs),
+(135,606,o),
+(179,669,o),
+(265,669,cs),
+(350,669,o),
+(401,605,o),
+(401,483,cs),
+(401,374,l),
+(208,242,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(459,374,l),
+(459,483,ls),
+(459,605,o),
+(509,669,o),
+(595,669,cs),
+(680,669,o),
+(724,606,o),
+(724,506,cs),
+(724,418,o),
+(679,325,o),
+(651,242,c)
+);
+}
+);
+width = 859;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1668;
+unicode = 5736;
+},
+{
+color = 9;
+glyphname = "ttseCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(577,-13,o),
+(645,64,o),
+(645,179,cs),
+(645,277,o),
+(591,344,o),
+(502,364,c),
+(502,350,l),
+(592,369,o),
+(645,436,o),
+(645,535,cs),
+(645,650,o),
+(577,727,o),
+(471,727,cs),
+(367,727,o),
+(247,620,o),
+(189,620,cs),
+(165,620,o),
+(141,635,o),
+(141,685,cs),
+(141,714,l),
+(84,714,l),
+(84,675,ls),
+(84,603,o),
+(122,566,o),
+(178,566,cs),
+(189,566,o),
+(200,567,o),
+(209,573,c),
+(163,594,l),
+(255,381,l),
+(125,381,l),
+(125,483,l),
+(84,483,l),
+(84,231,l),
+(125,231,l),
+(125,334,l),
+(255,334,l),
+(163,120,l),
+(209,141,l),
+(199,147,o),
+(189,148,o),
+(178,148,cs),
+(122,148,o),
+(84,111,o),
+(84,39,cs),
+(84,0,l),
+(141,0,l),
+(141,29,ls),
+(141,79,o),
+(165,94,o),
+(189,94,cs),
+(247,94,o),
+(367,-13,o),
+(471,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(382,44,o),
+(290,121,o),
+(220,140,c),
+(303,334,l),
+(428,334,ls),
+(523,334,o),
+(583,281,o),
+(583,185,cs),
+(583,97,o),
+(537,44,o),
+(460,44,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(220,574,l),
+(290,593,o),
+(382,670,o),
+(459,670,cs),
+(537,670,o),
+(583,617,o),
+(583,529,cs),
+(583,433,o),
+(522,381,o),
+(428,381,cs),
+(303,381,l)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1669;
+unicode = 5737;
+},
+{
+color = 9;
+glyphname = "ttseeCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(577,-13,o),
+(645,64,o),
+(645,179,cs),
+(645,277,o),
+(591,344,o),
+(502,364,c),
+(502,350,l),
+(592,369,o),
+(645,436,o),
+(645,535,cs),
+(645,650,o),
+(577,727,o),
+(471,727,cs),
+(367,727,o),
+(247,620,o),
+(189,620,cs),
+(165,620,o),
+(141,635,o),
+(141,685,cs),
+(141,714,l),
+(84,714,l),
+(84,675,ls),
+(84,603,o),
+(122,566,o),
+(178,566,cs),
+(189,566,o),
+(200,567,o),
+(207,574,c),
+(162,593,l),
+(254,381,l),
+(125,381,l),
+(125,483,l),
+(84,483,l),
+(84,231,l),
+(125,231,l),
+(125,334,l),
+(254,334,l),
+(162,121,l),
+(207,140,l),
+(200,147,o),
+(189,148,o),
+(178,148,cs),
+(122,148,o),
+(84,111,o),
+(84,39,cs),
+(84,0,l),
+(141,0,l),
+(141,29,ls),
+(141,79,o),
+(165,94,o),
+(189,94,cs),
+(247,94,o),
+(367,-13,o),
+(471,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(382,44,o),
+(290,122,o),
+(219,141,c),
+(301,334,l),
+(390,334,l),
+(390,233,l),
+(428,233,l),
+(428,348,l),
+(412,334,l),
+(428,334,ls),
+(523,334,o),
+(583,281,o),
+(583,185,cs),
+(583,97,o),
+(537,44,o),
+(460,44,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(428,470,l),
+(390,470,l),
+(390,381,l),
+(301,381,l),
+(219,573,l),
+(290,592,o),
+(382,670,o),
+(459,670,cs),
+(537,670,o),
+(583,617,o),
+(583,529,cs),
+(583,433,o),
+(522,381,o),
+(428,381,cs),
+(412,381,l),
+(428,366,l)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166A;
+unicode = 5738;
+},
+{
+color = 9;
+glyphname = "ttsiCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(577,-13,o),
+(645,64,o),
+(645,179,cs),
+(645,277,o),
+(591,344,o),
+(502,364,c),
+(502,350,l),
+(592,369,o),
+(645,436,o),
+(645,535,cs),
+(645,650,o),
+(577,727,o),
+(471,727,cs),
+(367,727,o),
+(247,620,o),
+(189,620,cs),
+(165,620,o),
+(141,635,o),
+(141,685,cs),
+(141,714,l),
+(84,714,l),
+(84,675,ls),
+(84,603,o),
+(122,566,o),
+(178,566,cs),
+(187,566,o),
+(195,566,o),
+(204,572,c),
+(167,584,l),
+(254,381,l),
+(125,381,l),
+(125,483,l),
+(84,483,l),
+(84,231,l),
+(125,231,l),
+(125,334,l),
+(254,334,l),
+(166,129,l),
+(204,142,l),
+(195,148,o),
+(187,148,o),
+(178,148,cs),
+(122,148,o),
+(84,111,o),
+(84,39,cs),
+(84,0,l),
+(141,0,l),
+(141,29,ls),
+(141,79,o),
+(165,94,o),
+(189,94,cs),
+(247,94,o),
+(367,-13,o),
+(471,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(381,44,o),
+(286,124,o),
+(215,142,c),
+(296,334,l),
+(339,334,l),
+(347,309,o),
+(370,292,o),
+(396,292,cs),
+(428,292,o),
+(454,317,o),
+(457,350,c),
+(418,334,l),
+(432,334,ls),
+(525,334,o),
+(583,281,o),
+(583,185,cs),
+(583,97,o),
+(537,44,o),
+(460,44,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(456,398,o),
+(429,423,o),
+(396,423,cs),
+(369,423,o),
+(346,405,o),
+(338,381,c),
+(296,381,l),
+(215,572,l),
+(286,590,o),
+(381,670,o),
+(459,670,cs),
+(537,670,o),
+(583,617,o),
+(583,529,cs),
+(583,433,o),
+(524,381,o),
+(432,381,cs),
+(419,381,l),
+(457,364,l)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166B;
+unicode = 5739;
+},
+{
+color = 9;
+glyphname = "ttsaCarrier-canadian";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(357,-13,o),
+(477,94,o),
+(535,94,cs),
+(560,94,o),
+(583,79,o),
+(583,29,cs),
+(583,0,l),
+(641,0,l),
+(641,39,ls),
+(641,111,o),
+(602,148,o),
+(546,148,cs),
+(535,148,o),
+(525,147,o),
+(515,141,c),
+(562,120,l),
+(470,334,l),
+(599,334,l),
+(599,231,l),
+(641,231,l),
+(641,483,l),
+(599,483,l),
+(599,381,l),
+(470,381,l),
+(562,594,l),
+(515,573,l),
+(525,567,o),
+(535,566,o),
+(546,566,cs),
+(602,566,o),
+(641,603,o),
+(641,675,cs),
+(641,714,l),
+(583,714,l),
+(583,685,ls),
+(583,635,o),
+(560,620,o),
+(535,620,cs),
+(477,620,o),
+(357,727,o),
+(254,727,cs),
+(147,727,o),
+(79,650,o),
+(79,535,cs),
+(79,436,o),
+(133,369,o),
+(222,350,c),
+(222,364,l),
+(133,344,o),
+(79,277,o),
+(79,179,cs),
+(79,64,o),
+(147,-13,o),
+(253,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(188,44,o),
+(142,97,o),
+(142,185,cs),
+(142,281,o),
+(201,334,o),
+(296,334,cs),
+(422,334,l),
+(504,140,l),
+(434,121,o),
+(342,44,o),
+(265,44,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(202,381,o),
+(142,433,o),
+(142,529,cs),
+(142,617,o),
+(188,670,o),
+(265,670,cs),
+(342,670,o),
+(434,593,o),
+(504,574,c),
+(422,381,l),
+(296,381,ls)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni166C;
+unicode = 5740;
+},
+{
+glyphname = "qai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (329,0);
+ref = "ke-canadian";
+}
+);
+width = 917;
+}
+);
+note = uni166F;
+unicode = 5743;
+},
+{
+glyphname = "ngai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (645,0);
+ref = "ce-canadian";
+}
+);
+width = 1229;
+}
+);
+note = uni1670;
+unicode = 5744;
+},
+{
+glyphname = "nngi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (936,0);
+ref = "ci-canadian";
+}
+);
+width = 1519;
+}
+);
+note = uni1671;
+unicode = 5745;
+},
+{
+glyphname = "nngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (936,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (1168,0);
+ref = dot_top;
+}
+);
+width = 1519;
+}
+);
+note = uni1672;
+unicode = 5746;
+},
+{
+glyphname = "nngo-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (936,0);
+ref = "ce-canadian";
+}
+);
+width = 1519;
+}
+);
+note = uni1673;
+unicode = 5747;
+},
+{
+glyphname = "nngoo-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (936,0);
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (1162,0);
+ref = dot_top;
+}
+);
+width = 1519;
+}
+);
+note = uni1674;
+unicode = 5748;
+},
+{
+glyphname = "nnga-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (936,0);
+ref = "ca-canadian";
+}
+);
+width = 1519;
+}
+);
+note = uni1675;
+unicode = 5749;
+},
+{
+glyphname = "nngaa-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (936,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (979,0);
+ref = dot_top;
+}
+);
+width = 1519;
+}
+);
+note = uni1676;
+unicode = 5750;
+},
+{
+glyphname = "thweeWoodScree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (608,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 829;
+}
+);
+note = uni1677;
+unicode = 5751;
+},
+{
+glyphname = "thwiWoodScree-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (608,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 829;
+}
+);
+note = uni1678;
+unicode = 5752;
+},
+{
+glyphname = "thwiiWoodScree-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (89,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (608,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 829;
+}
+);
+note = uni1679;
+unicode = 5753;
+},
+{
+glyphname = "thwoWoodScree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (608,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 829;
+}
+);
+note = uni167A;
+unicode = 5754;
+},
+{
+glyphname = "thwooWoodScree-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (391,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (608,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 829;
+}
+);
+note = uni167B;
+unicode = 5755;
+},
+{
+glyphname = "thwaWoodScree-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = middle_right_can;
+pos = (608,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 828;
+}
+);
+note = uni167C;
+unicode = 5756;
+},
+{
+glyphname = "thwaaWoodScree-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (89,0);
+ref = dot_top;
+},
+{
+anchor = middle_right_can;
+pos = (608,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 828;
+}
+);
+note = uni167D;
+unicode = 5757;
+},
+{
+glyphname = "wBlackfoot-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(390,584,l),
+(390,625,l),
+(70,625,l),
+(70,584,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(390,446,l),
+(390,487,l),
+(70,487,l),
+(70,446,l)
+);
+}
+);
+width = 460;
+}
+);
+metricRight = "=|";
+note = uni167F;
+unicode = 5759;
+},
+{
+glyphname = "oy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-13,0);
+ref = ring_top.canadian;
+}
+);
+width = 688;
+}
+);
+note = uni18B0;
+unicode = 6320;
+},
+{
+glyphname = "ay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (453,0);
+ref = ring_top.canadian;
+}
+);
+width = 688;
+}
+);
+note = uni18B1;
+unicode = 6321;
+},
+{
+glyphname = "aay-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (194,0);
+ref = ring_top.canadian;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (513,0);
+ref = dot_top;
+}
+);
+width = 688;
+}
+);
+note = uni18B2;
+unicode = 6322;
+},
+{
+glyphname = "way-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (673,0);
+ref = ring_top.canadian;
+}
+);
+width = 909;
+}
+);
+note = uni18B3;
+unicode = 6323;
+},
+{
+glyphname = "poy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-36,0);
+ref = ring_top.canadian;
+}
+);
+width = 658;
+}
+);
+note = uni18B4;
+unicode = 6324;
+},
+{
+glyphname = "pay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (445,0);
+ref = ring_top.canadian;
+}
+);
+width = 658;
+}
+);
+note = uni18B5;
+unicode = 6325;
+},
+{
+glyphname = "pwoy-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (184,0);
+ref = ring_top.canadian;
+}
+);
+width = 878;
+}
+);
+note = uni18B6;
+unicode = 6326;
+},
+{
+glyphname = "tay-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (210,0);
+ref = ring_top.canadian;
+}
+);
+width = 606;
+}
+);
+note = uni18B7;
+unicode = 6327;
+},
+{
+glyphname = "kay-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-16,0);
+ref = ring_top.canadian;
+}
+);
+width = 588;
+}
+);
+note = uni18B8;
+unicode = 6328;
+},
+{
+glyphname = "kway-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (204,0);
+ref = ring_top.canadian;
+}
+);
+width = 808;
+}
+);
+note = uni18B9;
+unicode = 6329;
+},
+{
+glyphname = "may-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-9,0);
+ref = ring_top.canadian;
+}
+);
+width = 520;
+}
+);
+note = uni18BA;
+unicode = 6330;
+},
+{
+glyphname = "noy-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (389,-207);
+ref = ring_top.canadian;
+}
+);
+width = 815;
+}
+);
+note = uni18BB;
+unicode = 6331;
+},
+{
+glyphname = "nay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (177,-207);
+ref = ring_top.canadian;
+}
+);
+width = 815;
+}
+);
+note = uni18BC;
+unicode = 6332;
+},
+{
+glyphname = "lay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (177,-207);
+ref = ring_top.canadian;
+}
+);
+width = 815;
+}
+);
+note = uni18BD;
+unicode = 6333;
+},
+{
+glyphname = "soy-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (295,0);
+ref = ring_top.canadian;
+}
+);
+width = 535;
+}
+);
+note = uni18BE;
+unicode = 6334;
+},
+{
+glyphname = "say-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-9,0);
+ref = ring_top.canadian;
+}
+);
+width = 535;
+}
+);
+note = uni18BF;
+unicode = 6335;
+},
+{
+glyphname = "shoy-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (351,-207);
+ref = ring_top.canadian;
+}
+);
+width = 951;
+}
+);
+note = uni18C0;
+unicode = 6336;
+},
+{
+glyphname = "shay-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (352,-207);
+ref = ring_top.canadian;
+}
+);
+width = 951;
+}
+);
+note = uni18C1;
+unicode = 6337;
+},
+{
+glyphname = "shwoy-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (572,-207);
+ref = ring_top.canadian;
+}
+);
+width = 1172;
+}
+);
+note = uni18C2;
+unicode = 6338;
+},
+{
+glyphname = "yoy-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (331,0);
+ref = ring_top.canadian;
+}
+);
+width = 569;
+}
+);
+note = uni18C3;
+unicode = 6339;
+},
+{
+glyphname = "yay-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-10,0);
+ref = ring_top.canadian;
+}
+);
+width = 569;
+}
+);
+note = uni18C4;
+unicode = 6340;
+},
+{
+glyphname = "ray-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (182,0);
+ref = ring_top.canadian;
+}
+);
+width = 540;
+}
+);
+note = uni18C5;
+unicode = 6341;
+},
+{
+glyphname = "nwi-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ni-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni18C6;
+unicode = 6342;
+},
+{
+glyphname = "nwiOjibway-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (815,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni18C7;
+unicode = 6343;
+},
+{
+glyphname = "nwii-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (463,-207);
+ref = dot_top;
+}
+);
+width = 1036;
+}
+);
+note = uni18C8;
+unicode = 6344;
+},
+{
+glyphname = "nwiiOjibway-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (243,-207);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (815,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni18C9;
+unicode = 6345;
+},
+{
+glyphname = "nwo-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "no-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni18CA;
+unicode = 6346;
+},
+{
+glyphname = "nwoOjibway-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (815,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni18CB;
+unicode = 6347;
+},
+{
+glyphname = "nwoo-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (670,-207);
+ref = dot_top;
+}
+);
+width = 1036;
+}
+);
+note = uni18CC;
+unicode = 6348;
+},
+{
+glyphname = "nwooOjibway-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (449,-207);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (815,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1036;
+}
+);
+note = uni18CD;
+unicode = 6349;
+},
+{
+glyphname = "rwee-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "reRCree-canadian";
+}
+);
+width = 1080;
+}
+);
+note = uni18CE;
+unicode = 6350;
+},
+{
+glyphname = "rwi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ri-canadian";
+}
+);
+width = 1080;
+}
+);
+note = uni18CF;
+unicode = 6351;
+},
+{
+glyphname = "rwii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (456,-207);
+ref = dot_top;
+}
+);
+width = 1080;
+}
+);
+note = uni18D0;
+unicode = 6352;
+},
+{
+glyphname = "rwo-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ro-canadian";
+}
+);
+width = 760;
+}
+);
+note = uni18D1;
+unicode = 6353;
+},
+{
+glyphname = "rwoo-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (389,0);
+ref = dot_top;
+}
+);
+width = 760;
+}
+);
+note = uni18D2;
+unicode = 6354;
+},
+{
+glyphname = "rwa-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = "ra-canadian";
+}
+);
+width = 760;
+}
+);
+note = uni18D3;
+unicode = 6355;
+},
+{
+glyphname = "pOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,357,l),
+(233,669,l),
+(199,669,l),
+(333,357,l),
+(376,357,l),
+(376,369,l),
+(223,714,l),
+(208,714,l),
+(55,369,l),
+(55,357,l)
+);
+}
+);
+width = 431;
+}
+);
+metricLeft = "kkCarrier-canadian";
+note = uni18D4;
+unicode = 6356;
+},
+{
+glyphname = "tOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 425;
+}
+);
+metricRight = "=|";
+note = uni1422;
+unicode = 6357;
+},
+{
+glyphname = "kOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(118,357,l),
+(118,536,l),
+(105,530,l),
+(112,482,o),
+(150,449,o),
+(199,449,cs),
+(264,449,o),
+(314,500,o),
+(314,582,cs),
+(314,668,o),
+(261,720,o),
+(193,720,cs),
+(119,720,o),
+(70,668,o),
+(70,583,cs),
+(70,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(147,486,o),
+(114,522,o),
+(114,584,cs),
+(114,649,o),
+(144,682,o),
+(193,682,cs),
+(239,682,o),
+(271,646,o),
+(271,583,cs),
+(271,521,o),
+(238,486,o),
+(192,486,cs)
+);
+}
+);
+width = 374;
+}
+);
+metricLeft = "k-canadian";
+metricRight = "k-canadian";
+note = uni18D6;
+unicode = 6358;
+},
+{
+glyphname = "cOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(118,357,l),
+(118,587,ls),
+(118,651,o),
+(145,680,o),
+(193,680,cs),
+(240,680,o),
+(270,651,o),
+(270,595,cs),
+(270,569,l),
+(315,569,l),
+(315,590,ls),
+(315,673,o),
+(264,720,o),
+(193,720,cs),
+(117,720,o),
+(70,673,o),
+(70,582,cs),
+(69.995,357,l)
+);
+}
+);
+width = 364;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni18D7;
+unicode = 6359;
+},
+{
+glyphname = "mOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(118,357,l),
+(118,670,l),
+(286,670,l),
+(286,714,l),
+(69.995,714,l),
+(69.995,357,l)
+);
+}
+);
+width = 337;
+}
+);
+metricLeft = "m-canadian";
+metricRight = "m-canadian";
+note = uni18D8;
+unicode = 6360;
+},
+{
+glyphname = "nOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(253,443,o),
+(302,494,o),
+(302,576,cs),
+(302,628,o),
+(279,676,o),
+(240,690,c),
+(238,670,l),
+(433,670,l),
+(433,714,l),
+(187,714,ls),
+(109,714,o),
+(60,660,o),
+(60,577,cs),
+(60,494,o),
+(110,443,o),
+(181,443,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(135,481,o),
+(103,516,o),
+(103,577,cs),
+(103,640,o),
+(135,676,o),
+(181,676,cs),
+(228,676,o),
+(259,640,o),
+(259,578,cs),
+(259,516,o),
+(228,481,o),
+(182,481,cs)
+);
+}
+);
+width = 484;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "n-canadian";
+note = uni18D9;
+unicode = 6361;
+},
+{
+glyphname = "sOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(118,357,l),
+(118,503,l),
+(92,478,l),
+(123,478,ls),
+(230,478,o),
+(287,548,o),
+(287,655,cs),
+(287,714,l),
+(240,714,l),
+(240,658,ls),
+(240,567,o),
+(199,519,o),
+(108,519,cs),
+(70,519,l),
+(69.995,357,l)
+);
+}
+);
+width = 357;
+}
+);
+metricLeft = "s-canadian";
+metricRight = "s-canadian";
+note = uni18DA;
+unicode = 6362;
+},
+{
+color = 1;
+glyphname = "shOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(245,351,o),
+(285,398,o),
+(293,486,cs),
+(302,589,ls),
+(308,650,o),
+(329,681,o),
+(377,681,cs),
+(424,681,o),
+(454,652,o),
+(454,595,cs),
+(454,569,l),
+(498,569,l),
+(498,591,ls),
+(498,674,o),
+(448,720,o),
+(378,720,cs),
+(302,720,o),
+(263,673,o),
+(255,585,cs),
+(245,482,ls),
+(239,421,o),
+(218,390,o),
+(170,390,cs),
+(123,390,o),
+(94,419,o),
+(94,476,cs),
+(94,502,l),
+(49,502,l),
+(49,480,ls),
+(49,397,o),
+(99,351,o),
+(169,351,cs)
+);
+}
+);
+width = 547;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "c-canadian";
+note = uni18DB;
+unicode = 6363;
+},
+{
+color = 9;
+glyphname = "easternw-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (44,-318);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (114,0);
+ref = "glottalstop-canadian";
+}
+);
+width = 561;
+}
+);
+note = uni18DC;
+unicode = 6364;
+},
+{
+color = 9;
+glyphname = "westernw-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (522,-318);
+ref = dot_top;
+scale = (-1,1);
+},
+{
+alignment = -1;
+pos = (447,0);
+ref = "glottalstop-canadian";
+scale = (-1,1);
+}
+);
+width = 565;
+}
+);
+metricLeft = "glottalstop-canadian";
+note = uni18DD;
+unicode = 6365;
+},
+{
+glyphname = "rweRCree-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "reRCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (860,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1080;
+}
+);
+note = uni18E0;
+unicode = 6368;
+},
+{
+glyphname = "looWestCree-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+}
+);
+width = 540;
+}
+);
+note = uni18E1;
+unicode = 6369;
+},
+{
+glyphname = "laaWestCree-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (360,0);
+ref = dot_top;
+}
+);
+width = 540;
+}
+);
+note = uni18E2;
+unicode = 6370;
+},
+{
+glyphname = "thwe-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "the-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (722,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 942;
+}
+);
+note = uni18E3;
+unicode = 6371;
+},
+{
+glyphname = "thwa-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (675,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 895;
+}
+);
+note = uni18E4;
+unicode = 6372;
+},
+{
+glyphname = "tthwe-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "tthe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (713,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 933;
+}
+);
+note = uni18E5;
+unicode = 6373;
+},
+{
+glyphname = "tthoo-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ttho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (256,0);
+ref = dot_top;
+}
+);
+width = 627;
+}
+);
+note = uni18E6;
+unicode = 6374;
+},
+{
+glyphname = "tthaa-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ttha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (262,0);
+ref = dot_top;
+}
+);
+width = 627;
+}
+);
+note = uni18E7;
+unicode = 6375;
+},
+{
+glyphname = "tlhwe-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "tlhe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (593,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 813;
+}
+);
+note = uni18E8;
+unicode = 6376;
+},
+{
+glyphname = "tlhoo-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "tlho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (252,0);
+ref = dot_top;
+}
+);
+width = 593;
+}
+);
+note = uni18E9;
+unicode = 6377;
+},
+{
+glyphname = "shweSayisi-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "sheSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (593,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 813;
+}
+);
+note = uni18EA;
+unicode = 6378;
+},
+{
+glyphname = "shooSayisi-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "shoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (422,0);
+ref = dot_top;
+}
+);
+width = 593;
+}
+);
+note = uni18EB;
+unicode = 6379;
+},
+{
+color = 9;
+glyphname = "hooSayisi-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "hoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (482,0);
+ref = dot_top;
+}
+);
+width = 661;
+}
+);
+note = uni18EC;
+unicode = 6380;
+},
+{
+color = 9;
+glyphname = "gwuCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "guCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (865,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1085;
+}
+);
+note = uni18ED;
+unicode = 6381;
+},
+{
+color = 9;
+glyphname = "deneGeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "geCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (289,0);
+ref = dot_top;
+}
+);
+width = 701;
+}
+);
+note = uni18EE;
+unicode = 6382;
+},
+{
+color = 9;
+glyphname = "gaaCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (302,0);
+ref = dot_top;
+}
+);
+width = 701;
+}
+);
+note = uni18EF;
+unicode = 6383;
+},
+{
+color = 9;
+glyphname = "gwaCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (701,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 921;
+}
+);
+note = uni18F0;
+unicode = 6384;
+},
+{
+color = 9;
+glyphname = "juuSayisi-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "juSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (300,0);
+ref = dot_top;
+}
+);
+width = 714;
+}
+);
+note = uni18F1;
+unicode = 6385;
+},
+{
+color = 9;
+glyphname = "jwaCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "jaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (760,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 981;
+}
+);
+note = uni18F2;
+unicode = 6386;
+},
+{
+glyphname = "lBeaverDene-canadian";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+ref = "pWestCree-canadian";
+}
+);
+width = 188;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+unicode = 6387;
+},
+{
+glyphname = "rBeaverDene-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(118,357,l),
+(118,576,ls),
+(118,638,o),
+(140,672,o),
+(191,672,cs),
+(200,672,l),
+(200,720,l),
+(191,720,ls),
+(142,720,o),
+(109,681,o),
+(108,636,c),
+(114,636,l),
+(114,714,l),
+(69.995,714,l),
+(69.995,357,l)
+);
+}
+);
+width = 232;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni18F4;
+unicode = 6388;
+},
+{
+color = 6;
+glyphname = "sDentalCarrier-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(224,189,ls),
+(301,189,o),
+(339,226,o),
+(339,287,cs),
+(339,349,o),
+(302,387,o),
+(227,387,cs),
+(186,387,ls),
+(139,387,o),
+(113,405,o),
+(113,447,cs),
+(113,489,o),
+(140,507,o),
+(186,507,cs),
+(333,507,l),
+(333,546,l),
+(185,546,ls),
+(108.006,546,o),
+(70,509,o),
+(70,448,cs),
+(70,387,o),
+(107,348,o),
+(182,348,cs),
+(223,348,ls),
+(270,348,o),
+(296,330,o),
+(296,288,cs),
+(296,246,o),
+(269,228,o),
+(223,228,cs),
+(76,228,l),
+(76,189,l)
+);
+}
+);
+width = 409;
+}
+);
+metricLeft = "shCarrier-canadian";
+metricRight = "=|";
+note = uni18F5;
+unicode = 6389;
+},
+{
+glyphname = "pWestCree-canadian.base";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "pWestCree-canadian";
+}
+);
+width = 188;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.base";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "c-canadian";
+}
+);
+width = 364;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "thSayisi-canadian.base";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "thSayisi-canadian";
+}
+);
+width = 364;
+}
+);
+metricLeft = "=|c-canadian";
+note = uni14A2;
+},
+{
+glyphname = "mWestCree-canadian.base";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "mWestCree-canadian";
+}
+);
+width = 374;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+glyphname = "pWestCree-canadian.mid";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "pWestCree-canadian";
+}
+);
+width = 188;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.mid";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "c-canadian";
+}
+);
+width = 364;
+}
+);
+metricLeft = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "mWestCree-canadian.mid";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "mWestCree-canadian";
+}
+);
+width = 374;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+color = 11;
+glyphname = "ngaai-canadian.nunavik";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (650,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (823,0);
+ref = ring_top.canadian;
+}
+);
+width = 1234;
+}
+);
+note = uni158E;
+},
+{
+color = 11;
+glyphname = "ngi-canadian.nunavik";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (650,0);
+ref = "ci-canadian";
+}
+);
+width = 1234;
+}
+);
+note = uni158F;
+},
+{
+color = 11;
+glyphname = "ngii-canadian.nunavik";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (650,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (883,0);
+ref = dot_top;
+}
+);
+width = 1234;
+}
+);
+note = uni1590;
+},
+{
+color = 11;
+glyphname = "ngo-canadian.nunavik";
+lastChange = "2023-01-13 15:30:54 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (650,0);
+ref = "co-canadian";
+}
+);
+width = 1235;
+}
+);
+note = uni1591;
+},
+{
+color = 11;
+glyphname = "ngoo-canadian.nunavik";
+lastChange = "2023-01-13 15:30:54 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+ref = "ngo-canadian.nunavik";
+},
+{
+anchor = top_right_can;
+pos = (1063,0);
+ref = dot_top;
+}
+);
+width = 1235;
+}
+);
+note = uni1592;
+},
+{
+color = 11;
+glyphname = "nga-canadian.nunavik";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (650,0);
+ref = "ca-canadian";
+}
+);
+width = 1234;
+}
+);
+note = uni1593;
+},
+{
+color = 11;
+glyphname = "ngaa-canadian.nunavik";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (650,0);
+ref = "ca-canadian";
+},
+{
+anchor = top_left_can;
+pos = (694,0);
+ref = dot_top;
+}
+);
+width = 1234;
+}
+);
+note = uni1594;
+},
+{
+color = 11;
+glyphname = "ng-canadian.nunavik";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(537,158,o),
+(590,209,o),
+(590,295,cs),
+(590,378,o),
+(540,429,o),
+(475,429,cs),
+(427,429,o),
+(391,397,o),
+(383,350,c),
+(393,352,l),
+(393,494,l),
+(243,494,l),
+(245,479,l),
+(281,493,o),
+(302,538,o),
+(302,587,cs),
+(302,669,o),
+(253,720,o),
+(181,720,cs),
+(110,720,o),
+(60,669,o),
+(60,586,cs),
+(60,503,o),
+(109,449,o),
+(187,449,cs),
+(374,449,l),
+(346,478,l),
+(346,295,ls),
+(346,209,o),
+(395,158,o),
+(468,158,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(419,196,o),
+(390,229,o),
+(390,294,cs),
+(390,356,o),
+(423,391,o),
+(468,391,cs),
+(514,391,o),
+(546,356,o),
+(546,295,cs),
+(546,232,o),
+(515,196,o),
+(468,196,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(135,487,o),
+(103,524,o),
+(103,586,cs),
+(103,647,o),
+(135,683,o),
+(182,683,cs),
+(228,683,o),
+(259,647,o),
+(259,585,cs),
+(259,523,o),
+(228,487,o),
+(181,487,cs)
+);
+}
+);
+width = 650;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+color = 11;
+glyphname = "ngai-canadian.nunavik";
+lastChange = "2023-01-13 15:30:54 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (650,0);
+ref = "ce-canadian";
+}
+);
+width = 1235;
+}
+);
+note = uni1670;
+},
+{
+color = 11;
+glyphname = "ke-canadian.square";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (338,714);
+},
+{
+name = top_left_can;
+pos = (106,714);
+},
+{
+name = top_right_can;
+pos = (574,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(605,0,l),
+(605,714,l),
+(378,714,ls),
+(179,714,o),
+(69,607,o),
+(69,427,cs),
+(69,248,o),
+(179,141,o),
+(378,141,cs),
+(541,141,l),
+(541,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(217,198,o),
+(133,281,o),
+(133,427,cs),
+(133,573,o),
+(217,657,o),
+(376,657,cs),
+(541,657,l),
+(541,198,l),
+(376,198,ls)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146B;
+},
+{
+color = 11;
+glyphname = "ki-canadian.square";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (352,714);
+},
+{
+name = top_left_can;
+pos = (116,714);
+},
+{
+name = top_right_can;
+pos = (588,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(147,0,l),
+(147,141,l),
+(311,141,ls),
+(510,141,o),
+(619,248,o),
+(619,427,cs),
+(619,607,o),
+(510,714,o),
+(311,714,cs),
+(83,714,l),
+(83,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(147,657,l),
+(313,657,ls),
+(472,657,o),
+(556,573,o),
+(556,427,cs),
+(556,281,o),
+(472,198,o),
+(313,198,cs),
+(147,198,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni146D;
+},
+{
+color = 11;
+glyphname = "kii-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (287,0);
+ref = dot_top;
+}
+);
+width = 689;
+}
+);
+note = uni146E;
+},
+{
+color = 11;
+glyphname = "ko-canadian.square";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (338,714);
+},
+{
+name = top_left_can;
+pos = (106,714);
+},
+{
+name = top_right_can;
+pos = (574,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(605,0,l),
+(605,714,l),
+(541,714,l),
+(541,573,l),
+(378,573,ls),
+(179,573,o),
+(69,466,o),
+(69,287,cs),
+(69,107,o),
+(179,0,o),
+(378,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(217,57,o),
+(133,141,o),
+(133,287,cs),
+(133,433,o),
+(217,516,o),
+(376,516,cs),
+(541,516,l),
+(541,57,l),
+(376,57,ls)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146F;
+},
+{
+color = 11;
+glyphname = "koo-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (509,0);
+ref = dot_top;
+}
+);
+width = 689;
+}
+);
+note = uni1470;
+},
+{
+color = 11;
+glyphname = "ka-canadian.square";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (352,714);
+},
+{
+name = top_left_can;
+pos = (116,714);
+},
+{
+name = top_right_can;
+pos = (588,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(311,0,ls),
+(510,0,o),
+(619,107,o),
+(619,287,cs),
+(619,466,o),
+(510,573,o),
+(311,573,cs),
+(147,573,l),
+(147,714,l),
+(83,714,l),
+(83,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(147,516,l),
+(313,516,ls),
+(472,516,o),
+(556,433,o),
+(556,287,cs),
+(556,141,o),
+(472,57,o),
+(313,57,cs),
+(147,57,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1472;
+},
+{
+color = 11;
+glyphname = "kaa-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+}
+);
+width = 689;
+}
+);
+note = uni1473;
+},
+{
+color = 11;
+glyphname = "kweWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (689,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 909;
+}
+);
+note = uni1475;
+},
+{
+color = 11;
+glyphname = "kwiiWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (287,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (689,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 909;
+}
+);
+note = uni1479;
+},
+{
+color = 11;
+glyphname = "kwoWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (689,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 909;
+}
+);
+note = uni147B;
+},
+{
+color = 11;
+glyphname = "kwooWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (509,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (689,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 909;
+}
+);
+note = uni147D;
+},
+{
+color = 11;
+glyphname = "kwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (689,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 909;
+}
+);
+note = uni147F;
+},
+{
+color = 11;
+glyphname = "kwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (689,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 909;
+}
+);
+note = uni1481;
+},
+{
+color = 11;
+glyphname = "ce-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (351,714);
+},
+{
+name = top_left_can;
+pos = (102,714);
+},
+{
+name = top_right_can;
+pos = (600,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(631,0,l),
+(631,422,ls),
+(631,620,o),
+(528,727,o),
+(345,727,cs),
+(172,727,o),
+(70,623,o),
+(70,445,cs),
+(70,405,l),
+(133,405,l),
+(133,448,ls),
+(133,594,o),
+(214,668,o),
+(344,668,cs),
+(491,668,o),
+(567,585,o),
+(567,418,cs),
+(567,0,l)
+);
+}
+);
+width = 707;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni1489;
+},
+{
+color = 11;
+glyphname = "ci-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (356,714);
+},
+{
+name = top_left_can;
+pos = (108,714);
+},
+{
+name = top_right_can;
+pos = (605,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(140,0,l),
+(140,418,ls),
+(140,585,o),
+(216,668,o),
+(363,668,cs),
+(493,668,o),
+(573,594,o),
+(573,448,cs),
+(573,405,l),
+(637,405,l),
+(637,445,ls),
+(637,623,o),
+(535,727,o),
+(362,727,cs),
+(179,727,o),
+(76,620,o),
+(76,422,cs),
+(76,0,l)
+);
+}
+);
+width = 707;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+},
+{
+color = 11;
+glyphname = "cii-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (292,0);
+ref = dot_top;
+}
+);
+width = 707;
+}
+);
+note = uni148C;
+},
+{
+color = 11;
+glyphname = "co-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (351,714);
+},
+{
+name = top_left_can;
+pos = (102,714);
+},
+{
+name = top_right_can;
+pos = (600,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(528,-13,o),
+(631,94,o),
+(631,292,cs),
+(631,714,l),
+(567,714,l),
+(567,296,ls),
+(567,129,o),
+(491,46,o),
+(344,46,cs),
+(214,46,o),
+(133,120,o),
+(133,266,cs),
+(133,309,l),
+(70,309,l),
+(70,269,ls),
+(70,91,o),
+(172,-13,o),
+(345,-13,cs)
+);
+}
+);
+width = 707;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+},
+{
+color = 11;
+glyphname = "coo-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (535,0);
+ref = dot_top;
+}
+);
+width = 707;
+}
+);
+note = uni148E;
+},
+{
+color = 11;
+glyphname = "ca-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (356,714);
+},
+{
+name = top_left_can;
+pos = (108,714);
+},
+{
+name = top_right_can;
+pos = (605,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(535,-13,o),
+(637,91,o),
+(637,269,cs),
+(637,309,l),
+(573,309,l),
+(573,266,ls),
+(573,120,o),
+(493,46,o),
+(363,46,cs),
+(216,46,o),
+(140,129,o),
+(140,296,cs),
+(140,714,l),
+(76,714,l),
+(76,292,ls),
+(76,94,o),
+(179,-13,o),
+(362,-13,cs)
+);
+}
+);
+width = 707;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+},
+{
+color = 11;
+glyphname = "caa-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (44,0);
+ref = dot_top;
+}
+);
+width = 707;
+}
+);
+note = uni1491;
+},
+{
+color = 11;
+glyphname = "me-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (283,714);
+},
+{
+name = top_double;
+pos = (488,714);
+},
+{
+name = top_left_can;
+pos = (75,714);
+},
+{
+name = top_right_can;
+pos = (488,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(520,0,l),
+(520,714,l),
+(43,714,l),
+(43,656,l),
+(456,656,l),
+(456,0,l)
+);
+}
+);
+width = 603;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+},
+{
+color = 11;
+glyphname = "mi-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (322,714);
+},
+{
+name = top_left_can;
+pos = (116,714);
+},
+{
+name = top_right_can;
+pos = (528,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(147,0,l),
+(147,656,l),
+(560,656,l),
+(560,714,l),
+(83,714,l),
+(83,0,l)
+);
+}
+);
+width = 603;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+},
+{
+color = 11;
+glyphname = "mii-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (258,0);
+ref = dot_top;
+}
+);
+width = 603;
+}
+);
+note = uni14A6;
+},
+{
+color = 11;
+glyphname = "mo-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (283,714);
+},
+{
+name = top_double;
+pos = (488,714);
+},
+{
+name = top_left_can;
+pos = (75,714);
+},
+{
+name = top_right_can;
+pos = (488,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(520,0,l),
+(520,714,l),
+(456,714,l),
+(456,58,l),
+(43,58,l),
+(43,0,l)
+);
+}
+);
+width = 603;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+},
+{
+color = 11;
+glyphname = "moo-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (424,0);
+ref = dot_top;
+}
+);
+width = 603;
+}
+);
+note = uni14A8;
+},
+{
+color = 11;
+glyphname = "ma-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (322,714);
+},
+{
+name = top_left_can;
+pos = (116,714);
+},
+{
+name = top_right_can;
+pos = (528,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(560,0,l),
+(560,58,l),
+(147,58,l),
+(147,714,l),
+(83,714,l),
+(83,0,l)
+);
+}
+);
+width = 603;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+},
+{
+color = 11;
+glyphname = "maa-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+}
+);
+width = 603;
+}
+);
+note = uni14AB;
+},
+{
+color = 11;
+glyphname = "ne-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (445,714);
+},
+{
+name = top_left_can;
+pos = (244,714);
+},
+{
+name = top_right_can;
+pos = (652,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(597,-13,o),
+(683,83,o),
+(683,257,cs),
+(683,714,l),
+(64,714,l),
+(64,656,l),
+(212,656,l),
+(212,258,ls),
+(212,83,o),
+(299,-13,o),
+(448,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(335,47,o),
+(276,117,o),
+(276,253,cs),
+(276,656,l),
+(620,656,l),
+(620,253,ls),
+(620,118,o),
+(560,47,o),
+(448,47,cs)
+);
+}
+);
+width = 759;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C0;
+},
+{
+color = 11;
+glyphname = "ni-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (311,714);
+},
+{
+name = top_left_can;
+pos = (108,714);
+},
+{
+name = top_right_can;
+pos = (516,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(460,-13,o),
+(547,83,o),
+(547,258,cs),
+(547,656,l),
+(695,656,l),
+(695.004,714,l),
+(76,714,l),
+(76,257,ls),
+(76,83,o),
+(162,-13,o),
+(311,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,47,o),
+(139,118,o),
+(139,253,cs),
+(139,656,l),
+(483,656,l),
+(483,253,ls),
+(483,117,o),
+(424,47,o),
+(311,47,cs)
+);
+}
+);
+width = 759;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+},
+{
+color = 11;
+glyphname = "nii-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (247,0);
+ref = dot_top;
+}
+);
+width = 759;
+}
+);
+note = uni14C3;
+},
+{
+color = 11;
+glyphname = "no-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (448,714);
+},
+{
+name = top_double;
+pos = (458,714);
+},
+{
+name = top_left_can;
+pos = (244,714);
+},
+{
+name = top_right_can;
+pos = (649,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(683,0,l),
+(683,457,ls),
+(683,631,o),
+(597,727,o),
+(448,727,cs),
+(299,727,o),
+(212,631,o),
+(212,456,cs),
+(212,58,l),
+(64,58,l),
+(64,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(276,461,ls),
+(276,597,o),
+(335,667,o),
+(448,667,cs),
+(560,667,o),
+(620,596,o),
+(620,461,cs),
+(620,58,l),
+(276,58,l)
+);
+}
+);
+width = 759;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C4;
+},
+{
+color = 11;
+glyphname = "noo-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (384,0);
+ref = dot_top;
+}
+);
+width = 759;
+}
+);
+note = uni14C5;
+},
+{
+color = 11;
+glyphname = "na-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (311,714);
+},
+{
+name = top_double;
+pos = (321,714);
+},
+{
+name = top_left_can;
+pos = (108,714);
+},
+{
+name = top_right_can;
+pos = (516,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(695.004,0,l),
+(695,58,l),
+(547,58,l),
+(547,456,ls),
+(547,631,o),
+(460,727,o),
+(311,727,cs),
+(162,727,o),
+(76,631,o),
+(76,457,cs),
+(76,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(139,461,ls),
+(139,596,o),
+(199,667,o),
+(311,667,cs),
+(424,667,o),
+(483,597,o),
+(483,461,cs),
+(483,58,l),
+(139,58,l)
+);
+}
+);
+width = 759;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+},
+{
+color = 11;
+glyphname = "naa-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (247,0);
+ref = dot_top;
+}
+);
+width = 759;
+}
+);
+note = uni14C8;
+},
+{
+color = 11;
+glyphname = "nweWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (759,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 979;
+}
+);
+note = uni14CA;
+},
+{
+color = 11;
+glyphname = "nwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (759,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 979;
+}
+);
+note = uni14CC;
+},
+{
+color = 11;
+glyphname = "nwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (247,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (759,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 979;
+}
+);
+note = uni14CE;
+},
+{
+color = 11;
+glyphname = "se-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (112,714);
+},
+{
+name = top_right_can;
+pos = (574,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(605,0,l),
+(605,238,l),
+(408,238,ls),
+(233,238,o),
+(144,333,o),
+(144,514,cs),
+(144,714,l),
+(80,714,l),
+(80,513,ls),
+(80,300,o),
+(195,181,o),
+(410,181,cs),
+(562,181,l),
+(541,202,l),
+(541,0,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14ED;
+},
+{
+color = 11;
+glyphname = "si-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (116,714);
+},
+{
+name = top_right_can;
+pos = (577,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(147,0,l),
+(147,202,l),
+(126,181,l),
+(279,181,ls),
+(493,181,o),
+(608,300,o),
+(608,511,cs),
+(608,714,l),
+(544,714,l),
+(544,512,ls),
+(544,333,o),
+(455,238,o),
+(281,238,cs),
+(83,238,l),
+(83,0,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+},
+{
+color = 11;
+glyphname = "sii-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (513,0);
+ref = dot_top;
+}
+);
+width = 688;
+}
+);
+note = uni14F0;
+},
+{
+color = 11;
+glyphname = "so-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (573,714);
+},
+{
+name = top_left_can;
+pos = (112,714);
+},
+{
+name = top_right_can;
+pos = (573,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(144,0,l),
+(144,200,ls),
+(144,381,o),
+(233,476,o),
+(408,476,cs),
+(605,476,l),
+(605,714,l),
+(541,714,l),
+(541,512,l),
+(562,533,l),
+(410,533,ls),
+(195,533,o),
+(80,414,o),
+(80,201,cs),
+(80,0,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+},
+{
+color = 11;
+glyphname = "soo-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (509,0);
+ref = dot_top;
+}
+);
+width = 688;
+}
+);
+note = uni14F2;
+},
+{
+color = 11;
+glyphname = "sa-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (117,714);
+},
+{
+name = top_right_can;
+pos = (576,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(608,0,l),
+(608,201,ls),
+(608,414,o),
+(493,533,o),
+(279,533,cs),
+(126,533,l),
+(147,512,l),
+(147,714,l),
+(83,714,l),
+(83,476,l),
+(280,476,ls),
+(455,476,o),
+(544,381,o),
+(544,200,cs),
+(544,0,l)
+);
+}
+);
+width = 688;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+},
+{
+color = 11;
+glyphname = "saa-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (52,0);
+ref = dot_top;
+}
+);
+width = 688;
+}
+);
+note = uni14F5;
+},
+{
+color = 11;
+glyphname = "sho-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (342,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(600,0,l),
+(600,55,l),
+(298,55,ls),
+(181,55,o),
+(137,103,o),
+(137,192,cs),
+(137,282,o),
+(181,330,o),
+(298,330,cs),
+(397,330,ls),
+(547,330,o),
+(611,401,o),
+(611,523,cs),
+(611,643,o),
+(547,714,o),
+(397,714,cs),
+(85,714,l),
+(85,659,l),
+(386,659,ls),
+(503,659,o),
+(547,611,o),
+(547,523,cs),
+(547,434,o),
+(503,385,o),
+(387,385,cs),
+(288,385,ls),
+(137,385,o),
+(73,313,o),
+(73,192,cs),
+(73,71,o),
+(137,0,o),
+(288,0,cs)
+);
+}
+);
+width = 684;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+color = 11;
+glyphname = "shoo-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (278,0);
+ref = dot_top;
+}
+);
+width = 684;
+}
+);
+note = g728;
+},
+{
+color = 11;
+glyphname = "sha-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (343,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(397,0,ls),
+(543,0,o),
+(611,71,o),
+(611,191,cs),
+(611,313,o),
+(543,384,o),
+(397,384,cs),
+(298,384,ls),
+(181,384,o),
+(137,434,o),
+(137,522,cs),
+(137,611,o),
+(181,659,o),
+(298,659,cs),
+(600,659,l),
+(600,714,l),
+(287,714,ls),
+(141,714,o),
+(73,643,o),
+(73,522,cs),
+(73,401,o),
+(141,329,o),
+(287,329,cs),
+(386,329,ls),
+(503,329,o),
+(547,282,o),
+(547,191,cs),
+(547,103,o),
+(503,55,o),
+(386,55,cs),
+(84,55,l),
+(84,0,l)
+);
+}
+);
+width = 684;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+color = 11;
+glyphname = "shaa-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (279,0);
+ref = dot_top;
+}
+);
+width = 684;
+}
+);
+note = g730;
+},
+{
+color = 11;
+glyphname = "ye-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (82,714);
+},
+{
+name = top_right_can;
+pos = (604,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(636,0,l),
+(636,238,l),
+(134,238,l),
+(135,202,l),
+(648,683,l),
+(606,726,l),
+(49,206,l),
+(49,181,l),
+(572,181,l),
+(572,0,l)
+);
+}
+);
+width = 716;
+}
+);
+metricLeft = "ye-canadian";
+note = uni1526;
+},
+{
+color = 11;
+glyphname = "yi-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (113,714);
+},
+{
+name = top_right_can;
+pos = (635,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(144,0,l),
+(144,181,l),
+(667,181,l),
+(667,206,l),
+(110,726,l),
+(69,683,l),
+(581,202,l),
+(582,238,l),
+(81,238,l),
+(81,0,l)
+);
+}
+);
+width = 716;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni1528;
+},
+{
+color = 11;
+glyphname = "yii-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (48,0);
+ref = dot_top;
+}
+);
+width = 716;
+}
+);
+note = uni1529;
+},
+{
+color = 11;
+glyphname = "yo-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (604,714);
+},
+{
+name = top_left_can;
+pos = (82,714);
+},
+{
+name = top_right_can;
+pos = (604,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(648,31,l),
+(135,512,l),
+(134,476,l),
+(636,476,l),
+(636,714,l),
+(572,714,l),
+(572,533,l),
+(49,533,l),
+(49,508,l),
+(606,-12,l)
+);
+}
+);
+width = 716;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152A;
+},
+{
+color = 11;
+glyphname = "yoo-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (540,0);
+ref = dot_top;
+}
+);
+width = 716;
+}
+);
+note = uni152B;
+},
+{
+color = 11;
+glyphname = "ya-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (113,714);
+},
+{
+name = top_right_can;
+pos = (635,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(667,508,l),
+(667,533,l),
+(144,533,l),
+(144,714,l),
+(81,714,l),
+(81,476,l),
+(582,476,l),
+(581,512,l),
+(69,31,l),
+(110,-12,l)
+);
+}
+);
+width = 716;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152D;
+},
+{
+color = 11;
+glyphname = "yaa-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (49,0);
+ref = dot_top;
+}
+);
+width = 716;
+}
+);
+note = uni152E;
+},
+{
+color = 11;
+glyphname = "re-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (311,714);
+},
+{
+name = top_left_can;
+pos = (108,714);
+},
+{
+name = top_right_can;
+pos = (516,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(461,-13,o),
+(547,83,o),
+(547,258,cs),
+(547,656,l),
+(695,656,l),
+(695.004,714,l),
+(483,714,l),
+(483,253,ls),
+(483,117,o),
+(424,47,o),
+(311,47,cs),
+(199,47,o),
+(139,118,o),
+(139,253,cs),
+(139,714,l),
+(76,714,l),
+(76,257,ls),
+(76,83,o),
+(162,-13,o),
+(311,-13,cs)
+);
+}
+);
+width = 759;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1542;
+},
+{
+color = 11;
+glyphname = "reRCree-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (448,714);
+},
+{
+name = top_left_can;
+pos = (244,714);
+},
+{
+name = top_right_can;
+pos = (652,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(597,-13,o),
+(683,83,o),
+(683,257,cs),
+(683,714,l),
+(620,714,l),
+(620,253,ls),
+(620,118,o),
+(560,47,o),
+(448,47,cs),
+(335,47,o),
+(276,117,o),
+(276,253,cs),
+(276,714,l),
+(64,714,l),
+(64,656,l),
+(212,656,l),
+(212,258,ls),
+(212,83,o),
+(298,-13,o),
+(448,-13,cs)
+);
+}
+);
+width = 759;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni1543;
+},
+{
+color = 11;
+glyphname = "leWestCree-canadian.square";
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (448,714);
+},
+{
+name = top_left_can;
+pos = (244,714);
+},
+{
+name = top_right_can;
+pos = (652,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(276,0,l),
+(276,461,ls),
+(276,597,o),
+(335,667,o),
+(448,667,cs),
+(560,667,o),
+(620,596,o),
+(620,461,cs),
+(620,0,l),
+(683,0,l),
+(683,457,ls),
+(683,631,o),
+(597,727,o),
+(448,727,cs),
+(298,727,o),
+(212,631,o),
+(212,456,cs),
+(212,58,l),
+(64,58,l),
+(64,0,l)
+);
+}
+);
+width = 762;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+},
+{
+color = 11;
+glyphname = "ri-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (311,714);
+},
+{
+name = top_left_can;
+pos = (112,714);
+},
+{
+name = top_right_can;
+pos = (516,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(139,0,l),
+(139,461,ls),
+(139,596,o),
+(199,667,o),
+(311,667,cs),
+(424,667,o),
+(483,597,o),
+(483,461,cs),
+(483,0,l),
+(695.004,0,l),
+(695,58,l),
+(547,58,l),
+(547,456,ls),
+(547,631,o),
+(461,727,o),
+(311,727,cs),
+(162,727,o),
+(76,631,o),
+(76,457,cs),
+(76,0,l)
+);
+}
+);
+width = 759;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+},
+{
+color = 11;
+glyphname = "rii-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (247,0);
+ref = dot_top;
+}
+);
+width = 759;
+}
+);
+note = uni1547;
+},
+{
+color = 11;
+glyphname = "ro-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (343,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(147,0,l),
+(147,163,l),
+(123,141,l),
+(292,141,ls),
+(492,141,o),
+(601,248,o),
+(601,427,cs),
+(601,607,o),
+(492,714,o),
+(292,714,cs),
+(83,714,l),
+(83,657,l),
+(295,657,ls),
+(454,657,o),
+(537,573,o),
+(537,427,cs),
+(537,281,o),
+(454,198,o),
+(295,198,cs),
+(83,198,l),
+(83,0,l)
+);
+}
+);
+width = 670;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1548;
+},
+{
+color = 11;
+glyphname = "loWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (342,714);
+},
+{
+name = top_left_can;
+pos = (116,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(292,0,ls),
+(492,0,o),
+(601,107,o),
+(601,287,cs),
+(601,466,o),
+(492,573,o),
+(292,573,cs),
+(123,573,l),
+(147,551,l),
+(147,714,l),
+(83,714,l),
+(83,516,l),
+(295,516,ls),
+(454,516,o),
+(537,433,o),
+(537,287,cs),
+(537,141,o),
+(454,57,o),
+(295,57,cs),
+(83,57,l),
+(83,0,l)
+);
+}
+);
+width = 668;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+},
+{
+color = 11;
+glyphname = "ra-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (326,714);
+},
+{
+name = top_right_can;
+pos = (553,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(585,0,l),
+(585,198,l),
+(374,198,ls),
+(214,198,o),
+(131,281,o),
+(131,427,cs),
+(131,573,o),
+(214,657,o),
+(374,657,cs),
+(585,657,l),
+(585,714,l),
+(376,714,ls),
+(176,714,o),
+(67,607,o),
+(67,427,cs),
+(67,248,o),
+(176,141,o),
+(376,141,cs),
+(545,141,l),
+(521,163,l),
+(521,0,l)
+);
+}
+);
+width = 668;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+},
+{
+color = 11;
+glyphname = "raa-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (262,0);
+ref = dot_top;
+}
+);
+width = 668;
+}
+);
+note = uni154C;
+},
+{
+color = 11;
+glyphname = "laWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (553,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(585,0,l),
+(585,57,l),
+(374,57,ls),
+(214,57,o),
+(131,141,o),
+(131,287,cs),
+(131,433,o),
+(214,516,o),
+(374,516,cs),
+(585,516,l),
+(585,714,l),
+(521,714,l),
+(521,551,l),
+(545,573,l),
+(376,573,ls),
+(176,573,o),
+(67,466,o),
+(67,287,cs),
+(67,107,o),
+(176,0,o),
+(376,0,cs)
+);
+}
+);
+width = 668;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+},
+{
+color = 11;
+glyphname = "reWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(624,0,l),
+(860,198,l),
+(825,242,l),
+(590,45,l),
+(631,45,l),
+(631,422,ls),
+(631,620,o),
+(528,727,o),
+(345,727,cs),
+(172,727,o),
+(70,623,o),
+(70,445,cs),
+(70,405,l),
+(133,405,l),
+(133,448,ls),
+(133,594,o),
+(214,668,o),
+(344,668,cs),
+(491,668,o),
+(567,585,o),
+(567,418,cs),
+(567,0,l)
+);
+}
+);
+width = 889;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+},
+{
+color = 11;
+glyphname = "riWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(322,0,l),
+(322,418,ls),
+(322,585,o),
+(398,668,o),
+(545,668,cs),
+(675,668,o),
+(756,594,o),
+(756,448,cs),
+(756,405,l),
+(819,405,l),
+(819,445,ls),
+(819,623,o),
+(717,727,o),
+(544,727,cs),
+(361,727,o),
+(258,620,o),
+(258,422,cs),
+(258,45,l),
+(299,45,l),
+(64,242,l),
+(29,198,l),
+(265,0,l)
+);
+}
+);
+width = 889;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+},
+{
+color = 11;
+glyphname = "roWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(528,-13,o),
+(631,94,o),
+(631,292,cs),
+(631,669,l),
+(590,669,l),
+(825,472,l),
+(860,516,l),
+(624,714,l),
+(567,714,l),
+(567,296,ls),
+(567,129,o),
+(491,46,o),
+(344,46,cs),
+(214,46,o),
+(133,120,o),
+(133,266,cs),
+(133,309,l),
+(70,309,l),
+(70,269,ls),
+(70,91,o),
+(172,-13,o),
+(345,-13,cs)
+);
+}
+);
+width = 889;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+},
+{
+color = 11;
+glyphname = "raWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(717,-13,o),
+(819,91,o),
+(819,269,cs),
+(819,309,l),
+(756,309,l),
+(756,266,ls),
+(756,120,o),
+(675,46,o),
+(545,46,cs),
+(398,46,o),
+(322,129,o),
+(322,296,cs),
+(322,714,l),
+(265,714,l),
+(29,516,l),
+(64,472,l),
+(299,669,l),
+(258,669,l),
+(258,292,ls),
+(258,94,o),
+(361,-13,o),
+(544,-13,cs)
+);
+}
+);
+width = 889;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+},
+{
+color = 11;
+glyphname = "theThCree-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (82,714);
+},
+{
+name = top_right_can;
+pos = (604,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(572,73,l),
+(572,0,l),
+(636,0,l),
+(636,73,l),
+(722,73,l),
+(722,111,l),
+(636,111,l),
+(636,238,l),
+(134,238,l),
+(135,202,l),
+(648,683,l),
+(606,726,l),
+(49,206,l),
+(49,181,l),
+(572,181,l),
+(572,111,l),
+(319,111,l),
+(319,73,l)
+);
+}
+);
+width = 759;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15A7;
+},
+{
+color = 11;
+glyphname = "thiThCree-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (144,714);
+},
+{
+name = top_right_can;
+pos = (666,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(187,0,l),
+(187,73,l),
+(440,73,l),
+(440,111,l),
+(187,111,l),
+(187,181,l),
+(710,181,l),
+(710,206,l),
+(153,726,l),
+(112,683,l),
+(624,202,l),
+(625,238,l),
+(124,238,l),
+(124,111,l),
+(37,111,l),
+(37,73,l),
+(124,73,l),
+(124,0,l)
+);
+}
+);
+width = 759;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+},
+{
+color = 11;
+glyphname = "thiiThCree-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (79,0);
+ref = dot_top;
+}
+);
+width = 759;
+}
+);
+note = uni15A9;
+},
+{
+color = 11;
+glyphname = "thoThCree-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (82,714);
+},
+{
+name = top_right_can;
+pos = (604,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(648,31,l),
+(135,512,l),
+(134,476,l),
+(636,476,l),
+(636,603,l),
+(722,603,l),
+(722,641,l),
+(636,641,l),
+(636,714,l),
+(572,714,l),
+(572,641,l),
+(319,641,l),
+(319,603,l),
+(572,603,l),
+(572,533,l),
+(49,533,l),
+(49,508,l),
+(606,-12,l)
+);
+}
+);
+width = 759;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+},
+{
+color = 11;
+glyphname = "thooThCree-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (540,0);
+ref = dot_top;
+}
+);
+width = 759;
+}
+);
+note = uni15AB;
+},
+{
+color = 11;
+glyphname = "thaThCree-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (156,714);
+},
+{
+name = top_right_can;
+pos = (678,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(710,508,l),
+(710,533,l),
+(187,533,l),
+(187,603,l),
+(440,603,l),
+(440,641,l),
+(187,641,l),
+(187,714,l),
+(124,714,l),
+(124,641,l),
+(37,641,l),
+(37,603,l),
+(124,603,l),
+(124,476,l),
+(625,476,l),
+(624,512,l),
+(112,31,l),
+(153,-12,l)
+);
+}
+);
+width = 759;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+},
+{
+color = 11;
+glyphname = "thaaThCree-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (92,0);
+ref = dot_top;
+}
+);
+width = 759;
+}
+);
+note = uni15AD;
+},
+{
+color = 11;
+glyphname = "thweeWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (759,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 980;
+}
+);
+note = uni1677;
+},
+{
+color = 11;
+glyphname = "thwiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (759,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 980;
+}
+);
+note = uni1678;
+},
+{
+color = 11;
+glyphname = "thwiiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (79,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (759,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 980;
+}
+);
+note = uni1679;
+},
+{
+color = 11;
+glyphname = "thwoWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (759,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 980;
+}
+);
+note = uni167A;
+},
+{
+color = 11;
+glyphname = "thwooWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (540,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (759,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 980;
+}
+);
+note = uni167B;
+},
+{
+color = 11;
+glyphname = "thwaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (759,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 980;
+}
+);
+note = uni167C;
+},
+{
+color = 11;
+glyphname = "thwaaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (92,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (759,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 980;
+}
+);
+note = uni167D;
+},
+{
+color = 11;
+glyphname = "nwiOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (759,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 979;
+}
+);
+note = uni18C7;
+},
+{
+color = 11;
+glyphname = "nwiiOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (247,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (759,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 979;
+}
+);
+note = uni18C9;
+},
+{
+color = 11;
+glyphname = "nwoOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (759,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 979;
+}
+);
+note = uni18CB;
+},
+{
+color = 11;
+glyphname = "nwooOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (384,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (759,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 979;
+}
+);
+note = uni18CD;
+},
+{
+color = 11;
+glyphname = "looWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+}
+);
+width = 668;
+}
+);
+note = uni18E1;
+},
+{
+color = 11;
+glyphname = "laaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (489,0);
+ref = dot_top;
+}
+);
+width = 668;
+}
+);
+note = uni18E2;
+},
+{
+color = 0;
+glyphname = zero;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(524,560,o),
+(475,725,o),
+(294,725,cs),
+(111,725,o),
+(62,544,o),
+(62,359,cs),
+(62,110,o),
+(146,-10,o),
+(293,-10,cs),
+(448,-10,o),
+(524,112,o),
+(524,359,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(128,506,o),
+(153,670,o),
+(294,670,cs),
+(444,670,o),
+(458,496,o),
+(458,359,cs),
+(458,165,o),
+(415,45,o),
+(293,45,cs),
+(178,45,o),
+(128,163,o),
+(128,359,cs)
+);
+}
+);
+width = 585;
+}
+);
+unicode = 48;
+},
+{
+color = 0;
+glyphname = one;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(227,714,l),
+(20,558,l),
+(56,514,l),
+(169,599,ls),
+(191,616,o),
+(204,628,o),
+(221,643,c),
+(219,620,o),
+(219,596,o),
+(219,570,cs),
+(219,0,l),
+(285,0,l),
+(285,714,l)
+);
+}
+);
+width = 408;
+}
+);
+unicode = 49;
+},
+{
+color = 0;
+glyphname = two;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(493,0,l),
+(493,56,l),
+(126,56,l),
+(126,58,l),
+(298,238,ls),
+(369,309,o),
+(419,365,o),
+(445,429,cs),
+(458,460,o),
+(464,496,o),
+(464,537,cs),
+(464,650,o),
+(382,724,o),
+(263,724,cs),
+(188,724,o),
+(118,699,o),
+(55,644,c),
+(91,600,l),
+(146,645,o),
+(204,667,o),
+(258,667,cs),
+(346,667,o),
+(399,617,o),
+(399,530,cs),
+(399,466,o),
+(378,417,o),
+(336,363,cs),
+(314,336,o),
+(287,305,o),
+(253,270,cs),
+(41,47,l),
+(41,0,l)
+);
+}
+);
+width = 545;
+}
+);
+unicode = 50;
+},
+{
+color = 0;
+glyphname = three;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(465,662,o),
+(383,724,o),
+(259,724,cs),
+(162,724,o),
+(92,694,o),
+(33,650,c),
+(62,604,l),
+(118,644,o),
+(180,669,o),
+(252,669,cs),
+(342,669,o),
+(401,628,o),
+(401,542,cs),
+(401,442,o),
+(313,397,o),
+(210,397,cs),
+(136,397,l),
+(136,344,l),
+(210,344,ls),
+(333,344,o),
+(418,308,o),
+(418,199,cs),
+(418,105,o),
+(355,45,o),
+(223,45,cs),
+(154,45,o),
+(80,63,o),
+(26,90,c),
+(26,31,l),
+(80,7,o),
+(147,-10,o),
+(229,-10,cs),
+(390,-10,o),
+(487,71,o),
+(487,196,cs),
+(487,302,o),
+(423,358,o),
+(312,373,c),
+(312,375,l),
+(399,393,o),
+(465,459,o),
+(465,553,cs)
+);
+}
+);
+width = 539;
+}
+);
+unicode = 51;
+},
+{
+color = 0;
+glyphname = four;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(458,234,l),
+(458,717,l),
+(395,717,l),
+(40,228,l),
+(40,181,l),
+(394,181,l),
+(394,0,l),
+(458,0,l),
+(458,181,l),
+(580,181,l),
+(580,234,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(106,234,l),
+(335,547,ls),
+(363,585,o),
+(372,601,o),
+(393,636,c),
+(396,636,l),
+(396,614,o),
+(394,579,o),
+(394,541,cs),
+(394,234,l)
+);
+}
+);
+width = 605;
+}
+);
+unicode = 52;
+},
+{
+color = 0;
+glyphname = five;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(203,436,o),
+(164,425,o),
+(133,418,c),
+(155,657,l),
+(450,657,l),
+(450,714,l),
+(99,714,l),
+(69,380,l),
+(101,360,l),
+(144,374,o),
+(189,382,o),
+(244,382,cs),
+(366,382,o),
+(428,321,o),
+(428,221,cs),
+(428,109,o),
+(350,45,o),
+(229,45,cs),
+(160,45,o),
+(95,65,o),
+(48,91,c),
+(48,31,l),
+(94,7,o),
+(156,-10,o),
+(233,-10,cs),
+(398,-10,o),
+(494,80,o),
+(494,222,cs),
+(494,359,o),
+(405,436,o),
+(267,436,cs)
+);
+}
+);
+width = 540;
+}
+);
+unicode = 53;
+},
+{
+color = 0;
+glyphname = six;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(60,139,o),
+(130,-10,o),
+(300,-10,cs),
+(438,-10,o),
+(522,82,o),
+(522,229,cs),
+(522,364,o),
+(446,448,o),
+(316,448,cs),
+(220,448,o),
+(152,401,o),
+(122,339,c),
+(119,339,l),
+(125,532,o),
+(194,671,o),
+(375,671,cs),
+(417,671,o),
+(450,666,o),
+(475,658,c),
+(475,714,l),
+(448,721,o),
+(413,726,o),
+(376,726,cs),
+(142,726,o),
+(60,541,o),
+(60,303,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(167,45,o),
+(129,172,o),
+(129,256,cs),
+(129,333,o),
+(215,394,o),
+(303,394,cs),
+(408,394,o),
+(458,331,o),
+(458,229,cs),
+(458,114,o),
+(401,45,o),
+(299,45,cs)
+);
+}
+);
+width = 570;
+}
+);
+unicode = 54;
+},
+{
+color = 0;
+glyphname = seven;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(483,674,l),
+(483,714,l),
+(17,714,l),
+(17,657,l),
+(412,657,l),
+(127,0,l),
+(196,0,l)
+);
+}
+);
+width = 508;
+}
+);
+unicode = 55;
+},
+{
+color = 0;
+glyphname = eight;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(425,-10,o),
+(522,61,o),
+(522,183,cs),
+(522,284,o),
+(450,341,o),
+(343,381,c),
+(437,419,o),
+(498,471,o),
+(498,558,cs),
+(498,665,o),
+(417,724,o),
+(293,724,cs),
+(170,724,o),
+(86,660,o),
+(86,557,cs),
+(86,457,o),
+(164,411,o),
+(237,379,c),
+(133,342,o),
+(64,285,o),
+(64,178,cs),
+(64,66,o),
+(150,-10,o),
+(289,-10,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(191,42,o),
+(126,95,o),
+(126,180,cs),
+(126,277,o),
+(207,322,o),
+(290,350,c),
+(405,307,o),
+(460,260,o),
+(460,184,cs),
+(460,91,o),
+(390,42,o),
+(289,42,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(207,441,o),
+(149,481,o),
+(149,553,cs),
+(149,630,o),
+(211,672,o),
+(292,672,cs),
+(382,672,o),
+(435,632,o),
+(435,554,cs),
+(435,485,o),
+(386,447,o),
+(294,409,c)
+);
+}
+);
+width = 584;
+}
+);
+unicode = 56;
+},
+{
+color = 0;
+glyphname = nine;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(508,582,o),
+(439,724,o),
+(268,724,cs),
+(130,724,o),
+(45,633,o),
+(45,486,cs),
+(45,351,o),
+(121,266,o),
+(250,266,cs),
+(345,266,o),
+(415,312,o),
+(445,377,c),
+(448,377,l),
+(442,179,o),
+(369,43,o),
+(190,43,cs),
+(149,43,o),
+(110,49,o),
+(86,57,c),
+(86,0,l),
+(113,-7,o),
+(155,-12,o),
+(192,-12,cs),
+(428,-12,o),
+(508,178,o),
+(508,410,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(402,669,o),
+(439,541,o),
+(439,459,cs),
+(439,383,o),
+(350,320,o),
+(265,320,cs),
+(162,320,o),
+(110,385,o),
+(110,487,cs),
+(110,602,o),
+(166,669,o),
+(269,669,cs)
+);
+}
+);
+width = 568;
+}
+);
+unicode = 57;
+},
+{
+glyphname = zero.canadian;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(528,607,o),
+(442,727,o),
+(296,727,cs),
+(149,727,o),
+(64,607,o),
+(64,357,cs),
+(64,107,o),
+(149,-12,o),
+(296,-12,cs),
+(442,-12,o),
+(528,107,o),
+(528,357,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(128,571,o),
+(185,668,o),
+(296,668,cs),
+(407,668,o),
+(464,572,o),
+(464,357,cs),
+(464,142,o),
+(407,46,o),
+(296,46,cs),
+(185,46,o),
+(128,143,o),
+(128,357,cs)
+);
+}
+);
+width = 592;
+}
+);
+metricRight = "=|";
+},
+{
+glyphname = one.canadian;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(273,0,l),
+(273,714,l),
+(215,714,l),
+(29,557,l),
+(65,514,l),
+(250,669,l),
+(209,671,l),
+(209,0,l)
+);
+}
+);
+width = 356;
+}
+);
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = two.canadian;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(519,58,l),
+(160,58,l),
+(161,36,l),
+(395,286,ls),
+(492,386,o),
+(509,452,o),
+(509,527,cs),
+(509,642,o),
+(433,727,o),
+(299,727,cs),
+(150,727,o),
+(68,629,o),
+(67,470,c),
+(131,470,l),
+(131,597,o),
+(188,670,o),
+(298,670,cs),
+(397,670,o),
+(445,608,o),
+(445,526,cs),
+(445,462,o),
+(430,405,o),
+(343,314,cs),
+(88,45,l),
+(88,0,l),
+(519,0,l)
+);
+}
+);
+width = 581;
+}
+);
+note = uni14BF;
+},
+{
+glyphname = three.canadian;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(447,-13,o),
+(530,60,o),
+(530,190,cs),
+(530,285,o),
+(478,355,o),
+(384,370,c),
+(384,347,l),
+(471,361,o),
+(521,430,o),
+(521,524,cs),
+(521,653,o),
+(441,727,o),
+(312,727,cs),
+(168,727,o),
+(81,635,o),
+(79,487,c),
+(143,487,l),
+(143,603,o),
+(203,670,o),
+(311,670,cs),
+(405,670,o),
+(457,620,o),
+(457,522,cs),
+(457,431,o),
+(412,385,o),
+(325,385,cs),
+(287,385,l),
+(287,330,l),
+(329,330,ls),
+(419,330,o),
+(466,283,o),
+(466,191,cs),
+(466,92,o),
+(411,44,o),
+(308,44,cs),
+(194,44,o),
+(136,108,o),
+(135,227,c),
+(72,227,l),
+(73,74,o),
+(157,-13,o),
+(308,-13,cs)
+);
+}
+);
+width = 609;
+}
+);
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = four.canadian;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(444,0,l),
+(444,181,l),
+(554,181,l),
+(554,236,l),
+(444,236,l),
+(444,717,l),
+(391,717,l),
+(47,223,l),
+(47,181,l),
+(382,181,l),
+(382,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(406,655,l),
+(382,655,l),
+(382,236,l),
+(103,236,l),
+(105,220,l)
+);
+}
+);
+width = 589;
+}
+);
+},
+{
+glyphname = five.canadian;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(456,-13,o),
+(538,69,o),
+(538,202,cs),
+(538,339,o),
+(456,411,o),
+(308,411,cs),
+(159,411,l),
+(179,390,l),
+(204,678,l),
+(183,657,l),
+(515,657,l),
+(515,714,l),
+(145,714,l),
+(117,369,l),
+(131,354,l),
+(299,354,ls),
+(419,354,o),
+(475,306,o),
+(475,200,cs),
+(475,99,o),
+(419,44,o),
+(315,44,cs),
+(196,44,o),
+(145,102,o),
+(145,199,c),
+(81,199,l),
+(83,68,o),
+(160,-13,o),
+(315,-13,cs)
+);
+}
+);
+width = 605;
+}
+);
+},
+{
+glyphname = six.canadian;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(443,-13,o),
+(531,76,o),
+(531,208,cs),
+(531,342,o),
+(447,427,o),
+(318,427,cs),
+(216,427,o),
+(134,370,o),
+(116,260,c),
+(132,245,l),
+(128,295,o),
+(127,322,o),
+(127,370,cs),
+(127,574,o),
+(184,670,o),
+(309,670,cs),
+(410,670,o),
+(455,605,o),
+(462,520,c),
+(525,520,l),
+(515,639,o),
+(446,727,o),
+(311,727,cs),
+(151,727,o),
+(64,608,o),
+(64,359,cs),
+(64,200,o),
+(87,113,o),
+(138,56,cs),
+(183,6,o),
+(240,-13,o),
+(311,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(203,43,o),
+(143,108,o),
+(143,211,cs),
+(143,308,o),
+(212,372,o),
+(311,372,cs),
+(413,372,o),
+(469,309,o),
+(469,207,cs),
+(469,107,o),
+(407,43,o),
+(309,43,cs)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = zero.canadian;
+},
+{
+glyphname = seven.canadian;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(447,674,l),
+(447,714,l),
+(29,714,l),
+(29,656,l),
+(386,656,l),
+(385,680,l),
+(132,20,l),
+(132,0,l),
+(194,0,l)
+);
+}
+);
+width = 482;
+}
+);
+},
+{
+glyphname = eight.canadian;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(453,-13,o),
+(543,63,o),
+(543,185,cs),
+(543,288,o),
+(474,354,o),
+(388,367,c),
+(383,349,l),
+(461,360,o),
+(527,425,o),
+(527,529,cs),
+(527,651,o),
+(444,727,o),
+(311,727,cs),
+(179,727,o),
+(95,651,o),
+(95,529,cs),
+(95,425,o),
+(161,360,o),
+(240,349,c),
+(235,367,l),
+(149,354,o),
+(79,288,o),
+(79,185,cs),
+(79,63,o),
+(169,-13,o),
+(311,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(206,42,o),
+(143,91,o),
+(143,187,cs),
+(143,283,o),
+(207,331,o),
+(311,331,cs),
+(416,331,o),
+(479,283,o),
+(479,187,cs),
+(479,91,o),
+(416,42,o),
+(311,42,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(216,384,o),
+(159,431,o),
+(159,527,cs),
+(159,622,o),
+(214,672,o),
+(311,672,cs),
+(409,672,o),
+(464,622,o),
+(464,527,cs),
+(464,431,o),
+(406,384,o),
+(311,384,cs)
+);
+}
+);
+width = 622;
+}
+);
+metricLeft = "=|";
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = nine.canadian;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(435,-13,o),
+(522,106,o),
+(522,355,cs),
+(522,514,o),
+(499,601,o),
+(448,658,cs),
+(403,708,o),
+(346,727,o),
+(275,727,cs),
+(144,727,o),
+(55,638,o),
+(55,506,cs),
+(55,372,o),
+(140,287,o),
+(268,287,cs),
+(371,287,o),
+(452,344,o),
+(470,454,c),
+(454,469,l),
+(458,419,o),
+(459,392,o),
+(459,344,cs),
+(459,140,o),
+(402,45,o),
+(277,45,cs),
+(177,45,o),
+(132,109,o),
+(125,194,c),
+(61,194,l),
+(71,75,o),
+(140,-13,o),
+(275,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(173,342,o),
+(118,405,o),
+(118,507,cs),
+(118,607,o),
+(179,671,o),
+(277,671,cs),
+(383,671,o),
+(444,606,o),
+(444,503,cs),
+(444,406,o),
+(374,342,o),
+(276,342,cs)
+);
+}
+);
+width = 586;
+}
+);
+metricLeft = "=|six.canadian";
+metricRight = "=|six.canadian";
+},
+{
+glyphname = CR;
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+width = 261;
+}
+);
+note = CR;
+unicode = 13;
+},
+{
+color = 0;
+glyphname = .notdef;
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(505,714,l),
+(94,714,l),
+(94,0,l),
+(505,0,l),
+(505,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(454,663,l),
+(454,51,l),
+(145,51,l),
+(145,663,l),
+(145,663,l)
+);
+}
+);
+width = 600;
+}
+);
+note = ".notdef";
+},
+{
+glyphname = .null;
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+width = 0;
+}
+);
+note = NULL;
+},
+{
+glyphname = space;
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+width = 263;
+}
+);
+note = space;
+unicode = 32;
+},
+{
+glyphname = nbspace;
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+width = 261;
+}
+);
+note = uni00A0;
+unicode = 160;
+},
+{
+glyphname = space.canadian;
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+width = 504;
+}
+);
+note = space;
+},
+{
+glyphname = "hyphen-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(390,416,l),
+(390,457,l),
+(70,457,l),
+(70,416,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(390,278,l),
+(390,319,l),
+(70,319,l),
+(70,278,l)
+);
+}
+);
+width = 460;
+}
+);
+metricRight = "=|";
+note = uni1400;
+unicode = 5120;
+},
+{
+glyphname = "chi-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(116,0,l),
+(288,327,l),
+(261,327,l),
+(433,0,l),
+(490,0,l),
+(490,20,l),
+(295,386,l),
+(295,336,l),
+(487,694,l),
+(487,714,l),
+(429,714,l),
+(261,395,l),
+(288,395,l),
+(120,714,l),
+(62,714,l),
+(62,694,l),
+(253,337,l),
+(253,387,l),
+(58,20,l),
+(58,0,l)
+);
+}
+);
+width = 548;
+}
+);
+metricRight = "=|";
+note = uni166D;
+unicode = 5741;
+},
+{
+glyphname = "fullstop-canadian";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(288,0,l),
+(288,10,l),
+(192,189,l),
+(193,171,l),
+(286,346,l),
+(286,357,l),
+(245,357,l),
+(164,200,l),
+(183,202,l),
+(102,357,l),
+(61,357,l),
+(61,346,l),
+(154,174,l),
+(154,191,l),
+(59,10,l),
+(59,0,l),
+(100,0,l),
+(184,163,l),
+(163,161,l),
+(247,0,l)
+);
+}
+);
+width = 347;
+}
+);
+note = uni1541;
+unicode = 5742;
+},
+{
+glyphname = period;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(74,8,o),
+(89,-9,o),
+(118,-9,cs),
+(149,-9,o),
+(162,8,o),
+(162,37,cs),
+(162,65,o),
+(149,82,o),
+(118,82,cs),
+(89,82,o),
+(74,65,o),
+(74,37,cs)
+);
+}
+);
+width = 229;
+}
+);
+note = period;
+unicode = 46;
+},
+{
+glyphname = comma;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(80,-131,l),
+(110,-60,o),
+(134,36,o),
+(150,111,c),
+(146,123,l),
+(86,123,l),
+(76,46,o),
+(59,-34,o),
+(32,-131,c)
+);
+}
+);
+width = 204;
+}
+);
+note = comma;
+unicode = 44;
+},
+{
+glyphname = hyphen;
+kernLeft = hyphen;
+kernRight = hyphen;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(262,298,l),
+(38,298,l),
+(38,243,l),
+(262,243,l)
+);
+}
+);
+width = 300;
+}
+);
+unicode = 45;
+},
+{
+glyphname = quotesinglbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (34,-591);
+ref = quoteright;
+}
+);
+width = 243;
+}
+);
+unicode = 8218;
+},
+{
+glyphname = quotedblbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+pos = (34,-591);
+ref = quotedblright;
+}
+);
+width = 415;
+}
+);
+unicode = 8222;
+},
+{
+glyphname = quotedblleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(256,459,l),
+(264,532,o),
+(285,630,o),
+(316,714,c),
+(272,714,l),
+(239,643,o),
+(211,555,o),
+(196,469,c),
+(203,459,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(93,459,l),
+(101,532,o),
+(122,630,o),
+(152,714,c),
+(109,714,l),
+(76,643,o),
+(48,554,o),
+(33,469,c),
+(39,459,l)
+);
+}
+);
+width = 346;
+}
+);
+unicode = 8220;
+},
+{
+glyphname = quotedblright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(238,459,l),
+(271,531,o),
+(299,623,o),
+(313,704,c),
+(307,714,l),
+(253,714,l),
+(247,639,o),
+(227,544,o),
+(194,459,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(74,459,l),
+(108,531,o),
+(136,623,o),
+(150,704,c),
+(143,714,l),
+(90,714,l),
+(84,642,o),
+(62,541,o),
+(31,459,c)
+);
+}
+);
+width = 346;
+}
+);
+unicode = 8221;
+},
+{
+glyphname = quoteleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(94,459,l),
+(102,532,o),
+(123,630,o),
+(153,714,c),
+(109,714,l),
+(76,643,o),
+(48,554,o),
+(33,469,c),
+(39,459,l)
+);
+}
+);
+width = 184;
+}
+);
+unicode = 8216;
+},
+{
+glyphname = quoteright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(75,459,l),
+(108,531,o),
+(137,624,o),
+(151,704,c),
+(144,714,l),
+(90,714,l),
+(84,642,o),
+(62,541,o),
+(31,459,c)
+);
+}
+);
+width = 184;
+}
+);
+unicode = 8217;
+},
+{
+glyphname = dottedCircle;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,522,o),
+(187,511,o),
+(187,496,cs),
+(187,483,o),
+(200,470,o),
+(213,470,cs),
+(228,470,o),
+(239,483,o),
+(239,496,cs),
+(239,511,o),
+(228,522,o),
+(213,522,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(368,522,o),
+(355,511,o),
+(355,496,cs),
+(355,483,o),
+(368,470,o),
+(381,470,cs),
+(396,470,o),
+(407,483,o),
+(407,496,cs),
+(407,511,o),
+(396,522,o),
+(381,522,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,112,o),
+(187,101,o),
+(187,86,cs),
+(187,73,o),
+(200,60,o),
+(213,60,cs),
+(228,60,o),
+(239,73,o),
+(239,86,cs),
+(239,101,o),
+(228,112,o),
+(213,112,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(368,112,o),
+(355,101,o),
+(355,86,cs),
+(355,73,o),
+(368,60,o),
+(381,60,cs),
+(396,60,o),
+(407,73,o),
+(407,86,cs),
+(407,101,o),
+(396,112,o),
+(381,112,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(284,540,o),
+(271,529,o),
+(271,514,cs),
+(271,501,o),
+(284,488,o),
+(297,488,cs),
+(312,488,o),
+(323,501,o),
+(323,514,cs),
+(323,529,o),
+(312,540,o),
+(297,540,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(284,94,o),
+(271,83,o),
+(271,68,cs),
+(271,55,o),
+(284,42,o),
+(297,42,cs),
+(312,42,o),
+(323,55,o),
+(323,68,cs),
+(323,83,o),
+(312,94,o),
+(297,94,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(48,278,o),
+(61,265,o),
+(74,265,cs),
+(89,265,o),
+(100,278,o),
+(100,291,cs),
+(100,306,o),
+(89,317,o),
+(74,317,cs),
+(61,317,o),
+(48,306,o),
+(48,291,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(494,278,o),
+(507,265,o),
+(520,265,cs),
+(535,265,o),
+(546,278,o),
+(546,291,cs),
+(546,306,o),
+(535,317,o),
+(520,317,cs),
+(507,317,o),
+(494,306,o),
+(494,291,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(113,120,o),
+(126,107,o),
+(139,107,cs),
+(154,107,o),
+(165,120,o),
+(165,133,cs),
+(165,148,o),
+(154,159,o),
+(139,159,cs),
+(126,159,o),
+(113,148,o),
+(113,133,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(113,436,o),
+(126,423,o),
+(139,423,cs),
+(154,423,o),
+(165,436,o),
+(165,449,cs),
+(165,464,o),
+(154,475,o),
+(139,475,cs),
+(126,475,o),
+(113,464,o),
+(113,449,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(429,120,o),
+(442,107,o),
+(455,107,cs),
+(470,107,o),
+(481,120,o),
+(481,133,cs),
+(481,148,o),
+(470,159,o),
+(455,159,cs),
+(442,159,o),
+(429,148,o),
+(429,133,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(429,436,o),
+(442,423,o),
+(455,423,cs),
+(470,423,o),
+(481,436,o),
+(481,449,cs),
+(481,464,o),
+(470,475,o),
+(455,475,cs),
+(442,475,o),
+(429,464,o),
+(429,449,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(66,194,o),
+(79,181,o),
+(92,181,cs),
+(107,181,o),
+(118,194,o),
+(118,207,cs),
+(118,222,o),
+(107,233,o),
+(92,233,cs),
+(79,233,o),
+(66,222,o),
+(66,207,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(66,362,o),
+(79,349,o),
+(92,349,cs),
+(107,349,o),
+(118,362,o),
+(118,375,cs),
+(118,390,o),
+(107,401,o),
+(92,401,cs),
+(79,401,o),
+(66,390,o),
+(66,375,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(476,194,o),
+(489,181,o),
+(502,181,cs),
+(517,181,o),
+(528,194,o),
+(528,207,cs),
+(528,222,o),
+(517,233,o),
+(502,233,cs),
+(489,233,o),
+(476,222,o),
+(476,207,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(476,362,o),
+(489,349,o),
+(502,349,cs),
+(517,349,o),
+(528,362,o),
+(528,375,cs),
+(528,390,o),
+(517,401,o),
+(502,401,cs),
+(489,401,o),
+(476,390,o),
+(476,375,cs)
+);
+}
+);
+width = 594;
+}
+);
+note = uni25CC;
+unicode = 9676;
+},
+{
+glyphname = dotaccentcomb;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(49,734,o),
+(35,718,o),
+(35,690,cs),
+(35,663,o),
+(49,647,o),
+(76,647,cs),
+(104,647,o),
+(118,662,o),
+(118,690,cs),
+(118,718,o),
+(104,734,o),
+(76,734,cs)
+);
+}
+);
+width = 153;
+}
+);
+note = uni0307;
+unicode = 775;
+},
+{
+glyphname = dotaccent;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(105,647,o),
+(119,662,o),
+(119,690,cs),
+(119,718,o),
+(105,734,o),
+(77,734,cs),
+(50,734,o),
+(36,718,o),
+(36,690,cs),
+(36,662,o),
+(50,647,o),
+(77,647,cs)
+);
+}
+);
+width = 155;
+}
+);
+note = dotaccent;
+unicode = 729;
+},
+{
+glyphname = caron;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(222,645,o),
+(262,701,o),
+(307,756,c),
+(307,764,l),
+(263,764,l),
+(231,731,o),
+(199,691,o),
+(170,651,c),
+(143,689,o),
+(112,731,o),
+(80,764,c),
+(36,764,l),
+(36,756,l),
+(75,710,o),
+(113,658,o),
+(140,606,c),
+(201,606,l),
+(201,606,l)
+);
+}
+);
+width = 343;
+}
+);
+note = caron;
+unicode = 711;
+},
+{
+glyphname = breve;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(238,606,o),
+(283,651,o),
+(291,734,c),
+(248,734,l),
+(242,680,o),
+(215,651,o),
+(162,651,cs),
+(109,651,o),
+(84,680,o),
+(77,734,c),
+(36,734,l),
+(41,650,o),
+(86,606,o),
+(162,606,cs)
+);
+}
+);
+width = 326;
+}
+);
+note = breve;
+unicode = 728;
+},
+{
+glyphname = ring;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(186,609,o),
+(230,652,o),
+(230,715,cs),
+(230,774,o),
+(186,820,o),
+(133,820,cs),
+(78,820,o),
+(36,776,o),
+(36,715,cs),
+(36,651,o),
+(79,609,o),
+(133,609,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(97,647,o),
+(73,677,o),
+(73,715,cs),
+(73,753,o),
+(99,783,o),
+(133,783,cs),
+(165,783,o),
+(192,753,o),
+(192,715,cs),
+(192,677,o),
+(168,647,o),
+(133,647,cs)
+);
+}
+);
+width = 265;
+}
+);
+note = ring;
+unicode = 730;
+},
+{
+glyphname = ogonek;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(143,-222,o),
+(162,-218,o),
+(175,-213,c),
+(175,-170,l),
+(165,-174,o),
+(146,-178,o),
+(130,-178,cs),
+(99,-178,o),
+(83,-159,o),
+(83,-123,cs),
+(83,-77,o),
+(118,-37,o),
+(158,0,c),
+(128,14,l),
+(64,-38,o),
+(36,-85,o),
+(36,-133,cs),
+(36,-191,o),
+(74,-222,o),
+(122,-222,cs)
+);
+}
+);
+width = 211;
+}
+);
+note = ogonek;
+unicode = 731;
+},
+{
+glyphname = ring_top.canadian;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (124,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(179,784,o),
+(224,824,o),
+(224,883,cs),
+(224,941,o),
+(179,981,o),
+(124,981,cs),
+(69,981,o),
+(24,941,o),
+(24,883,cs),
+(24,824,o),
+(69,784,o),
+(124,784,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(85,818,o),
+(61,845,o),
+(61,883,cs),
+(61,920,o),
+(86,947,o),
+(124,947,cs),
+(162,947,o),
+(188,920,o),
+(188,883,cs),
+(188,845,o),
+(163,818,o),
+(124,818,cs)
+);
+}
+);
+width = 248;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (64,357);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(89,313,o),
+(109,332,o),
+(109,357,cs),
+(109,382,o),
+(89,401,o),
+(64,401,cs),
+(39,401,o),
+(20,382,o),
+(20,357,cs),
+(20,332,o),
+(39,313,o),
+(64,313,cs)
+);
+}
+);
+width = 128;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (60,357);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(82,317,o),
+(99,334,o),
+(99,357,cs),
+(99,380,o),
+(82,397,o),
+(60,397,cs),
+(37,397,o),
+(20,380,o),
+(20,357,cs),
+(20,334,o),
+(37,317,o),
+(60,317,cs)
+);
+}
+);
+width = 119;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_small;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (55,357);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(75,322,o),
+(90,337,o),
+(90,357,cs),
+(90,377,o),
+(75,392,o),
+(55,392,cs),
+(35,392,o),
+(20,377,o),
+(20,357,cs),
+(20,337,o),
+(35,322,o),
+(55,322,cs)
+);
+}
+);
+width = 110;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_top;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (64,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(89,816,o),
+(109,835,o),
+(109,860,cs),
+(109,885,o),
+(89,905,o),
+(64,905,cs),
+(39,905,o),
+(20,885,o),
+(20,860,cs),
+(20,835,o),
+(39,816,o),
+(64,816,cs)
+);
+}
+);
+width = 128;
+}
+);
+note = g725;
+},
+{
+glyphname = doubledot_middle;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(136,402,o),
+(155,421,o),
+(155,447,cs),
+(155,472,o),
+(136,491,o),
+(111,491,cs),
+(85,491,o),
+(66,472,o),
+(66,447,cs),
+(66,421,o),
+(85,402,o),
+(111,402,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(136,223,o),
+(155,242,o),
+(155,267,cs),
+(155,293,o),
+(136,312,o),
+(111,312,cs),
+(85,312,o),
+(66,293,o),
+(66,267,cs),
+(66,242,o),
+(85,223,o),
+(111,223,cs)
+);
+}
+);
+width = 221;
+}
+);
+metricRight = "=|";
+note = g725;
+},
+{
+glyphname = doubledot_top;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top_double;
+pos = (226,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(251,816,o),
+(271,835,o),
+(271,860,cs),
+(271,885,o),
+(251,905,o),
+(226,905,cs),
+(201,905,o),
+(182,885,o),
+(182,860,cs),
+(182,835,o),
+(201,816,o),
+(226,816,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(86,816,o),
+(106,835,o),
+(106,860,cs),
+(106,885,o),
+(86,905,o),
+(61,905,cs),
+(36,905,o),
+(17,885,o),
+(17,860,cs),
+(17,835,o),
+(36,816,o),
+(61,816,cs)
+);
+}
+);
+width = 287;
+}
+);
+note = g725;
+},
+{
+glyphname = g727;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (342,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(600,0,l),
+(600,55,l),
+(298,55,ls),
+(181,55,o),
+(137,103,o),
+(137,192,cs),
+(137,282,o),
+(181,330,o),
+(298,330,cs),
+(397,330,ls),
+(543,330,o),
+(611,401,o),
+(611,523,cs),
+(611,643,o),
+(543,714,o),
+(397,714,cs),
+(85,714,l),
+(85,659,l),
+(386,659,ls),
+(503,659,o),
+(547,611,o),
+(547,523,cs),
+(547,434,o),
+(503,385,o),
+(387,385,cs),
+(288,385,ls),
+(141,385,o),
+(73,313,o),
+(73,192,cs),
+(73,71,o),
+(141,0,o),
+(288,0,cs)
+);
+}
+);
+width = 684;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+glyphname = g728;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (278,0);
+ref = dot_top;
+}
+);
+width = 684;
+}
+);
+note = g728;
+},
+{
+glyphname = g729;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (343,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(397,0,ls),
+(543,0,o),
+(611,71,o),
+(611,191,cs),
+(611,313,o),
+(543,384,o),
+(397,384,cs),
+(298,384,ls),
+(181,384,o),
+(137,434,o),
+(137,522,cs),
+(137,611,o),
+(181,659,o),
+(298,659,cs),
+(600,659,l),
+(600,714,l),
+(287,714,ls),
+(141,714,o),
+(73,643,o),
+(73,522,cs),
+(73,401,o),
+(141,329,o),
+(287,329,cs),
+(386,329,ls),
+(503,329,o),
+(547,282,o),
+(547,191,cs),
+(547,103,o),
+(503,55,o),
+(386,55,cs),
+(84,55,l),
+(84,0,l)
+);
+}
+);
+width = 684;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+glyphname = g730;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (279,0);
+ref = dot_top;
+}
+);
+width = 684;
+}
+);
+note = g730;
+},
+{
+glyphname = g731;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = g727;
+}
+);
+width = 904;
+}
+);
+note = g731;
+},
+{
+glyphname = g732;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (684,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 904;
+}
+);
+note = g732;
+},
+{
+glyphname = g733;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (498,0);
+ref = dot_top;
+}
+);
+width = 904;
+}
+);
+note = g733;
+},
+{
+glyphname = g734;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (278,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (684,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 904;
+}
+);
+note = g734;
+},
+{
+glyphname = g735;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = g729;
+}
+);
+width = 904;
+}
+);
+note = g735;
+},
+{
+glyphname = g736;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (684,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 904;
+}
+);
+note = g736;
+},
+{
+glyphname = g737;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (499,0);
+ref = dot_top;
+}
+);
+width = 904;
+}
+);
+note = g737;
+},
+{
+glyphname = g738;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (279,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (684,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 904;
+}
+);
+note = g738;
+},
+{
+glyphname = g739;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(535,223,o),
+(585,277,o),
+(585,357,cs),
+(585,438,o),
+(536,494,o),
+(459,494,cs),
+(238,494,l),
+(240,473,l),
+(277,486,o),
+(302,535,o),
+(302,587,cs),
+(302,667,o),
+(253,720,o),
+(181,720,cs),
+(110,720,o),
+(60,666,o),
+(60,586,cs),
+(60,505,o),
+(109,449,o),
+(186,449,cs),
+(407,449,l),
+(405,470,l),
+(368,456,o),
+(343,408,o),
+(343,356,cs),
+(343,276,o),
+(392,223,o),
+(464,223,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(135,487,o),
+(103,526,o),
+(103,586,cs),
+(103,645,o),
+(135,682,o),
+(182,682,cs),
+(227,682,o),
+(260,644,o),
+(260,585,cs),
+(260,526,o),
+(228,487,o),
+(181,487,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(418,260,o),
+(386,298,o),
+(386,358,cs),
+(386,417,o),
+(417,456,o),
+(464,456,cs),
+(511,456,o),
+(543,417,o),
+(543,357,cs),
+(543,298,o),
+(510,260,o),
+(463,260,cs)
+);
+}
+);
+width = 645;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+glyphname = g740;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (218,0);
+ref = ring_top.canadian;
+}
+);
+width = 684;
+}
+);
+note = g740;
+},
+{
+glyphname = g741;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (219,0);
+ref = ring_top.canadian;
+}
+);
+width = 684;
+}
+);
+note = g741;
+},
+{
+glyphname = g742;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (220,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (438,0);
+ref = ring_top.canadian;
+}
+);
+width = 904;
+}
+);
+note = g742;
+},
+{
+glyphname = stroke_middle;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (41,357);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(62,470,l),
+(19,470,l),
+(19,244,l),
+(62,244,l)
+);
+}
+);
+width = 82;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (37,357);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(55,456,l),
+(19,456,l),
+(19,258,l),
+(55,258,l)
+);
+}
+);
+width = 75;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_small;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (35,357);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(51,454,l),
+(19,454,l),
+(19,260,l),
+(51,260,l)
+);
+}
+);
+width = 70;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_threequart;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (41,357);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(62,469,l),
+(20,469,l),
+(20,245,l),
+(62,245,l)
+);
+}
+);
+width = 82;
+}
+);
+note = g723;
+},
+{
+color = 8;
+glyphname = uni11AB0;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (153,714);
+},
+{
+name = top_right_can;
+pos = (461,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(185,0,l),
+(185,121,l),
+(438,121,l),
+(438,163,l),
+(185,163,l),
+(185,293,l),
+(139,267,l),
+(168,267,ls),
+(370,267,o),
+(493,401,o),
+(493,623,cs),
+(493,714,l),
+(429,714,l),
+(429,630,ls),
+(429,431,o),
+(332,325,o),
+(156,325,cs),
+(121,325,l),
+(121,163,l),
+(37,163,l),
+(37,121,l),
+(121,121,l),
+(121,0,l)
+);
+}
+);
+width = 573;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB1;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB0;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (397,0);
+ref = dot_top;
+}
+);
+width = 573;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB2;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (112,714);
+},
+{
+name = top_right_can;
+pos = (420,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(144,0,l),
+(144,84,ls),
+(144,283,o),
+(241,389,o),
+(417,389,cs),
+(452,389,l),
+(452,551,l),
+(536,551,l),
+(536,593,l),
+(452,593,l),
+(452,714,l),
+(388,714,l),
+(388,593,l),
+(136,593,l),
+(136,551,l),
+(388,551,l),
+(388,421,l),
+(433,447,l),
+(405,447,ls),
+(203,447,o),
+(80,313,o),
+(80,91,cs),
+(80,0,l)
+);
+}
+);
+width = 573;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "theThCree-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB3;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB2;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (356,0);
+ref = dot_top;
+}
+);
+width = 573;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB4;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (153,714);
+},
+{
+name = top_right_can;
+pos = (461,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(493,0,l),
+(493,91,ls),
+(493,313,o),
+(370,447,o),
+(168,447,cs),
+(139,447,l),
+(185,421,l),
+(185,551,l),
+(438,551,l),
+(438,593,l),
+(185,593,l),
+(185,714,l),
+(121,714,l),
+(121,593,l),
+(37,593,l),
+(37,551,l),
+(121,551,l),
+(121,389,l),
+(156,389,ls),
+(332,389,o),
+(429,283,o),
+(429,84,cs),
+(429,0,l)
+);
+}
+);
+width = 573;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB5;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB4;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (89,0);
+ref = dot_top;
+}
+);
+width = 573;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB6;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (115,714);
+},
+{
+name = top_right_can;
+pos = (423,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(147,0,l),
+(147,293,l),
+(102,267,l),
+(131,267,ls),
+(332,267,o),
+(455,401,o),
+(455,623,cs),
+(455,686,l),
+(414,671,l),
+(650,472,l),
+(685,516,l),
+(449,714,l),
+(391,714,l),
+(391,630,ls),
+(391,431,o),
+(294,325,o),
+(119,325,cs),
+(83,325,l),
+(83,0,l)
+);
+}
+);
+width = 714;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB7;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB6;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (359,0);
+ref = dot_top;
+}
+);
+width = 714;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB8;
+kernRight = soright;
+lastChange = "2023-01-13 15:30:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (290,714);
+},
+{
+name = top_right_can;
+pos = (598,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(322,0,l),
+(322,84,ls),
+(322,283,o),
+(420,389,o),
+(595,389,cs),
+(630,389,l),
+(630,714,l),
+(566,714,l),
+(566,421,l),
+(612,447,l),
+(583,447,ls),
+(381,447,o),
+(259,313,o),
+(259,91,cs),
+(259,28,l),
+(300,43,l),
+(64,242,l),
+(29,198,l),
+(265,0,l)
+);
+}
+);
+width = 713;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB9;
+kernRight = soright;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB8;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (534,0);
+ref = dot_top;
+}
+);
+width = 714;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABA;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (115,714);
+},
+{
+name = top_right_can;
+pos = (423,714);
+}
+);
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(449,0,l),
+(685,198,l),
+(650,242,l),
+(414,43,l),
+(455,28,l),
+(455,91,ls),
+(455,313,o),
+(332,447,o),
+(131,447,cs),
+(102,447,l),
+(147,421,l),
+(147,714,l),
+(83,714,l),
+(83,389,l),
+(119,389,ls),
+(294,389,o),
+(391,283,o),
+(391,84,cs),
+(391,0,l)
+);
+}
+);
+width = 714;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABB;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+alignment = -1;
+ref = uni11ABA;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+}
+);
+width = 714;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABC;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(511,0,l),
+(511,58,l),
+(112,58,l),
+(112,30,l),
+(520,668,l),
+(520,714,l),
+(56,714,l),
+(56,656,l),
+(455,656,l),
+(455,684,l),
+(47,46,l),
+(47,0,l)
+);
+}
+);
+width = 567;
+}
+);
+metricRight = "=|";
+},
+{
+color = 8;
+glyphname = uni11ABD;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(520,0,l),
+(520,46,l),
+(113,684,l),
+(113,656,l),
+(511,656,l),
+(511,714,l),
+(47,714,l),
+(47,668,l),
+(454,30,l),
+(454,58,l),
+(56,58,l),
+(56,0,l)
+);
+}
+);
+width = 567;
+}
+);
+metricLeft = "=|uni11ABC";
+metricRight = "=|uni11ABC";
+},
+{
+color = 8;
+glyphname = uni11ABE;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(147,0,l),
+(147,650,l),
+(112,650,l),
+(528,0,l),
+(585,0,l),
+(585,714,l),
+(522,714,l),
+(522,64,l),
+(557,64,l),
+(140,714,l),
+(83,714,l),
+(83,0,l)
+);
+}
+);
+width = 668;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABF;
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(140,0,l),
+(557,654,l),
+(522,654,l),
+(522,0,l),
+(585,0,l),
+(585,714,l),
+(528,714,l),
+(112,60,l),
+(147,60,l),
+(147,714,l),
+(83,714,l),
+(83,0,l)
+);
+}
+);
+width = 668;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = "raiseddoubledotFinal-canadian.cree";
+lastChange = "2023-01-13 15:28:13 +0000";
+layers = (
+{
+layerId = "C6C6CC8B-76AD-4983-B2A6-35FF5D496205";
+shapes = (
+{
+closed = 1;
+nodes = (
+(137,637,o),
+(156,657,o),
+(156,682,cs),
+(156,707,o),
+(137,727,o),
+(112,727,cs),
+(86,727,o),
+(67,707,o),
+(67,682,cs),
+(67,657,o),
+(86,637,o),
+(112,637,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(137,458,o),
+(156,478,o),
+(156,503,cs),
+(156,528,o),
+(137,547,o),
+(112,547,cs),
+(86,547,o),
+(67,528,o),
+(67,503,cs),
+(67,478,o),
+(86,458,o),
+(112,458,cs)
+);
+}
+);
+width = 223;
+}
+);
+note = g725;
+}
+);
+instances = (
+{
+axesValues = (
+65,
+89,
+0
+);
+instanceInterpolations = {
+"C6C6CC8B-76AD-4983-B2A6-35FF5D496205" = 1;
+};
+name = "RC L roman";
+}
+);
+kerningLTR = {
+"C6C6CC8B-76AD-4983-B2A6-35FF5D496205" = {
+"@MMK_L_caright" = {
+"@MMK_R_ecanleft" = -80;
+"@MMK_R_mwestleft" = -28;
+"@MMK_R_neleft" = -64;
+};
+"@MMK_L_ciright" = {
+"@MMK_R_icanleft" = -80;
+"@MMK_R_noleft" = -108;
+};
+"@MMK_L_ecanright" = {
+"@MMK_R_coleft" = -80;
+"@MMK_R_moleft" = -82;
+"@MMK_R_sileft" = -49;
+};
+"@MMK_L_icanright" = {
+"@MMK_R_celeft" = -80;
+"@MMK_R_meleft" = -82;
+"@MMK_R_mwestleft" = -65;
+"@MMK_R_saleft" = -43;
+"she-canadian" = -82;
+};
+"@MMK_L_maright" = {
+"@MMK_R_acanleft" = -83;
+"@MMK_R_ecanleft" = -82;
+"@MMK_R_mwestleft" = -54;
+"@MMK_R_neleft" = -64;
+};
+"@MMK_L_miright" = {
+"@MMK_R_acanleft" = -83;
+"@MMK_R_icanleft" = -82;
+"@MMK_R_moleft" = -106;
+"@MMK_R_noleft" = -108;
+"@MMK_R_yeleft" = -109;
+};
+"@MMK_L_mwestright" = {
+"@MMK_R_coleft" = -28;
+"@MMK_R_icanleft" = -65;
+"@MMK_R_moleft" = -54;
+"@MMK_R_noleft" = -85;
+"@MMK_R_sileft" = -18;
+"@MMK_R_yeleft" = -30;
+};
+"@MMK_L_naright" = {
+"@MMK_R_acanleft" = -102;
+"@MMK_R_celeft" = -108;
+"@MMK_R_meleft" = -108;
+"@MMK_R_mwestleft" = -85;
+"@MMK_R_neleft" = -128;
+"@MMK_R_saleft" = -82;
+};
+"@MMK_L_niright" = {
+"@MMK_R_coleft" = -64;
+"@MMK_R_moleft" = -64;
+"@MMK_R_noleft" = -128;
+"@MMK_R_sileft" = -6;
+};
+"@MMK_L_ocanright" = {
+"@MMK_R_meleft" = -83;
+"@MMK_R_moleft" = -83;
+"@MMK_R_noleft" = -102;
+};
+"@MMK_L_seright" = {
+"@MMK_R_ecanleft" = -49;
+"@MMK_R_mwestleft" = -18;
+"@MMK_R_neleft" = -4;
+};
+"@MMK_L_soright" = {
+"@MMK_R_icanleft" = -43;
+"@MMK_R_noleft" = -82;
+};
+"@MMK_L_yiright" = {
+"@MMK_R_meleft" = -109;
+"@MMK_R_mwestleft" = -30;
+};
+"shi-canadian" = {
+"@MMK_R_icanleft" = -82;
+};
+};
+};
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "italic angle";
+}
+);
+properties = (
+{
+key = copyrights;
+values = (
+{
+language = ENG;
+value = "Copyright 2018 Google Inc. All Rights Reserved.";
+}
+);
+},
+{
+key = manufacturers;
+values = (
+{
+language = ENG;
+value = "Monotype Imaging Inc.";
+}
+);
+},
+{
+key = designers;
+values = (
+{
+language = ENG;
+value = "Monotype Design Team";
+}
+);
+},
+{
+key = description;
+value = "Designed by Monotype design team.";
+},
+{
+key = trademarks;
+values = (
+{
+language = ENG;
+value = "Noto is a trademark of Google Inc.";
+}
+);
+},
+{
+key = licenseURL;
+value = "http://scripts.sil.org/OFL";
+},
+{
+key = licenses;
+values = (
+{
+language = ENG;
+value = "This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.";
+}
+);
+},
+{
+key = manufacturerURL;
+value = "http://www.google.com/get/noto/";
+},
+{
+key = designerURL;
+value = "http://www.monotype.com/studio";
+}
+);
+settings = {
+disablesNiceNames = 1;
+};
+stems = (
+{
+name = "New Stem";
+}
+);
+unitsPerEm = 1000;
+userData = {
+GSDontShowVersionAlert = 1;
+};
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/sources/Exported instances UCAS SansCanadianAboriginal/Sans Canadian Aboriginal-RC R Italic.glyphs
+++ b/sources/Exported instances UCAS SansCanadianAboriginal/Sans Canadian Aboriginal-RC R Italic.glyphs
@@ -1,0 +1,37315 @@
+{
+.appVersion = "3151";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+},
+{
+name = Width;
+tag = wdth;
+},
+{
+name = Slant;
+tag = slnt;
+}
+);
+classes = (
+{
+code = "zero one two three four five six seven eight nine ";
+name = Num;
+},
+{
+code = "zero.canadian one.canadian two.canadian three.canadian four.canadian five.canadian six.canadian seven.canadian eight.canadian nine.canadian 
+";
+name = Num_can;
+},
+{
+code = "ke-canadian.square ki-canadian.square kii-canadian.square ko-canadian.square koo-canadian.square ka-canadian.square kaa-canadian.square kweWestCree-canadian.square kwiiWestCree-canadian.square kwoWestCree-canadian.square kwooWestCree-canadian.square kwaWestCree-canadian.square kwaaWestCree-canadian.square ce-canadian.square ci-canadian.square cii-canadian.square co-canadian.square coo-canadian.square ca-canadian.square caa-canadian.square me-canadian.square mi-canadian.square mii-canadian.square mo-canadian.square moo-canadian.square ma-canadian.square maa-canadian.square ne-canadian.square ni-canadian.square nii-canadian.square no-canadian.square noo-canadian.square na-canadian.square naa-canadian.square nweWestCree-canadian.square nwaWestCree-canadian.square nwaaWestCree-canadian.square se-canadian.square si-canadian.square sii-canadian.square so-canadian.square soo-canadian.square sa-canadian.square saa-canadian.square sho-canadian.square shoo-canadian.square sha-canadian.square shaa-canadian.square ye-canadian.square yi-canadian.square yii-canadian.square yo-canadian.square yoo-canadian.square ya-canadian.square yaa-canadian.square re-canadian.square reRCree-canadian.square leWestCree-canadian.square ri-canadian.square rii-canadian.square ro-canadian.square loWestCree-canadian.square ra-canadian.square raa-canadian.square laWestCree-canadian.square reWestCree-canadian.square riWestCree-canadian.square roWestCree-canadian.square raWestCree-canadian.square theThCree-canadian.square thiThCree-canadian.square thiiThCree-canadian.square thoThCree-canadian.square thooThCree-canadian.square thaThCree-canadian.square thaaThCree-canadian.square thweeWoodScree-canadian.square thwiWoodScree-canadian.square thwiiWoodScree-canadian.square thwoWoodScree-canadian.square thwooWoodScree-canadian.square thwaWoodScree-canadian.square thwaaWoodScree-canadian.square nwiOjibway-canadian.square nwiiOjibway-canadian.square nwoOjibway-canadian.square nwooOjibway-canadian.square looWestCree-canadian.square laaWestCree-canadian.square ";
+name = Dene_square;
+},
+{
+code = "ke-canadian ki-canadian kii-canadian ko-canadian koo-canadian ka-canadian kaa-canadian kweWestCree-canadian kwiiWestCree-canadian kwoWestCree-canadian kwooWestCree-canadian kwaWestCree-canadian kwaaWestCree-canadian ce-canadian ci-canadian cii-canadian co-canadian coo-canadian ca-canadian caa-canadian me-canadian mi-canadian mii-canadian mo-canadian moo-canadian ma-canadian maa-canadian ne-canadian ni-canadian nii-canadian no-canadian noo-canadian na-canadian naa-canadian nweWestCree-canadian nwaWestCree-canadian nwaaWestCree-canadian se-canadian si-canadian sii-canadian so-canadian soo-canadian sa-canadian saa-canadian sho-canadian shoo-canadian sha-canadian shaa-canadian ye-canadian yi-canadian yii-canadian yo-canadian yoo-canadian ya-canadian yaa-canadian re-canadian reRCree-canadian leWestCree-canadian ri-canadian rii-canadian ro-canadian loWestCree-canadian ra-canadian raa-canadian laWestCree-canadian reWestCree-canadian riWestCree-canadian roWestCree-canadian raWestCree-canadian theThCree-canadian thiThCree-canadian thiiThCree-canadian thoThCree-canadian thooThCree-canadian thaThCree-canadian thaaThCree-canadian thweeWoodScree-canadian thwiWoodScree-canadian thwiiWoodScree-canadian thwoWoodScree-canadian thwooWoodScree-canadian thwaWoodScree-canadian thwaaWoodScree-canadian nwiOjibway-canadian nwiiOjibway-canadian nwoOjibway-canadian nwooOjibway-canadian looWestCree-canadian laaWestCree-canadian 
+";
+name = Dene_round;
+},
+{
+code = "acuteFinal-canadian.mid graveFinal-canadian.mid ringTophalfFinal-canadian.mid ringRighthalfFinal-canadian.mid ringFinal-canadian.mid doubleacuteFinal-canadian.mid doubleshortverticalstrokesFinal-canadian.mid shorthorizontalstrokeFinal-canadian.mid downtackFinal-canadian.mid pWestCree-canadian.mid c-canadian.mid mWestCree-canadian.mid ";
+name = Final_mid;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian ringFinal-canadian doubleacuteFinal-canadian doubleshortverticalstrokesFinal-canadian shorthorizontalstrokeFinal-canadian downtackFinal-canadian pWestCree-canadian c-canadian mWestCree-canadian ";
+name = Final_mid_ori;
+},
+{
+code = "acuteFinal-canadian.base graveFinal-canadian.base ringBottomhalfFinal-canadian.base ringTophalfFinal-canadian.base ringRighthalfFinal-canadian.base plusFinal-canadian.base pWestCree-canadian.base c-canadian.base thSayisi-canadian.base mWestCree-canadian.base ";
+name = Final_base;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringBottomhalfFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian plusFinal-canadian pWestCree-canadian c-canadian thSayisi-canadian mWestCree-canadian ";
+name = Final_base_ori;
+},
+{
+code = "ng-canadian ngai-canadian ngaai-canadian ngi-canadian ngii-canadian ngo-canadian ngoo-canadian nga-canadian ngaa-canadian ";
+name = Nunavik;
+},
+{
+code = "ng-canadian.nunavik ngai-canadian.nunavik ngaai-canadian.nunavik ngi-canadian.nunavik ngii-canadian.nunavik ngo-canadian.nunavik ngoo-canadian.nunavik nga-canadian.nunavik ngaa-canadian.nunavik ";
+name = Nunavik_alt;
+}
+);
+customParameters = (
+{
+name = vendorID;
+value = GOOG;
+},
+{
+name = panose;
+value = (
+2,
+11,
+5,
+2,
+4,
+5,
+4,
+2,
+2,
+4
+);
+},
+{
+name = unicodeRanges;
+value = (
+0,
+1,
+2,
+5,
+6,
+45,
+77
+);
+},
+{
+name = codePageRanges;
+value = (
+"1252"
+);
+},
+{
+name = fsType;
+value = (
+);
+}
+);
+date = "2022-06-21 10:06:40 +0000";
+familyName = "Sans Canadian Aboriginal";
+featurePrefixes = (
+{
+automatic = 1;
+code = "languagesystem DFLT dflt;
+
+languagesystem cans dflt;
+";
+name = Languagesystems;
+}
+);
+features = (
+{
+automatic = 1;
+code = "feature ss01;
+feature ss02;
+feature ss03;
+feature ss04;
+";
+tag = aalt;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+tag = salt;
+},
+{
+code = "lookup space_can {
+sub space by space.canadian;
+} space_can;
+
+lookup num_can {
+sub @Num by @Num_can;
+} num_can;
+";
+labels = (
+{
+language = dflt;
+value = "CAN Space and numerals";
+}
+);
+tag = ss01;
+},
+{
+code = "lookup dene_square {
+sub @Dene_round by @Dene_square;
+} dene_square;
+
+";
+labels = (
+{
+language = dflt;
+value = "Dene Square";
+}
+);
+tag = ss02;
+},
+{
+code = "lookup nunavik_alt {
+sub @Nunavik by @Nunavik_alt;
+} nunavik_alt;
+
+";
+labels = (
+{
+language = dflt;
+value = "Nunanvik Alt";
+}
+);
+tag = ss03;
+},
+{
+code = "lookup final_mid {
+sub @Final_mid_ori by @Final_mid;
+} final_mid;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final mid";
+}
+);
+tag = ss04;
+},
+{
+code = "lookup final_base {
+sub @Final_base_ori by @Final_base;
+} final_base;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final base";
+}
+);
+tag = ss05;
+},
+{
+code = "lookup plaincree_first {
+sub wiWestCree-canadian' plusFinal-canadian by i-canadian;
+} plaincree_first;
+
+lookup plaincree_second {
+sub i-canadian plusFinal-canadian' by raiseddoubledotFinal-canadian.cree;
+} plaincree_second;
+
+lookup plaincree_third {
+sub middledotFinal-canadian plusFinal-canadian by raiseddoubledotFinal-canadian.cree;
+} plaincree_third;
+";
+labels = (
+{
+language = dflt;
+value = Plaincree;
+}
+);
+tag = ss06;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+labels = (
+{
+language = dflt;
+value = "";
+}
+);
+tag = ss07;
+}
+);
+fontMaster = (
+{
+axesValues = (
+0,
+0,
+0
+);
+customParameters = (
+{
+name = typoAscender;
+value = 1069;
+},
+{
+name = typoDescender;
+value = -293;
+},
+{
+name = typoLineGap;
+value = 0;
+},
+{
+name = winAscent;
+value = 1069;
+},
+{
+name = winDescent;
+value = 293;
+},
+{
+name = hheaAscender;
+value = 1069;
+},
+{
+name = hheaDescender;
+value = -293;
+},
+{
+name = strikeoutPosition;
+value = 297.53293;
+},
+{
+name = strikeoutSize;
+value = 50;
+},
+{
+name = "Master Icon Glyph Name";
+value = s;
+}
+);
+guides = (
+{
+lockAngle = 1;
+locked = 1;
+pos = (773,357);
+},
+{
+locked = 1;
+pos = (-54,-12);
+},
+{
+locked = 1;
+pos = (113,726);
+},
+{
+locked = 1;
+pos = (776,370);
+},
+{
+locked = 1;
+pos = (772,344);
+}
+);
+id = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+metricValues = (
+{
+over = 19;
+pos = 1069;
+},
+{
+over = 19;
+pos = 714;
+},
+{
+over = 19;
+pos = 496;
+},
+{
+over = -19;
+},
+{
+over = -19;
+pos = -293;
+},
+{
+pos = 12;
+}
+);
+name = "RC L Italic";
+stemValues = (
+99
+);
+}
+);
+glyphs = (
+{
+glyphname = idotless;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(120,0,l),
+(234,539,l),
+(136,539,l),
+(21,0,l)
+);
+}
+);
+width = 247;
+}
+);
+note = dotlessi;
+unicode = 305;
+},
+{
+glyphname = "acuteFinal-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(149.005,357,l),
+(386,714,l),
+(302,714,l),
+(65,357,l)
+);
+}
+);
+width = 329;
+}
+);
+metricRight = "=|";
+note = uni141F;
+unicode = 5151;
+},
+{
+glyphname = "graveFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(310,357,l),
+(216,714,l),
+(141,714,l),
+(235,357,l)
+);
+}
+);
+width = 329;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+unicode = 5152;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(353,351,o),
+(406,404,o),
+(426,495,cs),
+(472,714,l),
+(402,714,l),
+(358,508,ls),
+(344,444,o),
+(315,416,o),
+(260,416,cs),
+(202,416,o),
+(180,449,o),
+(193,513,cs),
+(236,714,l),
+(165,714,l),
+(124,517,ls),
+(102,414,o),
+(150,351,o),
+(255,351,cs)
+);
+}
+);
+width = 439;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1421;
+unicode = 5153;
+},
+{
+glyphname = "ringTophalfFinal-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(160,357,l),
+(204,563,ls),
+(217,627,o),
+(247,655,o),
+(302,655,cs),
+(360,655,o),
+(382,622,o),
+(368,558,cs),
+(326,357,l),
+(396,357,l),
+(438,554,ls),
+(460,657,o),
+(412,720,o),
+(307,720,cs),
+(209,720,o),
+(156,667,o),
+(136,576,cs),
+(89,357,l)
+);
+}
+);
+width = 439;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+unicode = 5154;
+},
+{
+glyphname = "ringRighthalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(166,357,ls),
+(310,357,o),
+(382,455,o),
+(382,573,cs),
+(382,660,o),
+(327,714,o),
+(233,714,cs),
+(162,714,l),
+(148,648,l),
+(223,648,ls),
+(282,648,o),
+(311,619,o),
+(311,567,cs),
+(311,502,o),
+(280,423,o),
+(175,423,cs),
+(100,423,l),
+(86,357,l)
+);
+}
+);
+width = 382;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+unicode = 5155;
+},
+{
+glyphname = "ringFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(409,368,o),
+(485,443,o),
+(485,544,cs),
+(485,645,o),
+(407,720,o),
+(305,720,cs),
+(203,720,o),
+(126,645,o),
+(126,544,cs),
+(126,443,o),
+(201,368,o),
+(305,368,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(237,429,o),
+(192,478,o),
+(192,544,cs),
+(192,610,o),
+(238,659,o),
+(305,659,cs),
+(371,659,o),
+(418,610,o),
+(418,544,cs),
+(418,478,o),
+(372,429,o),
+(305,429,cs)
+);
+}
+);
+width = 484;
+}
+);
+note = uni1424;
+unicode = 5156;
+},
+{
+glyphname = "doubleacuteFinal-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(147,357,l),
+(386,714,l),
+(304,714,l),
+(65,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(304,357,l),
+(542,714,l),
+(460,714,l),
+(221,357,l)
+);
+}
+);
+width = 485;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricRight = "=|";
+note = uni1425;
+unicode = 5157;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(160,357,l),
+(236,714,l),
+(165,714,l),
+(89,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(299,357,l),
+(375,714,l),
+(305,714,l),
+(229,357,l)
+);
+}
+);
+width = 342;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "pWestCree-canadian";
+note = uni1426;
+unicode = 5158;
+},
+{
+glyphname = "middledotFinal-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(173,310,o),
+(198,335,o),
+(198,367,cs),
+(198,399,o),
+(173,424,o),
+(141,424,cs),
+(110,424,o),
+(85,399,o),
+(85,367,cs),
+(85,335,o),
+(110,310,o),
+(141,310,cs)
+);
+}
+);
+width = 232;
+}
+);
+note = uni1427;
+unicode = 5159;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(451,506,l),
+(466,577,l),
+(135,577,l),
+(119,506,l)
+);
+}
+);
+width = 460;
+}
+);
+metricRight = "=|";
+note = uni1428;
+unicode = 5160;
+},
+{
+glyphname = "plusFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(292,375,l),
+(321,513,l),
+(452,513,l),
+(466,579,l),
+(335,579,l),
+(364,714,l),
+(294,714,l),
+(266,579,l),
+(134,579,l),
+(120,513,l),
+(252,513,l),
+(222,375,l)
+);
+}
+);
+width = 460;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+unicode = 5161;
+},
+{
+glyphname = "downtackFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(290,357,l),
+(351,647,l),
+(481,647,l),
+(496,714,l),
+(164,714,l),
+(149,647,l),
+(280,647,l),
+(219,357,l)
+);
+}
+);
+width = 461;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni142A;
+unicode = 5162;
+},
+{
+glyphname = "thFinalWoodScree-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(292,357,l),
+(309,435,l),
+(437,435,l),
+(450,493,l),
+(321,493,l),
+(339,578,l),
+(468,578,l),
+(480,636,l),
+(352,636,l),
+(368,714,l),
+(297,714,l),
+(281,636,l),
+(149,636,l),
+(137,578,l),
+(268,578,l),
+(250,493,l),
+(119,493,l),
+(106,435,l),
+(238,435,l),
+(221,357,l)
+);
+}
+);
+width = 464;
+}
+);
+metricLeft = "hyphen-canadian";
+metricRight = "hyphen-canadian";
+note = uni167E;
+unicode = 5758;
+},
+{
+glyphname = "ringSmallFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(312,517,o),
+(362,560,o),
+(362,622,cs),
+(362,684,o),
+(312,727,o),
+(253,727,cs),
+(195,727,o),
+(146,684,o),
+(146,622,cs),
+(146,560,o),
+(195,517,o),
+(253,517,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(218,563,o),
+(196,589,o),
+(196,622,cs),
+(196,655,o),
+(220,681,o),
+(254,681,cs),
+(289,681,o),
+(312,655,o),
+(312,622,cs),
+(312,589,o),
+(289,563,o),
+(254,563,cs)
+);
+}
+);
+width = 349;
+}
+);
+note = g725;
+unicode = 6366;
+},
+{
+glyphname = "raiseddotFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(239,614,o),
+(264,639,o),
+(264,671,cs),
+(264,702,o),
+(239,727,o),
+(207,727,cs),
+(175,727,o),
+(150,702,o),
+(150,671,cs),
+(150,639,o),
+(175,614,o),
+(207,614,cs)
+);
+}
+);
+width = 234;
+}
+);
+note = g725;
+unicode = 6367;
+},
+{
+glyphname = "acuteFinal-canadian.base";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "acuteFinal-canadian";
+}
+);
+width = 329;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.base";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "graveFinal-canadian";
+}
+);
+width = 329;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian.base";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 439;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1421;
+},
+{
+glyphname = "ringTophalfFinal-canadian.base";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 439;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.base";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 382;
+}
+);
+metricLeft = "==|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "plusFinal-canadian.base";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(213,0,l),
+(242,138,l),
+(373,138,l),
+(387,204,l),
+(257,204,l),
+(285,339,l),
+(216,339,l),
+(187,204,l),
+(55,204,l),
+(41,138,l),
+(173,138,l),
+(144,0,l)
+);
+}
+);
+width = 460;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+},
+{
+glyphname = "acuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "acuteFinal-canadian";
+}
+);
+width = 329;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.mid";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "graveFinal-canadian";
+}
+);
+width = 329;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringTophalfFinal-canadian.mid";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-38,-178);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 439;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.mid";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 382;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "ringFinal-canadian.mid";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-40,-187);
+ref = "ringFinal-canadian";
+}
+);
+width = 484;
+}
+);
+metricLeft = "ringFinal-canadian";
+metricWidth = "ringFinal-canadian";
+note = uni1424;
+},
+{
+glyphname = "doubleacuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "doubleacuteFinal-canadian";
+}
+);
+width = 485;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "doubleacuteFinal-canadian";
+note = uni1425;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian.mid";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "doubleshortverticalstrokesFinal-canadian";
+}
+);
+width = 342;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricWidth = "doubleshortverticalstrokesFinal-canadian";
+note = uni1426;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian.mid";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-37,-174);
+ref = "shorthorizontalstrokeFinal-canadian";
+}
+);
+width = 460;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "shorthorizontalstrokeFinal-canadian";
+note = uni1428;
+},
+{
+glyphname = "downtackFinal-canadian.mid";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "downtackFinal-canadian";
+}
+);
+width = 461;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "downtackFinal-canadian";
+note = uni142A;
+},
+{
+glyphname = "e-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (415,470);
+},
+{
+name = top_center_can;
+pos = (468,714);
+},
+{
+name = top_left_can;
+pos = (233,714);
+},
+{
+name = top_right_can;
+pos = (703,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(337,0,l),
+(801,687,l),
+(807,714,l),
+(133,714,l),
+(127,687,l),
+(300,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(355,117,l),
+(229,655,l),
+(213,632,l),
+(692,632,l),
+(673,655,l),
+(320,117,l)
+);
+}
+);
+width = 742;
+}
+);
+metricRight = "=|";
+note = uni1401;
+unicode = 5121;
+},
+{
+glyphname = "aai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (242,0);
+ref = ring_top.canadian;
+}
+);
+width = 742;
+}
+);
+note = uni1402;
+unicode = 5122;
+},
+{
+glyphname = "i-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (402,367);
+},
+{
+name = top_center_can;
+pos = (470,714);
+},
+{
+name = top_left_can;
+pos = (235,714);
+},
+{
+name = top_right_can;
+pos = (705,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(451,714,l),
+(-13,27,l),
+(-19,0,l),
+(655,0,l),
+(661,27,l),
+(488,714,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(433,597,l),
+(559,59,l),
+(575,82,l),
+(96,82,l),
+(115,59,l),
+(468,597,l)
+);
+}
+);
+width = 742;
+}
+);
+metricLeft = "e-canadian";
+metricWidth = "e-canadian";
+note = uni1403;
+unicode = 5123;
+},
+{
+glyphname = "ii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (295,0);
+ref = dot_top;
+}
+);
+width = 742;
+}
+);
+note = uni1404;
+unicode = 5124;
+},
+{
+glyphname = "o-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (309,366);
+},
+{
+name = top_center_can;
+pos = (471,714);
+},
+{
+name = top_double;
+pos = (569,714);
+},
+{
+name = top_left_can;
+pos = (221,714);
+},
+{
+name = top_right_can;
+pos = (719,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(52,0,l),
+(685,339,l),
+(693,375,l),
+(204,714,l),
+(178,714,l),
+(26,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(240,609,l),
+(210,613,l),
+(580,354,l),
+(583,376,l),
+(106,118,l),
+(134,110,l)
+);
+}
+);
+width = 701;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1405;
+unicode = 5125;
+},
+{
+glyphname = "oo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (45,0);
+ref = dot_top;
+}
+);
+width = 701;
+}
+);
+note = uni1406;
+unicode = 5126;
+},
+{
+glyphname = "yCreeoo-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (220,0);
+ref = doubledot_top;
+}
+);
+width = 701;
+}
+);
+note = uni1407;
+unicode = 5127;
+},
+{
+glyphname = "eeCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(52,0,l),
+(685,338,l),
+(693,375,l),
+(204,714,l),
+(178,714,l),
+(26,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(238,609,l),
+(215,610,l),
+(582,354,l),
+(587,377,l),
+(110,120,l),
+(132,110,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(307,278,l),
+(343,448,l),
+(304,448,l),
+(268,278,l)
+);
+}
+);
+width = 701;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "o-canadian";
+note = uni1408;
+unicode = 5128;
+},
+{
+glyphname = "iCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (227,9);
+ref = dot_middle_optic_small;
+}
+);
+width = 701;
+}
+);
+note = uni1409;
+unicode = 5129;
+},
+{
+glyphname = "a-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:29:07 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (428,353);
+},
+{
+name = top_center_can;
+pos = (423,714);
+},
+{
+name = top_left_can;
+pos = (179,714);
+},
+{
+name = top_right_can;
+pos = (678,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(695.007,714,l),
+(62,375,l),
+(54,339,l),
+(543.007,0,l),
+(570,0,l),
+(722,714,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(507,105,l),
+(537,101,l),
+(167,360,l),
+(164,338,l),
+(641,596,l),
+(613,604,l)
+);
+}
+);
+width = 702;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni140A;
+unicode = 5130;
+},
+{
+glyphname = "aa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (503,0);
+ref = dot_top;
+}
+);
+width = 701;
+}
+);
+note = uni140B;
+unicode = 5131;
+},
+{
+glyphname = "we-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "e-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni140C;
+unicode = 5132;
+},
+{
+glyphname = "weWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (742,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni140D;
+unicode = 5133;
+},
+{
+glyphname = "wi-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "i-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni140E;
+unicode = 5134;
+},
+{
+glyphname = "wiWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (742,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni140F;
+unicode = 5135;
+},
+{
+glyphname = "wii-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (527,0);
+ref = dot_top;
+}
+);
+width = 974;
+}
+);
+note = uni1410;
+unicode = 5136;
+},
+{
+glyphname = "wiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (295,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (742,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni1411;
+unicode = 5137;
+},
+{
+glyphname = "wo-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "o-canadian";
+}
+);
+width = 933;
+}
+);
+note = uni1412;
+unicode = 5138;
+},
+{
+glyphname = "woWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (701,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 933;
+}
+);
+note = uni1413;
+unicode = 5139;
+},
+{
+glyphname = "woo-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (528,0);
+ref = dot_top;
+}
+);
+width = 933;
+}
+);
+note = uni1414;
+unicode = 5140;
+},
+{
+glyphname = "wooWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (45,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (701,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 933;
+}
+);
+note = uni1415;
+unicode = 5141;
+},
+{
+glyphname = "wooNaskapi-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (187,-99);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (350,-210);
+ref = dot_top;
+}
+);
+width = 701;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricWidth = "o-canadian";
+note = uni1416;
+unicode = 5142;
+},
+{
+glyphname = "wa-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "a-canadian";
+}
+);
+width = 933;
+}
+);
+note = uni1417;
+unicode = 5143;
+},
+{
+glyphname = "waWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (701,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 933;
+}
+);
+note = uni1418;
+unicode = 5144;
+},
+{
+glyphname = "waa-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (735,0);
+ref = dot_top;
+}
+);
+width = 933;
+}
+);
+note = uni1419;
+unicode = 5145;
+},
+{
+glyphname = "waaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (503,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (701,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 933;
+}
+);
+note = uni141A;
+unicode = 5146;
+},
+{
+glyphname = "waaNaskapi-canadian";
+lastChange = "2023-01-13 15:29:07 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (130,-208);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (332,-99);
+ref = dot_top;
+}
+);
+width = 702;
+}
+);
+metricWidth = "a-canadian";
+note = uni141B;
+unicode = 5147;
+},
+{
+glyphname = "ai-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(306,351,o),
+(348,381,o),
+(378,442,c),
+(358,445,l),
+(363,383,o),
+(402,351,o),
+(471,351,cs),
+(564,351,o),
+(614,400,o),
+(638,509,cs),
+(681,714,l),
+(614,714,l),
+(571,507,ls),
+(557,441,o),
+(528,413,o),
+(474,413,cs),
+(419,413,o),
+(399,443,o),
+(413,508,cs),
+(457,714,l),
+(390,714,l),
+(346,508,ls),
+(332,442,o),
+(302,413,o),
+(251,413,cs),
+(197,413,o),
+(175,445,o),
+(188,507,cs),
+(232,714,l),
+(165,714,l),
+(122,509,ls),
+(102,413,o),
+(149,351,o),
+(242,351,cs)
+);
+}
+);
+width = 649;
+}
+);
+metricRight = "=|";
+note = uni141C;
+unicode = 5148;
+},
+{
+glyphname = "ycreew-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(438,528,o),
+(476,568,o),
+(476,624,cs),
+(476,681,o),
+(439,720,o),
+(388,720,cs),
+(336,720,o),
+(298,681,o),
+(298,624,cs),
+(298,568,o),
+(336,528,o),
+(387,528,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(249,351,o),
+(286,391,o),
+(286,447,cs),
+(286,504,o),
+(249,543,o),
+(198,543,cs),
+(147,543,o),
+(108,504,o),
+(108,447,cs),
+(108,391,o),
+(146,351,o),
+(197,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(168,388,o),
+(148,412,o),
+(148,447,cs),
+(148,482,o),
+(168,506,o),
+(197,506,cs),
+(227,506,o),
+(247,482,o),
+(247,447,cs),
+(247,412,o),
+(227,388,o),
+(197,388,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(357,565,o),
+(338,589,o),
+(338,624,cs),
+(338,659,o),
+(358,683,o),
+(387,683,cs),
+(416,683,o),
+(436,659,o),
+(436,624,cs),
+(436,589,o),
+(416,565,o),
+(387,565,cs)
+);
+}
+);
+width = 462;
+}
+);
+metricRight = "=|";
+note = uni141D;
+unicode = 5149;
+},
+{
+glyphname = "glottalstop-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(417,357,l),
+(421,372,l),
+(334,714,l),
+(315,714,l),
+(83,372,l),
+(80,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(332,648,l),
+(297,649,l),
+(359,387,l),
+(376,410,l),
+(145,410,l),
+(158,387,l)
+);
+}
+);
+width = 452;
+}
+);
+metricRight = "=|";
+note = uni141E;
+unicode = 5150;
+},
+{
+glyphname = "en-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+pos = (742,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni142B;
+unicode = 5163;
+},
+{
+glyphname = "in-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+pos = (507,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 836;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142C;
+unicode = 5164;
+},
+{
+glyphname = "on-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (553,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 882;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142D;
+unicode = 5165;
+},
+{
+glyphname = "an-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (654,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 983;
+}
+);
+metricRight = "graveFinal-canadian";
+note = uni142E;
+unicode = 5166;
+},
+{
+glyphname = "pe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (411,470);
+},
+{
+name = top_center_can;
+pos = (470,714);
+},
+{
+name = top_left_can;
+pos = (233,714);
+},
+{
+name = top_right_can;
+pos = (703,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(336,0,l),
+(801,687,l),
+(807,714,l),
+(704,714,l),
+(308,118,l),
+(364,118,l),
+(222,714,l),
+(133,714,l),
+(127,687,l),
+(300,0,l)
+);
+}
+);
+width = 742;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni142F;
+unicode = 5167;
+},
+{
+glyphname = "paai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (242,0);
+ref = ring_top.canadian;
+}
+);
+width = 742;
+}
+);
+note = uni1430;
+unicode = 5168;
+},
+{
+glyphname = "pi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (403,367);
+},
+{
+name = top_center_can;
+pos = (470,714);
+},
+{
+name = top_left_can;
+pos = (233,714);
+},
+{
+name = top_right_can;
+pos = (703,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(452,714,l),
+(-13,27,l),
+(-19,0,l),
+(84,0,l),
+(480,596,l),
+(424,596,l),
+(566,0,l),
+(655,0,l),
+(661,27,l),
+(488,714,l)
+);
+}
+);
+width = 742;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni1431;
+unicode = 5169;
+},
+{
+glyphname = "pii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (295,0);
+ref = dot_top;
+}
+);
+width = 742;
+}
+);
+note = uni1432;
+unicode = 5170;
+},
+{
+glyphname = "po-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (239,368);
+},
+{
+name = top_center_can;
+pos = (444,714);
+},
+{
+name = top_double;
+pos = (548,714);
+},
+{
+name = top_left_can;
+pos = (198,714);
+},
+{
+name = top_right_can;
+pos = (690,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+name = "Thin Slanted";
+shapes = (
+{
+closed = 1;
+nodes = (
+(29,0,l),
+(657,339,l),
+(664,375,l),
+(181,714,l),
+(154,714,l),
+(137,631,l),
+(545,344,l),
+(554,389,l),
+(24,103,l),
+(3,0,l)
+);
+}
+);
+width = 673;
+}
+);
+metricRight = "o-canadian";
+note = uni1433;
+unicode = 5171;
+},
+{
+glyphname = "poo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (22,0);
+ref = dot_top;
+}
+);
+width = 672;
+}
+);
+note = uni1434;
+unicode = 5172;
+},
+{
+glyphname = "ycreepoo-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (199,0);
+ref = doubledot_top;
+}
+);
+width = 672;
+}
+);
+note = uni1435;
+unicode = 5173;
+},
+{
+glyphname = "heeCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (173,11);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 672;
+}
+);
+note = uni1436;
+unicode = 5174;
+},
+{
+glyphname = "hiCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (150,14);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 672;
+}
+);
+note = uni1437;
+unicode = 5175;
+},
+{
+glyphname = "pa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (360,357);
+},
+{
+name = top_center_can;
+pos = (427,714);
+},
+{
+name = top_left_can;
+pos = (180,714);
+},
+{
+name = top_right_can;
+pos = (673,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(689,714,l),
+(62,375,l),
+(55,339,l),
+(538,0,l),
+(564,0,l),
+(582,83,l),
+(174,370,l),
+(165,325,l),
+(694,611,l),
+(716,714,l)
+);
+}
+);
+width = 672;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1438;
+unicode = 5176;
+},
+{
+glyphname = "paa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (498,0);
+ref = dot_top;
+}
+);
+width = 672;
+}
+);
+note = uni1439;
+unicode = 5177;
+},
+{
+glyphname = "pwe-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "pe-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni143A;
+unicode = 5178;
+},
+{
+glyphname = "pweWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "pe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (742,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni143B;
+unicode = 5179;
+},
+{
+glyphname = "pwi-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "pi-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni143C;
+unicode = 5180;
+},
+{
+glyphname = "pwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (742,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni143D;
+unicode = 5181;
+},
+{
+glyphname = "pwii-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (527,0);
+ref = dot_top;
+}
+);
+width = 974;
+}
+);
+note = uni143E;
+unicode = 5182;
+},
+{
+glyphname = "pwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (295,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (742,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni143F;
+unicode = 5183;
+},
+{
+glyphname = "pwo-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "po-canadian";
+}
+);
+width = 905;
+}
+);
+note = uni1440;
+unicode = 5184;
+},
+{
+glyphname = "pwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (672,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 905;
+}
+);
+note = uni1441;
+unicode = 5185;
+},
+{
+glyphname = "pwoo-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (501,0);
+ref = dot_top;
+}
+);
+width = 905;
+}
+);
+note = uni1442;
+unicode = 5186;
+},
+{
+glyphname = "pwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (22,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (672,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 905;
+}
+);
+note = uni1443;
+unicode = 5187;
+},
+{
+glyphname = "pwa-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "pa-canadian";
+}
+);
+width = 905;
+}
+);
+note = uni1444;
+unicode = 5188;
+},
+{
+glyphname = "pwaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (672,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 905;
+}
+);
+note = uni1445;
+unicode = 5189;
+},
+{
+glyphname = "pwaa-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (730,0);
+ref = dot_top;
+}
+);
+width = 905;
+}
+);
+note = uni1446;
+unicode = 5190;
+},
+{
+glyphname = "pwaaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (498,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (672,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 905;
+}
+);
+note = uni1447;
+unicode = 5191;
+},
+{
+glyphname = "ycreepwaa-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+pos = (126,-208);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (328,-99);
+ref = dot_top;
+}
+);
+width = 672;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1448;
+unicode = 5192;
+},
+{
+glyphname = "p-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(379,357,l),
+(391,415,l),
+(193,555,l),
+(181,504,l),
+(440,643,l),
+(455,714,l),
+(439,714,l),
+(129,546,l),
+(125,526,l),
+(363,357,l)
+);
+}
+);
+width = 423;
+}
+);
+note = uni1449;
+unicode = 5193;
+},
+{
+glyphname = "pWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(160,357,l),
+(236,714,l),
+(165,714,l),
+(89,357,l)
+);
+}
+);
+width = 203;
+}
+);
+metricRight = "=|";
+note = uni144A;
+unicode = 5194;
+},
+{
+color = 6;
+glyphname = "hCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(124,189,l),
+(151,319,ls),
+(160,362,o),
+(187,386,o),
+(222,386,cs),
+(264,386,o),
+(281,360,o),
+(271,314,cs),
+(244,189,l),
+(314,189,l),
+(343,326,ls),
+(359,400,o),
+(320,450,o),
+(247,450,cs),
+(200,450,o),
+(157,423,o),
+(145,385,c),
+(163,375,l),
+(200,546,l),
+(129,546,l),
+(53,189,l)
+);
+}
+);
+width = 371;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144B;
+unicode = 5195;
+},
+{
+glyphname = "te-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (391,357);
+},
+{
+name = top_center_can;
+pos = (467,714);
+},
+{
+name = top_left_can;
+pos = (219,714);
+},
+{
+name = top_right_can;
+pos = (716,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(527,-13,o),
+(632,85,o),
+(675,287,cs),
+(766,714,l),
+(667,714,l),
+(577,290,ls),
+(545,144,o),
+(474,78,o),
+(350,78,cs),
+(207,78,o),
+(150,155,o),
+(184,311,cs),
+(269,714,l),
+(170,714,l),
+(85,317,ls),
+(41,107,o),
+(141,-13,o),
+(342,-13,cs)
+);
+}
+);
+width = 737;
+}
+);
+metricRight = "=|";
+note = uni144C;
+unicode = 5196;
+},
+{
+glyphname = "taai-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (240,0);
+ref = ring_top.canadian;
+}
+);
+width = 738;
+}
+);
+note = uni144D;
+unicode = 5197;
+},
+{
+glyphname = "ti-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (391,357);
+},
+{
+name = middle_right_can;
+pos = (854,357);
+},
+{
+name = top_center_can;
+pos = (467,714);
+},
+{
+name = top_left_can;
+pos = (219,714);
+},
+{
+name = top_right_can;
+pos = (716,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(116,0,l),
+(207,424,ls),
+(238,570,o),
+(310,636,o),
+(433,636,cs),
+(576,636,o),
+(633,559,o),
+(599,403,cs),
+(514,0,l),
+(613,0,l),
+(698,397,ls),
+(742,607,o),
+(642,727,o),
+(441,727,cs),
+(256,727,o),
+(151,629,o),
+(108,427,cs),
+(17,0,l)
+);
+}
+);
+width = 736;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni144E;
+unicode = 5198;
+},
+{
+glyphname = "tii-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (293,0);
+ref = dot_top;
+}
+);
+width = 738;
+}
+);
+note = uni144F;
+unicode = 5199;
+},
+{
+glyphname = "to-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (286,357);
+},
+{
+name = middle_right_can;
+pos = (752,357);
+},
+{
+name = top_center_can;
+pos = (384,714);
+},
+{
+name = top_double;
+pos = (455,714);
+},
+{
+name = top_left_can;
+pos = (202,714);
+},
+{
+name = top_right_can;
+pos = (620,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(175,0,ls),
+(505,0,o),
+(593,262,o),
+(593,439,cs),
+(593,612,o),
+(489,714,o),
+(304,714,cs),
+(158,714,l),
+(139,624,l),
+(291,624,ls),
+(424,624,o),
+(494,557,o),
+(494,432,cs),
+(494,294,o),
+(428,90,o),
+(185,90,cs),
+(25,90,l),
+(6,0,l)
+);
+}
+);
+width = 628;
+}
+);
+note = uni1450;
+unicode = 5200;
+},
+{
+glyphname = "too-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (208,0);
+ref = dot_top;
+}
+);
+width = 628;
+}
+);
+note = uni1451;
+unicode = 5201;
+},
+{
+glyphname = "ycreetoo-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (106,0);
+ref = doubledot_top;
+}
+);
+width = 628;
+}
+);
+note = uni1452;
+unicode = 5202;
+},
+{
+glyphname = "deeCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (213,0);
+ref = stroke_middle;
+}
+);
+width = 628;
+}
+);
+note = uni1453;
+unicode = 5203;
+},
+{
+glyphname = "diCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (187,0);
+ref = dot_middle;
+}
+);
+width = 628;
+}
+);
+note = uni1454;
+unicode = 5204;
+},
+{
+glyphname = "ta-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (388,357);
+},
+{
+name = top_center_can;
+pos = (442,714);
+},
+{
+name = top_left_can;
+pos = (205,714);
+},
+{
+name = top_right_can;
+pos = (623,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(516,0,l),
+(535,90,l),
+(383,90,ls),
+(249,90,o),
+(181,157,o),
+(181,282,cs),
+(181,422,o),
+(248,624,o),
+(488,624,cs),
+(649,624,l),
+(668,714,l),
+(498,714,ls),
+(170,714,o),
+(81,454,o),
+(81,275,cs),
+(81,102,o),
+(184,0,o),
+(369,0,cs)
+);
+}
+);
+width = 628;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|to-canadian";
+note = uni1455;
+unicode = 5205;
+},
+{
+glyphname = "taa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (268,0);
+ref = dot_top;
+}
+);
+width = 628;
+}
+);
+note = uni1456;
+unicode = 5206;
+},
+{
+glyphname = "twe-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "te-canadian";
+}
+);
+width = 970;
+}
+);
+note = uni1457;
+unicode = 5207;
+},
+{
+glyphname = "tweWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (738,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 970;
+}
+);
+note = uni1458;
+unicode = 5208;
+},
+{
+glyphname = "twi-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ti-canadian";
+}
+);
+width = 970;
+}
+);
+note = uni1459;
+unicode = 5209;
+},
+{
+glyphname = "twiWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (738,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 970;
+}
+);
+note = uni145A;
+unicode = 5210;
+},
+{
+glyphname = "twii-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (525,0);
+ref = dot_top;
+}
+);
+width = 970;
+}
+);
+note = uni145B;
+unicode = 5211;
+},
+{
+glyphname = "twiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (293,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (738,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 970;
+}
+);
+note = uni145C;
+unicode = 5212;
+},
+{
+glyphname = "two-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "to-canadian";
+}
+);
+width = 861;
+}
+);
+note = uni145D;
+unicode = 5213;
+},
+{
+glyphname = "twoWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (628,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 861;
+}
+);
+note = uni145E;
+unicode = 5214;
+},
+{
+glyphname = "twoo-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (441,0);
+ref = dot_top;
+}
+);
+width = 861;
+}
+);
+note = uni145F;
+unicode = 5215;
+},
+{
+glyphname = "twooWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (208,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (628,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 861;
+}
+);
+note = uni1460;
+unicode = 5216;
+},
+{
+glyphname = "twa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ta-canadian";
+}
+);
+width = 861;
+}
+);
+note = uni1461;
+unicode = 5217;
+},
+{
+glyphname = "twaWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (628,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 861;
+}
+);
+note = uni1462;
+unicode = 5218;
+},
+{
+glyphname = "twaa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (500,0);
+ref = dot_top;
+}
+);
+width = 861;
+}
+);
+note = uni1463;
+unicode = 5219;
+},
+{
+glyphname = "twaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (268,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (628,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 861;
+}
+);
+note = uni1464;
+unicode = 5220;
+},
+{
+glyphname = "twaaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ta-canadian";
+}
+);
+width = 860;
+}
+);
+note = uni1465;
+unicode = 5221;
+},
+{
+glyphname = "t-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(341,357,l),
+(356,423,l),
+(280,423,ls),
+(221,423,o),
+(192,452,o),
+(192,504,cs),
+(192,570,o),
+(224,648,o),
+(328,648,cs),
+(403,648,l),
+(417,714,l),
+(337,714,ls),
+(194,714,o),
+(121,616,o),
+(121,498,cs),
+(121,411,o),
+(175,357,o),
+(270,357,cs)
+);
+}
+);
+width = 382;
+}
+);
+note = uni1466;
+unicode = 5222;
+},
+{
+glyphname = "tte-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+pos = (738,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 941;
+}
+);
+note = uni1467;
+unicode = 5223;
+},
+{
+glyphname = "tti-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+pos = (738,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 941;
+}
+);
+note = uni1468;
+unicode = 5224;
+},
+{
+glyphname = "tto-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+pos = (628,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 832;
+}
+);
+note = uni1469;
+unicode = 5225;
+},
+{
+glyphname = "tta-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+pos = (628,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 832;
+}
+);
+note = uni146A;
+unicode = 5226;
+},
+{
+glyphname = "ke-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (357,457);
+},
+{
+name = top_center_can;
+pos = (396,714);
+},
+{
+name = top_left_can;
+pos = (208,714);
+},
+{
+name = top_right_can;
+pos = (573,719);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(483,0,l),
+(574,427,ls),
+(605,576,o),
+(555,727,o),
+(374,727,cs),
+(190,727,o),
+(106,557,o),
+(106,414,cs),
+(106,288,o),
+(182,205,o),
+(301,205,cs),
+(377,205,o),
+(438,243,o),
+(467,308,c),
+(452,323,l),
+(384,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(247,290,o),
+(202,339,o),
+(202,420,cs),
+(202,501,o),
+(244,642,o),
+(366,642,cs),
+(442,642,o),
+(487,593,o),
+(487,511,cs),
+(487,429,o),
+(445,290,o),
+(323,290,cs)
+);
+}
+);
+width = 606;
+}
+);
+metricRight = "te-canadian";
+note = uni146B;
+unicode = 5227;
+},
+{
+glyphname = "kaai-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (175,0);
+ref = ring_top.canadian;
+}
+);
+width = 607;
+}
+);
+note = uni146C;
+unicode = 5228;
+},
+{
+glyphname = "ki-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (367,457);
+},
+{
+name = top_center_can;
+pos = (402,714);
+},
+{
+name = top_left_can;
+pos = (218,714);
+},
+{
+name = top_right_can;
+pos = (594,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(116,0,l),
+(189,342,l),
+(176,336,l),
+(174,268,o),
+(240,205,o),
+(336,205,cs),
+(516,205,o),
+(592,382,o),
+(592,513,cs),
+(592,645,o),
+(511,727,o),
+(381,727,cs),
+(247,727,o),
+(153,643,o),
+(122,493,cs),
+(17,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(256,290,o),
+(211,339,o),
+(211,420,cs),
+(211,500,o),
+(252,642,o),
+(374,642,cs),
+(450,642,o),
+(496,593,o),
+(496,512,cs),
+(496,432,o),
+(454,290,o),
+(332,290,cs)
+);
+}
+);
+width = 606;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni146D;
+unicode = 5229;
+},
+{
+glyphname = "kii-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (227,0);
+ref = dot_top;
+}
+);
+width = 607;
+}
+);
+note = uni146E;
+unicode = 5230;
+},
+{
+glyphname = "ko-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (341,368);
+},
+{
+name = top_center_can;
+pos = (398,714);
+},
+{
+name = top_double;
+pos = (586,714);
+},
+{
+name = top_left_can;
+pos = (210,714);
+},
+{
+name = top_right_can;
+pos = (586,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(405,-13,o),
+(499,71,o),
+(531,221,cs),
+(636,714,l),
+(536,714,l),
+(463,372,l),
+(477,378,l),
+(479,446,o),
+(413,509,o),
+(317,509,cs),
+(135,509,o),
+(60,331,o),
+(60,201,cs),
+(60,69,o),
+(141,-13,o),
+(275,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(202,72,o),
+(157,120,o),
+(157,202,cs),
+(157,282,o),
+(200,424,o),
+(321,424,cs),
+(397,424,o),
+(441,375,o),
+(441,294,cs),
+(441,213,o),
+(401,72,o),
+(278,72,cs)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni146F;
+unicode = 5231;
+},
+{
+glyphname = "koo-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (409,0);
+ref = dot_top;
+}
+);
+width = 607;
+}
+);
+note = uni1470;
+unicode = 5232;
+},
+{
+glyphname = "ycreekoo-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (235,0);
+ref = doubledot_top;
+}
+);
+width = 607;
+}
+);
+note = uni1471;
+unicode = 5233;
+},
+{
+glyphname = "ka-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (349,370);
+},
+{
+name = top_center_can;
+pos = (407,714);
+},
+{
+name = top_left_can;
+pos = (219,714);
+},
+{
+name = top_right_can;
+pos = (595,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(463,-13,o),
+(548,157,o),
+(548,299,cs),
+(548,427,o),
+(471,509,o),
+(352,509,cs),
+(276,509,o),
+(216,471,o),
+(186,406,c),
+(201,391,l),
+(269,714,l),
+(170,714,l),
+(79,288,ls),
+(41,106,o),
+(124,-13,o),
+(282,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(211,72,o),
+(166,121,o),
+(166,203,cs),
+(166,285,o),
+(208,424,o),
+(330,424,cs),
+(406,424,o),
+(451,375,o),
+(451,294,cs),
+(451,214,o),
+(409,72,o),
+(287,72,cs)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "==|ke-canadian";
+note = uni1472;
+unicode = 5234;
+},
+{
+glyphname = "kaa-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (44,0);
+ref = dot_top;
+}
+);
+width = 607;
+}
+);
+note = uni1473;
+unicode = 5235;
+},
+{
+glyphname = "kwe-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ke-canadian";
+}
+);
+width = 839;
+}
+);
+note = uni1474;
+unicode = 5236;
+},
+{
+glyphname = "kweWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 839;
+}
+);
+note = uni1475;
+unicode = 5237;
+},
+{
+glyphname = "kwi-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ki-canadian";
+}
+);
+width = 839;
+}
+);
+note = uni1476;
+unicode = 5238;
+},
+{
+glyphname = "kwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 839;
+}
+);
+note = uni1477;
+unicode = 5239;
+},
+{
+glyphname = "kwii-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (460,0);
+ref = dot_top;
+}
+);
+width = 839;
+}
+);
+note = uni1478;
+unicode = 5240;
+},
+{
+glyphname = "kwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (227,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 839;
+}
+);
+note = uni1479;
+unicode = 5241;
+},
+{
+glyphname = "kwo-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ko-canadian";
+}
+);
+width = 839;
+}
+);
+note = uni147A;
+unicode = 5242;
+},
+{
+glyphname = "kwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 839;
+}
+);
+note = uni147B;
+unicode = 5243;
+},
+{
+glyphname = "kwoo-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (641,0);
+ref = dot_top;
+}
+);
+width = 839;
+}
+);
+note = uni147C;
+unicode = 5244;
+},
+{
+glyphname = "kwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (409,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 839;
+}
+);
+note = uni147D;
+unicode = 5245;
+},
+{
+glyphname = "kwa-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ka-canadian";
+}
+);
+width = 839;
+}
+);
+note = uni147E;
+unicode = 5246;
+},
+{
+glyphname = "kwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 839;
+}
+);
+note = uni147F;
+unicode = 5247;
+},
+{
+glyphname = "kwaa-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (276,0);
+ref = dot_top;
+}
+);
+width = 839;
+}
+);
+note = uni1480;
+unicode = 5248;
+},
+{
+glyphname = "kwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (44,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 839;
+}
+);
+note = uni1481;
+unicode = 5249;
+},
+{
+glyphname = "kwaaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ka-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni1482;
+unicode = 5250;
+},
+{
+glyphname = "k-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(329,351,o),
+(382,437,o),
+(382,515,cs),
+(382,579,o),
+(343,622,o),
+(280,622,cs),
+(235,622,o),
+(200,596,o),
+(182,557,c),
+(202,554,l),
+(236,714,l),
+(165,714,l),
+(121,507,ls),
+(105,428,o),
+(134,351,o),
+(234,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(203,404,o),
+(181,428,o),
+(181,465,cs),
+(181,511,o),
+(209,570,o),
+(261,570,cs),
+(296,570,o),
+(318,547,o),
+(318,509,cs),
+(318,463,o),
+(290,404,o),
+(238,404,cs)
+);
+}
+);
+width = 386;
+}
+);
+note = uni1483;
+unicode = 5251;
+},
+{
+glyphname = "kw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(299,351,o),
+(352,396,o),
+(370,481,cs),
+(420,714,l),
+(349,714,l),
+(314,550,l),
+(330,550,l),
+(329,591,o),
+(293,622,o),
+(244,622,cs),
+(157,622,o),
+(107,539,o),
+(107,464,cs),
+(107,396,o),
+(153,351,o),
+(225,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(192,404,o),
+(170,427,o),
+(170,465,cs),
+(170,510,o),
+(198,569,o),
+(250,569,cs),
+(285,569,o),
+(308,545,o),
+(308,508,cs),
+(308,464,o),
+(280,404,o),
+(227,404,cs)
+);
+}
+);
+width = 387;
+}
+);
+metricLeft = "=|k-canadian";
+metricRight = "=|k-canadian";
+note = uni1484;
+unicode = 5252;
+},
+{
+glyphname = "southslaveykeh-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+pos = (607,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni1485;
+unicode = 5253;
+},
+{
+glyphname = "southslaveykih-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+pos = (607,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni1486;
+unicode = 5254;
+},
+{
+glyphname = "southslaveykoh-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+pos = (607,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni1487;
+unicode = 5255;
+},
+{
+glyphname = "southslaveykah-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+pos = (607,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni1488;
+unicode = 5256;
+},
+{
+glyphname = "ce-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (347,413);
+},
+{
+name = top_center_can;
+pos = (398,714);
+},
+{
+name = top_left_can;
+pos = (210,714);
+},
+{
+name = top_right_can;
+pos = (581,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(478,0,l),
+(574,450,ls),
+(609,614,o),
+(529,727,o),
+(373,727,cs),
+(232,727,o),
+(147,645,o),
+(111,481,cs),
+(94,401,l),
+(192,401,l),
+(209,478,ls),
+(232,590,o),
+(282,640,o),
+(365,640,cs),
+(461,640,o),
+(500,571,o),
+(476,461,cs),
+(379,0,l)
+);
+}
+);
+width = 601;
+}
+);
+metricRight = "te-canadian";
+note = uni1489;
+unicode = 5257;
+},
+{
+glyphname = "caai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (179,0);
+ref = ring_top.canadian;
+}
+);
+width = 601;
+}
+);
+note = uni148A;
+unicode = 5258;
+},
+{
+glyphname = "ci-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (350,413);
+},
+{
+name = top_center_can;
+pos = (408,714);
+},
+{
+name = top_left_can;
+pos = (219,714);
+},
+{
+name = top_right_can;
+pos = (591,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(117,0,l),
+(218,478,ls),
+(242,590,o),
+(292,640,o),
+(375,640,cs),
+(472,640,o),
+(509,571,o),
+(486,461,cs),
+(474,401,l),
+(572,401,l),
+(583,450,ls),
+(619,614,o),
+(538,727,o),
+(382,727,cs),
+(241,727,o),
+(156,645,o),
+(120,481,cs),
+(18,0,l)
+);
+}
+);
+width = 601;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+unicode = 5259;
+},
+{
+glyphname = "cii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (233,0);
+ref = dot_top;
+}
+);
+width = 601;
+}
+);
+note = uni148C;
+unicode = 5260;
+},
+{
+glyphname = "co-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (347,413);
+},
+{
+name = top_center_can;
+pos = (397,714);
+},
+{
+name = top_double;
+pos = (581,714);
+},
+{
+name = top_left_can;
+pos = (210,714);
+},
+{
+name = top_right_can;
+pos = (581,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(407,-13,o),
+(492,69,o),
+(527,233,cs),
+(630,714,l),
+(531,714,l),
+(429,236,ls),
+(406,124,o),
+(356,74,o),
+(273,74,cs),
+(176,74,o),
+(139,143,o),
+(161,253,cs),
+(174,313,l),
+(75,313,l),
+(65,264,ls),
+(29,100,o),
+(110,-13,o),
+(266,-13,cs)
+);
+}
+);
+width = 601;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+unicode = 5261;
+},
+{
+glyphname = "coo-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (405,0);
+ref = dot_top;
+}
+);
+width = 601;
+}
+);
+note = uni148E;
+unicode = 5262;
+},
+{
+glyphname = "ycreecoo-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (231,0);
+ref = doubledot_top;
+}
+);
+width = 601;
+}
+);
+note = uni148F;
+unicode = 5263;
+},
+{
+glyphname = "ca-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (350,413);
+},
+{
+name = top_center_can;
+pos = (407,714);
+},
+{
+name = top_left_can;
+pos = (219,714);
+},
+{
+name = top_right_can;
+pos = (589,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(415,-13,o),
+(500,69,o),
+(535,233,cs),
+(552,313,l),
+(454,313,l),
+(438,236,ls),
+(414,124,o),
+(365,74,o),
+(282,74,cs),
+(185,74,o),
+(147,143,o),
+(170,253,cs),
+(268,714,l),
+(169,714,l),
+(73,264,ls),
+(38,100,o),
+(118,-13,o),
+(274,-13,cs)
+);
+}
+);
+width = 599;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+unicode = 5264;
+},
+{
+glyphname = "caa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (45,0);
+ref = dot_top;
+}
+);
+width = 601;
+}
+);
+note = uni1491;
+unicode = 5265;
+},
+{
+glyphname = "cwe-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ce-canadian";
+}
+);
+width = 834;
+}
+);
+note = uni1492;
+unicode = 5266;
+},
+{
+glyphname = "cweWestCree-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (601,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 834;
+}
+);
+note = uni1493;
+unicode = 5267;
+},
+{
+glyphname = "cwi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+pos = (232,0);
+ref = "ci-canadian";
+}
+);
+width = 833;
+}
+);
+note = uni1494;
+unicode = 5268;
+},
+{
+glyphname = "cwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "ci-canadian";
+},
+{
+anchor = middle_right_can;
+pos = (601,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 833;
+}
+);
+note = uni1495;
+unicode = 5269;
+},
+{
+glyphname = "cwii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+pos = (232,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (465,0);
+ref = dot_top;
+}
+);
+width = 833;
+}
+);
+note = uni1496;
+unicode = 5270;
+},
+{
+glyphname = "cwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (233,0);
+ref = dot_top;
+},
+{
+anchor = middle_right_can;
+pos = (601,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 833;
+}
+);
+note = uni1497;
+unicode = 5271;
+},
+{
+glyphname = "cwo-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "co-canadian";
+}
+);
+width = 834;
+}
+);
+note = uni1498;
+unicode = 5272;
+},
+{
+glyphname = "cwoWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (601,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 834;
+}
+);
+note = uni1499;
+unicode = 5273;
+},
+{
+glyphname = "cwoo-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (638,0);
+ref = dot_top;
+}
+);
+width = 834;
+}
+);
+note = uni149A;
+unicode = 5274;
+},
+{
+glyphname = "cwooWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (405,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (601,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 834;
+}
+);
+note = uni149B;
+unicode = 5275;
+},
+{
+glyphname = "cwa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ca-canadian";
+}
+);
+width = 834;
+}
+);
+note = uni149C;
+unicode = 5276;
+},
+{
+glyphname = "cwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (601,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 834;
+}
+);
+note = uni149D;
+unicode = 5277;
+},
+{
+glyphname = "cwaa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (277,0);
+ref = dot_top;
+}
+);
+width = 834;
+}
+);
+note = uni149E;
+unicode = 5278;
+},
+{
+glyphname = "cwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (45,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (601,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 834;
+}
+);
+note = uni149F;
+unicode = 5279;
+},
+{
+glyphname = "cwaaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ca-canadian";
+}
+);
+width = 833;
+}
+);
+note = uni14A0;
+unicode = 5280;
+},
+{
+glyphname = "c-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(309,351,o),
+(362,395,o),
+(379,474,cs),
+(385,504,l),
+(319,504,l),
+(312,472,ls),
+(302,429,o),
+(277,407,o),
+(239,407,cs),
+(195,407,o),
+(177,434,o),
+(188,485,cs),
+(236,714,l),
+(166,714,l),
+(119,496,ls),
+(101,407,o),
+(145,351,o),
+(235,351,cs)
+);
+}
+);
+width = 376;
+}
+);
+note = uni14A1;
+unicode = 5281;
+},
+{
+glyphname = "thSayisi-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(290,351,o),
+(340,395,o),
+(358,474,cs),
+(409,714,l),
+(338,714,l),
+(287,474,ls),
+(277,428,o),
+(250,407,o),
+(213,407,cs),
+(169,407,o),
+(151,436,o),
+(160,480,cs),
+(165,504,l),
+(99,504,l),
+(96,487,ls),
+(79,409,o),
+(123,351,o),
+(210,351,cs)
+);
+}
+);
+width = 376;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "=|c-canadian";
+note = uni14A2;
+unicode = 5282;
+},
+{
+glyphname = "me-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:29:07 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (228,357);
+},
+{
+name = top_center_can;
+pos = (356,714);
+},
+{
+name = top_left_can;
+pos = (190,714);
+},
+{
+name = top_right_can;
+pos = (517,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(415,0,l),
+(567,714,l),
+(141,714,l),
+(122,624,l),
+(449,624,l),
+(316.007,0,l)
+);
+}
+);
+width = 547;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+unicode = 5283;
+},
+{
+glyphname = "maai-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (163,0);
+ref = ring_top.canadian;
+}
+);
+width = 547;
+}
+);
+note = uni14A4;
+unicode = 5284;
+},
+{
+glyphname = "mi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (365,357);
+},
+{
+name = top_center_can;
+pos = (391,714);
+},
+{
+name = top_left_can;
+pos = (228,714);
+},
+{
+name = top_right_can;
+pos = (554,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(125,0,l),
+(258,624,l),
+(585,624,l),
+(604.002,714,l),
+(178,714,l),
+(26,0,l)
+);
+}
+);
+width = 547;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+unicode = 5285;
+},
+{
+glyphname = "mii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (216,0);
+ref = dot_top;
+}
+);
+width = 547;
+}
+);
+note = uni14A6;
+unicode = 5286;
+},
+{
+glyphname = "mo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:29:07 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (229,357);
+},
+{
+name = top_center_can;
+pos = (356,714);
+},
+{
+name = top_double;
+pos = (518,714);
+},
+{
+name = top_left_can;
+pos = (190,714);
+},
+{
+name = top_right_can;
+pos = (518,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(415,0,l),
+(567,714,l),
+(468.007,714,l),
+(335,90,l),
+(8,90,l),
+(-11,0,l)
+);
+}
+);
+width = 547;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+unicode = 5287;
+},
+{
+glyphname = "moo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (342,0);
+ref = dot_top;
+}
+);
+width = 547;
+}
+);
+note = uni14A8;
+unicode = 5288;
+},
+{
+glyphname = "ycreemoo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (169,0);
+ref = doubledot_top;
+}
+);
+width = 547;
+}
+);
+note = uni14A9;
+unicode = 5289;
+},
+{
+glyphname = "ma-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (365,357);
+},
+{
+name = top_center_can;
+pos = (391,714);
+},
+{
+name = top_left_can;
+pos = (228,714);
+},
+{
+name = top_right_can;
+pos = (554,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(452,0,l),
+(471,90,l),
+(144,90,l),
+(277,714,l),
+(178,714,l),
+(26,0,l)
+);
+}
+);
+width = 547;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+unicode = 5290;
+},
+{
+glyphname = "maa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (52,0);
+ref = dot_top;
+}
+);
+width = 547;
+}
+);
+note = uni14AB;
+unicode = 5291;
+},
+{
+glyphname = "mwe-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "me-canadian";
+}
+);
+width = 779;
+}
+);
+note = uni14AC;
+unicode = 5292;
+},
+{
+glyphname = "mweWestCree-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "me-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (547,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 779;
+}
+);
+note = uni14AD;
+unicode = 5293;
+},
+{
+glyphname = "mwi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "mi-canadian";
+}
+);
+width = 779;
+}
+);
+note = uni14AE;
+unicode = 5294;
+},
+{
+glyphname = "mwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (547,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 779;
+}
+);
+note = uni14AF;
+unicode = 5295;
+},
+{
+glyphname = "mwii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (448,0);
+ref = dot_top;
+}
+);
+width = 779;
+}
+);
+note = uni14B0;
+unicode = 5296;
+},
+{
+glyphname = "mwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (216,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (547,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 779;
+}
+);
+note = uni14B1;
+unicode = 5297;
+},
+{
+glyphname = "mwo-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "mo-canadian";
+}
+);
+width = 779;
+}
+);
+note = uni14B2;
+unicode = 5298;
+},
+{
+glyphname = "mwoWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (547,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 779;
+}
+);
+note = uni14B3;
+unicode = 5299;
+},
+{
+glyphname = "mwoo-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (575,0);
+ref = dot_top;
+}
+);
+width = 779;
+}
+);
+note = uni14B4;
+unicode = 5300;
+},
+{
+glyphname = "mwooWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (342,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (547,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 779;
+}
+);
+note = uni14B5;
+unicode = 5301;
+},
+{
+glyphname = "mwa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ma-canadian";
+}
+);
+width = 779;
+}
+);
+note = uni14B6;
+unicode = 5302;
+},
+{
+glyphname = "mwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (547,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 779;
+}
+);
+note = uni14B7;
+unicode = 5303;
+},
+{
+glyphname = "mwaa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (284,0);
+ref = dot_top;
+}
+);
+width = 779;
+}
+);
+note = uni14B8;
+unicode = 5304;
+},
+{
+glyphname = "mwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (52,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (547,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 779;
+}
+);
+note = uni14B9;
+unicode = 5305;
+},
+{
+glyphname = "mwaaNaskapi-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ma-canadian";
+}
+);
+width = 778;
+}
+);
+note = uni14BA;
+unicode = 5306;
+},
+{
+glyphname = "m-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(322,357,l),
+(336,423,l),
+(174,423,l),
+(236,714,l),
+(165,714,l),
+(89,357,l)
+);
+}
+);
+width = 349;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni14BB;
+unicode = 5307;
+},
+{
+glyphname = "mWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "t-canadian";
+}
+);
+width = 382;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "t-canadian";
+note = uni14BC;
+unicode = 5308;
+},
+{
+glyphname = "mh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(307,357,l),
+(383,714,l),
+(312,714,l),
+(250,423,l),
+(88,423,l),
+(73,357,l)
+);
+}
+);
+width = 350;
+}
+);
+metricLeft = "=|m-canadian";
+metricRight = "=|m-canadian";
+note = uni14BD;
+unicode = 5309;
+},
+{
+glyphname = "mAthapascan-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(337,357,l),
+(350,414,l),
+(175,414,l),
+(173,383,l),
+(310,499,ls),
+(354,536,o),
+(377,573,o),
+(377,622,cs),
+(377,680,o),
+(335,720,o),
+(268,720,cs),
+(196,720,o),
+(145,681,o),
+(129,592,c),
+(192,592,l),
+(202,645,o),
+(227,667,o),
+(263,667,cs),
+(295,667,o),
+(314,649,o),
+(314,619,cs),
+(314,584,o),
+(295,557,o),
+(253,522,cs),
+(101,392,l),
+(93,357,l)
+);
+}
+);
+width = 365;
+}
+);
+note = uni14BE;
+unicode = 5310;
+},
+{
+glyphname = "mSayisi-canadian";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = two.canadian;
+}
+);
+width = 601;
+}
+);
+note = uni14BF;
+unicode = 5311;
+},
+{
+glyphname = "ne-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (529,254);
+},
+{
+name = top_center_can;
+pos = (573,515);
+},
+{
+name = top_left_can;
+pos = (164,515);
+},
+{
+name = top_right_can;
+pos = (779,515);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(678,-13,o),
+(772,142,o),
+(772,284,cs),
+(772,412,o),
+(687,496,o),
+(547,496,cs),
+(110,496,l),
+(91,407,l),
+(431,407,l),
+(429,446,l),
+(319,406,o),
+(282,284,o),
+(282,197,cs),
+(282,71,o),
+(368,-13,o),
+(505,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(426,72,o),
+(378,123,o),
+(378,202,cs),
+(378,292,o),
+(431,411,o),
+(545,411,cs),
+(628,411,o),
+(675,360,o),
+(675,281,cs),
+(675,191,o),
+(623,72,o),
+(509,72,cs)
+);
+}
+);
+width = 834;
+}
+);
+metricRight = "=|ke-canadian";
+note = uni14C0;
+unicode = 5312;
+},
+{
+glyphname = "naai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (146,-199);
+ref = ring_top.canadian;
+}
+);
+width = 833;
+}
+);
+note = uni14C1;
+unicode = 5313;
+},
+{
+glyphname = "ni-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (306,254);
+},
+{
+name = top_center_can;
+pos = (375,515);
+},
+{
+name = top_left_can;
+pos = (167,515);
+},
+{
+name = top_right_can;
+pos = (784,515);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(456,-13,o),
+(550,142,o),
+(550,284,cs),
+(550,344,o),
+(524,393,o),
+(486,418,c),
+(469,407,l),
+(811,407,l),
+(830,496,l),
+(333,496,ls),
+(152,496,o),
+(59,342,o),
+(59,199,cs),
+(59,71,o),
+(146,-13,o),
+(283,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(204,72,o),
+(156,123,o),
+(156,202,cs),
+(156,292,o),
+(209,411,o),
+(323,411,cs),
+(406,411,o),
+(453,360,o),
+(453,281,cs),
+(453,191,o),
+(401,72,o),
+(287,72,cs)
+);
+}
+);
+width = 834;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+unicode = 5314;
+},
+{
+glyphname = "nii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (199,-199);
+ref = dot_top;
+}
+);
+width = 833;
+}
+);
+note = uni14C3;
+unicode = 5315;
+},
+{
+glyphname = "no-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (530,254);
+},
+{
+name = top_center_can;
+pos = (583,515);
+},
+{
+name = top_double;
+pos = (586,515);
+},
+{
+name = top_left_can;
+pos = (164,515);
+},
+{
+name = top_right_can;
+pos = (781,515);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(501,0,ls),
+(682,0,o),
+(775,153,o),
+(775,297,cs),
+(775,425,o),
+(688,509,o),
+(551,509,cs),
+(378,509,o),
+(284,354,o),
+(284,211,cs),
+(284,152,o),
+(310,103,o),
+(348,78,c),
+(365,89,l),
+(23,89,l),
+(4,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(428,85,o),
+(381,136,o),
+(381,215,cs),
+(381,305,o),
+(433,424,o),
+(547,424,cs),
+(630,424,o),
+(678,373,o),
+(678,294,cs),
+(678,204,o),
+(625,85,o),
+(511,85,cs)
+);
+}
+);
+width = 834;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14C4;
+unicode = 5316;
+},
+{
+glyphname = "noo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (408,-199);
+ref = dot_top;
+}
+);
+width = 833;
+}
+);
+note = uni14C5;
+unicode = 5317;
+},
+{
+glyphname = "ycreenoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (237,-199);
+ref = doubledot_top;
+}
+);
+width = 833;
+}
+);
+note = uni14C6;
+unicode = 5318;
+},
+{
+glyphname = "na-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (307,254);
+},
+{
+name = top_center_can;
+pos = (364,515);
+},
+{
+name = top_double;
+pos = (526,515);
+},
+{
+name = top_left_can;
+pos = (167,515);
+},
+{
+name = top_right_can;
+pos = (784,515);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(724,0,l),
+(743,89,l),
+(403,89,l),
+(405,50,l),
+(515,90,o),
+(552,212,o),
+(552,298,cs),
+(552,425,o),
+(466,509,o),
+(329,509,cs),
+(156,509,o),
+(62,354,o),
+(62,212,cs),
+(62,84,o),
+(147,0,o),
+(287,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(206,85,o),
+(159,136,o),
+(159,215,cs),
+(159,305,o),
+(211,424,o),
+(325,424,cs),
+(408,424,o),
+(456,373,o),
+(456,294,cs),
+(456,204,o),
+(403,85,o),
+(289,85,cs)
+);
+}
+);
+width = 834;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+unicode = 5319;
+},
+{
+glyphname = "naa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (188,-199);
+ref = dot_top;
+}
+);
+width = 833;
+}
+);
+note = uni14C8;
+unicode = 5320;
+},
+{
+glyphname = "nwe-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ne-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni14C9;
+unicode = 5321;
+},
+{
+glyphname = "nweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (833,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni14CA;
+unicode = 5322;
+},
+{
+glyphname = "nwa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "na-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni14CB;
+unicode = 5323;
+},
+{
+glyphname = "nwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (833,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni14CC;
+unicode = 5324;
+},
+{
+glyphname = "nwaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (420,-199);
+ref = dot_top;
+}
+);
+width = 1065;
+}
+);
+note = uni14CD;
+unicode = 5325;
+},
+{
+glyphname = "nwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (188,-199);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (833,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni14CE;
+unicode = 5326;
+},
+{
+glyphname = "nwaaNaskapi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (175,-199);
+ref = doubledot_top;
+}
+);
+width = 833;
+}
+);
+note = uni14CF;
+unicode = 5327;
+},
+{
+glyphname = "n-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(489,450,l),
+(504,515,l),
+(321,515,l),
+(316,475,l),
+(370,495,o),
+(392,562,o),
+(392,606,cs),
+(392,675,o),
+(345,721,o),
+(272,721,cs),
+(182,721,o),
+(129,645,o),
+(129,566,cs),
+(129,496,o),
+(175,450,o),
+(248,450,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(213,502,o),
+(191,527,o),
+(191,565,cs),
+(191,605,o),
+(213,668,o),
+(271,668,cs),
+(308,668,o),
+(330,643,o),
+(330,606,cs),
+(330,566,o),
+(308,502,o),
+(250,502,cs)
+);
+}
+);
+width = 496;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni14D0;
+unicode = 5328;
+},
+{
+color = 6;
+glyphname = "ngCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-35,-167);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 440;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "=|";
+note = uni14D1;
+unicode = 5329;
+},
+{
+glyphname = "nh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(363,450,ls),
+(458,450,o),
+(510,525,o),
+(510,606,cs),
+(510,674,o),
+(464,721,o),
+(391,721,cs),
+(301,721,o),
+(248,645,o),
+(248,566,cs),
+(248,529,o),
+(266,501,o),
+(284,488,c),
+(294,515,l),
+(106,515,l),
+(92,450,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(332,502,o),
+(310,527,o),
+(310,565,cs),
+(310,605,o),
+(332,668,o),
+(389,668,cs),
+(426,668,o),
+(448,643,o),
+(448,606,cs),
+(448,566,o),
+(426,502,o),
+(369,502,cs)
+);
+}
+);
+width = 495;
+}
+);
+metricLeft = "=|n-canadian";
+metricRight = "=|n-canadian";
+note = uni14D2;
+unicode = 5330;
+},
+{
+glyphname = "le-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (529,254);
+},
+{
+name = top_center_can;
+pos = (574,515);
+},
+{
+name = top_left_can;
+pos = (164,515);
+},
+{
+name = top_right_can;
+pos = (780,515);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(461,0,ls),
+(682,0,o),
+(773,142,o),
+(773,291,cs),
+(773,416,o),
+(690,496,o),
+(552,496,cs),
+(110,496,l),
+(91,406,l),
+(534,406,ls),
+(625,406,o),
+(674,361,o),
+(674,283,cs),
+(674,189,o),
+(623,88,o),
+(472,88,cs),
+(424,88,l),
+(405,0,l)
+);
+}
+);
+width = 834;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D3;
+unicode = 5331;
+},
+{
+glyphname = "laai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (147,-199);
+ref = ring_top.canadian;
+}
+);
+width = 833;
+}
+);
+note = uni14D4;
+unicode = 5332;
+},
+{
+glyphname = "li-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (308,254);
+},
+{
+name = top_center_can;
+pos = (376,515);
+},
+{
+name = top_left_can;
+pos = (169,515);
+},
+{
+name = top_right_can;
+pos = (784,515);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(324,0,l),
+(343,88,l),
+(298,88,ls),
+(209,88,o),
+(159,134,o),
+(159,212,cs),
+(159,304,o),
+(211,406,o),
+(362,406,cs),
+(811,406,l),
+(829,496,l),
+(371,496,ls),
+(157,496,o),
+(61,360,o),
+(61,209,cs),
+(61,85,o),
+(145,0,o),
+(278,0,cs)
+);
+}
+);
+width = 834;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14D5;
+unicode = 5333;
+},
+{
+glyphname = "lii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (200,-199);
+ref = dot_top;
+}
+);
+width = 833;
+}
+);
+note = uni14D6;
+unicode = 5334;
+},
+{
+glyphname = "lo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (528,254);
+},
+{
+name = top_center_can;
+pos = (581,515);
+},
+{
+name = top_double;
+pos = (569,515);
+},
+{
+name = top_left_can;
+pos = (162,515);
+},
+{
+name = top_right_can;
+pos = (778,515);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(462,0,ls),
+(676,0,o),
+(772,136,o),
+(772,287,cs),
+(772,411,o),
+(688,496,o),
+(555,496,cs),
+(509,496,l),
+(490,408,l),
+(535,408,ls),
+(624,408,o),
+(674,362,o),
+(674,284,cs),
+(674,192,o),
+(622,90,o),
+(471,90,cs),
+(23,90,l),
+(4,0,l)
+);
+}
+);
+width = 833;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D7;
+unicode = 5335;
+},
+{
+glyphname = "loo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (406,-199);
+ref = dot_top;
+}
+);
+width = 833;
+}
+);
+note = uni14D8;
+unicode = 5336;
+},
+{
+glyphname = "ycreeloo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (221,-199);
+ref = doubledot_top;
+}
+);
+width = 833;
+}
+);
+note = uni14D9;
+unicode = 5337;
+},
+{
+glyphname = "la-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (308,254);
+},
+{
+name = top_center_can;
+pos = (365,515);
+},
+{
+name = top_left_can;
+pos = (169,515);
+},
+{
+name = top_right_can;
+pos = (784,515);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(724,0,l),
+(743,90,l),
+(300,90,ls),
+(209,90,o),
+(161,134,o),
+(161,213,cs),
+(161,307,o),
+(211,408,o),
+(362,408,cs),
+(410,408,l),
+(429,496,l),
+(374,496,ls),
+(152,496,o),
+(61,354,o),
+(61,205,cs),
+(61,80,o),
+(144,0,o),
+(282,0,cs)
+);
+}
+);
+width = 834;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14DA;
+unicode = 5338;
+},
+{
+glyphname = "laa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (189,-199);
+ref = dot_top;
+}
+);
+width = 833;
+}
+);
+note = uni14DB;
+unicode = 5339;
+},
+{
+glyphname = "lwe-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "le-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni14DC;
+unicode = 5340;
+},
+{
+glyphname = "lweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "le-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (833,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni14DD;
+unicode = 5341;
+},
+{
+glyphname = "lwi-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "li-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni14DE;
+unicode = 5342;
+},
+{
+glyphname = "lwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (833,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni14DF;
+unicode = 5343;
+},
+{
+glyphname = "lwii-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (432,-199);
+ref = dot_top;
+}
+);
+width = 1065;
+}
+);
+note = uni14E0;
+unicode = 5344;
+},
+{
+glyphname = "lwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (200,-199);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (833,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni14E1;
+unicode = 5345;
+},
+{
+glyphname = "lwo-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "lo-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni14E2;
+unicode = 5346;
+},
+{
+glyphname = "lwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (833,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni14E3;
+unicode = 5347;
+},
+{
+glyphname = "lwoo-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (638,-199);
+ref = dot_top;
+}
+);
+width = 1065;
+}
+);
+note = uni14E4;
+unicode = 5348;
+},
+{
+glyphname = "lwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (406,-199);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (833,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni14E5;
+unicode = 5349;
+},
+{
+glyphname = "lwa-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "la-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni14E6;
+unicode = 5350;
+},
+{
+glyphname = "lwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (833,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni14E7;
+unicode = 5351;
+},
+{
+glyphname = "lwaa-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (421,-199);
+ref = dot_top;
+}
+);
+width = 1065;
+}
+);
+note = uni14E8;
+unicode = 5352;
+},
+{
+glyphname = "lwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (189,-199);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (833,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni14E9;
+unicode = 5353;
+},
+{
+glyphname = "l-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(463,357,l),
+(477,423,l),
+(281,423,ls),
+(223,423,o),
+(191,452,o),
+(191,504,cs),
+(191,568,o),
+(222,650,o),
+(325,650,cs),
+(348,650,l),
+(361,714,l),
+(332,714,ls),
+(191,714,o),
+(121,615,o),
+(121,498,cs),
+(121,410,o),
+(178,357,o),
+(276,357,cs)
+);
+}
+);
+width = 490;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "m-canadian";
+note = uni14EA;
+unicode = 5354;
+},
+{
+glyphname = "lWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(338,357,l),
+(347,400,l),
+(174,475,l),
+(166,441,l),
+(372,516,l),
+(378,547,l),
+(204,621,l),
+(197,587,l),
+(403,663,l),
+(414,714,l),
+(400,714,l),
+(146,621,l),
+(141,596,l),
+(320,523,l),
+(326,548,l),
+(115,475,l),
+(109,449,l),
+(324,357,l)
+);
+}
+);
+width = 381;
+}
+);
+metricRight = "=|";
+note = uni14EB;
+unicode = 5355;
+},
+{
+glyphname = "mediall-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(533,-13,l),
+(547,53,l),
+(165,216,l),
+(155,168,l),
+(606,330,l),
+(615,373,l),
+(232,529,l),
+(223,485,l),
+(673,647,l),
+(690,727,l),
+(664,727,l),
+(133,535,l),
+(125,496,l),
+(509,339,l),
+(517,375,l),
+(66,218,l),
+(58,179,l),
+(507,-13,l)
+);
+}
+);
+width = 661;
+}
+);
+metricRight = "=|";
+note = uni14EC;
+unicode = 5356;
+},
+{
+glyphname = "se-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (225,714);
+},
+{
+name = top_right_can;
+pos = (530,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(427,0,l),
+(500,344,l),
+(460,344,ls),
+(286,344,o),
+(213,430,o),
+(254,616,cs),
+(275,714,l),
+(175,714,l),
+(153,609,ls),
+(107,393,o),
+(216,255,o),
+(439,255,cs),
+(461,255,l),
+(389,289,l),
+(328,0,l)
+);
+}
+);
+width = 558;
+}
+);
+note = uni14ED;
+unicode = 5357;
+},
+{
+glyphname = "saai-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (304,0);
+ref = ring_top.canadian;
+}
+);
+width = 558;
+}
+);
+note = uni14EE;
+unicode = 5358;
+},
+{
+glyphname = "si-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (227,714);
+},
+{
+name = top_right_can;
+pos = (532,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(125,0,l),
+(187,291,l),
+(105,255,l),
+(148,255,ls),
+(364,255,o),
+(505,364,o),
+(557,605,cs),
+(581,714,l),
+(481,714,l),
+(460,614,ls),
+(420,435,o),
+(315,344,o),
+(152,344,cs),
+(98,344,l),
+(25,0,l)
+);
+}
+);
+width = 558;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+unicode = 5359;
+},
+{
+glyphname = "sii-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (357,0);
+ref = dot_top;
+}
+);
+width = 558;
+}
+);
+note = uni14F0;
+unicode = 5360;
+},
+{
+glyphname = "so-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (530,714);
+},
+{
+name = top_left_can;
+pos = (225,714);
+},
+{
+name = top_right_can;
+pos = (530,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(123,0,l),
+(145,100,ls),
+(184,279,o),
+(289,370,o),
+(452,370,cs),
+(506,370,l),
+(579,714,l),
+(480,714,l),
+(418,423,l),
+(499,459,l),
+(456,459,ls),
+(241,459,o),
+(99,350,o),
+(47,109,cs),
+(23,0,l)
+);
+}
+);
+width = 558;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+unicode = 5361;
+},
+{
+glyphname = "soo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (354,0);
+ref = dot_top;
+}
+);
+width = 558;
+}
+);
+note = uni14F2;
+unicode = 5362;
+},
+{
+glyphname = "ycreesoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (180,0);
+ref = doubledot_top;
+}
+);
+width = 558;
+}
+);
+note = uni14F3;
+unicode = 5363;
+},
+{
+glyphname = "sa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (227,714);
+},
+{
+name = top_right_can;
+pos = (531,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(429,0,l),
+(451,105,ls),
+(497,321,o),
+(388,459,o),
+(165,459,cs),
+(143,459,l),
+(215,425,l),
+(276,714,l),
+(177,714,l),
+(104,370,l),
+(144,370,ls),
+(317,370,o),
+(391,284,o),
+(350,98,cs),
+(329,0,l)
+);
+}
+);
+width = 558;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+unicode = 5364;
+},
+{
+glyphname = "saa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (52,0);
+ref = dot_top;
+}
+);
+width = 558;
+}
+);
+note = uni14F5;
+unicode = 5365;
+},
+{
+glyphname = "swe-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "se-canadian";
+}
+);
+width = 791;
+}
+);
+note = uni14F6;
+unicode = 5366;
+},
+{
+glyphname = "sweWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "se-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (558,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 791;
+}
+);
+note = uni14F7;
+unicode = 5367;
+},
+{
+glyphname = "swi-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "si-canadian";
+}
+);
+width = 791;
+}
+);
+note = uni14F8;
+unicode = 5368;
+},
+{
+glyphname = "swiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (558,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 791;
+}
+);
+note = uni14F9;
+unicode = 5369;
+},
+{
+glyphname = "swii-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (589,0);
+ref = dot_top;
+}
+);
+width = 791;
+}
+);
+note = uni14FA;
+unicode = 5370;
+},
+{
+glyphname = "swiiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (357,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (558,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 791;
+}
+);
+note = uni14FB;
+unicode = 5371;
+},
+{
+glyphname = "swo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "so-canadian";
+}
+);
+width = 791;
+}
+);
+note = uni14FC;
+unicode = 5372;
+},
+{
+glyphname = "swoWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (558,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 791;
+}
+);
+note = uni14FD;
+unicode = 5373;
+},
+{
+glyphname = "swoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (586,0);
+ref = dot_top;
+}
+);
+width = 791;
+}
+);
+note = uni14FE;
+unicode = 5374;
+},
+{
+glyphname = "swooWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (354,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (558,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 791;
+}
+);
+note = uni14FF;
+unicode = 5375;
+},
+{
+glyphname = "swa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "sa-canadian";
+}
+);
+width = 791;
+}
+);
+note = uni1500;
+unicode = 5376;
+},
+{
+glyphname = "swaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (558,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 791;
+}
+);
+note = uni1501;
+unicode = 5377;
+},
+{
+glyphname = "swaa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (285,0);
+ref = dot_top;
+}
+);
+width = 791;
+}
+);
+note = uni1502;
+unicode = 5378;
+},
+{
+glyphname = "swaaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (52,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (558,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 791;
+}
+);
+note = uni1503;
+unicode = 5379;
+},
+{
+glyphname = "swaaNaskapi-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "sa-canadian";
+}
+);
+width = 790;
+}
+);
+note = uni1504;
+unicode = 5380;
+},
+{
+glyphname = "s-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(326,357,l),
+(338,409,ls),
+(362,525,o),
+(304,600,o),
+(190,600,cs),
+(169,600,l),
+(205,568,l),
+(236,714,l),
+(165,714,l),
+(129,543,l),
+(165,543,ls),
+(250,543,o),
+(286,499,o),
+(268,412,cs),
+(256,357,l)
+);
+}
+);
+width = 370;
+}
+);
+metricRight = "=|";
+note = uni1505;
+unicode = 5381;
+},
+{
+color = 6;
+glyphname = "sAthapascan-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(290,183,o),
+(336,233,o),
+(336,295,cs),
+(336,335,o),
+(313,364,o),
+(272,379,cs),
+(208,401,ls),
+(183,410,o),
+(173,425,o),
+(173,444,cs),
+(173,477,o),
+(197,501,o),
+(245,501,cs),
+(290,501,o),
+(312,480,o),
+(304,439,c),
+(366,439,l),
+(378,509,o),
+(329,552,o),
+(249,552,cs),
+(156,552,o),
+(111,502,o),
+(111,439,cs),
+(111,397,o),
+(138,367,o),
+(174,354,cs),
+(238,332,ls),
+(264,322,o),
+(274,308,o),
+(274,289,cs),
+(274,256,o),
+(249,234,o),
+(202,234,cs),
+(150,234,o),
+(131,256,o),
+(138,298,c),
+(76,298,l),
+(64,228,o),
+(107,183,o),
+(199,183,cs)
+);
+}
+);
+width = 394;
+}
+);
+metricRight = "=|";
+note = uni1506;
+unicode = 5382;
+},
+{
+glyphname = "sw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(159,357,l),
+(170,409,ls),
+(190,503,o),
+(237,543,o),
+(329,543,cs),
+(365,543,l),
+(401,714,l),
+(331,714,l),
+(300,569,l),
+(350,600,l),
+(314,600,ls),
+(198,600,o),
+(126,538,o),
+(101,414,cs),
+(89,357,l)
+);
+}
+);
+width = 368;
+}
+);
+metricLeft = "=|s-canadian";
+metricRight = "=|s-canadian";
+note = uni1507;
+unicode = 5383;
+},
+{
+glyphname = "sBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(333,357,l),
+(347,423,l),
+(257,423,ls),
+(203,423,o),
+(180,450,o),
+(192,509,cs),
+(236,714,l),
+(165,714,l),
+(122,510,ls),
+(102,415,o),
+(147,357,o),
+(246,357,cs)
+);
+}
+);
+width = 360;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "m-canadian";
+note = uni1508;
+unicode = 5384;
+},
+{
+glyphname = "moosecreesk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(318,225,o),
+(362,332,o),
+(362,436,cs),
+(362,541,o),
+(311,600,o),
+(198,600,cs),
+(180,600,l),
+(206,569,l),
+(237,714,l),
+(166,714,l),
+(130,543,l),
+(179,543,ls),
+(268,543,o),
+(300,513,o),
+(296,427,c),
+(314,433,l),
+(306,468,o),
+(276,494,o),
+(226,494,cs),
+(135,494,o),
+(90,411,o),
+(90,340,cs),
+(90,271,o),
+(136,225,o),
+(209,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(173,277,o),
+(152,302,o),
+(152,340,cs),
+(152,385,o),
+(180,444,o),
+(233,444,cs),
+(269,444,o),
+(291,420,o),
+(291,383,cs),
+(291,334,o),
+(260,277,o),
+(212,277,cs)
+);
+}
+);
+width = 397;
+}
+);
+metricRight = "=|";
+note = uni1509;
+unicode = 5385;
+},
+{
+glyphname = "skwNaskapi-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(307,225,o),
+(356,309,o),
+(356,386,cs),
+(356,451,o),
+(317,494,o),
+(256,494,cs),
+(213,494,o),
+(177,470,o),
+(160,428,c),
+(177,438,l),
+(203,509,o),
+(252,543,o),
+(337,543,cs),
+(391,543,l),
+(427,714,l),
+(356,714,l),
+(325,568,l),
+(366,600,l),
+(333,600,ls),
+(159,600,o),
+(94,451,o),
+(94,347,cs),
+(94,274,o),
+(138,225,o),
+(213,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(177,277,o),
+(157,302,o),
+(157,340,cs),
+(157,385,o),
+(184,444,o),
+(236,444,cs),
+(272,444,o),
+(293,420,o),
+(293,383,cs),
+(293,334,o),
+(263,277,o),
+(215,277,cs)
+);
+}
+);
+width = 398;
+}
+);
+metricLeft = "=|moosecreesk-canadian";
+metricRight = "=|moosecreesk-canadian";
+note = uni150A;
+unicode = 5386;
+},
+{
+glyphname = "swNaskapi-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(309,189,l),
+(319,235,ls),
+(343,348,o),
+(289,420,o),
+(176,420,cs),
+(151,420,l),
+(179,388,l),
+(209,526,l),
+(138,526,l),
+(104,363,l),
+(149,363,ls),
+(233,363,o),
+(268,325,o),
+(249,237,cs),
+(239,189,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(284,43,o),
+(309,68,o),
+(309,98,cs),
+(309,128,o),
+(284,153,o),
+(254,153,cs),
+(224,153,o),
+(199,128,o),
+(199,98,cs),
+(199,68,o),
+(224,43,o),
+(254,43,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(224,561,o),
+(248,586,o),
+(248,616,cs),
+(248,647,o),
+(224,671,o),
+(193,671,cs),
+(164,671,o),
+(139,647,o),
+(139,616,cs),
+(139,586,o),
+(164,561,o),
+(193,561,cs)
+);
+}
+);
+width = 402;
+}
+);
+metricRight = "=|";
+note = uni150B;
+unicode = 5387;
+},
+{
+glyphname = "spwaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(564,0,l),
+(582,83,l),
+(174,370,l),
+(165,325,l),
+(694,611,l),
+(716,714,l),
+(689,714,l),
+(62,375,l),
+(55,339,l),
+(538,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(228,509,o),
+(252,534,o),
+(252,564,cs),
+(252,595,o),
+(227,619,o),
+(197,619,cs),
+(167,619,o),
+(142,595,o),
+(142,564,cs),
+(142,533,o),
+(167,509,o),
+(197,509,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(438,624,l),
+(447,667,ls),
+(464,749,o),
+(425,803,o),
+(346,803,cs),
+(322,803,l),
+(358,777,l),
+(380,880,l),
+(311,880,l),
+(284,750,l),
+(313,750,ls),
+(370,750,o),
+(390,722,o),
+(377,663,cs),
+(369,624,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(640,729,o),
+(664,754,o),
+(664,785,cs),
+(664,816,o),
+(640,840,o),
+(609,840,cs),
+(579,840,o),
+(554,816,o),
+(554,785,cs),
+(554,754,o),
+(579,729,o),
+(609,729,cs)
+);
+}
+);
+width = 672;
+}
+);
+metricRight = "pa-canadian";
+metricWidth = "pa-canadian";
+note = uni150C;
+unicode = 5388;
+},
+{
+glyphname = "stwaNaskapi-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (401,0);
+ref = "ta-canadian";
+}
+);
+width = 1030;
+}
+);
+note = uni150D;
+unicode = 5389;
+},
+{
+glyphname = "skwaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (401,0);
+ref = "ka-canadian";
+}
+);
+width = 1008;
+}
+);
+note = uni150E;
+unicode = 5390;
+},
+{
+glyphname = "scwaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (401,0);
+ref = "ca-canadian";
+}
+);
+width = 1003;
+}
+);
+note = uni150F;
+unicode = 5391;
+},
+{
+glyphname = "she-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (391,714);
+},
+{
+name = top_right_can;
+pos = (823,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(755,-13,o),
+(839,78,o),
+(872,237,cs),
+(888,313,l),
+(789,313,l),
+(774,239,ls),
+(750,128,o),
+(704,74,o),
+(625,74,cs),
+(539,74,o),
+(506,132,o),
+(524,252,cs),
+(555,450,ls),
+(582,629,o),
+(512,727,o),
+(364,727,cs),
+(228,727,o),
+(144,636,o),
+(111,477,cs),
+(95,401,l),
+(194,401,l),
+(210,475,ls),
+(233,586,o),
+(279,640,o),
+(358,640,cs),
+(444,640,o),
+(477,581,o),
+(459,462,cs),
+(428,265,ls),
+(401,85,o),
+(471,-13,o),
+(619,-13,cs)
+);
+}
+);
+width = 936;
+}
+);
+metricRight = "=|";
+note = uni1510;
+unicode = 5392;
+},
+{
+glyphname = "shi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (314,714);
+},
+{
+name = top_right_can;
+pos = (746,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(390,-13,o),
+(465,68,o),
+(511,244,cs),
+(569,464,ls),
+(601,587,o),
+(643,640,o),
+(722,640,cs),
+(807,640,o),
+(847,582,o),
+(820,460,cs),
+(808,401,l),
+(907,401,l),
+(916,447,ls),
+(953,619,o),
+(875,727,o),
+(726,727,cs),
+(593,727,o),
+(518,645,o),
+(472,470,cs),
+(414,250,ls),
+(382,128,o),
+(340,74,o),
+(260,74,cs),
+(176,74,o),
+(136,131,o),
+(163,254,cs),
+(175,313,l),
+(76,313,l),
+(66,267,ls),
+(30,94,o),
+(108,-13,o),
+(257,-13,cs)
+);
+}
+);
+width = 936;
+}
+);
+metricLeft = "she-canadian";
+metricRight = "she-canadian";
+note = uni1511;
+unicode = 5393;
+},
+{
+glyphname = "shii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (570,0);
+ref = dot_top;
+}
+);
+width = 937;
+}
+);
+note = uni1512;
+unicode = 5394;
+},
+{
+glyphname = "sho-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (537,515);
+},
+{
+name = top_left_can;
+pos = (345,515);
+},
+{
+name = top_right_can;
+pos = (729,515);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(317,71,l),
+(207,71,o),
+(147,110,o),
+(147,173,cs),
+(147,234,o),
+(186,284,o),
+(267,284,cs),
+(408,284,o),
+(523,125,o),
+(703,125,cs),
+(833,125,o),
+(911,210,o),
+(911,325,cs),
+(911,436,o),
+(818,508,o),
+(662,509,c),
+(645,425,l),
+(755,424,o),
+(815,386,o),
+(815,322,cs),
+(815,262,o),
+(776,212,o),
+(696,212,cs),
+(554,212,o),
+(439,371,o),
+(259,371,cs),
+(129,371,o),
+(51,285,o),
+(51,171,cs),
+(51,59,o),
+(145,-13,o),
+(300,-13,c)
+);
+}
+);
+width = 962;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1513;
+unicode = 5395;
+},
+{
+glyphname = "shoo-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (361,-199);
+ref = dot_top;
+}
+);
+width = 960;
+}
+);
+note = uni1514;
+unicode = 5396;
+},
+{
+glyphname = "sha-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (538,515);
+},
+{
+name = top_left_can;
+pos = (345,515);
+},
+{
+name = top_right_can;
+pos = (730,515);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(739,-18,o),
+(887,51,o),
+(887,211,cs),
+(887,306,o),
+(819,371,o),
+(705,371,cs),
+(544,371,o),
+(392,212,o),
+(270,212,cs),
+(208,212,o),
+(172,243,o),
+(172,293,cs),
+(172,386,o),
+(258,426,o),
+(373,425,c),
+(391,509,l),
+(223,514,o),
+(75,445,o),
+(75,285,cs),
+(75,190,o),
+(143,125,o),
+(257,125,cs),
+(418,125,o),
+(570,284,o),
+(693,284,cs),
+(755,284,o),
+(790,252,o),
+(790,203,cs),
+(790,110,o),
+(705,70,o),
+(588,71,c),
+(570,-13,l)
+);
+}
+);
+width = 962;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1515;
+unicode = 5397;
+},
+{
+glyphname = "shaa-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (361,-199);
+ref = dot_top;
+}
+);
+width = 960;
+}
+);
+note = uni1516;
+unicode = 5398;
+},
+{
+glyphname = "shwe-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "she-canadian";
+}
+);
+width = 1169;
+}
+);
+note = uni1517;
+unicode = 5399;
+},
+{
+glyphname = "shweWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "she-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (937,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1169;
+}
+);
+note = uni1518;
+unicode = 5400;
+},
+{
+glyphname = "shwi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "shi-canadian";
+}
+);
+width = 1169;
+}
+);
+note = uni1519;
+unicode = 5401;
+},
+{
+glyphname = "shwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (937,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1169;
+}
+);
+note = uni151A;
+unicode = 5402;
+},
+{
+glyphname = "shwii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (802,0);
+ref = dot_top;
+}
+);
+width = 1169;
+}
+);
+note = uni151B;
+unicode = 5403;
+},
+{
+glyphname = "shwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (570,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (937,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1169;
+}
+);
+note = uni151C;
+unicode = 5404;
+},
+{
+glyphname = "shwo-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "sho-canadian";
+}
+);
+width = 1193;
+}
+);
+note = uni151D;
+unicode = 5405;
+},
+{
+glyphname = "shwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (960,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1193;
+}
+);
+note = uni151E;
+unicode = 5406;
+},
+{
+glyphname = "shwoo-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (593,-199);
+ref = dot_top;
+}
+);
+width = 1193;
+}
+);
+note = uni151F;
+unicode = 5407;
+},
+{
+glyphname = "shwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (361,-199);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (960,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1193;
+}
+);
+note = uni1520;
+unicode = 5408;
+},
+{
+glyphname = "shwa-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "sha-canadian";
+}
+);
+width = 1193;
+}
+);
+note = uni1521;
+unicode = 5409;
+},
+{
+glyphname = "shwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (960,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1193;
+}
+);
+note = uni1522;
+unicode = 5410;
+},
+{
+glyphname = "shwaa-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (593,-199);
+ref = dot_top;
+}
+);
+width = 1193;
+}
+);
+note = uni1523;
+unicode = 5411;
+},
+{
+glyphname = "shwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (361,-199);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (960,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1193;
+}
+);
+note = uni1524;
+unicode = 5412;
+},
+{
+glyphname = "sh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(616,292,o),
+(727,352,o),
+(727,475,cs),
+(727,548,o),
+(676,599,o),
+(589,599,cs),
+(471,599,o),
+(365,489,o),
+(273,489,cs),
+(227,489,o),
+(201,513,o),
+(201,551,cs),
+(201,623,o),
+(266,662,o),
+(362,659,c),
+(375,722,l),
+(241,729,o),
+(129,670,o),
+(129,545,cs),
+(129,473,o),
+(181,422,o),
+(268,422,cs),
+(386,422,o),
+(492,532,o),
+(584,532,cs),
+(629,532,o),
+(656,508,o),
+(656,470,cs),
+(656,399,o),
+(592,359,o),
+(495,362,c),
+(483,299,l)
+);
+}
+);
+width = 745;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni1525;
+unicode = 5413;
+},
+{
+glyphname = "ye-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (686,357);
+},
+{
+name = top_left_can;
+pos = (192,714);
+},
+{
+name = top_right_can;
+pos = (563,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(459,0,l),
+(531,337,l),
+(184,337,l),
+(185,286,l),
+(613,662,l),
+(553,726,l),
+(50,280,l),
+(44,249,l),
+(413,249,l),
+(360,0,l)
+);
+}
+);
+width = 590;
+}
+);
+note = uni1526;
+unicode = 5414;
+},
+{
+glyphname = "yaai-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (3,0);
+ref = ring_top.canadian;
+}
+);
+width = 590;
+}
+);
+note = uni1527;
+unicode = 5415;
+},
+{
+glyphname = "yi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (232,714);
+},
+{
+name = top_right_can;
+pos = (602,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(125,0,l),
+(178,249,l),
+(547,249,l),
+(554,280,l),
+(227,726,l),
+(155,673,l),
+(441,288,l),
+(446,337,l),
+(97,337,l),
+(26,0,l)
+);
+}
+);
+width = 590;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni1528;
+unicode = 5416;
+},
+{
+glyphname = "yii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (56,0);
+ref = dot_top;
+}
+);
+width = 590;
+}
+);
+note = uni1529;
+unicode = 5417;
+},
+{
+glyphname = "yo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (685,357);
+},
+{
+name = top_double;
+pos = (562,714);
+},
+{
+name = top_left_can;
+pos = (192,714);
+},
+{
+name = top_right_can;
+pos = (562,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(482,41,l),
+(196,426,l),
+(191,377,l),
+(540,377,l),
+(611,714,l),
+(512,714,l),
+(459,465,l),
+(90,465,l),
+(83,434,l),
+(410,-12,l)
+);
+}
+);
+width = 590;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152A;
+unicode = 5418;
+},
+{
+glyphname = "yoo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (386,0);
+ref = dot_top;
+}
+);
+width = 590;
+}
+);
+note = uni152B;
+unicode = 5419;
+},
+{
+glyphname = "ycreeyoo-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (212,0);
+ref = doubledot_top;
+}
+);
+width = 590;
+}
+);
+note = uni152C;
+unicode = 5420;
+},
+{
+glyphname = "ya-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (227,714);
+},
+{
+name = top_right_can;
+pos = (596,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(586,434,l),
+(593,465,l),
+(223,465,l),
+(277,714,l),
+(177,714,l),
+(105,377,l),
+(453,377,l),
+(451,428,l),
+(23,52,l),
+(83,-12,l)
+);
+}
+);
+width = 590;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152D;
+unicode = 5421;
+},
+{
+glyphname = "yaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (52,0);
+ref = dot_top;
+}
+);
+width = 590;
+}
+);
+note = uni152E;
+unicode = 5422;
+},
+{
+glyphname = "ywe-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ye-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni152F;
+unicode = 5423;
+},
+{
+glyphname = "yweWestCree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ye-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (590,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni1530;
+unicode = 5424;
+},
+{
+glyphname = "ywi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "yi-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni1531;
+unicode = 5425;
+},
+{
+glyphname = "ywiWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (590,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni1532;
+unicode = 5426;
+},
+{
+glyphname = "ywii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (288,0);
+ref = dot_top;
+}
+);
+width = 822;
+}
+);
+note = uni1533;
+unicode = 5427;
+},
+{
+glyphname = "ywiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (56,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (590,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni1534;
+unicode = 5428;
+},
+{
+glyphname = "ywo-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "yo-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni1535;
+unicode = 5429;
+},
+{
+glyphname = "ywoWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (590,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni1536;
+unicode = 5430;
+},
+{
+glyphname = "ywoo-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (619,0);
+ref = dot_top;
+}
+);
+width = 822;
+}
+);
+note = uni1537;
+unicode = 5431;
+},
+{
+glyphname = "ywooWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (386,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (590,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni1538;
+unicode = 5432;
+},
+{
+glyphname = "ywa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ya-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni1539;
+unicode = 5433;
+},
+{
+glyphname = "ywaWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (590,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni153A;
+unicode = 5434;
+},
+{
+glyphname = "ywaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (284,0);
+ref = dot_top;
+}
+);
+width = 822;
+}
+);
+note = uni153B;
+unicode = 5435;
+},
+{
+glyphname = "ywaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (52,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (590,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni153C;
+unicode = 5436;
+},
+{
+glyphname = "ywaaNaskapi-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ya-canadian";
+}
+);
+width = 821;
+}
+);
+note = uni153D;
+unicode = 5437;
+},
+{
+glyphname = "y-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(384,569,l),
+(389,589,l),
+(211,589,l),
+(237,714,l),
+(167,714,l),
+(128,532,l),
+(304,532,l),
+(300,573,l),
+(98,391,l),
+(141,347,l)
+);
+}
+);
+width = 354;
+}
+);
+note = uni153E;
+unicode = 5438;
+},
+{
+glyphname = "biblecreey-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(148,357,l),
+(275,640,l),
+(236,640,l),
+(274,357,l),
+(317,357,l),
+(478,640,l),
+(434,640,l),
+(444,357,l),
+(505,357,l),
+(509,374,l),
+(499,714,l),
+(452,714,l),
+(287,422,l),
+(326,422,l),
+(287,714,l),
+(240,714,l),
+(85,374,l),
+(81,357,l)
+);
+}
+);
+width = 540;
+}
+);
+metricRight = "=|";
+note = uni153F;
+unicode = 5439;
+},
+{
+glyphname = "yWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(255,198,l),
+(284,335,l),
+(415,335,l),
+(430,402,l),
+(298,402,l),
+(327,537,l),
+(258,537,l),
+(229,402,l),
+(97,402,l),
+(83,335,l),
+(215,335,l),
+(185,198,l)
+);
+}
+);
+width = 461;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1540;
+unicode = 5440;
+},
+{
+glyphname = "yiSayisi-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (40,189);
+ref = "fullstop-canadian";
+}
+);
+width = 367;
+}
+);
+metricLeft = "fullstop-canadian";
+metricWidth = "fullstop-canadian";
+note = uni1541;
+unicode = 5441;
+},
+{
+glyphname = "re-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (367,515);
+},
+{
+name = top_left_can;
+pos = (179,515);
+},
+{
+name = top_right_can;
+pos = (829,515);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(420,-13,o),
+(508,67,o),
+(543,228,cs),
+(581,407,l),
+(857,407,l),
+(876,496,l),
+(503,496,l),
+(446,232,ls),
+(423,124,o),
+(372,73,o),
+(290,73,cs),
+(192,73,o),
+(149,133,o),
+(173,244,cs),
+(227,496,l),
+(127,496,l),
+(75,253,ls),
+(41,91,o),
+(125,-13,o),
+(284,-13,cs)
+);
+}
+);
+width = 880;
+}
+);
+metricRight = "=|ne-canadian";
+note = uni1542;
+unicode = 5442;
+},
+{
+glyphname = "reRCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (625,515);
+},
+{
+name = top_left_can;
+pos = (163,515);
+},
+{
+name = top_right_can;
+pos = (813,515);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(679,-13,o),
+(767,67,o),
+(801,228,cs),
+(859,496,l),
+(759,496,l),
+(703,232,ls),
+(680,124,o),
+(629,73,o),
+(547,73,cs),
+(449,73,o),
+(406,134,o),
+(429,244,cs),
+(483,496,l),
+(110,496,l),
+(91,407,l),
+(367,407,l),
+(334,253,ls),
+(300,91,o),
+(383,-13,o),
+(543,-13,cs)
+);
+}
+);
+width = 880;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1543;
+unicode = 5443;
+},
+{
+glyphname = "leWestCree-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (625,515);
+},
+{
+name = top_left_can;
+pos = (163,515);
+},
+{
+name = top_right_can;
+pos = (813,515);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(378,0,l),
+(434,264,ls),
+(457,371,o),
+(508,423,o),
+(590,423,cs),
+(688,423,o),
+(731,363,o),
+(707,252,cs),
+(654,0,l),
+(753,0,l),
+(805,243,ls),
+(839,405,o),
+(756,509,o),
+(596,509,cs),
+(460,509,o),
+(372,429,o),
+(338,268,cs),
+(299,89,l),
+(23,89,l),
+(4,0,l)
+);
+}
+);
+width = 880;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+unicode = 5444;
+},
+{
+glyphname = "raai-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (141,-199);
+ref = ring_top.canadian;
+}
+);
+width = 880;
+}
+);
+note = uni1545;
+unicode = 5445;
+},
+{
+glyphname = "ri-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (368,515);
+},
+{
+name = top_left_can;
+pos = (180,515);
+},
+{
+name = top_right_can;
+pos = (830,515);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(120,0,l),
+(176,264,ls),
+(199,371,o),
+(251,423,o),
+(337,423,cs),
+(431,423,o),
+(473,362,o),
+(450,252,cs),
+(396,0,l),
+(769,0,l),
+(788,89,l),
+(512,89,l),
+(545,243,ls),
+(580,405,o),
+(496,509,o),
+(342,509,cs),
+(200,509,o),
+(112,429,o),
+(78,268,cs),
+(21,0,l)
+);
+}
+);
+width = 879;
+}
+);
+metricLeft = "re-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+unicode = 5446;
+},
+{
+glyphname = "rii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (193,-199);
+ref = dot_top;
+}
+);
+width = 880;
+}
+);
+note = uni1547;
+unicode = 5447;
+},
+{
+glyphname = "ro-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (344,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(125,0,l),
+(187,293,l),
+(134,249,l),
+(256,249,ls),
+(447,249,o),
+(553,361,o),
+(553,518,cs),
+(553,636,o),
+(470,714,o),
+(337,714,cs),
+(178,714,l),
+(159,625,l),
+(322,625,ls),
+(407,625,o),
+(455,582,o),
+(455,511,cs),
+(455,408,o),
+(385,337,o),
+(266,337,cs),
+(98,337,l),
+(26,0,l)
+);
+}
+);
+width = 562;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1548;
+unicode = 5448;
+},
+{
+glyphname = "roo-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (169,0);
+ref = dot_top;
+}
+);
+width = 562;
+}
+);
+note = uni1549;
+unicode = 5449;
+},
+{
+glyphname = "loWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (364,714);
+},
+{
+name = top_left_can;
+pos = (228,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(204,0,ls),
+(395,0,o),
+(500,112,o),
+(500,268,cs),
+(500,387,o),
+(418,465,o),
+(285,465,cs),
+(179,465,l),
+(215,419,l),
+(277,714,l),
+(178,714,l),
+(106,377,l),
+(270,377,ls),
+(355,377,o),
+(403,333,o),
+(403,263,cs),
+(403,159,o),
+(332,89,o),
+(213,89,cs),
+(45,89,l),
+(26,0,l)
+);
+}
+);
+width = 562;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+unicode = 5450;
+},
+{
+glyphname = "ra-canadian";
+lastChange = "2023-01-13 15:29:07 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (415,714);
+},
+{
+name = top_right_can;
+pos = (532,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(429,0,l),
+(501,337,l),
+(338,337,ls),
+(253,337,o),
+(205,381,o),
+(205,451,cs),
+(205,555,o),
+(275,625,o),
+(394,625,cs),
+(562,625,l),
+(581,714,l),
+(404,714,ls),
+(213,714,o),
+(108,602,o),
+(108,446,cs),
+(108,327,o),
+(190,249,o),
+(323,249,cs),
+(428,249,l),
+(392,295,l),
+(330,0,l)
+);
+}
+);
+width = 561;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+unicode = 5451;
+},
+{
+glyphname = "raa-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (240,0);
+ref = dot_top;
+}
+);
+width = 562;
+}
+);
+note = uni154C;
+unicode = 5452;
+},
+{
+glyphname = "laWestCree-canadian";
+lastChange = "2023-01-13 15:29:07 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (533,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(430,0,l),
+(449,89,l),
+(285,89,ls),
+(200,89,o),
+(153,132,o),
+(153,203,cs),
+(153,306,o),
+(223,377,o),
+(342,377,cs),
+(510,377,l),
+(582,714,l),
+(483,714,l),
+(421,421,l),
+(474,465,l),
+(351,465,ls),
+(160,465,o),
+(55,353,o),
+(55,196,cs),
+(55,78,o),
+(137,0,o),
+(270,0,cs)
+);
+}
+);
+width = 562;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+unicode = 5453;
+},
+{
+glyphname = "rwaa-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (472,0);
+ref = dot_top;
+}
+);
+width = 794;
+}
+);
+note = uni154E;
+unicode = 5454;
+},
+{
+glyphname = "rwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (240,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (562,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni154F;
+unicode = 5455;
+},
+{
+glyphname = "r-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(298,357,l),
+(336,535,l),
+(255,535,ls),
+(215,535,o),
+(196,552,o),
+(196,583,cs),
+(196,630,o),
+(223,658,o),
+(280,658,cs),
+(362,658,l),
+(374,714,l),
+(292,714,ls),
+(194,714,o),
+(131,669,o),
+(131,579,cs),
+(131,519,o),
+(172,479,o),
+(243,479,cs),
+(291,479,l),
+(259,505,l),
+(227,357,l)
+);
+}
+);
+width = 341;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni1550;
+unicode = 5456;
+},
+{
+glyphname = "rWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(166,714,l),
+(157,671,l),
+(330,596,l),
+(338,630,l),
+(132,555,l),
+(125,524,l),
+(299,450,l),
+(307,484,l),
+(101,408,l),
+(90,357,l),
+(103,357,l),
+(358,450,l),
+(363,475,l),
+(184,548,l),
+(178,523,l),
+(389,596,l),
+(395,622,l),
+(179,714,l)
+);
+}
+);
+width = 382;
+}
+);
+metricLeft = "=|lWestCree-canadian";
+metricRight = "=|lWestCree-canadian";
+note = uni1551;
+unicode = 5457;
+},
+{
+glyphname = "rMedial-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(44,-13,l),
+(574,179,l),
+(582,218,l),
+(199,375,l),
+(191,339,l),
+(642,496,l),
+(650,535,l),
+(201,727,l),
+(175,727,l),
+(160,661,l),
+(542,498,l),
+(552,546,l),
+(102,384,l),
+(93,341,l),
+(475,185,l),
+(485,229,l),
+(34,67,l),
+(17,-13,l)
+);
+}
+);
+width = 661;
+}
+);
+metricLeft = "mediall-canadian";
+metricRight = "mediall-canadian";
+note = uni1552;
+unicode = 5458;
+},
+{
+glyphname = "fe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(348,0,l),
+(848,687,l),
+(854,714,l),
+(764,714,l),
+(335,111,l),
+(352,110,l),
+(264,373,l),
+(204,374,l),
+(229,344,o),
+(261,329,o),
+(304,329,cs),
+(435,329,o),
+(502,464,o),
+(502,568,cs),
+(502,662,o),
+(446,727,o),
+(347,727,cs),
+(212,727,o),
+(147,595,o),
+(147,485,cs),
+(147,445,o),
+(155,407,o),
+(172,365,cs),
+(311,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(257,399,o),
+(229,433,o),
+(229,491,cs),
+(229,549,o),
+(258,653,o),
+(343,653,cs),
+(392,653,o),
+(421,618,o),
+(421,562,cs),
+(421,503,o),
+(392,399,o),
+(307,399,cs)
+);
+}
+);
+width = 789;
+}
+);
+metricRight = "e-canadian";
+note = uni1553;
+unicode = 5459;
+},
+{
+glyphname = "faai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (248,0);
+ref = ring_top.canadian;
+}
+);
+width = 789;
+}
+);
+note = uni1554;
+unicode = 5460;
+},
+{
+glyphname = "fi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (476,714);
+},
+{
+name = top_left_can;
+pos = (235,714);
+},
+{
+name = top_right_can;
+pos = (745,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(371,-13,o),
+(429,124,o),
+(429,223,cs),
+(429,319,o),
+(372,388,o),
+(286,388,cs),
+(255,388,o),
+(225,376,o),
+(198,353,c),
+(265,350,l),
+(468,603,l),
+(442,604,l),
+(625,0,l),
+(702,0,l),
+(708,27,l),
+(495,714,l),
+(458,714,l),
+(157,354,ls),
+(106,293,o),
+(75,224,o),
+(75,148,cs),
+(75,52,o),
+(135,-13,o),
+(230,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(184,61,o),
+(156,95,o),
+(156,153,cs),
+(156,211,o),
+(185,315,o),
+(270,315,cs),
+(320,315,o),
+(348,280,o),
+(348,223,cs),
+(348,164,o),
+(319,61,o),
+(234,61,cs)
+);
+}
+);
+width = 789;
+}
+);
+metricLeft = "fe-canadian";
+metricRight = "e-canadian";
+note = uni1555;
+unicode = 5461;
+},
+{
+glyphname = "fii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (301,0);
+ref = dot_top;
+}
+);
+width = 789;
+}
+);
+note = uni1556;
+unicode = 5462;
+},
+{
+glyphname = "fo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (331,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(68,0,l),
+(693,339,l),
+(701,374,l),
+(444,662,ls),
+(406,705,o),
+(365,727,o),
+(311,727,cs),
+(180,727,o),
+(117,596,o),
+(114,495,cs),
+(111,394,o),
+(169,326,o),
+(262,326,cs),
+(384,326,o),
+(455,437,o),
+(458,548,cs),
+(459,576,o),
+(455,602,o),
+(448,624,c),
+(412,578,l),
+(602,364,l),
+(607,382,l),
+(60,88,l),
+(41,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(222,399,o),
+(194,436,o),
+(195,499,cs),
+(197,559,o),
+(226,654,o),
+(309,654,cs),
+(359,654,o),
+(388,616,o),
+(386,555,cs),
+(385,493,o),
+(356,399,o),
+(273,399,cs)
+);
+}
+);
+width = 709;
+}
+);
+metricRight = "o-canadian";
+note = uni1557;
+unicode = 5463;
+},
+{
+glyphname = "foo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "fo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (156,0);
+ref = dot_top;
+}
+);
+width = 709;
+}
+);
+note = uni1558;
+unicode = 5464;
+},
+{
+glyphname = "fa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (575,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(561,0,l),
+(577,75,l),
+(157,370,l),
+(154,349,l),
+(435,575,l),
+(416,640,l),
+(384,596,o),
+(365,532,o),
+(365,483,cs),
+(365,390,o),
+(426,324,o),
+(522,324,cs),
+(649,324,o),
+(713,461,o),
+(713,562,cs),
+(713,661,o),
+(654,727,o),
+(560,727,cs),
+(514,727,o),
+(473,711,o),
+(431,675,cs),
+(62,374,l),
+(55,339,l),
+(534,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(469,398,o),
+(441,433,o),
+(441,491,cs),
+(441,548,o),
+(470,653,o),
+(555,653,cs),
+(605,653,o),
+(634,618,o),
+(634,562,cs),
+(634,503,o),
+(605,398,o),
+(519,398,cs)
+);
+}
+);
+width = 709;
+}
+);
+metricRight = "=|fo-canadian";
+note = uni1559;
+unicode = 5465;
+},
+{
+glyphname = "faa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (400,0);
+ref = dot_top;
+}
+);
+width = 709;
+}
+);
+note = uni155A;
+unicode = 5466;
+},
+{
+glyphname = "fwaa-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (632,0);
+ref = dot_top;
+}
+);
+width = 941;
+}
+);
+note = uni155B;
+unicode = 5467;
+},
+{
+glyphname = "fwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (400,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (709,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 941;
+}
+);
+note = uni155C;
+unicode = 5468;
+},
+{
+glyphname = "f-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(373,357,l),
+(383,404,l),
+(177,547,l),
+(174,528,l),
+(309,640,l),
+(305,683,l),
+(288,664,o),
+(275,626,o),
+(275,598,cs),
+(275,552,o),
+(306,519,o),
+(351,519,cs),
+(414,519,o),
+(447,583,o),
+(447,639,cs),
+(447,690,o),
+(419,720,o),
+(374,720,cs),
+(349,720,o),
+(325,711,o),
+(300,690,cs),
+(123,545,l),
+(119,525,l),
+(357,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(330,559,o),
+(317,575,o),
+(317,601,cs),
+(317,638,o),
+(338,679,o),
+(371,679,cs),
+(392,679,o),
+(405,664,o),
+(405,638,cs),
+(405,602,o),
+(386,559,o),
+(352,559,cs)
+);
+}
+);
+width = 427;
+}
+);
+note = uni155D;
+unicode = 5469;
+},
+{
+glyphname = "the-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (867,357);
+},
+{
+name = top_center_can;
+pos = (476,714);
+},
+{
+name = top_left_can;
+pos = (221,714);
+},
+{
+name = top_right_can;
+pos = (729,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(535,-13,o),
+(640,84,o),
+(684,287,cs),
+(775,714,l),
+(675,714,l),
+(585,288,ls),
+(553,142,o),
+(482,76,o),
+(350,76,cs),
+(184,76,o),
+(152,173,o),
+(181,309,cs),
+(209,435,l),
+(168,411,l),
+(180,360,o),
+(220,318,o),
+(284,318,cs),
+(416,318,o),
+(477,450,o),
+(481,557,cs),
+(485,659,o),
+(428,727,o),
+(329,727,cs),
+(223,727,o),
+(156,654,o),
+(130,528,cs),
+(87,327,ls),
+(45,132,o),
+(116,-13,o),
+(349,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(236,392,o),
+(208,427,o),
+(208,486,cs),
+(208,544,o),
+(237,653,o),
+(323,653,cs),
+(372,653,o),
+(400,618,o),
+(400,561,cs),
+(400,501,o),
+(372,392,o),
+(285,392,cs)
+);
+}
+);
+width = 746;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155E;
+unicode = 5470;
+},
+{
+glyphname = "theNCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(537,-13,o),
+(642,86,o),
+(686,294,cs),
+(728,488,ls),
+(757,627,o),
+(703,727,o),
+(584,727,cs),
+(448,727,o),
+(384,592,o),
+(384,480,cs),
+(384,391,o),
+(431,318,o),
+(526,318,cs),
+(576,318,o),
+(619,343,o),
+(645,385,c),
+(615,418,l),
+(587,286,ls),
+(556,140,o),
+(483,75,o),
+(353,75,cs),
+(200,75,o),
+(152,161,o),
+(184,313,cs),
+(269,714,l),
+(170,714,l),
+(85,317,ls),
+(41,108,o),
+(140,-13,o),
+(347,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(493,392,o),
+(465,427,o),
+(465,486,cs),
+(465,544,o),
+(495,653,o),
+(580,653,cs),
+(629,653,o),
+(657,618,o),
+(657,561,cs),
+(657,501,o),
+(628,392,o),
+(542,392,cs)
+);
+}
+);
+width = 747;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155F;
+unicode = 5471;
+},
+{
+glyphname = "thi-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (471,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(346,-13,o),
+(410,122,o),
+(410,234,cs),
+(410,323,o),
+(362,396,o),
+(267,396,cs),
+(217,396,o),
+(174,371,o),
+(149,329,c),
+(179,296,l),
+(207,428,ls),
+(238,574,o),
+(311,639,o),
+(441,639,cs),
+(593,639,o),
+(642,553,o),
+(609,401,cs),
+(524,0,l),
+(624,0,l),
+(708,397,ls),
+(752,606,o),
+(654,727,o),
+(447,727,cs),
+(257,727,o),
+(152,628,o),
+(107,420,cs),
+(66,226,ls),
+(37,87,o),
+(90,-13,o),
+(210,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(165,61,o),
+(137,96,o),
+(137,153,cs),
+(137,213,o),
+(165,322,o),
+(251,322,cs),
+(300,322,o),
+(328,287,o),
+(328,228,cs),
+(328,170,o),
+(299,61,o),
+(214,61,cs)
+);
+}
+);
+width = 747;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1560;
+unicode = 5472;
+},
+{
+glyphname = "thiNCree-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (470,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(569,-13,o),
+(635,60,o),
+(662,186,cs),
+(705,387,ls),
+(747,582,o),
+(676,727,o),
+(443,727,cs),
+(257,727,o),
+(151,630,o),
+(108,427,cs),
+(17,0,l),
+(116,0,l),
+(207,426,ls),
+(238,572,o),
+(310,638,o),
+(442,638,cs),
+(608,638,o),
+(640,541,o),
+(610,405,cs),
+(583,279,l),
+(624,303,l),
+(612,354,o),
+(572,396,o),
+(508,396,cs),
+(376,396,o),
+(315,264,o),
+(311,157,cs),
+(307,55,o),
+(364,-13,o),
+(462,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(420,61,o),
+(391,96,o),
+(391,153,cs),
+(391,213,o),
+(420,322,o),
+(506,322,cs),
+(556,322,o),
+(584,287,o),
+(584,228,cs),
+(584,170,o),
+(554,61,o),
+(469,61,cs)
+);
+}
+);
+width = 745;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1561;
+unicode = 5473;
+},
+{
+glyphname = "thii-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "thi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (295,0);
+ref = dot_top;
+}
+);
+width = 747;
+}
+);
+note = uni1562;
+unicode = 5474;
+},
+{
+glyphname = "thiiNCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "thiNCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (295,0);
+ref = dot_top;
+}
+);
+width = 747;
+}
+);
+note = uni1563;
+unicode = 5475;
+},
+{
+glyphname = "tho-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (415,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(244,0,ls),
+(542,0,o),
+(660,229,o),
+(660,436,cs),
+(660,614,o),
+(552,727,o),
+(390,727,cs),
+(216,727,o),
+(120,601,o),
+(120,458,cs),
+(120,360,o),
+(178,295,o),
+(272,295,cs),
+(398,295,o),
+(465,422,o),
+(465,529,cs),
+(465,616,o),
+(414,674,o),
+(329,675,c),
+(319,644,l),
+(335,652,o),
+(358,657,o),
+(385,657,cs),
+(488,656,o),
+(564,577,o),
+(564,441,cs),
+(564,305,o),
+(506,90,o),
+(253,90,cs),
+(71,90,l),
+(52,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(228,369,o),
+(201,403,o),
+(201,459,cs),
+(201,517,o),
+(230,633,o),
+(317,633,cs),
+(365,633,o),
+(392,598,o),
+(392,543,cs),
+(392,486,o),
+(362,369,o),
+(276,369,cs)
+);
+}
+);
+width = 695;
+}
+);
+metricRight = "to-canadian";
+note = uni1564;
+unicode = 5476;
+},
+{
+glyphname = "thoo-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "tho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (240,0);
+ref = dot_top;
+}
+);
+width = 696;
+}
+);
+note = uni1565;
+unicode = 5477;
+},
+{
+glyphname = "tha-canadian";
+lastChange = "2023-01-13 15:29:07 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (481,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(539,0,l),
+(558,90,l),
+(387,90,ls),
+(253,90,o),
+(180,161,o),
+(180,289,cs),
+(180,421,o),
+(253,653,o),
+(452,653,cs),
+(487,653,o),
+(523,646,o),
+(550,632,c),
+(529,672,l),
+(403,684,o),
+(333,561,o),
+(333,450,cs),
+(333,358,o),
+(389,295,o),
+(482,295,cs),
+(609,295,o),
+(681,418,o),
+(681,534,cs),
+(681,653,o),
+(595,727,o),
+(455,727,cs),
+(191,727,o),
+(81,464,o),
+(81,278,cs),
+(81,106,o),
+(185,0,o),
+(366,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(438,369,o),
+(410,403,o),
+(410,459,cs),
+(410,517,o),
+(439,633,o),
+(526,633,cs),
+(574,633,o),
+(601,598,o),
+(601,543,cs),
+(601,486,o),
+(572,369,o),
+(486,369,cs)
+);
+}
+);
+width = 695;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tho-canadian";
+note = uni1566;
+unicode = 5478;
+},
+{
+glyphname = "thaa-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (306,0);
+ref = dot_top;
+}
+);
+width = 696;
+}
+);
+note = uni1567;
+unicode = 5479;
+},
+{
+glyphname = "thwaa-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (539,0);
+ref = dot_top;
+}
+);
+width = 928;
+}
+);
+note = uni1568;
+unicode = 5480;
+},
+{
+glyphname = "thwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (306,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (696,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 928;
+}
+);
+note = uni1569;
+unicode = 5481;
+},
+{
+glyphname = "th-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(351,357,l),
+(363,415,l),
+(281,415,ls),
+(216,415,o),
+(184,446,o),
+(184,504,cs),
+(184,569,o),
+(221,676,o),
+(315,676,cs),
+(330,676,o),
+(350,672,o),
+(362,666,c),
+(343,689,l),
+(275,693,o),
+(250,629,o),
+(250,584,cs),
+(250,536,o),
+(278,504,o),
+(323,504,cs),
+(391,504,o),
+(421,576,o),
+(421,625,cs),
+(421,683,o),
+(380,720,o),
+(310,720,cs),
+(179,720,o),
+(121,591,o),
+(121,498,cs),
+(121,410,o),
+(177,357,o),
+(268,357,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(302,544,o),
+(290,560,o),
+(290,585,cs),
+(290,615,o),
+(304,664,o),
+(342,664,cs),
+(365,664,o),
+(378,649,o),
+(378,624,cs),
+(378,594,o),
+(364,544,o),
+(325,544,cs)
+);
+}
+);
+width = 403;
+}
+);
+metricLeft = "t-canadian";
+note = uni156A;
+unicode = 5482;
+},
+{
+glyphname = "tthe-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (855,357);
+},
+{
+name = top_center_can;
+pos = (468,714);
+},
+{
+name = top_left_can;
+pos = (220,714);
+},
+{
+name = top_right_can;
+pos = (717,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(526,-13,o),
+(632,82,o),
+(676,289,cs),
+(766,714,l),
+(669,714,l),
+(579,290,ls),
+(547,143,o),
+(475,78,o),
+(349,78,cs),
+(206,78,o),
+(148,155,o),
+(182,311,cs),
+(267,714,l),
+(170,714,l),
+(85,317,ls),
+(41,107,o),
+(141,-13,o),
+(343,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(442,401,l),
+(509,714,l),
+(427,714,l),
+(360,401,l)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156B;
+unicode = 5483;
+},
+{
+glyphname = "tthi-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(115,0,l),
+(205,424,ls),
+(237,571,o),
+(309,636,o),
+(435,636,cs),
+(578,636,o),
+(636,559,o),
+(603,403,cs),
+(517,0,l),
+(614,0,l),
+(699,397,ls),
+(743,607,o),
+(643,727,o),
+(441,727,cs),
+(258,727,o),
+(152,632,o),
+(108,425,cs),
+(18,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(357,0,l),
+(424,313,l),
+(342,313,l),
+(275,0,l)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156C;
+unicode = 5484;
+},
+{
+glyphname = "ttho-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (410,714);
+},
+{
+name = top_left_can;
+pos = (217,714);
+},
+{
+name = top_right_can;
+pos = (635,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(192,0,ls),
+(522,0,o),
+(610,262,o),
+(610,439,cs),
+(610,612,o),
+(506,714,o),
+(321,714,cs),
+(174,714,l),
+(156,624,l),
+(307,624,ls),
+(441,624,o),
+(510,557,o),
+(510,432,cs),
+(510,294,o),
+(445,90,o),
+(202,90,cs),
+(41,90,l),
+(23,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(334,317,l),
+(351,399,l),
+(107,399,l),
+(90,317,l)
+);
+}
+);
+width = 645;
+}
+);
+metricRight = "to-canadian";
+note = uni156D;
+unicode = 5485;
+},
+{
+glyphname = "ttha-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (427,714);
+},
+{
+name = top_left_can;
+pos = (210,714);
+},
+{
+name = top_right_can;
+pos = (617,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(516,0,l),
+(535,90,l),
+(383,90,ls),
+(249,90,o),
+(181,157,o),
+(181,282,cs),
+(181,422,o),
+(248,624,o),
+(488,624,cs),
+(649,624,l),
+(668,714,l),
+(498,714,ls),
+(170,714,o),
+(81,454,o),
+(81,275,cs),
+(81,102,o),
+(184,0,o),
+(369,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(582,317,l),
+(599,399,l),
+(355,399,l),
+(338,317,l)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|ttho-canadian";
+note = uni156E;
+unicode = 5486;
+},
+{
+glyphname = "tth-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(292,494,l),
+(265,494,l),
+(334,359,l),
+(389,388,l),
+(318,528,l),
+(303,502,l),
+(470,557,l),
+(452,613,l),
+(296,561,l),
+(316,546,l),
+(351,714,l),
+(290,714,l),
+(254,546,l),
+(279,559,l),
+(135,613,l),
+(114,558,l),
+(250,507,l),
+(247,533,l),
+(123,401,l),
+(168,359,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(713,494,l),
+(685,494,l),
+(754,359,l),
+(810,388,l),
+(738,528,l),
+(723,502,l),
+(891,557,l),
+(872,613,l),
+(716,561,l),
+(736,546,l),
+(772,714,l),
+(710,714,l),
+(674,546,l),
+(699,559,l),
+(555,613,l),
+(534,558,l),
+(670,507,l),
+(667,533,l),
+(543,401,l),
+(588,359,l)
+);
+}
+);
+width = 873;
+}
+);
+metricRight = "=|";
+note = uni156F;
+unicode = 5487;
+},
+{
+glyphname = "tye-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(528,-13,o),
+(632,85,o),
+(676,289,cs),
+(766,714,l),
+(670,714,l),
+(581,299,ls),
+(549,146,o),
+(476,78,o),
+(347,78,cs),
+(205,78,o),
+(148,155,o),
+(181,311,cs),
+(267,714,l),
+(170,714,l),
+(85,317,ls),
+(41,107,o),
+(140,-13,o),
+(344,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(489,426,o),
+(532,467,o),
+(551,551,cs),
+(586,714,l),
+(534,714,l),
+(501,559,ls),
+(489,503,o),
+(464,478,o),
+(419,478,cs),
+(373,478,o),
+(358,504,o),
+(370,561,cs),
+(402,714,l),
+(350,714,l),
+(318,560,ls),
+(300,477,o),
+(338,426,o),
+(417,426,cs)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1570;
+unicode = 5488;
+},
+{
+glyphname = "tyi-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(115,0,l),
+(203,415,ls),
+(235,568,o),
+(308,636,o),
+(437,636,cs),
+(579,636,o),
+(637,559,o),
+(603,403,cs),
+(518,0,l),
+(614,0,l),
+(699,397,ls),
+(743,607,o),
+(644,727,o),
+(440,727,cs),
+(256,727,o),
+(152,629,o),
+(108,425,cs),
+(18,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(250,0,l),
+(283,155,ls),
+(295,211,o),
+(320,236,o),
+(365,236,cs),
+(411,236,o),
+(426,210,o),
+(414,153,cs),
+(382,0,l),
+(434,0,l),
+(466,154,ls),
+(484,237,o),
+(446,288,o),
+(367,288,cs),
+(296,288,o),
+(252,247,o),
+(234,163,cs),
+(199,0,l)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1571;
+unicode = 5489;
+},
+{
+glyphname = "tyo-canadian";
+lastChange = "2023-01-13 15:29:07 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(195,0,ls),
+(525,0,o),
+(614,262,o),
+(614,439,cs),
+(614,612,o),
+(509,714,o),
+(324,714,cs),
+(179,714,l),
+(160,625,l),
+(311,625,ls),
+(444,625,o),
+(515,557,o),
+(515,432,cs),
+(515,283,o),
+(438,89,o),
+(205,89,cs),
+(45,89,l),
+(27,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(169,221,ls),
+(281,221,o),
+(336,291,o),
+(338,377,cs),
+(341,449,o),
+(296,493,o),
+(218,493,cs),
+(131,493,l),
+(120,441,l),
+(205,441,ls),
+(255,441,o),
+(281,417,o),
+(280,375,cs),
+(279,323,o),
+(249,273,o),
+(174,273,cs),
+(85,273,l),
+(73,221,l)
+);
+}
+);
+width = 649;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1572;
+unicode = 5490;
+},
+{
+glyphname = "tya-canadian";
+lastChange = "2023-01-13 15:29:07 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(516,0,l),
+(534,89,l),
+(384,89,ls),
+(251,89,o),
+(180,157,o),
+(180,282,cs),
+(180,431,o),
+(257,625,o),
+(490,625,cs),
+(649,625,l),
+(667,714,l),
+(500,714,ls),
+(170,714,o),
+(81,452,o),
+(81,275,cs),
+(81,102,o),
+(186,0,o),
+(371,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(563,221,l),
+(574,273,l),
+(490,273,ls),
+(440,273,o),
+(414,297,o),
+(415,339,cs),
+(416,391,o),
+(446,441,o),
+(521,441,cs),
+(610,441,l),
+(621,493,l),
+(526,493,ls),
+(414,493,o),
+(359,423,o),
+(357,337,cs),
+(354,265,o),
+(399,221,o),
+(477,221,cs)
+);
+}
+);
+width = 648;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1573;
+unicode = 5491;
+},
+{
+glyphname = "heNunavik-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(472,0,l),
+(760,201,l),
+(710,274,l),
+(467,106,l),
+(500,80,l),
+(574,427,ls),
+(605,573,o),
+(555,727,o),
+(374,727,cs),
+(190,727,o),
+(106,557,o),
+(106,414,cs),
+(106,288,o),
+(182,205,o),
+(301,205,cs),
+(378,205,o),
+(439,244,o),
+(468,309,c),
+(448,302,l),
+(384,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(247,290,o),
+(202,339,o),
+(202,420,cs),
+(202,500,o),
+(244,642,o),
+(366,642,cs),
+(442,642,o),
+(487,593,o),
+(487,511,cs),
+(487,429,o),
+(445,290,o),
+(323,290,cs)
+);
+}
+);
+width = 797;
+}
+);
+metricLeft = "ke-canadian";
+note = uni1574;
+unicode = 5492;
+},
+{
+glyphname = "hiNunavik-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (599,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(309,0,l),
+(383,346,l),
+(369,336,l),
+(367,268,o),
+(433,205,o),
+(529,205,cs),
+(709,205,o),
+(785,383,o),
+(785,513,cs),
+(785,645,o),
+(704,727,o),
+(574,727,cs),
+(440,727,o),
+(346,643,o),
+(314,493,cs),
+(226,77,l),
+(263,87,l),
+(80,265,l),
+(17,201,l),
+(221,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(449,290,o),
+(404,339,o),
+(404,420,cs),
+(404,500,o),
+(445,642,o),
+(567,642,cs),
+(643,642,o),
+(688,593,o),
+(688,512,cs),
+(688,432,o),
+(647,290,o),
+(525,290,cs)
+);
+}
+);
+width = 799;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1575;
+unicode = 5493;
+},
+{
+glyphname = "hiiNunavik-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "hiNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (422,0);
+ref = dot_top;
+}
+);
+width = 797;
+}
+);
+note = uni1576;
+unicode = 5494;
+},
+{
+glyphname = "hoNunavik-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (398,714);
+},
+{
+name = top_right_can;
+pos = (586,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(404,-13,o),
+(498,71,o),
+(530,221,cs),
+(618,637,l),
+(581,627,l),
+(764,449,l),
+(827,513,l),
+(624,714,l),
+(535,714,l),
+(462,368,l),
+(476,378,l),
+(478,446,o),
+(412,509,o),
+(316,509,cs),
+(135,509,o),
+(60,331,o),
+(60,201,cs),
+(60,69,o),
+(140,-13,o),
+(270,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(201,72,o),
+(156,121,o),
+(156,202,cs),
+(156,282,o),
+(198,424,o),
+(320,424,cs),
+(396,424,o),
+(440,375,o),
+(440,294,cs),
+(440,214,o),
+(399,72,o),
+(277,72,cs)
+);
+}
+);
+width = 798;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "heNunavik-canadian";
+note = uni1577;
+unicode = 5495;
+},
+{
+glyphname = "hooNunavik-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "hoNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (411,0);
+ref = dot_top;
+}
+);
+width = 797;
+}
+);
+note = uni1578;
+unicode = 5496;
+},
+{
+glyphname = "haNunavik-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (598,714);
+},
+{
+name = top_left_can;
+pos = (410,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(654,-13,o),
+(738,157,o),
+(738,300,cs),
+(738,426,o),
+(661,509,o),
+(542,509,cs),
+(465,509,o),
+(404,470,o),
+(376,405,c),
+(395,412,l),
+(460,714,l),
+(371,714,l),
+(83,513,l),
+(133,440,l),
+(376,608,l),
+(343,634,l),
+(270,287,ls),
+(239,141,o),
+(289,-13,o),
+(469,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(401,72,o),
+(357,121,o),
+(357,203,cs),
+(357,285,o),
+(399,424,o),
+(520,424,cs),
+(596,424,o),
+(641,375,o),
+(641,294,cs),
+(641,214,o),
+(600,72,o),
+(478,72,cs)
+);
+}
+);
+width = 797;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1579;
+unicode = 5497;
+},
+{
+glyphname = "haaNunavik-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "haNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (235,0);
+ref = dot_top;
+}
+);
+width = 797;
+}
+);
+note = uni157A;
+unicode = 5498;
+},
+{
+glyphname = "hNunavik-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(423,351,o),
+(477,437,o),
+(477,515,cs),
+(477,578,o),
+(437,622,o),
+(376,622,cs),
+(337,622,o),
+(304,605,o),
+(287,571,c),
+(297,558,l),
+(331,714,l),
+(266,714,l),
+(120,613,l),
+(153,568,l),
+(286,661,l),
+(255,689,l),
+(216,504,ls),
+(197,418,o),
+(240,351,o),
+(328,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(297,404,o),
+(275,426,o),
+(275,465,cs),
+(275,516,o),
+(304,569,o),
+(356,569,cs),
+(391,569,o),
+(414,546,o),
+(414,508,cs),
+(414,458,o),
+(384,404,o),
+(332,404,cs)
+);
+}
+);
+width = 481;
+}
+);
+metricRight = "k-canadian";
+note = uni157B;
+unicode = 5499;
+},
+{
+color = 4;
+glyphname = "nunavuth-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(125,0,l),
+(194,326,l),
+(550,326,l),
+(481,0,l),
+(580,0,l),
+(732,714,l),
+(633,714,l),
+(569,414,l),
+(213,414,l),
+(277,714,l),
+(178,714,l),
+(26,0,l)
+);
+}
+);
+width = 712;
+}
+);
+metricRight = "=|";
+note = uni157C;
+unicode = 5500;
+},
+{
+glyphname = "hk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (76,357);
+ref = "fullstop-canadian";
+}
+);
+width = 367;
+}
+);
+metricLeft = "fullstop-canadian";
+note = uni157D;
+unicode = 5501;
+},
+{
+glyphname = "qaai-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (341,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (516,0);
+ref = ring_top.canadian;
+}
+);
+width = 948;
+}
+);
+note = uni157E;
+unicode = 5502;
+},
+{
+glyphname = "qi-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (341,0);
+ref = "ki-canadian";
+}
+);
+width = 948;
+}
+);
+note = uni157F;
+unicode = 5503;
+},
+{
+glyphname = "qii-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (341,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (569,0);
+ref = dot_top;
+}
+);
+width = 948;
+}
+);
+note = uni1580;
+unicode = 5504;
+},
+{
+glyphname = "qo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (341,0);
+ref = "ko-canadian";
+}
+);
+width = 948;
+}
+);
+note = uni1581;
+unicode = 5505;
+},
+{
+glyphname = "qoo-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (341,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (750,0);
+ref = dot_top;
+}
+);
+width = 948;
+}
+);
+note = uni1582;
+unicode = 5506;
+},
+{
+glyphname = "qa-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (341,0);
+ref = "ka-canadian";
+}
+);
+width = 948;
+}
+);
+note = uni1583;
+unicode = 5507;
+},
+{
+glyphname = "qaa-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (341,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (385,0);
+ref = dot_top;
+}
+);
+width = 948;
+}
+);
+note = uni1584;
+unicode = 5508;
+},
+{
+glyphname = "q-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (341,0);
+ref = "k-canadian";
+}
+);
+width = 727;
+}
+);
+note = uni1585;
+unicode = 5509;
+},
+{
+glyphname = "tlhe-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (408,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(147,0,l),
+(348,279,l),
+(279,241,l),
+(289,241,o),
+(301,240,o),
+(311,240,cs),
+(383,240,o),
+(443,270,o),
+(474,325,c),
+(469,351,l),
+(395,0,l),
+(493,0,l),
+(590,457,ls),
+(622,607,o),
+(549,727,o),
+(385,727,cs),
+(214,727,o),
+(117,591,o),
+(117,442,cs),
+(117,358,o),
+(160,290,o),
+(232,263,c),
+(42,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(259,326,o),
+(213,376,o),
+(213,452,cs),
+(213,538,o),
+(267,642,o),
+(376,642,cs),
+(456,642,o),
+(501,595,o),
+(501,521,cs),
+(501,432,o),
+(445,326,o),
+(335,326,cs)
+);
+}
+);
+width = 616;
+}
+);
+metricRight = "te-canadian";
+note = uni1586;
+unicode = 5510;
+},
+{
+glyphname = "tlhi-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(116,0,l),
+(196,375,l),
+(160,360,l),
+(182,293,o),
+(246,246,o),
+(330,242,c),
+(280,283,l),
+(364,0,l),
+(469,0,l),
+(395,251,l),
+(521,268,o),
+(600,398,o),
+(600,520,cs),
+(600,643,o),
+(516,727,o),
+(381,727,cs),
+(247,727,o),
+(155,646,o),
+(122,493,cs),
+(18,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(263,326,o),
+(216,372,o),
+(216,449,cs),
+(216,535,o),
+(269,642,o),
+(379,642,cs),
+(458,642,o),
+(504,595,o),
+(504,520,cs),
+(504,434,o),
+(450,326,o),
+(340,326,cs)
+);
+}
+);
+width = 617;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|tlhe-canadian";
+note = uni1587;
+unicode = 5511;
+},
+{
+glyphname = "tlho-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (424,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(416,-13,o),
+(508,68,o),
+(541,221,cs),
+(646,714,l),
+(547,714,l),
+(468,339,l),
+(504,354,l),
+(481,421,o),
+(417,468,o),
+(333,472,c),
+(384,431,l),
+(300,714,l),
+(194,714,l),
+(269,463,l),
+(143,446,o),
+(63,316,o),
+(63,194,cs),
+(63,71,o),
+(147,-13,o),
+(282,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(205,72,o),
+(160,119,o),
+(160,194,cs),
+(160,280,o),
+(213,388,o),
+(323,388,cs),
+(401,388,o),
+(447,342,o),
+(447,265,cs),
+(447,179,o),
+(394,72,o),
+(284,72,cs)
+);
+}
+);
+width = 617;
+}
+);
+metricLeft = "tlhe-canadian";
+metricRight = "te-canadian";
+note = uni1588;
+unicode = 5512;
+},
+{
+glyphname = "tlha-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(448,-13,o),
+(545,123,o),
+(545,272,cs),
+(545,356,o),
+(502,424,o),
+(430,451,c),
+(620,714,l),
+(515,714,l),
+(314,435,l),
+(383,473,l),
+(373,473,o),
+(361,474,o),
+(351,474,cs),
+(279,474,o),
+(219,444,o),
+(188,389,c),
+(193,363,l),
+(267,714,l),
+(169,714,l),
+(72,257,ls),
+(40,107,o),
+(113,-13,o),
+(277,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(206,72,o),
+(161,119,o),
+(161,193,cs),
+(161,282,o),
+(217,388,o),
+(327,388,cs),
+(403,388,o),
+(449,338,o),
+(449,262,cs),
+(449,176,o),
+(395,72,o),
+(286,72,cs)
+);
+}
+);
+width = 616;
+}
+);
+metricLeft = "te-canadian";
+note = uni1589;
+unicode = 5513;
+},
+{
+glyphname = "reWestCree-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(467,0,l),
+(755,202,l),
+(703,275,l),
+(462,107,l),
+(495,81,l),
+(573,450,ls),
+(608,614,o),
+(529,727,o),
+(373,727,cs),
+(232,727,o),
+(147,645,o),
+(111,481,cs),
+(94,401,l),
+(192,401,l),
+(209,478,ls),
+(232,590,o),
+(282,640,o),
+(365,640,cs),
+(462,640,o),
+(500,571,o),
+(476,461,cs),
+(379,0,l)
+);
+}
+);
+width = 792;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+unicode = 5514;
+},
+{
+glyphname = "riWestCree-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(308,0,l),
+(409,478,ls),
+(432,590,o),
+(482,640,o),
+(565,640,cs),
+(662,640,o),
+(701,571,o),
+(677,461,cs),
+(664,401,l),
+(763,401,l),
+(773,450,ls),
+(809,614,o),
+(728,727,o),
+(572,727,cs),
+(431,727,o),
+(347,645,o),
+(311,481,cs),
+(226,79,l),
+(265,91,l),
+(85,269,l),
+(17,202,l),
+(219,0,l)
+);
+}
+);
+width = 791;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+unicode = 5515;
+},
+{
+glyphname = "roWestCree-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(407,-13,o),
+(491,69,o),
+(527,233,cs),
+(612,635,l),
+(573,623,l),
+(753,445,l),
+(821,512,l),
+(619,714,l),
+(531,714,l),
+(429,236,ls),
+(406,124,o),
+(356,74,o),
+(273,74,cs),
+(176,74,o),
+(137,143,o),
+(161,253,cs),
+(174,313,l),
+(75,313,l),
+(65,264,ls),
+(29,100,o),
+(110,-13,o),
+(266,-13,cs)
+);
+}
+);
+width = 792;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+unicode = 5516;
+},
+{
+glyphname = "raWestCree-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(606,-13,o),
+(691,69,o),
+(727,233,cs),
+(744,313,l),
+(646,313,l),
+(629,236,ls),
+(606,124,o),
+(556,74,o),
+(473,74,cs),
+(376,74,o),
+(338,143,o),
+(362,253,cs),
+(459,714,l),
+(371,714,l),
+(83,512,l),
+(135,439,l),
+(376,607,l),
+(343,633,l),
+(265,264,ls),
+(230,100,o),
+(309,-13,o),
+(465,-13,cs)
+);
+}
+);
+width = 791;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+unicode = 5517;
+},
+{
+glyphname = "ngaai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (661,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (841,0);
+ref = ring_top.canadian;
+}
+);
+width = 1262;
+}
+);
+note = uni158E;
+unicode = 5518;
+},
+{
+glyphname = "ngi-canadian";
+kernLeft = mwestleft;
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (661,0);
+ref = "ci-canadian";
+}
+);
+width = 1262;
+}
+);
+note = uni158F;
+unicode = 5519;
+},
+{
+glyphname = "ngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (661,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (894,0);
+ref = dot_top;
+}
+);
+width = 1262;
+}
+);
+note = uni1590;
+unicode = 5520;
+},
+{
+glyphname = "ngo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (632,0);
+ref = "co-canadian";
+}
+);
+width = 1233;
+}
+);
+note = uni1591;
+unicode = 5521;
+},
+{
+glyphname = "ngoo-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "ngo-canadian";
+},
+{
+anchor = top_right_can;
+pos = (1038,0);
+ref = dot_top;
+}
+);
+width = 1233;
+}
+);
+note = uni1592;
+unicode = 5522;
+},
+{
+glyphname = "nga-canadian";
+kernLeft = mwestleft;
+kernRight = caright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (661,0);
+ref = "ca-canadian";
+}
+);
+width = 1263;
+}
+);
+note = uni1593;
+unicode = 5523;
+},
+{
+glyphname = "ngaa-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (661,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (706,0);
+ref = dot_top;
+}
+);
+width = 1263;
+}
+);
+note = uni1594;
+unicode = 5524;
+},
+{
+glyphname = "ng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(567,225,o),
+(621,271,o),
+(639,355,cs),
+(644,378,l),
+(578,378,l),
+(572,351,ls),
+(561,305,o),
+(535,281,o),
+(495,281,cs),
+(452,281,o),
+(434,309,o),
+(445,357,cs),
+(479,515,l),
+(325,515,l),
+(326,479,l),
+(369,501,o),
+(389,559,o),
+(390,602,cs),
+(392,672,o),
+(346,721,o),
+(271,721,cs),
+(183,721,o),
+(131,648,o),
+(128,571,cs),
+(126,498,o),
+(173,450,o),
+(247,450,cs),
+(414,450,l),
+(399,473,l),
+(377,370,ls),
+(359,284,o),
+(403,225,o),
+(489,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(212,502,o),
+(190,528,o),
+(191,569,cs),
+(192,609,o),
+(214,668,o),
+(270,668,cs),
+(307,668,o),
+(329,642,o),
+(328,602,cs),
+(327,561,o),
+(305,502,o),
+(249,502,cs)
+);
+}
+);
+width = 661;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1595;
+unicode = 5525;
+},
+{
+glyphname = "nng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(869,225,o),
+(920,271,o),
+(938,355,cs),
+(944,378,l),
+(877,378,l),
+(871,351,ls),
+(860,305,o),
+(834,281,o),
+(795,281,cs),
+(751,281,o),
+(734,309,o),
+(744,357,cs),
+(778,515,l),
+(631,515,l),
+(629,479,l),
+(673,502,o),
+(694,564,o),
+(694,605,cs),
+(693,675,o),
+(648,721,o),
+(574,721,cs),
+(484,721,o),
+(431,645,o),
+(431,566,cs),
+(431,532,o),
+(443,505,o),
+(463,486,c),
+(475,515,l),
+(329,515,l),
+(327,479,l),
+(371,503,o),
+(392,564,o),
+(392,605,cs),
+(392,674,o),
+(345,721,o),
+(272,721,cs),
+(182,721,o),
+(129,645,o),
+(129,566,cs),
+(129,496,o),
+(175,450,o),
+(248,450,cs),
+(694,450,l),
+(677,370,ls),
+(658,283,o),
+(705,225,o),
+(791,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(213,502,o),
+(191,527,o),
+(191,565,cs),
+(191,605,o),
+(213,668,o),
+(271,668,cs),
+(308,668,o),
+(330,643,o),
+(330,606,cs),
+(330,566,o),
+(308,502,o),
+(250,502,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(515,502,o),
+(493,527,o),
+(493,565,cs),
+(493,605,o),
+(515,668,o),
+(573,668,cs),
+(610,668,o),
+(632,643,o),
+(632,606,cs),
+(632,566,o),
+(610,502,o),
+(552,502,cs)
+);
+}
+);
+width = 961;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1596;
+unicode = 5526;
+},
+{
+glyphname = "sheSayisi-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (729,357);
+},
+{
+name = top_center_can;
+pos = (406,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(490,0,l),
+(584,443,ls),
+(618,601,o),
+(556,727,o),
+(387,727,cs),
+(183,727,o),
+(100,530,o),
+(100,384,cs),
+(100,274,o),
+(154,206,o),
+(245,206,cs),
+(338,206,o),
+(394,277,o),
+(421,426,c),
+(363,426,l),
+(345,331,o),
+(314,289,o),
+(264,289,cs),
+(220,289,o),
+(195,322,o),
+(195,382,cs),
+(195,472,o),
+(240,642,o),
+(377,642,cs),
+(485,642,o),
+(508,552,o),
+(484,441,cs),
+(391,0,l)
+);
+}
+);
+width = 613;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1597;
+unicode = 5527;
+},
+{
+glyphname = "shiSayisi-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(116,0,l),
+(217,475,ls),
+(241,586,o),
+(296,642,o),
+(380,642,cs),
+(459,642,o),
+(503,594,o),
+(503,511,cs),
+(503,444,o),
+(467,289,o),
+(381,289,cs),
+(325,289,o),
+(303,337,o),
+(325,426,c),
+(267,426,l),
+(231,295,o),
+(281,206,o),
+(387,206,cs),
+(538,206,o),
+(598,401,o),
+(598,513,cs),
+(598,645,o),
+(518,727,o),
+(383,727,cs),
+(246,727,o),
+(153,643,o),
+(121,489,cs),
+(17,0,l)
+);
+}
+);
+width = 612;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni1598;
+unicode = 5528;
+},
+{
+glyphname = "shoSayisi-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (402,714);
+},
+{
+name = top_left_can;
+pos = (210,714);
+},
+{
+name = top_right_can;
+pos = (593,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(413,-13,o),
+(505,71,o),
+(538,225,cs),
+(642,714,l),
+(542,714,l),
+(441,239,ls),
+(418,128,o),
+(363,72,o),
+(279,72,cs),
+(200,72,o),
+(156,120,o),
+(156,203,cs),
+(156,270,o),
+(192,425,o),
+(278,425,cs),
+(334,425,o),
+(356,377,o),
+(334,288,c),
+(392,288,l),
+(428,419,o),
+(378,508,o),
+(272,508,cs),
+(121,508,o),
+(61,313,o),
+(61,201,cs),
+(61,69,o),
+(141,-13,o),
+(276,-13,cs)
+);
+}
+);
+width = 613;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1599;
+unicode = 5529;
+},
+{
+glyphname = "shaSayisi-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(477,-13,o),
+(558,184,o),
+(558,330,cs),
+(558,440,o),
+(505,508,o),
+(414,508,cs),
+(321,508,o),
+(265,437,o),
+(238,288,c),
+(296,288,l),
+(314,383,o),
+(345,425,o),
+(395,425,cs),
+(439,425,o),
+(464,392,o),
+(464,332,cs),
+(464,242,o),
+(419,72,o),
+(282,72,cs),
+(174,72,o),
+(151,162,o),
+(175,273,cs),
+(268,714,l),
+(169,714,l),
+(75,271,ls),
+(41,113,o),
+(103,-13,o),
+(273,-13,cs)
+);
+}
+);
+width = 612;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni159A;
+unicode = 5530;
+},
+{
+glyphname = "theWoodScree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(691,-13,o),
+(782,146,o),
+(782,283,cs),
+(782,410,o),
+(697,496,o),
+(559,496,cs),
+(120,496,l),
+(103,414,l),
+(442,414,l),
+(437,447,l),
+(328,406,o),
+(291,286,o),
+(291,201,cs),
+(291,74,o),
+(377,-13,o),
+(511,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(437,72,o),
+(388,126,o),
+(388,206,cs),
+(388,297,o),
+(445,411,o),
+(555,411,cs),
+(636,411,o),
+(685,359,o),
+(685,279,cs),
+(685,189,o),
+(630,72,o),
+(516,72,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(852,632,l),
+(869,714,l),
+(167,714,l),
+(150,632,l)
+);
+}
+);
+width = 849;
+}
+);
+note = uni159B;
+unicode = 5531;
+},
+{
+glyphname = "thiWoodScree-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(464,-13,o),
+(556,145,o),
+(556,283,cs),
+(556,343,o),
+(532,393,o),
+(492,422,c),
+(475,414,l),
+(816,414,l),
+(833,496,l),
+(341,496,ls),
+(157,496,o),
+(65,344,o),
+(65,201,cs),
+(65,74,o),
+(151,-13,o),
+(285,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(211,72,o),
+(162,126,o),
+(162,206,cs),
+(162,297,o),
+(219,411,o),
+(330,411,cs),
+(410,411,o),
+(459,359,o),
+(459,279,cs),
+(459,189,o),
+(404,72,o),
+(290,72,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(862,632,l),
+(880,714,l),
+(178,714,l),
+(161,632,l)
+);
+}
+);
+width = 848;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159C;
+unicode = 5532;
+},
+{
+glyphname = "thoWoodScree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(508,0,ls),
+(692,0,o),
+(784,152,o),
+(784,295,cs),
+(784,422,o),
+(697,509,o),
+(563,509,cs),
+(385,509,o),
+(293,351,o),
+(293,213,cs),
+(293,152,o),
+(317,103,o),
+(357,74,c),
+(374,82,l),
+(32,82,l),
+(15,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(438,85,o),
+(389,137,o),
+(389,217,cs),
+(389,307,o),
+(445,424,o),
+(559,424,cs),
+(638,424,o),
+(687,370,o),
+(687,289,cs),
+(687,198,o),
+(630,85,o),
+(519,85,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(851,632,l),
+(869,714,l),
+(167,714,l),
+(149,632,l)
+);
+}
+);
+width = 849;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159D;
+unicode = 5533;
+},
+{
+glyphname = "thaWoodScree-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(728,0,l),
+(746,82,l),
+(406,82,l),
+(411,49,l),
+(520,90,o),
+(558,210,o),
+(558,295,cs),
+(558,421,o),
+(472,509,o),
+(338,509,cs),
+(158,509,o),
+(67,350,o),
+(67,213,cs),
+(67,86,o),
+(152,0,o),
+(290,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(213,85,o),
+(164,137,o),
+(164,217,cs),
+(164,307,o),
+(219,424,o),
+(333,424,cs),
+(412,424,o),
+(461,370,o),
+(461,289,cs),
+(461,198,o),
+(404,85,o),
+(293,85,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(862,632,l),
+(880,714,l),
+(178,714,l),
+(160,632,l)
+);
+}
+);
+width = 848;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159E;
+unicode = 5534;
+},
+{
+glyphname = "thWoodScree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(479,356,l),
+(492,417,l),
+(309,417,l),
+(305,381,l),
+(359,401,o),
+(381,468,o),
+(381,513,cs),
+(381,581,o),
+(334,628,o),
+(261,628,cs),
+(171,628,o),
+(118,551,o),
+(118,473,cs),
+(118,403,o),
+(165,356,o),
+(237,356,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(202,409,o),
+(180,434,o),
+(180,472,cs),
+(180,511,o),
+(202,575,o),
+(260,575,cs),
+(297,575,o),
+(319,550,o),
+(319,512,cs),
+(319,472,o),
+(297,409,o),
+(239,409,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(546,686,l),
+(559,747,l),
+(177,747,l),
+(164,686,l)
+);
+}
+);
+width = 522;
+}
+);
+metricRight = "=|";
+note = uni159F;
+unicode = 5535;
+},
+{
+glyphname = "lhi-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (574,714);
+},
+{
+name = top_right_can;
+pos = (674,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(324,0,l),
+(343,88,l),
+(298,88,ls),
+(209,88,o),
+(159,134,o),
+(159,212,cs),
+(159,304,o),
+(210,406,o),
+(362,406,cs),
+(811,406,l),
+(827,486,l),
+(700,754,l),
+(613,712,l),
+(735,455,l),
+(762,496,l),
+(371,496,ls),
+(157,496,o),
+(61,360,o),
+(61,209,cs),
+(61,85,o),
+(145,0,o),
+(278,0,cs)
+);
+}
+);
+width = 834;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A0;
+unicode = 5536;
+},
+{
+glyphname = "lhii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "lhi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (398,0);
+ref = dot_top;
+}
+);
+width = 833;
+}
+);
+note = uni15A1;
+unicode = 5537;
+},
+{
+glyphname = "lho-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (464,514);
+},
+{
+name = top_right_can;
+pos = (579,514);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(220,-216,l),
+(98,40,l),
+(71,0,l),
+(462,0,ls),
+(676,0,o),
+(772,135,o),
+(772,286,cs),
+(772,411,o),
+(688,496,o),
+(555,496,cs),
+(509,496,l),
+(490,408,l),
+(535,408,ls),
+(624,408,o),
+(674,361,o),
+(674,284,cs),
+(674,192,o),
+(623,89,o),
+(471,89,cs),
+(23,89,l),
+(6,10,l),
+(133,-258,l)
+);
+}
+);
+width = 834;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni15A2;
+unicode = 5538;
+},
+{
+glyphname = "lhoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "lho-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (404,-200);
+ref = dot_top;
+}
+);
+width = 833;
+}
+);
+note = uni15A3;
+unicode = 5539;
+},
+{
+glyphname = "lha-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (485,514);
+},
+{
+name = top_left_can;
+pos = (369,514);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(726,10,l),
+(743,90,l),
+(300,90,ls),
+(209,90,o),
+(161,134,o),
+(161,213,cs),
+(161,307,o),
+(211,408,o),
+(362,408,cs),
+(411,408,l),
+(429,496,l),
+(374,496,ls),
+(152,496,o),
+(61,354,o),
+(61,205,cs),
+(61,80,o),
+(144,0,o),
+(282,0,cs),
+(654,0,l),
+(633,39,l),
+(419,-199,l),
+(485,-258,l)
+);
+}
+);
+width = 834;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A4;
+unicode = 5540;
+},
+{
+glyphname = "lhaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "lha-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (193,-200);
+ref = dot_top;
+}
+);
+width = 833;
+}
+);
+note = uni15A5;
+unicode = 5541;
+},
+{
+glyphname = "lh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(481,364,l),
+(494,423,l),
+(281,423,ls),
+(223,423,o),
+(191,452,o),
+(191,504,cs),
+(191,568,o),
+(222,650,o),
+(325,650,cs),
+(348,650,l),
+(361,714,l),
+(332,714,ls),
+(191,714,o),
+(121,615,o),
+(121,498,cs),
+(121,410,o),
+(178,357,o),
+(276,357,cs),
+(440,357,l),
+(418,399,l),
+(297,262,l),
+(348,215,l)
+);
+}
+);
+width = 519;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni15A6;
+unicode = 5542;
+},
+{
+glyphname = "theThCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (192,714);
+},
+{
+name = top_right_can;
+pos = (562,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(383,106,l),
+(360,0,l),
+(459,0,l),
+(482,106,l),
+(564,106,l),
+(576,164,l),
+(494,164,l),
+(531,337,l),
+(197,337,l),
+(209,306,l),
+(613,662,l),
+(553,726,l),
+(50,280,l),
+(44,249,l),
+(413,249,l),
+(395,164,l),
+(149,164,l),
+(137,106,l)
+);
+}
+);
+width = 628;
+}
+);
+metricLeft = "ye-canadian";
+note = uni15A7;
+unicode = 5543;
+},
+{
+glyphname = "thiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (265,714);
+},
+{
+name = top_right_can;
+pos = (635,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(163,0,l),
+(186,106,l),
+(431,106,l),
+(443,164,l),
+(198,164,l),
+(216,249,l),
+(585,249,l),
+(592,280,l),
+(264,726,l),
+(193,673,l),
+(468,300,l),
+(486,337,l),
+(135,337,l),
+(98,164,l),
+(16,164,l),
+(4,106,l),
+(86,106,l),
+(63,0,l)
+);
+}
+);
+width = 628;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+unicode = 5544;
+},
+{
+glyphname = "thiiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (89,0);
+ref = dot_top;
+}
+);
+width = 628;
+}
+);
+note = uni15A9;
+unicode = 5545;
+},
+{
+glyphname = "thoThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (191,714);
+},
+{
+name = top_right_can;
+pos = (562,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(482,41,l),
+(207,414,l),
+(188,377,l),
+(539,377,l),
+(576,550,l),
+(658,550,l),
+(670,608,l),
+(588,608,l),
+(611,714,l),
+(511,714,l),
+(489,608,l),
+(243,608,l),
+(231,550,l),
+(476,550,l),
+(458,465,l),
+(90,465,l),
+(83,434,l),
+(410,-12,l)
+);
+}
+);
+width = 628;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+unicode = 5546;
+},
+{
+glyphname = "thooThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (386,0);
+ref = dot_top;
+}
+);
+width = 628;
+}
+);
+note = uni15AB;
+unicode = 5547;
+},
+{
+glyphname = "thaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (266,714);
+},
+{
+name = top_right_can;
+pos = (636,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(626,434,l),
+(632,465,l),
+(262,465,l),
+(280,550,l),
+(526,550,l),
+(538,608,l),
+(292,608,l),
+(315,714,l),
+(216,714,l),
+(193,608,l),
+(111,608,l),
+(99,550,l),
+(181,550,l),
+(144,377,l),
+(479,377,l),
+(467,408,l),
+(62,52,l),
+(122,-12,l)
+);
+}
+);
+width = 629;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+unicode = 5548;
+},
+{
+glyphname = "thaaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:29:12 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (91,0);
+ref = dot_top;
+}
+);
+width = 629;
+}
+);
+note = uni15AD;
+unicode = 5549;
+},
+{
+glyphname = "thThCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(178,635,l),
+(156,532,l),
+(329,532,l),
+(316,563,l),
+(125,391,l),
+(169,347,l),
+(412,569,l),
+(417,589,l),
+(239,589,l),
+(248,635,l),
+(365,635,l),
+(372,668,l),
+(255,668,l),
+(265,714,l),
+(195,714,l),
+(185,668,l),
+(144,668,l),
+(137,635,l)
+);
+}
+);
+width = 382;
+}
+);
+metricRight = "y-canadian";
+note = uni15AE;
+unicode = 5550;
+},
+{
+glyphname = "bAivilik-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(470,-13,o),
+(557,157,o),
+(557,299,cs),
+(557,425,o),
+(479,509,o),
+(360,509,cs),
+(285,509,o),
+(227,471,o),
+(199,413,c),
+(210,398,l),
+(277,714,l),
+(178,714,l),
+(26,0,l),
+(121,0,l),
+(147,122,l),
+(137,109,l),
+(149,34,o),
+(210,-13,o),
+(298,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(220,72,o),
+(175,121,o),
+(175,203,cs),
+(175,285,o),
+(217,424,o),
+(339,424,cs),
+(415,424,o),
+(460,375,o),
+(460,294,cs),
+(460,214,o),
+(418,72,o),
+(296,72,cs)
+);
+}
+);
+width = 616;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|ke-canadian";
+note = uni15AF;
+unicode = 5551;
+},
+{
+glyphname = "eBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(125,0,l),
+(217,431,l),
+(242,387,o),
+(289,361,o),
+(348,361,cs),
+(471,361,o),
+(544,471,o),
+(544,573,cs),
+(544,663,o),
+(484,727,o),
+(391,727,cs),
+(343,727,o),
+(298,709,o),
+(266,679,c),
+(273,714,l),
+(178,714,l),
+(26,0,l)
+);
+}
+);
+width = 524;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B0;
+unicode = 5552;
+},
+{
+glyphname = "iBlackfoot-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(226,-13,o),
+(271,5,o),
+(304,35,c),
+(297,0,l),
+(392,0,l),
+(544,714,l),
+(445,714,l),
+(353,283,l),
+(328,327,o),
+(281,353,o),
+(222,353,cs),
+(99,353,o),
+(26,243,o),
+(26,141,cs),
+(26,51,o),
+(86,-13,o),
+(179,-13,cs)
+);
+}
+);
+width = 524;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B1;
+unicode = 5553;
+},
+{
+glyphname = "oBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(391,-13,o),
+(464,93,o),
+(464,197,cs),
+(464,288,o),
+(404,353,o),
+(313,353,cs),
+(267,353,o),
+(223,336,o),
+(190,307,c),
+(277,714,l),
+(178,714,l),
+(26,0,l),
+(121,0,l),
+(135,65,l),
+(158,16,o),
+(207,-13,o),
+(270,-13,cs)
+);
+}
+);
+width = 524;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "eBlackfoot-canadian";
+note = uni15B2;
+unicode = 5554;
+},
+{
+glyphname = "aBlackfoot-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(392,0,l),
+(544,714,l),
+(448,714,l),
+(435,649,l),
+(411,698,o),
+(362,727,o),
+(300,727,cs),
+(179,727,o),
+(106,621,o),
+(106,517,cs),
+(106,426,o),
+(165,361,o),
+(256,361,cs),
+(303,361,o),
+(347,378,o),
+(379,407,c),
+(293,0,l)
+);
+}
+);
+width = 524;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B3;
+unicode = 5555;
+},
+{
+glyphname = "weBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(125,0,l),
+(192,314,l),
+(551,314,l),
+(568,398,l),
+(210,398,l),
+(259,630,l),
+(618,630,l),
+(635,714,l),
+(178,714,l),
+(26,0,l)
+);
+}
+);
+width = 597;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B4;
+unicode = 5556;
+},
+{
+glyphname = "wiBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(465,0,l),
+(617,714,l),
+(518,714,l),
+(451,400,l),
+(92,400,l),
+(75,316,l),
+(433,316,l),
+(384,84,l),
+(25,84,l),
+(8,0,l)
+);
+}
+);
+width = 597;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B5;
+unicode = 5557;
+},
+{
+glyphname = "woBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(484,0,l),
+(501,84,l),
+(143,84,l),
+(192,316,l),
+(551,316,l),
+(569,400,l),
+(210,400,l),
+(277,714,l),
+(178,714,l),
+(26,0,l)
+);
+}
+);
+width = 597;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "weBlackfoot-canadian";
+note = uni15B6;
+unicode = 5558;
+},
+{
+glyphname = "waBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(465,0,l),
+(617,714,l),
+(159,714,l),
+(142,630,l),
+(500,630,l),
+(451,398,l),
+(92,398,l),
+(74,314,l),
+(433,314,l),
+(366,0,l)
+);
+}
+);
+width = 597;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B7;
+unicode = 5559;
+},
+{
+glyphname = "neBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(125,0,l),
+(261,639,l),
+(310,639,l),
+(293,701,l),
+(288,677,ls),
+(254,521,o),
+(337,413,o),
+(493,413,cs),
+(631,413,o),
+(724,496,o),
+(756,649,cs),
+(770,714,l),
+(672,714,l),
+(659,651,ls),
+(639,550,o),
+(584,499,o),
+(499,499,cs),
+(405,499,o),
+(362,561,o),
+(383,662,cs),
+(394,714,l),
+(178,714,l),
+(26,0,l)
+);
+}
+);
+width = 711;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B8;
+unicode = 5560;
+},
+{
+glyphname = "niBlackfoot-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(85,0,l),
+(98,63,ls),
+(119,164,o),
+(174,215,o),
+(259,215,cs),
+(353,215,o),
+(396,153,o),
+(375,52,cs),
+(364,0,l),
+(580,0,l),
+(732,714,l),
+(633,714,l),
+(496,75,l),
+(447,75,l),
+(464,13,l),
+(469,37,ls),
+(503,193,o),
+(421,301,o),
+(265,301,cs),
+(127,301,o),
+(33,218,o),
+(1,65,cs),
+(-12,0,l)
+);
+}
+);
+width = 712;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B9;
+unicode = 5561;
+},
+{
+glyphname = "noBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(242,0,l),
+(255,60,ls),
+(277,164,o),
+(328,215,o),
+(413,215,cs),
+(508,215,o),
+(552,152,o),
+(531,49,cs),
+(520,0,l),
+(618,0,l),
+(626,38,ls),
+(657,195,o),
+(575,302,o),
+(420,302,cs),
+(283,302,o),
+(191,219,o),
+(155,53,cs),
+(147,14,l),
+(190,75,l),
+(141,75,l),
+(277,714,l),
+(178,714,l),
+(26,0,l)
+);
+}
+);
+width = 711;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "neBlackfoot-canadian";
+note = uni15BA;
+unicode = 5562;
+},
+{
+glyphname = "naBlackfoot-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(580,0,l),
+(732,714,l),
+(516,714,l),
+(503,654,ls),
+(481,550,o),
+(430,499,o),
+(345,499,cs),
+(250,499,o),
+(205,562,o),
+(227,665,cs),
+(237,714,l),
+(139,714,l),
+(132,676,ls),
+(100,519,o),
+(183,412,o),
+(338,412,cs),
+(475,412,o),
+(566,495,o),
+(602,661,cs),
+(610,700,l),
+(567,639,l),
+(617,639,l),
+(481,0,l)
+);
+}
+);
+width = 712;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BB;
+unicode = 5563;
+},
+{
+glyphname = "keBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(125,0,l),
+(254,603,l),
+(218,603,l),
+(327,264,l),
+(370,264,l),
+(712,714,l),
+(595,714,l),
+(346,381,l),
+(375,378,l),
+(269,714,l),
+(178,714,l),
+(26,0,l)
+);
+}
+);
+width = 635;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15BC;
+unicode = 5564;
+},
+{
+glyphname = "kiBlackfoot-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(86,0,l),
+(335,333,l),
+(305,336,l),
+(411,0,l),
+(503,0,l),
+(655,714,l),
+(556,714,l),
+(427,112,l),
+(463,112,l),
+(353,450,l),
+(310,450,l),
+(-31,0,l)
+);
+}
+);
+width = 635;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BD;
+unicode = 5565;
+},
+{
+glyphname = "koBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(118,0,l),
+(394,349,l),
+(339,355,l),
+(457,0,l),
+(560,0,l),
+(409,450,l),
+(366,450,l),
+(110,111,l),
+(149,111,l),
+(277,714,l),
+(178,714,l),
+(26,0,l)
+);
+}
+);
+width = 635;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "keBlackfoot-canadian";
+note = uni15BE;
+unicode = 5566;
+},
+{
+glyphname = "kaBlackfoot-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(503,1,l),
+(655,715,l),
+(562,715,l),
+(287,366,l),
+(342,359,l),
+(224,715,l),
+(121,715,l),
+(271,265,l),
+(315,265,l),
+(570,603,l),
+(532,603,l),
+(404,1,l)
+);
+}
+);
+width = 635;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BF;
+unicode = 5567;
+},
+{
+color = 9;
+glyphname = "heSayisi-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_right_can;
+pos = (666,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(563,0,l),
+(715,714,l),
+(617,714,l),
+(524,278,l),
+(543,277,l),
+(593,555,o),
+(518,727,o),
+(345,727,cs),
+(227,727,o),
+(146,647,o),
+(110,495,cs),
+(100,449,o),
+(94,402,o),
+(92,348,c),
+(187,348,l),
+(190,397,o),
+(195,437,o),
+(203,473,cs),
+(228,583,o),
+(280,640,o),
+(358,640,cs),
+(514,640,o),
+(552,417,o),
+(464,0,c)
+);
+}
+);
+width = 695;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni15C0;
+unicode = 5568;
+},
+{
+color = 9;
+glyphname = "hiSayisi-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(125,0,l),
+(214,417,o),
+(340,640,o),
+(486,640,cs),
+(573,640,o),
+(608,564,o),
+(580,436,cs),
+(573,403,o),
+(564,376,o),
+(553,348,c),
+(648,348,l),
+(661,381,o),
+(672,411,o),
+(678,439,cs),
+(713,613,o),
+(649,727,o),
+(515,727,cs),
+(364,727,o),
+(235,571,o),
+(173,308,c),
+(189,307,l),
+(276,714,l),
+(178,714,l),
+(26,0,l)
+);
+}
+);
+width = 694;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C1;
+unicode = 5569;
+},
+{
+color = 9;
+glyphname = "hoSayisi-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (441,714);
+},
+{
+name = top_left_can;
+pos = (216,714);
+},
+{
+name = top_right_can;
+pos = (666,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(376,-13,o),
+(505,143,o),
+(568,406,c),
+(551,407,l),
+(465,0,l),
+(563,0,l),
+(715,714,l),
+(616,714,l),
+(527,297,o),
+(401,74,o),
+(255,74,cs),
+(168,74,o),
+(133,150,o),
+(160,278,cs),
+(168,311,o),
+(177,338,o),
+(188,366,c),
+(93,366,l),
+(79,333,o),
+(69,303,o),
+(63,275,cs),
+(28,101,o),
+(92,-13,o),
+(226,-13,cs)
+);
+}
+);
+width = 695;
+}
+);
+metricLeft = "heSayisi-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15C2;
+unicode = 5570;
+},
+{
+color = 9;
+glyphname = "haSayisi-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(514,-13,o),
+(595,67,o),
+(631,219,cs),
+(641,265,o),
+(647,312,o),
+(649,366,c),
+(553,366,l),
+(551,317,o),
+(546,277,o),
+(537,241,cs),
+(513,131,o),
+(460,74,o),
+(383,74,cs),
+(227,74,o),
+(189,297,o),
+(277,714,c),
+(178,714,l),
+(26,0,l),
+(124,0,l),
+(216,436,l),
+(198,437,l),
+(147,159,o),
+(223,-13,o),
+(395,-13,cs)
+);
+}
+);
+width = 694;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C3;
+unicode = 5571;
+},
+{
+color = 9;
+glyphname = "ghuCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(337,0,l),
+(801,687,l),
+(807,714,l),
+(715,714,l),
+(561,483,l),
+(596,502,l),
+(237,502,l),
+(267,483,l),
+(214,714,l),
+(133,714,l),
+(127,687,l),
+(300,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(549,426,l),
+(537,442,l),
+(319,111,l),
+(357,105,l),
+(276,444,l),
+(256,426,l)
+);
+}
+);
+width = 742;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C4;
+unicode = 5572;
+},
+{
+color = 9;
+glyphname = "ghoCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(73,0,l),
+(228,231,l),
+(192,212,l),
+(551,212,l),
+(521,231,l),
+(574,0,l),
+(655,0,l),
+(661,27,l),
+(488,714,l),
+(451,714,l),
+(-13,27,l),
+(-19,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(528,313,l),
+(253,315,l),
+(265,273,l),
+(473,578,l),
+(416,582,l),
+(497,268,l)
+);
+}
+);
+width = 742;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C5;
+unicode = 5573;
+},
+{
+color = 9;
+glyphname = "gheCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (106,366);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(29,0,l),
+(656,338,l),
+(664,375,l),
+(181,714,l),
+(154,714,l),
+(139,641,l),
+(288,536,l),
+(282,592,l),
+(186,142,l),
+(213,195,l),
+(22,92,l),
+(2,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(349,553,l),
+(323,521,l),
+(578,340,l),
+(581,387,l),
+(257,212,l),
+(269,179,l)
+);
+}
+);
+width = 672;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15C6;
+unicode = 5574;
+},
+{
+color = 9;
+glyphname = "gheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (40,9);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 672;
+}
+);
+note = uni15C7;
+unicode = 5575;
+},
+{
+color = 9;
+glyphname = "ghiCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (16,9);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 672;
+}
+);
+note = uni15C8;
+unicode = 5576;
+},
+{
+color = 9;
+glyphname = "ghaCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(564,0,l),
+(580,73,l),
+(431,178,l),
+(437,122,l),
+(533,572,l),
+(506,519,l),
+(697,622,l),
+(716,714,l),
+(690,714,l),
+(62,376,l),
+(54,339,l),
+(537,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(396,193,l),
+(146,370,l),
+(143,330,l),
+(462,502,l),
+(448,528,l),
+(371,169,l)
+);
+}
+);
+width = 673;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15C9;
+unicode = 5577;
+},
+{
+color = 9;
+glyphname = "ruCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(337,0,l),
+(801,687,l),
+(807,714,l),
+(714,714,l),
+(649,618,l),
+(690,636,l),
+(205,636,l),
+(236,617,l),
+(213,714,l),
+(133,714,l),
+(127,687,l),
+(300,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(641,558,l),
+(624,575,l),
+(320,114,l),
+(357,108,l),
+(245,577,l),
+(223,558,l)
+);
+}
+);
+width = 742;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CA;
+unicode = 5578;
+},
+{
+color = 9;
+glyphname = "roCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(452,714,l),
+(-13,27,l),
+(-19,0,l),
+(74,0,l),
+(139,96,l),
+(98,78,l),
+(583,78,l),
+(553,97,l),
+(575,0,l),
+(655,0,l),
+(661,27,l),
+(488,714,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(148,156,l),
+(165,139,l),
+(469,600,l),
+(431,606,l),
+(543,137,l),
+(565,156,l)
+);
+}
+);
+width = 742;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CB;
+unicode = 5579;
+},
+{
+color = 9;
+glyphname = "reCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(29,0,l),
+(657,339,l),
+(664,375,l),
+(181,714,l),
+(154,714,l),
+(139,642,l),
+(214,589,l),
+(205,646,l),
+(86,87,l),
+(116,140,l),
+(22,89,l),
+(3,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(274,602,l),
+(248,569,l),
+(572,340,l),
+(574,385,l),
+(161,162,l),
+(173,131,l)
+);
+}
+);
+width = 673;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CC;
+unicode = 5580;
+},
+{
+color = 9;
+glyphname = "reeCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(29,0,l),
+(657,339,l),
+(664,375,l),
+(181,714,l),
+(154,714,l),
+(141,652,l),
+(212,602,l),
+(207,655,l),
+(84,77,l),
+(108,129,l),
+(19,80,l),
+(2,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(268,619,l),
+(239,589,l),
+(594,341,l),
+(596,386,l),
+(149,145,l),
+(161,112,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(298,278,l),
+(335,450,l),
+(290,450,l),
+(253,278,l)
+);
+}
+);
+width = 673;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CD;
+unicode = 5581;
+},
+{
+color = 9;
+glyphname = "riCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(29,0,l),
+(657,339,l),
+(664,375,l),
+(181,714,l),
+(154,714,l),
+(141,652,l),
+(212,601,l),
+(207,655,l),
+(84,77,l),
+(113,131,l),
+(19,80,l),
+(2,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(360,323,o),
+(380,341,o),
+(380,366,cs),
+(380,391,o),
+(360,410,o),
+(337,410,cs),
+(313,410,o),
+(293,391,o),
+(293,366,cs),
+(293,341,o),
+(313,323,o),
+(337,323,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(268,619,l),
+(239,589,l),
+(594,341,l),
+(596,386,l),
+(150,146,l),
+(161,112,l)
+);
+}
+);
+width = 673;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CE;
+unicode = 5582;
+},
+{
+color = 9;
+glyphname = "raCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(564,0,l),
+(580,72,l),
+(505,125,l),
+(514,68,l),
+(632,627,l),
+(603,574,l),
+(697,625,l),
+(716,714,l),
+(690,714,l),
+(62,375,l),
+(55,339,l),
+(538,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(471,145,l),
+(147,374,l),
+(145,329,l),
+(558,552,l),
+(546,583,l),
+(445,112,l)
+);
+}
+);
+width = 672;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15CF;
+unicode = 5583;
+},
+{
+color = 9;
+glyphname = "wuCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(341,0,l),
+(810,687,l),
+(816,714,l),
+(727,714,l),
+(373,177,l),
+(395,177,l),
+(509,714,l),
+(428,714,l),
+(314,176,l),
+(337,176,l),
+(208,714,l),
+(133,714,l),
+(127,687,l),
+(304,0,l)
+);
+}
+);
+width = 751;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D0;
+unicode = 5584;
+},
+{
+color = 9;
+glyphname = "woCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(71,0,l),
+(424,537,l),
+(402,537,l),
+(288,0,l),
+(369,0,l),
+(484,538,l),
+(460,538,l),
+(589,0,l),
+(664,0,l),
+(670,27,l),
+(493,714,l),
+(456,714,l),
+(-13,27,l),
+(-19,0,l)
+);
+}
+);
+width = 751;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D1;
+unicode = 5585;
+},
+{
+color = 9;
+glyphname = "weCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(50,0,l),
+(678,339,l),
+(685,375,l),
+(202,714,l),
+(175,714,l),
+(160,641,l),
+(526,386,l),
+(532,404,l),
+(110,404,l),
+(93,328,l),
+(519,328,l),
+(520,344,l),
+(43,89,l),
+(24,0,l)
+);
+}
+);
+width = 694;
+}
+);
+metricRight = "o-canadian";
+note = uni15D2;
+unicode = 5586;
+},
+{
+color = 9;
+glyphname = "weeCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(50,0,l),
+(678,339,l),
+(685,375,l),
+(202,714,l),
+(176,714,l),
+(162,649,l),
+(550,379,l),
+(557,397,l),
+(244,397,l),
+(261,478,l),
+(205,478,l),
+(188,397,l),
+(108,397,l),
+(95,335,l),
+(174,335,l),
+(157,254,l),
+(214,254,l),
+(230,335,l),
+(547,335,l),
+(545,350,l),
+(41,81,l),
+(24,0,l)
+);
+}
+);
+width = 694;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D3;
+unicode = 5587;
+},
+{
+color = 9;
+glyphname = "wiCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(50,0,l),
+(678,339,l),
+(685,375,l),
+(202,714,l),
+(176,714,l),
+(162,649,l),
+(544,384,l),
+(556,398,l),
+(311,398,l),
+(300,425,o),
+(274,445,o),
+(242,445,cs),
+(210,445,o),
+(184,425,o),
+(174,398,c),
+(108,398,l),
+(96,339,l),
+(175,339,l),
+(187,313,o),
+(212,295,o),
+(243,295,cs),
+(273,295,o),
+(298,313,o),
+(309,339,c),
+(546,339,l),
+(540,348,l),
+(41,82,l),
+(24,0,l)
+);
+}
+);
+width = 694;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D4;
+unicode = 5588;
+},
+{
+color = 9;
+glyphname = "waCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(564,0,l),
+(580,73,l),
+(214,328,l),
+(208,310,l),
+(630,310,l),
+(646,386,l),
+(221,386,l),
+(220,370,l),
+(697,625,l),
+(716,714,l),
+(690,714,l),
+(62,375,l),
+(55,339,l),
+(538,0,l)
+);
+}
+);
+width = 693;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15D5;
+unicode = 5589;
+},
+{
+color = 9;
+glyphname = "hwuCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(341,0,l),
+(810,687,l),
+(816,714,l),
+(732,714,l),
+(588,498,l),
+(615,514,l),
+(458,514,l),
+(501,714,l),
+(436,714,l),
+(393,514,l),
+(235,514,l),
+(254,502,l),
+(203,714,l),
+(133,714,l),
+(127,687,l),
+(304,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(339,138,l),
+(258,475,l),
+(247,457,l),
+(386,457,l),
+(319,137,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(440,457,l),
+(581,457,l),
+(576,474,l),
+(356,141,l),
+(372,134,l)
+);
+}
+);
+width = 751;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D6;
+unicode = 5590;
+},
+{
+color = 9;
+glyphname = "hwoCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(65,0,l),
+(209,216,l),
+(183,200,l),
+(339,200,l),
+(296,0,l),
+(361,0,l),
+(404,200,l),
+(562,200,l),
+(543,212,l),
+(594,0,l),
+(664,0,l),
+(670,27,l),
+(493,714,l),
+(456,714,l),
+(-13,27,l),
+(-19,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(441,573,l),
+(425,580,l),
+(357,257,l),
+(216,257,l),
+(221,240,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(550,257,l),
+(411,257,l),
+(478,577,l),
+(458,576,l),
+(539,239,l)
+);
+}
+);
+width = 751;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D7;
+unicode = 5591;
+},
+{
+color = 9;
+glyphname = "hweCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(50,0,l),
+(678,339,l),
+(685,375,l),
+(202,714,l),
+(175,714,l),
+(162,650,l),
+(293,559,l),
+(260,400,l),
+(109,400,l),
+(95,334,l),
+(246,334,l),
+(212,173,l),
+(41,82,l),
+(23,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(298,339,l),
+(537,339,l),
+(268,197,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(339,533,l),
+(541,394,l),
+(310,394,l)
+);
+}
+);
+width = 694;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D8;
+unicode = 5592;
+},
+{
+color = 9;
+glyphname = "hweeCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(50,0,l),
+(678,339,l),
+(685,375,l),
+(202,714,l),
+(175,714,l),
+(162,651,l),
+(314,549,l),
+(281,395,l),
+(223,395,l),
+(240,475,l),
+(192,475,l),
+(175,395,l),
+(108,395,l),
+(96,338,l),
+(163,338,l),
+(146,258,l),
+(194,258,l),
+(210,338,l),
+(269,338,l),
+(236,182,l),
+(41,81,l),
+(23,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(316,342,l),
+(543,342,l),
+(288,206,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(355,524,l),
+(548,390,l),
+(327,390,l)
+);
+}
+);
+width = 694;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D9;
+unicode = 5593;
+},
+{
+color = 9;
+glyphname = "hwiCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(50,0,l),
+(678,339,l),
+(685,375,l),
+(202,714,l),
+(175,714,l),
+(162,651,l),
+(314,549,l),
+(280,390,l),
+(248,390,l),
+(240,414,o),
+(217,430,o),
+(191,430,cs),
+(165,430,o),
+(145,413,o),
+(136,390,c),
+(107,390,l),
+(96,342,l),
+(135,342,l),
+(144,319,o),
+(166,302,o),
+(191,302,cs),
+(217,302,o),
+(239,319,o),
+(247,342,c),
+(270,342,l),
+(236,182,l),
+(41,81,l),
+(23,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(317,342,l),
+(543,342,l),
+(288,206,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(355,524,l),
+(548,390,l),
+(327,390,l)
+);
+}
+);
+width = 694;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15DA;
+unicode = 5594;
+},
+{
+color = 9;
+glyphname = "hwaCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(689.993,714,l),
+(62,375,l),
+(55,339,l),
+(537.993,0,l),
+(564,0,l),
+(578,64,l),
+(446,155,l),
+(480,314,l),
+(631,314,l),
+(645,380,l),
+(494,380,l),
+(528,541,l),
+(699,632,l),
+(716,714,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(442,375,l),
+(203,375,l),
+(472,517,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(401,181,l),
+(199,320,l),
+(430,320,l)
+);
+}
+);
+width = 693;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15DB;
+unicode = 5595;
+},
+{
+color = 9;
+glyphname = "thuCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(527,-13,o),
+(632,85,o),
+(675,287,cs),
+(766,714,l),
+(170,714,l),
+(85,317,ls),
+(41,107,o),
+(141,-13,o),
+(342,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(251,626,l),
+(648,626,l),
+(577,290,ls),
+(545,144,o),
+(474,78,o),
+(350,78,cs),
+(207,78,o),
+(150,155,o),
+(184,311,cs)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DC;
+unicode = 5596;
+},
+{
+color = 9;
+glyphname = "thoCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(613,0,l),
+(698,397,ls),
+(742,607,o),
+(642,727,o),
+(441,727,cs),
+(256,727,o),
+(151,629,o),
+(108,427,cs),
+(17,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(207,424,ls),
+(238,570,o),
+(310,636,o),
+(433,636,cs),
+(576,636,o),
+(633,559,o),
+(599,403,cs),
+(532,88,l),
+(135,88,l)
+);
+}
+);
+width = 736;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DD;
+unicode = 5597;
+},
+{
+color = 9;
+glyphname = "theCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (384,357);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(267,0,ls),
+(592,0,o),
+(689,255,o),
+(689,440,cs),
+(689,612,o),
+(585,714,o),
+(400,714,cs),
+(178,714,l),
+(26,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(265,657,l),
+(229,626,l),
+(381,626,ls),
+(517,626,o),
+(591,558,o),
+(591,433,cs),
+(591,282,o),
+(509,88,o),
+(272,88,cs),
+(119,88,l),
+(137,58,l)
+);
+}
+);
+width = 723;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "to-canadian";
+note = uni15DE;
+unicode = 5598;
+},
+{
+color = 9;
+glyphname = "theeCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (311,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 724;
+}
+);
+note = uni15DF;
+unicode = 5599;
+},
+{
+color = 9;
+glyphname = "thiCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (285,0);
+ref = dot_middle;
+}
+);
+width = 724;
+}
+);
+note = uni15E0;
+unicode = 5600;
+},
+{
+color = 9;
+glyphname = "thaCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(592,0,l),
+(744,714,l),
+(503,714,ls),
+(177,714,o),
+(81,459,o),
+(81,274,cs),
+(81,102,o),
+(185,0,o),
+(369,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(179,432,o),
+(261,626,o),
+(497,626,cs),
+(651,626,l),
+(632,656,l),
+(505,57,l),
+(541,88,l),
+(389,88,ls),
+(252,88,o),
+(179,156,o),
+(179,281,cs)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15E1;
+unicode = 5601;
+},
+{
+color = 9;
+glyphname = "ttuCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(526,-13,o),
+(631,82,o),
+(675,290,cs),
+(765,714,l),
+(730,714,l),
+(388,517,l),
+(467,503,l),
+(206,714,l),
+(169,714,l),
+(84,315,ls),
+(39,106,o),
+(139,-13,o),
+(343,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(207,78,o),
+(150,155,o),
+(182,309,cs),
+(249,624,l),
+(200,611,l),
+(401,445,l),
+(423,445,l),
+(678,596,l),
+(646,622,l),
+(578,298,ls),
+(545,145,o),
+(473,78,o),
+(345,78,cs)
+);
+}
+);
+width = 736;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E2;
+unicode = 5602;
+},
+{
+color = 9;
+glyphname = "ttoCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(52,0,l),
+(394,197,l),
+(316,211,l),
+(576,0,l),
+(613,0,l),
+(698,399,ls),
+(743,608,o),
+(643,727,o),
+(439,727,cs),
+(256,727,o),
+(151,632,o),
+(107,424,cs),
+(17,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(575,636,o),
+(632,559,o),
+(600,405,cs),
+(533,90,l),
+(582,103,l),
+(382,269,l),
+(359,269,l),
+(105,118,l),
+(136,92,l),
+(205,416,ls),
+(237,569,o),
+(310,636,o),
+(437,636,cs)
+);
+}
+);
+width = 736;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E3;
+unicode = 5603;
+},
+{
+color = 9;
+glyphname = "tteCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (437,357);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(277,0,ls),
+(577.996,0,o),
+(699,232,o),
+(699,439,cs),
+(699,612,o),
+(595,714,o),
+(411,714,cs),
+(169,714,l),
+(163,687,l),
+(226,319,l),
+(235,401,l),
+(24,27,l),
+(18,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(310,346,l),
+(314,365,l),
+(262,670,l),
+(227,626,l),
+(390,626,ls),
+(528,626,o),
+(601,558,o),
+(601,432,cs),
+(601,282,o),
+(519,88,o),
+(282,88,cs),
+(118,88,l),
+(142,49,l)
+);
+}
+);
+width = 733;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15E4;
+unicode = 5604;
+},
+{
+color = 9;
+glyphname = "tteeCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (371,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 734;
+}
+);
+note = uni15E5;
+unicode = 5605;
+},
+{
+color = 9;
+glyphname = "ttiCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (356,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 734;
+}
+);
+note = uni15E6;
+unicode = 5606;
+},
+{
+color = 9;
+glyphname = "ttaCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(611,0,l),
+(617,27,l),
+(554,395,l),
+(545,313,l),
+(757,687,l),
+(763,714,l),
+(503,714,ls),
+(202,714,o),
+(81,482,o),
+(81,275,cs),
+(81,102,o),
+(186,0,o),
+(369,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(553,88,l),
+(390,88,ls),
+(253,88,o),
+(179,156,o),
+(179,282,cs),
+(179,432,o),
+(261,626,o),
+(498,626,cs),
+(663,626,l),
+(638,665,l),
+(471,368,l),
+(467,349,l),
+(519,44,l)
+);
+}
+);
+width = 734;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tteCarrier-canadian";
+note = uni15E7;
+unicode = 5607;
+},
+{
+color = 9;
+glyphname = "puCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(527,-13,o),
+(632,85,o),
+(675,287,cs),
+(766,714,l),
+(667,714,l),
+(632,549,l),
+(234,549,l),
+(269,714,l),
+(170,714,l),
+(85,317,ls),
+(41,107,o),
+(141,-13,o),
+(342,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(207,78,o),
+(150,155,o),
+(184,311,cs),
+(216,462,l),
+(613,462,l),
+(577,290,ls),
+(545,144,o),
+(474,78,o),
+(350,78,cs)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E8;
+unicode = 5608;
+},
+{
+color = 9;
+glyphname = "poCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(116,0,l),
+(151,165,l),
+(549,165,l),
+(514,0,l),
+(613,0,l),
+(698,397,ls),
+(742,607,o),
+(642,727,o),
+(441,727,cs),
+(256,727,o),
+(151,629,o),
+(108,427,cs),
+(17,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(207,424,ls),
+(238,570,o),
+(310,636,o),
+(433,636,cs),
+(576,636,o),
+(633,559,o),
+(599,403,cs),
+(568,252,l),
+(170,252,l)
+);
+}
+);
+width = 736;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E9;
+unicode = 5609;
+},
+{
+color = 9;
+glyphname = "peCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (423,357);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(273,0,ls),
+(597,0,o),
+(694,254,o),
+(694,440,cs),
+(694,612,o),
+(590,714,o),
+(407,714,cs),
+(165,714,l),
+(147,626,l),
+(238,626,l),
+(123,88,l),
+(32,88,l),
+(14,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(346,670,l),
+(278,626,l),
+(386,626,ls),
+(523,626,o),
+(596,558,o),
+(596,433,cs),
+(596,282,o),
+(515,88,o),
+(278,88,cs),
+(164,88,l),
+(213,44,l)
+);
+}
+);
+width = 728;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15EA;
+unicode = 5610;
+},
+{
+color = 9;
+glyphname = "peeCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (356,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 729;
+}
+);
+note = uni15EB;
+unicode = 5611;
+},
+{
+color = 9;
+glyphname = "piCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (342,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 729;
+}
+);
+note = uni15EC;
+unicode = 5612;
+},
+{
+color = 9;
+glyphname = "paCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(611,0,l),
+(629,88,l),
+(538,88,l),
+(653,626,l),
+(744,626,l),
+(762,714,l),
+(503,714,ls),
+(179,714,o),
+(81,460,o),
+(81,274,cs),
+(81,102,o),
+(185,0,o),
+(369,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(497,88,l),
+(390,88,ls),
+(253,88,o),
+(179,156,o),
+(179,281,cs),
+(179,432,o),
+(261,626,o),
+(498,626,cs),
+(612,626,l),
+(563,670,l),
+(430,44,l)
+);
+}
+);
+width = 730;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|peCarrier-canadian";
+note = uni15ED;
+unicode = 5613;
+},
+{
+color = 6;
+glyphname = "pCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(384,189,l),
+(398,256,l),
+(268,256,l),
+(330,546,l),
+(259,546,l),
+(198,256,l),
+(66,256,l),
+(51.997,189,l)
+);
+}
+);
+width = 461;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni15EE;
+unicode = 5614;
+},
+{
+color = 9;
+glyphname = "guCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (544,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(331,-13,o),
+(401,38,o),
+(444,138,c),
+(403,138,l),
+(417,41,o),
+(479,-13,o),
+(577,-13,cs),
+(697,-13,o),
+(773,60,o),
+(804,202,cs),
+(912,714,l),
+(817,714,l),
+(708,205,ls),
+(690,119,o),
+(645,75,o),
+(575,75,cs),
+(500,75,o),
+(466,127,o),
+(485,216,cs),
+(590,714,l),
+(497,714,l),
+(391,217,ls),
+(371,124,o),
+(324,75,o),
+(251,75,cs),
+(173,75,o),
+(143,125,o),
+(164,222,cs),
+(268,714,l),
+(173,714,l),
+(70,229,ls),
+(37,77,o),
+(99,-13,o),
+(235,-13,cs)
+);
+}
+);
+width = 888;
+}
+);
+metricRight = "=|";
+note = uni15EF;
+unicode = 5615;
+},
+{
+color = 9;
+glyphname = "goCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(117,0,l),
+(226,509,ls),
+(244,595,o),
+(289,639,o),
+(359,639,cs),
+(434,639,o),
+(468,587,o),
+(449,498,cs),
+(343,0,l),
+(437,0,l),
+(543,497,ls),
+(563,590,o),
+(610,639,o),
+(683,639,cs),
+(760,639,o),
+(790,589,o),
+(770,492,cs),
+(665,0,l),
+(761,0,l),
+(864,485,ls),
+(896,637,o),
+(835,727,o),
+(699,727,cs),
+(603,727,o),
+(533,676,o),
+(490,576,c),
+(531,576,l),
+(517,673,o),
+(455,727,o),
+(357,727,cs),
+(237,727,o),
+(161,654,o),
+(130,512,cs),
+(22,0,l)
+);
+}
+);
+width = 888;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F0;
+unicode = 5616;
+},
+{
+color = 9;
+glyphname = "geCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (469,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(387,0,ls),
+(549,0,o),
+(647,78,o),
+(647,217,cs),
+(647,289,o),
+(611,344,o),
+(545,368,c),
+(539,336,l),
+(662,360,o),
+(717,449,o),
+(717,547,cs),
+(717,648,o),
+(643,714,o),
+(529,714,cs),
+(178.006,714,l),
+(161,632,l),
+(506,632,ls),
+(578,632,o),
+(618,597,o),
+(618,538,cs),
+(618,449,o),
+(561,398,o),
+(457,398,cs),
+(111,398,l),
+(94,317,l),
+(441,317,ls),
+(512,317,o),
+(550,282,o),
+(550,222,cs),
+(550,140,o),
+(503,82,o),
+(389,82,cs),
+(44,82,l),
+(26,0,l)
+);
+}
+);
+width = 733;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15F1;
+unicode = 5617;
+},
+{
+color = 9;
+glyphname = "geeCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(387,0,ls),
+(549,0,o),
+(647,78,o),
+(647,217,cs),
+(647,289,o),
+(611,344,o),
+(545,368,c),
+(539,336,l),
+(662,360,o),
+(717,449,o),
+(717,547,cs),
+(717,648,o),
+(643,714,o),
+(529,714,cs),
+(178.006,714,l),
+(161,632,l),
+(506,632,ls),
+(578,632,o),
+(618,597,o),
+(618,538,cs),
+(618,449,o),
+(561,398,o),
+(457,398,cs),
+(388,398,l),
+(406,483,l),
+(345,483,l),
+(327,398,l),
+(111,398,l),
+(94,317,l),
+(309,317,l),
+(291,232,l),
+(352,232,l),
+(370,317,l),
+(441,317,ls),
+(512,317,o),
+(550,282,o),
+(550,222,cs),
+(550,140,o),
+(503,82,o),
+(389,82,cs),
+(44,82,l),
+(26,0,l)
+);
+}
+);
+width = 733;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F2;
+unicode = 5618;
+},
+{
+color = 9;
+glyphname = "giCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(387,0,ls),
+(549,0,o),
+(647,78,o),
+(647,217,cs),
+(647,288,o),
+(611,344,o),
+(546,368,c),
+(541,337,l),
+(662,361,o),
+(717,450,o),
+(717,547,cs),
+(717,648,o),
+(643,714,o),
+(529,714,cs),
+(178.006,714,l),
+(161,632,l),
+(506,632,ls),
+(578,632,o),
+(618,597,o),
+(618,538,cs),
+(618,449,o),
+(561,398,o),
+(457,398,cs),
+(402,398,l),
+(436,370,l),
+(431,411,o),
+(396,443,o),
+(352,443,cs),
+(320,443,o),
+(292,424,o),
+(279,398,c),
+(111,398,l),
+(94,317,l),
+(280,317,l),
+(293,291,o),
+(320,272,o),
+(353,272,cs),
+(395,272,o),
+(428,304,o),
+(435,344,c),
+(396,317,l),
+(441,317,ls),
+(512,317,o),
+(550,282,o),
+(550,222,cs),
+(550,140,o),
+(503,82,o),
+(389,82,cs),
+(44,82,l),
+(26,0,l)
+);
+}
+);
+width = 733;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F3;
+unicode = 5619;
+},
+{
+color = 9;
+glyphname = "gaCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (481,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(601,0,l),
+(618,82,l),
+(273,82,ls),
+(200,82,o),
+(161,117,o),
+(161,176,cs),
+(161,265,o),
+(218,316,o),
+(322,316,cs),
+(669,316,l),
+(686,397,l),
+(338,397,ls),
+(267,397,o),
+(229,432,o),
+(229,492,cs),
+(229,574,o),
+(276,632,o),
+(390,632,cs),
+(735,632,l),
+(753,714,l),
+(392,714,ls),
+(230,714,o),
+(132,636,o),
+(132,497,cs),
+(132,425,o),
+(168,370,o),
+(234,346,c),
+(240,378,l),
+(117,354,o),
+(62,265,o),
+(62,167,cs),
+(62,66,o),
+(136,0,o),
+(250,0,cs)
+);
+}
+);
+width = 734;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|geCarrier-canadian";
+note = uni15F4;
+unicode = 5620;
+},
+{
+color = 9;
+glyphname = "khuCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(327,-13,o),
+(395,34,o),
+(437,126,c),
+(406,128,l),
+(422,38,o),
+(482,-13,o),
+(577,-13,cs),
+(697,-13,o),
+(773,60,o),
+(804,202,cs),
+(912,714,l),
+(173,714,l),
+(70,229,ls),
+(37,77,o),
+(99,-13,o),
+(235,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(173,75,o),
+(143,125,o),
+(164,222,cs),
+(250,628,l),
+(479,628,l),
+(391,217,ls),
+(371,124,o),
+(324,75,o),
+(251,75,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(500,75,o),
+(466,127,o),
+(485,216,cs),
+(572,628,l),
+(799,628,l),
+(708,205,ls),
+(690,119,o),
+(645,75,o),
+(575,75,cs)
+);
+}
+);
+width = 888;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F5;
+unicode = 5621;
+},
+{
+color = 9;
+glyphname = "khoCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(761,0,l),
+(864,485,ls),
+(896,637,o),
+(835,727,o),
+(699,727,cs),
+(607,727,o),
+(539,680,o),
+(497,588,c),
+(528,586,l),
+(512,676,o),
+(452,727,o),
+(357,727,cs),
+(237,727,o),
+(161,654,o),
+(130,512,cs),
+(22,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(225,509,ls),
+(244,595,o),
+(289,639,o),
+(359,639,cs),
+(434,639,o),
+(468,587,o),
+(449,498,cs),
+(361,86,l),
+(135,86,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(543,497,ls),
+(563,590,o),
+(610,639,o),
+(683,639,cs),
+(760,639,o),
+(790,589,o),
+(770,492,cs),
+(684,86,l),
+(455,86,l)
+);
+}
+);
+width = 888;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F6;
+unicode = 5622;
+},
+{
+color = 9;
+glyphname = "kheCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(391,0,ls),
+(553,0,o),
+(651,79,o),
+(651,218,cs),
+(651,289,o),
+(615,343,o),
+(550,367,c),
+(545,337,l),
+(669,361,o),
+(721,454,o),
+(721,547,cs),
+(721,648,o),
+(647,714,o),
+(533,714,cs),
+(178,714,l),
+(26,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(192,317,l),
+(445,317,ls),
+(515,317,o),
+(555,282,o),
+(555,222,cs),
+(555,139,o),
+(506,81,o),
+(393,81,cs),
+(142,81,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(260,633,l),
+(510,633,ls),
+(583,633,o),
+(622,597,o),
+(622,538,cs),
+(622,451,o),
+(566,397,o),
+(461,397,cs),
+(209,397,l)
+);
+}
+);
+width = 736;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F7;
+unicode = 5623;
+},
+{
+color = 9;
+glyphname = "kheeCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(391,0,ls),
+(553,0,o),
+(651,79,o),
+(651,218,cs),
+(651,289,o),
+(615,343,o),
+(550,367,c),
+(545,337,l),
+(669,361,o),
+(721,454,o),
+(721,547,cs),
+(721,648,o),
+(647,714,o),
+(533,714,cs),
+(178,714,l),
+(26,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(192,318,l),
+(338,318,l),
+(319,230,l),
+(385,230,l),
+(407,335,l),
+(380,318,l),
+(445,318,ls),
+(515,318,o),
+(555,283,o),
+(555,223,cs),
+(555,140,o),
+(506,81,o),
+(393,81,cs),
+(142,81,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(439,485,l),
+(373,485,l),
+(354,397,l),
+(209,397,l),
+(260,633,l),
+(510,633,ls),
+(583,633,o),
+(622,597,o),
+(622,538,cs),
+(622,451,o),
+(566,397,o),
+(461,397,cs),
+(397,397,l),
+(417,380,l)
+);
+}
+);
+width = 736;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F8;
+unicode = 5624;
+},
+{
+color = 9;
+glyphname = "khiCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(391,0,ls),
+(553,0,o),
+(651,79,o),
+(651,218,cs),
+(651,288,o),
+(616,343,o),
+(550,367,c),
+(544,336,l),
+(670,361,o),
+(721,454,o),
+(721,547,cs),
+(721,648,o),
+(647,714,o),
+(533,714,cs),
+(178,714,l),
+(26,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(193,320,l),
+(304,320,l),
+(317,292,o),
+(346,272,o),
+(379,272,cs),
+(422,272,o),
+(456,306,o),
+(461,348,c),
+(403,320,l),
+(446,320,ls),
+(517,320,o),
+(555,284,o),
+(555,223,cs),
+(555,140,o),
+(506,81,o),
+(393,81,cs),
+(142,81,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(510,633,ls),
+(583,633,o),
+(622,597,o),
+(622,537,cs),
+(622,450,o),
+(568,395,o),
+(463,395,cs),
+(407,395,l),
+(462,366,l),
+(458,410,o),
+(423,443,o),
+(378,443,cs),
+(334,443,o),
+(299,410,o),
+(296,366,c),
+(331,395,l),
+(209,395,l),
+(260,633,l)
+);
+}
+);
+width = 736;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F9;
+unicode = 5625;
+},
+{
+color = 9;
+glyphname = "khaCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(606,0,l),
+(758,714,l),
+(393,714,ls),
+(231,714,o),
+(132,635,o),
+(132,496,cs),
+(132,425,o),
+(169,371,o),
+(234,347,c),
+(238,377,l),
+(114,353,o),
+(62,260,o),
+(62,167,cs),
+(62,66,o),
+(136,0,o),
+(251,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(201,81,o),
+(161,117,o),
+(161,176,cs),
+(161,263,o),
+(217,317,o),
+(323,317,cs),
+(574,317,l),
+(524,81,l),
+(273,81,ls)
+);
+},
+{
+closed = 1;
+nodes = (
+(268,397,o),
+(229,432,o),
+(229,492,cs),
+(229,575,o),
+(278,633,o),
+(391,633,cs),
+(642,633,l),
+(592,397,l),
+(339,397,ls)
+);
+}
+);
+width = 738;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15FA;
+unicode = 5626;
+},
+{
+color = 9;
+glyphname = "kkuCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(325,-13,o),
+(394,32,o),
+(438,127,c),
+(406,127,l),
+(422,39,o),
+(481,-13,o),
+(577,-13,cs),
+(697,-13,o),
+(773,60,o),
+(804,202,cs),
+(912,714,l),
+(876,714,l),
+(539,552,l),
+(519,451,l),
+(831,599,l),
+(799,633,l),
+(708,205,ls),
+(691,119,o),
+(645,75,o),
+(575,75,cs),
+(496,75,o),
+(466,132,o),
+(484,216,cs),
+(590,714,l),
+(497,714,l),
+(391,217,ls),
+(371,122,o),
+(322,75,o),
+(251,75,cs),
+(173,75,o),
+(143,125,o),
+(164,222,cs),
+(251,636,l),
+(203,615,l),
+(458,460,l),
+(478,551,l),
+(209,714,l),
+(173,714,l),
+(70,229,ls),
+(37,76,o),
+(100,-13,o),
+(235,-13,cs)
+);
+}
+);
+width = 888;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FB;
+unicode = 5627;
+},
+{
+color = 9;
+glyphname = "kkoCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(58,0,l),
+(395,162,l),
+(414,263,l),
+(103,115,l),
+(135,81,l),
+(226,509,ls),
+(243,595,o),
+(288,639,o),
+(358,639,cs),
+(437,639,o),
+(467,582,o),
+(449,498,cs),
+(343,0,l),
+(437,0,l),
+(542,497,ls),
+(563,592,o),
+(611,639,o),
+(683,639,cs),
+(760,639,o),
+(790,589,o),
+(770,492,cs),
+(682,78,l),
+(730,99,l),
+(475,254,l),
+(456,163,l),
+(724,0,l),
+(761,0,l),
+(864,485,ls),
+(896,638,o),
+(834,727,o),
+(699,727,cs),
+(608,727,o),
+(539,682,o),
+(496,587,c),
+(527,587,l),
+(512,675,o),
+(453,727,o),
+(357,727,cs),
+(236,727,o),
+(161,654,o),
+(130,512,cs),
+(22,0,l)
+);
+}
+);
+width = 888;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FC;
+unicode = 5628;
+},
+{
+color = 9;
+glyphname = "kkeCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(405,0,ls),
+(567,0,o),
+(665,78,o),
+(665,217,cs),
+(665,288,o),
+(630,343,o),
+(563,367,c),
+(559,337,l),
+(684,361,o),
+(736,453,o),
+(736,547,cs),
+(736,649,o),
+(662,714,o),
+(547,714,cs),
+(174,714,l),
+(168,687,l),
+(217,398,l),
+(118,398,l),
+(101,317,l),
+(195,317,l),
+(28,27,l),
+(22,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(297,317,l),
+(460,317,ls),
+(530,317,o),
+(569,282,o),
+(569,222,cs),
+(569,140,o),
+(522,82,o),
+(408,82,cs),
+(117,82,l),
+(142,44,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(266,676,l),
+(231,632,l),
+(524,632,ls),
+(597,632,o),
+(637,597,o),
+(637,538,cs),
+(637,449,o),
+(579,398,o),
+(475,398,cs),
+(313,398,l)
+);
+}
+);
+width = 751;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni15FD;
+unicode = 5629;
+},
+{
+color = 9;
+glyphname = "kkeeCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(405,0,ls),
+(567,0,o),
+(665,78,o),
+(665,217,cs),
+(665,288,o),
+(630,343,o),
+(563,367,c),
+(559,337,l),
+(684,361,o),
+(736,453,o),
+(736,547,cs),
+(736,649,o),
+(662,714,o),
+(547,714,cs),
+(174,714,l),
+(168,687,l),
+(217,398,l),
+(118,398,l),
+(101,317,l),
+(195,317,l),
+(28,27,l),
+(22,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(298,319,l),
+(374,319,l),
+(355,230,l),
+(422,230,l),
+(444,340,l),
+(419,319,l),
+(462,319,ls),
+(532,319,o),
+(569,282,o),
+(569,222,cs),
+(569,140,o),
+(522,82,o),
+(408,82,cs),
+(117,82,l),
+(142,44,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(476,485,l),
+(409,485,l),
+(390,396,l),
+(314,396,l),
+(266,676,l),
+(231,632,l),
+(524,632,ls),
+(597,632,o),
+(637,597,o),
+(637,538,cs),
+(637,449,o),
+(579,396,o),
+(477,396,cs),
+(435,396,l),
+(453,379,l)
+);
+}
+);
+width = 751;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FE;
+unicode = 5630;
+},
+{
+color = 9;
+glyphname = "kkiCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(405,0,ls),
+(567,0,o),
+(665,78,o),
+(665,217,cs),
+(665,288,o),
+(630,343,o),
+(563,367,c),
+(559,337,l),
+(684,361,o),
+(736,453,o),
+(736,547,cs),
+(736,649,o),
+(662,714,o),
+(547,714,cs),
+(174,714,l),
+(168,687,l),
+(217,398,l),
+(118,398,l),
+(101,317,l),
+(195,317,l),
+(28,27,l),
+(22,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(299,320,l),
+(337,320,l),
+(350,292,o),
+(378,272,o),
+(411,272,cs),
+(452,272,o),
+(484,303,o),
+(490,342,c),
+(432,320,l),
+(462,320,ls),
+(533,320,o),
+(569,282,o),
+(569,222,cs),
+(569,140,o),
+(522,82,o),
+(408,82,cs),
+(117,82,l),
+(142,44,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(487,412,o),
+(453,443,o),
+(410,443,cs),
+(377,443,o),
+(348,423,o),
+(336,394,c),
+(314,394,l),
+(266,676,l),
+(231,632,l),
+(524,632,ls),
+(597,632,o),
+(637,597,o),
+(637,538,cs),
+(637,449,o),
+(580,394,o),
+(477,394,cs),
+(433,394,l),
+(492,371,l)
+);
+}
+);
+width = 751;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FF;
+unicode = 5631;
+},
+{
+color = 9;
+glyphname = "kkaCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(623,0,l),
+(629,27,l),
+(581,316,l),
+(680,316,l),
+(697,397,l),
+(603,397,l),
+(769,687,l),
+(775,714,l),
+(392,714,ls),
+(230,714,o),
+(132,636,o),
+(132,497,cs),
+(132,426,o),
+(167,371,o),
+(235,347,c),
+(239,377,l),
+(114,353,o),
+(62,261,o),
+(62,167,cs),
+(62,65,o),
+(136,0,o),
+(251,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(567,82,l),
+(274,82,ls),
+(200,82,o),
+(161,117,o),
+(161,176,cs),
+(161,265,o),
+(219,316,o),
+(322,316,cs),
+(484,316,l),
+(532,38,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(267,397,o),
+(229,432,o),
+(229,492,cs),
+(229,574,o),
+(276,632,o),
+(390,632,cs),
+(681,632,l),
+(655,670,l),
+(500,397,l),
+(338,397,ls)
+);
+}
+);
+width = 751;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|kkeCarrier-canadian";
+note = uni1600;
+unicode = 5632;
+},
+{
+color = 6;
+glyphname = "kkCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(380,546,l),
+(193,260,l),
+(244,260,l),
+(177,546,l),
+(114,546,l),
+(110,531,l),
+(197,189,l),
+(216,189,l),
+(448,531,l),
+(451,546,l)
+);
+}
+);
+width = 438;
+}
+);
+note = uni1601;
+unicode = 5633;
+},
+{
+color = 9;
+glyphname = "nuCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(519,-13,o),
+(633,86,o),
+(671,267,cs),
+(681,314,l),
+(582,314,l),
+(574,275,ls),
+(546,144,o),
+(471,77,o),
+(353,77,cs),
+(214,77,o),
+(152,165,o),
+(185,318,cs),
+(269,714,l),
+(170,714,l),
+(86,322,ls),
+(43,119,o),
+(145,-13,o),
+(347,-13,cs)
+);
+}
+);
+width = 733;
+}
+);
+metricLeft = "te-canadian";
+note = uni1602;
+unicode = 5634;
+},
+{
+color = 9;
+glyphname = "noCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(609,0,l),
+(692,392,ls),
+(736,595,o),
+(634,727,o),
+(432,727,cs),
+(260,727,o),
+(146,628,o),
+(108,447,cs),
+(98,400,l),
+(196,400,l),
+(205,439,ls),
+(233,570,o),
+(308,637,o),
+(426,637,cs),
+(565,637,o),
+(626,549,o),
+(594,396,cs),
+(510,0,l)
+);
+}
+);
+width = 732;
+}
+);
+metricLeft = "=|nuCarrier-canadian";
+metricRight = "te-canadian";
+note = uni1603;
+unicode = 5635;
+},
+{
+color = 9;
+glyphname = "neCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (349,356);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(273,0,ls),
+(591,0,o),
+(690,249,o),
+(690,438,cs),
+(690,611,o),
+(586,714,o),
+(401,714,cs),
+(152,714,l),
+(133,624,l),
+(388,624,ls),
+(520,624,o),
+(592,555,o),
+(592,431,cs),
+(592,294,o),
+(522,89,o),
+(283,89,cs),
+(262,89,l),
+(243,0,l)
+);
+}
+);
+width = 725;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1604;
+unicode = 5636;
+},
+{
+color = 9;
+glyphname = "neeCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "neCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (276,-1);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 725;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1605;
+unicode = 5637;
+},
+{
+color = 9;
+glyphname = "niCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "neCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (250,-1);
+ref = dot_middle;
+}
+);
+width = 725;
+}
+);
+note = uni1606;
+unicode = 5638;
+},
+{
+color = 9;
+glyphname = "naCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(619,0,l),
+(638,90,l),
+(383,90,ls),
+(251,90,o),
+(179,159,o),
+(179,283,cs),
+(179,420,o),
+(248,625,o),
+(487,625,cs),
+(509,625,l),
+(528,714,l),
+(498,714,ls),
+(180,714,o),
+(81,465,o),
+(81,276,cs),
+(81,103,o),
+(185,0,o),
+(369,0,cs)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni1607;
+unicode = 5639;
+},
+{
+color = 9;
+glyphname = "muCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(329,-13,o),
+(401,36,o),
+(444,138,c),
+(403,138,l),
+(417,44,o),
+(477,-13,o),
+(577,-13,cs),
+(697,-13,o),
+(773,60,o),
+(804,202,cs),
+(847,404,l),
+(748,404,l),
+(706,205,ls),
+(688,119,o),
+(643,75,o),
+(576,75,cs),
+(498,75,o),
+(468,132,o),
+(486,215,cs),
+(526,404,l),
+(430,404,l),
+(390,217,ls),
+(369,121,o),
+(321,75,o),
+(251,75,cs),
+(175,75,o),
+(145,124,o),
+(166,222,cs),
+(271,714,l),
+(173,714,l),
+(70,229,ls),
+(37,76,o),
+(99,-13,o),
+(235,-13,cs)
+);
+}
+);
+width = 888;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "=|";
+note = uni1608;
+unicode = 5640;
+},
+{
+color = 9;
+glyphname = "moCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(760,0,l),
+(863,485,ls),
+(896,638,o),
+(834,727,o),
+(698,727,cs),
+(604,727,o),
+(532,678,o),
+(489,576,c),
+(529,576,l),
+(516,670,o),
+(456,727,o),
+(356,727,cs),
+(236,727,o),
+(160,654,o),
+(130,512,cs),
+(87,310,l),
+(185,310,l),
+(227,509,ls),
+(245,595,o),
+(290,639,o),
+(357,639,cs),
+(435,639,o),
+(465,582,o),
+(447,499,cs),
+(407,310,l),
+(503,310,l),
+(543,497,ls),
+(564,593,o),
+(612,639,o),
+(682,639,cs),
+(758,639,o),
+(787,590,o),
+(766,492,cs),
+(662,0,l)
+);
+}
+);
+width = 887;
+}
+);
+metricLeft = "=|muCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni1609;
+unicode = 5641;
+},
+{
+color = 9;
+glyphname = "meCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(388,0,ls),
+(550,0,o),
+(648,78,o),
+(648,217,cs),
+(648,289,o),
+(612,344,o),
+(547,368,c),
+(541,336,l),
+(663,360,o),
+(719,449,o),
+(719,547,cs),
+(719,648,o),
+(645,714,o),
+(530,714,cs),
+(152,714,l),
+(135,632,l),
+(508,632,ls),
+(580,632,o),
+(620,597,o),
+(620,538,cs),
+(620,449,o),
+(562,398,o),
+(459,398,cs),
+(328,398,l),
+(311,317,l),
+(442,317,ls),
+(513,317,o),
+(552,282,o),
+(552,222,cs),
+(552,140,o),
+(505,82,o),
+(391,82,cs),
+(261,82,l),
+(244,0,l)
+);
+}
+);
+width = 734;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160A;
+unicode = 5642;
+},
+{
+color = 9;
+glyphname = "meeCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(388,0,ls),
+(550,0,o),
+(648,78,o),
+(648,217,cs),
+(648,289,o),
+(612,344,o),
+(547,368,c),
+(541,336,l),
+(663,360,o),
+(719,449,o),
+(719,547,cs),
+(719,648,o),
+(645,714,o),
+(530,714,cs),
+(152,714,l),
+(135,632,l),
+(508,632,ls),
+(580,632,o),
+(620,597,o),
+(620,538,cs),
+(620,449,o),
+(562,396,o),
+(459,396,cs),
+(395,396,l),
+(413,481,l),
+(345,481,l),
+(293,234,l),
+(361,234,l),
+(378,318,l),
+(443,318,ls),
+(514,318,o),
+(552,282,o),
+(552,222,cs),
+(552,140,o),
+(505,82,o),
+(391,82,cs),
+(261,82,l),
+(244,0,l)
+);
+}
+);
+width = 734;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160B;
+unicode = 5643;
+},
+{
+color = 9;
+glyphname = "miCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(388,0,ls),
+(548,0,o),
+(635,72,o),
+(646,195,cs),
+(654,277,o),
+(619,340,o),
+(547,368,c),
+(541,336,l),
+(655,358,o),
+(708,437,o),
+(716,525,cs),
+(729,638,o),
+(653,714,o),
+(530,714,cs),
+(152,714,l),
+(135,632,l),
+(507,632,ls),
+(583,632,o),
+(623,594,o),
+(619,530,cs),
+(615,443,o),
+(558,396,o),
+(458,396,cs),
+(383,396,l),
+(437,367,l),
+(432,411,o),
+(398,444,o),
+(353,444,cs),
+(305,444,o),
+(269,405,o),
+(269,359,cs),
+(269,312,o),
+(306,273,o),
+(353,273,cs),
+(396,273,o),
+(430,305,o),
+(436,347,c),
+(382,318,l),
+(442,318,ls),
+(516,318,o),
+(555,281,o),
+(551,214,cs),
+(547,132,o),
+(498,82,o),
+(391,82,cs),
+(261,82,l),
+(244,0,l)
+);
+}
+);
+width = 732;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160C;
+unicode = 5644;
+},
+{
+color = 9;
+glyphname = "maCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(629,0,l),
+(647,82,l),
+(273,82,ls),
+(200,82,o),
+(161,117,o),
+(161,176,cs),
+(161,265,o),
+(218,316,o),
+(322,316,cs),
+(452,316,l),
+(469,397,l),
+(338,397,ls),
+(267,397,o),
+(229,432,o),
+(229,492,cs),
+(229,574,o),
+(276,632,o),
+(390,632,cs),
+(520,632,l),
+(537,714,l),
+(392,714,ls),
+(230,714,o),
+(132,636,o),
+(132,497,cs),
+(132,425,o),
+(168,370,o),
+(234,346,c),
+(240,378,l),
+(117,354,o),
+(62,265,o),
+(62,167,cs),
+(62,66,o),
+(136,0,o),
+(250,0,cs)
+);
+}
+);
+width = 735;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni160D;
+unicode = 5645;
+},
+{
+color = 9;
+glyphname = "yuCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(556,-13,o),
+(681,110,o),
+(735,371,cs),
+(777,568,o),
+(743,727,o),
+(584,727,cs),
+(437,727,o),
+(377,582,o),
+(377,473,cs),
+(377,377,o),
+(430,315,o),
+(518,315,cs),
+(532,315,o),
+(544,318,o),
+(563,322,c),
+(580,401,l),
+(570,398,o),
+(558,397,o),
+(546,397,cs),
+(493,397,o),
+(465,426,o),
+(465,481,cs),
+(465,537,o),
+(491,645,o),
+(576,645,cs),
+(671,645,o),
+(673,533,o),
+(644,390,cs),
+(600,171,o),
+(517,78,o),
+(364,78,cs),
+(207,78,o),
+(154,178,o),
+(187,331,cs),
+(269,714,l),
+(169,714,l),
+(88,332,ls),
+(46,132,o),
+(136,-13,o),
+(356,-13,cs)
+);
+}
+);
+width = 779;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160E;
+unicode = 5646;
+},
+{
+color = 9;
+glyphname = "yoCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(389,-13,o),
+(448,132,o),
+(448,241,cs),
+(448,337,o),
+(396,399,o),
+(308,399,cs),
+(294,399,o),
+(282,396,o),
+(263,392,c),
+(246,313,l),
+(256,316,o),
+(267,317,o),
+(279,317,cs),
+(333,317,o),
+(361,288,o),
+(361,233,cs),
+(361,177,o),
+(335,69,o),
+(249,69,cs),
+(155,69,o),
+(152,181,o),
+(181,324,cs),
+(225,543,o),
+(308,636,o),
+(462,636,cs),
+(619,636,o),
+(671,536,o),
+(639,383,cs),
+(557,0,l),
+(657,0,l),
+(738,382,ls),
+(780,582,o),
+(689,727,o),
+(470,727,cs),
+(269,727,o),
+(144,604,o),
+(90,343,cs),
+(48,146,o),
+(83,-13,o),
+(242,-13,cs)
+);
+}
+);
+width = 780;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160F;
+unicode = 5647;
+},
+{
+color = 9;
+glyphname = "yeCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(567,-13,o),
+(689,226,o),
+(689,426,cs),
+(689,607,o),
+(579,714,o),
+(387,714,cs),
+(178,714,l),
+(159,624,l),
+(370,624,ls),
+(513,624,o),
+(589,551,o),
+(589,420,cs),
+(589,274,o),
+(519,72,o),
+(318,72,cs),
+(209,72,o),
+(147,120,o),
+(147,200,cs),
+(147,263,o),
+(181,342,o),
+(255,342,cs),
+(303,342,o),
+(331,311,o),
+(331,258,cs),
+(331,226,o),
+(323,193,o),
+(311,164,c),
+(391,164,l),
+(406,199,o),
+(415,237,o),
+(415,273,cs),
+(415,364,o),
+(356,422,o),
+(259,422,cs),
+(132,422,o),
+(58,307,o),
+(58,190,cs),
+(58,67,o),
+(155,-13,o),
+(314,-13,cs)
+);
+}
+);
+width = 726;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1610;
+unicode = 5648;
+},
+{
+color = 9;
+glyphname = "yeeCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(567,-13,o),
+(690,226,o),
+(690,428,cs),
+(690,607,o),
+(580,714,o),
+(388,714,cs),
+(179,714,l),
+(160,624,l),
+(371,624,ls),
+(514,624,o),
+(590,551,o),
+(590,419,cs),
+(590,295,o),
+(533,72,o),
+(319,72,cs),
+(210,72,o),
+(148,118,o),
+(148,198,cs),
+(148,258,o),
+(181,342,o),
+(259,342,cs),
+(321,342,o),
+(336,290,o),
+(323,230,cs),
+(313,186,l),
+(375,186,l),
+(444,513,l),
+(383,513,l),
+(342,320,l),
+(351,319,l),
+(355,383,o),
+(316,422,o),
+(247,422,cs),
+(125,422,o),
+(59,301,o),
+(59,193,cs),
+(59,67,o),
+(156,-13,o),
+(317,-13,cs)
+);
+}
+);
+width = 726;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1611;
+unicode = 5649;
+},
+{
+color = 9;
+glyphname = "yiCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(555,-13,o),
+(689,203,o),
+(689,428,cs),
+(689,607,o),
+(579,714,o),
+(387,714,cs),
+(179,714,l),
+(160,624,l),
+(371,624,ls),
+(514,624,o),
+(589,551,o),
+(589,419,cs),
+(589,263,o),
+(514,72,o),
+(319,72,cs),
+(209,72,o),
+(146,119,o),
+(146,197,cs),
+(146,270,o),
+(188,332,o),
+(283,325,c),
+(255,355,l),
+(256,315,o),
+(289,283,o),
+(331,283,cs),
+(373,283,o),
+(405,316,o),
+(405,358,cs),
+(405,400,o),
+(373,431,o),
+(330,431,cs),
+(302,431,o),
+(279,417,o),
+(267,396,c),
+(136,391,o),
+(58,307,o),
+(58,187,cs),
+(58,67,o),
+(155,-13,o),
+(315,-13,cs)
+);
+}
+);
+width = 726;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1612;
+unicode = 5650;
+},
+{
+color = 9;
+glyphname = "yaCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(593,0,l),
+(612,90,l),
+(401,90,ls),
+(258,90,o),
+(183,163,o),
+(183,294,cs),
+(183,440,o),
+(252,642,o),
+(454,642,cs),
+(562,642,o),
+(625,594,o),
+(625,514,cs),
+(625,451,o),
+(590,372,o),
+(517,372,cs),
+(468,372,o),
+(440,403,o),
+(440,456,cs),
+(440,488,o),
+(449,521,o),
+(460,550,c),
+(380,550,l),
+(365,515,o),
+(356,477,o),
+(356,441,cs),
+(356,350,o),
+(416,292,o),
+(512,292,cs),
+(639,292,o),
+(713,407,o),
+(713,524,cs),
+(713,647,o),
+(616,727,o),
+(457,727,cs),
+(204,727,o),
+(83,488,o),
+(83,288,cs),
+(83,107,o),
+(192,0,o),
+(385,0,cs)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|yeCarrier-canadian";
+note = uni1613;
+unicode = 5651;
+},
+{
+color = 9;
+glyphname = "juCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(555,-13,o),
+(676,103,o),
+(676,257,cs),
+(676,355,o),
+(616,422,o),
+(518,422,cs),
+(398,422,o),
+(335,322,o),
+(323,214,cs),
+(320,197,o),
+(319,180,o),
+(320,164,c),
+(400,164,l),
+(400,174,o),
+(401,188,o),
+(403,205,cs),
+(411,275,o),
+(443,342,o),
+(512,342,cs),
+(561,342,o),
+(588,309,o),
+(588,255,cs),
+(588,153,o),
+(516,72,o),
+(391,72,cs),
+(257,72,o),
+(181,140,o),
+(181,258,cs),
+(181,475,o),
+(359,624,o),
+(632,624,cs),
+(747,624,l),
+(766,714,l),
+(169,714,l),
+(151,628,l),
+(476,628,l),
+(564,664,l),
+(288,661,o),
+(82,501,o),
+(82,257,cs),
+(82,96,o),
+(199,-13,o),
+(379,-13,cs)
+);
+}
+);
+width = 744;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni1614;
+unicode = 5652;
+},
+{
+color = 9;
+glyphname = "juSayisi-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (483,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(563,-13,o),
+(683,178,o),
+(689,366,cs),
+(694,552,o),
+(572,662,o),
+(341,666,c),
+(435,628,l),
+(754,628,l),
+(773,714,l),
+(174,714,l),
+(156,624,l),
+(277,624,ls),
+(493,624,o),
+(596,538,o),
+(592,373,cs),
+(589,249,o),
+(533,72,o),
+(323,72,cs),
+(206,72,o),
+(144,121,o),
+(146,203,cs),
+(147,273,o),
+(187,342,o),
+(255,342,cs),
+(304,342,o),
+(329,310,o),
+(329,254,cs),
+(328,225,o),
+(320,190,o),
+(309,164,c),
+(389,164,l),
+(405,201,o),
+(412,239,o),
+(412,268,cs),
+(415,362,o),
+(357,422,o),
+(259,422,cs),
+(141,422,o),
+(61,319,o),
+(58,199,cs),
+(53,71,o),
+(150,-13,o),
+(320,-13,cs)
+);
+}
+);
+width = 744;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1615;
+unicode = 5653;
+},
+{
+color = 9;
+glyphname = "joCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(621,0,l),
+(639,86,l),
+(314,86,l),
+(226,50,l),
+(502,53,o),
+(708,213,o),
+(708,457,cs),
+(708,618,o),
+(591,727,o),
+(412,727,cs),
+(235,727,o),
+(115,611,o),
+(115,457,cs),
+(115,359,o),
+(174,292,o),
+(272,292,cs),
+(392,292,o),
+(455,392,o),
+(467,500,cs),
+(470,517,o),
+(471,534,o),
+(470,550,c),
+(390,550,l),
+(390,540,o),
+(390,526,o),
+(387,509,cs),
+(379,439,o),
+(347,372,o),
+(278,372,cs),
+(229,372,o),
+(202,405,o),
+(202,459,cs),
+(202,561,o),
+(274,642,o),
+(400,642,cs),
+(533,642,o),
+(609,574,o),
+(609,456,cs),
+(609,239,o),
+(431,90,o),
+(158,90,cs),
+(43,90,l),
+(24,0,l)
+);
+}
+);
+width = 744;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1616;
+unicode = 5654;
+},
+{
+color = 9;
+glyphname = "jeCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(685,-13,o),
+(741,297,o),
+(741,442,cs),
+(741,622,o),
+(656,727,o),
+(500,727,cs),
+(362,727,o),
+(262,643,o),
+(206,479,c),
+(223,466,l),
+(276,714,l),
+(178,714,l),
+(26,0,l),
+(125,0,l),
+(187,291,ls),
+(235,518,o),
+(335,637,o),
+(479,637,cs),
+(592,637,o),
+(646,569,o),
+(646,437,cs),
+(646,356,o),
+(617,69,o),
+(482,69,cs),
+(432,69,o),
+(403,101,o),
+(403,157,cs),
+(403,226,o),
+(437,317,o),
+(534,317,cs),
+(547,317,o),
+(559,316,o),
+(570,313,c),
+(586,392,l),
+(567,396,o),
+(549,399,o),
+(529,399,cs),
+(375,399,o),
+(316,260,o),
+(316,150,cs),
+(316,50,o),
+(376,-13,o),
+(475,-13,cs)
+);
+}
+);
+width = 786;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "te-canadian";
+note = uni1617;
+unicode = 5655;
+},
+{
+color = 9;
+glyphname = "jeeCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(685,-13,o),
+(741,297,o),
+(741,441,cs),
+(741,622,o),
+(656,727,o),
+(500,727,cs),
+(362,727,o),
+(262,642,o),
+(206,478,c),
+(223,465,l),
+(276,714,l),
+(178,714,l),
+(26,0,l),
+(125,0,l),
+(186,289,ls),
+(235,518,o),
+(335,637,o),
+(479,637,cs),
+(592,637,o),
+(647,569,o),
+(647,437,cs),
+(647,342,o),
+(614,69,o),
+(469,69,cs),
+(410,69,o),
+(377,105,o),
+(377,167,cs),
+(377,229,o),
+(402,313,o),
+(481,329,c),
+(462,240,l),
+(517,240,l),
+(567,473,l),
+(511,473,l),
+(493,388,l),
+(362,368,o),
+(316,246,o),
+(316,149,cs),
+(316,50,o),
+(377,-13,o),
+(475,-13,cs)
+);
+}
+);
+width = 787;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1618;
+unicode = 5656;
+},
+{
+color = 9;
+glyphname = "jiCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(685,-13,o),
+(741,297,o),
+(741,441,cs),
+(741,622,o),
+(656,727,o),
+(500,727,cs),
+(362,727,o),
+(262,642,o),
+(206,478,c),
+(223,465,l),
+(276,714,l),
+(178,714,l),
+(26,0,l),
+(125,0,l),
+(186,289,ls),
+(235,518,o),
+(335,637,o),
+(479,637,cs),
+(592,637,o),
+(647,569,o),
+(647,437,cs),
+(647,342,o),
+(614,69,o),
+(469,69,cs),
+(410,69,o),
+(377,105,o),
+(377,167,cs),
+(377,216,o),
+(393,282,o),
+(445,308,c),
+(455,293,o),
+(473,283,o),
+(494,283,cs),
+(536,283,o),
+(566,317,o),
+(566,358,cs),
+(566,399,o),
+(535,431,o),
+(493,431,cs),
+(452,431,o),
+(421,398,o),
+(421,356,c),
+(343,316,o),
+(316,223,o),
+(316,149,cs),
+(316,50,o),
+(377,-13,o),
+(475,-13,cs)
+);
+}
+);
+width = 787;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1619;
+unicode = 5657;
+},
+{
+color = 9;
+glyphname = "jiSayisi-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(658,-13,o),
+(761,330,o),
+(761,518,cs),
+(761,653,o),
+(704,727,o),
+(596,727,cs),
+(447,727,o),
+(385,576,o),
+(385,470,cs),
+(385,374,o),
+(439,315,o),
+(522,315,cs),
+(541,315,o),
+(560,318,o),
+(571,323,c),
+(588,402,l),
+(578,398,o),
+(566,397,o),
+(553,397,cs),
+(500,397,o),
+(472,424,o),
+(472,479,cs),
+(472,529,o),
+(498,645,o),
+(588,645,cs),
+(642,645,o),
+(668,606,o),
+(668,525,cs),
+(668,395,o),
+(604,77,o),
+(382,77,cs),
+(192,77,o),
+(182,268,o),
+(218,437,cs),
+(277,714,l),
+(178,714,l),
+(26,0,l),
+(124,0,l),
+(189,308,l),
+(171,317,l),
+(139,147,o),
+(197,-13,o),
+(386,-13,cs)
+);
+}
+);
+width = 788;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161A;
+unicode = 5658;
+},
+{
+color = 9;
+glyphname = "jaCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (485,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(472,-13,o),
+(572,72,o),
+(628,235,c),
+(611,249,l),
+(558,0,l),
+(657,0,l),
+(809,714,l),
+(709,714,l),
+(647,423,ls),
+(599,196,o),
+(499,77,o),
+(355,77,cs),
+(243,77,o),
+(188,145,o),
+(188,277,cs),
+(188,359,o),
+(217,646,o),
+(352,646,cs),
+(402,646,o),
+(431,613,o),
+(431,558,cs),
+(431,488,o),
+(397,397,o),
+(301,397,cs),
+(287,397,o),
+(275,399,o),
+(264,402,c),
+(248,323,l),
+(267,318,o),
+(285,316,o),
+(305,316,cs),
+(459,316,o),
+(518,454,o),
+(518,564,cs),
+(518,665,o),
+(459,728,o),
+(359,728,cs),
+(149,728,o),
+(92,417,o),
+(92,272,cs),
+(92,93,o),
+(178,-13,o),
+(334,-13,cs)
+);
+}
+);
+width = 789;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni161B;
+unicode = 5659;
+},
+{
+color = 9;
+glyphname = "jjuCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(545,-13,o),
+(663,103,o),
+(663,258,cs),
+(663,356,o),
+(602,422,o),
+(504,422,cs),
+(406,422,o),
+(337,358,o),
+(313,245,cs),
+(306,217,o),
+(303,189,o),
+(303,164,c),
+(384,164,l),
+(384,183,o),
+(387,206,o),
+(392,232,cs),
+(408,303,o),
+(443,342,o),
+(497,342,cs),
+(546,342,o),
+(575,308,o),
+(575,254,cs),
+(575,152,o),
+(501,71,o),
+(377,71,cs),
+(249,71,o),
+(179,142,o),
+(179,264,cs),
+(179,458,o),
+(299,624,o),
+(574,624,cs),
+(729,624,l),
+(748,714,l),
+(588,714,ls),
+(453,714,o),
+(345,681,o),
+(265,627,c),
+(187,727,l),
+(106,664,l),
+(187,562,l),
+(111,480,o),
+(81,369,o),
+(81,268,cs),
+(81,99,o),
+(191,-13,o),
+(369,-13,cs)
+);
+}
+);
+width = 731;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni161C;
+unicode = 5660;
+},
+{
+color = 9;
+glyphname = "jjoCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(671,50,l),
+(590,152,l),
+(666,234,o),
+(696,345,o),
+(696,446,cs),
+(696,615,o),
+(586,727,o),
+(408,727,cs),
+(232,727,o),
+(115,611,o),
+(115,456,cs),
+(115,358,o),
+(176,292,o),
+(273,292,cs),
+(372,292,o),
+(440,356,o),
+(465,469,cs),
+(471,497,o),
+(474,525,o),
+(474,550,c),
+(394,550,l),
+(393,531,o),
+(390,508,o),
+(385,482,cs),
+(369,411,o),
+(334,372,o),
+(280,372,cs),
+(231,372,o),
+(202,406,o),
+(202,460,cs),
+(202,562,o),
+(276,643,o),
+(400,643,cs),
+(529,643,o),
+(598,572,o),
+(598,450,cs),
+(598,256,o),
+(478,90,o),
+(203,90,cs),
+(48,90,l),
+(29,0,l),
+(189,0,ls),
+(325,0,o),
+(432,33,o),
+(512,87,c),
+(591,-13,l)
+);
+}
+);
+width = 731;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|jjuCarrier-canadian";
+note = uni161D;
+unicode = 5661;
+},
+{
+color = 9;
+glyphname = "jjeCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(694,-13,o),
+(750,299,o),
+(750,442,cs),
+(750,626,o),
+(659,727,o),
+(487,727,cs),
+(400,727,o),
+(323,700,o),
+(261,643,c),
+(193,727,l),
+(115,663,l),
+(194,565,l),
+(156,511,o),
+(127,440,o),
+(108,352,cs),
+(34,0,l),
+(133,0,l),
+(206,341,ls),
+(247,537,o),
+(341,637,o),
+(481,637,cs),
+(598,637,o),
+(654,571,o),
+(654,437,cs),
+(654,356,o),
+(625,69,o),
+(491,69,cs),
+(440,69,o),
+(411,101,o),
+(411,157,cs),
+(411,227,o),
+(445,317,o),
+(541,317,cs),
+(557,317,o),
+(569,316,o),
+(578,313,c),
+(594,392,l),
+(580,396,o),
+(559,399,o),
+(540,399,cs),
+(385,399,o),
+(324,260,o),
+(324,150,cs),
+(324,50,o),
+(383,-13,o),
+(483,-13,cs)
+);
+}
+);
+width = 795;
+}
+);
+metricRight = "jeCarrier-canadian";
+note = uni161E;
+unicode = 5662;
+},
+{
+color = 9;
+glyphname = "jjeeCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(694,-13,o),
+(750,299,o),
+(750,442,cs),
+(750,626,o),
+(659,727,o),
+(487,727,cs),
+(400,727,o),
+(323,700,o),
+(261,643,c),
+(193,727,l),
+(115,663,l),
+(194,565,l),
+(156,511,o),
+(127,440,o),
+(108,352,cs),
+(34,0,l),
+(133,0,l),
+(206,341,ls),
+(247,537,o),
+(341,637,o),
+(481,637,cs),
+(598,637,o),
+(654,571,o),
+(654,437,cs),
+(654,353,o),
+(626,69,o),
+(478,69,cs),
+(420,69,o),
+(385,104,o),
+(385,167,cs),
+(385,234,o),
+(410,312,o),
+(484,329,c),
+(465,240,l),
+(521,240,l),
+(570,472,l),
+(514,472,l),
+(497,387,l),
+(372,367,o),
+(324,249,o),
+(324,150,cs),
+(324,50,o),
+(383,-13,o),
+(483,-13,cs)
+);
+}
+);
+width = 795;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161F;
+unicode = 5663;
+},
+{
+color = 9;
+glyphname = "jjiCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(644,-13,o),
+(713,181,o),
+(739,346,cs),
+(774,584,o),
+(684,727,o),
+(485,727,cs),
+(396,727,o),
+(320,699,o),
+(260,644,c),
+(193,727,l),
+(115,663,l),
+(193,567,l),
+(155,511,o),
+(127,439,o),
+(108,352,cs),
+(33,0,l),
+(133,0,l),
+(205,341,ls),
+(247,537,o),
+(341,637,o),
+(481,637,cs),
+(616,637,o),
+(671,542,o),
+(645,354,cs),
+(627,236,o),
+(593,69,o),
+(477,69,cs),
+(410,69,o),
+(378,116,o),
+(388,195,cs),
+(392,244,o),
+(409,292,o),
+(455,311,c),
+(465,294,o),
+(485,283,o),
+(508,283,cs),
+(550,283,o),
+(580,317,o),
+(580,358,cs),
+(580,399,o),
+(549,431,o),
+(508,431,cs),
+(465,431,o),
+(437,398,o),
+(435,361,c),
+(368,331,o),
+(337,262,o),
+(329,190,cs),
+(311,67,o),
+(373,-13,o),
+(483,-13,cs)
+);
+}
+);
+width = 790;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1620;
+unicode = 5664;
+},
+{
+color = 9;
+glyphname = "jjaCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(442,-13,o),
+(519,14,o),
+(581,71,c),
+(649,-13,l),
+(727,51,l),
+(648,149,l),
+(686,204,o),
+(715,274,o),
+(733,362,cs),
+(808,714,l),
+(709,714,l),
+(636,373,ls),
+(594,177,o),
+(500,77,o),
+(361,77,cs),
+(244,77,o),
+(188,143,o),
+(188,277,cs),
+(188,358,o),
+(216,645,o),
+(351,645,cs),
+(402,645,o),
+(431,613,o),
+(431,557,cs),
+(431,487,o),
+(397,397,o),
+(301,397,cs),
+(284,397,o),
+(273,398,o),
+(264,401,c),
+(248,322,l),
+(262,318,o),
+(282,315,o),
+(302,315,cs),
+(457,315,o),
+(517,454,o),
+(517,564,cs),
+(517,664,o),
+(458,727,o),
+(359,727,cs),
+(148,727,o),
+(92,415,o),
+(92,272,cs),
+(92,88,o),
+(183,-13,o),
+(355,-13,cs)
+);
+}
+);
+width = 796;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "=|jjeCarrier-canadian";
+note = uni1621;
+unicode = 5665;
+},
+{
+color = 9;
+glyphname = "luCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(524,-13,o),
+(634,86,o),
+(676,280,cs),
+(768,714,l),
+(668,714,l),
+(579,292,ls),
+(548,148,o),
+(475,77,o),
+(356,77,cs),
+(241,77,o),
+(178,143,o),
+(178,257,cs),
+(178,420,o),
+(283,622,o),
+(482,634,c),
+(499,714,l),
+(162,714,l),
+(145,631,l),
+(351,631,l),
+(425,659,l),
+(209,641,o),
+(79,442,o),
+(79,249,cs),
+(79,90,o),
+(182,-13,o),
+(353,-13,cs)
+);
+}
+);
+width = 739;
+}
+);
+metricRight = "te-canadian";
+note = uni1622;
+unicode = 5666;
+},
+{
+color = 9;
+glyphname = "loCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(118,0,l),
+(207,422,ls),
+(238,566,o),
+(311,637,o),
+(430,637,cs),
+(545,637,o),
+(607,571,o),
+(607,457,cs),
+(607,294,o),
+(502,92,o),
+(304,80,c),
+(287,0,l),
+(623,0,l),
+(641,83,l),
+(435,83,l),
+(361,55,l),
+(577,73,o),
+(707,272,o),
+(707,465,cs),
+(707,624,o),
+(604,727,o),
+(433,727,cs),
+(261,727,o),
+(152,628,o),
+(110,434,cs),
+(18,0,l)
+);
+}
+);
+width = 739;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|luCarrier-canadian";
+note = uni1623;
+unicode = 5667;
+},
+{
+color = 9;
+glyphname = "leCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (381,360);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(263,0,ls),
+(592,0,o),
+(685,257,o),
+(685,450,cs),
+(685,617,o),
+(599,727,o),
+(457,727,cs),
+(348,727,o),
+(260,661,o),
+(216,545,c),
+(227,544,l),
+(263,714,l),
+(173,714,l),
+(106,395,l),
+(190,395,l),
+(230,550,o),
+(314,637,o),
+(426,637,cs),
+(529,637,o),
+(587,563,o),
+(587,442,cs),
+(587,283,o),
+(504,90,o),
+(273,90,cs),
+(40,90,l),
+(21,0,l)
+);
+}
+);
+width = 718;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1624;
+unicode = 5668;
+},
+{
+color = 9;
+glyphname = "leeCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "leCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (308,3);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 718;
+}
+);
+metricLeft = "leCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1625;
+unicode = 5669;
+},
+{
+color = 9;
+glyphname = "liCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "leCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (282,3);
+ref = dot_middle;
+}
+);
+width = 719;
+}
+);
+note = uni1626;
+unicode = 5670;
+},
+{
+color = 9;
+glyphname = "laCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(592,0,l),
+(611,90,l),
+(397,90,ls),
+(250,90,o),
+(180,157,o),
+(180,285,cs),
+(180,416,o),
+(249,637,o),
+(437,637,cs),
+(557,637,o),
+(617,543,o),
+(592,395,c),
+(676,395,l),
+(744,714,l),
+(654,714,l),
+(615,527,l),
+(625,526,l),
+(623,650,o),
+(549,727,o),
+(428,727,cs),
+(187,727,o),
+(81,459,o),
+(81,279,cs),
+(81,102,o),
+(184,0,o),
+(384,0,cs)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|leCarrier-canadian";
+note = uni1627;
+unicode = 5671;
+},
+{
+color = 1;
+glyphname = "dluCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(602,-13,o),
+(690,243,o),
+(690,404,cs),
+(690,547,o),
+(614,642,o),
+(480,665,c),
+(515,638,l),
+(742,638,l),
+(724,554,l),
+(799,554,l),
+(851,798,l),
+(776,798,l),
+(758,714,l),
+(437,714,l),
+(420,633,l),
+(534,620,o),
+(596,545,o),
+(596,422,cs),
+(596,303,o),
+(539,77,o),
+(339,77,cs),
+(209,77,o),
+(152,162,o),
+(183,310,cs),
+(268,714,l),
+(169,714,l),
+(84,314,ls),
+(41,113,o),
+(139,-13,o),
+(334,-13,cs)
+);
+}
+);
+width = 786;
+}
+);
+metricLeft = "te-canadian";
+note = uni1628;
+unicode = 5672;
+},
+{
+color = 9;
+glyphname = "dloCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(665,-84,l),
+(717,160,l),
+(642,160,l),
+(624,77,l),
+(432,77,l),
+(426,67,l),
+(598,100,o),
+(707,285,o),
+(707,465,cs),
+(707,624,o),
+(604,727,o),
+(433,727,cs),
+(261,727,o),
+(152,628,o),
+(110,434,cs),
+(18,0,l),
+(118,0,l),
+(207,422,ls),
+(238,566,o),
+(311,637,o),
+(430,637,cs),
+(545,637,o),
+(607,571,o),
+(607,457,cs),
+(607,294,o),
+(502,92,o),
+(304,80,c),
+(287,0,l),
+(609,0,l),
+(590,-84,l)
+);
+}
+);
+width = 788;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "dluCarrier-canadian";
+note = uni1629;
+unicode = 5673;
+},
+{
+color = 9;
+glyphname = "dleCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (393,360);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(275,0,ls),
+(605,0,o),
+(698,257,o),
+(698,450,cs),
+(698,617,o),
+(611,727,o),
+(469,727,cs),
+(357,727,o),
+(251,650,o),
+(202,518,c),
+(213,518,l),
+(256,724,l),
+(343,724,l),
+(358,796,l),
+(122,796,l),
+(107,724,l),
+(188,724,l),
+(118,395,l),
+(202,395,l),
+(242,550,o),
+(326,637,o),
+(438,637,cs),
+(541,637,o),
+(599,563,o),
+(599,442,cs),
+(599,283,o),
+(517,90,o),
+(285,90,cs),
+(53,90,l),
+(34,0,l)
+);
+}
+);
+width = 731;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni162A;
+unicode = 5674;
+},
+{
+color = 9;
+glyphname = "dleeCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (319,3);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 732;
+}
+);
+note = uni162B;
+unicode = 5675;
+},
+{
+color = 9;
+glyphname = "dliCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (294,3);
+ref = dot_middle;
+}
+);
+width = 732;
+}
+);
+note = uni162C;
+unicode = 5676;
+},
+{
+color = 9;
+glyphname = "dlaCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(592,0,l),
+(611,90,l),
+(397,90,ls),
+(250,90,o),
+(180,157,o),
+(180,285,cs),
+(180,416,o),
+(249,637,o),
+(437,637,cs),
+(557,637,o),
+(617,543,o),
+(592,395,c),
+(676,395,l),
+(746,724,l),
+(826,724,l),
+(841,796,l),
+(606,796,l),
+(591,724,l),
+(672,724,l),
+(629,525,l),
+(639,523,l),
+(637,650,o),
+(549,727,o),
+(428,727,cs),
+(187,727,o),
+(81,459,o),
+(81,279,cs),
+(81,102,o),
+(184,0,o),
+(384,0,cs)
+);
+}
+);
+width = 731;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni162D;
+unicode = 5677;
+},
+{
+color = 9;
+glyphname = "lhuCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(623,-13,o),
+(728,212,o),
+(728,403,cs),
+(728,535,o),
+(668,631,o),
+(560,662,c),
+(592,629,l),
+(792,629,l),
+(810,714,l),
+(546,714,l),
+(529,634,l),
+(597,602,o),
+(633,528,o),
+(633,431,cs),
+(633,291,o),
+(571,77,o),
+(380,77,cs),
+(259,77,o),
+(189,151,o),
+(189,275,cs),
+(189,398,o),
+(252,590,o),
+(409,634,c),
+(426,714,l),
+(162,714,l),
+(144,629,l),
+(349,629,l),
+(394,666,l),
+(186,632,o),
+(90,433,o),
+(90,265,cs),
+(90,96,o),
+(200,-13,o),
+(379,-13,cs)
+);
+}
+);
+width = 774;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162E;
+unicode = 5678;
+},
+{
+color = 9;
+glyphname = "lhoCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(274,0,l),
+(291,80,l),
+(224,112,o),
+(188,186,o),
+(188,283,cs),
+(188,423,o),
+(249,637,o),
+(440,637,cs),
+(561,637,o),
+(631,563,o),
+(631,439,cs),
+(631,316,o),
+(569,124,o),
+(412,80,c),
+(394,0,l),
+(658,0,l),
+(676,85,l),
+(472,85,l),
+(426,48,l),
+(634,82,o),
+(731,281,o),
+(731,449,cs),
+(731,618,o),
+(621,727,o),
+(442,727,cs),
+(198,727,o),
+(92,502,o),
+(92,311,cs),
+(92,179,o),
+(153,83,o),
+(260,52,c),
+(228,85,l),
+(28,85,l),
+(10,0,l)
+);
+}
+);
+width = 774;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162F;
+unicode = 5679;
+},
+{
+color = 9;
+glyphname = "lheCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (399,357);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(613,-13,o),
+(715,254,o),
+(715,443,cs),
+(715,615,o),
+(622,727,o),
+(471,727,cs),
+(364,727,o),
+(275,669,o),
+(230,566,c),
+(237,565,l),
+(268,714,l),
+(179,714,l),
+(118,430,l),
+(202,430,l),
+(246,564,o),
+(331,637,o),
+(439,637,cs),
+(552,637,o),
+(616,562,o),
+(616,436,cs),
+(616,293,o),
+(542,77,o),
+(359,77,cs),
+(240,77,o),
+(164,162,o),
+(172,284,c),
+(87,284,l),
+(27,0,l),
+(116,0,l),
+(154,179,l),
+(140,176,l),
+(153,62,o),
+(245,-13,o),
+(372,-13,cs)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1630;
+unicode = 5680;
+},
+{
+color = 9;
+glyphname = "lheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (325,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 749;
+}
+);
+note = uni1631;
+unicode = 5681;
+},
+{
+color = 9;
+glyphname = "lhiCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (299,0);
+ref = dot_middle;
+}
+);
+width = 749;
+}
+);
+note = uni1632;
+unicode = 5682;
+},
+{
+color = 9;
+glyphname = "lhaCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(432,-13,o),
+(521,45,o),
+(567,148,c),
+(560,149,l),
+(528,0,l),
+(617,0,l),
+(678,284,l),
+(594,284,l),
+(550,150,o),
+(465,77,o),
+(357,77,cs),
+(244,77,o),
+(180,152,o),
+(180,278,cs),
+(180,421,o),
+(254,637,o),
+(437,637,cs),
+(556,637,o),
+(633,552,o),
+(625,430,c),
+(709,430,l),
+(769,714,l),
+(680,714,l),
+(642,535,l),
+(656,538,l),
+(643,652,o),
+(551,727,o),
+(425,727,cs),
+(184,727,o),
+(81,460,o),
+(81,271,cs),
+(81,99,o),
+(174,-13,o),
+(325,-13,cs)
+);
+}
+);
+width = 749;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1633;
+unicode = 5683;
+},
+{
+color = 9;
+glyphname = "tlhuCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(623,-13,o),
+(728,212,o),
+(728,403,cs),
+(728,530,o),
+(680,628,o),
+(574,662,c),
+(575,637,l),
+(778,637,l),
+(760,554,l),
+(835,554,l),
+(886,798,l),
+(812,798,l),
+(794,714,l),
+(546,714,l),
+(529,634,l),
+(597,602,o),
+(633,528,o),
+(633,431,cs),
+(633,291,o),
+(571,77,o),
+(380,77,cs),
+(259,77,o),
+(189,151,o),
+(189,275,cs),
+(189,398,o),
+(252,590,o),
+(409,634,c),
+(426,714,l),
+(162,714,l),
+(144,629,l),
+(349,629,l),
+(382,662,l),
+(165,621,o),
+(90,413,o),
+(90,265,cs),
+(90,96,o),
+(200,-13,o),
+(379,-13,cs)
+);
+}
+);
+width = 813;
+}
+);
+metricLeft = "lhuCarrier-canadian";
+note = uni1634;
+unicode = 5684;
+},
+{
+color = 9;
+glyphname = "tlhoCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(47,-84,l),
+(65,0,l),
+(313,0,l),
+(330,80,l),
+(262,112,o),
+(226,186,o),
+(226,283,cs),
+(226,423,o),
+(288,637,o),
+(479,637,cs),
+(600,637,o),
+(670,563,o),
+(670,439,cs),
+(670,316,o),
+(607,124,o),
+(450,80,c),
+(433,0,l),
+(697,0,l),
+(715,85,l),
+(510,85,l),
+(477,52,l),
+(694,93,o),
+(769,301,o),
+(769,449,cs),
+(769,618,o),
+(659,727,o),
+(480,727,cs),
+(236,727,o),
+(131,502,o),
+(131,311,cs),
+(131,184,o),
+(179,86,o),
+(285,52,c),
+(284,77,l),
+(81,77,l),
+(99,160,l),
+(24,160,l),
+(-27,-84,l)
+);
+}
+);
+width = 813;
+}
+);
+metricLeft = "=|tlhuCarrier-canadian";
+metricRight = "lhuCarrier-canadian";
+note = uni1635;
+unicode = 5685;
+},
+{
+color = 9;
+glyphname = "tlheCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (406,357);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(619,-13,o),
+(722,254,o),
+(722,443,cs),
+(722,615,o),
+(629,727,o),
+(478,727,cs),
+(358,727,o),
+(259,655,o),
+(207,532,c),
+(226,546,l),
+(263,724,l),
+(344,724,l),
+(359,796,l),
+(122,796,l),
+(107,724,l),
+(188,724,l),
+(125,430,l),
+(209,430,l),
+(253,564,o),
+(338,637,o),
+(446,637,cs),
+(559,637,o),
+(623,562,o),
+(623,436,cs),
+(623,293,o),
+(549,77,o),
+(365,77,cs),
+(247,77,o),
+(170,162,o),
+(178,284,c),
+(94,284,l),
+(34,0,l),
+(123,0,l),
+(161,179,l),
+(147,176,l),
+(160,62,o),
+(252,-13,o),
+(379,-13,cs)
+);
+}
+);
+width = 756;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1636;
+unicode = 5686;
+},
+{
+color = 9;
+glyphname = "tlheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (332,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 757;
+}
+);
+note = uni1637;
+unicode = 5687;
+},
+{
+color = 9;
+glyphname = "tlhiCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (307,0);
+ref = dot_middle;
+}
+);
+width = 757;
+}
+);
+note = uni1638;
+unicode = 5688;
+},
+{
+color = 9;
+glyphname = "tlhaCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(432,-13,o),
+(521,45,o),
+(567,148,c),
+(560,149,l),
+(528,0,l),
+(618,0,l),
+(678,284,l),
+(594,284,l),
+(550,150,o),
+(465,77,o),
+(357,77,cs),
+(244,77,o),
+(180,152,o),
+(180,278,cs),
+(180,421,o),
+(254,637,o),
+(437,637,cs),
+(557,637,o),
+(633,552,o),
+(625,430,c),
+(709,430,l),
+(772,724,l),
+(853,724,l),
+(868,796,l),
+(631,796,l),
+(616,724,l),
+(696,724,l),
+(655,532,l),
+(663,533,l),
+(646,654,o),
+(553,727,o),
+(425,727,cs),
+(184,727,o),
+(81,460,o),
+(81,271,cs),
+(81,99,o),
+(174,-13,o),
+(325,-13,cs)
+);
+}
+);
+width = 758;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni1639;
+unicode = 5689;
+},
+{
+color = 9;
+glyphname = "tluCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(338,-13,o),
+(401,31,o),
+(441,120,c),
+(412,121,l),
+(425,36,o),
+(485,-13,o),
+(578,-13,cs),
+(787,-13,o),
+(845,258,o),
+(845,406,cs),
+(845,532,o),
+(795,617,o),
+(704,651,c),
+(683,638,l),
+(898,638,l),
+(880,554,l),
+(955,554,l),
+(1007,798,l),
+(932,798,l),
+(914,714,l),
+(607,714,l),
+(589,633,l),
+(697,620,o),
+(750,552,o),
+(750,428,cs),
+(750,322,o),
+(712,75,o),
+(575,75,cs),
+(503,75,o),
+(471,128,o),
+(491,219,cs),
+(511,313,l),
+(415,313,l),
+(396,221,ls),
+(375,122,o),
+(335,75,o),
+(269,75,cs),
+(206,75,o),
+(174,116,o),
+(174,201,cs),
+(174,321,o),
+(237,628,o),
+(469,633,c),
+(486,714,l),
+(163,714,l),
+(145,629,l),
+(343,629,l),
+(325,644,l),
+(145,580,o),
+(75,349,o),
+(75,196,cs),
+(75,64,o),
+(139,-13,o),
+(253,-13,cs)
+);
+}
+);
+width = 933;
+}
+);
+metricRight = "tlhuCarrier-canadian";
+note = uni163A;
+unicode = 5690;
+},
+{
+color = 1;
+glyphname = "tloCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(819,-84,l),
+(871,160,l),
+(797,160,l),
+(779,77,l),
+(587,77,l),
+(604,64,l),
+(791,124,o),
+(867,359,o),
+(867,518,cs),
+(867,650,o),
+(802,727,o),
+(688,727,cs),
+(602,727,o),
+(540,682,o),
+(500,592,c),
+(529,591,l),
+(516,677,o),
+(456,727,o),
+(363,727,cs),
+(154,727,o),
+(96,456,o),
+(96,308,cs),
+(96,188,o),
+(143,105,o),
+(226,69,c),
+(249,84,l),
+(29,84,l),
+(11,0,l),
+(335,0,l),
+(352,81,l),
+(244,94,o),
+(191,162,o),
+(191,286,cs),
+(191,392,o),
+(229,639,o),
+(366,639,cs),
+(438,639,o),
+(470,586,o),
+(450,495,cs),
+(430,401,l),
+(526,401,l),
+(545,493,ls),
+(566,592,o),
+(606,639,o),
+(672,639,cs),
+(735,639,o),
+(767,598,o),
+(767,513,cs),
+(767,393,o),
+(704,86,o),
+(472,81,c),
+(455,0,l),
+(763,0,l),
+(745,-84,l)
+);
+}
+);
+width = 933;
+}
+);
+metricLeft = "tluCarrier-canadian";
+metricRight = "tlhuCarrier-canadian";
+note = uni163B;
+unicode = 5691;
+},
+{
+color = 9;
+glyphname = "tleCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (322,357);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(555,-13,o),
+(672,75,o),
+(672,219,cs),
+(672,296,o),
+(629,355,o),
+(560,368,c),
+(555,345,l),
+(666,358,o),
+(742,443,o),
+(742,548,cs),
+(742,654,o),
+(650,727,o),
+(505,727,cs),
+(376,727,o),
+(274,668,o),
+(218,558,c),
+(224,549,l),
+(261,724,l),
+(343,724,l),
+(358,796,l),
+(122,796,l),
+(107,724,l),
+(187,724,l),
+(124,430,l),
+(208,430,l),
+(246,570,o),
+(334,638,o),
+(474,638,cs),
+(580,638,o),
+(641,597,o),
+(641,529,cs),
+(641,441,o),
+(570,399,o),
+(475,399,cs),
+(431,399,l),
+(413,316,l),
+(456,316,ls),
+(532,316,o),
+(576,283,o),
+(576,224,cs),
+(576,127,o),
+(498,76,o),
+(391,76,cs),
+(244,76,o),
+(162,154,o),
+(177,284,c),
+(93,284,l),
+(33,0,l),
+(123,0,l),
+(161,180,l),
+(145,170,l),
+(156,58,o),
+(256,-13,o),
+(401,-13,cs)
+);
+}
+);
+width = 757;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni163C;
+unicode = 5692;
+},
+{
+color = 9;
+glyphname = "tleeCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (249,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 757;
+}
+);
+note = uni163D;
+unicode = 5693;
+},
+{
+color = 9;
+glyphname = "tliCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (233,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 757;
+}
+);
+note = uni163E;
+unicode = 5694;
+},
+{
+color = 9;
+glyphname = "tlaCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(417,-13,o),
+(513,37,o),
+(571,131,c),
+(561,152,l),
+(528,0,l),
+(618,0,l),
+(679,284,l),
+(595,284,l),
+(557,144,o),
+(469,76,o),
+(329,76,cs),
+(223,76,o),
+(162,117,o),
+(162,185,cs),
+(162,273,o),
+(233,315,o),
+(328,315,cs),
+(372,315,l),
+(390,398,l),
+(347,398,ls),
+(270,398,o),
+(227,431,o),
+(227,490,cs),
+(227,587,o),
+(304,638,o),
+(412,638,cs),
+(559,638,o),
+(641,560,o),
+(626,430,c),
+(710,430,l),
+(772,724,l),
+(852,724,l),
+(867,796,l),
+(631,796,l),
+(616,724,l),
+(697,724,l),
+(653,514,l),
+(667,529,l),
+(655,651,o),
+(552,727,o),
+(402,727,cs),
+(247,727,o),
+(131,639,o),
+(131,495,cs),
+(131,420,o),
+(173,362,o),
+(238,347,c),
+(243,368,l),
+(135,353,o),
+(60,270,o),
+(60,166,cs),
+(60,60,o),
+(153,-13,o),
+(297,-13,cs)
+);
+}
+);
+width = 757;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni163F;
+unicode = 5695;
+},
+{
+color = 9;
+glyphname = "zuCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(567,-13,o),
+(705,108,o),
+(705,304,cs),
+(705,393,o),
+(671,473,o),
+(671,538,cs),
+(671,594,o),
+(700,628,o),
+(760,628,cs),
+(791,628,l),
+(809,714,l),
+(760,714,ls),
+(642,714,o),
+(577,656,o),
+(577,542,cs),
+(577,469,o),
+(609,394,o),
+(609,310,cs),
+(609,169,o),
+(518,77,o),
+(368,77,cs),
+(246,77,o),
+(171,134,o),
+(171,223,cs),
+(171,363,o),
+(333,479,o),
+(333,605,cs),
+(333,671,o),
+(285,714,o),
+(206,714,cs),
+(160,714,l),
+(142,628,l),
+(178,628,ls),
+(218,628,o),
+(236,614,o),
+(236,586,cs),
+(236,501,o),
+(73,380,o),
+(73,210,cs),
+(73,77,o),
+(184,-13,o),
+(359,-13,cs)
+);
+}
+);
+width = 771;
+}
+);
+metricRight = "=|";
+note = uni1640;
+unicode = 5696;
+},
+{
+color = 9;
+glyphname = "zoCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(58,0,ls),
+(176,0,o),
+(241,58,o),
+(241,172,cs),
+(241,245,o),
+(209,320,o),
+(209,404,cs),
+(209,545,o),
+(300,637,o),
+(450,637,cs),
+(572,637,o),
+(647,580,o),
+(647,491,cs),
+(647,351,o),
+(485,235,o),
+(485,109,cs),
+(485,43,o),
+(533,0,o),
+(611,0,cs),
+(658,0,l),
+(676,86,l),
+(640,86,ls),
+(600,86,o),
+(582,100,o),
+(582,128,cs),
+(582,213,o),
+(745,334,o),
+(745,504,cs),
+(745,637,o),
+(634,727,o),
+(459,727,cs),
+(251,727,o),
+(113,606,o),
+(113,410,cs),
+(113,321,o),
+(147,241,o),
+(147,176,cs),
+(147,120,o),
+(117,86,o),
+(58,86,cs),
+(27,86,l),
+(9,0,l)
+);
+}
+);
+width = 772;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1641;
+unicode = 5697;
+},
+{
+color = 9;
+glyphname = "zeCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (402,357);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(603,-13,o),
+(701,326,o),
+(701,506,cs),
+(701,646,o),
+(641,727,o),
+(534,727,cs),
+(417,727,o),
+(314,626,o),
+(263,626,cs),
+(237,626,o),
+(228,647,o),
+(237,687,cs),
+(243,714,l),
+(152.997,714,l),
+(143,667,ls),
+(126,587,o),
+(157,538,o),
+(226,538,cs),
+(320,538,o),
+(415,637,o),
+(503,637,cs),
+(567,637,o),
+(600,586,o),
+(600,492,cs),
+(600,362,o),
+(531,77,o),
+(377,77,cs),
+(287,77,o),
+(235,176,o),
+(144,176,cs),
+(78,176,o),
+(28,129,o),
+(11,47,cs),
+(0.997,0,l),
+(91,0,l),
+(96,27,ls),
+(105,66,o),
+(125,88,o),
+(151,88,cs),
+(205,88,o),
+(270,-13,o),
+(386,-13,cs)
+);
+}
+);
+width = 724;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1642;
+unicode = 5698;
+},
+{
+color = 9;
+glyphname = "zeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (328,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 725;
+}
+);
+note = uni1643;
+unicode = 5699;
+},
+{
+color = 9;
+glyphname = "ziCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (303,0);
+ref = dot_middle;
+}
+);
+width = 725;
+}
+);
+note = uni1644;
+unicode = 5700;
+},
+{
+color = 9;
+glyphname = "zaCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(353,-13,o),
+(456,88,o),
+(507,88,cs),
+(533,88,o),
+(542,67,o),
+(533,27,cs),
+(527,0,l),
+(617,0,l),
+(627,47,ls),
+(644,127,o),
+(612,176,o),
+(544,176,cs),
+(449,176,o),
+(354,77,o),
+(267,77,cs),
+(203,77,o),
+(170,128,o),
+(170,222,cs),
+(170,352,o),
+(239,637,o),
+(392,637,cs),
+(483,637,o),
+(535,538,o),
+(625,538,cs),
+(691,538,o),
+(741,585,o),
+(759,667,cs),
+(769,714,l),
+(679,714,l),
+(673,687,ls),
+(664,648,o),
+(645,626,o),
+(619,626,cs),
+(564,626,o),
+(500,727,o),
+(384,727,cs),
+(167,727,o),
+(69,388,o),
+(69,208,cs),
+(69,68,o),
+(128,-13,o),
+(236,-13,cs)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|zeCarrier-canadian";
+note = uni1645;
+unicode = 5701;
+},
+{
+color = 6;
+glyphname = "zCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(363,189,l),
+(377,251,l),
+(142,251,l),
+(139,214,l),
+(428,510,l),
+(436,546,l),
+(130,546,l),
+(116,484,l),
+(348,484,l),
+(351,521,l),
+(62,225,l),
+(54,189,l)
+);
+}
+);
+width = 442;
+}
+);
+metricRight = "=|";
+note = uni1646;
+unicode = 5702;
+},
+{
+color = 6;
+glyphname = "initialzCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(222,99,l),
+(241,189,l),
+(363,189,l),
+(377,251,l),
+(129,251,l),
+(143,218,l),
+(428,510,l),
+(436,546,l),
+(317,546,l),
+(336,636,l),
+(268,636,l),
+(249,546,l),
+(130,546,l),
+(116,484,l),
+(360,484,l),
+(346,516,l),
+(62,225,l),
+(54,189,l),
+(173,189,l),
+(154,99,l)
+);
+}
+);
+width = 442;
+}
+);
+metricLeft = "zCarrier-canadian";
+metricRight = "zCarrier-canadian";
+note = uni1647;
+unicode = 5703;
+},
+{
+color = 9;
+glyphname = "dzuCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(567,-13,o),
+(705,108,o),
+(705,304,cs),
+(705,393,o),
+(671,473,o),
+(671,538,cs),
+(671,594,o),
+(700,628,o),
+(760,628,cs),
+(791,628,l),
+(809,714,l),
+(760,714,ls),
+(646,714,o),
+(580,656,o),
+(578,542,cs),
+(578,469,o),
+(610,391,o),
+(609,310,cs),
+(608,169,o),
+(518,77,o),
+(368,77,cs),
+(246,77,o),
+(171,134,o),
+(171,223,cs),
+(171,363,o),
+(331,479,o),
+(331,605,cs),
+(331,671,o),
+(285,714,o),
+(206,714,cs),
+(160,714,l),
+(142,628,l),
+(178,628,ls),
+(218,628,o),
+(236,614,o),
+(236,586,cs),
+(236,501,o),
+(73,380,o),
+(73,210,cs),
+(73,77,o),
+(184,-13,o),
+(359,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(462,499,l),
+(497,666,l),
+(562,666,l),
+(573,714,l),
+(393,714,l),
+(382,666,l),
+(447,666,l),
+(411,499,l)
+);
+}
+);
+width = 771;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1648;
+unicode = 5704;
+},
+{
+color = 9;
+glyphname = "dzoCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(58,0,ls),
+(172,0,o),
+(238,58,o),
+(240,172,cs),
+(240,245,o),
+(208,323,o),
+(209,404,cs),
+(209,545,o),
+(300,637,o),
+(450,637,cs),
+(572,637,o),
+(647,580,o),
+(647,491,cs),
+(647,351,o),
+(487,235,o),
+(487,109,cs),
+(487,43,o),
+(533,0,o),
+(611,0,cs),
+(658,0,l),
+(676,86,l),
+(640,86,ls),
+(600,86,o),
+(582,100,o),
+(582,128,cs),
+(582,213,o),
+(745,334,o),
+(745,504,cs),
+(745,637,o),
+(634,727,o),
+(459,727,cs),
+(251,727,o),
+(113,606,o),
+(113,410,cs),
+(113,321,o),
+(147,241,o),
+(147,176,cs),
+(147,120,o),
+(117,86,o),
+(58,86,cs),
+(27,86,l),
+(9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(425,0,l),
+(436,48,l),
+(371,48,l),
+(406,215,l),
+(356,215,l),
+(320,48,l),
+(256,48,l),
+(245,0,l)
+);
+}
+);
+width = 772;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1649;
+unicode = 5705;
+},
+{
+color = 9;
+glyphname = "dzeCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (416,357);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(627,-13,o),
+(726,326,o),
+(726,506,cs),
+(726,646,o),
+(666,727,o),
+(558,727,cs),
+(441,727,o),
+(338,626,o),
+(287,626,cs),
+(261,626,o),
+(252,647,o),
+(261,687,cs),
+(267,714,l),
+(178,714,l),
+(168,667,ls),
+(151,587,o),
+(182,538,o),
+(250,538,cs),
+(345,538,o),
+(440,637,o),
+(527,637,cs),
+(591,637,o),
+(625,586,o),
+(625,492,cs),
+(625,362,o),
+(555,77,o),
+(402,77,cs),
+(311,77,o),
+(259,176,o),
+(169,176,cs),
+(103,176,o),
+(53,129,o),
+(36,47,cs),
+(26,0,l),
+(115,0,l),
+(121,27,ls),
+(130,66,o),
+(150,88,o),
+(176,88,cs),
+(230,88,o),
+(294,-13,o),
+(410,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(135,250,l),
+(152,330,l),
+(283,330,l),
+(295,384,l),
+(163,384,l),
+(180,464,l),
+(125,464,l),
+(79,250,l)
+);
+}
+);
+width = 749;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164A;
+unicode = 5706;
+},
+{
+color = 9;
+glyphname = "dzeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "dzeCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (343,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 749;
+}
+);
+metricLeft = "dzeCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164B;
+unicode = 5707;
+},
+{
+color = 9;
+glyphname = "dziCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "dzeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (317,0);
+ref = dot_middle;
+}
+);
+width = 749;
+}
+);
+note = uni164C;
+unicode = 5708;
+},
+{
+color = 9;
+glyphname = "dzaCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(353,-13,o),
+(456,88,o),
+(508,88,cs),
+(533,88,o),
+(543,67,o),
+(533,27,cs),
+(528,0,l),
+(617,0,l),
+(627,47,ls),
+(644,127,o),
+(613,176,o),
+(544,176,cs),
+(450,176,o),
+(355,77,o),
+(268,77,cs),
+(204,77,o),
+(170,128,o),
+(170,222,cs),
+(170,352,o),
+(239,637,o),
+(393,637,cs),
+(483,637,o),
+(535,538,o),
+(626,538,cs),
+(692,538,o),
+(742,585,o),
+(759,667,cs),
+(769,714,l),
+(680,714,l),
+(674,687,ls),
+(665,648,o),
+(645,626,o),
+(619,626,cs),
+(565,626,o),
+(500,727,o),
+(384,727,cs),
+(167,727,o),
+(69,388,o),
+(69,208,cs),
+(69,68,o),
+(129,-13,o),
+(236,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(670,250,l),
+(716,464,l),
+(660,464,l),
+(643,384,l),
+(511,384,l),
+(500,330,l),
+(631,330,l),
+(614,250,l)
+);
+}
+);
+width = 749;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dzeCarrier-canadian";
+note = uni164D;
+unicode = 5709;
+},
+{
+color = 9;
+glyphname = "suCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(330,-13,o),
+(402,39,o),
+(446,146,c),
+(406,146,l),
+(417,43,o),
+(474,-13,o),
+(576,-13,cs),
+(747,-13,o),
+(813,130,o),
+(817,271,cs),
+(819,367,o),
+(790,469,o),
+(792,538,cs),
+(793,594,o),
+(820,628,o),
+(877,628,cs),
+(909,628,l),
+(928,714,l),
+(869,714,ls),
+(750,714,o),
+(701,643,o),
+(697,540,cs),
+(695,462,o),
+(722,357,o),
+(720,269,cs),
+(719,181,o),
+(684,75,o),
+(577,75,cs),
+(480,75,o),
+(473,161,o),
+(487,229,cs),
+(590,714,l),
+(497,714,l),
+(394,229,ls),
+(373,127,o),
+(324,75,o),
+(251,75,cs),
+(189,75,o),
+(155,111,o),
+(155,172,cs),
+(155,318,o),
+(332,481,o),
+(332,608,cs),
+(332,674,o),
+(288,714,o),
+(214,714,cs),
+(160,714,l),
+(142,628,l),
+(171,628,ls),
+(212,628,o),
+(232,614,o),
+(232,583,cs),
+(232,484,o),
+(55,337,o),
+(55,159,cs),
+(55,55,o),
+(121,-13,o),
+(232,-13,cs)
+);
+}
+);
+width = 890;
+}
+);
+metricRight = "=|";
+note = uni164E;
+unicode = 5710;
+},
+{
+color = 9;
+glyphname = "soCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(67,0,ls),
+(186,0,o),
+(235,71,o),
+(239,174,cs),
+(241,252,o),
+(214,357,o),
+(216,445,cs),
+(216,533,o),
+(252,639,o),
+(359,639,cs),
+(455,639,o),
+(463,553,o),
+(448,485,cs),
+(346,0,l),
+(439,0,l),
+(542,485,ls),
+(563,587,o),
+(612,639,o),
+(685,639,cs),
+(746,639,o),
+(781,603,o),
+(781,542,cs),
+(781,396,o),
+(604,233,o),
+(604,106,cs),
+(604,40,o),
+(648,0,o),
+(722,0,cs),
+(776,0,l),
+(794,86,l),
+(764,86,ls),
+(724,86,o),
+(704,100,o),
+(704,131,cs),
+(704,230,o),
+(881,377,o),
+(881,555,cs),
+(881,659,o),
+(815,727,o),
+(703,727,cs),
+(606,727,o),
+(534,675,o),
+(490,568,c),
+(530,568,l),
+(519,671,o),
+(462,727,o),
+(360,727,cs),
+(189,727,o),
+(123,584,o),
+(119,443,cs),
+(117,347,o),
+(146,245,o),
+(144,176,cs),
+(143,120,o),
+(116,86,o),
+(59,86,cs),
+(27,86,l),
+(8,0,l)
+);
+}
+);
+width = 890;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5711;
+},
+{
+color = 9;
+glyphname = "seCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(584,-13,o),
+(659,105,o),
+(659,212,cs),
+(659,287,o),
+(620,346,o),
+(549,370,c),
+(544,336,l),
+(664,361,o),
+(733,453,o),
+(733,561,cs),
+(733,658,o),
+(667,727,o),
+(570,727,cs),
+(452,727,o),
+(342,626,o),
+(287,626,cs),
+(260,626,o),
+(249,645,o),
+(258,685,cs),
+(264,714,l),
+(174,714,l),
+(165,669,ls),
+(149,592,o),
+(186,541,o),
+(256,541,cs),
+(348,541,o),
+(447,638,o),
+(540,638,cs),
+(597,638,o),
+(633,602,o),
+(633,546,cs),
+(633,463,o),
+(576,398,o),
+(474,398,cs),
+(107,398,l),
+(90,317,l),
+(459,317,ls),
+(526,317,o),
+(563,279,o),
+(563,220,cs),
+(563,154,o),
+(523,76,o),
+(439,76,cs),
+(346,76,o),
+(270,173,o),
+(167,173,cs),
+(96,173,o),
+(50,131,o),
+(32,45,cs),
+(23,0,l),
+(113,0,l),
+(118,27,ls),
+(128,68,o),
+(146,88,o),
+(175,88,cs),
+(244,88,o),
+(328,-13,o),
+(449,-13,cs)
+);
+}
+);
+width = 745;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni1650;
+unicode = 5712;
+},
+{
+color = 9;
+glyphname = "seeCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(584,-13,o),
+(659,105,o),
+(659,212,cs),
+(659,285,o),
+(622,343,o),
+(555,368,c),
+(550,340,l),
+(667,365,o),
+(733,455,o),
+(733,561,cs),
+(733,658,o),
+(667,727,o),
+(570,727,cs),
+(452,727,o),
+(342,626,o),
+(287,626,cs),
+(260,626,o),
+(249,645,o),
+(258,685,cs),
+(264,714,l),
+(174,714,l),
+(165,669,ls),
+(149,592,o),
+(186,541,o),
+(256,541,cs),
+(348,541,o),
+(447,638,o),
+(540,638,cs),
+(597,638,o),
+(633,602,o),
+(633,546,cs),
+(633,463,o),
+(576,397,o),
+(474,397,cs),
+(406,397,l),
+(421,353,l),
+(447,478,l),
+(387,478,l),
+(370,397,l),
+(107,397,l),
+(90,317,l),
+(352,317,l),
+(334,228,l),
+(394,228,l),
+(421,361,l),
+(389,317,l),
+(463,317,ls),
+(525,319,o),
+(563,280,o),
+(563,220,cs),
+(563,154,o),
+(523,76,o),
+(439,76,cs),
+(346,76,o),
+(270,173,o),
+(167,173,cs),
+(96,173,o),
+(50,131,o),
+(32,45,cs),
+(23,0,l),
+(113,0,l),
+(118,27,ls),
+(128,68,o),
+(146,88,o),
+(175,88,cs),
+(244,88,o),
+(328,-13,o),
+(449,-13,cs)
+);
+}
+);
+width = 745;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1651;
+unicode = 5713;
+},
+{
+color = 9;
+glyphname = "siCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(584,-13,o),
+(659,105,o),
+(659,212,cs),
+(659,285,o),
+(622,343,o),
+(555,368,c),
+(550,340,l),
+(667,365,o),
+(733,455,o),
+(733,561,cs),
+(733,658,o),
+(667,727,o),
+(570,727,cs),
+(452,727,o),
+(342,626,o),
+(287,626,cs),
+(260,626,o),
+(249,645,o),
+(258,685,cs),
+(264,714,l),
+(174,714,l),
+(165,669,ls),
+(149,592,o),
+(186,541,o),
+(256,541,cs),
+(348,541,o),
+(447,640,o),
+(540,640,cs),
+(597,640,o),
+(636,602,o),
+(636,546,cs),
+(636,463,o),
+(579,395,o),
+(477,395,cs),
+(409,395,l),
+(447,365,l),
+(444,409,o),
+(411,440,o),
+(368,440,cs),
+(337,440,o),
+(311,422,o),
+(299,397,c),
+(107,397,l),
+(90,317,l),
+(300,317,l),
+(312,293,o),
+(338,275,o),
+(368,275,cs),
+(409,275,o),
+(443,307,o),
+(446,348,c),
+(408,319,l),
+(464,319,ls),
+(531,319,o),
+(566,279,o),
+(566,220,cs),
+(566,154,o),
+(523,74,o),
+(439,74,cs),
+(346,74,o),
+(270,173,o),
+(167,173,cs),
+(96,173,o),
+(50,131,o),
+(32,45,cs),
+(23,0,l),
+(113,0,l),
+(118,27,ls),
+(128,68,o),
+(146,88,o),
+(175,88,cs),
+(244,88,o),
+(328,-13,o),
+(449,-13,cs)
+);
+}
+);
+width = 745;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1652;
+unicode = 5714;
+},
+{
+color = 9;
+glyphname = "saCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(339,-13,o),
+(449,88,o),
+(504,88,cs),
+(532,88,o),
+(543,69,o),
+(534,29,cs),
+(527,0,l),
+(617,0,l),
+(626,45,ls),
+(642,122,o),
+(606,173,o),
+(536,173,cs),
+(443,173,o),
+(345,76,o),
+(251,76,cs),
+(194,76,o),
+(158,112,o),
+(158,168,cs),
+(158,251,o),
+(215,316,o),
+(317,316,cs),
+(684,316,l),
+(701,397,l),
+(333,397,ls),
+(265,397,o),
+(228,435,o),
+(228,494,cs),
+(228,560,o),
+(268,638,o),
+(352,638,cs),
+(446,638,o),
+(521,541,o),
+(624,541,cs),
+(695,541,o),
+(741,583,o),
+(759,669,cs),
+(768,714,l),
+(679,714,l),
+(673,687,ls),
+(663,646,o),
+(645,626,o),
+(616,626,cs),
+(547,626,o),
+(463,727,o),
+(342,727,cs),
+(207,727,o),
+(132,609,o),
+(132,502,cs),
+(132,427,o),
+(172,368,o),
+(242,344,c),
+(248,378,l),
+(128,353,o),
+(58,261,o),
+(58,153,cs),
+(58,56,o),
+(124,-13,o),
+(222,-13,cs)
+);
+}
+);
+width = 745;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1653;
+unicode = 5715;
+},
+{
+color = 9;
+glyphname = "shuCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(324,-13,o),
+(393,34,o),
+(439,130,c),
+(409,132,l),
+(422,38,o),
+(479,-13,o),
+(576,-13,cs),
+(747,-13,o),
+(813,130,o),
+(817,271,cs),
+(819,367,o),
+(790,469,o),
+(792,538,cs),
+(793,594,o),
+(820,628,o),
+(877,628,cs),
+(909,628,l),
+(928,714,l),
+(869,714,ls),
+(755,714,o),
+(704,649,o),
+(698,551,cs),
+(697,541,o),
+(697,530,o),
+(698,518,c),
+(724,581,l),
+(563,581,l),
+(590,714,l),
+(497,714,l),
+(469,581,l),
+(304,581,l),
+(317,537,l),
+(327,562,o),
+(332,585,o),
+(332,608,cs),
+(332,674,o),
+(288,714,o),
+(214,714,cs),
+(160,714,l),
+(142,628,l),
+(171,628,ls),
+(212,628,o),
+(232,614,o),
+(232,583,cs),
+(232,484,o),
+(55,337,o),
+(55,159,cs),
+(55,55,o),
+(121,-13,o),
+(232,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(189,75,o),
+(155,111,o),
+(155,172,cs),
+(155,282,o),
+(254,395,o),
+(303,499,c),
+(452,499,l),
+(394,229,ls),
+(373,127,o),
+(324,75,o),
+(251,75,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(480,75,o),
+(473,161,o),
+(487,229,cs),
+(545,499,l),
+(697,499,l),
+(702,427,o),
+(721,344,o),
+(720,269,cs),
+(719,181,o),
+(684,75,o),
+(577,75,cs)
+);
+}
+);
+width = 890;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1654;
+unicode = 5716;
+},
+{
+color = 9;
+glyphname = "shoCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(67,0,ls),
+(181,0,o),
+(232,65,o),
+(238,163,cs),
+(239,173,o),
+(239,184,o),
+(238,196,c),
+(211,133,l),
+(373,133,l),
+(346,0,l),
+(439,0,l),
+(467,133,l),
+(632,133,l),
+(618,178,l),
+(609,152,o),
+(604,129,o),
+(604,106,cs),
+(604,40,o),
+(648,0,o),
+(722,0,cs),
+(776,0,l),
+(794,86,l),
+(765,86,ls),
+(724,86,o),
+(704,100,o),
+(704,131,cs),
+(704,230,o),
+(881,377,o),
+(881,555,cs),
+(881,659,o),
+(815,727,o),
+(703,727,cs),
+(611,727,o),
+(542,680,o),
+(497,584,c),
+(527,582,l),
+(514,676,o),
+(457,727,o),
+(360,727,cs),
+(189,727,o),
+(123,584,o),
+(119,443,cs),
+(117,347,o),
+(146,245,o),
+(144,176,cs),
+(143,120,o),
+(116,86,o),
+(59,86,cs),
+(27,86,l),
+(8,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(234,287,o),
+(214,370,o),
+(216,445,cs),
+(216,533,o),
+(252,639,o),
+(359,639,cs),
+(455,639,o),
+(463,553,o),
+(448,485,cs),
+(391,215,l),
+(238,215,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(542,485,ls),
+(563,587,o),
+(612,639,o),
+(685,639,cs),
+(746,639,o),
+(781,603,o),
+(781,542,cs),
+(781,432,o),
+(682,319,o),
+(633,215,c),
+(484,215,l)
+);
+}
+);
+width = 890;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1655;
+unicode = 5717;
+},
+{
+color = 9;
+glyphname = "sheCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(584,-13,o),
+(659,105,o),
+(659,212,cs),
+(659,285,o),
+(622,343,o),
+(555,368,c),
+(550,340,l),
+(667,365,o),
+(733,455,o),
+(733,561,cs),
+(733,658,o),
+(667,727,o),
+(570,727,cs),
+(452,727,o),
+(342,626,o),
+(287,626,cs),
+(260,626,o),
+(249,645,o),
+(258,685,cs),
+(264,714,l),
+(174,714,l),
+(165,669,ls),
+(149,592,o),
+(186,542,o),
+(256,542,cs),
+(277,542,o),
+(301,547,o),
+(318,554,c),
+(266,593,l),
+(224,398,l),
+(107,398,l),
+(90,317,l),
+(207,317,l),
+(166,120,l),
+(230,160,l),
+(209,168,o),
+(189,172,o),
+(167,172,cs),
+(96,172,o),
+(50,131,o),
+(32,45,cs),
+(23,0,l),
+(113,0,l),
+(118,27,ls),
+(128,68,o),
+(146,88,o),
+(175,88,cs),
+(244,88,o),
+(328,-13,o),
+(449,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(287,317,l),
+(459,317,ls),
+(526,317,o),
+(563,279,o),
+(563,220,cs),
+(563,154,o),
+(523,76,o),
+(439,76,cs),
+(373,76,o),
+(315,124,o),
+(251,152,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(338,562,l),
+(405,590,o),
+(474,638,o),
+(540,638,cs),
+(597,638,o),
+(633,602,o),
+(633,546,cs),
+(633,463,o),
+(576,398,o),
+(474,398,cs),
+(304,398,l)
+);
+}
+);
+width = 745;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1656;
+unicode = 5718;
+},
+{
+color = 9;
+glyphname = "sheeCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(584,-13,o),
+(659,105,o),
+(659,212,cs),
+(659,285,o),
+(622,343,o),
+(555,368,c),
+(550,340,l),
+(667,365,o),
+(733,455,o),
+(733,561,cs),
+(733,658,o),
+(667,727,o),
+(570,727,cs),
+(452,727,o),
+(342,626,o),
+(287,626,cs),
+(260,626,o),
+(249,645,o),
+(258,685,cs),
+(264,714,l),
+(174,714,l),
+(165,669,ls),
+(149,592,o),
+(186,542,o),
+(256,542,cs),
+(272,542,o),
+(288,546,o),
+(305,552,c),
+(266,593,l),
+(223,392,l),
+(106,392,l),
+(91,323,l),
+(208,323,l),
+(166,120,l),
+(222,162,l),
+(204,168,o),
+(186,172,o),
+(167,172,cs),
+(96,172,o),
+(50,131,o),
+(32,45,cs),
+(23,0,l),
+(113,0,l),
+(118,27,ls),
+(128,68,o),
+(146,88,o),
+(175,88,cs),
+(244,88,o),
+(328,-13,o),
+(449,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(371,74,o),
+(312,126,o),
+(244,154,c),
+(280,323,l),
+(393,323,l),
+(373,229,l),
+(424,229,l),
+(451,358,l),
+(432,323,l),
+(462,323,ls),
+(530,323,o),
+(566,279,o),
+(566,220,cs),
+(566,154,o),
+(523,74,o),
+(439,74,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(476,478,l),
+(426,478,l),
+(407,392,l),
+(295,392,l),
+(331,560,l),
+(401,588,o),
+(472,640,o),
+(540,640,cs),
+(597,640,o),
+(636,602,o),
+(636,546,cs),
+(636,463,o),
+(577,392,o),
+(475,392,cs),
+(447,392,l),
+(451,357,l)
+);
+}
+);
+width = 745;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1657;
+unicode = 5719;
+},
+{
+color = 9;
+glyphname = "shiCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(165,669,ls),
+(149,592,o),
+(186,542,o),
+(256,542,cs),
+(272,542,o),
+(289,546,o),
+(306,552,c),
+(266,593,l),
+(223,392,l),
+(106,392,l),
+(92,323,l),
+(208,323,l),
+(166,120,l),
+(221,162,l),
+(203,168,o),
+(186,172,o),
+(167,172,cs),
+(96,172,o),
+(50,131,o),
+(32,45,cs),
+(23,0,l),
+(113,0,l),
+(118,27,ls),
+(128,68,o),
+(146,88,o),
+(175,88,cs),
+(244,88,o),
+(328,-13,o),
+(449,-13,cs),
+(584,-13,o),
+(659,105,o),
+(659,212,cs),
+(659,285,o),
+(622,343,o),
+(555,368,c),
+(550,340,l),
+(667,365,o),
+(733,455,o),
+(733,561,cs),
+(733,658,o),
+(667,727,o),
+(570,727,cs),
+(452,727,o),
+(342,626,o),
+(287,626,cs),
+(260,626,o),
+(249,645,o),
+(258,685,cs),
+(264,714,l),
+(174,714,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(280,323,l),
+(355,323,l),
+(366,295,o),
+(393,275,o),
+(426,275,cs),
+(469,275,o),
+(497,310,o),
+(503,348,c),
+(441,323,l),
+(466,323,ls),
+(532,323,o),
+(566,279,o),
+(566,220,cs),
+(566,154,o),
+(523,74,o),
+(439,74,cs),
+(371,74,o),
+(312,126,o),
+(244,154,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(330,560,l),
+(401,588,o),
+(472,640,o),
+(540,640,cs),
+(597,640,o),
+(636,602,o),
+(636,546,cs),
+(636,463,o),
+(579,392,o),
+(479,392,cs),
+(441,392,l),
+(502,366,l),
+(500,405,o),
+(469,440,o),
+(425,440,cs),
+(393,440,o),
+(365,420,o),
+(354,392,c),
+(295,392,l)
+);
+}
+);
+width = 745;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1658;
+unicode = 5720;
+},
+{
+color = 9;
+glyphname = "shaCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(339,-13,o),
+(449,88,o),
+(504,88,cs),
+(532,88,o),
+(543,69,o),
+(534,29,cs),
+(527,0,l),
+(617,0,l),
+(626,45,ls),
+(642,122,o),
+(606,172,o),
+(536,172,cs),
+(514,172,o),
+(490,167,o),
+(474,160,c),
+(526,121,l),
+(567,316,l),
+(684,316,l),
+(701,397,l),
+(584,397,l),
+(626,594,l),
+(562,554,l),
+(582,546,o),
+(602,542,o),
+(624,542,cs),
+(695,542,o),
+(741,583,o),
+(759,669,cs),
+(768,714,l),
+(679,714,l),
+(673,687,ls),
+(663,646,o),
+(645,626,o),
+(616,626,cs),
+(547,626,o),
+(463,727,o),
+(342,727,cs),
+(207,727,o),
+(132,609,o),
+(132,502,cs),
+(132,429,o),
+(169,371,o),
+(236,346,c),
+(241,374,l),
+(124,349,o),
+(58,259,o),
+(58,153,cs),
+(58,56,o),
+(124,-13,o),
+(221,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(194,76,o),
+(158,112,o),
+(158,168,cs),
+(158,251,o),
+(215,316,o),
+(317,316,cs),
+(488,316,l),
+(453,152,l),
+(386,124,o),
+(317,76,o),
+(251,76,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(265,397,o),
+(228,435,o),
+(228,494,cs),
+(228,560,o),
+(268,638,o),
+(352,638,cs),
+(419,638,o),
+(476,590,o),
+(540,562,c),
+(505,397,l),
+(333,397,ls)
+);
+}
+);
+width = 745;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1659;
+unicode = 5721;
+},
+{
+color = 6;
+glyphname = "shCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(213,99,l),
+(236,206,l),
+(175,189,l),
+(226,189,ls),
+(315,189,o),
+(366,232,o),
+(366,309,cs),
+(366,361,o),
+(331,395,o),
+(267,395,cs),
+(221,395,ls),
+(186,395,o),
+(170,409,o),
+(170,432,cs),
+(170,471,o),
+(195,492,o),
+(241,492,cs),
+(402,492,l),
+(414,546,l),
+(308,546,l),
+(327,636,l),
+(260,636,l),
+(237,527,l),
+(295,546,l),
+(248,546,ls),
+(159,546,o),
+(107,503,o),
+(107,426,cs),
+(107,375,o),
+(143,341,o),
+(207,341,cs),
+(252,341,ls),
+(288,341,o),
+(304,327,o),
+(304,303,cs),
+(304,265,o),
+(280,243,o),
+(233,243,cs),
+(72,243,l),
+(60,189,l),
+(165,189,l),
+(146,99,l)
+);
+}
+);
+width = 422;
+}
+);
+metricRight = "=|";
+note = uni18F5;
+unicode = 5722;
+},
+{
+color = 9;
+glyphname = "tsuCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(324,-13,o),
+(393,34,o),
+(439,130,c),
+(409,132,l),
+(422,38,o),
+(479,-13,o),
+(576,-13,cs),
+(747,-13,o),
+(813,130,o),
+(817,271,cs),
+(819,367,o),
+(790,469,o),
+(792,538,cs),
+(793,594,o),
+(820,628,o),
+(877,628,cs),
+(909,628,l),
+(928,714,l),
+(869,714,ls),
+(750,714,o),
+(701,643,o),
+(698,540,cs),
+(697,499,o),
+(709,450,o),
+(715,398,c),
+(522,398,l),
+(574,643,l),
+(652,643,l),
+(667,714,l),
+(421,714,l),
+(405,643,l),
+(483,643,l),
+(431,398,l),
+(239,398,l),
+(282,476,o),
+(332,545,o),
+(332,608,cs),
+(332,674,o),
+(288,714,o),
+(214,714,cs),
+(160,714,l),
+(142,628,l),
+(171,628,ls),
+(212,628,o),
+(232,614,o),
+(232,583,cs),
+(232,484,o),
+(55,337,o),
+(55,159,cs),
+(55,55,o),
+(121,-13,o),
+(232,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(189,75,o),
+(155,111,o),
+(155,172,cs),
+(155,219,o),
+(173,268,o),
+(198,316,c),
+(414,316,l),
+(395,229,ls),
+(374,127,o),
+(324,75,o),
+(251,75,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(480,75,o),
+(472,161,o),
+(486,229,cs),
+(504,316,l),
+(719,316,l),
+(721,297,o),
+(721,279,o),
+(720,262,cs),
+(719,180,o),
+(684,75,o),
+(577,75,cs)
+);
+}
+);
+width = 890;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165B;
+unicode = 5723;
+},
+{
+color = 9;
+glyphname = "tsoCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(67,0,ls),
+(186,0,o),
+(235,71,o),
+(238,174,cs),
+(239,215,o),
+(227,264,o),
+(221,316,c),
+(414,316,l),
+(362,71,l),
+(284,71,l),
+(269,0,l),
+(515,0,l),
+(531,71,l),
+(453,71,l),
+(505,316,l),
+(697,316,l),
+(654,238,o),
+(604,169,o),
+(604,106,cs),
+(604,40,o),
+(648,0,o),
+(722,0,cs),
+(776,0,l),
+(794,86,l),
+(765,86,ls),
+(724,86,o),
+(704,100,o),
+(704,131,cs),
+(704,230,o),
+(881,377,o),
+(881,555,cs),
+(881,659,o),
+(815,727,o),
+(703,727,cs),
+(611,727,o),
+(543,680,o),
+(497,584,c),
+(527,582,l),
+(514,676,o),
+(457,727,o),
+(360,727,cs),
+(189,727,o),
+(123,584,o),
+(119,443,cs),
+(117,347,o),
+(146,245,o),
+(144,176,cs),
+(143,120,o),
+(116,86,o),
+(59,86,cs),
+(27,86,l),
+(8,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(215,417,o),
+(215,435,o),
+(216,452,cs),
+(216,534,o),
+(252,639,o),
+(359,639,cs),
+(455,639,o),
+(464,553,o),
+(450,485,cs),
+(431,398,l),
+(217,398,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(541,485,ls),
+(562,587,o),
+(612,639,o),
+(685,639,cs),
+(746,639,o),
+(781,603,o),
+(781,542,cs),
+(781,495,o),
+(763,446,o),
+(738,398,c),
+(522,398,l)
+);
+}
+);
+width = 890;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165C;
+unicode = 5724;
+},
+{
+color = 9;
+glyphname = "tseCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(588,-13,o),
+(663,105,o),
+(663,212,cs),
+(663,285,o),
+(625,343,o),
+(559,368,c),
+(554,340,l),
+(670,365,o),
+(737,455,o),
+(737,561,cs),
+(737,658,o),
+(671,727,o),
+(573,727,cs),
+(456,727,o),
+(346,626,o),
+(291,626,cs),
+(264,626,o),
+(253,645,o),
+(262,685,cs),
+(268,714,l),
+(179,714,l),
+(169,669,ls),
+(153,592,o),
+(190,544,o),
+(258,544,cs),
+(289,544,o),
+(322,555,o),
+(355,571,c),
+(327,605,l),
+(282,392,l),
+(169,392,l),
+(188,481,l),
+(129,481,l),
+(76,232,l),
+(136,232,l),
+(155,322,l),
+(267,322,l),
+(222,111,l),
+(263,145,l),
+(235,159,o),
+(200,170,o),
+(172,170,cs),
+(100,170,o),
+(55,131,o),
+(37,45,cs),
+(27,0,l),
+(117,0,l),
+(123,27,ls),
+(132,68,o),
+(150,88,o),
+(180,88,cs),
+(249,88,o),
+(332,-13,o),
+(453,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(391,76,o),
+(345,105,o),
+(298,130,c),
+(338,322,l),
+(463,322,ls),
+(531,322,o),
+(568,281,o),
+(568,220,cs),
+(568,154,o),
+(527,76,o),
+(443,76,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(395,587,l),
+(444,612,o),
+(495,638,o),
+(544,638,cs),
+(601,638,o),
+(637,602,o),
+(637,546,cs),
+(637,463,o),
+(580,392,o),
+(478,392,cs),
+(354,392,l)
+);
+}
+);
+width = 749;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni165D;
+unicode = 5725;
+},
+{
+color = 9;
+glyphname = "tseeCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(588,-13,o),
+(663,105,o),
+(663,212,cs),
+(663,285,o),
+(625,343,o),
+(559,368,c),
+(554,340,l),
+(670,365,o),
+(737,455,o),
+(737,561,cs),
+(737,658,o),
+(671,727,o),
+(573,727,cs),
+(456,727,o),
+(346,626,o),
+(291,626,cs),
+(264,626,o),
+(253,645,o),
+(262,685,cs),
+(268,714,l),
+(179,714,l),
+(169,669,ls),
+(153,592,o),
+(190,544,o),
+(258,544,cs),
+(289,544,o),
+(322,555,o),
+(355,571,c),
+(324,605,l),
+(279,392,l),
+(168,392,l),
+(187,481,l),
+(129,481,l),
+(76,232,l),
+(134,232,l),
+(153,323,l),
+(264,323,l),
+(219,111,l),
+(263,145,l),
+(235,159,o),
+(200,170,o),
+(172,170,cs),
+(100,170,o),
+(55,131,o),
+(37,45,cs),
+(27,0,l),
+(117,0,l),
+(123,27,ls),
+(132,68,o),
+(150,88,o),
+(180,88,cs),
+(249,88,o),
+(332,-13,o),
+(453,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(390,76,o),
+(341,108,o),
+(288,135,c),
+(328,323,l),
+(418,323,l),
+(398,227,l),
+(449,227,l),
+(472,337,l),
+(451,323,l),
+(463,323,ls),
+(531,323,o),
+(568,281,o),
+(568,220,cs),
+(568,152,o),
+(526,76,o),
+(443,76,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(503,480,l),
+(452,480,l),
+(433,392,l),
+(343,392,l),
+(383,582,l),
+(434,607,o),
+(493,638,o),
+(544,638,cs),
+(601,638,o),
+(638,602,o),
+(638,546,cs),
+(638,463,o),
+(580,392,o),
+(478,392,cs),
+(462,392,l),
+(482,381,l)
+);
+}
+);
+width = 749;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165E;
+unicode = 5726;
+},
+{
+color = 9;
+glyphname = "tsiCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(588,-13,o),
+(663,106,o),
+(663,213,cs),
+(663,285,o),
+(626,343,o),
+(559,368,c),
+(555,340,l),
+(671,365,o),
+(737,456,o),
+(737,562,cs),
+(737,659,o),
+(671,728,o),
+(574,728,cs),
+(456,728,o),
+(346,627,o),
+(291,627,cs),
+(264,627,o),
+(253,646,o),
+(262,685,cs),
+(268,714,l),
+(179,714,l),
+(169,670,ls),
+(153,593,o),
+(190,545,o),
+(258,545,cs),
+(285,545,o),
+(313,555,o),
+(341,568,c),
+(312,606,l),
+(267,392,l),
+(168,392,l),
+(187,481,l),
+(129,481,l),
+(76,233,l),
+(134,233,l),
+(153,323,l),
+(252,323,l),
+(207,111,l),
+(250,148,l),
+(224,161,o),
+(197,170,o),
+(172,170,cs),
+(100,170,o),
+(55,131,o),
+(37,45,cs),
+(27,0,l),
+(117,0,l),
+(123,27,ls),
+(132,69,o),
+(150,88,o),
+(180,88,cs),
+(249,88,o),
+(333,-13,o),
+(453,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(387,76,o),
+(330,114,o),
+(277,139,c),
+(315,323,l),
+(382,323,l),
+(393,295,o),
+(420,275,o),
+(451,275,cs),
+(490,275,o),
+(514,303,o),
+(523,333,c),
+(444,323,l),
+(463,323,ls),
+(531,323,o),
+(568,282,o),
+(568,221,cs),
+(568,152,o),
+(527,76,o),
+(444,76,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(516,417,o),
+(486,440,o),
+(452,440,cs),
+(421,440,o),
+(393,420,o),
+(383,392,c),
+(330,392,l),
+(370,579,l),
+(421,601,o),
+(490,639,o),
+(544,639,cs),
+(602,639,o),
+(638,603,o),
+(638,547,cs),
+(638,464,o),
+(581,392,o),
+(479,392,cs),
+(454,392,l),
+(526,382,l)
+);
+}
+);
+width = 749;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165F;
+unicode = 5727;
+},
+{
+color = 9;
+glyphname = "tsaCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(339,-13,o),
+(449,88,o),
+(504,88,cs),
+(531,88,o),
+(542,69,o),
+(533,29,cs),
+(527,0,l),
+(617,0,l),
+(626,45,ls),
+(642,122,o),
+(605,170,o),
+(537,170,cs),
+(506,170,o),
+(473,159,o),
+(440,144,c),
+(468,109,l),
+(513,322,l),
+(626,322,l),
+(607,233,l),
+(667,233,l),
+(719,482,l),
+(660,482,l),
+(641,392,l),
+(528,392,l),
+(573,603,l),
+(532,569,l),
+(560,556,o),
+(595,545,o),
+(624,545,cs),
+(695,545,o),
+(741,583,o),
+(759,670,cs),
+(768,714,l),
+(678,714,l),
+(673,688,ls),
+(663,646,o),
+(645,627,o),
+(616,627,cs),
+(547,627,o),
+(463,728,o),
+(342,728,cs),
+(207,728,o),
+(132,609,o),
+(132,502,cs),
+(132,430,o),
+(170,372,o),
+(236,347,c),
+(241,375,l),
+(124,350,o),
+(58,259,o),
+(58,153,cs),
+(58,56,o),
+(124,-13,o),
+(222,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(194,76,o),
+(158,112,o),
+(158,168,cs),
+(158,251,o),
+(215,322,o),
+(317,322,cs),
+(441,322,l),
+(400,127,l),
+(351,103,o),
+(300,76,o),
+(251,76,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(264,392,o),
+(227,433,o),
+(227,494,cs),
+(227,561,o),
+(268,639,o),
+(352,639,cs),
+(404,639,o),
+(450,610,o),
+(497,584,c),
+(457,392,l),
+(332,392,ls)
+);
+}
+);
+width = 749;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1660;
+unicode = 5728;
+},
+{
+color = 9;
+glyphname = "chuCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(324,-13,o),
+(393,34,o),
+(439,130,c),
+(409,132,l),
+(422,38,o),
+(479,-13,o),
+(576,-13,cs),
+(747,-13,o),
+(813,130,o),
+(817,271,cs),
+(819,367,o),
+(790,469,o),
+(792,538,cs),
+(793,594,o),
+(820,628,o),
+(877,628,cs),
+(909,628,l),
+(928,714,l),
+(869,714,ls),
+(750,714,o),
+(701,643,o),
+(698,540,cs),
+(695,462,o),
+(722,357,o),
+(720,269,cs),
+(719,181,o),
+(684,75,o),
+(577,75,cs),
+(480,75,o),
+(473,161,o),
+(487,229,cs),
+(575,643,l),
+(652,643,l),
+(667,714,l),
+(421,714,l),
+(405,643,l),
+(482,643,l),
+(394,229,ls),
+(373,127,o),
+(324,75,o),
+(251,75,cs),
+(189,75,o),
+(155,111,o),
+(155,172,cs),
+(155,318,o),
+(332,481,o),
+(332,608,cs),
+(332,674,o),
+(288,714,o),
+(214,714,cs),
+(160,714,l),
+(142,628,l),
+(171,628,ls),
+(212,628,o),
+(232,614,o),
+(232,583,cs),
+(232,484,o),
+(55,337,o),
+(55,159,cs),
+(55,55,o),
+(121,-13,o),
+(232,-13,cs)
+);
+}
+);
+width = 890;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164E;
+unicode = 5729;
+},
+{
+color = 9;
+glyphname = "choCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(67,0,ls),
+(186,0,o),
+(235,71,o),
+(238,174,cs),
+(241,252,o),
+(214,357,o),
+(216,445,cs),
+(216,533,o),
+(252,639,o),
+(359,639,cs),
+(455,639,o),
+(463,553,o),
+(448,485,cs),
+(361,71,l),
+(284,71,l),
+(269,0,l),
+(515,0,l),
+(531,71,l),
+(454,71,l),
+(542,485,ls),
+(563,587,o),
+(612,639,o),
+(685,639,cs),
+(746,639,o),
+(781,603,o),
+(781,542,cs),
+(781,396,o),
+(604,233,o),
+(604,106,cs),
+(604,40,o),
+(648,0,o),
+(722,0,cs),
+(776,0,l),
+(794,86,l),
+(765,86,ls),
+(724,86,o),
+(704,100,o),
+(704,131,cs),
+(704,230,o),
+(881,377,o),
+(881,555,cs),
+(881,659,o),
+(815,727,o),
+(703,727,cs),
+(611,727,o),
+(542,680,o),
+(497,584,c),
+(527,582,l),
+(514,676,o),
+(457,727,o),
+(360,727,cs),
+(189,727,o),
+(123,584,o),
+(119,443,cs),
+(117,347,o),
+(146,245,o),
+(144,176,cs),
+(143,120,o),
+(116,86,o),
+(59,86,cs),
+(27,86,l),
+(8,0,l)
+);
+}
+);
+width = 890;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5730;
+},
+{
+color = 9;
+glyphname = "cheCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(588,-13,o),
+(663,105,o),
+(663,212,cs),
+(663,285,o),
+(625,343,o),
+(559,368,c),
+(554,340,l),
+(670,365,o),
+(737,455,o),
+(737,561,cs),
+(737,658,o),
+(671,727,o),
+(573,727,cs),
+(456,727,o),
+(346,626,o),
+(291,626,cs),
+(264,626,o),
+(253,645,o),
+(262,685,cs),
+(268,714,l),
+(179,714,l),
+(169,669,ls),
+(153,592,o),
+(190,544,o),
+(260,544,cs),
+(353,544,o),
+(450,638,o),
+(544,638,cs),
+(601,638,o),
+(637,602,o),
+(637,546,cs),
+(637,463,o),
+(579,398,o),
+(478,398,cs),
+(171,398,l),
+(188,481,l),
+(129,481,l),
+(76,232,l),
+(136,232,l),
+(153,317,l),
+(462,317,ls),
+(530,317,o),
+(567,279,o),
+(567,220,cs),
+(567,154,o),
+(527,76,o),
+(443,76,cs),
+(349,76,o),
+(274,170,o),
+(172,170,cs),
+(100,170,o),
+(53,125,o),
+(37,45,cs),
+(27,0,l),
+(117,0,l),
+(123,27,ls),
+(132,68,o),
+(150,88,o),
+(180,88,cs),
+(249,88,o),
+(332,-13,o),
+(453,-13,cs)
+);
+}
+);
+width = 749;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni1663;
+unicode = 5731;
+},
+{
+color = 9;
+glyphname = "cheeCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(588,-13,o),
+(663,105,o),
+(663,212,cs),
+(663,285,o),
+(625,343,o),
+(559,368,c),
+(554,340,l),
+(670,365,o),
+(737,455,o),
+(737,561,cs),
+(737,658,o),
+(671,727,o),
+(573,727,cs),
+(456,727,o),
+(346,626,o),
+(291,626,cs),
+(264,626,o),
+(253,645,o),
+(262,685,cs),
+(268,714,l),
+(179,714,l),
+(169,669,ls),
+(153,592,o),
+(190,544,o),
+(260,544,cs),
+(353,544,o),
+(450,639,o),
+(544,639,cs),
+(601,639,o),
+(638,602,o),
+(638,546,cs),
+(638,463,o),
+(579,392,o),
+(477,392,cs),
+(413,392,l),
+(435,379,l),
+(455,478,l),
+(396,478,l),
+(377,392,l),
+(169,392,l),
+(188,481,l),
+(129,481,l),
+(76,232,l),
+(136,232,l),
+(155,323,l),
+(363,323,l),
+(343,228,l),
+(402,228,l),
+(427,341,l),
+(399,323,l),
+(465,323,ls),
+(533,323,o),
+(568,279,o),
+(568,220,cs),
+(568,154,o),
+(527,75,o),
+(443,75,cs),
+(349,75,o),
+(274,170,o),
+(172,170,cs),
+(100,170,o),
+(53,125,o),
+(37,45,cs),
+(27,0,l),
+(117,0,l),
+(123,27,ls),
+(132,68,o),
+(150,88,o),
+(180,88,cs),
+(249,88,o),
+(332,-13,o),
+(453,-13,cs)
+);
+}
+);
+width = 749;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1664;
+unicode = 5732;
+},
+{
+color = 9;
+glyphname = "chiCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(588,-13,o),
+(663,105,o),
+(663,212,cs),
+(663,285,o),
+(625,343,o),
+(559,368,c),
+(554,340,l),
+(670,365,o),
+(737,455,o),
+(737,561,cs),
+(737,658,o),
+(671,727,o),
+(573,727,cs),
+(456,727,o),
+(346,626,o),
+(291,626,cs),
+(264,626,o),
+(253,645,o),
+(262,685,cs),
+(268,714,l),
+(179,714,l),
+(169,669,ls),
+(153,592,o),
+(190,544,o),
+(260,544,cs),
+(353,544,o),
+(450,639,o),
+(544,639,cs),
+(601,639,o),
+(638,602,o),
+(638,546,cs),
+(638,463,o),
+(579,392,o),
+(479,392,cs),
+(424,392,l),
+(454,373,l),
+(450,411,o),
+(416,440,o),
+(376,440,cs),
+(342,440,o),
+(316,419,o),
+(304,392,c),
+(169,392,l),
+(189,481,l),
+(129,481,l),
+(76,233,l),
+(136,233,l),
+(155,323,l),
+(304,323,l),
+(318,294,o),
+(345,275,o),
+(376,275,cs),
+(417,275,o),
+(446,305,o),
+(454,342,c),
+(413,323,l),
+(467,323,ls),
+(532,323,o),
+(568,280,o),
+(568,220,cs),
+(568,154,o),
+(527,75,o),
+(443,75,cs),
+(350,75,o),
+(274,170,o),
+(172,170,cs),
+(100,170,o),
+(53,125,o),
+(37,45,cs),
+(27,0,l),
+(117,0,l),
+(123,27,ls),
+(132,68,o),
+(150,88,o),
+(180,88,cs),
+(249,88,o),
+(333,-13,o),
+(453,-13,cs)
+);
+}
+);
+width = 749;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1665;
+unicode = 5733;
+},
+{
+color = 9;
+glyphname = "chaCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(341,-12,o),
+(450,89,o),
+(505,89,cs),
+(532,89,o),
+(543,70,o),
+(534,30,cs),
+(528,1,l),
+(618,1,l),
+(627,46,ls),
+(643,123,o),
+(606,171,o),
+(536,171,cs),
+(443,171,o),
+(346,77,o),
+(253,77,cs),
+(195,77,o),
+(159,113,o),
+(159,169,cs),
+(159,252,o),
+(217,318,o),
+(319,318,cs),
+(626,318,l),
+(608,234,l),
+(668,234,l),
+(720,483,l),
+(661,483,l),
+(643,399,l),
+(334,399,ls),
+(266,399,o),
+(229,436,o),
+(229,495,cs),
+(229,561,o),
+(270,640,o),
+(354,640,cs),
+(447,640,o),
+(522,545,o),
+(624,545,cs),
+(696,545,o),
+(743,590,o),
+(760,671,cs),
+(769,715,l),
+(679,715,l),
+(673,689,ls),
+(664,647,o),
+(646,627,o),
+(616,627,cs),
+(548,627,o),
+(464,729,o),
+(344,729,cs),
+(208,729,o),
+(133,610,o),
+(133,503,cs),
+(133,430,o),
+(171,372,o),
+(238,347,c),
+(242,376,l),
+(126,350,o),
+(59,260,o),
+(59,154,cs),
+(59,57,o),
+(126,-12,o),
+(223,-12,cs)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1666;
+unicode = 5734;
+},
+{
+color = 9;
+glyphname = "ttsuCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(324,-13,o),
+(393,34,o),
+(439,130,c),
+(409,132,l),
+(422,38,o),
+(479,-13,o),
+(576,-13,cs),
+(747,-13,o),
+(813,130,o),
+(817,271,cs),
+(819,367,o),
+(790,469,o),
+(792,538,cs),
+(793,594,o),
+(820,628,o),
+(877,628,cs),
+(909,628,l),
+(928,714,l),
+(869,714,ls),
+(750,714,o),
+(701,643,o),
+(698,540,cs),
+(697,514,o),
+(699,488,o),
+(699,465,c),
+(738,550,l),
+(529,425,l),
+(575,643,l),
+(652,643,l),
+(667,714,l),
+(421,714,l),
+(405,643,l),
+(482,643,l),
+(436,426,l),
+(266,560,l),
+(287,469,l),
+(312,518,o),
+(332,565,o),
+(332,608,cs),
+(332,674,o),
+(288,714,o),
+(214,714,cs),
+(160,714,l),
+(142,628,l),
+(171,628,ls),
+(212,628,o),
+(232,614,o),
+(232,583,cs),
+(232,484,o),
+(55,337,o),
+(55,159,cs),
+(55,55,o),
+(121,-13,o),
+(232,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(189,75,o),
+(155,111,o),
+(155,172,cs),
+(155,266,o),
+(225,356,o),
+(274,443,c),
+(416,332,l),
+(394,229,ls),
+(373,127,o),
+(324,75,o),
+(251,75,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(480,75,o),
+(473,161,o),
+(487,229,cs),
+(507,323,l),
+(702,436,l),
+(709,382,o),
+(721,325,o),
+(720,269,cs),
+(719,181,o),
+(684,75,o),
+(577,75,cs)
+);
+}
+);
+width = 890;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1667;
+unicode = 5735;
+},
+{
+color = 9;
+glyphname = "ttsoCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(67,0,ls),
+(186,0,o),
+(235,71,o),
+(238,174,cs),
+(239,200,o),
+(237,226,o),
+(237,249,c),
+(198,164,l),
+(407,289,l),
+(361,71,l),
+(284,71,l),
+(269,0,l),
+(515,0,l),
+(531,71,l),
+(454,71,l),
+(500,288,l),
+(670,154,l),
+(649,245,l),
+(624,196,o),
+(604,149,o),
+(604,106,cs),
+(604,40,o),
+(648,0,o),
+(722,0,cs),
+(776,0,l),
+(794,86,l),
+(765,86,ls),
+(724,86,o),
+(704,100,o),
+(704,131,cs),
+(704,230,o),
+(881,377,o),
+(881,555,cs),
+(881,659,o),
+(815,727,o),
+(703,727,cs),
+(611,727,o),
+(543,680,o),
+(497,584,c),
+(527,582,l),
+(514,676,o),
+(457,727,o),
+(360,727,cs),
+(189,727,o),
+(123,584,o),
+(119,443,cs),
+(117,347,o),
+(146,245,o),
+(144,176,cs),
+(143,120,o),
+(116,86,o),
+(59,86,cs),
+(27,86,l),
+(8,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(227,332,o),
+(215,389,o),
+(216,445,cs),
+(216,533,o),
+(252,639,o),
+(359,639,cs),
+(455,639,o),
+(463,553,o),
+(448,485,cs),
+(429,391,l),
+(234,278,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(520,382,l),
+(542,485,ls),
+(563,587,o),
+(612,639,o),
+(685,639,cs),
+(746,639,o),
+(781,603,o),
+(781,542,cs),
+(781,448,o),
+(711,358,o),
+(662,271,c)
+);
+}
+);
+width = 890;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1668;
+unicode = 5736;
+},
+{
+color = 9;
+glyphname = "ttseCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(588,-13,o),
+(663,105,o),
+(663,212,cs),
+(663,285,o),
+(625,343,o),
+(558,368,c),
+(554,340,l),
+(670,365,o),
+(737,455,o),
+(737,561,cs),
+(737,658,o),
+(671,727,o),
+(573,727,cs),
+(455,727,o),
+(346,626,o),
+(291,626,cs),
+(264,626,o),
+(253,645,o),
+(262,685,cs),
+(268,714,l),
+(179,714,l),
+(169,669,ls),
+(153,593,o),
+(189,544,o),
+(260,544,cs),
+(271,544,o),
+(281,545,o),
+(292,547,c),
+(237,591,l),
+(282,392,l),
+(169,392,l),
+(189,481,l),
+(129,481,l),
+(76,232,l),
+(136,232,l),
+(155,323,l),
+(269,323,l),
+(142,129,l),
+(213,166,l),
+(200,169,o),
+(186,170,o),
+(172,170,cs),
+(99,170,o),
+(54,130,o),
+(37,45,cs),
+(27,0,l),
+(117,0,l),
+(123,27,ls),
+(132,68,o),
+(150,88,o),
+(180,88,cs),
+(248,88,o),
+(332,-13,o),
+(453,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(368,74,o),
+(306,135,o),
+(240,157,c),
+(347,323,l),
+(464,323,ls),
+(531,323,o),
+(569,282,o),
+(569,222,cs),
+(569,153,o),
+(526,74,o),
+(442,74,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(319,555,l),
+(389,574,o),
+(466,640,o),
+(543,640,cs),
+(601,640,o),
+(638,603,o),
+(638,546,cs),
+(638,463,o),
+(578,392,o),
+(477,392,cs),
+(355,392,l)
+);
+}
+);
+width = 749;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1669;
+unicode = 5737;
+},
+{
+color = 9;
+glyphname = "ttseeCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(588,-13,o),
+(663,105,o),
+(663,212,cs),
+(663,285,o),
+(625,343,o),
+(558,368,c),
+(554,340,l),
+(670,365,o),
+(737,455,o),
+(737,561,cs),
+(737,658,o),
+(671,727,o),
+(573,727,cs),
+(455,727,o),
+(346,626,o),
+(291,626,cs),
+(264,626,o),
+(253,645,o),
+(262,685,cs),
+(268,714,l),
+(179,714,l),
+(169,669,ls),
+(153,593,o),
+(189,544,o),
+(260,544,cs),
+(271,544,o),
+(281,545,o),
+(292,547,c),
+(236,591,l),
+(281,392,l),
+(169,392,l),
+(189,481,l),
+(129,481,l),
+(76,232,l),
+(136,232,l),
+(155,323,l),
+(268,323,l),
+(140,129,l),
+(213,166,l),
+(200,169,o),
+(186,170,o),
+(172,170,cs),
+(99,170,o),
+(54,130,o),
+(37,45,cs),
+(27,0,l),
+(117,0,l),
+(123,27,ls),
+(132,68,o),
+(150,88,o),
+(180,88,cs),
+(248,88,o),
+(332,-13,o),
+(453,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(368,74,o),
+(304,137,o),
+(237,158,c),
+(344,323,l),
+(412,323,l),
+(392,226,l),
+(444,226,l),
+(468,338,l),
+(447,323,l),
+(464,323,ls),
+(531,323,o),
+(569,282,o),
+(569,222,cs),
+(569,153,o),
+(526,74,o),
+(442,74,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(498,480,l),
+(446,480,l),
+(427,392,l),
+(351,392,l),
+(315,553,l),
+(386,572,o),
+(466,640,o),
+(543,640,cs),
+(601,640,o),
+(638,603,o),
+(638,546,cs),
+(638,463,o),
+(578,392,o),
+(477,392,cs),
+(459,392,l),
+(476,380,l)
+);
+}
+);
+width = 749;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166A;
+unicode = 5738;
+},
+{
+color = 9;
+glyphname = "ttsiCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(588,-13,o),
+(663,105,o),
+(663,212,cs),
+(663,285,o),
+(625,343,o),
+(558,368,c),
+(554,340,l),
+(670,365,o),
+(737,455,o),
+(737,561,cs),
+(737,658,o),
+(671,727,o),
+(573,727,cs),
+(455,727,o),
+(346,626,o),
+(291,626,cs),
+(264,626,o),
+(253,645,o),
+(262,685,cs),
+(268,714,l),
+(179,714,l),
+(169,669,ls),
+(153,593,o),
+(189,544,o),
+(260,544,cs),
+(271,544,o),
+(281,545,o),
+(292,547,c),
+(236,591,l),
+(281,392,l),
+(169,392,l),
+(189,481,l),
+(129,481,l),
+(76,232,l),
+(136,232,l),
+(155,323,l),
+(269,323,l),
+(142,129,l),
+(213,166,l),
+(200,169,o),
+(186,170,o),
+(172,170,cs),
+(99,170,o),
+(54,130,o),
+(37,45,cs),
+(27,0,l),
+(117,0,l),
+(123,27,ls),
+(132,68,o),
+(150,88,o),
+(180,88,cs),
+(248,88,o),
+(332,-13,o),
+(453,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(368,74,o),
+(298,140,o),
+(232,160,c),
+(337,323,l),
+(367,323,l),
+(379,293,o),
+(408,275,o),
+(436,275,cs),
+(474,275,o),
+(502,305,o),
+(509,338,c),
+(447,323,l),
+(476,323,ls),
+(537,323,o),
+(569,282,o),
+(569,222,cs),
+(569,153,o),
+(526,74,o),
+(442,74,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(499,416,o),
+(471,440,o),
+(435,440,cs),
+(408,440,o),
+(377,422,o),
+(367,392,c),
+(340,392,l),
+(305,550,l),
+(376,567,o),
+(466,640,o),
+(543,640,cs),
+(601,640,o),
+(638,603,o),
+(638,546,cs),
+(638,463,o),
+(585,392,o),
+(484,392,cs),
+(459,392,l),
+(508,380,l)
+);
+}
+);
+width = 749;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166B;
+unicode = 5739;
+},
+{
+color = 9;
+glyphname = "ttsaCarrier-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(340,-13,o),
+(448,88,o),
+(503,88,cs),
+(531,88,o),
+(542,69,o),
+(533,29,cs),
+(527,0,l),
+(616,0,l),
+(625,45,ls),
+(641,121,o),
+(606,170,o),
+(535,170,cs),
+(524,170,o),
+(514,169,o),
+(503,167,c),
+(558,123,l),
+(513,322,l),
+(625,322,l),
+(606,233,l),
+(666,233,l),
+(718,482,l),
+(659,482,l),
+(639,391,l),
+(526,391,l),
+(653,585,l),
+(582,548,l),
+(595,545,o),
+(609,544,o),
+(623,544,cs),
+(696,544,o),
+(740,584,o),
+(758,669,cs),
+(767,714,l),
+(678,714,l),
+(672,687,ls),
+(663,646,o),
+(645,626,o),
+(615,626,cs),
+(546,626,o),
+(463,727,o),
+(342,727,cs),
+(207,727,o),
+(132,609,o),
+(132,502,cs),
+(132,429,o),
+(170,371,o),
+(237,346,c),
+(241,374,l),
+(124,349,o),
+(58,259,o),
+(58,153,cs),
+(58,56,o),
+(124,-13,o),
+(222,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(194,74,o),
+(157,111,o),
+(157,168,cs),
+(157,251,o),
+(217,322,o),
+(318,322,cs),
+(440,322,l),
+(476,159,l),
+(406,140,o),
+(329,74,o),
+(252,74,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(264,391,o),
+(226,432,o),
+(226,492,cs),
+(226,561,o),
+(269,640,o),
+(353,640,cs),
+(427,640,o),
+(489,579,o),
+(555,557,c),
+(448,391,l),
+(331,391,ls)
+);
+}
+);
+width = 748;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni166C;
+unicode = 5740;
+},
+{
+glyphname = "qai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (341,0);
+ref = "ke-canadian";
+}
+);
+width = 948;
+}
+);
+note = uni166F;
+unicode = 5743;
+},
+{
+glyphname = "ngai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (658,0);
+ref = "ce-canadian";
+}
+);
+width = 1259;
+}
+);
+note = uni1670;
+unicode = 5744;
+},
+{
+glyphname = "nngi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (954,0);
+ref = "ci-canadian";
+}
+);
+width = 1554;
+}
+);
+note = uni1671;
+unicode = 5745;
+},
+{
+glyphname = "nngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (954,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (1186,0);
+ref = dot_top;
+}
+);
+width = 1554;
+}
+);
+note = uni1672;
+unicode = 5746;
+},
+{
+glyphname = "nngo-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (954,0);
+ref = "ce-canadian";
+}
+);
+width = 1554;
+}
+);
+note = uni1673;
+unicode = 5747;
+},
+{
+glyphname = "nngoo-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (954,0);
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (1176,0);
+ref = dot_top;
+}
+);
+width = 1554;
+}
+);
+note = uni1674;
+unicode = 5748;
+},
+{
+glyphname = "nnga-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (954,0);
+ref = "ca-canadian";
+}
+);
+width = 1554;
+}
+);
+note = uni1675;
+unicode = 5749;
+},
+{
+glyphname = "nngaa-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (954,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (998,0);
+ref = dot_top;
+}
+);
+width = 1554;
+}
+);
+note = uni1676;
+unicode = 5750;
+},
+{
+glyphname = "thweeWoodScree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (628,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 861;
+}
+);
+note = uni1677;
+unicode = 5751;
+},
+{
+glyphname = "thwiWoodScree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (628,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 861;
+}
+);
+note = uni1678;
+unicode = 5752;
+},
+{
+glyphname = "thwiiWoodScree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (89,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (628,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 861;
+}
+);
+note = uni1679;
+unicode = 5753;
+},
+{
+glyphname = "thwoWoodScree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (628,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 861;
+}
+);
+note = uni167A;
+unicode = 5754;
+},
+{
+glyphname = "thwooWoodScree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (386,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (628,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 861;
+}
+);
+note = uni167B;
+unicode = 5755;
+},
+{
+glyphname = "thwaWoodScree-canadian";
+lastChange = "2023-01-13 15:29:12 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = middle_right_can;
+pos = (629,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 861;
+}
+);
+note = uni167C;
+unicode = 5756;
+},
+{
+glyphname = "thwaaWoodScree-canadian";
+lastChange = "2023-01-13 15:29:12 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (91,0);
+ref = dot_top;
+},
+{
+anchor = middle_right_can;
+pos = (629,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 861;
+}
+);
+note = uni167D;
+unicode = 5757;
+},
+{
+glyphname = "wBlackfoot-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(466,577,l),
+(479,636,l),
+(149,636,l),
+(137,577,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(436,435,l),
+(448,494,l),
+(119,494,l),
+(106,435,l)
+);
+}
+);
+width = 463;
+}
+);
+metricRight = "=|";
+note = uni167F;
+unicode = 5759;
+},
+{
+glyphname = "oy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-7,0);
+ref = ring_top.canadian;
+}
+);
+width = 701;
+}
+);
+note = uni18B0;
+unicode = 6320;
+},
+{
+glyphname = "ay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (450,0);
+ref = ring_top.canadian;
+}
+);
+width = 701;
+}
+);
+note = uni18B1;
+unicode = 6321;
+},
+{
+glyphname = "aay-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (195,0);
+ref = ring_top.canadian;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (503,0);
+ref = dot_top;
+}
+);
+width = 701;
+}
+);
+note = uni18B2;
+unicode = 6322;
+},
+{
+glyphname = "way-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (683,0);
+ref = ring_top.canadian;
+}
+);
+width = 933;
+}
+);
+note = uni18B3;
+unicode = 6323;
+},
+{
+glyphname = "poy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-30,0);
+ref = ring_top.canadian;
+}
+);
+width = 672;
+}
+);
+note = uni18B4;
+unicode = 6324;
+},
+{
+glyphname = "pay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (445,0);
+ref = ring_top.canadian;
+}
+);
+width = 672;
+}
+);
+note = uni18B5;
+unicode = 6325;
+},
+{
+glyphname = "pwoy-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (202,0);
+ref = ring_top.canadian;
+}
+);
+width = 905;
+}
+);
+note = uni18B6;
+unicode = 6326;
+},
+{
+glyphname = "tay-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (215,0);
+ref = ring_top.canadian;
+}
+);
+width = 628;
+}
+);
+note = uni18B7;
+unicode = 6327;
+},
+{
+glyphname = "kay-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-9,0);
+ref = ring_top.canadian;
+}
+);
+width = 607;
+}
+);
+note = uni18B8;
+unicode = 6328;
+},
+{
+glyphname = "kway-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (224,0);
+ref = ring_top.canadian;
+}
+);
+width = 839;
+}
+);
+note = uni18B9;
+unicode = 6329;
+},
+{
+glyphname = "may-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+ref = ring_top.canadian;
+}
+);
+width = 547;
+}
+);
+note = uni18BA;
+unicode = 6330;
+},
+{
+glyphname = "noy-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (355,-199);
+ref = ring_top.canadian;
+}
+);
+width = 833;
+}
+);
+note = uni18BB;
+unicode = 6331;
+},
+{
+glyphname = "nay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (135,-199);
+ref = ring_top.canadian;
+}
+);
+width = 833;
+}
+);
+note = uni18BC;
+unicode = 6332;
+},
+{
+glyphname = "lay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (136,-199);
+ref = ring_top.canadian;
+}
+);
+width = 833;
+}
+);
+note = uni18BD;
+unicode = 6333;
+},
+{
+glyphname = "soy-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (302,0);
+ref = ring_top.canadian;
+}
+);
+width = 558;
+}
+);
+note = uni18BE;
+unicode = 6334;
+},
+{
+glyphname = "say-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+ref = ring_top.canadian;
+}
+);
+width = 558;
+}
+);
+note = uni18BF;
+unicode = 6335;
+},
+{
+glyphname = "shoy-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (308,-199);
+ref = ring_top.canadian;
+}
+);
+width = 960;
+}
+);
+note = uni18C0;
+unicode = 6336;
+},
+{
+glyphname = "shay-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (309,-199);
+ref = ring_top.canadian;
+}
+);
+width = 960;
+}
+);
+note = uni18C1;
+unicode = 6337;
+},
+{
+glyphname = "shwoy-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (541,-199);
+ref = ring_top.canadian;
+}
+);
+width = 1193;
+}
+);
+note = uni18C2;
+unicode = 6338;
+},
+{
+glyphname = "yoy-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (334,0);
+ref = ring_top.canadian;
+}
+);
+width = 590;
+}
+);
+note = uni18C3;
+unicode = 6339;
+},
+{
+glyphname = "yay-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-1,0);
+ref = ring_top.canadian;
+}
+);
+width = 590;
+}
+);
+note = uni18C4;
+unicode = 6340;
+},
+{
+glyphname = "ray-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (188,0);
+ref = ring_top.canadian;
+}
+);
+width = 562;
+}
+);
+note = uni18C5;
+unicode = 6341;
+},
+{
+glyphname = "nwi-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ni-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni18C6;
+unicode = 6342;
+},
+{
+glyphname = "nwiOjibway-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (833,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni18C7;
+unicode = 6343;
+},
+{
+glyphname = "nwii-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (431,-199);
+ref = dot_top;
+}
+);
+width = 1065;
+}
+);
+note = uni18C8;
+unicode = 6344;
+},
+{
+glyphname = "nwiiOjibway-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (199,-199);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (833,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni18C9;
+unicode = 6345;
+},
+{
+glyphname = "nwo-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "no-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni18CA;
+unicode = 6346;
+},
+{
+glyphname = "nwoOjibway-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (833,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni18CB;
+unicode = 6347;
+},
+{
+glyphname = "nwoo-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (640,-199);
+ref = dot_top;
+}
+);
+width = 1065;
+}
+);
+note = uni18CC;
+unicode = 6348;
+},
+{
+glyphname = "nwooOjibway-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (408,-199);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (833,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni18CD;
+unicode = 6349;
+},
+{
+glyphname = "rwee-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "reRCree-canadian";
+}
+);
+width = 1113;
+}
+);
+note = uni18CE;
+unicode = 6350;
+},
+{
+glyphname = "rwi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ri-canadian";
+}
+);
+width = 1113;
+}
+);
+note = uni18CF;
+unicode = 6351;
+},
+{
+glyphname = "rwii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (425,-199);
+ref = dot_top;
+}
+);
+width = 1113;
+}
+);
+note = uni18D0;
+unicode = 6352;
+},
+{
+glyphname = "rwo-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ro-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni18D1;
+unicode = 6353;
+},
+{
+glyphname = "rwoo-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (401,0);
+ref = dot_top;
+}
+);
+width = 794;
+}
+);
+note = uni18D2;
+unicode = 6354;
+},
+{
+glyphname = "rwa-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ra-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni18D3;
+unicode = 6355;
+},
+{
+glyphname = "pOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(144,357,l),
+(332,643,l),
+(280,643,l),
+(348,357,l),
+(411.001,357,l),
+(414,372,l),
+(328,714,l),
+(309,714,l),
+(77,372,l),
+(73,357,l)
+);
+}
+);
+width = 438;
+}
+);
+metricLeft = "kkCarrier-canadian";
+note = uni18D4;
+unicode = 6356;
+},
+{
+glyphname = "tOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 439;
+}
+);
+metricRight = "=|";
+note = uni1422;
+unicode = 6357;
+},
+{
+glyphname = "kOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(160,357,l),
+(195,521,l),
+(179,521,l),
+(180,480,o),
+(216,449,o),
+(265,449,cs),
+(352,449,o),
+(402,532,o),
+(402,607,cs),
+(402,675,o),
+(357,720,o),
+(284,720,cs),
+(210,720,o),
+(157,675,o),
+(139,590,cs),
+(90,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(224,502,o),
+(201,526,o),
+(201,563,cs),
+(201,607,o),
+(229,667,o),
+(282,667,cs),
+(318,667,o),
+(339,644,o),
+(339,606,cs),
+(339,561,o),
+(311,502,o),
+(259,502,cs)
+);
+}
+);
+width = 387;
+}
+);
+metricLeft = "k-canadian";
+metricRight = "k-canadian";
+note = uni18D6;
+unicode = 6358;
+},
+{
+glyphname = "cOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(160,357,l),
+(211,597,ls),
+(221,643,o),
+(248,664,o),
+(285,664,cs),
+(329,664,o),
+(347,635,o),
+(338,591,cs),
+(333,567,l),
+(399,567,l),
+(402,584,ls),
+(420,662,o),
+(375.01,720,o),
+(288,720,cs),
+(208,720,o),
+(158,676,o),
+(141,597,cs),
+(89,357,l)
+);
+}
+);
+width = 376;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni18D7;
+unicode = 6359;
+},
+{
+glyphname = "mOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(160,357,l),
+(222,648,l),
+(385,648,l),
+(399,714,l),
+(165,714,l),
+(89,357,l)
+);
+}
+);
+width = 350;
+}
+);
+metricLeft = "m-canadian";
+metricRight = "m-canadian";
+note = uni18D8;
+unicode = 6360;
+},
+{
+glyphname = "nOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(337,443,o),
+(390,519,o),
+(390,598,cs),
+(390,635,o),
+(372,662,o),
+(354,676,c),
+(344,648,l),
+(532,648,l),
+(546,714,l),
+(275,714,ls),
+(180,714,o),
+(127,638,o),
+(127,558,cs),
+(127,489,o),
+(174,443,o),
+(247,443,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(212,495,o),
+(190,520,o),
+(190,558,cs),
+(190,598,o),
+(212,661,o),
+(269,661,cs),
+(306,661,o),
+(328,636,o),
+(328,599,cs),
+(328,559,o),
+(306,495,o),
+(249,495,cs)
+);
+}
+);
+width = 496;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "n-canadian";
+note = uni18D9;
+unicode = 6361;
+},
+{
+glyphname = "sOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(160,357,l),
+(191,502,l),
+(141,471,l),
+(177,471,ls),
+(294,471,o),
+(365,533,o),
+(390,657,cs),
+(402,714,l),
+(332,714,l),
+(321,662,ls),
+(301,568,o),
+(254,528,o),
+(162,528,cs),
+(126,528,l),
+(89,357,l)
+);
+}
+);
+width = 369;
+}
+);
+metricLeft = "s-canadian";
+metricRight = "s-canadian";
+note = uni18DA;
+unicode = 6362;
+},
+{
+color = 1;
+glyphname = "shOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(287,352,o),
+(333,395,o),
+(357,480,cs),
+(391,594,ls),
+(405,642,o),
+(426,666,o),
+(467,666,cs),
+(509,666,o),
+(527,639,o),
+(518,594,cs),
+(513,567,l),
+(578,567,l),
+(582,589,ls),
+(598,667,o),
+(553,721,o),
+(468,721,cs),
+(391,721,o),
+(345,678,o),
+(321,592,cs),
+(287,478,ls),
+(273,430,o),
+(252,406,o),
+(211,406,cs),
+(169,406,o),
+(151,433,o),
+(160,478,cs),
+(165,505,l),
+(100,505,l),
+(96,483,ls),
+(80,405,o),
+(125,352,o),
+(210,352,cs)
+);
+}
+);
+width = 555;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "c-canadian";
+note = uni18DB;
+unicode = 6363;
+},
+{
+color = 9;
+glyphname = "easternw-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (-30,-318);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (136,0);
+ref = "glottalstop-canadian";
+}
+);
+width = 585;
+}
+);
+note = uni18DC;
+unicode = 6364;
+},
+{
+color = 9;
+glyphname = "westernw-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (744,-318);
+ref = dot_top;
+scale = (-1,1);
+},
+{
+alignment = -1;
+ref = "glottalstop-canadian";
+}
+);
+width = 587;
+}
+);
+metricLeft = "glottalstop-canadian";
+note = uni18DD;
+unicode = 6365;
+},
+{
+glyphname = "rweRCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "reRCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (880,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1113;
+}
+);
+note = uni18E0;
+unicode = 6368;
+},
+{
+glyphname = "looWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (53,0);
+ref = dot_top;
+}
+);
+width = 562;
+}
+);
+note = uni18E1;
+unicode = 6369;
+},
+{
+glyphname = "laaWestCree-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (357,0);
+ref = dot_top;
+}
+);
+width = 561;
+}
+);
+note = uni18E2;
+unicode = 6370;
+},
+{
+glyphname = "thwe-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "the-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (747,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 979;
+}
+);
+note = uni18E3;
+unicode = 6371;
+},
+{
+glyphname = "thwa-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (696,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 928;
+}
+);
+note = uni18E4;
+unicode = 6372;
+},
+{
+glyphname = "tthwe-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "tthe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (738,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 970;
+}
+);
+note = uni18E5;
+unicode = 6373;
+},
+{
+glyphname = "tthoo-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ttho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (235,0);
+ref = dot_top;
+}
+);
+width = 645;
+}
+);
+note = uni18E6;
+unicode = 6374;
+},
+{
+glyphname = "tthaa-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ttha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (253,0);
+ref = dot_top;
+}
+);
+width = 645;
+}
+);
+note = uni18E7;
+unicode = 6375;
+},
+{
+glyphname = "tlhwe-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "tlhe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (617,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 849;
+}
+);
+note = uni18E8;
+unicode = 6376;
+},
+{
+glyphname = "tlhoo-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "tlho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (248,0);
+ref = dot_top;
+}
+);
+width = 617;
+}
+);
+note = uni18E9;
+unicode = 6377;
+},
+{
+glyphname = "shweSayisi-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "sheSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (613,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni18EA;
+unicode = 6378;
+},
+{
+glyphname = "shooSayisi-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "shoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (416,0);
+ref = dot_top;
+}
+);
+width = 613;
+}
+);
+note = uni18EB;
+unicode = 6379;
+},
+{
+color = 9;
+glyphname = "hooSayisi-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "hoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (491,0);
+ref = dot_top;
+}
+);
+width = 694;
+}
+);
+note = uni18EC;
+unicode = 6380;
+},
+{
+color = 9;
+glyphname = "gwuCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "guCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (886,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1119;
+}
+);
+note = uni18ED;
+unicode = 6381;
+},
+{
+color = 9;
+glyphname = "deneGeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "geCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (294,0);
+ref = dot_top;
+}
+);
+width = 733;
+}
+);
+note = uni18EE;
+unicode = 6382;
+},
+{
+color = 9;
+glyphname = "gaaCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (306,0);
+ref = dot_top;
+}
+);
+width = 733;
+}
+);
+note = uni18EF;
+unicode = 6383;
+},
+{
+color = 9;
+glyphname = "gwaCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (733,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 965;
+}
+);
+note = uni18F0;
+unicode = 6384;
+},
+{
+color = 9;
+glyphname = "juuSayisi-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "juSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (309,0);
+ref = dot_top;
+}
+);
+width = 744;
+}
+);
+note = uni18F1;
+unicode = 6385;
+},
+{
+color = 9;
+glyphname = "jwaCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "jaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (789,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1021;
+}
+);
+note = uni18F2;
+unicode = 6386;
+},
+{
+glyphname = "lBeaverDene-canadian";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "pWestCree-canadian";
+}
+);
+width = 203;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+unicode = 6387;
+},
+{
+glyphname = "rBeaverDene-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(160,357,l),
+(203,559,ls),
+(216,619,o),
+(247,648,o),
+(295,648,cs),
+(305,648,l),
+(321,720,l),
+(313,720,ls),
+(259,720,o),
+(220,687,o),
+(208,629,c),
+(213,632,l),
+(231,714,l),
+(165,714,l),
+(89,357,l)
+);
+}
+);
+width = 252;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni18F4;
+unicode = 6388;
+},
+{
+color = 6;
+glyphname = "sDentalCarrier-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(225,189,ls),
+(315,189,o),
+(366,232,o),
+(366,309,cs),
+(366,361,o),
+(331,395,o),
+(267,395,cs),
+(221,395,ls),
+(186,395,o),
+(170,409,o),
+(170,432,cs),
+(170,471,o),
+(195,492,o),
+(241,492,cs),
+(402,492,l),
+(414,546,l),
+(249,546,ls),
+(159,546,o),
+(107,503,o),
+(107,426,cs),
+(107,374,o),
+(142,341,o),
+(206,341,cs),
+(252,341,ls),
+(288,341,o),
+(304,327,o),
+(304,303,cs),
+(304,265,o),
+(278,243,o),
+(232,243,cs),
+(72,243,l),
+(60,189,l)
+);
+}
+);
+width = 423;
+}
+);
+metricLeft = "shCarrier-canadian";
+metricRight = "=|";
+note = uni18F5;
+unicode = 6389;
+},
+{
+glyphname = "pWestCree-canadian.base";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "pWestCree-canadian";
+}
+);
+width = 203;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.base";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "c-canadian";
+}
+);
+width = 376;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "thSayisi-canadian.base";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-75,-357);
+ref = "thSayisi-canadian";
+}
+);
+width = 377;
+}
+);
+metricLeft = "=|c-canadian";
+note = uni14A2;
+},
+{
+glyphname = "mWestCree-canadian.base";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-76,-357);
+ref = "mWestCree-canadian";
+}
+);
+width = 382;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+glyphname = "pWestCree-canadian.mid";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "pWestCree-canadian";
+}
+);
+width = 203;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.mid";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "c-canadian";
+}
+);
+width = 376;
+}
+);
+metricLeft = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "mWestCree-canadian.mid";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-36,-168);
+ref = "mWestCree-canadian";
+}
+);
+width = 382;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+color = 11;
+glyphname = "ngaai-canadian.nunavik";
+lastChange = "2023-01-13 15:29:12 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (671,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (851,0);
+ref = ring_top.canadian;
+}
+);
+width = 1272;
+}
+);
+note = uni158E;
+},
+{
+color = 11;
+glyphname = "ngi-canadian.nunavik";
+lastChange = "2023-01-13 15:29:12 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (671,0);
+ref = "ci-canadian";
+}
+);
+width = 1272;
+}
+);
+note = uni158F;
+},
+{
+color = 11;
+glyphname = "ngii-canadian.nunavik";
+lastChange = "2023-01-13 15:29:12 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (671,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (904,0);
+ref = dot_top;
+}
+);
+width = 1272;
+}
+);
+note = uni1590;
+},
+{
+color = 11;
+glyphname = "ngo-canadian.nunavik";
+lastChange = "2023-01-13 15:29:12 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (671,0);
+ref = "co-canadian";
+}
+);
+width = 1272;
+}
+);
+note = uni1591;
+},
+{
+color = 11;
+glyphname = "ngoo-canadian.nunavik";
+lastChange = "2023-01-13 15:29:12 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "ngo-canadian.nunavik";
+},
+{
+anchor = top_right_can;
+pos = (1077,0);
+ref = dot_top;
+}
+);
+width = 1272;
+}
+);
+note = uni1592;
+},
+{
+color = 11;
+glyphname = "nga-canadian.nunavik";
+lastChange = "2023-01-13 15:29:12 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (671,0);
+ref = "ca-canadian";
+}
+);
+width = 1270;
+}
+);
+note = uni1593;
+},
+{
+color = 11;
+glyphname = "ngaa-canadian.nunavik";
+lastChange = "2023-01-13 15:29:12 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (671,0);
+ref = "ca-canadian";
+},
+{
+anchor = top_left_can;
+pos = (715,0);
+ref = dot_top;
+}
+);
+width = 1270;
+}
+);
+note = uni1594;
+},
+{
+color = 11;
+glyphname = "ng-canadian.nunavik";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(574,164,o),
+(627,248,o),
+(627,327,cs),
+(627,391,o),
+(587,435,o),
+(525,435,cs),
+(487,435,o),
+(453,417,o),
+(436,384,c),
+(446,366,l),
+(478,515,l),
+(328,515,l),
+(328,481,l),
+(372,505,o),
+(392,564,o),
+(392,607,cs),
+(392,674,o),
+(345,721,o),
+(271,721,cs),
+(179,721,o),
+(129,644,o),
+(129,566,cs),
+(129,496,o),
+(175,450,o),
+(248,450,cs),
+(433,450,l),
+(402,489,l),
+(365,318,ls),
+(348,237,o),
+(388,164,o),
+(479,164,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(448,218,o),
+(425,241,o),
+(425,280,cs),
+(425,324,o),
+(453,383,o),
+(505,383,cs),
+(541,383,o),
+(564,360,o),
+(564,322,cs),
+(564,276,o),
+(535,218,o),
+(483,218,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(213,502,o),
+(190,527,o),
+(190,565,cs),
+(190,612,o),
+(218,668,o),
+(270,668,cs),
+(307,668,o),
+(330,643,o),
+(330,605,cs),
+(330,559,o),
+(302,502,o),
+(250,502,cs)
+);
+}
+);
+width = 671;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+color = 11;
+glyphname = "ngai-canadian.nunavik";
+lastChange = "2023-01-13 15:29:12 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (671,0);
+ref = "ce-canadian";
+}
+);
+width = 1272;
+}
+);
+note = uni1670;
+},
+{
+color = 11;
+glyphname = "ke-canadian.square";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (452,714);
+},
+{
+name = top_left_can;
+pos = (223,714);
+},
+{
+name = top_right_can;
+pos = (692,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(589,0,l),
+(741,714,l),
+(478,714,ls),
+(233,714,o),
+(99,576,o),
+(99,374,cs),
+(99,228,o),
+(197,139,o),
+(362,139,cs),
+(519,139,l),
+(490,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(260,226,o),
+(197,282,o),
+(197,381,cs),
+(197,517,o),
+(282,626,o),
+(457,626,cs),
+(623,626,l),
+(538,226,l),
+(379,226,ls)
+);
+}
+);
+width = 721;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146B;
+},
+{
+color = 11;
+glyphname = "ki-canadian.square";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (467,714);
+},
+{
+name = top_left_can;
+pos = (228,714);
+},
+{
+name = top_right_can;
+pos = (706,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(125,0,l),
+(154,139,l),
+(324,139,ls),
+(563,139,o),
+(697,278,o),
+(697,476,cs),
+(697,624,o),
+(598,714,o),
+(434,714,cs),
+(178,714,l),
+(26,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(258,626,l),
+(418,626,ls),
+(535,626,o),
+(599,570,o),
+(599,471,cs),
+(599,336,o),
+(515,226,o),
+(343,226,cs),
+(173,226,l)
+);
+}
+);
+width = 721;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni146D;
+},
+{
+color = 11;
+glyphname = "kii-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (292,0);
+ref = dot_top;
+}
+);
+width = 722;
+}
+);
+note = uni146E;
+},
+{
+color = 11;
+glyphname = "ko-canadian.square";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (452,714);
+},
+{
+name = top_left_can;
+pos = (223,714);
+},
+{
+name = top_right_can;
+pos = (692,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(589,0,l),
+(741,714,l),
+(642,714,l),
+(613,575,l),
+(443,575,ls),
+(204,575,o),
+(70,436,o),
+(70,238,cs),
+(70,90,o),
+(168,0,o),
+(333,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(231,88,o),
+(168,144,o),
+(168,243,cs),
+(168,378,o),
+(252,488,o),
+(424,488,cs),
+(594,488,l),
+(509,88,l),
+(349,88,ls)
+);
+}
+);
+width = 721;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146F;
+},
+{
+color = 11;
+glyphname = "koo-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (518,0);
+ref = dot_top;
+}
+);
+width = 722;
+}
+);
+note = uni1470;
+},
+{
+color = 11;
+glyphname = "ka-canadian.square";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (467,714);
+},
+{
+name = top_left_can;
+pos = (228,714);
+},
+{
+name = top_right_can;
+pos = (707,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(289,0,ls),
+(533,0,o),
+(668,138,o),
+(668,340,cs),
+(668,486,o),
+(570,575,o),
+(404,575,cs),
+(248,575,l),
+(277,714,l),
+(178,714,l),
+(26,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(229,488,l),
+(387,488,ls),
+(506,488,o),
+(569,432,o),
+(569,333,cs),
+(569,197,o),
+(485,88,o),
+(310,88,cs),
+(144,88,l)
+);
+}
+);
+width = 721;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1472;
+},
+{
+color = 11;
+glyphname = "kaa-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (52,0);
+ref = dot_top;
+}
+);
+width = 722;
+}
+);
+note = uni1473;
+},
+{
+color = 11;
+glyphname = "kweWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (722,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 954;
+}
+);
+note = uni1475;
+},
+{
+color = 11;
+glyphname = "kwiiWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (292,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (722,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 954;
+}
+);
+note = uni1479;
+},
+{
+color = 11;
+glyphname = "kwoWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (722,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 954;
+}
+);
+note = uni147B;
+},
+{
+color = 11;
+glyphname = "kwooWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (518,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (722,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 954;
+}
+);
+note = uni147D;
+},
+{
+color = 11;
+glyphname = "kwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (722,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 954;
+}
+);
+note = uni147F;
+},
+{
+color = 11;
+glyphname = "kwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (52,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (722,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 954;
+}
+);
+note = uni1481;
+},
+{
+color = 11;
+glyphname = "ce-canadian.square";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (458,714);
+},
+{
+name = top_left_can;
+pos = (209,714);
+},
+{
+name = top_right_can;
+pos = (707,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(604,0,l),
+(687,392,ls),
+(731,595,o),
+(629,727,o),
+(427,727,cs),
+(255,727,o),
+(141,628,o),
+(103,447,cs),
+(93,400,l),
+(191,400,l),
+(200,439,ls),
+(228,570,o),
+(303,637,o),
+(421,637,cs),
+(560,637,o),
+(621,549,o),
+(589,396,cs),
+(505,0,l)
+);
+}
+);
+width = 727;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni1489;
+},
+{
+color = 11;
+glyphname = "ci-canadian.square";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (467,714);
+},
+{
+name = top_left_can;
+pos = (219,714);
+},
+{
+name = top_right_can;
+pos = (717,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(117,0,l),
+(207,427,ls),
+(237,567,o),
+(315,637,o),
+(437,637,cs),
+(566,637,o),
+(633,558,o),
+(607,432,cs),
+(600,400,l),
+(698,400,l),
+(704,427,ls),
+(741,605,o),
+(633,727,o),
+(441,727,cs),
+(267,727,o),
+(151,628,o),
+(112,447,cs),
+(17,0,l)
+);
+}
+);
+width = 727;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+},
+{
+color = 11;
+glyphname = "cii-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (293,0);
+ref = dot_top;
+}
+);
+width = 728;
+}
+);
+note = uni148C;
+},
+{
+color = 11;
+glyphname = "co-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (459,714);
+},
+{
+name = top_left_can;
+pos = (210,714);
+},
+{
+name = top_right_can;
+pos = (708,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(507,-13,o),
+(623,86,o),
+(662,267,cs),
+(757,714,l),
+(658,714,l),
+(567,287,ls),
+(537,147,o),
+(459,77,o),
+(337,77,cs),
+(208,77,o),
+(140,156,o),
+(167,282,cs),
+(174,314,l),
+(75,314,l),
+(69,287,ls),
+(32,109,o),
+(142,-13,o),
+(333,-13,cs)
+);
+}
+);
+width = 728;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+},
+{
+color = 11;
+glyphname = "coo-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (532,0);
+ref = dot_top;
+}
+);
+width = 728;
+}
+);
+note = uni148E;
+},
+{
+color = 11;
+glyphname = "ca-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (468,714);
+},
+{
+name = top_left_can;
+pos = (220,714);
+},
+{
+name = top_right_can;
+pos = (717,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(519,-13,o),
+(633,86,o),
+(671,267,cs),
+(681,314,l),
+(582,314,l),
+(574,275,ls),
+(546,144,o),
+(471,77,o),
+(353,77,cs),
+(214,77,o),
+(152,165,o),
+(185,318,cs),
+(269,714,l),
+(170,714,l),
+(86,322,ls),
+(43,119,o),
+(145,-13,o),
+(347,-13,cs)
+);
+}
+);
+width = 728;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+},
+{
+color = 11;
+glyphname = "caa-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (44,0);
+ref = dot_top;
+}
+);
+width = 728;
+}
+);
+note = uni1491;
+},
+{
+color = 11;
+glyphname = "me-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (396,714);
+},
+{
+name = top_double;
+pos = (597,714);
+},
+{
+name = top_left_can;
+pos = (190,714);
+},
+{
+name = top_right_can;
+pos = (597,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(494,0,l),
+(646,714,l),
+(141,714,l),
+(122,624,l),
+(528,624,l),
+(395,0,l)
+);
+}
+);
+width = 626;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+},
+{
+color = 11;
+glyphname = "mi-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (430,714);
+},
+{
+name = top_left_can;
+pos = (228,714);
+},
+{
+name = top_right_can;
+pos = (633,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(125,0,l),
+(258,624,l),
+(664,624,l),
+(683,714,l),
+(178,714,l),
+(26,0,l)
+);
+}
+);
+width = 626;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+},
+{
+color = 11;
+glyphname = "mii-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (255,0);
+ref = dot_top;
+}
+);
+width = 626;
+}
+);
+note = uni14A6;
+},
+{
+color = 11;
+glyphname = "mo-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (396,714);
+},
+{
+name = top_double;
+pos = (597,714);
+},
+{
+name = top_left_can;
+pos = (190,714);
+},
+{
+name = top_right_can;
+pos = (597,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(494,0,l),
+(646,714,l),
+(547,714,l),
+(414,90,l),
+(8,90,l),
+(-11,0,l)
+);
+}
+);
+width = 626;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+},
+{
+color = 11;
+glyphname = "moo-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (421,0);
+ref = dot_top;
+}
+);
+width = 626;
+}
+);
+note = uni14A8;
+},
+{
+color = 11;
+glyphname = "ma-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (430,714);
+},
+{
+name = top_left_can;
+pos = (228,714);
+},
+{
+name = top_right_can;
+pos = (633,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(531,0,l),
+(550,90,l),
+(144,90,l),
+(277,714,l),
+(178,714,l),
+(26,0,l)
+);
+}
+);
+width = 626;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+},
+{
+color = 11;
+glyphname = "maa-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (52,0);
+ref = dot_top;
+}
+);
+width = 626;
+}
+);
+note = uni14AB;
+},
+{
+color = 11;
+glyphname = "ne-canadian.square";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (551,714);
+},
+{
+name = top_left_can;
+pos = (353,714);
+},
+{
+name = top_right_can;
+pos = (754,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(575,-13,o),
+(667,72,o),
+(704,246,cs),
+(804,714,l),
+(156,714,l),
+(137,626,l),
+(284,626,l),
+(209,276,ls),
+(171,97,o),
+(252,-13,o),
+(424,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(325,78,o),
+(280,143,o),
+(305,260,cs),
+(383,626,l),
+(686,626,l),
+(605,247,ls),
+(581,132,o),
+(525,78,o),
+(431,78,cs)
+);
+}
+);
+width = 775;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C0;
+},
+{
+color = 11;
+glyphname = "ni-canadian.square";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (419,714);
+},
+{
+name = top_left_can;
+pos = (218,714);
+},
+{
+name = top_right_can;
+pos = (620,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(441,-13,o),
+(533,72,o),
+(570,246,cs),
+(651,626,l),
+(798,626,l),
+(817,714,l),
+(169,714,l),
+(76,276,ls),
+(38,97,o),
+(120,-13,o),
+(291,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(192,78,o),
+(147,144,o),
+(172,260,cs),
+(249,626,l),
+(552,626,l),
+(471,247,ls),
+(447,132,o),
+(392,78,o),
+(298,78,cs)
+);
+}
+);
+width = 775;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+},
+{
+color = 11;
+glyphname = "nii-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (245,0);
+ref = dot_top;
+}
+);
+width = 776;
+}
+);
+note = uni14C3;
+},
+{
+color = 11;
+glyphname = "no-canadian.square";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (554,714);
+},
+{
+name = top_double;
+pos = (564,714);
+},
+{
+name = top_left_can;
+pos = (354,714);
+},
+{
+name = top_right_can;
+pos = (751,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(652,0,l),
+(745,438,ls),
+(783,617,o),
+(702,727,o),
+(530,727,cs),
+(380,727,o),
+(288,642,o),
+(251,468,cs),
+(170,88,l),
+(23,88,l),
+(5,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(350,467,ls),
+(374,582,o),
+(429,636,o),
+(523,636,cs),
+(629,636,o),
+(674,570,o),
+(649,454,cs),
+(572,88,l),
+(269,88,l)
+);
+}
+);
+width = 775;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C4;
+},
+{
+color = 11;
+glyphname = "noo-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (379,0);
+ref = dot_top;
+}
+);
+width = 776;
+}
+);
+note = uni14C5;
+},
+{
+color = 11;
+glyphname = "na-canadian.square";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (420,714);
+},
+{
+name = top_double;
+pos = (430,714);
+},
+{
+name = top_left_can;
+pos = (219,714);
+},
+{
+name = top_right_can;
+pos = (621,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(665,0,l),
+(684,88,l),
+(537,88,l),
+(612,438,ls),
+(650,617,o),
+(568,727,o),
+(397,727,cs),
+(246,727,o),
+(154,642,o),
+(117,468,cs),
+(17,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(216,467,ls),
+(240,582,o),
+(296,636,o),
+(390,636,cs),
+(495,636,o),
+(541,571,o),
+(516,454,cs),
+(438,88,l),
+(135,88,l)
+);
+}
+);
+width = 775;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+},
+{
+color = 11;
+glyphname = "naa-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (245,0);
+ref = dot_top;
+}
+);
+width = 776;
+}
+);
+note = uni14C8;
+},
+{
+color = 11;
+glyphname = "nweWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (776,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1008;
+}
+);
+note = uni14CA;
+},
+{
+color = 11;
+glyphname = "nwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (776,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1008;
+}
+);
+note = uni14CC;
+},
+{
+color = 11;
+glyphname = "nwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (245,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (776,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1008;
+}
+);
+note = uni14CE;
+},
+{
+color = 11;
+glyphname = "se-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (225,714);
+},
+{
+name = top_right_can;
+pos = (692,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(588,0,l),
+(645,266,l),
+(414,266,ls),
+(256,266,o),
+(196,345,o),
+(232,513,cs),
+(275,714,l),
+(175,714,l),
+(133,513,ls),
+(89,306,o),
+(192,179,o),
+(396,179,cs),
+(554,179,l),
+(533,207,l),
+(489,0,l)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14ED;
+},
+{
+color = 11;
+glyphname = "si-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (227,714);
+},
+{
+name = top_right_can;
+pos = (694,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(125,0,l),
+(170,207,l),
+(136,179,l),
+(292,179,ls),
+(522,179,o),
+(651,284,o),
+(698,507,cs),
+(742,714,l),
+(643,714,l),
+(599,510,ls),
+(566,351,o),
+(463,266,o),
+(309,266,cs),
+(82,266,l),
+(26.006,0,l)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+},
+{
+color = 11;
+glyphname = "sii-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (519,0);
+ref = dot_top;
+}
+);
+width = 719;
+}
+);
+note = uni14F0;
+},
+{
+color = 11;
+glyphname = "so-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (690,714);
+},
+{
+name = top_left_can;
+pos = (225,714);
+},
+{
+name = top_right_can;
+pos = (690,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(123,0,l),
+(166,204,ls),
+(200,363,o),
+(302,448,o),
+(456,448,cs),
+(683,448,l),
+(740,714,l),
+(640,714,l),
+(596,507,l),
+(630,535,l),
+(474,535,ls),
+(244,535,o),
+(115,430,o),
+(67,207,cs),
+(23,0,l)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+},
+{
+color = 11;
+glyphname = "soo-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (515,0);
+ref = dot_top;
+}
+);
+width = 719;
+}
+);
+note = uni14F2;
+},
+{
+color = 11;
+glyphname = "sa-canadian.square";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (228,714);
+},
+{
+name = top_right_can;
+pos = (693,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(591,0,l),
+(633,201,ls),
+(677,408,o),
+(574,535,o),
+(369,535,cs),
+(211,535,l),
+(233,507,l),
+(277,714,l),
+(178,714,l),
+(121,448,l),
+(352,448,ls),
+(510,448,o),
+(570,369,o),
+(534,201,cs),
+(491,0,l)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+},
+{
+color = 11;
+glyphname = "saa-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (53,0);
+ref = dot_top;
+}
+);
+width = 719;
+}
+);
+note = uni14F5;
+},
+{
+color = 11;
+glyphname = "sho-canadian.square";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (455,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(581,0,l),
+(599,83,l),
+(274,83,ls),
+(195,83,o),
+(154,114,o),
+(154,174,cs),
+(154,260,o),
+(211,316,o),
+(321,316,cs),
+(438,316,ls),
+(612,316,o),
+(706,401,o),
+(706,547,cs),
+(706,650,o),
+(636,714,o),
+(518,714,cs),
+(177,714,l),
+(160,631,l),
+(488,631,ls),
+(567,631,o),
+(607,600,o),
+(607,540,cs),
+(607,453,o),
+(551,398,o),
+(440,398,cs),
+(324,398,ls),
+(149,398,o),
+(55,312,o),
+(55,168,cs),
+(55,65,o),
+(126,0,o),
+(244,0,cs)
+);
+}
+);
+width = 714;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+color = 11;
+glyphname = "shoo-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (281,0);
+ref = dot_top;
+}
+);
+width = 715;
+}
+);
+note = g728;
+},
+{
+color = 11;
+glyphname = "sha-canadian.square";
+lastChange = "2023-01-13 15:29:07 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (480,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(369,0,ls),
+(546,0,o),
+(639,86,o),
+(639,235,cs),
+(639,337,o),
+(570,398,o),
+(451,398,cs),
+(339,398,ls),
+(260,398,o),
+(220,427,o),
+(220,486,cs),
+(220,575,o),
+(274,631,o),
+(387,631,cs),
+(715,631,l),
+(733,714,l),
+(389,714,ls),
+(216,714,o),
+(121,629,o),
+(121,480,cs),
+(121,377,o),
+(190,316,o),
+(308,316,cs),
+(420,316,ls),
+(500,316,o),
+(540,287,o),
+(540,229,cs),
+(540,139,o),
+(484,83,o),
+(370,83,cs),
+(41,83,l),
+(24,0,l)
+);
+}
+);
+width = 714;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+color = 11;
+glyphname = "shaa-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (305,0);
+ref = dot_top;
+}
+);
+width = 715;
+}
+);
+note = g730;
+},
+{
+color = 11;
+glyphname = "ye-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (193,714);
+},
+{
+name = top_right_can;
+pos = (719,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(616,0,l),
+(673,266,l),
+(189,266,l),
+(190,212,l),
+(763,653,l),
+(706,726,l),
+(35,210,l),
+(29,179,l),
+(555,179,l),
+(517,0,l)
+);
+}
+);
+width = 744;
+}
+);
+metricLeft = "ye-canadian";
+note = uni1526;
+},
+{
+color = 11;
+glyphname = "yi-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (223,714);
+},
+{
+name = top_right_can;
+pos = (749,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,0,l),
+(159,179,l),
+(686,179,l),
+(692,210,l),
+(223,726,l),
+(148,660,l),
+(551,214,l),
+(562,266,l),
+(78,266,l),
+(22,0,l)
+);
+}
+);
+width = 744;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni1528;
+},
+{
+color = 11;
+glyphname = "yii-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (48,0);
+ref = dot_top;
+}
+);
+width = 744;
+}
+);
+note = uni1529;
+},
+{
+color = 11;
+glyphname = "yo-canadian.square";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (718,714);
+},
+{
+name = top_left_can;
+pos = (192,714);
+},
+{
+name = top_right_can;
+pos = (718,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(641,54,l),
+(238,500,l),
+(228,448,l),
+(711,448,l),
+(768,714,l),
+(668,714,l),
+(630,535,l),
+(104,535,l),
+(97,504,l),
+(567,-12,l)
+);
+}
+);
+width = 744;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152A;
+},
+{
+color = 11;
+glyphname = "yoo-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (544,0);
+ref = dot_top;
+}
+);
+width = 744;
+}
+);
+note = uni152B;
+},
+{
+color = 11;
+glyphname = "ya-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (222,714);
+},
+{
+name = top_right_can;
+pos = (747,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(755,504,l),
+(761,535,l),
+(235,535,l),
+(273,714,l),
+(173,714,l),
+(117,448,l),
+(600,448,l),
+(600,502,l),
+(26,61,l),
+(83,-12,l)
+);
+}
+);
+width = 744;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152D;
+},
+{
+color = 11;
+glyphname = "yaa-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (46,0);
+ref = dot_top;
+}
+);
+width = 744;
+}
+);
+note = uni152E;
+},
+{
+color = 11;
+glyphname = "re-canadian.square";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (419,714);
+},
+{
+name = top_left_can;
+pos = (219,714);
+},
+{
+name = top_right_can;
+pos = (621,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(441,-13,o),
+(533,72,o),
+(570,246,cs),
+(651,626,l),
+(798,626,l),
+(817,714,l),
+(571,714,l),
+(471,247,ls),
+(447,132,o),
+(392,78,o),
+(298,78,cs),
+(192,78,o),
+(147,144,o),
+(172,260,cs),
+(268,714,l),
+(169,714,l),
+(76,276,ls),
+(38,97,o),
+(120,-13,o),
+(291,-13,cs)
+);
+}
+);
+width = 775;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1542;
+},
+{
+color = 11;
+glyphname = "reRCree-canadian.square";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (553,714);
+},
+{
+name = top_left_can;
+pos = (353,714);
+},
+{
+name = top_right_can;
+pos = (754,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(575,-13,o),
+(667,72,o),
+(704,246,cs),
+(804,714,l),
+(705,714,l),
+(605,247,ls),
+(581,132,o),
+(525,78,o),
+(431,78,cs),
+(325,78,o),
+(280,143,o),
+(305,260,cs),
+(401,714,l),
+(156,714,l),
+(137,626,l),
+(284,626,l),
+(209,276,ls),
+(171,97,o),
+(252,-13,o),
+(424,-13,cs)
+);
+}
+);
+width = 775;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni1543;
+},
+{
+color = 11;
+glyphname = "leWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (554,714);
+},
+{
+name = top_left_can;
+pos = (354,714);
+},
+{
+name = top_right_can;
+pos = (755,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(251,0,l),
+(350,467,ls),
+(375,582,o),
+(429,636,o),
+(524,636,cs),
+(629,636,o),
+(674,570,o),
+(650,453,cs),
+(553,0,l),
+(653,0,l),
+(746,438,ls),
+(783,617,o),
+(702,727,o),
+(530,727,cs),
+(380,727,o),
+(288,642,o),
+(251,468,cs),
+(170,88,l),
+(23,88,l),
+(5,0,l)
+);
+}
+);
+width = 780;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+},
+{
+color = 11;
+glyphname = "ri-canadian.square";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (420,714);
+},
+{
+name = top_left_can;
+pos = (223,714);
+},
+{
+name = top_right_can;
+pos = (621,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(116,0,l),
+(216,467,ls),
+(240,582,o),
+(296,636,o),
+(390,636,cs),
+(495,636,o),
+(541,571,o),
+(516,454,cs),
+(419,0,l),
+(665,0,l),
+(684,88,l),
+(537,88,l),
+(612,438,ls),
+(650,617,o),
+(568,727,o),
+(397,727,cs),
+(246,727,o),
+(154,642,o),
+(117,468,cs),
+(17,0,l)
+);
+}
+);
+width = 775;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+},
+{
+color = 11;
+glyphname = "rii-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (245,0);
+ref = dot_top;
+}
+);
+width = 776;
+}
+);
+note = uni1547;
+},
+{
+color = 11;
+glyphname = "ro-canadian.square";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (459,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(125,0,l),
+(164,182,l),
+(110,139,l),
+(310,139,ls),
+(545,139,o),
+(679,277,o),
+(679,478,cs),
+(679,624,o),
+(580,714,o),
+(415,714,cs),
+(178.006,714,l),
+(159,626,l),
+(400,626,ls),
+(517,626,o),
+(580,570,o),
+(580,471,cs),
+(580,335,o),
+(496,226,o),
+(318,226,cs),
+(74,226,l),
+(26.006,0,l)
+);
+}
+);
+width = 702;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1548;
+},
+{
+color = 11;
+glyphname = "loWestCree-canadian.square";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (459,714);
+},
+{
+name = top_left_can;
+pos = (229,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(282,0,ls),
+(516,0,o),
+(650,138,o),
+(650,340,cs),
+(650,486,o),
+(553,575,o),
+(387,575,cs),
+(203,575,l),
+(239,532,l),
+(278,714,l),
+(179,714,l),
+(130,488,l),
+(371,488,ls),
+(490,488,o),
+(552,432,o),
+(552,333,cs),
+(552,197,o),
+(468,88,o),
+(291,88,cs),
+(45,88,l),
+(27,0,l)
+);
+}
+);
+width = 699;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+},
+{
+color = 11;
+glyphname = "ra-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (439,714);
+},
+{
+name = top_right_can;
+pos = (670,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(567,0,l),
+(615,226,l),
+(374,226,ls),
+(256,226,o),
+(194,282,o),
+(194,381,cs),
+(194,517,o),
+(278,626,o),
+(455,626,cs),
+(700,626,l),
+(719,714,l),
+(464,714,ls),
+(229,714,o),
+(95,576,o),
+(95,374,cs),
+(95,228,o),
+(193,139,o),
+(359,139,cs),
+(542,139,l),
+(506,182,l),
+(467,0,l)
+);
+}
+);
+width = 699;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+},
+{
+color = 11;
+glyphname = "raa-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (264,0);
+ref = dot_top;
+}
+);
+width = 699;
+}
+);
+note = uni154C;
+},
+{
+color = 11;
+glyphname = "laWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (670,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(567,0,l),
+(586,88,l),
+(345,88,ls),
+(227,88,o),
+(165,144,o),
+(165,243,cs),
+(165,379,o),
+(249,488,o),
+(427,488,cs),
+(671,488,l),
+(719,714,l),
+(620,714,l),
+(581,532,l),
+(636,575,l),
+(434,575,ls),
+(200,575,o),
+(66,437,o),
+(66,236,cs),
+(66,90,o),
+(164,0,o),
+(329,0,cs)
+);
+}
+);
+width = 699;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+},
+{
+color = 11;
+glyphname = "reWestCree-canadian.square";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(593,0,l),
+(881,202,l),
+(829,275,l),
+(588,107,l),
+(621,80,l),
+(688,392,ls),
+(731,596,o),
+(629,727,o),
+(428,727,cs),
+(260,727,o),
+(141,630,o),
+(103,447,cs),
+(93,400,l),
+(191,400,l),
+(200,439,ls),
+(228,570,o),
+(303,637,o),
+(421,637,cs),
+(560,637,o),
+(621,549,o),
+(589,396,cs),
+(505,0,l)
+);
+}
+);
+width = 918;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+},
+{
+color = 11;
+glyphname = "riWestCree-canadian.square";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(308,0,l),
+(398,427,ls),
+(428,567,o),
+(506,637,o),
+(628,637,cs),
+(757,637,o),
+(825,558,o),
+(798,432,cs),
+(791,400,l),
+(889,400,l),
+(895,427,ls),
+(932,605,o),
+(823,727,o),
+(632,727,cs),
+(460,727,o),
+(342,629,o),
+(303,447,cs),
+(225,80,l),
+(265,91,l),
+(85,269,l),
+(17,202,l),
+(219,0,l)
+);
+}
+);
+width = 918;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+},
+{
+color = 11;
+glyphname = "roWestCree-canadian.square";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(504,-13,o),
+(623,85,o),
+(662,267,cs),
+(740,634,l),
+(699,623,l),
+(880,445,l),
+(948,512,l),
+(745,714,l),
+(657,714,l),
+(566,287,ls),
+(536,147,o),
+(459,77,o),
+(337,77,cs),
+(208,77,o),
+(140,156,o),
+(167,282,cs),
+(174,314,l),
+(75,314,l),
+(69,287,ls),
+(32,109,o),
+(141,-13,o),
+(332,-13,cs)
+);
+}
+);
+width = 919;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+},
+{
+color = 11;
+glyphname = "raWestCree-canadian.square";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(704,-13,o),
+(823,84,o),
+(861,267,cs),
+(871,314,l),
+(773,314,l),
+(764,275,ls),
+(736,144,o),
+(661,77,o),
+(543,77,cs),
+(404,77,o),
+(342,165,o),
+(375,318,cs),
+(459,714,l),
+(371,714,l),
+(83,512,l),
+(135,439,l),
+(376,607,l),
+(343,634,l),
+(276,322,ls),
+(233,118,o),
+(335,-13,o),
+(536,-13,cs)
+);
+}
+);
+width = 918;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+},
+{
+color = 11;
+glyphname = "theThCree-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (193,714);
+},
+{
+name = top_right_can;
+pos = (719,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(616,0,l),
+(630,66,l),
+(716,66,l),
+(727,115,l),
+(641,115,l),
+(673,266,l),
+(218,266,l),
+(228,239,l),
+(763,653,l),
+(706,726,l),
+(35,210,l),
+(29,179,l),
+(555,179,l),
+(542,115,l),
+(295,115,l),
+(285,66,l),
+(531,66,l),
+(517,0,l)
+);
+}
+);
+width = 789;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15A7;
+},
+{
+color = 11;
+glyphname = "thiThCree-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (260,714);
+},
+{
+name = top_right_can;
+pos = (786,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(167,0,l),
+(181,66,l),
+(427,66,l),
+(437,115,l),
+(192,115,l),
+(205,179,l),
+(731,179,l),
+(738,210,l),
+(268,726,l),
+(194,660,l),
+(576,234,l),
+(590,266,l),
+(124,266,l),
+(92,115,l),
+(6,115,l),
+(-5,66,l),
+(81,66,l),
+(67,0,l)
+);
+}
+);
+width = 789;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+},
+{
+color = 11;
+glyphname = "thiiThCree-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (85,0);
+ref = dot_top;
+}
+);
+width = 789;
+}
+);
+note = uni15A9;
+},
+{
+color = 11;
+glyphname = "thoThCree-canadian.square";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (191,714);
+},
+{
+name = top_right_can;
+pos = (718,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(640,54,l),
+(259,480,l),
+(245,448,l),
+(711,448,l),
+(743,599,l),
+(829,599,l),
+(839,648,l),
+(753,648,l),
+(767,714,l),
+(667,714,l),
+(654,648,l),
+(408,648,l),
+(397,599,l),
+(643,599,l),
+(629,535,l),
+(104,535,l),
+(97,504,l),
+(566,-12,l)
+);
+}
+);
+width = 788;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+},
+{
+color = 11;
+glyphname = "thooThCree-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (543,0);
+ref = dot_top;
+}
+);
+width = 789;
+}
+);
+note = uni15AB;
+},
+{
+color = 11;
+glyphname = "thaThCree-canadian.square";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (270,714);
+},
+{
+name = top_right_can;
+pos = (796,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(801,504,l),
+(808,535,l),
+(281,535,l),
+(295,599,l),
+(541,599,l),
+(552,648,l),
+(306,648,l),
+(319,714,l),
+(220,714,l),
+(206,648,l),
+(120,648,l),
+(109,599,l),
+(195,599,l),
+(163,448,l),
+(618,448,l),
+(608,475,l),
+(73,61,l),
+(130,-12,l)
+);
+}
+);
+width = 790;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+},
+{
+color = 11;
+glyphname = "thaaThCree-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (94,0);
+ref = dot_top;
+}
+);
+width = 789;
+}
+);
+note = uni15AD;
+},
+{
+color = 11;
+glyphname = "thweeWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (789,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1022;
+}
+);
+note = uni1677;
+},
+{
+color = 11;
+glyphname = "thwiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (789,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1022;
+}
+);
+note = uni1678;
+},
+{
+color = 11;
+glyphname = "thwiiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (85,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (789,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1022;
+}
+);
+note = uni1679;
+},
+{
+color = 11;
+glyphname = "thwoWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (789,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1022;
+}
+);
+note = uni167A;
+},
+{
+color = 11;
+glyphname = "thwooWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (543,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (789,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1022;
+}
+);
+note = uni167B;
+},
+{
+color = 11;
+glyphname = "thwaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (789,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1022;
+}
+);
+note = uni167C;
+},
+{
+color = 11;
+glyphname = "thwaaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (94,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (789,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1022;
+}
+);
+note = uni167D;
+},
+{
+color = 11;
+glyphname = "nwiOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (776,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1008;
+}
+);
+note = uni18C7;
+},
+{
+color = 11;
+glyphname = "nwiiOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (245,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (776,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1008;
+}
+);
+note = uni18C9;
+},
+{
+color = 11;
+glyphname = "nwoOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (776,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1008;
+}
+);
+note = uni18CB;
+},
+{
+color = 11;
+glyphname = "nwooOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (379,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (776,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1008;
+}
+);
+note = uni18CD;
+},
+{
+color = 11;
+glyphname = "looWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (53,0);
+ref = dot_top;
+}
+);
+width = 699;
+}
+);
+note = uni18E1;
+},
+{
+color = 11;
+glyphname = "laaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (495,0);
+ref = dot_top;
+}
+);
+width = 699;
+}
+);
+note = uni18E2;
+},
+{
+color = 0;
+glyphname = zero;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(578,571,o),
+(519,725,o),
+(341,725,cs),
+(161,725,o),
+(102,561,o),
+(102,358,cs),
+(102,112,o),
+(186,-10,o),
+(340,-10,cs),
+(501,-10,o),
+(578,110,o),
+(578,358,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(203,483,o),
+(220,642,o),
+(341,642,cs),
+(468,642,o),
+(477,476,o),
+(477,358,cs),
+(477,199,o),
+(447,73,o),
+(340,73,cs),
+(238,73,o),
+(203,198,o),
+(203,358,cs)
+);
+}
+);
+width = 637;
+}
+);
+unicode = 48;
+},
+{
+color = 0;
+glyphname = one;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(298,714,l),
+(80,546,l),
+(134,479,l),
+(238,559,ls),
+(259,575,o),
+(272,588,o),
+(288,604,c),
+(287,571,o),
+(286,541,o),
+(286,509,cs),
+(286,0,l),
+(389,0,l),
+(389,714,l)
+);
+}
+);
+width = 512;
+}
+);
+unicode = 49;
+},
+{
+color = 0;
+glyphname = two;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(582,0,l),
+(582,85,l),
+(242,85,l),
+(242,88,l),
+(380,230,ls),
+(457,305,o),
+(510,362,o),
+(538,426,cs),
+(551,458,o),
+(557,494,o),
+(557,535,cs),
+(557,648,o),
+(472,724,o),
+(346,724,cs),
+(254,724,o),
+(185,692,o),
+(119,635,c),
+(175,568,l),
+(231,615,o),
+(284,637,o),
+(336,637,cs),
+(409,637,o),
+(457,597,o),
+(457,522,cs),
+(457,466,o),
+(438,423,o),
+(396,372,cs),
+(374,346,o),
+(347,315,o),
+(313,279,cs),
+(111,70,l),
+(111,0,l)
+);
+}
+);
+width = 633;
+}
+);
+unicode = 50;
+},
+{
+color = 0;
+glyphname = three;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(562,662,o),
+(478,724,o),
+(347,724,cs),
+(243,724,o),
+(173,694,o),
+(114,651,c),
+(158,581,l),
+(205,615,o),
+(265,641,o),
+(334,641,cs),
+(412,641,o),
+(464,607,o),
+(464,534,cs),
+(464,444,o),
+(377,408,o),
+(285,408,cs),
+(219,408,l),
+(219,329,l),
+(285,329,ls),
+(405,329,o),
+(477,298,o),
+(477,204,cs),
+(477,124,o),
+(425,72,o),
+(303,72,cs),
+(239,72,o),
+(166,90,o),
+(109,118,c),
+(109,31,l),
+(165,7,o),
+(230,-10,o),
+(315,-10,cs),
+(477,-10,o),
+(584,67,o),
+(584,198,cs),
+(584,303,o),
+(520,359,o),
+(408,373,c),
+(408,375,l),
+(496,395,o),
+(562,459,o),
+(562,555,cs)
+);
+}
+);
+width = 633;
+}
+);
+unicode = 51;
+},
+{
+color = 0;
+glyphname = four;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(469,247,l),
+(469,716,l),
+(373,716,l),
+(35,243,l),
+(35,169,l),
+(369,169,l),
+(369,0,l),
+(469,0,l),
+(469,169,l),
+(578,169,l),
+(578,247,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(129,247,l),
+(316,506,ls),
+(340,540,o),
+(350,556,o),
+(368,589,c),
+(371,589,l),
+(371,573,o),
+(369,538,o),
+(369,491,cs),
+(369,247,l)
+);
+}
+);
+width = 606;
+}
+);
+unicode = 52;
+},
+{
+color = 0;
+glyphname = five;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(276,445,o),
+(243,436,o),
+(215,430,c),
+(233,628,l),
+(514,628,l),
+(514,714,l),
+(147,714,l),
+(118,368,l),
+(161,344,l),
+(200,356,o),
+(241,364,o),
+(291,364,cs),
+(401,364,o),
+(456,312,o),
+(456,224,cs),
+(456,127,o),
+(389,72,o),
+(283,72,cs),
+(216,72,o),
+(147,93,o),
+(100,118,c),
+(100,31,l),
+(147,6,o),
+(211,-10,o),
+(290,-10,cs),
+(463,-10,o),
+(559,79,o),
+(559,226,cs),
+(559,365,o),
+(469,445,o),
+(335,445,cs)
+);
+}
+);
+width = 606;
+}
+);
+unicode = 53;
+},
+{
+color = 0;
+glyphname = six;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(88,132,o),
+(166,-10,o),
+(336,-10,cs),
+(480,-10,o),
+(567,83,o),
+(567,234,cs),
+(567,372,o),
+(491,456,o),
+(362,456,cs),
+(272,456,o),
+(212,412,o),
+(184,354,c),
+(180,354,l),
+(186,526,o),
+(249,644,o),
+(419,644,cs),
+(463,644,o),
+(495,639,o),
+(521,632,c),
+(521,714,l),
+(494,721,o),
+(456,725,o),
+(421,725,cs),
+(176,725,o),
+(88,547,o),
+(88,303,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(227,72,o),
+(192,176,o),
+(192,254,cs),
+(192,320,o),
+(262,375,o),
+(338,375,cs),
+(427,375,o),
+(469,321,o),
+(469,232,cs),
+(469,131,o),
+(420,72,o),
+(335,72,cs)
+);
+}
+);
+width = 612;
+}
+);
+unicode = 54;
+},
+{
+color = 0;
+glyphname = seven;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(599,653,l),
+(599,714,l),
+(119,714,l),
+(119,628,l),
+(490,628,l),
+(217,0,l),
+(322,0,l)
+);
+}
+);
+width = 624;
+}
+);
+unicode = 55;
+},
+{
+color = 0;
+glyphname = eight;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(480,-10,o),
+(580,59,o),
+(580,185,cs),
+(580,284,o),
+(507,341,o),
+(411,379,c),
+(499,417,o),
+(557,469,o),
+(557,556,cs),
+(557,665,o),
+(472,724,o),
+(343,724,cs),
+(214,724,o),
+(126,661,o),
+(126,555,cs),
+(126,460,o),
+(196,411,o),
+(266,377,c),
+(170,340,o),
+(104,285,o),
+(104,181,cs),
+(104,68,o),
+(189,-10,o),
+(339,-10,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(254,66,o),
+(199,112,o),
+(199,184,cs),
+(199,266,o),
+(268,307,o),
+(340,333,c),
+(434,296,o),
+(486,253,o),
+(486,186,cs),
+(486,108,o),
+(428,66,o),
+(339,66,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(271,452,o),
+(223,487,o),
+(223,547,cs),
+(223,612,o),
+(274,648,o),
+(342,648,cs),
+(415,648,o),
+(461,613,o),
+(461,548,cs),
+(461,488,o),
+(417,455,o),
+(343,423,c)
+);
+}
+);
+width = 636;
+}
+);
+unicode = 56;
+},
+{
+color = 0;
+glyphname = nine;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(579,587,o),
+(503,724,o),
+(332,724,cs),
+(188,724,o),
+(100,632,o),
+(100,482,cs),
+(100,343,o),
+(176,258,o),
+(303,258,cs),
+(393,258,o),
+(455,301,o),
+(483,361,c),
+(487,361,l),
+(481,181,o),
+(409,70,o),
+(243,70,cs),
+(204,70,o),
+(168,75,o),
+(143,82,c),
+(143,-2,l),
+(170,-8,o),
+(212,-11,o),
+(247,-11,cs),
+(492,-11,o),
+(579,170,o),
+(579,408,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(442,641,o),
+(475,535,o),
+(475,461,cs),
+(475,395,o),
+(403,339,o),
+(330,339,cs),
+(243,339,o),
+(199,395,o),
+(199,483,cs),
+(199,585,o),
+(247,641,o),
+(334,641,cs)
+);
+}
+);
+width = 637;
+}
+);
+unicode = 57;
+},
+{
+glyphname = zero.canadian;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(512,-12,o),
+(593,311,o),
+(593,482,cs),
+(593,637,o),
+(520,727,o),
+(388,727,cs),
+(151,727,o),
+(70,404,o),
+(70,234,cs),
+(70,78,o),
+(143,-12,o),
+(276,-12,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(206,78,o),
+(167,132,o),
+(167,233,cs),
+(167,348,o),
+(219,637,o),
+(381,637,cs),
+(457,637,o),
+(496,583,o),
+(496,482,cs),
+(496,367,o),
+(444,78,o),
+(282,78,cs)
+);
+}
+);
+width = 617;
+}
+);
+metricRight = "=|";
+},
+{
+glyphname = one.canadian;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(259,0,l),
+(411,714,l),
+(322,714,l),
+(85,547,l),
+(136,475,l),
+(365,635,l),
+(297,648,l),
+(159,0,l)
+);
+}
+);
+width = 391;
+}
+);
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = two.canadian;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(511,90,l),
+(163,90,l),
+(159,49,l),
+(431,275,ls),
+(529,355,o),
+(591,435,o),
+(591,542,cs),
+(591,652,o),
+(512,727,o),
+(384,727,cs),
+(241,727,o),
+(142,638,o),
+(106,468,c),
+(205,468,l),
+(229,583,o),
+(287,640,o),
+(376,640,cs),
+(451,640,o),
+(493,599,o),
+(493,535,cs),
+(493,452,o),
+(437,390,o),
+(359,327,cs),
+(44,67,l),
+(30,0,l),
+(492,0,l)
+);
+}
+);
+width = 601;
+}
+);
+note = uni14BF;
+},
+{
+glyphname = three.canadian;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(450,-13,o),
+(540,86,o),
+(540,217,cs),
+(540,295,o),
+(498,350,o),
+(426,367,c),
+(418,335,l),
+(538,348,o),
+(602,447,o),
+(602,549,cs),
+(602,652,o),
+(523,727,o),
+(389,727,cs),
+(243,727,o),
+(146,643,o),
+(118,483,c),
+(216,483,l),
+(237,587,o),
+(291,640,o),
+(380,640,cs),
+(457,640,o),
+(502,600,o),
+(502,535,cs),
+(502,459,o),
+(457,399,o),
+(363,399,cs),
+(322,399,l),
+(305,315,l),
+(346,315,ls),
+(410,315,o),
+(443,283,o),
+(443,225,cs),
+(443,143,o),
+(391,74,o),
+(291,74,cs),
+(187,74,o),
+(146,138,o),
+(159,231,c),
+(60,231,l),
+(43,89,o),
+(121,-13,o),
+(289,-13,cs)
+);
+}
+);
+width = 626;
+}
+);
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = four.canadian;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(418,0,l),
+(454,169,l),
+(558,169,l),
+(575,251,l),
+(471,251,l),
+(570,716,l),
+(489,716,l),
+(41,234,l),
+(27,169,l),
+(356,169,l),
+(320,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(493,621,l),
+(454,621,l),
+(375,251,l),
+(127,251,l),
+(131,227,l)
+);
+}
+);
+width = 608;
+}
+);
+},
+{
+glyphname = five.canadian;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(466,-13,o),
+(554,110,o),
+(554,244,cs),
+(554,356,o),
+(479,425,o),
+(353,425,cs),
+(218,425,l),
+(241,398,l),
+(318,657,l),
+(281,627,l),
+(612,627,l),
+(630,714,l),
+(239,714,l),
+(135,362,l),
+(152,339,l),
+(326,339,ls),
+(409,339,o),
+(455,303,o),
+(455,234,cs),
+(455,149,o),
+(403,74,o),
+(298,74,cs),
+(205,74,o),
+(153,126,o),
+(164,205,c),
+(66,205,l),
+(50,76,o),
+(143,-13,o),
+(296,-13,cs)
+);
+}
+);
+width = 622;
+}
+);
+},
+{
+glyphname = six.canadian;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(455,-13,o),
+(555,98,o),
+(555,241,cs),
+(555,357,o),
+(477,435,o),
+(353,435,cs),
+(262,435,o),
+(194,393,o),
+(154,311,c),
+(174,279,l),
+(176,312,o),
+(180,339,o),
+(188,378,cs),
+(220,538,o),
+(282,640,o),
+(394,640,cs),
+(485,640,o),
+(517,585,o),
+(514,512,c),
+(612,512,l),
+(621,637,o),
+(540,727,o),
+(399,727,cs),
+(151,727,o),
+(70,408,o),
+(70,230,cs),
+(70,165,o),
+(84,114,o),
+(110,75,cs),
+(146,20,o),
+(214,-13,o),
+(300,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(220,70,o),
+(170,117,o),
+(170,191,cs),
+(170,276,o),
+(228,352,o),
+(329,352,cs),
+(409,352,o),
+(459,307,o),
+(459,232,cs),
+(459,148,o),
+(402,70,o),
+(301,70,cs)
+);
+}
+);
+width = 612;
+}
+);
+metricLeft = zero.canadian;
+},
+{
+glyphname = seven.canadian;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(171,0,l),
+(557,653,l),
+(570,714,l),
+(130,714,l),
+(111,624,l),
+(453,624,l),
+(456,656,l),
+(77,27,l),
+(72,0,l)
+);
+}
+);
+width = 505;
+}
+);
+},
+{
+glyphname = eight.canadian;
+lastChange = "2023-01-13 15:29:07 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(448,-13,o),
+(553,74,o),
+(556,202,cs),
+(559,282,o),
+(512,344,o),
+(433,365,c),
+(419,335,l),
+(532,344,o),
+(608,429,o),
+(611,537,cs),
+(614,650,o),
+(530,727,o),
+(389,727,cs),
+(246,727,o),
+(151,639,o),
+(148,512,cs),
+(145,435,o),
+(187,372,o),
+(262,348,c),
+(261,380,l),
+(139,370,o),
+(64,281,o),
+(62,178,cs),
+(58,65,o),
+(152,-13,o),
+(300,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(209,69,o),
+(158,111,o),
+(160,179,cs),
+(161,264,o),
+(223,317,o),
+(316,317,cs),
+(410,317,o),
+(461,275,o),
+(459,207,cs),
+(458,124,o),
+(397,69,o),
+(303,69,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(290,397,o),
+(243,440,o),
+(244,508,cs),
+(245,586,o),
+(296,645,o),
+(386,645,cs),
+(466,645,o),
+(513,602,o),
+(512,535,cs),
+(511,457,o),
+(461,397,o),
+(370,397,cs)
+);
+}
+);
+width = 643;
+}
+);
+metricLeft = "=|";
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = nine.canadian;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(507,-13,o),
+(588,306,o),
+(588,484,cs),
+(588,549,o),
+(575,600,o),
+(549,639,cs),
+(512,694,o),
+(444,727,o),
+(359,727,cs),
+(203,727,o),
+(103,616,o),
+(103,473,cs),
+(103,357,o),
+(181,279,o),
+(306,279,cs),
+(396,279,o),
+(464,321,o),
+(505,403,c),
+(485,435,l),
+(482,402,o),
+(478,375,o),
+(471,336,cs),
+(438,176,o),
+(376,74,o),
+(264,74,cs),
+(173,74,o),
+(142,129,o),
+(144,202,c),
+(46,202,l),
+(37,77,o),
+(118,-13,o),
+(260,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(249,362,o),
+(200,407,o),
+(200,482,cs),
+(200,566,o),
+(256,644,o),
+(357,644,cs),
+(438,644,o),
+(489,597,o),
+(489,523,cs),
+(489,438,o),
+(430,362,o),
+(330,362,cs)
+);
+}
+);
+width = 612;
+}
+);
+metricLeft = "=|six.canadian";
+metricRight = "=|six.canadian";
+},
+{
+glyphname = CR;
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+width = 267;
+}
+);
+note = CR;
+unicode = 13;
+},
+{
+color = 0;
+glyphname = .notdef;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(604,714,l),
+(193,714,l),
+(193,0,l),
+(604,0,l),
+(604,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(553,663,l),
+(553,51,l),
+(244,51,l),
+(244,663,l),
+(244,663,l)
+);
+}
+);
+width = 699;
+}
+);
+note = ".notdef";
+},
+{
+glyphname = .null;
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+width = 0;
+}
+);
+note = NULL;
+},
+{
+glyphname = space;
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+width = 268;
+}
+);
+note = space;
+unicode = 32;
+},
+{
+glyphname = nbspace;
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+width = 267;
+}
+);
+note = uni00A0;
+unicode = 160;
+},
+{
+glyphname = space.canadian;
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+width = 523;
+}
+);
+note = space;
+},
+{
+glyphname = "hyphen-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(431,409,l),
+(443,468,l),
+(113,468,l),
+(101,409,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(401,267,l),
+(413,326,l),
+(83,326,l),
+(70,267,l)
+);
+}
+);
+width = 463;
+}
+);
+metricRight = "=|";
+note = uni1400;
+unicode = 5120;
+},
+{
+glyphname = "chi-canadian";
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(98,0,l),
+(327,305,l),
+(285,312,l),
+(389,0,l),
+(476,0,l),
+(482,27,l),
+(353,399,l),
+(342,322,l),
+(620,687,l),
+(626,714,l),
+(526,714,l),
+(304,416,l),
+(345,410,l),
+(243,714,l),
+(156,714,l),
+(150,687,l),
+(277,325,l),
+(289,402,l),
+(5,27,l),
+(-1,0,l)
+);
+}
+);
+width = 581;
+}
+);
+metricRight = "=|";
+note = uni166D;
+unicode = 5741;
+},
+{
+glyphname = "fullstop-canadian";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(70,0,l),
+(170,136,l),
+(154,139,l),
+(200,0,l),
+(258,0,l),
+(260,13,l),
+(196,196,l),
+(191,161,l),
+(329,343,l),
+(333,357,l),
+(267,357,l),
+(167,220,l),
+(186,217,l),
+(140,357,l),
+(82,357,l),
+(78,343,l),
+(141,168,l),
+(147,199,l),
+(6,13,l),
+(4,0,l)
+);
+}
+);
+width = 367;
+}
+);
+note = uni1541;
+unicode = 5742;
+},
+{
+glyphname = period;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(17,13,o),
+(37,-10,o),
+(80,-10,cs),
+(114,-10,o),
+(136,13,o),
+(142,50,cs),
+(148,86,o),
+(129,108,o),
+(85,108,cs),
+(48,108,o),
+(28,84,o),
+(23,48,cs)
+);
+}
+);
+width = 245;
+}
+);
+note = period;
+unicode = 46;
+},
+{
+glyphname = comma;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(21,-133,l),
+(69,-60,o),
+(116,42,o),
+(149,118,c),
+(146,129,l),
+(58,129,l),
+(31,52,o),
+(-5,-36,o),
+(-51,-133,c)
+);
+}
+);
+width = 232;
+}
+);
+note = comma;
+unicode = 44;
+},
+{
+glyphname = hyphen;
+kernLeft = hyphen;
+kernRight = hyphen;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(265,229,l),
+(282,311,l),
+(46,311,l),
+(29,229,l)
+);
+}
+);
+width = 302;
+}
+);
+unicode = 45;
+},
+{
+glyphname = quotesinglbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-43,-585);
+ref = quoteright;
+}
+);
+width = 244;
+}
+);
+unicode = 8218;
+},
+{
+glyphname = quotedblbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+pos = (-92,-585);
+ref = quotedblright;
+}
+);
+width = 460;
+}
+);
+unicode = 8222;
+},
+{
+glyphname = quotedblleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(346,451,l),
+(370,530,o),
+(411,627,o),
+(458,714,c),
+(388,714,l),
+(338,640,o),
+(291,545,o),
+(257,460,c),
+(261,451,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(159,451,l),
+(184,530,o),
+(224,626,o),
+(271,714,c),
+(202,714,l),
+(151,640,o),
+(105,545,o),
+(70,460,c),
+(74,451,l)
+);
+}
+);
+width = 384;
+}
+);
+unicode = 8220;
+},
+{
+glyphname = quotedblright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(324,451,l),
+(376,525,o),
+(423,622,o),
+(456,704,c),
+(452,714,l),
+(367,714,l),
+(343,635,o),
+(302,537,o),
+(255,451,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(137,451,l),
+(189,525,o),
+(236,622,o),
+(269,704,c),
+(265,714,l),
+(180,714,l),
+(156,635,o),
+(115,537,o),
+(68,451,c)
+);
+}
+);
+width = 384;
+}
+);
+unicode = 8221;
+},
+{
+glyphname = quoteleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(160,451,l),
+(185,530,o),
+(226,627,o),
+(273,714,c),
+(202,714,l),
+(152,640,o),
+(105,545,o),
+(70,460,c),
+(74,451,l)
+);
+}
+);
+width = 199;
+}
+);
+unicode = 8216;
+},
+{
+glyphname = quoteright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(139,451,l),
+(190,525,o),
+(238,622,o),
+(271,704,c),
+(267,714,l),
+(181,714,l),
+(156,635,o),
+(115,537,o),
+(68,451,c)
+);
+}
+);
+width = 199;
+}
+);
+unicode = 8217;
+},
+{
+glyphname = dottedCircle;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(210,522,o),
+(197,511,o),
+(197,496,cs),
+(197,483,o),
+(210,470,o),
+(223,470,cs),
+(238,470,o),
+(249,483,o),
+(249,496,cs),
+(249,511,o),
+(238,522,o),
+(223,522,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(378,522,o),
+(365,511,o),
+(365,496,cs),
+(365,483,o),
+(378,470,o),
+(391,470,cs),
+(406,470,o),
+(417,483,o),
+(417,496,cs),
+(417,511,o),
+(406,522,o),
+(391,522,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(210,112,o),
+(197,101,o),
+(197,86,cs),
+(197,73,o),
+(210,60,o),
+(223,60,cs),
+(238,60,o),
+(249,73,o),
+(249,86,cs),
+(249,101,o),
+(238,112,o),
+(223,112,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(378,112,o),
+(365,101,o),
+(365,86,cs),
+(365,73,o),
+(378,60,o),
+(391,60,cs),
+(406,60,o),
+(417,73,o),
+(417,86,cs),
+(417,101,o),
+(406,112,o),
+(391,112,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(294,540,o),
+(281,529,o),
+(281,514,cs),
+(281,501,o),
+(294,488,o),
+(307,488,cs),
+(322,488,o),
+(333,501,o),
+(333,514,cs),
+(333,529,o),
+(322,540,o),
+(307,540,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(294,94,o),
+(281,83,o),
+(281,68,cs),
+(281,55,o),
+(294,42,o),
+(307,42,cs),
+(322,42,o),
+(333,55,o),
+(333,68,cs),
+(333,83,o),
+(322,94,o),
+(307,94,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(58,278,o),
+(71,265,o),
+(84,265,cs),
+(99,265,o),
+(110,278,o),
+(110,291,cs),
+(110,306,o),
+(99,317,o),
+(84,317,cs),
+(71,317,o),
+(58,306,o),
+(58,291,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(504,278,o),
+(517,265,o),
+(530,265,cs),
+(545,265,o),
+(556,278,o),
+(556,291,cs),
+(556,306,o),
+(545,317,o),
+(530,317,cs),
+(517,317,o),
+(504,306,o),
+(504,291,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(123,120,o),
+(136,107,o),
+(149,107,cs),
+(164,107,o),
+(175,120,o),
+(175,133,cs),
+(175,148,o),
+(164,159,o),
+(149,159,cs),
+(136,159,o),
+(123,148,o),
+(123,133,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(123,436,o),
+(136,423,o),
+(149,423,cs),
+(164,423,o),
+(175,436,o),
+(175,449,cs),
+(175,464,o),
+(164,475,o),
+(149,475,cs),
+(136,475,o),
+(123,464,o),
+(123,449,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(439,120,o),
+(452,107,o),
+(465,107,cs),
+(480,107,o),
+(491,120,o),
+(491,133,cs),
+(491,148,o),
+(480,159,o),
+(465,159,cs),
+(452,159,o),
+(439,148,o),
+(439,133,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(439,436,o),
+(452,423,o),
+(465,423,cs),
+(480,423,o),
+(491,436,o),
+(491,449,cs),
+(491,464,o),
+(480,475,o),
+(465,475,cs),
+(452,475,o),
+(439,464,o),
+(439,449,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(76,194,o),
+(89,181,o),
+(102,181,cs),
+(117,181,o),
+(128,194,o),
+(128,207,cs),
+(128,222,o),
+(117,233,o),
+(102,233,cs),
+(89,233,o),
+(76,222,o),
+(76,207,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(76,362,o),
+(89,349,o),
+(102,349,cs),
+(117,349,o),
+(128,362,o),
+(128,375,cs),
+(128,390,o),
+(117,401,o),
+(102,401,cs),
+(89,401,o),
+(76,390,o),
+(76,375,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(486,194,o),
+(499,181,o),
+(512,181,cs),
+(527,181,o),
+(538,194,o),
+(538,207,cs),
+(538,222,o),
+(527,233,o),
+(512,233,cs),
+(499,233,o),
+(486,222,o),
+(486,207,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(486,362,o),
+(499,349,o),
+(512,349,cs),
+(527,349,o),
+(538,362,o),
+(538,375,cs),
+(538,390,o),
+(527,401,o),
+(512,401,cs),
+(499,401,o),
+(486,390,o),
+(486,375,cs)
+);
+}
+);
+width = 604;
+}
+);
+note = uni25CC;
+unicode = 9676;
+},
+{
+glyphname = dotaccentcomb;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(156,745,o),
+(137,729,o),
+(131,694,cs),
+(123,656,o),
+(142,636,o),
+(183,636,cs),
+(219,636,o),
+(238,652,o),
+(244,686,cs),
+(252,725,o),
+(234,745,o),
+(192,745,cs)
+);
+}
+);
+width = 187;
+}
+);
+note = uni0307;
+unicode = 775;
+},
+{
+glyphname = dotaccent;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(223,636,o),
+(241,657,o),
+(246,690,cs),
+(252,725,o),
+(234,745,o),
+(192,745,cs),
+(155,745,o),
+(137,726,o),
+(132,692,cs),
+(125,656,o),
+(143,636,o),
+(184,636,cs)
+);
+}
+);
+width = 189;
+}
+);
+note = dotaccent;
+unicode = 729;
+},
+{
+glyphname = caron;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(351,645,o),
+(404,701,o),
+(460,755,c),
+(463,764,l),
+(391,764,l),
+(352,735,o),
+(314,700,o),
+(277,662,c),
+(255,699,o),
+(234,735,o),
+(208,764,c),
+(147,764,l),
+(144,755,l),
+(174,711,o),
+(204,658,o),
+(222,606,c),
+(319,606,l),
+(319,606,l)
+);
+}
+);
+width = 390;
+}
+);
+note = caron;
+unicode = 711;
+},
+{
+glyphname = breve;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(355,606,o),
+(410,654,o),
+(435,748,c),
+(374,748,l),
+(355,696,o),
+(324,671,o),
+(274,671,cs),
+(222,671,o),
+(199,697,o),
+(201,748,c),
+(143,748,l),
+(131,662,o),
+(180,606,o),
+(271,606,cs)
+);
+}
+);
+width = 365;
+}
+);
+note = breve;
+unicode = 728;
+},
+{
+glyphname = ring;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(301,608,o),
+(348,652,o),
+(348,719,cs),
+(348,782,o),
+(301,829,o),
+(242,829,cs),
+(182,829,o),
+(137,784,o),
+(137,718,cs),
+(137,651,o),
+(183,608,o),
+(242,608,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(209,658,o),
+(188,685,o),
+(188,718,cs),
+(188,753,o),
+(212,779,o),
+(242,779,cs),
+(271,779,o),
+(296,753,o),
+(296,718,cs),
+(296,685,o),
+(273,658,o),
+(242,658,cs)
+);
+}
+);
+width = 286;
+}
+);
+note = ring;
+unicode = 730;
+},
+{
+glyphname = ogonek;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(57,-227,o),
+(78,-224,o),
+(97,-217,c),
+(111,-156,l),
+(97,-161,o),
+(77,-165,o),
+(64,-165,cs),
+(36,-165,o),
+(23,-149,o),
+(27,-120,cs),
+(31,-81,o),
+(58,-48,o),
+(123,0,c),
+(84,17,l),
+(4,-32,o),
+(-37,-81,o),
+(-44,-134,cs),
+(-52,-189,o),
+(-19,-227,o),
+(37,-227,cs)
+);
+}
+);
+width = 234;
+}
+);
+note = ogonek;
+unicode = 731;
+},
+{
+glyphname = ring_top.canadian;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (228,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(323,784,o),
+(373,827,o),
+(373,889,cs),
+(373,951,o),
+(323,995,o),
+(265,995,cs),
+(206,995,o),
+(157,951,o),
+(157,889,cs),
+(157,827,o),
+(206,784,o),
+(265,784,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(229,830,o),
+(207,856,o),
+(207,889,cs),
+(207,922,o),
+(231,948,o),
+(265,948,cs),
+(300,948,o),
+(323,922,o),
+(323,889,cs),
+(323,856,o),
+(300,830,o),
+(265,830,cs)
+);
+}
+);
+width = 258;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (99,357);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(131,301,o),
+(156,325,o),
+(156,357,cs),
+(156,389,o),
+(131,413,o),
+(99,413,cs),
+(68,413,o),
+(43,389,o),
+(43,357,cs),
+(43,325,o),
+(68,301,o),
+(99,301,cs)
+);
+}
+);
+width = 152;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (90,357);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(117,309,o),
+(138,330,o),
+(138,357,cs),
+(138,384,o),
+(117,405,o),
+(90,405,cs),
+(63,405,o),
+(42,384,o),
+(42,357,cs),
+(42,330,o),
+(63,309,o),
+(90,309,cs)
+);
+}
+);
+width = 134;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_small;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (81,357);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(103,318,o),
+(120,335,o),
+(120,357,cs),
+(120,379,o),
+(103,396,o),
+(81,396,cs),
+(59,396,o),
+(42,379,o),
+(42,357,cs),
+(42,335,o),
+(59,318,o),
+(81,318,cs)
+);
+}
+);
+width = 116;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_top;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (175,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(239,807,o),
+(264,832,o),
+(264,864,cs),
+(264,895,o),
+(239,920,o),
+(207,920,cs),
+(175,920,o),
+(150,895,o),
+(150,864,cs),
+(150,832,o),
+(175,807,o),
+(207,807,cs)
+);
+}
+);
+width = 152;
+}
+);
+note = g725;
+},
+{
+glyphname = doubledot_middle;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(191,395,o),
+(216,420,o),
+(216,451,cs),
+(216,483,o),
+(191,508,o),
+(159,508,cs),
+(128,508,o),
+(103,483,o),
+(103,451,cs),
+(103,419,o),
+(128,395,o),
+(159,395,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(151,206,o),
+(176,231,o),
+(176,263,cs),
+(176,294,o),
+(151,319,o),
+(119,319,cs),
+(87,319,o),
+(62,295,o),
+(62,263,cs),
+(62,231,o),
+(87,206,o),
+(119,206,cs)
+);
+}
+);
+width = 231;
+}
+);
+metricRight = "=|";
+note = g725;
+},
+{
+glyphname = doubledot_top;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top_double;
+pos = (349,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(412,807,o),
+(438,832,o),
+(438,864,cs),
+(438,895,o),
+(412,920,o),
+(381,920,cs),
+(349,920,o),
+(324,895,o),
+(324,864,cs),
+(324,832,o),
+(349,807,o),
+(381,807,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(232,807,o),
+(257,832,o),
+(257,864,cs),
+(257,895,o),
+(232,920,o),
+(201,920,cs),
+(169,920,o),
+(144,895,o),
+(144,864,cs),
+(144,832,o),
+(169,807,o),
+(201,807,cs)
+);
+}
+);
+width = 320;
+}
+);
+note = g725;
+},
+{
+glyphname = g727;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (456,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(581,0,l),
+(599,83,l),
+(274,83,ls),
+(195,83,o),
+(154,114,o),
+(154,174,cs),
+(154,260,o),
+(211,316,o),
+(321,316,cs),
+(438,316,ls),
+(612,316,o),
+(706,401,o),
+(706,547,cs),
+(706,650,o),
+(636,714,o),
+(518,714,cs),
+(177,714,l),
+(160,631,l),
+(488,631,ls),
+(567,631,o),
+(607,600,o),
+(607,540,cs),
+(607,453,o),
+(551,398,o),
+(440,398,cs),
+(324,398,ls),
+(149,398,o),
+(55,312,o),
+(55,168,cs),
+(55,65,o),
+(126,0,o),
+(244,0,cs)
+);
+}
+);
+width = 714;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+glyphname = g728;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (281,0);
+ref = dot_top;
+}
+);
+width = 715;
+}
+);
+note = g728;
+},
+{
+glyphname = g729;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (480,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(369,0,ls),
+(546,0,o),
+(639,86,o),
+(639,235,cs),
+(639,337,o),
+(570,398,o),
+(451,398,cs),
+(339,398,ls),
+(260,398,o),
+(220,427,o),
+(220,486,cs),
+(220,575,o),
+(274,631,o),
+(387,631,cs),
+(715,631,l),
+(733,714,l),
+(389,714,ls),
+(216,714,o),
+(121,629,o),
+(121,480,cs),
+(121,377,o),
+(190,316,o),
+(308,316,cs),
+(420,316,ls),
+(500,316,o),
+(540,287,o),
+(540,229,cs),
+(540,139,o),
+(484,83,o),
+(370,83,cs),
+(41,83,l),
+(24,0,l)
+);
+}
+);
+width = 714;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+glyphname = g730;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (305,0);
+ref = dot_top;
+}
+);
+width = 715;
+}
+);
+note = g730;
+},
+{
+glyphname = g731;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = g727;
+}
+);
+width = 947;
+}
+);
+note = g731;
+},
+{
+glyphname = g732;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (715,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 947;
+}
+);
+note = g732;
+},
+{
+glyphname = g733;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (513,0);
+ref = dot_top;
+}
+);
+width = 947;
+}
+);
+note = g733;
+},
+{
+glyphname = g734;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (281,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (715,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 947;
+}
+);
+note = g734;
+},
+{
+glyphname = g735;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = g729;
+}
+);
+width = 947;
+}
+);
+note = g735;
+},
+{
+glyphname = g736;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (715,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 947;
+}
+);
+note = g736;
+},
+{
+glyphname = g737;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (537,0);
+ref = dot_top;
+}
+);
+width = 947;
+}
+);
+note = g737;
+},
+{
+glyphname = g738;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (305,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (715,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 947;
+}
+);
+note = g738;
+},
+{
+glyphname = g739;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(584,244,o),
+(636,321,o),
+(636,399,cs),
+(636,469,o),
+(589,515,o),
+(516,515,cs),
+(315,515,l),
+(338,487,l),
+(375,514,o),
+(391,568,o),
+(391,606,cs),
+(391,675,o),
+(344,721,o),
+(270,721,cs),
+(180,721,o),
+(128,643,o),
+(128,566,cs),
+(128,496,o),
+(175,450,o),
+(247,450,cs),
+(449,450,l),
+(425,478,l),
+(387,449,o),
+(373,395,o),
+(373,359,cs),
+(373,290,o),
+(420,244,o),
+(493,244,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(212,502,o),
+(190,527,o),
+(190,565,cs),
+(190,612,o),
+(218,668,o),
+(269,668,cs),
+(306,668,o),
+(329,643,o),
+(329,605,cs),
+(329,559,o),
+(301,502,o),
+(249,502,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(458,297,o),
+(435,322,o),
+(435,360,cs),
+(435,406,o),
+(462,463,o),
+(515,463,cs),
+(551,463,o),
+(574,437,o),
+(574,400,cs),
+(574,353,o),
+(546,297,o),
+(494,297,cs)
+);
+}
+);
+width = 665;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+glyphname = g740;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (228,0);
+ref = ring_top.canadian;
+}
+);
+width = 715;
+}
+);
+note = g740;
+},
+{
+glyphname = g741;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (253,0);
+ref = ring_top.canadian;
+}
+);
+width = 715;
+}
+);
+note = g741;
+},
+{
+glyphname = g742;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (460,0);
+ref = ring_top.canadian;
+}
+);
+width = 947;
+}
+);
+note = g742;
+},
+{
+glyphname = stroke_middle;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (73,357);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(79,241,l),
+(128,474,l),
+(67,474,l),
+(18,241,l)
+);
+}
+);
+width = 100;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (66,357);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(71,267,l),
+(109,447,l),
+(61,447,l),
+(23,267,l)
+);
+}
+);
+width = 86;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_small;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (62,357);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(63,272,l),
+(99,442,l),
+(60,442,l),
+(24,272,l)
+);
+}
+);
+width = 77;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_threequart;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (73,357);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(79,243,l),
+(127,471,l),
+(68,471,l),
+(19,243,l)
+);
+}
+);
+width = 100;
+}
+);
+note = g723;
+},
+{
+color = 8;
+glyphname = uni11AB0;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (265,714);
+},
+{
+name = top_right_can;
+pos = (570,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(163,0,l),
+(186,106,l),
+(432,106,l),
+(444,164,l),
+(198,164,l),
+(225,289,l),
+(146,255,l),
+(187,255,ls),
+(402,255,o),
+(544,364,o),
+(596,605,cs),
+(619,714,l),
+(520,714,l),
+(498,614,ls),
+(459,435,o),
+(354,344,o),
+(191,344,cs),
+(137,344,l),
+(99,164,l),
+(16,164,l),
+(4,106,l),
+(86,106,l),
+(64,0,l)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB1;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB0;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (394,0);
+ref = dot_top;
+}
+);
+width = 596;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB2;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (224,714);
+},
+{
+name = top_right_can;
+pos = (529,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(123,0,l),
+(145,100,ls),
+(184,279,o),
+(289,370,o),
+(452,370,cs),
+(506,370,l),
+(544,550,l),
+(626,550,l),
+(639,608,l),
+(557,608,l),
+(579,714,l),
+(479,714,l),
+(457,608,l),
+(211,608,l),
+(199,550,l),
+(444,550,l),
+(418,425,l),
+(497,459,l),
+(456,459,ls),
+(240,459,o),
+(99,350,o),
+(47,109,cs),
+(23,0,l)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "theThCree-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB3;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB2;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (354,0);
+ref = dot_top;
+}
+);
+width = 596;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB4;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (266,714);
+},
+{
+name = top_right_can;
+pos = (571,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(468,0,l),
+(491,105,ls),
+(537,321,o),
+(428,459,o),
+(205,459,cs),
+(183,459,l),
+(255,427,l),
+(281,550,l),
+(527,550,l),
+(539,608,l),
+(293,608,l),
+(316,714,l),
+(216,714,l),
+(194,608,l),
+(111,608,l),
+(99,550,l),
+(181,550,l),
+(143,370,l),
+(184,370,ls),
+(357,370,o),
+(431,284,o),
+(390,98,cs),
+(369,0,l)
+);
+}
+);
+width = 597;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB5;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB4;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (90,0);
+ref = dot_top;
+}
+);
+width = 596;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB6;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (228,714);
+},
+{
+name = top_right_can;
+pos = (533,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(126,1,l),
+(187,290,l),
+(108,256,l),
+(140,256,ls),
+(372,256,o),
+(507,371,o),
+(559,610,cs),
+(575,680,l),
+(502,646,l),
+(704,444,l),
+(773,513,l),
+(572,715,l),
+(483,715,l),
+(462,618,ls),
+(423,440,o),
+(311,345,o),
+(139,345,cs),
+(99,345,l),
+(26,1,l)
+);
+}
+);
+width = 744;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB7;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB6;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (357,0);
+ref = dot_top;
+}
+);
+width = 743;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB8;
+kernRight = soright;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (410,714);
+},
+{
+name = top_right_can;
+pos = (715,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(309,0,l),
+(330,97,ls),
+(368,275,o),
+(480,370,o),
+(652,370,cs),
+(692,370,l),
+(765,714,l),
+(666,714,l),
+(604,425,l),
+(684,459,l),
+(651,459,ls),
+(419,459,o),
+(285,348,o),
+(232,105,cs),
+(217,35,l),
+(289,69,l),
+(86,271,l),
+(17,202,l),
+(219,0,l)
+);
+}
+);
+width = 744;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB9;
+kernRight = soright;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB8;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (539,0);
+ref = dot_top;
+}
+);
+width = 743;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABA;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (227,714);
+},
+{
+name = top_right_can;
+pos = (532,714);
+}
+);
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(418,0,l),
+(706,202,l),
+(655,275,l),
+(387,89,l),
+(439,52,l),
+(449,100,ls),
+(493,310,o),
+(386,459,o),
+(183,459,cs),
+(152,459,l),
+(214,420,l),
+(276,714,l),
+(177,714,l),
+(104,370,l),
+(141,370,ls),
+(324,370,o),
+(390,279,o),
+(348,87,cs),
+(329,0,l)
+);
+}
+);
+width = 743;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABB;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+alignment = -1;
+ref = uni11ABA;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (52,0);
+ref = dot_top;
+}
+);
+width = 743;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABC;
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(485,0,l),
+(504,90,l),
+(115,90,l),
+(117,53,l),
+(631,644,l),
+(646,714,l),
+(151,714,l),
+(132,624,l),
+(521,624,l),
+(518,662,l),
+(4,70,l),
+(-11,0,l)
+);
+}
+);
+width = 589;
+}
+);
+metricRight = "=|";
+},
+{
+color = 8;
+glyphname = uni11ABD;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(493,0,l),
+(508,70,l),
+(229,661,l),
+(228,624,l),
+(617,624,l),
+(635,714,l),
+(141,714,l),
+(126,644,l),
+(404,53,l),
+(405,90,l),
+(16,90,l),
+(-3,0,l)
+);
+}
+);
+width = 588;
+}
+);
+metricLeft = "=|uni11ABC";
+metricRight = "=|uni11ABC";
+},
+{
+color = 8;
+glyphname = uni11ABE;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(124,0,l),
+(256,623,l),
+(202,623,l),
+(474,0,l),
+(562,0,l),
+(714,714,l),
+(616,714,l),
+(483,91,l),
+(538,91,l),
+(266,714,l),
+(178,714,l),
+(26,0,l)
+);
+}
+);
+width = 694;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABF;
+lastChange = "2023-01-13 15:29:06 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(114,0,l),
+(666,625,l),
+(596,625,l),
+(463,0,l),
+(562,0,l),
+(714,714,l),
+(626,714,l),
+(73,88,l),
+(143,89,l),
+(277,714,l),
+(178,714,l),
+(26,0,l)
+);
+}
+);
+width = 694;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = "raiseddoubledotFinal-canadian.cree";
+lastChange = "2023-01-13 15:28:23 +0000";
+layers = (
+{
+layerId = "96DCC2AB-F6C9-4D02-A366-260ACDE51568";
+shapes = (
+{
+closed = 1;
+nodes = (
+(238,614,o),
+(263,639,o),
+(263,671,cs),
+(263,702,o),
+(238,727,o),
+(207,727,cs),
+(175,727,o),
+(150,703,o),
+(150,671,cs),
+(150,639,o),
+(175,614,o),
+(207,614,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,425,o),
+(224,450,o),
+(224,482,cs),
+(224,514,o),
+(199,539,o),
+(167,539,cs),
+(135,539,o),
+(110,514,o),
+(110,482,cs),
+(110,450,o),
+(135,425,o),
+(167,425,cs)
+);
+}
+);
+width = 234;
+}
+);
+note = g725;
+}
+);
+instances = (
+{
+axesValues = (
+101,
+91,
+12
+);
+instanceInterpolations = {
+"96DCC2AB-F6C9-4D02-A366-260ACDE51568" = 1;
+};
+name = "RC L Italic";
+}
+);
+kerningLTR = {
+"96DCC2AB-F6C9-4D02-A366-260ACDE51568" = {
+"@MMK_L_caright" = {
+"@MMK_R_ecanleft" = -80;
+"@MMK_R_mwestleft" = -29;
+"@MMK_R_neleft" = -57;
+};
+"@MMK_L_ciright" = {
+"@MMK_R_icanleft" = -80;
+"@MMK_R_noleft" = -100;
+};
+"@MMK_L_ecanright" = {
+"@MMK_R_coleft" = -80;
+"@MMK_R_moleft" = -83;
+"@MMK_R_sileft" = -49;
+};
+"@MMK_L_icanright" = {
+"@MMK_R_celeft" = -80;
+"@MMK_R_meleft" = -83;
+"@MMK_R_mwestleft" = -74;
+"@MMK_R_saleft" = -43;
+"she-canadian" = -83;
+};
+"@MMK_L_maright" = {
+"@MMK_R_acanleft" = -79;
+"@MMK_R_ecanleft" = -83;
+"@MMK_R_mwestleft" = -53;
+"@MMK_R_neleft" = -57;
+};
+"@MMK_L_miright" = {
+"@MMK_R_acanleft" = -79;
+"@MMK_R_icanleft" = -83;
+"@MMK_R_moleft" = -105;
+"@MMK_R_noleft" = -100;
+"@MMK_R_yeleft" = -111;
+};
+"@MMK_L_mwestright" = {
+"@MMK_R_coleft" = -29;
+"@MMK_R_icanleft" = -74;
+"@MMK_R_moleft" = -53;
+"@MMK_R_noleft" = -81;
+"@MMK_R_sileft" = -19;
+"@MMK_R_yeleft" = -34;
+};
+"@MMK_L_naright" = {
+"@MMK_R_acanleft" = -93;
+"@MMK_R_celeft" = -100;
+"@MMK_R_meleft" = -100;
+"@MMK_R_mwestleft" = -81;
+"@MMK_R_neleft" = -115;
+"@MMK_R_saleft" = -71;
+};
+"@MMK_L_niright" = {
+"@MMK_R_coleft" = -57;
+"@MMK_R_moleft" = -57;
+"@MMK_R_noleft" = -115;
+"@MMK_R_sileft" = -5;
+};
+"@MMK_L_ocanright" = {
+"@MMK_R_meleft" = -79;
+"@MMK_R_moleft" = -79;
+"@MMK_R_noleft" = -93;
+};
+"@MMK_L_seright" = {
+"@MMK_R_ecanleft" = -49;
+"@MMK_R_mwestleft" = -19;
+"@MMK_R_neleft" = -3;
+};
+"@MMK_L_soright" = {
+"@MMK_R_icanleft" = -43;
+"@MMK_R_noleft" = -71;
+};
+"@MMK_L_yiright" = {
+"@MMK_R_meleft" = -111;
+"@MMK_R_mwestleft" = -34;
+};
+"shi-canadian" = {
+"@MMK_R_icanleft" = -83;
+};
+};
+};
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "italic angle";
+}
+);
+properties = (
+{
+key = copyrights;
+values = (
+{
+language = ENG;
+value = "Copyright 2018 Google Inc. All Rights Reserved.";
+}
+);
+},
+{
+key = manufacturers;
+values = (
+{
+language = ENG;
+value = "Monotype Imaging Inc.";
+}
+);
+},
+{
+key = designers;
+values = (
+{
+language = ENG;
+value = "Monotype Design Team";
+}
+);
+},
+{
+key = description;
+value = "Designed by Monotype design team.";
+},
+{
+key = trademarks;
+values = (
+{
+language = ENG;
+value = "Noto is a trademark of Google Inc.";
+}
+);
+},
+{
+key = licenseURL;
+value = "http://scripts.sil.org/OFL";
+},
+{
+key = licenses;
+values = (
+{
+language = ENG;
+value = "This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.";
+}
+);
+},
+{
+key = manufacturerURL;
+value = "http://www.google.com/get/noto/";
+},
+{
+key = designerURL;
+value = "http://www.monotype.com/studio";
+}
+);
+settings = {
+disablesNiceNames = 1;
+};
+stems = (
+{
+name = "New Stem";
+}
+);
+unitsPerEm = 1000;
+userData = {
+GSDontShowVersionAlert = 1;
+};
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/sources/Exported instances UCAS SansCanadianAboriginal/Sans Canadian Aboriginal-RC R roman.glyphs
+++ b/sources/Exported instances UCAS SansCanadianAboriginal/Sans Canadian Aboriginal-RC R roman.glyphs
@@ -1,0 +1,37305 @@
+{
+.appVersion = "3151";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+},
+{
+name = Width;
+tag = wdth;
+},
+{
+name = Slant;
+tag = slnt;
+}
+);
+classes = (
+{
+code = "zero one two three four five six seven eight nine ";
+name = Num;
+},
+{
+code = "zero.canadian one.canadian two.canadian three.canadian four.canadian five.canadian six.canadian seven.canadian eight.canadian nine.canadian 
+";
+name = Num_can;
+},
+{
+code = "ke-canadian.square ki-canadian.square kii-canadian.square ko-canadian.square koo-canadian.square ka-canadian.square kaa-canadian.square kweWestCree-canadian.square kwiiWestCree-canadian.square kwoWestCree-canadian.square kwooWestCree-canadian.square kwaWestCree-canadian.square kwaaWestCree-canadian.square ce-canadian.square ci-canadian.square cii-canadian.square co-canadian.square coo-canadian.square ca-canadian.square caa-canadian.square me-canadian.square mi-canadian.square mii-canadian.square mo-canadian.square moo-canadian.square ma-canadian.square maa-canadian.square ne-canadian.square ni-canadian.square nii-canadian.square no-canadian.square noo-canadian.square na-canadian.square naa-canadian.square nweWestCree-canadian.square nwaWestCree-canadian.square nwaaWestCree-canadian.square se-canadian.square si-canadian.square sii-canadian.square so-canadian.square soo-canadian.square sa-canadian.square saa-canadian.square sho-canadian.square shoo-canadian.square sha-canadian.square shaa-canadian.square ye-canadian.square yi-canadian.square yii-canadian.square yo-canadian.square yoo-canadian.square ya-canadian.square yaa-canadian.square re-canadian.square reRCree-canadian.square leWestCree-canadian.square ri-canadian.square rii-canadian.square ro-canadian.square loWestCree-canadian.square ra-canadian.square raa-canadian.square laWestCree-canadian.square reWestCree-canadian.square riWestCree-canadian.square roWestCree-canadian.square raWestCree-canadian.square theThCree-canadian.square thiThCree-canadian.square thiiThCree-canadian.square thoThCree-canadian.square thooThCree-canadian.square thaThCree-canadian.square thaaThCree-canadian.square thweeWoodScree-canadian.square thwiWoodScree-canadian.square thwiiWoodScree-canadian.square thwoWoodScree-canadian.square thwooWoodScree-canadian.square thwaWoodScree-canadian.square thwaaWoodScree-canadian.square nwiOjibway-canadian.square nwiiOjibway-canadian.square nwoOjibway-canadian.square nwooOjibway-canadian.square looWestCree-canadian.square laaWestCree-canadian.square ";
+name = Dene_square;
+},
+{
+code = "ke-canadian ki-canadian kii-canadian ko-canadian koo-canadian ka-canadian kaa-canadian kweWestCree-canadian kwiiWestCree-canadian kwoWestCree-canadian kwooWestCree-canadian kwaWestCree-canadian kwaaWestCree-canadian ce-canadian ci-canadian cii-canadian co-canadian coo-canadian ca-canadian caa-canadian me-canadian mi-canadian mii-canadian mo-canadian moo-canadian ma-canadian maa-canadian ne-canadian ni-canadian nii-canadian no-canadian noo-canadian na-canadian naa-canadian nweWestCree-canadian nwaWestCree-canadian nwaaWestCree-canadian se-canadian si-canadian sii-canadian so-canadian soo-canadian sa-canadian saa-canadian sho-canadian shoo-canadian sha-canadian shaa-canadian ye-canadian yi-canadian yii-canadian yo-canadian yoo-canadian ya-canadian yaa-canadian re-canadian reRCree-canadian leWestCree-canadian ri-canadian rii-canadian ro-canadian loWestCree-canadian ra-canadian raa-canadian laWestCree-canadian reWestCree-canadian riWestCree-canadian roWestCree-canadian raWestCree-canadian theThCree-canadian thiThCree-canadian thiiThCree-canadian thoThCree-canadian thooThCree-canadian thaThCree-canadian thaaThCree-canadian thweeWoodScree-canadian thwiWoodScree-canadian thwiiWoodScree-canadian thwoWoodScree-canadian thwooWoodScree-canadian thwaWoodScree-canadian thwaaWoodScree-canadian nwiOjibway-canadian nwiiOjibway-canadian nwoOjibway-canadian nwooOjibway-canadian looWestCree-canadian laaWestCree-canadian 
+";
+name = Dene_round;
+},
+{
+code = "acuteFinal-canadian.mid graveFinal-canadian.mid ringTophalfFinal-canadian.mid ringRighthalfFinal-canadian.mid ringFinal-canadian.mid doubleacuteFinal-canadian.mid doubleshortverticalstrokesFinal-canadian.mid shorthorizontalstrokeFinal-canadian.mid downtackFinal-canadian.mid pWestCree-canadian.mid c-canadian.mid mWestCree-canadian.mid ";
+name = Final_mid;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian ringFinal-canadian doubleacuteFinal-canadian doubleshortverticalstrokesFinal-canadian shorthorizontalstrokeFinal-canadian downtackFinal-canadian pWestCree-canadian c-canadian mWestCree-canadian ";
+name = Final_mid_ori;
+},
+{
+code = "acuteFinal-canadian.base graveFinal-canadian.base ringBottomhalfFinal-canadian.base ringTophalfFinal-canadian.base ringRighthalfFinal-canadian.base plusFinal-canadian.base pWestCree-canadian.base c-canadian.base thSayisi-canadian.base mWestCree-canadian.base ";
+name = Final_base;
+},
+{
+code = "acuteFinal-canadian graveFinal-canadian ringBottomhalfFinal-canadian ringTophalfFinal-canadian ringRighthalfFinal-canadian plusFinal-canadian pWestCree-canadian c-canadian thSayisi-canadian mWestCree-canadian ";
+name = Final_base_ori;
+},
+{
+code = "ng-canadian ngai-canadian ngaai-canadian ngi-canadian ngii-canadian ngo-canadian ngoo-canadian nga-canadian ngaa-canadian ";
+name = Nunavik;
+},
+{
+code = "ng-canadian.nunavik ngai-canadian.nunavik ngaai-canadian.nunavik ngi-canadian.nunavik ngii-canadian.nunavik ngo-canadian.nunavik ngoo-canadian.nunavik nga-canadian.nunavik ngaa-canadian.nunavik ";
+name = Nunavik_alt;
+}
+);
+customParameters = (
+{
+name = vendorID;
+value = GOOG;
+},
+{
+name = panose;
+value = (
+2,
+11,
+5,
+2,
+4,
+5,
+4,
+2,
+2,
+4
+);
+},
+{
+name = unicodeRanges;
+value = (
+0,
+1,
+2,
+5,
+6,
+45,
+77
+);
+},
+{
+name = codePageRanges;
+value = (
+"1252"
+);
+},
+{
+name = fsType;
+value = (
+);
+}
+);
+date = "2022-06-21 10:06:40 +0000";
+familyName = "Sans Canadian Aboriginal";
+featurePrefixes = (
+{
+automatic = 1;
+code = "languagesystem DFLT dflt;
+
+languagesystem cans dflt;
+";
+name = Languagesystems;
+}
+);
+features = (
+{
+automatic = 1;
+code = "feature ss01;
+feature ss02;
+feature ss03;
+feature ss04;
+";
+tag = aalt;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+tag = salt;
+},
+{
+code = "lookup space_can {
+sub space by space.canadian;
+} space_can;
+
+lookup num_can {
+sub @Num by @Num_can;
+} num_can;
+";
+labels = (
+{
+language = dflt;
+value = "CAN Space and numerals";
+}
+);
+tag = ss01;
+},
+{
+code = "lookup dene_square {
+sub @Dene_round by @Dene_square;
+} dene_square;
+
+";
+labels = (
+{
+language = dflt;
+value = "Dene Square";
+}
+);
+tag = ss02;
+},
+{
+code = "lookup nunavik_alt {
+sub @Nunavik by @Nunavik_alt;
+} nunavik_alt;
+
+";
+labels = (
+{
+language = dflt;
+value = "Nunanvik Alt";
+}
+);
+tag = ss03;
+},
+{
+code = "lookup final_mid {
+sub @Final_mid_ori by @Final_mid;
+} final_mid;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final mid";
+}
+);
+tag = ss04;
+},
+{
+code = "lookup final_base {
+sub @Final_base_ori by @Final_base;
+} final_base;
+
+";
+labels = (
+{
+language = dflt;
+value = "Final base";
+}
+);
+tag = ss05;
+},
+{
+code = "lookup plaincree_first {
+sub wiWestCree-canadian' plusFinal-canadian by i-canadian;
+} plaincree_first;
+
+lookup plaincree_second {
+sub i-canadian plusFinal-canadian' by raiseddoubledotFinal-canadian.cree;
+} plaincree_second;
+
+lookup plaincree_third {
+sub middledotFinal-canadian plusFinal-canadian by raiseddoubledotFinal-canadian.cree;
+} plaincree_third;
+";
+labels = (
+{
+language = dflt;
+value = Plaincree;
+}
+);
+tag = ss06;
+},
+{
+code = "script DFLT;
+language dflt;
+lookup SUB_0 {
+	sub sho-canadian by g727;
+	sub shoo-canadian by g728;
+	sub sha-canadian by g729;
+	sub shaa-canadian by g730;
+	sub shwo-canadian by g731;
+	sub shwoWestCree-canadian by g732;
+	sub shwoo-canadian by g733;
+	sub shwooWestCree-canadian by g734;
+	sub shwa-canadian by g735;
+	sub shwaWestCree-canadian by g736;
+	sub shwaa-canadian by g737;
+	sub shwaaWestCree-canadian by g738;
+	sub thiiThCree-canadian by g739;
+	sub shoy-canadian by g740;
+	sub shay-canadian by g741;
+	sub shwoy-canadian by g742;
+} SUB_0;
+script cans;
+language dflt;
+lookup SUB_0;
+
+
+";
+disabled = 1;
+labels = (
+{
+language = dflt;
+value = "";
+}
+);
+tag = ss07;
+}
+);
+fontMaster = (
+{
+axesValues = (
+0,
+0,
+0
+);
+customParameters = (
+{
+name = typoAscender;
+value = 1069;
+},
+{
+name = typoDescender;
+value = -293;
+},
+{
+name = typoLineGap;
+value = 0;
+},
+{
+name = winAscent;
+value = 1069;
+},
+{
+name = winDescent;
+value = 293;
+},
+{
+name = hheaAscender;
+value = 1069;
+},
+{
+name = hheaDescender;
+value = -293;
+},
+{
+name = strikeoutPosition;
+value = 297.53293;
+},
+{
+name = strikeoutSize;
+value = 50;
+}
+);
+guides = (
+{
+lockAngle = 1;
+locked = 1;
+pos = (230,357);
+}
+);
+id = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+metricValues = (
+{
+over = 19;
+pos = 1069;
+},
+{
+over = 19;
+pos = 714;
+},
+{
+over = 19;
+pos = 496;
+},
+{
+over = -19;
+},
+{
+over = -19;
+pos = -293;
+},
+{
+}
+);
+name = "RC L roman";
+stemValues = (
+99
+);
+}
+);
+glyphs = (
+{
+glyphname = idotless;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(173,539,l),
+(74,539,l),
+(74,0,l),
+(173,0,l)
+);
+}
+);
+width = 247;
+}
+);
+note = dotlessi;
+unicode = 305;
+},
+{
+glyphname = "acuteFinal-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,357,l),
+(287,714,l),
+(208,714,l),
+(42,357,l)
+);
+}
+);
+width = 329;
+}
+);
+metricRight = "=|";
+note = uni141F;
+unicode = 5151;
+},
+{
+glyphname = "graveFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(287,357,l),
+(121,714,l),
+(42,714,l),
+(208,357,l)
+);
+}
+);
+width = 329;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+unicode = 5152;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(315,351,o),
+(373,410,o),
+(373,518,cs),
+(373,714,l),
+(302,714,l),
+(302,518,ls),
+(302,448,o),
+(273,416,o),
+(220,416,cs),
+(167,416,o),
+(137,449,o),
+(137,518,cs),
+(137,714,l),
+(66,714,l),
+(66,517,ls),
+(66,411,o),
+(126,351,o),
+(220,351,cs)
+);
+}
+);
+width = 439;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1421;
+unicode = 5153;
+},
+{
+glyphname = "ringTophalfFinal-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(137,357,l),
+(137,553,ls),
+(137,622,o),
+(167,655,o),
+(220,655,cs),
+(273,655,o),
+(302,623,o),
+(302,553,cs),
+(302,357,l),
+(373,357,l),
+(373,553,ls),
+(373,661,o),
+(315,720,o),
+(220,720,cs),
+(126,720,o),
+(66,660,o),
+(66,554,cs),
+(66,357,l)
+);
+}
+);
+width = 439;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+unicode = 5154;
+},
+{
+glyphname = "ringRighthalfFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(141,357,ls),
+(255,357,o),
+(319,425,o),
+(319,535,cs),
+(319,646,o),
+(255,714,o),
+(140,714,cs),
+(63,714,l),
+(63,648,l),
+(136,648,ls),
+(210,648,o),
+(248,608,o),
+(248,535,cs),
+(248,462,o),
+(210,423,o),
+(136,423,cs),
+(63,423,l),
+(63,357,l)
+);
+}
+);
+width = 382;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+unicode = 5155;
+},
+{
+glyphname = "ringFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(345,368,o),
+(421,443,o),
+(421,544,cs),
+(421,645,o),
+(344,720,o),
+(242,720,cs),
+(139,720,o),
+(62,645,o),
+(62,544,cs),
+(62,443,o),
+(138,368,o),
+(242,368,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(174,429,o),
+(129,478,o),
+(129,544,cs),
+(129,610,o),
+(175,659,o),
+(242,659,cs),
+(307,659,o),
+(355,610,o),
+(355,544,cs),
+(355,478,o),
+(308,429,o),
+(242,429,cs)
+);
+}
+);
+width = 484;
+}
+);
+note = uni1424;
+unicode = 5156;
+},
+{
+glyphname = "doubleacuteFinal-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(287,714,l),
+(208,714,l),
+(42,357,l),
+(121,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(443,714,l),
+(364,714,l),
+(198,357,l),
+(277,357,l)
+);
+}
+);
+width = 485;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricRight = "=|";
+note = uni1425;
+unicode = 5157;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(137,714,l),
+(66,714,l),
+(66,357,l),
+(137,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(276,714,l),
+(205,714,l),
+(205,357,l),
+(276,357,l)
+);
+}
+);
+width = 342;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "pWestCree-canadian";
+note = uni1426;
+unicode = 5158;
+},
+{
+glyphname = "middledotFinal-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(148,310,o),
+(173,335,o),
+(173,367,cs),
+(173,399,o),
+(148,424,o),
+(116,424,cs),
+(84,424,o),
+(59,399,o),
+(59,367,cs),
+(59,335,o),
+(84,310,o),
+(116,310,cs)
+);
+}
+);
+width = 232;
+}
+);
+note = uni1427;
+unicode = 5159;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(396,506,l),
+(396,577,l),
+(64,577,l),
+(64,506,l)
+);
+}
+);
+width = 460;
+}
+);
+metricRight = "=|";
+note = uni1428;
+unicode = 5160;
+},
+{
+glyphname = "plusFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(266,375,l),
+(266,513,l),
+(397,513,l),
+(397,579,l),
+(266,579,l),
+(266,714,l),
+(196,714,l),
+(196,579,l),
+(64,579,l),
+(64,513,l),
+(196,513,l),
+(196,375,l)
+);
+}
+);
+width = 461;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+unicode = 5161;
+},
+{
+glyphname = "downtackFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(266,357,l),
+(266,647,l),
+(397,647,l),
+(397,714,l),
+(64,714,l),
+(64,647,l),
+(196,647,l),
+(196,357,l)
+);
+}
+);
+width = 461;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni142A;
+unicode = 5162;
+},
+{
+glyphname = "thFinalWoodScree-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(268,357,l),
+(268,435,l),
+(398,435,l),
+(398,493,l),
+(268,493,l),
+(268,578,l),
+(398,578,l),
+(398,636,l),
+(268,636,l),
+(268,714,l),
+(198,714,l),
+(198,636,l),
+(66,636,l),
+(66,578,l),
+(198,578,l),
+(198,493,l),
+(66,493,l),
+(66,435,l),
+(198,435,l),
+(198,357,l)
+);
+}
+);
+width = 464;
+}
+);
+metricLeft = "hyphen-canadian";
+metricRight = "hyphen-canadian";
+note = uni167E;
+unicode = 5758;
+},
+{
+glyphname = "ringSmallFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(232,517,o),
+(282,560,o),
+(282,622,cs),
+(282,684,o),
+(232,727,o),
+(174,727,cs),
+(115,727,o),
+(66,684,o),
+(66,622,cs),
+(66,560,o),
+(115,517,o),
+(174,517,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(138,563,o),
+(116,589,o),
+(116,622,cs),
+(116,655,o),
+(140,681,o),
+(174,681,cs),
+(209,681,o),
+(232,655,o),
+(232,622,cs),
+(232,589,o),
+(209,563,o),
+(174,563,cs)
+);
+}
+);
+width = 349;
+}
+);
+note = g725;
+unicode = 6366;
+},
+{
+glyphname = "raiseddotFinal-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(149,614,o),
+(174,639,o),
+(174,671,cs),
+(174,702,o),
+(149,727,o),
+(117,727,cs),
+(85,727,o),
+(60,702,o),
+(60,671,cs),
+(60,639,o),
+(85,614,o),
+(117,614,cs)
+);
+}
+);
+width = 234;
+}
+);
+note = g725;
+unicode = 6367;
+},
+{
+glyphname = "acuteFinal-canadian.base";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "acuteFinal-canadian";
+}
+);
+width = 329;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.base";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "graveFinal-canadian";
+}
+);
+width = 329;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricRight = "=|acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringBottomhalfFinal-canadian.base";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 439;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1421;
+},
+{
+glyphname = "ringTophalfFinal-canadian.base";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 439;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "==|ai-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.base";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 382;
+}
+);
+metricLeft = "==|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "plusFinal-canadian.base";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(266,0,l),
+(266,138,l),
+(397,138,l),
+(397,204,l),
+(266,204,l),
+(266,339,l),
+(196,339,l),
+(196,204,l),
+(64,204,l),
+(64,138,l),
+(196,138,l),
+(196,0,l)
+);
+}
+);
+width = 461;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1429;
+},
+{
+glyphname = "acuteFinal-canadian.mid";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "acuteFinal-canadian";
+}
+);
+width = 329;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni141F;
+},
+{
+glyphname = "graveFinal-canadian.mid";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "graveFinal-canadian";
+}
+);
+width = 329;
+}
+);
+metricLeft = "=|acuteFinal-canadian";
+metricWidth = "acuteFinal-canadian";
+note = uni1420;
+},
+{
+glyphname = "ringTophalfFinal-canadian.mid";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-178);
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 439;
+}
+);
+metricLeft = "ai-canadian";
+metricWidth = "ringBottomhalfFinal-canadian";
+note = uni1422;
+},
+{
+glyphname = "ringRighthalfFinal-canadian.mid";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "ringRighthalfFinal-canadian";
+}
+);
+width = 382;
+}
+);
+metricLeft = "=|t-canadian";
+metricWidth = "t-canadian";
+note = uni1423;
+},
+{
+glyphname = "ringFinal-canadian.mid";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-187);
+ref = "ringFinal-canadian";
+}
+);
+width = 484;
+}
+);
+metricLeft = "ringFinal-canadian";
+metricWidth = "ringFinal-canadian";
+note = uni1424;
+},
+{
+glyphname = "doubleacuteFinal-canadian.mid";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "doubleacuteFinal-canadian";
+}
+);
+width = 485;
+}
+);
+metricLeft = "acuteFinal-canadian";
+metricWidth = "doubleacuteFinal-canadian";
+note = uni1425;
+},
+{
+glyphname = "doubleshortverticalstrokesFinal-canadian.mid";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "doubleshortverticalstrokesFinal-canadian";
+}
+);
+width = 342;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricWidth = "doubleshortverticalstrokesFinal-canadian";
+note = uni1426;
+},
+{
+glyphname = "shorthorizontalstrokeFinal-canadian.mid";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-174);
+ref = "shorthorizontalstrokeFinal-canadian";
+}
+);
+width = 460;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "shorthorizontalstrokeFinal-canadian";
+note = uni1428;
+},
+{
+glyphname = "downtackFinal-canadian.mid";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "downtackFinal-canadian";
+}
+);
+width = 461;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricWidth = "downtackFinal-canadian";
+note = uni142A;
+},
+{
+glyphname = "e-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (368,470);
+},
+{
+name = top_center_can;
+pos = (368,714);
+},
+{
+name = top_left_can;
+pos = (134,714);
+},
+{
+name = top_right_can;
+pos = (604,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(389,0,l),
+(708,687,l),
+(708,714,l),
+(33,714,l),
+(33,687,l),
+(352,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(388,120,l),
+(148,655,l),
+(135,632,l),
+(606,632,l),
+(597,655,l),
+(357,120,l)
+);
+}
+);
+width = 741;
+}
+);
+metricRight = "=|";
+note = uni1401;
+unicode = 5121;
+},
+{
+glyphname = "aai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (242,0);
+ref = ring_top.canadian;
+}
+);
+width = 742;
+}
+);
+note = uni1402;
+unicode = 5122;
+},
+{
+glyphname = "i-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (370,367);
+},
+{
+name = top_center_can;
+pos = (371,714);
+},
+{
+name = top_left_can;
+pos = (134,714);
+},
+{
+name = top_right_can;
+pos = (604,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(708,0,l),
+(708,27,l),
+(389,714,l),
+(352,714,l),
+(33,27,l),
+(33,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(385,594,l),
+(354,594,l),
+(594,59,l),
+(606,82,l),
+(135,82,l),
+(145,59,l)
+);
+}
+);
+width = 741;
+}
+);
+metricLeft = "e-canadian";
+metricWidth = "e-canadian";
+note = uni1403;
+unicode = 5123;
+},
+{
+glyphname = "ii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (295,0);
+ref = dot_top;
+}
+);
+width = 742;
+}
+);
+note = uni1404;
+unicode = 5124;
+},
+{
+glyphname = "o-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (282,357);
+},
+{
+name = top_center_can;
+pos = (371,714);
+},
+{
+name = top_double;
+pos = (469,714);
+},
+{
+name = top_left_can;
+pos = (121,714);
+},
+{
+name = top_right_can;
+pos = (619,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(105,0,l),
+(666,339,l),
+(666,375,l),
+(105,714,l),
+(78,714,l),
+(78,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(164,604,l),
+(138,600,l),
+(561,343,l),
+(561,372,l),
+(138,116,l),
+(164,111,l)
+);
+}
+);
+width = 701;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1405;
+unicode = 5125;
+},
+{
+glyphname = "oo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (45,0);
+ref = dot_top;
+}
+);
+width = 701;
+}
+);
+note = uni1406;
+unicode = 5126;
+},
+{
+glyphname = "yCreeoo-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (219,0);
+ref = doubledot_top;
+}
+);
+width = 701;
+}
+);
+note = uni1407;
+unicode = 5127;
+},
+{
+glyphname = "eeCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(105,0,l),
+(666,339,l),
+(666,375,l),
+(105,714,l),
+(78,714,l),
+(78,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(162,604,l),
+(138,602,l),
+(561,345,l),
+(561,370,l),
+(138,114,l),
+(162,111,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(300,442,l),
+(261,442,l),
+(261,272,l),
+(300,272,l)
+);
+}
+);
+width = 701;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "o-canadian";
+note = uni1408;
+unicode = 5128;
+},
+{
+glyphname = "iCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (224,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 701;
+}
+);
+note = uni1409;
+unicode = 5129;
+},
+{
+glyphname = "a-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (414,357);
+},
+{
+name = top_center_can;
+pos = (324,714);
+},
+{
+name = top_left_can;
+pos = (80,714);
+},
+{
+name = top_right_can;
+pos = (579,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(622,0,l),
+(622,714,l),
+(596,714,l),
+(35,375,l),
+(35,339,l),
+(596,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(562,115,l),
+(140,372,l),
+(140,343,l),
+(562,600,l),
+(537,604,l),
+(537,111,l)
+);
+}
+);
+width = 700;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni140A;
+unicode = 5130;
+},
+{
+glyphname = "aa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (503,0);
+ref = dot_top;
+}
+);
+width = 701;
+}
+);
+note = uni140B;
+unicode = 5131;
+},
+{
+glyphname = "we-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "e-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni140C;
+unicode = 5132;
+},
+{
+glyphname = "weWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (742,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni140D;
+unicode = 5133;
+},
+{
+glyphname = "wi-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "i-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni140E;
+unicode = 5134;
+},
+{
+glyphname = "wiWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (742,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni140F;
+unicode = 5135;
+},
+{
+glyphname = "wii-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (527,0);
+ref = dot_top;
+}
+);
+width = 974;
+}
+);
+note = uni1410;
+unicode = 5136;
+},
+{
+glyphname = "wiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (295,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (742,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni1411;
+unicode = 5137;
+},
+{
+glyphname = "wo-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "o-canadian";
+}
+);
+width = 933;
+}
+);
+note = uni1412;
+unicode = 5138;
+},
+{
+glyphname = "woWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (701,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 933;
+}
+);
+note = uni1413;
+unicode = 5139;
+},
+{
+glyphname = "woo-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (527,0);
+ref = dot_top;
+}
+);
+width = 933;
+}
+);
+note = uni1414;
+unicode = 5140;
+},
+{
+glyphname = "wooWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (45,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (701,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 933;
+}
+);
+note = uni1415;
+unicode = 5141;
+},
+{
+glyphname = "wooNaskapi-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (218,-99);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (400,-208);
+ref = dot_top;
+}
+);
+width = 701;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricWidth = "o-canadian";
+note = uni1416;
+unicode = 5142;
+},
+{
+glyphname = "wa-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "a-canadian";
+}
+);
+width = 933;
+}
+);
+note = uni1417;
+unicode = 5143;
+},
+{
+glyphname = "waWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (701,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 933;
+}
+);
+note = uni1418;
+unicode = 5144;
+},
+{
+glyphname = "waa-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (735,0);
+ref = dot_top;
+}
+);
+width = 933;
+}
+);
+note = uni1419;
+unicode = 5145;
+},
+{
+glyphname = "waaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (503,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (701,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 933;
+}
+);
+note = uni141A;
+unicode = 5146;
+},
+{
+glyphname = "waaNaskapi-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (148,-208);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (330,-99);
+ref = dot_top;
+}
+);
+width = 700;
+}
+);
+metricWidth = "a-canadian";
+note = uni141B;
+unicode = 5147;
+},
+{
+glyphname = "ai-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(273,351,o),
+(315,382,o),
+(335,444,c),
+(313,444,l),
+(333,382,o),
+(377,351,o),
+(439,351,cs),
+(526,351,o),
+(582,407,o),
+(582,514,cs),
+(582,714,l),
+(515,714,l),
+(515,514,ls),
+(515,441,o),
+(486,413,o),
+(436,413,cs),
+(388,413,o),
+(357,443,o),
+(357,513,cs),
+(357,714,l),
+(291,714,l),
+(291,514,ls),
+(291,441,o),
+(260,413,o),
+(211,413,cs),
+(163,413,o),
+(133,443,o),
+(133,513,cs),
+(133,714,l),
+(66,714,l),
+(66,512,ls),
+(66,407,o),
+(123,351,o),
+(210,351,cs)
+);
+}
+);
+width = 648;
+}
+);
+metricRight = "=|";
+note = uni141C;
+unicode = 5148;
+},
+{
+glyphname = "ycreew-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(361,528,o),
+(399,568,o),
+(399,624,cs),
+(399,681,o),
+(361,720,o),
+(310,720,cs),
+(259,720,o),
+(221,681,o),
+(221,624,cs),
+(221,568,o),
+(259,528,o),
+(310,528,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(203,351,o),
+(241,391,o),
+(241,447,cs),
+(241,504,o),
+(204,543,o),
+(153,543,cs),
+(101,543,o),
+(63,504,o),
+(63,447,cs),
+(63,391,o),
+(101,351,o),
+(152,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(123,388,o),
+(103,412,o),
+(103,447,cs),
+(103,482,o),
+(123,506,o),
+(152,506,cs),
+(181,506,o),
+(201,482,o),
+(201,447,cs),
+(201,412,o),
+(181,388,o),
+(152,388,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(280,565,o),
+(261,589,o),
+(261,624,cs),
+(261,659,o),
+(280,683,o),
+(310,683,cs),
+(339,683,o),
+(359,659,o),
+(359,624,cs),
+(359,589,o),
+(339,565,o),
+(310,565,cs)
+);
+}
+);
+width = 462;
+}
+);
+metricRight = "=|";
+note = uni141D;
+unicode = 5149;
+},
+{
+glyphname = "glottalstop-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(394,357,l),
+(394,372,l),
+(235,714,l),
+(216,714,l),
+(57,372,l),
+(57,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(242,649,l),
+(208,649,l),
+(326,387,l),
+(341,410,l),
+(110,410,l),
+(123,387,l)
+);
+}
+);
+width = 451;
+}
+);
+metricRight = "=|";
+note = uni141E;
+unicode = 5150;
+},
+{
+glyphname = "en-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "e-canadian";
+},
+{
+alignment = -1;
+pos = (742,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 1071;
+}
+);
+note = uni142B;
+unicode = 5163;
+},
+{
+glyphname = "in-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "i-canadian";
+},
+{
+alignment = -1;
+pos = (507,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 836;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142C;
+unicode = 5164;
+},
+{
+glyphname = "on-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+pos = (553,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 882;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "graveFinal-canadian";
+note = uni142D;
+unicode = 5165;
+},
+{
+glyphname = "an-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+pos = (654,0);
+ref = "graveFinal-canadian";
+}
+);
+width = 983;
+}
+);
+metricRight = "graveFinal-canadian";
+note = uni142E;
+unicode = 5166;
+},
+{
+glyphname = "pe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (368,470);
+},
+{
+name = top_center_can;
+pos = (368,714);
+},
+{
+name = top_left_can;
+pos = (134,714);
+},
+{
+name = top_right_can;
+pos = (604,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(389,0,l),
+(708,687,l),
+(708,714,l),
+(617,714,l),
+(347,119,l),
+(398,119,l),
+(130,714,l),
+(33,714,l),
+(33,687,l),
+(352,0,l)
+);
+}
+);
+width = 741;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni142F;
+unicode = 5167;
+},
+{
+glyphname = "paai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (242,0);
+ref = ring_top.canadian;
+}
+);
+width = 742;
+}
+);
+note = uni1430;
+unicode = 5168;
+},
+{
+glyphname = "pi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (369,367);
+},
+{
+name = top_center_can;
+pos = (371,714);
+},
+{
+name = top_left_can;
+pos = (136,714);
+},
+{
+name = top_right_can;
+pos = (606,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(126,0,l),
+(397,595,l),
+(345,595,l),
+(613,0,l),
+(708,0,l),
+(708,27,l),
+(389,714,l),
+(352,714,l),
+(33,27,l),
+(33,0,l)
+);
+}
+);
+width = 741;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni1431;
+unicode = 5169;
+},
+{
+glyphname = "pii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (295,0);
+ref = dot_top;
+}
+);
+width = 742;
+}
+);
+note = uni1432;
+unicode = 5170;
+},
+{
+glyphname = "po-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (214,357);
+},
+{
+name = top_center_can;
+pos = (345,714);
+},
+{
+name = top_double;
+pos = (449,714);
+},
+{
+name = top_left_can;
+pos = (99,714);
+},
+{
+name = top_right_can;
+pos = (591,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(81,0,l),
+(637,339,l),
+(637,375,l),
+(81,714,l),
+(55,714,l),
+(55,622,l),
+(526,335,l),
+(526,380,l),
+(55,93,l),
+(55,0,l)
+);
+}
+);
+width = 672;
+}
+);
+metricRight = "o-canadian";
+note = uni1433;
+unicode = 5171;
+},
+{
+glyphname = "poo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (22,0);
+ref = dot_top;
+}
+);
+width = 672;
+}
+);
+note = uni1434;
+unicode = 5172;
+},
+{
+glyphname = "ycreepoo-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (199,0);
+ref = doubledot_top;
+}
+);
+width = 672;
+}
+);
+note = uni1435;
+unicode = 5173;
+},
+{
+glyphname = "heeCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (171,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 672;
+}
+);
+note = uni1436;
+unicode = 5174;
+},
+{
+glyphname = "hiCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (147,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 672;
+}
+);
+note = uni1437;
+unicode = 5175;
+},
+{
+glyphname = "pa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (336,357);
+},
+{
+name = top_center_can;
+pos = (328,714);
+},
+{
+name = top_left_can;
+pos = (80,714);
+},
+{
+name = top_right_can;
+pos = (574,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(617,0,l),
+(617,92,l),
+(146,379,l),
+(146,334,l),
+(617,621,l),
+(617,714,l),
+(591,714,l),
+(35,375,l),
+(35,339,l),
+(591,0,l)
+);
+}
+);
+width = 672;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1438;
+unicode = 5176;
+},
+{
+glyphname = "paa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (498,0);
+ref = dot_top;
+}
+);
+width = 672;
+}
+);
+note = uni1439;
+unicode = 5177;
+},
+{
+glyphname = "pwe-canadian";
+kernRight = ecanright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "pe-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni143A;
+unicode = 5178;
+},
+{
+glyphname = "pweWestCree-canadian";
+kernLeft = ecanleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "pe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (742,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni143B;
+unicode = 5179;
+},
+{
+glyphname = "pwi-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "pi-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni143C;
+unicode = 5180;
+},
+{
+glyphname = "pwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (742,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni143D;
+unicode = 5181;
+},
+{
+glyphname = "pwii-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (527,0);
+ref = dot_top;
+}
+);
+width = 974;
+}
+);
+note = uni143E;
+unicode = 5182;
+},
+{
+glyphname = "pwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "pi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (295,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (742,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 974;
+}
+);
+note = uni143F;
+unicode = 5183;
+},
+{
+glyphname = "pwo-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "po-canadian";
+}
+);
+width = 905;
+}
+);
+note = uni1440;
+unicode = 5184;
+},
+{
+glyphname = "pwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (672,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 905;
+}
+);
+note = uni1441;
+unicode = 5185;
+},
+{
+glyphname = "pwoo-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (501,0);
+ref = dot_top;
+}
+);
+width = 905;
+}
+);
+note = uni1442;
+unicode = 5186;
+},
+{
+glyphname = "pwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (22,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (672,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 905;
+}
+);
+note = uni1443;
+unicode = 5187;
+},
+{
+glyphname = "pwa-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "pa-canadian";
+}
+);
+width = 905;
+}
+);
+note = uni1444;
+unicode = 5188;
+},
+{
+glyphname = "pwaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (672,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 905;
+}
+);
+note = uni1445;
+unicode = 5189;
+},
+{
+glyphname = "pwaa-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (730,0);
+ref = dot_top;
+}
+);
+width = 905;
+}
+);
+note = uni1446;
+unicode = 5190;
+},
+{
+glyphname = "pwaaWestCree-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (498,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (672,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 905;
+}
+);
+note = uni1447;
+unicode = 5191;
+},
+{
+glyphname = "ycreepwaa-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+pos = (145,-208);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (328,-99);
+ref = dot_top;
+}
+);
+width = 672;
+}
+);
+metricRight = "=|po-canadian";
+note = uni1448;
+unicode = 5192;
+},
+{
+glyphname = "p-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(356,357,l),
+(356,421,l),
+(127,561,l),
+(127,510,l),
+(356,649,l),
+(356,714,l),
+(341,714,l),
+(66,546,l),
+(66,526,l),
+(341,357,l)
+);
+}
+);
+width = 423;
+}
+);
+note = uni1449;
+unicode = 5193;
+},
+{
+glyphname = "pWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(137,357,l),
+(137,714,l),
+(66,714,l),
+(66,357,l)
+);
+}
+);
+width = 203;
+}
+);
+metricRight = "=|";
+note = uni144A;
+unicode = 5194;
+},
+{
+color = 6;
+glyphname = "hCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(137,189,l),
+(137,317,ls),
+(137,361,o),
+(162,386,o),
+(201,386,cs),
+(238,386,o),
+(257,363,o),
+(257,315,cs),
+(257,189,l),
+(328,189,l),
+(328,328,ls),
+(328,410,o),
+(277,450,o),
+(214,450,cs),
+(165,450,o),
+(125,421,o),
+(119,381,c),
+(137,370,l),
+(137,546,l),
+(66,546,l),
+(66,189,l)
+);
+}
+);
+width = 372;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144B;
+unicode = 5195;
+},
+{
+glyphname = "te-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (369,357);
+},
+{
+name = top_center_can;
+pos = (369,714);
+},
+{
+name = top_left_can;
+pos = (121,714);
+},
+{
+name = top_right_can;
+pos = (618,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(555,-13,o),
+(667,106,o),
+(667,313,cs),
+(667,714,l),
+(568,714,l),
+(568,311,ls),
+(568,157,o),
+(496,78,o),
+(369,78,cs),
+(245,78,o),
+(170,159,o),
+(170,311,cs),
+(170,714,l),
+(71,714,l),
+(71,310,ls),
+(71,105,o),
+(184,-13,o),
+(369,-13,cs)
+);
+}
+);
+width = 738;
+}
+);
+metricRight = "=|";
+note = uni144C;
+unicode = 5196;
+},
+{
+glyphname = "taai-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (240,0);
+ref = ring_top.canadian;
+}
+);
+width = 738;
+}
+);
+note = uni144D;
+unicode = 5197;
+},
+{
+glyphname = "ti-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (369,357);
+},
+{
+name = middle_right_can;
+pos = (831,357);
+},
+{
+name = top_center_can;
+pos = (369,714);
+},
+{
+name = top_left_can;
+pos = (121,714);
+},
+{
+name = top_right_can;
+pos = (618,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(170,0,l),
+(170,403,ls),
+(170,555,o),
+(245,636,o),
+(371,636,cs),
+(494,636,o),
+(568,555,o),
+(568,403,cs),
+(568,0,l),
+(667,0,l),
+(667,404,ls),
+(667,609,o),
+(554,727,o),
+(372,727,cs),
+(186,727,o),
+(71,609,o),
+(71,401,cs),
+(71,0,l)
+);
+}
+);
+width = 738;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni144E;
+unicode = 5198;
+},
+{
+glyphname = "tii-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (293,0);
+ref = dot_top;
+}
+);
+width = 738;
+}
+);
+note = uni144F;
+unicode = 5199;
+},
+{
+glyphname = "to-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (262,357);
+},
+{
+name = middle_right_can;
+pos = (728,357);
+},
+{
+name = top_center_can;
+pos = (284,714);
+},
+{
+name = top_double;
+pos = (355,714);
+},
+{
+name = top_left_can;
+pos = (102,714);
+},
+{
+name = top_right_can;
+pos = (520,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(222,0,ls),
+(440,0,o),
+(564,133,o),
+(564,358,cs),
+(564,583,o),
+(440,714,o),
+(219,714,cs),
+(58,714,l),
+(58,624,l),
+(216,624,ls),
+(377,624,o),
+(464,531,o),
+(464,358,cs),
+(464,185,o),
+(377,90,o),
+(218,90,cs),
+(58,90,l),
+(58,0,l)
+);
+}
+);
+width = 628;
+}
+);
+note = uni1450;
+unicode = 5200;
+},
+{
+glyphname = "too-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (208,0);
+ref = dot_top;
+}
+);
+width = 628;
+}
+);
+note = uni1451;
+unicode = 5201;
+},
+{
+glyphname = "ycreetoo-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (105,0);
+ref = doubledot_top;
+}
+);
+width = 628;
+}
+);
+note = uni1452;
+unicode = 5202;
+},
+{
+glyphname = "deeCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (212,0);
+ref = stroke_middle;
+}
+);
+width = 628;
+}
+);
+note = uni1453;
+unicode = 5203;
+},
+{
+glyphname = "diCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (186,0);
+ref = dot_middle;
+}
+);
+width = 628;
+}
+);
+note = uni1454;
+unicode = 5204;
+},
+{
+glyphname = "ta-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (366,357);
+},
+{
+name = top_center_can;
+pos = (344,714);
+},
+{
+name = top_left_can;
+pos = (107,714);
+},
+{
+name = top_right_can;
+pos = (525,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(569,0,l),
+(569,90,l),
+(411,90,ls),
+(251,90,o),
+(163,184,o),
+(163,357,cs),
+(163,530,o),
+(251,624,o),
+(410,624,cs),
+(569,624,l),
+(569,714,l),
+(407,714,ls),
+(188,714,o),
+(64,582,o),
+(64,357,cs),
+(64,133,o),
+(188,0,o),
+(406,0,cs)
+);
+}
+);
+width = 627;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|to-canadian";
+note = uni1455;
+unicode = 5205;
+},
+{
+glyphname = "taa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (269,0);
+ref = dot_top;
+}
+);
+width = 628;
+}
+);
+note = uni1456;
+unicode = 5206;
+},
+{
+glyphname = "twe-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "te-canadian";
+}
+);
+width = 970;
+}
+);
+note = uni1457;
+unicode = 5207;
+},
+{
+glyphname = "tweWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (738,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 970;
+}
+);
+note = uni1458;
+unicode = 5208;
+},
+{
+glyphname = "twi-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ti-canadian";
+}
+);
+width = 970;
+}
+);
+note = uni1459;
+unicode = 5209;
+},
+{
+glyphname = "twiWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (738,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 970;
+}
+);
+note = uni145A;
+unicode = 5210;
+},
+{
+glyphname = "twii-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (525,0);
+ref = dot_top;
+}
+);
+width = 970;
+}
+);
+note = uni145B;
+unicode = 5211;
+},
+{
+glyphname = "twiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (293,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (738,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 970;
+}
+);
+note = uni145C;
+unicode = 5212;
+},
+{
+glyphname = "two-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "to-canadian";
+}
+);
+width = 861;
+}
+);
+note = uni145D;
+unicode = 5213;
+},
+{
+glyphname = "twoWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (628,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 861;
+}
+);
+note = uni145E;
+unicode = 5214;
+},
+{
+glyphname = "twoo-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (440,0);
+ref = dot_top;
+}
+);
+width = 861;
+}
+);
+note = uni145F;
+unicode = 5215;
+},
+{
+glyphname = "twooWestCree-canadian";
+kernLeft = toleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (208,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (628,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 861;
+}
+);
+note = uni1460;
+unicode = 5216;
+},
+{
+glyphname = "twa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ta-canadian";
+}
+);
+width = 861;
+}
+);
+note = uni1461;
+unicode = 5217;
+},
+{
+glyphname = "twaWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (628,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 861;
+}
+);
+note = uni1462;
+unicode = 5218;
+},
+{
+glyphname = "twaa-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (501,0);
+ref = dot_top;
+}
+);
+width = 861;
+}
+);
+note = uni1463;
+unicode = 5219;
+},
+{
+glyphname = "twaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (269,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (628,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 861;
+}
+);
+note = uni1464;
+unicode = 5220;
+},
+{
+glyphname = "twaaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ta-canadian";
+}
+);
+width = 860;
+}
+);
+note = uni1465;
+unicode = 5221;
+},
+{
+glyphname = "t-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(319,357,l),
+(319,423,l),
+(245,423,ls),
+(171,423,o),
+(133,462,o),
+(133,535,cs),
+(133,607,o),
+(171,648,o),
+(245,648,cs),
+(319,648,l),
+(319,714,l),
+(240,714,ls),
+(126,714,o),
+(62,645,o),
+(62,535,cs),
+(62,425,o),
+(126,357,o),
+(241,357,cs)
+);
+}
+);
+width = 382;
+}
+);
+note = uni1466;
+unicode = 5222;
+},
+{
+glyphname = "tte-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "te-canadian";
+},
+{
+alignment = -1;
+pos = (738,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 941;
+}
+);
+note = uni1467;
+unicode = 5223;
+},
+{
+glyphname = "tti-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ti-canadian";
+},
+{
+alignment = -1;
+pos = (738,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 941;
+}
+);
+note = uni1468;
+unicode = 5224;
+},
+{
+glyphname = "tto-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "to-canadian";
+},
+{
+alignment = -1;
+pos = (628,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 832;
+}
+);
+note = uni1469;
+unicode = 5225;
+},
+{
+glyphname = "tta-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+pos = (628,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 832;
+}
+);
+note = uni146A;
+unicode = 5226;
+},
+{
+glyphname = "ke-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (315,457);
+},
+{
+name = top_center_can;
+pos = (299,714);
+},
+{
+name = top_left_can;
+pos = (111,714);
+},
+{
+name = top_right_can;
+pos = (487,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(536,0,l),
+(536,459,ls),
+(536,626,o),
+(447,727,o),
+(301,727,cs),
+(156,727,o),
+(62,625,o),
+(62,463,cs),
+(62,306,o),
+(153,205,o),
+(287,205,cs),
+(370,205,o),
+(432,251,o),
+(446,311,c),
+(436,324,l),
+(436,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(214,290,o),
+(160,353,o),
+(160,466,cs),
+(160,579,o),
+(212,642,o),
+(299,642,cs),
+(386,642,o),
+(438,580,o),
+(438,466,cs),
+(438,354,o),
+(384,290,o),
+(299,290,cs)
+);
+}
+);
+width = 607;
+}
+);
+metricRight = "te-canadian";
+note = uni146B;
+unicode = 5227;
+},
+{
+glyphname = "kaai-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (178,0);
+ref = ring_top.canadian;
+}
+);
+width = 607;
+}
+);
+note = uni146C;
+unicode = 5228;
+},
+{
+glyphname = "ki-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (323,457);
+},
+{
+name = top_center_can;
+pos = (307,714);
+},
+{
+name = top_left_can;
+pos = (120,714);
+},
+{
+name = top_right_can;
+pos = (496,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(170,0,l),
+(170,324,l),
+(160,311,l),
+(175,251,o),
+(237,205,o),
+(320,205,cs),
+(454,205,o),
+(545,307,o),
+(545,466,cs),
+(545,627,o),
+(451,727,o),
+(309,727,cs),
+(162,727,o),
+(71,625,o),
+(71,459,cs),
+(71,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(222,290,o),
+(168,354,o),
+(168,466,cs),
+(168,580,o),
+(221,642,o),
+(307,642,cs),
+(394,642,o),
+(447,579,o),
+(447,466,cs),
+(447,353,o),
+(392,290,o),
+(307,290,cs)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni146D;
+unicode = 5229;
+},
+{
+glyphname = "kii-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (231,0);
+ref = dot_top;
+}
+);
+width = 607;
+}
+);
+note = uni146E;
+unicode = 5230;
+},
+{
+glyphname = "ko-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (315,368);
+},
+{
+name = top_center_can;
+pos = (299,714);
+},
+{
+name = top_double;
+pos = (487,714);
+},
+{
+name = top_left_can;
+pos = (111,714);
+},
+{
+name = top_right_can;
+pos = (487,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(447,-13,o),
+(536,88,o),
+(536,255,cs),
+(536,714,l),
+(436,714,l),
+(436,390,l),
+(446,403,l),
+(432,463,o),
+(370,509,o),
+(288,509,cs),
+(153,509,o),
+(62,405,o),
+(62,246,cs),
+(62,87,o),
+(153,-13,o),
+(299,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(212,72,o),
+(160,135,o),
+(160,248,cs),
+(160,361,o),
+(214,424,o),
+(299,424,cs),
+(384,424,o),
+(438,360,o),
+(438,248,cs),
+(438,134,o),
+(386,72,o),
+(299,72,cs)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni146F;
+unicode = 5231;
+},
+{
+glyphname = "koo-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (410,0);
+ref = dot_top;
+}
+);
+width = 607;
+}
+);
+note = uni1470;
+unicode = 5232;
+},
+{
+glyphname = "ycreekoo-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (237,0);
+ref = doubledot_top;
+}
+);
+width = 607;
+}
+);
+note = uni1471;
+unicode = 5233;
+},
+{
+glyphname = "ka-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (323,370);
+},
+{
+name = top_center_can;
+pos = (308,714);
+},
+{
+name = top_left_can;
+pos = (120,714);
+},
+{
+name = top_right_can;
+pos = (496,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(450,-13,o),
+(545,87,o),
+(545,250,cs),
+(545,407,o),
+(454,509,o),
+(322,509,cs),
+(238,509,o),
+(176,463,o),
+(160,403,c),
+(170,390,l),
+(170,714,l),
+(71,714,l),
+(71,255,ls),
+(71,88,o),
+(159,-13,o),
+(306,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(221,72,o),
+(168,134,o),
+(168,248,cs),
+(168,360,o),
+(222,424,o),
+(307,424,cs),
+(392,424,o),
+(447,361,o),
+(447,248,cs),
+(447,135,o),
+(394,72,o),
+(307,72,cs)
+);
+}
+);
+width = 607;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "==|ke-canadian";
+note = uni1472;
+unicode = 5234;
+},
+{
+glyphname = "kaa-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (44,0);
+ref = dot_top;
+}
+);
+width = 607;
+}
+);
+note = uni1473;
+unicode = 5235;
+},
+{
+glyphname = "kwe-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ke-canadian";
+}
+);
+width = 839;
+}
+);
+note = uni1474;
+unicode = 5236;
+},
+{
+glyphname = "kweWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 839;
+}
+);
+note = uni1475;
+unicode = 5237;
+},
+{
+glyphname = "kwi-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ki-canadian";
+}
+);
+width = 839;
+}
+);
+note = uni1476;
+unicode = 5238;
+},
+{
+glyphname = "kwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 839;
+}
+);
+note = uni1477;
+unicode = 5239;
+},
+{
+glyphname = "kwii-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (464,0);
+ref = dot_top;
+}
+);
+width = 839;
+}
+);
+note = uni1478;
+unicode = 5240;
+},
+{
+glyphname = "kwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (231,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 839;
+}
+);
+note = uni1479;
+unicode = 5241;
+},
+{
+glyphname = "kwo-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ko-canadian";
+}
+);
+width = 839;
+}
+);
+note = uni147A;
+unicode = 5242;
+},
+{
+glyphname = "kwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 839;
+}
+);
+note = uni147B;
+unicode = 5243;
+},
+{
+glyphname = "kwoo-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (643,0);
+ref = dot_top;
+}
+);
+width = 839;
+}
+);
+note = uni147C;
+unicode = 5244;
+},
+{
+glyphname = "kwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (410,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 839;
+}
+);
+note = uni147D;
+unicode = 5245;
+},
+{
+glyphname = "kwa-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ka-canadian";
+}
+);
+width = 839;
+}
+);
+note = uni147E;
+unicode = 5246;
+},
+{
+glyphname = "kwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 839;
+}
+);
+note = uni147F;
+unicode = 5247;
+},
+{
+glyphname = "kwaa-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (277,0);
+ref = dot_top;
+}
+);
+width = 839;
+}
+);
+note = uni1480;
+unicode = 5248;
+},
+{
+glyphname = "kwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (44,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (607,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 839;
+}
+);
+note = uni1481;
+unicode = 5249;
+},
+{
+glyphname = "kwaaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ka-canadian";
+}
+);
+width = 838;
+}
+);
+note = uni1482;
+unicode = 5250;
+},
+{
+glyphname = "k-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(273,351,o),
+(330,402,o),
+(330,489,cs),
+(330,571,o),
+(278,622,o),
+(211,622,cs),
+(164,622,o),
+(129,593,o),
+(121,553,c),
+(137,548,l),
+(137,714,l),
+(66,714,l),
+(66,490,ls),
+(66,404,o),
+(118,351,o),
+(200,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(157,404,o),
+(131,432,o),
+(131,487,cs),
+(131,540,o),
+(160,569,o),
+(198,569,cs),
+(238,569,o),
+(266,540,o),
+(266,487,cs),
+(266,434,o),
+(239,404,o),
+(199,404,cs)
+);
+}
+);
+width = 386;
+}
+);
+note = uni1483;
+unicode = 5251;
+},
+{
+glyphname = "kw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(267,351,o),
+(320,404,o),
+(320,490,cs),
+(320,714,l),
+(249,714,l),
+(249,548,l),
+(265,553,l),
+(257,593,o),
+(222,622,o),
+(175,622,cs),
+(108,622,o),
+(56,571,o),
+(56,489,cs),
+(56,402,o),
+(113,351,o),
+(186,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(147,404,o),
+(120,434,o),
+(120,487,cs),
+(120,540,o),
+(148,569,o),
+(187,569,cs),
+(226,569,o),
+(254,540,o),
+(254,487,cs),
+(254,432,o),
+(229,404,o),
+(187,404,cs)
+);
+}
+);
+width = 386;
+}
+);
+metricLeft = "=|k-canadian";
+metricRight = "=|k-canadian";
+note = uni1484;
+unicode = 5252;
+},
+{
+glyphname = "southslaveykeh-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian";
+},
+{
+alignment = -1;
+pos = (607,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni1485;
+unicode = 5253;
+},
+{
+glyphname = "southslaveykih-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+pos = (607,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni1486;
+unicode = 5254;
+},
+{
+glyphname = "southslaveykoh-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+pos = (607,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni1487;
+unicode = 5255;
+},
+{
+glyphname = "southslaveykah-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+pos = (607,0);
+ref = "pWestCree-canadian";
+}
+);
+width = 810;
+}
+);
+note = uni1488;
+unicode = 5256;
+},
+{
+glyphname = "ce-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (312,413);
+},
+{
+name = top_center_can;
+pos = (299,714);
+},
+{
+name = top_left_can;
+pos = (111,714);
+},
+{
+name = top_right_can;
+pos = (481,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(531,0,l),
+(531,464,ls),
+(531,630,o),
+(444,727,o),
+(299,727,cs),
+(151,727,o),
+(61,629,o),
+(61,465,cs),
+(61,401,l),
+(160,401,l),
+(160,473,ls),
+(160,580,o),
+(209,640,o),
+(297,640,cs),
+(382,640,o),
+(431,580,o),
+(431,473,cs),
+(431,0,l)
+);
+}
+);
+width = 602;
+}
+);
+metricRight = "te-canadian";
+note = uni1489;
+unicode = 5257;
+},
+{
+glyphname = "caai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (179,0);
+ref = ring_top.canadian;
+}
+);
+width = 601;
+}
+);
+note = uni148A;
+unicode = 5258;
+},
+{
+glyphname = "ci-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (315,413);
+},
+{
+name = top_center_can;
+pos = (309,714);
+},
+{
+name = top_left_can;
+pos = (121,714);
+},
+{
+name = top_right_can;
+pos = (492,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(170,0,l),
+(170,473,ls),
+(170,580,o),
+(220,640,o),
+(307,640,cs),
+(394,640,o),
+(441,580,o),
+(441,474,cs),
+(441,401,l),
+(540,401,l),
+(540,465,ls),
+(540,629,o),
+(454,727,o),
+(309,727,cs),
+(158,727,o),
+(71,628,o),
+(71,464,cs),
+(71,0,l)
+);
+}
+);
+width = 601;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+unicode = 5259;
+},
+{
+glyphname = "cii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (233,0);
+ref = dot_top;
+}
+);
+width = 601;
+}
+);
+note = uni148C;
+unicode = 5260;
+},
+{
+glyphname = "co-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (312,413);
+},
+{
+name = top_center_can;
+pos = (298,714);
+},
+{
+name = top_double;
+pos = (481,714);
+},
+{
+name = top_left_can;
+pos = (111,714);
+},
+{
+name = top_right_can;
+pos = (481,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(443,-13,o),
+(531,82,o),
+(531,250,cs),
+(531,714,l),
+(431,714,l),
+(431,241,ls),
+(431,132,o),
+(382,74,o),
+(297,74,cs),
+(207,74,o),
+(160,134,o),
+(160,244,cs),
+(160,313,l),
+(61,313,l),
+(61,248,ls),
+(61,85,o),
+(147,-13,o),
+(299,-13,cs)
+);
+}
+);
+width = 602;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+unicode = 5261;
+},
+{
+glyphname = "coo-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (405,0);
+ref = dot_top;
+}
+);
+width = 601;
+}
+);
+note = uni148E;
+unicode = 5262;
+},
+{
+glyphname = "ycreecoo-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (232,0);
+ref = doubledot_top;
+}
+);
+width = 601;
+}
+);
+note = uni148F;
+unicode = 5263;
+},
+{
+glyphname = "ca-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (315,413);
+},
+{
+name = top_center_can;
+pos = (309,714);
+},
+{
+name = top_left_can;
+pos = (121,714);
+},
+{
+name = top_right_can;
+pos = (492,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(454,-13,o),
+(540,84,o),
+(540,249,cs),
+(540,313,l),
+(441,313,l),
+(441,243,ls),
+(441,132,o),
+(394,74,o),
+(307,74,cs),
+(218,74,o),
+(170,134,o),
+(170,243,cs),
+(170,714,l),
+(71,714,l),
+(71,250,ls),
+(71,83,o),
+(156,-13,o),
+(306,-13,cs)
+);
+}
+);
+width = 601;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+unicode = 5264;
+},
+{
+glyphname = "caa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (44,0);
+ref = dot_top;
+}
+);
+width = 601;
+}
+);
+note = uni1491;
+unicode = 5265;
+},
+{
+glyphname = "cwe-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ce-canadian";
+}
+);
+width = 834;
+}
+);
+note = uni1492;
+unicode = 5266;
+},
+{
+glyphname = "cweWestCree-canadian";
+kernLeft = celeft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (601,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 834;
+}
+);
+note = uni1493;
+unicode = 5267;
+},
+{
+glyphname = "cwi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ci-canadian";
+}
+);
+width = 834;
+}
+);
+note = uni1494;
+unicode = 5268;
+},
+{
+glyphname = "cwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (601,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 834;
+}
+);
+note = uni1495;
+unicode = 5269;
+},
+{
+glyphname = "cwii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (465,0);
+ref = dot_top;
+}
+);
+width = 834;
+}
+);
+note = uni1496;
+unicode = 5270;
+},
+{
+glyphname = "cwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (233,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (601,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 834;
+}
+);
+note = uni1497;
+unicode = 5271;
+},
+{
+glyphname = "cwo-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "co-canadian";
+}
+);
+width = 834;
+}
+);
+note = uni1498;
+unicode = 5272;
+},
+{
+glyphname = "cwoWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (601,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 834;
+}
+);
+note = uni1499;
+unicode = 5273;
+},
+{
+glyphname = "cwoo-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (638,0);
+ref = dot_top;
+}
+);
+width = 834;
+}
+);
+note = uni149A;
+unicode = 5274;
+},
+{
+glyphname = "cwooWestCree-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (405,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (601,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 834;
+}
+);
+note = uni149B;
+unicode = 5275;
+},
+{
+glyphname = "cwa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ca-canadian";
+}
+);
+width = 834;
+}
+);
+note = uni149C;
+unicode = 5276;
+},
+{
+glyphname = "cwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (601,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 834;
+}
+);
+note = uni149D;
+unicode = 5277;
+},
+{
+glyphname = "cwaa-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (277,0);
+ref = dot_top;
+}
+);
+width = 834;
+}
+);
+note = uni149E;
+unicode = 5278;
+},
+{
+glyphname = "cwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (44,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (601,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 834;
+}
+);
+note = uni149F;
+unicode = 5279;
+},
+{
+glyphname = "cwaaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ca-canadian";
+}
+);
+width = 833;
+}
+);
+note = uni14A0;
+unicode = 5280;
+},
+{
+glyphname = "c-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(278,351,o),
+(331,399,o),
+(331,484,cs),
+(331,504,l),
+(265,504,l),
+(265,479,ls),
+(265,432,o),
+(239,407,o),
+(200,407,cs),
+(160,407,o),
+(137,432,o),
+(137,484,cs),
+(137,714,l),
+(66,714,l),
+(66,493,ls),
+(66,400,o),
+(115,351,o),
+(200,351,cs)
+);
+}
+);
+width = 376;
+}
+);
+note = uni14A1;
+unicode = 5281;
+},
+{
+glyphname = "thSayisi-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(260,351,o),
+(309,400,o),
+(309,493,cs),
+(309,714,l),
+(239,714,l),
+(239,484,ls),
+(239,432,o),
+(216,407,o),
+(176,407,cs),
+(136,407,o),
+(111,432,o),
+(111,479,cs),
+(111,504,l),
+(45,504,l),
+(45,484,ls),
+(45,399,o),
+(98,351,o),
+(176,351,cs)
+);
+}
+);
+width = 375;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "=|c-canadian";
+note = uni14A2;
+unicode = 5282;
+},
+{
+glyphname = "me-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (205,357);
+},
+{
+name = top_center_can;
+pos = (257,714);
+},
+{
+name = top_left_can;
+pos = (91,714);
+},
+{
+name = top_right_can;
+pos = (419,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(468,0,l),
+(468,714,l),
+(41,714,l),
+(41,624,l),
+(369,624,l),
+(369,0,l)
+);
+}
+);
+width = 546;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+unicode = 5283;
+},
+{
+glyphname = "maai-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (163,0);
+ref = ring_top.canadian;
+}
+);
+width = 547;
+}
+);
+note = uni14A4;
+unicode = 5284;
+},
+{
+glyphname = "mi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (342,357);
+},
+{
+name = top_center_can;
+pos = (292,714);
+},
+{
+name = top_left_can;
+pos = (128,714);
+},
+{
+name = top_right_can;
+pos = (456,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(178,0,l),
+(178,624,l),
+(505,624,l),
+(505,714,l),
+(78,714,l),
+(78,0,l)
+);
+}
+);
+width = 546;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+unicode = 5285;
+},
+{
+glyphname = "mii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (216,0);
+ref = dot_top;
+}
+);
+width = 547;
+}
+);
+note = uni14A6;
+unicode = 5286;
+},
+{
+glyphname = "mo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (205,357);
+},
+{
+name = top_center_can;
+pos = (257,714);
+},
+{
+name = top_double;
+pos = (419,714);
+},
+{
+name = top_left_can;
+pos = (91,714);
+},
+{
+name = top_right_can;
+pos = (419,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(468,0,l),
+(468,714,l),
+(369,714,l),
+(369,90,l),
+(41,90,l),
+(41,0,l)
+);
+}
+);
+width = 546;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+unicode = 5287;
+},
+{
+glyphname = "moo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (343,0);
+ref = dot_top;
+}
+);
+width = 547;
+}
+);
+note = uni14A8;
+unicode = 5288;
+},
+{
+glyphname = "ycreemoo-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (169,0);
+ref = doubledot_top;
+}
+);
+width = 547;
+}
+);
+note = uni14A9;
+unicode = 5289;
+},
+{
+glyphname = "ma-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (342,357);
+},
+{
+name = top_center_can;
+pos = (292,714);
+},
+{
+name = top_left_can;
+pos = (128,714);
+},
+{
+name = top_right_can;
+pos = (455,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(505,0,l),
+(505,90,l),
+(178,90,l),
+(178,714,l),
+(78,714,l),
+(78,0,l)
+);
+}
+);
+width = 546;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+unicode = 5290;
+},
+{
+glyphname = "maa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (52,0);
+ref = dot_top;
+}
+);
+width = 547;
+}
+);
+note = uni14AB;
+unicode = 5291;
+},
+{
+glyphname = "mwe-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "me-canadian";
+}
+);
+width = 779;
+}
+);
+note = uni14AC;
+unicode = 5292;
+},
+{
+glyphname = "mweWestCree-canadian";
+kernLeft = meleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "me-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (547,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 779;
+}
+);
+note = uni14AD;
+unicode = 5293;
+},
+{
+glyphname = "mwi-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "mi-canadian";
+}
+);
+width = 779;
+}
+);
+note = uni14AE;
+unicode = 5294;
+},
+{
+glyphname = "mwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (547,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 779;
+}
+);
+note = uni14AF;
+unicode = 5295;
+},
+{
+glyphname = "mwii-canadian";
+kernRight = miright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (448,0);
+ref = dot_top;
+}
+);
+width = 779;
+}
+);
+note = uni14B0;
+unicode = 5296;
+},
+{
+glyphname = "mwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (216,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (547,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 779;
+}
+);
+note = uni14B1;
+unicode = 5297;
+},
+{
+glyphname = "mwo-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "mo-canadian";
+}
+);
+width = 779;
+}
+);
+note = uni14B2;
+unicode = 5298;
+},
+{
+glyphname = "mwoWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (547,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 779;
+}
+);
+note = uni14B3;
+unicode = 5299;
+},
+{
+glyphname = "mwoo-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (575,0);
+ref = dot_top;
+}
+);
+width = 779;
+}
+);
+note = uni14B4;
+unicode = 5300;
+},
+{
+glyphname = "mwooWestCree-canadian";
+kernLeft = moleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (343,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (547,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 779;
+}
+);
+note = uni14B5;
+unicode = 5301;
+},
+{
+glyphname = "mwa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ma-canadian";
+}
+);
+width = 779;
+}
+);
+note = uni14B6;
+unicode = 5302;
+},
+{
+glyphname = "mwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (547,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 779;
+}
+);
+note = uni14B7;
+unicode = 5303;
+},
+{
+glyphname = "mwaa-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (285,0);
+ref = dot_top;
+}
+);
+width = 779;
+}
+);
+note = uni14B8;
+unicode = 5304;
+},
+{
+glyphname = "mwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (52,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (547,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 779;
+}
+);
+note = uni14B9;
+unicode = 5305;
+},
+{
+glyphname = "mwaaNaskapi-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ma-canadian";
+}
+);
+width = 778;
+}
+);
+note = uni14BA;
+unicode = 5306;
+},
+{
+glyphname = "m-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(300,423,l),
+(137,423,l),
+(137,714,l),
+(66,714,l),
+(66,357,l),
+(300,357,l)
+);
+}
+);
+width = 349;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni14BB;
+unicode = 5307;
+},
+{
+glyphname = "mWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+ref = "t-canadian";
+}
+);
+width = 382;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "t-canadian";
+note = uni14BC;
+unicode = 5308;
+},
+{
+glyphname = "mh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(283,357,l),
+(283,714,l),
+(212,714,l),
+(212,423,l),
+(49,423,l),
+(49,357,l)
+);
+}
+);
+width = 349;
+}
+);
+metricLeft = "=|m-canadian";
+metricRight = "=|m-canadian";
+note = uni14BD;
+unicode = 5309;
+},
+{
+glyphname = "mAthapascan-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(315,357,l),
+(315,414,l),
+(141,414,l),
+(142,384,l),
+(250,498,ls),
+(286,536,o),
+(300,572,o),
+(300,613,cs),
+(300,677,o),
+(255,720,o),
+(182,720,cs),
+(102,720,o),
+(57,670,o),
+(56,592,c),
+(119,592,l),
+(119,642,o),
+(140,667,o),
+(181,667,cs),
+(217,667,o),
+(237,647,o),
+(237,611,cs),
+(237,579,o),
+(227,556,o),
+(194,520,cs),
+(70,392,l),
+(70,357,l)
+);
+}
+);
+width = 365;
+}
+);
+note = uni14BE;
+unicode = 5310;
+},
+{
+glyphname = "mSayisi-canadian";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = two.canadian;
+}
+);
+width = 601;
+}
+);
+note = uni14BF;
+unicode = 5311;
+},
+{
+glyphname = "ne-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (528,254);
+},
+{
+name = top_center_can;
+pos = (516,515);
+},
+{
+name = top_left_can;
+pos = (107,515);
+},
+{
+name = top_right_can;
+pos = (723,515);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(674,-13,o),
+(771,85,o),
+(771,242,cs),
+(771,401,o),
+(676,496,o),
+(516,496,cs),
+(57,496,l),
+(57,407,l),
+(394,407,l),
+(382,430,l),
+(318,396,o),
+(286,320,o),
+(286,237,cs),
+(286,82,o),
+(380,-13,o),
+(528,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(436,72,o),
+(383,137,o),
+(383,241,cs),
+(383,344,o),
+(436,411,o),
+(527,411,cs),
+(620,411,o),
+(673,345,o),
+(673,241,cs),
+(673,137,o),
+(620,72,o),
+(528,72,cs)
+);
+}
+);
+width = 833;
+}
+);
+metricRight = "=|ke-canadian";
+note = uni14C0;
+unicode = 5312;
+},
+{
+glyphname = "naai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (189,-199);
+ref = ring_top.canadian;
+}
+);
+width = 833;
+}
+);
+note = uni14C1;
+unicode = 5313;
+},
+{
+glyphname = "ni-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (306,254);
+},
+{
+name = top_center_can;
+pos = (319,515);
+},
+{
+name = top_left_can;
+pos = (111,515);
+},
+{
+name = top_right_can;
+pos = (726,515);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(453,-13,o),
+(547,82,o),
+(547,238,cs),
+(547,321,o),
+(514,397,o),
+(450,431,c),
+(439,407,l),
+(776,407,l),
+(776,496,l),
+(319,496,ls),
+(156,496,o),
+(62,395,o),
+(62,240,cs),
+(62,84,o),
+(159,-13,o),
+(305,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(213,72,o),
+(160,137,o),
+(160,242,cs),
+(160,346,o),
+(213,411,o),
+(306,411,cs),
+(397,411,o),
+(450,344,o),
+(450,242,cs),
+(450,137,o),
+(397,72,o),
+(305,72,cs)
+);
+}
+);
+width = 833;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+unicode = 5314;
+},
+{
+glyphname = "nii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (243,-199);
+ref = dot_top;
+}
+);
+width = 833;
+}
+);
+note = uni14C3;
+unicode = 5315;
+},
+{
+glyphname = "no-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (528,254);
+},
+{
+name = top_center_can;
+pos = (525,515);
+},
+{
+name = top_double;
+pos = (528,515);
+},
+{
+name = top_left_can;
+pos = (107,515);
+},
+{
+name = top_right_can;
+pos = (723,515);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(520,0,ls),
+(677,0,o),
+(771,97,o),
+(771,254,cs),
+(771,411,o),
+(675,509,o),
+(528,509,cs),
+(381,509,o),
+(286,412,o),
+(286,258,cs),
+(286,176,o),
+(318,100,o),
+(382,66,c),
+(394,89,l),
+(57,89,l),
+(57,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(436,85,o),
+(383,152,o),
+(383,254,cs),
+(383,359,o),
+(436,424,o),
+(528,424,cs),
+(620,424,o),
+(673,359,o),
+(673,254,cs),
+(673,150,o),
+(620,85,o),
+(527,85,cs)
+);
+}
+);
+width = 833;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14C4;
+unicode = 5316;
+},
+{
+glyphname = "noo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (449,-199);
+ref = dot_top;
+}
+);
+width = 833;
+}
+);
+note = uni14C5;
+unicode = 5317;
+},
+{
+glyphname = "ycreenoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (278,-199);
+ref = doubledot_top;
+}
+);
+width = 833;
+}
+);
+note = uni14C6;
+unicode = 5318;
+},
+{
+glyphname = "na-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (306,254);
+},
+{
+name = top_center_can;
+pos = (308,515);
+},
+{
+name = top_double;
+pos = (469,515);
+},
+{
+name = top_left_can;
+pos = (111,515);
+},
+{
+name = top_right_can;
+pos = (726,515);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(776,0,l),
+(776,89,l),
+(439,89,l),
+(451,64,l),
+(514,99,o),
+(547,175,o),
+(547,258,cs),
+(547,413,o),
+(453,509,o),
+(305,509,cs),
+(159,509,o),
+(62,411,o),
+(62,253,cs),
+(62,99,o),
+(155,0,o),
+(315,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(213,85,o),
+(160,150,o),
+(160,254,cs),
+(160,359,o),
+(213,424,o),
+(305,424,cs),
+(397,424,o),
+(450,359,o),
+(450,254,cs),
+(450,152,o),
+(397,85,o),
+(306,85,cs)
+);
+}
+);
+width = 833;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+unicode = 5319;
+},
+{
+glyphname = "naa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (232,-199);
+ref = dot_top;
+}
+);
+width = 833;
+}
+);
+note = uni14C8;
+unicode = 5320;
+},
+{
+glyphname = "nwe-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ne-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni14C9;
+unicode = 5321;
+},
+{
+glyphname = "nweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (833,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni14CA;
+unicode = 5322;
+},
+{
+glyphname = "nwa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "na-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni14CB;
+unicode = 5323;
+},
+{
+glyphname = "nwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (833,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni14CC;
+unicode = 5324;
+},
+{
+glyphname = "nwaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (464,-199);
+ref = dot_top;
+}
+);
+width = 1065;
+}
+);
+note = uni14CD;
+unicode = 5325;
+},
+{
+glyphname = "nwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (232,-199);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (833,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni14CE;
+unicode = 5326;
+},
+{
+glyphname = "nwaaNaskapi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (219,-199);
+ref = doubledot_top;
+}
+);
+width = 833;
+}
+);
+note = uni14CF;
+unicode = 5327;
+},
+{
+glyphname = "n-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(446,450,l),
+(446,515,l),
+(258,515,l),
+(261,485,l),
+(294,498,o),
+(317,540,o),
+(317,589,cs),
+(317,669,o),
+(266,721,o),
+(187,721,cs),
+(109,721,o),
+(56,668,o),
+(56,586,cs),
+(56,504,o),
+(108,450,o),
+(193,450,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(147,502,o),
+(119,533,o),
+(119,586,cs),
+(119,638,o),
+(147,668,o),
+(187,668,cs),
+(227,668,o),
+(254,638,o),
+(254,585,cs),
+(254,533,o),
+(227,502,o),
+(187,502,cs)
+);
+}
+);
+width = 495;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni14D0;
+unicode = 5328;
+},
+{
+color = 6;
+glyphname = "ngCarrier-canadian";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-167);
+ref = "ringBottomhalfFinal-canadian";
+}
+);
+width = 439;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "=|";
+note = uni14D1;
+unicode = 5329;
+},
+{
+glyphname = "nh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(303,450,ls),
+(387,450,o),
+(439,504,o),
+(439,586,cs),
+(439,668,o),
+(386,721,o),
+(308,721,cs),
+(229,721,o),
+(178,669,o),
+(178,589,cs),
+(178,540,o),
+(201,498,o),
+(234,485,c),
+(237,515,l),
+(49,515,l),
+(49,450,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(268,502,o),
+(241,533,o),
+(241,585,cs),
+(241,638,o),
+(269,668,o),
+(308,668,cs),
+(348,668,o),
+(376,638,o),
+(376,586,cs),
+(376,533,o),
+(348,502,o),
+(308,502,cs)
+);
+}
+);
+width = 495;
+}
+);
+metricLeft = "=|n-canadian";
+metricRight = "=|n-canadian";
+note = uni14D2;
+unicode = 5330;
+},
+{
+glyphname = "le-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (528,254);
+},
+{
+name = top_center_can;
+pos = (517,515);
+},
+{
+name = top_left_can;
+pos = (107,515);
+},
+{
+name = top_right_can;
+pos = (722,515);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(512,0,ls),
+(671,0,o),
+(771,94,o),
+(771,248,cs),
+(771,402,o),
+(678,496,o),
+(510,496,cs),
+(57,496,l),
+(57,406,l),
+(509,406,ls),
+(614,406,o),
+(673,348,o),
+(673,247,cs),
+(673,146,o),
+(612,88,o),
+(507,88,cs),
+(457,88,l),
+(457,0,l)
+);
+}
+);
+width = 833;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D3;
+unicode = 5331;
+},
+{
+glyphname = "laai-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (189,-199);
+ref = ring_top.canadian;
+}
+);
+width = 833;
+}
+);
+note = uni14D4;
+unicode = 5332;
+},
+{
+glyphname = "li-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (306,254);
+},
+{
+name = top_center_can;
+pos = (319,515);
+},
+{
+name = top_left_can;
+pos = (111,515);
+},
+{
+name = top_right_can;
+pos = (726,515);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(376,0,l),
+(376,88,l),
+(326,88,ls),
+(218,88,o),
+(161,146,o),
+(161,246,cs),
+(161,343,o),
+(213,406,o),
+(325,406,cs),
+(776,406,l),
+(776,496,l),
+(323,496,ls),
+(156,496,o),
+(62,398,o),
+(62,246,cs),
+(62,94,o),
+(161,0,o),
+(321,0,cs)
+);
+}
+);
+width = 833;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14D5;
+unicode = 5333;
+},
+{
+glyphname = "lii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (243,-199);
+ref = dot_top;
+}
+);
+width = 833;
+}
+);
+note = uni14D6;
+unicode = 5334;
+},
+{
+glyphname = "lo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (528,254);
+},
+{
+name = top_center_can;
+pos = (525,515);
+},
+{
+name = top_double;
+pos = (513,515);
+},
+{
+name = top_left_can;
+pos = (107,515);
+},
+{
+name = top_right_can;
+pos = (722,515);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(508,0,ls),
+(675,0,o),
+(771,94,o),
+(771,249,cs),
+(771,403,o),
+(672,496,o),
+(513,496,cs),
+(457,496,l),
+(457,408,l),
+(507,408,ls),
+(615,408,o),
+(673,350,o),
+(673,250,cs),
+(673,148,o),
+(615,90,o),
+(508,90,cs),
+(57,90,l),
+(57,0,l)
+);
+}
+);
+width = 833;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni14D7;
+unicode = 5335;
+},
+{
+glyphname = "loo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (449,-199);
+ref = dot_top;
+}
+);
+width = 833;
+}
+);
+note = uni14D8;
+unicode = 5336;
+},
+{
+glyphname = "ycreeloo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (263,-199);
+ref = doubledot_top;
+}
+);
+width = 833;
+}
+);
+note = uni14D9;
+unicode = 5337;
+},
+{
+glyphname = "la-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (306,254);
+},
+{
+name = top_center_can;
+pos = (308,515);
+},
+{
+name = top_left_can;
+pos = (111,515);
+},
+{
+name = top_right_can;
+pos = (726,515);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(776,0,l),
+(776,90,l),
+(327,90,ls),
+(218,90,o),
+(161,148,o),
+(161,249,cs),
+(161,350,o),
+(217,408,o),
+(323,408,cs),
+(376,408,l),
+(376,496,l),
+(322,496,ls),
+(158,496,o),
+(62,401,o),
+(62,248,cs),
+(62,92,o),
+(159.995,0,o),
+(324.992,0,cs)
+);
+}
+);
+width = 833;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni14DA;
+unicode = 5338;
+},
+{
+glyphname = "laa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (232,-199);
+ref = dot_top;
+}
+);
+width = 833;
+}
+);
+note = uni14DB;
+unicode = 5339;
+},
+{
+glyphname = "lwe-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "le-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni14DC;
+unicode = 5340;
+},
+{
+glyphname = "lweWestCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "le-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (833,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni14DD;
+unicode = 5341;
+},
+{
+glyphname = "lwi-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "li-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni14DE;
+unicode = 5342;
+},
+{
+glyphname = "lwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (833,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni14DF;
+unicode = 5343;
+},
+{
+glyphname = "lwii-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (475,-199);
+ref = dot_top;
+}
+);
+width = 1065;
+}
+);
+note = uni14E0;
+unicode = 5344;
+},
+{
+glyphname = "lwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "li-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (243,-199);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (833,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni14E1;
+unicode = 5345;
+},
+{
+glyphname = "lwo-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "lo-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni14E2;
+unicode = 5346;
+},
+{
+glyphname = "lwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (833,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni14E3;
+unicode = 5347;
+},
+{
+glyphname = "lwoo-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (681,-199);
+ref = dot_top;
+}
+);
+width = 1065;
+}
+);
+note = uni14E4;
+unicode = 5348;
+},
+{
+glyphname = "lwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "lo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (449,-199);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (833,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni14E5;
+unicode = 5349;
+},
+{
+glyphname = "lwa-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "la-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni14E6;
+unicode = 5350;
+},
+{
+glyphname = "lwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (833,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni14E7;
+unicode = 5351;
+},
+{
+glyphname = "lwaa-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (464,-199);
+ref = dot_top;
+}
+);
+width = 1065;
+}
+);
+note = uni14E8;
+unicode = 5352;
+},
+{
+glyphname = "lwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (232,-199);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (833,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni14E9;
+unicode = 5353;
+},
+{
+glyphname = "l-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(441,357,l),
+(441,423,l),
+(250,423,ls),
+(171,423,o),
+(133,462,o),
+(133,536,cs),
+(133,609,o),
+(171,650,o),
+(247,650,cs),
+(262,650,l),
+(262,714,l),
+(242,714,ls),
+(128,714,o),
+(62,646,o),
+(62,535,cs),
+(62,425,o),
+(128,357,o),
+(243,357,cs)
+);
+}
+);
+width = 490;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "m-canadian";
+note = uni14EA;
+unicode = 5354;
+},
+{
+glyphname = "lWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(315,357,l),
+(315,403,l),
+(123,480,l),
+(123,446,l),
+(315,520,l),
+(315,551,l),
+(123,625,l),
+(123,591,l),
+(315,667,l),
+(315,714,l),
+(301,714,l),
+(66,621,l),
+(66,596,l),
+(262,522,l),
+(262,548,l),
+(66,475,l),
+(66,449,l),
+(301,357,l)
+);
+}
+);
+width = 381;
+}
+);
+metricRight = "=|";
+note = uni14EB;
+unicode = 5355;
+},
+{
+glyphname = "mediall-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(589,-13,l),
+(589,60,l),
+(171,223,l),
+(171,178,l),
+(589,335,l),
+(589,378,l),
+(171,536,l),
+(171,491,l),
+(589,654,l),
+(589,727,l),
+(563,727,l),
+(72,535,l),
+(72,496,l),
+(490,339,l),
+(490,375,l),
+(72,218,l),
+(72,179,l),
+(563,-13,l)
+);
+}
+);
+width = 661;
+}
+);
+metricRight = "=|";
+note = uni14EC;
+unicode = 5356;
+},
+{
+glyphname = "se-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (126,714);
+},
+{
+name = top_right_can;
+pos = (431,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(479.995,0,l),
+(480,344,l),
+(440,344,ls),
+(266,344,o),
+(176,429,o),
+(176,617,cs),
+(176,714,l),
+(76,714,l),
+(76,607,ls),
+(76,380,o),
+(204,255,o),
+(421,255,cs),
+(454,255,l),
+(381,291,l),
+(381,0,l)
+);
+}
+);
+width = 558;
+}
+);
+note = uni14ED;
+unicode = 5357;
+},
+{
+glyphname = "saai-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (304,0);
+ref = ring_top.canadian;
+}
+);
+width = 558;
+}
+);
+note = uni14EE;
+unicode = 5358;
+},
+{
+glyphname = "si-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (128,714);
+},
+{
+name = top_right_can;
+pos = (433,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(178,0,l),
+(178,291,l),
+(104,255,l),
+(138,255,ls),
+(354,255,o),
+(482,380,o),
+(482,607,cs),
+(482,714,l),
+(383,714,l),
+(383,617,ls),
+(383,429,o),
+(293,344,o),
+(118,344,cs),
+(78,344,l),
+(78,0,l)
+);
+}
+);
+width = 558;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+unicode = 5359;
+},
+{
+glyphname = "sii-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (357,0);
+ref = dot_top;
+}
+);
+width = 558;
+}
+);
+note = uni14F0;
+unicode = 5360;
+},
+{
+glyphname = "so-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (431,714);
+},
+{
+name = top_left_can;
+pos = (126,714);
+},
+{
+name = top_right_can;
+pos = (430,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(176,0,l),
+(176,97,ls),
+(176,285,o),
+(266,370,o),
+(440,370,cs),
+(480,370,l),
+(479.995,714,l),
+(381,714,l),
+(381,423,l),
+(454,459,l),
+(421,459,ls),
+(204,459,o),
+(76,334,o),
+(76,107,cs),
+(76,0,l)
+);
+}
+);
+width = 558;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+unicode = 5361;
+},
+{
+glyphname = "soo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (354,0);
+ref = dot_top;
+}
+);
+width = 558;
+}
+);
+note = uni14F2;
+unicode = 5362;
+},
+{
+glyphname = "ycreesoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (181,0);
+ref = doubledot_top;
+}
+);
+width = 558;
+}
+);
+note = uni14F3;
+unicode = 5363;
+},
+{
+glyphname = "sa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (129,714);
+},
+{
+name = top_right_can;
+pos = (433,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(482,0,l),
+(482,107,ls),
+(482,334,o),
+(354,459,o),
+(138,459,cs),
+(104,459,l),
+(178,423,l),
+(178,714,l),
+(78,714,l),
+(78,370,l),
+(118,370,ls),
+(293,370,o),
+(383,285,o),
+(383,97,cs),
+(383,0,l)
+);
+}
+);
+width = 558;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+unicode = 5364;
+},
+{
+glyphname = "saa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (52,0);
+ref = dot_top;
+}
+);
+width = 558;
+}
+);
+note = uni14F5;
+unicode = 5365;
+},
+{
+glyphname = "swe-canadian";
+kernRight = seright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "se-canadian";
+}
+);
+width = 791;
+}
+);
+note = uni14F6;
+unicode = 5366;
+},
+{
+glyphname = "sweWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "se-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (558,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 791;
+}
+);
+note = uni14F7;
+unicode = 5367;
+},
+{
+glyphname = "swi-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "si-canadian";
+}
+);
+width = 791;
+}
+);
+note = uni14F8;
+unicode = 5368;
+},
+{
+glyphname = "swiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (558,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 791;
+}
+);
+note = uni14F9;
+unicode = 5369;
+},
+{
+glyphname = "swii-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (589,0);
+ref = dot_top;
+}
+);
+width = 791;
+}
+);
+note = uni14FA;
+unicode = 5370;
+},
+{
+glyphname = "swiiWestCree-canadian";
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (357,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (558,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 791;
+}
+);
+note = uni14FB;
+unicode = 5371;
+},
+{
+glyphname = "swo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "so-canadian";
+}
+);
+width = 791;
+}
+);
+note = uni14FC;
+unicode = 5372;
+},
+{
+glyphname = "swoWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (558,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 791;
+}
+);
+note = uni14FD;
+unicode = 5373;
+},
+{
+glyphname = "swoo-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (587,0);
+ref = dot_top;
+}
+);
+width = 791;
+}
+);
+note = uni14FE;
+unicode = 5374;
+},
+{
+glyphname = "swooWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (354,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (558,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 791;
+}
+);
+note = uni14FF;
+unicode = 5375;
+},
+{
+glyphname = "swa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "sa-canadian";
+}
+);
+width = 791;
+}
+);
+note = uni1500;
+unicode = 5376;
+},
+{
+glyphname = "swaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (558,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 791;
+}
+);
+note = uni1501;
+unicode = 5377;
+},
+{
+glyphname = "swaa-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (285,0);
+ref = dot_top;
+}
+);
+width = 791;
+}
+);
+note = uni1502;
+unicode = 5378;
+},
+{
+glyphname = "swaaWestCree-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (52,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (558,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 791;
+}
+);
+note = uni1503;
+unicode = 5379;
+},
+{
+glyphname = "swaaNaskapi-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "sa-canadian";
+}
+);
+width = 790;
+}
+);
+note = uni1504;
+unicode = 5380;
+},
+{
+glyphname = "s-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(304,357,l),
+(304,414,ls),
+(304,527,o),
+(241,600,o),
+(131,600,cs),
+(94,600,l),
+(137,568,l),
+(137,714,l),
+(66,714,l),
+(66,543,l),
+(105,543,ls),
+(193,543,o),
+(233,499,o),
+(233,410,cs),
+(233,357,l)
+);
+}
+);
+width = 370;
+}
+);
+metricRight = "=|";
+note = uni1505;
+unicode = 5381;
+},
+{
+color = 6;
+glyphname = "sAthapascan-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(278,183,o),
+(327,226,o),
+(327,284,cs),
+(327,328,o),
+(304,359,o),
+(251,378,cs),
+(175,404,ls),
+(144,416,o),
+(134,429,o),
+(134,451,cs),
+(134,481,o),
+(156,501,o),
+(198,501,cs),
+(240,501,o),
+(264,482,o),
+(265,439,c),
+(327,439,l),
+(326,510,o),
+(278,552,o),
+(198.005,552,cs),
+(121,552,o),
+(72,510,o),
+(72,451,cs),
+(72,406,o),
+(97,373,o),
+(146,356,cs),
+(223,330,ls),
+(253,318,o),
+(265,306,o),
+(265,282,cs),
+(265,252,o),
+(241,234,o),
+(199,234,cs),
+(154,234,o),
+(130,253,o),
+(128,298,c),
+(66,298,l),
+(68,224,o),
+(115,183,o),
+(198,183,cs)
+);
+}
+);
+width = 393;
+}
+);
+metricRight = "=|";
+note = uni1506;
+unicode = 5382;
+},
+{
+glyphname = "sw-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(137,357,l),
+(137,410,ls),
+(137,499,o),
+(177,543,o),
+(265,543,cs),
+(304,543,l),
+(304,714,l),
+(233,714,l),
+(233,568,l),
+(276,600,l),
+(239,600,ls),
+(129,600,o),
+(66,527,o),
+(66,414,cs),
+(66,357,l)
+);
+}
+);
+width = 370;
+}
+);
+metricLeft = "=|s-canadian";
+metricRight = "=|s-canadian";
+note = uni1507;
+unicode = 5383;
+},
+{
+glyphname = "sBlackfoot-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(310,357,l),
+(310,423,l),
+(221,423,ls),
+(164,423,o),
+(137,450,o),
+(137,510,cs),
+(137,714,l),
+(66,714,l),
+(66,502,ls),
+(66,408,o),
+(117,357,o),
+(211,357,c)
+);
+}
+);
+width = 359;
+}
+);
+metricLeft = "ai-canadian";
+metricRight = "m-canadian";
+note = uni1508;
+unicode = 5384;
+},
+{
+glyphname = "moosecreesk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(273,225,o),
+(330,280,o),
+(330,380,cs),
+(330,521,o),
+(266,600,o),
+(138,600,cs),
+(105,600,l),
+(139,568,l),
+(139,714,l),
+(68,714,l),
+(68,543,l),
+(120,543,ls),
+(221,543,o),
+(252,501,o),
+(260,432,c),
+(281,425,l),
+(272,464,o),
+(238,494,o),
+(192,494,cs),
+(119,494,o),
+(67,442,o),
+(67,362,cs),
+(67,276,o),
+(124,225,o),
+(196,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(157,277,o),
+(129,308,o),
+(129,361,cs),
+(129,414,o),
+(158,444,o),
+(198,444,cs),
+(237,444,o),
+(265,413,o),
+(265,361,cs),
+(265,309,o),
+(239,277,o),
+(197,277,cs)
+);
+}
+);
+width = 397;
+}
+);
+metricRight = "=|";
+note = uni1509;
+unicode = 5385;
+},
+{
+glyphname = "skwNaskapi-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(273,225,o),
+(330,276,o),
+(330,362,cs),
+(330,442,o),
+(278,494,o),
+(205,494,cs),
+(159,494,o),
+(125,464,o),
+(116,425,c),
+(137,432,l),
+(145,501,o),
+(176,543,o),
+(277,543,cs),
+(329,543,l),
+(329,714,l),
+(258,714,l),
+(258,568,l),
+(292,600,l),
+(259,600,ls),
+(131,600,o),
+(67,521,o),
+(67,380,cs),
+(67,280,o),
+(124,225,o),
+(200,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(158,277,o),
+(132,309,o),
+(132,361,cs),
+(132,413,o),
+(161,444,o),
+(199,444,cs),
+(239,444,o),
+(267,414,o),
+(267,361,cs),
+(267,308,o),
+(239,277,o),
+(200,277,cs)
+);
+}
+);
+width = 397;
+}
+);
+metricLeft = "=|moosecreesk-canadian";
+metricRight = "=|moosecreesk-canadian";
+note = uni150A;
+unicode = 5386;
+},
+{
+glyphname = "swNaskapi-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(322,189,l),
+(322,240,ls),
+(322,348,o),
+(259,420,o),
+(149,420,cs),
+(118,420,l),
+(150,389,l),
+(150,526,l),
+(79,526,l),
+(79,363,l),
+(123,363,ls),
+(211,363,o),
+(251,322,o),
+(251,237,cs),
+(251,189,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(317,42,o),
+(342,67,o),
+(342,98,cs),
+(342,129,o),
+(317,153,o),
+(287,153,cs),
+(256,153,o),
+(232,129,o),
+(232,98,cs),
+(232,67,o),
+(256,42,o),
+(287,42,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(145,561,o),
+(170,586,o),
+(170,617,cs),
+(170,648,o),
+(145,672,o),
+(115,672,cs),
+(84,672,o),
+(60,648,o),
+(60,617,cs),
+(60,586,o),
+(84,561,o),
+(115,561,cs)
+);
+}
+);
+width = 402;
+}
+);
+metricRight = "=|";
+note = uni150B;
+unicode = 5387;
+},
+{
+glyphname = "spwaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(617,0,l),
+(617,92,l),
+(146,379,l),
+(146,334,l),
+(617,621,l),
+(617,714,l),
+(591,714,l),
+(35,375,l),
+(35,339,l),
+(591,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(161,509,o),
+(186,533,o),
+(186,564,cs),
+(186,595,o),
+(161,619,o),
+(131,619,cs),
+(101,619,o),
+(76,595,o),
+(76,564,cs),
+(76,533,o),
+(101,509,o),
+(131,509,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(359,624,l),
+(359,667,ls),
+(359,750,o),
+(314,803,o),
+(231,803,cs),
+(205,803,l),
+(247,777,l),
+(247,880,l),
+(178,880,l),
+(178,750,l),
+(207,750,ls),
+(263,750,o),
+(290,720,o),
+(290,663,cs),
+(290,624,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(526,729,o),
+(551,754,o),
+(551,785,cs),
+(551,816,o),
+(526,840,o),
+(496,840,cs),
+(466,840,o),
+(441,816,o),
+(441,785,cs),
+(441,754,o),
+(466,729,o),
+(496,729,cs)
+);
+}
+);
+width = 672;
+}
+);
+metricRight = "pa-canadian";
+metricWidth = "pa-canadian";
+note = uni150C;
+unicode = 5388;
+},
+{
+glyphname = "stwaNaskapi-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (401,0);
+ref = "ta-canadian";
+}
+);
+width = 1030;
+}
+);
+note = uni150D;
+unicode = 5389;
+},
+{
+glyphname = "skwaNaskapi-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (401,0);
+ref = "ka-canadian";
+}
+);
+width = 1008;
+}
+);
+note = uni150E;
+unicode = 5390;
+},
+{
+glyphname = "scwaNaskapi-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "swNaskapi-canadian";
+},
+{
+alignment = -1;
+pos = (401,0);
+ref = "ca-canadian";
+}
+);
+width = 1003;
+}
+);
+note = uni150F;
+unicode = 5391;
+},
+{
+glyphname = "she-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (292,714);
+},
+{
+name = top_right_can;
+pos = (724,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(791,-13,o),
+(875,82,o),
+(875,250,cs),
+(875,313,l),
+(776,313,l),
+(776,245,ls),
+(776,131,o),
+(731,74,o),
+(652,74,cs),
+(569,74,o),
+(530,132,o),
+(523,246,cs),
+(511,467,ls),
+(501,633,o),
+(430,727,o),
+(291,727,cs),
+(149,727,o),
+(62,631,o),
+(62,464,cs),
+(62,401,l),
+(160,401,l),
+(160,472,ls),
+(160,581,o),
+(207,640,o),
+(287,640,cs),
+(367,640,o),
+(407,582,o),
+(413,471,cs),
+(425,247,ls),
+(435,80,o),
+(505,-13,o),
+(649,-13,cs)
+);
+}
+);
+width = 937;
+}
+);
+metricRight = "=|";
+note = uni1510;
+unicode = 5392;
+},
+{
+glyphname = "shi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (215,714);
+},
+{
+name = top_right_can;
+pos = (647,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(432,-13,o),
+(502,80,o),
+(511,247,cs),
+(523,471,ls),
+(530,582,o),
+(570,640,o),
+(649,640,cs),
+(730,640,o),
+(776,581,o),
+(776,472,cs),
+(776,401,l),
+(875,401,l),
+(875,464,ls),
+(875,631,o),
+(788,727,o),
+(645,727,cs),
+(506,727,o),
+(435,633,o),
+(425,467,cs),
+(413,246,ls),
+(406,132,o),
+(368,74,o),
+(285,74,cs),
+(205,74,o),
+(160,131,o),
+(160,245,cs),
+(160,313,l),
+(62,313,l),
+(62,250,ls),
+(62,82,o),
+(146,-13,o),
+(287,-13,cs)
+);
+}
+);
+width = 937;
+}
+);
+metricLeft = "she-canadian";
+metricRight = "she-canadian";
+note = uni1511;
+unicode = 5393;
+},
+{
+glyphname = "shii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (571,0);
+ref = dot_top;
+}
+);
+width = 937;
+}
+);
+note = uni1512;
+unicode = 5394;
+},
+{
+glyphname = "sho-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (480,515);
+},
+{
+name = top_left_can;
+pos = (288,515);
+},
+{
+name = top_right_can;
+pos = (672,515);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(357,71,l),
+(227,71,o),
+(160,111,o),
+(160,188,cs),
+(160,246,o),
+(194,284,o),
+(267,284,cs),
+(397,284,o),
+(535,125,o),
+(702,125,cs),
+(824,125,o),
+(898,196,o),
+(898,304,cs),
+(898,435,o),
+(790,510,o),
+(607,509,c),
+(604,425,l),
+(733,425,o),
+(801,385,o),
+(801,308,cs),
+(801,249,o),
+(766,212,o),
+(693,212,cs),
+(564,212,o),
+(425,371,o),
+(259,371,cs),
+(137,371,o),
+(62,299,o),
+(62,192,cs),
+(62,61,o),
+(171,-14,o),
+(353,-13,c)
+);
+}
+);
+width = 960;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1513;
+unicode = 5395;
+},
+{
+glyphname = "shoo-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (404,-199);
+ref = dot_top;
+}
+);
+width = 960;
+}
+);
+note = uni1514;
+unicode = 5396;
+},
+{
+glyphname = "sha-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (480,515);
+},
+{
+name = top_left_can;
+pos = (288,515);
+},
+{
+name = top_right_can;
+pos = (672,515);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(790,-15,o),
+(898,61,o),
+(898,191,cs),
+(898,299,o),
+(826,371,o),
+(702,371,cs),
+(535,371,o),
+(397,212,o),
+(267,212,cs),
+(194,212,o),
+(160,249,o),
+(160,308,cs),
+(160,385,o),
+(227,426,o),
+(357,425,c),
+(353,509,l),
+(171,511,o),
+(62,435,o),
+(62,305,cs),
+(62,196,o),
+(135,125,o),
+(259,125,cs),
+(425,125,o),
+(564,284,o),
+(693,284,cs),
+(766,284,o),
+(801,246,o),
+(801,188,cs),
+(801,111,o),
+(733,69,o),
+(604,71,c),
+(607,-13,l)
+);
+}
+);
+width = 960;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ke-canadian";
+note = uni1515;
+unicode = 5397;
+},
+{
+glyphname = "shaa-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (404,-199);
+ref = dot_top;
+}
+);
+width = 960;
+}
+);
+note = uni1516;
+unicode = 5398;
+},
+{
+glyphname = "shwe-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "she-canadian";
+}
+);
+width = 1169;
+}
+);
+note = uni1517;
+unicode = 5399;
+},
+{
+glyphname = "shweWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "she-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (937,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1169;
+}
+);
+note = uni1518;
+unicode = 5400;
+},
+{
+glyphname = "shwi-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "shi-canadian";
+}
+);
+width = 1169;
+}
+);
+note = uni1519;
+unicode = 5401;
+},
+{
+glyphname = "shwiWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (937,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1169;
+}
+);
+note = uni151A;
+unicode = 5402;
+},
+{
+glyphname = "shwii-canadian";
+kernLeft = coleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (803,0);
+ref = dot_top;
+}
+);
+width = 1169;
+}
+);
+note = uni151B;
+unicode = 5403;
+},
+{
+glyphname = "shwiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "shi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (571,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (937,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1169;
+}
+);
+note = uni151C;
+unicode = 5404;
+},
+{
+glyphname = "shwo-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "sho-canadian";
+}
+);
+width = 1193;
+}
+);
+note = uni151D;
+unicode = 5405;
+},
+{
+glyphname = "shwoWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (960,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1193;
+}
+);
+note = uni151E;
+unicode = 5406;
+},
+{
+glyphname = "shwoo-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (636,-199);
+ref = dot_top;
+}
+);
+width = 1193;
+}
+);
+note = uni151F;
+unicode = 5407;
+},
+{
+glyphname = "shwooWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (404,-199);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (960,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1193;
+}
+);
+note = uni1520;
+unicode = 5408;
+},
+{
+glyphname = "shwa-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "sha-canadian";
+}
+);
+width = 1193;
+}
+);
+note = uni1521;
+unicode = 5409;
+},
+{
+glyphname = "shwaWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (960,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1193;
+}
+);
+note = uni1522;
+unicode = 5410;
+},
+{
+glyphname = "shwaa-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (637,-199);
+ref = dot_top;
+}
+);
+width = 1193;
+}
+);
+note = uni1523;
+unicode = 5411;
+},
+{
+glyphname = "shwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (404,-199);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (960,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1193;
+}
+);
+note = uni1524;
+unicode = 5412;
+},
+{
+glyphname = "sh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(596,299,o),
+(682,357,o),
+(682,459,cs),
+(682,540,o),
+(625,599,o),
+(531,599,cs),
+(406,599,o),
+(317,489,o),
+(219,489,cs),
+(164,489,o),
+(135,518,o),
+(135,564,cs),
+(135,625,o),
+(188,659,o),
+(284,659,c),
+(281,722,l),
+(148,722,o),
+(62,664,o),
+(62,562,cs),
+(62,481,o),
+(120,422,o),
+(213,422,cs),
+(338,422,o),
+(428,532,o),
+(526,532,cs),
+(581,532,o),
+(610,503,o),
+(610,457,cs),
+(610,396,o),
+(557,362,o),
+(461,362,c),
+(463,299,l)
+);
+}
+);
+width = 744;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni1525;
+unicode = 5413;
+},
+{
+glyphname = "ye-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (662,357);
+},
+{
+name = top_left_can;
+pos = (92,714);
+},
+{
+name = top_right_can;
+pos = (463,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(512,0,l),
+(512,337,l),
+(165,337,l),
+(167,286,l),
+(528,666,l),
+(461,726,l),
+(43,280,l),
+(43,249,l),
+(413,249,l),
+(413,0,l)
+);
+}
+);
+width = 590;
+}
+);
+note = uni1526;
+unicode = 5414;
+},
+{
+glyphname = "yaai-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-2,0);
+ref = ring_top.canadian;
+}
+);
+width = 590;
+}
+);
+note = uni1527;
+unicode = 5415;
+},
+{
+glyphname = "yi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (128,714);
+},
+{
+name = top_right_can;
+pos = (498,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(178,0,l),
+(178,249,l),
+(547,249,l),
+(547,280,l),
+(130,726,l),
+(64,667,l),
+(425,287,l),
+(427,337,l),
+(79,337,l),
+(79,0,l)
+);
+}
+);
+width = 590;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni1528;
+unicode = 5416;
+},
+{
+glyphname = "yii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+}
+);
+width = 590;
+}
+);
+note = uni1529;
+unicode = 5417;
+},
+{
+glyphname = "yo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (662,357);
+},
+{
+name = top_double;
+pos = (463,714);
+},
+{
+name = top_left_can;
+pos = (92,714);
+},
+{
+name = top_right_can;
+pos = (463,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(527,47,l),
+(166,427,l),
+(164,377,l),
+(512,377,l),
+(512,714,l),
+(413,714,l),
+(413,465,l),
+(43,465,l),
+(43,434,l),
+(461,-12,l)
+);
+}
+);
+width = 590;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152A;
+unicode = 5418;
+},
+{
+glyphname = "yoo-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (387,0);
+ref = dot_top;
+}
+);
+width = 590;
+}
+);
+note = uni152B;
+unicode = 5419;
+},
+{
+glyphname = "ycreeyoo-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (213,0);
+ref = doubledot_top;
+}
+);
+width = 590;
+}
+);
+note = uni152C;
+unicode = 5420;
+},
+{
+glyphname = "ya-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (129,714);
+},
+{
+name = top_right_can;
+pos = (498,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(547,434,l),
+(547,465,l),
+(178,465,l),
+(178,714,l),
+(79,714,l),
+(79,377,l),
+(426,377,l),
+(424,428,l),
+(63,48,l),
+(130,-12,l)
+);
+}
+);
+width = 590;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian";
+note = uni152D;
+unicode = 5421;
+},
+{
+glyphname = "yaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (52,0);
+ref = dot_top;
+}
+);
+width = 590;
+}
+);
+note = uni152E;
+unicode = 5422;
+},
+{
+glyphname = "ywe-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ye-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni152F;
+unicode = 5423;
+},
+{
+glyphname = "yweWestCree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ye-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (590,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni1530;
+unicode = 5424;
+},
+{
+glyphname = "ywi-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "yi-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni1531;
+unicode = 5425;
+},
+{
+glyphname = "ywiWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (590,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni1532;
+unicode = 5426;
+},
+{
+glyphname = "ywii-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (284,0);
+ref = dot_top;
+}
+);
+width = 822;
+}
+);
+note = uni1533;
+unicode = 5427;
+},
+{
+glyphname = "ywiiWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (51,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (590,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni1534;
+unicode = 5428;
+},
+{
+glyphname = "ywo-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "yo-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni1535;
+unicode = 5429;
+},
+{
+glyphname = "ywoWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (590,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni1536;
+unicode = 5430;
+},
+{
+glyphname = "ywoo-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (619,0);
+ref = dot_top;
+}
+);
+width = 822;
+}
+);
+note = uni1537;
+unicode = 5431;
+},
+{
+glyphname = "ywooWestCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (387,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (590,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni1538;
+unicode = 5432;
+},
+{
+glyphname = "ywa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ya-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni1539;
+unicode = 5433;
+},
+{
+glyphname = "ywaWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (590,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni153A;
+unicode = 5434;
+},
+{
+glyphname = "ywaa-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (284,0);
+ref = dot_top;
+}
+);
+width = 822;
+}
+);
+note = uni153B;
+unicode = 5435;
+},
+{
+glyphname = "ywaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (52,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (590,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 822;
+}
+);
+note = uni153C;
+unicode = 5436;
+},
+{
+glyphname = "ywaaNaskapi-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = doubledot_middle;
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ya-canadian";
+}
+);
+width = 821;
+}
+);
+note = uni153D;
+unicode = 5437;
+},
+{
+glyphname = "y-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(316,569,l),
+(316,589,l),
+(138,589,l),
+(138,714,l),
+(68,714,l),
+(68,532,l),
+(243,532,l),
+(242,576,l),
+(66,387,l),
+(114,348,l)
+);
+}
+);
+width = 354;
+}
+);
+note = uni153E;
+unicode = 5438;
+},
+{
+glyphname = "biblecreey-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(190,640,l),
+(151,640,l),
+(249,357,l),
+(291,357,l),
+(389,640,l),
+(350,640,l),
+(420,357,l),
+(482,357,l),
+(482,374,l),
+(400,714,l),
+(353,714,l),
+(252,424,l),
+(288,424,l),
+(187,714,l),
+(141,714,l),
+(58,374,l),
+(58,357,l),
+(120,357,l)
+);
+}
+);
+width = 540;
+}
+);
+metricRight = "=|";
+note = uni153F;
+unicode = 5439;
+},
+{
+glyphname = "yWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(266,195,l),
+(266,333,l),
+(397,333,l),
+(397,400,l),
+(266,400,l),
+(266,534,l),
+(196,534,l),
+(196,400,l),
+(64,400,l),
+(64,333,l),
+(196,333,l),
+(196,195,l)
+);
+}
+);
+width = 461;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni1540;
+unicode = 5440;
+},
+{
+glyphname = "yiSayisi-canadian";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,189);
+ref = "fullstop-canadian";
+}
+);
+width = 367;
+}
+);
+metricLeft = "fullstop-canadian";
+metricWidth = "fullstop-canadian";
+note = uni1541;
+unicode = 5441;
+},
+{
+glyphname = "re-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (312,515);
+},
+{
+name = top_left_can;
+pos = (124,515);
+},
+{
+name = top_right_can;
+pos = (774,515);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(460,-13,o),
+(547,85,o),
+(547,243,cs),
+(547,407,l),
+(823,407,l),
+(823,496,l),
+(450,496,l),
+(450,244,ls),
+(450,134,o),
+(401,73,o),
+(312,73,cs),
+(222,73,o),
+(174,134,o),
+(174,244,cs),
+(174,496,l),
+(74,496,l),
+(74,243,ls),
+(74,84,o),
+(163,-13,o),
+(312,-13,cs)
+);
+}
+);
+width = 880;
+}
+);
+metricRight = "=|ne-canadian";
+note = uni1542;
+unicode = 5442;
+},
+{
+glyphname = "reRCree-canadian";
+kernLeft = neleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (568,515);
+},
+{
+name = top_left_can;
+pos = (106,515);
+},
+{
+name = top_right_can;
+pos = (756,515);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(718,-13,o),
+(806,84,o),
+(806,243,cs),
+(806,496,l),
+(707,496,l),
+(707,244,ls),
+(707,134,o),
+(659,73,o),
+(569,73,cs),
+(480,73,o),
+(430,132,o),
+(430,241,cs),
+(430,496,l),
+(57,496,l),
+(57,407,l),
+(333,407,l),
+(333,241,ls),
+(333,84,o),
+(421,-13,o),
+(569,-13,cs)
+);
+}
+);
+width = 880;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1543;
+unicode = 5443;
+},
+{
+glyphname = "leWestCree-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (568,515);
+},
+{
+name = top_left_can;
+pos = (106,515);
+},
+{
+name = top_right_can;
+pos = (756,515);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(430,0,l),
+(430,249,ls),
+(430,362,o),
+(479,423,o),
+(569,423,cs),
+(659,423,o),
+(707,361,o),
+(707,252,cs),
+(707,0,l),
+(806,0,l),
+(806,253,ls),
+(806,412,o),
+(720,509,o),
+(570,509,cs),
+(422,509,o),
+(333,410,o),
+(333,250,cs),
+(333,89,l),
+(57,89,l),
+(57,0,l)
+);
+}
+);
+width = 880;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+unicode = 5444;
+},
+{
+glyphname = "raai-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (183,-199);
+ref = ring_top.canadian;
+}
+);
+width = 880;
+}
+);
+note = uni1545;
+unicode = 5445;
+},
+{
+glyphname = "ri-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (312,515);
+},
+{
+name = top_left_can;
+pos = (124,515);
+},
+{
+name = top_right_can;
+pos = (774,515);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(174,0,l),
+(174,252,ls),
+(174,361,o),
+(221,423,o),
+(311,423,cs),
+(401,423,o),
+(450,364,o),
+(450,255,cs),
+(450,0,l),
+(823,0,l),
+(823,89,l),
+(547,89,l),
+(547,256,ls),
+(547,413,o),
+(462,509,o),
+(312,509,cs),
+(164,509,o),
+(74,412,o),
+(74,251,cs),
+(74,0,l)
+);
+}
+);
+width = 880;
+}
+);
+metricLeft = "re-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+unicode = 5446;
+},
+{
+glyphname = "rii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (236,-199);
+ref = dot_top;
+}
+);
+width = 880;
+}
+);
+note = uni1547;
+unicode = 5447;
+},
+{
+glyphname = "ro-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (245,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(178,0,l),
+(178,278,l),
+(150,249,l),
+(253,249,ls),
+(406,249,o),
+(502,342,o),
+(502,480,cs),
+(502,624,o),
+(410,714,o),
+(239,714,cs),
+(78,714,l),
+(78,625,l),
+(241,625,ls),
+(346,625,o),
+(403,570,o),
+(403,481,cs),
+(403,393,o),
+(345,337,o),
+(242,337,cs),
+(78,337,l),
+(78,0,l)
+);
+}
+);
+width = 562;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni1548;
+unicode = 5448;
+},
+{
+glyphname = "roo-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (169,0);
+ref = dot_top;
+}
+);
+width = 562;
+}
+);
+note = uni1549;
+unicode = 5449;
+},
+{
+glyphname = "loWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (264,714);
+},
+{
+name = top_left_can;
+pos = (128,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(239,0,ls),
+(410,0,o),
+(502,90,o),
+(502,234,cs),
+(502,373,o),
+(406,465,o),
+(253,465,cs),
+(150,465,l),
+(178,437,l),
+(178,714,l),
+(78,714,l),
+(78,377,l),
+(242,377,ls),
+(345,377,o),
+(403,321,o),
+(403,233,cs),
+(403,144,o),
+(346,89,o),
+(241,89,cs),
+(78,89,l),
+(78,0,l)
+);
+}
+);
+width = 562;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+unicode = 5450;
+},
+{
+glyphname = "ra-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (317,714);
+},
+{
+name = top_right_can;
+pos = (434,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(483,0,l),
+(483,337,l),
+(320,337,ls),
+(217,337,o),
+(159,393,o),
+(159,481,cs),
+(159,570,o),
+(216,625,o),
+(321,625,cs),
+(483,625,l),
+(483,714,l),
+(323,714,ls),
+(152,714,o),
+(60,624,o),
+(60,480,cs),
+(60,342,o),
+(156,249,o),
+(309,249,cs),
+(412,249,l),
+(384,278,l),
+(384,0,l)
+);
+}
+);
+width = 561;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+unicode = 5451;
+},
+{
+glyphname = "raa-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (241,0);
+ref = dot_top;
+}
+);
+width = 562;
+}
+);
+note = uni154C;
+unicode = 5452;
+},
+{
+glyphname = "laWestCree-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (434,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(483,0,l),
+(483,89,l),
+(321,89,ls),
+(216,89,o),
+(159,144,o),
+(159,233,cs),
+(159,321,o),
+(217,377,o),
+(320,377,cs),
+(483,377,l),
+(483,714,l),
+(384,714,l),
+(384,437,l),
+(412,465,l),
+(309,465,ls),
+(156,465,o),
+(60,373,o),
+(60,234,cs),
+(60,90,o),
+(152,0,o),
+(323,0,cs)
+);
+}
+);
+width = 561;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+unicode = 5453;
+},
+{
+glyphname = "rwaa-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (473,0);
+ref = dot_top;
+}
+);
+width = 794;
+}
+);
+note = uni154E;
+unicode = 5454;
+},
+{
+glyphname = "rwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (241,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (562,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni154F;
+unicode = 5455;
+},
+{
+glyphname = "r-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(275,357,l),
+(275,535,l),
+(193,535,ls),
+(145,535,o),
+(122,557,o),
+(122,596,cs),
+(122,635,o),
+(145,658,o),
+(194,658,cs),
+(275,658,l),
+(275,714,l),
+(194,714,ls),
+(105,714,o),
+(56,670,o),
+(56,596,cs),
+(56,525,o),
+(106,479,o),
+(186,479,cs),
+(241,479,l),
+(204,504,l),
+(204,357,l)
+);
+}
+);
+width = 341;
+}
+);
+metricLeft = "=|k-canadian";
+note = uni1550;
+unicode = 5456;
+},
+{
+glyphname = "rWestCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(80,357,l),
+(315,449,l),
+(315,475,l),
+(120,548,l),
+(120,522,l),
+(315,596,l),
+(315,621,l),
+(80,714,l),
+(66,714,l),
+(66,667,l),
+(258,591,l),
+(258,625,l),
+(66,551,l),
+(66,520,l),
+(258,446,l),
+(258,480,l),
+(66,403,l),
+(66,357,l)
+);
+}
+);
+width = 381;
+}
+);
+metricLeft = "=|lWestCree-canadian";
+metricRight = "=|lWestCree-canadian";
+note = uni1551;
+unicode = 5457;
+},
+{
+glyphname = "rMedial-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(98,-13,l),
+(594,179,l),
+(594,217,l),
+(174,373,l),
+(174,340,l),
+(594,497,l),
+(594,535,l),
+(98,727,l),
+(72,727,l),
+(72,655,l),
+(495,492,l),
+(495,537,l),
+(72,379,l),
+(72,334,l),
+(495,177,l),
+(495,223,l),
+(72,60,l),
+(72,-13,l)
+);
+}
+);
+width = 666;
+}
+);
+metricLeft = "mediall-canadian";
+metricRight = "mediall-canadian";
+note = uni1552;
+unicode = 5458;
+},
+{
+glyphname = "fe-canadian";
+kernLeft = ecanleft;
+kernRight = ecanright;
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(400,0,l),
+(755,687,l),
+(755,714,l),
+(670,714,l),
+(364,110,l),
+(389,110,l),
+(242,369,l),
+(180,363,l),
+(207,337,o),
+(236,325,o),
+(272,325,cs),
+(364,325,o),
+(438,408,o),
+(438,527,cs),
+(438,646,o),
+(371,727,o),
+(264,727,cs),
+(157,727,o),
+(90,646,o),
+(90,532,cs),
+(90,480,o),
+(104,428,o),
+(141,367,cs),
+(363,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(207,398,o),
+(172,448,o),
+(172,529,cs),
+(172,608,o),
+(206,653,o),
+(264,653,cs),
+(322,653,o),
+(356,609,o),
+(356,527,cs),
+(356,444,o),
+(322,398,o),
+(264,398,cs)
+);
+}
+);
+width = 788;
+}
+);
+metricRight = "e-canadian";
+note = uni1553;
+unicode = 5459;
+},
+{
+glyphname = "faai-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (254,0);
+ref = ring_top.canadian;
+}
+);
+width = 789;
+}
+);
+note = uni1554;
+unicode = 5460;
+},
+{
+glyphname = "fi-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (383,714);
+},
+{
+name = top_left_can;
+pos = (140,714);
+},
+{
+name = top_right_can;
+pos = (650,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(371,-13,o),
+(438,68,o),
+(438,187,cs),
+(438,306,o),
+(364,389,o),
+(272,389,cs),
+(236,389,o),
+(207,377,o),
+(180,351,c),
+(242,345,l),
+(389,604,l),
+(364,604,l),
+(670,0,l),
+(755,0,l),
+(755,27,l),
+(400,714,l),
+(363,714,l),
+(140,346,ls),
+(104,285,o),
+(90,234,o),
+(90,182,cs),
+(90,68,o),
+(157,-13,o),
+(264,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(206,61,o),
+(172,106,o),
+(172,185,cs),
+(172,266,o),
+(207,316,o),
+(264,316,cs),
+(322,316,o),
+(356,270,o),
+(356,187,cs),
+(356,105,o),
+(322,61,o),
+(264,61,cs)
+);
+}
+);
+width = 788;
+}
+);
+metricLeft = "fe-canadian";
+metricRight = "e-canadian";
+note = uni1555;
+unicode = 5461;
+},
+{
+glyphname = "fii-canadian";
+kernLeft = icanleft;
+kernRight = icanright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "fi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (307,0);
+ref = dot_top;
+}
+);
+width = 789;
+}
+);
+note = uni1556;
+unicode = 5462;
+},
+{
+glyphname = "fo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (232,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,0,l),
+(674,339,l),
+(674,374,l),
+(356,676,ls),
+(320,711,o),
+(276,727,o),
+(231,727,cs),
+(132,727,o),
+(58,652,o),
+(58,525,cs),
+(58,406,o),
+(125,325,o),
+(229,325,cs),
+(332,325,o),
+(397,406,o),
+(397,525,cs),
+(397,566,o),
+(385,609,o),
+(369,638,c),
+(341,577,l),
+(577,355,l),
+(576,377,l),
+(94,83,l),
+(94,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(173,399,o),
+(139,444,o),
+(139,526,cs),
+(139,609,o),
+(173,653,o),
+(231,653,cs),
+(289,653,o),
+(322,611,o),
+(322,527,cs),
+(322,444,o),
+(289,399,o),
+(231,399,cs)
+);
+}
+);
+width = 709;
+}
+);
+metricRight = "o-canadian";
+note = uni1557;
+unicode = 5463;
+},
+{
+glyphname = "foo-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "fo-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (156,0);
+ref = dot_top;
+}
+);
+width = 709;
+}
+);
+note = uni1558;
+unicode = 5464;
+},
+{
+glyphname = "fa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (477,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(615,0,l),
+(615,82,l),
+(131,378,l),
+(132,357,l),
+(368,580,l),
+(340,638,l),
+(323,609,o),
+(312,566,o),
+(312,525,cs),
+(312,406,o),
+(377,325,o),
+(480,325,cs),
+(584,325,o),
+(651,406,o),
+(651,525,cs),
+(651,652,o),
+(577,727,o),
+(478,727,cs),
+(433,727,o),
+(389,711,o),
+(353,676,cs),
+(35,374,l),
+(35,339,l),
+(588,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(420,398,o),
+(386,444,o),
+(386,527,cs),
+(386,610,o),
+(420,653,o),
+(477,653,cs),
+(535,653,o),
+(569,609,o),
+(569,526,cs),
+(569,443,o),
+(535,398,o),
+(478,398,cs)
+);
+}
+);
+width = 709;
+}
+);
+metricRight = "=|fo-canadian";
+note = uni1559;
+unicode = 5465;
+},
+{
+glyphname = "faa-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (401,0);
+ref = dot_top;
+}
+);
+width = 709;
+}
+);
+note = uni155A;
+unicode = 5466;
+},
+{
+glyphname = "fwaa-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (633,0);
+ref = dot_top;
+}
+);
+width = 941;
+}
+);
+note = uni155B;
+unicode = 5467;
+},
+{
+glyphname = "fwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "fa-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (401,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (709,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 941;
+}
+);
+note = uni155C;
+unicode = 5468;
+},
+{
+glyphname = "f-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(350,357,l),
+(350,401,l),
+(114,546,l),
+(114,534,l),
+(224,639,l),
+(214,675,l),
+(205,661,o),
+(199,639,o),
+(199,617,cs),
+(199,557,o),
+(234,519,o),
+(283,519,cs),
+(334,519,o),
+(367,557,o),
+(367,619,cs),
+(367,686,o),
+(329,720,o),
+(282,720,cs),
+(260,720,o),
+(236,711,o),
+(214,690,cs),
+(60,545,l),
+(60,525,l),
+(334,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(256,559,o),
+(241,580,o),
+(241,619,cs),
+(241,659,o),
+(256,679,o),
+(282,679,cs),
+(308,679,o),
+(324,660,o),
+(324,619,cs),
+(324,579,o),
+(308,559,o),
+(283,559,cs)
+);
+}
+);
+width = 427;
+}
+);
+note = uni155D;
+unicode = 5469;
+},
+{
+glyphname = "the-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (841,357);
+},
+{
+name = top_center_can;
+pos = (373,714);
+},
+{
+name = top_left_can;
+pos = (119,714);
+},
+{
+name = top_right_can;
+pos = (627,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(563,-13,o),
+(676,106,o),
+(676,313,cs),
+(676,714,l),
+(577,714,l),
+(577,309,ls),
+(577,156,o),
+(504,76,o),
+(373,76,cs),
+(246,76,o),
+(169,152,o),
+(169,300,cs),
+(169,434,l),
+(133,405,l),
+(148,351,o),
+(196,318,o),
+(252,318,cs),
+(352,318,o),
+(417,398,o),
+(417,523,cs),
+(417,646,o),
+(353,727,o),
+(246,727,cs),
+(136,727,o),
+(71,645,o),
+(71,503,cs),
+(71,325,ls),
+(71,106,o),
+(185,-13,o),
+(374,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(186,392,o),
+(152,437,o),
+(152,523,cs),
+(152,608,o),
+(186,653,o),
+(244,653,cs),
+(302,653,o),
+(335,608,o),
+(335,523,cs),
+(335,438,o),
+(302,392,o),
+(244,392,cs)
+);
+}
+);
+width = 747;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155E;
+unicode = 5470;
+},
+{
+glyphname = "theNCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(565,-13,o),
+(676,106,o),
+(676,325,cs),
+(676,503,ls),
+(676,645,o),
+(611,727,o),
+(501,727,cs),
+(394,727,o),
+(330,646,o),
+(330,523,cs),
+(330,399,o),
+(395,318,o),
+(495,318,cs),
+(551,318,o),
+(599,351,o),
+(614,405,c),
+(578,434,l),
+(578,300,ls),
+(578,151,o),
+(503,75,o),
+(374,75,cs),
+(245,75,o),
+(170,157,o),
+(170,308,cs),
+(170,714,l),
+(71,714,l),
+(71,310,ls),
+(71,105,o),
+(184,-13,o),
+(373,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(445,392,o),
+(412,439,o),
+(412,523,cs),
+(412,608,o),
+(445,653,o),
+(503,653,cs),
+(561,653,o),
+(595,608,o),
+(595,523,cs),
+(595,437,o),
+(561,392,o),
+(503,392,cs)
+);
+}
+);
+width = 747;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni155F;
+unicode = 5471;
+},
+{
+glyphname = "thi-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (371,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(353,-13,o),
+(417,68,o),
+(417,191,cs),
+(417,315,o),
+(352,396,o),
+(252,396,cs),
+(196,396,o),
+(148,363,o),
+(133,309,c),
+(169,280,l),
+(169,414,ls),
+(169,563,o),
+(244,639,o),
+(373,639,cs),
+(502,639,o),
+(577,557,o),
+(577,406,cs),
+(577,0,l),
+(676,0,l),
+(676,404,ls),
+(676,609,o),
+(563,727,o),
+(374,727,cs),
+(182,727,o),
+(71,608,o),
+(71,389,cs),
+(71,211,ls),
+(71,69,o),
+(136,-13,o),
+(246,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(186,61,o),
+(152,106,o),
+(152,191,cs),
+(152,277,o),
+(186,322,o),
+(244,322,cs),
+(302,322,o),
+(335,275,o),
+(335,191,cs),
+(335,106,o),
+(302,61,o),
+(244,61,cs)
+);
+}
+);
+width = 747;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1560;
+unicode = 5472;
+},
+{
+glyphname = "thiNCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (371,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(611,-13,o),
+(676,69,o),
+(676,211,cs),
+(676,389,ls),
+(676,608,o),
+(565,727,o),
+(373,727,cs),
+(184,727,o),
+(71,609,o),
+(71,404,cs),
+(71,0,l),
+(170,0,l),
+(170,406,ls),
+(170,557,o),
+(245,639,o),
+(374,639,cs),
+(503,639,o),
+(578,563,o),
+(578,414,cs),
+(578,280,l),
+(614,309,l),
+(599,363,o),
+(551,396,o),
+(495,396,cs),
+(395,396,o),
+(330,315,o),
+(330,191,cs),
+(330,68,o),
+(394,-13,o),
+(501,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(445,61,o),
+(412,106,o),
+(412,191,cs),
+(412,275,o),
+(445,322,o),
+(503,322,cs),
+(561,322,o),
+(595,277,o),
+(595,191,cs),
+(595,106,o),
+(561,61,o),
+(503,61,cs)
+);
+}
+);
+width = 747;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1561;
+unicode = 5473;
+},
+{
+glyphname = "thii-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "thi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (295,0);
+ref = dot_top;
+}
+);
+width = 747;
+}
+);
+note = uni1562;
+unicode = 5474;
+},
+{
+glyphname = "thiiNCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "thiNCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (295,0);
+ref = dot_top;
+}
+);
+width = 747;
+}
+);
+note = uni1563;
+unicode = 5475;
+},
+{
+glyphname = "tho-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (315,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(285,0,ls),
+(509,0,o),
+(631,129,o),
+(631,363,cs),
+(631,583,o),
+(512,727,o),
+(316,727,cs),
+(165,727,o),
+(69,638,o),
+(69,497,cs),
+(69,373,o),
+(137,295,o),
+(243,295,cs),
+(347,295,o),
+(410,370,o),
+(410,489,cs),
+(410,584,o),
+(362,670,o),
+(258,676,c),
+(226,638,l),
+(246,648,o),
+(276,654,o),
+(303,654,cs),
+(456,654,o),
+(533,542,o),
+(533,368,cs),
+(533,182,o),
+(448,90,o),
+(279,90,cs),
+(103,90,l),
+(103,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(184,369,o),
+(151,413,o),
+(151,501,cs),
+(151,588,o),
+(191,633,o),
+(242,633,cs),
+(295,633,o),
+(334,588,o),
+(334,500,cs),
+(334,413,o),
+(301,369,o),
+(242,369,cs)
+);
+}
+);
+width = 695;
+}
+);
+metricRight = "to-canadian";
+note = uni1564;
+unicode = 5476;
+},
+{
+glyphname = "thoo-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "tho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (239,0);
+ref = dot_top;
+}
+);
+width = 696;
+}
+);
+note = uni1565;
+unicode = 5477;
+},
+{
+glyphname = "tha-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (382,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(592,0,l),
+(592,90,l),
+(416,90,ls),
+(247,90,o),
+(162,182,o),
+(162,368,cs),
+(162,542,o),
+(239,654,o),
+(392,654,cs),
+(419,654,o),
+(449,648,o),
+(468,638,c),
+(437,676,l),
+(333,670,o),
+(285,584,o),
+(285,489,cs),
+(285,370,o),
+(349,295,o),
+(452,295,cs),
+(558,295,o),
+(626,374,o),
+(626,497,cs),
+(626,639,o),
+(529,727,o),
+(380,727,cs),
+(184,727,o),
+(64,583,o),
+(64,363,cs),
+(64,130,o),
+(185,0,o),
+(410,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(394,369,o),
+(361,413,o),
+(361,500,cs),
+(361,588,o),
+(400,633,o),
+(453,633,cs),
+(504,633,o),
+(544,588,o),
+(544,501,cs),
+(544,413,o),
+(511,369,o),
+(453,369,cs)
+);
+}
+);
+width = 695;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tho-canadian";
+note = uni1566;
+unicode = 5478;
+},
+{
+glyphname = "thaa-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (307,0);
+ref = dot_top;
+}
+);
+width = 696;
+}
+);
+note = uni1567;
+unicode = 5479;
+},
+{
+glyphname = "thwaa-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (539,0);
+ref = dot_top;
+}
+);
+width = 928;
+}
+);
+note = uni1568;
+unicode = 5480;
+},
+{
+glyphname = "thwaaWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (307,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (696,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 928;
+}
+);
+note = uni1569;
+unicode = 5481;
+},
+{
+glyphname = "th-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(326,357,l),
+(326,415,l),
+(246,415,ls),
+(162,415,o),
+(123,457,o),
+(123,540,cs),
+(123,622,o),
+(161,677,o),
+(235,677,cs),
+(249,677,o),
+(263,674,o),
+(272,670,c),
+(248,693,l),
+(198,690,o),
+(175,651,o),
+(175,604,cs),
+(175,542,o),
+(209,504,o),
+(259,504,cs),
+(309,504,o),
+(343,542,o),
+(343,604,cs),
+(343,678,o),
+(295,720,o),
+(222,720,cs),
+(124,720,o),
+(62,648,o),
+(62,535,cs),
+(62,425,o),
+(124,357,o),
+(242,357,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(232,544,o),
+(217,565,o),
+(217,604,cs),
+(217,644,o),
+(232,664,o),
+(258,664,cs),
+(284,664,o),
+(299,645,o),
+(299,604,cs),
+(299,564,o),
+(284,544,o),
+(258,544,cs)
+);
+}
+);
+width = 402;
+}
+);
+metricLeft = "t-canadian";
+note = uni156A;
+unicode = 5482;
+},
+{
+glyphname = "tthe-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (831,357);
+},
+{
+name = top_center_can;
+pos = (369,714);
+},
+{
+name = top_left_can;
+pos = (121,714);
+},
+{
+name = top_right_can;
+pos = (618,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(555,-13,o),
+(667,106,o),
+(667,313,cs),
+(667,714,l),
+(570,714,l),
+(570,311,ls),
+(570,157,o),
+(496,78,o),
+(369,78,cs),
+(245,78,o),
+(168,159,o),
+(168,310,cs),
+(167.993,714,l),
+(71,714,l),
+(71,310,ls),
+(71,105,o),
+(184,-13,o),
+(369,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(410,401,l),
+(410,714,l),
+(328,714,l),
+(328,401,l)
+);
+}
+);
+width = 738;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156B;
+unicode = 5483;
+},
+{
+glyphname = "tthi-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(167.993,0,l),
+(168,403,ls),
+(168,555,o),
+(245,636,o),
+(371,636,cs),
+(494,636,o),
+(570,555,o),
+(570,404,cs),
+(570,0,l),
+(667,0,l),
+(667,404,ls),
+(667,609,o),
+(554,727,o),
+(372,727,cs),
+(185,727,o),
+(71,609,o),
+(71,401,cs),
+(71,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(410,0,l),
+(410,313,l),
+(328,313,l),
+(328,0,l)
+);
+}
+);
+width = 738;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni156C;
+unicode = 5484;
+},
+{
+glyphname = "ttho-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (328,714);
+},
+{
+name = top_left_can;
+pos = (124,714);
+},
+{
+name = top_right_can;
+pos = (531,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(239,0,ls),
+(456,0,o),
+(580,133,o),
+(580,358,cs),
+(580,583,o),
+(456,714,o),
+(236,714,cs),
+(75,714,l),
+(75,624,l),
+(233,624,ls),
+(393,624,o),
+(481,531,o),
+(481,358,cs),
+(481,185,o),
+(393,90,o),
+(234,90,cs),
+(75,90,l),
+(75,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(319,317,l),
+(319,399,l),
+(75,399,l),
+(75,317,l)
+);
+}
+);
+width = 644;
+}
+);
+metricRight = "to-canadian";
+note = uni156D;
+unicode = 5485;
+},
+{
+glyphname = "ttha-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (330,714);
+},
+{
+name = top_left_can;
+pos = (113,714);
+},
+{
+name = top_right_can;
+pos = (520,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(569,0,l),
+(569,90,l),
+(411,90,ls),
+(251,90,o),
+(163,184,o),
+(163,357,cs),
+(163,530,o),
+(251,624,o),
+(410,624,cs),
+(569,624,l),
+(569,714,l),
+(407,714,ls),
+(188,714,o),
+(64,582,o),
+(64,357,cs),
+(64,132,o),
+(188,0,o),
+(406,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(569,317,l),
+(569,399,l),
+(325,399,l),
+(325,317,l)
+);
+}
+);
+width = 644;
+}
+);
+metricLeft = "=|to-canadian";
+metricRight = "=|ttho-canadian";
+note = uni156E;
+unicode = 5486;
+},
+{
+glyphname = "tth-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(659,494,l),
+(633,494,l),
+(729,359,l),
+(778,395,l),
+(681,530,l),
+(673,504,l),
+(825,557,l),
+(806,614,l),
+(654,560,l),
+(677,546,l),
+(677,714,l),
+(616,714,l),
+(616,546,l),
+(638,560,l),
+(487,614,l),
+(467,557,l),
+(619,504,l),
+(612,530,l),
+(514,395,l),
+(563,359,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(240,494,l),
+(214,494,l),
+(311,359,l),
+(360,395,l),
+(262,530,l),
+(254,504,l),
+(406,557,l),
+(386,614,l),
+(235,560,l),
+(257,546,l),
+(257,714,l),
+(197,714,l),
+(197,546,l),
+(219,560,l),
+(67,614,l),
+(48,557,l),
+(200,504,l),
+(192,530,l),
+(94,395,l),
+(143,359,l)
+);
+}
+);
+width = 873;
+}
+);
+metricRight = "=|";
+note = uni156F;
+unicode = 5487;
+},
+{
+glyphname = "tye-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(555,-13,o),
+(667,106,o),
+(667,313,cs),
+(667,714,l),
+(570,714,l),
+(570,313,ls),
+(570,157,o),
+(496,78,o),
+(369,78,cs),
+(245,78,o),
+(167,159,o),
+(167,312,cs),
+(167,714,l),
+(71,714,l),
+(71,310,ls),
+(71,105,o),
+(184,-13,o),
+(369,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(443,426,o),
+(486,473,o),
+(486,558,cs),
+(486,714,l),
+(435,714,l),
+(435,560,ls),
+(435,506,o),
+(413,478,o),
+(369,478,cs),
+(325,478,o),
+(303,506,o),
+(303,560,cs),
+(303,714,l),
+(251,714,l),
+(251,558,ls),
+(251,472,o),
+(296,426,o),
+(369,426,cs)
+);
+}
+);
+width = 738;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1570;
+unicode = 5488;
+},
+{
+glyphname = "tyi-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(168,0,l),
+(168,401,ls),
+(168,555,o),
+(245,636,o),
+(371,636,cs),
+(494,636,o),
+(570,555,o),
+(570,402,cs),
+(570,0,l),
+(667,0,l),
+(667,404,ls),
+(667,609,o),
+(554,727,o),
+(372,727,cs),
+(185,727,o),
+(71,609,o),
+(71,401,cs),
+(71,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(303,0,l),
+(303,153,ls),
+(303,208,o),
+(325,236,o),
+(369,236,cs),
+(412,236,o),
+(435,208,o),
+(435,153,cs),
+(435,0,l),
+(486,0,l),
+(486,156,ls),
+(486,242,o),
+(441,288,o),
+(368,288,cs),
+(295,288,o),
+(251,241,o),
+(251,156,cs),
+(251,0,l)
+);
+}
+);
+width = 738;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni1571;
+unicode = 5489;
+},
+{
+glyphname = "tyo-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(242,0,ls),
+(458,0,o),
+(584,133,o),
+(584,358,cs),
+(584,583,o),
+(458,714,o),
+(239,714,cs),
+(78,714,l),
+(78,625,l),
+(234,625,ls),
+(397,625,o),
+(484,531,o),
+(484,358,cs),
+(484,185,o),
+(397,89,o),
+(235,89,cs),
+(78,89,l),
+(78,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(172,221,ls),
+(263,221,o),
+(312,272,o),
+(312,357,cs),
+(312,443,o),
+(262,493,o),
+(172,493,cs),
+(78,493,l),
+(78,441,l),
+(165,441,ls),
+(227,441,o),
+(254,411,o),
+(254,357,cs),
+(254,303,o),
+(227,273,o),
+(165,273,cs),
+(78,273,l),
+(78,221,l)
+);
+}
+);
+width = 648;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1572;
+unicode = 5490;
+},
+{
+glyphname = "tya-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(569,0,l),
+(569,89,l),
+(414,89,ls),
+(251,89,o),
+(163,183,o),
+(163,357,cs),
+(163,530,o),
+(251,625,o),
+(413,625,cs),
+(569,625,l),
+(569,714,l),
+(407,714,ls),
+(189,714,o),
+(64,582,o),
+(64,357,cs),
+(64,132,o),
+(189,0,o),
+(406,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(569,221,l),
+(569,273,l),
+(483,273,ls),
+(421,273,o),
+(394,303,o),
+(394,357,cs),
+(394,411,o),
+(421,441,o),
+(482,441,cs),
+(569,441,l),
+(569,493,l),
+(475,493,ls),
+(385,493,o),
+(335,442,o),
+(335,357,cs),
+(335,271,o),
+(385,221,o),
+(475,221,cs)
+);
+}
+);
+width = 647;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1573;
+unicode = 5491;
+},
+{
+glyphname = "heNunavik-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(525,0,l),
+(771,202,l),
+(717,270,l),
+(473,70,l),
+(536,66,l),
+(536,459,ls),
+(536,626,o),
+(447,727,o),
+(301,727,cs),
+(156,727,o),
+(62,625,o),
+(62,463,cs),
+(62,306,o),
+(153,205,o),
+(287,205,cs),
+(370,205,o),
+(432,251,o),
+(446,311,c),
+(437,324,l),
+(437,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(214,290,o),
+(160,353,o),
+(160,466,cs),
+(160,579,o),
+(212,642,o),
+(299,642,cs),
+(386,642,o),
+(438,580,o),
+(438,466,cs),
+(438,354,o),
+(384,290,o),
+(299,290,cs)
+);
+}
+);
+width = 797;
+}
+);
+metricLeft = "ke-canadian";
+note = uni1574;
+unicode = 5492;
+},
+{
+glyphname = "hiNunavik-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (498,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(359,0,l),
+(359,324,l),
+(351,311,l),
+(365,251,o),
+(427,205,o),
+(510,205,cs),
+(644,205,o),
+(735,307,o),
+(735,465,cs),
+(735,627,o),
+(642,727,o),
+(498,727,cs),
+(352,727,o),
+(261,626,o),
+(261,459,cs),
+(261,73,l),
+(324,70,l),
+(80,270,l),
+(26,202,l),
+(271,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(413,290,o),
+(358,354,o),
+(358,466,cs),
+(358,580,o),
+(411,642,o),
+(498,642,cs),
+(584,642,o),
+(637,579,o),
+(637,466,cs),
+(637,353,o),
+(582,290,o),
+(498,290,cs)
+);
+}
+);
+width = 797;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1575;
+unicode = 5493;
+},
+{
+glyphname = "hiiNunavik-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "hiNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (422,0);
+ref = dot_top;
+}
+);
+width = 797;
+}
+);
+note = uni1576;
+unicode = 5494;
+},
+{
+glyphname = "hoNunavik-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (299,714);
+},
+{
+name = top_right_can;
+pos = (487,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(447,-13,o),
+(536,88,o),
+(536,255,cs),
+(536,648,l),
+(473,644,l),
+(717,444,l),
+(771,512,l),
+(525,714,l),
+(437,714,l),
+(437,390,l),
+(446,403,l),
+(432,463,o),
+(370,509,o),
+(288,509,cs),
+(153,509,o),
+(62,405,o),
+(62,248,cs),
+(62,87,o),
+(154,-13,o),
+(299,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(212,72,o),
+(160,135,o),
+(160,248,cs),
+(160,361,o),
+(214,424,o),
+(299,424,cs),
+(384,424,o),
+(438,360,o),
+(438,248,cs),
+(438,134,o),
+(386,72,o),
+(299,72,cs)
+);
+}
+);
+width = 797;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "heNunavik-canadian";
+note = uni1577;
+unicode = 5495;
+},
+{
+glyphname = "hooNunavik-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "hoNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (411,0);
+ref = dot_top;
+}
+);
+width = 797;
+}
+);
+note = uni1578;
+unicode = 5496;
+},
+{
+glyphname = "haNunavik-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (498,714);
+},
+{
+name = top_left_can;
+pos = (310,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(640,-13,o),
+(735,87,o),
+(735,250,cs),
+(735,407,o),
+(644,509,o),
+(512,509,cs),
+(429,509,o),
+(366,463,o),
+(351,403,c),
+(359,390,l),
+(359,714,l),
+(271,714,l),
+(26,512,l),
+(80,444,l),
+(324,644,l),
+(261,641,l),
+(261,255,ls),
+(261,88,o),
+(349,-13,o),
+(496,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(411,72,o),
+(358,134,o),
+(358,248,cs),
+(358,360,o),
+(413,424,o),
+(498,424,cs),
+(582,424,o),
+(637,361,o),
+(637,248,cs),
+(637,135,o),
+(584,72,o),
+(498,72,cs)
+);
+}
+);
+width = 797;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ke-canadian";
+note = uni1579;
+unicode = 5497;
+},
+{
+glyphname = "haaNunavik-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "haNunavik-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (234,0);
+ref = dot_top;
+}
+);
+width = 797;
+}
+);
+note = uni157A;
+unicode = 5498;
+},
+{
+glyphname = "hNunavik-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(368,351,o),
+(425,402,o),
+(425,489,cs),
+(425,571,o),
+(373,622,o),
+(306,622,cs),
+(259,622,o),
+(224,593,o),
+(216,553,c),
+(232,553,l),
+(232,714,l),
+(167,714,l),
+(44,613,l),
+(77,573,l),
+(200,674,l),
+(162,676,l),
+(162,490,ls),
+(162,404,o),
+(214,351,o),
+(295,351,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(252,404,o),
+(227,432,o),
+(227,487,cs),
+(227,540,o),
+(255,569,o),
+(294,569,cs),
+(333,569,o),
+(362,540,o),
+(362,487,cs),
+(362,434,o),
+(334,404,o),
+(294,404,cs)
+);
+}
+);
+width = 481;
+}
+);
+metricRight = "k-canadian";
+note = uni157B;
+unicode = 5499;
+},
+{
+color = 4;
+glyphname = "nunavuth-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(178,326,l),
+(533,326,l),
+(533,0,l),
+(633,0,l),
+(633,714,l),
+(533,714,l),
+(533,414,l),
+(178,414,l),
+(178,714,l),
+(78,714,l),
+(78,0,l),
+(178,0,l)
+);
+}
+);
+width = 711;
+}
+);
+metricRight = "=|";
+note = uni157C;
+unicode = 5500;
+},
+{
+glyphname = "hk-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,357);
+ref = "fullstop-canadian";
+}
+);
+width = 367;
+}
+);
+metricLeft = "fullstop-canadian";
+note = uni157D;
+unicode = 5501;
+},
+{
+glyphname = "qaai-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (341,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (519,0);
+ref = ring_top.canadian;
+}
+);
+width = 948;
+}
+);
+note = uni157E;
+unicode = 5502;
+},
+{
+glyphname = "qi-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (341,0);
+ref = "ki-canadian";
+}
+);
+width = 948;
+}
+);
+note = uni157F;
+unicode = 5503;
+},
+{
+glyphname = "qii-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (341,0);
+ref = "ki-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (573,0);
+ref = dot_top;
+}
+);
+width = 948;
+}
+);
+note = uni1580;
+unicode = 5504;
+},
+{
+glyphname = "qo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (341,0);
+ref = "ko-canadian";
+}
+);
+width = 948;
+}
+);
+note = uni1581;
+unicode = 5505;
+},
+{
+glyphname = "qoo-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (341,0);
+ref = "ko-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (752,0);
+ref = dot_top;
+}
+);
+width = 948;
+}
+);
+note = uni1582;
+unicode = 5506;
+},
+{
+glyphname = "qa-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (341,0);
+ref = "ka-canadian";
+}
+);
+width = 948;
+}
+);
+note = uni1583;
+unicode = 5507;
+},
+{
+glyphname = "qaa-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (341,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (385,0);
+ref = dot_top;
+}
+);
+width = 948;
+}
+);
+note = uni1584;
+unicode = 5508;
+},
+{
+glyphname = "q-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (341,0);
+ref = "k-canadian";
+}
+);
+width = 727;
+}
+);
+note = uni1585;
+unicode = 5509;
+},
+{
+glyphname = "tlhe-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (309,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,0,l),
+(342,279,l),
+(263,243,l),
+(273,241,o),
+(284,240,o),
+(294,240,cs),
+(376,240,o),
+(437,281,o),
+(453,331,c),
+(447,364,l),
+(447,0,l),
+(545.994,0,l),
+(546,474,ls),
+(546,631,o),
+(457,727,o),
+(309,727,cs),
+(156,727,o),
+(68,625,o),
+(68,482,cs),
+(68,363,o),
+(129,280,o),
+(225,256,c),
+(94,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(219,326,o),
+(165,384,o),
+(165,483,cs),
+(165,583,o),
+(219,642,o),
+(307,642,cs),
+(395,642,o),
+(448,584,o),
+(448,484,cs),
+(448,384,o),
+(394,326,o),
+(307,326,cs)
+);
+}
+);
+width = 617;
+}
+);
+metricRight = "te-canadian";
+note = uni1586;
+unicode = 5510;
+},
+{
+glyphname = "tlhi-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(169,0,l),
+(169,364,l),
+(162,335,l),
+(173,284,o),
+(236,240,o),
+(322,240,c),
+(274,279,l),
+(417,0,l),
+(522,0,l),
+(392,256,l),
+(487,280,o),
+(549,363,o),
+(549,482,cs),
+(549,625,o),
+(460,727,o),
+(308,727,cs),
+(160,727,o),
+(71,631,o),
+(71,474,cs),
+(71,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(222,326,o),
+(168,384,o),
+(168,484,cs),
+(168,584,o),
+(221,642,o),
+(310,642,cs),
+(398,642,o),
+(451,583,o),
+(451,483,cs),
+(451,384,o),
+(397,326,o),
+(310,326,cs)
+);
+}
+);
+width = 617;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|tlhe-canadian";
+note = uni1587;
+unicode = 5511;
+},
+{
+glyphname = "tlho-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (325,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(457,-13,o),
+(546,83,o),
+(546,240,cs),
+(545.994,714,l),
+(447,714,l),
+(447,350,l),
+(455,379,l),
+(443,430,o),
+(380,474,o),
+(294,474,c),
+(342,435,l),
+(200,714,l),
+(94,714,l),
+(225,458,l),
+(129,434,o),
+(68,351,o),
+(68,232,cs),
+(68,89,o),
+(156,-13,o),
+(309,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(219,72,o),
+(165,131,o),
+(165,231,cs),
+(165,330,o),
+(219,388,o),
+(307,388,cs),
+(394,388,o),
+(448,330,o),
+(448,230,cs),
+(448,130,o),
+(395,72,o),
+(307,72,cs)
+);
+}
+);
+width = 617;
+}
+);
+metricLeft = "tlhe-canadian";
+metricRight = "te-canadian";
+note = uni1588;
+unicode = 5512;
+},
+{
+glyphname = "tlha-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(460,-13,o),
+(549,89,o),
+(549,232,cs),
+(549,351,o),
+(487,434,o),
+(392,458,c),
+(522,714,l),
+(417,714,l),
+(274,435,l),
+(354,471,l),
+(343,473,o),
+(333,474,o),
+(322,474,cs),
+(236,474,o),
+(173,430,o),
+(162,379,c),
+(169,350,l),
+(169,714,l),
+(71,714,l),
+(71,240,ls),
+(71,83,o),
+(160,-13,o),
+(308,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(221,72,o),
+(168,130,o),
+(168,230,cs),
+(168,330,o),
+(222,388,o),
+(310,388,cs),
+(397,388,o),
+(451,330,o),
+(451,231,cs),
+(451,131,o),
+(398,72,o),
+(310,72,cs)
+);
+}
+);
+width = 617;
+}
+);
+metricLeft = "te-canadian";
+note = uni1589;
+unicode = 5513;
+},
+{
+glyphname = "reWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(520,0,l),
+(765,202,l),
+(711,270,l),
+(467,70,l),
+(530,66,l),
+(530,464,ls),
+(530,630,o),
+(444,727,o),
+(299,727,cs),
+(151,727,o),
+(61,629,o),
+(61,465,cs),
+(61,401,l),
+(160,401,l),
+(160,473,ls),
+(160,580,o),
+(209,640,o),
+(297,640,cs),
+(382,640,o),
+(431,580,o),
+(431,473,cs),
+(431,0,l)
+);
+}
+);
+width = 791;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+unicode = 5514;
+},
+{
+glyphname = "riWestCree-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(359,0,l),
+(359,473,ls),
+(359,580,o),
+(410,640,o),
+(496,640,cs),
+(584,640,o),
+(631,580,o),
+(631,473,cs),
+(631,401,l),
+(729,401,l),
+(729,465,ls),
+(729,629,o),
+(643,727,o),
+(497,727,cs),
+(348,727,o),
+(261,628,o),
+(261,464,cs),
+(261,66,l),
+(324,70,l),
+(80,270,l),
+(26,202,l),
+(271,0,l)
+);
+}
+);
+width = 790;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+unicode = 5515;
+},
+{
+glyphname = "roWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(443,-13,o),
+(530,82,o),
+(530,250,cs),
+(530,648,l),
+(467,644,l),
+(711,444,l),
+(765,512,l),
+(520,714,l),
+(431,714,l),
+(431,241,ls),
+(431,132,o),
+(382,74,o),
+(297,74,cs),
+(207,74,o),
+(160,134,o),
+(160,244,cs),
+(160,313,l),
+(61,313,l),
+(61,248,ls),
+(61,85,o),
+(147,-13,o),
+(299,-13,cs)
+);
+}
+);
+width = 791;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+unicode = 5516;
+},
+{
+glyphname = "raWestCree-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(643,-13,o),
+(729,84,o),
+(729,249,cs),
+(729,313,l),
+(631,313,l),
+(631,243,ls),
+(631,132,o),
+(583,74,o),
+(496,74,cs),
+(407,74,o),
+(359,132,o),
+(359,240,cs),
+(359,714,l),
+(271,714,l),
+(26,512,l),
+(80,444,l),
+(324,644,l),
+(261,648,l),
+(261,250,ls),
+(261,83,o),
+(346,-13,o),
+(496,-13,cs)
+);
+}
+);
+width = 790;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+unicode = 5517;
+},
+{
+glyphname = "ngaai-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (661,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (841,0);
+ref = ring_top.canadian;
+}
+);
+width = 1263;
+}
+);
+note = uni158E;
+unicode = 5518;
+},
+{
+glyphname = "ngi-canadian";
+kernLeft = mwestleft;
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (661,0);
+ref = "ci-canadian";
+}
+);
+width = 1263;
+}
+);
+note = uni158F;
+unicode = 5519;
+},
+{
+glyphname = "ngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (661,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (894,0);
+ref = dot_top;
+}
+);
+width = 1263;
+}
+);
+note = uni1590;
+unicode = 5520;
+},
+{
+glyphname = "ngo-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:30:44 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+ref = "ng-canadian";
+},
+{
+pos = (633,0);
+ref = "co-canadian";
+}
+);
+width = 1235;
+}
+);
+note = uni1591;
+unicode = 5521;
+},
+{
+glyphname = "ngoo-canadian";
+lastChange = "2023-01-13 15:30:44 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+ref = "ngo-canadian";
+},
+{
+anchor = top_right_can;
+pos = (1038,0);
+ref = dot_top;
+}
+);
+width = 1235;
+}
+);
+note = uni1592;
+unicode = 5522;
+},
+{
+glyphname = "nga-canadian";
+kernLeft = mwestleft;
+kernRight = caright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (661,0);
+ref = "ca-canadian";
+}
+);
+width = 1263;
+}
+);
+note = uni1593;
+unicode = 5523;
+},
+{
+glyphname = "ngaa-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (661,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (706,0);
+ref = dot_top;
+}
+);
+width = 1263;
+}
+);
+note = uni1594;
+unicode = 5524;
+},
+{
+glyphname = "ng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(564,225,o),
+(617,272,o),
+(617,356,cs),
+(617,378,l),
+(550,378,l),
+(550,352,ls),
+(550,305,o),
+(525,281,o),
+(485,281,cs),
+(445,281,o),
+(422,306,o),
+(422,357,cs),
+(422,515,l),
+(259,515,l),
+(263,486,l),
+(296,499,o),
+(317,541,o),
+(317,589,cs),
+(317,669,o),
+(266,721,o),
+(187,721,cs),
+(109,721,o),
+(56,668,o),
+(56,586,cs),
+(56,504,o),
+(108,450,o),
+(193,450,cs),
+(368,450,l),
+(351,469,l),
+(351,366,ls),
+(351,273,o),
+(401,225,o),
+(486,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(147,502,o),
+(119,533,o),
+(119,586,cs),
+(119,638,o),
+(147,668,o),
+(187,668,cs),
+(227,668,o),
+(254,638,o),
+(254,585,cs),
+(254,533,o),
+(227,502,o),
+(187,502,cs)
+);
+}
+);
+width = 662;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1595;
+unicode = 5525;
+},
+{
+glyphname = "nng-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(862,225,o),
+(915,272,o),
+(915,356,cs),
+(915,378,l),
+(849,378,l),
+(849,352,ls),
+(849,305,o),
+(823,281,o),
+(784,281,cs),
+(743,281,o),
+(720,306,o),
+(720,357,cs),
+(720,515,l),
+(563,515,l),
+(567,486,l),
+(599,499,o),
+(621,541,o),
+(621,589,cs),
+(621,670,o),
+(569,721,o),
+(490,721,cs),
+(412,721,o),
+(360,669,o),
+(360,588,cs),
+(360,541,o),
+(382,499,o),
+(413,485,c),
+(418,515,l),
+(260,515,l),
+(263,486,l),
+(296,499,o),
+(317,541,o),
+(317,589,cs),
+(317,669,o),
+(266,721,o),
+(187,721,cs),
+(109,721,o),
+(56,668,o),
+(56,586,cs),
+(56,504,o),
+(108,450,o),
+(193,450,cs),
+(650,450,l),
+(650,366,ls),
+(650,273,o),
+(699,225,o),
+(784,225,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(147,502,o),
+(119,533,o),
+(119,586,cs),
+(119,638,o),
+(147,668,o),
+(187,668,cs),
+(227,668,o),
+(254,638,o),
+(254,585,cs),
+(254,533,o),
+(227,502,o),
+(187,502,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(450,502,o),
+(423,533,o),
+(423,586,cs),
+(423,638,o),
+(450,668,o),
+(491,668,cs),
+(530,668,o),
+(558,638,o),
+(558,585,cs),
+(558,533,o),
+(531,502,o),
+(490,502,cs)
+);
+}
+);
+width = 960;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "c-canadian";
+note = uni1596;
+unicode = 5526;
+},
+{
+glyphname = "sheSayisi-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_right_can;
+pos = (705,357);
+},
+{
+name = top_center_can;
+pos = (306,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(542,0,l),
+(542,460,ls),
+(542,627,o),
+(455,727,o),
+(306,727,cs),
+(155,727,o),
+(62,623,o),
+(62,451,cs),
+(62,289,o),
+(134,206,o),
+(235,206,cs),
+(331,206,o),
+(387,281,o),
+(382,426,c),
+(324,426,l),
+(326,321,o),
+(293,289,o),
+(249,289,cs),
+(193,289,o),
+(158,337,o),
+(158,453,cs),
+(158,579,o),
+(213,642,o),
+(303,642,cs),
+(393,642,o),
+(443,580,o),
+(443,461,cs),
+(443,0,l)
+);
+}
+);
+width = 613;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1597;
+unicode = 5527;
+},
+{
+glyphname = "shiSayisi-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(170,0,l),
+(170,461,ls),
+(170,580,o),
+(221,642,o),
+(311,642,cs),
+(401,642,o),
+(455,581,o),
+(455,455,cs),
+(455,339,o),
+(420,289,o),
+(364,289,cs),
+(319,289,o),
+(286,321,o),
+(288,426,c),
+(231,426,l),
+(225,281,o),
+(281,206,o),
+(377,206,cs),
+(478,206,o),
+(551,291,o),
+(551,453,cs),
+(551,625,o),
+(461,727,o),
+(312,727,cs),
+(160,727,o),
+(71,627,o),
+(71,460,cs),
+(71,0,l)
+);
+}
+);
+width = 613;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni1598;
+unicode = 5528;
+},
+{
+glyphname = "shoSayisi-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (301,714);
+},
+{
+name = top_left_can;
+pos = (110,714);
+},
+{
+name = top_right_can;
+pos = (493,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(453,-13,o),
+(542,87,o),
+(542,254,cs),
+(542,714,l),
+(443,714,l),
+(443,253,ls),
+(443,134,o),
+(391,72,o),
+(301,72,cs),
+(211,72,o),
+(158,133,o),
+(158,259,cs),
+(158,375,o),
+(193,425,o),
+(249,425,cs),
+(293,425,o),
+(326,393,o),
+(324,288,c),
+(382,288,l),
+(387,433,o),
+(332,508,o),
+(235,508,cs),
+(134,508,o),
+(62,423,o),
+(62,258,cs),
+(62,88,o),
+(151,-13,o),
+(300,-13,cs)
+);
+}
+);
+width = 613;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "te-canadian";
+note = uni1599;
+unicode = 5529;
+},
+{
+glyphname = "shaSayisi-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(457,-13,o),
+(551,91,o),
+(551,263,cs),
+(551,425,o),
+(480,508,o),
+(379,508,cs),
+(283,508,o),
+(225,433,o),
+(231,288,c),
+(288,288,l),
+(286,393,o),
+(319,425,o),
+(364,425,cs),
+(420,425,o),
+(455,377,o),
+(455,261,cs),
+(455,135,o),
+(399,72,o),
+(310,72,cs),
+(219,72,o),
+(170,134,o),
+(170,253,cs),
+(170,714,l),
+(71,714,l),
+(71,254,ls),
+(71,87,o),
+(157,-13,o),
+(306,-13,cs)
+);
+}
+);
+width = 613;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ke-canadian";
+note = uni159A;
+unicode = 5530;
+},
+{
+glyphname = "theWoodScree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(684,-13,o),
+(781,85,o),
+(781,242,cs),
+(781,401,o),
+(686,496,o),
+(526,496,cs),
+(68,496,l),
+(68,414,l),
+(405,414,l),
+(392,430,l),
+(328,396,o),
+(296,320,o),
+(296,237,cs),
+(296,82,o),
+(391,-13,o),
+(538,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(446,72,o),
+(394,137,o),
+(394,242,cs),
+(394,344,o),
+(446,411,o),
+(537,411,cs),
+(630,411,o),
+(684,346,o),
+(684,242,cs),
+(684,137,o),
+(631,72,o),
+(538,72,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(769,632,l),
+(769,714,l),
+(68,714,l),
+(68,632,l)
+);
+}
+);
+width = 849;
+}
+);
+note = uni159B;
+unicode = 5531;
+},
+{
+glyphname = "thiWoodScree-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(458,-13,o),
+(553,82,o),
+(553,238,cs),
+(553,321,o),
+(520,397,o),
+(456,431,c),
+(444,414,l),
+(781,414,l),
+(781,496,l),
+(324,496,ls),
+(161,496,o),
+(68,395,o),
+(68,240,cs),
+(68,85,o),
+(164,-13,o),
+(311,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(218,72,o),
+(165,137,o),
+(165,242,cs),
+(165,346,o),
+(219,411,o),
+(312,411,cs),
+(403,411,o),
+(455,344,o),
+(455,242,cs),
+(455,137,o),
+(403,72,o),
+(311,72,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(781,632,l),
+(781,714,l),
+(80,714,l),
+(80,632,l)
+);
+}
+);
+width = 849;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159C;
+unicode = 5532;
+},
+{
+glyphname = "thoWoodScree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(530.002,0,ls),
+(687,0,o),
+(781,97,o),
+(781,254,cs),
+(781,411,o),
+(685,509,o),
+(538,509,cs),
+(391,509,o),
+(296,412,o),
+(296,258,cs),
+(296,176,o),
+(328,100,o),
+(392,66,c),
+(405,82,l),
+(68,82,l),
+(68,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(446,85,o),
+(394,152,o),
+(394,254,cs),
+(394,359,o),
+(446,424,o),
+(538,424,cs),
+(631,424,o),
+(684,359,o),
+(684,254,cs),
+(684,150,o),
+(630,85,o),
+(537,85,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(769,632,l),
+(769,714,l),
+(68,714,l),
+(68,632,l)
+);
+}
+);
+width = 849;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159D;
+unicode = 5533;
+},
+{
+glyphname = "thaWoodScree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(781,0,l),
+(781,82,l),
+(444,82,l),
+(456,64,l),
+(520,99,o),
+(553,175,o),
+(553,258,cs),
+(553,413,o),
+(458,509,o),
+(311,509,cs),
+(164,509,o),
+(68,411,o),
+(68,253,cs),
+(68,99,o),
+(161,0,o),
+(320,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(219,85,o),
+(165,150,o),
+(165,254,cs),
+(165,359,o),
+(218,424,o),
+(311,424,cs),
+(403,424,o),
+(455,359,o),
+(455,254,cs),
+(455,152,o),
+(403,85,o),
+(312,85,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(781,632,l),
+(781,714,l),
+(80,714,l),
+(80,632,l)
+);
+}
+);
+width = 849;
+}
+);
+metricLeft = "theWoodScree-canadian";
+metricRight = "theWoodScree-canadian";
+note = uni159E;
+unicode = 5534;
+},
+{
+glyphname = "thWoodScree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(456,357,l),
+(456,418,l),
+(268,418,l),
+(271,392,l),
+(304,404,o),
+(327,447,o),
+(327,496,cs),
+(327,576,o),
+(276,628,o),
+(197,628,cs),
+(119,628,o),
+(66,575,o),
+(66,493,cs),
+(66,411,o),
+(118,357,o),
+(203,357,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(157,409,o),
+(129,440,o),
+(129,493,cs),
+(129,545,o),
+(157,575,o),
+(197,575,cs),
+(237,575,o),
+(264,545,o),
+(264,492,cs),
+(264,440,o),
+(237,409,o),
+(197,409,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(454,686,l),
+(454,747,l),
+(71,747,l),
+(71,686,l)
+);
+}
+);
+width = 522;
+}
+);
+metricRight = "=|";
+note = uni159F;
+unicode = 5535;
+},
+{
+glyphname = "lhi-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (474,714);
+},
+{
+name = top_right_can;
+pos = (574,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(376,0,l),
+(376,88,l),
+(326,88,ls),
+(218,88,o),
+(161,146,o),
+(161,246,cs),
+(161,343,o),
+(213,406,o),
+(325,406,cs),
+(776,406,l),
+(776,486,l),
+(591,754,l),
+(518,704,l),
+(703,436,l),
+(699,496,l),
+(323,496,ls),
+(156,496,o),
+(62,398,o),
+(62,246,cs),
+(62,94,o),
+(161,0,o),
+(321,0,cs)
+);
+}
+);
+width = 833;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A0;
+unicode = 5536;
+},
+{
+glyphname = "lhii-canadian";
+kernRight = niright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "lhi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (398,0);
+ref = dot_top;
+}
+);
+width = 833;
+}
+);
+note = uni15A1;
+unicode = 5537;
+},
+{
+glyphname = "lho-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (408,514);
+},
+{
+name = top_right_can;
+pos = (523,514);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(315,-208,l),
+(130,60,l),
+(134,0,l),
+(508,0,ls),
+(675,0,o),
+(771,94,o),
+(771,249,cs),
+(771,403,o),
+(672,496,o),
+(513,496,cs),
+(457,496,l),
+(457,408,l),
+(507,408,ls),
+(615,408,o),
+(673,350,o),
+(673,250,cs),
+(673,149,o),
+(615,89,o),
+(508,89,cs),
+(57,89,l),
+(57,10,l),
+(242,-258,l)
+);
+}
+);
+width = 833;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|ke-canadian";
+note = uni15A2;
+unicode = 5538;
+},
+{
+glyphname = "lhoo-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "lho-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (447,-200);
+ref = dot_top;
+}
+);
+width = 833;
+}
+);
+note = uni15A3;
+unicode = 5539;
+},
+{
+glyphname = "lha-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (427,514);
+},
+{
+name = top_left_can;
+pos = (312,514);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(776,10,l),
+(776,90,l),
+(327,90,ls),
+(218,90,o),
+(161,148,o),
+(161,250,cs),
+(161,350,o),
+(217,408,o),
+(323,408,cs),
+(376,408,l),
+(376,496,l),
+(322,496,ls),
+(158,496,o),
+(62,401,o),
+(62,248,cs),
+(62,92,o),
+(159.995,0,o),
+(324.992,0,cs),
+(699,0,l),
+(703,60,l),
+(518,-208,l),
+(591,-258,l)
+);
+}
+);
+width = 833;
+}
+);
+metricLeft = "ke-canadian";
+metricRight = "=|ne-canadian";
+note = uni15A4;
+unicode = 5540;
+},
+{
+glyphname = "lhaa-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "lha-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (236,-200);
+ref = dot_top;
+}
+);
+width = 833;
+}
+);
+note = uni15A5;
+unicode = 5541;
+},
+{
+glyphname = "lh-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(456,364,l),
+(456,423,l),
+(248,423,ls),
+(170,423,o),
+(133,463,o),
+(133,536,cs),
+(133,609,o),
+(170,650,o),
+(245,650,cs),
+(261,650,l),
+(261,714,l),
+(241,714,ls),
+(126,714,o),
+(62,644,o),
+(62,536,cs),
+(62,426,o),
+(126,357,o),
+(244,357,cs),
+(412,357,l),
+(407,398,l),
+(305,249,l),
+(354,215,l)
+);
+}
+);
+width = 518;
+}
+);
+metricLeft = "t-canadian";
+metricRight = "=|";
+note = uni15A6;
+unicode = 5542;
+},
+{
+glyphname = "theThCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (92,714);
+},
+{
+name = top_right_can;
+pos = (463,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(512,0,l),
+(512,106,l),
+(594,106,l),
+(594,164,l),
+(512,164,l),
+(512,337,l),
+(170,337,l),
+(167,286,l),
+(528,666,l),
+(461,726,l),
+(43,280,l),
+(43,249,l),
+(413,249,l),
+(413,164,l),
+(167,164,l),
+(167,106,l),
+(413,106,l),
+(413,0,l)
+);
+}
+);
+width = 628;
+}
+);
+metricLeft = "ye-canadian";
+note = uni15A7;
+unicode = 5543;
+},
+{
+glyphname = "thiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (166,714);
+},
+{
+name = top_right_can;
+pos = (536,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(216,0,l),
+(216,106,l),
+(461,106,l),
+(461,164,l),
+(216,164,l),
+(216,249,l),
+(585,249,l),
+(585,280,l),
+(167,726,l),
+(102,667,l),
+(464,284,l),
+(460,337,l),
+(116,337,l),
+(116,164,l),
+(34,164,l),
+(34,106,l),
+(116,106,l),
+(116,0,l)
+);
+}
+);
+width = 628;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+unicode = 5544;
+},
+{
+glyphname = "thiiThCree-canadian";
+kernRight = yiright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (90,0);
+ref = dot_top;
+}
+);
+width = 628;
+}
+);
+note = uni15A9;
+unicode = 5545;
+},
+{
+glyphname = "thoThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (92,714);
+},
+{
+name = top_right_can;
+pos = (463,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(527,47,l),
+(166,427,l),
+(169,377,l),
+(512,377,l),
+(512,550,l),
+(594,550,l),
+(594,608,l),
+(512,608,l),
+(512,714,l),
+(413,714,l),
+(413,608,l),
+(167,608,l),
+(167,550,l),
+(413,550,l),
+(413,465,l),
+(43,465,l),
+(43,434,l),
+(461,-12,l)
+);
+}
+);
+width = 628;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+unicode = 5546;
+},
+{
+glyphname = "thooThCree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (387,0);
+ref = dot_top;
+}
+);
+width = 628;
+}
+);
+note = uni15AB;
+unicode = 5547;
+},
+{
+glyphname = "thaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (166,714);
+},
+{
+name = top_right_can;
+pos = (536,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(585,434,l),
+(585,465,l),
+(216,465,l),
+(216,550,l),
+(461,550,l),
+(461,608,l),
+(216,608,l),
+(216,714,l),
+(116,714,l),
+(116,608,l),
+(34,608,l),
+(34,550,l),
+(116,550,l),
+(116,377,l),
+(460,377,l),
+(462,427,l),
+(102,47,l),
+(167,-12,l)
+);
+}
+);
+width = 628;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+unicode = 5548;
+},
+{
+glyphname = "thaaThCree-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (90,0);
+ref = dot_top;
+}
+);
+width = 628;
+}
+);
+note = uni15AD;
+unicode = 5549;
+},
+{
+glyphname = "thThCree-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(344,569,l),
+(344,589,l),
+(166,589,l),
+(166,635,l),
+(282,635,l),
+(282,668,l),
+(166,668,l),
+(166,714,l),
+(95,714,l),
+(95,668,l),
+(54,668,l),
+(54,635,l),
+(95,635,l),
+(95,532,l),
+(276,532,l),
+(267,573,l),
+(94,387,l),
+(142,348,l)
+);
+}
+);
+width = 382;
+}
+);
+metricRight = "y-canadian";
+note = uni15AE;
+unicode = 5550;
+},
+{
+glyphname = "bAivilik-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(463,-13,o),
+(554,90,o),
+(554,249,cs),
+(554,404,o),
+(465,509,o),
+(332,509,cs),
+(247,509,o),
+(185,463,o),
+(170,403,c),
+(178,384,l),
+(178,714,l),
+(78,714,l),
+(78,0,l),
+(174,0,l),
+(174,111,l),
+(168,95,l),
+(185,34,o),
+(247,-13,o),
+(333,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(230,72,o),
+(177,135,o),
+(177,248,cs),
+(177,360,o),
+(231,424,o),
+(317,424,cs),
+(401,424,o),
+(456,361,o),
+(456,248,cs),
+(456,135,o),
+(402,72,o),
+(317,72,cs)
+);
+}
+);
+width = 616;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|ke-canadian";
+note = uni15AF;
+unicode = 5551;
+},
+{
+glyphname = "eBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(178,0,l),
+(178,419,l),
+(208,383,o),
+(254,361,o),
+(307,361,cs),
+(409,361,o),
+(480,439,o),
+(480,545,cs),
+(480,650,o),
+(409,727,o),
+(307,727,cs),
+(251,727,o),
+(204,704,o),
+(174,665,c),
+(174,714,l),
+(78,714,l),
+(78,0,l)
+);
+}
+);
+width = 524;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B0;
+unicode = 5552;
+},
+{
+glyphname = "iBlackfoot-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(272,-13,o),
+(320,10,o),
+(349,49,c),
+(349,0,l),
+(445,0,l),
+(445,714,l),
+(345,714,l),
+(345,295,l),
+(315,331,o),
+(270,353,o),
+(216,353,cs),
+(114,353,o),
+(44,275,o),
+(44,169,cs),
+(44,64,o),
+(114,-13,o),
+(216,-13,cs)
+);
+}
+);
+width = 523;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B1;
+unicode = 5553;
+},
+{
+glyphname = "oBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(409,-13,o),
+(480,64,o),
+(480,169,cs),
+(480,275,o),
+(409,353,o),
+(307,353,cs),
+(254,353,o),
+(208,331,o),
+(178,295,c),
+(178,714,l),
+(78,714,l),
+(78,0,l),
+(174,0,l),
+(174,49,l),
+(204,10,o),
+(251,-13,o),
+(307,-13,cs)
+);
+}
+);
+width = 524;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "eBlackfoot-canadian";
+note = uni15B2;
+unicode = 5554;
+},
+{
+glyphname = "aBlackfoot-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(445,0,l),
+(445,714,l),
+(349,714,l),
+(349,665,l),
+(320,704,o),
+(272,727,o),
+(216,727,cs),
+(114,727,o),
+(44,650,o),
+(44,545,cs),
+(44,439,o),
+(114,361,o),
+(216,361,cs),
+(270,361,o),
+(315,383,o),
+(345,419,c),
+(345,0,l)
+);
+}
+);
+width = 523;
+}
+);
+metricLeft = "=|eBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B3;
+unicode = 5555;
+},
+{
+glyphname = "weBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(178,314,l),
+(537,314,l),
+(537,398,l),
+(178,398,l),
+(178,630,l),
+(537,630,l),
+(537,714,l),
+(78,714,l),
+(78,0,l),
+(178,0,l)
+);
+}
+);
+width = 597;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B4;
+unicode = 5556;
+},
+{
+glyphname = "wiBlackfoot-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(518,0,l),
+(518,714,l),
+(419,714,l),
+(419,400,l),
+(60,400,l),
+(60,316,l),
+(419,316,l),
+(419,84,l),
+(60,84,l),
+(60,0,l)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B5;
+unicode = 5557;
+},
+{
+glyphname = "woBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(537,0,l),
+(537,84,l),
+(178,84,l),
+(178,316,l),
+(537,316,l),
+(537,400,l),
+(178,400,l),
+(178,714,l),
+(78,714,l),
+(78,0,l)
+);
+}
+);
+width = 597;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "weBlackfoot-canadian";
+note = uni15B6;
+unicode = 5558;
+},
+{
+glyphname = "waBlackfoot-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(518,0,l),
+(518,714,l),
+(60,714,l),
+(60,630,l),
+(419,630,l),
+(419,398,l),
+(60,398,l),
+(60,314,l),
+(419,314,l),
+(419,0,l)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "=|weBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B7;
+unicode = 5559;
+},
+{
+glyphname = "neBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(178,0,l),
+(178,639,l),
+(227,639,l),
+(197,701,l),
+(197,678,ls),
+(197,514,o),
+(285,413,o),
+(433,413,cs),
+(577,413,o),
+(671,513,o),
+(671,673,cs),
+(671,714,l),
+(573,714,l),
+(573,668,ls),
+(573,562,o),
+(521,499,o),
+(434,499,cs),
+(346,499,o),
+(295,561,o),
+(295,668,cs),
+(295,714,l),
+(78,714,l),
+(78,0,l)
+);
+}
+);
+width = 711;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15B8;
+unicode = 5560;
+},
+{
+glyphname = "niBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(138,0,l),
+(138,46,ls),
+(138,152,o),
+(190,215,o),
+(277,215,cs),
+(365,215,o),
+(417,153,o),
+(417,46,cs),
+(417,0,l),
+(633,0,l),
+(633,714,l),
+(533,714,l),
+(533,75,l),
+(484,75,l),
+(514,13,l),
+(514,36,ls),
+(514,200,o),
+(426,301,o),
+(279,301,cs),
+(135,301,o),
+(40,201,o),
+(40,41,cs),
+(40,0,l)
+);
+}
+);
+width = 711;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15B9;
+unicode = 5561;
+},
+{
+glyphname = "noBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(295,0,l),
+(295,46,ls),
+(295,153,o),
+(346,215,o),
+(434,215,cs),
+(521,215,o),
+(573,152,o),
+(573,46,cs),
+(573,0,l),
+(671,0,l),
+(671,41,ls),
+(671,201,o),
+(577,301,o),
+(433,301,cs),
+(285,301,o),
+(197,200,o),
+(197,36,cs),
+(197,13,l),
+(227,75,l),
+(178,75,l),
+(178,714,l),
+(78,714,l),
+(78,0,l)
+);
+}
+);
+width = 711;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "neBlackfoot-canadian";
+note = uni15BA;
+unicode = 5562;
+},
+{
+glyphname = "naBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(633,0,l),
+(633,714,l),
+(417,714,l),
+(417,668,ls),
+(417,561,o),
+(365,499,o),
+(277,499,cs),
+(190,499,o),
+(138,562,o),
+(138,668,cs),
+(138,714,l),
+(40,714,l),
+(40,673,ls),
+(40,513,o),
+(135,413,o),
+(279,413,cs),
+(426,413,o),
+(514,514,o),
+(514,678,cs),
+(514,701,l),
+(484,639,l),
+(533,639,l),
+(533,0,l)
+);
+}
+);
+width = 711;
+}
+);
+metricLeft = "=|neBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BB;
+unicode = 5563;
+},
+{
+glyphname = "keBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(178,0,l),
+(178,603,l),
+(139,603,l),
+(324,264,l),
+(367,264,l),
+(612,714,l),
+(509,714,l),
+(318,362,l),
+(361,362,l),
+(171,714,l),
+(78,714,l),
+(78,0,l)
+);
+}
+);
+width = 635;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15BC;
+unicode = 5564;
+},
+{
+glyphname = "kiBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(127,0,l),
+(317,352,l),
+(274,352,l),
+(465,0,l),
+(557,0,l),
+(557,714,l),
+(457,714,l),
+(457,111,l),
+(496,111,l),
+(312,450,l),
+(269,450,l),
+(23,0,l)
+);
+}
+);
+width = 635;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BD;
+unicode = 5565;
+},
+{
+glyphname = "koBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(171,0,l),
+(361,352,l),
+(318,352,l),
+(509,0,l),
+(612,0,l),
+(367,450,l),
+(324,450,l),
+(139,111,l),
+(178,111,l),
+(178,714,l),
+(78,714,l),
+(78,0,l)
+);
+}
+);
+width = 635;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "keBlackfoot-canadian";
+note = uni15BE;
+unicode = 5566;
+},
+{
+glyphname = "kaBlackfoot-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(557,0,l),
+(557,714,l),
+(465,714,l),
+(274,362,l),
+(317,362,l),
+(127,714,l),
+(23,714,l),
+(269,264,l),
+(312,264,l),
+(496,603,l),
+(457,603,l),
+(457,0,l)
+);
+}
+);
+width = 635;
+}
+);
+metricLeft = "=|keBlackfoot-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15BF;
+unicode = 5567;
+},
+{
+color = 9;
+glyphname = "heSayisi-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_right_can;
+pos = (567,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(616,0,l),
+(616,714,l),
+(517,714,l),
+(517,296,l),
+(535,296,l),
+(526,549,o),
+(431,727,o),
+(267,727,cs),
+(132,727,o),
+(57,633,o),
+(57,465,cs),
+(57,430,o),
+(61,389,o),
+(70,348,c),
+(165,348,l),
+(157,387,o),
+(154,426,o),
+(154,457,cs),
+(154,582,o),
+(202,640,o),
+(287,640,cs),
+(426,640,o),
+(514,456,o),
+(517,0,c)
+);
+}
+);
+width = 694;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni15C0;
+unicode = 5568;
+},
+{
+color = 9;
+glyphname = "hiSayisi-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(178,0,l),
+(180,456,o),
+(268,640,o),
+(408,640,cs),
+(492,640,o),
+(541,582,o),
+(541,457,cs),
+(541,426,o),
+(537,387,o),
+(530,348,c),
+(625,348,l),
+(634,389,o),
+(637,430,o),
+(637,465,cs),
+(637,633,o),
+(562,727,o),
+(427,727,cs),
+(264,727,o),
+(168,549,o),
+(159,296,c),
+(177,296,l),
+(177,714,l),
+(78,714,l),
+(78,0,l)
+);
+}
+);
+width = 694;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C1;
+unicode = 5569;
+},
+{
+color = 9;
+glyphname = "hoSayisi-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (342,714);
+},
+{
+name = top_left_can;
+pos = (117,714);
+},
+{
+name = top_right_can;
+pos = (567,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(431,-13,o),
+(526,165,o),
+(535,418,c),
+(517,418,l),
+(517,0,l),
+(616,0,l),
+(616,714,l),
+(517,714,l),
+(514,258,o),
+(426,74,o),
+(287,74,cs),
+(202,74,o),
+(154,132,o),
+(154,257,cs),
+(154,288,o),
+(157,327,o),
+(165,366,c),
+(70,366,l),
+(61,325,o),
+(57,284,o),
+(57,249,cs),
+(57,81,o),
+(132,-13,o),
+(267,-13,cs)
+);
+}
+);
+width = 694;
+}
+);
+metricLeft = "heSayisi-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15C2;
+unicode = 5570;
+},
+{
+color = 9;
+glyphname = "haSayisi-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(562,-13,o),
+(637,81,o),
+(637,249,cs),
+(637,284,o),
+(634,325,o),
+(625,366,c),
+(530,366,l),
+(537,327,o),
+(541,288,o),
+(541,257,cs),
+(541,132,o),
+(492,74,o),
+(408,74,cs),
+(268,74,o),
+(180,258,o),
+(178,714,c),
+(78,714,l),
+(78,0,l),
+(177,0,l),
+(177,418,l),
+(159,418,l),
+(168,165,o),
+(264,-13,o),
+(427,-13,cs)
+);
+}
+);
+width = 694;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|heSayisi-canadian";
+note = uni15C3;
+unicode = 5571;
+},
+{
+color = 9;
+glyphname = "ghuCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(389,0,l),
+(708,687,l),
+(708,714,l),
+(625,714,l),
+(521,486,l),
+(573,502,l),
+(171,502,l),
+(225,484,l),
+(121,714,l),
+(33,714,l),
+(33,687,l),
+(352,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(543,426,l),
+(505,441,l),
+(353,106,l),
+(392,106,l),
+(241,442,l),
+(204,426,l)
+);
+}
+);
+width = 741;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C4;
+unicode = 5572;
+},
+{
+color = 9;
+glyphname = "ghoCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,0,l),
+(225,230,l),
+(171,212,l),
+(573,212,l),
+(521,228,l),
+(625,0,l),
+(708,0,l),
+(708,27,l),
+(389,714,l),
+(352,714,l),
+(33,27,l),
+(33,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(392,608,l),
+(353,608,l),
+(505,273,l),
+(543,288,l),
+(204,288,l),
+(241,272,l)
+);
+}
+);
+width = 741;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15C5;
+unicode = 5573;
+},
+{
+color = 9;
+glyphname = "gheCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (79,357);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(81,0,l),
+(637,339,l),
+(637,375,l),
+(81,714,l),
+(55,714,l),
+(55,633,l),
+(217,533,l),
+(209,567,l),
+(209,136,l),
+(217,182,l),
+(55,82,l),
+(55,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(284,546,l),
+(267,512,l),
+(553,335,l),
+(554,380,l),
+(267,204,l),
+(284,170,l)
+);
+}
+);
+width = 672;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15C6;
+unicode = 5574;
+},
+{
+color = 9;
+glyphname = "gheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (36,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 672;
+}
+);
+note = uni15C7;
+unicode = 5575;
+},
+{
+color = 9;
+glyphname = "ghiCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "gheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (12,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 672;
+}
+);
+note = uni15C8;
+unicode = 5576;
+},
+{
+color = 9;
+glyphname = "ghaCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(617,0,l),
+(617,81,l),
+(462,178,l),
+(470,138,l),
+(470,576,l),
+(462,536,l),
+(617,632,l),
+(617,714,l),
+(591,714,l),
+(35,375,l),
+(35,339,l),
+(591,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(412,200,l),
+(120,380,l),
+(120,334,l),
+(412,514,l),
+(395,543,l),
+(395,173,l)
+);
+}
+);
+width = 672;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15C9;
+unicode = 5577;
+},
+{
+color = 9;
+glyphname = "ruCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(389,0,l),
+(708,687,l),
+(708,714,l),
+(625,714,l),
+(584,624,l),
+(605,636,l),
+(137,636,l),
+(162,623,l),
+(121,714,l),
+(33,714,l),
+(33,687,l),
+(352,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(582,558,l),
+(567,580,l),
+(353,108,l),
+(393,108,l),
+(181,578,l),
+(160,558,l)
+);
+}
+);
+width = 741;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CA;
+unicode = 5578;
+},
+{
+color = 9;
+glyphname = "roCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(120,0,l),
+(161,90,l),
+(138,78,l),
+(605,78,l),
+(582,91,l),
+(624,0,l),
+(708,0,l),
+(708,27,l),
+(389,714,l),
+(352,714,l),
+(33,27,l),
+(33,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(390,609,l),
+(351,609,l),
+(564,136,l),
+(582,156,l),
+(161,156,l),
+(177,134,l)
+);
+}
+);
+width = 741;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15CB;
+unicode = 5579;
+},
+{
+color = 9;
+glyphname = "reCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(82,0,l),
+(637,339,l),
+(637,375,l),
+(82,714,l),
+(55,714,l),
+(55,633,l),
+(134,584,l),
+(120,610,l),
+(120,104,l),
+(134,131,l),
+(55,82,l),
+(55,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(198,588,l),
+(185,559,l),
+(550,334,l),
+(550,380,l),
+(185,156,l),
+(198,125,l)
+);
+}
+);
+width = 672;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CC;
+unicode = 5580;
+},
+{
+color = 9;
+glyphname = "reeCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(82,0,l),
+(637,339,l),
+(637,375,l),
+(82,714,l),
+(55,714,l),
+(55,643,l),
+(134,593,l),
+(120,616,l),
+(120,94,l),
+(134,120,l),
+(55,71,l),
+(55,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(189,595,l),
+(177,574,l),
+(570,335,l),
+(570,380,l),
+(176,139,l),
+(189,125,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(291,272,l),
+(291,444,l),
+(247,444,l),
+(247,272,l)
+);
+}
+);
+width = 672;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CD;
+unicode = 5581;
+},
+{
+color = 9;
+glyphname = "riCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(82,0,l),
+(637,339,l),
+(637,375,l),
+(82,714,l),
+(55,714,l),
+(55,643,l),
+(134,593,l),
+(120,616,l),
+(120,95,l),
+(134,120,l),
+(55,71,l),
+(55,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(312,314,o),
+(332,332,o),
+(332,357,cs),
+(332,382,o),
+(312,400,o),
+(288,400,cs),
+(265,400,o),
+(245,382,o),
+(245,357,cs),
+(245,332,o),
+(265,314,o),
+(288,314,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(189,594,l),
+(177,574,l),
+(570,335,l),
+(570,380,l),
+(176,140,l),
+(189,126,l)
+);
+}
+);
+width = 672;
+}
+);
+metricLeft = "po-canadian";
+metricRight = "o-canadian";
+note = uni15CE;
+unicode = 5582;
+},
+{
+color = 9;
+glyphname = "raCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(617,0,l),
+(617,82,l),
+(542,129,l),
+(552,98,l),
+(552,617,l),
+(542,585,l),
+(617,632,l),
+(617,714,l),
+(591,714,l),
+(35,375,l),
+(35,339,l),
+(591,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(492,561,l),
+(474,589,l),
+(474,126,l),
+(492,154,l),
+(123,380,l),
+(123,335,l)
+);
+}
+);
+width = 672;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|po-canadian";
+note = uni15CF;
+unicode = 5583;
+},
+{
+color = 9;
+glyphname = "wuCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(394,0,l),
+(717,687,l),
+(717,714,l),
+(639,714,l),
+(394,167,l),
+(418,167,l),
+(418,714,l),
+(339,714,l),
+(339,167,l),
+(363,167,l),
+(117,714,l),
+(33,714,l),
+(33,687,l),
+(357,0,l)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D0;
+unicode = 5584;
+},
+{
+color = 9;
+glyphname = "woCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(115,0,l),
+(360,547,l),
+(336,547,l),
+(336,0,l),
+(415,0,l),
+(415,547,l),
+(391,547,l),
+(637,0,l),
+(717,0,l),
+(717,27,l),
+(394,714,l),
+(357,714,l),
+(33,27,l),
+(33,0,l)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D1;
+unicode = 5585;
+},
+{
+color = 9;
+glyphname = "weCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(102,0,l),
+(658,339,l),
+(658,375,l),
+(103,714,l),
+(76,714,l),
+(76,633,l),
+(504,375,l),
+(504,396,l),
+(78,396,l),
+(78,319,l),
+(503,319,l),
+(503,339,l),
+(76,81,l),
+(76,0,l)
+);
+}
+);
+width = 693;
+}
+);
+metricRight = "o-canadian";
+note = uni15D2;
+unicode = 5586;
+},
+{
+color = 9;
+glyphname = "weeCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(102,0,l),
+(658,339,l),
+(658,375,l),
+(103,714,l),
+(76,714,l),
+(76,641,l),
+(533,366,l),
+(540,388,l),
+(212,388,l),
+(212,470,l),
+(156,470,l),
+(156,388,l),
+(76,388,l),
+(76,327,l),
+(156,327,l),
+(156,245,l),
+(212,245,l),
+(212,327,l),
+(541,327,l),
+(534,348,l),
+(76,73,l),
+(76,0,l)
+);
+}
+);
+width = 693;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D3;
+unicode = 5587;
+},
+{
+color = 9;
+glyphname = "wiCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(102,0,l),
+(658,339,l),
+(658,375,l),
+(103,714,l),
+(76,714,l),
+(76,642,l),
+(534,366,l),
+(540,388,l),
+(284,388,l),
+(273,414,o),
+(247,432,o),
+(217,432,cs),
+(186,432,o),
+(160,414,o),
+(150,388,c),
+(76,388,l),
+(76,327,l),
+(150,327,l),
+(161,301,o),
+(187,282,o),
+(217,282,cs),
+(247,282,o),
+(272,301,o),
+(283,327,c),
+(541,327,l),
+(535,348,l),
+(76,72,l),
+(76,0,l)
+);
+}
+);
+width = 693;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D4;
+unicode = 5588;
+},
+{
+color = 9;
+glyphname = "waCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(617,0,l),
+(617,80,l),
+(189,339,l),
+(189,318,l),
+(616,318,l),
+(616,395,l),
+(190,395,l),
+(190,375,l),
+(617,633,l),
+(617,714,l),
+(591,714,l),
+(35,375,l),
+(35,339,l),
+(591,0,l)
+);
+}
+);
+width = 693;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15D5;
+unicode = 5589;
+},
+{
+color = 9;
+glyphname = "hwuCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(394,0,l),
+(717,687,l),
+(717,714,l),
+(643,714,l),
+(545,498,l),
+(580,514,l),
+(409,514,l),
+(409,714,l),
+(344,714,l),
+(344,514,l),
+(172,514,l),
+(209,499,l),
+(110,714,l),
+(33,714,l),
+(33,687,l),
+(357,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(350,457,l),
+(350,130,l),
+(368,135,l),
+(217,473,l),
+(196,457,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(404,457,l),
+(557,457,l),
+(538,473,l),
+(385,133,l),
+(404,129,l)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D6;
+unicode = 5590;
+},
+{
+color = 9;
+glyphname = "hwoCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(110,0,l),
+(209,216,l),
+(174,199,l),
+(344,199,l),
+(344,0,l),
+(409,0,l),
+(409,199,l),
+(582,199,l),
+(545,216,l),
+(643,0,l),
+(717,0,l),
+(717,27,l),
+(394,714,l),
+(357,714,l),
+(33,27,l),
+(33,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(359,562,l),
+(349,565,l),
+(349,258,l),
+(202,258,l),
+(216,241,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(555,258,l),
+(403,258,l),
+(403,567,l),
+(393,564,l),
+(538,241,l)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "e-canadian";
+metricRight = "e-canadian";
+note = uni15D7;
+unicode = 5591;
+},
+{
+color = 9;
+glyphname = "hweCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(102,0,l),
+(658,339,l),
+(658,375,l),
+(103,714,l),
+(76,714,l),
+(76,641,l),
+(228,550,l),
+(228,390,l),
+(76,390,l),
+(76,325,l),
+(228,325,l),
+(228,164,l),
+(76,72,l),
+(76,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(279,330,l),
+(517,330,l),
+(279,188,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(279,525,l),
+(515,385,l),
+(279,385,l)
+);
+}
+);
+width = 693;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D8;
+unicode = 5592;
+},
+{
+color = 9;
+glyphname = "hweeCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(102,0,l),
+(658,339,l),
+(658,375,l),
+(103,714,l),
+(76,714,l),
+(76,643,l),
+(250,540,l),
+(250,386,l),
+(192,386,l),
+(192,466,l),
+(144,466,l),
+(144,386,l),
+(76,386,l),
+(76,329,l),
+(144,329,l),
+(144,249,l),
+(192,249,l),
+(192,329,l),
+(250,329,l),
+(250,173,l),
+(76,71,l),
+(76,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(296,333,l),
+(522,333,l),
+(296,197,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(296,517,l),
+(520,382,l),
+(296,382,l)
+);
+}
+);
+width = 693;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15D9;
+unicode = 5593;
+},
+{
+color = 9;
+glyphname = "hwiCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(102,0,l),
+(658,339,l),
+(658,375,l),
+(103,714,l),
+(76,714,l),
+(76,643,l),
+(250,540,l),
+(250,382,l),
+(223,382,l),
+(215,405,o),
+(193,421,o),
+(166,421,cs),
+(141,421,o),
+(119,405,o),
+(110,382,c),
+(76,382,l),
+(76,333,l),
+(111,333,l),
+(119,310,o),
+(141,294,o),
+(167,294,cs),
+(192,294,o),
+(214,310,o),
+(222,333,c),
+(250,333,l),
+(250,173,l),
+(76,71,l),
+(76,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(296,333,l),
+(522,333,l),
+(296,197,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(296,517,l),
+(520,382,l),
+(296,382,l)
+);
+}
+);
+width = 693;
+}
+);
+metricLeft = "weCarrier-canadian";
+metricRight = "o-canadian";
+note = uni15DA;
+unicode = 5594;
+},
+{
+color = 9;
+glyphname = "hwaCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(617,0,l),
+(617,72,l),
+(465,164,l),
+(465,324,l),
+(617,324,l),
+(617,389,l),
+(465,389,l),
+(465,550,l),
+(617,641,l),
+(617,714,l),
+(591,714,l),
+(35,375,l),
+(35,339,l),
+(591,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(178,329,l),
+(414,329,l),
+(414,188,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(414,526,l),
+(414,384,l),
+(177,384,l)
+);
+}
+);
+width = 693;
+}
+);
+metricLeft = "=|o-canadian";
+metricRight = "=|weCarrier-canadian";
+note = uni15DB;
+unicode = 5595;
+},
+{
+color = 9;
+glyphname = "thuCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(555,-13,o),
+(667,106,o),
+(667,313,cs),
+(667,714,l),
+(71,714,l),
+(71,310,ls),
+(71,105,o),
+(184,-13,o),
+(369,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(170,626,l),
+(568,626,l),
+(568,311,ls),
+(568,157,o),
+(496,78,o),
+(369,78,cs),
+(245,78,o),
+(170,159,o),
+(170,311,cs)
+);
+}
+);
+width = 738;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DC;
+unicode = 5596;
+},
+{
+color = 9;
+glyphname = "thoCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(667,0,l),
+(667,404,ls),
+(667,609,o),
+(554,727,o),
+(372,727,cs),
+(185,727,o),
+(71,609,o),
+(71,401,cs),
+(71,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(170,403,ls),
+(170,555,o),
+(245,636,o),
+(371,636,cs),
+(494,636,o),
+(568,555,o),
+(568,403,cs),
+(568,88,l),
+(170,88,l)
+);
+}
+);
+width = 738;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15DD;
+unicode = 5597;
+},
+{
+color = 9;
+glyphname = "theCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (360,357);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(318,0,ls),
+(535.003,0,o),
+(659,133,o),
+(659,358,cs),
+(659,583,o),
+(535.003,714,o),
+(314,714,cs),
+(78,714,l),
+(78,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(178,655,l),
+(149,626,l),
+(312,626,ls),
+(474,626,o),
+(559,532,o),
+(559,358,cs),
+(559,185,o),
+(474,88,o),
+(313,88,cs),
+(149,88,l),
+(178,59,l)
+);
+}
+);
+width = 723;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "to-canadian";
+note = uni15DE;
+unicode = 5598;
+},
+{
+color = 9;
+glyphname = "theeCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (310,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 724;
+}
+);
+note = uni15DF;
+unicode = 5599;
+},
+{
+color = 9;
+glyphname = "thiCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "theCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (284,0);
+ref = dot_middle;
+}
+);
+width = 724;
+}
+);
+note = uni15E0;
+unicode = 5600;
+},
+{
+color = 9;
+glyphname = "thaCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(644,0,l),
+(644,714,l),
+(407,714,ls),
+(188,714,o),
+(64,582,o),
+(64,357,cs),
+(64,132,o),
+(188,0,o),
+(406,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(163,530,o),
+(249,626,o),
+(410,626,cs),
+(573,626,l),
+(545,655,l),
+(545,59,l),
+(573,88,l),
+(410,88,ls),
+(249,88,o),
+(163,183,o),
+(163,357,cs)
+);
+}
+);
+width = 722;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15E1;
+unicode = 5601;
+},
+{
+color = 9;
+glyphname = "ttuCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(555,-13,o),
+(667,106,o),
+(667,313,cs),
+(667,714,l),
+(632,714,l),
+(356,525,l),
+(383,525,l),
+(108,714,l),
+(71,714,l),
+(71,310,ls),
+(71,105,o),
+(184,-13,o),
+(369,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(245,78,o),
+(170,159,o),
+(170,311,cs),
+(170,636,l),
+(83,633,l),
+(358,445,l),
+(380,445,l),
+(656,633,l),
+(568,636,l),
+(568,311,ls),
+(568,157,o),
+(496,78,o),
+(369,78,cs)
+);
+}
+);
+width = 738;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E2;
+unicode = 5602;
+},
+{
+color = 9;
+glyphname = "ttoCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(106,0,l),
+(382,189,l),
+(355,189,l),
+(630,0,l),
+(667,0,l),
+(667,404,ls),
+(667,609,o),
+(553,727,o),
+(368,727,cs),
+(183,727,o),
+(71,608,o),
+(71,401,cs),
+(71,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(493,636,o),
+(568,555,o),
+(568,403,cs),
+(568,78,l),
+(655,81,l),
+(379,269,l),
+(358,269,l),
+(82,81,l),
+(170,78,l),
+(170,403,ls),
+(170,557,o),
+(242,636,o),
+(369,636,cs)
+);
+}
+);
+width = 738;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E3;
+unicode = 5603;
+},
+{
+color = 9;
+glyphname = "tteCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (413,357);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(328,0,ls),
+(545,0,o),
+(669,133,o),
+(669,358,cs),
+(669,583,o),
+(545,714,o),
+(324,714,cs),
+(70,714,l),
+(70,687,l),
+(200,343,l),
+(200,371,l),
+(70,27,l),
+(70,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(289,346,l),
+(289,365,l),
+(161,707,l),
+(160,626,l),
+(322,626,ls),
+(484,626,o),
+(570,532,o),
+(570,358,cs),
+(570,185,o),
+(484,88,o),
+(323,88,cs),
+(160,88,l),
+(161,5,l)
+);
+}
+);
+width = 733;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15E4;
+unicode = 5604;
+},
+{
+color = 9;
+glyphname = "tteeCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (370,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 734;
+}
+);
+note = uni15E5;
+unicode = 5605;
+},
+{
+color = 9;
+glyphname = "ttiCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "tteCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (355,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 734;
+}
+);
+note = uni15E6;
+unicode = 5606;
+},
+{
+color = 9;
+glyphname = "ttaCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(663,0,l),
+(663,27,l),
+(533,371,l),
+(533,343,l),
+(663,687,l),
+(663,714,l),
+(407,714,ls),
+(188,714,o),
+(64,582,o),
+(64,357,cs),
+(64,132,o),
+(188,0,o),
+(406,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(573,88,l),
+(410,88,ls),
+(249,88,o),
+(163,183,o),
+(163,357,cs),
+(163,530,o),
+(249,626,o),
+(410,626,cs),
+(573,626,l),
+(572,709,l),
+(443,368,l),
+(443,349,l),
+(572,8,l)
+);
+}
+);
+width = 733;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|tteCarrier-canadian";
+note = uni15E7;
+unicode = 5607;
+},
+{
+color = 9;
+glyphname = "puCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(555,-13,o),
+(667,106,o),
+(667,313,cs),
+(667,714,l),
+(568,714,l),
+(568,549,l),
+(170,549,l),
+(170,714,l),
+(71,714,l),
+(71,310,ls),
+(71,105,o),
+(184,-13,o),
+(369,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(245,78,o),
+(170,159,o),
+(170,311,cs),
+(170,462,l),
+(568,462,l),
+(568,311,ls),
+(568,157,o),
+(496,78,o),
+(369,78,cs)
+);
+}
+);
+width = 738;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E8;
+unicode = 5608;
+},
+{
+color = 9;
+glyphname = "poCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(170,0,l),
+(170,165,l),
+(568,165,l),
+(568,0,l),
+(667,0,l),
+(667,404,ls),
+(667,609,o),
+(554,727,o),
+(372,727,cs),
+(186,727,o),
+(71,609,o),
+(71,401,cs),
+(71,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(170,403,ls),
+(170,555,o),
+(245,636,o),
+(371,636,cs),
+(494,636,o),
+(568,555,o),
+(568,403,cs),
+(568,252,l),
+(170,252,l)
+);
+}
+);
+width = 738;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni15E9;
+unicode = 5609;
+},
+{
+color = 9;
+glyphname = "peCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (401,357);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(323,0,ls),
+(540,0,o),
+(664,133,o),
+(664,358,cs),
+(664,583,o),
+(540,714,o),
+(320,714,cs),
+(66,714,l),
+(66,626,l),
+(157,626,l),
+(157,88,l),
+(66,88,l),
+(66,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(255,655,l),
+(223,626,l),
+(318,626,ls),
+(480,626,o),
+(565,532,o),
+(565,358,cs),
+(565,185,o),
+(480,88,o),
+(319,88,cs),
+(223,88,l),
+(255,59,l)
+);
+}
+);
+width = 728;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni15EA;
+unicode = 5610;
+},
+{
+color = 9;
+glyphname = "peeCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (358,0);
+ref = stroke_middle_optic_halfsmall;
+}
+);
+width = 729;
+}
+);
+note = uni15EB;
+unicode = 5611;
+},
+{
+color = 9;
+glyphname = "piCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "peCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (343,0);
+ref = dot_middle_optic_small;
+}
+);
+width = 729;
+}
+);
+note = uni15EC;
+unicode = 5612;
+},
+{
+color = 9;
+glyphname = "paCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(663,0,l),
+(663,88,l),
+(571,88,l),
+(571,626,l),
+(663,626,l),
+(663,714,l),
+(408,714,ls),
+(188,714,o),
+(64,583,o),
+(64,358,cs),
+(64,133,o),
+(188,0,o),
+(405,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(505,88,l),
+(409,88,ls),
+(249,88,o),
+(163,185,o),
+(163,358,cs),
+(163,532,o),
+(249,626,o),
+(411,626,cs),
+(505,626,l),
+(473,655,l),
+(473,59,l)
+);
+}
+);
+width = 729;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|peCarrier-canadian";
+note = uni15ED;
+unicode = 5613;
+},
+{
+color = 6;
+glyphname = "pCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(397,189,l),
+(397,256,l),
+(266,256,l),
+(266,546,l),
+(196,546,l),
+(196,256,l),
+(64,256,l),
+(64,189,l)
+);
+}
+);
+width = 461;
+}
+);
+metricLeft = "shorthorizontalstrokeFinal-canadian";
+metricRight = "shorthorizontalstrokeFinal-canadian";
+note = uni15EE;
+unicode = 5614;
+},
+{
+color = 9;
+glyphname = "guCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (445,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(373,-13,o),
+(439,40,o),
+(466,138,c),
+(424,138,l),
+(455,38,o),
+(520,-13,o),
+(611,-13,cs),
+(738,-13,o),
+(813,75,o),
+(813,221,cs),
+(813.001,714,l),
+(717,714,l),
+(717,222,ls),
+(717,127,o),
+(678,75,o),
+(606,75,cs),
+(535,75,o),
+(492,128,o),
+(492,221,cs),
+(492,714,l),
+(398.004,714,l),
+(398,221,ls),
+(398,126,o),
+(356,75,o),
+(284,75,cs),
+(211,75,o),
+(169,126,o),
+(169,222,cs),
+(169,714,l),
+(73,714,l),
+(73,222,ls),
+(73,73,o),
+(152,-13,o),
+(278,-13,cs)
+);
+}
+);
+width = 886;
+}
+);
+metricRight = "=|";
+note = uni15EF;
+unicode = 5615;
+},
+{
+color = 9;
+glyphname = "goCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(169,0,l),
+(169,492,ls),
+(169,587,o),
+(209,639,o),
+(282,639,cs),
+(353,639,o),
+(396,587,o),
+(396,493,cs),
+(396,0,l),
+(490,0,l),
+(490,493,ls),
+(490,586,o),
+(533,639,o),
+(603,639,cs),
+(676,639,o),
+(717,587,o),
+(717,492,cs),
+(717,0,l),
+(813.001,0,l),
+(813,492,ls),
+(813,640,o),
+(734,727,o),
+(610,727,cs),
+(516,727,o),
+(450,674,o),
+(423,576,c),
+(465,576,l),
+(434,676,o),
+(369,727,o),
+(276,727,cs),
+(149,727,o),
+(73,640,o),
+(73,492,cs),
+(73,0,l)
+);
+}
+);
+width = 886;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F0;
+unicode = 5616;
+},
+{
+color = 9;
+glyphname = "geCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (369,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(436,0,ls),
+(583,0,o),
+(659,70,o),
+(659,193,cs),
+(659,278,o),
+(607,345,o),
+(525,373,c),
+(525,341,l),
+(609,365,o),
+(659,429,o),
+(659,519,cs),
+(659,642,o),
+(581,714,o),
+(436,714,cs),
+(78,714,l),
+(78,632,l),
+(419,632,ls),
+(515,632,o),
+(559,592,o),
+(559,516,cs),
+(559,439,o),
+(511,398,o),
+(421,398,cs),
+(78,398,l),
+(78,317,l),
+(422,317,ls),
+(511,317,o),
+(559,274,o),
+(559,197,cs),
+(559,122,o),
+(515,82,o),
+(419,82,cs),
+(78,82,l),
+(78,0,l)
+);
+}
+);
+width = 733;
+}
+);
+metricLeft = "nunavuth-canadian";
+note = uni15F1;
+unicode = 5617;
+},
+{
+color = 9;
+glyphname = "geeCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(436,0,ls),
+(583,0,o),
+(659,70,o),
+(659,193,cs),
+(659,278,o),
+(607,345,o),
+(525,373,c),
+(525,341,l),
+(609,365,o),
+(659,429,o),
+(659,519,cs),
+(659,642,o),
+(581,714,o),
+(436,714,cs),
+(78,714,l),
+(78,632,l),
+(419,632,ls),
+(515,632,o),
+(559,592,o),
+(559,516,cs),
+(559,439,o),
+(511,397,o),
+(421,397,cs),
+(353,397,l),
+(353,483,l),
+(294,483,l),
+(294,397,l),
+(78,397,l),
+(78,318,l),
+(294,318,l),
+(294,232,l),
+(353,232,l),
+(353,318,l),
+(422,318,ls),
+(511,318,o),
+(559,274,o),
+(559,197,cs),
+(559,122,o),
+(515,82,o),
+(419,82,cs),
+(78,82,l),
+(78,0,l)
+);
+}
+);
+width = 733;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F2;
+unicode = 5618;
+},
+{
+color = 9;
+glyphname = "giCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(436,0,ls),
+(583,0,o),
+(659,70,o),
+(659,193,cs),
+(659,278,o),
+(607,344,o),
+(526,369,c),
+(525,344,l),
+(609,367,o),
+(659,430,o),
+(659,519,cs),
+(659,642,o),
+(581,714,o),
+(436,714,cs),
+(78,714,l),
+(78,632,l),
+(419,632,ls),
+(515,632,o),
+(559,592,o),
+(559,516,cs),
+(559,439,o),
+(511,397,o),
+(424,397,cs),
+(375,397,l),
+(408,384,l),
+(397,419,o),
+(366,443,o),
+(328,443,cs),
+(296,443,o),
+(268,424,o),
+(255,397,c),
+(78,397,l),
+(78,318,l),
+(255,318,l),
+(268,291,o),
+(296,272,o),
+(329,272,cs),
+(366,272,o),
+(396,297,o),
+(408,331,c),
+(375,318,l),
+(425,318,ls),
+(511,318,o),
+(559,274,o),
+(559,197,cs),
+(559,122,o),
+(515,82,o),
+(419,82,cs),
+(78,82,l),
+(78,0,l)
+);
+}
+);
+width = 733;
+}
+);
+metricLeft = "geCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F3;
+unicode = 5619;
+},
+{
+color = 9;
+glyphname = "gaCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (383,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(655,0,l),
+(655,82,l),
+(314,82,ls),
+(218,82,o),
+(174,122,o),
+(174,197,cs),
+(174,274,o),
+(222,317,o),
+(311,317,cs),
+(655,317,l),
+(655,398,l),
+(312,398,ls),
+(222,398,o),
+(174,439,o),
+(174,516,cs),
+(174,592,o),
+(218,632,o),
+(314,632,cs),
+(655,632,l),
+(655,714,l),
+(297,714,ls),
+(152,714,o),
+(74,642,o),
+(74,519,cs),
+(74,429,o),
+(124,367,o),
+(208,342,c),
+(208,374,l),
+(126,346,o),
+(74,278,o),
+(74,193,cs),
+(74,70,o),
+(150,0,o),
+(297,0,cs)
+);
+}
+);
+width = 733;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|geCarrier-canadian";
+note = uni15F4;
+unicode = 5620;
+},
+{
+color = 9;
+glyphname = "khuCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(373,-13,o),
+(439,40,o),
+(466,138,c),
+(424,138,l),
+(455,38,o),
+(520,-13,o),
+(611,-13,cs),
+(738,-13,o),
+(813,75,o),
+(813,221,cs),
+(813.001,714,l),
+(73,714,l),
+(73,222,ls),
+(73,73,o),
+(152,-13,o),
+(278,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(211,75,o),
+(169,126,o),
+(169,222,cs),
+(169,628,l),
+(398,628,l),
+(398,221,ls),
+(398,126,o),
+(356,75,o),
+(284,75,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(535,75,o),
+(492,128,o),
+(492,221,cs),
+(492,628,l),
+(717,628,l),
+(717,222,ls),
+(717,127,o),
+(678,75,o),
+(606,75,cs)
+);
+}
+);
+width = 886;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F5;
+unicode = 5621;
+},
+{
+color = 9;
+glyphname = "khoCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(813.001,0,l),
+(813,492,ls),
+(813,639,o),
+(737,727,o),
+(611,727,cs),
+(519,727,o),
+(453,676,o),
+(423,576,c),
+(465,576,l),
+(437,674,o),
+(372,727,o),
+(277,727,cs),
+(152,727,o),
+(73,641,o),
+(73,492,cs),
+(73,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(169,492,ls),
+(169,588,o),
+(211,639,o),
+(284,639,cs),
+(355,639,o),
+(398,587,o),
+(398,493,cs),
+(398,86,l),
+(169,86,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(491,493,ls),
+(491,586,o),
+(534,639,o),
+(605,639,cs),
+(678,639,o),
+(717,587,o),
+(717,492,cs),
+(717,86,l),
+(491,86,l)
+);
+}
+);
+width = 886;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15F6;
+unicode = 5622;
+},
+{
+color = 9;
+glyphname = "kheCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,0,ls),
+(587,0,o),
+(663,70,o),
+(663,193,cs),
+(663,278,o),
+(611,345,o),
+(529,373,c),
+(529,341,l),
+(613,365,o),
+(663,429,o),
+(663,519,cs),
+(663,642,o),
+(586,714,o),
+(440,714,cs),
+(78,714,l),
+(78,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(178,318,l),
+(426,318,ls),
+(515,318,o),
+(564,274,o),
+(564,197,cs),
+(564,122,o),
+(519,81,o),
+(423,81,cs),
+(178,81,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(178,633,l),
+(423,633,ls),
+(519,633,o),
+(564,592,o),
+(564,516,cs),
+(564,439,o),
+(515,398,o),
+(425,398,cs),
+(178,398,l)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F7;
+unicode = 5623;
+},
+{
+color = 9;
+glyphname = "kheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,0,ls),
+(587,0,o),
+(663,70,o),
+(663,193,cs),
+(663,278,o),
+(611,345,o),
+(528,371,c),
+(528,342,l),
+(613,365,o),
+(663,429,o),
+(663,519,cs),
+(663,642,o),
+(586,714,o),
+(440,714,cs),
+(78,714,l),
+(78,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(178,319,l),
+(323,319,l),
+(323,230,l),
+(389,230,l),
+(389,341,l),
+(362,319,l),
+(429,319,ls),
+(517,319,o),
+(564,275,o),
+(564,198,cs),
+(564,122,o),
+(519,81,o),
+(423,81,cs),
+(178,81,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(389,485,l),
+(323,485,l),
+(323,397,l),
+(178,397,l),
+(178,633,l),
+(423,633,ls),
+(519,633,o),
+(564,592,o),
+(564,516,cs),
+(564,438,o),
+(516,397,o),
+(428,397,cs),
+(362,397,l),
+(389,374,l)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F8;
+unicode = 5624;
+},
+{
+color = 9;
+glyphname = "khiCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,0,ls),
+(587,0,o),
+(663,70,o),
+(663,193,cs),
+(663,278,o),
+(613,343,o),
+(532,371,c),
+(531,342,l),
+(614,366,o),
+(663,430,o),
+(663,519,cs),
+(663,642,o),
+(586,714,o),
+(440,714,cs),
+(78,714,l),
+(78,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(178,320,l),
+(280,320,l),
+(293,292,o),
+(321,272,o),
+(354,272,cs),
+(398,272,o),
+(432,306,o),
+(437,348,c),
+(383,320,l),
+(430,320,ls),
+(517,320,o),
+(564,276,o),
+(564,198,cs),
+(564,121,o),
+(519,81,o),
+(423,81,cs),
+(178,81,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(423,633,ls),
+(519,633,o),
+(564,592,o),
+(564,515,cs),
+(564,437,o),
+(516,395,o),
+(429,395,cs),
+(384,395,l),
+(438,366,l),
+(433,410,o),
+(398,443,o),
+(354,443,cs),
+(310,443,o),
+(275,410,o),
+(271,367,c),
+(305,395,l),
+(178,395,l),
+(178,633,l)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15F9;
+unicode = 5625;
+},
+{
+color = 9;
+glyphname = "khaCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(659,0,l),
+(659,714,l),
+(297,714,ls),
+(152,714,o),
+(74,642,o),
+(74,519,cs),
+(74,430,o),
+(123,367,o),
+(207,344,c),
+(205,372,l),
+(125,345,o),
+(74,278,o),
+(74,193,cs),
+(74,70,o),
+(150,0,o),
+(297,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(218,81,o),
+(174,122,o),
+(174,197,cs),
+(174,274,o),
+(222,318,o),
+(311,318,cs),
+(560,318,l),
+(560,81,l),
+(314,81,ls)
+);
+},
+{
+closed = 1;
+nodes = (
+(222,398,o),
+(174,439,o),
+(174,516,cs),
+(174,592,o),
+(218,633,o),
+(314,633,cs),
+(560,633,l),
+(560,398,l),
+(312,398,ls)
+);
+}
+);
+width = 737;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni15FA;
+unicode = 5626;
+},
+{
+color = 9;
+glyphname = "kkuCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(376,-13,o),
+(443,44,o),
+(467,148,c),
+(422,148,l),
+(450,42,o),
+(517,-13,o),
+(611,-13,cs),
+(738,-13,o),
+(813,75,o),
+(813,221,cs),
+(813.001,714,l),
+(777,714,l),
+(475,548,l),
+(475,455,l),
+(782,621,l),
+(717,627,l),
+(717,222,ls),
+(717,127,o),
+(678,75,o),
+(606,75,cs),
+(535,75,o),
+(492,128,o),
+(492,221,cs),
+(492,714,l),
+(398,714,l),
+(398,221,ls),
+(398,126,o),
+(356,75,o),
+(284,75,cs),
+(211,75,o),
+(169,126,o),
+(169,222,cs),
+(169,627,l),
+(105,621,l),
+(412,455,l),
+(412,548,l),
+(110,714,l),
+(73,714,l),
+(73,222,ls),
+(73,73,o),
+(152,-13,o),
+(278,-13,cs)
+);
+}
+);
+width = 886;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FB;
+unicode = 5627;
+},
+{
+color = 9;
+glyphname = "kkoCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(109,0,l),
+(412,166,l),
+(412,259,l),
+(104,93,l),
+(169,87,l),
+(169,492,ls),
+(169,587,o),
+(209,639,o),
+(281,639,cs),
+(352,639,o),
+(395,586,o),
+(395,493,cs),
+(395,0,l),
+(488,0,l),
+(488,493,ls),
+(488,588,o),
+(531,639,o),
+(602,639,cs),
+(676,639,o),
+(717,588,o),
+(717,492,cs),
+(717,87,l),
+(781,93,l),
+(474,259,l),
+(474,166,l),
+(776,0,l),
+(813.001,0,l),
+(813,492,ls),
+(813,641,o),
+(734,727,o),
+(609,727,cs),
+(510,727,o),
+(443,670,o),
+(419,566,c),
+(465,566,l),
+(436,672,o),
+(369,727,o),
+(275,727,cs),
+(149,727,o),
+(73,639,o),
+(73,493,cs),
+(73,0,l)
+);
+}
+);
+width = 886;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni15FC;
+unicode = 5628;
+},
+{
+color = 9;
+glyphname = "kkeCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(455,0,ls),
+(602.006,0,o),
+(678,70,o),
+(678,193,cs),
+(678,278,o),
+(626,344,o),
+(547,371,c),
+(546,342,l),
+(629,366,o),
+(678,430,o),
+(678,519,cs),
+(678,642,o),
+(600,714,o),
+(455,714,cs),
+(74,714,l),
+(74,687,l),
+(183,398,l),
+(85,398,l),
+(85,317,l),
+(183,317,l),
+(74,27,l),
+(74,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(283,317,l),
+(441,317,ls),
+(530,317,o),
+(578,274,o),
+(578,197,cs),
+(578,122,o),
+(534,82,o),
+(438,82,cs),
+(151,82,l),
+(179,40,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(178,674,l),
+(149,632,l),
+(438,632,ls),
+(534,632,o),
+(578,592,o),
+(578,516,cs),
+(578,439,o),
+(529,398,o),
+(440,398,cs),
+(282,398,l)
+);
+}
+);
+width = 752;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni15FD;
+unicode = 5629;
+},
+{
+color = 9;
+glyphname = "kkeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(455,0,ls),
+(602.006,0,o),
+(678,70,o),
+(678,193,cs),
+(678,278,o),
+(626,344,o),
+(547,371,c),
+(546,342,l),
+(629,366,o),
+(678,430,o),
+(678,519,cs),
+(678,642,o),
+(600,714,o),
+(455,714,cs),
+(74,714,l),
+(74,687,l),
+(183,398,l),
+(85,398,l),
+(85,317,l),
+(183,317,l),
+(74,27,l),
+(74,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(283,319,l),
+(359,319,l),
+(359,232,l),
+(425,232,l),
+(425,338,l),
+(400,319,l),
+(446,319,ls),
+(531,319,o),
+(578,276,o),
+(578,198,cs),
+(578,122,o),
+(534,82,o),
+(438,82,cs),
+(150,82,l),
+(179,40,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(425,483,l),
+(359,483,l),
+(359,396,l),
+(282,396,l),
+(177,674,l),
+(149,632,l),
+(438,632,ls),
+(534,632,o),
+(578,592,o),
+(578,515,cs),
+(578,437,o),
+(531,396,o),
+(446,396,cs),
+(400,396,l),
+(425,378,l)
+);
+}
+);
+width = 752;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FE;
+unicode = 5630;
+},
+{
+color = 9;
+glyphname = "kkiCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(455,0,ls),
+(602.006,0,o),
+(678,70,o),
+(678,193,cs),
+(678,278,o),
+(626,344,o),
+(547,371,c),
+(546,342,l),
+(629,366,o),
+(678,430,o),
+(678,519,cs),
+(678,642,o),
+(600,714,o),
+(455,714,cs),
+(74,714,l),
+(74,687,l),
+(183,398,l),
+(85,398,l),
+(85,317,l),
+(183,317,l),
+(74,27,l),
+(74,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(283,321,l),
+(315,321,l),
+(327,292,o),
+(355,272,o),
+(389,272,cs),
+(433,272,o),
+(466,307,o),
+(470,347,c),
+(420,321,l),
+(446,321,ls),
+(531,321,o),
+(578,276,o),
+(578,198,cs),
+(578,122,o),
+(534,82,o),
+(438,82,cs),
+(150,82,l),
+(179,40,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(467,410,o),
+(434,443,o),
+(389,443,cs),
+(355,443,o),
+(327,423,o),
+(315,395,c),
+(282,395,l),
+(177,674,l),
+(149,632,l),
+(438,632,ls),
+(534,632,o),
+(578,592,o),
+(578,514,cs),
+(578,437,o),
+(531,395,o),
+(446,395,cs),
+(421,395,l),
+(471,368,l)
+);
+}
+);
+width = 752;
+}
+);
+metricLeft = "kkeCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni15FF;
+unicode = 5631;
+},
+{
+color = 9;
+glyphname = "kkaCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(677,0,l),
+(677,27,l),
+(569,317,l),
+(659,317,l),
+(659,398,l),
+(569,398,l),
+(677,687,l),
+(677,714,l),
+(297,714,ls),
+(152,714,o),
+(74,642,o),
+(74,519,cs),
+(74,430,o),
+(123,367,o),
+(207,344,c),
+(205,372,l),
+(125,345,o),
+(74,278,o),
+(74,193,cs),
+(74,70,o),
+(150,0,o),
+(297,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(602,82,l),
+(314,82,ls),
+(218,82,o),
+(174,122,o),
+(174,197,cs),
+(174,274,o),
+(222,317,o),
+(311,317,cs),
+(469,317,l),
+(573,40,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(222,398,o),
+(174,439,o),
+(174,516,cs),
+(174,592,o),
+(218,632,o),
+(314,632,cs),
+(601,632,l),
+(573,674,l),
+(469,398,l),
+(312,398,ls)
+);
+}
+);
+width = 751;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|kkeCarrier-canadian";
+note = uni1600;
+unicode = 5632;
+},
+{
+color = 6;
+glyphname = "kkCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(229,189,l),
+(388,531,l),
+(388,546,l),
+(320,546,l),
+(192,261,l),
+(246,261,l),
+(119,546,l),
+(50,546,l),
+(50,531,l),
+(209,189,l)
+);
+}
+);
+width = 438;
+}
+);
+note = uni1601;
+unicode = 5633;
+},
+{
+color = 9;
+glyphname = "nuCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(561,-13,o),
+(667,97,o),
+(667,280,cs),
+(667,314,l),
+(568,314,l),
+(568,276,ls),
+(568,145,o),
+(496,77,o),
+(376,77,cs),
+(238,77,o),
+(170,153,o),
+(170,310,cs),
+(170,714,l),
+(71,714,l),
+(71,305,ls),
+(71,98,o),
+(180,-13,o),
+(374,-13,cs)
+);
+}
+);
+width = 732;
+}
+);
+metricLeft = "te-canadian";
+note = uni1602;
+unicode = 5634;
+},
+{
+color = 9;
+glyphname = "noCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(662,0,l),
+(662,409,ls),
+(662,616,o),
+(553,727,o),
+(358,727,cs),
+(172,727,o),
+(65,617,o),
+(65,434,cs),
+(65,400,l),
+(164,400,l),
+(164,438,ls),
+(164,569,o),
+(237,637,o),
+(357,637,cs),
+(494,637,o),
+(562,561,o),
+(562,404,cs),
+(562,0,l)
+);
+}
+);
+width = 733;
+}
+);
+metricLeft = "=|nuCarrier-canadian";
+metricRight = "te-canadian";
+note = uni1603;
+unicode = 5635;
+},
+{
+color = 9;
+glyphname = "neCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (327,356);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(321,0,ls),
+(536,0,o),
+(661,133,o),
+(661,358,cs),
+(661,583,o),
+(537,714,o),
+(316,714,cs),
+(53,714,l),
+(53,624,l),
+(314,624,ls),
+(474,624,o),
+(562,530,o),
+(562,357,cs),
+(562,185,o),
+(474,89,o),
+(317,89,cs),
+(296,89,l),
+(296,0,l)
+);
+}
+);
+width = 725;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1604;
+unicode = 5636;
+},
+{
+color = 9;
+glyphname = "neeCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+ref = "neCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (277,-1);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 725;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1605;
+unicode = 5637;
+},
+{
+color = 9;
+glyphname = "niCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "neCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (250,-1);
+ref = dot_middle;
+}
+);
+width = 725;
+}
+);
+note = uni1606;
+unicode = 5638;
+},
+{
+color = 9;
+glyphname = "naCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(672,0,l),
+(672,90,l),
+(410,90,ls),
+(250,90,o),
+(163,185,o),
+(163,357,cs),
+(163,530,o),
+(251,625,o),
+(407,625,cs),
+(429,625,l),
+(429,714,l),
+(403,714,ls),
+(188,714,o),
+(64,582,o),
+(64,357,cs),
+(64,132,o),
+(188,0,o),
+(406,0,cs)
+);
+}
+);
+width = 725;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni1607;
+unicode = 5639;
+},
+{
+color = 9;
+glyphname = "muCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(373,-13,o),
+(439,40,o),
+(466,138,c),
+(424,138,l),
+(455,38,o),
+(520,-13,o),
+(611,-13,cs),
+(738,-13,o),
+(813,75,o),
+(813,221,cs),
+(813,404,l),
+(717,404,l),
+(717,222,ls),
+(717,127,o),
+(678,75,o),
+(606,75,cs),
+(535,75,o),
+(492,128,o),
+(492,221,cs),
+(492,404,l),
+(398,404,l),
+(398,221,ls),
+(398,126,o),
+(356,75,o),
+(284,75,cs),
+(211,75,o),
+(169,126,o),
+(169,222,cs),
+(169,714,l),
+(73,714,l),
+(73,222,ls),
+(73,73,o),
+(152,-13,o),
+(278,-13,cs)
+);
+}
+);
+width = 886;
+}
+);
+metricLeft = "guCarrier-canadian";
+metricRight = "=|";
+note = uni1608;
+unicode = 5640;
+},
+{
+color = 9;
+glyphname = "moCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(813.001,0,l),
+(813,492,ls),
+(813,640,o),
+(734,727,o),
+(610,727,cs),
+(516,727,o),
+(450,674,o),
+(423,576,c),
+(465,576,l),
+(434,676,o),
+(369,727,o),
+(276,727,cs),
+(149,727,o),
+(73,640,o),
+(73,493,cs),
+(73,310,l),
+(169,310,l),
+(169,492,ls),
+(169,587,o),
+(209,639,o),
+(282,639,cs),
+(353,639,o),
+(396,586,o),
+(396,493,cs),
+(396,310,l),
+(490,310,l),
+(490,493,ls),
+(490,586,o),
+(533,639,o),
+(603,639,cs),
+(676,639,o),
+(717,587,o),
+(717,492,cs),
+(717,0,l)
+);
+}
+);
+width = 886;
+}
+);
+metricLeft = "=|muCarrier-canadian";
+metricRight = "guCarrier-canadian";
+note = uni1609;
+unicode = 5641;
+},
+{
+color = 9;
+glyphname = "meCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(438,0,ls),
+(585,0,o),
+(661,70,o),
+(661,193,cs),
+(661,278,o),
+(609,345,o),
+(526,373,c),
+(526,341,l),
+(611,365,o),
+(661,429,o),
+(661,519,cs),
+(661,642,o),
+(583,714,o),
+(438,714,cs),
+(53,714,l),
+(53,632,l),
+(421,632,ls),
+(517,632,o),
+(561,592,o),
+(561,516,cs),
+(561,439,o),
+(512,398,o),
+(423,398,cs),
+(296,398,l),
+(296,317,l),
+(424,317,ls),
+(513,317,o),
+(561,274,o),
+(561,197,cs),
+(561,122,o),
+(517,82,o),
+(421,82,cs),
+(296,82,l),
+(296,0,l)
+);
+}
+);
+width = 735;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160A;
+unicode = 5642;
+},
+{
+color = 9;
+glyphname = "meeCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(438,0,ls),
+(585,0,o),
+(661,70,o),
+(661,193,cs),
+(661,278,o),
+(609,344,o),
+(530,371,c),
+(528,342,l),
+(612,366,o),
+(661,430,o),
+(661,519,cs),
+(661,642,o),
+(583,714,o),
+(438,714,cs),
+(53,714,l),
+(53,632,l),
+(421,632,ls),
+(517,632,o),
+(561,592,o),
+(561,515,cs),
+(561,437,o),
+(513,396,o),
+(425,396,cs),
+(363,396,l),
+(363,481,l),
+(296,481,l),
+(296,234,l),
+(363,234,l),
+(363,319,l),
+(426,319,ls),
+(514,319,o),
+(561,276,o),
+(561,198,cs),
+(561,122,o),
+(517,82,o),
+(421,82,cs),
+(296,82,l),
+(296,0,l)
+);
+}
+);
+width = 735;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160B;
+unicode = 5643;
+},
+{
+color = 9;
+glyphname = "miCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(438,0,ls),
+(585,0,o),
+(661,70,o),
+(661,193,cs),
+(661,278,o),
+(609,344,o),
+(530,371,c),
+(528,342,l),
+(612,366,o),
+(661,430,o),
+(661,519,cs),
+(661,642,o),
+(583,714,o),
+(438,714,cs),
+(53,714,l),
+(53,632,l),
+(421,632,ls),
+(517,632,o),
+(561,592,o),
+(561,515,cs),
+(561,437,o),
+(513,396,o),
+(430,396,cs),
+(359,396,l),
+(413,368,l),
+(408,411,o),
+(373,443,o),
+(329,443,cs),
+(281,443,o),
+(245,405,o),
+(245,358,cs),
+(245,311,o),
+(282,272,o),
+(329,272,cs),
+(373,272,o),
+(407,306,o),
+(412,347,c),
+(358,319,l),
+(430,319,ls),
+(514,319,o),
+(561,276,o),
+(561,198,cs),
+(561,122,o),
+(517,82,o),
+(421,82,cs),
+(296,82,l),
+(296,0,l)
+);
+}
+);
+width = 735;
+}
+);
+metricLeft = "neCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni160C;
+unicode = 5644;
+},
+{
+color = 9;
+glyphname = "maCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(682,0,l),
+(682,82,l),
+(314,82,ls),
+(218,82,o),
+(174,121,o),
+(174,197,cs),
+(174,274,o),
+(222,317,o),
+(311,317,cs),
+(439,317,l),
+(439,398,l),
+(312,398,ls),
+(223,398,o),
+(174,439,o),
+(174,516,cs),
+(174,592,o),
+(218,632,o),
+(314,632,cs),
+(439,632,l),
+(439,714,l),
+(297,714,ls),
+(151,714,o),
+(74,642,o),
+(74,520,cs),
+(74,430,o),
+(125,367,o),
+(208,343,c),
+(208,374,l),
+(125,347,o),
+(74,280,o),
+(74,193,cs),
+(74,71,o),
+(150,0,o),
+(297,0,cs)
+);
+}
+);
+width = 735;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|neCarrier-canadian";
+note = uni160D;
+unicode = 5645;
+},
+{
+color = 9;
+glyphname = "yuCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(591,-13,o),
+(710,131,o),
+(710,403,cs),
+(710,622,o),
+(632,727,o),
+(506,727,cs),
+(399,727,o),
+(324,649,o),
+(324,519,cs),
+(324,393,o),
+(395,315,o),
+(502,315,cs),
+(517,315,o),
+(536,318,o),
+(548,322,c),
+(548,401,l),
+(539,399,o),
+(529,397,o),
+(512,397,cs),
+(445,397,o),
+(412,441,o),
+(412,522,cs),
+(412,600,o),
+(445,645,o),
+(503,645,cs),
+(575,645,o),
+(615,582,o),
+(615,406,cs),
+(615,171,o),
+(531,77,o),
+(387,77,cs),
+(250,77,o),
+(170,157,o),
+(170,325,cs),
+(170,714,l),
+(71,714,l),
+(71,320,ls),
+(71,104,o),
+(194,-13,o),
+(383,-13,cs)
+);
+}
+);
+width = 781;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160E;
+unicode = 5646;
+},
+{
+color = 9;
+glyphname = "yoCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(382,-13,o),
+(457,65,o),
+(457,195,cs),
+(457,321,o),
+(386,399,o),
+(279,399,cs),
+(264,399,o),
+(245,396,o),
+(233,392,c),
+(233,313,l),
+(242,315,o),
+(252,317,o),
+(269,317,cs),
+(336,317,o),
+(369,273,o),
+(369,192,cs),
+(369,114,o),
+(336,69,o),
+(278,69,cs),
+(206,69,o),
+(166,132,o),
+(166,308,cs),
+(166,543,o),
+(250,637,o),
+(394,637,cs),
+(531,637,o),
+(611,557,o),
+(611,389,cs),
+(611,0,l),
+(710,0,l),
+(710,394,ls),
+(710,610,o),
+(587,727,o),
+(398,727,cs),
+(190,727,o),
+(71,583,o),
+(71,311,cs),
+(71,92,o),
+(149,-13,o),
+(275,-13,cs)
+);
+}
+);
+width = 781;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "te-canadian";
+note = uni160F;
+unicode = 5647;
+},
+{
+color = 9;
+glyphname = "yeCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(541,-13,o),
+(661,131,o),
+(661,354,cs),
+(661,585,o),
+(534,714,o),
+(299,714,cs),
+(80,714,l),
+(80,624,l),
+(303,624,ls),
+(476,624,o),
+(562,531,o),
+(562,351,cs),
+(562,174,o),
+(490,72,o),
+(330,72,cs),
+(203,72,o),
+(152,137,o),
+(152,220,cs),
+(152,299,o),
+(188,342,o),
+(244,342,cs),
+(302,342,o),
+(335,297,o),
+(335,224,cs),
+(335,197,o),
+(333,181,o),
+(330,164,c),
+(410,164,l),
+(415,188,o),
+(417,204,o),
+(417,232,cs),
+(417,343,o),
+(353,422,o),
+(245,422,cs),
+(135,422,o),
+(64,341,o),
+(64,219,cs),
+(64,91,o),
+(155,-13,o),
+(330,-13,cs)
+);
+}
+);
+width = 725;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1610;
+unicode = 5648;
+},
+{
+color = 9;
+glyphname = "yeeCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(541,-13,o),
+(661,131,o),
+(661,354,cs),
+(661,585,o),
+(534,714,o),
+(299,714,cs),
+(80,714,l),
+(80,624,l),
+(303,624,ls),
+(476,624,o),
+(562,531,o),
+(562,351,cs),
+(562,174,o),
+(490,72,o),
+(330,72,cs),
+(203,72,o),
+(152,135,o),
+(152,225,cs),
+(152,298,o),
+(187,342,o),
+(238,342,cs),
+(292,342,o),
+(324,300,o),
+(324,229,cs),
+(324,186,l),
+(383,186,l),
+(383,513,l),
+(324,513,l),
+(324,311,l),
+(336,311,l),
+(328,382,o),
+(285,422,o),
+(217,422,cs),
+(128,422,o),
+(64,343,o),
+(64,224,cs),
+(64,89,o),
+(154,-13,o),
+(330,-13,cs)
+);
+}
+);
+width = 725;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1611;
+unicode = 5649;
+},
+{
+color = 9;
+glyphname = "yiCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(541,-13,o),
+(661,131,o),
+(661,354,cs),
+(661,585,o),
+(534,714,o),
+(299,714,cs),
+(80,714,l),
+(80,624,l),
+(303,624,ls),
+(476,624,o),
+(562,531,o),
+(562,351,cs),
+(562,174,o),
+(490,72,o),
+(334,72,cs),
+(204,72,o),
+(152,134,o),
+(152,211,cs),
+(152,291,o),
+(194,329,o),
+(269,326,c),
+(225,351,l),
+(229,314,o),
+(260,283,o),
+(301,283,cs),
+(344,283,o),
+(375,317,o),
+(375,358,cs),
+(375,400,o),
+(343,431,o),
+(300,431,cs),
+(272,431,o),
+(249,417,o),
+(237,396,c),
+(128,390,o),
+(64,316,o),
+(64,206,cs),
+(64,87,o),
+(155,-13,o),
+(330,-13,cs)
+);
+}
+);
+width = 725;
+}
+);
+metricRight = "theCarrier-canadian";
+metricWidth = "yeCarrier-canadian";
+note = uni1612;
+unicode = 5650;
+},
+{
+color = 9;
+glyphname = "yaCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(644,0,l),
+(644,90,l),
+(422,90,ls),
+(248,90,o),
+(163,183,o),
+(163,363,cs),
+(163,540,o),
+(235,642,o),
+(396,642,cs),
+(521,642,o),
+(573,577,o),
+(573,494,cs),
+(573,415,o),
+(536,372,o),
+(480,372,cs),
+(422,372,o),
+(390,417,o),
+(390,490,cs),
+(390,517,o),
+(392,533,o),
+(395,550,c),
+(315,550,l),
+(310,527,o),
+(308,510,o),
+(308,482,cs),
+(308,371,o),
+(372,292,o),
+(480,292,cs),
+(590,292,o),
+(660,373,o),
+(660,495,cs),
+(660,623,o),
+(570,727,o),
+(396,727,cs),
+(184,727,o),
+(64,583,o),
+(64,360,cs),
+(64,129,o),
+(191,0,o),
+(426,0,cs)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|yeCarrier-canadian";
+note = uni1613;
+unicode = 5651;
+},
+{
+color = 9;
+glyphname = "juCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(578,-13,o),
+(679,83,o),
+(679,228,cs),
+(679,341,o),
+(610,422,o),
+(500,422,cs),
+(393,422,o),
+(327,343,o),
+(327,232,cs),
+(327,204,o),
+(329,187,o),
+(334,164,c),
+(414,164,l),
+(411,181,o),
+(409,198,o),
+(409,224,cs),
+(409,297,o),
+(444,342,o),
+(500,342,cs),
+(557,342,o),
+(592,298,o),
+(592,229,cs),
+(592,130,o),
+(531,72,o),
+(406,72,cs),
+(252,72,o),
+(173,157,o),
+(173,317,cs),
+(173,529,o),
+(311,624,o),
+(549,624,cs),
+(663,624,l),
+(663,714,l),
+(66,714,l),
+(66,628,l),
+(390,628,l),
+(477,665,l),
+(219,665,o),
+(75,533,o),
+(75,313,cs),
+(75,114,o),
+(201,-13,o),
+(403,-13,cs)
+);
+}
+);
+width = 743;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni1614;
+unicode = 5652;
+},
+{
+color = 9;
+glyphname = "juSayisi-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (378,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(543,-13,o),
+(669,114,o),
+(669,313,cs),
+(669,533,o),
+(525,665,o),
+(267,665,c),
+(354,628,l),
+(678,628,l),
+(678,714,l),
+(80,714,l),
+(80,624,l),
+(195,624,ls),
+(433,624,o),
+(570,529,o),
+(570,317,cs),
+(570,157,o),
+(491,72,o),
+(337,72,cs),
+(213,72,o),
+(152,130,o),
+(152,229,cs),
+(152,298,o),
+(187,342,o),
+(243,342,cs),
+(300,342,o),
+(335,297,o),
+(335,224,cs),
+(335,198,o),
+(333,181,o),
+(330,164,c),
+(410,164,l),
+(415,187,o),
+(417,204,o),
+(417,232,cs),
+(417,343,o),
+(350,422,o),
+(244,422,cs),
+(134,422,o),
+(64,341,o),
+(64,228,cs),
+(64,83,o),
+(165,-13,o),
+(341,-13,cs)
+);
+}
+);
+width = 744;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1615;
+unicode = 5653;
+},
+{
+color = 9;
+glyphname = "joCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(678,0,l),
+(678,86,l),
+(354,86,l),
+(267,49,l),
+(525,49,o),
+(669,181,o),
+(669,401,cs),
+(669,600,o),
+(543,727,o),
+(341,727,cs),
+(165,727,o),
+(64,631,o),
+(64,486,cs),
+(64,373,o),
+(134,292,o),
+(244,292,cs),
+(350,292,o),
+(417,371,o),
+(417,482,cs),
+(417,510,o),
+(415,527,o),
+(410,550,c),
+(330,550,l),
+(333,533,o),
+(335,516,o),
+(335,490,cs),
+(335,417,o),
+(300,372,o),
+(243,372,cs),
+(187,372,o),
+(152,416,o),
+(152,485,cs),
+(152,584,o),
+(213,642,o),
+(337,642,cs),
+(491,642,o),
+(570,557,o),
+(570,397,cs),
+(570,185,o),
+(433,90,o),
+(195,90,cs),
+(80,90,l),
+(80,0,l)
+);
+}
+);
+width = 744;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|juCarrier-canadian";
+note = uni1616;
+unicode = 5654;
+},
+{
+color = 9;
+glyphname = "jeCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(640,-13,o),
+(718,92,o),
+(718,311,cs),
+(718,586,o),
+(598,727,o),
+(421,727,cs),
+(259,727,o),
+(163,619,o),
+(155,406,c),
+(177,426,l),
+(177,714,l),
+(78,714,l),
+(78,0,l),
+(178,0,l),
+(178,278,ls),
+(178,529,o),
+(257,637,o),
+(407,637,cs),
+(539,637,o),
+(622,539,o),
+(622,309,cs),
+(622,132,o),
+(583,69,o),
+(512,69,cs),
+(454,69,o),
+(420,114,o),
+(420,192,cs),
+(420,273,o),
+(453,317,o),
+(521,317,cs),
+(536,317,o),
+(547,315,o),
+(556,313,c),
+(556,392,l),
+(543,396,o),
+(525,399,o),
+(510,399,cs),
+(403,399,o),
+(332,321,o),
+(332,195,cs),
+(332,65,o),
+(407,-13,o),
+(514,-13,cs)
+);
+}
+);
+width = 789;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "te-canadian";
+note = uni1617;
+unicode = 5655;
+},
+{
+color = 9;
+glyphname = "jeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(640,-13,o),
+(718,92,o),
+(718,311,cs),
+(718,586,o),
+(598,727,o),
+(421,727,cs),
+(288,727,o),
+(197,656,o),
+(165,512,c),
+(177,499,l),
+(177,714,l),
+(78,714,l),
+(78,0,l),
+(178,0,l),
+(178,278,ls),
+(178,529,o),
+(257,637,o),
+(407,637,cs),
+(539,637,o),
+(622,539,o),
+(622,309,cs),
+(622,142,o),
+(582,69,o),
+(497,69,cs),
+(428,69,o),
+(390,119,o),
+(390,201,cs),
+(390,274,o),
+(417,314,o),
+(464,329,c),
+(464,240,l),
+(519,240,l),
+(519,473,l),
+(464,473,l),
+(464,388,l),
+(387,370,o),
+(332,304,o),
+(332,191,cs),
+(332,64,o),
+(404,-13,o),
+(511,-13,cs)
+);
+}
+);
+width = 789;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1618;
+unicode = 5656;
+},
+{
+color = 9;
+glyphname = "jiCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(640,-13,o),
+(718,92,o),
+(718,311,cs),
+(718,586,o),
+(598,727,o),
+(421,727,cs),
+(288,727,o),
+(197,656,o),
+(165,512,c),
+(177,499,l),
+(177,714,l),
+(78,714,l),
+(78,0,l),
+(178,0,l),
+(178,278,ls),
+(178,529,o),
+(257,637,o),
+(407,637,cs),
+(539,637,o),
+(622,539,o),
+(622,309,cs),
+(622,142,o),
+(582,69,o),
+(497,69,cs),
+(428,69,o),
+(390,119,o),
+(390,201,cs),
+(390,252,o),
+(404,283,o),
+(429,301,c),
+(438,290,o),
+(452,283,o),
+(467,283,cs),
+(510,283,o),
+(540,317,o),
+(540,358,cs),
+(540,399,o),
+(509,431,o),
+(467,431,cs),
+(419,431,o),
+(389,389,o),
+(395,347,c),
+(357,317,o),
+(332,266,o),
+(332,191,cs),
+(332,64,o),
+(404,-13,o),
+(511,-13,cs)
+);
+}
+);
+width = 789;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1619;
+unicode = 5657;
+},
+{
+color = 9;
+glyphname = "jiSayisi-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(598,-13,o),
+(718,128,o),
+(718,403,cs),
+(718,622,o),
+(640,727,o),
+(514,727,cs),
+(407,727,o),
+(332,649,o),
+(332,519,cs),
+(332,393,o),
+(403,315,o),
+(510,315,cs),
+(525,315,o),
+(543,318,o),
+(556,322,c),
+(556,401,l),
+(547,399,o),
+(536,397,o),
+(521,397,cs),
+(453,397,o),
+(420,441,o),
+(420,522,cs),
+(420,600,o),
+(453,645,o),
+(510,645,cs),
+(583,645,o),
+(622,582,o),
+(622,405,cs),
+(622,175,o),
+(539,77,o),
+(407,77,cs),
+(257,77,o),
+(178,185,o),
+(178,436,cs),
+(178,714,l),
+(78,714,l),
+(78,0,l),
+(177,0,l),
+(177,288,l),
+(155,308,l),
+(163,95,o),
+(259,-13,o),
+(421,-13,cs)
+);
+}
+);
+width = 789;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161A;
+unicode = 5658;
+},
+{
+color = 9;
+glyphname = "jaCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (387,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(530,-13,o),
+(626,95,o),
+(634,308,c),
+(612,288,l),
+(612,0,l),
+(710,0,l),
+(710,714,l),
+(611,714,l),
+(611,436,ls),
+(611,185,o),
+(531,77,o),
+(382,77,cs),
+(250,77,o),
+(166,175,o),
+(166,405,cs),
+(166,582,o),
+(206,645,o),
+(278,645,cs),
+(336,645,o),
+(369,600,o),
+(369,522,cs),
+(369,441,o),
+(336,397,o),
+(268,397,cs),
+(253,397,o),
+(242,399,o),
+(233,401,c),
+(233,322,l),
+(245,318,o),
+(264,315,o),
+(278,315,cs),
+(386,315,o),
+(457,393,o),
+(457,519,cs),
+(457,649,o),
+(382,727,o),
+(275,727,cs),
+(149,727,o),
+(71,622,o),
+(71,403,cs),
+(71,128,o),
+(191,-13,o),
+(368,-13,cs)
+);
+}
+);
+width = 788;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni161B;
+unicode = 5659;
+},
+{
+color = 9;
+glyphname = "jjuCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(575,-13,o),
+(667,91,o),
+(667,219,cs),
+(667,341,o),
+(596,422,o),
+(486,422,cs),
+(377,422,o),
+(312,343,o),
+(312,232,cs),
+(312,204,o),
+(314,187,o),
+(320,164,c),
+(400,164,l),
+(397,181,o),
+(394,199,o),
+(394,224,cs),
+(394,297,o),
+(427,342,o),
+(485,342,cs),
+(540,342,o),
+(577,298,o),
+(577,221,cs),
+(577,137,o),
+(521,71,o),
+(400,71,cs),
+(241,71,o),
+(169,169,o),
+(169,324,cs),
+(169,517,o),
+(280,624,o),
+(503,624,cs),
+(651,624,l),
+(651,714,l),
+(498,714,ls),
+(367,714,o),
+(264,679,o),
+(194,616,c),
+(83,727,l),
+(18,663,l),
+(132,549,l),
+(91,490,o),
+(70,414,o),
+(70,327,cs),
+(70,126,o),
+(189,-13,o),
+(399,-13,cs)
+);
+}
+);
+width = 731;
+}
+);
+metricRight = "=|yeCarrier-canadian";
+note = uni161C;
+unicode = 5660;
+},
+{
+color = 9;
+glyphname = "jjoCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(713,51,l),
+(599,165,l),
+(640,224,o),
+(661,300,o),
+(661,387,cs),
+(661,588,o),
+(542,727,o),
+(335,727,cs),
+(159,727,o),
+(64,623,o),
+(64,494,cs),
+(64,373,o),
+(134,292,o),
+(245,292,cs),
+(354,292,o),
+(419,371,o),
+(419,482,cs),
+(419,510,o),
+(417,527,o),
+(411,550,c),
+(331,550,l),
+(334,533,o),
+(336,515,o),
+(336,490,cs),
+(336,417,o),
+(304,372,o),
+(246,372,cs),
+(190,372,o),
+(154,416,o),
+(154,493,cs),
+(154,577,o),
+(207,643,o),
+(334,643,cs),
+(490,643,o),
+(562,545,o),
+(562,390,cs),
+(562,197,o),
+(451,90,o),
+(227,90,cs),
+(80,90,l),
+(80,0,l),
+(233,0,ls),
+(364,0,o),
+(467,35,o),
+(537,98,c),
+(648,-13,l)
+);
+}
+);
+width = 731;
+}
+);
+metricLeft = "yeCarrier-canadian";
+metricRight = "=|jjuCarrier-canadian";
+note = uni161D;
+unicode = 5661;
+},
+{
+color = 9;
+glyphname = "jjeCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(648,-13,o),
+(726,92,o),
+(726,311,cs),
+(726,583,o),
+(611,727,o),
+(407,727,cs),
+(316,727,o),
+(240,695,o),
+(184,634,c),
+(89,727,l),
+(26,661,l),
+(132,557,l),
+(102,500,o),
+(86,427,o),
+(86,340,cs),
+(86,0,l),
+(186,0,l),
+(186,338,ls),
+(186,537,o),
+(265,637,o),
+(407,637,cs),
+(546,637,o),
+(630,543,o),
+(630,308,cs),
+(630,132,o),
+(591,69,o),
+(519,69,cs),
+(461,69,o),
+(427,114,o),
+(427,192,cs),
+(427,273,o),
+(461,317,o),
+(528,317,cs),
+(544,317,o),
+(555,315,o),
+(564,313,c),
+(564,392,l),
+(551,396,o),
+(533,399,o),
+(518,399,cs),
+(411,399,o),
+(340,321,o),
+(340,195,cs),
+(340,65,o),
+(415,-13,o),
+(522,-13,cs)
+);
+}
+);
+width = 797;
+}
+);
+metricRight = "jeCarrier-canadian";
+note = uni161E;
+unicode = 5662;
+},
+{
+color = 9;
+glyphname = "jjeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(648,-13,o),
+(726,92,o),
+(726,311,cs),
+(726,583,o),
+(611,727,o),
+(407,727,cs),
+(316,727,o),
+(240,695,o),
+(184,634,c),
+(89,727,l),
+(26,661,l),
+(132,557,l),
+(102,500,o),
+(86,427,o),
+(86,340,cs),
+(86,0,l),
+(186,0,l),
+(186,338,ls),
+(186,537,o),
+(265,637,o),
+(407,637,cs),
+(546,637,o),
+(630,543,o),
+(630,308,cs),
+(630,142,o),
+(590,69,o),
+(504,69,cs),
+(435,69,o),
+(398,119,o),
+(398,201,cs),
+(398,273,o),
+(425,313,o),
+(468,327,c),
+(468,240,l),
+(523,240,l),
+(523,472,l),
+(468,472,l),
+(468,387,l),
+(393,370,o),
+(340,302,o),
+(340,191,cs),
+(340,64,o),
+(412,-13,o),
+(518,-13,cs)
+);
+}
+);
+width = 797;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni161F;
+unicode = 5663;
+},
+{
+color = 9;
+glyphname = "jjiCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(648,-13,o),
+(726,92,o),
+(726,311,cs),
+(726,583,o),
+(611,727,o),
+(407,727,cs),
+(316,727,o),
+(240,695,o),
+(184,634,c),
+(89,727,l),
+(26,661,l),
+(132,557,l),
+(102,500,o),
+(86,427,o),
+(86,340,cs),
+(86,0,l),
+(186,0,l),
+(186,338,ls),
+(186,537,o),
+(265,637,o),
+(407,637,cs),
+(546,637,o),
+(630,543,o),
+(630,308,cs),
+(630,142,o),
+(590,69,o),
+(504,69,cs),
+(435,69,o),
+(398,119,o),
+(398,201,cs),
+(398,255,o),
+(414,288,o),
+(441,304,c),
+(451,292,o),
+(467,283,o),
+(485,283,cs),
+(528,283,o),
+(558,317,o),
+(558,358,cs),
+(558,399,o),
+(527,431,o),
+(485,431,cs),
+(441,431,o),
+(411,395,o),
+(413,356,c),
+(368,327,o),
+(340,272,o),
+(340,191,cs),
+(340,64,o),
+(412,-13,o),
+(518,-13,cs)
+);
+}
+);
+width = 797;
+}
+);
+metricLeft = "jjeCarrier-canadian";
+metricRight = "jeCarrier-canadian";
+note = uni1620;
+unicode = 5664;
+},
+{
+color = 9;
+glyphname = "jjaCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(480,-13,o),
+(557,19,o),
+(612,80,c),
+(707,-13,l),
+(771,53,l),
+(665,157,l),
+(694,214,o),
+(710,287,o),
+(710,374,cs),
+(710,714,l),
+(611,714,l),
+(611,376,ls),
+(611,177,o),
+(531,77,o),
+(390,77,cs),
+(250,77,o),
+(166,171,o),
+(166,406,cs),
+(166,582,o),
+(206,645,o),
+(278,645,cs),
+(336,645,o),
+(369,600,o),
+(369,522,cs),
+(369,441,o),
+(336,397,o),
+(269,397,cs),
+(253,397,o),
+(242,399,o),
+(233,401,c),
+(233,322,l),
+(245,318,o),
+(264,315,o),
+(279,315,cs),
+(386,315,o),
+(457,393,o),
+(457,519,cs),
+(457,649,o),
+(382,727,o),
+(275,727,cs),
+(149,727,o),
+(71,622,o),
+(71,403,cs),
+(71,131,o),
+(185,-13,o),
+(389,-13,cs)
+);
+}
+);
+width = 797;
+}
+);
+metricLeft = "=|jeCarrier-canadian";
+metricRight = "=|jjeCarrier-canadian";
+note = uni1621;
+unicode = 5665;
+},
+{
+color = 9;
+glyphname = "luCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(557,-13,o),
+(669,98,o),
+(669,304,cs),
+(669,714,l),
+(569,714,l),
+(569,303,ls),
+(569,150,o),
+(496,77,o),
+(378,77,cs),
+(242,77,o),
+(171,170,o),
+(171,336,cs),
+(171,521,o),
+(248,625,o),
+(400,634,c),
+(400,714,l),
+(63,714,l),
+(63,631,l),
+(283,631,l),
+(351,666,l),
+(179,650,o),
+(72,542,o),
+(72,322,cs),
+(72,115,o),
+(182,-13,o),
+(374,-13,cs)
+);
+}
+);
+width = 740;
+}
+);
+metricRight = "te-canadian";
+note = uni1622;
+unicode = 5666;
+},
+{
+color = 9;
+glyphname = "loCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(170,0,l),
+(170,411,ls),
+(170,564,o),
+(243,637,o),
+(365,637,cs),
+(497,637,o),
+(568,544,o),
+(568,378,cs),
+(568,193,o),
+(492,89,o),
+(339,80,c),
+(339,0,l),
+(676,0,l),
+(676,83,l),
+(456,83,l),
+(388,48,l),
+(560,64,o),
+(667,172,o),
+(667,392,cs),
+(667,599,o),
+(557,727,o),
+(365,727,cs),
+(182,727,o),
+(71,616,o),
+(71,410,cs),
+(71,0,l)
+);
+}
+);
+width = 739;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|luCarrier-canadian";
+note = uni1623;
+unicode = 5667;
+},
+{
+color = 9;
+glyphname = "leCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (357,360);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(307,0,ls),
+(532,0,o),
+(655,132,o),
+(655,370,cs),
+(655,599,o),
+(539,727,o),
+(380,727,cs),
+(257,727,o),
+(175,649,o),
+(154,541,c),
+(163,541,l),
+(163,714,l),
+(74,714,l),
+(74,395,l),
+(158,395,l),
+(164,544,o),
+(238,637,o),
+(357,637,cs),
+(475,637,o),
+(556,548,o),
+(556,368,cs),
+(556,185,o),
+(471,90,o),
+(305,90,cs),
+(74,90,l),
+(74,0,l)
+);
+}
+);
+width = 719;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1624;
+unicode = 5668;
+},
+{
+color = 9;
+glyphname = "leeCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+ref = "leCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (307,3);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 719;
+}
+);
+metricLeft = "leCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1625;
+unicode = 5669;
+},
+{
+color = 9;
+glyphname = "liCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "leCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (281,3);
+ref = dot_middle;
+}
+);
+width = 719;
+}
+);
+note = uni1626;
+unicode = 5670;
+},
+{
+color = 9;
+glyphname = "laCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(644,0,l),
+(644,90,l),
+(413,90,ls),
+(247,90,o),
+(163,185,o),
+(163,368,cs),
+(163,548,o),
+(244,637,o),
+(363,637,cs),
+(481,637,o),
+(554,544,o),
+(560,395,c),
+(644,395,l),
+(644,714,l),
+(555,714,l),
+(555,541,l),
+(564,541,l),
+(543,649,o),
+(463,727,o),
+(340,727,cs),
+(180,727,o),
+(64,599,o),
+(64,370,cs),
+(64,132,o),
+(187,0,o),
+(411,0,cs)
+);
+}
+);
+width = 718;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|leCarrier-canadian";
+note = uni1627;
+unicode = 5671;
+},
+{
+color = 1;
+glyphname = "dluCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(557,-13,o),
+(667,115,o),
+(667,322,cs),
+(667,509,o),
+(591,613,o),
+(472,650,c),
+(454,638,l),
+(661,638,l),
+(661,554,l),
+(735,554,l),
+(735,798,l),
+(661,798,l),
+(661,714,l),
+(339,714,l),
+(339,633,l),
+(492,625,o),
+(568,521,o),
+(568,336,cs),
+(568,170,o),
+(497,77,o),
+(368,77,cs),
+(243,77,o),
+(170,152,o),
+(170,305,cs),
+(170,714,l),
+(71,714,l),
+(71,306,ls),
+(71,100,o),
+(182,-13,o),
+(367,-13,cs)
+);
+}
+);
+width = 787;
+}
+);
+metricLeft = "te-canadian";
+note = uni1628;
+unicode = 5672;
+},
+{
+color = 9;
+glyphname = "dloCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(735,-84,l),
+(735,160,l),
+(661,160,l),
+(661,76,l),
+(454,76,l),
+(472,64,l),
+(591,101,o),
+(667,205,o),
+(667,392,cs),
+(667,599,o),
+(557,727,o),
+(370,727,cs),
+(179,727,o),
+(71,614,o),
+(71,408,cs),
+(71,0,l),
+(170,0,l),
+(170,409,ls),
+(170,562,o),
+(243,637,o),
+(368,637,cs),
+(497,637,o),
+(568,544,o),
+(568,378,cs),
+(568,193,o),
+(492,89,o),
+(339,81,c),
+(339,0,l),
+(661,0,l),
+(661,-84,l)
+);
+}
+);
+width = 787;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "dluCarrier-canadian";
+note = uni1629;
+unicode = 5673;
+},
+{
+color = 9;
+glyphname = "dleCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (369,360);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(319,0,ls),
+(544,0,o),
+(667,132,o),
+(667,370,cs),
+(667,599,o),
+(552,727,o),
+(392,727,cs),
+(273,727,o),
+(183,658,o),
+(148,528,c),
+(161,517,l),
+(161,724,l),
+(242,724,l),
+(242,796,l),
+(6,796,l),
+(6,724,l),
+(86,724,l),
+(86,395,l),
+(170,395,l),
+(176,544,o),
+(250,637,o),
+(369,637,cs),
+(488,637,o),
+(568,548,o),
+(568,368,cs),
+(568,185,o),
+(483,90,o),
+(317,90,cs),
+(86,90,l),
+(86,0,l)
+);
+}
+);
+width = 731;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni162A;
+unicode = 5674;
+},
+{
+color = 9;
+glyphname = "dleeCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (319,3);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 732;
+}
+);
+note = uni162B;
+unicode = 5675;
+},
+{
+color = 9;
+glyphname = "dliCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "dleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (293,3);
+ref = dot_middle;
+}
+);
+width = 732;
+}
+);
+note = uni162C;
+unicode = 5676;
+},
+{
+color = 9;
+glyphname = "dlaCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(644,0,l),
+(644,90,l),
+(413,90,ls),
+(249,90,o),
+(163,183,o),
+(163,368,cs),
+(163,548,o),
+(243,637,o),
+(362,637,cs),
+(480,637,o),
+(554,544,o),
+(560,395,c),
+(644,395,l),
+(644,724,l),
+(725,724,l),
+(725,796,l),
+(489,796,l),
+(489,724,l),
+(570,724,l),
+(570,517,l),
+(583,528,l),
+(548,658,o),
+(458,727,o),
+(339,727,cs),
+(179,727,o),
+(64,599,o),
+(64,370,cs),
+(64,130,o),
+(188,0,o),
+(411,0,cs)
+);
+}
+);
+width = 731;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni162D;
+unicode = 5677;
+},
+{
+color = 9;
+glyphname = "lhuCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(591,-13,o),
+(702,116,o),
+(702,327,cs),
+(702,534,o),
+(603,635,o),
+(471,664,c),
+(510,629,l),
+(711,629,l),
+(711,714,l),
+(447,714,l),
+(447,634,l),
+(531,602,o),
+(602,512,o),
+(602,342,cs),
+(602,167,o),
+(531,77,o),
+(387,77,cs),
+(243,77,o),
+(172,167,o),
+(172,342,cs),
+(172,512,o),
+(243,602,o),
+(327,634,c),
+(327,714,l),
+(63,714,l),
+(63,629,l),
+(263,629,l),
+(303,664,l),
+(171,635,o),
+(72,534,o),
+(72,327,cs),
+(72,116,o),
+(183,-13,o),
+(387,-13,cs)
+);
+}
+);
+width = 774;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162E;
+unicode = 5678;
+},
+{
+color = 9;
+glyphname = "lhoCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(327,0,l),
+(327,80,l),
+(243,112,o),
+(172,202,o),
+(172,372,cs),
+(172,547,o),
+(243,637,o),
+(387,637,cs),
+(531,637,o),
+(602,547,o),
+(602,372,cs),
+(602,202,o),
+(531,112,o),
+(447,80,c),
+(447,0,l),
+(711,0,l),
+(711,85,l),
+(511,85,l),
+(471,50,l),
+(603,79,o),
+(702,180,o),
+(702,387,cs),
+(702,598,o),
+(591,727,o),
+(387,727,cs),
+(183,727,o),
+(72,598,o),
+(72,387,cs),
+(72,180,o),
+(171,79,o),
+(303,50,c),
+(264,85,l),
+(63,85,l),
+(63,0,l)
+);
+}
+);
+width = 774;
+}
+);
+metricLeft = "luCarrier-canadian";
+metricRight = "=|";
+note = uni162F;
+unicode = 5679;
+},
+{
+color = 9;
+glyphname = "lheCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (374,357);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(564,-13,o),
+(684,115,o),
+(684,357,cs),
+(684,599,o),
+(564,727,o),
+(395,727,cs),
+(267,727,o),
+(185,650,o),
+(161,554,c),
+(168,553,l),
+(168,714,l),
+(78,714,l),
+(78,430,l),
+(162,430,l),
+(177,545,o),
+(247,637,o),
+(374,637,cs),
+(495,637,o),
+(585,549,o),
+(585,357,cs),
+(585,165,o),
+(499,77,o),
+(374,77,cs),
+(247,77,o),
+(177,169,o),
+(162,284,c),
+(78,284,l),
+(78,0,l),
+(168,0,l),
+(168,161,l),
+(161,160,l),
+(185,64,o),
+(267,-13,o),
+(395,-13,cs)
+);
+}
+);
+width = 748;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1630;
+unicode = 5680;
+},
+{
+color = 9;
+glyphname = "lheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (325,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 749;
+}
+);
+note = uni1631;
+unicode = 5681;
+},
+{
+color = 9;
+glyphname = "lhiCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "lheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (298,0);
+ref = dot_middle;
+}
+);
+width = 749;
+}
+);
+note = uni1632;
+unicode = 5682;
+},
+{
+color = 9;
+glyphname = "lhaCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(481,-13,o),
+(563,64,o),
+(587,160,c),
+(580,161,l),
+(580,0,l),
+(670,0,l),
+(670,284,l),
+(586,284,l),
+(571,169,o),
+(501,77,o),
+(374,77,cs),
+(253,77,o),
+(163,165,o),
+(163,357,cs),
+(163,549,o),
+(249,637,o),
+(374,637,cs),
+(501,637,o),
+(571,545,o),
+(586,430,c),
+(670,430,l),
+(670,714,l),
+(580,714,l),
+(580,553,l),
+(587,554,l),
+(563,650,o),
+(481,727,o),
+(353,727,cs),
+(184,727,o),
+(64,599,o),
+(64,357,cs),
+(64,115,o),
+(184,-13,o),
+(353,-13,cs)
+);
+}
+);
+width = 748;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni1633;
+unicode = 5683;
+},
+{
+color = 9;
+glyphname = "tlhuCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(591,-13,o),
+(702,116,o),
+(702,327,cs),
+(702,507,o),
+(626,607,o),
+(525,649,c),
+(503,638,l),
+(695,638,l),
+(695,554,l),
+(770,554,l),
+(770,798,l),
+(695,798,l),
+(695,714,l),
+(447,714,l),
+(447,634,l),
+(532,602,o),
+(603,512,o),
+(603,342,cs),
+(603,167,o),
+(531,77,o),
+(387,77,cs),
+(243,77,o),
+(172,167,o),
+(172,342,cs),
+(172,512,o),
+(242,602,o),
+(327,634,c),
+(327,714,l),
+(63,714,l),
+(63,629,l),
+(258,629,l),
+(235,643,l),
+(140,598,o),
+(72,501,o),
+(72,327,cs),
+(72,116,o),
+(183,-13,o),
+(387,-13,cs)
+);
+}
+);
+width = 813;
+}
+);
+metricLeft = "lhuCarrier-canadian";
+note = uni1634;
+unicode = 5684;
+},
+{
+color = 9;
+glyphname = "tlhoCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(117,-84,l),
+(117,0,l),
+(365,0,l),
+(365,80,l),
+(281,112,o),
+(210,202,o),
+(210,372,cs),
+(210,547,o),
+(282,637,o),
+(426,637,cs),
+(569,637,o),
+(641,547,o),
+(641,372,cs),
+(641,202,o),
+(570,112,o),
+(486,80,c),
+(486,0,l),
+(749,0,l),
+(749,85,l),
+(555,85,l),
+(578,71,l),
+(672,116,o),
+(740,213,o),
+(740,387,cs),
+(740,598,o),
+(630,727,o),
+(426,727,cs),
+(221,727,o),
+(111,598,o),
+(111,387,cs),
+(111,207,o),
+(186,107,o),
+(288,65,c),
+(309,76,l),
+(117,76,l),
+(117,160,l),
+(43,160,l),
+(43,-84,l)
+);
+}
+);
+width = 812;
+}
+);
+metricLeft = "=|tlhuCarrier-canadian";
+metricRight = "lhuCarrier-canadian";
+note = uni1635;
+unicode = 5685;
+},
+{
+color = 9;
+glyphname = "tlheCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (382,357);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(572,-13,o),
+(692,115,o),
+(692,357,cs),
+(692,599,o),
+(572,727,o),
+(404,727,cs),
+(277,727,o),
+(185,654,o),
+(149,535,c),
+(162,523,l),
+(162,724,l),
+(243,724,l),
+(243,796,l),
+(6,796,l),
+(6,724,l),
+(86,724,l),
+(86,430,l),
+(170,430,l),
+(185,545,o),
+(255,637,o),
+(382,637,cs),
+(503,637,o),
+(593,550,o),
+(593,357,cs),
+(593,165,o),
+(503,77,o),
+(382,77,cs),
+(255,77,o),
+(185,169,o),
+(170,284,c),
+(86,284,l),
+(86,0,l),
+(176,0,l),
+(176,183,l),
+(168,164,l),
+(189,68,o),
+(274,-13,o),
+(404,-13,cs)
+);
+}
+);
+width = 756;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1636;
+unicode = 5686;
+},
+{
+color = 9;
+glyphname = "tlheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (333,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 757;
+}
+);
+note = uni1637;
+unicode = 5687;
+},
+{
+color = 9;
+glyphname = "tlhiCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "tlheCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (306,0);
+ref = dot_middle;
+}
+);
+width = 757;
+}
+);
+note = uni1638;
+unicode = 5688;
+},
+{
+color = 9;
+glyphname = "tlhaCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(482,-13,o),
+(568,65,o),
+(588,165,c),
+(580,184,l),
+(580,0,l),
+(670,0,l),
+(670,284,l),
+(586,284,l),
+(571,169,o),
+(501,77,o),
+(374,77,cs),
+(253,77,o),
+(163,165,o),
+(163,357,cs),
+(163,550,o),
+(249,637,o),
+(374,637,cs),
+(501,637,o),
+(571,545,o),
+(586,430,c),
+(670,430,l),
+(670,724,l),
+(751,724,l),
+(751,796,l),
+(513,796,l),
+(513,724,l),
+(594,724,l),
+(594,522,l),
+(607,534,l),
+(572,657,o),
+(479,727,o),
+(353,727,cs),
+(184,727,o),
+(64,599,o),
+(64,357,cs),
+(64,115,o),
+(184,-13,o),
+(353,-13,cs)
+);
+}
+);
+width = 757;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni1639;
+unicode = 5689;
+},
+{
+color = 9;
+glyphname = "tluCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(372,-13,o),
+(435,35,o),
+(462,128,c),
+(432,128,l),
+(460,35,o),
+(522,-13,o),
+(607,-13,cs),
+(744,-13,o),
+(822,85,o),
+(822,289,cs),
+(822,500,o),
+(751,609,o),
+(638,650,c),
+(617,638,l),
+(816,638,l),
+(816,554,l),
+(890,554,l),
+(890,798,l),
+(816,798,l),
+(816,714,l),
+(507,714,l),
+(507,633,l),
+(650,629,o),
+(722,520,o),
+(722,297,cs),
+(722,135,o),
+(679,75,o),
+(601,75,cs),
+(537,75,o),
+(495,128,o),
+(495,231,cs),
+(495,313,l),
+(399,313,l),
+(399,231,ls),
+(399,128,o),
+(357,75,o),
+(293,75,cs),
+(215,75,o),
+(172,135,o),
+(172,297,cs),
+(172,520,o),
+(244,629,o),
+(387,633,c),
+(387,714,l),
+(63,714,l),
+(63,629,l),
+(265,629,l),
+(242,643,l),
+(138,600,o),
+(73,492,o),
+(73,289,cs),
+(73,85,o),
+(150,-13,o),
+(287,-13,cs)
+);
+}
+);
+width = 933;
+}
+);
+metricRight = "tlhuCarrier-canadian";
+note = uni163A;
+unicode = 5690;
+},
+{
+color = 1;
+glyphname = "tloCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(890,-84,l),
+(890,160,l),
+(816,160,l),
+(816,76,l),
+(617,76,l),
+(638,64,l),
+(751,105,o),
+(822,214,o),
+(822,425,cs),
+(822,629,o),
+(744,727,o),
+(607,727,cs),
+(522,727,o),
+(460,679,o),
+(432,586,c),
+(462,586,l),
+(435,679,o),
+(372,727,o),
+(287,727,cs),
+(150,727,o),
+(73,629,o),
+(73,425,cs),
+(73,222,o),
+(138,114,o),
+(242,71,c),
+(265,85,l),
+(63,85,l),
+(63,0,l),
+(387,0,l),
+(387,81,l),
+(244,85,o),
+(172,194,o),
+(172,417,cs),
+(172,579,o),
+(215,639,o),
+(293,639,cs),
+(357,639,o),
+(399,586,o),
+(399,483,cs),
+(399,401,l),
+(495,401,l),
+(495,483,ls),
+(495,586,o),
+(537,639,o),
+(601,639,cs),
+(679,639,o),
+(722,579,o),
+(722,417,cs),
+(722,194,o),
+(650,85,o),
+(507,81,c),
+(507,0,l),
+(816,0,l),
+(816,-84,l)
+);
+}
+);
+width = 933;
+}
+);
+metricLeft = "tluCarrier-canadian";
+metricRight = "tlhuCarrier-canadian";
+note = uni163B;
+unicode = 5691;
+},
+{
+color = 9;
+glyphname = "tleCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (298,357);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(606,-13,o),
+(683,76,o),
+(683,192,cs),
+(683,279,o),
+(631,348,o),
+(542,369,c),
+(542,346,l),
+(632,364,o),
+(683,433,o),
+(683,522,cs),
+(683,638,o),
+(606,727,o),
+(434,727,cs),
+(280,727,o),
+(183,658,o),
+(150,545,c),
+(161,529,l),
+(161,724,l),
+(242,724,l),
+(242,796,l),
+(6,796,l),
+(6,724,l),
+(86,724,l),
+(86,430,l),
+(170,430,l),
+(177,553,o),
+(248,638,o),
+(413,638,cs),
+(533,638,o),
+(584,590,o),
+(584,512,cs),
+(584,439,o),
+(534,399,o),
+(443,399,cs),
+(399,399,l),
+(399,316,l),
+(443,316,ls),
+(538,316,o),
+(584,275,o),
+(584,202,cs),
+(584,124,o),
+(529,76,o),
+(412,76,cs),
+(248,76,o),
+(177,161,o),
+(170,284,c),
+(86,284,l),
+(86,0,l),
+(176,0,l),
+(176,169,l),
+(162,152,l),
+(198,48,o),
+(285,-13,o),
+(434,-13,cs)
+);
+}
+);
+width = 757;
+}
+);
+metricLeft = "dleCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni163C;
+unicode = 5692;
+},
+{
+color = 9;
+glyphname = "tleeCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (249,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 757;
+}
+);
+note = uni163D;
+unicode = 5693;
+},
+{
+color = 9;
+glyphname = "tliCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "tleCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (231,0);
+ref = dot_middle_optic_halfsmall;
+}
+);
+width = 757;
+}
+);
+note = uni163E;
+unicode = 5694;
+},
+{
+color = 9;
+glyphname = "tlaCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(472,-13,o),
+(559,48,o),
+(595,152,c),
+(581,169,l),
+(581,0,l),
+(671,0,l),
+(671,284,l),
+(587,284,l),
+(580,161,o),
+(509,76,o),
+(345,76,cs),
+(228,76,o),
+(173,124,o),
+(173,202,cs),
+(173,275,o),
+(219,316,o),
+(314,316,cs),
+(373,316,l),
+(373,399,l),
+(314,399,ls),
+(223,399,o),
+(173,439,o),
+(173,512,cs),
+(173,590,o),
+(224,638,o),
+(345,638,cs),
+(509,638,o),
+(580,553,o),
+(587,430,c),
+(671,430,l),
+(671,724,l),
+(752,724,l),
+(752,796,l),
+(516,796,l),
+(516,724,l),
+(596,724,l),
+(596,529,l),
+(607,545,l),
+(574,658,o),
+(477,727,o),
+(323,727,cs),
+(152,727,o),
+(74,638,o),
+(74,522,cs),
+(74,433,o),
+(125,365,o),
+(215,345,c),
+(215,369,l),
+(126,348,o),
+(74,279,o),
+(74,192,cs),
+(74,76,o),
+(152,-13,o),
+(323,-13,cs)
+);
+}
+);
+width = 758;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|dleCarrier-canadian";
+note = uni163F;
+unicode = 5695;
+},
+{
+color = 9;
+glyphname = "zuCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(583,-13,o),
+(700,91,o),
+(700,249,cs),
+(700,372,o),
+(606,496,o),
+(606,566,cs),
+(606,601,o),
+(623,628,o),
+(678,628,cs),
+(710,628,l),
+(710,714,l),
+(657,714,ls),
+(553,714,o),
+(509,657,o),
+(509,580,cs),
+(509,485,o),
+(600,376,o),
+(600,263,cs),
+(600,147,o),
+(523,77,o),
+(385,77,cs),
+(247,77,o),
+(170,147,o),
+(170,263,cs),
+(170,376,o),
+(261,485,o),
+(261,580,cs),
+(261,657,o),
+(217,714,o),
+(113,714,cs),
+(61,714,l),
+(61,628,l),
+(93,628,ls),
+(147,628,o),
+(164,601,o),
+(164,566,cs),
+(164,496,o),
+(70,372,o),
+(70,249,cs),
+(70,91,o),
+(187,-13,o),
+(385,-13,cs)
+);
+}
+);
+width = 771;
+}
+);
+metricRight = "=|";
+note = uni1640;
+unicode = 5696;
+},
+{
+color = 9;
+glyphname = "zoCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(113,0,ls),
+(217,0,o),
+(261,57,o),
+(261,134,cs),
+(261,229,o),
+(170,338,o),
+(170,451,cs),
+(170,567,o),
+(247,637,o),
+(385,637,cs),
+(524,637,o),
+(601,567,o),
+(601,451,cs),
+(601,338,o),
+(509,229,o),
+(509,134,cs),
+(509,57,o),
+(554,0,o),
+(657,0,cs),
+(710,0,l),
+(710,86,l),
+(678,86,ls),
+(623,86,o),
+(606,113,o),
+(606,148,cs),
+(606,218,o),
+(700,342,o),
+(700,465,cs),
+(700,623,o),
+(583,727,o),
+(385,727,cs),
+(187,727,o),
+(71,623,o),
+(71,465,cs),
+(71,342,o),
+(164,218,o),
+(164,148,cs),
+(164,113,o),
+(147,86,o),
+(93,86,cs),
+(61,86,l),
+(61,0,l)
+);
+}
+);
+width = 771;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1641;
+unicode = 5697;
+},
+{
+color = 9;
+glyphname = "zeCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (375,357);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(566,-13,o),
+(660,112,o),
+(660,357,cs),
+(660,602,o),
+(566,727,o),
+(428,727,cs),
+(321,727,o),
+(237,626,o),
+(189,626,cs),
+(163,626,o),
+(143,642,o),
+(143,687,cs),
+(143,714,l),
+(54,714,l),
+(54,667,ls),
+(54,582,o),
+(99,538,o),
+(167,538,cs),
+(249,538,o),
+(324,637,o),
+(408,637,cs),
+(498,637,o),
+(560,554,o),
+(560,357,cs),
+(560,160,o),
+(498,77,o),
+(408,77,cs),
+(324,77,o),
+(249,176,o),
+(167,176,cs),
+(99,176,o),
+(54,132,o),
+(54,47,cs),
+(54,0,l),
+(143,0,l),
+(143,27,ls),
+(143,72,o),
+(163,88,o),
+(189,88,cs),
+(237,88,o),
+(321,-13,o),
+(428,-13,cs)
+);
+}
+);
+width = 724;
+}
+);
+metricRight = "theCarrier-canadian";
+note = uni1642;
+unicode = 5698;
+},
+{
+color = 9;
+glyphname = "zeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (325,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 725;
+}
+);
+note = uni1643;
+unicode = 5699;
+},
+{
+color = 9;
+glyphname = "ziCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "zeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (299,0);
+ref = dot_middle;
+}
+);
+width = 725;
+}
+);
+note = uni1644;
+unicode = 5700;
+},
+{
+color = 9;
+glyphname = "zaCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(402,-13,o),
+(487,88,o),
+(535,88,cs),
+(561,88,o),
+(580,72,o),
+(580,27,cs),
+(580,0,l),
+(670,0,l),
+(670,47,ls),
+(670,132,o),
+(625,176,o),
+(556,176,cs),
+(474,176,o),
+(400,77,o),
+(316,77,cs),
+(225,77,o),
+(163,160,o),
+(163,357,cs),
+(163,554,o),
+(225,637,o),
+(316,637,cs),
+(400,637,o),
+(474,538,o),
+(556,538,cs),
+(625,538,o),
+(670,582,o),
+(670,667,cs),
+(670,714,l),
+(580,714,l),
+(580,687,ls),
+(580,642,o),
+(561,626,o),
+(535,626,cs),
+(487,626,o),
+(402,727,o),
+(296,727,cs),
+(158,727,o),
+(64,602,o),
+(64,357,cs),
+(64,112,o),
+(158,-13,o),
+(296,-13,cs)
+);
+}
+);
+width = 724;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|zeCarrier-canadian";
+note = uni1645;
+unicode = 5701;
+},
+{
+color = 6;
+glyphname = "zCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(376,189,l),
+(376,251,l),
+(141,251,l),
+(141,214,l),
+(372,510,l),
+(372,546,l),
+(66,546,l),
+(66,484,l),
+(298,484,l),
+(298,521,l),
+(66,225,l),
+(66,189,l)
+);
+}
+);
+width = 442;
+}
+);
+metricRight = "=|";
+note = uni1646;
+unicode = 5702;
+},
+{
+color = 6;
+glyphname = "initialzCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(185,189,l),
+(185,99,l),
+(253,99,l),
+(253,189,l),
+(376,189,l),
+(376,251,l),
+(124,251,l),
+(142,215,l),
+(372,510,l),
+(372,546,l),
+(253,546,l),
+(253,636,l),
+(185,636,l),
+(185,546,l),
+(66,546,l),
+(66,484,l),
+(314,484,l),
+(296,519,l),
+(66,225,l),
+(66,189,l)
+);
+}
+);
+width = 442;
+}
+);
+metricLeft = "zCarrier-canadian";
+metricRight = "zCarrier-canadian";
+note = uni1647;
+unicode = 5703;
+},
+{
+color = 9;
+glyphname = "dzuCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(583,-13,o),
+(700,91,o),
+(700,249,cs),
+(700,372,o),
+(606,496,o),
+(606,566,cs),
+(606,601,o),
+(623,628,o),
+(678,628,cs),
+(710,628,l),
+(710,714,l),
+(659,714,ls),
+(556,714,o),
+(511,657,o),
+(511,580,cs),
+(511,485,o),
+(600,378,o),
+(600,263,cs),
+(600,147,o),
+(524,77,o),
+(385,77,cs),
+(246,77,o),
+(170,147,o),
+(170,263,cs),
+(170,378,o),
+(259,485,o),
+(259,580,cs),
+(259,657,o),
+(214,714,o),
+(112,714,cs),
+(61,714,l),
+(61,628,l),
+(93,628,ls),
+(147,628,o),
+(164,601,o),
+(164,566,cs),
+(164,496,o),
+(70,372,o),
+(70,249,cs),
+(70,91,o),
+(187,-13,o),
+(385,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(411,499,l),
+(411,666,l),
+(475,666,l),
+(474.991,714,l),
+(295,714,l),
+(295,666,l),
+(360,666,l),
+(360,499,l)
+);
+}
+);
+width = 771;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1648;
+unicode = 5704;
+},
+{
+color = 9;
+glyphname = "dzoCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(112,0,ls),
+(214,0,o),
+(259,57,o),
+(259,134,cs),
+(259,229,o),
+(170,336,o),
+(170,451,cs),
+(170,567,o),
+(247,637,o),
+(385,637,cs),
+(524,637,o),
+(601,567,o),
+(601,451,cs),
+(601,336,o),
+(511,229,o),
+(511,134,cs),
+(511,57,o),
+(556,0,o),
+(659,0,cs),
+(710,0,l),
+(710,86,l),
+(678,86,ls),
+(623,86,o),
+(606,113,o),
+(606,148,cs),
+(606,218,o),
+(700,342,o),
+(700,465,cs),
+(700,623,o),
+(583,727,o),
+(385,727,cs),
+(187,727,o),
+(71,623,o),
+(71,465,cs),
+(71,342,o),
+(164,218,o),
+(164,148,cs),
+(164,113,o),
+(147,86,o),
+(93,86,cs),
+(61,86,l),
+(61,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(475,0,l),
+(475,48,l),
+(411,48,l),
+(411,215,l),
+(360,215,l),
+(360,48,l),
+(295,48,l),
+(295,0,l)
+);
+}
+);
+width = 771;
+}
+);
+metricLeft = "zuCarrier-canadian";
+metricRight = "zuCarrier-canadian";
+note = uni1649;
+unicode = 5705;
+},
+{
+color = 9;
+glyphname = "dzeCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = middle_center_can;
+pos = (393,357);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(590,-13,o),
+(684,112,o),
+(684,357,cs),
+(684,602,o),
+(591,727,o),
+(452,727,cs),
+(346,727,o),
+(261,626,o),
+(213,626,cs),
+(187,626,o),
+(168,642,o),
+(168,687,cs),
+(168,714,l),
+(78,714,l),
+(78,667,ls),
+(78,582,o),
+(124,538,o),
+(192,538,cs),
+(274,538,o),
+(348,637,o),
+(432,637,cs),
+(523,637,o),
+(585,554,o),
+(585,357,cs),
+(585,160,o),
+(523,77,o),
+(432,77,cs),
+(348,77,o),
+(274,176,o),
+(192,176,cs),
+(124,176,o),
+(78,132,o),
+(78,47,cs),
+(78,0,l),
+(168,0,l),
+(168,27,ls),
+(168,71,o),
+(187,87,o),
+(213,87,cs),
+(261,87,o),
+(346,-13,o),
+(452,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(134,250,l),
+(134,330,l),
+(266,330,l),
+(266,384,l),
+(134,384,l),
+(134,464,l),
+(78,464,l),
+(78,250,l)
+);
+}
+);
+width = 748;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164A;
+unicode = 5706;
+},
+{
+color = 9;
+glyphname = "dzeeCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+ref = "dzeCarrier-canadian";
+},
+{
+anchor = middle_center_can;
+pos = (343,0);
+ref = stroke_middle_optic_threequart;
+}
+);
+width = 748;
+}
+);
+metricLeft = "dzeCarrier-canadian";
+metricRight = "theCarrier-canadian";
+note = uni164B;
+unicode = 5707;
+},
+{
+color = 9;
+glyphname = "dziCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "dzeCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_center_can;
+pos = (317,0);
+ref = dot_middle;
+}
+);
+width = 749;
+}
+);
+note = uni164C;
+unicode = 5708;
+},
+{
+color = 9;
+glyphname = "dzaCarrier-canadian";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(402,-13,o),
+(487,87,o),
+(535,87,cs),
+(561,87,o),
+(580,71,o),
+(580,27,cs),
+(580,0,l),
+(670,0,l),
+(670,47,ls),
+(670,132,o),
+(625,176,o),
+(556,176,cs),
+(474,176,o),
+(400,77,o),
+(316,77,cs),
+(225,77,o),
+(163,160,o),
+(163,357,cs),
+(163,554,o),
+(225,637,o),
+(316,637,cs),
+(400,637,o),
+(474,538,o),
+(556,538,cs),
+(625,538,o),
+(670,582,o),
+(670,667,cs),
+(670,714,l),
+(580,714,l),
+(580,687,ls),
+(580,642,o),
+(561,626,o),
+(535,626,cs),
+(487,626,o),
+(402,727,o),
+(296,727,cs),
+(158,727,o),
+(64,602,o),
+(64,357,cs),
+(64,112,o),
+(158,-13,o),
+(296,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(670,250,l),
+(670,464,l),
+(614,464,l),
+(614,384,l),
+(483,384,l),
+(483,330,l),
+(614,330,l),
+(614,250,l)
+);
+}
+);
+width = 748;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "=|dzeCarrier-canadian";
+note = uni164D;
+unicode = 5709;
+},
+{
+color = 9;
+glyphname = "suCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(370,-13,o),
+(438,43,o),
+(463,145,c),
+(426,145,l),
+(452,43,o),
+(520,-13,o),
+(616,-13,cs),
+(750,-13,o),
+(820,79,o),
+(820,203,cs),
+(820,340,o),
+(728,482,o),
+(728,567,cs),
+(728,601,o),
+(744,628,o),
+(798,628,cs),
+(828,628,l),
+(828,714,l),
+(778,714,ls),
+(674,714,o),
+(631,658,o),
+(631,579,cs),
+(631,473,o),
+(721,331,o),
+(721,214,cs),
+(721,129,o),
+(683,75,o),
+(609,75,cs),
+(534,75,o),
+(491,129,o),
+(491,234,cs),
+(491,714,l),
+(398,714,l),
+(398,234,ls),
+(398,130,o),
+(355,75,o),
+(281,75,cs),
+(206,75,o),
+(169,129,o),
+(169,214,cs),
+(169,331,o),
+(258,473,o),
+(258,579,cs),
+(258,658,o),
+(215,714,o),
+(111,714,cs),
+(61.004,714,l),
+(61,628,l),
+(91,628,ls),
+(145,628,o),
+(162,601,o),
+(162,567,cs),
+(162,482,o),
+(70,340,o),
+(70,203,cs),
+(70,79,o),
+(140,-13,o),
+(273,-13,cs)
+);
+}
+);
+width = 889;
+}
+);
+metricRight = "=|";
+note = uni164E;
+unicode = 5710;
+},
+{
+color = 9;
+glyphname = "soCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(111,0,ls),
+(215,0,o),
+(258,56,o),
+(258,135,cs),
+(258,241,o),
+(169,383,o),
+(169,500,cs),
+(169,585,o),
+(206,639,o),
+(280,639,cs),
+(355,639,o),
+(398,585,o),
+(398,480,cs),
+(398,0,l),
+(491,0,l),
+(491,480,ls),
+(491,584,o),
+(534,639,o),
+(609,639,cs),
+(683,639,o),
+(721,585,o),
+(721,500,cs),
+(721,383,o),
+(631,241,o),
+(631,135,cs),
+(631,56,o),
+(674,0,o),
+(778,0,cs),
+(828,0,l),
+(828,86,l),
+(798,86,ls),
+(744,86,o),
+(727,113,o),
+(727,147,cs),
+(727,232,o),
+(819,374,o),
+(819,511,cs),
+(819,635,o),
+(750,727,o),
+(616,727,cs),
+(520,727,o),
+(452,671,o),
+(427,569,c),
+(463,569,l),
+(438,671,o),
+(369,727,o),
+(273,727,cs),
+(140,727,o),
+(70,635,o),
+(70,511,cs),
+(70,374,o),
+(162,232,o),
+(162,147,cs),
+(162,113,o),
+(145,86,o),
+(91,86,cs),
+(61,86,l),
+(61.004,0,l)
+);
+}
+);
+width = 889;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5711;
+},
+{
+color = 9;
+glyphname = "seCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(601,-13,o),
+(672,69,o),
+(672,183,cs),
+(672,284,o),
+(613,355,o),
+(514,371,c),
+(514,343,l),
+(614,357,o),
+(672,428,o),
+(672,531,cs),
+(672,645,o),
+(601,727,o),
+(486,727,cs),
+(380,727,o),
+(263,626,o),
+(209,626,cs),
+(184,626,o),
+(165,642,o),
+(165,687,cs),
+(165,714,l),
+(75,714,l),
+(75,669,ls),
+(75,584,o),
+(120,541,o),
+(188,541,cs),
+(273,541,o),
+(378,638,o),
+(463,638,cs),
+(532,638,o),
+(573,594,o),
+(573,521,cs),
+(573,440,o),
+(520,398,o),
+(428,398,cs),
+(75,398,l),
+(75,317,l),
+(428,317,ls),
+(521,317,o),
+(573,274,o),
+(573,193,cs),
+(573,120,o),
+(532,76,o),
+(463,76,cs),
+(378,76,o),
+(273,173,o),
+(188,173,cs),
+(120,173,o),
+(75,130,o),
+(75,45,cs),
+(75,0,l),
+(165,0,l),
+(165,27,ls),
+(165,72,o),
+(184,88,o),
+(209,88,cs),
+(263,88,o),
+(380,-13,o),
+(487,-13,cs)
+);
+}
+);
+width = 746;
+}
+);
+metricRight = "geCarrier-canadian";
+note = uni1650;
+unicode = 5712;
+},
+{
+color = 9;
+glyphname = "seeCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(601,-13,o),
+(672,69,o),
+(672,183,cs),
+(672,278,o),
+(619,348,o),
+(530,368,c),
+(530,346,l),
+(619,365,o),
+(672,433,o),
+(672,531,cs),
+(672,645,o),
+(601,727,o),
+(486,727,cs),
+(380,727,o),
+(263,626,o),
+(209,626,cs),
+(184,626,o),
+(165,642,o),
+(165,687,cs),
+(165,714,l),
+(75,714,l),
+(75,669,ls),
+(75,584,o),
+(120,541,o),
+(188,541,cs),
+(273,541,o),
+(378,638,o),
+(463,638,cs),
+(532,638,o),
+(573,594,o),
+(573,521,cs),
+(573,440,o),
+(520,397,o),
+(434,397,cs),
+(376,397,l),
+(397,363,l),
+(397,478,l),
+(337,478,l),
+(337,397,l),
+(75,397,l),
+(75,317,l),
+(337,317,l),
+(337,228,l),
+(397,228,l),
+(397,350,l),
+(376,317,l),
+(434,317,ls),
+(521,317,o),
+(573,274,o),
+(573,193,cs),
+(573,120,o),
+(532,76,o),
+(463,76,cs),
+(378,76,o),
+(273,173,o),
+(188,173,cs),
+(120,173,o),
+(75,130,o),
+(75,45,cs),
+(75,0,l),
+(165,0,l),
+(165,27,ls),
+(165,72,o),
+(184,88,o),
+(209,88,cs),
+(263,88,o),
+(380,-13,o),
+(487,-13,cs)
+);
+}
+);
+width = 746;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1651;
+unicode = 5713;
+},
+{
+color = 9;
+glyphname = "siCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(601,-13,o),
+(672,69,o),
+(672,183,cs),
+(672,278,o),
+(618,348,o),
+(531,368,c),
+(531,346,l),
+(619,365,o),
+(672,433,o),
+(672,531,cs),
+(672,645,o),
+(601,727,o),
+(486,727,cs),
+(380,727,o),
+(263,626,o),
+(209,626,cs),
+(184,626,o),
+(165,642,o),
+(165,687,cs),
+(165,714,l),
+(75,714,l),
+(75,669,ls),
+(75,584,o),
+(120,541,o),
+(188,541,cs),
+(273,541,o),
+(378,640,o),
+(465,640,cs),
+(535,640,o),
+(575,595,o),
+(575,520,cs),
+(575,437,o),
+(524,395,o),
+(444,395,cs),
+(390,395,l),
+(424,367,l),
+(421,408,o),
+(387,440,o),
+(344,440,cs),
+(314,440,o),
+(288,422,o),
+(275,397,c),
+(75,397,l),
+(75,317,l),
+(276,317,l),
+(289,293,o),
+(315,275,o),
+(345,275,cs),
+(387,275,o),
+(418,307,o),
+(423,348,c),
+(389,319,l),
+(444,319,ls),
+(525,319,o),
+(575,277,o),
+(575,194,cs),
+(575,119,o),
+(535,74,o),
+(465,74,cs),
+(379,74,o),
+(273,173,o),
+(188,173,cs),
+(120,173,o),
+(75,130,o),
+(75,45,cs),
+(75,0,l),
+(165,0,l),
+(165,27,ls),
+(165,72,o),
+(184,88,o),
+(209,88,cs),
+(263,88,o),
+(380,-13,o),
+(487,-13,cs)
+);
+}
+);
+width = 746;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1652;
+unicode = 5714;
+},
+{
+color = 9;
+glyphname = "saCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(367,-13,o),
+(484,88,o),
+(537,88,cs),
+(562,88,o),
+(582,72,o),
+(582,27,cs),
+(582,0,l),
+(671,0,l),
+(671,45,ls),
+(671,130,o),
+(626,173,o),
+(558,173,cs),
+(473,173,o),
+(368,76,o),
+(283,76,cs),
+(214,76,o),
+(173,120,o),
+(173,193,cs),
+(173,274,o),
+(225,317,o),
+(318,317,cs),
+(671,317,l),
+(671,398,l),
+(318,398,ls),
+(226,398,o),
+(173,440,o),
+(173,521,cs),
+(173,594,o),
+(214,638,o),
+(283,638,cs),
+(368,638,o),
+(473,541,o),
+(558,541,cs),
+(626,541,o),
+(671,584,o),
+(671,669,cs),
+(671,714,l),
+(582,714,l),
+(582,687,ls),
+(582,642,o),
+(562,626,o),
+(537,626,cs),
+(484,626,o),
+(367,727,o),
+(260,727,cs),
+(145,727,o),
+(74,645,o),
+(74,531,cs),
+(74,428,o),
+(133,357,o),
+(232,343,c),
+(232,371,l),
+(134,355,o),
+(74,284,o),
+(74,183,cs),
+(74,69,o),
+(145,-13,o),
+(260,-13,cs)
+);
+}
+);
+width = 746;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1653;
+unicode = 5715;
+},
+{
+color = 9;
+glyphname = "shuCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(366,-13,o),
+(431,38,o),
+(459,133,c),
+(431,133,l),
+(458,38,o),
+(524,-13,o),
+(616,-13,cs),
+(750,-13,o),
+(820,79,o),
+(820,203,cs),
+(820,340,o),
+(728,482,o),
+(728,567,cs),
+(728,601,o),
+(744,628,o),
+(798,628,cs),
+(828,628,l),
+(828,714,l),
+(778,714,ls),
+(674,714,o),
+(632,658,o),
+(632,579,cs),
+(632,560,o),
+(636,537,o),
+(639,518,c),
+(656,581,l),
+(491,581,l),
+(491,714,l),
+(398,714,l),
+(398,581,l),
+(233,581,l),
+(250,518,l),
+(254,537,o),
+(257,560,o),
+(257,579,cs),
+(257,658,o),
+(215,714,o),
+(111,714,cs),
+(61.004,714,l),
+(61,628,l),
+(91,628,ls),
+(145,628,o),
+(162,601,o),
+(162,567,cs),
+(162,482,o),
+(70,340,o),
+(70,203,cs),
+(70,79,o),
+(140,-13,o),
+(273,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(206,75,o),
+(169,129,o),
+(169,214,cs),
+(169,305,o),
+(222,409,o),
+(246,499,c),
+(398,499,l),
+(398,234,ls),
+(398,130,o),
+(355,75,o),
+(281,75,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(534,75,o),
+(491,129,o),
+(491,234,cs),
+(491,499,l),
+(644,499,l),
+(667,409,o),
+(721,305,o),
+(721,214,cs),
+(721,129,o),
+(683,75,o),
+(609,75,cs)
+);
+}
+);
+width = 889;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1654;
+unicode = 5716;
+},
+{
+color = 9;
+glyphname = "shoCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(111,0,ls),
+(215,0,o),
+(257,56,o),
+(257,135,cs),
+(257,154,o),
+(253,177,o),
+(250,196,c),
+(233,133,l),
+(398,133,l),
+(398,0,l),
+(491,0,l),
+(491,133,l),
+(656,133,l),
+(639,196,l),
+(636,177,o),
+(632,154,o),
+(632,135,cs),
+(632,56,o),
+(674,0,o),
+(778,0,cs),
+(828,0,l),
+(828,86,l),
+(798,86,ls),
+(744,86,o),
+(727,113,o),
+(727,147,cs),
+(727,232,o),
+(819,374,o),
+(819,511,cs),
+(819,635,o),
+(750,727,o),
+(616,727,cs),
+(524,727,o),
+(458,676,o),
+(430,581,c),
+(459,581,l),
+(431,676,o),
+(365,727,o),
+(273,727,cs),
+(140,727,o),
+(70,635,o),
+(70,511,cs),
+(70,374,o),
+(162,232,o),
+(162,147,cs),
+(162,113,o),
+(145,86,o),
+(91,86,cs),
+(61,86,l),
+(61.004,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(222,305,o),
+(169,409,o),
+(169,500,cs),
+(169,585,o),
+(206,639,o),
+(280,639,cs),
+(355,639,o),
+(398,585,o),
+(398,480,cs),
+(398,215,l),
+(246,215,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(491,480,ls),
+(491,584,o),
+(534,639,o),
+(609,639,cs),
+(683,639,o),
+(721,585,o),
+(721,500,cs),
+(721,409,o),
+(667,305,o),
+(644,215,c),
+(491,215,l)
+);
+}
+);
+width = 889;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni1655;
+unicode = 5717;
+},
+{
+color = 9;
+glyphname = "sheCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(601,-13,o),
+(672,69,o),
+(672,183,cs),
+(672,278,o),
+(619,348,o),
+(530,368,c),
+(530,346,l),
+(619,365,o),
+(672,433,o),
+(672,531,cs),
+(672,645,o),
+(601,727,o),
+(486,727,cs),
+(380,727,o),
+(263,626,o),
+(209,626,cs),
+(184,626,o),
+(165,642,o),
+(165,687,cs),
+(165,714,l),
+(75,714,l),
+(75,669,ls),
+(75,584,o),
+(120,542,o),
+(188,542,cs),
+(208,542,o),
+(228,547,o),
+(249,554,c),
+(192,570,l),
+(192,398,l),
+(75,398,l),
+(75,317,l),
+(192,317,l),
+(192,144,l),
+(248,160,l),
+(228,167,o),
+(208,172,o),
+(188,172,cs),
+(120,172,o),
+(75,130,o),
+(75,45,cs),
+(75,0,l),
+(165,0,l),
+(165,27,ls),
+(165,72,o),
+(184,88,o),
+(209,88,cs),
+(263,88,o),
+(380,-13,o),
+(487,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(271,317,l),
+(428,317,ls),
+(521,317,o),
+(573,274,o),
+(573,193,cs),
+(573,120,o),
+(532,76,o),
+(463,76,cs),
+(404,76,o),
+(335,122,o),
+(271,150,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(271,564,l),
+(335,592,o),
+(404,638,o),
+(463,638,cs),
+(532,638,o),
+(573,594,o),
+(573,521,cs),
+(573,440,o),
+(520,398,o),
+(428,398,cs),
+(271,398,l)
+);
+}
+);
+width = 746;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1656;
+unicode = 5718;
+},
+{
+color = 9;
+glyphname = "sheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(601,-13,o),
+(672,69,o),
+(672,183,cs),
+(672,278,o),
+(619,348,o),
+(530,368,c),
+(530,346,l),
+(619,365,o),
+(672,433,o),
+(672,531,cs),
+(672,645,o),
+(601,727,o),
+(486,727,cs),
+(380,727,o),
+(263,626,o),
+(209,626,cs),
+(184,626,o),
+(165,642,o),
+(165,687,cs),
+(165,714,l),
+(75,714,l),
+(75,669,ls),
+(75,584,o),
+(120,542,o),
+(188,542,cs),
+(207,542,o),
+(228,547,o),
+(248,554,c),
+(192,572,l),
+(192,392,l),
+(75,392,l),
+(75,323,l),
+(192,323,l),
+(192,142,l),
+(248,160,l),
+(228,167,o),
+(207,172,o),
+(188,172,cs),
+(120,172,o),
+(75,130,o),
+(75,45,cs),
+(75,0,l),
+(165,0,l),
+(165,27,ls),
+(165,72,o),
+(184,88,o),
+(209,88,cs),
+(263,88,o),
+(380,-13,o),
+(487,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(404,74,o),
+(330,125,o),
+(264,154,c),
+(264,323,l),
+(376,323,l),
+(376,229,l),
+(427,229,l),
+(427,341,l),
+(409,323,l),
+(439,323,ls),
+(524,323,o),
+(575,276,o),
+(575,197,cs),
+(575,119,o),
+(534,74,o),
+(465,74,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(427,478,l),
+(376,478,l),
+(376,392,l),
+(264,392,l),
+(264,560,l),
+(330,589,o),
+(404,640,o),
+(465,640,cs),
+(534,640,o),
+(575,595,o),
+(575,517,cs),
+(575,438,o),
+(524,392,o),
+(439,392,cs),
+(409,392,l),
+(427,374,l)
+);
+}
+);
+width = 746;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1657;
+unicode = 5719;
+},
+{
+color = 9;
+glyphname = "shiCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(75,669,ls),
+(75,584,o),
+(120,542,o),
+(188,542,cs),
+(206,542,o),
+(224,546,o),
+(244,553,c),
+(192,575,l),
+(192,392,l),
+(75,392,l),
+(75,323,l),
+(192,323,l),
+(192,139,l),
+(244,161,l),
+(224,168,o),
+(206,172,o),
+(188,172,cs),
+(120,172,o),
+(75,130,o),
+(75,45,cs),
+(75,0,l),
+(165,0,l),
+(165,27,ls),
+(165,72,o),
+(184,88,o),
+(209,88,cs),
+(263,88,o),
+(380,-13,o),
+(487,-13,cs),
+(601,-13,o),
+(672,69,o),
+(672,183,cs),
+(672,278,o),
+(618,348,o),
+(531,368,c),
+(531,346,l),
+(619,365,o),
+(672,433,o),
+(672,531,cs),
+(672,645,o),
+(601,727,o),
+(486,727,cs),
+(380,727,o),
+(263,626,o),
+(209,626,cs),
+(184,626,o),
+(165,642,o),
+(165,687,cs),
+(165,714,l),
+(75,714,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(264,323,l),
+(331,323,l),
+(344,293,o),
+(371,275,o),
+(401,275,cs),
+(444,275,o),
+(476,310,o),
+(479,351,c),
+(415,323,l),
+(447,323,ls),
+(526,323,o),
+(575,273,o),
+(575,197,cs),
+(575,119,o),
+(534,74,o),
+(465,74,cs),
+(404,74,o),
+(330,125,o),
+(264,153,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(264,561,l),
+(330,589,o),
+(404,640,o),
+(465,640,cs),
+(534,640,o),
+(575,595,o),
+(575,517,cs),
+(575,439,o),
+(526,392,o),
+(447,392,cs),
+(416,392,l),
+(479,363,l),
+(478,405,o),
+(445,440,o),
+(401,440,cs),
+(370,440,o),
+(343,422,o),
+(330,392,c),
+(264,392,l)
+);
+}
+);
+width = 746;
+}
+);
+metricLeft = "seCarrier-canadian";
+metricRight = "geCarrier-canadian";
+note = uni1658;
+unicode = 5720;
+},
+{
+color = 9;
+glyphname = "shaCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(367,-13,o),
+(484,88,o),
+(537,88,cs),
+(562,88,o),
+(582,72,o),
+(582,27,cs),
+(582,0,l),
+(671,0,l),
+(671,45,ls),
+(671,130,o),
+(626,172,o),
+(558,172,cs),
+(538,172,o),
+(518,167,o),
+(498,160,c),
+(554,144,l),
+(554,317,l),
+(671,317,l),
+(671,398,l),
+(554,398,l),
+(554,570,l),
+(497,554,l),
+(518,547,o),
+(538,542,o),
+(558,542,cs),
+(626,542,o),
+(671,584,o),
+(671,669,cs),
+(671,714,l),
+(582,714,l),
+(582,687,ls),
+(582,642,o),
+(562,626,o),
+(537,626,cs),
+(484,626,o),
+(367,727,o),
+(260,727,cs),
+(145,727,o),
+(74,645,o),
+(74,531,cs),
+(74,433,o),
+(127,365,o),
+(217,346,c),
+(216,368,l),
+(127,348,o),
+(74,278,o),
+(74,183,cs),
+(74,69,o),
+(145,-13,o),
+(260,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(214,76,o),
+(173,120,o),
+(173,193,cs),
+(173,274,o),
+(225,317,o),
+(318,317,cs),
+(475,317,l),
+(475,150,l),
+(411,122,o),
+(342,76,o),
+(283,76,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(226,398,o),
+(173,440,o),
+(173,521,cs),
+(173,594,o),
+(214,638,o),
+(283,638,cs),
+(342,638,o),
+(411,592,o),
+(475,564,c),
+(475,398,l),
+(318,398,ls)
+);
+}
+);
+width = 746;
+}
+);
+metricLeft = "=|geCarrier-canadian";
+metricRight = "=|seCarrier-canadian";
+note = uni1659;
+unicode = 5721;
+},
+{
+color = 6;
+glyphname = "shCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(245,99,l),
+(245,206,l),
+(209,189,l),
+(237,189,ls),
+(316,189,o),
+(357,226,o),
+(357,291,cs),
+(357,355,o),
+(317,395,o),
+(240,395,cs),
+(191,395,ls),
+(151,395,o),
+(129,408,o),
+(129,444,cs),
+(129,479,o),
+(152,492,o),
+(191,492,cs),
+(350,492,l),
+(350,546,l),
+(245,546,l),
+(245,636,l),
+(178,636,l),
+(178,526,l),
+(213,546,l),
+(186,546,ls),
+(107,546,o),
+(66,509,o),
+(66,444,cs),
+(66,380,o),
+(106,341,o),
+(183,341,cs),
+(232,341,ls),
+(272,341,o),
+(294,326,o),
+(294,291,cs),
+(294,257,o),
+(272,243,o),
+(232,243,cs),
+(73,243,l),
+(73,189,l),
+(178,189,l),
+(178,99,l)
+);
+}
+);
+width = 423;
+}
+);
+metricRight = "=|";
+note = uni18F5;
+unicode = 5722;
+},
+{
+color = 9;
+glyphname = "tsuCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(366,-13,o),
+(431,38,o),
+(459,133,c),
+(431,133,l),
+(458,38,o),
+(524,-13,o),
+(616,-13,cs),
+(750,-13,o),
+(820,79,o),
+(820,203,cs),
+(820,340,o),
+(728,482,o),
+(728,567,cs),
+(728,601,o),
+(744,628,o),
+(798,628,cs),
+(828,628,l),
+(828,714,l),
+(778,714,ls),
+(675,714,o),
+(633,659,o),
+(633,580,cs),
+(633,528,o),
+(661,465,o),
+(683,398,c),
+(490,398,l),
+(490,643,l),
+(568,643,l),
+(568,714,l),
+(321,714,l),
+(321,643,l),
+(400,643,l),
+(400,398,l),
+(206,398,l),
+(228,465,o),
+(256,528,o),
+(256,580,cs),
+(256,659,o),
+(214,714,o),
+(111,714,cs),
+(61.004,714,l),
+(61,628,l),
+(91,628,ls),
+(145,628,o),
+(162,601,o),
+(162,567,cs),
+(162,482,o),
+(70,340,o),
+(70,203,cs),
+(70,79,o),
+(140,-13,o),
+(273,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(207,75,o),
+(169,129,o),
+(169,214,cs),
+(169,246,o),
+(176,281,o),
+(185,316,c),
+(400,316,l),
+(400,234,ls),
+(400,130,o),
+(356,75,o),
+(281,75,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(534,75,o),
+(490,129,o),
+(490,234,cs),
+(490,316,l),
+(704,316,l),
+(714,281,o),
+(721,246,o),
+(721,214,cs),
+(721,129,o),
+(683,75,o),
+(609,75,cs)
+);
+}
+);
+width = 889;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165B;
+unicode = 5723;
+},
+{
+color = 9;
+glyphname = "tsoCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(111,0,ls),
+(214,0,o),
+(256,55,o),
+(256,134,cs),
+(256,186,o),
+(228,249,o),
+(206,316,c),
+(400,316,l),
+(400,71,l),
+(321,71,l),
+(321,0,l),
+(568,0,l),
+(568,71,l),
+(490,71,l),
+(490,316,l),
+(683,316,l),
+(661,249,o),
+(633,186,o),
+(633,134,cs),
+(633,55,o),
+(675,0,o),
+(778,0,cs),
+(828,0,l),
+(828,86,l),
+(798,86,ls),
+(744,86,o),
+(727,113,o),
+(727,147,cs),
+(727,232,o),
+(819,374,o),
+(819,511,cs),
+(819,635,o),
+(750,727,o),
+(616,727,cs),
+(524,727,o),
+(458,676,o),
+(430,581,c),
+(459,581,l),
+(431,676,o),
+(365,727,o),
+(273,727,cs),
+(140,727,o),
+(70,635,o),
+(70,511,cs),
+(70,374,o),
+(162,232,o),
+(162,147,cs),
+(162,113,o),
+(145,86,o),
+(91,86,cs),
+(61,86,l),
+(61.004,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(176,433,o),
+(169,468,o),
+(169,500,cs),
+(169,585,o),
+(206,639,o),
+(281,639,cs),
+(355,639,o),
+(400,585,o),
+(400,480,cs),
+(400,398,l),
+(185,398,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(490,480,ls),
+(490,584,o),
+(534,639,o),
+(608,639,cs),
+(683,639,o),
+(721,585,o),
+(721,500,cs),
+(721,468,o),
+(714,433,o),
+(704,398,c),
+(490,398,l)
+);
+}
+);
+width = 889;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni165C;
+unicode = 5724;
+},
+{
+color = 9;
+glyphname = "tseCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(605,-13,o),
+(676,69,o),
+(676,183,cs),
+(676,278,o),
+(623,348,o),
+(534,368,c),
+(533,346,l),
+(623,365,o),
+(676,433,o),
+(676,531,cs),
+(676,645,o),
+(605,727,o),
+(490,727,cs),
+(383,727,o),
+(266,626,o),
+(213,626,cs),
+(187,626,o),
+(168,642,o),
+(168,687,cs),
+(168,714,l),
+(79,714,l),
+(79,673,ls),
+(79,587,o),
+(124,544,o),
+(192,544,cs),
+(223,544,o),
+(257,557,o),
+(293,573,c),
+(251,581,l),
+(251,392,l),
+(138,392,l),
+(138,481,l),
+(79,481,l),
+(79,233,l),
+(138,233,l),
+(138,322,l),
+(251,322,l),
+(251,133,l),
+(292,141,l),
+(257,157,o),
+(223,170,o),
+(192,170,cs),
+(124,170,o),
+(79,127,o),
+(79,41,cs),
+(79,0,l),
+(168,0,l),
+(168,27,ls),
+(168,72,o),
+(187,88,o),
+(213,88,cs),
+(266,88,o),
+(383,-13,o),
+(490,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(423,76,o),
+(372,103,o),
+(323,127,c),
+(323,322,l),
+(432,322,ls),
+(525,322,o),
+(577,274,o),
+(577,193,cs),
+(577,120,o),
+(536,76,o),
+(468,76,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(323,587,l),
+(372,611,o),
+(423,638,o),
+(467,638,cs),
+(536,638,o),
+(577,594,o),
+(577,521,cs),
+(577,440,o),
+(525,392,o),
+(432,392,cs),
+(323,392,l)
+);
+}
+);
+width = 750;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni165D;
+unicode = 5725;
+},
+{
+color = 9;
+glyphname = "tseeCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(605,-13,o),
+(676,69,o),
+(676,183,cs),
+(676,278,o),
+(623,348,o),
+(534,368,c),
+(533,346,l),
+(623,365,o),
+(676,433,o),
+(676,531,cs),
+(676,645,o),
+(605,727,o),
+(490,727,cs),
+(383,727,o),
+(266,626,o),
+(213,626,cs),
+(187,626,o),
+(168,642,o),
+(168,687,cs),
+(168,714,l),
+(79,714,l),
+(79,673,ls),
+(79,587,o),
+(124,544,o),
+(192,544,cs),
+(219,544,o),
+(248,555,o),
+(279,569,c),
+(249,581,l),
+(249,392,l),
+(137,392,l),
+(137,481,l),
+(79,481,l),
+(79,233,l),
+(137,233,l),
+(137,323,l),
+(249,323,l),
+(249,129,l),
+(279,145,l),
+(248,159,o),
+(218,170,o),
+(192,170,cs),
+(124,170,o),
+(79,127,o),
+(79,41,cs),
+(79,0,l),
+(168,0,l),
+(168,27,ls),
+(168,72,o),
+(187,88,o),
+(213,88,cs),
+(266,88,o),
+(383,-13,o),
+(490,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(420,76,o),
+(365,106,o),
+(312,132,c),
+(312,323,l),
+(402,323,l),
+(402,226,l),
+(453,226,l),
+(453,357,l),
+(408,323,l),
+(446,323,ls),
+(531,323,o),
+(578,274,o),
+(578,198,cs),
+(578,120,o),
+(537,76,o),
+(468,76,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(453,480,l),
+(402,480,l),
+(402,392,l),
+(312,392,l),
+(312,582,l),
+(365,608,o),
+(420,638,o),
+(467,638,cs),
+(537,638,o),
+(578,594,o),
+(578,516,cs),
+(578,440,o),
+(530,392,o),
+(446,392,cs),
+(408,392,l),
+(453,357,l)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165E;
+unicode = 5726;
+},
+{
+color = 9;
+glyphname = "tsiCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(605,-13,o),
+(676,69,o),
+(676,183,cs),
+(676,278,o),
+(622,348,o),
+(535,368,c),
+(535,346,l),
+(623,365,o),
+(676,433,o),
+(676,531,cs),
+(676,645,o),
+(605,727,o),
+(490,727,cs),
+(383,727,o),
+(266,626,o),
+(213,626,cs),
+(187,626,o),
+(168,642,o),
+(168,687,cs),
+(168,714,l),
+(79,714,l),
+(79,673,ls),
+(79,586,o),
+(124,544,o),
+(192,544,cs),
+(216,544,o),
+(243,555,o),
+(270,567,c),
+(236,599,l),
+(236,392,l),
+(137,392,l),
+(137,481,l),
+(79,481,l),
+(79,233,l),
+(137,233,l),
+(137,323,l),
+(236,323,l),
+(236,115,l),
+(269,148,l),
+(241,160,o),
+(215,170,o),
+(192,170,cs),
+(124,170,o),
+(79,128,o),
+(79,41,cs),
+(79,0,l),
+(168,0,l),
+(168,27,ls),
+(168,72,o),
+(187,88,o),
+(213,88,cs),
+(266,88,o),
+(383,-13,o),
+(490,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(416,76,o),
+(357,110,o),
+(299,136,c),
+(299,323,l),
+(360,323,l),
+(371,294,o),
+(398,275,o),
+(429,275,cs),
+(472,275,o),
+(501,311,o),
+(504,351,c),
+(437,323,l),
+(456,323,ls),
+(533,323,o),
+(578,276,o),
+(578,198,cs),
+(578,120,o),
+(537,76,o),
+(468,76,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(503,405,o),
+(472,440,o),
+(429,440,cs),
+(397,440,o),
+(371,421,o),
+(360,392,c),
+(299,392,l),
+(299,578,l),
+(357,604,o),
+(416,638,o),
+(467,638,cs),
+(537,638,o),
+(578,594,o),
+(578,516,cs),
+(578,438,o),
+(533,391,o),
+(456,391,cs),
+(438,391,l),
+(505,362,l)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni165F;
+unicode = 5727;
+},
+{
+color = 9;
+glyphname = "tsaCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(367,-13,o),
+(484,88,o),
+(537,88,cs),
+(562,88,o),
+(582,72,o),
+(582,27,cs),
+(582,0,l),
+(671,0,l),
+(671,41,ls),
+(671,127,o),
+(626,170,o),
+(558,170,cs),
+(527,170,o),
+(493,157,o),
+(458,141,c),
+(498,133,l),
+(498,322,l),
+(611,322,l),
+(611,233,l),
+(671,233,l),
+(671,481,l),
+(611,481,l),
+(611,392,l),
+(498,392,l),
+(498,581,l),
+(457,573,l),
+(492,557,o),
+(526,544,o),
+(558,544,cs),
+(626,544,o),
+(671,587,o),
+(671,673,cs),
+(671,714,l),
+(582,714,l),
+(582,687,ls),
+(582,642,o),
+(562,626,o),
+(537,626,cs),
+(484,626,o),
+(367,727,o),
+(260,727,cs),
+(145,727,o),
+(74,645,o),
+(74,531,cs),
+(74,433,o),
+(127,365,o),
+(217,346,c),
+(216,368,l),
+(127,348,o),
+(74,278,o),
+(74,183,cs),
+(74,69,o),
+(145,-13,o),
+(260,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(213,76,o),
+(173,120,o),
+(173,193,cs),
+(173,274,o),
+(225,322,o),
+(318,322,cs),
+(427,322,l),
+(427,127,l),
+(378,103,o),
+(327,76,o),
+(282,76,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(225,392,o),
+(173,440,o),
+(173,521,cs),
+(173,594,o),
+(213,638,o),
+(282,638,cs),
+(327,638,o),
+(378,611,o),
+(427,587,c),
+(427,392,l),
+(318,392,ls)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1660;
+unicode = 5728;
+},
+{
+color = 9;
+glyphname = "chuCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(366,-13,o),
+(431,38,o),
+(459,133,c),
+(431,133,l),
+(458,38,o),
+(524,-13,o),
+(616,-13,cs),
+(750,-13,o),
+(820,79,o),
+(820,203,cs),
+(820,340,o),
+(728,482,o),
+(728,567,cs),
+(728,601,o),
+(744,628,o),
+(798,628,cs),
+(828,628,l),
+(828,714,l),
+(778,714,ls),
+(675,714,o),
+(633,659,o),
+(633,580,cs),
+(633,471,o),
+(721,331,o),
+(721,214,cs),
+(721,129,o),
+(683,75,o),
+(609,75,cs),
+(534,75,o),
+(491,129,o),
+(491,234,cs),
+(491,643,l),
+(568,643,l),
+(568,714,l),
+(321,714,l),
+(321,643,l),
+(399,643,l),
+(399,234,ls),
+(399,130,o),
+(356,75,o),
+(281,75,cs),
+(207,75,o),
+(169,129,o),
+(169,214,cs),
+(169,331,o),
+(256,471,o),
+(256,580,cs),
+(256,659,o),
+(214,714,o),
+(111,714,cs),
+(61.004,714,l),
+(61,628,l),
+(91,628,ls),
+(145,628,o),
+(162,601,o),
+(162,567,cs),
+(162,482,o),
+(70,340,o),
+(70,203,cs),
+(70,79,o),
+(140,-13,o),
+(273,-13,cs)
+);
+}
+);
+width = 889;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164E;
+unicode = 5729;
+},
+{
+color = 9;
+glyphname = "choCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(111,0,ls),
+(214,0,o),
+(256,55,o),
+(256,134,cs),
+(256,243,o),
+(169,383,o),
+(169,500,cs),
+(169,585,o),
+(206,639,o),
+(281,639,cs),
+(355,639,o),
+(399,585,o),
+(399,480,cs),
+(399,71,l),
+(321,71,l),
+(321,0,l),
+(568,0,l),
+(568,71,l),
+(490,71,l),
+(490,480,ls),
+(490,584,o),
+(534,639,o),
+(608,639,cs),
+(683,639,o),
+(721,585,o),
+(721,500,cs),
+(721,383,o),
+(633,243,o),
+(633,134,cs),
+(633,55,o),
+(675,0,o),
+(778,0,cs),
+(828,0,l),
+(828,86,l),
+(798,86,ls),
+(744,86,o),
+(727,113,o),
+(727,147,cs),
+(727,232,o),
+(819,374,o),
+(819,511,cs),
+(819,635,o),
+(750,727,o),
+(616,727,cs),
+(524,727,o),
+(458,676,o),
+(430,581,c),
+(459,581,l),
+(431,676,o),
+(365,727,o),
+(273,727,cs),
+(140,727,o),
+(70,635,o),
+(70,511,cs),
+(70,374,o),
+(162,232,o),
+(162,147,cs),
+(162,113,o),
+(145,86,o),
+(91,86,cs),
+(61,86,l),
+(61.004,0,l)
+);
+}
+);
+width = 889;
+}
+);
+metricLeft = "suCarrier-canadian";
+metricRight = "suCarrier-canadian";
+note = uni164F;
+unicode = 5730;
+},
+{
+color = 9;
+glyphname = "cheCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(605,-13,o),
+(676,69,o),
+(676,183,cs),
+(676,278,o),
+(623,348,o),
+(534,368,c),
+(533,346,l),
+(623,365,o),
+(676,433,o),
+(676,531,cs),
+(676,645,o),
+(605,727,o),
+(490,727,cs),
+(383,727,o),
+(266,626,o),
+(213,626,cs),
+(187,626,o),
+(168,642,o),
+(168,687,cs),
+(168,714,l),
+(79,714,l),
+(79,672,ls),
+(79,587,o),
+(124,544,o),
+(192,544,cs),
+(277,544,o),
+(382,638,o),
+(467,638,cs),
+(536,638,o),
+(577,594,o),
+(577,521,cs),
+(577,440,o),
+(524,398,o),
+(432,398,cs),
+(138,398,l),
+(138,481,l),
+(79,481,l),
+(79,233,l),
+(138,233,l),
+(138,317,l),
+(432,317,ls),
+(525,317,o),
+(577,274,o),
+(577,193,cs),
+(577,120,o),
+(536,76,o),
+(467,76,cs),
+(382,76,o),
+(277,170,o),
+(192,170,cs),
+(124,170,o),
+(79,127,o),
+(79,42,cs),
+(79,0,l),
+(168,0,l),
+(168,27,ls),
+(168,72,o),
+(187,88,o),
+(213,88,cs),
+(266,88,o),
+(383,-13,o),
+(490,-13,cs)
+);
+}
+);
+width = 750;
+}
+);
+metricRight = "khiCarrier-canadian";
+note = uni1663;
+unicode = 5731;
+},
+{
+color = 9;
+glyphname = "cheeCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(605,-13,o),
+(676,69,o),
+(676,183,cs),
+(676,278,o),
+(623,348,o),
+(534,368,c),
+(533,346,l),
+(623,365,o),
+(676,433,o),
+(676,531,cs),
+(676,645,o),
+(605,727,o),
+(490,727,cs),
+(383,727,o),
+(266,626,o),
+(213,626,cs),
+(187,626,o),
+(168,642,o),
+(168,687,cs),
+(168,714,l),
+(79,714,l),
+(79,672,ls),
+(79,587,o),
+(124,544,o),
+(192,544,cs),
+(277,544,o),
+(383,640,o),
+(469,640,cs),
+(538,640,o),
+(579,595,o),
+(579,519,cs),
+(579,438,o),
+(527,392,o),
+(442,392,cs),
+(383,392,l),
+(407,377,l),
+(407,478,l),
+(347,478,l),
+(347,392,l),
+(138,392,l),
+(138,481,l),
+(79,481,l),
+(79,233,l),
+(138,233,l),
+(138,323,l),
+(347,323,l),
+(347,228,l),
+(407,228,l),
+(407,337,l),
+(383,323,l),
+(442,323,ls),
+(528,323,o),
+(579,276,o),
+(579,195,cs),
+(579,119,o),
+(538,74,o),
+(469,74,cs),
+(383,74,o),
+(277,170,o),
+(192,170,cs),
+(124,170,o),
+(79,127,o),
+(79,42,cs),
+(79,0,l),
+(168,0,l),
+(168,27,ls),
+(168,72,o),
+(187,88,o),
+(213,88,cs),
+(266,88,o),
+(383,-13,o),
+(490,-13,cs)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1664;
+unicode = 5732;
+},
+{
+color = 9;
+glyphname = "chiCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(605,-13,o),
+(676,69,o),
+(676,183,cs),
+(676,278,o),
+(622,348,o),
+(535,368,c),
+(535,346,l),
+(623,365,o),
+(676,433,o),
+(676,531,cs),
+(676,645,o),
+(605,727,o),
+(490,727,cs),
+(383,727,o),
+(266,626,o),
+(213,626,cs),
+(187,626,o),
+(168,642,o),
+(168,687,cs),
+(168,714,l),
+(79,714,l),
+(79,672,ls),
+(79,587,o),
+(124,544,o),
+(192,544,cs),
+(277,544,o),
+(383,640,o),
+(469,640,cs),
+(538,640,o),
+(579,595,o),
+(579,519,cs),
+(579,438,o),
+(527,392,o),
+(447,392,cs),
+(402,392,l),
+(435,361,l),
+(433,406,o),
+(399,440,o),
+(355,440,cs),
+(322,440,o),
+(294,420,o),
+(282,392,c),
+(138,392,l),
+(138,481,l),
+(79,481,l),
+(79,233,l),
+(138,233,l),
+(138,323,l),
+(283,323,l),
+(295,295,o),
+(323,275,o),
+(355,275,cs),
+(399,275,o),
+(431,310,o),
+(435,352,c),
+(401,323,l),
+(447,323,ls),
+(528,323,o),
+(579,276,o),
+(579,195,cs),
+(579,119,o),
+(538,74,o),
+(469,74,cs),
+(383,74,o),
+(277,170,o),
+(192,170,cs),
+(124,170,o),
+(79,127,o),
+(79,42,cs),
+(79,0,l),
+(168,0,l),
+(168,27,ls),
+(168,72,o),
+(187,88,o),
+(213,88,cs),
+(266,88,o),
+(383,-13,o),
+(490,-13,cs)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1665;
+unicode = 5733;
+},
+{
+color = 9;
+glyphname = "chaCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(367,-13,o),
+(484,88,o),
+(537,88,cs),
+(562,88,o),
+(582,72,o),
+(582,27,cs),
+(582,0,l),
+(671,0,l),
+(671,42,ls),
+(671,127,o),
+(626,170,o),
+(558,170,cs),
+(473,170,o),
+(368,76,o),
+(283,76,cs),
+(214,76,o),
+(173,120,o),
+(173,193,cs),
+(173,274,o),
+(226,317,o),
+(318,317,cs),
+(611,317,l),
+(611,233,l),
+(671,233,l),
+(671,481,l),
+(611,481,l),
+(611,398,l),
+(318,398,ls),
+(225,398,o),
+(173,440,o),
+(173,521,cs),
+(173,594,o),
+(214,638,o),
+(283,638,cs),
+(368,638,o),
+(473,544,o),
+(558,544,cs),
+(626,544,o),
+(671,587,o),
+(671,672,cs),
+(671,714,l),
+(582,714,l),
+(582,687,ls),
+(582,642,o),
+(562,626,o),
+(537,626,cs),
+(484,626,o),
+(367,727,o),
+(260,727,cs),
+(145,727,o),
+(74,645,o),
+(74,531,cs),
+(74,433,o),
+(127,365,o),
+(217,346,c),
+(216,368,l),
+(127,348,o),
+(74,278,o),
+(74,183,cs),
+(74,69,o),
+(145,-13,o),
+(260,-13,cs)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni1666;
+unicode = 5734;
+},
+{
+color = 9;
+glyphname = "ttsuCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(366,-13,o),
+(431,38,o),
+(459,133,c),
+(431,133,l),
+(458,38,o),
+(524,-13,o),
+(616,-13,cs),
+(750,-13,o),
+(820,79,o),
+(820,203,cs),
+(820,340,o),
+(728,482,o),
+(728,567,cs),
+(728,601,o),
+(744,628,o),
+(798,628,cs),
+(828,628,l),
+(828,714,l),
+(778,714,ls),
+(675,714,o),
+(633,659,o),
+(633,580,cs),
+(633,549,o),
+(640,515,o),
+(649,480,c),
+(683,556,l),
+(490,424,l),
+(490,643,l),
+(568,643,l),
+(568,714,l),
+(321,714,l),
+(321,643,l),
+(400,643,l),
+(400,424,l),
+(206,556,l),
+(241,480,l),
+(249,516,o),
+(256,549,o),
+(256,580,cs),
+(256,659,o),
+(214,714,o),
+(111,714,cs),
+(61.004,714,l),
+(61,628,l),
+(91,628,ls),
+(145,628,o),
+(162,601,o),
+(162,567,cs),
+(162,482,o),
+(70,340,o),
+(70,203,cs),
+(70,79,o),
+(140,-13,o),
+(273,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(207,75,o),
+(169,129,o),
+(169,214,cs),
+(169,289,o),
+(206,370,o),
+(230,444,c),
+(400,331,l),
+(400,234,ls),
+(400,130,o),
+(356,75,o),
+(281,75,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(534,75,o),
+(490,129,o),
+(490,234,cs),
+(490,331,l),
+(659,444,l),
+(684,370,o),
+(721,288,o),
+(721,214,cs),
+(721,129,o),
+(683,75,o),
+(609,75,cs)
+);
+}
+);
+width = 889;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1667;
+unicode = 5735;
+},
+{
+color = 9;
+glyphname = "ttsoCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(111,0,ls),
+(214,0,o),
+(256,55,o),
+(256,134,cs),
+(256,165,o),
+(249,198,o),
+(241,234,c),
+(206,158,l),
+(400,290,l),
+(400,71,l),
+(321,71,l),
+(321,0,l),
+(568,0,l),
+(568,71,l),
+(490,71,l),
+(490,290,l),
+(683,158,l),
+(649,234,l),
+(640,199,o),
+(633,165,o),
+(633,134,cs),
+(633,55,o),
+(675,0,o),
+(778,0,cs),
+(828,0,l),
+(828,86,l),
+(798,86,ls),
+(744,86,o),
+(728,113,o),
+(728,147,cs),
+(728,232,o),
+(820,374,o),
+(820,511,cs),
+(820,635,o),
+(750,727,o),
+(616,727,cs),
+(524,727,o),
+(458,676,o),
+(431,581,c),
+(459,581,l),
+(431,676,o),
+(366,727,o),
+(273,727,cs),
+(140,727,o),
+(70,635,o),
+(70,511,cs),
+(70,374,o),
+(162,232,o),
+(162,147,cs),
+(162,113,o),
+(145,86,o),
+(91,86,cs),
+(61,86,l),
+(61.004,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(206,344,o),
+(169,425,o),
+(169,500,cs),
+(169,585,o),
+(207,639,o),
+(281,639,cs),
+(356,639,o),
+(400,584,o),
+(400,480,cs),
+(400,383,l),
+(230,270,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(490,383,l),
+(490,480,ls),
+(490,585,o),
+(534,639,o),
+(609,639,cs),
+(683,639,o),
+(721,585,o),
+(721,500,cs),
+(721,426,o),
+(684,344,o),
+(659,270,c)
+);
+}
+);
+width = 889;
+}
+);
+metricLeft = "soCarrier-canadian";
+metricRight = "soCarrier-canadian";
+note = uni1668;
+unicode = 5736;
+},
+{
+color = 9;
+glyphname = "ttseCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(605,-13,o),
+(676,69,o),
+(676,183,cs),
+(676,278,o),
+(622,348,o),
+(535,368,c),
+(535,346,l),
+(623,365,o),
+(676,433,o),
+(676,531,cs),
+(676,645,o),
+(605,727,o),
+(490,727,cs),
+(383,727,o),
+(266,626,o),
+(213,626,cs),
+(187,626,o),
+(168,642,o),
+(168,687,cs),
+(168,714,l),
+(79,714,l),
+(79,672,ls),
+(79,587,o),
+(124,544,o),
+(192,544,cs),
+(207,544,o),
+(221,546,o),
+(236,553,c),
+(164,588,l),
+(251,392,l),
+(138,392,l),
+(138,481,l),
+(79,481,l),
+(79,233,l),
+(138,233,l),
+(138,323,l),
+(251,323,l),
+(164,126,l),
+(236,161,l),
+(221,168,o),
+(207,170,o),
+(192,170,cs),
+(124,170,o),
+(79,127,o),
+(79,42,cs),
+(79,0,l),
+(168,0,l),
+(168,27,ls),
+(168,72,o),
+(187,88,o),
+(213,88,cs),
+(266,88,o),
+(383,-13,o),
+(490,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(400,74,o),
+(318,137,o),
+(252,157,c),
+(324,323,l),
+(447,323,ls),
+(528,323,o),
+(579,276,o),
+(579,195,cs),
+(579,119,o),
+(538,74,o),
+(469,74,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(252,557,l),
+(318,577,o),
+(400,640,o),
+(469,640,cs),
+(538,640,o),
+(579,595,o),
+(579,519,cs),
+(579,438,o),
+(527,392,o),
+(447,392,cs),
+(324,392,l)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni1669;
+unicode = 5737;
+},
+{
+color = 9;
+glyphname = "ttseeCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(605,-13,o),
+(676,69,o),
+(676,183,cs),
+(676,278,o),
+(622,348,o),
+(535,368,c),
+(535,346,l),
+(623,365,o),
+(676,433,o),
+(676,531,cs),
+(676,645,o),
+(605,727,o),
+(490,727,cs),
+(383,727,o),
+(266,626,o),
+(213,626,cs),
+(187,626,o),
+(168,642,o),
+(168,687,cs),
+(168,714,l),
+(79,714,l),
+(79,672,ls),
+(79,587,o),
+(124,544,o),
+(192,544,cs),
+(208,544,o),
+(223,546,o),
+(232,554,c),
+(163,586,l),
+(250,392,l),
+(138,392,l),
+(138,481,l),
+(79,481,l),
+(79,233,l),
+(138,233,l),
+(138,323,l),
+(250,323,l),
+(163,128,l),
+(232,160,l),
+(223,168,o),
+(208,170,o),
+(192,170,cs),
+(124,170,o),
+(79,127,o),
+(79,42,cs),
+(79,0,l),
+(168,0,l),
+(168,27,ls),
+(168,72,o),
+(187,88,o),
+(213,88,cs),
+(266,88,o),
+(383,-13,o),
+(490,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(399,74,o),
+(317,138,o),
+(249,158,c),
+(321,323,l),
+(396,323,l),
+(396,226,l),
+(448,226,l),
+(448,341,l),
+(426,323,l),
+(447,323,ls),
+(528,323,o),
+(579,276,o),
+(579,195,cs),
+(579,119,o),
+(538,74,o),
+(469,74,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(448,480,l),
+(396,480,l),
+(396,392,l),
+(321,392,l),
+(249,556,l),
+(317,576,o),
+(399,640,o),
+(469,640,cs),
+(538,640,o),
+(579,595,o),
+(579,519,cs),
+(579,438,o),
+(527,392,o),
+(447,392,cs),
+(426,392,l),
+(448,374,l)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166A;
+unicode = 5738;
+},
+{
+color = 9;
+glyphname = "ttsiCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(605,-13,o),
+(676,69,o),
+(676,183,cs),
+(676,278,o),
+(622,348,o),
+(535,368,c),
+(535,346,l),
+(623,365,o),
+(676,433,o),
+(676,531,cs),
+(676,645,o),
+(605,727,o),
+(490,727,cs),
+(383,727,o),
+(266,626,o),
+(213,626,cs),
+(187,626,o),
+(168,642,o),
+(168,687,cs),
+(168,714,l),
+(79,714,l),
+(79,672,ls),
+(79,587,o),
+(124,544,o),
+(192,544,cs),
+(203,544,o),
+(213,545,o),
+(226,550,c),
+(172,568,l),
+(250,392,l),
+(138,392,l),
+(138,481,l),
+(79,481,l),
+(79,233,l),
+(138,233,l),
+(138,323,l),
+(250,323,l),
+(171,143,l),
+(226,164,l),
+(213,169,o),
+(203,170,o),
+(192,170,cs),
+(124,170,o),
+(79,127,o),
+(79,42,cs),
+(79,0,l),
+(168,0,l),
+(168,27,ls),
+(168,72,o),
+(187,88,o),
+(213,88,cs),
+(266,88,o),
+(383,-13,o),
+(490,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(398,74,o),
+(311,142,o),
+(241,162,c),
+(311,323,l),
+(343,323,l),
+(355,295,o),
+(381,275,o),
+(412,275,cs),
+(452,275,o),
+(483,307,o),
+(486,348,c),
+(436,323,l),
+(455,323,ls),
+(532,323,o),
+(579,276,o),
+(579,195,cs),
+(579,119,o),
+(538,74,o),
+(469,74,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(485,408,o),
+(453,440,o),
+(412,440,cs),
+(380,440,o),
+(354,420,o),
+(343,392,c),
+(311,392,l),
+(241,552,l),
+(311,572,o),
+(398,640,o),
+(469,640,cs),
+(538,640,o),
+(579,595,o),
+(579,519,cs),
+(579,438,o),
+(532,392,o),
+(455,392,cs),
+(437,392,l),
+(487,366,l)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "tseCarrier-canadian";
+metricRight = "khiCarrier-canadian";
+note = uni166B;
+unicode = 5739;
+},
+{
+color = 9;
+glyphname = "ttsaCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(367,-13,o),
+(484,88,o),
+(537,88,cs),
+(562,88,o),
+(582,72,o),
+(582,27,cs),
+(582,0,l),
+(671,0,l),
+(671,42,ls),
+(671,127,o),
+(626,170,o),
+(558,170,cs),
+(542,170,o),
+(529,168,o),
+(514,161,c),
+(586,126,l),
+(498,323,l),
+(611,323,l),
+(611,233,l),
+(671,233,l),
+(671,481,l),
+(611,481,l),
+(611,392,l),
+(498,392,l),
+(586,588,l),
+(514,553,l),
+(529,546,o),
+(542,544,o),
+(558,544,cs),
+(626,544,o),
+(671,587,o),
+(671,672,cs),
+(671,714,l),
+(582,714,l),
+(582,687,ls),
+(582,642,o),
+(562,626,o),
+(537,626,cs),
+(484,626,o),
+(367,727,o),
+(260,727,cs),
+(145,727,o),
+(74,645,o),
+(74,531,cs),
+(74,433,o),
+(127,365,o),
+(215,346,c),
+(215,368,l),
+(128,348,o),
+(74,278,o),
+(74,183,cs),
+(74,69,o),
+(145,-13,o),
+(260,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(212,74,o),
+(171,119,o),
+(171,195,cs),
+(171,276,o),
+(222,323,o),
+(303,323,cs),
+(426,323,l),
+(498,157,l),
+(432,137,o),
+(350,74,o),
+(281,74,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(222,392,o),
+(171,438,o),
+(171,519,cs),
+(171,595,o),
+(212,640,o),
+(281,640,cs),
+(350,640,o),
+(432,577,o),
+(498,557,c),
+(426,392,l),
+(303,392,ls)
+);
+}
+);
+width = 750;
+}
+);
+metricLeft = "=|khiCarrier-canadian";
+metricRight = "=|tseCarrier-canadian";
+note = uni166C;
+unicode = 5740;
+},
+{
+glyphname = "qai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "r-canadian";
+},
+{
+alignment = -1;
+pos = (341,0);
+ref = "ke-canadian";
+}
+);
+width = 948;
+}
+);
+note = uni166F;
+unicode = 5743;
+},
+{
+glyphname = "ngai-canadian";
+kernLeft = mwestleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ng-canadian";
+},
+{
+alignment = -1;
+pos = (658,0);
+ref = "ce-canadian";
+}
+);
+width = 1259;
+}
+);
+note = uni1670;
+unicode = 5744;
+},
+{
+glyphname = "nngi-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (952,0);
+ref = "ci-canadian";
+}
+);
+width = 1551;
+}
+);
+note = uni1671;
+unicode = 5745;
+},
+{
+glyphname = "nngii-canadian";
+kernRight = ciright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (952,0);
+ref = "ci-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (1183,0);
+ref = dot_top;
+}
+);
+width = 1551;
+}
+);
+note = uni1672;
+unicode = 5746;
+},
+{
+glyphname = "nngo-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (952,0);
+ref = "ce-canadian";
+}
+);
+width = 1551;
+}
+);
+note = uni1673;
+unicode = 5747;
+},
+{
+glyphname = "nngoo-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (952,0);
+ref = "ce-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (1173,0);
+ref = dot_top;
+}
+);
+width = 1551;
+}
+);
+note = uni1674;
+unicode = 5748;
+},
+{
+glyphname = "nnga-canadian";
+kernRight = caright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (952,0);
+ref = "ca-canadian";
+}
+);
+width = 1551;
+}
+);
+note = uni1675;
+unicode = 5749;
+},
+{
+glyphname = "nngaa-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "nng-canadian";
+},
+{
+alignment = -1;
+pos = (952,0);
+ref = "ca-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (995,0);
+ref = dot_top;
+}
+);
+width = 1551;
+}
+);
+note = uni1676;
+unicode = 5750;
+},
+{
+glyphname = "thweeWoodScree-canadian";
+kernLeft = yeleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (628,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 861;
+}
+);
+note = uni1677;
+unicode = 5751;
+},
+{
+glyphname = "thwiWoodScree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (628,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 861;
+}
+);
+note = uni1678;
+unicode = 5752;
+},
+{
+glyphname = "thwiiWoodScree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (90,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (628,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 861;
+}
+);
+note = uni1679;
+unicode = 5753;
+},
+{
+glyphname = "thwoWoodScree-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (628,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 861;
+}
+);
+note = uni167A;
+unicode = 5754;
+},
+{
+glyphname = "thwooWoodScree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (387,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (628,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 861;
+}
+);
+note = uni167B;
+unicode = 5755;
+},
+{
+glyphname = "thwaWoodScree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = middle_right_can;
+pos = (628,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 860;
+}
+);
+note = uni167C;
+unicode = 5756;
+},
+{
+glyphname = "thwaaWoodScree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+ref = "thaThCree-canadian";
+},
+{
+anchor = top_left_can;
+pos = (90,0);
+ref = dot_top;
+},
+{
+anchor = middle_right_can;
+pos = (628,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 860;
+}
+);
+note = uni167D;
+unicode = 5757;
+},
+{
+glyphname = "wBlackfoot-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(397,577,l),
+(397,636,l),
+(66,636,l),
+(66,577,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(397,435,l),
+(397,494,l),
+(66,494,l),
+(66,435,l)
+);
+}
+);
+width = 463;
+}
+);
+metricRight = "=|";
+note = uni167F;
+unicode = 5759;
+},
+{
+glyphname = "oy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "o-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-8,0);
+ref = ring_top.canadian;
+}
+);
+width = 701;
+}
+);
+note = uni18B0;
+unicode = 6320;
+},
+{
+glyphname = "ay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (450,0);
+ref = ring_top.canadian;
+}
+);
+width = 701;
+}
+);
+note = uni18B1;
+unicode = 6321;
+},
+{
+glyphname = "aay-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (194,0);
+ref = ring_top.canadian;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (503,0);
+ref = dot_top;
+}
+);
+width = 701;
+}
+);
+note = uni18B2;
+unicode = 6322;
+},
+{
+glyphname = "way-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "a-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (682,0);
+ref = ring_top.canadian;
+}
+);
+width = 933;
+}
+);
+note = uni18B3;
+unicode = 6323;
+},
+{
+glyphname = "poy-canadian";
+kernLeft = ocanleft;
+kernRight = ocanright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-31,0);
+ref = ring_top.canadian;
+}
+);
+width = 672;
+}
+);
+note = uni18B4;
+unicode = 6324;
+},
+{
+glyphname = "pay-canadian";
+kernLeft = acanleft;
+kernRight = acanright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "pa-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (445,0);
+ref = ring_top.canadian;
+}
+);
+width = 672;
+}
+);
+note = uni18B5;
+unicode = 6325;
+},
+{
+glyphname = "pwoy-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "po-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (202,0);
+ref = ring_top.canadian;
+}
+);
+width = 905;
+}
+);
+note = uni18B6;
+unicode = 6326;
+},
+{
+glyphname = "tay-canadian";
+kernRight = taright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ta-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (216,0);
+ref = ring_top.canadian;
+}
+);
+width = 628;
+}
+);
+note = uni18B7;
+unicode = 6327;
+},
+{
+glyphname = "kay-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-9,0);
+ref = ring_top.canadian;
+}
+);
+width = 607;
+}
+);
+note = uni18B8;
+unicode = 6328;
+},
+{
+glyphname = "kway-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ka-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (224,0);
+ref = ring_top.canadian;
+}
+);
+width = 839;
+}
+);
+note = uni18B9;
+unicode = 6329;
+},
+{
+glyphname = "may-canadian";
+kernRight = maright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-1,0);
+ref = ring_top.canadian;
+}
+);
+width = 547;
+}
+);
+note = uni18BA;
+unicode = 6330;
+},
+{
+glyphname = "noy-canadian";
+kernLeft = noleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (396,-199);
+ref = ring_top.canadian;
+}
+);
+width = 833;
+}
+);
+note = uni18BB;
+unicode = 6331;
+},
+{
+glyphname = "nay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (178,-199);
+ref = ring_top.canadian;
+}
+);
+width = 833;
+}
+);
+note = uni18BC;
+unicode = 6332;
+},
+{
+glyphname = "lay-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "la-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (178,-199);
+ref = ring_top.canadian;
+}
+);
+width = 833;
+}
+);
+note = uni18BD;
+unicode = 6333;
+},
+{
+glyphname = "soy-canadian";
+kernRight = soright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (301,0);
+ref = ring_top.canadian;
+}
+);
+width = 558;
+}
+);
+note = uni18BE;
+unicode = 6334;
+},
+{
+glyphname = "say-canadian";
+kernLeft = saleft;
+kernRight = saright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-1,0);
+ref = ring_top.canadian;
+}
+);
+width = 558;
+}
+);
+note = uni18BF;
+unicode = 6335;
+},
+{
+glyphname = "shoy-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (351,-199);
+ref = ring_top.canadian;
+}
+);
+width = 960;
+}
+);
+note = uni18C0;
+unicode = 6336;
+},
+{
+glyphname = "shay-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "sha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (351,-199);
+ref = ring_top.canadian;
+}
+);
+width = 960;
+}
+);
+note = uni18C1;
+unicode = 6337;
+},
+{
+glyphname = "shwoy-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "sho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (583,-199);
+ref = ring_top.canadian;
+}
+);
+width = 1193;
+}
+);
+note = uni18C2;
+unicode = 6338;
+},
+{
+glyphname = "yoy-canadian";
+kernLeft = yoleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (333,0);
+ref = ring_top.canadian;
+}
+);
+width = 590;
+}
+);
+note = uni18C3;
+unicode = 6339;
+},
+{
+glyphname = "yay-canadian";
+kernRight = yaright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (-1,0);
+ref = ring_top.canadian;
+}
+);
+width = 590;
+}
+);
+note = uni18C4;
+unicode = 6340;
+},
+{
+glyphname = "ray-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (188,0);
+ref = ring_top.canadian;
+}
+);
+width = 562;
+}
+);
+note = uni18C5;
+unicode = 6341;
+},
+{
+glyphname = "nwi-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ni-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni18C6;
+unicode = 6342;
+},
+{
+glyphname = "nwiOjibway-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (833,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni18C7;
+unicode = 6343;
+},
+{
+glyphname = "nwii-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (475,-199);
+ref = dot_top;
+}
+);
+width = 1065;
+}
+);
+note = uni18C8;
+unicode = 6344;
+},
+{
+glyphname = "nwiiOjibway-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (243,-199);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (833,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni18C9;
+unicode = 6345;
+},
+{
+glyphname = "nwo-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "no-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni18CA;
+unicode = 6346;
+},
+{
+glyphname = "nwoOjibway-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (833,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni18CB;
+unicode = 6347;
+},
+{
+glyphname = "nwoo-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (681,-199);
+ref = dot_top;
+}
+);
+width = 1065;
+}
+);
+note = uni18CC;
+unicode = 6348;
+},
+{
+glyphname = "nwooOjibway-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (449,-199);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (833,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1065;
+}
+);
+note = uni18CD;
+unicode = 6349;
+},
+{
+glyphname = "rwee-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "reRCree-canadian";
+}
+);
+width = 1113;
+}
+);
+note = uni18CE;
+unicode = 6350;
+},
+{
+glyphname = "rwi-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ri-canadian";
+}
+);
+width = 1113;
+}
+);
+note = uni18CF;
+unicode = 6351;
+},
+{
+glyphname = "rwii-canadian";
+kernRight = naright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ri-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (468,-199);
+ref = dot_top;
+}
+);
+width = 1113;
+}
+);
+note = uni18D0;
+unicode = 6352;
+},
+{
+glyphname = "rwo-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ro-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni18D1;
+unicode = 6353;
+},
+{
+glyphname = "rwoo-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ro-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (401,0);
+ref = dot_top;
+}
+);
+width = 794;
+}
+);
+note = uni18D2;
+unicode = 6354;
+},
+{
+glyphname = "rwa-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = "ra-canadian";
+}
+);
+width = 794;
+}
+);
+note = uni18D3;
+unicode = 6355;
+},
+{
+glyphname = "pOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(117,357,l),
+(244,643,l),
+(195,643,l),
+(322,357,l),
+(388,357,l),
+(388,372,l),
+(229,714,l),
+(209,714,l),
+(50,372,l),
+(50,357,l)
+);
+}
+);
+width = 438;
+}
+);
+metricLeft = "kkCarrier-canadian";
+note = uni18D4;
+unicode = 6356;
+},
+{
+glyphname = "tOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+ref = "ringTophalfFinal-canadian";
+}
+);
+width = 439;
+}
+);
+metricRight = "=|";
+note = uni1422;
+unicode = 6357;
+},
+{
+glyphname = "kOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(137,357,l),
+(137,522,l),
+(121,518,l),
+(129,478,o),
+(164,449,o),
+(211,449,cs),
+(278,449,o),
+(330,500,o),
+(330,582,cs),
+(330,669,o),
+(273,720,o),
+(200,720,cs),
+(118,720,o),
+(66,666,o),
+(66,581,cs),
+(66,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(160,501,o),
+(131,531,o),
+(131,584,cs),
+(131,639,o),
+(157,667,o),
+(199,667,cs),
+(239,667,o),
+(266,637,o),
+(266,584,cs),
+(266,531,o),
+(238,501,o),
+(198,501,cs)
+);
+}
+);
+width = 386;
+}
+);
+metricLeft = "k-canadian";
+metricRight = "k-canadian";
+note = uni18D6;
+unicode = 6358;
+},
+{
+glyphname = "cOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(137,357,l),
+(137,587,ls),
+(137,639,o),
+(160,664,o),
+(200,664,cs),
+(239,664,o),
+(265,639,o),
+(265,592,cs),
+(265,567,l),
+(331,567,l),
+(331,587,ls),
+(331,672,o),
+(278,720,o),
+(200,720,cs),
+(115,720,o),
+(66,671,o),
+(66,578,cs),
+(66,357,l)
+);
+}
+);
+width = 376;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni18D7;
+unicode = 6359;
+},
+{
+glyphname = "mOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(137,357,l),
+(137,648,l),
+(300,648,l),
+(300,714,l),
+(66,714,l),
+(66,357,l)
+);
+}
+);
+width = 349;
+}
+);
+metricLeft = "m-canadian";
+metricRight = "m-canadian";
+note = uni18D8;
+unicode = 6360;
+},
+{
+glyphname = "nOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(266,443,o),
+(317,494,o),
+(317,575,cs),
+(317,624,o),
+(294,666,o),
+(261,679,c),
+(258,648,l),
+(446,648,l),
+(446,714,l),
+(193,714,ls),
+(108,714,o),
+(56,660,o),
+(56,578,cs),
+(56,496,o),
+(109,443,o),
+(187,443,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(147,496,o),
+(119,526,o),
+(119,578,cs),
+(119,631,o),
+(147,661,o),
+(187,661,cs),
+(227,661,o),
+(254,631,o),
+(254,578,cs),
+(254,526,o),
+(227,496,o),
+(187,496,cs)
+);
+}
+);
+width = 495;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "n-canadian";
+note = uni18D9;
+unicode = 6361;
+},
+{
+glyphname = "sOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(137,357,l),
+(137,503,l),
+(94,471,l),
+(131,471,ls),
+(241,471,o),
+(304,544,o),
+(304,657,cs),
+(304,714,l),
+(233,714,l),
+(233,661,ls),
+(233,572,o),
+(193,528,o),
+(105,528,cs),
+(66,528,l),
+(66,357,l)
+);
+}
+);
+width = 370;
+}
+);
+metricLeft = "s-canadian";
+metricRight = "s-canadian";
+note = uni18DA;
+unicode = 6362;
+},
+{
+color = 1;
+glyphname = "shOjibway-canadian";
+kernLeft = mwestleft;
+kernRight = mwestright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(256,351,o),
+(300,400,o),
+(307,488,cs),
+(316,588,ls),
+(321,639,o),
+(339,666,o),
+(380,666,cs),
+(421,666,o),
+(444,640,o),
+(444,591,cs),
+(444,567,l),
+(509,567,l),
+(509,588,ls),
+(509,673,o),
+(457,720,o),
+(380,720,cs),
+(298,720,o),
+(254,671,o),
+(246,583,cs),
+(238,483,ls),
+(233,432,o),
+(215,405,o),
+(174,405,cs),
+(133,405,o),
+(109,431,o),
+(109,480,cs),
+(109,504,l),
+(45,504,l),
+(45,483,ls),
+(45,398,o),
+(96,351,o),
+(173,351,cs)
+);
+}
+);
+width = 554;
+}
+);
+metricLeft = "=|c-canadian";
+metricRight = "c-canadian";
+note = uni18DB;
+unicode = 6363;
+},
+{
+color = 9;
+glyphname = "easternw-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (37,-318);
+ref = dot_top;
+},
+{
+alignment = -1;
+pos = (135,0);
+ref = "glottalstop-canadian";
+}
+);
+width = 585;
+}
+);
+note = uni18DC;
+unicode = 6364;
+},
+{
+color = 9;
+glyphname = "westernw-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (550,-318);
+ref = dot_top;
+scale = (-1,1);
+},
+{
+alignment = -1;
+pos = (451,0);
+ref = "glottalstop-canadian";
+scale = (-1,1);
+}
+);
+width = 587;
+}
+);
+metricLeft = "glottalstop-canadian";
+note = uni18DD;
+unicode = 6365;
+},
+{
+glyphname = "rweRCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "reRCree-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (880,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1113;
+}
+);
+note = uni18E0;
+unicode = 6368;
+},
+{
+glyphname = "looWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (52,0);
+ref = dot_top;
+}
+);
+width = 562;
+}
+);
+note = uni18E1;
+unicode = 6369;
+},
+{
+glyphname = "laaWestCree-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (358,0);
+ref = dot_top;
+}
+);
+width = 562;
+}
+);
+note = uni18E2;
+unicode = 6370;
+},
+{
+glyphname = "thwe-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "the-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (747,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 979;
+}
+);
+note = uni18E3;
+unicode = 6371;
+},
+{
+glyphname = "thwa-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "tha-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (696,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 928;
+}
+);
+note = uni18E4;
+unicode = 6372;
+},
+{
+glyphname = "tthwe-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "tthe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (738,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 970;
+}
+);
+note = uni18E5;
+unicode = 6373;
+},
+{
+glyphname = "tthoo-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ttho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (252,0);
+ref = dot_top;
+}
+);
+width = 645;
+}
+);
+note = uni18E6;
+unicode = 6374;
+},
+{
+glyphname = "tthaa-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ttha-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (255,0);
+ref = dot_top;
+}
+);
+width = 645;
+}
+);
+note = uni18E7;
+unicode = 6375;
+},
+{
+glyphname = "tlhwe-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "tlhe-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (617,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 849;
+}
+);
+note = uni18E8;
+unicode = 6376;
+},
+{
+glyphname = "tlhoo-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "tlho-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (249,0);
+ref = dot_top;
+}
+);
+width = 617;
+}
+);
+note = uni18E9;
+unicode = 6377;
+},
+{
+glyphname = "shweSayisi-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "sheSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (613,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 845;
+}
+);
+note = uni18EA;
+unicode = 6378;
+},
+{
+glyphname = "shooSayisi-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "shoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (417,0);
+ref = dot_top;
+}
+);
+width = 613;
+}
+);
+note = uni18EB;
+unicode = 6379;
+},
+{
+color = 9;
+glyphname = "hooSayisi-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "hoSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (491,0);
+ref = dot_top;
+}
+);
+width = 694;
+}
+);
+note = uni18EC;
+unicode = 6380;
+},
+{
+color = 9;
+glyphname = "gwuCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "guCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (886,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1119;
+}
+);
+note = uni18ED;
+unicode = 6381;
+},
+{
+color = 9;
+glyphname = "deneGeeCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "geCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (293,0);
+ref = dot_top;
+}
+);
+width = 733;
+}
+);
+note = uni18EE;
+unicode = 6382;
+},
+{
+color = 9;
+glyphname = "gaaCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (307,0);
+ref = dot_top;
+}
+);
+width = 733;
+}
+);
+note = uni18EF;
+unicode = 6383;
+},
+{
+color = 9;
+glyphname = "gwaCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "gaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (733,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 965;
+}
+);
+note = uni18F0;
+unicode = 6384;
+},
+{
+color = 9;
+glyphname = "juuSayisi-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "juSayisi-canadian";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (302,0);
+ref = dot_top;
+}
+);
+width = 744;
+}
+);
+note = uni18F1;
+unicode = 6385;
+},
+{
+color = 9;
+glyphname = "jwaCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "jaCarrier-canadian";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (789,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1021;
+}
+);
+note = uni18F2;
+unicode = 6386;
+},
+{
+glyphname = "lBeaverDene-canadian";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+ref = "pWestCree-canadian";
+}
+);
+width = 203;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+unicode = 6387;
+},
+{
+glyphname = "rBeaverDene-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(137,357,l),
+(137,558,ls),
+(137,616,o),
+(159,648,o),
+(210,648,cs),
+(220,648,l),
+(220,720,l),
+(211,720,ls),
+(160,720,o),
+(127,681,o),
+(125,633,c),
+(132,633,l),
+(132,714,l),
+(66,714,l),
+(66,357,l)
+);
+}
+);
+width = 252;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni18F4;
+unicode = 6388;
+},
+{
+color = 6;
+glyphname = "sDentalCarrier-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(234,189,ls),
+(316,189,o),
+(357,227,o),
+(357,291,cs),
+(357,354,o),
+(317,395,o),
+(237,395,cs),
+(191,395,ls),
+(151,395,o),
+(129,409,o),
+(129,443,cs),
+(129,477,o),
+(152,492,o),
+(191,492,cs),
+(350,492,l),
+(350,546,l),
+(189,546,ls),
+(107,546,o),
+(66,508,o),
+(66,444,cs),
+(66,382,o),
+(106,341,o),
+(186,341,cs),
+(232,341,ls),
+(272,341,o),
+(294,326,o),
+(294,292,cs),
+(294,258,o),
+(272,243,o),
+(232,243,cs),
+(73,243,l),
+(73,189,l)
+);
+}
+);
+width = 423;
+}
+);
+metricLeft = "shCarrier-canadian";
+metricRight = "=|";
+note = uni18F5;
+unicode = 6389;
+},
+{
+glyphname = "pWestCree-canadian.base";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "pWestCree-canadian";
+}
+);
+width = 203;
+}
+);
+metricLeft = "pWestCree-canadian";
+metricRight = "=|";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.base";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "c-canadian";
+}
+);
+width = 376;
+}
+);
+metricLeft = "c-canadian";
+metricRight = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "thSayisi-canadian.base";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "thSayisi-canadian";
+}
+);
+width = 376;
+}
+);
+metricLeft = "=|c-canadian";
+note = uni14A2;
+},
+{
+glyphname = "mWestCree-canadian.base";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-357);
+ref = "mWestCree-canadian";
+}
+);
+width = 382;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+glyphname = "pWestCree-canadian.mid";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "pWestCree-canadian";
+}
+);
+width = 203;
+}
+);
+metricLeft = "pWestCree-canadian";
+note = uni144A;
+},
+{
+glyphname = "c-canadian.mid";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "c-canadian";
+}
+);
+width = 376;
+}
+);
+metricLeft = "c-canadian";
+note = uni14A1;
+},
+{
+glyphname = "mWestCree-canadian.mid";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (0,-168);
+ref = "mWestCree-canadian";
+}
+);
+width = 382;
+}
+);
+metricLeft = "t-canadian";
+note = uni14BC;
+},
+{
+color = 11;
+glyphname = "ngaai-canadian.nunavik";
+lastChange = "2023-01-13 15:30:44 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (669,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (849,0);
+ref = ring_top.canadian;
+}
+);
+width = 1270;
+}
+);
+note = uni158E;
+},
+{
+color = 11;
+glyphname = "ngi-canadian.nunavik";
+lastChange = "2023-01-13 15:30:44 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (669,0);
+ref = "ci-canadian";
+}
+);
+width = 1270;
+}
+);
+note = uni158F;
+},
+{
+color = 11;
+glyphname = "ngii-canadian.nunavik";
+lastChange = "2023-01-13 15:30:44 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (669,0);
+ref = "ci-canadian";
+},
+{
+anchor = top_center_can;
+pos = (902,0);
+ref = dot_top;
+}
+);
+width = 1270;
+}
+);
+note = uni1590;
+},
+{
+color = 11;
+glyphname = "ngo-canadian.nunavik";
+lastChange = "2023-01-13 15:30:44 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (669,0);
+ref = "co-canadian";
+}
+);
+width = 1271;
+}
+);
+note = uni1591;
+},
+{
+color = 11;
+glyphname = "ngoo-canadian.nunavik";
+lastChange = "2023-01-13 15:30:44 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+ref = "ngo-canadian.nunavik";
+},
+{
+anchor = top_right_can;
+pos = (1074,0);
+ref = dot_top;
+}
+);
+width = 1271;
+}
+);
+note = uni1592;
+},
+{
+color = 11;
+glyphname = "nga-canadian.nunavik";
+lastChange = "2023-01-13 15:30:44 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (669,0);
+ref = "ca-canadian";
+}
+);
+width = 1270;
+}
+);
+note = uni1593;
+},
+{
+color = 11;
+glyphname = "ngaa-canadian.nunavik";
+lastChange = "2023-01-13 15:30:44 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (669,0);
+ref = "ca-canadian";
+},
+{
+anchor = top_left_can;
+pos = (714,0);
+ref = dot_top;
+}
+);
+width = 1270;
+}
+);
+note = uni1594;
+},
+{
+color = 11;
+glyphname = "ng-canadian.nunavik";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(557,164,o),
+(613,215,o),
+(613,302,cs),
+(613,384,o),
+(562,435,o),
+(494,435,cs),
+(452,435,o),
+(419,409,o),
+(410,372,c),
+(421,370,l),
+(421,515,l),
+(267,515,l),
+(272,496,l),
+(300,510,o),
+(317,548,o),
+(317,589,cs),
+(317,669,o),
+(266,721,o),
+(187,721,cs),
+(109,721,o),
+(56,668,o),
+(56,586,cs),
+(56,504,o),
+(108,450,o),
+(193,450,cs),
+(395,450,l),
+(350,494,l),
+(350,303,ls),
+(350,218,o),
+(402,164,o),
+(483,164,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(441,217,o),
+(415,245,o),
+(415,300,cs),
+(415,353,o),
+(444,382,o),
+(482,382,cs),
+(522,382,o),
+(550,353,o),
+(550,300,cs),
+(550,247,o),
+(522,217,o),
+(483,217,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(147,502,o),
+(119,533,o),
+(119,586,cs),
+(119,638,o),
+(147,668,o),
+(187,668,cs),
+(227,668,o),
+(254,638,o),
+(254,585,cs),
+(254,533,o),
+(227,502,o),
+(187,502,cs)
+);
+}
+);
+width = 669;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+color = 11;
+glyphname = "ngai-canadian.nunavik";
+lastChange = "2023-01-13 15:30:44 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+ref = "ng-canadian.nunavik";
+},
+{
+pos = (669,0);
+ref = "ce-canadian";
+}
+);
+width = 1271;
+}
+);
+note = uni1670;
+},
+{
+color = 11;
+glyphname = "ke-canadian.square";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (353,714);
+},
+{
+name = top_left_can;
+pos = (124,714);
+},
+{
+name = top_right_can;
+pos = (593,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(642,0,l),
+(642,714,l),
+(383,714,ls),
+(179,714,o),
+(64,606,o),
+(64,426,cs),
+(64,246,o),
+(179,139,o),
+(383,139,cs),
+(543,139,l),
+(543,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(238,226,o),
+(163,299,o),
+(163,426,cs),
+(163,554,o),
+(238,626,o),
+(379,626,cs),
+(543,626,l),
+(543,226,l),
+(379,226,ls)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146B;
+},
+{
+color = 11;
+glyphname = "ki-canadian.square";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (368,714);
+},
+{
+name = top_left_can;
+pos = (128,714);
+},
+{
+name = top_right_can;
+pos = (607,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(178,0,l),
+(178,139,l),
+(338,139,ls),
+(542,139,o),
+(657,246,o),
+(657,426,cs),
+(657,606,o),
+(542,714,o),
+(338,714,cs),
+(78,714,l),
+(78,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(178,626,l),
+(341,626,ls),
+(483,626,o),
+(557,554,o),
+(557,426,cs),
+(557,299,o),
+(483,226,o),
+(341,226,cs),
+(178,226,l)
+);
+}
+);
+width = 721;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni146D;
+},
+{
+color = 11;
+glyphname = "kii-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (292,0);
+ref = dot_top;
+}
+);
+width = 722;
+}
+);
+note = uni146E;
+},
+{
+color = 11;
+glyphname = "ko-canadian.square";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (353,714);
+},
+{
+name = top_left_can;
+pos = (124,714);
+},
+{
+name = top_right_can;
+pos = (593,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(642,0,l),
+(642,714,l),
+(543,714,l),
+(543,575,l),
+(383,575,ls),
+(179,575,o),
+(64,468,o),
+(64,288,cs),
+(64,108,o),
+(179,0,o),
+(383,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(238,88,o),
+(163,160,o),
+(163,288,cs),
+(163,415,o),
+(238,488,o),
+(379,488,cs),
+(543,488,l),
+(543,88,l),
+(379,88,ls)
+);
+}
+);
+width = 720;
+}
+);
+metricLeft = "=|theCarrier-canadian";
+metricRight = "nunavuth-canadian";
+note = uni146F;
+},
+{
+color = 11;
+glyphname = "koo-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (518,0);
+ref = dot_top;
+}
+);
+width = 722;
+}
+);
+note = uni1470;
+},
+{
+color = 11;
+glyphname = "ka-canadian.square";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (368,714);
+},
+{
+name = top_left_can;
+pos = (128,714);
+},
+{
+name = top_right_can;
+pos = (607,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(338,0,ls),
+(542,0,o),
+(657,108,o),
+(657,288,cs),
+(657,468,o),
+(542,575,o),
+(338,575,cs),
+(178,575,l),
+(178,714,l),
+(78,714,l),
+(78,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(178,488,l),
+(341,488,ls),
+(483,488,o),
+(557,415,o),
+(557,288,cs),
+(557,160,o),
+(483,88,o),
+(341,88,cs),
+(178,88,l)
+);
+}
+);
+width = 721;
+}
+);
+metricLeft = "=|nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1472;
+},
+{
+color = 11;
+glyphname = "kaa-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (52,0);
+ref = dot_top;
+}
+);
+width = 722;
+}
+);
+note = uni1473;
+},
+{
+color = 11;
+glyphname = "kweWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ke-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (722,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 954;
+}
+);
+note = uni1475;
+},
+{
+color = 11;
+glyphname = "kwiiWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ki-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (292,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (722,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 954;
+}
+);
+note = uni1479;
+},
+{
+color = 11;
+glyphname = "kwoWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (722,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 954;
+}
+);
+note = uni147B;
+},
+{
+color = 11;
+glyphname = "kwooWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ko-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (518,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (722,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 954;
+}
+);
+note = uni147D;
+},
+{
+color = 11;
+glyphname = "kwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (722,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 954;
+}
+);
+note = uni147F;
+},
+{
+color = 11;
+glyphname = "kwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ka-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (52,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (722,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 954;
+}
+);
+note = uni1481;
+},
+{
+color = 11;
+glyphname = "ce-canadian.square";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (360,714);
+},
+{
+name = top_left_can;
+pos = (111,714);
+},
+{
+name = top_right_can;
+pos = (608,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(658,0,l),
+(658,409,ls),
+(658,616,o),
+(549,727,o),
+(354,727,cs),
+(168,727,o),
+(61,617,o),
+(61,434,cs),
+(61,400,l),
+(160,400,l),
+(160,438,ls),
+(160,569,o),
+(233,637,o),
+(353,637,cs),
+(490,637,o),
+(558,561,o),
+(558,404,cs),
+(558,0,l)
+);
+}
+);
+width = 729;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni1489;
+},
+{
+color = 11;
+glyphname = "ci-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (369,714);
+},
+{
+name = top_left_can;
+pos = (121,714);
+},
+{
+name = top_right_can;
+pos = (618,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(170,0,l),
+(170,404,ls),
+(170,561,o),
+(238,637,o),
+(376,637,cs),
+(496,637,o),
+(568,569,o),
+(568,438,cs),
+(568,400,l),
+(667,400,l),
+(667,434,ls),
+(667,617,o),
+(561,727,o),
+(374,727,cs),
+(180,727,o),
+(71,616,o),
+(71,409,cs),
+(71,0,l)
+);
+}
+);
+width = 728;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni148B;
+},
+{
+color = 11;
+glyphname = "cii-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ci-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (293,0);
+ref = dot_top;
+}
+);
+width = 728;
+}
+);
+note = uni148C;
+},
+{
+color = 11;
+glyphname = "co-canadian.square";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (360,714);
+},
+{
+name = top_left_can;
+pos = (111,714);
+},
+{
+name = top_right_can;
+pos = (608,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(549,-13,o),
+(658,98,o),
+(658,305,cs),
+(658,714,l),
+(558,714,l),
+(558,310,ls),
+(558,153,o),
+(490,77,o),
+(353,77,cs),
+(233,77,o),
+(160,145,o),
+(160,276,cs),
+(160,314,l),
+(61,314,l),
+(61,280,ls),
+(61,97,o),
+(168,-13,o),
+(354,-13,cs)
+);
+}
+);
+width = 729;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "te-canadian";
+note = uni148D;
+},
+{
+color = 11;
+glyphname = "coo-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "co-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (532,0);
+ref = dot_top;
+}
+);
+width = 728;
+}
+);
+note = uni148E;
+},
+{
+color = 11;
+glyphname = "ca-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (369,714);
+},
+{
+name = top_left_can;
+pos = (121,714);
+},
+{
+name = top_right_can;
+pos = (618,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(561,-13,o),
+(667,97,o),
+(667,280,cs),
+(667,314,l),
+(568,314,l),
+(568,276,ls),
+(568,145,o),
+(496,77,o),
+(376,77,cs),
+(238,77,o),
+(170,153,o),
+(170,310,cs),
+(170,714,l),
+(71,714,l),
+(71,305,ls),
+(71,98,o),
+(180,-13,o),
+(374,-13,cs)
+);
+}
+);
+width = 728;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ce-canadian";
+note = uni1490;
+},
+{
+color = 11;
+glyphname = "caa-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ca-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (44,0);
+ref = dot_top;
+}
+);
+width = 728;
+}
+);
+note = uni1491;
+},
+{
+color = 11;
+glyphname = "me-canadian.square";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (297,714);
+},
+{
+name = top_double;
+pos = (498,714);
+},
+{
+name = top_left_can;
+pos = (91,714);
+},
+{
+name = top_right_can;
+pos = (498,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(547,0,l),
+(547,714,l),
+(41,714,l),
+(41,624,l),
+(448,624,l),
+(448,0,l)
+);
+}
+);
+width = 625;
+}
+);
+metricRight = "nunavuth-canadian";
+note = uni14A3;
+},
+{
+color = 11;
+glyphname = "mi-canadian.square";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (331,714);
+},
+{
+name = top_left_can;
+pos = (128,714);
+},
+{
+name = top_right_can;
+pos = (534,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(178,0,l),
+(178,624,l),
+(584,624,l),
+(584,714,l),
+(78,714,l),
+(78,0,l)
+);
+}
+);
+width = 625;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14A5;
+},
+{
+color = 11;
+glyphname = "mii-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "mi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (255,0);
+ref = dot_top;
+}
+);
+width = 626;
+}
+);
+note = uni14A6;
+},
+{
+color = 11;
+glyphname = "mo-canadian.square";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (297,714);
+},
+{
+name = top_double;
+pos = (498,714);
+},
+{
+name = top_left_can;
+pos = (91,714);
+},
+{
+name = top_right_can;
+pos = (498,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(547,0,l),
+(547,714,l),
+(448,714,l),
+(448,90,l),
+(41,90,l),
+(41,0,l)
+);
+}
+);
+width = 625;
+}
+);
+metricLeft = "me-canadian";
+metricRight = "nunavuth-canadian";
+note = uni14A7;
+},
+{
+color = 11;
+glyphname = "moo-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "mo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (421,0);
+ref = dot_top;
+}
+);
+width = 626;
+}
+);
+note = uni14A8;
+},
+{
+color = 11;
+glyphname = "ma-canadian.square";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (331,714);
+},
+{
+name = top_left_can;
+pos = (128,714);
+},
+{
+name = top_right_can;
+pos = (534,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(584,0,l),
+(584,90,l),
+(178,90,l),
+(178,714,l),
+(78,714,l),
+(78,0,l)
+);
+}
+);
+width = 625;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "=|me-canadian";
+note = uni14AA;
+},
+{
+color = 11;
+glyphname = "maa-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ma-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (52,0);
+ref = dot_top;
+}
+);
+width = 626;
+}
+);
+note = uni14AB;
+},
+{
+color = 11;
+glyphname = "ne-canadian.square";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (453,714);
+},
+{
+name = top_left_can;
+pos = (255,714);
+},
+{
+name = top_right_can;
+pos = (656,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(613,-13,o),
+(706,87,o),
+(706,267,cs),
+(706,714,l),
+(57,714,l),
+(57,626,l),
+(205,626,l),
+(205,267,ls),
+(205,87,o),
+(297,-13,o),
+(455,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(356,78,o),
+(304,140,o),
+(304,258,cs),
+(304,626,l),
+(606,626,l),
+(606,258,ls),
+(606,140,o),
+(554,78,o),
+(455,78,cs)
+);
+}
+);
+width = 777;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C0;
+},
+{
+color = 11;
+glyphname = "ni-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (321,714);
+},
+{
+name = top_left_can;
+pos = (120,714);
+},
+{
+name = top_right_can;
+pos = (522,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(479,-13,o),
+(571,87,o),
+(571,267,cs),
+(571,626,l),
+(719,626,l),
+(719,714,l),
+(71,714,l),
+(71,267,ls),
+(71,87,o),
+(163,-13,o),
+(321,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(222,78,o),
+(170,140,o),
+(170,258,cs),
+(170,626,l),
+(472,626,l),
+(472,258,ls),
+(472,140,o),
+(420,78,o),
+(321,78,cs)
+);
+}
+);
+width = 776;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C2;
+},
+{
+color = 11;
+glyphname = "nii-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (245,0);
+ref = dot_top;
+}
+);
+width = 776;
+}
+);
+note = uni14C3;
+},
+{
+color = 11;
+glyphname = "no-canadian.square";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (455,714);
+},
+{
+name = top_double;
+pos = (465,714);
+},
+{
+name = top_left_can;
+pos = (255,714);
+},
+{
+name = top_right_can;
+pos = (651,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(706,0,l),
+(706,447,ls),
+(706,627,o),
+(613,727,o),
+(455,727,cs),
+(297,727,o),
+(205,627,o),
+(205,447,cs),
+(205,88,l),
+(57,88,l),
+(57,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(304,456,ls),
+(304,574,o),
+(356,636,o),
+(455,636,cs),
+(554,636,o),
+(606,574,o),
+(606,456,cs),
+(606,88,l),
+(304,88,l)
+);
+}
+);
+width = 777;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni14C4;
+},
+{
+color = 11;
+glyphname = "noo-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (379,0);
+ref = dot_top;
+}
+);
+width = 776;
+}
+);
+note = uni14C5;
+},
+{
+color = 11;
+glyphname = "na-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (321,714);
+},
+{
+name = top_double;
+pos = (331,714);
+},
+{
+name = top_left_can;
+pos = (120,714);
+},
+{
+name = top_right_can;
+pos = (522,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(719,0,l),
+(719,88,l),
+(571,88,l),
+(571,447,ls),
+(571,627,o),
+(479,727,o),
+(321,727,cs),
+(163,727,o),
+(71,627,o),
+(71,447,cs),
+(71,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(170,456,ls),
+(170,574,o),
+(222,636,o),
+(321,636,cs),
+(420,636,o),
+(472,574,o),
+(472,456,cs),
+(472,88,l),
+(170,88,l)
+);
+}
+);
+width = 776;
+}
+);
+metricLeft = "te-canadian";
+metricRight = "=|ne-canadian";
+note = uni14C7;
+},
+{
+color = 11;
+glyphname = "naa-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (245,0);
+ref = dot_top;
+}
+);
+width = 776;
+}
+);
+note = uni14C8;
+},
+{
+color = 11;
+glyphname = "nweWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ne-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (776,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1008;
+}
+);
+note = uni14CA;
+},
+{
+color = 11;
+glyphname = "nwaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (776,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1008;
+}
+);
+note = uni14CC;
+},
+{
+color = 11;
+glyphname = "nwaaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "na-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (245,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (776,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1008;
+}
+);
+note = uni14CE;
+},
+{
+color = 11;
+glyphname = "se-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (126,714);
+},
+{
+name = top_right_can;
+pos = (593,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(641,0,l),
+(641,266,l),
+(414,266,ls),
+(256,266,o),
+(176,351,o),
+(176,513,cs),
+(176,714,l),
+(76,714,l),
+(76,510,ls),
+(76,299,o),
+(197,179,o),
+(416,179,cs),
+(569,179,l),
+(541,207,l),
+(541,0,l)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14ED;
+},
+{
+color = 11;
+glyphname = "si-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (129,714);
+},
+{
+name = top_right_can;
+pos = (596,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(178,0,l),
+(178,207,l),
+(150,179,l),
+(304,179,ls),
+(523,179,o),
+(643,299,o),
+(643,507,cs),
+(643,714,l),
+(544,714,l),
+(544,510,ls),
+(544,351,o),
+(464,266,o),
+(307,266,cs),
+(78,266,l),
+(78,0,l)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14EF;
+},
+{
+color = 11;
+glyphname = "sii-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "si-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (520,0);
+ref = dot_top;
+}
+);
+width = 719;
+}
+);
+note = uni14F0;
+},
+{
+color = 11;
+glyphname = "so-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (592,714);
+},
+{
+name = top_left_can;
+pos = (126,714);
+},
+{
+name = top_right_can;
+pos = (592,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(176,0,l),
+(176,201,ls),
+(176,363,o),
+(256,448,o),
+(414,448,cs),
+(641,448,l),
+(641,714,l),
+(541,714,l),
+(541,507,l),
+(569,535,l),
+(416,535,ls),
+(197,535,o),
+(76,415,o),
+(76,204,cs),
+(76,0,l)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "se-canadian";
+note = uni14F1;
+},
+{
+color = 11;
+glyphname = "soo-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "so-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (515,0);
+ref = dot_top;
+}
+);
+width = 719;
+}
+);
+note = uni14F2;
+},
+{
+color = 11;
+glyphname = "sa-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (129,714);
+},
+{
+name = top_right_can;
+pos = (594,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(643,0,l),
+(643,204,ls),
+(643,415,o),
+(523,535,o),
+(304,535,cs),
+(150,535,l),
+(178,507,l),
+(178,714,l),
+(78,714,l),
+(78,448,l),
+(306,448,ls),
+(464,448,o),
+(544,363,o),
+(544,201,cs),
+(544,0,l)
+);
+}
+);
+width = 719;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "=|se-canadian";
+note = uni14F4;
+},
+{
+color = 11;
+glyphname = "saa-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "sa-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (53,0);
+ref = dot_top;
+}
+);
+width = 719;
+}
+);
+note = uni14F5;
+},
+{
+color = 11;
+glyphname = "sho-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (358,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(635,0,l),
+(635,83,l),
+(309,83,ls),
+(207,83,o),
+(167,123,o),
+(167,199,cs),
+(167,276,o),
+(207,316,o),
+(309,316,cs),
+(422,316,ls),
+(579,316,o),
+(648,389,o),
+(648,516,cs),
+(648,642,o),
+(579,714,o),
+(422,714,cs),
+(80,714,l),
+(80,631,l),
+(406,631,ls),
+(508,631,o),
+(548,591,o),
+(548,516,cs),
+(548,442,o),
+(508,398,o),
+(406,398,cs),
+(293,398,ls),
+(136,398,o),
+(67,325,o),
+(67,199,cs),
+(67,72,o),
+(136,0,o),
+(293,0,cs)
+);
+}
+);
+width = 715;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+color = 11;
+glyphname = "shoo-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (282,0);
+ref = dot_top;
+}
+);
+width = 715;
+}
+);
+note = g728;
+},
+{
+color = 11;
+glyphname = "sha-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (358,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(422,0,ls),
+(575,0,o),
+(648,72,o),
+(648,198,cs),
+(648,325,o),
+(575,398,o),
+(422,398,cs),
+(309,398,ls),
+(207,398,o),
+(166,442,o),
+(166,515,cs),
+(166,591,o),
+(207,631,o),
+(309,631,cs),
+(635,631,l),
+(635,714,l),
+(293,714,ls),
+(139,714,o),
+(67,642,o),
+(67,515,cs),
+(67,389,o),
+(139,316,o),
+(293,316,cs),
+(406,316,ls),
+(508,316,o),
+(548,276,o),
+(548,198,cs),
+(548,123,o),
+(508,83,o),
+(406,83,cs),
+(79,83,l),
+(79,0,l)
+);
+}
+);
+width = 715;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+color = 11;
+glyphname = "shaa-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (282,0);
+ref = dot_top;
+}
+);
+width = 715;
+}
+);
+note = g730;
+},
+{
+color = 11;
+glyphname = "ye-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (94,714);
+},
+{
+name = top_right_can;
+pos = (620,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(669,0,l),
+(669,266,l),
+(186,266,l),
+(186,213,l),
+(682,660,l),
+(620,726,l),
+(43,210,l),
+(43,179,l),
+(570,179,l),
+(570,0,l)
+);
+}
+);
+width = 744;
+}
+);
+metricLeft = "ye-canadian";
+note = uni1526;
+},
+{
+color = 11;
+glyphname = "yi-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (124,714);
+},
+{
+name = top_right_can;
+pos = (650,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(174.005,0,l),
+(174,179,l),
+(701,179,l),
+(701,210,l),
+(124,726,l),
+(62,660,l),
+(557,213,l),
+(558,266,l),
+(75,266,l),
+(75,0,l)
+);
+}
+);
+width = 744;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni1528;
+},
+{
+color = 11;
+glyphname = "yii-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "yi-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (48,0);
+ref = dot_top;
+}
+);
+width = 744;
+}
+);
+note = uni1529;
+},
+{
+color = 11;
+glyphname = "yo-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_double;
+pos = (620,714);
+},
+{
+name = top_left_can;
+pos = (94,714);
+},
+{
+name = top_right_can;
+pos = (620,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(682,54,l),
+(186,501,l),
+(186,448,l),
+(669,448,l),
+(669,714,l),
+(570,714,l),
+(570,535,l),
+(43,535,l),
+(43,504,l),
+(620,-12,l)
+);
+}
+);
+width = 744;
+}
+);
+metricLeft = "ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152A;
+},
+{
+color = 11;
+glyphname = "yoo-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "yo-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (544,0);
+ref = dot_top;
+}
+);
+width = 744;
+}
+);
+note = uni152B;
+},
+{
+color = 11;
+glyphname = "ya-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (125,714);
+},
+{
+name = top_right_can;
+pos = (650,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(701,504,l),
+(701,535,l),
+(174,535,l),
+(174.005,714,l),
+(75,714,l),
+(75,448,l),
+(558,448,l),
+(557,501,l),
+(62,54,l),
+(124,-12,l)
+);
+}
+);
+width = 744;
+}
+);
+metricRight = "=|ye-canadian";
+metricWidth = "ye-canadian.square";
+note = uni152D;
+},
+{
+color = 11;
+glyphname = "yaa-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ya-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (48,0);
+ref = dot_top;
+}
+);
+width = 744;
+}
+);
+note = uni152E;
+},
+{
+color = 11;
+glyphname = "re-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (321,714);
+},
+{
+name = top_left_can;
+pos = (120,714);
+},
+{
+name = top_right_can;
+pos = (522,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(479,-13,o),
+(571,87,o),
+(571,267,cs),
+(571,626,l),
+(719,626,l),
+(719,714,l),
+(472,714,l),
+(472,258,ls),
+(472,140,o),
+(420,78,o),
+(321,78,cs),
+(222,78,o),
+(170,140,o),
+(170,258,cs),
+(170,714,l),
+(71,714,l),
+(71,267,ls),
+(71,87,o),
+(163,-13,o),
+(321,-13,cs)
+);
+}
+);
+width = 776;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1542;
+},
+{
+color = 11;
+glyphname = "reRCree-canadian.square";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (455,714);
+},
+{
+name = top_left_can;
+pos = (255,714);
+},
+{
+name = top_right_can;
+pos = (656,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(613,-13,o),
+(706,87,o),
+(706,267,cs),
+(706,714,l),
+(606,714,l),
+(606,258,ls),
+(606,140,o),
+(554,78,o),
+(455,78,cs),
+(356,78,o),
+(304,140,o),
+(304,258,cs),
+(304,714,l),
+(57,714,l),
+(57,626,l),
+(205,626,l),
+(205,267,ls),
+(205,87,o),
+(297,-13,o),
+(455,-13,cs)
+);
+}
+);
+width = 777;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "te-canadian";
+note = uni1543;
+},
+{
+color = 11;
+glyphname = "leWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (455,714);
+},
+{
+name = top_left_can;
+pos = (255,714);
+},
+{
+name = top_right_can;
+pos = (656,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(304,0,l),
+(304,455,ls),
+(304,574,o),
+(356,636,o),
+(455,636,cs),
+(554,636,o),
+(606,574,o),
+(606,455,cs),
+(606,0,l),
+(706,0,l),
+(706,447,ls),
+(706,626,o),
+(613,727,o),
+(455,727,cs),
+(297,727,o),
+(205,626,o),
+(205,447,cs),
+(205,88,l),
+(57,88,l),
+(57,0,l)
+);
+}
+);
+width = 780;
+}
+);
+metricLeft = "ne-canadian";
+metricRight = "=|re-canadian";
+note = uni1544;
+},
+{
+color = 11;
+glyphname = "ri-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (321,714);
+},
+{
+name = top_left_can;
+pos = (124,714);
+},
+{
+name = top_right_can;
+pos = (522,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(170,0,l),
+(170,456,ls),
+(170,574,o),
+(222,636,o),
+(321,636,cs),
+(420,636,o),
+(472,574,o),
+(472,456,cs),
+(472,0,l),
+(719,0,l),
+(719,88,l),
+(571,88,l),
+(571,447,ls),
+(571,627,o),
+(479,727,o),
+(321,727,cs),
+(163,727,o),
+(71,627,o),
+(71,447,cs),
+(71,0,l)
+);
+}
+);
+width = 776;
+}
+);
+metricLeft = "=|te-canadian";
+metricRight = "=|ne-canadian";
+note = uni1546;
+},
+{
+color = 11;
+glyphname = "rii-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ri-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (245,0);
+ref = dot_top;
+}
+);
+width = 776;
+}
+);
+note = uni1547;
+},
+{
+color = 11;
+glyphname = "ro-canadian.square";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (359,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(178,0,l),
+(178,168,l),
+(147,139,l),
+(319,139,ls),
+(523,139,o),
+(638,246,o),
+(638,426,cs),
+(638,606,o),
+(523,714,o),
+(319,714,cs),
+(78,714,l),
+(78,626,l),
+(323,626,ls),
+(464,626,o),
+(539,554,o),
+(539,426,cs),
+(539,299,o),
+(464,226,o),
+(323,226,cs),
+(78,226,l),
+(78,0,l)
+);
+}
+);
+width = 702;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "theCarrier-canadian";
+note = uni1548;
+},
+{
+color = 11;
+glyphname = "loWestCree-canadian.square";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (359,714);
+},
+{
+name = top_left_can;
+pos = (128,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(319,0,ls),
+(523,0,o),
+(638,108,o),
+(638,288,cs),
+(638,468,o),
+(523,575,o),
+(319,575,cs),
+(147,575,l),
+(178,546,l),
+(178,714,l),
+(78,714,l),
+(78,488,l),
+(323,488,ls),
+(464,488,o),
+(539,415,o),
+(539,288,cs),
+(539,160,o),
+(464,88,o),
+(323,88,cs),
+(78,88,l),
+(78,0,l)
+);
+}
+);
+width = 698;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "ro-canadian";
+note = uni154A;
+},
+{
+color = 11;
+glyphname = "ra-canadian.square";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (340,714);
+},
+{
+name = top_right_can;
+pos = (571,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(620,0,l),
+(620,226,l),
+(376,226,ls),
+(234,226,o),
+(160,299,o),
+(160,426,cs),
+(160,554,o),
+(234,626,o),
+(376,626,cs),
+(620,626,l),
+(620,714,l),
+(379,714,ls),
+(175,714,o),
+(60,606,o),
+(60,426,cs),
+(60,246,o),
+(175,139,o),
+(379,139,cs),
+(552,139,l),
+(521,168,l),
+(521,0,l)
+);
+}
+);
+width = 698;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154B;
+},
+{
+color = 11;
+glyphname = "raa-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ra-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (264,0);
+ref = dot_top;
+}
+);
+width = 699;
+}
+);
+note = uni154C;
+},
+{
+color = 11;
+glyphname = "laWestCree-canadian.square";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (571,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(620,0,l),
+(620,88,l),
+(376,88,ls),
+(234,88,o),
+(160,160,o),
+(160,288,cs),
+(160,415,o),
+(234,488,o),
+(376,488,cs),
+(620,488,l),
+(620,714,l),
+(521,714,l),
+(521,546,l),
+(552,575,l),
+(379,575,ls),
+(175,575,o),
+(60,468,o),
+(60,288,cs),
+(60,108,o),
+(175,0,o),
+(379,0,cs)
+);
+}
+);
+width = 698;
+}
+);
+metricLeft = "=|ro-canadian";
+metricRight = "nunavuth-canadian";
+note = uni154D;
+},
+{
+color = 11;
+glyphname = "reWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(647,0,l),
+(892,202,l),
+(838,270,l),
+(594,70,l),
+(658,69,l),
+(658,409,ls),
+(658,616,o),
+(549,727,o),
+(354,727,cs),
+(168,727,o),
+(61,617,o),
+(61,434,cs),
+(61,400,l),
+(160,400,l),
+(160,438,ls),
+(160,569,o),
+(233,637,o),
+(353,637,cs),
+(490,637,o),
+(558,561,o),
+(558,404,cs),
+(558,0,l)
+);
+}
+);
+width = 918;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158A;
+},
+{
+color = 11;
+glyphname = "riWestCree-canadian.square";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(359,0,l),
+(359,404,ls),
+(359,561,o),
+(428,637,o),
+(565,637,cs),
+(685,637,o),
+(758,569,o),
+(758,438,cs),
+(758,400,l),
+(856,400,l),
+(856,434,ls),
+(856,617,o),
+(750,727,o),
+(563,727,cs),
+(369,727,o),
+(260,616,o),
+(260,409,cs),
+(260,69,l),
+(324,70,l),
+(80,270,l),
+(26,202,l),
+(271,0,l)
+);
+}
+);
+width = 917;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158B;
+},
+{
+color = 11;
+glyphname = "roWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(549,-13,o),
+(658,98,o),
+(658,305,cs),
+(658,645,l),
+(594,644,l),
+(838,444,l),
+(892,512,l),
+(647,714,l),
+(558,714,l),
+(558,310,ls),
+(558,153,o),
+(490,77,o),
+(353,77,cs),
+(233,77,o),
+(160,145,o),
+(160,276,cs),
+(160,314,l),
+(61,314,l),
+(61,280,ls),
+(61,97,o),
+(168,-13,o),
+(354,-13,cs)
+);
+}
+);
+width = 918;
+}
+);
+metricLeft = "ce-canadian";
+metricRight = "heNunavik-canadian";
+note = uni158C;
+},
+{
+color = 11;
+glyphname = "raWestCree-canadian.square";
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(750,-13,o),
+(856,97,o),
+(856,280,cs),
+(856,314,l),
+(758,314,l),
+(758,276,ls),
+(758,145,o),
+(685,77,o),
+(565,77,cs),
+(428,77,o),
+(359,153,o),
+(359,310,cs),
+(359,714,l),
+(271,714,l),
+(26,512,l),
+(80,444,l),
+(324,644,l),
+(260,645,l),
+(260,305,ls),
+(260,98,o),
+(369,-13,o),
+(563,-13,cs)
+);
+}
+);
+width = 917;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "=|ce-canadian";
+note = uni158D;
+},
+{
+color = 11;
+glyphname = "theThCree-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (94,714);
+},
+{
+name = top_right_can;
+pos = (620,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(570,66,l),
+(570,0,l),
+(669,0,l),
+(669,66,l),
+(755,66,l),
+(755,115,l),
+(669,115,l),
+(669,266,l),
+(186,266,l),
+(186,213,l),
+(682,660,l),
+(620,726,l),
+(43,210,l),
+(43,179,l),
+(570,179,l),
+(570,115,l),
+(324,115,l),
+(324,66,l)
+);
+}
+);
+width = 789;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15A7;
+},
+{
+color = 11;
+glyphname = "thiThCree-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (161,714);
+},
+{
+name = top_right_can;
+pos = (687,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(220,0,l),
+(220,66,l),
+(465,66,l),
+(465,115,l),
+(220,115,l),
+(220,179,l),
+(746,179,l),
+(746,210,l),
+(170,726,l),
+(107,660,l),
+(603,213,l),
+(604,266,l),
+(120,266,l),
+(120,115,l),
+(34,115,l),
+(34,66,l),
+(120,66,l),
+(120,0,l)
+);
+}
+);
+width = 789;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15A8;
+},
+{
+color = 11;
+glyphname = "thiiThCree-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (85,0);
+ref = dot_top;
+}
+);
+width = 789;
+}
+);
+note = uni15A9;
+},
+{
+color = 11;
+glyphname = "thoThCree-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (94,714);
+},
+{
+name = top_right_can;
+pos = (620,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(682,54,l),
+(186,501,l),
+(186,448,l),
+(669,448,l),
+(669,599,l),
+(755,599,l),
+(755,648,l),
+(669,648,l),
+(669,714,l),
+(570,714,l),
+(570,648,l),
+(324,648,l),
+(324,599,l),
+(570,599,l),
+(570,535,l),
+(43,535,l),
+(43,504,l),
+(620,-12,l)
+);
+}
+);
+width = 789;
+}
+);
+metricLeft = "ye-canadian";
+metricRight = "theThCree-canadian";
+note = uni15AA;
+},
+{
+color = 11;
+glyphname = "thooThCree-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (544,0);
+ref = dot_top;
+}
+);
+width = 789;
+}
+);
+note = uni15AB;
+},
+{
+color = 11;
+glyphname = "thaThCree-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (170,714);
+},
+{
+name = top_right_can;
+pos = (696,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(746,504,l),
+(746,535,l),
+(220,535,l),
+(220,599,l),
+(465,599,l),
+(465,648,l),
+(220,648,l),
+(220,714,l),
+(120,714,l),
+(120,648,l),
+(34,648,l),
+(34,599,l),
+(120,599,l),
+(120,448,l),
+(604,448,l),
+(603,501,l),
+(107,54,l),
+(170,-12,l)
+);
+}
+);
+width = 789;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|ye-canadian";
+note = uni15AC;
+},
+{
+color = 11;
+glyphname = "thaaThCree-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (94,0);
+ref = dot_top;
+}
+);
+width = 789;
+}
+);
+note = uni15AD;
+},
+{
+color = 11;
+glyphname = "thweeWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "theThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (789,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1022;
+}
+);
+note = uni1677;
+},
+{
+color = 11;
+glyphname = "thwiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (789,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1022;
+}
+);
+note = uni1678;
+},
+{
+color = 11;
+glyphname = "thwiiWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "thiThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (85,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (789,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1022;
+}
+);
+note = uni1679;
+},
+{
+color = 11;
+glyphname = "thwoWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (789,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1022;
+}
+);
+note = uni167A;
+},
+{
+color = 11;
+glyphname = "thwooWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "thoThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (544,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (789,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1022;
+}
+);
+note = uni167B;
+},
+{
+color = 11;
+glyphname = "thwaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (789,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1022;
+}
+);
+note = uni167C;
+},
+{
+color = 11;
+glyphname = "thwaaWoodScree-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "thaThCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (94,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (789,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1022;
+}
+);
+note = uni167D;
+},
+{
+color = 11;
+glyphname = "nwiOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (776,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1008;
+}
+);
+note = uni18C7;
+},
+{
+color = 11;
+glyphname = "nwiiOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "ni-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (245,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (776,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1008;
+}
+);
+note = uni18C9;
+},
+{
+color = 11;
+glyphname = "nwoOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (776,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1008;
+}
+);
+note = uni18CB;
+},
+{
+color = 11;
+glyphname = "nwooOjibway-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "no-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (379,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (776,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 1008;
+}
+);
+note = uni18CD;
+},
+{
+color = 11;
+glyphname = "looWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "loWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (52,0);
+ref = dot_top;
+}
+);
+width = 699;
+}
+);
+note = uni18E1;
+},
+{
+color = 11;
+glyphname = "laaWestCree-canadian.square";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = "laWestCree-canadian.square";
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (495,0);
+ref = dot_top;
+}
+);
+width = 699;
+}
+);
+note = uni18E2;
+},
+{
+color = 0;
+glyphname = zero;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(536,571,o),
+(476,725,o),
+(298,725,cs),
+(118,725,o),
+(59,561,o),
+(59,358,cs),
+(59,112,o),
+(144,-10,o),
+(298,-10,cs),
+(458,-10,o),
+(536,110,o),
+(536,358,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(160,483,o),
+(177,642,o),
+(298,642,cs),
+(425,642,o),
+(435,476,o),
+(435,358,cs),
+(435,199,o),
+(404,73,o),
+(298,73,cs),
+(195,73,o),
+(160,198,o),
+(160,358,cs)
+);
+}
+);
+width = 594;
+}
+);
+unicode = 48;
+},
+{
+color = 0;
+glyphname = one;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(235,714,l),
+(17,546,l),
+(71,479,l),
+(175,559,ls),
+(196,575,o),
+(209,588,o),
+(225,604,c),
+(224,571,o),
+(223,541,o),
+(223,509,cs),
+(223,0,l),
+(325,0,l),
+(325,714,l)
+);
+}
+);
+width = 449;
+}
+);
+unicode = 49;
+},
+{
+color = 0;
+glyphname = two;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(511,0,l),
+(511,85,l),
+(172,85,l),
+(172,88,l),
+(310,230,ls),
+(386,305,o),
+(440,362,o),
+(467,426,cs),
+(480,458,o),
+(487,494,o),
+(487,535,cs),
+(487,648,o),
+(401,724,o),
+(275,724,cs),
+(184,724,o),
+(114,692,o),
+(49,635,c),
+(104,568,l),
+(160,615,o),
+(214,637,o),
+(265,637,cs),
+(339,637,o),
+(386,597,o),
+(386,522,cs),
+(386,466,o),
+(367,423,o),
+(325,372,cs),
+(304,346,o),
+(276,315,o),
+(242,279,cs),
+(41,70,l),
+(41,0,l)
+);
+}
+);
+width = 562;
+}
+);
+unicode = 50;
+},
+{
+color = 0;
+glyphname = three;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(482,662,o),
+(397,724,o),
+(267,724,cs),
+(162,724,o),
+(92,694,o),
+(33,651,c),
+(77,581,l),
+(125,615,o),
+(184,641,o),
+(253,641,cs),
+(331,641,o),
+(383,606,o),
+(383,534,cs),
+(383,444,o),
+(296,408,o),
+(204,408,cs),
+(138,408,l),
+(138,329,l),
+(204,329,ls),
+(324,329,o),
+(397,297,o),
+(397,204,cs),
+(397,123,o),
+(344,72,o),
+(222,72,cs),
+(158,72,o),
+(85,90,o),
+(28,118,c),
+(28,31,l),
+(84,7,o),
+(149,-10,o),
+(234,-10,cs),
+(396,-10,o),
+(503,67,o),
+(503,198,cs),
+(503,303,o),
+(440,359,o),
+(327,373,c),
+(327,375,l),
+(415,395,o),
+(482,459,o),
+(482,555,cs)
+);
+}
+);
+width = 552;
+}
+);
+unicode = 51;
+},
+{
+color = 0;
+glyphname = four;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(470,247,l),
+(470,716,l),
+(374,716,l),
+(36,243,l),
+(36,169,l),
+(370,169,l),
+(370,0,l),
+(470,0,l),
+(470,169,l),
+(579,169,l),
+(579,247,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(130,247,l),
+(317,506,ls),
+(342,540,o),
+(351,556,o),
+(369,589,c),
+(372,589,l),
+(372,573,o),
+(370,538,o),
+(370,491,cs),
+(370,247,l)
+);
+}
+);
+width = 607;
+}
+);
+unicode = 52;
+},
+{
+color = 0;
+glyphname = five;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(224,445,o),
+(191,436,o),
+(163,430,c),
+(181,628,l),
+(462,628,l),
+(462,714,l),
+(95,714,l),
+(66,368,l),
+(109,344,l),
+(148,356,o),
+(189,364,o),
+(239,364,cs),
+(349,364,o),
+(404,312,o),
+(404,224,cs),
+(404,127,o),
+(337,72,o),
+(231,72,cs),
+(164,72,o),
+(95,93,o),
+(48,118,c),
+(48,31,l),
+(95,6,o),
+(159,-10,o),
+(238,-10,cs),
+(411,-10,o),
+(507,79,o),
+(507,226,cs),
+(507,365,o),
+(417,445,o),
+(283,445,cs)
+);
+}
+);
+width = 555;
+}
+);
+unicode = 53;
+},
+{
+color = 0;
+glyphname = six;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(58,132,o),
+(135,-10,o),
+(306,-10,cs),
+(449,-10,o),
+(537,83,o),
+(537,234,cs),
+(537,372,o),
+(461,456,o),
+(332,456,cs),
+(241,456,o),
+(182,412,o),
+(153,354,c),
+(149,354,l),
+(155,526,o),
+(219,644,o),
+(388,644,cs),
+(432,644,o),
+(465,639,o),
+(490,632,c),
+(490,714,l),
+(463,721,o),
+(425,725,o),
+(390,725,cs),
+(145,725,o),
+(58,547,o),
+(58,303,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(196,72,o),
+(161,176,o),
+(161,254,cs),
+(161,320,o),
+(231,375,o),
+(307,375,cs),
+(396,375,o),
+(438,321,o),
+(438,232,cs),
+(438,131,o),
+(389,72,o),
+(304,72,cs)
+);
+}
+);
+width = 581;
+}
+);
+unicode = 54;
+},
+{
+color = 0;
+glyphname = seven;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(500,653,l),
+(500,714,l),
+(20,714,l),
+(20,628,l),
+(391,628,l),
+(117,0,l),
+(223,0,l)
+);
+}
+);
+width = 525;
+}
+);
+unicode = 55;
+},
+{
+color = 0;
+glyphname = eight;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(432,-10,o),
+(532,59,o),
+(532,185,cs),
+(532,284,o),
+(459,341,o),
+(364,379,c),
+(452,417,o),
+(510,469,o),
+(510,556,cs),
+(510,665,o),
+(424,724,o),
+(295,724,cs),
+(166,724,o),
+(79,661,o),
+(79,555,cs),
+(79,460,o),
+(149,411,o),
+(218,377,c),
+(122,340,o),
+(57,285,o),
+(57,181,cs),
+(57,68,o),
+(141,-10,o),
+(292,-10,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(206,66,o),
+(151,112,o),
+(151,184,cs),
+(150.994,265.994,o),
+(220,307,o),
+(292,333,c),
+(387,296,o),
+(438,253,o),
+(438,186,cs),
+(438,108,o),
+(381,66,o),
+(291,66,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(224,452,o),
+(175,487,o),
+(175,547,cs),
+(175,612,o),
+(227,648,o),
+(294,648,cs),
+(367,648,o),
+(414,613,o),
+(414,548,cs),
+(414,488,o),
+(369,455,o),
+(295,423,c)
+);
+}
+);
+width = 588;
+}
+);
+unicode = 56;
+},
+{
+color = 0;
+glyphname = nine;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(522,587,o),
+(446,724,o),
+(274,724,cs),
+(130,724,o),
+(43,632,o),
+(43,482,cs),
+(43,343,o),
+(119,258,o),
+(245,258,cs),
+(336,258,o),
+(397,301,o),
+(426,361,c),
+(430,361,l),
+(423,181,o),
+(352,70,o),
+(185,70,cs),
+(146,70,o),
+(111,75,o),
+(85,82,c),
+(85,-2,l),
+(112,-8,o),
+(155,-11,o),
+(190,-11,cs),
+(435,-11,o),
+(522,170,o),
+(522,408,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(385,641,o),
+(418,535,o),
+(418,461,cs),
+(418,395,o),
+(346,339,o),
+(273,339,cs),
+(186,339,o),
+(141,395,o),
+(141,483,cs),
+(141,585,o),
+(190,641,o),
+(276,641,cs)
+);
+}
+);
+width = 580;
+}
+);
+unicode = 57;
+},
+{
+glyphname = zero.canadian;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(558,605,o),
+(463,727,o),
+(308,727,cs),
+(153,727,o),
+(59,605,o),
+(59,357,cs),
+(59,109,o),
+(153,-12,o),
+(308,-12,cs),
+(463,-12,o),
+(558,109,o),
+(558,357,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(158,551,o),
+(210,638,o),
+(308,638,cs),
+(407,638,o),
+(459,551,o),
+(459,357,cs),
+(459,163,o),
+(407,78,o),
+(308,78,cs),
+(209,78,o),
+(158,163,o),
+(158,357,cs)
+);
+}
+);
+width = 617;
+}
+);
+metricRight = "=|";
+},
+{
+glyphname = one.canadian;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(312,0,l),
+(312,714,l),
+(223,714,l),
+(21,547,l),
+(76,479,l),
+(275,644,l),
+(213,648,l),
+(213,0,l)
+);
+}
+);
+width = 390;
+}
+);
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = two.canadian;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(545,90,l),
+(197,90,l),
+(198,57,l),
+(418,282,ls),
+(514,378,o),
+(534,444,o),
+(534,519,cs),
+(534,640,o),
+(450,727,o),
+(309,727,cs),
+(152,727,o),
+(61,626,o),
+(60,468,c),
+(158,468,l),
+(158,577,o),
+(210,640,o),
+(306,640,cs),
+(392,640,o),
+(434,588,o),
+(434,516,cs),
+(434,459,o),
+(420,407,o),
+(338,325,cs),
+(82,67,l),
+(82,0,l),
+(545,0,l)
+);
+}
+);
+width = 601;
+}
+);
+note = uni14BF;
+},
+{
+glyphname = three.canadian;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(461,-13,o),
+(553,64,o),
+(553,194,cs),
+(553,287,o),
+(500,359,o),
+(403,375,c),
+(402,341,l),
+(493,357,o),
+(543,428,o),
+(543,519,cs),
+(543,649,o),
+(456,727,o),
+(319,727,cs),
+(165,727,o),
+(75,630,o),
+(71,483,c),
+(169,483,l),
+(170,580,o),
+(221,640,o),
+(317,640,cs),
+(399,640,o),
+(444,596,o),
+(444,515,cs),
+(444,437,o),
+(404,399,o),
+(329,399,cs),
+(292,399,l),
+(292,315,l),
+(333,315,ls),
+(411,315,o),
+(453,276,o),
+(453,198,cs),
+(453,115,o),
+(405,74,o),
+(314,74,cs),
+(212,74,o),
+(163,131,o),
+(162,231,c),
+(63,231,l),
+(66,79,o),
+(154,-13,o),
+(315,-13,cs)
+);
+}
+);
+width = 627;
+}
+);
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = four.canadian;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(470,0,l),
+(470,169,l),
+(575,169,l),
+(575,251,l),
+(470,251,l),
+(470,716,l),
+(390,716,l),
+(44,234,l),
+(44,169,l),
+(373,169,l),
+(373,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(408,621,l),
+(374,621,l),
+(374,251,l),
+(127,251,l),
+(129,227,l)
+);
+}
+);
+width = 608;
+}
+);
+},
+{
+glyphname = five.canadian;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(473,-13,o),
+(561,75,o),
+(561,211,cs),
+(561,350,o),
+(474,425,o),
+(320,425,cs),
+(180,425,l),
+(209,397,l),
+(231,655,l),
+(200,627,l),
+(534,627,l),
+(534,714,l),
+(140,714,l),
+(111,361,l),
+(132,339,l),
+(306,339,ls),
+(412,339,o),
+(463,298,o),
+(463,208,cs),
+(463,122,o),
+(412,74,o),
+(322,74,cs),
+(220,74,o),
+(175,124,o),
+(173,205,c),
+(75,205,l),
+(79,70,o),
+(163,-13,o),
+(322,-13,cs)
+);
+}
+);
+width = 622;
+}
+);
+},
+{
+glyphname = six.canadian;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(468,-13,o),
+(561,77,o),
+(561,213,cs),
+(561,350,o),
+(471,435,o),
+(337,435,cs),
+(240,435,o),
+(164,388,o),
+(140,294,c),
+(163,267,l),
+(159,309,o),
+(158,333,o),
+(158,382,cs),
+(158,555,o),
+(208,641,o),
+(322,641,cs),
+(409,641,o),
+(452,585,o),
+(459,512,c),
+(557,512,l),
+(545,639,o),
+(467,727,o),
+(325,727,cs),
+(157,727,o),
+(59,607,o),
+(59,361,cs),
+(59,208,o),
+(83,118,o),
+(138,58,cs),
+(185,8,o),
+(247,-13,o),
+(323,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(227,70,o),
+(172,126,o),
+(172,216,cs),
+(172,299,o),
+(233,352,o),
+(322,352,cs),
+(415,352,o),
+(465,299,o),
+(465,212,cs),
+(465,125,o),
+(410,70,o),
+(321,70,cs)
+);
+}
+);
+width = 612;
+}
+);
+metricLeft = zero.canadian;
+},
+{
+glyphname = seven.canadian;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(471,653,l),
+(471,714,l),
+(31,714,l),
+(31,624,l),
+(373,624,l),
+(373,656,l),
+(125,27,l),
+(125,0,l),
+(222,0,l)
+);
+}
+);
+width = 505;
+}
+);
+},
+{
+glyphname = eight.canadian;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(474,-13,o),
+(571,67,o),
+(571,189,cs),
+(571,292,o),
+(503,359,o),
+(411,373,c),
+(405,343,l),
+(490,356,o),
+(555,422,o),
+(555,525,cs),
+(555,647,o),
+(464,727,o),
+(323,727,cs),
+(181,727,o),
+(90,647,o),
+(90,525,cs),
+(90,422,o),
+(155,356,o),
+(240,343,c),
+(235,373,l),
+(142,359,o),
+(74,292,o),
+(74,189,cs),
+(74,67,o),
+(172,-13,o),
+(323,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(229,69,o),
+(173,112,o),
+(173,194,cs),
+(173,276,o),
+(229,317,o),
+(322,317,cs),
+(416,317,o),
+(472,276,o),
+(472,194,cs),
+(472,112,o),
+(416,69,o),
+(323,69,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(238,398,o),
+(189,438,o),
+(189,520,cs),
+(189,601,o),
+(237,645,o),
+(323,645,cs),
+(409,645,o),
+(456,601,o),
+(456,520,cs),
+(456,438,o),
+(407,398,o),
+(322,398,cs)
+);
+}
+);
+width = 645;
+}
+);
+metricLeft = "=|";
+metricRight = "geCarrier-canadian";
+},
+{
+glyphname = nine.canadian;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(455,-13,o),
+(553,107,o),
+(553,353,cs),
+(553,506,o),
+(529,596,o),
+(474,656,cs),
+(427,706,o),
+(365,727,o),
+(289,727,cs),
+(144,727,o),
+(51,637,o),
+(51,501,cs),
+(51,364,o),
+(141,279,o),
+(275,279,cs),
+(372,279,o),
+(448,326,o),
+(472,420,c),
+(449,447,l),
+(453,405,o),
+(454,381,o),
+(454,332,cs),
+(454,159,o),
+(404,75,o),
+(290,75,cs),
+(203,75,o),
+(160,129,o),
+(153,202,c),
+(55,202,l),
+(67,75,o),
+(145,-13,o),
+(287,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(197,362,o),
+(147,415,o),
+(147,502,cs),
+(147,589,o),
+(202,644,o),
+(291,644,cs),
+(385,644,o),
+(440,588,o),
+(440,498,cs),
+(440,415,o),
+(379,362,o),
+(290,362,cs)
+);
+}
+);
+width = 612;
+}
+);
+metricLeft = "=|six.canadian";
+metricRight = "=|six.canadian";
+},
+{
+glyphname = CR;
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+width = 267;
+}
+);
+note = CR;
+unicode = 13;
+},
+{
+color = 0;
+glyphname = .notdef;
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(505,714,l),
+(94,714,l),
+(94,0,l),
+(505,0,l),
+(505,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(454,663,l),
+(454,51,l),
+(145,51,l),
+(145,663,l),
+(145,663,l)
+);
+}
+);
+width = 600;
+}
+);
+note = ".notdef";
+},
+{
+glyphname = .null;
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+width = 0;
+}
+);
+note = NULL;
+},
+{
+glyphname = space;
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+width = 268;
+}
+);
+note = space;
+unicode = 32;
+},
+{
+glyphname = nbspace;
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+width = 267;
+}
+);
+note = uni00A0;
+unicode = 160;
+},
+{
+glyphname = space.canadian;
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+width = 523;
+}
+);
+note = space;
+},
+{
+glyphname = "hyphen-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(397,409,l),
+(397,468,l),
+(66,468,l),
+(66,409,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(397,267,l),
+(397,326,l),
+(66,326,l),
+(66,267,l)
+);
+}
+);
+width = 463;
+}
+);
+metricRight = "=|";
+note = uni1400;
+unicode = 5120;
+},
+{
+glyphname = "chi-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(143,0,l),
+(313,312,l),
+(270,312,l),
+(438,0,l),
+(529,0,l),
+(529,27,l),
+(322,400,l),
+(322,323,l),
+(525,687,l),
+(525,714,l),
+(434,714,l),
+(269,410,l),
+(312,410,l),
+(146,714,l),
+(55,714,l),
+(55,687,l),
+(258,323,l),
+(258,400,l),
+(51,27,l),
+(51,0,l)
+);
+}
+);
+width = 580;
+}
+);
+metricRight = "=|";
+note = uni166D;
+unicode = 5741;
+},
+{
+glyphname = "fullstop-canadian";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(310,0,l),
+(310,13,l),
+(211,191,l),
+(212,167,l),
+(309,343,l),
+(309,357,l),
+(248,357,l),
+(170,208,l),
+(197,212,l),
+(119,357,l),
+(58,357,l),
+(58,343,l),
+(154,172,l),
+(155,196,l),
+(56,13,l),
+(56,0,l),
+(117,0,l),
+(199,158,l),
+(168,153,l),
+(250,0,l)
+);
+}
+);
+width = 367;
+}
+);
+note = uni1541;
+unicode = 5742;
+},
+{
+glyphname = period;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(64,10,o),
+(88,-10,o),
+(125,-10,cs),
+(163,-10,o),
+(185,10,o),
+(185,49,cs),
+(185,89,o),
+(163,108,o),
+(125,108,cs),
+(88,108,o),
+(64,89,o),
+(64,49,cs)
+);
+}
+);
+width = 245;
+}
+);
+note = period;
+unicode = 46;
+},
+{
+glyphname = comma;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(102,-133,l),
+(134,-59,o),
+(160,42,o),
+(177,118,c),
+(172,129,l),
+(83,129,l),
+(73,52,o),
+(56,-36,o),
+(31,-133,c)
+);
+}
+);
+width = 232;
+}
+);
+note = comma;
+unicode = 44;
+},
+{
+glyphname = hyphen;
+kernLeft = hyphen;
+kernRight = hyphen;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(269,311,l),
+(33,311,l),
+(33,229,l),
+(269,229,l)
+);
+}
+);
+width = 302;
+}
+);
+unicode = 45;
+},
+{
+glyphname = quotesinglbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (32,-585);
+ref = quoteright;
+}
+);
+width = 267;
+}
+);
+unicode = 8218;
+},
+{
+glyphname = quotedblbase;
+kernLeft = comma;
+kernRight = comma;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+pos = (32,-585);
+ref = quotedblright;
+}
+);
+width = 460;
+}
+);
+unicode = 8222;
+},
+{
+glyphname = quotedblleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(302,451,l),
+(311,527,o),
+(331,624,o),
+(359,714,c),
+(290,714,l),
+(257,641,o),
+(229,549,o),
+(211,460,c),
+(218,451,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(116,451,l),
+(125,527,o),
+(145,624,o),
+(172,714,c),
+(103,714,l),
+(71,641,o),
+(42,549,o),
+(25,460,c),
+(31,451,l)
+);
+}
+);
+width = 384;
+}
+);
+unicode = 8220;
+},
+{
+glyphname = quotedblright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(281,451,l),
+(315,525,o),
+(343,623,o),
+(359,704,c),
+(353,714,l),
+(268,714,l),
+(261,637,o),
+(242,539,o),
+(212,451,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(94,451,l),
+(128,525,o),
+(157,623,o),
+(173,704,c),
+(166,714,l),
+(81,714,l),
+(75,640,o),
+(54,537,o),
+(25,451,c)
+);
+}
+);
+width = 384;
+}
+);
+unicode = 8221;
+},
+{
+glyphname = quoteleft;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(117,451,l),
+(126,527,o),
+(146,624,o),
+(174,714,c),
+(103,714,l),
+(71,641,o),
+(42,549,o),
+(25,460,c),
+(31,451,l)
+);
+}
+);
+width = 199;
+}
+);
+unicode = 8216;
+},
+{
+glyphname = quoteright;
+kernLeft = quotedbl;
+kernRight = quotedbl;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(96,451,l),
+(130,525,o),
+(158,623,o),
+(174,704,c),
+(167,714,l),
+(81,714,l),
+(75,640,o),
+(54,537,o),
+(25,451,c)
+);
+}
+);
+width = 199;
+}
+);
+unicode = 8217;
+},
+{
+glyphname = dottedCircle;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,522,o),
+(187,511,o),
+(187,496,cs),
+(187,483,o),
+(200,470,o),
+(213,470,cs),
+(228,470,o),
+(239,483,o),
+(239,496,cs),
+(239,511,o),
+(228,522,o),
+(213,522,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(368,522,o),
+(355,511,o),
+(355,496,cs),
+(355,483,o),
+(368,470,o),
+(381,470,cs),
+(396,470,o),
+(407,483,o),
+(407,496,cs),
+(407,511,o),
+(396,522,o),
+(381,522,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(200,112,o),
+(187,101,o),
+(187,86,cs),
+(187,73,o),
+(200,60,o),
+(213,60,cs),
+(228,60,o),
+(239,73,o),
+(239,86,cs),
+(239,101,o),
+(228,112,o),
+(213,112,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(368,112,o),
+(355,101,o),
+(355,86,cs),
+(355,73,o),
+(368,60,o),
+(381,60,cs),
+(396,60,o),
+(407,73,o),
+(407,86,cs),
+(407,101,o),
+(396,112,o),
+(381,112,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(284,540,o),
+(271,529,o),
+(271,514,cs),
+(271,501,o),
+(284,488,o),
+(297,488,cs),
+(312,488,o),
+(323,501,o),
+(323,514,cs),
+(323,529,o),
+(312,540,o),
+(297,540,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(284,94,o),
+(271,83,o),
+(271,68,cs),
+(271,55,o),
+(284,42,o),
+(297,42,cs),
+(312,42,o),
+(323,55,o),
+(323,68,cs),
+(323,83,o),
+(312,94,o),
+(297,94,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(48,278,o),
+(61,265,o),
+(74,265,cs),
+(89,265,o),
+(100,278,o),
+(100,291,cs),
+(100,306,o),
+(89,317,o),
+(74,317,cs),
+(61,317,o),
+(48,306,o),
+(48,291,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(494,278,o),
+(507,265,o),
+(520,265,cs),
+(535,265,o),
+(546,278,o),
+(546,291,cs),
+(546,306,o),
+(535,317,o),
+(520,317,cs),
+(507,317,o),
+(494,306,o),
+(494,291,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(113,120,o),
+(126,107,o),
+(139,107,cs),
+(154,107,o),
+(165,120,o),
+(165,133,cs),
+(165,148,o),
+(154,159,o),
+(139,159,cs),
+(126,159,o),
+(113,148,o),
+(113,133,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(113,436,o),
+(126,423,o),
+(139,423,cs),
+(154,423,o),
+(165,436,o),
+(165,449,cs),
+(165,464,o),
+(154,475,o),
+(139,475,cs),
+(126,475,o),
+(113,464,o),
+(113,449,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(429,120,o),
+(442,107,o),
+(455,107,cs),
+(470,107,o),
+(481,120,o),
+(481,133,cs),
+(481,148,o),
+(470,159,o),
+(455,159,cs),
+(442,159,o),
+(429,148,o),
+(429,133,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(429,436,o),
+(442,423,o),
+(455,423,cs),
+(470,423,o),
+(481,436,o),
+(481,449,cs),
+(481,464,o),
+(470,475,o),
+(455,475,cs),
+(442,475,o),
+(429,464,o),
+(429,449,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(66,194,o),
+(79,181,o),
+(92,181,cs),
+(107,181,o),
+(118,194,o),
+(118,207,cs),
+(118,222,o),
+(107,233,o),
+(92,233,cs),
+(79,233,o),
+(66,222,o),
+(66,207,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(66,362,o),
+(79,349,o),
+(92,349,cs),
+(107,349,o),
+(118,362,o),
+(118,375,cs),
+(118,390,o),
+(107,401,o),
+(92,401,cs),
+(79,401,o),
+(66,390,o),
+(66,375,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(476,194,o),
+(489,181,o),
+(502,181,cs),
+(517,181,o),
+(528,194,o),
+(528,207,cs),
+(528,222,o),
+(517,233,o),
+(502,233,cs),
+(489,233,o),
+(476,222,o),
+(476,207,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(476,362,o),
+(489,349,o),
+(502,349,cs),
+(517,349,o),
+(528,362,o),
+(528,375,cs),
+(528,390,o),
+(517,401,o),
+(502,401,cs),
+(489,401,o),
+(476,390,o),
+(476,375,cs)
+);
+}
+);
+width = 594;
+}
+);
+note = uni25CC;
+unicode = 9676;
+},
+{
+glyphname = dotaccentcomb;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(58,745,o),
+(36,729,o),
+(36,690,cs),
+(36,652,o),
+(58,636,o),
+(93,636,cs),
+(129,636,o),
+(152,652,o),
+(152,690,cs),
+(152,729,o),
+(129,745,o),
+(93,745,cs)
+);
+}
+);
+width = 187;
+}
+);
+note = uni0307;
+unicode = 775;
+},
+{
+glyphname = dotaccent;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(130,636,o),
+(153,652,o),
+(153,690,cs),
+(153,729,o),
+(130,745,o),
+(94,745,cs),
+(59,745,o),
+(37,729,o),
+(37,690,cs),
+(37,652,o),
+(59,636,o),
+(94,636,cs)
+);
+}
+);
+width = 189;
+}
+);
+note = dotaccent;
+unicode = 729;
+},
+{
+glyphname = caron;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(266,645,o),
+(307,701,o),
+(353,755,c),
+(353,764,l),
+(287,764,l),
+(255,735,o),
+(224,699,o),
+(194,662,c),
+(165,698,o),
+(136,734,o),
+(103,764,c),
+(37,764,l),
+(37,755,l),
+(76,710,o),
+(118,657,o),
+(145.993,606,c),
+(243,606,l),
+(243,606,l)
+);
+}
+);
+width = 390;
+}
+);
+note = caron;
+unicode = 711;
+},
+{
+glyphname = breve;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(269,606,o),
+(321,659,o),
+(328,748,c),
+(268,748,l),
+(260,695,o),
+(230,671,o),
+(181,671,cs),
+(129,671,o),
+(104,694,o),
+(95,748,c),
+(37,748,l),
+(42,657,o),
+(92.007,606,o),
+(181,606,cs)
+);
+}
+);
+width = 365;
+}
+);
+note = breve;
+unicode = 728;
+},
+{
+glyphname = ring;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,608,o),
+(248,652,o),
+(248,719,cs),
+(248,782,o),
+(200,829,o),
+(141,829,cs),
+(81,829,o),
+(37,784,o),
+(37,718,cs),
+(37,651,o),
+(82,608,o),
+(141,608,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(109,658,o),
+(87,684,o),
+(87,718,cs),
+(87,753,o),
+(111,779,o),
+(141,779,cs),
+(171,779,o),
+(195,753,o),
+(195,718,cs),
+(195,685,o),
+(173,658,o),
+(141,658,cs)
+);
+}
+);
+width = 284;
+}
+);
+note = ring;
+unicode = 730;
+},
+{
+glyphname = ogonek;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(160,-227,o),
+(181,-222,o),
+(197,-217,c),
+(197,-156,l),
+(186,-160,o),
+(165,-165,o),
+(149,-165,cs),
+(121,-165,o),
+(105,-148,o),
+(105,-116,cs),
+(105,-74,o),
+(135,-39,o),
+(176,0,c),
+(134,17,l),
+(65,-36,o),
+(37,-83,o),
+(37,-131,cs),
+(37,-193,o),
+(80,-227,o),
+(135,-227,cs)
+);
+}
+);
+width = 234;
+}
+);
+note = ogonek;
+unicode = 731;
+},
+{
+glyphname = ring_top.canadian;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (129,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(187,784,o),
+(237,827,o),
+(237,889,cs),
+(237,951,o),
+(187,995,o),
+(129,995,cs),
+(70,995,o),
+(21,951,o),
+(21,889,cs),
+(21,827,o),
+(70,784,o),
+(129,784,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(93,830,o),
+(71,856,o),
+(71,889,cs),
+(71,922,o),
+(95,948,o),
+(129,948,cs),
+(164,948,o),
+(187,922,o),
+(187,889,cs),
+(187,856,o),
+(164,830,o),
+(129,830,cs)
+);
+}
+);
+width = 258;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (76,357);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(108,301,o),
+(132,325,o),
+(132,357,cs),
+(132,389,o),
+(108,413,o),
+(76,413,cs),
+(45,413,o),
+(20,389,o),
+(20,357,cs),
+(20,325,o),
+(45,301,o),
+(76,301,cs)
+);
+}
+);
+width = 152;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (67,357);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(94,309,o),
+(115,330,o),
+(115,357,cs),
+(115,384,o),
+(94,405,o),
+(67,405,cs),
+(40,405,o),
+(19,384,o),
+(19,357,cs),
+(19,330,o),
+(40,309,o),
+(67,309,cs)
+);
+}
+);
+width = 134;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_middle_optic_small;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (58,357);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(80,318,o),
+(97,335,o),
+(97,357,cs),
+(97,379,o),
+(80,396,o),
+(58,396,cs),
+(36,396,o),
+(19,379,o),
+(19,357,cs),
+(19,335,o),
+(36,318,o),
+(58,318,cs)
+);
+}
+);
+width = 116;
+}
+);
+note = g725;
+},
+{
+glyphname = dot_top;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (76,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(108,807,o),
+(133,832,o),
+(133,864,cs),
+(133,895,o),
+(108,920,o),
+(76,920,cs),
+(44,920,o),
+(19,895,o),
+(19,864,cs),
+(19,832,o),
+(44,807,o),
+(76,807,cs)
+);
+}
+);
+width = 152;
+}
+);
+note = g725;
+},
+{
+glyphname = doubledot_middle;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(148,395,o),
+(173,420,o),
+(173,451,cs),
+(173,483,o),
+(148,508,o),
+(116,508,cs),
+(84,508,o),
+(59,483,o),
+(59,451,cs),
+(59,419,o),
+(84,395,o),
+(116,395,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(148,206,o),
+(173,231,o),
+(173,263,cs),
+(173,294,o),
+(148,319,o),
+(116,319,cs),
+(84,319,o),
+(59,295,o),
+(59,263,cs),
+(59,231,o),
+(84,206,o),
+(116,206,cs)
+);
+}
+);
+width = 232;
+}
+);
+metricRight = "=|";
+note = g725;
+},
+{
+glyphname = doubledot_top;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top_double;
+pos = (250,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(282,807,o),
+(307,832,o),
+(307,864,cs),
+(307,895,o),
+(282,920,o),
+(250,920,cs),
+(218,920,o),
+(193,895,o),
+(193,864,cs),
+(193,832,o),
+(218,807,o),
+(250,807,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(102,807,o),
+(127,832,o),
+(127,864,cs),
+(127,895,o),
+(102,920,o),
+(70,920,cs),
+(38,920,o),
+(13,895,o),
+(13,864,cs),
+(13,832,o),
+(38,807,o),
+(70,807,cs)
+);
+}
+);
+width = 320;
+}
+);
+note = g725;
+},
+{
+glyphname = g727;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (358,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(635,0,l),
+(635,83,l),
+(309,83,ls),
+(207,83,o),
+(167,123,o),
+(167,199,cs),
+(167,276,o),
+(207,316,o),
+(309,316,cs),
+(422,316,ls),
+(575,316,o),
+(648,389,o),
+(648,516,cs),
+(648,642,o),
+(575,714,o),
+(422,714,cs),
+(80,714,l),
+(80,631,l),
+(406,631,ls),
+(508,631,o),
+(548,591,o),
+(548,516,cs),
+(548,442,o),
+(508,398,o),
+(406,398,cs),
+(293,398,ls),
+(139,398,o),
+(67,325,o),
+(67,199,cs),
+(67,72,o),
+(139,0,o),
+(293,0,cs)
+);
+}
+);
+width = 715;
+}
+);
+metricRight = "=|";
+note = g727;
+},
+{
+glyphname = g728;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (282,0);
+ref = dot_top;
+}
+);
+width = 715;
+}
+);
+note = g728;
+},
+{
+glyphname = g729;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_center_can;
+pos = (358,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(422,0,ls),
+(575,0,o),
+(648,72,o),
+(648,198,cs),
+(648,325,o),
+(575,398,o),
+(422,398,cs),
+(309,398,ls),
+(207,398,o),
+(166,442,o),
+(166,515,cs),
+(166,591,o),
+(207,631,o),
+(309,631,cs),
+(635,631,l),
+(635,714,l),
+(293,714,ls),
+(139,714,o),
+(67,642,o),
+(67,515,cs),
+(67,389,o),
+(139,316,o),
+(293,316,cs),
+(406,316,ls),
+(508,316,o),
+(548,276,o),
+(548,198,cs),
+(548,123,o),
+(508,83,o),
+(406,83,cs),
+(79,83,l),
+(79,0,l)
+);
+}
+);
+width = 715;
+}
+);
+metricLeft = g727;
+metricRight = g727;
+note = g729;
+},
+{
+glyphname = g730;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (282,0);
+ref = dot_top;
+}
+);
+width = 715;
+}
+);
+note = g730;
+},
+{
+glyphname = g731;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = g727;
+}
+);
+width = 947;
+}
+);
+note = g731;
+},
+{
+glyphname = g732;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (715,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 947;
+}
+);
+note = g732;
+},
+{
+glyphname = g733;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (514,0);
+ref = dot_top;
+}
+);
+width = 947;
+}
+);
+note = g733;
+},
+{
+glyphname = g734;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (282,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (715,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 947;
+}
+);
+note = g734;
+},
+{
+glyphname = g735;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = g729;
+}
+);
+width = 947;
+}
+);
+note = g735;
+},
+{
+glyphname = g736;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (715,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 947;
+}
+);
+note = g736;
+},
+{
+glyphname = g737;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (514,0);
+ref = dot_top;
+}
+);
+width = 947;
+}
+);
+note = g737;
+},
+{
+glyphname = g738;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (282,0);
+ref = dot_top;
+},
+{
+alignment = -1;
+anchor = middle_right_can;
+pos = (715,0);
+ref = "middledotFinal-canadian";
+}
+);
+width = 947;
+}
+);
+note = g738;
+},
+{
+glyphname = g739;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(555,244,o),
+(608,298,o),
+(608,379,cs),
+(608,459,o),
+(556,515,o),
+(472,515,cs),
+(258,515,l),
+(261,485,l),
+(293,497,o),
+(317,540,o),
+(317,589,cs),
+(317,668,o),
+(266,721,o),
+(187,721,cs),
+(109,721,o),
+(56,667,o),
+(56,586,cs),
+(56,505,o),
+(108,450,o),
+(192,450,cs),
+(406,450,l),
+(403,480,l),
+(371,467,o),
+(347,424,o),
+(347,376,cs),
+(347,297,o),
+(399,244,o),
+(477,244,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(147,502,o),
+(119,534,o),
+(119,586,cs),
+(119,637,o),
+(147,668,o),
+(187,668,cs),
+(226,668,o),
+(254,636,o),
+(254,585,cs),
+(254,535,o),
+(228,502,o),
+(187,502,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(438,297,o),
+(410,329,o),
+(410,380,cs),
+(410,430,o),
+(437,462,o),
+(477,462,cs),
+(517,462,o),
+(545,430,o),
+(545,379,cs),
+(545,328,o),
+(517,297,o),
+(477,297,cs)
+);
+}
+);
+width = 664;
+}
+);
+metricLeft = "n-canadian";
+metricRight = "=|n-canadian";
+note = g739;
+},
+{
+glyphname = g740;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (229,0);
+ref = ring_top.canadian;
+}
+);
+width = 715;
+}
+);
+note = g740;
+},
+{
+glyphname = g741;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = g729;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (229,0);
+ref = ring_top.canadian;
+}
+);
+width = 715;
+}
+);
+note = g741;
+},
+{
+glyphname = g742;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+anchor = middle_left_can;
+ref = "middledotFinal-canadian";
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = g727;
+},
+{
+alignment = -1;
+anchor = top_center_can;
+pos = (461,0);
+ref = ring_top.canadian;
+}
+);
+width = 947;
+}
+);
+note = g742;
+},
+{
+glyphname = stroke_middle;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (50,357);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(80,474,l),
+(19,474,l),
+(19,241,l),
+(80,241,l)
+);
+}
+);
+width = 100;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_halfsmall;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (43,357);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(67,447,l),
+(19,447,l),
+(19,267,l),
+(67,267,l)
+);
+}
+);
+width = 86;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_small;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (39,357);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(58,442,l),
+(19,442,l),
+(19,272,l),
+(58,272,l)
+);
+}
+);
+width = 77;
+}
+);
+note = g723;
+},
+{
+glyphname = stroke_middle_optic_threequart;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = _middle;
+pos = (50,357);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(80,471,l),
+(20,471,l),
+(20,243,l),
+(80,243,l)
+);
+}
+);
+width = 100;
+}
+);
+note = g723;
+},
+{
+color = 8;
+glyphname = uni11AB0;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (166,714);
+},
+{
+name = top_right_can;
+pos = (471,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(216,0,l),
+(216,106,l),
+(461,106,l),
+(461,164,l),
+(216,164,l),
+(216,291,l),
+(142,255,l),
+(175,255,ls),
+(390,255,o),
+(520,389,o),
+(520,620,cs),
+(520,714,l),
+(421,714,l),
+(421,630,ls),
+(421,437,o),
+(328,344,o),
+(154,344,cs),
+(116,344,l),
+(116,164,l),
+(34,164,l),
+(34,106,l),
+(116,106,l),
+(116,0,l)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB1;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB0;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (395,0);
+ref = dot_top;
+}
+);
+width = 596;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB2;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (126,714);
+},
+{
+name = top_right_can;
+pos = (431,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(176,0,l),
+(176,84,ls),
+(176,277,o),
+(268,370,o),
+(442,370,cs),
+(480,370,l),
+(480,550,l),
+(562,550,l),
+(562,608,l),
+(480,608,l),
+(480,714,l),
+(381,714,l),
+(381,608,l),
+(135,608,l),
+(135,550,l),
+(381,550,l),
+(381,423,l),
+(454,459,l),
+(422,459,ls),
+(206,459,o),
+(76,325,o),
+(76,94,cs),
+(76,0,l)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "se-canadian";
+metricRight = "theThCree-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB3;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB2;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (354,0);
+ref = dot_top;
+}
+);
+width = 596;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB4;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (166,714);
+},
+{
+name = top_right_can;
+pos = (471,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(520,0,l),
+(520,94,ls),
+(520,325,o),
+(390,459,o),
+(175,459,cs),
+(142,459,l),
+(216,423,l),
+(216,550,l),
+(461,550,l),
+(461,608,l),
+(216,608,l),
+(216,714,l),
+(116,714,l),
+(116,608,l),
+(34,608,l),
+(34,550,l),
+(116,550,l),
+(116,370,l),
+(154,370,ls),
+(328,370,o),
+(421,277,o),
+(421,84,cs),
+(421,0,l)
+);
+}
+);
+width = 596;
+}
+);
+metricLeft = "=|theThCree-canadian";
+metricRight = "=|se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB5;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB4;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (90,0);
+ref = dot_top;
+}
+);
+width = 596;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB6;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (128,714);
+},
+{
+name = top_right_can;
+pos = (433,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(178,0,l),
+(178,291,l),
+(104,255,l),
+(137,255,ls),
+(352,255,o),
+(482,389,o),
+(482,620,cs),
+(482,677,l),
+(419,647,l),
+(664,445,l),
+(718,512,l),
+(472,714,l),
+(383,714,l),
+(383,630,ls),
+(383,437,o),
+(291,344,o),
+(117,344,cs),
+(78,344,l),
+(78,0,l)
+);
+}
+);
+width = 744;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB7;
+kernLeft = sileft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB6;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (357,0);
+ref = dot_top;
+}
+);
+width = 743;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11AB8;
+kernRight = soright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (310,714);
+},
+{
+name = top_right_can;
+pos = (615,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(360,0,l),
+(360,84,ls),
+(360,277,o),
+(453,370,o),
+(627,370,cs),
+(665,370,l),
+(665,714,l),
+(565,714,l),
+(565,423,l),
+(639,459,l),
+(606,459,ls),
+(391,459,o),
+(261,325,o),
+(261,94,cs),
+(261,37,l),
+(325,67,l),
+(79,269,l),
+(26,202,l),
+(271,0,l)
+);
+}
+);
+width = 743;
+}
+);
+metricLeft = "=|heNunavik-canadian";
+metricRight = "se-canadian";
+},
+{
+color = 8;
+glyphname = uni11AB9;
+kernRight = soright;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = uni11AB8;
+},
+{
+alignment = -1;
+anchor = top_right_can;
+pos = (539,0);
+ref = dot_top;
+}
+);
+width = 743;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABA;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:30:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = top_left_can;
+pos = (128,714);
+},
+{
+name = top_right_can;
+pos = (433,714);
+}
+);
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(472,0,l),
+(718,202,l),
+(664,269,l),
+(419,67,l),
+(482,37,l),
+(482,94,ls),
+(482,325,o),
+(352,459,o),
+(137,459,cs),
+(104,459,l),
+(178,423,l),
+(178,714,l),
+(78,714,l),
+(78,370,l),
+(117,370,ls),
+(291,370,o),
+(383,277,o),
+(383,84,cs),
+(383,0,l)
+);
+}
+);
+width = 744;
+}
+);
+metricLeft = "=|se-canadian";
+metricRight = "heNunavik-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABB;
+kernLeft = saleft;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+alignment = -1;
+ref = uni11ABA;
+},
+{
+alignment = -1;
+anchor = top_left_can;
+pos = (52,0);
+ref = dot_top;
+}
+);
+width = 743;
+}
+);
+},
+{
+color = 8;
+glyphname = uni11ABC;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(537,0,l),
+(537,90,l),
+(148,90,l),
+(148,53,l),
+(547,644,l),
+(547,714,l),
+(51,714,l),
+(51,624,l),
+(440,624,l),
+(440,661,l),
+(42,70,l),
+(42,0,l)
+);
+}
+);
+width = 589;
+}
+);
+metricRight = "=|";
+},
+{
+color = 8;
+glyphname = uni11ABD;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(547,0,l),
+(547,70,l),
+(149,661,l),
+(149,624,l),
+(538,624,l),
+(538,714,l),
+(42,714,l),
+(42,644,l),
+(440,53,l),
+(440,90,l),
+(51,90,l),
+(51,0,l)
+);
+}
+);
+width = 589;
+}
+);
+metricLeft = "=|uni11ABC";
+metricRight = "=|uni11ABC";
+},
+{
+color = 8;
+glyphname = uni11ABE;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(177,0,l),
+(177,623,l),
+(119,623,l),
+(527,0,l),
+(615,0,l),
+(615,714,l),
+(516,714,l),
+(516,91,l),
+(574,91,l),
+(167,714,l),
+(78,714,l),
+(78,0,l)
+);
+}
+);
+width = 693;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+color = 8;
+glyphname = uni11ABF;
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(167,0,l),
+(574,625,l),
+(516,625,l),
+(516,0,l),
+(615,0,l),
+(615,714,l),
+(527,714,l),
+(119,89,l),
+(177,89,l),
+(177,714,l),
+(78,714,l),
+(78,0,l)
+);
+}
+);
+width = 693;
+}
+);
+metricLeft = "nunavuth-canadian";
+metricRight = "nunavuth-canadian";
+},
+{
+glyphname = "raiseddoubledotFinal-canadian.cree";
+lastChange = "2023-01-13 15:28:14 +0000";
+layers = (
+{
+layerId = "F8006AA5-6E21-4BD1-AC52-9C52C7F343AA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(149,614,o),
+(174,639,o),
+(174,671,cs),
+(174,702,o),
+(149,727,o),
+(117,727,cs),
+(85,727,o),
+(60,703,o),
+(60,671,cs),
+(60,639,o),
+(85,614,o),
+(117,614,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(149,425,o),
+(174,450,o),
+(174,482,cs),
+(174,514,o),
+(149,539,o),
+(117,539,cs),
+(85,539,o),
+(60,514,o),
+(60,482,cs),
+(60,450,o),
+(85,425,o),
+(117,425,cs)
+);
+}
+);
+width = 234;
+}
+);
+note = g725;
+}
+);
+instances = (
+{
+axesValues = (
+101,
+91,
+0
+);
+instanceInterpolations = {
+"F8006AA5-6E21-4BD1-AC52-9C52C7F343AA" = 1;
+};
+name = "RC L roman";
+}
+);
+kerningLTR = {
+"F8006AA5-6E21-4BD1-AC52-9C52C7F343AA" = {
+"@MMK_L_caright" = {
+"@MMK_R_ecanleft" = -80;
+"@MMK_R_mwestleft" = -29;
+"@MMK_R_neleft" = -57;
+};
+"@MMK_L_ciright" = {
+"@MMK_R_icanleft" = -80;
+"@MMK_R_noleft" = -100;
+};
+"@MMK_L_ecanright" = {
+"@MMK_R_coleft" = -80;
+"@MMK_R_moleft" = -83;
+"@MMK_R_sileft" = -49;
+};
+"@MMK_L_icanright" = {
+"@MMK_R_celeft" = -80;
+"@MMK_R_meleft" = -83;
+"@MMK_R_mwestleft" = -74;
+"@MMK_R_saleft" = -43;
+"she-canadian" = -83;
+};
+"@MMK_L_maright" = {
+"@MMK_R_acanleft" = -79;
+"@MMK_R_ecanleft" = -83;
+"@MMK_R_mwestleft" = -53;
+"@MMK_R_neleft" = -57;
+};
+"@MMK_L_miright" = {
+"@MMK_R_acanleft" = -79;
+"@MMK_R_icanleft" = -83;
+"@MMK_R_moleft" = -105;
+"@MMK_R_noleft" = -100;
+"@MMK_R_yeleft" = -111;
+};
+"@MMK_L_mwestright" = {
+"@MMK_R_coleft" = -29;
+"@MMK_R_icanleft" = -74;
+"@MMK_R_moleft" = -53;
+"@MMK_R_noleft" = -81;
+"@MMK_R_sileft" = -19;
+"@MMK_R_yeleft" = -34;
+};
+"@MMK_L_naright" = {
+"@MMK_R_acanleft" = -93;
+"@MMK_R_celeft" = -100;
+"@MMK_R_meleft" = -100;
+"@MMK_R_mwestleft" = -81;
+"@MMK_R_neleft" = -115;
+"@MMK_R_saleft" = -71;
+};
+"@MMK_L_niright" = {
+"@MMK_R_coleft" = -57;
+"@MMK_R_moleft" = -57;
+"@MMK_R_noleft" = -115;
+"@MMK_R_sileft" = -5;
+};
+"@MMK_L_ocanright" = {
+"@MMK_R_meleft" = -79;
+"@MMK_R_moleft" = -79;
+"@MMK_R_noleft" = -93;
+};
+"@MMK_L_seright" = {
+"@MMK_R_ecanleft" = -49;
+"@MMK_R_mwestleft" = -19;
+"@MMK_R_neleft" = -3;
+};
+"@MMK_L_soright" = {
+"@MMK_R_icanleft" = -43;
+"@MMK_R_noleft" = -71;
+};
+"@MMK_L_yiright" = {
+"@MMK_R_meleft" = -111;
+"@MMK_R_mwestleft" = -34;
+};
+"shi-canadian" = {
+"@MMK_R_icanleft" = -83;
+};
+};
+};
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "italic angle";
+}
+);
+properties = (
+{
+key = copyrights;
+values = (
+{
+language = ENG;
+value = "Copyright 2018 Google Inc. All Rights Reserved.";
+}
+);
+},
+{
+key = manufacturers;
+values = (
+{
+language = ENG;
+value = "Monotype Imaging Inc.";
+}
+);
+},
+{
+key = designers;
+values = (
+{
+language = ENG;
+value = "Monotype Design Team";
+}
+);
+},
+{
+key = description;
+value = "Designed by Monotype design team.";
+},
+{
+key = trademarks;
+values = (
+{
+language = ENG;
+value = "Noto is a trademark of Google Inc.";
+}
+);
+},
+{
+key = licenseURL;
+value = "http://scripts.sil.org/OFL";
+},
+{
+key = licenses;
+values = (
+{
+language = ENG;
+value = "This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.";
+}
+);
+},
+{
+key = manufacturerURL;
+value = "http://www.google.com/get/noto/";
+},
+{
+key = designerURL;
+value = "http://www.monotype.com/studio";
+}
+);
+settings = {
+disablesNiceNames = 1;
+};
+stems = (
+{
+name = "New Stem";
+}
+);
+unitsPerEm = 1000;
+userData = {
+GSDontShowVersionAlert = 1;
+};
+versionMajor = 1;
+versionMinor = 0;
+}


### PR DESCRIPTION
UCAS was added in the Roman and Italic.

Stylistics sets were added to cover different languages and local variations.

Ss03: Canadian Space and numerals: The UCAS needs a larger space for better readability and has a matching set of numerals.
Ss04: Dene Square: The squared variants of the Dene syllabics.
Ss05: Nunanvik alternates.
Ss06: Final mid alternates.
Ss07: Final base alternates.
Ss08: Plain Cree (alternates).